### PR TITLE
Bluetooth: controller: Revert cleanup redundant ticker busy loop

### DIFF
--- a/subsys/bluetooth/controller/ll_sw/ctrl.c
+++ b/subsys/bluetooth/controller/ll_sw/ctrl.c
@@ -3546,6 +3546,7 @@ static u32_t preempt_calc(struct shdr *hdr, u8_t ticker_id,
  */
 static void mayfly_xtal_stop_calc(void *params)
 {
+	u32_t volatile ret_cb = TICKER_STATUS_BUSY;
 	u32_t ticks_to_expire;
 	u32_t ticks_current;
 	u8_t ticker_id;
@@ -3555,9 +3556,17 @@ static void mayfly_xtal_stop_calc(void *params)
 	ticks_to_expire = 0;
 	ret = ticker_next_slot_get(RADIO_TICKER_INSTANCE_ID_RADIO,
 				   RADIO_TICKER_USER_ID_JOB, &ticker_id,
-				   &ticks_current, &ticks_to_expire, NULL,
-				   NULL);
-	LL_ASSERT(ret == TICKER_STATUS_SUCCESS);
+				   &ticks_current, &ticks_to_expire,
+				   ticker_if_done, (void *)&ret_cb);
+
+	if (ret == TICKER_STATUS_BUSY) {
+		while (ret_cb == TICKER_STATUS_BUSY) {
+			ticker_job_sched(RADIO_TICKER_INSTANCE_ID_RADIO,
+					 RADIO_TICKER_USER_ID_JOB);
+		}
+	}
+
+	LL_ASSERT(ret_cb == TICKER_STATUS_SUCCESS);
 
 	if ((ticker_id != 0xff) &&
 	    (ticks_to_expire <
@@ -3747,13 +3756,23 @@ static void sched_after_mstr_free_slot_get(u8_t user_id,
 	ticks_to_expire = ticks_to_expire_prev = *us_offset = 0;
 	ticks_slot_prev_abs = 0;
 	while (1) {
+		u32_t volatile ret_cb = TICKER_STATUS_BUSY;
 		struct connection *conn;
 		u32_t ret;
 
 		ret = ticker_next_slot_get(RADIO_TICKER_INSTANCE_ID_RADIO,
 					   user_id, &ticker_id, ticks_anchor,
-					   &ticks_to_expire, NULL, NULL);
-		LL_ASSERT(ret == TICKER_STATUS_SUCCESS);
+					   &ticks_to_expire, ticker_if_done,
+					   (void *)&ret_cb);
+
+		if (ret == TICKER_STATUS_BUSY) {
+			while (ret_cb == TICKER_STATUS_BUSY) {
+				ticker_job_sched(RADIO_TICKER_INSTANCE_ID_RADIO,
+						 user_id);
+			}
+		}
+
+		LL_ASSERT(ret_cb == TICKER_STATUS_SUCCESS);
 
 		if (ticker_id == 0xff) {
 			break;
@@ -3891,14 +3910,24 @@ static void sched_free_win_offset_calc(struct connection *conn_curr,
 		ticks_anchor_prev = offset_index = _win_offset = 0;
 	ticks_slot_prev_abs = 0;
 	do {
+		u32_t volatile ret_cb = TICKER_STATUS_BUSY;
 		struct connection *conn;
 		u32_t ret;
 
 		ret = ticker_next_slot_get(RADIO_TICKER_INSTANCE_ID_RADIO,
 					   RADIO_TICKER_USER_ID_JOB,
 					   &ticker_id, &ticks_anchor,
-					   &ticks_to_expire, NULL, NULL);
-		LL_ASSERT(ret == TICKER_STATUS_SUCCESS);
+					   &ticks_to_expire, ticker_if_done,
+					   (void *)&ret_cb);
+
+		if (ret == TICKER_STATUS_BUSY) {
+			while (ret_cb == TICKER_STATUS_BUSY) {
+				ticker_job_sched(RADIO_TICKER_INSTANCE_ID_RADIO,
+						 RADIO_TICKER_USER_ID_JOB);
+			}
+		}
+
+		LL_ASSERT(ret_cb == TICKER_STATUS_SUCCESS);
 
 		if (ticker_id == 0xff) {
 			break;


### PR DESCRIPTION
This reverts commit 698de8891660 ("Bluetooth: controller:
Cleanup redundant ticker busy loop")

Scan enable asserted in ctrl.c line 3756 due to the fact that a
role event was active and ticker job has hence been disabled.
Add back the busy loop so that scan enable can wait until the
active role event completes gracefully.

The ticker busy loop is mandatory in all ticker interface calls
if a blocking behavior is desired.

Signed-off-by: Vinayak Kariappa Chettimada <vich@nordicsemi.no>