### PR TITLE
Bluetooth: Mesh: Fix duplicate const declarations

### DIFF
--- a/samples/bluetooth/mesh/src/main.c
+++ b/samples/bluetooth/mesh/src/main.c
@@ -55,7 +55,7 @@ static void gen_onoff_set_unack(struct bt_mesh_model *model,
 {
 }
 
-static const struct bt_mesh_model_op const gen_onoff_op[] = {
+static const struct bt_mesh_model_op gen_onoff_op[] = {
 	{ BT_MESH_MODEL_OP_2(0x82, 0x01), 0, gen_onoff_get },
 	{ BT_MESH_MODEL_OP_2(0x82, 0x02), 2, gen_onoff_set },
 	{ BT_MESH_MODEL_OP_2(0x82, 0x03), 2, gen_onoff_set_unack },
@@ -104,7 +104,7 @@ static void gen_move_set_unack(struct bt_mesh_model *model,
 {
 }
 
-static const struct bt_mesh_model_op const gen_level_op[] = {
+static const struct bt_mesh_model_op gen_level_op[] = {
 	{ BT_MESH_MODEL_OP_2(0x82, 0x05), 0, gen_level_get },
 	{ BT_MESH_MODEL_OP_2(0x82, 0x06), 3, gen_level_set },
 	{ BT_MESH_MODEL_OP_2(0x82, 0x07), 3, gen_level_set_unack },

--- a/samples/bluetooth/mesh_demo/src/main.c
+++ b/samples/bluetooth/mesh_demo/src/main.c
@@ -116,7 +116,7 @@ static void vnd_button_pressed(struct bt_mesh_model *model,
 	board_play("100G200 100G");
 }
 
-static struct bt_mesh_model_op const vnd_ops[] = {
+static const struct bt_mesh_model_op vnd_ops[] = {
 	{ OP_VENDOR_BUTTON, 0, vnd_button_pressed },
 	BT_MESH_MODEL_OP_END,
 };

--- a/subsys/bluetooth/host/mesh/cfg.c
+++ b/subsys/bluetooth/host/mesh/cfg.c
@@ -2841,7 +2841,7 @@ static void hearbeat_sub_set(struct bt_mesh_model *model,
 	hb_sub_send_status(model, ctx, STATUS_SUCCESS);
 }
 
-const struct bt_mesh_model_op const bt_mesh_cfg_op[] = {
+const struct bt_mesh_model_op bt_mesh_cfg_op[] = {
 	{ OP_DEV_COMP_DATA_GET,        1,   dev_comp_data_get },
 	{ OP_APP_KEY_ADD,              19,  app_key_add },
 	{ OP_APP_KEY_UPDATE,           19,  app_key_update },

--- a/subsys/bluetooth/host/mesh/health.c
+++ b/subsys/bluetooth/host/mesh/health.c
@@ -326,7 +326,7 @@ static void health_period_set(struct bt_mesh_model *model,
 	send_health_period_status(model, ctx);
 }
 
-const struct bt_mesh_model_op const bt_mesh_health_op[] = {
+const struct bt_mesh_model_op bt_mesh_health_op[] = {
 	{ OP_HEALTH_FAULT_GET,         2,   health_fault_get },
 	{ OP_HEALTH_FAULT_CLEAR,       2,   health_fault_clear },
 	{ OP_HEALTH_FAULT_CLEAR_UNREL, 2,   health_fault_clear_unrel },

--- a/tests/bluetooth/mesh/src/main.c
+++ b/tests/bluetooth/mesh/src/main.c
@@ -126,7 +126,7 @@ static struct bt_mesh_model_pub vnd_pub = {
 
 static struct bt_mesh_model_pub vnd_pub2;
 
-static struct bt_mesh_model_op const vnd_ops[] = {
+static const struct bt_mesh_model_op vnd_ops[] = {
 	BT_MESH_MODEL_OP_END,
 };
 


### PR DESCRIPTION
Remvoe duplicate const declarations which may cause compiler warnings.

Jira: ZEP-2442

Signed-off-by: Johan Hedberg <johan.hedberg@intel.com>