### PR TITLE
LWM2M: fix handle_reqest() errors

### DIFF
--- a/subsys/net/lib/lwm2m/lwm2m_engine.c
+++ b/subsys/net/lib/lwm2m/lwm2m_engine.c
@@ -2330,7 +2330,8 @@ static int handle_request(struct zoap_packet *request,
 	obj = get_engine_obj(path.obj_id);
 	if (!obj) {
 		/* No matching object found - ignore request */
-		return -ENOENT;
+		r = -ENOENT;
+		goto error;
 	}
 
 	format = select_reader(&in, format);
@@ -2475,7 +2476,7 @@ static int handle_request(struct zoap_packet *request,
 
 	default:
 		SYS_LOG_ERR("Unknown operation: %u", context.operation);
-		return -EINVAL;
+		r = -EINVAL;
 	}
 
 	if (r) {

--- a/subsys/net/lib/lwm2m/lwm2m_engine.c
+++ b/subsys/net/lib/lwm2m/lwm2m_engine.c
@@ -2290,17 +2290,23 @@ static int handle_request(struct zoap_packet *request,
 
 	/* parse the URL path into components */
 	r = zoap_find_options(in.in_zpkt, ZOAP_OPTION_URI_PATH, options, 4);
-	if (r > 0) {
-		/* check for .well-known/core URI query (DISCOVER) */
-		if (r == 2 &&
-		    (options[0].len == 11 &&
-		     strncmp(options[0].value, ".well-known", 11) == 0) &&
-		    (options[1].len == 4 &&
-		     strncmp(options[1].value, "core", 4) == 0)) {
-			discover = true;
-		} else {
-			zoap_options_to_path(options, r, &path);
-		}
+	if (r <= 0) {
+		/* '/' is used by bootstrap-delete only */
+
+		/* TODO: handle bootstrap-delete */
+		r = -EPERM;
+		goto error;
+	}
+
+	/* check for .well-known/core URI query (DISCOVER) */
+	if (r == 2 &&
+	    (options[0].len == 11 &&
+	     strncmp(options[0].value, ".well-known", 11) == 0) &&
+	    (options[1].len == 4 &&
+	     strncmp(options[1].value, "core", 4) == 0)) {
+		discover = true;
+	} else {
+		zoap_options_to_path(options, r, &path);
 	}
 
 	/* read Content Format */


### PR DESCRIPTION
1. Refactor the error handling section (split from #1049)
1. Respond 4.5 (Method Not Allowed) when option PATH is not given.
    '/' is only allowed when performing bootstrap-delete
1. Respond 4.4 (Not found) when object doesn't exist
1. Respond 4.4 (Not found) when URI contains character other than digits
1. Respond 5.0 (Internal server error) when OP is not supported
1. Respond 4.5 (Method Not Allowed) when request method is not GET for URI .well-know/core