### PR TITLE
dts: quark_d2000: fix build warning

### DIFF
--- a/dts/x86/intel_quark_d2000.dtsi
+++ b/dts/x86/intel_quark_d2000.dtsi
@@ -3,6 +3,9 @@
 
 / {
 	cpus {
+		#address-cells = <1>;
+		#size-cells = <0>;
+
 		cpu@0 {
 			device_type = "cpu";
 			compatible = "intel,quark";


### PR DESCRIPTION
patch fix the build warning generated while building
application for quark_d2000. This is a fix for Jira ZEP-2437

Signed-off-by: Savinay Dharmappa <savinay.dharmappa@intel.com>