### PR TITLE
net: context: handle multiple tcp SYNs on the same iface

### DIFF
--- a/subsys/net/ip/net_context.c
+++ b/subsys/net/ip/net_context.c
@@ -1346,6 +1346,11 @@ NET_CONN_CB(tcp_syn_rcvd)
 
 		net_tcp_print_recv_info("SYN", pkt, NET_TCP_HDR(pkt)->src_port);
 
+		if (net_tcp_get_state(tcp) != NET_TCP_LISTEN) {
+			NET_DBG("we cannot process 2 SYNs here simultaneously.");
+			return NET_DROP;
+		}
+
 		net_tcp_change_state(tcp, NET_TCP_SYN_RCVD);
 
 		remote = create_sockaddr(pkt, &peer);


### PR DESCRIPTION
When we are waiting connections and tcp is under the state of SYN_RCVD or other but not LISTEN, then a SYN packet is received, we should drop it. For example we are as a server, and multiple clients or multiple processes of single client send SYNs to the same iface on the server.

Signed-off-by: likai liu <likai.liu@linaro.org>