### PR TITLE
tests: context: move idle test to the end

### DIFF
--- a/tests/kernel/context/src/context.c
+++ b/tests/kernel/context/src/context.c
@@ -890,20 +890,6 @@ void main(void)
 	if (rv != TC_PASS) {
 		goto tests_done;
 	}
-#ifdef HAS_POWERSAVE_INSTRUCTION
-	TC_PRINT("Testing k_cpu_idle()\n");
-	rv = test_kernel_cpu_idle(0);
-	if (rv != TC_PASS) {
-		goto tests_done;
-	}
-#ifndef CONFIG_ARM
-	TC_PRINT("Testing k_cpu_atomic_idle()\n");
-	rv = test_kernel_cpu_idle(1);
-	if (rv != TC_PASS) {
-		goto tests_done;
-	}
-#endif
-#endif
 
 	TC_PRINT("Testing interrupt locking and unlocking\n");
 	rv = test_kernel_interrupts(irq_lock_wrapper, irq_unlock_wrapper, -1);
@@ -970,6 +956,21 @@ void main(void)
 	if (rv != TC_PASS) {
 		goto tests_done;
 	}
+
+#ifdef HAS_POWERSAVE_INSTRUCTION
+	TC_PRINT("Testing k_cpu_idle()\n");
+	rv = test_kernel_cpu_idle(0);
+	if (rv != TC_PASS) {
+		goto tests_done;
+	}
+#ifndef CONFIG_ARM
+	TC_PRINT("Testing k_cpu_atomic_idle()\n");
+	rv = test_kernel_cpu_idle(1);
+	if (rv != TC_PASS) {
+		goto tests_done;
+	}
+#endif
+#endif
 
 tests_done:
 	TC_END_RESULT(rv);


### PR DESCRIPTION
On some devices, when k_cpu_idle() was called we were getting
interrupts that were not the timer interrupt. On bbc_micro
a power clock control driver interrupt was happening instead
and k_cpu_idle() was returning without the system tick advancing,
failing the test.

The clock control interrupts seem to only happen early in device
boot; moving the idle test much later lets the test pass on this
board (and likely all other NRF5 based boards).

Issue: ZEP-2257
Signed-off-by: Andrew Boie <andrew.p.boie@intel.com>