### PR TITLE
drivers/ieee802154: Fix licence headers in Kconfig files

### DIFF
--- a/drivers/ieee802154/Kconfig
+++ b/drivers/ieee802154/Kconfig
@@ -3,31 +3,7 @@
 #
 # Copyright (c) 2015 Intel Corporation
 #
-# Redistribution and use in source and binary forms, with or without
-# modification, are permitted provided that the following conditions are met:
-#
-# 1) Redistributions of source code must retain the above copyright notice,
-# this list of conditions and the following disclaimer.
-#
-# 2) Redistributions in binary form must reproduce the above copyright notice,
-# this list of conditions and the following disclaimer in the documentation
-# and/or other materials provided with the distribution.
-#
-# 3) Neither the name of Intel Corporation nor the names of its contributors
-# may be used to endorse or promote products derived from this software without
-# specific prior written permission.
-#
-# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
-# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
-# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
-# ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
-# LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
-# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
-# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
-# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
-# CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
-# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
-# POSSIBILITY OF SUCH DAMAGE.
+# SPDX-License-Identifier: Apache-2.0
 #
 
 #

--- a/drivers/ieee802154/Kconfig.cc2520
+++ b/drivers/ieee802154/Kconfig.cc2520
@@ -1,5 +1,10 @@
 # Kconfig.cc2520 - TI CC2520 configuration options
 #
+#
+# Copyright (c) 2017 Intel Corporation
+#
+# SPDX-License-Identifier: Apache-2.0
+#
 
 menuconfig IEEE802154_CC2520
 	bool "TI CC2520 Driver support"

--- a/drivers/ieee802154/Kconfig.kw41z
+++ b/drivers/ieee802154/Kconfig.kw41z
@@ -1,5 +1,10 @@
 # Kconfig.kw41z - NXP KW41Z configuration options
 #
+#
+# Copyright (c) 2017 Linaro Limited
+#
+# SPDX-License-Identifier: Apache-2.0
+#
 
 menuconfig  IEEE802154_KW41Z
 	bool "NXP KW41Z Driver support"

--- a/drivers/ieee802154/Kconfig.mcr20a
+++ b/drivers/ieee802154/Kconfig.mcr20a
@@ -1,5 +1,10 @@
 # Kconfig.mcr20a - NXP MCR20A configuration options
 #
+#
+# Copyright (c) 2017 PHYTEC Messtechnik GmbH
+#
+# SPDX-License-Identifier: Apache-2.0
+#
 
 menuconfig  IEEE802154_MCR20A
 	bool "NXP MCR20A Driver support"

--- a/drivers/ieee802154/Kconfig.nrf5
+++ b/drivers/ieee802154/Kconfig.nrf5
@@ -1,5 +1,10 @@
 # Kconfig.nrf5 - Nordic Semiconductor nRF5 802.15.4 configuration options
 #
+#
+# Copyright (c) 2017 Nordic Semiconductor ASA
+#
+# SPDX-License-Identifier: Apache-2.0
+#
 
 choice IEEE802154_NRF5_DRIVER_SUPPORT
 	prompt "nRF52 series IEEE 802.15.4 Driver support"


### PR DESCRIPTION
Signed-off-by: Tomasz Bursztyka <tomasz.bursztyka@linux.intel.com>