### PR TITLE
Move config BT_WAIT_NOP and restructure drivers/bluetooth/Kconfig

### DIFF
--- a/drivers/bluetooth/Kconfig
+++ b/drivers/bluetooth/Kconfig
@@ -29,15 +29,6 @@ config BT_NRF51_PM
 	  Power Management support for Nordic BLE nRF51 chip. Allows to enable,
 	  disable the chip and handle wakeups.
 
-config BT_WAIT_NOP
-	bool "Wait for \"NOP\" Command Complete event during init"
-	depends on BT_HCI
-	help
-	  Some controllers emit a Command Complete event for the NOP
-	  opcode to indicate that they're ready to receive commands.
-	  This option should be selected if the controller used
-	  exhibits such behavior.
-
 endmenu
 
 endif # BT

--- a/drivers/bluetooth/Kconfig
+++ b/drivers/bluetooth/Kconfig
@@ -10,7 +10,9 @@
 # Bluetooth options
 #
 
-if BT
+# Controller support is an HCI driver in itself, so these HCI driver
+# options are only applicable if controller support hasn't been enabled.
+if BT && ! BT_CONTROLLER
 
 menu "Bluetooth Drivers"
 
@@ -31,4 +33,4 @@ config BT_NRF51_PM
 
 endmenu
 
-endif # BT
+endif # BT && ! BT_CONTROLLER

--- a/drivers/bluetooth/hci/Kconfig
+++ b/drivers/bluetooth/hci/Kconfig
@@ -8,10 +8,6 @@
 
 comment "Bluetooth HCI Driver Options"
 
-# Controller support is an HCI driver in itself, so these HCI driver
-# options are only applicable if controller support hasn't been enabled.
-if !BT_CONTROLLER
-
 config BT_UART
 	bool
 
@@ -55,8 +51,6 @@ config BT_NO_DRIVER
 	  should be selected.
 
 endchoice
-
-endif # !BT_CONTROLLER
 
 if !HAS_DTS
 config BT_UART_ON_DEV_NAME

--- a/subsys/bluetooth/host/Kconfig
+++ b/subsys/bluetooth/host/Kconfig
@@ -62,6 +62,15 @@ config BT_HCI_TX_PRIO
 	int
 	default 7
 
+config BT_WAIT_NOP
+	bool "Wait for \"NOP\" Command Complete event during init"
+	depends on BT_HCI
+	help
+	  Some controllers emit a Command Complete event for the NOP
+	  opcode to indicate that they're ready to receive commands.
+	  This option should be selected if the controller used
+	  exhibits such behavior.
+
 # Headroom that the driver needs for sending and receiving buffers.
 # Add a new 'default' entry for each new driver.
 config BT_HCI_RESERVE


### PR DESCRIPTION
It used to be that there was a fairly empty "Bluetooth Drivers" menu
entry in the drivers menu. This entry was present even though there
was no drivers/bluetooth code being compiled in.

With this patch "Bluetooth Drivers" will no longer be present when
BT_CONTROLLER is enabled.