### PR TITLE
link-time separation of kernel and application

### DIFF
--- a/arch/x86/core/crt0.S
+++ b/arch/x86/core/crt0.S
@@ -211,27 +211,15 @@ __csSet:
 	movl	$__data_rom_start, %esi /* DATA in ROM (src) */
 	movl	$__data_num_words, %ecx /* Size of DATA in quad bytes */
 
-  #ifdef CONFIG_SSE
-	/* copy 16 bytes at a time using XMM until < 16 bytes remain */
+	call	_x86_data_copy
 
-	movl	%ecx ,%edx		/* save number of quad bytes */
-	shrl	$2, %ecx		/* How many 16 bytes? */
-	je	dataWords
+#ifdef CONFIG_APPLICATION_MEMORY
+	movl	$__app_data_ram_start, %edi /* DATA in RAM (dest) */
+	movl	$__app_data_rom_start, %esi /* DATA in ROM (src) */
+	movl	$__app_data_num_words, %ecx /* Size of DATA in quad bytes */
 
-dataDQ:
-	movdqu	(%esi), %xmm0
-	movdqu	%xmm0, (%edi)
-	addl	$16, %esi
-	addl	$16, %edi
-	loop	dataDQ
-
-dataWords:
-	movl	%edx, %ecx	/* restore # quad bytes */
-	andl	$0x3, %ecx	/* only need to copy at most 3 quad bytes */
-  #endif /* CONFIG_SSE */
-
-	rep
-	movsl				/* copy data 4 bytes at a time */
+	call	_x86_data_copy
+#endif /* CONFIG_APPLICATION_MEMORY */
 
 #endif /* CONFIG_XIP */
 
@@ -241,44 +229,15 @@ dataWords:
 	 * It's assumed that BSS size will be a multiple of a long (4 bytes),
 	 * and aligned on a double word (32-bit) boundary
 	 */
-
-#ifdef CONFIG_SSE
-
-	/* use XMM register to clear 16 bytes at a time */
-
-	pxor	%xmm0, %xmm0		/* zero out xmm0 register */
 	movl	$__bss_start, %edi	/* load BSS start address */
 	movl	$__bss_num_words, %ecx	/* number of quad bytes in .bss */
-	movl	%ecx, %edx		/* make a copy of # quad bytes */
-	shrl	$2, %ecx		/* How many multiples of 16 byte ? */
-	je	bssWords
-bssDQ:
-	movdqu	%xmm0, (%edi)		/* zero 16 bytes... */
-	addl	$16, %edi
-	loop	bssDQ
+	call	_x86_bss_zero
 
-	/* fall through to handle the remaining double words (32-bit chunks) */
-
-bssWords:
-	xorl	%eax, %eax		/* fill memory with 0 */
-	movl	%edx, %ecx		/* move # quad bytes into ECX (for rep) */
-	andl	$0x3, %ecx		/* only need to zero at most 3 quad bytes */
-	cld
-	rep
-	stosl				/* zero memory per 4 bytes */
-
-#else /* !CONFIG_SSE */
-
-	/* clear out BSS double words (32-bits at a time) */
-
-	xorl	%eax, %eax		/* fill memory with 0 */
-	movl	$__bss_start, %edi	/* load BSS start address */
-	movl	$__bss_num_words, %ecx	/* number of quad bytes */
-	cld
-	rep
-	stosl				/* zero memory per 4 bytes */
-
-#endif /* CONFIG_SSE */
+#ifdef CONFIG_APPLICATION_MEMORY
+	movl	$__app_bss_start, %edi		/* load app BSS start address */
+	movl	$__app_bss_num_words, %ecx	/* number of quad bytes */
+	call	_x86_bss_zero
+#endif
 
 #ifdef CONFIG_GDT_DYNAMIC
 	/* activate RAM-based Global Descriptor Table (GDT) */
@@ -307,6 +266,70 @@ bssWords:
 	/* Jump to C portion of kernel initialization and never return */
 
 	jmp	_Cstart
