### PR TITLE
tests: kernel: threads: add specific test tags

### DIFF
--- a/tests/kernel/threads/custom_data/custom_data_api/testcase.yaml
+++ b/tests/kernel/threads/custom_data/custom_data_api/testcase.yaml
@@ -1,3 +1,3 @@
 tests:
 -   test:
-        tags: kernel
+        tags: kernel threads

--- a/tests/kernel/threads/lifecycle/lifecycle_api/testcase.yaml
+++ b/tests/kernel/threads/lifecycle/lifecycle_api/testcase.yaml
@@ -1,4 +1,4 @@
 tests:
 -   test:
         arch_exclude: nios2
-        tags: kernel
+        tags: kernel threads

--- a/tests/kernel/threads/lifecycle/thread_init/testcase.yaml
+++ b/tests/kernel/threads/lifecycle/thread_init/testcase.yaml
@@ -1,3 +1,3 @@
 tests:
 -   test:
-        tags: kernel
+        tags: kernel threads

--- a/tests/kernel/threads/scheduling/schedule_api/testcase.yaml
+++ b/tests/kernel/threads/scheduling/schedule_api/testcase.yaml
@@ -1,4 +1,4 @@
 tests:
 -   test:
-        tags: kernel
+        tags: kernel threads sched
         min_ram: 20


### PR DESCRIPTION
Extend test tags to make it easier to filter threads related tests.

Signed-off-by: Ricardo Salveti <ricardo.salveti@linaro.org>