### PR TITLE
Bugfix: fixing copy past error for UART1 handler

### DIFF
--- a/drivers/serial/uart_fe310.c
+++ b/drivers/serial/uart_fe310.c
@@ -438,7 +438,7 @@ DEVICE_AND_API_INIT(uart_fe310_1, CONFIG_UART_FE310_PORT_1_NAME,
 		    (void *)&uart_fe310_driver_api);
 
 #ifdef CONFIG_UART_INTERRUPT_DRIVEN
-static void uart_fe310_irq_cfg_func_0(void)
+static void uart_fe310_irq_cfg_func_1(void)
 {
 	IRQ_CONNECT(FE310_UART_1_IRQ,
 		    CONFIG_UART_FE310_PORT_1_IRQ_PRIORITY,


### PR DESCRIPTION
drivers: serial: uart_fe310: fix function definiton name for UART1 IRQ

This commit fixes the compilation error that occurs if both UART
ports on the FE310 SoC are enabled. The error occurs due to the
missing function definition of uart_fe310_irq_cfg_func_1 .

Signed-off-by: Jens Peter Schroer <jens@manetos.com>
