### PR TITLE
usb_dc_dw: Correctly assign endpoint FIFOs

### DIFF
--- a/drivers/usb/device/usb_dw_registers.h
+++ b/drivers/usb/device/usb_dw_registers.h
@@ -120,6 +120,7 @@ struct usb_dw_reg {
 };
 
 /* USB register offsets and masks */
+#define USB_DW_HWCFG4_DEDFIFOMODE BIT(25)
 #define USB_DW_GRSTCTL_AHB_IDLE BIT(31)
 #define USB_DW_GRSTCTL_TX_FNUM_OFFSET (6)
 #define USB_DW_GRSTCTL_TX_FFLSH BIT(5)
@@ -147,6 +148,8 @@ struct usb_dw_reg {
 #define USB_DW_DEPCTL_SNAK BIT(27)
 #define USB_DW_DEPCTL_CNAK BIT(26)
 #define USB_DW_DEPCTL_STALL BIT(21)
+#define USB_DW_DEPCTL_TXFNUM_OFFSET (22)
+#define USB_DW_DEPCTL_TXFNUM_MASK (0xf << 22)
 #define USB_DW_DEPCTL_EP_TYPE_MASK (0x3 << 18)
 #define USB_DW_DEPCTL_EP_TYPE_OFFSET (18)
 #define USB_DW_DEPCTL_EP_TYPE_CONTROL (0)


### PR DESCRIPTION
The designware hardware in dedicated FIFO mode (which is all we do
right now for lack of supported shared-FIFO controllers) has one
hardware FIFO per IN (i.e. transmit) endpoint.  But it doesn't assign
them on its own, it's the drivers responsibility to populate the
TxFNum field of the DIEPCTL registers with integer indices
corresponding to the desired FIFO.

We weren't doing that, which meant that all IN endpoints were sharing
the same FIFO zero which is supposed to be dedicated to EP0 control
transfers.  The net effect is that sometimes outbound transfers would
be corrupted, showing data from the wrong endpoint.  More often that
not this would leak from control transfers over to the
higher-bandwidth bulk endpoints of the application, but occasionally
you'd see a control transfer itself get borked and the USB device
would glitch.

Get this right and set the FIFOs properly.

Signed-off-by: Andy Ross <andrew.j.ross@intel.com>