### PR TITLE
doc: fix misspellings in Kconfig files

### DIFF
--- a/drivers/dma/Kconfig
+++ b/drivers/dma/Kconfig
@@ -62,9 +62,9 @@ config SYS_LOG_DMA_LEVEL
 	  Levels are:
 	  0 OFF, do not write
 	  1 ERROR, only write SYS_LOG_ERR
-	  2 WARNING, write SYS_LOG_WRN in adition to previous level
-	  3 INFO, write SYS_LOG_INF in adition to previous levels
-	  4 DEBUG, write SYS_LOG_DBG in adition to previous levels
+	  2 WARNING, write SYS_LOG_WRN in addition to previous level
+	  3 INFO, write SYS_LOG_INF in addition to previous levels
+	  4 DEBUG, write SYS_LOG_DBG in addition to previous levels
 
 source "drivers/dma/Kconfig.qmsi"
 

--- a/drivers/random/Kconfig.esp32
+++ b/drivers/random/Kconfig.esp32
@@ -1,6 +1,6 @@
 # Kconfig.esp32 - esp32 random generator driver configuration
 #
-# Copyright (c) 2017 Intel Corproation
+# Copyright (c) 2017 Intel Corporation
 #
 # SPDX-License-Identifier: Apache-2.0
 


### PR DESCRIPTION
Also fixed missing newline at end of file

Signed-off-by: David B. Kinder <david.b.kinder@intel.com>