### PR TITLE
Bluetooth: conn: Fix notifying all pending tx packets in send_frag()

### DIFF
--- a/subsys/bluetooth/host/conn.c
+++ b/subsys/bluetooth/host/conn.c
@@ -1099,6 +1099,22 @@ void bt_conn_notify_tx(struct bt_conn *conn)
 	}
 }
 
+static void notify_tx(void)
+{
+	int i;
+
+	for (i = 0; i < ARRAY_SIZE(conns); i++) {
+		if (!atomic_get(&conns[i].ref)) {
+			continue;
+		}
+
+		if (conns[i].state == BT_CONN_CONNECTED ||
+		    conns[i].state == BT_CONN_DISCONNECT) {
+			bt_conn_notify_tx(&conns[i]);
+		}
+	}
+}
+
 static sys_snode_t *add_pending_tx(struct bt_conn *conn, bt_conn_tx_cb_t cb)
 {
 	sys_snode_t *node;
@@ -1144,7 +1160,7 @@ static bool send_frag(struct bt_conn *conn, struct net_buf *buf, u8_t flags,
 	k_sem_take(bt_conn_get_pkts(conn), K_FOREVER);
 
 	/* Make sure we notify and free up any pending tx contexts */
-	bt_conn_notify_tx(conn);
+	notify_tx();
 
 	/* Check for disconnection while waiting for pkts_sem */
 	if (conn->state != BT_CONN_CONNECTED) {


### PR DESCRIPTION
The code in send_frag() depends on being able to allocate a new
pending tx contexts with 100% certainty. We must therefore notify
*all* connections instead of the current one in order to ensure that
there are free contexts available in free_tx.

Signed-off-by: Johan Hedberg <johan.hedberg@intel.com>