### PR TITLE
soc: stm32f3/f4/l4: gpio: Fix unnecessary else statement

### DIFF
--- a/arch/arm/soc/st_stm32/stm32f3/soc_gpio.c
+++ b/arch/arm/soc/st_stm32/stm32f3/soc_gpio.c
@@ -79,7 +79,7 @@ int stm32_gpio_flags_to_conf(int flags, int *pincfg)
 					STM32F3X_PIN_CONFIG_DRIVE_PUSH_PULL_PD;
 			}
 		}
-	} else if (direction == GPIO_DIR_IN) {
+	} else {
 		if (pud == GPIO_PUD_PULL_UP) {
 			*pincfg = STM32F3X_PIN_CONFIG_BIAS_PULL_UP;
 		} else if (pud == GPIO_PUD_PULL_DOWN) {
@@ -88,8 +88,6 @@ int stm32_gpio_flags_to_conf(int flags, int *pincfg)
 			/* floating */
 			*pincfg = STM32F3X_PIN_CONFIG_BIAS_HIGH_IMPEDANCE;
 		}
-	} else {
-		return -ENOTSUP;
 	}
 
 	return 0;

--- a/arch/arm/soc/st_stm32/stm32f4/soc_gpio.c
+++ b/arch/arm/soc/st_stm32/stm32f4/soc_gpio.c
@@ -144,7 +144,7 @@ int stm32_gpio_flags_to_conf(int flags, int *pincfg)
 		} else {
 			*pincfg = STM32F4X_PIN_CONFIG_DRIVE_PUSH_PULL;
 		}
-	} else if (direction == GPIO_DIR_IN) {
+	} else {
 		if (pud == GPIO_PUD_PULL_UP) {
 			*pincfg = STM32F4X_PIN_CONFIG_BIAS_PULL_UP;
 		} else if (pud == GPIO_PUD_PULL_DOWN) {
@@ -152,8 +152,6 @@ int stm32_gpio_flags_to_conf(int flags, int *pincfg)
 		} else {
 			*pincfg = STM32F4X_PIN_CONFIG_BIAS_HIGH_IMPEDANCE;
 		}
-	} else {
-		return -ENOTSUP;
 	}
 
 	return 0;

--- a/arch/arm/soc/st_stm32/stm32l4/soc_gpio.c
+++ b/arch/arm/soc/st_stm32/stm32l4/soc_gpio.c
@@ -139,7 +139,7 @@ int stm32_gpio_flags_to_conf(int flags, int *pincfg)
 
 	if (direction == GPIO_DIR_OUT) {
 		*pincfg = STM32L4X_PIN_CONFIG_PUSH_PULL;
-	} else if (direction == GPIO_DIR_IN) {
+	} else {
 		int pud = flags & GPIO_PUD_MASK;
 
 		/* pull-{up,down} maybe? */
@@ -151,8 +151,6 @@ int stm32_gpio_flags_to_conf(int flags, int *pincfg)
 			/* floating */
 			*pincfg = STM32L4X_PIN_CONFIG_BIAS_HIGH_IMPEDANCE;
 		}
-	} else {
-		return -ENOTSUP;
 	}
 
 	return 0;


### PR DESCRIPTION
The bitfield determining the I/O direction already defines the pin
as either input or output, cannot be none or both at the same time

This issue was reported by Coverity

Coverity-CID: 151970

Signed-off-by: Kumar Gala <kumar.gala@linaro.org>