### PR TITLE
tests/zoap: fix net_pkt leak in test_observer_client()

### DIFF
--- a/tests/net/lib/zoap/src/main.c
+++ b/tests/net/lib/zoap/src/main.c
@@ -903,7 +903,7 @@ static int test_observer_client(void)
 done:
 	net_pkt_unref(pkt);
 	if (rsp_pkt) {
-		net_pkt_unref(pkt);
+		net_pkt_unref(rsp_pkt);
 	}
 
 	TC_END_RESULT(result);


### PR DESCRIPTION
Signed-off-by: Michael Scott <michael.scott@linaro.org>