### PR TITLE
net: fix references to stack buffers

### DIFF
--- a/drivers/ieee802154/ieee802154_cc2520.c
+++ b/drivers/ieee802154/ieee802154_cc2520.c
@@ -688,8 +688,8 @@ static void cc2520_rx(int arg)
 		}
 
 		net_analyze_stack("CC2520 Rx Fiber stack",
-				  (unsigned char *)cc2520->cc2520_rx_stack,
-				  CONFIG_IEEE802154_CC2520_RX_STACK_SIZE);
+				K_THREAD_STACK_BUFFER(cc2520->cc2520_rx_stack),
+				K_THREAD_STACK_SIZEOF(cc2520->cc2520_rx_stack));
 		continue;
 flush:
 		_cc2520_print_exceptions(cc2520);

--- a/drivers/ieee802154/ieee802154_mcr20a.c
+++ b/drivers/ieee802154/ieee802154_mcr20a.c
@@ -591,8 +591,8 @@ static inline void mcr20a_rx(struct mcr20a_context *mcr20a, u8_t len)
 	}
 
 	net_analyze_stack("MCR20A Rx Fiber stack",
-			  mcr20a->mcr20a_rx_stack,
-			  CONFIG_IEEE802154_MCR20A_RX_STACK_SIZE);
+			  K_THREAD_STACK_BUFFER(mcr20a->mcr20a_rx_stack),
+			  K_THREAD_STACK_SIZEOF(mcr20a->mcr20a_rx_stack));
 	return;
 out:
 	if (pkt) {

--- a/drivers/ieee802154/ieee802154_nrf5.c
+++ b/drivers/ieee802154/ieee802154_nrf5.c
@@ -124,8 +124,8 @@ static void nrf5_rx_thread(void *arg1, void *arg2, void *arg3)
 		}
 
 		net_analyze_stack("nRF5 rx stack",
-				  (unsigned char *)nrf5_radio->rx_stack,
-				  CONFIG_IEEE802154_NRF5_RX_STACK_SIZE);
+				  K_THREAD_STACK_BUFFER(nrf5_radio->rx_stack),
+				  K_THREAD_STACK_SIZEOF(nrf5_radio->rx_stack));
 		continue;
 
 out:

--- a/subsys/net/ip/net_core.c
+++ b/subsys/net/ip/net_core.c
@@ -165,7 +165,7 @@ static void net_rx_thread(void)
 
 		pkt = k_fifo_get(&rx_queue, K_FOREVER);
 
-		net_analyze_stack("RX thread", rx_stack,
+		net_analyze_stack("RX thread", K_THREAD_STACK_BUFFER(rx_stack),
 				  K_THREAD_STACK_SIZEOF(rx_stack));
 
 #if defined(CONFIG_NET_STATISTICS) || defined(CONFIG_NET_DEBUG_CORE)

--- a/subsys/net/ip/net_mgmt.c
+++ b/subsys/net/ip/net_mgmt.c
@@ -157,8 +157,9 @@ static inline void mgmt_run_callbacks(struct mgmt_event_entry *mgmt_event)
 	}
 
 #ifdef CONFIG_NET_DEBUG_MGMT_EVENT_STACK
-	net_analyze_stack("Net MGMT event stack", mgmt_stack,
-			  CONFIG_NET_MGMT_EVENT_STACK_SIZE);
+	net_analyze_stack("Net MGMT event stack",
+			  K_THREAD_STACK_BUFFER(mgmt_stack),
+			  K_THREAD_STACK_SIZEOF(mgmt_stack));
 #endif
 }
 

--- a/subsys/net/ip/net_shell.c
+++ b/subsys/net/ip/net_shell.c
@@ -1431,8 +1431,8 @@ int net_shell_cmd_route(int argc, char *argv[])
 }
 
 #if defined(CONFIG_INIT_STACKS)
-extern char _main_stack[];
-extern char _interrupt_stack[];
+extern K_THREAD_STACK_DEFINE(_main_stack, CONFIG_MAIN_STACK_SIZE);
+extern K_THREAD_STACK_DEFINE(_interrupt_stack, CONFIG_ISR_STACK_SIZE);
 #endif
 
 int net_shell_cmd_stacks(int argc, char *argv[])
@@ -1446,8 +1446,8 @@ int net_shell_cmd_stacks(int argc, char *argv[])
 	ARG_UNUSED(argv);
 
 	for (info = __net_stack_start; info != __net_stack_end; info++) {
-		net_analyze_stack_get_values(info->stack, info->size,
-					     &pcnt, &unused);
+		net_analyze_stack_get_values(K_THREAD_STACK_BUFFER(info->stack),
+					     info->size, &pcnt, &unused);
 
 #if defined(CONFIG_INIT_STACKS)
 		printk("%s [%s] stack size %zu/%zu bytes unused %u usage"
@@ -1462,7 +1462,8 @@ int net_shell_cmd_stacks(int argc, char *argv[])
 	}
 
 #if defined(CONFIG_INIT_STACKS)
-	net_analyze_stack_get_values(_main_stack, CONFIG_MAIN_STACK_SIZE,
+	net_analyze_stack_get_values(K_THREAD_STACK_BUFFER(_main_stack),
+				     K_THREAD_STACK_SIZEOF(_main_stack),
 				     &pcnt, &unused);
 	printk("%s [%s] stack size %d/%d bytes unused %u usage"
 	       " %d/%d (%u %%)\n",
@@ -1470,7 +1471,8 @@ int net_shell_cmd_stacks(int argc, char *argv[])
 	       CONFIG_MAIN_STACK_SIZE, unused,
 	       CONFIG_MAIN_STACK_SIZE - unused, CONFIG_MAIN_STACK_SIZE, pcnt);
 
-	net_analyze_stack_get_values(_interrupt_stack, CONFIG_ISR_STACK_SIZE,
+	net_analyze_stack_get_values(K_THREAD_STACK_BUFFER(_interrupt_stack),
+				     K_THREAD_STACK_SIZEOF(_interrupt_stack),
 				     &pcnt, &unused);
 	printk("%s [%s] stack size %d/%d bytes unused %u usage"
 	       " %d/%d (%u %%)\n",


### PR DESCRIPTION
The net_stack_analyze function wants to look at the stack buffer,
but it is making assumptions on where this data is that are no
longer valid. Change to use the proper APIs for referencing this.

Signed-off-by: Andrew Boie <andrew.p.boie@intel.com>