### PR TITLE
Bluetooth: controller: Fix HCI remote version structure

### DIFF
--- a/include/bluetooth/hci.h
+++ b/include/bluetooth/hci.h
@@ -1328,7 +1328,7 @@ struct bt_hci_evt_remote_version_info {
 	u16_t handle;
 	u8_t  version;
 	u16_t manufacturer;
-	u8_t  subversion;
+	u16_t subversion;
 } __packed;
 
 #define BT_HCI_EVT_CMD_COMPLETE                 0x0e

--- a/subsys/bluetooth/controller/hci/hci.c
+++ b/subsys/bluetooth/controller/hci/hci.c
@@ -2033,6 +2033,7 @@ static void le_unknown_rsp(struct pdu_data *pdu_data, u16_t handle,
 static void remote_version_info(struct pdu_data *pdu_data, u16_t handle,
 				struct net_buf *buf)
 {
+	struct pdu_data_llctrl_version_ind *ver_ind;
 	struct bt_hci_evt_remote_version_info *ep;
 
 	if (!(event_mask & BT_EVT_MASK_REMOTE_VERSION_INFO)) {
@@ -2042,14 +2043,12 @@ static void remote_version_info(struct pdu_data *pdu_data, u16_t handle,
 	evt_create(buf, BT_HCI_EVT_REMOTE_VERSION_INFO, sizeof(*ep));
 	ep = net_buf_add(buf, sizeof(*ep));
 
+	ver_ind = &pdu_data->payload.llctrl.ctrldata.version_ind;
 	ep->status = 0x00;
 	ep->handle = sys_cpu_to_le16(handle);
-	ep->version =
-	      pdu_data->payload.llctrl.ctrldata.version_ind.version_number;
-	ep->manufacturer =
-		pdu_data->payload.llctrl.ctrldata.version_ind.company_id;
-	ep->subversion =
-	      pdu_data->payload.llctrl.ctrldata.version_ind.sub_version_number;
+	ep->version = ver_ind->version_number;
+	ep->manufacturer = sys_cpu_to_le16(ver_ind->company_id);
+	ep->subversion = sys_cpu_to_le16(ver_ind->sub_version_number);
 }
 
 static void le_conn_param_req(struct pdu_data *pdu_data, u16_t handle,


### PR DESCRIPTION
The HCI Read Remote Version Information Complete event structure was
incorrect, leading to qualification test failures. This patch fixes the
structure and also the storing of the data in an endianness-agnostic
manner.

Signed-off-by: Carles Cufi <carles.cufi@nordicsemi.no>