### PR TITLE
arch: arm: stm32f1: Fix how we determine pull-up/pull-down for gpio

### DIFF
--- a/arch/arm/soc/st_stm32/stm32f1/soc_gpio.c
+++ b/arch/arm/soc/st_stm32/stm32f1/soc_gpio.c
@@ -89,7 +89,7 @@ int stm32_gpio_configure(u32_t *base_addr, int pin, int conf, int altf)
 	mode_io = (conf >> STM32_MODE_INOUT_SHIFT) & STM32_MODE_INOUT_MASK;
 
 	if (mode_io == STM32_MODE_INPUT) {
-		int in_pudpd = (conf >> STM32_PUPD_SHIFT) & STM32_PUPD_MASK;
+		int in_pudpd = conf & (STM32_PUPD_MASK << STM32_PUPD_SHIFT);
 
 		/* Pin configured in input mode */
 		/* Mode: 00 */


### PR DESCRIPTION
When we mask out the GPIO High impedance/Pull-up/Pull-down field we
should be shifting the mask file, not shifting the field.  This is
because all the other defines already assume the shift.

Coverity-CID: 173640

Jira: ZEP-2538

Signed-off-by: Kumar Gala <kumar.gala@linaro.org>