### PR TITLE
lib: json: Fix crashes on xtensa/nios2

### DIFF
--- a/lib/json/json.c
+++ b/lib/json/json.c
@@ -9,10 +9,11 @@
 #include <errno.h>
 #include <limits.h>
 #include <misc/printk.h>
+#include <misc/util.h>
 #include <stdbool.h>
-#include <zephyr/types.h>
 #include <stdlib.h>
 #include <string.h>
+#include <zephyr/types.h>
 
 #include "json.h"
 
@@ -475,6 +476,8 @@ static int decode_value(struct json_obj *obj,
 
 static ptrdiff_t get_elem_size(const struct json_obj_descr *descr)
 {
+	assert(descr->alignment);
+
 	switch (descr->type) {
 	case JSON_TOK_NUMBER:
 		return sizeof(s32_t);
@@ -489,8 +492,10 @@ static ptrdiff_t get_elem_size(const struct json_obj_descr *descr)
 		ptrdiff_t total = 0;
 		size_t i;
 
-		for (i = 0; i < descr->sub_descr_len; i++) {
-			total += get_elem_size(&descr->object.sub_descr[i]);
+		for (i = 0; i < descr->object.sub_descr_len; i++) {
+			ptrdiff_t s = get_elem_size(&descr->object.sub_descr[i]);
+
+			total += ROUND_UP(s, descr->alignment);
 		}
 
 		return total;

--- a/lib/json/json.c
+++ b/lib/json/json.c
@@ -797,10 +797,6 @@ static int bool_encode(const bool *value, json_append_bytes_t append_bytes,
 	return append_bytes("false", 5, data);
 }
 
-static int obj_encode(const struct json_obj_descr *descr, size_t descr_len,
-		      const void *val, json_append_bytes_t append_bytes,
-		      void *data);
-
 static int encode(const struct json_obj_descr *descr, const void *val,
 		  json_append_bytes_t append_bytes, void *data)
 {
@@ -816,8 +812,9 @@ static int encode(const struct json_obj_descr *descr, const void *val,
 		return arr_encode(descr->element_descr, ptr,
 				  val, append_bytes, data);
 	case JSON_TOK_OBJECT_START:
-		return obj_encode(descr->sub_descr, descr->sub_descr_len,
-				  ptr, append_bytes, data);
+		return json_obj_encode(descr->sub_descr,
+				       descr->sub_descr_len,
+				       ptr, append_bytes, data);
 	case JSON_TOK_NUMBER:
 		return num_encode(ptr, append_bytes, data);
 	default:
@@ -825,9 +822,9 @@ static int encode(const struct json_obj_descr *descr, const void *val,
 	}
 }
 
-static int obj_encode(const struct json_obj_descr *descr, size_t descr_len,
-		      const void *val, json_append_bytes_t append_bytes,
-		      void *data)
+int json_obj_encode(const struct json_obj_descr *descr, size_t descr_len,
+		    const void *val, json_append_bytes_t append_bytes,
+		    void *data)
 {
 	size_t i;
 	int ret;
@@ -863,20 +860,6 @@ static int obj_encode(const struct json_obj_descr *descr, size_t descr_len,
 	}
 
 	return append_bytes("}", 1, data);
-}
-
-int json_obj_encode(const struct json_obj_descr *descr, size_t descr_len,
-		    const void *val, json_append_bytes_t append_bytes,
-		    void *data)
-{
-	int ret;
-
-	ret = obj_encode(descr, descr_len, val, append_bytes, data);
-	if (ret < 0) {
-		return ret;
-	}
-
-	return append_bytes("", 1, data);
 }
 
 struct appender {

--- a/lib/json/json.c
+++ b/lib/json/json.c
@@ -903,6 +903,8 @@ static int measure_bytes(const char *bytes, size_t len, void *data)
 
 	*total += (ssize_t)len;
 
+	ARG_UNUSED(bytes);
+
 	return 0;
 }
 

--- a/lib/json/json.c
+++ b/lib/json/json.c
@@ -441,12 +441,12 @@ static int decode_value(struct json_obj *obj,
 
 	switch (descr->type) {
 	case JSON_TOK_OBJECT_START:
-		return obj_parse(obj, descr->sub_descr,
-				 descr->sub_descr_len,
+		return obj_parse(obj, descr->object.sub_descr,
+				 descr->object.sub_descr_len,
 				 field);
 	case JSON_TOK_LIST_START:
-		return arr_parse(obj, descr->element_descr,
-				 descr->n_elements, field, val);
+		return arr_parse(obj, descr->array.element_descr,
+				 descr->array.n_elements, field, val);
 	case JSON_TOK_FALSE:
 	case JSON_TOK_TRUE: {
 		bool *v = field;
@@ -484,13 +484,13 @@ static ptrdiff_t get_elem_size(const struct json_obj_descr *descr)
 	case JSON_TOK_FALSE:
 		return sizeof(bool);
 	case JSON_TOK_LIST_START:
-		return descr->n_elements * get_elem_size(descr->element_descr);
+		return descr->array.n_elements * get_elem_size(descr->array.element_descr);
 	case JSON_TOK_OBJECT_START: {
 		ptrdiff_t total = 0;
 		size_t i;
 
 		for (i = 0; i < descr->sub_descr_len; i++) {
-			total += get_elem_size(&descr->sub_descr[i]);
+			total += get_elem_size(&descr->object.sub_descr[i]);
 		}
 
 		return total;
@@ -809,11 +809,11 @@ static int encode(const struct json_obj_descr *descr, const void *val,
 	case JSON_TOK_STRING:
 		return str_encode(ptr, append_bytes, data);
 	case JSON_TOK_LIST_START:
-		return arr_encode(descr->element_descr, ptr,
+		return arr_encode(descr->array.element_descr, ptr,
 				  val, append_bytes, data);
 	case JSON_TOK_OBJECT_START:
-		return json_obj_encode(descr->sub_descr,
-				       descr->sub_descr_len,
+		return json_obj_encode(descr->object.sub_descr,
+				       descr->object.sub_descr_len,
 				       ptr, append_bytes, data);
 	case JSON_TOK_NUMBER:
 		return num_encode(ptr, append_bytes, data);

--- a/lib/json/json.h
+++ b/lib/json/json.h
@@ -33,6 +33,7 @@ struct json_obj_descr {
 	const char *field_name;
 	size_t field_name_len;
 	size_t offset;
+	size_t alignment;
 
 	/* Valid values here: JSON_TOK_STRING, JSON_TOK_NUMBER,
 	 * JSON_TOK_TRUE, JSON_TOK_FALSE, JSON_TOK_OBJECT_START,
@@ -95,6 +96,7 @@ typedef int (*json_append_bytes_t)(const char *bytes, size_t len,
 		.field_name = (#field_name_), \
 		.field_name_len = sizeof(#field_name_) - 1, \
 		.offset = offsetof(struct_, field_name_), \
+		.alignment = __alignof__(struct_), \
 		.type = type_, \
 	}
 
@@ -128,6 +130,7 @@ typedef int (*json_append_bytes_t)(const char *bytes, size_t len,
 		.field_name = (#field_name_), \
 		.field_name_len = (sizeof(#field_name_) - 1), \
 		.offset = offsetof(struct_, field_name_), \
+		.alignment = __alignof__(struct_), \
 		.type = JSON_TOK_OBJECT_START, \
 		.object = { \
 			.sub_descr = sub_descr_, \
@@ -166,11 +169,13 @@ typedef int (*json_append_bytes_t)(const char *bytes, size_t len,
 		.field_name = (#field_name_), \
 		.field_name_len = sizeof(#field_name_) - 1, \
 		.offset = offsetof(struct_, field_name_), \
+		.alignment = __alignof__(struct_), \
 		.type = JSON_TOK_LIST_START, \
 		.array = { \
 			.element_descr = &(struct json_obj_descr) { \
 				.type = elem_type_, \
 				.offset = offsetof(struct_, len_field_), \
+				.alignment = __alignof__(struct_), \
 			}, \
 			.n_elements = (max_len_), \
 		}, \
@@ -221,6 +226,7 @@ typedef int (*json_append_bytes_t)(const char *bytes, size_t len,
 		.field_name = (#field_name_), \
 		.field_name_len = sizeof(#field_name_) - 1, \
 		.offset = offsetof(struct_, field_name_), \
+		.alignment = __alignof__(struct_), \
 		.type = JSON_TOK_LIST_START, \
 		.array = { \
 			.element_descr = &(struct json_obj_descr) { \
@@ -230,6 +236,7 @@ typedef int (*json_append_bytes_t)(const char *bytes, size_t len,
 					.sub_descr_len = elem_descr_len_, \
 				}, \
 				.offset = offsetof(struct_, len_field_), \
+				.alignment = __alignof__(struct_), \
 			}, \
 			.n_elements = (max_len_), \
 		}, \
@@ -258,6 +265,7 @@ typedef int (*json_append_bytes_t)(const char *bytes, size_t len,
 		.field_name = (json_field_name_), \
 		.field_name_len = sizeof(json_field_name_) - 1, \
 		.offset = offsetof(struct_, struct_field_name_), \
+		.alignment = __alignof__(struct_), \
 		.type = type_, \
 	}
 
@@ -283,6 +291,7 @@ typedef int (*json_append_bytes_t)(const char *bytes, size_t len,
 		.field_name = (json_field_name_), \
 		.field_name_len = (sizeof(json_field_name_) - 1), \
 		.offset = offsetof(struct_, struct_field_name_), \
+		.alignment = __alignof__(struct_), \
 		.type = JSON_TOK_OBJECT_START, \
 		.object = { \
 			.sub_descr = sub_descr_, \
@@ -318,11 +327,13 @@ typedef int (*json_append_bytes_t)(const char *bytes, size_t len,
 		.field_name = (json_field_name_), \
 		.field_name_len = sizeof(json_field_name_) - 1, \
 		.offset = offsetof(struct_, struct_field_name_), \
+		.alignment = __alignof__(struct_), \
 		.type = JSON_TOK_LIST_START, \
 		.array = { \
 			.element_descr = &(struct json_obj_descr) { \
 				.type = elem_type_, \
 				.offset = offsetof(struct_, len_field_), \
+				.alignment = __alignof__(struct_), \
 			}, \
 			.n_elements = (max_len_), \
 		}, \
@@ -382,6 +393,7 @@ typedef int (*json_append_bytes_t)(const char *bytes, size_t len,
 		.field_name = json_field_name_, \
 		.field_name_len = sizeof(json_field_name_) - 1, \
 		.offset = offsetof(struct_, struct_field_name_), \
+		.alignment = __alignof__(struct_), \
 		.type = JSON_TOK_LIST_START, \
 		.element_descr = &(struct json_obj_descr) { \
 			.type = JSON_TOK_OBJECT_START, \
@@ -390,6 +402,7 @@ typedef int (*json_append_bytes_t)(const char *bytes, size_t len,
 				.sub_descr_len = elem_descr_len_, \
 			}, \
 			.offset = offsetof(struct_, len_field_), \
+			.alignment = __alignof__(struct_), \
 		}, \
 		.n_elements = (max_len_), \
 	}

--- a/lib/json/json.h
+++ b/lib/json/json.h
@@ -44,11 +44,11 @@ struct json_obj_descr {
 		struct {
 			const struct json_obj_descr *sub_descr;
 			size_t sub_descr_len;
-		};
+		} object;
 		struct {
 			const struct json_obj_descr *element_descr;
 			size_t n_elements;
-		};
+		} array;
 	};
 };
 
@@ -129,8 +129,10 @@ typedef int (*json_append_bytes_t)(const char *bytes, size_t len,
 		.field_name_len = (sizeof(#field_name_) - 1), \
 		.offset = offsetof(struct_, field_name_), \
 		.type = JSON_TOK_OBJECT_START, \
-		.sub_descr = sub_descr_, \
-		.sub_descr_len = ARRAY_SIZE(sub_descr_) \
+		.object = { \
+			.sub_descr = sub_descr_, \
+			.sub_descr_len = ARRAY_SIZE(sub_descr_), \
+		}, \
 	}
 
 /**
@@ -165,11 +167,13 @@ typedef int (*json_append_bytes_t)(const char *bytes, size_t len,
 		.field_name_len = sizeof(#field_name_) - 1, \
 		.offset = offsetof(struct_, field_name_), \
 		.type = JSON_TOK_LIST_START, \
-		.element_descr = &(struct json_obj_descr) { \
-			.type = elem_type_, \
-			.offset = offsetof(struct_, len_field_), \
+		.array = { \
+			.element_descr = &(struct json_obj_descr) { \
+				.type = elem_type_, \
+				.offset = offsetof(struct_, len_field_), \
+			}, \
+			.n_elements = (max_len_), \
 		}, \
-		.n_elements = (max_len_), \
 	}
 
 /**
@@ -218,13 +222,17 @@ typedef int (*json_append_bytes_t)(const char *bytes, size_t len,
 		.field_name_len = sizeof(#field_name_) - 1, \
 		.offset = offsetof(struct_, field_name_), \
 		.type = JSON_TOK_LIST_START, \
-		.element_descr = &(struct json_obj_descr) { \
-			.type = JSON_TOK_OBJECT_START, \
-			.sub_descr = elem_descr_, \
-			.sub_descr_len = elem_descr_len_, \
-			.offset = offsetof(struct_, len_field_), \
+		.array = { \
+			.element_descr = &(struct json_obj_descr) { \
+				.type = JSON_TOK_OBJECT_START, \
+				.object = { \
+					.sub_descr = elem_descr_, \
+					.sub_descr_len = elem_descr_len_, \
+				}, \
+				.offset = offsetof(struct_, len_field_), \
+			}, \
+			.n_elements = (max_len_), \
 		}, \
-		.n_elements = (max_len_), \
 	}
 
 /**
@@ -276,8 +284,10 @@ typedef int (*json_append_bytes_t)(const char *bytes, size_t len,
 		.field_name_len = (sizeof(json_field_name_) - 1), \
 		.offset = offsetof(struct_, struct_field_name_), \
 		.type = JSON_TOK_OBJECT_START, \
-		.sub_descr = sub_descr_, \
-		.sub_descr_len = ARRAY_SIZE(sub_descr_) \
+		.object = { \
+			.sub_descr = sub_descr_, \
+			.sub_descr_len = ARRAY_SIZE(sub_descr_), \
+		}, \
 	}
 
 /**
@@ -309,11 +319,13 @@ typedef int (*json_append_bytes_t)(const char *bytes, size_t len,
 		.field_name_len = sizeof(json_field_name_) - 1, \
 		.offset = offsetof(struct_, struct_field_name_), \
 		.type = JSON_TOK_LIST_START, \
-		.element_descr = &(struct json_obj_descr) { \
-			.type = elem_type_, \
-			.offset = offsetof(struct_, len_field_), \
+		.array = { \
+			.element_descr = &(struct json_obj_descr) { \
+				.type = elem_type_, \
+				.offset = offsetof(struct_, len_field_), \
+			}, \
+			.n_elements = (max_len_), \
 		}, \
-		.n_elements = (max_len_), \
 	}
 
 /**
@@ -373,8 +385,10 @@ typedef int (*json_append_bytes_t)(const char *bytes, size_t len,
 		.type = JSON_TOK_LIST_START, \
 		.element_descr = &(struct json_obj_descr) { \
 			.type = JSON_TOK_OBJECT_START, \
-			.sub_descr = elem_descr_, \
-			.sub_descr_len = elem_descr_len_, \
+			.object = { \
+				.sub_descr = elem_descr_, \
+				.sub_descr_len = elem_descr_len_, \
+			}, \
 			.offset = offsetof(struct_, len_field_), \
 		}, \
 		.n_elements = (max_len_), \

--- a/tests/lib/json/testcase.yaml
+++ b/tests/lib/json/testcase.yaml
@@ -1,5 +1,4 @@
 tests:
 -   test:
-        build_only: true
         filter: not CONFIG_NEWLIB_LIBC
         tags: json


### PR DESCRIPTION
This fixes two issues: alignment not being considered when calculating struct size, and an off-by-one error when serializing an object.

Tested on Linux with both address and behavior sanitizers, and on Zephyr running on qemu_nios2 and qemu_xtensa.

Should fix #1347.