### PR TITLE
arm: nxp: mpu: Return constant number of mpu regions

### DIFF
--- a/arch/arm/core/cortex_m/mpu/nxp_mpu.c
+++ b/arch/arm/core/cortex_m/mpu/nxp_mpu.c
@@ -38,22 +38,7 @@ static inline u32_t _get_region_attr_by_type(u32_t type)
 
 static inline u8_t _get_num_regions(void)
 {
-	u32_t type = (SYSMPU->CESR & SYSMPU_CESR_NRGD_MASK)
-			>> SYSMPU_CESR_NRGD_SHIFT;
-
-	switch (type) {
-	case 0:
-		return 8;
-	case 1:
-		return 12;
-	case 2:
-		return 16;
-	default:
-		__ASSERT(0, "Unsupported MPU configuration.");
-		return 0;
-	}
-
-	return NXP_MPU_REGION_NUMBER;
+	return FSL_FEATURE_SYSMPU_DESCRIPTOR_COUNT;
 }
 
 static void _region_init(u32_t index, u32_t region_base,


### PR DESCRIPTION
The original implementation of _get_num_regions() parsed the CESR[NRGD]
register field to determine the number of mpu region descriptors
implemented in hardware. There was a possible path in the code to return
zero, which would cause underflow later on in arm_core_mpu_configure().
Coverity complained despite an assert to catch this condition. Instead,
use a preprocessor macro from mcux that defines the number of mpu region
descriptors.

Coverity-CID: 169811
Jira: ZEP-2208

Signed-off-by: Maureen Helm <maureen.helm@nxp.com>