### PR TITLE
dts: quark_d2000: uart0 instance to be used for console

### DIFF
--- a/dts/x86/quark_d2000_crb.dts
+++ b/dts/x86/quark_d2000_crb.dts
@@ -14,7 +14,7 @@
 	chosen {
 		zephyr,sram = &sram0;
 		zephyr,flash = &flash0;
-		zephyr,console = &uart1;
+		zephyr,console = &uart0;
 	};
 };
 


### PR DESCRIPTION
This patch is a fix for jira ZEP-2436.

Signed-off-by: Savinay Dharmappa <savinay.dharmappa@intel.com>