### PR TITLE
samples: coaps_server: Fix platforms to build coap_server test on

### DIFF
--- a/samples/net/coaps_server/sample.yaml
+++ b/samples/net/coaps_server/sample.yaml
@@ -3,6 +3,6 @@ sample:
     name: TBD
 tests:
 -   test:
-        arch_whitelist: qemu_x86
+        platform_whitelist: arduino_101 frdm_k64f qemu_x86
         build_only: true
         tags: net


### PR DESCRIPTION
We incorrectly had an arch_whitelist constraint set to 'qemu_x86' which should
have been a platform_whitelist, so fix that and add arduino_101
frdm_k64f to the platform_whitelist as targets that we can test this on.

Signed-off-by: Kumar Gala <kumar.gala@linaro.org>