### PR TITLE
subsys: bluetooth: shell: gatt_read: Reset offset to 0

### DIFF
--- a/subsys/bluetooth/shell/gatt.c
+++ b/subsys/bluetooth/shell/gatt.c
@@ -235,6 +235,7 @@ int cmd_gatt_read(int argc, char *argv[])
 
 	read_params.handle_count = 1;
 	read_params.single.handle = strtoul(argv[1], NULL, 16);
+	read_params.single.offset = 0;
 
 	if (argc > 2) {
 		read_params.single.offset = strtoul(argv[2], NULL, 16);


### PR DESCRIPTION
Unless offset was specified, it should default to 0, whereas
previously, value from the last command was used.

Signed-off-by: Paul Sokolovsky <paul.sokolovsky@linaro.org>