### PR TITLE
dts: stm32: uart clocks

### DIFF
--- a/dts/arm/st/stm32f103Xb.dtsi
+++ b/dts/arm/st/stm32f103Xb.dtsi
@@ -9,6 +9,7 @@
 
 #include <arm/armv7-m.dtsi>
 #include <st/mem.h>
+#include <dt-bindings/clock/stm32_clock.h>
 
 / {
 	cpus {
@@ -43,6 +44,7 @@
 		usart1: serial@40013800 {
 			compatible = "st,stm32-usart", "st,stm32-uart";
 			reg = <0x40013800 0x400>;
+			clocks = <&rcc STM32_CLOCK_BUS_APB2 0x00004000>;
 			interrupts = <37 0>;
 			status = "disabled";
 			label = "UART_1";
@@ -51,6 +53,7 @@
 		usart2: serial@40004400 {
 			compatible = "st,stm32-usart", "st,stm32-uart";
 			reg = <0x40004400 0x400>;
+			clocks = <&rcc STM32_CLOCK_BUS_APB1 0x00020000>;
 			interrupts = <38 0>;
 			status = "disabled";
 			label = "UART_2";
@@ -59,6 +62,7 @@
 		usart3: serial@40004800 {
 			compatible = "st,stm32-usart", "st,stm32-uart";
 			reg = <0x40004800 0x400>;
+			clocks = <&rcc STM32_CLOCK_BUS_APB1 0x00040000>;
 			interrupts = <39 0>;
 			status = "disabled";
 			label = "UART_3";

--- a/dts/arm/st/stm32f103Xb.dtsi
+++ b/dts/arm/st/stm32f103Xb.dtsi
@@ -32,6 +32,14 @@
 	};
 
 	soc {
+		rcc: rcc@40021000 {
+			compatible = "st,stm32-rcc";
+			clocks-controller;
+			#clocks-cells = <2>;
+			reg = <0x40021000 0x400>;
+			label = "STM32_CLK_RCC";
+		};
+
 		usart1: serial@40013800 {
 			compatible = "st,stm32-usart", "st,stm32-uart";
 			reg = <0x40013800 0x400>;

--- a/dts/arm/st/stm32f103Xe.dtsi
+++ b/dts/arm/st/stm32f103Xe.dtsi
@@ -9,6 +9,7 @@
 
 #include <arm/armv7-m.dtsi>
 #include <st/mem.h>
+#include <dt-bindings/clock/stm32_clock.h>
 
 / {
 	cpus {
@@ -43,6 +44,7 @@
 		usart1: serial@40013800 {
 			compatible = "st,stm32-usart", "st,stm32-uart";
 			reg = <0x40013800 0x400>;
+			clocks = <&rcc STM32_CLOCK_BUS_APB2 0x00004000>;
 			interrupts = <37 0>;
 			status = "disabled";
 			label = "UART_1";
@@ -51,6 +53,7 @@
 		usart2: serial@40004400 {
 			compatible = "st,stm32-usart", "st,stm32-uart";
 			reg = <0x40004400 0x400>;
+			clocks = <&rcc STM32_CLOCK_BUS_APB1 0x00020000>;
 			interrupts = <38 0>;
 			status = "disabled";
 			label = "UART_2";
@@ -59,6 +62,7 @@
 		usart3: serial@40004800 {
 			compatible = "st,stm32-usart", "st,stm32-uart";
 			reg = <0x40004800 0x400>;
+			clocks = <&rcc STM32_CLOCK_BUS_APB1 0x00040000>;
 			interrupts = <39 0>;
 			status = "disabled";
 			label = "UART_3";

--- a/dts/arm/st/stm32f103Xe.dtsi
+++ b/dts/arm/st/stm32f103Xe.dtsi
@@ -32,6 +32,14 @@
 	};
 
 	soc {
+		rcc: rcc@40021000 {
+			compatible = "st,stm32-rcc";
+			clocks-controller;
+			#clocks-cells = <2>;
+			reg = <0x40021000 0x400>;
+			label = "STM32_CLK_RCC";
+		};
+
 		usart1: serial@40013800 {
 			compatible = "st,stm32-usart", "st,stm32-uart";
 			reg = <0x40013800 0x400>;

--- a/dts/arm/st/stm32f107.dtsi
+++ b/dts/arm/st/stm32f107.dtsi
@@ -6,6 +6,7 @@
 
 #include <arm/armv7-m.dtsi>
 #include <st/mem.h>
+#include <dt-bindings/clock/stm32_clock.h>
 
 / {
 	cpus {
@@ -40,6 +41,7 @@
 		usart1: serial@40013800 {
 			compatible = "st,stm32-usart", "st,stm32-uart";
 			reg = <0x40013800 0x400>;
+			clocks = <&rcc STM32_CLOCK_BUS_APB2 0x00004000>;
 			interrupts = <37 0>;
 			status = "disabled";
 			label = "UART_1";
@@ -48,6 +50,7 @@
 		usart2: serial@40004400 {
 			compatible = "st,stm32-usart", "st,stm32-uart";
 			reg = <0x40004400 0x400>;
+			clocks = <&rcc STM32_CLOCK_BUS_APB1 0x00020000>;
 			interrupts = <38 0>;
 			status = "disabled";
 			label = "UART_2";
@@ -56,6 +59,7 @@
 		usart3: serial@40004800 {
 			compatible = "st,stm32-usart", "st,stm32-uart";
 			reg = <0x40004800 0x400>;
+			clocks = <&rcc STM32_CLOCK_BUS_APB1 0x00040000>;
 			interrupts = <39 0>;
 			status = "disabled";
 			label = "UART_3";

--- a/dts/arm/st/stm32f107.dtsi
+++ b/dts/arm/st/stm32f107.dtsi
@@ -29,6 +29,14 @@
 	};
 
 	soc {
+		rcc: rcc@40021000 {
+			compatible = "st,stm32-rcc";
+			clocks-controller;
+			#clocks-cells = <2>;
+			reg = <0x40021000 0x400>;
+			label = "STM32_CLK_RCC";
+		};
+
 		usart1: serial@40013800 {
 			compatible = "st,stm32-usart", "st,stm32-uart";
 			reg = <0x40013800 0x400>;

--- a/dts/arm/st/stm32f303.dtsi
+++ b/dts/arm/st/stm32f303.dtsi
@@ -6,6 +6,7 @@
 
 #include <arm/armv7-m.dtsi>
 #include <st/mem.h>
+#include <dt-bindings/clock/stm32_clock.h>
 
 / {
 	cpus {
@@ -40,6 +41,7 @@
 		usart1: serial@40013800 {
 			compatible = "st,stm32-usart", "st,stm32-uart";
 			reg = <0x40013800 0x400>;
+			clocks = <&rcc STM32_CLOCK_BUS_APB2 0x00004000>;
 			interrupts = <37 0>;
 			status = "disabled";
 			label = "UART_1";
@@ -48,6 +50,7 @@
 		usart2: serial@40004400 {
 			compatible = "st,stm32-usart", "st,stm32-uart";
 			reg = <0x40004400 0x400>;
+			clocks = <&rcc STM32_CLOCK_BUS_APB1 0x00020000>;
 			interrupts = <38 0>;
 			status = "disabled";
 			label = "UART_2";
@@ -56,6 +59,7 @@
 		usart3: serial@40004800 {
 			compatible = "st,stm32-usart", "st,stm32-uart";
 			reg = <0x40004800 0x400>;
+			clocks = <&rcc STM32_CLOCK_BUS_APB1 0x00040000>;
 			interrupts = <39 0>;
 			status = "disabled";
 			label = "UART_3";

--- a/dts/arm/st/stm32f303.dtsi
+++ b/dts/arm/st/stm32f303.dtsi
@@ -29,6 +29,14 @@
 	};
 
 	soc {
+		rcc: rcc@40021000 {
+			compatible = "st,stm32-rcc";
+			clocks-controller;
+			#clocks-cells = <2>;
+			reg = <0x40021000 0x400>;
+			label = "STM32_CLK_RCC";
+		};
+
 		usart1: serial@40013800 {
 			compatible = "st,stm32-usart", "st,stm32-uart";
 			reg = <0x40013800 0x400>;

--- a/dts/arm/st/stm32f334.dtsi
+++ b/dts/arm/st/stm32f334.dtsi
@@ -6,6 +6,7 @@
 
 #include <arm/armv7-m.dtsi>
 #include <st/mem.h>
+#include <dt-bindings/clock/stm32_clock.h>
 
 / {
 	cpus {
@@ -40,6 +41,7 @@
 		usart1: serial@40013800 {
 			compatible = "st,stm32-usart", "st,stm32-uart";
 			reg = <0x40013800 0x400>;
+			clocks = <&rcc STM32_CLOCK_BUS_APB2 0x00004000>;
 			interrupts = <37 0>;
 			status = "disabled";
 			label = "UART_1";
@@ -48,6 +50,7 @@
 		usart2: serial@40004400 {
 			compatible = "st,stm32-usart", "st,stm32-uart";
 			reg = <0x40004400 0x400>;
+			clocks = <&rcc STM32_CLOCK_BUS_APB1 0x00020000>;
 			interrupts = <38 0>;
 			status = "disabled";
 			label = "UART_2";
@@ -56,6 +59,7 @@
 		usart3: serial@40004800 {
 			compatible = "st,stm32-usart", "st,stm32-uart";
 			reg = <0x40004800 0x400>;
+			clocks = <&rcc STM32_CLOCK_BUS_APB1 0x00040000>;
 			interrupts = <39 0>;
 			status = "disabled";
 			label = "UART_3";

--- a/dts/arm/st/stm32f334.dtsi
+++ b/dts/arm/st/stm32f334.dtsi
@@ -29,6 +29,14 @@
 	};
 
 	soc {
+		rcc: rcc@40021000 {
+			compatible = "st,stm32-rcc";
+			clocks-controller;
+			#clocks-cells = <2>;
+			reg = <0x40021000 0x400>;
+			label = "STM32_CLK_RCC";
+		};
+
 		usart1: serial@40013800 {
 			compatible = "st,stm32-usart", "st,stm32-uart";
 			reg = <0x40013800 0x400>;

--- a/dts/arm/st/stm32f373.dtsi
+++ b/dts/arm/st/stm32f373.dtsi
@@ -6,6 +6,7 @@
 
 #include <arm/armv7-m.dtsi>
 #include <st/mem.h>
+#include <dt-bindings/clock/stm32_clock.h>
 
 / {
 	cpus {
@@ -40,6 +41,7 @@
 		usart1: serial@40013800 {
 			compatible = "st,stm32-usart", "st,stm32-uart";
 			reg = <0x40013800 0x400>;
+			clocks = <&rcc STM32_CLOCK_BUS_APB2 0x00004000>;
 			interrupts = <37 0>;
 			status = "disabled";
 			label = "UART_1";
@@ -48,6 +50,7 @@
 		usart2: serial@40004400 {
 			compatible = "st,stm32-usart", "st,stm32-uart";
 			reg = <0x40004400 0x400>;
+			clocks = <&rcc STM32_CLOCK_BUS_APB1 0x00020000>;
 			interrupts = <38 0>;
 			status = "disabled";
 			label = "UART_2";
@@ -56,6 +59,7 @@
 		usart3: serial@40004800 {
 			compatible = "st,stm32-usart", "st,stm32-uart";
 			reg = <0x40004800 0x400>;
+			clocks = <&rcc STM32_CLOCK_BUS_APB1 0x00040000>;
 			interrupts = <39 0>;
 			status = "disabled";
 			label = "UART_3";

--- a/dts/arm/st/stm32f373.dtsi
+++ b/dts/arm/st/stm32f373.dtsi
@@ -29,6 +29,14 @@
 	};
 
 	soc {
+		rcc: rcc@40021000 {
+			compatible = "st,stm32-rcc";
+			clocks-controller;
+			#clocks-cells = <2>;
+			reg = <0x40021000 0x400>;
+			label = "STM32_CLK_RCC";
+		};
+
 		usart1: serial@40013800 {
 			compatible = "st,stm32-usart", "st,stm32-uart";
 			reg = <0x40013800 0x400>;

--- a/dts/arm/st/stm32f4.dtsi
+++ b/dts/arm/st/stm32f4.dtsi
@@ -6,6 +6,7 @@
 
 #include <arm/armv7-m.dtsi>
 #include <st/mem.h>
+#include <dt-bindings/clock/stm32_clock.h>
 
 / {
 	cpus {
@@ -40,6 +41,7 @@
 		usart1: serial@40011000 {
 			compatible = "st,stm32-usart", "st,stm32-uart";
 			reg = <0x40011000 0x400>;
+			clocks = <&rcc STM32_CLOCK_BUS_APB2 0x00004000>;
 			interrupts = <37 0>;
 			status = "disabled";
 			label = "UART_1";
@@ -48,6 +50,7 @@
 		usart2: serial@40004400 {
 			compatible = "st,stm32-usart", "st,stm32-uart";
 			reg = <0x40004400 0x400>;
+			clocks = <&rcc STM32_CLOCK_BUS_APB1 0x00020000>;
 			interrupts = <38 0>;
 			status = "disabled";
 			label = "UART_2";
@@ -56,6 +59,7 @@
 		usart6: serial@40011400 {
 			compatible = "st,stm32-usart", "st,stm32-uart";
 			reg = <0x40011400 0x400>;
+			clocks = <&rcc STM32_CLOCK_BUS_APB2 0x00000020>;
 			interrupts = <71 0>;
 			status = "disabled";
 			label = "UART_6";

--- a/dts/arm/st/stm32f4.dtsi
+++ b/dts/arm/st/stm32f4.dtsi
@@ -29,6 +29,14 @@
 	};
 
 	soc {
+		rcc: rcc@40023800 {
+			compatible = "st,stm32-rcc";
+			clocks-controller;
+			#clocks-cells = <2>;
+			reg = <0x40023800 0x400>;
+			label = "STM32_CLK_RCC";
+		};
+
 		usart1: serial@40011000 {
 			compatible = "st,stm32-usart", "st,stm32-uart";
 			reg = <0x40011000 0x400>;

--- a/dts/arm/st/stm32f407.dtsi
+++ b/dts/arm/st/stm32f407.dtsi
@@ -11,6 +11,7 @@
 		usart3: serial@40004800 {
 			compatible = "st,stm32-usart", "st,stm32-uart";
 			reg = <0x40004800 0x400>;
+			clocks = <&rcc STM32_CLOCK_BUS_APB1 0x00040000>;
 			interrupts = <39 0>;
 			status = "disabled";
 			label = "UART_3";
@@ -19,6 +20,7 @@
 		uart4: serial@40004c00 {
 			compatible ="st,stm32-uart";
 			reg = <0x40004c00 0x400>;
+			clocks = <&rcc STM32_CLOCK_BUS_APB1 0x00080000>;
 			interrupts = <52 0>;
 			status = "disabled";
 			label = "UART_4";
@@ -27,6 +29,7 @@
 		uart5: serial@40005000 {
 			compatible = "st,stm32-uart";
 			reg = <0x40005000 0x400>;
+			clocks = <&rcc STM32_CLOCK_BUS_APB1 0x00100000>;
 			interrupts = <53 0>;
 			status = "disabled";
 			label = "UART_5";

--- a/dts/arm/st/stm32f412.dtsi
+++ b/dts/arm/st/stm32f412.dtsi
@@ -11,6 +11,7 @@
 		usart3: serial@40004800 {
 			compatible = "st,stm32-usart", "st,stm32-uart";
 			reg = <0x40004800 0x400>;
+			clocks = <&rcc STM32_CLOCK_BUS_APB1 0x00040000>;
 			interrupts = <39 0>;
 			status = "disabled";
 			label = "UART_3";

--- a/dts/arm/st/stm32f413.dtsi
+++ b/dts/arm/st/stm32f413.dtsi
@@ -11,6 +11,7 @@
 		usart3: serial@40004800 {
 			compatible = "st,stm32-usart", "st,stm32-uart";
 			reg = <0x40004800 0x400>;
+			clocks = <&rcc STM32_CLOCK_BUS_APB1 0x00040000>;
 			interrupts = <39 0>;
 			status = "disabled";
 			label = "UART_3";
@@ -19,6 +20,7 @@
 		uart4: serial@40004c00 {
 			compatible ="st,stm32-uart";
 			reg = <0x40004c00 0x400>;
+			clocks = <&rcc STM32_CLOCK_BUS_APB1 0x00080000>;
 			interrupts = <52 0>;
 			status = "disabled";
 			label = "UART_4";
@@ -27,6 +29,7 @@
 		uart5: serial@40005000 {
 			compatible = "st,stm32-uart";
 			reg = <0x40005000 0x400>;
+			clocks = <&rcc STM32_CLOCK_BUS_APB1 0x00100000>;
 			interrupts = <53 0>;
 			status = "disabled";
 			label = "UART_5";
@@ -35,6 +38,7 @@
 		uart7: serial@40007800 {
 			compatible = "st,stm32-uart";
 			reg = <0x40007800 0x400>;
+			clocks = <&rcc STM32_CLOCK_BUS_APB1 0x40000000>;
 			interrupts = <82 0>;
 			status = "disabled";
 			label = "UART_7";
@@ -43,6 +47,7 @@
 		uart8: serial@40007c00 {
 			compatible = "st,stm32-uart";
 			reg = <0x40007c00 0x400>;
+			clocks = <&rcc STM32_CLOCK_BUS_APB1 0x80000000>;
 			interrupts = <83 0>;
 			status = "disabled";
 			label = "UART_8";
@@ -51,6 +56,7 @@
 		uart9: serial@40011800 {
 			compatible = "st,stm32-uart";
 			reg = <0x40011800 0x400>;
+			clocks = <&rcc STM32_CLOCK_BUS_APB2 0x00000040>;
 			interrupts = <88 0>;
 			status = "disabled";
 			label = "UART_9";
@@ -59,6 +65,7 @@
 		uart10: serial@40011c00 {
 			compatible = "st,stm32-uart";
 			reg = <0x40011c00 0x400>;
+			clocks = <&rcc STM32_CLOCK_BUS_APB2 0x00000080>;
 			interrupts = <89 0>;
 			status = "disabled";
 			label = "UART_10";

--- a/dts/arm/st/stm32f469.dtsi
+++ b/dts/arm/st/stm32f469.dtsi
@@ -11,6 +11,7 @@
 		uart7: serial@40007800 {
 			compatible = "st,stm32-uart";
 			reg = <0x40007800 0x400>;
+			clocks = <&rcc STM32_CLOCK_BUS_APB1 0x40000000>;
 			interrupts = <82 0>;
 			status = "disabled";
 			label = "UART_7";
@@ -19,6 +20,7 @@
 		uart8: serial@40007c00 {
 			compatible = "st,stm32-uart";
 			reg = <0x40007c00 0x400>;
+			clocks = <&rcc STM32_CLOCK_BUS_APB1 0x80000000>;
 			interrupts = <83 0>;
 			status = "disabled";
 			label = "UART_8";

--- a/dts/arm/st/stm32l432.dtsi
+++ b/dts/arm/st/stm32l432.dtsi
@@ -29,6 +29,14 @@
 	};
 
 	soc {
+		rcc: rcc@40021000 {
+			compatible = "st,stm32-rcc";
+			clocks-controller;
+			#clocks-cells = <2>;
+			reg = <0x40021000 0x400>;
+			label = "STM32_CLK_RCC";
+		};
+
 		usart1: serial@40013800 {
 			compatible = "st,stm32-usart", "st,stm32-uart";
 			reg = <0x40013800 0x400>;

--- a/dts/arm/st/stm32l432.dtsi
+++ b/dts/arm/st/stm32l432.dtsi
@@ -6,6 +6,7 @@
 
 #include <arm/armv7-m.dtsi>
 #include <st/mem.h>
+#include <dt-bindings/clock/stm32_clock.h>
 
 / {
 	cpus {
@@ -40,6 +41,7 @@
 		usart1: serial@40013800 {
 			compatible = "st,stm32-usart", "st,stm32-uart";
 			reg = <0x40013800 0x400>;
+			clocks = <&rcc STM32_CLOCK_BUS_APB2 0x00004000>;
 			interrupts = <37 0>;
 			status = "disabled";
 			label = "UART_1";
@@ -48,6 +50,7 @@
 		usart2: serial@40004400 {
 			compatible = "st,stm32-usart", "st,stm32-uart";
 			reg = <0x40004400 0x400>;
+			clocks = <&rcc STM32_CLOCK_BUS_APB1 0x00020000>;
 			interrupts = <38 0>;
 			status = "disabled";
 			label = "UART_2";
@@ -56,6 +59,7 @@
 		usart3: serial@40004800 {
 			compatible = "st,stm32-usart", "st,stm32-uart";
 			reg = <0x40004800 0x400>;
+			clocks = <&rcc STM32_CLOCK_BUS_APB1 0x00040000>;
 			interrupts = <39 0>;
 			status = "disabled";
 			label = "UART_3";
@@ -64,6 +68,7 @@
 		uart4: serial@40004c00 {
 			compatible = "st,stm32-uart";
 			reg = <0x40004c00 0x400>;
+			clocks = <&rcc STM32_CLOCK_BUS_APB1 0x00080000>;
 			interrupts = <52 0>;
 			status = "disabled";
 			label = "UART_4";

--- a/dts/arm/st/stm32l475.dtsi
+++ b/dts/arm/st/stm32l475.dtsi
@@ -6,6 +6,7 @@
 
 #include <arm/armv7-m.dtsi>
 #include <st/mem.h>
+#include <dt-bindings/clock/stm32_clock.h>
 
 / {
 	cpus {
@@ -40,6 +41,7 @@
 		usart1: serial@40013800 {
 			compatible = "st,stm32-usart", "st,stm32-uart";
 			reg = <0x40013800 0x400>;
+			clocks = <&rcc STM32_CLOCK_BUS_APB2 0x00004000>;
 			interrupts = <37 0>;
 			status = "disabled";
 			label = "UART_1";
@@ -48,6 +50,7 @@
 		usart2: serial@40004400 {
 			compatible = "st,stm32-usart", "st,stm32-uart";
 			reg = <0x40004400 0x400>;
+			clocks = <&rcc STM32_CLOCK_BUS_APB1 0x00020000>;
 			interrupts = <38 0>;
 			status = "disabled";
 			label = "UART_2";
@@ -56,6 +59,7 @@
 		usart3: serial@40004800 {
 			compatible = "st,stm32-usart", "st,stm32-uart";
 			reg = <0x40004800 0x400>;
+			clocks = <&rcc STM32_CLOCK_BUS_APB1 0x00040000>;
 			interrupts = <39 0>;
 			status = "disabled";
 			label = "UART_3";
@@ -64,6 +68,7 @@
 		uart4: serial@40004c00 {
 			compatible = "st,stm32-uart";
 			reg = <0x40004c00 0x400>;
+			clocks = <&rcc STM32_CLOCK_BUS_APB1 0x00080000>;
 			interrupts = <52 0>;
 			status = "disabled";
 			label = "UART_4";
@@ -72,6 +77,7 @@
 		uart5: serial@40005000 {
 			compatible = "st,stm32-uart";
 			reg = <0x40005000 0x400>;
+			clocks = <&rcc STM32_CLOCK_BUS_APB1 0x00100000>;
 			interrupts = <53 0>;
 			status = "disabled";
 			label = "UART_5";

--- a/dts/arm/st/stm32l475.dtsi
+++ b/dts/arm/st/stm32l475.dtsi
@@ -29,6 +29,14 @@
 	};
 
 	soc {
+		rcc: rcc@40021000 {
+			compatible = "st,stm32-rcc";
+			clocks-controller;
+			#clocks-cells = <2>;
+			reg = <0x40021000 0x400>;
+			label = "STM32_CLK_RCC";
+		};
+
 		usart1: serial@40013800 {
 			compatible = "st,stm32-usart", "st,stm32-uart";
 			reg = <0x40013800 0x400>;

--- a/dts/arm/yaml/st,stm32-rcc.yaml
+++ b/dts/arm/yaml/st,stm32-rcc.yaml
@@ -1,0 +1,28 @@
+---
+title: STM32 RCC
+id: st,stm32-rcc
+version: 0.1
+
+description: >
+    This binding gives a base representation of the STM32 Clock control
+
+properties:
+  - compatible:
+      type: string
+      category: required
+      description: compatible strings
+      constraint: "st,stm32-rcc"
+
+  - reg:
+      type: array
+      description: mmio register space
+      generation: define
+      category: required
+
+cell_string: clocks
+
+"#cells":
+  - bus
+  - bits
+
+...

--- a/dts/common/yaml/uart.yaml
+++ b/dts/common/yaml/uart.yaml
@@ -27,4 +27,14 @@ properties:
       category: required
       description: Human readable string describing the device (used by Zephyr for API name)
       generation: define
+  - interrupt-names:
+      type: stringlist
+      category: optional
+      description: names of required interrupts
+      generation: define
+  - pinctrl-\d+:
+      type: array
+      category: optional
+      description: pinmux information for RX, TX, CTS, RTS
+      generation: define
 ...

--- a/include/drivers/clock_control/stm32_clock_control.h
+++ b/include/drivers/clock_control/stm32_clock_control.h
@@ -10,20 +10,11 @@
 #define _STM32_CLOCK_CONTROL_H_
 
 #include <clock_control.h>
+#include <dt-bindings/clock/stm32_clock.h>
 
 /* common clock control device name for all STM32 chips */
 #define STM32_CLOCK_CONTROL_NAME "stm32-cc"
 
-/* Bus */
-enum {
-	STM32_CLOCK_BUS_AHB1,
-	STM32_CLOCK_BUS_AHB2,
-	STM32_CLOCK_BUS_APB1,
-#ifdef CONFIG_SOC_SERIES_STM32L4X
-	STM32_CLOCK_BUS_APB1_2,
-#endif
-	STM32_CLOCK_BUS_APB2,
-};
 
 struct stm32_pclken {
 	u32_t bus;

--- a/include/dt-bindings/clock/stm32_clock.h
+++ b/include/dt-bindings/clock/stm32_clock.h
@@ -1,0 +1,17 @@
+/*
+ * Copyright (c) 2017 Linaro Limited
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+#ifndef __STM32_CLOCK_H
+#define __STM32_CLOCK_H
+
+/* clock bus references */
+#define STM32_CLOCK_BUS_AHB1    0
+#define STM32_CLOCK_BUS_AHB2    1
+#define STM32_CLOCK_BUS_APB1    2
+#define STM32_CLOCK_BUS_APB2    3
+#define STM32_CLOCK_BUS_APB1_2  4
+
+
+#endif /* __STM32_CLOCK_H */


### PR DESCRIPTION
Provide rcc node to stm32 based socs.
Use rcc node to provide clock information on STM32 u(s)art nodes