### PR TITLE
esp32: Watchdog driver fixes

### DIFF
--- a/arch/xtensa/core/xtensa_vectors.S
+++ b/arch/xtensa/core/xtensa_vectors.S
@@ -1161,7 +1161,12 @@ _xt_medint3_exit:
 
 #endif  /* Level 3 */
 
-#if XCHAL_EXCM_LEVEL >= 4
+/* FIXME: For some reason, the HAL provided by the ESP32 port of FreeRTOS,
+ * that Zephyr uses, defines XCHAL_EXCM_LEVEL to 3.  That essentially
+ * enables the other _Level4Vector routine, that doesn't work on ESP32.
+ * This is tracked by: https://jira.zephyrproject.org/browse/ZEP-2570
+ */
+#if defined(CONFIG_SOC_ESP32) || (XCHAL_EXCM_LEVEL >= 4)
 
     .begin      literal_prefix .Level4InterruptVector
     .section    .Level4InterruptVector.text, "ax"
@@ -1488,7 +1493,7 @@ _xt_highint3:
 
 #endif  /* Level 3 */
 
-#if XCHAL_NUM_INTLEVELS >=4 && XCHAL_EXCM_LEVEL <4 && XCHAL_DEBUGLEVEL !=4
+#if !defined(CONFIG_SOC_ESP32) && XCHAL_NUM_INTLEVELS >=4 && XCHAL_EXCM_LEVEL <4 && XCHAL_DEBUGLEVEL !=4
 
     .begin      literal_prefix .Level4InterruptVector
     .section    .Level4InterruptVector.text, "ax"

