### PR TITLE
net: ip: Make struct in_addr::s_addr compatible with POSIX definition

### DIFF
--- a/include/net/net_ip.h
+++ b/include/net/net_ip.h
@@ -83,7 +83,7 @@ struct in_addr {
 #define s4_addr16		in4_u.u4_addr16
 #define s4_addr32		in4_u.u4_addr32
 
-#define s_addr			s4_addr32
+#define s_addr			s4_addr32[0]
 };
 
 typedef unsigned short int sa_family_t;
@@ -427,7 +427,7 @@ static inline bool net_is_ipv4_addr_loopback(struct in_addr *addr)
  */
 static inline bool net_is_ipv4_addr_unspecified(const struct in_addr *addr)
 {
-	return addr->s_addr[0] == 0;
+	return addr->s_addr == 0;
 }
 
 /**
@@ -439,7 +439,7 @@ static inline bool net_is_ipv4_addr_unspecified(const struct in_addr *addr)
  */
 static inline bool net_is_ipv4_addr_mcast(const struct in_addr *addr)
 {
-	return (addr->s_addr[0] & 0xE0000000) == 0xE0000000;
+	return (addr->s_addr & 0xE0000000) == 0xE0000000;
 }
 
 extern struct net_if_addr *net_if_ipv4_addr_lookup(const struct in_addr *addr,
@@ -482,7 +482,7 @@ static inline bool net_is_my_ipv4_addr(const struct in_addr *addr)
 static inline bool net_ipv4_addr_cmp(const struct in_addr *addr1,
 				     const struct in_addr *addr2)
 {
-	return addr1->s_addr[0] == addr2->s_addr[0];
+	return addr1->s_addr == addr2->s_addr;
 }
 
 /**

--- a/subsys/net/ip/connection.c
+++ b/subsys/net/ip/connection.c
@@ -131,17 +131,17 @@ static inline u16_t ipv4_to_hash(struct in_addr *addr)
 	/* There is 11 bits available for IPv4 address */
 	/* Use more bits from the lower part of address space */
 	return
-		TAKE_BIT(addr->s_addr[0], 31, 11, 1) |
-		TAKE_BIT(addr->s_addr[0], 27, 11, 2) |
-		TAKE_BIT(addr->s_addr[0], 21, 11, 3) |
-		TAKE_BIT(addr->s_addr[0], 17, 11, 4) |
-		TAKE_BIT(addr->s_addr[0], 14, 11, 5) |
-		TAKE_BIT(addr->s_addr[0], 11, 11, 6) |
-		TAKE_BIT(addr->s_addr[0], 8, 11, 7) |
-		TAKE_BIT(addr->s_addr[0], 5, 11, 8) |
-		TAKE_BIT(addr->s_addr[0], 3, 11, 9) |
-		TAKE_BIT(addr->s_addr[0], 2, 11, 10) |
-		TAKE_BIT(addr->s_addr[0], 0, 11, 11);
+		TAKE_BIT(addr->s_addr, 31, 11, 1) |
+		TAKE_BIT(addr->s_addr, 27, 11, 2) |
+		TAKE_BIT(addr->s_addr, 21, 11, 3) |
+		TAKE_BIT(addr->s_addr, 17, 11, 4) |
+		TAKE_BIT(addr->s_addr, 14, 11, 5) |
+		TAKE_BIT(addr->s_addr, 11, 11, 6) |
+		TAKE_BIT(addr->s_addr, 8, 11, 7) |
+		TAKE_BIT(addr->s_addr, 5, 11, 8) |
+		TAKE_BIT(addr->s_addr, 3, 11, 9) |
+		TAKE_BIT(addr->s_addr, 2, 11, 10) |
+		TAKE_BIT(addr->s_addr, 0, 11, 11);
 }
 
 /* Return either the first free position in the cache (idx < 0) or
@@ -594,7 +594,7 @@ int net_conn_register(enum net_ip_protocol proto,
 #if defined(CONFIG_NET_IPV4)
 			if (remote_addr->family == AF_INET) {
 				if (!net_sin(remote_addr)->
-							sin_addr.s_addr[0]) {
+							sin_addr.s_addr) {
 					rank |= NET_RANK_REMOTE_UNSPEC_ADDR;
 				} else {
 					rank |= NET_RANK_REMOTE_SPEC_ADDR;
@@ -629,7 +629,7 @@ int net_conn_register(enum net_ip_protocol proto,
 
 #if defined(CONFIG_NET_IPV4)
 			if (local_addr->family == AF_INET) {
-				if (!net_sin(local_addr)->sin_addr.s_addr[0]) {
+				if (!net_sin(local_addr)->sin_addr.s_addr) {
 					rank |= NET_RANK_LOCAL_UNSPEC_ADDR;
 				} else {
 					rank |= NET_RANK_LOCAL_SPEC_ADDR;
@@ -735,7 +735,7 @@ static bool check_addr(struct net_pkt *pkt,
 			addr4 = &NET_IPV4_HDR(pkt)->dst;
 		}
 
-		if (net_sin(addr)->sin_addr.s_addr[0]) {
+		if (net_sin(addr)->sin_addr.s_addr) {
 			if (!net_ipv4_addr_cmp(&net_sin(addr)->sin_addr,
 					       addr4)) {
 				return false;

--- a/subsys/net/ip/dhcpv4.c
+++ b/subsys/net/ip/dhcpv4.c
@@ -1018,8 +1018,8 @@ void net_dhcpv4_start(struct net_if *iface)
 		iface->dhcpv4.lease_time = 0;
 		iface->dhcpv4.renewal_time = 0;
 
-		iface->dhcpv4.server_id.s_addr[0] = 0;
-		iface->dhcpv4.requested_ip.s_addr[0] = 0;
+		iface->dhcpv4.server_id.s_addr = 0;
+		iface->dhcpv4.requested_ip.s_addr = 0;
 
 		k_delayed_work_init(&iface->dhcpv4.timer, dhcpv4_timeout);
 		k_delayed_work_init(&iface->dhcpv4.t1_timer, dhcpv4_t1_timeout);

--- a/subsys/net/ip/net_context.c
+++ b/subsys/net/ip/net_context.c
@@ -561,7 +561,7 @@ int net_context_bind(struct net_context *context, const struct sockaddr *addr,
 			return -EINVAL;
 		}
 
-		if (addr4->sin_addr.s_addr[0] == INADDR_ANY) {
+		if (addr4->sin_addr.s_addr == INADDR_ANY) {
 			iface = net_if_get_default();
 
 			ptr = (struct in_addr *)net_ipv4_unspecified_address();
@@ -1161,7 +1161,7 @@ int net_context_connect(struct net_context *context,
 		addr4->sin_port = net_sin(addr)->sin_port;
 		addr4->sin_family = AF_INET;
 
-		if (addr4->sin_addr.s_addr[0]) {
+		if (addr4->sin_addr.s_addr) {
 			context->flags |= NET_CONTEXT_REMOTE_ADDR_SET;
 		} else {
 			context->flags &= ~NET_CONTEXT_REMOTE_ADDR_SET;
@@ -1803,7 +1803,7 @@ static int sendto(struct net_pkt *pkt,
 			return -EINVAL;
 		}
 
-		if (!addr4->sin_addr.s_addr[0]) {
+		if (!addr4->sin_addr.s_addr) {
 			return -EDESTADDRREQ;
 		}
 	} else

--- a/subsys/net/ip/net_if.c
+++ b/subsys/net/ip/net_if.c
@@ -1394,8 +1394,8 @@ struct net_if_router *net_if_ipv4_router_add(struct net_if *iface,
 bool net_if_ipv4_addr_mask_cmp(struct net_if *iface,
 			       struct in_addr *addr)
 {
-	u32_t subnet = ntohl(addr->s_addr[0]) &
-			ntohl(iface->ipv4.netmask.s_addr[0]);
+	u32_t subnet = ntohl(addr->s_addr) &
+			ntohl(iface->ipv4.netmask.s_addr);
 	int i;
 
 	for (i = 0; i < NET_IF_MAX_IPV4_ADDR; i++) {
@@ -1403,8 +1403,8 @@ bool net_if_ipv4_addr_mask_cmp(struct net_if *iface,
 		    iface->ipv4.unicast[i].address.family != AF_INET) {
 				continue;
 		}
-		if ((ntohl(iface->ipv4.unicast[i].address.in_addr.s_addr[0]) &
-		     ntohl(iface->ipv4.netmask.s_addr[0])) == subnet) {
+		if ((ntohl(iface->ipv4.unicast[i].address.in_addr.s_addr) &
+		     ntohl(iface->ipv4.netmask.s_addr)) == subnet) {
 			return true;
 		}
 	}
@@ -1427,7 +1427,7 @@ struct net_if_addr *net_if_ipv4_addr_lookup(const struct in_addr *addr,
 			}
 
 			if (UNALIGNED_GET(&addr->s4_addr32[0]) ==
-			    iface->ipv4.unicast[i].address.in_addr.s_addr[0]) {
+			    iface->ipv4.unicast[i].address.in_addr.s_addr) {
 
 				if (ret) {
 					*ret = iface;


### PR DESCRIPTION
From
http://pubs.opengroup.org/onlinepubs/7908799/xns/netinetin.h.html:

in_addr_t
    An unsigned integral type of exactly 32 bits.

[] the in_addr structure [] includes at least the following member:

in_addr_t      s_addr

In other words, POSIX requires s_addr to be a single integer value,
whereas Zephyr defines it as an array, and then access as s_addr[0]
everywhere. Fix that by following POSIX definition, which helps to
port existing apps to Zephyr.

Jira: ZEP-2264

Signed-off-by: Paul Sokolovsky <paul.sokolovsky@linaro.org>