### PR TITLE
Bluetooth: controller: Fix advertisement event lengths

### DIFF
--- a/subsys/bluetooth/controller/include/ll.h
+++ b/subsys/bluetooth/controller/include/ll.h
@@ -19,12 +19,12 @@ void ll_addr_set(u8_t addr_type, u8_t const *const p_bdaddr);
 u32_t ll_adv_params_set(u8_t handle, u16_t evt_prop, u32_t interval,
 			u8_t adv_type, u8_t own_addr_type,
 			u8_t direct_addr_type, u8_t const *const direct_addr,
-			u8_t chl_map, u8_t filter_policy, u8_t *tx_pwr,
+			u8_t chan_map, u8_t filter_policy, u8_t *tx_pwr,
 			u8_t phy_p, u8_t skip, u8_t phy_s, u8_t sid, u8_t sreq);
 #else /* !CONFIG_BLUETOOTH_CONTROLLER_ADV_EXT */
 u32_t ll_adv_params_set(u16_t interval, u8_t adv_type,
 			u8_t own_addr_type, u8_t direct_addr_type,
-			u8_t const *const direct_addr, u8_t chl_map,
+			u8_t const *const direct_addr, u8_t chan_map,
 			u8_t filter_policy);
 #endif /* !CONFIG_BLUETOOTH_CONTROLLER_ADV_EXT */
 

--- a/subsys/bluetooth/controller/ll_sw/ctrl.c
+++ b/subsys/bluetooth/controller/ll_sw/ctrl.c
@@ -78,13 +78,13 @@ struct advertiser {
 	struct shdr hdr;
 
 	u8_t is_enabled:1;
-	u8_t chl_map_current:3;
+	u8_t chan_map_current:3;
 	u8_t rfu:4;
 
 #if defined(CONFIG_BLUETOOTH_CONTROLLER_ADV_EXT)
 	u8_t phy_p:3;
 #endif /* CONFIG_BLUETOOTH_CONTROLLER_ADV_EXT */
-	u8_t chl_map:3;
+	u8_t chan_map:3;
 	u8_t filter_policy:2;
 #if defined(CONFIG_BLUETOOTH_CONTROLLER_PRIVACY)
 	u8_t rl_idx:4;
@@ -502,7 +502,7 @@ static void common_init(void)
 	memq_init(link, &_radio.link_rx_head, (void *)&_radio.link_rx_tail);
 
 	/* initialise advertiser channel map */
-	_radio.advertiser.chl_map = 0x07;
+	_radio.advertiser.chan_map = 0x07;
 
 	/* initialise connection channel map */
 	_radio.data_chan_map[0] = 0xFF;
@@ -2873,7 +2873,7 @@ static inline u32_t isr_close_adv(void)
 	u32_t dont_close = 0;
 
 	if ((_radio.state == STATE_CLOSE) &&
-	    (_radio.advertiser.chl_map_current != 0)) {
+	    (_radio.advertiser.chan_map_current != 0)) {
 		dont_close = 1;
 
 		adv_setup();
@@ -4930,14 +4930,14 @@ static void adv_setup(void)
 		radio_switch_complete_and_disable();
 	}
 
-	bitmap = _radio.advertiser.chl_map_current;
+	bitmap = _radio.advertiser.chan_map_current;
 	chan = 0;
 	while ((bitmap & 0x01) == 0) {
 		chan++;
 		bitmap >>= 1;
 	}
-	_radio.advertiser.chl_map_current &=
-		(_radio.advertiser.chl_map_current - 1);
+	_radio.advertiser.chan_map_current &=
+		(_radio.advertiser.chan_map_current - 1);
 
 	chan_set(37 + chan);
 }
@@ -4971,7 +4971,7 @@ static void event_adv(u32_t ticks_at_expire, u32_t remainder,
 	adv_scan_configure(0, 0);
 #endif /* !CONFIG_BLUETOOTH_CONTROLLER_ADV_EXT */
 
-	_radio.advertiser.chl_map_current = _radio.advertiser.chl_map;
+	_radio.advertiser.chan_map_current = _radio.advertiser.chan_map;
 	adv_setup();
 
 #if defined(CONFIG_BLUETOOTH_CONTROLLER_PRIVACY)
@@ -8248,10 +8248,10 @@ role_disable_cleanup:
 }
 
 #if defined(CONFIG_BLUETOOTH_CONTROLLER_ADV_EXT)
