### PR TITLE
net: doc: Add missing defgroups to network header files

### DIFF
--- a/.known-issues/doc/networking.conf
+++ b/.known-issues/doc/networking.conf
@@ -47,3 +47,67 @@
 ^(?P=filename):(?P=lineno): WARNING: Invalid definition: Expected end of definition. \[error at [0-9]+]
 ^.*net_mgmt_event_callback.__unnamed__
 ^[- \t]*\^
+#
+# include/net/buf.h
+#
+^(?P<filename>[-._/\w]+/doc/api/networking.rst):(?P<lineno>[0-9]+): WARNING: Invalid definition: Expected identifier in nested name. \[error at [0-9]+]
+^[ \t]*
+^[ \t]*\^
+^(?P=filename):(?P=lineno): WARNING: Invalid definition: Expected identifier in nested name. \[error at [0-9]+]
+^[ \t]*
+^[ \t]*\^
+^(?P=filename):(?P=lineno): WARNING: Invalid definition: Expected end of definition. \[error at [0-9]+]
+^.*net_buf.__unnamed__
+^[- \t]*\^
+#
+# include/net/ieee802154.h
+#
+^(?P<filename>[-._/\w]+/doc/api/networking.rst):(?P<lineno>[0-9]+): WARNING: Invalid definition: Expected identifier in nested name. \[error at [0-9]+]
+^[ \t]*
+^[ \t]*\^
+^(?P=filename):(?P=lineno): WARNING: Invalid definition: Expected identifier in nested name. \[error at [0-9]+]
+^[ \t]*
+^[ \t]*\^
+^(?P=filename):(?P=lineno): WARNING: Invalid definition: Expected end of definition. \[error at [0-9]+]
+^.*ieee802154_req_params.__unnamed__
+^[- \t]*\^
+#
+# Various warning about net_mgmt declarations
+#
+^(?P<filename>[-._/\w]+/doc/api/networking.rst):(?P<lineno>[0-9]+): WARNING: Error when parsing function declaration\.
+^If the function has no return type\:
+^[ \t]*Error in declarator or parameters and qualifiers
+^[ \t]*Invalid definition: Expected identifier in nested name\. \[error at [0-9]+\]
+^[ \t]*NET_MGMT_DEFINE_.*?$
+^[- \t]*\^
+#
+^If the function has a return type\:
+^[ \t]*Error in declarator
+^[ \t]*If pointer to member declarator:
+^[ \t]*Invalid definition: Expected identifier in nested name\. \[error at [0-9]+\]
+^[ \t]*NET_MGMT_DEFINE_.*?$
+^[- \t]*\^
+#
+^[ \t]*If declId, parameters, and qualifiers\:
+^[ \t]*Invalid definition: Expected identifier in nested name\. \[error at [0-9]+\]
+^[ \t]*NET_MGMT_DEFINE_.*?$
+^[- \t]*\^
+#
+^[ \t]*If parenthesis in noptr-declarator\:
+^[ \t]*Error in declarator
+^[ \t]*If pointer to member declarator:
+^[ \t]*Invalid definition: Expected identifier in nested name\. \[error at [0-9]+\]
+^[ \t]*NET_MGMT_DEFINE_.*?$
+^[- \t]*\^
+#
+^[ \t]*If parenthesis in noptr-declarator\:
+^[ \t]*Error in declarator or parameters and qualifiers
+^[ \t]*If pointer to member declarator:
+^[ \t]*Invalid definition: Expected \'\:\:\' in pointer to member \(function\)\. \[error at [0-9]+\]
+^[ \t]*NET_MGMT_DEFINE_.*?$
+^[- \t]*\^
+#
+^[ \t]*If declarator-id:
+^[ \t]*Invalid definition: Expecting \"\(\" in parameters_and_qualifiers\. \[error at [0-9]+\]
+^[ \t]*NET_MGMT_DEFINE_.*?$
+^[- \t]*\^

