### PR TITLE
doc: Update NXP board docs for pyOCD and Segger J-Link

### DIFF
--- a/boards/arm/frdm_k64f/doc/frdm_k64f.rst
+++ b/boards/arm/frdm_k64f/doc/frdm_k64f.rst
@@ -181,33 +181,30 @@ HCI, and the remaining are not used.
 Programming and Debugging
 *************************
 
+The FRDM-K64F includes the :ref:`nxp_opensda` serial and debug adapter built
+into the board to provide debugging, flash programming, and serial
+communication over USB.
+
+To use the pyOCD tools with OpenSDA, follow the instructions in the
+:ref:`nxp_opensda_pyocd` page using the `DAPLink FRDM-K64F Firmware`_.
+
+To use the Segger J-Link tools with OpenSDA, follow the instructions in the
+:ref:`nxp_opensda_jlink` page using the `Segger J-Link OpenSDA V2.1 Firmware`_.
+
 Flashing
 ========
 
-The FRDM-K64F includes an `OpenSDA`_ serial and debug adaptor built into the
-board. The adaptor provides:
-
-- A USB connection to the host computer, which exposes a Mass Storage and an
-  USB Serial Port.
-- A Serial Flash device, which implements the USB flash disk file storage.
-- A physical UART connection which is relayed over interface USB Serial port.
-
-Flashing an application to FRDM-K64F
--------------------------------------
-
-The sample application :ref:`hello_world` is used for this example.
-Build the Zephyr kernel and application:
+This example uses the :ref:`hello_world` sample with the
+:ref:`nxp_opensda_pyocd` tools. Use the ``make flash`` build target to build
+your Zephyr application, invoke the pyOCD flash tool and program your Zephyr
+application to flash.
 
 .. code-block:: console
 
-   $ cd $ZEPHYR_BASE
+   $ cd <zephyr_root_path>
    $ . zephyr-env.sh
-   $ cd $ZEPHYR_BASE/samples/hello_world/
-   $ make BOARD=frdm_k64f
-
-Connect the FRDM-K64F to your host computer using the USB port and you should
-see a USB connection which exposes a Mass Storage (MBED) and a USB Serial Port.
-Copy the generated zephyr.bin in the MBED drive.
+   $ cd samples/hello_world/
+   $ make BOARD=frdm_k64f FLASH_SCRIPT=pyocd.sh flash
 
 Open a serial terminal (minicom, putty, etc.) with the following settings:
 
@@ -223,6 +220,21 @@ the following message:
 
    Hello World! arm
 
+Debugging
+=========
+
+This example uses the :ref:`hello_world` sample with the
+:ref:`nxp_opensda_pyocd` tools. Use the ``make debug`` build target to build
+your Zephyr application, invoke the pyOCD GDB server, attach a GDB client, and
+program your Zephyr application to flash. It will leave you at a gdb prompt.
+
+.. code-block:: console
+
+   $ cd <zephyr_root_path>
+   $ . zephyr-env.sh
+   $ cd samples/hello_world/
+   $ make BOARD=frdm_k64f DEBUG_SCRIPT=pyocd.sh debug
+
 
 .. _FRDM-K64F Website:
    http://www.nxp.com/products/software-and-tools/hardware-development-tools/freedom-development-boards/freedom-development-platform-for-kinetis-k64-k63-and-k24-mcus:FRDM-K64F
@@ -233,9 +245,6 @@ the following message:
 .. _FRDM-K64F Schematics:
    http://www.nxp.com/assets/downloads/data/en/schematics/FRDM-K64F-SCH-E4.pdf
 
-.. _OpenSDA:
-   http://www.nxp.com/products/software-and-tools/hardware-development-tools/startertrak-development-boards/opensda-serial-and-debug-adapter:OPENSDA#FRDM-K64F
-
 .. _K64F Website:
    http://www.nxp.com/products/microcontrollers-and-processors/arm-processors/kinetis-cortex-m-mcus/k-series-performance-m4/k6x-ethernet/kinetis-k64-120-mhz-256kb-sram-microcontrollers-mcus-based-on-arm-cortex-m4-core:K64_120
 
@@ -244,3 +253,9 @@ the following message:
 
 .. _K64F Reference Manual:
    http://www.nxp.com/assets/documents/data/en/reference-manuals/K64P144M120SF5RM.pdf
+
+.. _DAPLink FRDM-K64F Firmware:
+   http://www.nxp.com/assets/downloads/data/en/ide-debug-compile-build-tools/OpenSDAv2.2_DAPLink_frdmk64f_rev0242.zip
+
+.. _Segger J-Link OpenSDA V2.1 Firmware:
+   https://www.segger.com/downloads/jlink/OpenSDA_V2_1.bin

