### PR TITLE
drivers: i2c_ll_stm32_v1: Fix TX and RX operations

### DIFF
--- a/drivers/i2c/i2c_ll_stm32_v1.c
+++ b/drivers/i2c/i2c_ll_stm32_v1.c
@@ -160,13 +160,12 @@ s32_t stm32_i2c_msg_write(struct device *dev, struct i2c_msg *msg,
 	LL_I2C_EnableIT_ERR(i2c);
 	LL_I2C_AcknowledgeNextData(i2c, LL_I2C_ACK);
 	LL_I2C_GenerateStartCondition(i2c);
-	LL_I2C_EnableIT_TX(i2c);
-	LL_I2C_EnableIT_ERR(i2c);
+	LL_I2C_EnableIT_BUF(i2c);
+
 	k_sem_take(&data->device_sync_sem, K_FOREVER);
 
+	LL_I2C_DisableIT_BUF(i2c);
 	if (data->current.is_nack || data->current.is_err) {
-		LL_I2C_DisableIT_TX(i2c);
-		LL_I2C_DisableIT_ERR(i2c);
 
 		if (data->current.is_nack)
 			SYS_LOG_DBG("%s: NACK", __func__);
@@ -178,11 +177,8 @@ s32_t stm32_i2c_msg_write(struct device *dev, struct i2c_msg *msg,
 		data->current.is_nack = 0;
 		data->current.is_err = 0;
 		ret = -EIO;
-		goto error;
 	}
-	LL_I2C_DisableIT_TX(i2c);
-	LL_I2C_DisableIT_ERR(i2c);
-error:
+
 	LL_I2C_DisableIT_EVT(i2c);
 	LL_I2C_DisableIT_ERR(i2c);
 
@@ -209,18 +205,17 @@ s32_t stm32_i2c_msg_read(struct device *dev, struct i2c_msg *msg,
 	LL_I2C_EnableIT_ERR(i2c);
 	LL_I2C_AcknowledgeNextData(i2c, LL_I2C_ACK);
 	LL_I2C_GenerateStartCondition(i2c);
-	LL_I2C_EnableIT_RX(i2c);
+	LL_I2C_EnableIT_BUF(i2c);
+
 	k_sem_take(&data->device_sync_sem, K_FOREVER);
 
+	LL_I2C_DisableIT_BUF(i2c);
 	if (data->current.is_err) {
-		LL_I2C_DisableIT_RX(i2c);
 		SYS_LOG_DBG("%s: ERR %d", __func__, data->current.is_err);
 		data->current.is_err = 0;
 		ret = -EIO;
-		goto error;
 	}
-	LL_I2C_DisableIT_RX(i2c);
-error:
+
 	LL_I2C_DisableIT_EVT(i2c);
 	LL_I2C_DisableIT_ERR(i2c);
 


### PR DESCRIPTION
Fixes single byte reception. In case a single byte has to be received, the Acknowledge
disable is made before ADDR flag is cleared.

Disables/enables only Buffer interrupts. Use the LL_I2C_EnableIT_BUF and  LL_I2C_DisableIT_BUF functions to enable and disable the I2C Buffer interrupts (TxE, RxNE). The LL_I2C_*IT_TX and LL_I2C_*IT_RX functions enable and disable both I2C Buffer and Event interrupts.

Fixes TX if flag I2C_MSG_RESTART is set. In interrupt mode, the drivers entered a forever loop if the
I2C_MSG_RESTART flag was set.

Fixes RX operation for all the receptions (1-byte, 2-bytes, N-bytes when N > 2).

Both interrupt and polling modes were tested on 96b_carbon. 