### PR TITLE
Bluetooth: controller: Handle reset atomic properly

### DIFF
--- a/subsys/bluetooth/controller/hci/hci.c
+++ b/subsys/bluetooth/controller/hci/hci.c
@@ -189,8 +189,10 @@ static void reset(struct net_buf *buf, struct net_buf **evt)
 	hci_hbuf_sent = 0;
 	hci_hbuf_acked = 0;
 	conn_count = 0;
-	atomic_set_bit(&hci_state_mask, HCI_STATE_BIT_RESET);
-	k_poll_signal(hbuf_signal, 0x0);
+	if (buf) {
+		atomic_set_bit(&hci_state_mask, HCI_STATE_BIT_RESET);
+		k_poll_signal(hbuf_signal, 0x0);
+	}
 #endif
 }
 


### PR DESCRIPTION
In order to reuse code, the reset() function is used both to handle the
reset HCI command but also to initialize the internal HCI variables when
bringing up the system. In the latter case, avoid setting the reset bit
in the state atomic and signalling the polling API, since that is not
required during initialization.

Signed-off-by: Carles Cufi <carles.cufi@nordicsemi.no>