### PR TITLE
net/if: Do not start TX thread if there is no network interface

### DIFF
--- a/subsys/net/ip/net_if.c
+++ b/subsys/net/ip/net_if.c
@@ -1673,6 +1673,11 @@ void net_if_init(struct k_sem *startup_sync)
 #endif
 	}
 
+	if (iface == __net_if_start) {
+		NET_WARN("There is no network interface to work with!");
+		return;
+	}
+
 	k_thread_spawn(tx_stack, sizeof(tx_stack),
 		       (k_thread_entry_t)net_if_tx_thread,
 		       startup_sync, NULL, NULL, K_PRIO_COOP(7),


### PR DESCRIPTION
And print a warning if that happens.

This will also avoid to raise an ASSERT on net_if_tx_thread()'s k_poll
as this one will be called with no events to work with.

Signed-off-by: Tomasz Bursztyka <tomasz.bursztyka@linux.intel.com>