### PR TITLE
samples: nfc_hello: limit to uarts that support interrupts

### DIFF
--- a/samples/nfc/nfc_hello/sample.yaml
+++ b/samples/nfc/nfc_hello/sample.yaml
@@ -5,4 +5,5 @@ tests:
 -   test:
         arch_whitelist: x86 arm
         build_only: true
+        filter: CONFIG_SERIAL_SUPPORT_INTERRUPT
         tags: apps


### PR DESCRIPTION
We get some failures to build if we don't filter this test to only
boards that support uart interrupts.

Signed-off-by: Kumar Gala <kumar.gala@linaro.org>