### PR TITLE
net: Fix connectivity issues if only UDP or TCP is enabled

### DIFF
--- a/subsys/net/ip/tcp.h
+++ b/subsys/net/ip/tcp.h
@@ -412,6 +412,7 @@ u16_t net_tcp_get_chksum(struct net_pkt *pkt, struct net_buf *frag);
 #define net_tcp_get_chksum(pkt, frag) (0)
 #define net_tcp_set_chksum(pkt, frag) NULL
 #define net_tcp_set_hdr(pkt, frag) NULL
+#define net_tcp_get_hdr(pkt, frag) NULL
 #endif
 
 #if defined(CONFIG_NET_TCP)

--- a/subsys/net/lib/app/net_app.c
+++ b/subsys/net/lib/app/net_app.c
@@ -116,10 +116,12 @@ void _net_app_received(struct net_context *net_ctx,
 				ctx->cb.close(ctx, status, ctx->user_data);
 			}
 
+#if defined(CONFIG_NET_TCP)
 			if (ctx->proto == IPPROTO_TCP) {
 				net_context_put(ctx->server.net_ctx);
 				ctx->server.net_ctx = NULL;
 			}
+#endif
 
 			return;
 		}
@@ -420,7 +422,11 @@ struct net_context *_net_app_select_net_ctx(struct net_app_ctx *ctx,
 #if defined(CONFIG_NET_APP_SERVER)
 	if (ctx->app_type == NET_APP_SERVER) {
 		if (ctx->proto == IPPROTO_TCP) {
+#if defined(CONFIG_NET_TCP)
 			return ctx->server.net_ctx;
+#else
+			return NULL;
+#endif
 		} else if (ctx->proto == IPPROTO_UDP) {
 			if (!dst) {
 				return ctx->default_ctx->ctx;
@@ -673,7 +679,7 @@ int net_app_close(struct net_app_ctx *ctx)
 		ctx->cb.close(ctx, 0, ctx->user_data);
 	}
 
-#if defined(CONFIG_NET_APP_SERVER)
+#if defined(CONFIG_NET_APP_SERVER) && defined(CONFIG_NET_TCP)
 	if (ctx->app_type == NET_APP_SERVER) {
 		ctx->server.net_ctx = NULL;
 	}


### PR DESCRIPTION
If either UDP or TCP is enabled but not both, then connectivity
fails. This was a side effect of commit 3604c391e ("net: udp:
Remove NET_UDP_HDR() macro and direct access to net_buf")

Jira: ZEP-2380

Signed-off-by: Jukka Rissanen <jukka.rissanen@linux.intel.com>