### PR TITLE
dts: arm: Add unit-address component to memory and flash nodes

### DIFF
--- a/dts/arm/atmel/sam3x.dtsi
+++ b/dts/arm/atmel/sam3x.dtsi
@@ -18,12 +18,12 @@
 		};
 	};
 
-	sram0: memory {
+	sram0: memory@20070000 {
 		compatible = "mmio-sram";
 		reg = <0x20070000 0x18000>;
 	};
 
-	flash0: flash {
+	flash0: flash@80000 {
 		reg = <0x00080000 0x80000>;
 	};
 

--- a/dts/arm/atmel/sam3x.dtsi
+++ b/dts/arm/atmel/sam3x.dtsi
@@ -19,6 +19,7 @@
 	};
 
 	sram0: memory@20070000 {
+		device_type = "memory";
 		compatible = "mmio-sram";
 		reg = <0x20070000 0x18000>;
 	};

--- a/dts/arm/atmel/sam4s.dtsi
+++ b/dts/arm/atmel/sam4s.dtsi
@@ -19,6 +19,7 @@
 	};
 
 	sram0: memory@20100000 {
+		device_type = "memory";
 		compatible = "mmio-sram";
 		reg = <0x20100000 0x20000>;
 	};

--- a/dts/arm/atmel/sam4s.dtsi
+++ b/dts/arm/atmel/sam4s.dtsi
@@ -18,12 +18,12 @@
 		};
 	};
 
-	sram0: memory {
+	sram0: memory@20100000 {
 		compatible = "mmio-sram";
 		reg = <0x20100000 0x20000>;
 	};
 
-	flash0: flash {
+	flash0: flash@400000 {
 		reg = <0x00400000 0x100000>;
 	};
 

--- a/dts/arm/atmel/same70.dtsi
+++ b/dts/arm/atmel/same70.dtsi
@@ -20,11 +20,11 @@
 		};
 	};
 
-	flash0: flash {
+	flash0: flash@400000 {
 		reg = <0x00400000 DT_FLASH_SIZE>;
 	};
 
-	sram0: memory {
+	sram0: memory@20400000 {
 		compatible = "mmio-sram";
 		reg = <0x20400000 DT_SRAM_SIZE>;
 	};

--- a/dts/arm/atmel/same70.dtsi
+++ b/dts/arm/atmel/same70.dtsi
@@ -25,6 +25,7 @@
 	};
 
 	sram0: memory@20400000 {
+		device_type = "memory";
 		compatible = "mmio-sram";
 		reg = <0x20400000 DT_SRAM_SIZE>;
 	};

--- a/dts/arm/nordic/nrf51822.dtsi
+++ b/dts/arm/nordic/nrf51822.dtsi
@@ -18,6 +18,7 @@
 	};
 
 	sram0: memory@20000000 {
+		device_type = "memory";
 		compatible = "mmio-sram";
 		reg = <0x20000000 DT_SRAM_SIZE>;
 	};

--- a/dts/arm/nordic/nrf51822.dtsi
+++ b/dts/arm/nordic/nrf51822.dtsi
@@ -13,11 +13,11 @@
 		};
 	};
 
-	flash0: flash {
+	flash0: flash@0 {
 		reg = <0x00000000 DT_FLASH_SIZE>;
 	};
 
-	sram0: memory {
+	sram0: memory@20000000 {
 		compatible = "mmio-sram";
 		reg = <0x20000000 DT_SRAM_SIZE>;
 	};

--- a/dts/arm/nordic/nrf52832.dtsi
+++ b/dts/arm/nordic/nrf52832.dtsi
@@ -18,6 +18,7 @@
 	};
 
 	sram0: memory@20000000 {
+		device_type = "memory";
 		compatible = "mmio-sram";
 		reg = <0x20000000 DT_SRAM_SIZE>;
 	};

--- a/dts/arm/nordic/nrf52832.dtsi
+++ b/dts/arm/nordic/nrf52832.dtsi
@@ -13,11 +13,11 @@
 		};
 	};
 
