### PR TITLE
samples: drivers/net/: apps: Resolved Kconfig dependencies

### DIFF
--- a/drivers/spi/Kconfig
+++ b/drivers/spi/Kconfig
@@ -75,7 +75,7 @@ config SYS_LOG_SPI_LEVEL
 
 config SPI_CS_GPIO
 	bool "SPI port CS pin is controlled via a GPIO port"
-	select GPIO
+	depends on GPIO
 	default n
 
 config	SPI_0


### PR DESCRIPTION
patch add missing dependency CONFIG_FLASH and removes CONFIG_GPIO
as it is selected by default. This patch is a fix for jira ZEP2071

Signed-off-by: Savinay Dharmappa <savinay.dharmappa@intel.com>