### PR TITLE
net: app: Allow to set static IPv4 netmask and gateway

### DIFF
--- a/subsys/net/lib/app/Kconfig
+++ b/subsys/net/lib/app/Kconfig
@@ -167,6 +167,19 @@ config NET_APP_MY_IPV4_ADDR
 	help
 	  Use 192.0.2.1 here if uncertain.
 
+config NET_APP_MY_IPV4_NETMASK
+	string "My IPv4 netmask"
+	default "255.255.255.0"
+	help
+	  Static netmask to use if not overriden by DHCP. Use empty value to
+	  skip setting static value.
+
+config NET_APP_MY_IPV4_GW
+	string "My IPv4 gateway"
+	help
+	  Static gateway to use if not overriden by DHCP. Use empty value to
+	  skip setting static value.
+
 config NET_APP_PEER_IPV4_ADDR
 	string "Peer IPv4 address"
 	help

--- a/subsys/net/lib/app/init.c
+++ b/subsys/net/lib/app/init.c
@@ -120,6 +120,28 @@ static void setup_ipv4(struct net_if *iface)
 		 net_addr_ntop(AF_INET, &addr, hr_addr, NET_IPV4_ADDR_LEN));
 #endif
 
+	if (sizeof(CONFIG_NET_APP_MY_IPV4_NETMASK) > 1) {
+		/* If not empty */
+		if (net_addr_pton(AF_INET, CONFIG_NET_APP_MY_IPV4_NETMASK,
+				  &addr)) {
+			NET_ERR("Invalid netmask: %s",
+				CONFIG_NET_APP_MY_IPV4_NETMASK);
+		} else {
+			net_if_ipv4_set_netmask(iface, &addr);
+		}
+	}
+
+	if (sizeof(CONFIG_NET_APP_MY_IPV4_GW) > 1) {
+		/* If not empty */
+		if (net_addr_pton(AF_INET, CONFIG_NET_APP_MY_IPV4_GW,
+				  &addr)) {
+			NET_ERR("Invalid gateway: %s",
+				CONFIG_NET_APP_MY_IPV4_GW);
+		} else {
+			net_if_ipv4_set_gw(iface, &addr);
+		}
+	}
+
 	k_sem_take(&counter, K_NO_WAIT);
 	k_sem_give(&waiter);
 }


### PR DESCRIPTION
Setting just IPv4 address as was allowed before isn't enough for
real-world usage (e.g. accessing DNS and outside servers in general).

Signed-off-by: Paul Sokolovsky <paul.sokolovsky@linaro.org>