### PR TITLE
doc: misspellings in Kconfig files

### DIFF
--- a/drivers/clock_control/Kconfig.stm32f107xx
+++ b/drivers/clock_control/Kconfig.stm32f107xx
@@ -85,7 +85,7 @@ config CLOCK_STM32F10X_CONN_LINE_HSE_BYPASS
 	 Enable this option to bypass external high-speed clock (HSE).
 
 config CLOCK_STM32F10X_CONN_LINE_PREDIV1
-	int "PREDIV1 Prescler"
+	int "PREDIV1 Prescaler"
 	depends on CLOCK_CONTROL_STM32F10X_CONN_LINE && CLOCK_STM32F10X_CONN_LINE_PLL_SRC_PREDIV1
 	default 0
 	range 0 16
@@ -110,7 +110,7 @@ config CLOCK_STM32F10X_CONN_LINE_PLL2_MULTIPLIER
 	 PLL2 multiplier, allowed values: 8 - 20. PLL2 output must not exceed 72MHz.
 
 config CLOCK_STM32F10X_CONN_LINE_PREDIV2
-	int "PREDIV2 Prescler"
+	int "PREDIV2 Prescaler"
 	depends on CLOCK_CONTROL_STM32F10X_CONN_LINE && CLOCK_STM32F10X_CONN_LINE_PREDIV1_SRC_PLL2CLK
 	default 0
 	range 0 16

--- a/drivers/crypto/Kconfig.ataes132a
+++ b/drivers/crypto/Kconfig.ataes132a
@@ -28,7 +28,7 @@ config CRYPTO_ATAES132A_I2C_PORT_NAME
 	  Master I2C port name through which ATAES132A chip is accessed.
 
 config CRYPTO_ATAES132A_I2C_ADDR
-	hex "ATAES132A I2C addess"
+	hex "ATAES132A I2C address"
 	default 0x50
 	help
 	  ATAES132A chip's I2C address.

--- a/drivers/ethernet/Kconfig.sam_gmac
+++ b/drivers/ethernet/Kconfig.sam_gmac
@@ -119,7 +119,7 @@ config ETH_SAM_GMAC_MAC_I2C_INT_ADDRESS_SIZE
 config ETH_SAM_GMAC_MAC_I2C_DEV_NAME
 	string "I2C bus driver device name"
 	help
-	  Device name, e.g. I2C_0, of an I2C bus driver device. It is requied to
+	  Device name, e.g. I2C_0, of an I2C bus driver device. It is required to
 	  obtain handle to the I2C device object.
 
 endif # ETH_SAM_GMAC_MAC_I2C_EEPROM

--- a/drivers/ieee802154/Kconfig.cc2520
+++ b/drivers/ieee802154/Kconfig.cc2520
@@ -46,7 +46,7 @@ config IEEE802154_CC2520_RX_STACK_SIZE
 	a too little one, this option makes it easy to play with the size.
 
 config IEEE802154_CC2520_INIT_PRIO
-	int "CC2520 intialization priority"
+	int "CC2520 initialization priority"
 	default 80
 	help
 	Set the initialization priority number. Do not mess with it unless

--- a/drivers/ieee802154/Kconfig.kw41z
+++ b/drivers/ieee802154/Kconfig.kw41z
@@ -17,7 +17,7 @@ config IEEE802154_KW41Z_DRV_NAME
 	  This option sets the driver name
 
 config IEEE802154_KW41Z_INIT_PRIO
-	int "KW41Z intialization priority"
+	int "KW41Z initialization priority"
 	default 80
 	help
 	  Set the initialization priority number. Do not mess with it unless

--- a/drivers/ieee802154/Kconfig.mcr20a
+++ b/drivers/ieee802154/Kconfig.mcr20a
@@ -108,7 +108,7 @@ config IEEE802154_MCR20A_RX_STACK_SIZE
 	a too little one, this option makes it easy to play with the size.
 
 config IEEE802154_MCR20A_INIT_PRIO
-	int "MCR20A intialization priority"
+	int "MCR20A initialization priority"
 	default 80
 	help
 	Set the initialization priority number. Do not mess with it unless

