### PR TITLE
doc: fix uses of back quotes in documentation

### DIFF
--- a/boards/arm/96b_nitrogen/doc/96b_nitrogen.rst
+++ b/boards/arm/96b_nitrogen/doc/96b_nitrogen.rst
@@ -279,7 +279,7 @@ application to flash.
    $ cd samples/hello_world/
    $ make BOARD=96b_nitrogen
 
-You can either flash the board by using the `make flash` target:
+You can either flash the board by using the ``make flash`` target:
 
 .. code-block:: console
 

--- a/boards/arm/cc2650_sensortag/doc/cc2650_sensortag.rst
+++ b/boards/arm/cc2650_sensortag/doc/cc2650_sensortag.rst
@@ -190,8 +190,8 @@ SensorTag board would be:
   source [find target/cc26xx.cfg]
   adapter_khz 5000
 
-Copy this in a file named `ti-sensortag.cfg`, located in the :file:`scripts/board`
-subdirectory of your local OpenOCD installation path.
+Copy this in a file named ``ti-sensortag.cfg``, located in the
+:file:`scripts/board` subdirectory of your local OpenOCD installation path.
 When you wish to launch the OpenOCD server, just type:
 
 .. code-block:: console

--- a/boards/arm/nucleo_f334r8/doc/nucleof334r8.rst
+++ b/boards/arm/nucleo_f334r8/doc/nucleof334r8.rst
@@ -128,7 +128,7 @@ This interface is supported by the openocd version included in Zephyr SDK.
 Flashing an application to Nucleo F334R8
 ----------------------------------------
 
-The sample application `blinky` is being used in this tutorial:
+The sample application :ref:`blinky-sample` is being used in this tutorial:
 
 .. code-block:: console
 

--- a/boards/arm/sam_e70_xplained/doc/sam_e70_xplained.rst
+++ b/boards/arm/sam_e70_xplained/doc/sam_e70_xplained.rst
@@ -143,9 +143,9 @@ Flashing
 
    You can flash the image using an external debug adapter such as J-Link or
    ULINK, connected to the 20-pin JTAG header. Supply the name of the debug
-   adapter (e.g., `jlink`) to the make command via an OPENOCD_INTERFACE
+   adapter (e.g., ``jlink``) to the make command via an OPENOCD_INTERFACE
    variable. OpenOCD will look for the appropriate interface configuration in an
-   `interface/$(OPENOCD_INTERFACE).cfg` file on its internal search path.
+   ``interface/$(OPENOCD_INTERFACE).cfg`` file on its internal search path.
 
    .. code-block:: console
 

--- a/boards/arm/stm3210c_eval/doc/stm3210c_eval.rst
+++ b/boards/arm/stm3210c_eval/doc/stm3210c_eval.rst
@@ -82,8 +82,8 @@ The Zephyr stm3210c_eval board configuration supports the following hardware fea
 
 Other hardware features are not yet supported in this Zephyr port.
 
-The default configuration can be found in the defconfig file:
-``boards/arm/stm3210c_eval/stm3210c_eval_defconfig``
+The default configuration can be found in the defconfig file
+:file:`boards/arm/stm3210c_eval/stm3210c_eval_defconfig`.
 
 Connections and IOs
 ===================
@@ -122,7 +122,7 @@ This interface is supported by the openocd version included in Zephyr SDK.
 Flashing an application to STM3210C-EVAL
 ----------------------------------------
 
-The sample application `blinky` is being used in this tutorial:
+The sample application :ref:`blinky-sample` is being used in this tutorial:
 
 .. code-block:: console
 

--- a/boards/arm/stm32373c_eval/doc/stm32373c_eval.rst
+++ b/boards/arm/stm32373c_eval/doc/stm32373c_eval.rst
@@ -86,8 +86,8 @@ The Zephyr stm32373c_eval board configuration supports the following hardware fe
 
 Other hardware features are not yet supported in this Zephyr port.
 
