### PR TITLE
net: http: HTTP header field state was not reset

### DIFF
--- a/subsys/net/lib/http/http_server.c
+++ b/subsys/net/lib/http/http_server.c
@@ -768,6 +768,7 @@ fail:
 
 quit:
 	http_parser_init(&http_ctx->req.parser, HTTP_REQUEST);
+	http_ctx->req.field_values_ctr = 0;
 	http_ctx->req.data_len = 0;
 	net_pkt_unref(pkt);
 }
@@ -1536,6 +1537,7 @@ reset:
 
 close:
 	http_parser_init(&ctx->req.parser, HTTP_REQUEST);
+	ctx->req.field_values_ctr = 0;
 
 	mbedtls_ssl_close_notify(&ctx->https.mbedtls.ssl);
 


### PR DESCRIPTION
The HTTP header field pointers are saved for each HTTP request.
But the counter that saves the pointers was never reset to initial
value when the connection was dropped. This meant that the header
field values were only proper for first HTTP request.

Jira: ZEP-2463

Signed-off-by: Jukka Rissanen <jukka.rissanen@linux.intel.com>