### PR TITLE
kernel: start: relocate vector table

### DIFF
--- a/arch/arm/core/cortex_m/prep_c.c
+++ b/arch/arm/core/cortex_m/prep_c.c
@@ -22,9 +22,20 @@
 #include <linker/linker-defs.h>
 #include <nano_internal.h>
 #include <arch/arm/cortex_m/cmsis.h>
+#include <string.h>
 
 #ifdef CONFIG_ARMV6_M
-static inline void relocate_vector_table(void) { /* do nothing */ }
+
+#define VECTOR_ADDRESS 0
+static inline void relocate_vector_table(void)
+{
+#if defined(CONFIG_XIP) && (CONFIG_FLASH_BASE_ADDRESS != 0) || \
+    !defined(CONFIG_XIP) && (CONFIG_SRAM_BASE_ADDRESS != 0)
+	size_t vector_size = (size_t)_vector_end - (size_t)_vector_start;
+	memcpy(VECTOR_ADDRESS, _vector_start, vector_size);
+#endif
+}
+
 #elif defined(CONFIG_ARMV7_M)
 #ifdef CONFIG_XIP
 #define VECTOR_ADDRESS ((uintptr_t)&_image_rom_start + \

--- a/include/arch/arm/cortex_m/scripts/linker.ld
+++ b/include/arch/arm/cortex_m/scripts/linker.ld
@@ -94,7 +94,7 @@ SECTIONS
 	KEEP(*(.dbghdr))
 	KEEP(*(".dbghdr.*"))
 #endif
-
+	_vector_start = .;
 	. = CONFIG_TEXT_SECTION_OFFSET;
 	KEEP(*(.exc_vector_table))
 	KEEP(*(".exc_vector_table.*"))
@@ -112,7 +112,7 @@ SECTIONS
 #ifdef CONFIG_GEN_SW_ISR_TABLE
 	KEEP(*(SW_ISR_TABLE))
 #endif
-
+	_vector_end = .;
 	_image_text_start = .;
 	*(.text)
 	*(".text.*")

--- a/include/linker/linker-defs.h
+++ b/include/linker/linker-defs.h
@@ -208,6 +208,9 @@ extern char _image_text_end[];
 extern char _image_rodata_start[];
 extern char _image_rodata_end[];
 
+extern char _vector_start[];
+extern char _vector_end[];
+
 /* end address of image, used by newlib for the heap */
 extern char _end[];
 


### PR DESCRIPTION
An abnormal crash was encountered in our chips
(eflash address is not zero, the 0 address is
mapped by bootlink(SRAM) and can be written)
with zephyr OS, and the reason for this crash is
that, on the arm architecture ARMV6_M, the system
requires an exception vector table at the 0 address.
Because the relocate_vector_table function is not
implemented, the exception vector table doesn't move
to the 0 address, so the system generates an exception.
With this fix we implemented this function and the
exception vector table moves to the 0 address. The
system runs in flash when the macro CONFIG_XIP is defined
while running in sram when the macro CONFIG_XIP not defined.
If the system starts from the 0 address, the exception
vector table doesn't need to be moved, while the system
doesn't start from the 0 address, the exception vector
table needs to be moved to 0 address.

Signed-off-by: Xiaorui Hu <xiaorui.hu@linaro.org>