### PR TITLE
doc: move non-board docs from boards TOC list

### DIFF
--- a/boards/boards.rst
+++ b/boards/boards.rst
@@ -3,6 +3,9 @@
 Supported Boards
 ################
 
+Zephyr project developers are continually adding board-specific support as
+documented below.
+
 To add support documentation for a new board, please use the template available
 under :file:`doc/templates/board.tmpl`
 

--- a/doc/tools/nordic_segger.rst
+++ b/doc/tools/nordic_segger.rst
@@ -1,3 +1,5 @@
+:orphan:
+
 .. _nordic_segger:
 
 Nordic nRF5x Segger J-Link

--- a/doc/tools/opensda.rst
+++ b/doc/tools/opensda.rst
@@ -1,3 +1,5 @@
+:orphan:
+
 .. _nxp_opensda:
 
 NXP OpenSDA


### PR DESCRIPTION
A couple of docs were created in previous PRs with board support
information common to a few boards.  Move these to a new section
for "Board Support Tools".  (I debated about hiding them completely
but decided it would still be useful to have these tool docs appear
in the table of contents, just not embedded with the supported boards
docs.)

JIRA: ZEP-2285

Signed-off-by: David B. Kinder <david.b.kinder@intel.com>