### PR TITLE
doc: remove use of :download: directive

### DIFF
--- a/doc/LICENSING.rst
+++ b/doc/LICENSING.rst
@@ -6,18 +6,25 @@ Licensing of Zephyr Project components
 ######################################
 
 The Zephyr kernel tree imports or reuses packages, scripts and other files that
-are not covered by the :download:`Apache License <../LICENSE>`. In some places
+are not covered by the `Apache 2.0 License`_. In some places
 there is no LICENSE file or way to put a LICENSE file there, so we describe the
 licensing in this document.
 
+.. _Apache 2.0 License:
+   https://github.com/zephyrproject-rtos/zephyr/blob/master/LICENSE
+
+.. _GPLv2 License:
+   https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/plain/COPYING
 
 *kconfig* and *kbuild*
   *Origin:* Linux Kernel
-  *Licensing:* *GPLv2*
+
+  *Licensing:* `GPLv2 License`_
 
 *scripts/{checkpatch.pl,checkstack.pl,get_maintainers.pl,spelling.txt}*
   *Origin:* Linux Kernel
-  *Licensing:* *GPLv2*
+
+  *Licensing:* `GPLv2 License`_
 
 *ext/fs/fat/*
   *Origin:* FatFs is a file system based on the FAT file system specification.  This is
@@ -42,19 +49,31 @@ licensing in this document.
 *ext/hal/cmsis/*
   *Origin:* https://github.com/ARM-software/CMSIS.git
 
-  *Licensing*: :download:`CMSIS_END_USER_LICENCE_AGREEMENT <../ext/hal/cmsis/CMSIS_END_USER_LICENCE_AGREEMENT.pdf>`
+  *Licensing*: `CMSIS END USER LICENCE AGREEMENT`_
+
+.. _CMSIS END USER LICENCE AGREEMENT:
+   https://github.com/zephyrproject-rtos/zephyr/blob/master/ext/hal/cmsis/CMSIS_END_USER_LICENCE_AGREEMENT.pdf
 
 *ext/hal/nordic/*
   *Origin:*
 
-  *Licensing*: 3-clause BSD (see :download:`source <../ext/hal/nordic/mdk/nrf51.h>`)
+  *Licensing*: 3-clause BSD (see `ext/hal/nordic source`_)
+
+.. _ext/hal/nordic source:
+   https://github.com/zephyrproject-rtos/zephyr/blob/master/ext/hal/nordic/mdk/nrf51.h
 
 *ext/hal/nxp/mcux/*
   *Origin:* http://mcux.nxp.com
 
-  *Licensing*: 3-clause BSD (see :download:`source <../ext/hal/nxp/mcux/drivers/fsl_rtc.h>`)
+  *Licensing*: 3-clause BSD (see `ext/hal/nxp/mcux source`_)
+
+.. _ext/hal/nxp/mcux source:
+   https://github.com/zephyrproject-rtos/zephyr/blob/master/ext/hal/nxp/mcux/drivers/fsl_rtc.h
 
 *ext/hal/qmsi/*
   *Origin:* https://github.com/quark-mcu/qmsi/releases
 
-  *Licensing*: 3-clause BSD (see :download:`source <../ext/hal/qmsi/include/qm_common.h>`)
+  *Licensing*: 3-clause BSD (see `ext/hal/qmsi source`_)
+
+.. _ext/hal/qmsi source:
+   https://github.com/zephyrproject-rtos/zephyr/blob/master/ext/hal/qmsi/include/qm_common.h

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -25,16 +25,19 @@ Zephyr Project Documentation
 For more information about previous releases, please consult the published
 :ref:`zephyr_release_notes`.
 
-The Zephyr OS is provided under the :download:`Apache 2.0 license<../LICENSE>`.
-The Zephyr OS also imports or reuses packages, scripts, and other files that
-are not covered by the Apache License. A list of those licenses can be found
-under :ref:`zephyr_licensing`.
+The Zephyr OS is provided under the `Apache 2.0 license`_ (as found in
+the LICENSE file in the project's `GitHub repo`_).  The Zephyr OS also
+imports or reuses packages, scripts, and other files that use other
+licensing, as described in :ref:`Zephyr_Licensing`.
 
-Source code for the Zephyr Project is maintained in the
-`Zephyr Project GitHub repository`_.
+Source code for the Zephyr Project is maintained in the Zephyr Project's
+`GitHub repo`_.
 
-.. _Zephyr Project GitHub repository:
-   https://github.com/zephyrproject-rtos/zephyr
+.. _Apache 2.0 license:
+   https://github.com/zephyrproject-rtos/zephyr/blob/master/LICENSE
+
+.. _GitHub repo: https://github.com/zephyrproject-rtos/zephyr
+
 
 Sections
 ********


### PR DESCRIPTION
The :download: directive doesn't format well on output, and also
links to files that likely have linux line endings that don't
display well on Windows systems.

fixes: #1204

Signed-off-by: David B. Kinder <david.b.kinder@intel.com>