### PR TITLE
Bluetooth: controller: Require nRF52 for privacy

### DIFF
--- a/subsys/bluetooth/controller/Kconfig
+++ b/subsys/bluetooth/controller/Kconfig
@@ -134,6 +134,7 @@ config BT_CTLR_LE_PING
 
 config BT_CTLR_PRIVACY
 	bool "LE Controller-based Privacy"
+	depends on !SOC_SERIES_NRF51X
 	default y
 	select BT_RPA
 	help


### PR DESCRIPTION
Privacy on nRF51 is not passing the conformance and qualification tests
due to the time it takes to execute the privacy code while in ISR. Until
we come up with a way of optimizing and/or deferring the work, do not
allow privacy on nRF51 targets.

Signed-off-by: Carles Cufi <carles.cufi@nordicsemi.no>