### PR TITLE
samples: Add bbc_microbit to hci_uart's whitelist

### DIFF
--- a/samples/bluetooth/hci_uart/sample.yaml
+++ b/samples/bluetooth/hci_uart/sample.yaml
@@ -4,7 +4,7 @@ sample:
 tests:
 -   test_arm:
         build_only: true
-        platform_whitelist: 96b_nitrogen nrf51_pca10028 nrf52_pca10040
+        platform_whitelist: 96b_nitrogen nrf51_pca10028 nrf52_pca10040 bbc_microbit
         tags: uart bluetooth
 -   test_nrf5:
         build_only: true


### PR DESCRIPTION
bbc_microbit has been observed to regress on this sample and is
therefore a good candidate for CI.

See https://github.com/zephyrproject-rtos/zephyr/pull/1363

Signed-off-by: Sebastian Boe <sebastian.boe@nordicsemi.no>