### PR TITLE
net: context: Close connection fast if TIME_WAIT support is off

### DIFF
--- a/subsys/net/ip/net_context.c
+++ b/subsys/net/ip/net_context.c
@@ -433,10 +433,12 @@ int net_context_put(struct net_context *context)
 		if ((net_context_get_state(context) == NET_CONTEXT_CONNECTED ||
 		     net_context_get_state(context) == NET_CONTEXT_LISTENING)
 		    && !context->tcp->fin_rcvd) {
-			NET_DBG("TCP connection in active close, not "
-				"disposing yet");
-			queue_fin(context);
-			return 0;
+			if (IS_ENABLED(CONFIG_NET_TCP_TIME_WAIT)) {
+				NET_DBG("TCP connection in active close, not "
+					"disposing yet");
+				queue_fin(context);
+				return 0;
+			}
 		}
 	}
 #endif /* CONFIG_NET_TCP */


### PR DESCRIPTION
If the CONFIG_NET_TCP_TIME_WAIT support is disabled, then do not
start to wait for reply to sent FIN in active close, but unref
the corresponding net_context in order to close the connection
as soon as possible.

Signed-off-by: Jukka Rissanen <jukka.rissanen@linux.intel.com>