### PR TITLE
boards: arm: doc: Add I2C feature and serial port section

### DIFF
--- a/boards/arm/96b_carbon/doc/96b_carbon.rst
+++ b/boards/arm/96b_carbon/doc/96b_carbon.rst
@@ -69,6 +69,8 @@ features:
 +-----------+------------+-------------------------------------+
 | SPI       | on-chip    | spi                                 |
 +-----------+------------+-------------------------------------+
+| I2C       | on-chip    | i2c                                 |
++-----------+------------+-------------------------------------+
 
 More details about the board can be found at `96Boards website`_.
 
@@ -171,6 +173,22 @@ System Clock
 
 STM32F4 has two external oscillators. The frequency of the slow clock is
 32.768 kHz. The frequency of the main clock is 16 MHz.
+
+Serial Port
+===========
+
+96Boards Carbon board has up to 4 U(S)ARTs. The Zephyr console output is
+assigned to USART1. Default settings are 115200 8N1.
+
+I2C
+===
+
+96Boards Carbon board has up to 2 I2Cs. The default I2C mapping for Zephyr is:
+
+- I2C1_SCL : PB6
+- I2C1_SDA : PB7
+- I2C2_SCL : PB10
+- I2C2_SDA : PB3
 
 Flashing Zephyr onto 96Boards Carbon
 ************************************

--- a/boards/arm/nucleo_f401re/doc/nucleof401re.rst
+++ b/boards/arm/nucleo_f401re/doc/nucleof401re.rst
@@ -77,6 +77,8 @@ The Zephyr nucleo_401re board configuration supports the following hardware feat
 +-----------+------------+-------------------------------------+
 | PWM       | on-chip    | pwm                                 |
 +-----------+------------+-------------------------------------+
+| I2C       | on-chip    | i2c                                 |
++-----------+------------+-------------------------------------+
 
 Other hardware features are not yet supported on Zephyr porting.
 
@@ -129,6 +131,13 @@ Serial Port
 Nucleo F401RE board has 3 UARTs. The Zephyr console output is assigned to UART2.
 Default settings are 115200 8N1.
 
+I2C
+===
+
+Nucleo F401RE board has up to 3 I2Cs. The default I2C mapping for Zephyr is:
+
+- I2C1_SCL : PB8
+- I2C1_SDA : PB9
 
 Programming and Debugging
 *************************

--- a/boards/arm/olimexino_stm32/doc/olimexino_stm32.rst
+++ b/boards/arm/olimexino_stm32/doc/olimexino_stm32.rst
@@ -41,6 +41,8 @@ hardware features:
 +-----------+------------+----------------------+
 | GPIO      | on-chip    | gpio                 |
 +-----------+------------+----------------------+
+| I2C       | on-chip    | i2c                  |
++-----------+------------+----------------------+
 
 Other hardware features are not supported by the Zephyr kernel.
 
@@ -290,6 +292,20 @@ OLIMEXINO-STM32 has two external oscillators. The frequency of
 the slow clock is 32.768 kHz. The frequency of the main clock
 is 8 MHz. The processor can setup HSE to drive the master clock,
 which can be set as high as 72 MHz.
+
+Serial Port
+===========
+
+OLIMEXINO-STM32 board has up to 3 U(S)ARTs. The Zephyr console output is
+assigned to USART1. Default settings are 115200 8N1.
+
+I2C
+===
+
+OLIMEXINO-STM32 board has up to 1 I2C. The default I2C mapping for Zephyr is:
+
+- I2C2_SCL : PB10
+- I2C2_SDA : PB11
 
 Jumpers
 =======


### PR DESCRIPTION
This patch add I2C to supported features of 96b_carbon,
nucleof401re and olimexino_stm32.

It also adds serial port section to 96b_carbon and olimexino_stm32

Signed-off-by: Yannis Damigos <giannis.damigos@gmail.com>