--- a/boards/arm/frdm_k64f/doc/opensda.rst
+++ b/boards/arm/frdm_k64f/doc/opensda.rst
@@ -1,0 +1,421 @@
+.. _nxp_opensda:
+
+NXP OpenSDA
+###########
+
+Overview
+********
+
+`OpenSDA`_ is a serial and debug adapter that is built into several NXP
+evaluation boards. It provides a bridge between your computer (or other USB
+host) and the embedded target processor, which can be used for debugging, flash
+programming, and serial communication, all over a simple USB cable.
+
+The OpenSDA hardware features a Kinetis K2x microcontroller with an integrated
+USB controller. On the software side, it implements a mass storage device
+bootloader which offers a quick and easy way to load OpenSDA applications such
+as flash programmers, run-control debug interfaces, serial to USB converters,
+and more.
+
+Zephyr supports the following debug tools through OpenSDA:
+
+* :ref:`nxp_opensda_pyocd`
+* :ref:`nxp_opensda_jlink`
+
+.. _nxp_opensda_firmware:
+
+Program the Firmware
+====================
+
+Once you've selected which debug tool you wish to use, you need to program the
+associated OpenSDA firmware application to the OpenSDA adapter.
+
+Put the OpenSDA adapter into bootloader mode by holding the reset button while
+you power on the board. After you power on the board, release the reset button
+and a USB mass storage device called **BOOTLOADER** or **MAINTENANCE** will
+enumerate. Copy the OpenSDA firmware application binary to the USB mass storage
+device. Power cycle the board, this time without holding the reset button.
+
+
+.. _nxp_opensda_pyocd:
+
+pyOCD
+*****
+
+pyOCD is an Open Source python 2.7 based library for programming and debugging
+ARM Cortex-M microcontrollers using CMSIS-DAP.
+
+Host Tools and Firmware
+=======================
+
+Follow the instructions in `pyOCD Installation`_ to install the pyOCD flash
+tool and GDB server for your host computer.
+
+Select your board in `OpenSDA`_ and download the latest DAPLink firmware
+application binary. :ref:`nxp_opensda_firmware` with this application.
+
+Flashing
+========
+
+Use the ``make flash`` build target to build your Zephyr application, invoke
+the pyOCD flash tool and program your Zephyr application to flash.
+
+  .. code-block:: console
+
+     $ make FLASH_SCRIPT=pyocd.sh flash
+     Using /home/maureen/zephyr/boards/arm/frdm_k64f/frdm_k64f_defconfig as base
+     Merging /home/maureen/zephyr/tests/include/test.config
+     Merging /home/maureen/zephyr/kernel/configs/kernel.config
+     Merging prj.conf
+     #
+     # configuration written to .config
+     #
+     make[1]: Entering directory '/home/maureen/zephyr'
+     make[2]: Entering directory '/home/maureen/zephyr/samples/hello_world/outdir/frdm_k64f'
+       GEN     ./Makefile
+     scripts/kconfig/conf --silentoldconfig Kconfig
+       Using /home/maureen/zephyr as source for kernel
+       GEN     ./Makefile
+       CHK     include/generated/version.h
+       UPD     include/generated/version.h
+       DTC     dts/arm/frdm_k64f.dts_compiled
+       CHK     include/generated/generated_dts_board.h
+       UPD     include/generated/generated_dts_board.h
+       CHK     misc/generated/configs.c
+       UPD     misc/generated/configs.c
+       CHK     include/generated/offsets.h
+       UPD     include/generated/offsets.h
+       CC      lib/libc/minimal/source/stdlib/strtol.o
+
+     <snip>
+
+       CC      kernel/work_q.o
+       AR      kernel/lib.a
+       CC      src/main.o
+       LD      src/built-in.o
+       AR      libzephyr.a
+       LINK    zephyr.lnk
+       IRQ     isr_tables.c
+       CC      isr_tables.o
+       LINK    zephyr.elf
+       BIN     zephyr.bin
+     Flashing frdm_k64f
+     Flashing Target Device
+     INFO:root:DAP SWD MODE initialised
+     INFO:root:K64F not in secure state
+     INFO:root:ROM table #0 @ 0xe00ff000 cidr=b105100d pidr=4000bb4c4
+     INFO:root:[0]<e000e000:SCS-M4 cidr=b105e00d, pidr=4000bb00c, class=14>
+     WARNING:root:Invalid coresight component, cidr=0x0
+     INFO:root:[1]<e0001000: cidr=0, pidr=0, component invalid>
+     INFO:root:[2]<e0002000:FPB cidr=b105e00d, pidr=4002bb003, class=14>
+     WARNING:root:Invalid coresight component, cidr=0x1010101
+     INFO:root:[3]<e0000000: cidr=1010101, pidr=101010101010101, component invalid>
+     WARNING:root:Invalid coresight component, cidr=0x0
+     INFO:root:[4]<e0040000: cidr=0, pidr=0, component invalid>
+     INFO:root:[5]<e0041000:ETM-M4 cidr=b105900d, pidr=4000bb925, class=9, devtype=13, devid=0>
+     INFO:root:[6]<e0042000:ETB cidr=b105900d, pidr=4003bb907, class=9, devtype=21, devid=0>
+     INFO:root:[7]<e0043000:CSTF cidr=b105900d, pidr=4001bb908, class=9, devtype=12, devid=28>
+     INFO:root:CPU core is Cortex-M4
+     INFO:root:FPU present
+     INFO:root:6 hardware breakpoints, 4 literal comparators
+     INFO:root:4 hardware watchpoints
+     [====================] 100%
+     INFO:root:Programmed 12288 bytes (3 pages) at 10.57 kB/s
+     make[2]: Leaving directory '/home/maureen/zephyr/samples/hello_world/outdir/frdm_k64f'
+     make[1]: Leaving directory '/home/maureen/zephyr'
+
+
+Debugging
+=========
+
+Use the ``make debug`` build target to build your Zephyr application, invoke
+the pyOCD GDB server, attach a GDB client, and program your Zephyr application
+to flash. It will leave you at a gdb prompt.
+
+  .. code-block:: console
+
+     $ make DEBUG_SCRIPT=pyocd.sh debug
+     Using /home/maureen/zephyr/boards/arm/frdm_k64f/frdm_k64f_defconfig as base
+     Merging /home/maureen/zephyr/tests/include/test.config
+     Merging /home/maureen/zephyr/kernel/configs/kernel.config
+     Merging prj.conf
+     #
+     # configuration written to .config
+     #
+     make[1]: Entering directory '/home/maureen/zephyr'
+     make[2]: Entering directory '/home/maureen/zephyr/samples/hello_world/outdir/frdm_k64f'
+       GEN     ./Makefile
+     scripts/kconfig/conf --silentoldconfig Kconfig
+       Using /home/maureen/zephyr as source for kernel
+       GEN     ./Makefile
+       CHK     include/generated/version.h
+       UPD     include/generated/version.h
+       DTC     dts/arm/frdm_k64f.dts_compiled
+       CHK     include/generated/generated_dts_board.h
+       UPD     include/generated/generated_dts_board.h
+       CHK     misc/generated/configs.c
+       UPD     misc/generated/configs.c
+       CHK     include/generated/offsets.h
+       UPD     include/generated/offsets.h
+       CC      lib/libc/minimal/source/stdlib/strtol.o
+
+     <snip>
+
+       CC      kernel/work_q.o
+       AR      kernel/lib.a
+       CC      src/main.o
+       LD      src/built-in.o
+       AR      libzephyr.a
+       LINK    zephyr.lnk
+       IRQ     isr_tables.c
+       CC      isr_tables.o
+       LINK    zephyr.elf
+       BIN     zephyr.bin
+     pyOCD GDB server running on port 3333
+     GNU gdb (GDB) 7.11.0.20160511-git
+     Copyright (C) 2016 Free Software Foundation, Inc.
+     License GPLv3+: GNU GPL version 3 or later <http://gnu.org/licenses/gpl.html>
+     This is free software: you are free to change and redistribute it.
+     There is NO WARRANTY, to the extent permitted by law.  Type "show copying"
+     and "show warranty" for details.
+     This GDB was configured as "--host=x86_64-pokysdk-linux --target=arm-zephyr-eabi".
+     Type "show configuration" for configuration details.
+     For bug reporting instructions, please see:
+     <http://www.gnu.org/software/gdb/bugs/>.
+     Find the GDB manual and other documentation resources online at:
+     <http://www.gnu.org/software/gdb/documentation/>.
+     For help, type "help".
+     Type "apropos word" to search for commands related to "word"...
+     Reading symbols from /home/maureen/zephyr/samples/hello_world/outdir/frdm_k64f/zephyr.elf...done.
+     INFO:root:DAP SWD MODE initialised
+     INFO:root:K64F not in secure state
+     INFO:root:ROM table #0 @ 0xe00ff000 cidr=b105100d pidr=4000bb4c4
+     INFO:root:[0]<e000e000:SCS-M4 cidr=b105e00d, pidr=4000bb00c, class=14>
+     WARNING:root:Invalid coresight component, cidr=0x0
+     INFO:root:[1]<e0001000: cidr=0, pidr=0, component invalid>
+     INFO:root:[2]<e0002000:FPB cidr=b105e00d, pidr=4002bb003, class=14>
+     WARNING:root:Invalid coresight component, cidr=0x1010101
+     INFO:root:[3]<e0000000: cidr=1010101, pidr=101010101010101, component invalid>
+     WARNING:root:Invalid coresight component, cidr=0x0
+     INFO:root:[4]<e0040000: cidr=0, pidr=0, component invalid>
+     INFO:root:[5]<e0041000:ETM-M4 cidr=b105900d, pidr=4000bb925, class=9, devtype=13, devid=0>
+     INFO:root:[6]<e0042000:ETB cidr=b105900d, pidr=4003bb907, class=9, devtype=21, devid=0>
+     INFO:root:[7]<e0043000:CSTF cidr=b105900d, pidr=4001bb908, class=9, devtype=12, devid=28>
+     INFO:root:CPU core is Cortex-M4
+     INFO:root:FPU present
+     INFO:root:6 hardware breakpoints, 4 literal comparators
+     INFO:root:4 hardware watchpoints
+     INFO:root:Telnet: server started on port 4444
+     INFO:root:GDB server started at port:3333
+     Remote debugging using :3333
+     INFO:root:One client connected!
+     k_cpu_idle () at /home/maureen/zephyr/arch/arm/core/cpu_idle.S:135
+     135		bx lr
+     Loading section text, size 0x233e lma 0x0
+     Loading section devconfig, size 0xa8 lma 0x2340
+     Loading section rodata, size 0x5d4 lma 0x23e8
+     Loading section datas, size 0x14 lma 0x29bc
+     Loading section initlevel, size 0xa8 lma 0x29d0
+     [====================] 100%
+     INFO:root:Programmed 45056 bytes (3 pages) at 38.21 kB/s
+     Start address 0x1b64, load size 10870
+     Transfer rate: 9 KB/sec, 1207 bytes/write.
+     (gdb)
+
+
+.. _nxp_opensda_jlink:
+
+Segger J-Link
+*************
+
+Segger offers firmware running on the OpenSDA platform which makes OpenSDA
+compatible to J-Link Lite, allowing users to take advantage of most J-Link
+features like the ultra fast flash download and debugging speed or the
+free-to-use GDB Server, by using a low-cost OpenSDA platform for developing on
+evaluation boards.
+
+Host Tools and Firmware
+=======================
+
+Download and install the `Segger J-Link Software and Documentation Pack`_ to
+get the J-Link GDB server for your host computer.
+
+Select your board in `OpenSDA`_ and download the Segger J-Link firmware
+application binary. :ref:`nxp_opensda_firmware` with this application.
+
+Flashing
+========
+
+The Segger J-Link firmware does not support command line flashing, therefore
+the ``make flash`` build target is not supported.
+
+Debugging
+=========
+
+Use the ``make debug`` build target to build your Zephyr application, invoke
+the J-Link GDB server, attach a GDB client, and program your Zephyr application
+to flash. It will leave you at a gdb prompt.
+
+  .. code-block:: console
+
+     $ make DEBUG_SCRIPT=jlink.sh debug
+     Using /home/maureen/zephyr/boards/arm/frdm_k64f/frdm_k64f_defconfig as base
+     Merging /home/maureen/zephyr/tests/include/test.config
+     Merging /home/maureen/zephyr/kernel/configs/kernel.config
+     Merging prj.conf
+     #
+     # configuration written to .config
+     #
+     make[1]: Entering directory '/home/maureen/zephyr'
+     make[2]: Entering directory '/home/maureen/zephyr/samples/hello_world/outdir/frdm_k64f'
+       GEN     ./Makefile
+     scripts/kconfig/conf --silentoldconfig Kconfig
+       Using /home/maureen/zephyr as source for kernel
+       GEN     ./Makefile
+       CHK     include/generated/version.h
+       UPD     include/generated/version.h
+       DTC     dts/arm/frdm_k64f.dts_compiled
+       CHK     include/generated/generated_dts_board.h
+       UPD     include/generated/generated_dts_board.h
+       CHK     misc/generated/configs.c
+       UPD     misc/generated/configs.c
+       CHK     include/generated/offsets.h
+       UPD     include/generated/offsets.h
+       CC      lib/libc/minimal/source/stdlib/strtol.o
+
+     <snip>
+
+       CC      kernel/work_q.o
+       AR      kernel/lib.a
+       CC      src/main.o
+       LD      src/built-in.o
+       AR      libzephyr.a
+       LINK    zephyr.lnk
+       IRQ     isr_tables.c
+       CC      isr_tables.o
+       LINK    zephyr.elf
+       BIN     zephyr.bin
+     JLink GDB server running on port 2331
+     SEGGER J-Link GDB Server V6.14b Command Line Version
+
+     JLinkARM.dll V6.14b (DLL compiled Mar  9 2017 08:48:20)
+
+     -----GDB Server start settings-----
+     GDBInit file:                  none
+     GDB Server Listening port:     2331
+     SWO raw output listening port: 2332
+     Terminal I/O port:             2333
+     Accept remote connection:      yes
+     Generate logfile:              off
+     Verify download:               off
+     Init regs on start:            off
+     Silent mode:                   off
+     Single run mode:               on
+     Target connection timeout:     0 ms
+     ------J-Link related settings------
+     J-Link Host interface:         USB
+     J-Link script:                 none
+     J-Link settings file:          none
+     ------Target related settings------
+     Target device:                 MK64FN1M0xxx12
+     Target interface:              SWD
+     Target interface speed:        1000kHz
+     Target endian:                 little
+
+     Connecting to J-Link...
+     GNU gdb (GDB) 7.11.0.20160511-git
+     Copyright (C) 2016 Free Software Foundation, Inc.
+     License GPLv3+: GNU GPL version 3 or later <http://gnu.org/licenses/gpl.html>
+     This is free software: you are free to change and redistribute it.
+     There is NO WARRANTY, to the extent permitted by law.  Type "show copying"
+     and "show warranty" for details.
+     This GDB was configured as "--host=x86_64-pokysdk-linux --target=arm-zephyr-eabi".
+     Type "show configuration" for configuration details.
+     For bug reporting instructions, please see:
+     <http://www.gnu.org/software/gdb/bugs/>.
+     Find the GDB manual and other documentation resources online at:
+     <http://www.gnu.org/software/gdb/documentation/>.
+     For help, type "help".
+     Type "apropos word" to search for commands related to "word"...
+     Reading symbols from /home/maureen/zephyr/samples/hello_world/outdir/frdm_k64f/zephyr.elf...done.
+     J-Link is connected.
+     Firmware: J-Link OpenSDA 2 compiled Feb 28 2017 19:27:57
+     Hardware: V1.00
+     S/N: 621000000
+     Checking target voltage...
+     Target voltage: 3.30 V
+     Listening on TCP/IP port 2331
+     Connecting to target...Connected to target
+     Waiting for GDB connection...Remote debugging using :2331
+     Connected to 127.0.0.1
+     Reading all registers
+     Read 4 bytes @ address 0x00001A04 (Data = 0xBF004770)
+     Read 2 bytes @ address 0x000019FC (Data = 0x4040)
+     Read 2 bytes @ address 0x000019FE (Data = 0xF380)
+     Read 2 bytes @ address 0x00001A00 (Data = 0x8811)
+     Read 2 bytes @ address 0x00001A02 (Data = 0xBF30)
+     k_cpu_idle () at /home/maureen/zephyr/arch/arm/core/cpu_idle.S:135
+     135		bx lr
+     Halting target CPU...
+     ...Target halted (PC = 0x00001A04)
+     Loading section text, size 0x233e lma 0x0
+     Downloading 4096 bytes @ address 0x00000000
+     Downloading 4096 bytes @ address 0x00001000
+     Downloading 830 bytes @ address 0x00002000
+     Loading section devconfig, size 0xa8 lma 0x2340
+     Downloading 168 bytes @ address 0x00002340
+     Loading section rodata, size 0x5d4 lma 0x23e8
+     Downloading 1492 bytes @ address 0x000023E8
+     Loading section datas, size 0x14 lma 0x29bc
+     Downloading 20 bytes @ address 0x000029BC
+     Loading section initlevel, size 0xa8 lma 0x29d0
+     Downloading 168 bytes @ address 0x000029D0
+     Start address 0x1b64, load size 10870
+     Writing register (PC = 0x641b0000)
+     Transfer rate: 5307 KB/sec, 1552 bytes/write.
+     Read 4 bytes @ address 0x00001B64 (Data = 0xF3802010)
+     Resetting target
+     Resetting target
+     (gdb)
+
+
+Console
+=======
+
+If you configured your Zephyr application to use a UART console (most boards
+enable this by default), open a serial terminal (minicom, putty, etc.) with the
+following settings:
+
+   - Speed: 115200
+   - Data: 8 bits
+   - Parity: None
+   - Stop bits: 1
+
+If you configured your Zephyr application to use `Segger RTT`_ console instead,
+open telnet:
+
+  .. code-block:: console
+
+     $ telnet localhost 19021
+     Trying 127.0.0.1...
+     Connected to localhost.
+     Escape character is '^]'.
+     SEGGER J-Link V6.14b - Real time terminal output
+     J-Link OpenSDA 2 compiled Feb 28 2017 19:27:57 V1.0, SN=621000000
+     Process: JLinkGDBServer
+
+
+.. _OpenSDA:
+   http://www.nxp.com/opensda
+
+.. _Segger J-Link OpenSDA:
+   https://www.segger.com/opensda.html
+
+.. _Segger J-Link Software and Documentation Pack:
+   https://www.segger.com/downloads/jlink
+
+.. _Segger RTT:
+    https://www.segger.com/jlink-rtt.html
+
+.. _pyOCD Installation:
+   https://github.com/mbedmicro/pyOCD#installation

