### PR TITLE
Fixes for ZEP-2244

### DIFF
--- a/arch/arc/core/sys_fatal_error_handler.c
+++ b/arch/arc/core/sys_fatal_error_handler.c
@@ -37,8 +37,8 @@
  *
  * @return N/A
  */
-FUNC_NORETURN void _SysFatalErrorHandler(unsigned int reason,
-					 const NANO_ESF *pEsf)
+FUNC_NORETURN __weak void _SysFatalErrorHandler(unsigned int reason,
+						const NANO_ESF *pEsf)
 {
 	ARG_UNUSED(pEsf);
 

--- a/arch/arm/core/swap.S
+++ b/arch/arm/core/swap.S
@@ -42,24 +42,17 @@ GDATA(_kernel)
 
 SECTION_FUNC(TEXT, __pendsv)
 
-#if defined (CONFIG_KERNEL_EVENT_LOGGER_CONTEXT_SWITCH) || \
-		defined(CONFIG_STACK_SENTINEL)
+#ifdef CONFIG_KERNEL_EVENT_LOGGER_CONTEXT_SWITCH
     /* Register the context switch */
     push {lr}
-
-#ifdef CONFIG_KERNEL_EVENT_LOGGER_CONTEXT_SWITCH
     bl _sys_k_event_logger_context_switch
-#endif
-#ifdef CONFIG_STACK_SENTINEL
-    bl _check_stack_sentinel
-#endif
 #if defined(CONFIG_ARMV6_M)
     pop {r0}
     mov lr, r0
 #else
     pop {lr}
 #endif /* CONFIG_ARMV6_M */
-#endif /* CONFIG_KERNEL_EVENT_LOGGER_CONTEXT_SWITCH || CONFIG_STACK_SENTINEL */
+#endif /* CONFIG_KERNEL_EVENT_LOGGER_CONTEXT_SWITCH  */
 
     /* load _kernel into r1 and current k_thread into r2 */
     ldr r1, =_kernel

--- a/arch/arm/core/sys_fatal_error_handler.c
+++ b/arch/arm/core/sys_fatal_error_handler.c
@@ -44,6 +44,11 @@ void __weak _SysFatalErrorHandler(unsigned int reason,
 	ARG_UNUSED(pEsf);
 
 #if !defined(CONFIG_SIMPLE_FATAL_ERROR_HANDLER)
+#ifdef CONFIG_STACK_SENTINEL
+	if (reason == _NANO_ERR_STACK_CHK_FAIL) {
+		goto hang_system;
+	}
+#endif
 	if (reason == _NANO_ERR_KERNEL_PANIC) {
 		goto hang_system;
 	}

--- a/arch/arm/core/sys_fatal_error_handler.c
+++ b/arch/arm/core/sys_fatal_error_handler.c
@@ -38,7 +38,7 @@
  *
  * @return N/A
  */
-void _SysFatalErrorHandler(unsigned int reason,
+void __weak _SysFatalErrorHandler(unsigned int reason,
 					 const NANO_ESF *pEsf)
 {
 	ARG_UNUSED(pEsf);

--- a/arch/nios2/core/fatal.c
+++ b/arch/nios2/core/fatal.c
@@ -226,6 +226,11 @@ FUNC_NORETURN __weak void _SysFatalErrorHandler(unsigned int reason,
 	ARG_UNUSED(pEsf);
 
 #if !defined(CONFIG_SIMPLE_FATAL_ERROR_HANDLER)
+#ifdef CONFIG_STACK_SENTINEL
+	if (reason == _NANO_ERR_STACK_CHK_FAIL) {
+		goto hang_system;
+	}
+#endif
 	if (reason == _NANO_ERR_KERNEL_PANIC) {
 		goto hang_system;
 	}

--- a/arch/nios2/core/fatal.c
+++ b/arch/nios2/core/fatal.c
@@ -220,8 +220,8 @@ FUNC_NORETURN void _Fault(const NANO_ESF *esf)
  *
  * @return N/A
  */
-FUNC_NORETURN void _SysFatalErrorHandler(unsigned int reason,
-					 const NANO_ESF *pEsf)
+FUNC_NORETURN __weak void _SysFatalErrorHandler(unsigned int reason,
+						const NANO_ESF *pEsf)
 {
 	ARG_UNUSED(pEsf);
 

--- a/arch/nios2/core/swap.S
+++ b/arch/nios2/core/swap.S
@@ -59,12 +59,6 @@ SECTION_FUNC(exception.other, __swap)
 
 #if CONFIG_KERNEL_EVENT_LOGGER_CONTEXT_SWITCH
 	call _sys_k_event_logger_context_switch
-#endif
-#ifdef CONFIG_STACK_SENTINEL
-	call _check_stack_sentinel
-#endif
-#if defined(CONFIG_STACK_SENTINEL) || \
-		defined (CONFIG_KERNEL_EVENT_LOGGER_CONTEXT_SWITCH)
 	/* restore caller-saved r10 */
 	movhi r10, %hi(_kernel)
 	ori   r10, r10, %lo(_kernel)

--- a/arch/riscv32/core/fatal.c
+++ b/arch/riscv32/core/fatal.c
@@ -134,7 +134,8 @@ FUNC_NORETURN void _NanoFatalErrorHandler(unsigned int reason,
  *
  * @return N/A
  */
-void _SysFatalErrorHandler(unsigned int reason, const NANO_ESF *esf)
+FUNC_NORETURN __weak void _SysFatalErrorHandler(unsigned int reason,
+						const NANO_ESF *esf)
 {
 	ARG_UNUSED(esf);
 

--- a/arch/riscv32/core/fatal.c
+++ b/arch/riscv32/core/fatal.c
@@ -140,6 +140,11 @@ FUNC_NORETURN __weak void _SysFatalErrorHandler(unsigned int reason,
 	ARG_UNUSED(esf);
 
 #if !defined(CONFIG_SIMPLE_FATAL_ERROR_HANDLER)
+#ifdef CONFIG_STACK_SENTINEL
+	if (reason == _NANO_ERR_STACK_CHK_FAIL) {
+		goto hang_system;
+	}
+#endif
 	if (reason == _NANO_ERR_KERNEL_PANIC) {
 		goto hang_system;
 	}

--- a/arch/riscv32/core/isr.S
+++ b/arch/riscv32/core/isr.S
@@ -274,14 +274,14 @@ on_thread_stack:
 	addi t2, t2, -1
 	sw t2, _kernel_offset_to_nested(t1)
 
+	/* Restore thread stack pointer */
+	lw t0, 0x00(sp)
+	addi sp, t0, 0
+
 #ifdef CONFIG_STACK_SENTINEL
 	call _check_stack_sentinel
 	la t1, _kernel
 #endif
-
-	/* Restore thread stack pointer */
-	lw t0, 0x00(sp)
-	addi sp, t0, 0
 
 #ifdef CONFIG_PREEMPT_ENABLED
 	/*
@@ -316,9 +316,6 @@ reschedule:
 #if CONFIG_KERNEL_EVENT_LOGGER_CONTEXT_SWITCH
 	call _sys_k_event_logger_context_switch
 #endif /* CONFIG_KERNEL_EVENT_LOGGER_CONTEXT_SWITCH */
-#ifdef CONFIG_STACK_SENTINEL
-	call _check_stack_sentinel
-#endif
 	/* Get reference to _kernel */
 	la t0, _kernel
 

--- a/arch/x86/core/intstub.S
+++ b/arch/x86/core/intstub.S
@@ -343,6 +343,9 @@ alreadyOnIntStack:
 #if defined(CONFIG_TIMESLICING)
 	call	_update_time_slice_before_swap
 #endif
+#ifdef CONFIG_STACK_SENTINEL
+	call	_check_stack_sentinel
+#endif
 	pushfl			/* push KERNEL_LOCK_KEY argument */
 #ifdef CONFIG_X86_IAMCU
 	/* IAMCU first argument goes into a register, not the stack.
@@ -398,8 +401,9 @@ noReschedule:
 	popl	%esp		/* pop thread stack pointer */
 
 #ifdef CONFIG_STACK_SENTINEL
-	call _check_stack_sentinel
+	call	_check_stack_sentinel
 #endif
+
 	/* fall through to 'nestedInterrupt' */
 
 

--- a/arch/x86/core/swap.S
+++ b/arch/x86/core/swap.S
@@ -27,9 +27,6 @@
 
 	/* externs */
 	GDATA(_k_neg_eagain)
-#ifdef CONFIG_STACK_SENTINEL
-	GTEXT(_check_stack_sentinel)
-#endif
 
 /**
  *
@@ -142,9 +139,6 @@ SECTION_FUNC(TEXT, __swap)
 #ifdef CONFIG_KERNEL_EVENT_LOGGER_CONTEXT_SWITCH
 	/* Register the context switch */
 	call	_sys_k_event_logger_context_switch
-#endif
-#ifdef CONFIG_STACK_SENTINEL
-	call	_check_stack_sentinel
 #endif
 	movl	_kernel_offset_to_ready_q_cache(%edi), %eax
 

--- a/arch/x86/core/sys_fatal_error_handler.c
+++ b/arch/x86/core/sys_fatal_error_handler.c
@@ -44,6 +44,11 @@ FUNC_NORETURN __weak void _SysFatalErrorHandler(unsigned int reason,
 	ARG_UNUSED(pEsf);
 
 #if !defined(CONFIG_SIMPLE_FATAL_ERROR_HANDLER)
+#ifdef CONFIG_STACK_SENTINEL
+	if (reason == _NANO_ERR_STACK_CHK_FAIL) {
+		goto hang_system;
+	}
+#endif
 	if (reason == _NANO_ERR_KERNEL_PANIC) {
 		goto hang_system;
 	}

--- a/arch/x86/core/sys_fatal_error_handler.c
+++ b/arch/x86/core/sys_fatal_error_handler.c
@@ -38,7 +38,7 @@
  *
  * @return This function does not return.
  */
-FUNC_NORETURN void _SysFatalErrorHandler(unsigned int reason,
+FUNC_NORETURN __weak void _SysFatalErrorHandler(unsigned int reason,
 					 const NANO_ESF *pEsf)
 {
 	ARG_UNUSED(pEsf);

--- a/arch/xtensa/core/fatal.c
+++ b/arch/xtensa/core/fatal.c
@@ -235,7 +235,7 @@ void exit(int return_code)
  *
  * @return N/A
  */
-FUNC_NORETURN void _SysFatalErrorHandler(unsigned int reason,
+FUNC_NORETURN __weak void _SysFatalErrorHandler(unsigned int reason,
 					 const NANO_ESF *pEsf)
 {
 	ARG_UNUSED(pEsf);

--- a/arch/xtensa/core/fatal.c
+++ b/arch/xtensa/core/fatal.c
@@ -241,6 +241,11 @@ FUNC_NORETURN __weak void _SysFatalErrorHandler(unsigned int reason,
 	ARG_UNUSED(pEsf);
 
 #if !defined(CONFIG_SIMPLE_FATAL_ERROR_HANDLER)
+#ifdef CONFIG_STACK_SENTINEL
+	if (reason == _NANO_ERR_STACK_CHK_FAIL) {
+		goto hang_system;
+	}
+#endif
 	if (reason == _NANO_ERR_KERNEL_PANIC) {
 		goto hang_system;
 	}

--- a/arch/xtensa/core/swap.S
+++ b/arch/xtensa/core/swap.S
@@ -83,13 +83,6 @@ __swap:
 	call4 _sys_k_event_logger_context_switch
 #endif
 #endif
-#ifdef CONFIG_STACK_SENTINEL
-#ifdef __XTENSA_CALL0_ABI__
-	call0 _check_stack_sentinel
-#else
-	call4 _check_stack_sentinel
-#endif
-#endif
 	/* _thread := _kernel.ready_q.cache */
 	l32i a3, a2, KERNEL_OFFSET(ready_q_cache)
 	/*

--- a/boards/arm/frdm_k64f/Makefile.board
+++ b/boards/arm/frdm_k64f/Makefile.board
@@ -1,5 +1,5 @@
-FLASH_SCRIPT = openocd.sh
-DEBUG_SCRIPT = openocd.sh
+FLASH_SCRIPT = pyocd.sh
+DEBUG_SCRIPT = pyocd.sh
 
 OPENOCD_LOAD_CMD = "flash write_image erase ${O}/${KERNEL_BIN_NAME} ${CONFIG_FLASH_BASE_ADDRESS}"
 OPENOCD_VERIFY_CMD = "verify_image ${O}/${KERNEL_BIN_NAME} ${CONFIG_FLASH_BASE_ADDRESS}"

--- a/boards/arm/frdm_k64f/doc/frdm_k64f.rst
+++ b/boards/arm/frdm_k64f/doc/frdm_k64f.rst
@@ -204,7 +204,7 @@ application to flash.
    $ cd <zephyr_root_path>
    $ . zephyr-env.sh
    $ cd samples/hello_world/
-   $ make BOARD=frdm_k64f FLASH_SCRIPT=pyocd.sh flash
+   $ make BOARD=frdm_k64f flash
 
 Open a serial terminal (minicom, putty, etc.) with the following settings:
 
@@ -233,7 +233,7 @@ program your Zephyr application to flash. It will leave you at a gdb prompt.
    $ cd <zephyr_root_path>
    $ . zephyr-env.sh
    $ cd samples/hello_world/
-   $ make BOARD=frdm_k64f DEBUG_SCRIPT=pyocd.sh debug
+   $ make BOARD=frdm_k64f debug
 
 
 .. _FRDM-K64F Website:

--- a/kernel/include/ksched.h
+++ b/kernel/include/ksched.h
@@ -31,9 +31,6 @@ extern void _update_time_slice_before_swap(void);
 extern s32_t _ms_to_ticks(s32_t ms);
 #endif
 extern void idle(void *, void *, void *);
-#ifdef CONFIG_STACK_SENTINEL
-extern void _check_stack_sentinel(void);
-#endif
 
 /* find which one is the next thread to run */
 /* must be called with interrupts locked */

--- a/kernel/include/nano_internal.h
+++ b/kernel/include/nano_internal.h
@@ -52,19 +52,27 @@ extern void _new_thread(struct k_thread *thread, char *pStack, size_t stackSize,
 
 extern unsigned int __swap(unsigned int key);
 
-#if defined(CONFIG_TIMESLICING)
+#ifdef CONFIG_TIMESLICING
 extern void _update_time_slice_before_swap(void);
+#endif
 
-static inline unsigned int _time_slice_swap(unsigned int key)
+#ifdef CONFIG_STACK_SENTINEL
+extern void _check_stack_sentinel(void);
+#endif
+
+static inline unsigned int _Swap(unsigned int key)
 {
+
+#ifdef CONFIG_STACK_SENTINEL
+	_check_stack_sentinel();
+#endif
+#ifdef CONFIG_TIMESLICING
 	_update_time_slice_before_swap();
+#endif
+
 	return __swap(key);
 }
 
-#define _Swap(x)  _time_slice_swap(x)
-#else
-#define _Swap(x)  __swap(x)
-#endif
 /* set and clear essential fiber/task flag */
 
 extern void _thread_essential_set(void);

--- a/kernel/thread.c
+++ b/kernel/thread.c
@@ -141,12 +141,11 @@ void _thread_monitor_exit(struct k_thread *thread)
  * in a few places:
  *
  * 1) In k_yield() if the current thread is not swapped out
- * 2) In the interrupt code, after the interrupt has been serviced, and
- *    a decision *not* to call _Swap() has been made.
+ * 2) After servicing a non-nested interrupt
  * 3) In _Swap(), check the sentinel in the outgoing thread
  * 4) When a thread returns from its entry function to cooperatively terminate
  *
- * Items 2 and 3 require support in arch/ code.
+ * Item 2 requires support in arch/ code.
  *
  * If the check fails, the thread will be terminated appropriately through
  * the system fatal error handler.

--- a/tests/kernel/fatal/src/main.c
+++ b/tests/kernel/fatal/src/main.c
@@ -25,6 +25,27 @@ static char *overflow_stack = alt_stack + (STACKSIZE - OVERFLOW_STACKSIZE);
 static struct k_thread alt_thread;
 volatile int rv;
 
+static volatile int crash_reason;
+
+/* ARM is a special case, in that k_thread_abort() does indeed return
+ * instead of calling _Swap() directly. The PendSV exception is queued
+ * and immediately fires upon completing the exception path; the faulting
+ * thread is never run again.
+ */
+#ifndef CONFIG_ARM
+FUNC_NORETURN
+#endif
+void _SysFatalErrorHandler(unsigned int reason, const NANO_ESF *pEsf)
+{
+	TC_PRINT("Caught system error -- reason %d\n", reason);
+	crash_reason = reason;
+
+	k_thread_abort(_current);
+#ifndef CONFIG_ARM
+	CODE_UNREACHABLE;
+#endif
+}
+
 void alt_thread1(void)
 {
 #if defined(CONFIG_X86)
@@ -52,15 +73,26 @@ void alt_thread2(void)
 
 	key = irq_lock();
 	k_oops();
+	TC_ERROR("SHOULD NEVER SEE THIS\n");
 	rv = TC_FAIL;
 	irq_unlock(key);
 }
 
+void alt_thread3(void)
+{
+	int key;
+
+	key = irq_lock();
+	k_panic();
+	TC_ERROR("SHOULD NEVER SEE THIS\n");
+	rv = TC_FAIL;
+	irq_unlock(key);
+}
 
 void blow_up_stack(void)
 {
 	char buf[OVERFLOW_STACKSIZE];
-	printk("posting %zu bytes of junk to stack...\n", sizeof(buf));
+	TC_PRINT("posting %zu bytes of junk to stack...\n", sizeof(buf));
 	memset(buf, 0xbb, sizeof(buf));
 }
 
@@ -68,9 +100,9 @@ void stack_thread1(void)
 {
 	/* Test that stack overflow check due to timer interrupt works */
 	blow_up_stack();
-	printk("busy waiting...\n");
+	TC_PRINT("busy waiting...\n");
 	k_busy_wait(1024 * 1024);
-	printk("should never see this\n");
+	TC_ERROR("should never see this\n");
 	rv = TC_FAIL;
 }
 
@@ -81,9 +113,9 @@ void stack_thread2(void)
 
 	/* Test that stack overflow check due to swap works */
 	blow_up_stack();
-	printk("swapping...\n");
+	TC_PRINT("swapping...\n");
 	_Swap(irq_lock());
-	printk("should never see this\n");
+	TC_ERROR("should never see this\n");
 	rv = TC_FAIL;
 	irq_unlock(key);
 }
@@ -97,31 +129,55 @@ void main(void)
 
 	k_thread_priority_set(_current, K_PRIO_PREEMPT(MAIN_PRIORITY));
 
-	printk("test alt thread 1: generic CPU exception\n");
+	TC_PRINT("test alt thread 1: generic CPU exception\n");
 	k_thread_create(&alt_thread, alt_stack, sizeof(alt_stack),
 			(k_thread_entry_t)alt_thread1,
-			NULL, NULL, NULL, K_PRIO_PREEMPT(PRIORITY), 0,
+			NULL, NULL, NULL, K_PRIO_COOP(PRIORITY), 0,
 			K_NO_WAIT);
 	if (rv == TC_FAIL) {
-		printk("thread was not aborted\n");
+		TC_ERROR("thread was not aborted\n");
 		goto out;
 	} else {
-		printk("PASS\n");
+		TC_PRINT("PASS\n");
 	}
 
-	printk("test alt thread 2: initiate kernel oops\n");
+	TC_PRINT("test alt thread 2: initiate kernel oops\n");
 	k_thread_create(&alt_thread, alt_stack, sizeof(alt_stack),
 			(k_thread_entry_t)alt_thread2,
-			NULL, NULL, NULL, K_PRIO_PREEMPT(PRIORITY), 0,
+			NULL, NULL, NULL, K_PRIO_COOP(PRIORITY), 0,
 			K_NO_WAIT);
+	k_thread_abort(&alt_thread);
+	if (crash_reason != _NANO_ERR_KERNEL_OOPS) {
+		TC_ERROR("bad reason code got %d expected %d\n",
+			 crash_reason, _NANO_ERR_KERNEL_OOPS);
+		rv = TC_FAIL;
+	}
 	if (rv == TC_FAIL) {
-		printk("thread was not aborted\n");
+		TC_ERROR("thread was not aborted\n");
 		goto out;
 	} else {
-		printk("PASS\n");
+		TC_PRINT("PASS\n");
 	}
 
-	printk("test stack overflow - timer irq\n");
+	TC_PRINT("test alt thread 3: initiate kernel panic\n");
+	k_thread_create(&alt_thread, alt_stack, sizeof(alt_stack),
+			(k_thread_entry_t)alt_thread3,
+			NULL, NULL, NULL, K_PRIO_COOP(PRIORITY), 0,
+			K_NO_WAIT);
+	k_thread_abort(&alt_thread);
+	if (crash_reason != _NANO_ERR_KERNEL_PANIC) {
+		TC_ERROR("bad reason code got %d expected %d\n",
+			 crash_reason, _NANO_ERR_KERNEL_PANIC);
+		rv = TC_FAIL;
+	}
+	if (rv == TC_FAIL) {
+		TC_ERROR("thread was not aborted\n");
+		goto out;
+	} else {
+		TC_PRINT("PASS\n");
+	}
+
+	TC_PRINT("test stack overflow - timer irq\n");
 #ifdef CONFIG_STACK_SENTINEL
 	/* When testing stack sentinel feature, the overflow stack is a
 	 * smaller section of alt_stack near the end.
@@ -135,14 +191,19 @@ void main(void)
 			(k_thread_entry_t)stack_thread1,
 			NULL, NULL, NULL, K_PRIO_PREEMPT(PRIORITY), 0,
 			K_NO_WAIT);
+	if (crash_reason != _NANO_ERR_STACK_CHK_FAIL) {
+		TC_ERROR("bad reason code got %d expected %d\n",
+			 crash_reason, _NANO_ERR_KERNEL_PANIC);
+		rv = TC_FAIL;
+	}
 	if (rv == TC_FAIL) {
-		printk("thread was not aborted\n");
+		TC_ERROR("thread was not aborted\n");
 		goto out;
 	} else {
-		printk("PASS\n");
+		TC_PRINT("PASS\n");
 	}
 
-	printk("test stack overflow - swap\n");
+	TC_PRINT("test stack overflow - swap\n");
 #ifdef CONFIG_STACK_SENTINEL
 	k_thread_create(&alt_thread, overflow_stack, OVERFLOW_STACKSIZE,
 #else
@@ -151,13 +212,17 @@ void main(void)
 			(k_thread_entry_t)stack_thread2,
 			NULL, NULL, NULL, K_PRIO_PREEMPT(PRIORITY), 0,
 			K_NO_WAIT);
+	if (crash_reason != _NANO_ERR_STACK_CHK_FAIL) {
+		TC_ERROR("bad reason code got %d expected %d\n",
+			 crash_reason, _NANO_ERR_KERNEL_PANIC);
+		rv = TC_FAIL;
+	}
 	if (rv == TC_FAIL) {
-		printk("thread was not aborted\n");
+		TC_ERROR("thread was not aborted\n");
 		goto out;
 	} else {
-		printk("PASS\n");
+		TC_PRINT("PASS\n");
 	}
-
 out:
 	TC_END_RESULT(rv);
 	TC_END_REPORT(rv);


### PR DESCRIPTION
Bugs in QEMU allowed design issues with the ARM implementation of stack sentinel to slip through.
This is now handled properly, with improvements to the test case and default policy.

Issue: https://jira.zephyrproject.org/browse/ZEP-2244