### PR TITLE
net: ip: Prevent unaligned exception

### DIFF
--- a/include/net/net_ip.h
+++ b/include/net/net_ip.h
@@ -488,7 +488,7 @@ static inline bool net_is_my_ipv4_addr(const struct in_addr *addr)
 static inline bool net_ipv4_addr_cmp(const struct in_addr *addr1,
 				     const struct in_addr *addr2)
 {
-	return addr1->s_addr == addr2->s_addr;
+	return UNALIGNED_GET(&addr1->s_addr) == UNALIGNED_GET(&addr2->s_addr);
 }
 
 /**


### PR DESCRIPTION
s_addr is actually an unsigned integer and it's not guaranteed to be
aligned on 4-byte boundary. In net_ipv4_addr_cmp(), accessing s_addr
directly might cause an unaligned exception on some platform
like xtensa. Use memcmp() to prevent unalgined exception.

Signed-off-by: Aska Wu <aska.wu@linaro.org>