### PR TITLE
shell: Add 'exit' command to leave a module

### DIFF
--- a/subsys/shell/shell.c
+++ b/subsys/shell/shell.c
@@ -233,6 +233,7 @@ static int show_help(int argc, char *argv[])
 		}
 
 		print_module_commands(module);
+		printk("\nEnter 'exit' to leave current module.\n");
 	} else { /* help for all entities */
 		printk("Available modules:\n");
 		for (module = 0; module < NUM_OF_SHELL_ENTITIES; module++) {
@@ -280,6 +281,15 @@ static int select_module(int argc, char *argv[])
 	return 0;
 }
 
+static int exit_module(int argc, char *argv[])
+{
+	if (argc == 1) {
+		default_module = -1;
+	}
+
+	return 0;
+}
+
 static shell_cmd_function_t get_cb(int argc, char *argv[])
 {
 	const char *first_string = argv[0];
@@ -299,6 +309,10 @@ static shell_cmd_function_t get_cb(int argc, char *argv[])
 
 	if (!strcmp(first_string, "select")) {
 		return select_module;
+	}
+
+	if (!strcmp(first_string, "exit")) {
+		return exit_module;
 	}
 
 	if ((argc == 1) && (default_module == -1)) {


### PR DESCRIPTION
In shell, to select a module, we use 'select <module_name>'. When inside a module, there is no indication on how one has to leave the module. So add 'exit' command to leave a module.

I know (after reading code) we can use 'select' without an argument to go back to default module but having an exit will make it more obvious. Besides, people are used to hitting 'exit' or 'quit' to leave a prompt so I thought it makes sense to have it here as well.