### PR TITLE
x86: cleanup _new_thread()

### DIFF
--- a/arch/x86/core/thread.c
+++ b/arch/x86/core/thread.c
@@ -26,77 +26,8 @@
 
 #if defined(CONFIG_GDB_INFO) || defined(CONFIG_DEBUG_INFO) \
 	|| defined(CONFIG_X86_IAMCU)
-void _thread_entry_wrapper(_thread_entry_t, void *,
-			   void *, void *);
-#endif
-
-/**
- *
- * @brief Initialize a new execution thread
- *
- * This function is utilized to initialize all execution threads (both fiber
- * and task).  The 'priority' parameter will be set to -1 for the creation of
- * task.
- *
- * This function is called by _new_thread() to initialize tasks.
- *
- * @param thread pointer to thread struct memory
- * @param pStackMem pointer to thread stack memory
- * @param stackSize size of a stack in bytes
- * @param priority thread priority
- * @param options thread options: K_ESSENTIAL, K_FP_REGS, K_SSE_REGS
- *
- * @return N/A
- */
-static void _new_thread_internal(char *pStackMem, unsigned int stackSize,
-				 int priority,
-				 unsigned int options,
-				 struct k_thread *thread)
-{
-	unsigned long *pInitialCtx;
-
-#if (defined(CONFIG_FP_SHARING) || defined(CONFIG_GDB_INFO))
-	thread->arch.excNestCount = 0;
-#endif /* CONFIG_FP_SHARING || CONFIG_GDB_INFO */
-
-	/*
-	 * The creation of the initial stack for the task has already been done.
-	 * Now all that is needed is to set the ESP. However, we have been passed
-	 * the base address of the stack which is past the initial stack frame.
-	 * Therefore some of the calculations done in the other routines that
-	 * initialize the stack frame need to be repeated.
-	 */
-
-	pInitialCtx = (unsigned long *)STACK_ROUND_DOWN(pStackMem + stackSize);
-
-#ifdef CONFIG_THREAD_MONITOR
-	/*
-	 * In debug mode thread->entry give direct access to the thread entry
-	 * and the corresponding parameters.
-	 */
-	thread->entry = (struct __thread_entry *)(pInitialCtx -
-		sizeof(struct __thread_entry));
-#endif
-
-	/* The stack needs to be set up so that when we do an initial switch
-	 * to it in the middle of _Swap(), it needs to be set up as follows:
-	 *  - 4 thread entry routine parameters
-	 *  - eflags
-	 *  - eip (so that _Swap() "returns" to the entry point)
-	 *  - edi, esi, ebx, ebp,  eax
-	 */
-	pInitialCtx -= 11;
-
-	thread->callee_saved.esp = (unsigned long)pInitialCtx;
-	PRINTK("\nInitial context ESP = 0x%x\n", thread->coopReg.esp);
-
-	PRINTK("\nstruct thread * = 0x%x", thread);
-
-	thread_monitor_init(thread);
-}
-
-#if defined(CONFIG_GDB_INFO) || defined(CONFIG_DEBUG_INFO) \
-	|| defined(CONFIG_X86_IAMCU)
+extern void _thread_entry_wrapper(_thread_entry_t entry,
+				  void *p1, void *p2, void *p3);
 /**
  *
  * @brief Adjust stack/parameters before invoking _thread_entry
@@ -175,93 +106,85 @@ __asm__("\t.globl _thread_entry\n"
 	"\tjmp _thread_entry\n");
 #endif /* CONFIG_GDB_INFO || CONFIG_DEBUG_INFO) || CONFIG_X86_IAMCU */
 
