### PR TITLE
build: workaround build bug in tests

### DIFF
--- a/samples/bluetooth/ipsp/src/Makefile
+++ b/samples/bluetooth/ipsp/src/Makefile
@@ -1,3 +1,3 @@
 ccflags-y +=-I${ZEPHYR_BASE}/samples/bluetooth
 
-obj-y = main.o ../../gatt/ipss.o
+obj-y = main.o ipss.o

--- a/samples/bluetooth/ipsp/src/ipss.c
+++ b/samples/bluetooth/ipsp/src/ipss.c
@@ -1,0 +1,2 @@
+/* Workaround build system bug that will put objects in source dir */
+#include "../../../bluetooth/gatt/ipss.c"

--- a/samples/bluetooth/peripheral/src/Makefile
+++ b/samples/bluetooth/peripheral/src/Makefile
@@ -1,4 +1,3 @@
 ccflags-y +=-I${ZEPHYR_BASE}/samples/bluetooth
 
-obj-y = main.o ../../gatt/hrs.o ../../gatt/dis.o \
-	../../gatt/bas.o ../../gatt/cts.o
+obj-y = main.o hrs.o dis.o bas.o cts.o

--- a/samples/bluetooth/peripheral/src/bas.c
+++ b/samples/bluetooth/peripheral/src/bas.c
@@ -1,0 +1,2 @@
+/* Workaround build system bug that will put objects in source dir */
+#include "../../gatt/bas.c"

--- a/samples/bluetooth/peripheral/src/cts.c
+++ b/samples/bluetooth/peripheral/src/cts.c
@@ -1,0 +1,2 @@
+/* Workaround build system bug that will put objects in source dir */
+#include "../../gatt/cts.c"

--- a/samples/bluetooth/peripheral/src/dis.c
+++ b/samples/bluetooth/peripheral/src/dis.c
@@ -1,0 +1,2 @@
+/* Workaround build system bug that will put objects in source dir */
+#include "../../gatt/dis.c"

--- a/samples/bluetooth/peripheral/src/hrs.c
+++ b/samples/bluetooth/peripheral/src/hrs.c
@@ -1,0 +1,2 @@
+/* Workaround build system bug that will put objects in source dir */
+#include "../../gatt/hrs.c"

--- a/samples/bluetooth/peripheral_csc/src/Makefile
+++ b/samples/bluetooth/peripheral_csc/src/Makefile
@@ -1,3 +1,3 @@
 ccflags-y +=-I${ZEPHYR_BASE}/samples/bluetooth
 
-obj-y = main.o ../../gatt/dis.o ../../gatt/bas.o
+obj-y = main.o dis.o bas.o

--- a/samples/bluetooth/peripheral_csc/src/bas.c
+++ b/samples/bluetooth/peripheral_csc/src/bas.c
@@ -1,0 +1,2 @@
+/* Workaround build system bug that will put objects in source dir */
+#include "../../gatt/bas.c"

--- a/samples/bluetooth/peripheral_csc/src/dis.c
+++ b/samples/bluetooth/peripheral_csc/src/dis.c
@@ -1,0 +1,2 @@
+/* Workaround build system bug that will put objects in source dir */
+#include "../../gatt/dis.c"

--- a/samples/bluetooth/peripheral_dis/src/Makefile
+++ b/samples/bluetooth/peripheral_dis/src/Makefile
@@ -1,3 +1,3 @@
 ccflags-y +=-I${ZEPHYR_BASE}/samples/bluetooth
 
-obj-y = main.o ../../gatt/dis.o
+obj-y = main.o dis.o

--- a/samples/bluetooth/peripheral_dis/src/dis.c
+++ b/samples/bluetooth/peripheral_dis/src/dis.c
@@ -1,0 +1,2 @@
+/* Workaround build system bug that will put objects in source dir */
+#include "../../gatt/dis.c"

--- a/samples/bluetooth/peripheral_esp/src/Makefile
+++ b/samples/bluetooth/peripheral_esp/src/Makefile
@@ -1,3 +1,3 @@
 ccflags-y +=-I${ZEPHYR_BASE}/samples/bluetooth
 
