### PR TITLE
net: ipv6: Fragmentation was accessing NULL pointer

### DIFF
--- a/subsys/net/ip/ipv6.c
+++ b/subsys/net/ip/ipv6.c
@@ -3325,7 +3325,9 @@ static int send_ipv6_fragment(struct net_if *iface,
 		pkt->frags = end;
 	}
 
-	end->frags = NULL;
+	if (end) {
+		end->frags = NULL;
+	}
 
 	memcpy(ipv6, pkt, sizeof(struct net_pkt));
 


### PR DESCRIPTION
When IPv6 fragments were sent, the last IPv6 fragmented packet
was accessing NULL pointer.

Signed-off-by: Jukka Rissanen <jukka.rissanen@linux.intel.com>