### PR TITLE
doc: fix typos and licensing text

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -15,7 +15,7 @@ resource-constrained systems: from simple embedded environmental sensors and
 LED wearables to sophisticated smart watches and IoT wireless gateways.
 
 The Zephyr kernel supports multiple architectures, including ARM Cortex-M,
-Intel x86, ARC, NIOS II and RISC V, and a large number of
+Intel x86, ARC, NIOS II, Tensilica Xtensa, and RISC V, and a large number of
 `supported boards`_.
 
 .. below included in doc/introduction/introduction.rst

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -25,7 +25,7 @@ Zephyr Project Documentation
 For more information about previous releases, please consult the published
 :ref:`zephyr_release_notes`.
 
-The Zephyr OS is provided under the :download:`Apache 2.0 license. <../LICENSE>`.
+The Zephyr OS is provided under the :download:`Apache 2.0 license<../LICENSE>`.
 The Zephyr OS also imports or reuses packages, scripts, and other files that
 are not covered by the Apache License. A list of those licenses can be found
 under :ref:`zephyr_licensing`.

--- a/doc/introduction/introducing_zephyr.rst
+++ b/doc/introduction/introducing_zephyr.rst
@@ -14,8 +14,16 @@ boards can be found :ref:`here <boards>`.
 Licensing
 *********
 
-The Zephyr project associated with the kernel makes it available
-to users and developers under the Apache License, version 2.0.
+Zephyr uses the `Apache 2.0 license`_ (as found in the LICENSE file in the
+project's `GitHub repo`_).  There are some
+imported or reused components of the Zephyr project that use other licensing,
+as described in :ref:`Zephyr_Licensing`.
+
+.. _Apache 2.0 license:
+   https://github.com/zephyrproject-rtos/zephyr/blob/master/LICENSE
+
+.. _GitHub repo: https://github.com/zephyrproject-rtos/zephyr
+
 
 Distinguishing Features
 ***********************


### PR DESCRIPTION
Also updated architecture support list in the repo's README.rst

Signed-off-by: David B. Kinder <david.b.kinder@intel.com>