### PR TITLE
Bluetooth: controller: Fix to use correct anchor for scanner

### DIFF
--- a/subsys/bluetooth/controller/ll_sw/ctrl.c
+++ b/subsys/bluetooth/controller/ll_sw/ctrl.c
@@ -8595,10 +8595,19 @@ u32_t radio_scan_enable(u8_t type, u8_t init_addr_type, u8_t *init_addr,
 	}
 #if defined(CONFIG_BLUETOOTH_CONTROLLER_SCHED_ADVANCED)
 	else {
+		u32_t ticks_ref = 0;
+
 		sched_after_mstr_free_slot_get(RADIO_TICKER_USER_ID_APP,
 					       (ticks_slot_offset +
 						_radio.scanner.hdr.ticks_slot),
-					       &ticks_anchor, &us_offset);
+					       &ticks_ref, &us_offset);
+		/* Use the ticks_ref as scanner's anchor if a free time space
+		 * after any master role is available (indicated by a non-zero
+		 * us_offset value).
+		 */
+		if (us_offset) {
+			ticks_anchor = ticks_ref;
+		}
 	}
 #endif /* CONFIG_BLUETOOTH_CONTROLLER_SCHED_ADVANCED */
 

--- a/subsys/bluetooth/controller/ll_sw/ctrl.c
+++ b/subsys/bluetooth/controller/ll_sw/ctrl.c
@@ -4425,25 +4425,19 @@ static void event_stop(u32_t ticks_at_expire, u32_t remainder,
 	LL_ASSERT(!retval);
 }
 
-static u32_t event_common_prepare(u32_t ticks_at_expire,
-				  u32_t remainder,
-				  u32_t *ticks_xtal_to_start,
-				  u32_t *ticks_active_to_start,
-				  u32_t ticks_preempt_to_start,
-				  u8_t ticker_id,
-				  ticker_timeout_func ticker_timeout_fp,
-				  void *context)
+static void event_common_prepare(u32_t ticks_at_expire,
+				 u32_t remainder,
+				 u32_t *ticks_xtal_to_start,
+				 u32_t *ticks_active_to_start,
+				 u32_t ticks_preempt_to_start,
+				 u8_t ticker_id,
+				 ticker_timeout_func ticker_timeout_fp,
+				 void *context)
 {
 	u32_t ticker_status;
 	u32_t _ticks_xtal_to_start = *ticks_xtal_to_start;
 	u32_t _ticks_active_to_start = *ticks_active_to_start;
 	u32_t ticks_to_start;
-
-	/* Check for stale ticks_at_expire */
-	if (ticker_ticks_diff_get(ticker_ticks_now_get(), ticks_at_expire) >
-	    TICKER_US_TO_TICKS(RADIO_TICKER_START_PART_US)) {
-		return 1;
-	}
 
 	/* in case this event is short prepare, xtal to start duration will be
 	 * active to start duration.
@@ -4587,8 +4581,6 @@ static u32_t event_common_prepare(u32_t ticks_at_expire,
 		LL_ASSERT(!retval);
 	}
 #endif /* CONFIG_BLUETOOTH_CONTROLLER_XTAL_ADVANCED */
-
-	return 0;
 }
 
 static u8_t chan_sel_remap(u8_t *chan_map, u8_t chan_index)
@@ -4867,23 +4859,19 @@ static void adv_scan_configure(u8_t phy, u8_t flags)
 void radio_event_adv_prepare(u32_t ticks_at_expire, u32_t remainder,
 			     u16_t lazy, void *context)
 {
-	u32_t err;
-
 	ARG_UNUSED(lazy);
 	ARG_UNUSED(context);
 
 	DEBUG_RADIO_PREPARE_A(1);
 
 	LL_ASSERT(!_radio.ticker_id_prepare);
+	_radio.ticker_id_prepare = RADIO_TICKER_ID_ADV;
 
-	err = event_common_prepare(ticks_at_expire, remainder,
-				   &_radio.advertiser.hdr.ticks_xtal_to_start,
-				   &_radio.advertiser.hdr.ticks_active_to_start,
-				   _radio.advertiser.hdr.ticks_preempt_to_start,
-				   RADIO_TICKER_ID_ADV, event_adv, NULL);
-	if (!err) {
-		_radio.ticker_id_prepare = RADIO_TICKER_ID_ADV;
-	}
+	event_common_prepare(ticks_at_expire, remainder,
+			     &_radio.advertiser.hdr.ticks_xtal_to_start,
+			     &_radio.advertiser.hdr.ticks_active_to_start,
+			     _radio.advertiser.hdr.ticks_preempt_to_start,
+			     RADIO_TICKER_ID_ADV, event_adv, NULL);
 
 	DEBUG_RADIO_PREPARE_A(0);
 }
