### PR TITLE
esp32: Fix redefinition of BIT() macro

### DIFF
--- a/arch/xtensa/soc/esp32/soc.c
+++ b/arch/xtensa/soc/esp32/soc.c
@@ -4,13 +4,15 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+/* Include esp-idf headers first to avoid redefining BIT() macro */
 #include <soc/dport_reg.h>
 #include <soc/rtc_cntl_reg.h>
 #include <soc/timer_group_reg.h>
-#include <string.h>
-#include <toolchain/gcc.h>
 #include <xtensa/config/core-isa.h>
 #include <xtensa/corebits.h>
+
+#include <string.h>
+#include <toolchain/gcc.h>
 #include <zephyr/types.h>
 
 extern void _Cstart(void);

--- a/drivers/gpio/gpio_esp32.c
+++ b/drivers/gpio/gpio_esp32.c
@@ -4,10 +4,12 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+/* Include esp-idf headers first to avoid redefining BIT() macro */
 #include <rom/ets_sys.h>
 #include <soc/dport_reg.h>
 #include <soc/gpio_reg.h>
 #include <soc/soc.h>
+
 #include <errno.h>
 #include <device.h>
 #include <gpio.h>

--- a/drivers/pinmux/pinmux_esp32.c
+++ b/drivers/pinmux/pinmux_esp32.c
@@ -4,9 +4,11 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+/* Include esp-idf headers first to avoid redefining BIT() macro */
 #include <soc/gpio_reg.h>
 #include <soc/io_mux_reg.h>
 #include <soc/soc.h>
+
 #include <errno.h>
 #include <misc/util.h>
 #include <pinmux.h>

--- a/drivers/serial/uart_esp32.c
+++ b/drivers/serial/uart_esp32.c
@@ -4,11 +4,11 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-/* include rom/uart.h (from the esp-dif package) before Z's uart.h so
- * that the definition of BIT is not overriden */
+/* Include esp-idf headers first to avoid redefining BIT() macro */
 #include <rom/uart.h>
-#include <uart.h>
 #include <rom/ets_sys.h>
+
+#include <uart.h>
 #include <errno.h>
 
 static unsigned char esp32_uart_tx(struct device *dev,

--- a/drivers/watchdog/wdt_esp32.c
+++ b/drivers/watchdog/wdt_esp32.c
@@ -4,13 +4,14 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <string.h>
-#include <watchdog.h>
-#include <device.h>
-
+/* Include esp-idf headers first to avoid redefining BIT() macro */
 #include <rom/ets_sys.h>
 #include <soc/rtc_cntl_reg.h>
 #include <soc/timer_group_reg.h>
+
+#include <string.h>
+#include <watchdog.h>
+#include <device.h>
 
 struct wdt_esp32_data {
 	struct wdt_config config;


### PR DESCRIPTION
Esp-idf defines the BIT macro that is also defined in Zephyr's
misc/util.h.  Fix the issue by including the esp-idf headers first, so
that a check in util.h won't redefine the macro if it's already
defined.

Signed-off-by: Leandro Pereira <leandro.pereira@intel.com>