### PR TITLE
net: if: Check in delete addr if delayed work needs cancelling

### DIFF
--- a/subsys/net/ip/net_if.c
+++ b/subsys/net/ip/net_if.c
@@ -668,7 +668,9 @@ bool net_if_ipv6_addr_rm(struct net_if *iface, const struct in6_addr *addr)
 			continue;
 		}
 
-		k_delayed_work_cancel(&iface->ipv6.unicast[i].lifetime);
+		if (!iface->ipv6.unicast[i].is_infinite) {
+			k_delayed_work_cancel(&iface->ipv6.unicast[i].lifetime);
+		}
 
 		iface->ipv6.unicast[i].is_used = false;
 


### PR DESCRIPTION
The address lifetime timer was cancelled always even if the address
timer was never installed.

Jira: ZEP-2397

Signed-off-by: Jukka Rissanen <jukka.rissanen@linux.intel.com>