### PR TITLE
drivers: gpio: Fix Coverity static scan issues

### DIFF
--- a/drivers/gpio/gpio_cc2650.c
+++ b/drivers/gpio/gpio_cc2650.c
@@ -174,10 +174,10 @@ static int gpio_cc2650_config_pin(int pin, int flags)
 	if (flags & GPIO_DS_DISCONNECT_LOW) {
 		disconnect(pin, &gpio_doe31_0_config, &iocfg_config);
 	}
-	if (flags & GPIO_DS_DFLT_LOW) {
-		iocfg_config |= CC2650_IOC_MIN_DRIVE_STRENGTH;
-	} else {
+	if (flags & GPIO_DS_ALT_LOW) {
 		iocfg_config |= CC2650_IOC_MAX_DRIVE_STRENGTH;
+	} else {
+		iocfg_config |= CC2650_IOC_MIN_DRIVE_STRENGTH;
 	}
 
 	/* Commit changes */


### PR DESCRIPTION
patch fix the dead code issue reported by coverity static scan
for gpio driver of cc2650 TI SOC. GPIO_DS_DFLT_LOW macro
is defined Zero, bitwise and with any value would result to
zero,because of which only false condition of if is evaluated
but not the true condition.This is a fix for jira ZEP-2355.

Signed-off-by: Savinay Dharmappa <savinay.dharmappa@intel.com>