### PR TITLE
dts: i2c: Fix size and address cells

### DIFF
--- a/dts/common/yaml/i2c.yaml
+++ b/dts/common/yaml/i2c.yaml
@@ -7,11 +7,11 @@ description: >
     This binding gives the base structures for all I2C devices
 
 properties:
-  - #address-cells:
+  - "#address-cells":
       type: int
       category: required
       description: should be 1.
-  - #size-cells:
+  - "#size-cells":
       type: int
       category: required
       description: should be 0.


### PR DESCRIPTION
This patch fixes the size and address cells yaml generation.  Due to
the leading #, the yaml generation incorrectly parses the property
name.  Adding quotes around the property name fixes this.

Signed-off-by: Andy Gross <andy.gross@linaro.org>