### PR TITLE
arm: core: mpu: Prevent updating unexpected region

### DIFF
--- a/arch/arm/core/cortex_m/mpu/arm_mpu.c
+++ b/arch/arm/core/cortex_m/mpu/arm_mpu.c
@@ -64,7 +64,8 @@ static void _region_init(u32_t index, u32_t region_addr,
 	/* Select the region you want to access */
 	ARM_MPU_DEV->rnr = index;
 	/* Configure the region */
-	ARM_MPU_DEV->rbar = region_addr | REGION_VALID | index;
+	ARM_MPU_DEV->rbar = (region_addr & REGION_BASE_ADDR_MASK)
+				| REGION_VALID | index;
 	ARM_MPU_DEV->rasr = region_attr | REGION_ENABLE;
 }
 

--- a/include/arch/arm/cortex_m/mpu/arm_mpu.h
+++ b/include/arch/arm/cortex_m/mpu/arm_mpu.h
@@ -44,6 +44,9 @@ struct arm_mpu {
 #define ARM_MPU_PRIVDEFENA	(1 << 2)
 
 #define REGION_VALID	(1 << 4)
+/* ARM MPU RBAR Register */
+/* Region base address mask */
+#define REGION_BASE_ADDR_MASK	0xFFFFFFE0
 
 /* eXecute Never */
 #define NOT_EXEC        (0x1 << 28)


### PR DESCRIPTION
The REGION bits (bit[3:0]) of MPU_RBAR register can specify the number
of the regiion to update if the VALID bit (bit[4]) is also set.

If the bit[3:0] of "region_addr" are not zero, might cause to update
unexpected region. This could happen since we might not declare stack
memory with specific alignment.

This patch will mask the bit[4:0] of "region_addr" to prevent updating
unexpected region.