### PR TITLE
Bluetooth: controller: Temporarily disable scan req notification

### DIFF
--- a/subsys/bluetooth/controller/ll_sw/ctrl.c
+++ b/subsys/bluetooth/controller/ll_sw/ctrl.c
@@ -726,13 +726,16 @@ static inline u32_t isr_rx_adv(u8_t devmatch_ok, u8_t irkmatch_ok,
 	    (1 /** @todo own addr match check */)) {
 
 #if defined(CONFIG_BLUETOOTH_CONTROLLER_SCAN_REQ_NOTIFY)
-		u32_t err;
+		if (!IS_ENABLED(CONFIG_BLUETOOTH_CONTROLLER_ADV_EXT) ||
+		    0 /* TODO: extended adv. scan req notification enabled */) {
+			u32_t err;
 
-		/* Generate the scan request event */
-		err = isr_rx_adv_sr_report(pdu_adv, rssi_ready);
-		if (err) {
-			/* Scan Response will not be transmitted */
-			return err;
+			/* Generate the scan request event */
+			err = isr_rx_adv_sr_report(pdu_adv, rssi_ready);
+			if (err) {
+				/* Scan Response will not be transmitted */
+				return err;
+			}
 		}
 #endif /* CONFIG_BLUETOOTH_CONTROLLER_SCAN_REQ_NOTIFY */
 


### PR DESCRIPTION
Temporarily, disable scan request notification reports when
LE Advertising Extensions feature is enabled; as support for
enabling scan request notification is not yet added to the
Controller's Link Layer interface functions, yet.

Signed-off-by: Vinayak Kariappa Chettimada <vich@nordicsemi.no>