### PR TITLE
boards: arm: doc: Delete Segger RTT and Add BLE 5.0 in nrf52_vbluno52

### DIFF
--- a/boards/arm/nrf52_vbluno52/doc/nrf52_vbluno52.rst
+++ b/boards/arm/nrf52_vbluno52/doc/nrf52_vbluno52.rst
@@ -16,8 +16,7 @@ the following devices:
 * UART
 * GPIO
 * FLASH
-* RADIO (Bluetooth Low Energy)
-* Segger RTT (RTT Console)
+* RADIO (Bluetooth Low Energy 5.0)
 
 .. figure:: img/nrf52_vbluno52_pinout.png
      :align: center
@@ -53,8 +52,6 @@ hardware features:
 | FLASH     | on-chip    | flash                |
 +-----------+------------+----------------------+
 | RADIO     | on-chip    | Bluetooth            |
-+-----------+------------+----------------------+
-| RTT       | on-chip    | console              |
 +-----------+------------+----------------------+
 | I2C       | on-chip    | i2c                  |
 +-----------+------------+----------------------+


### PR DESCRIPTION
Delete Segger RTT and Add BLE 5.0 version in nrf52_vbluno52 document

This patch fix problems in nrf52_vbluno52 document:
+ Delete `Segger RTT` from supported features
+ Add `5.0` version to Bluetooth Low Energy feature

Signed-off-by: Nam Do <robotden@gmail.com>