### PR TITLE
samples: net: mqtt: Define the stack properly

### DIFF
--- a/samples/net/mqtt_publisher/src/main.c
+++ b/samples/net/mqtt_publisher/src/main.c
@@ -77,7 +77,7 @@ static int network_setup(void);
 
 static u8_t tls_request_buf[TLS_REQUEST_BUF_SIZE];
 
-NET_STACK_DEFINE("mqtt_tls_stack", tls_stack,
+NET_STACK_DEFINE(mqtt_tls_stack, tls_stack,
 		CONFIG_NET_APP_TLS_STACK_SIZE, CONFIG_NET_APP_TLS_STACK_SIZE);
 
 NET_APP_TLS_POOL_DEFINE(tls_mem_pool, 30);


### PR DESCRIPTION
The stack name was incorrectly specified in mqtt_publisher sample
application, this cause compilation error when certain Kconfig
options were specified.

Jira: ZEP-2566

Signed-off-by: Jukka Rissanen <jukka.rissanen@linux.intel.com>