### PR TITLE
doc: update source tree structure documentation

### DIFF
--- a/doc/kernel/overview/source_tree.rst
+++ b/doc/kernel/overview/source_tree.rst
@@ -24,10 +24,16 @@ which are not described here.
     Board related code and configuration files.
 
 :file:`doc`
-    Zephyr documentation source files and tools.
+    Zephyr technical documentation source files and tools used to
+    generate the http://zephyrproject.org/doc web content.
 
 :file:`drivers`
     Device driver code.
+
+:file:`dts`
+    Device tree source (.dts) files used to describe non-discoverable
+    board-specific hardware details previously hard coded in the OS
+    source code.
 
 :file:`ext`
     Externally created code that has been integrated into Zephyr
@@ -54,13 +60,13 @@ which are not described here.
     Various programs and other files used to build and test Zephyr
     applications.
 
-:file:`tests`
-    Test code and benchmarks for Zephyr features.
-
 :file:`subsys`
     Subsystems of Zephyr, including:
+
     * USB device stack code.
     * Networking code, including the Bluetooth stack and networking stacks.
     * File system code.
     * Bluetooth host and controller
 
+:file:`tests`
+    Test code and benchmarks for Zephyr features.


### PR DESCRIPTION
New top-level dts/ folder and description added.

Fixed error in bullet list in subsys/ description (needed
a blank line before the list).

Alphabetized folder list (subsys/ was listed after tests/)

Signed-off-by: David B. Kinder <david.b.kinder@intel.com>