### PR TITLE
doc: fix wiki board references in non .rst files

### DIFF
--- a/samples/net/mbedtls_sslclient/README
+++ b/samples/net/mbedtls_sslclient/README
@@ -103,5 +103,5 @@ References
 ==========
 
 [1] https://www.zephyrproject.org/doc/getting_started/getting_started.html
-[2] https://wiki.zephyrproject.org/view/Galileo_Gen1_Gen2
+[2] https://www.zephyrproject.org/doc/boards/x86/galileo/doc/galileo.html
 [3] https://tls.mbed.org/

--- a/samples/subsys/usb/console/README.txt
+++ b/samples/subsys/usb/console/README.txt
@@ -17,8 +17,8 @@ trying to access the device in the background.
 
 Building and Running Project:
 
-Refer to https://wiki.zephyrproject.org/view/Arduino_101 for details on flashing
-the image into an Arduno 101.
+Refer to https://www.zephyrproject.org/doc/boards/x86/arduino_101/doc/board.html
+for details on flashing the image into an Arduno 101.
 
 
 Sample Output:

--- a/samples/subsys/usb/mass/README.txt
+++ b/samples/subsys/usb/mass/README.txt
@@ -21,8 +21,8 @@ The RAM Disk config should run out of the box.
 
 Building and Running Project:
 
-Refer to https://wiki.zephyrproject.org/view/Arduino_101 for details on flashing
-the image into an Arduino 101.
+Refer to https://www.zephyrproject.org/doc/boards/x86/arduino_101/doc/board.html
+for details on flashing the image into an Arduino 101.
 
 --------------------------------------------------------------------------------
 

--- a/samples/subsys/usb/webusb/README.txt
+++ b/samples/subsys/usb/webusb/README.txt
@@ -29,8 +29,9 @@ real usecase, implement applications based on the WebUSB API.
 Building and flashing:
 ----------------------
 
-Refer to https://wiki.zephyrproject.org/view/Arduino_101 for details on
-building and flashing the image into an Arduino 101.
+Refer to
+https://www.zephyrproject.org/doc/boards/x86/arduino_101/doc/board.html
+for details on building and flashing the image into an Arduino 101.
 
 Testing with latest Google Chrome on host
 -----------------------------------------

--- a/tests/bluetooth/tester/README
+++ b/tests/bluetooth/tester/README
@@ -40,7 +40,7 @@ to control tester application.
 Building and running on Arduino 101:
 
 Arduino 101 is equipped with Nordic nRF51 Bluetooth LE controller.
-Please refer to the Zephyr Project wikis [1] to see how to build and flash the
+Please refer to the Zephyr Project docs [1] to see how to build and flash the
 controller with the HCI Bluetooth LE firmware.
 
 Next, build and flash tester application:
@@ -55,4 +55,4 @@ USB port.
 Use serial client, e.g. PUTTY to communicate over the serial port
 (typically /dev/ttyUSBx) with the tester using BTP.
 
-[1] https://wiki.zephyrproject.org/view/Arduino_101#Bluetooth_firmware_for_the_Arduino_101
+[1] https://www.zephyrproject.org/doc/boards/x86/arduino_101/doc/board.html#flashing-the-bluetooth-core

--- a/tests/net/lib/mqtt_packet/README
+++ b/tests/net/lib/mqtt_packet/README
@@ -23,7 +23,7 @@ Build and Run
   sudo dfu-util -a x86_app -D outdir/arduino_101/zephyr.bin
 
   For more information about this board, see:
-  https://wiki.zephyrproject.org/view/Arduino_101
+  https://www.zephyrproject.org/doc/boards/x86/arduino_101/doc/board.html
 
 * NXP Freedom-K64F (frdm-k64f)
 


### PR DESCRIPTION
Some README files referenced wiki articles that have been
moved to the doc area on the website.

Fixes #668

Signed-off-by: David B. Kinder <david.b.kinder@intel.com>