### PR TITLE
board: arduino_101: remove unused !HAS_DTS bits

### DIFF
--- a/boards/x86/arduino_101/Kconfig.defconfig
+++ b/boards/x86/arduino_101/Kconfig.defconfig
@@ -13,30 +13,6 @@ config SS_RESET_VECTOR
 config ROM_SIZE
 	default 144
 
-if !HAS_DTS
-config PHYS_LOAD_ADDR
-	default 0x40010000
-endif
-
-if BLUETOOTH_H4 && !HAS_DTS
-
-config BLUETOOTH_UART_ON_DEV_NAME
-	default UART_QMSI_0_NAME
-
-endif
-
-if UART_PIPE && !HAS_DTS
-
-config UART_PIPE_ON_DEV_NAME
-	default UART_QMSI_1_NAME
-
-endif
-
-if !HAS_DTS
-config BLUETOOTH_MONITOR_ON_DEV_NAME
-	default UART_QMSI_1_NAME if BLUETOOTH_DEBUG_MONITOR
-endif
-
 if FLASH && SPI
 
 config SPI_FLASH_W25QXXDV


### PR DESCRIPTION
Since HAS_DTS is always defined for arduino_101 the board specific
Kconfig bits associated with !HAS_DTS are never used, so lets remove
them.

Signed-off-by: Kumar Gala <kumar.gala@linaro.org>