+/* Initial thread stack frame, such that everything is laid out as expected
+ * for when _Swap() switches to it for the first time.
+ */
+struct _x86_initial_frame {
+	u32_t swap_retval;
+	u32_t ebp;
+	u32_t ebx;
+	u32_t esi;
+	u32_t edi;
+	void *_thread_entry;
+	u32_t eflags;
+	_thread_entry_t entry;
+	void *p1;
+	void *p2;
+	void *p3;
+};
+
 /**
- *
  * @brief Create a new kernel execution thread
  *
- * This function is utilized to create execution threads for both fiber
- * threads and kernel tasks.
+ * Initializes the k_thread object and sets up initial stack frame.
  *
  * @param thread pointer to thread struct memory, including any space needed
  *		for extra coprocessor context
- * @param pStackmem the pointer to aligned stack memory
- * @param stackSize the stack size in bytes
- * @param pEntry thread entry point routine
+ * @param stack the pointer to aligned stack memory
+ * @param stack_size the stack size in bytes
+ * @param entry thread entry point routine
  * @param parameter1 first param to entry point
  * @param parameter2 second param to entry point
  * @param parameter3 third param to entry point
  * @param priority thread priority
  * @param options thread options: K_ESSENTIAL, K_FP_REGS, K_SSE_REGS
- *
- *
- * @return opaque pointer to initialized k_thread structure
  */
 void _new_thread(struct k_thread *thread, k_thread_stack_t stack,
-		 size_t stackSize,
-		 _thread_entry_t pEntry,
+		 size_t stack_size, _thread_entry_t entry,
 		 void *parameter1, void *parameter2, void *parameter3,
 		 int priority, unsigned int options)
 {
-	char *pStackMem;
+	char *stack_buf;
+	char *stack_high;
+	struct _x86_initial_frame *initial_frame;
 
-	_ASSERT_VALID_PRIO(priority, pEntry);
-
-	unsigned long *pInitialThread;
-
+	_ASSERT_VALID_PRIO(priority, entry);
 #if CONFIG_X86_STACK_PROTECTION
 	_x86_mmu_set_flags(stack, MMU_PAGE_SIZE, MMU_ENTRY_NOT_PRESENT,
 			   MMU_PTE_P_MASK);
 #endif
-	pStackMem = K_THREAD_STACK_BUFFER(stack);
-	_new_thread_init(thread, pStackMem, stackSize, priority, options);
+	stack_buf = K_THREAD_STACK_BUFFER(stack);
+	_new_thread_init(thread, stack_buf, stack_size, priority, options);
 
-	/* carve the thread entry struct from the "base" of the stack */
+	stack_high = (char *)STACK_ROUND_DOWN(stack_buf + stack_size);
 
-	pInitialThread =
-		(unsigned long *)STACK_ROUND_DOWN(pStackMem + stackSize);
-
-	/*
-	 * Create an initial context on the stack expected by the _Swap()
-	 * primitive.
-	 */
-
-	/* push arguments required by _thread_entry() */
-
-	*--pInitialThread = (unsigned long)parameter3;
-	*--pInitialThread = (unsigned long)parameter2;
-	*--pInitialThread = (unsigned long)parameter1;
-	*--pInitialThread = (unsigned long)pEntry;
-
-	/* push initial EFLAGS; only modify IF and IOPL bits */
-
-	*--pInitialThread = (EflagsGet() & ~EFLAGS_MASK) | EFLAGS_INITIAL;
-
+	/* Create an initial context on the stack expected by _Swap() */
+	initial_frame = (struct _x86_initial_frame *)
+		(stack_high - sizeof(struct _x86_initial_frame));
+	/* _thread_entry() arguments */
+	initial_frame->entry = entry;
+	initial_frame->p1 = parameter1;
+	initial_frame->p2 = parameter2;
+	initial_frame->p3 = parameter3;
+	/* initial EFLAGS; only modify IF and IOPL bits */
+	initial_frame->eflags = (EflagsGet() & ~EFLAGS_MASK) | EFLAGS_INITIAL;
 #if defined(CONFIG_GDB_INFO) || defined(CONFIG_DEBUG_INFO) \
 	|| defined(CONFIG_X86_IAMCU)
-	/*
-	 * Arrange for the _thread_entry_wrapper() function to be called
-	 * to adjust the stack before _thread_entry() is invoked.
+	 /* Adjust the stack before _thread_entry() is invoked */
+	initial_frame->_thread_entry = _thread_entry_wrapper;
+#else
+	initial_frame->_thread_entry = _thread_entry;
+#endif
+	/* Remaining _x86_initial_frame members can be garbage, _thread_entry()
+	 * doesn't care about their state when execution begins
 	 */
+	thread->callee_saved.esp = (unsigned long)initial_frame;
 
-	*--pInitialThread = (unsigned long)_thread_entry_wrapper;
-
-#else /* defined(CONFIG_GDB_INFO) || defined(CONFIG_DEBUG_INFO) */
-
-	*--pInitialThread = (unsigned long)_thread_entry;
-
-#endif /* defined(CONFIG_GDB_INFO) || defined(CONFIG_DEBUG_INFO) */
-
-	/*
-	 * note: stack area for edi, esi, ebx, ebp, and eax registers can be
-	 * left
-	 * uninitialized, since _thread_entry() doesn't care about the values
-	 * of these registers when it begins execution
-	 */
-
-	/*
-	 * The k_thread structure is located at the "low end" of memory set
-	 * aside for the thread's stack.
-	 */
-
-	_new_thread_internal(pStackMem, stackSize, priority, options, thread);
+#if (defined(CONFIG_FP_SHARING) || defined(CONFIG_GDB_INFO))
+	thread->arch.excNestCount = 0;
+#endif /* CONFIG_FP_SHARING || CONFIG_GDB_INFO */
+#ifdef CONFIG_THREAD_MONITOR
+	thread->entry = (struct __thread_entry *)&initial_frame->entry;
+	thread_monitor_init(thread);
+#endif
 }


### PR DESCRIPTION
Years of iterative development had made this function more complicated
than it needed to be. Fixed some errors in the documentation as well.

Signed-off-by: Andrew Boie <andrew.p.boie@intel.com>