### PR TITLE
RFC: gpio: add configuration for DMA request

### DIFF
--- a/drivers/gpio/gpio_mcux.c
+++ b/drivers/gpio/gpio_mcux.c
@@ -107,6 +107,17 @@ static int gpio_mcux_configure(struct device *dev,
 			}
 		}
 		pcr |= PORT_PCR_IRQC(port_interrupt);
+	} else {
+		if (flags & GPIO_DMA_REQ_MASK) {
+			if (flags & GPIO_DMA_REQ_EDGE_HIGH) {
+				port_interrupt = kPORT_DMARisingEdge;
+			} else if (flags & GPIO_DMA_REQ_EDGE_DOUBLE) {
+				port_interrupt = kPORT_DMAEitherEdge;
+			} else {
+				port_interrupt = kPORT_DMAFallingEdge;
+			}
+		}
+		pcr |= PORT_PCR_IRQC(port_interrupt);
 	}
 
 	/* Now we can write the PORT PCR register(s). If accessing by pin, we

--- a/include/gpio.h
+++ b/include/gpio.h
@@ -189,6 +189,20 @@ extern "C" {
  */
 #define GPIO_DS_DISCONNECT_HIGH (0x3 << GPIO_DS_HIGH_POS)
 
+/** @cond INTERNAL_HIDDEN */
+#define GPIO_DMA_REQ_POS		15
+#define GPIO_DMA_REQ_MASK		(0x3 << GPIO_DMA_REQ_POS)
+/** @endcond */
+
+/** GPIO pin trigger DMA requenst on falling edge. */
+#define GPIO_DMA_REQ_EDGE_LOW		(1 << GPIO_DMA_REQ_POS)
+
+/** GPIO pin trigger DMA requenst on rising edge. */
+#define GPIO_DMA_REQ_EDGE_HIGH		(2 << GPIO_DMA_REQ_POS)
+
+/** GPIO pin trigger DMA requenst on rising and falling edge. */
+#define GPIO_DMA_REQ_EDGE_DOUBLE	(3 << GPIO_DMA_REQ_POS)
+
 struct gpio_callback;
 
 /**


### PR DESCRIPTION
This patch adds GPIO configuration flags for DMA request.
The configured GPIO can be used to trigger a DMA transfer,
this is very useful for a parallel interface, so a gpio
can triggers the transfert from peripheral to memory or vice versa.