### PR TITLE
arch: arm: stm32f1: Fix GPIO configuration

### DIFF
--- a/arch/arm/soc/st_stm32/stm32f1/soc_gpio.c
+++ b/arch/arm/soc/st_stm32/stm32f1/soc_gpio.c
@@ -35,24 +35,20 @@ int stm32_gpio_flags_to_conf(int flags, int *pincfg)
 
 	if (direction == GPIO_DIR_OUT) {
 		/* Pin is configured as an output */
-		*pincfg = (STM32_MODE_OUTPUT << STM32_MODE_INOUT_SHIFT) |
-			  (STM32_CNF_GP_OUTPUT << STM32_CNF_OUT_1_SHIFT) |
-			  (STM32_CNF_PUSH_PULL << STM32_CNF_OUT_0_SHIFT);
+		*pincfg = (STM32_MODE_OUTPUT | STM32_CNF_GP_OUTPUT |
+			   STM32_CNF_PUSH_PULL);
 	} else {
 		/* Pin is configured as an input */
 		int pud = flags & GPIO_PUD_MASK;
 
 		/* pull-{up,down} maybe? */
 		if (pud == GPIO_PUD_PULL_UP) {
-			*pincfg = (STM32_MODE_INPUT << STM32_MODE_INOUT_SHIFT) |
-				  (STM32_PUPD_PULL_UP << STM32_PUPD_SHIFT);
+			*pincfg = (STM32_MODE_INPUT | STM32_PUPD_PULL_UP);
 		} else if (pud == GPIO_PUD_PULL_DOWN) {
-			*pincfg = (STM32_MODE_INPUT << STM32_MODE_INOUT_SHIFT) |
-				  (STM32_PUPD_PULL_DOWN << STM32_PUPD_SHIFT);
+			*pincfg = (STM32_MODE_INPUT | STM32_PUPD_PULL_DOWN);
 		} else {
 			/* floating */
-			*pincfg = (STM32_MODE_INPUT << STM32_MODE_INOUT_SHIFT) |
-				  (STM32_PUPD_NO_PULL << STM32_PUPD_SHIFT);
+			*pincfg = (STM32_MODE_INPUT | STM32_PUPD_NO_PULL);
 		}
 	}
 

--- a/arch/arm/soc/st_stm32/stm32f1/soc_gpio.c
+++ b/arch/arm/soc/st_stm32/stm32f1/soc_gpio.c
@@ -43,12 +43,15 @@ int stm32_gpio_flags_to_conf(int flags, int *pincfg)
 
 		/* pull-{up,down} maybe? */
 		if (pud == GPIO_PUD_PULL_UP) {
-			*pincfg = (STM32_MODE_INPUT | STM32_PUPD_PULL_UP);
+			*pincfg = (STM32_MODE_INPUT | STM32_CNF_IN_PUPD |
+				   STM32_PUPD_PULL_UP);
 		} else if (pud == GPIO_PUD_PULL_DOWN) {
-			*pincfg = (STM32_MODE_INPUT | STM32_PUPD_PULL_DOWN);
+			*pincfg = (STM32_MODE_INPUT | STM32_CNF_IN_PUPD |
+				   STM32_PUPD_PULL_DOWN);
 		} else {
 			/* floating */
-			*pincfg = (STM32_MODE_INPUT | STM32_PUPD_NO_PULL);
+			*pincfg = (STM32_MODE_INPUT | STM32_CNF_IN_FLOAT |
+				   STM32_PUPD_NO_PULL);
 		}
 	}
 


### PR DESCRIPTION
Fix GPIO configuration for STM32F1 family.

In the stm32_gpio_flags_to_conf function the configuration
values of the GPIO pin are shifted two times. One in the
stm32-pinctrlf1 header and one in the function. This PR
removes the shift in the function. Moreover, when GPIO is
configured as input the CNF bits weren't configured. This
PR adds the missing CNF bits. 


Signed-off-by: Yannis Damigos <giannis.damigos@gmail.com>