### PR TITLE
net: ethernet: Do not unref pending ARP request

### DIFF
--- a/subsys/net/ip/l2/ethernet.c
+++ b/subsys/net/ip/l2/ethernet.c
@@ -203,11 +203,6 @@ static enum net_verdict ethernet_send(struct net_if *iface,
 		NET_DBG("Sending arp pkt %p (orig %p) to iface %p",
 			arp_pkt, pkt, iface);
 
-		if (pkt != arp_pkt) {
-			/* pkt went to ARP pending queue */
-			net_pkt_unref(pkt);
-		}
-
 		pkt = arp_pkt;
 
 		net_pkt_ll_src(pkt)->addr = (u8_t *)&NET_ETH_HDR(pkt)->src;


### PR DESCRIPTION
If the packet is put pending because ARP request need to be
done, then do not unref original packet.

Fixes #1416

Signed-off-by: Jukka Rissanen <jukka.rissanen@linux.intel.com>