### PR TITLE
tests: json: only build if newlib isn't configured

### DIFF
--- a/tests/lib/json/testcase.yaml
+++ b/tests/lib/json/testcase.yaml
@@ -1,5 +1,6 @@
 tests:
 -   test:
         build_only: true
+        filter: not CONFIG_NEWLIB_LIBC
         min_ram: 32
         tags: json


### PR DESCRIPTION
Right now we have various type conflicts between the json library and
newlib.  Until these are resolved only build the json test if newlib
isn't enabled.

This fixes #1092.

Signed-off-by: Kumar Gala <kumar.gala@linaro.org>