### PR TITLE
samples: grove: set min_flash filter

### DIFF
--- a/samples/grove/temperature/sample.yaml
+++ b/samples/grove/temperature/sample.yaml
@@ -4,6 +4,6 @@ sample:
 tests:
 -   test:
         build_only: true
-        platform_whitelist: arduino_101_sss quark_d2000_crb
-            arduino_due
+        platform_whitelist: arduino_101_sss quark_d2000_crb arduino_due
         tags: drivers
+        min_flash: 33


### PR DESCRIPTION
This sample does not fit in < 32Kb when built with asserts enabled.

Signed-off-by: Anas Nashif <anas.nashif@intel.com>