--- a/boards/arm/frdm_kl25z/doc/frdm_kl25z.rst
+++ b/boards/arm/frdm_kl25z/doc/frdm_kl25z.rst
@@ -115,40 +115,59 @@ The KL25Z UART0 is used for the console.
 Programming and Debugging
 *************************
 
+The FRDM-KL25Z includes the :ref:`nxp_opensda` serial and debug adapter built
+into the board to provide debugging, flash programming, and serial
+communication over USB.
+
+To use the pyOCD tools with OpenSDA, follow the instructions in the
+:ref:`nxp_opensda_pyocd` page using the `DAPLink FRDM-KL25Z Firmware`_.
+
+To use the Segger J-Link tools with OpenSDA, follow the instructions in the
+:ref:`nxp_opensda_jlink` page using the `Segger J-Link OpenSDA V2.1 Firmware`_.
+
 Flashing
 ========
 
-The FRDM-KL25Z includes an `OpenSDA`_ serial and debug adaptor built into the
-board. The adaptor provides:
-
-- A USB connection to the host computer, which exposes on-board Mass Storage and a
-  USB Serial Port.
-- A Serial Flash device, which implements the USB flash disk file storage.
-- A physical UART connection, which is relayed over interface USB Serial port.
-
-Flashing an application to FRDM-KL25Z
--------------------------------------
-
-The sample application :ref:`hello_world` is used for this example.
-Build the Zephyr kernel and application:
+This example uses the :ref:`hello_world` sample with the
+:ref:`nxp_opensda_pyocd` tools. Use the ``make flash`` build target to build
+your Zephyr application, invoke the pyOCD flash tool and program your Zephyr
+application to flash.
 
 .. code-block:: console
 
