### PR TITLE
drivers: adc: deprecate adc_enable/adc_disable functions

### DIFF
--- a/include/adc.h
+++ b/include/adc.h
@@ -85,11 +85,14 @@ struct adc_driver_api {
  * This routine enables the ADC hardware block for data sampling for the
  * specified device.
  *
+ * @deprecated This function is deprecated, power management API should be used
+ * instead.
+ *
  * @param dev Pointer to the device structure for the driver instance.
  *
  * @return N/A
  */
-static inline void adc_enable(struct device *dev)
+static inline void __deprecated adc_enable(struct device *dev)
 {
 	const struct adc_driver_api *api = dev->driver_api;
 
@@ -102,11 +105,14 @@ static inline void adc_enable(struct device *dev)
  * This routine disables the ADC hardware block for data sampling for the
  * specified device.
  *
+ * @deprecated This function is deprecated, power management API should be used
+ * instead.
+ *
  * @param dev Pointer to the device structure for the driver instance.
  *
  * @return N/A
  */
-static inline void adc_disable(struct device *dev)
+static inline void __deprecated adc_disable(struct device *dev)
 {
 	const struct adc_driver_api *api = dev->driver_api;
 

--- a/tests/drivers/adc/adc_api/src/test_adc.c
+++ b/tests/drivers/adc/adc_api/src/test_adc.c
@@ -15,7 +15,6 @@
  *   -# Connect A0 to VCC3.3.
  *   -# Prepare ADC sequence table.
  *   -# Bind ADC device.
- *   -# Enable ADC device.
  *   -# Call adc_read() to fetch ADC sample.
  *   -# Dump the sample results.
  * - Expected Results
@@ -75,9 +74,6 @@ static int test_task(void)
 		return TC_FAIL;
 	}
 
-	/* 1. Verify adc_enable() */
-	adc_enable(adc_dev);
-
 	k_sleep(500);
 
 	/* 2. Verify adc_read() */
@@ -92,9 +88,6 @@ static int test_task(void)
 		TC_PRINT("%d ", seq_buffer[i]);
 	}
 	TC_PRINT("\n");
-
-	/* 3. Verify adc_disable() */
-	adc_disable(adc_dev);
 
 	return TC_PASS;
 }

--- a/tests/drivers/adc/adc_simple/src/main.c
+++ b/tests/drivers/adc/adc_simple/src/main.c
@@ -72,7 +72,6 @@ static void adc_test(void)
 	adc = device_get_binding(ADC_DEVICE_NAME);
 	zassert_not_null(adc, "Cannot get adc controller\n");
 
-	adc_enable(adc);
 	while (loops--) {
 		bufi = loops & 0x1;
 		/* .buffer should be void * ... */
@@ -96,7 +95,6 @@ static void adc_test(void)
 		k_sleep(SLEEPTIME);
 		bufi0 = bufi;
 	}
-	adc_disable(adc);
 }
 
 


### PR DESCRIPTION
adc_enable/adc_disable functions are no more required. Power management
should be done via Zephyr Power Management Subsystem API.

This commit marks the two functions as deprecated and removes them
from the test suite.

Fixes #3980

Signed-off-by: Piotr Mienkowski <piotr.mienkowski@gmail.com>