### PR TITLE
qemu_x86: terminate emulator on fatal system error

### DIFF
--- a/arch/x86/core/sys_fatal_error_handler.c
+++ b/arch/x86/core/sys_fatal_error_handler.c
@@ -65,8 +65,16 @@ hang_system:
 	ARG_UNUSED(reason);
 #endif
 
+#ifdef CONFIG_BOARD_QEMU_X86
+	printk("Terminate emulator due to fatal kernel error\n");
+	/* Causes QEMU to exit. We passed the following on the command line:
+	 * -device isa-debug-exit,iobase=0xf4,iosize=0x04
+	 */
+	sys_out32(0, 0xf4);
+#else
 	for (;;) {
 		k_cpu_idle();
 	}
+#endif
 	CODE_UNREACHABLE;
 }

--- a/boards/x86/qemu_x86/Makefile.board
+++ b/boards/x86/qemu_x86/Makefile.board
@@ -6,6 +6,7 @@ QEMU_CPU_TYPE_x86 = qemu32
 QEMU_X86_NO_REBOOT_y =
 QEMU_X86_NO_REBOOT_  = -no-reboot
 QEMU_FLAGS_x86 = -m 8 -cpu $(QEMU_CPU_TYPE_x86) \
+		-device isa-debug-exit,iobase=0xf4,iosize=0x04 \
 		$(QEMU_X86_NO_REBOOT_$(CONFIG_REBOOT)) \
 		-nographic -vga none -display none -net none \
 		-clock dynticks -no-acpi -balloon none \


### PR DESCRIPTION
This will cause sanitycheck runs to finish more quickly
instead of sitting there waiting on a timeout. We already
do this with the Xtensa simulator.

Signed-off-by: Andrew Boie <andrew.p.boie@intel.com>