### PR TITLE
Bluetooth: controller: LE Directed Advertising Report

### DIFF
--- a/include/bluetooth/hci.h
+++ b/include/bluetooth/hci.h
@@ -1608,8 +1608,8 @@ struct bt_hci_evt_le_enh_conn_complete {
 #define BT_HCI_EVT_LE_DIRECT_ADV_REPORT         0x0b
 struct bt_hci_evt_le_direct_adv_info {
 	u8_t         evt_type;
-	bt_addr_le_t dir_addr;
 	bt_addr_le_t addr;
+	bt_addr_le_t dir_addr;
 	s8_t         rssi;
 } __packed;
 struct bt_hci_evt_le_direct_adv_report {

--- a/subsys/bluetooth/controller/ll_sw/ctrl.c
+++ b/subsys/bluetooth/controller/ll_sw/ctrl.c
@@ -1094,7 +1094,7 @@ static inline u32_t isr_rx_adv(u8_t devmatch_ok, u8_t devmatch_id,
 	return 1;
 }
 
-static u32_t isr_rx_scan_report(u8_t rssi_ready, u8_t rl_idx)
+static u32_t isr_rx_scan_report(u8_t rssi_ready, u8_t rl_idx, bool dir_report)
 {
 	struct radio_pdu_node_rx *radio_pdu_node_rx;
 	struct pdu_adv *pdu_adv_rx;
@@ -1139,6 +1139,9 @@ static u32_t isr_rx_scan_report(u8_t rssi_ready, u8_t rl_idx)
 	/* save the resolving list index */
 	((u8_t *)pdu_adv_rx)[offsetof(struct pdu_adv, payload) +
 			     pdu_adv_rx->len + 1] = rl_idx;
+	/* save the directed adv report flag */
+	((u8_t *)pdu_adv_rx)[offsetof(struct pdu_adv, payload) +
+			     pdu_adv_rx->len + 2] = dir_report ? 1 : 0;
 #endif /* CONFIG_BT_CONTROLLER_PRIVACY */
 
 	packet_rx_enqueue();
@@ -1183,8 +1186,25 @@ static inline bool isr_scan_init_adva_check(struct pdu_adv *pdu,
 			&pdu->payload.adv_ind.addr[0], BDADDR_SIZE) == 0));
 }
 
