### PR TITLE
Bluetooth: controller: Add HCI Tx buffer overflow return code

### DIFF
--- a/subsys/bluetooth/controller/hci/hci.c
+++ b/subsys/bluetooth/controller/hci/hci.c
@@ -1206,6 +1206,7 @@ int hci_acl_handle(struct net_buf *buf)
 {
 	struct radio_pdu_node_tx *radio_pdu_node_tx;
 	struct bt_hci_acl_hdr *acl;
+	struct pdu_data *pdu_data;
 	u16_t handle;
 	u8_t flags;
 	u16_t len;
@@ -1230,20 +1231,24 @@ int hci_acl_handle(struct net_buf *buf)
 	handle = bt_acl_handle(handle);
 
 	radio_pdu_node_tx = radio_tx_mem_acquire();
-	if (radio_pdu_node_tx) {
-		struct pdu_data *pdu_data;
+	if (!radio_pdu_node_tx) {
+		BT_ERR("Tx Buffer Overflow");
+		return -ENOBUFS;
+	}
 
-		pdu_data = (struct pdu_data *)radio_pdu_node_tx->pdu_data;
-		if (flags == BT_ACL_START_NO_FLUSH || flags == BT_ACL_START) {
-			pdu_data->ll_id = PDU_DATA_LLID_DATA_START;
-		} else {
-			pdu_data->ll_id = PDU_DATA_LLID_DATA_CONTINUE;
-		}
-		pdu_data->len = len;
-		memcpy(&pdu_data->payload.lldata[0], buf->data, len);
-		if (radio_tx_mem_enqueue(handle, radio_pdu_node_tx)) {
-			radio_tx_mem_release(radio_pdu_node_tx);
-		}
+	pdu_data = (struct pdu_data *)radio_pdu_node_tx->pdu_data;
+	if (flags == BT_ACL_START_NO_FLUSH || flags == BT_ACL_START) {
+		pdu_data->ll_id = PDU_DATA_LLID_DATA_START;
+	} else {
+		pdu_data->ll_id = PDU_DATA_LLID_DATA_CONTINUE;
+	}
+	pdu_data->len = len;
+	memcpy(&pdu_data->payload.lldata[0], buf->data, len);
+
+	if (radio_tx_mem_enqueue(handle, radio_pdu_node_tx)) {
+		BT_ERR("Invalid Tx Enqueue");
+		radio_tx_mem_release(radio_pdu_node_tx);
+		return -EINVAL;
 	}
 
 	return 0;


### PR DESCRIPTION
Return error codes for HCI Tx buffer overflow conditions are
missing which would lead to silent dropping of Tx packets if
host implementations do not follow number of completed packets
or use correct buffer counts as returned by HCI Read Buffer
Size command.

Signed-off-by: Vinayak Kariappa Chettimada <vich@nordicsemi.no>