### PR TITLE
Bluetooth: Mesh: Fix setting the right value for Static OOB type

### DIFF
--- a/subsys/bluetooth/host/mesh/prov.c
+++ b/subsys/bluetooth/host/mesh/prov.c
@@ -479,7 +479,7 @@ static void prov_invite(const u8_t *data)
 	net_buf_simple_add_u8(buf, 0x00);
 
 	/* Static OOB Type */
-	net_buf_simple_add_u8(buf, prov->static_val ? BIT(1) : 0x00);
+	net_buf_simple_add_u8(buf, prov->static_val ? BIT(0) : 0x00);
 
 	/* Output OOB Size */
 	net_buf_simple_add_u8(buf, prov->output_size);


### PR DESCRIPTION
The code was setting the wrong bit of the Static OOB Type when a
static value has been provided.

Signed-off-by: Johan Hedberg <johan.hedberg@intel.com>