### PR TITLE
Bluetooth: Increase CONFIG_BT_HCI_TX_STACK_SIZE for BT_SPI

### DIFF
--- a/subsys/bluetooth/host/Kconfig
+++ b/subsys/bluetooth/host/Kconfig
@@ -55,7 +55,7 @@ config BT_HCI_TX_STACK_SIZE
 	default 256
 	default 256 if BT_H4
 	default 256 if BT_H5
-	default 256 if BT_SPI
+	default 416 if BT_SPI
 	default 640 if BT_CTLR
 
 config BT_HCI_TX_PRIO


### PR DESCRIPTION
Older value of 256 was introduced in 1.7 times. Testing on
BOARD=96b_carbon with 2 weeks old codebase however showed that TX
thread stack however can grow to 324 bytes. Finally, with the
latest master, following stacks are reported on BLE disconnect
(with CONFIG_INIT_STACKS enabled):

rx stack (real size 1024): unused 452	usage 572 / 1024 (55 %)
tx stack (real size 384):  unused 16	usage 368 / 384 (95 %)

Two outcomes:

1. TX stack needs increase.
2. Over time, the stack usage grows, plus variations in SPI
drivers should also be taken into account.

So, increase the stack size to 416 bytes, to leave some headroom
beyond the immediate values seen on 96b_carbon.

Jira: ZEP-2510

Signed-off-by: Paul Sokolovsky <paul.sokolovsky@linaro.org>