### PR TITLE
net: Fix out-of-bounds access when registering connections

### DIFF
--- a/subsys/net/ip/connection.c
+++ b/subsys/net/ip/connection.c
@@ -362,7 +362,7 @@ int net_conn_unregister(struct net_conn_handle *handle)
 	NET_DBG("[%zu] connection handler %p removed",
 		(conn - conns) / sizeof(*conn), conn);
 
-	conn->flags = 0;
+	memset(conn, 0, sizeof(*conn));
 
 	return 0;
 }


### PR DESCRIPTION
If either a remote or a local address were supplied to the
net_conn_register() function, the IP stack would proceed to copy
sizeof(struct sockaddr) bytes from the respective remote_addr
or local_addr pointers, regardless of the actual size of the storage
these pointers point to.

Use the proper size depending on the socket address family.

Coverity-ID: 173630
Signed-off-by: Leandro Pereira <leandro.pereira@intel.com>