### PR TITLE
net: bt: Fix not setting lladdr type

### DIFF
--- a/subsys/net/ip/l2/bluetooth.c
+++ b/subsys/net/ip/l2/bluetooth.c
@@ -138,6 +138,7 @@ static void ipsp_connected(struct bt_l2cap_chan *chan)
 
 	ll.addr = ctxt->dst.val;
 	ll.len = sizeof(ctxt->dst.val);
+	ll.type = NET_LINK_BLUETOOTH;
 
 	/* Add remote link-local address to the nbr cache to avoid sending ns:
 	 * https://tools.ietf.org/html/rfc7668#section-3.2.3


### PR DESCRIPTION
When adding link-local address to the cache the type needs to be
properly set as net_ipv6_addr_create_iid will attempt to use it
when generating the IPv6 address.

Jira: ZEP-2077
Signed-off-by: Luiz Augusto von Dentz <luiz.von.dentz@intel.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/zephyrproject-rtos/zephyr/41)
<!-- Reviewable:end -->
