### PR TITLE
dts: arm: st: Correct pin assignment of node usart1@0

### DIFF
--- a/dts/arm/st/stm32f4-pinctrl.dtsi
+++ b/dts/arm/st/stm32f4-pinctrl.dtsi
@@ -11,8 +11,8 @@
 		pinctrl: pin-controller {
 			usart1_pins_a: usart1@0 {
 				rx_tx {
-					rx = <STM32_PIN_PB6 (STM32_PINMUX_ALT_FUNC_7 | STM32_PUPDR_NO_PULL)>;
-					tx = <STM32_PIN_PB7 (STM32_PINMUX_ALT_FUNC_7 | STM32_PUSHPULL_NOPULL)>;
+					rx = <STM32_PIN_PB7 (STM32_PINMUX_ALT_FUNC_7 | STM32_PUPDR_NO_PULL)>;
+					tx = <STM32_PIN_PB6 (STM32_PINMUX_ALT_FUNC_7 | STM32_PUSHPULL_NOPULL)>;
 				};
 			};
 			usart1_pins_b: usart1@1 {

--- a/dts/arm/st/stm32l4-pinctrl.dtsi
+++ b/dts/arm/st/stm32l4-pinctrl.dtsi
@@ -11,8 +11,8 @@
 		pinctrl: pin-controller {
 			usart1_pins_a: usart1@0 {
 				rx_tx {
-					rx = <STM32_PIN_PB6 (STM32_PINMUX_ALT_FUNC_7 | STM32_PUPDR_NO_PULL)>;
-					tx = <STM32_PIN_PB7 (STM32_PINMUX_ALT_FUNC_7 | STM32_PUSHPULL_NOPULL)>;
+					rx = <STM32_PIN_PB7 (STM32_PINMUX_ALT_FUNC_7 | STM32_PUPDR_NO_PULL)>;
+					tx = <STM32_PIN_PB6 (STM32_PINMUX_ALT_FUNC_7 | STM32_PUSHPULL_NOPULL)>;
 				};
 			};
 			usart1_pins_b: usart1@1 {


### PR DESCRIPTION
Corrects pin assignment for node usart1@0. PB6 is TX
and PB7 is RX.

Signed-off-by: Yannis Damigos <giannis.damigos@gmail.com>