### PR TITLE
drivers, net: Clean up semaphore initialization

### DIFF
--- a/drivers/adc/adc_qmsi.c
+++ b/drivers/adc/adc_qmsi.c
@@ -240,8 +240,7 @@ static int adc_qmsi_init(struct device *dev)
 
 	k_sem_init(&info->device_sync_sem, 0, UINT_MAX);
 
-	k_sem_init(&info->sem, 0, UINT_MAX);
-	k_sem_give(&info->sem);
+	k_sem_init(&info->sem, 1, UINT_MAX);
 	info->state = ADC_STATE_IDLE;
 
 	adc_config_irq();

--- a/drivers/adc/adc_qmsi_ss.c
+++ b/drivers/adc/adc_qmsi_ss.c
@@ -308,8 +308,7 @@ static int adc_qmsi_ss_init(struct device *dev)
 	ss_clk_adc_set_div(CONFIG_ADC_QMSI_CLOCK_RATIO);
 	k_sem_init(&info->device_sync_sem, 0, UINT_MAX);
 
-	k_sem_init(&info->sem, 0, UINT_MAX);
-	k_sem_give(&info->sem);
+	k_sem_init(&info->sem, 1, UINT_MAX);
 	info->state = ADC_STATE_IDLE;
 
 	adc_config_irq();

--- a/drivers/counter/counter_qmsi_aonpt.c
+++ b/drivers/counter/counter_qmsi_aonpt.c
@@ -229,8 +229,7 @@ static int aon_timer_init(struct device *dev)
 	QM_IR_UNMASK_INTERRUPTS(QM_INTERRUPT_ROUTER->aonpt_0_int_mask);
 
 	if (IS_ENABLED(CONFIG_AON_API_REENTRANCY)) {
-		k_sem_init(RP_GET(dev), 0, UINT_MAX);
-		k_sem_give(RP_GET(dev));
+		k_sem_init(RP_GET(dev), 1, UINT_MAX);
 	}
 
 	aonpt_qmsi_set_power_state(dev, DEVICE_PM_ACTIVE_STATE);

--- a/drivers/crypto/crypto_ataes132a.c
+++ b/drivers/crypto/crypto_ataes132a.c
@@ -183,8 +183,7 @@ int ataes132a_init(struct device *dev)
 
 	i2c_configure(ataes132a->i2c, i2c_cfg.raw);
 
-	k_sem_init(&ataes132a->device_sem, 0, UINT_MAX);
-	k_sem_give(&ataes132a->device_sem);
+	k_sem_init(&ataes132a->device_sem, 1, UINT_MAX);
 
 	ataes132a_init_states();
 

--- a/drivers/ethernet/eth_enc28j60.c
+++ b/drivers/ethernet/eth_enc28j60.c
@@ -337,8 +337,7 @@ static int eth_enc28j60_init(struct device *dev)
 	struct eth_enc28j60_runtime *context = dev->driver_data;
 	struct spi_config spi_cfg;
 
