### PR TITLE
Bluetooth: doc: update SM PICs file

### DIFF
--- a/doc/subsystems/bluetooth/sm-pics.rst
+++ b/doc/subsystems/bluetooth/sm-pics.rst
@@ -1,7 +1,7 @@
 SM PICS
 #######
 
-PTS version: 6.4
+PTS version: 7.0.1
 
 \* - different than PTS defaults
 
@@ -33,7 +33,7 @@ TSPC_SM_2_1	True		Authenticated MITM protection (O)
 TSPC_SM_2_2	True		Unauthenticated no MITM protection (C.1)
 TSPC_SM_2_3	True		No security requirements (M)
 TSPC_SM_2_4	False		OOB supported (O)
-TSPC_SM_2_5	(^)		LE Secure Connections (C.2)
+TSPC_SM_2_5	True		LE Secure Connections (C.2)
 ===============	===========	=======================================
 
 
@@ -90,6 +90,6 @@ Key Distribution
 Parameter Name	Selected	Description
 ===============	===========	=======================================
 TSPC_SM_7_1	True		Encryption Key (C.1)
-TSPC_SM_7_2	False (*)	Identity Key (C.2)
+TSPC_SM_7_2	True		Identity Key (C.2)
 TSPC_SM_7_3	True		Signing Key (C.3)
 ===============	===========	=======================================


### PR DESCRIPTION
This commit makes SM PICs up-to-date with the Zephyr HCI
TPG test plan

Signed-off-by: Ruslan Mstoi <ruslan.mstoi@intel.com>