### PR TITLE
zoap: Include net/net_ip.h when sockaddr is used

### DIFF
--- a/include/net/zoap.h
+++ b/include/net/zoap.h
@@ -16,6 +16,7 @@
 #include <zephyr/types.h>
 #include <stddef.h>
 #include <stdbool.h>
+#include <net/net_ip.h>
 
 #include <misc/slist.h>
 


### PR DESCRIPTION
Add missing include file net/net_ip.h as zoap header files use struct sockaddr.
