### PR TITLE
ci: use docker image v0.1

### DIFF
--- a/.shippable.yml
+++ b/.shippable.yml
@@ -23,7 +23,7 @@ build:
         - ${SHIPPABLE_BUILD_DIR}/ccache
     pre_ci_boot:
         image_name: zephyrprojectrtos/ci
-        image_tag: master.43
+        image_tag: v0.1
         pull: true
         options: "-e HOME=/home/buildslave --privileged=true --tty --net=bridge --user buildslave"
 

--- a/scripts/ci/check-compliance.py
+++ b/scripts/ci/check-compliance.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 import sys
 import subprocess
 import re


### PR DESCRIPTION
This new image has the following additions:
- gperf
- cmake
- Zephyr SDK 0.9.2-rc4 for initial testing (in addition to 0.9.1)
- Various python modules needed for building and CI

Signed-off-by: Anas Nashif <anas.nashif@intel.com>