### PR TITLE
net: lwm2m: general cleanup and fixes

### DIFF
--- a/subsys/net/lib/lwm2m/Kconfig
+++ b/subsys/net/lib/lwm2m/Kconfig
@@ -127,6 +127,17 @@ config LWM2M_FIRMWARE_UPDATE_PULL_SUPPORT
 	  block transfer and "FIRMWARE PACKAGE URI" resource.  This option
 	  adds another UDP context and packet handling.
 
+config LWM2M_FIRMWARE_UPDATE_PULL_COAP_BLOCK_SIZE
+	int "Firmware Update object pull CoAP block size"
+	depends on LWM2M_FIRMWARE_UPDATE_PULL_SUPPORT
+	default 256
+	default 64 if NET_L2_BT
+	default 64 if NET_L2_IEEE802154
+	range 16 1024
+	help
+	  CoAP block size used by firmware pull when performing block-wise
+	  transfers. Possible values: 16, 32, 64, 128, 256, 512 and 1024.
+
 config LWM2M_RW_JSON_SUPPORT
 	bool "support for JSON writer"
 	default y

--- a/subsys/net/lib/lwm2m/lwm2m_engine.c
+++ b/subsys/net/lib/lwm2m/lwm2m_engine.c
@@ -261,7 +261,7 @@ static int engine_remove_observer(const u8_t *token, u8_t tkl)
 
 	sys_slist_remove(&engine_observer_list, NULL, &found_obj->node);
 
-	SYS_LOG_DBG("oberver '%s' removed", sprint_token(token, tkl));
+	SYS_LOG_DBG("observer '%s' removed", sprint_token(token, tkl));
 
 	return 0;
 }

--- a/subsys/net/lib/lwm2m/lwm2m_engine.c
+++ b/subsys/net/lib/lwm2m/lwm2m_engine.c
@@ -126,6 +126,7 @@ char *lwm2m_sprint_ip_addr(const struct sockaddr *addr)
 	return NULL;
 }
 
+#if CONFIG_SYS_LOG_LWM2M_LEVEL > 3
 static char *sprint_token(const u8_t *token, u8_t tkl)
 {
 	int i;
@@ -138,6 +139,7 @@ static char *sprint_token(const u8_t *token, u8_t tkl)
 	buf[pos] = '\0';
 	return buf;
 }
+#endif
 
 /* observer functions */
 

--- a/subsys/net/lib/lwm2m/lwm2m_engine.h
+++ b/subsys/net/lib/lwm2m/lwm2m_engine.h
@@ -54,6 +54,7 @@ int lwm2m_udp_sendto(struct net_pkt *pkt, const struct sockaddr *dst_addr);
 void lwm2m_udp_receive(struct net_context *ctx, struct net_pkt *pkt,
 		       struct zoap_pending *zpendings, int num_zpendings,
 		       struct zoap_reply *zreplies, int num_zreplies,
+		       bool handle_separate_response,
 		       int (*udp_request_handler)(struct zoap_packet *request,
 				struct zoap_packet *response,
 				struct sockaddr *from_addr));

--- a/subsys/net/lib/lwm2m/lwm2m_engine.h
+++ b/subsys/net/lib/lwm2m/lwm2m_engine.h
@@ -50,6 +50,7 @@ int lwm2m_write_handler(struct lwm2m_engine_obj_inst *obj_inst,
 			struct lwm2m_engine_obj_field *obj_field,
 			struct lwm2m_engine_context *context);
 
+int lwm2m_udp_sendto(struct net_pkt *pkt, const struct sockaddr *dst_addr);
 void lwm2m_udp_receive(struct net_context *ctx, struct net_pkt *pkt,
 		       struct zoap_pending *zpendings, int num_zpendings,
 		       struct zoap_reply *zreplies, int num_zreplies,

--- a/subsys/net/lib/lwm2m/lwm2m_obj_firmware_pull.c
+++ b/subsys/net/lib/lwm2m/lwm2m_obj_firmware_pull.c
@@ -47,7 +47,7 @@ firmware_udp_receive(struct net_context *ctx, struct net_pkt *pkt, int status,
 		     void *user_data)
 {
 	lwm2m_udp_receive(ctx, pkt, pendings, NUM_PENDINGS,
-			  replies, NUM_REPLIES, NULL);
+			  replies, NUM_REPLIES, true, NULL);
 }
 
 static void retransmit_request(struct k_work *work)

--- a/subsys/net/lib/lwm2m/lwm2m_obj_firmware_pull.c
+++ b/subsys/net/lib/lwm2m/lwm2m_obj_firmware_pull.c
@@ -198,6 +198,28 @@ do_firmware_transfer_reply_cb(const struct zoap_packet *response,
 	return ret;
 }
 
+static enum zoap_block_size default_block_size(void)
+{
+	switch (CONFIG_LWM2M_FIRMWARE_UPDATE_PULL_COAP_BLOCK_SIZE) {
+	case 16:
+		return ZOAP_BLOCK_16;
+	case 32:
+		return ZOAP_BLOCK_32;
+	case 64:
+		return ZOAP_BLOCK_64;
+	case 128:
+		return ZOAP_BLOCK_128;
+	case 256:
+		return ZOAP_BLOCK_256;
+	case 512:
+		return ZOAP_BLOCK_512;
+	case 1024:
+		return ZOAP_BLOCK_1024;
+	}
+
+	return ZOAP_BLOCK_256;
+}
+
 static void firmware_transfer(struct k_work *work)
 {
 #if defined(CONFIG_NET_IPV6)
@@ -279,11 +301,7 @@ static void firmware_transfer(struct k_work *work)
 	}
 
 	/* reset block transfer context */
