### PR TITLE
doc: fix sphinx 1.5 broken search box

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -242,6 +242,8 @@ html_show_license = True
 #   'nl', 'no', 'pt', 'ro', 'ru', 'sv', 'tr'
 #html_search_language = 'en'
 
+sourcelink_suffix = '.txt'
+
 # A dictionary with options for the search language support, empty by default.
 # Now only 'ja' uses this config value
 #html_search_options = {'type': 'default'}


### PR DESCRIPTION
Sphinx 1.5 introduced changes that broke the
sphinx-supplied search (as explained in
https://github.com/sphinx-doc/sphinx/pull/2454)

This patch, along with a patch in the docs-theme
https://github.com/zephyrproject-rtos/docs-theme/pull/10
repairs things.

Jira: INF-136

Signed-off-by: David B. Kinder <david.b.kinder@intel.com>