### PR TITLE
Bluetooth: tester: Fix bt-stack-tester to unix domain socket

### DIFF
--- a/tests/bluetooth/tester/Makefile
+++ b/tests/bluetooth/tester/Makefile
@@ -13,7 +13,7 @@ BOARD ?= arduino_101
 CONF_FILE ?= default.conf
 
 # UART for Tester
-QEMU_EXTRA_FLAGS = -serial pipe:/tmp/bt-stack-tester
+QEMU_EXTRA_FLAGS = -serial unix:/tmp/bt-stack-tester
 
 # UART for Bluetooth
 QEMU_EXTRA_FLAGS += -serial unix:/tmp/bt-server-bredr


### PR DESCRIPTION
/tmp/bt-stack-tester is not a pipe, but unix domain socket.
This commit fixes respective "make run" errors:

qemu-system-arm: -serial pipe:/tmp/bt-stack-tester: Could
not open '/tmp/bt-stack-tester': No such device or address

qemu-system-arm: -serial pipe:/tmp/bt-stack-tester: could
not connect serial device to character backend
'pipe:/tmp/bt-stack-tester

Signed-off-by: Ruslan Mstoi <ruslan.mstoi@intel.com>