### PR TITLE
doc: fix misspellings in include (API docs)

### DIFF
--- a/include/arch/x86/arch.h
+++ b/include/arch/x86/arch.h
@@ -620,11 +620,11 @@ void _x86_mmu_set_flags(void *ptr, size_t size, u32_t flags, u32_t mask);
 /**
  * @brief check page table entry flags
  *
- * This routine checks if the buffer is avaialable to the whoever calls
+ * This routine checks if the buffer is available to whoever calls
  * this API.
  * @param addr start address of the buffer
  * @param size the size of the buffer
- * @param flags permisions to check.
+ * @param flags permissions to check.
  *    Consists of 2 bits the bit0 represents the RW permissions
  *    The bit1 represents the user/supervisor permissions
  *    Use macro BUFF_READABLE/BUFF_WRITEABLE or BUFF_USER to build the flags

--- a/include/bluetooth/bluetooth.h
+++ b/include/bluetooth/bluetooth.h
@@ -235,7 +235,7 @@ struct bt_le_scan_param {
 /** Helper macro to enable passive scanning to discover new devices.
  *
  * This macro should be used if information required for device identification
- * (eg UUID) are known to be placed in Advertising Data.
+ * (e.g., UUID) are known to be placed in Advertising Data.
  */
 #define BT_LE_SCAN_PASSIVE BT_LE_SCAN_PARAM(BT_HCI_LE_SCAN_PASSIVE, \
 					    BT_HCI_LE_SCAN_FILTER_DUP_ENABLE, \

