### PR TITLE
samples: mesh: build sample where they fit

### DIFF
--- a/samples/bluetooth/mesh/sample.yaml
+++ b/samples/bluetooth/mesh/sample.yaml
@@ -4,4 +4,5 @@ tests:
 -   test:
         build_only: true
         tags: bluetooth
-        depends_on: ble
+        # FIXME: does not fit on all Bluetooth devices
+        platform_whitelist: bbc_microbit nrf51_blenano qemu_x86

--- a/samples/bluetooth/mesh_demo/sample.yaml
+++ b/samples/bluetooth/mesh_demo/sample.yaml
@@ -4,4 +4,5 @@ tests:
 -   test:
         build_only: true
         tags: bluetooth
-        depends_on: ble
+        # FIXME: does not fit on all Bluetooth devices
+        platform_whitelist: bbc_microbit nrf51_blenano qemu_x86


### PR DESCRIPTION
Not easily done using RAM/ROM filters, configurations need to be adapted
to make this fit on more devices. Limit the target platforms now while
we figure out configurations.

Signed-off-by: Anas Nashif <anas.nashif@intel.com>