### PR TITLE
Bluetooth: controller: Fix Read Peer RPA Command

### DIFF
--- a/subsys/bluetooth/controller/hci/hci.c
+++ b/subsys/bluetooth/controller/hci/hci.c
@@ -1202,7 +1202,7 @@ static void le_read_peer_rpa(struct net_buf *buf, struct net_buf **evt)
 	bt_addr_le_copy(&peer_id_addr, &cmd->peer_id_addr);
 	rp = cmd_complete(evt, sizeof(*rp));
 
-	rp->status = ll_rl_prpa_get(&peer_id_addr, &rp->peer_rpa);
+	rp->status = ll_rl_crpa_get(&peer_id_addr, &rp->peer_rpa);
 }
 
 static void le_read_local_rpa(struct net_buf *buf, struct net_buf **evt)
@@ -1686,6 +1686,16 @@ static void le_advertising_report(struct pdu_data *pdu_data, u8_t *b,
 #endif /* CONFIG_BT_CTLR_EXT_SCAN_FP */
 	s8_t *prssi;
 
+#if defined(CONFIG_BT_CTLR_PRIVACY)
+	rl_idx = b[offsetof(struct radio_pdu_node_rx, pdu_data) +
+		   offsetof(struct pdu_adv, payload) + adv->len + 1];
+	/* Update current RPA */
+	if (adv->tx_addr) {
+		ll_rl_crpa_set(0x00, NULL, rl_idx,
+			       &adv->payload.adv_ind.addr[0]);
+	}
+#endif
+
 	if (!(event_mask & BT_EVT_MASK_LE_META_EVENT)) {
 		return;
 	}
@@ -1735,8 +1745,6 @@ static void le_advertising_report(struct pdu_data *pdu_data, u8_t *b,
 		dir_info->evt_type = c_adv_type[PDU_ADV_TYPE_DIRECT_IND];
 
 #if defined(CONFIG_BT_CTLR_PRIVACY)
-		rl_idx = b[offsetof(struct radio_pdu_node_rx, pdu_data) +
-			   offsetof(struct pdu_adv, payload) + adv->len + 1];
 		if (rl_idx < ll_rl_size_get()) {
 			/* Store identity address */
 			ll_rl_id_addr_get(rl_idx, &dir_info->addr.type,
@@ -1917,6 +1925,13 @@ static void le_conn_complete(struct pdu_data *pdu_data, u16_t handle,
 	struct bt_hci_evt_le_conn_complete *lecc;
 	struct radio_le_conn_cmplt *radio_cc;
 
+	radio_cc = (struct radio_le_conn_cmplt *) (pdu_data->payload.lldata);
+
+#if defined(CONFIG_BT_CTLR_PRIVACY)
+	/* Update current RPA */
+	ll_rl_crpa_set(radio_cc->peer_addr_type, &radio_cc->peer_addr[0],
+		       0xff, &radio_cc->peer_rpa[0]);
+#endif
 	if (!(event_mask & BT_EVT_MASK_LE_META_EVENT) ||
 	    (!(le_event_mask & BT_EVT_MASK_LE_CONN_COMPLETE) &&
 #if defined(CONFIG_BT_CTLR_PRIVACY)
@@ -1926,8 +1941,6 @@ static void le_conn_complete(struct pdu_data *pdu_data, u16_t handle,
 #endif /* CONFIG_BT_CTLR_PRIVACY */
 		return;
 	}
-
-	radio_cc = (struct radio_le_conn_cmplt *) (pdu_data->payload.lldata);
 
 	if (!radio_cc->status) {
 		conn_count++;

--- a/subsys/bluetooth/controller/include/ll.h
+++ b/subsys/bluetooth/controller/include/ll.h
@@ -46,7 +46,8 @@ u32_t ll_rl_clear(void);
 u32_t ll_rl_add(bt_addr_le_t *id_addr, const u8_t pirk[16],
 		const u8_t lirk[16]);
 u32_t ll_rl_remove(bt_addr_le_t *id_addr);
-u32_t ll_rl_prpa_get(bt_addr_le_t *id_addr, bt_addr_t *prpa);
+void ll_rl_crpa_set(u8_t id_addr_type, u8_t *id_addr, u8_t rl_idx, u8_t *crpa);
+u32_t ll_rl_crpa_get(bt_addr_le_t *id_addr, bt_addr_t *crpa);
 u32_t ll_rl_lrpa_get(bt_addr_le_t *id_addr, bt_addr_t *lrpa);
 u32_t ll_rl_enable(u8_t enable);
 void  ll_rl_timeout_set(u16_t timeout);


### PR DESCRIPTION
There are 2 possible interpretations regarding the address to return in
response to the Read Peer RPA HCI Command:

1) The RPA that the local controller generates to be used in certain
packets it sends
2) The RPA generated and used by the peer device in its packets

We used to return 1) but our interpretation turned out to be incorrect
when reading the HCI test specification, so this commit switches to
returning 2).

Signed-off-by: Carles Cufi <carles.cufi@nordicsemi.no>