### PR TITLE
net: tcp: Check pkt before sending RESET

### DIFF
--- a/subsys/net/ip/net_context.c
+++ b/subsys/net/ip/net_context.c
@@ -778,7 +778,7 @@ static int send_reset(struct net_context *context,
 	int ret;
 
 	ret = net_tcp_prepare_reset(context->tcp, remote, &pkt);
-	if (ret) {
+	if (ret || !pkt) {
 		return ret;
 	}
 


### PR DESCRIPTION
In certain TCP states we should not try to send RESET segment
to peer. So check this and do not try to use NULL pkt to send
a message.

Signed-off-by: Jukka Rissanen <jukka.rissanen@linux.intel.com>