### PR TITLE
include: kernel: Fix use of K_POLL_MODE_INFORM_ONLY in docstring

### DIFF
--- a/include/kernel.h
+++ b/include/kernel.h
@@ -3646,7 +3646,7 @@ struct k_poll_event {
  *             values. Only values that apply to the same object being polled
  *             can be used together. Choosing K_POLL_TYPE_IGNORE disables the
  *             event.
- * @param mode Future. Use K_POLL_MODE_INFORM_ONLY.
+ * @param mode Future. Use K_POLL_MODE_NOTIFY_ONLY.
  * @param obj Kernel object or poll signal.
  *
  * @return N/A


### PR DESCRIPTION
K_POLL_MODE_INFORM_ONLY was renamed to K_POLL_MODE_NOTIFY_ONLY, but
stale use was in a docstring.

Signed-off-by: Paul Sokolovsky <paul.sokolovsky@linaro.org>