### PR TITLE
Network interface helpers

### DIFF
--- a/include/net/net_if.h
+++ b/include/net/net_if.h
@@ -539,6 +539,19 @@ struct net_if *net_if_get_default(void);
  */
 struct net_if *net_if_get_first_by_type(const struct net_l2 *l2);
 
+#if defined(CONFIG_NET_L2_IEEE802154)
+/**
+ * @brief Get the first IEEE 802.15.4 network interface.
+ *
+ * @return First IEEE 802.15.4 network interface or NULL if no such
+ * interfaces was found.
+ */
+static inline struct net_if *net_if_get_ieee802154(void)
+{
+	return net_if_get_first_by_type(&NET_L2_GET_NAME(IEEE802154));
+}
+#endif /* CONFIG_NET_L2_IEEE802154 */
+
 #if defined(CONFIG_NET_IPV6)
 /**
  * @brief Check if this IPv6 address belongs to one of the interfaces.

--- a/include/net/net_if.h
+++ b/include/net/net_if.h
@@ -529,6 +529,16 @@ static inline void net_if_router_rm(struct net_if_router *router)
  */
 struct net_if *net_if_get_default(void);
 
+/**
+ * @brief Get the first network interface according to its type.
+ *
+ * @param l2 Layer 2 type of the network interface.
+ *
+ * @return First network interface of a given type or NULL if no such
+ * interfaces was found.
+ */
+struct net_if *net_if_get_first_by_type(const struct net_l2 *l2);
+
 #if defined(CONFIG_NET_IPV6)
 /**
  * @brief Check if this IPv6 address belongs to one of the interfaces.

--- a/subsys/net/ip/net_if.c
+++ b/subsys/net/ip/net_if.c
@@ -336,6 +336,19 @@ struct net_if *net_if_get_default(void)
 	return __net_if_start;
 }
 
+struct net_if *net_if_get_first_by_type(const struct net_l2 *l2)
+{
+	struct net_if *iface;
+
+	for (iface = __net_if_start; iface != __net_if_end; iface++) {
+		if (iface->l2 == l2) {
+			return iface;
+		}
+	}
+
+	return NULL;
+}
+
 #if defined(CONFIG_NET_IPV6)
 
 #if defined(CONFIG_NET_IPV6_MLD)


### PR DESCRIPTION
If we have multiple network interface of different types, then it is useful to have helpers that can return the desired interface to the caller.