### PR TITLE
net: sockets: Add docs for BSD Sockets compatible API.

### DIFF
--- a/doc/api/networking.rst
+++ b/doc/api/networking.rst
@@ -76,6 +76,13 @@ Application network context
    :project: Zephyr
    :content-only:
 
+BSD Sockets compatible API
+**************************
+
+.. doxygengroup:: bsd_sockets
+   :project: Zephyr
+   :content-only:
+
 Network offloading support
 **************************
 

--- a/doc/subsystems/networking/bsd-sockets.rst
+++ b/doc/subsystems/networking/bsd-sockets.rst
@@ -1,0 +1,64 @@
+.. _bsd_sockets_api:
+
+BSD Sockets compatible API
+##########################
+
+Zephyr offers an implementation of a subset of the BSD Sockets API (a part
+of the POSIX standard). This API allows to reuse existing programming experience
+and port existing simple networking applications to Zephyr.
+
+Here are the key requirements and concepts which governed BSD Sockets
+compatible API implementation for Zephyr:
+
+* Should have minimal overhead, similar to the requirement for other
+  Zephyr subsystems.
+* Should be implemented on top of
+  :ref:`native networking API <networking_api_usage>` to keep modular
+  design.
+* Should be namespaced by default, to avoid name conflicts with well-known
+  names like ``close()``, which may be part of libc or other POSIX
+  compatibility libraries. If enabled, should also expose native POSIX
+  names.
+
+BSD Sockets compatible API is enabled using :option:`CONFIG_NET_SOCKETS`
+config option and implements the following operations: ``socket()``,
+``close()``, ``recv()``, ``send()``, ``connect()``, ``bind()``,
+``listen()``, ``fcntl()`` (to set non-blocking mode), ``poll()``.
+
+Based on the namespacing requirements above, these operations are by
+default exposed as functions with ``zsock_`` prefix, e.g.
+:c:func:`zsock_socket()` and :c:func:`zsock_close()`. If the config option
+:option:`CONFIG_NET_SOCKETS_POSIX_NAMES` is defined, all the functions
+will be also exposed as aliases without the prefix. This includes the
+functions like ``close()`` and ``fcntl()`` (which may conflict with
+functions in libc or other libraries, for example, with the filesystem
+libraries).
+
+The native BSD Sockets API uses file descriptors to represent sockets. File descriptors
+are small integers, consecutively assigned from zero. Internally, there is usually a table
+mapping file descriptors to internal object pointers. For memory efficiency reasons, the
+Zephyr BSD Sockets compatible API is devoid of such a table. Instead, ``net_context``
+pointers, cast to an int, are used to represent sockets. Thus, socket identifiers aren't
+really small integers, so the ``select()`` operation is not available, as it depends on the
+"small int" property of file descriptors. Instead of using ``select()`` then, use the ``poll()``
+operation, which is generally more efficient.
+
+The BSD Sockets API (and the POSIX API in general) also treat negative file
+descriptors values in a special way (such values usually mean an
+error). As the Zephyr API uses a pointer value cast to an int for file descriptors, it means
+that the pointer should not have the highest bit set, in other words,
+pointers should not refer to the second (highest) part of the address space.
+For many CPU architectures and SoCs Zephyr supports, user RAM is
+located in the lower half, so the above condition is satisfied. If
+you face an issue with some SoC because of this, please report it to the Zephyr bug
+tracker or mailing list. The decision to use pointers to represent
+sockets might be reworked in the future.
+
+The final entailment of the design requirements above is that the Zephyr
+API aggressively employs the short-read/short-write property of the POSIX API
+whenever possible (to minimize complexity and overheads). POSIX allows
+for calls like ``recv()`` and ``send()`` to actually process (receive
+or send) less data than requested by the user (on STREAM type sockets).
+For example, a call ``recv(sock, 1000, 0)`` may return 100,
+meaning that only 100 bytes were read (short read), and the application
+needs to retry call(s) to read the remaining 900 bytes.

--- a/doc/subsystems/networking/networking.rst
+++ b/doc/subsystems/networking/networking.rst
@@ -13,6 +13,7 @@ operation of the stacks and how they were implemented.
    overview.rst
    ip-stack-architecture.rst
    networking-api-usage.rst
+   bsd-sockets.rst
    l2-and-drivers.rst
    network-management-api.rst
    net-app-api.rst

--- a/doc/subsystems/networking/overview.rst
+++ b/doc/subsystems/networking/overview.rst
@@ -47,6 +47,10 @@ can be disabled if not needed.
   and client roles can be used the the application. The amount of TCP sockets
   that are available to applications can be configured at build time.
 
+* **BSD Sockets API** Experimental support for a subset of a BSD Sockets
+  compatible API is implemented. Both blocking and non-blocking DGRAM (UDP)
+  amd STREAM (TCP) sockets are supported.
+
 * **HTTP** Hypertext Transfer Protocol (RFC 2116) is supported. A simple
   library is provided that applications can use. Sample applications are
   implemented for :ref:`http-client-sample` and :ref:`http-server-sample`.
@@ -89,16 +93,15 @@ can be disabled if not needed.
   is even possible to have zero-copy data path from application to device
   driver.
 
-Additionally these network technologies are supported in Zephyr OS v1.7
-or later:
+Additionally these network technologies (link layers) are supported in
+Zephyr OS v1.7 and later:
 
 * IEEE 802.15.4
 * Bluetooth
 * Ethernet
-
-  * SLIP (IP over serial line) is used for testing with QEMU. It provides
-    ethernet interface to host system (like Linux) and test applications
-    can be run in Linux host and send network data to Zephyr OS device.
+* SLIP (IP over serial line). Used for testing with QEMU. It provides
+  ethernet interface to host system (like Linux) and test applications
+  can be run in Linux host and send network data to Zephyr OS device.
 
 Source Tree Layout
 ******************
@@ -107,6 +110,10 @@ The IP stack source code tree is organized as follows:
 
 ``subsys/net/ip/``
   This is where the IP stack code is located.
+
+``subsys/net/lib/``
+  Application-level protocols (DNS, MQTT, etc.) and additional stack
+  components (BSD Sockets, etc.).
 
 ``include/net/``
   Public API header files. These are the header files applications need

--- a/include/net/socket.h
+++ b/include/net/socket.h
@@ -1,3 +1,10 @@
+/**
+ * @file
+ * @brief BSD Sockets compatible API definitions
+ *
+ * An API for applications to use BSD Sockets like API.
+ */
+
 /*
  * Copyright (c) 2017 Linaro Limited
  *
@@ -6,6 +13,12 @@
 
 #ifndef __NET_SOCKET_H
 #define __NET_SOCKET_H
+
+/**
+ * @brief BSD Sockets compatible API
+ * @defgroup bsd_sockets BSD Sockets compatible API
+ * @{
+ */
 
 #include <sys/types.h>
 #include <zephyr/types.h>
@@ -59,5 +72,9 @@ int zsock_poll(struct zsock_pollfd *fds, int nfds, int timeout);
 #ifdef __cplusplus
 }
 #endif
+
+/**
+ * @}
+ */
 
 #endif /* __NET_SOCKET_H */


### PR DESCRIPTION
Includes updates to Zephyr networking API feature list (also minor
tweaks to it not dorectly related to sockets), overview of BSD
Sockets compatible API, and basic API reference section.

Signed-off-by: Paul Sokolovsky <paul.sokolovsky@linaro.org>