### PR TITLE
net: tcp: Set context->tcp to NULL after release tcp

### DIFF
--- a/subsys/net/ip/net_context.c
+++ b/subsys/net/ip/net_context.c
@@ -388,6 +388,7 @@ int net_context_unref(struct net_context *context)
 #if defined(CONFIG_NET_TCP)
 	if (context->tcp) {
 		net_tcp_release(context->tcp);
+		context->tcp = NULL;
 	}
 #endif /* CONFIG_NET_TCP */
 


### PR DESCRIPTION
Set context->tcp to NULL after net_tcp_release,
or it will release again when udp use this context and unref.

Signed-off-by: june li <junelizh@foxmail.com>