### PR TITLE
net: lwm2m: ignore optional resource when not implmeneted

### DIFF
--- a/subsys/net/lib/lwm2m/lwm2m_rw_json.c
+++ b/subsys/net/lib/lwm2m/lwm2m_rw_json.c
@@ -606,7 +606,7 @@ int do_write_op_json(struct lwm2m_engine_obj *obj,
 			obj_field = lwm2m_get_engine_obj_field(obj,
 							       path->res_id);
 			if (!obj_field) {
-				return -EINVAL;
+				goto skip_optional;
 			}
 
 			if ((obj_field->permissions & LWM2M_PERM_W) !=
@@ -633,6 +633,7 @@ int do_write_op_json(struct lwm2m_engine_obj *obj,
 
 			lwm2m_write_handler(obj_inst, res, obj_field, context);
 
+skip_optional:
 			mode = MODE_NONE;
 			in->inbuf = inbuf;
 			in->inpos = inpos;

--- a/subsys/net/lib/lwm2m/lwm2m_rw_oma_tlv.c
+++ b/subsys/net/lib/lwm2m/lwm2m_rw_oma_tlv.c
@@ -615,10 +615,11 @@ static int do_write_op_tlv_item(struct lwm2m_engine_context *context,
 		return ret;
 	}
 
+	/* if obj_field is not found, treated as an optional resource */
 	obj_field = lwm2m_get_engine_obj_field(obj_inst->obj,
 					       context->path->res_id);
 	if (!obj_field) {
-		return -EINVAL;
+		return -ENOTSUP;
 	}
 
 	if ((obj_field->permissions & LWM2M_PERM_W) != LWM2M_PERM_W) {
@@ -703,7 +704,8 @@ int do_write_op_tlv(struct lwm2m_engine_obj *obj,
 			path->level = 3;
 			ret = do_write_op_tlv_item(context,
 						   &inbuf[tlvpos], len);
-			if (ret < 0) {
+			/* skip optional */
+			if (ret < 0 && ret != -ENOTSUP) {
 				return ret;
 			}
 		}

--- a/subsys/net/lib/lwm2m/lwm2m_rw_plain_text.c
+++ b/subsys/net/lib/lwm2m/lwm2m_rw_plain_text.c
@@ -412,7 +412,7 @@ int do_write_op_plain_text(struct lwm2m_engine_obj *obj,
 
 	obj_field = lwm2m_get_engine_obj_field(obj, path->res_id);
 	if (!obj_field) {
-		return -EINVAL;
+		return -ENOENT;
 	}
 
 	if ((obj_field->permissions & LWM2M_PERM_W) != LWM2M_PERM_W) {


### PR DESCRIPTION
Per LwM2M specification 7.3.2.4, "Optional Resources MAY be conveyed
in the "New Value" parameter as well; the LwM2M Client MAY ignore the
optional resources it doesn't support."

Update TLV/JSON writer to ignore error when object fields are not
found (treated as optional resource). This will allow the resources
supported being written.

Update PLAIN TEXT writer to return -ENOENT when object field is not
found which will avoid returning internal
ZOAP_RESPONSE_CODE_INTERNAL_ERROR but ZOAP_RESPONSE_CODE_NOT_FOUND
to the server

Signed-off-by: Robert Chou <robert.ch.chou@acer.com>