### PR TITLE
arc: fix balign position to properly 4byte align global vars

### DIFF
--- a/arch/arc/core/cpu_idle.S
+++ b/arch/arc/core/cpu_idle.S
@@ -21,8 +21,8 @@ GTEXT(k_cpu_idle)
 GTEXT(k_cpu_atomic_idle)
 GDATA(k_cpu_sleep_mode)
 
-	.balign 4
 SECTION_VAR(BSS, k_cpu_sleep_mode)
+	.balign 4
 	.word 0
 
 /*

--- a/arch/arc/core/fault_s.S
+++ b/arch/arc/core/fault_s.S
@@ -33,8 +33,8 @@ GTEXT(__ev_div_zero)
 GTEXT(__ev_dc_error)
 GTEXT(__ev_maligned)
 
-	.balign 4
 SECTION_VAR(BSS, saved_stack_pointer)
+	.balign 4
 	.word 0
 
 #if CONFIG_RGF_NUM_BANKS == 1

--- a/arch/arc/core/isr_wrapper.S
+++ b/arch/arc/core/isr_wrapper.S
@@ -26,9 +26,10 @@ GTEXT(_isr_demux)
 #if CONFIG_RGF_NUM_BANKS == 1
 GDATA(saved_r0)
 
-	.balign 4
 SECTION_VAR(BSS, saved_r0)
-        .word 0
+	.balign 4
+	.word 0
+
 #endif
 
 #if defined(CONFIG_SYS_POWER_MANAGEMENT)


### PR DESCRIPTION
The .balign directives were not working correctly in their
previous positions as the directive was applying to the section
before the variable's section, causing in some builds the
variables to be misaligned, and accesses to them causing faults.
With the alignments after the section declaration, the variables
will now be aligned as specified. Any future variable declarations
should use this form instead to ensure proper alignment.

Signed-off-by: Michael R Rosen <michael.r.rosen@intel.com>