### PR TITLE
Bluetooth: drivers: Make RX thread priority consistent

### DIFF
--- a/drivers/bluetooth/hci/h4.c
+++ b/drivers/bluetooth/hci/h4.c
@@ -441,7 +441,7 @@ static int h4_open(void)
 
 	k_thread_create(&rx_thread_data, rx_thread_stack,
 			K_THREAD_STACK_SIZEOF(rx_thread_stack), rx_thread,
-			NULL, NULL, NULL, K_PRIO_COOP(7), 0, K_NO_WAIT);
+			NULL, NULL, NULL, K_PRIO_COOP(8), 0, K_NO_WAIT);
 
 	return 0;
 }

--- a/drivers/bluetooth/hci/h5.c
+++ b/drivers/bluetooth/hci/h5.c
@@ -726,7 +726,7 @@ static void h5_init(void)
 	k_thread_create(&rx_thread_data, rx_stack,
 			K_THREAD_STACK_SIZEOF(rx_stack),
 			(k_thread_entry_t)rx_thread,
-			NULL, NULL, NULL, K_PRIO_COOP(7), 0, K_NO_WAIT);
+			NULL, NULL, NULL, K_PRIO_COOP(8), 0, K_NO_WAIT);
 
 	/* Unack queue */
 	k_fifo_init(&h5.unack_queue);

--- a/drivers/bluetooth/hci/spi.c
+++ b/drivers/bluetooth/hci/spi.c
@@ -328,7 +328,7 @@ static int bt_spi_open(void)
 	k_thread_create(&rx_thread_data, rx_stack,
 			K_THREAD_STACK_SIZEOF(rx_stack),
 			(k_thread_entry_t)bt_spi_rx_thread,
-			NULL, NULL, NULL, K_PRIO_COOP(7), 0, K_NO_WAIT);
+			NULL, NULL, NULL, K_PRIO_COOP(8), 0, K_NO_WAIT);
 
 	/* Take BLE out of reset */
 	gpio_pin_write(rst_dev, GPIO_RESET_PIN, 1);


### PR DESCRIPTION
The controller and host-side RX threads recently had their priorities
lowered to 8. Make the driver RX threads consistent with this.

Signed-off-by: Johan Hedberg <johan.hedberg@intel.com>