### PR TITLE
Fixes for XCC compiler

### DIFF
--- a/arch/xtensa/soc/sample_controller/linker.ld
+++ b/arch/xtensa/soc/sample_controller/linker.ld
@@ -519,13 +519,7 @@ SECTIONS
     _data_start = ABSOLUTE(.);
     *(.data)
     *(.data.*)
-	KEEP(*(.isr_irq*))
-	/* sections for IRQ0-9 */
-	KEEP(*(SORT(.gnu.linkonce.d.isr_irq[0-9])))
-	/* sections for IRQ10-99 */
-	KEEP(*(SORT(.gnu.linkonce.d.isr_irq[0-9][0-9])))
-	/* sections for IRQ100-999 */
-	KEEP(*(SORT(.gnu.linkonce.d.isr_irq[0-9][0-9][0-9])))
+    KEEP(*(SW_ISR_TABLE))
     *(.gnu.linkonce.d.*)
     KEEP(*(.gnu.linkonce.d.*personality*))
     *(.data1)

--- a/include/debug/object_tracing_common.h
+++ b/include/debug/object_tracing_common.h
@@ -99,7 +99,7 @@
 
 struct ring_buf;
 
-struct ring_buf   *_trace_list_sys_ring_buf;
+extern struct ring_buf   *_trace_list_sys_ring_buf;
 
 #endif  /*CONFIG_OBJECT_TRACING*/
 #endif  /*_OBJECT_TRACING_COMMON_H_*/

--- a/include/irq.h
+++ b/include/irq.h
@@ -15,7 +15,7 @@
 #include <arch/cpu.h>
 
 #ifndef _ASMLANGUAGE
-#include <toolchain/gcc.h>
+#include <toolchain.h>
 
 #ifdef __cplusplus
 extern "C" {

--- a/include/toolchain/xcc.h
+++ b/include/toolchain/xcc.h
@@ -9,6 +9,13 @@
 
 #include <toolchain/gcc.h>
 
+/* XCC doesn't support __COUNTER__ but this should be good enough */
+#define __COUNTER__ __LINE__
+
+#undef __in_section_unique
+#define __in_section_unique(seg) \
+	__attribute__((section("." STRINGIFY(seg) "." STRINGIFY(__COUNTER__))))
+
 #ifndef __GCC_LINKER_CMD__
 #include <xtensa/config/core.h>
 

--- a/samples/cpp_synchronization/src/main.cpp
+++ b/samples/cpp_synchronization/src/main.cpp
@@ -133,7 +133,7 @@ void coop_thread_entry(void)
 	}
 }
 
