### PR TITLE
ext: simplelink: host driver: depend on multithreading

### DIFF
--- a/ext/hal/ti/simplelink/Kconfig
+++ b/ext/hal/ti/simplelink/Kconfig
@@ -8,6 +8,7 @@ config SIMPLELINK_HOST_DRIVER
 	bool "Build the SimpleLink WiFi Host Driver"
 	default n
 	depends on HAS_CC3220SDK
+	depends on MULTITHREADING
 	select NEWLIB_LIBC
 	help
 	Build the SimpleLink host driver


### PR DESCRIPTION
Only build the simplelink host driver if we have networking enabled.

Signed-off-by: Kumar Gala <kumar.gala@linaro.org>