### PR TITLE
Bluetooth: Fix auto PHY update on connection

### DIFF
--- a/subsys/bluetooth/host/conn_internal.h
+++ b/subsys/bluetooth/host/conn_internal.h
@@ -24,6 +24,7 @@ enum {
 	BT_CONN_BR_NOBOND,		/* SSP no bond pairing tracker */
 	BT_CONN_BR_PAIRING_INITIATOR,	/* local host starts authentication */
 	BT_CONN_CLEANUP,                /* Disconnected, pending cleanup */
+	BT_CONN_AUTO_PHY_UPDATE,        /* Auto-update PHY */
 
 	/* Total number of flags - must be at the end of the enum */
 	BT_CONN_NUM_FLAGS,


### PR DESCRIPTION
Since the PHY update complete event can be generated due to the
procedure being initiated by the peer, use a flag to
differentiate between local auto update initiated on connection
complete versus peer initiated anytime in the connection. This
is necessary to avoid repeated initiation of auto-update
procedures intended only to be issued on connection complete.

Signed-off-by: Vinayak Kariappa Chettimada <vich@nordicsemi.no>