### PR TITLE
Bluetooth: controller: Enable Read Remote Ver Info bit

### DIFF
--- a/subsys/bluetooth/controller/hci/hci.c
+++ b/subsys/bluetooth/controller/hci/hci.c
@@ -423,6 +423,8 @@ static void read_supported_commands(struct net_buf *buf, struct net_buf **evt)
 	rp->status = 0x00;
 	memset(&rp->commands[0], 0, sizeof(rp->commands));
 
+	/* Read Remote Version Info. */
+	rp->commands[2] |= BIT(7);
 	/* Set Event Mask, and Reset. */
 	rp->commands[5] |= BIT(6) | BIT(7);
 #if defined(CONFIG_BT_HCI_ACL_FLOW_CONTROL)


### PR DESCRIPTION
The Read Remote Version Information command is supported on the BLE
controller, enable the bit in Read Local Supported Commands to reflect
this.

Signed-off-by: Carles Cufi <carles.cufi@nordicsemi.no>