### PR TITLE
xtensa: fix XCC build

### DIFF
--- a/arch/xtensa/core/fatal.c
+++ b/arch/xtensa/core/fatal.c
@@ -207,7 +207,7 @@ void exit(int return_code)
 	    "movi a2, %[call]\n\t"
 	    "simcall\n\t"
 	    :
-	    : [code] "r" (return_code), [call] "I" (SYS_exit)
+	    : [code] "r" (return_code), [call] "i" (SYS_exit)
 	    : "a3", "a2");
 #else
 	printk("exit(%d)\n", return_code);


### PR DESCRIPTION
XCC doesn't recognize the "I" compiler constraint but GCC does. Switch
to "i" which is understood by both.

Signed-off-by: Andrew Boie <andrew.p.boie@intel.com>