### PR TITLE
doc: improve API docs with sections

### DIFF
--- a/doc/api/bluetooth.rst
+++ b/doc/api/bluetooth.rst
@@ -20,70 +20,60 @@ Generic Access Profile (GAP)
 
 .. doxygengroup:: bt_gap
    :project: Zephyr
-   :content-only:
 
 Connection Management
 *********************
 
 .. doxygengroup:: bt_conn
    :project: Zephyr
-   :content-only:
 
 Generic Attribute Profile (GATT)
 ********************************
 
 .. doxygengroup:: bt_gatt
    :project: Zephyr
-   :content-only:
 
 Mesh Profile
 ************
 
 .. doxygengroup:: bt_mesh
    :project: Zephyr
-   :content-only:
 
 Universal Unique Identifiers (UUIDs)
 ************************************
 
 .. doxygengroup:: bt_uuid
    :project: Zephyr
-   :content-only:
 
 Logical Link Control and Adaptation Protocol (L2CAP)
 ****************************************************
 
 .. doxygengroup:: bt_l2cap
    :project: Zephyr
-   :content-only:
 
 Serial Port Emulation (RFCOMM)
 ******************************
 
 .. doxygengroup:: bt_rfcomm
    :project: Zephyr
-   :content-only:
 
 Data Buffers
 ************
 
 .. doxygengroup:: bt_buf
    :project: Zephyr
-   :content-only:
 
 Persistent Storage
 ******************
 
 .. doxygengroup:: bt_storage
    :project: Zephyr
-   :content-only:
 
 HCI Drivers
 ***********
 
 .. doxygengroup:: bt_hci_driver
    :project: Zephyr
-   :content-only:
 
 HCI RAW channel
 ***************
@@ -95,4 +85,3 @@ are sent and received by the Bluetooth HCI driver.
 
 .. doxygengroup:: hci_raw
    :project: Zephyr
-   :content-only:

--- a/doc/api/device.rst
+++ b/doc/api/device.rst
@@ -13,5 +13,3 @@ Device Model
 
 .. doxygengroup:: device_model
    :project: Zephyr
-   :content-only:
-

--- a/doc/api/file_system.rst
+++ b/doc/api/file_system.rst
@@ -8,11 +8,9 @@ File System Functions
 
 .. doxygengroup:: file_system_api
    :project: Zephyr
-   :content-only:
 
 File System Data Structures
 *******************************
 
 .. doxygengroup:: data_structures
    :project: Zephyr
-   :content-only:

--- a/doc/api/io_interfaces.rst
+++ b/doc/api/io_interfaces.rst
@@ -13,21 +13,18 @@ ADC Interface
 
 .. doxygengroup:: adc_interface
    :project: Zephyr
-   :content-only:
 
 GPIO Interface
 **************
 
 .. doxygengroup:: gpio_interface
    :project: Zephyr
-   :content-only:
 
 I2C Interface
 *************
 
 .. doxygengroup:: i2c_interface
    :project: Zephyr
-   :content-only:
 
 I2S Interface
 *************
@@ -38,53 +35,45 @@ and Left/Right Justified Data Formats.
 
 .. doxygengroup:: i2s_interface
    :project: Zephyr
-   :content-only:
 
 IPM Interface
 *************
 
 .. doxygengroup:: ipm_interface
    :project: Zephyr
-   :content-only:
 
 PWM Interface
 *************
 
 .. doxygengroup:: pwm_interface
    :project: Zephyr
-   :content-only:
 
 Pinmux Interface
 ****************
 
 .. doxygengroup:: pinmux_interface
    :project: Zephyr
-   :content-only:
 
 SPI Interface
 *************
 
 .. doxygengroup:: spi_interface
    :project: Zephyr
-   :content-only:
 
 Random Interface
 ****************
 
 .. doxygengroup:: random_interface
    :project: Zephyr
-   :content-only:
 
 UART Interface
 **************
 
 .. doxygengroup:: uart_interface
    :project: Zephyr
-   :content-only:
 
 Sensor Interface
 ****************
 
 .. doxygengroup:: sensor_interface
    :project: Zephyr
-   :content-only:

--- a/doc/api/kernel_api.rst
+++ b/doc/api/kernel_api.rst
@@ -24,7 +24,6 @@ that is too lengthy or too complex to be performed by an ISR.
 
 .. doxygengroup:: thread_apis
    :project: Zephyr
-   :content-only:
 
 Workqueues
 **********
@@ -36,7 +35,6 @@ or high-priority thread to offload non-urgent processing.
 
 .. doxygengroup:: workqueue_apis
    :project: Zephyr
-   :content-only:
 
 Clocks
 ******
