### PR TITLE
Additional flash partitions

### DIFF
--- a/dts/arm/96b_carbon.dts
+++ b/dts/arm/96b_carbon.dts
@@ -31,3 +31,45 @@
 &i2c1 {
 	status = "ok";
 };
+
+&flash0 {
+	/*
+	 * If chosen's zephyr,code-partition
+	 * is unset, the image will be linked
+	 * into the entire flash device.  If
+	 * it points to an individual
+	 * partition, the code will be linked
+	 * to, and restricted to that
+	 * partition.
+	 */
+	partitions {
+		compatible = "fixed-partitions";
+		#address-cells = <1>;
+		#size-cells = <1>;
+
+		boot_partition: partition@0 {
+			label = "mcuboot";
+			reg = <0x00000000 0x00008000>;
+			read-only;
+		};
+
+		/*
+		 * The flash starting at offset 0x00008000 and ending at
+		 * offset 0x0001ffff (sectors 2 through 4) is reserved for
+		 * use by the application.
+		 */
+
+		slot0_partition: partition@20000 {
+			label = "image-0";
+			reg = <0x00020000 0x00020000>;
+		};
+		slot1_partition: partition@40000 {
+			label = "image-1";
+			reg = <0x00040000 0x00020000>;
+		};
+		scratch_partition: partition@60000 {
+			label = "image-scratch";
+			reg = <0x00060000 0x00020000>;
+		};
+	};
+};

--- a/dts/arm/96b_nitrogen.dts
+++ b/dts/arm/96b_nitrogen.dts
@@ -24,3 +24,48 @@
 	current-speed = <115200>;
 	status = "ok";
 };
+
+&flash0 {
+	/*
+	 * If chosen's zephyr,code-partition
+	 * is unset, the image will be linked
+	 * into the entire flash device.  If
+	 * it points to an individual
+	 * partition, the code will be linked
+	 * to, and restricted to that
+	 * partition.
+	 */
+	partitions {
+		compatible = "fixed-partitions";
+		#address-cells = <1>;
+		#size-cells = <1>;
+
+		boot_partition: partition@0 {
+			label = "mcuboot";
+			reg = <0x00000000 0x8000>;
+		};
+		slot0_partition: partition@8000 {
+			label = "image-0";
+			reg = <0x00008000 0x34000>;
+		};
+		slot1_partition: partition@3c000 {
+			label = "image-1";
+			reg = <0x0003c000 0x34000>;
+		};
+		scratch_partition: partition@70000 {
+			label = "image-scratch";
+			reg = <0x00070000 0xD000>;
+		};
+
+		/*
+		 * The flash starting at 0x0007d000 and ending at
+		 * 0x0007ffff (sectors 125-127) is reserved for use
+		 * by the application.
+		 */
+
+		app_state_partition: partition@7d000 {
+			label = "application-state";
+			reg = <0x0007d000 0x3000>;
+		};
+	};
+};

--- a/dts/arm/frdm_k64f.dts
+++ b/dts/arm/frdm_k64f.dts
@@ -39,3 +39,42 @@
 	current-speed = <115200>;
 };
 #endif
+
+&flash0 {
+	/*
+	 * If chosen's zephyr,code-partition
+	 * is unset, the image will be linked
+	 * into the entire flash device.  If
+	 * it points to an individual
+	 * partition, the code will be linked
+	 * to, and restricted to that
+	 * partition.
+	 */
+	partitions {
+		compatible = "fixed-partitions";
+		#address-cells = <1>;
+		#size-cells = <1>;
+
+		boot_partition: partition@0 {
+			label = "mcuboot";
+			reg = <0x00000000 0x00010000>;
+			read-only;
+		};
+		app_state_partition: partition@10000 {
+			label = "application-state";
+			reg = <0x00010000 0x00010000>;
+		};
+		slot0_partition: partition@20000 {
+			label = "image-0";
+			reg = <0x00020000 0x00060000>;
+		};
+		slot1_partition: partition@80000 {
+			label = "image-1";
+			reg = <0x00080000 0x00060000>;
+		};
+		scratch_partition: partition@e0000 {
+			label = "image-scratch";
+			reg = <0x000e0000 0x00020000>;
+		};
+	};
+};