-	k_sem_init(&context->spi_sem, 0, UINT_MAX);
-	k_sem_give(&context->spi_sem);
+	k_sem_init(&context->spi_sem, 1, UINT_MAX);
 
 	context->gpio = device_get_binding((char *)config->gpio_port);
 	if (!context->gpio) {

--- a/drivers/flash/soc_flash_qmsi.c
+++ b/drivers/flash/soc_flash_qmsi.c
@@ -330,8 +330,7 @@ static int quark_flash_init(struct device *dev)
 #endif
 
 	if (IS_ENABLED(CONFIG_SOC_FLASH_QMSI_API_REENTRANCY)) {
-		k_sem_init(RP_GET(dev), 0, UINT_MAX);
-		k_sem_give(RP_GET(dev));
+		k_sem_init(RP_GET(dev), 1, UINT_MAX);
 	}
 
 	flash_qmsi_set_power_state(dev, DEVICE_PM_ACTIVE_STATE);

--- a/drivers/flash/spi_flash_w25qxxdv.c
+++ b/drivers/flash/spi_flash_w25qxxdv.c
@@ -359,8 +359,7 @@ static int spi_flash_init(struct device *dev)
 
 	data->spi = spi_dev;
 
-	k_sem_init(&data->sem, 0, UINT_MAX);
-	k_sem_give(&data->sem);
+	k_sem_init(&data->sem, 1, UINT_MAX);
 
 	ret = spi_flash_wb_config(dev);
 	if (!ret) {

--- a/drivers/gpio/gpio_qmsi.c
+++ b/drivers/gpio/gpio_qmsi.c
@@ -369,8 +369,7 @@ static int gpio_qmsi_init(struct device *port)
 	const struct gpio_qmsi_config *gpio_config = port->config->config_info;
 
 	if (IS_ENABLED(CONFIG_GPIO_QMSI_API_REENTRANCY)) {
-		k_sem_init(RP_GET(port), 0, UINT_MAX);
-		k_sem_give(RP_GET(port));
+		k_sem_init(RP_GET(port), 1, UINT_MAX);
 	}
 
 	switch (gpio_config->gpio) {

--- a/drivers/gpio/gpio_qmsi_ss.c
+++ b/drivers/gpio/gpio_qmsi_ss.c
@@ -368,8 +368,7 @@ static int ss_gpio_qmsi_init(struct device *port)
 	u32_t *scss_intmask = NULL;
 
 	if (IS_ENABLED(CONFIG_GPIO_QMSI_API_REENTRANCY)) {
-		k_sem_init(RP_GET(port), 0, UINT_MAX);
-		k_sem_give(RP_GET(port));
+		k_sem_init(RP_GET(port), 1, UINT_MAX);
 	}
 
 	switch (gpio_config->gpio) {

--- a/drivers/i2c/i2c_qmsi.c
+++ b/drivers/i2c/i2c_qmsi.c
@@ -261,8 +261,7 @@ static int i2c_qmsi_init(struct device *dev)
 	int err;
 
 	k_sem_init(&driver_data->device_sync_sem, 0, UINT_MAX);
-	k_sem_init(&driver_data->sem, 0, UINT_MAX);
-	k_sem_give(&driver_data->sem);
+	k_sem_init(&driver_data->sem, 1, UINT_MAX);
 
 	switch (instance) {
 	case QM_I2C_0:

--- a/drivers/i2c/i2c_qmsi_ss.c
+++ b/drivers/i2c/i2c_qmsi_ss.c
@@ -350,8 +350,7 @@ static int i2c_qmsi_ss_init(struct device *dev)
 	config->irq_cfg();
 	ss_clk_i2c_enable(instance);
 
-	k_sem_init(&driver_data->sem, 0, UINT_MAX);
-	k_sem_give(&driver_data->sem);
+	k_sem_init(&driver_data->sem, 1, UINT_MAX);
 
 	err = i2c_qmsi_ss_configure(dev, config->default_cfg.raw);
 

--- a/drivers/ieee802154/ieee802154_mcr20a.c
+++ b/drivers/ieee802154/ieee802154_mcr20a.c
@@ -1408,8 +1408,7 @@ static int mcr20a_init(struct device *dev)
 {
 	struct mcr20a_context *mcr20a = dev->driver_data;
 
-	k_sem_init(&mcr20a->spi.spi_sem, 0, UINT_MAX);
-	k_sem_give(&mcr20a->spi.spi_sem);
+	k_sem_init(&mcr20a->spi.spi_sem, 1, UINT_MAX);
 
 	k_mutex_init(&mcr20a->phy_mutex);
 	k_sem_init(&mcr20a->isr_sem, 0, 1);

--- a/drivers/pwm/pwm_qmsi.c
+++ b/drivers/pwm/pwm_qmsi.c
@@ -206,8 +206,7 @@ static int pwm_qmsi_init(struct device *dev)
 	clk_periph_enable(CLK_PERIPH_PWM_REGISTER | CLK_PERIPH_CLK);
 
 	if (IS_ENABLED(CONFIG_PWM_QMSI_API_REENTRANCY)) {
-		k_sem_init(RP_GET(dev), 0, UINT_MAX);
-		k_sem_give(RP_GET(dev));
+		k_sem_init(RP_GET(dev), 1, UINT_MAX);
 	}
 
 	pwm_qmsi_set_power_state(dev, DEVICE_PM_ACTIVE_STATE);

--- a/drivers/rtc/rtc_qmsi.c
+++ b/drivers/rtc/rtc_qmsi.c
@@ -139,8 +139,7 @@ static const struct rtc_driver_api api = {
 static int rtc_qmsi_init(struct device *dev)
 {
 	if (IS_ENABLED(CONFIG_RTC_QMSI_API_REENTRANCY)) {
-		k_sem_init(RP_GET(dev), 0, UINT_MAX);
-		k_sem_give(RP_GET(dev));
+		k_sem_init(RP_GET(dev), 1, UINT_MAX);
 	}
 
 	IRQ_CONNECT(IRQ_GET_NUMBER(QM_IRQ_RTC_0_INT), CONFIG_RTC_0_IRQ_PRI,

--- a/drivers/sensor/bmg160/bmg160.c
+++ b/drivers/sensor/bmg160/bmg160.c
@@ -281,8 +281,7 @@ int bmg160_init(struct device *dev)
 		return -EINVAL;
 	}
 
-	k_sem_init(&bmg160->sem, 0, UINT_MAX);
-	k_sem_give(&bmg160->sem);
+	k_sem_init(&bmg160->sem, 1, UINT_MAX);
 
 	if (bmg160_read_byte(dev, BMG160_REG_CHIPID, &chip_id) < 0) {
 		SYS_LOG_DBG("Failed to read chip id.");

--- a/drivers/sensor/fxas21002/fxas21002.c
+++ b/drivers/sensor/fxas21002/fxas21002.c
@@ -265,8 +265,7 @@ static int fxas21002_init(struct device *dev)
 	k_busy_wait(transition_time);
 
 
-	k_sem_init(&data->sem, 0, UINT_MAX);
-	k_sem_give(&data->sem);
+	k_sem_init(&data->sem, 1, UINT_MAX);
 
 	SYS_LOG_DBG("Init complete");
 

--- a/drivers/sensor/fxos8700/fxos8700.c
+++ b/drivers/sensor/fxos8700/fxos8700.c
@@ -345,8 +345,7 @@ static int fxos8700_init(struct device *dev)
 		return -EIO;
 	}
 
-	k_sem_init(&data->sem, 0, UINT_MAX);
-	k_sem_give(&data->sem);
+	k_sem_init(&data->sem, 1, UINT_MAX);
 
 	SYS_LOG_DBG("Init complete");
 

--- a/drivers/spi/spi_qmsi.c
+++ b/drivers/spi/spi_qmsi.c
@@ -291,8 +291,7 @@ static int spi_qmsi_init(struct device *dev)
 	context->gpio_cs = gpio_cs_init(spi_config);
 
 	k_sem_init(&context->device_sync_sem, 0, UINT_MAX);
-	k_sem_init(&context->sem, 0, UINT_MAX);
-	k_sem_give(&context->sem);
+	k_sem_init(&context->sem, 1, UINT_MAX);
 
 	spi_master_set_power_state(dev, DEVICE_PM_ACTIVE_STATE);
 

--- a/drivers/spi/spi_qmsi_ss.c
+++ b/drivers/spi/spi_qmsi_ss.c
@@ -450,8 +450,7 @@ static int ss_spi_qmsi_init(struct device *dev)
 	context->gpio_cs = gpio_cs_init(spi_config);
 #endif
 	k_sem_init(&context->device_sync_sem, 0, UINT_MAX);
-	k_sem_init(&context->sem, 0, UINT_MAX);
-	k_sem_give(&context->sem);
+	k_sem_init(&context->sem, 1, UINT_MAX);
 
 	ss_spi_master_set_power_state(dev, DEVICE_PM_ACTIVE_STATE);
 

--- a/drivers/watchdog/wdt_qmsi.c
+++ b/drivers/watchdog/wdt_qmsi.c
@@ -169,8 +169,7 @@ static int wdt_qmsi_device_ctrl(struct device *dev, u32_t ctrl_command,
 static int init(struct device *dev)
 {
 	if (IS_ENABLED(CONFIG_WDT_QMSI_API_REENTRANCY)) {
-		k_sem_init(RP_GET(dev), 0, UINT_MAX);
-		k_sem_give(RP_GET(dev));
+		k_sem_init(RP_GET(dev), 1, UINT_MAX);
 	}
 
 	IRQ_CONNECT(IRQ_GET_NUMBER(QM_IRQ_WDT_0_INT), CONFIG_WDT_0_IRQ_PRI,

--- a/subsys/net/ip/net_context.c
+++ b/subsys/net/ip/net_context.c
@@ -554,8 +554,7 @@ int net_context_get(sa_family_t family,
 #endif
 
 #if defined(CONFIG_NET_CONTEXT_SYNC_RECV)
-		k_sem_init(&contexts[i].recv_data_wait, 0, UINT_MAX);
-		k_sem_give(&contexts[i].recv_data_wait);
+		k_sem_init(&contexts[i].recv_data_wait, 1, UINT_MAX);
 #endif /* CONFIG_NET_CONTEXT_SYNC_RECV */
 
 		*context = &contexts[i];
@@ -2446,7 +2445,5 @@ void net_context_foreach(net_context_cb_t cb, void *user_data)
 
 void net_context_init(void)
 {
-	k_sem_init(&contexts_lock, 0, UINT_MAX);
-
-	k_sem_give(&contexts_lock);
+	k_sem_init(&contexts_lock, 1, UINT_MAX);
 }

--- a/tests/kernel/obj_tracing/src/main.c
+++ b/tests/kernel/obj_tracing/src/main.c
@@ -25,8 +25,7 @@ int main(void)
 	int i;
 
 	for (i = 0; i < N_PHILOSOPHERS; i++) {
-		k_sem_init(&forks[i], 0, 1);
-		k_sem_give(&forks[i]);
+		k_sem_init(&forks[i], 1, 1);
 	}
 
 	/* create philosopher threads */


### PR DESCRIPTION
Change the common "init with 0" + "give" idiom to "init with 1".  This
won't change the behavior or performance, but should decrease the size
ever so slightly.

This change has been performed mechanically with the following
Coccinelle script:

    @@
    expression SEM;
    expression LIMIT;
    expression TIMEOUT;
    @@

    - k_sem_init(SEM, 0, LIMIT);
    - k_sem_give(SEM);
    + k_sem_init(SEM, 1, LIMIT);

Signed-off-by: Leandro Pereira <leandro.pereira@intel.com>