### PR TITLE
drivers: i2c: hide I2C_x_DEFAULT_CFG from Kconfig for DTS drivers

### DIFF
--- a/drivers/i2c/Kconfig
+++ b/drivers/i2c/Kconfig
@@ -199,7 +199,7 @@ config I2C_0_NAME
 
 config I2C_0_DEFAULT_CFG
 	hex "Port 0 default configuration"
-	depends on I2C_0
+	depends on I2C_0 && !HAS_DTS_I2C
 	default 0x0
 	help
 	  Allows the I2C port to be brought up with a default configuration.
@@ -225,7 +225,7 @@ config I2C_1_NAME
 
 config I2C_1_DEFAULT_CFG
 	hex "Port 1 default configuration"
-	depends on I2C_1
+	depends on I2C_1 && !HAS_DTS_I2C
 	default 0x0
 	help
 	  Allows the I2C port to be brought up with a default configuration.
@@ -251,7 +251,7 @@ config I2C_2_NAME
 
 config I2C_2_DEFAULT_CFG
 	hex "Port 2 default configuration"
-	depends on I2C_2
+	depends on I2C_2 && !HAS_DTS_I2C
 	default 0x0
 	help
 	  Allows the I2C port to be brought up with a default configuration.
@@ -277,7 +277,7 @@ config I2C_3_NAME
 
 config I2C_3_DEFAULT_CFG
 	hex "Port 3 default configuration"
-	depends on I2C_3
+	depends on I2C_3 && !HAS_DTS_I2C
 	default 0x0
 	help
 	  Allows the I2C port to be brought up with a default configuration.


### PR DESCRIPTION
I2C device drivers which support DTS have their default boot
configuration provided by DTS. The legacy I2C_x_DEFAULT_CFG
option in Kconfig is no longer required. This patch hides
this option from the Kconfig menu for I2C device drivers which
support DTS.

Signed-off-by: Piotr Mienkowski <piotr.mienkowski@gmail.com>