### PR TITLE
samples: net: Fix README.rst file documentation

### DIFF
--- a/samples/net/coaps_client/README.rst
+++ b/samples/net/coaps_client/README.rst
@@ -10,7 +10,7 @@ This sample code shows a CoAP over DTLS client using mbedTLS on top of Zephyr.
 Building and Running
 ********************
 
-Follow the steps for testing :ref:`networking with Qemu <networking_with_qemu>`.
+Follow the steps for testing :ref:`networking_with_qemu`.
 
 Run the server application at samples/net/coaps_server, with the following
 command:

--- a/samples/net/coaps_server/README.rst
+++ b/samples/net/coaps_server/README.rst
@@ -10,7 +10,7 @@ This sample code shows a CoAP over DTLS server using mbedTLS on top of Zephyr.
 Building and Running
 ********************
 
-Follow the steps for testing :ref:`networking with Qemu <networking_with_qemu>`.
+Follow the steps for testing :ref:`networking_with_qemu`.
 
 In the application directory type:
 

--- a/samples/net/dhcpv4_client/README.rst
+++ b/samples/net/dhcpv4_client/README.rst
@@ -13,33 +13,19 @@ information to a serial console.
 Requirements
 ************
 
-- :ref:`networking with Qemu <networking_with_qemu>`
+- :ref:`networking_with_qemu`
 
 Building and Running
 ********************
 
-QEMU x86
-========
+Running DHCPv4 client in Linux Host
+===================================
 
 These are instructions for how to use this sample application using
 QEMU on a Linux host to negotiate IP address from DHCPv4 server running
 on Linux host.
 
-Follow readme from:
-
-    Run 'loop_socat' and 'loop-slip-tap' scripts from net-tools.
-
-    https://github.com/zephyrproject-rtos/net-tools
-
-.. code-block:: console
-
-    $ ./loop_socat.sh
-
-In another window:
-
-.. code-block:: console
-
-    $ sudo ./loop-slip-tap.sh
+To use QEMU for testing, follow the :ref:`networking_with_qemu` guide.
 
 Here's a sample server configuration file '/etc/dhcpd/dhcp.conf'
 used to configure the DHCPv4 server:

--- a/samples/net/dns_resolve/README.rst
+++ b/samples/net/dns_resolve/README.rst
@@ -21,7 +21,7 @@ For more information about DNS configuration variables, see:
 Requirements
 ************
 
-- :ref:`networking with Qemu <networking_with_qemu>`
+- :ref:`networking_with_qemu`
 
 - screen terminal emulator or equivalent.
 
@@ -82,11 +82,8 @@ DNS server
 ==========
 
 The dnsmasq tool may be used for testing purposes. Sample dnsmasq start
-script can be found in net-tools project.
-
-The net-tools can be downloaded from
-
-    https://github.com/zephyrproject-rtos/net-tools
+script can be downloaded from the zephyrproject-rtos/net-tools project area:
+https://github.com/zephyrproject-rtos/net-tools
 
 Open a terminal window and type:
 
@@ -131,24 +128,7 @@ Try to launch the dnsmasq application again.
 QEMU x86
 ========
 
-Open a terminal window and type:
-
-.. code-block:: console
-
-    $ make
-
-
-Run 'loop_socat.sh' and 'loop-slip-tap.sh' as shown in the net-tools README
-at:
-
-    https://github.com/zephyrproject-rtos/net-tools
-
-
-Open a terminal where the project was build (i.e. :file:`samples/net/dns_resolve`) and type:
-
-.. code-block:: console
-
-    $ make run
+To use QEMU for testing, follow the :ref:`networking_with_qemu` guide.
 
 
 FRDM K64F

--- a/samples/net/echo_client/README.rst
+++ b/samples/net/echo_client/README.rst
@@ -13,12 +13,17 @@ and then verify it matches the data that was sent.
 The source code for this sample application can be found at:
 :file:`samples/net/echo_client`.
 
+Requirements
+************
+
+- :ref:`networking_with_qemu`
+
 Building and Running
 ********************
 
 There are multiple ways to use this application. One of the most common
 usage scenario is to run echo-client application inside QEMU. This is
