### PR TITLE
tests: kernel: sprintf: Fix build warning.

### DIFF
--- a/tests/kernel/sprintf/src/test_sprintf.c
+++ b/tests/kernel/sprintf/src/test_sprintf.c
@@ -435,7 +435,7 @@ int sprintf_misc_test(void)
 	}
 
 	/*******************/
-	sprintf(buffer, "%hx", 1234);
+	sprintf(buffer, "%hx", (unsigned short)1234);
 	if (strcmp("4d2", buffer) != 0) {
 		TC_ERROR("sprintf(%%hx).  Expected '4d2', got '%s'\n", buffer);
 		status = TC_FAIL;


### PR DESCRIPTION
As there is no suffix to represent a literal as unsigned short
it is typecasted. It is fix for Jira ZEP-2156

Signed-off-by: Savinay Dharmappa <savinay.dharmappa@intel.com>