### PR TITLE
boards: Fix QEMU_TARGET config prompt and default

### DIFF
--- a/boards/Kconfig
+++ b/boards/Kconfig
@@ -8,7 +8,8 @@ config BOARD_DEPRECATED
 	deprecation warning.
 
 config QEMU_TARGET
-	bool n
+	bool
+	default n
 	help
 	  Mark all QEMU targets with this variable for checking whether we are
 	  running in an emulated environment.


### PR DESCRIPTION
The default boolean setting for QEMU_TARGET was incorrectly placed in
the prompt field, so it was showing up as a config option in 'make
menuconfig' when it should be hidden.

Signed-off-by: Maureen Helm <maureen.helm@nxp.com>