### PR TITLE
net: ipv6: Skip unknown options in NA message

### DIFF
--- a/subsys/net/ip/ipv6.c
+++ b/subsys/net/ip/ipv6.c
@@ -1662,7 +1662,7 @@ static enum net_verdict handle_na_input(struct net_pkt *pkt)
 					     net_pkt_ipv6_ext_opt_len(pkt) +
 					     (hdr->len << 3));
 
-		if (prev_opt_len == net_pkt_ipv6_ext_opt_len(pkt)) {
+		if (prev_opt_len >= net_pkt_ipv6_ext_opt_len(pkt)) {
 			NET_ERR("Corrupted NA message");
 			goto drop;
 		}


### PR DESCRIPTION
If we receive unknown option in neighbor advertisement message,
then skip those properly. Old code did not check the length of
the extension options which could cause infinite loop.

Jira: ZEP-2219

Signed-off-by: Ruslan Mstoi <ruslan.mstoi@intel.com>