### PR TITLE
tests: benchmark: boot_time: Reading time stamps made arch agnostic

### DIFF
--- a/arch/x86/core/cpuhalt.c
+++ b/arch/x86/core/cpuhalt.c
@@ -28,7 +28,7 @@
 #include <arch/cpu.h>
 
 #ifdef CONFIG_BOOT_TIME_MEASUREMENT
-extern u64_t __idle_tsc;  /* timestamp when CPU went idle */
+extern u64_t __idle_time_stamp;  /* timestamp when CPU went idle */
 #endif
 
 /**
@@ -47,7 +47,7 @@ void k_cpu_idle(void)
 	_int_latency_stop();
 	_sys_k_event_logger_enter_sleep();
 #if defined(CONFIG_BOOT_TIME_MEASUREMENT)
-	__idle_tsc = _tsc_read();
+	__idle_time_stamp = (u64_t)k_cycle_get_32();
 #endif
 
 	__asm__ volatile (

--- a/arch/x86/core/crt0.S
+++ b/arch/x86/core/crt0.S
@@ -34,7 +34,7 @@
 #endif
 
 #if defined(CONFIG_BOOT_TIME_MEASUREMENT)
-	GDATA(__start_tsc)
+	GDATA(__start_time_stamp)
 #endif
 
 #ifdef CONFIG_SYS_POWER_DEEP_SLEEP
@@ -105,8 +105,8 @@ __csSet:
 	/*
 	 * Store rdtsc result from temporary regiter ESI & EDI into memory.
 	 */
-        mov  %esi, __start_tsc    	/* low  value */
-        mov  %edi, __start_tsc+4    	/* high value */
+        mov  %esi, __start_time_stamp  	/* low  value */
+        mov  %edi, __start_time_stamp+4    	/* high value */
 #endif
 
 #if !defined(CONFIG_FLOAT)

--- a/kernel/idle.c
+++ b/kernel/idle.c
@@ -159,9 +159,9 @@ void idle(void *unused1, void *unused2, void *unused3)
 #ifdef CONFIG_BOOT_TIME_MEASUREMENT
 	/* record timestamp when idling begins */
 
-	extern u64_t __idle_tsc;
+	extern u64_t __idle_time_stamp;
 
