### PR TITLE
spi context: Add function for getting single transfer buffers length.

### DIFF
--- a/drivers/spi/spi_context.h
+++ b/drivers/spi/spi_context.h
@@ -245,6 +245,19 @@ bool spi_context_rx_on(struct spi_context *ctx)
 	return !!(ctx->rx_buf || ctx->rx_len);
 }
 
+static inline size_t spi_context_longest_current_buf(struct spi_context *ctx)
+{
+	if (!ctx->tx_len) {
+		return ctx->rx_len;
+	} else if (!ctx->rx_len) {
+		return ctx->tx_len;
+	} else if (ctx->tx_len < ctx->rx_len) {
+		return ctx->tx_len;
+	}
+
+	return ctx->rx_len;
+}
+
 #ifdef __cplusplus
 }
 #endif


### PR DESCRIPTION
Added function helps setting the longest possible rx and tx buffers for
single SPI transfer. Each of these buffers is a continuous memory
region. It is useful for example when peripheral supports easyDMA.

Signed-off-by: Michał Kruszewski <michal.kruszewski@nordicsemi.no>