### PR TITLE
arm: dts: Add zephyr,console to missing device trees

### DIFF
--- a/dts/arm/arduino_due.dts
+++ b/dts/arm/arduino_due.dts
@@ -13,6 +13,7 @@
 	chosen {
 		zephyr,sram = &sram0;
 		zephyr,flash = &flash0;
+		zephyr,console = &uart0;
 	};
 };
 

--- a/dts/arm/cc3200_launchxl.dts
+++ b/dts/arm/cc3200_launchxl.dts
@@ -14,6 +14,7 @@
 	chosen {
 		zephyr,sram = &sram0;
 		zephyr,flash = &flash0;
+		zephyr,console = &uart0;
 	};
 };
 

--- a/dts/arm/cc3220sf_launchxl.dts
+++ b/dts/arm/cc3220sf_launchxl.dts
@@ -14,6 +14,7 @@
 	chosen {
 		zephyr,sram = &sram0;
 		zephyr,flash = &flash1;
+		zephyr,console = &uart0;
 	};
 };
 

--- a/dts/arm/qemu_cortex_m3.dts
+++ b/dts/arm/qemu_cortex_m3.dts
@@ -15,6 +15,7 @@
 	chosen {
 		zephyr,sram = &sram0;
 		zephyr,flash = &flash0;
+		zephyr,console = &uart0;
 	};
 };
 


### PR DESCRIPTION
The chosen property that sets which serial port is being used for the
console device wasn't set.  Add the property "zephyr,console" to the
Arduino Due, CC3200-LaunchXL, CC3220SF-LaunchXL, Hexiware KW40Z, and
QEMU Cortex M3 boards.

Signed-off-by: Kumar Gala <kumar.gala@linaro.org>