### PR TITLE
Bluetooth: doc: update L2CAP PICs file

### DIFF
--- a/doc/subsystems/bluetooth/l2cap-pics.rst
+++ b/doc/subsystems/bluetooth/l2cap-pics.rst
@@ -1,7 +1,7 @@
 L2CAP PICS
 ##########
 
-PTS version: 6.4
+PTS version: 7.0.1
 
 * - different than PTS defaults
 


### PR DESCRIPTION
This commit makes L2CAP PICs up-to-date with the Zephyr HCI
TPG test plan

Signed-off-by: Ruslan Mstoi <ruslan.mstoi@intel.com>