### PR TITLE
net: http: allow HTTP_NETWORK_TIMEOUT to be configured

### DIFF
--- a/include/net/http.h
+++ b/include/net/http.h
@@ -107,9 +107,6 @@ enum http_final_call {
 #define HTTP_STATUS_STR_SIZE	32
 #endif
 
-/* Default network activity timeout in seconds */
-#define HTTP_NETWORK_TIMEOUT	K_SECONDS(20)
-
 /* It seems enough to hold 'Content-Length' and its value */
 #define HTTP_CONTENT_LEN_SIZE	48
 

--- a/subsys/net/lib/http/Kconfig
+++ b/subsys/net/lib/http/Kconfig
@@ -48,6 +48,14 @@ config HTTP_CLIENT
 	help
 	Enables HTTP client routines
 
+config HTTP_CLIENT_NETWORK_TIMEOUT
+	int "Default network activity timeout in seconds"
+	default 20
+	depends on HTTP_CLIENT
+	help
+	Default network activity timeout in seconds.  This setting is used
+	for TCP connection timeout.
+
 config HTTP_PARSER
 	bool "HTTP Parser support"
 	default n

--- a/subsys/net/lib/http/http_client.c
+++ b/subsys/net/lib/http/http_client.c
@@ -49,6 +49,9 @@
 #define HTTP_CONTENT_TYPE  "Content-Type: "
 #define HTTP_CONT_LEN_SIZE 64
 
+/* Default network activity timeout in seconds */
+#define HTTP_NETWORK_TIMEOUT	K_SECONDS(CONFIG_HTTP_CLIENT_NETWORK_TIMEOUT)
+
 struct waiter {
 	struct http_client_ctx *ctx;
 	struct k_sem wait;


### PR DESCRIPTION
Currently, the HTTP_NETWORK_TIMEOUT setting is hard-coded as 20 seconds.
Not every application may want to wait that long, so let's change this
to a CONFIG option: CONFIG_HTTP_CLIENT_NETWORK_TIMEOUT

NOTE: This also removes HTTP_NETWORK_TIMEOUT from the public http.h
include file.  It was not being used externally to HTTP client sources.

Signed-off-by: Michael Scott <michael.scott@linaro.org>