### PR TITLE
JSON: fix-ups and additional helper macros

### DIFF
--- a/lib/json/json.h
+++ b/lib/json/json.h
@@ -154,7 +154,8 @@ typedef int (*json_append_bytes_t)(const u8_t *bytes, size_t len,
  *      };
  *
  *      struct json_obj_descr array[] = {
- *           JSON_OBJ_DESCR_ARRAY(struct example, foo, JSON_TOK_NUMBER)
+ *           JSON_OBJ_DESCR_ARRAY(struct example, foo, 10, foo_len,
+ *                                JSON_TOK_NUMBER)
  *      };
  */
 #define JSON_OBJ_DESCR_ARRAY(struct_, field_name_, max_len_, \

--- a/lib/json/json.h
+++ b/lib/json/json.h
@@ -173,6 +173,95 @@ typedef int (*json_append_bytes_t)(const u8_t *bytes, size_t len,
 	}
 
 /**
+ * @brief Variant of JSON_OBJ_DESCR_PRIM that can be used when the
+ *        structure and JSON field names differ.
+ *
+ * This is useful when the JSON field is not a valid C identifier.
+ *
+ * @param struct_ Struct packing the values.
+ *
+ * @param json_field_name_ String, field name in JSON strings
+ *
+ * @param struct_field_name_ Field name in the struct
+ *
+ * @param type_ Token type for JSON value corresponding to a primitive
+ * type.
+ *
+ * @see JSON_OBJ_DESCR_PRIM
+ */
+#define JSON_OBJ_DESCR_PRIM_NAMED(struct_, json_field_name_, \
+				  struct_field_name_, type_) \
+	{ \
+		.field_name = (json_field_name_), \
+		.field_name_len = sizeof(json_field_name_) - 1, \
+		.offset = offsetof(struct_, struct_field_name_), \
+		.type = type_, \
+	}
+
+/**
+ * @brief Variant of JSON_OBJ_DESCR_OBJECT that can be used when the
+ *        structure and JSON field names differ.
+ *
+ * This is useful when the JSON field is not a valid C identifier.
+ *
+ * @param struct_ Struct packing the values
+ *
+ * @param json_field_name_ String, field name in JSON strings
+ *
+ * @param struct_field_name_ Field name in the struct
+ *
+ * @param sub_descr_ Array of json_obj_descr describing the subobject
+ *
+ * @see JSON_OBJ_DESCR_OBJECT
+ */
+#define JSON_OBJ_DESCR_OBJECT_NAMED(struct_, json_field_name_, \
+				    struct_field_name_, sub_descr_) \
+	{ \
+		.field_name = (json_field_name_), \
+		.field_name_len = (sizeof(json_field_name_) - 1), \
+		.offset = offsetof(struct_, struct_field_name_), \
+		.type = JSON_TOK_OBJECT_START, \
+		.sub_descr = sub_descr_, \
+		.sub_descr_len = ARRAY_SIZE(sub_descr_) \
+	}
+
+/**
+ * @brief Variant of JSON_OBJ_DESCR_ARRAY that can be used when the
+ *        structure and JSON field names differ.
+ *
+ * This is useful when the JSON field is not a valid C identifier.
+ *
+ * @param struct_ Struct packing the values
+ *
+ * @param json_field_name_ String, field name in JSON strings
+ *
+ * @param struct_field_name_ Field name in the struct
+ *
+ * @param max_len_ Maximum number of elements in array
+ *
+ * @param len_field_ Field name in the struct for the number of elements
+ * in the array
+ *
+ * @param elem_type_ Element type
+ *
+ * @see JSON_OBJ_DESCR_ARRAY
+ */
+#define JSON_OBJ_DESCR_ARRAY_NAMED(struct_, json_field_name_,\
+				   struct_field_name_, max_len_, len_field_, \
+				   elem_type_) \
+	{ \
+		.field_name = (json_field_name_), \
+		.field_name_len = sizeof(json_field_name_) - 1, \
+		.offset = offsetof(struct_, struct_field_name_), \
+		.type = JSON_TOK_LIST_START, \
+		.element_descr = &(struct json_obj_descr) { \
+			.type = elem_type_, \
+			.offset = offsetof(struct_, len_field_), \
+		}, \
+		.n_elements = (max_len_), \
+	}
+
+/**
  * @brief Parses the JSON-encoded object pointer to by @param json, with
  * size @param len, according to the descriptor pointed to by @param descr.
  * Values are stored in a struct pointed to by @param val.  Set up the

--- a/tests/lib/json/src/main.c
+++ b/tests/lib/json/src/main.c
@@ -113,7 +113,7 @@ static void test_json_decoding(void)
 	zassert_equal(ts.some_array_len, 5, "Array has correct number of items");
 	zassert_true(!memcmp(ts.some_array, expected_array,
 		    sizeof(expected_array)),
-		    "Array decoded with unexpected values");
+		    "Array decoded with expected values");
 }
 
 static void test_json_invalid_unicode(void)

--- a/tests/lib/json/src/main.c
+++ b/tests/lib/json/src/main.c
@@ -22,6 +22,11 @@ struct test_struct {
 	struct test_nested some_nested_struct;
 	int some_array[16];
 	size_t some_array_len;
+	bool another_bxxl;		 /* JSON field: "another_b!@l" */
+	bool if_;			 /* JSON: "if" */
+	int another_array[10];		 /* JSON: "another-array" */
+	size_t another_array_len;
+	struct test_nested xnother_nexx; /* JSON: "4nother_ne$+" */
 };
 
 static const struct json_obj_descr nested_descr[] = {
@@ -39,6 +44,15 @@ static const struct json_obj_descr test_descr[] = {
 			      nested_descr),
 	JSON_OBJ_DESCR_ARRAY(struct test_struct, some_array,
 			     16, some_array_len, JSON_TOK_NUMBER),
+	JSON_OBJ_DESCR_PRIM_NAMED(struct test_struct, "another_b!@l",
+				  another_bxxl, JSON_TOK_TRUE),
+	JSON_OBJ_DESCR_PRIM_NAMED(struct test_struct, "if",
+				  if_, JSON_TOK_TRUE),
+	JSON_OBJ_DESCR_ARRAY_NAMED(struct test_struct, "another-array",
+				   another_array, 10, another_array_len,
+				   JSON_TOK_NUMBER),
+	JSON_OBJ_DESCR_OBJECT_NAMED(struct test_struct, "4nother_ne$+",
+				    xnother_nexx, nested_descr),
 };
 
 static void test_json_encoding(void)