+static inline bool isr_scan_tgta_rpa_check(struct pdu_adv *pdu,
+					   bool *dir_report)
+{
+	if (((_radio.scanner.filter_policy & 0x02) != 0) &&
+	    (pdu->rx_addr != 0) &&
+	    ((pdu->payload.direct_ind.tgt_addr[5] & 0xc0) == 0x40)) {
+
+		if (dir_report) {
+			*dir_report = true;
+		}
+
+		return true;
+	}
+
+	return false;
+}
+
 static inline bool isr_scan_tgta_check(bool init, struct pdu_adv *pdu,
-				       u8_t rl_idx)
+				       u8_t rl_idx, bool *dir_report)
 {
 #if defined(CONFIG_BT_CONTROLLER_PRIVACY)
 	if (ctrl_rl_addr_resolve(pdu->rx_addr,
@@ -1205,9 +1225,7 @@ static inline bool isr_scan_tgta_check(bool init, struct pdu_adv *pdu,
 		  /* allow directed adv packets where TargetA address
 		   * is resolvable private address (scanner only)
 		   */
-	       (((_radio.scanner.filter_policy & 0x02) != 0) &&
-		(pdu->rx_addr != 0) &&
-		((pdu->payload.direct_ind.tgt_addr[5] & 0xc0) == 0x40));
+	       isr_scan_tgta_rpa_check(pdu, dir_report);
 }
 
 static inline bool isr_scan_init_check(struct pdu_adv *pdu, u8_t rl_idx)
@@ -1217,7 +1235,7 @@ static inline bool isr_scan_init_check(struct pdu_adv *pdu, u8_t rl_idx)
 		((pdu->type == PDU_ADV_TYPE_ADV_IND) ||
 		((pdu->type == PDU_ADV_TYPE_DIRECT_IND) &&
 		 (/* allow directed adv packets addressed to this device */
-		  isr_scan_tgta_check(true, pdu, rl_idx)))));
+		  isr_scan_tgta_check(true, pdu, rl_idx, NULL)))));
 }
 
 static inline u32_t isr_rx_scan(u8_t devmatch_ok, u8_t devmatch_id,
@@ -1225,6 +1243,8 @@ static inline u32_t isr_rx_scan(u8_t devmatch_ok, u8_t devmatch_id,
 				u8_t rssi_ready)
 {
 	struct pdu_adv *pdu_adv_rx;
+	/* Directed Adverising Report */
+	bool dir_report = false;
 
 	pdu_adv_rx = (struct pdu_adv *)
 		_radio.packet_rx[_radio.packet_rx_last]->pdu_data;
@@ -1511,7 +1531,8 @@ static inline u32_t isr_rx_scan(u8_t devmatch_ok, u8_t devmatch_id,
 		/* save the adv packet */
 		err = isr_rx_scan_report(rssi_ready,
 					 irkmatch_ok ? rl_idx :
-						       FILTER_IDX_NONE);
+						       FILTER_IDX_NONE,
+					 false);
 		if (err) {
 			return err;
 		}
@@ -1553,7 +1574,8 @@ static inline u32_t isr_rx_scan(u8_t devmatch_ok, u8_t devmatch_id,
 	else if (((pdu_adv_rx->type == PDU_ADV_TYPE_ADV_IND) ||
 		  ((pdu_adv_rx->type == PDU_ADV_TYPE_DIRECT_IND) &&
 		   (/* allow directed adv packets addressed to this device */
-		    isr_scan_tgta_check(false, pdu_adv_rx, rl_idx))) ||
+		    isr_scan_tgta_check(false, pdu_adv_rx, rl_idx,
+					&dir_report))) ||
 		  (pdu_adv_rx->type == PDU_ADV_TYPE_NONCONN_IND) ||
 		  (pdu_adv_rx->type == PDU_ADV_TYPE_SCAN_IND) ||
 #if defined(CONFIG_BT_CONTROLLER_ADV_EXT)
@@ -1569,7 +1591,8 @@ static inline u32_t isr_rx_scan(u8_t devmatch_ok, u8_t devmatch_id,
 		/* save the scan response packet */
 		err = isr_rx_scan_report(rssi_ready,
 					 irkmatch_ok ? rl_idx :
-						       FILTER_IDX_NONE);
+						       FILTER_IDX_NONE,
+					 dir_report);
 		if (err) {
 			return err;
 		}

--- a/subsys/bluetooth/controller/ll_sw/ctrl_internal.h
+++ b/subsys/bluetooth/controller/ll_sw/ctrl_internal.h
@@ -261,9 +261,11 @@ struct pdu_data_q_tx {
 	struct radio_pdu_node_tx *node_tx;
 };
 
-/* Extra bytes for enqueued rx_node metadata: rssi and resolving index */
+/* Extra bytes for enqueued rx_node metadata: rssi (always) and resolving
+ * index and directed adv report (with privacy enabled).
+ */
 #if defined(CONFIG_BT_CONTROLLER_PRIVACY)
-#define PDU_AC_SIZE_EXTRA 2
+#define PDU_AC_SIZE_EXTRA 3
 #else
 #define PDU_AC_SIZE_EXTRA 1
 #endif /* CONFIG_BT_CONTROLLER_PRIVACY */


### PR DESCRIPTION
Implement the 4.2 event LE Directed Advertising Report, used for
scanners in a privacy-enabled controller to report directed advertising
events whose TargetA cannot be resolved by the local controller.

Signed-off-by: Carles Cufi <carles.cufi@nordicsemi.no>