+
+
+_x86_bss_zero:
+	/* ECX = size, EDI = starting address */
+#ifdef CONFIG_SSE
+	/* use XMM register to clear 16 bytes at a time */
+	pxor	%xmm0, %xmm0		/* zero out xmm0 register */
+
+	movl	%ecx, %edx		/* make a copy of # quad bytes */
+	shrl	$2, %ecx		/* How many multiples of 16 byte ? */
+	je	bssWords
+bssDQ:
+	movdqu	%xmm0, (%edi)		/* zero 16 bytes... */
+	addl	$16, %edi
+	loop	bssDQ
+
+	/* fall through to handle the remaining double words (32-bit chunks) */
+
+bssWords:
+	xorl	%eax, %eax		/* fill memory with 0 */
+	movl	%edx, %ecx		/* move # quad bytes into ECX (for rep) */
+	andl	$0x3, %ecx		/* only need to zero at most 3 quad bytes */
+	cld
+	rep
+	stosl				/* zero memory per 4 bytes */
+
+#else /* !CONFIG_SSE */
+
+	/* clear out BSS double words (32-bits at a time) */
+
+	xorl	%eax, %eax		/* fill memory with 0 */
+	cld
+	rep
+	stosl				/* zero memory per 4 bytes */
+
+#endif /* CONFIG_SSE */
+	ret
+
+#ifdef CONFIG_XIP
+_x86_data_copy:
+	/* EDI = dest, ESI = source, ECX = size in 32-bit chunks */
+  #ifdef CONFIG_SSE
+	/* copy 16 bytes at a time using XMM until < 16 bytes remain */
+
+	movl	%ecx ,%edx		/* save number of quad bytes */
+	shrl	$2, %ecx		/* How many 16 bytes? */
+	je	dataWords
+
+dataDQ:
+	movdqu	(%esi), %xmm0
+	movdqu	%xmm0, (%edi)
+	addl	$16, %esi
+	addl	$16, %edi
+	loop	dataDQ
+
+dataWords:
+	movl	%edx, %ecx	/* restore # quad bytes */
+	andl	$0x3, %ecx	/* only need to copy at most 3 quad bytes */
+  #endif /* CONFIG_SSE */
+
+	rep
+	movsl				/* copy data 4 bytes at a time */
+	ret
+#endif /* CONFIG_XIP */
 
 #if defined(CONFIG_SSE)
 

--- a/arch/x86/soc/ia32/Kconfig.defconfig
+++ b/arch/x86/soc/ia32/Kconfig.defconfig
@@ -22,7 +22,7 @@ config RAM_SIZE
 	default 256
 
 config ROM_SIZE
-	default 72 if XIP
+	default 3072 if XIP
 
 config SYS_CLOCK_HW_CYCLES_PER_SEC
 	default 150000000 if LOAPIC_TIMER

