### PR TITLE
net: lwm2m: use JSON writer to handle LINK_FORMAT requests

### DIFF
--- a/subsys/net/lib/lwm2m/lwm2m_engine.c
+++ b/subsys/net/lib/lwm2m/lwm2m_engine.c
@@ -649,6 +649,7 @@ static u16_t select_writer(struct lwm2m_output_context *out, u16_t accept)
 		break;
 
 #ifdef CONFIG_LWM2M_RW_JSON_SUPPORT
+	case LWM2M_FORMAT_APP_LINK_FORMAT:
 	case LWM2M_FORMAT_OMA_JSON:
 	case LWM2M_FORMAT_OMA_OLD_JSON:
 		out->writer = &json_writer;


### PR DESCRIPTION
When sending a DISCOVER operation to LwM2M client an error is
generated: "Unknown Accept type 40, using LWM2M plain text"

This is because we are not handling LWM2M_FORMAT_APP_LINK_FORMAT
accept type in select_writer().  The output formatting for this
kind of request is JSON, so let's add it there.

Signed-off-by: Michael Scott <michael.scott@linaro.org>