### PR TITLE
Bluetooth: controller: Use RL indices in adv ISR

### DIFF
--- a/subsys/bluetooth/controller/ll_sw/ll_filter.c
+++ b/subsys/bluetooth/controller/ll_sw/ll_filter.c
@@ -211,7 +211,7 @@ u8_t *ctrl_irks_get(u8_t *count)
 	return (u8_t *)peer_irks;
 }
 
-bool ctrl_irk_whitelisted(u8_t irkmatch_id)
+u8_t ctrl_rl_idx(u8_t irkmatch_id)
 {
 	u8_t i;
 
@@ -220,19 +220,19 @@ bool ctrl_irk_whitelisted(u8_t irkmatch_id)
 	LL_ASSERT(i < CONFIG_BLUETOOTH_CONTROLLER_RL_SIZE);
 	LL_ASSERT(rl[i].taken);
 
-	return rl[i].wl;
+	return i;
 }
 
-bool ctrl_rl_idx_match(u8_t irkmatch_id, u8_t rl_idx)
+bool ctrl_irk_whitelisted(u8_t rl_idx)
 {
-	u8_t i;
+	if (rl_idx == RL_IDX_NONE) {
+		return false;
+	}
 
-	LL_ASSERT(irkmatch_id < peer_irk_count);
-	i = peer_irk_rl_ids[irkmatch_id];
-	LL_ASSERT(i < CONFIG_BLUETOOTH_CONTROLLER_RL_SIZE);
-	LL_ASSERT(rl[i].taken);
+	LL_ASSERT(rl_idx < CONFIG_BLUETOOTH_CONTROLLER_RL_SIZE);
+	LL_ASSERT(rl[rl_idx].taken);
 
-	return i == rl_idx;
+	return rl[rl_idx].wl;
 }
 #endif
 

--- a/subsys/bluetooth/controller/ll_sw/ll_filter.h
+++ b/subsys/bluetooth/controller/ll_sw/ll_filter.h
@@ -20,8 +20,8 @@ void ll_filters_scan_update(u8_t scan_fp);
 
 struct ll_filter *ctrl_filter_get(bool whitelist);
 u8_t *ctrl_irks_get(u8_t *count);
-bool ctrl_irk_whitelisted(u8_t irkmatch_id);
-bool ctrl_rl_idx_match(u8_t irkmatch_id, u8_t rl_idx);
+u8_t ctrl_rl_idx(u8_t irkmatch_id);
+bool ctrl_irk_whitelisted(u8_t rl_idx);
 
 bool ctrl_rl_enabled(void);
 void ll_rl_rpa_update(bool timeout);


### PR DESCRIPTION
To avoid manipulation of the irkmatch_ok and irkmatch_id, rely instead
on Resolving List indices for all checks in the advertising ISR.
Although we do incur in a small overhead to look it up initially, the
overall gains are worth the change.

Signed-off-by: Carles Cufi <carles.cufi@nordicsemi.no>