### PR TITLE
Verify UDP and TCP checksum on receival

### DIFF
--- a/subsys/net/ip/Kconfig
+++ b/subsys/net/ip/Kconfig
@@ -94,6 +94,14 @@ config NET_TCP
 	help
 	The value depends on your network needs.
 
+config NET_TCP_CHECKSUM
+	bool "Check TCP checksum"
+	default y
+	depends on NET_TCP
+	help
+	Enables TCP handler to check TCP checksum. If the checksum is invalid,
+	then the packet is discarded.
+
 config NET_DEBUG_TCP
 	bool "Debug TCP"
 	default n
@@ -126,6 +134,14 @@ config NET_UDP
 	default y
 	help
 	The value depends on your network needs.
+
+config NET_UDP_CHECKSUM
+	bool "Check UDP checksum"
+	default y
+	depends on NET_UDP
+	help
+	Enables UDP handler to check UDP checksum. If the checksum is invalid,
+	then the packet is discarded.
 
 config NET_DEBUG_UDP
 	bool "Debug UDP"

--- a/tests/net/dhcpv4/prj.conf
+++ b/tests/net/dhcpv4/prj.conf
@@ -21,3 +21,6 @@ CONFIG_NET_IPV6=n
 
 CONFIG_NET_MGMT=y
 CONFIG_NET_MGMT_EVENT=y
+
+# Turn off UDP checksum checking as the test fails otherwise.
+CONFIG_NET_UDP_CHECKSUM=n

--- a/tests/net/udp/prj.conf
+++ b/tests/net/udp/prj.conf
@@ -21,3 +21,6 @@ CONFIG_NET_DEBUG_CORE=y
 CONFIG_NET_DEBUG_CONN=y
 #CONFIG_NET_DEBUG_NET_PKT=y
 #CONFIG_NET_DEBUG_IF=y
+
+# Turn off UDP checksum checking as the test fails otherwise.
+CONFIG_NET_UDP_CHECKSUM=n


### PR DESCRIPTION
Make sure that UDP and TCP checksums are correct before accepting the received network packet. This is ON by default but can be turned OFF if needed. This needs to be applied on top of PR #204 