### PR TITLE
scripts: add version check for pyelftools

### DIFF
--- a/scripts/gen_gdt.py
+++ b/scripts/gen_gdt.py
@@ -8,8 +8,14 @@ import argparse
 import sys
 import struct
 import os
+import elftools
+from distutils.version import LooseVersion
 from elftools.elf.elffile import ELFFile
 from elftools.elf.sections import SymbolTableSection
+
+if LooseVersion(elftools.__version__) < LooseVersion('0.24'):
+    sys.stderr.write("pyelftools is out of date, need version 0.24 or later\n")
+    sys.exit(1)
 
 def debug(text):
     if not args.verbose:

--- a/scripts/gen_idt.py
+++ b/scripts/gen_idt.py
@@ -8,8 +8,14 @@ import argparse
 import sys
 import struct
 import os
+import elftools
+from distutils.version import LooseVersion
 from elftools.elf.elffile import ELFFile
 from elftools.elf.sections import SymbolTableSection
+
+if LooseVersion(elftools.__version__) < LooseVersion('0.24'):
+    sys.stderr.write("pyelftools is out of date, need version 0.24 or later\n")
+    sys.exit(1)
 
 # This will never change, first selector in the GDT after the null selector
 KERNEL_CODE_SEG = 0x08


### PR DESCRIPTION
Versions before 0.24 have string handling issues in Python 3.

Signed-off-by: Andrew Boie <andrew.p.boie@intel.com>