### PR TITLE
Bluetooth: controller: Fix Read Version Info VS cmd

### DIFF
--- a/subsys/bluetooth/controller/hci/hci.c
+++ b/subsys/bluetooth/controller/hci/hci.c
@@ -8,6 +8,7 @@
 #include <stddef.h>
 #include <zephyr/types.h>
 #include <string.h>
+#include <version.h>
 
 #include <soc.h>
 #include <toolchain.h>
@@ -1651,12 +1652,13 @@ static void vs_read_version_info(struct net_buf *buf, struct net_buf **evt)
 	rp = cmd_complete(evt, sizeof(*rp));
 
 	rp->status = 0x00;
-	rp->hw_platform = sys_cpu_to_le16(0);
-	rp->hw_variant = sys_cpu_to_le16(0);
+	rp->hw_platform = BT_HCI_VS_HW_PLAT;
+	rp->hw_variant = BT_HCI_VS_HW_VAR;
+
 	rp->fw_variant = 0;
-	rp->fw_version = 0;
-	rp->fw_revision = sys_cpu_to_le16(0);
-	rp->fw_build = sys_cpu_to_le32(0);
+	rp->fw_version = (KERNEL_VERSION_MAJOR & 0xff);
+	rp->fw_revision = KERNEL_VERSION_MINOR;
+	rp->fw_build = (KERNEL_PATCHLEVEL & 0xffff);
 }
 
 static void vs_read_supported_commands(struct net_buf *buf,

--- a/subsys/bluetooth/controller/hci/hci_internal.h
+++ b/subsys/bluetooth/controller/hci/hci_internal.h
@@ -22,6 +22,18 @@ extern atomic_t hci_state_mask;
 #define HCI_CLASS_EVT_CONNECTION  2
 #define HCI_CLASS_ACL_DATA        3
 
+#if defined(CONFIG_SOC_FAMILY_NRF5)
+#define BT_HCI_VS_HW_PLAT BT_HCI_VS_HW_PLAT_NORDIC
+#if defined(CONFIG_SOC_SERIES_NRF51X)
+#define BT_HCI_VS_HW_VAR  BT_HCI_VS_HW_VAR_NORDIC_NRF51X;
+#elif defined(CONFIG_SOC_SERIES_NRF52X)
+#define BT_HCI_VS_HW_VAR  BT_HCI_VS_HW_VAR_NORDIC_NRF52X;
+#endif
+#else
+#define BT_HCI_VS_HW_PLAT 0
+#define BT_HCI_VS_HW_VAR  0
+#endif /* CONFIG_SOC_FAMILY_NRF5 */
+
 void hci_init(struct k_poll_signal *signal_host_buf);
 struct net_buf *hci_cmd_handle(struct net_buf *cmd);
 void hci_evt_encode(struct radio_pdu_node_rx *node_rx, struct net_buf *buf);


### PR DESCRIPTION
Use the macros generated during the build and located in version.h to
fill in the version information in the Read Version Information VS
command. Additionally reply with the correct hardware identifiers when
running on Nordic hardware.

Signed-off-by: Carles Cufi <carles.cufi@nordicsemi.no>