### PR TITLE
boards: arm: nrf52_blenano2: Add embedded LED definition

### DIFF
--- a/boards/arm/nrf52_blenano2/board.h
+++ b/boards/arm/nrf52_blenano2/board.h
@@ -9,4 +9,8 @@
 
 #include <soc.h>
 
+/* Onboard LED P0_11 */
+#define LED0_GPIO_PIN	11
+#define LED0_GPIO_PORT	CONFIG_GPIO_NRF5_P0_DEV_NAME
+
 #endif /* __INC_BOARD_H */


### PR DESCRIPTION
The on-board LED is connected to Pin 11 (P0_11)
Tested with samples/basic/blinky.

Signed-off-by: Loic Poulain <loic.poulain@gmail.com>