### PR TITLE
samples: net: mqtt_publisher: fixed formatting

### DIFF
--- a/samples/net/mqtt_publisher/README.rst
+++ b/samples/net/mqtt_publisher/README.rst
@@ -78,7 +78,7 @@ MQTT Client Identifier:
 This sample application supports the IBM Bluemix Watson topic format that can
 be enabled by changing the default value of APP_BLUEMIX_TOPIC from 0 to 1:
 
-.. code block:: c
+.. code-block:: c
 
 	#define APP_BLUEMIX_TOPIC	1
 
@@ -86,7 +86,7 @@ The Bluemix topic may include some parameters like device type, device
 identifier, event type and message format. This application uses the
 following macros to specify those values:
 
-.. code block:: c
+.. code-block:: c
 
 	#define BLUEMIX_DEVTYPE		"sensor"
 	#define BLUEMIX_DEVID		"carbon"


### PR DESCRIPTION
README.rst had formatting which was making things disappear in the
online documentation.

Signed-off-by: John Andersen <john.s.andersen@intel.com>