### PR TITLE
Misc net fixes

### DIFF
--- a/include/net/net_app.h
+++ b/include/net/net_app.h
@@ -173,6 +173,7 @@ typedef int (*net_app_send_data_t)(struct net_pkt *pkt,
 /* Internal information for managing TLS data */
 struct tls_context {
 	struct net_pkt *rx_pkt;
+	struct net_buf *hdr; /* IP + UDP/TCP header */
 	struct net_buf *frag;
 	struct k_sem tx_sem;
 	struct k_fifo tx_rx_fifo;

--- a/include/net/net_app.h
+++ b/include/net/net_app.h
@@ -11,7 +11,7 @@
 #ifndef __NET_APP_H
 #define __NET_APP_H
 
-#if defined(CONFIG_NET_APP_TLS)
+#if defined(CONFIG_NET_APP_TLS) || defined(CONFIG_NET_APP_DTLS)
 #if defined(CONFIG_MBEDTLS)
 #if !defined(CONFIG_MBEDTLS_CFG_FILE)
 #include "mbedtls/config.h"
@@ -38,7 +38,7 @@
 #include <mbedtls/error.h>
 #include <mbedtls/debug.h>
 #endif /* CONFIG_MBEDTLS */
-#endif /* CONFIG_NET_APP_TLS */
+#endif /* CONFIG_NET_APP_TLS || CONFIG_NET_APP_DTLS */
 
 #include <net/net_ip.h>
 #include <net/net_pkt.h>
@@ -169,7 +169,7 @@ typedef int (*net_app_send_data_t)(struct net_pkt *pkt,
 				   void *token,
 				   void *user_data);
 
-#if defined(CONFIG_NET_APP_TLS)
+#if defined(CONFIG_NET_APP_TLS) || defined(CONFIG_NET_APP_DTLS)
 /* Internal information for managing TLS data */
 struct tls_context {
 	struct net_pkt *rx_pkt;
@@ -241,7 +241,7 @@ typedef int (*net_app_ca_cert_cb_t)(struct net_app_ctx *ctx,
  */
 typedef int (*net_app_entropy_src_cb_t)(void *data, unsigned char *output,
 					size_t len, size_t *olen);
-#endif /* CONFIG_NET_APP_TLS */
+#endif /* CONFIG_NET_APP_TLS || CONFIG_NET_APP_DTLS */
 
 #if defined(CONFIG_NET_APP_DTLS)
 struct dtls_timing_context {
@@ -333,7 +333,7 @@ struct net_app_ctx {
 	} client;
 #endif /* CONFIG_NET_APP_CLIENT */
 
-#if defined(CONFIG_NET_APP_TLS)
+#if defined(CONFIG_NET_APP_TLS) || defined(CONFIG_NET_APP_DTLS)
 	struct {
 		/** TLS stack for mbedtls library. */
 		k_thread_stack_t stack;
@@ -389,7 +389,7 @@ struct net_app_ctx {
 		/** Have we called connect cb yet? */
 		bool connect_cb_called;
 	} tls;
-#endif /* CONFIG_NET_APP_TLS */
+#endif /* CONFIG_NET_APP_TLS || CONFIG_NET_APP_DTLS */
 
 #if defined(CONFIG_NET_CONTEXT_NET_PKT_POOL)
 	/** Network packet (net_pkt) memory pool for network contexts attached
@@ -877,7 +877,7 @@ int net_app_close(struct net_app_ctx *ctx);
  */
 int net_app_release(struct net_app_ctx *ctx);
 
-#if defined(CONFIG_NET_APP_TLS)
+#if defined(CONFIG_NET_APP_TLS) || defined(CONFIG_NET_APP_DTLS)
 #if defined(CONFIG_NET_APP_CLIENT)
 /**
  * @brief Initialize TLS support for this net_app client context.
@@ -955,7 +955,7 @@ int net_app_server_tls(struct net_app_ctx *ctx,
 
 #endif /* CONFIG_NET_APP_SERVER */
 
-#endif /* CONFIG_NET_APP_TLS */
+#endif /* CONFIG_NET_APP_TLS || CONFIG_NET_APP_DTLS */
 
 /**
  * @}

--- a/include/net/net_pkt.h
+++ b/include/net/net_pkt.h
@@ -39,6 +39,9 @@ extern "C" {
 
 struct net_context;
 
+/* Note that if you add new fields into net_pkt, remember to update
+ * net_pkt_clone() function.
+ */
 struct net_pkt {
 	/** FIFO uses first 4 bytes itself, reserve space */
 	int _reserved;
@@ -1332,6 +1335,16 @@ int net_pkt_split(struct net_pkt *pkt, struct net_buf *orig_frag,
 struct net_buf *net_frag_get_pos(struct net_pkt *pkt,
 				 u16_t offset,
 				 u16_t *pos);
+
+/**
+ * @brief Clone pkt and its fragment chain.
+ *
+ * @param pkt Original pkt to be cloned
+ * @param timeout Timeout to wait for free net_buf
+ *
+ * @return NULL if error, clone fragment chain otherwise.
+ */
+struct net_pkt *net_pkt_clone(struct net_pkt *pkt, s32_t timeout);
 
 /**
  * @brief Get information about predefined RX, TX and DATA pools.

--- a/subsys/net/ip/net_if.c
+++ b/subsys/net/ip/net_if.c
@@ -63,6 +63,10 @@ static struct k_thread tx_thread_data;
 static inline void net_context_send_cb(struct net_context *context,
 				       void *token, int status)
 {
+	if (!context) {
+		return;
+	}
+
 	if (context->send_cb) {
 		context->send_cb(context, status, token, context->user_data);
 	}

--- a/subsys/net/ip/net_pkt.c
+++ b/subsys/net/ip/net_pkt.c
@@ -1679,15 +1679,16 @@ struct net_buf *net_frag_get_pos(struct net_pkt *pkt,
 }
 
 #if defined(CONFIG_NET_DEBUG_NET_PKT)
-static void too_short_msg(struct net_pkt *pkt, u16_t offset, size_t extra_len)
+static void too_short_msg(char *msg, struct net_pkt *pkt, u16_t offset,
+			  size_t extra_len)
 {
 	size_t total_len = net_buf_frags_len(pkt->frags);
 	size_t hdr_len = net_pkt_ip_hdr_len(pkt) + net_pkt_ipv6_ext_len(pkt);
 
 	if (total_len != (hdr_len + extra_len)) {
 		/* Print info how many bytes past the end we tried to print */
-		NET_ERR("IP hdr %d ext len %d offset %d pos %zd total %zd",
-			net_pkt_ip_hdr_len(pkt),
+		NET_ERR("%s: IP hdr %d ext len %d offset %d pos %zd total %zd",
+			msg, net_pkt_ip_hdr_len(pkt),
 			net_pkt_ipv6_ext_len(pkt),
 			offset, hdr_len + extra_len, total_len);
 	}
@@ -1707,7 +1708,7 @@ struct net_icmp_hdr *net_pkt_icmp_data(struct net_pkt *pkt)
 				&offset);
 	if (!frag) {
 		/* We tried to read past the end of the data */
-		too_short_msg(pkt, offset, 0);
+		too_short_msg("icmp data", pkt, offset, 0);
 		return NULL;
 	}
 
@@ -1725,7 +1726,7 @@ u8_t *net_pkt_icmp_opt_data(struct net_pkt *pkt, size_t opt_len)
 				&offset);
 	if (!frag) {
 		/* We tried to read past the end of the data */
-		too_short_msg(pkt, offset, opt_len);
+		too_short_msg("icmp opt data", pkt, offset, opt_len);
 		return NULL;
 	}
 
@@ -1743,7 +1744,7 @@ struct net_udp_hdr *net_pkt_udp_data(struct net_pkt *pkt)
 				&offset);
 	if (!frag) {
 		/* We tried to read past the end of the data */
-		too_short_msg(pkt, offset, 0);
+		too_short_msg("udp data", pkt, offset, 0);
 		return NULL;
 	}
 
@@ -1761,7 +1762,7 @@ struct net_tcp_hdr *net_pkt_tcp_data(struct net_pkt *pkt)
 				&offset);
 	if (!frag) {
 		/* We tried to read past the end of the data */
-		too_short_msg(pkt, offset, 0);
+		too_short_msg("tcp data", pkt, offset, 0);
 		return NULL;
 	}
 

--- a/subsys/net/ip/tcp.c
+++ b/subsys/net/ip/tcp.c
@@ -850,9 +850,15 @@ int net_tcp_send_data(struct net_context *context)
 		}
 
 		if (!net_pkt_sent(pkt)) {
-			NET_DBG("[%p] Sending pkt %p", context->tcp, pkt);
-			if (net_tcp_send_pkt(pkt) < 0 &&
-			    !is_6lo_technology(pkt)) {
+			int ret;
+
+			NET_DBG("[%p] Sending pkt %p (%zd bytes)", context->tcp,
+				pkt, net_pkt_get_len(pkt));
+
+			ret = net_tcp_send_pkt(pkt);
+			if (ret < 0 && !is_6lo_technology(pkt)) {
+				NET_DBG("[%p] pkt %p not sent (%d)",
+					context->tcp, pkt, ret);
 				net_pkt_unref(pkt);
 			}
 

--- a/subsys/net/ip/tcp.c
+++ b/subsys/net/ip/tcp.c
@@ -790,21 +790,10 @@ int net_tcp_send_pkt(struct net_pkt *pkt)
 		}
 
 		if (pkt_in_slist) {
-			new_pkt = net_pkt_get_tx(ctx, ALLOC_TIMEOUT);
+			new_pkt = net_pkt_clone(pkt, ALLOC_TIMEOUT);
 			if (!new_pkt) {
 				return -ENOMEM;
 			}
-
-			memcpy(new_pkt, pkt, sizeof(struct net_pkt));
-			new_pkt->frags = net_pkt_copy_all(pkt, 0,
-							  ALLOC_TIMEOUT);
-			if (!new_pkt->frags) {
-				net_pkt_unref(new_pkt);
-				return -ENOMEM;
-			}
-
-			NET_DBG("[%p] Copied %zu bytes from %p to %p", ctx->tcp,
-				net_pkt_get_len(new_pkt), pkt, new_pkt);
 
 			/* This function is called from net_context.c and if we
 			 * return < 0, the caller will unref the original pkt.

--- a/subsys/net/lib/app/Kconfig
+++ b/subsys/net/lib/app/Kconfig
@@ -87,6 +87,7 @@ config NET_APP_CLIENT
 config NET_APP_TLS
 	bool "Enable TLS support for TCP applications"
 	default n
+	depends on NET_TCP
 	select MBEDTLS
 	help
 	Enables net app library to use TLS for encrypted communication.
@@ -94,10 +95,10 @@ config NET_APP_TLS
 config NET_APP_DTLS
 	bool "Enable DTLS support for UDP applications"
 	depends on NET_UDP
-	depends on NET_APP_TLS
+	select MBEDTLS
 	default n
 	help
-	Enables net app library to use TLS for encrypted UDP communication.
+	Enables net app library to use DTLS for encrypted UDP communication.
 
 config NET_APP_DTLS_TIMEOUT
 	int "DTLS session timeout"
@@ -109,7 +110,7 @@ config NET_APP_DTLS_TIMEOUT
 
 config NET_DEBUG_APP_TLS_LEVEL
 	int "Debug level for mbedtls in net app library"
-	depends on NET_APP_TLS && NET_DEBUG_APP
+	depends on (NET_APP_TLS || NET_APP_DTLS) && NET_DEBUG_APP
 	default 0
 	range 0 4
 	help
@@ -124,7 +125,7 @@ config NET_DEBUG_APP_TLS_LEVEL
 config NET_APP_TLS_STACK_SIZE
 	int "TLS handler thread stack size"
 	default 8192
-	depends on NET_APP_TLS
+	depends on NET_APP_TLS || NET_APP_DTLS
 	help
 	TLS handler thread stack size. The mbedtls routines will use this stack
 	thus it is by default very large.

--- a/subsys/net/lib/app/client.c
+++ b/subsys/net/lib/app/client.c
@@ -28,10 +28,10 @@
 
 #include "net_app_private.h"
 
-#if defined(CONFIG_NET_APP_TLS)
+#if defined(CONFIG_NET_APP_TLS) || defined(CONFIG_NET_APP_DTLS)
 #define TLS_STARTUP_TIMEOUT K_SECONDS(5)
 static int start_tls_client(struct net_app_ctx *ctx);
-#endif /* CONFIG_NET_APP_TLS */
+#endif /* CONFIG_NET_APP_TLS || CONFIG_NET_APP_DTLS */
 
 #if defined(CONFIG_DNS_RESOLVER)
 static void dns_cb(enum dns_resolve_status status,
@@ -422,7 +422,7 @@ static void _app_connected(struct net_context *net_ctx,
 {
 	struct net_app_ctx *ctx = user_data;
 
-#if defined(CONFIG_NET_APP_TLS)
+#if defined(CONFIG_NET_APP_TLS) || defined(CONFIG_NET_APP_DTLS)
 	if (ctx->is_tls) {
 		k_sem_give(&ctx->client.connect_wait);
 	}
@@ -430,7 +430,7 @@ static void _app_connected(struct net_context *net_ctx,
 
 	net_context_recv(net_ctx, ctx->recv_cb, K_NO_WAIT, ctx);
 
-#if defined(CONFIG_NET_APP_TLS)
+#if defined(CONFIG_NET_APP_TLS) || defined(CONFIG_NET_APP_DTLS)
 	if (ctx->is_tls) {
 		/* If we have TLS connection, the connect cb is called
 		 * after TLS handshakes are done.
@@ -553,7 +553,7 @@ int net_app_connect(struct net_app_ctx *ctx, s32_t timeout)
 		return -EAFNOSUPPORT;
 	}
 
-#if defined(CONFIG_NET_APP_TLS)
+#if defined(CONFIG_NET_APP_TLS) || defined(CONFIG_NET_APP_DTLS)
 	if (ctx->is_tls && !ctx->tls.tid &&
 	    (ctx->proto == IPPROTO_TCP ||
 	     (IS_ENABLED(CONFIG_NET_APP_DTLS) && ctx->proto == IPPROTO_UDP))) {
@@ -571,7 +571,7 @@ int net_app_connect(struct net_app_ctx *ctx, s32_t timeout)
 	}
 #else
 	ARG_UNUSED(started);
-#endif /* CONFIG_NET_APP_TLS */
+#endif /* CONFIG_NET_APP_TLS || CONFIG_NET_APP_DTLS */
 
 #if defined(CONFIG_NET_APP_DTLS)
 	if (ctx->proto == IPPROTO_UDP) {
@@ -608,7 +608,7 @@ int net_app_connect(struct net_app_ctx *ctx, s32_t timeout)
 	if (ret < 0) {
 		NET_DBG("Cannot connect to peer (%d)", ret);
 
-#if defined(CONFIG_NET_APP_TLS)
+#if defined(CONFIG_NET_APP_TLS) || defined(CONFIG_NET_APP_DTLS)
 		if (started) {
 			_net_app_tls_handler_stop(ctx);
 		}
@@ -618,7 +618,7 @@ int net_app_connect(struct net_app_ctx *ctx, s32_t timeout)
 	return ret;
 }
 
-#if defined(CONFIG_NET_APP_TLS)
+#if defined(CONFIG_NET_APP_TLS) || defined(CONFIG_NET_APP_DTLS)
 static void tls_client_handler(struct net_app_ctx *ctx,
 			       struct k_sem *startup_sync)
 {
@@ -746,4 +746,4 @@ int net_app_client_tls(struct net_app_ctx *ctx,
 	 */
 	return 0;
 }
-#endif /* CONFIG_NET_APP_TLS */
+#endif /* CONFIG_NET_APP_TLS || CONFIG_NET_APP_DTLS */

--- a/subsys/net/lib/app/net_app.c
+++ b/subsys/net/lib/app/net_app.c
@@ -864,7 +864,7 @@ int net_app_close(struct net_app_ctx *ctx)
 	return 0;
 }
 
-#if defined(CONFIG_NET_APP_TLS)
+#if defined(CONFIG_NET_APP_TLS) || defined(CONFIG_NET_APP_DTLS)
 #if defined(MBEDTLS_DEBUG_C) && defined(CONFIG_NET_DEBUG_APP)
 static void my_debug(void *ctx, int level,
 		     const char *file, int line, const char *str)
@@ -1301,7 +1301,6 @@ void _net_app_tls_received(struct net_context *context,
 			 */
 		}
 	}
-dtls_disconnect:
 #endif /* CONFIG_NET_APP_DTLS */
 
 	ret = k_mem_pool_alloc(ctx->tls.pool, &block,
@@ -1960,5 +1959,5 @@ void _net_app_tls_handler_stop(struct net_app_ctx *ctx)
 	k_thread_abort(ctx->tls.tid);
 	ctx->tls.tid = 0;
 }
-#endif /* CONFIG_NET_APP_TLS */
+#endif /* CONFIG_NET_APP_TLS || CONFIG_NET_APP_DTLS */
 

--- a/subsys/net/lib/app/net_app_private.h
+++ b/subsys/net/lib/app/net_app_private.h
@@ -103,7 +103,7 @@ void _net_app_accept_cb(struct net_context *net_ctx,
 #if defined(CONFIG_NET_APP_CLIENT)
 #endif /* CONFIG_NET_APP_CLIENT */
 
-#if defined(CONFIG_NET_APP_TLS)
+#if defined(CONFIG_NET_APP_TLS) || defined(CONFIG_NET_APP_DTLS)
 bool _net_app_server_tls_enable(struct net_app_ctx *ctx);
 bool _net_app_server_tls_disable(struct net_app_ctx *ctx);
 void _net_app_tls_handler_stop(struct net_app_ctx *ctx);
@@ -111,7 +111,7 @@ int _net_app_tls_init(struct net_app_ctx *ctx, int client_or_server);
 int _net_app_entropy_source(void *data, unsigned char *output, size_t len,
 			    size_t *olen);
 int _net_app_ssl_tx(void *context, const unsigned char *buf, size_t size);
-#endif /* CONFIG_NET_APP_TLS */
+#endif /* CONFIG_NET_APP_TLS || CONFIG_NET_APP_DTLS */
 
 #if defined(CONFIG_NET_APP_DTLS)
 #include "../../ip/connection.h"

--- a/subsys/net/lib/app/server.c
+++ b/subsys/net/lib/app/server.c
@@ -260,7 +260,7 @@ fail:
 	return ret;
 }
 
-#if defined(CONFIG_NET_APP_TLS)
+#if defined(CONFIG_NET_APP_TLS) || defined(CONFIG_NET_APP_DTLS)
 static inline void new_server(struct net_app_ctx *ctx,
 			      const char *server_banner)
 {
@@ -426,7 +426,7 @@ int net_app_server_tls(struct net_app_ctx *ctx,
 	/* Then mbedtls specific initialization */
 	return 0;
 }
-#endif /* CONFIG_NET_APP_TLS */
+#endif /* CONFIG_NET_APP_TLS || CONFIG_NET_APP_DTLS */
 
 bool net_app_server_enable(struct net_app_ctx *ctx)
 {
@@ -438,7 +438,7 @@ bool net_app_server_enable(struct net_app_ctx *ctx)
 
 	ctx->is_enabled = true;
 
-#if defined(CONFIG_NET_APP_TLS)
+#if defined(CONFIG_NET_APP_TLS) || defined(CONFIG_NET_APP_DTLS)
 	if (ctx->is_tls) {
 		_net_app_server_tls_enable(ctx);
 	}
@@ -456,7 +456,7 @@ bool net_app_server_disable(struct net_app_ctx *ctx)
 
 	ctx->is_enabled = false;
 
-#if defined(CONFIG_NET_APP_TLS)
+#if defined(CONFIG_NET_APP_TLS) || defined(CONFIG_NET_APP_DTLS)
 	if (ctx->is_tls) {
 		_net_app_server_tls_disable(ctx);
 	}


### PR DESCRIPTION
Various fixes to net-app, IPv6 and TCP.

@mike-scott The first patch fixes the issue we had with IP addresses having wrong values in your application.
The rest of the patches were found while testing large IPv6 packets over TLS.

This set is probably something that would be useful to have in 1.9.