--- a/drivers/watchdog/wdt_esp32.c
+++ b/drivers/watchdog/wdt_esp32.c
@@ -25,21 +25,21 @@ static struct wdt_esp32_data shared_data;
  */
 static inline void wdt_esp32_seal(void)
 {
-	volatile u32_t *reg = (u32_t *)TIMG_WDTWPROTECT_REG(0);
+	volatile u32_t *reg = (u32_t *)TIMG_WDTWPROTECT_REG(1);
 
 	*reg = 0;
 }
 
 static inline void wdt_esp32_unseal(void)
 {
-	volatile u32_t *reg = (u32_t *)TIMG_WDTWPROTECT_REG(0);
+	volatile u32_t *reg = (u32_t *)TIMG_WDTWPROTECT_REG(1);
 
 	*reg = TIMG_WDT_WKEY_VALUE;
 }
 
 static void wdt_esp32_enable(struct device *dev)
 {
-	volatile u32_t *reg = (u32_t *)TIMG_WDTCONFIG0_REG(0);
+	volatile u32_t *reg = (u32_t *)TIMG_WDTCONFIG0_REG(1);
 
 	ARG_UNUSED(dev);
 
@@ -50,7 +50,7 @@ static void wdt_esp32_enable(struct device *dev)
 
 static void wdt_esp32_disable(struct device *dev)
 {
-	volatile u32_t *reg = (u32_t *)TIMG_WDTCONFIG0_REG(0);
+	volatile u32_t *reg = (u32_t *)TIMG_WDTCONFIG0_REG(1);
 
 	ARG_UNUSED(dev);
 
@@ -88,7 +88,7 @@ static void adjust_timeout(u32_t timeout)
 	 /* MWDT ticks every 12.5ns.  Set the prescaler to 40000, so the
 	  * counter for each watchdog stage is decremented every 0.5ms.
 	  */
-	 reg = (u32_t *)TIMG_WDTCONFIG1_REG(0);
+	 reg = (u32_t *)TIMG_WDTCONFIG1_REG(1);
 	 *reg = 40000;
 
 	 ticks = 1<<(cycles + 2);
@@ -100,10 +100,10 @@ static void adjust_timeout(u32_t timeout)
 	  */
 	 ticks += (1<<cycles) / 10;
 
-	 reg = (u32_t *)TIMG_WDTCONFIG2_REG(0);
+	 reg = (u32_t *)TIMG_WDTCONFIG2_REG(1);
 	 *reg = ticks;
 
-	 reg = (u32_t *)TIMG_WDTCONFIG3_REG(0);
+	 reg = (u32_t *)TIMG_WDTCONFIG3_REG(1);
 	 *reg = ticks;
 }
 
@@ -111,7 +111,7 @@ static void wdt_esp32_isr(void *param);
 
 static void wdt_esp32_reload(struct device *dev)
 {
-	volatile u32_t *reg = (u32_t *)TIMG_WDTFEED_REG(0);
+	volatile u32_t *reg = (u32_t *)TIMG_WDTFEED_REG(1);
 
 	ARG_UNUSED(dev);
 
@@ -122,7 +122,7 @@ static void wdt_esp32_reload(struct device *dev)
 
 static void set_interrupt_enabled(bool setting)
 {
-	volatile u32_t *intr_enable_reg = (u32_t *)TIMG_INT_ENA_TIMERS_REG(0);
+	volatile u32_t *intr_enable_reg = (u32_t *)TIMG_INT_ENA_TIMERS_REG(1);
 
 	wdt_esp32_unseal();
 	if (setting) {
@@ -141,7 +141,7 @@ static void set_interrupt_enabled(bool setting)
 static int wdt_esp32_set_config(struct device *dev, struct wdt_config *config)
 {
 	struct wdt_esp32_data *data = dev->driver_data;
-	volatile u32_t *reg = (u32_t *)TIMG_WDTCONFIG0_REG(0);
+	volatile u32_t *reg = (u32_t *)TIMG_WDTCONFIG0_REG(1);
 	u32_t v;
 
 	if (!config) {

--- a/drivers/watchdog/wdt_esp32.c
+++ b/drivers/watchdog/wdt_esp32.c
@@ -124,7 +124,6 @@ static void set_interrupt_enabled(bool setting)
 {
 	volatile u32_t *intr_enable_reg = (u32_t *)TIMG_INT_ENA_TIMERS_REG(1);
 
-	wdt_esp32_unseal();
 	if (setting) {
 		*intr_enable_reg |= TIMG_WDT_INT_ENA;
 
@@ -135,7 +134,6 @@ static void set_interrupt_enabled(bool setting)
 		*intr_enable_reg &= ~TIMG_WDT_INT_ENA;
 		irq_disable(CONFIG_WDT_ESP32_IRQ);
 	}
-	wdt_esp32_seal();
 }
 
 static int wdt_esp32_set_config(struct device *dev, struct wdt_config *config)
@@ -160,22 +158,19 @@ static int wdt_esp32_set_config(struct device *dev, struct wdt_config *config)
 
 	if (config->mode == WDT_MODE_RESET) {
 		/* Warm reset on timeout */
-		v |= TIMG_WDT_STG_SEL_RESET_CPU<<TIMG_WDT_STG0_S;
+		v |= TIMG_WDT_STG_SEL_RESET_SYSTEM<<TIMG_WDT_STG0_S;
 		v |= TIMG_WDT_STG_SEL_OFF<<TIMG_WDT_STG1_S;
 
 		/* Disable interrupts for this mode. */
-		v &= ~TIMG_WDT_LEVEL_INT_EN;
-
-		set_interrupt_enabled(false);
+		v &= ~(TIMG_WDT_LEVEL_INT_EN | TIMG_WDT_EDGE_INT_EN);
 	} else if (config->mode == WDT_MODE_INTERRUPT_RESET) {
 		/* Interrupt first, and warm reset if not reloaded */
 		v |= TIMG_WDT_STG_SEL_INT<<TIMG_WDT_STG0_S;
-		v |= TIMG_WDT_STG_SEL_RESET_CPU<<TIMG_WDT_STG1_S;
+		v |= TIMG_WDT_STG_SEL_RESET_SYSTEM<<TIMG_WDT_STG1_S;
 
 		/* Use level-triggered interrupts. */
 		v |= TIMG_WDT_LEVEL_INT_EN;
-
-		set_interrupt_enabled(true);
+		v &= ~TIMG_WDT_EDGE_INT_EN;
 	} else {
 		return -EINVAL;
 	}
@@ -183,6 +178,7 @@ static int wdt_esp32_set_config(struct device *dev, struct wdt_config *config)
 	wdt_esp32_unseal();
 	*reg = v;
 	adjust_timeout(config->timeout & WDT_TIMEOUT_MASK);
+	set_interrupt_enabled(config->mode == WDT_MODE_INTERRUPT_RESET);
 	wdt_esp32_seal();
 
 	wdt_esp32_reload(dev);


### PR DESCRIPTION
This fixes a bunch of stuff related to the watchdog driver.  It also changes the interrupt service routine for level 4 interrupts (inline comment explains rationale).

https://jira.zephyrproject.org/browse/ZEP-2556