### PR TITLE
ext: lib: mbedtls: Add example config for DTLS support

### DIFF
--- a/ext/lib/crypto/mbedtls/configs/config-mini-dtls1_2.h
+++ b/ext/lib/crypto/mbedtls/configs/config-mini-dtls1_2.h
@@ -1,0 +1,83 @@
+/*
+ * Copyright (C) 2006-2015, ARM Limited, All Rights Reserved
+ * Copyright (c) 2017 Intel Corporation.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Minimal configuration for DTLS 1.2 for Zephyr with PSK and AES-CCM
+ * ciphersuites.
+ *
+ * See README.txt for usage instructions.
+ */
+#ifndef MBEDTLS_CONFIG_H
+#define MBEDTLS_CONFIG_H
+
+/* System support */
+#define MBEDTLS_PLATFORM_C
+#define MBEDTLS_PLATFORM_MEMORY
+#define MBEDTLS_MEMORY_BUFFER_ALLOC_C
+#define MBEDTLS_PLATFORM_NO_STD_FUNCTIONS
+#define MBEDTLS_PLATFORM_EXIT_ALT
+#define MBEDTLS_NO_PLATFORM_ENTROPY
+#define MBEDTLS_NO_DEFAULT_ENTROPY_SOURCES
+#define MBEDTLS_PLATFORM_PRINTF_ALT
+
+#if defined(CONFIG_MBEDTLS_TEST)
+#define MBEDTLS_SELF_TEST
+#define MBEDTLS_DEBUG_C
+#else
+#define MBEDTLS_ENTROPY_C
+#endif
+
+/* mbed TLS feature support */
+#define MBEDTLS_CIPHER_MODE_CBC
+#define MBEDTLS_PKCS1_V15
+#define MBEDTLS_KEY_EXCHANGE_RSA_ENABLED
+#define MBEDTLS_KEY_EXCHANGE_PSK_ENABLED
+#define MBEDTLS_SSL_MAX_FRAGMENT_LENGTH
+#define MBEDTLS_SSL_PROTO_TLS1_2
+#define MBEDTLS_SSL_PROTO_DTLS
+#define MBEDTLS_SSL_DTLS_ANTI_REPLAY
+#define MBEDTLS_SSL_DTLS_HELLO_VERIFY
+
+/* mbed TLS modules */
+#define MBEDTLS_AES_C
+#define MBEDTLS_ASN1_PARSE_C
+#define MBEDTLS_ASN1_WRITE_C
+#define MBEDTLS_BIGNUM_C
+#define MBEDTLS_CIPHER_C
+#define MBEDTLS_CTR_DRBG_C
+#define MBEDTLS_DES_C
+#define MBEDTLS_ENTROPY_C
+#define MBEDTLS_MD_C
+#define MBEDTLS_MD5_C
+#define MBEDTLS_OID_C
+#define MBEDTLS_RSA_C
+#define MBEDTLS_PK_C
+#define MBEDTLS_PK_PARSE_C
+#define MBEDTLS_SHA1_C
+#define MBEDTLS_SHA256_C
+#define MBEDTLS_SSL_CLI_C
+#define MBEDTLS_SSL_SRV_C
+#define MBEDTLS_SSL_TLS_C
+#define MBEDTLS_X509_CRT_PARSE_C
+#define MBEDTLS_X509_USE_C
+#define MBEDTLS_CCM_C
+#define MBEDTLS_SSL_COOKIE_C
+
+/* For test certificates */
+#define MBEDTLS_BASE64_C
+#define MBEDTLS_CERTS_C
+
+#if defined(CONFIG_MBEDTLS_DEBUG)
+#define MBEDTLS_ERROR_C
+#define MBEDTLS_DEBUG_C
+#define MBEDTLS_SSL_DEBUG_ALL
+#define MBEDTLS_SSL_ALL_ALERT_MESSAGES
+#endif
+
+#define MBEDTLS_SSL_MAX_CONTENT_LEN             1500
+
+#include "mbedtls/check_config.h"
+
+#endif /* MBEDTLS_CONFIG_H */


### PR DESCRIPTION
This mbedtls configuration creates support for DTLS. The values
are not optimized for RAM usage, but can be used for various
networking sample applications.

Signed-off-by: Jukka Rissanen <jukka.rissanen@linux.intel.com>