### PR TITLE
tests: net: second pass at cleanup tests to build on all platforms

### DIFF
--- a/tests/net/context/testcase.yaml
+++ b/tests/net/context/testcase.yaml
@@ -1,4 +1,10 @@
 tests:
 -   test:
         tags: net
-        platform_exclude: bbc_microbit
+        filter: not CONFIG_BLUETOOTH
+        min_ram: 12
+        platform_exclude: hexiwear_kw40z
+-   test_with_bt:
+        tags: net
+        filter: CONFIG_BLUETOOTH
+        min_ram: 16

--- a/tests/net/ip-addr/testcase.yaml
+++ b/tests/net/ip-addr/testcase.yaml
@@ -1,4 +1,9 @@
 tests:
 -   test:
         tags: net
-        platform_exclude: bbc_microbit
+        filter: not CONFIG_BLUETOOTH
+        min_ram: 12
+-   test_with_bt:
+        tags: net
+        filter: CONFIG_BLUETOOTH
+        min_ram: 16

--- a/tests/net/lib/http_header_fields/testcase.yaml
+++ b/tests/net/lib/http_header_fields/testcase.yaml
@@ -1,4 +1,10 @@
 tests:
 -   test:
-        platform_exclude: bbc_microbit
         tags: http net
+        filter: not CONFIG_BLUETOOTH
+        min_ram: 12
+        platform_exclude: hexiwear_kw40z
+-   test_with_bt:
+        tags: http net
+        filter: CONFIG_BLUETOOTH
+        min_ram: 16

--- a/tests/net/mgmt/testcase.yaml
+++ b/tests/net/mgmt/testcase.yaml
@@ -1,4 +1,9 @@
 tests:
 -   test:
         tags: net
-        platform_exclude: bbc_microbit
+        filter: not CONFIG_BLUETOOTH
+        min_ram: 12
+-   test_with_bt:
+        tags: net
+        filter: CONFIG_BLUETOOTH
+        min_ram: 16

--- a/tests/net/neighbor/testcase.yaml
+++ b/tests/net/neighbor/testcase.yaml
@@ -1,4 +1,9 @@
 tests:
 -   test:
         tags: net
-        platform_exclude: bbc_microbit
+        filter: not CONFIG_BLUETOOTH
+        min_ram: 12
+-   test_with_bt:
+        tags: net
+        filter: CONFIG_BLUETOOTH
+        min_ram: 16

--- a/tests/net/route/testcase.yaml
+++ b/tests/net/route/testcase.yaml
@@ -1,4 +1,10 @@
 tests:
 -   test:
         tags: net
-        platform_exclude: bbc_microbit
+        filter: not CONFIG_BLUETOOTH
+        min_ram: 12
+        platform_exclude: hexiwear_kw40z
+-   test_with_bt:
+        tags: net
+        filter: CONFIG_BLUETOOTH
+        min_ram: 16

--- a/tests/net/trickle/testcase.yaml
+++ b/tests/net/trickle/testcase.yaml
@@ -2,4 +2,4 @@ tests:
 -   test:
         tags: net
         platform_exclude: qemu_cortex_m3 # FIXME
-        min_ram: 16
+        min_ram: 12


### PR DESCRIPTION
The majority of these fixes adjust the memory limit needed to build the
various tests on systems with and without BLE support.  We also fixup
one test case that was able to run on platforms with 16k of memory.

Signed-off-by: Kumar Gala <kumar.gala@linaro.org>