--- a/include/arch/x86/arch.h
+++ b/include/arch/x86/arch.h
@@ -491,6 +491,27 @@ extern FUNC_NORETURN void _NanoFatalErrorHandler(unsigned int reason,
 extern FUNC_NORETURN void _SysFatalErrorHandler(unsigned int reason,
 						const NANO_ESF * pEsf);
 
+
+/* All thread stacks, regardless of whether owned by application or kernel,
+ * go in the .stacks input section, which will end up in the kernel's
+ * noinit.
+ */
+
+#define _ARCH_THREAD_STACK_DEFINE(sym, size) \
+	char _GENERIC_SECTION(.stacks) __aligned(STACK_ALIGN) sym[size]
+
+#define _ARCH_THREAD_STACK_ARRAY_DEFINE(sym, nmemb, size) \
+	char _GENERIC_SECTION(.stacks) __aligned(STACK_ALIGN) sym[nmemb][size]
+
+#define _ARCH_THREAD_STACK_MEMBER(sym, size) \
+	char __aligned(STACK_ALIGN) sym[size]
+
+#define _ARCH_THREAD_STACK_SIZEOF(sym) \
+	sizeof(sym)
+
+#define _ARCH_THREAD_STACK_BUFFER(sym) \
+	sym
+
 #if CONFIG_X86_KERNEL_OOPS
 #define _ARCH_EXCEPT(reason_p) do { \
 	__asm__ volatile( \

--- a/include/arch/x86/linker.ld
+++ b/include/arch/x86/linker.ld
@@ -129,9 +129,11 @@ SECTIONS
 	{
 	KEXEC_PGALIGN_PAD(MMU_PAGE_SIZE)
 	_image_ram_start = .;
+	__kernel_ram_start = .;
 	__data_ram_start = .;
-	*(.data)
-	*(".data.*")
+
+	KERNEL_INPUT_SECTION(.data)
+	KERNEL_INPUT_SECTION(".data.*")
 
 #ifdef CONFIG_CUSTOM_RWDATA_LD
 /* Located in project source directory */
@@ -163,9 +165,9 @@ SECTIONS
 
 	__bss_start = .;
 
-	*(.bss)
-	*(".bss.*")
-	COMMON_SYMBOLS
+	KERNEL_INPUT_SECTION(.bss)
+	KERNEL_INPUT_SECTION(".bss.*")
+	KERNEL_INPUT_SECTION(COMMON)
 	/*
 	 * As memory is cleared in words only, it is simpler to ensure the BSS
 	 * section ends on a 4 byte boundary. This wastes a maximum of 3 bytes.
@@ -173,15 +175,9 @@ SECTIONS
 	. = ALIGN(4);
 	__bss_end = .;
 	KEXEC_PGALIGN_PAD(MMU_PAGE_SIZE)
-	} GROUP_LINK_IN(RAMABLE_REGION)
-#ifdef CONFIG_XIP
-	/*
-	 * Ensure linker keeps sections in correct order, despite the fact
-	 * the previous section specified a load address and this no-load
-	 * section doesn't.
-	 */
-	  GROUP_FOLLOWS_AT(RAMABLE_REGION)
-#endif
+	} GROUP_DATA_LINK_IN(RAMABLE_REGION, RAMABLE_REGION)
+
+	__bss_num_words	= (__bss_end - __bss_start) >> 2;
 
 	SECTION_PROLOGUE(_NOINIT_SECTION_NAME, (NOLOAD OPTIONAL),)
 	{
@@ -189,18 +185,55 @@ SECTIONS
 	 * This section is used for non-initialized objects that
 	 * will not be cleared during the boot process.
 	 */
-	*(.noinit)
-	*(".noinit.*")
-	} GROUP_LINK_IN(RAMABLE_REGION)
+	KERNEL_INPUT_SECTION(.noinit)
+	KERNEL_INPUT_SECTION(".noinit.*")
 
+	/* All stacks go in kernel's noinit, regardless of where they
+	 * were defined.
+	 */
+	*(.stacks)
+	*(".stacks.*")
+
+	__kernel_ram_end = .;
+	} GROUP_DATA_LINK_IN(RAMABLE_REGION, RAMABLE_REGION)
+
+#ifdef CONFIG_APPLICATION_MEMORY
+	SECTION_DATA_PROLOGUE(_APP_DATA_SECTION_NAME, (OPTIONAL),)
+	{
+		__app_ram_start = .;
+		__app_data_ram_start = .;
+		APP_INPUT_SECTION(.data)
+		APP_INPUT_SECTION(".data.*")
+		__app_data_ram_end = .;
+	} GROUP_DATA_LINK_IN(RAMABLE_REGION, ROMABLE_REGION)
+
+	__app_data_rom_start = LOADADDR(_APP_DATA_SECTION_NAME);
+
+	SECTION_PROLOGUE(_APP_BSS_SECTION_NAME, (NOLOAD OPTIONAL),)
+	{
+		__app_bss_start = .;
+		APP_INPUT_SECTION(.bss)
+		APP_INPUT_SECTION(".bss.*")
+		APP_INPUT_SECTION(COMMON)
+		__app_bss_end = .;
+	} GROUP_DATA_LINK_IN(RAMABLE_REGION, RAMABLE_REGION)
+
+	__app_bss_num_words = (__app_bss_end - __app_bss_start) >> 2;
+
+	SECTION_PROLOGUE(_APP_NOINIT_SECTION_NAME, (NOLOAD OPTIONAL),)
+	{
+		APP_INPUT_SECTION(.noinit)
+		APP_INPUT_SECTION(".noinit.*")
+	} GROUP_DATA_LINK_IN(RAMABLE_REGION, RAMABLE_REGION)
+
+	__app_ram_end = .;
+#endif /* CONFIG_APPLICATION_MEMORY */
 
 	/* Define linker symbols */
 	_image_ram_end = .;
 	_end = .; /* end of image */
 
 	. = ALIGN(MMU_PAGE_SIZE);
-
-	__bss_num_words	= (__bss_end - __bss_start) >> 2;
 
 	GROUP_END(RAMABLE_REGION)
 
@@ -262,5 +295,9 @@ SECTIONS
  */
 __data_size = (__data_ram_end - __data_ram_start);
 __data_num_words = (__data_size + 3) >> 2;
+#ifdef CONFIG_APPLICATION_MEMORY
+__app_data_size = (__app_data_ram_end - __app_data_ram_start);
+__app_data_num_words = (__app_data_size + 3) >> 2;
+#endif
 
 #endif

--- a/include/linker/linker-defs.h
+++ b/include/linker/linker-defs.h
@@ -136,14 +136,19 @@ GDATA(__data_num_words)
 #else /* ! _ASMLANGUAGE */
 
 #include <zephyr/types.h>
+
+/* Used by _bss_zero or arch-specific implementation */
 extern char __bss_start[];
 extern char __bss_end[];
+
+/* Used by _data_copy() or arch-specific implementation */
 #ifdef CONFIG_XIP
 extern char __data_rom_start[];
 extern char __data_ram_start[];
 extern char __data_ram_end[];
 #endif
 
+/* used by mem_safe subsystem */
 extern char _image_rom_start[];
 extern char _image_rom_end[];
 extern char _image_ram_start[];
@@ -151,7 +156,7 @@ extern char _image_ram_end[];
 extern char _image_text_start[];
 extern char _image_text_end[];
 
-/* end address of image. */
+/* end address of image, used by newlib for the heap */
 extern char _end[];
 
 #endif /* ! _ASMLANGUAGE */

--- a/include/linker/linker-defs.h
+++ b/include/linker/linker-defs.h
@@ -101,6 +101,14 @@
 		KEEP(*(".shell_*"));		\
 		__shell_cmd_end = .;
 
+#ifdef CONFIG_APPLICATION_MEMORY
+#define KERNEL_INPUT_SECTION(sect)	libzephyr.a (sect) kernel/lib.a (sect)
+#define APP_INPUT_SECTION(sect)		EXCLUDE_FILE (*libzephyr.a *kernel/lib.a) *(sect)
+#else
+#define KERNEL_INPUT_SECTION(sect)	*(sect)
+#define APP_INPUT_SECTION(sect)		*(sect)
+#endif
+
 
 #ifdef CONFIG_X86 /* LINKER FILES: defines used by linker script */
 /* Should be moved to linker-common-defs.h */

--- a/include/linker/linker-defs.h
+++ b/include/linker/linker-defs.h
@@ -145,16 +145,35 @@ GDATA(__data_num_words)
 
 #include <zephyr/types.h>
 
+#ifdef CONFIG_APPLICATION_MEMORY
+/* Application memory area bounds */
+extern char __app_ram_start[];
+extern char __app_ram_end[];
+#endif
+
+/* Memory owned by the kernel */
+extern char __kernel_ram_start[];
+extern char __kernel_ram_end[];
+
 /* Used by _bss_zero or arch-specific implementation */
 extern char __bss_start[];
 extern char __bss_end[];
+#ifdef CONFIG_APPLICATION_MEMORY
+extern char __app_bss_start[];
+extern char __app_bss_end[];
+#endif
 
 /* Used by _data_copy() or arch-specific implementation */
 #ifdef CONFIG_XIP
 extern char __data_rom_start[];
 extern char __data_ram_start[];
 extern char __data_ram_end[];
-#endif
+#ifdef CONFIG_APPLICATION_MEMORY
+extern char __app_data_rom_start[];
+extern char __app_data_ram_start[];
+extern char __app_data_ram_end[];
+#endif /* CONFIG_APPLICATION_MEMORY */
+#endif /* CONFIG_XIP */
 
 /* used by mem_safe subsystem */
 extern char _image_rom_start[];

--- a/include/linker/sections.h
+++ b/include/linker/sections.h
@@ -23,6 +23,10 @@
 #define _BSS_SECTION_NAME bss
 #define _NOINIT_SECTION_NAME noinit
 
+#define _APP_DATA_SECTION_NAME		app_datas
+#define _APP_BSS_SECTION_NAME		app_bss
+#define _APP_NOINIT_SECTION_NAME	app_noinit
+
 #define _UNDEFINED_SECTION_NAME undefined
 
 /* Various text section names */

--- a/kernel/Kconfig
+++ b/kernel/Kconfig
@@ -164,6 +164,16 @@ config ERRNO
 	symbol. The C library must access the per-thread errno via the
 	_get_errno() symbol.
 
+config APPLICATION_MEMORY
+	bool
+	prompt "Split kernel and application memory"
+	default n
+	help
+	For all read-write memory sections (namely bss, noinit, data),
+	separate them into application and kernel areas. The application area
+	will have the project-level application objects and any libraries
+	including the C library in it.
+
 menu "Kernel Debugging and Metrics"
 config KERNEL_DEBUG
 	bool

--- a/kernel/init.c
+++ b/kernel/init.c
@@ -143,6 +143,10 @@ void _bss_zero(void)
 {
 	memset(&__bss_start, 0,
 		 ((u32_t) &__bss_end - (u32_t) &__bss_start));
+#ifdef CONFIG_APPLICATION_MEMORY
+	memset(&__app_bss_start, 0,
+		 ((u32_t) &__app_bss_end - (u32_t) &__app_bss_start));
+#endif
 }
 
 
@@ -159,6 +163,10 @@ void _data_copy(void)
 {
 	memcpy(&__data_ram_start, &__data_rom_start,
 		 ((u32_t) &__data_ram_end - (u32_t) &__data_ram_start));
+#ifdef CONFIG_APPLICATION_MEMORY
+	memcpy(&__app_data_ram_start, &__app_data_rom_start,
+		 ((u32_t) &__app_data_ram_end - (u32_t) &__app_data_ram_start));
+#endif
 }
 #endif
 

--- a/scripts/check_link_map.py
+++ b/scripts/check_link_map.py
@@ -25,7 +25,7 @@ import sys
 section_re = re.compile('(?x)'                    # (allow whitespace)
                         '^([a-zA-Z0-9_\.]+) \s+'  # name
                         ' (0x[0-9a-f]+)     \s+'  # addr
-                        ' (0x[0-9a-f]+)     \s+') # size
+                        ' (0x[0-9a-f]+)\s*')      # size
 
 load_addr_re = re.compile('load address (0x[0-9a-f]+)')
 
