### PR TITLE
test: spi: Use k_thread_abort to end asynchronous thread.

### DIFF
--- a/tests/drivers/spi/spi_loopback/src/spi.c
+++ b/tests/drivers/spi/spi_loopback/src/spi.c
@@ -395,5 +395,5 @@ void main(void)
 
 	SYS_LOG_INF("All tx/rx passed");
 end:
-	k_thread_cancel(async_thread_id);
+	k_thread_abort(async_thread_id);
 }


### PR DESCRIPTION
k_thread_cancel() is replaced with k_thread_abort() because
k_thread_cancel() is used to cancel threads that have not started yet.
Canceling asynchronous thread was returning an error.

Signed-off-by: Michał Kruszewski <michal.kruszewski@nordicsemi.no>