-	flash0: flash {
+	flash0: flash@0 {
 		reg = <0x00000000 DT_FLASH_SIZE>;
 	};
 
-	sram0: memory {
+	sram0: memory@20000000 {
 		compatible = "mmio-sram";
 		reg = <0x20000000 DT_SRAM_SIZE>;
 	};

--- a/dts/arm/nordic/nrf52840.dtsi
+++ b/dts/arm/nordic/nrf52840.dtsi
@@ -18,6 +18,7 @@
 	};
 
 	sram0: memory@20000000 {
+		device_type = "memory";
 		compatible = "mmio-sram";
 		reg = <0x20000000 DT_SRAM_SIZE>;
 	};

--- a/dts/arm/nordic/nrf52840.dtsi
+++ b/dts/arm/nordic/nrf52840.dtsi
@@ -13,11 +13,11 @@
 		};
 	};
 
-	flash0: flash {
+	flash0: flash@0 {
 		reg = <0x00000000 DT_FLASH_SIZE>;
 	};
 
-	sram0: memory {
+	sram0: memory@20000000 {
 		compatible = "mmio-sram";
 		reg = <0x20000000 DT_SRAM_SIZE>;
 	};

--- a/dts/arm/nxp/nxp_k6x.dtsi
+++ b/dts/arm/nxp/nxp_k6x.dtsi
@@ -13,6 +13,7 @@
 	};
 
 	sram0: memory@20000000 {
+		device_type = "memory";
 		compatible = "mmio-sram";
 		reg = <0x20000000 0x30000>;
 	};

--- a/dts/arm/nxp/nxp_k6x.dtsi
+++ b/dts/arm/nxp/nxp_k6x.dtsi
@@ -12,7 +12,7 @@
 		};
 	};
 
-	sram0: memory {
+	sram0: memory@20000000 {
 		compatible = "mmio-sram";
 		reg = <0x20000000 0x30000>;
 	};

--- a/dts/arm/nxp/nxp_kl25z.dtsi
+++ b/dts/arm/nxp/nxp_kl25z.dtsi
@@ -13,6 +13,7 @@
 	};
 
 	sram0: memory@1FFFF000 {
+		device_type = "memory";
 		compatible = "mmio-sram";
 		reg = <0x1FFFF000 0x4000>;
 	};

--- a/dts/arm/nxp/nxp_kl25z.dtsi
+++ b/dts/arm/nxp/nxp_kl25z.dtsi
@@ -12,7 +12,7 @@
 		};
 	};
 
-	sram0: memory {
+	sram0: memory@1FFFF000 {
 		compatible = "mmio-sram";
 		reg = <0x1FFFF000 0x4000>;
 	};

--- a/dts/arm/nxp/nxp_kw40z.dtsi
+++ b/dts/arm/nxp/nxp_kw40z.dtsi
@@ -13,6 +13,7 @@
 	};
 
 	sram0: memory@20000000 {
+		device_type = "memory";
 		compatible = "mmio-sram";
 		reg = <0x20000000 0x4000>;
 	};

--- a/dts/arm/nxp/nxp_kw40z.dtsi
+++ b/dts/arm/nxp/nxp_kw40z.dtsi
@@ -12,7 +12,7 @@
 		};
 	};
 
-	sram0: memory {
+	sram0: memory@20000000 {
 		compatible = "mmio-sram";
 		reg = <0x20000000 0x4000>;
 	};

--- a/dts/arm/nxp/nxp_kw41z.dtsi
+++ b/dts/arm/nxp/nxp_kw41z.dtsi
@@ -13,6 +13,7 @@
 	};
 
 	sram0: memory@20000000 {
+		device_type = "memory";
 		compatible = "mmio-sram";
 		reg = <0x20000000 0x20000>;
 	};

--- a/dts/arm/nxp/nxp_kw41z.dtsi
+++ b/dts/arm/nxp/nxp_kw41z.dtsi
@@ -12,7 +12,7 @@
 		};
 	};
 