-obj-y = main.o ../../gatt/dis.o ../../gatt/bas.o
+obj-y = main.o dis.o bas.o

--- a/samples/bluetooth/peripheral_esp/src/bas.c
+++ b/samples/bluetooth/peripheral_esp/src/bas.c
@@ -1,0 +1,2 @@
+/* Workaround build system bug that will put objects in source dir */
+#include "../../gatt/bas.c"

--- a/samples/bluetooth/peripheral_esp/src/dis.c
+++ b/samples/bluetooth/peripheral_esp/src/dis.c
@@ -1,0 +1,2 @@
+/* Workaround build system bug that will put objects in source dir */
+#include "../../gatt/dis.c"

--- a/samples/bluetooth/peripheral_hids/src/Makefile
+++ b/samples/bluetooth/peripheral_hids/src/Makefile
@@ -1,4 +1,3 @@
 ccflags-y +=-I${ZEPHYR_BASE}/samples/bluetooth
 
-obj-y = main.o ../../gatt/dis.o ../../gatt/bas.o \
-	../../gatt/hog.o
+obj-y = main.o dis.o bas.o hog.o

--- a/samples/bluetooth/peripheral_hids/src/bas.c
+++ b/samples/bluetooth/peripheral_hids/src/bas.c
@@ -1,0 +1,2 @@
+/* Workaround build system bug that will put objects in source dir */
+#include "../../gatt/bas.c"

--- a/samples/bluetooth/peripheral_hids/src/dis.c
+++ b/samples/bluetooth/peripheral_hids/src/dis.c
@@ -1,0 +1,2 @@
+/* Workaround build system bug that will put objects in source dir */
+#include "../../gatt/dis.c"

--- a/samples/bluetooth/peripheral_hids/src/hog.c
+++ b/samples/bluetooth/peripheral_hids/src/hog.c
@@ -1,0 +1,2 @@
+/* Workaround build system bug that will put objects in source dir */
+#include "../../gatt/hog.c"

--- a/samples/bluetooth/peripheral_hr/src/Makefile
+++ b/samples/bluetooth/peripheral_hr/src/Makefile
@@ -1,4 +1,3 @@
 ccflags-y +=-I${ZEPHYR_BASE}/samples/bluetooth
 
-obj-y = main.o ../../gatt/hrs.o ../../gatt/dis.o \
-	../../gatt/bas.o
+obj-y = main.o hrs.o dis.o bas.o

--- a/samples/bluetooth/peripheral_hr/src/bas.c
+++ b/samples/bluetooth/peripheral_hr/src/bas.c
@@ -1,0 +1,2 @@
+/* Workaround build system bug that will put objects in source dir */
+#include "../../gatt/bas.c"

--- a/samples/bluetooth/peripheral_hr/src/dis.c
+++ b/samples/bluetooth/peripheral_hr/src/dis.c
@@ -1,0 +1,2 @@
+/* Workaround build system bug that will put objects in source dir */
+#include "../../gatt/dis.c"

--- a/samples/bluetooth/peripheral_hr/src/hrs.c
+++ b/samples/bluetooth/peripheral_hr/src/hrs.c
@@ -1,0 +1,2 @@
+/* Workaround build system bug that will put objects in source dir */
+#include "../../gatt/hrs.c"

--- a/samples/net/ieee802154/hw/src/Makefile
+++ b/samples/net/ieee802154/hw/src/Makefile
@@ -1,4 +1,4 @@
 obj-y = ieee802154_test.o
 
 ccflags-y +=-I${ZEPHYR_BASE}/samples/net/common/
-obj-y += ../../../common/ieee802154_settings.o
+obj-y += ieee802154_settings.o

--- a/samples/net/ieee802154/hw/src/ieee802154_settings.c
+++ b/samples/net/ieee802154/hw/src/ieee802154_settings.c
@@ -1,0 +1,2 @@
+/* Workaround build system bug that will put objects in source dir */
+#include "../../common/ieee802154_settings.c"

