### PR TITLE
net: bt: Check return of bt_conn_get_info

### DIFF
--- a/subsys/net/ip/l2/bluetooth.c
+++ b/subsys/net/ip/l2/bluetooth.c
@@ -119,7 +119,11 @@ static void ipsp_connected(struct bt_l2cap_chan *chan)
 	char dst[BT_ADDR_LE_STR_LEN];
 #endif
 
-	bt_conn_get_info(chan->conn, &info);
+	if (bt_conn_get_info(chan->conn, &info) < 0) {
+		NET_ERR("Unable to get connection info");
+		bt_l2cap_chan_disconnect(chan);
+		return;
+	}
 
 #if defined(CONFIG_NET_DEBUG_L2_BLUETOOTH)
 	bt_addr_le_to_str(info.le.src, src, sizeof(src));


### PR DESCRIPTION
This fixes coverity CID 171565 which may be valid in case of the
connection is not properly setup, or its memory is corrupted, it
may cause use of invalid addresses to be set using
net_if_set_link_addr.

Jira: ZEP-2344
Signed-off-by: Luiz Augusto von Dentz <luiz.von.dentz@intel.com>