### PR TITLE
arm: Fixup sanity check list of boards

### DIFF
--- a/scripts/sanity_chk/arches/arm.ini
+++ b/scripts/sanity_chk/arches/arm.ini
@@ -8,7 +8,7 @@ platforms = qemu_cortex_m3 frdm_k64f arduino_due nucleo_f103rb stm32_mini_a15
             stm3210c_eval nucleo_f334r8 stm32373c_eval mps2_an385 frdm_kw41z
             sam_e70_xplained curie_ble nrf52_blenano2 hexiwear_kw40z
             cc3220sf_launchxl frdm_kl25z disco_l475_iot1 nucleo_l432kc
-            nucleo_f413zh stm32l496g_disco stm32f4discovery
+            nucleo_f413zh stm32l496g_disco stm32f4_disco 96b_carbon_nrf51
 
 supported_toolchains = zephyr gccarmemb
 


### PR DESCRIPTION
The stm32f4discovery was incorrectly named and should have been
stm32f4_disco.  Also added 96b_carbon_nrf51 that was missing from the
list.

Signed-off-by: Kumar Gala <kumar.gala@linaro.org>