### PR TITLE
doc: add python pip requirements.txt

### DIFF
--- a/doc/README.rst
+++ b/doc/README.rst
@@ -67,26 +67,11 @@ Ubuntu:
 
 .. code-block:: bash
 
-   $ sudo -E apt-get install python-pip
-   $ pip install --upgrade pip
    $ sudo -E apt-get install doxygen
-   $ pip install sphinx==1.4.4
-   $ sudo -HE pip install breathe
-   $ sudo -HE pip install sphinx-rtd-theme
-
-There is a known issue that causes docutils version 0.13 to fail with sphinx
-1.4.4.  Verify the version of docutils using:
-
-.. code-block:: bash
-
-   $ pip show docutils
-
-If this shows you've got version 0.13 of docutils installed, you can install
-the working version of docutils with:
-
-.. code-block:: bash
-
-   $ sudo -HE  pip install docutils==0.12
+   $ curl -O 'https://bootstrap.pypa.io/get-pip.py'
+   $ ./get-pip.py
+   $ rm get-pip.py
+   $ pip install -r scripts/requirements.txt
 
 
 Running the Documentation Generators

--- a/doc/getting_started/installation_linux.rst
+++ b/doc/getting_started/installation_linux.rst
@@ -54,8 +54,8 @@ Install the required packages in a Ubuntu host system with:
 
 .. code-block:: console
 
-   $ sudo apt-get install git make gcc g++ python3-ply ncurses-dev \
-	 python3-yaml dfu-util device-tree-compiler
+   $ sudo apt-get install git make gcc g++ ncurses-dev \
+	 doxygen dfu-util device-tree-compiler
 
 Install the required packages in a Fedora host system with:
 
@@ -63,8 +63,16 @@ Install the required packages in a Fedora host system with:
 
    $ sudo dnf group install "Development Tools"
    $ sudo dnf install git make gcc glibc-static \
-	 libstdc++-static python3-ply ncurses-devel \
-	 python-yaml dfu-util dtc
+	 libstdc++-static ncurses-devel \
+	 doxygen dfu-util dtc
+
+
+Install additional packages required for development with Zephyr::
+
+   $ curl -O 'https://bootstrap.pypa.io/get-pip.py'
+   $ ./get-pip.py
+   $ rm get-pip.py
+   $ pip3 install -r scripts/requirements.txt
 
 .. _zephyr_sdk:
 

--- a/doc/getting_started/installation_mac.rst
+++ b/doc/getting_started/installation_mac.rst
@@ -57,8 +57,11 @@ Install tools to build Zephyr binaries:
 
 .. code-block:: console
 
-   $ brew install dfu-util qemu dtc python3
-   $ pip3 install ply pyyaml
+   $ brew install dfu-util doxygen qemu dtc python3
+   $ curl -O 'https://bootstrap.pypa.io/get-pip.py'
+   $ ./get-pip.py
+   $ rm get-pip.py
+   $ pip3 install -r scripts/requirements.txt
 
 Install tools needed for building the toolchain (if needed):
 

--- a/doc/getting_started/installation_win.rst
+++ b/doc/getting_started/installation_win.rst
@@ -64,7 +64,7 @@ environment for Windows. Follow the steps below to set it up:
       $ ./get-pip.py
       $ rm get-pip.py
 
-      $ pip install pyaml
+      $ pip install -r scripts/requirements.txt
 
 #. Build the Device Tree Compiler (DTC)
 

--- a/scripts/requirements.txt
+++ b/scripts/requirements.txt
@@ -1,0 +1,12 @@
+breathe==4.6.0
+sphinx==1.5.5
+docutils==0.13.1
+sphinx_rtd_theme
+junit2html
+PyYAML==3.12
+ply==3.10
+hub==2.0
+pyocd
+gitlint
+pyelftools==0.24
+pykwalify


### PR DESCRIPTION
List all required modules in one file and just call pip with this file to
install all needed modules instead of listing them individually.

Signed-off-by: Anas Nashif <anas.nashif@intel.com>