-The default configuration can be found in the defconfig file:
-``boards/arm/stm32373c_eval/stm32373c_eval_defconfig``
+The default configuration can be found in the defconfig file
+:file:`boards/arm/stm32373c_eval/stm32373c_eval_defconfig`
 
 Connections and IOs
 ===================
@@ -126,7 +126,7 @@ This interface is supported by the openocd version included in Zephyr SDK.
 Flashing an application to STM32373C-EVAL
 -----------------------------------------
 
-The sample application `blinky` is being used in this tutorial:
+The sample application :ref:`blinky-sample` is being used in this tutorial:
 
 .. code-block:: console
 

--- a/boards/xtensa/xt-sim/doc/xt-sim.rst
+++ b/boards/xtensa/xt-sim/doc/xt-sim.rst
@@ -54,7 +54,7 @@ A Linux host system is required for Xtensa development work.
 We recommend using a __``Debian 9.x (Stretch)``__ or recent __``Ubuntu``__
 releases (with multilib support).
 
-Only `Xtensa tools` version ``RF-2016.4-linux`` or later are officially
+Only Xtensa tools version ``RF-2016.4-linux`` or later are officially
 supported. Other versions may work but are not supported by Cadence Systems Inc.
 
 In order to set up the Zephyr OS build system, a Linux 32-bit GCC compiler must

--- a/doc/contribute/security.rst
+++ b/doc/contribute/security.rst
@@ -34,7 +34,7 @@ from other open source efforts.
 
 We begin with an overview of secure design as it relates to
 Zephyr.  This is followed by
-a section on `Secure development knowledge`, which
+a section on `Secure development knowledge`_, which
 gives basic requirements that a developer working on the project will
 need to have.  This section gives references to other security
 documents, and full details of how to write secure software are beyond

--- a/doc/drivers/drivers.rst
+++ b/doc/drivers/drivers.rst
@@ -92,16 +92,16 @@ split into read-only and runtime-mutable parts. At a high level we have:
         void *driver_data;
   };
 
-The `config` member is for read-only configuration data set at build time. For
+The ``config`` member is for read-only configuration data set at build time. For
 example, base memory mapped IO addresses, IRQ line numbers, or other fixed
-physical characteristics of the device. This is the `config_info` structure
-passed to the `DEVICE_*INIT()` macros.
+physical characteristics of the device. This is the ``config_info`` structure
+passed to the ``DEVICE_*INIT()`` macros.
 
-The `driver_data` struct is kept in RAM, and is used by the driver for
+The ``driver_data`` struct is kept in RAM, and is used by the driver for
 per-instance runtime housekeeping. For example, it may contain reference counts,
 semaphores, scratch buffers, etc.
 
-The `driver_api` struct maps generic subsystem APIs to the device-specific
+The ``driver_api`` struct maps generic subsystem APIs to the device-specific
 implementations in the driver. It is typically read-only and populated at
 build time. The next section describes this in more detail.
 
@@ -141,7 +141,7 @@ A subsystem API definition typically looks like this:
         api->do_that(device, foo, bar);
   }
 
-In general, it's best to use `__ASSERT()` macros instead of
+In general, it's best to use ``__ASSERT()`` macros instead of
 propagating return values unless the failure is expected to occur during
 the normal course of operation (such as a storage device full). Bad
 parameters, programming errors, consistency checks, pathological/unrecoverable
@@ -172,15 +172,15 @@ of these APIs, and populate an instance of subsystem_api structure:
         .do_that = my_driver_do_that
   };
 
-The driver would then pass `my_driver_api_funcs` as the `api` argument to
-`DEVICE_AND_API_INIT()`, or manually assign it to `device->driver_api` in the
-driver init function.
+The driver would then pass ``my_driver_api_funcs`` as the ``api`` argument to
+``DEVICE_AND_API_INIT()``, or manually assign it to ``device->driver_api``
+in the driver init function.
 
 .. note::
 
