### PR TITLE
doc: add GitHub mention on doc home page

### DIFF
--- a/doc/index.rst
+++ b/doc/index.rst
@@ -22,6 +22,12 @@ Zephyr Project Documentation
 
    `Zephyr 1.5.0`_ | `Zephyr 1.6.0`_ | `Zephyr 1.7.0`_ | `Zephyr 1.8.0`_
 
+Source code for the Zephyr Project is maintained in the
+`Zephyr Project GitHub repository`_.
+
+.. _Zephyr Project GitHub repository:
+   https://github.com/zephyrproject-rtos/zephyr
+
 Sections
 ********
 


### PR DESCRIPTION
Request from Marketing and Linux Foundation to add a link to the Zephyr
GitHub repo on the documentation home page.

Signed-off-by: David B. Kinder <david.b.kinder@intel.com>