### PR TITLE
Increase usefulness of Makefile.export

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -414,7 +414,7 @@ exports += VERSION_MAJOR VERSION_MINOR PATCHLEVEL VERSION_RESERVED EXTRAVERSION
 exports += KERNELRELEASE KERNELVERSION
 exports += ARCH CONFIG_SHELL HOSTCC HOSTCFLAGS CROSS_COMPILE AS LD CC CXX
 exports += CPP AR NM STRIP OBJCOPY OBJDUMP GDB
-exports += MAKE AWK INSTALLKERNEL PERL PYTHON
+exports += MAKE AWK PERL PYTHON
 exports += HOSTCXX HOSTCXXFLAGS CHECK CHECKFLAGS
 
 exports += KBUILD_CPPFLAGS NOSTDINC_FLAGS ZEPHYRINCLUDE OBJCOPYFLAGS LDFLAGS
@@ -435,7 +435,8 @@ define filechk_Makefile.export
 	echo "BOARD=$(BOARD)"; \
 	echo; \
 	$(foreach e,$(exports),echo $(e)=$($(e));) echo; \
-	echo "include $(O)/include/config/auto.conf";)
+	echo "include $(O)/include/config/auto.conf"; \
+	echo "-include $(srctree)/boards/$(ARCH)/$(BOARD_NAME)/Makefile.board";)
 endef
 
 # Files to ignore in find ... statements

--- a/Makefile
+++ b/Makefile
@@ -436,6 +436,7 @@ define filechk_Makefile.export
 	echo; \
 	$(foreach e,$(exports),echo $(e)=$($(e));) echo; \
 	echo "include $(O)/include/config/auto.conf"; \
+	echo "include $(O)/include/generated/generated_dts_board.conf"; \
 	echo "-include $(srctree)/boards/$(ARCH)/$(BOARD_NAME)/Makefile.board";)
 endef
 


### PR DESCRIPTION
It's convenient for glue outside of the Zephyr build system to know which script could be used to flash an image. Let's include that in the 'outputexports' results in place of (the unused and Linux-specific) INSTALLKERNEL.
