### PR TITLE
kconfig: serial: esp32: Make driver depend on SOC_ESP32

### DIFF
--- a/drivers/serial/Kconfig.esp32
+++ b/drivers/serial/Kconfig.esp32
@@ -2,6 +2,7 @@ menuconfig UART_ESP32
 	bool "ESP32 UART driver"
 	default n
 	select SERIAL_HAS_DRIVER
+	depends on SOC_ESP32
 	help
 	Enable the ESP32 UART using ROM routines.
 


### PR DESCRIPTION
The ESP32 UART driver can only be used on the ESP32 SoC AFAICT. But it
did not have a depend clause so it was polluting the options of other
platforms.

With this patch the ESP32 driver will no longer be exposed to users of
non-ESP32 devices.

Tested with sanitycheck.

Signed-off-by: Sebastian Bøe <sebastian.boe@nordicsemi.no>