### PR TITLE
tests: protection: add testcase.yaml

### DIFF
--- a/tests/kernel/protection/testcase.yaml
+++ b/tests/kernel/protection/testcase.yaml
@@ -1,0 +1,4 @@
+tests:
+-   test:
+        filter: CONFIG_CPU_HAS_MPU or CONFIG_X86_MMU
+        tags: core security ignore_faults


### PR DESCRIPTION
commit d859295be9fc ("tests: protection: convert to testcase.yaml")
removed testcase.ini but did not add an equivalent testcase.yaml.
Add it.

Signed-off-by: Stephen Smalley <sds@tycho.nsa.gov>