### PR TITLE
Bluetooth: Mesh: Health: Fix Current Status encoding

### DIFF
--- a/subsys/bluetooth/host/mesh/health.c
+++ b/subsys/bluetooth/host/mesh/health.c
@@ -86,7 +86,7 @@ static size_t health_get_current(struct bt_mesh_model *mod,
 
 	bt_mesh_model_msg_init(msg, OP_HEALTH_CURRENT_STATUS);
 
-	test_id = net_buf_simple_add(msg, sizeof(test_id));
+	test_id = net_buf_simple_add(msg, 1);
 	company_ptr = net_buf_simple_add(msg, sizeof(company_id));
 
 	fault_count = net_buf_simple_tailroom(msg) - 4;


### PR DESCRIPTION
The Test ID was incorrectly being added as 4 bytes (size of a pointer)
instead of the intended 1 byte.

This fixes Coverity CID 173643.

Signed-off-by: Johan Hedberg <johan.hedberg@intel.com>