### PR TITLE
Bluetooth: GATT: Rename bt_gatt_unregister_service

### DIFF
--- a/include/bluetooth/gatt.h
+++ b/include/bluetooth/gatt.h
@@ -293,7 +293,7 @@ int bt_gatt_service_register(struct bt_gatt_service *svc);
  *
  *  @return 0 in case of success or negative value in case of error.
  */
-int bt_gatt_unregister_service(struct bt_gatt_service *svc);
+int bt_gatt_service_unregister(struct bt_gatt_service *svc);
 
 enum {
 	BT_GATT_ITER_STOP = 0,

--- a/subsys/bluetooth/host/gatt.c
+++ b/subsys/bluetooth/host/gatt.c
@@ -194,7 +194,7 @@ int bt_gatt_service_register(struct bt_gatt_service *svc)
 	return 0;
 }
 
-int bt_gatt_unregister_service(struct bt_gatt_service *svc)
+int bt_gatt_service_unregister(struct bt_gatt_service *svc)
 {
 	__ASSERT(svc, "invalid parameters\n");
 

--- a/subsys/bluetooth/shell/gatt.c
+++ b/subsys/bluetooth/shell/gatt.c
@@ -613,7 +613,7 @@ int cmd_gatt_register_test_svc(int argc, char *argv[])
 
 int cmd_gatt_unregister_test_svc(int argc, char *argv[])
 {
-	bt_gatt_unregister_service(&vnd_svc);
+	bt_gatt_service_unregister(&vnd_svc);
 
 	printk("Unregistering test vendor service\n");
 


### PR DESCRIPTION
Rename bt_gatt_unregister_service to bt_gatt_service_unregister to be
consistent with other APIs such as bt_gatt_service_register.

Signed-off-by: Luiz Augusto von Dentz <luiz.von.dentz@intel.com>