### PR TITLE
TinyCrypt fixes

### DIFF
--- a/tests/crypto/ecc_dh/src/ecc_dh.c
+++ b/tests/crypto/ecc_dh/src/ecc_dh.c
@@ -94,7 +94,7 @@ int ecdh_vectors(char **qx_vec, char **qy_vec, char **d_vec, char **z_vec,
 		uint8_t private_bytes[NUM_ECC_BYTES];
 		uECC_vli_nativeToBytes(private_bytes, NUM_ECC_BYTES, prv);
 		uint8_t z_bytes[NUM_ECC_BYTES];
-		uECC_vli_nativeToBytes(z_bytes, NUM_ECC_BYTES, z);
+		uECC_vli_nativeToBytes(z_bytes, NUM_ECC_BYTES, exp_z);
 
 		rc = uECC_shared_secret(pub_bytes, private_bytes, z_bytes, curve);
 


### PR DESCRIPTION
TinyCrypt 0.2.7 has a stack overflow in `uECC_shared_secret()`.  A fix has been sent upstream and has been merged.  This is a backport, and fixes some of the test failures under NIOS-II architecture.

Also fixes the test harness to use the `exp_z` array when calling `uECC_vli_nativeToBytes()` instead of the -- at the time of the call -- uninitialized `z` array.
