### PR TITLE
arm: core: mpu: Add core support to NXP MPU

### DIFF
--- a/arch/arm/soc/nxp_kinetis/k6x/nxp_mpu_regions.c
+++ b/arch/arm/soc/nxp_kinetis/k6x/nxp_mpu_regions.c
@@ -46,4 +46,5 @@ static struct nxp_mpu_region mpu_regions[] = {
 struct nxp_mpu_config mpu_config = {
 	.num_regions = ARRAY_SIZE(mpu_regions),
 	.mpu_regions = mpu_regions,
+	.sram_region = 3,
 };

--- a/include/arch/arm/cortex_m/mpu/nxp_mpu.h
+++ b/include/arch/arm/cortex_m/mpu/nxp_mpu.h
@@ -25,11 +25,15 @@
 /* Super User Attributes */
 #define MPU_REGION_SU    ((3 << 3) | (3 << 9) | (3 << 15) | (3 << 21))
 
+/* The ENDADDR field has the last 5 bit reserved and set to 1 */
+#define ENDADDR_ROUND(x) (x - 0x1F)
+
 /* Some helper defines for common regions */
 #define REGION_RAM_ATTR	(MPU_REGION_READ | MPU_REGION_WRITE | MPU_REGION_SU)
 #define REGION_FLASH_ATTR (MPU_REGION_READ | MPU_REGION_EXEC | MPU_REGION_SU)
 #define REGION_IO_ATTR (MPU_REGION_READ | MPU_REGION_WRITE | \
 			MPU_REGION_EXEC |  MPU_REGION_SU)
+#define REGION_RO_ATTR (MPU_REGION_READ | MPU_REGION_SU)
 
 /* Region definition data structure */
 struct nxp_mpu_region {
@@ -57,6 +61,8 @@ struct nxp_mpu_config {
 	u32_t num_regions;
 	/* Regions */
 	struct nxp_mpu_region *mpu_regions;
+	/* SRAM Region */
+	u32_t sram_region;
 };
 
 /* Reference to the MPU configuration */

--- a/samples/mpu_stack_guard_test/testcase.ini
+++ b/samples/mpu_stack_guard_test/testcase.ini
@@ -7,4 +7,4 @@ build_only = true
 extra_args = CONF_FILE=prj_stack_guard.conf
 tags = apps
 arch_whitelist = arm
-filter = CONFIG_MPU_STACK_GUARD and CONFIG_ARM_MPU
+filter = CONFIG_MPU_STACK_GUARD


### PR DESCRIPTION
This patch add arm core MPU support to NXP MPU driver.

With this feature it is now possible to enable stack guarding on NXP
MPUs.

Signed-off-by: Vincenzo Frascino <vincenzo.frascino@linaro.org>