### PR TITLE
doc: spelling check doxygen comments include/

### DIFF
--- a/include/arch/x86/arch.h
+++ b/include/arch/x86/arch.h
@@ -440,7 +440,7 @@ extern void	_arch_irq_disable(unsigned int irq);
  * by _Swap() it will either inherit an FPU that is guaranteed to be in a "sane"
  * state (if the most recent user of the FPU was cooperatively swapped out)
  * or the thread's own floating point context will be loaded (if the most
- * recent user of the FPU was pre-empted, or if this thread is the first user
+ * recent user of the FPU was preempted, or if this thread is the first user
  * of the FPU). Thereafter, the kernel will protect the thread's FP context
  * so that it is not altered during a preemptive context switch.
  *

--- a/include/bluetooth/bluetooth.h
+++ b/include/bluetooth/bluetooth.h
@@ -118,7 +118,7 @@ struct bt_le_adv_param {
 	/** Maximum Advertising Interval (N * 0.625) */
 	u16_t interval_max;
 
-	/** Optional pre-defined (random) own address. Currently
+	/** Optional predefined (random) own address. Currently
 	 *  the only permitted use of this is for NRPA with
 	 *  non-connectable advertising.
 	 */
@@ -179,7 +179,7 @@ int bt_le_adv_stop(void);
  *  @param addr Advertiser LE address and type.
  *  @param rssi Strength of advertiser signal.
  *  @param adv_type Type of advertising response from advertiser.
- *  @param data Buffer containig advertiser data.
+ *  @param data Buffer containing advertiser data.
  */
 typedef void bt_le_scan_cb_t(const bt_addr_le_t *addr, s8_t rssi,
 			     u8_t adv_type, struct net_buf_simple *buf);

--- a/include/bluetooth/conn.h
+++ b/include/bluetooth/conn.h
@@ -196,7 +196,7 @@ struct bt_conn *bt_conn_create_le(const bt_addr_le_t *peer,
 /** @brief Automatically connect to remote device if it's in range.
  *
  *  This function enables/disables automatic connection initiation.
- *  Everytime the device looses the connection with peer, this connection
+ *  Every time the device looses the connection with peer, this connection
  *  will be re-established if connectable advertisement from peer is received.
  *
  *  @param addr Remote Bluetooth address.
@@ -219,7 +219,7 @@ int bt_le_set_auto_conn(bt_addr_le_t *addr,
  *  In case of high duty cycle this will result in a callback with
  *  connected() with a new connection or with an error.
  *
- *  The advertising may be cancelled with bt_conn_disconnect().
+ *  The advertising may be canceled with bt_conn_disconnect().
  *
  *  Returns a new reference that the the caller is responsible for managing.
  *
@@ -282,7 +282,7 @@ u8_t bt_conn_enc_key_size(struct bt_conn *conn);
  *
  *  This structure is used for tracking the state of a connection.
  *  It is registered with the help of the bt_conn_cb_register() API.
- *  It's premissible to register multiple instances of this @ref bt_conn_cb
+ *  It's permissible to register multiple instances of this @ref bt_conn_cb
  *  type, in case different modules of an application are interested in
  *  tracking the connection state. If a callback is not of interest for
  *  an instance, it may be set to NULL and will as a consequence not be

--- a/include/bluetooth/gatt.h
+++ b/include/bluetooth/gatt.h
@@ -343,7 +343,7 @@ ssize_t bt_gatt_attr_read(struct bt_conn *conn, const struct bt_gatt_attr *attr,
 /** @brief Read Service Attribute helper.
  *
  *  Read service attribute value storing the result into buffer after
- *  enconding it.
+ *  encoding it.
  *  NOTE: Only use this with attributes which user_data is a bt_uuid.
  *
  *  @param conn Connection object.
@@ -408,7 +408,7 @@ ssize_t bt_gatt_attr_read_service(struct bt_conn *conn,
 /** @brief Read Include Attribute helper.
  *
  *  Read include service attribute value storing the result into buffer after
- *  enconding it.
+ *  encoding it.
  *  NOTE: Only use this with attributes which user_data is a bt_gatt_include.
  *
  *  @param conn Connection object.
@@ -442,7 +442,7 @@ ssize_t bt_gatt_attr_read_included(struct bt_conn *conn,
 /** @brief Read Characteristic Attribute helper.
  *
  *  Read characteristic attribute value storing the result into buffer after
- *  enconding it.
+ *  encoding it.
  *  NOTE: Only use this with attributes which user_data is a bt_gatt_chrc.
  *
  *  @param conn Connection object.
@@ -497,7 +497,7 @@ struct _bt_gatt_ccc {
 /** @brief Read Client Characteristic Configuration Attribute helper.
  *
  *  Read CCC attribute value storing the result into buffer after
- *  enconding it.
+ *  encoding it.
  *  NOTE: Only use this with attributes which user_data is a _bt_gatt_ccc.
  *
  *  @param conn Connection object.
@@ -943,7 +943,7 @@ int bt_gatt_write(struct bt_conn *conn, struct bt_gatt_write_params *params);
 /** @brief Write Attribute Value by handle without response
  *
  * This procedure write the attribute value without requiring an
- * acknowledgement that the write was successfully performed
+ * acknowledgment that the write was successfully performed
  *
  * @param conn Connection object.
  * @param handle Attribute handle.

--- a/include/bluetooth/sdp.h
+++ b/include/bluetooth/sdp.h
@@ -472,7 +472,7 @@ struct bt_sdp_client_result {
 };
 
 /** @brief Helper enum to be used as return value of bt_sdp_discover_func_t.
- *  The value informs the caller to perform futher pending actions or stop them.
+ *  The value informs the caller to perform further pending actions or stop them.
  */
 enum {
 	BT_SDP_DISCOVER_UUID_STOP = 0,
@@ -483,7 +483,7 @@ enum {
  *
  *  @brief Callback type reporting to user that there is a resolved result
  *  on remote for given UUID and the result record buffer can be used by user
- *  for futher inspection.
+ *  for further inspection.
  *
  *  A function of this type is given by the user to the bt_sdp_discover_params
  *  object. It'll be called on each valid record discovery completion for given

--- a/include/display/grove_lcd.h
+++ b/include/display/grove_lcd.h
@@ -50,7 +50,7 @@ void glcd_clear(struct device *port);
  *  @brief Function to change the display state.
  *  @details This function provides the user the ability to change the state
  *  of the display as per needed. Controlling things like powering on or off
- *  the screen, the option to display the cusror or not, and the ability to
+ *  the screen, the option to display the cursor or not, and the ability to
  *  blink the cursor.
  *
  *  @param port Pointer to device structure for driver instance.
@@ -129,9 +129,9 @@ u8_t glcd_function_get(struct device *port);
 #define GROVE_RGB_GREEN		2
 #define GROVE_RGB_BLUE		3
 /**
- *  @brief Set LCD background to a predfined color
+ *  @brief Set LCD background to a predefined color
  *  @param port Pointer to device structure for driver instance.
- *  @param color One of the pre-defined color options
+ *  @param color One of the predefined color options
  */
 void glcd_color_select(struct device *port, u8_t color);
 

--- a/include/drivers/usb/usb_dc.h
+++ b/include/drivers/usb/usb_dc.h
@@ -277,7 +277,7 @@ int usb_dc_ep_read(const u8_t ep, u8_t *const data,
  * @brief set callback function for the specified endpoint
  *
  * Function to set callback function for notification of data received and
- * available to application or trasmit done on the selected endpoint,
+ * available to application or transmit done on the selected endpoint,
  * NULL if callback not required by application code.
  *
  * @param[in] ep Endpoint address corresponding to the one
@@ -291,7 +291,7 @@ int usb_dc_ep_set_callback(const u8_t ep, const usb_dc_ep_callback cb);
 /**
  * @brief read data from the specified endpoint
  *
- * This is similar to usb_dc_ep_read, the difference being that, it doesnt
+ * This is similar to usb_dc_ep_read, the difference being that, it doesn't
  * clear the endpoint NAKs so that the consumer is not bogged down by further
  * upcalls till he is done with the processing of the data. The caller should
  * reactivate ep by invoking usb_dc_ep_read_continue() do so.
@@ -316,7 +316,7 @@ int usb_dc_ep_read_wait(u8_t ep, u8_t *data, u32_t max_data_len,
  * Clear the endpoint NAK and enable the endpoint to accept more data
  * from the host. Usually called after usb_dc_ep_read_wait() when the consumer
  * is fine to accept more data. Thus these calls together acts as flow control
- * meachanism.
+ * mechanism.
  *
  * @param[in]  ep           Endpoint address corresponding to the one
  *                          listed in the device configuration table

--- a/include/kernel.h
+++ b/include/kernel.h
@@ -1139,7 +1139,7 @@ extern s64_t k_uptime_get(void);
 /**
  * @brief Enable clock always on in tickless kernel
  *
- * This routine enables keepng the clock running when
+ * This routine enables keeping the clock running when
  * there are no timer events programmed in tickless kernel
  * scheduling. This is necessary if the clock is used to track
  * passage of time.
@@ -1159,7 +1159,7 @@ static inline int k_enable_sys_clock_always_on(void)
 /**
  * @brief Disable clock always on in tickless kernel
  *
- * This routine disables keepng the clock running when
+ * This routine disables keeping the clock running when
  * there are no timer events programmed in tickless kernel
  * scheduling. To save power, this routine should be called
  * immediately when clock is not used to track time.

--- a/include/logging/kernel_event_logger.h
+++ b/include/logging/kernel_event_logger.h
@@ -18,7 +18,7 @@
 extern "C" {
 #endif
 
-/* pre-defined event types */
+/* predefined event types */
 
 #define KERNEL_EVENT_LOGGER_CONTEXT_SWITCH_EVENT_ID             0x0001
 #define KERNEL_EVENT_LOGGER_INTERRUPT_EVENT_ID                  0x0002

--- a/include/logging/sys_log.h
+++ b/include/logging/sys_log.h
@@ -156,7 +156,7 @@ void syslog_hook_install(void (*hook)(const char *, ...));
  *
  * @details available if SYS_LOG_LEVEL is SYS_LOG_LEVEL_WARNING or higher.
  * It's meant to register messages related to unusual situations that are
- * not necesarily errors.
+ * not necessarily errors.
  *
  * @param ... A string optionally containing printk valid conversion specifier,
  * followed by as many values as specifiers.

--- a/include/misc/byteorder.h
+++ b/include/misc/byteorder.h
@@ -109,7 +109,7 @@
 #endif
 
 /**
- *  @brief Put a 16-bit intger as big-endian to arbitrary location.
+ *  @brief Put a 16-bit integer as big-endian to arbitrary location.
  *
  *  Put a 16-bit integer, originally in host endianness, to a
  *  potentially unaligned memory location in big-endian format.
@@ -124,7 +124,7 @@ static inline void sys_put_be16(u16_t val, u8_t dst[2])
 }
 
 /**
- *  @brief Put a 32-bit intger as big-endian to arbitrary location.
+ *  @brief Put a 32-bit integer as big-endian to arbitrary location.
  *
  *  Put a 32-bit integer, originally in host endianness, to a
  *  potentially unaligned memory location in big-endian format.
@@ -139,7 +139,7 @@ static inline void sys_put_be32(u32_t val, u8_t dst[4])
 }
 
 /**
- *  @brief Put a 16-bit intger as little-endian to arbitrary location.
+ *  @brief Put a 16-bit integer as little-endian to arbitrary location.
  *
  *  Put a 16-bit integer, originally in host endianness, to a
  *  potentially unaligned memory location in little-endian format.
@@ -154,7 +154,7 @@ static inline void sys_put_le16(u16_t val, u8_t dst[2])
 }
 
 /**
- *  @brief Put a 32-bit intger as little-endian to arbitrary location.
+ *  @brief Put a 32-bit integer as little-endian to arbitrary location.
  *
  *  Put a 32-bit integer, originally in host endianness, to a
  *  potentially unaligned memory location in little-endian format.
@@ -184,7 +184,7 @@ static inline void sys_put_le64(u64_t val, u8_t dst[8])
 }
 
 /**
- *  @brief Get a 16-bit intger stored in big-endian format.
+ *  @brief Get a 16-bit integer stored in big-endian format.
  *
  *  Get a 16-bit integer, stored in big-endian format in a potentially
  *  unaligned memory location, and convert it to the host endianness.
@@ -199,7 +199,7 @@ static inline u16_t sys_get_be16(const u8_t src[2])
 }
 
 /**
- *  @brief Get a 32-bit intger stored in big-endian format.
+ *  @brief Get a 32-bit integer stored in big-endian format.
  *
  *  Get a 32-bit integer, stored in big-endian format in a potentially
  *  unaligned memory location, and convert it to the host endianness.
@@ -214,7 +214,7 @@ static inline u32_t sys_get_be32(const u8_t src[4])
 }
 
 /**
- *  @brief Get a 16-bit intger stored in little-endian format.
+ *  @brief Get a 16-bit integer stored in little-endian format.
  *
  *  Get a 16-bit integer, stored in little-endian format in a potentially
  *  unaligned memory location, and convert it to the host endianness.
@@ -229,7 +229,7 @@ static inline u16_t sys_get_le16(const u8_t src[2])
 }
 
 /**
- *  @brief Get a 32-bit intger stored in little-endian format.
+ *  @brief Get a 32-bit integer stored in little-endian format.
  *
  *  Get a 32-bit integer, stored in little-endian format in a potentially
  *  unaligned memory location, and convert it to the host endianness.

--- a/include/misc/dlist.h
+++ b/include/misc/dlist.h
@@ -132,7 +132,7 @@ typedef struct _dnode sys_dnode_t;
 
 /**
  * @brief Provide the primitive to iterate on a list under a container
- * Note: the loop is unsafe and thus __cn should not be dettached
+ * Note: the loop is unsafe and thus __cn should not be detached
  *
  * User _MUST_ add the loop statement curly braces enclosing its own code:
  *
@@ -150,7 +150,7 @@ typedef struct _dnode sys_dnode_t;
 
 /**
  * @brief Provide the primitive to safely iterate on a list under a container
- * Note: __cn can be dettached, it will not break the loop.
+ * Note: __cn can be detached, it will not break the loop.
  *
  * User _MUST_ add the loop statement curly braces enclosing its own code:
  *

--- a/include/misc/slist.h
+++ b/include/misc/slist.h
@@ -138,7 +138,7 @@ typedef struct _slist sys_slist_t;
 
 /**
  * @brief Provide the primitive to iterate on a list under a container
- * Note: the loop is unsafe and thus __cn should not be dettached
+ * Note: the loop is unsafe and thus __cn should not be detached
  *
  * User _MUST_ add the loop statement curly braces enclosing its own code:
  *
@@ -156,7 +156,7 @@ typedef struct _slist sys_slist_t;
 
 /**
  * @brief Provide the primitive to safely iterate on a list under a container
- * Note: __cn can be dettached, it will not break the loop.
+ * Note: __cn can be detached, it will not break the loop.
  *
  * User _MUST_ add the loop statement curly braces enclosing its own code:
  *

--- a/include/net/buf.h
+++ b/include/net/buf.h
@@ -226,7 +226,7 @@ void net_buf_simple_push_u8(struct net_buf_simple *buf, u8_t val);
 /**
  *  @brief Remove data from the beginning of the buffer.
  *
- *  Removes data from the beginnig of the buffer by modifying the data
+ *  Removes data from the beginning of the buffer by modifying the data
  *  pointer and buffer length.
  *
  *  @param buf Buffer to update.
@@ -826,7 +826,7 @@ static inline void *net_buf_user_data(struct net_buf *buf)
  *  @def net_buf_pull
  *  @brief Remove data from the beginning of the buffer.
  *
- *  Removes data from the beginnig of the buffer by modifying the data
+ *  Removes data from the beginning of the buffer by modifying the data
  *  pointer and buffer length.
  *
  *  @param buf Buffer to update.

--- a/include/net/ieee802154_radio.h
+++ b/include/net/ieee802154_radio.h
@@ -74,7 +74,7 @@ extern int ieee802154_radio_send(struct net_if *iface,
  * @brief Radio driver ACK handling function that hw drivers should use
  *
  * @details ACK handling requires fast handling and thus such function
- *          helps to hook direcly the hw drivers to the radio driver.
+ *          helps to hook directly the hw drivers to the radio driver.
  *
  * @param iface A valid pointer on a network interface that received the packet
  * @param pkt A valid pointer on a packet to check

--- a/include/net/net_context.h
+++ b/include/net/net_context.h
@@ -691,7 +691,7 @@ int net_context_sendto(struct net_pkt *pkt,
  * called. The callback is called even if timeout was set to K_FOREVER,
  * the callback is called before this function will return in this case.
  * The callback is not called if the timeout expires. The timeout functionality
- * can be compiled out if synchronous behaviour is not needed. The sync call
+ * can be compiled out if synchronous behavior is not needed. The sync call
  * logic requires some memory that can be saved if only async way of call is
  * used. If CONFIG_NET_CONTEXT_SYNC_RECV is not set, then the timeout parameter
  * value is ignored.

--- a/include/net/net_mgmt.h
+++ b/include/net/net_mgmt.h
@@ -199,7 +199,7 @@ void net_mgmt_event_notify(u32_t mgmt_event, struct net_if *iface);
  *        has bit NET_MGMT_IFACE_BIT set relevantly, depending on events
  *        the caller wants to listen to.
  * @param timeout a delay in milliseconds. K_FOREVER can be used to wait
- *        undefinitely.
+ *        indefinitely.
  *
  * @return 0 on success, a negative error code otherwise. -ETIMEDOUT will
  *         be specifically returned if the timeout kick-in instead of an
@@ -220,7 +220,7 @@ int net_mgmt_event_wait(u32_t mgmt_event_mask,
  *        the mask generated the event. Can be NULL if the caller is not
  *        interested in that information.
  * @param timeout a delay in milliseconds. K_FOREVER can be used to wait
- *        undefinitely.
+ *        indefinitely.
  *
  * @return 0 on success, a negative error code otherwise. -ETIMEDOUT will
  *         be specifically returned if the timeout kick-in instead of an

--- a/include/net/net_offload.h
+++ b/include/net/net_offload.h
@@ -369,7 +369,7 @@ static inline int net_offload_sendto(struct net_if *iface,
  * called. The callback is called even if timeout was set to K_FOREVER,
  * the callback is called before this function will return in this case.
  * The callback is not called if the timeout expires. The timeout functionality
- * can be compiled out if synchronous behaviour is not needed. The sync call
+ * can be compiled out if synchronous behavior is not needed. The sync call
  * logic requires some memory that can be saved if only async way of call is
  * used. If CONFIG_NET_CONTEXT_SYNC_RECV is not set, then the timeout parameter
  * value is ignored.

--- a/include/net/net_pkt.h
+++ b/include/net/net_pkt.h
@@ -775,7 +775,7 @@ struct net_buf *net_pkt_frag_del(struct net_pkt *pkt,
 void net_pkt_frag_add(struct net_pkt *pkt, struct net_buf *frag);
 
 /**
- * @brief Insert a fragment to a packet at the beginning of its framgment list
+ * @brief Insert a fragment to a packet at the beginning of its fragment list
  *
  * @param pkt pkt Network packet where to insert the fragment
  * @param frag Fragment to insert
@@ -989,7 +989,7 @@ static inline bool net_pkt_append_le32(struct net_pkt *pkt, u32_t data)
  * @brief Get data from buffer
  *
  * @details Get N number of bytes starting from fragment's offset. If the total
- * length of data is placed in multiple framgents, this function will read from
+ * length of data is placed in multiple fragments, this function will read from
  * all fragments until it reaches N number of bytes. Caller has to take care of
  * endianness if needed.
  *
@@ -1011,7 +1011,7 @@ struct net_buf *net_frag_read(struct net_buf *frag, u16_t offset,
  * @brief Skip N number of bytes while reading buffer
  *
  * @details Skip N number of bytes starting from fragment's offset. If the total
- * length of data is placed in multiple framgents, this function will skip from
+ * length of data is placed in multiple fragments, this function will skip from
  * all fragments until it reaches N number of bytes. This function is useful
  * when unwanted data (e.g. reserved or not supported data in message) is part
  * of fragment and want to skip it.
@@ -1280,7 +1280,7 @@ int net_pkt_split(struct net_pkt *pkt, struct net_buf *orig_frag,
 		  struct net_buf **fragB, s32_t timeout);
 
 /**
- * @brief Get information about pre-defined RX, TX and DATA pools.
+ * @brief Get information about predefined RX, TX and DATA pools.
  *
  * @param rx Pointer to RX pool is returned.
  * @param tx Pointer to TX pool is returned.

--- a/include/net/zoap.h
+++ b/include/net/zoap.h
@@ -443,7 +443,7 @@ void zoap_pending_clear(struct zoap_pending *pending);
  * @brief Cancels awaiting for this reply, so it becomes available
  * again.
  *
- * @param reply The reply to be cancelled
+ * @param reply The reply to be canceled
  */
 void zoap_reply_clear(struct zoap_reply *reply);
 
@@ -511,7 +511,7 @@ int zoap_packet_set_used(struct zoap_packet *zpkt, u16_t len);
 /**
  * @brief Adds an option to the packet.
  *
- * Note: ptions must be added in numeric order of their codes.
+ * Note: options must be added in numeric order of their codes.
  *
  * @param zpkt Packet to be updated
  * @param code Option code to add to the packet, see #zoap_option_num

--- a/include/usb/usb_device.h
+++ b/include/usb/usb_device.h
@@ -263,7 +263,7 @@ int usb_ep_clear_stall(u8_t ep);
 /**
  * @brief read data from the specified endpoint
  *
- * This is similar to usb_ep_read, the difference being that, it doesnt
+ * This is similar to usb_ep_read, the difference being that, it doesn't
  * clear the endpoint NAKs so that the consumer is not bogged down by further
  * upcalls till he is done with the processing of the data. The caller should
  * reactivate ep by invoking usb_ep_read_continue() do so.
@@ -288,7 +288,7 @@ int usb_ep_read_wait(u8_t ep, u8_t *data, u32_t max_data_len,
  * Clear the endpoint NAK and enable the endpoint to accept more data
  * from the host. Usually called after usb_ep_read_wait() when the consumer
  * is fine to accept more data. Thus these calls together acts as flow control
- * meachanism.
+ * mechanism.
  *
  * @param[in]  ep           Endpoint address corresponding to the one
  *                          listed in the device configuration table

--- a/include/usb/usbstruct.h
+++ b/include/usb/usbstruct.h
@@ -28,9 +28,9 @@
 
 /**
  * @file
- * @brief standard USB packet stuctures and defines
+ * @brief standard USB packet structures and defines
  *
- * This file contains stuctures and defines of the standard USB packets
+ * This file contains structures and defines of the standard USB packets
  */
 
 #ifndef _USBSTRUCT_H_


### PR DESCRIPTION
fix misspellings found in doxygen comments used for API docs

Signed-off-by: David B. Kinder <david.b.kinder@intel.com>