### PR TITLE
timer: k_timer_start should be allowed to start start with duration = 0 

### DIFF
--- a/kernel/include/timeout_q.h
+++ b/kernel/include/timeout_q.h
@@ -197,7 +197,7 @@ static inline void _add_timeout(struct k_thread *thread,
 				_wait_q_t *wait_q,
 				s32_t timeout_in_ticks)
 {
-	__ASSERT(timeout_in_ticks > 0, "");
+	__ASSERT(timeout_in_ticks >= 0, "");
 
 	timeout->delta_ticks_from_prev = timeout_in_ticks;
 	timeout->thread = thread;
@@ -206,6 +206,16 @@ static inline void _add_timeout(struct k_thread *thread,
 	K_DEBUG("before adding timeout %p\n", timeout);
 	_dump_timeout(timeout, 0);
 	_dump_timeout_q();
+
+	/* If timer is submitted to expire ASAP with
+	 * timeout_in_ticks (duration) as zero value,
+	 * then handle timeout immedately without going
+	 * through timeout queue.
+	 */
+	if (!timeout_in_ticks) {
+		_handle_one_expired_timeout(timeout);
+		return;
+	}
 
 	s32_t *delta = &timeout->delta_ticks_from_prev;
 	struct _timeout *in_q;

--- a/kernel/timer.c
+++ b/kernel/timer.c
@@ -114,7 +114,7 @@ void k_timer_start(struct k_timer *timer, s32_t duration, s32_t period)
 	volatile s32_t period_in_ticks, duration_in_ticks;
 
 	period_in_ticks = _ms_to_ticks(period);
-	duration_in_ticks = _TICK_ALIGN + _ms_to_ticks(duration);
+	duration_in_ticks = _ms_to_ticks(duration);
 
 	unsigned int key = irq_lock();
 
@@ -123,8 +123,8 @@ void k_timer_start(struct k_timer *timer, s32_t duration, s32_t period)
 	}
 
 	timer->period = period_in_ticks;
-	_add_timeout(NULL, &timer->timeout, &timer->wait_q, duration_in_ticks);
 	timer->status = 0;
+	_add_timeout(NULL, &timer->timeout, &timer->wait_q, duration_in_ticks);
 	irq_unlock(key);
 }
 


### PR DESCRIPTION
Duration specify time interval before timer expires for first time,
it is measured in milliseconds. 
A user may submit an periodic activity starting with ASAP. 
So it should allow 0 as value for duration.

So this patch implements adds 0 as valid value for duration.

Jira: ZEP-2497

Signed-off-by: Youvedeep Singh <youvedeep.singh@intel.com>