### PR TITLE
boards: disco_l475_iot: fix wrong link to reference manual

### DIFF
--- a/boards/arm/disco_l475_iot1/doc/disco_l475_iot1.rst
+++ b/boards/arm/disco_l475_iot1/doc/disco_l475_iot1.rst
@@ -243,4 +243,4 @@ Access gdb with the following make command:
    http://www.st.com/en/microcontrollers/stm32l475rg.html
 
 .. _STM32L475 reference manual:
-   http://www.st.com/resource/en/reference_manual/DM00031020.pdf
+   http://www.st.com/resource/en/reference_manual/dm00083560.pdf


### PR DESCRIPTION
Link was pointing to wrong reference manual.
Fixed by this commit

Change-Id: I97c6748fcad27ad6f2541ed4cba6141fcbb2576a
Signed-off-by: Erwan Gouriou <erwan.gouriou@linaro.org>