@@ -44,6 +44,13 @@ for line in fileinput.input():
         sec = match.group(1)
         vma = int(match.group(2), 16)
         size = int(match.group(3), 16)
+
+        if (sec == "bss"):
+            # Make sure we don't compare the last section of kernel data
+            # with the first section of application data, the kernel's bss
+            # and noinit are in between.
+            last_sec = None
+            continue
 
         lmatch = load_addr_re.search(line.rstrip())
         if lmatch:

--- a/scripts/sanitycheck
+++ b/scripts/sanitycheck
@@ -467,7 +467,7 @@ class QEMUHandler(Handler):
 
 class SizeCalculator:
 
-    alloc_sections = ["bss", "noinit"]
+    alloc_sections = ["bss", "noinit", "app_bss", "app_noinit"]
     rw_sections = ["datas", "initlevel", "_k_task_list", "_k_event_list",
                    "_k_memory_pool", "exceptions", "initshell",
 		   "_static_thread_area", "_k_timer_area",
@@ -476,7 +476,7 @@ class SizeCalculator:
 		   "_k_fifo_area", "_k_lifo_area", "_k_stack_area",
 		   "_k_msgq_area", "_k_mbox_area", "_k_pipe_area",
                    "net_if", "net_if_event", "net_stack", "net_l2_data",
-                   "_k_queue_area", "_net_buf_pool_area" ]
+                   "_k_queue_area", "_net_buf_pool_area", "app_datas" ]
     # These get copied into RAM only on non-XIP
     ro_sections = ["text", "ctors", "init_array", "reset",
                    "rodata", "devconfig", "net_l2", "vector"]


### PR DESCRIPTION
For memory protection scenarios, it is necessary to distinguish between memory owned by the kernel and the application. We want toplevel globals defined for the application to be writable by application threads regardless of privilege, but kernel data and thread stacks should be walled off unless access is specifically granted.

We do this here by using an LD feature which lets you conditionally route input sections to output sections based on the source file that they come from.