@@ -57,14 +71,33 @@ static void test_json_encoding(void)
 		.some_array[2] = 8,
 		.some_array[3] = 16,
 		.some_array[4] = 32,
-		.some_array_len = 5
+		.some_array_len = 5,
+		.another_bxxl = true,
+		.if_ = false,
+		.another_array[0] = 2,
+		.another_array[1] = 3,
+		.another_array[2] = 5,
+		.another_array[3] = 7,
+		.another_array_len = 4,
+		.xnother_nexx = {
+			.nested_int = 1234,
+			.nested_bool = true,
+			.nested_string = "no escape necessary",
+		},
 	};
 	char encoded[] = "{\"some_string\":\"zephyr 123\","
 		"\"some_int\":42,\"some_bool\":true,"
 		"\"some_nested_struct\":{\"nested_int\":-1234,"
 		"\"nested_bool\":false,\"nested_string\":"
 		"\"this should be escaped: \\t\"},"
-		"\"some_array\":[1,4,8,16,32]}";
+		"\"some_array\":[1,4,8,16,32],"
+		"\"another_b!@l\":true,"
+		"\"if\":false,"
+		"\"another-array\":[2,3,5,7],"
+		"\"4nother_ne$+\":{\"nested_int\":1234,"
+		"\"nested_bool\":true,"
+		"\"nested_string\":\"no escape necessary\"}"
+		"}";
 	char buffer[sizeof(encoded)];
 	int ret;
 
@@ -89,8 +122,15 @@ static void test_json_decoding(void)
 		"\"nested_bool\":false,\t"
 		"\"nested_string\":\"this should be escaped: \\t\"},"
 		"\"some_array\":[11,22, 33,\t45,\n299]"
+		"\"another_b!@l\":true,"
+		"\"if\":false,"
+		"\"another-array\":[2,3,5,7],"
+		"\"4nother_ne$+\":{\"nested_int\":1234,"
+		"\"nested_bool\":true,"
+		"\"nested_string\":\"no escape necessary\"}"
 		"}";
 	const int expected_array[] = { 11, 22, 33, 45, 299 };
+	const int expected_other_array[] = { 2, 3, 5, 7 };
 	int ret;
 
 	ret = json_obj_parse(encoded, sizeof(encoded) - 1, test_descr,
@@ -114,6 +154,22 @@ static void test_json_decoding(void)
 	zassert_true(!memcmp(ts.some_array, expected_array,
 		    sizeof(expected_array)),
 		    "Array decoded with expected values");
+	zassert_true(ts.another_bxxl,
+		     "Named boolean (special chars) decoded correctly");
+	zassert_false(ts.if_,
+		      "Named boolean (reserved word) decoded correctly");
+	zassert_equal(ts.another_array_len, 4,
+		      "Named array has correct number of items");
+	zassert_true(!memcmp(ts.another_array, expected_other_array,
+			     sizeof(expected_other_array)),
+		     "Decoded named array with expected values");
+	zassert_equal(ts.xnother_nexx.nested_int, 1234,
+		      "Named nested integer decoded correctly");
+	zassert_equal(ts.xnother_nexx.nested_bool, true,
+		      "Named nested boolean decoded correctly");
+	zassert_true(!strcmp(ts.xnother_nexx.nested_string,
+			     "no escape necessary"),
+		     "Named nested string decoded correctly");
 }
 
 static void test_json_invalid_unicode(void)


### PR DESCRIPTION
A couple of trivial fix-ups, some new helper macros for creating descriptors, and updated tests. 

It's possible to use the JSON library without the new helpers by initializing descriptors manually, but mixing that with JSON_OBJ_DESCR_XXX() is ugly.

Intended for 1.9, but shouldn't cause any harm if merged early; the new macros have no users.
