### PR TITLE
Bluetooth: Fix missing test for BLUETOOTH_CONN with DLE

### DIFF
--- a/subsys/bluetooth/host/hci_core.c
+++ b/subsys/bluetooth/host/hci_core.c
@@ -3338,7 +3338,8 @@ static int le_init(void)
 		net_buf_unref(rsp);
 	}
 
-	if (BT_FEAT_LE_DLE(bt_dev.le.features)) {
+	if (IS_ENABLED(CONFIG_BLUETOOTH_CONN) &&
+	    BT_FEAT_LE_DLE(bt_dev.le.features)) {
 		struct bt_hci_cp_le_write_default_data_len *cp;
 		struct bt_hci_rp_le_read_max_data_len *rp;
 		struct net_buf *buf, *rsp;


### PR DESCRIPTION
There's no point in doing anything about DLE if connection support is
not enabled.

Signed-off-by: Johan Hedberg <johan.hedberg@intel.com>