### PR TITLE
Bluetooth: controller: Fix assert on connection establishment

### DIFF
--- a/subsys/bluetooth/controller/ll_sw/ctrl.c
+++ b/subsys/bluetooth/controller/ll_sw/ctrl.c
@@ -1270,7 +1270,7 @@ static inline u32_t isr_rx_scan(u8_t devmatch_ok, u8_t devmatch_id,
 	if ((_radio.scanner.conn) && ((_radio.fc_ena == 0) ||
 				      (_radio.fc_req == _radio.fc_ack)) &&
 	    isr_scan_init_check(pdu_adv_rx, rl_idx) &&
-	    ((radio_tmr_end_get() + 502) <
+	    ((radio_tmr_end_get() + 502 + (RADIO_TICKER_JITTER_US << 1)) <
 	     (TICKER_TICKS_TO_US(_radio.scanner.hdr.ticks_slot) -
 	      RADIO_TICKER_START_PART_US))) {
 		struct radio_le_conn_cmplt *radio_le_conn_cmplt;


### PR DESCRIPTION
Fixes an assert during connection establishment when the
initiator overflows the initiator window in time while
sending the CONNECT_IND PDU. The actual window is one low
frequency tick less, hence corrected the check that permits
the transmission of CONNECT_IND PDU inside the initiator
window.

Symptom was, stopping of the scanner's ticker succeeds on
connection establishment, but next interval prepare was
already run when continuous scanning was used, breaking the
design, hence there was an assert.

Signed-off-by: Vinayak Kariappa Chettimada <vich@nordicsemi.no>