### PR TITLE
net: http: fix http client request "Host" header

### DIFF
--- a/subsys/net/lib/http/http_client.c
+++ b/subsys/net/lib/http/http_client.c
@@ -45,6 +45,7 @@
 /* HTTP client defines */
 #define HTTP_EOF           "\r\n\r\n"
 
+#define HTTP_HOST          "Host: "
 #define HTTP_CONTENT_TYPE  "Content-Type: "
 #define HTTP_CONT_LEN_SIZE 64
 
@@ -87,6 +88,11 @@ int http_request(struct http_client_ctx *ctx,
 	}
 
 	if (req->host) {
+		if (!net_pkt_append_all(pkt, strlen(HTTP_HOST),
+					(u8_t *)HTTP_HOST, timeout)) {
+			goto out;
+		}
+
 		if (!net_pkt_append_all(pkt, strlen(req->host),
 					(u8_t *)req->host, timeout)) {
 			goto out;


### PR DESCRIPTION
RFC-7230 "HTTP/1.1 Message Syntax and Routing" Section 5.4
describes the "Host" header formatting.  If Zephyr user
specifies a host string as a part of the HTTP client request
structure, we end up sending an incorrect HTTP header due
to a missing "Host :" text.

Fix this by prepending "Host: " to the header data before
the user supplied host string.

Signed-off-by: Michael Scott <michael.scott@linaro.org>