### PR TITLE
sam4x: report correct number of IRQ priority bits

### DIFF
--- a/dts/arm/atmel/sam4s.dtsi
+++ b/dts/arm/atmel/sam4s.dtsi
@@ -25,5 +25,5 @@
 };
 
 &nvic {
-	arm,num-irq-priority-bits = <3>;
+	arm,num-irq-priority-bits = <4>;
 };


### PR DESCRIPTION
The Sam4x HAL defines __NVIC_PRIO_BITS to 4.  Fixes an issue where
interrupt priorities and masking were not being done correctly.

Issue: ZEP-2243
Signed-off-by: Anas Nashif <anas.nashif@intel.com>