### PR TITLE
net: Added Ipv4 missing debugging

### DIFF
--- a/subsys/net/ip/net_core.c
+++ b/subsys/net/ip/net_core.c
@@ -241,6 +241,7 @@ static inline int check_ip_addr(struct net_pkt *pkt)
 	if (net_pkt_family(pkt) == AF_INET) {
 		if (net_ipv4_addr_cmp(&NET_IPV4_HDR(pkt)->dst,
 				      net_ipv4_unspecified_address())) {
+			NET_DBG("IPv4 dst address missing");
 			return -EADDRNOTAVAIL;
 		}
 


### PR DESCRIPTION
For IPv6 check_ip_addr in subsys/net/ip/net_core.c makes a
NET_DBG call to report when a net_pkt is missing a destination
address. An analogous NET_DBG call has been added to the IPv4
destination address checking.

Signed-off-by: John Andersen <john.s.andersen@intel.com>