### PR TITLE
x86: don't shift data addresses between builds

### DIFF
--- a/include/arch/x86/linker.ld
+++ b/include/arch/x86/linker.ld
@@ -93,12 +93,20 @@ SECTIONS
 
 	. = ALIGN(8);
 	_idt_base_address = .;
+#ifdef LINKER_PASS2
 	KEEP(*(staticIdt))
+#else
+	. += CONFIG_IDT_NUM_VECTORS * 8;
+#endif
 
 #ifndef CONFIG_X86_FIXED_IRQ_MAPPING
 	. = ALIGN(4);
 	_irq_to_interrupt_vector = .;
+#ifdef LINKER_PASS2
 	KEEP(*(irq_int_vector_map))
+#else
+	. += CONFIG_MAX_IRQ_LINES;
+#endif
 #endif
 
 #ifdef CONFIG_CUSTOM_RODATA_LD


### PR DESCRIPTION
Inserting the IDT results in any data afterwards being shifted.
We want the memory addresses between the zephyr_prebuilt.elf
and zephyr.elf to be as close as possible. Insert some dummy
data in the linker script the same size as the gen_idt data
structures. Needed for forthcoming patches which generate MMU
page tables at build time.

Signed-off-by: Andrew Boie <andrew.p.boie@intel.com>