### PR TITLE
tests: boot_time: cleanup boot_time test to work on ARM

### DIFF
--- a/arch/arm/core/cortex_m/prep_c.c
+++ b/arch/arm/core/cortex_m/prep_c.c
@@ -87,12 +87,18 @@ extern FUNC_NORETURN void _Cstart(void);
  * @return N/A
  */
 
+#ifdef CONFIG_BOOT_TIME_MEASUREMENT
+	extern u64_t __start_time_stamp;
+#endif
 void _PrepC(void)
 {
 	relocate_vector_table();
 	enable_floating_point();
 	_bss_zero();
 	_data_copy();
+#ifdef CONFIG_BOOT_TIME_MEASUREMENT
+	__start_time_stamp = 0;
+#endif
 	_Cstart();
 	CODE_UNREACHABLE;
 }

--- a/tests/benchmarks/boot_time/src/main.c
+++ b/tests/benchmarks/boot_time/src/main.c
@@ -17,6 +17,7 @@
  */
 
 #include <zephyr.h>
+
 #include <tc_util.h>
 
 /* externs */
@@ -58,16 +59,16 @@ void main(void)
 	/* Only print lower 32bit of time result */
 	TC_PRINT("Boot Result: Clock Frequency: %d MHz\n",
 		 freq);
-	TC_PRINT("__start       : %d cycles, %d us\n",
+	TC_PRINT("__start       : %u cycles, %u us\n",
 		 (u32_t)(__start_time_stamp & 0xFFFFFFFFULL),
 		 (u32_t) (_start_us  & 0xFFFFFFFFULL));
-	TC_PRINT("_start->main(): %d cycles, %d us\n",
+	TC_PRINT("_start->main(): %u cycles, %u us\n",
 		 (u32_t)(s_main_time_stamp & 0xFFFFFFFFULL),
 		 (u32_t)  (main_us  & 0xFFFFFFFFULL));
-	TC_PRINT("_start->task  : %d cycles, %d us\n",
+	TC_PRINT("_start->task  : %u cycles, %u us\n",
 		 (u32_t)(s_task_time_stamp & 0xFFFFFFFFULL),
 		 (u32_t)  (task_us  & 0xFFFFFFFFULL));
-	TC_PRINT("_start->idle  : %d cycles, %d us\n",
+	TC_PRINT("_start->idle  : %u cycles, %u us\n",
 		 (u32_t)(s_idle_time_stamp & 0xFFFFFFFFULL),
 		 (u32_t)  (idle_us  & 0xFFFFFFFFULL));
 

--- a/tests/benchmarks/boot_time/testcase.yaml
+++ b/tests/benchmarks/boot_time/testcase.yaml
@@ -1,4 +1,4 @@
 tests:
 -   test:
-        arch_whitelist: x86
+        arch_whitelist: x86 arm
         tags: benchmark


### PR DESCRIPTION
Enabled the boot_time test on ARM SoCs, dropped the noinit on
__start_time_stamp so we at least start at 0 if we don't have some
initialization of it on a give architecture (like on ARM).  Also moved
to printing the values out as %u to increase the range of values.

Signed-off-by: Kumar Gala <kumar.gala@linaro.org>