-	sram0: memory {
+	sram0: memory@20000000 {
 		compatible = "mmio-sram";
 		reg = <0x20000000 0x20000>;
 	};

--- a/dts/arm/st/stm32f103Xb.dtsi
+++ b/dts/arm/st/stm32f103Xb.dtsi
@@ -27,6 +27,7 @@
 	};
 
 	sram0: memory@20000000 {
+		device_type = "memory";
 		compatible = "mmio-sram";
 		reg = <0x20000000 DT_SRAM_SIZE>;
 	};

--- a/dts/arm/st/stm32f103Xb.dtsi
+++ b/dts/arm/st/stm32f103Xb.dtsi
@@ -22,11 +22,11 @@
 		};
 	};
 
-	flash0: flash {
+	flash0: flash@8000000 {
 		reg = <0x08000000 DT_FLASH_SIZE>;
 	};
 
-	sram0: memory {
+	sram0: memory@20000000 {
 		compatible = "mmio-sram";
 		reg = <0x20000000 DT_SRAM_SIZE>;
 	};

--- a/dts/arm/st/stm32f103Xe.dtsi
+++ b/dts/arm/st/stm32f103Xe.dtsi
@@ -27,6 +27,7 @@
 	};
 
 	sram0: memory@20000000 {
+		device_type = "memory";
 		compatible = "mmio-sram";
 		reg = <0x20000000 DT_SRAM_SIZE>;
 	};

--- a/dts/arm/st/stm32f103Xe.dtsi
+++ b/dts/arm/st/stm32f103Xe.dtsi
@@ -22,11 +22,11 @@
 		};
 	};
 
-	flash0: flash {
+	flash0: flash@8000000 {
 		reg = <0x08000000 DT_FLASH_SIZE>;
 	};
 
-	sram0: memory {
+	sram0: memory@20000000 {
 		compatible = "mmio-sram";
 		reg = <0x20000000 DT_SRAM_SIZE>;
 	};

--- a/dts/arm/st/stm32f107.dtsi
+++ b/dts/arm/st/stm32f107.dtsi
@@ -19,11 +19,11 @@
 		};
 	};
 
-	flash0: flash {
+	flash0: flash@8000000 {
 		reg = <0x08000000 DT_FLASH_SIZE>;
 	};
 
-	sram0: memory {
+	sram0: memory@20000000 {
 		compatible = "mmio-sram";
 		reg = <0x20000000 DT_SRAM_SIZE>;
 	};

--- a/dts/arm/st/stm32f107.dtsi
+++ b/dts/arm/st/stm32f107.dtsi
@@ -24,6 +24,7 @@
 	};
 
 	sram0: memory@20000000 {
+		device_type = "memory";
 		compatible = "mmio-sram";
 		reg = <0x20000000 DT_SRAM_SIZE>;
 	};

--- a/dts/arm/st/stm32f303.dtsi
+++ b/dts/arm/st/stm32f303.dtsi
@@ -19,11 +19,11 @@
 		};
 	};
 
-	flash0: flash {
+	flash0: flash@8000000 {
 		reg = <0x08000000 DT_FLASH_SIZE>;
 	};
 
-	sram0: memory {
+	sram0: memory@20000000 {
 		compatible = "mmio-sram";
 		reg = <0x20000000 DT_SRAM_SIZE>;
 	};

--- a/dts/arm/st/stm32f303.dtsi
+++ b/dts/arm/st/stm32f303.dtsi
@@ -24,6 +24,7 @@
 	};
 
 	sram0: memory@20000000 {
+		device_type = "memory";
 		compatible = "mmio-sram";
 		reg = <0x20000000 DT_SRAM_SIZE>;
 	};

--- a/dts/arm/st/stm32f334.dtsi
+++ b/dts/arm/st/stm32f334.dtsi
@@ -19,11 +19,11 @@
 		};
 	};
 
-	flash0: flash {
+	flash0: flash@8000000 {
 		reg = <0x08000000 DT_FLASH_SIZE>;
 	};
 
-	sram0: memory {
+	sram0: memory@20000000 {
 		compatible = "mmio-sram";
 		reg = <0x20000000 DT_SRAM_SIZE>;
 	};

--- a/dts/arm/st/stm32f334.dtsi
+++ b/dts/arm/st/stm32f334.dtsi
@@ -24,6 +24,7 @@
 	};
 
 	sram0: memory@20000000 {
+		device_type = "memory";
 		compatible = "mmio-sram";
 		reg = <0x20000000 DT_SRAM_SIZE>;
 	};

--- a/dts/arm/st/stm32f373.dtsi
+++ b/dts/arm/st/stm32f373.dtsi
@@ -19,11 +19,11 @@
 		};
 	};
 
