### PR TITLE
tests/ieee802154: Fix how is initialized the driver lock in l2 test

### DIFF
--- a/tests/net/ieee802154/l2/src/ieee802154_test.c
+++ b/tests/net/ieee802154/l2/src/ieee802154_test.c
@@ -101,8 +101,8 @@ struct ieee802154_pkt_test test_sec_data_pkt = {
 };
 
 struct net_pkt *current_pkt;
-struct k_sem driver_lock;
 struct net_if *iface;
+K_SEM_DEFINE(driver_lock, 0, UINT_MAX);
 
 static void pkt_hexdump(u8_t *pkt, u8_t length)
 {
@@ -259,7 +259,7 @@ static bool initialize_test_environment(void)
 {
 	struct device *dev;
 
-	k_sem_init(&driver_lock, 0, UINT_MAX);
+	k_sem_reset(&driver_lock);
 
 	current_pkt = net_pkt_get_reserve_rx(0, K_FOREVER);
 	if (!current_pkt) {


### PR DESCRIPTION
The test starts the last one: after the driver and the net stack.
However, the net stack (due to DAD and else) will already try to send
some packet, resulting in giving an uninitialized semaphore. But once
properly initialized, this semaphore will end up with a non-zero count
when the test will start: thus resetting it to 0 before running the
tests.

Jira: ZEP-2319

Reported-by Andrew Boie <andrew.p.boie@intel.com>

Signed-off-by: Tomasz Bursztyka <tomasz.bursztyka@linux.intel.com>