### PR TITLE
tests: net: reduce timeout of testcase

### DIFF
--- a/tests/net/lib/dns_resolve/testcase.ini
+++ b/tests/net/lib/dns_resolve/testcase.ini
@@ -2,5 +2,5 @@
 tags = dns net
 build_only = false
 platform_whitelist = qemu_x86
-timeout = 10800
+timeout = 600
 slow = True


### PR DESCRIPTION
Use a reasonable timeout for the testcase.

Signed-off-by: Anas Nashif <anas.nashif@intel.com>