### PR TITLE
[WIP] net: tcp: Explicitly manage TCP receive window.

### DIFF
--- a/subsys/net/ip/tcp.c
+++ b/subsys/net/ip/tcp.c
@@ -191,6 +191,7 @@ struct net_tcp *net_tcp_alloc(struct net_context *context)
 
 	tcp_context[i].send_seq = init_isn();
 	tcp_context[i].recv_max_ack = tcp_context[i].send_seq + 1u;
+	tcp_context[i].recv_wnd = min(NET_TCP_MAX_WIN, NET_TCP_BUF_MAX_LEN);
 
 	tcp_context[i].accept_cb = NULL;
 
@@ -356,8 +357,9 @@ static struct net_pkt *prepare_segment(struct net_tcp *tcp,
 	return pkt;
 }
 
-static inline u32_t get_recv_wnd(struct net_tcp *tcp)
+u32_t get_recv_wnd(struct net_tcp *tcp)
 {
+	return tcp->recv_wnd;
 	ARG_UNUSED(tcp);
 
 	/* We don't queue received data inside the stack, we hand off

--- a/subsys/net/ip/tcp.h
+++ b/subsys/net/ip/tcp.h
@@ -151,6 +151,8 @@ struct net_tcp {
 	 * Semaphore to signal TCP connection completion
 	 */
 	struct k_sem connect_wait;
+
+	uint16_t recv_wnd;
 };
 
 static inline bool net_tcp_is_used(struct net_tcp *tcp)


### PR DESCRIPTION
Challange the existing situation that "if application buffers data,
it's the problem of application". It's actually the problem of the
stack, as it doesn't allow application to control receive window,
and without this control, any buffer will overflow, peer packets
will be dropped, peer won't receive acks for them, and will employ
exponential backoff, the connection will crawl to a halt.

This patch adds net_context_tcp_recved() function which an
application must explicitly call when it *processes* data, to
advance receive window.

Jira: ZEP-1999

Change-Id: Id7255df3d4898e289a2d20e7a02fd5f3f8f05291
Signed-off-by: Paul Sokolovsky <paul.sokolovsky@linaro.org>