### PR TITLE
scripts: extract: Make dts pinmux define usable in array init.

### DIFF
--- a/scripts/extract_dts_includes.py
+++ b/scripts/extract_dts_includes.py
@@ -408,7 +408,8 @@ def extract_pinctrl(node_address, yaml, pinconf, names, index, defs,
 
                     prop_def[key_label] = cells
                     prop_def[func_label] = \
-                        reduced[subnode]['props'][cells]
+                        "{%s, %s}" % (str(reduced[subnode]['props'][cells][0]), 
+                                      str(reduced[subnode]['props'][cells][1]))
 
     insert_defs(node_address, defs, prop_def, {})
 


### PR DESCRIPTION
The pinmux function define is most probably
only used to initialize configuration data
and not as an index into an array (as e.g reg).
Make it usable in array init: [ pin, function ] -> { pin, function }

Signed-off-by: b0661n0e17e@gmail.com