### PR TITLE
gitlint: Ignore signed-off-by line

### DIFF
--- a/.gitlint
+++ b/.gitlint
@@ -35,7 +35,7 @@ words=wip,title
 # (e.g. title-must-not-contain-word).
 #regex=^US[0-9]*
 
-[B1]
+[max-line-length-with-exceptions]
 # B1 = body-max-line-length
 line-length=72
 

--- a/scripts/gitlint/zephyr_commit_rules.py
+++ b/scripts/gitlint/zephyr_commit_rules.py
@@ -1,4 +1,4 @@
-from gitlint.rules import CommitRule, RuleViolation, TitleRegexMatches, CommitMessageTitle, LineRule
+from gitlint.rules import CommitRule, RuleViolation, TitleRegexMatches, CommitMessageTitle, LineRule, CommitMessageBody
 from gitlint.options import IntOption, BoolOption, StrOption, ListOption
 import re
 
@@ -68,3 +68,15 @@ class TitleStartsWithSubsystem(LineRule):
         violation_message = "Title does not follow <subsystem>: <subject>"
         if not pattern.search(title):
             return [RuleViolation(self.id, violation_message, title)]
+
+class MaxLineLengthExceptions(LineRule):
+    name = "max-line-length-with-exceptions"
+    id = "UC4"
+    target = CommitMessageBody
+    options_spec = [IntOption('line-length', 80, "Max line length")]
+    violation_message = "Line exceeds max length ({0}>{1})"
+
+    def validate(self, line, _commit):
+        max_length = self.options['line-length'].value
+        if len(line) > max_length and not line.startswith('Signed-off-by'):
+            return [RuleViolation(self.id, self.violation_message.format(len(line), max_length), line)]


### PR DESCRIPTION
When checking for line length limits, ignore lines with Signed-off-by.
Some developers have a long name that would not fit within the limits.