### PR TITLE
net: context: Remove useless asserts when setting net_buf pools

### DIFF
--- a/include/net/net_context.h
+++ b/include/net/net_context.h
@@ -763,8 +763,6 @@ static inline void net_context_setup_pools(struct net_context *context,
 					   net_pkt_get_pool_func_t data_pool)
 {
 	NET_ASSERT(context);
-	NET_ASSERT(tx_slab);
-	NET_ASSERT(data_pool);
 
 	context->tx_slab = tx_slab;
 	context->data_pool = data_pool;


### PR DESCRIPTION
No need to print errors if assinging null values into net_buf
pools as this is a normal condition if those pools are not used.

Signed-off-by: Jukka Rissanen <jukka.rissanen@linux.intel.com>