### PR TITLE
k_thread_abort(): fail assert if abort essential thread

### DIFF
--- a/arch/arc/core/fatal.c
+++ b/arch/arc/core/fatal.c
@@ -44,10 +44,6 @@ FUNC_NORETURN void _NanoFatalErrorHandler(unsigned int reason,
 	case _NANO_ERR_HW_EXCEPTION:
 		break;
 
-	case _NANO_ERR_INVALID_TASK_EXIT:
-		printk("***** Invalid Exit Software Error! *****\n");
-		break;
-
 #if defined(CONFIG_STACK_CANARIES) || defined(CONFIG_ARC_STACK_CHECKING)
 	case _NANO_ERR_STACK_CHK_FAIL:
 		printk("***** Stack Check Fail! *****\n");

--- a/arch/arm/core/fatal.c
+++ b/arch/arm/core/fatal.c
@@ -46,10 +46,6 @@ void _NanoFatalErrorHandler(unsigned int reason,
 					  const NANO_ESF *pEsf)
 {
 	switch (reason) {
-	case _NANO_ERR_INVALID_TASK_EXIT:
-		printk("***** Invalid Exit Software Error! *****\n");
-		break;
-
 #if defined(CONFIG_STACK_CANARIES) || defined(CONFIG_STACK_SENTINEL)
 	case _NANO_ERR_STACK_CHK_FAIL:
 		printk("***** Stack Check Fail! *****\n");

--- a/arch/arm/core/thread_abort.c
+++ b/arch/arm/core/thread_abort.c
@@ -22,6 +22,7 @@
 #include <linker/sections.h>
 #include <ksched.h>
 #include <wait_q.h>
+#include <misc/__assert.h>
 
 extern void _k_thread_single_abort(struct k_thread *thread);
 
@@ -30,6 +31,9 @@ void k_thread_abort(k_tid_t thread)
 	unsigned int key;
 
 	key = irq_lock();
+
+	__ASSERT(!(thread->base.user_options & K_ESSENTIAL),
+		 "essential thread aborted");
 
 	_k_thread_single_abort(thread);
 	_thread_monitor_exit(thread);

--- a/arch/nios2/core/fatal.c
+++ b/arch/nios2/core/fatal.c
@@ -56,11 +56,6 @@ FUNC_NORETURN void _NanoFatalErrorHandler(unsigned int reason,
 	case _NANO_ERR_SPURIOUS_INT:
 		break;
 
-	case _NANO_ERR_INVALID_TASK_EXIT:
-		printk("***** Invalid Exit Software Error! *****\n");
-		break;
-
-
 	case _NANO_ERR_ALLOCATION_FAIL:
 		printk("**** Kernel Allocation Failure! ****\n");
 		break;

--- a/arch/riscv32/core/fatal.c
+++ b/arch/riscv32/core/fatal.c
@@ -65,10 +65,6 @@ FUNC_NORETURN void _NanoFatalErrorHandler(unsigned int reason,
 	case _NANO_ERR_SPURIOUS_INT:
 		break;
 
-	case _NANO_ERR_INVALID_TASK_EXIT:
-		printk("***** Invalid Exit Software Error! *****\n");
-		break;
-
 #if defined(CONFIG_STACK_CANARIES) || defined(CONFIG_STACK_SENTINEL)
 	case _NANO_ERR_STACK_CHK_FAIL:
 		printk("***** Stack Check Fail! *****\n");

--- a/arch/x86/core/fatal.c
+++ b/arch/x86/core/fatal.c
@@ -64,10 +64,6 @@ FUNC_NORETURN void _NanoFatalErrorHandler(unsigned int reason,
 		printk("*****\n");
 		break;
 	}
-	case _NANO_ERR_INVALID_TASK_EXIT:
-		printk("***** Invalid Exit Software Error! *****\n");
-		break;
-
 #if defined(CONFIG_STACK_CANARIES) || defined(CONFIG_STACK_SENTINEL) || \
 		defined(CONFIG_X86_STACK_PROTECTION)
 	case _NANO_ERR_STACK_CHK_FAIL:

--- a/arch/xtensa/core/fatal.c
+++ b/arch/xtensa/core/fatal.c
@@ -52,9 +52,6 @@ FUNC_NORETURN void _NanoFatalErrorHandler(unsigned int reason,
 	case _NANO_ERR_RESERVED_IRQ:
 		break;
 
-	case _NANO_ERR_INVALID_TASK_EXIT:
-		printk("***** Invalid Exit Software Error! *****\n");
-		break;
 #if defined(CONFIG_STACK_CANARIES) || defined(CONFIG_STACK_SENTINEL)
 	case _NANO_ERR_STACK_CHK_FAIL:
 		printk("***** Stack Check Fail! *****\n");

--- a/include/arch/arc/v2/error.h
+++ b/include/arch/arc/v2/error.h
@@ -28,7 +28,6 @@ extern void _SysFatalErrorHandler(unsigned int cause, const NANO_ESF *esf);
 #endif
 
 #define _NANO_ERR_HW_EXCEPTION (0)      /* MPU/Bus/Usage fault */
-#define _NANO_ERR_INVALID_TASK_EXIT (1) /* Invalid task exit */
 #define _NANO_ERR_STACK_CHK_FAIL (2)    /* Stack corruption detected */
 #define _NANO_ERR_ALLOCATION_FAIL (3)   /* Kernel Allocation Failure */
 #define _NANO_ERR_KERNEL_OOPS (4)       /* Kernel oops (fatal to thread) */

--- a/include/arch/arm/cortex_m/error.h
+++ b/include/arch/arm/cortex_m/error.h
@@ -26,7 +26,6 @@ extern void _SysFatalErrorHandler(unsigned int reason, const NANO_ESF *esf);
 #endif
 
 #define _NANO_ERR_HW_EXCEPTION (0)      /* MPU/Bus/Usage fault */
-#define _NANO_ERR_INVALID_TASK_EXIT (1) /* Invalid task exit */
 #define _NANO_ERR_STACK_CHK_FAIL (2)    /* Stack corruption detected */
 #define _NANO_ERR_ALLOCATION_FAIL (3)   /* Kernel Allocation Failure */
 #define _NANO_ERR_KERNEL_OOPS (4)       /* Kernel oops (fatal to thread) */

--- a/include/arch/nios2/arch.h
+++ b/include/arch/nios2/arch.h
@@ -25,7 +25,6 @@ extern "C" {
 #define STACK_ALIGN  4
 
 #define _NANO_ERR_CPU_EXCEPTION (0)     /* Any unhandled exception */
-#define _NANO_ERR_INVALID_TASK_EXIT (1) /* Invalid task exit */
 #define _NANO_ERR_STACK_CHK_FAIL (2)    /* Stack corruption detected */
 #define _NANO_ERR_ALLOCATION_FAIL (3)   /* Kernel Allocation Failure */
 #define _NANO_ERR_SPURIOUS_INT (4)	/* Spurious interrupt */

--- a/include/arch/riscv32/exp.h
+++ b/include/arch/riscv32/exp.h
@@ -69,7 +69,6 @@ extern void _SysFatalErrorHandler(unsigned int reason,
 #endif /* _ASMLANGUAGE */
 
 #define _NANO_ERR_CPU_EXCEPTION (0)      /* Any unhandled exception */
-#define _NANO_ERR_INVALID_TASK_EXIT (1)  /* Invalid task exit */
 #define _NANO_ERR_STACK_CHK_FAIL (2)     /* Stack corruption detected */
 #define _NANO_ERR_ALLOCATION_FAIL (3)    /* Kernel Allocation Failure */
 #define _NANO_ERR_SPURIOUS_INT (4)	 /* Spurious interrupt */

--- a/include/arch/x86/arch.h
+++ b/include/arch/x86/arch.h
@@ -358,8 +358,6 @@ typedef struct nanoIsf {
 #define _NANO_ERR_PAGE_FAULT		 (1)
 /** General protection fault */
 #define _NANO_ERR_GEN_PROT_FAULT	 (2)
-/** Invalid task exit */
-#define _NANO_ERR_INVALID_TASK_EXIT  (3)
 /** Stack corruption detected */
 #define _NANO_ERR_STACK_CHK_FAIL	 (4)
 /** Kernel Allocation Failure */

--- a/include/arch/xtensa/arch.h
+++ b/include/arch/xtensa/arch.h
@@ -31,7 +31,6 @@ extern "C" {
 #define SIZEOFUNIT_TO_OCTET(X) (X)
 
 #define _NANO_ERR_HW_EXCEPTION (0)      /* MPU/Bus/Usage fault */
-#define _NANO_ERR_INVALID_TASK_EXIT (1) /* Invalid task exit */
 #define _NANO_ERR_STACK_CHK_FAIL (2)    /* Stack corruption detected */
 #define _NANO_ERR_ALLOCATION_FAIL (3)   /* Kernel Allocation Failure */
 #define _NANO_ERR_RESERVED_IRQ (4)	/* Reserved interrupt */

--- a/kernel/thread.c
+++ b/kernel/thread.c
@@ -189,10 +189,6 @@ FUNC_NORETURN void _thread_entry(void (*entry)(void *, void *, void *),
 	_check_stack_sentinel();
 #endif
 #ifdef CONFIG_MULTITHREADING
-	if (_is_thread_essential()) {
-		_k_except_reason(_NANO_ERR_INVALID_TASK_EXIT);
-	}
-
 	k_thread_abort(_current);
 #else
 	for (;;) {

--- a/kernel/thread_abort.c
+++ b/kernel/thread_abort.c
@@ -18,6 +18,7 @@
 #include <linker/sections.h>
 #include <wait_q.h>
 #include <ksched.h>
+#include <misc/__assert.h>
 
 extern void _k_thread_single_abort(struct k_thread *thread);
 
@@ -27,6 +28,9 @@ void k_thread_abort(k_tid_t thread)
 	unsigned int key;
 
 	key = irq_lock();
+
+	__ASSERT(!(thread->base.user_options & K_ESSENTIAL),
+		 "essential thread aborted");
 
 	_k_thread_single_abort(thread);
 	_thread_monitor_exit(thread);


### PR DESCRIPTION
Previously, this was only done if an essential thread self-exited.
Now if any thread has k_thread_abort() called on it, and that thread
is essential to the system operation, this check is made.

Signed-off-by: Andrew Boie <andrew.p.boie@intel.com>