### PR TITLE
samples: ipm_mailbox: Remove unneeded definitions

### DIFF
--- a/samples/subsys/ipc/ipm_mailbox/ap/src/hello.c
+++ b/samples/subsys/ipc/ipm_mailbox/ap/src/hello.c
@@ -18,8 +18,6 @@ QUARK_SE_IPM_DEFINE(message_ipm2, 3, QUARK_SE_IPM_OUTBOUND);
 /* specify delay between greetings (in ms); compute equivalent in ticks */
 
 #define SLEEPTIME               1000
-#define SCSS_REGISTER_BASE      0xB0800000
-#define SCSS_SS_STS             0x0604
 
 #define PING_TIME               1000
 #define STACKSIZE               2000


### PR DESCRIPTION
Make sample working for other architectures.
SCSS_REGISTER_BASE and SCSS_SS_STS are defined in soc.h

Change-Id: Ie477520d2fb9bfcbbb5038ff42356a56d8180a1f
Signed-off-by: Andrei Emeltchenko <andrei.emeltchenko@intel.com>