### PR TITLE
net: shell: Add ARP cache printing

### DIFF
--- a/include/net/arp.h
+++ b/include/net/arp.h
@@ -49,6 +49,18 @@ struct net_arp_hdr {
 struct net_pkt *net_arp_prepare(struct net_pkt *pkt);
 enum net_verdict net_arp_input(struct net_pkt *pkt);
 
+struct arp_entry {
+	u32_t time;	/* FIXME - implement timeout functionality */
+	struct net_if *iface;
+	struct net_pkt *pending;
+	struct in_addr ip;
+	struct net_eth_addr eth;
+};
+
+typedef void (*net_arp_cb_t)(struct arp_entry *entry,
+			     void *user_data);
+int net_arp_foreach(net_arp_cb_t cb, void *user_data);
+
 void net_arp_clear_cache(void);
 void net_arp_init(void);
 

--- a/subsys/net/ip/l2/arp.c
+++ b/subsys/net/ip/l2/arp.c
@@ -21,14 +21,6 @@
 #include <net/arp.h>
 #include "net_private.h"
 
-struct arp_entry {
-	u32_t time;	/* FIXME - implement timeout functionality */
-	struct net_if *iface;
-	struct net_pkt *pending;
-	struct in_addr ip;
-	struct net_eth_addr eth;
-};
-
 static struct arp_entry arp_table[CONFIG_NET_ARP_TABLE_SIZE];
 
 static inline struct arp_entry *find_entry(struct net_if *iface,
@@ -493,6 +485,23 @@ void net_arp_clear_cache(void)
 	}
 
 	memset(&arp_table, 0, sizeof(arp_table));
+}
+
+int net_arp_foreach(net_arp_cb_t cb, void *user_data)
+{
+	int i, ret = 0;
+
+	for (i = 0; i < CONFIG_NET_ARP_TABLE_SIZE; i++) {
+		if (!arp_table[i].iface) {
+			continue;
+		}
+
+		ret++;
+
+		cb(&arp_table[i], user_data);
+	}
+
+	return ret;
 }
 
 void net_arp_init(void)


### PR DESCRIPTION
Add a command "net arp" to net-shell. This new command will
print ARP cache contents if IPv4 and Ethernet are enabled.

Signed-off-by: Jukka Rissanen <jukka.rissanen@linux.intel.com>