### PR TITLE
cc32xx watchdog support

### DIFF
--- a/arch/arm/soc/ti_simplelink/cc32xx/Kconfig.defconfig.cc3200
+++ b/arch/arm/soc/ti_simplelink/cc32xx/Kconfig.defconfig.cc3200
@@ -37,6 +37,9 @@ config GPIO_CC32XX_A2
 config GPIO_CC32XX_A3
 	default n
 
+config WDT_CC32XX
+	default y
+
 endif # GPIO
 
 endif # SOC_CC3200

--- a/drivers/watchdog/Kconfig
+++ b/drivers/watchdog/Kconfig
@@ -26,4 +26,6 @@ source "drivers/watchdog/Kconfig.cmsdk_apb"
 
 source "drivers/watchdog/Kconfig.sam"
 
+source "drivers/watchdog/Kconfig.cc32xx"
+
 endif

--- a/drivers/watchdog/Kconfig.cc32xx
+++ b/drivers/watchdog/Kconfig.cc32xx
@@ -38,5 +38,13 @@ config WDT_0_NAME
 	help
 	  Watchdog driver instance name
 
+config WDT_CC32XX_DEBUGGER_STALL_MODE
+	bool "Stall watchdog timer during debugging breakpoints"
+	depends on WDT_CC32XX
+	default y
+	help
+	  Stall the watchdog countdown while debugging, to preven a
+	  reset during breakpoints.
+
 endif # WDT_CC32XX
 

--- a/drivers/watchdog/Kconfig.cc32xx
+++ b/drivers/watchdog/Kconfig.cc32xx
@@ -1,0 +1,42 @@
+# Kconfig - CC320xx WDT configuration
+#
+# Copyright (C) 2017 Matthias Boesl
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+
+menuconfig WDT_CC32XX
+	bool "TI CC32xx MCU Watchdog (WDT) Driver"
+	depends on SOC_SERIES_CC32XX
+	default n
+	help
+	  Enable WDT driver for TI CC32xx MCUs.
+
+if WDT_CC32XX
+
+config WDT_CC32XX_RELOAD_TIME
+	int "Watchdog timer reload in sec"
+	depends on WDT_CC32XX
+	default 15
+	range 0 30
+	help
+	  Configure the value to be loaded into the watchdog's counter each
+	  time a reload operation is performed.
+
+config WDT_CC32XX_IRQ_PRI
+	int "WDT interrupt priority"
+	depends on WDT_CC32XX
+	range 0 5
+	default 1
+	help
+	  CC32XX WDT IRQ priority.
+
+config WDT_0_NAME
+	string "Watchdog driver instance name"
+	default "WATCHDOG_0"
+	depends on WDT_CC32XX
+	help
+	  Watchdog driver instance name
+
+endif # WDT_CC32XX
+

--- a/drivers/watchdog/Makefile
+++ b/drivers/watchdog/Makefile
@@ -2,3 +2,4 @@ obj-$(CONFIG_WDT_QMSI) += wdt_qmsi.o
 obj-$(CONFIG_IWDG_STM32) += iwdg_stm32.o
 obj-$(CONFIG_WDOG_CMSDK_APB) += wdog_cmsdk_apb.o
 obj-$(CONFIG_WDT_SAM) += wdt_sam.o
+obj-$(CONFIG_WDT_CC32XX) += wdt_cc32xx.o

