### PR TITLE
Bluetooth: controller: Add functions to get active filter policy

### DIFF
--- a/subsys/bluetooth/controller/ll_sw/ctrl.c
+++ b/subsys/bluetooth/controller/ll_sw/ctrl.c
@@ -8301,6 +8301,20 @@ u32_t radio_adv_is_enabled(void)
 	return _radio.advertiser.is_enabled;
 }
 
+u32_t radio_adv_filter_pol_get(void)
+{
+	/* NOTE: filter_policy is only written in thread mode; if is_enabled is
+	 * unset by ISR, returning the stale filter_policy is acceptable because
+	 * the unset code path in ISR will generate a connection complete
+	 * event.
+	 */
+	if (_radio.advertiser.is_enabled) {
+		return _radio.advertiser.filter_policy;
+	}
+
+	return 0;
+}
+
 u32_t radio_scan_enable(u8_t type, u8_t init_addr_type, u8_t *init_addr,
 			u16_t interval, u16_t window, u8_t filter_policy)
 {
@@ -8423,6 +8437,20 @@ u32_t radio_scan_disable(void)
 u32_t radio_scan_is_enabled(void)
 {
 	return _radio.scanner.is_enabled;
+}
+
+u32_t radio_scan_filter_pol_get(void)
+{
+	/* NOTE: filter_policy is only written in thread mode; if is_enabled is
+	 * unset by ISR, returning the stale filter_policy is acceptable because
+	 * the unset code path in ISR will generate a connection complete
+	 * event.
+	 */
+	if (_radio.scanner.is_enabled) {
+		return _radio.scanner.filter_policy;
+	}
+
+	return 0;
 }
 
 u32_t radio_connect_enable(u8_t adv_addr_type, u8_t *adv_addr, u16_t interval,

--- a/subsys/bluetooth/controller/ll_sw/ctrl.h
+++ b/subsys/bluetooth/controller/ll_sw/ctrl.h
@@ -319,12 +319,14 @@ u32_t radio_adv_enable(u16_t interval, u8_t chl_map,
 		       u8_t filter_policy);
 u32_t radio_adv_disable(void);
 u32_t radio_adv_is_enabled(void);
+u32_t radio_adv_filter_pol_get(void);
 /* Downstream - Scanner */
 u32_t radio_scan_enable(u8_t type, u8_t init_addr_type,
 			u8_t *init_addr, u16_t interval,
 			u16_t window, u8_t filter_policy);
 u32_t radio_scan_disable(void);
 u32_t radio_scan_is_enabled(void);
+u32_t radio_scan_filter_pol_get(void);
 
 u32_t radio_connect_enable(u8_t adv_addr_type, u8_t *adv_addr,
 			   u16_t interval, u16_t latency,


### PR DESCRIPTION
Add internal functions to read advertiser and scanner filter
policy if the roles are enabled. This is required to
restrict updates to whitelist and resolving lists when
filter policy are being used by the roles.

Signed-off-by: Vinayak Kariappa Chettimada <vich@nordicsemi.no>