### PR TITLE
CI: Add building hello world on all platforms as part of sanitycheck

### DIFF
--- a/.shippable.yml
+++ b/.shippable.yml
@@ -78,6 +78,9 @@ build:
       - >
           if [ "$JOB_TRIGGERED_BY_NAME" != "code-scan" ]; then
             ./scripts/sanitycheck ${PLATFORMS} ${ARCH} ${COVERAGE} ${SANITYCHECK_OPTIONS} || ./scripts/sanitycheck ${PLATFORMS} ${ARCH} ${COVERAGE} ${SANITYCHECK_OPTIONS_RETRY};
+            if [ "$RUN_COMPLIANCE" = "1" ]; then
+              ./scripts/sanitycheck -l -b -s samples/hello_world/test || ./scripts/sanitycheck ${SANITYCHECK_OPTIONS_RETRY} -l -b -s samples/hello_world/test
+            fi
           fi
       - ccache -s
     on_success:


### PR DESCRIPTION
Do a simple build test on all platforms to make sure they build when we
change things.  This will hopefully catch an errors we run into from
time to time on platforms that don't get typicaly run by sanitycheck.

Signed-off-by: Kumar Gala <kumar.gala@linaro.org>