### PR TITLE
Add DTLS support to net-app API

### DIFF
--- a/include/net/net_app.h
+++ b/include/net/net_app.h
@@ -410,6 +410,11 @@ struct net_app_ctx {
 	/** User data pointer */
 	void *user_data;
 
+#if defined(CONFIG_NET_DEBUG_APP)
+	/** Used when debugging with net-shell */
+	sys_snode_t node;
+#endif
+
 	/** Type of the connection (stream or datagram) */
 	enum net_sock_type sock_type;
 
@@ -942,6 +947,12 @@ bool net_app_server_tls_disable(struct net_app_ctx *ctx);
 /**
  * @}
  */
+
+#if defined(CONFIG_NET_DEBUG_APP)
+typedef void (*net_app_ctx_cb_t)(struct net_app_ctx *ctx, void *user_data);
+void net_app_server_foreach(net_app_ctx_cb_t cb, void *user_data);
+void net_app_client_foreach(net_app_ctx_cb_t cb, void *user_data);
+#endif /* CONFIG_NET_DEBUG_APP */
 
 #ifdef __cplusplus
 }

--- a/samples/net/echo_client/src/test_certs.h
+++ b/samples/net/echo_client/src/test_certs.h
@@ -111,12 +111,12 @@ static const unsigned char ca_certificate[] = {
 #endif /* MBEDTLS_X509_CRT_PARSE_C */
 
 #if defined(MBEDTLS_KEY_EXCHANGE__SOME__PSK_ENABLED)
-const unsigned char client_psk[] = {
+static const unsigned char client_psk[] = {
 	0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07,
 	0x08, 0x09, 0x0a, 0x0b, 0x0c, 0x0d, 0x0e, 0x0f
 };
 
-const char client_psk_id[] = "Client_identity";
+static const char client_psk_id[] = "Client_identity";
 #endif
 
 #endif

--- a/samples/net/echo_client/src/udp.c
+++ b/samples/net/echo_client/src/udp.c
@@ -50,6 +50,94 @@ static struct net_buf_pool *data_udp_pool(void)
 #define data_udp_pool NULL
 #endif /* CONFIG_NET_CONTEXT_NET_PKT_POOL */
 
+#if defined(CONFIG_NET_APP_DTLS)
+#define HOSTNAME "localhost"   /* for cert verification if that is enabled */
+
+/* The result buf size is set to large enough so that we can receive max size
+ * buf back. Note that mbedtls needs also be configured to have equal size
+ * value for its buffer size. See MBEDTLS_SSL_MAX_CONTENT_LEN option in DTLS
+ * config file.
+ */
+#define RESULT_BUF_SIZE 1500
+static u8_t dtls_result_ipv6[RESULT_BUF_SIZE];
+static u8_t dtls_result_ipv4[RESULT_BUF_SIZE];
+
+#if !defined(CONFIG_NET_APP_TLS_STACK_SIZE)
+#define CONFIG_NET_APP_TLS_STACK_SIZE		6144
+#endif /* CONFIG_NET_APP_TLS_STACK_SIZE */
+
+#define INSTANCE_INFO "Zephyr DTLS echo-client #1"
+
+/* Note that each net_app context needs its own stack as there will be
+ * a separate thread needed.
+ */
+NET_STACK_DEFINE(NET_APP_DTLS_IPv4, net_app_dtls_stack_ipv4,
+		 CONFIG_NET_APP_TLS_STACK_SIZE, CONFIG_NET_APP_TLS_STACK_SIZE);
+
+NET_STACK_DEFINE(NET_APP_DTLS_IPv6, net_app_dtls_stack_ipv6,
+		 CONFIG_NET_APP_TLS_STACK_SIZE, CONFIG_NET_APP_TLS_STACK_SIZE);
+
+NET_APP_TLS_POOL_DEFINE(dtls_pool, 10);
+#else
+#define dtls_result_ipv6 NULL
+#define dtls_result_ipv4 NULL
+#define net_app_dtls_stack_ipv4 NULL
+#define net_app_dtls_stack_ipv6 NULL
+#endif /* CONFIG_NET_APP_TLS */
+
+#if defined(CONFIG_NET_APP_TLS)
+/* Load the certificates and private RSA key. */
+
+#include "test_certs.h"
+
+static int setup_cert(struct net_app_ctx *ctx, void *cert)
+{
+#if defined(MBEDTLS_KEY_EXCHANGE__SOME__PSK_ENABLED)
+	mbedtls_ssl_conf_psk(&ctx->tls.mbedtls.conf,
+			     client_psk, sizeof(client_psk),
+			     (const unsigned char *)client_psk_id,
+			     sizeof(client_psk_id) - 1);
+#endif
+
+#if defined(MBEDTLS_X509_CRT_PARSE_C)
+	{
+		mbedtls_x509_crt *ca_cert = cert;
+		int ret;
+
+		ret = mbedtls_x509_crt_parse_der(ca_cert,
+						 ca_certificate,
+						 sizeof(ca_certificate));
+		if (ret != 0) {
+			NET_ERR("mbedtls_x509_crt_parse_der failed "
+				"(-0x%x)", -ret);
+			return ret;
+		}
+
+		mbedtls_ssl_conf_ca_chain(&ctx->tls.mbedtls.conf,
+					  ca_cert, NULL);
+
+		/* In this example, we skip the certificate checks. In real
+		 * life scenarios, one should always verify the certificates.
+		 */
+		mbedtls_ssl_conf_authmode(&ctx->tls.mbedtls.conf,
+					  MBEDTLS_SSL_VERIFY_REQUIRED);
+
+		mbedtls_ssl_conf_cert_profile(&ctx->tls.mbedtls.conf,
+					    &mbedtls_x509_crt_profile_default);
+#define VERIFY_CERTS 0
+#if VERIFY_CERTS
+		mbedtls_ssl_conf_authmode(&ctx->tls.mbedtls.conf,
+					  MBEDTLS_SSL_VERIFY_OPTIONAL);
+#else
+		;
+#endif /* VERIFY_CERTS */
+	}
+#endif /* MBEDTLS_X509_CRT_PARSE_C */
+
+	return 0;
+}
+#endif /* CONFIG_NET_APP_TLS */
+
 static void send_udp_data(struct net_app_ctx *ctx, struct data *data)
 {
 	struct net_pkt *pkt;
@@ -131,7 +219,7 @@ static void udp_received(struct net_app_ctx *ctx,
 	ARG_UNUSED(status);
 
 	if (data->expecting_udp != net_pkt_appdatalen(pkt)) {
-		NET_ERR("Sent %d bytes, received %u bytes",
+		NET_DBG("Sent %d bytes, received %u bytes",
 			data->expecting_udp, net_pkt_appdatalen(pkt));
 	}
 
@@ -164,7 +252,9 @@ static void udp_connected(struct net_app_ctx *ctx,
 }
 
 static int connect_udp(struct net_app_ctx *ctx, const char *peer,
-		       void *user_data)
+		       void *user_data, u8_t *dtls_result_buf,
+		       size_t dtls_result_buf_len,
+		       u8_t *stack, size_t stack_size)
 {
 	struct data *data = user_data;
 	int ret;
@@ -185,6 +275,29 @@ static int connect_udp(struct net_app_ctx *ctx, const char *peer,
 		NET_ERR("Cannot set callbacks (%d)", ret);
 		goto fail;
 	}
+
+#if defined(CONFIG_NET_APP_DTLS)
+	ret = net_app_client_tls(ctx,
+				 dtls_result_buf,
+				 dtls_result_buf_len,
+				 INSTANCE_INFO,
+				 strlen(INSTANCE_INFO),
+				 setup_cert,
+				 HOSTNAME,
+				 NULL,
+				 &dtls_pool,
+				 stack,
+				 stack_size);
+	if (ret < 0) {
+		NET_ERR("Cannot init DTLS");
+		goto fail;
+	}
+#else
+	ARG_UNUSED(dtls_result_buf);
+	ARG_UNUSED(dtls_result_buf_len);
+	ARG_UNUSED(stack);
+	ARG_UNUSED(stack_size);
+#endif
 
 	ret = net_app_connect(ctx, CONNECT_TIME);
 	if (ret < 0) {
@@ -215,7 +328,11 @@ void start_udp(void)
 		k_delayed_work_init(&conf.ipv6.recv, wait_reply);
 
 		ret = connect_udp(&udp6, CONFIG_NET_APP_PEER_IPV6_ADDR,
-				  &conf.ipv6);
+				  &conf.ipv6, dtls_result_ipv6,
+				  sizeof(dtls_result_ipv6),
+				  net_app_dtls_stack_ipv6,
+				  K_THREAD_STACK_SIZEOF(
+					  net_app_dtls_stack_ipv6));
 		if (ret < 0) {
 			NET_ERR("Cannot init IPv6 UDP client (%d)", ret);
 		}
@@ -225,7 +342,11 @@ void start_udp(void)
 		k_delayed_work_init(&conf.ipv4.recv, wait_reply);
 
 		ret = connect_udp(&udp4, CONFIG_NET_APP_PEER_IPV4_ADDR,
-				  &conf.ipv4);
+				  &conf.ipv4, dtls_result_ipv4,
+				  sizeof(dtls_result_ipv4),
+				  net_app_dtls_stack_ipv4,
+				  K_THREAD_STACK_SIZEOF(
+					  net_app_dtls_stack_ipv4));
 		if (ret < 0) {
 			NET_ERR("Cannot init IPv4 UDP client (%d)", ret);
 		}

--- a/subsys/net/lib/app/Kconfig
+++ b/subsys/net/lib/app/Kconfig
@@ -91,6 +91,22 @@ config NET_APP_TLS
 	help
 	Enables net app library to use TLS for encrypted communication.
 
+config NET_APP_DTLS
+	bool "Enable DTLS support for UDP applications"
+	depends on NET_UDP
+	depends on NET_APP_TLS
+	default n
+	help
+	Enables net app library to use TLS for encrypted UDP communication.
+
+config NET_APP_DTLS_TIMEOUT
+	int "DTLS session timeout"
+	depends on NET_APP_DTLS
+	default 15
+	help
+	If a DTLS session does not have any activity, then disconnect
+	the session. The value is in seconds.
+
 config NET_DEBUG_APP_TLS_LEVEL
 	int "Debug level for mbedtls in net app library"
 	depends on NET_APP_TLS && NET_DEBUG_APP

--- a/subsys/net/lib/app/client.c
+++ b/subsys/net/lib/app/client.c
@@ -409,6 +409,8 @@ int net_app_init_client(struct net_app_ctx *ctx,
 out:
 	ctx->is_init = true;
 
+	_net_app_register(ctx);
+
 fail:
 	return ret;
 

--- a/subsys/net/lib/app/net_app_private.h
+++ b/subsys/net/lib/app/net_app_private.h
@@ -118,4 +118,12 @@ enum net_verdict _net_app_dtls_established(struct net_conn *conn,
 					   void *user_data);
 #endif /* CONFIG_NET_APP_DTLS */
 
+#if defined(CONFIG_NET_DEBUG_APP)
+void _net_app_register(struct net_app_ctx *ctx);
+void _net_app_unregister(struct net_app_ctx *ctx);
+#else
+#define _net_app_register(...)
+#define _net_app_unregister(...)
+#endif /* CONFIG_NET_DEBUG_APP */
+
 #endif /* CONFIG_NET_APP_SERVER || CONFIG_NET_APP_CLIENT */

--- a/subsys/net/lib/app/net_app_private.h
+++ b/subsys/net/lib/app/net_app_private.h
@@ -111,4 +111,11 @@ int _net_app_entropy_source(void *data, unsigned char *output, size_t len,
 int _net_app_ssl_tx(void *context, const unsigned char *buf, size_t size);
 #endif /* CONFIG_NET_APP_TLS */
 
+#if defined(CONFIG_NET_APP_DTLS)
+#include "../../ip/connection.h"
+enum net_verdict _net_app_dtls_established(struct net_conn *conn,
+					   struct net_pkt *pkt,
+					   void *user_data);
+#endif /* CONFIG_NET_APP_DTLS */
+
 #endif /* CONFIG_NET_APP_SERVER || CONFIG_NET_APP_CLIENT */

--- a/subsys/net/lib/app/server.c
+++ b/subsys/net/lib/app/server.c
@@ -232,6 +232,8 @@ int net_app_init_server(struct net_app_ctx *ctx,
 
 	ctx->is_init = true;
 
+	_net_app_register(ctx);
+
 fail:
 	return ret;
 }

--- a/subsys/net/lib/app/server.c
+++ b/subsys/net/lib/app/server.c
@@ -120,7 +120,15 @@ int net_app_listen(struct net_app_ctx *ctx)
 		net_context_put(ctx->ipv4.ctx);
 		ctx->ipv4.ctx = NULL;
 	}
+#if defined(CONFIG_NET_APP_DTLS)
+	else {
+		if (ctx->is_tls && ctx->proto == IPPROTO_UDP) {
+			net_context_recv(ctx->ipv4.ctx, ctx->recv_cb,
+					 K_NO_WAIT, ctx);
+		}
+	}
 #endif
+#endif /* CONFIG_NET_IPV4 */
 
 	/* We ignore the IPv4 error if IPv6 is enabled */
 
@@ -138,7 +146,15 @@ int net_app_listen(struct net_app_ctx *ctx)
 		net_context_put(ctx->ipv6.ctx);
 		ctx->ipv6.ctx = NULL;
 	}
+#if defined(CONFIG_NET_APP_DTLS)
+	else {
+		if (ctx->is_tls && ctx->proto == IPPROTO_UDP) {
+			net_context_recv(ctx->ipv6.ctx, ctx->recv_cb,
+					 K_NO_WAIT, ctx);
+		}
+	}
 #endif
+#endif /* CONFIG_NET_IPV6 */
 
 	return ret;
 }


### PR DESCRIPTION
This set adds both DTLS server and client support to net-app API. Both echo-client and echo-server sample applications are modified to support DTLS.
The last two patches add "net app" shell command that gives more information about currently active net-app connections.

