### PR TITLE
Bluetooth: conn: Do not crash if there is nothing to send

### DIFF
--- a/subsys/bluetooth/host/conn.c
+++ b/subsys/bluetooth/host/conn.c
@@ -1347,9 +1347,10 @@ void bt_conn_process_tx(struct bt_conn *conn)
 
 	/* Get next ACL packet for connection */
 	buf = net_buf_get(&conn->tx_queue, K_NO_WAIT);
-	BT_ASSERT(buf);
-	if (!send_buf(conn, buf)) {
-		net_buf_unref(buf);
+	if (buf) {
+		if (!send_buf(conn, buf)) {
+			net_buf_unref(buf);
+		}
 	}
 }
 


### PR DESCRIPTION
The bt_conn_process_tx() reads the tx_queue for any packet but
as that is using K_NO_WAIT when reading, it might return NULL.
If this happens, just return without trying to send this NULL
buffer.

Jira: ZEP-2395

Signed-off-by: Jukka Rissanen <jukka.rissanen@linux.intel.com>