### PR TITLE
ieee802154_shell: Only accept channels within expected range

### DIFF
--- a/subsys/net/ip/l2/ieee802154/ieee802154_shell.c
+++ b/subsys/net/ip/l2/ieee802154/ieee802154_shell.c
@@ -122,7 +122,10 @@ static inline u32_t parse_channel_set(char *str_set)
 		}
 
 		chan = atoi(p);
-		channel_set |= BIT(chan - 1);
+		if (chan > 0 && chan < 32) {
+			channel_set |= BIT(chan - 1);
+		}
+
 		p = n ? n + 1 : n;
 	} while (n);
 


### PR DESCRIPTION
Fixes the following issue:
	"In expression 1UL << chan - 1U, left shifting by more than 31
	bits has undefined behavior.  The shift amount, chan - 1U, is
	4294967295."