### PR TITLE
tests: benchmark: app_kernel: Return values from kernel APIs are read.

### DIFF
--- a/tests/benchmarks/app_kernel/src/mailbox_r.c
+++ b/tests/benchmarks/app_kernel/src/mailbox_r.c
@@ -14,7 +14,7 @@
 /*
  * Function prototypes.
  */
-int mailbox_get(struct k_mbox *mailbox,
+void mailbox_get(struct k_mbox *mailbox,
 		int size,
 		int count,
 		unsigned int *time);
@@ -70,10 +70,14 @@ void mailrecvtask(void)
  * @param count     Number of data portions.
  * @param time      Resulting time.
  */
-int mailbox_get(struct k_mbox *mailbox, int size, int count, unsigned int *time)
+void mailbox_get(struct k_mbox *mailbox,
+		 int size,
+		 int count,
+		 unsigned int *time)
 {
 	int i;
 	unsigned int t;
+	s32_t return_value = 0;
 	struct k_mbox_msg Message;
 
 	Message.rx_source_thread = K_ANY;
@@ -83,7 +87,10 @@ int mailbox_get(struct k_mbox *mailbox, int size, int count, unsigned int *time)
 	k_sem_take(&SEM0, K_FOREVER);
 	t = BENCH_START();
 	for (i = 0; i < count; i++) {
-		k_mbox_get(mailbox, &Message, &data_recv, K_FOREVER);
+		return_value |= k_mbox_get(mailbox,
+					  &Message,
+					  &data_recv,
+					  K_FOREVER);
 	}
 
 	t = TIME_STAMP_DELTA_GET(t);
@@ -91,7 +98,9 @@ int mailbox_get(struct k_mbox *mailbox, int size, int count, unsigned int *time)
 	if (bench_test_end() < 0) {
 		PRINT_OVERFLOW_ERROR();
 	}
-	return 0;
+	if (return_value != 0) {
+		k_panic();
+	}
 }
 
 #endif /* MAILBOX_BENCH */

--- a/tests/benchmarks/app_kernel/src/mempool_b.c
+++ b/tests/benchmarks/app_kernel/src/mempool_b.c
@@ -20,17 +20,24 @@ void mempool_test(void)
 {
 	u32_t et; /* elapsed time */
 	int i;
+	s32_t return_value = 0;
 	struct k_mem_block block;
 
 	PRINT_STRING(dashline, output_file);
 	et = BENCH_START();
 	for (i = 0; i < NR_OF_POOL_RUNS; i++) {
-		k_mem_pool_alloc(&DEMOPOOL, &block, 16, K_FOREVER);
+		return_value |= k_mem_pool_alloc(&DEMOPOOL,
+						&block,
+						16,
+						K_FOREVER);
 		k_mem_pool_free(&block);
 	}
 	et = TIME_STAMP_DELTA_GET(et);
 	check_result();
 
+	if (return_value != 0) {
+		k_panic();
+	}
 	PRINT_F(output_file, FORMAT,
 		"average alloc and dealloc memory pool block",
 		SYS_CLOCK_HW_CYCLES_TO_NS_AVG(et, (2 * NR_OF_POOL_RUNS)));


### PR DESCRIPTION
Static code analysis reported some kernel APIs were used without
reading the return value. Since the benchmark doesn't need error
conditions, a simple read of the values followed by a ARG_UNUSED
is used to handle static code analysis errors.

JIRA: ZEP-2134

Signed-off-by: Adithya Baglody <adithya.nagaraj.baglody@intel.com>