### PR TITLE
net: Make struct sockaddr POSIX compliant, add struct sockaddr_storage

### DIFF
--- a/include/net/net_ip.h
+++ b/include/net/net_ip.h
@@ -144,6 +144,12 @@ struct sockaddr_ptr {
 	char data[NET_SOCKADDR_PTR_MAX_SIZE - sizeof(sa_family_t)];
 };
 
+/* Same as sockaddr in our case */
+struct sockaddr_storage {
+	sa_family_t ss_family;
+	char data[NET_SOCKADDR_MAX_SIZE - sizeof(sa_family_t)];
+};
+
 struct net_addr {
 	sa_family_t family;
 	union {

--- a/include/net/net_ip.h
+++ b/include/net/net_ip.h
@@ -135,7 +135,7 @@ struct sockaddr_in_ptr {
 #endif
 
 struct sockaddr {
-	sa_family_t family;
+	sa_family_t sa_family;
 	char data[NET_SOCKADDR_MAX_SIZE - sizeof(sa_family_t)];
 };
 

--- a/samples/net/irc_bot/src/irc-bot.c
+++ b/samples/net/irc_bot/src/irc-bot.c
@@ -492,7 +492,7 @@ static void resolve_cb(enum dns_resolve_status status,
 				&net_sin6(&info->ai_addr)->sin6_addr);
 		net_sin6(&irc->remote_addr)->sin6_port = htons(DEFAULT_PORT);
 		net_sin6(&irc->remote_addr)->sin6_family = AF_INET6;
-		irc->remote_addr.family = AF_INET6;
+		irc->remote_addr.sa_family = AF_INET6;
 	} else
 #endif
 #if defined(CONFIG_NET_IPV4)
@@ -501,7 +501,7 @@ static void resolve_cb(enum dns_resolve_status status,
 				&net_sin(&info->ai_addr)->sin_addr);
 		net_sin(&irc->remote_addr)->sin_port = htons(DEFAULT_PORT);
 		net_sin(&irc->remote_addr)->sin_family = AF_INET;
-		irc->remote_addr.family = AF_INET;
+		irc->remote_addr.sa_family = AF_INET;
 	} else
 #endif
 	{
@@ -906,7 +906,7 @@ static void setup_dhcpv4(struct zirc *irc, struct net_if *iface)
 
 	net_ipaddr_copy(&net_sin(&irc->local_addr)->sin_addr,
 			&iface->dhcpv4.requested_ip);
-	irc->local_addr.family = AF_INET;
+	irc->local_addr.sa_family = AF_INET;
 	net_sin(&irc->local_addr)->sin_family = AF_INET;
 	net_sin(&irc->local_addr)->sin_port = 0;
 

--- a/samples/net/lwm2m_client/src/lwm2m-client.c
+++ b/samples/net/lwm2m_client/src/lwm2m-client.c
@@ -303,7 +303,7 @@ void main(void)
 		goto cleanup_ipv6;
 	}
 
-	ret = set_endpoint_name(ep_name, udp6.ipv6.local.family);
+	ret = set_endpoint_name(ep_name, udp6.ipv6.local.sa_family);
 	if (ret < 0) {
 		SYS_LOG_ERR("Cannot set IPv6 endpoint name (%d)", ret);
 		goto cleanup_ipv6;
@@ -333,7 +333,7 @@ void main(void)
 		goto cleanup_ipv4;
 	}
 
-	ret = set_endpoint_name(ep_name, udp4.ipv4.local.family);
+	ret = set_endpoint_name(ep_name, udp4.ipv4.local.sa_family);
 	if (ret < 0) {
 		SYS_LOG_ERR("Cannot set IPv4 endpoint name (%d)", ret);
 		goto cleanup_ipv4;

--- a/samples/net/mbedtls_sslclient/src/tcp.c
+++ b/samples/net/mbedtls_sslclient/src/tcp.c
@@ -110,12 +110,12 @@ static int set_addr(struct sockaddr *sock_addr, const char *addr,
 
 #ifdef CONFIG_NET_IPV6
 	net_sin6(sock_addr)->sin6_port = htons(server_port);
-	sock_addr->family = AF_INET6;
+	sock_addr->sa_family = AF_INET6;
 	ptr = &(net_sin6(sock_addr)->sin6_addr);
 	rc = net_addr_pton(AF_INET6, addr, ptr);
 #else
 	net_sin(sock_addr)->sin_port = htons(server_port);
-	sock_addr->family = AF_INET;
+	sock_addr->sa_family = AF_INET;
 	ptr = &(net_sin(sock_addr)->sin_addr);
 	rc = net_addr_pton(AF_INET, addr, ptr);
 #endif

--- a/samples/net/nats/src/main.c
+++ b/samples/net/nats/src/main.c
@@ -85,7 +85,7 @@ static int in_addr_set(sa_family_t family,
 {
 	int rc = 0;
 
-	_sockaddr->family = family;
+	_sockaddr->sa_family = family;
 
 	if (ip_addr) {
 		if (family == AF_INET6) {

--- a/subsys/net/ip/connection.c
+++ b/subsys/net/ip/connection.c
@@ -396,7 +396,7 @@ void prepare_register_debug_print(char *dst, int dst_len,
 				  const struct sockaddr *remote_addr,
 				  const struct sockaddr *local_addr)
 {
-	if (remote_addr && remote_addr->family == AF_INET6) {
+	if (remote_addr && remote_addr->sa_family == AF_INET6) {
 #if defined(CONFIG_NET_IPV6)
 		snprintk(dst, dst_len, "%s",
 			 net_sprint_ipv6_addr(&net_sin6(remote_addr)->
@@ -405,7 +405,7 @@ void prepare_register_debug_print(char *dst, int dst_len,
 		snprintk(dst, dst_len, "%s", "?");
 #endif
 
-	} else if (remote_addr && remote_addr->family == AF_INET) {
+	} else if (remote_addr && remote_addr->sa_family == AF_INET) {
 #if defined(CONFIG_NET_IPV4)
 		snprintk(dst, dst_len, "%s",
 			 net_sprint_ipv4_addr(&net_sin(remote_addr)->
@@ -418,7 +418,7 @@ void prepare_register_debug_print(char *dst, int dst_len,
 		snprintk(dst, dst_len, "%s", "-");
 	}
 
-	if (local_addr && local_addr->family == AF_INET6) {
+	if (local_addr && local_addr->sa_family == AF_INET6) {
 #if defined(CONFIG_NET_IPV6)
 		snprintk(src, src_len, "%s",
 			 net_sprint_ipv6_addr(&net_sin6(local_addr)->
@@ -427,7 +427,7 @@ void prepare_register_debug_print(char *dst, int dst_len,
 		snprintk(src, src_len, "%s", "?");
 #endif
 
-	} else if (local_addr && local_addr->family == AF_INET) {
+	} else if (local_addr && local_addr->sa_family == AF_INET) {
 #if defined(CONFIG_NET_IPV4)
 		snprintk(src, src_len, "%s",
 			 net_sprint_ipv4_addr(&net_sin(local_addr)->
@@ -466,9 +466,9 @@ static int find_conn_handler(enum net_ip_protocol proto,
 			}
 
 #if defined(CONFIG_NET_IPV6)
-			if (remote_addr->family == AF_INET6 &&
-			    remote_addr->family ==
-			    conns[i].remote_addr.family) {
+			if (remote_addr->sa_family == AF_INET6 &&
+			    remote_addr->sa_family ==
+			    conns[i].remote_addr.sa_family) {
 				if (!net_ipv6_addr_cmp(
 					    &net_sin6(remote_addr)->sin6_addr,
 					    &net_sin6(&conns[i].remote_addr)->
@@ -478,9 +478,9 @@ static int find_conn_handler(enum net_ip_protocol proto,
 			} else
 #endif
 #if defined(CONFIG_NET_IPV4)
-			if (remote_addr->family == AF_INET &&
-			    remote_addr->family ==
-			    conns[i].remote_addr.family) {
+			if (remote_addr->sa_family == AF_INET &&
+			    remote_addr->sa_family ==
+			    conns[i].remote_addr.sa_family) {
 				if (!net_ipv4_addr_cmp(
 					    &net_sin(remote_addr)->sin_addr,
 					    &net_sin(&conns[i].remote_addr)->
@@ -504,9 +504,9 @@ static int find_conn_handler(enum net_ip_protocol proto,
 			}
 
 #if defined(CONFIG_NET_IPV6)
-			if (local_addr->family == AF_INET6 &&
-			    local_addr->family ==
-			    conns[i].local_addr.family) {
+			if (local_addr->sa_family == AF_INET6 &&
+			    local_addr->sa_family ==
+			    conns[i].local_addr.sa_family) {
 				if (!net_ipv6_addr_cmp(
 					    &net_sin6(local_addr)->sin6_addr,
 					    &net_sin6(&conns[i].local_addr)->
@@ -516,9 +516,9 @@ static int find_conn_handler(enum net_ip_protocol proto,
 			} else
 #endif
 #if defined(CONFIG_NET_IPV4)
-			if (local_addr->family == AF_INET &&
-			    local_addr->family ==
-			    conns[i].local_addr.family) {
+			if (local_addr->sa_family == AF_INET &&
+			    local_addr->sa_family ==
+			    conns[i].local_addr.sa_family) {
 				if (!net_ipv4_addr_cmp(
 					    &net_sin(local_addr)->sin_addr,
 					    &net_sin(&conns[i].local_addr)->
@@ -578,8 +578,8 @@ int net_conn_register(enum net_ip_protocol proto,
 		}
 
 		if (remote_addr) {
-			if (remote_addr->family != AF_INET &&
-			    remote_addr->family != AF_INET6) {
+			if (remote_addr->sa_family != AF_INET &&
+			    remote_addr->sa_family != AF_INET6) {
 				NET_ERR("Remote address family not set.");
 				return -EINVAL;
 			}
@@ -590,7 +590,7 @@ int net_conn_register(enum net_ip_protocol proto,
 			       sizeof(struct sockaddr));
 
 #if defined(CONFIG_NET_IPV6)
-			if (remote_addr->family == AF_INET6) {
+			if (remote_addr->sa_family == AF_INET6) {
 				if (net_is_ipv6_addr_unspecified(
 					    &net_sin6(remote_addr)->
 							sin6_addr)) {
@@ -602,7 +602,7 @@ int net_conn_register(enum net_ip_protocol proto,
 #endif
 
 #if defined(CONFIG_NET_IPV4)
-			if (remote_addr->family == AF_INET) {
+			if (remote_addr->sa_family == AF_INET) {
 				if (!net_sin(remote_addr)->
 							sin_addr.s_addr) {
 					rank |= NET_RANK_REMOTE_UNSPEC_ADDR;
@@ -614,8 +614,8 @@ int net_conn_register(enum net_ip_protocol proto,
 		}
 
 		if (local_addr) {
-			if (local_addr->family != AF_INET &&
-			    local_addr->family != AF_INET6) {
+			if (local_addr->sa_family != AF_INET &&
+			    local_addr->sa_family != AF_INET6) {
 				NET_ERR("Local address family not set.");
 				return -EINVAL;
 			}
@@ -626,7 +626,7 @@ int net_conn_register(enum net_ip_protocol proto,
 			       sizeof(struct sockaddr));
 
 #if defined(CONFIG_NET_IPV6)
-			if (local_addr->family == AF_INET6) {
+			if (local_addr->sa_family == AF_INET6) {
 				if (net_is_ipv6_addr_unspecified(
 					    &net_sin6(local_addr)->
 							sin6_addr)) {
@@ -638,7 +638,7 @@ int net_conn_register(enum net_ip_protocol proto,
 #endif
 
 #if defined(CONFIG_NET_IPV4)
-			if (local_addr->family == AF_INET) {
+			if (local_addr->sa_family == AF_INET) {
 				if (!net_sin(local_addr)->sin_addr.s_addr) {
 					rank |= NET_RANK_LOCAL_UNSPEC_ADDR;
 				} else {
@@ -649,7 +649,7 @@ int net_conn_register(enum net_ip_protocol proto,
 		}
 
 		if (remote_addr && local_addr) {
-			if (remote_addr->family != local_addr->family) {
+			if (remote_addr->sa_family != local_addr->sa_family) {
 				NET_ERR("Address families different.");
 				return -EINVAL;
 			}
@@ -688,7 +688,7 @@ int net_conn_register(enum net_ip_protocol proto,
 
 			NET_DBG("[%d/%d/%u/0x%02x] remote %p/%s/%u "
 				"local %p/%s/%u cb %p ud %p",
-				i, local_addr ? local_addr->family : AF_UNSPEC,
+				i, local_addr ? local_addr->sa_family : AF_UNSPEC,
 				proto, rank, remote_addr, dst, remote_port,
 				local_addr, src, local_port,
 				cb, user_data);
@@ -709,12 +709,12 @@ static bool check_addr(struct net_pkt *pkt,
 		       struct sockaddr *addr,
 		       bool is_remote)
 {
-	if (addr->family != net_pkt_family(pkt)) {
+	if (addr->sa_family != net_pkt_family(pkt)) {
 		return false;
 	}
 
 #if defined(CONFIG_NET_IPV6)
-	if (net_pkt_family(pkt) == AF_INET6 && addr->family == AF_INET6) {
+	if (net_pkt_family(pkt) == AF_INET6 && addr->sa_family == AF_INET6) {
 		struct in6_addr *addr6;
 
 		if (is_remote) {
@@ -736,7 +736,7 @@ static bool check_addr(struct net_pkt *pkt,
 #endif /* CONFIG_NET_IPV6 */
 
 #if defined(CONFIG_NET_IPV4)
-	if (net_pkt_family(pkt) == AF_INET && addr->family == AF_INET) {
+	if (net_pkt_family(pkt) == AF_INET && addr->sa_family == AF_INET) {
 		struct in_addr *addr4;
 
 		if (is_remote) {

--- a/subsys/net/ip/dhcpv4.c
+++ b/subsys/net/ip/dhcpv4.c
@@ -1103,7 +1103,7 @@ int dhcpv4_init(void)
 
 	net_ipaddr_copy(&net_sin(&local_addr)->sin_addr,
 			net_ipv4_unspecified_address());
-	local_addr.family = AF_INET;
+	local_addr.sa_family = AF_INET;
 
 	/* Register UDP input callback on
 	 * DHCPV4_SERVER_PORT(67) and DHCPV4_CLIENT_PORT(68) for

--- a/subsys/net/ip/net_context.c
+++ b/subsys/net/ip/net_context.c
@@ -162,7 +162,7 @@ static int tcp_backlog_find(struct net_pkt *pkt, int *empty_slot)
 			continue;
 		}
 
-		if (net_pkt_family(pkt) != tcp_backlog[i].remote.family) {
+		if (net_pkt_family(pkt) != tcp_backlog[i].remote.sa_family) {
 			continue;
 		}
 
@@ -370,7 +370,7 @@ static int check_used_port(enum net_ip_protocol ip_proto,
 			continue;
 		}
 
-		if (local_addr->family == AF_INET6) {
+		if (local_addr->sa_family == AF_INET6) {
 			if (net_ipv6_addr_cmp(
 				    net_sin6_ptr(&contexts[i].local)->
 							     sin6_addr,
@@ -776,7 +776,7 @@ int net_context_bind(struct net_context *context, const struct sockaddr *addr,
 	}
 
 #if defined(CONFIG_NET_IPV6)
-	if (addr->family == AF_INET6) {
+	if (addr->sa_family == AF_INET6) {
 		struct net_if *iface = NULL;
 		struct in6_addr *ptr;
 		struct sockaddr_in6 *addr6 = (struct sockaddr_in6 *)addr;
@@ -862,7 +862,7 @@ int net_context_bind(struct net_context *context, const struct sockaddr *addr,
 #endif
 
 #if defined(CONFIG_NET_IPV4)
-	if (addr->family == AF_INET) {
+	if (addr->sa_family == AF_INET) {
 		struct sockaddr_in *addr4 = (struct sockaddr_in *)addr;
 		struct net_if_addr *ifaddr;
 		struct net_if *iface;
@@ -1428,11 +1428,11 @@ int net_context_connect(struct net_context *context,
 		return ret;
 	}
 
-	if (addr->family != net_context_get_family(context)) {
-		NET_ASSERT_INFO(addr->family == \
+	if (addr->sa_family != net_context_get_family(context)) {
+		NET_ASSERT_INFO(addr->sa_family == \
 				net_context_get_family(context),
 				"Family mismatch %d should be %d",
-				addr->family,
+				addr->sa_family,
 				net_context_get_family(context));
 		return -EINVAL;
 	}
@@ -1938,7 +1938,7 @@ int net_context_accept(struct net_context *context,
 		}
 	}
 
-	local_addr.family = net_context_get_family(context);
+	local_addr.sa_family = net_context_get_family(context);
 
 #if defined(CONFIG_NET_IPV6)
 	if (net_context_get_family(context) == AF_INET6) {
@@ -2335,7 +2335,7 @@ static int recv_udp(struct net_context *context,
 		    void *user_data)
 {
 	struct sockaddr local_addr = {
-		.family = net_context_get_family(context),
+		.sa_family = net_context_get_family(context),
 	};
 	struct sockaddr *laddr = NULL;
 	u16_t lport = 0;

--- a/subsys/net/ip/net_shell.c
+++ b/subsys/net/ip/net_shell.c
@@ -604,7 +604,7 @@ static void conn_handler_cb(struct net_conn *conn, void *user_data)
 	char addr_remote[ADDR_LEN + 7] = "";
 
 #if defined(CONFIG_NET_IPV6)
-	if (conn->local_addr.family == AF_INET6) {
+	if (conn->local_addr.sa_family == AF_INET6) {
 		snprintk(addr_local, sizeof(addr_local), "[%s]:%u",
 			 net_sprint_ipv6_addr(
 				 &net_sin6(&conn->local_addr)->sin6_addr),
@@ -616,7 +616,7 @@ static void conn_handler_cb(struct net_conn *conn, void *user_data)
 	} else
 #endif
 #if defined(CONFIG_NET_IPV4)
-	if (conn->local_addr.family == AF_INET) {
+	if (conn->local_addr.sa_family == AF_INET) {
 		snprintk(addr_local, sizeof(addr_local), "%s:%d",
 			 net_sprint_ipv4_addr(
 				 &net_sin(&conn->local_addr)->sin_addr),
@@ -627,11 +627,11 @@ static void conn_handler_cb(struct net_conn *conn, void *user_data)
 			 ntohs(net_sin(&conn->remote_addr)->sin_port));
 	} else
 #endif
-	if (conn->local_addr.family == AF_UNSPEC) {
+	if (conn->local_addr.sa_family == AF_UNSPEC) {
 		snprintk(addr_local, sizeof(addr_local), "AF_UNSPEC");
 	} else {
 		snprintk(addr_local, sizeof(addr_local), "AF_UNK(%d)",
-			 conn->local_addr.family);
+			 conn->local_addr.sa_family);
 	}
 
 	printk("[%2d] %p %p\t%s\t%16s\t%16s\n",
@@ -1153,14 +1153,14 @@ static void print_dns_info(struct dns_resolve_context *ctx)
 	printk("DNS servers:\n");
 
 	for (i = 0; i < CONFIG_DNS_RESOLVER_MAX_SERVERS; i++) {
-		if (ctx->servers[i].dns_server.family == AF_INET) {
+		if (ctx->servers[i].dns_server.sa_family == AF_INET) {
 			printk("\t%s:%u\n",
 			       net_sprint_ipv4_addr(
 				       &net_sin(&ctx->servers[i].dns_server)->
 				       sin_addr),
 			       ntohs(net_sin(&ctx->servers[i].
 					     dns_server)->sin_port));
-		} else if (ctx->servers[i].dns_server.family == AF_INET6) {
+		} else if (ctx->servers[i].dns_server.sa_family == AF_INET6) {
 			printk("\t[%s]:%u\n",
 			       net_sprint_ipv6_addr(
 				       &net_sin6(&ctx->servers[i].dns_server)->
@@ -2144,7 +2144,7 @@ static int tcp_connect(char *host, u16_t port, struct net_context **ctx)
 	net_sin6(&addr)->sin6_port = htons(port);
 	addrlen = sizeof(struct sockaddr_in6);
 	get_my_ipv6_addr(net_if_get_default(), &myaddr);
-	family = addr.family = myaddr.family = AF_INET6;
+	family = addr.sa_family = myaddr.sa_family = AF_INET6;
 #endif
 
 #if defined(CONFIG_NET_IPV4) && !defined(CONFIG_NET_IPV6)
@@ -2157,7 +2157,7 @@ static int tcp_connect(char *host, u16_t port, struct net_context **ctx)
 	get_my_ipv4_addr(net_if_get_default(), &myaddr);
 	net_sin(&addr)->sin_port = htons(port);
 	addrlen = sizeof(struct sockaddr_in);
-	family = addr.family = myaddr.family = AF_INET;
+	family = addr.sa_family = myaddr.sa_family = AF_INET;
 #endif
 
 #if defined(CONFIG_NET_IPV6) && defined(CONFIG_NET_IPV4)
@@ -2172,12 +2172,12 @@ static int tcp_connect(char *host, u16_t port, struct net_context **ctx)
 		net_sin(&addr)->sin_port = htons(port);
 		addrlen = sizeof(struct sockaddr_in);
 		get_my_ipv4_addr(net_if_get_default(), &myaddr);
-		family = addr.family = myaddr.family = AF_INET;
+		family = addr.sa_family = myaddr.sa_family = AF_INET;
 	} else {
 		net_sin6(&addr)->sin6_port = htons(port);
 		addrlen = sizeof(struct sockaddr_in6);
 		get_my_ipv6_addr(net_if_get_default(), &myaddr);
-		family = addr.family = myaddr.family = AF_INET6;
+		family = addr.sa_family = myaddr.sa_family = AF_INET6;
 	}
 #endif
 

--- a/subsys/net/lib/app/client.c
+++ b/subsys/net/lib/app/client.c
@@ -48,7 +48,7 @@ static void dns_cb(enum dns_resolve_status status,
 #if defined(CONFIG_NET_IPV4)
 		net_ipaddr_copy(&net_sin(&ctx->ipv4.remote)->sin_addr,
 				&net_sin(&info->ai_addr)->sin_addr);
-		ctx->ipv4.remote.family = info->ai_family;
+		ctx->ipv4.remote.sa_family = info->ai_family;
 #else
 		goto out;
 #endif
@@ -56,7 +56,7 @@ static void dns_cb(enum dns_resolve_status status,
 #if defined(CONFIG_NET_IPV6)
 		net_ipaddr_copy(&net_sin6(&ctx->ipv6.remote)->sin6_addr,
 				&net_sin6(&info->ai_addr)->sin6_addr);
-		ctx->ipv6.remote.family = info->ai_family;
+		ctx->ipv6.remote.sa_family = info->ai_family;
 #else
 		goto out;
 #endif
@@ -96,7 +96,7 @@ static int resolve_name(struct net_app_ctx *ctx,
 
 	ctx->client.dns_id = 0;
 
-	if (ctx->default_ctx->remote.family == AF_UNSPEC) {
+	if (ctx->default_ctx->remote.sa_family == AF_UNSPEC) {
 		return -EINVAL;
 	}
 
@@ -207,7 +207,7 @@ static int set_remote_addr(struct net_app_ctx *ctx,
 
 	net_sin6(&ctx->ipv6.remote)->sin6_port = htons(peer_port);
 	net_sin6(&ctx->ipv6.remote)->sin6_family = AF_INET6;
-	ctx->ipv6.remote.family = AF_INET6;
+	ctx->ipv6.remote.sa_family = AF_INET6;
 	ctx->default_ctx = &ctx->ipv6;
 #endif /* IPV6 && !IPV4 */
 
@@ -230,7 +230,7 @@ static int set_remote_addr(struct net_app_ctx *ctx,
 
 	net_sin(&ctx->ipv4.remote)->sin_port = htons(peer_port);
 	net_sin(&ctx->ipv4.remote)->sin_family = AF_INET;
-	ctx->ipv4.remote.family = AF_INET;
+	ctx->ipv4.remote.sa_family = AF_INET;
 	ctx->default_ctx = &ctx->ipv4;
 #endif /* IPV6 && !IPV4 */
 
@@ -270,7 +270,7 @@ static int set_remote_addr(struct net_app_ctx *ctx,
 			net_sin6(&ctx->ipv6.remote)->sin6_port =
 				htons(peer_port);
 			net_sin6(&ctx->ipv6.remote)->sin6_family = AF_INET6;
-			ctx->ipv6.remote.family = AF_INET6;
+			ctx->ipv6.remote.sa_family = AF_INET6;
 			ctx->default_ctx = &ctx->ipv6;
 		}
 	} else {
@@ -279,7 +279,7 @@ static int set_remote_addr(struct net_app_ctx *ctx,
 #endif
 		net_sin(&ctx->ipv4.remote)->sin_port = htons(peer_port);
 		net_sin(&ctx->ipv4.remote)->sin_family = AF_INET;
-		ctx->ipv4.remote.family = AF_INET;
+		ctx->ipv4.remote.sa_family = AF_INET;
 		ctx->default_ctx = &ctx->ipv4;
 	}
 #endif /* IPV4 && IPV6 */
@@ -288,7 +288,7 @@ static int set_remote_addr(struct net_app_ctx *ctx,
 	 * then we cannot continue.
 	 */
 	if (!ctx->default_ctx ||
-	    ctx->default_ctx->remote.family == AF_UNSPEC) {
+	    ctx->default_ctx->remote.sa_family == AF_UNSPEC) {
 		NET_ERR("Unknown protocol family.");
 		return -EPFNOSUPPORT;
 	}
@@ -322,7 +322,7 @@ int net_app_init_client(struct net_app_ctx *ctx,
 	if (client_addr) {
 		memcpy(&addr, client_addr, sizeof(addr));
 	} else {
-		addr.family = AF_UNSPEC;
+		addr.sa_family = AF_UNSPEC;
 	}
 
 	ctx->app_type = NET_APP_CLIENT;
@@ -338,7 +338,7 @@ int net_app_init_client(struct net_app_ctx *ctx,
 	}
 
 	if (peer_addr) {
-		if (peer_addr->family == AF_INET) {
+		if (peer_addr->sa_family == AF_INET) {
 #if defined(CONFIG_NET_IPV4)
 			memcpy(&ctx->ipv4.remote, peer_addr,
 			       sizeof(ctx->ipv4.remote));
@@ -346,7 +346,7 @@ int net_app_init_client(struct net_app_ctx *ctx,
 #else
 			return -EPROTONOSUPPORT;
 #endif
-		} else if (peer_addr->family == AF_INET6) {
+		} else if (peer_addr->sa_family == AF_INET6) {
 #if defined(CONFIG_NET_IPV6)
 			memcpy(&ctx->ipv6.remote, peer_addr,
 			       sizeof(ctx->ipv6.remote));
@@ -371,8 +371,8 @@ int net_app_init_client(struct net_app_ctx *ctx,
 	}
 
 #if defined(CONFIG_NET_IPV4)
-	if (ctx->ipv4.remote.family == AF_INET) {
-		ctx->ipv4.local.family = AF_INET;
+	if (ctx->ipv4.remote.sa_family == AF_INET) {
+		ctx->ipv4.local.sa_family = AF_INET;
 		_net_app_set_local_addr(&ctx->ipv4.local, NULL,
 					net_sin(&ctx->ipv4.local)->sin_port);
 
@@ -388,8 +388,8 @@ int net_app_init_client(struct net_app_ctx *ctx,
 #endif
 
 #if defined(CONFIG_NET_IPV6)
-	if (ctx->ipv6.remote.family == AF_INET6) {
-		ctx->ipv6.local.family = AF_INET6;
+	if (ctx->ipv6.remote.sa_family == AF_INET6) {
+		ctx->ipv6.local.sa_family = AF_INET6;
 		_net_app_set_local_addr(&ctx->ipv6.local, NULL,
 				       net_sin6(&ctx->ipv6.local)->sin6_port);
 

--- a/subsys/net/lib/app/net_app.c
+++ b/subsys/net/lib/app/net_app.c
@@ -88,21 +88,21 @@ int net_app_set_net_pkt_pool(struct net_app_ctx *ctx,
 char *_net_app_sprint_ipaddr(char *buf, int buflen,
 			     const struct sockaddr *addr)
 {
-	if (addr->family == AF_INET6) {
+	if (addr->sa_family == AF_INET6) {
 #if defined(CONFIG_NET_IPV6)
 		char ipaddr[NET_IPV6_ADDR_LEN];
 
-		net_addr_ntop(addr->family,
+		net_addr_ntop(addr->sa_family,
 			      &net_sin6(addr)->sin6_addr,
 			      ipaddr, sizeof(ipaddr));
 		snprintk(buf, buflen, "[%s]:%u", ipaddr,
 			 ntohs(net_sin6(addr)->sin6_port));
 #endif
-	} else if (addr->family == AF_INET) {
+	} else if (addr->sa_family == AF_INET) {
 #if defined(CONFIG_NET_IPV4)
 		char ipaddr[NET_IPV4_ADDR_LEN];
 
-		net_addr_ntop(addr->family,
+		net_addr_ntop(addr->sa_family,
 			      &net_sin(addr)->sin_addr,
 			      ipaddr, sizeof(ipaddr));
 		snprintk(buf, buflen, "%s:%u", ipaddr,
@@ -231,14 +231,14 @@ int _net_app_set_local_addr(struct sockaddr *addr, const char *myaddr,
 	if (myaddr) {
 		void *inaddr;
 
-		if (addr->family == AF_INET) {
+		if (addr->sa_family == AF_INET) {
 #if defined(CONFIG_NET_IPV4)
 			inaddr = &net_sin(addr)->sin_addr;
 			net_sin(addr)->sin_port = htons(port);
 #else
 			return -EPFNOSUPPORT;
 #endif
-		} else if (addr->family == AF_INET6) {
+		} else if (addr->sa_family == AF_INET6) {
 #if defined(CONFIG_NET_IPV6)
 			inaddr = &net_sin6(addr)->sin6_addr;
 			net_sin6(addr)->sin6_port = htons(port);
@@ -249,13 +249,13 @@ int _net_app_set_local_addr(struct sockaddr *addr, const char *myaddr,
 			return -EAFNOSUPPORT;
 		}
 
-		return net_addr_pton(addr->family, myaddr, inaddr);
+		return net_addr_pton(addr->sa_family, myaddr, inaddr);
 	}
 
 	/* If the caller did not supply the address where to bind, then
 	 * try to figure it out ourselves.
 	 */
-	if (addr->family == AF_INET6) {
+	if (addr->sa_family == AF_INET6) {
 #if defined(CONFIG_NET_IPV6)
 		net_ipaddr_copy(&net_sin6(addr)->sin6_addr,
 				net_if_ipv6_select_src_addr(NULL,
@@ -264,7 +264,7 @@ int _net_app_set_local_addr(struct sockaddr *addr, const char *myaddr,
 #else
 		return -EPFNOSUPPORT;
 #endif
-	} else if (addr->family == AF_INET) {
+	} else if (addr->sa_family == AF_INET) {
 #if defined(CONFIG_NET_IPV4)
 		struct net_if *iface = net_if_get_default();
 
@@ -346,8 +346,8 @@ int _net_app_config_local_ctx(struct net_app_ctx *ctx,
 
 	if (!addr) {
 #if defined(CONFIG_NET_IPV6)
-		if (ctx->ipv6.local.family == AF_INET6 ||
-		    ctx->ipv6.local.family == AF_UNSPEC) {
+		if (ctx->ipv6.local.sa_family == AF_INET6 ||
+		    ctx->ipv6.local.sa_family == AF_UNSPEC) {
 			ret = setup_ipv6_ctx(ctx, sock_type, proto);
 		} else {
 			ret = -EPFNOSUPPORT;
@@ -356,8 +356,8 @@ int _net_app_config_local_ctx(struct net_app_ctx *ctx,
 #endif
 
 #if defined(CONFIG_NET_IPV4)
-		if (ctx->ipv4.local.family == AF_INET ||
-		    ctx->ipv4.local.family == AF_UNSPEC) {
+		if (ctx->ipv4.local.sa_family == AF_INET ||
+		    ctx->ipv4.local.sa_family == AF_UNSPEC) {
 			ret = setup_ipv4_ctx(ctx, sock_type, proto);
 		} else {
 			ret = -EPFNOSUPPORT;
@@ -367,7 +367,7 @@ int _net_app_config_local_ctx(struct net_app_ctx *ctx,
 
 		select_default_ctx(ctx);
 	} else {
-		if (addr->family == AF_INET6) {
+		if (addr->sa_family == AF_INET6) {
 #if defined(CONFIG_NET_IPV6)
 			ret = setup_ipv6_ctx(ctx, sock_type, proto);
 			ctx->default_ctx = &ctx->ipv6;
@@ -375,7 +375,7 @@ int _net_app_config_local_ctx(struct net_app_ctx *ctx,
 			ret = -EPFNOSUPPORT;
 			goto fail;
 #endif
-		} else if (addr->family == AF_INET) {
+		} else if (addr->sa_family == AF_INET) {
 #if defined(CONFIG_NET_IPV4)
 			ret = setup_ipv4_ctx(ctx, sock_type, proto);
 			ctx->default_ctx = &ctx->ipv4;
@@ -383,7 +383,7 @@ int _net_app_config_local_ctx(struct net_app_ctx *ctx,
 			ret = -EPFNOSUPPORT;
 			goto fail;
 #endif
-		} else if (addr->family == AF_UNSPEC) {
+		} else if (addr->sa_family == AF_UNSPEC) {
 #if defined(CONFIG_NET_IPV4)
 			ret = setup_ipv4_ctx(ctx, sock_type, proto);
 			ctx->default_ctx = &ctx->ipv4;
@@ -473,7 +473,7 @@ struct net_context *select_client_ctx(struct net_app_ctx *ctx,
 			return ctx->default_ctx->ctx;
 		} else {
 		common_checks:
-			if (dst->family == AF_INET) {
+			if (dst->sa_family == AF_INET) {
 #if defined(CONFIG_NET_IPV4)
 				return ctx->ipv4.ctx;
 #else
@@ -481,7 +481,7 @@ struct net_context *select_client_ctx(struct net_app_ctx *ctx,
 #endif
 			}
 
-			if (dst->family == AF_INET6) {
+			if (dst->sa_family == AF_INET6) {
 #if defined(CONFIG_NET_IPV6)
 				return ctx->ipv6.ctx;
 #else
@@ -489,7 +489,7 @@ struct net_context *select_client_ctx(struct net_app_ctx *ctx,
 #endif
 			}
 
-			if (dst->family == AF_UNSPEC) {
+			if (dst->sa_family == AF_UNSPEC) {
 				return ctx->default_ctx->ctx;
 			}
 		}
@@ -532,7 +532,7 @@ struct net_context *select_server_ctx(struct net_app_ctx *ctx,
 #endif
 			}
 
-			if (dst->family == AF_INET) {
+			if (dst->sa_family == AF_INET) {
 #if defined(CONFIG_NET_IPV4)
 				return ctx->ipv4.ctx;
 #else
@@ -540,7 +540,7 @@ struct net_context *select_server_ctx(struct net_app_ctx *ctx,
 #endif
 			}
 
-			if (dst->family == AF_INET6) {
+			if (dst->sa_family == AF_INET6) {
 #if defined(CONFIG_NET_IPV6)
 				return ctx->ipv6.ctx;
 #else
@@ -548,7 +548,7 @@ struct net_context *select_server_ctx(struct net_app_ctx *ctx,
 #endif
 			}
 
-			if (dst->family == AF_UNSPEC) {
+			if (dst->sa_family == AF_UNSPEC) {
 				return ctx->default_ctx->ctx;
 			}
 		}
@@ -778,7 +778,7 @@ struct net_pkt *net_app_get_net_pkt(struct net_app_ctx *ctx,
 		return NULL;
 	}
 
-	dst.family = family;
+	dst.sa_family = family;
 
 	net_ctx = _net_app_select_net_ctx(ctx, &dst);
 	if (!net_ctx) {

--- a/subsys/net/lib/app/server.c
+++ b/subsys/net/lib/app/server.c
@@ -106,8 +106,8 @@ int net_app_listen(struct net_app_ctx *ctx)
 	}
 
 #if defined(CONFIG_NET_IPV4)
-	if (ctx->ipv4.local.family == AF_UNSPEC) {
-		ctx->ipv4.local.family = AF_INET;
+	if (ctx->ipv4.local.sa_family == AF_UNSPEC) {
+		ctx->ipv4.local.sa_family = AF_INET;
 		dual = true;
 
 		_net_app_set_local_addr(&ctx->ipv4.local, NULL,
@@ -133,8 +133,8 @@ int net_app_listen(struct net_app_ctx *ctx)
 	/* We ignore the IPv4 error if IPv6 is enabled */
 
 #if defined(CONFIG_NET_IPV6)
-	if (ctx->ipv6.local.family == AF_UNSPEC || dual) {
-		ctx->ipv6.local.family = AF_INET6;
+	if (ctx->ipv6.local.sa_family == AF_UNSPEC || dual) {
+		ctx->ipv6.local.sa_family = AF_INET6;
 
 		_net_app_set_local_addr(&ctx->ipv6.local, NULL,
 				       net_sin6(&ctx->ipv6.local)->sin6_port);
@@ -184,7 +184,7 @@ int net_app_init_server(struct net_app_ctx *ctx,
 #endif
 
 	if (server_addr) {
-		if (server_addr->family == AF_INET) {
+		if (server_addr->sa_family == AF_INET) {
 #if defined(CONFIG_NET_IPV4)
 			memcpy(&ctx->ipv4.local, server_addr,
 			       sizeof(ctx->ipv4.local));
@@ -193,7 +193,7 @@ int net_app_init_server(struct net_app_ctx *ctx,
 #endif
 		}
 
-		if (server_addr->family == AF_INET6) {
+		if (server_addr->sa_family == AF_INET6) {
 #if defined(CONFIG_NET_IPV6)
 			memcpy(&ctx->ipv6.local, server_addr,
 			       sizeof(ctx->ipv6.local));
@@ -207,11 +207,11 @@ int net_app_init_server(struct net_app_ctx *ctx,
 		}
 
 #if defined(CONFIG_NET_IPV4)
-		ctx->ipv4.local.family = AF_INET;
+		ctx->ipv4.local.sa_family = AF_INET;
 		net_sin(&ctx->ipv4.local)->sin_port = htons(port);
 #endif
 #if defined(CONFIG_NET_IPV6)
-		ctx->ipv6.local.family = AF_INET6;
+		ctx->ipv6.local.sa_family = AF_INET6;
 		net_sin6(&ctx->ipv6.local)->sin6_port = htons(port);
 #endif
 	}

--- a/subsys/net/lib/dns/resolve.c
+++ b/subsys/net/lib/dns/resolve.c
@@ -145,7 +145,7 @@ int dns_resolve_init(struct dns_resolve_context *ctx, const char *servers[])
 			NET_DBG("[%d] IPv6 server %s port %d", idx, server,
 				port);
 
-			ctx->servers[idx++].dns_server.family = AF_INET6;
+			ctx->servers[idx++].dns_server.sa_family = AF_INET6;
 #endif /* CONFIG_NET_IPV6 */
 
 			continue;
@@ -196,7 +196,7 @@ int dns_resolve_init(struct dns_resolve_context *ctx, const char *servers[])
 			NET_DBG("[%d] IPv4 server %s port %d", idx, server,
 				port);
 
-			ctx->servers[idx++].dns_server.family = AF_INET;
+			ctx->servers[idx++].dns_server.sa_family = AF_INET;
 #endif /* CONFIG_NET_IPV4 */
 
 			continue;
@@ -218,7 +218,7 @@ int dns_resolve_init(struct dns_resolve_context *ctx, const char *servers[])
 			NET_DBG("[%d] IPv4 server %s port %d", idx, servers[i],
 				53);
 
-			ctx->servers[idx++].dns_server.family = AF_INET;
+			ctx->servers[idx++].dns_server.sa_family = AF_INET;
 
 		} else if (ret == -EINVAL) {
 			/* Then the address must be IPv6 based */
@@ -239,7 +239,7 @@ int dns_resolve_init(struct dns_resolve_context *ctx, const char *servers[])
 			NET_DBG("[%d] IPv6 server %s port %d", idx, servers[i],
 				53);
 
-			ctx->servers[idx++].dns_server.family = AF_INET6;
+			ctx->servers[idx++].dns_server.sa_family = AF_INET6;
 		}
 #endif
 
@@ -258,7 +258,7 @@ int dns_resolve_init(struct dns_resolve_context *ctx, const char *servers[])
 		NET_DBG("[%d] IPv4 server %s port %d", idx, servers[i], 53);
 
 		net_sin(&ctx->servers[idx].dns_server)->sin_port = htons(53);
-		ctx->servers[idx++].dns_server.family = AF_INET;
+		ctx->servers[idx++].dns_server.sa_family = AF_INET;
 #endif /* IPv4 && !IPv6 */
 
 #if defined(CONFIG_NET_IPV6) && !defined(CONFIG_NET_IPV4)
@@ -275,14 +275,14 @@ int dns_resolve_init(struct dns_resolve_context *ctx, const char *servers[])
 		NET_DBG("[%d] IPv6 server %s port %d", idx, servers[i], 53);
 
 		net_sin6(&ctx->servers[idx].dns_server)->sin6_port = htons(53);
-		ctx->servers[idx++].dns_server.family = AF_INET6;
+		ctx->servers[idx++].dns_server.sa_family = AF_INET6;
 #endif /* IPv6 && !IPv4 */
 	}
 
 	for (i = 0, count = 0; i < CONFIG_DNS_RESOLVER_MAX_SERVERS &&
-		     ctx->servers[i].dns_server.family; i++) {
+		     ctx->servers[i].dns_server.sa_family; i++) {
 
-		if (ctx->servers[i].dns_server.family == AF_INET6) {
+		if (ctx->servers[i].dns_server.sa_family == AF_INET6) {
 #if defined(CONFIG_NET_IPV6)
 			local_addr = (struct sockaddr *)&local_addr6;
 			addr_len = sizeof(struct sockaddr_in6);
@@ -291,7 +291,7 @@ int dns_resolve_init(struct dns_resolve_context *ctx, const char *servers[])
 #endif
 		}
 
-		if (ctx->servers[i].dns_server.family == AF_INET) {
+		if (ctx->servers[i].dns_server.sa_family == AF_INET) {
 #if defined(CONFIG_NET_IPV4)
 			local_addr = (struct sockaddr *)&local_addr4;
 			addr_len = sizeof(struct sockaddr_in);
@@ -305,7 +305,7 @@ int dns_resolve_init(struct dns_resolve_context *ctx, const char *servers[])
 			return -EAFNOSUPPORT;
 		}
 
-		ret = net_context_get(ctx->servers[i].dns_server.family,
+		ret = net_context_get(ctx->servers[i].dns_server.sa_family,
 				      SOCK_DGRAM, IPPROTO_UDP,
 				      &ctx->servers[i].net_ctx);
 		if (ret < 0) {
@@ -436,13 +436,13 @@ static int dns_read(struct dns_resolve_context *ctx,
 		address_size = DNS_IPV4_LEN;
 		addr = (u8_t *)&net_sin(&info->ai_addr)->sin_addr;
 		info->ai_family = AF_INET;
-		info->ai_addr.family = AF_INET;
+		info->ai_addr.sa_family = AF_INET;
 		info->ai_addrlen = sizeof(struct sockaddr_in);
 	} else if (ctx->queries[query_idx].query_type == DNS_QUERY_TYPE_AAAA) {
 		address_size = DNS_IPV6_LEN;
 		addr = (u8_t *)&net_sin6(&info->ai_addr)->sin6_addr;
 		info->ai_family = AF_INET6;
-		info->ai_addr.family = AF_INET6;
+		info->ai_addr.sa_family = AF_INET6;
 		info->ai_addrlen = sizeof(struct sockaddr_in6);
 	} else {
 		ret = DNS_EAI_FAMILY;
@@ -686,7 +686,7 @@ static int dns_write(struct dns_resolve_context *ctx,
 		goto quit;
 	}
 
-	if (server->family == AF_INET) {
+	if (server->sa_family == AF_INET) {
 		server_addr_len = sizeof(struct sockaddr_in);
 	} else {
 		server_addr_len = sizeof(struct sockaddr_in6);

--- a/subsys/net/lib/http/http_client.c
+++ b/subsys/net/lib/http/http_client.c
@@ -523,7 +523,7 @@ out:
 
 static int get_local_addr(struct http_client_ctx *ctx)
 {
-	if (ctx->tcp.local.family == AF_INET6) {
+	if (ctx->tcp.local.sa_family == AF_INET6) {
 #if defined(CONFIG_NET_IPV6)
 		struct in6_addr *dst = &net_sin6(&ctx->tcp.remote)->sin6_addr;
 
@@ -532,7 +532,7 @@ static int get_local_addr(struct http_client_ctx *ctx)
 #else
 		return -EPFNOSUPPORT;
 #endif
-	} else if (ctx->tcp.local.family == AF_INET) {
+	} else if (ctx->tcp.local.sa_family == AF_INET) {
 #if defined(CONFIG_NET_IPV4)
 		struct net_if *iface = net_if_get_default();
 
@@ -558,7 +558,7 @@ static int tcp_connect(struct http_client_ctx *ctx)
 		return -EALREADY;
 	}
 
-	if (ctx->tcp.remote.family == AF_INET6) {
+	if (ctx->tcp.remote.sa_family == AF_INET6) {
 		addrlen = sizeof(struct sockaddr_in6);
 
 		/* If we are reconnecting, then make sure the source port
@@ -579,7 +579,7 @@ static int tcp_connect(struct http_client_ctx *ctx)
 		return ret;
 	}
 
-	ret = net_context_get(ctx->tcp.remote.family, SOCK_STREAM,
+	ret = net_context_get(ctx->tcp.remote.sa_family, SOCK_STREAM,
 			      IPPROTO_TCP, &ctx->tcp.ctx);
 	if (ret) {
 		NET_DBG("Get context error (%d)", ret);
@@ -634,10 +634,10 @@ static inline void print_info(struct http_client_ctx *ctx,
 	char local[NET_IPV6_ADDR_LEN];
 	char remote[NET_IPV6_ADDR_LEN];
 
-	sprint_addr(local, NET_IPV6_ADDR_LEN, ctx->tcp.local.family,
+	sprint_addr(local, NET_IPV6_ADDR_LEN, ctx->tcp.local.sa_family,
 		    &ctx->tcp.local);
 
-	sprint_addr(remote, NET_IPV6_ADDR_LEN, ctx->tcp.remote.family,
+	sprint_addr(remote, NET_IPV6_ADDR_LEN, ctx->tcp.remote.sa_family,
 		    &ctx->tcp.remote);
 
 	NET_DBG("HTTP %s (%s) %s -> %s port %d",
@@ -1395,7 +1395,7 @@ static void dns_cb(enum dns_resolve_status status,
 		goto out;
 	}
 
-	ctx->tcp.remote.family = info->ai_family;
+	ctx->tcp.remote.sa_family = info->ai_family;
 
 out:
 	k_sem_give(&waiter->wait);
@@ -1433,7 +1433,7 @@ static int resolve_name(struct http_client_ctx *ctx,
 
 	ctx->dns_id = 0;
 
-	if (ctx->tcp.remote.family == AF_UNSPEC) {
+	if (ctx->tcp.remote.sa_family == AF_UNSPEC) {
 		return -EINVAL;
 	}
 
@@ -1535,7 +1535,7 @@ static inline int set_remote_addr(struct http_client_ctx *ctx,
 	/* If we have not yet figured out what is the protocol family,
 	 * then we cannot continue.
 	 */
-	if (ctx->tcp.remote.family == AF_UNSPEC) {
+	if (ctx->tcp.remote.sa_family == AF_UNSPEC) {
 		NET_ERR("Unknown protocol family.");
 		return -EPFNOSUPPORT;
 	}
@@ -1560,7 +1560,7 @@ int http_client_init(struct http_client_ctx *ctx,
 			return ret;
 		}
 
-		ctx->tcp.local.family = ctx->tcp.remote.family;
+		ctx->tcp.local.sa_family = ctx->tcp.remote.sa_family;
 		ctx->server = server;
 	}
 
@@ -1676,7 +1676,7 @@ int https_client_init(struct http_client_ctx *ctx,
 			return ret;
 		}
 
-		ctx->tcp.local.family = ctx->tcp.remote.family;
+		ctx->tcp.local.sa_family = ctx->tcp.remote.sa_family;
 		ctx->server = server;
 	}
 

--- a/subsys/net/lib/http/http_server.c
+++ b/subsys/net/lib/http/http_server.c
@@ -328,14 +328,14 @@ int http_server_set_local_addr(struct sockaddr *addr, const char *myaddr,
 	if (myaddr) {
 		void *inaddr;
 
-		if (addr->family == AF_INET) {
+		if (addr->sa_family == AF_INET) {
 #if defined(CONFIG_NET_IPV4)
 			inaddr = &net_sin(addr)->sin_addr;
 			net_sin(addr)->sin_port = htons(port);
 #else
 			return -EPFNOSUPPORT;
 #endif
-		} else if (addr->family == AF_INET6) {
+		} else if (addr->sa_family == AF_INET6) {
 #if defined(CONFIG_NET_IPV6)
 			inaddr = &net_sin6(addr)->sin6_addr;
 			net_sin6(addr)->sin6_port = htons(port);
@@ -346,13 +346,13 @@ int http_server_set_local_addr(struct sockaddr *addr, const char *myaddr,
 			return -EAFNOSUPPORT;
 		}
 
-		return net_addr_pton(addr->family, myaddr, inaddr);
+		return net_addr_pton(addr->sa_family, myaddr, inaddr);
 	}
 
 	/* If the caller did not supply the address where to bind, then
 	 * try to figure it out ourselves.
 	 */
-	if (addr->family == AF_INET6) {
+	if (addr->sa_family == AF_INET6) {
 #if defined(CONFIG_NET_IPV6)
 		net_ipaddr_copy(&net_sin6(addr)->sin6_addr,
 				net_if_ipv6_select_src_addr(NULL,
@@ -361,7 +361,7 @@ int http_server_set_local_addr(struct sockaddr *addr, const char *myaddr,
 #else
 		return -EPFNOSUPPORT;
 #endif
-	} else if (addr->family == AF_INET) {
+	} else if (addr->sa_family == AF_INET) {
 #if defined(CONFIG_NET_IPV4)
 		struct net_if *iface = net_if_get_default();
 
@@ -453,21 +453,21 @@ int http_server_del_default(struct http_server_urls *my)
 #if defined(CONFIG_NET_DEBUG_HTTP) && (CONFIG_SYS_LOG_NET_LEVEL > 2)
 static char *sprint_ipaddr(char *buf, int buflen, const struct sockaddr *addr)
 {
-	if (addr->family == AF_INET6) {
+	if (addr->sa_family == AF_INET6) {
 #if defined(CONFIG_NET_IPV6)
 		char ipaddr[NET_IPV6_ADDR_LEN];
 
-		net_addr_ntop(addr->family,
+		net_addr_ntop(addr->sa_family,
 			      &net_sin6(addr)->sin6_addr,
 			      ipaddr, sizeof(ipaddr));
 		snprintk(buf, buflen, "[%s]:%u", ipaddr,
 			 ntohs(net_sin6(addr)->sin6_port));
 #endif
-	} else if (addr->family == AF_INET) {
+	} else if (addr->sa_family == AF_INET) {
 #if defined(CONFIG_NET_IPV4)
 		char ipaddr[NET_IPV4_ADDR_LEN];
 
-		net_addr_ntop(addr->family,
+		net_addr_ntop(addr->sa_family,
 			      &net_sin(addr)->sin_addr,
 			      ipaddr, sizeof(ipaddr));
 		snprintk(buf, buflen, "%s:%u", ipaddr,
@@ -855,8 +855,8 @@ static int setup_ipv4_ctx(struct http_server_ctx *http_ctx,
 	net_context_setup_pools(http_ctx->net_ipv4_ctx, http_ctx->tx_slab,
 				http_ctx->data_pool);
 
-	if (addr->family == AF_UNSPEC) {
-		addr->family = AF_INET;
+	if (addr->sa_family == AF_UNSPEC) {
+		addr->sa_family = AF_INET;
 
 		http_server_set_local_addr(addr, NULL,
 					   net_sin(addr)->sin_port);
@@ -892,8 +892,8 @@ int setup_ipv6_ctx(struct http_server_ctx *http_ctx, struct sockaddr *addr)
 	net_context_setup_pools(http_ctx->net_ipv6_ctx, http_ctx->tx_slab,
 				http_ctx->data_pool);
 
-	if (addr->family == AF_UNSPEC) {
-		addr->family = AF_INET6;
+	if (addr->sa_family == AF_UNSPEC) {
+		addr->sa_family = AF_INET6;
 
 		http_server_set_local_addr(addr, NULL,
 					   net_sin6(addr)->sin6_port);
@@ -922,30 +922,30 @@ static int init_net(struct http_server_ctx *ctx,
 	if (server_addr) {
 		memcpy(&addr, server_addr, sizeof(addr));
 	} else {
-		addr.family = AF_UNSPEC;
+		addr.sa_family = AF_UNSPEC;
 		net_sin(&addr)->sin_port = htons(port);
 	}
 
-	if (addr.family == AF_INET6) {
+	if (addr.sa_family == AF_INET6) {
 #if defined(CONFIG_NET_IPV6)
 		ret = setup_ipv6_ctx(ctx, &addr);
 #else
 		return -EPFNOSUPPORT;
 #endif
-	} else if (addr.family == AF_INET) {
+	} else if (addr.sa_family == AF_INET) {
 #if defined(CONFIG_NET_IPV4)
 		ret = setup_ipv4_ctx(ctx, &addr);
 #else
 		return -EPFNOSUPPORT;
 #endif
-	} else if (addr.family == AF_UNSPEC) {
+	} else if (addr.sa_family == AF_UNSPEC) {
 #if defined(CONFIG_NET_IPV4)
 		ret = setup_ipv4_ctx(ctx, &addr);
 #endif
 		/* We ignore the IPv4 error if IPv6 is enabled */
 #if defined(CONFIG_NET_IPV6)
 		memset(&addr, 0, sizeof(addr));
-		addr.family = AF_UNSPEC;
+		addr.sa_family = AF_UNSPEC;
 		net_sin6(&addr)->sin6_port = htons(port);
 
 		ret = setup_ipv6_ctx(ctx, &addr);

--- a/subsys/net/lib/lwm2m/lwm2m_engine.c
+++ b/subsys/net/lib/lwm2m/lwm2m_engine.c
@@ -118,19 +118,19 @@ char *lwm2m_sprint_ip_addr(const struct sockaddr *addr)
 	static char buf[NET_IPV6_ADDR_LEN];
 
 #if defined(CONFIG_NET_IPV6)
-	if (addr->family == AF_INET6) {
+	if (addr->sa_family == AF_INET6) {
 		return net_addr_ntop(AF_INET6, &net_sin6(addr)->sin6_addr,
 				     buf, sizeof(buf));
 	}
 #endif
 #if defined(CONFIG_NET_IPV4)
-	if (addr->family == AF_INET) {
+	if (addr->sa_family == AF_INET) {
 		return net_addr_ntop(AF_INET, &net_sin(addr)->sin_addr,
 				     buf, sizeof(buf));
 	}
 #endif
 
-	SYS_LOG_ERR("Unknown IP address family:%d", addr->family);
+	SYS_LOG_ERR("Unknown IP address family:%d", addr->sa_family);
 	return NULL;
 }
 

--- a/subsys/net/lib/lwm2m/lwm2m_obj_firmware_pull.c
+++ b/subsys/net/lib/lwm2m/lwm2m_obj_firmware_pull.c
@@ -238,9 +238,9 @@ static void firmware_transfer(struct k_work *work)
 
 #if defined(CONFIG_NET_IPV6)
 	if (family == AF_INET6) {
-		firmware_addr.family = family;
+		firmware_addr.sa_family = family;
 		/* HACK: use firmware_uri directly as IP address */
-		net_addr_pton(firmware_addr.family, firmware_uri,
+		net_addr_pton(firmware_addr.sa_family, firmware_uri,
 			      &net_sin6(&firmware_addr)->sin6_addr);
 		net_sin6(&firmware_addr)->sin6_port = htons(5685);
 	}
@@ -248,14 +248,14 @@ static void firmware_transfer(struct k_work *work)
 
 #if defined(CONFIG_NET_IPV4)
 	if (family == AF_INET) {
-		firmware_addr.family = family;
-		net_addr_pton(firmware_addr.family, firmware_uri,
+		firmware_addr.sa_family = family;
+		net_addr_pton(firmware_addr.sa_family, firmware_uri,
 			      &net_sin(&firmware_addr)->sin_addr);
 		net_sin(&firmware_addr)->sin_port = htons(5685);
 	}
 #endif
 
-	ret = net_context_get(firmware_addr.family, SOCK_DGRAM, IPPROTO_UDP,
+	ret = net_context_get(firmware_addr.sa_family, SOCK_DGRAM, IPPROTO_UDP,
 			      &firmware_net_ctx);
 	if (ret) {
 		NET_ERR("Could not get an UDP context (err:%d)", ret);
@@ -269,7 +269,7 @@ static void firmware_transfer(struct k_work *work)
 	}
 
 #if defined(CONFIG_NET_IPV6)
-	if (firmware_addr.family == AF_INET6) {
+	if (firmware_addr.sa_family == AF_INET6) {
 		ret = net_context_bind(firmware_net_ctx,
 				       (struct sockaddr *)&any_addr6,
 				       sizeof(any_addr6));
@@ -277,7 +277,7 @@ static void firmware_transfer(struct k_work *work)
 #endif
 
 #if defined(CONFIG_NET_IPV4)
-	if (firmware_addr.family == AF_INET) {
+	if (firmware_addr.sa_family == AF_INET) {
 		ret = net_context_bind(firmware_net_ctx,
 				       (struct sockaddr *)&any_addr4,
 				       sizeof(any_addr4));

--- a/subsys/net/lib/lwm2m/lwm2m_rd_client.c
+++ b/subsys/net/lib/lwm2m/lwm2m_rd_client.c
@@ -784,14 +784,14 @@ static bool peer_addr_exist(struct sockaddr *peer_addr)
 	/* look for duplicate peer_addr */
 	for (i = 0; i < client_count; i++) {
 #if defined(CONFIG_NET_IPV6)
-		if (peer_addr->family == AF_INET6 && net_ipv6_addr_cmp(
+		if (peer_addr->sa_family == AF_INET6 && net_ipv6_addr_cmp(
 				&net_sin6(&clients[i].bs_server)->sin6_addr,
 				&net_sin6(peer_addr)->sin6_addr)) {
 			ret = true;
 			break;
 		}
 
-		if (peer_addr->family == AF_INET6 && net_ipv6_addr_cmp(
+		if (peer_addr->sa_family == AF_INET6 && net_ipv6_addr_cmp(
 				&net_sin6(&clients[i].reg_server)->sin6_addr,
 				&net_sin6(peer_addr)->sin6_addr)) {
 			ret = true;
@@ -800,14 +800,14 @@ static bool peer_addr_exist(struct sockaddr *peer_addr)
 #endif
 
 #if defined(CONFIG_NET_IPV4)
-		if (peer_addr->family == AF_INET && net_ipv4_addr_cmp(
+		if (peer_addr->sa_family == AF_INET && net_ipv4_addr_cmp(
 				&net_sin(&clients[i].bs_server)->sin_addr,
 				&net_sin(peer_addr)->sin_addr)) {
 			ret = true;
 			break;
 		}
 
-		if (peer_addr->family == AF_INET && net_ipv4_addr_cmp(
+		if (peer_addr->sa_family == AF_INET && net_ipv4_addr_cmp(
 				&net_sin(&clients[i].reg_server)->sin_addr,
 				&net_sin(peer_addr)->sin_addr)) {
 			ret = true;
@@ -822,24 +822,24 @@ static bool peer_addr_exist(struct sockaddr *peer_addr)
 static void set_ep_ports(int index)
 {
 #if defined(CONFIG_NET_IPV6)
-	if (clients[index].bs_server.family == AF_INET6) {
+	if (clients[index].bs_server.sa_family == AF_INET6) {
 		net_sin6(&clients[index].bs_server)->sin6_port =
 			htons(LWM2M_BOOTSTRAP_PORT);
 	}
 
-	if (clients[index].reg_server.family == AF_INET6) {
+	if (clients[index].reg_server.sa_family == AF_INET6) {
 		net_sin6(&clients[index].reg_server)->sin6_port =
 			htons(LWM2M_PEER_PORT);
 	}
 #endif
 
 #if defined(CONFIG_NET_IPV4)
-	if (clients[index].bs_server.family == AF_INET) {
+	if (clients[index].bs_server.sa_family == AF_INET) {
 		net_sin(&clients[index].bs_server)->sin_port =
 			htons(LWM2M_BOOTSTRAP_PORT);
 	}
 
-	if (clients[index].reg_server.family == AF_INET) {
+	if (clients[index].reg_server.sa_family == AF_INET) {
 		net_sin(&clients[index].reg_server)->sin_port =
 			htons(LWM2M_PEER_PORT);
 	}

--- a/subsys/net/lib/zoap/zoap.c
+++ b/subsys/net/lib/zoap/zoap.c
@@ -372,14 +372,14 @@ struct zoap_reply *zoap_reply_next_unused(
 
 static inline bool is_addr_unspecified(const struct sockaddr *addr)
 {
-	if (addr->family == AF_UNSPEC) {
+	if (addr->sa_family == AF_UNSPEC) {
 		return true;
 	}
 
-	if (addr->family == AF_INET6) {
+	if (addr->sa_family == AF_INET6) {
 		return net_is_ipv6_addr_unspecified(
 			&(net_sin6(addr)->sin6_addr));
-	} else if (addr->family == AF_INET) {
+	} else if (addr->sa_family == AF_INET) {
 		return net_sin(addr)->sin_addr.s4_addr32[0] == 0;
 	}
 
@@ -757,11 +757,11 @@ static bool sockaddr_equal(const struct sockaddr *a,
 	 * FIXME: Should we consider ipv6-mapped ipv4 addresses as equal to
 	 * ipv4 addresses?
 	 */
-	if (a->family != b->family) {
+	if (a->sa_family != b->sa_family) {
 		return false;
 	}
 
-	if (a->family == AF_INET) {
+	if (a->sa_family == AF_INET) {
 		const struct sockaddr_in *a4 = net_sin(a);
 		const struct sockaddr_in *b4 = net_sin(b);
 
@@ -772,7 +772,7 @@ static bool sockaddr_equal(const struct sockaddr *a,
 		return net_ipv4_addr_cmp(&a4->sin_addr, &b4->sin_addr);
 	}
 
-	if (b->family == AF_INET6) {
+	if (b->sa_family == AF_INET6) {
 		const struct sockaddr_in6 *a6 = net_sin6(a);
 		const struct sockaddr_in6 *b6 = net_sin6(b);
 

--- a/tests/net/lib/dns_resolve/src/main.c
+++ b/tests/net/lib/dns_resolve/src/main.c
@@ -370,7 +370,7 @@ static void dns_query_ipv4_server_count(void)
 			continue;
 		}
 
-		if (ctx->servers[i].dns_server.family == AF_INET) {
+		if (ctx->servers[i].dns_server.sa_family == AF_INET) {
 			count++;
 		}
 
@@ -398,7 +398,7 @@ static void dns_query_ipv6_server_count(void)
 			continue;
 		}
 
-		if (ctx->servers[i].dns_server.family == AF_INET6) {
+		if (ctx->servers[i].dns_server.sa_family == AF_INET6) {
 			count++;
 		}
 

--- a/tests/net/lib/zoap/src/main.c
+++ b/tests/net/lib/zoap/src/main.c
@@ -587,14 +587,14 @@ done:
 
 static bool ipaddr_cmp(const struct sockaddr *a, const struct sockaddr *b)
 {
-	if (a->family != b->family) {
+	if (a->sa_family != b->sa_family) {
 		return false;
 	}
 
-	if (a->family == AF_INET6) {
+	if (a->sa_family == AF_INET6) {
 		return net_ipv6_addr_cmp(&net_sin6(a)->sin6_addr,
 					 &net_sin6(b)->sin6_addr);
-	} else if (a->family == AF_INET) {
+	} else if (a->sa_family == AF_INET) {
 		return net_ipv4_addr_cmp(&net_sin(a)->sin_addr,
 					 &net_sin(b)->sin_addr);
 	}


### PR DESCRIPTION
Story behind the change: I decided to port one of BSD Sockets samples to IPv6 after all, to let be run on 6lowpan device. Fairly speaking, I needed just sockaddr_storage, but decided do my homework well and also fix struct sockaddr. Seeing it's more or less big change, I split it to a separate commit.