-	flash0: flash {
+	flash0: flash@8000000 {
 		reg = <0x08000000 DT_FLASH_SIZE>;
 	};
 
-	sram0: memory {
+	sram0: memory@20000000 {
 		compatible = "mmio-sram";
 		reg = <0x20000000 DT_SRAM_SIZE>;
 	};

--- a/dts/arm/st/stm32f373.dtsi
+++ b/dts/arm/st/stm32f373.dtsi
@@ -24,6 +24,7 @@
 	};
 
 	sram0: memory@20000000 {
+		device_type = "memory";
 		compatible = "mmio-sram";
 		reg = <0x20000000 DT_SRAM_SIZE>;
 	};

--- a/dts/arm/st/stm32f4.dtsi
+++ b/dts/arm/st/stm32f4.dtsi
@@ -19,11 +19,11 @@
 		};
 	};
 
-	flash0: flash {
+	flash0: flash@8000000 {
 		reg = <0x08000000 DT_FLASH_SIZE>;
 	};
 
-	sram0: memory {
+	sram0: memory@20000000 {
 		compatible = "mmio-sram";
 		reg = <0x20000000 DT_SRAM_SIZE>;
 	};

--- a/dts/arm/st/stm32f4.dtsi
+++ b/dts/arm/st/stm32f4.dtsi
@@ -24,6 +24,7 @@
 	};
 
 	sram0: memory@20000000 {
+		device_type = "memory";
 		compatible = "mmio-sram";
 		reg = <0x20000000 DT_SRAM_SIZE>;
 	};

--- a/dts/arm/st/stm32l432.dtsi
+++ b/dts/arm/st/stm32l432.dtsi
@@ -19,11 +19,11 @@
 		};
 	};
 
-	flash0: flash {
+	flash0: flash@8000000 {
 		reg = <0x08000000 DT_FLASH_SIZE>;
 	};
 
-	sram0: memory {
+	sram0: memory@20000000 {
 		compatible = "mmio-sram";
 		reg = <0x20000000 DT_SRAM_SIZE>;
 	};

--- a/dts/arm/st/stm32l432.dtsi
+++ b/dts/arm/st/stm32l432.dtsi
@@ -24,6 +24,7 @@
 	};
 
 	sram0: memory@20000000 {
+		device_type = "memory";
 		compatible = "mmio-sram";
 		reg = <0x20000000 DT_SRAM_SIZE>;
 	};

--- a/dts/arm/st/stm32l475.dtsi
+++ b/dts/arm/st/stm32l475.dtsi
@@ -19,11 +19,11 @@
 		};
 	};
 
-	flash0: flash {
+	flash0: flash@8000000 {
 		reg = <0x08000000 DT_FLASH_SIZE>;
 	};
 
-	sram0: memory {
+	sram0: memory@20000000 {
 		compatible = "mmio-sram";
 		reg = <0x20000000 DT_SRAM_SIZE>;
 	};

--- a/dts/arm/st/stm32l475.dtsi
+++ b/dts/arm/st/stm32l475.dtsi
@@ -24,6 +24,7 @@
 	};
 
 	sram0: memory@20000000 {
+		device_type = "memory";
 		compatible = "mmio-sram";
 		reg = <0x20000000 DT_SRAM_SIZE>;
 	};

--- a/dts/arm/ti/cc2650.dtsi
+++ b/dts/arm/ti/cc2650.dtsi
@@ -19,6 +19,7 @@
 	};
 
 	sram0: memory@20000000 {
+		device_type = "memory";
 		compatible = "mmio-sram";
 		reg = <0x20000000 0x5000>;
 	};

--- a/dts/arm/ti/cc2650.dtsi
+++ b/dts/arm/ti/cc2650.dtsi
@@ -18,12 +18,12 @@
 		};
 	};
 
