### PR TITLE
dts: Add cpus and cpu nodes missing properties

### DIFF
--- a/dts/arm/atmel/sam3x.dtsi
+++ b/dts/arm/atmel/sam3x.dtsi
@@ -8,8 +8,13 @@
 
 / {
 	cpus {
+		#address-cells = <1>;
+		#size-cells = <0>;
+
 		cpu@0 {
+			device_type = "cpu";
 			compatible = "arm,cortex-m4";
+			reg = <0>;
 		};
 	};
 

--- a/dts/arm/atmel/sam4s.dtsi
+++ b/dts/arm/atmel/sam4s.dtsi
@@ -8,8 +8,13 @@
 
 / {
 	cpus {
+		#address-cells = <1>;
+		#size-cells = <0>;
+
 		cpu@0 {
+			device_type = "cpu";
 			compatible = "arm,cortex-m4";
+			reg = <0>;
 		};
 	};
 

--- a/dts/arm/atmel/same70.dtsi
+++ b/dts/arm/atmel/same70.dtsi
@@ -10,8 +10,13 @@
 
 / {
 	cpus {
+		#address-cells = <1>;
+		#size-cells = <0>;
+
 		cpu@0 {
+			device_type = "cpu";
 			compatible = "arm,cortex-m7";
+			reg = <0>;
 		};
 	};
 

--- a/dts/arm/nordic/nrf51822.dtsi
+++ b/dts/arm/nordic/nrf51822.dtsi
@@ -3,8 +3,13 @@
 
 / {
 	cpus {
+		#address-cells = <1>;
+		#size-cells = <0>;
+
 		cpu@0 {
+			device_type = "cpu";
 			compatible = "arm,cortex-m0";
+			reg = <0>;
 		};
 	};
 

--- a/dts/arm/nordic/nrf52832.dtsi
+++ b/dts/arm/nordic/nrf52832.dtsi
@@ -3,8 +3,13 @@
 
 / {
 	cpus {
+		#address-cells = <1>;
+		#size-cells = <0>;
+
 		cpu@0 {
+			device_type = "cpu";
 			compatible = "arm,cortex-m4f";
+			reg = <0>;
 		};
 	};
 

--- a/dts/arm/nordic/nrf52840.dtsi
+++ b/dts/arm/nordic/nrf52840.dtsi
@@ -3,8 +3,13 @@
 
 / {
 	cpus {
+		#address-cells = <1>;
+		#size-cells = <0>;
+
 		cpu@0 {
+			device_type = "cpu";
 			compatible = "arm,cortex-m4f";
+			reg = <0>;
 		};
 	};
 

--- a/dts/arm/nxp/nxp_k6x.dtsi
+++ b/dts/arm/nxp/nxp_k6x.dtsi
@@ -2,8 +2,13 @@
 
 / {
 	cpus {
+		#address-cells = <1>;
+		#size-cells = <0>;
+
 		cpu@0 {
+			device_type = "cpu";
 			compatible = "arm,cortex-m4f";
+			reg = <0>;
 		};
 	};
 

--- a/dts/arm/nxp/nxp_kl25z.dtsi
+++ b/dts/arm/nxp/nxp_kl25z.dtsi
@@ -2,8 +2,13 @@
 
 / {
 	cpus {
+		#address-cells = <1>;
+		#size-cells = <0>;
+
 		cpu@0 {
+			device_type = "cpu";
 			compatible = "arm,cortex-m0+";
+			reg = <0>;
 		};
 	};
 

--- a/dts/arm/nxp/nxp_kw40z.dtsi
+++ b/dts/arm/nxp/nxp_kw40z.dtsi
@@ -2,8 +2,13 @@
 
 / {
 	cpus {
+		#address-cells = <1>;
+		#size-cells = <0>;
+
 		cpu@0 {
+			device_type = "cpu";
 			compatible = "arm,cortex-m0+";
+			reg = <0>;
 		};
 	};
 

--- a/dts/arm/nxp/nxp_kw41z.dtsi
+++ b/dts/arm/nxp/nxp_kw41z.dtsi
@@ -2,8 +2,13 @@
 
 / {
 	cpus {
+		#address-cells = <1>;
+		#size-cells = <0>;
+
 		cpu@0 {
+			device_type = "cpu";
 			compatible = "arm,cortex-m0+";
+			reg = <0>;
 		};
 	};
 

--- a/dts/arm/st/stm32f103Xb.dtsi
+++ b/dts/arm/st/stm32f103Xb.dtsi
@@ -11,6 +11,17 @@
 #include <st/mem.h>
 
 / {
+	cpus {
+		#address-cells = <1>;
+		#size-cells = <0>;
+
+		cpu@0 {
+			device_type = "cpu";
+			compatible = "arm,cortex-m3";
+			reg = <0>;
+		};
+	};
+
 	flash0: flash {
 		reg = <0x08000000 DT_FLASH_SIZE>;
 	};

--- a/dts/arm/st/stm32f103Xe.dtsi
+++ b/dts/arm/st/stm32f103Xe.dtsi
@@ -11,6 +11,17 @@
 #include <st/mem.h>
 
 / {
+	cpus {
+		#address-cells = <1>;
+		#size-cells = <0>;
+
+		cpu@0 {
+			device_type = "cpu";
+			compatible = "arm,cortex-m3";
+			reg = <0>;
+		};
+	};
+
 	flash0: flash {
 		reg = <0x08000000 DT_FLASH_SIZE>;
 	};

--- a/dts/arm/st/stm32f107.dtsi
+++ b/dts/arm/st/stm32f107.dtsi
@@ -8,6 +8,17 @@
 #include <st/mem.h>
 
 / {
+	cpus {
+		#address-cells = <1>;
+		#size-cells = <0>;
+
+		cpu@0 {
+			device_type = "cpu";
+			compatible = "arm,cortex-m3";
+			reg = <0>;
+		};
+	};
+
 	flash0: flash {
 		reg = <0x08000000 DT_FLASH_SIZE>;
 	};

--- a/dts/arm/st/stm32f303.dtsi
+++ b/dts/arm/st/stm32f303.dtsi
@@ -8,6 +8,17 @@
 #include <st/mem.h>
 
 / {
+	cpus {
+		#address-cells = <1>;
+		#size-cells = <0>;
+
+		cpu@0 {
+			device_type = "cpu";
+			compatible = "arm,cortex-m4f";
+			reg = <0>;
+		};
+	};
+
 	flash0: flash {
 		reg = <0x08000000 DT_FLASH_SIZE>;
 	};

--- a/dts/arm/st/stm32f334.dtsi
+++ b/dts/arm/st/stm32f334.dtsi
@@ -8,6 +8,17 @@
 #include <st/mem.h>
 
 / {
+	cpus {
+		#address-cells = <1>;
+		#size-cells = <0>;
+
+		cpu@0 {
+			device_type = "cpu";
+			compatible = "arm,cortex-m4f";
+			reg = <0>;
+		};
+	};
+
 	flash0: flash {
 		reg = <0x08000000 DT_FLASH_SIZE>;
 	};

--- a/dts/arm/st/stm32f373.dtsi
+++ b/dts/arm/st/stm32f373.dtsi
@@ -8,6 +8,17 @@
 #include <st/mem.h>
 
 / {
+	cpus {
+		#address-cells = <1>;
+		#size-cells = <0>;
+
+		cpu@0 {
+			device_type = "cpu";
+			compatible = "arm,cortex-m4f";
+			reg = <0>;
+		};
+	};
+
 	flash0: flash {
 		reg = <0x08000000 DT_FLASH_SIZE>;
 	};

--- a/dts/arm/st/stm32f4.dtsi
+++ b/dts/arm/st/stm32f4.dtsi
@@ -8,6 +8,17 @@
 #include <st/mem.h>
 
 / {
+	cpus {
+		#address-cells = <1>;
+		#size-cells = <0>;
+
+		cpu@0 {
+			device_type = "cpu";
+			compatible = "arm,cortex-m4f";
+			reg = <0>;
+		};
+	};
+
 	flash0: flash {
 		reg = <0x08000000 DT_FLASH_SIZE>;
 	};

--- a/dts/arm/st/stm32l432.dtsi
+++ b/dts/arm/st/stm32l432.dtsi
@@ -8,6 +8,17 @@
 #include <st/mem.h>
 
 / {
+	cpus {
+		#address-cells = <1>;
+		#size-cells = <0>;
+
+		cpu@0 {
+			device_type = "cpu";
+			compatible = "arm,cortex-m4f";
+			reg = <0>;
+		};
+	};
+
 	flash0: flash {
 		reg = <0x08000000 DT_FLASH_SIZE>;
 	};

--- a/dts/arm/st/stm32l475.dtsi
+++ b/dts/arm/st/stm32l475.dtsi
@@ -8,6 +8,17 @@
 #include <st/mem.h>
 
 / {
+	cpus {
+		#address-cells = <1>;
+		#size-cells = <0>;
+
+		cpu@0 {
+			device_type = "cpu";
+			compatible = "arm,cortex-m4f";
+			reg = <0>;
+		};
+	};
+
 	flash0: flash {
 		reg = <0x08000000 DT_FLASH_SIZE>;
 	};

--- a/dts/arm/ti/cc2650.dtsi
+++ b/dts/arm/ti/cc2650.dtsi
@@ -8,8 +8,13 @@
 
 / {
 	cpus {
+		#address-cells = <1>;
+		#size-cells = <0>;
+
 		cpu@0 {
+			device_type = "cpu";
 			compatible = "arm,cortex-m3";
+			reg = <0>;
 		};
 	};
 

--- a/dts/arm/ti/cc32xx.dtsi
+++ b/dts/arm/ti/cc32xx.dtsi
@@ -9,8 +9,13 @@
 
 / {
 	cpus {
+		#address-cells = <1>;
+		#size-cells = <0>;
+
 		cpu@0 {
+			device_type = "cpu";
 			compatible = "arm,cortex-m4";
+			reg = <0>;
 		};
 	};
 

--- a/dts/arm/ti/lm3s6965.dtsi
+++ b/dts/arm/ti/lm3s6965.dtsi
@@ -2,8 +2,13 @@
 
 / {
 	cpus {
+		#address-cells = <1>;
+		#size-cells = <0>;
+
 		cpu@0 {
+			device_type = "cpu";
 			compatible = "arm,cortex-m3";
+			reg = <0>;
 		};
 	};
 

--- a/dts/x86/intel_curie.dtsi
+++ b/dts/x86/intel_curie.dtsi
@@ -3,12 +3,19 @@
 
 / {
 	cpus {
+		#address-cells = <1>;
+		#size-cells = <0>;
+
 		cpu@0 {
+			device_type = "cpu";
 			compatible = "intel,quark";
+			reg = <0>;
 		};
 
 		cpu@1 {
+			device_type = "cpu";
 			compatible = "arc";
+			reg = <1>;
 		};
 	};
 


### PR DESCRIPTION
This patch adds #address-cell, #size-cell properties to
cpus container node and device_type, reg properties to
cpu node.

Signed-off-by: Yannis Damigos <giannis.damigos@gmail.com>