--- a/doc/api/networking.rst
+++ b/doc/api/networking.rst
@@ -13,6 +13,27 @@ depends on relevant Kconfig options. For instance IPv6 related
 APIs will not be present if :option:`CONFIG_NET_IPV6` has not
 been selected.
 
+Network core helpers
+********************
+
+.. doxygengroup:: net_core
+   :project: Zephyr
+   :content-only:
+
+Network buffers
+***************
+
+.. doxygengroup:: net_buf
+   :project: Zephyr
+   :content-only:
+
+Network packet management
+*************************
+
+.. doxygengroup:: net_pkt
+   :project: Zephyr
+   :content-only:
+
 IPv4/IPv6 primitives and helpers
 ********************************
 
@@ -34,6 +55,20 @@ Network Management
    :project: Zephyr
    :content-only:
 
+Network layer 2 management
+**************************
+
+.. doxygengroup:: net_l2
+   :project: Zephyr
+   :content-only:
+
+Network link address
+********************
+
+.. doxygengroup:: net_linkaddr
+   :project: Zephyr
+   :content-only:
+
 Application network context
 ***************************
 
@@ -41,8 +76,60 @@ Application network context
    :project: Zephyr
    :content-only:
 
+Network offloading support
+**************************
+
+.. doxygengroup:: net_offload
+   :project: Zephyr
+   :content-only:
+
+Network statistics
+******************
+
+.. doxygengroup:: net_stats
+   :project: Zephyr
+   :content-only:
+
+Trickle timer support
+*********************
+
+.. doxygengroup:: trickle
+   :project: Zephyr
+   :content-only:
+
+UDP
+***
+
+.. doxygengroup:: udp
+   :project: Zephyr
+   :content-only:
+
+Network technologies
+********************
+
+Ethernet
+========
+
+.. doxygengroup:: ethernet
+   :project: Zephyr
+   :content-only:
+
+IEEE 802.15.4
+=============
+
+.. doxygengroup:: ieee802154
+   :project: Zephyr
+   :content-only:
+
 Network and application libraries
 *********************************
+
+Network application
+===================
+
+.. doxygengroup:: net_app
+   :project: Zephyr
+   :content-only:
 
 DHCPv4
 ======
@@ -58,9 +145,23 @@ MQTT 3.1.1
    :project: Zephyr
    :content-only:
 
+CoAP
+====
+
+.. doxygengroup:: zoap
+   :project: Zephyr
+   :content-only:
+
 DNS Resolve
 ===========
 
 .. doxygengroup:: dns_resolve
+   :project: Zephyr
+   :content-only:
+
+HTTP
+====
+
+.. doxygengroup:: http
    :project: Zephyr
    :content-only:

