### PR TITLE
Bluetooth: Reshuffle Kconfig options

### DIFF
--- a/samples/bluetooth/hci_uart/src/main.c
+++ b/samples/bluetooth/hci_uart/src/main.c
@@ -317,7 +317,7 @@ static int hci_uart_init(struct device *unused)
 	SYS_LOG_DBG("");
 
 	hci_uart_dev =
-		device_get_binding(CONFIG_BLUETOOTH_UART_TO_HOST_DEV_NAME);
+		device_get_binding(CONFIG_BLUETOOTH_CONTROLLER_TO_HOST_UART_DEV_NAME);
 	if (!hci_uart_dev) {
 		return -EINVAL;
 	}

--- a/subsys/bluetooth/Kconfig
+++ b/subsys/bluetooth/Kconfig
@@ -34,6 +34,100 @@ config BLUETOOTH_CUSTOM
 endchoice
 
 if BLUETOOTH_HCI
+
+config BLUETOOTH_HCI_RAW
+	bool "RAW HCI access"
+	help
+	  This option allows to access Bluetooth controller
+	  from the application with the RAW HCI protocol.
+
+
+config BLUETOOTH_PERIPHERAL
+	bool "Peripheral Role support"
+	select BLUETOOTH_CONN
+	default y if BLUETOOTH_HCI_RAW
+	help
+	  Select this for LE Peripheral role support.
+
+config BLUETOOTH_CENTRAL
+	bool "Central Role support"
+	select BLUETOOTH_CONN
+	default y if BLUETOOTH_HCI_RAW
+	help
+	  Select this for LE Central role support.
+
+config BLUETOOTH_CONN
+	# Virtual/hidden option
+	bool
+
+config BLUETOOTH_MAX_CONN
+	int "Maximum number of simultaneous connections"
+	depends on BLUETOOTH_CONN
+	range 1 64
+	default 1
+	help
+	  Maximum number of simultaneous Bluetooth connections
+	  supported.
+
+config BLUETOOTH_DEBUG
+	# Virtual/hidden option to make the conditions more intuitive
+	bool
+
+choice
+	prompt "Bluetooth debug type"
+	depends on BLUETOOTH
+	default BLUETOOTH_DEBUG_NONE
+
+config BLUETOOTH_DEBUG_NONE
+	bool "No debug log"
+	help
+	  Select this to disable all Bluetooth debug logs.
+
+config BLUETOOTH_DEBUG_LOG
+	bool "Normal printf-style to console"
+	select BLUETOOTH_DEBUG
+	select PRINTK
+	select SYS_LOG
+	help
+	  This option enables Bluetooth debug going to standard
+	  serial console.
+
+config BLUETOOTH_DEBUG_MONITOR
+	bool "Monitor protocol over UART"
+	select BLUETOOTH_DEBUG
+	select PRINTK
+	select CONSOLE_HAS_DRIVER
+	help
+	  Use a custom logging protocol over the console UART
+	  instead of plain-text output. Requires a special application
+	  on the host side that can decode this protocol. Currently
+	  the 'btmon' tool from BlueZ is capable of doing this.
+
+	  If the target board has two or more external UARTs it is
+	  possible to keep using UART_CONSOLE together with this option,
+	  however if there is only a single external UART then
+	  UART_CONSOLE needs to be disabled (in which case printk/printf
+	  will get encoded into the monitor protocol).
+
+endchoice
+
+config BLUETOOTH_DEBUG_COLOR
+	bool "Use colored logs"
+	depends on BLUETOOTH_DEBUG_LOG
+	select SYS_LOG_SHOW_COLOR
+	default y
+	help
+	  Use color in the logs. This requires an ANSI capable terminal.
+
+config BLUETOOTH_MONITOR_ON_DEV_NAME
+	string "Device Name of Bluetooth monitor logging UART"
+	depends on BLUETOOTH_DEBUG_MONITOR
+	default "UART_0"
+	help
+	 This option specifies the name of UART device to be used
+	 for the Bluetooth monitor logging.
+
+
 source "subsys/bluetooth/host/Kconfig"
 source "subsys/bluetooth/controller/Kconfig"
 endif # BLUETOOTH_HCI

--- a/subsys/bluetooth/controller/Kconfig
+++ b/subsys/bluetooth/controller/Kconfig
@@ -30,6 +30,15 @@ endchoice
 
 comment "BLE Controller configuration"
 
+config BLUETOOTH_CONTROLLER_TO_HOST_UART_DEV_NAME
+	string "Device Name of UART Device to an external Bluetooth Host"
+	default "UART_0"
+	depends on BLUETOOTH_HCI_RAW
+	help
+	  This option specifies the name of UART device to be used
+	  to connect to an external Bluetooth Host when Zephyr is
+	  acting as a Bluetooth Controller.
+
 config BLUETOOTH_CONTROLLER_TO_HOST_FC
 	bool "Controller to Host Flow Control"
 	depends on BLUETOOTH_CONN

