### PR TITLE
net: net_app: fix syntax error when accessing remote from default_ctx

### DIFF
--- a/subsys/net/lib/app/client.c
+++ b/subsys/net/lib/app/client.c
@@ -94,7 +94,7 @@ static int resolve_name(struct net_app_ctx *ctx,
 
 	ctx->client.dns_id = 0;
 
-	if (ctx->default_ctx.remote.family == AF_UNSPEC) {
+	if (ctx->default_ctx->remote.family == AF_UNSPEC) {
 		return -EINVAL;
 	}
 


### PR DESCRIPTION
To replicate the issue by enabling CONFIG_DNS_RESOLVER=y at samples/net/echo_client/prj_qemu_x86.conf

Signed-off-by: Robert Chou <robert.ch.chou@acer.com>