### PR TITLE
Bluetooth: controller: Privacy filtering in scanner and initiator

### DIFF
--- a/subsys/bluetooth/common/rpa.c
+++ b/subsys/bluetooth/common/rpa.c
@@ -54,7 +54,8 @@ static int ah(const u8_t irk[16], const u8_t r[3], u8_t out[3])
 	return 0;
 }
 
-#if defined(CONFIG_BLUETOOTH_SMP)
+#if defined(CONFIG_BLUETOOTH_SMP) || \
+	defined(CONFIG_BLUETOOTH_CONTROLLER_PRIVACY)
 bool bt_rpa_irk_matches(const u8_t irk[16], const bt_addr_t *addr)
 {
 	u8_t hash[3];

--- a/subsys/bluetooth/controller/ll_sw/ctrl.c
+++ b/subsys/bluetooth/controller/ll_sw/ctrl.c
@@ -1225,16 +1225,20 @@ static inline u32_t isr_rx_scan(u8_t devmatch_ok, u8_t devmatch_id,
 		pdu_adv_tx->rx_addr = pdu_adv_rx->tx_addr;
 		pdu_adv_tx->len = sizeof(struct pdu_adv_payload_connect_ind);
 #if defined(CONFIG_BLUETOOTH_CONTROLLER_PRIVACY)
-		/*@todo: obtain RPA based on rl_idx if rl_idx != NONE and
-		 * own address > 0x01 */
-		pdu_adv_tx->tx_addr = _radio.scanner.init_addr_type;
-		memcpy(&pdu_adv_tx->payload.connect_ind.init_addr[0],
-		       &_radio.scanner.init_addr[0], BDADDR_SIZE);
+		if (_radio.scanner.rpa_gen && rl_idx != FILTER_IDX_NONE) {
+			bt_addr_t *lrpa = ctrl_lrpa_get(rl_idx);
+			LL_ASSERT(lrpa);
+			pdu_adv_tx->tx_addr = 1;
+			memcpy(&pdu_adv_tx->payload.connect_ind.init_addr[0],
+			       lrpa->val, BDADDR_SIZE);
+		} else {
 #else
-		pdu_adv_tx->tx_addr = _radio.scanner.init_addr_type;
-		memcpy(&pdu_adv_tx->payload.connect_ind.init_addr[0],
-		       &_radio.scanner.init_addr[0], BDADDR_SIZE);
+		if (1) {
 #endif /* CONFIG_BLUETOOTH_CONTROLLER_PRIVACY */
+			pdu_adv_tx->tx_addr = _radio.scanner.init_addr_type;
+			memcpy(&pdu_adv_tx->payload.connect_ind.init_addr[0],
+			       &_radio.scanner.init_addr[0], BDADDR_SIZE);
+		}
 		memcpy(&pdu_adv_tx->payload.connect_ind.adv_addr[0],
 			 &pdu_adv_rx->payload.adv_ind.addr[0], BDADDR_SIZE);
 		memcpy(&pdu_adv_tx->payload.connect_ind.lldata.
@@ -1437,16 +1441,20 @@ static inline u32_t isr_rx_scan(u8_t devmatch_ok, u8_t devmatch_id,
 		pdu_adv_tx->rx_addr = pdu_adv_rx->tx_addr;
 		pdu_adv_tx->len = sizeof(struct pdu_adv_payload_scan_req);
 #if defined(CONFIG_BLUETOOTH_CONTROLLER_PRIVACY)
-		/*@todo: obtain RPA based on rl_idx if rl_idx != NONE and
-		 * own address > 0x01 */
-		pdu_adv_tx->tx_addr = _radio.scanner.init_addr_type;
-		memcpy(&pdu_adv_tx->payload.scan_req.scan_addr[0],
-		       &_radio.scanner.init_addr[0], BDADDR_SIZE);
+		if (_radio.scanner.rpa_gen && rl_idx != FILTER_IDX_NONE) {
+			bt_addr_t *lrpa = ctrl_lrpa_get(rl_idx);
+			LL_ASSERT(lrpa);
+			pdu_adv_tx->tx_addr = 1;
+			memcpy(&pdu_adv_tx->payload.scan_req.adv_addr[0],
+			       lrpa->val, BDADDR_SIZE);
+		} else {
 #else
-		pdu_adv_tx->tx_addr = _radio.scanner.init_addr_type;
-		memcpy(&pdu_adv_tx->payload.scan_req.scan_addr[0],
-		       &_radio.scanner.init_addr[0], BDADDR_SIZE);
-#endif
+		if (1) {
+#endif /* CONFIG_BLUETOOTH_CONTROLLER_PRIVACY */
+			pdu_adv_tx->tx_addr = _radio.scanner.init_addr_type;
+			memcpy(&pdu_adv_tx->payload.scan_req.scan_addr[0],
+			       &_radio.scanner.init_addr[0], BDADDR_SIZE);
+		}
 		memcpy(&pdu_adv_tx->payload.scan_req.adv_addr[0],
 		       &pdu_adv_rx->payload.adv_ind.addr[0], BDADDR_SIZE);
 

--- a/subsys/bluetooth/controller/ll_sw/ctrl.h
+++ b/subsys/bluetooth/controller/ll_sw/ctrl.h
@@ -340,9 +340,9 @@ u32_t radio_adv_disable(void);
 u32_t radio_adv_is_enabled(void);
 u32_t radio_adv_filter_pol_get(void);
 /* Downstream - Scanner */
-u32_t radio_scan_enable(u8_t type, u8_t init_addr_type,
-			u8_t *init_addr, u16_t interval,
-			u16_t window, u8_t filter_policy);
+u32_t radio_scan_enable(u8_t type, u8_t init_addr_type, u8_t *init_addr,
+			u16_t interval, u16_t window, u8_t filter_policy,
+			u8_t rpa_gen, u8_t rl_idx);
 u32_t radio_scan_disable(void);
 u32_t radio_scan_is_enabled(void);
 u32_t radio_scan_filter_pol_get(void);

--- a/subsys/bluetooth/controller/ll_sw/ll_adv.c
+++ b/subsys/bluetooth/controller/ll_sw/ll_adv.c
@@ -337,7 +337,7 @@ u32_t ll_adv_enable(u8_t enable)
 {
 	struct radio_adv_data *radio_scan_data;
 	struct radio_adv_data *radio_adv_data;
-	int rl_idx = FILTER_IDX_NONE;
+	u8_t   rl_idx = FILTER_IDX_NONE;
 	struct pdu_adv *pdu_scan;
 	struct pdu_adv *pdu_adv;
 	u32_t status;

--- a/subsys/bluetooth/controller/ll_sw/ll_filter.c
+++ b/subsys/bluetooth/controller/ll_sw/ll_filter.c
@@ -473,7 +473,8 @@ bool ctrl_rl_addr_resolve(u8_t id_addr_type, u8_t *id_addr, u8_t rl_idx)
 	}
 
 	if ((id_addr_type != 0) && ((id_addr[5] & 0xc0) == 0x40)) {
-		/*@todo: resolve address */
+		return bt_rpa_irk_matches(rl[rl_idx].local_irk,
+					  (bt_addr_t *)id_addr);
 	}
 
 	return false;

--- a/subsys/bluetooth/controller/ll_sw/ll_filter.c
+++ b/subsys/bluetooth/controller/ll_sw/ll_filter.c
@@ -221,7 +221,24 @@ u8_t *ctrl_irks_get(u8_t *count)
 	return (u8_t *)peer_irks;
 }
 
-u8_t ctrl_rl_idx(u8_t irkmatch_id)
+u8_t ctrl_rl_idx(bool whitelist, u8_t devmatch_id)
+{
+	u8_t i;
+
+	if (whitelist) {
+		LL_ASSERT(devmatch_id < ARRAY_SIZE(wl));
+		LL_ASSERT(wl[devmatch_id].taken);
+		i = wl[devmatch_id].rl_idx;
+	} else {
+		LL_ASSERT(devmatch_id < ARRAY_SIZE(rl));
+		i = devmatch_id;
+		LL_ASSERT(rl[i].taken);
+	}
+
+	return i;
+}
+
+u8_t ctrl_rl_irk_idx(u8_t irkmatch_id)
 {
 	u8_t i;
 
@@ -349,7 +366,7 @@ static void filter_rl_update(void)
 	filter_clear(&rl_filter);
 
 	for (i = 0; i < CONFIG_BLUETOOTH_CONTROLLER_RL_SIZE; i++) {
-		if (rl[i].taken && (!rl[i].pirk || rl[i].dev)) {
+		if (rl[i].taken) {
 			filter_insert(&rl_filter, i, rl[i].id_addr_type,
 				      rl[i].id_addr.val);
 		}
@@ -403,11 +420,28 @@ u8_t ll_rl_find(u8_t id_addr_type, u8_t *id_addr, u8_t *free)
 	return FILTER_IDX_NONE;
 }
 
-bool ctrl_rl_allowed(u8_t id_addr_type, u8_t *id_addr, u8_t *rl_idx)
+bool ctrl_rl_idx_allowed(u8_t irkmatch_ok, u8_t rl_idx)
+{
+	/* If AR is disabled or we don't know the device or we matched an IRK
+	 * then we're all set.
+	 */
+	if (!rl_enable || rl_idx >= ARRAY_SIZE(rl) || irkmatch_ok) {
+		return true;
+	}
+
+	LL_ASSERT(rl_idx < CONFIG_BLUETOOTH_CONTROLLER_RL_SIZE);
+	LL_ASSERT(rl[rl_idx].taken);
+
+	return !rl[rl_idx].pirk || rl[rl_idx].dev;
+}
+
+bool ctrl_rl_addr_allowed(u8_t id_addr_type, u8_t *id_addr, u8_t *rl_idx)
 {
 	int i, j;
 
-	/* If AR is disabled or we matched an IRK then we're all set */
+	/* If AR is disabled or we matched an IRK then we're all set. No hw
+	 * filters are used in this case.
+	 */
 	if (!rl_enable || *rl_idx != FILTER_IDX_NONE) {
 		return true;
 	}
@@ -429,6 +463,20 @@ bool ctrl_rl_allowed(u8_t id_addr_type, u8_t *id_addr, u8_t *rl_idx)
 	}
 
 	return true;
+}
+
+bool ctrl_rl_addr_resolve(u8_t id_addr_type, u8_t *id_addr, u8_t rl_idx)
+{
+	/* Unable to resolve if AR is disabled, no RL entry or no local IRK */
+	if (!rl_enable || rl_idx >= ARRAY_SIZE(rl) || !rl[rl_idx].lirk) {
+		return false;
+	}
+
+	if ((id_addr_type != 0) && ((id_addr[5] & 0xc0) == 0x40)) {
+		/*@todo: resolve address */
+	}
+
+	return false;
 }
 
 bool ctrl_rl_enabled(void)

--- a/subsys/bluetooth/controller/ll_sw/ll_filter.h
+++ b/subsys/bluetooth/controller/ll_sw/ll_filter.h
@@ -19,6 +19,7 @@ void ll_filters_adv_update(u8_t adv_fp);
 void ll_filters_scan_update(u8_t scan_fp);
 
 struct ll_filter *ctrl_filter_get(bool whitelist);
+bt_addr_t *ctrl_lrpa_get(u8_t rl_idx);
 u8_t *ctrl_irks_get(u8_t *count);
 u8_t ctrl_rl_idx(bool whitelist, u8_t devmatch_id);
 u8_t ctrl_rl_irk_idx(u8_t irkmatch_id);

--- a/subsys/bluetooth/controller/ll_sw/ll_filter.h
+++ b/subsys/bluetooth/controller/ll_sw/ll_filter.h
@@ -20,12 +20,15 @@ void ll_filters_scan_update(u8_t scan_fp);
 
 struct ll_filter *ctrl_filter_get(bool whitelist);
 u8_t *ctrl_irks_get(u8_t *count);
-u8_t ctrl_rl_idx(u8_t irkmatch_id);
+u8_t ctrl_rl_idx(bool whitelist, u8_t devmatch_id);
+u8_t ctrl_rl_irk_idx(u8_t irkmatch_id);
 bool ctrl_irk_whitelisted(u8_t rl_idx);
 
 bool ctrl_rl_enabled(void);
 void ll_rl_rpa_update(bool timeout);
 
 u8_t ll_rl_find(u8_t id_addr_type, u8_t *id_addr, u8_t *free);
-bool ctrl_rl_allowed(u8_t id_addr_type, u8_t *id_addr, u8_t *rl_idx);
+bool ctrl_rl_addr_allowed(u8_t id_addr_type, u8_t *id_addr, u8_t *rl_idx);
+bool ctrl_rl_addr_resolve(u8_t id_addr_type, u8_t *id_addr, u8_t rl_idx);
+bool ctrl_rl_idx_allowed(u8_t irkmatch_ok, u8_t rl_idx);
 void ll_rl_pdu_adv_update(int idx, struct pdu_adv *pdu);

--- a/subsys/bluetooth/controller/ll_sw/ll_scan.c
+++ b/subsys/bluetooth/controller/ll_sw/ll_scan.c
@@ -60,6 +60,7 @@ u32_t ll_scan_params_set(u8_t type, u16_t interval, u16_t window,
 u32_t ll_scan_enable(u8_t enable)
 {
 	u32_t status;
+	u8_t  rpa_gen = 0;
 
 	if (!enable) {
 		return radio_scan_disable();
@@ -76,12 +77,15 @@ u32_t ll_scan_enable(u8_t enable)
 	     ll_scan.own_addr_type == BT_ADDR_LE_RANDOM_ID)) {
 		/* Generate RPAs if required */
 		ll_rl_rpa_update(false);
+		rpa_gen = 1;
 	}
 #endif
-	status = radio_scan_enable(ll_scan.type, ll_scan.own_addr_type,
-				   ll_addr_get(ll_scan.own_addr_type, NULL),
+	status = radio_scan_enable(ll_scan.type, ll_scan.own_addr_type & 0x1,
+				   ll_addr_get(ll_scan.own_addr_type & 0x1,
+					       NULL),
 				   ll_scan.interval, ll_scan.window,
-				   ll_scan.filter_policy);
+				   ll_scan.filter_policy, rpa_gen,
+				   FILTER_IDX_NONE);
 
 	return status;
 }


### PR DESCRIPTION
This commit introduces controller-based privacy for both the scanner and
the initiator roles. All the features in the specification are
implemented except:

* RPA resolution for directed advertising (TargetA address)
* RPA generation for scan requests and conn ind packets

Follow-up patches will cover the 2 items of functionality still missing
from the basic implementation. Hosts not using controller-based privacy
should not be affected by this change.

Signed-off-by: Carles Cufi <carles.cufi@nordicsemi.no>