### PR TITLE
kernel tests: fatal: added "ignore_faults" tag

### DIFF
--- a/tests/kernel/fatal/testcase.ini
+++ b/tests/kernel/fatal/testcase.ini
@@ -1,2 +1,2 @@
 [test]
-tags = core
+tags = core ignore_faults


### PR DESCRIPTION
 This test generates a fault as part of the test,hence make the
 test-suite aware of that by tagging it.

Signed-off-by: Rishi Khare <rishi.khare@intel.com>