### PR TITLE
Bluetooth: controller: Map debug pins to P3 pin head on nRF5x DK

### DIFF
--- a/subsys/bluetooth/controller/Kconfig
+++ b/subsys/bluetooth/controller/Kconfig
@@ -375,6 +375,7 @@ config BT_CTLR_PROFILE_ISR
 
 config BT_CTLR_DEBUG_PINS
 	bool "Bluetooth Controller Debug Pins"
+	depends on BOARD_NRF51_PCA10028 || BOARD_NRF52_PCA10040 || BOARD_NRF52840_PCA10056
 	help
 	  Turn on debug GPIO toggling for the BLE Controller. This is useful
 	  when debugging with a logic analyzer or profiling certain sections of

--- a/subsys/bluetooth/controller/hal/nrf5/debug.h
+++ b/subsys/bluetooth/controller/hal/nrf5/debug.h
@@ -8,157 +8,202 @@
 #ifndef _DEBUG_H_
 #define _DEBUG_H_
 
+#ifdef CONFIG_BT_CTLR_DEBUG_PINS
+#if defined(CONFIG_BOARD_NRF52840_PCA10056)
+#define DEBUG_PORT       NRF_P1
+#define DEBUG_PIN0       BIT(1)
+#define DEBUG_PIN1       BIT(2)
+#define DEBUG_PIN2       BIT(3)
+#define DEBUG_PIN3       BIT(4)
+#define DEBUG_PIN4       BIT(5)
+#define DEBUG_PIN5       BIT(6)
+#define DEBUG_PIN6       BIT(7)
+#define DEBUG_PIN7       BIT(8)
+#define DEBUG_PIN8       BIT(10)
+#define DEBUG_PIN9       BIT(11)
+#elif defined(CONFIG_BOARD_NRF52_PCA10040)
+#define DEBUG_PORT       NRF_GPIO
+#define DEBUG_PIN0       BIT(11)
+#define DEBUG_PIN1       BIT(12)
+#define DEBUG_PIN2       BIT(13)
+#define DEBUG_PIN3       BIT(14)
+#define DEBUG_PIN4       BIT(15)
+#define DEBUG_PIN5       BIT(16)
+#define DEBUG_PIN6       BIT(17)
+#define DEBUG_PIN7       BIT(18)
+#define DEBUG_PIN8       BIT(19)
+#define DEBUG_PIN9       BIT(20)
+#elif defined(CONFIG_BOARD_NRF51_PCA10028)
+#define DEBUG_PORT       NRF_GPIO
+#define DEBUG_PIN0       BIT(12)
+#define DEBUG_PIN1       BIT(13)
+#define DEBUG_PIN2       BIT(14)
+#define DEBUG_PIN3       BIT(15)
+#define DEBUG_PIN4       BIT(16)
+#define DEBUG_PIN5       BIT(17)
+#define DEBUG_PIN6       BIT(18)
+#define DEBUG_PIN7       BIT(19)
+#define DEBUG_PIN8       BIT(20)
+#define DEBUG_PIN9       BIT(23)
+#else
+#error BT_CTLR_DEBUG_PINS not supported on this board.
+#endif
+
+#define DEBUG_PIN_MASK   (DEBUG_PIN0 | DEBUG_PIN1 | DEBUG_PIN2 | DEBUG_PIN3 | \
+			  DEBUG_PIN4 | DEBUG_PIN5 | DEBUG_PIN6 | DEBUG_PIN7 | \
+			  DEBUG_PIN8 | DEBUG_PIN9)
+#define DEBUG_CLOSE_MASK (DEBUG_PIN3 | DEBUG_PIN4 | DEBUG_PIN5 | DEBUG_PIN6)
+
 /* below are some interesting macros referenced by controller
  * which can be defined to SoC's GPIO toggle to observe/debug the
  * controller's runtime behavior.
  */
-#ifdef CONFIG_BT_CTLR_DEBUG_PINS
 #define DEBUG_INIT()            do { \
