### PR TITLE
doc: add 1.9.0 docs link to index page

### DIFF
--- a/doc/index.rst
+++ b/doc/index.rst
@@ -20,7 +20,8 @@ Zephyr Project Documentation
    ``https://www.zephyrproject.org/doc/<version>``. The following documentation
    versions are available:
 
-   `Zephyr 1.5.0`_ | `Zephyr 1.6.0`_ | `Zephyr 1.7.0`_ | `Zephyr 1.8.0`_
+   `Zephyr 1.5.0`_ | `Zephyr 1.6.0`_ | `Zephyr 1.7.0`_ | `Zephyr 1.8.0`_ |
+   `Zephyr 1.9.0`_
 
 For more information about previous releases, please consult the published
 :ref:`zephyr_release_notes`.
@@ -62,6 +63,7 @@ Indices and Tables
 
 * :ref:`genindex`
 
+.. _Zephyr 1.9.0: https://www.zephyrproject.org/doc/1.9.0/
 .. _Zephyr 1.8.0: https://www.zephyrproject.org/doc/1.8.0/
 .. _Zephyr 1.7.0: https://www.zephyrproject.org/doc/1.7.0/
 .. _Zephyr 1.6.0: https://www.zephyrproject.org/doc/1.6.0/


### PR DESCRIPTION
In final preparation for the 1.9 release, add the doc link for the
tagged 1.9.0 documentation to the index page.

Signed-off-by: David B. Kinder <david.b.kinder@intel.com>