### PR TITLE
net: udp: replace net_udp_get/set_hdr macros with static inline

### DIFF
--- a/include/net/udp.h
+++ b/include/net/udp.h
@@ -66,8 +66,19 @@ struct net_udp_hdr *net_udp_set_hdr(struct net_pkt *pkt,
 				    struct net_udp_hdr *hdr);
 
 #else
-#define net_udp_get_hdr(pkt, frag) NULL
-#define net_udp_set_hdr(pkt, frag) NULL
+
+static inline struct net_udp_hdr *net_udp_get_hdr(struct net_pkt *pkt,
+						  struct net_udp_hdr *hdr)
+{
+	return NULL;
+}
+
+static inline struct net_udp_hdr *net_udp_set_hdr(struct net_pkt *pkt,
+						  struct net_udp_hdr *hdr)
+{
+	return NULL;
+}
+
 #endif /* CONFIG_NET_UDP */
 
 /**


### PR DESCRIPTION
subsys/net/ip/6lo.c: In function 'compress_IPHC_header':
subsys/net/ip/6lo.c:759:22: warning: unused variable 'hdr' [-Wunused-variable]
   struct net_udp_hdr hdr, *udp;
                      ^~~

Signed-off-by: Ricardo Salveti <ricardo.salveti@linaro.org>