### PR TITLE
net: tcp: Limit number of segment retransmissions

### DIFF
--- a/subsys/net/ip/Kconfig
+++ b/subsys/net/ip/Kconfig
@@ -139,6 +139,25 @@ config NET_TCP_ACK_TIMEOUT
 	various TCP states. The value is in milliseconds. Note that
 	having a very low value here could prevent connectivity.
 
+config NET_TCP_RETRY_COUNT
+	int "Maximum number of TCP segment retransmissions"
+	depends on NET_TCP
+	default 9
+	help
+	The following formula can be used to determine the time (in ms)
+	that a segment will be be buffered awaiting retransmission:
+	n=NET_TCP_RETRY_COUNT
+	∑((1<<n) * 200)
+	n=0
+	With the default value of 9, the IP stack will try to
+	retransmit for up to 1:42 minutes.  This is as close as possible
+	to the minimum value recommended by RFC1122 (1:40 minutes).
+	Only 5 bits are dedicated for the retransmission count, so accepted
+	values are in the 0-31 range.  It's highly recommended to not go
+	below 9, though.
+	Should a retransmission timeout occur, the receive callback is
+	called with -ECONNRESET error code and the context is dereferenced.
+
 config NET_UDP
 	bool "Enable UDP"
 	default y


### PR DESCRIPTION
Defines a new tunable, CONFIG_NET_TCP_RETRY_COUNT, that determines the
number of segment retransmissions that the IP stack will attempt to
perform before resetting the connection.

The default value is 9 retransmissions, which amounts to 1:42 minutes,
as close as possible to the minimum recommended by RFC1122.

Jira: ZEP-1956, ZEP-1957

Signed-off-by: Leandro Pereira <leandro.pereira@intel.com>