### PR TITLE
Remove explicit app state partitions from DTS

### DIFF
--- a/dts/arm/96b_nitrogen.dts
+++ b/dts/arm/96b_nitrogen.dts
@@ -62,10 +62,5 @@
 		 * 0x0007ffff (sectors 125-127) is reserved for use
 		 * by the application.
 		 */
-
-		app_state_partition: partition@7d000 {
-			label = "application-state";
-			reg = <0x0007d000 0x3000>;
-		};
 	};
 };

--- a/dts/arm/disco_l475_iot1.dts
+++ b/dts/arm/disco_l475_iot1.dts
@@ -48,10 +48,12 @@
 			reg = <0x00000000 0x00010000>;
 			read-only;
 		};
-		app_state_partition: partition@10000 {
-			label = "application-state";
-			reg = <0x00010000 0x00010000>;
-		};
+
+		/*
+		 * The flash starting at offset 0x10000 and ending at
+		 * offset 0x1ffff is reserved for use by the application.
+		 */
+
 		slot0_partition: partition@20000 {
 			label = "image-0";
 			reg = <0x00020000 0x0006C000>;

--- a/dts/arm/nucleo_f401re.dts
+++ b/dts/arm/nucleo_f401re.dts
@@ -49,10 +49,12 @@
 			reg = <0x00000000 0x00010000>;
 			read-only;
 		};
-		app_state_partition: partition@10000 {
-			label = "application-state";
-			reg = <0x00010000 0x00010000>;
-		};
+
+		/*
+		 * The flash starting at offset 0x10000 and ending at
+		 * offset 0x1ffff is reserved for use by the application.
+		 */
+
 		slot0_partition: partition@20000 {
 			label = "image-0";
 			reg = <0x00020000 0x00020000>;


### PR DESCRIPTION
This finishes the work begun in https://github.com/zephyrproject-rtos/zephyr/pull/770 by applying the same approach to other boards.