### PR TITLE
arch: arm: Differentiate between stack align and guard size

### DIFF
--- a/arch/arm/core/cortex_m/mpu/arm_core_mpu.c
+++ b/arch/arm/core/cortex_m/mpu/arm_core_mpu.c
@@ -24,8 +24,8 @@ void configure_mpu_stack_guard(struct k_thread *thread)
 {
 	arm_core_mpu_disable();
 	arm_core_mpu_configure(THREAD_STACK_GUARD_REGION,
-			       thread->stack_info.start - STACK_ALIGN,
-			       thread->stack_info.size);
+			thread->stack_info.start - MPU_GUARD_ALIGN_AND_SIZE,
+			thread->stack_info.size);
 	arm_core_mpu_enable();
 }
 #endif

--- a/arch/arm/core/thread.c
+++ b/arch/arm/core/thread.c
@@ -58,18 +58,14 @@ void _new_thread(struct k_thread *thread, k_thread_stack_t stack,
 
 	_ASSERT_VALID_PRIO(priority, pEntry);
 
-	__ASSERT(!((u32_t)pStackMem & (STACK_ALIGN - 1)),
-		 "stack is not aligned properly\n"
-		 "%d-byte alignment required\n", STACK_ALIGN);
-
 	char *stackEnd = pStackMem + stackSize;
 	struct __esf *pInitCtx;
 	_new_thread_init(thread, pStackMem, stackSize, priority, options);
 
 	/* carve the thread entry struct from the "base" of the stack */
 
-	pInitCtx = (struct __esf *)(STACK_ROUND_DOWN(stackEnd) -
-				    sizeof(struct __esf));
+	pInitCtx = (struct __esf *)(STACK_ROUND_DOWN(stackEnd -
+						     sizeof(struct __esf)));
 
 	pInitCtx->pc = ((u32_t)_thread_entry) & 0xfffffffe;
 	pInitCtx->a1 = (u32_t)pEntry;

--- a/arch/arm/include/cortex_m/stack.h
+++ b/arch/arm/include/cortex_m/stack.h
@@ -21,12 +21,6 @@
 extern "C" {
 #endif
 
-#ifdef CONFIG_STACK_ALIGN_DOUBLE_WORD
-#define STACK_ALIGN_SIZE 8
-#else
-#define STACK_ALIGN_SIZE 4
-#endif
-
 #ifdef _ASMLANGUAGE
 
 /* nothing */


### PR DESCRIPTION
This patch fixes a bug related to the stack guards.  If guards are
disabled, don't add anything to the size.  The alignment is still
required as the minimum alignment without guard is 4 bytes, and with
guard is 32 bytes.

Signed-off-by: Andy Gross <andy.gross@linaro.org>