### PR TITLE
Bluetooth: controller: Fix failing fast encryption setup feature

### DIFF
--- a/subsys/bluetooth/controller/ll_sw/ctrl.c
+++ b/subsys/bluetooth/controller/ll_sw/ctrl.c
@@ -5549,8 +5549,15 @@ static inline void event_enc_prep(struct connection *conn)
 			/* send enc start resp */
 			start_enc_rsp_send(conn, pdu_ctrl_tx);
 		}
+
 		/* slave send reject ind or start enc req at control priority */
+
+#if defined(CONFIG_BLUETOOTH_CONTROLLER_FAST_ENC)
+		else {
+#else /* !CONFIG_BLUETOOTH_CONTROLLER_FAST_ENC */
 		else if (!conn->pause_tx || conn->refresh) {
+#endif /* !CONFIG_BLUETOOTH_CONTROLLER_FAST_ENC */
+
 			/* ll ctrl packet */
 			pdu_ctrl_tx->ll_id = PDU_DATA_LLID_CTRL;
 
@@ -5575,7 +5582,7 @@ static inline void event_enc_prep(struct connection *conn)
 				 * controller.
 				 */
 				enc_rsp_send(conn);
-#endif /* CONFIG_BLUETOOTH_CONTROLLER_FAST_ENC */
+#endif /* !CONFIG_BLUETOOTH_CONTROLLER_FAST_ENC */
 
 				/* calc the Session Key */
 				ecb_encrypt(&conn->llcp.encryption.ltk[0],
@@ -5614,9 +5621,9 @@ static inline void event_enc_prep(struct connection *conn)
 				pdu_ctrl_tx->payload.llctrl.opcode =
 					PDU_DATA_LLCTRL_TYPE_START_ENC_REQ;
 			}
-		} else {
 
 #if !defined(CONFIG_BLUETOOTH_CONTROLLER_FAST_ENC)
+		} else {
 			/* enable transmit encryption */
 			_radio.conn_curr->enc_tx = 1;
 
@@ -5625,13 +5632,7 @@ static inline void event_enc_prep(struct connection *conn)
 			/* resume data packet rx and tx */
 			_radio.conn_curr->pause_rx = 0;
 			_radio.conn_curr->pause_tx = 0;
-#else /* CONFIG_BLUETOOTH_CONTROLLER_FAST_ENC */
-			/* Fast Enc implementation shall have enqueued the
-			 * start enc rsp in the radio ISR itself, we should
-			 * not get here.
-			 */
-			LL_ASSERT(0);
-#endif /* CONFIG_BLUETOOTH_CONTROLLER_FAST_ENC */
+#endif /* !CONFIG_BLUETOOTH_CONTROLLER_FAST_ENC */
 
 		}
 


### PR DESCRIPTION
In commit c41d3edda when implementing the alternative
encryption setup implementation, the original fast
encryption setup implementation was broken. When host is
slow in responding to LTK request, the controller asserted
when fast encryption implementation is selected. This is
now fixed.

Signed-off-by: Vinayak Kariappa Chettimada <vich@nordicsemi.no>