### PR TITLE
test: spi: Define asynchronous stack with K_THREAD_STACK_DEFINE.

### DIFF
--- a/tests/drivers/spi/spi_loopback/src/spi.c
+++ b/tests/drivers/spi/spi_loopback/src/spi.c
@@ -330,7 +330,7 @@ static struct k_poll_event async_evt =
 				 K_POLL_MODE_NOTIFY_ONLY,
 				 &async_sig);
 static K_SEM_DEFINE(caller, 0, 1);
-static char __noinit spi_async_stack[256];
+K_THREAD_STACK_DEFINE(spi_async_stack, 256);
 static int result = 1;
 
 static void spi_async_call_cb(struct k_poll_event *async_evt,


### PR DESCRIPTION
Previous stack definition caused following warning: passing argument 2
of 'k_thread_create' from incompatible pointer type.

Signed-off-by: Michał Kruszewski <michal.kruszewski@nordicsemi.no>