### PR TITLE
Bluetooth: controller: Fix Coverity unreachable code

### DIFF
--- a/subsys/bluetooth/controller/hci/hci.c
+++ b/subsys/bluetooth/controller/hci/hci.c
@@ -1672,12 +1672,12 @@ static void vs_read_key_hierarchy_roots(struct net_buf *buf,
 	}
 
 	return;
-#endif /* CONFIG_SOC_FAMILY_NRF5 */
-
+#else
 	/* Mark IR as invalid */
 	memset(rp->ir, 0x00, sizeof(rp->ir));
 	/* Mark ER as invalid */
 	memset(rp->er, 0x00, sizeof(rp->er));
+#endif /* CONFIG_SOC_FAMILY_NRF5 */
 }
 
 #endif /* CONFIG_BT_CTLR_HCI_VS_EXT */


### PR DESCRIPTION
CID: 175182

Use #else to avoid Coverity warning about unreachable code.

Signed-off-by: Carles Cufi <carles.cufi@nordicsemi.no>