### PR TITLE
SPI initialization fixes

### DIFF
--- a/drivers/spi/spi_dw.c
+++ b/drivers/spi/spi_dw.c
@@ -418,7 +418,7 @@ int spi_dw_init(struct device *dev)
 
 	SYS_LOG_DBG("Designware SPI driver initialized on device: %p", dev);
 
-	spi_context_release(&spi->ctx, 0);
+	spi_context_unlock_unconditionally(&spi->ctx);
 
 	return 0;
 }

--- a/drivers/spi/spi_ll_stm32.c
+++ b/drivers/spi/spi_ll_stm32.c
@@ -351,7 +351,7 @@ static int spi_stm32_init(struct device *dev)
 	cfg->irq_config(dev);
 #endif
 
-	spi_context_release(&data->ctx, 0);
+	spi_context_unlock_unconditionally(&data->ctx);
 
 	return 0;
 }


### PR DESCRIPTION
Fixes (well, once fix applied twice) to the init routines for new-style SPI drivers. Please see the commit log for a083c37 for details.

@ldts, @tbursztyka, am I missing something?
