### PR TITLE
boards: be pedantic about type of networking

### DIFF
--- a/boards/arm/qemu_cortex_m3/qemu_cortex_m3.yaml
+++ b/boards/arm/qemu_cortex_m3/qemu_cortex_m3.yaml
@@ -5,5 +5,7 @@ arch: arm
 toolchain:
   - zephyr
   - gccarmemb
+supported:
+  - slip
 testing:
         default: true

--- a/boards/x86/qemu_x86/qemu_x86.yaml
+++ b/boards/x86/qemu_x86/qemu_x86.yaml
@@ -6,4 +6,4 @@ toolchain:
   - zephyr
 supported:
   - pci
-  - net
+  - slip

--- a/boards/x86/qemu_x86/qemu_x86_iamcu.yaml
+++ b/boards/x86/qemu_x86/qemu_x86_iamcu.yaml
@@ -6,6 +6,6 @@ toolchain:
   - zephyr
 supported:
   - pci
-  - net
+  - slip
 testing:
         default: true


### PR DESCRIPTION
Renamed 'net' to 'slip' to be pedantic about the type of networking that
we currently support on the QEMU targets.  Also marked the arm
(qemu_cortex_m3) board as supporting 'slip'.

Signed-off-by: Kumar Gala <kumar.gala@linaro.org>