### PR TITLE
x86: arm: don't force stacks into kernel memory

### DIFF
--- a/include/arch/arm/cortex_m/scripts/linker.ld
+++ b/include/arch/arm/cortex_m/scripts/linker.ld
@@ -246,10 +246,6 @@ SECTIONS
         KERNEL_INPUT_SECTION(.noinit)
         KERNEL_INPUT_SECTION(".noinit.*")
 
-	/* Put all the stacks here in the kernel noinit */
-	*(.stacks)
-	*(".stacks.*")
-
         } GROUP_LINK_IN(RAMABLE_REGION)
 
     SECTION_DATA_PROLOGUE(_DATA_SECTION_NAME,,)

--- a/include/arch/x86/arch.h
+++ b/include/arch/x86/arch.h
@@ -537,20 +537,13 @@ extern FUNC_NORETURN void _SysFatalErrorHandler(unsigned int reason,
 #define _STACK_BASE_ALIGN	STACK_ALIGN
 #endif
 
-
-
-/* All thread stacks, regardless of whether owned by application or kernel,
- * go in the .stacks input section, which will end up in the kernel's
- * noinit.
- */
-
 #define _ARCH_THREAD_STACK_DEFINE(sym, size) \
-	struct _k_thread_stack_element _GENERIC_SECTION(.stacks) \
+	struct _k_thread_stack_element __noinit \
 		__aligned(_STACK_BASE_ALIGN) \
 		sym[(size) + _STACK_GUARD_SIZE]
 
 #define _ARCH_THREAD_STACK_ARRAY_DEFINE(sym, nmemb, size) \
-	struct _k_thread_stack_element _GENERIC_SECTION(.stacks) \
+	struct _k_thread_stack_element __noinit \
 		__aligned(_STACK_BASE_ALIGN) \
 		sym[nmemb][ROUND_UP(size, _STACK_BASE_ALIGN) + \
 			   _STACK_GUARD_SIZE]

--- a/include/arch/x86/linker.ld
+++ b/include/arch/x86/linker.ld
@@ -215,12 +215,6 @@ SECTIONS
 	KERNEL_INPUT_SECTION(".noinit.*")
 	*(".kernel_noinit.*")
 
-	/* All stacks go in kernel's noinit, regardless of where they
-	 * were defined.
-	 */
-	*(.stacks)
-	*(".stacks.*")
-
 	MMU_PAGE_ALIGN
 
 	} GROUP_DATA_LINK_IN(RAMABLE_REGION, RAMABLE_REGION)


### PR DESCRIPTION
This was felt to be necessary at one point but actually isn't.

- When a thread is initialized to use a particular stack, calls will be
made to the MMU/MPU to restrict access to that stack to only that
thread. Once a stack is in use, it will not be generally readable even
if the buffer exists in application memory space.

- If a user thread wants to create a thread, we will need to have some
way to ensure that whatever stack buffer passed in is unused and
appropriate. Since unused stacks in application memory will be generally
accessible, we can just check that the calling thread to
k_thread_create() has access to the stack buffer passed in, it won't if
the stack is in use.

On ARM we had a linker definition for .stacks, but currently stacks are
just tagged with __noinit (which is fine).

Signed-off-by: Andrew Boie <andrew.p.boie@intel.com>