### PR TITLE
build: Fix distclean for gen_idt

### DIFF
--- a/scripts/Makefile
+++ b/scripts/Makefile
@@ -19,4 +19,4 @@ build_docproc: $(obj)/docproc
 	@:
 
 # Let clean descend into subdirs
-subdir-	+= basic kconfig gen_idt
+subdir-	+= basic kconfig


### PR DESCRIPTION
This patch removes the gen_idt subdirectory from the clean target as
this directory is no longer in use due to recent changes to the way the
gen_idt is generated.

Signed-off-by: Andy Gross <andy.gross@linaro.org>