### PR TITLE
Add .envrc file used by direnv to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,4 @@ tags
 .project
 .cproject
 .xxproject
+.envrc


### PR DESCRIPTION
This PR adds the .envrc file used by direnv to .gitignore.

Change-Id: Ibe1a3004d511e7896b8c30b8198bf490758568a9
Signed-off-by: Wojciech Bober <wojciech.bober@nordicsemi.no>