### PR TITLE
Fix DTS generation of LOAD_OFFSET

### DIFF
--- a/dts/arm/nxp/nxp_k6x.dtsi
+++ b/dts/arm/nxp/nxp_k6x.dtsi
@@ -93,7 +93,7 @@
 						label = "image-0";
 						reg = <0x00020000 0x00060000>;
 					};
-					slot1_partition: partition@60000 {
+					slot1_partition: partition@80000 {
 						label = "image-1";
 						reg = <0x00080000 0x00060000>;
 					};

--- a/scripts/extract_dts_includes.py
+++ b/scripts/extract_dts_includes.py
@@ -722,8 +722,7 @@ def main():
                      "PARTITION", 1, 'offset')
     part_base = lookup_defs(part_defs, chosen['zephyr,code-partition'],
                      'PARTITION_OFFSET')
-    load_defs['CONFIG_FLASH_LOAD_OFFSET'] = \
-            hex(int(part_base, 16) - int(flash_base, 16))
+    load_defs['CONFIG_FLASH_LOAD_OFFSET'] = part_base
     load_defs['CONFIG_FLASH_LOAD_SIZE'] = \
             lookup_defs(part_defs, chosen['zephyr,code-partition'],
                         'PARTITION_SIZE')


### PR DESCRIPTION
This set of patches fixes the LOAD_OFFSET generation to be the actual offset.  This assumes that the partition table in DTS is using offsets for the partition@XXXXX and reg info.  This set also fixes a typo in the k6x DTS partition table.