### PR TITLE
tests: sys_kernel: Enable test on ARM

### DIFF
--- a/tests/benchmarks/sys_kernel/README.txt
+++ b/tests/benchmarks/sys_kernel/README.txt
@@ -34,7 +34,7 @@ Sample Output:
 MODULE: kernel API test
 KERNEL VERSION: 0x1066300
 
-Each test below is repeated 5000 times;
+Each test below is repeated 2500 times;
 average time for one iteration is displayed.
 
 TEST CASE: Semaphore #1

--- a/tests/benchmarks/sys_kernel/src/syskernel.h
+++ b/tests/benchmarks/sys_kernel/src/syskernel.h
@@ -15,7 +15,7 @@
 #include <toolchain.h>
 
 #define STACK_SIZE 2048
-#define NUMBER_OF_LOOPS 5000
+#define NUMBER_OF_LOOPS 2500
 
 extern char thread_stack1[STACK_SIZE];
 extern char thread_stack2[STACK_SIZE];

--- a/tests/benchmarks/sys_kernel/testcase.yaml
+++ b/tests/benchmarks/sys_kernel/testcase.yaml
@@ -1,5 +1,5 @@
 tests:
 -   test:
-        arch_whitelist: x86
+        arch_whitelist: x86 arm
         min_ram: 32
         tags: benchmark


### PR DESCRIPTION
Enable building sys_kernel on ARM.  Reduce down number of iterations to
allow it to pass within one timeslice on ARM SoCs.

Signed-off-by: Kumar Gala <kumar.gala@linaro.org>