### PR TITLE
scripts/dts/extract_dts_includes.py: allow multiple fixup files

### DIFF
--- a/scripts/dts/extract_dts_includes.py
+++ b/scripts/dts/extract_dts_includes.py
@@ -661,19 +661,21 @@ def generate_include_file(defs, args):
 
         sys.stdout.write("\n")
 
-    if args.fixup and os.path.exists(args.fixup):
-        sys.stdout.write("\n")
-        sys.stdout.write(
-            "/* Following definitions fixup the generated include */\n")
-        try:
-            with open(args.fixup, "r") as fd:
-                for line in fd.readlines():
-                    sys.stdout.write(line)
+    if args.fixup:
+        for fixup in args.fixup:
+            if os.path.exists(fixup):
                 sys.stdout.write("\n")
-        except:
-            raise Exception(
-                "Input file " + os.path.abspath(args.fixup) +
-                " does not exist.")
+                sys.stdout.write(
+                    "/* Following definitions fixup the generated include */\n")
+                try:
+                    with open(fixup, "r") as fd:
+                        for line in fd.readlines():
+                            sys.stdout.write(line)
+                        sys.stdout.write("\n")
+                except:
+                    raise Exception(
+                        "Input file " + os.path.abspath(fixup) +
+                        " does not exist.")
 
     sys.stdout.write("#endif\n")
 
@@ -695,7 +697,8 @@ def parse_arguments():
 
     parser.add_argument("-d", "--dts", help="DTS file")
     parser.add_argument("-y", "--yaml", help="YAML file")
-    parser.add_argument("-f", "--fixup", help="Fixup file")
+    parser.add_argument("-f", "--fixup", action="append",
+                        help="Fixup file, we allow multiple")
     parser.add_argument("-k", "--keyvalue", action="store_true",
                         help="Generate include file for the build system")
 


### PR DESCRIPTION
Allow the script to take multiple -f (fixup) file options.  We output
the fixup files in order that the -f options are passed.  This will
allow us to have a common soc fixup and board fixup if we desire.

Signed-off-by: Kumar Gala <kumar.gala@linaro.org>