### PR TITLE
net: context: tcp: set the pkt appdatalen info when sending packets

### DIFF
--- a/subsys/net/ip/l2/bluetooth.c
+++ b/subsys/net/ip/l2/bluetooth.c
@@ -138,6 +138,7 @@ static void ipsp_connected(struct bt_l2cap_chan *chan)
 
 	ll.addr = ctxt->dst.val;
 	ll.len = sizeof(ctxt->dst.val);
+	ll.type = NET_LINK_BLUETOOTH;
 
 	/* Add remote link-local address to the nbr cache to avoid sending ns:
 	 * https://tools.ietf.org/html/rfc7668#section-3.2.3

--- a/subsys/net/ip/net_context.c
+++ b/subsys/net/ip/net_context.c
@@ -1730,6 +1730,7 @@ static int sendto(struct net_pkt *pkt,
 
 #if defined(CONFIG_NET_TCP)
 	if (net_context_get_ip_proto(context) == IPPROTO_TCP) {
+		net_pkt_set_appdatalen(pkt, net_pkt_get_len(pkt));
 		ret = net_tcp_queue_data(context, pkt);
 	} else
 #endif /* CONFIG_NET_TCP */

--- a/subsys/net/ip/tcp.c
+++ b/subsys/net/ip/tcp.c
@@ -216,6 +216,7 @@ int net_tcp_release(struct net_tcp *tcp)
 		net_pkt_unref(pkt);
 	}
 
+	tcp->ack_timer_cancelled = true;
 	k_delayed_work_cancel(&tcp->ack_timer);
 	k_timer_stop(&tcp->retry_timer);
 	k_sem_reset(&tcp->connect_wait);


### PR DESCRIPTION
when received an ACK, we need the pkt appdatalen info to calculate seq which determine these packets should be released. 