-				NRF_GPIO->DIRSET = 0x03FF0000; \
-				NRF_GPIO->OUTCLR = 0x03FF0000; } \
+				DEBUG_PORT->DIRSET = DEBUG_PIN_MASK; \
+				DEBUG_PORT->OUTCLR = DEBUG_PIN_MASK; } \
 				while (0)
 
 #define DEBUG_CPU_SLEEP(flag)   do { \
 				if (flag) { \
-				NRF_GPIO->OUTSET = BIT(16); \
-				NRF_GPIO->OUTCLR = BIT(16); } \
+				DEBUG_PORT->OUTSET = DEBUG_PIN0; \
+				DEBUG_PORT->OUTCLR = DEBUG_PIN0; } \
 				else { \
-				NRF_GPIO->OUTCLR = BIT(16); \
-				NRF_GPIO->OUTSET = BIT(16); } \
+				DEBUG_PORT->OUTCLR = DEBUG_PIN0; \
+				DEBUG_PORT->OUTSET = DEBUG_PIN0; } \
 				} while (0)
 
 #define DEBUG_TICKER_ISR(flag)   do { \
 				if (flag) { \
-				NRF_GPIO->OUTCLR = BIT(17); \
-				NRF_GPIO->OUTSET = BIT(17); } \
+				DEBUG_PORT->OUTCLR = DEBUG_PIN1; \
+				DEBUG_PORT->OUTSET = DEBUG_PIN1; } \
 				else { \
-				NRF_GPIO->OUTSET = BIT(17); \
-				NRF_GPIO->OUTCLR = BIT(17); } \
+				DEBUG_PORT->OUTSET = DEBUG_PIN1; \
+				DEBUG_PORT->OUTCLR = DEBUG_PIN1; } \
 				} while (0)
 
 #define DEBUG_TICKER_TASK(flag)  do { \
 				if (flag) { \
-				NRF_GPIO->OUTCLR = BIT(17); \
-				NRF_GPIO->OUTSET = BIT(17); } \
+				DEBUG_PORT->OUTCLR = DEBUG_PIN1; \
+				DEBUG_PORT->OUTSET = DEBUG_PIN1; } \
 				else { \
-				NRF_GPIO->OUTSET = BIT(17); \
-				NRF_GPIO->OUTCLR = BIT(17); } \
+				DEBUG_PORT->OUTSET = DEBUG_PIN1; \
+				DEBUG_PORT->OUTCLR = DEBUG_PIN1; } \
 				} while (0)
 
 #define DEBUG_TICKER_JOB(flag)   do { \
 				if (flag) { \
-				NRF_GPIO->OUTCLR = BIT(18); \
-				NRF_GPIO->OUTSET = BIT(18); } \
+				DEBUG_PORT->OUTCLR = DEBUG_PIN2; \
+				DEBUG_PORT->OUTSET = DEBUG_PIN2; } \
 				else { \
-				NRF_GPIO->OUTSET = BIT(18); \
-				NRF_GPIO->OUTCLR = BIT(18); } \
+				DEBUG_PORT->OUTSET = DEBUG_PIN2; \
+				DEBUG_PORT->OUTCLR = DEBUG_PIN2; } \
 				} while (0)
 
 #define DEBUG_RADIO_ISR(flag)   do { \
 				if (flag) { \
-				NRF_GPIO->OUTCLR = BIT(23); \
-				NRF_GPIO->OUTSET = BIT(23); } \
+				DEBUG_PORT->OUTCLR = DEBUG_PIN7; \
+				DEBUG_PORT->OUTSET = DEBUG_PIN7; } \
 				else { \
-				NRF_GPIO->OUTSET = BIT(23); \
-				NRF_GPIO->OUTCLR = BIT(23); } \
+				DEBUG_PORT->OUTSET = DEBUG_PIN7; \
+				DEBUG_PORT->OUTCLR = DEBUG_PIN7; } \
 				} while (0)
 
 #define DEBUG_RADIO_XTAL(flag)  do { \
 				if (flag) { \
-				NRF_GPIO->OUTCLR = BIT(24); \
-				NRF_GPIO->OUTSET = BIT(24); } \
+				DEBUG_PORT->OUTCLR = DEBUG_PIN8; \
+				DEBUG_PORT->OUTSET = DEBUG_PIN8; } \
 				else { \
-				NRF_GPIO->OUTSET = BIT(24); \
-				NRF_GPIO->OUTCLR = BIT(24); } \
+				DEBUG_PORT->OUTSET = DEBUG_PIN8; \
+				DEBUG_PORT->OUTCLR = DEBUG_PIN8; } \
 				} while (0)
 
 #define DEBUG_RADIO_ACTIVE(flag)    do { \
 				if (flag) { \
-				NRF_GPIO->OUTCLR = BIT(25); \
-				NRF_GPIO->OUTSET = BIT(25); } \
+				DEBUG_PORT->OUTCLR = DEBUG_PIN9; \
+				DEBUG_PORT->OUTSET = DEBUG_PIN9; } \
 				else { \
-				NRF_GPIO->OUTSET = BIT(25); \
-				NRF_GPIO->OUTCLR = BIT(25); } \
+				DEBUG_PORT->OUTSET = DEBUG_PIN9; \
+				DEBUG_PORT->OUTCLR = DEBUG_PIN9; } \
 				} while (0)
 
 #define DEBUG_RADIO_CLOSE(flag)     do { \
 				if (flag) { \
-				NRF_GPIO->OUTCLR = 0x00000000; \
-				NRF_GPIO->OUTSET = 0x00000000; } \
+				DEBUG_PORT->OUTCLR = 0x00000000; \
+				DEBUG_PORT->OUTSET = 0x00000000; } \
 				else { \
-				NRF_GPIO->OUTCLR = 0x00780000; } \
+				DEBUG_PORT->OUTCLR = DEBUG_CLOSE_MASK; } \
 				} while (0)
 
 #define DEBUG_RADIO_PREPARE_A(flag) do { \
 				if (flag) { \
-				NRF_GPIO->OUTCLR = BIT(19); \
-				NRF_GPIO->OUTSET = BIT(19); } \
+				DEBUG_PORT->OUTCLR = DEBUG_PIN3; \
+				DEBUG_PORT->OUTSET = DEBUG_PIN3; } \
 				else { \
-				NRF_GPIO->OUTCLR = BIT(19); \
-				NRF_GPIO->OUTSET = BIT(19); } \
+				DEBUG_PORT->OUTCLR = DEBUG_PIN3; \
+				DEBUG_PORT->OUTSET = DEBUG_PIN3; } \
 				} while (0)
 
 #define DEBUG_RADIO_START_A(flag)   do { \
 				if (flag) { \
-				NRF_GPIO->OUTCLR = BIT(19); \
-				NRF_GPIO->OUTSET = BIT(19); } \
+				DEBUG_PORT->OUTCLR = DEBUG_PIN3; \
+				DEBUG_PORT->OUTSET = DEBUG_PIN3; } \
 				else { \
-				NRF_GPIO->OUTCLR = BIT(19); \
-				NRF_GPIO->OUTSET = BIT(19); } \
+				DEBUG_PORT->OUTCLR = DEBUG_PIN3; \
+				DEBUG_PORT->OUTSET = DEBUG_PIN3; } \
 				} while (0)
 
 #define DEBUG_RADIO_PREPARE_S(flag) do { \
 				if (flag) { \
-				NRF_GPIO->OUTCLR = BIT(20); \
-				NRF_GPIO->OUTSET = BIT(20); } \
+				DEBUG_PORT->OUTCLR = DEBUG_PIN4; \
+				DEBUG_PORT->OUTSET = DEBUG_PIN4; } \
 				else { \
-				NRF_GPIO->OUTCLR = BIT(20); \
-				NRF_GPIO->OUTSET = BIT(20); } \
+				DEBUG_PORT->OUTCLR = DEBUG_PIN4; \
+				DEBUG_PORT->OUTSET = DEBUG_PIN4; } \
 				} while (0)
 
 #define DEBUG_RADIO_START_S(flag)   do { \
 				if (flag) { \
-				NRF_GPIO->OUTCLR = BIT(20); \
-				NRF_GPIO->OUTSET = BIT(20); } \
+				DEBUG_PORT->OUTCLR = DEBUG_PIN4; \
+				DEBUG_PORT->OUTSET = DEBUG_PIN4; } \
 				else { \
-				NRF_GPIO->OUTCLR = BIT(20); \
-				NRF_GPIO->OUTSET = BIT(20); } \
+				DEBUG_PORT->OUTCLR = DEBUG_PIN4; \
+				DEBUG_PORT->OUTSET = DEBUG_PIN4; } \
 				} while (0)
 
 #define DEBUG_RADIO_PREPARE_O(flag) do { \
 				if (flag) { \
-				NRF_GPIO->OUTCLR = BIT(21); \
-				NRF_GPIO->OUTSET = BIT(21); } \
+				DEBUG_PORT->OUTCLR = DEBUG_PIN5; \
+				DEBUG_PORT->OUTSET = DEBUG_PIN5; } \
 				else { \
-				NRF_GPIO->OUTCLR = BIT(21); \
-				NRF_GPIO->OUTSET = BIT(21); } \
+				DEBUG_PORT->OUTCLR = DEBUG_PIN5; \
+				DEBUG_PORT->OUTSET = DEBUG_PIN5; } \
 				} while (0)
 
 #define DEBUG_RADIO_START_O(flag)   do { \
 				if (flag) { \
-				NRF_GPIO->OUTCLR = BIT(21); \
-				NRF_GPIO->OUTSET = BIT(21); } \
+				DEBUG_PORT->OUTCLR = DEBUG_PIN5; \
+				DEBUG_PORT->OUTSET = DEBUG_PIN5; } \
 				else { \
-				NRF_GPIO->OUTCLR = BIT(21); \
-				NRF_GPIO->OUTSET = BIT(21); } \
+				DEBUG_PORT->OUTCLR = DEBUG_PIN5; \
+				DEBUG_PORT->OUTSET = DEBUG_PIN5; } \
 				} while (0)
 
 #define DEBUG_RADIO_PREPARE_M(flag) do { \
 				if (flag) { \
-				NRF_GPIO->OUTCLR = BIT(22); \
-				NRF_GPIO->OUTSET = BIT(22); } \
+				DEBUG_PORT->OUTCLR = DEBUG_PIN6; \
+				DEBUG_PORT->OUTSET = DEBUG_PIN6; } \
 				else { \
-				NRF_GPIO->OUTCLR = BIT(22); \
-				NRF_GPIO->OUTSET = BIT(22); } \
+				DEBUG_PORT->OUTCLR = DEBUG_PIN6; \
+				DEBUG_PORT->OUTSET = DEBUG_PIN6; } \
 				} while (0)
 
 #define DEBUG_RADIO_START_M(flag)   do { \
 				if (flag) { \
-				NRF_GPIO->OUTCLR = BIT(22); \
-				NRF_GPIO->OUTSET = BIT(22); } \
+				DEBUG_PORT->OUTCLR = DEBUG_PIN6; \
+				DEBUG_PORT->OUTSET = DEBUG_PIN6; } \
 				else { \
-				NRF_GPIO->OUTCLR = BIT(22); \
-				NRF_GPIO->OUTSET = BIT(22); } \
+				DEBUG_PORT->OUTCLR = DEBUG_PIN6; \
+				DEBUG_PORT->OUTSET = DEBUG_PIN6; } \
 				} while (0)
 
 #else


### PR DESCRIPTION
Updated debug pin mapping so that the outputs are on P3 pin
head on all nRF5x Development Kits.

Signed-off-by: Vinayak Kariappa Chettimada <vich@nordicsemi.no>