### PR TITLE
arch: xtensa: Fix newlib link error

### DIFF
--- a/arch/xtensa/soc/sample_controller/linker.ld
+++ b/arch/xtensa/soc/sample_controller/linker.ld
@@ -568,7 +568,7 @@ SECTIONS
     _memmap_seg_sram0_end = ALIGN(0x8);
   } >sram0_seg :sram0_bss_phdr
   __stack = 0x64000000;
-  _heap_sentry = 0x64000000;
+  __heap_sentry = 0x64000000;
   .debug  0 :  { *(.debug) }
   .line  0 :  { *(.line) }
   .debug_srcinfo  0 :  { *(.debug_srcinfo) }


### PR DESCRIPTION
libc-hooks.c references "__heap_sentry" but "_heap_sentry" is defined
in the linker script.

Signed-off-by: Aska Wu <aska.wu@linaro.org>