--- a/include/bluetooth/conn.h
+++ b/include/bluetooth/conn.h
@@ -257,7 +257,7 @@ typedef enum __packed {
  *  pairing will be initiated.
  *
  *  This function may return error if required level of security is not possible
- *  to achieve due to local or remote device limitation (eg input output
+ *  to achieve due to local or remote device limitation (e.g., input output
  *  capabilities).
  *
  *  @param conn Connection object.

--- a/include/bluetooth/l2cap.h
+++ b/include/bluetooth/l2cap.h
@@ -296,7 +296,7 @@ int bt_l2cap_chan_disconnect(struct bt_l2cap_chan *chan);
 /** @brief Send data to L2CAP channel
  *
  *  Send data from buffer to the channel. If credits are not available, buf will
- *  be queued and sent as and when credits are recieved from peer.
+ *  be queued and sent as and when credits are received from peer.
  *  Regarding to first input parameter, to get details see reference description
  *  to bt_l2cap_chan_connect() API above.
  *

--- a/include/console.h
+++ b/include/console.h
@@ -17,7 +17,7 @@ extern "C" {
  *
  *  This function should be called once to initialize pull-style
  *  access to console via console_getchar() function and buffered
- *  output using console_putchar() function. This function supercedes,
+ *  output using console_putchar() function. This function supersedes,
  *  and incompatible with, callback (push-style) console handling
  *  (via console_input_fn callback, etc.).
  *

--- a/include/net/http.h
+++ b/include/net/http.h
@@ -421,9 +421,9 @@ int http_request(struct http_client_ctx *ctx,
  * @param http_ctx HTTP context.
  * @param req HTTP request to perform.
  * @param cb Callback to call when the response has been received from peer.
- * @param response_buf Caller supplied buffer where the HTTP response will be
+ * @param response_buf Caller-supplied buffer where the HTTP response will be
  * stored
- * @param response_buf_len Length of the caller suppied buffer.
+ * @param response_buf_len Length of the caller-supplied buffer.
  * @param user_data A valid pointer on some user data or NULL
  * @param timeout Amount of time to wait for a reply. If the timeout is 0,
  * then we return immediately and the callback (if set) will be called later.
@@ -449,9 +449,9 @@ int http_client_send_req(struct http_client_ctx *http_ctx,
  * to add. This can be set to NULL. The format is "name: value\r\n"
  * Example: "Accept: text/plain\r\nConnection: Close\r\n"
  * @param cb Callback to call when the response has been received from peer.
- * @param response_buf Caller supplied buffer where the HTTP request will be
+ * @param response_buf Caller-supplied buffer where the HTTP request will be
  * stored
- * @param response_buf_len Length of the caller suppied buffer.
+ * @param response_buf_len Length of the caller-supplied buffer.
  * @param user_data A valid pointer on some user data or NULL
  * @param timeout Amount of time to wait for a reply. If the timeout is 0,
  * then we return immediately and the callback (if set) will be called later.
@@ -493,9 +493,9 @@ static inline int http_client_send_get_req(struct http_client_ctx *http_ctx,
  * @param content_type Content type of the data.
  * @param payload Payload data.
  * @param cb Callback to call when the response has been received from peer.
- * @param response_buf Caller supplied buffer where the HTTP response will be
+ * @param response_buf Caller-supplied buffer where the HTTP response will be
  * stored
- * @param response_buf_len Length of the caller suppied buffer.
+ * @param response_buf_len Length of the caller-supplied buffer.
  * @param user_data A valid pointer on some user data or NULL
  * @param timeout Amount of time to wait for a reply. If the timeout is 0,
  * then we return immediately and the callback (if set) will be called later.
@@ -529,7 +529,7 @@ static inline int http_client_send_post_req(struct http_client_ctx *http_ctx,
 }
 
 /**
- * @brief Initialize user supplied HTTP context.
+ * @brief Initialize user-supplied HTTP context.
  *
  * @detail Caller can set the various fields in http_ctx after this call
  * if needed.
@@ -549,7 +549,7 @@ int http_client_init(struct http_client_ctx *http_ctx,
 
 #if defined(CONFIG_HTTPS)
 /**
- * @brief Initialize user supplied HTTP context when using HTTPS.
+ * @brief Initialize user-supplied HTTP context when using HTTPS.
  *
  * @detail Caller can set the various fields in http_ctx after this call
  * if needed.
@@ -564,7 +564,7 @@ int http_client_init(struct http_client_ctx *http_ctx,
  * @param personalization_data Personalization data (Device specific
  * identifiers) for random number generator. (Can be NULL).
  * @param personalization_data_len Length of the personalization data.
- * @param cert_cb User supplied callback that setups the certifacates.
+ * @param cert_cb User-supplied callback that setups the certificates.
  * @param cert_host Hostname that is used to verify the server certificate.
  * This value is used when HTTP client API calls mbedtls_ssl_set_hostname()
  * which sets the hostname to check against the received server certificate.
@@ -572,7 +572,7 @@ int http_client_init(struct http_client_ctx *http_ctx,
  * This can be left NULL in which case mbedtls will silently skip certificate
  * verification entirely. This option is only used if MBEDTLS_X509_CRT_PARSE_C
  * is enabled in mbedtls config file.
- * @param entropy_src_cb User supplied callback that setup the entropy. This
+ * @param entropy_src_cb User-supplied callback that setup the entropy. This
  * can be set to NULL, in which case default entropy source is used.
  * @param pool Memory pool for RX data reads.
  * @param https_stack HTTPS thread stack.
@@ -839,7 +839,7 @@ void http_server_conn_monitor(http_server_cb_t cb, void *user_data);
 #endif /* CONFIG_NET_DEBUG_HTTP_CONN */
 
 /**
- * @brief Initialize user supplied HTTP context.
+ * @brief Initialize user-supplied HTTP context.
  *
  * @detail Caller can set the various callback fields in http_ctx and
  * http_ctx.req.parser after this call if needed.
@@ -859,9 +859,9 @@ void http_server_conn_monitor(http_server_cb_t cb, void *user_data);
  * listened. The parameter can be left NULL in which case a listener to port 80
  * using IPv4 and IPv6 is created. Note that if IPv4 or IPv6 is disabled, then
  * the corresponding disabled service listener is not created.
- * @param request_buf Caller supplied buffer where the HTTP request will be
+ * @param request_buf Caller-supplied buffer where the HTTP request will be
  * stored
- * @param request_buf_len Length of the caller suppied buffer.
+ * @param request_buf_len Length of the caller-supplied buffer.
  * @param server_banner Print information about started service. This is only
  * printed if HTTP debugging is activated. The parameter can be set to NULL if
  * no extra prints are needed.
@@ -877,7 +877,7 @@ int http_server_init(struct http_server_ctx *http_ctx,
 
 #if defined(CONFIG_HTTPS)
 /**
- * @brief Initialize user supplied HTTP context. This function must be
+ * @brief Initialize user-supplied HTTP context. This function must be
  * used if HTTPS server is created.
  *
  * @detail Caller can set the various callback fields in http_ctx and
@@ -898,17 +898,17 @@ int http_server_init(struct http_server_ctx *http_ctx,
  * listened. The parameter can be left NULL in which case a listener to port 80
  * using IPv4 and IPv6 is created. Note that if IPv4 or IPv6 is disabled, then
  * the corresponding disabled service listener is not created.
- * @param request_buf Caller supplied buffer where the HTTP request will be
+ * @param request_buf Caller-supplied buffer where the HTTP request will be
  * stored
- * @param request_buf_len Length of the caller suppied buffer.
+ * @param request_buf_len Length of the caller-supplied buffer.
  * @param server_banner Print information about started service. This is only
  * printed if HTTP debugging is activated. The parameter can be set to NULL if
  * no extra prints are needed.
  * @param personalization_data Personalization data (Device specific
  * identifiers) for random number generator. (Can be NULL).
  * @param personalization_data_len Length of the personalization data.
- * @param cert_cb User supplied callback that setups the certifacates.
- * @param entropy_src_cb User supplied callback that setup the entropy. This
+ * @param cert_cb User-supplied callback that setups the certificates.
+ * @param entropy_src_cb User-supplied callback that setup the entropy. This
  * can be set to NULL, in which case default entropy source is used.
  * @param pool Memory pool for RX data reads.
  * @param https_stack HTTPS thread stack.

--- a/include/net/net_app.h
+++ b/include/net/net_app.h
@@ -606,7 +606,7 @@ int net_app_listen(struct net_app_ctx *ctx);
  * given here. Note that the port number is optional in the string. If the
  * port number is not given in the string, then peer_port variable is used
  * instead.
- * Following syntex is supported for the address:
+ * Following syntax is supported for the address:
  *      192.0.2.1
  *      192.0.2.1:5353
  *      2001:db8::1
@@ -650,7 +650,7 @@ int net_app_init_client(struct net_app_ctx *ctx,
  * given here. Note that the port number is optional in the string. If the
  * port number is not given in the string, then peer_port variable is used
  * instead.
- * Following syntex is supported for the address:
+ * Following syntax is supported for the address:
  *      192.0.2.1
  *      192.0.2.1:5353
  *      2001:db8::1
@@ -703,7 +703,7 @@ static inline int net_app_init_tcp_client(struct net_app_ctx *ctx,
  * given here. Note that the port number is optional in the string. If the
  * port number is not given in the string, then peer_port variable is used
  * instead.
- * Following syntex is supported for the address:
+ * Following syntax is supported for the address:
  *      192.0.2.1
  *      192.0.2.1:5353
  *      2001:db8::1
@@ -868,13 +868,13 @@ int net_app_release(struct net_app_ctx *ctx);
  * @brief Initialize TLS support for this net_app client context.
  *
  * @param ctx net_app context.
- * @param request_buf Caller supplied buffer where the TLS request will be
+ * @param request_buf Caller-supplied buffer where the TLS request will be
  * stored
- * @param request_buf_len Length of the caller suppied buffer.
+ * @param request_buf_len Length of the caller-supplied buffer.
  * @param personalization_data Personalization data (Device specific
  * identifiers) for random number generator. (Can be NULL).
  * @param personalization_data_len Length of the personalization data.
- * @param cert_cb User supplied callback that setups the certifacates.
+ * @param cert_cb User-supplied callback that setups the certificates.
  * @param cert_host Hostname that is used to verify the server certificate.
  * This value is used when net_api API calls mbedtls_ssl_set_hostname()
  * which sets the hostname to check against the received server certificate.
@@ -882,7 +882,7 @@ int net_app_release(struct net_app_ctx *ctx);
  * This can be left NULL in which case mbedtls will silently skip certificate
  * verification entirely. This option is only used if MBEDTLS_X509_CRT_PARSE_C
  * is enabled in mbedtls config file.
- * @param entropy_src_cb User supplied callback that setup the entropy. This
+ * @param entropy_src_cb User-supplied callback that setup the entropy. This
  * can be set to NULL, in which case default entropy source is used.
  * @param pool Memory pool for RX data reads.
  * @param stack TLS thread stack.
@@ -908,17 +908,17 @@ int net_app_client_tls(struct net_app_ctx *ctx,
  * @brief Initialize TLS support for this net_app server context.
  *
  * @param ctx net_app context.
- * @param request_buf Caller supplied buffer where the TLS request will be
+ * @param request_buf Caller-supplied buffer where the TLS request will be
  * stored
- * @param request_buf_len Length of the caller suppied buffer.
+ * @param request_buf_len Length of the caller-supplied buffer.
  * @param server_banner Print information about started service. This is only
  * printed if net_app debugging is activated. The parameter can be set to NULL
  * if no extra prints are needed.
  * @param personalization_data Personalization data (Device specific
  * identifiers) for random number generator. (Can be NULL).
  * @param personalization_data_len Length of the personalization data.
- * @param cert_cb User supplied callback that setups the certifacates.
- * @param entropy_src_cb User supplied callback that setup the entropy. This
+ * @param cert_cb User-supplied callback that setups the certificates.
+ * @param entropy_src_cb User-supplied callback that setup the entropy. This
  * can be set to NULL, in which case default entropy source is used.
  * @param pool Memory pool for RX data reads.
  * @param stack TLS thread stack.

--- a/include/net/net_context.h
+++ b/include/net/net_context.h
@@ -573,7 +573,7 @@ int net_context_listen(struct net_context *context,
  *
  * @details          The net_context_connect function creates a network
  *                   connection to the host specified by addr. After the
- *                   connection is established, the user supplied callback (cb)
+ *                   connection is established, the user-supplied callback (cb)
  *                   is executed. cb is called even if the timeout was set to
  *                   K_FOREVER. cb is not called if the timeout expires.
  *                   For datagram sockets (SOCK_DGRAM), this function only sets
@@ -614,17 +614,17 @@ int net_context_connect(struct net_context *context,
  * If the timeout is set to K_FOREVER, the function will wait
  * until the connection is established. Timeout value > 0, will wait as
  * many ms.
- * After the connection is established a caller supplied callback is called.
+ * After the connection is established a caller-supplied callback is called.
  * The callback is called even if timeout was set to K_FOREVER, the
  * callback is called before this function will return in this case.
  * The callback is not called if the timeout expires.
  * This is similar as BSD accept() function.
  *
  * @param context The context to use.
- * @param cb Caller supplied callback function.
+ * @param cb Caller-supplied callback function.
  * @param timeout Timeout for the connection. Possible values
  * are K_FOREVER, K_NO_WAIT, >0.
- * @param user_data Caller supplied user data.
+ * @param user_data Caller-supplied user data.
  *
  * @return 0 if ok, < 0 if error
  */
@@ -641,7 +641,7 @@ int net_context_accept(struct net_context *context,
  * is set to K_NO_WAIT. If the timeout is set to K_FOREVER, the function
  * will wait until the network buffer is sent. Timeout value > 0 will
  * wait as many ms. After the network buffer is sent,
- * a caller supplied callback is called. The callback is called even
+ * a caller-supplied callback is called. The callback is called even
  * if timeout was set to K_FOREVER, the callback is called
  * before this function will return in this case. The callback is not
  * called if the timeout expires. For context of type SOCK_DGRAM,
@@ -650,11 +650,11 @@ int net_context_accept(struct net_context *context,
  * This is similar as BSD send() function.
  *
  * @param pkt The network buffer to send.
- * @param cb Caller supplied callback function.
+ * @param cb Caller-supplied callback function.
  * @param timeout Timeout for the connection. Possible values
  * are K_FOREVER, K_NO_WAIT, >0.
  * @param token Caller specified value that is passed as is to callback.
- * @param user_data Caller supplied user data.
+ * @param user_data Caller-supplied user data.
  *
  * @return 0 if ok, < 0 if error
  */
@@ -673,7 +673,7 @@ int net_context_send(struct net_pkt *pkt,
  * if the timeout is set to K_NO_WAIT. If the timeout is set to K_FOREVER,
  * the function will wait until the network buffer is sent. Timeout
  * value > 0 will wait as many ms. After the network buffer
- * is sent, a caller supplied callback is called. The callback is called
+ * is sent, a caller-supplied callback is called. The callback is called
  * even if timeout was set to K_FOREVER, the callback is called
  * before this function will return. The callback is not called if the
  * timeout expires.
@@ -683,11 +683,11 @@ int net_context_send(struct net_pkt *pkt,
  * @param dst_addr Destination address. This will override the address
  * already set in network buffer.
  * @param addrlen Length of the address.
- * @param cb Caller supplied callback function.
+ * @param cb Caller-supplied callback function.
  * @param timeout Timeout for the connection. Possible values
  * are K_FOREVER, K_NO_WAIT, >0.
  * @param token Caller specified value that is passed as is to callback.
- * @param user_data Caller supplied user data.
+ * @param user_data Caller-supplied user data.
  *
  * @return 0 if ok, < 0 if error
  */
@@ -712,7 +712,7 @@ int net_context_sendto(struct net_pkt *pkt,
  * This function will return immediately if the timeout is set to K_NO_WAIT.
  * If the timeout is set to K_FOREVER, the function will wait until the
  * network buffer is received. Timeout value > 0 will wait as many ms.
- * After the network buffer is received, a caller supplied callback is
+ * After the network buffer is received, a caller-supplied callback is
  * called. The callback is called even if timeout was set to K_FOREVER,
  * the callback is called before this function will return in this case.
  * The callback is not called if the timeout expires. The timeout functionality
@@ -728,10 +728,10 @@ int net_context_sendto(struct net_pkt *pkt,
  * a connection associated.
  *
  * @param context The network context to use.
- * @param cb Caller supplied callback function.
- * @param timeout Caller supplied timeout. Possible values
+ * @param cb Caller-supplied callback function.
+ * @param timeout Caller-supplied timeout. Possible values
  * are K_FOREVER, K_NO_WAIT, >0.
- * @param user_data Caller supplied user data.
+ * @param user_data Caller-supplied user data.
  *
  * @return 0 if ok, < 0 if error
  */
@@ -776,7 +776,7 @@ typedef void (*net_context_cb_t)(struct net_context *context, void *user_data);
  * @brief Go through all the network connections and call callback
  * for each network context.
  *
- * @param cb User supplied callback function to call.
+ * @param cb User-supplied callback function to call.
  * @param user_data User specified data.
  */
 void net_context_foreach(net_context_cb_t cb, void *user_data);

--- a/include/net/net_if.h
+++ b/include/net/net_if.h
@@ -1192,7 +1192,7 @@ typedef void (*net_if_cb_t)(struct net_if *iface, void *user_data);
  * @brief Go through all the network interfaces and call callback
  * for each interface.
  *
- * @param cb User supplied callback function to call
+ * @param cb User-supplied callback function to call
  * @param user_data User specified data
  */
 void net_if_foreach(net_if_cb_t cb, void *user_data);

--- a/include/net/net_offload.h
+++ b/include/net/net_offload.h
@@ -191,7 +191,7 @@ static inline int net_offload_listen(struct net_if *iface,
  *
  * @details          The net_context_connect function creates a network
  *                   connection to the host specified by addr. After the
- *                   connection is established, the user supplied callback (cb)
+ *                   connection is established, the user-supplied callback (cb)
  *                   is executed. cb is called even if the timeout was set to
  *                   K_FOREVER. cb is not called if the timeout expires.
  *                   For datagram sockets (SOCK_DGRAM), this function only sets
@@ -242,7 +242,7 @@ static inline int net_offload_connect(struct net_if *iface,
  * If the timeout is set to K_FOREVER, the function will wait
  * until the connection is established. Timeout value > 0, will wait as
  * many ms.
- * After the connection is established a caller supplied callback is called.
+ * After the connection is established a caller-supplied callback is called.
  * The callback is called even if timeout was set to K_FOREVER, the
  * callback is called before this function will return in this case.
  * The callback is not called if the timeout expires.
@@ -251,10 +251,10 @@ static inline int net_offload_connect(struct net_if *iface,
  * @param iface Network interface where the offloaded IP stack can be
  * reached.
  * @param context The context to use.
- * @param cb Caller supplied callback function.
+ * @param cb Caller-supplied callback function.
  * @param timeout Timeout for the connection. Possible values
  * are K_FOREVER, K_NO_WAIT, >0.
- * @param user_data Caller supplied user data.
+ * @param user_data Caller-supplied user data.
  *
  * @return 0 if ok, < 0 if error
  */
@@ -279,7 +279,7 @@ static inline int net_offload_accept(struct net_if *iface,
  * is set to K_NO_WAIT. If the timeout is set to K_FOREVER, the function
  * will wait until the network packet is sent. Timeout value > 0 will
  * wait as many ms. After the network packet is sent,
- * a caller supplied callback is called. The callback is called even
+ * a caller-supplied callback is called. The callback is called even
  * if timeout was set to K_FOREVER, the callback is called
  * before this function will return in this case. The callback is not
  * called if the timeout expires. For context of type SOCK_DGRAM,
@@ -290,11 +290,11 @@ static inline int net_offload_accept(struct net_if *iface,
  * @param iface Network interface where the offloaded IP stack can be
  * reached.
  * @param pkt The network packet to send.
- * @param cb Caller supplied callback function.
+ * @param cb Caller-supplied callback function.
  * @param timeout Timeout for the connection. Possible values
  * are K_FOREVER, K_NO_WAIT, >0.
  * @param token Caller specified value that is passed as is to callback.
- * @param user_data Caller supplied user data.
+ * @param user_data Caller-supplied user data.
  *
  * @return 0 if ok, < 0 if error
  */
@@ -321,7 +321,7 @@ static inline int net_offload_send(struct net_if *iface,
  * if the timeout is set to K_NO_WAIT. If the timeout is set to K_FOREVER,
  * the function will wait until the network packet is sent. Timeout
  * value > 0 will wait as many ms. After the network packet
- * is sent, a caller supplied callback is called. The callback is called
+ * is sent, a caller-supplied callback is called. The callback is called
  * even if timeout was set to K_FOREVER, the callback is called
  * before this function will return. The callback is not called if the
  * timeout expires.
@@ -333,11 +333,11 @@ static inline int net_offload_send(struct net_if *iface,
  * @param dst_addr Destination address. This will override the address
  * already set in network packet.
  * @param addrlen Length of the address.
- * @param cb Caller supplied callback function.
+ * @param cb Caller-supplied callback function.
  * @param timeout Timeout for the connection. Possible values
  * are K_FOREVER, K_NO_WAIT, >0.
  * @param token Caller specified value that is passed as is to callback.
- * @param user_data Caller supplied user data.
+ * @param user_data Caller-supplied user data.
  *
  * @return 0 if ok, < 0 if error
  */
@@ -371,7 +371,7 @@ static inline int net_offload_sendto(struct net_if *iface,
  * This function will return immediately if the timeout is set to K_NO_WAIT.
  * If the timeout is set to K_FOREVER, the function will wait until the
  * network packet is received. Timeout value > 0 will wait as many ms.
- * After the network packet is received, a caller supplied callback is
+ * After the network packet is received, a caller-supplied callback is
  * called. The callback is called even if timeout was set to K_FOREVER,
  * the callback is called before this function will return in this case.
  * The callback is not called if the timeout expires. The timeout functionality
@@ -384,10 +384,10 @@ static inline int net_offload_sendto(struct net_if *iface,
  * @param iface Network interface where the offloaded IP stack can be
  * reached.
  * @param context The network context to use.
- * @param cb Caller supplied callback function.
- * @param timeout Caller supplied timeout. Possible values
+ * @param cb Caller-supplied callback function.
+ * @param timeout Caller-supplied timeout. Possible values
  * are K_FOREVER, K_NO_WAIT, >0.
- * @param user_data Caller supplied user data.
+ * @param user_data Caller-supplied user data.
  *
  * @return 0 if ok, < 0 if error
  */

--- a/include/spi.h
+++ b/include/spi.h
@@ -59,7 +59,7 @@ extern "C" {
 /**
  * Clock Phase: this dictates when is the data captured, and depends
  * clock's polarity. When SPI_MODE_CPOL is set and this bit as well,
- * capture will occure on low to high transition and high to low if
+ * capture will occur on low to high transition and high to low if
  * this bit is not set (default). This is fully reversed if CPOL is
  * not set.
  */
@@ -152,10 +152,10 @@ struct spi_cs_control {
  *    word_size           [ 5 : 10 ]  - Size of a data frame in bits.
  *    lines               [ 11 : 12 ] - MISO lines: Single/Dual/Quad.
  *    cs_hold             [ 13 ]      - Hold on the CS line if possible.
- *    lock_on             [ 14 ]      - Keep ressource locked for the caller.
+ *    lock_on             [ 14 ]      - Keep resource locked for the caller.
  *    eeprom              [ 15 ]      - EEPROM mode.
  * vendor is a vendor specific bitfield
- * slave is the slave number from 0 to host constoller slave limit.
+ * slave is the slave number from 0 to host controller slave limit.
  *
  * cs is a valid pointer on a struct spi_cs_control is CS line is
  *    emulated through a gpio line, or NULL otherwise.


### PR DESCRIPTION
Fix misspellings in .h files missed during code reviews
and affecting generated API documentation

Signed-off-by: David B. Kinder <david.b.kinder@intel.com>