### PR TITLE
net: context: Call send_cb for TCP after ACK is received

### DIFF
--- a/include/net/net_pkt.h
+++ b/include/net/net_pkt.h
@@ -69,6 +69,9 @@ struct net_pkt {
 
 #if defined(CONFIG_NET_TCP)
 	sys_snode_t sent_list;
+
+	/* Send callback timer, this is set in net_context when data is sent. */
+	struct k_delayed_work send_cb_timer;
 #endif
 
 	u8_t sent       : 1;	/* Is this sent or not

--- a/subsys/net/ip/net_context.c
+++ b/subsys/net/ip/net_context.c
@@ -33,6 +33,8 @@
 #include "udp.h"
 #include "tcp.h"
 
+#include "net_stats.h"
+
 #define NET_MAX_CONTEXT CONFIG_NET_MAX_CONTEXTS
 
 /* Declares a wrapper function for a net_conn callback that refs the
@@ -1595,14 +1597,18 @@ static int send_data(struct net_context *context,
 	if (net_context_get_ip_proto(context) == IPPROTO_TCP) {
 		int ret = net_tcp_send_data(context);
 
-		/* Just make the callback synchronously even if it didn't
-		 * go over the wire.  In theory it would be nice to track
-		 * specific ACK locations in the stream and make the
-		 * callback at that time, but there's nowhere to store the
-		 * potentially-separate token/user_data values right now.
+		/* If there is no timeout, then we can only call the send_cb
+		 * immediately, otherwise wait until we have received ACK
+		 * to the packet or timeout happens. If the timeout is
+		 * K_FOREVER, then do not install cancel worker but wait
+		 * until we have received the ACK.
 		 */
-		if (cb) {
-			cb(context, ret, token, user_data);
+		if (timeout > 0) {
+			k_delayed_work_submit(&pkt->send_cb_timer, timeout);
+		} else if (timeout == K_NO_WAIT) {
+			if (cb) {
+				cb(context, ret, token, user_data);
+			}
 		}
 
 		return ret;
@@ -1812,6 +1818,39 @@ int net_context_sendto(struct net_pkt *pkt,
 #endif /* CONFIG_NET_TCP */
 
 	return sendto(pkt, dst_addr, addrlen, cb, timeout, token, user_data);
+}
+
+void net_context_send_cb(struct net_context *context, void *token, int status)
+{
+	if (!context) {
+		return;
+	}
+
+	if (status < 0) {
+		/* If there was an error, then call the callback always.
+		 * For success call it only for UDP as TCP one will be called
+		 * after we have received ACK.
+		 */
+		if (context->send_cb) {
+			context->send_cb(context, status, token,
+					 context->user_data);
+		}
+	} else {
+#if defined(CONFIG_NET_UDP)
+		if (net_context_get_ip_proto(context) == IPPROTO_UDP) {
+			if (context->send_cb) {
+				context->send_cb(context, status, token,
+						 context->user_data);
+			}
+		}
+#endif
+	}
+
+#if defined(CONFIG_NET_UDP)
+	if (net_context_get_ip_proto(context) == IPPROTO_UDP) {
+		net_stats_update_udp_sent();
+	}
+#endif
 }
 
 static void set_appdata_values(struct net_pkt *pkt, enum net_ip_protocol proto)

--- a/subsys/net/ip/net_if.c
+++ b/subsys/net/ip/net_if.c
@@ -60,20 +60,6 @@ static struct k_thread tx_thread_data;
 #define debug_check_packet(...)
 #endif /* CONFIG_NET_DEBUG_IF */
 
-static inline void net_context_send_cb(struct net_context *context,
-				       void *token, int status)
-{
-	if (context->send_cb) {
-		context->send_cb(context, status, token, context->user_data);
-	}
-
-#if defined(CONFIG_NET_UDP)
-	if (net_context_get_ip_proto(context) == IPPROTO_UDP) {
-		net_stats_update_udp_sent();
-	}
-#endif
-}
-
 static bool net_if_tx(struct net_if *iface)
 {
 	const struct net_if_api *api = iface->dev->driver_api;

--- a/subsys/net/ip/net_private.h
+++ b/subsys/net/ip/net_private.h
@@ -19,6 +19,8 @@ extern void net_pkt_init(void);
 extern void net_if_init(struct k_sem *startup_sync);
 extern void net_if_post_init(void);
 extern void net_context_init(void);
+extern void net_context_send_cb(struct net_context *context, void *token,
+				int status);
 enum net_verdict net_ipv4_process_pkt(struct net_pkt *pkt);
 enum net_verdict net_ipv6_process_pkt(struct net_pkt *pkt);
 extern void net_ipv6_init(void);

--- a/subsys/net/ip/tcp.c
+++ b/subsys/net/ip/tcp.c
@@ -790,6 +790,8 @@ void net_tcp_ack_received(struct net_context *ctx, u32_t ack)
 	bool valid_ack = false;
 
 	while (!sys_slist_is_empty(list)) {
+		void *token;
+
 		head = sys_slist_peek_head(list);
 		pkt = CONTAINER_OF(head, struct net_pkt, sent_list);
 		tcphdr = NET_TCP_HDR(pkt);
@@ -811,6 +813,17 @@ void net_tcp_ack_received(struct net_context *ctx, u32_t ack)
 		}
 
 		sys_slist_remove(list, NULL, head);
+
+		/* Call the network context send callback after we have
+		 * received the ACK for it.
+		 */
+		token = net_pkt_token(pkt);
+		net_pkt_set_token(pkt, NULL);
+
+		k_delayed_work_cancel(&pkt->send_cb_timer);
+
+		net_context_send_cb(net_pkt_context(pkt), token, 0);
+
 		net_pkt_unref(pkt);
 		valid_ack = true;
 	}


### PR DESCRIPTION
Change the TCP send_cb call to be done after we have received
ACK to sent packet. It did not make much sense to call the
callback immediately (synchronously) after we sent the net_pkt.

Signed-off-by: Jukka Rissanen <jukka.rissanen@linux.intel.com>