### PR TITLE
Bluetooth: Fix bogus decoding of 8-bit num_handles as 16-bit

### DIFF
--- a/subsys/bluetooth/host/hci_core.c
+++ b/subsys/bluetooth/host/hci_core.c
@@ -483,11 +483,11 @@ static void hci_acl(struct net_buf *buf)
 static void hci_num_completed_packets(struct net_buf *buf)
 {
 	struct bt_hci_evt_num_completed_packets *evt = (void *)buf->data;
-	u16_t i, num_handles = sys_le16_to_cpu(evt->num_handles);
+	int i;
 
-	BT_DBG("num_handles %u", num_handles);
+	BT_DBG("num_handles %u", evt->num_handles);
 
-	for (i = 0; i < num_handles; i++) {
+	for (i = 0; i < evt->num_handles; i++) {
 		u16_t handle, count;
 		struct bt_conn *conn;
 		unsigned int key;


### PR DESCRIPTION
The num_handles parameter of the Number Of Completed Packets event is
8-bits and not 16-bits, so no helper variable or byte order conversion
is needed.

Signed-off-by: Johan Hedberg <johan.hedberg@intel.com>