-        Since pointers to the API functions are referenced in the driver_api`
+        Since pointers to the API functions are referenced in the ``driver_api``
         struct, they will always be included in the binary even if unused;
-        `gc-sections` linker option will always see at least one reference to
+        ``gc-sections`` linker option will always see at least one reference to
         them. Providing for link-time size optimizations with driver APIs in
         most cases requires that the optional feature be controlled by a
         Kconfig option.
@@ -190,15 +190,15 @@ Single Driver, Multiple Instances
 
 Some drivers may be instantiated multiple times in a given system. For example
 there can be multiple GPIO banks, or multiple UARTS. Each instance of the driver
-will have a different `config_info` struct and `driver_data` struct.
+will have a different ``config_info`` struct and ``driver_data`` struct.
 
 Configuring interrupts for multiple drivers instances is a special case. If each
 instance needs to configure a different interrupt line, this can be accomplished
 through the use of per-instance configuration functions, since the parameters
-to `IRQ_CONNECT()` need to be resolvable at build time.
+to ``IRQ_CONNECT()`` need to be resolvable at build time.
 
-For example, let's say we need to configure two instances of `my_driver`, each
-with a different interrupt line. In `drivers/subsystem/subsystem_my_driver.h`:
+For example, let's say we need to configure two instances of ``my_driver``, each
+with a different interrupt line. In ``drivers/subsystem/subsystem_my_driver.h``:
 
 .. code-block:: C
 
@@ -258,7 +258,7 @@ Then when the particular instance is declared:
 
   #endif /* CONFIG_MY_DRIVER_0 */
 
-Note the use of `DEVICE_DECLARE()` to avoid a circular dependency on providing
+Note the use of ``DEVICE_DECLARE()`` to avoid a circular dependency on providing
 the IRQ handler argument and the definition of the device itself.
 
 Initialization Levels
@@ -269,7 +269,7 @@ require the use of kernel services. The DEVICE_INIT() APIs allow the user to
 specify at what time during the boot sequence the init function will be
 executed. Any driver will specify one of five initialization levels:
 
-`PRE_KERNEL_1`
+``PRE_KERNEL_1``
         Used for devices that have no dependencies, such as those that rely
         solely on hardware present in the processor/SOC. These devices cannot
         use any kernel services during configuration, since the services are
@@ -277,17 +277,17 @@ executed. Any driver will specify one of five initialization levels:
         so it's OK to set up interrupts. Init functions at this level run on the
         interrupt stack.
 
-`PRE_KERNEL_2`
+``PRE_KERNEL_2``
         Used for devices that rely on the initialization of devices initialized
         as part of the PRIMARY level. These devices cannot use any kernel
         services during configuration, since the kernel services are not yet
         available. Init functions at this level run on the interrupt stack.
 
-`POST_KERNEL`
+``POST_KERNEL``
         Used for devices that require kernel services during configuration.
         Init functions at this level run in context of the kernel main task.
 
-`APPLICATION`
+``APPLICATION``
         Used for application components (i.e. non-kernel components) that need
         automatic configuration. These devices can use all services provided by
         the kernel during configuration. Init functions at this level run on
@@ -298,21 +298,22 @@ other devices in the same initialization level. The priority level is specified
 as an integer value in the range 0 to 99; lower values indicate earlier
 initialization.  The priority level must be a decimal integer literal without
 leading zeroes or sign (e.g. 32), or an equivalent symbolic name (e.g.
-`\#define MY_INIT_PRIO 32`); symbolic expressions are *not* permitted (e.g.
-`CONFIG_KERNEL_INIT_PRIORITY_DEFAULT + 5`).
+``\#define MY_INIT_PRIO 32``); symbolic expressions are *not* permitted (e.g.
+``CONFIG_KERNEL_INIT_PRIORITY_DEFAULT + 5``).
 
 
 System Drivers
 **************
 
