### PR TITLE
Bluetooth: tests: Fix left-over issues from bt_gatt_service() removal

### DIFF
--- a/tests/bluetooth/tester/src/gatt.c
+++ b/tests/bluetooth/tester/src/gatt.c
@@ -209,7 +209,7 @@ static int register_service(void)
 				       (attr_count - svc_attr_count);
 	server_svcs[svc_count].attr_count = svc_attr_count;
 
-	return bt_gatt_service_register(server_svcs);
+	return bt_gatt_service_register(&server_svcs[svc_count]);
 }
 
 static void add_service(u8_t *data, u16_t len)
@@ -797,7 +797,9 @@ static void start_server(u8_t *data, u16_t len)
 		return;
 	}
 
-	/* All handles of gatt db are now assigned by bt_gatt_register */
+	/* All handles of gatt db are now assigned by
+	 * bt_gatt_service_register().
+	 */
 	db_attr_off = server_db[0].handle - 1;
 
 	update_incl_svc_offset(db_attr_off);


### PR DESCRIPTION
The new GATT service registration API is bt_gatt_service_register(),
which takes a bt_gatt_service object pointer.

Signed-off-by: Johan Hedberg <johan.hedberg@intel.com>