### PR TITLE
ci: retry sanitycheck without --subset arg

### DIFF
--- a/.shippable.yml
+++ b/.shippable.yml
@@ -70,13 +70,13 @@ build:
           ./scripts/ci/get_modified_tests.py --commits origin/${PULL_REQUEST_BASE_BRANCH}..HEAD > modified_tests.args;
 
           if [ -s modified_tests.args ]; then
-            ./scripts/sanitycheck --subset ${MATRIX_BUILD}/${MATRIX_BUILDS_EXTRA} +modified_tests.args;
+            ./scripts/sanitycheck --subset ${MATRIX_BUILD}/${MATRIX_BUILDS_EXTRA} +modified_tests.args ./scripts/sanitycheck || +modified_tests.args --only-failed
             cp ./scripts/sanity_chk/last_sanity.xml modified_tests.xml;
           fi;
           rm -f modified_tests.args;
       - >
           if [ "$MATRIX_BUILD" != "3" ]; then
-          	./scripts/sanitycheck ${PLATFORMS} --subset ${MATRIX_BUILD}/${MATRIX_BUILDS} ${COVERAGE} ${SANITYCHECK_OPTIONS} || ./scripts/sanitycheck ${PLATFORMS} --subset ${MATRIX_BUILD}/${MATRIX_BUILDS}  ${COVERAGE} ${SANITYCHECK_OPTIONS_RETRY};
+             ./scripts/sanitycheck ${PLATFORMS} --subset ${MATRIX_BUILD}/${MATRIX_BUILDS} ${COVERAGE} ${SANITYCHECK_OPTIONS} || ./scripts/sanitycheck ${PLATFORMS} ${COVERAGE} ${SANITYCHECK_OPTIONS_RETRY} || ./scripts/sanitycheck ${PLATFORMS} ${COVERAGE} ${SANITYCHECK_OPTIONS_RETRY}
           fi;
       - ccache -s
     on_failure:


### PR DESCRIPTION
When retrying sanitycheck with --only-failed, do not use --subset
argument which can reduce the number of tests to be run (failed tests)
to 0.