### PR TITLE
doc: fix reference to nios2-configure-sof tool

### DIFF
--- a/boards/nios2/altera_max10/doc/board.rst
+++ b/boards/nios2/altera_max10/doc/board.rst
@@ -46,7 +46,8 @@ You will need the Altera Quartus SDK in order to work with this device. The
 `Altera Lite Distribution`_ of Quartus may be obtained without
 charge.
 
-For convenience, once installed you should put the binaries provided by the SDK
+For your convenience using the SDK tools (such as ``nios2-configure-sof``),
+you should put the binaries provided by the SDK
 in your path. Below is an example, adjust ALTERA_BASE to where you installed the
 SDK:
 
@@ -92,11 +93,12 @@ like:
 Reference CPU
 =============
 
-A reference CPU design of a Nios II/f core is included in the Zephyr tree. The
-CPU may be found in the :file:`arch/nios2/soc/nios2f-zephyr/cpu` directory.
+A reference CPU design of a Nios II/f core is included in the Zephyr tree
+in the :file:`arch/nios2/soc/nios2f-zephyr/cpu` directory.
 
-To flash this CPU, use the :file:`arch/nios2/soc/nios2f-zephyr/cpu/nios2-configure-sof`
-tool:
+Flash ths CPU using the ``nios2-configure-sof`` SDK tool with the FPGA
+configuration file
+:file:`arch/nios2/soc/nios2f-zephyr/cpu/ghrd_10m50da.sof`:
 
 .. code-block:: console
 


### PR DESCRIPTION
Board documentaion for altera_max10 referenced the nios2-configure-sof
tool in arch/nios2/soc/nios2f-zephyr/cpu/ when this tool is actually
part of the Altera Quartus SDK (the .sof FPGA configuration files are
in this folder)

jira: ZEP-2006

Signed-off-by: David B. Kinder <david.b.kinder@intel.com>