### PR TITLE
Fix samples/net/wpanusb/test_15_4 to only build on platforms that have support features

### DIFF
--- a/boards/x86/arduino_101/arduino_101.yaml
+++ b/boards/x86/arduino_101/arduino_101.yaml
@@ -5,3 +5,5 @@ arch: x86
 toolchain:
   - zephyr
   - issm
+supported:
+  - usb_device

--- a/boards/x86/panther/panther.yaml
+++ b/boards/x86/panther/panther.yaml
@@ -5,3 +5,5 @@ arch: x86
 toolchain:
   - zephyr
   - issm
+supported:
+  - usb_device

--- a/boards/x86/quark_se_c1000_devboard/quark_se_c1000_devboard.yaml
+++ b/boards/x86/quark_se_c1000_devboard/quark_se_c1000_devboard.yaml
@@ -7,3 +7,4 @@ toolchain:
   - issm
 supported:
   - ieee802154
+  - usb_device

--- a/boards/x86/tinytile/tinytile.yaml
+++ b/boards/x86/tinytile/tinytile.yaml
@@ -5,3 +5,5 @@ arch: x86
 toolchain:
   - zephyr
   - issm
+supported:
+  - usb_device

--- a/samples/bluetooth/hci_usb/sample.yaml
+++ b/samples/bluetooth/hci_usb/sample.yaml
@@ -6,3 +6,4 @@ tests:
         build_only: true
         platform_whitelist: quark_se_c1000_devboard
         tags: usb bluetooth
+        depends_on: usb_device

--- a/samples/net/wpan_serial/sample.yaml
+++ b/samples/net/wpan_serial/sample.yaml
@@ -6,3 +6,4 @@ tests:
         build_only: true
         platform_whitelist: quark_se_c1000_devboard
         tags: usb
+        depends_on: usb_device

--- a/samples/net/wpanusb/sample.yaml
+++ b/samples/net/wpanusb/sample.yaml
@@ -5,4 +5,4 @@ tests:
 - test_15_4:
         build_only: true
         tags: net ieee802154 usb
-        depends_on: ieee802154
+        depends_on: ieee802154 usb_device

--- a/samples/subsys/usb/cdc_acm/sample.yaml
+++ b/samples/subsys/usb/cdc_acm/sample.yaml
@@ -6,3 +6,4 @@ tests:
         build_only: true
         platform_whitelist: quark_se_c1000_devboard
         tags: usb
+        depends_on: usb_device

--- a/samples/subsys/usb/console/sample.yaml
+++ b/samples/subsys/usb/console/sample.yaml
@@ -6,3 +6,4 @@ tests:
         build_only: true
         platform_whitelist: arduino_101
         tags: usb
+        depends_on: usb_device

--- a/samples/subsys/usb/dfu/sample.yaml
+++ b/samples/subsys/usb/dfu/sample.yaml
@@ -6,3 +6,4 @@ tests:
         build_only: true
         platform_whitelist: quark_se_c1000_devboard
         tags: usb
+        depends_on: usb_device

--- a/samples/subsys/usb/webusb/sample.yaml
+++ b/samples/subsys/usb/webusb/sample.yaml
@@ -6,3 +6,4 @@ tests:
         build_only: true
         platform_whitelist: quark_se_c1000_devboard
         tags: usb
+        depends_on: usb_device

--- a/scripts/sanitycheck
+++ b/scripts/sanitycheck
@@ -1363,8 +1363,10 @@ class TestSuite:
                     if set(plat.ignore_tags) & tc.tags:
                         continue
 
-                    if tc.depends_on and not tc.depends_on.intersection(set(plat.supported)):
-                        continue
+                    if tc.depends_on:
+                        dep_intersection = tc.depends_on.intersection(set(plat.supported))
+                        if dep_intersection != set(tc.depends_on):
+                            continue
 
                     if plat.flash < tc.min_flash:
                         continue
@@ -1485,9 +1487,11 @@ class TestSuite:
                         discards[instance] = "Not enough RAM"
                         continue
 
-                    if tc.depends_on and not tc.depends_on.intersection(set(plat.supported)):
-                        discards[instance] = "No hardware support"
-                        continue
+                    if tc.depends_on:
+                        dep_intersection = tc.depends_on.intersection(set(plat.supported))
+                        if dep_intersection != set(tc.depends_on):
+                            discards[instance] = "No hardware support"
+                            continue
 
                     if plat.flash< tc.min_flash:
                         discards[instance] = "Not enough FLASH"


### PR DESCRIPTION
wpanusb/test_15_4 requires both usb and ieee802154 support - we are currently trying to build it on some platforms that only meet the ieee802154 requirement.  To fix this we introduce a usb_device tag into the yaml and fixup an issue with sanitycheck's depends_on checking.