### PR TITLE
samples: net: Fix compile error in echo-server when using TLS

### DIFF
--- a/samples/net/echo_server/src/tcp.c
+++ b/samples/net/echo_server/src/tcp.c
@@ -191,9 +191,7 @@ void start_tcp(void)
 
 void stop_tcp(void)
 {
-#if defined(CONFIG_NET_APP_TLS)
-	net_app_server_tls_disable(&tcp);
-#endif
+	net_app_server_disable(&tcp);
 
 	net_app_close(&tcp);
 	net_app_release(&tcp);


### PR DESCRIPTION
The echo-server sample was using removed net_app_server_tls_disable()
function, the correct one is called net_app_server_disable()

Signed-off-by: Jukka Rissanen <jukka.rissanen@linux.intel.com>