### PR TITLE
spim_nrf52: Fixes

### DIFF
--- a/drivers/spi/spim_nrf52.c
+++ b/drivers/spi/spim_nrf52.c
@@ -139,6 +139,7 @@ static int spim_nrf52_configure(struct device *dev,
 		break;
 	case 8000000:
 		spim->FREQUENCY = SPIM_FREQUENCY_FREQUENCY_M8;
+		break;
 	default:
 		SYS_LOG_ERR("unsupported frequency sck=%d\n",
 			    spi_config->max_sys_freq);

--- a/drivers/spi/spim_nrf52.c
+++ b/drivers/spi/spim_nrf52.c
@@ -326,7 +326,7 @@ static int spim_nrf52_init(struct device *dev)
 		if (config->psel.ss[i] != SS_UNUSED) {
 			status = gpio_pin_configure(data->gpio_port,
 						    config->psel.ss[i],
-						    GPIO_DIR_OUT);
+						    GPIO_DIR_OUT | GPIO_PUD_PULL_UP);
 			__ASSERT_NO_MSG(status == 0);
 
 			spim_nrf52_csn(data->gpio_port, config->psel.ss[i],


### PR DESCRIPTION
Here are two fixes for the SPIM driver of the NRF52.

- The first patch fixes a bug that prevents using a speed of 8 MHz due to a missing "break"
- The second patch fixes a glitch issue when configuring the CS line