--- a/drivers/ieee802154/Kconfig.nrf5
+++ b/drivers/ieee802154/Kconfig.nrf5
@@ -43,7 +43,7 @@ config IEEE802154_NRF5_RX_STACK_SIZE
 	a too little one, this option makes it easy to play with the size.
 
 config IEEE802154_NRF5_INIT_PRIO
-	int "nRF52 IEEE 802.15.4 intialization priority"
+	int "nRF52 IEEE 802.15.4 initialization priority"
 	default 80
 	help
 	Set the initialization priority number. Do not mess with it unless
@@ -56,7 +56,7 @@ choice IEEE802154_NRF5_CCA_MODE
 	CCA mode
 
 config IEEE802154_NRF5_CCA_MODE_ED
-	bool "Energy Above Threashold"
+	bool "Energy Above Threshold"
 
 config IEEE802154_NRF5_CCA_MODE_CARRIER
 	bool "Carrier Seen"

--- a/drivers/sensor/lis2dh/Kconfig
+++ b/drivers/sensor/lis2dh/Kconfig
@@ -196,7 +196,7 @@ choice
 	depends on LIS2DH
 	default LIS2DH_ODR_RUNTIME
 	help
-	  Initial data rate frequency of acceleration data at initialisation.
+	  Initial data rate frequency of acceleration data at initialization.
 	  Supported values:
 	  1Hz, 10Hz, 25Hz, 50Hz, 100Hz, 200Hz, 400Hz in all power modes
 	  1620Hz, 5376Hz in low power mode only

--- a/drivers/spi/Kconfig.dw
+++ b/drivers/spi/Kconfig.dw
@@ -43,7 +43,7 @@ config SPI_DW_INTERRUPT_SEPARATED_LINES
 endchoice
 
 config SPI_DW_CLOCK_GATE
-	bool "Enable glock gating"
+	bool "Enable clock gating"
 	depends on SPI_DW && SOC_QUARK_SE_C1000
 	select CLOCK_CONTROL
 	default n

--- a/kernel/Kconfig.power_mgmt
+++ b/kernel/Kconfig.power_mgmt
@@ -92,11 +92,11 @@ config TICKLESS_KERNEL_TIME_UNIT_IN_MICRO_SECS
 	default 1000
 	depends on TICKLESS_KERNEL
 	help
-	This option makes the system clock and scheduling granurality.
+	This option makes the system clock and scheduling granularity.
 	The default will be one mili second. This option also determines
 	the time unit passed in functions like _sys_soc_suspend. The
 	value should be determined based what the timer hardware and driver
-	can support. Spceficying too small a time unit than what the overall
+	can support. Specifying too small a time unit than what the overall
 	system speed can support would cause scheduling errors.
 
 config BUSY_WAIT_USES_ALTERNATE_CLOCK
@@ -106,7 +106,7 @@ config BUSY_WAIT_USES_ALTERNATE_CLOCK
 	help
 	In tickless kernel mode, the system clock will be stopped when
 	there are no timer events programmed. If the system clock is to
-	be used to keep time e.g. to get a delata of time cycles then it
+	be used to keep time e.g. to get a delta of time cycles then it
 	needs to be turned on using provided APIs. Some platforms have
 	alternate clocks which can be used instead. In that case this flag
 	would be set to true. This flag would be checked before turning

--- a/misc/Kconfig
+++ b/misc/Kconfig
@@ -173,7 +173,7 @@ config BOOT_TIME_MEASUREMENT
 
 config CPU_CLOCK_FREQ_MHZ
 	int
-	prompt "CPU CLock Frequency in MHz"
+	prompt "CPU Clock Frequency in MHz"
 	default 20
 	depends on BOOT_TIME_MEASUREMENT
 	help

--- a/subsys/net/ip/l2/Kconfig
+++ b/subsys/net/ip/l2/Kconfig
@@ -89,7 +89,7 @@ config NET_DEBUG_L2_BLUETOOTH
 	Enables Bluetooth L2 output debug messages
 
 config NET_L2_BLUETOOTH_MGMT
-	bool "Enable Blueooth Network Management support"
+	bool "Enable Bluetooth Network Management support"
 	depends on NET_L2_BLUETOOTH
 	select NET_MGMT
 	select NET_MGMT_EVENT


### PR DESCRIPTION
fix misspelling in Kconfig files that would show up in configuration
documentation and screens.

Signed-off-by: David B. Kinder <david.b.kinder@intel.com>