### PR TITLE
ztest: reduce MAIN_STACK_SIZE stack to 512 bytes

### DIFF
--- a/kernel/Kconfig
+++ b/kernel/Kconfig
@@ -104,6 +104,7 @@ config MAIN_STACK_SIZE
 	int
 	prompt "Size of stack for initialization and main thread"
 	default 1024
+	default 512 if ZTEST
 	help
 	When the initialization is complete, the thread executing it then
 	executes the main() routine, so as to reuse the stack used by the


### PR DESCRIPTION
Save some memory for small memory systems when running ztests.  We have
our own stack in ztest so we should be able to get away reducing down
the main stack.

Signed-off-by: Kumar Gala <kumar.gala@linaro.org>