### PR TITLE
net: route: Do not try to access null link layer address

### DIFF
--- a/subsys/net/ip/route.c
+++ b/subsys/net/ip/route.c
@@ -735,6 +735,11 @@ int net_route_packet(struct net_pkt *pkt, struct in6_addr *nexthop)
 		return -ESRCH;
 	}
 
+	if (!net_pkt_ll_src(pkt)->addr) {
+		NET_DBG("Link layer source address not set");
+		return -EINVAL;
+	}
+
 	/* Sanitycheck: If src and dst ll addresses are going to be same,
 	 * then something went wrong in route lookup.
 	 */


### PR DESCRIPTION
In some cases the lladdr might not be set, currently this is
seen with RPL unit tests, in which case we must not access
the lladdr.

Jira: ZEP-2330

Signed-off-by: Jukka Rissanen <jukka.rissanen@linux.intel.com>