### PR TITLE
arch: arm: Fix compile error on ARMv6-M SoCs with TICKLESS_KERNEL

### DIFF
--- a/arch/arm/core/exc_exit.S
+++ b/arch/arm/core/exc_exit.S
@@ -61,7 +61,12 @@ SECTION_SUBSEC_FUNC(TEXT, _HandlerModeExit, _IntExit)
 #ifdef CONFIG_TICKLESS_KERNEL
     push {lr}
     bl _update_time_slice_before_swap
+#if defined(CONFIG_ARMV6_M)
+    pop {r0}
+    mov lr, r0
+#else
     pop {lr}
+#endif /* CONFIG_ARMV6_M */
 #endif
 
 /**


### PR DESCRIPTION
pop {lr} instruction is not supported in ARMv6-M, fixed by
using pop {r0}; mov lr, r0; instructions.

Jira: ZEP-2222

Signed-off-by: Vinayak Kariappa Chettimada <vich@nordicsemi.no>