### PR TITLE
scripts/extract_dts_includes.py: Fix typo in device name list

### DIFF
--- a/scripts/extract_dts_includes.py
+++ b/scripts/extract_dts_includes.py
@@ -781,7 +781,7 @@ def main():
     name_dict = {
             "CONFIG_UART_CONSOLE_ON_DEV_NAME": "zephyr,console",
             "CONFIG_BLUETOOTH_UART_ON_DEV_NAME": "zephyr,bt-uart",
-            "CONFIG_UART_PIPE_ON_DEV_NAME": "zephyr,bt-mon-uart",
+            "CONFIG_UART_PIPE_ON_DEV_NAME": "zephyr,uart-pipe",
             "CONFIG_BLUETOOTH_MONITOR_ON_DEV_NAME": "zephyr,bt-mon-uart"
             }
 


### PR DESCRIPTION
For CONFIG_UART_PIPE_ON_DEV_NAME the chosen property is
"zephyr,uart-pipe" not ""zephyr,bt-mon-uart".

Signed-off-by: Kumar Gala <kumar.gala@linaro.org>