### PR TITLE
Bluetooth: shell: Fix compile error with LL cmds included

### DIFF
--- a/subsys/bluetooth/shell/ll.c
+++ b/subsys/bluetooth/shell/ll.c
@@ -14,6 +14,8 @@
 #include <shell/shell.h>
 #include <misc/printk.h>
 
+#include <bluetooth/hci.h>
+
 #include "../controller/include/ll.h"
 
 #if defined(CONFIG_BLUETOOTH_CONTROLLER_ADV_EXT)


### PR DESCRIPTION
Fixed compile error due to the missing header file
dependency on bluetooth/hci.h, for bt_addr_le_t, in the
Link Layer header file.

Merge of PR #475 introduced the new dependency that broke
compilation after merge of #474.

Signed-off-by: Vinayak Kariappa Chettimada <vich@nordicsemi.no>