### PR TITLE
Bluetooth: Move PRNG initialization a bit later in HCI init

### DIFF
--- a/subsys/bluetooth/host/crypto.c
+++ b/subsys/bluetooth/host/crypto.c
@@ -66,6 +66,11 @@ int prng_init(void)
 	struct net_buf *rsp;
 	int ret;
 
+	/* Check first that HCI_LE_Rand is supported */
+	if (!(bt_dev.supported_commands[27] & BIT(7))) {
+		return -ENOTSUP;
+	}
+
 	ret = bt_hci_cmd_send_sync(BT_HCI_OP_LE_RAND, NULL, &rsp);
 	if (ret) {
 		return ret;


### PR DESCRIPTION
Move the PRNG initialization after reading local supported commands,
so that we don't send HCI_LE_Rand if the controller doesn't support it
(we still need to fail the init however).

Signed-off-by: Johan Hedberg <johan.hedberg@intel.com>