-   $ cd $ZEPHYR_BASE
+   $ cd <zephyr_root_path>
    $ . zephyr-env.sh
-   $ cd $ZEPHYR_BASE/samples/hello_world/
-   $ make BOARD=frdm_kl25z
+   $ cd samples/hello_world/
+   $ make BOARD=frdm_kl25z FLASH_SCRIPT=pyocd.sh flash
 
-Connect the FRDM-KL25Z to your host computer using the USB port and you should
-see a USB connection which exposes on-board Mass Storage (FRDM-KL25ZJ) and a USB Serial
-Port. Copy the generated zephyr.bin to the FRDM-KL25ZJ drive.
+Open a serial terminal (minicom, putty, etc.) with the following settings:
 
-Run a serial console app on your host computer. Reset the board and you'll see the
-following message written to the serial port:
+- Speed: 115200
+- Data: 8 bits
+- Parity: None
+- Stop bits: 1
+
+Reset the board and you should be able to see on the corresponding Serial Port
+the following message:
 
 .. code-block:: console
 
    Hello World! arm
+
+Debugging
+=========
+
+This example uses the :ref:`hello_world` sample with the
+:ref:`nxp_opensda_pyocd` tools. Use the ``make debug`` build target to build
+your Zephyr application, invoke the pyOCD GDB server, attach a GDB client, and
+program your Zephyr application to flash. It will leave you at a gdb prompt.
+
+.. code-block:: console
+
+   $ cd <zephyr_root_path>
+   $ . zephyr-env.sh
+   $ cd samples/hello_world/
+   $ make BOARD=frdm_kl25z DEBUG_SCRIPT=pyocd.sh debug
 
 
 .. _FRDM-KL25Z Website:
