### PR TITLE
eth_enc28j60: Update Kconfig dependancy for SPI

### DIFF
--- a/drivers/ethernet/Kconfig.enc28j60
+++ b/drivers/ethernet/Kconfig.enc28j60
@@ -9,6 +9,7 @@
 menuconfig ETH_ENC28J60
 	bool "ENC28J60C Ethernet Controller"
 	depends on NET_L2_ETHERNET
+	depends on SPI_LEGACY_API
 	depends on SPI
 	default n
 	help


### PR DESCRIPTION
The driver uses the SPI legacy API so make it depend on the SPI legacy
API being enabled.

Signed-off-by: Kumar Gala <kumar.gala@linaro.org>