### PR TITLE
net: sockets: inet_pton() should return 1 on success

### DIFF
--- a/include/net/socket.h
+++ b/include/net/socket.h
@@ -48,6 +48,7 @@ ssize_t zsock_send(int sock, const void *buf, size_t len, int flags);
 ssize_t zsock_recv(int sock, void *buf, size_t max_len, int flags);
 int zsock_fcntl(int sock, int cmd, int flags);
 int zsock_poll(struct zsock_pollfd *fds, int nfds, int timeout);
+int zsock_inet_pton(sa_family_t family, const char *src, void *dst);
 
 #if defined(CONFIG_NET_SOCKETS_POSIX_NAMES)
 #define socket zsock_socket
@@ -66,7 +67,7 @@ int zsock_poll(struct zsock_pollfd *fds, int nfds, int timeout);
 #define POLLOUT ZSOCK_POLLOUT
 
 #define inet_ntop net_addr_ntop
-#define inet_pton net_addr_pton
+#define inet_pton zsock_inet_pton
 #endif
 
 #ifdef __cplusplus

--- a/subsys/net/lib/sockets/sockets.c
+++ b/subsys/net/lib/sockets/sockets.c
@@ -460,3 +460,12 @@ int zsock_poll(struct zsock_pollfd *fds, int nfds, int timeout)
 
 	return ret;
 }
+
+int zsock_inet_pton(sa_family_t family, const char *src, void *dst)
+{
+	if (net_addr_pton(family, src, dst) == 0) {
+		return 1;
+	} else {
+		return 0;
+	}
+}


### PR DESCRIPTION
Add zsock_inet_pton() to convert the return value of net_addr_pton()
which returns 0 on success.

Signed-off-by: Aska Wu <aska.wu@linaro.org>