### PR TITLE
timer fixes for tickless kernel issues

### DIFF
--- a/drivers/timer/cortex_m_systick.c
+++ b/drivers/timer/cortex_m_systick.c
@@ -66,6 +66,9 @@ static u32_t __noinit default_load_value; /* default count */
 #ifndef CONFIG_TICKLESS_KERNEL
 static u32_t idle_original_count;
 #endif
+#ifdef CONFIG_TICKLESS_KERNEL
+static u32_t timer_overflow;
+#endif
 static u32_t __noinit max_system_ticks;
 static u32_t idle_original_ticks;
 static u32_t __noinit max_load_value;
@@ -142,7 +145,8 @@ static ALWAYS_INLINE u32_t sysTickCurrentGet(void)
 	 * Counter can rollover if irqs are locked for too long.
 	 * Return 0 to indicate programmed cycles have expired.
 	 */
-	if (SysTick->CTRL & SysTick_CTRL_COUNTFLAG_Msk) {
+	if ((SysTick->CTRL & SysTick_CTRL_COUNTFLAG_Msk) || (timer_overflow)) {
+		timer_overflow = 1;
 		return 0;
 	}
 #endif
@@ -239,13 +243,13 @@ void _timer_int_handler(void *unused)
 
 #ifdef CONFIG_TICKLESS_IDLE
 #if defined(CONFIG_TICKLESS_KERNEL)
-
-	sysTickStop();
-
 	if (!idle_original_ticks) {
 		if (_sys_clock_always_on) {
 			_sys_clock_tick_count = _get_elapsed_clock_time();
-
+			/* clear overflow tracking flag as it is accounted */
+			timer_overflow = 0;
+			sysTickStop();
+			idle_original_ticks = max_system_ticks;
 			sysTickReloadSet(max_load_value);
 			sysTickStart();
 			sys_tick_reload();
@@ -272,6 +276,9 @@ void _timer_int_handler(void *unused)
 	/* _sys_clock_tick_announce() could cause new programming */
 	if (!idle_original_ticks && _sys_clock_always_on) {
 		_sys_clock_tick_count = _get_elapsed_clock_time();
+		/* clear overflow tracking flag as it is accounted */
+		timer_overflow = 0;
+		sysTickStop();
 		sysTickReloadSet(max_load_value);
 		sysTickStart();
 		sys_tick_reload();
@@ -363,7 +370,8 @@ u32_t _get_remaining_program_time(void)
 		return 0;
 	}
 
-	return sysTickCurrentGet() / default_load_value;
+	return (u32_t)ceiling_fraction((u32_t)sysTickCurrentGet(),
+						default_load_value);
 }
 
 u32_t _get_elapsed_program_time(void)
@@ -377,8 +385,6 @@ u32_t _get_elapsed_program_time(void)
 
 void _set_time(u32_t time)
 {
-	sysTickStop();
-
 	if (!time) {
 		idle_original_ticks = 0;
 		return;
@@ -388,6 +394,9 @@ void _set_time(u32_t time)
 
 	_sys_clock_tick_count = _get_elapsed_clock_time();
 
+	/* clear overflow tracking flag as it is accounted */
+	timer_overflow = 0;
+	sysTickStop();
 	sysTickReloadSet(idle_original_ticks * default_load_value);
 
 	sysTickStart();
@@ -406,8 +415,12 @@ static inline u64_t get_elapsed_count(void)
 {
 	u64_t elapsed;
 
-	if (SysTick->CTRL & SysTick_CTRL_COUNTFLAG_Msk) {
+	if ((SysTick->CTRL & SysTick_CTRL_COUNTFLAG_Msk) || (timer_overflow)) {
 		elapsed = SysTick->LOAD;
+		/* Keep track of overflow till it is accounted in
+		 * _sys_clock_tick_count as COUNTFLAG bit is clear on read
+		 */
+		timer_overflow = 1;
 	} else {
 		elapsed = (SysTick->LOAD - SysTick->VAL);
 	}
@@ -594,6 +607,8 @@ void _timer_idle_exit(void)
 	if (idle_mode == IDLE_TICKLESS) {
 		idle_mode = IDLE_NOT_TICKLESS;
 		if (!idle_original_ticks && _sys_clock_always_on) {
+			_sys_clock_tick_count = _get_elapsed_clock_time();
+			timer_overflow = 0;
 			sysTickReloadSet(max_load_value);
 			sysTickStart();
 			sys_tick_reload();

--- a/kernel/sched.c
+++ b/kernel/sched.c
@@ -432,7 +432,13 @@ void _update_time_slice_before_swap(void)
 
 	if (!remaining || (_time_slice_duration < remaining)) {
 		_set_time(_time_slice_duration);
+	} else {
+		/* Account previous elapsed time and reprogram
+		 * timer with remaining time
+		 */
+		_set_time(remaining);
 	}
+
 #endif
 	/* Restart time slice count at new thread switch */
 	_time_slice_elapsed = 0;


### PR DESCRIPTION
There were few issues around tickless kernel related to systick Cortex m timer and a scheduler issue which was impacting all the timers.



Timer Systick : Handle Systick timer rollback in tickless kernel Case
******Issues related to cortex_m_systick ******
1. System time keeping was not happening properly. When systick was getting expired it's overflow bit was get. This bit was clear on read and it was getting cleared in multiple places like sysTickstop, get current time etc. Due to which while updating _sys_clock_tick_count, it was getting updated with SysTick->LOAD - SysTick->VAL instead of SysTick->LOAD. Due to which kernel time keeping was not happening properly. This patch tracks overflow occurrence and update _sys_clock_tick_count correctly.





Patch :    Scheduler : Account kernel time keeping when thread releases cpu befo
*****Issue related to cortex_m_systick /local apic/ hpet timers *************************
When multiple pre-emptive threads of same priority are queued together, then these threads should execute in round robin fashion with equal time slice, but in certain scenarios this scheduling is not fair and one thread gets lower time slice than expected. 
For example if threads A, B and C are of equal priority and are queued in order A -> B ->C.
Let us assume Thread A is running with  time slice as 200mSec. 
So timer is programmed for 200 ticks and thread A starts running. 
Let us assume thread A has run for 100 ticks and it gets semtake and not at this stage A is put at end of queue and Thread B is in top (B -> C ->A). Now thread B starts running and on timer expire after 100 ticks.
At the end of 200 ticks (100 ticks spent by A + 100 ticks by B), timer expired. now elapsed ticks updated = 200. and which results in elapsed_timeslice for B too to 200 (but actually B has taken only 100 ticks). 

So this patch sets the time out to remaining time again and accounts the spend time. So that after 100 ticks expired for A it accounts only 100 ticks and B gets fair chance.
