### PR TITLE
scripts: Run JLinkGDBServer in silent mode

### DIFF
--- a/scripts/support/jlink.sh
+++ b/scripts/support/jlink.sh
@@ -51,6 +51,7 @@ do_debugserver() {
 	-port ${GDB_PORT} \
 	-if ${JLINK_IF} \
 	-device ${JLINK_DEVICE} \
+	-silent \
 	-singlerun
 }
 


### PR DESCRIPTION
The JLinkGDBServer was printing log messages that messed with debugging
in -tui mode. Run it in silent mode instead.

Signed-off-by: Maureen Helm <maureen.helm@nxp.com>