-In some cases you may just need to run a function at boot. Special `SYS_INIT`
-macros exist that map to `DEVICE_INIT()` or `DEVICE_INIT_PM()` calls.
-For `SYS_INIT()` there are no config or runtime data structures and there isn't a way
+In some cases you may just need to run a function at boot. Special ``SYS_INIT``
+macros exist that map to ``DEVICE_INIT()`` or ``DEVICE_INIT_PM()`` calls.
+For ``SYS_INIT()`` there are no config or runtime data structures and there
+isn't a way
 to later get a device pointer by name. The same policies for initialization
 level and priority apply.
 
-For `SYS_INIT_PM()` you can obtain pointers by name, see :ref:`power management
-<power_management>` section.
+For ``SYS_INIT_PM()`` you can obtain pointers by name, see
+:ref:`power management <power_management>` section.
 
 :c:func:`SYS_INIT()`
 

--- a/doc/getting_started/installation_linux.rst
+++ b/doc/getting_started/installation_linux.rst
@@ -121,7 +121,7 @@ Follow these steps to install the SDK on your Linux host system.
       $ chmod +x zephyr-sdk-<version>-setup.run
       $ ./zephyr-sdk-<version>-setup.run
 
-   There is no need for `sudo` if the SDK is installed in the current
+   There is no need to use ``sudo`` if the SDK is installed in the current
    user's home directory.
 
 #. Follow the installation instructions on the screen. The

--- a/doc/getting_started/installation_win.rst
+++ b/doc/getting_started/installation_win.rst
@@ -95,7 +95,7 @@ environment for Windows. Follow the steps below to set it up:
    * For ARM, install GNU ARM Embedded from the ARM developer website:
      `GNU ARM Embedded`_ (install to :file:`c:\\gccarmemb`).
 
-#. From within the `MSYS2 MSYS Shell`, clone a copy of the Zephyr source into
+#. From within the MSYS2 MSYS Shell, clone a copy of the Zephyr source into
    your home directory using Git:
 
    .. code-block:: console

--- a/doc/release-notes-1.5.rst
+++ b/doc/release-notes-1.5.rst
@@ -206,7 +206,7 @@ Bug
 * :jira:`ZEP-401` - PWM driver turns off pin if off time is 0 in set_values
 * :jira:`ZEP-423` - Quark D2000 CRB documentation should include instructions to flash bootloader
 * :jira:`ZEP-435` - Ethernet/IPv4/TCP: ip_buf_appdatalen returns wrong values
-* :jira:`ZEP-456` - doc: `IDT security` section disappeared
+* :jira:`ZEP-456` - doc: ``IDT security`` section dissapeared
 * :jira:`ZEP-457` - doc: contribute/doxygen/typedefs.rst: examples files are broken
 * :jira:`ZEP-459` - doc: kconfig reference entries in HTML are lacking a title
 * :jira:`ZEP-460` - doc: document parameters of DEVICE* macros

--- a/doc/subsystems/networking/ip-stack-architecture.rst
+++ b/doc/subsystems/networking/ip-stack-architecture.rst
@@ -81,7 +81,7 @@ connectivity APIs, following things will happen.
 4) The application will then receive the data, which is stored inside a chain
    of net_bufs. The application now owns the data. After it has finished working
    with it, the application should release the net_bufs data by calling
-   `net_pkt_unref()`.
+   :cpp:func:`net_pkt_unref()`.
 
 *Data sending (TX):*
 

--- a/doc/subsystems/networking/l2-and-drivers.rst
+++ b/doc/subsystems/networking/l2-and-drivers.rst
@@ -6,11 +6,11 @@ L2 Stack and Drivers
 The L2 stack is designed to hide the whole networking link-layer part
 and the related device drivers from the higher IP stack. This is made
 through a unique object known as the "network interface object":
