### PR TITLE
doc: Switch to MSYS2's dtc package

### DIFF
--- a/doc/getting_started/installation_win.rst
+++ b/doc/getting_started/installation_win.rst
@@ -56,7 +56,7 @@ environment for Windows. Follow the steps below to set it up:
 
    .. code-block:: console
 
-      $ pacman -S git make gcc diffutils ncurses-devel python3
+      $ pacman -S git make gcc dtc diffutils ncurses-devel python3
 
 #. Install pip and the required Python modules::
 
@@ -64,33 +64,6 @@ environment for Windows. Follow the steps below to set it up:
       $ ./get-pip.py
       $ rm get-pip.py
       $ pip install --user -r scripts/requirements.txt
-
-#. Build the Device Tree Compiler (DTC)
-
-   For the architectures and boards listed in the ``dts/`` folder of the Zephyr
-   source tree, the DTC is required to be able to build Zephyr.
-   To set up the DTC follow the instructions below:
-
-   * Install the required build tools::
-
-        $ pacman -S bison
-        $ pacman -R flex
-        $ pacman -U http://repo.msys2.org/msys/x86_64/flex-2.6.0-1-x86_64.pkg.tar.xz
-
-   .. note::
-        At this time we need to pin the ``flex`` version to an older one due
-        to an issue with the latest available.
-
-   * Clone and build the DTC::
-
-        $ cd ~
-        $ git clone https://git.kernel.org/pub/scm/utils/dtc/dtc.git
-        $ cd dtc
-        $ make
-
-   * Export the location of the DTC::
-
-        $ export DTC=~/dtc/dtc
 
 #. The build system should now be ready to work with any toolchain installed in
    your system. In the next step you'll find instructions for installing


### PR DESCRIPTION
After Andy Gross submitted a package for the Device Tree Compiler
(dtc), and it has now become available on the MSYS2 package
repository, it's no longer needed for the user to manually compile
the DTC.

Signed-off-by: Carles Cufi <carles.cufi@nordicsemi.no>