### PR TITLE
kernel: start: relocate vector table

### DIFF
--- a/arch/arm/core/cortex_m/prep_c.c
+++ b/arch/arm/core/cortex_m/prep_c.c
@@ -22,9 +22,14 @@
 #include <linker-defs.h>
 #include <nano_internal.h>
 #include <arch/arm/cortex_m/cmsis.h>
+#include <string.h>
 
 #ifdef CONFIG_ARMV6_M
-static inline void relocate_vector_table(void) { /* do nothing */ }
+#define VECTOR_ADDRESS 0
+static inline void relocate_vector_table(void)
+{
+	memcpy(VECTOR_ADDRESS, _vector_start, (size_t)_vector_end - (size_t)_vector_start);
+}
 #elif defined(CONFIG_ARMV7_M)
 #ifdef CONFIG_XIP
 #define VECTOR_ADDRESS ((uintptr_t)&_image_rom_start + \

--- a/include/arch/arm/cortex_m/scripts/linker.ld
+++ b/include/arch/arm/cortex_m/scripts/linker.ld
@@ -84,7 +84,7 @@ SECTIONS
 	KEEP(*(.dbghdr))
 	KEEP(*(".dbghdr.*"))
 #endif
-
+        _vector_start = .;
 	. = CONFIG_TEXT_SECTION_OFFSET;
 	KEEP(*(.exc_vector_table))
 	KEEP(*(".exc_vector_table.*"))
@@ -102,7 +102,7 @@ SECTIONS
 #ifdef CONFIG_GEN_SW_ISR_TABLE
 	KEEP(*(SW_ISR_TABLE))
 #endif
-
+        _vector_end = .;
 	_image_text_start = .;
 	*(.text)
 	*(".text.*")

--- a/include/linker-defs.h
+++ b/include/linker-defs.h
@@ -151,6 +151,9 @@ extern char _image_ram_end[];
 extern char _image_text_start[];
 extern char _image_text_end[];
 
+extern char _vector_start[];
+extern char _vector_end[];
+
 /* end address of image. */
 extern char _end[];
 


### PR DESCRIPTION
Without this vector table initiated, an system exception
will be raised under arm arch M0.

Signed-off-by: likai liu <likai.liu@linaro.org>