### PR TITLE
Bluetooth: controller: Fix return type in hal/rand.c

### DIFF
--- a/subsys/bluetooth/controller/hal/nrf5/rand.c
+++ b/subsys/bluetooth/controller/hal/nrf5/rand.c
@@ -143,7 +143,7 @@ void isr_rand(void *param)
 	ARG_UNUSED(param);
 
 	if (NRF_RNG->EVENTS_VALRDY) {
-		u8_t ret;
+		int ret;
 
 		ret = isr(rng_isr, true);
 		if (ret != -EBUSY) {


### PR DESCRIPTION
Fix incorrect return data type, which causes controller to
hang generating random numbers.

Fixes bug introduced in commit d90095b5561a ("Bluetooth:
controller: Use random numbers in adv and enc setup")

Signed-off-by: Vinayak Kariappa Chettimada <vich@nordicsemi.no>