### PR TITLE
doc: Remove micro:bit Pong game from release notes

### DIFF
--- a/doc/release-notes-1.8.rst
+++ b/doc/release-notes-1.8.rst
@@ -96,7 +96,6 @@ Bluetooth
 * Added HCI Controller to Host flow control support in both Host and Controller
 * BR/EDR: Added HFP (e)SCO audio channel establishment support
 * BR/EDR: Added support for a functional SDP server
-* micro:bit: Added a new sample that implements a game of Pong over BLE
 
 Build and Infrastructure
 ************************


### PR DESCRIPTION
It did not make the 1.8 release, was added by mistake.

Signed-off-by: Carles Cufi <carles.cufi@nordicsemi.no>