### PR TITLE
Bluetooth: controller: Allow devices not in resolving list

### DIFF
--- a/subsys/bluetooth/controller/ll_sw/ll_filter.c
+++ b/subsys/bluetooth/controller/ll_sw/ll_filter.c
@@ -421,7 +421,7 @@ bool ctrl_rl_allowed(u8_t id_addr_type, u8_t *id_addr, u8_t *rl_idx)
 		}
 	}
 
-	return false;
+	return true;
 }
 
 bool ctrl_rl_enabled(void)


### PR DESCRIPTION
Whenever not using the whitelist the resolving list is traversed to
verify that the device is allowed depending on its current privacy mode.
In the case where the device is not found by address in the resolving
list, allow the request to go through, since we are then dealing with an
unknown devices and the resolving list restrictions do not apply.

Signed-off-by: Carles Cufi <carles.cufi@nordicsemi.no>