### PR TITLE
net: tcp: Reset context->tcp to NULL after net_tcp_release.

### DIFF
--- a/subsys/net/ip/net_context.c
+++ b/subsys/net/ip/net_context.c
@@ -565,6 +565,7 @@ int net_context_unref(struct net_context *context)
 #if defined(CONFIG_NET_TCP)
 	if (context->tcp) {
 		net_tcp_release(context->tcp);
+		context->tcp = NULL;
 	}
 #endif /* CONFIG_NET_TCP */
 


### PR DESCRIPTION
net_context_unref() is protocol agnostic, after being un-referenced,
the same context might end up being used then for UDP,
if context->tcp is not reset to NULL, calling net_context_unref()
after this UDP usage will again try to release this TCP pointer
which might lead to random error.

Signed-off-by: june li <junelizh@foxmail.com>