### PR TITLE
Bluetooth: controller: ticker refactoring and simple fairness

### DIFF
--- a/subsys/bluetooth/controller/ticker/ticker.c
+++ b/subsys/bluetooth/controller/ticker/ticker.c
@@ -789,6 +789,7 @@ static inline u32_t ticker_job_insert(struct ticker_instance *instance,
 
 			ticker_collide = &node[id_collide];
 			if (ticker_collide->ticks_periodic &&
+			    ticker_collide->ticks_periodic &&
 			    ticker_collide->force < ticker->force) {
 				/* dequeue and get the reminder of ticks
 				 * to expire.


### PR DESCRIPTION
When force scheduling a ticker use the number of times the
tickers have already skipped their intervals to decide if
the forced ticker can pre-empt the colliding ticker. This
introduces a fairness amongst tickers contesting for the
overlapping time slice.

Flashing in co-operation with Radio needs to be fair in
order to avoid connection supervision timeouts.

Signed-off-by: Vinayak Kariappa Chettimada <vich@nordicsemi.no>