### PR TITLE
Bluetooth: GATT: Fix aligment of bt_gatt_ccc_cfg and _bt_gatt_ccc

### DIFF
--- a/include/bluetooth/gatt.h
+++ b/include/bluetooth/gatt.h
@@ -490,7 +490,7 @@ struct bt_gatt_ccc_cfg {
 	/** Config peer address. */
 	bt_addr_le_t		peer;
 	/** Config peer value. */
-	u16_t		value;
+	u16_t			value;
 	/** Config valid flag. */
 	u8_t			valid;
 };
@@ -499,7 +499,7 @@ struct bt_gatt_ccc_cfg {
 struct _bt_gatt_ccc {
 	struct bt_gatt_ccc_cfg	*cfg;
 	size_t			cfg_len;
-	u16_t		value;
+	u16_t			value;
 	void			(*cfg_changed)(const struct bt_gatt_attr *attr,
 					       u16_t value);
 };


### PR DESCRIPTION
During the conversion of uint16_t to u16_t the value field of these
structs was not aligned properly.

Signed-off-by: Luiz Augusto von Dentz <luiz.von.dentz@intel.com>