### PR TITLE
Bluetooth: controller: Refactor whitelisting

### DIFF
--- a/subsys/bluetooth/controller/hci/hci.c
+++ b/subsys/bluetooth/controller/hci/hci.c
@@ -494,17 +494,15 @@ static void le_read_wl_size(struct net_buf *buf, struct net_buf **evt)
 	rp = cmd_complete(evt, sizeof(*rp));
 	rp->status = 0x00;
 
-	rp->wl_size = 8;
+	rp->wl_size = ll_wl_size_get();
 }
 
 static void le_clear_wl(struct net_buf *buf, struct net_buf **evt)
 {
 	struct bt_hci_evt_cc_status *ccst;
 
-	ll_filter_clear();
-
 	ccst = cmd_complete(evt, sizeof(*ccst));
-	ccst->status = 0x00;
+	ccst->status = ll_wl_clear();
 }
 
 static void le_add_dev_to_wl(struct net_buf *buf, struct net_buf **evt)
@@ -513,10 +511,10 @@ static void le_add_dev_to_wl(struct net_buf *buf, struct net_buf **evt)
 	struct bt_hci_evt_cc_status *ccst;
 	u32_t status;
 
-	status = ll_filter_add(cmd->addr.type, &cmd->addr.a.val[0]);
+	status = ll_wl_add(&cmd->addr);
 
 	ccst = cmd_complete(evt, sizeof(*ccst));
-	ccst->status = (!status) ? 0x00 : BT_HCI_ERR_MEM_CAPACITY_EXCEEDED;
+	ccst->status = status;
 }
 
 static void le_rem_dev_from_wl(struct net_buf *buf, struct net_buf **evt)
@@ -525,10 +523,10 @@ static void le_rem_dev_from_wl(struct net_buf *buf, struct net_buf **evt)
 	struct bt_hci_evt_cc_status *ccst;
 	u32_t status;
 
-	status = ll_filter_remove(cmd->addr.type, &cmd->addr.a.val[0]);
+	status = ll_wl_remove(&cmd->addr);
 
 	ccst = cmd_complete(evt, sizeof(*ccst));
-	ccst->status = (!status) ? 0x00 : BT_HCI_ERR_CMD_DISALLOWED;
+	ccst->status = status;
 }
 
 static void le_encrypt(struct net_buf *buf, struct net_buf **evt)

--- a/subsys/bluetooth/controller/include/ll.h
+++ b/subsys/bluetooth/controller/include/ll.h
@@ -22,9 +22,11 @@ u32_t ll_adv_enable(u8_t enable);
 u32_t ll_scan_params_set(u8_t type, u16_t interval, u16_t window,
 			 u8_t own_addr_type, u8_t filter_policy);
 u32_t ll_scan_enable(u8_t enable);
-void ll_filter_clear(void);
-u32_t ll_filter_add(u8_t addr_type, u8_t *addr);
-u32_t ll_filter_remove(u8_t addr_type, u8_t *addr);
+
+u32_t ll_wl_size_get(void);
+u32_t ll_wl_clear(void);
+u32_t ll_wl_add(bt_addr_le_t *addr);
+u32_t ll_wl_remove(bt_addr_le_t *addr);
 
 void ll_irk_clear(void);
 u32_t ll_irk_add(u8_t *irk);

--- a/subsys/bluetooth/controller/ll_sw/Makefile
+++ b/subsys/bluetooth/controller/ll_sw/Makefile
@@ -2,7 +2,7 @@ ccflags-y += -I$(srctree)/subsys/bluetooth/controller/include
 ccflags-y += -I$(srctree)/subsys/bluetooth/controller
 ccflags-y += -I$(srctree)/subsys/bluetooth
 
-obj-y += crypto.o ctrl.o ll.o
+obj-y += crypto.o ctrl.o ll.o ll_filter.o
 obj-$(CONFIG_BLUETOOTH_BROADCASTER)            += ll_adv.o
 obj-$(CONFIG_BLUETOOTH_OBSERVER)               += ll_scan.o
 obj-$(CONFIG_BLUETOOTH_CENTRAL)                += ll_master.o

--- a/subsys/bluetooth/controller/ll_sw/ll.c
+++ b/subsys/bluetooth/controller/ll_sw/ll.c
@@ -14,6 +14,7 @@
 #ifdef CONFIG_CLOCK_CONTROL_NRF5
 #include <drivers/clock_control/nrf5_clock_control.h>
 #endif
+#include <bluetooth/hci.h>
 
 #define BT_DBG_ENABLED IS_ENABLED(CONFIG_BLUETOOTH_DEBUG_HCI_DRIVER)
 #include "common/log.h"

--- a/subsys/bluetooth/controller/ll_sw/ll_adv.c
+++ b/subsys/bluetooth/controller/ll_sw/ll_adv.c
@@ -8,6 +8,7 @@
 #include <string.h>
 
 #include <zephyr.h>
+#include <bluetooth/hci.h>
 
 #include "util/util.h"
 

