### PR TITLE
Bluetooth: Move common code to common/

### DIFF
--- a/drivers/bluetooth/Makefile
+++ b/drivers/bluetooth/Makefile
@@ -1,3 +1,5 @@
+ccflags-y += -I$(srctree)/subsys/bluetooth
+
 obj-y += hci/
 obj-$(CONFIG_NBLE) += nble/
 obj-$(CONFIG_BLUETOOTH_NRF51_PM) += nrf51_pm.o

--- a/drivers/bluetooth/hci/Makefile
+++ b/drivers/bluetooth/hci/Makefile
@@ -1,3 +1,5 @@
+ccflags-y += -I$(srctree)/subsys/bluetooth
+
 obj-$(CONFIG_BLUETOOTH_H4) += h4.o
 obj-$(CONFIG_BLUETOOTH_H5) += h5.o
 obj-$(CONFIG_BLUETOOTH_SPI) += spi.o

--- a/drivers/bluetooth/hci/h4.c
+++ b/drivers/bluetooth/hci/h4.c
@@ -18,11 +18,12 @@
 #include <misc/byteorder.h>
 #include <string.h>
 
-#define BT_DBG_ENABLED IS_ENABLED(CONFIG_BLUETOOTH_DEBUG_HCI_DRIVER)
-#include <bluetooth/log.h>
 #include <bluetooth/bluetooth.h>
 #include <bluetooth/hci.h>
 #include <bluetooth/hci_driver.h>
+
+#define BT_DBG_ENABLED IS_ENABLED(CONFIG_BLUETOOTH_DEBUG_HCI_DRIVER)
+#include "common/log.h"
 
 #include "../util.h"
 

--- a/drivers/bluetooth/hci/h5.c
+++ b/drivers/bluetooth/hci/h5.c
@@ -20,11 +20,12 @@
 #include <misc/printk.h>
 #include <string.h>
 
-#define BT_DBG_ENABLED IS_ENABLED(CONFIG_BLUETOOTH_DEBUG_HCI_DRIVER)
-#include <bluetooth/log.h>
 #include <bluetooth/bluetooth.h>
 #include <bluetooth/hci.h>
 #include <bluetooth/hci_driver.h>
+
+#define BT_DBG_ENABLED IS_ENABLED(CONFIG_BLUETOOTH_DEBUG_HCI_DRIVER)
+#include "common/log.h"
 
 #include "../util.h"
 

--- a/drivers/bluetooth/hci/spi.c
+++ b/drivers/bluetooth/hci/spi.c
@@ -12,9 +12,10 @@
 #include <misc/byteorder.h>
 #include <misc/util.h>
 
-#define BT_DBG_ENABLED IS_ENABLED(CONFIG_BLUETOOTH_DEBUG_HCI_DRIVER)
-#include <bluetooth/log.h>
 #include <bluetooth/hci_driver.h>
+
+#define BT_DBG_ENABLED IS_ENABLED(CONFIG_BLUETOOTH_DEBUG_HCI_DRIVER)
+#include "common/log.h"
 
 #define HCI_CMD			0x01
 #define HCI_ACL			0x02

--- a/drivers/bluetooth/nble/Makefile
+++ b/drivers/bluetooth/nble/Makefile
@@ -1,3 +1,5 @@
+ccflags-y += -I$(srctree)/subsys/bluetooth
+
 obj-$(CONFIG_NBLE) += gap.o conn.o gatt.o uart.o rpc_serialize.o \
 		      rpc_deserialize.o stubs.o smp.o \
 		      ../../../subsys/bluetooth/host/uuid.o

--- a/drivers/bluetooth/nble/conn.c
+++ b/drivers/bluetooth/nble/conn.c
@@ -9,11 +9,12 @@
 #include <atomic.h>
 #include <misc/util.h>
 
-#define BT_DBG_ENABLED IS_ENABLED(CONFIG_NBLE_DEBUG_CONN)
-#include <bluetooth/log.h>
 #include <bluetooth/bluetooth.h>
 #include <bluetooth/conn.h>
 #include <bluetooth/gatt.h>
+
+#define BT_DBG_ENABLED IS_ENABLED(CONFIG_NBLE_DEBUG_CONN)
+#include "common/log.h"
 
 #include "gap_internal.h"
 #include "gatt_internal.h"

--- a/drivers/bluetooth/nble/gap.c
+++ b/drivers/bluetooth/nble/gap.c
@@ -10,12 +10,13 @@
 #include <zephyr.h>
 #include <device.h>
 
-#define BT_DBG_ENABLED IS_ENABLED(CONFIG_NBLE_DEBUG_GAP)
-#include <bluetooth/log.h>
 #include <net/buf.h>
 #include <bluetooth/bluetooth.h>
 #include <bluetooth/conn.h>
 #include <bluetooth/gatt.h>
+
+#define BT_DBG_ENABLED IS_ENABLED(CONFIG_NBLE_DEBUG_GAP)
+#include "common/log.h"
 
 #include "gap_internal.h"
 #include "conn_internal.h"
@@ -41,22 +42,6 @@ static bt_le_scan_cb_t *scan_dev_found_cb;
 struct nble nble;
 
 static const struct bt_storage *storage;
