### PR TITLE
net: sock: zsock_close: Explicitly cast few calls to (void).

### DIFF
--- a/subsys/net/lib/sockets/sockets.c
+++ b/subsys/net/lib/sockets/sockets.c
@@ -90,11 +90,12 @@ int zsock_close(int sock)
 	struct net_context *ctx = INT_TO_POINTER(sock);
 
 	/* Reset callbacks to avoid any race conditions while
-	 * flushing queues. No need to check return values here
-	 * as Coverity complains in CID 173646.
+	 * flushing queues. No need to check return values here,
+	 * as these are fail-free operations and we're closing
+	 * socket anyway.
 	 */
-	net_context_accept(ctx, NULL, K_NO_WAIT, NULL);
-	net_context_recv(ctx, NULL, K_NO_WAIT, NULL);
+	(void)net_context_accept(ctx, NULL, K_NO_WAIT, NULL);
+	(void)net_context_recv(ctx, NULL, K_NO_WAIT, NULL);
 
 	zsock_flush_queue(ctx);
 


### PR DESCRIPTION
To make Coverity happy.

Coverity-CID: 173646
Jira: ZEP-2465

Signed-off-by: Paul Sokolovsky <paul.sokolovsky@linaro.org>