### PR TITLE
handle RST packets under the status of tcp established

### DIFF
--- a/subsys/net/ip/net_context.c
+++ b/subsys/net/ip/net_context.c
@@ -816,6 +816,11 @@ NET_CONN_CB(tcp_established)
 				     sys_get_be32(NET_TCP_HDR(pkt)->ack));
 	}
 
+	if (tcp_flags & NET_TCP_RST) {
+		net_context_unref(context);
+		return NET_DROP;
+	}
+
 	if (sys_get_be32(NET_TCP_HDR(pkt)->seq) - context->tcp->send_ack) {
 		/* Don't try to reorder packets.  If it doesn't
 		 * match the next segment exactly, drop and wait for


### PR DESCRIPTION
when tcp connection was established, if one RST packet
received from peer next, the current connection should
be free.
