### PR TITLE
boot: move boot banner and delay before SYS_INIT_LEVEL_APPLICATION

### DIFF
--- a/kernel/init.c
+++ b/kernel/init.c
@@ -193,6 +193,12 @@ static void _main(void *unused1, void *unused2, void *unused3)
 	ARG_UNUSED(unused3);
 
 	_sys_device_do_config_level(_SYS_INIT_LEVEL_POST_KERNEL);
+	if (boot_delay > 0) {
+		printk("***** delaying boot " STRINGIFY(CONFIG_BOOT_DELAY)
+		       "ms (per build configuration) *****\n");
+		k_sleep(CONFIG_BOOT_DELAY);
+	}
+	PRINT_BOOT_BANNER();
 
 	/* Final init level before app starts */
 	_sys_device_do_config_level(_SYS_INIT_LEVEL_APPLICATION);
@@ -205,12 +211,6 @@ static void _main(void *unused1, void *unused2, void *unused3)
 	__do_init_array_aux();
 #endif
 
-	if (boot_delay > 0) {
-		printk("***** delaying boot " STRINGIFY(CONFIG_BOOT_DELAY)
-		       "ms (per build configuration) *****\n");
-		k_sleep(CONFIG_BOOT_DELAY);
-	}
-	PRINT_BOOT_BANNER();
 	_init_static_threads();
 
 


### PR DESCRIPTION
Fixes https://github.com/zephyrproject-rtos/zephyr/issues/1280, but
also many other failures, where output was garbled due to this. Other
similarly affected issues are missing first benchmark (context) in
latency benchmark and some net tests.

Signed-off-by: Inaky Perez-Gonzalez <inaky.perez-gonzalez@intel.com>