-#if defined(CONFIG_NET_L2_BT)
-	zoap_block_transfer_init(&firmware_block_ctx, ZOAP_BLOCK_64, 0);
-#else
-	zoap_block_transfer_init(&firmware_block_ctx, ZOAP_BLOCK_256, 0);
-#endif
+	zoap_block_transfer_init(&firmware_block_ctx, default_block_size(), 0);
 
 	transfer_request(&firmware_block_ctx, NULL, 0,
 			 do_firmware_transfer_reply_cb);

--- a/subsys/net/lib/lwm2m/lwm2m_obj_firmware_pull.c
+++ b/subsys/net/lib/lwm2m/lwm2m_obj_firmware_pull.c
@@ -60,9 +60,7 @@ static void retransmit_request(struct k_work *work)
 		return;
 	}
 
-	r = net_context_sendto(pending->pkt, &pending->addr,
-			       NET_SOCKADDR_MAX_SIZE,
-			       NULL, K_NO_WAIT, NULL, NULL);
+	r = lwm2m_udp_sendto(pending->pkt, &pending->addr);
 	if (r < 0) {
 		return;
 	}
@@ -129,8 +127,7 @@ static int transfer_request(struct zoap_block_context *ctx,
 	}
 
 	/* send request */
-	ret = net_context_sendto(pkt, &firmware_addr, NET_SOCKADDR_MAX_SIZE,
-				 NULL, 0, NULL, NULL);
+	ret = lwm2m_udp_sendto(pkt, &firmware_addr);
 	if (ret < 0) {
 		SYS_LOG_ERR("Error sending LWM2M packet (err:%d).",
 			    ret);

--- a/subsys/net/lib/lwm2m/lwm2m_rd_client.c
+++ b/subsys/net/lib/lwm2m/lwm2m_rd_client.c
@@ -440,9 +440,7 @@ static int sm_do_bootstrap(int index)
 			    lwm2m_sprint_ip_addr(&clients[index].bs_server),
 			    query_buffer);
 
-		ret = net_context_sendto(pkt, &clients[index].bs_server,
-					 NET_SOCKADDR_MAX_SIZE,
-					 NULL, 0, NULL, NULL);
+		ret = lwm2m_udp_sendto(pkt, &clients[index].bs_server);
 		if (ret < 0) {
 			SYS_LOG_ERR("Error sending LWM2M packet (err:%d).",
 				    ret);
@@ -587,9 +585,7 @@ static int sm_send_registration(int index, bool send_obj_support_data,
 	SYS_LOG_DBG("registration sent [%s]",
 		    lwm2m_sprint_ip_addr(&clients[index].reg_server));
 
-	ret = net_context_sendto(pkt, &clients[index].reg_server,
-				 NET_SOCKADDR_MAX_SIZE,
-				 NULL, 0, NULL, NULL);
+	ret = lwm2m_udp_sendto(pkt, &clients[index].reg_server);
 	if (ret < 0) {
 		SYS_LOG_ERR("Error sending LWM2M packet (err:%d).",
 			    ret);
@@ -687,9 +683,7 @@ static int sm_do_deregister(int index)
 
 	SYS_LOG_INF("Deregister from '%s'", clients[index].server_ep);
 
-	ret = net_context_sendto(pkt, &clients[index].reg_server,
-				 NET_SOCKADDR_MAX_SIZE,
-				 NULL, 0, NULL, NULL);
+	ret = lwm2m_udp_sendto(pkt, &clients[index].reg_server);
 	if (ret < 0) {
 		SYS_LOG_ERR("Error sending LWM2M packet (err:%d).",
 			    ret);

--- a/subsys/net/lib/lwm2m/lwm2m_rd_client.c
+++ b/subsys/net/lib/lwm2m/lwm2m_rd_client.c
@@ -204,6 +204,9 @@ static int do_bootstrap_reply_cb(const struct zoap_packet *response,
 	} else if (code == ZOAP_RESPONSE_CODE_NOT_FOUND) {
 		SYS_LOG_ERR("Failed: NOT_FOUND.  Not Retrying.");
 		set_sm_state(index, ENGINE_DO_REGISTRATION);
+	} else if (code == ZOAP_RESPONSE_CODE_FORBIDDEN) {
+		SYS_LOG_ERR("Failed: 4.03 - Forbidden.  Not Retrying.");
+		set_sm_state(index, ENGINE_DO_REGISTRATION);
 	} else {
 		/* TODO: Read payload for error message? */
 		SYS_LOG_ERR("Failed with code %u.%u. Retrying ...",
@@ -270,10 +273,14 @@ static int do_registration_reply_cb(const struct zoap_packet *response,
 		SYS_LOG_ERR("Failed: NOT_FOUND.  Not Retrying.");
 		set_sm_state(index, ENGINE_REGISTRATION_DONE);
 		return 0;
+	} else if (code == ZOAP_RESPONSE_CODE_FORBIDDEN) {
+		SYS_LOG_ERR("Failed: 4.03 - Forbidden.  Not Retrying.");
+		set_sm_state(index, ENGINE_REGISTRATION_DONE);
+		return 0;
 	}
 
 	/* TODO: Read payload for error message? */
-	/* Possible error response codes: 4.00 Bad request & 4.03 Forbidden */
+	/* Possible error response codes: 4.00 Bad request */
 	SYS_LOG_ERR("failed with code %u.%u. Re-init network",
 		    ZOAP_RESPONSE_CODE_CLASS(code),
 		    ZOAP_RESPONSE_CODE_DETAIL(code));


### PR DESCRIPTION
- Add Kconfig option for CoAP block size, so it can be customized by the app.
- Handle forbidden errors during the bootstrap and registration process
- Use common wrapper for net_context_sendto
- Add additional flag to allow handling CoAP separate response messages (useful when downloading block messages, like firmware)
