### PR TITLE
net: tcp: Mark ACK timer as cancelled

### DIFF
--- a/subsys/net/ip/tcp.c
+++ b/subsys/net/ip/tcp.c
@@ -216,6 +216,7 @@ int net_tcp_release(struct net_tcp *tcp)
 		net_pkt_unref(pkt);
 	}
 
+	tcp->ack_timer_cancelled = true;
 	k_delayed_work_cancel(&tcp->ack_timer);
 	k_timer_stop(&tcp->retry_timer);
 	k_sem_reset(&tcp->connect_wait);


### PR DESCRIPTION
This is related to commit "net: tcp: Make sure ACK timer is not
run if cancelled" which did not set the cancel flag when the timer
was cancelled from tcp.c.

Signed-off-by: Jukka Rissanen <jukka.rissanen@linux.intel.com>