### PR TITLE
Bluetooth: controller: Fix regression in WL filter population

### DIFF
--- a/subsys/bluetooth/controller/ll_sw/ll_filter.c
+++ b/subsys/bluetooth/controller/ll_sw/ll_filter.c
@@ -326,7 +326,7 @@ static void filter_wl_update(void)
 	for (i = 0; i < WL_SIZE; i++) {
 		int j = wl[i].rl_idx;
 
-		if (!rl_enable || j < ARRAY_SIZE(rl) || !rl[j].pirk ||
+		if (!rl_enable || j >= ARRAY_SIZE(rl) || !rl[j].pirk ||
 		    rl[j].dev) {
 			filter_insert(&wl_filter, i, wl[i].id_addr_type,
 				      wl[i].id_addr.val);


### PR DESCRIPTION
Erroneous check conversion triggered a regression when populating the
whitelist filter.

Signed-off-by: Carles Cufi <carles.cufi@nordicsemi.no>