### PR TITLE
net: tcp: Handle case when RST is received in any state

### DIFF
--- a/subsys/net/ip/tcp.c
+++ b/subsys/net/ip/tcp.c
@@ -855,16 +855,22 @@ static void validate_state_transition(enum net_tcp_state current,
 			1 << NET_TCP_CLOSED,
 		[NET_TCP_SYN_SENT] = 1 << NET_TCP_CLOSED |
 			1 << NET_TCP_ESTABLISHED |
-			1 << NET_TCP_SYN_RCVD,
+			1 << NET_TCP_SYN_RCVD |
+			1 << NET_TCP_CLOSED,
 		[NET_TCP_ESTABLISHED] = 1 << NET_TCP_CLOSE_WAIT |
-			1 << NET_TCP_FIN_WAIT_1,
-		[NET_TCP_CLOSE_WAIT] = 1 << NET_TCP_LAST_ACK,
+			1 << NET_TCP_FIN_WAIT_1 |
+			1 << NET_TCP_CLOSED,
+		[NET_TCP_CLOSE_WAIT] = 1 << NET_TCP_LAST_ACK |
+			1 << NET_TCP_CLOSED,
 		[NET_TCP_LAST_ACK] = 1 << NET_TCP_CLOSED,
 		[NET_TCP_FIN_WAIT_1] = 1 << NET_TCP_CLOSING |
 			1 << NET_TCP_FIN_WAIT_2 |
-			1 << NET_TCP_TIME_WAIT,
-		[NET_TCP_FIN_WAIT_2] = 1 << NET_TCP_TIME_WAIT,
-		[NET_TCP_CLOSING] = 1 << NET_TCP_TIME_WAIT,
+			1 << NET_TCP_TIME_WAIT |
+			1 << NET_TCP_CLOSED,
+		[NET_TCP_FIN_WAIT_2] = 1 << NET_TCP_TIME_WAIT |
+			1 << NET_TCP_CLOSED,
+		[NET_TCP_CLOSING] = 1 << NET_TCP_TIME_WAIT |
+			1 << NET_TCP_CLOSED,
 		[NET_TCP_TIME_WAIT] = 1 << NET_TCP_CLOSED
 	};
 
@@ -940,4 +946,10 @@ void net_tcp_foreach(net_tcp_cb_t cb, void *user_data)
 	}
 
 	irq_unlock(key);
+}
+
+bool net_tcp_validate_seq(struct net_tcp *tcp, struct net_pkt *pkt)
+{
+	return !net_tcp_seq_greater(tcp->send_ack + get_recv_wnd(tcp),
+				    sys_get_be32(NET_TCP_HDR(pkt)->seq));
 }

--- a/subsys/net/ip/tcp.h
+++ b/subsys/net/ip/tcp.h
@@ -338,6 +338,16 @@ static inline enum net_tcp_state net_tcp_get_state(const struct net_tcp *tcp)
 	return (enum net_tcp_state)tcp->state;
 }
 
+/**
+ * @brief Check if the sequence number is valid i.e., it is inside the window.
+ *
+ * @param tcp TCP context
+ * @param pkt Network packet
+ *
+ * @return true if network packet sequence number is valid, false otherwise
+ */
+bool net_tcp_validate_seq(struct net_tcp *tcp, struct net_pkt *pkt);
+
 #if defined(CONFIG_NET_TCP)
 void net_tcp_init(void);
 #else


### PR DESCRIPTION
We must check if we receive RST in any of the TCP states.
If we do not do this, then the net_context will leak as it
is never released in this case. Receiving RST in any TCP state
is not described in TCP state diagram but this is described in
RFC 793 which says in chapter "Reset Processing" that system
"...aborts the connection and advises the user and goes to the
CLOSED state.".

The validate_state_transitions() function is also changed to
accept this CLOSED state transition from various other states.

Signed-off-by: Jukka Rissanen <jukka.rissanen@linux.intel.com>