### PR TITLE
shippable: remove comment before get_modified_tests.py call

### DIFF
--- a/.shippable.yml
+++ b/.shippable.yml
@@ -66,7 +66,6 @@ build:
             ./scripts/ci/check-compliance.py --commits ${COMMIT_RANGE} || true;
           fi;
       - >
-          # installing due to missing sh module for python3 in image, remove after docker image update
           sudo pip3 install sh;
           ./scripts/ci/get_modified_tests.py --commits origin/${PULL_REQUEST_BASE_BRANCH}..HEAD > modified_tests.args;
 


### PR DESCRIPTION
The code block is being treated as a comment, remove the leading comment
to make this run correctly.

Signed-off-by: Anas Nashif <anas.nashif@intel.com>