### PR TITLE
doc: change UTF-8 chars to sphinx inline replaces

### DIFF
--- a/boards/arm/disco_l475_iot1/doc/disco_l475_iot1.rst
+++ b/boards/arm/disco_l475_iot1/doc/disco_l475_iot1.rst
@@ -54,10 +54,10 @@ The STM32L475RG SoC provides the following hardware IPs:
 - Clock Sources:
         - 4 to 48 MHz crystal oscillator
         - 32 kHz crystal oscillator for RTC (LSE)
-        - Internal 16 MHz factory-trimmed RC (±1%)
-        - Internal low-power 32 kHz RC (±5%)
+        - Internal 16 MHz factory-trimmed RC ( |plusminus| 1%)
+        - Internal low-power 32 kHz RC ( |plusminus| 5%)
         - Internal multispeed 100 kHz to 48 MHz oscillator, auto-trimmed by
-          LSE (better than ±0.25 % accuracy)
+          LSE (better than |plusminus| 0.25 % accuracy)
         - 3 PLLs for system clock, USB, audio, ADC
 - RTC with HW calendar, alarms and calibration
 - Up to 24 capacitive sensing channels: support touchkey, linear and rotary touch sensors

--- a/boards/arm/frdm_kw41z/doc/frdm_kw41z.rst
+++ b/boards/arm/frdm_kw41z/doc/frdm_kw41z.rst
@@ -36,7 +36,8 @@ Hardware
 - SMA RF Connector
 - RF regulatory certified
 - Serial Flash for OTA firmware upgrades
-- On board NXP FXOS8700CQ digital sensor, 3D Accelerometer (±2g/±4g/±8g) + 3D
+- On board NXP FXOS8700CQ digital sensor, 3D Accelerometer ( |plusminus| 2g/
+  |plusminus| 4g/ |plusminus| 8g) + 3D
   Magnetometer
 - OpenSDA and JTAG debug
 

--- a/boards/arm/nucleo_f412zg/doc/nucleo412zg.rst
+++ b/boards/arm/nucleo_f412zg/doc/nucleo412zg.rst
@@ -13,7 +13,7 @@ some highlights of the Nucleo F412ZG board:
 
 - STM32 microcontroller in LQFP144 package
 - Two types of extension resources:
-       - ST Zio connector including: support for Arduino™ Uno V3 connectivity
+       - ST Zio connector including: support for Arduino* Uno V3 connectivity
          (A0 to A5, D0 to D15) and additional signals exposing a wide range of
          peripherals
        - ST morpho extension pin headers for full access to all STM32 I/Os
@@ -39,7 +39,7 @@ Hardware
 Nucleo F412ZG provides the following hardware components:
 
 - STM32F412ZGT6 in LQFP144 package
-- ARM®32-bit Cortex®-M4 CPU with FPU
+- ARM |reg| 32-bit Cortex |reg| -M4 CPU with FPU
 - 100 MHz max CPU frequency
 - VDD from 1.7 V to 3.6 V
 - 1 MB Flash

--- a/boards/arm/nucleo_f413zh/doc/nucleof413zh.rst
+++ b/boards/arm/nucleo_f413zh/doc/nucleof413zh.rst
@@ -13,7 +13,7 @@ some highlights of the Nucleo F413ZH board:
 
 - STM32 microcontroller in LQFP144 package
 - Two types of extension resources:
-       - ST Zio connector including: support for Arduino™ Uno V3 connectivity
+       - ST Zio connector including: support for Arduino* Uno V3 connectivity
          (A0 to A5, D0 to D15) and additional signals exposing a wide range of
          peripherals
        - ST morpho extension pin headers for full access to all STM32 I/Os
@@ -39,7 +39,7 @@ Hardware
 Nucleo F413ZH provides the following hardware components:
 
 - STM32F413ZHT6 in LQFP144 package
-- ARM®32-bit Cortex®-M4 CPU with FPU
+- ARM |reg| 32-bit Cortex |reg| -M4 CPU with FPU
 - 100 MHz max CPU frequency
 - VDD from 1.7 V to 3.6 V
 - 1.5 MB Flash

--- a/boards/arm/nucleo_l432kc/doc/nucleol432kc.rst
+++ b/boards/arm/nucleo_l432kc/doc/nucleol432kc.rst
@@ -34,14 +34,17 @@ Hardware
 
 The STM32L432KC SoC provides the following hardware IPs:
 
