### PR TITLE
Make k_delayed_work_cancel cancel pending work

### DIFF
--- a/include/kernel.h
+++ b/include/kernel.h
@@ -1441,6 +1441,24 @@ extern void k_queue_merge_slist(struct k_queue *queue, sys_slist_t *list);
 extern void *k_queue_get(struct k_queue *queue, s32_t timeout);
 
 /**
+ * @brief Find and remove an element from a queue.
+ *
+ * This routine removes data item from @a queue. The first 32 bits of the
+ * data item are reserved for the kernel's use.
+ *
+ * @note Can be called by ISRs
+ *
+ * @param queue Address of the queue.
+ * @param data Address of the data item.
+ *
+ * @return true if data item was removed
+ */
+static inline bool k_queue_find_and_remove(struct k_queue *queue, void *data)
+{
+	return sys_slist_find_and_remove(&queue->data_q, (sys_snode_t *)data);
+}
+
+/**
  * @brief Query a queue to see if it has data available.
  *
  * Note that the data might be already gone by the time this function returns

--- a/include/kernel.h
+++ b/include/kernel.h
@@ -1922,7 +1922,7 @@ typedef void (*k_work_handler_t)(struct k_work *work);
  */
 
 struct k_work_q {
-	struct k_fifo fifo;
+	struct k_queue queue;
 	struct k_thread thread;
 };
 
@@ -1931,7 +1931,7 @@ enum {
 };
 
 struct k_work {
-	void *_reserved;		/* Used by k_fifo implementation. */
+	void *_reserved;		/* Used by k_queue implementation. */
 	k_work_handler_t handler;
 	atomic_t flags[1];
 };
@@ -2006,7 +2006,7 @@ static inline void k_work_submit_to_queue(struct k_work_q *work_q,
 					  struct k_work *work)
 {
 	if (!atomic_test_and_set_bit(work->flags, K_WORK_STATE_PENDING)) {
-		k_fifo_put(&work_q->fifo, work);
+		k_fifo_put(&work_q->queue, work);
 	}
 }
 

--- a/include/kernel.h
+++ b/include/kernel.h
@@ -2006,7 +2006,7 @@ static inline void k_work_submit_to_queue(struct k_work_q *work_q,
 					  struct k_work *work)
 {
 	if (!atomic_test_and_set_bit(work->flags, K_WORK_STATE_PENDING)) {
-		k_fifo_put(&work_q->queue, work);
+		k_queue_append(&work_q->queue, work);
 	}
 }
 

--- a/kernel/work_q.c
+++ b/kernel/work_q.c
@@ -26,13 +26,13 @@ static void work_q_main(void *work_q_ptr, void *p2, void *p3)
 		struct k_work *work;
 		k_work_handler_t handler;
 
-		work = k_fifo_get(&work_q->fifo, K_FOREVER);
+		work = k_queue_get(&work_q->queue, K_FOREVER);
 
 		handler = work->handler;
 
 		/* Reset pending state so it can be resubmitted by handler */
 		if (atomic_test_and_clear_bit(work->flags,
-					       K_WORK_STATE_PENDING)) {
+					      K_WORK_STATE_PENDING)) {
 			handler(work);
 		}
 
@@ -46,7 +46,7 @@ static void work_q_main(void *work_q_ptr, void *p2, void *p3)
 void k_work_q_start(struct k_work_q *work_q, char *stack,
 		    size_t stack_size, int prio)
 {
-	k_fifo_init(&work_q->fifo);
+	k_queue_init(&work_q->queue);
 
 	k_thread_create(&work_q->thread, stack, stack_size, work_q_main,
 			work_q, 0, 0, prio, 0, 0);

--- a/kernel/work_q.c
+++ b/kernel/work_q.c
@@ -60,8 +60,6 @@ static void work_timeout(struct _timeout *t)
 
 	/* submit work to workqueue */
 	k_work_submit_to_queue(w->work_q, &w->work);
-	/* detach from workqueue, for cancel to return appropriate status */
-	w->work_q = NULL;
 }
 
 void k_delayed_work_init(struct k_delayed_work *work, k_work_handler_t handler)
