### PR TITLE
boards: 96b_carbon: Enable NET_L2_BT by default

### DIFF
--- a/boards/arm/96b_carbon/Kconfig.defconfig
+++ b/boards/arm/96b_carbon/Kconfig.defconfig
@@ -32,4 +32,17 @@ config SPI_LEGACY_API
 
 endif # BT
 
+if NETWORKING
+
+# BT is the only onboard network iface, so use it for IP networking
+# if it's enabled
+
+config NET_L2_BT
+	default y
+
+config NET_L2_BT_ZEP1656
+	default y
+
+endif # NETWORKING
+
 endif # BOARD_96B_CARBON


### PR DESCRIPTION
BLE is the only networking interface on 96b_carbon, so if
CONFIG_NETWORKING is set, automatically use 6lowpan/BLE link
layer. This will allow to make networking apps work "out of the
box" on 96b_carbon, similar to e.g. qemu_x86 (which automatically
uses SLIP) or frdm_k64f (which automatically uses Ethernet).

Signed-off-by: Paul Sokolovsky <paul.sokolovsky@linaro.org>