### PR TITLE
Bluetooth: l2cap: Fix initial credit calculaton for MTU < MPS

### DIFF
--- a/subsys/bluetooth/host/l2cap.c
+++ b/subsys/bluetooth/host/l2cap.c
@@ -641,7 +641,8 @@ static void l2cap_chan_rx_init(struct bt_l2cap_le_chan *chan)
 	if (!chan->rx.init_credits) {
 		if (chan->chan.ops->alloc_buf) {
 			/* Auto tune credits to receive a full packet */
-			chan->rx.init_credits = chan->rx.mtu /
+			chan->rx.init_credits = (chan->rx.mtu +
+						 (L2CAP_MAX_LE_MPS - 1)) /
 						L2CAP_MAX_LE_MPS;
 		} else {
 			chan->rx.init_credits = L2CAP_LE_MAX_CREDITS;


### PR DESCRIPTION
When required Rx MTU is less than configured Rx MPS, the
resultant initial credits was 0 which prevented any L2CAP
packet to be received.

Fixed by ceiling the initial credits count in the credits
calculation.

Signed-off-by: Vinayak Kariappa Chettimada <vich@nordicsemi.no>