### PR TITLE
net: Add missing __cplusplus checks to includes

### DIFF
--- a/include/net/arp.h
+++ b/include/net/arp.h
@@ -13,6 +13,10 @@
 #ifndef __ARP_H
 #define __ARP_H
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 #if defined(CONFIG_NET_ARP)
 
 #include <net/ethernet.h>
@@ -48,5 +52,9 @@ void net_arp_init(void);
 #define net_arp_init(...)
 
 #endif /* CONFIG_NET_ARP */
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* __ARP_H */

--- a/include/net/dhcpv4.h
+++ b/include/net/dhcpv4.h
@@ -11,6 +11,10 @@
 #ifndef __DHCPV4_H
 #define __DHCPV4_H
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /**
  * @brief DHCPv4
  * @defgroup dhcpv4 DHCPv4
@@ -67,5 +71,9 @@ const char *net_dhcpv4_state_name(enum net_dhcpv4_state state);
 /**
  * @}
  */
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* __DHCPV4_H */

--- a/include/net/dns_resolve.h
+++ b/include/net/dns_resolve.h
@@ -16,6 +16,10 @@
 #include <net/net_ip.h>
 #include <net/net_context.h>
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /**
  * @brief DNS resolving library
  * @defgroup dns_resolve DNS Resolve Library
@@ -319,5 +323,9 @@ void dns_init_resolver(void);
 #else
 #define dns_init_resolver(...)
 #endif /* CONFIG_DNS_RESOLVER */
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* _DNS_RESOLVE_H */

--- a/include/net/ethernet.h
+++ b/include/net/ethernet.h
@@ -20,6 +20,10 @@
 #include <net/net_pkt.h>
 #include <misc/util.h>
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 #define NET_ETH_HDR(pkt) ((struct net_eth_hdr *)net_pkt_ll(pkt))
 
 #define NET_ETH_PTYPE_ARP		0x0806
@@ -63,5 +67,9 @@ static inline bool net_eth_is_addr_multicast(struct net_eth_addr *addr)
 }
 
 const struct net_eth_addr *net_eth_broadcast_addr(void);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* __ETHERNET_H */

--- a/include/net/http.h
+++ b/include/net/http.h
@@ -9,6 +9,10 @@
 
 #include <net/net_context.h>
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 #if defined(CONFIG_HTTPS)
 #if defined(CONFIG_MBEDTLS)
 #if !defined(CONFIG_MBEDTLS_CFG_FILE)
@@ -1047,5 +1051,9 @@ int http_response_403(struct http_server_ctx *ctx, const char *html_payload);
 int http_response_404(struct http_server_ctx *ctx, const char *html_payload);
 
 #endif /* CONFIG_HTTP_SERVER */
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* __HTTP_H__ */

--- a/include/net/ieee802154.h
+++ b/include/net/ieee802154.h
@@ -15,6 +15,10 @@
 #include <net/net_mgmt.h>
 #include <crypto/cipher_structs.h>
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 #define IEEE802154_MAX_ADDR_LENGTH	8
 
 struct ieee802154_security_ctx {
@@ -253,5 +257,9 @@ struct ieee802154_security_params {
 	u8_t level	: 3;
 	u8_t _unused	: 3;
 };
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* __IEEE802154_H__ */

--- a/include/net/ieee802154_radio.h
+++ b/include/net/ieee802154_radio.h
@@ -15,6 +15,10 @@
 #include <device.h>
 #include <net/net_if.h>
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 struct ieee802154_radio_api {
 	/**
 	 * Mandatory to get in first position.
@@ -90,5 +94,9 @@ extern enum net_verdict ieee802154_radio_handle_ack(struct net_if *iface,
  * @param iface A valid pointer on a network interface
  */
 void ieee802154_init(struct net_if *iface);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* __IEEE802154_RADIO_H__ */

--- a/include/net/mqtt.h
+++ b/include/net/mqtt.h
@@ -10,6 +10,10 @@
 #include <net/mqtt_types.h>
 #include <net/net_context.h>
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /**
  * @brief MQTT library
  * @defgroup mqtt MQTT library
@@ -418,4 +422,8 @@ int mqtt_rx_publish(struct mqtt_ctx *ctx, struct net_buf *rx);
  * @}
  */
 
+#ifdef __cplusplus
+}
 #endif
+
+#endif /* _MQTT_H_ */

--- a/include/net/mqtt_types.h
+++ b/include/net/mqtt_types.h
@@ -9,6 +9,10 @@
 
 #include <zephyr/types.h>
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /**
  * @brief MQTT library
  * @defgroup mqtt MQTT library
@@ -86,4 +90,8 @@ struct mqtt_publish_msg {
  * @}
  */
 
+#ifdef __cplusplus
+}
 #endif
+
+#endif /* _MQTT_TYPES_H_ */

--- a/include/net/net_event.h
+++ b/include/net/net_event.h
@@ -12,6 +12,10 @@
 #ifndef __NET_EVENT_H__
 #define __NET_EVENT_H__
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /* Network Interface events */
 #define _NET_IF_LAYER		NET_MGMT_LAYER_L1
 #define _NET_IF_CORE_CODE	0x001
@@ -120,5 +124,9 @@ enum net_event_ipv4_cmd {
 
 #define NET_EVENT_IPV4_ROUTER_ADD				\
 	(_NET_EVENT_IPV4_BASE |	NET_EVENT_IPV4_CMD_ROUTER_ADD)
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* __NET_EVENT_H__ */

--- a/include/net/net_mgmt.h
+++ b/include/net/net_mgmt.h
@@ -12,6 +12,10 @@
 #ifndef __NET_MGMT_H__
 #define __NET_MGMT_H__
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /**
  * @brief Network Management
  * @defgroup net_mgmt Network Management
@@ -263,5 +267,9 @@ static inline int net_mgmt_event_wait_on_iface(struct net_if *iface,
 /**
  * @}
  */
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* __NET_MGMT_H__ */

--- a/include/net/zoap.h
+++ b/include/net/zoap.h
@@ -20,6 +20,10 @@
 
 #include <misc/slist.h>
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /**
  * @brief COAP library
  * @defgroup zoap COAP Library
@@ -810,5 +814,9 @@ u8_t *zoap_next_token(void);
 /**
  * @}
  */
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* __ZOAP_H__ */

--- a/include/net/zoap_link_format.h
+++ b/include/net/zoap_link_format.h
@@ -13,6 +13,10 @@
 #ifndef __LINK_FORMAT_H__
 #define __LINK_FORMAT_H__
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /**
  * @brief COAP library
  * @defgroup zoap COAP Library
@@ -48,5 +52,9 @@ struct zoap_core_metadata {
 /**
  * @}
  */
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* __LINK_FORMAT_H__ */


### PR DESCRIPTION
Some of the public networking include files did not had
__cplusplus checks.

Signed-off-by: Jukka Rissanen <jukka.rissanen@linux.intel.com>