### PR TITLE
arm: Add build time consistency check for irq priority defines

### DIFF
--- a/include/arch/arm/cortex_m/cmsis.h
+++ b/include/arch/arm/cortex_m/cmsis.h
@@ -124,6 +124,10 @@ typedef enum {
 #define __Vendor_SysTickConfig         0 /* Default to standard SysTick */
 #endif /* __NVIC_PRIO_BITS */
 
+#if __NVIC_PRIO_BITS != CONFIG_NUM_IRQ_PRIO_BITS
+#error "CONFIG_NUM_IRQ_PRIO_BITS and __NVIC_PRIO_BITS are not set to the same value"
+#endif
+
 #if defined(CONFIG_CPU_CORTEX_M0)
 #include <core_cm0.h>
 #elif defined(CONFIG_CPU_CORTEX_M0PLUS)


### PR DESCRIPTION
We need to make sure that __NVIC_PRIO_BITS & CONFIG_NUM_IRQ_PRIO_BITS
are set to the same value.  Add a simple build time check to ensure
this is the case.

Signed-off-by: Kumar Gala <kumar.gala@linaro.org>