### PR TITLE
boot: add CONFIG_BOOT_DELAY option

### DIFF
--- a/kernel/Kconfig
+++ b/kernel/Kconfig
@@ -204,6 +204,20 @@ config BOOT_BANNER
 	This option outputs a banner to the console device during boot up. It
 	also embeds a date & time stamp in the kernel and in each USAP image.
 
+config BOOT_DELAY
+	int "milliseconds to delay boot"
+	prompt "Boot delay"
+	default 0
+	help
+	This option delays bootup for the specified amount of
+	milliseconds. This is used to allow serial ports to get ready
+	before starting to print information on them during boot, as
+	some systems might boot to fast for a receiving endpoint to
+	detect the new USB serial bus, enumerate it and get ready to
+	receive before it actually gets data. A similar effect can be
+	achieved by waiting for DCD on the serial port--however, not
+	all serial ports have DCD.
+
 config BUILD_TIMESTAMP
 	bool
 	prompt "Build Timestamp"


### PR DESCRIPTION
Introduce a configurable boot delay option that happens right before
calling switch_to_main_thresd() in kernel/init.c:_Cstart(), defaulting
to 0 (none).

The rationale for this is some boards will boot really fast and print
out some test case output in the serial port before the system that is
monitoring the serial port is able to read from the serial port.

This happens in MCUs whose serial port is embedded in a USB connection
which also is used to power the MCU board. When powering it on by
powering the USB port, there is a time it takes the host system to
detect the USB connection, enumerate the serial port, configure it and
load, start and read from the serial port. At this time, it might have
printed the output of the serial port.

While manually it is possible to press a reset button, on automation
setups this adds a lot of overhead and cabling or modifications to the
MCU that are easier (and cheaper) to overcome with this delay.

Signed-off-by: Inaky Perez-Gonzalez <inaky.perez-gonzalez@intel.com>