### PR TITLE
tests: benchmark: Fixed build error from icx toolchain.

### DIFF
--- a/tests/benchmarks/timing_info/src/thread_bench.c
+++ b/tests/benchmarks/timing_info/src/thread_bench.c
@@ -54,7 +54,12 @@ u64_t dummy_time;
 u64_t start_time;
 u64_t test_end_time;
 
-#if CONFIG_X86
+/* Disable the overhead calculations, this is needed to calculate
+ * the overhead created by the benchmarking code itself.
+ */
+#define DISABLE_OVERHEAD_MEASUREMENT
+
+#if defined(CONFIG_X86) && !defined(DISABLE_OVERHEAD_MEASUREMENT)
 u32_t benchmarking_overhead_swap(void)
 {
 


### PR DESCRIPTION
The error was generated by a piece of code that is
not currently being used. This piece of code was kept to measure
the overhead caused by the benchmarking code on x86.

JIRA:ZEP-2160

Signed-off-by: Adithya Baglody <adithya.nagaraj.baglody@intel.com>