### PR TITLE
net: zoap: correct description of zoap_response_received()

### DIFF
--- a/include/net/zoap.h
+++ b/include/net/zoap.h
@@ -393,8 +393,8 @@ struct zoap_pending *zoap_pending_received(
 	struct zoap_pending *pendings, size_t len);
 
 /**
- * @brief After a response is received, clear all pending
- * retransmissions related to that response.
+ * @brief After a response is received, call zoap_reply_t handler
+ * registered in #zoap_reply structure
  *
  * @param response A response received
  * @param from Address from which the response was received


### PR DESCRIPTION
The original description seems copied from zoap_pending_received().
Correct the description to reflect what it does actually

Signed-off-by: Robert Chou <robert.ch.chou@acer.com>