### PR TITLE
net: app: fix build when NET_DEBUG_APP is used with SYS_LOG_NET_LEVEL=1

### DIFF
--- a/subsys/net/lib/app/init.c
+++ b/subsys/net/lib/app/init.c
@@ -55,6 +55,7 @@ static void ipv4_addr_add_handler(struct net_mgmt_event_callback *cb,
 			continue;
 		}
 
+#if defined(CONFIG_NET_DEBUG_APP) && CONFIG_SYS_LOG_NET_LEVEL > 1
 		NET_INFO("IPv4 address: %s",
 			 net_addr_ntop(AF_INET, &if_addr->address.in_addr,
 				       hr_addr, NET_IPV4_ADDR_LEN));
@@ -65,6 +66,7 @@ static void ipv4_addr_add_handler(struct net_mgmt_event_callback *cb,
 		NET_INFO("Router: %s",
 			 net_addr_ntop(AF_INET, &iface->ipv4.gw,
 				       hr_addr, NET_IPV4_ADDR_LEN));
+#endif
 		break;
 	}
 
@@ -107,8 +109,10 @@ static void setup_ipv4(struct net_if *iface)
 
 	net_if_ipv4_addr_add(iface, &addr, NET_ADDR_MANUAL, 0);
 
+#if defined(CONFIG_NET_DEBUG_APP) && CONFIG_SYS_LOG_NET_LEVEL > 1
 	NET_INFO("IPv4 address: %s",
 		 net_addr_ntop(AF_INET, &addr, hr_addr, NET_IPV4_ADDR_LEN));
+#endif
 
 	k_sem_take(&counter, K_NO_WAIT);
 	k_sem_give(&waiter);
@@ -143,9 +147,11 @@ static void ipv6_event_handler(struct net_mgmt_event_callback *cb,
 			return;
 		}
 
+#if defined(CONFIG_NET_DEBUG_APP) && CONFIG_SYS_LOG_NET_LEVEL > 1
 		NET_INFO("IPv6 address: %s",
 			 net_addr_ntop(AF_INET6, &laddr, hr_addr,
 				       NET_IPV6_ADDR_LEN));
+#endif
 
 		k_sem_take(&counter, K_NO_WAIT);
 		k_sem_give(&waiter);


### PR DESCRIPTION
hr_addr is only available when SYS_LOG_NET_LEVEL is > 1.

Signed-off-by: Ricardo Salveti <ricardo.salveti@linaro.org>