### PR TITLE
samples: fixed typo in README.rst

### DIFF
--- a/samples/bluetooth/eddystone/README.rst
+++ b/samples/bluetooth/eddystone/README.rst
@@ -5,7 +5,7 @@ Bluetooth: Eddystone
 
 Overview
 ********
-Application demostrating `Eddystone Configuration Service`_
+Application demonstrating `Eddystone Configuration Service`_
 
 The Eddystone Configuration Service runs as a GATT service on the beacon while
 it is connectable and allows configuration of the advertised data, the

--- a/samples/synchronization/README.rst
+++ b/samples/synchronization/README.rst
@@ -6,7 +6,7 @@ Synchronization Sample
 Overview
 ********
 
-A simple application that demonstates basic sanity of the kernel.
+A simple application that demonstrates basic sanity of the kernel.
 Two threads (A and B) take turns printing a greeting message to the console,
 and use sleep requests and semaphores to control the rate at which messages
 are generated. This demonstrates that kernel scheduling, communication,


### PR DESCRIPTION
Per ISSM team feedbacks:
samples/bluetooth/eddystone/README.rst: “demostrating” >> “demonstrating”
samples/synchronization/README.rst: “demonstates” >> ”demonstrates”

Signed-off-by: Sharron LIU <sharron.liu@intel.com>