### PR TITLE
doc: fix doxygen errors in bt include files

### DIFF
--- a/include/bluetooth/gatt.h
+++ b/include/bluetooth/gatt.h
@@ -139,7 +139,7 @@ struct bt_gatt_attr {
 	u8_t			perm;
 };
 
-/** @bried GATT Service structure */
+/** @brief GATT Service structure */
 struct bt_gatt_service {
 	/** Service Attributes */
 	struct bt_gatt_attr	*attrs;
@@ -372,7 +372,7 @@ ssize_t bt_gatt_attr_read_service(struct bt_conn *conn,
 				  const struct bt_gatt_attr *attr,
 				  void *buf, u16_t len, u16_t offset);
 
-/** @def BT_GATT_SVC
+/** @def BT_GATT_SERVICE
  *  @brief Service Structure Declaration Macro.
  *
  *  Helper macro to declare a service structure.

--- a/include/bluetooth/uuid.h
+++ b/include/bluetooth/uuid.h
@@ -219,7 +219,7 @@ struct bt_uuid_128 {
  */
 #define BT_UUID_GAP_PPCP                  BT_UUID_DECLARE_16(0x2a04)
 #define BT_UUID_GAP_PPCP_VAL              0x2a04
-/** @def BT_UUID_GATT_SVC_CHANGED
+/** @def BT_UUID_GATT_SC
  *  @brief GATT Characteristic Service Changed
  */
 #define BT_UUID_GATT_SC                   BT_UUID_DECLARE_16(0x2a05)


### PR DESCRIPTION
Misspelled @brief and a couple names were different than
what was in the doxygen comments (generated warnings)

Signed-off-by: David B. Kinder <david.b.kinder@intel.com>