### PR TITLE
ci: boards: retry sanitycheck without --subset arg

### DIFF
--- a/.shippable.yml
+++ b/.shippable.yml
@@ -71,7 +71,7 @@ build:
           ./scripts/ci/get_modified_boards.py --commits origin/${PULL_REQUEST_BASE_BRANCH}..HEAD > modified_boards.args;
 
           if [ -s modified_boards.args ]; then
-            ./scripts/sanitycheck --subset ${MATRIX_BUILD}/${MATRIX_BUILDS_EXTRA} +modified_boards.args || ./scripts/sanitycheck --subset ${MATRIX_BUILD}/${MATRIX_BUILDS_EXTRA} +modified_boards.args --only-failed;
+            ./scripts/sanitycheck --subset ${MATRIX_BUILD}/${MATRIX_BUILDS_EXTRA} +modified_boards.args || ./scripts/sanitycheck +modified_boards.args --only-failed;
             cp ./scripts/sanity_chk/last_sanity.xml modified_boards.xml;
           fi;
           if [ -s modified_tests.args ]; then


### PR DESCRIPTION
Do not use --subset on failed tests, run them all on the same host.