### PR TITLE
boards: sam_e70_xplained: allow flashing via JTAG header

### DIFF
--- a/boards/arm/sam_e70_xplained/doc/sam_e70_xplained.rst
+++ b/boards/arm/sam_e70_xplained/doc/sam_e70_xplained.rst
@@ -141,6 +141,16 @@ Flashing
    The command will also verify that the image was programmed correctly, reset
    the board and run the Zephyr application.
 
+   You can flash the image using an external debug adapter such as J-Link or
+   ULINK, connected to the 20-pin JTAG header. Supply the name of the debug
+   adapter (e.g., `jlink`) to the make command via an OPENOCD_INTERFACE
+   variable. OpenOCD will look for the appropriate interface configuration in an
+   `interface/$(OPENOCD_INTERFACE).cfg` file on its internal search path.
+
+   .. code-block:: console
+
+      $ make BOARD=sam_e70_xplained OPENOCD_INTERFACE=jlink flash
+
    You should see "Hello World!" in your terminal.
 
 Debugging

--- a/boards/arm/sam_e70_xplained/support/openocd.cfg
+++ b/boards/arm/sam_e70_xplained/support/openocd.cfg
@@ -1,12 +1,27 @@
-source [find board/atmel_same70_xplained.cfg]
+if {[info exists env(OPENOCD_INTERFACE)]} {
+	set INTERFACE $env(OPENOCD_INTERFACE)
+} else {
+	# By default connect over Debug USB port using the EDBG chip
+	set INTERFACE "cmsis-dap"
+}
+
+source [find interface/$INTERFACE.cfg]
+
+transport select swd
+
+set CHIPNAME atsame70q21
+
+source [find target/atsamv.cfg]
+
+reset_config srst_only
 
 $_TARGETNAME configure -event gdb-attach {
-        echo "Debugger attaching: halting execution"
-        reset halt
-        gdb_breakpoint_override hard
+	echo "Debugger attaching: halting execution"
+	reset halt
+	gdb_breakpoint_override hard
 }
 
 $_TARGETNAME configure -event gdb-detach {
-        echo "Debugger detaching: resuming execution"
-        resume
+	echo "Debugger detaching: resuming execution"
+	resume
 }


### PR DESCRIPTION
Allow to use an external debug adapter such as J-Link or ULINK
connected to a 20-pin JTAG header to flash the image. The
actual protocol used by the debug interface is SWD.

Signed-off-by: Piotr Mienkowski <piotr.mienkowski@gmail.com>