### PR TITLE
net: tcp: Allow application to manage TCP receive window 

### DIFF
--- a/include/net/net_context.h
+++ b/include/net/net_context.h
@@ -741,6 +741,29 @@ int net_context_recv(struct net_context *context,
 		     void *user_data);
 
 /**
+ * @brief Update TCP receive window for context.
+ *
+ * @details This function should be used by an application which
+ * doesn't fully process incoming data in its receive callback,
+ * but for example, queues it. In this case, receive callback
+ * should decrease the window (call this function with a negative
+ * value) by the size of queued data, and function(s) which dequeue
+ * data - with positive value corresponding to the dequeued size.
+ * For example, if receive callback gets a packet with the data
+ * size of 256 and queues it, it should call this function with
+ * delta of -256. If a function extracts 10 bytes of the queued
+ * data, it should call it with delta of 10.
+ *
+ * @param context The TCP network context to use.
+ * @param delta Size, in bytes, by which to increase TCP receive
+ * window (negative value to decrease).
+ *
+ * @return 0 if ok, < 0 if error
+ */
+int net_context_update_recv_wnd(struct net_context *context,
+				s32_t delta);
+
+/**
  * @typedef net_context_cb_t
  * @brief Callback used while iterating over network contexts
  *

--- a/subsys/net/ip/tcp.h
+++ b/subsys/net/ip/tcp.h
@@ -154,6 +154,8 @@ struct net_tcp {
 	 * Semaphore to signal TCP connection completion
 	 */
 	struct k_sem connect_wait;
+
+	u16_t recv_wnd;
 };
 
 static inline bool net_tcp_is_used(struct net_tcp *tcp)
@@ -341,6 +343,15 @@ void net_tcp_ack_received(struct net_context *ctx, u32_t ack);
  * @return Maximum Segment Size
  */
 u16_t net_tcp_get_recv_mss(const struct net_tcp *tcp);
+
+/**
+ * @brief Returns the receive window for a given TCP context
+ *
+ * @param tcp TCP context
+ *
+ * @return Current TCP receive window
+ */
+u32_t net_tcp_get_recv_wnd(const struct net_tcp *tcp);
 
 /**
  * @brief Obtains the state for a TCP context

--- a/subsys/net/lib/sockets/sockets.c
+++ b/subsys/net/lib/sockets/sockets.c
@@ -141,6 +141,10 @@ static void zsock_received_cb(struct net_context *ctx, struct net_pkt *pkt,
 	header_len = net_pkt_appdata(pkt) - pkt->frags->data;
 	net_buf_pull(pkt->frags, header_len);
 
+	if (net_context_get_type(ctx) == SOCK_STREAM) {
+		net_context_update_recv_wnd(ctx, -net_pkt_appdatalen(pkt));
+	}
+
 	k_fifo_put(&ctx->recv_q, pkt);
 }
 
@@ -310,6 +314,8 @@ static inline ssize_t zsock_recv_stream(struct net_context *ctx, void *buf, size
 			}
 		}
 	} while (recv_len == 0);
+
+	net_context_update_recv_wnd(ctx, recv_len);
 
 	return recv_len;
 }


### PR DESCRIPTION
This is rework of https://github.com/zephyrproject-rtos/zephyr/pull/81. As we didn't agree how TCP recv window management should work on the level of native Zephyr networking API, the new patch makes the management completely optional. By default, all apps continue to work as they did before (where there's static window size). However, apps which queue up data, can both shrink and widen it as needed. This feature is required and used by BSD Sockets implementation to achieve reliable transfers of large amounts of data (megabytes).
