### PR TITLE
printk: fix printing of long long types

### DIFF
--- a/tests/kernel/common/src/printk.c
+++ b/tests/kernel/common/src/printk.c
@@ -25,6 +25,7 @@ char *expected = "22 113 10000 32768 40000 22\n"
 		 "42 42   42       42\n"
 		 "42 42 0042 00000042\n"
 		 "255     42    abcdef  0x0000002a      42\n"
+		 "-1 4294967295 ffffffff\n"
 ;
 
 
@@ -61,6 +62,8 @@ void printk_test(void)
 {
 	int count;
 
+	printk("%lld %llu %llx",
+			  1LL, -1ULL, -1ULL);
 	_old_char_out = __printk_get_hook();
 	__printk_hook_install(ram_console_out);
 
@@ -74,6 +77,7 @@ void printk_test(void)
 	printk("%u %2u %4u %8u\n", 42, 42, 42, 42);
 	printk("%u %02u %04u %08u\n", 42, 42, 42, 42);
 	printk("%-8u%-6d%-4x%-2p%8d\n", 0xFF, 42, 0xABCDEF, (char *)42, 42);
+	printk("%lld %llu %llx\n", -1LL, -1ULL, -1ULL);
 
 	ram_console[pos] = '\0';
 	zassert_true((strcmp(ram_console, expected) == 0), "printk failed");
@@ -103,6 +107,9 @@ void printk_test(void)
 	count += snprintk(ram_console + count, sizeof(ram_console) - count,
 			  "%-8u%-6d%-4x%-2p%8d\n",
 			  0xFF, 42, 0xABCDEF, (char *)42, 42);
+	count += snprintk(ram_console + count, sizeof(ram_console) - count,
+			  "%lld %llu %llx\n",
+			  -1LL, -1ULL, -1ULL);
 	ram_console[count] = '\0';
 	zassert_true((strcmp(ram_console, expected) == 0), "snprintk failed");
 }


### PR DESCRIPTION
64-bit types were not being handled properly and depending on the
calling convention could result in garbage values being printed.

We still truncate these to 32-bit values, the predominant use-case
is printing timestamp delta values which generally fit in a 32-bit
value. However we are no longer printing random stuff.

Signed-off-by: Andrew Boie <andrew.p.boie@intel.com>