### PR TITLE
doc: system_log: Fix global Kconfig options path

### DIFF
--- a/doc/subsystems/logging/system_log.rst
+++ b/doc/subsystems/logging/system_log.rst
@@ -43,7 +43,7 @@ end of the logging message.
 Global Kconfig Options
 **********************
 
-These options can be found in the following path :file:`misc/Kconfig`.
+These options can be found in the following path :file:`subsys/logging/Kconfig`.
 
 :option:`CONFIG_SYS_LOG`: Global switch, turns on/off all system logging.
 


### PR DESCRIPTION
This patch fixes global Kconfig options path for system logging documentation.

Signed-off-by: Yannis Damigos <giannis.damigos@gmail.com>