### PR TITLE
cdc_acm : Restrict writing more than 4 bytes into TX USB Endpoint.

### DIFF
--- a/samples/subsys/usb/cdc_acm/src/main.c
+++ b/samples/subsys/usb/cdc_acm/src/main.c
@@ -41,12 +41,25 @@ static void interrupt_handler(struct device *dev)
 
 static void write_data(struct device *dev, const char *buf, int len)
 {
+	int sent;
 	uart_irq_tx_enable(dev);
 
-	data_transmitted = false;
-	uart_fifo_fill(dev, (const u8_t *)buf, len);
-	while (data_transmitted == false)
-		;
+	while (len) {
+		data_transmitted = false;
+		sent = uart_fifo_fill(dev, (const u8_t *)buf, len);
+
+		if (!sent) {
+			printf("Unable to send Data !\n");
+			break;
+		}
+
+		/* Wait until Tx interrupr is generated*/
+		while (data_transmitted == false)
+			;
+		/* Update remainging Data length to transfer*/
+		len -= sent;
+		buf += sent;
+	}
 
 	uart_irq_tx_disable(dev);
 }

--- a/subsys/usb/class/cdc_acm.c
+++ b/subsys/usb/class/cdc_acm.c
@@ -538,6 +538,18 @@ static int cdc_acm_fifo_fill(struct device *dev,
 	}
 
 	dev_data->tx_ready = 0;
+
+	/* FIXME: On Quark SE Family processor, restrict writing more than
+	 * 4 bytes into TX USB Endpoint. When more than 4 bytes are written,
+	 * sometimes (freq ~1/3000) first 4 bytes are  repeated.
+	 * (example: abcdef prints as abcdabcdef) (refer Jira ZEP-2074).
+	 * Application should handle partial data transfer while writing
+	 * into USB TX Endpoint.
+	 */
+#ifdef CONFIG_SOC_SERIES_QUARK_SE
+	len = len > sizeof(u32_t) ? sizeof(u32_t) : len;
+#endif
+
 	usb_write(CDC_ENDP_IN, tx_data, len, &bytes_written);
 
 	return bytes_written;


### PR DESCRIPTION
Jira: ZEP-2074

sometime it is observed that when we write more than 4 bytes into
TX USB Endpoint, first 4 bytes are getting repeated
(frequency of occurrence ~1/3000). So this Patch is workaround to
avoid issue occurrence.

Signed-off-by: Youvedeep Singh <youvedeep.singh@intel.com>
Signed-off-by: Andy Ross <andrew.j.ross@intel.com>