-	sram0: memory {
+	sram0: memory@20000000 {
 		compatible = "mmio-sram";
 		reg = <0x20000000 0x5000>;
 	};
 
-	flash0: serial-flash {
+	flash0: serial-flash@0 {
 		compatible = "serial-flash";
 		reg = <0x0 0x20000>;
 	};

--- a/dts/arm/ti/cc32xx.dtsi
+++ b/dts/arm/ti/cc32xx.dtsi
@@ -19,18 +19,18 @@
 		};
 	};
 
-	sram0: memory {
+	sram0: memory@20004000 {
 		compatible = "mmio-sram";
 		reg = <DT_SRAM_START DT_SRAM_SIZE>;
 	};
 
-	flash0: serial-flash {
+	flash0: serial-flash@0 {
 		compatible = "serial-flash";
 		reg = <0x0 DT_SFLASH_SIZE>;
 	};
 
 #if defined(CONFIG_SOC_CC3220SF)
-	flash1: flash {
+	flash1: flash@1000000 {
 		reg = <0x01000000 DT_FLASH_SIZE>;
 	};
 #endif

--- a/dts/arm/ti/cc32xx.dtsi
+++ b/dts/arm/ti/cc32xx.dtsi
@@ -20,6 +20,7 @@
 	};
 
 	sram0: memory@20004000 {
+		device_type = "memory";
 		compatible = "mmio-sram";
 		reg = <DT_SRAM_START DT_SRAM_SIZE>;
 	};

--- a/dts/arm/ti/lm3s6965.dtsi
+++ b/dts/arm/ti/lm3s6965.dtsi
@@ -12,12 +12,12 @@
 		};
 	};
 
-	sram0: memory {
+	sram0: memory@20000000 {
 		compatible = "mmio-sram";
 		reg = <0x20000000 (64*1024)>;
 	};
 
-	flash0: flash {
+	flash0: flash@0 {
 		reg = <0x00000000 (256*1024)>;
 	};
 

--- a/dts/arm/ti/lm3s6965.dtsi
+++ b/dts/arm/ti/lm3s6965.dtsi
@@ -13,6 +13,7 @@
 	};
 
 	sram0: memory@20000000 {
+		device_type = "memory";
 		compatible = "mmio-sram";
 		reg = <0x20000000 (64*1024)>;
 	};

--- a/dts/common/skeleton.dtsi
+++ b/dts/common/skeleton.dtsi
@@ -9,5 +9,4 @@
 	#size-cells = <1>;
 	chosen { };
 	aliases { };
-	memory { device_type = "memory"; reg = <0 0>; };
 };

--- a/dts/x86/intel_curie.dtsi
+++ b/dts/x86/intel_curie.dtsi
@@ -25,6 +25,7 @@
 
 
 	sram0: memory@a8006400 {
+		device_type = "memory";
 		compatible = "mmio-sram";
 		reg = <0xa8006400 DT_SRAM_SIZE>;
 	};

--- a/dts/x86/intel_quark_d2000.dtsi
+++ b/dts/x86/intel_quark_d2000.dtsi
@@ -14,6 +14,7 @@
 	};
 
 	sram0: memory@00280000 {
+		device_type = "memory";
 		compatible = "mmio-sram";
 		reg = <0x00280000 DT_SRAM_SIZE>;
 	};

--- a/dts/x86/intel_quark_d2000.dtsi
+++ b/dts/x86/intel_quark_d2000.dtsi
@@ -4,7 +4,9 @@
 / {
 	cpus {
 		cpu@0 {
+			device_type = "cpu";
 			compatible = "intel,quark";
+			reg = <0>;
 		};
 
 	};


### PR DESCRIPTION
This patch add the unit-address component to memory and flash
nodes. According to the DT specification, the unit-address of
a node must match the first address specified in the reg
property of the node.

It removes memory node from skeleton dtsi and add device_type
property in every memory node in soc dtsi files.

Adds device_type and reg properties in cpu node of intel_quark_d2000 dtsi file

Signed-off-by: Yannis Damigos <giannis.damigos@gmail.com>