### PR TITLE
doc: identify release version in generated docs

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -335,8 +335,10 @@ breathe_projects = {
 }
 breathe_default_project = "Zephyr"
 
+# docs_title is used in the breadcrumb title in the zephyr docs theme
 html_context = {
     'show_license': html_show_license,
+    'docs_title': 'Docs / ' + version,
 }
 
 extlinks = {'jira': ('https://jira.zephyrproject.org/browse/%s', '')}


### PR DESCRIPTION
It's not obvious which kernel release version you're reading about in the
documentation.  Add the version info in the breadcrumb header (instead
of "Home / Docs / Subsystems /" show as "Home / Docs (1.8) / Subsystems /").

(Depends on docs-theme PR-9, but can be merged now with no ill-effect)

Signed-off-by: David B. Kinder <david.b.kinder@intel.com>