-void main(void)
+int main(void)
 {
 	struct k_timer timer;
 

--- a/subsys/net/ip/net_context.c
+++ b/subsys/net/ip/net_context.c
@@ -34,6 +34,13 @@
 #include "tcp.h"
 #include "net_stats.h"
 
+#ifndef EPFNOSUPPORT
+/* Some old versions of newlib haven't got this defined in errno.h,
+ * Just use EPROTONOSUPPORT in this case
+ */
+#define EPFNOSUPPORT EPROTONOSUPPORT
+#endif
+
 #define NET_MAX_CONTEXT CONFIG_NET_MAX_CONTEXTS
 
 #if defined(CONFIG_NET_TCP_ACK_TIMEOUT)

--- a/subsys/net/ip/net_mgmt.c
+++ b/subsys/net/ip/net_mgmt.c
@@ -200,6 +200,7 @@ static int mgmt_event_wait_call(struct net_if *iface,
 				struct net_if **event_iface,
 				int timeout)
 {
+#ifndef __XCC__
 	struct mgmt_event_wait sync_data = {
 		.sync_call = _K_SEM_INITIALIZER(sync_data.sync_call, 0, 1),
 	};
@@ -207,8 +208,16 @@ static int mgmt_event_wait_call(struct net_if *iface,
 		.sync_call = &sync_data.sync_call,
 		.event_mask = mgmt_event_mask | NET_MGMT_SYNC_EVENT_BIT,
 	};
+#endif
 	int ret;
+#ifdef __XCC__
+	struct mgmt_event_wait sync_data = {};
+	struct net_mgmt_event_callback sync = {};
 
+	k_sem_init(&sync_data.sync_call, 0, 1);
+	sync.sync_call = &sync_data.sync_call;
+	sync.event_mask = mgmt_event_mask | NET_MGMT_SYNC_EVENT_BIT;
+#endif
 	if (iface) {
 		sync_data.iface = iface;
 	}

--- a/subsys/net/ip/rpl.c
+++ b/subsys/net/ip/rpl.c
@@ -140,7 +140,7 @@ static void remove_parents(struct net_if *iface,
 			   struct net_rpl_dag *dag,
 			   u16_t minimum_rank);
 
-static void net_rpl_schedule_dao_now(struct net_rpl_instance *instance);
+static inline void net_rpl_schedule_dao_now(struct net_rpl_instance *instance);
 static void net_rpl_local_repair(struct net_if *iface,
 				 struct net_rpl_instance *instance);
 

--- a/subsys/net/ip/rpl.c
+++ b/subsys/net/ip/rpl.c
@@ -2782,7 +2782,7 @@ static void net_rpl_process_dio(struct net_if *iface,
 
 static enum net_verdict handle_dio(struct net_pkt *pkt)
 {
-	struct net_rpl_dio dio = { 0 };
+	struct net_rpl_dio dio = { };
 	struct net_buf *frag;
 	struct net_nbr *nbr;
 	u16_t offset, pos;

--- a/subsys/net/ip/tcp.c
+++ b/subsys/net/ip/tcp.c
@@ -641,7 +641,7 @@ int net_tcp_prepare_reset(struct net_tcp *tcp,
 	return 0;
 }
 
-const char * const net_tcp_state_str(enum net_tcp_state state)
+const char *net_tcp_state_str(enum net_tcp_state state)
 {
 #if defined(CONFIG_NET_DEBUG_TCP)
 	switch (state) {

--- a/subsys/net/ip/tcp.h
+++ b/subsys/net/ip/tcp.h
@@ -215,7 +215,7 @@ static inline u32_t tcp_init_isn(void)
 	return sys_rand32_get();
 }
 
-const char * const net_tcp_state_str(enum net_tcp_state state);
+const char *net_tcp_state_str(enum net_tcp_state state);
 
 #if defined(CONFIG_NET_TCP)
 void net_tcp_change_state(struct net_tcp *tcp, enum net_tcp_state new_state);

--- a/subsys/net/ip/tcp.h
+++ b/subsys/net/ip/tcp.h
@@ -419,11 +419,40 @@ struct net_buf *net_tcp_set_chksum(struct net_pkt *pkt, struct net_buf *frag);
  * @return Return the checksum in host byte order.
  */
 u16_t net_tcp_get_chksum(struct net_pkt *pkt, struct net_buf *frag);
+
 #else
-#define net_tcp_get_chksum(pkt, frag) (0)
-#define net_tcp_set_chksum(pkt, frag) NULL
-#define net_tcp_set_hdr(pkt, frag) NULL
-#define net_tcp_get_hdr(pkt, frag) NULL
+
+static inline u16_t net_tcp_get_chksum(struct net_pkt *pkt,
+				       struct net_buf *frag)
+{
+	ARG_UNUSED(pkt);
+	ARG_UNUSED(frag);
+	return 0;
+}
+
+static inline struct net_buf *net_tcp_set_chksum(struct net_pkt *pkt,
+						 struct net_buf *frag)
+{
+	ARG_UNUSED(pkt);
+	ARG_UNUSED(frag);
+	return NULL;
+}
+
+static inline struct net_tcp_hdr *net_tcp_get_hdr(struct net_pkt *pkt,
+						  struct net_tcp_hdr *hdr)
+{
+	ARG_UNUSED(pkt);
+	ARG_UNUSED(hdr);
+	return NULL;
+}
+
+static inline struct net_tcp_hdr *net_tcp_set_hdr(struct net_pkt *pkt,
+						  struct net_tcp_hdr *hdr)
+{
+	ARG_UNUSED(pkt);
+	ARG_UNUSED(hdr);
+	return NULL;
+}
 #endif
 
 #if defined(CONFIG_NET_TCP)

--- a/subsys/net/ip/tcp.h
+++ b/subsys/net/ip/tcp.h
@@ -209,7 +209,7 @@ static inline int net_tcp_unregister(struct net_conn_handle *handle)
  *
  * @return Return a random TCP sequence number
  */
-inline u32_t tcp_init_isn(void)
+static inline u32_t tcp_init_isn(void)
 {
 	/* Randomise initial seq number */
 	return sys_rand32_get();

--- a/subsys/net/lib/dns/resolve.c
+++ b/subsys/net/lib/dns/resolve.c
@@ -550,7 +550,7 @@ static void cb_recv(struct net_context *net_ctx,
 		    void *user_data)
 {
 	struct dns_resolve_context *ctx = user_data;
-	struct dns_addrinfo info = { 0 };
+	struct dns_addrinfo info = { };
 	struct net_buf *dns_cname = NULL;
 	struct net_buf *dns_data = NULL;
 	u16_t dns_id = 0;

--- a/tests/kernel/threads/scheduling/schedule_api/src/test_priority_scheduling.c
+++ b/tests/kernel/threads/scheduling/schedule_api/src/test_priority_scheduling.c
@@ -19,13 +19,13 @@
 static K_THREAD_STACK_ARRAY_DEFINE(tstack, NUM_THREAD, STACK_SIZE);
 
 /* Semaphore on which Ztest thread wait*/
-K_SEM_DEFINE(sema2, 0, NUM_THREAD);
+static K_SEM_DEFINE(sema2, 0, NUM_THREAD);
 
 /* Semaphore on which application threads wait*/
-K_SEM_DEFINE(sema3, 0, NUM_THREAD);
+static K_SEM_DEFINE(sema3, 0, NUM_THREAD);
 
 static int thread_idx;
-struct k_thread t[NUM_THREAD];
+static struct k_thread t[NUM_THREAD];
 
 /* Application thread */
 static void thread_tslice(void *p1, void *p2, void *p3)

--- a/tests/kernel/threads/scheduling/schedule_api/src/test_slice_scheduling.c
+++ b/tests/kernel/threads/scheduling/schedule_api/src/test_slice_scheduling.c
@@ -6,7 +6,7 @@
 
 #include <ztest.h>
 
-#define STACK_SIZE 256
+#define STACK_SIZE (256 + CONFIG_TEST_EXTRA_STACKSIZE)
 /* nrf 51 has lower ram, so creating less number of threads */
 #if defined(CONFIG_SOC_SERIES_NRF51X) || defined(CONFIG_SOC_SERIES_STM32F3X)
 	#define NUM_THREAD 3

--- a/tests/kernel/threads/scheduling/schedule_api/src/test_slice_scheduling.c
+++ b/tests/kernel/threads/scheduling/schedule_api/src/test_slice_scheduling.c
@@ -20,9 +20,9 @@ static K_THREAD_STACK_ARRAY_DEFINE(tstack, NUM_THREAD, STACK_SIZE);
 #define SLICE_SIZE 200
 /* busy for more than one slice*/
 #define BUSY_MS (SLICE_SIZE + 20)
-struct k_thread t[NUM_THREAD];
+static struct k_thread t[NUM_THREAD];
 
-K_SEM_DEFINE(sema1, 0, NUM_THREAD);
+static K_SEM_DEFINE(sema1, 0, NUM_THREAD);
 /*elapsed_slice taken by last thread*/
 static s64_t elapsed_slice;
 
@@ -35,14 +35,14 @@ static void thread_tslice(void *p1, void *p2, void *p3)
 								((int)p1 + 'A');
 
 	while (1) {
-		s64_t t = k_uptime_delta(&elapsed_slice);
+		s64_t tdelta = k_uptime_delta(&elapsed_slice);
 
 		TC_PRINT("%c", thread_parameter);
 		/* Test Fails if thread exceed allocated time slice or
 		 * Any thread is scheduled out of order.
 		 */
-		zassert_true(((t <= SLICE_SIZE) && ((int)p1 == thread_idx)),
-				NULL);
+		zassert_true(((tdelta <= SLICE_SIZE) &&
+			      ((int)p1 == thread_idx)), NULL);
 		thread_idx = (thread_idx+1) % (NUM_THREAD);
 		u32_t t32 = k_uptime_get_32();
 


### PR DESCRIPTION
This patch series fixes numerous issues preventing compilation of Zephyr from succeeding with the Cadence XCC toolchain.