### PR TITLE
sam3x: report correct number of IRQ priority bits

### DIFF
--- a/dts/arm/atmel/sam3x.dtsi
+++ b/dts/arm/atmel/sam3x.dtsi
@@ -35,5 +35,5 @@
 };
 
 &nvic {
-	arm,num-irq-priority-bits = <3>;
+	arm,num-irq-priority-bits = <4>;
 };


### PR DESCRIPTION
The Sam3x HAL defines __NVIC_PRIO_BITS to 4.
Fixes an issue where interrupt priorities and masking
were not being done correctly.

Issue: ZEP-2243
Signed-off-by: Andrew Boie <andrew.p.boie@intel.com>