### PR TITLE
scripts: extract_dts_includes.py: Fix names generation

### DIFF
--- a/scripts/extract_dts_includes.py
+++ b/scripts/extract_dts_includes.py
@@ -224,7 +224,7 @@ def extract_interrupts(node_address, yaml, y_key, names, defs, def_label):
       l_fqn = '_'.join(l_base + l_cell_prefix + l_idx + l_cell_name)
       prop_def[l_fqn] = props.pop(0)
       if len(name):
-        prop_alias['_'.join(l_base + name + l_cell_prefix)] = l_fqn
+        prop_alias['_'.join(l_base + name + l_cell_name)] = l_fqn
 
     index += 1
     insert_defs(node_address, defs, prop_def, prop_alias)


### PR DESCRIPTION
This patch fixes issues with the IRQ definitions when using
the interrupt-names property in the DT entry.

Signed-off-by: Andy Gross <andy.gross@linaro.org>