### PR TITLE
dts nucleo_f401re flash partition

### DIFF
--- a/dts/arm/nucleo_f401re.dts
+++ b/dts/arm/nucleo_f401re.dts
@@ -27,3 +27,41 @@
 	current-speed = <115200>;
 	status = "ok";
 };
+
+&flash0 {
+	partitions {
+		/*
+		 * If chosen's zephyr,code-partion is unset, the image will be
+		 * linked into the entire flash device.  If it points to an
+		 * individual partition, the code will be linked to, and
+		 * restricted to that partition.
+		 */
+		compatible = "fixed-partitions";
+		#address-cells = <1>;
+		#size-cells = <1>;
+
+		boot_partition: partition@0 {
+			label = "mcuboot";
+			reg = <0x00000000 0x00010000>;
+			read-only;
+		};
+		app_state_partition: partition@10000 {
+			label = "application-state";
+			reg = <0x00010000 0x00010000>;
+		};
+		slot0_partition: partition@20000 {
+			label = "image-0";
+			reg = <0x00020000 0x00020000>;
+		};
+		slot1_partition: partition@40000 {
+			label = "image-1";
+			reg = <0x00040000 0x00020000>;
+		};
+		scratch_partition: partition@60000 {
+			label = "image-scratch";
+			reg = <0x00060000 0x00020000>;
+		};
+	};
+
+
+};


### PR DESCRIPTION
 Add partition to be able to build application in slot 0
    with  a file called nucleo_f401re.overlay :
    / {
        chosen {
                zephyr,code-partition = &slot0_partition;
        };
    };
    
    present in application directory tree.
