### PR TITLE
esp32: fix linker script issues

### DIFF
--- a/arch/xtensa/soc/esp32/linker.ld
+++ b/arch/xtensa/soc/esp32/linker.ld
@@ -141,25 +141,26 @@ SECTIONS
     _iram_text_start = ABSOLUTE(.);
     *(.iram1 .iram1.*)
     *(.iram0.literal .iram.literal .iram.text.literal .iram0.text .iram.text)
-    *libhal.a:(.literal .text .literal.* .text.*)
+    *(.literal .text .literal.* .text.*)
     _iram_text_end = ABSOLUTE(.);
   } GROUP_LINK_IN(ROMABLE_REGION)
 
   .dram0.data :
   {
     _data_start = ABSOLUTE(.);
-    KEEP(*(.data))
-    KEEP(*(.data.*))
-    KEEP(*(.gnu.linkonce.d.*))
-    KEEP(*(.data1))
-    KEEP(*(.sdata))
-    KEEP(*(.sdata.*))
-    KEEP(*(.gnu.linkonce.s.*))
-    KEEP(*(.sdata2))
-    KEEP(*(.sdata2.*))
-    KEEP(*(.gnu.linkonce.s2.*))
+    *(.data)
+    *(.data.*)
+    *(.gnu.linkonce.d.*)
+    *(.data1)
+    *(.sdata)
+    *(.sdata.*)
+    *(.gnu.linkonce.s.*)
+    *(.sdata2)
+    *(.sdata2.*)
+    *(.gnu.linkonce.s2.*)
     KEEP(*(.jcr))
     *(.dram1 .dram1.*)
+    KEEP(*(SW_ISR_TABLE))
     _data_end = ABSOLUTE(.);
     . = ALIGN(4);
   } GROUP_LINK_IN(RAMABLE_REGION)
@@ -220,6 +221,14 @@ SECTIONS
     *(COMMON)
     . = ALIGN (8);
     _bss_end = ABSOLUTE(.);
+  } GROUP_LINK_IN(RAMABLE_REGION)
+
+  SECTION_DATA_PROLOGUE(_NOINIT_SECTION_NAME, (NOLOAD),)
+  {
+    . = ALIGN (8);
+    *(.noinit)
+    *(".noinit.*")
+    . = ALIGN (8);
     _heap_start = ABSOLUTE(.);
   } GROUP_LINK_IN(RAMABLE_REGION)
 


### PR DESCRIPTION
- .text, .text.*, .literal, .literal.* had no matching input section
   rule and were being passed to the output binary verbatim. These
   are all now in the output "text" section as intended.

- various rules in the data section were unnecessarily using KEEP().

- SW_ISR_TABLE wasn't included in linker script anywhere and was
  ending up in its own section, and not the data section as intended.

- noinit section didn't exist at all, now defined.

Issue: ZEP-2508
Signed-off-by: Andrew Boie <andrew.p.boie@intel.com>