### PR TITLE
zephyr: use k_thread_entry_t everywhere

### DIFF
--- a/arch/arc/core/thread.c
+++ b/arch/arc/core/thread.c
@@ -55,7 +55,7 @@ struct init_stack_frame {
  * @return N/A
  */
 void _new_thread(struct k_thread *thread, k_thread_stack_t stack,
-		 size_t stackSize, _thread_entry_t pEntry,
+		 size_t stackSize, k_thread_entry_t pEntry,
 		 void *parameter1, void *parameter2, void *parameter3,
 		 int priority, unsigned int options)
 {

--- a/arch/arm/core/thread.c
+++ b/arch/arm/core/thread.c
@@ -50,7 +50,7 @@
  */
 
 void _new_thread(struct k_thread *thread, k_thread_stack_t stack,
-		 size_t stackSize, _thread_entry_t pEntry,
+		 size_t stackSize, k_thread_entry_t pEntry,
 		 void *parameter1, void *parameter2, void *parameter3,
 		 int priority, unsigned int options)
 {

--- a/arch/arm/include/kernel_arch_func.h
+++ b/arch/arm/include/kernel_arch_func.h
@@ -40,7 +40,7 @@ static ALWAYS_INLINE void kernel_arch_init(void)
 static ALWAYS_INLINE void
 _arch_switch_to_main_thread(struct k_thread *main_thread,
 			    k_thread_stack_t main_stack,
-			    size_t main_stack_size, _thread_entry_t _main)
+			    size_t main_stack_size, k_thread_entry_t _main)
 {
 	/* get high address of the stack, i.e. its start (stack grows down) */
 	char *start_of_main_stack;

--- a/arch/nios2/core/thread.c
+++ b/arch/nios2/core/thread.c
@@ -14,7 +14,7 @@
  * to _thread_entry() since this arch puts the first four arguments
  * in r4-r7 and not on the stack
  */
-void _thread_entry_wrapper(_thread_entry_t, void *, void *, void *);
+void _thread_entry_wrapper(k_thread_entry_t, void *, void *, void *);
 
 struct init_stack_frame {
 	/* top of the stack / most recently pushed */
@@ -22,7 +22,7 @@ struct init_stack_frame {
 	/* Used by _thread_entry_wrapper. pulls these off the stack and
 	 * into argument registers before calling _thread_entry()
 	 */
-	_thread_entry_t entry_point;
+	k_thread_entry_t entry_point;
 	void *arg1;
 	void *arg2;
 	void *arg3;
@@ -32,7 +32,7 @@ struct init_stack_frame {
 
 
 void _new_thread(struct k_thread *thread, k_thread_stack_t stack,
-		 size_t stack_size, _thread_entry_t thread_func,
+		 size_t stack_size, k_thread_entry_t thread_func,
 		 void *arg1, void *arg2, void *arg3,
 		 int priority, unsigned int options)
 {

--- a/arch/riscv32/core/swap.S
+++ b/arch/riscv32/core/swap.S
@@ -57,7 +57,7 @@ SECTION_FUNC(exception.other, __swap)
 
 
 /*
- * void _thread_entry_wrapper(_thread_entry_t, void *, void *, void *)
+ * void _thread_entry_wrapper(k_thread_entry_t, void *, void *, void *)
  */
 SECTION_FUNC(TEXT, _thread_entry_wrapper)
 	/*

--- a/arch/riscv32/core/thread.c
+++ b/arch/riscv32/core/thread.c
@@ -10,13 +10,13 @@
 #include <wait_q.h>
 #include <string.h>
 
-void _thread_entry_wrapper(_thread_entry_t thread,
+void _thread_entry_wrapper(k_thread_entry_t thread,
 			   void *arg1,
 			   void *arg2,
 			   void *arg3);
 
 void _new_thread(struct k_thread *thread, k_thread_stack_t stack,
-		 size_t stack_size, _thread_entry_t thread_func,
+		 size_t stack_size, k_thread_entry_t thread_func,
 		 void *arg1, void *arg2, void *arg3,
 		 int priority, unsigned int options)
 {

--- a/arch/x86/core/thread.c
+++ b/arch/x86/core/thread.c
@@ -26,7 +26,7 @@
 
 #if defined(CONFIG_GDB_INFO) || defined(CONFIG_DEBUG_INFO) \
 	|| defined(CONFIG_X86_IAMCU)
-extern void _thread_entry_wrapper(_thread_entry_t entry,
+extern void _thread_entry_wrapper(k_thread_entry_t entry,
 				  void *p1, void *p2, void *p3);
 /**
  *
@@ -117,7 +117,7 @@ struct _x86_initial_frame {
 	u32_t edi;
 	void *_thread_entry;
 	u32_t eflags;
-	_thread_entry_t entry;
+	k_thread_entry_t entry;
 	void *p1;
 	void *p2;
 	void *p3;
@@ -140,7 +140,7 @@ struct _x86_initial_frame {
  * @param options thread options: K_ESSENTIAL, K_FP_REGS, K_SSE_REGS
  */
 void _new_thread(struct k_thread *thread, k_thread_stack_t stack,
-		 size_t stack_size, _thread_entry_t entry,
+		 size_t stack_size, k_thread_entry_t entry,
 		 void *parameter1, void *parameter2, void *parameter3,
 		 int priority, unsigned int options)
 {

--- a/arch/xtensa/core/thread.c
+++ b/arch/xtensa/core/thread.c
@@ -43,8 +43,7 @@ extern void _xt_user_exit(void);
  */
 
 void _new_thread(struct k_thread *thread, k_thread_stack_t stack,
-		size_t stackSize,
-		void (*pEntry)(void *, void *, void *),
+		size_t stackSize, k_thread_entry_t pEntry,
 		void *p1, void *p2, void *p3,
 		int priority, unsigned int options)
 {

--- a/include/kernel.h
+++ b/include/kernel.h
@@ -235,12 +235,29 @@ struct _timeout {
 
 extern s32_t _timeout_remaining_get(struct _timeout *timeout);
 
-/* Threads */
-typedef void (*_thread_entry_t)(void *, void *, void *);
+/**
+ * @typedef k_thread_entry_t
+ * @brief Thread entry point function type.
+ *
+ * A thread's entry point function is invoked when the thread starts executing.
+ * Up to 3 argument values can be passed to the function.
+ *
+ * The thread terminates execution permanently if the entry point function
+ * returns. The thread is responsible for releasing any shared resources
+ * it may own (such as mutexes and dynamically allocated memory), prior to
+ * returning.
+ *
+ * @param p1 First argument.
+ * @param p2 Second argument.
+ * @param p3 Third argument.
+ *
+ * @return N/A
+ */
+typedef void (*k_thread_entry_t)(void *p1, void *p2, void *p3);
 
 #ifdef CONFIG_THREAD_MONITOR
 struct __thread_entry {
-	_thread_entry_t pEntry;
+	k_thread_entry_t pEntry;
 	void *parameter1;
 	void *parameter2;
 	void *parameter3;
@@ -394,26 +411,6 @@ extern void k_call_stacks_analyze(void);
  * @{
  */
 
-/**
- * @typedef k_thread_entry_t
- * @brief Thread entry point function type.
- *
- * A thread's entry point function is invoked when the thread starts executing.
- * Up to 3 argument values can be passed to the function.
- *
- * The thread terminates execution permanently if the entry point function
- * returns. The thread is responsible for releasing any shared resources
- * it may own (such as mutexes and dynamically allocated memory), prior to
- * returning.
- *
- * @param p1 First argument.
- * @param p2 Second argument.
- * @param p3 Third argument.
- *
- * @return N/A
- */
-typedef void (*k_thread_entry_t)(void *p1, void *p2, void *p3);
-
 #endif /* !_ASMLANGUAGE */
 
 
@@ -499,7 +496,7 @@ typedef struct _k_thread_stack_element *k_thread_stack_t;
 extern k_tid_t k_thread_create(struct k_thread *new_thread,
 			       k_thread_stack_t stack,
 			       size_t stack_size,
-			       void (*entry)(void *, void *, void*),
+			       k_thread_entry_t entry,
 			       void *p1, void *p2, void *p3,
 			       int prio, u32_t options, s32_t delay);
 
@@ -611,7 +608,7 @@ struct _static_thread_data {
 	struct k_thread *init_thread;
 	k_thread_stack_t init_stack;
 	unsigned int init_stack_size;
-	void (*init_entry)(void *, void *, void *);
+	k_thread_entry_t init_entry;
 	void *init_p1;
 	void *init_p2;
 	void *init_p3;
@@ -629,7 +626,7 @@ struct _static_thread_data {
 	.init_thread = (thread),				 \
 	.init_stack = (stack),					 \
 	.init_stack_size = (stack_size),                         \
-	.init_entry = (void (*)(void *, void *, void *))entry,   \
+	.init_entry = (k_thread_entry_t)entry,			 \
 	.init_p1 = (void *)p1,                                   \
 	.init_p2 = (void *)p2,                                   \
 	.init_p3 = (void *)p3,                                   \

--- a/kernel/include/nano_internal.h
+++ b/kernel/include/nano_internal.h
@@ -40,12 +40,11 @@ static inline void _data_copy(void)
 #endif
 FUNC_NORETURN void _Cstart(void);
 
-extern FUNC_NORETURN void _thread_entry(void (*)(void *, void *, void *),
-			  void *, void *, void *);
+extern FUNC_NORETURN void _thread_entry(k_thread_entry_t entry,
+			  void *p1, void *p2, void *p3);
 
 extern void _new_thread(struct k_thread *thread, k_thread_stack_t pStack,
-			size_t stackSize,
-			void (*pEntry)(void *, void *, void *),
+			size_t stackSize, k_thread_entry_t entry,
 			void *p1, void *p2, void *p3,
 			int prio, unsigned int options);
 

--- a/kernel/thread.c
+++ b/kernel/thread.c
@@ -180,7 +180,7 @@ void _check_stack_sentinel(void)
  * This routine does not return, and is marked as such so the compiler won't
  * generate preamble code that is only used by functions that actually return.
  */
-FUNC_NORETURN void _thread_entry(void (*entry)(void *, void *, void *),
+FUNC_NORETURN void _thread_entry(k_thread_entry_t entry,
 				 void *p1, void *p2, void *p3)
 {
 	entry(p1, p2, p3);
@@ -252,7 +252,7 @@ static void schedule_new_thread(struct k_thread *thread, s32_t delay)
 
 k_tid_t k_thread_create(struct k_thread *new_thread,
 			k_thread_stack_t stack,
-			size_t stack_size, void (*entry)(void *, void *, void*),
+			size_t stack_size, k_thread_entry_t entry,
 			void *p1, void *p2, void *p3,
 			int prio, u32_t options, s32_t delay)
 {


### PR DESCRIPTION
In various places, a private _thread_entry_t, or the full prototype
were being used. Be consistent and use the same typedef everywhere.

Signen-off-by: Andrew Boie <andrew.p.boie@intel.com>