### PR TITLE
Makefile: explicitly disable PIE

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -660,6 +660,8 @@ endif
 
 # Some GCC variants don't support these
 KBUILD_CFLAGS += $(call cc-option,-fno-asynchronous-unwind-tables,)
+KBUILD_CFLAGS += $(call cc-option,-fno-pie,)
+KBUILD_CFLAGS += $(call cc-option,-fno-pic,)
 
 ifeq ($(CONFIG_STACK_CANARIES),y)
 KBUILD_CFLAGS += $(call cc-option,-fstack-protector-all,)
@@ -754,6 +756,7 @@ KBUILD_CFLAGS += $(KCFLAGS)
 
 LINKFLAGPREFIX ?= -Wl,
 LDFLAGS_zephyr += $(LDFLAGS)
+LDFLAGS_zephyr += $(call cc-ldoption,-no-pie)
 LDFLAGS_zephyr += $(call cc-ldoption,$(LINKFLAGPREFIX)-X)
 LDFLAGS_zephyr += $(call cc-ldoption,$(LINKFLAGPREFIX)-N)
 LDFLAGS_zephyr += $(call cc-ldoption,$(LINKFLAGPREFIX)--gc-sections)


### PR DESCRIPTION
Modern GCC can be configured to default to PIE. To support
such toolchains, turn PIE off as otherwise the generated
binaries are broken in multiple ways (e.g. the ELF will have
additional sections that get inserted at end of _TEXT_SECTION
making __data_rom_start point to these sections and not
the data secions).

Signed-off-by: Timo Teräs <timo.teras@iki.fi>