### PR TITLE
doc: update linux setup on Fedora

### DIFF
--- a/doc/getting_started/installation_linux.rst
+++ b/doc/getting_started/installation_linux.rst
@@ -66,6 +66,11 @@ Install the required packages in a Fedora host system with:
 	 libstdc++-static python3-ply ncurses-devel \
 	 python-yaml python2 dfu-util
 
+.. note::
+
+   If you're using the ISSM icx compiler, to avoid compile-time errors,
+   you must use ncurses 5.x version and not ncurses 6.0 or later.
+
 .. _zephyr_sdk:
 
 Installing the Zephyr Software Development Kit


### PR DESCRIPTION
Document compiler error (and work-around) if using ncurses 6.0 and ISSM
icx compiler on Fedora 25

jira: ZEP-2153

Signed-off-by: David B. Kinder <david.b.kinder@intel.com>