### PR TITLE
Bluetooth: AVDTP: Remove dead code

### DIFF
--- a/subsys/bluetooth/host/avdtp.c
+++ b/subsys/bluetooth/host/avdtp.c
@@ -161,10 +161,6 @@ void bt_avdtp_l2cap_recv(struct bt_l2cap_chan *chan, struct net_buf *buf)
 		msgtype, sigid, tid);
 	net_buf_pull(buf, sizeof(*hdr));
 
-	if (msgtype > BT_AVDTP_REJECT) {
-		return;
-	}
-
 	/* validate if there is an outstanding resp expected*/
 	if (msgtype != BT_AVDTP_CMD) {
 		if (session->req == NULL) {


### PR DESCRIPTION
The msgtype value is created using 'hdr & 3' which means that the
resulting value can never be greater than 3. This fixes Coverity CID
166771.

Signed-off-by: Johan Hedberg <johan.hedberg@intel.com>