### PR TITLE
kernel: Use SYS_DLIST_FOR_EACH_CONTAINER whenever possible

### DIFF
--- a/kernel/include/timeout_q.h
+++ b/kernel/include/timeout_q.h
@@ -108,11 +108,11 @@ static inline void _handle_one_expired_timeout(struct _timeout *timeout)
 
 static inline void _handle_expired_timeouts(sys_dlist_t *expired)
 {
-	sys_dnode_t *timeout, *next;
+	struct _timeout *timeout, *next;
 
-	SYS_DLIST_FOR_EACH_NODE_SAFE(expired, timeout, next) {
-		sys_dlist_remove(timeout);
-		_handle_one_expired_timeout((struct _timeout *)timeout);
+	SYS_DLIST_FOR_EACH_CONTAINER_SAFE(expired, timeout, next, node) {
+		sys_dlist_remove(&timeout->node);
+		_handle_one_expired_timeout(timeout);
 	}
 }
 
@@ -161,13 +161,13 @@ static inline void _dump_timeout(struct _timeout *timeout, int extra_tab)
 static inline void _dump_timeout_q(void)
 {
 #ifdef CONFIG_KERNEL_DEBUG
-	sys_dnode_t *node;
+	struct _timeout *timeout;
 
 	K_DEBUG("_timeout_q: %p, head: %p, tail: %p\n",
 		&_timeout_q, _timeout_q.head, _timeout_q.tail);
 
-	SYS_DLIST_FOR_EACH_NODE(&_timeout_q, node) {
-		_dump_timeout((struct _timeout *)node, 1);
+	SYS_DLIST_FOR_EACH_CONTAINER(&_timeout_q, timeout, node) {
+		_dump_timeout(timeout, 1);
 	}
 #endif
 }

--- a/kernel/mailbox.c
+++ b/kernel/mailbox.c
@@ -240,9 +240,8 @@ static int _mbox_message_put(struct k_mbox *mbox, struct k_mbox_msg *tx_msg,
 			     s32_t timeout)
 {
 	struct k_thread *sending_thread;
-	struct k_thread *receiving_thread;
+	struct k_thread *receiving_thread, *next;
 	struct k_mbox_msg *rx_msg;
-	sys_dnode_t *wait_q_item, *next_wait_q_item;
 	unsigned int key;
 
 	/* save sender id so it can be used during message matching */
@@ -255,10 +254,8 @@ static int _mbox_message_put(struct k_mbox *mbox, struct k_mbox_msg *tx_msg,
 	/* search mailbox's rx queue for a compatible receiver */
 	key = irq_lock();
 
-	SYS_DLIST_FOR_EACH_NODE_SAFE(&mbox->rx_msg_queue, wait_q_item,
-				     next_wait_q_item) {
-
-		receiving_thread = (struct k_thread *)wait_q_item;
+	SYS_DLIST_FOR_EACH_CONTAINER_SAFE(&mbox->rx_msg_queue, receiving_thread,
+					  next, base.k_q_node) {
 		rx_msg = (struct k_mbox_msg *)receiving_thread->base.swap_data;
 
 		if (_mbox_message_match(tx_msg, rx_msg) == 0) {
@@ -428,9 +425,8 @@ static int _mbox_message_data_check(struct k_mbox_msg *rx_msg, void *buffer)
 int k_mbox_get(struct k_mbox *mbox, struct k_mbox_msg *rx_msg, void *buffer,
 	       s32_t timeout)
 {
-	struct k_thread *sending_thread;
+	struct k_thread *sending_thread, *next;
 	struct k_mbox_msg *tx_msg;
-	sys_dnode_t *wait_q_item, *next_wait_q_item;
 	unsigned int key;
 	int result;
 
@@ -440,10 +436,9 @@ int k_mbox_get(struct k_mbox *mbox, struct k_mbox_msg *rx_msg, void *buffer,
 	/* search mailbox's tx queue for a compatible sender */
 	key = irq_lock();
 
-	SYS_DLIST_FOR_EACH_NODE_SAFE(&mbox->tx_msg_queue, wait_q_item,
-				     next_wait_q_item) {
+	SYS_DLIST_FOR_EACH_CONTAINER_SAFE(&mbox->tx_msg_queue, sending_thread,
+					  next, base.k_q_node) {
 
-		sending_thread = (struct k_thread *)wait_q_item;
 		tx_msg = (struct k_mbox_msg *)sending_thread->base.swap_data;
 
 		if (_mbox_message_match(tx_msg, rx_msg) == 0) {

--- a/kernel/sched.c
+++ b/kernel/sched.c
@@ -188,13 +188,12 @@ void _pend_thread(struct k_thread *thread, _wait_q_t *wait_q, s32_t timeout)
 {
 #ifdef CONFIG_MULTITHREADING
 	sys_dlist_t *wait_q_list = (sys_dlist_t *)wait_q;
-	sys_dnode_t *node;
+	struct k_thread *pending;
 
-	SYS_DLIST_FOR_EACH_NODE(wait_q_list, node) {
-		struct k_thread *pending = (struct k_thread *)node;
-
+	SYS_DLIST_FOR_EACH_CONTAINER(wait_q_list, pending, base.k_q_node) {
 		if (_is_t1_higher_prio_than_t2(thread, pending)) {
-			sys_dlist_insert_before(wait_q_list, node,
+			sys_dlist_insert_before(wait_q_list,
+						&pending->base.k_q_node,
 						&thread->base.k_q_node);
 			goto inserted;
 		}


### PR DESCRIPTION
SYS_DLIST_FOR_EACH_CONTAINER is preferable over using
SYS_DLIST_FOR_EACH_NODE as that avoid casting directly which assumes the
node field is always at the beginning.

Signed-off-by: Luiz Augusto von Dentz <luiz.von.dentz@intel.com>