### PR TITLE
arch: arm: stm32l4: Add pin config for USART1 on PB6/PB7

### DIFF
--- a/arch/arm/soc/st_stm32/stm32l4/soc_pinmux.c
+++ b/arch/arm/soc/st_stm32/stm32l4/soc_pinmux.c
@@ -37,11 +37,15 @@ static const stm32_pin_func_t pin_pa3_funcs[] = {
 static const stm32_pin_func_t pin_pb6_funcs[] = {
 	[STM32L4X_PINMUX_FUNC_PB6_I2C1_SCL - 1] =
 		STM32L4X_PIN_CONFIG_OPEN_DRAIN_PULL_UP,
+	[STM32L4X_PINMUX_FUNC_PB6_USART1_TX - 1] =
+		STM32L4X_PIN_CONFIG_PUSH_PULL,
 };
 
 static const stm32_pin_func_t pin_pb7_funcs[] = {
 	[STM32L4X_PINMUX_FUNC_PB7_I2C1_SDA - 1] =
 		STM32L4X_PIN_CONFIG_OPEN_DRAIN_PULL_UP,
+	[STM32L4X_PINMUX_FUNC_PB7_USART1_RX - 1] =
+		STM32L4X_PIN_CONFIG_BIAS_HIGH_IMPEDANCE,
 };
 
 static const stm32_pin_func_t pin_pb10_funcs[] = {


### PR DESCRIPTION
With introduction of commit "pinmux: stm32: directly return error if
stm32_get_pin_config fails", pin configuration fails when
pins are not configured in pins[] array.
This was the case for configuration UART1 assigned on PB6/PB7.

Signed-off-by: Erwan Gouriou <erwan.gouriou@linaro.org>