### PR TITLE
arm: nrf: Fix I2C_0_DEFAULT_CFG settings

### DIFF
--- a/boards/arm/bbc_microbit/Kconfig.defconfig
+++ b/boards/arm/bbc_microbit/Kconfig.defconfig
@@ -49,7 +49,7 @@ config I2C_NRF5_GPIO_SCA_PIN
 
 config I2C_0_DEFAULT_CFG
 	# Standard speed, master
-	default 0x11
+	default 0x12
 
 endif
 

--- a/boards/arm/nrf51_vbluno51/Kconfig.defconfig
+++ b/boards/arm/nrf51_vbluno51/Kconfig.defconfig
@@ -55,7 +55,7 @@ config I2C_NRF5_GPIO_SCA_PIN
 
 config I2C_0_DEFAULT_CFG
 	# Standard speed, master
-	default 0x11
+	default 0x12
 
 endif # I2C_NRF5
 

--- a/boards/arm/nrf52_vbluno52/Kconfig.defconfig
+++ b/boards/arm/nrf52_vbluno52/Kconfig.defconfig
@@ -55,7 +55,7 @@ config I2C_NRF5_GPIO_SCA_PIN
 
 config I2C_0_DEFAULT_CFG
 	# Standard speed, master
-	default 0x11
+	default 0x12
 
 endif # I2C_NRF5
 


### PR DESCRIPTION
The I2C_0_DEFAULT_CFG was trying to set the speed setting to standard
but didn't shift the value.

Signed-off-by: Kumar Gala <kumar.gala@linaro.org>