### PR TITLE
drivers: gpio: Fix Coverity static scan issues

### DIFF
--- a/drivers/gpio/gpio_cc2650.c
+++ b/drivers/gpio/gpio_cc2650.c
@@ -162,12 +162,12 @@ static int gpio_cc2650_config_pin(int pin, int flags)
 		iocfg_config |= CC2650_IOC_NORMAL_IO;
 	}
 
-	if (flags & GPIO_PUD_NORMAL) {
-		iocfg_config |= CC2650_IOC_NO_PULL;
-	} else if (flags & GPIO_PUD_PULL_UP) {
+	if (flags & GPIO_PUD_PULL_UP) {
 		iocfg_config |= CC2650_IOC_PULL_UP;
 	} else if (flags & GPIO_PUD_PULL_DOWN) {
 		iocfg_config |= CC2650_IOC_PULL_DOWN;
+	} else {
+		iocfg_config |= CC2650_IOC_NO_PULL;
 	}
 
 	/* Remember, we only look at GPIO_DS_*_LOW ! */


### PR DESCRIPTION
patch fix the dead code issue reported by coverity static scan
for gpio driver of cc2650 TI SOC. CC2650_IOC_NO_PULL macro
is defined Zero, bitwise and with any value would result to
zero,because of which only false condition of if is evaluated
but not the true condition.

Jira ZEP-2469.

Signed-off-by: Savinay Dharmappa <savinay.dharmappa@intel.com>