### PR TITLE
drivers: serial: esp32: Return transmitted character on success

### DIFF
--- a/drivers/serial/uart_esp32.c
+++ b/drivers/serial/uart_esp32.c
@@ -18,7 +18,7 @@ static unsigned char esp32_uart_tx(struct device *dev,
 
 	uart_tx_one_char(c);
 
-	return 0;
+	return c;
 }
 
 static int esp32_uart_rx(struct device *dev, unsigned char *p_char)


### PR DESCRIPTION
When transmitting to the UART interface using polled mode, the ESP32
driver would return 0 regardless of the success state.  Return the
character that has been transmitted to comply with the API.

Jira: ZEP-2552
Signed-off-by: Leandro Pereira <leandro.pereira@intel.com>