### PR TITLE
doc: linux installation for python3-pip incorrect

### DIFF
--- a/doc/getting_started/installation_linux.rst
+++ b/doc/getting_started/installation_linux.rst
@@ -55,7 +55,7 @@ Install the required packages in a Ubuntu host system with:
 .. code-block:: console
 
    $ sudo apt-get install git make gcc g++ ncurses-dev \
-	 doxygen dfu-util device-tree-compiler python-pip3
+	 doxygen dfu-util device-tree-compiler python3-pip
 
 Install the required packages in a Fedora host system with:
 


### PR DESCRIPTION
package name is python3-pip (not python-pip3)

Signed-off-by: David B. Kinder <david.b.kinder@intel.com>