### PR TITLE
x86: add missing rule for __kernel objects

### DIFF
--- a/include/arch/x86/linker.ld
+++ b/include/arch/x86/linker.ld
@@ -144,6 +144,7 @@ SECTIONS
 
 	KERNEL_INPUT_SECTION(.data)
 	KERNEL_INPUT_SECTION(".data.*")
+	*(".kernel.*")
 
 #ifdef CONFIG_CUSTOM_RWDATA_LD
 /* Located in project source directory */


### PR DESCRIPTION
Signed-off-by: Andrew Boie <andrew.p.boie@intel.com>