### PR TITLE
toolchain: require SDK 0.9.1

### DIFF
--- a/doc/getting_started/installation_linux.rst
+++ b/doc/getting_started/installation_linux.rst
@@ -95,12 +95,12 @@ Follow these steps to install the SDK on your Linux host system.
    including the latest version.
 
    Alternatively, you can use the following command to download the
-   desired version (*0.9* can be replaced with the version number you
+   desired version (*0.9.1* can be replaced with the version number you
    wish to download).
 
    .. code-block:: console
 
-      $ wget https://github.com/zephyrproject-rtos/meta-zephyr-sdk/releases/download/0.9/zephyr-sdk-0.9-setup.run
+      $ wget https://github.com/zephyrproject-rtos/meta-zephyr-sdk/releases/download/0.9.1/zephyr-sdk-0.9.1-setup.run
 
 #. Run the installation binary, follow this example:
 

--- a/scripts/Makefile.toolchain.zephyr
+++ b/scripts/Makefile.toolchain.zephyr
@@ -12,7 +12,7 @@
 #
 #######################################################################
 
-REQUIRED_SDK_VER=0.8.2
+REQUIRED_SDK_VER=0.9.1
 
 ifndef ZEPHYR_SDK_INSTALL_DIR
 
@@ -21,8 +21,20 @@ else
 SDK_VERSION = $(shell cat ${ZEPHYR_SDK_INSTALL_DIR}/sdk_version)
 SDK_CHECK = $(shell ${ZEPHYR_BASE}/scripts/vercomp $(REQUIRED_SDK_VER) $(SDK_VERSION) || echo $$?)
 
+SDK_MESSAGE=" 								\
+The SDK version you are using is old, please update your SDK. 		\
+									\
+You need at least SDK version $(REQUIRED_SDK_VER).			\
+									\
+The new version of the SDK can be download from:			\
+									\
+https://github.com/zephyrproject-rtos/meta-zephyr-sdk/releases/download/$(REQUIRED_SDK_VER)/zephyr-sdk-$(REQUIRED_SDK_VER)-setup.run \
+\
+\
+"
+
 ifeq ($(SDK_CHECK),1)
-$(error (The SDK version you are using is old, please update your SDK. You need at least SDK version $(REQUIRED_SDK_VER)))
+$(error $(SDK_MESSAGE))
 endif
 endif
 


### PR DESCRIPTION
The 0.9.1 SDK is now required to cover all architectures and to enable
tests on all plartforms supported.