### PR TITLE
samples: hello_world: remove min_ram requirement

### DIFF
--- a/samples/hello_world/sample.yaml
+++ b/samples/hello_world/sample.yaml
@@ -6,10 +6,8 @@ tests:
     - test:
         build_only: true
         tags: samples tests
-        min_ram: 16
     - singlethread:
         build_only: true
         extra_args: CONF_FILE=prj_single.conf
         filter: not CONFIG_BLUETOOTH and not CONFIG_GPIO_SCH
         tags: samples tests
-        min_ram: 16


### PR DESCRIPTION
The hello_world sample builds everywhere so remove the min_ram
requirement from samples.yaml.

Signed-off-by: Kumar Gala <kumar.gala@linaro.org>