### PR TITLE
net: tcp: Handle case when RST is received in ESTABLISHED

### DIFF
--- a/subsys/net/ip/tcp.c
+++ b/subsys/net/ip/tcp.c
@@ -866,7 +866,14 @@ static void validate_state_transition(enum net_tcp_state current,
 			1 << NET_TCP_ESTABLISHED |
 			1 << NET_TCP_SYN_RCVD,
 		[NET_TCP_ESTABLISHED] = 1 << NET_TCP_CLOSE_WAIT |
-			1 << NET_TCP_FIN_WAIT_1,
+			1 << NET_TCP_FIN_WAIT_1 |
+			/* Going into CLOSED state from ESTABLISHED is not
+			 * described in TCP state diagram but RFC 793 says in
+			 * chapter "Reset Processing" that if device receives
+			 * RST "...it aborts the connection and advises the
+			 * user and goes to the CLOSED state".
+			 */
+			1 << NET_TCP_CLOSED,
 		[NET_TCP_CLOSE_WAIT] = 1 << NET_TCP_LAST_ACK,
 		[NET_TCP_LAST_ACK] = 1 << NET_TCP_CLOSED,
 		[NET_TCP_FIN_WAIT_1] = 1 << NET_TCP_CLOSING |


### PR DESCRIPTION
We must check if we receive RST in ESTABLISHED state. If we do
not do this, then the net_context will leak as it is never
released. Receiving RST in this state is not described in TCP
state diagram but RFC 793 says in chapter "Reset Processing"
that system "...aborts the connection and advises the user
and goes to the CLOSED state.".
The validate_state_transitions() function is also changed to
accept this state transition.

Signed-off-by: Jukka Rissanen <jukka.rissanen@linux.intel.com>