### PR TITLE
api: adc: Update timing parameters of sampling sequence entry.

### DIFF
--- a/drivers/adc/Kconfig
+++ b/drivers/adc/Kconfig
@@ -6,6 +6,14 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 
+config ADC_LEGACY_API
+	bool "Use legacy ADC API (default)"
+	default y
+	help
+	  Legacy API uses clock ticks as timing parameters unit.
+	  There is also no distinction between sampling delay and
+	  sampling interval.
+
 #
 # ADC options
 #

--- a/include/adc.h
+++ b/include/adc.h
@@ -33,8 +33,16 @@ extern "C" {
  * to define a sample from a specific channel.
  */
 struct adc_seq_entry {
+#if defined(CONFIG_ADC_LEGACY_API)
 	/** Clock ticks delay before sampling the ADC. */
 	s32_t sampling_delay;
+#else
+	/** Delay before starting sampling the ADC in microseconds. */
+	u32_t sampling_delay;
+
+	/** Interval between adjacent samples in microseconds. */
+	u32_t sampling_interval;
+#endif
 
 	/** Buffer pointer where the sample is written.*/
 	u8_t *buffer;

--- a/tests/drivers/adc/adc_api/src/test_adc.c
+++ b/tests/drivers/adc/adc_api/src/test_adc.c
@@ -28,6 +28,10 @@
 #include <zephyr.h>
 #include <ztest.h>
 
+#ifndef CONFIG_ADC_LEGACY_API
+#error "Supports only legacy API"
+#endif
+
 #define BUFFER_SIZE 5
 
 #if defined(CONFIG_BOARD_FRDM_K64F)

--- a/tests/drivers/adc/adc_simple/src/main.c
+++ b/tests/drivers/adc/adc_simple/src/main.c
@@ -16,6 +16,10 @@
 #include <adc.h>
 #include <misc/printk.h>
 
+#ifndef CONFIG_ADC_LEGACY_API
+#error "Supports only legacy API"
+#endif
+
 /* in millisecond */
 #define SLEEPTIME  2000
 


### PR DESCRIPTION
This patch changes timing parameters unit from clock ticks
to more human friendly microseconds.
It also introduces sampling interval as it may differ from
sampling delay.

Signed-off-by: Michał Kruszewski <michal.kruszewski@nordicsemi.no>

This patch still needs updating existing ADC drivers so that they comply with it.
It should probably take less than 1 hour for someone who knows these platforms.