-	__idle_tsc = _tsc_read();
+	__idle_time_stamp = (u64_t)k_cycle_get_32();
 #endif
 
 	for (;;) {

--- a/kernel/init.c
+++ b/kernel/init.c
@@ -51,9 +51,9 @@ const char * const build_timestamp = BUILD_TIMESTAMP;
 /* boot time measurement items */
 
 #ifdef CONFIG_BOOT_TIME_MEASUREMENT
-u64_t __noinit __start_tsc; /* timestamp when kernel starts */
-u64_t __noinit __main_tsc;  /* timestamp when main task starts */
-u64_t __noinit __idle_tsc;  /* timestamp when CPU goes idle */
+u64_t __noinit __start_time_stamp; /* timestamp when kernel starts */
+u64_t __noinit __main_time_stamp;  /* timestamp when main task starts */
+u64_t __noinit __idle_time_stamp;  /* timestamp when CPU goes idle */
 #endif
 
 #ifdef CONFIG_EXECUTION_BENCHMARKING
@@ -194,9 +194,9 @@ static void _main(void *unused1, void *unused2, void *unused3)
 
 #ifdef CONFIG_BOOT_TIME_MEASUREMENT
 	/* record timestamp for kernel's _main() function */
-	extern u64_t __main_tsc;
+	extern u64_t __main_time_stamp;
 
-	__main_tsc = _tsc_read();
+	__main_time_stamp = (u64_t)k_cycle_get_32();
 #endif
 
 	extern void main(void);

--- a/misc/Kconfig
+++ b/misc/Kconfig
@@ -168,9 +168,9 @@ config BOOT_TIME_MEASUREMENT
 	depends on PERFORMANCE_METRICS
 	help
 	This option enables the recording of timestamps during system start
-	up. The global variable __start_tsc records the time kernel begins
-	executing, while __main_tsc records when main() begins executing,
-	and __idle_tsc records when the CPU becomes idle. All values are
+	up. The global variable __start_time_stamp records the time kernel begins
+	executing, while __main_time_stamp records when main() begins executing,
+	and __idle_time_stamp records when the CPU becomes idle. All values are
 	recorded in terms of CPU clock cycles since system reset.
 
 config CPU_CLOCK_FREQ_MHZ

--- a/tests/benchmarks/boot_time/src/main.c
+++ b/tests/benchmarks/boot_time/src/main.c
@@ -20,22 +20,22 @@
 #include <tc_util.h>
 
 /* externs */
-extern u64_t __start_tsc;    /* timestamp when kernel begins executing */
-extern u64_t __main_tsc;     /* timestamp when main() begins executing */
-extern u64_t __idle_tsc;     /* timestamp when CPU went idle */
+extern u64_t __start_time_stamp;    /* timestamp when kernel begins executing */
+extern u64_t __main_time_stamp;     /* timestamp when main() begins executing */
+extern u64_t __idle_time_stamp;     /* timestamp when CPU went idle */
 
 void main(void)
 {
-	u64_t task_tsc;      /* timestamp at beginning of first task  */
+	u64_t task_time_stamp;      /* timestamp at beginning of first task  */
 	u64_t _start_us;     /* being of __start timestamp in us	 */
 	u64_t main_us;       /* begin of main timestamp in us	 */
 	u64_t task_us;       /* begin of task timestamp in us	 */
-	u64_t s_main_tsc;    /* __start->main timestamp		 */
-	u64_t s_task_tsc;    /*__start->task timestamp		 */
+	u64_t s_main_time_stamp;    /* __start->main timestamp		 */
+	u64_t s_task_time_stamp;    /*__start->task timestamp		 */
 	u64_t idle_us;       /* begin of idle timestamp in us	 */
-	u64_t s_idle_tsc;    /*__start->idle timestamp		 */
+	u64_t s_idle_time_stamp;    /*__start->idle timestamp		 */
 
-	task_tsc = _tsc_read();
+	task_time_stamp = (u64_t)k_cycle_get_32();
 
 	/*
 	 * Go to sleep for 1 tick in order to timestamp when idle thread halts.
@@ -44,13 +44,13 @@ void main(void)
 
 	int freq = CONFIG_SYS_CLOCK_HW_CYCLES_PER_SEC / 1000000;
 
-	_start_us  =  __start_tsc / freq;
-	s_main_tsc =  __main_tsc - __start_tsc;
-	main_us    =  s_main_tsc / freq;
-	s_task_tsc =  task_tsc   - __start_tsc;
-	task_us    =  s_task_tsc / freq;
-	s_idle_tsc =  __idle_tsc - __start_tsc;
-	idle_us    =  s_idle_tsc / freq;
+	_start_us  =  __start_time_stamp / freq;
+	s_main_time_stamp =  __main_time_stamp - __start_time_stamp;
+	main_us    =  s_main_time_stamp / freq;
+	s_task_time_stamp =  task_time_stamp   - __start_time_stamp;
+	task_us    =  s_task_time_stamp / freq;
+	s_idle_time_stamp =  __idle_time_stamp - __start_time_stamp;
+	idle_us    =  s_idle_time_stamp / freq;
 
 	/* Indicate start for sanity test suite */
 	TC_START("Boot Time Measurement");
@@ -59,16 +59,16 @@ void main(void)
 	TC_PRINT("Boot Result: Clock Frequency: %d MHz\n",
 		 freq);
 	TC_PRINT("__start       : %d cycles, %d us\n",
-		 (u32_t)(__start_tsc & 0xFFFFFFFFULL),
+		 (u32_t)(__start_time_stamp & 0xFFFFFFFFULL),
 		 (u32_t) (_start_us  & 0xFFFFFFFFULL));
 	TC_PRINT("_start->main(): %d cycles, %d us\n",
-		 (u32_t)(s_main_tsc & 0xFFFFFFFFULL),
+		 (u32_t)(s_main_time_stamp & 0xFFFFFFFFULL),
 		 (u32_t)  (main_us  & 0xFFFFFFFFULL));
 	TC_PRINT("_start->task  : %d cycles, %d us\n",
-		 (u32_t)(s_task_tsc & 0xFFFFFFFFULL),
+		 (u32_t)(s_task_time_stamp & 0xFFFFFFFFULL),
 		 (u32_t)  (task_us  & 0xFFFFFFFFULL));
 	TC_PRINT("_start->idle  : %d cycles, %d us\n",
-		 (u32_t)(s_idle_tsc & 0xFFFFFFFFULL),
+		 (u32_t)(s_idle_time_stamp & 0xFFFFFFFFULL),
 		 (u32_t)  (idle_us  & 0xFFFFFFFFULL));
 
 	TC_PRINT("Boot Time Measurement finished\n");


### PR DESCRIPTION
Changed _tsc_read() to k_cycles_get_32(). Thus reading the
time stamp will be agnostic of the architecutre used.

JIRA: ZEP-1426

Signed-off-by: Adithya Baglody <adithya.nagaraj.baglody@intel.com>