### PR TITLE
bluetooth: Allow to specify Logging Domain

### DIFF
--- a/subsys/bluetooth/common/log.h
+++ b/subsys/bluetooth/common/log.h
@@ -54,7 +54,9 @@ __printf_like(2, 3) void bt_log(int prio, const char *fmt, ...);
 
 #elif defined(CONFIG_BLUETOOTH_DEBUG_LOG)
 
+#if !defined(SYS_LOG_DOMAIN)
 #define SYS_LOG_DOMAIN "bt"
+#endif
 #define SYS_LOG_LEVEL SYS_LOG_LEVEL_DEBUG
 #include <logging/sys_log.h>
 


### PR DESCRIPTION
At the moment all bluetooth logs are prefixed with [bt] making it
difficult to understand where the logs belong to.