### PR TITLE
tests: net: ipv6_fragment: Fix llvm compiler warning

### DIFF
--- a/tests/net/ipv6_fragment/src/main.c
+++ b/tests/net/ipv6_fragment/src/main.c
@@ -642,7 +642,7 @@ static void send_ipv6_fragment(void)
 
 	/* Then add some data that is over 1280 bytes long */
 	for (i = 0; i < count; i++) {
-		bool written = net_pkt_append_all(pkt, data_len, data,
+		bool written = net_pkt_append_all(pkt, data_len, (u8_t *)data,
 						  ALLOC_TIMEOUT);
 		zassert_true(written, "Cannot append data");
 


### PR DESCRIPTION
Jira: ZEP-2274

Signed-off-by: Jukka Rissanen <jukka.rissanen@linux.intel.com>