### PR TITLE
dts: arm: nrf52_blenano2: add flash partitions

### DIFF
--- a/dts/arm/nrf52_blenano2.dts
+++ b/dts/arm/nrf52_blenano2.dts
@@ -24,3 +24,43 @@
 	current-speed = <115200>;
 	status = "ok";
 };
+
+&flash0 {
+	/*
+	 * If chosen's zephyr,code-partition
+	 * is unset, the image will be linked
+	 * into the entire flash device.  If
+	 * it points to an individual
+	 * partition, the code will be linked
+	 * to, and restricted to that
+	 * partition.
+	 */
+	partitions {
+		compatible = "fixed-partitions";
+		#address-cells = <1>;
+		#size-cells = <1>;
+
+		boot_partition: partition@0 {
+			label = "mcuboot";
+			reg = <0x00000000 0x8000>;
+		};
+		slot0_partition: partition@8000 {
+			label = "image-0";
+			reg = <0x00008000 0x34000>;
+		};
+		slot1_partition: partition@3c000 {
+			label = "image-1";
+			reg = <0x0003c000 0x34000>;
+		};
+		scratch_partition: partition@70000 {
+			label = "image-scratch";
+			reg = <0x00070000 0xD000>;
+		};
+
+		/*
+		 * The flash starting at 0x0007d000 and ending at
+		 * 0x0007ffff (sectors 125-127) is reserved for use
+		 * by the application.
+		 */
+	};
+};


### PR DESCRIPTION
Add flash partitions dts node for single bank OTAs.

Signed-off-by: Tyler Baker <tyler.baker@linaro.org>