-
-#if defined(CONFIG_NBLE_DEBUG_GAP)
-static const char *bt_addr_le_str(const bt_addr_le_t *addr)
-{
-	static char str[BT_ADDR_LE_STR_LEN];
-
-	bt_addr_le_to_str(addr, str, sizeof(str));
-
-	return str;
-}
-#else
-static inline const char *bt_addr_le_str(const bt_addr_le_t *addr)
-{
-	return NULL;
-}
-#endif /* CONFIG_BLUETOOTH_DEBUG */
 
 static void clear_bonds(const bt_addr_le_t *addr)
 {

--- a/drivers/bluetooth/nble/gatt.c
+++ b/drivers/bluetooth/nble/gatt.c
@@ -8,11 +8,12 @@
 #include <atomic.h>
 #include <misc/byteorder.h>
 
-#define BT_DBG_ENABLED IS_ENABLED(CONFIG_BLUETOOTH_DEBUG_GATT)
-#include <bluetooth/log.h>
 #include <net/buf.h>
 #include <bluetooth/gatt.h>
 #include <bluetooth/att.h>
+
+#define BT_DBG_ENABLED IS_ENABLED(CONFIG_BLUETOOTH_DEBUG_GATT)
+#include "common/log.h"
 
 #include "conn.h"
 #include "conn_internal.h"

--- a/drivers/bluetooth/nble/rpc_deserialize.c
+++ b/drivers/bluetooth/nble/rpc_deserialize.c
@@ -8,8 +8,6 @@
 #include <string.h>
 #include <atomic.h>
 
-#define BT_DBG_ENABLED IS_ENABLED(CONFIG_NBLE_DEBUG_RPC)
-#include <bluetooth/log.h>
 #include <bluetooth/gatt.h>
 /* for bt_security_t */
 #include <bluetooth/conn.h>
@@ -20,6 +18,9 @@
 #else
 #define PRINTK(...)
 #endif /* CONFIG_PRINTK */
+
+#define BT_DBG_ENABLED IS_ENABLED(CONFIG_NBLE_DEBUG_RPC)
+#include "common/log.h"
 
 #include "rpc.h"
 #include "gap_internal.h"

--- a/drivers/bluetooth/nble/smp.c
+++ b/drivers/bluetooth/nble/smp.c
@@ -10,12 +10,13 @@
 #include <zephyr.h>
 #include <device.h>
 
-#define BT_DBG_ENABLED IS_ENABLED(NBLE_DEBUG_GAP)
-#include <bluetooth/log.h>
 #include <bluetooth/bluetooth.h>
 #include <bluetooth/conn.h>
 
 #include <misc/util.h>
+
+#define BT_DBG_ENABLED IS_ENABLED(NBLE_DEBUG_GAP)
+#include "common/log.h"
 
 #include "gap_internal.h"
 #include "conn_internal.h"

--- a/drivers/bluetooth/nble/stubs.c
+++ b/drivers/bluetooth/nble/stubs.c
@@ -8,7 +8,7 @@
 
 #include <bluetooth/gatt.h>
 #include <bluetooth/conn.h>
-#include <bluetooth/log.h>
+#include "common/log.h"
 
 #include "gap_internal.h"
 #include "gatt_internal.h"

--- a/drivers/bluetooth/nble/uart.c
+++ b/drivers/bluetooth/nble/uart.c
@@ -20,7 +20,7 @@
 #include <net/buf.h>
 
 #define BT_DBG_ENABLED IS_ENABLED(CONFIG_BLUETOOTH_DEBUG_HCI_DRIVER)
-#include <bluetooth/log.h>
+#include "common/log.h"
 
 #include "../util.h"
 #include "rpc.h"

--- a/drivers/bluetooth/nrf51_pm.c
+++ b/drivers/bluetooth/nrf51_pm.c
@@ -10,9 +10,10 @@
 #include <gpio.h>
 #include <uart.h>
 
-#define BT_DBG_ENABLED IS_ENABLED(CONFIG_BLUETOOTH_DEBUG_HCI_DRIVER)
-#include <bluetooth/log.h>
 #include <errno.h>
+
+#define BT_DBG_ENABLED IS_ENABLED(CONFIG_BLUETOOTH_DEBUG_HCI_DRIVER)
+#include "common/log.h"
 
 #define NBLE_SWDIO_PIN	6
 #define NBLE_RESET_PIN	NBLE_SWDIO_PIN

--- a/include/bluetooth/rfcomm.h
+++ b/include/bluetooth/rfcomm.h
@@ -21,7 +21,8 @@
 extern "C" {
 #endif
 
-#include <bluetooth/log.h>
+/* FIXME: temporary workaround until thread details are made internal */
+#include "../../subsys/bluetooth/common/log.h"
 #include <bluetooth/buf.h>
 #include <bluetooth/conn.h>
 

--- a/samples/bluetooth/hci_uart/src/Makefile
+++ b/samples/bluetooth/hci_uart/src/Makefile
@@ -1,1 +1,3 @@
+ccflags-y += -I${ZEPHYR_BASE}/subsys/bluetooth
+
 obj-y += main.o

--- a/samples/bluetooth/hci_uart/src/main.c
+++ b/samples/bluetooth/hci_uart/src/main.c
@@ -23,10 +23,11 @@
 #include <net/buf.h>
 #include <bluetooth/bluetooth.h>
 #include <bluetooth/l2cap.h>
-#include <bluetooth/log.h>
 #include <bluetooth/hci.h>
 #include <bluetooth/buf.h>
 #include <bluetooth/hci_raw.h>
+
+#include "common/log.h"
 
 static struct device *hci_uart_dev;
 static BT_STACK_NOINIT(tx_thread_stack, CONFIG_BLUETOOTH_HCI_TX_STACK_SIZE);

--- a/subsys/bluetooth/Kconfig
+++ b/subsys/bluetooth/Kconfig
@@ -85,74 +85,7 @@ config BLUETOOTH_HCI_ACL_FLOW_CONTROL
 	  not run out of incoming ACL buffers.
 endif # BLUETOOTH_CONN
 
-config BLUETOOTH_DEBUG
-	# Virtual/hidden option to make the conditions more intuitive
-	bool
-
-choice
-	prompt "Bluetooth debug type"
-	depends on BLUETOOTH
-	default BLUETOOTH_DEBUG_NONE
-
-config BLUETOOTH_DEBUG_NONE
-	bool "No debug log"
-	help
-	  Select this to disable all Bluetooth debug logs.
-
-config BLUETOOTH_DEBUG_LOG
-	bool "Normal printf-style to console"
-	select BLUETOOTH_DEBUG
-	select PRINTK
-	select SYS_LOG
-	help
-	  This option enables Bluetooth debug going to standard
-	  serial console.
-
-config BLUETOOTH_DEBUG_MONITOR
-	bool "Monitor protocol over UART"
-	select BLUETOOTH_DEBUG
-	select PRINTK
-	select CONSOLE_HAS_DRIVER
-	help
-	  Use a custom logging protocol over the console UART
-	  instead of plain-text output. Requires a special application
-	  on the host side that can decode this protocol. Currently
-	  the 'btmon' tool from BlueZ is capable of doing this.
-
-	  If the target board has two or more external UARTs it is
-	  possible to keep using UART_CONSOLE together with this option,
-	  however if there is only a single external UART then
-	  UART_CONSOLE needs to be disabled (in which case printk/printf
-	  will get encoded into the monitor protocol).
-
-endchoice
-
-if BLUETOOTH_DEBUG
-config BLUETOOTH_DEBUG_COLOR
-	bool "Use colored logs"
-	depends on BLUETOOTH_DEBUG_LOG
-	select SYS_LOG_SHOW_COLOR
-	default y
-	help
-	  Use color in the logs. This requires an ANSI capable terminal.
-
-config BLUETOOTH_MONITOR_ON_DEV_NAME
-	string "Device Name of Bluetooth monitor logging UART"
-	depends on BLUETOOTH_DEBUG_MONITOR
-	default "UART_0"
-	help
-	 This option specifies the name of UART device to be used
-	 for the Bluetooth monitor logging.
-
-config BLUETOOTH_DEBUG_HCI_DRIVER
-	bool "Bluetooth HCI driver debug"
-	depends on BLUETOOTH_DEBUG
-	help
-	  This option enables debug support for the active
-	  Bluetooth HCI driver, including the Controller-side HCI layer
-	  when included in the build.
-endif #BLUETOOTH_DEBUG
-
+source "subsys/bluetooth/common/Kconfig"
 source "subsys/bluetooth/host/Kconfig"
 source "subsys/bluetooth/controller/Kconfig"
 endif # BLUETOOTH_HCI

--- a/subsys/bluetooth/Makefile
+++ b/subsys/bluetooth/Makefile
@@ -1,2 +1,3 @@
+obj-y += common/
 obj-$(CONFIG_BLUETOOTH_HCI) += host/
 obj-$(CONFIG_BLUETOOTH_CONTROLLER) += controller/

--- a/subsys/bluetooth/common/Kconfig
+++ b/subsys/bluetooth/common/Kconfig
@@ -1,0 +1,91 @@
+# Kconfig - Bluetooth common configuration options
+#
+# Copyright (c) 2017 Nordic Semiconductor ASA
+# Copyright (c) 2016 Intel Corporation
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+
+if BLUETOOTH_HCI
+
+config BLUETOOTH_RPA
+	# Virtual/hidden option
+	bool
+	default n
+
+config BLUETOOTH_DEBUG
+	# Virtual/hidden option to make the conditions more intuitive
+	bool
+
+choice
+	prompt "Bluetooth debug type"
+	depends on BLUETOOTH
+	default BLUETOOTH_DEBUG_NONE
+
+config BLUETOOTH_DEBUG_NONE
+	bool "No debug log"
+	help
+	  Select this to disable all Bluetooth debug logs.
+
+config BLUETOOTH_DEBUG_LOG
+	bool "Normal printf-style to console"
+	select BLUETOOTH_DEBUG
+	select PRINTK
+	select SYS_LOG
+	help
+	  This option enables Bluetooth debug going to standard
+	  serial console.
+
+config BLUETOOTH_DEBUG_MONITOR
+	bool "Monitor protocol over UART"
+	select BLUETOOTH_DEBUG
+	select PRINTK
+	select CONSOLE_HAS_DRIVER
+	help
+	  Use a custom logging protocol over the console UART
+	  instead of plain-text output. Requires a special application
+	  on the host side that can decode this protocol. Currently
+	  the 'btmon' tool from BlueZ is capable of doing this.
+
+	  If the target board has two or more external UARTs it is
+	  possible to keep using UART_CONSOLE together with this option,
+	  however if there is only a single external UART then
+	  UART_CONSOLE needs to be disabled (in which case printk/printf
+	  will get encoded into the monitor protocol).
+
+endchoice
+
+if BLUETOOTH_DEBUG
+config BLUETOOTH_DEBUG_COLOR
+	bool "Use colored logs"
+	depends on BLUETOOTH_DEBUG_LOG
+	select SYS_LOG_SHOW_COLOR
+	default y
+	help
+	  Use color in the logs. This requires an ANSI capable terminal.
+
+config BLUETOOTH_MONITOR_ON_DEV_NAME
+	string "Device Name of Bluetooth monitor logging UART"
+	depends on BLUETOOTH_DEBUG_MONITOR
+	default "UART_0"
+	help
+	 This option specifies the name of UART device to be used
+	 for the Bluetooth monitor logging.
+
+config BLUETOOTH_DEBUG_HCI_DRIVER
+	bool "Bluetooth HCI driver debug"
+	depends on BLUETOOTH_DEBUG
+	help
+	  This option enables debug support for the active
+	  Bluetooth HCI driver, including the Controller-side HCI layer
+	  when included in the build.
+
+config BLUETOOTH_DEBUG_RPA
+	bool "Bluetooth Resolvable Private Address (RPA) debug"
+	depends on BLUETOOTH_RPA
+	help
+	  This option enables debug support for the Bluetooth
+	  Resolvable Private Address (RPA) generation and resolution.
+
+endif #BLUETOOTH_DEBUG
+endif # BLUETOOTH_HCI

--- a/subsys/bluetooth/common/Makefile
+++ b/subsys/bluetooth/common/Makefile
@@ -1,0 +1,4 @@
+ccflags-y += -I$(srctree)/subsys/bluetooth
+
+obj-$(CONFIG_BLUETOOTH_DEBUG) += log.o
+obj-$(CONFIG_BLUETOOTH_RPA) += rpa.o

--- a/subsys/bluetooth/common/log.c
+++ b/subsys/bluetooth/common/log.c
@@ -1,6 +1,7 @@
 /* log.c - logging helpers */
 
 /*
+ * Copyright (c) 2017 Nordic Semiconductor ASA
  * Copyright (c) 2016 Intel Corporation
  *
  * SPDX-License-Identifier: Apache-2.0
@@ -15,6 +16,8 @@
 #include <zephyr/types.h>
 #include <zephyr.h>
 #include <misc/util.h>
+#include <bluetooth/bluetooth.h>
+#include <bluetooth/hci.h>
 
 const char *bt_hex(const void *buf, size_t len)
 {
@@ -42,3 +45,32 @@ const char *bt_hex(const void *buf, size_t len)
 
 	return str;
 }
+
+#if defined(CONFIG_BLUETOOTH_DEBUG)
+const char *bt_addr_str(const bt_addr_t *addr)
+{
+	static char bufs[2][18];
+	static u8_t cur;
+	char *str;
+
+	str = bufs[cur++];
+	cur %= ARRAY_SIZE(bufs);
+	bt_addr_to_str(addr, str, sizeof(bufs[cur]));
+
+	return str;
+}
+
+const char *bt_addr_le_str(const bt_addr_le_t *addr)
+{
+	static char bufs[2][27];
+	static u8_t cur;
+	char *str;
+
+	str = bufs[cur++];
+	cur %= ARRAY_SIZE(bufs);
+	bt_addr_le_to_str(addr, str, sizeof(bufs[cur]));
+
+	return str;
+}
+#endif /* CONFIG_BLUETOOTH_DEBUG */
+

--- a/subsys/bluetooth/common/log.h
+++ b/subsys/bluetooth/common/log.h
@@ -3,6 +3,7 @@
  */
 
 /*
+ * Copyright (c) 2017 Nordic Semiconductor ASA
  * Copyright (c) 2015-2016 Intel Corporation
  *
  * SPDX-License-Identifier: Apache-2.0
@@ -13,6 +14,9 @@
 #include <sections.h>
 #include <offsets.h>
 #include <zephyr.h>
+
+#include <bluetooth/bluetooth.h>
+#include <bluetooth/hci.h>
 
 #ifdef __cplusplus
 extern "C" {
@@ -96,8 +100,16 @@ static inline __printf_like(1, 2) void _bt_log_dummy(const char *fmt, ...) {};
 /* This helper is only available when BLUETOOTH_DEBUG is enabled */
 const char *bt_hex(const void *buf, size_t len);
 
+/* These helpers are only safe to be called from internal threads as they're
+ * not multi-threading safe
+ */
+const char *bt_addr_str(const bt_addr_t *addr);
+const char *bt_addr_le_str(const bt_addr_le_t *addr);
+
+
 #ifdef __cplusplus
 }
 #endif
 
 #endif /* __BT_LOG_H */
+

--- a/subsys/bluetooth/common/rpa.c
+++ b/subsys/bluetooth/common/rpa.c
@@ -1,0 +1,101 @@
+/**
+ * @file rpa.c
+ * Resolvable Private Address Generation and Resolution
+ */
+
+/*
+ * Copyright (c) 2017 Nordic Semiconductor ASA
+ * Copyright (c) 2015-2016 Intel Corporation
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <zephyr.h>
+#include <stddef.h>
+#include <errno.h>
+#include <string.h>
+#include <atomic.h>
+#include <misc/util.h>
+#include <misc/byteorder.h>
+#include <misc/stack.h>
+
+#include <tinycrypt/constants.h>
+#include <tinycrypt/aes.h>
+#include <tinycrypt/utils.h>
+#include <tinycrypt/cmac_mode.h>
+
+#define BT_DBG_ENABLED IS_ENABLED(CONFIG_BLUETOOTH_DEBUG_RPA)
+#include "common/log.h"
+
+static int ah(const u8_t irk[16], const u8_t r[3], u8_t out[3])
+{
+	u8_t res[16];
+	int err;
+
+	BT_DBG("irk %s, r %s", bt_hex(irk, 16), bt_hex(r, 3));
+
+	/* r' = padding || r */
+	memcpy(res, r, 3);
+	memset(res + 3, 0, 13);
+
+	err = bt_encrypt_le(irk, res, res);
+	if (err) {
+		return err;
+	}
+
+	/* The output of the random address function ah is:
+	 *      ah(h, r) = e(k, r') mod 2^24
+	 * The output of the security function e is then truncated to 24 bits
+	 * by taking the least significant 24 bits of the output of e as the
+	 * result of ah.
+	 */
+	memcpy(out, res, 3);
+
+	return 0;
+}
+
+#if defined(CONFIG_BLUETOOTH_SMP)
+bool bt_rpa_irk_matches(const u8_t irk[16], const bt_addr_t *addr)
+{
+	u8_t hash[3];
+	int err;
+
+	BT_DBG("IRK %s bdaddr %s", bt_hex(irk, 16), bt_addr_str(addr));
+
+	err = ah(irk, addr->val + 3, hash);
+	if (err) {
+		return false;
+	}
+
+	return !memcmp(addr->val, hash, 3);
+}
+#endif
+
+#if defined(CONFIG_BLUETOOTH_PRIVACY)
+int bt_rpa_create(const u8_t irk[16], bt_addr_t *rpa)
+{
+	int err;
+
+	err = bt_rand(rpa->val + 3, 3);
+	if (err) {
+		return err;
+	}
+
+	BT_ADDR_SET_RPA(rpa);
+
+	err = ah(irk, rpa->val + 3, rpa->val);
+	if (err) {
+		return err;
+	}
+
+	BT_DBG("Created RPA %s", bt_addr_str((bt_addr_t *)rpa->val));
+
+	return 0;
+}
+#else
+int bt_rpa_create(const u8_t irk[16], bt_addr_t *rpa)
+{
+	return -ENOTSUP;
+}
+#endif /* CONFIG_BLUETOOTH_PRIVACY */
+

