### PR TITLE
net: tcp: Queue FIN instead of sending it immediately

### DIFF
--- a/subsys/net/ip/net_context.c
+++ b/subsys/net/ip/net_context.c
@@ -579,10 +579,7 @@ static void queue_fin(struct net_context *ctx)
 		return;
 	}
 
-	ret = net_tcp_send_pkt(pkt);
-	if (ret < 0) {
-		net_pkt_unref(pkt);
-	}
+	net_tcp_queue_pkt(ctx, pkt);
 }
 
 #endif /* CONFIG_NET_TCP */

--- a/subsys/net/ip/tcp.h
+++ b/subsys/net/ip/tcp.h
@@ -313,6 +313,17 @@ int net_tcp_send_data(struct net_context *context);
 int net_tcp_queue_data(struct net_context *context, struct net_pkt *pkt);
 
 /**
+ * @brief Enqueue a single packet for transmission, this version just places
+ * the packet into queue and triggers sending if needed.
+ *
+ * @param context TCP context
+ * @param pkt Packet
+ *
+ * @return 0 if ok, < 0 if error
+ */
+void net_tcp_queue_pkt(struct net_context *context, struct net_pkt *pkt);
+
+/**
  * @brief Sends one TCP packet initialized with the _prepare_*()
  *        family of functions.
  *


### PR DESCRIPTION
If network context is closed, send FIN by placing it to the end
of send queue instead of sending it immediately. This way all
pending data is sent before the connection is closed.

Jira: ZEP-1853

Signed-off-by: Jukka Rissanen <jukka.rissanen@linux.intel.com>