### PR TITLE
x86: dts: use BOARD Kconfig symbol not SOC for arduino_101

### DIFF
--- a/dts/x86/Makefile
+++ b/dts/x86/Makefile
@@ -1,5 +1,5 @@
 ifeq ($(CONFIG_HAS_DTS),y)
-dtb-$(CONFIG_SOC_QUARK_SE_C1000)	=	arduino_101.dts_compiled
+dtb-$(CONFIG_BOARD_ARDUINO_101)		=	arduino_101.dts_compiled
 dtb-$(CONFIG_BOARD_QUARK_D2000_CRB)	=	quark_d2000_crb.dts_compiled
 dtb-$(CONFIG_BOARD_TINYTILE)		=	tinytile.dts_compiled
 always	:= $(dtb-y)


### PR DESCRIPTION
As the device tree is board specific we should be using the board
Kconfig variable to decide which .dts to use and not the SoC one for
arduino_101.

Signed-off-by: Kumar Gala <kumar.gala@linaro.org>