### PR TITLE
dts: arm: Add soc container node missing properties

### DIFF
--- a/dts/arm/atmel/sam3x.dtsi
+++ b/dts/arm/atmel/sam3x.dtsi
@@ -24,6 +24,11 @@
 	};
 
 	soc {
+		compatible = "simple-bus";
+		#address-cells = <1>;
+		#size-cells = <1>;
+		ranges;
+
 		uart0: uart@400E0800 {
 			compatible = "atmel,sam-uart";
 			reg = <0x400E0800 0x124>;

--- a/dts/arm/atmel/sam4s.dtsi
+++ b/dts/arm/atmel/sam4s.dtsi
@@ -24,6 +24,11 @@
 	};
 
 	soc {
+		compatible = "simple-bus";
+		#address-cells = <1>;
+		#size-cells = <1>;
+		ranges;
+
 		uart0: uart@400E0600 {
 			compatible = "atmel,sam-uart";
 			reg = <0x400E0600 0x200>;

--- a/dts/arm/atmel/same70.dtsi
+++ b/dts/arm/atmel/same70.dtsi
@@ -26,6 +26,11 @@
 	};
 
 	soc {
+		compatible = "simple-bus";
+		#address-cells = <1>;
+		#size-cells = <1>;
+		ranges;
+
 		uart0: uart@400E0800 {
 			compatible = "atmel,sam-uart";
 			reg = <0x400E0800 0x100>;

--- a/dts/arm/nordic/nrf51822.dtsi
+++ b/dts/arm/nordic/nrf51822.dtsi
@@ -17,6 +17,11 @@
 	};
 
 	soc {
+		compatible = "simple-bus";
+		#address-cells = <1>;
+		#size-cells = <1>;
+		ranges;
+
 		uart0: uart@40002000 {
 			compatible = "nordic,nrf-uart";
 			reg = <0x40002000 0x1000>;

--- a/dts/arm/nordic/nrf52832.dtsi
+++ b/dts/arm/nordic/nrf52832.dtsi
@@ -17,6 +17,11 @@
 	};
 
 	soc {
+		compatible = "simple-bus";
+		#address-cells = <1>;
+		#size-cells = <1>;
+		ranges;
+
 		uart0: uart@40002000 {
 			compatible = "nordic,nrf-uarte", "nordic,nrf-uart";
 			reg = <0x40002000 0x1000>;

--- a/dts/arm/nordic/nrf52840.dtsi
+++ b/dts/arm/nordic/nrf52840.dtsi
@@ -17,6 +17,11 @@
 	};
 
 	soc {
+		compatible = "simple-bus";
+		#address-cells = <1>;
+		#size-cells = <1>;
+		ranges;
+
 		uart0: uart@40002000 {
 			compatible = "nordic,nrf-uarte", "nordic,nrf-uart";
 			reg = <0x40002000 0x1000>;

--- a/dts/arm/nxp/nxp_k6x.dtsi
+++ b/dts/arm/nxp/nxp_k6x.dtsi
@@ -13,6 +13,10 @@
 	};
 
 	soc {
+		compatible = "simple-bus";
+		#address-cells = <1>;
+		#size-cells = <1>;
+		ranges;
 
 		mpu@4000d000 {
 			compatible = "nxp,k64f-mpu";

--- a/dts/arm/nxp/nxp_kl25z.dtsi
+++ b/dts/arm/nxp/nxp_kl25z.dtsi
@@ -13,6 +13,11 @@
 	};
 
 	soc {
+		compatible = "simple-bus";
+		#address-cells = <1>;
+		#size-cells = <1>;
+		ranges;
+
 		flash0: flash@0 {
 			reg = <0 0x20000>;
 		};

--- a/dts/arm/nxp/nxp_kw40z.dtsi
+++ b/dts/arm/nxp/nxp_kw40z.dtsi
@@ -13,6 +13,11 @@
 	};
 
 	soc {
+		compatible = "simple-bus";
+		#address-cells = <1>;
+		#size-cells = <1>;
+		ranges;
+
 		mcg: clock-controller@40064000 {
 			compatible = "nxp,kw41z-mcg";
 			reg = <0x40064000 0x13>;

--- a/dts/arm/nxp/nxp_kw41z.dtsi
+++ b/dts/arm/nxp/nxp_kw41z.dtsi
@@ -13,6 +13,11 @@
 	};
 
 	soc {
+		compatible = "simple-bus";
+		#address-cells = <1>;
+		#size-cells = <1>;
+		ranges;
+
 		mcg: clock-controller@40064000 {
 			compatible = "nxp,kw41z-mcg";
 			reg = <0x40064000 0x13>;

--- a/dts/arm/st/stm32f103Xb.dtsi
+++ b/dts/arm/st/stm32f103Xb.dtsi
@@ -20,6 +20,11 @@
 	};
 
 	soc {
+		compatible = "simple-bus";
+		#address-cells = <1>;
+		#size-cells = <1>;
+		ranges;
+
 		usart1: serial@40013800 {
 			compatible = "st,stm32-usart", "st,stm32-uart";
 			reg = <0x40013800 0x400>;

--- a/dts/arm/st/stm32f103Xe.dtsi
+++ b/dts/arm/st/stm32f103Xe.dtsi
@@ -20,6 +20,11 @@
 	};
 
 	soc {
+		compatible = "simple-bus";
+		#address-cells = <1>;
+		#size-cells = <1>;
+		ranges;
+
 		usart1: serial@40013800 {
 			compatible = "st,stm32-usart", "st,stm32-uart";
 			reg = <0x40013800 0x400>;

--- a/dts/arm/st/stm32f107.dtsi
+++ b/dts/arm/st/stm32f107.dtsi
@@ -17,6 +17,11 @@
 	};
 
 	soc {
+		compatible = "simple-bus";
+		#address-cells = <1>;
+		#size-cells = <1>;
+		ranges;
+
 		usart1: serial@40013800 {
 			compatible = "st,stm32-usart", "st,stm32-uart";
 			reg = <0x40013800 0x400>;

--- a/dts/arm/st/stm32f334.dtsi
+++ b/dts/arm/st/stm32f334.dtsi
@@ -17,6 +17,11 @@
 	};
 
 	soc {
+		compatible = "simple-bus";
+		#address-cells = <1>;
+		#size-cells = <1>;
+		ranges;
+
 		usart1: serial@40013800 {
 			compatible = "st,stm32-usart", "st,stm32-uart";
 			reg = <0x40013800 0x400>;

--- a/dts/arm/st/stm32f373.dtsi
+++ b/dts/arm/st/stm32f373.dtsi
@@ -17,6 +17,11 @@
 	};
 
 	soc {
+		compatible = "simple-bus";
+		#address-cells = <1>;
+		#size-cells = <1>;
+		ranges;
+
 		usart1: serial@40013800 {
 			compatible = "st,stm32-usart", "st,stm32-uart";
 			reg = <0x40013800 0x400>;

--- a/dts/arm/st/stm32f4.dtsi
+++ b/dts/arm/st/stm32f4.dtsi
@@ -17,6 +17,11 @@
 	};
 
 	soc {
+		compatible = "simple-bus";
+		#address-cells = <1>;
+		#size-cells = <1>;
+		ranges;
+
 		usart1: serial@40011000 {
 			compatible = "st,stm32-usart", "st,stm32-uart";
 			reg = <0x40011000 0x400>;

--- a/dts/arm/st/stm32l432.dtsi
+++ b/dts/arm/st/stm32l432.dtsi
@@ -17,6 +17,11 @@
 	};
 
 	soc {
+		compatible = "simple-bus";
+		#address-cells = <1>;
+		#size-cells = <1>;
+		ranges;
+
 		usart1: serial@40013800 {
 			compatible = "st,stm32-usart", "st,stm32-uart";
 			reg = <0x40013800 0x400>;

--- a/dts/arm/st/stm32l475.dtsi
+++ b/dts/arm/st/stm32l475.dtsi
@@ -17,6 +17,11 @@
 	};
 
 	soc {
+		compatible = "simple-bus";
+		#address-cells = <1>;
+		#size-cells = <1>;
+		ranges;
+
 		usart1: serial@40013800 {
 			compatible = "st,stm32-usart", "st,stm32-uart";
 			reg = <0x40013800 0x400>;

--- a/dts/arm/ti/cc2650.dtsi
+++ b/dts/arm/ti/cc2650.dtsi
@@ -7,22 +7,27 @@
 #include "armv7-m.dtsi"
 
 / {
+	cpus {
+		cpu@0 {
+			compatible = "arm,cortex-m3";
+		};
+	};
+
+	sram0: memory {
+		compatible = "sram";
+		reg = <0x20000000 0x5000>;
+	};
+
+	flash0: serial-flash {
+		compatible = "serial-flash";
+		reg = <0x0 0x20000>;
+	};
+
 	soc {
-		cpus {
-			cpu@0 {
-				compatible = "arm,cortex-m3";
-			};
-		};
-
-		sram0: memory {
-			compatible = "sram";
-			reg = <0x20000000 0x5000>;
-		};
-
-		flash0: serial-flash {
-			compatible = "serial-flash";
-			reg = <0x0 0x20000>;
-		};
+		compatible = "simple-bus";
+		#address-cells = <1>;
+		#size-cells = <1>;
+		ranges;
 
 		gpioa: gpio@40022000 {
 			compatible = "ti,cc2650-gpio";

--- a/dts/arm/ti/cc32xx.dtsi
+++ b/dts/arm/ti/cc32xx.dtsi
@@ -31,6 +31,11 @@
 #endif
 
 	soc {
+		compatible = "simple-bus";
+		#address-cells = <1>;
+		#size-cells = <1>;
+		ranges;
+
 		uart0: uart@4000C000 {
 			compatible = "ti,cc32xx-uart";
 			reg = <0x4000C000 0x4c>;

--- a/dts/arm/ti/lm3s6965.dtsi
+++ b/dts/arm/ti/lm3s6965.dtsi
@@ -17,6 +17,11 @@
 	};
 
 	soc {
+		compatible = "simple-bus";
+		#address-cells = <1>;
+		#size-cells = <1>;
+		ranges;
+
 		uart0: uart@4000C000 {
 			compatible = "ti,stellaris-uart";
 			reg = <0x4000C000 0x4c>;


### PR DESCRIPTION
This patch adds compatible, #address-cell, #size-cell and ranges
missing properties from soc container node.

Signed-off-by: Yannis Damigos <giannis.damigos@gmail.com>