### PR TITLE
tcp: Use TCP queueing for control segments as well

### DIFF
--- a/subsys/net/ip/net_context.c
+++ b/subsys/net/ip/net_context.c
@@ -710,17 +710,26 @@ static inline int send_control_segment(struct net_context *context,
 
 	ret = net_tcp_prepare_segment(context->tcp, flags, NULL, 0,
 				      local, remote, &pkt);
-	if (ret) {
+	if (ret < 0) {
 		return ret;
+	}
+
+	ret = net_tcp_queue_data(context, pkt);
+	if (ret < 0) {
+		goto out;
 	}
 
 	ret = net_send_data(pkt);
 	if (ret < 0) {
-		net_pkt_unref(pkt);
+		goto out;
 	}
 
 	net_tcp_print_send_info(msg, pkt, NET_TCP_HDR(pkt)->dst_port);
 
+	return 0;
+
+out:
+	net_pkt_unref(pkt);
 	return ret;
 }
 


### PR DESCRIPTION
Use the same queueing mechanism used for the synchronized states during
the synchronization phase of a TCP connection.

This way, the "SYN" segment should be retransmitted until a "SYN+ACK" is
received from the peer, using exponential backoff until NET_TCP_RETRY_COUNT
tries, whichever comes first.

On timeout, the connection callback is called with -ETIMEDOUT as the
status code (similar to POSIX connect(2)).

Jira: ZEP-1974
Signed-off-by: Leandro Pereira <leandro.pereira@intel.com>