### PR TITLE
uart_esp32: alter the uart.h include order to avoid warning

### DIFF
--- a/drivers/serial/uart_esp32.c
+++ b/drivers/serial/uart_esp32.c
@@ -4,8 +4,10 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <uart.h>
+/* include rom/uart.h (from the esp-dif package) before Z's uart.h so
+ * that the definition of BIT is not overriden */
 #include <rom/uart.h>
+#include <uart.h>
 #include <rom/ets_sys.h>
 #include <errno.h>
 


### PR DESCRIPTION
The esp-idf package contains on the BSP a definition of the BIT macro
unconditionally #defined when rom/uart.h is #included. When Zephyr's
uart.h (which pulls in include/misc/util.h) that conditionally

This generates a compile warning on the re-definiton of BIT by the
esp-idf package.

Thus include uart.h after esp-idf's rom/uart.h to have BIT not
re-defined thanks to Zephyr's conditional definition.

Signed-off-by: Inaky Perez-Gonzalez <inaky.perez-gonzalez@intel.com>