@@ -47,7 +45,6 @@ with either normal and high precision.
 
 .. doxygengroup:: clock_apis
    :project: Zephyr
-   :content-only:
 
 Timers
 ******
@@ -58,7 +55,6 @@ an action when the timer expires.
 
 .. doxygengroup:: timer_apis
    :project: Zephyr
-   :content-only:
 
 Memory Slabs
 ************
@@ -69,7 +65,6 @@ memory blocks.
 
 .. doxygengroup:: mem_slab_apis
    :project: Zephyr
-   :content-only:
 
 Memory Pools
 ************
@@ -80,7 +75,6 @@ memory blocks.
 
 .. doxygengroup:: mem_pool_apis
    :project: Zephyr
-   :content-only:
 
 Heap Memory Pool
 ****************
@@ -91,7 +85,6 @@ in a :cpp:func:`malloc()`-like manner.
 
 .. doxygengroup:: heap_apis
    :project: Zephyr
-   :content-only:
 
 Semaphores
 **********
@@ -101,7 +94,6 @@ Semaphores provide traditional counting semaphore capabilities.
 
 .. doxygengroup:: semaphore_apis
    :project: Zephyr
-   :content-only:
 
 Mutexes
 *******
@@ -112,7 +104,6 @@ with basic priority inheritance.
 
 .. doxygengroup:: mutex_apis
    :project: Zephyr
-   :content-only:
 
 Alerts
 ******
@@ -123,7 +114,6 @@ somewhat akin to Unix-style signals.
 
 .. doxygengroup:: alert_apis
    :project: Zephyr
-   :content-only:
 
 Fifos
 *****
@@ -134,7 +124,6 @@ of any size.
 
 .. doxygengroup:: fifo_apis
    :project: Zephyr
-   :content-only:
 
 Lifos
 *****
@@ -145,7 +134,6 @@ of any size.
 
 .. doxygengroup:: lifo_apis
    :project: Zephyr
-   :content-only:
 
 Stacks
 ******
@@ -156,7 +144,6 @@ data items.
 
 .. doxygengroup:: stack_apis
    :project: Zephyr
-   :content-only:
 
 Message Queues
 **************
@@ -167,7 +154,6 @@ for fixed-size data items.
 
 .. doxygengroup:: msgq_apis
    :project: Zephyr
-   :content-only:
 
 Mailboxes
 *********
@@ -178,7 +164,6 @@ for variable-size messages.
 
 .. doxygengroup:: mailbox_apis
    :project: Zephyr
-   :content-only:
 
 Pipes
 *****
@@ -189,7 +174,6 @@ variable-size chunks of data, in whole or in part.
 
 .. doxygengroup:: pipe_apis
    :project: Zephyr
-   :content-only:
 
 Interrupt Service Routines (ISRs)
 *********************************
@@ -200,7 +184,6 @@ executed asynchronously in response to a hardware or software interrupt.
 
 .. doxygengroup:: isr_apis
    :project: Zephyr
-   :content-only:
 
 Atomic Services
 ***************
@@ -214,7 +197,6 @@ The atomic services enable multiple threads and ISRs to read and modify
 
 .. doxygengroup:: atomic_apis
    :project: Zephyr
-   :content-only:
 
 Floating Point Services
 ***********************
@@ -225,7 +207,6 @@ registers.
 
 .. doxygengroup:: float_apis
    :project: Zephyr
-   :content-only:
 
 Ring Buffers
 ************
@@ -236,5 +217,3 @@ of variable-size data items.
 
 .. doxygengroup:: ring_buffer_apis
    :project: Zephyr
-   :content-only:
-

--- a/doc/api/networking.rst
+++ b/doc/api/networking.rst
@@ -18,98 +18,84 @@ Network core helpers
 
 .. doxygengroup:: net_core
    :project: Zephyr
-   :content-only:
 
 Network buffers
 ***************
 
 .. doxygengroup:: net_buf
    :project: Zephyr
-   :content-only:
 
 Network packet management
 *************************
 
 .. doxygengroup:: net_pkt
    :project: Zephyr
-   :content-only:
 
 IPv4/IPv6 primitives and helpers
 ********************************
 
 .. doxygengroup:: ip_4_6
    :project: Zephyr
-   :content-only:
 
 Network interface
 *****************
 
 .. doxygengroup:: net_if
    :project: Zephyr
-   :content-only:
 
 Network Management
 ******************
 
 .. doxygengroup:: net_mgmt
    :project: Zephyr
-   :content-only:
 
 Network layer 2 management
 **************************
 
 .. doxygengroup:: net_l2
    :project: Zephyr
-   :content-only:
 
 Network link address
 ********************
 
 .. doxygengroup:: net_linkaddr
    :project: Zephyr
