### PR TITLE
Bluetooth: VS: Add RSSI to Scan Req Received Event

### DIFF
--- a/doc/subsystems/bluetooth/hci.txt
+++ b/doc/subsystems/bluetooth/hci.txt
@@ -908,7 +908,8 @@ This event indicates that a SCAN_REQ PDU has been received by an advertiser.
 +-------------------------------+------------+-------------------------------+
 | Scan_Request_Received         | 0xFF       | Subevent_Code,                |
 |                               |            | Address_Type,                 |
-|                               |            | Address                       |
+|                               |            | Address,                      |
+|                               |            | RSSI                          |
 +-------------------------------+------------+-------------------------------+
 
 The request contains a device address from a scanner that is allowed by the
@@ -944,6 +945,19 @@ advertising sets, this event shall not be generated.
 	|                    | Address, Public Identity Address or  |
 	|                    | Random (static) Identity Address of  |
 	|                    | the advertising device.              |
+	+--------------------+--------------------------------------+
+
+	RSSI:                                           Size: 1 Octet
+	+--------------------+--------------------------------------+
+	| Value              | Parameter Description                |
+	+--------------------+--------------------------------------+
+	| N                  | Size: 1 Octet (signed integer)       |
+	|                    | Range: -127 <= N <= +20              |
+	|                    | Units: dBm                           |
+	+--------------------+--------------------------------------+
+	| 127                | RSSI is not available                |
+	+--------------------+--------------------------------------+
+	| 21 to 126          | Reserved for future use              |
 	+--------------------+--------------------------------------+
 
 The event is only reported when unmasked by Set_Event_Mask command.

--- a/include/bluetooth/hci_vs.h
+++ b/include/bluetooth/hci_vs.h
@@ -154,6 +154,7 @@ struct bt_hci_evt_vs_trace_info {
 #define BT_HCI_EVT_VS_SCAN_REQ_RX              0x04
 struct bt_hci_evt_vs_scan_req_rx {
 	bt_addr_le_t addr;
+	s8_t         rssi;
 } __packed;
 
 /* Event mask bits */

--- a/include/bluetooth/hci_vs.h
+++ b/include/bluetooth/hci_vs.h
@@ -84,7 +84,7 @@ struct bt_hci_rp_vs_read_build_info {
 
 struct bt_hci_vs_static_addr {
 	bt_addr_t bdaddr;
-	u8_t      irk[16];
+	u8_t      ir[16];
 } __packed;
 
 #define BT_HCI_OP_VS_READ_STATIC_ADDRS          BT_OP(BT_OGF_VS, 0x0009)
@@ -97,7 +97,7 @@ struct bt_hci_rp_vs_read_static_addrs {
 #define BT_HCI_OP_VS_READ_KEY_HIERARCHY_ROOTS   BT_OP(BT_OGF_VS, 0x000a)
 struct bt_hci_rp_vs_read_key_hierarchy_roots {
 	u8_t  status;
-	u8_t  irk[16];
+	u8_t  ir[16];
 	u8_t  er[16];
 } __packed;
 


### PR DESCRIPTION
In order to allow for the controller to report the RSSI of a received
Scan Request, include the field inside the Scan Request Received
Vendor-Specific Event.

Signed-off-by: Carles Cufi <carles.cufi@nordicsemi.no>