### PR TITLE
Bluetooth: GATT: Rework Service Changed indications

### DIFF
--- a/subsys/bluetooth/shell/gatt.c
+++ b/subsys/bluetooth/shell/gatt.c
@@ -713,8 +713,8 @@ int cmd_gatt_write_cmd_metrics(int argc, char *argv[])
 			registered = true;
 		}
 	} else if (!strcmp(argv[1], "off")) {
-		printk("Not supported.\n");
-		err = -EINVAL;
+		printk("Unregistering GATT metrics test Service.\n");
+		err = bt_gatt_service_unregister(&met_svc);
 	} else {
 		printk("Incorrect value: %s\n", argv[1]);
 		return -EINVAL;


### PR DESCRIPTION
There could be situations where many services are changed in a row which
would cause k_sem_take to block on the second change, but if the calling
thread is actually the RX thread then this will deadlock since the RX
thread is the one processing the confirmations of indications and it is
blocked k_sem_give is never called.

To solve this the services changes are now offloaded to the system wq
and the code will attempt to consolidate the range being changed so only
one indication is send. If for some reason another changes is caused
while confirmation is pending we just reschedule it to run later to avoid
blocking the system wq in the same way.

Signed-off-by: Luiz Augusto von Dentz <luiz.von.dentz@intel.com>