@@ -160,9 +179,6 @@ following message written to the serial port:
 .. _FRDM-KL25Z Schematics:
    http://www.nxp.com/assets/downloads/data/en/schematics/FRDM-KL25Z_SCH_REV_E.pdf
 
-.. _OpenSDA:
-   http://www.nxp.com/assets/documents/data/en/user-guides/OPENSDAUG.pdf
-
 .. _KL25Z Website:
    http://www.nxp.com/products/microcontrollers-and-processors/arm-processors/kinetis-cortex-m-mcus/l-series-ultra-low-power-m0-plus/kinetis-kl2x-48-mhz-usb-ultra-low-power-microcontrollers-mcus-based-on-arm-cortex-m0-plus-core:KL2x?lang_cd=en
 
@@ -171,3 +187,9 @@ following message written to the serial port:
 
 .. _KL25Z Reference Manual:
    http://www.nxp.com/assets/documents/data/en/reference-manuals/KL25P80M48SF0RM.pdf
+
+.. _DAPLink FRDM-KL25Z Firmware:
+   http://www.nxp.com/assets/downloads/data/en/ide-debug-compile-build-tools/OpenSDAv2.2_DAPLink_frdmkl25z_rev0242.zip
+
+.. _Segger J-Link OpenSDA V2.1 Firmware:
+   https://www.segger.com/downloads/jlink/OpenSDA_V2_1.bin

--- a/boards/arm/frdm_kw41z/doc/frdm_kw41z.rst
+++ b/boards/arm/frdm_kw41z/doc/frdm_kw41z.rst
@@ -124,40 +124,35 @@ The KW41Z SoC has one UART, which is used for the console.
 Programming and Debugging
 *************************
 
+The FRDM-KW41Z includes the :ref:`nxp_opensda` serial and debug adapter built
+into the board to provide debugging, flash programming, and serial
+communication over USB.
+
+The :ref:`nxp_opensda_pyocd` tools do not yet support the KW41Z SoC.
+
+To use the Segger J-Link tools with OpenSDA, follow the instructions in the
+:ref:`nxp_opensda_jlink` page using the `Segger J-Link OpenSDA V2.1 Firmware`_.
+
 Flashing
 ========
 
