### PR TITLE
Fix build failure of mbed tls on zedboard_pulpino

### DIFF
--- a/boards/riscv32/zedboard_pulpino/zedboard_pulpino.yaml
+++ b/boards/riscv32/zedboard_pulpino/zedboard_pulpino.yaml
@@ -5,6 +5,7 @@ arch: riscv32
 toolchain:
   - zephyr
 ram: 32
+flash: 32
 testing:
   ignore_tags:
     - net

--- a/tests/crypto/mbedtls/testcase.yaml
+++ b/tests/crypto/mbedtls/testcase.yaml
@@ -1,6 +1,7 @@
 tests:
 -   test:
         min_ram: 32
+        min_flash: 33
         tags: crypto mbedtls
         timeout: 200
         filter: not CONFIG_DEBUG


### PR DESCRIPTION
The zedboard_pulpino has a small amount of flash and thus we shouldn't attempt to build the mbed tls test on it.  Limit this by adding a flash (code size) constraint to the test and having the board yaml convey the limited amount of flash on the board.