### PR TITLE
doc: genrest writing files without final newline

### DIFF
--- a/doc/scripts/genrest/genrest.py
+++ b/doc/scripts/genrest/genrest.py
@@ -53,7 +53,7 @@ def print_items(items, outdir, indent):
                     config.write("\n%s\n\n" %text)
                 else:
                     config.write("\nThe configuration item %s:\n\n" %var)
-                config.write(item.rest())
+                config.write("%s\n" %item.rest())
 
                 config.close()
         elif item.is_menu():


### PR DESCRIPTION
The script used to generate Kconfig documentation (genrest.py)
was creating .rst files without a final newline.

Signed-off-by: David B. Kinder <david.b.kinder@intel.com>