### PR TITLE
tests: convert testcase.ini to new format

### DIFF
--- a/tests/net/socket/udp/testcase.ini
+++ b/tests/net/socket/udp/testcase.ini
@@ -1,5 +1,0 @@
-[test]
-tags = net
-build_only = true
-arch_whitelist = x86
-platform_exclude = quark_d2000_crb

--- a/tests/net/socket/udp/testcase.yaml
+++ b/tests/net/socket/udp/testcase.yaml
@@ -1,0 +1,5 @@
+tests:
+-   test:
+        build_only: true
+        platform_whitelist: qemu_x86
+        tags: net


### PR DESCRIPTION
This test went in with obsoleted testcase.ini