--- a/samples/net/leds_demo/src/Makefile
+++ b/samples/net/leds_demo/src/Makefile
@@ -10,12 +10,12 @@ ccflags-$(CONFIG_NET_L2_BLUETOOTH) += -I${ZEPHYR_BASE}/samples/bluetooth/
 obj-y = leds-demo.o
 
 ifeq ($(CONFIG_NET_L2_BLUETOOTH), y)
-obj-y += ../../../bluetooth/gatt/ipss.o
+obj-y += ipss.o
 endif
 
 ifeq ($(CONFIG_NET_L2_IEEE802154), y)
 ccflags-y +=-I${ZEPHYR_BASE}/samples/net/common/
 ifeq ($(CONFIG_NET_APP_SETTINGS), y)
-obj-y += ../../common/ieee802154_settings.o
+obj-y += ieee802154_settings.o
 endif
 endif

--- a/samples/net/leds_demo/src/ieee802154_settings.c
+++ b/samples/net/leds_demo/src/ieee802154_settings.c
@@ -1,0 +1,2 @@
+/* Workaround build system bug that will put objects in source dir */
+#include "../../common/ieee802154_settings.c"

--- a/samples/net/leds_demo/src/ipss.c
+++ b/samples/net/leds_demo/src/ipss.c
@@ -1,0 +1,2 @@
+/* Workaround build system bug that will put objects in source dir */
+#include "../../../bluetooth/gatt/ipss.c"

--- a/samples/net/mqtt_publisher/src/Makefile
+++ b/samples/net/mqtt_publisher/src/Makefile
@@ -8,5 +8,5 @@ obj-y += main.o
 
 ifeq ($(CONFIG_NET_L2_BLUETOOTH), y)
 ccflags-y +=-I${ZEPHYR_BASE}/samples/bluetooth/
-obj-y += ../../../bluetooth/gatt/ipss.o
+obj-y += ipss.o
 endif

--- a/samples/net/mqtt_publisher/src/ipss.c
+++ b/samples/net/mqtt_publisher/src/ipss.c
@@ -1,0 +1,2 @@
+/* Workaround build system bug that will put objects in source dir */
+#include "../../../bluetooth/gatt/ipss.c"

--- a/samples/net/zoap_client/src/Makefile
+++ b/samples/net/zoap_client/src/Makefile
@@ -7,5 +7,5 @@ obj-y = zoap-client.o
 
 ifeq ($(CONFIG_NET_L2_BLUETOOTH), y)
 ccflags-y +=-I${ZEPHYR_BASE}/samples/bluetooth/
-obj-y += ../../../bluetooth/gatt/ipss.o
+obj-y += ipss.o
 endif

--- a/samples/net/zoap_client/src/ipss.c
+++ b/samples/net/zoap_client/src/ipss.c
@@ -1,0 +1,2 @@
+/* Workaround build system bug that will put objects in source dir */
+#include "../../../bluetooth/gatt/ipss.c"

--- a/samples/net/zoap_server/src/Makefile
+++ b/samples/net/zoap_server/src/Makefile
@@ -7,12 +7,12 @@ obj-y = zoap-server.o
 
 ifeq ($(CONFIG_NET_L2_BLUETOOTH), y)
 ccflags-y += -I${ZEPHYR_BASE}/samples/bluetooth/
-obj-y += ../../../bluetooth/gatt/ipss.o
+obj-y += ipss.o
 endif
 
 ifeq ($(CONFIG_NET_L2_IEEE802154), y)
 ccflags-y +=-I${ZEPHYR_BASE}/samples/net/common/
 ifeq ($(CONFIG_NET_APP_SETTINGS), y)
-obj-y += ../../common/ieee802154_settings.o
+obj-y += ieee802154_settings.o
 endif
 endif

--- a/samples/net/zoap_server/src/ieee802154_settings.c
+++ b/samples/net/zoap_server/src/ieee802154_settings.c
@@ -1,0 +1,2 @@
+/* Workaround build system bug that will put objects in source dir */
+#include "../../common/ieee802154_settings.c"

--- a/samples/net/zoap_server/src/ipss.c
+++ b/samples/net/zoap_server/src/ipss.c
@@ -1,0 +1,2 @@
+/* Workaround build system bug that will put objects in source dir */
+#include "../../../bluetooth/gatt/ipss.c"

