### PR TITLE
Bluetooth: controller: Fix RL index check

### DIFF
--- a/subsys/bluetooth/controller/ll_sw/ll_filter.h
+++ b/subsys/bluetooth/controller/ll_sw/ll_filter.h
@@ -32,4 +32,4 @@ u8_t ll_rl_find(u8_t id_addr_type, u8_t *id_addr, u8_t *free);
 bool ctrl_rl_addr_allowed(u8_t id_addr_type, u8_t *id_addr, u8_t *rl_idx);
 bool ctrl_rl_addr_resolve(u8_t id_addr_type, u8_t *id_addr, u8_t rl_idx);
 bool ctrl_rl_idx_allowed(u8_t irkmatch_ok, u8_t rl_idx);
-void ll_rl_pdu_adv_update(int idx, struct pdu_adv *pdu);
+void ll_rl_pdu_adv_update(u8_t idx, struct pdu_adv *pdu);


### PR DESCRIPTION
In the ll_rl_pdu_adv_update() function, the check to verify if we are
dealing with an item from the resolving list or else with a simple
standard non-privacy enabled device was left over from the previous
iteration, which used negative values. Replace that check with the
proper current one, using the size of the rl array as an indicator of
whether the index is valid.

Signed-off-by: Carles Cufi <carles.cufi@nordicsemi.no>