--- a/subsys/bluetooth/common/rpa.h
+++ b/subsys/bluetooth/common/rpa.h
@@ -1,0 +1,16 @@
+/* rpa.h - Bluetooth Resolvable Private Addresses (RPA) generation and
+ * resolution
+ */
+
+/*
+ * Copyright (c) 2017 Nordic Semiconductor ASA
+ * Copyright (c) 2015-2016 Intel Corporation
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <bluetooth/bluetooth.h>
+#include <bluetooth/hci.h>
+
+bool bt_rpa_irk_matches(const u8_t irk[16], const bt_addr_t *addr);
+int bt_rpa_create(const u8_t irk[16], bt_addr_t *rpa);

--- a/subsys/bluetooth/controller/hal/nrf5/Makefile
+++ b/subsys/bluetooth/controller/hal/nrf5/Makefile
@@ -1,3 +1,4 @@
 ccflags-y += -I$(srctree)/subsys/bluetooth/controller
+ccflags-y += -I$(srctree)/subsys/bluetooth
 
 obj-y += cntr.o ecb.o radio.o rand.o

--- a/subsys/bluetooth/controller/hal/nrf5/cntr.c
+++ b/subsys/bluetooth/controller/hal/nrf5/cntr.c
@@ -8,7 +8,7 @@
 #include <soc.h>
 #include "hal/cntr.h"
 
-#include <bluetooth/log.h>
+#include "common/log.h"
 #include "hal/debug.h"
 
 #ifndef NRF_RTC

--- a/subsys/bluetooth/controller/hal/nrf5/ecb.c
+++ b/subsys/bluetooth/controller/hal/nrf5/ecb.c
@@ -12,7 +12,7 @@
 #include "util/mem.h"
 #include "hal/ecb.h"
 
-#include <bluetooth/log.h>
+#include "common/log.h"
 #include "hal/debug.h"
 
 struct ecb_param {

--- a/subsys/bluetooth/controller/hal/nrf5/rand.c
+++ b/subsys/bluetooth/controller/hal/nrf5/rand.c
@@ -9,7 +9,7 @@
 
 #include "hal/rand.h"
 
-#include <bluetooth/log.h>
+#include "common/log.h"
 #include "hal/debug.h"
 
 #define RAND_RESERVED (4)

--- a/subsys/bluetooth/controller/hci/Makefile
+++ b/subsys/bluetooth/controller/hci/Makefile
@@ -1,4 +1,5 @@
 ccflags-$(CONFIG_BLUETOOTH_LL_SW) += -I$(srctree)/subsys/bluetooth/controller/include
 ccflags-$(CONFIG_BLUETOOTH_LL_SW) += -I$(srctree)/subsys/bluetooth/controller
+ccflags-y += -I$(srctree)/subsys/bluetooth
 
 obj-y += hci.o hci_driver.o

--- a/subsys/bluetooth/controller/hci/hci.c
+++ b/subsys/bluetooth/controller/hci/hci.c
@@ -27,7 +27,7 @@
 #include "hci_internal.h"
 
 #define BT_DBG_ENABLED IS_ENABLED(CONFIG_BLUETOOTH_DEBUG_HCI_DRIVER)
-#include <bluetooth/log.h>
+#include "common/log.h"
 #include "hal/debug.h"
 
 /* opcode of the HCI command currently being processed. The opcode is stored

--- a/subsys/bluetooth/controller/hci/hci_driver.c
+++ b/subsys/bluetooth/controller/hci/hci_driver.c
@@ -20,8 +20,6 @@
 #include <misc/stack.h>
 #include <misc/byteorder.h>
 
-#define BT_DBG_ENABLED IS_ENABLED(CONFIG_BLUETOOTH_DEBUG_HCI_DRIVER)
-#include <bluetooth/log.h>
 #include <bluetooth/bluetooth.h>
 #include <bluetooth/hci.h>
 #include <drivers/bluetooth/hci_driver.h>
@@ -29,6 +27,9 @@
 #ifdef CONFIG_CLOCK_CONTROL_NRF5
 #include <drivers/clock_control/nrf5_clock_control.h>
 #endif
+
+#define BT_DBG_ENABLED IS_ENABLED(CONFIG_BLUETOOTH_DEBUG_HCI_DRIVER)
+#include "common/log.h"
 
 #include "util/util.h"
 #include "hal/ccm.h"

--- a/subsys/bluetooth/controller/ll_sw/Makefile
+++ b/subsys/bluetooth/controller/ll_sw/Makefile
@@ -1,5 +1,6 @@
 ccflags-y += -I$(srctree)/subsys/bluetooth/controller/include
 ccflags-y += -I$(srctree)/subsys/bluetooth/controller
+ccflags-y += -I$(srctree)/subsys/bluetooth
 
 obj-y += crypto.o ctrl.o ll.o
 obj-$(CONFIG_BLUETOOTH_CONTROLLER_STATE_ADV)   += ll_adv.o

--- a/subsys/bluetooth/controller/ll_sw/crypto.c
+++ b/subsys/bluetooth/controller/ll_sw/crypto.c
@@ -7,7 +7,7 @@
 #include <soc.h>
 
 #define BT_DBG_ENABLED IS_ENABLED(CONFIG_BLUETOOTH_DEBUG_HCI_DRIVER)
-#include <bluetooth/log.h>
+#include "common/log.h"
 
 #include "hal/cpu.h"
 #include "hal/rand.h"

--- a/subsys/bluetooth/controller/ll_sw/ctrl.c
+++ b/subsys/bluetooth/controller/ll_sw/ctrl.c
@@ -34,7 +34,7 @@
 #include "ctrl_internal.h"
 
 #define BT_DBG_ENABLED IS_ENABLED(CONFIG_BLUETOOTH_DEBUG_HCI_DRIVER)
-#include <bluetooth/log.h>
+#include "common/log.h"
 
 #define RADIO_TIFS                      150
 #define RADIO_CONN_EVENTS(x, y)		((u16_t)((x) / (y)))

--- a/subsys/bluetooth/controller/ll_sw/ll.c
+++ b/subsys/bluetooth/controller/ll_sw/ll.c
@@ -16,7 +16,7 @@
 #endif
 
 #define BT_DBG_ENABLED IS_ENABLED(CONFIG_BLUETOOTH_DEBUG_HCI_DRIVER)
-#include <bluetooth/log.h>
+#include "common/log.h"
 
 #include "hal/cpu.h"
 #include "hal/cntr.h"

--- a/subsys/bluetooth/controller/ticker/Makefile
+++ b/subsys/bluetooth/controller/ticker/Makefile
@@ -1,3 +1,4 @@
 ccflags-y += -I$(srctree)/subsys/bluetooth/controller
+ccflags-y += -I$(srctree)/subsys/bluetooth
 
 obj-y += ticker.o

--- a/subsys/bluetooth/controller/ticker/ticker.c
+++ b/subsys/bluetooth/controller/ticker/ticker.c
@@ -11,7 +11,7 @@
 #include "hal/cntr.h"
 #include "ticker.h"
 
-#include <bluetooth/log.h>
+#include "common/log.h"
 #include "hal/debug.h"
 
 /*****************************************************************************

--- a/subsys/bluetooth/host/Kconfig
+++ b/subsys/bluetooth/host/Kconfig
@@ -189,6 +189,7 @@ config BLUETOOTH_ATT_TX_MAX
 
 config BLUETOOTH_SMP
 	bool "Security Manager Protocol support"
+	select BLUETOOTH_RPA
 	select TINYCRYPT
 	select TINYCRYPT_AES
 	select TINYCRYPT_AES_CMAC

--- a/subsys/bluetooth/host/Makefile
+++ b/subsys/bluetooth/host/Makefile
@@ -1,8 +1,7 @@
 ccflags-y +=-I$(srctree)/include/drivers
+ccflags-y +=-I$(srctree)/subsys/bluetooth
 
 obj-$(CONFIG_BLUETOOTH_HCI_RAW) += hci_raw.o
-
-obj-$(CONFIG_BLUETOOTH_DEBUG) += log.o
 
 obj-$(CONFIG_BLUETOOTH_DEBUG_MONITOR) += monitor.o
 

--- a/subsys/bluetooth/host/a2dp.c
+++ b/subsys/bluetooth/host/a2dp.c
@@ -17,12 +17,13 @@
 #include <misc/printk.h>
 #include <assert.h>
 
-#define BT_DBG_ENABLED IS_ENABLED(CONFIG_BLUETOOTH_DEBUG_A2DP)
-#include <bluetooth/log.h>
 #include <bluetooth/bluetooth.h>
 #include <bluetooth/l2cap.h>
 #include <bluetooth/avdtp.h>
 #include <bluetooth/a2dp.h>
+
+#define BT_DBG_ENABLED IS_ENABLED(CONFIG_BLUETOOTH_DEBUG_A2DP)
+#include "common/log.h"
 
 #include "hci_core.h"
 #include "conn_internal.h"

--- a/subsys/bluetooth/host/att.c
+++ b/subsys/bluetooth/host/att.c
@@ -14,13 +14,14 @@
 #include <misc/byteorder.h>
 #include <misc/util.h>
 
-#define BT_DBG_ENABLED IS_ENABLED(CONFIG_BLUETOOTH_DEBUG_ATT)
-#include <bluetooth/log.h>
 #include <bluetooth/hci.h>
 #include <bluetooth/bluetooth.h>
 #include <bluetooth/uuid.h>
 #include <bluetooth/gatt.h>
 #include <bluetooth/hci_driver.h>
+
+#define BT_DBG_ENABLED IS_ENABLED(CONFIG_BLUETOOTH_DEBUG_ATT)
+#include "common/log.h"
 
 #include "hci_core.h"
 #include "conn_internal.h"

--- a/subsys/bluetooth/host/avdtp.c
+++ b/subsys/bluetooth/host/avdtp.c
@@ -13,12 +13,13 @@
 #include <misc/byteorder.h>
 #include <misc/util.h>
 
-#define BT_DBG_ENABLED IS_ENABLED(CONFIG_BLUETOOTH_DEBUG_AVDTP)
-#include <bluetooth/log.h>
 #include <bluetooth/hci.h>
 #include <bluetooth/bluetooth.h>
 #include <bluetooth/l2cap.h>
 #include <bluetooth/avdtp.h>
+
+#define BT_DBG_ENABLED IS_ENABLED(CONFIG_BLUETOOTH_DEBUG_AVDTP)
+#include "common/log.h"
 
 #include "hci_core.h"
 #include "conn_internal.h"

--- a/subsys/bluetooth/host/conn.c
+++ b/subsys/bluetooth/host/conn.c
@@ -17,13 +17,14 @@
 #include <misc/stack.h>
 #include <misc/__assert.h>
 
-#define BT_DBG_ENABLED IS_ENABLED(CONFIG_BLUETOOTH_DEBUG_CONN)
-#include <bluetooth/log.h>
 #include <bluetooth/hci.h>
 #include <bluetooth/bluetooth.h>
 #include <bluetooth/conn.h>
 #include <bluetooth/hci_driver.h>
 #include <bluetooth/att.h>
+
+#define BT_DBG_ENABLED IS_ENABLED(CONFIG_BLUETOOTH_DEBUG_CONN)
+#include "common/log.h"
 
 #include "hci_core.h"
 #include "conn_internal.h"

--- a/subsys/bluetooth/host/crypto.c
+++ b/subsys/bluetooth/host/crypto.c
@@ -15,15 +15,15 @@
 #include <bluetooth/hci.h>
 #include <bluetooth/conn.h>
 
-#define BT_DBG_ENABLED IS_ENABLED(CONFIG_BLUETOOTH_DEBUG_HCI_CORE)
-#include <bluetooth/log.h>
-
-#include "hci_core.h"
-
 #include <tinycrypt/constants.h>
 #include <tinycrypt/hmac_prng.h>
 #include <tinycrypt/aes.h>
 #include <tinycrypt/utils.h>
+
+#define BT_DBG_ENABLED IS_ENABLED(CONFIG_BLUETOOTH_DEBUG_HCI_CORE)
+#include "common/log.h"
+
+#include "hci_core.h"
 
 static struct tc_hmac_prng_struct prng;
 

--- a/subsys/bluetooth/host/gatt.c
+++ b/subsys/bluetooth/host/gatt.c
@@ -14,13 +14,14 @@
 #include <misc/byteorder.h>
 #include <misc/util.h>
 
-#define BT_DBG_ENABLED IS_ENABLED(CONFIG_BLUETOOTH_DEBUG_GATT)
-#include <bluetooth/log.h>
 #include <bluetooth/hci.h>
 #include <bluetooth/bluetooth.h>
 #include <bluetooth/uuid.h>
 #include <bluetooth/gatt.h>
 #include <bluetooth/hci_driver.h>
+
+#define BT_DBG_ENABLED IS_ENABLED(CONFIG_BLUETOOTH_DEBUG_GATT)
+#include "common/log.h"
 
 #include "hci_core.h"
 #include "conn_internal.h"

--- a/subsys/bluetooth/host/hci_core.c
+++ b/subsys/bluetooth/host/hci_core.c
@@ -19,8 +19,6 @@
 #include <misc/__assert.h>
 #include <soc.h>
 
-#define BT_DBG_ENABLED IS_ENABLED(CONFIG_BLUETOOTH_DEBUG_HCI_CORE)
-#include <bluetooth/log.h>
 #include <bluetooth/bluetooth.h>
 #include <bluetooth/conn.h>
 #include <bluetooth/l2cap.h>
@@ -28,6 +26,10 @@
 #include <bluetooth/hci_driver.h>
 #include <bluetooth/storage.h>
 
+#define BT_DBG_ENABLED IS_ENABLED(CONFIG_BLUETOOTH_DEBUG_HCI_CORE)
+#include "common/log.h"
+
+#include "common/rpa.h"
 #include "keys.h"
 #include "monitor.h"
 #include "hci_core.h"
@@ -165,34 +167,6 @@ static void report_completed_packet(struct net_buf *buf)
 NET_BUF_POOL_DEFINE(acl_in_pool, CONFIG_BLUETOOTH_ACL_RX_COUNT, ACL_IN_SIZE,
 		    BT_BUF_USER_DATA_MIN, report_completed_packet);
 #endif /* CONFIG_BLUETOOTH_HCI_ACL_FLOW_CONTROL */