--- a/drivers/watchdog/wdt_cc32xx.c
+++ b/drivers/watchdog/wdt_cc32xx.c
@@ -74,9 +74,10 @@ static void wdt_cc32xx_get_config(struct device *dev, struct wdt_config *config)
 static void wdt_cc32xx_reload(struct device *dev)
 {
 	ARG_UNUSED(dev);
+	MAP_WatchdogUnlock(WDT_BASE);
 	MAP_WatchdogReloadSet(WDT_BASE, CONFIG_WDT_CC32XX_RELOAD_TIME *
 			      CONFIG_SYS_CLOCK_HW_CYCLES_PER_SEC);
-	MAP_WatchdogIntClear(WDT_BASE);
+	MAP_WatchdogLock(WDT_BASE);
 }
 
 static const struct wdt_driver_api wdt_cc32xx_api = {
@@ -94,22 +95,29 @@ static int wdt_cc32xx_init(struct device *dev)
 	/* store ref for callback */
 	wdog_r = dev;
 
-	MAP_PRCMPeripheralClkEnable(PRCM_WDT, PRCM_RUN_MODE_CLK);
-
-	/* Check to see if the registers are locked, and if so, unlock them. */
-	if (MAP_WatchdogLockState(WDT_BASE) == true) {
-		MAP_WatchdogUnlock(WDT_BASE);
+	MAP_PRCMPeripheralClkEnable(PRCM_WDT,
+				    PRCM_RUN_MODE_CLK | PRCM_SLP_MODE_CLK);
+	/* spin until status returns TRUE */
+	while(!MAP_PRCMPeripheralStatusGet(PRCM_WDT)) {
 	}
 
+	MAP_WatchdogUnlock(WDT_BASE);
 	MAP_WatchdogReloadSet(WDT_BASE, CONFIG_WDT_CC32XX_RELOAD_TIME *
 			      CONFIG_SYS_CLOCK_HW_CYCLES_PER_SEC);
 	MAP_WatchdogIntClear(WDT_BASE);
+
+	/* Set debug stall mode */
+#ifdef CONFIG_WDT_CC32XX_DEBUGGER_STALL_MODE
+	MAP_WatchdogStallEnable(WDT_BASE);
+#endif
 
 	IRQ_CONNECT(EXCEPTION_WDT0, CONFIG_WDT_CC32XX_IRQ_PRI,
 		    wdt_cc32xx_isr, DEVICE_GET(wdt_cc32xx), 0);
 
 	MAP_IntPendClear(INT_WDT);
 	irq_enable(EXCEPTION_WDT0);
+
+	MAP_WatchdogLock(WDT_BASE);
 
 	return 0;
 }

--- a/drivers/watchdog/wdt_cc32xx.c
+++ b/drivers/watchdog/wdt_cc32xx.c
@@ -1,0 +1,120 @@
+/*
+ * Copyright (C) 2017 Matthias Boesl  <matthias.boesl@gmail.com>
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * @brief Watchdog (WDT) Driver for CC32xx devices
+ *
+ */
+
+#include <watchdog.h>
+#include <soc.h>
+#include <misc/printk.h>
+
+/* Driverlib includes */
+#include <inc/hw_types.h>
+#include <inc/hw_memmap.h>
+#include <inc/hw_ints.h>
+#include <driverlib/rom.h>
+#include <driverlib/pin.h>
+#include <driverlib/rom_map.h>
+
+#ifdef CONFIG_CC3200SDK_ROM_DRIVERLIB
+#include <inc/hw_wdt.h>
+#endif
+
+#define SYS_LOG_DOMAIN "dev/wdt_cc32xx"
+#include <logging/sys_log.h>
+
+/* Note: Zephyr uses exception numbers, vs the IRQ #s used by the CC3200 SDK */
+#define EXCEPTION_WDT0  18  /* (INT_WDT - 16) = (34-16) */
+
+static void (*user_cb)(struct device *dev);
+
+/* Keep reference of the device to pass it to the callback */
+struct device *wdog_r;
+
+static void wdt_cc32xx_enable(struct device *dev)
+{
+	ARG_UNUSED(dev);
+	MAP_WatchdogEnable(WDT_BASE);
+}
+
+static void wdt_cc32xx_disable(struct device *dev)
+{
+	ARG_UNUSED(dev);
+}
+
+static void wdt_cc32xx_isr(void)
+{
+	MAP_WatchdogIntClear(WDT_BASE);
+
+	if (user_cb != NULL) {
+		user_cb(wdog_r);
+	}
+}
+
+static int wdt_cc32xx_set_config(struct device *dev, struct wdt_config *config)
+{
+	ARG_UNUSED(dev);
+	/* Configure only the callback */
+	user_cb = config->interrupt_fn;
+	return 0;
+}
+
+static void wdt_cc32xx_get_config(struct device *dev, struct wdt_config *config)
+{
+	ARG_UNUSED(dev);
+	ARG_UNUSED(config);
+	SYS_LOG_ERR("Function not implemented!");
+}
+
+static void wdt_cc32xx_reload(struct device *dev)
+{
+	ARG_UNUSED(dev);
+	MAP_WatchdogReloadSet(WDT_BASE, CONFIG_WDT_CC32XX_RELOAD_TIME *
+			      CONFIG_SYS_CLOCK_HW_CYCLES_PER_SEC);
+	MAP_WatchdogIntClear(WDT_BASE);
+}
+
+static const struct wdt_driver_api wdt_cc32xx_api = {
+	.enable = wdt_cc32xx_enable,
+	.disable = wdt_cc32xx_disable,
+	.get_config = wdt_cc32xx_get_config,
+	.set_config = wdt_cc32xx_set_config,
+	.reload = wdt_cc32xx_reload
+};
+
+static struct device DEVICE_NAME_GET(wdt_cc32xx);
+
+static int wdt_cc32xx_init(struct device *dev)
+{
+	/* store ref for callback */
+	wdog_r = dev;
+
+	MAP_PRCMPeripheralClkEnable(PRCM_WDT, PRCM_RUN_MODE_CLK);
+
+	/* Check to see if the registers are locked, and if so, unlock them. */
+	if (MAP_WatchdogLockState(WDT_BASE) == true) {
+		MAP_WatchdogUnlock(WDT_BASE);
+	}
+
+	MAP_WatchdogReloadSet(WDT_BASE, CONFIG_WDT_CC32XX_RELOAD_TIME *
+			      CONFIG_SYS_CLOCK_HW_CYCLES_PER_SEC);
+	MAP_WatchdogIntClear(WDT_BASE);
+
+	IRQ_CONNECT(EXCEPTION_WDT0, CONFIG_WDT_CC32XX_IRQ_PRI,
+		    wdt_cc32xx_isr, DEVICE_GET(wdt_cc32xx), 0);
+
+	MAP_IntPendClear(INT_WDT);
+	irq_enable(EXCEPTION_WDT0);
+
+	return 0;
+}
+
+DEVICE_AND_API_INIT(wdt_cc32xx, CONFIG_WDT_0_NAME, wdt_cc32xx_init,
+		    NULL, NULL,
+		    PRE_KERNEL_1, CONFIG_KERNEL_INIT_PRIORITY_DEVICE,
+		    &wdt_cc32xx_api);


### PR DESCRIPTION
this PR adds basic watchdog support for the cc32xx platforms to zephyr