-- Ultra-low-power with FlexPowerControl (down to 28 nA Standby mode and 84 μA/MHz run mode)
-- Core: ARM® 32-bit Cortex®-M4 CPU with FPU, frequency up to 80 MHz, 100DMIPS/1.25DMIPS/MHz (Dhrystone 2.1)
+- Ultra-low-power with FlexPowerControl (down to 28 nA Standby mode and 84
+  |micro| A/MHz run mode)
+- Core: ARM |reg| 32-bit Cortex |reg| -M4 CPU with FPU, frequency up to 80 MHz,
+  100DMIPS/1.25DMIPS/MHz (Dhrystone 2.1)
 - Clock Sources:
 
         - 32 kHz crystal oscillator for RTC (LSE)
-        - Internal 16 MHz factory-trimmed RC (±1%)
-        - Internal low-power 32 kHz RC (±5%)
-        - Internal multispeed 100 kHz to 48 MHz oscillator, auto-trimmed by LSE (better than ±0.25 % accuracy)
+        - Internal 16 MHz factory-trimmed RC ( |plusminus| 1%)
+        - Internal low-power 32 kHz RC ( |plusminus| 5%)
+        - Internal multispeed 100 kHz to 48 MHz oscillator, auto-trimmed by
+          LSE (better than |plusminus| 0.25 % accuracy)
         - 2 PLLs for system clock, USB, audio, ADC
 
 - RTC with HW calendar, alarms and calibration
@@ -64,7 +67,8 @@ The STM32L432KC SoC provides the following hardware IPs:
 
 - Rich analog peripherals (independent supply)
 
-        - 1× 12-bit ADC 5 MSPS, up to 16-bit with hardware oversampling, 200 μA/MSPS
+        - 1x 12-bit ADC 5 MSPS, up to 16-bit with hardware oversampling, 200
+          |micro| A/MSPS
         - 2x 12-bit DAC, low-power sample and hold
         - 1x operational amplifiers with built-in PGA
         - 2x ultra-low-power comparators
@@ -83,7 +87,7 @@ The STM32L432KC SoC provides the following hardware IPs:
 - 14-channel DMA controller
 - True random number generator
 - CRC calculation unit, 96-bit unique ID
-- Development support: serial wire debug (SWD), JTAG, Embedded Trace Macrocell™
+- Development support: serial wire debug (SWD), JTAG, Embedded Trace Macrocell*
 
 
 More information about STM32L432KC can be found here:

--- a/boards/arm/nucleo_l476rg/doc/nucleol476rg.rst
+++ b/boards/arm/nucleo_l476rg/doc/nucleol476rg.rst
@@ -40,10 +40,10 @@ The STM32L476RG SoC provides the following hardware IPs:
 - Clock Sources:
         - 4 to 48 MHz crystal oscillator
         - 32 kHz crystal oscillator for RTC (LSE)
-        - Internal 16 MHz factory-trimmed RC (±1%)
-        - Internal low-power 32 kHz RC (±5%)
+        - Internal 16 MHz factory-trimmed RC ( |plusminus| 1%)
+        - Internal low-power 32 kHz RC ( |plusminus| 5%)
         - Internal multispeed 100 kHz to 48 MHz oscillator, auto-trimmed by
-          LSE (better than ±0.25 % accuracy)
+          LSE (better than  |plusminus| 0.25 % accuracy)
         - 3 PLLs for system clock, USB, audio, ADC
 - RTC with HW calendar, alarms and calibration
 - LCD 8 x 40 or 4 x 44 with step-up converter

--- a/boards/arm/stm3210c_eval/doc/stm3210c_eval.rst
+++ b/boards/arm/stm3210c_eval/doc/stm3210c_eval.rst
@@ -116,7 +116,7 @@ Flashing
 
 STM3210C-EVAL board includes an ST-LINK/V2-1 embedded debug tool interface.
 At power-on, the board is in firmware-upgrade mode (also called DFU for
-"Device Firmware Upgrade”), allowing the firmware to be updated through the USB. 
+"Device Firmware Upgrade"), allowing the firmware to be updated through the USB.
 This interface is supported by the openocd version included in Zephyr SDK.
 
 Flashing an application to STM3210C-EVAL

--- a/boards/arm/stm32373c_eval/doc/stm32373c_eval.rst
+++ b/boards/arm/stm32373c_eval/doc/stm32373c_eval.rst
@@ -120,7 +120,7 @@ Flashing
 
 STM32373C-EVAL board includes an ST-LINK/V2-1 embedded debug tool interface.
 At power-on, the board is in firmware-upgrade mode (also called DFU for
-"Device Firmware Upgrade”), allowing the firmware to be updated through the USB.
+"Device Firmware Upgrade"), allowing the firmware to be updated through the USB.
 This interface is supported by the openocd version included in Zephyr SDK.
 
 Flashing an application to STM32373C-EVAL

