### PR TITLE
tests: include: Remove confusing string tc_start()

### DIFF
--- a/tests/include/tc_util.h
+++ b/tests/include/tc_util.h
@@ -67,15 +67,15 @@
 	} while (0)
 
 #define TC_PRINT(fmt, ...) PRINT_DATA(fmt, ##__VA_ARGS__)
-#define TC_START(name) PRINT_DATA("tc_start() - %s\n", name)
+#define TC_START(name) PRINT_DATA("starting test - %s\n", name)
 #define TC_END(result, fmt, ...) PRINT_DATA(fmt, ##__VA_ARGS__)
 
 /* prints result and the function name */
 #define _TC_END_RESULT(result, func)					\
 	do {								\
-		PRINT_LINE;						\
 		TC_END(result, "%s - %s.\n",				\
 		       (result) == TC_PASS ? PASS : FAIL, func);	\
+		PRINT_LINE;						\
 	} while (0)
 #define TC_END_RESULT(result)                           \
 	_TC_END_RESULT((result), __func__)

--- a/tests/ztest/src/ztest.c
+++ b/tests/ztest/src/ztest.c
@@ -229,6 +229,7 @@ void _ztest_run_test_suite(const char *name, struct unit_test *suite)
 	init_testing();
 
 	PRINT("Running test suite %s\n", name);
+	PRINT_LINE;
 	while (suite->test) {
 		fail += run_test(suite);
 		suite++;


### PR DESCRIPTION
This patch removes confusing strnig tc_start() and
unnecessary print line from output of all test cases which use
ztest framework.

Signed-off-by: Punit Vara <punit.vara@intel.com>