### PR TITLE
net: Fix NULL pointer access

### DIFF
--- a/subsys/net/ip/connection.c
+++ b/subsys/net/ip/connection.c
@@ -688,8 +688,8 @@ int net_conn_register(enum net_ip_protocol proto,
 
 			NET_DBG("[%d/%d/%u/0x%02x] remote %p/%s/%u "
 				"local %p/%s/%u cb %p ud %p",
-				i, local_addr->family, proto, rank,
-				remote_addr, dst, remote_port,
+				i, local_addr ? local_addr->family : AF_UNSPEC,
+				proto, rank, remote_addr, dst, remote_port,
 				local_addr, src, local_port,
 				cb, user_data);
 		} while (0);

--- a/subsys/net/ip/icmpv6.c
+++ b/subsys/net/ip/icmpv6.c
@@ -101,7 +101,7 @@ static inline void setup_ipv6_header(struct net_pkt *pkt, u16_t extra_len,
 
 	/* ICMPv6 header has 4 unused bytes that must be zero, RFC 4443 ch 3.1
 	 */
-	net_pkt_write(pkt, frag, pos, &pos, 4, (u8_t *)unused, PKT_WAIT_TIME);
+	net_pkt_write(pkt, frag, pos, &pos, 4, (u8_t *)&unused, PKT_WAIT_TIME);
 }
 
 #if defined(CONFIG_NET_DEBUG_ICMPV6)


### PR DESCRIPTION
The networking code was accessing NULL pointer which it should
not do.

Jira: ZEP-2367

Signed-off-by: Jukka Rissanen <jukka.rissanen@linux.intel.com>