### PR TITLE
build: Treat MSYS2 build as a UNIX build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -27,7 +27,6 @@ UNAME := $(shell uname)
 ifeq (MSYS, $(findstring MSYS, $(UNAME)))
 DISABLE_TRYRUN=y
 HOST_OS=MSYS
-PWD_OPT=-W
 else ifeq (MINGW, $(findstring MINGW, $(UNAME)))
 HOST_OS=MINGW
 PWD_OPT=-W

--- a/zephyr-env.sh
+++ b/zephyr-env.sh
@@ -35,7 +35,7 @@ fi
 # .zephyrrc in your home directory. It will be automatically
 # run (if it exists) by this script.
 
-if uname | grep -q -P "MINGW|MSYS"; then
+if uname | grep -q -P "MINGW"; then
     win_build=1
     PWD_OPT="-W"
 else


### PR DESCRIPTION
Since MSYS2 provides a UNIX-like environment, treating it as a Windows
build caused issues with the paths.

Signed-off-by: Carles Cufi <carles.cufi@nordicsemi.no>