### PR TITLE
doc: fix board/sample broken links

### DIFF
--- a/boards/arc/em_starterkit/doc/board.rst
+++ b/boards/arc/em_starterkit/doc/board.rst
@@ -284,4 +284,4 @@ References
 
 .. _Putty website: http://www.putty.org
 
-.. _ARC EM Starter Kit User Guide: https://www.embarc.org/help.html#starterkit
+.. _ARC EM Starter Kit User Guide: https://www.synopsys.com/dw/ipdir.php?ds=arc_em_starter_kit

--- a/boards/x86/galileo/doc/galileo.rst
+++ b/boards/x86/galileo/doc/galileo.rst
@@ -343,10 +343,10 @@ At this time, the kernel does not support the following:
 Bibliography
 ************
 
-1. `Intel® Galileo Datasheet`_, Order Number: 329681-001US
+1. `Intel® Galileo Datasheet`_, Order Number: 329681-003US
 
 .. _Intel® Galileo Datasheet:
-   http://www.intel.com/newsroom/kits/quark/galileo/pdfs/Intel_Galileo_Datasheet.pdf
+   https://www.intel.com/content/dam/support/us/en/documents/galileo/sb/galileo_datasheet_329681_003.pdf
 
 2. `Intel® Galileo Board User Guide`_.
 
@@ -356,8 +356,7 @@ Bibliography
 3. `Intel® Quark SoC X1000 Datasheet`_, Order Number: 329676-001US
 
 .. _Intel® Quark SoC X1000 Datasheet:
-   https://communities.intel.com/servlet/JiveServlet/previewBody/
-   21828-102-2-25120/329676_QuarkDatasheet.pdf
+   https://communities.intel.com/servlet/JiveServlet/previewBody/21828-102-2-25120/329676_QuarkDatasheet.pdf
 
 4. `Intel® Quark Core Hardware Reference Manual`_.
 

--- a/samples/net/mbedtls_dtlsclient/README.rst
+++ b/samples/net/mbedtls_dtlsclient/README.rst
@@ -12,14 +12,11 @@ Building and running
 
 Follow the steps for testing :ref:`networking_with_qemu`.
 
-Obtain the mbed TLS code from:
-
-https://tls.mbed.org/download/start/mbedtls-2.3.0-apache.tgz
-
+Obtain the mbed TLS code from: https://tls.mbed.org/download-archive
 and put it in a well known directory on your Linux machine, this will be your
-server.
+server. (We're using version 2.3.0 for this example.)
 
-change to that directory and compile the mbedTLS on your host machine:
+Change to that directory and compile the mbedTLS on your host machine:
 
 .. code-block:: console
 

--- a/samples/net/mbedtls_dtlsserver/README.rst
+++ b/samples/net/mbedtls_dtlsserver/README.rst
@@ -27,12 +27,10 @@ In the application directory type:
    . Setting up ecjpake password ... ok
    . Performing the TLS handshake...
 
-In other terminal window, obtain the mbed TLS code from:
-
-	https://tls.mbed.org/download/start/mbedtls-2.3.0-apache.tgz
-
-and put it in a well known directory, in your Linux machine, this will be your
-client.
+In another terminal window, obtain the mbed TLS code from:
+https://tls.mbed.org/download-archive
+and put it in a well known directory on your Linux machine, this will be your
+client. (We're using version 2.3.0 for this example.)
 
 Move to that directory and compile the mbedTLS on your host machine
 

--- a/samples/sensor/th02/README.rst
+++ b/samples/sensor/th02/README.rst
@@ -38,4 +38,4 @@ References
 
 
 .. _Grove LCD Module: http://wiki.seeed.cc/Grove-LCD_RGB_Backlight/
-.. _Grove Tempture And Humidity: http://wiki.seeed.cc/Grove-TemptureAndHumidity_Sensor-High-Accuracy_AndMini-v1.0/
+.. _Grove Temperature And Humidity: http://wiki.seeed.cc/Grove-TemptureAndHumidity_Sensor-High-Accuracy_AndMini-v1.0/


### PR DESCRIPTION
Some files have moved from their original location, or are no longer
available.  For the mbedtls samples, tweak the link to point to a page where
links for current and previous downloads can be found.

Signed-off-by: David B. Kinder <david.b.kinder@intel.com>