### PR TITLE
crypto: Update TinyCrypt to 0.2.7

### DIFF
--- a/doc/zephyr.doxyfile
+++ b/doc/zephyr.doxyfile
@@ -107,7 +107,6 @@ INPUT                  = \
 			../include/arch/arm/cortex_m \
                         ../include/arch/nios2/ \
                         ../lib/libc/minimal/include/ \
-                        ../ext/lib/crypto/tinycrypt/include/ \
                         ../include/net/zoap.h \
                         ../include/net/dns_resolve.h \
                         ../tests/ztest/include/

--- a/drivers/crypto/crypto_tc_shim.c
+++ b/drivers/crypto/crypto_tc_shim.c
@@ -105,9 +105,9 @@ static int do_ccm_encrypt_mac(struct cipher_ctx *ctx,
 		return -EIO;
 	}
 
-	if (tc_ccm_generation_encryption(op->out_buf, aead_op->ad,
-					 aead_op->ad_len, op->in_buf,
-					  op->in_len, &ccm) == TC_CRYPTO_FAIL) {
+	if (tc_ccm_generation_encryption(op->out_buf, op->out_buf_max,
+					 aead_op->ad, aead_op->ad_len, op->in_buf,
+					 op->in_len, &ccm) == TC_CRYPTO_FAIL) {
 		SYS_LOG_ERR("TC internal error during CCM Encryption OP");
 		return -EIO;
 	}
@@ -146,10 +146,11 @@ static int do_ccm_decrypt_auth(struct cipher_ctx *ctx,
 		return -EIO;
 	}
 
-	if (tc_ccm_decryption_verification(op->out_buf, aead_op->ad,
-					   aead_op->ad_len, op->in_buf,
+	if (tc_ccm_decryption_verification(op->out_buf, op->out_buf_max,
+					   aead_op->ad, aead_op->ad_len,
+					   op->in_buf,
 					   op->in_len + ccm_param->tag_len,
-					    &ccm) == TC_CRYPTO_FAIL) {
+					   &ccm) == TC_CRYPTO_FAIL) {
 		SYS_LOG_ERR("TC internal error during CCM decryption OP");
 		return -EIO;
 	}

--- a/ext/lib/crypto/tinycrypt/Kconfig
+++ b/ext/lib/crypto/tinycrypt/Kconfig
@@ -53,19 +53,27 @@ config TINYCRYPT_ECC_DH
 	bool
 	prompt "ECC_DH anonymous key agreement protocol"
 	depends on TINYCRYPT
+	select RANDOM_GENERATOR
 	default n
 	help
 	This option enables support for the Elliptic curve
 	Diffie-Hellman anonymous key agreement protocol.
 
+	Enabling ECC requires a cryptographically secure random number
+	generator.
+
 config TINYCRYPT_ECC_DSA
 	bool
 	prompt "ECC_DSA digital signature algorithm"
 	depends on TINYCRYPT
+	select RANDOM_GENERATOR
 	default n
 	help
 	This option enables support for the Elliptic Curve Digital
 	Signature Algorithm (ECDSA).
+
+	Enabling ECC requires a cryptographically secure random number
+	generator.
 
 config TINYCRYPT_AES
 	bool

--- a/ext/lib/crypto/tinycrypt/README
+++ b/ext/lib/crypto/tinycrypt/README
@@ -3,7 +3,7 @@ open source project.  The original upstream code can be found at:
 
 https://github.com/01org/tinycrypt
 
-At revision e6cffb820b91578d9816fc0bcc8f72f32f6ee76b, version 0.2.6
+At revision c214460d7f760e2a75908cb41000afcc0bfca282, version 0.2.7
 
 Any changes to the local version should include Zephyr's TinyCrypt
 maintainer in the review.  That can be found via the git history.
@@ -16,32 +16,32 @@ The following is the license information for this code:
 
 ================================================================================
 
-          Copyright (c) 2015, Intel Corporation. All rights reserved.
+          Copyright (c) 2017, Intel Corporation. All rights reserved.         
 
 Redistribution and use in source and binary forms, with or without modification,
 are permitted provided that the following conditions are met:
 
-  - Redistributions of source code must retain the above copyright notice, this
+  - Redistributions of source code must retain the above copyright notice, this 
       list of conditions and the following disclaimer.
-
-  - Redistributions in binary form must reproduce the above copyright notice,
-      this list of conditions and the following disclaimer in the documentation
+      
+  - Redistributions in binary form must reproduce the above copyright notice, 
+      this list of conditions and the following disclaimer in the documentation 
       and/or other materials provided with the distribution.
+      
+  - Neither the name of the Intel Corporation nor the names of its contributors 
+      may be used to endorse or promote products derived from this software 
+      without specific prior written permission. 
 
-  - Neither the name of the Intel Corporation nor the names of its contributors
-      may be used to endorse or promote products derived from this software
-      without specific prior written permission.
 
-
-THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
-ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
-WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
-DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
-ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
-(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
-LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
-ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
-(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND 
+ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED 
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE 
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR 
+ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES 
+(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; 
+LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON 
+ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT 
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS 
 SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 ================================================================================
@@ -69,5 +69,3 @@ LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
 ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
 (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
 SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-
-================================================================================

--- a/ext/lib/crypto/tinycrypt/include/tinycrypt/aes.h
+++ b/ext/lib/crypto/tinycrypt/include/tinycrypt/aes.h
@@ -1,7 +1,7 @@
 /* aes.h - TinyCrypt interface to an AES-128 implementation */
 
 /*
- *  Copyright (C) 2015 by Intel Corporation, All Rights Reserved.
+ *  Copyright (C) 2017 by Intel Corporation, All Rights Reserved.
  *
  *  Redistribution and use in source and binary forms, with or without
  *  modification, are permitted provided that the following conditions are met:
@@ -61,10 +61,9 @@ extern "C" {
 #define TC_AES_BLOCK_SIZE (Nb*Nk)
 #define TC_AES_KEY_SIZE (Nb*Nk)
 
-struct tc_aes_key_sched_struct {
-	uint32_t words[Nb*(Nr+1)];
-};
-typedef struct tc_aes_key_sched_struct *TCAesKeySched_t;
+typedef struct tc_aes_key_sched_struct {
+	unsigned int words[Nb*(Nr+1)];
+} *TCAesKeySched_t;
 
 /**
  *  @brief Set AES-128 encryption key
@@ -77,7 +76,7 @@ typedef struct tc_aes_key_sched_struct *TCAesKeySched_t;
  *  @param      s IN/OUT -- initialized struct tc_aes_key_sched_struct
  *  @param      k IN -- points to the AES key
  */
-int32_t tc_aes128_set_encrypt_key(TCAesKeySched_t s, const uint8_t *k);
+int tc_aes128_set_encrypt_key(TCAesKeySched_t s, const uint8_t *k);
 
 /**
  *  @brief AES-128 Encryption procedure
@@ -91,9 +90,8 @@ int32_t tc_aes128_set_encrypt_key(TCAesKeySched_t s, const uint8_t *k);
  *  @param in IN -- a plaintext block to encrypt
  *  @param s IN -- initialized AES key schedule
  */
-int32_t tc_aes_encrypt(uint8_t *out,
-		       const uint8_t *in,
-		       const TCAesKeySched_t s);
+int tc_aes_encrypt(uint8_t *out, const uint8_t *in, 
+		   const TCAesKeySched_t s);
 
 /**
  *  @brief Set the AES-128 decryption key
@@ -109,7 +107,7 @@ int32_t tc_aes_encrypt(uint8_t *out,
  *  @param s  IN/OUT -- initialized struct tc_aes_key_sched_struct
  *  @param k  IN -- points to the AES key
  */
-int32_t tc_aes128_set_decrypt_key(TCAesKeySched_t s, const uint8_t *k);
+int tc_aes128_set_decrypt_key(TCAesKeySched_t s, const uint8_t *k);
 
 /**
  *  @brief AES-128 Encryption procedure
@@ -122,12 +120,11 @@ int32_t tc_aes128_set_decrypt_key(TCAesKeySched_t s, const uint8_t *k);
  *  @param in IN -- a plaintext block to encrypt
  *  @param s IN -- initialized AES key schedule
  */
-int32_t tc_aes_decrypt(uint8_t *out,
-		       const uint8_t *in,
-		       const TCAesKeySched_t s);
+int tc_aes_decrypt(uint8_t *out, const uint8_t *in, 
+		   const TCAesKeySched_t s);
 
 #ifdef __cplusplus
 }
 #endif
 
-#endif
+#endif /* __TC_AES_H__ */

--- a/ext/lib/crypto/tinycrypt/include/tinycrypt/cbc_mode.h
+++ b/ext/lib/crypto/tinycrypt/include/tinycrypt/cbc_mode.h
@@ -1,7 +1,7 @@
 /* cbc_mode.h - TinyCrypt interface to a CBC mode implementation */
 
 /*
- *  Copyright (C) 2015 by Intel Corporation, All Rights Reserved.
+ *  Copyright (C) 2017 by Intel Corporation, All Rights Reserved.
  *
  *  Redistribution and use in source and binary forms, with or without
  *  modification, are permitted provided that the following conditions are met:
@@ -107,9 +107,9 @@ extern "C" {
  *  @param iv IN -- the IV for the this encrypt/decrypt
  *  @param sched IN --  AES key schedule for this encrypt
  */
-int32_t tc_cbc_mode_encrypt(uint8_t *out, uint32_t outlen, const uint8_t *in,
-			    uint32_t inlen, const uint8_t *iv,
-			    const TCAesKeySched_t sched);
+int tc_cbc_mode_encrypt(uint8_t *out, unsigned int outlen, const uint8_t *in,
+			unsigned int inlen, const uint8_t *iv,
+			const TCAesKeySched_t sched);
 
 /**
  * @brief CBC decryption procedure
@@ -140,12 +140,12 @@ int32_t tc_cbc_mode_encrypt(uint8_t *out, uint32_t outlen, const uint8_t *in,
  * @param sched IN --  AES key schedule for this decrypt
  *
  */
-int32_t tc_cbc_mode_decrypt(uint8_t *out, uint32_t outlen, const uint8_t *in,
-			    uint32_t inlen, const uint8_t *iv,
-			    const TCAesKeySched_t sched);
+int tc_cbc_mode_decrypt(uint8_t *out, unsigned int outlen, const uint8_t *in,
+			unsigned int inlen, const uint8_t *iv,
+			const TCAesKeySched_t sched);
 
 #ifdef __cplusplus
 }
 #endif
 
-#endif
+#endif /* __TC_CBC_MODE_H__ */

--- a/ext/lib/crypto/tinycrypt/include/tinycrypt/cmac_mode.h
+++ b/ext/lib/crypto/tinycrypt/include/tinycrypt/cmac_mode.h
@@ -1,7 +1,7 @@
 /*  cmac_mode.h -- interface to a CMAC implementation */
 
 /*
- *  Copyright (C) 2015 by Intel Corporation, All Rights Reserved
+ *  Copyright (C) 2017 by Intel Corporation, All Rights Reserved
  *
  *  Redistribution and use in source and binary forms, with or without
  *  modification, are permitted provided that the following conditions are met:
@@ -119,9 +119,9 @@ typedef struct tc_cmac_struct {
 /* where to put bytes that didn't fill a block */
 	uint8_t leftover[TC_AES_BLOCK_SIZE];
 /* identifies the encryption key */
-	uint32_t keyid;
+	unsigned int keyid;
 /* next available leftover location */
-	uint32_t leftover_offset;
+	unsigned int leftover_offset;
 /* AES key schedule */
 	TCAesKeySched_t sched;
 /* calls to tc_cmac_update left before re-key */
@@ -139,8 +139,8 @@ typedef struct tc_cmac_struct {
  * @param key IN -- the key to use
  * @param sched IN -- AES key schedule
  */
-int32_t tc_cmac_setup(TCCmacState_t s, const uint8_t *key,
-			   TCAesKeySched_t sched);
+int tc_cmac_setup(TCCmacState_t s, const uint8_t *key,
+		      TCAesKeySched_t sched);
 
 /**
  * @brief Erases the CMAC state
@@ -150,7 +150,7 @@ int32_t tc_cmac_setup(TCCmacState_t s, const uint8_t *key,
  *
  * @param s IN/OUT -- the state to erase
  */
-int32_t tc_cmac_erase(TCCmacState_t s);
+int tc_cmac_erase(TCCmacState_t s);
 
 /**
  * @brief Initializes a new CMAC computation
@@ -160,7 +160,7 @@ int32_t tc_cmac_erase(TCCmacState_t s);
  *
  * @param s IN/OUT -- the state to initialize
  */
-int32_t tc_cmac_init(TCCmacState_t s);
+int tc_cmac_init(TCCmacState_t s);
 
 /**
  * @brief Incrementally computes CMAC over the next data segment
@@ -173,7 +173,7 @@ int32_t tc_cmac_init(TCCmacState_t s);
  * @param data IN -- the next data segment to MAC
  * @param dlen IN -- the length of data in bytes
  */
-int32_t tc_cmac_update(TCCmacState_t s, const uint8_t *data, size_t dlen);
+int tc_cmac_update(TCCmacState_t s, const uint8_t *data, size_t dlen);
 
 /**
  * @brief Generates the tag from the CMAC state
@@ -185,10 +185,10 @@ int32_t tc_cmac_update(TCCmacState_t s, const uint8_t *data, size_t dlen);
  * @param tag OUT -- the CMAC tag
  * @param s IN -- CMAC state
  */
-int32_t tc_cmac_final(uint8_t *tag, TCCmacState_t s);
+int tc_cmac_final(uint8_t *tag, TCCmacState_t s);
 
 #ifdef __cplusplus
 }
 #endif
 
-#endif
+#endif /* __TC_CMAC_MODE_H__ */

--- a/ext/lib/crypto/tinycrypt/include/tinycrypt/constants.h
+++ b/ext/lib/crypto/tinycrypt/include/tinycrypt/constants.h
@@ -1,7 +1,7 @@
 /* constants.h - TinyCrypt interface to constants */
 
 /*
- *  Copyright (C) 2015 by Intel Corporation, All Rights Reserved.
+ *  Copyright (C) 2017 by Intel Corporation, All Rights Reserved.
  *
  *  Redistribution and use in source and binary forms, with or without
  *  modification, are permitted provided that the following conditions are met:
@@ -43,6 +43,8 @@
 extern "C" {
 #endif
 
+#include <stdbool.h>
+
 #ifndef NULL
 #define NULL ((void *)0)
 #endif
@@ -56,4 +58,4 @@ extern "C" {
 }
 #endif
 
-#endif
+#endif /* __TC_CONSTANTS_H__ */

--- a/ext/lib/crypto/tinycrypt/include/tinycrypt/ctr_mode.h
+++ b/ext/lib/crypto/tinycrypt/include/tinycrypt/ctr_mode.h
@@ -1,7 +1,7 @@
 /* ctr_mode.h - TinyCrypt interface to CTR mode */
 
 /*
- *  Copyright (C) 2015 by Intel Corporation, All Rights Reserved.
+ *  Copyright (C) 2017 by Intel Corporation, All Rights Reserved.
  *
  *  Redistribution and use in source and binary forms, with or without
  *  modification, are permitted provided that the following conditions are met:
@@ -98,11 +98,11 @@ extern "C" {
  * @param ctr IN/OUT -- the current counter value
  * @param sched IN -- an initialized AES key schedule
  */
-int32_t tc_ctr_mode(uint8_t *out, uint32_t outlen, const uint8_t *in,
-		    uint32_t inlen, uint8_t *ctr, const TCAesKeySched_t sched);
+int tc_ctr_mode(uint8_t *out, unsigned int outlen, const uint8_t *in,
+		unsigned int inlen, uint8_t *ctr, const TCAesKeySched_t sched);
 
 #ifdef __cplusplus
 }
 #endif
 
-#endif
+#endif /* __TC_CTR_MODE_H__ */

--- a/ext/lib/crypto/tinycrypt/include/tinycrypt/ctr_prng.h
+++ b/ext/lib/crypto/tinycrypt/include/tinycrypt/ctr_prng.h
@@ -67,10 +67,9 @@
 extern "C" {
 #endif
 
-typedef struct
-{
+typedef struct {
 	/* updated each time another BLOCKLEN_BYTES bytes are produced */
-	uint8_t V[TC_AES_BLOCK_SIZE];
+	uint8_t V[TC_AES_BLOCK_SIZE]; 
 
 	/* updated whenever the PRNG is reseeded */
 	struct tc_aes_key_sched_struct key;
@@ -96,14 +95,14 @@ typedef struct
  *  @param entropyLen IN -- entropy length in bytes
  *  @param personalization IN -- personalization string used to seed the PRNG
  *  (may be null)
- *  @param pLen IN -- personalization length in bytes
+ *  @param plen IN -- personalization length in bytes
  *
  */
-int32_t tc_ctr_prng_init(TCCtrPrng_t * const ctx,
-			uint8_t const * const entropy,
-			uint32_t entropyLen,
-			uint8_t const * const personalization,
-			uint32_t pLen);
+int tc_ctr_prng_init(TCCtrPrng_t * const ctx, 
+		     uint8_t const * const entropy,
+		     unsigned int entropyLen, 
+		     uint8_t const * const personalization,
+		     unsigned int pLen);
 
 /**
  *  @brief CTR-PRNG reseed procedure
@@ -120,15 +119,15 @@ int32_t tc_ctr_prng_init(TCCtrPrng_t * const ctx,
  *  @note Assumes tc_ctr_prng_init has been called for ctx
  *  @param ctx IN/OUT -- the PRNG state
  *  @param entropy IN -- entropy to mix into the prng
- *  @param entropyLen IN -- length of entropy in bytes
+ *  @param entropylen IN -- length of entropy in bytes
  *  @param additional_input IN -- additional input to the prng (may be null)
  *  @param additionallen IN -- additional input length in bytes
  */
-int32_t tc_ctr_prng_reseed(TCCtrPrng_t * const ctx,
-			uint8_t const * const entropy,
-			uint32_t entropyLen,
-			uint8_t const * const additional_input,
-			uint32_t additionallen);
+int tc_ctr_prng_reseed(TCCtrPrng_t * const ctx, 
+		       uint8_t const * const entropy,
+		       unsigned int entropyLen,
+		       uint8_t const * const additional_input,
+		       unsigned int additionallen);
 
 /**
  *  @brief CTR-PRNG generate procedure
@@ -146,11 +145,11 @@ int32_t tc_ctr_prng_reseed(TCCtrPrng_t * const ctx,
  *  @param out IN/OUT -- buffer to receive output
  *  @param outlen IN -- size of out buffer in bytes
  */
-int32_t tc_ctr_prng_generate(TCCtrPrng_t * const ctx,
-			uint8_t const * const additional_input,
-			uint32_t additionallen,
-			uint8_t * const out,
-			uint32_t outlen);
+int tc_ctr_prng_generate(TCCtrPrng_t * const ctx,
+			 uint8_t const * const additional_input,
+			 unsigned int additionallen,
+			 uint8_t * const out,
+			 unsigned int outlen);
 
 /**
  *  @brief CTR-PRNG uninstantiate procedure
@@ -164,4 +163,4 @@ void tc_ctr_prng_uninstantiate(TCCtrPrng_t * const ctx);
 }
 #endif
 
-#endif
+#endif /* __TC_CTR_PRNG_H__ */

--- a/ext/lib/crypto/tinycrypt/include/tinycrypt/ecc.h
+++ b/ext/lib/crypto/tinycrypt/include/tinycrypt/ecc.h
@@ -1,10 +1,7 @@
-/* ecc.h - TinyCrypt interface to ECC auxiliary functions */
+/* ecc.h - TinyCrypt interface to common ECC functions */
 
-/*
- * =============================================================================
- * Copyright (c) 2013, Kenneth MacKay
+/* Copyright (c) 2014, Kenneth MacKay
  * All rights reserved.
- * https://github.com/kmackay/micro-ecc
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:
@@ -27,9 +24,10 @@
  * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
  * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
  * POSSIBILITY OF SUCH DAMAGE.
- *
- * =============================================================================
- * Copyright (C) 2015 by Intel Corporation, All Rights Reserved.
+ */
+
+/*
+ *  Copyright (C) 2017 by Intel Corporation, All Rights Reserved.
  *
  *  Redistribution and use in source and binary forms, with or without
  *  modification, are permitted provided that the following conditions are met:
@@ -60,9 +58,9 @@
 
 /**
  * @file
- * @brief -- Interface to ECC auxiliary functions.
+ * @brief -- Interface to common ECC functions.
  *
- *  Overview: This software is an implementation of auxiliary functions
+ *  Overview: This software is an implementation of common functions
  *            necessary to elliptic curve cryptography. This implementation uses
  *            curve NIST p-256.
  *
@@ -70,8 +68,8 @@
  *
  */
 
-#ifndef __TC_ECC_H__
-#define __TC_ECC_H__
+#ifndef __TC_UECC_H__
+#define __TC_UECC_H__
 
 #include <stdint.h>
 
@@ -80,278 +78,468 @@ extern "C" {
 #endif
 
 /* Word size (4 bytes considering 32-bits architectures) */
-#define WORD_SIZE 4
+#define uECC_WORD_SIZE 4
+
+/* setting max number of calls to prng: */
+#ifndef uECC_RNG_MAX_TRIES
+#define uECC_RNG_MAX_TRIES 64
+#endif
+
+/* defining data types to store word and bit counts: */
+typedef int8_t wordcount_t;
+typedef int16_t bitcount_t;
+/* defining data type for comparison result: */
+typedef int8_t cmpresult_t;
+/* defining data type to store ECC coordinate/point in 32bits words: */
+typedef unsigned int uECC_word_t;
+/* defining data type to store an ECC coordinate/point in 64bits words: */
+typedef uint64_t uECC_dword_t;
+
+/* defining masks useful for ecc computations: */
+#define HIGH_BIT_SET 0x80000000
+#define uECC_WORD_BITS 32
+#define uECC_WORD_BITS_SHIFT 5
+#define uECC_WORD_BITS_MASK 0x01F
+
 /* Number of words of 32 bits to represent an element of the the curve p-256: */
-#define NUM_ECC_DIGITS 8
+#define NUM_ECC_WORDS 8
 /* Number of bytes to represent an element of the the curve p-256: */
-#define NUM_ECC_BYTES (WORD_SIZE*NUM_ECC_DIGITS)
+#define NUM_ECC_BYTES (uECC_WORD_SIZE*NUM_ECC_WORDS)
 
-/* struct to represent a point of the curve (uses X and Y coordinates): */
-typedef struct EccPoint {
-	uint32_t x[NUM_ECC_DIGITS];
-	uint32_t y[NUM_ECC_DIGITS];
-} EccPoint;
-
-/* struct to represent a point of the curve in Jacobian coordinates
- * (uses X, Y and Z coordinates):
- */
-typedef struct EccPointJacobi {
-	uint32_t X[NUM_ECC_DIGITS];
-	uint32_t Y[NUM_ECC_DIGITS];
-	uint32_t Z[NUM_ECC_DIGITS];
-} EccPointJacobi;
-
-/*
- * @brief Check if p_vli is zero.
- * @return returns non-zero if p_vli == 0, zero otherwise.
- *
- * @param p_native OUT -- will be filled in with the native integer value.
- * @param p_bytes IN -- standard octet representation of the integer to convert.
- *
- * @note Side-channel countermeasure: algorithm strengthened against timing
- * attack.
- */
-uint32_t vli_isZero(uint32_t *p_vli);
+/* structure that represents an elliptic curve (e.g. p256):*/
+struct uECC_Curve_t;
+typedef const struct uECC_Curve_t * uECC_Curve;
+struct uECC_Curve_t {
+  wordcount_t num_words;
+  wordcount_t num_bytes;
+  bitcount_t num_n_bits;
+  uECC_word_t p[NUM_ECC_WORDS];
+  uECC_word_t n[NUM_ECC_WORDS];
+  uECC_word_t G[NUM_ECC_WORDS * 2];
+  uECC_word_t b[NUM_ECC_WORDS];
+  void (*double_jacobian)(uECC_word_t * X1, uECC_word_t * Y1, uECC_word_t * Z1,
+	uECC_Curve curve);
+  void (*x_side)(uECC_word_t *result, const uECC_word_t *x, uECC_Curve curve);
+  void (*mmod_fast)(uECC_word_t *result, uECC_word_t *product);
+};
 
 /*
- * @brief Set the content of p_src in p_dest.
- *
- * @param p_dest OUT -- Destination buffer.
- * @param p_src IN -- Origin buffer.
- *
+ * @brief computes doubling of point ion jacobian coordinates, in place.
+ * @param X1 IN/OUT -- x coordinate
+ * @param Y1 IN/OUT -- y coordinate
+ * @param Z1 IN/OUT -- z coordinate
+ * @param curve IN -- elliptic curve
  */
-void vli_set(uint32_t *p_dest, uint32_t *p_src);
+void double_jacobian_default(uECC_word_t * X1, uECC_word_t * Y1,
+			     uECC_word_t * Z1, uECC_Curve curve);
 
 /*
- * @brief Computes the sign of p_left - p_right.
- * @return returns the sign of p_left - p_right.
- *
- * @param p_left IN -- buffer to be compared.
- * @param p_right IN -- buffer to be compared.
- * @param word_size IN -- size of the word.
- *
- * @note Side-channel countermeasure: algorithm strengthened against timing
- * attack.
+ * @brief Computes x^3 + ax + b. result must not overlap x.
+ * @param result OUT -- x^3 + ax + b
+ * @param x IN -- value of x
+ * @param curve IN -- elliptic curve
  */
-int32_t vli_cmp(uint32_t *p_left, uint32_t *p_right, int32_t word_size);
+void x_side_default(uECC_word_t *result, const uECC_word_t *x,
+		    uECC_Curve curve);
 
 /*
- * @brief Computes p_result = p_left - p_right, returns borrow.
- * @return returns the sign of p_left - p_right.
+ * @brief Computes result = product % curve_p
+ * from http://www.nsa.gov/ia/_files/nist-routines.pdf
+ * @param result OUT -- product % curve_p
+ * @param product IN -- value to be reduced mod curve_p
+ */
+void vli_mmod_fast_secp256r1(unsigned int *result, unsigned int *product);
+
+/* Bytes to words ordering: */
+#define BYTES_TO_WORDS_8(a, b, c, d, e, f, g, h) 0x##d##c##b##a, 0x##h##g##f##e
+#define BYTES_TO_WORDS_4(a, b, c, d) 0x##d##c##b##a
+#define BITS_TO_WORDS(num_bits) \
+	((num_bits + ((uECC_WORD_SIZE * 8) - 1)) / (uECC_WORD_SIZE * 8))
+#define BITS_TO_BYTES(num_bits) ((num_bits + 7) / 8)
+
+/* definition of curve NIST p-256: */
+static const struct uECC_Curve_t curve_secp256r1 = {
+	NUM_ECC_WORDS,
+	NUM_ECC_BYTES,
+	256, /* num_n_bits */ {
+		BYTES_TO_WORDS_8(FF, FF, FF, FF, FF, FF, FF, FF),
+		BYTES_TO_WORDS_8(FF, FF, FF, FF, 00, 00, 00, 00),
+        	BYTES_TO_WORDS_8(00, 00, 00, 00, 00, 00, 00, 00),
+        	BYTES_TO_WORDS_8(01, 00, 00, 00, FF, FF, FF, FF)
+	}, {
+		BYTES_TO_WORDS_8(51, 25, 63, FC, C2, CA, B9, F3),
+            	BYTES_TO_WORDS_8(84, 9E, 17, A7, AD, FA, E6, BC),
+            	BYTES_TO_WORDS_8(FF, FF, FF, FF, FF, FF, FF, FF),
+            	BYTES_TO_WORDS_8(00, 00, 00, 00, FF, FF, FF, FF)
+	}, {
+		BYTES_TO_WORDS_8(96, C2, 98, D8, 45, 39, A1, F4),
+                BYTES_TO_WORDS_8(A0, 33, EB, 2D, 81, 7D, 03, 77),
+                BYTES_TO_WORDS_8(F2, 40, A4, 63, E5, E6, BC, F8),
+                BYTES_TO_WORDS_8(47, 42, 2C, E1, F2, D1, 17, 6B),
+
+                BYTES_TO_WORDS_8(F5, 51, BF, 37, 68, 40, B6, CB),
+                BYTES_TO_WORDS_8(CE, 5E, 31, 6B, 57, 33, CE, 2B),
+                BYTES_TO_WORDS_8(16, 9E, 0F, 7C, 4A, EB, E7, 8E),
+                BYTES_TO_WORDS_8(9B, 7F, 1A, FE, E2, 42, E3, 4F)
+	}, {
+		BYTES_TO_WORDS_8(4B, 60, D2, 27, 3E, 3C, CE, 3B),
+                BYTES_TO_WORDS_8(F6, B0, 53, CC, B0, 06, 1D, 65),
+                BYTES_TO_WORDS_8(BC, 86, 98, 76, 55, BD, EB, B3),
+                BYTES_TO_WORDS_8(E7, 93, 3A, AA, D8, 35, C6, 5A)
+	},
+        &double_jacobian_default,
+        &x_side_default,
+        &vli_mmod_fast_secp256r1
+};
+
+uECC_Curve uECC_secp256r1(void);
+
+/*
+ * @brief Generates a random integer in the range 0 < random < top.
+ * Both random and top have num_words words.
+ * @param random OUT -- random integer in the range 0 < random < top
+ * @param top IN -- upper limit
+ * @param num_words IN -- number of words
+ * @return a random integer in the range 0 < random < top
+ */
+int uECC_generate_random_int(uECC_word_t *random, const uECC_word_t *top,
+			     wordcount_t num_words);
+
+
+/* uECC_RNG_Function type
+ * The RNG function should fill 'size' random bytes into 'dest'. It should
+ * return 1 if 'dest' was filled with random data, or 0 if the random data could
+ * not be generated. The filled-in values should be either truly random, or from
+ * a cryptographically-secure PRNG.
  *
- * @param p_result IN -- buffer to be compared.
- * @param p_left IN -- buffer p_left in (p_left - p_right).
- * @param p_right IN -- buffer p_right in (p_left - p_right).
- * @param word_size IN -- size of the word.
+ * A correctly functioning RNG function must be set (using uECC_set_rng())
+ * before calling uECC_make_key() or uECC_sign().
  *
- * @note Side-channel countermeasure: algorithm strengthened against timing
- * attack.
+ * Setting a correctly functioning RNG function improves the resistance to
+ * side-channel attacks for uECC_shared_secret().
+ *
+ * A correct RNG function is set by default. If you are building on another
+ * POSIX-compliant system that supports /dev/random or /dev/urandom, you can
+ * define uECC_POSIX to use the predefined RNG.
+ */
+typedef int(*uECC_RNG_Function)(uint8_t *dest, unsigned int size);
+
+/*
+ * @brief Set the function that will be used to generate random bytes. The RNG
+ * function should return 1 if the random data was generated, or 0 if the random
+ * data could not be generated.
+ *
+ * @note On platforms where there is no predefined RNG function, this must be
+ * called before uECC_make_key() or uECC_sign() are used.
+ *
+ * @param rng_function IN -- function that will be used to generate random bytes
+ */
+void uECC_set_rng(uECC_RNG_Function rng_function);
+
+/*
+ * @brief provides current uECC_RNG_Function.
+ * @return Returns the function that will be used to generate random bytes.
+ */
+uECC_RNG_Function uECC_get_rng(void);
+
+/*
+ * @brief computes the size of a private key for the curve in bytes.
+ * @param curve IN -- elliptic curve
+ * @return size of a private key for the curve in bytes.
+ */
+int uECC_curve_private_key_size(uECC_Curve curve);
+
+/*
+ * @brief computes the size of a public key for the curve in bytes.
+ * @param curve IN -- elliptic curve
+ * @return the size of a public key for the curve in bytes.
+ */
+int uECC_curve_public_key_size(uECC_Curve curve);
+
+/*
+ * @brief Compute the corresponding public key for a private key.
+ * @param private_key IN -- The private key to compute the public key for
+ * @param public_key OUT -- Will be filled in with the corresponding public key
+ * @param curve
+ * @return Returns 1 if key was computed successfully, 0 if an error occurred.
+ */
+int uECC_compute_public_key(const uint8_t *private_key,
+			    uint8_t *public_key, uECC_Curve curve);
+
+/*
+ * @brief Compute public-key.
+ * @return corresponding public-key.
+ * @param result OUT -- public-key
+ * @param private_key IN -- private-key
+ * @param curve IN -- elliptic curve
+ */
+uECC_word_t EccPoint_compute_public_key(uECC_word_t *result,
+					uECC_word_t *private_key, uECC_Curve curve);
+
+/*
+ * @brief Regularize the bitcount for the private key so that attackers cannot
+ * use a side channel attack to learn the number of leading zeros.
+ * @return Regularized k
+ * @param k IN -- private-key
+ * @param k0 IN/OUT -- regularized k
+ * @param k1 IN/OUT -- regularized k
+ * @param curve IN -- elliptic curve
+ */
+uECC_word_t regularize_k(const uECC_word_t * const k, uECC_word_t *k0,
+			 uECC_word_t *k1, uECC_Curve curve);
+
+/*
+ * @brief Point multiplication algorithm using Montgomery's ladder with co-Z
+ * coordinates. See http://eprint.iacr.org/2011/338.pdf.
+ * @note Result may overlap point.
+ * @param result OUT -- returns scalar*point
+ * @param point IN -- elliptic curve point
+ * @param scalar IN -- scalar
+ * @param initial_Z IN -- initial value for z
+ * @param num_bits IN -- number of bits in scalar
+ * @param curve IN -- elliptic curve
+ */
+void EccPoint_mult(uECC_word_t * result, const uECC_word_t * point,
+		   const uECC_word_t * scalar, const uECC_word_t * initial_Z,
+		   bitcount_t num_bits, uECC_Curve curve);
+
+/*
+ * @brief Constant-time comparison to zero - secure way to compare long integers
+ * @param vli IN -- very long integer
+ * @param num_words IN -- number of words in the vli
+ * @return 1 if vli == 0, 0 otherwise.
+ */
+uECC_word_t uECC_vli_isZero(const uECC_word_t *vli, wordcount_t num_words);
+
+/*
+ * @brief Check if 'point' is the point at infinity
+ * @param point IN -- elliptic curve point
+ * @param curve IN -- elliptic curve
+ * @return if 'point' is the point at infinity, 0 otherwise.
+ */
+uECC_word_t EccPoint_isZero(const uECC_word_t *point, uECC_Curve curve);
+
+/*
+ * @brief computes the sign of left - right, in constant time.
+ * @param left IN -- left term to be compared
+ * @param right IN -- right term to be compared
+ * @param num_words IN -- number of words
+ * @return the sign of left - right
+ */
+cmpresult_t uECC_vli_cmp(const uECC_word_t *left, const uECC_word_t *right,
+			 wordcount_t num_words);
+
+/*
+ * @brief computes sign of left - right, not in constant time.
+ * @note should not be used if inputs are part of a secret
+ * @param left IN -- left term to be compared
+ * @param right IN -- right term to be compared
+ * @param num_words IN -- number of words
+ * @return the sign of left - right
+ */
+cmpresult_t uECC_vli_cmp_unsafe(const uECC_word_t *left, const uECC_word_t *right,
+				wordcount_t num_words);
+
+/*
+ * @brief Computes result = (left - right) % mod.
+ * @note Assumes that (left < mod) and (right < mod), and that result does not
+ * overlap mod.
+ * @param result OUT -- (left - right) % mod
+ * @param left IN -- leftright term in modular subtraction
+ * @param right IN -- right term in modular subtraction
+ * @param mod IN -- mod
+ * @param num_words IN -- number of words
+ */
+void uECC_vli_modSub(uECC_word_t *result, const uECC_word_t *left,
+		     const uECC_word_t *right, const uECC_word_t *mod,
+		     wordcount_t num_words);
+
+/*
+ * @brief Computes P' = (x1', y1', Z3), P + Q = (x3, y3, Z3) or
+ * P => P', Q => P + Q
+ * @note assumes Input P = (x1, y1, Z), Q = (x2, y2, Z)
+ * @param X1 IN -- x coordinate of P
+ * @param Y1 IN -- y coordinate of P
+ * @param X2 IN -- x coordinate of Q
+ * @param Y2 IN -- y coordinate of Q
+ * @param curve IN -- elliptic curve
+ */
+void XYcZ_add(uECC_word_t * X1, uECC_word_t * Y1, uECC_word_t * X2,
+	      uECC_word_t * Y2, uECC_Curve curve);
+
+/*
+ * @brief Computes (x1 * z^2, y1 * z^3)
+ * @param X1 IN -- previous x1 coordinate
+ * @param Y1 IN -- previous y1 coordinate
+ * @param Z IN -- z value
+ * @param curve IN -- elliptic curve
+ */
+void apply_z(uECC_word_t * X1, uECC_word_t * Y1, const uECC_word_t * const Z,
+	     uECC_Curve curve);
+
+/*
+ * @brief Check if bit is set.
+ * @return Returns nonzero if bit 'bit' of vli is set.
+ * @warning It is assumed that the value provided in 'bit' is within the
+ * boundaries of the word-array 'vli'.
+ * @note The bit ordering layout assumed for vli is: {31, 30, ..., 0},
+ * {63, 62, ..., 32}, {95, 94, ..., 64}, {127, 126,..., 96} for a vli consisting
+ * of 4 uECC_word_t elements.
+ */
+uECC_word_t uECC_vli_testBit(const uECC_word_t *vli, bitcount_t bit);
+
+/*
+ * @brief Computes result = product % mod, where product is 2N words long.
+ * @param result OUT -- product % mod
+ * @param mod IN -- module
+ * @param num_words IN -- number of words
+ * @warning Currently only designed to work for curve_p or curve_n.
+ */
+void uECC_vli_mmod(uECC_word_t *result, uECC_word_t *product,
+		   const uECC_word_t *mod, wordcount_t num_words);
+
+/*
+ * @brief Computes modular product (using curve->mmod_fast)
+ * @param result OUT -- (left * right) mod % curve_p
+ * @param left IN -- left term in product
+ * @param right IN -- right term in product
+ * @param curve IN -- elliptic curve
+ */
+void uECC_vli_modMult_fast(uECC_word_t *result, const uECC_word_t *left,
+			   const uECC_word_t *right, uECC_Curve curve);
+
+/*
+ * @brief Computes result = left - right.
  * @note Can modify in place.
+ * @param result OUT -- left - right
+ * @param left IN -- left term in subtraction
+ * @param right IN -- right term in subtraction
+ * @param num_words IN -- number of words
+ * @return borrow
  */
-uint32_t vli_sub(uint32_t *p_result, uint32_t *p_left, uint32_t *p_right,
-		uint32_t word_size);
+uECC_word_t uECC_vli_sub(uECC_word_t *result, const uECC_word_t *left,
+			 const uECC_word_t *right, wordcount_t num_words);
 
 /*
- * @brief Conditional set: sets either 'p_true' or 'p_false' to 'output',
- * depending on the value of 'cond'.
- *
- * @param output OUT -- result buffer after setting either p_true or p_false.
- * @param p_true IN -- buffer to be used if cond is true.
- * @param p_false IN -- buffer to be used if cond is false.
- * @param cond IN -- boolean value that will determine which value will be set
- * to output.
+ * @brief Constant-time comparison function(secure way to compare long ints)
+ * @param left IN -- left term in comparison
+ * @param right IN -- right term in comparison
+ * @param num_words IN -- number of words
+ * @return Returns 0 if left == right, 1 otherwise.
  */
-void vli_cond_set(uint32_t *output, uint32_t *p_true, uint32_t *p_false,
-		uint32_t cond);
+uECC_word_t uECC_vli_equal(const uECC_word_t *left, const uECC_word_t *right,
+			   wordcount_t num_words);
 
 /*
- * @brief Computes p_result = (p_left + p_right) % p_mod.
- *
- * @param p_result OUT -- result buffer.
- * @param p_left IN -- buffer p_left in (p_left + p_right) % p_mod.
- * @param p_right IN -- buffer p_right in (p_left + p_right) % p_mod.
- * @param p_mod IN -- module.
- *
- * @note Assumes that p_left < p_mod and p_right < p_mod, p_result != p_mod.
- * @note Side-channel countermeasure: algorithm strengthened against timing
- * attack.
+ * @brief Computes (left * right) % mod
+ * @param result OUT -- (left * right) % mod
+ * @param left IN -- left term in product
+ * @param right IN -- right term in product
+ * @param mod IN -- mod
+ * @param num_words IN -- number of words
  */
-void vli_modAdd(uint32_t *p_result, uint32_t *p_left, uint32_t *p_right,
-		uint32_t *p_mod);
+void uECC_vli_modMult(uECC_word_t *result, const uECC_word_t *left,
+		      const uECC_word_t *right, const uECC_word_t *mod,
+	              wordcount_t num_words);
 
 /*
- * @brief Computes p_result = (p_left - p_right) % p_mod.
- *
- * @param p_result OUT -- result buffer.
- * @param p_left IN -- buffer p_left in (p_left - p_right) % p_mod.
- * @param p_right IN -- buffer p_right in (p_left - p_right) % p_mod.
- * @param p_mod IN -- module.
- *
- * @note Assumes that p_left < p_mod and p_right < p_mod, p_result != p_mod.
- * @note Side-channel countermeasure: algorithm strengthened against timing
- * attack.
+ * @brief Computes (1 / input) % mod
+ * @note All VLIs are the same size.
+ * @note See "Euclid's GCD to Montgomery Multiplication to the Great Divide"
+ * @param result OUT -- (1 / input) % mod
+ * @param input IN -- value to be modular inverted
+ * @param mod IN -- mod
+ * @param num_words -- number of words
  */
-void vli_modSub(uint32_t *p_result, uint32_t *p_left, uint32_t *p_right,
-		uint32_t *p_mod);
+void uECC_vli_modInv(uECC_word_t *result, const uECC_word_t *input,
+		     const uECC_word_t *mod, wordcount_t num_words);
 
 /*
- * @brief Computes p_result = (p_left * p_right) % curve_p.
- *
- * @param p_result OUT -- result buffer.
- * @param p_left IN -- buffer p_left in (p_left * p_right) % curve_p.
- * @param p_right IN -- buffer p_right in (p_left * p_right) % curve_p.
+ * @brief Sets dest = src.
+ * @param dest OUT -- destination buffer
+ * @param src IN --  origin buffer
+ * @param num_words IN -- number of words
  */
-void vli_modMult_fast(uint32_t *p_result, uint32_t *p_left,
-		uint32_t *p_right);
+void uECC_vli_set(uECC_word_t *dest, const uECC_word_t *src,
+		  wordcount_t num_words);
 
 /*
- * @brief Computes p_result = p_left^2 % curve_p.
- *
- * @param p_result OUT -- result buffer.
- * @param p_left IN -- buffer p_left in (p_left^2 % curve_p).
+ * @brief Computes (left + right) % mod.
+ * @note Assumes that (left < mod) and right < mod), and that result does not
+ * overlap mod.
+ * @param result OUT -- (left + right) % mod.
+ * @param left IN -- left term in addition
+ * @param right IN -- right term in addition
+ * @param mod IN -- mod
+ * @param num_words IN -- number of words
  */
-void vli_modSquare_fast(uint32_t *p_result, uint32_t *p_left);
+void uECC_vli_modAdd(uECC_word_t *result,  const uECC_word_t *left,
+    		     const uECC_word_t *right, const uECC_word_t *mod,
+   		     wordcount_t num_words);
 
 /*
- * @brief Computes p_result = (p_left * p_right) % p_mod.
- *
- * @param p_result OUT -- result buffer.
- * @param p_left IN -- buffer p_left in (p_left * p_right) % p_mod.
- * @param p_right IN -- buffer p_right in (p_left * p_right) % p_mod.
- * @param p_mod IN -- module.
- * @param p_barrett IN -- used for Barrett reduction.
- * @note Side-channel countermeasure: algorithm strengthened against timing
- * attack.
+ * @brief Counts the number of bits required to represent vli.
+ * @param vli IN -- very long integer
+ * @param max_words IN -- number of words
+ * @return number of bits in given vli
  */
-void vli_modMult(uint32_t *p_result, uint32_t *p_left, uint32_t *p_right,
-		uint32_t *p_mod, uint32_t *p_barrett);
+bitcount_t uECC_vli_numBits(const uECC_word_t *vli, 
+			    const wordcount_t max_words);
 
 /*
- * @brief Computes modular inversion: (1/p_intput) % p_mod.
- *
- * @param p_result OUT -- result buffer.
- * @param p_input IN -- buffer p_input in (1/p_intput) % p_mod.
- * @param p_mod IN -- module.
- * @param p_barrett IN -- used for Barrett reduction.
- * @note Side-channel countermeasure: algorithm strengthened against timing
- * attack.
+ * @brief Erases (set to 0) vli
+ * @param vli IN -- very long integer
+ * @param num_words IN -- number of words
  */
-void vli_modInv(uint32_t *p_result, uint32_t *p_input,
-		uint32_t *p_mod, uint32_t *p_barrett);
+void uECC_vli_clear(uECC_word_t *vli, wordcount_t num_words);
 
 /*
- * @brief modular reduction based on Barrett's method
- * @param p_result OUT -- p_product % p_mod.
- * @param p_product IN -- buffer p_product in (p_product % p_mod).
- * @param p_mod IN -- buffer p_mod in (p_product % p_mod).
- * @param p_barrett -- used for Barrett reduction.
- * @note Side-channel countermeasure: algorithm strengthened against timing
- * attack.
+ * @brief check if it is a valid point in the curve
+ * @param point IN -- point to be checked
+ * @param curve IN -- elliptic curve
+ * @return 0 if point is valid
+ * @exception returns -1 if it is a point at infinity
+ * @exception returns -2 if x or y is smaller than p,
+ * @exception returns -3 if y^2 != x^3 + ax + b.
  */
-void vli_mmod_barrett(
-    uint32_t *p_result,
-    uint32_t *p_product,
-    uint32_t *p_mod,
-    uint32_t *p_barrett);
+int uECC_valid_point(const uECC_word_t *point, uECC_Curve curve);
 
 /*
- * @brief Check if a point is zero.
- * @return Returns 1 if p_point is the point at infinity, 0 otherwise.
+ * @brief Check if a public key is valid.
+ * @param public_key IN -- The public key to be checked.
+ * @return returns 0 if the public key is valid
+ * @exception returns -1 if it is a point at infinity
+ * @exception returns -2 if x or y is smaller than p,
+ * @exception returns -3 if y^2 != x^3 + ax + b.
+ * @exception returns -4 if public key is the group generator.
  *
- * @param p_point IN -- point to be checked.
+ * @note Note that you are not required to check for a valid public key before
+ * using any other uECC functions. However, you may wish to avoid spending CPU
+ * time computing a shared secret or verifying a signature using an invalid
+ * public key.
  */
-uint32_t EccPoint_isZero(EccPoint *p_point);
+int uECC_valid_public_key(const uint8_t *public_key, uECC_Curve curve);
+
+ /*
+  * @brief Converts an integer in uECC native format to big-endian bytes.
+  * @param bytes OUT -- bytes representation
+  * @param num_bytes IN -- number of bytes
+  * @param native IN -- uECC native representation
+  */
+void uECC_vli_nativeToBytes(uint8_t *bytes, int num_bytes,
+    			    const unsigned int *native);
 
 /*
- * @brief Check if point in Jacobi coordinates is zero.
- * @return Returns 1 if p_point_jacobi is the point at infinity, 0 otherwise.
- *
- * @param p_point IN -- point to be checked.
+ * @brief Converts big-endian bytes to an integer in uECC native format.
+ * @param native OUT -- uECC native representation
+ * @param bytes IN -- bytes representation
+ * @param num_bytes IN -- number of bytes
  */
-uint32_t EccPointJacobi_isZero(EccPointJacobi *p_point_jacobi);
-
-/*
- * @brief Conversion from Jacobi coordinates to Affine coordinates.
- *
- * @param p_point OUT -- point in Affine coordinates.
- * @param p_point_jacobi OUT -- point in Jacobi coordinates.
- */
-void EccPoint_toAffine(EccPoint *p_point, EccPointJacobi *p_point_jacobi);
-
-/*
- * @brief Elliptic curve point addition in Jacobi coordinates: P1 = P1 + P2.
- *
- * @param P1 IN/OUT -- P1 in P1 = P1 + P2.
- * @param P2 IN -- P2 in P1 = P1 + P2.
- */
-void EccPoint_add(EccPointJacobi *P1, EccPointJacobi *P2);
-
-/*
- * @brief Elliptic curve scalar multiplication with result in Jacobi coordinates
- *
- * @param p_result OUT -- Product of p_point by p_scalar.
- * @param p_point IN -- Elliptic curve point
- * @param p_scalar IN -- Scalar integer
- * @note Side-channel countermeasure: algorithm strengthened against timing
- * attack.
- */
-void EccPoint_mult_safe(EccPointJacobi *p_result, EccPoint *p_point,
-		uint32_t *p_scalar);
-
-/*
- * @brief Fast elliptic curve scalar multiplication with result in Jacobi
- * coordinates
- * @note non constant time
- * @param p_result OUT -- Product of p_point by p_scalar.
- * @param p_point IN -- Elliptic curve point
- * @param p_scalar IN -- Scalar integer
- * @note algorithm NOT strengthened against timing attack.
- */
-void EccPoint_mult_unsafe(
-    EccPointJacobi *p_result,
-    EccPoint *p_point,
-    uint32_t *p_scalar);
-
-/*
- * @brief Convert an integer in standard octet representation to native format.
- * @return returns TC_CRYPTO_SUCCESS (1)
- *         returns TC_CRYPTO_FAIL (0) if:
- *                out == NULL or
- *                c == NULL or
- *                ((plen > 0) and (payload == NULL)) or
- *                ((alen > 0) and (associated_data == NULL)) or
- *                (alen >= TC_CCM_AAD_MAX_BYTES) or
- *                (plen >= TC_CCM_PAYLOAD_MAX_BYTES)
- *
- * @param p_native OUT -- will be filled in with the native integer value.
- * @param p_bytes IN -- standard octet representation of the integer to convert.
- *
- */
-void ecc_bytes2native(uint32_t p_native[NUM_ECC_DIGITS],
-		uint8_t p_bytes[NUM_ECC_DIGITS*4]);
-
-
-/*
- * @brief Convert an integer in native format to standard octet representation.
- * @return returns TC_CRYPTO_SUCCESS (1)
- *         returns TC_CRYPTO_FAIL (0) if:
- *                out == NULL or
- *                c == NULL or
- *                ((plen > 0) and (payload == NULL)) or
- *                ((alen > 0) and (associated_data == NULL)) or
- *                (alen >= TC_CCM_AAD_MAX_BYTES) or
- *                (plen >= TC_CCM_PAYLOAD_MAX_BYTES)
- *
- * @param p_bytes OUT -- will be filled in with the standard octet
- *                        representation of the integer.
- * @param p_native IN -- native integer value to convert.
- *
- */
-void ecc_native2bytes(uint8_t p_bytes[NUM_ECC_DIGITS*4],
-		uint32_t p_native[NUM_ECC_DIGITS]);
+void uECC_vli_bytesToNative(unsigned int *native, const uint8_t *bytes,
+			    int num_bytes);
 
 #ifdef __cplusplus
 }
 #endif
 
-#endif
+#endif /* __TC_UECC_H__ */

--- a/ext/lib/crypto/tinycrypt/include/tinycrypt/ecc_platform_specific.h
+++ b/ext/lib/crypto/tinycrypt/include/tinycrypt/ecc_platform_specific.h
@@ -1,0 +1,81 @@
+/*  uECC_platform_specific.h - Interface to platform specific functions*/
+
+/* Copyright (c) 2014, Kenneth MacKay
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *  * Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *  * Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.*/
+
+/*
+ *  Copyright (C) 2017 by Intel Corporation, All Rights Reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions are met:
+ *
+ *    - Redistributions of source code must retain the above copyright notice,
+ *     this list of conditions and the following disclaimer.
+ *
+ *    - Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ *    - Neither the name of Intel Corporation nor the names of its contributors
+ *    may be used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ *  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ *  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ *  ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+ *  LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ *  CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ *  SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ *  INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ *  CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ *  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ *
+ *  uECC_platform_specific.h -- Interface to platform specific functions
+ */
+
+#ifndef __UECC_PLATFORM_SPECIFIC_H_
+#define __UECC_PLATFORM_SPECIFIC_H_
+
+/*
+ * The RNG function should fill 'size' random bytes into 'dest'. It should
+ * return 1 if 'dest' was filled with random data, or 0 if the random data could
+ * not be generated. The filled-in values should be either truly random, or from
+ * a cryptographically-secure PRNG.
+ *
+ * A cryptographically-secure PRNG function must be set (using uECC_set_rng())
+ * before calling uECC_make_key() or uECC_sign().
+ *
+ * Setting a cryptographically-secure PRNG function improves the resistance to
+ * side-channel attacks for uECC_shared_secret().
+ *
+ * A correct PRNG function is set by default (default_RNG_defined = 1) and works
+ * for some platforms, such as Unix and Linux. For other platforms, you may need
+ * to provide another PRNG function.
+*/
+#define default_RNG_defined 1
+
+int default_CSPRNG(uint8_t *dest, unsigned int size);
+
+#endif /* __UECC_PLATFORM_SPECIFIC_H_ */

--- a/ext/lib/crypto/tinycrypt/include/tinycrypt/hmac.h
+++ b/ext/lib/crypto/tinycrypt/include/tinycrypt/hmac.h
@@ -1,7 +1,7 @@
 /* hmac.h - TinyCrypt interface to an HMAC implementation */
 
 /*
- *  Copyright (C) 2015 by Intel Corporation, All Rights Reserved.
+ *  Copyright (C) 2017 by Intel Corporation, All Rights Reserved.
  *
  *  Redistribution and use in source and binary forms, with or without
  *  modification, are permitted provided that the following conditions are met:
@@ -89,9 +89,8 @@ typedef struct tc_hmac_state_struct *TCHmacState_t;
  * @param key IN -- the HMAC key to configure
  * @param key_size IN -- the HMAC key size
  */
-int32_t tc_hmac_set_key(TCHmacState_t ctx,
-			const uint8_t *key,
-			uint32_t key_size);
+int tc_hmac_set_key(TCHmacState_t ctx, const uint8_t *key,
+		    unsigned int key_size);
 
 /**
  * @brief HMAC init procedure
@@ -100,7 +99,7 @@ int32_t tc_hmac_set_key(TCHmacState_t ctx,
  *         returns TC_CRYPTO_FAIL (0) if: ctx == NULL or key == NULL
  * @param ctx IN/OUT -- struct tc_hmac_state_struct buffer to init
  */
-int32_t tc_hmac_init(TCHmacState_t ctx);
+int tc_hmac_init(TCHmacState_t ctx);
 
 /**
  *  @brief HMAC update procedure
@@ -112,9 +111,8 @@ int32_t tc_hmac_init(TCHmacState_t ctx);
  *  @param data IN -- data to incorporate into state
  *  @param data_length IN -- size of data in bytes
  */
-int32_t tc_hmac_update(TCHmacState_t ctx,
-		       const void *data,
-		       uint32_t data_length);
+int tc_hmac_update(TCHmacState_t ctx, const void *data,
+		   unsigned int data_length);
 
 /**
  *  @brief HMAC final procedure
@@ -125,17 +123,17 @@ int32_t tc_hmac_update(TCHmacState_t ctx,
  *                ctx == NULL or
  *                key == NULL or
  *                taglen != TC_SHA256_DIGEST_SIZE
- *  @note 'ctx' is erased before exiting (this must never be changed/removed).
+ *  @note ctx is erased before exiting. This should never be changed/removed.
  *  @note Assumes the tag bufer is at least sizeof(hmac_tag_size(state)) bytes
  *  state has been initialized by tc_hmac_init
  *  @param tag IN/OUT -- buffer to receive computed HMAC tag
  *  @param taglen IN -- size of tag in bytes
  *  @param ctx IN/OUT -- the HMAC state for computing tag
  */
-int32_t tc_hmac_final(uint8_t *tag, uint32_t taglen, TCHmacState_t ctx);
+int tc_hmac_final(uint8_t *tag, unsigned int taglen, TCHmacState_t ctx);
 
 #ifdef __cplusplus
 }
 #endif
 
-#endif
+#endif /*__TC_HMAC_H__*/

--- a/ext/lib/crypto/tinycrypt/include/tinycrypt/hmac_prng.h
+++ b/ext/lib/crypto/tinycrypt/include/tinycrypt/hmac_prng.h
@@ -1,7 +1,7 @@
 /* hmac_prng.h - TinyCrypt interface to an HMAC-PRNG implementation */
 
 /*
- *  Copyright (C) 2015 by Intel Corporation, All Rights Reserved.
+ *  Copyright (C) 2017 by Intel Corporation, All Rights Reserved.
  *
  *  Redistribution and use in source and binary forms, with or without
  *  modification, are permitted provided that the following conditions are met:
@@ -85,7 +85,7 @@ struct tc_hmac_prng_struct {
 	/* PRNG state */
 	uint8_t v[TC_SHA256_DIGEST_SIZE];
 	/* calls to tc_hmac_prng_generate left before re-seed */
-	uint32_t countdown;
+	unsigned int countdown;
 };
 
 typedef struct tc_hmac_prng_struct *TCHmacPrng_t;
@@ -112,15 +112,15 @@ typedef struct tc_hmac_prng_struct *TCHmacPrng_t;
  *  @param personalization IN -- personalization string
  *  @param plen IN -- personalization length in bytes
  */
-int32_t tc_hmac_prng_init(TCHmacPrng_t prng,
-			  const uint8_t *personalization,
-			  uint32_t plen);
+int tc_hmac_prng_init(TCHmacPrng_t prng,
+		      const uint8_t *personalization,
+		      unsigned int plen);
 
 /**
  *  @brief HMAC-PRNG reseed procedure
  *  Mixes seed into prng, enables tc_hmac_prng_generate
  *  @return returns  TC_CRYPTO_SUCCESS (1)
- *  returns TC_CRYPTO_FAIL (0) if:
+ *  	    returns TC_CRYPTO_FAIL (0) if:
  *          prng == NULL,
  *          seed == NULL,
  *          seedlen < MIN_SLEN,
@@ -136,16 +136,16 @@ int32_t tc_hmac_prng_init(TCHmacPrng_t prng,
  *  @param additional_input IN -- additional input to the prng
  *  @param additionallen IN -- additional input length in bytes
  */
-int32_t tc_hmac_prng_reseed(TCHmacPrng_t prng, const uint8_t *seed,
-			    uint32_t seedlen, const uint8_t *additional_input,
-			    uint32_t additionallen);
+int tc_hmac_prng_reseed(TCHmacPrng_t prng, const uint8_t *seed,
+			unsigned int seedlen, const uint8_t *additional_input,
+			unsigned int additionallen);
 
 /**
  *  @brief HMAC-PRNG generate procedure
  *  Generates outlen pseudo-random bytes into out buffer, updates prng
  *  @return returns TC_CRYPTO_SUCCESS (1)
  *          returns TC_HMAC_PRNG_RESEED_REQ (-1) if a reseed is needed
- *             returns TC_CRYPTO_FAIL (0) if:
+ *          returns TC_CRYPTO_FAIL (0) if:
  *                out == NULL,
  *                prng == NULL,
  *                outlen == 0,
@@ -155,10 +155,10 @@ int32_t tc_hmac_prng_reseed(TCHmacPrng_t prng, const uint8_t *seed,
  *  @param outlen IN -- size of out buffer in bytes
  *  @param prng IN/OUT -- the PRNG state
  */
-int32_t tc_hmac_prng_generate(uint8_t *out, uint32_t outlen, TCHmacPrng_t prng);
+int tc_hmac_prng_generate(uint8_t *out, unsigned int outlen, TCHmacPrng_t prng);
 
 #ifdef __cplusplus
 }
 #endif
 
-#endif
+#endif /* __TC_HMAC_PRNG_H__ */

--- a/ext/lib/crypto/tinycrypt/include/tinycrypt/sha256.h
+++ b/ext/lib/crypto/tinycrypt/include/tinycrypt/sha256.h
@@ -1,7 +1,7 @@
 /* sha256.h - TinyCrypt interface to a SHA-256 implementation */
 
 /*
- *  Copyright (C) 2015 by Intel Corporation, All Rights Reserved.
+ *  Copyright (C) 2017 by Intel Corporation, All Rights Reserved.
  *
  *  Redistribution and use in source and binary forms, with or without
  *  modification, are permitted provided that the following conditions are met:
@@ -69,7 +69,7 @@ extern "C" {
 #define TC_SHA256_STATE_BLOCKS (TC_SHA256_DIGEST_SIZE/4)
 
 struct tc_sha256_state_struct {
-	uint32_t iv[TC_SHA256_STATE_BLOCKS];
+	unsigned int iv[TC_SHA256_STATE_BLOCKS];
 	uint64_t bits_hashed;
 	uint8_t leftover[TC_SHA256_BLOCK_SIZE];
 	size_t leftover_offset;
@@ -84,7 +84,7 @@ typedef struct tc_sha256_state_struct *TCSha256State_t;
  *          returns TC_CRYPTO_FAIL (0) if s == NULL
  *  @param s Sha256 state struct
  */
-int32_t tc_sha256_init(TCSha256State_t s);
+int tc_sha256_init(TCSha256State_t s);
 
 /**
  *  @brief SHA256 update procedure
@@ -102,9 +102,7 @@ int32_t tc_sha256_init(TCSha256State_t s);
  *  @param data message to hash
  *  @param datalen length of message to hash
  */
-int32_t tc_sha256_update(TCSha256State_t s,
-			 const uint8_t *data,
-			 size_t datalen);
+int tc_sha256_update (TCSha256State_t s, const uint8_t *data, size_t datalen);
 
 /**
  *  @brief SHA256 final procedure
@@ -120,12 +118,12 @@ int32_t tc_sha256_update(TCSha256State_t s,
  *           If your application intends to have sensitive data in this
  *           buffer, remind to erase it after the data has been processed
  *  @param digest unsigned eight bit integer
- *  @param s Sha256 state struct
+ *  @param Sha256 state struct
  */
-int32_t tc_sha256_final(uint8_t *digest, TCSha256State_t s);
+int tc_sha256_final(uint8_t *digest, TCSha256State_t s);
 
 #ifdef __cplusplus
 }
 #endif
 
-#endif
+#endif /* __TC_SHA256_H__ */

--- a/ext/lib/crypto/tinycrypt/include/tinycrypt/utils.h
+++ b/ext/lib/crypto/tinycrypt/include/tinycrypt/utils.h
@@ -1,7 +1,7 @@
 /* utils.h - TinyCrypt interface to platform-dependent run-time operations */
 
 /*
- *  Copyright (C) 2015 by Intel Corporation, All Rights Reserved.
+ *  Copyright (C) 2017 by Intel Corporation, All Rights Reserved.
  *
  *  Redistribution and use in source and binary forms, with or without
  *  modification, are permitted provided that the following conditions are met:
@@ -57,8 +57,8 @@ extern "C" {
  * @param from IN -- origin buffer
  * @param from_len IN -- length of origin buffer
  */
-uint32_t _copy(uint8_t *to, uint32_t to_len,
-	       const uint8_t *from, uint32_t from_len);
+unsigned int _copy(uint8_t *to, unsigned int to_len,
+	           const uint8_t *from, unsigned int from_len);
 
 /**
  * @brief Set the value 'val' into the buffer 'to', 'len' times.
@@ -67,7 +67,7 @@ uint32_t _copy(uint8_t *to, uint32_t to_len,
  * @param val IN -- value to be set in 'to'
  * @param len IN -- number of times the value will be copied
  */
-void _set(void *to, uint8_t val, uint32_t len);
+void _set(void *to, uint8_t val, unsigned int len);
 
 /*
  * @brief AES specific doubling function, which utilizes
@@ -86,10 +86,10 @@ uint8_t _double_byte(uint8_t a);
  * @param b IN -- sequence of bytes b
  * @param size IN -- size of sequences a and b
  */
-int32_t _compare(const uint8_t *a, const uint8_t *b, size_t size);
+int _compare(const uint8_t *a, const uint8_t *b, size_t size);
 
 #ifdef __cplusplus
 }
 #endif
 
-#endif
+#endif /* __TC_UTILS_H__ */

--- a/ext/lib/crypto/tinycrypt/source/aes_decrypt.c
+++ b/ext/lib/crypto/tinycrypt/source/aes_decrypt.c
@@ -1,7 +1,7 @@
 /* aes_decrypt.c - TinyCrypt implementation of AES decryption procedure */
 
 /*
- *  Copyright (C) 2015 by Intel Corporation, All Rights Reserved.
+ *  Copyright (C) 2017 by Intel Corporation, All Rights Reserved.
  *
  *  Redistribution and use in source and binary forms, with or without
  *  modification, are permitted provided that the following conditions are met:
@@ -34,8 +34,6 @@
 #include <tinycrypt/constants.h>
 #include <tinycrypt/utils.h>
 
-#define ZERO_BYTE 0x00
-
 static const uint8_t inv_sbox[256] = {
 	0x52, 0x09, 0x6a, 0xd5, 0x30, 0x36, 0xa5, 0x38, 0xbf, 0x40, 0xa3, 0x9e,
 	0x81, 0xf3, 0xd7, 0xfb, 0x7c, 0xe3, 0x39, 0x82, 0x9b, 0x2f, 0xff, 0x87,
@@ -61,7 +59,7 @@ static const uint8_t inv_sbox[256] = {
 	0x55, 0x21, 0x0c, 0x7d
 };
 
-int32_t tc_aes128_set_decrypt_key(TCAesKeySched_t s, const uint8_t *k)
+int tc_aes128_set_decrypt_key(TCAesKeySched_t s, const uint8_t *k)
 {
 	return tc_aes128_set_encrypt_key(s, k);
 }
@@ -91,7 +89,7 @@ static inline void inv_mix_columns(uint8_t *s)
 	(void)_copy(s, sizeof(t), t, sizeof(t));
 }
 
-static inline void add_round_key(uint8_t *s, const uint32_t *k)
+static inline void add_round_key(uint8_t *s, const unsigned int *k)
 {
 	s[0] ^= (uint8_t)(k[0] >> 24); s[1] ^= (uint8_t)(k[0] >> 16);
 	s[2] ^= (uint8_t)(k[0] >> 8); s[3] ^= (uint8_t)(k[0]);
@@ -105,7 +103,7 @@ static inline void add_round_key(uint8_t *s, const uint32_t *k)
 
 static inline void inv_sub_bytes(uint8_t *s)
 {
-	uint32_t i;
+	unsigned int i;
 
 	for (i = 0; i < (Nb*Nk); ++i) {
 		s[i] = inv_sbox[s[i]];
@@ -128,10 +126,10 @@ static inline void inv_shift_rows(uint8_t *s)
 	(void)_copy(s, sizeof(t), t, sizeof(t));
 }
 
-int32_t tc_aes_decrypt(uint8_t *out, const uint8_t *in, const TCAesKeySched_t s)
+int tc_aes_decrypt(uint8_t *out, const uint8_t *in, const TCAesKeySched_t s)
 {
 	uint8_t state[Nk*Nb];
-	uint32_t i;
+	unsigned int i;
 
 	if (out == (uint8_t *) 0) {
 		return TC_CRYPTO_FAIL;
@@ -145,7 +143,7 @@ int32_t tc_aes_decrypt(uint8_t *out, const uint8_t *in, const TCAesKeySched_t s)
 
 	add_round_key(state, s->words + Nb*Nr);
 
-	for (i = Nr-1; i > 0; --i) {
+	for (i = Nr - 1; i > 0; --i) {
 		inv_shift_rows(state);
 		inv_sub_bytes(state);
 		add_round_key(state, s->words + Nb*i);
@@ -157,8 +155,10 @@ int32_t tc_aes_decrypt(uint8_t *out, const uint8_t *in, const TCAesKeySched_t s)
 	add_round_key(state, s->words);
 
 	(void)_copy(out, sizeof(state), state, sizeof(state));
-	/*zeroing out one byte state buffer */
-	_set(state, ZERO_BYTE, sizeof(state));
+
+	/*zeroing out the state buffer */
+	_set(state, TC_ZERO_BYTE, sizeof(state));
+
 
 	return TC_CRYPTO_SUCCESS;
 }

--- a/ext/lib/crypto/tinycrypt/source/aes_encrypt.c
+++ b/ext/lib/crypto/tinycrypt/source/aes_encrypt.c
@@ -1,7 +1,7 @@
 /* aes_encrypt.c - TinyCrypt implementation of AES encryption procedure */
 
 /*
- *  Copyright (C) 2015 by Intel Corporation, All Rights Reserved.
+ *  Copyright (C) 2017 by Intel Corporation, All Rights Reserved.
  *
  *  Redistribution and use in source and binary forms, with or without
  *  modification, are permitted provided that the following conditions are met:
@@ -59,7 +59,7 @@ static const uint8_t sbox[256] = {
 	0xb0, 0x54, 0xbb, 0x16
 };
 
-static inline uint32_t rotword(uint32_t a)
+static inline unsigned int rotword(unsigned int a)
 {
 	return (((a) >> 24)|((a) << 8));
 }
@@ -67,14 +67,14 @@ static inline uint32_t rotword(uint32_t a)
 #define subbyte(a, o)(sbox[((a) >> (o))&0xff] << (o))
 #define subword(a)(subbyte(a, 24)|subbyte(a, 16)|subbyte(a, 8)|subbyte(a, 0))
 
-int32_t tc_aes128_set_encrypt_key(TCAesKeySched_t s, const uint8_t *k)
+int tc_aes128_set_encrypt_key(TCAesKeySched_t s, const uint8_t *k)
 {
-	const uint32_t rconst[11] = {
-	0x00000000, 0x01000000, 0x02000000, 0x04000000, 0x08000000, 0x10000000,
-	0x20000000, 0x40000000, 0x80000000, 0x1b000000, 0x36000000
+	const unsigned int rconst[11] = {
+		0x00000000, 0x01000000, 0x02000000, 0x04000000, 0x08000000, 0x10000000,
+		0x20000000, 0x40000000, 0x80000000, 0x1b000000, 0x36000000
 	};
-	uint32_t i;
-	uint32_t t;
+	unsigned int i;
+	unsigned int t;
 
 	if (s == (TCAesKeySched_t) 0) {
 		return TC_CRYPTO_FAIL;
@@ -87,7 +87,7 @@ int32_t tc_aes128_set_encrypt_key(TCAesKeySched_t s, const uint8_t *k)
 			      (k[Nb*i+2]<<8) | (k[Nb*i+3]);
 	}
 
-	for (; i < (Nb*(Nr+1)); ++i) {
+	for (; i < (Nb * (Nr + 1)); ++i) {
 		t = s->words[i-1];
 		if ((i % Nk) == 0) {
 			t = subword(rotword(t)) ^ rconst[i/Nk];
@@ -98,7 +98,7 @@ int32_t tc_aes128_set_encrypt_key(TCAesKeySched_t s, const uint8_t *k)
 	return TC_CRYPTO_SUCCESS;
 }
 
-static inline void add_round_key(uint8_t *s, const uint32_t *k)
+static inline void add_round_key(uint8_t *s, const unsigned int *k)
 {
 	s[0] ^= (uint8_t)(k[0] >> 24); s[1] ^= (uint8_t)(k[0] >> 16);
 	s[2] ^= (uint8_t)(k[0] >> 8); s[3] ^= (uint8_t)(k[0]);
@@ -112,9 +112,9 @@ static inline void add_round_key(uint8_t *s, const uint32_t *k)
 
 static inline void sub_bytes(uint8_t *s)
 {
-	uint32_t i;
+	unsigned int i;
 
-	for (i = 0; i < (Nb*Nk); ++i) {
+	for (i = 0; i < (Nb * Nk); ++i) {
 		s[i] = sbox[s[i]];
 	}
 }
@@ -135,8 +135,8 @@ static inline void mix_columns(uint8_t *s)
 
 	mult_row_column(t, s);
 	mult_row_column(&t[Nb], s+Nb);
-	mult_row_column(&t[2*Nb], s+(2*Nb));
-	mult_row_column(&t[3*Nb], s+(3*Nb));
+	mult_row_column(&t[2 * Nb], s + (2 * Nb));
+	mult_row_column(&t[3 * Nb], s + (3 * Nb));
 	(void) _copy(s, sizeof(t), t, sizeof(t));
 }
 
@@ -146,7 +146,7 @@ static inline void mix_columns(uint8_t *s)
  */
 static inline void shift_rows(uint8_t *s)
 {
-	uint8_t t[Nb*Nk];
+	uint8_t t[Nb * Nk];
 
 	t[0]  = s[0]; t[1] = s[5]; t[2] = s[10]; t[3] = s[15];
 	t[4]  = s[4]; t[5] = s[9]; t[6] = s[14]; t[7] = s[3];
@@ -155,10 +155,10 @@ static inline void shift_rows(uint8_t *s)
 	(void) _copy(s, sizeof(t), t, sizeof(t));
 }
 
-int32_t tc_aes_encrypt(uint8_t *out, const uint8_t *in, const TCAesKeySched_t s)
+int tc_aes_encrypt(uint8_t *out, const uint8_t *in, const TCAesKeySched_t s)
 {
 	uint8_t state[Nk*Nb];
-	uint32_t i;
+	unsigned int i;
 
 	if (out == (uint8_t *) 0) {
 		return TC_CRYPTO_FAIL;
@@ -171,7 +171,7 @@ int32_t tc_aes_encrypt(uint8_t *out, const uint8_t *in, const TCAesKeySched_t s)
 	(void)_copy(state, sizeof(state), in, sizeof(state));
 	add_round_key(state, s->words);
 
-	for (i = 0; i < (Nr-1); ++i) {
+	for (i = 0; i < (Nr - 1); ++i) {
 		sub_bytes(state);
 		shift_rows(state);
 		mix_columns(state);

--- a/ext/lib/crypto/tinycrypt/source/cbc_mode.c
+++ b/ext/lib/crypto/tinycrypt/source/cbc_mode.c
@@ -1,7 +1,7 @@
 /* cbc_mode.c - TinyCrypt implementation of CBC mode encryption & decryption */
 
 /*
- *  Copyright (C) 2015 by Intel Corporation, All Rights Reserved.
+ *  Copyright (C) 2017 by Intel Corporation, All Rights Reserved.
  *
  *  Redistribution and use in source and binary forms, with or without
  *  modification, are permitted provided that the following conditions are met:
@@ -34,13 +34,13 @@
 #include <tinycrypt/constants.h>
 #include <tinycrypt/utils.h>
 
-int32_t tc_cbc_mode_encrypt(uint8_t *out, uint32_t outlen, const uint8_t *in,
-			    uint32_t inlen, const uint8_t *iv,
+int tc_cbc_mode_encrypt(uint8_t *out, unsigned int outlen, const uint8_t *in,
+			    unsigned int inlen, const uint8_t *iv,
 			    const TCAesKeySched_t sched)
 {
 
 	uint8_t buffer[TC_AES_BLOCK_SIZE];
-	uint32_t n, m;
+	unsigned int n, m;
 
 	/* input sanity check: */
 	if (out == (uint8_t *) 0 ||
@@ -74,13 +74,14 @@ int32_t tc_cbc_mode_encrypt(uint8_t *out, uint32_t outlen, const uint8_t *in,
 	return TC_CRYPTO_SUCCESS;
 }
 
-int32_t tc_cbc_mode_decrypt(uint8_t *out, uint32_t outlen, const uint8_t *in,
-			    uint32_t inlen, const uint8_t *iv,
+int tc_cbc_mode_decrypt(uint8_t *out, unsigned int outlen, const uint8_t *in,
+			    unsigned int inlen, const uint8_t *iv,
 			    const TCAesKeySched_t sched)
 {
+
 	uint8_t buffer[TC_AES_BLOCK_SIZE];
 	const uint8_t *p;
-	uint32_t n, m;
+	unsigned int n, m;
 
 	/* sanity check the inputs */
 	if (out == (uint8_t *) 0 ||

--- a/ext/lib/crypto/tinycrypt/source/cmac_mode.c
+++ b/ext/lib/crypto/tinycrypt/source/cmac_mode.c
@@ -1,7 +1,7 @@
 /* cmac_mode.c - TinyCrypt CMAC mode implementation */
 
 /*
- *  Copyright (C) 2015 by Intel Corporation, All Rights Reserved.
+ *  Copyright (C) 2017 by Intel Corporation, All Rights Reserved.
  *
  *  Redistribution and use in source and binary forms, with or without
  *  modification, are permitted provided that the following conditions are met:
@@ -36,7 +36,7 @@
 #include <tinycrypt/utils.h>
 
 /* max number of calls until change the key (2^48).*/
-static uint64_t MAX_CALLS = ((uint64_t)1 << 48);
+const static uint64_t MAX_CALLS = ((uint64_t)1 << 48);
 
 /*
  *  gf_wrap -- In our implementation, GF(2^128) is represented as a 16 byte
@@ -94,7 +94,7 @@ void gf_double(uint8_t *out, uint8_t *in)
 	}
 }
 
-int32_t tc_cmac_setup(TCCmacState_t s, const uint8_t *key, TCAesKeySched_t sched)
+int tc_cmac_setup(TCCmacState_t s, const uint8_t *key, TCAesKeySched_t sched)
 {
 
 	/* input sanity check: */
@@ -122,7 +122,7 @@ int32_t tc_cmac_setup(TCCmacState_t s, const uint8_t *key, TCAesKeySched_t sched
 	return TC_CRYPTO_SUCCESS;
 }
 
-int32_t tc_cmac_erase(TCCmacState_t s)
+int tc_cmac_erase(TCCmacState_t s)
 {
 	if (s == (TCCmacState_t) 0) {
 		return TC_CRYPTO_FAIL;
@@ -134,7 +134,7 @@ int32_t tc_cmac_erase(TCCmacState_t s)
 	return TC_CRYPTO_SUCCESS;
 }
 
-int32_t tc_cmac_init(TCCmacState_t s)
+int tc_cmac_init(TCCmacState_t s)
 {
 	/* input sanity check: */
 	if (s == (TCCmacState_t) 0) {
@@ -154,9 +154,9 @@ int32_t tc_cmac_init(TCCmacState_t s)
 	return TC_CRYPTO_SUCCESS;
 }
 
-int32_t tc_cmac_update(TCCmacState_t s, const uint8_t *data, size_t data_length)
+int tc_cmac_update(TCCmacState_t s, const uint8_t *data, size_t data_length)
 {
-	uint32_t i;
+	unsigned int i;
 
 	/* input sanity check: */
 	if (s == (TCCmacState_t) 0) {
@@ -219,10 +219,10 @@ int32_t tc_cmac_update(TCCmacState_t s, const uint8_t *data, size_t data_length)
 	return TC_CRYPTO_SUCCESS;
 }
 
-int32_t tc_cmac_final(uint8_t *tag, TCCmacState_t s)
+int tc_cmac_final(uint8_t *tag, TCCmacState_t s)
 {
 	uint8_t *k;
-	uint32_t i;
+	unsigned int i;
 
 	/* input sanity check: */
 	if (tag == (uint8_t *) 0 ||

--- a/ext/lib/crypto/tinycrypt/source/ctr_mode.c
+++ b/ext/lib/crypto/tinycrypt/source/ctr_mode.c
@@ -1,7 +1,7 @@
 /* ctr_mode.c - TinyCrypt CTR mode implementation */
 
 /*
- *  Copyright (C) 2015 by Intel Corporation, All Rights Reserved.
+ *  Copyright (C) 2017 by Intel Corporation, All Rights Reserved.
  *
  *  Redistribution and use in source and binary forms, with or without
  *  modification, are permitted provided that the following conditions are met:
@@ -34,14 +34,14 @@
 #include <tinycrypt/ctr_mode.h>
 #include <tinycrypt/utils.h>
 
-int32_t tc_ctr_mode(uint8_t *out, uint32_t outlen, const uint8_t *in,
-		    uint32_t inlen, uint8_t *ctr, const TCAesKeySched_t sched)
+int tc_ctr_mode(uint8_t *out, unsigned int outlen, const uint8_t *in,
+		unsigned int inlen, uint8_t *ctr, const TCAesKeySched_t sched)
 {
 
 	uint8_t buffer[TC_AES_BLOCK_SIZE];
 	uint8_t nonce[TC_AES_BLOCK_SIZE];
-	uint32_t block_num;
-	uint32_t i;
+	unsigned int block_num;
+	unsigned int i;
 
 	/* input sanity check: */
 	if (out == (uint8_t *) 0 ||

--- a/ext/lib/crypto/tinycrypt/source/ctr_prng.c
+++ b/ext/lib/crypto/tinycrypt/source/ctr_prng.c
@@ -50,15 +50,12 @@
  *  @param arr IN/OUT -- array to be incremented
  *  @param len IN -- size of arr in bytes
  */
-static void arrInc(uint8_t arr[], uint32_t len)
+static void arrInc(uint8_t arr[], unsigned int len)
 {
-	uint32_t i;
-	if (0 != arr)
-	{
-		for (i = len; i > 0U; i--)
-		{
-			if (++arr[i-1] != 0U)
-			{
+	unsigned int i;
+	if (0 != arr) {
+		for (i = len; i > 0U; i--) {
+			if (++arr[i-1] != 0U) {
 				break;
 			}
 		}
@@ -76,24 +73,21 @@ static void arrInc(uint8_t arr[], uint32_t len)
  */
 static void tc_ctr_prng_update(TCCtrPrng_t * const ctx, uint8_t const * const providedData)
 {
-	if (0 != ctx)
-	{
+	if (0 != ctx) {
 		/* 10.2.1.2 step 1 */
 		uint8_t temp[TC_AES_KEY_SIZE + TC_AES_BLOCK_SIZE];
-		uint32_t len = 0U;
+		unsigned int len = 0U;
 
 		/* 10.2.1.2 step 2 */
-		while (len < sizeof temp)
-		{
-			uint32_t blocklen = sizeof(temp) - len;
+		while (len < sizeof temp) {
+			unsigned int blocklen = sizeof(temp) - len;
 			uint8_t output_block[TC_AES_BLOCK_SIZE];
 
 			/* 10.2.1.2 step 2.1 */
 			arrInc(ctx->V, sizeof ctx->V);
 
 			/* 10.2.1.2 step 2.2 */
-			if (blocklen > TC_AES_BLOCK_SIZE)
-			{
+			if (blocklen > TC_AES_BLOCK_SIZE) {
 				blocklen = TC_AES_BLOCK_SIZE;
 			}
 			(void)tc_aes_encrypt(output_block, ctx->V, &ctx->key);
@@ -105,11 +99,9 @@ static void tc_ctr_prng_update(TCCtrPrng_t * const ctx, uint8_t const * const pr
 		}
 
 		/* 10.2.1.2 step 4 */
-		if (0 != providedData)
-		{
-			uint32_t i;
-			for (i = 0U; i < sizeof temp; i++)
-			{
+		if (0 != providedData) {
+			unsigned int i;
+			for (i = 0U; i < sizeof temp; i++) {
 				temp[i] ^= providedData[i];
 			}
 		}
@@ -122,24 +114,22 @@ static void tc_ctr_prng_update(TCCtrPrng_t * const ctx, uint8_t const * const pr
 	}
 }
 
-int32_t tc_ctr_prng_init(TCCtrPrng_t * const ctx, 
-			uint8_t const * const entropy,
-			uint32_t entropyLen, 
-			uint8_t const * const personalization,
-			uint32_t pLen)
+int tc_ctr_prng_init(TCCtrPrng_t * const ctx, 
+		     uint8_t const * const entropy,
+		     unsigned int entropyLen, 
+		     uint8_t const * const personalization,
+		     unsigned int pLen)
 {
-	int32_t result = TC_CRYPTO_FAIL;	
-	uint32_t i;
+	int result = TC_CRYPTO_FAIL;	
+	unsigned int i;
 	uint8_t personalization_buf[TC_AES_KEY_SIZE + TC_AES_BLOCK_SIZE] = {0U};
 	uint8_t seed_material[TC_AES_KEY_SIZE + TC_AES_BLOCK_SIZE];
 	uint8_t zeroArr[TC_AES_BLOCK_SIZE] = {0U};
   
-	if (0 != personalization)
-	{
+	if (0 != personalization) {
 		/* 10.2.1.3.1 step 1 */
-		uint32_t len = pLen;
-		if (len > sizeof personalization_buf)
-		{
+		unsigned int len = pLen;
+		if (len > sizeof personalization_buf) {
 			len = sizeof personalization_buf;
 		}
 
@@ -147,12 +137,10 @@ int32_t tc_ctr_prng_init(TCCtrPrng_t * const ctx,
 		memcpy(personalization_buf, personalization, len);
 	}
 
-	if ((0 != ctx) && (0 != entropy) && (entropyLen >= sizeof seed_material))
-	{
+	if ((0 != ctx) && (0 != entropy) && (entropyLen >= sizeof seed_material)) {
 		/* 10.2.1.3.1 step 3 */
 		memcpy(seed_material, entropy, sizeof seed_material);
-		for (i = 0U; i < sizeof seed_material; i++)
-		{
+		for (i = 0U; i < sizeof seed_material; i++) {
 			seed_material[i] ^= personalization_buf[i];
 		}
 
@@ -173,23 +161,21 @@ int32_t tc_ctr_prng_init(TCCtrPrng_t * const ctx,
 	return result;
 }
 
-int32_t tc_ctr_prng_reseed(TCCtrPrng_t * const ctx, 
+int tc_ctr_prng_reseed(TCCtrPrng_t * const ctx, 
 			uint8_t const * const entropy,
-			uint32_t entropyLen,
+			unsigned int entropyLen,
 			uint8_t const * const additional_input,
-			uint32_t additionallen)
+			unsigned int additionallen)
 {
-	uint32_t i;
-	int32_t result = TC_CRYPTO_FAIL;
+	unsigned int i;
+	int result = TC_CRYPTO_FAIL;
 	uint8_t additional_input_buf[TC_AES_KEY_SIZE + TC_AES_BLOCK_SIZE] = {0U};
 	uint8_t seed_material[TC_AES_KEY_SIZE + TC_AES_BLOCK_SIZE];
 
-	if (0 != additional_input)
-	{
+	if (0 != additional_input) {
 		/* 10.2.1.4.1 step 1 */
-		uint32_t len = additionallen;
-		if (len > sizeof additional_input_buf)
-		{
+		unsigned int len = additionallen;
+		if (len > sizeof additional_input_buf) {
 			len = sizeof additional_input_buf;
 		}
 
@@ -197,13 +183,11 @@ int32_t tc_ctr_prng_reseed(TCCtrPrng_t * const ctx,
 		memcpy(additional_input_buf, additional_input, len);
 	}
 	
-	uint32_t seedlen = (uint32_t)TC_AES_KEY_SIZE + (uint32_t)TC_AES_BLOCK_SIZE;
-	if ((0 != ctx) && (entropyLen >= seedlen))
-	{
+	unsigned int seedlen = (unsigned int)TC_AES_KEY_SIZE + (unsigned int)TC_AES_BLOCK_SIZE;
+	if ((0 != ctx) && (entropyLen >= seedlen)) {
 		/* 10.2.1.4.1 step 3 */
 		memcpy(seed_material, entropy, sizeof seed_material);
-		for (i = 0U; i < sizeof seed_material; i++)
-		{
+		for (i = 0U; i < sizeof seed_material; i++) {
 			seed_material[i] ^= additional_input_buf[i];
 		}
 
@@ -218,36 +202,30 @@ int32_t tc_ctr_prng_reseed(TCCtrPrng_t * const ctx,
 	return result;
 }
 
-int32_t tc_ctr_prng_generate(TCCtrPrng_t * const ctx,
+int tc_ctr_prng_generate(TCCtrPrng_t * const ctx,
 			uint8_t const * const additional_input,
-			uint32_t additionallen,
+			unsigned int additionallen,
 			uint8_t * const out,
-			uint32_t outlen)
+			unsigned int outlen)
 {
 	/* 2^48 - see section 10.2.1 */
 	static const uint64_t MAX_REQS_BEFORE_RESEED = 0x1000000000000ULL; 
 
 	/* 2^19 bits - see section 10.2.1 */ 
-	static const uint32_t MAX_BYTES_PER_REQ = 65536U; 
+	static const unsigned int MAX_BYTES_PER_REQ = 65536U; 
 
-	int32_t result = TC_CRYPTO_FAIL;
+	unsigned int result = TC_CRYPTO_FAIL;
 
-	if ((0 != ctx) && (0 != out) && (outlen < MAX_BYTES_PER_REQ))
-	{
+	if ((0 != ctx) && (0 != out) && (outlen < MAX_BYTES_PER_REQ)) {
 		/* 10.2.1.5.1 step 1 */
-		if (ctx->reseedCount > MAX_REQS_BEFORE_RESEED)
-		{
+		if (ctx->reseedCount > MAX_REQS_BEFORE_RESEED) {
 			result = TC_CTR_PRNG_RESEED_REQ;
-		}
-		else
-		{
+		} else {
 			uint8_t additional_input_buf[TC_AES_KEY_SIZE + TC_AES_BLOCK_SIZE] = {0U};
-			if (0 != additional_input)
-			{
+			if (0 != additional_input) {
 				/* 10.2.1.5.1 step 2  */
-				uint32_t len = additionallen;
-				if (len > sizeof additional_input_buf)
-				{
+				unsigned int len = additionallen;
+				if (len > sizeof additional_input_buf) {
 					len = sizeof additional_input_buf;
 				}
 				memcpy(additional_input_buf, additional_input, len);
@@ -257,10 +235,9 @@ int32_t tc_ctr_prng_generate(TCCtrPrng_t * const ctx,
 			/* 10.2.1.5.1 step 3 - implicit */
 
 			/* 10.2.1.5.1 step 4 */
-			uint32_t len = 0U;      
-			while (len < outlen)
-			{
-				uint32_t blocklen = outlen - len;
+			unsigned int len = 0U;      
+			while (len < outlen) {
+				unsigned int blocklen = outlen - len;
 				uint8_t output_block[TC_AES_BLOCK_SIZE];
 
 				/* 10.2.1.5.1 step 4.1 */
@@ -270,8 +247,7 @@ int32_t tc_ctr_prng_generate(TCCtrPrng_t * const ctx,
 				(void)tc_aes_encrypt(output_block, ctx->V, &ctx->key);
       
 				/* 10.2.1.5.1 step 4.3/step 5 */
-				if (blocklen > TC_AES_BLOCK_SIZE)
-				{
+				if (blocklen > TC_AES_BLOCK_SIZE) {
 					blocklen = TC_AES_BLOCK_SIZE;
 				}
 				memcpy(&(out[len]), output_block, blocklen);
@@ -295,8 +271,7 @@ int32_t tc_ctr_prng_generate(TCCtrPrng_t * const ctx,
 
 void tc_ctr_prng_uninstantiate(TCCtrPrng_t * const ctx)
 {
-	if (0 != ctx)
-	{
+	if (0 != ctx) {
 		memset(ctx->key.words, 0x00, sizeof ctx->key.words);
 		memset(ctx->V,         0x00, sizeof ctx->V);
 		ctx->reseedCount = 0U;

--- a/ext/lib/crypto/tinycrypt/source/ecc.c
+++ b/ext/lib/crypto/tinycrypt/source/ecc.c
@@ -1,625 +1,942 @@
-/* ecc.c - TinyCrypt implementation of ECC auxiliary functions */
+/* ecc.c - TinyCrypt implementation of common ECC functions */
 
 /*
-  *
-  * Copyright (c) 2013, Kenneth MacKay
-  * All rights reserved.
-  * https://github.com/kmackay/micro-ecc
-  *
-  *  Redistribution and use in source and binary forms, with or without modification,
-  *  are permitted provided that the following conditions are met:
-  * * Redistributions of source code must retain the above copyright notice, this
-  * list of conditions and the following disclaimer.
-  * * Redistributions in binary form must reproduce the above copyright notice,
-  * this list of conditions and the following disclaimer in the documentation
-  * and/or other materials provided with the distribution.
-  *
-  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
-  * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
-  * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
-  * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR
-  * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
-  * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
-  * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
-  * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
-  * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
-  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-  *
-  *  Copyright (C) 2015 by Intel Corporation, All Rights Reserved.
-  *
-  *  Redistribution and use in source and binary forms, with or without
-  *  modification, are permitted provided that the following conditions are met:
-  *
-  *    - Redistributions of source code must retain the above copyright notice,
-  *     this list of conditions and the following disclaimer.
-  *
-  *    - Redistributions in binary form must reproduce the above copyright
-  *    notice, this list of conditions and the following disclaimer in the
-  *    documentation and/or other materials provided with the distribution.
-  *
-  *    - Neither the name of Intel Corporation nor the names of its contributors
-  *    may be used to endorse or promote products derived from this software
-  *    without specific prior written permission.
-  *
-  *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
-  *  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
-  *  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
-  *  ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
-  *  LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
-  *  CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
-  *  SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
-  *  INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
-  *  CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
-  *  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
-  *  POSSIBILITY OF SUCH DAMAGE.
-  */
+ * Copyright (c) 2014, Kenneth MacKay
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * * Redistributions of source code must retain the above copyright notice,
+ * this list of conditions and the following disclaimer.
+ * * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ *  Copyright (C) 2017 by Intel Corporation, All Rights Reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions are met:
+ *
+ *    - Redistributions of source code must retain the above copyright notice,
+ *     this list of conditions and the following disclaimer.
+ *
+ *    - Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ *    - Neither the name of Intel Corporation nor the names of its contributors
+ *    may be used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ *  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ *  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ *  ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+ *  LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ *  CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ *  SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ *  INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ *  CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ *  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ */
 
 #include <tinycrypt/ecc.h>
+#include <tinycrypt/ecc_platform_specific.h>
+#include <string.h>
 
-/* ------ Curve NIST P-256 constants: ------ */
+/* IMPORTANT: Make sure a cryptographically-secure PRNG is set and the platform
+ * has access to enough entropy in order to feed the PRNG regularly. */
+#if default_RNG_defined
+static uECC_RNG_Function g_rng_function = &default_CSPRNG;
+#else
+static uECC_RNG_Function g_rng_function = 0;
+#endif
 
-#define Curve_P {0xFFFFFFFF, 0xFFFFFFFF, 0xFFFFFFFF, 0x00000000,	\
-			0x00000000, 0x00000000, 0x00000001, 0xFFFFFFFF}
-
-#define Curve_B {0x27D2604B, 0x3BCE3C3E, 0xCC53B0F6, 0x651D06B0,	\
-			0x769886BC, 0xB3EBBD55, 0xAA3A93E7, 0x5AC635D8}
-
-#define Curve_N {0xFC632551, 0xF3B9CAC2, 0xA7179E84, 0xBCE6FAAD,	\
-			0xFFFFFFFF, 0xFFFFFFFF, 0x00000000, 0xFFFFFFFF}
-
-#define Curve_G {{0xD898C296, 0xF4A13945, 0x2DEB33A0, 0x77037D81,	\
-				0x63A440F2, 0xF8BCE6E5, 0xE12C4247, 0x6B17D1F2}, \
-		{0x37BF51F5, 0xCBB64068, 0x6B315ECE, 0x2BCE3357,	\
-				0x7C0F9E16, 0x8EE7EB4A, 0xFE1A7F9B, 0x4FE342E2} }
-
-#define Curve_P_Barrett {0x00000003, 0x00000000, 0xFFFFFFFF, 0xFFFFFFFE, \
-			0xFFFFFFFE, 0xFFFFFFFE, 0xFFFFFFFF, 0x00000000, 0x00000001}
-
-#define Curve_N_Barrett {0xEEDF9BFE, 0x012FFD85, 0xDF1A6C21, 0x43190552, \
-			0xFFFFFFFF, 0xFFFFFFFE, 0xFFFFFFFF, 0x00000000, 0x00000001}
-
-uint32_t curve_p[NUM_ECC_DIGITS] = Curve_P;
-uint32_t curve_b[NUM_ECC_DIGITS] = Curve_B;
-EccPoint curve_G = Curve_G;
-uint32_t curve_n[NUM_ECC_DIGITS] = Curve_N;
-uint32_t curve_pb[NUM_ECC_DIGITS + 1] = Curve_P_Barrett;
-uint32_t curve_nb[NUM_ECC_DIGITS + 1] = Curve_N_Barrett;
-
-/* ------ Static functions: ------ */
-
-/* Zeroing out p_vli. */
-static void vli_clear(uint32_t *p_vli)
+void uECC_set_rng(uECC_RNG_Function rng_function)
 {
-	uint32_t i;
+	g_rng_function = rng_function;
+}
 
-	for (i = 0; i < NUM_ECC_DIGITS; ++i) {
-		p_vli[i] = 0;
+uECC_RNG_Function uECC_get_rng(void)
+{
+	return g_rng_function;
+}
+
+int uECC_curve_private_key_size(uECC_Curve curve)
+{
+	return BITS_TO_BYTES(curve->num_n_bits);
+}
+
+int uECC_curve_public_key_size(uECC_Curve curve)
+{
+	return 2 * curve->num_bytes;
+}
+
+void uECC_vli_clear(uECC_word_t *vli, wordcount_t num_words)
+{
+	wordcount_t i;
+	for (i = 0; i < num_words; ++i) {
+		 vli[i] = 0;
 	}
 }
 
-/* Returns nonzero if bit p_bit of p_vli is set.
- * It is assumed that the value provided in 'bit' is within
- * the boundaries of the word-array 'p_vli'.*/
-static uint32_t vli_testBit(uint32_t *p_vli, uint32_t p_bit)
+uECC_word_t uECC_vli_isZero(const uECC_word_t *vli, wordcount_t num_words)
 {
-	return (p_vli[p_bit / 32] & (1 << (p_bit % 32)));
+	uECC_word_t bits = 0;
+	wordcount_t i;
+	for (i = 0; i < num_words; ++i) {
+		bits |= vli[i];
+	}
+	return (bits == 0);
 }
 
-uint32_t vli_isZero(uint32_t *p_vli)
+uECC_word_t uECC_vli_testBit(const uECC_word_t *vli, bitcount_t bit)
 {
-	uint32_t acc = 0;
+	return (vli[bit >> uECC_WORD_BITS_SHIFT] &
+		((uECC_word_t)1 << (bit & uECC_WORD_BITS_MASK)));
+}
 
-	for (uint32_t i = 0; i < NUM_ECC_DIGITS; ++i) {
-		acc |= p_vli[i];
+/* Counts the number of words in vli. */
+static wordcount_t vli_numDigits(const uECC_word_t *vli,
+				 const wordcount_t max_words)
+{
+
+	wordcount_t i;
+	/* Search from the end until we find a non-zero digit. We do it in reverse
+	 * because we expect that most digits will be nonzero. */
+	for (i = max_words - 1; i >= 0 && vli[i] == 0; --i) {
 	}
 
-	return (!acc);
+	return (i + 1);
 }
 
-/*
- * Find the right-most nonzero 32-bit "digits" in p_vli.
- *
- * Side-channel countermeasure: algorithm strengthened against timing attack.
- */
-static uint32_t vli_numDigits(uint32_t *p_vli)
+bitcount_t uECC_vli_numBits(const uECC_word_t *vli,
+			    const wordcount_t max_words)
 {
-	int32_t i;
-	uint32_t digits = 0;
 
-	for (i = NUM_ECC_DIGITS - 1; i >= 0 ; --i) {
-		digits += p_vli[i] || digits;
+	uECC_word_t i;
+	uECC_word_t digit;
+
+	wordcount_t num_digits = vli_numDigits(vli, max_words);
+	if (num_digits == 0) {
+		return 0;
 	}
 
-	return digits;
-}
-
-/*
- * Find the left-most non-zero bit in p_vli.
- *
- * Side-channel countermeasure: algorithm strengthened against timing attack.
- */
-static uint32_t vli_numBits(uint32_t *p_vli)
-{
-	uint32_t l_digit;
-	uint32_t i, acc = 32;
-	uint32_t l_numDigits = vli_numDigits(p_vli);
-
-	l_digit = p_vli[l_numDigits - 1];
-
-	for (i = 0; i < 32; ++i) {
-		acc -= !l_digit;
-		l_digit >>= 1;
+	digit = vli[num_digits - 1];
+	for (i = 0; digit; ++i) {
+		digit >>= 1;
 	}
 
-	return ((l_numDigits - 1) * 32 + acc);
+	return (((bitcount_t)(num_digits - 1) << uECC_WORD_BITS_SHIFT) + i);
 }
 
-/*
- * Computes p_result = p_left + p_right, returns carry.
- *
- * Side-channel countermeasure: algorithm strengthened against timing attack.
- */
-static uint32_t vli_add(uint32_t *p_result, uint32_t *p_left,
-			uint32_t *p_right)
+void uECC_vli_set(uECC_word_t *dest, const uECC_word_t *src,
+		  wordcount_t num_words)
 {
+	wordcount_t i;
 
-	uint32_t l_carry = 0;
-
-	for (uint32_t i = 0; i < NUM_ECC_DIGITS; ++i) {
-		uint32_t l_sum = p_left[i] + p_right[i] + l_carry;
-
-		l_carry = (l_sum < p_left[i]) | ((l_sum == p_left[i]) && l_carry);
-		p_result[i] = l_sum;
-	}
-
-	return l_carry;
+	for (i = 0; i < num_words; ++i) {
+		dest[i] = src[i];
+  	}
 }
 
-
-/* Computes p_result = p_left * p_right. */
-static void vli_mult(uint32_t *p_result, uint32_t *p_left,
-		     uint32_t *p_right, uint32_t word_size)
+cmpresult_t uECC_vli_cmp_unsafe(const uECC_word_t *left,
+				const uECC_word_t *right,
+				wordcount_t num_words)
 {
+	wordcount_t i;
 
-	uint64_t r01 = 0;
-	uint32_t r2 = 0;
-
-	/* Compute each digit of p_result in sequence, maintaining the carries. */
-	for (uint32_t k = 0; k < word_size*2 - 1; ++k) {
-
-		uint32_t l_min = (k < word_size ? 0 : (k + 1) - word_size);
-
-		for (uint32_t i = l_min; i <= k && i < word_size; ++i) {
-
-			uint64_t l_product = (uint64_t)p_left[i] * p_right[k - i];
-
-			r01 += l_product;
-			r2 += (r01 < l_product);
+	for (i = num_words - 1; i >= 0; --i) {
+		if (left[i] > right[i]) {
+			return 1;
+		} else if (left[i] < right[i]) {
+			return -1;
 		}
-		p_result[k] = (uint32_t)r01;
-		r01 = (r01 >> 32) | (((uint64_t)r2) << 32);
+	}
+	return 0;
+}
+
+uECC_word_t uECC_vli_equal(const uECC_word_t *left, const uECC_word_t *right,
+			   wordcount_t num_words)
+{
+
+	uECC_word_t diff = 0;
+	wordcount_t i;
+
+	for (i = num_words - 1; i >= 0; --i) {
+		diff |= (left[i] ^ right[i]);
+	}
+	return !(diff == 0);
+}
+
+uECC_word_t cond_set(uECC_word_t p_true, uECC_word_t p_false, unsigned int cond)
+{
+	return (p_true*(cond)) | (p_false*(!cond));
+}
+
+/* Computes result = left - right, returning borrow, in constant time.
+ * Can modify in place. */
+uECC_word_t uECC_vli_sub(uECC_word_t *result, const uECC_word_t *left,
+			 const uECC_word_t *right, wordcount_t num_words)
+{
+	uECC_word_t borrow = 0;
+	wordcount_t i;
+	for (i = 0; i < num_words; ++i) {
+		uECC_word_t diff = left[i] - right[i] - borrow;
+		uECC_word_t val = (diff > left[i]);
+		borrow = cond_set(val, borrow, (diff != left[i]));
+
+		result[i] = diff;
+	}
+	return borrow;
+}
+
+/* Computes result = left + right, returning carry, in constant time.
+ * Can modify in place. */
+static uECC_word_t uECC_vli_add(uECC_word_t *result, const uECC_word_t *left,
+				const uECC_word_t *right, wordcount_t num_words)
+{
+	uECC_word_t carry = 0;
+	wordcount_t i;
+	for (i = 0; i < num_words; ++i) {
+		uECC_word_t sum = left[i] + right[i] + carry;
+		uECC_word_t val = (sum < left[i]);
+		carry = cond_set(val, carry, (sum != left[i]));
+		result[i] = sum;
+	}
+	return carry;
+}
+
+cmpresult_t uECC_vli_cmp(const uECC_word_t *left, const uECC_word_t *right,
+			 wordcount_t num_words)
+{
+	uECC_word_t tmp[NUM_ECC_WORDS];
+	uECC_word_t neg = !!uECC_vli_sub(tmp, left, right, num_words);
+	uECC_word_t equal = uECC_vli_isZero(tmp, num_words);
+	return (!equal - 2 * neg);
+}
+
+/* Computes vli = vli >> 1. */
+static void uECC_vli_rshift1(uECC_word_t *vli, wordcount_t num_words)
+{
+	uECC_word_t *end = vli;
+	uECC_word_t carry = 0;
+
+	vli += num_words;
+	while (vli-- > end) {
+		uECC_word_t temp = *vli;
+		*vli = (temp >> 1) | carry;
+		carry = temp << (uECC_WORD_BITS - 1);
+	}
+}
+
+static void muladd(uECC_word_t a, uECC_word_t b, uECC_word_t *r0,
+		   uECC_word_t *r1, uECC_word_t *r2)
+{
+
+	uECC_dword_t p = (uECC_dword_t)a * b;
+	uECC_dword_t r01 = ((uECC_dword_t)(*r1) << uECC_WORD_BITS) | *r0;
+	r01 += p;
+	*r2 += (r01 < p);
+	*r1 = r01 >> uECC_WORD_BITS;
+	*r0 = (uECC_word_t)r01;
+
+}
+
+/* Computes result = left * right. Result must be 2 * num_words long. */
+static void uECC_vli_mult(uECC_word_t *result, const uECC_word_t *left,
+			  const uECC_word_t *right, wordcount_t num_words)
+{
+
+	uECC_word_t r0 = 0;
+	uECC_word_t r1 = 0;
+	uECC_word_t r2 = 0;
+	wordcount_t i, k;
+
+	/* Compute each digit of result in sequence, maintaining the carries. */
+	for (k = 0; k < num_words; ++k) {
+
+		for (i = 0; i <= k; ++i) {
+			muladd(left[i], right[k - i], &r0, &r1, &r2);
+		}
+
+		result[k] = r0;
+		r0 = r1;
+		r1 = r2;
 		r2 = 0;
 	}
 
-	p_result[word_size * 2 - 1] = (uint32_t)r01;
+	for (k = num_words; k < num_words * 2 - 1; ++k) {
+
+		for (i = (k + 1) - num_words; i < num_words; ++i) {
+			muladd(left[i], right[k - i], &r0, &r1, &r2);
+		}
+		result[k] = r0;
+		r0 = r1;
+		r1 = r2;
+		r2 = 0;
+	}
+	result[num_words * 2 - 1] = r0;
 }
 
-/* Computes p_result = p_left^2. */
-static void vli_square(uint32_t *p_result, uint32_t *p_left)
+void uECC_vli_modAdd(uECC_word_t *result, const uECC_word_t *left,
+		     const uECC_word_t *right, const uECC_word_t *mod,
+		     wordcount_t num_words)
 {
+	uECC_word_t carry = uECC_vli_add(result, left, right, num_words);
+	if (carry || uECC_vli_cmp_unsafe(mod, result, num_words) != 1) {
+	/* result > mod (result = mod + remainder), so subtract mod to get
+	 * remainder. */
+		uECC_vli_sub(result, result, mod, num_words);
+	}
+}
 
-	uint64_t r01 = 0;
-	uint32_t r2 = 0;
-	uint32_t i, k;
+void uECC_vli_modSub(uECC_word_t *result, const uECC_word_t *left,
+		     const uECC_word_t *right, const uECC_word_t *mod,
+		     wordcount_t num_words)
+{
+	uECC_word_t l_borrow = uECC_vli_sub(result, left, right, num_words);
+	if (l_borrow) {
+		/* In this case, result == -diff == (max int) - diff. Since -x % d == d - x,
+		 * we can get the correct result from result + mod (with overflow). */
+		uECC_vli_add(result, result, mod, num_words);
+	}
+}
 
-	for (k = 0; k < NUM_ECC_DIGITS * 2 - 1; ++k) {
+/* Computes result = product % mod, where product is 2N words long. */
+/* Currently only designed to work for curve_p or curve_n. */
+void uECC_vli_mmod(uECC_word_t *result, uECC_word_t *product,
+    		   const uECC_word_t *mod, wordcount_t num_words)
+{
+	uECC_word_t mod_multiple[2 * NUM_ECC_WORDS];
+	uECC_word_t tmp[2 * NUM_ECC_WORDS];
+	uECC_word_t *v[2] = {tmp, product};
+	uECC_word_t index;
 
-		uint32_t l_min = (k < NUM_ECC_DIGITS ? 0 : (k + 1) - NUM_ECC_DIGITS);
+	/* Shift mod so its highest set bit is at the maximum position. */
+	bitcount_t shift = (num_words * 2 * uECC_WORD_BITS) -
+			   uECC_vli_numBits(mod, num_words);
+	wordcount_t word_shift = shift / uECC_WORD_BITS;
+	wordcount_t bit_shift = shift % uECC_WORD_BITS;
+	uECC_word_t carry = 0;
+	uECC_vli_clear(mod_multiple, word_shift);
+	if (bit_shift > 0) {
+		for(index = 0; index < (uECC_word_t)num_words; ++index) {
+			mod_multiple[word_shift + index] = (mod[index] << bit_shift) | carry;
+			carry = mod[index] >> (uECC_WORD_BITS - bit_shift);
+		}
+	} else {
+		uECC_vli_set(mod_multiple + word_shift, mod, num_words);
+	}
 
-		for (i = l_min; i <= k && i <= k - i; ++i) {
-
-			uint64_t l_product = (uint64_t)p_left[i] * p_left[k - i];
-
-			if (i < k - i) {
-
-				r2 += l_product >> 63;
-				l_product *= 2;
+	for (index = 1; shift >= 0; --shift) {
+		uECC_word_t borrow = 0;
+		wordcount_t i;
+		for (i = 0; i < num_words * 2; ++i) {
+			uECC_word_t diff = v[index][i] - mod_multiple[i] - borrow;
+			if (diff != v[index][i]) {
+				borrow = (diff > v[index][i]);
 			}
-			r01 += l_product;
-			r2 += (r01 < l_product);
+			v[1 - index][i] = diff;
 		}
-		p_result[k] = (uint32_t)r01;
-		r01 = (r01 >> 32) | (((uint64_t)r2) << 32);
-		r2 = 0;
+		/* Swap the index if there was no borrow */
+		index = !(index ^ borrow);
+		uECC_vli_rshift1(mod_multiple, num_words);
+		mod_multiple[num_words - 1] |= mod_multiple[num_words] <<
+					       (uECC_WORD_BITS - 1);
+		uECC_vli_rshift1(mod_multiple + num_words, num_words);
 	}
-
-	p_result[NUM_ECC_DIGITS * 2 - 1] = (uint32_t)r01;
+	uECC_vli_set(result, v[index], num_words);
 }
 
-/* Computes p_result = p_product % curve_p using Barrett reduction. */
-void vli_mmod_barrett(uint32_t *p_result, uint32_t *p_product,
-			     uint32_t *p_mod, uint32_t *p_barrett)
+void uECC_vli_modMult(uECC_word_t *result, const uECC_word_t *left,
+		      const uECC_word_t *right, const uECC_word_t *mod,
+		      wordcount_t num_words)
 {
-	uint32_t i;
-	uint32_t q1[NUM_ECC_DIGITS + 1];
-
-	for (i = NUM_ECC_DIGITS - 1; i < 2 * NUM_ECC_DIGITS; i++) {
-		q1[i - (NUM_ECC_DIGITS - 1)] = p_product[i];
-	}
-
-	uint32_t q2[2*NUM_ECC_DIGITS + 2];
-
-	vli_mult(q2, q1, p_barrett, NUM_ECC_DIGITS + 1);
-	for (i = NUM_ECC_DIGITS + 1; i < 2 * NUM_ECC_DIGITS + 2; i++) {
-		q1[i - (NUM_ECC_DIGITS + 1)] = q2[i];
-	}
-
-	uint32_t prime2[2*NUM_ECC_DIGITS];
-
-	for (i = 0; i < NUM_ECC_DIGITS; i++) {
-		prime2[i] = p_mod[i];
-		prime2[NUM_ECC_DIGITS + i] = 0;
-	}
-
-	vli_mult(q2, q1, prime2, NUM_ECC_DIGITS + 1);
-	vli_sub(p_product, p_product, q2, 2 * NUM_ECC_DIGITS);
-
-	uint32_t borrow;
-
-	borrow = vli_sub(q1, p_product, prime2, NUM_ECC_DIGITS + 1);
-	vli_cond_set(p_product, p_product, q1, borrow);
-	p_product[NUM_ECC_DIGITS] = q1[NUM_ECC_DIGITS] * (!borrow);
-	borrow = vli_sub(q1, p_product, prime2, NUM_ECC_DIGITS + 1);
-	vli_cond_set(p_product, p_product, q1, borrow);
-	p_product[NUM_ECC_DIGITS] = q1[NUM_ECC_DIGITS] * (!borrow);
-	borrow = vli_sub(q1, p_product, prime2, NUM_ECC_DIGITS + 1);
-	vli_cond_set(p_product, p_product, q1, borrow);
-	p_product[NUM_ECC_DIGITS] = q1[NUM_ECC_DIGITS] * (!borrow);
-
-	for (i = 0; i < NUM_ECC_DIGITS; i++) {
-		p_result[i] = p_product[i];
-	}
+	uECC_word_t product[2 * NUM_ECC_WORDS];
+	uECC_vli_mult(product, left, right, num_words);
+	uECC_vli_mmod(result, product, mod, num_words);
 }
 
-/*
- * Computes modular exponentiation.
- *
- * Side-channel countermeasure: algorithm strengthened against timing attack.
- */
-static void vli_modExp(uint32_t *p_result, uint32_t *p_base,
-		       uint32_t *p_exp, uint32_t *p_mod, uint32_t *p_barrett)
+void uECC_vli_modMult_fast(uECC_word_t *result, const uECC_word_t *left,
+			   const uECC_word_t *right, uECC_Curve curve)
+{
+	uECC_word_t product[2 * NUM_ECC_WORDS];
+	uECC_vli_mult(product, left, right, curve->num_words);
+
+	curve->mmod_fast(result, product);
+}
+
+static void uECC_vli_modSquare_fast(uECC_word_t *result,
+				    const uECC_word_t *left,
+				    uECC_Curve curve)
+{
+	uECC_vli_modMult_fast(result, left, left, curve);
+}
+
+
+#define EVEN(vli) (!(vli[0] & 1))
+
+static void vli_modInv_update(uECC_word_t *uv,
+			      const uECC_word_t *mod,
+			      wordcount_t num_words)
 {
 
-	uint32_t acc[NUM_ECC_DIGITS], tmp[NUM_ECC_DIGITS], product[2 * NUM_ECC_DIGITS];
-	uint32_t j;
-	int32_t i;
+	uECC_word_t carry = 0;
 
-	vli_clear(acc);
-	acc[0] = 1;
-
-	for (i = NUM_ECC_DIGITS - 1; i >= 0; i--) {
-		for (j = 1 << 31; j > 0; j = j >> 1) {
-			vli_square(product, acc);
-			vli_mmod_barrett(acc, product, p_mod, p_barrett);
-			vli_mult(product, acc, p_base, NUM_ECC_DIGITS);
-			vli_mmod_barrett(tmp, product, p_mod, p_barrett);
-			vli_cond_set(acc, tmp, acc, j & p_exp[i]);
-		}
+	if (!EVEN(uv)) {
+		carry = uECC_vli_add(uv, uv, mod, num_words);
 	}
-
-	vli_set(p_result, acc);
-}
-
-/* Conversion from Affine coordinates to Jacobi coordinates. */
-static void EccPoint_fromAffine(EccPointJacobi *p_point_jacobi,
-	EccPoint *p_point) {
-
-	vli_set(p_point_jacobi->X, p_point->x);
-	vli_set(p_point_jacobi->Y, p_point->y);
-	vli_clear(p_point_jacobi->Z);
-	p_point_jacobi->Z[0] = 1;
-}
-
-/*
- * Elliptic curve point doubling in Jacobi coordinates: P = P + P.
- *
- * Requires 4 squares and 4 multiplications.
- */
-static void EccPoint_double(EccPointJacobi *P)
-{
-
-	uint32_t m[NUM_ECC_DIGITS], s[NUM_ECC_DIGITS], t[NUM_ECC_DIGITS];
-
-	vli_modSquare_fast(t, P->Z);
-	vli_modSub(m, P->X, t, curve_p);
-	vli_modAdd(s, P->X, t, curve_p);
-	vli_modMult_fast(m, m, s);
-	vli_modAdd(s, m, m, curve_p);
-	vli_modAdd(m, s, m, curve_p); /* m = 3X^2 - 3Z^4 */
-	vli_modSquare_fast(t, P->Y);
-	vli_modMult_fast(s, P->X, t);
-	vli_modAdd(s, s, s, curve_p);
-	vli_modAdd(s, s, s, curve_p); /* s = 4XY^2 */
-	vli_modMult_fast(P->Z, P->Y, P->Z);
-	vli_modAdd(P->Z, P->Z, P->Z, curve_p); /* Z' = 2YZ */
-	vli_modSquare_fast(P->X, m);
-	vli_modSub(P->X, P->X, s, curve_p);
-	vli_modSub(P->X, P->X, s, curve_p); /* X' = m^2 - 2s */
-	vli_modSquare_fast(P->Y, t);
-	vli_modAdd(P->Y, P->Y, P->Y, curve_p);
-	vli_modAdd(P->Y, P->Y, P->Y, curve_p);
-	vli_modAdd(P->Y, P->Y, P->Y, curve_p);
-	vli_modSub(t, s, P->X, curve_p);
-	vli_modMult_fast(t, t, m);
-	vli_modSub(P->Y, t, P->Y, curve_p); /* Y' = m(s - X') - 8Y^4 */
-
-}
-
-/* Copy input to target. */
-static void EccPointJacobi_set(EccPointJacobi *target, EccPointJacobi *input)
-{
-	vli_set(target->X, input->X);
-	vli_set(target->Y, input->Y);
-	vli_set(target->Z, input->Z);
-}
-
-/* ------ Externally visible functions (see header file for comments): ------ */
-
-void vli_set(uint32_t *p_dest, uint32_t *p_src)
-{
-
-	uint32_t i;
-
-	for (i = 0; i < NUM_ECC_DIGITS; ++i) {
-		p_dest[i] = p_src[i];
+	uECC_vli_rshift1(uv, num_words);
+	if (carry) {
+		uv[num_words - 1] |= HIGH_BIT_SET;
 	}
 }
 
-int32_t vli_cmp(uint32_t *p_left, uint32_t *p_right, int32_t word_size)
+void uECC_vli_modInv(uECC_word_t *result, const uECC_word_t *input,
+		     const uECC_word_t *mod, wordcount_t num_words)
 {
+	uECC_word_t a[NUM_ECC_WORDS], b[NUM_ECC_WORDS];
+	uECC_word_t u[NUM_ECC_WORDS], v[NUM_ECC_WORDS];
+	cmpresult_t cmpResult;
 
-	int32_t i, cmp = 0;
-
-	for (i = word_size-1; i >= 0; --i) {
-		cmp |= ((p_left[i] > p_right[i]) - (p_left[i] < p_right[i])) * (!cmp);
-	}
-
-	return cmp;
-}
-
-uint32_t vli_sub(uint32_t *p_result, uint32_t *p_left, uint32_t *p_right,
-	uint32_t word_size)
-{
-
-	uint32_t l_borrow = 0;
-
-	for (uint32_t i = 0; i < word_size; ++i) {
-		uint32_t l_diff = p_left[i] - p_right[i] - l_borrow;
-
-		l_borrow = (l_diff > p_left[i]) | ((l_diff == p_left[i]) && l_borrow);
-		p_result[i] = l_diff;
-	}
-
-	return l_borrow;
-}
-
-void vli_cond_set(uint32_t *output, uint32_t *p_true, uint32_t *p_false,
-	uint32_t cond)
-{
-	uint32_t i;
-
-	cond = (!cond);
-
-	for (i = 0; i < NUM_ECC_DIGITS; i++) {
-		output[i] = (p_true[i]*(!cond)) | (p_false[i]*cond);
-	}
-}
-
-void vli_modAdd(uint32_t *p_result, uint32_t *p_left, uint32_t *p_right,
-	uint32_t *p_mod)
-{
-	uint32_t l_carry = vli_add(p_result, p_left, p_right);
-	uint32_t p_temp[NUM_ECC_DIGITS];
-
-	l_carry = l_carry == vli_sub(p_temp, p_result, p_mod, NUM_ECC_DIGITS);
-	vli_cond_set(p_result, p_temp, p_result, l_carry);
-}
-
-void vli_modSub(uint32_t *p_result, uint32_t *p_left, uint32_t *p_right,
-	uint32_t *p_mod)
-{
-	uint32_t l_borrow = vli_sub(p_result, p_left, p_right, NUM_ECC_DIGITS);
-	uint32_t p_temp[NUM_ECC_DIGITS];
-
-	vli_add(p_temp, p_result, p_mod);
-	vli_cond_set(p_result, p_temp, p_result, l_borrow);
-}
-
-void vli_modMult_fast(uint32_t *p_result, uint32_t *p_left,
-	uint32_t *p_right)
-{
-	uint32_t l_product[2 * NUM_ECC_DIGITS];
-
-	vli_mult(l_product, p_left, p_right, NUM_ECC_DIGITS);
-	vli_mmod_barrett(p_result, l_product, curve_p, curve_pb);
-}
-
-void vli_modSquare_fast(uint32_t *p_result, uint32_t *p_left)
-{
-	uint32_t l_product[2 * NUM_ECC_DIGITS];
-
-	vli_square(l_product, p_left);
-	vli_mmod_barrett(p_result, l_product, curve_p, curve_pb);
-}
-
-void vli_modMult(uint32_t *p_result, uint32_t *p_left, uint32_t *p_right,
-		 uint32_t *p_mod, uint32_t *p_barrett)
-{
-
-	uint32_t l_product[2 * NUM_ECC_DIGITS];
-
-	vli_mult(l_product, p_left, p_right, NUM_ECC_DIGITS);
-	vli_mmod_barrett(p_result, l_product, p_mod, p_barrett);
-}
-
-void vli_modInv(uint32_t *p_result, uint32_t *p_input, uint32_t *p_mod,
-	uint32_t *p_barrett)
-{
-	uint32_t p_power[NUM_ECC_DIGITS];
-
-	vli_set(p_power, p_mod);
-	p_power[0] -= 2;
-	vli_modExp(p_result, p_input, p_power, p_mod, p_barrett);
-}
-
-uint32_t EccPoint_isZero(EccPoint *p_point)
-{
-	return (vli_isZero(p_point->x) && vli_isZero(p_point->y));
-}
-
-uint32_t EccPointJacobi_isZero(EccPointJacobi *p_point_jacobi)
-{
-	return vli_isZero(p_point_jacobi->Z);
-}
-
-void EccPoint_toAffine(EccPoint *p_point, EccPointJacobi *p_point_jacobi)
-{
-
-	if (vli_isZero(p_point_jacobi->Z)) {
-		vli_clear(p_point->x);
-		vli_clear(p_point->y);
+	if (uECC_vli_isZero(input, num_words)) {
+		uECC_vli_clear(result, num_words);
 		return;
 	}
 
-	uint32_t z[NUM_ECC_DIGITS];
-
-	vli_set(z, p_point_jacobi->Z);
-	vli_modInv(z, z, curve_p, curve_pb);
-	vli_modSquare_fast(p_point->x, z);
-	vli_modMult_fast(p_point->y, p_point->x, z);
-	vli_modMult_fast(p_point->x, p_point->x, p_point_jacobi->X);
-	vli_modMult_fast(p_point->y, p_point->y, p_point_jacobi->Y);
+	uECC_vli_set(a, input, num_words);
+	uECC_vli_set(b, mod, num_words);
+	uECC_vli_clear(u, num_words);
+	u[0] = 1;
+	uECC_vli_clear(v, num_words);
+	while ((cmpResult = uECC_vli_cmp_unsafe(a, b, num_words)) != 0) {
+		if (EVEN(a)) {
+			uECC_vli_rshift1(a, num_words);
+      			vli_modInv_update(u, mod, num_words);
+    		} else if (EVEN(b)) {
+			uECC_vli_rshift1(b, num_words);
+			vli_modInv_update(v, mod, num_words);
+		} else if (cmpResult > 0) {
+			uECC_vli_sub(a, a, b, num_words);
+			uECC_vli_rshift1(a, num_words);
+			if (uECC_vli_cmp_unsafe(u, v, num_words) < 0) {
+        			uECC_vli_add(u, u, mod, num_words);
+      			}
+      			uECC_vli_sub(u, u, v, num_words);
+      			vli_modInv_update(u, mod, num_words);
+    		} else {
+      			uECC_vli_sub(b, b, a, num_words);
+      			uECC_vli_rshift1(b, num_words);
+      			if (uECC_vli_cmp_unsafe(v, u, num_words) < 0) {
+        			uECC_vli_add(v, v, mod, num_words);
+      			}
+      			uECC_vli_sub(v, v, u, num_words);
+      			vli_modInv_update(v, mod, num_words);
+    		}
+  	}
+  	uECC_vli_set(result, u, num_words);
 }
 
-void EccPoint_add(EccPointJacobi *P1, EccPointJacobi *P2)
+/* ------ Point operations ------ */
+
+void double_jacobian_default(uECC_word_t * X1, uECC_word_t * Y1,
+			     uECC_word_t * Z1, uECC_Curve curve)
 {
+	/* t1 = X, t2 = Y, t3 = Z */
+	uECC_word_t t4[NUM_ECC_WORDS];
+	uECC_word_t t5[NUM_ECC_WORDS];
+	wordcount_t num_words = curve->num_words;
 
-	uint32_t s1[NUM_ECC_DIGITS], u1[NUM_ECC_DIGITS], t[NUM_ECC_DIGITS];
-	uint32_t h[NUM_ECC_DIGITS], r[NUM_ECC_DIGITS];
-
-	vli_modSquare_fast(r, P1->Z);
-	vli_modSquare_fast(s1, P2->Z);
-	vli_modMult_fast(u1, P1->X, s1); /* u1 = X1 Z2^2 */
-	vli_modMult_fast(h, P2->X, r);
-	vli_modMult_fast(s1, P1->Y, s1);
-	vli_modMult_fast(s1, s1, P2->Z); /* s1 = Y1 Z2^3 */
-	vli_modMult_fast(r, P2->Y, r);
-	vli_modMult_fast(r, r, P1->Z);
-	vli_modSub(h, h, u1, curve_p); /* h = X2 Z1^2 - u1 */
-	vli_modSub(r, r, s1, curve_p); /* r = Y2 Z1^3 - s1 */
-
-	if (vli_isZero(h)) {
-		if (vli_isZero(r)) {
-			/* P1 = P2 */
-			EccPoint_double(P1);
-			return;
-		}
-		/* point at infinity */
-		vli_clear(P1->Z);
+	if (uECC_vli_isZero(Z1, num_words)) {
 		return;
 	}
 
-	vli_modMult_fast(P1->Z, P1->Z, P2->Z);
-	vli_modMult_fast(P1->Z, P1->Z, h); /* Z3 = h Z1 Z2 */
-	vli_modSquare_fast(t, h);
-	vli_modMult_fast(h, t, h);
-	vli_modMult_fast(u1, u1, t);
-	vli_modSquare_fast(P1->X, r);
-	vli_modSub(P1->X, P1->X, h, curve_p);
-	vli_modSub(P1->X, P1->X, u1, curve_p);
-	vli_modSub(P1->X, P1->X, u1, curve_p); /* X3 = r^2 - h^3 - 2 u1 h^2 */
-	vli_modMult_fast(t, s1, h);
-	vli_modSub(P1->Y, u1, P1->X, curve_p);
-	vli_modMult_fast(P1->Y, P1->Y, r);
-	vli_modSub(P1->Y, P1->Y, t, curve_p); /* Y3 = r(u1 h^2 - X3) - s1 h^3 */
+	uECC_vli_modSquare_fast(t4, Y1, curve);   /* t4 = y1^2 */
+	uECC_vli_modMult_fast(t5, X1, t4, curve); /* t5 = x1*y1^2 = A */
+	uECC_vli_modSquare_fast(t4, t4, curve);   /* t4 = y1^4 */
+	uECC_vli_modMult_fast(Y1, Y1, Z1, curve); /* t2 = y1*z1 = z3 */
+	uECC_vli_modSquare_fast(Z1, Z1, curve);   /* t3 = z1^2 */
+
+	uECC_vli_modAdd(X1, X1, Z1, curve->p, num_words); /* t1 = x1 + z1^2 */
+	uECC_vli_modAdd(Z1, Z1, Z1, curve->p, num_words); /* t3 = 2*z1^2 */
+	uECC_vli_modSub(Z1, X1, Z1, curve->p, num_words); /* t3 = x1 - z1^2 */
+	uECC_vli_modMult_fast(X1, X1, Z1, curve); /* t1 = x1^2 - z1^4 */
+
+	uECC_vli_modAdd(Z1, X1, X1, curve->p, num_words); /* t3 = 2*(x1^2 - z1^4) */
+	uECC_vli_modAdd(X1, X1, Z1, curve->p, num_words); /* t1 = 3*(x1^2 - z1^4) */
+	if (uECC_vli_testBit(X1, 0)) {
+		uECC_word_t l_carry = uECC_vli_add(X1, X1, curve->p, num_words);
+		uECC_vli_rshift1(X1, num_words);
+		X1[num_words - 1] |= l_carry << (uECC_WORD_BITS - 1);
+	} else {
+		uECC_vli_rshift1(X1, num_words);
+	}
+
+	/* t1 = 3/2*(x1^2 - z1^4) = B */
+	uECC_vli_modSquare_fast(Z1, X1, curve); /* t3 = B^2 */
+	uECC_vli_modSub(Z1, Z1, t5, curve->p, num_words); /* t3 = B^2 - A */
+	uECC_vli_modSub(Z1, Z1, t5, curve->p, num_words); /* t3 = B^2 - 2A = x3 */
+	uECC_vli_modSub(t5, t5, Z1, curve->p, num_words); /* t5 = A - x3 */
+	uECC_vli_modMult_fast(X1, X1, t5, curve); /* t1 = B * (A - x3) */
+	/* t4 = B * (A - x3) - y1^4 = y3: */
+	uECC_vli_modSub(t4, X1, t4, curve->p, num_words);
+
+	uECC_vli_set(X1, Z1, num_words);
+	uECC_vli_set(Z1, Y1, num_words);
+	uECC_vli_set(Y1, t4, num_words);
 }
 
-/*
- * Elliptic curve scalar multiplication with result in Jacobi coordinates:
- *
- * p_result = p_scalar * p_point.
+void x_side_default(uECC_word_t *result,
+		    const uECC_word_t *x,
+		    uECC_Curve curve)
+{
+	uECC_word_t _3[NUM_ECC_WORDS] = {3}; /* -a = 3 */
+	wordcount_t num_words = curve->num_words;
+
+	uECC_vli_modSquare_fast(result, x, curve); /* r = x^2 */
+	uECC_vli_modSub(result, result, _3, curve->p, num_words); /* r = x^2 - 3 */
+	uECC_vli_modMult_fast(result, result, x, curve); /* r = x^3 - 3x */
+	/* r = x^3 - 3x + b: */
+	uECC_vli_modAdd(result, result, curve->b, curve->p, num_words);
+}
+
+uECC_Curve uECC_secp256r1(void)
+{
+	return &curve_secp256r1;
+}
+
+void vli_mmod_fast_secp256r1(unsigned int *result, unsigned int*product)
+{
+	unsigned int tmp[NUM_ECC_WORDS];
+	int carry;
+
+	/* t */
+	uECC_vli_set(result, product, NUM_ECC_WORDS);
+
+	/* s1 */
+	tmp[0] = tmp[1] = tmp[2] = 0;
+	tmp[3] = product[11];
+	tmp[4] = product[12];
+	tmp[5] = product[13];
+	tmp[6] = product[14];
+	tmp[7] = product[15];
+	carry = uECC_vli_add(tmp, tmp, tmp, NUM_ECC_WORDS);
+	carry += uECC_vli_add(result, result, tmp, NUM_ECC_WORDS);
+
+	/* s2 */
+	tmp[3] = product[12];
+	tmp[4] = product[13];
+	tmp[5] = product[14];
+	tmp[6] = product[15];
+	tmp[7] = 0;
+	carry += uECC_vli_add(tmp, tmp, tmp, NUM_ECC_WORDS);
+	carry += uECC_vli_add(result, result, tmp, NUM_ECC_WORDS);
+
+	/* s3 */
+	tmp[0] = product[8];
+	tmp[1] = product[9];
+	tmp[2] = product[10];
+	tmp[3] = tmp[4] = tmp[5] = 0;
+	tmp[6] = product[14];
+	tmp[7] = product[15];
+  	carry += uECC_vli_add(result, result, tmp, NUM_ECC_WORDS);
+
+	/* s4 */
+	tmp[0] = product[9];
+	tmp[1] = product[10];
+	tmp[2] = product[11];
+	tmp[3] = product[13];
+	tmp[4] = product[14];
+	tmp[5] = product[15];
+	tmp[6] = product[13];
+	tmp[7] = product[8];
+	carry += uECC_vli_add(result, result, tmp, NUM_ECC_WORDS);
+
+	/* d1 */
+	tmp[0] = product[11];
+	tmp[1] = product[12];
+	tmp[2] = product[13];
+	tmp[3] = tmp[4] = tmp[5] = 0;
+	tmp[6] = product[8];
+	tmp[7] = product[10];
+	carry -= uECC_vli_sub(result, result, tmp, NUM_ECC_WORDS);
+
+	/* d2 */
+	tmp[0] = product[12];
+	tmp[1] = product[13];
+	tmp[2] = product[14];
+	tmp[3] = product[15];
+	tmp[4] = tmp[5] = 0;
+	tmp[6] = product[9];
+	tmp[7] = product[11];
+	carry -= uECC_vli_sub(result, result, tmp, NUM_ECC_WORDS);
+
+	/* d3 */
+	tmp[0] = product[13];
+	tmp[1] = product[14];
+	tmp[2] = product[15];
+	tmp[3] = product[8];
+	tmp[4] = product[9];
+	tmp[5] = product[10];
+	tmp[6] = 0;
+	tmp[7] = product[12];
+	carry -= uECC_vli_sub(result, result, tmp, NUM_ECC_WORDS);
+
+	/* d4 */
+	tmp[0] = product[14];
+	tmp[1] = product[15];
+	tmp[2] = 0;
+	tmp[3] = product[9];
+	tmp[4] = product[10];
+	tmp[5] = product[11];
+	tmp[6] = 0;
+	tmp[7] = product[13];
+	carry -= uECC_vli_sub(result, result, tmp, NUM_ECC_WORDS);
+
+	if (carry < 0) {
+		do {
+			carry += uECC_vli_add(result, result, curve_secp256r1.p, NUM_ECC_WORDS);
+		}
+		while (carry < 0);
+	} else  {
+		while (carry || 
+		       uECC_vli_cmp_unsafe(curve_secp256r1.p, result, NUM_ECC_WORDS) != 1) {
+			carry -= uECC_vli_sub(result, result, curve_secp256r1.p, NUM_ECC_WORDS);
+		}
+	}
+}
+
+uECC_word_t EccPoint_isZero(const uECC_word_t *point, uECC_Curve curve)
+{
+	return uECC_vli_isZero(point, curve->num_words * 2);
+}
+
+void apply_z(uECC_word_t * X1, uECC_word_t * Y1, const uECC_word_t * const Z,
+	     uECC_Curve curve)
+{
+	uECC_word_t t1[NUM_ECC_WORDS];
+
+	uECC_vli_modSquare_fast(t1, Z, curve);    /* z^2 */
+	uECC_vli_modMult_fast(X1, X1, t1, curve); /* x1 * z^2 */
+	uECC_vli_modMult_fast(t1, t1, Z, curve);  /* z^3 */
+	uECC_vli_modMult_fast(Y1, Y1, t1, curve); /* y1 * z^3 */
+}
+
+/* P = (x1, y1) => 2P, (x2, y2) => P' */
+static void XYcZ_initial_double(uECC_word_t * X1, uECC_word_t * Y1,
+				uECC_word_t * X2, uECC_word_t * Y2,
+				const uECC_word_t * const initial_Z,
+				uECC_Curve curve)
+{
+	uECC_word_t z[NUM_ECC_WORDS];
+	wordcount_t num_words = curve->num_words;
+	if (initial_Z) {
+		uECC_vli_set(z, initial_Z, num_words);
+	} else {
+		uECC_vli_clear(z, num_words);
+		z[0] = 1;
+	}
+
+	uECC_vli_set(X2, X1, num_words);
+	uECC_vli_set(Y2, Y1, num_words);
+
+	apply_z(X1, Y1, z, curve);
+	curve->double_jacobian(X1, Y1, z, curve);
+	apply_z(X2, Y2, z, curve);
+}
+
+void XYcZ_add(uECC_word_t * X1, uECC_word_t * Y1,
+	      uECC_word_t * X2, uECC_word_t * Y2,
+	      uECC_Curve curve)
+{
+	/* t1 = X1, t2 = Y1, t3 = X2, t4 = Y2 */
+	uECC_word_t t5[NUM_ECC_WORDS];
+	wordcount_t num_words = curve->num_words;
+
+	uECC_vli_modSub(t5, X2, X1, curve->p, num_words); /* t5 = x2 - x1 */
+	uECC_vli_modSquare_fast(t5, t5, curve); /* t5 = (x2 - x1)^2 = A */
+	uECC_vli_modMult_fast(X1, X1, t5, curve); /* t1 = x1*A = B */
+	uECC_vli_modMult_fast(X2, X2, t5, curve); /* t3 = x2*A = C */
+	uECC_vli_modSub(Y2, Y2, Y1, curve->p, num_words); /* t4 = y2 - y1 */
+	uECC_vli_modSquare_fast(t5, Y2, curve); /* t5 = (y2 - y1)^2 = D */
+
+	uECC_vli_modSub(t5, t5, X1, curve->p, num_words); /* t5 = D - B */
+	uECC_vli_modSub(t5, t5, X2, curve->p, num_words); /* t5 = D - B - C = x3 */
+	uECC_vli_modSub(X2, X2, X1, curve->p, num_words); /* t3 = C - B */
+	uECC_vli_modMult_fast(Y1, Y1, X2, curve); /* t2 = y1*(C - B) */
+	uECC_vli_modSub(X2, X1, t5, curve->p, num_words); /* t3 = B - x3 */
+	uECC_vli_modMult_fast(Y2, Y2, X2, curve); /* t4 = (y2 - y1)*(B - x3) */
+	uECC_vli_modSub(Y2, Y2, Y1, curve->p, num_words); /* t4 = y3 */
+
+	uECC_vli_set(X2, t5, num_words);
+}
+
+/* Input P = (x1, y1, Z), Q = (x2, y2, Z)
+   Output P + Q = (x3, y3, Z3), P - Q = (x3', y3', Z3)
+   or P => P - Q, Q => P + Q
  */
-void EccPoint_mult_safe(EccPointJacobi *p_result, EccPoint *p_point, uint32_t *p_scalar)
+static void XYcZ_addC(uECC_word_t * X1, uECC_word_t * Y1,
+		      uECC_word_t * X2, uECC_word_t * Y2,
+		      uECC_Curve curve)
+{
+	/* t1 = X1, t2 = Y1, t3 = X2, t4 = Y2 */
+	uECC_word_t t5[NUM_ECC_WORDS];
+	uECC_word_t t6[NUM_ECC_WORDS];
+	uECC_word_t t7[NUM_ECC_WORDS];
+	wordcount_t num_words = curve->num_words;
+
+	uECC_vli_modSub(t5, X2, X1, curve->p, num_words); /* t5 = x2 - x1 */
+	uECC_vli_modSquare_fast(t5, t5, curve); /* t5 = (x2 - x1)^2 = A */
+	uECC_vli_modMult_fast(X1, X1, t5, curve); /* t1 = x1*A = B */
+	uECC_vli_modMult_fast(X2, X2, t5, curve); /* t3 = x2*A = C */
+	uECC_vli_modAdd(t5, Y2, Y1, curve->p, num_words); /* t5 = y2 + y1 */
+	uECC_vli_modSub(Y2, Y2, Y1, curve->p, num_words); /* t4 = y2 - y1 */
+
+	uECC_vli_modSub(t6, X2, X1, curve->p, num_words); /* t6 = C - B */
+	uECC_vli_modMult_fast(Y1, Y1, t6, curve); /* t2 = y1 * (C - B) = E */
+	uECC_vli_modAdd(t6, X1, X2, curve->p, num_words); /* t6 = B + C */
+	uECC_vli_modSquare_fast(X2, Y2, curve); /* t3 = (y2 - y1)^2 = D */
+	uECC_vli_modSub(X2, X2, t6, curve->p, num_words); /* t3 = D - (B + C) = x3 */
+
+	uECC_vli_modSub(t7, X1, X2, curve->p, num_words); /* t7 = B - x3 */
+	uECC_vli_modMult_fast(Y2, Y2, t7, curve); /* t4 = (y2 - y1)*(B - x3) */
+	/* t4 = (y2 - y1)*(B - x3) - E = y3: */
+	uECC_vli_modSub(Y2, Y2, Y1, curve->p, num_words);
+
+	uECC_vli_modSquare_fast(t7, t5, curve); /* t7 = (y2 + y1)^2 = F */
+	uECC_vli_modSub(t7, t7, t6, curve->p, num_words); /* t7 = F - (B + C) = x3' */
+	uECC_vli_modSub(t6, t7, X1, curve->p, num_words); /* t6 = x3' - B */
+	uECC_vli_modMult_fast(t6, t6, t5, curve); /* t6 = (y2+y1)*(x3' - B) */
+	/* t2 = (y2+y1)*(x3' - B) - E = y3': */
+	uECC_vli_modSub(Y1, t6, Y1, curve->p, num_words);
+
+	uECC_vli_set(X1, t7, num_words);
+}
+
+void EccPoint_mult(uECC_word_t * result, const uECC_word_t * point,
+		   const uECC_word_t * scalar,
+		   const uECC_word_t * initial_Z,
+		   bitcount_t num_bits, uECC_Curve curve) 
+{
+	/* R0 and R1 */
+	uECC_word_t Rx[2][NUM_ECC_WORDS];
+	uECC_word_t Ry[2][NUM_ECC_WORDS];
+	uECC_word_t z[NUM_ECC_WORDS];
+	bitcount_t i;
+	uECC_word_t nb;
+	wordcount_t num_words = curve->num_words;
+
+	uECC_vli_set(Rx[1], point, num_words);
+  	uECC_vli_set(Ry[1], point + num_words, num_words);
+
+	XYcZ_initial_double(Rx[1], Ry[1], Rx[0], Ry[0], initial_Z, curve);
+
+	for (i = num_bits - 2; i > 0; --i) {
+		nb = !uECC_vli_testBit(scalar, i);
+		XYcZ_addC(Rx[1 - nb], Ry[1 - nb], Rx[nb], Ry[nb], curve);
+		XYcZ_add(Rx[nb], Ry[nb], Rx[1 - nb], Ry[1 - nb], curve);
+	}
+
+	nb = !uECC_vli_testBit(scalar, 0);
+	XYcZ_addC(Rx[1 - nb], Ry[1 - nb], Rx[nb], Ry[nb], curve);
+
+	/* Find final 1/Z value. */
+	uECC_vli_modSub(z, Rx[1], Rx[0], curve->p, num_words); /* X1 - X0 */
+	uECC_vli_modMult_fast(z, z, Ry[1 - nb], curve); /* Yb * (X1 - X0) */
+	uECC_vli_modMult_fast(z, z, point, curve); /* xP * Yb * (X1 - X0) */
+	uECC_vli_modInv(z, z, curve->p, num_words); /* 1 / (xP * Yb * (X1 - X0))*/
+	/* yP / (xP * Yb * (X1 - X0)) */
+	uECC_vli_modMult_fast(z, z, point + num_words, curve);
+	/* Xb * yP / (xP * Yb * (X1 - X0)) */
+	uECC_vli_modMult_fast(z, z, Rx[1 - nb], curve);
+	/* End 1/Z calculation */
+
+	XYcZ_add(Rx[nb], Ry[nb], Rx[1 - nb], Ry[1 - nb], curve);
+	apply_z(Rx[0], Ry[0], z, curve);
+
+	uECC_vli_set(result, Rx[0], num_words);
+	uECC_vli_set(result + num_words, Ry[0], num_words);
+}
+
+uECC_word_t regularize_k(const uECC_word_t * const k, uECC_word_t *k0,
+			 uECC_word_t *k1, uECC_Curve curve)
 {
 
-	int32_t i;
-	uint32_t bit;
-	EccPointJacobi p_point_jacobi, p_tmp;
+	wordcount_t num_n_words = BITS_TO_WORDS(curve->num_n_bits);
 
-	EccPoint_fromAffine(p_result, p_point);
-	EccPoint_fromAffine(&p_point_jacobi, p_point);
+	bitcount_t num_n_bits = curve->num_n_bits;
 
-	for (i = vli_numBits(p_scalar) - 2; i >= 0; i--) {
-		EccPoint_double(p_result);
-		EccPointJacobi_set(&p_tmp, p_result);
-		EccPoint_add(&p_tmp, &p_point_jacobi);
-		bit = vli_testBit(p_scalar, i);
-		vli_cond_set(p_result->X, p_tmp.X, p_result->X, bit);
-		vli_cond_set(p_result->Y, p_tmp.Y, p_result->Y, bit);
-		vli_cond_set(p_result->Z, p_tmp.Z, p_result->Z, bit);
+	uECC_word_t carry = uECC_vli_add(k0, k, curve->n, num_n_words) ||
+			     (num_n_bits < ((bitcount_t)num_n_words * uECC_WORD_SIZE * 8) &&
+			     uECC_vli_testBit(k0, num_n_bits));
+
+	uECC_vli_add(k1, k0, curve->n, num_n_words);
+
+	return carry;
+}
+
+uECC_word_t EccPoint_compute_public_key(uECC_word_t *result,
+					uECC_word_t *private_key,
+					uECC_Curve curve)
+{
+
+	uECC_word_t tmp1[NUM_ECC_WORDS];
+ 	uECC_word_t tmp2[NUM_ECC_WORDS];
+	uECC_word_t *p2[2] = {tmp1, tmp2};
+	uECC_word_t carry;
+
+	/* Regularize the bitcount for the private key so that attackers cannot
+	 * use a side channel attack to learn the number of leading zeros. */
+	carry = regularize_k(private_key, tmp1, tmp2, curve);
+
+	EccPoint_mult(result, curve->G, p2[!carry], 0, curve->num_n_bits + 1, curve);
+
+	if (EccPoint_isZero(result, curve)) {
+		return 0;
+	}
+	return 1;
+}
+
+/* Converts an integer in uECC native format to big-endian bytes. */
+void uECC_vli_nativeToBytes(uint8_t *bytes, int num_bytes,
+			    const unsigned int *native)
+{
+	wordcount_t i;
+	for (i = 0; i < num_bytes; ++i) {
+		unsigned b = num_bytes - 1 - i;
+		bytes[i] = native[b / uECC_WORD_SIZE] >> (8 * (b % uECC_WORD_SIZE));
 	}
 }
 
-/* Ellptic curve scalar multiplication with result in Jacobi coordinates */
-/* p_result = p_scalar * p_point */
-void EccPoint_mult_unsafe(EccPointJacobi *p_result, EccPoint *p_point, uint32_t *p_scalar)
+/* Converts big-endian bytes to an integer in uECC native format. */
+void uECC_vli_bytesToNative(unsigned int *native, const uint8_t *bytes,
+			    int num_bytes)
 {
-  int i;
-  EccPointJacobi p_point_jacobi;
-  EccPoint_fromAffine(p_result, p_point);
-  EccPoint_fromAffine(&p_point_jacobi, p_point);
-
-  for(i = vli_numBits(p_scalar) - 2; i >= 0; i--)
-  {
-    EccPoint_double(p_result);
-    if (vli_testBit(p_scalar, i))
-    {
-      EccPoint_add(p_result, &p_point_jacobi);
-    }
-  }
+	wordcount_t i;
+	uECC_vli_clear(native, (num_bytes + (uECC_WORD_SIZE - 1)) / uECC_WORD_SIZE);
+	for (i = 0; i < num_bytes; ++i) {
+		unsigned b = num_bytes - 1 - i;
+		native[b / uECC_WORD_SIZE] |=
+			(uECC_word_t)bytes[i] << (8 * (b % uECC_WORD_SIZE));
+  	}
 }
 
-/* -------- Conversions between big endian and little endian: -------- */
-
-void ecc_bytes2native(uint32_t p_native[NUM_ECC_DIGITS],
-		      uint8_t p_bytes[NUM_ECC_DIGITS * 4])
+int uECC_generate_random_int(uECC_word_t *random, const uECC_word_t *top,
+			     wordcount_t num_words)
 {
+	uECC_word_t mask = (uECC_word_t)-1;
+	uECC_word_t tries;
+	bitcount_t num_bits = uECC_vli_numBits(top, num_words);
 
-	uint32_t i;
-
-	for (i = 0; i < NUM_ECC_DIGITS; ++i) {
-		uint8_t *p_digit = p_bytes + 4 * (NUM_ECC_DIGITS - 1 - i);
-
-		p_native[i] = ((uint32_t)p_digit[0] << 24) |
-			((uint32_t)p_digit[1] << 16) |
-			((uint32_t)p_digit[2] << 8) |
-			(uint32_t)p_digit[3];
+	if (!g_rng_function) {
+		return 0;
 	}
+
+	for (tries = 0; tries < uECC_RNG_MAX_TRIES; ++tries) {
+		if (!g_rng_function((uint8_t *)random, num_words * uECC_WORD_SIZE)) {
+      			return 0;
+    		}
+		random[num_words - 1] &=
+        		mask >> ((bitcount_t)(num_words * uECC_WORD_SIZE * 8 - num_bits));
+		if (!uECC_vli_isZero(random, num_words) &&
+			uECC_vli_cmp(top, random, num_words) == 1) {
+			return 1;
+		}
+	}
+	return 0;
 }
 
-void ecc_native2bytes(uint8_t p_bytes[NUM_ECC_DIGITS * 4],
-	uint32_t p_native[NUM_ECC_DIGITS])
+
+int uECC_valid_point(const uECC_word_t *point, uECC_Curve curve)
+{
+	uECC_word_t tmp1[NUM_ECC_WORDS];
+	uECC_word_t tmp2[NUM_ECC_WORDS];
+	wordcount_t num_words = curve->num_words;
+
+	/* The point at infinity is invalid. */
+	if (EccPoint_isZero(point, curve)) {
+		return -1;
+	}
+
+	/* x and y must be smaller than p. */
+	if (uECC_vli_cmp_unsafe(curve->p, point, num_words) != 1 ||
+		uECC_vli_cmp_unsafe(curve->p, point + num_words, num_words) != 1) {
+		return -2;
+	}
+
+	uECC_vli_modSquare_fast(tmp1, point + num_words, curve);
+	curve->x_side(tmp2, point, curve); /* tmp2 = x^3 + ax + b */
+
+	/* Make sure that y^2 == x^3 + ax + b */
+	if (uECC_vli_equal(tmp1, tmp2, num_words) != 0)
+		return -3;
+
+	return 0;
+}
+
+int uECC_valid_public_key(const uint8_t *public_key, uECC_Curve curve)
 {
 
-	uint32_t i;
+	uECC_word_t _public[NUM_ECC_WORDS * 2];
 
-	for (i = 0; i < NUM_ECC_DIGITS; ++i) {
-		uint8_t *p_digit = p_bytes + 4 * (NUM_ECC_DIGITS - 1 - i);
+	uECC_vli_bytesToNative(_public, public_key, curve->num_bytes);
+	uECC_vli_bytesToNative(
+	_public + curve->num_words,
+	public_key + curve->num_bytes,
+	curve->num_bytes);
 
-		p_digit[0] = p_native[i] >> 24;
-		p_digit[1] = p_native[i] >> 16;
-		p_digit[2] = p_native[i] >> 8;
-		p_digit[3] = p_native[i];
+	if (uECC_vli_cmp_unsafe(_public, curve->G, NUM_ECC_WORDS * 2) == 0) {
+		return -4;
 	}
+
+	return uECC_valid_point(_public, curve);
 }
+
+int uECC_compute_public_key(const uint8_t *private_key, uint8_t *public_key,
+			    uECC_Curve curve)
+{
+
+	uECC_word_t _private[NUM_ECC_WORDS];
+	uECC_word_t _public[NUM_ECC_WORDS * 2];
+
+	uECC_vli_bytesToNative(
+	_private,
+	private_key,
+	BITS_TO_BYTES(curve->num_n_bits));
+
+	/* Make sure the private key is in the range [1, n-1]. */
+	if (uECC_vli_isZero(_private, BITS_TO_WORDS(curve->num_n_bits))) {
+		return 0;
+	}
+
+	if (uECC_vli_cmp(curve->n, _private, BITS_TO_WORDS(curve->num_n_bits)) != 1) {
+		return 0;
+	}
+
+	/* Compute public key. */
+	if (!EccPoint_compute_public_key(_public, _private, curve)) {
+		return 0;
+	}
+
+	uECC_vli_nativeToBytes(public_key, curve->num_bytes, _public);
+	uECC_vli_nativeToBytes(
+	public_key +
+	curve->num_bytes, curve->num_bytes, _public + curve->num_words);
+	return 1;
+}
+
+
 

--- a/ext/lib/crypto/tinycrypt/source/ecc_dh.c
+++ b/ext/lib/crypto/tinycrypt/source/ecc_dh.c
@@ -1,7 +1,32 @@
 /* ec_dh.c - TinyCrypt implementation of EC-DH */
 
+/* 
+ * Copyright (c) 2014, Kenneth MacKay
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *  * Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *  * Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
 /*
- *  Copyright (C) 2015 by Intel Corporation, All Rights Reserved.
+ *  Copyright (C) 2017 by Intel Corporation, All Rights Reserved.
  *
  *  Redistribution and use in source and binary forms, with or without
  *  modification, are permitted provided that the following conditions are met:
@@ -31,102 +56,135 @@
  */
 #include <tinycrypt/constants.h>
 #include <tinycrypt/ecc.h>
+#include <tinycrypt/ecc_dh.h>
+#include <string.h>
 
-extern uint32_t curve_p[NUM_ECC_DIGITS];
-extern uint32_t curve_b[NUM_ECC_DIGITS];
-extern uint32_t curve_n[NUM_ECC_DIGITS];
-extern uint32_t curve_pb[NUM_ECC_DIGITS + 1];
-extern EccPoint curve_G;
+#if default_RNG_defined
+static uECC_RNG_Function g_rng_function = &default_CSPRNG;
+#else
+static uECC_RNG_Function g_rng_function = 0;
+#endif
 
-int32_t ecc_make_key(EccPoint *p_publicKey, uint32_t p_privateKey[NUM_ECC_DIGITS],
-			 uint32_t p_random[NUM_ECC_DIGITS * 2])
-{
-  /* computing modular reduction of p_random (see FIPS 186.4 B.4.1): */
-  vli_mmod_barrett(p_privateKey, p_random, curve_p, curve_pb);
-
-	/* Make sure the private key is in the range [1, n-1].
-	 * For the supported curve, n is always large enough
-	 * that we only need to subtract once at most.
-	 */
-	uint32_t p_tmp[NUM_ECC_DIGITS];
-	vli_sub(p_tmp, p_privateKey, curve_n, NUM_ECC_DIGITS);
-
-	vli_cond_set(p_privateKey, p_privateKey, p_tmp,
-		     vli_cmp(curve_n, p_privateKey, NUM_ECC_DIGITS) == 1);
-
-  /* erasing temporary buffer used to store secret: */
-  for (uint32_t i = 0; i < NUM_ECC_DIGITS; i++)
-    p_tmp[i] = 0;
-
-	if (vli_isZero(p_privateKey)) {
-		return TC_CRYPTO_FAIL; /* The private key cannot be 0 (mod p). */
-	}
-
-	EccPointJacobi P;
-
-	EccPoint_mult_safe(&P, &curve_G, p_privateKey);
-	EccPoint_toAffine(p_publicKey, &P);
-
-	return TC_CRYPTO_SUCCESS;
-}
-
-/* Compute p_result = x^3 - 3x + b */
-static void curve_x_side(uint32_t p_result[NUM_ECC_DIGITS],
-			 uint32_t x[NUM_ECC_DIGITS])
+int uECC_make_key_with_d(uint8_t *public_key, uint8_t *private_key,
+			 unsigned int *d, uECC_Curve curve)
 {
 
-	uint32_t _3[NUM_ECC_DIGITS] = {3}; /* -a = 3 */
+	uECC_word_t _private[NUM_ECC_WORDS];
+	uECC_word_t _public[NUM_ECC_WORDS * 2];
 
-	vli_modSquare_fast(p_result, x); /* r = x^2 */
-	vli_modSub(p_result, p_result, _3, curve_p); /* r = x^2 - 3 */
-	vli_modMult_fast(p_result, p_result, x); /* r = x^3 - 3x */
-	vli_modAdd(p_result, p_result, curve_b, curve_p); /* r = x^3 - 3x + b */
+	/* This function is designed for test purposes-only (such as validating NIST
+	 * test vectors) as it uses a provided value for d instead of generating
+	 * it uniformly at random. */
+	memcpy (_private, d, NUM_ECC_BYTES);
 
-}
+	/* Computing public-key from private: */
+	if (EccPoint_compute_public_key(_public, _private, curve)) {
 
-int32_t ecc_valid_public_key(EccPoint *p_publicKey)
-{
-	uint32_t l_tmp1[NUM_ECC_DIGITS];
-	uint32_t l_tmp2[NUM_ECC_DIGITS];
+		/* Converting buffers to correct bit order: */
+		uECC_vli_nativeToBytes(private_key,
+				       BITS_TO_BYTES(curve->num_n_bits),
+				       _private);
+		uECC_vli_nativeToBytes(public_key,
+				       curve->num_bytes,
+				       _public);
+		uECC_vli_nativeToBytes(public_key + curve->num_bytes,
+				       curve->num_bytes,
+				       _public + curve->num_words);
 
-	if (EccPoint_isZero(p_publicKey)) {
-		return -1;
+		/* erasing temporary buffer used to store secret: */
+		memset(_private, 0, NUM_ECC_BYTES);
+
+		return 1;
 	}
-
-	if ((vli_cmp(curve_p, p_publicKey->x, NUM_ECC_DIGITS) != 1) ||
-	   (vli_cmp(curve_p, p_publicKey->y, NUM_ECC_DIGITS) != 1)) {
-		return -2;
-	}
-
-	vli_modSquare_fast(l_tmp1, p_publicKey->y); /* tmp1 = y^2 */
-
-	curve_x_side(l_tmp2, p_publicKey->x); /* tmp2 = x^3 - 3x + b */
-
-	/* Make sure that y^2 == x^3 + ax + b */
-	if (vli_cmp(l_tmp1, l_tmp2, NUM_ECC_DIGITS) != 0) {
-		return -3;
-	}
-
-	if (vli_cmp(p_publicKey->x, curve_G.x, NUM_ECC_DIGITS) == 0 &&
-	   vli_cmp(p_publicKey->y, curve_G.y, NUM_ECC_DIGITS) == 0 )
-		return -4;
-
 	return 0;
 }
 
-int32_t ecdh_shared_secret(uint32_t p_secret[NUM_ECC_DIGITS],
-			   EccPoint *p_publicKey, uint32_t p_privateKey[NUM_ECC_DIGITS])
+int uECC_make_key(uint8_t *public_key, uint8_t *private_key, uECC_Curve curve)
 {
 
-	EccPoint p_point;
-	EccPointJacobi P;
+	uECC_word_t _random[NUM_ECC_WORDS * 2];
+	uECC_word_t _private[NUM_ECC_WORDS];
+	uECC_word_t _public[NUM_ECC_WORDS * 2];
+	uECC_word_t tries;
 
-	EccPoint_mult_safe(&P, p_publicKey, p_privateKey);
-	if (EccPointJacobi_isZero(&P)) {
-		return TC_CRYPTO_FAIL;
-	}
-	EccPoint_toAffine(&p_point, &P);
-	vli_set(p_secret, p_point.x);
+	for (tries = 0; tries < uECC_RNG_MAX_TRIES; ++tries) {
+		/* Generating _private uniformly at random: */
+		uECC_RNG_Function rng_function = uECC_get_rng();
+		if (!rng_function ||
+			!rng_function((uint8_t *)_random, 2 * NUM_ECC_WORDS*uECC_WORD_SIZE)) {
+        		return 0;
+		}
 
-	return TC_CRYPTO_SUCCESS;
+		/* computing modular reduction of _random (see FIPS 186.4 B.4.1): */
+		uECC_vli_mmod(_private, _random, curve->n, BITS_TO_WORDS(curve->num_n_bits));
+
+		/* Computing public-key from private: */
+		if (EccPoint_compute_public_key(_public, _private, curve)) {
+
+			/* Converting buffers to correct bit order: */
+			uECC_vli_nativeToBytes(private_key,
+					       BITS_TO_BYTES(curve->num_n_bits),
+					       _private);
+			uECC_vli_nativeToBytes(public_key,
+					       curve->num_bytes,
+					       _public);
+			uECC_vli_nativeToBytes(public_key + curve->num_bytes,
+ 					       curve->num_bytes,
+					       _public + curve->num_words);
+
+			/* erasing temporary buffer that stored secret: */
+			memset(_private, 0, NUM_ECC_BYTES);
+
+      			return 1;
+    		}
+  	}
+	return 0;
+}
+
+int uECC_shared_secret(const uint8_t *public_key, const uint8_t *private_key,
+		       uint8_t *secret, uECC_Curve curve)
+{
+
+	uECC_word_t _public[NUM_ECC_WORDS * 2];
+	uECC_word_t _private[NUM_ECC_WORDS];
+
+	uECC_word_t tmp[NUM_ECC_WORDS];
+	uECC_word_t *p2[2] = {_private, tmp};
+	uECC_word_t *initial_Z = 0;
+	uECC_word_t carry;
+	wordcount_t num_words = curve->num_words;
+	wordcount_t num_bytes = curve->num_bytes;
+
+	/* Converting buffers to correct bit order: */
+	uECC_vli_bytesToNative(_private,
+      			       private_key,
+			       BITS_TO_BYTES(curve->num_n_bits));
+	uECC_vli_bytesToNative(_public,
+      			       public_key,
+			       num_bytes);
+	uECC_vli_bytesToNative(_public + num_words,
+			       public_key + num_bytes,
+			       num_bytes);
+
+	/* Regularize the bitcount for the private key so that attackers cannot use a
+	 * side channel attack to learn the number of leading zeros. */
+	carry = regularize_k(_private, _private, tmp, curve);
+
+	/* If an RNG function was specified, try to get a random initial Z value to
+	 * improve protection against side-channel attacks. */
+	if (g_rng_function) {
+		if (!uECC_generate_random_int(p2[carry], curve->p, num_words)) {
+			return 0;
+    		}
+    		initial_Z = p2[carry];
+  	}
+
+	EccPoint_mult(_public, _public, p2[!carry], initial_Z, curve->num_n_bits + 1,
+		      curve);
+
+	/* erasing temporary buffer used to store secret: */
+	memset (p2, 0, 2*NUM_ECC_WORDS);
+
+	uECC_vli_nativeToBytes(secret, num_bytes, _public);
+	return !EccPoint_isZero(_public, curve);
 }

--- a/ext/lib/crypto/tinycrypt/source/ecc_dsa.c
+++ b/ext/lib/crypto/tinycrypt/source/ecc_dsa.c
@@ -1,7 +1,30 @@
 /* ec_dsa.c - TinyCrypt implementation of EC-DSA */
 
+/* Copyright (c) 2014, Kenneth MacKay
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *  * Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *  * Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.*/
+
 /*
- *  Copyright (C) 2015 by Intel Corporation, All Rights Reserved.
+ *  Copyright (C) 2017 by Intel Corporation, All Rights Reserved.
  *
  *  Redistribution and use in source and binary forms, with or without
  *  modification, are permitted provided that the following conditions are met:
@@ -32,84 +55,241 @@
 
 #include <tinycrypt/constants.h>
 #include <tinycrypt/ecc.h>
+#include <tinycrypt/ecc_dsa.h>
 
-extern uint32_t curve_n[NUM_ECC_DIGITS];
-extern EccPoint curve_G;
-extern uint32_t curve_nb[NUM_ECC_DIGITS + 1];
+#if default_RNG_defined
+static uECC_RNG_Function g_rng_function = &default_CSPRNG;
+#else
+static uECC_RNG_Function g_rng_function = 0;
+#endif
 
-int32_t ecdsa_sign(uint32_t r[NUM_ECC_DIGITS], uint32_t s[NUM_ECC_DIGITS],
-		   uint32_t p_privateKey[NUM_ECC_DIGITS], uint32_t p_random[NUM_ECC_DIGITS],
-		   uint32_t p_hash[NUM_ECC_DIGITS])
+static void bits2int(uECC_word_t *native, const uint8_t *bits,
+		     unsigned bits_size, uECC_Curve curve)
 {
+	unsigned num_n_bytes = BITS_TO_BYTES(curve->num_n_bits);
+	unsigned num_n_words = BITS_TO_WORDS(curve->num_n_bits);
+	int shift;
+	uECC_word_t carry;
+	uECC_word_t *ptr;
 
-	uint32_t k[NUM_ECC_DIGITS], tmp[NUM_ECC_DIGITS];
-	EccPoint p_point;
-	EccPointJacobi P;
-
-	if (vli_isZero(p_random)) {
-		return TC_CRYPTO_FAIL; /* The random number must not be 0. */
+	if (bits_size > num_n_bytes) {
+		bits_size = num_n_bytes;
 	}
 
-	vli_set(k, p_random);
-
-	vli_sub(tmp, k, curve_n, NUM_ECC_DIGITS);
-	vli_cond_set(k, k, tmp, vli_cmp(curve_n, k, NUM_ECC_DIGITS) == 1);
-
-	/* tmp = k * G */
-	EccPoint_mult_safe(&P, &curve_G, k);
-	EccPoint_toAffine(&p_point, &P);
-
-	/* r = x1 (mod n) */
-	vli_set(r, p_point.x);
-	if (vli_cmp(curve_n, r, NUM_ECC_DIGITS) != 1) {
-		vli_sub(r, r, curve_n, NUM_ECC_DIGITS);
+	uECC_vli_clear(native, num_n_words);
+	uECC_vli_bytesToNative(native, bits, bits_size);
+	if (bits_size * 8 <= (unsigned)curve->num_n_bits) {
+		return;
+	}
+	shift = bits_size * 8 - curve->num_n_bits;
+	carry = 0;
+	ptr = native + num_n_words;
+	while (ptr-- > native) {
+		uECC_word_t temp = *ptr;
+		*ptr = (temp >> shift) | carry;
+		carry = temp << (uECC_WORD_BITS - shift);
 	}
 
-	if (vli_isZero(r)) {
-		return TC_CRYPTO_FAIL; /* If r == 0, fail (need a different random number). */
+	/* Reduce mod curve_n */
+	if (uECC_vli_cmp_unsafe(curve->n, native, num_n_words) != 1) {
+		uECC_vli_sub(native, native, curve->n, num_n_words);
 	}
-
-	vli_modMult(s, r, p_privateKey, curve_n, curve_nb); /* s = r*d */
-	vli_modAdd(s, p_hash, s, curve_n); /* s = e + r*d */
-	vli_modInv(k, k, curve_n, curve_nb); /* k = 1 / k */
-	vli_modMult(s, s, k, curve_n, curve_nb); /* s = (e + r*d) / k */
-
-	return TC_CRYPTO_SUCCESS;
 }
 
-int32_t ecdsa_verify(EccPoint *p_publicKey, uint32_t p_hash[NUM_ECC_DIGITS],
-		     uint32_t r[NUM_ECC_DIGITS], uint32_t s[NUM_ECC_DIGITS])
+int uECC_sign_with_k(const uint8_t *private_key, const uint8_t *message_hash,
+		     unsigned hash_size, uECC_word_t *k, uint8_t *signature,
+		     uECC_Curve curve)
 {
 
-	uint32_t u1[NUM_ECC_DIGITS], u2[NUM_ECC_DIGITS];
-	uint32_t z[NUM_ECC_DIGITS];
-	EccPointJacobi P, R;
-	EccPoint p_point;
+	uECC_word_t tmp[NUM_ECC_WORDS];
+	uECC_word_t s[NUM_ECC_WORDS];
+	uECC_word_t *k2[2] = {tmp, s};
+	uECC_word_t p[NUM_ECC_WORDS * 2];
+	uECC_word_t carry;
+	wordcount_t num_words = curve->num_words;
+	wordcount_t num_n_words = BITS_TO_WORDS(curve->num_n_bits);
+	bitcount_t num_n_bits = curve->num_n_bits;
 
-	if (vli_isZero(r) || vli_isZero(s)) {
-		return TC_CRYPTO_FAIL; /* r, s must not be 0. */
+	/* Make sure 0 < k < curve_n */
+  	if (uECC_vli_isZero(k, num_words) ||
+	    uECC_vli_cmp(curve->n, k, num_n_words) != 1) {
+		return 0;
 	}
 
-	if ((vli_cmp(curve_n, r, NUM_ECC_DIGITS) != 1) ||
-	   (vli_cmp(curve_n, s, NUM_ECC_DIGITS) != 1)) {
-		return TC_CRYPTO_FAIL; /* r, s must be < n. */
+	carry = regularize_k(k, tmp, s, curve);
+	EccPoint_mult(p, curve->G, k2[!carry], 0, num_n_bits + 1, curve);
+	if (uECC_vli_isZero(p, num_words)) {
+		return 0;
+	}
+
+	/* If an RNG function was specified, get a random number
+	to prevent side channel analysis of k. */
+	if (!g_rng_function) {
+		uECC_vli_clear(tmp, num_n_words);
+		tmp[0] = 1;
+	}
+	else if (!uECC_generate_random_int(tmp, curve->n, num_n_words)) {
+		return 0;
+	}
+
+	/* Prevent side channel analysis of uECC_vli_modInv() to determine
+	bits of k / the private key by premultiplying by a random number */
+	uECC_vli_modMult(k, k, tmp, curve->n, num_n_words); /* k' = rand * k */
+	uECC_vli_modInv(k, k, curve->n, num_n_words);       /* k = 1 / k' */
+	uECC_vli_modMult(k, k, tmp, curve->n, num_n_words); /* k = 1 / k */
+
+	uECC_vli_nativeToBytes(signature, curve->num_bytes, p); /* store r */
+
+	/* tmp = d: */
+	uECC_vli_bytesToNative(tmp, private_key, BITS_TO_BYTES(curve->num_n_bits));
+
+	s[num_n_words - 1] = 0;
+	uECC_vli_set(s, p, num_words);
+	uECC_vli_modMult(s, tmp, s, curve->n, num_n_words); /* s = r*d */
+
+	bits2int(tmp, message_hash, hash_size, curve);
+	uECC_vli_modAdd(s, tmp, s, curve->n, num_n_words); /* s = e + r*d */
+	uECC_vli_modMult(s, s, k, curve->n, num_n_words);  /* s = (e + r*d) / k */
+	if (uECC_vli_numBits(s, num_n_words) > (bitcount_t)curve->num_bytes * 8) {
+		return 0;
+	}
+
+	uECC_vli_nativeToBytes(signature + curve->num_bytes, curve->num_bytes, s);
+	return 1;
+}
+
+int uECC_sign(const uint8_t *private_key, const uint8_t *message_hash,
+	      unsigned hash_size, uint8_t *signature, uECC_Curve curve)
+{
+	      uECC_word_t _random[2*NUM_ECC_WORDS];
+	      uECC_word_t k[NUM_ECC_WORDS];
+	      uECC_word_t tries;
+
+	for (tries = 0; tries < uECC_RNG_MAX_TRIES; ++tries) {
+		/* Generating _random uniformly at random: */
+		uECC_RNG_Function rng_function = uECC_get_rng();
+		if (!rng_function ||
+		    !rng_function((uint8_t *)_random, 2*NUM_ECC_WORDS*uECC_WORD_SIZE)) {
+			return 0;
+		}
+
+		// computing k as modular reduction of _random (see FIPS 186.4 B.5.1):
+		uECC_vli_mmod(k, _random, curve->n, BITS_TO_WORDS(curve->num_n_bits));
+
+		if (uECC_sign_with_k(private_key, message_hash, hash_size, k, signature, 
+		    curve)) {
+			return 1;
+		}
+	}
+	return 0;
+}
+
+static bitcount_t smax(bitcount_t a, bitcount_t b)
+{
+	return (a > b ? a : b);
+}
+
+int uECC_verify(const uint8_t *public_key, const uint8_t *message_hash,
+		unsigned hash_size, const uint8_t *signature,
+	        uECC_Curve curve)
+{
+
+	uECC_word_t u1[NUM_ECC_WORDS], u2[NUM_ECC_WORDS];
+	uECC_word_t z[NUM_ECC_WORDS];
+	uECC_word_t sum[NUM_ECC_WORDS * 2];
+	uECC_word_t rx[NUM_ECC_WORDS];
+	uECC_word_t ry[NUM_ECC_WORDS];
+	uECC_word_t tx[NUM_ECC_WORDS];
+	uECC_word_t ty[NUM_ECC_WORDS];
+	uECC_word_t tz[NUM_ECC_WORDS];
+	const uECC_word_t *points[4];
+	const uECC_word_t *point;
+	bitcount_t num_bits;
+	bitcount_t i;
+
+	uECC_word_t _public[NUM_ECC_WORDS * 2];
+	uECC_word_t r[NUM_ECC_WORDS], s[NUM_ECC_WORDS];
+	wordcount_t num_words = curve->num_words;
+	wordcount_t num_n_words = BITS_TO_WORDS(curve->num_n_bits);
+
+	rx[num_n_words - 1] = 0;
+	r[num_n_words - 1] = 0;
+	s[num_n_words - 1] = 0;
+
+	uECC_vli_bytesToNative(_public, public_key, curve->num_bytes);
+	uECC_vli_bytesToNative(_public + num_words, public_key + curve->num_bytes,
+			       curve->num_bytes);
+	uECC_vli_bytesToNative(r, signature, curve->num_bytes);
+	uECC_vli_bytesToNative(s, signature + curve->num_bytes, curve->num_bytes);
+
+	/* r, s must not be 0. */
+	if (uECC_vli_isZero(r, num_words) || uECC_vli_isZero(s, num_words)) {
+		return 0;
+	}
+
+	/* r, s must be < n. */
+	if (uECC_vli_cmp_unsafe(curve->n, r, num_n_words) != 1 ||
+	    uECC_vli_cmp_unsafe(curve->n, s, num_n_words) != 1) {
+		return 0;
 	}
 
 	/* Calculate u1 and u2. */
-	vli_modInv(z, s, curve_n, curve_nb); /* Z = s^-1 */
-	vli_modMult(u1, p_hash, z, curve_n, curve_nb); /* u1 = e/s */
-	vli_modMult(u2, r, z, curve_n, curve_nb); /* u2 = r/s */
+	uECC_vli_modInv(z, s, curve->n, num_n_words); /* z = 1/s */
+	u1[num_n_words - 1] = 0;
+	bits2int(u1, message_hash, hash_size, curve);
+	uECC_vli_modMult(u1, u1, z, curve->n, num_n_words); /* u1 = e/s */
+	uECC_vli_modMult(u2, r, z, curve->n, num_n_words); /* u2 = r/s */
 
-	/* calculate P = u1*G + u2*Q */
-	EccPoint_mult_unsafe(&P, &curve_G, u1);
-	EccPoint_mult_unsafe(&R, p_publicKey, u2);
-	EccPoint_add(&P, &R);
-	EccPoint_toAffine(&p_point, &P);
+	/* Calculate sum = G + Q. */
+	uECC_vli_set(sum, _public, num_words);
+	uECC_vli_set(sum + num_words, _public + num_words, num_words);
+	uECC_vli_set(tx, curve->G, num_words);
+	uECC_vli_set(ty, curve->G + num_words, num_words);
+	uECC_vli_modSub(z, sum, tx, curve->p, num_words); /* z = x2 - x1 */
+	XYcZ_add(tx, ty, sum, sum + num_words, curve);
+	uECC_vli_modInv(z, z, curve->p, num_words); /* z = 1/z */
+	apply_z(sum, sum + num_words, z, curve);
 
-	/* Accept only if P.x == r. */
-	if (!vli_sub(z, p_point.x, curve_n, NUM_ECC_DIGITS)) {
-	  vli_set(p_point.x, z);
+	/* Use Shamir's trick to calculate u1*G + u2*Q */
+	points[0] = 0;
+	points[1] = curve->G;
+	points[2] = _public;
+	points[3] = sum;
+	num_bits = smax(uECC_vli_numBits(u1, num_n_words),
+	uECC_vli_numBits(u2, num_n_words));
+
+	point = points[(!!uECC_vli_testBit(u1, num_bits - 1)) |
+                       ((!!uECC_vli_testBit(u2, num_bits - 1)) << 1)];
+	uECC_vli_set(rx, point, num_words);
+	uECC_vli_set(ry, point + num_words, num_words);
+	uECC_vli_clear(z, num_words);
+	z[0] = 1;
+
+	for (i = num_bits - 2; i >= 0; --i) {
+		uECC_word_t index;
+		curve->double_jacobian(rx, ry, z, curve);
+
+		index = (!!uECC_vli_testBit(u1, i)) | ((!!uECC_vli_testBit(u2, i)) << 1);
+		point = points[index];
+		if (point) {
+			uECC_vli_set(tx, point, num_words);
+			uECC_vli_set(ty, point + num_words, num_words);
+			apply_z(tx, ty, z, curve);
+			uECC_vli_modSub(tz, rx, tx, curve->p, num_words); /* Z = x2 - x1 */
+			XYcZ_add(tx, ty, rx, ry, curve);
+			uECC_vli_modMult_fast(z, z, tz, curve);
+		}
+  	}
+
+	uECC_vli_modInv(z, z, curve->p, num_words); /* Z = 1/Z */
+	apply_z(rx, ry, z, curve);
+
+	/* v = x1 (mod n) */
+	if (uECC_vli_cmp_unsafe(curve->n, rx, num_n_words) != 1) {
+		uECC_vli_sub(rx, rx, curve->n, num_n_words);
 	}
 
-	return (vli_cmp(p_point.x, r, NUM_ECC_DIGITS) == 0);
+	/* Accept only if v == r. */
+	return (int)(uECC_vli_equal(rx, r, num_words) == 0);
 }
+

--- a/ext/lib/crypto/tinycrypt/source/ecc_platform_specific.c
+++ b/ext/lib/crypto/tinycrypt/source/ecc_platform_specific.c
@@ -1,0 +1,105 @@
+/*  uECC_platform_specific.c - Implementation of platform specific functions*/
+
+/* Copyright (c) 2014, Kenneth MacKay
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *  * Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *  * Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.*/
+
+/*
+ *  Copyright (C) 2017 by Intel Corporation, All Rights Reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions are met:
+ *
+ *    - Redistributions of source code must retain the above copyright notice,
+ *     this list of conditions and the following disclaimer.
+ *
+ *    - Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ *    - Neither the name of Intel Corporation nor the names of its contributors
+ *    may be used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ *  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ *  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ *  ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+ *  LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ *  CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ *  SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ *  INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ *  CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ *  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ *
+ *  uECC_platform_specific.c -- Implementation of platform specific functions
+ */
+
+
+#if defined(unix) || defined(__linux__) || defined(__unix__) || \
+    defined(__unix) |  (defined(__APPLE__) && defined(__MACH__)) || \
+    defined(uECC_POSIX)
+
+/* Some POSIX-like system with /dev/urandom or /dev/random. */
+#include <sys/types.h>
+#include <fcntl.h>
+#include <unistd.h>
+
+#include <stdint.h>
+
+#ifndef O_CLOEXEC
+#define O_CLOEXEC 0
+#endif
+
+int default_CSPRNG(uint8_t *dest, unsigned int size) {
+
+  /* input sanity check: */
+  if (dest == (uint8_t *) 0 || (size <= 0))
+    return 0;
+
+  int fd = open("/dev/urandom", O_RDONLY | O_CLOEXEC);
+  if (fd == -1) {
+    fd = open("/dev/random", O_RDONLY | O_CLOEXEC);
+    if (fd == -1) {
+      return 0;
+    }
+  }
+
+  char *ptr = (char *)dest;
+  size_t left = (size_t) size;
+  while (left > 0) {
+    ssize_t bytes_read = read(fd, ptr, left);
+    if (bytes_read <= 0) { // read failed
+      close(fd);
+      return 0;
+    }
+    left -= bytes_read;
+    ptr += bytes_read;
+  }
+
+  close(fd);
+  return 1;
+}
+
+#endif /* platform */
+

--- a/ext/lib/crypto/tinycrypt/source/hmac.c
+++ b/ext/lib/crypto/tinycrypt/source/hmac.c
@@ -1,7 +1,7 @@
 /* hmac.c - TinyCrypt implementation of the HMAC algorithm */
 
 /*
- *  Copyright (C) 2015 by Intel Corporation, All Rights Reserved.
+ *  Copyright (C) 2017 by Intel Corporation, All Rights Reserved.
  *
  *  Redistribution and use in source and binary forms, with or without
  *  modification, are permitted provided that the following conditions are met:
@@ -34,11 +34,11 @@
 #include <tinycrypt/constants.h>
 #include <tinycrypt/utils.h>
 
-static void rekey(uint8_t *key, const uint8_t *new_key, uint32_t key_size)
+static void rekey(uint8_t *key, const uint8_t *new_key, unsigned int key_size)
 {
 	const uint8_t inner_pad = (uint8_t) 0x36;
 	const uint8_t outer_pad = (uint8_t) 0x5c;
-	uint32_t i;
+	unsigned int i;
 
 	for (i = 0; i < key_size; ++i) {
 		key[i] = inner_pad ^ new_key[i];
@@ -49,10 +49,10 @@ static void rekey(uint8_t *key, const uint8_t *new_key, uint32_t key_size)
 	}
 }
 
-int32_t tc_hmac_set_key(TCHmacState_t ctx,
-			const uint8_t *key,
-			uint32_t key_size)
+int tc_hmac_set_key(TCHmacState_t ctx, const uint8_t *key,
+		    unsigned int key_size)
 {
+
 	/* input sanity check: */
 	if (ctx == (TCHmacState_t) 0 ||
 	    key == (const uint8_t *) 0 ||
@@ -93,27 +93,29 @@ int32_t tc_hmac_set_key(TCHmacState_t ctx,
 	return TC_CRYPTO_SUCCESS;
 }
 
-int32_t tc_hmac_init(TCHmacState_t ctx)
+int tc_hmac_init(TCHmacState_t ctx)
 {
+
 	/* input sanity check: */
-	if (ctx == (TCHmacState_t) 0) {
+	if (ctx == (TCHmacState_t) 0 ||
+      	    ctx->key == (uint8_t *) 0) {
 		return TC_CRYPTO_FAIL;
 	}
 
-	(void)tc_sha256_init(&ctx->hash_state);
-	(void)tc_sha256_update(&ctx->hash_state,
-			       ctx->key,
-			       TC_SHA256_BLOCK_SIZE);
+  (void) tc_sha256_init(&ctx->hash_state);
+  (void) tc_sha256_update(&ctx->hash_state, ctx->key, TC_SHA256_BLOCK_SIZE);
 
 	return TC_CRYPTO_SUCCESS;
 }
 
-int32_t tc_hmac_update(TCHmacState_t ctx,
-		       const void *data,
-		       uint32_t data_length)
+int tc_hmac_update(TCHmacState_t ctx,
+		   const void *data,
+		   unsigned int data_length)
 {
+
 	/* input sanity check: */
-	if (ctx == (TCHmacState_t) 0) {
+	if (ctx == (TCHmacState_t) 0 ||
+	    ctx->key == (uint8_t *) 0) {
 		return TC_CRYPTO_FAIL;
 	}
 
@@ -122,12 +124,14 @@ int32_t tc_hmac_update(TCHmacState_t ctx,
 	return TC_CRYPTO_SUCCESS;
 }
 
-int32_t tc_hmac_final(uint8_t *tag, uint32_t taglen, TCHmacState_t ctx)
+int tc_hmac_final(uint8_t *tag, unsigned int taglen, TCHmacState_t ctx)
 {
+
 	/* input sanity check: */
 	if (tag == (uint8_t *) 0 ||
 	    taglen != TC_SHA256_DIGEST_SIZE ||
-	    ctx == (TCHmacState_t) 0) {
+	    ctx == (TCHmacState_t) 0 ||
+	    ctx->key == (uint8_t *) 0) {
 		return TC_CRYPTO_FAIL;
 	}
 

--- a/ext/lib/crypto/tinycrypt/source/hmac_prng.c
+++ b/ext/lib/crypto/tinycrypt/source/hmac_prng.c
@@ -1,7 +1,7 @@
 /* hmac_prng.c - TinyCrypt implementation of HMAC-PRNG */
 
 /*
- *  Copyright (C) 2015 by Intel Corporation, All Rights Reserved.
+ *  Copyright (C) 2017 by Intel Corporation, All Rights Reserved.
  *
  *  Redistribution and use in source and binary forms, with or without
  *  modification, are permitted provided that the following conditions are met:
@@ -39,43 +39,43 @@
  * min bytes in the seed string.
  * MIN_SLEN*8 must be at least the expected security level.
  */
-static const uint32_t MIN_SLEN = 32;
+static const unsigned int MIN_SLEN = 32;
 
 /*
  * max bytes in the seed string;
  * SP800-90A specifies a maximum of 2^35 bits (i.e., 2^32 bytes).
  */
-static const uint32_t MAX_SLEN = UINT32_MAX;
+static const unsigned int MAX_SLEN = UINT32_MAX;
 
 /*
  * max bytes in the personalization string;
  * SP800-90A specifies a maximum of 2^35 bits (i.e., 2^32 bytes).
  */
-static const uint32_t MAX_PLEN = UINT32_MAX;
+static const unsigned int MAX_PLEN = UINT32_MAX;
 
 /*
  * max bytes in the additional_info string;
  * SP800-90A specifies a maximum of 2^35 bits (i.e., 2^32 bytes).
  */
-static const uint32_t MAX_ALEN = UINT32_MAX;
+static const unsigned int MAX_ALEN = UINT32_MAX;
 
 /*
  * max number of generates between re-seeds;
  * TinyCrypt accepts up to (2^32 - 1) which is the maximal value of
- * a uint32_t variable, while SP800-90A specifies a maximum of 2^48.
+ * a 32-bit unsigned int variable, while SP800-90A specifies a maximum of 2^48.
  */
-static const uint32_t MAX_GENS = UINT32_MAX;
+static const unsigned int MAX_GENS = UINT32_MAX;
 
 /*
  * maximum bytes per generate call;
  * SP800-90A specifies a maximum up to 2^19.
  */
-static const uint32_t MAX_OUT = (1 << 19);
+static const unsigned int  MAX_OUT = (1 << 19);
 
 /*
  * Assumes: prng != NULL, e != NULL, len >= 0.
  */
-static void update(TCHmacPrng_t prng, const uint8_t *e, uint32_t len)
+static void update(TCHmacPrng_t prng, const uint8_t *e, unsigned int len)
 {
 	const uint8_t separator0 = 0x00;
 	const uint8_t separator1 = 0x01;
@@ -109,10 +109,11 @@ static void update(TCHmacPrng_t prng, const uint8_t *e, uint32_t len)
 	(void)tc_hmac_final(prng->v, sizeof(prng->v), &prng->h);
 }
 
-int32_t tc_hmac_prng_init(TCHmacPrng_t prng,
-			  const uint8_t *personalization,
-			  uint32_t plen)
+int tc_hmac_prng_init(TCHmacPrng_t prng,
+		      const uint8_t *personalization,
+		      unsigned int plen)
 {
+
 	/* input sanity check: */
 	if (prng == (TCHmacPrng_t) 0 ||
 	    personalization == (uint8_t *) 0 ||
@@ -134,12 +135,13 @@ int32_t tc_hmac_prng_init(TCHmacPrng_t prng,
 	return TC_CRYPTO_SUCCESS;
 }
 
-int32_t tc_hmac_prng_reseed(TCHmacPrng_t prng,
-			    const uint8_t *seed,
-			    uint32_t seedlen,
-			    const uint8_t *additional_input,
-			    uint32_t additionallen)
+int tc_hmac_prng_reseed(TCHmacPrng_t prng,
+			const uint8_t *seed,
+			unsigned int seedlen,
+			const uint8_t *additional_input,
+			unsigned int additionallen)
 {
+
 	/* input sanity check: */
 	if (prng == (TCHmacPrng_t) 0 ||
 	    seed == (const uint8_t *) 0 ||
@@ -172,9 +174,9 @@ int32_t tc_hmac_prng_reseed(TCHmacPrng_t prng,
 	return TC_CRYPTO_SUCCESS;
 }
 
-int32_t tc_hmac_prng_generate(uint8_t *out, uint32_t outlen, TCHmacPrng_t prng)
+int tc_hmac_prng_generate(uint8_t *out, unsigned int outlen, TCHmacPrng_t prng)
 {
-	uint32_t bufferlen;
+	unsigned int bufferlen;
 
 	/* input sanity check: */
 	if (out == (uint8_t *) 0 ||

--- a/ext/lib/crypto/tinycrypt/source/utils.c
+++ b/ext/lib/crypto/tinycrypt/source/utils.c
@@ -1,7 +1,7 @@
 /* utils.c - TinyCrypt platform-dependent run-time operations */
 
 /*
- *  Copyright (C) 2015 by Intel Corporation, All Rights Reserved.
+ *  Copyright (C) 2017 by Intel Corporation, All Rights Reserved.
  *
  *  Redistribution and use in source and binary forms, with or without
  *  modification, are permitted provided that the following conditions are met:
@@ -35,11 +35,10 @@
 
 #include <string.h>
 
-#define MASK_MOST_SIG_BIT 0x80
 #define MASK_TWENTY_SEVEN 0x1b
 
-uint32_t _copy(uint8_t *to, uint32_t to_len,
-	       const uint8_t *from, uint32_t from_len)
+unsigned int _copy(uint8_t *to, unsigned int to_len,
+		   const uint8_t *from, unsigned int from_len)
 {
 	if (from_len <= to_len) {
 		(void)memcpy(to, from, from_len);
@@ -49,7 +48,7 @@ uint32_t _copy(uint8_t *to, uint32_t to_len,
 	}
 }
 
-void _set(void *to, uint8_t val, uint32_t len)
+void _set(void *to, uint8_t val, unsigned int len)
 {
 	(void)memset(to, val, len);
 }
@@ -62,13 +61,13 @@ uint8_t _double_byte(uint8_t a)
 	return ((a<<1) ^ ((a>>7) * MASK_TWENTY_SEVEN));
 }
 
-int32_t _compare(const uint8_t *a, const uint8_t *b, size_t size)
+int _compare(const uint8_t *a, const uint8_t *b, size_t size)
 {
 	const uint8_t *tempa = a;
 	const uint8_t *tempb = b;
 	uint8_t result = 0;
 
-	for (uint32_t i = 0; i < size; i++) {
+	for (unsigned int i = 0; i < size; i++) {
 		result |= tempa[i] ^ tempb[i];
 	}
 	return result;

--- a/tests/crypto/ccm_mode/src/test_ccm_mode.c
+++ b/tests/crypto/ccm_mode/src/test_ccm_mode.c
@@ -90,8 +90,8 @@ u32_t do_test(const u8_t *key,
 		goto exitTest1;
 	}
 
-	result = tc_ccm_generation_encryption(ciphertext, hdr, hlen,
-					      data, dlen, &c);
+	result = tc_ccm_generation_encryption(ciphertext, sizeof(ciphertext),
+					      hdr, hlen, data, dlen, &c);
 	if (result == 0) {
 		TC_ERROR("ccm_encrypt failed in %s.\n", __func__);
 
@@ -110,8 +110,9 @@ u32_t do_test(const u8_t *key,
 		goto exitTest1;
 	}
 
-	result = tc_ccm_decryption_verification(decrypted, hdr, hlen,
-						ciphertext, dlen + mlen, &c);
+	result = tc_ccm_decryption_verification(decrypted, sizeof(decrypted),
+						hdr, hlen, ciphertext,
+						dlen + mlen, &c);
 	if (result == 0) {
 		TC_ERROR("ccm_decrypt failed in %s.\n", __func__);
 		show_str("\t\tExpected", data, dlen);
@@ -393,8 +394,8 @@ u32_t test_vector_7(void)
 		goto exitTest1;
 	}
 
-	result = tc_ccm_generation_encryption(ciphertext, hdr, 0,
-					      data, sizeof(data), &c);
+	result = tc_ccm_generation_encryption(ciphertext, sizeof(ciphertext),
+					      hdr, 0, data, sizeof(data), &c);
 	if (result == 0) {
 		TC_ERROR("ccm_encryption failed in %s.\n", __func__);
 
@@ -402,7 +403,8 @@ u32_t test_vector_7(void)
 		goto exitTest1;
 	}
 
-	result = tc_ccm_decryption_verification(decrypted, hdr, 0, ciphertext,
+	result = tc_ccm_decryption_verification(decrypted, sizeof(decrypted),
+						hdr, 0, ciphertext,
 						sizeof(data) + mlen, &c);
 	if (result == 0) {
 		TC_ERROR("ccm_decrypt failed in %s.\n", __func__);
@@ -453,8 +455,9 @@ u32_t test_vector_8(void)
 		goto exitTest1;
 	}
 
-	result = tc_ccm_generation_encryption(ciphertext, hdr, sizeof(hdr),
-					      data, sizeof(data), &c);
+	result = tc_ccm_generation_encryption(ciphertext, sizeof(ciphertext),
+					      hdr, sizeof(hdr), data,
+					      sizeof(data), &c);
 	if (result == 0) {
 		TC_ERROR("ccm_encrypt failed in %s.\n", __func__);
 
@@ -462,7 +465,8 @@ u32_t test_vector_8(void)
 		goto exitTest1;
 	}
 
-	result = tc_ccm_decryption_verification(decrypted, hdr, sizeof(hdr),
+	result = tc_ccm_decryption_verification(decrypted, sizeof(decrypted),
+						hdr, sizeof(hdr),
 						ciphertext, mlen, &c);
 	if (result == 0) {
 		TC_ERROR("ccm_decrypt failed in %s.\n", __func__);

--- a/tests/crypto/ecc_dh/src/test_ecc_dh.c
+++ b/tests/crypto/ecc_dh/src/test_ecc_dh.c
@@ -1,7 +1,30 @@
-/* test_ecc_ecdh.c - TinyCrypt implementation of some EC-DH tests */
+/* test_ecc_dh.c - TinyCrypt implementation of some EC-DH tests */
+
+/* Copyright (c) 2014, Kenneth MacKay
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *  * Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *  * Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.*/
 
 /*
- *  Copyright (C) 2015 by Intel Corporation, All Rights Reserved.
+ *  Copyright (C) 2017 by Intel Corporation, All Rights Reserved.
  *
  *  Redistribution and use in source and binary forms, with or without
  *  modification, are permitted provided that the following conditions are met:
@@ -32,246 +55,280 @@
  *  test_ecc_ecdh.c -- Implementation of some EC-DH tests
  *
  */
-
 #include <tinycrypt/ecc.h>
 #include <tinycrypt/ecc_dh.h>
+#include <tinycrypt/ecc_platform_specific.h>
 #include <test_ecc_utils.h>
 #include <test_utils.h>
 #include <tinycrypt/constants.h>
 
+#include <stdio.h>
+#include <stdlib.h>
 #include <string.h>
 
 int ecdh_vectors(char **qx_vec, char **qy_vec, char **d_vec, char **z_vec,
 		 int tests, int verbose)
 {
-	EccPoint Q;
-	u32_t prv[NUM_ECC_DIGITS];
-	u32_t z[NUM_ECC_DIGITS];
-	u32_t exp_z[NUM_ECC_DIGITS];
 
-	int rc = TC_FAIL;
+	unsigned int pub[2 * NUM_ECC_WORDS];
+	unsigned int prv[NUM_ECC_WORDS];
+	unsigned int z[NUM_ECC_WORDS];
+	unsigned int result = TC_PASS;
+
+	int rc;
+	unsigned int exp_z[NUM_ECC_WORDS];
+
+	const struct uECC_Curve_t *curve = uECC_secp256r1();
 
 	for (int i = 0; i < tests; i++) {
-		str_to_scalar(Q.x, NUM_ECC_DIGITS, qx_vec[i]);
-		str_to_scalar(Q.y, NUM_ECC_DIGITS, qy_vec[i]);
-		str_to_scalar(exp_z, NUM_ECC_DIGITS, z_vec[i]);
-		str_to_scalar(prv, NUM_ECC_DIGITS, d_vec[i]);
 
-		rc = ecdh_shared_secret(z, &Q, prv);
-		if (rc != TC_CRYPTO_SUCCESS) {
-			TC_PRINT("ECDH failure, exit.\n");
-			rc = TC_FAIL;
-			goto exit_test;
+		string2scalar(pub + NUM_ECC_WORDS, NUM_ECC_WORDS, qx_vec[i]);
+		string2scalar(pub, NUM_ECC_WORDS, qy_vec[i]);
+		string2scalar(exp_z, NUM_ECC_WORDS, z_vec[i]);
+		string2scalar(prv, NUM_ECC_WORDS, d_vec[i]);
+
+		uint8_t pub_bytes[2 * NUM_ECC_BYTES];
+		uECC_vli_nativeToBytes(pub_bytes, 2 * NUM_ECC_BYTES, pub);
+		uint8_t private_bytes[NUM_ECC_BYTES];
+		uECC_vli_nativeToBytes(private_bytes, NUM_ECC_BYTES, prv);
+		uint8_t z_bytes[NUM_ECC_BYTES];
+		uECC_vli_nativeToBytes(z_bytes, NUM_ECC_BYTES, z);
+
+		rc = uECC_shared_secret(pub_bytes, private_bytes, z_bytes, curve);
+
+		if (rc == TC_CRYPTO_FAIL) {
+			TC_ERROR("ECDH failure, exit.\n");
+			result = TC_FAIL;
+			return result;;
 		}
-		rc = check_ecc_result(i, "Z", exp_z, z, NUM_ECC_DIGITS,
-				      verbose);
-		if (rc != TC_PASS) {
-			goto exit_test;
+
+		uECC_vli_bytesToNative(z, z_bytes, NUM_ECC_BYTES);
+
+		result = check_ecc_result(i, "Z", exp_z, z, NUM_ECC_WORDS, verbose);
+		if (result == TC_FAIL) {
+			return result;
 		}
 	}
-
-	rc = TC_PASS;
-
-exit_test:
-	return rc;
+	return result;
 }
 
-char *dh_d[] = {
-	"7d7dc5f71eb29ddaf80d6214632eeae03d9058af1fb6d22ed80badb62bc1a534",
-	"38f65d6dce47676044d58ce5139582d568f64bb16098d179dbab07741dd5caf5",
-	"1accfaf1b97712b85a6f54b148985a1bdc4c9bec0bd258cad4b3d603f49f32c8",
-	"207c43a79bfee03db6f4b944f53d2fb76cc49ef1c9c4d34d51b6c65c4db6932d",
-	"59137e38152350b195c9718d39673d519838055ad908dd4757152fd8255c09bf",
-	"f5f8e0174610a661277979b58ce5c90fee6c9b3bb346a90a7196255e40b132ef",
-	"3b589af7db03459c23068b64f63f28d3c3c6bc25b5bf76ac05f35482888b5190",
-	"d8bf929a20ea7436b2461b541a11c80e61d826c0a4c9d322b31dd54e7f58b9c8",
-	"0f9883ba0ef32ee75ded0d8bda39a5146a29f1f2507b3bd458dbea0b2bb05b4d",
-	"2beedb04b05c6988f6a67500bb813faf2cae0d580c9253b6339e4a3337bb6c08",
-	"77c15dcf44610e41696bab758943eff1409333e4d5a11bbe72c8f6c395e9f848",
-	"42a83b985011d12303db1a800f2610f74aa71cdf19c67d54ce6c9ed951e9093e",
-	"ceed35507b5c93ead5989119b9ba342cfe38e6e638ba6eea343a55475de2800b",
-	"43e0e9d95af4dc36483cdd1968d2b7eeb8611fcce77f3a4e7d059ae43e509604",
-	"b2f3600df3368ef8a0bb85ab22f41fc0e5f4fdd54be8167a5c3cd4b08db04903",
-	"4002534307f8b62a9bf67ff641ddc60fef593b17c3341239e95bdb3e579bfdc8",
-	"4dfa12defc60319021b681b3ff84a10a511958c850939ed45635934ba4979147",
-	"1331f6d874a4ed3bc4a2c6e9c74331d3039796314beee3b7152fcdba5556304e",
-	"dd5e9f70ae740073ca0204df60763fb6036c45709bf4a7bb4e671412fad65da3",
-	"5ae026cfc060d55600717e55b8a12e116d1d0df34af831979057607c2d9c2f76",
-	"b601ac425d5dbf9e1735c5e2d5bdb79ca98b3d5be4a2cfd6f2273f150e064d9d",
-	"fefb1dda1845312b5fce6b81b2be205af2f3a274f5a212f66c0d9fc33d7ae535",
-	"334ae0c4693d23935a7e8e043ebbde21e168a7cba3fa507c9be41d7681e049ce",
-	"2c4bde40214fcc3bfc47d4cf434b629acbe9157f8fd0282540331de7942cf09d",
-	"85a268f9d7772f990c36b42b0a331adc92b5941de0b862d5d89a347cbf8faab0",
-};
-
-char *dh_x[] = {
-	"700c48f77f56584c5cc632ca65640db91b6bacce3a4df6b42ce7cc838833d287",
-	"809f04289c64348c01515eb03d5ce7ac1a8cb9498f5caa50197e58d43a86a7ae",
-	"a2339c12d4a03c33546de533268b4ad667debf458b464d77443636440ee7fec3",
-	"df3989b9fa55495719b3cf46dccd28b5153f7808191dd518eff0c3cff2b705ed",
-	"41192d2813e79561e6a1d6f53c8bc1a433a199c835e141b05a74a97b0faeb922",
-	"33e82092a0f1fb38f5649d5867fba28b503172b7035574bf8e5b7100a3052792",
-	"6a9e0c3f916e4e315c91147be571686d90464e8bf981d34a90b6353bca6eeba7",
-	"a9c0acade55c2a73ead1a86fb0a9713223c82475791cd0e210b046412ce224bb",
-	"94e94f16a98255fff2b9ac0c9598aac35487b3232d3231bd93b7db7df36f9eb9",
-	"e099bf2a4d557460b5544430bbf6da11004d127cb5d67f64ab07c94fcdf5274f",
-	"f75a5fe56bda34f3c1396296626ef012dc07e4825838778a645c8248cff01658",
-	"2db4540d50230756158abf61d9835712b6486c74312183ccefcaef2797b7674d",
-	"cd94fc9497e8990750309e9a8534fd114b0a6e54da89c4796101897041d14ecb",
-	"15b9e467af4d290c417402e040426fe4cf236bae72baa392ed89780dfccdb471",
-	"49c503ba6c4fa605182e186b5e81113f075bc11dcfd51c932fb21e951eee2fa1",
-	"19b38de39fdd2f70f7091631a4f75d1993740ba9429162c2a45312401636b29c",
-	"2c91c61f33adfe9311c942fdbff6ba47020feff416b7bb63cec13faf9b099954",
-	"a28a2edf58025668f724aaf83a50956b7ac1cfbbff79b08c3bf87dfd2828d767",
-	"a2ef857a081f9d6eb206a81c4cf78a802bdf598ae380c8886ecd85fdc1ed7644",
-	"ccd8a2d86bc92f2e01bce4d6922cf7fe1626aed044685e95e2eebd464505f01f",
-	"c188ffc8947f7301fb7b53e36746097c2134bf9cc981ba74b4e9c4361f595e4e",
-	"317e1020ff53fccef18bf47bb7f2dd7707fb7b7a7578e04f35b3beed222a0eb6",
-	"45fb02b2ceb9d7c79d9c2fa93e9c7967c2fa4df5789f9640b24264b1e524fcb1",
-	"a19ef7bff98ada781842fbfc51a47aff39b5935a1c7d9625c8d323d511c92de6",
-	"356c5a444c049a52fee0adeb7e5d82ae5aa83030bfff31bbf8ce2096cf161c4b",
-};
-
-char *dh_y[] = {
-	"db71e509e3fd9b060ddb20ba5c51dcc5948d46fbf640dfe0441782cab85fa4ac",
-	"b29d84e811197f25eba8f5194092cb6ff440e26d4421011372461f579271cda3",
-	"ef48a3ab26e20220bcda2c1851076839dae88eae962869a497bf73cb66faf536",
-	"422294ff46003429d739a33206c8752552c8ba54a270defc06e221e0feaf6ac4",
-	"1af98cc45e98a7e041b01cf35f462b7562281351c8ebf3ffa02e33a0722a1328",
-	"f2cf6b601e0a05945e335550bf648d782f46186c772c0f20d3cd0d6b8ca14b2f",
-	"40f9bead39c2f2bcc2602f75b8a73ec7bdffcbcead159d0174c6c4d3c5357f05",
-	"f6de0afa20e93e078467c053d241903edad734c6b403ba758c2b5ff04c9d4229",
-	"d8049a43579cfa90b8093a94416cbefbf93386f15b3f6e190b6e3455fedfe69a",
-	"d9c50dbe70d714edb5e221f4e020610eeb6270517e688ca64fb0e98c7ef8c1c5",
-	"33bbdf1b1772d8059df568b061f3f1122f28a8d819167c97be448e3dc3fb0c3c",
-	"62f57f314e3f3495dc4e099012f5e0ba71770f9660a1eada54104cdfde77243e",
-	"c3def4b5fe04faee0a11932229fff563637bfdee0e79c6deeaf449f85401c5c4",
-	"cdf4e9170fb904302b8fd93a820ba8cc7ed4efd3a6f2d6b05b80b2ff2aee4e77",
-	"8af706ff0922d87b3f0c5e4e31d8b259aeb260a9269643ed520a13bb25da5924",
-	"09aed7232b28e060941741b6828bcdfa2bc49cc844f3773611504f82a390a5ae",
-	"6cab31b06419e5221fca014fb84ec870622a1b12bab5ae43682aa7ea73ea08d0",
-	"dfa7bfffd4c766b86abeaf5c99b6e50cb9ccc9d9d00b7ffc7804b0491b67bc03",
-	"563c4c20419f07bc17d0539fade1855e34839515b892c0f5d26561f97fa04d1a",
-	"e9ddd583a9635a667777d5b8a8f31b0f79eba12c75023410b54b8567dddc0f38",
-	"bf7d2f2056e72421ef393f0c0f2b0e00130e3cac4abbcc00286168e85ec55051",
-	"09420ce5a19d77c6fe1ee587e6a49fbaf8f280e8df033d75403302e5a27db2ae",
-	"5c6e8ecf1f7d3023893b7b1ca1e4d178972ee2a230757ddc564ffe37f5c5a321",
-	"e9c184df75c955e02e02e400ffe45f78f339e1afe6d056fb3245f4700ce606ef",
-	"57d128de8b2a57a094d1a001e572173f96e8866ae352bf29cddaf92fc85b2f92",
-};
-
-char *dh_z[] = {
-	"46fc62106420ff012e54a434fbdd2d25ccc5852060561e68040dd7778997bd7b",
-	"057d636096cb80b67a8c038c890e887d1adfa4195e9b3ce241c8a778c59cda67",
-	"2d457b78b4614132477618a5b077965ec90730a8c81a1c75d6d4ec68005d67ec",
-	"96441259534b80f6aee3d287a6bb17b5094dd4277d9e294f8fe73e48bf2a0024",
-	"19d44c8d63e8e8dd12c22a87b8cd4ece27acdde04dbf47f7f27537a6999a8e62",
-	"664e45d5bba4ac931cd65d52017e4be9b19a515f669bea4703542a2c525cd3d3",
-	"ca342daa50dc09d61be7c196c85e60a80c5cb04931746820be548cdde055679d",
-	"35aa9b52536a461bfde4e85fc756be928c7de97923f0416c7a3ac8f88b3d4489",
-	"605c16178a9bc875dcbff54d63fe00df699c03e8a888e9e94dfbab90b25f39b4",
-	"f96e40a1b72840854bb62bc13c40cc2795e373d4e715980b261476835a092e0b",
-	"8388fa79c4babdca02a8e8a34f9e43554976e420a4ad273c81b26e4228e9d3a3",
-	"72877cea33ccc4715038d4bcbdfe0e43f42a9e2c0c3b017fc2370f4b9acbda4a",
-	"e4e7408d85ff0e0e9c838003f28cdbd5247cdce31f32f62494b70e5f1bc36307",
-	"ed56bcf695b734142c24ecb1fc1bb64d08f175eb243a31f37b3d9bb4407f3b96",
-	"bc5c7055089fc9d6c89f83c1ea1ada879d9934b2ea28fcf4e4a7e984b28ad2cf",
-	"9a4e8e657f6b0e097f47954a63c75d74fcba71a30d83651e3e5a91aa7ccd8343",
-	"3ca1fc7ad858fb1a6aba232542f3e2a749ffc7203a2374a3f3d3267f1fc97b78",
-	"1aaabe7ee6e4a6fa732291202433a237df1b49bc53866bfbe00db96a0f58224f",
-	"430e6a4fba4449d700d2733e557f66a3bf3d50517c1271b1ddae1161b7ac798c",
-	"1ce9e6740529499f98d1f1d71329147a33df1d05e4765b539b11cf615d6974d3",
-	"4690e3743c07d643f1bc183636ab2a9cb936a60a802113c49bb1b3f2d0661660",
-	"30c2261bd0004e61feda2c16aa5e21ffa8d7e7f7dbf6ec379a43b48e4b36aeb0",
-	"2adae4a138a239dcd93c243a3803c3e4cf96e37fe14e6a9b717be9599959b11c",
-	"2e277ec30f5ea07d6ce513149b9479b96e07f4b6913b1b5c11305c1444a1bc0b",
-	"1e51373bd2c6044c129c436e742a55be2a668a85ae08441b6756445df5493857",
-};
-
-int cavp_ecdh(int verbose)
+int cavp_ecdh(bool verbose)
 {
-/*
- * P-256
- */
-	int rc;
+	unsigned int result = TC_PASS;
+	/*
+	 * P-256
+	 */
+	char *d[] = {
+		"7d7dc5f71eb29ddaf80d6214632eeae03d9058af1fb6d22ed80badb62bc1a534",
+		"38f65d6dce47676044d58ce5139582d568f64bb16098d179dbab07741dd5caf5",
+		"1accfaf1b97712b85a6f54b148985a1bdc4c9bec0bd258cad4b3d603f49f32c8",
+		"207c43a79bfee03db6f4b944f53d2fb76cc49ef1c9c4d34d51b6c65c4db6932d",
+		"59137e38152350b195c9718d39673d519838055ad908dd4757152fd8255c09bf",
+		"f5f8e0174610a661277979b58ce5c90fee6c9b3bb346a90a7196255e40b132ef",
+		"3b589af7db03459c23068b64f63f28d3c3c6bc25b5bf76ac05f35482888b5190",
+		"d8bf929a20ea7436b2461b541a11c80e61d826c0a4c9d322b31dd54e7f58b9c8",
+		"0f9883ba0ef32ee75ded0d8bda39a5146a29f1f2507b3bd458dbea0b2bb05b4d",
+		"2beedb04b05c6988f6a67500bb813faf2cae0d580c9253b6339e4a3337bb6c08",
+		"77c15dcf44610e41696bab758943eff1409333e4d5a11bbe72c8f6c395e9f848",
+		"42a83b985011d12303db1a800f2610f74aa71cdf19c67d54ce6c9ed951e9093e",
+		"ceed35507b5c93ead5989119b9ba342cfe38e6e638ba6eea343a55475de2800b",
+		"43e0e9d95af4dc36483cdd1968d2b7eeb8611fcce77f3a4e7d059ae43e509604",
+		"b2f3600df3368ef8a0bb85ab22f41fc0e5f4fdd54be8167a5c3cd4b08db04903",
+		"4002534307f8b62a9bf67ff641ddc60fef593b17c3341239e95bdb3e579bfdc8",
+		"4dfa12defc60319021b681b3ff84a10a511958c850939ed45635934ba4979147",
+		"1331f6d874a4ed3bc4a2c6e9c74331d3039796314beee3b7152fcdba5556304e",
+		"dd5e9f70ae740073ca0204df60763fb6036c45709bf4a7bb4e671412fad65da3",
+		"5ae026cfc060d55600717e55b8a12e116d1d0df34af831979057607c2d9c2f76",
+		"b601ac425d5dbf9e1735c5e2d5bdb79ca98b3d5be4a2cfd6f2273f150e064d9d",
+		"fefb1dda1845312b5fce6b81b2be205af2f3a274f5a212f66c0d9fc33d7ae535",
+		"334ae0c4693d23935a7e8e043ebbde21e168a7cba3fa507c9be41d7681e049ce",
+		"2c4bde40214fcc3bfc47d4cf434b629acbe9157f8fd0282540331de7942cf09d",
+		"85a268f9d7772f990c36b42b0a331adc92b5941de0b862d5d89a347cbf8faab0",
+	};
 
-	rc = ecdh_vectors(dh_x, dh_y, dh_d, dh_z, 25, verbose);
-	return rc;
+	char *x[] = {
+		"700c48f77f56584c5cc632ca65640db91b6bacce3a4df6b42ce7cc838833d287",
+		"809f04289c64348c01515eb03d5ce7ac1a8cb9498f5caa50197e58d43a86a7ae",
+		"a2339c12d4a03c33546de533268b4ad667debf458b464d77443636440ee7fec3",
+		"df3989b9fa55495719b3cf46dccd28b5153f7808191dd518eff0c3cff2b705ed",
+		"41192d2813e79561e6a1d6f53c8bc1a433a199c835e141b05a74a97b0faeb922",
+		"33e82092a0f1fb38f5649d5867fba28b503172b7035574bf8e5b7100a3052792",
+		"6a9e0c3f916e4e315c91147be571686d90464e8bf981d34a90b6353bca6eeba7",
+		"a9c0acade55c2a73ead1a86fb0a9713223c82475791cd0e210b046412ce224bb",
+		"94e94f16a98255fff2b9ac0c9598aac35487b3232d3231bd93b7db7df36f9eb9",
+		"e099bf2a4d557460b5544430bbf6da11004d127cb5d67f64ab07c94fcdf5274f",
+		"f75a5fe56bda34f3c1396296626ef012dc07e4825838778a645c8248cff01658",
+		"2db4540d50230756158abf61d9835712b6486c74312183ccefcaef2797b7674d",
+		"cd94fc9497e8990750309e9a8534fd114b0a6e54da89c4796101897041d14ecb",
+		"15b9e467af4d290c417402e040426fe4cf236bae72baa392ed89780dfccdb471",
+		"49c503ba6c4fa605182e186b5e81113f075bc11dcfd51c932fb21e951eee2fa1",
+		"19b38de39fdd2f70f7091631a4f75d1993740ba9429162c2a45312401636b29c",
+		"2c91c61f33adfe9311c942fdbff6ba47020feff416b7bb63cec13faf9b099954",
+		"a28a2edf58025668f724aaf83a50956b7ac1cfbbff79b08c3bf87dfd2828d767",
+		"a2ef857a081f9d6eb206a81c4cf78a802bdf598ae380c8886ecd85fdc1ed7644",
+		"ccd8a2d86bc92f2e01bce4d6922cf7fe1626aed044685e95e2eebd464505f01f",
+		"c188ffc8947f7301fb7b53e36746097c2134bf9cc981ba74b4e9c4361f595e4e",
+		"317e1020ff53fccef18bf47bb7f2dd7707fb7b7a7578e04f35b3beed222a0eb6",
+		"45fb02b2ceb9d7c79d9c2fa93e9c7967c2fa4df5789f9640b24264b1e524fcb1",
+		"a19ef7bff98ada781842fbfc51a47aff39b5935a1c7d9625c8d323d511c92de6",
+		"356c5a444c049a52fee0adeb7e5d82ae5aa83030bfff31bbf8ce2096cf161c4b",
+	};
+
+	char *y[] = {
+		"db71e509e3fd9b060ddb20ba5c51dcc5948d46fbf640dfe0441782cab85fa4ac",
+		"b29d84e811197f25eba8f5194092cb6ff440e26d4421011372461f579271cda3",
+		"ef48a3ab26e20220bcda2c1851076839dae88eae962869a497bf73cb66faf536",
+		"422294ff46003429d739a33206c8752552c8ba54a270defc06e221e0feaf6ac4",
+		"1af98cc45e98a7e041b01cf35f462b7562281351c8ebf3ffa02e33a0722a1328",
+		"f2cf6b601e0a05945e335550bf648d782f46186c772c0f20d3cd0d6b8ca14b2f",
+		"40f9bead39c2f2bcc2602f75b8a73ec7bdffcbcead159d0174c6c4d3c5357f05",
+		"f6de0afa20e93e078467c053d241903edad734c6b403ba758c2b5ff04c9d4229",
+		"d8049a43579cfa90b8093a94416cbefbf93386f15b3f6e190b6e3455fedfe69a",
+		"d9c50dbe70d714edb5e221f4e020610eeb6270517e688ca64fb0e98c7ef8c1c5",
+		"33bbdf1b1772d8059df568b061f3f1122f28a8d819167c97be448e3dc3fb0c3c",
+		"62f57f314e3f3495dc4e099012f5e0ba71770f9660a1eada54104cdfde77243e",
+		"c3def4b5fe04faee0a11932229fff563637bfdee0e79c6deeaf449f85401c5c4",
+		"cdf4e9170fb904302b8fd93a820ba8cc7ed4efd3a6f2d6b05b80b2ff2aee4e77",
+		"8af706ff0922d87b3f0c5e4e31d8b259aeb260a9269643ed520a13bb25da5924",
+		"09aed7232b28e060941741b6828bcdfa2bc49cc844f3773611504f82a390a5ae",
+		"6cab31b06419e5221fca014fb84ec870622a1b12bab5ae43682aa7ea73ea08d0",
+		"dfa7bfffd4c766b86abeaf5c99b6e50cb9ccc9d9d00b7ffc7804b0491b67bc03",
+		"563c4c20419f07bc17d0539fade1855e34839515b892c0f5d26561f97fa04d1a",
+		"e9ddd583a9635a667777d5b8a8f31b0f79eba12c75023410b54b8567dddc0f38",
+		"bf7d2f2056e72421ef393f0c0f2b0e00130e3cac4abbcc00286168e85ec55051",
+		"09420ce5a19d77c6fe1ee587e6a49fbaf8f280e8df033d75403302e5a27db2ae",
+		"5c6e8ecf1f7d3023893b7b1ca1e4d178972ee2a230757ddc564ffe37f5c5a321",
+		"e9c184df75c955e02e02e400ffe45f78f339e1afe6d056fb3245f4700ce606ef",
+		"57d128de8b2a57a094d1a001e572173f96e8866ae352bf29cddaf92fc85b2f92",
+	};
+
+	char *Z[] = {
+		"46fc62106420ff012e54a434fbdd2d25ccc5852060561e68040dd7778997bd7b",
+		"057d636096cb80b67a8c038c890e887d1adfa4195e9b3ce241c8a778c59cda67",
+		"2d457b78b4614132477618a5b077965ec90730a8c81a1c75d6d4ec68005d67ec",
+		"96441259534b80f6aee3d287a6bb17b5094dd4277d9e294f8fe73e48bf2a0024",
+		"19d44c8d63e8e8dd12c22a87b8cd4ece27acdde04dbf47f7f27537a6999a8e62",
+		"664e45d5bba4ac931cd65d52017e4be9b19a515f669bea4703542a2c525cd3d3",
+		"ca342daa50dc09d61be7c196c85e60a80c5cb04931746820be548cdde055679d",
+		"35aa9b52536a461bfde4e85fc756be928c7de97923f0416c7a3ac8f88b3d4489",
+		"605c16178a9bc875dcbff54d63fe00df699c03e8a888e9e94dfbab90b25f39b4",
+		"f96e40a1b72840854bb62bc13c40cc2795e373d4e715980b261476835a092e0b",
+		"8388fa79c4babdca02a8e8a34f9e43554976e420a4ad273c81b26e4228e9d3a3",
+		"72877cea33ccc4715038d4bcbdfe0e43f42a9e2c0c3b017fc2370f4b9acbda4a",
+		"e4e7408d85ff0e0e9c838003f28cdbd5247cdce31f32f62494b70e5f1bc36307",
+		"ed56bcf695b734142c24ecb1fc1bb64d08f175eb243a31f37b3d9bb4407f3b96",
+		"bc5c7055089fc9d6c89f83c1ea1ada879d9934b2ea28fcf4e4a7e984b28ad2cf",
+		"9a4e8e657f6b0e097f47954a63c75d74fcba71a30d83651e3e5a91aa7ccd8343",
+		"3ca1fc7ad858fb1a6aba232542f3e2a749ffc7203a2374a3f3d3267f1fc97b78",
+		"1aaabe7ee6e4a6fa732291202433a237df1b49bc53866bfbe00db96a0f58224f",
+		"430e6a4fba4449d700d2733e557f66a3bf3d50517c1271b1ddae1161b7ac798c",
+		"1ce9e6740529499f98d1f1d71329147a33df1d05e4765b539b11cf615d6974d3",
+		"4690e3743c07d643f1bc183636ab2a9cb936a60a802113c49bb1b3f2d0661660",
+		"30c2261bd0004e61feda2c16aa5e21ffa8d7e7f7dbf6ec379a43b48e4b36aeb0",
+		"2adae4a138a239dcd93c243a3803c3e4cf96e37fe14e6a9b717be9599959b11c",
+		"2e277ec30f5ea07d6ce513149b9479b96e07f4b6913b1b5c11305c1444a1bc0b",
+		"1e51373bd2c6044c129c436e742a55be2a668a85ae08441b6756445df5493857",
+	};
+
+	TC_PRINT("Test #1: ECDH");
+	TC_PRINT("NIST-p256\n");
+
+	result = ecdh_vectors(x, y, d, Z, 25, verbose);
+	if (result == TC_FAIL) {
+		goto exitTest1;
+	}
+
+exitTest1:
+	TC_END_RESULT(result);
+	return result;
 }
 
-char *gen_d[] = {
-	"c9806898a0334916c860748880a541f093b579a9b1f32934d86c363c39800357",
-	"710735c8388f48c684a97bd66751cc5f5a122d6b9a96a2dbe73662f78217446d",
-	"78d5d8b7b3e2c16b3e37e7e63becd8ceff61e2ce618757f514620ada8a11f6e4",
-	"2a61a0703860585fe17420c244e1de5a6ac8c25146b208ef88ad51ae34c8cb8c",
-	"01b965b45ff386f28c121c077f1d7b2710acc6b0cb58d8662d549391dcf5a883",
-	"fac92c13d374c53a085376fe4101618e1e181b5a63816a84a0648f3bdc24e519",
-	"f257a192dde44227b3568008ff73bcf599a5c45b32ab523b5b21ca582fef5a0a",
-	"add67e57c42a3d28708f0235eb86885a4ea68e0d8cfd76eb46134c596522abfd",
-	"4494860fd2c805c5c0d277e58f802cff6d731f76314eb1554142a637a9bc5538",
-	"d40b07b1ea7b86d4709ef9dc634c61229feb71abd63dc7fc85ef46711a87b210",
-};
-
-char *gen_x[] = {
-	"d0720dc691aa80096ba32fed1cb97c2b620690d06de0317b8618d5ce65eb728f",
-	"f6836a8add91cb182d8d258dda6680690eb724a66dc3bb60d2322565c39e4ab9",
-	"76711126cbb2af4f6a5fe5665dad4c88d27b6cb018879e03e54f779f203a854e",
-	"e1aa7196ceeac088aaddeeba037abb18f67e1b55c0a5c4e71ec70ad666fcddc8",
-	"1f038c5422e88eec9e88b815e8f6b3e50852333fc423134348fc7d79ef8e8a10",
-	"7258f2ab96fc84ef6ccb33e308cd392d8b568ea635730ceb4ebd72fa870583b9",
-	"d2e01411817b5512b79bbbe14d606040a4c90deb09e827d25b9f2fc068997872",
-	"55bed2d9c029b7f230bde934c7124ed52b1330856f13cbac65a746f9175f85d7",
-	"5190277a0c14d8a3d289292f8a544ce6ea9183200e51aec08440e0c1a463a4e4",
-	"fbcea7c2827e0e8085d7707b23a3728823ea6f4878b24747fb4fd2842d406c73",
-};
-
-char *gen_y[] = {
-	"9681b517b1cda17d0d83d335d9c4a8a9a9b0b1b3c7106d8f3c72bc5093dc275f",
-	"1f837aa32864870cb8e8d0ac2ff31f824e7beddc4bb7ad72c173ad974b289dc2",
-	"a26df39960ab5248fd3620fd018398e788bd89a3cea509b352452b69811e6856",
-	"d7d35bdce6dedc5de98a7ecb27a9cd066a08f586a733b59f5a2cdb54f971d5c8",
-	"43a047cb20e94b4ffb361ef68952b004c0700b2962e0c0635a70269bc789b849",
-	"489807ca55bdc29ca5c8fe69b94f227b0345cccdbe89975e75d385cc2f6bb1e2",
-	"503f138f8bab1df2c4507ff663a1fdf7f710e7adb8e7841eaa902703e314e793",
-	"32805e311d583b4e007c40668185e85323948e21912b6b0d2cda8557389ae7b0",
-	"ecd98514821bd5aaf3419ab79b71780569470e4fed3da3c1353b28fe137f36eb",
-	"2393c85f1f710c5afc115a39ba7e18abe03f19c9d4bb3d47d19468b818efa535",
-};
-
-int cavp_keygen(int verbose)
+int cavp_keygen(bool verbose)
 {
-/*
- * [P-256, B.4.2 Key Pair Generation by Testing Candidates]
- */
-	EccPoint point;
-	int rc;
+	unsigned int result = TC_PASS;
+	/*
+	 * [P-256, B.4.2 Key Pair Generation by Testing Candidates]
+	 */
+	char *d[] = {
+		"c9806898a0334916c860748880a541f093b579a9b1f32934d86c363c39800357",
+		"710735c8388f48c684a97bd66751cc5f5a122d6b9a96a2dbe73662f78217446d",
+		"78d5d8b7b3e2c16b3e37e7e63becd8ceff61e2ce618757f514620ada8a11f6e4",
+		"2a61a0703860585fe17420c244e1de5a6ac8c25146b208ef88ad51ae34c8cb8c",
+		"01b965b45ff386f28c121c077f1d7b2710acc6b0cb58d8662d549391dcf5a883",
+		"fac92c13d374c53a085376fe4101618e1e181b5a63816a84a0648f3bdc24e519",
+		"f257a192dde44227b3568008ff73bcf599a5c45b32ab523b5b21ca582fef5a0a",
+		"add67e57c42a3d28708f0235eb86885a4ea68e0d8cfd76eb46134c596522abfd",
+		"4494860fd2c805c5c0d277e58f802cff6d731f76314eb1554142a637a9bc5538",
+		"d40b07b1ea7b86d4709ef9dc634c61229feb71abd63dc7fc85ef46711a87b210",
+	};
 
-	rc = keygen_vectors(&point, gen_d, gen_x, gen_y, 10, verbose);
-	return rc;
+	char *x[] = {
+		"d0720dc691aa80096ba32fed1cb97c2b620690d06de0317b8618d5ce65eb728f",
+		"f6836a8add91cb182d8d258dda6680690eb724a66dc3bb60d2322565c39e4ab9",
+		"76711126cbb2af4f6a5fe5665dad4c88d27b6cb018879e03e54f779f203a854e",
+		"e1aa7196ceeac088aaddeeba037abb18f67e1b55c0a5c4e71ec70ad666fcddc8",
+		"1f038c5422e88eec9e88b815e8f6b3e50852333fc423134348fc7d79ef8e8a10",
+		"7258f2ab96fc84ef6ccb33e308cd392d8b568ea635730ceb4ebd72fa870583b9",
+		"d2e01411817b5512b79bbbe14d606040a4c90deb09e827d25b9f2fc068997872",
+		"55bed2d9c029b7f230bde934c7124ed52b1330856f13cbac65a746f9175f85d7",
+		"5190277a0c14d8a3d289292f8a544ce6ea9183200e51aec08440e0c1a463a4e4",
+		"fbcea7c2827e0e8085d7707b23a3728823ea6f4878b24747fb4fd2842d406c73",
+	};
+
+	char *y[] = {
+		"9681b517b1cda17d0d83d335d9c4a8a9a9b0b1b3c7106d8f3c72bc5093dc275f",
+		"1f837aa32864870cb8e8d0ac2ff31f824e7beddc4bb7ad72c173ad974b289dc2",
+		"a26df39960ab5248fd3620fd018398e788bd89a3cea509b352452b69811e6856",
+		"d7d35bdce6dedc5de98a7ecb27a9cd066a08f586a733b59f5a2cdb54f971d5c8",
+		"43a047cb20e94b4ffb361ef68952b004c0700b2962e0c0635a70269bc789b849",
+		"489807ca55bdc29ca5c8fe69b94f227b0345cccdbe89975e75d385cc2f6bb1e2",
+		"503f138f8bab1df2c4507ff663a1fdf7f710e7adb8e7841eaa902703e314e793",
+		"32805e311d583b4e007c40668185e85323948e21912b6b0d2cda8557389ae7b0",
+		"ecd98514821bd5aaf3419ab79b71780569470e4fed3da3c1353b28fe137f36eb",
+		"2393c85f1f710c5afc115a39ba7e18abe03f19c9d4bb3d47d19468b818efa535",
+	};
+
+	TC_PRINT("Test #2: ECC KeyGen ");
+	TC_PRINT("NIST-p256\n");
+
+	result = keygen_vectors(d, x, y, 10, verbose);
+	if (result == TC_FAIL) {
+		goto exitTest1;
+	}
+
+exitTest1:
+	TC_END_RESULT(result);
+	return result;
 }
 
 /* Test ecc_make_keys, and also as keygen part of other tests */
-int pkv_vectors(char **qx_vec, char **qy_vec, char **res_vec, int *results,
-		int tests, int verbose)
+int pkv_vectors(char **qx_vec, char **qy_vec, int res_vec[], int tests,
+		bool verbose)
 {
-	EccPoint pub;
+
+	unsigned int pub[2 * NUM_ECC_WORDS];
+	uint8_t _public[2 * NUM_ECC_BYTES];
+	int rc;
 	int exp_rc;
-	int rc = TC_FAIL;
+	unsigned int result = TC_PASS;
+	const struct uECC_Curve_t *curve = uECC_secp256r1();
 
 	for (int i = 0; i < tests; i++) {
-
-		exp_rc = results[i];
+		exp_rc = res_vec[i];
 
 		if (strlen(qx_vec[i]) > 2 * NUM_ECC_BYTES ||
-				strlen(qy_vec[i]) > 2 * NUM_ECC_BYTES) {
-			/* invalid input to ECC digit conversion
-			 * (string2native())
-			 */
+		    strlen(qy_vec[i]) > 2 * NUM_ECC_BYTES) {
+			/* invalid input to ECC digit conversion (string2native()) */
 			rc = -2;
 		} else {
-			str_to_scalar(pub.x, NUM_ECC_DIGITS, qx_vec[i]);
-			str_to_scalar(pub.y, NUM_ECC_DIGITS, qy_vec[i]);
-			rc = ecc_valid_public_key(&pub);
+			string2scalar(pub, NUM_ECC_WORDS, qx_vec[i]);
+			string2scalar(pub + NUM_ECC_WORDS, NUM_ECC_WORDS, qy_vec[i]);
+
+			uECC_vli_nativeToBytes(_public, NUM_ECC_BYTES, pub);
+			uECC_vli_nativeToBytes(_public + NUM_ECC_BYTES,
+					       NUM_ECC_BYTES, pub + NUM_ECC_WORDS);
+
+			rc = uECC_valid_public_key(_public, curve);
 		}
 
 		/*
@@ -280,6 +337,7 @@ int pkv_vectors(char **qx_vec, char **qy_vec, char **res_vec, int *results,
 		 * -1 => ? - (x,y) = (0,0) (not covered)
 		 * -2 => 1 - out of bounds (pubverify or ecc import)
 		 * -3 => 2 - not on curve
+		 * -4 => ? - public key is the group generator
 		 */
 
 		if (rc == -3) {
@@ -289,170 +347,183 @@ int pkv_vectors(char **qx_vec, char **qy_vec, char **res_vec, int *results,
 			rc = 1;
 		}
 
-		rc = check_code(i, res_vec[i], exp_rc, rc, verbose);
-		if (rc != TC_PASS) {
-			goto exit_test;
+		result = check_code(i, exp_rc, rc, verbose);
+		if (result == TC_FAIL) {
+			goto exitTest1;
 		}
 	}
 
-	rc = TC_PASS;
-
-exit_test:
-	return rc;
+exitTest1:
+	TC_END_RESULT(result);
+	return result;
 }
 
-char *verify_x[] = {
-	"e0f7449c5588f24492c338f2bc8f7865f755b958d48edb0f2d0056e50c3fd5b7",
-	"d17c446237d9df87266ba3a91ff27f45abfdcb77bfd83536e92903efb861a9a9",
-	"17875397ae87369365656d490e8ce956911bd97607f2aff41b56f6f3a61989826",
-	"f2d1c0dc0852c3d8a2a2500a23a44813ccce1ac4e58444175b440469ffc12273",
-	"10b0ca230fff7c04768f4b3d5c75fa9f6c539bea644dffbec5dc796a213061b58",
-	"2c1052f25360a15062d204a056274e93cbe8fc4c4e9b9561134ad5c15ce525da",
-	"a40d077a87dae157d93dcccf3fe3aca9c6479a75aa2669509d2ef05c7de6782f",
-	"2633d398a3807b1895548adbb0ea2495ef4b930f91054891030817df87d4ac0a",
-	"14bf57f76c260b51ec6bbc72dbd49f02a56eaed070b774dc4bad75a54653c3d56",
-	"2fa74931ae816b426f484180e517f5050c92decfc8daf756cd91f54d51b302f1",
-	"f8c6dd3181a76aa0e36c2790bba47041acbe7b1e473ff71eee39a824dc595ff0",
-	"7a81a7e0b015252928d8b36e4ca37e92fdc328eb25c774b4f872693028c4be38",
-};
-
-char *verify_y[] = {
-	"86d7e9255d0f4b6f44fa2cd6f8ba3c0aa828321d6d8cc430ca6284ce1d5b43a0",
-	"1eabb6a349ce2cd447d777b6739c5fc066add2002d2029052c408d0701066231c",
-	"980a3c4f61b9692633fbba5ef04c9cb546dd05cdec9fa8428b8849670e2fba92",
-	"32bfe992831b305d8c37b9672df5d29fcb5c29b4a40534683e3ace23d24647dd",
-	"f5edf37c11052b75f771b7f9fa050e353e464221fec916684ed45b6fead38205",
-	"ced9783713a8a2a09eff366987639c625753295d9a85d0f5325e32dedbcada0b",
-	"503d86b87d743ba20804fd7e7884aa017414a7b5b5963e0d46e3a9611419ddf3",
-	"d6b2f738e3873cc8364a2d364038ce7d0798bb092e3dd77cbdae7c263ba618d2",
-	"7a231a23bf8b3aa31d9600d888a0678677a30e573decd3dc56b33f365cc11236",
-	"5b994346137988c58c14ae2152ac2f6ad96d97decb33099bd8a0210114cd1141",
-	"9c965f227f281b3072b95b8daf29e88b35284f3574462e268e529bbdc50e9e52",
-	"08862f7335147261e7b1c3d055f9a316e4cab7daf99cc09d1c647f5dd6e7d5bb",
-};
-
-char *names[] = {
-	"P (0 )",                          "F (1 - Q_x or Q_y out of range)",
-	"F (1 - Q_x or Q_y out of range)", "F (2 - Point not on curve)",
-	"F (1 - Q_x or Q_y out of range)", "P (0 )",
-	"F (2 - Point not on curve)",      "P (0 )",
-	"F (1 - Q_x or Q_y out of range)", "P (0 )",
-	"F (2 - Point not on curve)",      "F (2 - Point not on curve)",
-};
-
-int results[] = {0, 1, 1, 2, 1, 0, 2, 0, 1, 0, 2, 2};
-
-int cavp_pkv(int verbose)
+int cavp_pkv(bool verbose)
 {
-/*
- * [P-256]
- */
-	int rc;
+	/*
+	 * [P-256]
+	 */
+	char *x[] = {
+		"e0f7449c5588f24492c338f2bc8f7865f755b958d48edb0f2d0056e50c3fd5b7",
+		"d17c446237d9df87266ba3a91ff27f45abfdcb77bfd83536e92903efb861a9a9",
+		"17875397ae87369365656d490e8ce956911bd97607f2aff41b56f6f3a61989826",
+		"f2d1c0dc0852c3d8a2a2500a23a44813ccce1ac4e58444175b440469ffc12273",
+		"10b0ca230fff7c04768f4b3d5c75fa9f6c539bea644dffbec5dc796a213061b58",
+		"2c1052f25360a15062d204a056274e93cbe8fc4c4e9b9561134ad5c15ce525da",
+		"a40d077a87dae157d93dcccf3fe3aca9c6479a75aa2669509d2ef05c7de6782f",
+		"2633d398a3807b1895548adbb0ea2495ef4b930f91054891030817df87d4ac0a",
+		"14bf57f76c260b51ec6bbc72dbd49f02a56eaed070b774dc4bad75a54653c3d56",
+		"2fa74931ae816b426f484180e517f5050c92decfc8daf756cd91f54d51b302f1",
+		"f8c6dd3181a76aa0e36c2790bba47041acbe7b1e473ff71eee39a824dc595ff0",
+		"7a81a7e0b015252928d8b36e4ca37e92fdc328eb25c774b4f872693028c4be38",
+	};
 
-	rc = pkv_vectors(verify_x, verify_y, names, results, 12, verbose);
-	return rc;
+	char *y[] = {
+		"86d7e9255d0f4b6f44fa2cd6f8ba3c0aa828321d6d8cc430ca6284ce1d5b43a0",
+		"1eabb6a349ce2cd447d777b6739c5fc066add2002d2029052c408d0701066231c",
+		"980a3c4f61b9692633fbba5ef04c9cb546dd05cdec9fa8428b8849670e2fba92",
+		"32bfe992831b305d8c37b9672df5d29fcb5c29b4a40534683e3ace23d24647dd",
+		"f5edf37c11052b75f771b7f9fa050e353e464221fec916684ed45b6fead38205",
+		"ced9783713a8a2a09eff366987639c625753295d9a85d0f5325e32dedbcada0b",
+		"503d86b87d743ba20804fd7e7884aa017414a7b5b5963e0d46e3a9611419ddf3",
+		"d6b2f738e3873cc8364a2d364038ce7d0798bb092e3dd77cbdae7c263ba618d2",
+		"7a231a23bf8b3aa31d9600d888a0678677a30e573decd3dc56b33f365cc11236",
+		"5b994346137988c58c14ae2152ac2f6ad96d97decb33099bd8a0210114cd1141",
+		"9c965f227f281b3072b95b8daf29e88b35284f3574462e268e529bbdc50e9e52",
+		"08862f7335147261e7b1c3d055f9a316e4cab7daf99cc09d1c647f5dd6e7d5bb",
+	};
+
+	int results[] = { 0, 1, 1, 2, 1, 0, 2, 0, 1, 0, 2, 2 };
+
+	TC_PRINT("Test #3: PubKeyVerify ");
+	TC_PRINT("NIST-p256-SHA2-256\n");
+
+	return pkv_vectors(x, y, results, 12, verbose);
 }
 
-int montecarlo_ecdh(u32_t num, int verbose)
+int montecarlo_ecdh(int num_tests, bool verbose)
 {
-	EccPoint l_Q1, l_Q2; /* public keys */
-	u32_t l_random1[2 * NUM_ECC_DIGITS];
-	u32_t l_random2[2 * NUM_ECC_DIGITS];
-	u32_t l_secret1[NUM_ECC_DIGITS];
-	u32_t l_secret2[NUM_ECC_DIGITS];
+	int i;
+	uint8_t private1[NUM_ECC_BYTES] = { 0 };
+	uint8_t private2[NUM_ECC_BYTES] = { 0 };
+	uint8_t public1[2 * NUM_ECC_BYTES] = { 0 };
+	uint8_t public2[2 * NUM_ECC_BYTES] = { 0 };
+	uint8_t secret1[NUM_ECC_BYTES] = { 0 };
+	uint8_t secret2[NUM_ECC_BYTES] = { 0 };
+	unsigned int result = TC_PASS;
 
-	u32_t l_shared1[NUM_ECC_DIGITS];
-	u32_t l_shared2[NUM_ECC_DIGITS];
+	const struct uECC_Curve_t *curve = uECC_secp256r1();
 
-	int rc = TC_FAIL;
+	TC_PRINT("Test #4: Monte Carlo (%d Randomized EC-DH key-exchange) ", num_tests);
+	TC_PRINT("NIST-p256\n  ");
 
-	for (u32_t i = 0; i < num; ++i) {
-		random_bytes(l_random1, 2 * NUM_ECC_DIGITS);
-		random_bytes(l_random2, 2 * NUM_ECC_DIGITS);
-
-		ecc_make_key(&l_Q1, l_secret1, l_random1);
-		ecc_make_key(&l_Q2, l_secret2, l_random2);
-
-		if (!ecdh_shared_secret(l_shared1, &l_Q1, l_secret2)) {
-			TC_PRINT("shared_secret() failed (1)\n");
-			rc = TC_FAIL;
-			goto exit_test;
+	for (i = 0; i < num_tests; ++i) {
+		if (verbose) {
+			TC_PRINT(".");
 		}
 
-		if (!ecdh_shared_secret(l_shared2, &l_Q2, l_secret1)) {
-			TC_PRINT("shared_secret() failed (2)\n");
-			rc = TC_FAIL;
-			goto exit_test;
+		if (!uECC_make_key(public1, private1, curve) ||
+		    !uECC_make_key(public2, private2, curve)) {
+			TC_ERROR("uECC_make_key() failed\n");
+			result = TC_FAIL;
+			goto exitTest1;
 		}
 
-		if (memcmp(l_shared1, l_shared2, sizeof(l_shared1)) != 0) {
+		if (!uECC_shared_secret(public2, private1, secret1, curve)) {
+			TC_ERROR("shared_secret() failed (1)\n");
+			result = TC_FAIL;
+			goto exitTest1;;
+		}
+
+		if (!uECC_shared_secret(public1, private2, secret2, curve)) {
+			TC_ERROR("shared_secret() failed (2)\n");
+			result = TC_FAIL;
+			goto exitTest1;
+		}
+
+		if (memcmp(secret1, secret2, sizeof(secret1)) != 0) {
 			TC_PRINT("Shared secrets are not identical!\n");
-			TC_PRINT("Shared secret 1 = ");
-			vli_print(l_shared1, NUM_ECC_DIGITS);
-			TC_PRINT("\n");
-			TC_PRINT("Shared secret 2 = ");
-			vli_print(l_shared2, NUM_ECC_DIGITS);
-			TC_PRINT("\n");
 			TC_PRINT("Private key 1 = ");
-			vli_print(l_secret1, NUM_ECC_DIGITS);
+			vli_print_bytes(private1, 32);
+			TC_PRINT("\nPrivate key 2 = ");
+			vli_print_bytes(private2, 32);
+			TC_PRINT("\nPublic key 1 = ");
+			vli_print_bytes(public1, 64);
+			TC_PRINT("\nPublic key 2 = ");
+			vli_print_bytes(public2, 64);
+			TC_PRINT("\nShared secret 1 = ");
+			vli_print_bytes(secret1, 32);
+			TC_PRINT("\nShared secret 2 = ");
+			vli_print_bytes(secret2, 32);
 			TC_PRINT("\n");
-			TC_PRINT("Private key 2 = ");
-			vli_print(l_secret2, NUM_ECC_DIGITS);
-			TC_PRINT("\n");
-
-			rc = TC_FAIL;
-			goto exit_test;
 		}
 	}
 
-	rc = TC_PASS;
-exit_test:
-	return rc;
+	TC_PRINT("\n");
+
+exitTest1:
+	TC_END_RESULT(result);
+	return result;
 }
 
-#define RC_STR(rc)	(rc == TC_PASS ? PASS : FAIL)
+int default_CSPRNG(u8_t *dest, unsigned int size)
+{
+	/* This is not a CSPRNG, but it's the only thing available in the
+	 * system at this point in time.  */
+
+	while (size) {
+		u32_t len = size >= sizeof(u32_t) ? sizeof(u32_t) : size;
+		u32_t rv = sys_rand32_get();
+
+		memcpy(dest, &rv, len);
+		dest += len;
+		size -= len;
+	}
+
+	return 1;
+}
 
 int main(void)
 {
-	int verbose = 0;
-	int rc;
+	unsigned int result = TC_PASS;
 
-	TC_START("TinyCrypt ECC DH tests");
+	TC_START("Performing ECC-DH tests:");
 
-	random_start(NULL);
+	/* Setup of the Cryptographically Secure PRNG. */
+	uECC_set_rng(&default_CSPRNG);
 
-	rc = cavp_ecdh(verbose);
-	TC_PRINT("[%s] Test #1: ECDH - NIST-p256\n", RC_STR(rc));
-	if (rc != TC_PASS) {
-		goto exit_test;
+	bool verbose = true;
+
+	TC_PRINT("Performing cavp_ecdh test:\n");
+	result = cavp_ecdh(verbose);
+	if (result == TC_FAIL) { /* terminate test */
+		TC_ERROR("cavp_ecdh test failed.\n");
+		goto exitTest;
+	}
+	TC_PRINT("Performing cavp_keygen test:\n");
+	result = cavp_keygen(verbose);
+	if (result == TC_FAIL) { /* terminate test */
+		TC_ERROR("cavp_keygen test failed.\n");
+		goto exitTest;
+	}
+	TC_PRINT("Performing cavp_pkv test:\n");
+	result = cavp_pkv(verbose);
+	if (result == TC_FAIL) { /* terminate test */
+		TC_ERROR("cavp_pkv failed.\n");
+		goto exitTest;
+	}
+	TC_PRINT("Performing montecarlo_ecdh test:\n");
+	result = montecarlo_ecdh(10, verbose);
+	if (result == TC_FAIL) { /* terminate test */
+		TC_ERROR("montecarlo_ecdh test failed.\n");
+		goto exitTest;
 	}
 
-	rc = cavp_keygen(verbose);
-	TC_PRINT("[%s] Test #2: ECC KeyGen - NIST-p256\n", RC_STR(rc));
-	if (rc != TC_PASS) {
-		goto exit_test;
-	}
+	TC_PRINT("All EC-DH tests succeeded!\n");
 
-	rc = cavp_pkv(verbose);
-	TC_PRINT("[%s] Test #3: PubKeyVerify - NIST-p256-SHA2-256\n",
-		 RC_STR(rc));
-	if (rc != TC_PASS) {
-		goto exit_test;
-	}
+exitTest:
+	TC_END_RESULT(result);
+	TC_END_REPORT(result);
 
-	rc = montecarlo_ecdh(10, verbose);
-	TC_PRINT("[%s] Test #4: Monte Carlo (Randomized EC-DH key-exchange) - "
-		 "NIST-p256\n", RC_STR(rc));
-	if (rc != TC_PASS) {
-		goto exit_test;
-	}
-
-	TC_PRINT("\nAll ECC tests succeeded.\n");
-	rc = TC_PASS;
-
-exit_test:
-	TC_END_RESULT(rc);
-	TC_END_REPORT(rc);
-
-	return rc;
+	return 0;
 }

--- a/tests/crypto/ecc_dsa/src/test_ecc_dsa.c
+++ b/tests/crypto/ecc_dsa/src/test_ecc_dsa.c
@@ -1,7 +1,30 @@
 /* test_ecc_ecdsa.c - TinyCrypt implementation of some EC-DSA tests */
 
+/* Copyright (c) 2014, Kenneth MacKay
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *  * Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *  * Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.*/
+
 /*
- *  Copyright (C) 2015 by Intel Corporation, All Rights Reserved.
+ *  Copyright (C) 2017 by Intel Corporation, All Rights Reserved.
  *
  *  Redistribution and use in source and binary forms, with or without
  *  modification, are permitted provided that the following conditions are met:
@@ -33,612 +56,621 @@
  *
  */
 
-#include <tinycrypt/ecc_dsa.h>
+#define ENABLE_TESTS 1
+
 #include <tinycrypt/ecc.h>
+#include <tinycrypt/ecc_platform_specific.h>
+#include <tinycrypt/ecc_dsa.h>
 #include <tinycrypt/ecc_dh.h>
+#include <tinycrypt/constants.h>
+#include <tinycrypt/sha256.h>
 #include <test_utils.h>
 #include <test_ecc_utils.h>
-#include <tinycrypt/sha256.h>
-#include <tinycrypt/constants.h>
 
+#include <stdio.h>
+#include <stdlib.h>
 #include <string.h>
 
+/* Maximum size of message to be signed. */
 #define BUF_SIZE 256
 
 int sign_vectors(TCSha256State_t hash, char **d_vec, char **k_vec,
 		 char **msg_vec, char **qx_vec, char **qy_vec, char **r_vec,
-		 char **s_vec, int tests, int verbose)
+		 char **s_vec, int tests, bool verbose)
 {
-	EccPoint point;
 
-	u32_t seed[2 * NUM_ECC_DIGITS];
-	u32_t prv[NUM_ECC_DIGITS];
-	u32_t r[NUM_ECC_DIGITS];
-	u32_t s[NUM_ECC_DIGITS];
-	u8_t  digest[TC_SHA256_DIGEST_SIZE];
-	u32_t dig32[NUM_ECC_DIGITS];
+	unsigned int k[NUM_ECC_WORDS];
+	unsigned int private[NUM_ECC_WORDS];
+	uint8_t private_bytes[NUM_ECC_BYTES];
+	unsigned int sig[2 * NUM_ECC_WORDS];
+	uint8_t sig_bytes[2 * NUM_ECC_BYTES];
+	unsigned int digest[TC_SHA256_DIGEST_SIZE / 4];
+	uint8_t digest_bytes[TC_SHA256_DIGEST_SIZE];
+	unsigned int result = TC_PASS;
 
 	/* expected outputs (converted input vectors) */
-	u32_t exp_r[NUM_ECC_DIGITS];
-	u32_t exp_s[NUM_ECC_DIGITS];
+	unsigned int exp_r[NUM_ECC_WORDS];
+	unsigned int exp_s[NUM_ECC_WORDS];
 
-	u8_t msg[BUF_SIZE];
+	uint8_t msg[BUF_SIZE];
 	size_t msglen;
 
-	int rc = TC_FAIL;
-
 	for (int i = 0; i < tests; i++) {
-		int hash_dwords;
 
-		/* use keygen test to generate+validate pubkey */
-		rc = keygen_vectors(&point, d_vec+i, qx_vec+i, qy_vec+i, 1,
-				    0);
-		if (rc != TC_PASS) {
-			goto exit_test;
-		}
-		str_to_scalar(prv, NUM_ECC_DIGITS, d_vec[i]);
+		/* use keygen test to generate and validate pubkey */
+		keygen_vectors(d_vec + i, qx_vec + i, qy_vec + i, 1, false);
+		string2scalar(private, NUM_ECC_WORDS, d_vec[i]);
+		uECC_vli_nativeToBytes(private_bytes, NUM_ECC_BYTES, private);
 
 		/* validate ECDSA: hash message, sign digest, check r+s */
-		memset(seed, 0, 2 * NUM_ECC_BYTES);
-		str_to_scalar(seed, NUM_ECC_DIGITS, k_vec[i]);
-		str_to_scalar(exp_r, NUM_ECC_DIGITS, r_vec[i]);
-		str_to_scalar(exp_s, NUM_ECC_DIGITS, s_vec[i]);
+		memset(k, 0, NUM_ECC_BYTES);
+		string2scalar(k, NUM_ECC_WORDS, k_vec[i]);
+		string2scalar(exp_r, NUM_ECC_WORDS, r_vec[i]);
+		string2scalar(exp_s, NUM_ECC_WORDS, s_vec[i]);
 
-		msglen = hex_to_num_str(msg, BUF_SIZE, msg_vec[i],
-					strlen(msg_vec[i]));
+		msglen = hex2bin(msg, BUF_SIZE, msg_vec[i], strlen(msg_vec[i]));
 
-		if (msglen == 0) {
-			TC_PRINT("failed to import message!\n");
-			rc = TC_FAIL;
-			goto exit_test;
+		if (msglen == false) {
+			TC_ERROR("failed to import message!\n");
+			result = TC_FAIL;
+			goto exitTest1;
 		}
 
 		tc_sha256_init(hash);
 		tc_sha256_update(hash, msg, msglen);
-		tc_sha256_final(digest, hash);
+		tc_sha256_final(digest_bytes, hash);
 
 		/* if digest larger than ECC scalar, drop the end
-		 * if digest smaller than ECC scalar, zero-pad front
-		 */
-		/* Note: here it is assumed that:
-		 * NUM_ECC_DIGITS * 4 == TC_SHA256_DIGEST_SIZE
-		 */
-		hash_dwords = TC_SHA256_DIGEST_SIZE / 4;
-
-		memset(dig32, 0, NUM_ECC_BYTES - 4 * hash_dwords);
-		ecc_bytes2native(dig32+(NUM_ECC_DIGITS - hash_dwords), digest);
-
-		if (ecdsa_sign(r, s, prv, seed, dig32) != TC_CRYPTO_SUCCESS) {
-			TC_PRINT("ECDSA_sign failed!\n");
-			rc = TC_FAIL;
-			goto exit_test;
+		 * if digest smaller than ECC scalar, zero-pad front */
+		int hash_dwords = TC_SHA256_DIGEST_SIZE / 4;
+		if (NUM_ECC_WORDS < hash_dwords) {
+			hash_dwords = NUM_ECC_WORDS;
 		}
 
-		rc = check_ecc_result(i, "sig.r", exp_r, r, NUM_ECC_DIGITS,
-				      verbose);
-		if (rc != TC_PASS) {
-			goto exit_test;
-		}
-		rc = check_ecc_result(i, "sig.s", exp_s, s, NUM_ECC_DIGITS,
-				      verbose);
-		if (rc != TC_PASS) {
-			goto exit_test;
+		memset(digest, 0, NUM_ECC_BYTES - 4 * hash_dwords);
+		uECC_vli_bytesToNative(digest + (NUM_ECC_WORDS - hash_dwords),
+				       digest_bytes, TC_SHA256_DIGEST_SIZE);
+
+		if (uECC_sign_with_k(private_bytes, digest_bytes,
+				     sizeof(digest_bytes), k, sig_bytes, uECC_secp256r1()) == 0) {
+			TC_ERROR("ECDSA_sign failed!\n");
+			result = TC_FAIL;
+			goto exitTest1;
 		}
 
+		uECC_vli_bytesToNative(sig, sig_bytes, NUM_ECC_BYTES);
+		uECC_vli_bytesToNative(sig + NUM_ECC_WORDS, sig_bytes + NUM_ECC_BYTES, NUM_ECC_BYTES);
+
+		result = check_ecc_result(i, "sig.r", exp_r, sig,  NUM_ECC_WORDS, verbose);
+		if (result == TC_FAIL) {
+			goto exitTest1;
+		}
+		result = check_ecc_result(i, "sig.s", exp_s, sig + NUM_ECC_WORDS,  NUM_ECC_WORDS, verbose);
+		if (result == TC_FAIL) {
+			goto exitTest1;
+		}
 	}
 
-	rc = TC_PASS;
-
-exit_test:
-	return rc;
+exitTest1:
+	TC_END_RESULT(result);
+	return result;
 }
 
-char *sign_d[] = {
-	"519b423d715f8b581f4fa8ee59f4771a5b44c8130b4e3eacca54a56dda72b464",
-	"0f56db78ca460b055c500064824bed999a25aaf48ebb519ac201537b85479813",
-	"e283871239837e13b95f789e6e1af63bf61c918c992e62bca040d64cad1fc2ef",
-	"a3d2d3b7596f6592ce98b4bfe10d41837f10027a90d7bb75349490018cf72d07",
-	"53a0e8a8fe93db01e7ae94e1a9882a102ebd079b3a535827d583626c272d280d",
-	"4af107e8e2194c830ffb712a65511bc9186a133007855b49ab4b3833aefc4a1d",
-	"78dfaa09f1076850b3e206e477494cddcfb822aaa0128475053592c48ebaf4ab",
-	"80e692e3eb9fcd8c7d44e7de9f7a5952686407f90025a1d87e52c7096a62618a",
-	"5e666c0db0214c3b627a8e48541cc84a8b6fd15f300da4dff5d18aec6c55b881",
-	"f73f455271c877c4d5334627e37c278f68d143014b0a05aa62f308b2101c5308",
-	"b20d705d9bd7c2b8dc60393a5357f632990e599a0975573ac67fd89b49187906",
-	"d4234bebfbc821050341a37e1240efe5e33763cbbb2ef76a1c79e24724e5a5e7",
-	"b58f5211dff440626bb56d0ad483193d606cf21f36d9830543327292f4d25d8c",
-	"54c066711cdb061eda07e5275f7e95a9962c6764b84f6f1f3ab5a588e0a2afb1",
-	"34fa4682bf6cb5b16783adcd18f0e6879b92185f76d7c920409f904f522db4b1",
-};
-
-char *sign_k[] = {
-	"94a1bbb14b906a61a280f245f9e93c7f3b4a6247824f5d33b9670787642a68de",
-	"6d3e71882c3b83b156bb14e0ab184aa9fb728068d3ae9fac421187ae0b2f34c6",
-	"ad5e887eb2b380b8d8280ad6e5ff8a60f4d26243e0124c2f31a297b5d0835de2",
-	"24fc90e1da13f17ef9fe84cc96b9471ed1aaac17e3a4bae33a115df4e5834f18",
-	"5d833e8d24cc7a402d7ee7ec852a3587cddeb48358cea71b0bedb8fabe84e0c4",
-	"e18f96f84dfa2fd3cdfaec9159d4c338cd54ad314134f0b31e20591fc238d0ab",
-	"295544dbb2da3da170741c9b2c6551d40af7ed4e891445f11a02b66a5c258a77",
-	"7c80fd66d62cc076cef2d030c17c0a69c99611549cb32c4ff662475adbe84b22",
-	"2e7625a48874d86c9e467f890aaa7cd6ebdf71c0102bfdcfa24565d6af3fdce9",
-	"62f8665fd6e26b3fa069e85281777a9b1f0dfd2c0b9f54a086d0c109ff9fd615",
-	"72b656f6b35b9ccbc712c9f1f3b1a14cbbebaec41c4bca8da18f492a062d6f6f",
-	"d926fe10f1bfd9855610f4f5a3d666b1a149344057e35537373372ead8b1a778",
-	"e158bf4a2d19a99149d9cdb879294ccb7aaeae03d75ddd616ef8ae51a6dc1071",
-	"646fe933e96c3b8f9f507498e907fdd201f08478d0202c752a7c2cfebf4d061a",
-	"a6f463ee72c9492bc792fe98163112837aebd07bab7a84aaed05be64db3086f4",
-};
-
-char *sign_msg[] = {
-"5905238877c77421f73e43ee3da6f2d9e2ccad5fc942dcec0cbd25482935faaf416983fe16"
-"5b1a045ee2bcd2e6dca3bdf46c4310a7461f9a37960ca672d3feb5473e253605fb1ddfd280"
-"65b53cb5858a8ad28175bf9bd386a5e471ea7a65c17cc934a9d791e91491eb3754d0379979"
-"0fe2d308d16146d5c9b0d0debd97d79ce8",
-"c35e2f092553c55772926bdbe87c9796827d17024dbb9233a545366e2e5987dd344deb72df"
-"987144b8c6c43bc41b654b94cc856e16b96d7a821c8ec039b503e3d86728c494a967d83011"
-"a0e090b5d54cd47f4e366c0912bc808fbb2ea96efac88fb3ebec9342738e225f7c7c2b011c"
-"e375b56621a20642b4d36e060db4524af1",
-"3c054e333a94259c36af09ab5b4ff9beb3492f8d5b4282d16801daccb29f70fe61a0b37ffe"
-"f5c04cd1b70e85b1f549a1c4dc672985e50f43ea037efa9964f096b5f62f7ffdf8d6bfb2cc"
-"859558f5a393cb949dbd48f269343b5263dcdb9c556eca074f2e98e6d94c2c29a677afaf80"
-"6edf79b15a3fcd46e7067b7669f83188ee",
-"0989122410d522af64ceb07da2c865219046b4c3d9d99b01278c07ff63eaf1039cb787ae9e"
-"2dd46436cc0415f280c562bebb83a23e639e476a02ec8cff7ea06cd12c86dcc3adefbf1a9e"
-"9a9b6646c7599ec631b0da9a60debeb9b3e19324977f3b4f36892c8a38671c8e1cc8e50fcd"
-"50f9e51deaf98272f9266fc702e4e57c30",
-"dc66e39f9bbfd9865318531ffe9207f934fa615a5b285708a5e9c46b7775150e818d7f24d2"
-"a123df3672fff2094e3fd3df6fbe259e3989dd5edfcccbe7d45e26a775a5c4329a084f057c"
-"42c13f3248e3fd6f0c76678f890f513c32292dd306eaa84a59abe34b16cb5e38d0e885525d"
-"10336ca443e1682aa04a7af832b0eee4e7",
-"600974e7d8c5508e2c1aab0783ad0d7c4494ab2b4da265c2fe496421c4df238b0be25f2565"
-"9157c8a225fb03953607f7df996acfd402f147e37aee2f1693e3bf1c35eab3ae360a2bd91d"
-"04622ea47f83d863d2dfecb618e8b8bdc39e17d15d672eee03bb4ce2cc5cf6b217e5faf3f3"
-"36fdd87d972d3a8b8a593ba85955cc9d71",
-"dfa6cb9b39adda6c74cc8b2a8b53a12c499ab9dee01b4123642b4f11af336a91a5c9ce0520"
-"eb2395a6190ecbf6169c4cba81941de8e76c9c908eb843b98ce95e0da29c5d4388040264e0"
-"5e07030a577cc5d176387154eabae2af52a83e85c61c7c61da930c9b19e45d7e34c8516dc3"
-"c238fddd6e450a77455d534c48a152010b",
-"51d2547cbff92431174aa7fc7302139519d98071c755ff1c92e4694b58587ea560f72f32fc"
-"6dd4dee7d22bb7387381d0256e2862d0644cdf2c277c5d740fa089830eb52bf79d1e75b859"
-"6ecf0ea58a0b9df61e0c9754bfcd62efab6ea1bd216bf181c5593da79f10135a9bc6e164f1"
-"854bc8859734341aad237ba29a81a3fc8b",
-"558c2ac13026402bad4a0a83ebc9468e50f7ffab06d6f981e5db1d082098065bcff6f21a7a"
-"74558b1e8612914b8b5a0aa28ed5b574c36ac4ea5868432a62bb8ef0695d27c1e3ceaf75c7"
-"b251c65ddb268696f07c16d2767973d85beb443f211e6445e7fe5d46f0dce70d58a4cd9fe7"
-"0688c035688ea8c6baec65a5fc7e2c93e8",
-"4d55c99ef6bd54621662c3d110c3cb627c03d6311393b264ab97b90a4b15214a5593ba2510"
-"a53d63fb34be251facb697c973e11b665cb7920f1684b0031b4dd370cb927ca7168b0bf8ad"
-"285e05e9e31e34bc24024739fdc10b78586f29eff94412034e3b606ed850ec2c1900e8e681"
-"51fc4aee5adebb066eb6da4eaa5681378e",
-"f8248ad47d97c18c984f1f5c10950dc1404713c56b6ea397e01e6dd925e903b4fadfe2c9e8"
-"77169e71ce3c7fe5ce70ee4255d9cdc26f6943bf48687874de64f6cf30a012512e787b8805"
-"9bbf561162bdcc23a3742c835ac144cc14167b1bd6727e940540a9c99f3cbb41fb1dcb00d7"
-"6dda04995847c657f4c19d303eb09eb48a",
-"3b6ee2425940b3d240d35b97b6dcd61ed3423d8e71a0ada35d47b322d17b35ea0472f35edd"
-"1d252f87b8b65ef4b716669fc9ac28b00d34a9d66ad118c9d94e7f46d0b4f6c2b2d339fd6b"
-"cd351241a387cc82609057048c12c4ec3d85c661975c45b300cb96930d89370a327c98b67d"
-"efaa89497aa8ef994c77f1130f752f94a4",
-"c5204b81ec0a4df5b7e9fda3dc245f98082ae7f4efe81998dcaa286bd4507ca840a53d21b0"
-"1e904f55e38f78c3757d5a5a4a44b1d5d4e480be3afb5b394a5d2840af42b1b4083d40afbf"
-"e22d702f370d32dbfd392e128ea4724d66a3701da41ae2f03bb4d91bb946c7969404cb544f"
-"71eb7a49eb4c4ec55799bda1eb545143a7",
-"72e81fe221fb402148d8b7ab03549f1180bcc03d41ca59d7653801f0ba853add1f6d29edd7"
-"f9abc621b2d548f8dbf8979bd16608d2d8fc3260b4ebc0dd42482481d548c7075711b57596"
-"49c41f439fad69954956c9326841ea6492956829f9e0dc789f73633b40f6ac77bcae6dfc79"
-"30cfe89e526d1684365c5b0be2437fdb01",
-"21188c3edd5de088dacc1076b9e1bcecd79de1003c2414c3866173054dc82dde85169baa77"
-"993adb20c269f60a5226111828578bcc7c29e6e8d2dae81806152c8ba0c6ada1986a1983eb"
-"eec1473a73a04795b6319d48662d40881c1723a706f516fe75300f92408aa1dc6ae4288d20"
-"46f23c1aa2e54b7fb6448a0da922bd7f34",
-};
-
-char *sign_qx[] = {
-	"1ccbe91c075fc7f4f033bfa248db8fccd3565de94bbfb12f3c59ff46c271bf83",
-	"e266ddfdc12668db30d4ca3e8f7749432c416044f2d2b8c10bf3d4012aeffa8a",
-	"74ccd8a62fba0e667c50929a53f78c21b8ff0c3c737b0b40b1750b2302b0bde8",
-	"322f80371bf6e044bc49391d97c1714ab87f990b949bc178cb7c43b7c22d89e1",
-	"1bcec4570e1ec2436596b8ded58f60c3b1ebc6a403bc5543040ba82963057244",
-	"a32e50be3dae2c8ba3f5e4bdae14cf7645420d425ead94036c22dd6c4fc59e00",
-	"8bcfe2a721ca6d753968f564ec4315be4857e28bef1908f61a366b1f03c97479",
-	"a88bc8430279c8c0400a77d751f26c0abc93e5de4ad9a4166357952fe041e767",
-	"1bc487570f040dc94196c9befe8ab2b6de77208b1f38bdaae28f9645c4d2bc3a",
-	"b8188bd68701fc396dab53125d4d28ea33a91daf6d21485f4770f6ea8c565dde",
-	"51f99d2d52d4a6e734484a018b7ca2f895c2929b6754a3a03224d07ae61166ce",
-	"8fb287f0202ad57ae841aea35f29b2e1d53e196d0ddd9aec24813d64c0922fb7",
-	"68229b48c2fe19d3db034e4c15077eb7471a66031f28a980821873915298ba76",
-	"0a7dbb8bf50cb605eb2268b081f26d6b08e012f952c4b70a5a1e6e7d46af98bb",
-	"105d22d9c626520faca13e7ced382dcbe93498315f00cc0ac39c4821d0d73737",
-};
-
-char *sign_qy[] = {
-	"ce4014c68811f9a21a1fdb2c0e6113e06db7ca93b7404e78dc7ccd5ca89a4ca9",
-	"bfa86404a2e9ffe67d47c587ef7a97a7f456b863b4d02cfc6928973ab5b1cb39",
-	"29074e21f3a0ef88b9efdf10d06aa4c295cc1671f758ca0e4cd108803d0f2614",
-	"3c15d54a5cc6b9f09de8457e873eb3deb1fceb54b0b295da6050294fae7fd999",
-	"8af62a4c683f096b28558320737bf83b9959a46ad2521004ef74cf85e67494e1",
-	"d623bf641160c289d6742c6257ae6ba574446dd1d0e74db3aaa80900b78d4ae9",
-	"0f67576a30b8e20d4232d8530b52fb4c89cbc589ede291e499ddd15fe870ab96",
-	"2d365a1eef25ead579cc9a069b6abc1b16b81c35f18785ce26a10ba6d1381185",
-	"ec81602abd8345e71867c8210313737865b8aa186851e1b48eaca140320f5d8f",
-	"423f058810f277f8fe076f6db56e9285a1bf2c2a1dae145095edd9c04970bc4a",
-	"4737da963c6ef7247fb88d19f9b0c667cac7fe12837fdab88c66f10d3c14cad1",
-	"1f6daff1aa2dd2d6d3741623eecb5e7b612997a1039aab2e5cf2de969cfea573",
-	"303e8ee3742a893f78b810991da697083dd8f11128c47651c27a56740a80c24c",
-	"f26dd7d799930062480849962ccf5004edcfd307c044f4e8f667c9baa834eeae",
-	"6c47f3cbbfa97dfcebe16270b8c7d5d3a5900b888c42520d751e8faf3b401ef4",
-};
-
-char *sign_r[] = {
-	"f3ac8061b514795b8843e3d6629527ed2afd6b1f6a555a7acabb5e6f79c8c2ac",
-	"976d3a4e9d23326dc0baa9fa560b7c4e53f42864f508483a6473b6a11079b2db",
-	"35fb60f5ca0f3ca08542fb3cc641c8263a2cab7a90ee6a5e1583fac2bb6f6bd1",
-	"d7c562370af617b581c84a2468cc8bd50bb1cbf322de41b7887ce07c0e5884ca",
-	"18caaf7b663507a8bcd992b836dec9dc5703c080af5e51dfa3a9a7c387182604",
-	"8524c5024e2d9a73bde8c72d9129f57873bbad0ed05215a372a84fdbc78f2e68",
-	"c5a186d72df452015480f7f338970bfe825087f05c0088d95305f87aacc9b254",
-	"9d0c6afb6df3bced455b459cc21387e14929392664bb8741a3693a1795ca6902",
-	"2f9e2b4e9f747c657f705bffd124ee178bbc5391c86d056717b140c153570fd9",
-	"1cc628533d0004b2b20e7f4baad0b8bb5e0673db159bbccf92491aef61fc9620",
-	"9886ae46c1415c3bc959e82b760ad760aab66885a84e620aa339fdf102465c42",
-	"490efd106be11fc365c7467eb89b8d39e15d65175356775deab211163c2504cb",
-	"e67a9717ccf96841489d6541f4f6adb12d17b59a6bef847b6183b8fcf16a32eb",
-	"b53ce4da1aa7c0dc77a1896ab716b921499aed78df725b1504aba1597ba0c64b",
-	"542c40a18140a6266d6f0286e24e9a7bad7650e72ef0e2131e629c076d962663",
-};
-
-char *sign_s[] = {
-	"8bf77819ca05a6b2786c76262bf7371cef97b218e96f175a3ccdda2acc058903",
-	"1b766e9ceb71ba6c01dcd46e0af462cd4cfa652ae5017d4555b8eeefe36e1932",
-	"ee59d81bc9db1055cc0ed97b159d8784af04e98511d0a9a407b99bb292572e96",
-	"b46d9f2d8c4bf83546ff178f1d78937c008d64e8ecc5cbb825cb21d94d670d89",
-	"77c68928ac3b88d985fb43fb615fb7ff45c18ba5c81af796c613dfa98352d29c",
-	"d18c2caf3b1072f87064ec5e8953f51301cada03469c640244760328eb5a05cb",
-	"84a58f9e9d9e735344b316b1aa1ab5185665b85147dc82d92e969d7bee31ca30",
-	"d7f9ddd191f1f412869429209ee3814c75c72fa46a9cccf804a2f5cc0b7e739f",
-	"f5413bfd85949da8d83de83ab0d19b2986613e224d1901d76919de23ccd03199",
-	"880e0bbf82a8cf818ed46ba03cf0fc6c898e36fca36cc7fdb1d2db7503634430",
-	"2bf3a80bc04faa35ebecc0f4864ac02d349f6f126e0f988501b8d3075409a26c",
-	"644300fc0da4d40fb8c6ead510d14f0bd4e1321a469e9c0a581464c7186b7aa7",
-	"9ae6ba6d637706849a6a9fc388cf0232d85c26ea0d1fe7437adb48de58364333",
-	"d7c246dc7ad0e67700c373edcfdd1c0a0495fc954549ad579df6ed1438840851",
-	"4f7f65305e24a6bbb5cff714ba8f5a2cee5bdc89ba8d75dcbf21966ce38eb66f",
-};
-
-int cavp_sign(int verbose)
+int cavp_sign(bool verbose)
 {
-/*
- * [P-256,SHA-256]
- */
+
+	/*
+	 * [P-256,SHA-256]
+	 */
+	char *d[] = {
+		"519b423d715f8b581f4fa8ee59f4771a5b44c8130b4e3eacca54a56dda72b464",
+		"0f56db78ca460b055c500064824bed999a25aaf48ebb519ac201537b85479813",
+		"e283871239837e13b95f789e6e1af63bf61c918c992e62bca040d64cad1fc2ef",
+		"a3d2d3b7596f6592ce98b4bfe10d41837f10027a90d7bb75349490018cf72d07",
+		"53a0e8a8fe93db01e7ae94e1a9882a102ebd079b3a535827d583626c272d280d",
+		"4af107e8e2194c830ffb712a65511bc9186a133007855b49ab4b3833aefc4a1d",
+		"78dfaa09f1076850b3e206e477494cddcfb822aaa0128475053592c48ebaf4ab",
+		"80e692e3eb9fcd8c7d44e7de9f7a5952686407f90025a1d87e52c7096a62618a",
+		"5e666c0db0214c3b627a8e48541cc84a8b6fd15f300da4dff5d18aec6c55b881",
+		"f73f455271c877c4d5334627e37c278f68d143014b0a05aa62f308b2101c5308",
+		"b20d705d9bd7c2b8dc60393a5357f632990e599a0975573ac67fd89b49187906",
+		"d4234bebfbc821050341a37e1240efe5e33763cbbb2ef76a1c79e24724e5a5e7",
+		"b58f5211dff440626bb56d0ad483193d606cf21f36d9830543327292f4d25d8c",
+		"54c066711cdb061eda07e5275f7e95a9962c6764b84f6f1f3ab5a588e0a2afb1",
+		"34fa4682bf6cb5b16783adcd18f0e6879b92185f76d7c920409f904f522db4b1",
+	};
+
+	char *k[] = {
+		"94a1bbb14b906a61a280f245f9e93c7f3b4a6247824f5d33b9670787642a68de",
+		"6d3e71882c3b83b156bb14e0ab184aa9fb728068d3ae9fac421187ae0b2f34c6",
+		"ad5e887eb2b380b8d8280ad6e5ff8a60f4d26243e0124c2f31a297b5d0835de2",
+		"24fc90e1da13f17ef9fe84cc96b9471ed1aaac17e3a4bae33a115df4e5834f18",
+		"5d833e8d24cc7a402d7ee7ec852a3587cddeb48358cea71b0bedb8fabe84e0c4",
+		"e18f96f84dfa2fd3cdfaec9159d4c338cd54ad314134f0b31e20591fc238d0ab",
+		"295544dbb2da3da170741c9b2c6551d40af7ed4e891445f11a02b66a5c258a77",
+		"7c80fd66d62cc076cef2d030c17c0a69c99611549cb32c4ff662475adbe84b22",
+		"2e7625a48874d86c9e467f890aaa7cd6ebdf71c0102bfdcfa24565d6af3fdce9",
+		"62f8665fd6e26b3fa069e85281777a9b1f0dfd2c0b9f54a086d0c109ff9fd615",
+		"72b656f6b35b9ccbc712c9f1f3b1a14cbbebaec41c4bca8da18f492a062d6f6f",
+		"d926fe10f1bfd9855610f4f5a3d666b1a149344057e35537373372ead8b1a778",
+		"e158bf4a2d19a99149d9cdb879294ccb7aaeae03d75ddd616ef8ae51a6dc1071",
+		"646fe933e96c3b8f9f507498e907fdd201f08478d0202c752a7c2cfebf4d061a",
+		"a6f463ee72c9492bc792fe98163112837aebd07bab7a84aaed05be64db3086f4",
+	};
+
+	char *Msg[] = {
+		"5905238877c77421f73e43ee3da6f2d9e2ccad5fc942dcec0cbd25482935faaf416983fe16"
+		"5b1a045ee2bcd2e6dca3bdf46c4310a7461f9a37960ca672d3feb5473e253605fb1ddfd280"
+		"65b53cb5858a8ad28175bf9bd386a5e471ea7a65c17cc934a9d791e91491eb3754d0379979"
+		"0fe2d308d16146d5c9b0d0debd97d79ce8",
+		"c35e2f092553c55772926bdbe87c9796827d17024dbb9233a545366e2e5987dd344deb72df"
+		"987144b8c6c43bc41b654b94cc856e16b96d7a821c8ec039b503e3d86728c494a967d83011"
+		"a0e090b5d54cd47f4e366c0912bc808fbb2ea96efac88fb3ebec9342738e225f7c7c2b011c"
+		"e375b56621a20642b4d36e060db4524af1",
+		"3c054e333a94259c36af09ab5b4ff9beb3492f8d5b4282d16801daccb29f70fe61a0b37ffe"
+		"f5c04cd1b70e85b1f549a1c4dc672985e50f43ea037efa9964f096b5f62f7ffdf8d6bfb2cc"
+		"859558f5a393cb949dbd48f269343b5263dcdb9c556eca074f2e98e6d94c2c29a677afaf80"
+		"6edf79b15a3fcd46e7067b7669f83188ee",
+		"0989122410d522af64ceb07da2c865219046b4c3d9d99b01278c07ff63eaf1039cb787ae9e"
+		"2dd46436cc0415f280c562bebb83a23e639e476a02ec8cff7ea06cd12c86dcc3adefbf1a9e"
+		"9a9b6646c7599ec631b0da9a60debeb9b3e19324977f3b4f36892c8a38671c8e1cc8e50fcd"
+		"50f9e51deaf98272f9266fc702e4e57c30",
+		"dc66e39f9bbfd9865318531ffe9207f934fa615a5b285708a5e9c46b7775150e818d7f24d2"
+		"a123df3672fff2094e3fd3df6fbe259e3989dd5edfcccbe7d45e26a775a5c4329a084f057c"
+		"42c13f3248e3fd6f0c76678f890f513c32292dd306eaa84a59abe34b16cb5e38d0e885525d"
+		"10336ca443e1682aa04a7af832b0eee4e7",
+		"600974e7d8c5508e2c1aab0783ad0d7c4494ab2b4da265c2fe496421c4df238b0be25f2565"
+		"9157c8a225fb03953607f7df996acfd402f147e37aee2f1693e3bf1c35eab3ae360a2bd91d"
+		"04622ea47f83d863d2dfecb618e8b8bdc39e17d15d672eee03bb4ce2cc5cf6b217e5faf3f3"
+		"36fdd87d972d3a8b8a593ba85955cc9d71",
+		"dfa6cb9b39adda6c74cc8b2a8b53a12c499ab9dee01b4123642b4f11af336a91a5c9ce0520"
+		"eb2395a6190ecbf6169c4cba81941de8e76c9c908eb843b98ce95e0da29c5d4388040264e0"
+		"5e07030a577cc5d176387154eabae2af52a83e85c61c7c61da930c9b19e45d7e34c8516dc3"
+		"c238fddd6e450a77455d534c48a152010b",
+		"51d2547cbff92431174aa7fc7302139519d98071c755ff1c92e4694b58587ea560f72f32fc"
+		"6dd4dee7d22bb7387381d0256e2862d0644cdf2c277c5d740fa089830eb52bf79d1e75b859"
+		"6ecf0ea58a0b9df61e0c9754bfcd62efab6ea1bd216bf181c5593da79f10135a9bc6e164f1"
+		"854bc8859734341aad237ba29a81a3fc8b",
+		"558c2ac13026402bad4a0a83ebc9468e50f7ffab06d6f981e5db1d082098065bcff6f21a7a"
+		"74558b1e8612914b8b5a0aa28ed5b574c36ac4ea5868432a62bb8ef0695d27c1e3ceaf75c7"
+		"b251c65ddb268696f07c16d2767973d85beb443f211e6445e7fe5d46f0dce70d58a4cd9fe7"
+		"0688c035688ea8c6baec65a5fc7e2c93e8",
+		"4d55c99ef6bd54621662c3d110c3cb627c03d6311393b264ab97b90a4b15214a5593ba2510"
+		"a53d63fb34be251facb697c973e11b665cb7920f1684b0031b4dd370cb927ca7168b0bf8ad"
+		"285e05e9e31e34bc24024739fdc10b78586f29eff94412034e3b606ed850ec2c1900e8e681"
+		"51fc4aee5adebb066eb6da4eaa5681378e",
+		"f8248ad47d97c18c984f1f5c10950dc1404713c56b6ea397e01e6dd925e903b4fadfe2c9e8"
+		"77169e71ce3c7fe5ce70ee4255d9cdc26f6943bf48687874de64f6cf30a012512e787b8805"
+		"9bbf561162bdcc23a3742c835ac144cc14167b1bd6727e940540a9c99f3cbb41fb1dcb00d7"
+		"6dda04995847c657f4c19d303eb09eb48a",
+		"3b6ee2425940b3d240d35b97b6dcd61ed3423d8e71a0ada35d47b322d17b35ea0472f35edd"
+		"1d252f87b8b65ef4b716669fc9ac28b00d34a9d66ad118c9d94e7f46d0b4f6c2b2d339fd6b"
+		"cd351241a387cc82609057048c12c4ec3d85c661975c45b300cb96930d89370a327c98b67d"
+		"efaa89497aa8ef994c77f1130f752f94a4",
+		"c5204b81ec0a4df5b7e9fda3dc245f98082ae7f4efe81998dcaa286bd4507ca840a53d21b0"
+		"1e904f55e38f78c3757d5a5a4a44b1d5d4e480be3afb5b394a5d2840af42b1b4083d40afbf"
+		"e22d702f370d32dbfd392e128ea4724d66a3701da41ae2f03bb4d91bb946c7969404cb544f"
+		"71eb7a49eb4c4ec55799bda1eb545143a7",
+		"72e81fe221fb402148d8b7ab03549f1180bcc03d41ca59d7653801f0ba853add1f6d29edd7"
+		"f9abc621b2d548f8dbf8979bd16608d2d8fc3260b4ebc0dd42482481d548c7075711b57596"
+		"49c41f439fad69954956c9326841ea6492956829f9e0dc789f73633b40f6ac77bcae6dfc79"
+		"30cfe89e526d1684365c5b0be2437fdb01",
+		"21188c3edd5de088dacc1076b9e1bcecd79de1003c2414c3866173054dc82dde85169baa77"
+		"993adb20c269f60a5226111828578bcc7c29e6e8d2dae81806152c8ba0c6ada1986a1983eb"
+		"eec1473a73a04795b6319d48662d40881c1723a706f516fe75300f92408aa1dc6ae4288d20"
+		"46f23c1aa2e54b7fb6448a0da922bd7f34",
+	};
+
+	char *Qx[] = {
+		"1ccbe91c075fc7f4f033bfa248db8fccd3565de94bbfb12f3c59ff46c271bf83",
+		"e266ddfdc12668db30d4ca3e8f7749432c416044f2d2b8c10bf3d4012aeffa8a",
+		"74ccd8a62fba0e667c50929a53f78c21b8ff0c3c737b0b40b1750b2302b0bde8",
+		"322f80371bf6e044bc49391d97c1714ab87f990b949bc178cb7c43b7c22d89e1",
+		"1bcec4570e1ec2436596b8ded58f60c3b1ebc6a403bc5543040ba82963057244",
+		"a32e50be3dae2c8ba3f5e4bdae14cf7645420d425ead94036c22dd6c4fc59e00",
+		"8bcfe2a721ca6d753968f564ec4315be4857e28bef1908f61a366b1f03c97479",
+		"a88bc8430279c8c0400a77d751f26c0abc93e5de4ad9a4166357952fe041e767",
+		"1bc487570f040dc94196c9befe8ab2b6de77208b1f38bdaae28f9645c4d2bc3a",
+		"b8188bd68701fc396dab53125d4d28ea33a91daf6d21485f4770f6ea8c565dde",
+		"51f99d2d52d4a6e734484a018b7ca2f895c2929b6754a3a03224d07ae61166ce",
+		"8fb287f0202ad57ae841aea35f29b2e1d53e196d0ddd9aec24813d64c0922fb7",
+		"68229b48c2fe19d3db034e4c15077eb7471a66031f28a980821873915298ba76",
+		"0a7dbb8bf50cb605eb2268b081f26d6b08e012f952c4b70a5a1e6e7d46af98bb",
+		"105d22d9c626520faca13e7ced382dcbe93498315f00cc0ac39c4821d0d73737",
+	};
+
+	char *Qy[] = {
+		"ce4014c68811f9a21a1fdb2c0e6113e06db7ca93b7404e78dc7ccd5ca89a4ca9",
+		"bfa86404a2e9ffe67d47c587ef7a97a7f456b863b4d02cfc6928973ab5b1cb39",
+		"29074e21f3a0ef88b9efdf10d06aa4c295cc1671f758ca0e4cd108803d0f2614",
+		"3c15d54a5cc6b9f09de8457e873eb3deb1fceb54b0b295da6050294fae7fd999",
+		"8af62a4c683f096b28558320737bf83b9959a46ad2521004ef74cf85e67494e1",
+		"d623bf641160c289d6742c6257ae6ba574446dd1d0e74db3aaa80900b78d4ae9",
+		"0f67576a30b8e20d4232d8530b52fb4c89cbc589ede291e499ddd15fe870ab96",
+		"2d365a1eef25ead579cc9a069b6abc1b16b81c35f18785ce26a10ba6d1381185",
+		"ec81602abd8345e71867c8210313737865b8aa186851e1b48eaca140320f5d8f",
+		"423f058810f277f8fe076f6db56e9285a1bf2c2a1dae145095edd9c04970bc4a",
+		"4737da963c6ef7247fb88d19f9b0c667cac7fe12837fdab88c66f10d3c14cad1",
+		"1f6daff1aa2dd2d6d3741623eecb5e7b612997a1039aab2e5cf2de969cfea573",
+		"303e8ee3742a893f78b810991da697083dd8f11128c47651c27a56740a80c24c",
+		"f26dd7d799930062480849962ccf5004edcfd307c044f4e8f667c9baa834eeae",
+		"6c47f3cbbfa97dfcebe16270b8c7d5d3a5900b888c42520d751e8faf3b401ef4",
+	};
+
+	char *R[] = {
+		"f3ac8061b514795b8843e3d6629527ed2afd6b1f6a555a7acabb5e6f79c8c2ac",
+		"976d3a4e9d23326dc0baa9fa560b7c4e53f42864f508483a6473b6a11079b2db",
+		"35fb60f5ca0f3ca08542fb3cc641c8263a2cab7a90ee6a5e1583fac2bb6f6bd1",
+		"d7c562370af617b581c84a2468cc8bd50bb1cbf322de41b7887ce07c0e5884ca",
+		"18caaf7b663507a8bcd992b836dec9dc5703c080af5e51dfa3a9a7c387182604",
+		"8524c5024e2d9a73bde8c72d9129f57873bbad0ed05215a372a84fdbc78f2e68",
+		"c5a186d72df452015480f7f338970bfe825087f05c0088d95305f87aacc9b254",
+		"9d0c6afb6df3bced455b459cc21387e14929392664bb8741a3693a1795ca6902",
+		"2f9e2b4e9f747c657f705bffd124ee178bbc5391c86d056717b140c153570fd9",
+		"1cc628533d0004b2b20e7f4baad0b8bb5e0673db159bbccf92491aef61fc9620",
+		"9886ae46c1415c3bc959e82b760ad760aab66885a84e620aa339fdf102465c42",
+		"490efd106be11fc365c7467eb89b8d39e15d65175356775deab211163c2504cb",
+		"e67a9717ccf96841489d6541f4f6adb12d17b59a6bef847b6183b8fcf16a32eb",
+		"b53ce4da1aa7c0dc77a1896ab716b921499aed78df725b1504aba1597ba0c64b",
+		"542c40a18140a6266d6f0286e24e9a7bad7650e72ef0e2131e629c076d962663",
+	};
+
+	char *S[] = {
+		"8bf77819ca05a6b2786c76262bf7371cef97b218e96f175a3ccdda2acc058903",
+		"1b766e9ceb71ba6c01dcd46e0af462cd4cfa652ae5017d4555b8eeefe36e1932",
+		"ee59d81bc9db1055cc0ed97b159d8784af04e98511d0a9a407b99bb292572e96",
+		"b46d9f2d8c4bf83546ff178f1d78937c008d64e8ecc5cbb825cb21d94d670d89",
+		"77c68928ac3b88d985fb43fb615fb7ff45c18ba5c81af796c613dfa98352d29c",
+		"d18c2caf3b1072f87064ec5e8953f51301cada03469c640244760328eb5a05cb",
+		"84a58f9e9d9e735344b316b1aa1ab5185665b85147dc82d92e969d7bee31ca30",
+		"d7f9ddd191f1f412869429209ee3814c75c72fa46a9cccf804a2f5cc0b7e739f",
+		"f5413bfd85949da8d83de83ab0d19b2986613e224d1901d76919de23ccd03199",
+		"880e0bbf82a8cf818ed46ba03cf0fc6c898e36fca36cc7fdb1d2db7503634430",
+		"2bf3a80bc04faa35ebecc0f4864ac02d349f6f126e0f988501b8d3075409a26c",
+		"644300fc0da4d40fb8c6ead510d14f0bd4e1321a469e9c0a581464c7186b7aa7",
+		"9ae6ba6d637706849a6a9fc388cf0232d85c26ea0d1fe7437adb48de58364333",
+		"d7c246dc7ad0e67700c373edcfdd1c0a0495fc954549ad579df6ed1438840851",
+		"4f7f65305e24a6bbb5cff714ba8f5a2cee5bdc89ba8d75dcbf21966ce38eb66f",
+	};
+
 	struct tc_sha256_state_struct sha256_ctx;
-	int rc;
 
-	rc = sign_vectors(&sha256_ctx, sign_d, sign_k, sign_msg, sign_qx,
-			  sign_qy, sign_r, sign_s, 15, verbose);
+	TC_PRINT("Test #1: ECDSAsign ");
+	TC_PRINT("NIST-p256, SHA2-256\n");
 
-	return rc;
+	return sign_vectors(&sha256_ctx, d, k, Msg, Qx, Qy, R, S, 15, verbose);
 }
 
-int verify_vectors(TCSha256State_t hash, char **msg_vec, char **qx_vec,
-		   char **qy_vec, char **r_vec, char **s_vec,
-		   char **names, int *verify_results, int tests,
-		   int verbose)
+int vrfy_vectors(TCSha256State_t hash, char **msg_vec, char **qx_vec, char **qy_vec,
+		 char **r_vec, char **s_vec, int res_vec[], int tests, bool verbose)
 {
-	EccPoint pub;
-	u32_t r[NUM_ECC_DIGITS];
-	u32_t s[NUM_ECC_DIGITS];
-	u8_t  digest[TC_SHA256_DIGEST_SIZE];
-	u32_t dig32[NUM_ECC_DIGITS];
-	u8_t msg[BUF_SIZE];
-	size_t msglen;
+
+	const struct uECC_Curve_t *curve = uECC_secp256r1();
+	unsigned int pub[2 * NUM_ECC_WORDS];
+	uint8_t pub_bytes[2 * NUM_ECC_BYTES];
+	unsigned int sig[2 * NUM_ECC_WORDS];
+	uint8_t sig_bytes[2 * NUM_ECC_BYTES];
+	uint8_t digest_bytes[TC_SHA256_DIGEST_SIZE];
+	unsigned int digest[TC_SHA256_DIGEST_SIZE / 4];
+	unsigned int result = TC_PASS;
+
+	int rc;
 	int exp_rc;
-	int rc = TC_FAIL;
+
+	uint8_t msg[BUF_SIZE];
+	size_t msglen;
 
 	for (int i = 0; i < tests; i++) {
-		int hash_dwords;
 
-		str_to_scalar(pub.x, NUM_ECC_DIGITS, qx_vec[i]);
-		str_to_scalar(pub.y, NUM_ECC_DIGITS, qy_vec[i]);
-		str_to_scalar(r, NUM_ECC_DIGITS, r_vec[i]);
-		str_to_scalar(s, NUM_ECC_DIGITS, s_vec[i]);
+		string2scalar(pub, NUM_ECC_WORDS, qx_vec[i]);
+		string2scalar(pub + NUM_ECC_WORDS, NUM_ECC_WORDS, qy_vec[i]);
+		string2scalar(sig, NUM_ECC_WORDS, r_vec[i]);
+		string2scalar(sig + NUM_ECC_WORDS, NUM_ECC_WORDS, s_vec[i]);
 
-		exp_rc = verify_results[i];
+		exp_rc = res_vec[i];
 
 		/* validate ECDSA: hash message, verify r+s */
-		msglen = hex_to_num_str(msg, BUF_SIZE, msg_vec[i],
-					strlen(msg_vec[i]));
+		msglen = hex2bin(msg, BUF_SIZE, msg_vec[i], strlen(msg_vec[i]));
 
-		if (msglen == 0) {
-			TC_PRINT("failed to import message!\n");
-			rc = TC_FAIL;
-			goto exit_test;
+		if (msglen == false) {
+			TC_ERROR("failed to import message!\n");
+			result = TC_FAIL;
+			goto exitTest1;
 		}
 
 		tc_sha256_init(hash);
 		tc_sha256_update(hash, msg, msglen);
-		tc_sha256_final(digest, hash);
+		tc_sha256_final(digest_bytes, hash);
 
 		/* if digest larger than ECC scalar, drop the end
-		 * if digest smaller than ECC scalar, zero-pad front
-		 */
-		/* Note: here it is assumed that:
-		 * NUM_ECC_DIGITS * 4 == TC_SHA256_DIGEST_SIZE
-		 */
-		hash_dwords = TC_SHA256_DIGEST_SIZE / 4;
+		 * if digest smaller than ECC scalar, zero-pad front */
+		int hash_dwords = TC_SHA256_DIGEST_SIZE / 4;
+		if (NUM_ECC_WORDS < hash_dwords) {
+			hash_dwords = NUM_ECC_WORDS;
+		}
 
-		memset(dig32, 0, NUM_ECC_BYTES - 4 * hash_dwords);
-		ecc_bytes2native(dig32 + (NUM_ECC_DIGITS - hash_dwords),
-				 digest);
+		memset(digest, 0, NUM_ECC_BYTES - 4 * hash_dwords);
+		uECC_vli_bytesToNative(digest + (NUM_ECC_WORDS - hash_dwords), digest_bytes,
+				       TC_SHA256_DIGEST_SIZE);
 
-		/* adapt return codes to match CAVP error.. */
-		if (ecc_valid_public_key(&pub) != 0) {
+		uECC_vli_nativeToBytes(pub_bytes, NUM_ECC_BYTES, pub);
+		uECC_vli_nativeToBytes(pub_bytes + NUM_ECC_BYTES, NUM_ECC_BYTES,
+				       pub + NUM_ECC_WORDS);
+
+		/* adapt return codes to match CAVP error: */
+		if (0 != uECC_valid_public_key(pub_bytes, curve)) {
 			/* error 4 - Q changed */
 			rc = 4;
 		} else {
-			rc = ecdsa_verify(&pub, dig32, r, s);
+			uECC_vli_nativeToBytes(sig_bytes, NUM_ECC_BYTES, sig);
+			uECC_vli_nativeToBytes(sig_bytes + NUM_ECC_BYTES, NUM_ECC_BYTES,
+					       sig + NUM_ECC_WORDS);
+
+			rc = uECC_verify(pub_bytes, digest_bytes, sizeof(digest_bytes), sig_bytes,
+					 uECC_secp256r1());
 			/* CAVP expects 0 for success, others for fail */
 			rc = !rc;
 			if (exp_rc != 0 && rc != 0) {
-				/* mimic CAVP code on errors.. */
+				/* mimic CAVP code on errors. */
 				rc = exp_rc;
 			}
 		}
 
-		if (check_code(i, names[i], exp_rc, rc, verbose) != TC_PASS) {
-			rc = TC_FAIL;
-			goto exit_test;
+		result = check_code(i, exp_rc, rc, verbose);
+		if (result == TC_FAIL) {
+			goto exitTest1;
 		}
 	}
-
-	rc = TC_PASS;
-
-exit_test:
-	return rc;
+exitTest1:
+	TC_END_RESULT(result);
+	return result;
 }
 
-char *verify_msg[] = {
-"e4796db5f785f207aa30d311693b3702821dff1168fd2e04c0836825aefd850d9aa60326d8"
-"8cde1a23c7745351392ca2288d632c264f197d05cd424a30336c19fd09bb229654f0222fcb"
-"881a4b35c290a093ac159ce13409111ff0358411133c24f5b8e2090d6db6558afc36f06ca1"
-"f6ef779785adba68db27a409859fc4c4a0",
-"069a6e6b93dfee6df6ef6997cd80dd2182c36653cef10c655d524585655462d683877f95ec"
-"c6d6c81623d8fac4e900ed0019964094e7de91f1481989ae1873004565789cbf5dc56c62ae"
-"dc63f62f3b894c9c6f7788c8ecaadc9bd0e81ad91b2b3569ea12260e93924fdddd3972af52"
-"73198f5efda0746219475017557616170e",
-"df04a346cf4d0e331a6db78cca2d456d31b0a000aa51441defdb97bbeb20b94d8d746429a3"
-"93ba88840d661615e07def615a342abedfa4ce912e562af714959896858af817317a840dcf"
-"f85a057bb91a3c2bf90105500362754a6dd321cdd86128cfc5f04667b57aa78c112411e42d"
-"a304f1012d48cd6a7052d7de44ebcc01de",
-"e1130af6a38ccb412a9c8d13e15dbfc9e69a16385af3c3f1e5da954fd5e7c45fd75e2b8c36"
-"699228e92840c0562fbf3772f07e17f1add56588dd45f7450e1217ad239922dd9c32695dc7"
-"1ff2424ca0dec1321aa47064a044b7fe3c2b97d03ce470a592304c5ef21eed9f93da56bb23"
-"2d1eeb0035f9bf0dfafdcc4606272b20a3",
-"73c5f6a67456ae48209b5f85d1e7de7758bf235300c6ae2bdceb1dcb27a7730fb68c950b7f"
-"cada0ecc4661d3578230f225a875e69aaa17f1e71c6be5c831f22663bac63d0c7a9635edb0"
-"043ff8c6f26470f02a7bc56556f1437f06dfa27b487a6c4290d8bad38d4879b334e341ba09"
-"2dde4e4ae694a9c09302e2dbf443581c08",
-"666036d9b4a2426ed6585a4e0fd931a8761451d29ab04bd7dc6d0c5b9e38e6c2b263ff6cb8"
-"37bd04399de3d757c6c7005f6d7a987063cf6d7e8cb38a4bf0d74a282572bd01d0f41e3fd0"
-"66e3021575f0fa04f27b700d5b7ddddf50965993c3f9c7118ed78888da7cb221849b326059"
-"2b8e632d7c51e935a0ceae15207bedd548",
-"7e80436bce57339ce8da1b5660149a20240b146d108deef3ec5da4ae256f8f894edcbbc57b"
-"34ce37089c0daa17f0c46cd82b5a1599314fd79d2fd2f446bd5a25b8e32fcf05b76d644573"
-"a6df4ad1dfea707b479d97237a346f1ec632ea5660efb57e8717a8628d7f82af50a4e84b11"
-"f21bdff6839196a880ae20b2a0918d58cd",
-"1669bfb657fdc62c3ddd63269787fc1c969f1850fb04c933dda063ef74a56ce13e3a649700"
-"820f0061efabf849a85d474326c8a541d99830eea8131eaea584f22d88c353965dabcdc4bf"
-"6b55949fd529507dfb803ab6b480cd73ca0ba00ca19c438849e2cea262a1c57d8f81cd257f"
-"b58e19dec7904da97d8386e87b84948169",
-"3fe60dd9ad6caccf5a6f583b3ae65953563446c4510b70da115ffaa0ba04c076115c7043ab"
-"8733403cd69c7d14c212c655c07b43a7c71b9a4cffe22c2684788ec6870dc2013f269172c8"
-"22256f9e7cc674791bf2d8486c0f5684283e1649576efc982ede17c7b74b214754d70402fb"
-"4bb45ad086cf2cf76b3d63f7fce39ac970",
-"983a71b9994d95e876d84d28946a041f8f0a3f544cfcc055496580f1dfd4e312a2ad418fe6"
-"9dbc61db230cc0c0ed97e360abab7d6ff4b81ee970a7e97466acfd9644f828ffec538abc38"
-"3d0e92326d1c88c55e1f46a668a039beaa1be631a89129938c00a81a3ae46d4aecbf9707f7"
-"64dbaccea3ef7665e4c4307fa0b0a3075c",
-"4a8c071ac4fd0d52faa407b0fe5dab759f7394a5832127f2a3498f34aac287339e043b4ffa"
-"79528faf199dc917f7b066ad65505dab0e11e6948515052ce20cfdb892ffb8aa9bf3f1aa5b"
-"e30a5bbe85823bddf70b39fd7ebd4a93a2f75472c1d4f606247a9821f1a8c45a6cb80545de"
-"2e0c6c0174e2392088c754e9c8443eb5af",
-"0a3a12c3084c865daf1d302c78215d39bfe0b8bf28272b3c0b74beb4b7409db0718239de70"
-"0785581514321c6440a4bbaea4c76fa47401e151e68cb6c29017f0bce4631290af5ea5e2bf"
-"3ed742ae110b04ade83a5dbd7358f29a85938e23d87ac8233072b79c94670ff0959f9c7f45"
-"17862ff829452096c78f5f2e9a7e4e9216",
-"785d07a3c54f63dca11f5d1a5f496ee2c2f9288e55007e666c78b007d95cc28581dce51f49"
-"0b30fa73dc9e2d45d075d7e3a95fb8a9e1465ad191904124160b7c60fa720ef4ef1c5d2998"
-"f40570ae2a870ef3e894c2bc617d8a1dc85c3c55774928c38789b4e661349d3f84d2441a3b"
-"856a76949b9f1f80bc161648a1cad5588e",
-"76f987ec5448dd72219bd30bf6b66b0775c80b394851a43ff1f537f140a6e7229ef8cd72ad"
-"58b1d2d20298539d6347dd5598812bc65323aceaf05228f738b5ad3e8d9fe4100fd767c2f0"
-"98c77cb99c2992843ba3eed91d32444f3b6db6cd212dd4e5609548f4bb62812a920f6e2bf1"
-"581be1ebeebdd06ec4e971862cc42055ca",
-"60cd64b2cd2be6c33859b94875120361a24085f3765cb8b2bf11e026fa9d8855dbe435acf7"
-"882e84f3c7857f96e2baab4d9afe4588e4a82e17a78827bfdb5ddbd1c211fbc2e6d884cddd"
-"7cb9d90d5bf4a7311b83f352508033812c776a0e00c003c7e0d628e50736c7512df0acfa9f"
-"2320bd102229f46495ae6d0857cc452a84",
-};
-
-char *verify_qx[] = {
-	"87f8f2b218f49845f6f10eec3877136269f5c1a54736dbdf69f89940cad41555",
-	"5cf02a00d205bdfee2016f7421807fc38ae69e6b7ccd064ee689fc1a94a9f7d2",
-	"2ddfd145767883ffbb0ac003ab4a44346d08fa2570b3120dcce94562422244cb",
-	"e424dc61d4bb3cb7ef4344a7f8957a0c5134e16f7a67c074f82e6e12f49abf3c",
-	"e0fc6a6f50e1c57475673ee54e3a57f9a49f3328e743bf52f335e3eeaa3d2864",
-	"a849bef575cac3c6920fbce675c3b787136209f855de19ffe2e8d29b31a5ad86",
-	"3dfb6f40f2471b29b77fdccba72d37c21bba019efa40c1c8f91ec405d7dcc5df",
-	"69b7667056e1e11d6caf6e45643f8b21e7a4bebda463c7fdbc13bc98efbd0214",
-	"bf02cbcf6d8cc26e91766d8af0b164fc5968535e84c158eb3bc4e2d79c3cc682",
-	"224a4d65b958f6d6afb2904863efd2a734b31798884801fcab5a590f4d6da9de",
-	"43691c7795a57ead8c5c68536fe934538d46f12889680a9cb6d055a066228369",
-	"9157dbfcf8cf385f5bb1568ad5c6e2a8652ba6dfc63bc1753edf5268cb7eb596",
-	"072b10c081a4c1713a294f248aef850e297991aca47fa96a7470abe3b8acfdda",
-	"09308ea5bfad6e5adf408634b3d5ce9240d35442f7fe116452aaec0d25be8c24",
-	"2d98ea01f754d34bbc3003df5050200abf445ec728556d7ed7d5c54c55552b6d",
-};
-
-char *verify_qy[] = {
-	"e15f369036f49842fac7a86c8a2b0557609776814448b8f5e84aa9f4395205e9",
-	"ec530ce3cc5c9d1af463f264d685afe2b4db4b5828d7e61b748930f3ce622a85",
-	"5f70c7d11ac2b7a435ccfbbae02c3df1ea6b532cc0e9db74f93fffca7c6f9a64",
-	"970eed7aa2bc48651545949de1dddaf0127e5965ac85d1243d6f60e7dfaee927",
-	"7f59d689c91e463607d9194d99faf316e25432870816dde63f5d4b373f12f22a",
-	"bf5fe4f7858f9b805bd8dcc05ad5e7fb889de2f822f3d8b41694e6c55c16b471",
-	"f22f953f1e395a52ead7f3ae3fc47451b438117b1e04d613bc8555b7d6e6d1bb",
-	"d3f9b12eb46c7c6fda0da3fc85bc1fd831557f9abc902a3be3cb3e8be7d1aa2f",
-	"069ba6cb06b49d60812066afa16ecf7b51352f2c03bd93ec220822b1f3dfba03",
-	"178d51fddada62806f097aa615d33b8f2404e6b1479f5fd4859d595734d6d2b9",
-	"f8790110b3c3b281aa1eae037d4f1234aff587d903d93ba3af225c27ddc9ccac",
-	"972570f4313d47fc96f7c02d5594d77d46f91e949808825b3d31f029e8296405",
-	"9581145cca04a0fb94cedce752c8f0370861916d2a94e7c647c5373ce6a4c8f5",
-	"f40c93e023ef494b1c3079b2d10ef67f3170740495ce2cc57f8ee4b0618b8ee5",
-	"9b52672742d637a32add056dfd6d8792f2a33c2e69dafabea09b960bc61e230a",
-};
-
-char *verify_r[] = {
-	"d19ff48b324915576416097d2544f7cbdf8768b1454ad20e0baac50e211f23b0",
-	"dc23d130c6117fb5751201455e99f36f59aba1a6a21cf2d0e7481a97451d6693",
-	"9913111cff6f20c5bf453a99cd2c2019a4e749a49724a08774d14e4c113edda8",
-	"bf96b99aa49c705c910be33142017c642ff540c76349b9dab72f981fd9347f4f",
-	"1d75830cd36f4c9aa181b2c4221e87f176b7f05b7c87824e82e396c88315c407",
-	"25acc3aa9d9e84c7abf08f73fa4195acc506491d6fc37cb9074528a7db87b9d6",
-	"548886278e5ec26bed811dbb72db1e154b6f17be70deb1b210107decb1ec2a5a",
-	"288f7a1cd391842cce21f00e6f15471c04dc182fe4b14d92dc18910879799790",
-	"f5acb06c59c2b4927fb852faa07faf4b1852bbb5d06840935e849c4d293d1bad",
-	"87b93ee2fecfda54deb8dff8e426f3c72c8864991f8ec2b3205bb3b416de93d2",
-	"8acd62e8c262fa50dd9840480969f4ef70f218ebf8ef9584f199031132c6b1ce",
-	"dfaea6f297fa320b707866125c2a7d5d515b51a503bee817de9faa343cc48eeb",
-	"09f5483eccec80f9d104815a1be9cc1a8e5b12b6eb482a65c6907b7480cf4f19",
-	"5cc8aa7c35743ec0c23dde88dabd5e4fcd0192d2116f6926fef788cddb754e73",
-	"06108e525f845d0155bf60193222b3219c98e3d49424c2fb2a0987f825c17959",
-};
-
-char *verify_names[] = {
-	"F (3 - S changed)", "F (2 - R changed)",       "F (4 - Q changed)",
-	"P (0 )",            "P (0 )",                  "F (2 - R changed)",
-	"F (4 - Q changed)", "F (1 - Message changed)", "F (3 - S changed)",
-	"F (2 - R changed)", "F (3 - S changed)",       "F (1 - Message "
-	"changed)",
-	"F (4 - Q changed)", "F (1 - Message changed)", "P (0 )",
-};
-
-int verify_results[] = {3, 2, 4, 0, 0, 2, 4, 1, 3, 2, 3, 1, 4, 1, 0};
-
-char *verify_s[] = {
-	"a3e81e59311cdfff2d4784949f7a2cb50ba6c3a91fa54710568e61aca3e847c6",
-	"d6ce7708c18dbf35d4f8aa7240922dc6823f2e7058cbc1484fcad1599db5018c",
-	"9467cd4cd21ecb56b0cab0a9a453b43386845459127a952421f5c6382866c5cc",
-	"17c55095819089c2e03b9cd415abdf12444e323075d98f31920b9e0f57ec871c",
-	"cb2acb01dac96efc53a32d4a0d85d0c2e48955214783ecf50a4f0414a319c05a",
-	"9b21d5b5259ed3f2ef07dfec6cc90d3a37855d1ce122a85ba6a333f307d31537",
-	"e93bfebd2f14f3d827ca32b464be6e69187f5edbd52def4f96599c37d58eee75",
-	"247b3c4e89a3bcadfea73c7bfd361def43715fa382b8c3edf4ae15d6e55e9979",
-	"049dab79c89cc02f1484c437f523e080a75f134917fda752f2d5ca397addfe5d",
-	"4044a24df85be0cc76f21a4430b75b8e77b932a87f51e4eccbc45c263ebf8f66",
-	"cfca7ed3d4347fb2a29e526b43c348ae1ce6c60d44f3191b6d8ea3a2d9c92154",
-	"8f780ad713f9c3e5a4f7fa4c519833dfefc6a7432389b1e4af463961f09764f2",
-	"a4f90e560c5e4eb8696cb276e5165b6a9d486345dedfb094a76e8442d026378d",
-	"9c9c045ebaa1b828c32f82ace0d18daebf5e156eb7cbfdc1eff4399a8a900ae7",
-	"62b5cdd591e5b507e560167ba8f6f7cda74673eb315680cb89ccbc4eec477dce",
-};
-
-int cavp_verify(int verbose)
+int cavp_verify(bool verbose)
 {
-/*
- * [P-256,SHA-256]
- */
+
+	/*
+	 * [P-256,SHA-256]
+	 */
+	char *Msg[] = {
+		"e4796db5f785f207aa30d311693b3702821dff1168fd2e04c0836825aefd850d9aa60326d8"
+		"8cde1a23c7745351392ca2288d632c264f197d05cd424a30336c19fd09bb229654f0222fcb"
+		"881a4b35c290a093ac159ce13409111ff0358411133c24f5b8e2090d6db6558afc36f06ca1"
+		"f6ef779785adba68db27a409859fc4c4a0",
+		"069a6e6b93dfee6df6ef6997cd80dd2182c36653cef10c655d524585655462d683877f95ec"
+		"c6d6c81623d8fac4e900ed0019964094e7de91f1481989ae1873004565789cbf5dc56c62ae"
+		"dc63f62f3b894c9c6f7788c8ecaadc9bd0e81ad91b2b3569ea12260e93924fdddd3972af52"
+		"73198f5efda0746219475017557616170e",
+		"df04a346cf4d0e331a6db78cca2d456d31b0a000aa51441defdb97bbeb20b94d8d746429a3"
+		"93ba88840d661615e07def615a342abedfa4ce912e562af714959896858af817317a840dcf"
+		"f85a057bb91a3c2bf90105500362754a6dd321cdd86128cfc5f04667b57aa78c112411e42d"
+		"a304f1012d48cd6a7052d7de44ebcc01de",
+		"e1130af6a38ccb412a9c8d13e15dbfc9e69a16385af3c3f1e5da954fd5e7c45fd75e2b8c36"
+		"699228e92840c0562fbf3772f07e17f1add56588dd45f7450e1217ad239922dd9c32695dc7"
+		"1ff2424ca0dec1321aa47064a044b7fe3c2b97d03ce470a592304c5ef21eed9f93da56bb23"
+		"2d1eeb0035f9bf0dfafdcc4606272b20a3",
+		"73c5f6a67456ae48209b5f85d1e7de7758bf235300c6ae2bdceb1dcb27a7730fb68c950b7f"
+		"cada0ecc4661d3578230f225a875e69aaa17f1e71c6be5c831f22663bac63d0c7a9635edb0"
+		"043ff8c6f26470f02a7bc56556f1437f06dfa27b487a6c4290d8bad38d4879b334e341ba09"
+		"2dde4e4ae694a9c09302e2dbf443581c08",
+		"666036d9b4a2426ed6585a4e0fd931a8761451d29ab04bd7dc6d0c5b9e38e6c2b263ff6cb8"
+		"37bd04399de3d757c6c7005f6d7a987063cf6d7e8cb38a4bf0d74a282572bd01d0f41e3fd0"
+		"66e3021575f0fa04f27b700d5b7ddddf50965993c3f9c7118ed78888da7cb221849b326059"
+		"2b8e632d7c51e935a0ceae15207bedd548",
+		"7e80436bce57339ce8da1b5660149a20240b146d108deef3ec5da4ae256f8f894edcbbc57b"
+		"34ce37089c0daa17f0c46cd82b5a1599314fd79d2fd2f446bd5a25b8e32fcf05b76d644573"
+		"a6df4ad1dfea707b479d97237a346f1ec632ea5660efb57e8717a8628d7f82af50a4e84b11"
+		"f21bdff6839196a880ae20b2a0918d58cd",
+		"1669bfb657fdc62c3ddd63269787fc1c969f1850fb04c933dda063ef74a56ce13e3a649700"
+		"820f0061efabf849a85d474326c8a541d99830eea8131eaea584f22d88c353965dabcdc4bf"
+		"6b55949fd529507dfb803ab6b480cd73ca0ba00ca19c438849e2cea262a1c57d8f81cd257f"
+		"b58e19dec7904da97d8386e87b84948169",
+		"3fe60dd9ad6caccf5a6f583b3ae65953563446c4510b70da115ffaa0ba04c076115c7043ab"
+		"8733403cd69c7d14c212c655c07b43a7c71b9a4cffe22c2684788ec6870dc2013f269172c8"
+		"22256f9e7cc674791bf2d8486c0f5684283e1649576efc982ede17c7b74b214754d70402fb"
+		"4bb45ad086cf2cf76b3d63f7fce39ac970",
+		"983a71b9994d95e876d84d28946a041f8f0a3f544cfcc055496580f1dfd4e312a2ad418fe6"
+		"9dbc61db230cc0c0ed97e360abab7d6ff4b81ee970a7e97466acfd9644f828ffec538abc38"
+		"3d0e92326d1c88c55e1f46a668a039beaa1be631a89129938c00a81a3ae46d4aecbf9707f7"
+		"64dbaccea3ef7665e4c4307fa0b0a3075c",
+		"4a8c071ac4fd0d52faa407b0fe5dab759f7394a5832127f2a3498f34aac287339e043b4ffa"
+		"79528faf199dc917f7b066ad65505dab0e11e6948515052ce20cfdb892ffb8aa9bf3f1aa5b"
+		"e30a5bbe85823bddf70b39fd7ebd4a93a2f75472c1d4f606247a9821f1a8c45a6cb80545de"
+		"2e0c6c0174e2392088c754e9c8443eb5af",
+		"0a3a12c3084c865daf1d302c78215d39bfe0b8bf28272b3c0b74beb4b7409db0718239de70"
+		"0785581514321c6440a4bbaea4c76fa47401e151e68cb6c29017f0bce4631290af5ea5e2bf"
+		"3ed742ae110b04ade83a5dbd7358f29a85938e23d87ac8233072b79c94670ff0959f9c7f45"
+		"17862ff829452096c78f5f2e9a7e4e9216",
+		"785d07a3c54f63dca11f5d1a5f496ee2c2f9288e55007e666c78b007d95cc28581dce51f49"
+		"0b30fa73dc9e2d45d075d7e3a95fb8a9e1465ad191904124160b7c60fa720ef4ef1c5d2998"
+		"f40570ae2a870ef3e894c2bc617d8a1dc85c3c55774928c38789b4e661349d3f84d2441a3b"
+		"856a76949b9f1f80bc161648a1cad5588e",
+		"76f987ec5448dd72219bd30bf6b66b0775c80b394851a43ff1f537f140a6e7229ef8cd72ad"
+		"58b1d2d20298539d6347dd5598812bc65323aceaf05228f738b5ad3e8d9fe4100fd767c2f0"
+		"98c77cb99c2992843ba3eed91d32444f3b6db6cd212dd4e5609548f4bb62812a920f6e2bf1"
+		"581be1ebeebdd06ec4e971862cc42055ca",
+		"60cd64b2cd2be6c33859b94875120361a24085f3765cb8b2bf11e026fa9d8855dbe435acf7"
+		"882e84f3c7857f96e2baab4d9afe4588e4a82e17a78827bfdb5ddbd1c211fbc2e6d884cddd"
+		"7cb9d90d5bf4a7311b83f352508033812c776a0e00c003c7e0d628e50736c7512df0acfa9f"
+		"2320bd102229f46495ae6d0857cc452a84",
+	};
+
+	char *Qx[] = {
+		"87f8f2b218f49845f6f10eec3877136269f5c1a54736dbdf69f89940cad41555",
+		"5cf02a00d205bdfee2016f7421807fc38ae69e6b7ccd064ee689fc1a94a9f7d2",
+		"2ddfd145767883ffbb0ac003ab4a44346d08fa2570b3120dcce94562422244cb",
+		"e424dc61d4bb3cb7ef4344a7f8957a0c5134e16f7a67c074f82e6e12f49abf3c",
+		"e0fc6a6f50e1c57475673ee54e3a57f9a49f3328e743bf52f335e3eeaa3d2864",
+		"a849bef575cac3c6920fbce675c3b787136209f855de19ffe2e8d29b31a5ad86",
+		"3dfb6f40f2471b29b77fdccba72d37c21bba019efa40c1c8f91ec405d7dcc5df",
+		"69b7667056e1e11d6caf6e45643f8b21e7a4bebda463c7fdbc13bc98efbd0214",
+		"bf02cbcf6d8cc26e91766d8af0b164fc5968535e84c158eb3bc4e2d79c3cc682",
+		"224a4d65b958f6d6afb2904863efd2a734b31798884801fcab5a590f4d6da9de",
+		"43691c7795a57ead8c5c68536fe934538d46f12889680a9cb6d055a066228369",
+		"9157dbfcf8cf385f5bb1568ad5c6e2a8652ba6dfc63bc1753edf5268cb7eb596",
+		"072b10c081a4c1713a294f248aef850e297991aca47fa96a7470abe3b8acfdda",
+		"09308ea5bfad6e5adf408634b3d5ce9240d35442f7fe116452aaec0d25be8c24",
+		"2d98ea01f754d34bbc3003df5050200abf445ec728556d7ed7d5c54c55552b6d",
+	};
+
+	char *Qy[] = {
+		"e15f369036f49842fac7a86c8a2b0557609776814448b8f5e84aa9f4395205e9",
+		"ec530ce3cc5c9d1af463f264d685afe2b4db4b5828d7e61b748930f3ce622a85",
+		"5f70c7d11ac2b7a435ccfbbae02c3df1ea6b532cc0e9db74f93fffca7c6f9a64",
+		"970eed7aa2bc48651545949de1dddaf0127e5965ac85d1243d6f60e7dfaee927",
+		"7f59d689c91e463607d9194d99faf316e25432870816dde63f5d4b373f12f22a",
+		"bf5fe4f7858f9b805bd8dcc05ad5e7fb889de2f822f3d8b41694e6c55c16b471",
+		"f22f953f1e395a52ead7f3ae3fc47451b438117b1e04d613bc8555b7d6e6d1bb",
+		"d3f9b12eb46c7c6fda0da3fc85bc1fd831557f9abc902a3be3cb3e8be7d1aa2f",
+		"069ba6cb06b49d60812066afa16ecf7b51352f2c03bd93ec220822b1f3dfba03",
+		"178d51fddada62806f097aa615d33b8f2404e6b1479f5fd4859d595734d6d2b9",
+		"f8790110b3c3b281aa1eae037d4f1234aff587d903d93ba3af225c27ddc9ccac",
+		"972570f4313d47fc96f7c02d5594d77d46f91e949808825b3d31f029e8296405",
+		"9581145cca04a0fb94cedce752c8f0370861916d2a94e7c647c5373ce6a4c8f5",
+		"f40c93e023ef494b1c3079b2d10ef67f3170740495ce2cc57f8ee4b0618b8ee5",
+		"9b52672742d637a32add056dfd6d8792f2a33c2e69dafabea09b960bc61e230a",
+	};
+
+	char *R[] = {
+		"d19ff48b324915576416097d2544f7cbdf8768b1454ad20e0baac50e211f23b0",
+		"dc23d130c6117fb5751201455e99f36f59aba1a6a21cf2d0e7481a97451d6693",
+		"9913111cff6f20c5bf453a99cd2c2019a4e749a49724a08774d14e4c113edda8",
+		"bf96b99aa49c705c910be33142017c642ff540c76349b9dab72f981fd9347f4f",
+		"1d75830cd36f4c9aa181b2c4221e87f176b7f05b7c87824e82e396c88315c407",
+		"25acc3aa9d9e84c7abf08f73fa4195acc506491d6fc37cb9074528a7db87b9d6",
+		"548886278e5ec26bed811dbb72db1e154b6f17be70deb1b210107decb1ec2a5a",
+		"288f7a1cd391842cce21f00e6f15471c04dc182fe4b14d92dc18910879799790",
+		"f5acb06c59c2b4927fb852faa07faf4b1852bbb5d06840935e849c4d293d1bad",
+		"87b93ee2fecfda54deb8dff8e426f3c72c8864991f8ec2b3205bb3b416de93d2",
+		"8acd62e8c262fa50dd9840480969f4ef70f218ebf8ef9584f199031132c6b1ce",
+		"dfaea6f297fa320b707866125c2a7d5d515b51a503bee817de9faa343cc48eeb",
+		"09f5483eccec80f9d104815a1be9cc1a8e5b12b6eb482a65c6907b7480cf4f19",
+		"5cc8aa7c35743ec0c23dde88dabd5e4fcd0192d2116f6926fef788cddb754e73",
+		"06108e525f845d0155bf60193222b3219c98e3d49424c2fb2a0987f825c17959",
+	};
+
+	int results[] = { 3, 2, 4, 0, 0, 2, 4, 1, 3, 2, 3, 1, 4, 1, 0 };
+
+	char *S[] = {
+		"a3e81e59311cdfff2d4784949f7a2cb50ba6c3a91fa54710568e61aca3e847c6",
+		"d6ce7708c18dbf35d4f8aa7240922dc6823f2e7058cbc1484fcad1599db5018c",
+		"9467cd4cd21ecb56b0cab0a9a453b43386845459127a952421f5c6382866c5cc",
+		"17c55095819089c2e03b9cd415abdf12444e323075d98f31920b9e0f57ec871c",
+		"cb2acb01dac96efc53a32d4a0d85d0c2e48955214783ecf50a4f0414a319c05a",
+		"9b21d5b5259ed3f2ef07dfec6cc90d3a37855d1ce122a85ba6a333f307d31537",
+		"e93bfebd2f14f3d827ca32b464be6e69187f5edbd52def4f96599c37d58eee75",
+		"247b3c4e89a3bcadfea73c7bfd361def43715fa382b8c3edf4ae15d6e55e9979",
+		"049dab79c89cc02f1484c437f523e080a75f134917fda752f2d5ca397addfe5d",
+		"4044a24df85be0cc76f21a4430b75b8e77b932a87f51e4eccbc45c263ebf8f66",
+		"cfca7ed3d4347fb2a29e526b43c348ae1ce6c60d44f3191b6d8ea3a2d9c92154",
+		"8f780ad713f9c3e5a4f7fa4c519833dfefc6a7432389b1e4af463961f09764f2",
+		"a4f90e560c5e4eb8696cb276e5165b6a9d486345dedfb094a76e8442d026378d",
+		"9c9c045ebaa1b828c32f82ace0d18daebf5e156eb7cbfdc1eff4399a8a900ae7",
+		"62b5cdd591e5b507e560167ba8f6f7cda74673eb315680cb89ccbc4eec477dce",
+	};
+
 	struct tc_sha256_state_struct sha256_ctx;
-	int rc;
 
-	rc = verify_vectors(&sha256_ctx, verify_msg, verify_qx, verify_qy,
-			    verify_r, verify_s, verify_names,
-			    verify_results, 15, verbose);
+	printf("Test #2: ECDSAvrfy ");
+	printf("NIST-p256, SHA2-256\n");
 
-	return rc;
+	return vrfy_vectors(&sha256_ctx, Msg, Qx, Qy, R, S, results, 15, verbose);
 }
 
-int montecarlo_signverify(u32_t num, int verbose)
+int montecarlo_signverify(int num_tests, bool verbose)
 {
-	EccPoint l_public;
-	u32_t l_private[NUM_ECC_DIGITS];
+	printf("Test #3: Monte Carlo (%d Randomized EC-DSA signatures) ", num_tests);
+	printf("NIST-p256, SHA2-256\n  ");
+	int i;
+	uint8_t private[NUM_ECC_BYTES];
+	uint8_t public[2 * NUM_ECC_BYTES];
+	uint8_t hash[NUM_ECC_BYTES];
+	unsigned int hash_words[NUM_ECC_WORDS];
+	uint8_t sig[2 * NUM_ECC_BYTES];
 
-	u32_t l_hash[NUM_ECC_DIGITS];
-	u32_t l_random[2 * NUM_ECC_DIGITS];
+	const struct uECC_Curve_t *curve = uECC_secp256r1();
 
-	u32_t r[NUM_ECC_DIGITS];
-	u32_t s[NUM_ECC_DIGITS];
-	int rc = TC_FAIL;
-
-	ARG_UNUSED(verbose);
-
-	for (u32_t i = 0; i < num; ++i) {
-		random_bytes(l_random, 2 * NUM_ECC_DIGITS);
-		ecc_make_key(&l_public, l_private, l_random);
-
-		random_bytes(l_hash, NUM_ECC_DIGITS);
-		random_bytes(l_random, 2 * NUM_ECC_DIGITS);
-
-		if (!ecdsa_sign(r, s, l_private, l_random, l_hash)) {
-			TC_PRINT("ecdsa_sign() failed\n");
-			rc = TC_FAIL;
-			goto exit_test;
+	for (i = 0; i < num_tests; ++i) {
+		if (verbose) {
+			TC_PRINT(".");
 		}
 
-		if (ecc_valid_public_key(&l_public) != 0) {
-			TC_PRINT("Not a valid public key!\n");
-			rc = TC_FAIL;
-			goto exit_test;
+		uECC_generate_random_int(hash_words, curve->n, BITS_TO_WORDS(curve->num_n_bits));
+		uECC_vli_nativeToBytes(hash, NUM_ECC_BYTES, hash_words);
+
+		if (!uECC_make_key(public, private, curve)) {
+			TC_ERROR("uECC_make_key() failed\n");
+			return TC_FAIL;
 		}
 
-		if (!ecdsa_verify(&l_public, l_hash, r, s)) {
-			TC_PRINT("ecdsa_verify() failed\n");
-			rc = TC_FAIL;
-			goto exit_test;
+		if (!uECC_sign(private, hash, sizeof(hash), sig, curve)) {
+			TC_ERROR("uECC_sign() failed\n");
+			return TC_FAIL;
+		}
+
+		if (!uECC_verify(public, hash, sizeof(hash), sig, curve)) {
+			TC_ERROR("uECC_verify() failed\n");
+			return TC_FAIL;
+		}
+		if (verbose) {
+			printf(".");
 		}
 	}
-
-	rc = TC_PASS;
-
-exit_test:
-	return rc;
+	TC_PRINT("\n");
+	return TC_PASS;
 }
 
-#define RC_STR(rc) (rc == TC_PASS ? PASS : FAIL)
+int default_CSPRNG(u8_t *dest, unsigned int size)
+{
+	/* This is not a CSPRNG, but it's the only thing available in the
+	 * system at this point in time.  */
+
+	while (size) {
+		u32_t len = size >= sizeof(u32_t) ? sizeof(u32_t) : size;
+		u32_t rv = sys_rand32_get();
+
+		memcpy(dest, &rv, len);
+		dest += len;
+		size -= len;
+	}
+
+	return 1;
+}
 
 int main(void)
 {
-	int verbose = 0;
-	int rc;
+	unsigned int result = TC_PASS;
 
-	TC_START("TinyCrypt ECC DSA test");
+	TC_START("Performing ECC-DSA tests:");
+	/* Setup of the Cryptographically Secure PRNG. */
+	uECC_set_rng(&default_CSPRNG);
 
-	random_start(NULL);
+	bool verbose = true;
 
-	rc = cavp_sign(verbose);
-	TC_PRINT("[%s] Test #1: ECDSAsign - NIST-p256, SHA2-256\n",
-		 RC_STR(rc));
-	if (rc != TC_PASS) {
-		goto exit_test;
+	TC_PRINT("Performing cavp_sign test:\n");
+	result = cavp_sign(verbose);
+	if (result == TC_FAIL) { /* terminate test */
+		TC_ERROR("cavp_sign test failed.\n");
+		goto exitTest;
 	}
-
-	rc = cavp_verify(verbose);
-	TC_PRINT("[%s] Test #2: ECDSAvrfy - NIST-p256, SHA2-256\n", RC_STR(rc));
-	if (rc != TC_PASS) {
-		goto exit_test;
+	TC_PRINT("Performing cavp_verify test:\n");
+	result = cavp_verify(verbose);
+	if (result == TC_FAIL) {
+		TC_ERROR("cavp_verify test failed.\n");
+		goto exitTest;
 	}
-
-	rc = montecarlo_signverify(10, verbose);
-	TC_PRINT("[%s] Test #3: Monte Carlo (Randomized EC-DSA signatures) - "
-		 "NIST-p256, SHA2-256\n", RC_STR(rc));
-	if (rc != TC_PASS) {
-		goto exit_test;
+	TC_PRINT("Performing montecarlo_signverify test:\n");
+	result = montecarlo_signverify(10, verbose);
+	if (result == TC_FAIL) {
+		TC_ERROR("montecarlo_signverify test failed.\n");
+		goto exitTest;
 	}
 
 	TC_PRINT("\nAll ECC-DSA tests succeeded.\n");
-	rc = TC_PASS;
 
-exit_test:
-	TC_END_RESULT(rc);
-	TC_END_REPORT(rc);
+exitTest:
+	TC_END_RESULT(result);
+	TC_END_REPORT(result);
 
-	return rc;
+	return 0;
 }

--- a/tests/crypto/ecc_dsa/src/test_ecc_utils.c
+++ b/tests/crypto/ecc_dsa/src/test_ecc_utils.c
@@ -1,7 +1,30 @@
 /* test_ecc_utils.c - TinyCrypt common functions for ECC tests */
 
+/* Copyright (c) 2014, Kenneth MacKay
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *  * Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *  * Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.*/
+
 /*
- *  Copyright (C) 2015 by Intel Corporation, All Rights Reserved.
+ *  Copyright (C) 2017 by Intel Corporation, All Rights Reserved.
  *
  *  Redistribution and use in source and binary forms, with or without
  *  modification, are permitted provided that the following conditions are met:
@@ -33,45 +56,17 @@
  *
  */
 
-#include <zephyr.h>
-#include <drivers/rand32.h>
-
-#include <tinycrypt/ecc.h>
-#include <tinycrypt/ecc_dh.h>
 #include <test_ecc_utils.h>
-#include <test_utils.h>
 #include <tinycrypt/constants.h>
 
+#include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
-#include <errno.h>
+#include <stdbool.h>
 
-int random_start(const char *fn)
+int hex2int(char hex)
 {
-	(void)fn;
-
-	return 0;
-}
-
-int random_end(void)
-{
-	return 0;
-}
-
-int random_bytes(u32_t *out, size_t len)
-{
-	size_t i;
-
-	for (i = 0; i < len; i++) {
-		out[i] = sys_rand32_get();
-	}
-
-	return i == len ? 0 : -EINVAL;
-}
-
-int hex_to_num(char hex)
-{
-	u8_t dec;
+	uint8_t dec;
 
 	if ('0' <= hex && hex <= '9') {
 		dec = hex - '0';
@@ -79,7 +74,7 @@ int hex_to_num(char hex)
 		dec = hex - 'a' + 10;
 	} else if ('A' <= hex && hex <= 'F') {
 		dec = hex - 'A' + 10;
-	} else {
+	} else                                                                                                                    {
 		return -1;
 	}
 
@@ -90,20 +85,21 @@ int hex_to_num(char hex)
  * Convert hex string to byte string
  * Return number of bytes written to buf, or 0 on error
  */
-int hex_to_num_str(u8_t *buf, const size_t buflen, const char *hex,
-		   const size_t hexlen)
+int hex2bin(uint8_t *buf, const size_t buflen, const char *hex,
+	    const size_t hexlen)
 {
+
 	int dec;
 
 	if (buflen < hexlen / 2 + hexlen % 2) {
-		return 0;
+		return false;
 	}
 
 	/* if hexlen is uneven, insert leading zero nibble */
 	if (hexlen % 2) {
-		dec = hex_to_num(hex[0]);
+		dec = hex2int(hex[0]);
 		if (dec == -1) {
-			return 0;
+			return false;
 		}
 		buf[0] = dec;
 		buf++;
@@ -112,15 +108,15 @@ int hex_to_num_str(u8_t *buf, const size_t buflen, const char *hex,
 
 	/* regular hex conversion */
 	for (size_t i = 0; i < hexlen / 2; i++) {
-		dec = hex_to_num(hex[2 * i]);
+		dec = hex2int(hex[2 * i]);
 		if (dec == -1) {
-			return 0;
+			return false;
 		}
 		buf[i] = dec << 4;
 
-		dec = hex_to_num(hex[2 * i + 1]);
+		dec = hex2int(hex[2 * i + 1]);
 		if (dec == -1) {
-			return 0;
+			return false;
 		}
 		buf[i] += dec;
 	}
@@ -130,123 +126,142 @@ int hex_to_num_str(u8_t *buf, const size_t buflen, const char *hex,
 /*
  * Convert hex string to zero-padded nanoECC scalar
  */
-int str_to_scalar(u32_t *scalar, u32_t num_word32, char *str)
+void string2scalar(unsigned int *scalar, unsigned int num_word32, char *str)
 {
-	u32_t num_bytes = 4 * num_word32;
-	u8_t tmp[num_bytes];
-	size_t hexlen = strlen(str);
-	int padding;
-	int rc;
 
-	padding = 2 * num_bytes - strlen(str);
-	if (padding < 0) {
-		TC_PRINT("Error: 2*num_bytes(%d) < strlen(hex) (%zu)\n",
-			 2 * num_bytes, strlen(str));
-		return TC_FAIL;
+	unsigned int num_bytes = 4 * num_word32;
+	uint8_t tmp[num_bytes];
+	size_t hexlen = strlen(str);
+
+	int padding;
+
+	if (0 > (padding = 2 * num_bytes - strlen(str))) {
+		printf("Error: 2 * num_bytes(%d) < strlen(hex) (%zu)\n",
+		       2 * num_bytes, strlen(str));
+		k_panic();
 	}
 
 	memset(tmp, 0, padding / 2);
 
-	rc = hex_to_num_str(tmp + padding / 2, num_bytes, str, hexlen);
-	if (rc == 0) {
-		return TC_FAIL;
+	if (false == hex2bin(tmp + padding / 2, num_bytes, str, hexlen)) {
+		k_panic();
+	}
+	uECC_vli_bytesToNative(scalar, tmp, num_bytes);
+
+}
+
+void vli_print_bytes(uint8_t *vli, unsigned int size)
+{
+	for (unsigned i = 0; i < size; ++i) {
+		printf("%02X ", (unsigned)vli[i]);
+	}
+}
+
+void print_ecc_scalar(const char *label, const unsigned int *p_vli,
+		      unsigned int num_word32)
+{
+	unsigned int i;
+
+	if (label) {
+		printf("%s = { ", label);
 	}
 
-	ecc_bytes2native(scalar, tmp);
+	for (i = 0; i < num_word32 - 1; ++i) {
+		printf("0x%08lX, ", (unsigned long)p_vli[i]);
+	}
+	printf("0x%08lX", (unsigned long)p_vli[i]);
 
+	if (label) {
+		printf(" };\n");
+	}
+}
+
+int check_ecc_result(const int num, const char *name,
+		     const unsigned int *expected,
+		     const unsigned int *computed,
+		     const unsigned int num_word32, const bool verbose)
+{
+	uint32_t num_bytes = 4 * num_word32;
+
+	if (memcmp(computed, expected, num_bytes)) {
+		TC_PRINT("\n  Vector #%02d check %s - FAILURE:\n\n", num, name);
+		print_ecc_scalar("Expected", expected, num_word32);
+		print_ecc_scalar("Computed", computed, num_word32);
+		TC_PRINT("\n");
+		return TC_FAIL;
+	}
+	if (verbose) {
+		TC_PRINT("  Vector #%02d check %s - success\n", num, name);
+	}
 	return TC_PASS;
 }
 
-void vli_print(u32_t *p_vli, unsigned int p_size)
-{
-	while (p_size) {
-		TC_PRINT("%08X ", (unsigned)p_vli[p_size - 1]);
-		--p_size;
-	}
-}
-
-int check_code(const int num, const char *name, const int expected,
+int check_code(const int num, const int expected,
 	       const int computed, const int verbose)
 {
+
 	if (expected != computed) {
-		TC_PRINT("\nVector #%02d check %s - FAILURE:\n", num, name);
-		TC_PRINT("\nExpected: %d, computed: %d\n\n", expected,
-			 computed);
+		TC_ERROR("\n  Vector #%02d check - FAILURE:\n", num);
+		TC_ERROR("\n  Expected: %d, computed: %d\n\n", expected, computed);
 		return TC_FAIL;
 	}
 
 	if (verbose) {
-		TC_PRINT("Vector #%02d check %s - success (%d=%d)\n", num, name,
+		TC_PRINT("  Vector #%02d check - success (%d=%d)\n", num,
 			 expected, computed);
 	}
 
 	return TC_PASS;
 }
 
-int check_ecc_result(const int num, const char *name, const u32_t *expected,
-		     const u32_t *computed, const u32_t num_word32,
-		     int verbose)
-{
-	u32_t num_bytes = 4 * num_word32;
-
-	if (memcmp(computed, expected, num_bytes)) {
-		TC_PRINT("\n  Vector #%02d check %s - FAILURE\n", num, name);
-		return TC_FAIL;
-	}
-	if (verbose) {
-		TC_PRINT("  Vector #%02d check %s - success\n", num, name);
-	}
-
-	return TC_PASS;
-}
-
 /* Test ecc_make_keys, and also as keygen part of other tests */
-int keygen_vectors(EccPoint *pub, char **d_vec, char **qx_vec, char **qy_vec,
-		   int tests, int verbose)
+int keygen_vectors(char **d_vec, char **qx_vec, char **qy_vec, int tests,
+		   bool verbose)
 {
-	u32_t seed[2 * NUM_ECC_DIGITS];
-	u32_t prv[NUM_ECC_DIGITS];
+
+	unsigned int pub[2 * NUM_ECC_WORDS];
+	unsigned int d[NUM_ECC_WORDS];
+	unsigned int prv[NUM_ECC_WORDS];
+	unsigned int result = TC_PASS;
 
 	/* expected outputs (converted input vectors) */
-	EccPoint exp_pub;
-	u32_t exp_prv[NUM_ECC_DIGITS];
-
-	int rc;
+	unsigned int exp_pub[2 * NUM_ECC_WORDS];
+	unsigned int exp_prv[NUM_ECC_WORDS];
 
 	for (int i = 0; i < tests; i++) {
-
-		str_to_scalar(exp_prv, NUM_ECC_DIGITS, d_vec[i]);
-		str_to_scalar(exp_pub.x, NUM_ECC_DIGITS, qx_vec[i]);
-		str_to_scalar(exp_pub.y, NUM_ECC_DIGITS, qy_vec[i]);
+		string2scalar(exp_prv, NUM_ECC_WORDS, d_vec[i]);
+		string2scalar(exp_pub, NUM_ECC_WORDS, qx_vec[i]);
+		string2scalar(exp_pub + NUM_ECC_WORDS, NUM_ECC_WORDS, qy_vec[i]);
 
 		/*
 		 * Feed prvkey vector as padded random seed into ecc_make_key.
-		 * Internal mod-reduction will be zero-op and generate correct
-		 * prv/pub
+		 * Internal mod-reduction will be zero-op and generate correct prv/pub
 		 */
-		memset(seed, 0, 2 * NUM_ECC_BYTES);
-		str_to_scalar(seed, NUM_ECC_DIGITS, d_vec[i]);
-		ecc_make_key(pub, prv, seed);
+		memset(d, 0, NUM_ECC_WORDS);
+		string2scalar(d, NUM_ECC_WORDS, d_vec[i]);
+
+		uint8_t pub_bytes[2 * NUM_ECC_BYTES];
+		uint8_t prv_bytes[NUM_ECC_BYTES];
+
+		uECC_make_key_with_d(pub_bytes, prv_bytes, d, uECC_secp256r1());
+
+		uECC_vli_bytesToNative(prv, prv_bytes, NUM_ECC_BYTES);
+		uECC_vli_bytesToNative(pub, pub_bytes, NUM_ECC_BYTES);
+		uECC_vli_bytesToNative(pub + NUM_ECC_WORDS, pub_bytes + NUM_ECC_BYTES, NUM_ECC_BYTES);
 
 		/* validate correctness of vector conversion and make_key() */
-		rc = check_ecc_result(i, "prv  ", exp_prv, prv,
-				      NUM_ECC_DIGITS, verbose);
-		if (rc != TC_PASS) {
-			goto exit_test;
+		result = check_ecc_result(i, "prv  ", exp_prv, prv,  NUM_ECC_WORDS, verbose);
+		if (result == TC_FAIL) {
+			return result;
 		}
-		rc = check_ecc_result(i, "pub.x", exp_pub.x, pub->x,
-				      NUM_ECC_DIGITS, verbose);
-		if (rc != TC_PASS) {
-			goto exit_test;
+		result = check_ecc_result(i, "pub.x", exp_pub, pub,  NUM_ECC_WORDS, verbose);
+		if (result == TC_FAIL) {
+			return result;
 		}
-		rc = check_ecc_result(i, "pub.y", exp_pub.y, pub->y,
-				      NUM_ECC_DIGITS, verbose);
-		if (rc != TC_PASS) {
-			goto exit_test;
+		result = check_ecc_result(i, "pub.y", exp_pub + NUM_ECC_WORDS, pub + NUM_ECC_WORDS,  NUM_ECC_WORDS, verbose);
+		if (result == TC_FAIL) {
+			return result;
 		}
 	}
-
-	rc = TC_PASS;
-exit_test:
-	return rc;
+	return result;
 }

--- a/tests/include/test_ecc_utils.h
+++ b/tests/include/test_ecc_utils.h
@@ -1,7 +1,30 @@
 /*  test_ecc_utils.h - TinyCrypt interface to common functions for ECC tests */
 
+/* Copyright (c) 2014, Kenneth MacKay
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *  * Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *  * Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.*/
+
 /*
- *  Copyright (C) 2015 by Intel Corporation, All Rights Reserved.
+ *  Copyright (C) 2017 by Intel Corporation, All Rights Reserved.
  *
  *  Redistribution and use in source and binary forms, with or without
  *  modification, are permitted provided that the following conditions are met:
@@ -35,33 +58,45 @@
 #ifndef __TEST_ECC_UTILS_H__
 #define __TEST_ECC_UTILS_H__
 
-#include <stdlib.h>
-#include <zephyr/types.h>
-#include <tinycrypt/constants.h>
+#define ENABLE_TESTS 1
 
-int keygen_vectors(EccPoint  *point, char **d_vec, char **qx_vec, char **qy_vec,
-		   int tests, int verbose);
+#include <tinycrypt/ecc_dh.h>
+#include <tinycrypt/ecc.h>
+#include <test_utils.h>
 
-int random_start(const char *fn);
-int random_end(void);
-int random_bytes(u32_t *out, size_t len);
+int hex2int(char hex);
 
-void string2host(u32_t *native, const u8_t *bytes, size_t len);
 
-int hex_to_num(char hex);
+/*
+ * Convert hex string to byte string
+ * Return number of bytes written to buf, or 0 on error
+ */
+int hex2bin(uint8_t *buf, const size_t buflen, const char *hex,
+	    const size_t hexlen);
 
-int hex_to_num_str(u8_t *buf, const size_t buflen, const char *hex,
-		   const size_t hexlen);
+/*
+ * Convert hex string to zero-padded nanoECC scalar
+ */
+void string2scalar(unsigned int *scalar, unsigned int num_word32, char *str);
 
-int str_to_scalar(u32_t *scalar, u32_t num_word32, char *str);
 
-void vli_print(u32_t *p_vli, unsigned int p_size);
+void print_ecc_scalar(const char *label, const unsigned int *p_vli,
+		      unsigned int num_word32);
 
-int check_code(const int num, const char *name, const int expected,
+int check_ecc_result(const int num, const char *name,
+		     const unsigned int *expected,
+		     const unsigned int *computed,
+		     const unsigned int num_word32, const bool verbose);
+
+/* Test ecc_make_keys, and also as keygen part of other tests */
+int keygen_vectors(char **d_vec, char **qx_vec, char **qy_vec, int tests, bool verbose);
+
+void vli_print_bytes(uint8_t *vli, unsigned int size);
+
+
+int check_code(const int num, const int expected,
 	       const int computed, const int verbose);
 
-int check_ecc_result(const int num, const char *name, const u32_t *expected,
-		     const u32_t *computed, const u32_t num_word32,
-		     int verbose);
 
-#endif
+#endif /* __TEST_ECC_UTILS_H__ */
+


### PR DESCRIPTION
Version 0.2.7 of this library has been released on June 30th, and this
patch updates the library from version 0.2.6.  A summary of changes
is available at the official repository at:

	https://github.com/01org/tinycrypt/releases/tag/v0.2.7

There were some API changes in this version, so some tests are not
building: ccm_mode, ecc_dh, and ecc_dsa.  Fixes to these tests and
subsystems affected by the changes will be provided.