### PR TITLE
net: l2: bt: Make 6lowpan/BLE be compatible with Linux by default

### DIFF
--- a/subsys/net/ip/l2/Kconfig
+++ b/subsys/net/ip/l2/Kconfig
@@ -60,7 +60,7 @@ config NET_L2_BT
 config NET_L2_BT_ZEP1656
 	bool "***Workaround to work with Linux.***"
 	depends on NET_L2_BT
-	default n
+	default y
 	help
 	This workaround is necessary to interoperate with Linux up to 4.10 but
 	it might not be compliant with RFC 7668 as it cause the stack to skip


### PR DESCRIPTION
As https://jira.zephyrproject.org/browse/ZEP-1656 mentions, "RFC 7668
(https://tools.ietf.org/html/rfc7668) is actually quite recent and
there is basically only Zephyr and Linux implementions so far".

And Zephyr manages to have default configuration not compatible
with Linux, which doesn't make sense. Also, the description of
CONFIG_NET_L2_BT_ZEP1656 says that it's required for Linux below
4.10, but without it, kernel 4.10.0 still doesn't work. So, enable
the option by default for the time being.

Signed-off-by: Paul Sokolovsky <paul.sokolovsky@linaro.org>