-The FRDM-KW41Z includes an `OpenSDA`_ serial and debug adaptor built into the
-board. The adaptor provides:
+The Segger J-Link firmware does not support command line flashing, therefore
+the ``make flash`` build target is not supported.
 
-- A USB connection to the host computer, which exposes a Mass Storage and an
-  USB Serial Port.
-- A Serial Flash device, which implements the USB flash disk file storage.
-- A physical UART connection which is relayed over interface USB Serial port.
+Debugging
+=========
 
-Flashing an application to FRDM-KW41Z
--------------------------------------
-
-The sample application :ref:`hello_world` is used for this example.
-Build the Zephyr kernel and application:
+This example uses the :ref:`hello_world` sample with the
+:ref:`nxp_opensda_jlink` tools. Use the ``make debug`` build target to build
+your Zephyr application, invoke the J-Link GDB server, attach a GDB client, and
+program your Zephyr application to flash. It will leave you at a gdb prompt.
 
 .. code-block:: console
 
-   $ cd $ZEPHYR_BASE
+   $ cd <zephyr_root_path>
    $ . zephyr-env.sh
-   $ cd $ZEPHYR_BASE/samples/hello_world/
-   $ make BOARD=frdm_kw41z
-
-Connect the FRDM-KW41Z to your host computer using the USB port and you should
-see a USB connection which exposes a Mass Storage (DAPLINK) and a USB Serial
-Port. Copy the generated zephyr.bin in the DAPLINK drive.
-
-Reset the board and you should be able to see on the corresponding Serial Port
-the following message:
-
-.. code-block:: console
-
-   Hello World! arm
+   $ cd samples/hello_world/
+   $ make BOARD=frdm_kw41z DEBUG_SCRIPT=jlink.sh debug
 
 
 .. _FRDM-KW41Z Website:
@@ -169,9 +164,6 @@ the following message:
 .. _FRDM-KW41Z Schematics:
    http://www.nxp.com/assets/downloads/data/en/schematics/FRDM-KW41Z-SCH.pdf
 
-.. _OpenSDA:
-   http://www.nxp.com/products/software-and-tools/hardware-development-tools/startertrak-development-boards/opensda-serial-and-debug-adapter:OPENSDA#FRDM-KW41Z
-
 .. _KW41Z Website:
    http://www.nxp.com/products/microcontrollers-and-processors/arm-processors/kinetis-cortex-m-mcus/w-series-wireless-m0-plus-m4/kinetis-kw41z-2.4-ghz-dual-mode-ble-and-802.15.4-wireless-radio-microcontroller-mcu-based-on-arm-cortex-m0-plus-core:KW41Z
 
@@ -180,3 +172,6 @@ the following message:
 
 .. _KW41Z Reference Manual:
    http://www.nxp.com/assets/documents/data/en/reference-manuals/MKW41Z512RM.pdf
+
+.. _Segger J-Link OpenSDA V2.1 Firmware:
+   https://www.segger.com/downloads/jlink/OpenSDA_V2_1.bin

--- a/boards/arm/hexiwear_k64/doc/hexiwear_k64.rst
+++ b/boards/arm/hexiwear_k64/doc/hexiwear_k64.rst
@@ -144,75 +144,87 @@ HCI, and the remaining are not used.
 Programming and Debugging
 *************************
 
+The Hexiwear docking station includes the :ref:`nxp_opensda` serial and debug
+adapter built into the board to provide debugging, flash programming, and
+serial communication over USB.
+
+To use the pyOCD tools with OpenSDA, follow the instructions in the
+:ref:`nxp_opensda_pyocd` page using the `DAPLink Hexiwear Firmware`_.
+
+To use the Segger J-Link tools with OpenSDA, follow the instructions in the
+:ref:`nxp_opensda_jlink` page using the `Segger J-Link OpenSDA V2.1 Firmware`_.
+
+.. note::
+   The OpenSDA adapter is shared between the K64 and the KW40Z via switches,
+   therefore only one SoC can be flashed, debugged, or have an open console at
+   a time.
+
+Configure the docking station switches to route the desired SoC signals to the
+OpenSDA adapter:
+
++--------+-------------+-------+-----+
+| Switch | Signal      | KW40Z | K64 |
++========+=============+=======+=====+
+| 1      | MK64 SWDIO  | OFF   | ON  |
++--------+-------------+-------+-----+
+| 2      | MK64 RST    | OFF   | ON  |
++--------+-------------+-------+-----+
+| 3      | MKW40 RST   | ON    | OFF |
++--------+-------------+-------+-----+
+| 4      | MKW40 SWDIO | ON    | OFF |
++--------+-------------+-------+-----+
+| 5      | OSDA        | ON    | ON  |
++--------+-------------+-------+-----+
+| 6      | LED1        | OFF   | OFF |
++--------+-------------+-------+-----+
+| 7      | LED2        | OFF   | OFF |
++--------+-------------+-------+-----+
+| 8      | LED3        | OFF   | OFF |
++--------+-------------+-------+-----+
+
 Flashing
 ========
 
-The Hexiwear docking station includes an `OpenSDA`_ serial and debug adaptor
-built into the board. The adaptor provides:
+This example uses the :ref:`hello_world` sample with the
+:ref:`nxp_opensda_pyocd` tools. Use the ``make flash`` build target to build
+your Zephyr application, invoke the pyOCD flash tool and program your Zephyr
+application to flash.
 
-- A USB connection to the host computer, which exposes a Mass Storage and an
-  USB Serial Port.
-- A Serial Flash device, which implements the USB flash disk file storage.
-- A physical UART connection which is relayed over interface USB Serial port.
+.. code-block:: console
 
