### PR TITLE
toolchain.gccarmemb: Fix support for where to find newlib

### DIFF
--- a/scripts/Makefile.toolchain.gccarmemb
+++ b/scripts/Makefile.toolchain.gccarmemb
@@ -6,8 +6,9 @@ CROSS_COMPILE = ${GCCARMEMB_TOOLCHAIN_PATH}/bin/arm-none-eabi-
 
 TOOLCHAIN_LIBS = gcc
 LIBGCC_DIR = $(shell dirname `$(CROSS_COMPILE)gcc ${KBUILD_CFLAGS} -print-libgcc-file-name`)
+NEWLIB_DIR = ${GCCARMEMB_TOOLCHAIN_PATH}/arm-none-eabi/lib/`$(CROSS_COMPILE)gcc ${KBUILD_CFLAGS} -print-multi-directory`
 
-LIB_INCLUDE_DIR += -L ${LIBGCC_DIR}
+LIB_INCLUDE_DIR += -L ${LIBGCC_DIR} -L ${NEWLIB_DIR}
 TOOLCHAIN_CFLAGS = -I${GCCARMEMB_TOOLCHAIN_PATH}/arm-none-eabi/include
 
 DTC ?= dtc


### PR DESCRIPTION
When we build with newlib enabled and utilizing one of the other
variants (like having floating point enabled) we need to have the proper
library path setup to find the library.  This is mimicked after what we
do in Makefile.toolchain.zephyr for newlib.

Issue: ZEP-2240

Signed-off-by: Kumar Gala <kumar.gala@linaro.org>