### PR TITLE
release-notes: Make a clear note about the Kconfig prefix change

### DIFF
--- a/doc/release-notes-1.9.rst
+++ b/doc/release-notes-1.9.rst
@@ -97,6 +97,10 @@ Bluetooth
 * Controller roles (Advertiser, Scanner, Master and Slave) separation in
   source code, conditionally includable
 * Flash access cooperation with BLE radio activity
+* Bluetooth Kconfig options have been renamed have the same (consistent)
+  prefix as the Bluetooth APIs, namely BT_* instead of BLUETOOTH_*.
+  Controller Kconfig options have been shortened to use CTLR instead of
+  CONTROLLER.
 
 Build and Infrastructure
 ************************


### PR DESCRIPTION
Make it known to any out-of-tree apps that they need to update their
references to any Bluetooth Kconfig options.

Jira: ZEP-2558

Signed-off-by: Johan Hedberg <johan.hedberg@intel.com>