### PR TITLE
doc: release notes: Add BLE controller to the highlights

### DIFF
--- a/doc/release-notes-1.9.rst
+++ b/doc/release-notes-1.9.rst
@@ -15,6 +15,7 @@ Major enhancements planned with this release include:
 * Expand Device Tree support to more architectures
 * BLE Mesh
 * Bluetooth 5.0 Support (all features except Advertising Extensions)
+* Bluetooth Qualification-ready BLE Controller
 * Revamp Testsuite, Increase Coverage
 * Lightweight Machine to Machine (LwM2M) support
 * MMU/MPU (Cont.): Thread Isolation, Paging


### PR DESCRIPTION
Include the fact that the Zephyr BLE Controller is ready for
qualification in the release highlights.

Signed-off-by: Carles Cufi <carles.cufi@nordicsemi.no>