-   :content-only:
 
 Application network context
 ***************************
 
 .. doxygengroup:: net_context
    :project: Zephyr
-   :content-only:
 
 BSD Sockets compatible API
 **************************
 
 .. doxygengroup:: bsd_sockets
    :project: Zephyr
-   :content-only:
 
 Network offloading support
 **************************
 
 .. doxygengroup:: net_offload
    :project: Zephyr
-   :content-only:
 
 Network statistics
 ******************
 
 .. doxygengroup:: net_stats
    :project: Zephyr
-   :content-only:
 
 Trickle timer support
 *********************
 
 .. doxygengroup:: trickle
    :project: Zephyr
-   :content-only:
 
 UDP
 ***
 
 .. doxygengroup:: udp
    :project: Zephyr
-   :content-only:
 
 Network technologies
 ********************
@@ -119,14 +105,12 @@ Ethernet
 
 .. doxygengroup:: ethernet
    :project: Zephyr
-   :content-only:
 
 IEEE 802.15.4
 =============
 
 .. doxygengroup:: ieee802154
    :project: Zephyr
-   :content-only:
 
 Network and application libraries
 *********************************
@@ -136,39 +120,33 @@ Network application
 
 .. doxygengroup:: net_app
    :project: Zephyr
-   :content-only:
 
 DHCPv4
 ======
 
 .. doxygengroup:: dhcpv4
    :project: Zephyr
-   :content-only:
 
 MQTT 3.1.1
 ==========
 
 .. doxygengroup:: mqtt
    :project: Zephyr
-   :content-only:
 
 CoAP
 ====
 
 .. doxygengroup:: zoap
    :project: Zephyr
-   :content-only:
 
 DNS Resolve
 ===========
 
 .. doxygengroup:: dns_resolve
    :project: Zephyr
-   :content-only:
 
 HTTP
 ====
 
 .. doxygengroup:: http
    :project: Zephyr
-   :content-only:

--- a/doc/api/power_management_api.rst
+++ b/doc/api/power_management_api.rst
@@ -8,11 +8,9 @@ Power Management Hook Interface
 
 .. doxygengroup:: power_management_hook_interface
    :project: Zephyr
-   :content-only:
 
 Device Power Management APIs
 ****************************
 
 .. doxygengroup:: device_power_management_api
    :project: Zephyr
-   :content-only:

--- a/doc/subsystems/logging/kernel_event_logger.rst
+++ b/doc/subsystems/logging/kernel_event_logger.rst
@@ -260,7 +260,6 @@ events, which can be subsequently extracted and reviewed.
 
 .. doxygengroup:: event_logger
    :project: Zephyr
-   :content-only:
 
 Kernel Event Logger
 ===================
@@ -271,4 +270,3 @@ which can be subsequently extracted and reviewed.
 
 .. doxygengroup:: kernel_event_logger
    :project: Zephyr
-   :content-only:

--- a/doc/subsystems/logging/system_log.rst
+++ b/doc/subsystems/logging/system_log.rst
@@ -88,5 +88,3 @@ APIs
 
 .. doxygengroup:: system_log
    :project: Zephyr
-   :content-only:
-

--- a/doc/subsystems/shell.rst
+++ b/doc/subsystems/shell.rst
@@ -130,4 +130,3 @@ Shell API Functions
 *******************
 .. doxygengroup:: _shell_api_functions
    :project: Zephyr
-   :content-only:

--- a/doc/subsystems/test/ztest.rst
+++ b/doc/subsystems/test/ztest.rst
@@ -105,7 +105,6 @@ Running tests
 
 .. doxygengroup:: ztest_test
    :project: Zephyr
-   :content-only:
 
 Assertions
 ==========
@@ -126,7 +125,6 @@ Example output for a failed macro from
 
 .. doxygengroup:: ztest_assert
    :project: Zephyr
-   :content-only:
 
 Mocking
 =======
@@ -147,4 +145,3 @@ expect the values ``a=2`` and ``b=3``, and telling ``returns_int`` to return
 
 .. doxygengroup:: ztest_mock
    :project: Zephyr
-   :content-only:


### PR DESCRIPTION
Doxygen-generated API documentation had the ability to
group API information into sections based on the class
of items: Defines, Typedefs, Enums, Functions and then
alphabetized with these groups.  By removing the
Breathe directive :content-only: we can get these class
groupings back (instead of having items just sorted
alphabetically across all classes), and also allow @name
groups to be defined for creating and displaying additional
groups (as requested by a developer).

Depends on CSS changes in
https://github.com/zephyrproject-rtos/docs-theme/pull/14

Fixes #1445 

Signed-off-by: David B. Kinder <david.b.kinder@intel.com>