### PR TITLE
boards: mark qemu targets with a unified Kconfig

### DIFF
--- a/boards/Kconfig
+++ b/boards/Kconfig
@@ -7,6 +7,12 @@ config BOARD_DEPRECATED
 	When set, any build for that board will generate a clearly visible
 	deprecation warning.
 
+config QEMU_TARGET
+	bool n
+	help
+	  Mark all QEMU targets with this variable for checking whether we are
+	  running in an emulated environment.
+
 choice
 prompt "Board Selection"
 source "boards/*/*/Kconfig.board"

--- a/boards/arm/qemu_cortex_m3/Kconfig.board
+++ b/boards/arm/qemu_cortex_m3/Kconfig.board
@@ -2,3 +2,4 @@
 config BOARD_QEMU_CORTEX_M3
 	bool "Cortex-M3 Emulation (QEMU)"
 	depends on SOC_TI_LM3S6965
+	select QEMU_TARGET

--- a/boards/nios2/qemu_nios2/Kconfig.board
+++ b/boards/nios2/qemu_nios2/Kconfig.board
@@ -2,3 +2,4 @@
 config BOARD_QEMU_NIOS2
 	bool "QEMU NIOS II target"
 	depends on SOC_NIOS2_QEMU
+	select QEMU_TARGET

--- a/boards/riscv32/qemu_riscv32/Kconfig.board
+++ b/boards/riscv32/qemu_riscv32/Kconfig.board
@@ -2,3 +2,4 @@
 config BOARD_QEMU_RISCV32
 	bool "QEMU RISCV32 target"
 	depends on SOC_RISCV32_QEMU
+	select QEMU_TARGET

--- a/boards/x86/qemu_x86/Kconfig.board
+++ b/boards/x86/qemu_x86/Kconfig.board
@@ -2,3 +2,4 @@
 config BOARD_QEMU_X86
 	bool "QEMU x86"
 	depends on SOC_IA32
+	select QEMU_TARGET

--- a/boards/xtensa/qemu_xtensa/Kconfig.board
+++ b/boards/xtensa/qemu_xtensa/Kconfig.board
@@ -6,3 +6,4 @@
 config  BOARD_QEMU_XTENSA
 	bool "Xtensa emulation using QEMU"
 	depends on SOC_XTENSA_SAMPLE_CONTROLLER
+	select QEMU_TARGET


### PR DESCRIPTION
This will allow checking if we are building for QEMU globally, without
having to know the exact architecture and board name.

Signed-off-by: Anas Nashif <anas.nashif@intel.com>