### PR TITLE
clock_control: nRF5x: Select 251-500ppm as default for 32kHz RCOSC

### DIFF
--- a/drivers/clock_control/Kconfig.nrf5
+++ b/drivers/clock_control/Kconfig.nrf5
@@ -51,6 +51,7 @@ endchoice
 
 choice
 	prompt "32KHz clock accuracy"
+	default CLOCK_CONTROL_NRF5_K32SRC_500PPM if CLOCK_CONTROL_NRF5_K32SRC_RC
 	default CLOCK_CONTROL_NRF5_K32SRC_20PPM
 	depends on CLOCK_CONTROL_NRF5
 


### PR DESCRIPTION
Frequency tolerance for LFRC after calibration for nRF5x
Series ICs is between 251 and 500 ppm as per Product
Specification. For more details refer to:
http://infocenter.nordicsemi.com/

Signed-off-by: Vinayak Kariappa Chettimada <vich@nordicsemi.no>