### PR TITLE
Bluetooth: controller: Fix broken switch statement

### DIFF
--- a/subsys/bluetooth/controller/hci/hci.c
+++ b/subsys/bluetooth/controller/hci/hci.c
@@ -1541,6 +1541,7 @@ static int controller_cmd_handle(u16_t  ocf, struct net_buf *cmd,
 
 	case BT_OCF(BT_HCI_OP_LE_READ_TX_POWER):
 		le_read_tx_power(cmd, evt);
+		break;
 
 	default:
 		return -EINVAL;


### PR DESCRIPTION
Add a missing break that was forgotten when we introduced the Read TX
Power command.

Signed-off-by: Carles Cufi <carles.cufi@nordicsemi.no>