--- a/include/net/arp.h
+++ b/include/net/arp.h
@@ -21,6 +21,12 @@ extern "C" {
 
 #include <net/ethernet.h>
 
+/**
+ * @brief Address resolution (ARP) library
+ * @defgroup arp ARP Library
+ * @{
+ */
+
 #define NET_ARP_HDR(pkt) ((struct net_arp_hdr *)net_pkt_ip_data(pkt))
 
 struct net_arp_hdr {
@@ -45,6 +51,10 @@ enum net_verdict net_arp_input(struct net_pkt *pkt);
 
 void net_arp_clear_cache(void);
 void net_arp_init(void);
+
+/**
+ * @}
+ */
 
 #else /* CONFIG_NET_ARP */
 

--- a/include/net/buf.h
+++ b/include/net/buf.h
@@ -19,6 +19,12 @@
 extern "C" {
 #endif
 
+/**
+ * @brief Network buffer library
+ * @defgroup net_buf Network Buffer Library
+ * @{
+ */
+
 /* Alignment needed for various parts of the buffer definition */
 #define __net_buf_align __aligned(sizeof(int))
 
@@ -1021,6 +1027,10 @@ static inline size_t net_buf_frags_len(struct net_buf *buf)
 
 	return bytes;
 }
+
+/**
+ * @}
+ */
 
 #ifdef __cplusplus
 }

--- a/include/net/ethernet.h
+++ b/include/net/ethernet.h
@@ -24,6 +24,12 @@
 extern "C" {
 #endif
 
+/**
+ * @brief Ethernet support functions
+ * @defgroup ethernet Ethernet Support Functions
+ * @{
+ */
+
 #define NET_ETH_HDR(pkt) ((struct net_eth_hdr *)net_pkt_ll(pkt))
 
 #define NET_ETH_PTYPE_ARP		0x0806
@@ -71,5 +77,9 @@ const struct net_eth_addr *net_eth_broadcast_addr(void);
 #ifdef __cplusplus
 }
 #endif
+
+/**
+ * @}
+ */
 
 #endif /* __ETHERNET_H */

--- a/include/net/http.h
+++ b/include/net/http.h
@@ -13,6 +13,12 @@
 extern "C" {
 #endif
 
+/**
+ * @brief HTTP client and server library
+ * @defgroup http HTTP Library
+ * @{
+ */
+
 #if defined(CONFIG_HTTPS)
 #if defined(CONFIG_MBEDTLS)
 #if !defined(CONFIG_MBEDTLS_CFG_FILE)
@@ -1055,5 +1061,9 @@ int http_response_404(struct http_server_ctx *ctx, const char *html_payload);
 #ifdef __cplusplus
 }
 #endif
+
+/**
+ * @}
+ */
 
 #endif /* __HTTP_H__ */

--- a/include/net/ieee802154.h
+++ b/include/net/ieee802154.h
@@ -19,6 +19,12 @@
 extern "C" {
 #endif
 
+/**
+ * @brief IEEE 802.15.4 library
+ * @defgroup ieee802154 IEEE 802.15.4 Library
+ * @{
+ */
+
 #define IEEE802154_MAX_ADDR_LENGTH	8
 
 struct ieee802154_security_ctx {
@@ -261,5 +267,9 @@ struct ieee802154_security_params {
 #ifdef __cplusplus
 }
 #endif
+
+/**
+ * @}
+ */
 
 #endif /* __IEEE802154_H__ */

--- a/include/net/ieee802154_radio.h
+++ b/include/net/ieee802154_radio.h
@@ -19,6 +19,11 @@
 extern "C" {
 #endif
 
+/**
+ * @addtogroup ieee802154
+ * @{
+ */
+
 struct ieee802154_radio_api {
 	/**
 	 * Mandatory to get in first position.
@@ -98,5 +103,9 @@ void ieee802154_init(struct net_if *iface);
 #ifdef __cplusplus
 }
 #endif
+
+/**
+ * @}
+ */
 
 #endif /* __IEEE802154_RADIO_H__ */

--- a/include/net/mii.h
+++ b/include/net/mii.h
@@ -11,6 +11,11 @@
 #ifndef _MII_H_
 #define _MII_H_
 
+/**
+ * @addtogroup ethernet
+ * @{
+ */
+
 /* MII management registers */
 #define MII_BMCR       0x0  /** Basic Mode Control Register */
 #define MII_BMSR       0x1  /** Basic Mode Status Register */
@@ -75,5 +80,9 @@
 #define MII_ADVERTISE_ALL (MII_ADVERTISE_10_HALF | MII_ADVERTISE_10_FULL |\
 			   MII_ADVERTISE_100_HALF | MII_ADVERTISE_100_FULL |\
 			   MII_ADVERTISE_SEL_IEEE_802_3)
+
+/**
+ * @}
+ */
 
 #endif /* _MII_H_ */

--- a/include/net/mqtt_types.h
+++ b/include/net/mqtt_types.h
@@ -14,8 +14,7 @@ extern "C" {
 #endif
 
 /**
- * @brief MQTT library
- * @defgroup mqtt MQTT library
+ * @addtogroup mqtt
  * @{
  */
 

--- a/include/net/net_app.h
+++ b/include/net/net_app.h
@@ -48,6 +48,12 @@
 extern "C" {
 #endif
 
+/**
+ * @brief Network application library
+ * @defgroup net_app Network Application Library
+ * @{
+ */
+
 /** Flags that tell what kind of functionality is needed by the application. */
 #define NET_APP_NEED_ROUTER 0x00000001
 #define NET_APP_NEED_IPV6   0x00000002
@@ -898,6 +904,10 @@ bool net_app_server_tls_disable(struct net_app_ctx *ctx);
 #endif /* CONFIG_NET_APP_SERVER */
 
 #endif /* CONFIG_NET_APP_TLS */
+
+/**
+ * @}
+ */
 
 #ifdef __cplusplus
 }

--- a/include/net/net_core.h
+++ b/include/net/net_core.h
@@ -17,6 +17,12 @@
 extern "C" {
 #endif
 
+/**
+ * @brief Network core library
+ * @defgroup net_core Network Core Library
+ * @{
+ */
+
 /* Network subsystem logging helpers */
 
 #if defined(NET_LOG_ENABLED)
@@ -163,6 +169,10 @@ static inline void net_analyze_stack(const char *name,
 #define net_analyze_stack_get_values(...)
 #endif
 /* @endcond */
+
+/**
+ * @}
+ */
 
 #ifdef __cplusplus
 }

--- a/include/net/net_event.h
+++ b/include/net/net_event.h
@@ -16,6 +16,11 @@
 extern "C" {
 #endif
 
+/**
+ * @addtogroup net_mgmt
+ * @{
+ */
+
 /* Network Interface events */
 #define _NET_IF_LAYER		NET_MGMT_LAYER_L1
 #define _NET_IF_CORE_CODE	0x001
@@ -128,5 +133,9 @@ enum net_event_ipv4_cmd {
 #ifdef __cplusplus
 }
 #endif
+
+/**
+ * @}
+ */
 
 #endif /* __NET_EVENT_H__ */

--- a/include/net/net_l2.h
+++ b/include/net/net_l2.h
@@ -18,6 +18,12 @@
 extern "C" {
 #endif
 
+/**
+ * @brief Network Layer 2 abstraction layer
+ * @defgroup net_l2 Network L2 Abstraction Layer
+ * @{
+ */
+
 struct net_if;
 
 struct net_l2 {
@@ -100,6 +106,10 @@ extern struct net_l2 __net_l2_end[];
 #define NET_L2_DATA_INIT(name, sfx, ctx_type)				\
 	static ctx_type NET_L2_GET_DATA(name, sfx) __used		\
 	__attribute__((__section__(".net_l2.data")));
+
+/**
+ * @}
+ */
 
 #ifdef __cplusplus
 }

--- a/include/net/net_linkaddr.h
+++ b/include/net/net_linkaddr.h
@@ -20,6 +20,12 @@
 extern "C" {
 #endif
 
+/**
+ * @brief Network link address library
+ * @defgroup net_linkaddr Network Link Address Library
+ * @{
+ */
+
 #ifdef CONFIG_NET_L2_IEEE802154
 #define NET_LINK_ADDR_MAX_LENGTH 8
 #else
@@ -124,6 +130,10 @@ static inline int net_linkaddr_set(struct net_linkaddr_storage *lladdr_store,
 
 	return 0;
 }
+
+/**
+ * @}
+ */
 
 #ifdef __cplusplus
 }

--- a/include/net/net_offload.h
+++ b/include/net/net_offload.h
@@ -12,6 +12,12 @@
 #ifndef __NET_OFFLOAD_H__
 #define __NET_OFFLOAD_H__
 
+/**
+ * @brief Network offloading interface
+ * @defgroup net_offload Network Offloading Interface
+ * @{
+ */
+
 #if defined(CONFIG_NET_OFFLOAD)
 
 #include <net/buf.h>
@@ -426,5 +432,9 @@ static inline int net_offload_put(struct net_if *iface,
 #endif
 
 #endif /* CONFIG_NET_OFFLOAD */
+
+/**
+ * @}
+ */
 
 #endif /* __NET_OFFLOAD_H__ */

--- a/include/net/net_pkt.h
+++ b/include/net/net_pkt.h
@@ -31,6 +31,12 @@
 extern "C" {
 #endif
 
+/**
+ * @brief Network packet management library
+ * @defgroup net_pkt Network Packet Library
+ * @{
+ */
+
 struct net_context;
 
 struct net_pkt {
@@ -1351,6 +1357,10 @@ const char *net_pkt_pool2str(struct net_buf_pool *pool);
 #else
 #define net_pkt_print(...)
 #endif /* CONFIG_NET_DEBUG_NET_PKT */
+
+/**
+ * @}
+ */
 
 #ifdef __cplusplus
 }

--- a/include/net/net_stats.h
+++ b/include/net/net_stats.h
@@ -20,6 +20,12 @@
 extern "C" {
 #endif
 
+/**
+ * @brief Network statistics library
+ * @defgroup net_stats Network Statistics Library
+ * @{
+ */
+
 typedef u32_t net_stats_t;
 
 struct net_stats_bytes {
@@ -359,6 +365,10 @@ NET_MGMT_DEFINE_REQUEST_HANDLER(NET_REQUEST_STATS_GET_RPL);
 #endif /* CONFIG_NET_STATISTICS_RPL */
 
 #endif /* CONFIG_NET_STATISTICS_USER_API */
+
+/**
+ * @}
+ */
 
 #ifdef __cplusplus
 }

--- a/include/net/trickle.h
+++ b/include/net/trickle.h
@@ -23,6 +23,12 @@
 extern "C" {
 #endif
 
+/**
+ * @brief Trickle algorithm library
+ * @defgroup trickle Trickle Algorithm Library
+ * @{
+ */
+
 struct net_trickle;
 
 typedef void (*net_trickle_cb_t)(struct net_trickle *trickle,
@@ -119,6 +125,10 @@ static inline bool net_trickle_is_running(struct net_trickle *trickle)
 
 	return trickle->I != 0;
 }
+
+/**
+ * @}
+ */
 
 #ifdef __cplusplus
 }

--- a/include/net/udp.h
+++ b/include/net/udp.h
@@ -21,6 +21,12 @@
 extern "C" {
 #endif
 
+/**
+ * @brief UDP library
+ * @defgroup udp UDP Library
+ * @{
+ */
+
 #if defined(CONFIG_NET_UDP)
 
 /**
@@ -58,10 +64,15 @@ struct net_udp_hdr *net_udp_get_hdr(struct net_pkt *pkt,
  */
 struct net_udp_hdr *net_udp_set_hdr(struct net_pkt *pkt,
 				    struct net_udp_hdr *hdr);
+
 #else
 #define net_udp_get_hdr(pkt, frag) NULL
 #define net_udp_set_hdr(pkt, frag) NULL
 #endif /* CONFIG_NET_UDP */
+
+/**
+ * @}
+ */
 
 #ifdef __cplusplus
 }

--- a/include/net/zoap_link_format.h
+++ b/include/net/zoap_link_format.h
@@ -18,8 +18,7 @@ extern "C" {
 #endif
 
 /**
- * @brief COAP library
- * @defgroup zoap COAP Library
+ * @addtogroup zoap COAP Library
  * @{
  */
 


### PR DESCRIPTION
Some of the networking header files in include/net/ directory were
missing @defgroup doxygen directives.

There was also duplicate @defgroup directives which are now changed
to @addtogroup directives.

Jira: ZEP-2308

Signed-off-by: Jukka Rissanen <jukka.rissanen@linux.intel.com>