### PR TITLE
net: lwm2m: reset obj_inst/res_inst data structure when delete

### DIFF
--- a/subsys/net/lib/lwm2m/lwm2m_engine.c
+++ b/subsys/net/lib/lwm2m/lwm2m_engine.c
@@ -252,6 +252,7 @@ static int engine_add_observer(struct net_context *net_ctx,
 static int engine_remove_observer(const u8_t *token, u8_t tkl)
 {
 	struct observe_node *obs, *found_obj = NULL;
+	sys_snode_t *prev_node = NULL;
 
 	if (!token || tkl == 0) {
 		SYS_LOG_ERR("token(%p) and token length(%u) must be valid.",
@@ -265,13 +266,16 @@ static int engine_remove_observer(const u8_t *token, u8_t tkl)
 			found_obj = obs;
 			break;
 		}
+
+		prev_node = &obs->node;
 	}
 
 	if (!found_obj) {
 		return -ENOENT;
 	}
 
-	sys_slist_remove(&engine_observer_list, NULL, &found_obj->node);
+	sys_slist_remove(&engine_observer_list, prev_node, &found_obj->node);
+	memset(found_obj, 0, sizeof(*found_obj));
 
 	SYS_LOG_DBG("observer '%s' removed", sprint_token(token, tkl));
 
@@ -288,7 +292,7 @@ void lwm2m_register_obj(struct lwm2m_engine_obj *obj)
 void lwm2m_unregister_obj(struct lwm2m_engine_obj *obj)
 {
 	/* TODO: remove all observer instances */
-	sys_slist_remove(&engine_obj_list, NULL, &obj->node);
+	sys_slist_find_and_remove(&engine_obj_list, &obj->node);
 }
 
 static struct lwm2m_engine_obj *get_engine_obj(int obj_id)
@@ -329,7 +333,7 @@ static void engine_register_obj_inst(struct lwm2m_engine_obj_inst *obj_inst)
 
 static void engine_unregister_obj_inst(struct lwm2m_engine_obj_inst *obj_inst)
 {
-	sys_slist_remove(&engine_obj_inst_list, NULL, &obj_inst->node);
+	sys_slist_find_and_remove(&engine_obj_inst_list, &obj_inst->node);
 }
 
 static struct lwm2m_engine_obj_inst *get_engine_obj_inst(int obj_id,

--- a/subsys/net/lib/lwm2m/lwm2m_rw_oma_tlv.c
+++ b/subsys/net/lib/lwm2m/lwm2m_rw_oma_tlv.c
@@ -691,11 +691,21 @@ int do_write_op_tlv(struct lwm2m_engine_obj *obj,
 				if (tlv2.type == OMA_TLV_TYPE_RESOURCE) {
 					path->res_id = tlv2.id;
 					path->level = 3;
-					/* ignore errors */
-					do_write_op_tlv_item(
+					ret = do_write_op_tlv_item(
 							context,
 							(u8_t *)&tlv.value[pos],
 							len2);
+					/*
+					 * ignore errors for CREATE op
+					 * TODO: support BOOTSTRAP WRITE where
+					 * optional resources are ignored
+					 */
+					if (ret < 0 &&
+					    (context->operation !=
+					     LWM2M_OP_CREATE ||
+					     ret != -ENOTSUP)) {
+						return ret;
+					}
 				}
 
 				pos += len2;


### PR DESCRIPTION
When a request demands to create a new object instance, it will search whether the request object instance exists or not. However, the current implementation does not reset the lwm2m_engine_obj_inst at the time it is deleted. It only removes the object instance from the sys list.
    
Correct the behavior by resetting both object instance and resource instances at the time it's deleted. Also, consolidate function lwm2m_delete_handler() and lwm2m_delete_obj_inst().
    
To reproduce the issue, try to create light control object instance (/3301), delete the created instance and create it again. You shall find following error message dumped.
> [ipso_light_control] [ERR] light_control_create: Can not create instance - already existing: 0
> [lib/lwm2m_engine] [ERR] lwm2m_create_obj_inst: unable to create obj - 3311 instance 0
