### PR TITLE
DO NOT MERGE: dlist: Allow for NULL-initialized list heads

### DIFF
--- a/include/misc/dlist.h
+++ b/include/misc/dlist.h
@@ -10,9 +10,12 @@
  *
  * Doubly-linked list implementation.
  *
- * The lists are expected to be initialized such that both the head and tail
- * pointers point to the list itself.  Initializing the lists in such a fashion
- * simplifies the adding and removing of nodes to/from the list.
+ * The sys_dlist_t handle object acts as an extra node that connects
+ * both the head and the tail of the list, making the list a cycle and
+ * allowing removals to work in a uniform way even at the start or end
+ * of a list.  For initialization convenience, both the "head == tail"
+ * state and the "head == tail == NULL" state are accepted as
+ * indicating an empty list.
  */
 
 #ifndef _misc_dlist__h_
@@ -179,11 +182,10 @@ typedef struct _dnode sys_dnode_t;
 
 static inline void sys_dlist_init(sys_dlist_t *list)
 {
-	list->head = (sys_dnode_t *)list;
-	list->tail = (sys_dnode_t *)list;
+	list->head = list->tail = NULL;
 }
 
-#define SYS_DLIST_STATIC_INIT(ptr_to_list) {{(ptr_to_list)}, {(ptr_to_list)}}
+#define SYS_DLIST_STATIC_INIT(unused) __DEPRECATED_MACRO {{NULL, NULL}}
 
 /**
  * @brief check if a node is the list's head
@@ -223,7 +225,7 @@ static inline int sys_dlist_is_tail(sys_dlist_t *list, sys_dnode_t *node)
 
 static inline int sys_dlist_is_empty(sys_dlist_t *list)
 {
-	return list->head == list;
+	return (!list->head) || (list->head == list);
 }
 
 /**
@@ -324,11 +326,18 @@ static inline sys_dnode_t *sys_dlist_peek_tail(sys_dlist_t *list)
 
 static inline void sys_dlist_append(sys_dlist_t *list, sys_dnode_t *node)
 {
-	node->next = list;
-	node->prev = list->tail;
+	if (list->head) {
+		node->next = list;
+		node->prev = list->tail;
 
-	list->tail->next = node;
-	list->tail = node;
+		list->tail->next = node;
+		list->tail = node;
+	} else {
+		list->head = node;
+		list->tail = node;
+		node->next = list;
+		node->prev = list;
+	}
 }
 
 /**
@@ -342,11 +351,18 @@ static inline void sys_dlist_append(sys_dlist_t *list, sys_dnode_t *node)
 
 static inline void sys_dlist_prepend(sys_dlist_t *list, sys_dnode_t *node)
 {
-	node->next = list->head;
-	node->prev = list;
+	if (list->head) {
+		node->next = list->head;
+		node->prev = list;
 
-	list->head->prev = node;
-	list->head = node;
+		list->head->prev = node;
+		list->head = node;
+	} else {
+		node->next = list;
+		node->prev = list;
+		list->tail = node;
+		list->head = node;
+	}
 }
 
 /**


### PR DESCRIPTION
[Comments only right now.  This is a quick attempt to address the "can't write pthread INITIALIZER macros for Zephyr" problem.  Seems to work, though note that it marks the existing initializer deprecated and will need extra patches to remove existing usage before merge.  Worthwhile?  Yes?  No?]

The sys_dlist_t list header has traditionally been initialized with
pointers to itself in the head/tail fields.  This allows for clean
symmetric operation when the list is modified as the cycle formed by
the head being part of the list means that no head/tail checking needs
to occur at runtime.

Nonetheless this meant that dlists have trouble with static
initialization, as they can't live in BSS.  Worse, the initializer
macro requires an argument specifying the address of the object being
initialized, which is annoying to get right and disallows some kinds
of APIs that might want to use a static dlist.

Making this work with NULL pointers in addition to the backpointers
turns out to be not so hard: one null test and branch at each list
modification and in the is_empty predicate is all that's required.

Signed-off-by: Andy Ross <andrew.j.ross@intel.com>