-
-#if defined(CONFIG_BLUETOOTH_DEBUG)
-const char *bt_addr_str(const bt_addr_t *addr)
-{
-	static char bufs[2][18];
-	static u8_t cur;
-	char *str;
-
-	str = bufs[cur++];
-	cur %= ARRAY_SIZE(bufs);
-	bt_addr_to_str(addr, str, sizeof(bufs[cur]));
-
-	return str;
-}
-
-const char *bt_addr_le_str(const bt_addr_le_t *addr)
-{
-	static char bufs[2][27];
-	static u8_t cur;
-	char *str;
-
-	str = bufs[cur++];
-	cur %= ARRAY_SIZE(bufs);
-	bt_addr_le_to_str(addr, str, sizeof(bufs[cur]));
-
-	return str;
-}
-#endif /* CONFIG_BLUETOOTH_DEBUG */
 
 struct net_buf *bt_hci_cmd_create(u16_t opcode, u8_t param_len)
 {
@@ -419,7 +393,7 @@ static int le_set_private_addr(void)
 		return 0;
 	}
 
-	err = bt_smp_create_rpa(bt_dev.irk, &rpa);
+	err = bt_rpa_create(bt_dev.irk, &rpa);
 	if (!err) {
 		err = set_random_address(&rpa);
 		if (!err) {

--- a/subsys/bluetooth/host/hci_core.h
+++ b/subsys/bluetooth/host/hci_core.h
@@ -152,12 +152,6 @@ int bt_hci_cmd_send(u16_t opcode, struct net_buf *buf);
 int bt_hci_cmd_send_sync(u16_t opcode, struct net_buf *buf,
 			 struct net_buf **rsp);
 
-/* The helper is only safe to be called from internal threads as it's
- * not multi-threading safe
- */
-const char *bt_addr_str(const bt_addr_t *addr);
-const char *bt_addr_le_str(const bt_addr_le_t *addr);
-
 int bt_le_scan_update(bool fast_scan);
 
 bool bt_addr_le_is_bonded(const bt_addr_le_t *addr);

--- a/subsys/bluetooth/host/hci_ecc.c
+++ b/subsys/bluetooth/host/hci_ecc.c
@@ -18,12 +18,13 @@
 #include <tinycrypt/ecc.h>
 #include <tinycrypt/ecc_dh.h>
 
-#define BT_DBG_ENABLED IS_ENABLED(CONFIG_BLUETOOTH_DEBUG_HCI_CORE)
-#include <bluetooth/log.h>
 #include <bluetooth/bluetooth.h>
 #include <bluetooth/conn.h>
 #include <bluetooth/hci.h>
 #include <bluetooth/hci_driver.h>
+
+#define BT_DBG_ENABLED IS_ENABLED(CONFIG_BLUETOOTH_DEBUG_HCI_CORE)
+#include "common/log.h"
 
 #include "hci_ecc.h"
 #ifdef CONFIG_BLUETOOTH_HCI_RAW

--- a/subsys/bluetooth/host/hci_raw.c
+++ b/subsys/bluetooth/host/hci_raw.c
@@ -9,10 +9,11 @@
 #include <errno.h>
 #include <atomic.h>
 
-#define BT_DBG_ENABLED IS_ENABLED(CONFIG_BLUETOOTH_DEBUG_HCI_CORE)
-#include <bluetooth/log.h>
 #include <bluetooth/hci_driver.h>
 #include <bluetooth/hci_raw.h>
+
+#define BT_DBG_ENABLED IS_ENABLED(CONFIG_BLUETOOTH_DEBUG_HCI_CORE)
+#include "common/log.h"
 
 #include "hci_ecc.h"
 #include "monitor.h"

--- a/subsys/bluetooth/host/hfp_hf.c
+++ b/subsys/bluetooth/host/hfp_hf.c
@@ -12,9 +12,10 @@
 #include <misc/util.h>
 #include <misc/printk.h>
 
-#define BT_DBG_ENABLED IS_ENABLED(CONFIG_BLUETOOTH_DEBUG_HFP_HF)
-#include <bluetooth/log.h>
 #include <bluetooth/conn.h>
+
+#define BT_DBG_ENABLED IS_ENABLED(CONFIG_BLUETOOTH_DEBUG_HFP_HF)
+/* FIXME: #include "common/log.h" */
 #include <bluetooth/rfcomm.h>
 #include <bluetooth/hfp_hf.h>
 

--- a/subsys/bluetooth/host/keys.c
+++ b/subsys/bluetooth/host/keys.c
@@ -11,12 +11,14 @@
 #include <atomic.h>
 #include <misc/util.h>
 
-#define BT_DBG_ENABLED IS_ENABLED(CONFIG_BLUETOOTH_DEBUG_KEYS)
-#include <bluetooth/log.h>
 #include <bluetooth/bluetooth.h>
 #include <bluetooth/conn.h>
 #include <bluetooth/hci.h>
 
+#define BT_DBG_ENABLED IS_ENABLED(CONFIG_BLUETOOTH_DEBUG_KEYS)
+#include "common/log.h"
+
+#include "common/rpa.h"
 #include "hci_core.h"
 #include "smp.h"
 #include "keys.h"
@@ -113,7 +115,7 @@ struct bt_keys *bt_keys_find_irk(const bt_addr_le_t *addr)
 			continue;
 		}
 
-		if (bt_smp_irk_matches(key_pool[i].irk.val, &addr->a)) {
+		if (bt_rpa_irk_matches(key_pool[i].irk.val, &addr->a)) {
 			BT_DBG("RPA %s matches %s",
 			       bt_addr_str(&key_pool[i].irk.rpa),
 			       bt_addr_le_str(&key_pool[i].addr));

--- a/subsys/bluetooth/host/keys_br.c
+++ b/subsys/bluetooth/host/keys_br.c
@@ -11,11 +11,12 @@
 #include <atomic.h>
 #include <misc/util.h>
 
-#define BT_DBG_ENABLED IS_ENABLED(CONFIG_BLUETOOTH_DEBUG_KEYS)
-#include <bluetooth/log.h>
 #include <bluetooth/bluetooth.h>
 #include <bluetooth/conn.h>
 #include <bluetooth/hci.h>
+
+#define BT_DBG_ENABLED IS_ENABLED(CONFIG_BLUETOOTH_DEBUG_KEYS)
+#include "common/log.h"
 
 #include "hci_core.h"
 #include "keys.h"

--- a/subsys/bluetooth/host/l2cap.c
+++ b/subsys/bluetooth/host/l2cap.c
@@ -13,12 +13,13 @@
 #include <misc/byteorder.h>
 #include <misc/util.h>
 
-#define BT_DBG_ENABLED IS_ENABLED(CONFIG_BLUETOOTH_DEBUG_L2CAP)
-#include <bluetooth/log.h>
 #include <bluetooth/hci.h>
 #include <bluetooth/bluetooth.h>
 #include <bluetooth/conn.h>
 #include <bluetooth/hci_driver.h>
+
+#define BT_DBG_ENABLED IS_ENABLED(CONFIG_BLUETOOTH_DEBUG_L2CAP)
+#include "common/log.h"
 
 #include "hci_core.h"
 #include "conn_internal.h"

--- a/subsys/bluetooth/host/l2cap_br.c
+++ b/subsys/bluetooth/host/l2cap_br.c
@@ -13,12 +13,13 @@
 #include <misc/byteorder.h>
 #include <misc/util.h>
 
-#define BT_DBG_ENABLED IS_ENABLED(CONFIG_BLUETOOTH_DEBUG_L2CAP)
-#include <bluetooth/log.h>
 #include <bluetooth/hci.h>
 #include <bluetooth/bluetooth.h>
 #include <bluetooth/conn.h>
 #include <bluetooth/hci_driver.h>
+
+#define BT_DBG_ENABLED IS_ENABLED(CONFIG_BLUETOOTH_DEBUG_L2CAP)
+#include "common/log.h"
 
 #include "hci_core.h"
 #include "conn_internal.h"

--- a/subsys/bluetooth/host/rfcomm.c
+++ b/subsys/bluetooth/host/rfcomm.c
@@ -14,13 +14,14 @@
 #include <misc/util.h>
 #include <misc/stack.h>
 
-#define BT_DBG_ENABLED IS_ENABLED(CONFIG_BLUETOOTH_DEBUG_RFCOMM)
-#include <bluetooth/log.h>
 #include <bluetooth/hci.h>
 #include <bluetooth/bluetooth.h>
 #include <bluetooth/conn.h>
 #include <bluetooth/hci_driver.h>
 #include <bluetooth/l2cap.h>
+
+#define BT_DBG_ENABLED IS_ENABLED(CONFIG_BLUETOOTH_DEBUG_RFCOMM)
+/* FIXME: #include "common/log.h" */
 #include <bluetooth/rfcomm.h>
 
 #include "hci_core.h"

--- a/subsys/bluetooth/host/sdp.c
+++ b/subsys/bluetooth/host/sdp.c
@@ -13,9 +13,10 @@
 #include <misc/byteorder.h>
 #include <misc/__assert.h>
 
-#define BT_DBG_ENABLED IS_ENABLED(CONFIG_BLUETOOTH_DEBUG_SDP)
-#include <bluetooth/log.h>
 #include <bluetooth/sdp.h>
+
+#define BT_DBG_ENABLED IS_ENABLED(CONFIG_BLUETOOTH_DEBUG_SDP)
+#include "common/log.h"
 
 #include "hci_core.h"
 #include "conn_internal.h"

--- a/subsys/bluetooth/host/smp.c
+++ b/subsys/bluetooth/host/smp.c
@@ -19,8 +19,6 @@
 #include <misc/byteorder.h>
 #include <misc/stack.h>
 
-#define BT_DBG_ENABLED IS_ENABLED(CONFIG_BLUETOOTH_DEBUG_SMP)
-#include <bluetooth/log.h>
 #include <net/buf.h>
 #include <bluetooth/hci.h>
 #include <bluetooth/bluetooth.h>
@@ -31,6 +29,9 @@
 #include <tinycrypt/aes.h>
 #include <tinycrypt/utils.h>
 #include <tinycrypt/cmac_mode.h>
+
+#define BT_DBG_ENABLED IS_ENABLED(CONFIG_BLUETOOTH_DEBUG_SMP)
+#include "common/log.h"
 
 #include "hci_core.h"
 #include "ecc.h"
@@ -299,33 +300,6 @@ static struct net_buf *smp_create_pdu(struct bt_conn *conn, u8_t op,
 	hdr->code = op;
 
 	return buf;
-}
-
-static int smp_ah(const u8_t irk[16], const u8_t r[3], u8_t out[3])
-{
-	u8_t res[16];
-	int err;
-
-	BT_DBG("irk %s, r %s", bt_hex(irk, 16), bt_hex(r, 3));
-
-	/* r' = padding || r */
-	memcpy(res, r, 3);
-	memset(res + 3, 0, 13);
-
-	err = bt_encrypt_le(irk, res, res);
-	if (err) {
-		return err;
-	}
-
-	/* The output of the random address function ah is:
-	 *      ah(h, r) = e(k, r') mod 2^24
-	 * The output of the security function e is then truncated to 24 bits
-	 * by taking the least significant 24 bits of the output of e as the
-	 * result of ah.
-	 */
-	memcpy(out, res, 3);
-
-	return 0;
 }
 
 /* Cypher based Message Authentication Code (CMAC) with AES 128 bit
@@ -3628,50 +3602,6 @@ static void bt_smp_encrypt_change(struct bt_l2cap_chan *chan,
 		smp_pairing_complete(smp, 0);
 	}
 }
-
-bool bt_smp_irk_matches(const u8_t irk[16], const bt_addr_t *addr)
-{
-	u8_t hash[3];
-	int err;
-
-	BT_DBG("IRK %s bdaddr %s", bt_hex(irk, 16), bt_addr_str(addr));
-
-	err = smp_ah(irk, addr->val + 3, hash);
-	if (err) {
-		return false;
-	}
-
-	return !memcmp(addr->val, hash, 3);
-}
-
-#if defined(CONFIG_BLUETOOTH_PRIVACY)
-int bt_smp_create_rpa(const u8_t irk[16], bt_addr_t *rpa)
-{
-	int err;
-
-	err = bt_rand(rpa->val + 3, 3);
-	if (err) {
-		return err;
-	}
-
-	BT_ADDR_SET_RPA(rpa);
-
-	err = smp_ah(irk, rpa->val + 3, rpa->val);
-	if (err) {
-		return err;
-	}
-
-	BT_DBG("Created RPA %s", bt_addr_str((bt_addr_t *)rpa->val));
-
-	return 0;
-}
-#else
-int bt_smp_create_rpa(const u8_t irk[16], bt_addr_t *rpa)
-{
-	return -ENOTSUP;
-}
-#endif /* CONFIG_BLUETOOTH_PRIVACY */
-
 
 #if defined(CONFIG_BLUETOOTH_SIGNING)
 /* Sign message using msg as a buffer, len is a size of the message,

--- a/subsys/bluetooth/host/smp.h
+++ b/subsys/bluetooth/host/smp.h
@@ -122,8 +122,6 @@ struct bt_smp_dhkey_check {
 	u8_t e[16];
 } __packed;
 
-bool bt_smp_irk_matches(const u8_t irk[16], const bt_addr_t *addr);
-int bt_smp_create_rpa(const u8_t irk[16], bt_addr_t *rpa);
 int bt_smp_send_pairing_req(struct bt_conn *conn);
 int bt_smp_send_security_req(struct bt_conn *conn);
 void bt_smp_update_keys(struct bt_conn *conn);

--- a/subsys/bluetooth/host/smp_null.c
+++ b/subsys/bluetooth/host/smp_null.c
@@ -14,11 +14,12 @@
 #include <atomic.h>
 #include <misc/util.h>
 
-#define BT_DBG_ENABLED IS_ENABLED(CONFIG_BLUETOOTH_DEBUG_HCI_CORE)
-#include <bluetooth/log.h>
 #include <bluetooth/bluetooth.h>
 #include <bluetooth/conn.h>
 #include <bluetooth/buf.h>
+
+#define BT_DBG_ENABLED IS_ENABLED(CONFIG_BLUETOOTH_DEBUG_HCI_CORE)
+#include "common/log.h"
 
 #include "hci_core.h"
 #include "conn_internal.h"

--- a/subsys/bluetooth/host/storage.c
+++ b/subsys/bluetooth/host/storage.c
@@ -12,10 +12,11 @@
 #include <init.h>
 #include <fs.h>
 
-#define BT_DBG_ENABLED IS_ENABLED(CONFIG_BLUETOOTH_DEBUG_HCI_CORE)
-#include <bluetooth/log.h>
 #include <bluetooth/bluetooth.h>
 #include <bluetooth/storage.h>
+
+#define BT_DBG_ENABLED IS_ENABLED(CONFIG_BLUETOOTH_DEBUG_HCI_CORE)
+#include "common/log.h"
 
 #define STORAGE_ROOT          "/bt"
 


### PR DESCRIPTION
Since more and more code is going to be reused by both the Host and the
Controller, this commit introduces a common/ folder that will contain
everything that is not tied to one of the two components but shared by
them.

Signed-off-by: Carles Cufi <carles.cufi@nordicsemi.no>