### PR TITLE
samples: static_lib: fix hardcoded "BOARD = qemu_x86"

### DIFF
--- a/samples/static_lib/hello_world/Makefile
+++ b/samples/static_lib/hello_world/Makefile
@@ -4,7 +4,7 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 
-BOARD = qemu_x86
+BOARD ?= qemu_x86
 CONF_FILE = prj.conf
 
 export SOURCE_DIR = $(ZEPHYR_BASE)/samples/static_lib/hello_world


### PR DESCRIPTION
The sample app "static_lib" is very important to Zephyr user, which
demonstrate how to build and link a static lib.
ISSM team wanted to integrate this app in their IDE for quark platforms.
However they found the in "static_lib/hello_world/Makefile" BOARD is
hardcoded as qemu_x86.

This patch allow customer BOARD passed from build command.
I have verified this app working fine @Arduino101.

Signed-off-by: Sharron LIU <sharron.liu@intel.com>