-.. note::
-   The OpenSDA is shared between the K64 and the KW40Z via switches, therefore
-   only one SoC can be flashed, debugged, or have an open console at a time.
+   $ cd <zephyr_root_path>
+   $ . zephyr-env.sh
+   $ cd samples/hello_world/
+   $ make BOARD=hexiwear_k64 FLASH_SCRIPT=pyocd.sh flash
 
-Flashing an application to Hexiwear
------------------------------------
+Open a serial terminal (minicom, putty, etc.) with the following settings:
 
-#. Build the Zephyr kernel and application:
+- Speed: 115200
+- Data: 8 bits
+- Parity: None
+- Stop bits: 1
 
-   .. code-block:: console
+Reset the board and you should be able to see on the corresponding Serial Port
+the following message:
 
-      $ cd $ZEPHYR_BASE
-      $ . zephyr-env.sh
-      $ cd $ZEPHYR_BASE/samples/hello_world/
-      $ make BOARD=hexiwear_k64
+.. code-block:: console
 
-#. Make sure the docking station USB cable is unplugged.
-#. Attach the Hexiwear board to the docking station.
-#. Configure the docking station switches to route the desired SoC signals to
-   the OpenSDA circuit:
+   Hello World! arm
 
-   +--------+-------------+-------+-----+
-   | Switch | Signal      | KW40Z | K64 |
-   +========+=============+=======+=====+
-   | 1      | MK64 SWDIO  | OFF   | ON  |
-   +--------+-------------+-------+-----+
-   | 2      | MK64 RST    | OFF   | ON  |
-   +--------+-------------+-------+-----+
-   | 3      | MKW40 RST   | ON    | OFF |
-   +--------+-------------+-------+-----+
-   | 4      | MKW40 SWDIO | ON    | OFF |
-   +--------+-------------+-------+-----+
-   | 5      | OSDA        | ON    | ON  |
-   +--------+-------------+-------+-----+
-   | 6      | LED1        | OFF   | OFF |
-   +--------+-------------+-------+-----+
-   | 7      | LED2        | OFF   | OFF |
-   +--------+-------------+-------+-----+
-   | 8      | LED3        | OFF   | OFF |
-   +--------+-------------+-------+-----+
+Debugging
+=========
 
-#. Attach the USB cable and make sure the power switch is ON. A USB Mass
-   Storage Device called DAPLINK will enumerate.
-#. Copy the application binary ``zephyr.bin`` to the DAPLINK drive. The drive
-   will temporarily disappear, then reappear after several seconds.
-#. Open a serial terminal (minicom, putty, etc.) with the following settings:
+This example uses the :ref:`hello_world` sample with the
+:ref:`nxp_opensda_pyocd` tools. Use the ``make debug`` build target to build
+your Zephyr application, invoke the pyOCD GDB server, attach a GDB client, and
+program your Zephyr application to flash. It will leave you at a gdb prompt.
 
-   - Speed: 115200
-   - Data: 8 bits
-   - Parity: None
-   - Stop bits: 1
+.. code-block:: console
 
-#. Reset the SoC. Each SoC has a reset button on docking station. You should
-   see the following message on the Serial Port:
-
-  .. code-block:: console
-
-     Hello World! arm
+   $ cd <zephyr_root_path>
+   $ . zephyr-env.sh
+   $ cd samples/hello_world/
+   $ make BOARD=hexiwear_k64 DEBUG_SCRIPT=pyocd.sh debug
 
 Using Bluetooth
 ***************
@@ -264,9 +276,6 @@ will then see a plot of the heart rate data that updates once per second.
 .. _Hexiwear Schematics:
    http://cdn-docs.mikroe.com/images/c/c0/Sch_Hexiwear_MainBoard_v106c.pdf
 
-.. _OpenSDA:
-   http://www.nxp.com/products/software-and-tools/hardware-development-tools/startertrak-development-boards/opensda-serial-and-debug-adapter:OPENSDA
-
 .. _K64F Website:
    http://www.nxp.com/products/microcontrollers-and-processors/arm-processors/kinetis-cortex-m-mcus/k-series-performance-m4/k6x-ethernet/kinetis-k64-120-mhz-256kb-sram-microcontrollers-mcus-based-on-arm-cortex-m4-core:K64_120
 
@@ -275,6 +284,12 @@ will then see a plot of the heart rate data that updates once per second.
 
 .. _K64F Reference Manual:
    http://www.nxp.com/assets/documents/data/en/reference-manuals/K64P144M120SF5RM.pdf
+
+.. _DAPLink Hexiwear Firmware:
+   https://github.com/MikroElektronika/HEXIWEAR/blob/master/HW/HEXIWEAR_DockingStation/HEXIWEAR_DockingStation_DAPLINK_FW.bin
+
+.. _Segger J-Link OpenSDA V2.1 Firmware:
+   https://www.segger.com/downloads/jlink/OpenSDA_V2_1.bin
 
 .. _KW40Z Connectivity Software:
    https://www.nxp.com/webapp/Download?colCode=KW40Z-CONNECTIVITY-SOFTWARE&appType=license&location=null&fpsp=1&WT_TYPE=Protocol%20Stacks&WT_VENDOR=FREESCALE&WT_FILE_FORMAT=exe&WT_ASSET=Downloads&fileExt=.exe&Parent_nodeId=1432854896956716810497&Parent_pageType=product

--- a/boards/arm/hexiwear_kw40z/doc/hexiwear_kw40z.rst
+++ b/boards/arm/hexiwear_kw40z/doc/hexiwear_kw40z.rst
@@ -75,64 +75,40 @@ using `Segger RTT`_.
 Programming and Debugging
 *************************
 
