### PR TITLE
drivers: clock_control: fix AHB2 bus clock activation on stm32f4

### DIFF
--- a/drivers/clock_control/stm32_ll_clock.c
+++ b/drivers/clock_control/stm32_ll_clock.c
@@ -51,11 +51,11 @@ static inline int stm32_clock_control_on(struct device *dev,
 	case STM32_CLOCK_BUS_AHB1:
 		LL_AHB1_GRP1_EnableClock(pclken->enr);
 		break;
-#ifdef CONFIG_SOC_SERIES_STM32L4X
+#if defined(CONFIG_SOC_SERIES_STM32L4X) || defined(CONFIG_SOC_SERIES_STM32F4X)
 	case STM32_CLOCK_BUS_AHB2:
 		LL_AHB2_GRP1_EnableClock(pclken->enr);
 		break;
-#endif /* CONFIG_SOC_SERIES_STM32L4X */
+#endif /* CONFIG_SOC_SERIES_STM32L4X || CONFIG_SOC_SERIES_STM32F4X */
 	case STM32_CLOCK_BUS_APB1:
 		LL_APB1_GRP1_EnableClock(pclken->enr);
 		break;
@@ -84,11 +84,11 @@ static inline int stm32_clock_control_off(struct device *dev,
 	case STM32_CLOCK_BUS_AHB1:
 		LL_AHB1_GRP1_DisableClock(pclken->enr);
 		break;
-#ifdef CONFIG_SOC_SERIES_STM32L4X
+#if defined(CONFIG_SOC_SERIES_STM32L4X) || defined(CONFIG_SOC_SERIES_STM32F4X)
 	case STM32_CLOCK_BUS_AHB2:
 		LL_AHB2_GRP1_DisableClock(pclken->enr);
 		break;
-#endif /* CONFIG_SOC_SERIES_STM32L4X */
+#endif /* CONFIG_SOC_SERIES_STM32L4X || CONFIG_SOC_SERIES_STM32F4X */
 	case STM32_CLOCK_BUS_APB1:
 		LL_APB1_GRP1_DisableClock(pclken->enr);
 		break;


### PR DESCRIPTION
During introduction of LL clock_control driver on stm32f4 series,
AHB2 clock activation/deactivation case was let under stm32l4 condition
preventing activation of this clock with F4 series.
This patch fixes the issue.

Change-Id: I5e488e990d33252f491f8960fc7a798ca3416be2
Signed-off-by: Erwan Gouriou <erwan.gouriou@linaro.org>