### PR TITLE
tests: kernel: Use SYS_LOG_INF instead of TC_PRINT

### DIFF
--- a/tests/kernel/irq_offload/src/irq_offload.c
+++ b/tests/kernel/irq_offload/src/irq_offload.c
@@ -17,7 +17,7 @@ static void offload_function(void *param)
 {
 	u32_t x = (u32_t)param;
 
-	TC_PRINT("offload_function running\n");
+	SYS_LOG_INF("offload_function running\n");
 
 	/* Make sure we're in IRQ context */
 	zassert_true(_is_in_isr(), "Not in IRQ context!\n");

--- a/tests/kernel/xip/src/main.c
+++ b/tests/kernel/xip/src/main.c
@@ -5,12 +5,12 @@
  */
 
 #include <ztest.h>
-extern void test_xip(void);
+extern void test_globals(void);
 
 /**test case main entry*/
 void test_main(void)
 {
-	ztest_test_suite(test_xip_fn,
-		ztest_unit_test(test_xip));
-	ztest_run_test_suite(test_xip_fn);
+	ztest_test_suite(test_xip,
+		ztest_unit_test(test_globals));
+	ztest_run_test_suite(test_xip);
 }

--- a/tests/kernel/xip/src/xip.c
+++ b/tests/kernel/xip/src/xip.c
@@ -24,17 +24,9 @@
  * @return N/A
  */
 
-void test_xip(void)
+void test_globals(void)
 {
 	int  i;
-
-	TC_START("kernel_xip");
-	PRINT_DATA("Starting XIP tests\n");
-	PRINT_LINE;
-
-	/* Test globals are correct */
-
-	TC_PRINT("Test globals\n");
 
 	/* Array should be filled with monotomically incrementing values */
 	for (i = 0; i < XIP_TEST_ARRAY_SZ; i++) {

--- a/tests/ztest/include/ztest.h
+++ b/tests/ztest/include/ztest.h
@@ -47,5 +47,6 @@
 #include <ztest_mock.h>
 #include <ztest_test.h>
 #include <tc_util.h>
+#include <logging/sys_log.h>
 
 #endif /* __ZTEST_H__ */


### PR DESCRIPTION
Do not print messages by default on console for test cases.
Use SYS_LOG_INF which provides functionality to choose print whenever
require.

Signed-off-by: Punit Vara <punit.vara@intel.com>