### PR TITLE
kernel: sparse fixes

### DIFF
--- a/kernel/include/nano_internal.h
+++ b/kernel/include/nano_internal.h
@@ -40,7 +40,7 @@ static inline void _data_copy(void)
 #endif
 FUNC_NORETURN void _Cstart(void);
 
-extern void _thread_entry(void (*)(void *, void *, void *),
+extern FUNC_NORETURN void _thread_entry(void (*)(void *, void *, void *),
 			  void *, void *, void *);
 
 extern void _new_thread(struct k_thread *thread, char *pStack, size_t stackSize,

--- a/kernel/mailbox.c
+++ b/kernel/mailbox.c
@@ -50,7 +50,9 @@ static inline void _mbox_async_free(struct k_mbox_async *async)
 extern struct k_mbox _k_mbox_list_start[];
 extern struct k_mbox _k_mbox_list_end[];
 
+#ifdef CONFIG_OBJECT_TRACING
 struct k_mbox *_trace_list_k_mbox;
+#endif	/* CONFIG_OBJECT_TRACING */
 
 #if (CONFIG_NUM_MBOX_ASYNC_MSGS > 0) || \
 	defined(CONFIG_OBJECT_TRACING)

--- a/kernel/mem_slab.c
+++ b/kernel/mem_slab.c
@@ -17,7 +17,9 @@
 extern struct k_mem_slab _k_mem_slab_list_start[];
 extern struct k_mem_slab _k_mem_slab_list_end[];
 
+#ifdef CONFIG_OBJECT_TRACING
 struct k_mem_slab *_trace_list_k_mem_slab;
+#endif	/* CONFIG_OBJECT_TRACING */
 
 /**
  * @brief Initialize kernel memory slab subsystem.

--- a/kernel/msg_q.c
+++ b/kernel/msg_q.c
@@ -23,9 +23,9 @@
 extern struct k_msgq _k_msgq_list_start[];
 extern struct k_msgq _k_msgq_list_end[];
 
-struct k_msgq *_trace_list_k_msgq;
-
 #ifdef CONFIG_OBJECT_TRACING
+
+struct k_msgq *_trace_list_k_msgq;
 
 /*
  * Complete initialization of statically defined message queues.

--- a/kernel/mutex.c
+++ b/kernel/mutex.c
@@ -43,9 +43,9 @@
 extern struct k_mutex _k_mutex_list_start[];
 extern struct k_mutex _k_mutex_list_end[];
 
-struct k_mutex *_trace_list_k_mutex;
-
 #ifdef CONFIG_OBJECT_TRACING
+
+struct k_mutex *_trace_list_k_mutex;
 
 /*
  * Complete initialization of statically defined mutexes.

--- a/kernel/pipes.c
+++ b/kernel/pipes.c
@@ -37,7 +37,9 @@ struct k_pipe_async {
 extern struct k_pipe _k_pipe_list_start[];
 extern struct k_pipe _k_pipe_list_end[];
 
+#ifdef CONFIG_OBJECT_TRACING
 struct k_pipe *_trace_list_k_pipe;
+#endif	/* CONFIG_OBJECT_TRACING */
 
 #if (CONFIG_NUM_PIPE_ASYNC_MSGS > 0)
 

--- a/kernel/queue.c
+++ b/kernel/queue.c
@@ -24,9 +24,9 @@
 extern struct k_queue _k_queue_list_start[];
 extern struct k_queue _k_queue_list_end[];
 
-struct k_queue *_trace_list_k_queue;
-
 #ifdef CONFIG_OBJECT_TRACING
+
+struct k_queue *_trace_list_k_queue;
 
 /*
  * Complete initialization of statically defined queues.

--- a/kernel/sched.c
+++ b/kernel/sched.c
@@ -221,6 +221,23 @@ void _pend_current_thread(_wait_q_t *wait_q, s32_t timeout)
 	_pend_thread(_current, wait_q, timeout);
 }
 
+#if defined(CONFIG_PREEMPT_ENABLED) && defined(CONFIG_KERNEL_DEBUG)
+/* debug aid */
+static void _dump_ready_q(void)
+{
+	K_DEBUG("bitmaps: ");
+	for (int bitmap = 0; bitmap < K_NUM_PRIO_BITMAPS; bitmap++) {
+		K_DEBUG("%x", _ready_q.prio_bmap[bitmap]);
+	}
+	K_DEBUG("\n");
+	for (int prio = 0; prio < K_NUM_PRIORITIES; prio++) {
+		K_DEBUG("prio: %d, head: %p\n",
+			prio - _NUM_COOP_PRIO,
+			sys_dlist_peek_head(&_ready_q.q[prio]));
+	}
+}
+#endif  /* CONFIG_PREEMPT_ENABLED && CONFIG_KERNEL_DEBUG */
+
 /*
  * Check if there is a thread of higher prio than the current one. Should only
  * be called if we already know that the current thread is preemptible.
@@ -231,8 +248,9 @@ int __must_switch_threads(void)
 	K_DEBUG("current prio: %d, highest prio: %d\n",
 		_current->base.prio, _get_highest_ready_prio());
 
-	extern void _dump_ready_q(void);
+#ifdef CONFIG_KERNEL_DEBUG
 	_dump_ready_q();
+#endif  /* CONFIG_KERNEL_DEBUG */
 
 	return _is_prio_higher(_get_highest_ready_prio(), _current->base.prio);
 #else
@@ -362,21 +380,6 @@ void k_wakeup(k_tid_t thread)
 k_tid_t k_current_get(void)
 {
 	return _current;
-}
-
-/* debug aid */
-void _dump_ready_q(void)
-{
-	K_DEBUG("bitmaps: ");
-	for (int bitmap = 0; bitmap < K_NUM_PRIO_BITMAPS; bitmap++) {
-		K_DEBUG("%x", _ready_q.prio_bmap[bitmap]);
-	}
-	K_DEBUG("\n");
-	for (int prio = 0; prio < K_NUM_PRIORITIES; prio++) {
-		K_DEBUG("prio: %d, head: %p\n",
-			prio - _NUM_COOP_PRIO,
-			sys_dlist_peek_head(&_ready_q.q[prio]));
-	}
 }
 
 #ifdef CONFIG_TIMESLICING

--- a/kernel/sem.c
+++ b/kernel/sem.c
@@ -29,9 +29,9 @@
 extern struct k_sem _k_sem_list_start[];
 extern struct k_sem _k_sem_list_end[];
 
-struct k_sem *_trace_list_k_sem;
-
 #ifdef CONFIG_OBJECT_TRACING
+
+struct k_sem *_trace_list_k_sem;
 
 /*
  * Complete initialization of statically defined semaphores.

--- a/kernel/stack.c
+++ b/kernel/stack.c
@@ -21,9 +21,9 @@
 extern struct k_stack _k_stack_list_start[];
 extern struct k_stack _k_stack_list_end[];
 
-struct k_stack *_trace_list_k_stack;
-
 #ifdef CONFIG_OBJECT_TRACING
+
+struct k_stack *_trace_list_k_stack;
 
 /*
  * Complete initialization of statically defined stacks.

--- a/kernel/timer.c
+++ b/kernel/timer.c
@@ -102,7 +102,7 @@ void k_timer_init(struct k_timer *timer,
 	_init_timeout(&timer->timeout, _timer_expiration_handler);
 	SYS_TRACING_OBJ_INIT(k_timer, timer);
 
-	timer->user_data = 0;
+	timer->user_data = NULL;
 }
 
 

--- a/kernel/timer.c
+++ b/kernel/timer.c
@@ -12,9 +12,9 @@
 extern struct k_timer _k_timer_list_start[];
 extern struct k_timer _k_timer_list_end[];
 
-struct k_timer *_trace_list_k_timer;
-
 #ifdef CONFIG_OBJECT_TRACING
+
+struct k_timer *_trace_list_k_timer;
 
 /*
  * Complete initialization of statically defined timers.

--- a/misc/printk.c
+++ b/misc/printk.c
@@ -47,7 +47,7 @@ static int _nop_char_out(int c)
 	return 0;
 }
 
-int (*_char_out)(int) = _nop_char_out;
+static int (*_char_out)(int) = _nop_char_out;
 
 /**
  * @brief Install the character output routine for printk

--- a/tests/kernel/common/src/printk.c
+++ b/tests/kernel/common/src/printk.c
@@ -11,7 +11,8 @@
 static int pos;
 char ram_console[BUF_SZ];
 
-extern int (*_char_out)(int);
+void __printk_hook_install(int (*fn)(int));
+void *__printk_get_hook(void);
 int (*_old_char_out)(int);
 
 char *expected = "22 113 10000 32768 40000 22\n"
@@ -60,8 +61,8 @@ void printk_test(void)
 {
 	int count;
 
-	_old_char_out = _char_out;
-	_char_out = ram_console_out;
+	_old_char_out = __printk_get_hook();
+	__printk_hook_install(ram_console_out);
 
 	printk("%zu %hhu %hu %u %lu %llu\n", stv, uc, usi, ui, ul, ull);
 	printk("%c %hhd %hd %d %ld %lld\n", c, c, ssi, si, sl, sll);


### PR DESCRIPTION
Fix some issues identified with sparse.

I'm using the following revision of sparse:
```
commit 14964df5373292af78b29529d4fc7e1a26b67a97
Author: Luc Van Oostenryck <luc.vanoostenryck@gmail.com>
Date:   Sun Mar 19 19:01:18 2017 +0100
```
There is also a bunch of warnings raised for minimal libc. My bet is that most of these are false positive and would be better addressed in sparse.
