### PR TITLE
tests: shell: Fix string not null-terminated

### DIFF
--- a/tests/shell/src/main.c
+++ b/tests/shell/src/main.c
@@ -19,7 +19,9 @@ static void test_shell_exec(const char *line, int result)
 	char cmd[80];
 	int ret;
 
-	strncpy(cmd, line, sizeof(cmd));
+	strncpy(cmd, line, sizeof(cmd) - 1);
+	cmd[79] = '\0';
+
 	ret = shell_exec(cmd);
 
 	TC_PRINT("shell_exec(%s): %d\n", line, ret);


### PR DESCRIPTION
shell_exec expects a string that is null-terminated but if line passed
to strncpy is equal or bigger than the buffer it will not produce a
null-terminated command.

Jira: ZEP-2474

Signed-off-by: Luiz Augusto von Dentz <luiz.von.dentz@intel.com>