### PR TITLE
net: ipv6: Increase default multicast address count to 3

### DIFF
--- a/subsys/net/ip/Kconfig.ipv6
+++ b/subsys/net/ip/Kconfig.ipv6
@@ -21,7 +21,7 @@ config NET_IF_UNICAST_IPV6_ADDR_COUNT
 
 config NET_IF_MCAST_IPV6_ADDR_COUNT
 	int "Max number of multicast IPv6 addresses per network interface"
-	default 1
+	default 3
 
 config NET_IF_IPV6_PREFIX_COUNT
 	int "Max number of IPv6 prefixes per network interface"


### PR DESCRIPTION
Usually it is not enough to have just one IPv6 multicast
address defined for the network interface. So allocate three
IPv6 multicast addresses for the network interface as IPv6
by default uses multicast a lot. This hopefully will avoid
some mysterious errors if the addresses run out.

Note that this will increase memory usage a bit so you might
need to lower the count in your conf file if memory is low.

Signed-off-by: Jukka Rissanen <jukka.rissanen@linux.intel.com>