### PR TITLE
TCP SYN backlog

### DIFF
--- a/subsys/net/ip/Kconfig
+++ b/subsys/net/ip/Kconfig
@@ -109,6 +109,15 @@ config NET_DEBUG_TCP
 	help
 	Enables TCP handler output debug messages
 
+config NET_TCP_BACKLOG_SIZE
+	int "Number of simultaneous incoming TCP connections"
+	depends on NET_TCP
+	default 1
+	range 1 128
+	help
+	The number of simultaneous TCP connection attempts, i.e. outstanding
+	TCP connections waiting for initial ACK.
+
 config NET_TCP_TIME_WAIT
 	bool "Enable TCP TIME_WAIT timeouts"
 	depends on NET_TCP

--- a/subsys/net/ip/tcp.c
+++ b/subsys/net/ip/tcp.c
@@ -112,12 +112,6 @@ static void net_tcp_trace(struct net_pkt *pkt, struct net_tcp *tcp)
 #define net_tcp_trace(...)
 #endif /* CONFIG_NET_DEBUG_TCP */
 
-static inline u32_t init_isn(void)
-{
-	/* Randomise initial seq number */
-	return sys_rand32_get();
-}
-
 static inline u32_t retry_timeout(const struct net_tcp *tcp)
 {
 	return ((u32_t)1 << tcp->retry_timeout_shift) * INIT_RETRY_MS;
@@ -217,7 +211,7 @@ struct net_tcp *net_tcp_alloc(struct net_context *context)
 	tcp_context[i].state = NET_TCP_CLOSED;
 	tcp_context[i].context = context;
 
-	tcp_context[i].send_seq = init_isn();
+	tcp_context[i].send_seq = tcp_init_isn();
 	tcp_context[i].recv_max_ack = tcp_context[i].send_seq + 1u;
 
 	tcp_context[i].accept_cb = NULL;

--- a/subsys/net/ip/tcp.h
+++ b/subsys/net/ip/tcp.h
@@ -197,6 +197,17 @@ static inline int net_tcp_unregister(struct net_conn_handle *handle)
 	return net_conn_unregister(handle);
 }
 
+/*
+ * @brief Generate initial TCP sequence number
+ *
+ * @return Return a random TCP sequence number
+ */
+inline u32_t tcp_init_isn(void)
+{
+	/* Randomise initial seq number */
+	return sys_rand32_get();
+}
+
 const char * const net_tcp_state_str(enum net_tcp_state state);
 
 #if defined(CONFIG_NET_TCP)


### PR DESCRIPTION
This is a first attempt to improve TCP SYN handling such that more than one remote endpoint is able to simultaneously establish a connection to a listening TCP port.

In this patch set an array with a size configurable with Kconfig is created to hold the outstanding connections where a SYN-ACK response has been sent. The array contains TCP connection sequence numbers in both directions as well as the delayed worker struct. As a result the TCP SYN sent state is no more, it exists now only as an entry in the table, whereby the state of the listening context is never updated. Once the connection has received an ACK or has a time out, the array entry is zeroed out and can be reused.

In the array there is a boolean used for cancellation. It turns out that the worker can be cancelled only as long as it has not been scheduled; the scheduling point is a point of no return after which the worker will run, no matter what.

As a result of all this, patch 4/4 removes code whose functionality now is handled by the new TCP backlog code. It all should continue working as before, but please review and especially test!