### PR TITLE
samples: ipm_mailbox: fix thread creation

### DIFF
--- a/samples/subsys/ipc/ipm_mailbox/ap/src/hello.c
+++ b/samples/subsys/ipc/ipm_mailbox/ap/src/hello.c
@@ -138,7 +138,7 @@ void main(void)
 			main_thread, 0, 0, 0,
 			K_PRIO_COOP(MAIN_FIBER_PRI), 0, 0);
 
-	k_thread_create(&threads[0], &thread_stacks[1][0], STACKSIZE,
+	k_thread_create(&threads[1], &thread_stacks[1][0], STACKSIZE,
 			ping_source_thread, 0, 0, 0,
 			K_PRIO_COOP(PING_FIBER_PRI), 0, 0);
 }


### PR DESCRIPTION
We have been starting the same thread twice. Introduced when we moved
from k_thread_spawn.