### PR TITLE
debug: openocd: build openocd symbols using obj-

### DIFF
--- a/subsys/debug/Makefile
+++ b/subsys/debug/Makefile
@@ -1,9 +1,3 @@
 ccflags-y +=-I$(srctree)/include/debug
 
-obj- = dummy.o
-
-ifeq ($(CONFIG_OPENOCD_SUPPORT),y)
-lib-y += openocd.o
-ldflags-y += --undefined=_kernel_openocd_size_t_size
-ldflags-y += --undefined=_kernel_openocd_offsets
-endif
+obj-$(CONFIG_OPENOCD_SUPPORT) += openocd.o


### PR DESCRIPTION
openocd object was put in a library causing it to be stripped. We want
those symbols in the final ELF to allow debugging with openocd, building
those as objects like the rest of the kernel keeps the symbols in the
kernel.

This fixes #1070.