### PR TITLE
tests/object_footprint: fix build error due to bad Kconfig specification

### DIFF
--- a/tests/benchmarks/object_footprint/Makefile
+++ b/tests/benchmarks/object_footprint/Makefile
@@ -3,7 +3,7 @@
 BOARD ?= qemu_x86
 CONF_FILE ?= prj1.conf
 
-KBUILD_KCONFIG = $(PWD)/Kconfig
+KBUILD_KCONFIG = Kconfig
 export KBUILD_KCONFIG
 
 include $(ZEPHYR_BASE)/Makefile.test


### PR DESCRIPTION
This was failing to build when the PWD was not that of the
tests/benchmarks/object_footprint because it was asking to load
$(PWD)/Kconfig.

Kconfig shall be specified with no directory location, as the file
will be imported relative to to Zephyr app's directory.

Signed-off-by: Inaky Perez-Gonzalez <inaky.perez-gonzalez@intel.com>