--- a/subsys/bluetooth/controller/ll_sw/ll_filter.c
+++ b/subsys/bluetooth/controller/ll_sw/ll_filter.c
@@ -1,0 +1,108 @@
+/*
+ * Copyright (c) 2017 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <string.h>
+
+#include <zephyr.h>
+#include <bluetooth/hci.h>
+
+#include "util/util.h"
+
+#include "pdu.h"
+#include "ctrl.h"
+#include "ll.h"
+#include "ll_filter.h"
+
+#define ADDR_TYPE_ANON 0xFF
+
+#define BT_DBG_ENABLED IS_ENABLED(CONFIG_BLUETOOTH_DEBUG_HCI_DRIVER)
+#include "common/log.h"
+
+static struct ll_wl wl;
+
+struct ll_wl *ctrl_wl_get(void)
+{
+	return &wl;
+}
+
+u32_t ll_wl_size_get(void)
+{
+	return WL_SIZE;
+}
+
+u32_t ll_wl_clear(void)
+{
+	if (radio_adv_filter_pol_get() || (radio_scan_filter_pol_get() & 0x1)) {
+		return BT_HCI_ERR_CMD_DISALLOWED;
+	}
+
+	wl.enable_bitmask = 0;
+	wl.addr_type_bitmask = 0;
+	wl.anon = 0;
+
+	return 0;
+}
+
+u32_t ll_wl_add(bt_addr_le_t *addr)
+{
+	u8_t index;
+
+	if (radio_adv_filter_pol_get() || (radio_scan_filter_pol_get() & 0x1)) {
+		return BT_HCI_ERR_CMD_DISALLOWED;
+	}
+
+	if (addr->type == ADDR_TYPE_ANON) {
+		wl.anon = 1;
+		return 0;
+	}
+
+	if (wl.enable_bitmask == 0xFF) {
+		return BT_HCI_ERR_MEM_CAPACITY_EXCEEDED;
+	}
+
+	for (index = 0;
+	     (wl.enable_bitmask & (1 << index));
+	     index++) {
+	}
+	wl.enable_bitmask |= (1 << index);
+	wl.addr_type_bitmask |= ((addr->type & 0x01) << index);
+	memcpy(&wl.bdaddr[index][0], addr->a.val, BDADDR_SIZE);
+
+	return 0;
+}
+
+u32_t ll_wl_remove(bt_addr_le_t *addr)
+{
+	u8_t index;
+
+	if (radio_adv_filter_pol_get() || (radio_scan_filter_pol_get() & 0x1)) {
+		return BT_HCI_ERR_CMD_DISALLOWED;
+	}
+
+	if (addr->type == ADDR_TYPE_ANON) {
+		wl.anon = 0;
+		return 0;
+	}
+
+	if (!wl.enable_bitmask) {
+		return BT_HCI_ERR_INVALID_PARAM;
+	}
+
+	index = 8;
+	while (index--) {
+		if ((wl.enable_bitmask & BIT(index)) &&
+		    (((wl.addr_type_bitmask >> index) & 0x01) ==
+		     (addr->type & 0x01)) &&
+		    !memcmp(wl.bdaddr[index], addr->a.val, BDADDR_SIZE)) {
+			wl.enable_bitmask &= ~BIT(index);
+			wl.addr_type_bitmask &= ~BIT(index);
+			return 0;
+		}
+	}
+
+	return BT_HCI_ERR_INVALID_PARAM;
+}
+

--- a/subsys/bluetooth/controller/ll_sw/ll_filter.h
+++ b/subsys/bluetooth/controller/ll_sw/ll_filter.h
@@ -1,0 +1,17 @@
+/*
+ * Copyright (c) 2017 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#define WL_SIZE        8
+
+struct ll_wl {
+	u8_t  enable_bitmask;
+	u8_t  addr_type_bitmask;
+	u8_t  bdaddr[WL_SIZE][BDADDR_SIZE];
+	u8_t  anon;
+};
+
+struct ll_wl *ctrl_wl_get(void);
+

--- a/subsys/bluetooth/controller/ll_sw/ll_master.c
+++ b/subsys/bluetooth/controller/ll_sw/ll_master.c
@@ -6,6 +6,7 @@
  */
 
 #include <zephyr.h>
+#include <bluetooth/hci.h>
 
 #include "util/util.h"
 

--- a/subsys/bluetooth/controller/ll_sw/ll_scan.c
+++ b/subsys/bluetooth/controller/ll_sw/ll_scan.c
@@ -6,6 +6,7 @@
  */
 
 #include <zephyr.h>
+#include <bluetooth/hci.h>
 
 #include "util/util.h"
 


### PR DESCRIPTION
As a preparation for advanced filtering (Controller-based privacy) this
commit refactors whitelisting so that it becomes its own module and
actually correctly performs state tracking to avoid modifying the
whitelist when it's in use.
Additionally it also removes the duplicate separate entries for
advertising and scanning, since the specification only allows one single
global whitelist singleton.

Signed-off-by: Carles Cufi <carles.cufi@nordicsemi.no>