### PR TITLE
Bluetooth: ATT: Fix adding timeout for NULL request

### DIFF
--- a/subsys/bluetooth/host/att.c
+++ b/subsys/bluetooth/host/att.c
@@ -155,7 +155,9 @@ static void att_req_sent(struct bt_conn *conn)
 	k_sem_give(&att->tx_sem);
 
 	/* Start timeout work */
-	k_delayed_work_submit(&att->timeout_work, ATT_TIMEOUT);
+	if (att->req) {
+		k_delayed_work_submit(&att->timeout_work, ATT_TIMEOUT);
+	}
 }
 
 static void att_pdu_sent(struct bt_conn *conn)


### PR DESCRIPTION
In certain cases a response may happen even before number of complete
packets is generated by the controller:

[bt] [DBG] att_req_destroy: (0x0011cfe0) req 0x0011daa0
[bt] [DBG] att_process: (0x0011cfe0)
[bt] [DBG] att_req_sent: (0x0011d780) conn 0x0011d820 att 0x0011d9a0
 att->req 0x00000000

Signed-off-by: Luiz Augusto von Dentz <luiz.von.dentz@intel.com>