### PR TITLE
Revert "net: tcp: Queue FIN instead of sending it immediately"

### DIFF
--- a/subsys/net/ip/net_context.c
+++ b/subsys/net/ip/net_context.c
@@ -579,7 +579,10 @@ static void queue_fin(struct net_context *ctx)
 		return;
 	}
 
-	net_tcp_queue_pkt(ctx, pkt);
+	ret = net_tcp_send_pkt(pkt);
+	if (ret < 0) {
+		net_pkt_unref(pkt);
+	}
 }
 
 #endif /* CONFIG_NET_TCP */

--- a/subsys/net/ip/tcp.c
+++ b/subsys/net/ip/tcp.c
@@ -686,20 +686,6 @@ const char *net_tcp_state_str(enum net_tcp_state state)
 	return "";
 }
 
-/* This one just queues the packet and nothing else */
-void net_tcp_queue_pkt(struct net_context *context, struct net_pkt *pkt)
-{
-	sys_slist_append(&context->tcp->sent_list, &pkt->sent_list);
-
-	/* We need to restart retry_timer if it is stopped. */
-	if (k_timer_remaining_get(&context->tcp->retry_timer) == 0) {
-		k_timer_start(&context->tcp->retry_timer,
-			      retry_timeout(context->tcp), 0);
-	}
-
-	do_ref_if_needed(context->tcp, pkt);
-}
-
 int net_tcp_queue_data(struct net_context *context, struct net_pkt *pkt)
 {
 	struct net_conn *conn = (struct net_conn *)context->conn_handler;
@@ -722,7 +708,15 @@ int net_tcp_queue_data(struct net_context *context, struct net_pkt *pkt)
 
 	net_stats_update_tcp_sent(data_len);
 
-	net_tcp_queue_pkt(context, pkt);
+	sys_slist_append(&context->tcp->sent_list, &pkt->sent_list);
+
+	/* We need to restart retry_timer if it is stopped. */
+	if (k_timer_remaining_get(&context->tcp->retry_timer) == 0) {
+		k_timer_start(&context->tcp->retry_timer,
+			      retry_timeout(context->tcp), 0);
+	}
+
+	do_ref_if_needed(context->tcp, pkt);
 
 	return 0;
 }

--- a/subsys/net/ip/tcp.h
+++ b/subsys/net/ip/tcp.h
@@ -313,17 +313,6 @@ int net_tcp_send_data(struct net_context *context);
 int net_tcp_queue_data(struct net_context *context, struct net_pkt *pkt);
 
 /**
- * @brief Enqueue a single packet for transmission, this version just places
- * the packet into queue and triggers sending if needed.
- *
- * @param context TCP context
- * @param pkt Packet
- *
- * @return 0 if ok, < 0 if error
- */
-void net_tcp_queue_pkt(struct net_context *context, struct net_pkt *pkt);
-
-/**
  * @brief Sends one TCP packet initialized with the _prepare_*()
  *        family of functions.
  *


### PR DESCRIPTION
This reverts commit 817245c5645bd433a468f245a215490c07a4df5a.

In certain cases the peer seems to discard the FIN packet we are
sending, which means that the TCP stream is not closed properly.
This needs more work so revert this for time being.

Signed-off-by: Jukka Rissanen <jukka.rissanen@linux.intel.com>