### PR TITLE
Bluetooth: ipsp: Remove requirements section

### DIFF
--- a/samples/bluetooth/ipsp/README.rst
+++ b/samples/bluetooth/ipsp/README.rst
@@ -9,12 +9,6 @@ Application demonstrating the IPSP (Internet Protocol Support Profile) Node
 role. IPSP is the Bluetooth profile that underneath utilizes 6LoWPAN, i.e. gives
 you IPv6 connectivity over BLE.
 
-Requirements
-************
-
-This application currently only works with HCI based firmware since it
-requires L2CAP channels support.
-
 Building and Running
 ********************
 


### PR DESCRIPTION
All supported drivers are HCI based so there is no need have it state on
the README.

Signed-off-by: Luiz Augusto von Dentz <luiz.von.dentz@intel.com>