### PR TITLE
[1.8 backport] drivers/ethernet/eth_mcux: Fix selection of promisc mode workaround (IPv6)

### DIFF
--- a/drivers/ethernet/Kconfig.mcux
+++ b/drivers/ethernet/Kconfig.mcux
@@ -17,8 +17,8 @@ menuconfig ETH_MCUX
 if ETH_MCUX
 config ETH_MCUX_PROMISCUOUS_MODE
 	bool "Enable promiscuous mode"
-	default false if !NET_IPV6
-	default true if NET_IPV6
+	default n if !NET_IPV6
+	default y if NET_IPV6
 	help
 	  Place the ethernet receiver in promiscuous mode.
 


### PR DESCRIPTION
Until we have better solution, we enable promiscuous mode as a
workaround to get IPv6 neighbour discovery going. Kconfig had
typos/thinkos preventing that to work however.

Signed-off-by: Paul Sokolovsky <paul.sokolovsky@linaro.org>