### PR TITLE
net: app: config for net app to skip the wait after net init

### DIFF
--- a/subsys/net/lib/app/Kconfig
+++ b/subsys/net/lib/app/Kconfig
@@ -39,6 +39,16 @@ config NET_APP_INIT_TIMEOUT
 	received within this limit, then the net_app_init() call will fail
 	during the device startup.
 
+config NET_APP_INIT_ASYNC
+	bool "Don't wait for networking startup after init"
+	default n
+	depends on NET_APP_AUTO_INIT
+	help
+	If this option is set, the net_app API won't wait for network init.
+	Applications with this enabled, need to handle NET_EVENT_IF_UP
+	notifications via the net_mgmt APIs prior to performing any network
+	activity.
+
 config NET_APP_NEED_IPV6
 	bool "This application wants IPv6 support"
 	depends on NET_APP_AUTO_INIT


### PR DESCRIPTION
The net app API makes initialization of network components very easy.
However, it introduces a wait loop till the network is ready before
proceeding to application code.  This can be undesirable for
applications which need to setup threads and start services which
shouldn't be blocked by network access.

This commit introduces CONFIG_NET_APP_INIT_ASYNC which is defaulted
to "n" for current compatibility.  When enabled, the net app
framework will skip the wait for network finalization after init is
performed.  Application code is executed immediately and will need
to use the net_mgmt event APIs to detect when the network is
ready.

Signed-off-by: Michael Scott <michael.scott@linaro.org>