### PR TITLE
stm32: Don't perform any side effects in irq_update().

### DIFF
--- a/drivers/serial/uart_stm32.c
+++ b/drivers/serial/uart_stm32.c
@@ -218,11 +218,6 @@ static int uart_stm32_irq_is_pending(struct device *dev)
 
 static int uart_stm32_irq_update(struct device *dev)
 {
-	 struct uart_stm32_data *data = DEV_DATA(dev);
-	 UART_HandleTypeDef *UartHandle = &data->huart;
-
-	__HAL_UART_CLEAR_FLAG(UartHandle, UART_FLAG_TC);
-
 	return 1;
 }
 


### PR DESCRIPTION
The purpose of irq_update() is to cache value of UART IRQ status
register for devices which needs such caching. No other driver
performs any other side effects in this call. For STM32, clearing
TC (tx complete) bit was introduced in 8c079e91c90f94ece822e3be06
which is otherwise titled as a conversion to STM32Cube HAL. Thus,
there does not seem to be specific reasons why this code was added.
On the other hand, it leads to behaviorial artifacts when dealing
with interrup-driven UART code (specific issue seen was delaying
of transmitting every other character).

Change-Id: Id20bf214b36eeb6c09e29cc2e6bfca4f7221a1a4
Signed-off-by: Paul Sokolovsky <paul.sokolovsky@linaro.org>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/zephyrproject-rtos/zephyr/43)
<!-- Reviewable:end -->
