### PR TITLE
Add support for label in devicetree

### DIFF
--- a/dts/common/yaml/uart.yaml
+++ b/dts/common/yaml/uart.yaml
@@ -22,4 +22,9 @@ properties:
       category: required
       description: Clock gate information
       generation: define
+  - label:
+      type: string
+      category: required
+      description: Human readable string describing the device (used by Zephyr for API name)
+      generation: define
 ...

--- a/scripts/extract_dts_includes.py
+++ b/scripts/extract_dts_includes.py
@@ -380,10 +380,14 @@ def extract_single(node_address, yaml, prop, key, prefix, defs, def_label):
     for i, p in enumerate(prop):
       k = convert_string_to_label(key).upper()
       label = def_label + '_' + k
+      if isinstance(p, str):
+         p = "\"" + p + "\""
       prop_def[label + '_' + str(i)] = p
   else:
       k = convert_string_to_label(key).upper()
       label = def_label + '_' +  k
+      if isinstance(prop, str):
+         prop = "\"" + prop + "\""
       prop_def[label] = prop
 
   if node_address in defs:


### PR DESCRIPTION
Fixup issue with string generation and support label in UART so we can use DT to generate device name strings rather than Kconfig.  (Patchset on top of this will convert UARTs over)