### PR TITLE
net: route: Do not try to del null route

### DIFF
--- a/subsys/net/ip/route.c
+++ b/subsys/net/ip/route.c
@@ -465,6 +465,10 @@ int net_route_del_by_nexthop(struct net_if *iface, struct in6_addr *nexthop)
 		struct net_nbr *nbr = get_nbr(i);
 		struct net_route_entry *route = net_route_data(nbr);
 
+		if (!route) {
+			continue;
+		}
+
 		SYS_SLIST_FOR_EACH_CONTAINER(&route->nexthop, nexthop_route,
 					     node) {
 			if (nexthop_route->nbr == nbr_nexthop) {


### PR DESCRIPTION
If there is no route to the neighbor, then do not try to delete
it because the route pointer is NULL.

Jira: ZEP-2329

Signed-off-by: Jukka Rissanen <jukka.rissanen@linux.intel.com>