### PR TITLE
net: shell: Fix build when NET_DEBUG_APP defined, but client/server - not

### DIFF
--- a/subsys/net/ip/net_shell.c
+++ b/subsys/net/ip/net_shell.c
@@ -994,6 +994,8 @@ static void net_app_cb(struct net_app_ctx *ctx, void *user_data)
 
 	return;
 }
+#elif defined(CONFIG_NET_DEBUG_APP)
+static void net_app_cb(struct net_app_ctx *ctx, void *user_data) {}
 #endif
 
 int net_shell_cmd_app(int argc, char *argv[])


### PR DESCRIPTION
If CONFIG_NET_DEBUG_APP was defined, but neither NET_APP_SERVER nor
NET_APP_CLIENT, build failed due to net_app_cb() haven't beeen
defined. So, define it to empty in this case.

Signed-off-by: Paul Sokolovsky <paul.sokolovsky@linaro.org>