### PR TITLE
net: Remove check for k_delayed_work_cancel

### DIFF
--- a/include/net/http.h
+++ b/include/net/http.h
@@ -784,9 +784,6 @@ struct http_server_ctx {
 
 		/** URL's length */
 		u16_t url_len;
-
-		/** Has the request timer been cancelled. */
-		u8_t timer_cancelled;
 	} req;
 
 #if defined(CONFIG_HTTPS)

--- a/include/net/net_app.h
+++ b/include/net/net_app.h
@@ -300,11 +300,6 @@ struct net_app_ctx {
 		/** DTLS final timer. Connection is terminated if this expires.
 		 */
 		struct k_delayed_work fin_timer;
-
-		/** Timer flag telling whether the dtls timer has been
-		 * cancelled or not.
-		 */
-		bool fin_timer_cancelled;
 	} dtls;
 #endif
 

--- a/subsys/net/ip/ipv6.c
+++ b/subsys/net/ip/ipv6.c
@@ -222,12 +222,7 @@ struct net_ipv6_nbr_data *net_ipv6_get_nbr_by_index(u8_t idx)
 
 static inline void nbr_clear_ns_pending(struct net_ipv6_nbr_data *data)
 {
-	int ret;
-
-	ret = k_delayed_work_cancel(&data->send_ns);
-	if (ret < 0) {
-		NET_DBG("Cannot cancel NS work (%d)", ret);
-	}
+	k_delayed_work_cancel(&data->send_ns);
 
 	if (data->pending) {
 		net_pkt_unref(data->pending);

--- a/subsys/net/ip/tcp.c
+++ b/subsys/net/ip/tcp.c
@@ -248,13 +248,11 @@ struct net_tcp *net_tcp_alloc(struct net_context *context)
 
 static void ack_timer_cancel(struct net_tcp *tcp)
 {
-	tcp->ack_timer_cancelled = true;
 	k_delayed_work_cancel(&tcp->ack_timer);
 }
 
 static void fin_timer_cancel(struct net_tcp *tcp)
 {
-	tcp->fin_timer_cancelled = true;
 	k_delayed_work_cancel(&tcp->fin_timer);
 }
 

--- a/subsys/net/ip/tcp.h
+++ b/subsys/net/ip/tcp.h
@@ -135,15 +135,8 @@ struct net_tcp {
 	u32_t fin_sent : 1;
 	/* An inbound FIN packet has been received */
 	u32_t fin_rcvd : 1;
-	/* Tells if ack timer has been already cancelled. It might happen
-	 * that the timer is executed even if it is cancelled, this is because
-	 * of various timing issues when timer is scheduled to run.
-	 */
-	u32_t ack_timer_cancelled : 1;
-	/* Tells if fin timer has been already cancelled. */
-	u32_t fin_timer_cancelled : 1;
 	/** Remaining bits in this u32_t */
-	u32_t _padding : 11;
+	u32_t _padding : 13;
 
 	/** Accept callback to be called when the connection has been
 	 * established.

--- a/subsys/net/lib/app/net_app.c
+++ b/subsys/net/lib/app/net_app.c
@@ -1037,8 +1037,6 @@ static int dtls_timing_get_delay(void *data)
 
 static void dtls_cleanup(struct net_app_ctx *ctx, bool cancel_timer)
 {
-	ctx->dtls.fin_timer_cancelled = true;
-
 	if (cancel_timer) {
 		k_delayed_work_cancel(&ctx->dtls.fin_timer);
 	}
@@ -1056,11 +1054,9 @@ static void dtls_timeout(struct k_work *work)
 	struct net_app_ctx *ctx =
 		CONTAINER_OF(work, struct net_app_ctx, dtls.fin_timer);
 
-	if (!ctx->dtls.fin_timer_cancelled) {
-		NET_DBG("Did not receive DTLS traffic in %dms", DTLS_TIMEOUT);
+	NET_DBG("Did not receive DTLS traffic in %dms", DTLS_TIMEOUT);
 
-		dtls_cleanup(ctx, false);
-	}
+	dtls_cleanup(ctx, false);
 }
 
 enum net_verdict _net_app_dtls_established(struct net_conn *conn,
@@ -1113,12 +1109,10 @@ enum net_verdict _net_app_dtls_established(struct net_conn *conn,
 
 	k_fifo_put(&ctx->tls.mbedtls.ssl_ctx.tx_rx_fifo, (void *)rx_data);
 
-	ctx->dtls.fin_timer_cancelled = true;
 	k_delayed_work_cancel(&ctx->dtls.fin_timer);
 
 	k_yield();
 
-	ctx->dtls.fin_timer_cancelled = false;
 	k_delayed_work_submit(&ctx->dtls.fin_timer, DTLS_TIMEOUT);
 
 	return NET_OK;
@@ -1222,7 +1216,6 @@ static int accept_dtls(struct net_app_ctx *ctx,
 
 	ctx->dtls.ctx = dtls_context;
 
-	ctx->dtls.fin_timer_cancelled = false;
 	k_delayed_work_submit(&ctx->dtls.fin_timer, DTLS_TIMEOUT);
 
 	return 0;
@@ -1275,17 +1268,6 @@ void _net_app_tls_received(struct net_context *context,
 			net_pkt_unref(pkt);
 			return;
 		} else {
-			if (ctx->dtls.fin_timer_cancelled) {
-				if (pkt) {
-					net_pkt_unref(pkt);
-					pkt = NULL;
-				}
-
-				ctx->dtls.fin_timer_cancelled = false;
-
-				goto dtls_disconnect;
-			}
-
 			ret = accept_dtls(ctx, context, pkt);
 			if (ret < 0) {
 				NET_DBG("Cannot accept new DTLS "

--- a/subsys/net/lib/http/http_server.c
+++ b/subsys/net/lib/http/http_server.c
@@ -152,7 +152,6 @@ static int http_add_chunk(struct net_pkt *pkt, s32_t timeout, const char *str)
 
 static void req_timer_cancel(struct http_server_ctx *ctx)
 {
-	ctx->req.timer_cancelled = true;
 	k_delayed_work_cancel(&ctx->req.timer);
 
 	NET_DBG("Context %p request timer cancelled", ctx);
@@ -163,10 +162,6 @@ static void req_timeout(struct k_work *work)
 	struct http_server_ctx *ctx = CONTAINER_OF(work,
 						   struct http_server_ctx,
 						   req.timer);
-
-	if (ctx->req.timer_cancelled) {
-		return;
-	}
 
 	NET_DBG("Context %p request timeout", ctx);
 
@@ -194,8 +189,6 @@ static void pkt_sent(struct net_context *context,
 		NET_DBG("Context %p starting timer", ctx);
 
 		k_delayed_work_submit(&ctx->req.timer, timeout);
-
-		ctx->req.timer_cancelled = false;
 	}
 
 	/* Note that if the timeout is K_FOREVER, we do not close


### PR DESCRIPTION
k_delayed_work_cancel now only fail if it hasn't been submitted which
means it is not in use anyway so it safe to reset its data regardless
of its return.

Signed-off-by: Luiz Augusto von Dentz <luiz.von.dentz@intel.com>