### PR TITLE
tests: net: set reasonable timeout on various testcases

### DIFF
--- a/tests/crypto/test_sha256/testcase.ini
+++ b/tests/crypto/test_sha256/testcase.ini
@@ -1,12 +1,12 @@
 [test]
 tags = crypto sha256
 build_only = false
-timeout = 10800
+timeout = 600
 arch_whitelist = arm arc x86
 filter = ( CONFIG_SRAM_SIZE > 32 or CONFIG_DCCM_SIZE > 32 or CONFIG_RAM_SIZE > 32 )
 
 [test_nios2]
 tags = crypto sha256
 build_only = false
-timeout = 10800
+timeout = 600
 arch_whitelist = nios2

--- a/tests/net/lib/dns_packet/testcase.ini
+++ b/tests/net/lib/dns_packet/testcase.ini
@@ -2,6 +2,6 @@
 tags = dns
 build_only = false
 platform_whitelist = qemu_x86 arduino_101 quark_se_c1000_devboard frdm_k64f
-timeout = 10800
+timeout = 200
 slow = True
 


### PR DESCRIPTION
A few tests have been slowing daily runs for no good reason, timeout of
10800 is way too high.

Signed-off-by: Anas Nashif <anas.nashif@intel.com>