-:c:type:`struct net_if` declared in `include/net/net_if.h`.
+:c:type:`struct net_if` declared in :file:`include/net/net_if.h`.
 
 The IP layer is unaware of implementation details beyond the net_if
 object and the generic API provided by the L2 layer in
-`include/net/net_l2.h` as :c:type:`struct net_l2`.
+:file:`include/net/net_l2.h` as :c:type:`struct net_l2`.
 
 Only the L2 layer can talk to the device driver, linked to the net_if
 object. The L2 layer dictates the API provided by the device driver,
@@ -61,7 +61,7 @@ There are, however, two differences:
 - the driver_api pointer must point to a valid :c:type:`struct
   net_if_api` pointer.
 
-- The network device driver must use NET_DEVICE_INIT_INSTANCE(). This
+- The network device driver must use ``NET_DEVICE_INIT_INSTANCE()``. This
   macro will call the DEVICE_AND_API_INIT() macro, and also
   instantiate a unique :c:type:`struct net_if` related to the created
   device driver instance.
@@ -82,7 +82,7 @@ as many data fragments as required. The buffer itself is a
 allocated through :c:func:`net_pkt_get_reserve_data(0)`. Of course
 the amount of required fragments depends on the size of the received
 packet and on the size of a fragment, which is given by
-`CONFIG_NET_PKT_DATA_SIZE`.
+:option:`CONFIG_NET_BUF_DATA_SIZE`.
 
 Note that it is not up to the device driver to decide on the
 link-layer space to be reserved in the buffer. Hence the 0 given as
@@ -97,10 +97,10 @@ On sending, it is up to the device driver to send the buffer all at
 once, with all the fragments.
 
 In case of a fully successful packet transmission only, the device
-driver must unreference the buffer via `net_pkt_unref()`.
+driver must unreference the buffer via :c:func:`net_pkt_unref()`.
 
 Each Ethernet device driver will need, in the end, to call
-`NET_DEVICE_INIT_INSTANCE()` like this:
+``NET_DEVICE_INIT_INSTANCE()`` like this:
 
 .. code-block:: c
 
