### PR TITLE
net: Wrong networking defines used in the code

### DIFF
--- a/samples/net/wpan_serial/src/main.c
+++ b/samples/net/wpan_serial/src/main.c
@@ -527,16 +527,16 @@ static bool init_ieee802154(void)
 	 */
 	get_mac(ieee802154_dev);
 
-#ifdef CONFIG_NET_SAMPLES_SETTINGS
+#ifdef CONFIG_NET_APP_SETTINGS
 	SYS_LOG_INF("Set panid %x channel %d",
-		    CONFIG_NET_SAMPLES_IEEE802154_PAN_ID,
-		    CONFIG_NET_SAMPLES_IEEE802154_CHANNEL);
+		    CONFIG_NET_APP_IEEE802154_PAN_ID,
+		    CONFIG_NET_APP_IEEE802154_CHANNEL);
 
 	radio_api->set_pan_id(ieee802154_dev,
-			      CONFIG_NET_SAMPLES_IEEE802154_PAN_ID);
+			      CONFIG_NET_APP_IEEE802154_PAN_ID);
 	radio_api->set_channel(ieee802154_dev,
-			       CONFIG_NET_SAMPLES_IEEE802154_CHANNEL);
-#endif /* CONFIG_NET_SAMPLES_SETTINGS */
+			       CONFIG_NET_APP_IEEE802154_CHANNEL);
+#endif /* CONFIG_NET_APP_SETTINGS */
 
 	/* Set short address */
 	short_addr = (mac_addr[0] << 8) + mac_addr[1];

--- a/subsys/net/ip/net_shell.c
+++ b/subsys/net/ip/net_shell.c
@@ -133,7 +133,7 @@ static const char *iface2str(struct net_if *iface, const char **extra)
 	}
 #endif
 
-#ifdef CONFIG_NET_L2_OFFLOAD
+#ifdef CONFIG_NET_OFFLOAD
 	if (iface->l2 == &NET_L2_GET_NAME(OFFLOAD_IP)) {
 		if (extra) {
 			*extra = "==========";

--- a/tests/net/all/src/main.c
+++ b/tests/net/all/src/main.c
@@ -12,6 +12,34 @@
 
 #include <ztest.h>
 
+#include <net/net_if.h>
+#include <net/net_pkt.h>
+#include <net/net_l2.h>
+
+/* Net offloading support needs L2 defined here, otherwise there will
+ * be a linking error as by default there is no L2 offloading driver
+ * in Zephyr.
+ */
+NET_L2_INIT(OFFLOAD_IP_L2, NULL, NULL, NULL, NULL);
+
+static struct offload_context {
+	void *none;
+} offload_context_data = {
+	.none = NULL
+};
+
+static struct net_if_api offload_if_api = {
+	.init = NULL,
+	.send = NULL,
+};
+
+NET_DEVICE_INIT(net_offload, "net_offload",
+		NULL,
+		&offload_context_data, NULL,
+		CONFIG_KERNEL_INIT_PRIORITY_DEFAULT,
+		&offload_if_api, OFFLOAD_IP_L2,
+		NET_L2_GET_CTX_TYPE(OFFLOAD_IP_L2), 0);
+
 static void ok(void)
 {
 	zassert_true(true, "This test should never fail");

--- a/tests/net/mld/src/main.c
+++ b/tests/net/mld/src/main.c
@@ -29,7 +29,7 @@
 #define NET_LOG_ENABLED 1
 #include "net_private.h"
 
-#if defined(CONFIG_NET_DEBUG_MLD)
+#if defined(CONFIG_NET_IPV6)
 #define DBG(fmt, ...) printk(fmt, ##__VA_ARGS__)
 #else
 #define DBG(fmt, ...)


### PR DESCRIPTION
There were bunch of config options in tests/net, net-shell and
wpan_serial sample, and those options had wrong name so they
were ignored by the code.

Fixes #1428

Signed-off-by: Jukka Rissanen <jukka.rissanen@linux.intel.com>