### PR TITLE
Fix call sites of net_context_accept to use K_NO_WAIT not 0

### DIFF
--- a/drivers/console/telnet_console.c
+++ b/drivers/console/telnet_console.c
@@ -484,7 +484,7 @@ static void telnet_setup_server(struct net_context **ctx, sa_family_t family,
 		goto error;
 	}
 
-	if (net_context_accept(*ctx, telnet_accept, 0, NULL)) {
+	if (net_context_accept(*ctx, telnet_accept, K_NO_WAIT, NULL)) {
 		SYS_LOG_ERR("Cannot accept");
 		goto error;
 	}

--- a/samples/bluetooth/ipsp/src/main.c
+++ b/samples/bluetooth/ipsp/src/main.c
@@ -312,7 +312,7 @@ static void setup_tcp_accept(struct net_context *tcp_recv6)
 {
 	int ret;
 
-	ret = net_context_accept(tcp_recv6, tcp_accepted, 0, NULL);
+	ret = net_context_accept(tcp_recv6, tcp_accepted, K_NO_WAIT, NULL);
 	if (ret < 0) {
 		printk("Cannot receive IPv6 TCP packets (%d)", ret);
 	}

--- a/samples/net/zperf/src/zperf_tcp_receiver.c
+++ b/samples/net/zperf/src/zperf_tcp_receiver.c
@@ -192,7 +192,7 @@ static void zperf_tcp_rx_thread(int port)
 			return;
 		}
 
-		ret = net_context_accept(context6, tcp_accepted, 0, NULL);
+		ret = net_context_accept(context6, tcp_accepted, K_NO_WAIT, NULL);
 		if (ret < 0) {
 			printk(TAG "Cannot receive IPv6 TCP packets (%d)", ret);
 			return;
@@ -217,7 +217,7 @@ static void zperf_tcp_rx_thread(int port)
 			return;
 		}
 
-		ret = net_context_accept(context4, tcp_accepted, 0, NULL);
+		ret = net_context_accept(context4, tcp_accepted, K_NO_WAIT, NULL);
 		if (ret < 0) {
 			printk(TAG "Cannot receive IPv4 TCP packets (%d)", ret);
 			return;

--- a/subsys/net/lib/http/http_server.c
+++ b/subsys/net/lib/http/http_server.c
@@ -777,7 +777,7 @@ static int set_net_ctx(struct http_server_ctx *http_ctx,
 		goto out;
 	}
 
-	ret = net_context_accept(ctx, accept_cb, 0, http_ctx);
+	ret = net_context_accept(ctx, accept_cb, K_NO_WAIT, http_ctx);
 	if (ret < 0) {
 		NET_ERR("Cannot accept context (%d)", ret);
 		goto out;

--- a/tests/net/context/src/main.c
+++ b/tests/net/context/src/main.c
@@ -449,7 +449,7 @@ static bool net_ctx_accept_v6(void)
 {
 	int ret;
 
-	ret = net_context_accept(udp_v6_ctx, accept_cb, 0,
+	ret = net_context_accept(udp_v6_ctx, accept_cb, K_NO_WAIT,
 				 INT_TO_POINTER(AF_INET6));
 	if (ret != -EINVAL || cb_failure) {
 		TC_ERROR("Context accept IPv6 UDP test failed (%d)\n", ret);
@@ -463,7 +463,7 @@ static bool net_ctx_accept_v4(void)
 {
 	int ret;
 
-	ret = net_context_accept(udp_v4_ctx, accept_cb, 0,
+	ret = net_context_accept(udp_v4_ctx, accept_cb, K_NO_WAIT,
 				 INT_TO_POINTER(AF_INET));
 	if (ret != -EINVAL || cb_failure) {
 		TC_ERROR("Context accept IPv4 UDP test failed (%d)\n", ret);

--- a/tests/net/tcp/src/main.c
+++ b/tests/net/tcp/src/main.c
@@ -1524,7 +1524,7 @@ static bool test_init_tcp_accept(void)
 		return false;
 	}
 
-	ret = net_context_accept(reply_v6_ctx, accept_v6_cb, 0,
+	ret = net_context_accept(reply_v6_ctx, accept_v6_cb, K_NO_WAIT,
 				 INT_TO_POINTER(AF_INET6));
 	if (ret) {
 		TC_ERROR("Context accept v6 test failed (%d)\n", ret);
@@ -1537,7 +1537,7 @@ static bool test_init_tcp_accept(void)
 		return false;
 	}
 
-	ret = net_context_accept(reply_v4_ctx, accept_v4_cb, 0,
+	ret = net_context_accept(reply_v4_ctx, accept_v4_cb, K_NO_WAIT,
 				 INT_TO_POINTER(AF_INET));
 	if (ret) {
 		TC_ERROR("Context accept v4 test failed (%d)\n", ret);


### PR DESCRIPTION
Signed-off-by: Geoff Gustafson <geoff@linux.intel.com>