@@ -121,7 +121,7 @@ here as well.  There are two specific differences however:
   ieee802154_radio_api`, which overloads :c:type:`struct
   net_if_api`. This is because 802.15.4 L2 needs more from the device
   driver than just send and recv functions.  This dedicated API is
-  declared in `include/net/ieee802154_radio.h`. Each and every IEEE
+  declared in :file:`include/net/ieee802154_radio.h`. Each and every IEEE
   802.15.4 device driver must provide a valid pointer on such
   relevantly filled-in API structure.
 
@@ -143,7 +143,7 @@ here as well.  There are two specific differences however:
   only when all the transmission were successful.
 
 Each IEEE 802.15.4 device driver, in the end, will need to call
-`NET_DEVICE_INIT_INSTANCE()` that way:
+``NET_DEVICE_INIT_INSTANCE()`` that way:
 
 .. code-block:: c
 

--- a/doc/subsystems/networking/network-management-api.rst
+++ b/doc/subsystems/networking/network-management-api.rst
@@ -15,7 +15,7 @@ by eliminating code at build time for management routines that are not
 used. Distinct and statically defined APIs for network management
 procedures are not used.  Instead, defined procedure handlers are
 registered by using a `NET_MGMT_REGISTER_REQUEST_HANDLER`
-macro. Procedure requests are done through a single `net_mgmt()` API
+macro. Procedure requests are done through a single :cpp:func:`net_mgmt()` API
 that invokes the registered handler for the corresponding request.
 
 The current implementation is experimental and may change and improve
@@ -25,13 +25,13 @@ Requesting a defined procedure
 ******************************
 
 All network management requests are of the form
-`net_mgmt(mgmt_request, ...)`. The `mgmt_request` parameter is a bit
-mask that tells which stack layer is targeted, if a `net_if` object is
+``net_mgmt(mgmt_request, ...)``. The ``mgmt_request`` parameter is a bit
+mask that tells which stack layer is targeted, if a ``net_if`` object is
 implied, and the specific management procedure being requested. The
 available procedure requests depend on what has been implemented in
 the stack.
 
-To avoid extra cost, all `net_mgmt()` calls are direct. Though this
+To avoid extra cost, all :cpp:func:`net_mgmt()` calls are direct. Though this
 may change in a future release, it will not affect the users of this
 function.
 
@@ -42,9 +42,10 @@ You can receive notifications on network events by registering a
 callback function and specifying an event mask used to match one or
 more events that are relevant.
 
-Two functions are available, `net_mgmt_add_event_callback()` for
-registering the callback function, and `net_mgmt_del_event_callback()`
-for unregistering. A helper function, `net_mgmt_init_event_cb()`, can
+Two functions are available, :cpp:func:`net_mgmt_add_event_callback()` for
+registering the callback function, and
+:cpp:func:`net_mgmt_del_event_callback()`
+for unregistering. A helper function, :cpp:func:`net_mgmt_init_event_cb()`, can
 be used to ease the initialization of the callback structure.
 
 When an event is raised that matches a registered event mask, the
@@ -53,7 +54,7 @@ code. This makes it possible for different events to be handled by the
 same callback function, if desired.
 
 See an example of registering callback functions and using the network
-management API in `test/net/mgmt/src/mgmt.c`.
+management API in :file:`test/net/mgmt/src/mgmt.c`.
 
 Defining a network management procedure
 ***************************************
@@ -65,9 +66,9 @@ associated mgmt_request code.
 Management request code are defined in relevant places depending on
 the targeted layer or eventually, if l2 is the layer, on the
 technology as well. For instance, all IP layer management request code
-will be found in the `include/net/net_mgmt.h` header file. But in case
+will be found in the :file:`include/net/net_mgmt.h` header file. But in case
 of an L2 technology, let's say Ethernet, these would be found in
-`include/net/ethernet.h`
+:file:`include/net/ethernet.h`
 
 You define your handler modeled with this signature:
 
@@ -92,9 +93,9 @@ This new management procedure could then be called by using:
 Signaling a network event
 *************************
 
-You can signal a specific network event using the `net_mgmt_notify()`
+You can signal a specific network event using the :cpp:func:`net_mgmt_notify()`
 function and provide the network event code. See
-`include/net/net_mgmt.h` for details. As for the management request
+:file:`include/net/net_mgmt.h` for details. As for the management request
 code, event code can be also found on specific L2 technology headers,
-for example `include/net/ieee802154.h` would be the right place if
+for example :file:`include/net/ieee802154.h` would be the right place if
 802.15.4 L2 is the technology one wants to listen to events.

--- a/doc/subsystems/shell.rst
+++ b/doc/subsystems/shell.rst
@@ -23,34 +23,34 @@ Specific module's commands
 A shell interface exposing subsystem features is a shell module, multiple
 modules can be available at the same time.
 
-`MODULE_NAME COMMAND`
+``MODULE_NAME COMMAND``
  One of the available modules is "KERNEL", for the Kernel module.  More
  information can be found in :c:macro:`SHELL_REGISTER`.
 
 Help commands
 =============
 
-`help`
+``help``
  Prints the list of available modules.
 
-`help MODULE_NAME`
+``help MODULE_NAME``
  Prints the names of the available commands for the module.
 
-`help MODULE_NAME COMMAND`
+``help MODULE_NAME COMMAND``
  Prints help for the module's command (the help should show function
  goal and required parameters).
 
 Select module commands
 ======================
 
-`select MODULE_NAME`
+``select MODULE_NAME``
  Use this command when using the shell only for one module. After entering this
  command, you will not need to enter module name in further commands. If
  the selected module has set a default shell prompt during its initialization,
  the prompt will be changed to that one. Otherwise, the prompt will be
  changed to the selected module's name to reflect the current module in use.
 
-`select`
+``select``
  Clears selected module. Restores prompt as well.
 
 Shell configuration

--- a/doc/subsystems/test/ztest.rst
+++ b/doc/subsystems/test/ztest.rst
@@ -13,11 +13,13 @@ integration testing, or for unit testing specific modules.
 Quick start - Integration testing
 *********************************
 
-A simple working base is located at `samples/testing/integration`. Just copy the
-files to `tests/` and edit them for your needs. The test will then be
-automatically built and run by the sanitycheck script. If you are testing the `bar`
-component of `foo`, you should copy the sample folder to tests/foo/bar. It can
-then be tested with `./scripts/sanitycheck -s tests/foo/bar/test`.
+A simple working base is located at :file:`samples/testing/integration`.  Just
+copy the files to ``tests/`` and edit them for your needs. The test will then
+be automatically built and run by the sanitycheck script. If you are testing
+the **bar** component of **foo**, you should copy the sample folder to
+``tests/foo/bar``. It can then be tested with::
+
+    ./scripts/sanitycheck -s tests/foo/bar/test
 
 The sample contains the following files:
 
@@ -74,7 +76,7 @@ and are used to decide whether a test failed or passed by verifying whether an
 interaction with an object occurred, and if required, to assert the order of
 that interaction.
 
-The `samples/testing/unit` folder contains an example for testing
+The :file:`samples/testing/unit` folder contains an example for testing
 the net-buf api of Zephyr.
 
 Makefile
@@ -111,11 +113,11 @@ Assertions
 These macros will instantly fail the test if the related assertion fails.
 When an assertion fails, it will print the current file, line and function,
 alongside a reason for the failure and an optional message. If the config
-option `CONFIG_ZTEST_ASSERT_VERBOSE=0`, the assertions will only print the
+option:`CONFIG_ZTEST_ASSERT_VERBOSE` is 0, the assertions will only print the
 file and line numbers, reducing the binary size of the test.
 
 Example output for a failed macro from
-`zassert_equal(buf->ref, 2, "Invalid refcount")`:
+``zassert_equal(buf->ref, 2, "Invalid refcount")``:
 
 .. code-block:: none
 
@@ -131,12 +133,13 @@ Mocking
 
 These functions allow abstracting callbacks and related functions and
 controlling them from specific tests. You can enable the mocking framework by
-setting `CONFIG_ZTEST_MOCKING=y` in the configuration file of the test.
-The amount of concurrent return values and expected parameters is
-limited by `ZTEST_PARAMETER_COUNT`.
+setting :option:`CONFIG_ZTEST_MOCKING` to "y" in the configuration file of the
+test.  The amount of concurrent return values and expected parameters is
+limited by :option:`CONFIG_ZTEST_PARAMETER_COUNT`.
 
-Here is an example for configuring the function `expect_two_parameters` to
-expect the values `a=2` and `b=3`, and telling `returns_int` to return `5`:
+Here is an example for configuring the function ``expect_two_parameters`` to
+expect the values ``a=2`` and ``b=3``, and telling ``returns_int`` to return
+``5``:
 
 .. literalinclude:: mocking.c
    :language: c

--- a/ext/debug/segger/systemview/README.rst
+++ b/ext/debug/segger/systemview/README.rst
@@ -7,7 +7,7 @@ This is a free-to-use tool that records and visualizes events such as thread
 scheduling and interrupts, and is helpful to find unintended interactions
 and resource conflicts on complex systems.  The tool is available for the
 major development platforms, and requires hardware support.  Please consult
-the `product web page <https://www.segger.com/systemview.html?p=1731>` for
+the `product web page <https://www.segger.com/systemview.html?p=1731>`_ for
 more information.
 
 Source code in this package has been obtained from the product web page

