### PR TITLE
net: app: Fix for net_app_get_net_buf()

### DIFF
--- a/samples/net/echo_server/src/echo-server.c
+++ b/samples/net/echo_server/src/echo-server.c
@@ -116,8 +116,6 @@ struct net_pkt *build_reply_pkt(const char *name,
 
 		memcpy(net_buf_add(frag, tmp->len), tmp->data, tmp->len);
 
-		net_pkt_frag_add(reply_pkt, frag);
-
 		tmp = net_pkt_frag_del(pkt, NULL, tmp);
 	}
 

--- a/subsys/net/lib/app/net_app.c
+++ b/subsys/net/lib/app/net_app.c
@@ -792,6 +792,8 @@ struct net_buf *net_app_get_net_buf(struct net_app_ctx *ctx,
 				    struct net_pkt *pkt,
 				    s32_t timeout)
 {
+	struct net_buf *frag;
+
 	if (!ctx || !pkt) {
 		return NULL;
 	}
@@ -800,7 +802,14 @@ struct net_buf *net_app_get_net_buf(struct net_app_ctx *ctx,
 		return NULL;
 	}
 
-	return net_pkt_get_frag(pkt, timeout);
+	frag = net_pkt_get_frag(pkt, timeout);
+	if (!frag) {
+		return NULL;
+	}
+
+	net_pkt_frag_add(pkt, frag);
+
+	return frag;
 }
 
 int net_app_close(struct net_app_ctx *ctx)


### PR DESCRIPTION
The documentation says that the API will automatically append the
net_buf fragment to the end of network packet fragment chain.
This was not the case and current only user for this API in
echo-server sample appended the fragment itself. The fix is to
automatically append the fragment to the end of fragment chain.

Signed-off-by: Jukka Rissanen <jukka.rissanen@linux.intel.com>