### PR TITLE
boards; cc2650_sensortag: Get building with sanitycheck

### DIFF
--- a/arch/arm/soc/ti_simplelink/cc2650/soc.c
+++ b/arch/arm/soc/ti_simplelink/cc2650/soc.c
@@ -66,9 +66,11 @@ ti_ccfg[CCFG_SIZE / sizeof(u32_t)] = {
 static const u32_t clkloadctl =
 	REG_ADDR(TI_CC2650_PRCM_40082000_BASE_ADDRESS,
 		 CC2650_PRCM_CLKLOADCTL);
+#ifdef CONFIG_CC2650_TRNG_RANDOM_GENERATOR
 static const u32_t secdmaclkgr =
 	REG_ADDR(TI_CC2650_PRCM_40082000_BASE_ADDRESS,
 		 CC2650_PRCM_SECDMACLKGR);
+#endif
 static const u32_t gpioclkgr =
 	REG_ADDR(TI_CC2650_PRCM_40082000_BASE_ADDRESS,
 		 CC2650_PRCM_GPIOCLKGR);
@@ -78,9 +80,11 @@ static const u32_t pdctl0 =
 static const u32_t pdstat0 =
 	REG_ADDR(TI_CC2650_PRCM_40082000_BASE_ADDRESS,
 		 CC2650_PRCM_PDSTAT0);
+#ifdef CONFIG_SERIAL
 static const u32_t uartclkgr =
 	REG_ADDR(TI_CC2650_PRCM_40082000_BASE_ADDRESS,
 		 CC2650_PRCM_UARTCLKGR);
+#endif
 
 /* Setup power and clock for needed hardware modules. */
 static void setup_modules_prcm(void)

--- a/boards/arm/cc2650_sensortag/cc2650_sensortag.yaml
+++ b/boards/arm/cc2650_sensortag/cc2650_sensortag.yaml
@@ -1,0 +1,8 @@
+identifier: cc2650_sensortag
+name: SimpleLink multi-standard CC2650 SensorTag kit
+type: mcu
+arch: arm
+toolchain:
+  - zephyr
+  - gccarmemb
+ram: 20


### PR DESCRIPTION
Board port was done before the yaml transition, so was missing a
cc2650_sensortag.yaml.  As such when we build all the test we get a few
build errors that we also fixed up.

Signed-off-by: Kumar Gala <kumar.gala@linaro.org>