### PR TITLE
kernel: boot: Fix double prompt definition for CONFIG_BOOT_DELAY

### DIFF
--- a/kernel/Kconfig
+++ b/kernel/Kconfig
@@ -205,8 +205,8 @@ config BOOT_BANNER
 	also embeds a date & time stamp in the kernel and in each USAP image.
 
 config BOOT_DELAY
-	int "milliseconds to delay boot"
-	prompt "Boot delay"
+	int
+	prompt "Boot delay in milliseconds"
 	default 0
 	help
 	This option delays bootup for the specified amount of


### PR DESCRIPTION
This fixes Kconfig warning:

scripts/kconfig/conf --silentoldconfig Kconfig
zephyr/kernel/Kconfig:209:warning: prompt redefined

Signed-off-by: Paul Sokolovsky <paul.sokolovsky@linaro.org>