### PR TITLE
tests: Remove camel case and fix coding style

### DIFF
--- a/tests/benchmarks/app_kernel/src/event_b.c
+++ b/tests/benchmarks/app_kernel/src/event_b.c
@@ -12,13 +12,13 @@
 
 /* #define EVENT_CHECK */
 #ifdef EVENT_CHECK
-static const char EventSignalErr[] = "------------ Error signalling event.\n";
-static const char EventTestErr[] = "------------ Error testing event.\n";
-static const char EventHandlerErr[] = "------------ Error in event handler.\n";
+static const char event_signal_err[] = "----------- Error signalling event.\n";
+static const char event_test_err[] = "----------- Error testing event.\n";
+static const char event_handler_err[] = "----------- Error in event handler\n";
 #endif
 
 /* global Event value */
-volatile int nEventValue;
+volatile int nevent_value;
 
 /*
  * Function prototypes.
@@ -37,17 +37,17 @@ int example_handler (struct k_alert *alert);
  */
 void event_test(void)
 {
-	int nReturn = 0;
-	int nCounter;
+	int nreturn = 0;
+	int ncounter;
 	u32_t et; /* elapsed time */
 
 	PRINT_STRING(dashline, output_file);
 	et = BENCH_START();
-	for (nCounter = 0; nCounter < NR_OF_EVENT_RUNS; nCounter++) {
+	for (ncounter = 0; ncounter < NR_OF_EVENT_RUNS; ncounter++) {
 		k_alert_send(&TEST_EVENT);
 #ifdef EVENT_CHECK
-		if (nReturn != 0) {
-			PRINT_STRING(EventSignalErr, output_file);
+		if (nreturn != 0) {
+			PRINT_STRING(event_signal_err, output_file);
 			return; /* error */
 		}
 #endif /* EVENT_CHECK */
@@ -59,19 +59,19 @@ void event_test(void)
 			SYS_CLOCK_HW_CYCLES_TO_NS_AVG(et, NR_OF_EVENT_RUNS));
 
 	et = BENCH_START();
-	for (nCounter = 0; nCounter < NR_OF_EVENT_RUNS; nCounter++) {
+	for (ncounter = 0; ncounter < NR_OF_EVENT_RUNS; ncounter++) {
 		k_alert_send(&TEST_EVENT);
 #ifdef EVENT_CHECK
-		if (nReturn != 0) {
-			PRINT_STRING(EventSignalErr, output_file);
+		if (nreturn != 0) {
+			PRINT_STRING(event_signal_err, output_file);
 			k_sleep(1);
 			return; /* error */
 		}
 #endif /* EVENT_CHECK */
 		k_alert_recv(&TEST_EVENT, K_NO_WAIT);
 #ifdef EVENT_CHECK
-		if (nReturn != 0) {
-			PRINT_STRING(EventTestErr, output_file);
+		if (nreturn != 0) {
+			PRINT_STRING(event_test_err, output_file);
 			k_sleep(1);
 			return; /* error */
 		}
@@ -84,18 +84,18 @@ void event_test(void)
 			SYS_CLOCK_HW_CYCLES_TO_NS_AVG(et, NR_OF_EVENT_RUNS));
 
 	et = BENCH_START();
-	for (nCounter = 0; nCounter < NR_OF_EVENT_RUNS; nCounter++) {
+	for (ncounter = 0; ncounter < NR_OF_EVENT_RUNS; ncounter++) {
 		k_alert_send(&TEST_EVENT);
 #ifdef EVENT_CHECK
-		if (nReturn != 0) {
-			PRINT_STRING(EventSignalErr, output_file);
+		if (nreturn != 0) {
+			PRINT_STRING(event_signal_err, output_file);
 			return; /* error */
 		}
 #endif /* EVENT_CHECK */
 		k_alert_recv(&TEST_EVENT, K_FOREVER);
 #ifdef EVENT_CHECK
-		if (nReturn != 0) {
-			PRINT_STRING(EventTestErr, output_file);
+		if (nreturn != 0) {
+			PRINT_STRING(event_test_err, output_file);
 			return; /* error */
 		}
 #endif /* EVENT_CHECK */
@@ -109,32 +109,32 @@ void event_test(void)
 	PRINT_STRING("| Signal event with installed handler"
 		 "                                         |\n", output_file);
 	TEST_EVENT.handler = example_handler;
-	if (nReturn != 0) {
+	if (nreturn != 0) {
 		PRINT_F(output_file,
 			"-------- Error installing event handler.\n");
 		k_sleep(1);
 		return; /* error */
 	}
 
-	for (nCounter = 0; nCounter < NR_OF_EVENT_RUNS; nCounter++) {
+	for (ncounter = 0; ncounter < NR_OF_EVENT_RUNS; ncounter++) {
 		k_alert_send(&TEST_EVENT);
 #ifdef EVENT_CHECK
-		if (nReturn != 0) {
-			PRINT_STRING(EventSignalErr, output_file);
+		if (nreturn != 0) {
+			PRINT_STRING(event_signal_err, output_file);
 			k_sleep(1);
 			return; /* error */
 		}
-		if (nEventValue != TEST_EVENT.send_count + 1) {
-			PRINT_STRING(EventHandlerErr, output_file);
+		if (nevent_value != TEST_EVENT.send_count + 1) {
+			PRINT_STRING(event_handler_err, output_file);
 			k_sleep(1);
 			return; /* error */
 		}
 #endif /* EVENT_CHECK */
-		nEventValue = 0;
+		nevent_value = 0;
 	}
 
 	TEST_EVENT.handler = NULL;
-	if (nReturn != 0) {
+	if (nreturn != 0) {
 		PRINT_F(output_file, "Error removing event handler.\n");
 		k_sleep(1);
 		return; /* error */
@@ -160,7 +160,7 @@ void event_test(void)
 int example_handler (struct k_alert *alert)
 {
 	ARG_UNUSED(alert);
-	nEventValue = alert->send_count + 1;
+	nevent_value = alert->send_count + 1;
 
 	return 1;
 }

--- a/tests/benchmarks/app_kernel/src/mailbox_r.c
+++ b/tests/benchmarks/app_kernel/src/mailbox_r.c
@@ -36,7 +36,7 @@ void mailrecvtask(void)
 	int getsize;
 	unsigned int gettime;
 	int getcount;
-	GetInfo getinfo;
+	struct getinfo getinfo;
 
 	getcount = NR_OF_MBOX_RUNS;
 

--- a/tests/benchmarks/app_kernel/src/master.c
+++ b/tests/benchmarks/app_kernel/src/master.c
@@ -17,11 +17,11 @@
 #include <tc_util.h>
 #include "master.h"
 
-char Msg[MAX_MSG];
+char msg[MAX_MSG];
 char data_bench[OCTET_TO_SIZEOFUNIT(MESSAGE_SIZE)];
 
 #ifdef PIPE_BENCH
-struct k_pipe *TestPipes[] = {&PIPE_NOBUFF, &PIPE_SMALLBUFF, &PIPE_BIGBUFF};
+struct k_pipe *test_pipes[] = {&PIPE_NOBUFF, &PIPE_SMALLBUFF, &PIPE_BIGBUFF};
 #endif
 char sline[SLINE_LEN + 1];
 const char newline[] = "\n";
@@ -38,7 +38,7 @@ u32_t tm_off;
 /********************************************************************/
 /* static allocation  */
 K_THREAD_DEFINE(RECVTASK, 1024, recvtask, NULL, NULL, NULL, 5, 0, K_NO_WAIT);
-K_THREAD_DEFINE(BENCHTASK, 1024, BenchTask, NULL, NULL, NULL, 6, 0, K_NO_WAIT);
+K_THREAD_DEFINE(BENCHTASK, 1024, bench_task, NULL, NULL, NULL, 6, 0, K_NO_WAIT);
 
 K_MSGQ_DEFINE(DEMOQX1, 1, 500, 4);
 K_MSGQ_DEFINE(DEMOQX4, 4, 500, 4);
@@ -120,7 +120,7 @@ void output_close(void)
  *
  * @return N/A
  */
-void BenchTask(void *p1, void *p2, void *p3)
+void bench_task(void *p1, void *p2, void *p3)
 {
 	int autorun = 0, continuously = 0;
 
@@ -166,5 +166,4 @@ void BenchTask(void *p1, void *p2, void *p3)
  */
 void dummy_test(void)
 {
-	return;
 }

--- a/tests/benchmarks/app_kernel/src/master.h
+++ b/tests/benchmarks/app_kernel/src/master.h
@@ -48,12 +48,12 @@
 #define NR_OF_EVENT_RUNS  1000
 #define NR_OF_MBOX_RUNS 128
 #define NR_OF_PIPE_RUNS 256
-//#define SEMA_WAIT_TIME (5 * sys_clock_ticks_per_sec)
+/* #define SEMA_WAIT_TIME (5 * sys_clock_ticks_per_sec) */
 #define SEMA_WAIT_TIME (5000)
 /* global data */
-extern char Msg[MAX_MSG];
+extern char msg[MAX_MSG];
 extern char data_bench[OCTET_TO_SIZEOFUNIT(MESSAGE_SIZE)];
-extern struct k_pipe *TestPipes[];
+extern struct k_pipe *test_pipes[];
 extern FILE *output_file;
 extern const char newline[];
 extern char sline[];
@@ -65,11 +65,11 @@ extern char sline[];
 
 
 /* pipe amount of content to receive (0+, 1+, all) */
-typedef enum {
+enum pipe_options {
 	_0_TO_N = 0x0,
 	_1_TO_N = 0x1,
 	_ALL_N  = 0x2,
-} pipe_options;
+};
 
 /* dummy_test is a function that is mapped when we */
 /* do not want to test a specific Benchmark */
@@ -77,7 +77,7 @@ extern void dummy_test(void);
 
 /* other external functions */
 
-extern void BenchTask(void *p1, void *p2, void *p3);
+extern void bench_task(void *p1, void *p2, void *p3);
 extern void recvtask(void *p1, void *p2, void *p3);
 
 #ifdef MAILBOX_BENCH
@@ -189,12 +189,12 @@ static inline u32_t BENCH_START(void)
 	return et;
 }
 
-#define check_result()				\
-{									\
-	if (bench_test_end() < 0) {		\
-		PRINT_OVERFLOW_ERROR();		\
-		return; /* error */			\
-	}								\
+static inline void check_result(void)
+{
+	if (bench_test_end() < 0) {
+		PRINT_OVERFLOW_ERROR();
+		return; /* error */
+	}
 }
 
 

--- a/tests/benchmarks/app_kernel/src/receiver.h
+++ b/tests/benchmarks/app_kernel/src/receiver.h
@@ -15,11 +15,11 @@
 #include "master.h"
 
 /* type defines. */
-typedef struct {
+struct getinfo{
 	int count;
 	unsigned int time;
 	int size;
-} GetInfo;
+};
 
 /* global data */
 extern char data_recv[OCTET_TO_SIZEOFUNIT(MESSAGE_SIZE)];

--- a/tests/drivers/uart/uart_basic_api/src/test_uart_poll.c
+++ b/tests/drivers/uart/uart_basic_api/src/test_uart_poll.c
@@ -32,7 +32,7 @@ static const char *poll_data = "This is a POLL test.\r\n";
 
 static int test_poll_in(void)
 {
-	unsigned char recvChar;
+	unsigned char recv_char;
 	struct device *uart_dev = device_get_binding(UART_DEVICE_NAME);
 
 	if (!uart_dev) {
@@ -44,12 +44,12 @@ static int test_poll_in(void)
 
 	/* Verify uart_poll_in() */
 	while (1) {
-		while (uart_poll_in(uart_dev, &recvChar) < 0)
+		while (uart_poll_in(uart_dev, &recv_char) < 0)
 			;
 
-		TC_PRINT("%c", recvChar);
+		TC_PRINT("%c", recv_char);
 
-		if ((recvChar == '\n') || (recvChar == '\r')) {
+		if ((recv_char == '\n') || (recv_char == '\r')) {
 			break;
 		}
 	}
@@ -60,7 +60,7 @@ static int test_poll_in(void)
 static int test_poll_out(void)
 {
 	int i;
-	unsigned char sentChar;
+	unsigned char sent_char;
 	struct device *uart_dev = device_get_binding(UART_DEVICE_NAME);
 
 	if (!uart_dev) {
@@ -70,11 +70,11 @@ static int test_poll_out(void)
 
 	/* Verify uart_poll_out() */
 	for (i = 0; i < strlen(poll_data); i++) {
-		sentChar = uart_poll_out(uart_dev, poll_data[i]);
+		sent_char = uart_poll_out(uart_dev, poll_data[i]);
 
-		if (sentChar != poll_data[i]) {
+		if (sent_char != poll_data[i]) {
 			TC_PRINT("expect send %c, actaul send %c\n",
-						poll_data[i], sentChar);
+						poll_data[i], sent_char);
 			return TC_FAIL;
 		}
 	}

--- a/tests/kernel/alert/alert_api/src/test_alert_contexts.c
+++ b/tests/kernel/alert/alert_api/src/test_alert_contexts.c
@@ -82,7 +82,7 @@ static void alert_recv(void)
 	}
 }
 
-static void tThread_entry(void *p1, void *p2, void *p3)
+static void thread_entry(void *p1, void *p2, void *p3)
 {
 	alert_recv();
 }
@@ -92,14 +92,14 @@ static void thread_alert(void)
 	handler_executed = 0;
 	/**TESTPOINT: thread-thread sync via alert*/
 	k_tid_t tid = k_thread_create(&tdata, tstack, STACK_SIZE,
-				      tThread_entry, NULL, NULL, NULL,
+				      thread_entry, NULL, NULL, NULL,
 				      K_PRIO_PREEMPT(0), 0, 0);
 	alert_send();
 	k_sleep(TIMEOUT);
 	k_thread_abort(tid);
 }
 
-static void tIsr_entry(void *p)
+static void tisr_entry(void *p)
 {
 	alert_send();
 }
@@ -108,7 +108,7 @@ static void isr_alert(void)
 {
 	handler_executed = 0;
 	/**TESTPOINT: thread-isr sync via alert*/
-	irq_offload(tIsr_entry, NULL);
+	irq_offload(tisr_entry, NULL);
 	k_sleep(TIMEOUT);
 	alert_recv();
 }

--- a/tests/kernel/msgq/msgq_api/src/test_msgq_contexts.c
+++ b/tests/kernel/msgq/msgq_api/src/test_msgq_contexts.c
@@ -31,7 +31,8 @@ static void put_msgq(struct k_msgq *pmsgq)
 		ret = k_msgq_put(pmsgq, (void *)&data[i], K_NO_WAIT);
 		zassert_false(ret, NULL);
 		/**TESTPOINT: msgq free get*/
-		zassert_equal(k_msgq_num_free_get(pmsgq), MSGQ_LEN - 1 - i, NULL);
+		zassert_equal(k_msgq_num_free_get(pmsgq),
+				MSGQ_LEN - 1 - i, NULL);
 		/**TESTPOINT: msgq used get*/
 		zassert_equal(k_msgq_num_used_get(pmsgq), i + 1, NULL);
 	}
@@ -49,7 +50,8 @@ static void get_msgq(struct k_msgq *pmsgq)
 		/**TESTPOINT: msgq free get*/
 		zassert_equal(k_msgq_num_free_get(pmsgq), i + 1, NULL);
 		/**TESTPOINT: msgq used get*/
-		zassert_equal(k_msgq_num_used_get(pmsgq), MSGQ_LEN - 1 - i, NULL);
+		zassert_equal(k_msgq_num_used_get(pmsgq),
+				MSGQ_LEN - 1 - i, NULL);
 	}
 }
 
@@ -60,12 +62,12 @@ static void purge_msgq(struct k_msgq *pmsgq)
 	zassert_equal(k_msgq_num_used_get(pmsgq), 0, NULL);
 }
 
-static void tIsr_entry(void *p)
+static void tisr_entry(void *p)
 {
 	put_msgq((struct k_msgq *)p);
 }
 
-static void tThread_entry(void *p1, void *p2, void *p3)
+static void thread_entry(void *p1, void *p2, void *p3)
 {
 	get_msgq((struct k_msgq *)p1);
 	k_sem_give(&end_sema);
@@ -76,7 +78,7 @@ static void msgq_thread(struct k_msgq *pmsgq)
 	k_sem_init(&end_sema, 0, 1);
 	/**TESTPOINT: thread-thread data passing via message queue*/
 	k_tid_t tid = k_thread_create(&tdata, tstack, STACK_SIZE,
-				      tThread_entry, pmsgq, NULL, NULL,
+				      thread_entry, pmsgq, NULL, NULL,
 				      K_PRIO_PREEMPT(0), 0, 0);
 	put_msgq(pmsgq);
 	k_sem_take(&end_sema, K_FOREVER);
@@ -89,7 +91,7 @@ static void msgq_thread(struct k_msgq *pmsgq)
 static void msgq_isr(struct k_msgq *pmsgq)
 {
 	/**TESTPOINT: thread-isr data passing via message queue*/
-	irq_offload(tIsr_entry, pmsgq);
+	irq_offload(tisr_entry, pmsgq);
 	get_msgq(pmsgq);
 
 	/**TESTPOINT: msgq purge*/

--- a/tests/kernel/mutex/mutex/src/mutex.c
+++ b/tests/kernel/mutex/mutex/src/mutex.c
@@ -51,35 +51,35 @@
 
 #define STACKSIZE 512
 
-static int tcRC = TC_PASS;         /* test case return code */
+static int tc_rc = TC_PASS;         /* test case return code */
 
 K_MUTEX_DEFINE(private_mutex);
 
 
-K_MUTEX_DEFINE(Mutex1);
-K_MUTEX_DEFINE(Mutex2);
-K_MUTEX_DEFINE(Mutex3);
-K_MUTEX_DEFINE(Mutex4);
+K_MUTEX_DEFINE(mutex1);
+K_MUTEX_DEFINE(mutex2);
+K_MUTEX_DEFINE(mutex3);
+K_MUTEX_DEFINE(mutex4);
 
 /**
  *
- * Task05 -
+ * task05 -
  *
  * @return  N/A
  */
 
-void Task05(void)
+void task05(void)
 {
 	int rv;
 
 	k_sleep(K_MSEC(3500));
 
 	/* Wait and boost owner priority to 5 */
-	rv = k_mutex_lock(&Mutex4, K_SECONDS(1));
+	rv = k_mutex_lock(&mutex4, K_SECONDS(1));
 	if (rv != -EAGAIN) {
-		tcRC = TC_FAIL;
+		tc_rc = TC_FAIL;
 		TC_ERROR("Failed to timeout on mutex 0x%x\n",
-			 (u32_t)&Mutex4);
+			 (u32_t)&mutex4);
 		return;
 	}
 }
@@ -87,12 +87,12 @@ void Task05(void)
 
 /**
  *
- * Task06 -
+ * task06 -
  *
  * @return  N/A
  */
 
-void Task06(void)
+void task06(void)
 {
 	int rv;
 
@@ -107,24 +107,24 @@ void Task06(void)
 	 * to 7, but will instead drop to 6.
 	 */
 
-	rv = k_mutex_lock(&Mutex4, K_SECONDS(2));
+	rv = k_mutex_lock(&mutex4, K_SECONDS(2));
 	if (rv != 0) {
-		tcRC = TC_FAIL;
-		TC_ERROR("Failed to take mutex 0x%x\n", (u32_t)&Mutex4);
+		tc_rc = TC_FAIL;
+		TC_ERROR("Failed to take mutex 0x%x\n", (u32_t)&mutex4);
 		return;
 	}
 
-	k_mutex_unlock(&Mutex4);
+	k_mutex_unlock(&mutex4);
 }
 
 /**
  *
- * Task07 -
+ * task07 -
  *
  * @return  N/A
  */
 
-void Task07(void)
+void task07(void)
 {
 	int rv;
 
@@ -138,11 +138,11 @@ void Task07(void)
 	 * priority of the owning task RegressionTask will drop to 8.
 	 */
 
-	rv = k_mutex_lock(&Mutex3, K_SECONDS(3));
+	rv = k_mutex_lock(&mutex3, K_SECONDS(3));
 	if (rv != -EAGAIN) {
-		tcRC = TC_FAIL;
+		tc_rc = TC_FAIL;
 		TC_ERROR("Failed to timeout on mutex 0x%x\n",
-			 (u32_t)&Mutex3);
+			 (u32_t)&mutex3);
 		return;
 	}
 
@@ -150,85 +150,85 @@ void Task07(void)
 
 /**
  *
- * Task08 -
+ * task08 -
  *
  * @return  N/A
  */
 
-void Task08(void)
+void task08(void)
 {
 	int rv;
 
 	k_sleep(K_MSEC(1500));
 
 	/* Wait and boost owner priority to 8 */
-	rv = k_mutex_lock(&Mutex2, K_FOREVER);
+	rv = k_mutex_lock(&mutex2, K_FOREVER);
 	if (rv != 0) {
-		tcRC = TC_FAIL;
-		TC_ERROR("Failed to take mutex 0x%x\n", (u32_t)&Mutex2);
+		tc_rc = TC_FAIL;
+		TC_ERROR("Failed to take mutex 0x%x\n", (u32_t)&mutex2);
 		return;
 	}
 
-	k_mutex_unlock(&Mutex2);
+	k_mutex_unlock(&mutex2);
 }
 
 /**
  *
- * Task09 -
+ * task09 -
  *
  * @return  N/A
  */
 
-void Task09(void)
+void task09(void)
 {
 	int rv;
 
-	k_sleep(K_MSEC(500));                   /* Allow lower priority task to run */
+	k_sleep(K_MSEC(500));	/* Allow lower priority task to run */
 
-	rv = k_mutex_lock(&Mutex1, K_NO_WAIT);  /*<Mutex1> is already locked. */
-	if (rv != -EBUSY) {                     /* This attempt to lock the mutex */
+	rv = k_mutex_lock(&mutex1, K_NO_WAIT);  /*<Mutex1> is already locked. */
+	if (rv != -EBUSY) {	/* This attempt to lock the mutex */
 		/* should not succeed. */
-		tcRC = TC_FAIL;
+		tc_rc = TC_FAIL;
 		TC_ERROR("Failed to NOT take locked mutex 0x%x\n",
-			 (u32_t)&Mutex1);
+			 (u32_t)&mutex1);
 		return;
 	}
 
 	/* Wait and boost owner priority to 9 */
-	rv = k_mutex_lock(&Mutex1, K_FOREVER);
+	rv = k_mutex_lock(&mutex1, K_FOREVER);
 	if (rv != 0) {
-		tcRC = TC_FAIL;
-		TC_ERROR("Failed to take mutex 0x%x\n", (u32_t)&Mutex1);
+		tc_rc = TC_FAIL;
+		TC_ERROR("Failed to take mutex 0x%x\n", (u32_t)&mutex1);
 		return;
 	}
 
-	k_mutex_unlock(&Mutex1);
+	k_mutex_unlock(&mutex1);
 }
 
 /**
  *
- * Task11 -
+ * task11 -
  *
  * @return N/A
  */
 
-void Task11(void)
+void task11(void)
 {
 	int rv;
 
 	k_sleep(K_MSEC(3500));
-	rv = k_mutex_lock(&Mutex3, K_FOREVER);
+	rv = k_mutex_lock(&mutex3, K_FOREVER);
 	if (rv != 0) {
-		tcRC = TC_FAIL;
-		TC_ERROR("Failed to take mutex 0x%x\n", (u32_t)&Mutex2);
+		tc_rc = TC_FAIL;
+		TC_ERROR("Failed to take mutex 0x%x\n", (u32_t)&mutex2);
 		return;
 	}
-	k_mutex_unlock(&Mutex3);
+	k_mutex_unlock(&mutex3);
 }
 
 K_THREAD_STACK_DEFINE(task12_stack_area, STACKSIZE);
 struct k_thread task12_thread_data;
-extern void Task12(void);
+extern void task12(void);
 
 /**
  *
@@ -240,14 +240,14 @@ extern void Task12(void);
  * @return  N/A
  */
 
-void RegressionTask(void)
+void regression_task(void)
 {
 	int rv;
 	int i;
-	struct k_mutex *mutexes[4] = { &Mutex1, &Mutex2, &Mutex3, &Mutex4 };
-	struct k_mutex *giveMutex[3] = { &Mutex3, &Mutex2, &Mutex1 };
+	struct k_mutex *mutexes[4] = { &mutex1, &mutex2, &mutex3, &mutex4 };
+	struct k_mutex *givemutex[3] = { &mutex3, &mutex2, &mutex1 };
 	int priority[4] = { 9, 8, 7, 5 };
-	int dropPri[3] = { 8, 8, 9 };
+	int droppri[3] = { 8, 8, 9 };
 
 	TC_START("Test kernel Mutex API");
 
@@ -265,8 +265,8 @@ void RegressionTask(void)
 		if (rv != 0) {
 			TC_ERROR("Failed to lock mutex 0x%x\n",
 				 (u32_t)mutexes[i]);
-			tcRC = TC_FAIL;
-			goto errorReturn;
+			tc_rc = TC_FAIL;
+			goto error_return;
 		}
 		k_sleep(K_SECONDS(1));
 
@@ -274,12 +274,12 @@ void RegressionTask(void)
 		if (rv != priority[i]) {
 			TC_ERROR("Expected priority %d, not %d\n",
 				 priority[i], rv);
-			tcRC = TC_FAIL;
-			goto errorReturn;
+			tc_rc = TC_FAIL;
+			goto error_return;
 		}
 
-		if (tcRC != TC_PASS) {  /* Catch any errors from other tasks */
-			goto errorReturn;
+		if (tc_rc != TC_PASS) {  /* Catch any errors from other tasks */
+			goto error_return;
 		}
 	}
 
@@ -297,49 +297,49 @@ void RegressionTask(void)
 		TC_ERROR("%s timed out and out priority should drop.\n",
 			 "Task05");
 		TC_ERROR("Expected priority %d, not %d\n", 6, rv);
-		tcRC = TC_FAIL;
-		goto errorReturn;
+		tc_rc = TC_FAIL;
+		goto error_return;
 	}
 
-	k_mutex_unlock(&Mutex4);
+	k_mutex_unlock(&mutex4);
 	rv = k_thread_priority_get(k_current_get());
 	if (rv != 7) {
 		TC_ERROR("Gave %s and priority should drop.\n", "Mutex4");
 		TC_ERROR("Expected priority %d, not %d\n", 7, rv);
-		tcRC = TC_FAIL;
-		goto errorReturn;
+		tc_rc = TC_FAIL;
+		goto error_return;
 	}
 
-	k_sleep(K_SECONDS(1));       /* Task07 should time out */
+	k_sleep(K_SECONDS(1));       /* task07 should time out */
 
 	/* ~ 6 seconds have passed */
 
 	for (i = 0; i < 3; i++) {
 		rv = k_thread_priority_get(k_current_get());
-		if (rv != dropPri[i]) {
+		if (rv != droppri[i]) {
 			TC_ERROR("Expected priority %d, not %d\n",
-				 dropPri[i], rv);
-			tcRC = TC_FAIL;
-			goto errorReturn;
+				 droppri[i], rv);
+			tc_rc = TC_FAIL;
+			goto error_return;
 		}
-		k_mutex_unlock(giveMutex[i]);
+		k_mutex_unlock(givemutex[i]);
 
-		if (tcRC != TC_PASS) {
-			goto errorReturn;
+		if (tc_rc != TC_PASS) {
+			goto error_return;
 		}
 	}
 
 	rv = k_thread_priority_get(k_current_get());
 	if (rv != 10) {
 		TC_ERROR("Expected priority %d, not %d\n", 10, rv);
-		tcRC = TC_FAIL;
-		goto errorReturn;
+		tc_rc = TC_FAIL;
+		goto error_return;
 	}
 
-	k_sleep(K_SECONDS(1));     /* Give Task11 time to run */
+	k_sleep(K_SECONDS(1));     /* Give task11 time to run */
 
-	if (tcRC != TC_PASS) {
-		goto errorReturn;
+	if (tc_rc != TC_PASS) {
+		goto error_return;
 	}
 
 	/* test recursive locking using a private mutex */
@@ -349,20 +349,20 @@ void RegressionTask(void)
 	rv = k_mutex_lock(&private_mutex, K_NO_WAIT);
 	if (rv != 0) {
 		TC_ERROR("Failed to lock private mutex\n");
-		tcRC = TC_FAIL;
-		goto errorReturn;
+		tc_rc = TC_FAIL;
+		goto error_return;
 	}
 
 	rv = k_mutex_lock(&private_mutex, K_NO_WAIT);
 	if (rv != 0) {
 		TC_ERROR("Failed to recursively lock private mutex\n");
-		tcRC = TC_FAIL;
-		goto errorReturn;
+		tc_rc = TC_FAIL;
+		goto error_return;
 	}
 
 	/* Start thread */
 	k_thread_create(&task12_thread_data, task12_stack_area, STACKSIZE,
-			(k_thread_entry_t)Task12, NULL, NULL, NULL,
+			(k_thread_entry_t)task12, NULL, NULL, NULL,
 			K_PRIO_PREEMPT(12), 0, K_NO_WAIT);
 	k_sleep(1);     /* Give Task12 a chance to block on the mutex */
 
@@ -372,44 +372,44 @@ void RegressionTask(void)
 	rv = k_mutex_lock(&private_mutex, K_NO_WAIT);
 	if (rv != -EBUSY) {
 		TC_ERROR("Unexpectedly got lock on private mutex\n");
-		tcRC = TC_FAIL;
-		goto errorReturn;
+		tc_rc = TC_FAIL;
+		goto error_return;
 	}
 
 	rv = k_mutex_lock(&private_mutex, K_SECONDS(1));
 	if (rv != 0) {
 		TC_ERROR("Failed to re-obtain lock on private mutex\n");
-		tcRC = TC_FAIL;
-		goto errorReturn;
+		tc_rc = TC_FAIL;
+		goto error_return;
 	}
 
 	k_mutex_unlock(&private_mutex);
 
 	TC_PRINT("Recursive locking tests successful\n");
 
-errorReturn:
-	TC_END_RESULT(tcRC);
-	TC_END_REPORT(tcRC);
+error_return:
+	TC_END_RESULT(tc_rc);
+	TC_END_REPORT(tc_rc);
 }  /* RegressionTask */
 
 
-K_THREAD_DEFINE(TASK05, STACKSIZE, Task05, NULL, NULL, NULL,
+K_THREAD_DEFINE(TASK05, STACKSIZE, task05, NULL, NULL, NULL,
 		5, 0, K_NO_WAIT);
 
-K_THREAD_DEFINE(TASK06, STACKSIZE, Task06, NULL, NULL, NULL,
+K_THREAD_DEFINE(TASK06, STACKSIZE, task06, NULL, NULL, NULL,
 		6, 0, K_NO_WAIT);
 
-K_THREAD_DEFINE(TASK07, STACKSIZE, Task07, NULL, NULL, NULL,
+K_THREAD_DEFINE(TASK07, STACKSIZE, task07, NULL, NULL, NULL,
 		7, 0, K_NO_WAIT);
 
-K_THREAD_DEFINE(TASK08, STACKSIZE, Task08, NULL, NULL, NULL,
+K_THREAD_DEFINE(TASK08, STACKSIZE, task08, NULL, NULL, NULL,
 		8, 0, K_NO_WAIT);
 
-K_THREAD_DEFINE(TASK09, STACKSIZE, Task09, NULL, NULL, NULL,
+K_THREAD_DEFINE(TASK09, STACKSIZE, task09, NULL, NULL, NULL,
 		9, 0, K_NO_WAIT);
 
-K_THREAD_DEFINE(TASK11, STACKSIZE, Task11, NULL, NULL, NULL,
+K_THREAD_DEFINE(TASK11, STACKSIZE, task11, NULL, NULL, NULL,
 		11, 0, K_NO_WAIT);
 
-K_THREAD_DEFINE(REGRESSTASK, STACKSIZE, RegressionTask, NULL, NULL, NULL,
+K_THREAD_DEFINE(REGRESSTASK, STACKSIZE, regression_task, NULL, NULL, NULL,
 		10, 0, K_NO_WAIT);

--- a/tests/kernel/mutex/mutex/src/task12.c
+++ b/tests/kernel/mutex/mutex/src/task12.c
@@ -19,7 +19,7 @@
 #include <zephyr.h>
 
 
-static int tcRC = TC_PASS;         /* test case return code */
+static int tc_rc = TC_PASS;         /* test case return code */
 
 extern struct k_mutex private_mutex;
 
@@ -30,7 +30,7 @@ extern struct k_mutex private_mutex;
  * @return  N/A
  */
 
-void Task12(void)
+void task12(void)
 {
 	int rv;
 
@@ -38,7 +38,7 @@ void Task12(void)
 
 	rv = k_mutex_lock(&private_mutex, K_FOREVER);
 	if (rv != 0) {
-		tcRC = TC_FAIL;
+		tc_rc = TC_FAIL;
 		TC_ERROR("Failed to obtain private mutex\n");
 		return;
 	}

--- a/tests/kernel/semaphore/sema_api/src/test_sema_contexts.c
+++ b/tests/kernel/semaphore/sema_api/src/test_sema_contexts.c
@@ -30,12 +30,12 @@ static K_THREAD_STACK_DEFINE(tstack, STACK_SIZE);
 static struct k_thread tdata;
 
 /*entry of contexts*/
-static void tIsr_entry(void *p)
+static void tisr_entry(void *p)
 {
 	k_sem_give((struct k_sem *)p);
 }
 
-static void tThread_entry(void *p1, void *p2, void *p3)
+static void thread_entry(void *p1, void *p2, void *p3)
 {
 	k_sem_give((struct k_sem *)p1);
 }
@@ -44,7 +44,7 @@ static void tsema_thread_thread(struct k_sem *psem)
 {
 	/**TESTPOINT: thread-thread sync via sema*/
 	k_tid_t tid = k_thread_create(&tdata, tstack, STACK_SIZE,
-				      tThread_entry, psem, NULL, NULL,
+				      thread_entry, psem, NULL, NULL,
 				      K_PRIO_PREEMPT(0), 0, 0);
 
 	zassert_false(k_sem_take(psem, K_FOREVER), NULL);
@@ -55,7 +55,7 @@ static void tsema_thread_thread(struct k_sem *psem)
 static void tsema_thread_isr(struct k_sem *psem)
 {
 	/**TESTPOINT: thread-isr sync via sema*/
-	irq_offload(tIsr_entry, psem);
+	irq_offload(tisr_entry, psem);
 	zassert_false(k_sem_take(psem, K_FOREVER), NULL);
 }
 

--- a/tests/kernel/sprintf/src/test_sprintf.c
+++ b/tests/kernel/sprintf/src/test_sprintf.c
@@ -7,8 +7,8 @@
  */
 
 /*
-DESCRIPTION
-This module contains the code for testing sprintf() functionality.
+ * DESCRIPTION
+ * This module contains the code for testing sprintf() functionality.
  */
 
 #include <tc_util.h>
@@ -32,22 +32,28 @@ This module contains the code for testing sprintf() functionality.
  * The underlying sprintf() architecture will truncate it.
  */
 #define REALLY_LONG_STRING \
-		"11111111111111111111111111111111111111111111111111111111111111111" \
-		"22222222222222222222222222222222222222222222222222222222222222222" \
-		"33333333333333333333333333333333333333333333333333333333333333333" \
-		"44444444444444444444444444444444444444444444444444444444444444444" \
-		"55555555555555555555555555555555555555555555555555555555555555555" \
-		"66666666666666666666666666666666666666666666666666666666666666666"
+		"1111111111111111111111111111111111" \
+		"1111111111111111111111111111111" \
+		"22222222222222222222222222222222" \
+		"222222222222222222222222222222222" \
+		"333333333333333333333333333333333" \
+		"33333333333333333333333333333333" \
+		"44444444444444444444444444444444" \
+		"444444444444444444444444444444444" \
+		"555555555555555555555555555555555" \
+		"55555555555555555555555555555555" \
+		"66666666666666666666666666666666" \
+		"666666666666666666666666666666666"
 
 #define PRINTF_MAX_STRING_LENGTH   200
 
-typedef union {
+union raw_double_u {
 	double  d;
 	struct {
 		u32_t  u1;    /* This part contains the exponent */
 		u32_t  u2;    /* This part contains the fraction */
 	};
-} raw_double_u;
+};
 
 #ifdef CONFIG_FLOAT
 /**
@@ -57,10 +63,10 @@ typedef union {
  * @return TC_PASS on success, TC_FAIL otherwise
  */
 
-int sprintfDoubleTest(void)
+int sprintf_double_test(void)
 {
 	char buffer[100];
-	raw_double_u var;
+	union raw_double_u var;
 	int  status = TC_PASS;
 
 	var.u1 = 0x00000000;
@@ -108,25 +114,29 @@ int sprintfDoubleTest(void)
 
 	sprintf(buffer, "%.*f", 11, var.d);
 	if (strcmp(buffer, "1.00000000000") != 0) {
-		TC_ERROR("sprintf(1.00000000000) - incorrect output '%s'\n", buffer);
+		TC_ERROR("sprintf(1.00000000000) - incorrect "
+			"output '%s'\n", buffer);
 		status = TC_FAIL;
 	}
 
 	sprintf(buffer, "%12f", var.d);
 	if (strcmp(buffer, "    1.000000") != 0) {
-		TC_ERROR("sprintf(    1.000000) - incorrect output '%s'\n", buffer);
+		TC_ERROR("sprintf(    1.000000) - incorrect "
+			"output '%s'\n", buffer);
 		status = TC_FAIL;
 	}
 
 	sprintf(buffer, "%-12f", var.d);
 	if (strcmp(buffer, "1.000000    ") != 0) {
-		TC_ERROR("sprintf(1.000000    ) - incorrect output '%s'\n", buffer);
+		TC_ERROR("sprintf(1.000000    ) - incorrect "
+			"output '%s'\n", buffer);
 		status = TC_FAIL;
 	}
 
 	sprintf(buffer, "%012f", var.d);
 	if (strcmp(buffer, "00001.000000") != 0) {
-		TC_ERROR("sprintf(00001.000000) - incorrect output '%s'\n", buffer);
+		TC_ERROR("sprintf(00001.000000) - incorrect "
+			"output '%s'\n", buffer);
 		status = TC_FAIL;
 	}
 
@@ -148,13 +158,15 @@ int sprintfDoubleTest(void)
 	var.d = 1234.0;
 	sprintf(buffer, "%e", var.d);
 	if (strcmp(buffer, "1.234000e+003") != 0) {
-		TC_ERROR("sprintf(1.234000e+003) - incorrect output '%s'\n", buffer);
+		TC_ERROR("sprintf(1.234000e+003) - incorrect "
+			"output '%s'\n", buffer);
 		status = TC_FAIL;
 	}
 
 	sprintf(buffer, "%E", var.d);
 	if (strcmp(buffer, "1.234000E+003") != 0) {
-		TC_ERROR("sprintf(1.234000E+003) - incorrect output '%s'\n", buffer);
+		TC_ERROR("sprintf(1.234000E+003) - incorrect "
+			"output '%s'\n", buffer);
 		status = TC_FAIL;
 	}
 
@@ -162,13 +174,15 @@ int sprintfDoubleTest(void)
 	var.d = 0.1234;
 	sprintf(buffer, "%e", var.d);
 	if (strcmp(buffer, "1.234000e-001") != 0) {
-		TC_ERROR("sprintf(1.234000e-001) - incorrect output '%s'\n", buffer);
+		TC_ERROR("sprintf(1.234000e-001) - incorrect "
+			"output '%s'\n", buffer);
 		status = TC_FAIL;
 	}
 
 	sprintf(buffer, "%E", var.d);
 	if (strcmp(buffer, "1.234000E-001") != 0) {
-		TC_ERROR("sprintf(1.234000E-001) - incorrect output '%s'\n", buffer);
+		TC_ERROR("sprintf(1.234000E-001) - incorrect "
+			"output '%s'\n", buffer);
 		status = TC_FAIL;
 	}
 
@@ -176,13 +190,15 @@ int sprintfDoubleTest(void)
 	var.d = 1234000000.0;
 	sprintf(buffer, "%g", var.d);
 	if (strcmp(buffer, "1.234e+009") != 0) {
-		TC_ERROR("sprintf(1.234e+009) - incorrect output '%s'\n", buffer);
+		TC_ERROR("sprintf(1.234e+009) - incorrect "
+			"output '%s'\n", buffer);
 		status = TC_FAIL;
 	}
 
 	sprintf(buffer, "%G", var.d);
 	if (strcmp(buffer, "1.234E+009") != 0) {
-		TC_ERROR("sprintf(1.234E+009) - incorrect output '%s'\n", buffer);
+		TC_ERROR("sprintf(1.234E+009) - incorrect "
+			"output '%s'\n", buffer);
 		status = TC_FAIL;
 	}
 
@@ -220,7 +236,7 @@ int tvsnprintf(char *s, size_t len, const char *format, ...)
  * @return TC_PASS on success, TC_FAIL otherwise
  */
 
-int vsnprintfTest(void)
+int vsnprintf_test(void)
 {
 	int  len;
 	int  status = TC_PASS;
@@ -286,7 +302,7 @@ int tvsprintf(char *s, const char *format, ...)
  * @return TC_PASS on success, TC_FAIL otherwise
  */
 
-int vsprintfTest(void)
+int vsprintf_test(void)
 {
 	int  len;
 	int  status = TC_PASS;
@@ -320,7 +336,7 @@ int vsprintfTest(void)
  * @return TC_PASS on success, TC_FAIL otherwise
  */
 
-int snprintfTest(void)
+int snprintf_test(void)
 {
 	int  len;
 	int  status = TC_PASS;
@@ -366,7 +382,7 @@ int snprintfTest(void)
  * @return TC_PASS on success, TC_FAIL otherwise
  */
 
-int sprintfMiscTest(void)
+int sprintf_misc_test(void)
 {
 	int  status = TC_PASS;
 	int  count;
@@ -442,7 +458,7 @@ int sprintfMiscTest(void)
  * @return TC_PASS on success, TC_FAIL otherwise
  */
 
-int sprintfIntegerTest(void)
+int sprintf_integer_test(void)
 {
 	int  status = TC_PASS;
 	int  len;
@@ -453,12 +469,14 @@ int sprintfIntegerTest(void)
 	/* Note: prints hex numbers in 8 characters */
 	len = sprintf(buffer, "%x", 0x11);
 	if (len != 2) {
-		TC_ERROR("sprintf(%%x).  Expected 2 bytes written, not %d\n", len);
+		TC_ERROR("sprintf(%%x). "
+			"Expected 2 bytes written, not %d\n", len);
 		status = TC_FAIL;
 	}
 
 	if (strcmp(buffer, "11") != 0) {
-		TC_ERROR("sprintf(%%x).  Expected '%s', got '%s'\n", "11", buffer);
+		TC_ERROR("sprintf(%%x). "
+			"Expected '%s', got '%s'\n", "11", buffer);
 		status = TC_FAIL;
 	}
 
@@ -595,7 +613,7 @@ int sprintfIntegerTest(void)
  * @return TC_PASS on success, TC_FAIL otherwise
  */
 
-int sprintfStringTest(void)
+int sprintf_stringtest(void)
 {
 	int  len;
 	int  status = TC_PASS;
@@ -615,20 +633,24 @@ int sprintfStringTest(void)
 
 	sprintf(buffer, "%s", "short string");
 	if (strcmp(buffer, "short string") != 0) {
-		TC_ERROR("sprintf(%%s).  Expected 'short string', got '%s'\n", buffer);
+		TC_ERROR("sprintf(%%s). "
+			"Expected 'short string', got '%s'\n", buffer);
 		status = TC_FAIL;
 	}
 
 	len = sprintf(buffer, "%s", REALLY_LONG_STRING);
 #ifndef CONFIG_NEWLIB_LIBC
 	if (len != PRINTF_MAX_STRING_LENGTH) {
-		TC_ERROR("Internals changed.  Max string length no longer %d got %d\n",
+		TC_ERROR("Internals changed. "
+			"Max string length no longer %d got %d\n",
 				 PRINTF_MAX_STRING_LENGTH, len);
 		status = TC_FAIL;
 	}
 #endif
-	if (strncmp(buffer, REALLY_LONG_STRING, PRINTF_MAX_STRING_LENGTH) != 0) {
-		TC_ERROR("First %d characters of REALLY_LONG_STRING not printed!\n",
+	if (strncmp(buffer, REALLY_LONG_STRING,
+			PRINTF_MAX_STRING_LENGTH) != 0) {
+		TC_ERROR("First %d characters of REALLY_LONG_STRING "
+			"not printed!\n",
 				 PRINTF_MAX_STRING_LENGTH);
 		status = TC_FAIL;
 	}
@@ -652,38 +674,38 @@ void main(void)
 	PRINT_LINE;
 
 	TC_PRINT("Testing sprintf() with integers ....\n");
-	if (sprintfIntegerTest() != TC_PASS) {
+	if (sprintf_integer_test() != TC_PASS) {
 		status = TC_FAIL;
 	}
 
 	TC_PRINT("Testing snprintf() ....\n");
-	if (snprintfTest() != TC_PASS) {
+	if (snprintf_test() != TC_PASS) {
 		status = TC_FAIL;
 	}
 
 	TC_PRINT("Testing vsprintf() ....\n");
-	if (vsprintfTest() != TC_PASS) {
+	if (vsprintf_test() != TC_PASS) {
 		status = TC_FAIL;
 	}
 
 	TC_PRINT("Testing vsnprintf() ....\n");
-	if (vsnprintfTest() != TC_PASS) {
+	if (vsnprintf_test() != TC_PASS) {
 		status = TC_FAIL;
 	}
 
 	TC_PRINT("Testing sprintf() with strings ....\n");
-	if (sprintfStringTest() != TC_PASS) {
+	if (sprintf_stringtest() != TC_PASS) {
 		status = TC_FAIL;
 	}
 
 	TC_PRINT("Testing sprintf() with misc options ....\n");
-	if (sprintfMiscTest() != TC_PASS) {
+	if (sprintf_misc_test() != TC_PASS) {
 		status = TC_FAIL;
 	}
 
 #ifdef CONFIG_FLOAT
 	TC_PRINT("Testing sprintf() with doubles ....\n");
-	if (sprintfDoubleTest() != TC_PASS) {
+	if (sprintf_double_test() != TC_PASS) {
 		status = TC_FAIL;
 	}
 #endif /* CONFIG_FLOAT */

--- a/tests/kernel/tickless/tickless/src/timestamps.c
+++ b/tests/kernel/tickless/tickless/src/timestamps.c
@@ -23,21 +23,21 @@
 
 #define _TIMESTAMP_NUM 0  /* set to timer # for use by timestamp (0-3) */
 
-#define _CLKGATECTRL *((volatile u32_t *)0x400FE104)
+#define _CLKGATECTRL (*((volatile u32_t *)0x400FE104))
 #define _CLKGATECTRL_TIMESTAMP_EN (1 << (16 + _TIMESTAMP_NUM))
 
 #define _TIMESTAMP_BASE 0x40030000
 #define _TIMESTAMP_OFFSET (0x1000 * _TIMESTAMP_NUM)
 #define _TIMESTAMP_ADDR (_TIMESTAMP_BASE + _TIMESTAMP_OFFSET)
 
-#define _TIMESTAMP_CFG *((volatile u32_t *)(_TIMESTAMP_ADDR + 0))
-#define _TIMESTAMP_CTRL *((volatile u32_t *)(_TIMESTAMP_ADDR + 0xC))
-#define _TIMESTAMP_MODE *((volatile u32_t *)(_TIMESTAMP_ADDR + 0x4))
-#define _TIMESTAMP_LOAD *((volatile u32_t *)(_TIMESTAMP_ADDR + 0x28))
-#define _TIMESTAMP_IMASK *((volatile u32_t *)(_TIMESTAMP_ADDR + 0x18))
-#define _TIMESTAMP_ISTATUS *((volatile u32_t *)(_TIMESTAMP_ADDR + 0x1C))
-#define _TIMESTAMP_ICLEAR *((volatile u32_t *)(_TIMESTAMP_ADDR + 0x24))
-#define _TIMESTAMP_VAL *((volatile u32_t *)(_TIMESTAMP_ADDR + 0x48))
+#define _TIMESTAMP_CFG (*((volatile u32_t *)(_TIMESTAMP_ADDR + 0)))
+#define _TIMESTAMP_CTRL (*((volatile u32_t *)(_TIMESTAMP_ADDR + 0xC)))
+#define _TIMESTAMP_MODE (*((volatile u32_t *)(_TIMESTAMP_ADDR + 0x4)))
+#define _TIMESTAMP_LOAD (*((volatile u32_t *)(_TIMESTAMP_ADDR + 0x28)))
+#define _TIMESTAMP_IMASK (*((volatile u32_t *)(_TIMESTAMP_ADDR + 0x18)))
+#define _TIMESTAMP_ISTATUS (*((volatile u32_t *)(_TIMESTAMP_ADDR + 0x1C)))
+#define _TIMESTAMP_ICLEAR (*((volatile u32_t *)(_TIMESTAMP_ADDR + 0x24)))
+#define _TIMESTAMP_VAL (*((volatile u32_t *)(_TIMESTAMP_ADDR + 0x48)))
 
 /*
  * Set the rollover value such that it leaves the most significant bit of
@@ -57,7 +57,7 @@
  *
  * @return N/A
  */
-void _TimestampOpen(void)
+void _timestamp_open(void)
 {
 	/* QEMU does not currently support the 32-bit timer modes of the GPTM */
 	printk("WARNING! Timestamp is not supported for this target!\n");
@@ -71,7 +71,9 @@ void _TimestampOpen(void)
 	_TIMESTAMP_CTRL = 0x0;  /* disable/reset timer */
 	_TIMESTAMP_CFG = 0x0;  /* 32-bit timer */
 	_TIMESTAMP_MODE = 0x2;  /* periodic mode */
-	_TIMESTAMP_LOAD = _TIMESTAMP_MAX; /* maximum interval to reduce rollovers */
+	_TIMESTAMP_LOAD = _TIMESTAMP_MAX; /* maximum interval
+					   * to reduce rollovers
+					   */
 	_TIMESTAMP_IMASK = 0x70F;  /* mask all timer interrupts */
 	_TIMESTAMP_ICLEAR = 0x70F;  /* clear all interrupt status */
 
@@ -86,29 +88,29 @@ void _TimestampOpen(void)
  *
  * @return timestamp value
  */
-u32_t _TimestampRead(void)
+u32_t _timestamp_read(void)
 {
-	static u32_t lastTimerVal;
+	static u32_t last_timer_val;
 	static u32_t cnt;
-	u32_t timerVal = _TIMESTAMP_VAL;
+	u32_t timer_val = _TIMESTAMP_VAL;
 
 	/* handle rollover for every other read (end of sleep) */
 
-	if ((cnt % 2) && (timerVal > lastTimerVal)) {
-		lastTimerVal = timerVal;
+	if ((cnt % 2) && (timer_val > last_timer_val)) {
+		last_timer_val = timer_val;
 
 		/* convert to extended up-counter value */
-		timerVal = _TIMESTAMP_EXT + (_TIMESTAMP_MAX - timerVal);
+		timer_val = _TIMESTAMP_EXT + (_TIMESTAMP_MAX - timer_val);
 	} else {
-		lastTimerVal = timerVal;
+		last_timer_val = timer_val;
 
 		/* convert to up-counter value */
-		timerVal = _TIMESTAMP_MAX - timerVal;
+		timer_val = _TIMESTAMP_MAX - timer_val;
 	}
 
 	cnt++;
 
-	return timerVal;
+	return timer_val;
 }
 
 /**
@@ -119,7 +121,7 @@ u32_t _TimestampRead(void)
  *
  * @return N/A
  */
-void _TimestampClose(void)
+void _timestamp_close(void)
 {
 
 	/* disable/reset timer */
@@ -135,25 +137,25 @@ void _TimestampClose(void)
 
 #define _COUNTDOWN_TIMER false
 
-#define _CLKGATECTRL *((volatile u32_t *)0x4004803C)
+#define _CLKGATECTRL (*((volatile u32_t *)0x4004803C))
 #define _CLKGATECTRL_TIMESTAMP_EN (1 << 29)
 
-#define _SYSOPTCTRL2 *((volatile u32_t *)0x40048004)
+#define _SYSOPTCTRL2 (*((volatile u32_t *)0x40048004))
 #define _SYSOPTCTRL2_32KHZRTCCLK (1 << 4)
 
 #define _TIMESTAMP_ADDR (0x4003D000)
 
-#define _TIMESTAMP_ICLEAR *((volatile u32_t *)(_TIMESTAMP_ADDR + 0x24))
+#define _TIMESTAMP_ICLEAR (*((volatile u32_t *)(_TIMESTAMP_ADDR + 0x24)))
 
-#define _TIMESTAMP_VAL *((volatile u32_t *)(_TIMESTAMP_ADDR + 0))
-#define _TIMESTAMP_PRESCALE *((volatile u32_t *)(_TIMESTAMP_ADDR + 0x4))
-#define _TIMESTAMP_COMP *((volatile u32_t *)(_TIMESTAMP_ADDR + 0xC))
-#define _TIMESTAMP_CTRL *((volatile u32_t *)(_TIMESTAMP_ADDR + 0x10))
-#define _TIMESTAMP_STATUS *((volatile u32_t *)(_TIMESTAMP_ADDR + 0x14))
-#define _TIMESTAMP_LOCK *((volatile u32_t *)(_TIMESTAMP_ADDR + 0x18))
-#define _TIMESTAMP_IMASK *((volatile u32_t *)(_TIMESTAMP_ADDR + 0x1C))
-#define _TIMESTAMP_RACCESS *((volatile u32_t *)(_TIMESTAMP_ADDR + 0x800))
-#define _TIMESTAMP_WACCESS *((volatile u32_t *)(_TIMESTAMP_ADDR + 0x804))
+#define _TIMESTAMP_VAL (*((volatile u32_t *)(_TIMESTAMP_ADDR + 0)))
+#define _TIMESTAMP_PRESCALE (*((volatile u32_t *)(_TIMESTAMP_ADDR + 0x4)))
+#define _TIMESTAMP_COMP (*((volatile u32_t *)(_TIMESTAMP_ADDR + 0xC)))
+#define _TIMESTAMP_CTRL (*((volatile u32_t *)(_TIMESTAMP_ADDR + 0x10)))
+#define _TIMESTAMP_STATUS (*((volatile u32_t *)(_TIMESTAMP_ADDR + 0x14)))
+#define _TIMESTAMP_LOCK (*((volatile u32_t *)(_TIMESTAMP_ADDR + 0x18)))
+#define _TIMESTAMP_IMASK (*((volatile u32_t *)(_TIMESTAMP_ADDR + 0x1C)))
+#define _TIMESTAMP_RACCESS (*((volatile u32_t *)(_TIMESTAMP_ADDR + 0x800)))
+#define _TIMESTAMP_WACCESS (*((volatile u32_t *)(_TIMESTAMP_ADDR + 0x804)))
 
 /**
  *
@@ -163,7 +165,7 @@ void _TimestampClose(void)
  *
  * @return N/A
  */
-void _TimestampOpen(void)
+void _timestamp_open(void)
 {
 	/* enable timer access */
 	_CLKGATECTRL |= _CLKGATECTRL_TIMESTAMP_EN;
@@ -197,9 +199,9 @@ void _TimestampOpen(void)
  *
  * @return timestamp value
  */
-u32_t _TimestampRead(void)
+u32_t _timestamp_read(void)
 {
-	static u32_t lastPrescale;
+	static u32_t last_prescale;
 	static u32_t cnt;
 	u32_t prescale1 = _TIMESTAMP_PRESCALE;
 	u32_t prescale2 = _TIMESTAMP_PRESCALE;
@@ -211,13 +213,15 @@ u32_t _TimestampRead(void)
 		prescale2 = _TIMESTAMP_PRESCALE;
 	}
 
-	/* handle prescale rollover @ 0x8000 for every other read (end of sleep) */
+	 /* handle prescale rollover @ 0x8000
+	  * for every other read (end of sleep)
+	  */
 
-	if ((cnt % 2) && (prescale1 < lastPrescale)) {
+	if ((cnt % 2) && (prescale1 < last_prescale)) {
 		prescale1 += 0x8000;
 	}
 
-	lastPrescale = prescale2;
+	last_prescale = prescale2;
 	cnt++;
 
 	return prescale1;
@@ -231,7 +235,7 @@ u32_t _TimestampRead(void)
  *
  * @return N/A
  */
-void _TimestampClose(void)
+void _timestamp_close(void)
 {
 	_TIMESTAMP_STATUS = 0x0;  /* disable counter */
 	_TIMESTAMP_CTRL = 0x0;  /* disable oscillator */
@@ -255,7 +259,7 @@ void _TimestampClose(void)
  *
  * @return N/A
  */
-void _TimestampOpen(void)
+void _timestamp_open(void)
 {
 	/* enable RTT clock from PMC */
 	soc_pmc_peripheral_enable(ID_RTT);
@@ -272,7 +276,7 @@ void _TimestampOpen(void)
  *
  * @return timestamp value
  */
-u32_t _TimestampRead(void)
+u32_t _timestamp_read(void)
 {
 	static u32_t last_val;
 	u32_t tmr_val = _TIMESTAMP_VAL;
@@ -298,7 +302,7 @@ u32_t _TimestampRead(void)
  *
  * @return N/A
  */
-void _TimestampClose(void)
+void _timestamp_close(void)
 {
 	/* disable RTT clock from PMC */
 	soc_pmc_peripheral_disable(ID_RTT);

--- a/tests/net/net_pkt/src/main.c
+++ b/tests/net/net_pkt/src/main.c
@@ -282,31 +282,31 @@ static const char test_data[] = { '0', '1', '2', '3', '4',
 				  '5', '6', '7' };
 
 static const char sample_data[] =
-	"abcdefghijklmnopqrstuvxyz"
-	"abcdefghijklmnopqrstuvxyz"
-	"abcdefghijklmnopqrstuvxyz"
-	"abcdefghijklmnopqrstuvxyz"
-	"abcdefghijklmnopqrstuvxyz"
-	"abcdefghijklmnopqrstuvxyz"
-	"abcdefghijklmnopqrstuvxyz"
-	"abcdefghijklmnopqrstuvxyz"
-	"abcdefghijklmnopqrstuvxyz"
-	"abcdefghijklmnopqrstuvxyz"
-	"abcdefghijklmnopqrstuvxyz"
-	"abcdefghijklmnopqrstuvxyz"
+	"abcdefghijklmnopqrstuvxyz "
+	"abcdefghijklmnopqrstuvxyz "
+	"abcdefghijklmnopqrstuvxyz "
+	"abcdefghijklmnopqrstuvxyz "
+	"abcdefghijklmnopqrstuvxyz "
+	"abcdefghijklmnopqrstuvxyz "
+	"abcdefghijklmnopqrstuvxyz "
+	"abcdefghijklmnopqrstuvxyz "
+	"abcdefghijklmnopqrstuvxyz "
+	"abcdefghijklmnopqrstuvxyz "
+	"abcdefghijklmnopqrstuvxyz "
+	"abcdefghijklmnopqrstuvxyz "
 	"abcdefghijklmnopqrstuvxyz";
 
 static char test_rw_short[] =
 	"abcdefghijklmnopqrstuvwxyz";
 
 static char test_rw_long[] =
-	"abcdefghijklmnopqrstuvwxyz"
-	"abcdefghijklmnopqrstuvwxyz"
-	"abcdefghijklmnopqrstuvwxyz"
-	"abcdefghijklmnopqrstuvwxyz"
-	"abcdefghijklmnopqrstuvwxyz"
-	"abcdefghijklmnopqrstuvwxyz"
-	"abcdefghijklmnopqrstuvwxyz";
+	"abcdefghijklmnopqrstuvwxyz "
+	"abcdefghijklmnopqrstuvwxyz "
+	"abcdefghijklmnopqrstuvwxyz "
+	"abcdefghijklmnopqrstuvwxyz "
+	"abcdefghijklmnopqrstuvwxyz "
+	"abcdefghijklmnopqrstuvwxyz "
+	"abcdefghijklmnopqrstuvwxyz ";
 
 static void test_pkt_read_append(void)
 {
@@ -440,7 +440,7 @@ static void test_pkt_read_append(void)
 	tfrag = net_frag_read(tfrag, off + 10, &tpos, 10, data);
 	if (!tfrag ||
 	    memcmp(sample_data + off + 10, data, 10)) {
-		printk("Failed to read from offset %d, frag length %d"
+		printk("Failed to read from offset %d, frag length %d "
 		       "read length %d\n",
 		       tfrag->len + 10, tfrag->len, 10);
 		zassert_true(false, "Fail offset read");
@@ -995,8 +995,8 @@ static void test_fragment_split(void)
 #define FRAGA (FRAG_COUNT - 2)
 #define FRAGB (FRAG_COUNT - 1)
 	struct net_pkt *pkt;
-	struct net_buf *frags[FRAG_COUNT], *frag, *fragA, *fragB;
-	int i, total, splitA, splitB;
+	struct net_buf *frags[FRAG_COUNT], *frag, *frag_a, *frag_b;
+	int i, total, split_a, split_b;
 	int ret, frag_size;
 
 	memset(frags, 0, FRAG_COUNT * sizeof(void *));
@@ -1031,45 +1031,45 @@ static void test_fragment_split(void)
 
 	net_pkt_frag_add(pkt, frags[0]);
 
-	fragA = frags[FRAGA];
-	fragB = frags[FRAGB];
+	frag_a = frags[FRAGA];
+	frag_b = frags[FRAGB];
 
-	zassert_is_null(fragA, "fragA is not NULL");
-	zassert_is_null(fragB, "fragB is not NULL");
+	zassert_is_null(frag_a, "frag_a is not NULL");
+	zassert_is_null(frag_b, "frag_b is not NULL");
 
-	splitA = frag_size * 2 / 3;
-	splitB = frag_size - splitA;
+	split_a = frag_size * 2 / 3;
+	split_b = frag_size - split_a;
 
-	zassert_true(splitA > 0, "A size is 0");
-	zassert_true(splitA > splitB, "A is smaller than B");
+	zassert_true(split_a > 0, "A size is 0");
+	zassert_true(split_a > split_b, "A is smaller than B");
 
 	/* Test some error cases first */
-	ret = net_pkt_split(NULL, NULL, 1024, &fragA, &fragB, K_NO_WAIT);
+	ret = net_pkt_split(NULL, NULL, 1024, &frag_a, &frag_b, K_NO_WAIT);
 	zassert_equal(ret, -EINVAL, "Invalid buf pointers");
 
 	ret = net_pkt_split(pkt, pkt->frags, CONFIG_NET_BUF_DATA_SIZE + 1,
-			    &fragA, &fragB, K_NO_WAIT);
+			    &frag_a, &frag_b, K_NO_WAIT);
 	zassert_equal(ret, 0, "Split failed");
 
-	ret = net_pkt_split(pkt, pkt->frags, splitA,
-			     &fragA, &fragB, K_NO_WAIT);
+	ret = net_pkt_split(pkt, pkt->frags, split_a,
+			     &frag_a, &frag_b, K_NO_WAIT);
 	zassert_equal(ret, 0, "Cannot split frag");
 
-	if (fragA->len != splitA) {
-		printk("Frag A len %d not %d\n", fragA->len, splitA);
-		zassert_equal(fragA->len, splitA, "FragA len wrong");
+	if (frag_a->len != split_a) {
+		printk("Frag_a len %d not %d\n", frag_a->len, split_a);
+		zassert_equal(frag_a->len, split_a, "Frag_a len wrong");
 	}
 
-	if (fragB->len != splitB) {
-		printk("Frag B len %d not %d\n", fragB->len, splitB);
-		zassert_true(false, "FragB len wrong");
+	if (frag_b->len != split_b) {
+		printk("Frag_b len %d not %d\n", frag_b->len, split_b);
+		zassert_true(false, "Frag_b len wrong");
 	}
 
-	zassert_false(memcmp(pkt->frags->data, fragA->data, splitA),
-		      "Frag A data mismatch");
+	zassert_false(memcmp(pkt->frags->data, frag_a->data, split_a),
+		      "Frag_a data mismatch");
 
-	zassert_false(memcmp(pkt->frags->data + splitA, fragB->data, splitB),
-		      "Frag B data mismatch");
+	zassert_false(memcmp(pkt->frags->data + split_a, frag_b->data, split_b),
+		      "Frag_b data mismatch");
 }
 
 void test_main(void)

--- a/tests/subsys/debug/gdb_server/src/main.c
+++ b/tests/subsys/debug/gdb_server/src/main.c
@@ -32,7 +32,7 @@
  * @param my_sem       thread's own semaphore
  * @param other_sem    other thread's semaphore
  */
-void helloLoop(const char *my_name,
+void hello_loop(const char *my_name,
 	       struct k_sem *my_sem, struct k_sem *other_sem)
 {
 	while (1) {
@@ -50,32 +50,32 @@ void helloLoop(const char *my_name,
 
 /* define semaphores */
 
-K_SEM_DEFINE(threadA_sem, 1, 1);	/* starts off "available" */
-K_SEM_DEFINE(threadB_sem, 0, 1);	/* starts off "not available" */
+K_SEM_DEFINE(threada_sem, 1, 1);	/* starts off "available" */
+K_SEM_DEFINE(threadb_sem, 0, 1);	/* starts off "not available" */
 
 
-/* threadB is a dynamic thread that is spawned by threadA */
+/* threadb is a dynamic thread that is spawned by threadA */
 
-void threadB(void *dummy1, void *dummy2, void *dummy3)
+void threadb(void *dummy1, void *dummy2, void *dummy3)
 {
 	/* invoke routine to ping-pong hello messages with threadA */
-	helloLoop(__func__, &threadB_sem, &threadA_sem);
+	hello_loop(__func__, &threadb_sem, &threada_sem);
 }
 
-K_THREAD_STACK_DEFINE(threadB_stack_area, STACKSIZE);
-static struct k_thread threadB_data;
+K_THREAD_STACK_DEFINE(threadb_stack_area, STACKSIZE);
+static struct k_thread threadb_data;
 
-/* threadA is a static thread that is spawned automatically */
+/* threada is a static thread that is spawned automatically */
 
-void threadA(void *dummy1, void *dummy2, void *dummy3)
+void threada(void *dummy1, void *dummy2, void *dummy3)
 {
 	/* spawn threadB */
-	k_thread_create(&threadB_data, threadB_stack_area, STACKSIZE, threadB,
+	k_thread_create(&threadb_data, threadb_stack_area, STACKSIZE, threadb,
 			NULL, NULL, NULL, PRIORITY, 0, K_NO_WAIT);
 
 	/* invoke routine to ping-pong hello messages with threadB */
-	helloLoop(__func__, &threadA_sem, &threadB_sem);
+	hello_loop(__func__, &threada_sem, &threadb_sem);
 }
 
-K_THREAD_DEFINE(threadA_id, STACKSIZE, threadA, NULL, NULL, NULL,
+K_THREAD_DEFINE(threada_id, STACKSIZE, threada, NULL, NULL, NULL,
 		PRIORITY, 0, K_NO_WAIT);


### PR DESCRIPTION
Test whichever had Camel case defined for functions and variables have
been replaced.

Following warnings have been fixed in test cases as well.
- line over 80 characters
- Macros with flow control statements should be avoided
- Macros with complex values should be enclosed in parentheses
- break quoted strings at a space character
- do not add new typedefs
- Comparisons should place the constant on the right
  side of the test
- suspect code indent for conditional statements
- Missing a blank line after declarations
- macros should not use a trailing semicolon
- Macros with multiple statements should be
  enclosed in a do - while loop
- do not use C99 // comments

JIRA: ZEP-2249

Signed-off-by: Punit Vara <punit.vara@intel.com>