### PR TITLE
samples: net: dtls_client: Fix Coverity warning

### DIFF
--- a/samples/net/mbedtls_dtlsclient/src/udp.c
+++ b/samples/net/mbedtls_dtlsclient/src/udp.c
@@ -128,7 +128,14 @@ int udp_rx(void *context, unsigned char *buf, size_t size)
 	}
 
 	ptr = net_pkt_appdata(ctx->rx_pkt);
+
 	rx_buf = ctx->rx_pkt->frags;
+	if (!rx_buf) {
+		net_pkt_unref(ctx->rx_pkt);
+		ctx->rx_pkt = NULL;
+		return -ENOMEM;
+	}
+
 	len = rx_buf->len - (ptr - rx_buf->data);
 	pos = 0;
 


### PR DESCRIPTION
This fix is basically a no-op as the rx_buf pointer cannot be null
in practice, but in order to avoid Coverity complaining about
it add some null pointer checks to the UDP handling code.

Coverity-CID: 170124
Jira: ZEP-2235

Signed-off-by: Jukka Rissanen <jukka.rissanen@linux.intel.com>