### PR TITLE
Bluetooth: controller: Add packet transmit time restrictions

### DIFF
--- a/subsys/bluetooth/controller/hci/hci.c
+++ b/subsys/bluetooth/controller/hci/hci.c
@@ -1030,12 +1030,13 @@ static void le_set_data_len(struct net_buf *buf, struct net_buf **evt)
 	struct bt_hci_rp_le_set_data_len *rp;
 	u32_t status;
 	u16_t tx_octets;
+	u16_t tx_time;
 	u16_t handle;
 
 	handle = sys_le16_to_cpu(cmd->handle);
 	tx_octets = sys_le16_to_cpu(cmd->tx_octets);
-	/** @todo add reject_ext_ind support in ctrl.c */
-	status = ll_length_req_send(handle, tx_octets);
+	tx_time = sys_le16_to_cpu(cmd->tx_time);
+	status = ll_length_req_send(handle, tx_octets, tx_time);
 
 	rp = cmd_complete(evt, sizeof(*rp));
 	rp->status = (!status) ?  0x00 : BT_HCI_ERR_CMD_DISALLOWED;

--- a/subsys/bluetooth/controller/include/ll.h
+++ b/subsys/bluetooth/controller/include/ll.h
@@ -78,7 +78,7 @@ u32_t ll_apto_set(u16_t handle, u16_t apto);
 #endif /* CONFIG_BT_CONTROLLER_LE_PING */
 
 #if defined(CONFIG_BT_CONTROLLER_DATA_LENGTH)
-u32_t ll_length_req_send(u16_t handle, u16_t tx_octets);
+u32_t ll_length_req_send(u16_t handle, u16_t tx_octets, u16_t tx_time);
 void ll_length_default_get(u16_t *max_tx_octets, u16_t *max_tx_time);
 u32_t ll_length_default_set(u16_t max_tx_octets, u16_t max_tx_time);
 void ll_length_max_get(u16_t *max_tx_octets, u16_t *max_tx_time,

--- a/subsys/bluetooth/controller/ll_sw/ctrl_internal.h
+++ b/subsys/bluetooth/controller/ll_sw/ctrl_internal.h
@@ -66,6 +66,12 @@ struct connection {
 	u16_t default_tx_octets;
 	u16_t max_tx_octets;
 	u16_t max_rx_octets;
+
+#if defined(CONFIG_BT_CONTROLLER_PHY)
+	u16_t default_tx_time;
+	u16_t max_tx_time;
+	u16_t max_rx_time;
+#endif /* CONFIG_BT_CONTROLLER_PHY */
 #endif /* CONFIG_BT_CONTROLLER_DATA_LENGTH */
 
 #if defined(CONFIG_BT_CONTROLLER_PHY)
@@ -73,6 +79,8 @@ struct connection {
 	u8_t phy_tx:3;
 	u8_t phy_pref_flags:1;
 	u8_t phy_flags:1;
+	u8_t phy_tx_time:3;
+
 	u8_t phy_pref_rx:3;
 	u8_t phy_rx:3;
 #endif /* CONFIG_BT_CONTROLLER_PHY */
@@ -209,6 +217,10 @@ struct connection {
 #define LLCP_LENGTH_STATE_RESIZE     3
 		u16_t rx_octets;
 		u16_t tx_octets;
+#if defined(CONFIG_BT_CONTROLLER_PHY)
+		u16_t rx_time;
+		u16_t tx_time;
+#endif /* CONFIG_BT_CONTROLLER_PHY */
 	} llcp_length;
 #endif /* CONFIG_BT_CONTROLLER_DATA_LENGTH */
 


### PR DESCRIPTION
Add implementation to support PHY update procedure with
packet transmit time restrictions.

This fixes:
TP/CON/SLA/BV-49-C [Initiating PHY Update Procedure Packet
Time Restrictions]
TP/CON/SLA/BV-50-C [Responding to PHY Update Procedure
Packet Time Restrictions]
TP/CON/SLA/BV-52-C [Initiating PHY Update Procedure Packet
Time Restrictions, No Change]
TP/CON/SLA/BV-53-C [Responding to PHY Update Procedure
Packet Time Restrictions, No Change]
TP/CON/MAS/BV-49-C [Initiating PHY Update Procedure Packet
Time Restrictions]
TP/CON/MAS/BV-50-C [Responding to PHY Update Procedure
Packet Time Restrictions]
conformance tests in LL.TS.5.0.0.

Signed-off-by: Vinayak Kariappa Chettimada <vich@nordicsemi.no>