### PR TITLE
net/mqtt: tweak doxygen comment for return value

### DIFF
--- a/include/net/mqtt.h
+++ b/include/net/mqtt.h
@@ -199,7 +199,7 @@ struct mqtt_ctx {
  *
  * @param ctx MQTT context structure
  * @param app_type See enum mqtt_app
- * @retval 0, always.
+ * @retval 0 always
  */
 int mqtt_init(struct mqtt_ctx *ctx, enum mqtt_app app_type);
 


### PR DESCRIPTION
mqtt_init's return value in the generated docs didn't format
correctly.  Needs to be a space after the 0, so just delete
the comma.

Signed-off-by: David B. Kinder <david.b.kinder@intel.com>