### PR TITLE
Arm: Handle time slicing before context swicth on exception.

### DIFF
--- a/arch/arm/core/exc_exit.S
+++ b/arch/arm/core/exc_exit.S
@@ -58,17 +58,6 @@ SECTION_SUBSEC_FUNC(TEXT, _HandlerModeExit, _IntExit)
 
 /* _IntExit falls through to _ExcExit (they are aliases of each other) */
 
-#ifdef CONFIG_TIMESLICING
-    push {lr}
-    bl _update_time_slice_before_swap
-#if defined(CONFIG_ARMV6_M)
-    pop {r0}
-    mov lr, r0
-#else
-    pop {lr}
-#endif /* CONFIG_ARMV6_M */
-#endif
-
 /**
  *
  * @brief Kernel housekeeping when exiting exception handler installed
@@ -97,6 +86,17 @@ SECTION_SUBSEC_FUNC(TEXT, _HandlerModeExit, _ExcExit)
     ldr r0, [r0, _kernel_offset_to_ready_q_cache]
     cmp r0, r1
     beq _EXIT_EXC
+
+#ifdef CONFIG_TIMESLICING
+    push {lr}
+    bl _update_time_slice_before_swap
+#if defined(CONFIG_ARMV6_M)
+    pop {r0}
+    mov lr, r0
+#else
+    pop {lr}
+#endif /* CONFIG_ARMV6_M */
+#endif /* CONFIG_TIMESLICING */
 
     /* context switch required, pend the PendSV exception */
     ldr r1, =_SCS_ICSR


### PR DESCRIPTION
Currently Thread time slice is getting reset at end of timer
interrupt. Due to which equal priority threads behind current thread
in ready_q are not getting chance to run and leading to starvation.

This patch handles time slice in _ExcExit section context switch is
required.

Jira: ZEP-2444

Signed-off-by: Youvedeep Singh <youvedeep.singh@intel.com>
Signed-off-by: Ramesh Thomas <ramesh.thomas@intel.com>