### PR TITLE
Bluetooth: controller: Implement Read/Write Auth Payload timeout

### DIFF
--- a/include/bluetooth/hci.h
+++ b/include/bluetooth/hci.h
@@ -555,6 +555,28 @@ struct bt_hci_cp_write_sc_host_supp {
 	u8_t  sc_support;
 } __packed;
 
+#define BT_HCI_OP_READ_AUTH_PAYLOAD_TIMEOUT     BT_OP(BT_OGF_BASEBAND, 0x007b)
+struct bt_hci_cp_read_auth_payload_timeout {
+	u16_t handle;
+} __packed;
+
+struct bt_hci_rp_read_auth_payload_timeout {
+	u8_t  status;
+	u16_t handle;
+	u16_t auth_payload_timeout;
+} __packed;
+
+#define BT_HCI_OP_WRITE_AUTH_PAYLOAD_TIMEOUT    BT_OP(BT_OGF_BASEBAND, 0x007c)
+struct bt_hci_cp_write_auth_payload_timeout {
+	u16_t handle;
+	u16_t auth_payload_timeout;
+} __packed;
+
+struct bt_hci_rp_write_auth_payload_timeout {
+	u8_t  status;
+	u16_t handle;
+} __packed;
+
 /* HCI version from Assigned Numbers */
 #define BT_HCI_VERSION_1_0B                     0
 #define BT_HCI_VERSION_1_1                      1

--- a/subsys/bluetooth/controller/include/ll.h
+++ b/subsys/bluetooth/controller/include/ll.h
@@ -71,6 +71,11 @@ u32_t ll_version_ind_send(u16_t handle);
 u32_t ll_terminate_ind_send(u16_t handle, u8_t reason);
 void ll_timeslice_ticker_id_get(u8_t * const instance_index, u8_t * const user_id);
 
+#if defined(CONFIG_BLUETOOTH_CONTROLLER_LE_PING)
+u32_t ll_apto_get(u16_t handle, u16_t *apto);
+u32_t ll_apto_set(u16_t handle, u16_t apto);
+#endif /* CONFIG_BLUETOOTH_CONTROLLER_LE_PING */
+
 #if defined(CONFIG_BLUETOOTH_CONTROLLER_DATA_LENGTH)
 u32_t ll_length_req_send(u16_t handle, u16_t tx_octets);
 void ll_length_default_get(u16_t *max_tx_octets, u16_t *max_tx_time);


### PR DESCRIPTION
Added implementation to support HCI Read Authenticated
Payload Timeout Command and HCI Write Authenticated Payload
Timeout Command.

This fixes:
TP/SEC/SLA/BV-08-C [No response to LL_PING_REQ]
TP/SEC/SLA/BV-09-C [Modified Authentication Payload Timeout]
TP/SEC/MAS/BV-08-C [No response to LL_PING_REQ]
TP/SEC/MAS/BV-09-C [Modified Authentication Payload Timeout]
conformance tests in LL.TS.5.0.0.

Signed-off-by: Vinayak Kariappa Chettimada <vich@nordicsemi.no>