### PR TITLE
Bluetooth: Fix hci_raw's RX buffer alloc

### DIFF
--- a/subsys/bluetooth/host/hci_raw.c
+++ b/subsys/bluetooth/host/hci_raw.c
@@ -47,7 +47,15 @@ int bt_hci_driver_register(const struct bt_hci_driver *drv)
 
 struct net_buf *bt_buf_get_rx(enum bt_buf_type type, s32_t timeout)
 {
-	return net_buf_alloc(&hci_rx_pool, timeout);
+	struct net_buf *buf;
+
+	buf = net_buf_alloc(&hci_rx_pool, timeout);
+
+	if (buf) {
+		bt_buf_set_type(buf, type);
+	}
+
+	return buf;
 }
 
 struct net_buf *bt_buf_get_cmd_complete(s32_t timeout)
@@ -57,30 +65,6 @@ struct net_buf *bt_buf_get_cmd_complete(s32_t timeout)
 	buf = net_buf_alloc(&hci_rx_pool, timeout);
 	if (buf) {
 		bt_buf_set_type(buf, BT_BUF_EVT);
-	}
-
-	return buf;
-}
-
-struct net_buf *bt_buf_get_evt(u8_t opcode, int timeout)
-{
-	struct net_buf *buf;
-
-	buf = net_buf_alloc(&hci_rx_pool, timeout);
-	if (buf) {
-		bt_buf_set_type(buf, BT_BUF_EVT);
-	}
-
-	return buf;
-}
-
-struct net_buf *bt_buf_get_acl(s32_t timeout)
-{
-	struct net_buf *buf;
-
-	buf = net_buf_alloc(&hci_rx_pool, timeout);
-	if (buf) {
-		bt_buf_set_type(buf, BT_BUF_ACL_IN);
 	}
 
 	return buf;


### PR DESCRIPTION
The APIs for allocating RX buffers were modified recently and hci_raw
had not reflected those changes properly.

Signed-off-by: Carles Cufi <carles.cufi@nordicsemi.no>