### PR TITLE
Entrypoint: Define Entrypoint in linker files

### DIFF
--- a/arch/xtensa/soc/esp32/linker.ld
+++ b/arch/xtensa/soc/esp32/linker.ld
@@ -49,6 +49,9 @@ PHDRS
 }
 
 /*  Default entry point:  */
+ENTRY(__start)
+
+/*  Default entry point:  */
 PROVIDE ( _ResetVector = 0x40000400 );
 
 _rom_store_table = 0;

--- a/include/arch/arc/v2/linker.ld
+++ b/include/arch/arc/v2/linker.ld
@@ -61,6 +61,9 @@ MEMORY {
 	IDT_LIST  (wx)      : ORIGIN = 0xFFFFF7FF, LENGTH = 2K
 }
 
+/*  Default entry point:  */
+ENTRY(__start)
+
 SECTIONS {
 	GROUP_START(ROMABLE_REGION)
 

--- a/include/arch/arm/cortex_m/scripts/linker.ld
+++ b/include/arch/arm/cortex_m/scripts/linker.ld
@@ -80,6 +80,9 @@ MEMORY
     IDT_LIST  (wx)      : ORIGIN = (RAM_ADDR + RAM_SIZE), LENGTH = 2K
     }
 
+/*  Default entry point:  */
+ENTRY(__start)
+
 SECTIONS
     {
     GROUP_START(ROMABLE_REGION)

--- a/include/arch/nios2/linker.ld
+++ b/include/arch/nios2/linker.ld
@@ -78,6 +78,9 @@ MEMORY
 }
 #endif
 
+/*  Default entry point:  */
+ENTRY(__start)
+
 SECTIONS
     {
     GROUP_START(ROMABLE_REGION)

--- a/include/arch/riscv32/common/linker.ld
+++ b/include/arch/riscv32/common/linker.ld
@@ -41,6 +41,9 @@ MEMORY
     IDT_LIST  (wx)      : ORIGIN = 0xFFFFF7FF, LENGTH = 2K
 }
 
+/*  Default entry point:  */
+ENTRY(__start)
+
 SECTIONS
     {
 

--- a/include/arch/riscv32/pulpino/linker.ld
+++ b/include/arch/riscv32/pulpino/linker.ld
@@ -37,6 +37,9 @@ MEMORY
     IDT_LIST  (wx)      : ORIGIN = 0xFFFFF7FF, LENGTH = 2K
 }
 
+/*  Default entry point:  */
+ENTRY(__start)
+
 SECTIONS
     {
     GROUP_START(INSTRRAM)

--- a/include/arch/x86/linker.ld
+++ b/include/arch/x86/linker.ld
@@ -61,6 +61,9 @@
 	#define MMU_PAGE_ALIGN
 #endif
 
+/*  Default entry point:  */
+ENTRY(__start)
+
 /* SECTIONS definitions */
 SECTIONS
 	{


### PR DESCRIPTION
The entrypoint was hardcoded to __start in the base level Makefile.
This made it inflexible for architectures that needed an entrypoint
different from __start. This is now fixed by specifying the entrypoint
in the linker scripts.

Signed-off-by: Rajavardhan Gundi <rajavardhan.gundi@intel.com>