### PR TITLE
net: if: net_if_get_default: Return NULL if no interfaces configured

### DIFF
--- a/subsys/net/ip/net_if.c
+++ b/subsys/net/ip/net_if.c
@@ -321,6 +321,10 @@ struct net_if *net_if_lookup_by_dev(struct device *dev)
 
 struct net_if *net_if_get_default(void)
 {
+	if (__net_if_start == __net_if_end) {
+		return NULL;
+	}
+
 	return __net_if_start;
 }
 


### PR DESCRIPTION
net_if_get_default() was documented as returning "Default interface
or NULL if no interfaces are configured.", but actually didn't
return NULL in the latter case. Instead, it effectively returned
a pointer to random area of memory, shared with other system
structures, so calling functions like net_if_ipv4_set_netmask(),
etc. could trash unrelated memory.

Jira: ZEP-2105

Signed-off-by: Paul Sokolovsky <paul.sokolovsky@linaro.org>