### PR TITLE
Bluetooth: Mesh: Fix alignment issue resulting from Kconfig change

### DIFF
--- a/include/bluetooth/mesh.h
+++ b/include/bluetooth/mesh.h
@@ -209,10 +209,10 @@ struct bt_mesh_model_op {
 {                                                                            \
 	.id = (_id),                                                         \
 	.op = _op,                                                           \
-	.keys = { [0 ... (CONFIG_BT_MESH_MODEL_KEY_COUNT - 1)] =      \
+	.keys = { [0 ... (CONFIG_BT_MESH_MODEL_KEY_COUNT - 1)] =             \
 			BT_MESH_KEY_UNUSED },                                \
 	.pub = _pub,                                                         \
-	.groups = { [0 ... (CONFIG_BT_MESH_MODEL_GROUP_COUNT - 1)] =  \
+	.groups = { [0 ... (CONFIG_BT_MESH_MODEL_GROUP_COUNT - 1)] =         \
 			BT_MESH_ADDR_UNASSIGNED },                           \
 	.user_data = _user_data,                                             \
 }
@@ -223,9 +223,9 @@ struct bt_mesh_model_op {
 	.vnd.id = (_id),                                                     \
 	.op = _op,                                                           \
 	.pub = _pub,                                                         \
-	.keys = { [0 ... (CONFIG_BT_MESH_MODEL_KEY_COUNT - 1)] =      \
+	.keys = { [0 ... (CONFIG_BT_MESH_MODEL_KEY_COUNT - 1)] =             \
 			BT_MESH_KEY_UNUSED },                                \
-	.groups = { [0 ... (CONFIG_BT_MESH_MODEL_GROUP_COUNT - 1)] =  \
+	.groups = { [0 ... (CONFIG_BT_MESH_MODEL_GROUP_COUNT - 1)] =         \
 			BT_MESH_ADDR_UNASSIGNED },                           \
 	.user_data = _user_data,                                             \
 }


### PR DESCRIPTION
The alignment of these defines went a bit off with the shortened
Kconfig variable names.

Signed-off-by: Johan Hedberg <johan.hedberg@intel.com>