### PR TITLE
tests: net: limit tests to boards with enough memory to build them

### DIFF
--- a/tests/net/all/testcase.yaml
+++ b/tests/net/all/testcase.yaml
@@ -2,4 +2,5 @@ tests:
 -   test:
         build_only: true
         tags: net
-        platform_exclude: bbc_microbit qemu_xtensa
+        min_ram: 32
+        platform_exclude: qemu_xtensa

--- a/tests/net/arp/testcase.yaml
+++ b/tests/net/arp/testcase.yaml
@@ -1,4 +1,11 @@
 tests:
 -   test:
         tags: net
-        platform_exclude: bbc_microbit qemu_xtensa
+        filter: not CONFIG_BLUETOOTH
+        min_ram: 12
+        platform_exclude: qemu_xtensa
+-   test_with_bt:
+        tags: net
+        filter: CONFIG_BLUETOOTH
+        min_ram: 16
+        platform_exclude: qemu_xtensa

--- a/tests/net/icmpv6/testcase.yaml
+++ b/tests/net/icmpv6/testcase.yaml
@@ -1,4 +1,9 @@
 tests:
 -   test:
         tags: net
-        platform_exclude: bbc_microbit
+        filter: not CONFIG_BLUETOOTH
+        min_ram: 12
+-   test_with_bt:
+        tags: net
+        filter: CONFIG_BLUETOOTH
+        min_ram: 16

--- a/tests/net/ieee802154/l2/testcase.yaml
+++ b/tests/net/ieee802154/l2/testcase.yaml
@@ -1,4 +1,5 @@
 tests:
 -   test:
         tags: net
-        platform_exclude: bbc_microbit qemu_xtensa
+        min_ram: 16
+        platform_exclude: qemu_xtensa

--- a/tests/net/iface/testcase.yaml
+++ b/tests/net/iface/testcase.yaml
@@ -1,4 +1,4 @@
 tests:
 -   test:
         tags: net
-        platform_exclude: bbc_microbit
+        min_ram: 16

--- a/tests/net/lib/dns_packet/testcase.yaml
+++ b/tests/net/lib/dns_packet/testcase.yaml
@@ -1,5 +1,5 @@
 tests:
 -   test:
-        platform_exclude: bbc_microbit
+        min_ram: 16
         tags: dns net
         timeout: 200

--- a/tests/net/lib/dns_resolve/testcase.yaml
+++ b/tests/net/lib/dns_resolve/testcase.yaml
@@ -1,5 +1,5 @@
 tests:
 -   test:
         tags: dns net
+        min_ram: 16
         timeout: 600
-        platform_exclude: bbc_microbit

--- a/tests/net/lib/mqtt_packet/testcase.yaml
+++ b/tests/net/lib/mqtt_packet/testcase.yaml
@@ -1,4 +1,4 @@
 tests:
 -   test:
-        platform_exclude: bbc_microbit
+        min_ram: 16
         tags: mqtt net

--- a/tests/net/lib/mqtt_publisher/testcase.yaml
+++ b/tests/net/lib/mqtt_publisher/testcase.yaml
@@ -1,5 +1,5 @@
 tests:
 -   test:
         build_only: true
-        platform_exclude: bbc_microbit
+        min_ram: 16
         tags: net mqtt

--- a/tests/net/lib/mqtt_subscriber/testcase.yaml
+++ b/tests/net/lib/mqtt_subscriber/testcase.yaml
@@ -1,5 +1,5 @@
 tests:
 -   test:
         build_only: true
-        platform_exclude: bbc_microbit
+        min_ram: 16
         tags: net mqtt

--- a/tests/net/lib/zoap/testcase.yaml
+++ b/tests/net/lib/zoap/testcase.yaml
@@ -1,4 +1,4 @@
 tests:
 -   test:
         tags: net
-        platform_exclude: bbc_microbit
+        min_ram: 16

--- a/tests/net/net_pkt/testcase.yaml
+++ b/tests/net/net_pkt/testcase.yaml
@@ -1,4 +1,4 @@
 tests:
 -   test:
         tags: net
-        platform_exclude: bbc_microbit
+        min_ram: 20

--- a/tests/net/rpl/testcase.yaml
+++ b/tests/net/rpl/testcase.yaml
@@ -1,4 +1,4 @@
 tests:
 -   test:
         tags: net
-        platform_exclude: bbc_microbit
+        min_ram: 16

--- a/tests/net/socket/udp/testcase.yaml
+++ b/tests/net/socket/udp/testcase.yaml
@@ -1,5 +1,5 @@
 tests:
 -   test:
         build_only: true
+        min_ram: 16
         tags: net
-        platform_exclude: bbc_microbit

--- a/tests/net/udp/testcase.yaml
+++ b/tests/net/udp/testcase.yaml
@@ -1,4 +1,4 @@
 tests:
 -   test:
         tags: net
-        platform_exclude: bbc_microbit
+        min_ram: 20

--- a/tests/net/utils/testcase.yaml
+++ b/tests/net/utils/testcase.yaml
@@ -1,4 +1,4 @@
 tests:
 -   test:
         tags: net
-        platform_exclude: bbc_microbit
+        min_ram: 16


### PR DESCRIPTION
A number of the network tests have minimal memory requirements that not
all boards are able to meet.  Add in those memory requirements so we
don't attempt to build these tests for those platforms.  Utilized the
frdm_kl25z (with 16K of memory) and cc2650_sensortag (with 20K) to test
the limits.

Signed-off-by: Kumar Gala <kumar.gala@linaro.org>