### PR TITLE
ci: update to latest docker image

### DIFF
--- a/.shippable.yml
+++ b/.shippable.yml
@@ -21,7 +21,7 @@ build:
         - ${SHIPPABLE_BUILD_DIR}/ccache
     pre_ci_boot:
         image_name: zephyrprojectrtos/ci
-        image_tag: master.15
+        image_tag: master.16
         pull: true
         options: "-e HOME=/home/buildslave --privileged=true --tty --net=bridge --user buildslave"
 


### PR DESCRIPTION
This image installs sphinx 1.5.5 which is the version currently
supported by Zephyr. Newer versions seem to have issues building our
documentation.