### PR TITLE
env: Remove usage of -P in grep

### DIFF
--- a/zephyr-env.sh
+++ b/zephyr-env.sh
@@ -35,7 +35,7 @@ fi
 # .zephyrrc in your home directory. It will be automatically
 # run (if it exists) by this script.
 
-if uname | grep -q -P "MINGW"; then
+if uname | grep -q "MINGW"; then
     win_build=1
     PWD_OPT="-W"
 else


### PR DESCRIPTION
Since -P is not supported in non-GNU versions of grep, avoid using it
now that it is no longer required (no "|" operator anymore inside the
regex).

Signed-off-by: Carles Cufi <carles.cufi@nordicsemi.no>