### PR TITLE
arc: em7d/em9d: fix typo in soc flags

### DIFF
--- a/arch/arc/soc/em7d/Makefile
+++ b/arch/arc/soc/em7d/Makefile
@@ -2,7 +2,7 @@
 KBUILD_CFLAGS += -mcpu=em4_dmips
 
 soc-cflags = $(call cc-option,-mcpu=em4_dmips -mno-sdata) \
-		$(call cc-option,-mdiv-rem -mswap -mnormm) \
+		$(call cc-option,-mdiv-rem -mswap -mnorm) \
 		$(call cc-option,-mmpy-option=6 -mbarrel-shifter) \
 		$(call cc-option,--param l1-cache-size=16384) \
 		$(call cc-option,--param l1-cache-line-size=32)

--- a/arch/arc/soc/em9d/Makefile
+++ b/arch/arc/soc/em9d/Makefile
@@ -2,7 +2,7 @@
 KBUILD_CFLAGS += -mcpu=em4_fpus
 
 soc-cflags += $(call cc-option,-mcpu=em4_fpus -mno-sdata) \
-		$(call cc-option,-mdiv-rem -mswap -mnormm) \
+		$(call cc-option,-mdiv-rem -mswap -mnorm) \
 		$(call cc-option,-mmpy-option=6 -mbarrel-shifter) \
 
 ifeq ($(CONFIG_CODE_DENSITY), y)


### PR DESCRIPTION
fixed typo: mnormm -> -mnorm

Signed-off-by: Anas Nashif <anas.nashif@intel.com>