### PR TITLE
doc: release-notes: Add mention of micro:bit display driver

### DIFF
--- a/doc/release-notes-1.8.rst
+++ b/doc/release-notes-1.8.rst
@@ -67,6 +67,7 @@ Boards
 * arm: Added support for Nucleo L432KC board
 * arm: Added support for STM32L496G Discovery board
 * arm: Added support for STM32F469I-DISCO board
+* BBC micro:bit: Added driver & API for the 5x5 LED display
 
 Drivers and Sensors
 *******************


### PR DESCRIPTION
Support for the 5x5 LED display on the BBC micro:bit makes the board
much more usable, so it's worth to mention it in the release notes.

Signed-off-by: Johan Hedberg <johan.hedberg@intel.com>