### PR TITLE
scripts/extract_dts_includes.py: Reduce code for handling chosen names

### DIFF
--- a/scripts/extract_dts_includes.py
+++ b/scripts/extract_dts_includes.py
@@ -778,21 +778,16 @@ def main():
         extract_reg_prop(chosen['zephyr,sram'], None,
                          defs, "CONFIG_SRAM", 1024, None)
 
-    if 'zephyr,console' in chosen:
-        extract_string_prop(chosen['zephyr,console'], None, "label",
-                            "CONFIG_UART_CONSOLE_ON_DEV_NAME", defs)
+    name_dict = {
+            "CONFIG_UART_CONSOLE_ON_DEV_NAME": "zephyr,console",
+            "CONFIG_BLUETOOTH_UART_ON_DEV_NAME": "zephyr,bt-uart",
+            "CONFIG_UART_PIPE_ON_DEV_NAME": "zephyr,bt-mon-uart",
+            "CONFIG_BLUETOOTH_MONITOR_ON_DEV_NAME": "zephyr,bt-mon-uart"
+            }
 
-    if 'zephyr,bt-uart' in chosen:
-       extract_string_prop(chosen['zephyr,bt-uart'], None, "label",
-                           "CONFIG_BLUETOOTH_UART_ON_DEV_NAME", defs)
-
-    if 'zephyr,uart-pipe' in chosen:
-       extract_string_prop(chosen['zephyr,uart-pipe'], None, "label",
-                           "CONFIG_UART_PIPE_ON_DEV_NAME", defs)
-
-    if 'zephyr,bt-mon-uart' in chosen:
-       extract_string_prop(chosen['zephyr,bt-mon-uart'], None, "label",
-                           "CONFIG_BLUETOOTH_MONITOR_ON_DEV_NAME", defs)
+    for k, v in name_dict.items():
+        if v in chosen:
+            extract_string_prop(chosen[v], None, "label", k, defs)
 
     # only compute the load offset if a code partition exists and it is not the
     # same as the flash base address


### PR DESCRIPTION
We have the same pattern for how we map a chosen property to the device
label that generates a Kconfig define.  Rather than duplicating the code
over and over again, lets just iterate over a list of defines and chosen
properties.  This also provides us a list we can use in the future to
special case handle the defines associated with names.

Signed-off-by: Kumar Gala <kumar.gala@linaro.org>