### PR TITLE
samples: appdev: static_lib: added "make flash"

### DIFF
--- a/samples/application_development/static_lib/Makefile
+++ b/samples/application_development/static_lib/Makefile
@@ -4,7 +4,7 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 
-all qemu pristine clean:
+all qemu flash pristine clean:
 	$(MAKE) -C hello_world $@
 
 run : qemu

--- a/samples/application_development/static_lib/hello_world/Makefile
+++ b/samples/application_development/static_lib/hello_world/Makefile
@@ -13,7 +13,7 @@ export ALL_LIBS += mylib
 
 include ${ZEPHYR_BASE}/Makefile.inc
 
-all qemu zephyr : all-mylib
+all qemu flash zephyr : all-mylib
 clean pristine mrproper : clean-mylib
 all-mylib: outputexports
 


### PR DESCRIPTION
ISSM team wanted to integrate "samples/appdev/static_lib" app
into their IDE. Al-ashi, Mahmoud <mahmoud.al-ashi@intel.com> found
it failed to "make flash" this app.

This patch added "make flash" build targets.

Signed-off-by: Sharron LIU <sharron.liu@intel.com>