--- a/samples/subsys/debug/sysview/README.rst
+++ b/samples/subsys/debug/sysview/README.rst
@@ -23,7 +23,7 @@ Building and Running
 
 * Follow the instructions to install J-Link and SystemView software on your
   computer
-* Open J-Link Commander.  On Linux, its executable is named `JLinkExe`:
+* Open J-Link Commander.  On Linux, its executable is named ``JLinkExe``:
 
 .. code-block:: console
 
@@ -40,11 +40,11 @@ Building and Running
   Type "connect" to establish a target connection, '?' for help
   J-Link>
 
-* Issue the "connect" command.  If it's the only connected board, `Enter`
-  can be pressed at the `Device>` prompt.
-* Select the target interface.  Some devices only support the `SWD` type, so
-  select it by typing `S` followed by `Enter`.
-* At the `Speed>` prompt, select the interface polling frequency.  The
+* Issue the "connect" command.  If it's the only connected board, ``Enter``
+  can be pressed at the ``Device>`` prompt.
+* Select the target interface.  Some devices only support the ``SWD`` type,
+  so select it by typing ``S`` followed by ``Enter``.
+* At the ``Speed>`` prompt, select the interface polling frequency.  The
   default of 4000kHz is sufficient, but a higher frequency can be specified.
 * Once the connection has been successful, an output similar to this one
   should be produced:
