### PR TITLE
riscv32: fixed context restore upon exiting ISR

### DIFF
--- a/arch/riscv32/core/isr.S
+++ b/arch/riscv32/core/isr.S
@@ -378,6 +378,15 @@ no_reschedule:
 	/* Restore context at SOC level */
 	jal ra, __soc_restore_context
 #endif /* CONFIG_RISCV_SOC_CONTEXT_SAVE */
+
+	/* Restore MEPC register */
+	lw t0, __NANO_ESF_mepc_OFFSET(sp)
+	csrw mepc, t0
+
+	/* Restore SOC-specific MSTATUS register */
+	lw t0, __NANO_ESF_mstatus_OFFSET(sp)
+	csrw SOC_MSTATUS_REG, t0
+
 	/* Restore caller-saved registers from thread stack */
 	lw ra, __NANO_ESF_ra_OFFSET(sp)
 	lw gp, __NANO_ESF_gp_OFFSET(sp)
@@ -397,14 +406,6 @@ no_reschedule:
 	lw a5, __NANO_ESF_a5_OFFSET(sp)
 	lw a6, __NANO_ESF_a6_OFFSET(sp)
 	lw a7, __NANO_ESF_a7_OFFSET(sp)
-
-	/* Restore MEPC register */
-	lw t0, __NANO_ESF_mepc_OFFSET(sp)
-	csrw mepc, t0
-
-	/* Restore SOC-specific MSTATUS register */
-	lw t0, __NANO_ESF_mstatus_OFFSET(sp)
-	csrw SOC_MSTATUS_REG, t0
 
 	/* Release stack space */
 	addi sp, sp, __NANO_ESF_SIZEOF

--- a/tests/crypto/ecc_dh/testcase.yaml
+++ b/tests/crypto/ecc_dh/testcase.yaml
@@ -1,6 +1,5 @@
 tests:
 -   test:
-        platform_exclude: qemu_riscv32
         slow: true
         tags: crypto ecc dh
         timeout: 500

--- a/tests/crypto/ecc_dsa/testcase.yaml
+++ b/tests/crypto/ecc_dsa/testcase.yaml
@@ -1,6 +1,5 @@
 tests:
 -   test:
-        arch_exclude: riscv32 # ZEP-2020
         min_ram: 16
         tags: crypto ecc dsa
         timeout: 180

--- a/tests/crypto/mbedtls/testcase.yaml
+++ b/tests/crypto/mbedtls/testcase.yaml
@@ -3,4 +3,3 @@ tests:
         min_ram: 32
         tags: crypto mbedtls
         timeout: 200
-        arch_exclude: riscv32


### PR DESCRIPTION
- riscv32:  fixed context restore upon exiting ISR
- tests: crypto: include back riscv32 arch for ecc_dh, ecc_dsa and mbedtls tests