### PR TITLE
Fix a build warning in mcux ethernet driver

### DIFF
--- a/drivers/ethernet/eth_mcux.c
+++ b/drivers/ethernet/eth_mcux.c
@@ -365,7 +365,8 @@ static void eth_rx(struct device *iface)
 	status_t status;
 	unsigned int imask;
 
-	status = ENET_GetRxFrameSize(&context->enet_handle, &frame_length);
+	status = ENET_GetRxFrameSize(&context->enet_handle,
+				     (uint32_t *)&frame_length);
 	if (status) {
 		enet_data_error_stats_t error_stats;
 


### PR DESCRIPTION
Add a cast to work around a difference between Zephyr's u32_t and the HAL's uint32_t which is causing a build warning.