### PR TITLE
scripts/sanitycheck: split out log from config-sanitycheck

### DIFF
--- a/scripts/sanitycheck
+++ b/scripts/sanitycheck
@@ -716,7 +716,7 @@ class MakeGenerator:
         if not os.path.exists(outdir):
             os.makedirs(outdir)
 
-    def add_build_goal(self, name, directory, outdir, args):
+    def add_build_goal(self, name, directory, outdir, args, buildlog):
         """Add a goal to invoke a Kbuild session
 
         @param name A unique string name for this build goal. The results
@@ -729,7 +729,7 @@ class MakeGenerator:
             environment variables or specific Make goals
         """
         self._add_goal(outdir)
-        build_logfile = os.path.join(outdir, "build.log")
+        build_logfile = os.path.join(outdir, buildlog)
         text = (self._get_rule_header(name) +
                 self._get_sub_make(name, "building", directory,
                                    outdir, build_logfile, args) +
@@ -813,7 +813,8 @@ class MakeGenerator:
             self.add_unit_goal(ti.name, ti.test.code_location, ti.outdir,
                                args, ti.test.timeout, coverage)
         else:
-            self.add_build_goal(ti.name, ti.test.code_location, ti.outdir, args)
+            self.add_build_goal(ti.name, ti.test.code_location, ti.outdir,
+                    args, "build.log")
 
     def execute(self, callback_fn=None, context=None):
         """Execute all the registered build goals
@@ -1378,7 +1379,8 @@ class TestSuite:
                         o = os.path.join(self.outdir, plat.name, tc.path)
                         dlist[tc, plat, tc.name.split("/")[-1]] = os.path.join(o,".config-sanitycheck")
                         goal = "_".join([plat.name, "_".join(tc.name.split("/")), "config-sanitycheck"])
-                        mg.add_build_goal(goal, os.path.join(ZEPHYR_BASE, tc.code_location), o, args)
+                        mg.add_build_goal(goal, os.path.join(ZEPHYR_BASE, tc.code_location), o,
+                                args, "config-sanitycheck.log")
 
         info("Building testcase defconfigs...")
         results = mg.execute(defconfig_cb)


### PR DESCRIPTION
Put the results of the config-sanitycheck into their own log so we can
see warnings from that stage of the build.

Signed-off-by: Kumar Gala <kumar.gala@linaro.org>