### PR TITLE
tests: kernel: Fixed tickless test for Arduino Due.

### DIFF
--- a/tests/kernel/test_tickless/src/timestamps.c
+++ b/tests/kernel/test_tickless/src/timestamps.c
@@ -258,7 +258,7 @@ void _TimestampClose(void)
 void _TimestampOpen(void)
 {
 	/* enable RTT clock from PMC */
-	__PMC->pcer0 = (1 << PID_RTT);
+	soc_pmc_peripheral_enable(ID_RTT);
 
 	/* Reset RTT and set prescaler to 1 */
 	_TIMESTAMP_MODE = (1 << 18) | (1 << 0);
@@ -301,7 +301,7 @@ u32_t _TimestampRead(void)
 void _TimestampClose(void)
 {
 	/* disable RTT clock from PMC */
-	__PMC->pcdr0 = (1 << PID_RTT);
+	soc_pmc_peripheral_disable(ID_RTT);
 }
 
 #else


### PR DESCRIPTION
Arduino Due now uses ASF. The timestamps.c file was still
using old register definitions.

Signed-off-by: Justin Watson <jwatson5@gmail.com>