### PR TITLE
Display: Duration value for k_timer_start is non Zero positive number.

### DIFF
--- a/drivers/display/mb_display.c
+++ b/drivers/display/mb_display.c
@@ -118,7 +118,7 @@ static void start_image(struct mb_display *disp, const struct mb_image *img)
 		disp->expiry = k_uptime_get() + disp->duration;
 	}
 
-	k_timer_start(&disp->timer, K_NO_WAIT, K_MSEC(4));
+	k_timer_start(&disp->timer, K_MSEC(1), K_MSEC(4));
 }
 
 #define ROW_PIN(n) (LED_ROW1_GPIO_PIN + (n))


### PR DESCRIPTION
k_timer_start needs Duration parameter as non Zero positive number.
So changing duration value from 0 to minimum Duration value of 1.

Jira: ZEP-2498

Signed-off-by: Youvedeep Singh <youvedeep.singh@intel.com>