### PR TITLE
Bluetooth: samples: ipsp: Fix crash on TCP connection closure

### DIFF
--- a/samples/bluetooth/ipsp/src/main.c
+++ b/samples/bluetooth/ipsp/src/main.c
@@ -270,9 +270,16 @@ static void tcp_received(struct net_context *context,
 			 void *user_data)
 {
 	static char dbg[MAX_DBG_PRINT + 1];
-	sa_family_t family = net_pkt_family(pkt);
+	sa_family_t family;
 	struct net_pkt *reply_pkt;
 	int ret;
+
+	if (!pkt) {
+		/* EOF condition */
+		return;
+	}
+
+	family = net_pkt_family(pkt);
 
 	snprintf(dbg, MAX_DBG_PRINT, "TCP IPv%c",
 		 family == AF_INET6 ? '6' : '4');


### PR DESCRIPTION
Be sure to check for NULL pkt in receive callback, which means TCP
EOF. The fix ported from echo_server sample.

Jira: ZEP-2423

Signed-off-by: Paul Sokolovsky <paul.sokolovsky@linaro.org>