### PR TITLE
drivers: ieee802154: cc2520: Fix compiler warning

### DIFF
--- a/drivers/ieee802154/ieee802154_cc2520.c
+++ b/drivers/ieee802154/ieee802154_cc2520.c
@@ -1133,8 +1133,7 @@ NET_DEVICE_INIT(cc2520, CONFIG_IEEE802154_CC2520_DRV_NAME,
 NET_STACK_INFO_ADDR(RX, cc2520,
 		    CONFIG_IEEE802154_CC2520_RX_STACK_SIZE,
 		    CONFIG_IEEE802154_CC2520_RX_STACK_SIZE,
-		    ((struct cc2520_context *)(&__device_cc2520))->
-							cc2520_rx_stack,
+		    cc2520_context_data.cc2520_rx_stack,
 		    0);
 #endif
 


### PR DESCRIPTION
The stack address was incorrectly specified when stack usage
was being debugged. This caused compiler to emit this warning

drivers/ieee802154/ieee802154_cc2520.c:1136:16: warning:
    dereferencing type-punned pointer will break strict-aliasing
    rules [-Wstrict-aliasing]
       ((struct cc2520_context *)(&__device_cc2520))->
                ^

Signed-off-by: Jukka Rissanen <jukka.rissanen@linux.intel.com>