-described in :ref:`networking with QEMU <networking_with_qemu>`.
+described in :ref:`networking_with_qemu`.
 
 There are configuration files for different boards and setups in the
 echo-client directory:
@@ -68,25 +73,15 @@ Build echo-client sample application like this:
 Make can select the default configuration file based on the BOARD you've
 specified automatically so you might not always need to mention it.
 
-Running echo-server Linux Host
-==============================
+Running echo-server in Linux Host
+=================================
 
 There is one useful testing scenario that can be used with Linux host.
 Here echo-client is run in QEMU and echo-server is run in Linux host.
 
-Run 'loop_socat' and 'loop-slip-tap' scripts from net-tools in Linux host.
+To use QEMU for testing, follow the :ref:`networking_with_qemu` guide.
 
-.. code-block:: console
-
-    $ ./loop_socat.sh
-
-In another window:
-
-.. code-block:: console
-
-    $ sudo ./loop-slip-tap.sh
-
-In third window:
+In a terminal window:
 
 .. code-block:: console
 
@@ -96,5 +91,5 @@ Run echo-client application in QEMU:
 
 .. code-block:: console
 
-    $ cd $ZEPHYR_BASE/samples/net/echo-client
+    $ cd $ZEPHYR_BASE/samples/net/echo_client
     $ make pristine && make qemu

--- a/samples/net/echo_server/README.rst
+++ b/samples/net/echo_server/README.rst
@@ -14,12 +14,17 @@ them back.
 The source code for this sample application can be found at:
 :file:`samples/net/echo_server`.
 
+Requirements
+************
+
+- :ref:`networking_with_qemu`
+
 Building and Running
 ********************
 
 There are multiple ways to use this application. One of the most common
 usage scenario is to run echo-server application inside QEMU. This is
-described in :ref:`networking with QEMU <networking_with_qemu>`.
+described in :ref:`networking_with_qemu`.
 
 There are configuration files for different boards and setups in the
 echo-server directory:
@@ -75,26 +80,16 @@ Running echo-client in Linux Host
 There is one useful testing scenario that can be used with Linux host.
 Here echo-server is run in QEMU and echo-client is run in Linux host.
 
-Run 'loop_socat' and 'loop-slip-tap' scripts from net-tools in Linux host.
-
-.. code-block:: console
-
-    $ ./loop_socat.sh
-
-In another window:
-
-.. code-block:: console
-
-    $ sudo ./loop-slip-tap.sh
+To use QEMU for testing, follow the :ref:`networking_with_qemu` guide.
 
 Run echo-server application in QEMU:
 
 .. code-block:: console
 
-    $ cd $ZEPHYR_BASE/samples/net/echo-server
+    $ cd $ZEPHYR_BASE/samples/net/echo_server
     $ make pristine && make qemu
 
-In third window:
+In a terminal window:
 
 .. code-block:: console
 

--- a/samples/net/http_client/README.rst
+++ b/samples/net/http_client/README.rst
@@ -16,16 +16,20 @@ The source code for this sample application can be found at:
 Requirements
 ************
 
-- QEMU
+- :ref:`networking_with_qemu`
 - Terminal emulator software
 - HTTP Server
 - DNS server (optional)
+
 
 Building and Running
 ********************
 
 Open the project configuration file for your platform, for example:
 :file:`prj_qemu_x86.conf` is the configuration file for QEMU.
+
+To use QEMU for testing, follow the :ref:`networking_with_qemu` guide.
+
 For IPv4 networks, set the following variables:
 
 .. code-block:: console
@@ -69,12 +73,9 @@ port is 8000.
 HTTP Server
 ===========
 
-A very simple HTTP server is provided in net-tool project.
-
-The net-tools can be downloaded from
-
-    https://github.com/zephyrproject-rtos/net-tools
-
+Sample code for a very simple HTTP server can be downloaded from the
+zephyrproject-rtos/net-tools project area:
+https://github.com/zephyrproject-rtos/net-tools
 
 Open a terminal window and type:
 
