### PR TITLE
Bluetooth: controller: Privacy filtering in advertiser

### DIFF
--- a/subsys/bluetooth/controller/include/ll.h
+++ b/subsys/bluetooth/controller/include/ll.h
@@ -51,8 +51,6 @@ u32_t ll_rl_enable(u8_t enable);
 void  ll_rl_timeout_set(u16_t timeout);
 u32_t ll_priv_mode_set(bt_addr_le_t *id_addr, u8_t mode);
 
-void ll_irk_clear(void);
-u32_t ll_irk_add(u8_t *irk);
 u32_t ll_create_connection(u16_t scan_interval, u16_t scan_window,
 			   u8_t filter_policy, u8_t peer_addr_type,
 			   u8_t *p_peer_addr, u8_t own_addr_type,

--- a/subsys/bluetooth/controller/ll_sw/ctrl.h
+++ b/subsys/bluetooth/controller/ll_sw/ctrl.h
@@ -330,9 +330,10 @@ struct radio_adv_data *radio_scan_data_get(void);
 
 #if defined(CONFIG_BLUETOOTH_CONTROLLER_ADV_EXT)
 u32_t radio_adv_enable(u8_t phy_p, u16_t interval, u8_t chl_map,
-		       u8_t filter_policy);
+		       u8_t filter_policy, u8_t rl_idx);
 #else /* !CONFIG_BLUETOOTH_CONTROLLER_ADV_EXT */
-u32_t radio_adv_enable(u16_t interval, u8_t chl_map, u8_t filter_policy);
+u32_t radio_adv_enable(u16_t interval, u8_t chl_map, u8_t filter_policy,
+		       u8_t rl_idx);
 #endif /* !CONFIG_BLUETOOTH_CONTROLLER_ADV_EXT */
 
 u32_t radio_adv_disable(void);

--- a/subsys/bluetooth/controller/ll_sw/ll.c
+++ b/subsys/bluetooth/controller/ll_sw/ll.c
@@ -254,6 +254,10 @@ void ll_timeslice_ticker_id_get(u8_t * const instance_index, u8_t * const user_i
 
 u8_t *ll_addr_get(u8_t addr_type, u8_t *bdaddr)
 {
+	if (addr_type > 1) {
+		return NULL;
+	}
+
 	if (addr_type) {
 		if (bdaddr) {
 			memcpy(bdaddr, _ll_context.rnd_addr, BDADDR_SIZE);

--- a/subsys/bluetooth/controller/ll_sw/ll_adv.c
+++ b/subsys/bluetooth/controller/ll_sw/ll_adv.c
@@ -337,6 +337,7 @@ u32_t ll_adv_enable(u8_t enable)
 {
 	struct radio_adv_data *radio_scan_data;
 	struct radio_adv_data *radio_adv_data;
+	int rl_idx = RL_IDX_NONE;
 	struct pdu_adv *pdu_scan;
 	struct pdu_adv *pdu_adv;
 	u32_t status;
@@ -391,17 +392,18 @@ u32_t ll_adv_enable(u8_t enable)
 		if (ll_adv.own_addr_type == BT_ADDR_LE_PUBLIC_ID ||
 		    ll_adv.own_addr_type == BT_ADDR_LE_RANDOM_ID) {
 			/* Look up the resolving list */
-			int idx = ll_rl_find(ll_adv.id_addr_type,
-					     ll_adv.id_addr);
+			rl_idx = ll_rl_find(ll_adv.id_addr_type,
+					    ll_adv.id_addr);
 
-			if (idx >= 0) {
+			if (rl_idx >= 0) {
 				/* Generate RPAs if required */
 				ll_rl_rpa_update(false);
 			}
 
-			ll_rl_pdu_adv_update(idx, pdu_adv);
-			ll_rl_pdu_adv_update(idx, pdu_scan);
+			ll_rl_pdu_adv_update(rl_idx, pdu_adv);
+			ll_rl_pdu_adv_update(rl_idx, pdu_scan);
 			priv = true;
+			rl_idx = rl_idx >= 0 ? rl_idx : RL_IDX_NONE;
 		}
 #endif /* !CONFIG_BLUETOOTH_CONTROLLER_PRIVACY */
 		if (!priv) {
@@ -413,10 +415,10 @@ u32_t ll_adv_enable(u8_t enable)
 	}
 #if defined(CONFIG_BLUETOOTH_CONTROLLER_ADV_EXT)
 	status = radio_adv_enable(ll_adv.phy_p, ll_adv.interval, ll_adv.chl_map,
-				  ll_adv.filter_policy);
+				  ll_adv.filter_policy, rl_idx);
 #else /* !CONFIG_BLUETOOTH_CONTROLLER_ADV_EXT */
 	status = radio_adv_enable(ll_adv.interval, ll_adv.chl_map,
-				  ll_adv.filter_policy);
+				  ll_adv.filter_policy, rl_idx);
 #endif /* !CONFIG_BLUETOOTH_CONTROLLER_ADV_EXT */
 
 	return status;

--- a/subsys/bluetooth/controller/ll_sw/ll_adv.h
+++ b/subsys/bluetooth/controller/ll_sw/ll_adv.h
@@ -8,7 +8,7 @@ struct ll_adv_set {
 	u8_t  chl_map:3;
 	u8_t  filter_policy:2;
 #if defined(CONFIG_BLUETOOTH_CONTROLLER_PRIVACY)
-	u8_t  rl_idx:5;
+	u8_t  rl_idx:4;
 	u8_t  own_addr_type:2;
 	u8_t  id_addr_type:1;
 	u8_t  id_addr[BDADDR_SIZE];

--- a/subsys/bluetooth/controller/ll_sw/ll_filter.h
+++ b/subsys/bluetooth/controller/ll_sw/ll_filter.h
@@ -6,6 +6,8 @@
 
 #define WL_SIZE        8
 
+#define RL_IDX_NONE    0xF
+
 struct ll_filter {
 	u8_t  enable_bitmask;
 	u8_t  addr_type_bitmask;
@@ -16,10 +18,14 @@ void ll_filter_reset(bool init);
 void ll_filters_adv_update(u8_t adv_fp);
 void ll_filters_scan_update(u8_t scan_fp);
 
-struct ll_filter *ctrl_filter_get(void);
+struct ll_filter *ctrl_filter_get(bool whitelist);
+u8_t *ctrl_irks_get(u8_t *count);
+bool ctrl_irk_whitelisted(u8_t irkmatch_id);
+bool ctrl_rl_idx_match(u8_t irkmatch_id, u8_t rl_idx);
 
 bool ctrl_rl_enabled(void);
 void ll_rl_rpa_update(bool timeout);
 
 int ll_rl_find(u8_t id_addr_type, u8_t *id_addr);
+bool ctrl_rl_allowed(u8_t id_addr_type, u8_t *id_addr);
 void ll_rl_pdu_adv_update(int idx, struct pdu_adv *pdu);


### PR DESCRIPTION
Implement privacy-enabled filtering in the advertiser role. This
includes all required checks when running address generation and
resolution so that the advertiser complies with the relevant
specification sections.

Signed-off-by: Carles Cufi <carles.cufi@nordicsemi.no>