--- a/boards/arm/stm32f469i_disco/doc/stm32f469i_disco.rst
+++ b/boards/arm/stm32f469i_disco/doc/stm32f469i_disco.rst
@@ -17,7 +17,7 @@ some highlights of the STM32F469I-DISCO board:
 
        - ST-LINK/V2-1 USB connector
        - User USB FS connector
-       - VIN from Arduino™ compatible connectors
+       - VIN from Arduino* compatible connectors
 
 - Four user LEDs
 - Two push-buttons: USER and RESET
@@ -29,7 +29,7 @@ some highlights of the STM32F469I-DISCO board:
 - I2C extension connector
 - 4Mx32bit SDRAM
 - 128-Mbit Quad-SPI NOR Flash
-- Expansion connectors and Arduino™ UNO V3 connectors
+- Expansion connectors and Arduino UNO V3 connectors
 
 .. image:: img/en.stm32f469i-disco.jpg
      :width: 457px
@@ -45,7 +45,7 @@ Hardware
 STM32F469I-DISCO Discovery kit provides the following hardware components:
 
 - STM32F469NIH6 in BGA216 package
-- ARM®32-bit Cortex®-M4 CPU with FPU
+- ARM |reg| 32-bit Cortex |reg| -M4 CPU with FPU
 - 180 MHz max CPU frequency
 - VDD from 1.8 V to 3.6 V
 - 2 MB Flash
@@ -53,7 +53,7 @@ STM32F469I-DISCO Discovery kit provides the following hardware components:
 - GPIO with external interrupt capability
 - LCD parallel interface, 8080/6800 modes
 - LCD TFT controller supporting up to XGA resolution
-- MIPI® DSI host controller supporting up to 720p 30Hz resolution
+- MIPI |reg|  DSI host controller supporting up to 720p 30Hz resolution
 - 3x12-bit ADC with 24 channels
 - 2x12-bit D/A converters
 - RTC

--- a/boards/arm/stm32f4_disco/doc/stm32f4_disco.rst
+++ b/boards/arm/stm32f4_disco/doc/stm32f4_disco.rst
@@ -46,7 +46,7 @@ Hardware
 STM32F4DISCOVERY Discovery kit provides the following hardware components:
 
 - STM32F407VGT6 in LQFP100 package
-- ARM®32-bit Cortex®-M4 CPU with FPU
+- ARM |reg| 32-bit Cortex |reg| -M4 CPU with FPU
 - 168 MHz max CPU frequency
 - VDD from 1.8 V to 3.6 V
 - 1 MB Flash

--- a/boards/arm/stm32l496g_disco/doc/stm32l496g_disco.rst
+++ b/boards/arm/stm32l496g_disco/doc/stm32l496g_disco.rst
@@ -24,15 +24,15 @@ some highlights of the STM32L496G Discovery board:
 - Two types of extension resources:
 
        - STMod+ and PMOD connectors
-       - Compatible Arduino™ Uno V3 connectors
+       - Compatible Arduino* Uno V3 connectors
 
 - On-board ST-LINK/V2-1 debugger/programmer with SWD connector
 - 5 source options for power supply
 
        - ST-LINK/V2-1 USB connector
        - User USB FS connector
-       - VIN from Arduino™ connector
-       - 5 V from Arduino™ connector
+       - VIN from Arduino connector
+       - 5 V from Arduino connector
        - USB charger
        - USB VBUS or external source(3.3V, 5V, 7 - 12V)
        - Power management access point
@@ -54,20 +54,23 @@ Hardware
 
 The STM32L496AG SoC provides the following hardware capabilities:
 
-- Ultra-low-power with FlexPowerControl (down to 108 nA Standby mode and 91 μA/MHz run mode)
-- Core: ARM® 32-bit Cortex®-M4 CPU with FPU, frequency up to 80 MHz, 100DMIPS/1.25DMIPS/MHz (Dhrystone 2.1)
+- Ultra-low-power with FlexPowerControl (down to 108 nA Standby mode and 91
+  |micro| A/MHz run mode)
+- Core: ARM |reg| 32-bit Cortex |reg| -M4 CPU with FPU, frequency up to 80 MHz,
+  100DMIPS/1.25DMIPS/MHz (Dhrystone 2.1)
 - Clock Sources:
 
         - 4 to 48 MHz crystal oscillator
         - 32 kHz crystal oscillator for RTC (LSE)
