### PR TITLE
[1.8 backport] drivers/ethernet/eth_mcux: Fix extra PHY debug Kconfig name.

### DIFF
--- a/drivers/ethernet/eth_mcux.c
+++ b/drivers/ethernet/eth_mcux.c
@@ -142,7 +142,7 @@ static void eth_mcux_phy_enter_reset(struct eth_context *context)
 
 static void eth_mcux_phy_start(struct eth_context *context)
 {
-#ifdef CONFIG_ETH_MCUX_PHY_DETAILED_DEBUG
+#ifdef CONFIG_ETH_MCUX_PHY_EXTRA_DEBUG
 	SYS_LOG_DBG("phy_state=%s", phy_state_name(context->phy_state));
 #endif
 
@@ -166,7 +166,7 @@ static void eth_mcux_phy_start(struct eth_context *context)
 
 void eth_mcux_phy_stop(struct eth_context *context)
 {
-#ifdef CONFIG_ETH_MCUX_PHY_DETAILED_DEBUG
+#ifdef CONFIG_ETH_MCUX_PHY_EXTRA_DEBUG
 	SYS_LOG_DBG("phy_state=%s", phy_state_name(context->phy_state));
 #endif
 
@@ -203,7 +203,7 @@ static void eth_mcux_phy_event(struct eth_context *context)
 	phy_speed_t phy_speed = kPHY_Speed100M;
 	const u32_t phy_addr = 0;
 
-#ifdef CONFIG_ETH_MCUX_PHY_DETAILED_DEBUG
+#ifdef CONFIG_ETH_MCUX_PHY_EXTRA_DEBUG
 	SYS_LOG_DBG("phy_state=%s", phy_state_name(context->phy_state));
 #endif
 	switch (context->phy_state) {


### PR DESCRIPTION
Source had CONFIG_ETH_MCUX_PHY_DETAILED_DEBUG, while Kconfig had
CONFIG_ETH_MCUX_PHY_EXTRA_DEBUG. Use the shorter name consistently.

Signed-off-by: Paul Sokolovsky <paul.sokolovsky@linaro.org>