### PR TITLE
spi: Allow updating TX and RX of spi context by multiple words.

### DIFF
--- a/drivers/spi/spi_context.h
+++ b/drivers/spi/spi_context.h
@@ -193,13 +193,18 @@ static inline void spi_context_buffers_setup(struct spi_context *ctx,
 }
 
 static ALWAYS_INLINE
-void spi_context_update_tx(struct spi_context *ctx, u8_t dfs)
+void spi_context_update_tx(struct spi_context *ctx, u8_t dfs, u32_t len)
 {
 	if (!ctx->tx_len) {
 		return;
 	}
 
-	ctx->tx_len--;
+	if (len > ctx->tx_len) {
+		SYS_LOG_ERR("Update exceeds current buffer");
+		return;
+	}
+
+	ctx->tx_len -= len;
 	if (!ctx->tx_len) {
 		ctx->current_tx++;
 		ctx->tx_count--;
@@ -211,7 +216,7 @@ void spi_context_update_tx(struct spi_context *ctx, u8_t dfs)
 			ctx->tx_buf = NULL;
 		}
 	} else if (ctx->tx_buf) {
-		ctx->tx_buf += dfs;
+		ctx->tx_buf += dfs * len;
 	}
 
 	SYS_LOG_DBG("tx buf/len %p/%zu", ctx->tx_buf, ctx->tx_len);
@@ -224,13 +229,18 @@ bool spi_context_tx_on(struct spi_context *ctx)
 }
 
 static ALWAYS_INLINE
-void spi_context_update_rx(struct spi_context *ctx, u8_t dfs)
+void spi_context_update_rx(struct spi_context *ctx, u8_t dfs, u32_t len)
 {
 	if (!ctx->rx_len) {
 		return;
 	}
 
-	ctx->rx_len--;
+	if (len > ctx->rx_len) {
+		SYS_LOG_ERR("Update exceeds current buffer");
+		return;
+	}
+
+	ctx->rx_len -= len;
 	if (!ctx->rx_len) {
 		ctx->current_rx++;
 		ctx->rx_count--;
@@ -242,7 +252,7 @@ void spi_context_update_rx(struct spi_context *ctx, u8_t dfs)
 			ctx->rx_buf = NULL;
 		}
 	} else if (ctx->rx_buf) {
-		ctx->rx_buf += dfs;
+		ctx->rx_buf += dfs * len;
 	}
 
 	SYS_LOG_DBG("rx buf/len %p/%zu", ctx->rx_buf, ctx->rx_len);

--- a/drivers/spi/spi_dw.c
+++ b/drivers/spi/spi_dw.c
@@ -129,7 +129,7 @@ static void push_data(struct device *dev)
 
 		write_dr(data, info->regs);
 
-		spi_context_update_tx(&spi->ctx, spi->dfs);
+		spi_context_update_tx(&spi->ctx, spi->dfs, 1);
 		spi->fifo_diff++;
 
 		f_tx--;
@@ -173,7 +173,7 @@ static void pull_data(struct device *dev)
 			}
 		}
 
-		spi_context_update_rx(&spi->ctx, spi->dfs);
+		spi_context_update_rx(&spi->ctx, spi->dfs, 1);
 		spi->fifo_diff--;
 	}
 

--- a/drivers/spi/spi_ll_stm32.c
+++ b/drivers/spi/spi_ll_stm32.c
@@ -66,7 +66,7 @@ static void spi_stm32_shift_m(SPI_TypeDef *spi, struct spi_stm32_data *data)
 	}
 	LL_SPI_TransmitData8(spi, tx_frame);
 	/* The update is ignored if TX is off. */
-	spi_context_update_tx(&data->ctx, 1);
+	spi_context_update_tx(&data->ctx, 1, 1);
 
 	while (!LL_SPI_IsActiveFlag_RXNE(spi)) {
 		/* NOP */
@@ -74,7 +74,7 @@ static void spi_stm32_shift_m(SPI_TypeDef *spi, struct spi_stm32_data *data)
 	rx_frame = LL_SPI_ReceiveData8(spi);
 	if (spi_context_rx_on(&data->ctx)) {
 		*data->ctx.rx_buf = rx_frame;
-		spi_context_update_rx(&data->ctx, 1);
+		spi_context_update_rx(&data->ctx, 1, 1);
 	}
 }
 
@@ -88,14 +88,14 @@ static void spi_stm32_shift_s(SPI_TypeDef *spi, struct spi_stm32_data *data)
 	if (LL_SPI_IsActiveFlag_TXE(spi)) {
 		LL_SPI_TransmitData8(spi, tx_frame);
 		/* The update is ignored if TX is off. */
-		spi_context_update_tx(&data->ctx, 1);
+		spi_context_update_tx(&data->ctx, 1, 1);
 	}
 
 	if (LL_SPI_IsActiveFlag_RXNE(spi)) {
 		rx_frame = LL_SPI_ReceiveData8(spi);
 		if (spi_context_rx_on(&data->ctx)) {
 			*data->ctx.rx_buf = rx_frame;
-			spi_context_update_rx(&data->ctx, 1);
+			spi_context_update_rx(&data->ctx, 1, 1);
 		}
 	}
 }


### PR DESCRIPTION
Previous approach allowed only single word update for single
function call. Updating context in ISR was inefficient for
controllers supporting automatic multiple data packets transaction.

Signed-off-by: Michał Kruszewski <michal.kruszewski@nordicsemi.no>