### PR TITLE
dts: x86: Add serial over usb support.

### DIFF
--- a/dts/x86/arduino_101.dts
+++ b/dts/x86/arduino_101.dts
@@ -14,7 +14,11 @@
 	chosen {
 		zephyr,sram = &sram0;
 		zephyr,flash = &flash0;
+#ifdef CONFIG_USB_UART_CONSOLE
+		zephyr,console = &usb_cdc;
+#else
 		zephyr,console = &uart1;
+#endif
 		zephyr,bt-uart = &uart0;
 		zephyr,uart-pipe = &uart1;
 		zephyr,bt-mon-uart = &uart1;

--- a/dts/x86/tinytile.dts
+++ b/dts/x86/tinytile.dts
@@ -14,7 +14,11 @@
 	chosen {
 		zephyr,sram = &sram0;
 		zephyr,flash = &flash0;
+#ifdef CONFIG_USB_UART_CONSOLE
+		zephyr,console = &usb_cdc;
+#else
 		zephyr,console = &uart1;
+#endif
 		zephyr,bt-uart = &uart0;
 		zephyr,uart-pipe = &uart1;
 		zephyr,bt-mon-uart = &uart1;


### PR DESCRIPTION
choose console as usb_cdc when the config USB_UART_CONSOLE is
selected for arduino_101 and tinytile

Signed-off-by: Savinay Dharmappa <savinay.dharmappa@intel.com>