### PR TITLE
x86: don't set FS/GS segment selectors

### DIFF
--- a/arch/x86/core/crt0.S
+++ b/arch/x86/core/crt0.S
@@ -91,9 +91,10 @@ SECTION_FUNC(TEXT_START, __start)
 	movw	$DATA_SEG, %ax	/* data segment selector (entry = 3) */
 	movw	%ax, %ds	/* set DS */
 	movw	%ax, %es	/* set ES */
-	movw	%ax, %fs	/* set FS */
-	movw	%ax, %gs	/* set GS */
 	movw	%ax, %ss	/* set SS */
+	xorw	%ax, %ax	/* AX = 0 */
+	movw	%ax, %fs	/* Zero FS */
+	movw	%ax, %gs	/* Zero GS */
 
 	ljmp	$CODE_SEG, $__csSet	/* set CS = 0x08 */
 

--- a/arch/x86/core/fatal.c
+++ b/arch/x86/core/fatal.c
@@ -284,8 +284,6 @@ struct task_state_segment _df_tss = {
 	.cs = CODE_SEG,
 	.ds = DATA_SEG,
 	.es = DATA_SEG,
-	.fs = DATA_SEG,
-	.gs = DATA_SEG,
 	.ss = DATA_SEG,
 	.eip = (u32_t)_df_handler_top,
 	.cr3 = (u32_t)X86_MMU_PD
@@ -341,8 +339,6 @@ static FUNC_NORETURN __used void _df_handler_top(void)
 	_main_tss.cs = CODE_SEG;
 	_main_tss.ds = DATA_SEG;
 	_main_tss.es = DATA_SEG;
-	_main_tss.fs = DATA_SEG;
-	_main_tss.gs = DATA_SEG;
 	_main_tss.ss = DATA_SEG;
 	_main_tss.eip = (u32_t)_df_handler_bottom;
 	_main_tss.cr3 = (u32_t)X86_MMU_PD;


### PR DESCRIPTION
We shouldn't be imposing any policy here, we do not yet use these in
Zephyr. Zero these at boot and otherwise leave alone.

Signed-off-by: Andrew Boie <andrew.p.boie@intel.com>