### PR TITLE
samples: net: zoap_server: Check IPv6 address add return value

### DIFF
--- a/samples/net/zoap_server/src/zoap-server.c
+++ b/samples/net/zoap_server/src/zoap-server.c
@@ -1200,6 +1200,11 @@ static bool join_coap_multicast_group(void)
 #endif
 
 	ifaddr = net_if_ipv6_addr_add(iface, &my_addr, NET_ADDR_MANUAL, 0);
+	if (!ifaddr) {
+		NET_ERR("Could not add unicast address to interface");
+		return false;
+	}
+
 	ifaddr->addr_state = NET_ADDR_PREFERRED;
 
 	mcast = net_if_ipv6_maddr_add(iface, &mcast_addr.sin6_addr);


### PR DESCRIPTION
When unicast IPv6 address is added to network interface, it is
possible that the return value is NULL (if all the address slots
are already occupied).

Coverity-CID: 157607

Jira: ZEP-2467

Signed-off-by: Jukka Rissanen <jukka.rissanen@linux.intel.com>