### PR TITLE
doc: 1.9: Elaborate on BSD Sockets and some other factual fixes

### DIFF
--- a/doc/release-notes-1.9.rst
+++ b/doc/release-notes-1.9.rst
@@ -10,8 +10,8 @@ We are pleased to announce the release of Zephyr kernel version 1.9.0
 
 Major enhancements planned with this release include:
 
-* POSIX API Layer
-* BSD Socket Support
+* Pthreads compatible API
+* BSD Sockets compatible API
 * Expand Device Tree support to more architectures
 * BLE Mesh
 * Bluetooth 5.0 Support (all features except Advertising Extensions)
@@ -64,10 +64,12 @@ Networking
 * Network sample application configuration file unification, where most of the
   similar configuration files were merged together
 * Added Bluetooth support to HTTP(S) server sample application
-* BSD socket layer fixes and enhancements
+* BSD Socket compatible API layer, allowing to write and/or port simple
+  networking applications using a well-known, cross-platform API
 * Networking API documentation fixes
 * Network shell enhancements
 * Trickle algorithm fixes
+* Improvements to HTTP server and client libraries
 * CoAP API fixes
 * IPv6 fixes
 * RPL fixes


### PR DESCRIPTION
There're no "POSIX API support", of POSIX features, only subsets of
Pthreads and BSD Sockets APIs are implemented.

Also, mention HTTP client/server improvements.

Signed-off-by: Paul Sokolovsky <paul.sokolovsky@linaro.org>