### PR TITLE
CI: Fix the git commit range we pass on to gitlint

### DIFF
--- a/.shippable.yml
+++ b/.shippable.yml
@@ -26,8 +26,6 @@ build:
 
     ci:
       - export CCACHE_DIR=${SHIPPABLE_BUILD_DIR}/ccache/.ccache
-      - export COMMIT_RANGE=${SHIPPABLE_COMMIT_RANGE}
-      - echo ${SHIPPABLE_COMMIT_RANGE}
       - source zephyr-env.sh
       - ccache -s --max-size=2000M
       - make host-tools
@@ -46,8 +44,10 @@ build:
           fi;
       - >
           if [ "$RUN_COMPLIANCE" = "1" -a "$IS_PULL_REQUEST" = "true" ]; then
+            export COMMIT_RANGE=origin/${PULL_REQUEST_BASE_BRANCH}..${COMMIT}
             echo "Building a Pull Request";
             echo "- Building Documentation";
+            echo "Commit range:" ${COMMIT_RANGE}
             make htmldocs > doc.log 2>&1;
             ./scripts/filter-known-issues.py --config-dir .known-issues/doc/ doc.log > doc.warnings;
             if [ -s doc.warnings ]; then


### PR DESCRIPTION
The check-compliance.py script uses gitlint to verify the commit message
and takes a range of git commits to validate via the env var
${COMMIT_RANGE}.  Previously we used ${SHIPPABLE_COMMIT_RANGE} however
for branches that doesn't get us what we want.  So we move to using
origin/${PULL_REQUEST_BASE_BRANCH}..${COMMIT}.

Signed-off-by: Kumar Gala <kumar.gala@linaro.org>