### PR TITLE
scripts: Makefile.lib: Add dependency for DTS overlay

### DIFF
--- a/scripts/Makefile.lib
+++ b/scripts/Makefile.lib
@@ -264,6 +264,9 @@ cmd_gzip = (cat $(filter-out FORCE,$^) | gzip -n -f -9 > $@) || \
 # DTC
 # ---------------------------------------------------------------------------
 
+DTC_OVERLAY_DIR ?= $(PROJECT_BASE)
+DTC_OVERLAY_FILE = $(abspath $(DTC_OVERLAY_DIR)/$(BOARD_NAME).overlay)
+
 # Generate an assembly file to wrap the output of the device tree compiler
 quiet_cmd_dt_S_dtb= DTB     $@
 cmd_dt_S_dtb=						\
@@ -282,12 +285,10 @@ cmd_dt_S_dtb=						\
 $(obj)/%.dtb.S: $(obj)/%.dtb
 	$(call cmd,dt_S_dtb)
 
-DTS_OVERLAY ?= $(PROJECT_BASE)/$(BOARD_NAME).overlay
-
 quiet_cmd_dtc = DTC     $@
 cmd_dtc = echo '\#include "$(notdir $<)"' > dts/$(ARCH)/$(notdir $<)_pre_compiled ; \
-	if test -e $(DTS_OVERLAY); then \
-		echo '\#include "$(BOARD_NAME).overlay"' >> dts/$(ARCH)/$(notdir $<)_pre_compiled ; \
+	if test -e $(DTC_OVERLAY_FILE); then \
+		echo '\#include "$(DTC_OVERLAY_FILE)"' >> dts/$(ARCH)/$(notdir $<)_pre_compiled ; \
 	fi ; \
 	$(CPP) $(dtc_cpp_flags) -x assembler-with-cpp -o $(dtc-tmp) dts/$(ARCH)/$(notdir $<)_pre_compiled ; \
 	$(DTC) -O dts -o $@ -b 0 \
@@ -298,7 +299,7 @@ cmd_dtc = echo '\#include "$(notdir $<)"' > dts/$(ARCH)/$(notdir $<)_pre_compile
 $(obj)/%.dtb: $(src)/%.dts FORCE
 	$(call if_changed_dep,dtc)
 
-$(obj)/%.dts_compiled: $(src)/%.dts $(DTS_OVERLAY) FORCE
+$(obj)/%.dts_compiled: $(src)/%.dts $(wildcard $(DTC_OVERLAY_FILE)) FORCE
 	$(call if_changed_dep,dtc)
 
 dtc-tmp = $(subst $(comma),_,$(dot-target).dts.tmp)

--- a/scripts/Makefile.lib
+++ b/scripts/Makefile.lib
@@ -282,9 +282,11 @@ cmd_dt_S_dtb=						\
 $(obj)/%.dtb.S: $(obj)/%.dtb
 	$(call cmd,dt_S_dtb)
 
+DTS_OVERLAY ?= $(PROJECT_BASE)/$(BOARD_NAME).overlay
+
 quiet_cmd_dtc = DTC     $@
 cmd_dtc = echo '\#include "$(notdir $<)"' > dts/$(ARCH)/$(notdir $<)_pre_compiled ; \
-	if test -e $(PROJECT_BASE)/$(BOARD_NAME).overlay; then \
+	if test -e $(DTS_OVERLAY); then \
 		echo '\#include "$(BOARD_NAME).overlay"' >> dts/$(ARCH)/$(notdir $<)_pre_compiled ; \
 	fi ; \
 	$(CPP) $(dtc_cpp_flags) -x assembler-with-cpp -o $(dtc-tmp) dts/$(ARCH)/$(notdir $<)_pre_compiled ; \
@@ -296,7 +298,7 @@ cmd_dtc = echo '\#include "$(notdir $<)"' > dts/$(ARCH)/$(notdir $<)_pre_compile
 $(obj)/%.dtb: $(src)/%.dts FORCE
 	$(call if_changed_dep,dtc)
 
-$(obj)/%.dts_compiled: $(src)/%.dts FORCE
+$(obj)/%.dts_compiled: $(src)/%.dts $(DTS_OVERLAY) FORCE
 	$(call if_changed_dep,dtc)
 
 dtc-tmp = $(subst $(comma),_,$(dot-target).dts.tmp)


### PR DESCRIPTION
This patch adds a dependency for the DTS overlay so that the DTS is compiled
when the state of the overlay file changes.

Change-Id: I2affe67f90f56b1d97384d5cd4e3026abed24253
Signed-off-by: Andy Gross <andy.gross@linaro.org>