### PR TITLE
Bluetooth: L2CAP: Fix bt_l2cap_chan_send() API doc

### DIFF
--- a/include/bluetooth/l2cap.h
+++ b/include/bluetooth/l2cap.h
@@ -295,9 +295,8 @@ int bt_l2cap_chan_disconnect(struct bt_l2cap_chan *chan);
 
 /** @brief Send data to L2CAP channel
  *
- *  Send data from buffer to the channel. This procedure may block waiting for
- *  credits to send data therefore it shall be used from a fiber to be able to
- *  receive credits when necessary.
+ *  Send data from buffer to the channel. If credits are not available, buf will
+ *  be queued and sent as and when credits are recieved from peer.
  *  Regarding to first input parameter, to get details see reference description
  *  to bt_l2cap_chan_connect() API above.
  *


### PR DESCRIPTION
This API no longer blocks and if the credits are not available
buf will be queued and will be sent once credits are recieved
from peer.

Signed-off-by: Jaganath Kanakkassery <jaganathx.kanakkassery@intel.com>