### PR TITLE
samples: net: echo-client: Fix compile error

### DIFF
--- a/samples/net/echo_client/src/echo-client.c
+++ b/samples/net/echo_client/src/echo-client.c
@@ -164,7 +164,7 @@ static struct k_thread ipv6_udp_thread_data;
 #endif
 
 #if defined(CONFIG_NET_TCP)
-static K_THREAD_STACK_DEFINE(ipv6_tcp_stack, STACKSIZE)
+static K_THREAD_STACK_DEFINE(ipv6_tcp_stack, STACKSIZE);
 static struct k_thread ipv6_tcp_thread_data;
 #endif
 


### PR DESCRIPTION
This commit fixes compile error caused by commit 39962dc9
"samples: use k_thread_create()"

Signed-off-by: Jukka Rissanen <jukka.rissanen@linux.intel.com>