### PR TITLE
Bluetooth: controller: Increase RX prio stack size

### DIFF
--- a/subsys/bluetooth/controller/Kconfig
+++ b/subsys/bluetooth/controller/Kconfig
@@ -116,7 +116,7 @@ config BLUETOOTH_CONTROLLER_SUBVERSION_NUMBER
 
 config BLUETOOTH_CONTROLLER_RX_PRIO_STACK_SIZE
 	int
-	default 320
+	default 448
 
 comment "BLE Controller features"
 


### PR DESCRIPTION
Due to several changes in the way stacks are calculated, 320 bytes is no
longer enough for the controller-only build. After measuring usages of
up to 320 bytes (locally) and 376 (reported by Ricardo Salveti), the
stack size is increased by 128 bytes, up to 448 bytes.

Signed-off-by: Carles Cufi <carles.cufi@nordicsemi.no>