### PR TITLE
[RC regression] net: sockets: Be sure to initialize socket's queue on accept

### DIFF
--- a/subsys/net/lib/sockets/sockets.c
+++ b/subsys/net/lib/sockets/sockets.c
@@ -108,6 +108,7 @@ static void zsock_accepted_cb(struct net_context *new_ctx,
 	struct net_context *parent = user_data;
 
 	net_context_recv(new_ctx, zsock_received_cb, K_NO_WAIT, NULL);
+	k_fifo_init(&new_ctx->recv_q);
 
 	NET_DBG("parent=%p, ctx=%p, st=%d", parent, new_ctx, status);
 


### PR DESCRIPTION
When new socket context is created on accepting connection to a
listening socket, its recv_q FIFO should be initialized. Without
initialization, this worked by a chance when FIFO structure was
simple, but recent change to add dlist to it (which now needs
proper initialization) exposed this issue.

Jira: ZEP-2576

Signed-off-by: Paul Sokolovsky <paul.sokolovsky@linaro.org>