### PR TITLE
net: sockets: Consistently use "BSD Sockets compatible API" moniker

### DIFF
--- a/samples/net/sockets/echo/README.rst
+++ b/samples/net/sockets/echo/README.rst
@@ -7,9 +7,9 @@ Overview
 ********
 
 The sockets/echo sample application for Zephyr implements an IPv4 TCP echo
-server using a BSD Sockets like API. The purpose of this sample is to show
-how it's possible to develop a sockets application portable to both POSIX
-and Zephyr. As such, it is kept minimal and supports only IPv4 and TCP.
+server using a BSD Sockets compatible API. The purpose of this sample is to
+show how it's possible to develop a sockets application portable to both
+POSIX and Zephyr. As such, it is kept minimal and supports only IPv4 and TCP.
 
 The source code for this sample application can be found at:
 :file:`samples/net/sockets/echo`.
@@ -53,8 +53,8 @@ Running application on POSIX Host
 =================================
 
 The same application source code can be built for a POSIX system, e.g.
-Linux. (Note: if you look at the source, you will see that code is the
-same except the header files are different for Zephyr vs POSIX.)
+Linux. (Note: if you look at the source, you will see that the code is
+the same except the header files are different for Zephyr vs POSIX.)
 
 To build for a host POSIX OS:
 

--- a/samples/net/sockets/echo_async/README.rst
+++ b/samples/net/sockets/echo_async/README.rst
@@ -7,7 +7,7 @@ Overview
 ********
 
 The sockets/echo-async sample application for Zephyr implements an
-asyncronous IPv4 TCP echo server using a BSD Sockets like API with
+asyncronous IPv4 TCP echo server using a BSD Sockets compatible API with
 non-blocking sockets and a ``poll()`` call. This is an extension of
 the :ref:`sockets-echo-sample` sample. The purpose of this sample is
 still to show how it's possible to develop a sockets application portable
@@ -58,7 +58,7 @@ Running application on POSIX Host
 =================================
 
 The same application source code can be built for a POSIX system, e.g.
-Linux. (Note: if you look at the source, you will see that code is
+Linux. (Note: if you look at the source, you will see that the code is
 the same except the header files are different for Zephyr vs POSIX.)
 
 To build for a host POSIX OS:

--- a/subsys/net/lib/sockets/Kconfig
+++ b/subsys/net/lib/sockets/Kconfig
@@ -1,4 +1,4 @@
-# Kconfig - BSD Sockets like API
+# Kconfig - BSD Sockets compatible API
 
 #
 # Copyright (c) 2017 Linaro Limited.
@@ -7,7 +7,7 @@
 #
 
 menuconfig NET_SOCKETS
-	bool "BSD Sockets like API"
+	bool "BSD Sockets compatible API"
 	default n
 	help
 	Provide BSD Sockets like API on top of native Zephyr networking API.
@@ -33,7 +33,7 @@ config NET_SOCKETS_POLL_MAX
 	Maximum number of entries supported for poll() call.
 
 config NET_DEBUG_SOCKETS
-	bool "Debug BSD Sockets like API calls"
+	bool "Debug BSD Sockets compatible API calls"
 	default n
 	help
 	Enables logging for sockets code. (Logging level is defined by


### PR DESCRIPTION
This is how it's called in the main docs, so use this same phrase in
Kconfig and samples too.

Also, added some articles to docs.

Signed-off-by: Paul Sokolovsky <paul.sokolovsky@linaro.org>