### PR TITLE
DTS: flash alignment description

### DIFF
--- a/dts/arm/nordic/nrf52840.dtsi
+++ b/dts/arm/nordic/nrf52840.dtsi
@@ -13,8 +13,18 @@
 		};
 	};
 
-	flash0: flash@0 {
-		reg = <0x00000000 DT_FLASH_SIZE>;
+	flash-controller@4001E000 {
+			compatible = "nrf,nrf52-flash-controller";
+			reg = <0x4001E000 0x550>;
+
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			flash0: flash@0 {
+				compatible = "soc-nv-flash";
+				reg = <0x00000000 DT_FLASH_SIZE>;
+				write-block-size = <4>;
+			};
 	};
 
 	sram0: memory@20000000 {

--- a/dts/common/yaml/soc-nv-flash.yaml
+++ b/dts/common/yaml/soc-nv-flash.yaml
@@ -1,0 +1,26 @@
+---
+title: Flash base node description
+id: soc-nv-flash
+version: 0.1
+
+description: >
+    This binding gives a base FLASH description
+
+properties:
+  - compatible:
+      type: string
+      category: optional
+      description: compatible strings
+      constraint: "soc-nv-flash"
+
+  - write-block-size:
+     type: int
+     description: address alignment required by flash write operations
+     generation: define
+     category: optional
+     label: alignment
+
+base_label: FLASH
+use-property-label: yes
+
+...


### PR DESCRIPTION
Added property for description of
the flash alignment required by write operations.
Thanks to that l-value FLASH_WRITE_BLOCK_SIZE macro
will be generated. It is useful for any component uses
the flash.

Added such a description for nrf52840 SoC.

Signed-off-by: Andrzej Puzdrowski <andrzej.puzdrowski@nordicsemi.no>