### PR TITLE
tests: clock: Initialize d64 value

### DIFF
--- a/tests/kernel/common/src/clock.c
+++ b/tests/kernel/common/src/clock.c
@@ -16,7 +16,7 @@
 static void tclock_uptime(void)
 {
 	u64_t t64, t32;
-	s64_t d64;
+	s64_t d64 = 0;
 
 	/**TESTPOINT: uptime elapse*/
 	t64 = k_uptime_get();


### PR DESCRIPTION
All other issues in ZEP-2130 were intentional/false positives.