### PR TITLE
net: http: Parsing state was not cleared

### DIFF
--- a/subsys/net/lib/http/http_server.c
+++ b/subsys/net/lib/http/http_server.c
@@ -670,6 +670,7 @@ fail:
 	}
 
 quit:
+	http_parser_init(&http_ctx->req.parser, HTTP_REQUEST);
 	http_ctx->req.data_len = 0;
 	net_pkt_unref(pkt);
 }


### PR DESCRIPTION
If we received a bad HTTP request, then subsequent good requests
were also returning 400 error code. The parsing state needs to
be initialized after each received HTTP request.

Jira: ZEP-2181

Signed-off-by: Jukka Rissanen <jukka.rissanen@linux.intel.com>