### PR TITLE
net: shell: Do not access NULL pointer if interface is down

### DIFF
--- a/include/net/net_if.h
+++ b/include/net/net_if.h
@@ -1184,6 +1184,20 @@ void net_if_foreach(net_if_cb_t cb, void *user_data);
 int net_if_up(struct net_if *iface);
 
 /**
+ * @brief Check if interface is up.
+ *
+ * @param iface Pointer to network interface
+ *
+ * @return True if interface is up, False if it is down.
+ */
+static inline bool net_if_is_up(struct net_if *iface)
+{
+	NET_ASSERT(iface);
+
+	return atomic_test_bit(iface->flags, NET_IF_UP);
+}
+
+/**
  * @brief Bring interface down
  *
  * @param iface Pointer to network interface

--- a/subsys/net/ip/net_shell.c
+++ b/subsys/net/ip/net_shell.c
@@ -98,6 +98,11 @@ static void iface_cb(struct net_if *iface, void *user_data)
 	printk("Interface %p\n", iface);
 	printk("====================\n");
 
+	if (!net_if_is_up(iface)) {
+		printk("Interface is down.\n");
+		return;
+	}
+
 	printk("Link addr : %s\n", net_sprint_ll_addr(iface->link_addr.addr,
 						      iface->link_addr.len));
 	printk("MTU       : %d\n", iface->mtu);


### PR DESCRIPTION
Normally network interface is always UP, but Bluetooth
interfaces are down until connected. So if this is the case,
then check the interface status before trying to access variables
that are NULL. This was seen with "net iface" shell command when
BT was enabled.

Signed-off-by: Jukka Rissanen <jukka.rissanen@linux.intel.com>