### PR TITLE
i2c: Fix missing Kconfig !HAS_I2C_DTS dependencies

### DIFF
--- a/drivers/i2c/Kconfig
+++ b/drivers/i2c/Kconfig
@@ -193,7 +193,7 @@ config I2C_0
 
 config I2C_0_NAME
 	string "Port 0 device name"
-	depends on I2C_0
+	depends on I2C_0 && !HAS_DTS_I2C
 	default "I2C_0"
 
 config I2C_0_DEFAULT_CFG
@@ -209,7 +209,7 @@ config I2C_0_DEFAULT_CFG
 
 config I2C_0_IRQ_PRI
 	int "Port 0 interrupt priority"
-	depends on I2C_0
+	depends on I2C_0 && !HAS_DTS_I2C
 	help
 	  IRQ priority.
 


### PR DESCRIPTION
As I2C_0 (port 0) isn't used on the STM32 platforms we didn't exclude
the related Kconfig options if DTS was enabled.  However other SoCs
(like NXP) do use I2C_0 so we need to fixup the Kconfig dependencies

Signed-off-by: Kumar Gala <kumar.gala@linaro.org>