### PR TITLE
tests: net: ipv6: Fix possible NULL pointer dereference behind a macro

### DIFF
--- a/tests/net/ipv6/src/main.c
+++ b/tests/net/ipv6/src/main.c
@@ -194,12 +194,14 @@ static struct net_pkt *prepare_ra_message(void)
 
 static int tester_send(struct net_if *iface, struct net_pkt *pkt)
 {
-	struct net_icmp_hdr *icmp = NET_ICMP_HDR(pkt);
+	struct net_icmp_hdr *icmp;
 
 	if (!pkt->frags) {
 		TC_ERROR("No data to send!\n");
 		return -ENODATA;
 	}
+
+	icmp = NET_ICMP_HDR(pkt);
 
 	/* Reply with RA messge */
 	if (icmp->type == NET_ICMPV6_RS) {


### PR DESCRIPTION
Coverity CID 169303. As this is a test, it's minor issue, but let's
keep Coverity report clean.

Signed-off-by: Paul Sokolovsky <paul.sokolovsky@linaro.org>