### PR TITLE
tests: watchdog: Added support for esp32

### DIFF
--- a/tests/drivers/watchdog/wdt_basic_api/testcase.yaml
+++ b/tests/drivers/watchdog/wdt_basic_api/testcase.yaml
@@ -1,8 +1,8 @@
 tests:
 -   test_watchdog_reset:
-        platform_whitelist: quark_se_c1000_devboard quark_d2000_crb
+        platform_whitelist: quark_se_c1000_devboard quark_d2000_crb esp32
         tags: drivers
 -   test_watchdog_int_reset:
         extra_args: CFLAGS=-DINT_RESET
-        platform_whitelist: quark_se_c1000_devboard quark_d2000_crb
+        platform_whitelist: quark_se_c1000_devboard quark_d2000_crb esp32
         tags: drivers


### PR DESCRIPTION
Added support of esp32 for polling and interrupt mode in watchdog
testcases.
Signed-off-by: Vikram Singh Shekhawat <vikramx.shekhawat@intel.com>