### PR TITLE
net: http: fix avoiding timeout on HTTP requests w/o body

### DIFF
--- a/include/net/http.h
+++ b/include/net/http.h
@@ -324,6 +324,7 @@ struct http_client_ctx {
 
 		u8_t cl_present:1;
 		u8_t body_found:1;
+		u8_t message_complete:1;
 	} rsp;
 
 #if defined(CONFIG_HTTPS)


### PR DESCRIPTION
The original commit 8ebaf29927c2 ("net: http: dont timeout
on HTTP requests w/o body") was intended to handle a case
where an HTTP response had been retrieved from the server but
the HTTP parser couldn't meet the criteria for calling
"on_message_complete".  For example, a POST to a REST API
where the server doesn't return anything but an HTTP
status code.

It was a really bad idea to check a semaphore count.  There
is a lot of kernel logic built into semaphores and how the
count is adjusted.  The assumption that the value is 0
after the k_sem_give() is incorrect.  It's STILL 0 if
something is pending with a k_sem_take().  By the time
k_sem_give() is done executing the other thread has now
been kicked and the count is back to 0.

This caused the original check to always pass and in turn
breakage was noticed in the http_client sample.

Let's do this the right way by setting a flag when
on_message_complete is called and if that flag is not set
by the time we reach recv_cb, let's give back the semaphore
to avoid a timeout.

Jira: ZEP-2561

Signed-off-by: Michael Scott <michael.scott@linaro.org>