### PR TITLE
Allow specifying DTC_OVERLAY_FILE directly

### DIFF
--- a/scripts/Makefile.lib
+++ b/scripts/Makefile.lib
@@ -264,10 +264,12 @@ cmd_gzip = (cat $(filter-out FORCE,$^) | gzip -n -f -9 > $@) || \
 # DTC
 # ---------------------------------------------------------------------------
 
+ifeq ($(DTC_OVERLAY_FILE),)
 DTC_OVERLAY_DIR ?= $(PROJECT_BASE)
 # Since this goes into a file, use the native path
 DTC_ABS_OVERLAY_DIR = $(shell cd $(DTC_OVERLAY_DIR) && pwd $(NATIVE_PWD_OPT))
 DTC_OVERLAY_FILE = $(DTC_ABS_OVERLAY_DIR)/$(BOARD_NAME).overlay
+endif
 
 # Generate an assembly file to wrap the output of the device tree compiler
 quiet_cmd_dt_S_dtb= DTB     $@


### PR DESCRIPTION
Let the environment provide DTC_OVERLAY_FILE instead of searching DTC_OVERLAY_DIR/$(BOARD).overlay.