--- a/subsys/bluetooth/host/Kconfig
+++ b/subsys/bluetooth/host/Kconfig
@@ -9,53 +9,12 @@
 
 comment "Host Stack Configuration"
 
-config BLUETOOTH_HCI_RAW
-	bool "RAW HCI access"
-	help
-	  This option allows to access Bluetooth controller
-	  from the application with the RAW HCI protocol.
-
-config BLUETOOTH_UART_TO_HOST_DEV_NAME
-	string "Device Name of UART Device to an external Bluetooth Host"
-	default "UART_0"
-	depends on BLUETOOTH_HCI_RAW
-	help
-	  This option specifies the name of UART device to be used
-	  to connect to an external Bluetooth Host when Zephyr is
-	  acting as a Bluetooth Controller.
-
 config BLUETOOTH_HCI_HOST
 	# Virtual/hidden option to make the conditions more intuitive
 	bool
 	default y
 	depends on !BLUETOOTH_HCI_RAW
 	select POLL
-
-config BLUETOOTH_PERIPHERAL
-	bool "Peripheral Role support"
-	select BLUETOOTH_CONN
-	default y if BLUETOOTH_HCI_RAW
-	help
-	  Select this for LE Peripheral role support.
-
-config BLUETOOTH_CENTRAL
-	bool "Central Role support"
-	select BLUETOOTH_CONN
-	default y if BLUETOOTH_HCI_RAW
-	help
-	  Select this for LE Central role support.
-
-config BLUETOOTH_CONN
-	bool
-
-config BLUETOOTH_MAX_CONN
-	int "Maximum number of simultaneous connections"
-	depends on BLUETOOTH_CONN
-	range 1 64
-	default 1
-	help
-	  Maximum number of simultaneous Bluetooth connections
-	  supported.
 
 config BLUETOOTH_HCI_CMD_COUNT
 	int "Number of HCI command buffers"
@@ -310,63 +269,6 @@ config BLUETOOTH_TINYCRYPT_ECC
 	  In builds including the HCI Raw interface and the BLE Controller, this
 	  option injects support for the 2 HCI commands required for LE Secure
 	  Connections so that Hosts can make use of those.
-
-config BLUETOOTH_DEBUG
-	bool
-
-choice
-	prompt "Bluetooth debug type"
-	depends on BLUETOOTH
-	default BLUETOOTH_DEBUG_NONE
-
-config BLUETOOTH_DEBUG_NONE
-	bool "No debug log"
-	help
-	  Select this to disable all Bluetooth debug logs.
-
-config BLUETOOTH_DEBUG_LOG
-	bool "Normal printf-style to console"
-	select BLUETOOTH_DEBUG
-	select PRINTK
-	select SYS_LOG
-	help
-	  This option enables Bluetooth debug going to standard
-	  serial console.
-
-config BLUETOOTH_DEBUG_MONITOR
-	bool "Monitor protocol over UART"
-	select BLUETOOTH_DEBUG
-	select PRINTK
-	select CONSOLE_HAS_DRIVER
-	help
-	  Use a custom logging protocol over the console UART
-	  instead of plain-text output. Requires a special application
-	  on the host side that can decode this protocol. Currently
-	  the 'btmon' tool from BlueZ is capable of doing this.
-
-	  If the target board has two or more external UARTs it is
-	  possible to keep using UART_CONSOLE together with this option,
-	  however if there is only a single external UART then
-	  UART_CONSOLE needs to be disabled (in which case printk/printf
-	  will get encoded into the monitor protocol).
-
-endchoice
-
-config BLUETOOTH_DEBUG_COLOR
-	bool "Use colored logs"
-	depends on BLUETOOTH_DEBUG_LOG
-	select SYS_LOG_SHOW_COLOR
-	default y
-	help
-	  Use color in the logs. This requires an ANSI capable terminal.
-
-config BLUETOOTH_MONITOR_ON_DEV_NAME
-	string "Device Name of Bluetooth monitor logging UART"
-	depends on BLUETOOTH_DEBUG_MONITOR
-	default "UART_0"
-	help
-	 This option specifies the name of UART device to be used
-	 for the Bluetooth monitor logging.
 
 if BLUETOOTH_DEBUG
 config BLUETOOTH_DEBUG_HCI_CORE


### PR DESCRIPTION
In order to achieve proper sharing of configuration options, everything
that is common to both the Host and the Controller should now be placed
in the top-level Kconfig file, and Controller-only options are in the
controller/ Kconfig one.

Signed-off-by: Carles Cufi <carles.cufi@nordicsemi.no>