--- a/dts/arm/frdm_k64f.dts
+++ b/dts/arm/frdm_k64f.dts
@@ -60,10 +60,13 @@
 			reg = <0x00000000 0x00010000>;
 			read-only;
 		};
-		app_state_partition: partition@10000 {
-			label = "application-state";
-			reg = <0x00010000 0x00010000>;
-		};
+
+		/*
+		 * The flash starting at 0x00010000 and ending at
+		 * 0x0001ffff (sectors 16-31) is reserved for use
+		 * by the application.
+		 */
+
 		slot0_partition: partition@20000 {
 			label = "image-0";
 			reg = <0x00020000 0x00060000>;

--- a/dts/arm/nrf52840_pca10056.dts
+++ b/dts/arm/nrf52840_pca10056.dts
@@ -24,3 +24,43 @@
 	current-speed = <115200>;
 	status = "ok";
 };
+
+&flash0 {
+	/*
+	 * If chosen's zephyr,code-partition
+	 * is unset, the image will be linked
+	 * into the entire flash device.  If
+	 * it points to an individual
+	 * partition, the code will be linked
+	 * to, and restricted to that
+	 * partition.
+	 */
+	partitions {
+		compatible = "fixed-partitions";
+		#address-cells = <1>;
+		#size-cells = <1>;
+
+		boot_partition: partition@0 {
+			label = "mcuboot";
+			reg = <0x000000000 0x00008000>;
+		};
+		slot0_partition: partition@8000 {
+			label = "image-0";
+			reg = <0x00008000 0x00006c000>;
+		};
+		slot1_partition: partition@74000 {
+			label = "image-1";
+			reg = <0x00074000 0x00006c000>;
+		};
+		scratch_partition: partition@e0000 {
+			label = "image-scratch";
+			reg = <0x000e0000 0x0001d000>;
+		};
+
+		/*
+		 * The flash starting at 0x000fd000 and ending at 0x000fffff
+		 * (sectors 253 through 255) is reserved for use by the
+		 * application.
+		 */
+	};
+};

--- a/dts/arm/nxp/nxp_k6x.dtsi
+++ b/dts/arm/nxp/nxp_k6x.dtsi
@@ -65,43 +65,6 @@
 
 			flash0: flash@0 {
 				reg = <0 0x100000>;
-
-				/*
-				 * If chosen's zephyr,code-partition
-				 * is unset, the image will be linked
-				 * into the entire flash device.  If
-				 * it points to an individual
-				 * partition, the code will be linked
-				 * to, and restricted to that
-				 * partition.
-				 */
-				partitions {
-					compatible = "fixed-partitions";
-					#address-cells = <1>;
-					#size-cells = <1>;
-
-					boot_partition: partition@0 {
-						label = "mcuboot";
-						reg = <0x00000000 0x00010000>;
-						read-only;
-					};
-					app_state_partition: partition@10000 {
-						label = "application-state";
-						reg = <0x00010000 0x00010000>;
-					};
-					slot0_partition: partition@20000 {
-						label = "image-0";
-						reg = <0x00020000 0x00060000>;
-					};
-					slot1_partition: partition@80000 {
-						label = "image-1";
-						reg = <0x00080000 0x00060000>;
-					};
-					scratch_partition: partition@e0000 {
-						label = "image-scratch";
-						reg = <0x000e0000 0x00020000>;
-					};
-				};
 			};
 		};
 


### PR DESCRIPTION
This series moves the NXP K6X flash partitions into the frdm_k64f board file, and alters the way the application state partition is handled there. It also adds analogous partition information for some other boards.

@jamike, @d3zd3z, @agross-linaro, how does this seem to you? We can do the same to dts/arm/nucleo_f401re.dts if it looks OK.