### PR TITLE
doc: remove :orphan: from README.rst

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,5 +1,3 @@
-:orphan:
-
 Zephyr™ Project
 ###############
 


### PR DESCRIPTION
github doesn't handle sphinx directves (and ends up displaying them)

Signed-off-by: David B. Kinder <david.b.kinder@intel.com>