### PR TITLE
quark_d2000: fix IDT_LIST definition

### DIFF
--- a/arch/x86/soc/intel_quark/quark_d2000/linker.ld
+++ b/arch/x86/soc/intel_quark/quark_d2000/linker.ld
@@ -49,7 +49,7 @@ MEMORY
      * target. However, it shouldn't overlap any other regions.
      */
 
-    IDT_LIST        : ORIGIN = 512, LENGTH = 512
+    IDT_LIST        : ORIGIN = 0, LENGTH = 2K
     }
 
 #include <arch/x86/linker.ld>


### PR DESCRIPTION
This should be the same size as other x86 boards.

Signed-off-by: Andrew Boie <andrew.p.boie@intel.com>