### PR TITLE
kernel: introduce opaque data type for stacks

### DIFF
--- a/arch/arc/core/thread.c
+++ b/arch/arc/core/thread.c
@@ -54,11 +54,12 @@ struct init_stack_frame {
  *
  * @return N/A
  */
-void _new_thread(struct k_thread *thread, char *pStackMem, size_t stackSize,
-		 _thread_entry_t pEntry,
+void _new_thread(struct k_thread *thread, k_thread_stack_t stack,
+		 size_t stackSize, _thread_entry_t pEntry,
 		 void *parameter1, void *parameter2, void *parameter3,
 		 int priority, unsigned int options)
 {
+	char *pStackMem = K_THREAD_STACK_BUFFER(stack);
 	_ASSERT_VALID_PRIO(priority, pEntry);
 
 	char *stackEnd = pStackMem + stackSize;

--- a/arch/arc/include/v2/irq.h
+++ b/arch/arc/include/v2/irq.h
@@ -33,7 +33,7 @@ extern "C" {
 #ifndef _ASMLANGUAGE
 
 extern void _firq_stack_setup(void);
-extern char _interrupt_stack[];
+extern K_THREAD_STACK_DEFINE(_interrupt_stack, CONFIG_ISR_STACK_SIZE);
 
 /*
  * _irq_setup
@@ -54,7 +54,8 @@ static ALWAYS_INLINE void _irq_setup(void)
 	k_cpu_sleep_mode = _ARC_V2_WAKE_IRQ_LEVEL;
 	_arc_v2_aux_reg_write(_ARC_V2_AUX_IRQ_CTRL, aux_irq_ctrl_value);
 
-	_kernel.irq_stack = _interrupt_stack + CONFIG_ISR_STACK_SIZE;
+	_kernel.irq_stack =
+		K_THREAD_STACK_BUFFER(_interrupt_stack) + CONFIG_ISR_STACK_SIZE;
 	_firq_stack_setup();
 }
 

--- a/arch/arm/core/thread.c
+++ b/arch/arm/core/thread.c
@@ -49,11 +49,13 @@
  * @return N/A
  */
 
-void _new_thread(struct k_thread *thread, char *pStackMem, size_t stackSize,
-		 _thread_entry_t pEntry,
+void _new_thread(struct k_thread *thread, k_thread_stack_t stack,
+		 size_t stackSize, _thread_entry_t pEntry,
 		 void *parameter1, void *parameter2, void *parameter3,
 		 int priority, unsigned int options)
 {
+	char *pStackMem = K_THREAD_STACK_BUFFER(stack);
+
 	_ASSERT_VALID_PRIO(priority, pEntry);
 
 	__ASSERT(!((u32_t)pStackMem & (STACK_ALIGN - 1)),

--- a/arch/arm/include/cortex_m/stack.h
+++ b/arch/arm/include/cortex_m/stack.h
@@ -33,7 +33,7 @@ extern "C" {
 
 #else
 
-extern char _interrupt_stack[CONFIG_ISR_STACK_SIZE];
+extern K_THREAD_STACK_DEFINE(_interrupt_stack, CONFIG_ISR_STACK_SIZE);
 
 /**
  *
@@ -46,7 +46,8 @@ extern char _interrupt_stack[CONFIG_ISR_STACK_SIZE];
  */
 static ALWAYS_INLINE void _InterruptStackSetup(void)
 {
-	u32_t msp = (u32_t)(_interrupt_stack + CONFIG_ISR_STACK_SIZE);
+	u32_t msp = (u32_t)(K_THREAD_STACK_BUFFER(_interrupt_stack) +
+			    CONFIG_ISR_STACK_SIZE);
 
 	_MspSet(msp);
 }

--- a/arch/arm/include/kernel_arch_func.h
+++ b/arch/arm/include/kernel_arch_func.h
@@ -38,13 +38,15 @@ static ALWAYS_INLINE void kernel_arch_init(void)
 }
 
 static ALWAYS_INLINE void
-_arch_switch_to_main_thread(struct k_thread *main_thread, char *main_stack,
+_arch_switch_to_main_thread(struct k_thread *main_thread,
+			    k_thread_stack_t main_stack,
 			    size_t main_stack_size, _thread_entry_t _main)
 {
 	/* get high address of the stack, i.e. its start (stack grows down) */
 	char *start_of_main_stack;
 
-	start_of_main_stack = main_stack + main_stack_size;
+	start_of_main_stack =
+		K_THREAD_STACK_BUFFER(main_stack) + main_stack_size;
 	start_of_main_stack = (void *)STACK_ROUND_DOWN(start_of_main_stack);
 
 	_current = main_thread;

--- a/arch/nios2/core/thread.c
+++ b/arch/nios2/core/thread.c
@@ -31,11 +31,12 @@ struct init_stack_frame {
 };
 
 
-void _new_thread(struct k_thread *thread, char *stack_memory, size_t stack_size,
-		 _thread_entry_t thread_func,
+void _new_thread(struct k_thread *thread, k_thread_stack_t stack,
+		 size_t stack_size, _thread_entry_t thread_func,
 		 void *arg1, void *arg2, void *arg3,
 		 int priority, unsigned int options)
 {
+	char *stack_memory = K_THREAD_STACK_BUFFER(stack);
 	_ASSERT_VALID_PRIO(priority, thread_func);
 
 	struct init_stack_frame *iframe;

--- a/arch/nios2/include/kernel_arch_data.h
+++ b/arch/nios2/include/kernel_arch_data.h
@@ -53,7 +53,7 @@ struct _kernel_arch {
 
 typedef struct _kernel_arch _kernel_arch_t;
 
-extern char _interrupt_stack[CONFIG_ISR_STACK_SIZE];
+extern K_THREAD_STACK_DEFINE(_interrupt_stack, CONFIG_ISR_STACK_SIZE);
 
 #endif /* _ASMLANGUAGE */
 

--- a/arch/nios2/include/kernel_arch_func.h
+++ b/arch/nios2/include/kernel_arch_func.h
@@ -31,7 +31,8 @@ void k_cpu_atomic_idle(unsigned int key);
 
 static ALWAYS_INLINE void kernel_arch_init(void)
 {
-	_kernel.irq_stack = _interrupt_stack + CONFIG_ISR_STACK_SIZE;
+	_kernel.irq_stack =
+		K_THREAD_STACK_BUFFER(_interrupt_stack) + CONFIG_ISR_STACK_SIZE;
 }
 
 static ALWAYS_INLINE void

--- a/arch/riscv32/core/thread.c
+++ b/arch/riscv32/core/thread.c
@@ -15,11 +15,12 @@ void _thread_entry_wrapper(_thread_entry_t thread,
 			   void *arg2,
 			   void *arg3);
 
-void _new_thread(struct k_thread *thread, char *stack_memory,
+void _new_thread(struct k_thread *thread, k_thread_stack_t stack,
 		 size_t stack_size, _thread_entry_t thread_func,
 		 void *arg1, void *arg2, void *arg3,
 		 int priority, unsigned int options)
 {
+	char *stack_memory = K_THREAD_STACK_BUFFER(stack);
 	_ASSERT_VALID_PRIO(priority, thread_func);
 
 	struct __esf *stack_init;

--- a/arch/riscv32/include/kernel_arch_data.h
+++ b/arch/riscv32/include/kernel_arch_data.h
@@ -37,7 +37,7 @@ struct _kernel_arch {
 
 typedef struct _kernel_arch _kernel_arch_t;
 
-extern char _interrupt_stack[CONFIG_ISR_STACK_SIZE];
+extern K_THREAD_STACK_DEFINE(_interrupt_stack, CONFIG_ISR_STACK_SIZE);
 
 #endif /* _ASMLANGUAGE */
 

--- a/arch/riscv32/include/kernel_arch_func.h
+++ b/arch/riscv32/include/kernel_arch_func.h
@@ -27,7 +27,8 @@ void k_cpu_atomic_idle(unsigned int key);
 
 static ALWAYS_INLINE void kernel_arch_init(void)
 {
-	_kernel.irq_stack = _interrupt_stack + CONFIG_ISR_STACK_SIZE;
+	_kernel.irq_stack =
+		K_THREAD_STACK_BUFFER(_interrupt_stack) + CONFIG_ISR_STACK_SIZE;
 }
 
 static ALWAYS_INLINE void

--- a/arch/x86/core/thread.c
+++ b/arch/x86/core/thread.c
@@ -196,22 +196,23 @@ __asm__("\t.globl _thread_entry\n"
  *
  * @return opaque pointer to initialized k_thread structure
  */
-void _new_thread(struct k_thread *thread, char *pStackMem, size_t stackSize,
+void _new_thread(struct k_thread *thread, k_thread_stack_t stack,
+		 size_t stackSize,
 		 _thread_entry_t pEntry,
 		 void *parameter1, void *parameter2, void *parameter3,
 		 int priority, unsigned int options)
 {
+	char *pStackMem;
+
 	_ASSERT_VALID_PRIO(priority, pEntry);
 
 	unsigned long *pInitialThread;
 
 #if CONFIG_X86_STACK_PROTECTION
-	_x86_mmu_set_flags(pStackMem, MMU_PAGE_SIZE, MMU_ENTRY_NOT_PRESENT,
+	_x86_mmu_set_flags(stack, MMU_PAGE_SIZE, MMU_ENTRY_NOT_PRESENT,
 			   MMU_PTE_P_MASK);
 #endif
-#if _STACK_GUARD_SIZE
-	pStackMem += _STACK_GUARD_SIZE;
-#endif
+	pStackMem = K_THREAD_STACK_BUFFER(stack);
 	_new_thread_init(thread, pStackMem, stackSize, priority, options);
 
 	/* carve the thread entry struct from the "base" of the stack */

--- a/arch/xtensa/core/thread.c
+++ b/arch/xtensa/core/thread.c
@@ -42,11 +42,14 @@ extern void _xt_user_exit(void);
  * @return N/A
  */
 
-void _new_thread(struct k_thread *thread, char *pStack, size_t stackSize,
+void _new_thread(struct k_thread *thread, k_thread_stack_t stack,
+		size_t stackSize,
 		void (*pEntry)(void *, void *, void *),
 		void *p1, void *p2, void *p3,
 		int priority, unsigned int options)
 {
+	char *pStack = K_THREAD_STACK_BUFFER(stack);
+
 	/* Align stack end to maximum alignment requirement. */
 	char *stackEnd = (char *)ROUND_DOWN(pStack + stackSize, 16);
 #if XCHAL_CP_NUM > 0

--- a/include/arch/x86/arch.h
+++ b/include/arch/x86/arch.h
@@ -547,22 +547,25 @@ extern FUNC_NORETURN void _SysFatalErrorHandler(unsigned int reason,
  */
 
 #define _ARCH_THREAD_STACK_DEFINE(sym, size) \
-	char _GENERIC_SECTION(.stacks) __aligned(_STACK_BASE_ALIGN) \
-		sym[size + _STACK_GUARD_SIZE]
+	struct _k_thread_stack_element _GENERIC_SECTION(.stacks) \
+		__aligned(_STACK_BASE_ALIGN) \
+		sym[(size) + _STACK_GUARD_SIZE]
 
 #define _ARCH_THREAD_STACK_ARRAY_DEFINE(sym, nmemb, size) \
-	char _GENERIC_SECTION(.stacks) __aligned(_STACK_BASE_ALIGN) \
+	struct _k_thread_stack_element _GENERIC_SECTION(.stacks) \
+		__aligned(_STACK_BASE_ALIGN) \
 		sym[nmemb][ROUND_UP(size, _STACK_BASE_ALIGN) + \
 			   _STACK_GUARD_SIZE]
 
 #define _ARCH_THREAD_STACK_MEMBER(sym, size) \
-	char __aligned(_STACK_BASE_ALIGN) sym[size + _STACK_GUARD_SIZE]
+	struct _k_thread_stack_element __aligned(_STACK_BASE_ALIGN) \
+		sym[(size) + _STACK_GUARD_SIZE]
 
 #define _ARCH_THREAD_STACK_SIZEOF(sym) \
 	(sizeof(sym) - _STACK_GUARD_SIZE)
 
 #define _ARCH_THREAD_STACK_BUFFER(sym) \
-	(sym + _STACK_GUARD_SIZE)
+	((char *)((sym) + _STACK_GUARD_SIZE))
 
 #if CONFIG_X86_KERNEL_OOPS
 #define _ARCH_EXCEPT(reason_p) do { \

--- a/include/drivers/console/ipm_console.h
+++ b/include/drivers/console/ipm_console.h
@@ -35,7 +35,7 @@ struct ipm_console_receiver_config_info {
 	 * Stack for the receiver's thread, which prints out messages as
 	 * they come in. Should be sized CONFIG_IPM_CONSOLE_STACK_SIZE
 	 */
-	char *thread_stack;
+	k_thread_stack_t thread_stack;
 
 	/**
 	 * Ring buffer data area for stashing characters from the interrupt

--- a/include/net/http.h
+++ b/include/net/http.h
@@ -326,7 +326,7 @@ struct http_client_ctx {
 #if defined(CONFIG_HTTPS)
 	struct {
 		/** HTTPS stack for mbedtls library. */
-		u8_t *stack;
+		k_thread_stack_t stack;
 
 		/** HTTPS stack size. */
 		int stack_size;
@@ -582,7 +582,7 @@ int https_client_init(struct http_client_ctx *http_ctx,
 		      const char *cert_host,
 		      https_entropy_src_cb_t entropy_src_cb,
 		      struct k_mem_pool *pool,
-		      u8_t *https_stack,
+		      k_thread_stack_t https_stack,
 		      size_t https_stack_size);
 #endif /* CONFIG_HTTPS */
 
@@ -789,7 +789,7 @@ struct http_server_ctx {
 #if defined(CONFIG_HTTPS)
 	struct {
 		/** HTTPS stack for mbedtls library. */
-		u8_t *stack;
+		k_thread_stack_t stack;
 
 		/** HTTPS stack size. */
 		int stack_size;
@@ -921,7 +921,7 @@ int https_server_init(struct http_server_ctx *http_ctx,
 		      https_server_cert_cb_t cert_cb,
 		      https_entropy_src_cb_t entropy_src_cb,
 		      struct k_mem_pool *pool,
-		      u8_t *https_stack,
+		      k_thread_stack_t https_stack,
 		      size_t https_stack_len);
 #endif /* CONFIG_HTTPS */
 

--- a/include/net/mqtt.h
+++ b/include/net/mqtt.h
@@ -81,7 +81,7 @@ struct mqtt_ctx {
 
 	/** TLS thread parameters */
 	struct k_mem_pool *tls_mem_pool;
-	u8_t *tls_stack;
+	k_thread_stack_t tls_stack;
 	size_t tls_stack_size;
 
 	/** TLS callback */

--- a/include/net/net_app.h
+++ b/include/net/net_app.h
@@ -304,7 +304,7 @@ struct net_app_ctx {
 #if defined(CONFIG_NET_APP_TLS)
 	struct {
 		/** TLS stack for mbedtls library. */
-		u8_t *stack;
+		k_thread_stack_t stack;
 
 		/** TLS stack size. */
 		int stack_size;
@@ -854,7 +854,7 @@ int net_app_client_tls(struct net_app_ctx *ctx,
 		       const char *cert_host,
 		       net_app_entropy_src_cb_t entropy_src_cb,
 		       struct k_mem_pool *pool,
-		       u8_t *stack,
+		       k_thread_stack_t stack,
 		       size_t stack_size);
 #endif /* CONFIG_NET_APP_CLIENT */
 
@@ -890,7 +890,7 @@ int net_app_server_tls(struct net_app_ctx *ctx,
 		       net_app_cert_cb_t cert_cb,
 		       net_app_entropy_src_cb_t entropy_src_cb,
 		       struct k_mem_pool *pool,
-		       u8_t *stack,
+		       k_thread_stack_t stack,
 		       size_t stack_len);
 
 bool net_app_server_tls_enable(struct net_app_ctx *ctx);

--- a/include/net/net_core.h
+++ b/include/net/net_core.h
@@ -89,7 +89,7 @@ int net_recv_data(struct net_if *iface, struct net_pkt *pkt);
 int net_send_data(struct net_pkt *pkt);
 
 struct net_stack_info {
-	char *stack;
+	k_thread_stack_t stack;
 	const char *pretty_name;
 	const char *name;
 	size_t orig_size;

--- a/kernel/include/nano_internal.h
+++ b/kernel/include/nano_internal.h
@@ -43,7 +43,8 @@ FUNC_NORETURN void _Cstart(void);
 extern FUNC_NORETURN void _thread_entry(void (*)(void *, void *, void *),
 			  void *, void *, void *);
 
-extern void _new_thread(struct k_thread *thread, char *pStack, size_t stackSize,
+extern void _new_thread(struct k_thread *thread, k_thread_stack_t pStack,
+			size_t stackSize,
 			void (*pEntry)(void *, void *, void *),
 			void *p1, void *p2, void *p3,
 			int prio, unsigned int options);

--- a/kernel/thread.c
+++ b/kernel/thread.c
@@ -249,28 +249,31 @@ static void schedule_new_thread(struct k_thread *thread, s32_t delay)
 
 #ifdef CONFIG_MULTITHREADING
 
-k_tid_t k_thread_create(struct k_thread *new_thread, char *stack,
+k_tid_t k_thread_create(struct k_thread *new_thread,
+			k_thread_stack_t stack,
 			size_t stack_size, void (*entry)(void *, void *, void*),
 			void *p1, void *p2, void *p3,
 			int prio, u32_t options, s32_t delay)
 {
 	__ASSERT(!_is_in_isr(), "Threads may not be created in ISRs");
-	_new_thread(new_thread, stack, stack_size, entry, p1, p2, p3, prio,
-		    options);
+	_new_thread(new_thread, stack, stack_size, entry, p1, p2, p3,
+		    prio, options);
 
 	schedule_new_thread(new_thread, delay);
 	return new_thread;
 }
 
 
-k_tid_t k_thread_spawn(char *stack, size_t stack_size,
+k_tid_t k_thread_spawn(k_thread_stack_t stack, size_t stack_size,
 			void (*entry)(void *, void *, void*),
 			void *p1, void *p2, void *p3,
 			int prio, u32_t options, s32_t delay)
 {
-	struct k_thread *new_thread = (struct k_thread *)stack;
+	struct k_thread *new_thread =
+		(struct k_thread *)K_THREAD_STACK_BUFFER(stack);
 
-	return k_thread_create(new_thread, stack, stack_size, entry, p1, p2,
+	return k_thread_create(new_thread, stack,
+			       stack_size, entry, p1, p2,
 			       p3, prio, options, delay);
 }
 

--- a/kernel/work_q.c
+++ b/kernel/work_q.c
@@ -43,7 +43,7 @@ static void work_q_main(void *work_q_ptr, void *p2, void *p3)
 	}
 }
 
-void k_work_q_start(struct k_work_q *work_q, char *stack,
+void k_work_q_start(struct k_work_q *work_q, k_thread_stack_t stack,
 		    size_t stack_size, int prio)
 {
 	k_fifo_init(&work_q->fifo);

--- a/subsys/net/lib/app/client.c
+++ b/subsys/net/lib/app/client.c
@@ -576,7 +576,7 @@ int net_app_client_tls(struct net_app_ctx *ctx,
 		       const char *cert_host,
 		       net_app_entropy_src_cb_t entropy_src_cb,
 		       struct k_mem_pool *pool,
-		       u8_t *stack,
+		       k_thread_stack_t stack,
 		       size_t stack_size)
 {
 	if (!request_buf || request_buf_len == 0) {

--- a/subsys/net/lib/app/server.c
+++ b/subsys/net/lib/app/server.c
@@ -342,7 +342,7 @@ int net_app_server_tls(struct net_app_ctx *ctx,
 		       net_app_cert_cb_t cert_cb,
 		       net_app_entropy_src_cb_t entropy_src_cb,
 		       struct k_mem_pool *pool,
-		       u8_t *stack,
+		       k_thread_stack_t stack,
 		       size_t stack_size)
 {
 	if (!request_buf || request_buf_len == 0) {

--- a/subsys/net/lib/http/http_client.c
+++ b/subsys/net/lib/http/http_client.c
@@ -1635,7 +1635,7 @@ int https_client_init(struct http_client_ctx *ctx,
 		      const char *cert_host,
 		      https_entropy_src_cb_t entropy_src_cb,
 		      struct k_mem_pool *pool,
-		      u8_t *https_stack,
+		      k_thread_stack_t https_stack,
 		      size_t https_stack_size)
 {
 	int ret;

--- a/subsys/net/lib/http/http_server.c
+++ b/subsys/net/lib/http/http_server.c
@@ -1575,7 +1575,7 @@ int https_server_init(struct http_server_ctx *ctx,
 		      https_server_cert_cb_t cert_cb,
 		      https_entropy_src_cb_t entropy_src_cb,
 		      struct k_mem_pool *pool,
-		      u8_t *https_stack,
+		      k_thread_stack_t https_stack,
 		      size_t https_stack_size)
 {
 	int ret;

--- a/tests/kernel/fatal/src/main.c
+++ b/tests/kernel/fatal/src/main.c
@@ -17,7 +17,8 @@ static K_THREAD_STACK_DEFINE(alt_stack, STACKSIZE);
 
 #ifdef CONFIG_STACK_SENTINEL
 #define OVERFLOW_STACKSIZE 1024
-static char *overflow_stack = alt_stack + (STACKSIZE - OVERFLOW_STACKSIZE);
+static k_thread_stack_t overflow_stack =
+		alt_stack + (STACKSIZE - OVERFLOW_STACKSIZE);
 #else
 #define OVERFLOW_STACKSIZE STACKSIZE
 #endif


### PR DESCRIPTION
Historically, stacks were just character buffers and could be treated
as such if the user wanted to look inside the stack data, and also
declared as an array of the desired stack size.

This is no longer the case. Certain architectures will create a memory
region much larger to account for MPU/MMU guard pages. Unfortunately,
the kernel interfaces treat both the declared stack, and the valid
stack buffer within it as the same char * data type, even though these
absolutely cannot be used interchangeably.

We introduce an opaque k_thread_stack_t which gets instantiated by
K_THREAD_STACK_DECLARE(), this is no longer treated by the compiler
as a character pointer, even though it really is.

To access the real stack buffer within, the result of
K_THREAD_STACK_BUFFER() can be used, which will return a char * type.

This should catch a bunch of programming mistakes at build time:

- Declaring a character array outside of K_THREAD_STACK_DECLARE() and
  passing it to K_THREAD_CREATE
- Directly examining the stack created by K_THREAD_STACK_DECLARE()
  which is not actually the memory desired and may trigger a CPU
  exception

Signed-off-by: Andrew Boie <andrew.p.boie@intel.com>