### PR TITLE
Bluetooth: shell: Fix compile warnings when CONFIG_DEBUG=y

### DIFF
--- a/subsys/bluetooth/shell/gatt.c
+++ b/subsys/bluetooth/shell/gatt.c
@@ -350,11 +350,11 @@ int cmd_gatt_write(int argc, char *argv[])
 
 int cmd_gatt_write_without_rsp(int argc, char *argv[])
 {
-	int err;
-	bool sign;
 	u16_t handle;
-	u16_t len;
 	u16_t repeat;
+	int err = 0;
+	u16_t len;
+	bool sign;
 
 	if (!default_conn) {
 		printk("Not connected\n");

--- a/subsys/bluetooth/shell/ll.c
+++ b/subsys/bluetooth/shell/ll.c
@@ -117,8 +117,8 @@ exit:
 
 int cmd_scanx(int argc, char *argv[])
 {
+	u8_t type = 0;
 	u8_t enable;
-	u8_t type;
 	s32_t err;
 
 	if (argc < 2) {


### PR DESCRIPTION
Fixed uninitialised auto variables, that had caused compile
errors under CONFIG_DEBUG=y.

Jira: Zep-2334

Signed-off-by: Vinayak Kariappa Chettimada <vich@nordicsemi.no>