### PR TITLE
doc: fix Zephyr SDK archive URL

### DIFF
--- a/doc/getting_started/installation_linux.rst
+++ b/doc/getting_started/installation_linux.rst
@@ -148,4 +148,4 @@ Follow these steps to install the SDK on your Linux host system.
      EOF
 
 .. _Zephyr SDK archive:
-    https://zephyrproject.org/downloads/tools
+    https://www.zephyrproject.org/downloads#Zephyr_SDK_Tools


### PR DESCRIPTION
The Linux getting started guide points towards an empty Zephyr SDK archive page. This PR fixes the URL.