### PR TITLE
net: shell: Remove net_shell_init() as it is not needed

### DIFF
--- a/subsys/net/ip/net_core.c
+++ b/subsys/net/ip/net_core.c
@@ -382,8 +382,6 @@ static int net_init(struct device *unused)
 
 	NET_DBG("Priority %d", CONFIG_NET_INIT_PRIO);
 
-	net_shell_init();
-
 	net_pkt_init();
 
 	net_context_init();

--- a/subsys/net/ip/net_shell.c
+++ b/subsys/net/ip/net_shell.c
@@ -1812,8 +1812,4 @@ static struct shell_cmd net_commands[] = {
 	{ NULL, NULL, NULL }
 };
 
-void net_shell_init(void)
-{
-}
-
 SHELL_REGISTER(NET_SHELL_MODULE, net_commands);

--- a/subsys/net/ip/net_shell.h
+++ b/subsys/net/ip/net_shell.h
@@ -13,12 +13,6 @@
 #ifndef __NET_SHELL_H
 #define __NET_SHELL_H
 
-#if defined(CONFIG_NET_SHELL)
-void net_shell_init(void);
-#else
-#define net_shell_init(...)
-#endif /* CONFIG_NET_SHELL */
-
 int net_shell_cmd_allocs(int argc, char *argv[]);
 int net_shell_cmd_conn(int argc, char *argv[]);
 int net_shell_cmd_dns(int argc, char *argv[]);


### PR DESCRIPTION
The net_shell_init() is empty function and there is no use
for it so removing it.

Signed-off-by: Jukka Rissanen <jukka.rissanen@linux.intel.com>