### PR TITLE
scripts: convert helper scripts to python3

### DIFF
--- a/scripts/checkconfig.py
+++ b/scripts/checkconfig.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2
+#!/usr/bin/env python3
 
 """Zephyr Check kconfigs Definitions
 
@@ -62,7 +62,7 @@ import kconfiglib
 
 def separate_location_lines(dirs):
     for dir in dirs:
-        print "    ", dir
+        print("    ", dir)
 
 def search_kconfig_items(items, name, completelog):
     findConfig = False
@@ -84,7 +84,7 @@ def search_kconfig_items(items, name, completelog):
 
         elif item.is_comment():
             if (item.get_text() == name):
-                print completelog
+                print(completelog)
                 if (completelog == True):
                     separate_location_lines(item.get_location())
                 findConfig = True
@@ -100,7 +100,7 @@ def search_config_in_file(tree, items, completelog, exclude):
             if (fname.endswith(".c") or
             fname.endswith(".h") or
             fname.endswith(".S")):
-                with open(os.path.join(dirName, fname), "r") as f:
+                with open(os.path.join(dirName, fname), "r", encoding="utf-8", errors="ignore") as f:
                     searchConf = f.readlines()
                 for i, line in enumerate(searchConf):
                     if re.search('(^|[\s|(])CONFIG_([a-zA-Z0-9_]+)', line) :
@@ -108,20 +108,20 @@ def search_config_in_file(tree, items, completelog, exclude):
                                                +'CONFIG_([a-zA-Z0-9_]+)', line)
                         configs = configs + 1
                         if (completelog == True):
-                            print ('\n' + configName.group(2) + ' at '
+                            print('\n' + configName.group(2) + ' at '
                                    + os.path.join(dirName, fname))
-                            print 'line: ' + line.rstrip()
+                            print('line: ' + line.rstrip())
                         find = search_kconfig_items(items, configName.group(2),
                                                     completelog)
                         if (find == False):
-                            print ('\n' + configName.group(2) + ' at '
+                            print('\n' + configName.group(2) + ' at '
                                    + os.path.join(dirName, fname)
                                    + ' IS NOT DEFINED')
-                            print 'line: ' + line.rstrip()
+                            print('line: ' + line.rstrip())
                             notdefConfig = notdefConfig + 1
     if (completelog == True):
-        print "\n{} Kconfigs evaluated".format(configs)
-        print "{} Kconfigs not defined".format(notdefConfig)
+        print("\n{} Kconfigs evaluated".format(configs))
+        print("{} Kconfigs not defined".format(notdefConfig))
 
 parser = argparse.ArgumentParser(description = help_text,
                                  usage = SUPPRESS,
@@ -138,9 +138,9 @@ parser.add_argument('-e', '--exclude', action='append', dest='exclude',
 
 args= parser.parse_args()
 if args.completelog:
-    print 'sub dir      = ', os.path.join(zephyrbase + args.subdir)
-    print 'complete-log = ', args.completelog
-    print 'exclude dirs = ', args.exclude
+    print('sub dir      = ', os.path.join(zephyrbase + args.subdir))
+    print('complete-log = ', args.completelog)
+    print('exclude dirs = ', args.exclude)
 
 conf = kconfiglib.Config(os.path.join(zephyrbase,'Kconfig'))
 search_config_in_file(os.path.join(zephyrbase + os.path.sep + args.subdir),

--- a/scripts/compare_footprint
+++ b/scripts/compare_footprint
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2
+#!/usr/bin/env python3
 
 """
 This script help you to compare footprint results with previous commits in git.

--- a/scripts/diffconfig
+++ b/scripts/diffconfig
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2
+#!/usr/bin/env python3
 #
 # diffconfig - a tool to compare .config files.
 #

