### PR TITLE
arm: Add partition table to hexiwear

### DIFF
--- a/dts/arm/hexiwear_k64.dts
+++ b/dts/arm/hexiwear_k64.dts
@@ -72,3 +72,45 @@
 	current-speed = <115200>;
 };
 #endif
+
+&flash0 {
+	/*
+	 * If chosen's zephyr,code-partition
+	 * is unset, the image will be linked
+	 * into the entire flash device.  If
+	 * it points to an individual
+	 * partition, the code will be linked
+	 * to, and restricted to that
+	 * partition.
+	 */
+	partitions {
+		compatible = "fixed-partitions";
+		#address-cells = <1>;
+		#size-cells = <1>;
+
+		boot_partition: partition@0 {
+			label = "mcuboot";
+			reg = <0x00000000 0x00010000>;
+			read-only;
+		};
+
+		/*
+		 * The flash starting at 0x00010000 and ending at
+		 * 0x0001ffff (sectors 16-31) is reserved for use
+		 * by the application.
+		 */
+
+		slot0_partition: partition@20000 {
+			label = "image-0";
+			reg = <0x00020000 0x00060000>;
+		};
+		slot1_partition: partition@80000 {
+			label = "image-1";
+			reg = <0x00080000 0x00060000>;
+		};
+		scratch_partition: partition@e0000 {
+			label = "image-scratch";
+			reg = <0x000e0000 0x00020000>;
+		};
+	};
+};


### PR DESCRIPTION
Use the same partition table as is used on the frdm_k64 board.

Signed-off-by: David Brown <david.brown@linaro.org>