-        - Internal 16 MHz factory-trimmed RC (±1%)
-        - Internal low-power 32 kHz RC (±5%)
-        - Internal multispeed 100 kHz to 48 MHz oscillator, auto-trimmed by LSE (better than ±0.25 % accuracy)
+        - Internal 16 MHz factory-trimmed RC ( |plusminus| 1%)
+        - Internal low-power 32 kHz RC ( |plusminus| 5%)
+        - Internal multispeed 100 kHz to 48 MHz oscillator, auto-trimmed by
+          LSE (better than |plusminus| 0.25 % accuracy)
         - Internal 48 MHz with clock recovery
         - 3 PLLs for system clock, USB, audio, ADC
 
 - RTC with HW calendar, alarms and calibration
-- LCD 8 × 40 or 4 × 44 with step-up converter
+- LCD 8 x 40 or 4 x 44 with step-up converter
 - Up to 24 capacitive sensing channels: support touchkey, linear and rotary touch sensors
 - 16x timers:
 
@@ -89,7 +92,8 @@ The STM32L496AG SoC provides the following hardware capabilities:
 - 4x digital filters for sigma delta modulator
 - Rich analog peripherals (independent supply)
 
-        - 3× 12-bit ADC 5 MSPS, up to 16-bit with hardware oversampling, 200 μA/MSPS
+        - 3x 12-bit ADC 5 MSPS, up to 16-bit with hardware oversampling, 200
+          |micro| A/MSPS
         - 2x 12-bit DAC, low-power sample and hold
         - 2x operational amplifiers with built-in PGA
         - 2x ultra-low-power comparators
@@ -109,7 +113,7 @@ The STM32L496AG SoC provides the following hardware capabilities:
 - 14-channel DMA controller
 - True random number generator
 - CRC calculation unit, 96-bit unique ID
-- Development support: serial wire debug (SWD), JTAG, Embedded Trace Macrocell™
+- Development support: serial wire debug (SWD), JTAG, Embedded Trace Macrocell*
 
 
 More information about STM32L496AG can be found here:

--- a/boards/x86/galileo/doc/galileo.rst
+++ b/boards/x86/galileo/doc/galileo.rst
@@ -58,9 +58,9 @@ This board supports the following hardware features:
 +-----------+------------+-----------------------+
 
 The kernel currently does not support other hardware features.
-See the `Intel® Quark Core Hardware Reference Manual`_ for a
+See the `Intel |reg| Quark Core Hardware Reference Manual`_ for a
 complete list of Galileo board hardware features, and the
-`Intel® Quark Software Developer Manual for Linux`_
+`Intel |reg| Quark Software Developer Manual for Linux`_
 
 
 PCI
@@ -81,7 +81,7 @@ Serial Port Polling Mode Support
 
 The polling mode serial port allows debug output to be printed.
 
-For more information, see `Intel® Quark SoC X1000 Datasheet`_,
+For more information, see `Intel |reg| Quark SoC X1000 Datasheet`_,
 section 18.3.3 FIFO Polled-Mode Operation
 
 
@@ -91,7 +91,7 @@ Serial Port Interrupt Mode Support
 The interrupt mode serial port provides general serial communication
 and external communication.
 
-For more information, see `Intel® Quark SoC X1000 Datasheet`_, section 21.12.1.4.5 Poll Mode
+For more information, see `Intel |reg| Quark SoC X1000 Datasheet`_, section 21.12.1.4.5 Poll Mode
 
 
 Interrupt Controller
@@ -124,18 +124,18 @@ pair of receive and transmit buffers and descriptors.  The driver
 operates the network interface in store-and-forward mode and enables
 the receive interrupt.
 
-For more information, see `Intel® Quark SoC X1000 Datasheet`_,
+For more information, see `Intel |reg| Quark SoC X1000 Datasheet`_,
 section 15.0 10/100 Mbps Ethernet
 
 Connections and IOs
 ===================
 
 For a component layout diagram showing pin names, see page 46 of the
-`Intel® Quark SoC X1000 Datasheet`_.
+`Intel |reg| Quark SoC X1000 Datasheet`_.
 
-See also the `Intel® Galileo Datasheet`_.
+See also the `Intel |reg| Galileo Datasheet`_.
 
-For the Galileo Board Connection Diagram see page 9 of the `Intel® Galileo Board User Guide`_.
+For the Galileo Board Connection Diagram see page 9 of the `Intel |reg| Galileo Board User Guide`_.
 
 
 Jumpers & Switches
@@ -155,7 +155,7 @@ The Galileo default switch settings are:
 +--------+--------------+
 
 For more information, see page 14 of the
