### PR TITLE
net: pkt: Handle out-of-mem case properly

### DIFF
--- a/subsys/net/ip/net_pkt.c
+++ b/subsys/net/ip/net_pkt.c
@@ -1615,6 +1615,7 @@ int net_pkt_split(struct net_pkt *pkt, struct net_buf *orig_frag,
 	*fragB = net_pkt_get_frag(pkt, timeout);
 	if (!*fragB) {
 		net_pkt_frag_unref(*fragA);
+		*fragA = NULL;
 		return -ENOMEM;
 	}
 


### PR DESCRIPTION
If we could not split the packet properly, make sure that the
fragments that we managed to allocate are unreffed and marked
as NULL.

Signed-off-by: Jukka Rissanen <jukka.rissanen@linux.intel.com>