### PR TITLE
doc: Clarify the Bluetooth 5.0 support in 1.9

### DIFF
--- a/doc/release-notes-1.9.rst
+++ b/doc/release-notes-1.9.rst
@@ -14,7 +14,7 @@ Major enhancements planned with this release include:
 * BSD Socket Support
 * Expand Device Tree support to more architectures
 * BLE Mesh
-* Full Bluetooth 5.0 Support
+* Bluetooth 5.0 Support (all features except Advertising Extensions)
 * Expand LLVM Support to more architectures
 * Revamp Testsuite, Increase Coverage
 * Zephyr SDK NG


### PR DESCRIPTION
Since Advertising Extensions are not supported yet by Zephyr, clarify
the extend of Bluetooth 5.0 support in the subsystem.

Signed-off-by: Carles Cufi <carles.cufi@nordicsemi.no>