### PR TITLE
flash: stm32 l4 fix

### DIFF
--- a/drivers/flash/flash_stm32.c
+++ b/drivers/flash/flash_stm32.c
@@ -95,7 +95,7 @@ void flash_stm32_flush_caches(struct flash_stm32_priv *p)
 static int flash_stm32_read(struct device *dev, off_t offset, void *data,
 			    size_t len)
 {
-	if (!flash_stm32_valid_range(offset, len)) {
+	if (!flash_stm32_valid_range(offset, len, false)) {
 		return -EINVAL;
 	}
 
@@ -113,7 +113,7 @@ int flash_stm32_erase(struct device *dev, off_t offset, size_t len)
 	struct flash_stm32_priv *p = dev->driver_data;
 	int rc;
 
-	if (!flash_stm32_valid_range(offset, len)) {
+	if (!flash_stm32_valid_range(offset, len, true)) {
 		return -EINVAL;
 	}
 
@@ -138,7 +138,7 @@ int flash_stm32_write(struct device *dev, off_t offset,
 	struct flash_stm32_priv *p = dev->driver_data;
 	int rc;
 
-	if (!flash_stm32_valid_range(offset, len)) {
+	if (!flash_stm32_valid_range(offset, len, true)) {
 		return -EINVAL;
 	}
 

--- a/drivers/flash/flash_stm32.h
+++ b/drivers/flash/flash_stm32.h
@@ -30,7 +30,7 @@ struct flash_stm32_priv {
 	struct k_sem sem;
 };
 
-bool flash_stm32_valid_range(off_t offset, u32_t len);
+bool flash_stm32_valid_range(off_t offset, u32_t len, bool write);
 
 int flash_stm32_write_range(unsigned int offset, const void *data,
 			    unsigned int len, struct flash_stm32_priv *p);

--- a/drivers/flash/flash_stm32f4x.c
+++ b/drivers/flash/flash_stm32f4x.c
@@ -13,8 +13,9 @@
 
 #include <flash_stm32.h>
 
-bool flash_stm32_valid_range(off_t offset, u32_t len)
+bool flash_stm32_valid_range(off_t offset, u32_t len, bool write)
 {
+	ARG_UNUSED(write);
 	return offset >= 0 && (offset + len - 1 <= STM32F4X_FLASH_END);
 }
 

--- a/drivers/flash/flash_stm32l4x.c
+++ b/drivers/flash/flash_stm32l4x.c
@@ -142,7 +142,7 @@ int flash_stm32_write_range(unsigned int offset, const void *data,
 	int i, rc = 0;
 
 	for (i = 0; i < len; i += 8, offset += 8) {
-		rc = write_dword(offset, ((const u64_t *) data)[i], p);
+		rc = write_dword(offset, ((const u64_t *) data)[i>>3], p);
 		if (rc < 0) {
 			return rc;
 		}

--- a/drivers/flash/flash_stm32l4x.c
+++ b/drivers/flash/flash_stm32l4x.c
@@ -20,13 +20,13 @@
 #define STM32L4X_FLASH_END \
 	((u32_t)(STM32L4X_BANK_SIZE_MAX << STM32L4X_PAGE_SHIFT) - 1)
 
-/* offset and len must be aligned on 8, positive and not beyond end of flash */
-bool flash_stm32_valid_range(off_t offset, u32_t len)
+/* offset and len must be aligned on 8 for write
+ * , positive and not beyond end of flash */
+bool flash_stm32_valid_range(off_t offset, u32_t len, bool write)
 {
-	return offset % 8 == 0 &&
-	       len % 8 == 0 &&
-	       offset >= 0 &&
-	       (offset + len - 1 <= STM32L4X_FLASH_END);
+	return (!write || (offset % 8 == 0 && len % 8 == 0)) &&
+		offset >= 0 &&
+		(offset + len - 1 <= STM32L4X_FLASH_END);
 }
 
 /* STM32L4xx devices can have up to 512 2K pages on two 256x2K pages banks */


### PR DESCRIPTION
Here are fixes  on stm32l4 flash driver
flash write access on L4 64bits  fetches wrong data to write.
flash read access on l4 64 bits implements align check not needed
