### PR TITLE
arch: quark_se: select config UART_QMSI_0 by default

### DIFF
--- a/arch/x86/soc/intel_quark/quark_se/Kconfig.defconfig.series
+++ b/arch/x86/soc/intel_quark/quark_se/Kconfig.defconfig.series
@@ -201,10 +201,10 @@ if BLUETOOTH_H4
 if !HAS_DTS
 config BLUETOOTH_UART_ON_DEV_NAME
 	default UART_QMSI_0_NAME
+endif
 
 config UART_QMSI_0
 	def_bool y
-endif
 
 if !HAS_DTS
 config UART_QMSI_0_BAUDRATE


### PR DESCRIPTION
'commit
("devicetree: Generate BLUETOOTH_UART ,UART_PIPE etc config from dt")'
created a dependency of selecting UART_QMSI_0 on device tree.
This change is reverted as it incorrect.

Signed-off-by: Savinay Dharmappa <savinay.dharmappa@intel.com>