### PR TITLE
tests/object_footprint: fix path to Kconfig specification

### DIFF
--- a/tests/benchmarks/object_footprint/Makefile
+++ b/tests/benchmarks/object_footprint/Makefile
@@ -3,7 +3,7 @@
 BOARD ?= qemu_x86
 CONF_FILE ?= prj1.conf
 
-KBUILD_KCONFIG = Kconfig
+KBUILD_KCONFIG = $(ZEPHYR_BASE)/tests/benchmarks/object_footprint/Kconfig
 export KBUILD_KCONFIG
 
 include $(ZEPHYR_BASE)/Makefile.test


### PR DESCRIPTION
This was failing to set the proper path to KBUILD_KCONFIG
and hence correcting it.

Signed-off-by: Nirmala Devi <nirmala.devix.m@intel.com>