### PR TITLE
scripts: Fix string pattern on byte like objects error

### DIFF
--- a/.shippable.yml
+++ b/.shippable.yml
@@ -50,7 +50,8 @@ build:
             echo "- Building Documentation";
             echo "Commit range:" ${COMMIT_RANGE}
             make htmldocs > doc.log 2>&1;
-            python2 ./scripts/filter-known-issues.py --config-dir .known-issues/doc/ doc.log > doc.warnings;
+            ./scripts/filter-known-issues.py --config-dir .known-issues/doc/ doc.log > doc.warnings;
+
             if [ "$?" != 0 ]; then
               echo " ==> Error running filter script"
               exit 1

--- a/scripts/filter-known-issues.py
+++ b/scripts/filter-known-issues.py
@@ -43,8 +43,8 @@ exclude_regexs = []
 # first is a list of one or more comment lines
 # followed by a list of non-comments which describe a multiline regex
 config_regex = \
-    "(?P<comment>(^\s*#.*\n)+)" \
-    "(?P<regex>(^[^#].*\n)+)"
+    b"(?P<comment>(^\s*#.*\n)+)" \
+    b"(?P<regex>(^[^#].*\n)+)"
 
 def config_import_file(filename):
     """
@@ -72,7 +72,7 @@ def config_import_file(filename):
                     raise
                 logging.debug("%s: found regex at bytes %d-%d: %s",
                               filename, m.start(), m.end(), regex)
-                if '#WARNING' in comment:
+                if b'#WARNING' in comment:
                     exclude_regexs.append((r, origin, ('warning',)))
                 else:
                     exclude_regexs.append((r, origin, ()))


### PR DESCRIPTION
This patch fixes following error which was blocking -e
argument of python script.

TypeError: cannot use a string pattern on a bytes-like object

Jira: ZEP-2290

Signed-off-by: Punit Vara <punit.vara@intel.com>