### PR TITLE
Add k_thread_create() API; replace k_thread_spawn()

### DIFF
--- a/arch/arc/core/thread.c
+++ b/arch/arc/core/thread.c
@@ -54,7 +54,7 @@ struct init_stack_frame {
  *
  * @return N/A
  */
-void _new_thread(char *pStackMem, size_t stackSize,
+void _new_thread(struct k_thread *thread, char *pStackMem, size_t stackSize,
 		 _thread_entry_t pEntry,
 		 void *parameter1, void *parameter2, void *parameter3,
 		 int priority, unsigned int options)
@@ -64,12 +64,9 @@ void _new_thread(char *pStackMem, size_t stackSize,
 	char *stackEnd = pStackMem + stackSize;
 	struct init_stack_frame *pInitCtx;
 
-	struct k_thread *thread;
-
-	thread = _new_thread_init(pStackMem, stackSize, priority, options);
+	_new_thread_init(thread, pStackMem, stackSize, priority, options);
 
 	/* carve the thread entry struct from the "base" of the stack */
-
 	pInitCtx = (struct init_stack_frame *)(STACK_ROUND_DOWN(stackEnd) -
 				       sizeof(struct init_stack_frame));
 

--- a/arch/arm/core/thread.c
+++ b/arch/arm/core/thread.c
@@ -49,7 +49,7 @@
  * @return N/A
  */
 
-void _new_thread(char *pStackMem, size_t stackSize,
+void _new_thread(struct k_thread *thread, char *pStackMem, size_t stackSize,
 		 _thread_entry_t pEntry,
 		 void *parameter1, void *parameter2, void *parameter3,
 		 int priority, unsigned int options)
@@ -62,9 +62,8 @@ void _new_thread(char *pStackMem, size_t stackSize,
 
 	char *stackEnd = pStackMem + stackSize;
 	struct __esf *pInitCtx;
-	struct k_thread *thread = (struct k_thread *) pStackMem;
 
-	thread = _new_thread_init(pStackMem, stackSize, priority, options);
+	_new_thread_init(thread, pStackMem, stackSize, priority, options);
 
 	/* carve the thread entry struct from the "base" of the stack */
 

--- a/arch/arm/include/kernel_arch_func.h
+++ b/arch/arm/include/kernel_arch_func.h
@@ -38,8 +38,8 @@ static ALWAYS_INLINE void kernel_arch_init(void)
 }
 
 static ALWAYS_INLINE void
-_arch_switch_to_main_thread(char *main_stack, size_t main_stack_size,
-			    _thread_entry_t _main)
+_arch_switch_to_main_thread(struct k_thread *main_thread, char *main_stack,
+			    size_t main_stack_size, _thread_entry_t _main)
 {
 	/* get high address of the stack, i.e. its start (stack grows down) */
 	char *start_of_main_stack;
@@ -47,7 +47,7 @@ _arch_switch_to_main_thread(char *main_stack, size_t main_stack_size,
 	start_of_main_stack = main_stack + main_stack_size;
 	start_of_main_stack = (void *)STACK_ROUND_DOWN(start_of_main_stack);
 
-	_current = (void *)main_stack;
+	_current = main_thread;
 
 	/* the ready queue cache already contains the main thread */
 

--- a/arch/nios2/core/thread.c
+++ b/arch/nios2/core/thread.c
@@ -31,17 +31,16 @@ struct init_stack_frame {
 };
 
 
-void _new_thread(char *stack_memory, size_t stack_size,
+void _new_thread(struct k_thread *thread, char *stack_memory, size_t stack_size,
 		 _thread_entry_t thread_func,
 		 void *arg1, void *arg2, void *arg3,
 		 int priority, unsigned int options)
 {
 	_ASSERT_VALID_PRIO(priority, thread_func);
 
-	struct k_thread *thread;
 	struct init_stack_frame *iframe;
 
-	thread = _new_thread_init(stack_memory, stack_size, priority, options);
+	_new_thread_init(thread, stack_memory, stack_size, priority, options);
 
 	/* Initial stack frame data, stored at the base of the stack */
 	iframe = (struct init_stack_frame *)

--- a/arch/riscv32/core/thread.c
+++ b/arch/riscv32/core/thread.c
@@ -15,17 +15,16 @@ void _thread_entry_wrapper(_thread_entry_t thread,
 			   void *arg2,
 			   void *arg3);
 
-void _new_thread(char *stack_memory, size_t stack_size,
-		 _thread_entry_t thread_func,
+void _new_thread(struct k_thread *thread, char *stack_memory,
+		 size_t stack_size, _thread_entry_t thread_func,
 		 void *arg1, void *arg2, void *arg3,
 		 int priority, unsigned int options)
 {
 	_ASSERT_VALID_PRIO(priority, thread_func);
 
-	struct k_thread *thread;
 	struct __esf *stack_init;
 
-	thread = _new_thread_init(stack_memory, stack_size, priority, options);
+	_new_thread_init(thread, stack_memory, stack_size, priority, options);
 
 	/* Initial stack frame for thread */
 	stack_init = (struct __esf *)

--- a/arch/x86/core/thread.c
+++ b/arch/x86/core/thread.c
@@ -39,6 +39,7 @@ void _thread_entry_wrapper(_thread_entry_t, void *,
  *
  * This function is called by _new_thread() to initialize tasks.
  *
+ * @param thread pointer to thread struct memory
  * @param pStackMem pointer to thread stack memory
  * @param stackSize size of a stack in bytes
  * @param priority thread priority
@@ -180,9 +181,8 @@ __asm__("\t.globl _thread_entry\n"
  * This function is utilized to create execution threads for both fiber
  * threads and kernel tasks.
  *
- * The k_thread structure is carved from the "end" of the specified
- * thread stack memory.
- *
+ * @param thread pointer to thread struct memory, including any space needed
+ *		for extra coprocessor context
  * @param pStackmem the pointer to aligned stack memory
  * @param stackSize the stack size in bytes
  * @param pEntry thread entry point routine
@@ -195,7 +195,7 @@ __asm__("\t.globl _thread_entry\n"
  *
  * @return opaque pointer to initialized k_thread structure
  */
-void _new_thread(char *pStackMem, size_t stackSize,
+void _new_thread(struct k_thread *thread, char *pStackMem, size_t stackSize,
 		 _thread_entry_t pEntry,
 		 void *parameter1, void *parameter2, void *parameter3,
 		 int priority, unsigned int options)
@@ -203,9 +203,8 @@ void _new_thread(char *pStackMem, size_t stackSize,
 	_ASSERT_VALID_PRIO(priority, pEntry);
 
 	unsigned long *pInitialThread;
-	struct k_thread *thread;
 
-	thread = _new_thread_init(pStackMem, stackSize, priority, options);
+	_new_thread_init(thread, pStackMem, stackSize, priority, options);
 
 	/* carve the thread entry struct from the "base" of the stack */
 

--- a/arch/xtensa/core/thread.c
+++ b/arch/xtensa/core/thread.c
@@ -16,9 +16,9 @@
 extern void _xt_user_exit(void);
 
 /*
- * @brief Initialize a new thread from its stack space
+ * @brief Initialize a new thread
  *
- * The struct k_thread is put at the lower address of the stack. An
+ * Any coprocessor context data is put at the lower address of the stack. An
  * initial context, to be "restored" by __return_from_coop(), is put at
  * the other end of the stack, and thus reusable by the stack when not
  * needed anymore.
@@ -29,6 +29,7 @@ extern void _xt_user_exit(void);
  *
  * <options> is currently unused.
  *
+ * @param thread pointer to k_thread memory
  * @param pStackmem the pointer to aligned stack memory
  * @param stackSize the stack size in bytes
  * @param pEntry thread entry point routine
@@ -41,23 +42,19 @@ extern void _xt_user_exit(void);
  * @return N/A
  */
 
-void _new_thread(char *pStack, size_t stackSize,
+void _new_thread(struct k_thread *thread, char *pStack, size_t stackSize,
 		void (*pEntry)(void *, void *, void *),
 		void *p1, void *p2, void *p3,
 		int priority, unsigned int options)
 {
 	/* Align stack end to maximum alignment requirement. */
 	char *stackEnd = (char *)ROUND_DOWN(pStack + stackSize, 16);
-	/* k_thread is located at top of stack while frames are located at end
-	 * of it
-	 */
-	struct k_thread *thread;
 #if XCHAL_CP_NUM > 0
 	u32_t *cpSA;
 	char *cpStack;
 #endif
 
-	thread = _new_thread_init(pStack, stackSize, priority, options);
+	_new_thread_init(thread, pStack, stackSize, priority, options);
 
 #ifdef CONFIG_DEBUG
 	printk("\nstackPtr = %p, stackSize = %d\n", pStack, stackSize);

--- a/doc/kernel/other/float.rst
+++ b/doc/kernel/other/float.rst
@@ -100,15 +100,15 @@ tagged as an SSE user, or if the application wants to avoid the exception
 handling overhead involved in auto-tagging threads, it is possible to
 pre-tag a thread using one of the techniques listed below.
 
-* A statically-spawned x86 thread can be pre-tagged by passing the
+* A statically-created x86 thread can be pre-tagged by passing the
   :c:macro:`K_FP_REGS` or :c:macro:`K_SSE_REGS` option to
   :c:macro:`K_THREAD_DEFINE`.
 
-* A dynamically-spawned x86 thread can be pre-tagged by passing the
+* A dynamically-created x86 thread can be pre-tagged by passing the
   :c:macro:`K_FP_REGS` or :c:macro:`K_SSE_REGS` option to
-  :cpp:func:`k_thread_spawn()`.
+  :cpp:func:`k_thread_create()`.
 
-* An already-spawned x86 thread can pre-tag itself once it has started
+* An already-created x86 thread can pre-tag itself once it has started
   by passing the :c:macro:`K_FP_REGS` or :c:macro:`K_SSE_REGS` option to
   :cpp:func:`k_float_enable()`.
 

--- a/doc/kernel/threads/lifecycle.rst
+++ b/doc/kernel/threads/lifecycle.rst
@@ -18,10 +18,12 @@ referenced by a :dfn:`thread id` that is assigned when the thread is spawned.
 
 A thread has the following key properties:
 
-* A **stack area**, which is a region of memory used for the thread's
-  control block (of type :c:type:`struct k_thread`) and for its stack.
+* A **stack area**, which is a region of memory used for the thread's stack.
   The **size** of the stack area can be tailored to conform to the actual needs
   of the thread's processing.
+
+* A **thread control block** for private kernel bookkeeping of the thread's
+  metadata. This is an instance of type :c:type:`struct k_thread`.
 
 * An **entry point function**, which is invoked when the thread is started.
   Up to 3 **argument values** can be passed to this function.
@@ -38,13 +40,12 @@ A thread has the following key properties:
 
 .. _spawning_thread:
 
-Thread Spawning
+Thread Creation
 ===============
 
-A thread must be spawned before it can be used. The kernel initializes
-the control block portion of the thread's stack area, as well as one
-end of the stack portion. The remainder of the thread's stack is typically
-left uninitialized.
+A thread must be created before it can be used. The kernel initializes
+the thread control block as well as one end of the stack portion. The remainder
+of the thread's stack is typically left uninitialized.
 
 Specifying a start delay of :c:macro:`K_NO_WAIT` instructs the kernel
 to start thread execution immediately. Alternatively, the kernel can be
@@ -146,11 +147,9 @@ Implementation
 Spawning a Thread
 =================
 
-A thread is spawned by defining its stack area and then calling
-:cpp:func:`k_thread_spawn()`. The stack area is an array of bytes
-whose size must equal :c:macro:`K_THREAD_SIZEOF` plus the size
-of the thread's stack. The stack area must be defined using the
-:c:macro:`__stack` attribute to ensure it is properly aligned.
+A thread is spawned by defining its stack area and its thread control block,
+and then calling :cpp:func:`k_thread_create()`. The stack area must be defined
+using the :c:macro:`__stack` attribute to ensure it is properly aligned.
 
 The thread spawning function returns its thread id, which can be used
 to reference the thread.
@@ -165,14 +164,16 @@ The following code spawns a thread that starts immediately.
     extern void my_entry_point(void *, void *, void *);
 
     char __noinit __stack my_stack_area[MY_STACK_SIZE];
+    struct k_thread my_thread_data;
 
-    k_tid_t my_tid = k_thread_spawn(my_stack_area, MY_STACK_SIZE,
-                                    my_entry_point, NULL, NULL, NULL,
-                                    MY_PRIORITY, 0, K_NO_WAIT);
+    k_tid_t my_tid = k_thread_create(&my_thread_data, my_stack_area,
+                                     MY_STACK_SIZE, my_entry_point,
+                                     NULL, NULL, NULL,
+                                     MY_PRIORITY, 0, K_NO_WAIT);
 
 Alternatively, a thread can be spawned at compile time by calling
 :c:macro:`K_THREAD_DEFINE`. Observe that the macro defines
-the stack area and thread id variables automatically.
+the stack area, control block, and thread id variables automatically.
 
 The following code has the same effect as the code segment above.
 
@@ -231,7 +232,7 @@ APIs
 The following thread APIs are provided by :file:`kernel.h`:
 
 * :c:macro:`K_THREAD_DEFINE`
-* :cpp:func:`k_thread_spawn()`
+* :cpp:func:`k_thread_create()`
 * :cpp:func:`k_thread_cancel()`
 * :cpp:func:`k_thread_abort()`
 * :cpp:func:`k_thread_suspend()`

--- a/doc/kernel/threads/workqueues.rst
+++ b/doc/kernel/threads/workqueues.rst
@@ -149,16 +149,14 @@ Defining a Workqueue
 
 A workqueue is defined using a variable of type :c:type:`struct k_work_q`.
 The workqueue is initialized by defining the stack area used by its thread
-and then calling :cpp:func:`k_work_q_start()`. The stack area is an array
-of bytes whose size must equal :c:macro:`K_THREAD_SIZEOF` plus the size
-of the thread's stack. The stack area must be defined using the
-:c:macro:`__stack` attribute to ensure it is properly aligned.
+and then calling :cpp:func:`k_work_q_start()`. The stack area must be defined
+using the :c:macro:`__stack` attribute to ensure it is properly aligned.
 
 The following code defines and initializes a workqueue.
 
 .. code-block:: c
 
-    #define MY_STACK_SIZE (K_THREAD_SIZEOF + 500)
+    #define MY_STACK_SIZE 512
     #define MY_PRIORITY 5
 
     char __noinit __stack my_stack_area[MY_STACK_SIZE];

--- a/drivers/bluetooth/hci/h4.c
+++ b/drivers/bluetooth/hci/h4.c
@@ -37,6 +37,7 @@
 #define H4_EVT  0x04
 
 static BT_STACK_NOINIT(rx_thread_stack, CONFIG_BLUETOOTH_RX_STACK_SIZE);
+static struct k_thread rx_thread_data;
 
 static struct {
 	struct net_buf *buf;
@@ -437,8 +438,9 @@ static int h4_open(void)
 
 	uart_irq_callback_set(h4_dev, bt_uart_isr);
 
-	k_thread_spawn(rx_thread_stack, sizeof(rx_thread_stack), rx_thread,
-		       NULL, NULL, NULL, K_PRIO_COOP(7), 0, K_NO_WAIT);
+	k_thread_create(&rx_thread_data, rx_thread_stack,
+			sizeof(rx_thread_stack), rx_thread,
+			NULL, NULL, NULL, K_PRIO_COOP(7), 0, K_NO_WAIT);
 
 	return 0;
 }

--- a/drivers/bluetooth/hci/h5.c
+++ b/drivers/bluetooth/hci/h5.c
@@ -31,6 +31,9 @@
 static BT_STACK_NOINIT(tx_stack, 256);
 static BT_STACK_NOINIT(rx_stack, 256);
 
+static struct k_thread tx_thread_data;
+static struct k_thread rx_thread_data;
+
 static struct k_delayed_work ack_work;
 static struct k_delayed_work retx_work;
 
@@ -713,12 +716,14 @@ static void h5_init(void)
 
 	/* TX thread */
 	k_fifo_init(&h5.tx_queue);
-	k_thread_spawn(tx_stack, sizeof(tx_stack), (k_thread_entry_t)tx_thread,
-		       NULL, NULL, NULL, K_PRIO_COOP(7), 0, K_NO_WAIT);
+	k_thread_create(&tx_thread_data, tx_stack, sizeof(tx_stack),
+			(k_thread_entry_t)tx_thread,
+			NULL, NULL, NULL, K_PRIO_COOP(7), 0, K_NO_WAIT);
 
 	k_fifo_init(&h5.rx_queue);
-	k_thread_spawn(rx_stack, sizeof(rx_stack), (k_thread_entry_t)rx_thread,
-		       NULL, NULL, NULL, K_PRIO_COOP(7), 0, K_NO_WAIT);
+	k_thread_create(&rx_thread_data, rx_stack, sizeof(rx_stack),
+			(k_thread_entry_t)rx_thread,
+			NULL, NULL, NULL, K_PRIO_COOP(7), 0, K_NO_WAIT);
 
 	/* Unack queue */
 	k_fifo_init(&h5.unack_queue);

--- a/drivers/bluetooth/hci/spi.c
+++ b/drivers/bluetooth/hci/spi.c
@@ -74,6 +74,7 @@ static K_SEM_DEFINE(sem_request, 0, 1);
 static K_SEM_DEFINE(sem_busy, 1, 1);
 
 static BT_STACK_NOINIT(rx_stack, 448);
+static struct k_thread rx_thread_data;
 
 static struct spi_config spi_conf = {
 	.config = SPI_WORD(8),
@@ -323,9 +324,9 @@ static int bt_spi_open(void)
 	}
 
 	/* Start RX thread */
-	k_thread_spawn(rx_stack, sizeof(rx_stack),
-		       (k_thread_entry_t)bt_spi_rx_thread,
-		       NULL, NULL, NULL, K_PRIO_COOP(7), 0, K_NO_WAIT);
+	k_thread_create(&rx_thread_data, rx_stack, sizeof(rx_stack),
+			(k_thread_entry_t)bt_spi_rx_thread,
+			NULL, NULL, NULL, K_PRIO_COOP(7), 0, K_NO_WAIT);
 
 	/* Take BLE out of reset */
 	gpio_pin_write(rst_dev, GPIO_RESET_PIN, 1);

--- a/drivers/bluetooth/nble/uart.c
+++ b/drivers/bluetooth/nble/uart.c
@@ -48,6 +48,8 @@ NET_BUF_POOL_DEFINE(tx_pool, NBLE_TX_BUF_COUNT, NBLE_BUF_SIZE, 0, NULL);
 
 static BT_STACK_NOINIT(rx_thread_stack, CONFIG_BLUETOOTH_RX_STACK_SIZE);
 
+static struct k_thread rx_thread_data;
+
 static struct device *nble_dev;
 
 static K_FIFO_DEFINE(rx_queue);
@@ -204,9 +206,9 @@ int nble_open(void)
 	BT_DBG("");
 
 	/* Initialize receive queue and start rx_thread */
-	k_thread_spawn(rx_thread_stack, sizeof(rx_thread_stack),
-		       (k_thread_entry_t)rx_thread,
-		       NULL, NULL, NULL, K_PRIO_COOP(7), 0, K_NO_WAIT);
+	k_thread_create(&rx_thread_data, rx_thread_stack,
+			sizeof(rx_thread_stack), (k_thread_entry_t)rx_thread,
+			NULL, NULL, NULL, K_PRIO_COOP(7), 0, K_NO_WAIT);
 
 	uart_irq_rx_disable(nble_dev);
 	uart_irq_tx_disable(nble_dev);

--- a/drivers/console/ipm_console_receiver.c
+++ b/drivers/console/ipm_console_receiver.c
@@ -144,9 +144,9 @@ int ipm_console_receiver_init(struct device *d)
 
 	ipm_register_callback(ipm, ipm_console_receive_callback, d);
 
-	k_thread_spawn(config_info->thread_stack, CONFIG_IPM_CONSOLE_STACK_SIZE,
-			 ipm_console_thread, d, NULL, NULL,
-			 K_PRIO_COOP(IPM_CONSOLE_PRI), 0, 0);
+	k_thread_create(&driver_data->rx_thread, config_info->thread_stack,
+			CONFIG_IPM_CONSOLE_STACK_SIZE, ipm_console_thread, d,
+			NULL, NULL, K_PRIO_COOP(IPM_CONSOLE_PRI), 0, 0);
 	ipm_set_enabled(ipm, 1);
 
 	return 0;

--- a/drivers/console/telnet_console.c
+++ b/drivers/console/telnet_console.c
@@ -67,6 +67,7 @@ struct line_buf_rb {
 static struct line_buf_rb telnet_rb;
 
 static char __noinit __stack telnet_stack[TELNET_STACK_SIZE];
+static struct k_thread telnet_thread_data;
 static K_SEM_DEFINE(send_lock, 0, UINT_MAX);
 
 /* The timer is used to send non-lf terminated output that has
@@ -541,11 +542,11 @@ static int telnet_console_init(struct device *arg)
 			    sizeof(any_addr6));
 #endif
 
-	k_thread_spawn(&telnet_stack[0],
-		       TELNET_STACK_SIZE,
-		       (k_thread_entry_t)telnet_run,
-		       NULL, NULL, NULL,
-		       K_PRIO_COOP(TELNET_PRIORITY), 0, K_MSEC(10));
+	k_thread_create(&telnet_thread_data, telnet_stack,
+			TELNET_STACK_SIZE,
+			(k_thread_entry_t)telnet_run,
+			NULL, NULL, NULL,
+			K_PRIO_COOP(TELNET_PRIORITY), 0, K_MSEC(10));
 
 	SYS_LOG_INF("Telnet console initialized");
 

--- a/drivers/ethernet/eth_enc28j60.c
+++ b/drivers/ethernet/eth_enc28j60.c
@@ -413,11 +413,11 @@ static int eth_enc28j60_init(struct device *dev)
 	k_sem_give(&context->tx_rx_sem);
 
 	/* Start interruption-poll thread */
-	k_thread_spawn(context->thread_stack,
-		       CONFIG_ETH_ENC28J60_RX_THREAD_STACK_SIZE,
-		       enc28j60_thread_main, (void *) dev, NULL, NULL,
-		       K_PRIO_COOP(CONFIG_ETH_ENC28J60_RX_THREAD_PRIO),
-		       0, K_NO_WAIT);
+	k_thread_create(&context->thread, context->thread_stack,
+			CONFIG_ETH_ENC28J60_RX_THREAD_STACK_SIZE,
+			enc28j60_thread_main, (void *) dev, NULL, NULL,
+			K_PRIO_COOP(CONFIG_ETH_ENC28J60_RX_THREAD_PRIO),
+			0, K_NO_WAIT);
 
 	SYS_LOG_INF("ENC28J60 Initialized");
 

--- a/drivers/ethernet/eth_enc28j60_priv.h
+++ b/drivers/ethernet/eth_enc28j60_priv.h
@@ -226,6 +226,7 @@ struct eth_enc28j60_config {
 struct eth_enc28j60_runtime {
 	struct net_if *iface;
 	char __stack thread_stack[CONFIG_ETH_ENC28J60_RX_THREAD_STACK_SIZE];
+	struct k_thread thread;
 	struct device *gpio;
 	struct device *spi;
 	struct gpio_callback gpio_cb;

--- a/drivers/gpio/gpio_sch.c
+++ b/drivers/gpio/gpio_sch.c
@@ -217,11 +217,12 @@ static void _gpio_sch_manage_callback(struct device *dev)
 		if (!gpio->poll) {
 			SYS_LOG_DBG("Starting SCH GPIO polling fiber");
 			gpio->poll = 1;
-			k_thread_spawn(gpio->polling_stack,
-				       GPIO_SCH_POLLING_STACK_SIZE,
-				       (k_thread_entry_t)_gpio_sch_poll_status,
-				       dev, NULL, NULL,
-				       K_PRIO_COOP(1), 0, 0);
+			k_thread_create(&gpio->polling_thread,
+					gpio->polling_stack,
+					GPIO_SCH_POLLING_STACK_SIZE,
+					(k_thread_entry_t)_gpio_sch_poll_status,
+					dev, NULL, NULL,
+					K_PRIO_COOP(1), 0, 0);
 		}
 	} else {
 		gpio->poll = 0;

--- a/drivers/gpio/gpio_sch.h
+++ b/drivers/gpio/gpio_sch.h
@@ -34,6 +34,7 @@ struct gpio_sch_config {
 
 struct gpio_sch_data {
 	char __stack polling_stack[GPIO_SCH_POLLING_STACK_SIZE];
+	struct k_thread polling_thread;
 	sys_slist_t callbacks;
 	struct k_timer poll_timer;
 

--- a/drivers/ieee802154/ieee802154_cc2520.c
+++ b/drivers/ieee802154/ieee802154_cc2520.c
@@ -1075,11 +1075,10 @@ static int cc2520_init(struct device *dev)
 		return -EIO;
 	}
 
-	k_thread_spawn(cc2520->cc2520_rx_stack,
-		       CONFIG_IEEE802154_CC2520_RX_STACK_SIZE,
-		       (k_thread_entry_t)cc2520_rx,
-		       dev, NULL, NULL,
-		       K_PRIO_COOP(2), 0, 0);
+	k_thread_create(&cc2520->cc2520_rx_thread, cc2520->cc2520_rx_stack,
+			CONFIG_IEEE802154_CC2520_RX_STACK_SIZE,
+			(k_thread_entry_t)cc2520_rx,
+			dev, NULL, NULL, K_PRIO_COOP(2), 0, 0);
 
 	SYS_LOG_INF("CC2520 initialized");
 

--- a/drivers/ieee802154/ieee802154_cc2520.h
+++ b/drivers/ieee802154/ieee802154_cc2520.h
@@ -41,6 +41,7 @@ struct cc2520_context {
 	atomic_t tx;
 	/************RX************/
 	char __stack cc2520_rx_stack[CONFIG_IEEE802154_CC2520_RX_STACK_SIZE];
+	struct k_thread cc2520_rx_thread;
 	struct k_sem rx_lock;
 #ifdef CONFIG_IEEE802154_CC2520_CRYPTO
 	struct k_sem access_lock;

--- a/drivers/ieee802154/ieee802154_mcr20a.c
+++ b/drivers/ieee802154/ieee802154_mcr20a.c
@@ -1405,11 +1405,10 @@ static int mcr20a_init(struct device *dev)
 		return -EIO;
 	}
 
-	k_thread_spawn(mcr20a->mcr20a_rx_stack,
-		       CONFIG_IEEE802154_MCR20A_RX_STACK_SIZE,
-		       (k_thread_entry_t)mcr20a_thread_main,
-		       dev, NULL, NULL,
-		       K_PRIO_COOP(2), 0, 0);
+	k_thread_create(&mcr20a->mcr20a_rx_thread, mcr20a->mcr20a_rx_stack,
+			CONFIG_IEEE802154_MCR20A_RX_STACK_SIZE,
+			(k_thread_entry_t)mcr20a_thread_main,
+			dev, NULL, NULL, K_PRIO_COOP(2), 0, 0);
 
 	return 0;
 }

--- a/drivers/ieee802154/ieee802154_mcr20a.h
+++ b/drivers/ieee802154/ieee802154_mcr20a.h
@@ -43,6 +43,7 @@ struct mcr20a_context {
 	atomic_t seq_retval;
 	/************RX************/
 	char __stack mcr20a_rx_stack[CONFIG_IEEE802154_MCR20A_RX_STACK_SIZE];
+	struct k_thread mcr20a_rx_thread;
 	u8_t lqi;
 };
 

--- a/drivers/ieee802154/ieee802154_nrf5.c
+++ b/drivers/ieee802154/ieee802154_nrf5.c
@@ -335,11 +335,10 @@ static int nrf5_init(struct device *dev)
 
 	nrf5_radio_cfg->irq_config_func(dev);
 
-	k_thread_spawn(nrf5_radio->rx_stack,
-		       CONFIG_IEEE802154_NRF5_RX_STACK_SIZE,
-		       nrf5_rx_thread,
-		       dev, NULL, NULL,
-		       K_PRIO_COOP(2), 0, 0);
+	k_thread_create(&nrf5_radio->rx_thread, nrf5_radio->rx_stack,
+			CONFIG_IEEE802154_NRF5_RX_STACK_SIZE,
+			nrf5_rx_thread, dev, NULL, NULL,
+			K_PRIO_COOP(2), 0, 0);
 
 	SYS_LOG_INF("nRF5 802154 radio initialized");
 

--- a/drivers/ieee802154/ieee802154_nrf5.h
+++ b/drivers/ieee802154/ieee802154_nrf5.h
@@ -28,6 +28,8 @@ struct nrf5_802154_data {
 	u8_t mac[8];
 	/* RX thread stack. */
 	char __stack rx_stack[CONFIG_IEEE802154_NRF5_RX_STACK_SIZE];
+	/* RX thread control block */
+	struct k_thread rx_thread;
 
 	/* CCA complete sempahore. Unlocked when CCA is complete. */
 	struct k_sem cca_wait;

--- a/drivers/sensor/bma280/bma280.h
+++ b/drivers/sensor/bma280/bma280.h
@@ -132,6 +132,7 @@ struct bma280_data {
 
 #if defined(CONFIG_BMA280_TRIGGER_OWN_THREAD)
 	char __stack thread_stack[CONFIG_BMA280_THREAD_STACK_SIZE];
+	struct k_thread thread;
 	struct k_sem gpio_sem;
 #elif defined(CONFIG_BMA280_TRIGGER_GLOBAL_THREAD)
 	struct k_work work;

--- a/drivers/sensor/bma280/bma280_trigger.c
+++ b/drivers/sensor/bma280/bma280_trigger.c
@@ -262,9 +262,11 @@ int bma280_init_interrupt(struct device *dev)
 #if defined(CONFIG_BMA280_TRIGGER_OWN_THREAD)
 	k_sem_init(&drv_data->gpio_sem, 0, UINT_MAX);
 
-	k_thread_spawn(drv_data->thread_stack, CONFIG_BMA280_THREAD_STACK_SIZE,
-		    (k_thread_entry_t)bma280_thread, POINTER_TO_INT(dev), 0, NULL,
-		    K_PRIO_COOP(CONFIG_BMA280_THREAD_PRIORITY), 0, 0);
+	k_thread_create(&drv_data->thread, drv_data->thread_stack,
+			CONFIG_BMA280_THREAD_STACK_SIZE,
+			(k_thread_entry_t)bma280_thread, POINTER_TO_INT(dev),
+			0, NULL, K_PRIO_COOP(CONFIG_BMA280_THREAD_PRIORITY),
+			0, 0);
 #elif defined(CONFIG_BMA280_TRIGGER_GLOBAL_THREAD)
 	drv_data->work.handler = bma280_work_cb;
 	drv_data->dev = dev;

--- a/drivers/sensor/bmc150_magn/bmc150_magn.h
+++ b/drivers/sensor/bmc150_magn/bmc150_magn.h
@@ -118,6 +118,7 @@ struct bmc150_magn_data {
 
 #if defined(CONFIG_BMC150_MAGN_TRIGGER)
 	char __stack thread_stack[CONFIG_BMC150_MAGN_TRIGGER_THREAD_STACK];
+	struct k_thread thread;
 #endif
 
 #if defined(CONFIG_BMC150_MAGN_TRIGGER_DRDY)

--- a/drivers/sensor/bmc150_magn/bmc150_magn_trigger.c
+++ b/drivers/sensor/bmc150_magn/bmc150_magn_trigger.c
@@ -136,10 +136,10 @@ int bmc150_magn_init_interrupt(struct device *dev)
 
 	k_sem_init(&data->sem, 0, UINT_MAX);
 
-	k_thread_spawn(data->thread_stack,
-			 CONFIG_BMC150_MAGN_TRIGGER_THREAD_STACK,
-			 bmc150_magn_thread_main, dev, NULL, NULL,
-			 K_PRIO_COOP(10), 0, 0);
+	k_thread_create(&data->thread, data->thread_stack,
+			CONFIG_BMC150_MAGN_TRIGGER_THREAD_STACK,
+			bmc150_magn_thread_main, dev, NULL, NULL,
+			K_PRIO_COOP(10), 0, 0);
 
 	data->gpio_drdy = device_get_binding(config->gpio_drdy_dev_name);
 	if (!data->gpio_drdy) {

--- a/drivers/sensor/bmg160/bmg160_trigger.c
+++ b/drivers/sensor/bmg160/bmg160_trigger.c
@@ -164,6 +164,7 @@ static void bmg160_handle_int(void *arg)
 
 #ifdef CONFIG_BMG160_TRIGGER_OWN_THREAD
 static char __stack bmg160_thread_stack[CONFIG_BMG160_THREAD_STACK_SIZE];
+static struct k_thread bmg160_thread;
 
 static void bmg160_thread_main(void *arg1, void *arg2, void *arg3)
 {
@@ -228,8 +229,9 @@ int bmg160_trigger_init(struct device *dev)
 
 #if defined(CONFIG_BMG160_TRIGGER_OWN_THREAD)
 	k_sem_init(&bmg160->trig_sem, 0, UINT_MAX);
-	k_thread_spawn(bmg160_thread_stack, CONFIG_BMG160_THREAD_STACK_SIZE,
-		    bmg160_thread_main, dev, NULL, NULL, K_PRIO_COOP(10), 0, 0);
+	k_thread_create(&bmg160_thread, bmg160_thread_stack,
+			CONFIG_BMG160_THREAD_STACK_SIZE, bmg160_thread_main,
+			dev, NULL, NULL, K_PRIO_COOP(10), 0, 0);
 
 #elif defined(CONFIG_BMG160_TRIGGER_GLOBAL_THREAD)
 	bmg160->work.handler = bmg160_work_cb;

--- a/drivers/sensor/bmi160/bmi160_trigger.c
+++ b/drivers/sensor/bmi160/bmi160_trigger.c
@@ -78,6 +78,7 @@ static void bmi160_handle_interrupts(void *arg)
 
 #ifdef CONFIG_BMI160_TRIGGER_OWN_THREAD
 static char __stack bmi160_thread_stack[CONFIG_BMI160_THREAD_STACK_SIZE];
+static struct k_thread bmi160_thread;
 
 static void bmi160_thread_main(void *arg1, void *unused1, void *unused2)
 {
@@ -281,9 +282,10 @@ int bmi160_trigger_mode_init(struct device *dev)
 #if defined(CONFIG_BMI160_TRIGGER_OWN_THREAD)
 	k_sem_init(&bmi160->sem, 0, UINT_MAX);
 
-	k_thread_spawn(bmi160_thread_stack, CONFIG_BMI160_THREAD_STACK_SIZE,
-		    bmi160_thread_main, dev, NULL, NULL,
-		    K_PRIO_COOP(CONFIG_BMI160_THREAD_PRIORITY), 0, 0);
+	k_thread_create(&bmi160_thread, bmi160_thread_stack,
+			CONFIG_BMI160_THREAD_STACK_SIZE,
+			bmi160_thread_main, dev, NULL, NULL,
+			K_PRIO_COOP(CONFIG_BMI160_THREAD_PRIORITY), 0, 0);
 #elif defined(CONFIG_BMI160_TRIGGER_GLOBAL_THREAD)
 	bmi160->work.handler = bmi160_work_handler;
 	bmi160->dev = dev;

--- a/drivers/sensor/fxas21002/fxas21002.h
+++ b/drivers/sensor/fxas21002/fxas21002.h
@@ -83,6 +83,7 @@ struct fxas21002_data {
 #endif
 #ifdef CONFIG_FXAS21002_TRIGGER_OWN_THREAD
 	char __stack thread_stack[CONFIG_FXAS21002_THREAD_STACK_SIZE];
+	struct k_thread thread;
 	struct k_sem trig_sem;
 #endif
 #ifdef CONFIG_FXAS21002_TRIGGER_GLOBAL_THREAD

--- a/drivers/sensor/fxas21002/fxas21002_trigger.c
+++ b/drivers/sensor/fxas21002/fxas21002_trigger.c
@@ -171,9 +171,10 @@ int fxas21002_trigger_init(struct device *dev)
 
 #if defined(CONFIG_FXAS21002_TRIGGER_OWN_THREAD)
 	k_sem_init(&data->trig_sem, 0, UINT_MAX);
-	k_thread_spawn(data->thread_stack, CONFIG_FXAS21002_THREAD_STACK_SIZE,
-		       fxas21002_thread_main, dev, 0, NULL,
-		       K_PRIO_COOP(CONFIG_FXAS21002_THREAD_PRIORITY), 0, 0);
+	k_thread_create(&data->thread, data->thread_stack,
+			CONFIG_FXAS21002_THREAD_STACK_SIZE,
+			fxas21002_thread_main, dev, 0, NULL,
+			K_PRIO_COOP(CONFIG_FXAS21002_THREAD_PRIORITY), 0, 0);
 #elif defined(CONFIG_FXAS21002_TRIGGER_GLOBAL_THREAD)
 	data->work.handler = fxas21002_work_handler;
 	data->dev = dev;

--- a/drivers/sensor/fxos8700/fxos8700.h
+++ b/drivers/sensor/fxos8700/fxos8700.h
@@ -125,6 +125,7 @@ struct fxos8700_data {
 #endif
 #ifdef CONFIG_FXOS8700_TRIGGER_OWN_THREAD
 	char __stack thread_stack[CONFIG_FXOS8700_THREAD_STACK_SIZE];
+	struct k_thread thread;
 	struct k_sem trig_sem;
 #endif
 #ifdef CONFIG_FXOS8700_TRIGGER_GLOBAL_THREAD

--- a/drivers/sensor/fxos8700/fxos8700_trigger.c
+++ b/drivers/sensor/fxos8700/fxos8700_trigger.c
@@ -262,9 +262,10 @@ int fxos8700_trigger_init(struct device *dev)
 
 #if defined(CONFIG_FXOS8700_TRIGGER_OWN_THREAD)
 	k_sem_init(&data->trig_sem, 0, UINT_MAX);
-	k_thread_spawn(data->thread_stack, CONFIG_FXOS8700_THREAD_STACK_SIZE,
-		       fxos8700_thread_main, dev, 0, NULL,
-		       K_PRIO_COOP(CONFIG_FXOS8700_THREAD_PRIORITY), 0, 0);
+	k_thread_create(&data->thread, data->thread_stack,
+			CONFIG_FXOS8700_THREAD_STACK_SIZE,
+			fxos8700_thread_main, dev, 0, NULL,
+			K_PRIO_COOP(CONFIG_FXOS8700_THREAD_PRIORITY), 0, 0);
 #elif defined(CONFIG_FXOS8700_TRIGGER_GLOBAL_THREAD)
 	data->work.handler = fxos8700_work_handler;
 	data->dev = dev;

--- a/drivers/sensor/hmc5883l/hmc5883l.h
+++ b/drivers/sensor/hmc5883l/hmc5883l.h
@@ -62,6 +62,7 @@ struct hmc5883l_data {
 
 #if defined(CONFIG_HMC5883L_TRIGGER_OWN_THREAD)
 	char __stack thread_stack[CONFIG_HMC5883L_THREAD_STACK_SIZE];
+	struct k_thread thread;
 	struct k_sem gpio_sem;
 #elif defined(CONFIG_HMC5883L_TRIGGER_GLOBAL_THREAD)
 	struct k_work work;

--- a/drivers/sensor/hmc5883l/hmc5883l_trigger.c
+++ b/drivers/sensor/hmc5883l/hmc5883l_trigger.c
@@ -118,9 +118,11 @@ int hmc5883l_init_interrupt(struct device *dev)
 #if defined(CONFIG_HMC5883L_TRIGGER_OWN_THREAD)
 	k_sem_init(&drv_data->gpio_sem, 0, UINT_MAX);
 
-	k_thread_spawn(drv_data->thread_stack, CONFIG_HMC5883L_THREAD_STACK_SIZE,
-		    (k_thread_entry_t)hmc5883l_thread, POINTER_TO_INT(dev),
-		    0, NULL, K_PRIO_COOP(CONFIG_HMC5883L_THREAD_PRIORITY), 0, 0);
+	k_thread_create(&drv_data->thread, drv_data->thread_stack,
+			CONFIG_HMC5883L_THREAD_STACK_SIZE,
+			(k_thread_entry_t)hmc5883l_thread, POINTER_TO_INT(dev),
+			0, NULL, K_PRIO_COOP(CONFIG_HMC5883L_THREAD_PRIORITY),
+			0, 0);
 #elif defined(CONFIG_HMC5883L_TRIGGER_GLOBAL_THREAD)
 	drv_data->work.handler = hmc5883l_work_cb;
 	drv_data->dev = dev;

--- a/drivers/sensor/hts221/hts221.h
+++ b/drivers/sensor/hts221/hts221.h
@@ -60,6 +60,7 @@ struct hts221_data {
 
 #if defined(CONFIG_HTS221_TRIGGER_OWN_THREAD)
 	char __stack thread_stack[CONFIG_HTS221_THREAD_STACK_SIZE];
+	struct k_thread thread;
 	struct k_sem gpio_sem;
 #elif defined(CONFIG_HTS221_TRIGGER_GLOBAL_THREAD)
 	struct k_work work;

--- a/drivers/sensor/hts221/hts221_trigger.c
+++ b/drivers/sensor/hts221/hts221_trigger.c
@@ -125,9 +125,11 @@ int hts221_init_interrupt(struct device *dev)
 #if defined(CONFIG_HTS221_TRIGGER_OWN_THREAD)
 	k_sem_init(&drv_data->gpio_sem, 0, UINT_MAX);
 
-	k_thread_spawn(drv_data->thread_stack, CONFIG_HTS221_THREAD_STACK_SIZE,
-		    (k_thread_entry_t)hts221_thread, POINTER_TO_INT(dev),
-		    0, NULL, K_PRIO_COOP(CONFIG_HTS221_THREAD_PRIORITY), 0, 0);
+	k_thread_create(&drv_data->thread, drv_data->thread_stack,
+			CONFIG_HTS221_THREAD_STACK_SIZE,
+			(k_thread_entry_t)hts221_thread, POINTER_TO_INT(dev),
+			0, NULL, K_PRIO_COOP(CONFIG_HTS221_THREAD_PRIORITY),
+			0, 0);
 #elif defined(CONFIG_HTS221_TRIGGER_GLOBAL_THREAD)
 	drv_data->work.handler = hts221_work_cb;
 	drv_data->dev = dev;

--- a/drivers/sensor/isl29035/isl29035.h
+++ b/drivers/sensor/isl29035/isl29035.h
@@ -123,6 +123,7 @@ struct isl29035_driver_data {
 
 #if defined(CONFIG_ISL29035_TRIGGER_OWN_THREAD)
 	char __stack thread_stack[CONFIG_ISL29035_THREAD_STACK_SIZE];
+	struct k_thread thread;
 	struct k_sem gpio_sem;
 #elif defined(CONFIG_ISL29035_TRIGGER_GLOBAL_THREAD)
 	struct k_work work;

--- a/drivers/sensor/isl29035/isl29035_trigger.c
+++ b/drivers/sensor/isl29035/isl29035_trigger.c
@@ -169,9 +169,11 @@ int isl29035_init_interrupt(struct device *dev)
 #if defined(CONFIG_ISL29035_TRIGGER_OWN_THREAD)
 	k_sem_init(&drv_data->gpio_sem, 0, UINT_MAX);
 
-	k_thread_spawn(drv_data->thread_stack, CONFIG_ISL29035_THREAD_STACK_SIZE,
-		    (k_thread_entry_t)isl29035_thread, POINTER_TO_INT(dev),
-		    0, NULL, K_PRIO_COOP(CONFIG_ISL29035_THREAD_PRIORITY), 0, 0);
+	k_thread_create(&drv_data->thread, drv_data->thread_stack,
+			CONFIG_ISL29035_THREAD_STACK_SIZE,
+			(k_thread_entry_t)isl29035_thread, POINTER_TO_INT(dev),
+			0, NULL, K_PRIO_COOP(CONFIG_ISL29035_THREAD_PRIORITY),
+			0, 0);
 #elif defined(CONFIG_ISL29035_TRIGGER_GLOBAL_THREAD)
 	drv_data->work.handler = isl29035_work_cb;
 	drv_data->dev = dev;

--- a/drivers/sensor/lis2dh/lis2dh.h
+++ b/drivers/sensor/lis2dh/lis2dh.h
@@ -202,6 +202,7 @@ struct lis2dh_data {
 
 #if defined(CONFIG_LIS2DH_TRIGGER_OWN_THREAD)
 	char __stack thread_stack[CONFIG_LIS2DH_THREAD_STACK_SIZE];
+	struct k_thread thread;
 	struct k_sem gpio_sem;
 #elif defined(CONFIG_LIS2DH_TRIGGER_GLOBAL_THREAD)
 	struct k_work work;

--- a/drivers/sensor/lis2dh/lis2dh_trigger.c
+++ b/drivers/sensor/lis2dh/lis2dh_trigger.c
@@ -392,9 +392,10 @@ int lis2dh_init_interrupt(struct device *dev)
 #if defined(CONFIG_LIS2DH_TRIGGER_OWN_THREAD)
 	k_sem_init(&lis2dh->gpio_sem, 0, UINT_MAX);
 
-	k_thread_spawn(lis2dh->thread_stack, CONFIG_LIS2DH_THREAD_STACK_SIZE,
-		       (k_thread_entry_t)lis2dh_thread, dev, NULL, NULL,
-		       K_PRIO_COOP(CONFIG_LIS2DH_THREAD_PRIORITY), 0, 0);
+	k_thread_create(&lis2dh->thread, lis2dh->thread_stack,
+			CONFIG_LIS2DH_THREAD_STACK_SIZE,
+			(k_thread_entry_t)lis2dh_thread, dev, NULL, NULL,
+			K_PRIO_COOP(CONFIG_LIS2DH_THREAD_PRIORITY), 0, 0);
 #elif defined(CONFIG_LIS2DH_TRIGGER_GLOBAL_THREAD)
 	lis2dh->work.handler = lis2dh_work_cb;
 	lis2dh->dev = dev;

--- a/drivers/sensor/lis3dh/lis3dh.h
+++ b/drivers/sensor/lis3dh/lis3dh.h
@@ -94,6 +94,7 @@ struct lis3dh_data {
 
 #if defined(CONFIG_LIS3DH_TRIGGER_OWN_THREAD)
 	char __stack thread_stack[CONFIG_LIS3DH_THREAD_STACK_SIZE];
+	struct k_thread thread;
 	struct k_sem gpio_sem;
 #elif defined(CONFIG_LIS3DH_TRIGGER_GLOBAL_THREAD)
 	struct k_work work;

--- a/drivers/sensor/lis3dh/lis3dh_trigger.c
+++ b/drivers/sensor/lis3dh/lis3dh_trigger.c
@@ -131,9 +131,11 @@ int lis3dh_init_interrupt(struct device *dev)
 #if defined(CONFIG_LIS3DH_TRIGGER_OWN_THREAD)
 	k_sem_init(&drv_data->gpio_sem, 0, UINT_MAX);
 
-	k_thread_spawn(drv_data->thread_stack, CONFIG_LIS3DH_THREAD_STACK_SIZE,
-		    (k_thread_entry_t)lis3dh_thread, POINTER_TO_INT(dev),
-		    0, NULL, K_PRIO_COOP(CONFIG_LIS3DH_THREAD_PRIORITY), 0, 0);
+	k_thread_create(&drv_data->thread, drv_data->thread_stack,
+			CONFIG_LIS3DH_THREAD_STACK_SIZE,
+			(k_thread_entry_t)lis3dh_thread, POINTER_TO_INT(dev),
+			0, NULL, K_PRIO_COOP(CONFIG_LIS3DH_THREAD_PRIORITY),
+			0, 0);
 #elif defined(CONFIG_LIS3DH_TRIGGER_GLOBAL_THREAD)
 	drv_data->work.handler = lis3dh_work_cb;
 	drv_data->dev = dev;

--- a/drivers/sensor/lis3mdl/lis3mdl.h
+++ b/drivers/sensor/lis3mdl/lis3mdl.h
@@ -109,6 +109,7 @@ struct lis3mdl_data {
 #if defined(CONFIG_LIS3MDL_TRIGGER_OWN_THREAD)
 	char __stack thread_stack[CONFIG_LIS3MDL_THREAD_STACK_SIZE];
 	struct k_sem gpio_sem;
+	struct k_thread thread;
 #elif defined(CONFIG_LIS3MDL_TRIGGER_GLOBAL_THREAD)
 	struct k_work work;
 	struct device *dev;

--- a/drivers/sensor/lis3mdl/lis3mdl_trigger.c
+++ b/drivers/sensor/lis3mdl/lis3mdl_trigger.c
@@ -131,9 +131,11 @@ int lis3mdl_init_interrupt(struct device *dev)
 #if defined(CONFIG_LIS3MDL_TRIGGER_OWN_THREAD)
 	k_sem_init(&drv_data->gpio_sem, 0, UINT_MAX);
 
-	k_thread_spawn(drv_data->thread_stack, CONFIG_LIS3MDL_THREAD_STACK_SIZE,
-		    (k_thread_entry_t)lis3mdl_thread, POINTER_TO_INT(dev),
-		    0, NULL, K_PRIO_COOP(CONFIG_LIS3MDL_THREAD_PRIORITY), 0, 0);
+	k_thread_create(&drv_data->thread, drv_data->thread_stack,
+			CONFIG_LIS3MDL_THREAD_STACK_SIZE,
+			(k_thread_entry_t)lis3mdl_thread, POINTER_TO_INT(dev),
+			0, NULL, K_PRIO_COOP(CONFIG_LIS3MDL_THREAD_PRIORITY),
+			0, 0);
 #elif defined(CONFIG_LIS3MDL_TRIGGER_GLOBAL_THREAD)
 	drv_data->work.handler = lis3mdl_work_cb;
 	drv_data->dev = dev;

--- a/drivers/sensor/lsm9ds0_gyro/lsm9ds0_gyro.h
+++ b/drivers/sensor/lsm9ds0_gyro/lsm9ds0_gyro.h
@@ -230,6 +230,7 @@ struct lsm9ds0_gyro_data {
 
 #if defined(CONFIG_LSM9DS0_GYRO_TRIGGER_DRDY)
 	char __stack thread_stack[CONFIG_LSM9DS0_GYRO_THREAD_STACK_SIZE];
+	struct k_thread thread;
 	struct device *dev;
 
 	struct device *gpio_drdy;

--- a/drivers/sensor/lsm9ds0_gyro/lsm9ds0_gyro_trigger.c
+++ b/drivers/sensor/lsm9ds0_gyro/lsm9ds0_gyro_trigger.c
@@ -97,10 +97,10 @@ int lsm9ds0_gyro_init_interrupt(struct device *dev)
 
 	k_sem_init(&data->sem, 0, UINT_MAX);
 
-	k_thread_spawn(data->thread_stack,
-			 CONFIG_LSM9DS0_GYRO_THREAD_STACK_SIZE,
-			 lsm9ds0_gyro_thread_main, dev, NULL, NULL,
-			 K_PRIO_COOP(10), 0, 0);
+	k_thread_create(&data->thread, data->thread_stack,
+			CONFIG_LSM9DS0_GYRO_THREAD_STACK_SIZE,
+			lsm9ds0_gyro_thread_main, dev, NULL, NULL,
+			K_PRIO_COOP(10), 0, 0);
 
 	data->gpio_drdy = device_get_binding(config->gpio_drdy_dev_name);
 	if (!data->gpio_drdy) {

--- a/drivers/sensor/mcp9808/mcp9808_trigger.c
+++ b/drivers/sensor/mcp9808/mcp9808_trigger.c
@@ -127,7 +127,7 @@ static void mcp9808_thread_main(int arg1, int arg2)
 }
 
 static char __stack mcp9808_thread_stack[CONFIG_MCP9808_THREAD_STACK_SIZE];
-
+static struct k_thread mcp9808_thread;
 #else /* CONFIG_MCP9808_TRIGGER_GLOBAL_THREAD */
 
 static void mcp9808_gpio_cb(struct device *dev,
@@ -168,10 +168,10 @@ void mcp9808_setup_interrupt(struct device *dev)
 #ifdef CONFIG_MCP9808_TRIGGER_OWN_THREAD
 	k_sem_init(&data->sem, 0, UINT_MAX);
 
-	k_thread_spawn(mcp9808_thread_stack,
-			  CONFIG_MCP9808_THREAD_STACK_SIZE,
-			  mcp9808_thread_main, POINTER_TO_INT(dev), 0, NULL,
-			  K_PRIO_COOP(CONFIG_MCP9808_THREAD_PRIORITY), 0, 0);
+	k_thread_create(&mcp9808_thread, mcp9808_thread_stack,
+			CONFIG_MCP9808_THREAD_STACK_SIZE,
+			mcp9808_thread_main, POINTER_TO_INT(dev), 0, NULL,
+			K_PRIO_COOP(CONFIG_MCP9808_THREAD_PRIORITY), 0, 0);
 #else /* CONFIG_MCP9808_TRIGGER_GLOBAL_THREAD */
 	data->work.handler = mcp9808_gpio_thread_cb;
 	data->dev = dev;

--- a/drivers/sensor/mpu6050/mpu6050.h
+++ b/drivers/sensor/mpu6050/mpu6050.h
@@ -62,6 +62,7 @@ struct mpu6050_data {
 
 #if defined(CONFIG_MPU6050_TRIGGER_OWN_THREAD)
 	char __stack thread_stack[CONFIG_MPU6050_THREAD_STACK_SIZE];
+	struct k_thread thread;
 	struct k_sem gpio_sem;
 #elif defined(CONFIG_MPU6050_TRIGGER_GLOBAL_THREAD)
 	struct k_work work;

--- a/drivers/sensor/mpu6050/mpu6050_trigger.c
+++ b/drivers/sensor/mpu6050/mpu6050_trigger.c
@@ -126,9 +126,11 @@ int mpu6050_init_interrupt(struct device *dev)
 #if defined(CONFIG_MPU6050_TRIGGER_OWN_THREAD)
 	k_sem_init(&drv_data->gpio_sem, 0, UINT_MAX);
 
-	k_thread_spawn(drv_data->thread_stack, CONFIG_MPU6050_THREAD_STACK_SIZE,
-		    (k_thread_entry_t)mpu6050_thread, POINTER_TO_INT(dev),
-		    0, NULL, K_PRIO_COOP(CONFIG_MPU6050_THREAD_PRIORITY), 0, 0);
+	k_thread_create(&drv_data->thread, drv_data->thread_stack,
+			CONFIG_MPU6050_THREAD_STACK_SIZE,
+			(k_thread_entry_t)mpu6050_thread, POINTER_TO_INT(dev),
+			0, NULL, K_PRIO_COOP(CONFIG_MPU6050_THREAD_PRIORITY),
+			0, 0);
 #elif defined(CONFIG_MPU6050_TRIGGER_GLOBAL_THREAD)
 	drv_data->work.handler = mpu6050_work_cb;
 	drv_data->dev = dev;

--- a/drivers/sensor/sht3xd/sht3xd.h
+++ b/drivers/sensor/sht3xd/sht3xd.h
@@ -77,6 +77,7 @@ struct sht3xd_data {
 #if defined(CONFIG_SHT3XD_TRIGGER_OWN_THREAD)
 	char __stack thread_stack[CONFIG_SHT3XD_THREAD_STACK_SIZE];
 	struct k_sem gpio_sem;
+	struct k_thread thread;
 #elif defined(CONFIG_SHT3XD_TRIGGER_GLOBAL_THREAD)
 	struct k_work work;
 	struct device *dev;

--- a/drivers/sensor/sht3xd/sht3xd_trigger.c
+++ b/drivers/sensor/sht3xd/sht3xd_trigger.c
@@ -206,9 +206,11 @@ int sht3xd_init_interrupt(struct device *dev)
 #if defined(CONFIG_SHT3XD_TRIGGER_OWN_THREAD)
 	k_sem_init(&drv_data->gpio_sem, 0, UINT_MAX);
 
-	k_thread_spawn(drv_data->thread_stack, CONFIG_SHT3XD_THREAD_STACK_SIZE,
-		    (k_thread_entry_t)sht3xd_thread, POINTER_TO_INT(dev),
-		    0, NULL, K_PRIO_COOP(CONFIG_SHT3XD_THREAD_PRIORITY), 0, 0);
+	k_thread_create(&drv_data->thread, drv_data->thread_stack,
+			CONFIG_SHT3XD_THREAD_STACK_SIZE,
+			(k_thread_entry_t)sht3xd_thread, POINTER_TO_INT(dev),
+			0, NULL, K_PRIO_COOP(CONFIG_SHT3XD_THREAD_PRIORITY),
+			0, 0);
 #elif defined(CONFIG_SHT3XD_TRIGGER_GLOBAL_THREAD)
 	drv_data->work.handler = sht3xd_work_cb;
 	drv_data->dev = dev;

--- a/drivers/sensor/sx9500/sx9500_trigger.c
+++ b/drivers/sensor/sx9500/sx9500_trigger.c
@@ -15,6 +15,7 @@
 
 #ifdef CONFIG_SX9500_TRIGGER_OWN_THREAD
 static char __stack sx9500_thread_stack[CONFIG_SX9500_THREAD_STACK_SIZE];
+static struct k_thread sx9500_thread;
 #endif
 
 int sx9500_trigger_set(struct device *dev,
@@ -171,9 +172,10 @@ int sx9500_setup_interrupt(struct device *dev)
 	gpio_pin_enable_callback(gpio, CONFIG_SX9500_GPIO_PIN);
 
 #ifdef CONFIG_SX9500_TRIGGER_OWN_THREAD
-	k_thread_spawn(sx9500_thread_stack, CONFIG_SX9500_THREAD_STACK_SIZE,
-			  sx9500_thread_main, POINTER_TO_INT(dev), 0, NULL,
-			  K_PRIO_COOP(CONFIG_SX9500_THREAD_PRIORITY), 0, 0);
+	k_thread_create(&sx9500_thread, sx9500_thread_stack,
+			CONFIG_SX9500_THREAD_STACK_SIZE,
+			sx9500_thread_main, POINTER_TO_INT(dev), 0, NULL,
+			K_PRIO_COOP(CONFIG_SX9500_THREAD_PRIORITY), 0, 0);
 #endif
 
 	return 0;

--- a/drivers/sensor/tmp007/tmp007.h
+++ b/drivers/sensor/tmp007/tmp007.h
@@ -50,6 +50,7 @@ struct tmp007_data {
 #if defined(CONFIG_TMP007_TRIGGER_OWN_THREAD)
 	char __stack thread_stack[CONFIG_TMP007_THREAD_STACK_SIZE];
 	struct k_sem gpio_sem;
+	struct k_thread thread;
 #elif defined(CONFIG_TMP007_TRIGGER_GLOBAL_THREAD)
 	struct k_work work;
 	struct device *dev;

--- a/drivers/sensor/tmp007/tmp007_trigger.c
+++ b/drivers/sensor/tmp007/tmp007_trigger.c
@@ -164,9 +164,11 @@ int tmp007_init_interrupt(struct device *dev)
 #if defined(CONFIG_TMP007_TRIGGER_OWN_THREAD)
 	k_sem_init(&drv_data->gpio_sem, 0, UINT_MAX);
 
-	k_thread_spawn(drv_data->thread_stack, CONFIG_TMP007_THREAD_STACK_SIZE,
-		    (k_thread_entry_t)tmp007_thread, POINTER_TO_INT(dev),
-		    0, NULL, K_PRIO_COOP(CONFIG_TMP007_THREAD_PRIORITY), 0, 0);
+	k_thread_create(&drv_data->thread, drv_data->thread_stack,
+			CONFIG_TMP007_THREAD_STACK_SIZE,
+			(k_thread_entry_t)tmp007_thread, POINTER_TO_INT(dev),
+			0, NULL, K_PRIO_COOP(CONFIG_TMP007_THREAD_PRIORITY),
+			0, 0);
 #elif defined(CONFIG_TMP007_TRIGGER_GLOBAL_THREAD)
 	drv_data->work.handler = tmp007_work_cb;
 	drv_data->dev = dev;

--- a/include/bluetooth/log.h
+++ b/include/bluetooth/log.h
@@ -89,11 +89,9 @@ static inline __printf_like(1, 2) void _bt_log_dummy(const char *fmt, ...) {};
 			}
 
 #define BT_STACK(name, size) \
-		char __stack name[(size) + K_THREAD_SIZEOF + \
-				  BT_STACK_DEBUG_EXTRA]
+		char __stack name[(size) + BT_STACK_DEBUG_EXTRA]
 #define BT_STACK_NOINIT(name, size) \
-		char __noinit __stack name[(size) + K_THREAD_SIZEOF + \
-					   BT_STACK_DEBUG_EXTRA]
+		char __noinit __stack name[(size) + BT_STACK_DEBUG_EXTRA]
 
 /* This helper is only available when BLUETOOTH_DEBUG is enabled */
 const char *bt_hex(const void *buf, size_t len);

--- a/include/bluetooth/rfcomm.h
+++ b/include/bluetooth/rfcomm.h
@@ -95,7 +95,8 @@ struct bt_rfcomm_dlc {
 	u8_t                       state;
 	u8_t                       rx_credit;
 
-	/* Stack for TX fiber */
+	/* Stack & kernel data for TX thread */
+	struct k_thread            tx_thread;
 	BT_STACK(stack, 256);
 };
 

--- a/include/drivers/console/ipm_console.h
+++ b/include/drivers/console/ipm_console.h
@@ -77,6 +77,9 @@ struct ipm_console_receiver_runtime_data {
 	 * full buffer
 	 */
 	int channel_disabled;
+
+	/** Receiver worker thread */
+	struct k_thread rx_thread;
 };
 
 struct ipm_console_sender_config_info {

--- a/include/misc/stack.h
+++ b/include/misc/stack.h
@@ -9,29 +9,22 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#if defined(CONFIG_INIT_STACKS) && defined(CONFIG_PRINTK)
-#include <offsets.h>
 #include <misc/printk.h>
 
-static inline void stack_analyze(const char *name, const char *stack,
-				 unsigned size)
+#if defined(CONFIG_INIT_STACKS)
+static inline size_t stack_unused_space_get(const char *stack, size_t size)
 {
-	unsigned i, stack_offset, pcnt, unused = 0;
+	size_t unused = 0;
+	int i;
 
-	/* The TCS is always placed on a 4-byte aligned boundary - if
-	 * the stack beginning doesn't match that there will be some
-	 * unused bytes in the beginning.
+	/* TODO Currently all supported platforms have stack growth down and
+	 * there is no Kconfig option to configure it so this always build
+	 * "else" branch.  When support for platform with stack direction up
+	 * (or configurable direction) is added this check should be confirmed
+	 * that correct Kconfig option is used.
 	 */
-	stack_offset = K_THREAD_SIZEOF + ((4 - ((unsigned)stack % 4)) % 4);
-
-/* TODO
- * Currently all supported platforms have stack growth down and there is no
- * Kconfig option to configure it so this always build "else" branch.
- * When support for platform with stack direction up (or configurable direction)
- * is added this check should be confirmed that correct Kconfig option is used.
- */
 #if defined(CONFIG_STACK_GROWS_UP)
-	for (i = size - 1; i >= stack_offset; i--) {
+	for (i = size - 1; i >= 0; i--) {
 		if ((unsigned char)stack[i] == 0xaa) {
 			unused++;
 		} else {
@@ -39,7 +32,7 @@ static inline void stack_analyze(const char *name, const char *stack,
 		}
 	}
 #else
-	for (i = stack_offset; i < size; i++) {
+	for (i = 0; i < size; i++) {
 		if ((unsigned char)stack[i] == 0xaa) {
 			unused++;
 		} else {
@@ -47,17 +40,32 @@ static inline void stack_analyze(const char *name, const char *stack,
 		}
 	}
 #endif
+	return unused;
+}
+#else
+static inline size_t stack_unused_space_get(const char *stack, size_t size)
+{
+	return 0;
+}
+#endif
+
+#if defined(CONFIG_INIT_STACKS) && defined(CONFIG_PRINTK)
+static inline void stack_analyze(const char *name, const char *stack,
+				 unsigned int size)
+{
+	unsigned int pcnt, unused = 0;
+
+	unused = stack_unused_space_get(stack, size);
 
 	/* Calculate the real size reserved for the stack */
-	size -= stack_offset;
 	pcnt = ((size - unused) * 100) / size;
 
 	printk("%s (real size %u):\tunused %u\tusage %u / %u (%u %%)\n", name,
-	       size + stack_offset, unused, size - unused, size, pcnt);
+	       size, unused, size - unused, size, pcnt);
 }
 #else
 static inline void stack_analyze(const char *name, const char *stack,
-				 unsigned size)
+				 unsigned int size)
 {
 }
 #endif

--- a/kernel/include/kernel_structs.h
+++ b/kernel/include/kernel_structs.h
@@ -142,20 +142,19 @@ extern void _init_thread_base(struct _thread_base *thread_base,
 			      int priority, u32_t initial_state,
 			      unsigned int options);
 
-static ALWAYS_INLINE struct k_thread *_new_thread_init(char *pStack,
-						       size_t stackSize,
-						       int prio,
-						       unsigned int options)
+static ALWAYS_INLINE void _new_thread_init(struct k_thread *thread,
+					    char *pStack, size_t stackSize,
+					    int prio, unsigned int options)
 {
-	struct k_thread *thread;
+#if !defined(CONFIG_INIT_STACKS) && !defined(CONFIG_THREAD_STACK_INFO)
+	ARG_UNUSED(pStack);
+	ARG_UNUSED(stackSize);
+#endif
 
 #ifdef CONFIG_INIT_STACKS
 	memset(pStack, 0xaa, stackSize);
 #endif
-
 	/* Initialize various struct k_thread members */
-	thread = (struct k_thread *)pStack;
-
 	_init_thread_base(&thread->base, prio, _THREAD_PRESTART, options);
 
 	/* static threads overwrite it afterwards with real value */
@@ -171,8 +170,6 @@ static ALWAYS_INLINE struct k_thread *_new_thread_init(char *pStack,
 	thread->stack_info.start = (u32_t)pStack;
 	thread->stack_info.size = (u32_t)stackSize;
 #endif /* CONFIG_THREAD_STACK_INFO */
-
-	return thread;
 }
 
 #if defined(CONFIG_THREAD_MONITOR)

--- a/kernel/include/nano_internal.h
+++ b/kernel/include/nano_internal.h
@@ -43,7 +43,7 @@ FUNC_NORETURN void _Cstart(void);
 extern void _thread_entry(void (*)(void *, void *, void *),
 			  void *, void *, void *);
 
-extern void _new_thread(char *pStack, size_t stackSize,
+extern void _new_thread(struct k_thread *thread, char *pStack, size_t stackSize,
 			void (*pEntry)(void *, void *, void *),
 			void *p1, void *p2, void *p3,
 			int prio, unsigned int options);

--- a/kernel/work_q.c
+++ b/kernel/work_q.c
@@ -48,9 +48,8 @@ void k_work_q_start(struct k_work_q *work_q, char *stack,
 {
 	k_fifo_init(&work_q->fifo);
 
-	k_thread_spawn(stack, stack_size,
-		       work_q_main, work_q, 0, 0,
-		       prio, 0, 0);
+	k_thread_create(&work_q->thread, stack, stack_size, work_q_main,
+			work_q, 0, 0, prio, 0, 0);
 }
 
 #ifdef CONFIG_SYS_CLOCK_EXISTS

--- a/samples/bluetooth/hci_uart/src/main.c
+++ b/samples/bluetooth/hci_uart/src/main.c
@@ -30,6 +30,7 @@
 
 static struct device *hci_uart_dev;
 static BT_STACK_NOINIT(tx_thread_stack, CONFIG_BLUETOOTH_HCI_TX_STACK_SIZE);
+static struct k_thread tx_thread_data;
 
 /* HCI command buffers */
 #define CMD_BUF_SIZE BT_BUF_RX_SIZE
@@ -348,8 +349,9 @@ void main(void)
 	/* Spawn the TX thread and start feeding commands and data to the
 	 * controller
 	 */
-	k_thread_spawn(tx_thread_stack, sizeof(tx_thread_stack), tx_thread,
-		       NULL, NULL, NULL, K_PRIO_COOP(7), 0, K_NO_WAIT);
+	k_thread_create(&tx_thread_data, tx_thread_stack,
+			sizeof(tx_thread_stack), tx_thread,
+			NULL, NULL, NULL, K_PRIO_COOP(7), 0, K_NO_WAIT);
 
 	while (1) {
 		struct net_buf *buf;

--- a/samples/bluetooth/ipsp/src/main.c
+++ b/samples/bluetooth/ipsp/src/main.c
@@ -36,6 +36,7 @@ static struct in6_addr in6addr_my = MY_IP6ADDR;
 
 #define STACKSIZE 2000
 char __noinit __stack thread_stack[STACKSIZE];
+static struct k_thread thread_data;
 
 #define MAX_DBG_PRINT 64
 
@@ -357,7 +358,7 @@ void main(void)
 
 	printk("Advertising successfully started\n");
 
-	k_thread_spawn(&thread_stack[0], STACKSIZE,
-		       (k_thread_entry_t)listen,
-		       NULL, NULL, NULL, K_PRIO_COOP(7), 0, 0);
+	k_thread_create(&thread_data, thread_stack, STACKSIZE,
+			(k_thread_entry_t)listen,
+			NULL, NULL, NULL, K_PRIO_COOP(7), 0, 0);
 }

--- a/samples/net/coaps_client/src/coaps_client.c
+++ b/samples/net/coaps_client/src/coaps_client.c
@@ -412,6 +412,7 @@ exit:
 
 #define STACK_SIZE		4096
 u8_t stack[STACK_SIZE];
+static struct k_thread thread_data;
 
 static inline int init_app(void)
 {
@@ -440,6 +441,7 @@ void main(void)
 		return;
 	}
 
-	k_thread_spawn(stack, STACK_SIZE, (k_thread_entry_t) dtls_client,
-		       NULL, NULL, NULL, K_PRIO_COOP(7), 0, 0);
+	k_thread_create(&thread_data, stack, STACK_SIZE,
+			(k_thread_entry_t) dtls_client,
+			NULL, NULL, NULL, K_PRIO_COOP(7), 0, 0);
 }

--- a/samples/net/coaps_server/src/coaps_server.c
+++ b/samples/net/coaps_server/src/coaps_server.c
@@ -633,6 +633,7 @@ exit:
 
 #define STACK_SIZE		4096
 u8_t stack[STACK_SIZE];
+static struct k_thread thread_data;
 
 static inline int init_app(void)
 {
@@ -660,7 +661,8 @@ void main(void)
 		return;
 	}
 
-	k_thread_spawn(stack, STACK_SIZE, (k_thread_entry_t) dtls_server,
-		       NULL, NULL, NULL, K_PRIO_COOP(7), 0, 0);
+	k_thread_create(&thread_data, stack, STACK_SIZE,
+			(k_thread_entry_t) dtls_server,
+			NULL, NULL, NULL, K_PRIO_COOP(7), 0, 0);
 
 }

--- a/samples/net/dhcpv4_client/src/main.c
+++ b/samples/net/dhcpv4_client/src/main.c
@@ -25,6 +25,7 @@
 
 #define STACKSIZE 2000
 char __noinit __stack thread_stack[STACKSIZE];
+static struct k_thread thread_data;
 
 static struct net_mgmt_event_callback mgmt_cb;
 
@@ -78,7 +79,7 @@ void main(void)
 {
 	NET_INFO("In main");
 
-	k_thread_spawn(&thread_stack[0], STACKSIZE,
-		       (k_thread_entry_t)main_thread,
-		       NULL, NULL, NULL, K_PRIO_COOP(7), 0, 0);
+	k_thread_create(&thread_data, &thread_stack[0], STACKSIZE,
+			(k_thread_entry_t)main_thread,
+			NULL, NULL, NULL, K_PRIO_COOP(7), 0, 0);
 }

--- a/samples/net/dns_resolve/src/main.c
+++ b/samples/net/dns_resolve/src/main.c
@@ -22,6 +22,7 @@
 
 #define STACKSIZE 2000
 char __noinit __stack thread_stack[STACKSIZE];
+static struct k_thread thread_data;
 
 #define DNS_TIMEOUT 2000 /* ms */
 
@@ -281,7 +282,7 @@ void main(void)
 {
 	NET_INFO("Starting DNS resolve sample");
 
-	k_thread_spawn(&thread_stack[0], STACKSIZE,
-		       (k_thread_entry_t)network_setup,
-		       NULL, NULL, NULL, K_PRIO_COOP(7), 0, 0);
+	k_thread_create(&thread_data, thread_stack, STACKSIZE,
+			(k_thread_entry_t)network_setup,
+			NULL, NULL, NULL, K_PRIO_COOP(7), 0, 0);
 }

--- a/samples/net/echo_client/src/echo-client.c
+++ b/samples/net/echo_client/src/echo-client.c
@@ -160,10 +160,12 @@ static struct sockaddr_in6 peer_addr6 = {
 
 #if defined(CONFIG_NET_UDP)
 static char __noinit __stack ipv6_udp_stack[STACKSIZE];
+static struct k_thread ipv6_udp_thread_data;
 #endif
 
 #if defined(CONFIG_NET_TCP)
 static char __noinit __stack ipv6_tcp_stack[STACKSIZE];
+static struct k_thread ipv6_tcp_thread_data;
 #endif
 
 #endif /* CONFIG_NET_IPV6 */
@@ -189,10 +191,12 @@ static struct sockaddr_in peer_addr4 = {
 
 #if defined(CONFIG_NET_UDP)
 static char __noinit __stack ipv4_udp_stack[STACKSIZE];
+static struct k_thread ipv4_udp_thread_data;
 #endif
 
 #if defined(CONFIG_NET_TCP)
 static char __noinit __stack ipv4_tcp_stack[STACKSIZE];
+static struct k_thread ipv4_tcp_thread_data;
 #endif
 
 #endif /* CONFIG_NET_IPV4 */
@@ -870,27 +874,27 @@ static void event_iface_up(struct net_mgmt_event_callback *cb,
 	}
 
 #if defined(CONFIG_NET_IPV4) && defined(CONFIG_NET_UDP)
-	k_thread_spawn(ipv4_udp_stack, STACKSIZE,
-		       (k_thread_entry_t)send_udp_ipv4,
-		       udp_send4, NULL, NULL, K_PRIO_COOP(7), 0, 0);
+	k_thread_create(&ipv4_udp_thread_data, ipv4_udp_stack, STACKSIZE,
+			(k_thread_entry_t)send_udp_ipv4,
+			udp_send4, NULL, NULL, K_PRIO_COOP(7), 0, 0);
 #endif
 
 #if defined(CONFIG_NET_IPV4) && defined(CONFIG_NET_TCP)
-	k_thread_spawn(ipv4_tcp_stack, STACKSIZE,
-		       (k_thread_entry_t)send_tcp_ipv4,
-		       tcp_send4, NULL, NULL, K_PRIO_COOP(7), 0, 0);
+	k_thread_create(&ipv4_tcp_thread_data, ipv4_tcp_stack, STACKSIZE,
+			(k_thread_entry_t)send_tcp_ipv4,
+			tcp_send4, NULL, NULL, K_PRIO_COOP(7), 0, 0);
 #endif
 
 #if defined(CONFIG_NET_IPV6) && defined(CONFIG_NET_UDP)
-	k_thread_spawn(ipv6_udp_stack, STACKSIZE,
-		       (k_thread_entry_t)send_udp_ipv6,
-		       udp_send6, NULL, NULL, K_PRIO_COOP(7), 0, 0);
+	k_thread_create(&ipv6_udp_thread_data, ipv6_udp_stack, STACKSIZE,
+			(k_thread_entry_t)send_udp_ipv6,
+			udp_send6, NULL, NULL, K_PRIO_COOP(7), 0, 0);
 #endif
 
 #if defined(CONFIG_NET_IPV6) && defined(CONFIG_NET_TCP)
-	k_thread_spawn(ipv6_tcp_stack, STACKSIZE,
-		       (k_thread_entry_t)send_tcp_ipv6,
-		       tcp_send6, NULL, NULL, K_PRIO_COOP(7), 0, 0);
+	k_thread_create(&ipv6_tcp_thread_data, ipv6_tcp_stack, STACKSIZE,
+			(k_thread_entry_t)send_tcp_ipv6,
+			tcp_send6, NULL, NULL, K_PRIO_COOP(7), 0, 0);
 #endif
 }
 

--- a/samples/net/echo_server/src/echo-server.c
+++ b/samples/net/echo_server/src/echo-server.c
@@ -90,6 +90,7 @@ static struct net_buf_pool *data_udp_pool(void)
 
 #define STACKSIZE 2000
 char __noinit __stack thread_stack[STACKSIZE];
+static struct k_thread thread_data;
 
 #define MAX_DBG_PRINT 64
 
@@ -582,7 +583,7 @@ void main(void)
 	}
 #endif
 
-	k_thread_spawn(&thread_stack[0], STACKSIZE,
-		       (k_thread_entry_t)receive,
-		       NULL, NULL, NULL, K_PRIO_COOP(7), 0, 0);
+	k_thread_create(&thread_data, thread_stack, STACKSIZE,
+			(k_thread_entry_t)receive,
+			NULL, NULL, NULL, K_PRIO_COOP(7), 0, 0);
 }

--- a/samples/net/http_server/src/https_server.c
+++ b/samples/net/http_server/src/https_server.c
@@ -367,6 +367,7 @@ exit:
 
 #define STACK_SIZE		8192
 u8_t stack[STACK_SIZE];
+struct k_thread https_thread;
 
 static inline int init_app(void)
 {
@@ -400,7 +401,7 @@ void https_server_start(void)
 		return;
 	}
 
-	k_thread_spawn(stack, STACK_SIZE, (k_thread_entry_t) https_server,
-		       NULL, NULL, NULL, K_PRIO_COOP(7), 0, 0);
-
+	k_thread_create(&https_thread, stack, STACK_SIZE,
+			(k_thread_entry_t) https_server,
+			NULL, NULL, NULL, K_PRIO_COOP(7), 0, 0);
 }

--- a/samples/net/irc_bot/src/irc-bot.c
+++ b/samples/net/irc_bot/src/irc-bot.c
@@ -30,6 +30,7 @@
 
 #define STACK_SIZE	2048
 u8_t stack[STACK_SIZE];
+static struct k_thread bot_thread;
 
 #define CMD_BUFFER_SIZE 256
 static u8_t cmd_buf[CMD_BUFFER_SIZE];
@@ -1068,6 +1069,7 @@ static void irc_bot(void)
 
 void main(void)
 {
-	k_thread_spawn(stack, STACK_SIZE, (k_thread_entry_t)irc_bot,
-		       NULL, NULL, NULL, K_PRIO_COOP(7), 0, 0);
+	k_thread_create(&bot_thread, stack, STACK_SIZE,
+			(k_thread_entry_t)irc_bot,
+			NULL, NULL, NULL, K_PRIO_COOP(7), 0, 0);
 }

--- a/samples/net/mbedtls_dtlsclient/src/dtls_client.c
+++ b/samples/net/mbedtls_dtlsclient/src/dtls_client.c
@@ -285,6 +285,7 @@ exit:
 
 #define STACK_SIZE		8192
 u8_t stack[STACK_SIZE];
+static struct k_thread dtls_thread;
 
 static inline int init_app(void)
 {
@@ -328,7 +329,8 @@ void main(void)
 		return;
 	}
 
-	k_thread_spawn(stack, STACK_SIZE, (k_thread_entry_t) dtls_client,
-		       NULL, NULL, NULL, K_PRIO_COOP(7), 0, 0);
+	k_thread_create(&dtls_thread, stack, STACK_SIZE,
+			(k_thread_entry_t) dtls_client,
+			NULL, NULL, NULL, K_PRIO_COOP(7), 0, 0);
 
 }

--- a/samples/net/mbedtls_dtlsserver/src/dtls_server.c
+++ b/samples/net/mbedtls_dtlsserver/src/dtls_server.c
@@ -363,6 +363,7 @@ exit:
 
 #define STACK_SIZE		8192
 u8_t stack[STACK_SIZE];
+static struct k_thread dtls_thread;
 
 static inline int init_app(void)
 {
@@ -405,7 +406,7 @@ void main(void)
 		return;
 	}
 
-	k_thread_spawn(stack, STACK_SIZE, (k_thread_entry_t) dtls_server,
-		       NULL, NULL, NULL, K_PRIO_COOP(7), 0, 0);
-
+	k_thread_create(&dtls_thread, stack, STACK_SIZE,
+			(k_thread_entry_t) dtls_server,
+			NULL, NULL, NULL, K_PRIO_COOP(7), 0, 0);
 }

--- a/samples/net/mbedtls_sslclient/src/mini_client.c
+++ b/samples/net/mbedtls_sslclient/src/mini_client.c
@@ -316,9 +316,11 @@ exit:
 
 #define STACK_SIZE		8192
 u8_t stack[STACK_SIZE];
+static struct k_thread tls_thread;
 
 void main(void)
 {
-	k_thread_spawn(stack, STACK_SIZE, (k_thread_entry_t) tls_client,
-		       NULL, NULL, NULL, K_PRIO_COOP(7), 0, 0);
+	k_thread_create(&tls_thread, stack, STACK_SIZE,
+			(k_thread_entry_t) tls_client,
+			NULL, NULL, NULL, K_PRIO_COOP(7), 0, 0);
 }

--- a/samples/net/nats/src/main.c
+++ b/samples/net/nats/src/main.c
@@ -71,6 +71,7 @@ static bool fake_led;
 #define DEFAULT_PORT		4222
 
 static u8_t stack[2048];
+static struct k_thread thread_data;
 
 static void panic(const char *msg)
 {
@@ -320,6 +321,7 @@ static void nats_client(void)
 
 void main(void)
 {
-	k_thread_spawn(stack, sizeof(stack), (k_thread_entry_t)nats_client,
-		       NULL, NULL, NULL, K_PRIO_COOP(7), 0, 0);
+	k_thread_create(&thread_data, stack, sizeof(stack),
+			(k_thread_entry_t)nats_client,
+			NULL, NULL, NULL, K_PRIO_COOP(7), 0, 0);
 }

--- a/samples/net/telnet/src/telnet.c
+++ b/samples/net/telnet/src/telnet.c
@@ -21,6 +21,7 @@
 
 #define STACKSIZE 2000
 char __noinit __stack thread_stack[STACKSIZE];
+static struct k_thread thread_data;
 
 #if defined(CONFIG_NET_DHCPV4)
 static struct net_mgmt_event_callback mgmt_cb;
@@ -144,7 +145,7 @@ void main(void)
 {
 	NET_INFO("Starting Telnet sample");
 
-	k_thread_spawn(&thread_stack[0], STACKSIZE,
-		       (k_thread_entry_t)network_setup,
-		       NULL, NULL, NULL, K_PRIO_COOP(7), 0, 0);
+	k_thread_create(&thread_data, thread_stack, STACKSIZE,
+			(k_thread_entry_t)network_setup,
+			NULL, NULL, NULL, K_PRIO_COOP(7), 0, 0);
 }

--- a/samples/net/wpan_serial/src/main.c
+++ b/samples/net/wpan_serial/src/main.c
@@ -43,11 +43,13 @@ enum slip_state {
 /* RX queue */
 static struct k_fifo rx_queue;
 static char __noinit __stack rx_stack[1024];
+static struct k_thread rx_thread_data;
 
 /* TX queue */
 static struct k_sem tx_sem;
 static struct k_fifo tx_queue;
 static char __noinit __stack tx_stack[1024];
+static struct k_thread tx_thread_data;
 
 /* Buffer for SLIP encoded data for the worst case */
 static u8_t slip_buf[1 + 2 * CONFIG_NET_BUF_DATA_SIZE];
@@ -470,8 +472,9 @@ static void init_rx_queue(void)
 {
 	k_fifo_init(&rx_queue);
 
-	k_thread_spawn(rx_stack, sizeof(rx_stack), (k_thread_entry_t)rx_thread,
-		       NULL, NULL, NULL, K_PRIO_COOP(8), 0, K_NO_WAIT);
+	k_thread_create(&rx_thread_data, rx_stack, sizeof(rx_stack),
+			(k_thread_entry_t)rx_thread,
+			NULL, NULL, NULL, K_PRIO_COOP(8), 0, K_NO_WAIT);
 }
 
 static void init_tx_queue(void)
@@ -479,8 +482,9 @@ static void init_tx_queue(void)
 	k_sem_init(&tx_sem, 0, UINT_MAX);
 	k_fifo_init(&tx_queue);
 
-	k_thread_spawn(tx_stack, sizeof(tx_stack), (k_thread_entry_t)tx_thread,
-		       NULL, NULL, NULL, K_PRIO_COOP(8), 0, K_NO_WAIT);
+	k_thread_create(&tx_thread_data, tx_stack, sizeof(tx_stack),
+			(k_thread_entry_t)tx_thread,
+			NULL, NULL, NULL, K_PRIO_COOP(8), 0, K_NO_WAIT);
 }
 
 /**

--- a/samples/net/wpanusb/src/wpanusb.c
+++ b/samples/net/wpanusb/src/wpanusb.c
@@ -76,6 +76,7 @@ static struct k_fifo tx_queue;
  * Stack for the tx thread.
  */
 static char __noinit __stack tx_stack[1024];
+static struct k_thread tx_thread_data;
 
 #define DEV_DATA(dev) \
 	((struct wpanusb_dev_data_t * const)(dev)->driver_data)
@@ -530,8 +531,9 @@ static void init_tx_queue(void)
 	/* Transmit queue init */
 	k_fifo_init(&tx_queue);
 
-	k_thread_spawn(tx_stack, sizeof(tx_stack), (k_thread_entry_t)tx_thread,
-		       NULL, NULL, NULL, K_PRIO_COOP(8), 0, K_NO_WAIT);
+	k_thread_create(&tx_thread_data, tx_stack, sizeof(tx_stack),
+			(k_thread_entry_t)tx_thread,
+			NULL, NULL, NULL, K_PRIO_COOP(8), 0, K_NO_WAIT);
 }
 
 extern enum net_verdict ieee802154_radio_handle_ack(struct net_if *iface,

--- a/samples/net/zperf/src/zperf_tcp_receiver.c
+++ b/samples/net/zperf/src/zperf_tcp_receiver.c
@@ -29,6 +29,7 @@
 #define TCP_RX_FIBER_STACK_SIZE 1024
 
 static char __noinit __stack zperf_tcp_rx_stack[TCP_RX_FIBER_STACK_SIZE];
+static struct k_thread zperf_tcp_rx_thread_data;
 
 #if defined(CONFIG_NET_IPV6)
 static struct sockaddr_in6 *in6_addr_my;
@@ -240,8 +241,9 @@ void zperf_tcp_receiver_init(int port)
 	in4_addr_my = zperf_get_sin();
 #endif
 
-	k_thread_spawn(zperf_tcp_rx_stack, sizeof(zperf_tcp_rx_stack),
-		       (k_thread_entry_t)zperf_tcp_rx_thread,
-		       INT_TO_POINTER(port), 0, 0,
-		       K_PRIO_COOP(7), 0, K_NO_WAIT);
+	k_thread_create(&zperf_tcp_rx_thread_data, zperf_tcp_rx_stack,
+			sizeof(zperf_tcp_rx_stack),
+			(k_thread_entry_t)zperf_tcp_rx_thread,
+			INT_TO_POINTER(port), 0, 0,
+			K_PRIO_COOP(7), 0, K_NO_WAIT);
 }

--- a/samples/net/zperf/src/zperf_udp_receiver.c
+++ b/samples/net/zperf/src/zperf_udp_receiver.c
@@ -29,6 +29,7 @@
 
 /* Static data */
 static char __noinit __stack zperf_rx_stack[RX_THREAD_STACK_SIZE];
+static struct k_thread zperf_rx_thread_data;
 
 static struct sockaddr_in6 *in6_addr_my;
 static struct sockaddr_in *in4_addr_my;
@@ -383,8 +384,9 @@ void zperf_receiver_init(int port)
 	in4_addr_my = zperf_get_sin();
 #endif
 
-	k_thread_spawn(zperf_rx_stack, sizeof(zperf_rx_stack),
-		       (k_thread_entry_t)zperf_rx_thread,
-		       INT_TO_POINTER(port), 0, 0,
-		       K_PRIO_COOP(7), 0, K_NO_WAIT);
+	k_thread_create(&zperf_rx_thread_data, zperf_rx_stack,
+			sizeof(zperf_rx_stack),
+			(k_thread_entry_t)zperf_rx_thread,
+			INT_TO_POINTER(port), 0, 0,
+			K_PRIO_COOP(7), 0, K_NO_WAIT);
 }

--- a/samples/philosophers/src/main.c
+++ b/samples/philosophers/src/main.c
@@ -230,8 +230,8 @@ static void start_threads(void)
 	for (int i = 0; i < NUM_PHIL; i++) {
 		int prio = new_prio(i);
 
-		k_thread_spawn(&stacks[i][0], STACK_SIZE,
-			       philosopher, (void *)i, NULL, NULL, prio, 0, 0);
+		k_thread_create(&threads[i], &stacks[i][0], STACK_SIZE,
+				philosopher, (void *)i, NULL, NULL, prio, 0, 0);
 	}
 }
 

--- a/samples/philosophers/src/phil_obj_abstract.h
+++ b/samples/philosophers/src/phil_obj_abstract.h
@@ -157,5 +157,6 @@ static fork_t forks[NUM_PHIL] = {
 };
 
 static char __stack __noinit stacks[NUM_PHIL][STACK_SIZE];
+static struct k_thread threads[NUM_PHIL];
 
 #endif /* phil_obj_abstract__h */

--- a/samples/subsys/debug/sysview/src/main.c
+++ b/samples/subsys/debug/sysview/src/main.c
@@ -15,8 +15,12 @@
 
 static u8_t printer_stack[1024];
 static u8_t calc_stack[1024];
-
 static u8_t sysview_stack[2048];
+
+static struct k_thread printer_thread_data;
+static struct k_thread calc_thread_data;
+static struct k_thread sysview_thread_data;
+
 static u32_t timestamp, interrupt;
 
 extern SEGGER_RTT_CB _SEGGER_RTT;
@@ -245,14 +249,18 @@ static void calc_thread(void)
 
 void main(void)
 {
-	k_thread_spawn(sysview_stack, sizeof(sysview_stack),
-		       (k_thread_entry_t)sysview_thread,
-		       NULL, NULL, NULL, K_PRIO_COOP(1), 0, 0);
+	k_thread_create(&sysview_thread_data, sysview_stack,
+			sizeof(sysview_stack),
+			(k_thread_entry_t)sysview_thread,
+			NULL, NULL, NULL, K_PRIO_COOP(1), 0, 0);
 
-	k_thread_spawn(printer_stack, sizeof(printer_stack),
-		       (k_thread_entry_t)printer_thread,
-		       NULL, NULL, NULL, K_PRIO_COOP(1), 0, 0);
-	k_thread_spawn(calc_stack, sizeof(calc_stack),
-		       (k_thread_entry_t)calc_thread,
-		       NULL, NULL, NULL, K_PRIO_COOP(1), 0, 0);
+	k_thread_create(&printer_thread_data, printer_stack,
+			sizeof(printer_stack),
+			(k_thread_entry_t)printer_thread,
+			NULL, NULL, NULL, K_PRIO_COOP(1), 0, 0);
+
+	k_thread_create(&calc_thread_data, calc_stack,
+			sizeof(calc_stack),
+			(k_thread_entry_t)calc_thread,
+			NULL, NULL, NULL, K_PRIO_COOP(1), 0, 0);
 }

--- a/samples/subsys/ipc/ipm_mailbox/ap/src/hello.c
+++ b/samples/subsys/ipc/ipm_mailbox/ap/src/hello.c
@@ -28,6 +28,7 @@ QUARK_SE_IPM_DEFINE(message_ipm2, 3, QUARK_SE_IPM_OUTBOUND);
 #define TASK_PRIO               7
 
 char thread_stacks[2][STACKSIZE];
+static struct k_thread threads[2];
 
 u32_t scss_reg(u32_t offset)
 {
@@ -133,11 +134,12 @@ void main(void)
 {
 	printk("===== app started ========\n");
 
-	k_thread_spawn(&thread_stacks[0][0], STACKSIZE, main_thread,
-		       0, 0, 0, K_PRIO_COOP(MAIN_FIBER_PRI), 0, 0);
+	k_thread_create(&threads[0], &thread_stacks[0][0], STACKSIZE,
+			main_thread, 0, 0, 0,
+			K_PRIO_COOP(MAIN_FIBER_PRI), 0, 0);
 
-	k_thread_spawn(&thread_stacks[1][0], STACKSIZE, ping_source_thread,
-		       0, 0, 0, K_PRIO_COOP(PING_FIBER_PRI), 0, 0);
-
+	k_thread_create(&threads[0], &thread_stacks[1][0], STACKSIZE,
+			ping_source_thread, 0, 0, 0,
+			K_PRIO_COOP(PING_FIBER_PRI), 0, 0);
 }
 

--- a/samples/synchronization/src/main.c
+++ b/samples/synchronization/src/main.c
@@ -67,7 +67,7 @@ void threadB(void *dummy1, void *dummy2, void *dummy3)
 }
 
 char __noinit __stack threadB_stack_area[STACKSIZE];
-
+static struct k_thread threadB_data;
 
 /* threadA is a static thread that is spawned automatically */
 
@@ -78,8 +78,9 @@ void threadA(void *dummy1, void *dummy2, void *dummy3)
 	ARG_UNUSED(dummy3);
 
 	/* spawn threadB */
-	k_thread_spawn(threadB_stack_area, STACKSIZE, threadB, NULL, NULL, NULL,
-		       PRIORITY, 0, K_NO_WAIT);
+	k_thread_create(&threadB_data, threadB_stack_area, STACKSIZE,
+			threadB, NULL, NULL, NULL,
+			PRIORITY, 0, K_NO_WAIT);
 
 	/* invoke routine to ping-pong hello messages with threadB */
 	helloLoop(__func__, &threadA_sem, &threadB_sem);

--- a/subsys/bluetooth/controller/hci/hci_driver.c
+++ b/subsys/bluetooth/controller/hci/hci_driver.c
@@ -46,8 +46,10 @@
 static K_SEM_DEFINE(sem_prio_recv, 0, UINT_MAX);
 static K_FIFO_DEFINE(recv_fifo);
 
+struct k_thread prio_recv_thread_data;
 static BT_STACK_NOINIT(prio_recv_thread_stack,
 		       CONFIG_BLUETOOTH_CONTROLLER_RX_PRIO_STACK_SIZE);
+struct k_thread recv_thread_data;
 static BT_STACK_NOINIT(recv_thread_stack, CONFIG_BLUETOOTH_RX_STACK_SIZE);
 
 #if defined(CONFIG_INIT_STACKS)
@@ -399,13 +401,13 @@ static int hci_driver_open(void)
 	hci_init(NULL);
 #endif
 
-	k_thread_spawn(prio_recv_thread_stack, sizeof(prio_recv_thread_stack),
-		       prio_recv_thread, NULL, NULL, NULL, K_PRIO_COOP(6), 0,
-		       K_NO_WAIT);
+	k_thread_create(&prio_recv_thread_data, prio_recv_thread_stack,
+			sizeof(prio_recv_thread_stack), prio_recv_thread,
+			NULL, NULL, NULL, K_PRIO_COOP(6), 0, K_NO_WAIT);
 
-	k_thread_spawn(recv_thread_stack, sizeof(recv_thread_stack),
-		       recv_thread, NULL, NULL, NULL, K_PRIO_COOP(7), 0,
-		       K_NO_WAIT);
+	k_thread_create(&recv_thread_data, recv_thread_stack,
+			sizeof(recv_thread_stack), recv_thread,
+			NULL, NULL, NULL, K_PRIO_COOP(7), 0, K_NO_WAIT);
 
 	BT_DBG("Success.");
 

--- a/subsys/bluetooth/host/hci_ecc.c
+++ b/subsys/bluetooth/host/hci_ecc.c
@@ -33,6 +33,7 @@
 #include "hci_core.h"
 #endif
 
+static struct k_thread ecc_thread_data;
 static BT_STACK_NOINIT(ecc_thread_stack, 1060);
 
 /* based on Core Specification 4.2 Vol 3. Part H 2.3.5.6.1 */
@@ -307,7 +308,7 @@ int bt_hci_ecc_send(struct net_buf *buf)
 
 void bt_hci_ecc_init(void)
 {
-	k_thread_spawn(ecc_thread_stack, sizeof(ecc_thread_stack),
-		       ecc_thread, NULL, NULL, NULL,
-		       K_PRIO_PREEMPT(10), 0, K_NO_WAIT);
+	k_thread_create(&ecc_thread_data, ecc_thread_stack,
+			sizeof(ecc_thread_stack), ecc_thread, NULL, NULL, NULL,
+			K_PRIO_PREEMPT(10), 0, K_NO_WAIT);
 }

--- a/subsys/bluetooth/host/rfcomm.c
+++ b/subsys/bluetooth/host/rfcomm.c
@@ -750,8 +750,9 @@ static void rfcomm_dlc_connected(struct bt_rfcomm_dlc *dlc)
 	k_delayed_work_cancel(&dlc->rtx_work);
 
 	k_fifo_init(&dlc->tx_queue);
-	k_thread_spawn(dlc->stack, sizeof(dlc->stack), rfcomm_dlc_tx_thread,
-		       dlc, NULL, NULL, K_PRIO_COOP(7), 0, K_NO_WAIT);
+	k_thread_create(&dlc->tx_thread, dlc->stack, sizeof(dlc->stack),
+			rfcomm_dlc_tx_thread, dlc, NULL, NULL, K_PRIO_COOP(7),
+			0, K_NO_WAIT);
 
 	if (dlc->ops && dlc->ops->connected) {
 		dlc->ops->connected(dlc);

--- a/subsys/net/ip/net_core.c
+++ b/subsys/net/ip/net_core.c
@@ -59,7 +59,7 @@
 
 NET_STACK_DEFINE(RX, rx_stack, CONFIG_NET_RX_STACK_SIZE,
 		 CONFIG_NET_RX_STACK_SIZE + CONFIG_NET_RX_STACK_RPL);
-
+static struct k_thread rx_thread_data;
 static struct k_fifo rx_queue;
 static k_tid_t rx_tid;
 static K_SEM_DEFINE(startup_sync, 0, UINT_MAX);
@@ -186,10 +186,10 @@ static void init_rx_queue(void)
 {
 	k_fifo_init(&rx_queue);
 
-	rx_tid = k_thread_spawn(rx_stack, sizeof(rx_stack),
-				(k_thread_entry_t)net_rx_thread,
-				NULL, NULL, NULL, K_PRIO_COOP(8),
-				K_ESSENTIAL, K_NO_WAIT);
+	rx_tid = k_thread_create(&rx_thread_data, rx_stack, sizeof(rx_stack),
+				 (k_thread_entry_t)net_rx_thread,
+				 NULL, NULL, NULL, K_PRIO_COOP(8),
+				 K_ESSENTIAL, K_NO_WAIT);
 }
 
 #if defined(CONFIG_NET_IP_ADDR_CHECK)

--- a/subsys/net/ip/net_if.c
+++ b/subsys/net/ip/net_if.c
@@ -44,6 +44,7 @@ static sys_slist_t link_callbacks;
 
 NET_STACK_DEFINE(TX, tx_stack, CONFIG_NET_TX_STACK_SIZE,
 		 CONFIG_NET_TX_STACK_SIZE);
+static struct k_thread tx_thread_data;
 
 #if defined(CONFIG_NET_DEBUG_IF)
 #define debug_check_packet(pkt)						    \
@@ -1678,10 +1679,10 @@ void net_if_init(struct k_sem *startup_sync)
 		return;
 	}
 
-	k_thread_spawn(tx_stack, sizeof(tx_stack),
-		       (k_thread_entry_t)net_if_tx_thread,
-		       startup_sync, NULL, NULL, K_PRIO_COOP(7),
-		       K_ESSENTIAL, K_NO_WAIT);
+	k_thread_create(&tx_thread_data, tx_stack, sizeof(tx_stack),
+			(k_thread_entry_t)net_if_tx_thread,
+			startup_sync, NULL, NULL, K_PRIO_COOP(7),
+			K_ESSENTIAL, K_NO_WAIT);
 }
 
 void net_if_post_init(void)

--- a/subsys/net/ip/net_mgmt.c
+++ b/subsys/net/ip/net_mgmt.c
@@ -31,6 +31,7 @@ static K_SEM_DEFINE(network_event, 0, UINT_MAX);
 
 NET_STACK_DEFINE(MGMT, mgmt_stack, CONFIG_NET_MGMT_EVENT_STACK_SIZE,
 		 CONFIG_NET_MGMT_EVENT_STACK_SIZE);
+static struct k_thread mgmt_thread_data;
 static struct mgmt_event_entry events[CONFIG_NET_MGMT_EVENT_QUEUE_SIZE];
 static u32_t global_event_mask;
 static sys_slist_t event_callbacks;
@@ -297,9 +298,9 @@ void net_mgmt_event_init(void)
 	       CONFIG_NET_MGMT_EVENT_QUEUE_SIZE *
 	       sizeof(struct mgmt_event_entry));
 
-	k_thread_spawn(mgmt_stack, sizeof(mgmt_stack),
-		       (k_thread_entry_t)mgmt_thread, NULL, NULL, NULL,
-		       K_PRIO_COOP(CONFIG_NET_MGMT_EVENT_THREAD_PRIO), 0, 0);
+	k_thread_create(&mgmt_thread_data, mgmt_stack, sizeof(mgmt_stack),
+			(k_thread_entry_t)mgmt_thread, NULL, NULL, NULL,
+			K_PRIO_COOP(CONFIG_NET_MGMT_EVENT_THREAD_PRIO), 0, 0);
 
 	NET_DBG("Net MGMT initialized: queue of %u entries, stack size of %u",
 		CONFIG_NET_MGMT_EVENT_QUEUE_SIZE,

--- a/subsys/net/ip/net_shell.c
+++ b/subsys/net/ip/net_shell.c
@@ -1302,7 +1302,7 @@ extern char _interrupt_stack[];
 int net_shell_cmd_stacks(int argc, char *argv[])
 {
 #if defined(CONFIG_INIT_STACKS)
-	unsigned int stack_offset, pcnt, unused;
+	unsigned int pcnt, unused;
 #endif
 	struct net_stack_info *info;
 
@@ -1311,13 +1311,13 @@ int net_shell_cmd_stacks(int argc, char *argv[])
 
 	for (info = __net_stack_start; info != __net_stack_end; info++) {
 		net_analyze_stack_get_values(info->stack, info->size,
-					     &stack_offset, &pcnt, &unused);
+					     &pcnt, &unused);
 
 #if defined(CONFIG_INIT_STACKS)
 		printk("%s [%s] stack size %zu/%zu bytes unused %u usage"
 		       " %zu/%zu (%u %%)\n",
 		       info->pretty_name, info->name, info->orig_size,
-		       info->size + stack_offset, unused,
+		       info->size, unused,
 		       info->size - unused, info->size, pcnt);
 #else
 		printk("%s [%s] stack size %zu usage not available\n",
@@ -1327,19 +1327,19 @@ int net_shell_cmd_stacks(int argc, char *argv[])
 
 #if defined(CONFIG_INIT_STACKS)
 	net_analyze_stack_get_values(_main_stack, CONFIG_MAIN_STACK_SIZE,
-				     &stack_offset, &pcnt, &unused);
+				     &pcnt, &unused);
 	printk("%s [%s] stack size %d/%d bytes unused %u usage"
 	       " %d/%d (%u %%)\n",
 	       "main", "_main_stack", CONFIG_MAIN_STACK_SIZE,
-	       CONFIG_MAIN_STACK_SIZE + stack_offset, unused,
+	       CONFIG_MAIN_STACK_SIZE, unused,
 	       CONFIG_MAIN_STACK_SIZE - unused, CONFIG_MAIN_STACK_SIZE, pcnt);
 
 	net_analyze_stack_get_values(_interrupt_stack, CONFIG_ISR_STACK_SIZE,
-				     &stack_offset, &pcnt, &unused);
+				     &pcnt, &unused);
 	printk("%s [%s] stack size %d/%d bytes unused %u usage"
 	       " %d/%d (%u %%)\n",
 	       "ISR", "_interrupt_stack", CONFIG_ISR_STACK_SIZE,
-	       CONFIG_ISR_STACK_SIZE + stack_offset, unused,
+	       CONFIG_ISR_STACK_SIZE, unused,
 	       CONFIG_ISR_STACK_SIZE - unused, CONFIG_ISR_STACK_SIZE, pcnt);
 #endif
 

--- a/subsys/shell/shell.c
+++ b/subsys/shell/shell.c
@@ -44,7 +44,8 @@ static char default_module_prompt[PROMPT_MAX_LEN];
 static int default_module = -1;
 
 #define STACKSIZE CONFIG_CONSOLE_SHELL_STACKSIZE
-static char __stack stack[STACKSIZE];
+static char __noinit __stack stack[STACKSIZE];
+static struct k_thread shell_thread;
 
 #define MAX_CMD_QUEUED CONFIG_CONSOLE_SHELL_MAX_CMD_QUEUED
 static struct console_input buf[MAX_CMD_QUEUED];
@@ -522,8 +523,8 @@ void shell_init(const char *str)
 
 	prompt = str ? str : "";
 
-	k_thread_spawn(stack, STACKSIZE, shell, NULL, NULL, NULL,
-		       K_PRIO_COOP(7), 0, K_NO_WAIT);
+	k_thread_create(&shell_thread, stack, STACKSIZE, shell, NULL, NULL,
+			NULL, K_PRIO_COOP(7), 0, K_NO_WAIT);
 
 	/* Register serial console handler */
 #ifdef CONFIG_UART_CONSOLE

--- a/subsys/usb/class/mass_storage.c
+++ b/subsys/usb/class/mass_storage.c
@@ -57,7 +57,8 @@
 #define DISK_THREAD_PRIO	-5
 
 static volatile int thread_op;
-static char __stack mass_thread_stack[DISK_THREAD_STACK_SZ];
+static char __noinit __stack mass_thread_stack[DISK_THREAD_STACK_SZ];
+static struct k_thread mass_thread_data;
 static struct k_sem disk_wait_sem;
 static volatile u32_t defered_wr_sz;
 
@@ -967,8 +968,9 @@ static int mass_storage_init(struct device *dev)
 	k_sem_init(&disk_wait_sem, 0, 1);
 
 	/* Start a thread to offload disk ops */
-	k_thread_spawn(mass_thread_stack, DISK_THREAD_STACK_SZ,
-		       (k_thread_entry_t)mass_thread_main, NULL, NULL, NULL,
+	k_thread_create(&mass_thread_data, mass_thread_stack,
+			DISK_THREAD_STACK_SZ,
+			(k_thread_entry_t)mass_thread_main, NULL, NULL, NULL,
 			DISK_THREAD_PRIO, 0, 0);
 
 	return 0;

--- a/tests/benchmarks/footprint/src/main.c
+++ b/tests/benchmarks/footprint/src/main.c
@@ -123,7 +123,7 @@ static pfunc func_array[] = {
 	(pfunc)k_uptime_delta_32,
 
 	/* thread stuff */
-	(pfunc)k_thread_spawn,
+	(pfunc)k_thread_create,
 	(pfunc)k_sleep,
 	(pfunc)k_busy_wait,
 	(pfunc)k_yield,

--- a/tests/benchmarks/latency_measure/src/coop_ctx_switch.c
+++ b/tests/benchmarks/latency_measure/src/coop_ctx_switch.c
@@ -29,6 +29,8 @@
 /* stack used by the fibers */
 static char __stack thread_one_stack[STACKSIZE];
 static char __stack thread_two_stack[STACKSIZE];
+static struct k_thread thread_one_data;
+static struct k_thread thread_two_data;
 
 static u32_t timestamp;
 
@@ -93,10 +95,12 @@ int coop_ctx_switch(void)
 	ctx_switch_balancer = 0;
 
 	bench_test_start();
-	k_thread_spawn(&thread_one_stack[0], STACKSIZE,
-		       (k_thread_entry_t) thread_one, NULL, NULL, NULL, 6, 0, K_NO_WAIT);
-	k_thread_spawn(&thread_two_stack[0], STACKSIZE,
-		       (k_thread_entry_t) thread_two, NULL, NULL, NULL, 6, 0, K_NO_WAIT);
+	k_thread_create(&thread_one_data, thread_one_stack, STACKSIZE,
+			(k_thread_entry_t) thread_one, NULL, NULL, NULL,
+			6, 0, K_NO_WAIT);
+	k_thread_create(&thread_two_data, thread_two_stack, STACKSIZE,
+			(k_thread_entry_t) thread_two, NULL, NULL, NULL,
+			6, 0, K_NO_WAIT);
 
 	if (ctx_switch_balancer > 3 || ctx_switch_balancer < -3) {
 		PRINT_FORMAT(" Balance is %d. FAILED", ctx_switch_balancer);

--- a/tests/benchmarks/latency_measure/src/thread_switch_yield.c
+++ b/tests/benchmarks/latency_measure/src/thread_switch_yield.c
@@ -30,6 +30,7 @@ static u32_t helper_thread_iterations;
 #define Y_PRIORITY      10
 
 char __noinit __stack y_stack_area[Y_STACK_SIZE];
+static struct k_thread y_thread;
 
 /**
  *
@@ -63,8 +64,9 @@ void thread_switch_yield(void)
 	bench_test_start();
 
 	/* launch helper thread of the same priority than this routine */
-	k_thread_spawn(y_stack_area, Y_STACK_SIZE, yielding_thread, NULL, NULL, NULL,
-		       Y_PRIORITY, 0, K_NO_WAIT);
+	k_thread_create(&y_thread, y_stack_area, Y_STACK_SIZE,
+			yielding_thread, NULL, NULL, NULL,
+			Y_PRIORITY, 0, K_NO_WAIT);
 
 	/* get initial timestamp */
 	timestamp = TIME_STAMP_DELTA_GET(0);

--- a/tests/benchmarks/object_footprint/src/main.c
+++ b/tests/benchmarks/object_footprint/src/main.c
@@ -31,6 +31,7 @@ typedef void * (*pfunc) (void *);
 /* stack used by thread */
 #ifdef CONFIG_OBJECTS_THREAD
 static char __stack pStack[THREAD_STACK_SIZE];
+static struct k_thread objects_thread;
 #endif
 
 /* pointer array ensures specified functions are linked into the image */
@@ -116,8 +117,9 @@ void main(void)
 
 #ifdef CONFIG_OBJECTS_THREAD
 	/* start a trivial fiber */
-	k_thread_spawn(pStack, THREAD_STACK_SIZE, thread_entry, MESSAGE, (void *)func_array,
-		       NULL, 10, 0, K_NO_WAIT);
+	k_thread_create(&objects_thread, pStack, THREAD_STACK_SIZE,
+			thread_entry, MESSAGE, (void *)func_array,
+			NULL, 10, 0, K_NO_WAIT);
 #endif
 
 #ifdef CONFIG_OBJECTS_WHILELOOP

--- a/tests/benchmarks/sys_kernel/src/lifo.c
+++ b/tests/benchmarks/sys_kernel/src/lifo.c
@@ -159,11 +159,11 @@ int lifo_test(void)
 
 	t = BENCH_START();
 
-	k_thread_spawn(thread_stack1, STACK_SIZE, lifo_thread1,
+	k_thread_create(&thread_data1, thread_stack1, STACK_SIZE, lifo_thread1,
 			 NULL, (void *) NUMBER_OF_LOOPS, NULL,
 			 K_PRIO_COOP(3), 0, K_NO_WAIT);
 
-	k_thread_spawn(thread_stack2, STACK_SIZE, lifo_thread2,
+	k_thread_create(&thread_data2, thread_stack2, STACK_SIZE, lifo_thread2,
 			 (void *) &i, (void *) NUMBER_OF_LOOPS, NULL,
 			 K_PRIO_COOP(3), 0, K_NO_WAIT);
 
@@ -193,11 +193,11 @@ int lifo_test(void)
 
 	i = 0;
 
-	k_thread_spawn(thread_stack1, STACK_SIZE, lifo_thread1,
+	k_thread_create(&thread_data1, thread_stack1, STACK_SIZE, lifo_thread1,
 			 NULL, (void *) NUMBER_OF_LOOPS, NULL,
 			 K_PRIO_COOP(3), 0, K_NO_WAIT);
 
-	k_thread_spawn(thread_stack2, STACK_SIZE, lifo_thread3,
+	k_thread_create(&thread_data2, thread_stack2, STACK_SIZE, lifo_thread3,
 			 (void *) &i, (void *) NUMBER_OF_LOOPS, NULL,
 			 K_PRIO_COOP(3), 0, K_NO_WAIT);
 
@@ -225,7 +225,7 @@ int lifo_test(void)
 
 	t = BENCH_START();
 
-	k_thread_spawn(thread_stack1, STACK_SIZE, lifo_thread1,
+	k_thread_create(&thread_data1, thread_stack1, STACK_SIZE, lifo_thread1,
 			 NULL, (void *) NUMBER_OF_LOOPS, NULL,
 			 K_PRIO_COOP(3), 0, K_NO_WAIT);
 	for (i = 0; i < NUMBER_OF_LOOPS / 2; i++) {

--- a/tests/benchmarks/sys_kernel/src/mwfifo.c
+++ b/tests/benchmarks/sys_kernel/src/mwfifo.c
@@ -159,10 +159,10 @@ int fifo_test(void)
 
 	t = BENCH_START();
 
-	k_thread_spawn(thread_stack1, STACK_SIZE, fifo_thread1,
+	k_thread_create(&thread_data1, thread_stack1, STACK_SIZE, fifo_thread1,
 			 NULL, (void *) NUMBER_OF_LOOPS, NULL,
 			 K_PRIO_COOP(3), 0, K_NO_WAIT);
-	k_thread_spawn(thread_stack2, STACK_SIZE, fifo_thread2,
+	k_thread_create(&thread_data2, thread_stack2, STACK_SIZE, fifo_thread2,
 			 (void *) &i, (void *) NUMBER_OF_LOOPS, NULL,
 			 K_PRIO_COOP(3), 0, K_NO_WAIT);
 
@@ -191,10 +191,10 @@ int fifo_test(void)
 	t = BENCH_START();
 
 	i = 0;
-	k_thread_spawn(thread_stack1, STACK_SIZE, fifo_thread1,
+	k_thread_create(&thread_data1, thread_stack1, STACK_SIZE, fifo_thread1,
 			 NULL, (void *) NUMBER_OF_LOOPS, NULL,
 			 K_PRIO_COOP(3), 0, K_NO_WAIT);
-	k_thread_spawn(thread_stack2, STACK_SIZE, fifo_thread3,
+	k_thread_create(&thread_data2, thread_stack2, STACK_SIZE, fifo_thread3,
 			 (void *) &i, (void *) NUMBER_OF_LOOPS, NULL,
 			 K_PRIO_COOP(3), 0, K_NO_WAIT);
 
@@ -222,10 +222,10 @@ int fifo_test(void)
 
 	t = BENCH_START();
 
-	k_thread_spawn(thread_stack1, STACK_SIZE, fifo_thread1,
+	k_thread_create(&thread_data1, thread_stack1, STACK_SIZE, fifo_thread1,
 			 NULL, (void *) (NUMBER_OF_LOOPS / 2), NULL,
 			 K_PRIO_COOP(3), 0, K_NO_WAIT);
-	k_thread_spawn(thread_stack2, STACK_SIZE, fifo_thread1,
+	k_thread_create(&thread_data2, thread_stack2, STACK_SIZE, fifo_thread1,
 			 NULL, (void *) (NUMBER_OF_LOOPS / 2), NULL,
 			 K_PRIO_COOP(3), 0, K_NO_WAIT);
 	for (i = 0; i < NUMBER_OF_LOOPS / 2; i++) {

--- a/tests/benchmarks/sys_kernel/src/sema.c
+++ b/tests/benchmarks/sys_kernel/src/sema.c
@@ -123,10 +123,10 @@ int sema_test(void)
 
 	t = BENCH_START();
 
-	k_thread_spawn(thread_stack1, STACK_SIZE, sema_thread1,
+	k_thread_create(&thread_data1, thread_stack1, STACK_SIZE, sema_thread1,
 			 NULL, (void *) NUMBER_OF_LOOPS, NULL,
 			 K_PRIO_COOP(3), 0, K_NO_WAIT);
-	k_thread_spawn(thread_stack2, STACK_SIZE, sema_thread2,
+	k_thread_create(&thread_data2, thread_stack2, STACK_SIZE, sema_thread2,
 			 (void *) &i, (void *) NUMBER_OF_LOOPS, NULL,
 			 K_PRIO_COOP(3), 0, K_NO_WAIT);
 
@@ -148,10 +148,10 @@ int sema_test(void)
 
 	t = BENCH_START();
 
-	k_thread_spawn(thread_stack1, STACK_SIZE, sema_thread1,
+	k_thread_create(&thread_data1, thread_stack1, STACK_SIZE, sema_thread1,
 			 NULL, (void *) NUMBER_OF_LOOPS, NULL,
 			 K_PRIO_COOP(3), 0, K_NO_WAIT);
-	k_thread_spawn(thread_stack2, STACK_SIZE, sema_thread3,
+	k_thread_create(&thread_data2, thread_stack2, STACK_SIZE, sema_thread3,
 			 (void *) &i, (void *) NUMBER_OF_LOOPS, NULL,
 			 K_PRIO_COOP(3), 0, K_NO_WAIT);
 
@@ -173,7 +173,7 @@ int sema_test(void)
 
 	t = BENCH_START();
 
-	k_thread_spawn(thread_stack1, STACK_SIZE, sema_thread1,
+	k_thread_create(&thread_data1, thread_stack1, STACK_SIZE, sema_thread1,
 			 NULL, (void *) NUMBER_OF_LOOPS, NULL,
 			 K_PRIO_COOP(3), 0, K_NO_WAIT);
 	for (i = 0; i < NUMBER_OF_LOOPS; i++) {

--- a/tests/benchmarks/sys_kernel/src/stack.c
+++ b/tests/benchmarks/sys_kernel/src/stack.c
@@ -157,10 +157,10 @@ int stack_test(void)
 
 	t = BENCH_START();
 
-	k_thread_spawn(thread_stack1, STACK_SIZE, stack_thread1,
+	k_thread_create(&thread_data1, thread_stack1, STACK_SIZE, stack_thread1,
 			 0, (void *) NUMBER_OF_LOOPS, NULL,
 			 K_PRIO_COOP(3), 0, K_NO_WAIT);
-	k_thread_spawn(thread_stack2, STACK_SIZE, stack_thread2,
+	k_thread_create(&thread_data2, thread_stack2, STACK_SIZE, stack_thread2,
 			 (void *) &i, (void *) NUMBER_OF_LOOPS, NULL,
 			 K_PRIO_COOP(3), 0, K_NO_WAIT);
 
@@ -184,10 +184,10 @@ int stack_test(void)
 	t = BENCH_START();
 
 	i = 0;
-	k_thread_spawn(thread_stack1, STACK_SIZE, stack_thread1,
+	k_thread_create(&thread_data1, thread_stack1, STACK_SIZE, stack_thread1,
 			 0, (void *) NUMBER_OF_LOOPS, NULL,
 			 K_PRIO_COOP(3), 0, K_NO_WAIT);
-	k_thread_spawn(thread_stack2, STACK_SIZE, stack_thread3,
+	k_thread_create(&thread_data2, thread_stack2, STACK_SIZE, stack_thread3,
 			 (void *) &i, (void *) NUMBER_OF_LOOPS, NULL,
 			 K_PRIO_COOP(3), 0, K_NO_WAIT);
 
@@ -212,7 +212,7 @@ int stack_test(void)
 
 	t = BENCH_START();
 
-	k_thread_spawn(thread_stack1, STACK_SIZE, stack_thread1,
+	k_thread_create(&thread_data1, thread_stack1, STACK_SIZE, stack_thread1,
 			 0, (void *) NUMBER_OF_LOOPS, NULL,
 			 K_PRIO_COOP(3), 0, K_NO_WAIT);
 

--- a/tests/benchmarks/sys_kernel/src/syskernel.c
+++ b/tests/benchmarks/sys_kernel/src/syskernel.c
@@ -15,6 +15,8 @@
 
 char __stack thread_stack1[STACK_SIZE];
 char __stack thread_stack2[STACK_SIZE];
+struct k_thread thread_data1;
+struct k_thread thread_data2;
 
 char Msg[256];
 

--- a/tests/benchmarks/sys_kernel/src/syskernel.h
+++ b/tests/benchmarks/sys_kernel/src/syskernel.h
@@ -19,6 +19,8 @@
 
 extern char thread_stack1[STACK_SIZE];
 extern char thread_stack2[STACK_SIZE];
+extern struct k_thread thread_data1;
+extern struct k_thread thread_data2;
 
 extern FILE *output_file;
 

--- a/tests/benchmarks/timing_info/src/msg_passing_bench.c
+++ b/tests/benchmarks/timing_info/src/msg_passing_bench.c
@@ -73,6 +73,8 @@ k_tid_t thread_mbox_async_put_receive_tid;
 #define STACK_SIZE 500
 extern char __noinit __stack my_stack_area[STACK_SIZE];
 extern char __noinit __stack my_stack_area_0[STACK_SIZE];
+extern struct k_thread my_thread;
+extern struct k_thread my_thread_0;
 
 /* thread functions*/
 void thread_producer_msgq_w_cxt_switch(void *p1, void *p2, void *p3);
@@ -115,16 +117,16 @@ void msg_passing_bench(void)
 	int received_data = 0;
 
 	producer_w_cxt_switch_tid =
-		k_thread_spawn(my_stack_area, STACK_SIZE,
-			       thread_producer_msgq_w_cxt_switch, NULL,
-			       NULL, NULL, 2 /*priority*/, 0, 50);
+		k_thread_create(&my_thread, my_stack_area, STACK_SIZE,
+				thread_producer_msgq_w_cxt_switch, NULL,
+				NULL, NULL, 2 /*priority*/, 0, 50);
 
 	u32_t msg_status =  k_msgq_get(&benchmark_q, &received_data, 300);
 
 	producer_wo_cxt_switch_tid =
-		k_thread_spawn(my_stack_area_0, STACK_SIZE,
-			       thread_producer_msgq_wo_cxt_switch,
-			       NULL, NULL, NULL, -2 /*priority*/, 0, 0);
+		k_thread_create(&my_thread_0, my_stack_area_0, STACK_SIZE,
+				thread_producer_msgq_wo_cxt_switch,
+				NULL, NULL, NULL, -2 /*priority*/, 0, 0);
 
 	k_thread_abort(producer_w_cxt_switch_tid);
 	k_thread_abort(producer_wo_cxt_switch_tid);
@@ -136,16 +138,16 @@ void msg_passing_bench(void)
 	/* Msg queue for get*/
 
 	producer_get_w_cxt_switch_tid =
-		k_thread_spawn(my_stack_area,
-			       STACK_SIZE,
-			       thread_producer_get_msgq_w_cxt_switch, NULL,
-			       NULL, NULL, 1 /*priority*/, 0, 50);
+		k_thread_create(&my_thread, my_stack_area,
+				STACK_SIZE,
+				thread_producer_get_msgq_w_cxt_switch, NULL,
+				NULL, NULL, 1 /*priority*/, 0, 50);
 	consumer_get_w_cxt_switch_tid =
-		k_thread_spawn(my_stack_area_0,
-			       STACK_SIZE,
-			       thread_consumer_get_msgq_w_cxt_switch,
-			       NULL, NULL, NULL,
-			       2 /*priority*/, 0, 50);
+		k_thread_create(&my_thread_0, my_stack_area_0,
+				STACK_SIZE,
+				thread_consumer_get_msgq_w_cxt_switch,
+				NULL, NULL, NULL,
+				2 /*priority*/, 0, 50);
 	k_sleep(2000);  /* make the main thread sleep */
 	k_thread_abort(producer_get_w_cxt_switch_tid);
 	__msg_q_get_w_cxt_end_tsc = (__common_var_swap_end_tsc);
@@ -168,17 +170,17 @@ void msg_passing_bench(void)
 	/* Msg box to benchmark sync put */
 
 	thread_mbox_sync_put_send_tid  =
-		k_thread_spawn(my_stack_area,
-			       STACK_SIZE,
-			       thread_mbox_sync_put_send,
-			       NULL, NULL, NULL,
-			       2 /*priority*/, 0, 0);
+		k_thread_create(&my_thread, my_stack_area,
+				STACK_SIZE,
+				thread_mbox_sync_put_send,
+				NULL, NULL, NULL,
+				2 /*priority*/, 0, 0);
 	thread_mbox_sync_put_receive_tid =
-		k_thread_spawn(my_stack_area_0,
-			       STACK_SIZE,
-			       thread_mbox_sync_put_receive,
-			       NULL, NULL, NULL,
-			       1 /*priority*/, 0, 0);
+		k_thread_create(&my_thread_0, my_stack_area_0,
+				STACK_SIZE,
+				thread_mbox_sync_put_receive,
+				NULL, NULL, NULL,
+				1 /*priority*/, 0, 0);
 	k_sleep(1000);  /* make the main thread sleep */
 	mbox_sync_put_end_tsc = (__common_var_swap_end_tsc);
 
@@ -187,16 +189,16 @@ void msg_passing_bench(void)
 	/* Msg box to benchmark sync get */
 
 	thread_mbox_sync_get_send_tid  =
-		k_thread_spawn(my_stack_area,
-			       STACK_SIZE,
-			       thread_mbox_sync_get_send,
-			       NULL, NULL, NULL,
-			       1 /*prio*/, 0, 0);
+		k_thread_create(&my_thread, my_stack_area,
+				STACK_SIZE,
+				thread_mbox_sync_get_send,
+				NULL, NULL, NULL,
+				1 /*prio*/, 0, 0);
 	thread_mbox_sync_get_receive_tid =
-		k_thread_spawn(my_stack_area_0,
-			       STACK_SIZE,
-			       thread_mbox_sync_get_receive, NULL,
-			       NULL, NULL, 2 /*priority*/, 0, 0);
+		k_thread_create(&my_thread_0, my_stack_area_0,
+				STACK_SIZE,
+				thread_mbox_sync_get_receive, NULL,
+				NULL, NULL, 2 /*priority*/, 0, 0);
 	k_sleep(1000); /* make the main thread sleep */
 	mbox_sync_get_end_tsc = (__common_var_swap_end_tsc);
 
@@ -205,17 +207,17 @@ void msg_passing_bench(void)
 	/* Msg box to benchmark async put */
 
 	thread_mbox_async_put_send_tid  =
-		k_thread_spawn(my_stack_area,
-			       STACK_SIZE,
-			       thread_mbox_async_put_send,
-			       NULL, NULL, NULL,
-			       2 /*prio*/, 0, 0);
+		k_thread_create(&my_thread, my_stack_area,
+				STACK_SIZE,
+				thread_mbox_async_put_send,
+				NULL, NULL, NULL,
+				2 /*prio*/, 0, 0);
 	thread_mbox_async_put_receive_tid =
-		k_thread_spawn(my_stack_area_0,
-			       STACK_SIZE,
-			       thread_mbox_async_put_receive,
-			       NULL, NULL, NULL,
-			       3 /*priority*/, 0, 0);
+		k_thread_create(&my_thread_0, my_stack_area_0,
+				STACK_SIZE,
+				thread_mbox_async_put_receive,
+				NULL, NULL, NULL,
+				3 /*priority*/, 0, 0);
 	k_sleep(1000); /* make the main thread sleep */
 
 	/*******************************************************************/

--- a/tests/benchmarks/timing_info/src/semaphore_bench.c
+++ b/tests/benchmarks/timing_info/src/semaphore_bench.c
@@ -14,6 +14,8 @@ K_SEM_DEFINE(sem_bench_1, 0, 1);
 #define STACK_SIZE 500
 extern char __noinit __stack my_stack_area[STACK_SIZE];
 extern char __noinit __stack my_stack_area_0[STACK_SIZE];
+extern struct k_thread my_thread;
+extern struct k_thread my_thread_0;
 
 /* u64_t thread_yield_start_tsc[1000]; */
 /* u64_t thread_yield_end_tsc[1000]; */
@@ -44,14 +46,14 @@ void semaphore_bench(void)
 
 	/* Thread yield*/
 
-	sem0_tid = k_thread_spawn(my_stack_area,
-				  STACK_SIZE,
-				  thread_sem0_test, NULL, NULL, NULL,
-				  2 /*priority*/, 0, 0);
-	sem1_tid = k_thread_spawn(my_stack_area_0,
-				  STACK_SIZE, thread_sem1_test,
-				  NULL, NULL, NULL,
-				  2 /*priority*/, 0, 0);
+	sem0_tid = k_thread_create(&my_thread, my_stack_area,
+				   STACK_SIZE,
+				   thread_sem0_test, NULL, NULL, NULL,
+				   2 /*priority*/, 0, 0);
+	sem1_tid = k_thread_create(&my_thread_0, my_stack_area_0,
+				   STACK_SIZE, thread_sem1_test,
+				   NULL, NULL, NULL,
+				   2 /*priority*/, 0, 0);
 
 	k_sleep(1000);
 
@@ -60,14 +62,14 @@ void semaphore_bench(void)
 	sem_end_time = (__common_var_swap_end_tsc);
 	u32_t sem_cycles = sem_end_time - sem_start_time;
 
-	sem0_tid = k_thread_spawn(my_stack_area,
-				  STACK_SIZE, thread_sem0_give_test,
-				  NULL, NULL, NULL,
-				  2 /*priority*/, 0, 0);
-	sem1_tid = k_thread_spawn(my_stack_area_0,
-				  STACK_SIZE, thread_sem1_give_test,
-				  NULL, NULL, NULL,
-				  2 /*priority*/, 0, 0);
+	sem0_tid = k_thread_create(&my_thread, my_stack_area,
+				   STACK_SIZE, thread_sem0_give_test,
+				   NULL, NULL, NULL,
+				   2 /*priority*/, 0, 0);
+	sem1_tid = k_thread_create(&my_thread_0, my_stack_area_0,
+				   STACK_SIZE, thread_sem1_give_test,
+				   NULL, NULL, NULL,
+				   2 /*priority*/, 0, 0);
 
 	k_sleep(1000);
 	sem_give_end_time = (__common_var_swap_end_tsc);

--- a/tests/benchmarks/timing_info/src/thread_bench.c
+++ b/tests/benchmarks/timing_info/src/thread_bench.c
@@ -46,6 +46,8 @@ k_tid_t consumer_tid;
 #define STACK_SIZE 500
 char __noinit __stack my_stack_area[STACK_SIZE];
 char __noinit __stack my_stack_area_0[STACK_SIZE];
+struct k_thread my_thread;
+struct k_thread my_thread_0;
 
 u32_t __read_swap_end_tsc_value_test = 1;
 u64_t dummy_time;
@@ -171,11 +173,10 @@ void system_thread_bench(void)
 
 
 	/* to measure context switch time */
-	k_thread_spawn(my_stack_area_0,
-		       STACK_SIZE,
-		       thread_swap_test,
-		       NULL, NULL, NULL,
-		       -1 /*priority*/, 0, 0);
+	k_thread_create(&my_thread_0, my_stack_area_0, STACK_SIZE,
+			thread_swap_test,
+			NULL, NULL, NULL,
+			-1 /*priority*/, 0, 0);
 
 	thread_abort_end_tsc = (__common_var_swap_end_tsc);
 	__end_swap_tsc = __common_var_swap_end_tsc;
@@ -196,11 +197,11 @@ void system_thread_bench(void)
 	/* thread create*/
 	thread_create_start_tsc = OS_GET_TIME();
 
-	k_tid_t my_tid = k_thread_spawn(my_stack_area,
-					STACK_SIZE,
-					thread_swap_test,
-					NULL, NULL, NULL,
-					5 /*priority*/, 0, 10);
+	k_tid_t my_tid = k_thread_create(&my_thread, my_stack_area,
+					 STACK_SIZE,
+					 thread_swap_test,
+					 NULL, NULL, NULL,
+					 5 /*priority*/, 0, 10);
 
 	thread_create_end_tsc = OS_GET_TIME();
 
@@ -212,11 +213,11 @@ void system_thread_bench(void)
 	ARG_UNUSED(ret_value_thread_cancel);
 
 	/* Thread suspend*/
-	k_tid_t sus_res_tid = k_thread_spawn(my_stack_area,
-					     STACK_SIZE,
-					     thread_suspend_test,
-					     NULL, NULL, NULL,
-					     -1 /*priority*/, 0, 0);
+	k_tid_t sus_res_tid = k_thread_create(&my_thread, my_stack_area,
+					      STACK_SIZE,
+					      thread_suspend_test,
+					      NULL, NULL, NULL,
+					      -1 /*priority*/, 0, 0);
 
 	thread_suspend_end_tsc = OS_GET_TIME();
 	/* At this point test for resume*/

--- a/tests/benchmarks/timing_info/src/yield_bench.c
+++ b/tests/benchmarks/timing_info/src/yield_bench.c
@@ -10,6 +10,8 @@ K_SEM_DEFINE(yield_sem, 0, 1);
 #define STACK_SIZE 500
 extern char __noinit __stack my_stack_area[STACK_SIZE];
 extern char __noinit __stack my_stack_area_0[STACK_SIZE];
+extern struct k_thread my_thread;
+extern struct k_thread my_thread_0;
 
 /* u64_t thread_yield_start_tsc[1000]; */
 /* u64_t thread_yield_end_tsc[1000]; */
@@ -34,17 +36,17 @@ void yield_bench(void)
 
 	/* Thread yield*/
 
-	yield0_tid = k_thread_spawn(my_stack_area,
-				    STACK_SIZE,
-				    thread_yield0_test,
-				    NULL, NULL, NULL,
-				    0 /*priority*/, 0, 0);
+	yield0_tid = k_thread_create(&my_thread, my_stack_area,
+				     STACK_SIZE,
+				     thread_yield0_test,
+				     NULL, NULL, NULL,
+				     0 /*priority*/, 0, 0);
 
-	yield1_tid = k_thread_spawn(my_stack_area_0,
-				    STACK_SIZE,
-				    thread_yield1_test,
-				    NULL, NULL, NULL,
-				    0 /*priority*/, 0, 0);
+	yield1_tid = k_thread_create(&my_thread_0, my_stack_area_0,
+				     STACK_SIZE,
+				     thread_yield1_test,
+				     NULL, NULL, NULL,
+				     0 /*priority*/, 0, 0);
 
 	/*read the time of start of the sleep till the swap happens */
 	__read_swap_end_tsc_value = 1;

--- a/tests/bluetooth/tester/src/bttester.c
+++ b/tests/bluetooth/tester/src/bttester.c
@@ -20,6 +20,7 @@
 
 #define STACKSIZE 2048
 static char __stack stack[STACKSIZE];
+static struct k_thread cmd_thread;
 
 #define CMD_QUEUED 2
 static u8_t cmd_buf[CMD_QUEUED * BTP_MTU];
@@ -200,8 +201,8 @@ void tester_init(void)
 		k_fifo_put(&avail_queue, &cmd_buf[i * BTP_MTU]);
 	}
 
-	k_thread_spawn(stack, STACKSIZE, cmd_handler, NULL, NULL, NULL,
-		       K_PRIO_COOP(7), 0, K_NO_WAIT);
+	k_thread_create(&cmd_thread, stack, STACKSIZE, cmd_handler,
+			NULL, NULL, NULL, K_PRIO_COOP(7), 0, K_NO_WAIT);
 
 	uart_pipe_register(k_fifo_get(&avail_queue, K_NO_WAIT),
 			   BTP_MTU, recv_cb);

--- a/tests/kernel/alert/test_alert_api/src/test_alert_contexts.c
+++ b/tests/kernel/alert/test_alert_api/src/test_alert_contexts.c
@@ -25,6 +25,7 @@ K_ALERT_DEFINE(kalert_pending, alert_handler1, PENDING_MAX);
 K_ALERT_DEFINE(kalert_consumed, alert_handler0, PENDING_MAX);
 
 static char __noinit __stack tstack[STACK_SIZE];
+static struct k_thread tdata;
 static struct k_alert *palert;
 static volatile int handler_executed;
 
@@ -88,7 +89,7 @@ static void thread_alert(void)
 {
 	handler_executed = 0;
 	/**TESTPOINT: thread-thread sync via alert*/
-	k_tid_t tid = k_thread_spawn(tstack, STACK_SIZE,
+	k_tid_t tid = k_thread_create(&tdata, tstack, STACK_SIZE,
 		tThread_entry, NULL, NULL, NULL,
 		K_PRIO_PREEMPT(0), 0, 0);
 	alert_send();

--- a/tests/kernel/common/src/timeout_order.c
+++ b/tests/kernel/common/src/timeout_order.c
@@ -34,14 +34,15 @@ static void thread(void *p1, void *p2, void *p3)
 #define STACKSIZE (512 + CONFIG_TEST_EXTRA_STACKSIZE)
 
 static __noinit __stack char stacks[NUM_TIMEOUTS][STACKSIZE];
+static struct k_thread threads[NUM_TIMEOUTS];
 
 void timeout_order_test(void)
 {
 	int ii, prio = k_thread_priority_get(k_current_get()) + 1;
 
 	for (ii = 0; ii < NUM_TIMEOUTS; ii++) {
-		(void)k_thread_spawn(stacks[ii], STACKSIZE, thread,
-				     (void *)ii, 0, 0, prio, 0, 0);
+		(void)k_thread_create(&threads[ii], stacks[ii], STACKSIZE,
+				      thread, (void *)ii, 0, 0, prio, 0, 0);
 		k_timer_init(&timer[ii], 0, 0);
 		k_sem_init(&sem[ii], 0, 1);
 		results[ii] = -1;

--- a/tests/kernel/context/README.txt
+++ b/tests/kernel/context/README.txt
@@ -8,7 +8,7 @@ This test verifies that the kernel CPU and context APIs operate as expected.
 APIs tested in this test set
 ============================
 
-k_thread_spawn
+k_thread_create
   - start a helper fiber to help with k_yield() tests
   - start a fiber to test fiber related functionality
 
@@ -94,7 +94,7 @@ Thread busy waiting completed
 Testing k_sleep()
  thread sleeping for 50 milliseconds
  thread back from sleep
-Testing k_thread_spawn() without cancellation
+Testing k_thread_create() without cancellation
  thread (q order: 2, t/o: 500) is running
  got thread (q order: 2, t/o: 500) as expected
  thread (q order: 3, t/o: 750) is running
@@ -109,7 +109,7 @@ Testing k_thread_spawn() without cancellation
  got thread (q order: 4, t/o: 1750) as expected
  thread (q order: 5, t/o: 2000) is running
  got thread (q order: 5, t/o: 2000) as expected
-Testing k_thread_spawn() with cancellations
+Testing k_thread_create() with cancellations
  cancelling [q order: 0, t/o: 1000, t/o order: 0]
  thread (q order: 3, t/o: 750) is running
  got (q order: 3, t/o: 750, t/o order 1) as expected

--- a/tests/kernel/critical/src/critical.c
+++ b/tests/kernel/critical/src/critical.c
@@ -28,6 +28,9 @@ static char __stack offload_work_q_stack[CONFIG_OFFLOAD_WORKQUEUE_STACK_SIZE];
 static char __stack stack1[STACK_SIZE];
 static char __stack stack2[STACK_SIZE];
 
+static struct k_thread thread1;
+static struct k_thread thread2;
+
 K_SEM_DEFINE(ALT_SEM, 0, UINT_MAX);
 K_SEM_DEFINE(REGRESS_SEM, 0, UINT_MAX);
 K_SEM_DEFINE(TEST_SEM, 0, UINT_MAX);
@@ -164,13 +167,13 @@ static void init_objects(void)
 
 static void start_threads(void)
 {
-	k_thread_spawn(stack1, STACK_SIZE,
-		       AlternateTask, NULL, NULL, NULL,
-		       K_PRIO_PREEMPT(12), 0, 0);
+	k_thread_create(&thread1, stack1, STACK_SIZE,
+			AlternateTask, NULL, NULL, NULL,
+			K_PRIO_PREEMPT(12), 0, 0);
 
-	k_thread_spawn(stack2, STACK_SIZE,
-		       RegressionTask, NULL, NULL, NULL,
-		       K_PRIO_PREEMPT(12), 0, 0);
+	k_thread_create(&thread2, stack2, STACK_SIZE,
+			RegressionTask, NULL, NULL, NULL,
+			K_PRIO_PREEMPT(12), 0, 0);
 }
 
 void test_critical(void)

--- a/tests/kernel/errno/src/main.c
+++ b/tests/kernel/errno/src/main.c
@@ -12,6 +12,7 @@
 
 #define STACK_SIZE 384
 static __stack char stacks[N_THREADS][STACK_SIZE];
+static struct k_thread threads[N_THREADS];
 
 static int errno_values[N_THREADS + 1] = {
 	0xbabef00d,
@@ -60,7 +61,7 @@ void main(void)
 	}
 
 	for (int ii = 0; ii < N_THREADS; ii++) {
-		k_thread_spawn(stacks[ii], STACK_SIZE,
+		k_thread_create(&threads[ii], stacks[ii], STACK_SIZE,
 				(k_thread_entry_t) errno_fiber,
 				(void *) ii, (void *) errno_values[ii], NULL,
 				K_PRIO_PREEMPT(ii + 5), 0, K_NO_WAIT);

--- a/tests/kernel/fatal/src/main.c
+++ b/tests/kernel/fatal/src/main.c
@@ -13,6 +13,7 @@
 #define PRIORITY 5
 
 static char __noinit __stack alt_stack[STACKSIZE];
+static struct k_thread alt_thread;
 volatile int rv;
 
 void alt_thread1(void)
@@ -50,9 +51,10 @@ void main(void)
 	TC_START("test_fatal");
 
 	printk("test alt thread 1: generic CPU exception\n");
-	k_thread_spawn(alt_stack, STACKSIZE, (k_thread_entry_t)alt_thread1,
-		       NULL, NULL, NULL, K_PRIO_PREEMPT(PRIORITY), 0,
-		       K_NO_WAIT);
+	k_thread_create(&alt_thread, alt_stack, STACKSIZE,
+			(k_thread_entry_t)alt_thread1,
+			NULL, NULL, NULL, K_PRIO_PREEMPT(PRIORITY), 0,
+			K_NO_WAIT);
 	if (rv == TC_FAIL) {
 		printk("thread was not aborted\n");
 		goto out;
@@ -61,9 +63,10 @@ void main(void)
 	}
 
 	printk("test alt thread 2: initiate kernel oops\n");
-	k_thread_spawn(alt_stack, STACKSIZE, (k_thread_entry_t)alt_thread2,
-		       NULL, NULL, NULL, K_PRIO_PREEMPT(PRIORITY), 0,
-		       K_NO_WAIT);
+	k_thread_create(&alt_thread, alt_stack, STACKSIZE,
+			(k_thread_entry_t)alt_thread2,
+			NULL, NULL, NULL, K_PRIO_PREEMPT(PRIORITY), 0,
+			K_NO_WAIT);
 	if (rv == TC_FAIL) {
 		printk("thread was not aborted\n");
 		goto out;

--- a/tests/kernel/fifo/test_fifo_api/src/test_fifo_cancel.c
+++ b/tests/kernel/fifo/test_fifo_api/src/test_fifo_cancel.c
@@ -14,6 +14,7 @@ K_FIFO_DEFINE(kfifo_c);
 struct k_fifo fifo_c;
 
 static char __noinit __stack tstack[STACK_SIZE];
+static struct k_thread thread;
 
 static void t_cancel_wait_entry(void *p1, void *p2, void *p3)
 {
@@ -23,7 +24,7 @@ static void t_cancel_wait_entry(void *p1, void *p2, void *p3)
 
 static void tfifo_thread_thread(struct k_fifo *pfifo)
 {
-	k_tid_t tid = k_thread_spawn(tstack, STACK_SIZE,
+	k_tid_t tid = k_thread_create(&thread, tstack, STACK_SIZE,
 		t_cancel_wait_entry, pfifo, NULL, NULL,
 		K_PRIO_PREEMPT(0), 0, 0);
 	u32_t start_t = k_uptime_get_32();

--- a/tests/kernel/fifo/test_fifo_api/src/test_fifo_contexts.c
+++ b/tests/kernel/fifo/test_fifo_api/src/test_fifo_contexts.c
@@ -29,6 +29,7 @@ static fdata_t data_l[LIST_LEN];
 static fdata_t data_sl[LIST_LEN];
 
 static char __noinit __stack tstack[STACK_SIZE];
+static struct k_thread tdata;
 static struct k_sem end_sema;
 
 static void tfifo_put(struct k_fifo *pfifo)
@@ -99,7 +100,7 @@ static void tfifo_thread_thread(struct k_fifo *pfifo)
 {
 	k_sem_init(&end_sema, 0, 1);
 	/**TESTPOINT: thread-thread data passing via fifo*/
-	k_tid_t tid = k_thread_spawn(tstack, STACK_SIZE,
+	k_tid_t tid = k_thread_create(&tdata, tstack, STACK_SIZE,
 		tThread_entry, pfifo, NULL, NULL,
 		K_PRIO_PREEMPT(0), 0, 0);
 	tfifo_put(pfifo);

--- a/tests/kernel/fifo/test_fifo_api/src/test_fifo_loop.c
+++ b/tests/kernel/fifo/test_fifo_api/src/test_fifo_loop.c
@@ -35,6 +35,7 @@
 static fdata_t data[LIST_LEN];
 static struct k_fifo fifo;
 static char __noinit __stack tstack[STACK_SIZE];
+static struct k_thread tdata;
 static struct k_sem end_sema;
 
 static void tfifo_put(struct k_fifo *pfifo)
@@ -81,7 +82,7 @@ static void tfifo_read_write(struct k_fifo *pfifo)
 {
 	k_sem_init(&end_sema, 0, 1);
 	/**TESTPOINT: thread-isr-thread data passing via fifo*/
-	k_tid_t tid = k_thread_spawn(tstack, STACK_SIZE,
+	k_tid_t tid = k_thread_create(&tdata, tstack, STACK_SIZE,
 		tThread_entry, pfifo, NULL, NULL,
 		K_PRIO_PREEMPT(0), 0, 0);
 

--- a/tests/kernel/lifo/test_lifo_api/src/test_lifo_contexts.c
+++ b/tests/kernel/lifo/test_lifo_api/src/test_lifo_contexts.c
@@ -28,6 +28,7 @@ struct k_lifo lifo;
 static ldata_t data[LIST_LEN];
 
 static char __noinit __stack tstack[STACK_SIZE];
+static struct k_thread tdata;
 static struct k_sem end_sema;
 
 static void tlifo_put(struct k_lifo *plifo)
@@ -71,7 +72,7 @@ static void tlifo_thread_thread(struct k_lifo *plifo)
 {
 	k_sem_init(&end_sema, 0, 1);
 	/**TESTPOINT: thread-thread data passing via lifo*/
-	k_tid_t tid = k_thread_spawn(tstack, STACK_SIZE,
+	k_tid_t tid = k_thread_create(&tdata, tstack, STACK_SIZE,
 		tThread_entry, plifo, NULL, NULL,
 		K_PRIO_PREEMPT(0), 0, 0);
 	tlifo_put(plifo);

--- a/tests/kernel/lifo/test_lifo_api/src/test_lifo_loop.c
+++ b/tests/kernel/lifo/test_lifo_api/src/test_lifo_loop.c
@@ -35,6 +35,7 @@
 static ldata_t data[LIST_LEN];
 static struct k_lifo lifo;
 static char __noinit __stack tstack[STACK_SIZE];
+static struct k_thread tdata;
 static struct k_sem end_sema;
 
 static void tlifo_put(struct k_lifo *plifo)
@@ -81,7 +82,7 @@ static void tlifo_read_write(struct k_lifo *plifo)
 {
 	k_sem_init(&end_sema, 0, 1);
 	/**TESTPOINT: thread-isr-thread data passing via lifo*/
-	k_tid_t tid = k_thread_spawn(tstack, STACK_SIZE,
+	k_tid_t tid = k_thread_create(&tdata, tstack, STACK_SIZE,
 		tThread_entry, plifo, NULL, NULL,
 		K_PRIO_PREEMPT(0), 0, 0);
 

--- a/tests/kernel/mbox/mbox_api/src/test_mbox_api.c
+++ b/tests/kernel/mbox/mbox_api/src/test_mbox_api.c
@@ -37,6 +37,7 @@ static struct k_mbox mbox;
 static k_tid_t sender_tid, receiver_tid;
 
 static char __noinit __stack tstack[STACK_SIZE];
+static struct k_thread tdata;
 
 static struct k_sem end_sema, sync_sema;
 
@@ -214,7 +215,7 @@ static void tmbox(struct k_mbox *pmbox)
 
 	/**TESTPOINT: thread-thread data passing via mbox*/
 	sender_tid = k_current_get();
-	receiver_tid = k_thread_spawn(tstack, STACK_SIZE,
+	receiver_tid = k_thread_create(&tdata, tstack, STACK_SIZE,
 		tmbox_entry, pmbox, NULL, NULL,
 		K_PRIO_PREEMPT(0), 0, 0);
 	tmbox_put(pmbox);

--- a/tests/kernel/mem_pool/test_mpool_concept/src/test_mpool_alloc_wait.c
+++ b/tests/kernel/mem_pool/test_mpool_concept/src/test_mpool_alloc_wait.c
@@ -43,6 +43,7 @@
 K_MEM_POOL_DEFINE(mpool1, BLK_SIZE_MIN, BLK_SIZE_MAX, BLK_NUM_MAX, BLK_ALIGN);
 
 static char __noinit __stack tstack[THREAD_NUM][STACK_SIZE];
+static struct k_thread tdata[THREAD_NUM];
 static struct k_sem sync_sema;
 static struct k_mem_block block_ok;
 
@@ -85,15 +86,15 @@ void test_mpool_alloc_wait_prio(void)
 	 * can optionally wait for one to become available
 	 */
 	/*the low-priority thread*/
-	tid[0] = k_thread_spawn(tstack[0], STACK_SIZE,
+	tid[0] = k_thread_create(&tdata[0], tstack[0], STACK_SIZE,
 		tmpool_alloc_wait_timeout, NULL, NULL, NULL,
 		K_PRIO_PREEMPT(1), 0, 0);
 	/*the highest-priority thread that has waited the longest*/
-	tid[1] = k_thread_spawn(tstack[1], STACK_SIZE,
+	tid[1] = k_thread_create(&tdata[1], tstack[1], STACK_SIZE,
 		tmpool_alloc_wait_ok, NULL, NULL, NULL,
 		K_PRIO_PREEMPT(0), 0, 10);
 	/*the highest-priority thread that has waited shorter*/
-	tid[2] = k_thread_spawn(tstack[2], STACK_SIZE,
+	tid[2] = k_thread_create(&tdata[2], tstack[2], STACK_SIZE,
 		tmpool_alloc_wait_timeout, NULL, NULL, NULL,
 		K_PRIO_PREEMPT(0), 0, 20);
 	/*relinquish CPU for above threads to start */

--- a/tests/kernel/mem_pool/test_mpool_threadsafe/src/test_mpool_threadsafe.c
+++ b/tests/kernel/mem_pool/test_mpool_threadsafe/src/test_mpool_threadsafe.c
@@ -47,6 +47,7 @@
 K_MEM_POOL_DEFINE(mpool1, BLK_SIZE_MIN, BLK_SIZE_MAX, BLK_NUM_MAX, BLK_ALIGN);
 K_MEM_POOL_DEFINE(mpool2, BLK_SIZE_MIN, BLK_SIZE_MAX, BLK_NUM_MAX, BLK_ALIGN);
 static char __noinit __stack tstack[THREAD_NUM][STACK_SIZE];
+static struct k_thread tdata[THREAD_NUM];
 static struct k_mem_pool *pools[POOL_NUM] = {&mpool1, &mpool2};
 static struct k_sem sync_sema;
 static atomic_t pool_id;
@@ -84,7 +85,7 @@ void test_mpool_threadsafe(void)
 
 	/* create multiple threads to invoke same memory pool APIs*/
 	for (int i = 0; i < THREAD_NUM; i++) {
-		tid[i] = k_thread_spawn(tstack[i], STACK_SIZE,
+		tid[i] = k_thread_create(&tdata[i], tstack[i], STACK_SIZE,
 			tmpool_api, NULL, NULL, NULL,
 			K_PRIO_PREEMPT(1), 0, 0);
 	}

--- a/tests/kernel/mem_slab/test_mslab_concept/src/test_mslab_alloc_wait.c
+++ b/tests/kernel/mem_slab/test_mslab_concept/src/test_mslab_alloc_wait.c
@@ -35,6 +35,7 @@
 K_MEM_SLAB_DEFINE(mslab1, BLK_SIZE, BLK_NUM, BLK_ALIGN);
 
 static char __noinit __stack tstack[THREAD_NUM][STACK_SIZE];
+static struct k_thread tdata[THREAD_NUM];
 static struct k_sem sync_sema;
 static void *block_ok;
 
@@ -77,15 +78,15 @@ void test_mslab_alloc_wait_prio(void)
 	 * optionally wait for one to become available.
 	 */
 	/*the low-priority thread*/
-	tid[0] = k_thread_spawn(tstack[0], STACK_SIZE,
+	tid[0] = k_thread_create(&tdata[0], tstack[0], STACK_SIZE,
 		tmslab_alloc_wait_timeout, NULL, NULL, NULL,
 		K_PRIO_PREEMPT(1), 0, 0);
 	/*the highest-priority thread that has waited the longest*/
-	tid[1] = k_thread_spawn(tstack[1], STACK_SIZE,
+	tid[1] = k_thread_create(&tdata[1], tstack[1], STACK_SIZE,
 		tmslab_alloc_wait_ok, NULL, NULL, NULL,
 		K_PRIO_PREEMPT(0), 0, 10);
 	/*the highest-priority thread that has waited shorter*/
-	tid[2] = k_thread_spawn(tstack[2], STACK_SIZE,
+	tid[2] = k_thread_create(&tdata[2], tstack[2], STACK_SIZE,
 		tmslab_alloc_wait_timeout, NULL, NULL, NULL,
 		K_PRIO_PREEMPT(0), 0, 20);
 	/*relinquish CPU for above threads to start */

--- a/tests/kernel/mem_slab/test_mslab_threadsafe/src/test_mslab_threadsafe.c
+++ b/tests/kernel/mem_slab/test_mslab_threadsafe/src/test_mslab_threadsafe.c
@@ -27,6 +27,7 @@
 K_MEM_SLAB_DEFINE(mslab1, BLK_SIZE1, BLK_NUM, BLK_ALIGN);
 static struct k_mem_slab mslab2, *slabs[SLAB_NUM] = {&mslab1, &mslab2};
 static char __noinit __stack tstack[THREAD_NUM][STACK_SIZE];
+static struct k_thread tdata[THREAD_NUM];
 static char __aligned(BLK_ALIGN) tslab[BLK_SIZE2 * BLK_NUM];
 static struct k_sem sync_sema;
 static atomic_t slab_id;
@@ -65,7 +66,7 @@ void test_mslab_threadsafe(void)
 
 	/* create multiple threads to invoke same memory slab APIs*/
 	for (int i = 0; i < THREAD_NUM; i++) {
-		tid[i] = k_thread_spawn(tstack[i], STACK_SIZE,
+		tid[i] = k_thread_create(&tdata[i], tstack[i], STACK_SIZE,
 			tmslab_api, NULL, NULL, NULL,
 			K_PRIO_PREEMPT(1), 0, 0);
 	}

--- a/tests/kernel/msgq/msgq_api/src/test_msgq_contexts.c
+++ b/tests/kernel/msgq/msgq_api/src/test_msgq_contexts.c
@@ -18,6 +18,7 @@
 K_MSGQ_DEFINE(kmsgq, MSG_SIZE, MSGQ_LEN, 4);
 
 static char __noinit __stack tstack[STACK_SIZE];
+static struct k_thread tdata;
 static char __aligned(4) tbuffer[MSG_SIZE * MSGQ_LEN];
 static u32_t data[MSGQ_LEN] = { MSG0, MSG1 };
 static struct k_sem end_sema;
@@ -74,9 +75,9 @@ static void msgq_thread(struct k_msgq *pmsgq)
 {
 	k_sem_init(&end_sema, 0, 1);
 	/**TESTPOINT: thread-thread data passing via message queue*/
-	k_tid_t tid = k_thread_spawn(tstack, STACK_SIZE,
-				     tThread_entry, pmsgq, NULL, NULL,
-				     K_PRIO_PREEMPT(0), 0, 0);
+	k_tid_t tid = k_thread_create(&tdata, tstack, STACK_SIZE,
+				      tThread_entry, pmsgq, NULL, NULL,
+				      K_PRIO_PREEMPT(0), 0, 0);
 	put_msgq(pmsgq);
 	k_sem_take(&end_sema, K_FOREVER);
 	k_thread_abort(tid);

--- a/tests/kernel/msgq/msgq_api/src/test_msgq_purge.c
+++ b/tests/kernel/msgq/msgq_api/src/test_msgq_purge.c
@@ -16,6 +16,7 @@
 #include "test_msgq.h"
 
 static char __noinit __stack tstack[STACK_SIZE];
+static struct k_thread tdata;
 static char __aligned(4) tbuffer[MSG_SIZE * MSGQ_LEN];
 static u32_t data[MSGQ_LEN] = { MSG0, MSG1 };
 
@@ -40,9 +41,9 @@ void test_msgq_purge_when_put(void)
 		zassert_equal(ret, 0, NULL);
 	}
 	/*create another thread waiting to put msg*/
-	k_tid_t tid = k_thread_spawn(tstack, STACK_SIZE,
-				     tThread_entry, &msgq, NULL, NULL,
-				     K_PRIO_PREEMPT(0), 0, 0);
+	k_tid_t tid = k_thread_create(&tdata, tstack, STACK_SIZE,
+				      tThread_entry, &msgq, NULL, NULL,
+				      K_PRIO_PREEMPT(0), 0, 0);
 	k_sleep(TIMEOUT >> 1);
 	/**TESTPOINT: msgq purge while another thread waiting to put msg*/
 	k_msgq_purge(&msgq);

--- a/tests/kernel/mutex/mutex/src/mutex.c
+++ b/tests/kernel/mutex/mutex/src/mutex.c
@@ -227,6 +227,7 @@ void Task11(void)
 }
 
 char __noinit __stack task12_stack_area[STACKSIZE];
+struct k_thread task12_thread_data;
 extern void Task12(void);
 
 /**
@@ -360,9 +361,9 @@ void RegressionTask(void)
 	}
 
 		/* Start thread */
-	k_thread_spawn(task12_stack_area, STACKSIZE,
-		       (k_thread_entry_t)Task12, NULL, NULL, NULL,
-		       K_PRIO_PREEMPT(12), 0, K_NO_WAIT);
+	k_thread_create(&task12_thread_data, task12_stack_area, STACKSIZE,
+			(k_thread_entry_t)Task12, NULL, NULL, NULL,
+			K_PRIO_PREEMPT(12), 0, K_NO_WAIT);
 	k_sleep(1);	/* Give Task12 a chance to block on the mutex */
 
 	k_mutex_unlock(&private_mutex);

--- a/tests/kernel/mutex/mutex_api/src/test_mutex_apis.c
+++ b/tests/kernel/mutex/mutex_api/src/test_mutex_apis.c
@@ -27,6 +27,7 @@ K_MUTEX_DEFINE(kmutex);
 static struct k_mutex mutex;
 
 static char __noinit __stack tstack[STACK_SIZE];
+static struct k_thread tdata;
 
 static void tThread_entry_lock_forever(void *p1, void *p2, void *p3)
 {
@@ -58,9 +59,9 @@ static void tmutex_test_lock(struct k_mutex *pmutex,
 			     void (*entry_fn)(void *, void *, void *))
 {
 	k_mutex_init(pmutex);
-	k_tid_t tid = k_thread_spawn(tstack, STACK_SIZE,
-				     entry_fn, pmutex, NULL, NULL,
-				     K_PRIO_PREEMPT(0), 0, 0);
+	k_tid_t tid = k_thread_create(&tdata, tstack, STACK_SIZE,
+				      entry_fn, pmutex, NULL, NULL,
+				      K_PRIO_PREEMPT(0), 0, 0);
 	k_mutex_lock(pmutex, K_FOREVER);
 	TC_PRINT("access resource from main thread\n");
 
@@ -76,9 +77,9 @@ static void tmutex_test_lock_timeout(struct k_mutex *pmutex,
 {
 	/**TESTPOINT: test k_mutex_init mutex*/
 	k_mutex_init(pmutex);
-	k_tid_t tid = k_thread_spawn(tstack, STACK_SIZE,
-				     entry_fn, pmutex, NULL, NULL,
-				     K_PRIO_PREEMPT(0), 0, 0);
+	k_tid_t tid = k_thread_create(&tdata, tstack, STACK_SIZE,
+				      entry_fn, pmutex, NULL, NULL,
+				      K_PRIO_PREEMPT(0), 0, 0);
 	k_mutex_lock(pmutex, K_FOREVER);
 	TC_PRINT("access resource from main thread\n");
 

--- a/tests/kernel/obj_tracing/src/main.c
+++ b/tests/kernel/obj_tracing/src/main.c
@@ -15,7 +15,9 @@ extern void phil_entry(void);
 extern void object_monitor(void);
 
 char __stack phil_stack[N_PHILOSOPHERS][STSIZE];
+static struct k_thread phil_data[N_PHILOSOPHERS];
 char __stack mon_stack[STSIZE];
+static struct k_thread mon_data;
 struct k_sem forks[N_PHILOSOPHERS];
 
 int main(void)
@@ -29,15 +31,15 @@ int main(void)
 
 	/* create philosopher threads */
 	for (i = 0; i < N_PHILOSOPHERS; i++) {
-		k_thread_spawn(&phil_stack[i][0], STSIZE,
-		       (k_thread_entry_t)phil_entry, NULL, NULL, NULL,
-		       K_PRIO_COOP(6), 0, K_NO_WAIT);
+		k_thread_create(&phil_data[i], &phil_stack[i][0], STSIZE,
+				(k_thread_entry_t)phil_entry, NULL, NULL, NULL,
+				K_PRIO_COOP(6), 0, K_NO_WAIT);
 	}
 
 	/* create object counter monitor thread */
-	k_thread_spawn(mon_stack, STSIZE,
-		       (k_thread_entry_t)object_monitor, NULL, NULL, NULL,
-		       K_PRIO_COOP(7), 0, K_NO_WAIT);
+	k_thread_create(&mon_data, mon_stack, STSIZE,
+			(k_thread_entry_t)object_monitor, NULL, NULL, NULL,
+			K_PRIO_COOP(7), 0, K_NO_WAIT);
 
 	return 0;
 }

--- a/tests/kernel/pending/src/pend.c
+++ b/tests/kernel/pending/src/pend.c
@@ -48,6 +48,7 @@ struct offload_work {
 };
 
 static char __stack coop_stack[2][COOP_STACKSIZE];
+static struct k_thread coop_thread[2];
 
 static struct k_fifo fifo;
 static struct k_lifo lifo;
@@ -247,11 +248,11 @@ void task_high(void)
 
 	counter = SEM_TEST_START;
 
-	k_thread_spawn(coop_stack[0], COOP_STACKSIZE,
-		       coop_high, NULL, NULL, NULL, K_PRIO_COOP(3), 0, 0);
+	k_thread_create(&coop_thread[0], coop_stack[0], COOP_STACKSIZE,
+			coop_high, NULL, NULL, NULL, K_PRIO_COOP(3), 0, 0);
 
-	k_thread_spawn(coop_stack[1], COOP_STACKSIZE,
-		       coop_low, NULL, NULL, NULL, K_PRIO_COOP(7), 0, 0);
+	k_thread_create(&coop_thread[1], coop_stack[1], COOP_STACKSIZE,
+			coop_low, NULL, NULL, NULL, K_PRIO_COOP(7), 0, 0);
 
 	counter = FIFO_TEST_START;
 	fifo_tests(THIRD_SECOND, &task_high_state, my_fifo_get, k_sem_take);

--- a/tests/kernel/pipe/test_pipe_api/src/test_pipe_contexts.c
+++ b/tests/kernel/pipe/test_pipe_api/src/test_pipe_contexts.c
@@ -30,6 +30,7 @@ K_PIPE_DEFINE(kpipe, PIPE_LEN, 4);
 static struct k_pipe pipe;
 
 static char __noinit __stack tstack[STACK_SIZE];
+static struct k_thread tdata;
 static struct k_sem end_sema;
 
 static void tpipe_put(struct k_pipe *ppipe)
@@ -102,7 +103,7 @@ static void tpipe_thread_thread(struct k_pipe *ppipe)
 	k_sem_init(&end_sema, 0, 1);
 
 	/**TESTPOINT: thread-thread data passing via pipe*/
-	k_tid_t tid = k_thread_spawn(tstack, STACK_SIZE,
+	k_tid_t tid = k_thread_create(&tdata, tstack, STACK_SIZE,
 		tThread_entry, ppipe, NULL, NULL,
 		K_PRIO_PREEMPT(0), 0, 0);
 	tpipe_put(ppipe);
@@ -130,7 +131,7 @@ void test_pipe_block_put(void)
 {
 
 	/**TESTPOINT: test k_pipe_block_put without semaphore*/
-	k_tid_t tid = k_thread_spawn(tstack, STACK_SIZE,
+	k_tid_t tid = k_thread_create(&tdata, tstack, STACK_SIZE,
 		tThread_block_put, &kpipe, NULL, NULL,
 		K_PRIO_PREEMPT(0), 0, 0);
 	k_sleep(10);
@@ -146,7 +147,7 @@ void test_pipe_block_put_sema(void)
 
 	k_sem_init(&sync_sema, 0, 1);
 	/**TESTPOINT: test k_pipe_block_put with semaphore*/
-	k_tid_t tid = k_thread_spawn(tstack, STACK_SIZE,
+	k_tid_t tid = k_thread_create(&tdata, tstack, STACK_SIZE,
 		tThread_block_put, &pipe, &sync_sema, NULL,
 		K_PRIO_PREEMPT(0), 0, 0);
 	k_sleep(10);
@@ -159,7 +160,7 @@ void test_pipe_block_put_sema(void)
 void test_pipe_get_put(void)
 {
 	/**TESTPOINT: test API sequence: [get, put]*/
-	k_tid_t tid = k_thread_spawn(tstack, STACK_SIZE,
+	k_tid_t tid = k_thread_create(&tdata, tstack, STACK_SIZE,
 		tThread_block_put, &kpipe, NULL, NULL,
 		K_PRIO_PREEMPT(0), 0, 0);
 	/*get will be executed previor to put*/

--- a/tests/kernel/poll/src/test_poll.c
+++ b/tests/kernel/poll/src/test_poll.c
@@ -95,6 +95,7 @@ static struct k_poll_signal wait_signal = K_POLL_SIGNAL_INITIALIZER();
 
 struct fifo_msg wait_msg = { NULL, FIFO_MSG_VALUE };
 
+static struct k_thread poll_wait_helper_thread;
 static __stack __noinit char poll_wait_helper_stack[KB(1)];
 
 #define TAG_0 10
@@ -143,8 +144,9 @@ void test_poll_wait(void)
 	 */
 	k_thread_priority_set(k_current_get(), main_low_prio);
 
-	k_thread_spawn(poll_wait_helper_stack, KB(1), poll_wait_helper,
-		       (void *)1, 0, 0, main_low_prio - 1, 0, 0);
+	k_thread_create(&poll_wait_helper_thread, poll_wait_helper_stack,
+			sizeof(poll_wait_helper_stack), poll_wait_helper,
+			(void *)1, 0, 0, main_low_prio - 1, 0, 0);
 
 	rc = k_poll(wait_events, ARRAY_SIZE(wait_events), K_SECONDS(1));
 
@@ -193,8 +195,9 @@ void test_poll_wait(void)
 	 */
 	k_thread_priority_set(k_current_get(), main_low_prio);
 
-	k_thread_spawn(poll_wait_helper_stack, KB(1), poll_wait_helper, 0, 0, 0,
-		       main_low_prio - 1, 0, 0);
+	k_thread_create(&poll_wait_helper_thread, poll_wait_helper_stack,
+			sizeof(poll_wait_helper_stack), poll_wait_helper,
+			0, 0, 0, main_low_prio - 1, 0, 0);
 
 	rc = k_poll(wait_events, ARRAY_SIZE(wait_events), K_SECONDS(1));
 
@@ -226,8 +229,9 @@ void test_poll_wait(void)
 	wait_events[2].state = K_POLL_STATE_NOT_READY;
 	wait_signal.signaled = 0;
 
-	k_thread_spawn(poll_wait_helper_stack, KB(1), poll_wait_helper,
-		       (void *)1, 0, 0, old_prio + 1, 0, 0);
+	k_thread_create(&poll_wait_helper_thread, poll_wait_helper_stack,
+			sizeof(poll_wait_helper_stack), poll_wait_helper,
+			(void *)1, 0, 0, old_prio + 1, 0, 0);
 
 	/* semaphore */
 	rc = k_poll(wait_events, ARRAY_SIZE(wait_events), K_SECONDS(1));
@@ -296,6 +300,7 @@ static struct k_sem eaddrinuse_sem = K_SEM_INITIALIZER(eaddrinuse_sem, 0, 1);
 static struct k_sem eaddrinuse_reply =
 	K_SEM_INITIALIZER(eaddrinuse_reply, 0, 1);
 
+static struct k_thread eaddrinuse_hogger_thread;
 static __stack __noinit char eaddrinuse_hogger_stack[KB(1)];
 
 static void eaddrinuse_hogger(void *p1, void *p2, void *p3)
@@ -332,8 +337,9 @@ void test_poll_eaddrinuse(void)
 
 	k_thread_priority_set(k_current_get(), main_low_prio);
 
-	k_thread_spawn(eaddrinuse_hogger_stack, KB(1), eaddrinuse_hogger,
-		       0, 0, 0, main_low_prio - 1, 0, 0);
+	k_thread_create(&eaddrinuse_hogger_thread, eaddrinuse_hogger_stack,
+			sizeof(eaddrinuse_hogger_stack), eaddrinuse_hogger,
+			0, 0, 0, main_low_prio - 1, 0, 0);
 
 	rc = k_poll(events, ARRAY_SIZE(events), K_SECONDS(1));
 

--- a/tests/kernel/queue/src/test_queue_contexts.c
+++ b/tests/kernel/queue/src/test_queue_contexts.c
@@ -30,6 +30,7 @@ static qdata_t data_l[LIST_LEN];
 static qdata_t data_sl[LIST_LEN];
 
 static char __noinit __stack tstack[STACK_SIZE];
+static struct k_thread tdata;
 static struct k_sem end_sema;
 
 static void tqueue_append(struct k_queue *pqueue)
@@ -109,7 +110,7 @@ static void tqueue_thread_thread(struct k_queue *pqueue)
 {
 	k_sem_init(&end_sema, 0, 1);
 	/**TESTPOINT: thread-thread data passing via queue*/
-	k_tid_t tid = k_thread_spawn(tstack, STACK_SIZE,
+	k_tid_t tid = k_thread_create(&tdata, tstack, STACK_SIZE,
 		tThread_entry, pqueue, NULL, NULL,
 		K_PRIO_PREEMPT(0), 0, 0);
 	tqueue_append(pqueue);

--- a/tests/kernel/queue/src/test_queue_loop.c
+++ b/tests/kernel/queue/src/test_queue_loop.c
@@ -37,6 +37,7 @@ static qdata_t data[LIST_LEN];
 static qdata_t data_p[LIST_LEN];
 static struct k_queue queue;
 static char __noinit __stack tstack[STACK_SIZE];
+static struct k_thread tdata;
 static struct k_sem end_sema;
 
 static void tqueue_append(struct k_queue *pqueue)
@@ -95,7 +96,7 @@ static void tqueue_read_write(struct k_queue *pqueue)
 {
 	k_sem_init(&end_sema, 0, 1);
 	/**TESTPOINT: thread-isr-thread data passing via queue*/
-	k_tid_t tid = k_thread_spawn(tstack, STACK_SIZE,
+	k_tid_t tid = k_thread_create(&tdata, tstack, STACK_SIZE,
 		tThread_entry, pqueue, NULL, NULL,
 		K_PRIO_PREEMPT(0), 0, 0);
 

--- a/tests/kernel/semaphore/sema_api/src/test_sema_contexts.c
+++ b/tests/kernel/semaphore/sema_api/src/test_sema_contexts.c
@@ -27,6 +27,7 @@
 K_SEM_DEFINE(ksema, SEM_INITIAL, SEM_LIMIT);
 static struct k_sem sema;
 static char __noinit __stack tstack[STACK_SIZE];
+static struct k_thread tdata;
 
 /*entry of contexts*/
 static void tIsr_entry(void *p)
@@ -42,9 +43,9 @@ static void tThread_entry(void *p1, void *p2, void *p3)
 static void tsema_thread_thread(struct k_sem *psem)
 {
 	/**TESTPOINT: thread-thread sync via sema*/
-	k_tid_t tid = k_thread_spawn(tstack, STACK_SIZE,
-				     tThread_entry, psem, NULL, NULL,
-				     K_PRIO_PREEMPT(0), 0, 0);
+	k_tid_t tid = k_thread_create(&tdata, tstack, STACK_SIZE,
+				      tThread_entry, psem, NULL, NULL,
+				      K_PRIO_PREEMPT(0), 0, 0);
 
 	zassert_false(k_sem_take(psem, K_FOREVER), NULL);
 	/*clean the spawn thread avoid side effect in next TC*/

--- a/tests/kernel/stack/stack_api/src/test_stack_contexts.c
+++ b/tests/kernel/stack/stack_api/src/test_stack_contexts.c
@@ -27,6 +27,7 @@ K_STACK_DEFINE(kstack, STACK_LEN);
 static struct k_stack stack;
 
 static char __noinit __stack threadstack[STACK_SIZE];
+static struct k_thread thread_data;
 static u32_t data[STACK_LEN] = { 0xABCD, 0x1234 };
 static struct k_sem end_sema;
 
@@ -72,9 +73,9 @@ static void tstack_thread_thread(struct k_stack *pstack)
 {
 	k_sem_init(&end_sema, 0, 1);
 	/**TESTPOINT: thread-thread data passing via stack*/
-	k_tid_t tid = k_thread_spawn(threadstack, STACK_SIZE,
-				     tThread_entry, pstack, NULL, NULL,
-				     K_PRIO_PREEMPT(0), 0, 0);
+	k_tid_t tid = k_thread_create(&thread_data, threadstack, STACK_SIZE,
+				      tThread_entry, pstack, NULL, NULL,
+				      K_PRIO_PREEMPT(0), 0, 0);
 	tstack_push(pstack);
 	k_sem_take(&end_sema, K_FOREVER);
 

--- a/tests/kernel/stackprot/src/main.c
+++ b/tests/kernel/stackprot/src/main.c
@@ -102,6 +102,7 @@ void alternate_thread(void)
 
 
 char __noinit __stack alt_thread_stack_area[STACKSIZE];
+static struct k_thread alt_thread_data;
 
 /**
  *
@@ -118,9 +119,9 @@ void main(void)
 	TC_PRINT("Starts %s\n", __func__);
 
 	/* Start thread */
-	k_thread_spawn(alt_thread_stack_area, STACKSIZE,
-		       (k_thread_entry_t)alternate_thread, NULL, NULL, NULL,
-		       K_PRIO_PREEMPT(PRIORITY), 0, K_NO_WAIT);
+	k_thread_create(&alt_thread_data, alt_thread_stack_area, STACKSIZE,
+			(k_thread_entry_t)alternate_thread, NULL, NULL, NULL,
+			K_PRIO_PREEMPT(PRIORITY), 0, K_NO_WAIT);
 
 	if (ret == TC_FAIL) {
 		goto errorExit;

--- a/tests/kernel/static_idt/src/static_idt.c
+++ b/tests/kernel/static_idt/src/static_idt.c
@@ -31,6 +31,7 @@
 #define MY_PRIORITY 5
 
 char __noinit __stack my_stack_area[MY_STACK_SIZE];
+static struct k_thread my_thread;
 
 /* externs */
 
@@ -206,9 +207,9 @@ void main(void)
 	 * Start task to trigger the spurious interrupt handler
 	 */
 	TC_PRINT("Testing to see spurious handler executes properly\n");
-	k_thread_spawn(my_stack_area, MY_STACK_SIZE,
-		       idt_spur_task, NULL, NULL, NULL,
-		       MY_PRIORITY, 0, K_NO_WAIT);
+	k_thread_create(&my_thread, my_stack_area, MY_STACK_SIZE,
+			idt_spur_task, NULL, NULL, NULL,
+			MY_PRIORITY, 0, K_NO_WAIT);
 
 	/*
 	 * The fiber/task should not run past where the spurious interrupt is

--- a/tests/kernel/test_sleep/src/sleep.c
+++ b/tests/kernel/test_sleep/src/sleep.c
@@ -46,6 +46,9 @@ static char __stack helper_thread_stack[THREAD_STACK];
 static k_tid_t  test_thread_id;
 static k_tid_t  helper_thread_id;
 
+static struct k_thread test_thread_data;
+static struct k_thread helper_thread_data;
+
 static bool test_failure = true;     /* Assume the test will fail */
 
 static void test_objects_init(void)
@@ -185,15 +188,19 @@ void main(void)
 
 	test_objects_init();
 
-	test_thread_id = k_thread_spawn(test_thread_stack, THREAD_STACK,
-			 (k_thread_entry_t) test_thread, 0, 0, NULL,
-			 TEST_THREAD_PRIORITY, 0, 0);
+	test_thread_id = k_thread_create(&test_thread_data, test_thread_stack,
+					 THREAD_STACK,
+					 (k_thread_entry_t) test_thread,
+					 0, 0, NULL, TEST_THREAD_PRIORITY,
+					 0, 0);
 
 	TC_PRINT("Test thread started: id = %p\n", test_thread_id);
 
-	helper_thread_id = k_thread_spawn(helper_thread_stack, THREAD_STACK,
-			(k_thread_entry_t) helper_thread, 0, 0, NULL,
-			HELPER_THREAD_PRIORITY, 0, 0);
+	helper_thread_id = k_thread_create(&helper_thread_data,
+					   helper_thread_stack, THREAD_STACK,
+					   (k_thread_entry_t) helper_thread,
+					   0, 0, NULL, HELPER_THREAD_PRIORITY,
+					   0, 0);
 
 	TC_PRINT("Helper thread started: id = %p\n", helper_thread_id);
 

--- a/tests/kernel/threads_customdata/cdata_api/src/test_customdata_api.c
+++ b/tests/kernel/threads_customdata/cdata_api/src/test_customdata_api.c
@@ -16,6 +16,7 @@
 
 /*local variables*/
 static char __stack tstack[STACK_SIZE];
+static struct k_thread tdata;
 
 static void customdata_entry(void *p1, void *p2, void *p3)
 {
@@ -39,7 +40,7 @@ static void customdata_entry(void *p1, void *p2, void *p3)
  */
 void test_customdata_get_set_coop(void)
 {
-	k_tid_t tid = k_thread_spawn(tstack, STACK_SIZE,
+	k_tid_t tid = k_thread_create(&tdata, tstack, STACK_SIZE,
 		customdata_entry, NULL, NULL, NULL,
 		K_PRIO_COOP(1), 0, 0);
 	k_sleep(500);
@@ -55,7 +56,7 @@ void test_customdata_get_set_coop(void)
 void test_customdata_get_set_preempt(void)
 {
 	/** TESTPOINT: custom data of preempt thread */
-	k_tid_t tid = k_thread_spawn(tstack, STACK_SIZE,
+	k_tid_t tid = k_thread_create(&tdata, tstack, STACK_SIZE,
 		customdata_entry, NULL, NULL, NULL,
 		K_PRIO_PREEMPT(0), 0, 0);
 	k_sleep(500);

--- a/tests/kernel/threads_lifecycle/lifecycle_api/src/test_threads_cancel_abort.c
+++ b/tests/kernel/threads_lifecycle/lifecycle_api/src/test_threads_cancel_abort.c
@@ -14,6 +14,7 @@
 
 #define STACK_SIZE (256 + CONFIG_TEST_EXTRA_STACKSIZE)
 static char __noinit __stack tstack[STACK_SIZE];
+static struct k_thread tdata;
 static int execute_flag;
 
 static void thread_entry(void *p1, void *p2, void *p3)
@@ -41,9 +42,9 @@ void test_threads_cancel_undelayed(void)
 	/* spawn thread with lower priority */
 	int spawn_prio = cur_prio + 1;
 
-	k_tid_t tid = k_thread_spawn(tstack, STACK_SIZE,
-				     thread_entry, NULL, NULL, NULL,
-				     spawn_prio, 0, 0);
+	k_tid_t tid = k_thread_create(&tdata, tstack, STACK_SIZE,
+				      thread_entry, NULL, NULL, NULL,
+				      spawn_prio, 0, 0);
 
 	/**TESTPOINT: check cancel retcode when thread is not delayed*/
 	int cancel_ret = k_thread_cancel(tid);
@@ -59,9 +60,9 @@ void test_threads_cancel_started(void)
 	/* spawn thread with lower priority */
 	int spawn_prio = cur_prio + 1;
 
-	k_tid_t tid = k_thread_spawn(tstack, STACK_SIZE,
-				     thread_entry, NULL, NULL, NULL,
-				     spawn_prio, 0, 0);
+	k_tid_t tid = k_thread_create(&tdata, tstack, STACK_SIZE,
+				      thread_entry, NULL, NULL, NULL,
+				      spawn_prio, 0, 0);
 
 	k_sleep(50);
 	/**TESTPOINT: check cancel retcode when thread is started*/
@@ -78,9 +79,9 @@ void test_threads_cancel_delayed(void)
 	/* spawn thread with lower priority */
 	int spawn_prio = cur_prio + 1;
 
-	k_tid_t tid = k_thread_spawn(tstack, STACK_SIZE,
-				     thread_entry, NULL, NULL, NULL,
-				     spawn_prio, 0, 100);
+	k_tid_t tid = k_thread_create(&tdata, tstack, STACK_SIZE,
+				      thread_entry, NULL, NULL, NULL,
+				      spawn_prio, 0, 100);
 
 	k_sleep(50);
 	/**TESTPOINT: check cancel retcode when thread is started*/
@@ -93,9 +94,9 @@ void test_threads_cancel_delayed(void)
 void test_threads_abort_self(void)
 {
 	execute_flag = 0;
-	k_tid_t tid = k_thread_spawn(tstack, STACK_SIZE,
-				     thread_entry_abort, NULL, NULL, NULL,
-				     0, 0, 0);
+	k_tid_t tid = k_thread_create(&tdata, tstack, STACK_SIZE,
+				      thread_entry_abort, NULL, NULL, NULL,
+				      0, 0, 0);
 	k_sleep(100);
 	/**TESTPOINT: spawned thread executed but abort itself*/
 	zassert_true(execute_flag == 1, NULL);
@@ -105,18 +106,18 @@ void test_threads_abort_self(void)
 void test_threads_abort_others(void)
 {
 	execute_flag = 0;
-	k_tid_t tid = k_thread_spawn(tstack, STACK_SIZE,
-				     thread_entry, NULL, NULL, NULL,
-				     0, 0, 0);
+	k_tid_t tid = k_thread_create(&tdata, tstack, STACK_SIZE,
+				      thread_entry, NULL, NULL, NULL,
+				      0, 0, 0);
 
 	k_thread_abort(tid);
 	k_sleep(100);
 	/**TESTPOINT: check not-started thread is aborted*/
 	zassert_true(execute_flag == 0, NULL);
 
-	tid = k_thread_spawn(tstack, STACK_SIZE,
-			     thread_entry, NULL, NULL, NULL,
-			     0, 0, 0);
+	tid = k_thread_create(&tdata, tstack, STACK_SIZE,
+			      thread_entry, NULL, NULL, NULL,
+			      0, 0, 0);
 	k_sleep(50);
 	k_thread_abort(tid);
 	/**TESTPOINT: check running thread is aborted*/

--- a/tests/kernel/threads_lifecycle/lifecycle_api/src/test_threads_spawn.c
+++ b/tests/kernel/threads_lifecycle/lifecycle_api/src/test_threads_spawn.c
@@ -16,6 +16,7 @@
 
 #define STACK_SIZE (256 + CONFIG_TEST_EXTRA_STACKSIZE)
 static char __noinit __stack tstack[STACK_SIZE];
+static struct k_thread tdata;
 
 static char tp1[8];
 static int tp2 = 100;
@@ -44,9 +45,9 @@ static void thread_entry_delay(void *p1, void *p2, void *p3)
 /*test cases*/
 void test_threads_spawn_params(void)
 {
-	k_tid_t tid = k_thread_spawn(tstack, STACK_SIZE,
-				     thread_entry_params, (void *)tp1, (void *)tp2, (void *)tp3,
-				     0, 0, 0);
+	k_tid_t tid = k_thread_create(&tdata, tstack, STACK_SIZE,
+				      thread_entry_params, (void *)tp1,
+				      (void *)tp2, (void *)tp3, 0, 0, 0);
 
 	k_sleep(100);
 	k_thread_abort(tid);
@@ -56,9 +57,9 @@ void test_threads_spawn_priority(void)
 {
 	/* spawn thread with higher priority */
 	spawn_prio = k_thread_priority_get(k_current_get()) - 1;
-	k_tid_t tid = k_thread_spawn(tstack, STACK_SIZE,
-				     thread_entry_priority, NULL, NULL, NULL,
-				     spawn_prio, 0, 0);
+	k_tid_t tid = k_thread_create(&tdata, tstack, STACK_SIZE,
+				      thread_entry_priority, NULL, NULL, NULL,
+				      spawn_prio, 0, 0);
 	k_sleep(100);
 	k_thread_abort(tid);
 }
@@ -67,9 +68,9 @@ void test_threads_spawn_delay(void)
 {
 	/* spawn thread with higher priority */
 	tp2 = 10;
-	k_tid_t tid = k_thread_spawn(tstack, STACK_SIZE,
-				     thread_entry_delay, NULL, NULL, NULL,
-				     0, 0, 120);
+	k_tid_t tid = k_thread_create(&tdata, tstack, STACK_SIZE,
+				      thread_entry_delay, NULL, NULL, NULL,
+				      0, 0, 120);
 	/* 100 < 120 ensure spawn thread not start */
 	k_sleep(100);
 	/* checkpoint: check spawn thread not execute */

--- a/tests/kernel/threads_lifecycle/thread_init/src/test_thread_init.c
+++ b/tests/kernel/threads_lifecycle/thread_init/src/test_thread_init.c
@@ -56,6 +56,8 @@ K_SEM_DEFINE(end_sema, 0, 1);
 /*local variables*/
 static char __noinit __stack stack_coop[INIT_COOP_STACK_SIZE];
 static char __noinit __stack stack_preempt[INIT_PREEMPT_STACK_SIZE];
+static struct k_thread thread_coop;
+static struct k_thread thread_preempt;
 static u64_t t_create;
 static struct thread_data{
 	int init_prio;
@@ -72,7 +74,7 @@ static void thread_entry(void *p1, void *p2, void *p3)
 		u64_t t_delay = k_uptime_get() - t_create;
 		/**TESTPOINT: check delay start*/
 		zassert_true(t_delay >= expected.init_delay,
-			"k_thread_spawn delay start failed\n");
+			"k_thread_create delay start failed\n");
 	}
 
 	k_sem_take(&start_sema, K_FOREVER);
@@ -135,17 +137,18 @@ void test_kdefine_coop_thread(void)
 
 /**
  * @ingroup t_thread_init
- * @brief test preempt thread initialization via k_thread_spawn
+ * @brief test preempt thread initialization via k_thread_create
  */
 void test_kinit_preempt_thread(void)
 {
 	/*create preempt thread*/
-	k_tid_t pthread = k_thread_spawn(stack_preempt, INIT_PREEMPT_STACK_SIZE,
-		thread_entry, INIT_PREEMPT_P1, INIT_PREEMPT_P2, INIT_PREEMPT_P3,
-		INIT_PREEMPT_PRIO, INIT_PREEMPT_OPTION, INIT_PREEMPT_DELAY);
+	k_tid_t pthread = k_thread_create(&thread_preempt, stack_preempt,
+		INIT_PREEMPT_STACK_SIZE, thread_entry, INIT_PREEMPT_P1,
+		INIT_PREEMPT_P2, INIT_PREEMPT_P3, INIT_PREEMPT_PRIO,
+		INIT_PREEMPT_OPTION, INIT_PREEMPT_DELAY);
 	/*record time stamp of thread creation*/
 	t_create = k_uptime_get();
-	zassert_not_null(pthread, "thread spawn failed\n");
+	zassert_not_null(pthread, "thread creation failed\n");
 
 	expected.init_p1 = INIT_PREEMPT_P1;
 	expected.init_p2 = INIT_PREEMPT_P2;
@@ -163,14 +166,15 @@ void test_kinit_preempt_thread(void)
 
 /**
  * @ingroup t_thread_init
- * @brief test coop thread initialization via k_thread_spawn
+ * @brief test coop thread initialization via k_thread_create
  */
 void test_kinit_coop_thread(void)
 {
 	/*create coop thread*/
-	k_tid_t pthread = k_thread_spawn(stack_coop, INIT_COOP_STACK_SIZE,
-		thread_entry, INIT_COOP_P1, INIT_COOP_P2, INIT_COOP_P3,
-		INIT_COOP_PRIO, INIT_COOP_OPTION, INIT_COOP_DELAY);
+	k_tid_t pthread = k_thread_create(&thread_coop, stack_coop,
+		INIT_COOP_STACK_SIZE, thread_entry, INIT_COOP_P1,
+		INIT_COOP_P2, INIT_COOP_P3, INIT_COOP_PRIO,
+		INIT_COOP_OPTION, INIT_COOP_DELAY);
 	/*record time stamp of thread creation*/
 	t_create = k_uptime_get();
 	zassert_not_null(pthread, "thread spawn failed\n");

--- a/tests/kernel/threads_scheduling/schedule_api/src/test_sched_is_preempt_thread.c
+++ b/tests/kernel/threads_scheduling/schedule_api/src/test_sched_is_preempt_thread.c
@@ -22,6 +22,7 @@
 
 /*local variables*/
 static char __noinit __stack tstack[STACK_SIZE];
+static struct k_thread tdata;
 static struct k_sem end_sema;
 
 static void tIsr(void *data)
@@ -68,14 +69,14 @@ void test_sched_is_preempt_thread(void)
 	k_sem_init(&end_sema, 0, 1);
 
 	/*create preempt thread*/
-	k_tid_t tid = k_thread_spawn(tstack, STACK_SIZE,
+	k_tid_t tid = k_thread_create(&tdata, tstack, STACK_SIZE,
 		tpreempt_ctx, NULL, NULL, NULL,
 		K_PRIO_PREEMPT(1), 0, 0);
 	k_sem_take(&end_sema, K_FOREVER);
 	k_thread_abort(tid);
 
 	/*create coop thread*/
-	tid = k_thread_spawn(tstack, STACK_SIZE,
+	tid = k_thread_create(&tdata, tstack, STACK_SIZE,
 		tcoop_ctx, NULL, NULL, NULL,
 		K_PRIO_COOP(1), 0, 0);
 	k_sem_take(&end_sema, K_FOREVER);

--- a/tests/kernel/threads_scheduling/schedule_api/src/test_sched_priority.c
+++ b/tests/kernel/threads_scheduling/schedule_api/src/test_sched_priority.c
@@ -15,6 +15,7 @@
 #include "test_sched.h"
 
 static char __noinit __stack tstack[STACK_SIZE];
+static struct k_thread tdata;
 static int last_prio;
 
 static void thread_entry(void *p1, void *p2, void *p3)
@@ -34,9 +35,9 @@ void test_priority_cooperative(void)
 	/* spawn thread with higher priority */
 	int spawn_prio = last_prio - 1;
 
-	k_tid_t tid = k_thread_spawn(tstack, STACK_SIZE,
-				     thread_entry, NULL, NULL, NULL,
-				     spawn_prio, 0, 0);
+	k_tid_t tid = k_thread_create(&tdata, tstack, STACK_SIZE,
+				      thread_entry, NULL, NULL, NULL,
+				      spawn_prio, 0, 0);
 	/* checkpoint: current thread shouldn't preempted by higher thread */
 	zassert_true(last_prio == k_thread_priority_get(k_current_get()), NULL);
 	k_sleep(100);
@@ -58,9 +59,9 @@ void test_priority_preemptible(void)
 
 	int spawn_prio = last_prio - 1;
 
-	k_tid_t tid = k_thread_spawn(tstack, STACK_SIZE,
-				     thread_entry, NULL, NULL, NULL,
-				     spawn_prio, 0, 0);
+	k_tid_t tid = k_thread_create(&tdata, tstack, STACK_SIZE,
+				      thread_entry, NULL, NULL, NULL,
+				      spawn_prio, 0, 0);
 	/* checkpoint: thread is preempted by higher thread */
 	zassert_true(last_prio == spawn_prio, NULL);
 
@@ -68,9 +69,9 @@ void test_priority_preemptible(void)
 	k_thread_abort(tid);
 
 	spawn_prio = last_prio + 1;
-	tid = k_thread_spawn(tstack, STACK_SIZE,
-			     thread_entry, NULL, NULL, NULL,
-			     spawn_prio, 0, 0);
+	tid = k_thread_create(&tdata, tstack, STACK_SIZE,
+			      thread_entry, NULL, NULL, NULL,
+			      spawn_prio, 0, 0);
 	/* checkpoint: thread is not preempted by lower thread */
 	zassert_false(last_prio == spawn_prio, NULL);
 	k_thread_abort(tid);

--- a/tests/kernel/threads_scheduling/schedule_api/src/test_sched_timeslice_and_lock.c
+++ b/tests/kernel/threads_scheduling/schedule_api/src/test_sched_timeslice_and_lock.c
@@ -17,6 +17,7 @@
 static char __noinit __stack tstack[THREADS_NUM][STACK_SIZE];
 
 static struct thread_data tdata[THREADS_NUM];
+static struct k_thread tthread[THREADS_NUM];
 static int old_prio, init_prio;
 
 static void thread_entry(void *p1, void *p2, void *p3)
@@ -54,9 +55,10 @@ static void setup_threads(void)
 static void spawn_threads(int sleep_sec)
 {
 	for (int i = 0; i < THREADS_NUM; i++) {
-		tdata[i].tid = k_thread_spawn(tstack[i], STACK_SIZE,
-					      thread_entry, (void *)i, (void *)sleep_sec, NULL,
-					      tdata[i].priority, 0, 0);
+		tdata[i].tid = k_thread_create(&tthread[i], tstack[i],
+					       STACK_SIZE, thread_entry,
+					       (void *)i, (void *)sleep_sec,
+					       NULL, tdata[i].priority, 0, 0);
 	}
 }
 

--- a/tests/kernel/tickless/tickless_concept/src/test_tickless_sysclock.c
+++ b/tests/kernel/tickless/tickless_concept/src/test_tickless_sysclock.c
@@ -20,6 +20,7 @@ https://www.zephyrproject.org/doc/subsystems/power_management.html#tickless-idle
 #define STACK_SIZE 512
 #define NUM_THREAD 4
 static char __noinit __stack tstack[NUM_THREAD][STACK_SIZE];
+static struct k_thread tdata[NUM_THREAD];
 /*for those not supporting tickless idle*/
 #ifndef CONFIG_TICKLESS_IDLE
 #define CONFIG_TICKLESS_IDLE_THRESH 20
@@ -92,7 +93,7 @@ void test_tickless_slice(void)
 
 	/*create delayed threads with equal preemptive priority*/
 	for (int i = 0; i < NUM_THREAD; i++) {
-		tid[i] = k_thread_spawn(tstack[i], STACK_SIZE,
+		tid[i] = k_thread_create(&tdata[i], tstack[i], STACK_SIZE,
 			thread_tslice, NULL, NULL, NULL,
 			K_PRIO_PREEMPT(0), 0, SLICE_SIZE);
 	}

--- a/tests/kernel/workq/work_queue/src/main.c
+++ b/tests/kernel/workq/work_queue/src/main.c
@@ -29,6 +29,7 @@ struct test_item {
 };
 
 static char __stack co_op_stack[STACK_SIZE];
+static struct k_thread co_op_data;
 
 static struct test_item tests[NUM_TEST_ITEMS];
 
@@ -76,10 +77,9 @@ static void test_items_submit(void)
 {
 	int i;
 
-	k_thread_spawn(co_op_stack, STACK_SIZE,
+	k_thread_create(&co_op_data, co_op_stack, STACK_SIZE,
 			(k_thread_entry_t)coop_work_main,
-				NULL, NULL,
-				NULL, K_PRIO_COOP(10), 0, 0);
+			NULL, NULL, NULL, K_PRIO_COOP(10), 0, 0);
 
 	for (i = 0; i < NUM_TEST_ITEMS; i += 2) {
 		TC_PRINT(" - Submitting work %d from preempt thread\n", i + 1);
@@ -211,8 +211,8 @@ static int test_delayed_submit(void)
 {
 	int i;
 
-	k_thread_spawn(co_op_stack, STACK_SIZE,
-		       (k_thread_entry_t)coop_delayed_work_main,
+	k_thread_create(&co_op_data, co_op_stack, STACK_SIZE,
+			(k_thread_entry_t)coop_delayed_work_main,
 			NULL, NULL, NULL, K_PRIO_COOP(10), 0, 0);
 
 	for (i = 0; i < NUM_TEST_ITEMS; i += 2) {
@@ -247,8 +247,8 @@ static int test_delayed_cancel(void)
 	TC_PRINT(" - Cancel delayed work from preempt thread\n");
 	k_delayed_work_cancel(&tests[0].work);
 
-	k_thread_spawn(co_op_stack, STACK_SIZE,
-		       (k_thread_entry_t)coop_delayed_work_cancel_main,
+	k_thread_create(&co_op_data, co_op_stack, STACK_SIZE,
+			(k_thread_entry_t)coop_delayed_work_cancel_main,
 			NULL, NULL, NULL, K_PRIO_COOP(10), 0, 0);
 
 	TC_PRINT(" - Waiting for work to finish\n");
@@ -315,8 +315,8 @@ static int test_delayed_resubmit_fiber(void)
 	tests[0].key = 1;
 	k_delayed_work_init(&tests[0].work, delayed_work_handler);
 
-	k_thread_spawn(co_op_stack, STACK_SIZE,
-		       (k_thread_entry_t)coop_delayed_work_resubmit,
+	k_thread_create(&co_op_data, co_op_stack, STACK_SIZE,
+			(k_thread_entry_t)coop_delayed_work_resubmit,
 			NULL, NULL, NULL, K_PRIO_COOP(10), 0, 0);
 
 	TC_PRINT(" - Waiting for work to finish\n");

--- a/tests/net/6lo/src/main.c
+++ b/tests/net/6lo/src/main.c
@@ -906,10 +906,11 @@ static void main_thread(void)
 
 #define STACKSIZE 2000
 char __noinit __stack thread_stack[STACKSIZE];
+static struct k_thread thread_data;
 
 void main(void)
 {
-	k_thread_spawn(&thread_stack[0], STACKSIZE,
-		       (k_thread_entry_t)main_thread,
-		       NULL, NULL, NULL, K_PRIO_COOP(7), 0, 0);
+	k_thread_create(&thread_data, thread_stack, STACKSIZE,
+			(k_thread_entry_t)main_thread,
+			NULL, NULL, NULL, K_PRIO_COOP(7), 0, 0);
 }

--- a/tests/net/arp/src/main.c
+++ b/tests/net/arp/src/main.c
@@ -680,10 +680,11 @@ void main_thread(void)
 
 #define STACKSIZE 2000
 char __noinit __stack thread_stack[STACKSIZE];
+static struct k_thread thread_data;
 
 void main(void)
 {
-	k_thread_spawn(&thread_stack[0], STACKSIZE,
-		       (k_thread_entry_t)main_thread,
-		       NULL, NULL, NULL, K_PRIO_COOP(7), 0, 0);
+	k_thread_create(&thread_data, thread_stack, STACKSIZE,
+			(k_thread_entry_t)main_thread,
+			NULL, NULL, NULL, K_PRIO_COOP(7), 0, 0);
 }

--- a/tests/net/buf/src/main.c
+++ b/tests/net/buf/src/main.c
@@ -170,6 +170,7 @@ static void test_3_thread(void *arg1, void *arg2, void *arg3)
 static void net_buf_test_3(void)
 {
 	static char __stack test_3_thread_stack[1024];
+	static struct k_thread test_3_thread_data;
 	struct net_buf *frag, *head;
 	struct k_fifo fifo;
 	struct k_sem sema;
@@ -188,9 +189,10 @@ static void net_buf_test_3(void)
 	k_fifo_init(&fifo);
 	k_sem_init(&sema, 0, UINT_MAX);
 
-	k_thread_spawn(test_3_thread_stack, sizeof(test_3_thread_stack),
-		       (k_thread_entry_t) test_3_thread, &fifo, &sema, NULL,
-		       K_PRIO_COOP(7), 0, 0);
+	k_thread_create(&test_3_thread_data, test_3_thread_stack,
+			sizeof(test_3_thread_stack),
+			(k_thread_entry_t) test_3_thread, &fifo, &sema, NULL,
+			K_PRIO_COOP(7), 0, 0);
 
 	zassert_true(k_sem_take(&sema, TEST_TIMEOUT) == 0,
 		    "Timeout while waiting for semaphore");

--- a/tests/net/context/src/main.c
+++ b/tests/net/context/src/main.c
@@ -905,6 +905,7 @@ static bool net_ctx_recv_v4_reconfig(void)
 
 #define STACKSIZE 1024
 char __noinit __stack thread_stack[STACKSIZE];
+static struct k_thread thread_data;
 
 static void recv_cb_timeout(struct net_context *context,
 			    struct net_pkt *pkt,
@@ -940,18 +941,18 @@ void timeout_thread(struct net_context *ctx, sa_family_t *family)
 
 static void start_timeout_v6_thread(void)
 {
-	k_thread_spawn(&thread_stack[0], STACKSIZE,
-		       (k_thread_entry_t)timeout_thread,
-		       udp_v6_ctx, INT_TO_POINTER(AF_INET6), NULL,
-		       K_PRIO_COOP(7), 0, 0);
+	k_thread_create(&thread_data, thread_stack, STACKSIZE,
+			(k_thread_entry_t)timeout_thread,
+			udp_v6_ctx, INT_TO_POINTER(AF_INET6), NULL,
+			K_PRIO_COOP(7), 0, 0);
 }
 
 static void start_timeout_v4_thread(void)
 {
-	k_thread_spawn(&thread_stack[0], STACKSIZE,
-		       (k_thread_entry_t)timeout_thread,
-		       udp_v4_ctx, INT_TO_POINTER(AF_INET), NULL,
-		       K_PRIO_COOP(7), 0, 0);
+	k_thread_create(&thread_data, thread_stack, STACKSIZE,
+			(k_thread_entry_t)timeout_thread,
+			udp_v4_ctx, INT_TO_POINTER(AF_INET), NULL,
+			K_PRIO_COOP(7), 0, 0);
 }
 
 static bool net_ctx_recv_v6_timeout(void)

--- a/tests/net/dhcpv4/src/main.c
+++ b/tests/net/dhcpv4/src/main.c
@@ -546,10 +546,11 @@ void main_thread(void)
 
 #define STACKSIZE 3000
 char __noinit __stack thread_stack[STACKSIZE];
+static struct k_thread thread_data;
 
 void main(void)
 {
-	k_thread_spawn(&thread_stack[0], STACKSIZE,
-		       (k_thread_entry_t)main_thread, NULL, NULL, NULL,
-		       K_PRIO_COOP(7), 0, 0);
+	k_thread_create(&thread_data, thread_stack, STACKSIZE,
+			(k_thread_entry_t)main_thread, NULL, NULL, NULL,
+			K_PRIO_COOP(7), 0, 0);
 }

--- a/tests/net/icmpv6/src/main.c
+++ b/tests/net/icmpv6/src/main.c
@@ -120,10 +120,11 @@ void main_thread(void)
 
 #define STACKSIZE 2000
 char __noinit __stack thread_stack[STACKSIZE];
+static struct k_thread thread_data;
 
 void main(void)
 {
-	k_thread_spawn(&thread_stack[0], STACKSIZE,
-		       (k_thread_entry_t)main_thread, NULL, NULL, NULL,
-		       K_PRIO_COOP(7), 0, 0);
+	k_thread_create(&thread_data, thread_stack, STACKSIZE,
+			(k_thread_entry_t)main_thread, NULL, NULL, NULL,
+			K_PRIO_COOP(7), 0, 0);
 }

--- a/tests/net/ieee802154/fragment/src/main.c
+++ b/tests/net/ieee802154/fragment/src/main.c
@@ -533,10 +533,11 @@ static void main_thread(void)
 
 #define STACKSIZE 8000
 char __noinit __stack thread_stack[STACKSIZE];
+static struct k_thread thread_data;
 
 void main(void)
 {
-	k_thread_spawn(&thread_stack[0], STACKSIZE,
-		       (k_thread_entry_t)main_thread, NULL, NULL, NULL,
-		       K_PRIO_COOP(7), 0, 0);
+	k_thread_create(&thread_data, thread_stack, STACKSIZE,
+			(k_thread_entry_t)main_thread, NULL, NULL, NULL,
+			K_PRIO_COOP(7), 0, 0);
 }

--- a/tests/net/ip-addr/src/main.c
+++ b/tests/net/ip-addr/src/main.c
@@ -444,10 +444,11 @@ void main_thread(void)
 
 #define STACKSIZE 2000
 char __noinit __stack thread_stack[STACKSIZE];
+static struct k_thread thread_data;
 
 void main(void)
 {
-	k_thread_spawn(&thread_stack[0], STACKSIZE,
-		       (k_thread_entry_t)main_thread, NULL, NULL, NULL,
-		       K_PRIO_COOP(7), 0, 0);
+	k_thread_create(&thread_data, thread_stack, STACKSIZE,
+			(k_thread_entry_t)main_thread,
+			NULL, NULL, NULL, K_PRIO_COOP(7), 0, 0);
 }

--- a/tests/net/mgmt/src/mgmt.c
+++ b/tests/net/mgmt/src/mgmt.c
@@ -22,6 +22,7 @@ static u32_t event2throw;
 static u32_t throw_times;
 static int throw_sleep;
 static char __noinit __stack thrower_stack[512];
+static struct k_thread thrower_thread_data;
 static struct k_sem thrower_lock;
 
 /* Receiver infra */
@@ -205,9 +206,10 @@ static void initialize_event_tests(void)
 
 	net_mgmt_init_event_callback(&rx_cb, receiver_cb, TEST_MGMT_EVENT);
 
-	k_thread_spawn(thrower_stack, sizeof(thrower_stack),
-		       (k_thread_entry_t)thrower_thread,
-		       NULL, NULL, NULL, K_PRIO_COOP(7), 0, 0);
+	k_thread_create(&thrower_thread_data, thrower_stack,
+			sizeof(thrower_stack),
+			(k_thread_entry_t)thrower_thread,
+			NULL, NULL, NULL, K_PRIO_COOP(7), 0, 0);
 }
 
 static int test_core_event(u32_t event, bool (*func)(void))

--- a/tests/net/neighbor/src/main.c
+++ b/tests/net/neighbor/src/main.c
@@ -370,10 +370,11 @@ void main_thread(void)
 
 #define STACKSIZE 2000
 char __noinit __stack thread_stack[STACKSIZE];
+static struct k_thread thread_data;
 
 void main(void)
 {
-	k_thread_spawn(&thread_stack[0], STACKSIZE,
-		       (k_thread_entry_t)main_thread, NULL, NULL, NULL,
-		       K_PRIO_COOP(7), 0, 0);
+	k_thread_create(&thread_data, thread_stack, STACKSIZE,
+			(k_thread_entry_t)main_thread, NULL, NULL, NULL,
+			K_PRIO_COOP(7), 0, 0);
 }

--- a/tests/net/udp/src/main.c
+++ b/tests/net/udp/src/main.c
@@ -592,10 +592,11 @@ void main_thread(void)
 
 #define STACKSIZE 2000
 char __noinit __stack thread_stack[STACKSIZE];
+static struct k_thread thread_data;
 
 void main(void)
 {
-	k_thread_spawn(&thread_stack[0], STACKSIZE,
-		       (k_thread_entry_t)main_thread,
-		       NULL, NULL, NULL, K_PRIO_COOP(7), 0, 0);
+	k_thread_create(&thread_data, thread_stack, STACKSIZE,
+			(k_thread_entry_t)main_thread,
+			NULL, NULL, NULL, K_PRIO_COOP(7), 0, 0);
 }

--- a/tests/net/utils/src/main.c
+++ b/tests/net/utils/src/main.c
@@ -753,10 +753,11 @@ void main_thread(void)
 
 #define STACKSIZE 2000
 char __noinit __stack thread_stack[STACKSIZE];
+static struct k_thread thread_data;
 
 void main(void)
 {
-	k_thread_spawn(&thread_stack[0], STACKSIZE,
-		       (k_thread_entry_t)main_thread,
-		       NULL, NULL, NULL, K_PRIO_COOP(7), 0, 0);
+	k_thread_create(&thread_data, thread_stack, STACKSIZE,
+			(k_thread_entry_t)main_thread,
+			NULL, NULL, NULL, K_PRIO_COOP(7), 0, 0);
 }

--- a/tests/power/power_states/src/soc_watch_logger.c
+++ b/tests/power/power_states/src/soc_watch_logger.c
@@ -7,7 +7,8 @@
 #include "soc_watch_logger.h"
 
 #define STSIZE 512
-char __stack soc_watch_event_logger_stack[1][STSIZE];
+static char __stack __noinit soc_watch_event_logger_stack[STSIZE];
+static struct k_thread soc_watch_event_logger_data;
 
 /**
  * @brief soc_watch data collector thread
@@ -91,7 +92,8 @@ void soc_watch_logger_thread_start(void)
 {
 	PRINTF("\x1b[2J\x1b[15;1H");
 
-	k_thread_spawn(&soc_watch_event_logger_stack[0][0], STSIZE,
+	k_thread_create(&soc_watch_event_logger_data,
+			soc_watch_event_logger_stack, STSIZE,
 			(k_thread_entry_t) soc_watch_data_collector, 0, 0, 0,
 			6, 0, 0);
 }

--- a/tests/subsys/debug/gdb_server/src/main.c
+++ b/tests/subsys/debug/gdb_server/src/main.c
@@ -63,15 +63,15 @@ void threadB(void *dummy1, void *dummy2, void *dummy3)
 }
 
 char __noinit __stack threadB_stack_area[STACKSIZE];
-
+static struct k_thread threadB_data;
 
 /* threadA is a static thread that is spawned automatically */
 
 void threadA(void *dummy1, void *dummy2, void *dummy3)
 {
 	/* spawn threadB */
-	k_thread_spawn(threadB_stack_area, STACKSIZE, threadB, NULL, NULL, NULL,
-		       PRIORITY, 0, K_NO_WAIT);
+	k_thread_create(&threadB_data, threadB_stack_area, STACKSIZE, threadB,
+			NULL, NULL, NULL, PRIORITY, 0, K_NO_WAIT);
 
 	/* invoke routine to ping-pong hello messages with threadB */
 	helloLoop(__func__, &threadA_sem, &threadB_sem);

--- a/tests/ztest/src/ztest.c
+++ b/tests/ztest/src/ztest.c
@@ -128,8 +128,9 @@ out:
 #if CONFIG_ZTEST_STACKSIZE & (STACK_ALIGN - 1)
     #error "CONFIG_ZTEST_STACKSIZE must be a multiple of the stack alignment"
 #endif
-static char __stack thread_stack[CONFIG_ZTEST_STACKSIZE +
-				 CONFIG_TEST_EXTRA_STACKSIZE];
+static struct k_thread ztest_thread;
+static char __stack __noinit thread_stack[CONFIG_ZTEST_STACKSIZE +
+					  CONFIG_TEST_EXTRA_STACKSIZE];
 
 static int test_result;
 static struct k_sem test_end_signal;
@@ -165,7 +166,7 @@ static int run_test(struct unit_test *test)
 	int ret = TC_PASS;
 
 	TC_START(test->name);
-	k_thread_spawn(&thread_stack[0], sizeof(thread_stack),
+	k_thread_create(&ztest_thread, thread_stack, sizeof(thread_stack),
 			 (k_thread_entry_t) test_cb, (struct unit_test *)test,
 			 NULL, NULL, -1, 0, 0);
 


### PR DESCRIPTION
This series of patches replaces the k_thread_spawn() API with k_thread_create(). The difference is that the location of the struct k_thread is not forced to be in the stack memory region, a pointer to it is supplied as an argument.

Upcoming stack overflow and memory protection features will need this. The struct k_thread contains data private to the kernel and should not be in a thread-writable area. Given the size and alignment constraints in a typical MPU/MMU, it is not possible to guard the thread stack region without leaving the contained struct k_thread data vulnerable to corruption.

k_thread_spawn() marked as __deprecated and will be removed in a future release.