### PR TITLE
net/ethernet/arp: Let ethernet L2 managing pkt's reference while sending

### DIFF
--- a/subsys/net/ip/l2/ethernet.c
+++ b/subsys/net/ip/l2/ethernet.c
@@ -203,6 +203,11 @@ static enum net_verdict ethernet_send(struct net_if *iface,
 		NET_DBG("Sending arp pkt %p (orig %p) to iface %p",
 			arp_pkt, pkt, iface);
 
+		if (pkt != arp_pkt) {
+			/* pkt went to ARP pending queue */
+			net_pkt_unref(pkt);
+		}
+
 		pkt = arp_pkt;
 
 		net_pkt_ll_src(pkt)->addr = (u8_t *)&NET_ETH_HDR(pkt)->src;


### PR DESCRIPTION
prepare_arp() was unreferencing original pkt (called pending there) in
case of error.

net_prepare_arp() was always unreferencing pkt, though it could have
been already unreferenced by prepare_arp() as seen previously which is
an extra boguf unref in this case.

And in case it returned NULL, ethernet_send() would return NET_DROP
which in turn would make net_if's tx code to unref again the pkt.

This patch ensures pkt is unrefed only once and at the right place.

Signed-off-by: Tomasz Bursztyka <tomasz.bursztyka@linux.intel.com>