-`Intel® Galileo Board User Guide`_.
+`Intel |reg| Galileo Board User Guide`_.
 
 
 Memory Mappings
@@ -165,17 +165,17 @@ This board configuration uses default hardware memory map
 addresses and sizes.
 
 For a list of memory mapped registers, see page 868 of the
-`Intel® Quark SoC X1000 Datasheet`_.
+`Intel |reg| Quark SoC X1000 Datasheet`_.
 
 
 Component Layout
 ================
 
-See page 3 of the Intel® Galileo Datasheet for a component layout
-diagram. Click the link to open the `Intel® Galileo Datasheet`_.
+See page 3 of the Intel |reg| Galileo Datasheet for a component layout
+diagram. Click the link to open the `Intel |reg| Galileo Datasheet`_.
 
 
-For a block diagram, see page 38 of the `Intel® Quark SoC X1000 Datasheet`_.
+For a block diagram, see page 38 of the `Intel |reg| Quark SoC X1000 Datasheet`_.
 
 
 Programming and Debugging
@@ -343,27 +343,27 @@ At this time, the kernel does not support the following:
 Bibliography
 ************
 
-1. `Intel® Galileo Datasheet`_, Order Number: 329681-003US
+1. `Intel |reg| Galileo Datasheet`_, Order Number: 329681-003US
 
-.. _Intel® Galileo Datasheet:
+.. _Intel |reg| Galileo Datasheet:
    https://www.intel.com/content/dam/support/us/en/documents/galileo/sb/galileo_datasheet_329681_003.pdf
 
-2. `Intel® Galileo Board User Guide`_.
+2. `Intel |reg| Galileo Board User Guide`_.
 
-.. _Intel® Galileo Board User Guide:
+.. _Intel |reg| Galileo Board User Guide:
    http://download.intel.com/support/galileo/sb/galileo_boarduserguide_330237_001.pdf
 
-3. `Intel® Quark SoC X1000 Datasheet`_, Order Number: 329676-001US
+3. `Intel |reg| Quark SoC X1000 Datasheet`_, Order Number: 329676-001US
 
-.. _Intel® Quark SoC X1000 Datasheet:
+.. _Intel |reg| Quark SoC X1000 Datasheet:
    https://communities.intel.com/servlet/JiveServlet/previewBody/21828-102-2-25120/329676_QuarkDatasheet.pdf
 
-4. `Intel® Quark Core Hardware Reference Manual`_.
+4. `Intel |reg| Quark Core Hardware Reference Manual`_.
 
-.. _Intel® Quark Core Hardware Reference Manual:
+.. _Intel |reg| Quark Core Hardware Reference Manual:
    http://caxapa.ru/thumbs/497461/Intel_Quark_Core_HWRefMan_001.pdf
 
-5. `Intel® Quark Software Developer Manual for Linux`_.
+5. `Intel |reg| Quark Software Developer Manual for Linux`_.
 
-.. _Intel® Quark Software Developer Manual for Linux:
+.. _Intel |reg| Quark Software Developer Manual for Linux:
    http://www.intel.com/content/dam/www/public/us/en/documents/manuals/quark-x1000-linux-sw-developers-manual.pdf

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -136,9 +136,9 @@ rst_epilog = """
 .. |deg|    unicode:: U+000B0 .. DEGREE SIGN
    :ltrim:
 .. |plusminus|  unicode:: U+000B1 .. PLUS-MINUS SIGN
-   :trim:
+   :rtrim:
 .. |micro|  unicode:: U+000B5 .. MICRO SIGN
-   :trim:
+   :rtrim:
 """
 
 # -- Options for HTML output ----------------------------------------------

--- a/samples/sensor/mcp9808/README.rst
+++ b/samples/sensor/mcp9808/README.rst
@@ -12,8 +12,9 @@ Sample application that periodically reads temperature from the MCP9808 sensor.
 Requirements
 ************
 
-The MCP9808 digital temperature sensor converts temperatures between -20°C and
-+100°C to a digital word with ±0.5°C (max.) accuracy. It is I2C compatible and
+The MCP9808 digital temperature sensor converts temperatures between -20 |deg|
+C and +100 |deg| C to a digital word with |plusminus| 0.5 |deg| C (max.)
+accuracy. It is I2C compatible and
 supports up to 16 devices on the bus. We do not require pullup resistors on the
 data or clock signals as they are already installed on the breakout board.
 


### PR DESCRIPTION
Avoiding use of UTF-8 characters (trip up some tools)

Signed-off-by: David B. Kinder <david.b.kinder@intel.com>