### PR TITLE
net: sockets: Move under "Network Application Support" heading

### DIFF
--- a/subsys/net/lib/Kconfig
+++ b/subsys/net/lib/Kconfig
@@ -6,8 +6,6 @@
 
 menu "Network Protocols"
 
-source "subsys/net/lib/sockets/Kconfig"
-
 source "subsys/net/lib/zoap/Kconfig"
 
 source "subsys/net/lib/dns/Kconfig"
@@ -20,8 +18,10 @@ source "subsys/net/lib/lwm2m/Kconfig"
 
 endmenu
 
-menu "Network Applications"
+menu "Network Application Support"
 
 source "subsys/net/lib/app/Kconfig"
+
+source "subsys/net/lib/sockets/Kconfig"
 
 endmenu


### PR DESCRIPTION
"Network Application Support" itself is renamed from "Network
Applications" and also includes net_app API.

Signed-off-by: Paul Sokolovsky <paul.sokolovsky@linaro.org>