-u32_t radio_adv_enable(u8_t phy_p, u16_t interval, u8_t chl_map,
+u32_t radio_adv_enable(u8_t phy_p, u16_t interval, u8_t chan_map,
 		       u8_t filter_policy, u8_t rl_idx)
 #else /* !CONFIG_BLUETOOTH_CONTROLLER_ADV_EXT */
-u32_t radio_adv_enable(u16_t interval, u8_t chl_map, u8_t filter_policy,
+u32_t radio_adv_enable(u16_t interval, u8_t chan_map, u8_t filter_policy,
 		       u8_t rl_idx)
 #endif /* !CONFIG_BLUETOOTH_CONTROLLER_ADV_EXT */
 {
@@ -8373,7 +8373,7 @@ u32_t radio_adv_enable(u16_t interval, u8_t chl_map, u8_t filter_policy,
 	_radio.advertiser.phy_p = phy_p;
 #endif /* CONFIG_BLUETOOTH_CONTROLLER_ADV_EXT */
 
-	_radio.advertiser.chl_map = chl_map;
+	_radio.advertiser.chan_map = chan_map;
 	_radio.advertiser.filter_policy = filter_policy;
 #if defined(CONFIG_BLUETOOTH_CONTROLLER_PRIVACY)
 	_radio.advertiser.rl_idx = rl_idx;

--- a/subsys/bluetooth/controller/ll_sw/ctrl.h
+++ b/subsys/bluetooth/controller/ll_sw/ctrl.h
@@ -329,10 +329,10 @@ struct radio_adv_data *radio_adv_data_get(void);
 struct radio_adv_data *radio_scan_data_get(void);
 
 #if defined(CONFIG_BLUETOOTH_CONTROLLER_ADV_EXT)
-u32_t radio_adv_enable(u8_t phy_p, u16_t interval, u8_t chl_map,
+u32_t radio_adv_enable(u8_t phy_p, u16_t interval, u8_t chan_map,
 		       u8_t filter_policy, u8_t rl_idx);
 #else /* !CONFIG_BLUETOOTH_CONTROLLER_ADV_EXT */
-u32_t radio_adv_enable(u16_t interval, u8_t chl_map, u8_t filter_policy,
+u32_t radio_adv_enable(u16_t interval, u8_t chan_map, u8_t filter_policy,
 		       u8_t rl_idx);
 #endif /* !CONFIG_BLUETOOTH_CONTROLLER_ADV_EXT */
 

--- a/subsys/bluetooth/controller/ll_sw/ll_adv.c
+++ b/subsys/bluetooth/controller/ll_sw/ll_adv.c
@@ -32,7 +32,7 @@ struct ll_adv_set *ll_adv_set_get(void)
 u32_t ll_adv_params_set(u8_t handle, u16_t evt_prop, u32_t interval,
 			u8_t adv_type, u8_t own_addr_type,
 			u8_t direct_addr_type, u8_t const *const direct_addr,
-			u8_t chl_map, u8_t filter_policy, u8_t *tx_pwr,
+			u8_t chan_map, u8_t filter_policy, u8_t *tx_pwr,
 			u8_t phy_p, u8_t skip, u8_t phy_s, u8_t sid, u8_t sreq)
 {
 	u8_t const pdu_adv_type[] = {PDU_ADV_TYPE_ADV_IND,
@@ -44,7 +44,7 @@ u32_t ll_adv_params_set(u8_t handle, u16_t evt_prop, u32_t interval,
 #else /* !CONFIG_BLUETOOTH_CONTROLLER_ADV_EXT */
 u32_t ll_adv_params_set(u16_t interval, u8_t adv_type,
 			u8_t own_addr_type, u8_t direct_addr_type,
-			u8_t const *const direct_addr, u8_t chl_map,
+			u8_t const *const direct_addr, u8_t chan_map,
 			u8_t filter_policy)
 {
 	u8_t const pdu_adv_type[] = {PDU_ADV_TYPE_ADV_IND,
@@ -106,7 +106,7 @@ u32_t ll_adv_params_set(u16_t interval, u8_t adv_type,
 	} else {
 		ll_adv.interval = 0;
 	}
-	ll_adv.chl_map = chl_map;
+	ll_adv.chan_map = chan_map;
 	ll_adv.filter_policy = filter_policy;
 
 	/* update the "current" primary adv data */
@@ -414,10 +414,11 @@ u32_t ll_adv_enable(u8_t enable)
 		}
 	}
 #if defined(CONFIG_BLUETOOTH_CONTROLLER_ADV_EXT)
-	status = radio_adv_enable(ll_adv.phy_p, ll_adv.interval, ll_adv.chl_map,
-				  ll_adv.filter_policy, rl_idx);
+	status = radio_adv_enable(ll_adv.phy_p, ll_adv.interval,
+				  ll_adv.chan_map, ll_adv.filter_policy,
+				  rl_idx);
 #else /* !CONFIG_BLUETOOTH_CONTROLLER_ADV_EXT */
-	status = radio_adv_enable(ll_adv.interval, ll_adv.chl_map,
+	status = radio_adv_enable(ll_adv.interval, ll_adv.chan_map,
 				  ll_adv.filter_policy, rl_idx);
 #endif /* !CONFIG_BLUETOOTH_CONTROLLER_ADV_EXT */
 

--- a/subsys/bluetooth/controller/ll_sw/ll_adv.h
+++ b/subsys/bluetooth/controller/ll_sw/ll_adv.h
@@ -5,7 +5,7 @@
  */
 
 struct ll_adv_set {
-	u8_t  chl_map:3;
+	u8_t  chan_map:3;
 	u8_t  filter_policy:2;
 #if defined(CONFIG_BLUETOOTH_CONTROLLER_PRIVACY)
 	u8_t  rl_idx:4;


### PR DESCRIPTION
The Controller reserved more than required time for
advertisement event length. Due to this, directed
advertisements did not meet the required <= 3.75ms
interval. It is now fixed by having event lengths based
on the advertisement PDU types.

Signed-off-by: Vinayak Kariappa Chettimada <vich@nordicsemi.no>