### PR TITLE
Bluetooth: controller: Fix pointless expression

### DIFF
--- a/subsys/bluetooth/controller/ticker/ticker.c
+++ b/subsys/bluetooth/controller/ticker/ticker.c
@@ -809,7 +809,6 @@ static inline u32_t ticker_job_insert(struct ticker_instance *instance,
 			}
 
 			if (ticker_collide->ticks_periodic &&
-			    ticker_collide->ticks_periodic &&
 			    skip_collide <= skip &&
 			    ticker_collide->force < ticker->force) {
 				/* dequeue and get the reminder of ticks


### PR DESCRIPTION
Seems due to incorrect rebase in commit 07270e52ba45
("Bluetooth: controller: Coding style and refactoring"),
commit 95d55a2bfc29 ("Bluetooth: controller: Do not skip
one-shot tickers with slot"), and
commit 4ba2bb0d1c59 ("Bluetooth: controller: Be fair when
pre-empting a ticker"), a pointless expression was
introduced, fixed it.

Coverity-CID: 171563

Signed-off-by: Vinayak Kariappa Chettimada <vich@nordicsemi.no>