### PR TITLE
Revert "x86: call gen_idt with $ZEPHYR_BASE too"

### DIFF
--- a/arch/x86/Makefile.idt
+++ b/arch/x86/Makefile.idt
@@ -5,7 +5,7 @@ else
 endif
 
 ifeq ($(PREBUILT_HOST_TOOLS),)
-	GENIDT := $(ZEPHYR_BASE)/scripts/gen_idt/gen_idt
+	GENIDT := scripts/gen_idt/gen_idt
 else
 	GENIDT := $(PREBUILT_HOST_TOOLS)/gen_idt
 endif
@@ -29,7 +29,7 @@ quiet_cmd_gen_idt = SIDT    $@
 )
 
 $(GENIDT):
-	$(Q)$(MAKE) $(build)=$(ZEPHYR_BASE)/scripts/gen_idt
+	$(Q)$(MAKE) $(build)=scripts/gen_idt
 
 staticIdt.o: $(PREBUILT_KERNEL) $(GENIDT)
 	$(call cmd,gen_idt)


### PR DESCRIPTION
This reverts commit 37f4178f58a8f08ffa5c1a64f072b1a3a255a352.

This change builds gen_idt in the zephyr project tree instead of
building it in outdir of the application. The build process should all
happen inside outdir and no binaries should be places in the zephyr
tree.