### PR TITLE
net: dhcpv4: Properly register UDP handler

### DIFF
--- a/subsys/net/ip/dhcpv4.c
+++ b/subsys/net/ip/dhcpv4.c
@@ -1091,15 +1091,20 @@ void net_dhcpv4_stop(struct net_if *iface)
 
 int dhcpv4_init(void)
 {
+	struct sockaddr local_addr;
 	int ret;
 
 	NET_DBG("");
+
+	net_ipaddr_copy(&net_sin(&local_addr)->sin_addr,
+			net_ipv4_unspecified_address());
+	local_addr.family = AF_INET;
 
 	/* Register UDP input callback on
 	 * DHCPV4_SERVER_PORT(67) and DHCPV4_CLIENT_PORT(68) for
 	 * all dhcpv4 related incoming packets.
 	 */
-	ret = net_udp_register(NULL, NULL,
+	ret = net_udp_register(NULL, &local_addr,
 			       DHCPV4_SERVER_PORT,
 			       DHCPV4_CLIENT_PORT,
 			       net_dhcpv4_input, NULL, NULL);


### PR DESCRIPTION
The address family of the UDP port listener was not set. This
caused weird debug prints in net-shell. Now the listener will
be registering IPv4 any address as it should.

Signed-off-by: Jukka Rissanen <jukka.rissanen@linux.intel.com>