### PR TITLE
doc: fix sidebar nav issues with board docs

### DIFF
--- a/boards/arc/index.rst
+++ b/boards/arc/index.rst
@@ -1,0 +1,10 @@
+.. _boards-arc:
+
+ARC Boards
+##########
+
+.. toctree::
+   :maxdepth: 1
+   :glob:
+
+   **/*

--- a/boards/arm/index.rst
+++ b/boards/arm/index.rst
@@ -1,0 +1,10 @@
+.. _boards-arm:
+
+ARM Boards
+##########
+
+.. toctree::
+   :maxdepth: 1
+   :glob:
+
+   **/*

--- a/boards/boards.rst
+++ b/boards/boards.rst
@@ -9,47 +9,12 @@ documented below.
 To add support documentation for a new board, please use the template available
 under :file:`doc/templates/board.tmpl`
 
-X86 Boards
-**********
 
 .. toctree::
-   :maxdepth: 1
-   :glob:
+   :maxdepth: 2
 
-   x86/**/*
-
-ARM Boards
-**********
-
-.. toctree::
-   :maxdepth: 1
-   :glob:
-
-   arm/**/*
-
-ARC Boards
-**********
-
-.. toctree::
-   :maxdepth: 1
-   :glob:
-
-   arc/**/*
-
-NIOS II Boards
-**************
-
-.. toctree::
-   :maxdepth: 1
-   :glob:
-
-   nios2/**/*
-
-XTENSA Boards
-*************
-
-.. toctree::
-   :maxdepth: 1
-   :glob:
-
-   xtensa/**/*
+   x86/index.rst
+   arm/index.rst
+   arc/index.rst
+   nios2/index.rst
+   xtensa/index.rst

--- a/boards/nios2/index.rst
+++ b/boards/nios2/index.rst
@@ -1,0 +1,10 @@
+.. _boards-nios2:
+
+NIOS II Boards
+##############
+
+.. toctree::
+   :maxdepth: 1
+   :glob:
+
+   **/*

--- a/boards/x86/index.rst
+++ b/boards/x86/index.rst
@@ -1,0 +1,10 @@
+.. _boards-x86:
+
+x86 Boards
+##########
+
+.. toctree::
+   :maxdepth: 1
+   :glob:
+
+   **/*

--- a/boards/xtensa/index.rst
+++ b/boards/xtensa/index.rst
@@ -1,0 +1,10 @@
+.. _boards-xtensa:
+
+XTENSA Boards
+#############
+
+.. toctree::
+   :maxdepth: 1
+   :glob:
+
+   **/*


### PR DESCRIPTION
Sidebar navigation for supported boards is wonky: opens to show
all boards (making for lots of scrolling to see the sidebar) and
sidebar items aren't always clickable (as explained in the JIRA
issue).

Fix is to not use multiple toctree directives in boards.rst

JIRA: INF-132

Signed-off-by: David B. Kinder <david.b.kinder@intel.com>