### PR TITLE
Bluetooth: controller: bugfix / cleanups

### DIFF
--- a/subsys/bluetooth/controller/ll_sw/ctrl.c
+++ b/subsys/bluetooth/controller/ll_sw/ctrl.c
@@ -249,9 +249,7 @@ static void prepare_pdu_data_tx(struct connection *conn,
 				struct pdu_data **pdu_data_tx);
 static void packet_rx_allocate(u8_t max);
 
-#if defined(CONFIG_BLUETOOTH_CONTROLLER_DATA_LENGTH)
 static u8_t packet_rx_acquired_count_get(void);
-#endif /* CONFIG_BLUETOOTH_CONTROLLER_DATA_LENGTH */
 
 static struct radio_pdu_node_rx *packet_rx_reserve_get(u8_t count);
 static void packet_rx_enqueue(void);
@@ -6798,7 +6796,6 @@ static void packet_rx_allocate(u8_t max)
 	}
 }
 
-#if defined(CONFIG_BLUETOOTH_CONTROLLER_DATA_LENGTH)
 static u8_t packet_rx_acquired_count_get(void)
 {
 	if (_radio.packet_rx_acquire >=
@@ -6811,7 +6808,6 @@ static u8_t packet_rx_acquired_count_get(void)
 			_radio.packet_rx_acquire);
 	}
 }
-#endif /* CONFIG_BLUETOOTH_CONTROLLER_DATA_LENGTH */
 
 static struct radio_pdu_node_rx *packet_rx_reserve_get(u8_t count)
 {

--- a/subsys/bluetooth/controller/ll_sw/ctrl.c
+++ b/subsys/bluetooth/controller/ll_sw/ctrl.c
@@ -1615,14 +1615,18 @@ static inline u8_t isr_rx_conn_pkt_ctrl_dle(struct pdu_data *pdu_data_rx,
 		/* use the minimal of our default_tx_octets and
 		 * peer max_rx_octets
 		 */
-		eff_tx_octets = min(lr->max_rx_octets,
-				    _radio.conn_curr->default_tx_octets);
+		if (lr->max_rx_octets >= RADIO_LL_LENGTH_OCTETS_RX_MIN) {
+			eff_tx_octets = min(lr->max_rx_octets,
+					    _radio.conn_curr->default_tx_octets);
+		}
 
 		/* use the minimal of our max supported and
 		 * peer max_tx_octets
 		 */
-		eff_rx_octets = min(lr->max_tx_octets,
-				    RADIO_LL_LENGTH_OCTETS_RX_MAX);
+		if (lr->max_tx_octets >= RADIO_LL_LENGTH_OCTETS_RX_MIN) {
+			eff_rx_octets = min(lr->max_tx_octets,
+					    RADIO_LL_LENGTH_OCTETS_RX_MAX);
+		}
 
 		/* check if change in rx octets */
 		if (eff_rx_octets != _radio.conn_curr->max_rx_octets) {

--- a/subsys/bluetooth/controller/ll_sw/ctrl.c
+++ b/subsys/bluetooth/controller/ll_sw/ctrl.c
@@ -6813,17 +6813,8 @@ static struct radio_pdu_node_rx *packet_rx_reserve_get(u8_t count)
 {
 	struct radio_pdu_node_rx *radio_pdu_node_rx;
 
-	if (_radio.packet_rx_last > _radio.packet_rx_acquire) {
-		if (count >
-		    ((_radio.packet_rx_count - _radio.packet_rx_last) +
-		     _radio.packet_rx_acquire)) {
-			return 0;
-		}
-	} else {
-		if (count >
-		    (_radio.packet_rx_acquire - _radio.packet_rx_last)) {
-			return 0;
-		}
+	if (count > packet_rx_acquired_count_get()) {
+		return 0;
 	}
 
 	radio_pdu_node_rx = _radio.packet_rx[_radio.packet_rx_last];


### PR DESCRIPTION
This patch series:
- Fixes the calculation of the packet_rx_data_size / counts when CONFIG_BLUETOOTH_CONTROLLER_DATA_LENGTH is used.
- Makes sure the initial value of conn->max_rx_octets is CONFIG_BLUETOOTH_CONTROLLER_DATA_LENGTH_MAX when it's set.
- verifies the values in max_rx_octets/max_tx_octets for a DLE req_rsp prior to using them.
- Removes duplicated code in packet_rx_reserve_get() by re-using the calculation in packet_rx_acquired_count_get().