### PR TITLE
Bluetooth: Use higher RX_BUF_LEN when Mesh Proxy protocol is used

### DIFF
--- a/subsys/bluetooth/host/Kconfig
+++ b/subsys/bluetooth/host/Kconfig
@@ -35,6 +35,7 @@ config BT_RX_BUF_COUNT
 config BT_RX_BUF_LEN
 	int "Maximum supported HCI RX buffer length"
 	default 76
+	default 77 if BT_MESH_PROXY
 	default 264 if BT_BREDR
 	range 73 2000
 	help


### PR DESCRIPTION
Avoiding segmentation in the GATT-based Mesh Proxy protocol requires
having an RX buffer length of at least 77. We could round it up to 80
since there's otherwise wasted space, however there's also
BT_HCI_RESERVE to consider, so to avoid pushing over the 4-byte
boundary for certain HCI drivers just leave the size at 77.

Signed-off-by: Johan Hedberg <johan.hedberg@intel.com>