### PR TITLE
x86: add printk for protection faults

### DIFF
--- a/arch/x86/core/fatal.c
+++ b/arch/x86/core/fatal.c
@@ -157,7 +157,12 @@ const NANO_ESF _default_esf = {
 static FUNC_NORETURN void generic_exc_handle(unsigned int vector,
 					     const NANO_ESF *pEsf)
 {
-	printk("***** CPU exception %d\n", vector);
+	printk("***** ");
+	if (vector == 13) {
+		printk("General Protection Fault\n");
+	} else {
+		printk("CPU exception %d\n", vector);
+	}
 	if ((1 << vector) & _EXC_ERROR_CODE_FAULTS) {
 		printk("***** Exception code: 0x%x\n", pEsf->errorCode);
 	}


### PR DESCRIPTION
Most x86 exceptions that don't already have their own handlers
are fairly rare, but with the introduction of userspace
people will be seeing General Protection Faults much more
often. Report it as text so that users unfamiliar with x86
internals will know what is happening.

Signed-off-by: Andrew Boie <andrew.p.boie@intel.com>