### PR TITLE
Bluetooth: controller: Fix controller assert at clock rollover

### DIFF
--- a/subsys/bluetooth/controller/ticker/ticker.c
+++ b/subsys/bluetooth/controller/ticker/ticker.c
@@ -419,7 +419,7 @@ static void ticks_to_expire_prep(struct ticker_node *ticker,
 	u16_t ticks_to_expire_minus = ticker->ticks_to_expire_minus;
 
 	/* Calculate ticks to expire for this new node */
-	if (((ticks_at_start - ticks_current) & BIT(31)) == 0) {
+	if (((ticks_at_start - ticks_current) & BIT(23)) == 0) {
 		ticks_to_expire += ticker_ticks_diff_get(ticks_at_start,
 							 ticks_current);
 	} else {


### PR DESCRIPTION
Fix controller assert due to a bug introduced in commit
07270e52ba45 ("Bluetooth: controller: Coding style and
refactoring").

This reverts implementation to original way it was and the
calculation of the ticker expiry will now not overflow the
range of the RTC peripheral, which is a 24 bit counter.

Signed-off-by: Vinayak Kariappa Chettimada <vich@nordicsemi.no>