@@ -116,18 +114,21 @@ int k_delayed_work_cancel(struct k_delayed_work *work)
 {
 	int key = irq_lock();
 
-	if (k_work_pending(&work->work)) {
-		irq_unlock(key);
-		return -EINPROGRESS;
-	}
-
 	if (!work->work_q) {
 		irq_unlock(key);
 		return -EINVAL;
 	}
 
-	/* Abort timeout, if it has expired this will do nothing */
-	_abort_timeout(&work->timeout);
+	if (k_work_pending(&work->work)) {
+		/* Remove from the queue if already submitted */
+		if (!k_queue_find_and_remove(&work->work_q->queue,
+					     &work->work)) {
+			irq_unlock(key);
+			return -EINVAL;
+		}
+	} else {
+		_abort_timeout(&work->timeout);
+	}
 
 	/* Detach from workqueue */
 	work->work_q = NULL;

--- a/tests/kernel/queue/src/test_queue_loop.c
+++ b/tests/kernel/queue/src/test_queue_loop.c
@@ -12,9 +12,9 @@
  *                     in loop
  * @details
  * - Test Steps
- *   -# queue append/prepend from main thread
+ *   -# queue append/prepend/find_and_remove from main thread
  *   -# queue read from isr
- *   -# queue append/prepend from isr
+ *   -# queue append/prepend/find_and_remove from isr
  *   -# queue get from spawn thread
  *   -# loop above steps for LOOPs times
  * - Expected Results
@@ -23,6 +23,7 @@
  *   -# k_queue_init
  *   -# k_queue_append
  *   -# k_queue_prepend
+ *   -# k_queue_find_and_remove
  *   -# k_queue_get
  * @}
  */
@@ -35,6 +36,7 @@
 
 static qdata_t data[LIST_LEN];
 static qdata_t data_p[LIST_LEN];
+static qdata_t data_r[LIST_LEN];
 static struct k_queue queue;
 static K_THREAD_STACK_DEFINE(tstack, STACK_SIZE);
 static struct k_thread tdata;
@@ -50,6 +52,11 @@ static void tqueue_append(struct k_queue *pqueue)
 	/**TESTPOINT: queue prepend*/
 	for (int i = LIST_LEN - 1; i >= 0; i--) {
 		k_queue_prepend(pqueue, (void *)&data_p[i]);
+	}
+
+	/**TESTPOINT: queue find and remove*/
+	for (int i = LIST_LEN - 1; i >= 0; i--) {
+		k_queue_prepend(pqueue, (void *)&data_r[i]);
 	}
 }
 
@@ -72,9 +79,20 @@ static void tqueue_get(struct k_queue *pqueue)
 	}
 }
 
