### PR TITLE
gen_mmu.py: Ignore 0-sized regions

### DIFF
--- a/scripts/gen_mmu.py
+++ b/scripts/gen_mmu.py
@@ -101,6 +101,9 @@ def read_mmu_list_marshal_param():
                                                size_read_from_binary);
         size_read_from_binary += struct.calcsize(struct_mmu_regions_format);
 
+        if basic_mem_region_values[1] == 0:
+            continue
+
         #validate for memory overlap here
         for i in raw_info:
             start_location = basic_mem_region_values[0]


### PR DESCRIPTION
Prevents overlapping region errors when enabling application memory
but there is nothing to put in application data.

Signed-off-by: Andrew Boie <andrew.p.boie@intel.com>