### PR TITLE
net: context: Operations on unused context should lead to EBADF.

### DIFF
--- a/subsys/net/ip/net_context.c
+++ b/subsys/net/ip/net_context.c
@@ -646,7 +646,7 @@ int net_context_listen(struct net_context *context, int backlog)
 	NET_ASSERT(PART_OF_ARRAY(contexts, context));
 
 	if (!net_context_is_used(context)) {
-		return -ENOENT;
+		return -EBADF;
 	}
 
 #if defined(CONFIG_NET_OFFLOAD)
@@ -1064,7 +1064,7 @@ int net_context_connect(struct net_context *context,
 #endif
 
 	if (!net_context_is_used(context)) {
-		return -ENOENT;
+		return -EBADF;
 	}
 
 	if (addr->family != net_context_get_family(context)) {
@@ -1577,7 +1577,7 @@ int net_context_accept(struct net_context *context,
 	NET_ASSERT(PART_OF_ARRAY(contexts, context));
 
 	if (!net_context_is_used(context)) {
-		return -ENOENT;
+		return -EBADF;
 	}
 
 #if defined(CONFIG_NET_OFFLOAD)
@@ -1748,7 +1748,7 @@ static int sendto(struct net_pkt *pkt,
 	int ret;
 
 	if (!net_context_is_used(context)) {
-		return -ENOENT;
+		return -EBADF;
 	}
 
 #if defined(CONFIG_NET_TCP)
@@ -2051,7 +2051,7 @@ int net_context_recv(struct net_context *context,
 	NET_ASSERT(context);
 
 	if (!net_context_is_used(context)) {
-		return -ENOENT;
+		return -EBADF;
 	}
 
 #if defined(CONFIG_NET_OFFLOAD)


### PR DESCRIPTION
Semantics of ENOENT error as used previously is "named entity not
found", whereas for "I/O handle is not valid", there's EBADF. For
example, POSIX/SUSV2 doesn't even list ENOENT as a possible error
for accept(), connect(), recv(), etc. whereas it lists EBADF, e.g.:
http://pubs.opengroup.org/onlinepubs/7908799/xns/connect.html

Signed-off-by: Paul Sokolovsky <paul.sokolovsky@linaro.org>