### PR TITLE
k_thread_create(): allow K_FOREVER delay

### DIFF
--- a/include/kernel.h
+++ b/include/kernel.h
@@ -400,7 +400,8 @@ typedef struct _k_thread_stack_element *k_thread_stack_t;
  * @param p3 3rd entry point parameter.
  * @param prio Thread priority.
  * @param options Thread options.
- * @param delay Scheduling delay (in milliseconds), or K_NO_WAIT (for no delay).
+ * @param delay Scheduling delay (in milliseconds), or K_NO_WAIT (for no delay),
+ *              or K_FOREVER (to not run until k_thread_start() is called)
  *
  * @return ID of new thread.
  */
@@ -529,6 +530,18 @@ extern int k_thread_cancel(k_tid_t thread);
  * @return N/A
  */
 extern void k_thread_abort(k_tid_t thread);
+
+
+/**
+ * @brief Start an inactive thread
+ *
+ * If a thread was created with K_FOREVER in the delay parameter, it will
+ * not be added to the scheduling queue until this function is called
+ * on it.
+ *
+ * @param thread thread to start
+ */
+extern void k_thread_start(k_tid_t thread);
 
 /**
  * @cond INTERNAL_HIDDEN

--- a/tests/kernel/threads/lifecycle/lifecycle_api/src/main.c
+++ b/tests/kernel/threads/lifecycle/lifecycle_api/src/main.c
@@ -16,6 +16,7 @@
 extern void test_threads_spawn_params(void);
 extern void test_threads_spawn_priority(void);
 extern void test_threads_spawn_delay(void);
+extern void test_threads_spawn_forever(void);
 extern void test_threads_suspend_resume_cooperative(void);
 extern void test_threads_suspend_resume_preemptible(void);
 extern void test_threads_cancel_undelayed(void);
@@ -31,6 +32,7 @@ void test_main(void)
 			 ztest_unit_test(test_threads_spawn_params),
 			 ztest_unit_test(test_threads_spawn_priority),
 			 ztest_unit_test(test_threads_spawn_delay),
+			 ztest_unit_test(test_threads_spawn_forever),
 			 ztest_unit_test(test_threads_suspend_resume_cooperative),
 			 ztest_unit_test(test_threads_suspend_resume_preemptible),
 			 ztest_unit_test(test_threads_cancel_undelayed),

--- a/tests/kernel/threads/lifecycle/lifecycle_api/src/test_threads_spawn.c
+++ b/tests/kernel/threads/lifecycle/lifecycle_api/src/test_threads_spawn.c
@@ -80,3 +80,22 @@ void test_threads_spawn_delay(void)
 	zassert_true(tp2 == 100, NULL);
 	k_thread_abort(tid);
 }
+
+void test_threads_spawn_forever(void)
+{
+	/* spawn thread with highest priority. It will run immediately once
+	 * started.
+	 */
+	tp2 = 10;
+	k_tid_t tid = k_thread_create(&tdata, tstack, STACK_SIZE,
+				      thread_entry_delay, NULL, NULL, NULL,
+				      K_HIGHEST_THREAD_PRIO, 0, K_FOREVER);
+	k_yield();
+	/* checkpoint: check spawn thread not execute */
+	zassert_true(tp2 == 10, NULL);
+	/* checkpoint: check spawn thread executed */
+	k_thread_start(tid);
+	k_yield();
+	zassert_true(tp2 == 100, NULL);
+	k_thread_abort(tid);
+}


### PR DESCRIPTION
It's now possible to instantiate a thread object, but delay its
execution indefinitely. This was already supported with K_THREAD_DEFINE.

A new API, k_thread_start(), now exists to start threads that are in
this state.

The intended use-case is to initialize a thread with K_USER, then grant
it various access permissions, and only then start it.

Signed-off-by: Andrew Boie <andrew.p.boie@intel.com>