### PR TITLE
net: app: Fix dual IPv4 and IPv6 support

### DIFF
--- a/include/net/net_app.h
+++ b/include/net/net_app.h
@@ -233,16 +233,29 @@ typedef int (*net_app_entropy_src_cb_t)(void *data, unsigned char *output,
 					size_t len, size_t *olen);
 #endif /* CONFIG_NET_APP_TLS */
 
+/* Information for the context and local/remote addresses used. */
+struct net_app_endpoint {
+	/** Network context. */
+	struct net_context *ctx;
+
+	/** Local address */
+	struct sockaddr local;
+
+	/** Remote address */
+	struct sockaddr remote;
+};
+
 /** Network application context. */
 struct net_app_ctx {
 #if defined(CONFIG_NET_IPV6)
-	/** Network IPv6 context. */
-	struct net_context *ipv6_ctx;
+	struct net_app_endpoint ipv6;
 #endif
 #if defined(CONFIG_NET_IPV4)
-	/** Network IPv4 context. */
-	struct net_context *ipv4_ctx;
+	struct net_app_endpoint ipv4;
 #endif
+
+	/** What is the default endpoint for this context. */
+	struct net_app_endpoint *default_ctx;
 
 	/** Internal function that is called when user data is sent to
 	 * network. By default this is set to net_context_sendto() but
@@ -258,12 +271,6 @@ struct net_app_ctx {
 	 * application.
 	 */
 	net_context_recv_cb_t recv_cb;
-
-	/** Local address */
-	struct sockaddr local;
-
-	/** Remote address */
-	struct sockaddr remote;
 
 #if defined(CONFIG_NET_APP_SERVER)
 	struct {
@@ -763,11 +770,13 @@ int net_app_send_buf(struct net_app_ctx *ctx,
  * @brief Create network packet.
  *
  * @param ctx Network application context.
+ * @param family What kind of network packet to get (AF_INET or AF_INET6)
  * @param timeout How long to wait the send before giving up.
  *
  * @return valid net_pkt if ok, NULL if error.
  */
 struct net_pkt *net_app_get_net_pkt(struct net_app_ctx *ctx,
+				    sa_family_t family,
 				    s32_t timeout);
 
 /**

--- a/samples/net/echo_client/src/echo-client.c
+++ b/samples/net/echo_client/src/echo-client.c
@@ -133,7 +133,7 @@ struct net_pkt *prepare_send_pkt(struct net_app_ctx *ctx,
 	struct net_pkt *send_pkt;
 	bool status;
 
-	send_pkt = net_app_get_net_pkt(ctx, K_FOREVER);
+	send_pkt = net_app_get_net_pkt(ctx, AF_UNSPEC, K_FOREVER);
 
 	NET_ASSERT(send_pkt);
 

--- a/samples/net/echo_server/src/echo-server.c
+++ b/samples/net/echo_server/src/echo-server.c
@@ -72,7 +72,7 @@ struct net_pkt *build_reply_pkt(const char *name,
 		return NULL;
 	}
 
-	reply_pkt = net_app_get_net_pkt(ctx, K_FOREVER);
+	reply_pkt = net_app_get_net_pkt(ctx, net_pkt_family(pkt), K_FOREVER);
 
 	NET_ASSERT(reply_pkt);
 

--- a/subsys/net/lib/app/net_app_private.h
+++ b/subsys/net/lib/app/net_app_private.h
@@ -77,7 +77,8 @@ int _net_app_config_local_ctx(struct net_app_ctx *ctx,
 			      enum net_sock_type sock_type,
 			      enum net_ip_protocol proto,
 			      struct sockaddr *addr);
-struct net_context *_net_app_select_net_ctx(struct net_app_ctx *ctx);
+struct net_context *_net_app_select_net_ctx(struct net_app_ctx *ctx,
+					    const struct sockaddr *dst);
 int _net_app_ssl_mux(void *context, unsigned char *buf, size_t size);
 int _net_app_tls_sendto(struct net_pkt *pkt,
 			const struct sockaddr *dst_addr,


### PR DESCRIPTION
It was not possible to send IPv4 packets if IPv6 was also
enabled.

Signed-off-by: Jukka Rissanen <jukka.rissanen@linux.intel.com>