### PR TITLE
net: lwm2m: rename CONFIG_NET_L2_BLUETOOTH to CONFIG_NET_L2_BT

### DIFF
--- a/samples/net/lwm2m_client/src/lwm2m-client.c
+++ b/samples/net/lwm2m_client/src/lwm2m-client.c
@@ -15,7 +15,7 @@
 #include <net/net_app.h>
 #include <net/lwm2m.h>
 
-#if defined(CONFIG_NET_L2_BLUETOOTH)
+#if defined(CONFIG_NET_L2_BT)
 #include <bluetooth/bluetooth.h>
 #include <gatt/ipss.h>
 #endif
@@ -212,7 +212,7 @@ void main(void)
 
 	k_sem_init(&quit_lock, 0, UINT_MAX);
 
-#if defined(CONFIG_NET_L2_BLUETOOTH)
+#if defined(CONFIG_NET_L2_BT)
 	if (bt_enable(NULL)) {
 		SYS_LOG_ERR("Bluetooth init failed");
 		return;

--- a/subsys/net/lib/lwm2m/lwm2m_obj_firmware_pull.c
+++ b/subsys/net/lib/lwm2m/lwm2m_obj_firmware_pull.c
@@ -279,7 +279,7 @@ static void firmware_transfer(struct k_work *work)
 	}
 
 	/* reset block transfer context */
-#if defined(CONFIG_NET_L2_BLUETOOTH)
+#if defined(CONFIG_NET_L2_BT)
 	zoap_block_transfer_init(&firmware_block_ctx, ZOAP_BLOCK_64, 0);
 #else
 	zoap_block_transfer_init(&firmware_block_ctx, ZOAP_BLOCK_256, 0);


### PR DESCRIPTION
Change according to @jhedberg 's patch 2975ca07543a648ed23b2db3fa8fdb7c6c86d32b.
