### PR TITLE
poll: Minimize overhead when polling single event

### DIFF
--- a/include/kernel.h
+++ b/include/kernel.h
@@ -3944,6 +3944,7 @@ extern void k_poll_event_init(struct k_poll_event *event, u32_t type,
  *
  * @retval 0 One or more events are ready.
  * @retval -EAGAIN Waiting period timed out.
+ * @retval -EINTR Poller thread has been interrupted.
  */
 
 extern int k_poll(struct k_poll_event *events, int num_events,

--- a/kernel/poll.c
+++ b/kernel/poll.c
@@ -227,9 +227,7 @@ int k_poll(struct k_poll_event *events, int num_events, s32_t timeout)
 	/*
 	 * If we're not polling anymore, it means that at least one event
 	 * condition is met, either when looping through the events here or
-	 * because one of the events registered has had its state changed, or
-	 * that one of the objects we wanted to poll on already had a thread
-	 * polling on it.
+	 * because one of the events registered has had its state changed.
 	 */
 	if (!is_polling()) {
 		clear_event_registrations(events, last_registered, key);


### PR DESCRIPTION
This attempts to minimize as much as possible when polling a single event which is what k_queue_get does when CONFIG_POLL is enabled.

Jira: 2593