@@ -5096,25 +5084,19 @@ void event_adv_stop(u32_t ticks_at_expire, u32_t remainder, u16_t lazy,
 static void event_scan_prepare(u32_t ticks_at_expire, u32_t remainder,
 			      u16_t lazy, void *context)
 {
-	u32_t err;
-
 	ARG_UNUSED(lazy);
 	ARG_UNUSED(context);
 
 	DEBUG_RADIO_PREPARE_O(1);
 
 	LL_ASSERT(!_radio.ticker_id_prepare);
-
-	err = event_common_prepare(ticks_at_expire, remainder,
-				   &_radio.scanner.hdr.ticks_xtal_to_start,
-				   &_radio.scanner.hdr.ticks_active_to_start,
-				   _radio.scanner.hdr.ticks_preempt_to_start,
-				   RADIO_TICKER_ID_SCAN, event_scan, NULL);
-	if (err) {
-		goto skip;
-	}
-
 	_radio.ticker_id_prepare = RADIO_TICKER_ID_SCAN;
+
+	event_common_prepare(ticks_at_expire, remainder,
+			     &_radio.scanner.hdr.ticks_xtal_to_start,
+			     &_radio.scanner.hdr.ticks_active_to_start,
+			     _radio.scanner.hdr.ticks_preempt_to_start,
+			     RADIO_TICKER_ID_SCAN, event_scan, NULL);
 
 #if defined(CONFIG_BLUETOOTH_CONTROLLER_SCHED_ADVANCED)
 	/* calc next group in us for the anchor where first connection event
@@ -5151,7 +5133,6 @@ static void event_scan_prepare(u32_t ticks_at_expire, u32_t remainder,
 	}
 #endif /* CONFIG_BLUETOOTH_CONTROLLER_SCHED_ADVANCED */
 
-skip:
 	DEBUG_RADIO_PREPARE_O(0);
 }
 
@@ -6507,9 +6488,10 @@ static void event_connection_prepare(u32_t ticks_at_expire,
 				     struct connection *conn)
 {
 	u16_t event_counter;
-	u32_t err;
 
 	LL_ASSERT(!_radio.ticker_id_prepare);
+	_radio.ticker_id_prepare = RADIO_TICKER_ID_FIRST_CONNECTION +
+				   conn->handle;
 
 	/* Calc window widening */
 	if (conn->role) {
@@ -6643,22 +6625,17 @@ static void event_connection_prepare(u32_t ticks_at_expire,
 	}
 #endif /* CONFIG_BLUETOOTH_CONTROLLER_DATA_LENGTH */
 
+	/* Setup XTAL startup and radio active events */
+	event_common_prepare(ticks_at_expire, remainder,
+			     &conn->hdr.ticks_xtal_to_start,
+			     &conn->hdr.ticks_active_to_start,
+			     conn->hdr.ticks_preempt_to_start,
+			     (RADIO_TICKER_ID_FIRST_CONNECTION + conn->handle),
+			     conn->role ? event_slave : event_master,
+			     conn);
+
 	/* store the next event counter value */
 	conn->event_counter = event_counter + 1;
-
-	/* Setup XTAL startup and radio active events */
-	err = event_common_prepare(ticks_at_expire, remainder,
-				   &conn->hdr.ticks_xtal_to_start,
-				   &conn->hdr.ticks_active_to_start,
-				   conn->hdr.ticks_preempt_to_start,
-				   (RADIO_TICKER_ID_FIRST_CONNECTION +
-				    conn->handle),
-				   conn->role ? event_slave : event_master,
-				   conn);
-	if (!err) {
-		_radio.ticker_id_prepare = RADIO_TICKER_ID_FIRST_CONNECTION +
-					   conn->handle;
-	}
 }
 
 static void connection_configure(struct connection *conn)

--- a/subsys/bluetooth/controller/ll_sw/ctrl.c
+++ b/subsys/bluetooth/controller/ll_sw/ctrl.c
@@ -4442,12 +4442,6 @@ static u32_t event_common_prepare(u32_t ticks_at_expire,
 	/* Check for stale ticks_at_expire */
 	if (ticker_ticks_diff_get(ticker_ticks_now_get(), ticks_at_expire) >
 	    TICKER_US_TO_TICKS(RADIO_TICKER_START_PART_US)) {
-		/* Abort any running role, as it probably is the cause for
-		 * stale ticks_at_expire.
-		 */
-		event_stop(0, 0, 0, (void *)STATE_ABORT);
-
-		/* TODO: How much consecutive skips is tolerable? */
 		return 1;
 	}
 


### PR DESCRIPTION
Fixed a defect wherein anchor for first scanner event was in
the past (when looking for a free timeslice to avoid
overlapping with master role events) when actually there
were no master roles active. This defect caused the scanner
role to assert, when started with other roles active (eg.
advertiser), when trying to catch-up to current tick.

Signed-off-by: Vinayak Kariappa Chettimada <vich@nordicsemi.no>