### PR TITLE
Kconfig: Source Kconfig from Zephyr application directory.

### DIFF
--- a/Kconfig.zephyr
+++ b/Kconfig.zephyr
@@ -28,6 +28,12 @@ source "ext/Kconfig"
 
 source "tests/Kconfig"
 
+config PROJECT_BASE
+	string
+	option env="PROJECT_BASE"
+
+source "$PROJECT_BASE/Kconfig"
+
 #
 # The following are for Kconfig files for default values only.
 # These should be parsed at the end.

--- a/samples/application_development/app_kconfig/Kconfig
+++ b/samples/application_development/app_kconfig/Kconfig
@@ -1,0 +1,5 @@
+menu "APPLICATION CONFIGURATION"
+
+source "$PROJECT_BASE/src/Kconfig"
+
+endmenu

--- a/samples/application_development/app_kconfig/Makefile
+++ b/samples/application_development/app_kconfig/Makefile
@@ -1,0 +1,4 @@
+BOARD ?= qemu_x86
+CONF_FILE = prj.conf
+
+include ${ZEPHYR_BASE}/Makefile.test

--- a/samples/application_development/app_kconfig/prj.conf
+++ b/samples/application_development/app_kconfig/prj.conf
@@ -1,0 +1,1 @@
+# nothing here

--- a/samples/application_development/app_kconfig/src/Kconfig
+++ b/samples/application_development/app_kconfig/src/Kconfig
@@ -1,0 +1,6 @@
+config MERGE_PATCH
+	bool "Merge patch"
+	default y
+	help
+	Will this patch, supporting application
+	Kconfig configuration, be merged?

--- a/samples/application_development/app_kconfig/src/Makefile
+++ b/samples/application_development/app_kconfig/src/Makefile
@@ -1,0 +1,1 @@
+obj-y = main.o

--- a/samples/application_development/app_kconfig/src/main.c
+++ b/samples/application_development/app_kconfig/src/main.c
@@ -1,0 +1,15 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <zephyr.h>
+#include <misc/printk.h>
+
+void main(void)
+{
+#if defined(CONFIG_MERGE_PATCH)
+	printk("This patch will be merged!\n");
+#else
+	printk("This patch will not be merged!\n");
+#endif
+}

--- a/samples/application_development/app_kconfig/testcase.ini
+++ b/samples/application_development/app_kconfig/testcase.ini
@@ -1,0 +1,4 @@
+[test]
+tags = appdev
+build_only = true
+platform_whitelist = qemu_x86


### PR DESCRIPTION
Enable application specific configuration to be easily included
and manageable via Kconfig. Add sample.

Signed-off-by: Michał Kruszewski <mkru@protonmail.com>