### PR TITLE
Bluetooth: Enforce cooperative priorities in Bluetooth threads

### DIFF
--- a/include/drivers/bluetooth/hci_driver.h
+++ b/include/drivers/bluetooth/hci_driver.h
@@ -134,6 +134,8 @@ struct bt_hci_driver {
 	 * Send an HCI command or ACL data to the controller. The exact
 	 * type of the data can be checked with the help of bt_buf_get_type().
 	 *
+	 * @note This function must only be called from a cooperative thread.
+	 *
 	 * @param buf Buffer containing data to be sent to the controller.
 	 *
 	 * @return 0 on success or negative error number on failure.

--- a/subsys/bluetooth/common/Makefile
+++ b/subsys/bluetooth/common/Makefile
@@ -1,4 +1,5 @@
 ccflags-y += -I$(srctree)/subsys/bluetooth
 
+obj-y += dummy.o
 obj-$(CONFIG_BLUETOOTH_DEBUG) += log.o
 obj-$(CONFIG_BLUETOOTH_RPA) += rpa.o

--- a/subsys/bluetooth/common/dummy.c
+++ b/subsys/bluetooth/common/dummy.c
@@ -1,0 +1,19 @@
+/**
+ * @file dummy.c
+ * Static compilation checks.
+ */
+
+/*
+ * Copyright (c) 2017 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <zephyr.h>
+
+/* The Bluetooth subsystem requires the system workqueue to execute at a
+ * cooperative priority to function correctly. If this build assert triggers
+ * verify your configuration to ensure that cooperative threads are enabled
+ * and that the system workqueue priority is negative (cooperative).
+ */
+BUILD_ASSERT(CONFIG_SYSTEM_WORKQUEUE_PRIORITY < 0);


### PR DESCRIPTION
The Bluetooth subsystem assumes execution of its system threads in
cooperative priority, including the system workqueue and the thread
that interact with the controller (i.e. calling bt_send). This commit
adds a compile-time check for the system workqueue priority and
documentation for the bt_send API call.

Signed-off-by: Carles Cufi <carles.cufi@nordicsemi.no>