--- a/samples/net/zperf/src/Makefile
+++ b/samples/net/zperf/src/Makefile
@@ -18,12 +18,12 @@ endif
 
 ifeq ($(CONFIG_NET_L2_BLUETOOTH), y)
 ccflags-y +=-I${ZEPHYR_BASE}/samples/bluetooth/
-obj-y += ../../../bluetooth/gatt/ipss.o
+obj-y += ipss.o
 endif
 
 ifeq ($(CONFIG_NET_L2_IEEE802154), y)
 ccflags-y +=-I${ZEPHYR_BASE}/samples/net/common/
 ifeq ($(CONFIG_NET_APP_SETTINGS), y)
-obj-y += ../../common/ieee802154_settings.o
+obj-y += ieee802154_settings.o
 endif
 endif

--- a/samples/net/zperf/src/ieee802154_settings.c
+++ b/samples/net/zperf/src/ieee802154_settings.c
@@ -1,0 +1,2 @@
+/* Workaround build system bug that will put objects in source dir */
+#include "../../common/ieee802154_settings.c"

--- a/samples/net/zperf/src/ipss.c
+++ b/samples/net/zperf/src/ipss.c
@@ -1,0 +1,2 @@
+/* Workaround build system bug that will put objects in source dir */
+#include "../../../bluetooth/gatt/ipss.c"

--- a/tests/bluetooth/shell/src/Makefile
+++ b/tests/bluetooth/shell/src/Makefile
@@ -1,4 +1,4 @@
 ccflags-y +=-I$(ZEPHYR_BASE)/include/drivers
 ccflags-y +=-I$(ZEPHYR_BASE)/samples/bluetooth
 
-obj-y = main.o ../../../../samples/bluetooth/gatt/hrs.o
+obj-y = main.o hrs.o

--- a/tests/bluetooth/shell/src/hrs.c
+++ b/tests/bluetooth/shell/src/hrs.c
@@ -1,0 +1,2 @@
+/* Workaround build system bug that will put objects in source dir */
+#include "../../../../samples/bluetooth/gatt/hrs.c"

--- a/tests/crypto/ecc_dh/src/Makefile
+++ b/tests/crypto/ecc_dh/src/Makefile
@@ -1,4 +1,3 @@
 ccflags-y += -I$(ZEPHYR_BASE)/tests/include
 
-obj-y = ../../ecc_dsa/src/test_ecc_utils.o
-obj-y += test_ecc_dh.o
+obj-y = test_ecc_utils.o test_ecc_dh.o

--- a/tests/crypto/ecc_dh/src/test_ecc_utils.c
+++ b/tests/crypto/ecc_dh/src/test_ecc_utils.c
@@ -1,0 +1,2 @@
+/* Workaround build system bug that will put objects in source dir */
+#include "../../ecc_dsa/src/test_ecc_utils.c"


### PR DESCRIPTION
When an app uses a construct such as:

obj-y = main.o ../../../../samples/bluetooth/gatt/hrs.o

in its makefile, it causes said object module to be built in the
source tree, not in the object tree.

When building massively parallel, this usually resuls on the files
getting corrupted, leading to bugs such as:

https://jira.zephyrproject.org/browse/ZEP-2316
https://jira.zephyrproject.org/browse/ZEP-2317

src/../../../../samples/bluetooth/gatt/.gap.o.cmd:3: warning: NUL character seen; rest of line ignored
src/../../../../samples/bluetooth/gatt/.gap.o.cmd:4: warning: NUL character seen; rest of line ignored
src/../../../../samples/bluetooth/gatt/.gap.o.cmd:5: *** missing separator.  Stop.

as multiple build are trying to touch the same file in the source tree
and of course, race and causes a build bug.

We have known about this issue for a long time, but it requires
modifications in the build system that there is no time to tackle.

A suggested workaround is to include the source files into a local .c
file, so this is what this patch does, to remove the random noise.

Change-Id: Iba8a2b982fc63b5e990cda340fe17b79ca5abfcf
Signed-off-by: Inaky Perez-Gonzalez <inaky.perez-gonzalez@intel.com>