@@ -73,8 +73,8 @@ Building and Running
   J-Link>
 
 * Now open SystemView.  Select the option *Start Recording* from the
-  *Target* menu (or press `F5`), choose USB, the target device (in this
-  case, `MK64FN1M0XXX12`), and confirm that the target interface and speed
+  *Target* menu (or press ``F5``), choose USB, the target device (in this
+  case, ``MK64FN1M0XXX12``), and confirm that the target interface and speed
   matches the ones selected in J-Link Commander.  The *RTT Control Block
   Detection* can be left on *Auto Detection*.
 * Once OK is clicked, information will be pulled from the device as usual:

--- a/samples/subsys/usb/cdc_acm/README.rst
+++ b/samples/subsys/usb/cdc_acm/README.rst
@@ -99,4 +99,4 @@ For this example, it would look like this:
    ATTRS{idVendor}=="8086" ATTRS{idProduct}=="f8a1", ENV{ID_MM_DEVICE_IGNORE}="1"
 
 You can use
-`/lib/udev/rules.d/77-mm-usb-device-blacklist.rules` as reference.
+``/lib/udev/rules.d/77-mm-usb-device-blacklist.rules`` as reference.

--- a/subsys/net/lib/sockets/Kconfig
+++ b/subsys/net/lib/sockets/Kconfig
@@ -18,7 +18,7 @@ config NET_SOCKETS_POSIX_NAMES
 	bool "Standard POSIX names for Sockets API"
 	default n
 	help
-	By default, Sockets API function are prefixed with `zsock_` to avoid
+	By default, Sockets API function are prefixed with ``zsock_`` to avoid
 	namespacing issues. If this option is enabled, they will be provided
 	with standard POSIX names like socket(), recv(), and close(), to help
 	with porting existing code. Note that close() may require a special


### PR DESCRIPTION
ReST defines interpreted text roles where text enclosed by single quotes
can be "intrepreted", for example :ref:`some name` becomes a link to
a label anywhere in the doc set named "some name", :c:func:`funcname()`
becomes a link to the API documentation for "funcname", and
:option:`CONFIG_NAME` becomes a link to, in our case, the documentation for
the generated Kconfig option.

This patch fixes uses of `some name` (without a role) by either adding an
explicit role, or changing to ``some name``, which indicates inline code
block formatting (most likely what was intended).

This is a precursor to changing the default behavior of interpreted text to
treat `some name` as :any:`some name` (as configured in doc/conf.py), which
would attempt to create a link to any available definition of "some name".

We may not change this default role behavior, but it becomes an option after
the fixes in this patch.  In any case, this patch fixes incorrect uses of
single-quoted text.

Jira: ZEP-2414

Signed-off-by: David B. Kinder <david.b.kinder@intel.com>