### PR TITLE
net: app: Setup IEEE 802.15.4 during init

### DIFF
--- a/subsys/net/lib/app/Makefile
+++ b/subsys/net/lib/app/Makefile
@@ -5,7 +5,6 @@
 #
 
 ccflags-$(CONFIG_NET_L2_BLUETOOTH) += -I${ZEPHYR_BASE}/samples/bluetooth/
-ccflags-$(CONFIG_NET_L2_IEEE802154) += -I${ZEPHYR_BASE}/samples/net/common/
 
 obj-$(CONFIG_NET_APP) += init.o
 obj-$(CONFIG_NET_APP_SERVER) += server.o
@@ -17,4 +16,8 @@ else
 	ifeq ($(CONFIG_NET_APP_CLIENT),y)
 		obj-y += net_app.o
 	endif
+endif
+
+ifeq ($(CONFIG_NET_APP_SETTINGS),y)
+	obj-$(CONFIG_NET_L2_IEEE802154) += ieee802154_settings.o
 endif

--- a/subsys/net/lib/app/ieee802154_settings.c
+++ b/subsys/net/lib/app/ieee802154_settings.c
@@ -1,0 +1,62 @@
+/* IEEE 802.15.4 settings code */
+
+/*
+ * Copyright (c) 2017 Intel Corporation.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <zephyr.h>
+#include <errno.h>
+
+#include <net/net_if.h>
+#include <net/net_core.h>
+#include <net/net_mgmt.h>
+#include <net/ieee802154.h>
+
+int _net_app_ieee802154_setup(void)
+{
+	u16_t channel = CONFIG_NET_APP_IEEE802154_CHANNEL;
+	u16_t pan_id = CONFIG_NET_APP_IEEE802154_PAN_ID;
+	s16_t tx_power = CONFIG_NET_APP_IEEE802154_RADIO_TX_POWER;
+
+#ifdef CONFIG_NET_L2_IEEE802154_SECURITY
+	struct ieee802154_security_params sec_params = {
+		.key = CONFIG_NET_APP_IEEE802154_SECURITY_KEY,
+		.key_len = sizeof(CONFIG_NET_APP_IEEE802154_SECURITY_KEY),
+		.key_mode = CONFIG_NET_APP_IEEE802154_SECURITY_KEY_MODE,
+		.level = CONFIG_NET_APP_IEEE802154_SECURITY_LEVEL,
+	};
+#endif /* CONFIG_NET_L2_IEEE802154_SECURITY */
+
+	struct net_if *iface;
+	struct device *dev;
+
+	dev = device_get_binding(CONFIG_NET_APP_IEEE802154_DEV_NAME);
+	if (!dev) {
+		return -ENODEV;
+	}
+
+	iface = net_if_lookup_by_dev(dev);
+	if (!iface) {
+		return -EINVAL;
+	}
+
+	if (net_mgmt(NET_REQUEST_IEEE802154_SET_PAN_ID,
+		     iface, &pan_id, sizeof(u16_t)) ||
+	    net_mgmt(NET_REQUEST_IEEE802154_SET_CHANNEL,
+		     iface, &channel, sizeof(u16_t)) ||
+	    net_mgmt(NET_REQUEST_IEEE802154_SET_TX_POWER,
+		     iface, &tx_power, sizeof(s16_t))) {
+		return -EINVAL;
+	}
+
+#ifdef CONFIG_NET_L2_IEEE802154_SECURITY
+	if (net_mgmt(NET_REQUEST_IEEE802154_SET_SECURITY_SETTINGS, iface,
+		     &sec_params, sizeof(struct ieee802154_security_params))) {
+		return -EINVAL;
+	}
+#endif /* CONFIG_NET_L2_IEEE802154_SECURITY */
+
+	return 0;
+}

--- a/subsys/net/lib/app/ieee802154_settings.h
+++ b/subsys/net/lib/app/ieee802154_settings.h
@@ -1,0 +1,13 @@
+/* IEEE 802.15.4 settings header */
+
+/*
+ * Copyright (c) 2017 Intel Corporation.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#if defined(CONFIG_NET_L2_IEEE802154) && defined(CONFIG_NET_APP_SETTINGS)
+int _net_app_ieee802154_setup(void);
+#else
+#define _net_app_ieee802154_setup(...) 0
+#endif

--- a/subsys/net/lib/app/init.c
+++ b/subsys/net/lib/app/init.c
@@ -27,6 +27,8 @@
 
 #include <net/net_app.h>
 
+#include "ieee802154_settings.h"
+
 static K_SEM_DEFINE(waiter, 0, 1);
 static struct k_sem counter;
 
@@ -245,6 +247,14 @@ static int init_net_app(struct device *device)
 	int ret;
 
 	ARG_UNUSED(device);
+
+#if defined(CONFIG_NET_IPV6)
+	/* IEEE 802.15.4 is only usable if IPv6 is enabled */
+	ret = _net_app_ieee802154_setup();
+	if (ret < 0) {
+		NET_ERR("Cannot setup IEEE 802.15.4 interface (%d)", ret);
+	}
+#endif
 
 	if (IS_ENABLED(CONFIG_NET_APP_NEED_IPV6)) {
 		flags |= NET_APP_NEED_IPV6;


### PR DESCRIPTION
If IEEE 802.15.4 is enabled, then setup the network settings
automatically so that the device is ready for IP configuration.
This is only done if CONFIG_NET_APP_AUTO_INIT is enabled, which
is currently the default.

Signed-off-by: Jukka Rissanen <jukka.rissanen@linux.intel.com>