--- a/scripts/filter-known-issues.py
+++ b/scripts/filter-known-issues.py
@@ -1,4 +1,4 @@
-#! /usr/bin/env python2
+#! /usr/bin/env python3
 """
 Filters a file, classifying output in errors, warnings and discarding
 the rest.
@@ -175,7 +175,7 @@ else:
     errors = None
 
 def report_error(data):
-    sys.stdout.write(data)
+    sys.stdout.write(data.decode('utf-8'))
     if errors:
         errors.write(data)
 

--- a/scripts/size_report
+++ b/scripts/size_report
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2
+#!/usr/bin/env python3
 #
 # Copyright (c) 2016, Intel Corporation
 #
@@ -49,7 +49,7 @@ parser.add_option("-F", "--rom",
 def load_symbols_and_paths(elf_file, path_to_strip = None):
     symbols_paths = {}
     nm_out = subprocess.check_output(["nm", elf_file, "-S", "-l", "--size-sort", "--radix=d"])
-    for line in nm_out.split('\n'):
+    for line in nm_out.decode('utf8').split('\n'):
         fields = line.replace('\t', ' ').split(' ')
         # Get rid of trailing empty field
         if len(fields) == 1 and fields[0] == '':
@@ -121,7 +121,7 @@ def generate_target_memory_section(out, kernel_name, source_dir, features_json):
     ram_section_total = 0
     ram_section_names = []
     ram_section_names_sizes = {}
-    for line in size_out.split('\n'):
+    for line in size_out.decode('utf8').split('\n'):
         if "LOAD" in line:
             loaded_section_total = loaded_section_total + int(line.split()[2], 16)
             loaded_section_names.append(line.split()[1])
@@ -183,7 +183,7 @@ def generate_target_memory_section(out, kernel_name, source_dir, features_json):
     ram_symbols_total = 0
     ram_nodes = {}
     ram_nodes['root'] = 0
-    for l in symbols_out.split('\n'):
+    for l in symbols_out.decode('utf8').split('\n'):
         line = l[0:9] + "......." + l[16:]
         fields = line.replace('\t', ' ').split(' ')
         # Get rid of trailing empty field
@@ -299,8 +299,8 @@ def generate_target_memory_section(out, kernel_name, source_dir, features_json):
 def print_tree(data, total, depth):
     base = os.environ['ZEPHYR_BASE']
     totp = 0
-    print '{:92s} {:10s} {:8s}'.format(bcolors.FAIL + "Path", "Size", "%" + bcolors.ENDC)
-    print '='*110
+    print('{:92s} {:10s} {:8s}'.format(bcolors.FAIL + "Path", "Size", "%" + bcolors.ENDC))
+    print("'='*110i")
     for i in sorted(data):
         p = i.split("/")
         if depth and len(p) > depth:
@@ -316,12 +316,12 @@ def print_tree(data, total, depth):
                 s = bcolors.WARNING + p[-1] + bcolors.ENDC
             else:
                 s = bcolors.OKBLUE + p[-1] + bcolors.ENDC
-            print '{:80s} {:20d} {:8.2f}%'.format("  "*(len(p)-1) + s, data[i], percent_c )
+            print('{:80s} {:20d} {:8.2f}%'.format("  "*(len(p)-1) + s, data[i], percent_c ))
         else:
-            print '{:80s} {:20d} {:8.2f}%'.format(bcolors.OKBLUE + i + bcolors.ENDC, data[i], percent_c )
+            print('{:80s} {:20d} {:8.2f}%'.format(bcolors.OKBLUE + i + bcolors.ENDC, data[i], percent_c ))
 
-    print '='*110
-    print '{:92d}'.format(total)
+    print('='*110)
+    print('{:92d}'.format(total))
     return totp
 
 
@@ -338,4 +338,4 @@ if options.outdir and os.path.exists(binary):
         print_tree(ram, fp['total_ram'], options.depth)
 
 else:
-    print "%s does not exist." %(binary)
+    print("%s does not exist." %(binary))


### PR DESCRIPTION
This patch ports helper scripts from python2 to python3
with following changes:

- print should be used with () in python3
- resolved bytes-like object is required, not 'str'
- added python3 header

Signed-off-by: punit vara <punit.vara@intel.com>