### PR TITLE
net: lwm2m: Set 2.01 CREATED to out packet when instance is created

### DIFF
--- a/subsys/net/lib/lwm2m/lwm2m_engine.c
+++ b/subsys/net/lib/lwm2m/lwm2m_engine.c
@@ -1892,7 +1892,7 @@ int lwm2m_get_or_create_engine_obj(struct lwm2m_engine_context *context,
 			return ret;
 		}
 
-		zoap_header_set_code(context->in->in_zpkt,
+		zoap_header_set_code(context->out->out_zpkt,
 				     ZOAP_RESPONSE_CODE_CREATED);
 		/* set created flag to one */
 		if (created) {


### PR DESCRIPTION
It was set to in packet but not out packet.
2.04 Changed is reported in original implementation no matter object
instance is created or not

Signed-off-by: Robert Chou <robert.ch.chou@acer.com>