@@ -87,7 +88,7 @@ Open a terminal window and type:
 DNS setup
 =========
 
-The net-tool project provides a simple DNS resolver. You can activate
+The net-tools project provides a simple DNS resolver. You can activate
 it like this if you want to test the DNS resolving with HTTP client.
 
 Open a terminal window and type:

--- a/samples/net/http_server/README.rst
+++ b/samples/net/http_server/README.rst
@@ -23,7 +23,9 @@ Requirements
 
 - Linux machine with wget and the screen terminal emulator
 - Either QEMU or real device like Freedom Board (FRDM-K64F)
+- For QEMU see this :ref:`networking_with_qemu`
 - LAN for testing purposes (Ethernet)
+
 
 Building and Running
 ********************
@@ -32,6 +34,8 @@ Currently, the HTTP Server application is configured to listen at port 80.
 If you want to modify the http-server sample application, please check
 the configuration settings in :file:`samples/net/http_server/src/main.c` file
 and also in the :file:`samples/net/http_server/src/config.h` file.
+
+To use QEMU for testing, follow the :ref:`networking_with_qemu` guide.
 
 This sample code supports both static and dynamic (DHCPv4) IP addresses that
 can be defined in the project configuration file:
@@ -248,9 +252,6 @@ In order to compile and run the code execute:
 .. code-block:: console
 
         make BOARD=qemu_x86 run
-
-The sample code supports only one hard-coded valid URL (index.html) and
-will return 404 code for other requests.
 
 Sample Output
 =============

--- a/samples/net/mbedtls_dtlsclient/README.rst
+++ b/samples/net/mbedtls_dtlsclient/README.rst
@@ -10,7 +10,7 @@ This sample code shows a simple DTLS client using mbed TLS on top of Zephyr
 Building and running
 ********************
 
-Follow the steps for testing :ref:`networking with Qemu <networking_with_qemu>`.
+Follow the steps for testing :ref:`networking_with_qemu`.
 
 Obtain the mbed TLS code from:
 
@@ -50,7 +50,7 @@ From the application directory type
 
    $ make run
 
-This will result in Qemu running with the following output:
+This will result in QEMU running with the following output:
 
 .. code-block:: console
 

--- a/samples/net/mbedtls_dtlsserver/README.rst
+++ b/samples/net/mbedtls_dtlsserver/README.rst
@@ -10,7 +10,7 @@ This sample code shows a simple DTLS server using mbedTLS on top of Zephyr.
 Building and Running
 ********************
 
-Follow the steps for testing :ref:`networking with Qemu <networking_with_qemu>`.
+Follow the steps for testing :ref:`networking_with_qemu`.
 
 In the application directory type:
 

--- a/samples/net/telnet/README.rst
+++ b/samples/net/telnet/README.rst
@@ -15,7 +15,7 @@ using a telnet client.
 Requirements
 ************
 
-- :ref:`Networking with Qemu <networking_with_qemu>`
+- :ref:`networking_with_qemu`
 
 
 Building and Running
@@ -27,20 +27,7 @@ QEMU x86
 These are instructions for how to use this sample application using
 QEMU on a Linux host connected to a network with DHCP service.
 
-To use QEMU for testing, follow the :ref:`Networking with Qemu
-<networking_with_qemu>` guide.
-
-Run 'loop_socat' and 'loop-slip-tap' scripts from net-tools.
-
-.. code-block:: console
-
-    $ ./loop_socat.sh
-
-In another window:
-
-.. code-block:: console
-
-    $ sudo ./loop-slip-tap.sh
+To use QEMU for testing, follow the :ref:`networking_with_qemu` guide.
 
 Run Zephyr samples/net/telnet application in QEMU:
 


### PR DESCRIPTION
Various network samples contained QEMU slip setup instructions
or those instructions were missing. A reference doc in
doc/subsystems/networking/qemu_setup.rst file already has the
setup instructions for QEMU. So add a reference to that file
in samples/net/*/README.rst files and remove unnecessary slip
setup instructions in relevant files.

Fix various typos in readme files at the same time.

Signed-off-by: Jukka Rissanen <jukka.rissanen@linux.intel.com>