### PR TITLE
Fixes for timeslicing related issues

### DIFF
--- a/arch/arm/core/exc_exit.S
+++ b/arch/arm/core/exc_exit.S
@@ -24,7 +24,7 @@ _ASM_FILE_PROLOGUE
 GTEXT(_ExcExit)
 GTEXT(_IntExit)
 GDATA(_kernel)
-#ifdef CONFIG_TICKLESS_KERNEL
+#ifdef CONFIG_TIMESLICING
 GTEXT(_update_time_slice_before_swap)
 #endif
 
@@ -58,7 +58,7 @@ SECTION_SUBSEC_FUNC(TEXT, _HandlerModeExit, _IntExit)
 
 /* _IntExit falls through to _ExcExit (they are aliases of each other) */
 
-#ifdef CONFIG_TICKLESS_KERNEL
+#ifdef CONFIG_TIMESLICING
     push {lr}
     bl _update_time_slice_before_swap
 #if defined(CONFIG_ARMV6_M)

--- a/arch/nios2/core/exception.S
+++ b/arch/nios2/core/exception.S
@@ -18,6 +18,9 @@ GTEXT(__swap)
 GTEXT(_irq_do_offload)
 GTEXT(_offload_routine)
 #endif
+#ifdef CONFIG_TIMESLICING
+GTEXT(_update_time_slice_before_swap)
+#endif
 
 /* Allows use of r1/at register, otherwise reserved for assembler use */
 .set noat
@@ -144,6 +147,10 @@ on_irq_stack:
 	 * we switched stacks. Restore it to go back to thread stack
 	 */
 	ldw sp, 0(sp)
+
+#ifdef CONFIG_TIMESLICING
+	call _update_time_slice_before_swap
+#endif
 
 	/* Argument to Swap() is estatus since that's the state of the
 	 * status register before the exception happened. When coming

--- a/arch/riscv32/core/isr.S
+++ b/arch/riscv32/core/isr.S
@@ -37,6 +37,10 @@ GTEXT(_sys_k_event_logger_interrupt)
 GTEXT(_offload_routine)
 #endif
 
+#ifdef CONFIG_TIMESLICING
+GTEXT(_update_time_slice_before_swap)
+#endif
+
 /* exports */
 GTEXT(__irq_wrapper)
 
@@ -306,6 +310,9 @@ on_thread_stack:
 #endif /* CONFIG_PREEMPT_ENABLED */
 
 reschedule:
+#if CONFIG_TIMESLICING
+	call _update_time_slice_before_swap
+#endif
 #if CONFIG_KERNEL_EVENT_LOGGER_CONTEXT_SWITCH
 	call _sys_k_event_logger_context_switch
 #endif /* CONFIG_KERNEL_EVENT_LOGGER_CONTEXT_SWITCH */

--- a/arch/x86/core/intstub.S
+++ b/arch/x86/core/intstub.S
@@ -30,7 +30,7 @@
 	/* externs */
 
 	GTEXT(__swap)
-#if defined(CONFIG_TICKLESS_KERNEL) && defined(CONFIG_TIMESLICING)
+#if defined(CONFIG_TIMESLICING)
 	GTEXT(_update_time_slice_before_swap)
 #endif
 
@@ -340,7 +340,7 @@ alreadyOnIntStack:
 	popl	%esi
 #endif
 
-#if defined(CONFIG_TICKLESS_KERNEL) && defined(CONFIG_TIMESLICING)
+#if defined(CONFIG_TIMESLICING)
 	call	_update_time_slice_before_swap
 #endif
 	pushfl			/* push KERNEL_LOCK_KEY argument */

--- a/kernel/include/nano_internal.h
+++ b/kernel/include/nano_internal.h
@@ -52,7 +52,7 @@ extern void _new_thread(struct k_thread *thread, char *pStack, size_t stackSize,
 
 extern unsigned int __swap(unsigned int key);
 
-#if defined(CONFIG_TICKLESS_KERNEL) && defined(CONFIG_TIMESLICING)
+#if defined(CONFIG_TIMESLICING)
 extern void _update_time_slice_before_swap(void);
 
 static inline unsigned int _time_slice_swap(unsigned int key)

--- a/kernel/sched.c
+++ b/kernel/sched.c
@@ -397,7 +397,6 @@ void k_sched_time_slice_set(s32_t duration_in_ms, int prio)
 	_time_slice_prio_ceiling = prio;
 }
 
-#ifdef CONFIG_TICKLESS_KERNEL
 int _is_thread_time_slicing(struct k_thread *thread)
 {
 	/*
@@ -424,21 +423,20 @@ int _is_thread_time_slicing(struct k_thread *thread)
 /* Should be called only immediately before a thread switch */
 void _update_time_slice_before_swap(void)
 {
+#ifdef CONFIG_TICKLESS_KERNEL
 	if (!_is_thread_time_slicing(_get_next_ready_thread())) {
 		return;
 	}
-
-	/* Restart time slice count at new thread switch */
-	_time_slice_elapsed = 0;
 
 	u32_t remaining = _get_remaining_program_time();
 
 	if (!remaining || (_time_slice_duration < remaining)) {
 		_set_time(_time_slice_duration);
 	}
-}
 #endif
-
+	/* Restart time slice count at new thread switch */
+	_time_slice_elapsed = 0;
+}
 #endif /* CONFIG_TIMESLICING */
 
 int k_is_preempt_thread(void)

--- a/kernel/sys_clock.c
+++ b/kernel/sys_clock.c
@@ -307,18 +307,10 @@ static void handle_time_slicing(s32_t ticks)
 {
 #ifdef CONFIG_TICKLESS_KERNEL
 	next_ts = 0;
+#endif
 	if (!_is_thread_time_slicing(_current)) {
 		return;
 	}
-#else
-	if (_time_slice_duration == 0) {
-		return;
-	}
-
-	if (_is_prio_higher(_current->base.prio, _time_slice_prio_ceiling)) {
-		return;
-	}
-#endif
 
 	_time_slice_elapsed += __ticks_to_ms(ticks);
 	if (_time_slice_elapsed >= _time_slice_duration) {

--- a/tests/kernel/threads_scheduling/schedule_api/testcase.ini
+++ b/tests/kernel/threads_scheduling/schedule_api/testcase.ini
@@ -1,4 +1,2 @@
 [test]
 tags = kernel
-# tickless is not supported on nios2
-arch_exclude = nios2


### PR DESCRIPTION
Fix for: https://jira.zephyrproject.org/browse/ZEP-2107

I also added proper support for interrupt-induced swaps for Nios II and RISCV32.
Xtensa and ARC are more complex, I opened:
https://jira.zephyrproject.org/browse/ZEP-2233
https://jira.zephyrproject.org/browse/ZEP-2234