### PR TITLE
net: slip: Clarify slip settings in Kconfig

### DIFF
--- a/drivers/slip/Kconfig
+++ b/drivers/slip/Kconfig
@@ -71,11 +71,10 @@ config	SLIP_STATISTICS
 
 config  SLIP_TAP
 	bool "Use TAP interface to host"
-	default n
+	default y
 	select NET_L2_ETHERNET
 	help
-	  By default TUN is used. In TAP the Ethernet frames
-	  are transferred over SLIP.
+	  In TAP the Ethernet frames are transferred over SLIP.
 
 
 config	SLIP_MAC_ADDR

--- a/subsys/net/ip/Kconfig
+++ b/subsys/net/ip/Kconfig
@@ -255,9 +255,10 @@ config NET_SLIP_TAP
 	default n
 	default y if (QEMU_TARGET && !NET_TEST && !NET_L2_BLUETOOTH)
 	help
-	  SLIP TAP support is necessary when testing IPv4/ARP. The host
-	  needs to have tunslip with TAP support running in order to
-	  communicate via the SLIP driver.
+	  SLIP TAP support is necessary when testing with QEMU. The host
+	  needs to have tunslip6 with TAP support running in order to
+	  communicate via the SLIP driver. See net-tools project at
+	  https://github.com/zephyrproject-rtos/net-tools for more details.
 
 config NET_TRICKLE
 	bool "Enable Trickle library"

--- a/subsys/net/ip/l2/Kconfig
+++ b/subsys/net/ip/l2/Kconfig
@@ -11,16 +11,16 @@ config NET_L2_DUMMY
 	default n
 	default y if !NET_L2_ETHERNET && NET_TEST
 	help
-	Add a dummy L2 layer driver, usually in case you need SLIP in
-	TUN mode.
+	Add a dummy L2 layer driver. This is usually only needed when
+	simulating a network interface when running network stack inside QEMU.
 
 config NET_L2_ETHERNET
 	bool "Enable Ethernet support"
 	default n
 	help
 	Add support for Ethernet, enabling selecting relevant hardware drivers.
-	If SLIP_TAP is selected, NET_L2_ETHERNET will enable to fully simulate
-	Ethernet through SLIP.
+	If NET_SLIP_TAP is selected, NET_L2_ETHERNET will enable to fully
+	simulate Ethernet through SLIP.
 
 config NET_DEBUG_L2_ETHERNET
 	bool "Debug Ethernet L2 layer"


### PR DESCRIPTION
As SLIP TAP is now the default after the commit ca0ad13a61ff5
("net: enable SLIP only on QEMU targets"), clarify the comments
and settings in various Kconfig files that talk about slip.

Signed-off-by: Jukka Rissanen <jukka.rissanen@linux.intel.com>