### PR TITLE
samples: net: irc_bot: fix stack declarations

### DIFF
--- a/samples/net/irc_bot/src/irc-bot.c
+++ b/samples/net/irc_bot/src/irc-bot.c
@@ -29,7 +29,7 @@
 #endif
 
 #define STACK_SIZE	2048
-u8_t stack[STACK_SIZE];
+static K_THREAD_STACK_DEFINE(bot_stack, STACK_SIZE);
 static struct k_thread bot_thread;
 
 #define CMD_BUFFER_SIZE 256
@@ -1069,7 +1069,8 @@ static void irc_bot(void)
 
 void main(void)
 {
-	k_thread_create(&bot_thread, stack, STACK_SIZE,
+	k_thread_create(&bot_thread, bot_stack,
+			K_THREAD_STACK_SIZEOF(bot_stack),
 			(k_thread_entry_t)irc_bot,
 			NULL, NULL, NULL, K_PRIO_COOP(7), 0, 0);
 }


### PR DESCRIPTION
kernel APIs have changed to using K_THREAD_STACK_DEFINE to declare stack
memory as well as K_THREAD_STACK_SIZEOF to calculate it's size.

Adjust irc_bot sample to reflect those changes.

This fixes stack related page faults when running irc_bot with
CONFIG_X86_STACK_PROTECTION enabled (which it is by default for qemu).

Signed-off-by: Michael Scott <michael.scott@linaro.org>