### PR TITLE
arm: nxp: mpu: Fix region descriptor 0 attributes

### DIFF
--- a/arch/arm/soc/nxp_kinetis/k6x/nxp_mpu_regions.c
+++ b/arch/arm/soc/nxp_kinetis/k6x/nxp_mpu_regions.c
@@ -15,7 +15,7 @@ static struct nxp_mpu_region mpu_regions[] = {
 	MPU_REGION_ENTRY("DEBUGGER_0",
 			 0,
 			 0xFFFFFFFF,
-			 0),
+			 REGION_DEBUG_ATTR),
 	/* Region 1 */
 	MPU_REGION_ENTRY("FLASH_0",
 			 CONFIG_FLASH_BASE_ADDRESS,

--- a/include/arch/arm/cortex_m/mpu/nxp_mpu.h
+++ b/include/arch/arm/cortex_m/mpu/nxp_mpu.h
@@ -78,6 +78,9 @@
 #define REGION_RO_ATTR	  (MPU_REGION_READ | \
 			   MPU_REGION_SU)
 
+#define REGION_DEBUG_ATTR  MPU_REGION_SU
+
+
 /* Region definition data structure */
 struct nxp_mpu_region {
 	/* Region Base Address */


### PR DESCRIPTION
Clearing fields in the region descriptor attributes doesn't always have
the expected effect of revoking permissions. In the case of bus master
supervisor mode fields (MxSM), setting to zero actually enables read,
write, and execute access.

When we reworked handling of region descriptor 0, we inadvertently
enabled execution from RAM by clearing the MxSM fields and enabling the
descriptor. This caused samples/mpu_test run to throw a usage fault
instead of an MPU-triggered bus fault.

Fix this by setting all the MxSM fields to 2'b11, which gives supervisor
mode the same access as user mode.

Signed-off-by: Maureen Helm <maureen.helm@nxp.com>