### PR TITLE
build: Fix DTC overlay file paths

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -27,9 +27,11 @@ UNAME := $(shell uname)
 ifeq (MSYS, $(findstring MSYS, $(UNAME)))
 DISABLE_TRYRUN=y
 HOST_OS=MSYS
+NATIVE_PWD_OPT=-W
 else ifeq (MINGW, $(findstring MINGW, $(UNAME)))
 HOST_OS=MINGW
 PWD_OPT=-W
+NATIVE_PWD_OPT=-W
 DISABLE_TRYRUN=y
 CPATH ?= $(MIGW_DIR)/include
 LIBRARY_PATH ?= $(MINGW_DIR)/lib
@@ -39,7 +41,7 @@ HOST_OS=Linux
 else ifeq (Darwin, $(findstring Darwin, $(UNAME)))
 HOST_OS=Darwin
 endif
-export HOST_OS
+export HOST_OS NATIVE_PWD_OPT
 
 # Avoid funny character set dependencies
 unexport LC_ALL

--- a/scripts/Makefile.lib
+++ b/scripts/Makefile.lib
@@ -265,7 +265,9 @@ cmd_gzip = (cat $(filter-out FORCE,$^) | gzip -n -f -9 > $@) || \
 # ---------------------------------------------------------------------------
 
 DTC_OVERLAY_DIR ?= $(PROJECT_BASE)
-DTC_OVERLAY_FILE = $(abspath $(DTC_OVERLAY_DIR)/$(BOARD_NAME).overlay)
+# Since this goes into a file, use the native path
+DTC_ABS_OVERLAY_DIR = $(shell cd $(DTC_OVERLAY_DIR) && pwd $(NATIVE_PWD_OPT))
+DTC_OVERLAY_FILE = $(DTC_ABS_OVERLAY_DIR)/$(BOARD_NAME).overlay
 
 # Generate an assembly file to wrap the output of the device tree compiler
 quiet_cmd_dt_S_dtb= DTB     $@


### PR DESCRIPTION
On MSYS2, the #include paths for GCC need to be in native format
(Windows-style paths) since GCC is a native Windows application and
therefore requires standard paths.

Signed-off-by: Carles Cufi <carles.cufi@nordicsemi.no>