### PR TITLE
Bluetooth: Decrease Rx processing priority

### DIFF
--- a/subsys/bluetooth/controller/hci/hci_driver.c
+++ b/subsys/bluetooth/controller/hci/hci_driver.c
@@ -407,7 +407,7 @@ static int hci_driver_open(void)
 
 	k_thread_create(&recv_thread_data, recv_thread_stack,
 			K_THREAD_STACK_SIZEOF(recv_thread_stack), recv_thread,
-			NULL, NULL, NULL, K_PRIO_COOP(7), 0, K_NO_WAIT);
+			NULL, NULL, NULL, K_PRIO_COOP(8), 0, K_NO_WAIT);
 
 	BT_DBG("Success.");
 

--- a/subsys/bluetooth/host/hci_core.c
+++ b/subsys/bluetooth/host/hci_core.c
@@ -4075,7 +4075,7 @@ int bt_enable(bt_ready_cb_t cb)
 	k_thread_create(&rx_thread_data, rx_thread_stack,
 			K_THREAD_STACK_SIZEOF(rx_thread_stack),
 			(k_thread_entry_t)hci_rx_thread, NULL, NULL, NULL,
-			K_PRIO_COOP(7), 0, K_NO_WAIT);
+			K_PRIO_COOP(8), 0, K_NO_WAIT);
 #endif
 
 	if (IS_ENABLED(CONFIG_BLUETOOTH_TINYCRYPT_ECC)) {


### PR DESCRIPTION
The following error and warning is received when connecting
to certain central devices:
[bt] [ERR] hci_num_completed_packets: packets count mismatch
[bt] [WRN] bt_att_recv: Ignoring unexpected request

This could happen if Tx-ed packet is not added to pending
list before a num of completed packets event and/or new Rx
packet is received.

This is fixed by reducing the Rx thread priorities in the
Host and the Controller.

Signed-off-by: Vinayak Kariappa Chettimada <vich@nordicsemi.no>