### PR TITLE
Bluetooth: hci_ecc: Fine-tune thread stack size

### DIFF
--- a/subsys/bluetooth/host/hci_ecc.c
+++ b/subsys/bluetooth/host/hci_ecc.c
@@ -35,7 +35,7 @@
 #endif
 
 static struct k_thread ecc_thread_data;
-static BT_STACK_NOINIT(ecc_thread_stack, 960);
+static BT_STACK_NOINIT(ecc_thread_stack, 1024);
 
 /* based on Core Specification 4.2 Vol 3. Part H 2.3.5.6.1 */
 static const u32_t debug_private_key[8] = {


### PR DESCRIPTION
The current 960 is at least too small under qemu_x86:

ecc stack (real size 1024):	unused 36	usage 988 / 1024 (96 %)

Signed-off-by: Johan Hedberg <johan.hedberg@intel.com>