-The Hexiwear docking station includes an `OpenSDA`_ serial and debug adaptor
-built into the board. Different firmware options are available for the adaptor
-including Segger J-Link and DAPLink. Because `Segger RTT`_ is required for a
-console, the `Segger J-Link OpenSDA`_ firmware is recommended.
+The Hexiwear docking station includes the :ref:`nxp_opensda` serial and debug
+adapter built into the board to provide debugging, flash programming, and
+serial communication over USB.
 
-Segger J-Link
-=============
+To use the pyOCD tools with OpenSDA, follow the instructions in the
+:ref:`nxp_opensda_pyocd` page using the `DAPLink Hexiwear Firmware`_.
 
-Download and install the `Segger J-Link Software and Documentation Pack`_ to
-get the JLinkGDBServer for your host computer.
+To use the Segger J-Link tools with OpenSDA, follow the instructions in the
+:ref:`nxp_opensda_jlink` page using the `Segger J-Link OpenSDA V2.1 Firmware`_.
 
-Put the OpenSDA adapter into bootloader mode by holding the reset button while
-you power on the board. A USB mass storage device called MAINTENANCE will
-enumerate. Copy the `Segger J-Link OpenSDA V2.1 Bootloader`_ to the MAINTENANCE
-drive. Power cycle the board, this time without holding the reset button.
+Because `Segger RTT`_ is required for a console to KW40Z, the J-Link tools are
+recommended.
 
-Start the GDB Server:
+Flashing
+========
 
-  .. code-block:: console
+The Segger J-Link firmware does not support command line flashing, therefore
+the ``make flash`` build target is not supported.
 
-     $ JLinkGDBServer -if swd -device MKW40Z160xxx4
+Debugging
+=========
 
-     SEGGER J-Link GDB Server V6.14b Command Line Version
+This example uses the :ref:`hello_world` sample with the
+:ref:`nxp_opensda_jlink` tools. Use the ``make debug`` build target to build
+your Zephyr application, invoke the J-Link GDB server, attach a GDB client, and
+program your Zephyr application to flash. It will leave you at a gdb prompt.
 
-     JLinkARM.dll V6.14b (DLL compiled Mar  9 2017 08:48:20)
+.. code-block:: console
 
-     -----GDB Server start settings-----
-     GDBInit file:                  none
-     GDB Server Listening port:     2331
-     SWO raw output listening port: 2332
-     Terminal I/O port:             2333
-     Accept remote connection:      yes
-     Generate logfile:              off
-     Verify download:               off
-     Init regs on start:            off
-     Silent mode:                   off
-     Single run mode:               off
-     Target connection timeout:     0 ms
-     ------J-Link related settings------
-     J-Link Host interface:         USB
-     J-Link script:                 none
-     J-Link settings file:          none
-     ------Target related settings------
-     Target device:                 MKW40Z160xxx4
-     Target interface:              SWD
-     Target interface speed:        1000kHz
-     Target endian:                 little
+   $ cd <zephyr_root_path>
+   $ . zephyr-env.sh
+   $ cd samples/hello_world/
+   $ make BOARD=hexiwear_kw40z DEBUG_SCRIPT=jlink.sh debug
 
-     Connecting to J-Link...
-     J-Link is connected.
-     Firmware: J-Link OpenSDA 2 compiled Feb 28 2017 19:27:57
-     Hardware: V1.00
-     S/N: 621000000
-     Checking target voltage...
-     Target voltage: 3.30 V
-     Listening on TCP/IP port 2331
-     Connecting to target...Connected to target
-     Waiting for GDB connection...
 
 In a second terminal, open telnet:
 
@@ -146,31 +122,7 @@ In a second terminal, open telnet:
      J-Link OpenSDA 2 compiled Feb 28 2017 19:27:57 V1.0, SN=621000000
      Process: JLinkGDBServer
 
-In a third terminal, build the Zephyr kernel and application:
-
-   .. code-block:: console
-
-      $ cd $ZEPHYR_BASE
-      $ . zephyr-env.sh
-      $ cd $ZEPHYR_BASE/samples/hello_world/
-      $ make BOARD=hexiwear_kw40z
-
-Start the GDB client:
-
-  .. code-block:: console
-
-     $ arm-zephyr-eabi-gdb outdir/hexiwear_kw40z/zephyr.elf
-
-Connect to the GDB server:
-
-  .. code-block:: console
-
-     (gdb) target remote localhost:2331
-     (gdb) load
-     (gdb) monitor reset
-     (gdb) continue
-
-Back in the second terminal where you opened telnet, you should see:
+Continue program execution in GDB, then in the telnet terminal you should see:
 
   .. code-block:: console
 
@@ -190,14 +142,8 @@ Back in the second terminal where you opened telnet, you should see:
 .. _Segger RTT:
     https://www.segger.com/jlink-rtt.html
 
-.. _OpenSDA:
-   http://www.nxp.com/products/software-and-tools/hardware-development-tools/startertrak-development-boards/opensda-serial-and-debug-adapter:OPENSDA
+.. _DAPLink Hexiwear Firmware:
+   https://github.com/MikroElektronika/HEXIWEAR/blob/master/HW/HEXIWEAR_DockingStation/HEXIWEAR_DockingStation_DAPLINK_FW.bin
 
-.. _Segger J-Link OpenSDA:
-   https://www.segger.com/opensda.html
-
-.. _Segger J-Link OpenSDA V2.1 Bootloader:
+.. _Segger J-Link OpenSDA V2.1 Firmware:
    https://www.segger.com/downloads/jlink/OpenSDA_V2_1.bin
-
-.. _Segger J-Link Software and Documentation Pack:
-   https://www.segger.com/downloads/jlink


### PR DESCRIPTION
Now that NXP boards support 'make flash' and 'make debug' via pyOCD and
Segger J-Link, update all the NXP board docs accordingly. Adds a new
generalized OpenSDA document so certain details don't have to be
repeated for every OpenSDA board.

Signed-off-by: Maureen Helm <maureen.helm@nxp.com>