### PR TITLE
Adjust how post-build data structures are generated

### DIFF
--- a/arch/common/Makefile.gen_isr_tables
+++ b/arch/common/Makefile.gen_isr_tables
@@ -37,31 +37,4 @@ quiet_cmd_gen_irq = IRQ     $@
 $(OUTPUT_SRC): $(PREBUILT_KERNEL) $(GEN_ISR_TABLE)
 	$(call cmd,gen_irq)
 
-# Build system pattern rules will handle building $(OUTPUT_OBJ) from
-# $(OUTPUT_SRC), nothing we need to do here explicitly for its compilation.
-
-# Now link the kernel again, this time with the compiled interrupt tables
-# included, replacing the dummy tables defined in arch/common/isr_tables.c
-#
-# On x86, we just strip out the intList with objcopy -j. However this is not
-# very portable; for instance on ARM this results in a zero-sized program
-# header segment which produces a linker warning and gives QEMU fits.
-# Set to NOLOAD instead, now that we have extracted the information we need
-# from it.
-quiet_cmd_lnk_elf = LINK    $@
-      cmd_lnk_elf = \
-( \
-	$(CC) -T linker.cmd $(OUTPUT_OBJ) @$(KERNEL_NAME).lnk \
-		-o elf.tmp && \
-	$(OBJCOPY) -I $(OUTPUT_FORMAT) -O $(OUTPUT_FORMAT) \
-		--set-section-flags .intList=noload \
-		elf.tmp $@ && \
-	rm -f elf.tmp; \
-)
-
-$(KERNEL_ELF_NAME): $(OUTPUT_OBJ) linker.cmd
-	$(call cmd,lnk_elf)
-	@$(srctree)/scripts/check_link_map.py $(KERNEL_NAME).map
-	@$(WARN_ABOUT_ASSERT)
-	@$(WARN_ABOUT_DEPRECATION)
-
+GENERATED_KERNEL_OBJECT_FILES += $(OUTPUT_OBJ)

--- a/arch/x86/Makefile.idt
+++ b/arch/x86/Makefile.idt
@@ -34,20 +34,7 @@ $(GENIDT):
 staticIdt.o: $(PREBUILT_KERNEL) $(GENIDT)
 	$(call cmd,gen_idt)
 
-quiet_cmd_lnk_elf = LINK    $@
-      cmd_lnk_elf =								\
-(										\
-	$(CC) -T linker.cmd @$(KERNEL_NAME).lnk staticIdt.o			\
-		irq_int_vector_map.o -o $@;					\
-	${OBJCOPY} --change-section-address intList=${CONFIG_PHYS_LOAD_ADDR}	\
-		$@ elf.tmp;							\
-	$(OBJCOPY) -R intList elf.tmp $@;					\
-	rm elf.tmp								\
-)
+irq_int_vector_map.o: staticIdt.o
 
-$(KERNEL_ELF_NAME): staticIdt.o linker.cmd
-	$(call cmd,lnk_elf)
-	@$(srctree)/scripts/check_link_map.py $(KERNEL_NAME).map
-	@$(WARN_ABOUT_ASSERT)
-	@$(WARN_ABOUT_DEPRECATION)
+GENERATED_KERNEL_OBJECT_FILES += staticIdt.o irq_int_vector_map.o
 

--- a/arch/x86/core/irq_manage.c
+++ b/arch/x86/core/irq_manage.c
@@ -26,17 +26,6 @@ extern void _SpuriousIntHandler(void *);
 extern void _SpuriousIntNoErrCodeHandler(void *);
 
 /*
- * These 'dummy' variables are used in kernel_arch_init() to force the
- * inclusion of the spurious interrupt handlers. They *must* be declared in a
- * module other than the one they are used in to get around garbage collection
- * issues and warnings issued some compilers that they aren't used. Therefore
- * care must be taken if they are to be moved. See kernel_structs.h for more
- * information.
- */
-void *_dummy_spurious_interrupt;
-void *_dummy_exception_vector_stub;
-
-/*
  * Place the addresses of the spurious interrupt handlers into the intList
  * section. The genIdt tool can then populate any unused vectors with
  * these routines.

--- a/arch/x86/include/kernel_arch_func.h
+++ b/arch/x86/include/kernel_arch_func.h
@@ -32,33 +32,10 @@ extern "C" {
  */
 static inline void kernel_arch_init(void)
 {
-	extern void *__isr___SpuriousIntHandler;
-	extern void *_dummy_spurious_interrupt;
-	extern void *_dummy_exception_vector_stub;
 	extern char _interrupt_stack[CONFIG_ISR_STACK_SIZE];
 
-	extern void _exception_enter(void);
-
 	_kernel.nested = 0;
-
 	_kernel.irq_stack = _interrupt_stack + CONFIG_ISR_STACK_SIZE;
-	/*
-	 * Forces the inclusion of the spurious interrupt handlers. If a
-	 * reference isn't made then intconnect.o is never pulled in by the
-	 * linker.
-	 */
-
-	_dummy_spurious_interrupt = &__isr___SpuriousIntHandler;
-
-	/*
-	 * Forces the inclusion of the exception vector stub code. If a
-	 * reference isn't made then excstubs.o is never pulled in by the
-	 * linker.
-	 */
-
-	_dummy_exception_vector_stub = &_exception_enter;
-
-
 }
 
 /**

--- a/include/arch/x86/linker.ld
+++ b/include/arch/x86/linker.ld
@@ -194,6 +194,7 @@ SECTIONS
 
 	GROUP_END(RAMABLE_REGION)
 
+#ifndef LINKER_PASS2
 	/* static interrupts */
 	SECTION_PROLOGUE(intList, (OPTIONAL),)
 	{
@@ -205,6 +206,15 @@ SECTIONS
 	KEEP(*(.gnu.linkonce.intList.*))
 	__INT_LIST_END__ = .;
 	} > IDT_LIST
+#else
+	/DISCARD/ :
+	{
+	KEEP(*(.spurIsr))
+	KEEP(*(.spurNoErrIsr))
+	KEEP(*(.intList))
+	KEEP(*(.gnu.linkonce.intList.*))
+	}
+#endif
 
 #ifdef CONFIG_CUSTOM_SECTIONS_LD
 /* Located in project source directory */

--- a/include/linker/intlist.ld
+++ b/include/linker/intlist.ld
@@ -34,12 +34,7 @@
  * }
  */
 
-/* We don't set NOLOAD here, as objcopy will not let us extract the intList
- * section into a file if we do so; the resulting file is 0 bytes. We do so
- * with objcopy in Makefile.gen_isr_tables after we have extracted the
- * information we need.
- */
-
+#ifndef LINKER_PASS2
 SECTION_PROLOGUE(.intList,,)
 {
 	KEEP(*(.irq_info))
@@ -48,4 +43,10 @@ SECTION_PROLOGUE(.intList,,)
 	KEEP(*(.intList))
 	__INT_LIST_END__ = .;
 } GROUP_LINK_IN(IDT_LIST)
-
+#else
+/DISCARD/ :
+{
+	KEEP(*(.irq_info))
+	KEEP(*(.intList))
+}
+#endif


### PR DESCRIPTION
This is in preparation for some forthcoming work to generate MMU page tables in a way similar to how the x86 IDT is generated. This patch set should make adding additional post-build steps much easier and we don't have a bunch of copypasta to generate the final .elf file.