### PR TITLE
i2c: remove I2C Slave Read config

### DIFF
--- a/drivers/i2c/i2c_atmel_sam3.c
+++ b/drivers/i2c/i2c_atmel_sam3.c
@@ -194,11 +194,6 @@ static int i2c_sam3_runtime_configure(struct device *dev, u32_t config)
 	dev_data->dev_config.raw = config;
 	reg = 0;
 
-	/* Currently support master mode only */
-	if (dev_data->dev_config.bits.is_slave_read) {
-		return -EINVAL;
-	}
-
 	/* Calculate clock dividers */
 	clk = clk_div_calc(dev);
 	if (!clk) {

--- a/drivers/i2c/i2c_bitbang.c
+++ b/drivers/i2c/i2c_bitbang.c
@@ -54,9 +54,6 @@ int i2c_bitbang_configure(struct i2c_bitbang *context, u32_t dev_config)
 	union dev_config config = { .raw = dev_config };
 
 	/* Check for features we don't support */
-	if (config.bits.is_slave_read) {
-		return -ENOTSUP;
-	}
 	if (config.bits.use_10_bit_addr) {
 		return -ENOTSUP;
 	}

--- a/drivers/i2c/i2c_dw.c
+++ b/drivers/i2c/i2c_dw.c
@@ -257,27 +257,6 @@ static void i2c_dw_isr(void *arg)
 				goto done;
 			}
 		}
-	} else { /* we must be configured as a slave device */
-
-		/* We have a read requested by the master device */
-		if (intr_stat.bits.rd_req &&
-		    (!dw->app_config.bits.is_slave_read)) {
-
-			/* data is not ready to send */
-			if (intr_stat.bits.tx_abrt) {
-				/* clear the TX_ABRT interrupt */
-				value = regs->ic_clr_tx_abrt;
-			}
-
-			_i2c_dw_data_send(port);
-			value = regs->ic_clr_rd_req;
-		}
-
-		/* The slave device is ready to receive */
-		if (intr_stat.bits.rx_full &&
-		    dw->app_config.bits.is_slave_read) {
-			_i2c_dw_data_read(port);
-		}
 	}
 
 	/* STOP detected: finish processing this message */
@@ -321,6 +300,8 @@ static int _i2c_dw_setup(struct device *dev, u16_t slave_address)
 		SYS_LOG_DBG("I2C: host configured as Master Device");
 		ic_con.bits.master_mode = 1;
 		ic_con.bits.slave_disable = 1;
+	} else {
+		return -EINVAL;
 	}
 
 	ic_con.bits.restart_en = 1;

--- a/drivers/i2c/i2c_ll_stm32.c
+++ b/drivers/i2c/i2c_ll_stm32.c
@@ -24,9 +24,6 @@ static int i2c_stm32_runtime_configure(struct device *dev, u32_t config)
 	I2C_TypeDef *i2c = cfg->i2c;
 	u32_t clock;
 
-	if (data->dev_config.bits.is_slave_read)
-		return -EINVAL;
-
 	data->dev_config.raw = config;
 
 	clock_control_get_rate(device_get_binding(STM32_CLOCK_CONTROL_NAME),

--- a/drivers/i2c/i2c_mcux.c
+++ b/drivers/i2c/i2c_mcux.c
@@ -43,10 +43,6 @@ static int i2c_mcux_configure(struct device *dev, u32_t dev_config_raw)
 		return -EINVAL;
 	}
 
-	if (dev_config.bits.is_slave_read) {
-		return -EINVAL;
-	}
-
 	if (dev_config.bits.use_10_bit_addr) {
 		return -EINVAL;
 	}

--- a/drivers/i2c/i2c_nrf5.c
+++ b/drivers/i2c/i2c_nrf5.c
@@ -55,10 +55,6 @@ static int i2c_nrf5_configure(struct device *dev, u32_t dev_config_raw)
 
 	SYS_LOG_DBG("");
 
-	if (dev_config.bits.is_slave_read) {
-		return -EINVAL;
-	}
-
 	if (dev_config.bits.use_10_bit_addr) {
 		return -EINVAL;
 	}

--- a/drivers/i2c/twihs_sam.c
+++ b/drivers/i2c/twihs_sam.c
@@ -92,14 +92,8 @@ static int twihs_sam_configure(struct device *dev, u32_t config)
 	u32_t i2c_speed;
 	u32_t clk;
 
-	if (!(config & (I2C_MODE_MASTER | I2C_MODE_SLAVE_READ))) {
-		SYS_LOG_ERR("Neither Master nor Slave I2C Mode is enabled");
-		return -EIO;
-	}
-
-	if (config & I2C_MODE_SLAVE_READ) {
-		SYS_LOG_ERR("I2C Slave Mode is currently not supported");
-		SYS_LOG_ERR("Please submit a patch");
+	if (!(config & I2C_MODE_MASTER)) {
+		SYS_LOG_ERR("Master I2C Mode is enabled");
 		return -EIO;
 	}
 

--- a/include/i2c.h
+++ b/include/i2c.h
@@ -55,10 +55,6 @@ extern "C" {
 /** Controller to act as Master. */
 #define I2C_MODE_MASTER			(1 << 4)
 
-/** Controller to act as Slave. */
-#define I2C_MODE_SLAVE_READ		(1 << 5)
-
-
 /*
  * I2C_MSG_* are I2C Message flags.
  */
@@ -101,7 +97,6 @@ union dev_config {
 		u32_t        use_10_bit_addr : 1;
 		u32_t        speed : 3;
 		u32_t        is_master_device : 1;
-		u32_t        is_slave_read : 1;
 		u32_t        reserved : 26;
 	} bits;
 };

--- a/tests/drivers/i2c/i2c_api/src/test_i2c.c
+++ b/tests/drivers/i2c/i2c_api/src/test_i2c.c
@@ -28,7 +28,6 @@ static union dev_config i2c_cfg = {
 		.use_10_bit_addr = 0,
 		.is_master_device = 1,
 		.speed = I2C_SPEED_STANDARD,
-		.is_slave_read = 0,
 	},
 };
 


### PR DESCRIPTION
The I2C Slave Read support isn't well defined and not actually supported
by any i2c driver at this point.  We can add this back when slave mode
is more thought out.

Signed-off-by: Kumar Gala <kumar.gala@linaro.org>