### PR TITLE
net: app: fix IPv6 init for late IP assigment

### DIFF
--- a/subsys/net/lib/app/init.c
+++ b/subsys/net/lib/app/init.c
@@ -195,7 +195,13 @@ static void setup_ipv6(struct net_if *iface, u32_t flags)
 	net_mgmt_init_event_callback(&mgmt6_cb, ipv6_event_handler, mask);
 	net_mgmt_add_event_callback(&mgmt6_cb);
 
-	if (mask && NET_EVENT_IPV6_ADDR_ADD == 0) {
+	/*
+	 * check for CMD_ADDR_ADD bit here, NET_EVENT_IPV6_ADDR_ADD is
+	 * a combination of _NET_EVENT_IPV6_BASE | NET_EVENT_IPV6_CMD_ADDR_ADD
+	 * so NET_EVENT_IPV6_ADDR_ADD will always return != 0 if any other
+	 * event is set (for instance NET_EVENT_IPV6_ROUTER_ADD)
+	 */
+	if ((mask & NET_EVENT_IPV6_CMD_ADDR_ADD) == 0) {
 		ifaddr = net_if_ipv6_addr_add(iface, &laddr,
 					      NET_ADDR_MANUAL, 0);
 		if (!ifaddr) {


### PR DESCRIPTION
- Fix typo'd "&&" when checking bit value
- Don't use NET_EVENT_IPV6_ADDR_ADD for checking mask value
  due to combination of bits: _NET_EVENT_IPV6_BASE |
  NET_EVENT_IPV6_CMD_ADDR_ADD
  Instead use NET_EVENT_IPV6_CMD_ADDR_ADD so the check works
  when NET_EVENT_IPV6_ROUTER_ADD is enabled.

Tested fix with echo_server on x86 qemu where it was previously
broken.

Signed-off-by: Michael Scott <michael.scott@linaro.org>