### PR TITLE
arches: move _NanoFatalErrorHandler defintion

### DIFF
--- a/arch/nios2/include/kernel_arch_func.h
+++ b/arch/nios2/include/kernel_arch_func.h
@@ -45,10 +45,6 @@ static inline void _IntLibInit(void)
 	/* No special initialization of the interrupt subsystem required */
 }
 
-FUNC_NORETURN void _NanoFatalErrorHandler(unsigned int reason,
-					  const NANO_ESF * esf);
-
-
 #define _is_in_isr() (_kernel.nested != 0)
 
 #ifdef CONFIG_IRQ_OFFLOAD

--- a/arch/xtensa/include/kernel_arch_func.h
+++ b/arch/xtensa/include/kernel_arch_func.h
@@ -76,9 +76,6 @@ static inline void _IntLibInit(void)
 {
 }
 
-FUNC_NORETURN void _NanoFatalErrorHandler(unsigned int reason,
-					  const NANO_ESF *pEsf);
-
 #include <stddef.h> /* For size_t */
 
 #ifdef __cplusplus

--- a/include/arch/nios2/arch.h
+++ b/include/arch/nios2/arch.h
@@ -159,6 +159,8 @@ extern const NANO_ESF _default_esf;
 FUNC_NORETURN void _SysFatalErrorHandler(unsigned int reason,
 					 const NANO_ESF *esf);
 
+FUNC_NORETURN void _NanoFatalErrorHandler(unsigned int reason,
+					  const NANO_ESF *esf);
 
 enum nios2_exception_cause {
 	NIOS2_EXCEPTION_UNKNOWN                      = -1,

--- a/include/arch/xtensa/arch.h
+++ b/include/arch/xtensa/arch.h
@@ -129,6 +129,9 @@ extern void _irq_priority_set(u32_t irq, u32_t prio, u32_t flags);
 FUNC_NORETURN void _SysFatalErrorHandler(unsigned int reason,
 					 const NANO_ESF *esf);
 
+FUNC_NORETURN void _NanoFatalErrorHandler(unsigned int reason,
+					  const NANO_ESF *pEsf);
+
 extern u32_t _timer_cycle_get_32(void);
 #define _arch_k_cycle_get_32()	_timer_cycle_get_32()
 


### PR DESCRIPTION
This needs to be in <arch/cpu.h> so that it can be called
from the k_panic()/k_oops() macros in kernel.h.

Fixes build errors on these arches when using k_panic() or
k_oops().

Signed-off-by: Andrew Boie <andrew.p.boie@intel.com>