+static void tqueue_find_and_remove(struct k_queue *pqueue)
+{
+	/*remove queue data from "queue_find_and_remove"*/
+	for (int i = 0; i < LIST_LEN; i++) {
+		/**TESTPOINT: queue find and remove*/
+		zassert_true(k_queue_find_and_remove(pqueue, &data_r[i]), NULL);
+	}
+}
+
 /*entry of contexts*/
 static void tIsr_entry(void *p)
 {
+	TC_PRINT("isr queue find and remove\n");
+	tqueue_find_and_remove((struct k_queue *)p);
 	TC_PRINT("isr queue get\n");
 	tqueue_get((struct k_queue *)p);
 	TC_PRINT("isr queue append ---> ");
@@ -83,6 +101,8 @@ static void tIsr_entry(void *p)
 
 static void tThread_entry(void *p1, void *p2, void *p3)
 {
+	TC_PRINT("thread queue find and remove\n");
+	tqueue_find_and_remove((struct k_queue *)p1);
 	TC_PRINT("thread queue get\n");
 	tqueue_get((struct k_queue *)p1);
 	k_sem_give(&end_sema);
@@ -106,6 +126,8 @@ static void tqueue_read_write(struct k_queue *pqueue)
 	k_sem_take(&end_sema, K_FOREVER);
 	k_sem_take(&end_sema, K_FOREVER);
 
+	TC_PRINT("main queue find and remove\n");
+	tqueue_find_and_remove(pqueue);
 	TC_PRINT("main queue get\n");
 	tqueue_get(pqueue);
 	k_thread_abort(tid);

--- a/tests/kernel/workq/work_queue/README.txt
+++ b/tests/kernel/workq/work_queue/README.txt
@@ -95,6 +95,7 @@ Starting delayed resubmit from coop thread test
 Starting delayed cancel test
  - Cancel delayed work from preempt thread
  - Cancel delayed work from coop thread
+ - Cancel pending delayed work from coop thread
  - Waiting for work to finish
  - Checking results
 ===================================================================

--- a/tests/kernel/workq/work_queue/src/main.c
+++ b/tests/kernel/workq/work_queue/src/main.c
@@ -236,6 +236,11 @@ static void coop_delayed_work_cancel_main(int arg1, int arg2)
 
 	TC_PRINT(" - Cancel delayed work from coop thread\n");
 	k_delayed_work_cancel(&tests[1].work);
+
+	k_delayed_work_submit(&tests[2].work, 0 /* Submit immeditelly */);
+
+	TC_PRINT(" - Cancel pending delayed work from coop thread\n");
+	k_delayed_work_cancel(&tests[2].work);
 }
 
 static int test_delayed_cancel(void)
@@ -249,7 +254,8 @@ static int test_delayed_cancel(void)
 
 	k_thread_create(&co_op_data, co_op_stack, STACK_SIZE,
 			(k_thread_entry_t)coop_delayed_work_cancel_main,
-			NULL, NULL, NULL, K_PRIO_COOP(10), 0, 0);
+			NULL, NULL, NULL,
+			K_PRIO_COOP(CONFIG_SYSTEM_WORKQUEUE_PRIORITY), 0, 0);
 
 	TC_PRINT(" - Waiting for work to finish\n");
 	k_sleep(2 * WORK_ITEM_WAIT);

--- a/tests/kernel/workq/work_queue_api/src/test_workq_api.c
+++ b/tests/kernel/workq/work_queue_api/src/test_workq_api.c
@@ -124,10 +124,10 @@ static void tdelayed_work_cancel(void *data)
 	 * >t0: cancel delayed_work[0], expected cancellation success
 	 * >t0+TIMEOUT: handling delayed_work_sleepy, which do k_sleep TIMEOUT
 	 *              pending delayed_work[1], check pending flag, expected 1
-	 *              cancel delayed_work[1], expected -EINPROGRESS
+	 *              cancel delayed_work[1], expected 0
 	 * >t0+2*TIMEOUT: delayed_work_sleepy completed
 	 *                delayed_work[1] completed
-	 *                cancel delayed_work_sleepy, expected -EINVAL
+	 *                cancel delayed_work_sleepy, expected 0
 	 */
 	zassert_true(ret == 0, NULL);
 	/**TESTPOINT: delayed work cancel when countdown*/
@@ -143,7 +143,8 @@ static void tdelayed_work_cancel(void *data)
 			     NULL);
 		/**TESTPOINT: delayed work cancel when pending*/
 		ret = k_delayed_work_cancel(&delayed_work[1]);
-		zassert_equal(ret, -EINPROGRESS, NULL);
+		zassert_equal(ret, 0, NULL);
+		k_sem_give(&sync_sema);
 		/*wait for completed work_sleepy and delayed_work[1]*/
 		k_sleep(TIMEOUT);
 		/**TESTPOINT: check pending when work completed*/
@@ -151,7 +152,7 @@ static void tdelayed_work_cancel(void *data)
 				      (struct k_work *)&delayed_work_sleepy), NULL);
 		/**TESTPOINT: delayed work cancel when completed*/
 		ret = k_delayed_work_cancel(&delayed_work_sleepy);
-		zassert_equal(ret, -EINVAL, NULL);
+		zassert_equal(ret, 0, NULL);
 	}
 	/*work items not cancelled: delayed_work[1], delayed_work_sleepy*/
 }


### PR DESCRIPTION
This makes k_delayed_work_cancel more reliable by allowing the user to remove items already pending.