### PR TITLE
samples: microbit/pong: Various minor fixes

### DIFF
--- a/samples/boards/microbit/pong/src/ble.c
+++ b/samples/boards/microbit/pong/src/ble.c
@@ -242,6 +242,10 @@ static void connected(struct bt_conn *conn, u8_t err)
 		return;
 	}
 
+	if (ble_state == BLE_ADVERTISING) {
+		bt_le_adv_stop();
+	}
+
 	if (!default_conn) {
 		default_conn = bt_conn_ref(conn);
 	}

--- a/samples/boards/microbit/pong/src/main.c
+++ b/samples/boards/microbit/pong/src/main.c
@@ -266,6 +266,10 @@ static void game_ended(bool won)
 {
 	struct mb_display *disp = mb_display_get();
 
+	if (sound_state != SOUND_IDLE) {
+		sound_set(SOUND_IDLE);
+	}
+
 	remote_lost = won;
 	ended = k_uptime_get();
 	started = false;


### PR DESCRIPTION
Occasionally the sound might stay enabled for the restart timeout (2
seconds) if the ball would hit the wall right before missing the
paddle. Ensure that it's disabled whenever the game ends.

Signed-off-by: Johan Hedberg <johan.hedberg@intel.com>