### PR TITLE
Bluetooth: Kconfig: fix default value and range for BT_RX_STACK_SIZE

### DIFF
--- a/subsys/bluetooth/host/Kconfig
+++ b/subsys/bluetooth/host/Kconfig
@@ -96,10 +96,10 @@ config BT_RX_STACK_SIZE
 	depends on BT_HCI_HOST || BT_RECV_IS_RX_THREAD
 	default 1024
 	default 2048 if BT_MESH
-	default 512 if CONFIG_BT_HCI_RAW
-	range 1024 65536
+	default 512 if BT_HCI_RAW
+	range 512 65536 if BT_HCI_RAW
 	range 1100 65536 if BT_MESH
-	range 512 65536 if CONFIG_BT_HCI_RAW
+	range 1024 65536
 	help
 	  Size of the receiving thread stack. This is the context from
 	  which all event callbacks to the application occur. The


### PR DESCRIPTION
Fix checks for BT_HCI_RAW and move default range after the other range
options, required by Kconfig to avoid overwriting other options.

Signed-off-by: Ricardo Salveti <ricardo.salveti@linaro.org>