### PR TITLE
samples: wpanusb: remove unnecessary condition for ccflags

### DIFF
--- a/samples/net/wpanusb/src/Makefile
+++ b/samples/net/wpanusb/src/Makefile
@@ -1,5 +1,5 @@
 ccflags-y += -I${ZEPHYR_BASE}/usb/include -I${ZEPHYR_BASE}/include/drivers/usb -I${ZEPHYR_BASE}/include/usb/
 
-ccflags-$(CONFIG_IEEE802154_CC2520_RAW) += -I${ZEPHYR_BASE}/subsys/net/ip
+ccflags-y += -I${ZEPHYR_BASE}/subsys/net/ip
 
 obj-y += wpanusb.o


### PR DESCRIPTION
The condition in src/Makefile is not necessary since the
net_private.h is always included from wpanusb.c and is not
dependent on the transceiver.