### PR TITLE
mem_pool: Don't check level_empty() before breaking a block

### DIFF
--- a/kernel/mempool.c
+++ b/kernel/mempool.c
@@ -273,9 +273,7 @@ static int pool_alloc(struct k_mem_pool *p, struct k_mem_block *block,
 		return -EAGAIN;
 	}
 
-	for (from_l = free_l;
-	     level_empty(p, alloc_l) && from_l < alloc_l;
-	     from_l++) {
+	for (from_l = free_l; from_l < alloc_l; from_l++) {
 		blk = break_block(p, blk, from_l, lsizes);
 	}
 


### PR DESCRIPTION
This test was just wrong.  If the current thread did not race with any
others during the allocation process, then the result will be false
because it was detected so earlier in the function.  If we did race,
then sure: it might be true now if someone snuck in and freed a block.
But so what?  We already have the block we want to break.  The
behavior in the code as written was to early-exit from the break loop,
returning a buffer that was larger than the one requested (though
otherwise benign -- we wouldn't leak, just waste memory).  No idea
what I was thinking.

Thanks to Du Quanwen for the diagnosis.

Signed-off-by: Andy Ross <andrew.j.ross@intel.com>