### PR TITLE
Bluetooth: controller: Fix CSA#2 assert

### DIFF
--- a/subsys/bluetooth/controller/ll_sw/ctrl.c
+++ b/subsys/bluetooth/controller/ll_sw/ctrl.c
@@ -738,8 +738,7 @@ static inline u32_t isr_rx_adv(u8_t devmatch_ok, u8_t irkmatch_ok,
 		struct connection *conn;
 		u32_t ticker_status;
 
-		if (IS_ENABLED(CONFIG_BLUETOOTH_CONTROLLER_CHAN_SEL_2) &&
-		    pdu_adv->chan_sel) {
+		if (IS_ENABLED(CONFIG_BLUETOOTH_CONTROLLER_CHAN_SEL_2)) {
 			radio_pdu_node_rx = packet_rx_reserve_get(4);
 		} else {
 			radio_pdu_node_rx = packet_rx_reserve_get(3);
@@ -1005,8 +1004,7 @@ static inline u32_t isr_rx_obs(u8_t irkmatch_id, u8_t rssi_ready)
 		u32_t ticker_status;
 		u32_t conn_space_us;
 
-		if (IS_ENABLED(CONFIG_BLUETOOTH_CONTROLLER_CHAN_SEL_2) &&
-		    pdu_adv_rx->chan_sel) {
+		if (IS_ENABLED(CONFIG_BLUETOOTH_CONTROLLER_CHAN_SEL_2)) {
 			radio_pdu_node_rx = packet_rx_reserve_get(4);
 		} else {
 			radio_pdu_node_rx = packet_rx_reserve_get(3);


### PR DESCRIPTION
Fix the assert in the controller during connection setup
when peer does not support CSA#2 feature and free Rx buffer
queue does not have enough buffers to generate CSA event.

The assert was reproduced by turning on advertisement
indication and scan request notification features in the
controllers advanced features, and a peer that does not
support CSA#2 initiated a connection.

Signed-off-by: Vinayak Kariappa Chettimada <vich@nordicsemi.no>