### PR TITLE
doc: update release-notes index page

### DIFF
--- a/doc/release-notes.rst
+++ b/doc/release-notes.rst
@@ -3,6 +3,27 @@
 Release Notes
 #############
 
+Zephyr project is provided as source code and build scripts for different
+target architectures and configurations, and not as a binary image. Updated
+versions of the Zephyr project are released approximately every three-months.
+
+All Zephyr project source code is maintained in a GitHub repository; you can
+either download source as a tar.gz file (see the bottom of the GitHub release
+notes pages listed below), or use Git clone and checkout commands, such as:
+
+.. code-block:: shell
+
+   git clone https://github.com/zephyrproject-rtos/zephyr
+   cd zephyr
+   git checkout tags/v1.8.0
+
+
+The project’s technical documentation is also tagged to correspond with a
+specific release and can be found at https://www.zephyrproject.org/doc/.
+
+Zephyr Kernel Releases
+**********************
+
 .. toctree::
    :maxdepth: 1
 
@@ -10,5 +31,3 @@ Release Notes
    release-notes-1.7
    release-notes-1.6
    release-notes-1.5
-
-


### PR DESCRIPTION
Add general release information to the release-notes index page
(currently just a set of links to the release-specific pages).

Signed-off-by: David B. Kinder <david.b.kinder@intel.com>