### PR TITLE
x86: install guard page for interrupt stack

### DIFF
--- a/arch/x86/core/crt0.S
+++ b/arch/x86/core/crt0.S
@@ -175,14 +175,23 @@ __csSet:
 #ifdef CONFIG_INIT_STACKS
 	movl $0xAAAAAAAA, %eax
 	leal _interrupt_stack, %edi
+#ifdef CONFIG_X86_STACK_PROTECTION
+	addl $4096, %edi
+#endif
 	stack_size_dwords = (CONFIG_ISR_STACK_SIZE / 4)
 	movl $stack_size_dwords, %ecx
 	rep  stosl
 #endif
 
 	movl	$_interrupt_stack, %esp
+#ifdef CONFIG_X86_STACK_PROTECTION
+	/* In this configuration, all stacks, including IRQ stack, are declared
+	 * with a 4K non-present guard page preceding the stack buffer
+	 */
+	addl	$(CONFIG_ISR_STACK_SIZE + 4096), %esp
+#else
 	addl	$CONFIG_ISR_STACK_SIZE, %esp
-
+#endif
 #if defined(CONFIG_SYS_POWER_DEEP_SLEEP) && \
              !defined(CONFIG_BOOTLOADER_CONTEXT_RESTORE)
 	/*

--- a/arch/x86/include/kernel_arch_func.h
+++ b/arch/x86/include/kernel_arch_func.h
@@ -37,6 +37,10 @@ static inline void kernel_arch_init(void)
 	_kernel.nested = 0;
 	_kernel.irq_stack = K_THREAD_STACK_BUFFER(_interrupt_stack) +
 				CONFIG_ISR_STACK_SIZE;
+#if CONFIG_X86_STACK_PROTECTION
+	_x86_mmu_set_flags(_interrupt_stack, MMU_PAGE_SIZE,
+			   MMU_ENTRY_NOT_PRESENT, MMU_PTE_P_MASK);
+#endif
 }
 
 /**


### PR DESCRIPTION
We need to know when the interrupt stack overflows as well as
thread stacks.

Signed-off-by: Andrew Boie <andrew.p.boie@intel.com>