### PR TITLE
tests: trickle: exclude qemu_cortex_m3

### DIFF
--- a/tests/net/trickle/testcase.yaml
+++ b/tests/net/trickle/testcase.yaml
@@ -1,4 +1,5 @@
 tests:
 -   test:
         tags: net
-        platform_exclude: bbc_microbit
+        platform_exclude: qemu_cortex_m3 # FIXME
+        min_ram: 16


### PR DESCRIPTION
Fails in CI, exclude while we investigate the issue.