### PR TITLE
Kconfig: Move BLUETOOTH_HCI_RESERVE into subsys/bluetooth/host

### DIFF
--- a/drivers/bluetooth/hci/Kconfig
+++ b/drivers/bluetooth/hci/Kconfig
@@ -79,17 +79,6 @@ config BLUETOOTH_SPI_DEV_NAME
 	  this device is used to reply back with HCI frames that are sent over
 	  the air.
 
-# Headroom that the driver needs for sending and receiving buffers.
-# Add a new 'default' entry for each new driver.
-config BLUETOOTH_HCI_RESERVE
-	int
-	# Even if no driver is selected the following default is still
-	# needed e.g. for unit tests.
-	default 0
-	default 0 if BLUETOOTH_H4
-	default 1 if BLUETOOTH_H5
-	default 1 if BLUETOOTH_SPI
-
 if BLUETOOTH_SPI
 
 config BLUETOOTH_SPI_BLUENRG

--- a/subsys/bluetooth/host/Kconfig
+++ b/subsys/bluetooth/host/Kconfig
@@ -62,6 +62,17 @@ config BLUETOOTH_HCI_TX_PRIO
 	int
 	default 7
 
+# Headroom that the driver needs for sending and receiving buffers.
+# Add a new 'default' entry for each new driver.
+config BLUETOOTH_HCI_RESERVE
+	int
+	# Even if no driver is selected the following default is still
+	# needed e.g. for unit tests.
+	default 0
+	default 0 if BLUETOOTH_H4
+	default 1 if BLUETOOTH_H5
+	default 1 if BLUETOOTH_SPI
+
 config BLUETOOTH_RECV_IS_RX_THREAD
 	# Virtual option set by the HCI driver to indicate that there's
 	# no need for the host to have its own RX thread, rather the


### PR DESCRIPTION
Currently, the bluetooth subsystem is dependent on several configs in
 drivers/bluetooth, even thought the bluetooth subsystem can function
 just fine without a bluetooth driver. This dependency forces the user
 to have a Bluetooth driver menu entry even though it is not using a
 bluetooth driver.

This patch moves one of these configs, BLUETOOTH_HCI_RESERVE, from
drivers/bluetooth/hci/Kconfig to subsys/bluetooth/host/Kconfig such
that eventually we can omit the entire Bluetooth driver.

This re-organization does not change when the config can be enabled.

Signed-off-by: Sebastian Bøe <sebastian.boe@nordicsemi.no>