### PR TITLE
net: Don't enable SLIP driver if Bluetooth is enabled

### DIFF
--- a/subsys/net/ip/Kconfig
+++ b/subsys/net/ip/Kconfig
@@ -253,7 +253,7 @@ config NET_SLIP_TAP
 	select UART_INTERRUPT_DRIVEN
 	select SLIP_TAP
 	default n
-	default y if (QEMU_TARGET && !NET_TEST)
+	default y if (QEMU_TARGET && !NET_TEST && !NET_L2_BLUETOOTH)
 	help
 	  SLIP TAP support is necessary when testing IPv4/ARP. The host
 	  needs to have tunslip with TAP support running in order to


### PR DESCRIPTION
In case the application is using NET_L2_BLUETOOTH SLIP shall not be used
as they both use the UART as bus they cannot coexist.

Signed-off-by: Luiz Augusto von Dentz <luiz.von.dentz@intel.com>