### PR TITLE
dts: i2c: fix build issue by defaulting HAS_DTS_I2C to n

### DIFF
--- a/kernel/Kconfig
+++ b/kernel/Kconfig
@@ -17,6 +17,7 @@ config HAS_DTS
 
 config HAS_DTS_I2C
 	bool "I2C uses Device Tree"
+	default n
 	depends on HAS_DTS
 	help
 	This option specifies that the target platform supports device tree


### PR DESCRIPTION
The fact that HAS_DTS_I2C has no default is causing prompting when building Zephyr on other targets with DTS. Give it a default (n) to let builds complete as usual.