### PR TITLE
gitlint: verify full name in signed-off-by line

### DIFF
--- a/scripts/gitlint/zephyr_commit_rules.py
+++ b/scripts/gitlint/zephyr_commit_rules.py
@@ -1,5 +1,6 @@
 from gitlint.rules import CommitRule, RuleViolation
 from gitlint.options import IntOption
+import re
 
 """
 The classes below are examples of user-defined CommitRules. Commit rules are gitlint rules that
@@ -45,8 +46,12 @@ class SignedOffBy(CommitRule):
     id = "UC2"
 
     def validate(self, commit):
+        flags = re.UNICODE
+        flags |= re.IGNORECASE
         for line in commit.message.body:
             if line.lower().startswith("signed-off-by"):
-                return
-
+                if not re.search('(^)Signed-off-by: ([-\w.]+) ([-\w.]+) (.*)', line, flags=flags):
+                    return [RuleViolation(self.id, "Signed-off-by: must have a full name", line_nr=1)]
+                else:
+                    return
         return [RuleViolation(self.id, "Body does not contain a 'Signed-Off-By' line", line_nr=1)]


### PR DESCRIPTION
Make sure we get full name in the commit message and not the username or
some incomplete data that we need to decipher. We still need to verify
the commiter name that is not part of the commit message body, but this
is out of scope of gitlint.

Signed-off-by: Anas Nashif <anas.nashif@intel.com>