### PR TITLE
add __kernel macros

### DIFF
--- a/include/arch/x86/linker.ld
+++ b/include/arch/x86/linker.ld
@@ -168,6 +168,8 @@ SECTIONS
 	KERNEL_INPUT_SECTION(.bss)
 	KERNEL_INPUT_SECTION(".bss.*")
 	KERNEL_INPUT_SECTION(COMMON)
+	*(".kernel_bss.*")
+
 	/*
 	 * As memory is cleared in words only, it is simpler to ensure the BSS
 	 * section ends on a 4 byte boundary. This wastes a maximum of 3 bytes.
@@ -187,6 +189,7 @@ SECTIONS
 	 */
 	KERNEL_INPUT_SECTION(.noinit)
 	KERNEL_INPUT_SECTION(".noinit.*")
+	*(".kernel_noinit.*")
 
 	/* All stacks go in kernel's noinit, regardless of where they
 	 * were defined.

--- a/include/toolchain/gcc.h
+++ b/include/toolchain/gcc.h
@@ -69,8 +69,7 @@ do {                                                                    \
 				"." _STRINGIFY(c))))
 #define __in_section(a, b, c) ___in_section(a, b, c)
 
-#define __in_section_unique(seg) ___in_section(seg, _FILE_PATH_HASH, \
-						      __COUNTER__)
+#define __in_section_unique(seg) ___in_section(seg, __FILE__, __COUNTER__)
 
 #ifndef __packed
 #define __packed        __attribute__((__packed__))

--- a/include/toolchain/gcc.h
+++ b/include/toolchain/gcc.h
@@ -71,6 +71,16 @@ do {                                                                    \
 
 #define __in_section_unique(seg) ___in_section(seg, __FILE__, __COUNTER__)
 
+#ifdef CONFIG_APPLICATION_MEMORY
+#define __kernel	__in_section_unique(kernel)
+#define __kernel_noinit	__in_section_unique(kernel_noinit)
+#define __kernel_bss	__in_section_unique(kernel_bss)
+#else
+#define __kernel
+#define __kernel_noinit	__noinit
+#define __kernel_bss
+#endif
+
 #ifndef __packed
 #define __packed        __attribute__((__packed__))
 #endif


### PR DESCRIPTION
This is to force the declared object to be contained within the kernel's memory space if CONFIG_APPLICATION_MEMORY is enabled.

https://jira.zephyrproject.org/browse/ZEP-2366