### PR TITLE
dts: arm: olimexino_stm32: Fix typo on USART3 node

### DIFF
--- a/dts/arm/olimexino_stm32.dts
+++ b/dts/arm/olimexino_stm32.dts
@@ -31,7 +31,7 @@
 	pinctrl-names = "default";
 };
 
-&usart2 {
+&usart3 {
 	current-speed = <115200>;
 	pinctrl-0 = <&usart3_pins_a>;
 	pinctrl-names = "default";


### PR DESCRIPTION
Fix typo on USART3 node

Signed-off-by: Yannis Damigos <giannis.damigos@gmail.com>