### PR TITLE
kernel: start: relocate vector table

### DIFF
--- a/arch/arm/core/cortex_m/prep_c.c
+++ b/arch/arm/core/cortex_m/prep_c.c
@@ -22,9 +22,21 @@
 #include <linker-defs.h>
 #include <nano_internal.h>
 #include <arch/arm/cortex_m/cmsis.h>
+#include <string.h>
 
 #ifdef CONFIG_ARMV6_M
-static inline void relocate_vector_table(void) { /* do nothing */ }
+
+#ifndef CONFIG_XIP
+#define VECTOR_ADDRESS 0
+#endif
+
+static inline void relocate_vector_table(void)
+{
+#ifndef CONFIG_XIP
+	memcpy(VECTOR_ADDRESS, _vector_start, (size_t)_vector_end - (size_t)_vector_start);
+#endif
+}
+
 #elif defined(CONFIG_ARMV7_M)
 #ifdef CONFIG_XIP
 #define VECTOR_ADDRESS ((uintptr_t)&_image_rom_start + \

--- a/include/arch/arm/cortex_m/scripts/linker.ld
+++ b/include/arch/arm/cortex_m/scripts/linker.ld
@@ -84,7 +84,7 @@ SECTIONS
 	KEEP(*(.dbghdr))
 	KEEP(*(".dbghdr.*"))
 #endif
-
+	_vector_start = .;
 	. = CONFIG_TEXT_SECTION_OFFSET;
 	KEEP(*(.exc_vector_table))
 	KEEP(*(".exc_vector_table.*"))
@@ -102,7 +102,7 @@ SECTIONS
 #ifdef CONFIG_GEN_SW_ISR_TABLE
 	KEEP(*(SW_ISR_TABLE))
 #endif
-
+	_vector_end = .;
 	_image_text_start = .;
 	*(.text)
 	*(".text.*")

--- a/include/linker-defs.h
+++ b/include/linker-defs.h
@@ -151,6 +151,9 @@ extern char _image_ram_end[];
 extern char _image_text_start[];
 extern char _image_text_end[];
 
+extern char _vector_start[];
+extern char _vector_end[];
+
 /* end address of image. */
 extern char _end[];
 


### PR DESCRIPTION
An abnormal crash was encountered in our chips(eflash
address is not zero, the 0 address is mapped by bootlink
(SRAM) and can be written) with zephyr OS, and the reason
for this crash is that, on the arm architecture ARMV6_M,
the system requires an exception vector table at the 0
address. Because the relocate_vector_table function
is not implemented, the exception vector table does not
move to the 0 address, so the system generates an exception.
With this fix we implemented the function. If the system
starts from the 0 address, the exception vector table
doesn't need to be moved, and we use the macro CONFIG_XIP
to control this. If it is not started from 0 address, the
exception vector table needs to be moved when it is moved.

Signed-off-by: huxr <huxiaorui001@126.com>