### PR TITLE
Get sanitycheck working properly with DTS enabled targets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1005,6 +1005,17 @@ endif
 
 dts: include/generated/generated_dts_board.h
 
+define filechk_.config-sanitycheck
+	(cat .config; \
+	 grep -e '^CONFIG' include/generated/generated_dts_board.conf | cat; \
+	)
+endef
+
+.config-sanitycheck: include/generated/generated_dts_board.conf FORCE
+	$(call filechk,.config-sanitycheck)
+
+config-sanitycheck: .config-sanitycheck
+
 # The actual objects are generated when descending,
 # make sure no implicit rule kicks in
 $(sort $(zephyr-deps)): $(zephyr-dirs) zephyr-app-dir ;
@@ -1121,6 +1132,7 @@ CLEAN_DIRS  += $(MODVERDIR)
 
 CLEAN_FILES += 	include/generated/generated_dts_board.conf \
 		include/generated/generated_dts_board.h \
+		.config-sanitycheck \
 		.old_version .tmp_System.map .tmp_version \
 		.tmp_* System.map *.lnk *.map *.elf *.lst \
 		*.bin *.hex *.stat *.strip staticIdt.o linker.cmd \

--- a/Makefile.inc
+++ b/Makefile.inc
@@ -125,6 +125,9 @@ outputexports: initconfig
 dts: initconfig
 	$(Q)$(call zephyrmake,$(O),$@)
 
+config-sanitycheck: dts
+	$(Q)$(call zephyrmake,$(O),$@)
+
 menuconfig: initconfig
 	$(Q)$(call zephyrmake,$(O),$@)
 

--- a/drivers/bluetooth/hci/Kconfig
+++ b/drivers/bluetooth/hci/Kconfig
@@ -40,7 +40,7 @@ config BLUETOOTH_H5
 
 config BLUETOOTH_SPI
 	bool "SPI HCI"
-	select SPI
+	depends on SPI
 	help
 	  Supports Bluetooth ICs using SPI as the communication protocol.
 	  HCI packets are sent and received as single Byte transfers,

--- a/drivers/rtc/Kconfig
+++ b/drivers/rtc/Kconfig
@@ -34,7 +34,7 @@ config RTC_0_NAME
 
 config RTC_0_IRQ_PRI
 	int "RTC Driver Interrupt priority"
-	depends on RTC
+	depends on RTC_QMSI
 	help
 	RTC interrupt priority.
 

--- a/scripts/sanitycheck
+++ b/scripts/sanitycheck
@@ -1354,7 +1354,7 @@ class TestSuite:
                     if tc.tc_filter and (plat in arch.platforms[:platform_limit] or all_plats or platform_filter):
                         args = tc.extra_args[:]
                         args.extend(["ARCH=" + plat.arch.name,
-                                "BOARD=" + plat.name, "initconfig"])
+                                "BOARD=" + plat.name, "config-sanitycheck"])
                         args.extend(extra_args)
                         # FIXME would be nice to use a common outdir for this so that
                         # conf, gen_idt, etc aren't rebuilt for every  combination,
@@ -1362,8 +1362,8 @@ class TestSuite:
                         # each other since they all try to build them simultaneously
 
                         o = os.path.join(self.outdir, plat.name, tc.path)
-                        dlist[tc, plat, tc.name.split("/")[-1]] = os.path.join(o,".config")
-                        goal = "_".join([plat.name, "_".join(tc.name.split("/")), "initconfig"])
+                        dlist[tc, plat, tc.name.split("/")[-1]] = os.path.join(o,".config-sanitycheck")
+                        goal = "_".join([plat.name, "_".join(tc.name.split("/")), "config-sanitycheck"])
                         mg.add_build_goal(goal, os.path.join(ZEPHYR_BASE, tc.code_location), o, args)
 
         info("Building testcase defconfigs...")


### PR DESCRIPTION
This patch creates a new sanitycheck target.  this target collates the kconfig options with the DTS generated ones.  Sanitycheck will now filter properly for DTS enabled targets for DTS generated config options.