### PR TITLE
net: shell: Fix TCP state printing

### DIFF
--- a/subsys/net/ip/net_shell.c
+++ b/subsys/net/ip/net_shell.c
@@ -1081,8 +1081,8 @@ int net_shell_cmd_conn(int argc, char *argv[])
 #endif
 
 #if defined(CONFIG_NET_TCP)
-	printk("\nTCP        Src port  Dst port   Send-Seq   Send-Ack  MSS    "
-	       "State\n");
+	printk("\nTCP        Src port  Dst port   Send-Seq   Send-Ack  MSS"
+	       "%s\n", IS_ENABLED(CONFIG_NET_DEBUG_TCP) ? "    State" : "");
 
 	count = 0;
 


### PR DESCRIPTION
The TCP state string is only printed if CONFIG_NET_DEBUG_TCP is
defined. If that is not the case, then the "net conn" command
should not print the "State" column name as the state will not
be printed.

Signed-off-by: Jukka Rissanen <jukka.rissanen@linux.intel.com>