### PR TITLE
LwM2M 1.10 changes: LwM2M library use net_app API internally

### DIFF
--- a/include/net/lwm2m.h
+++ b/include/net/lwm2m.h
@@ -8,6 +8,7 @@
 #define __LWM2M_H__
 
 #include <net/net_context.h>
+#include <net/zoap.h>
 
 /* LWM2M Objects defined by OMA */
 
@@ -35,6 +36,8 @@ struct lwm2m_ctx {
 	struct net_context *net_ctx;
 
 	/** Private ZoAP and networking structures */
+	struct zoap_pending pendings[CONFIG_LWM2M_ENGINE_MAX_PENDING];
+	struct zoap_reply replies[CONFIG_LWM2M_ENGINE_MAX_REPLIES];
 	struct k_delayed_work retransmit_work;
 };
 

--- a/include/net/lwm2m.h
+++ b/include/net/lwm2m.h
@@ -25,6 +25,16 @@
 #define IPSO_OBJECT_TEMP_SENSOR_ID			3303
 #define IPSO_OBJECT_LIGHT_CONTROL_ID			3311
 
+/**
+ * LwM2M context structure
+ *
+ * @details Context structure for the LwM2M high-level API.
+ */
+struct lwm2m_ctx {
+	/** Net context structure */
+	struct net_context *net_ctx;
+};
+
 /* callback can return 1 if handled (don't update value) */
 typedef void *(*lwm2m_engine_get_data_cb_t)(u16_t obj_inst_id,
 				       size_t *data_len);
@@ -149,11 +159,11 @@ int lwm2m_engine_register_post_write_callback(char *path,
 int lwm2m_engine_register_exec_callback(char *path,
 					lwm2m_engine_exec_cb_t cb);
 
-int lwm2m_engine_start(struct net_context *net_ctx);
+int lwm2m_engine_start(struct lwm2m_ctx *client_ctx);
 
 /* LWM2M RD Client */
 
-int lwm2m_rd_client_start(struct net_context *net_ctx,
+int lwm2m_rd_client_start(struct lwm2m_ctx *client_ctx,
 			  struct sockaddr *peer_addr,
 			  const char *ep_name);
 

--- a/include/net/lwm2m.h
+++ b/include/net/lwm2m.h
@@ -33,6 +33,9 @@
 struct lwm2m_ctx {
 	/** Net context structure */
 	struct net_context *net_ctx;
+
+	/** Private ZoAP and networking structures */
+	struct k_delayed_work retransmit_work;
 };
 
 /* callback can return 1 if handled (don't update value) */

--- a/samples/net/lwm2m_client/src/lwm2m-client.c
+++ b/samples/net/lwm2m_client/src/lwm2m-client.c
@@ -252,9 +252,13 @@ static int lwm2m_setup(void)
 	return 0;
 }
 
-int setup_net_app_ctx(struct net_app_ctx *ctx, const char *peer)
+int setup_net_app_ctx(struct lwm2m_ctx *client_ctx,
+		      struct net_app_ctx *ctx, const char *peer)
 {
 	int ret;
+
+	/* Set everything to 0 and later just assign the required fields. */
+	memset(client_ctx, 0x00, sizeof(*client_ctx));
 
 	ret = net_app_init_udp_client(ctx, NULL, NULL, peer,
 				      CONFIG_LWM2M_PEER_PORT, WAIT_TIME, NULL);
@@ -286,7 +290,8 @@ void main(void)
 	}
 
 #if defined(CONFIG_NET_IPV6)
-	ret = setup_net_app_ctx(&app_udp6, CONFIG_NET_APP_PEER_IPV6_ADDR);
+	ret = setup_net_app_ctx(&udp6, &app_udp6,
+				CONFIG_NET_APP_PEER_IPV6_ADDR);
 	if (ret < 0) {
 		goto cleanup_ipv6;
 	}
@@ -315,7 +320,8 @@ void main(void)
 #endif
 
 #if defined(CONFIG_NET_IPV4)
-	ret = setup_net_app_ctx(&app_udp4, CONFIG_NET_APP_PEER_IPV4_ADDR);
+	ret = setup_net_app_ctx(&udp4, &app_udp4,
+				CONFIG_NET_APP_PEER_IPV4_ADDR);
 	if (ret < 0) {
 		goto cleanup_ipv4;
 	}

--- a/subsys/net/lib/lwm2m/lwm2m_engine.c
+++ b/subsys/net/lib/lwm2m/lwm2m_engine.c
@@ -2592,12 +2592,12 @@ static void lwm2m_engine_service(void)
 	}
 }
 
-int lwm2m_engine_start(struct net_context *net_ctx)
+int lwm2m_engine_start(struct lwm2m_ctx *client_ctx)
 {
 	int ret = 0;
 
 	/* set callback */
-	ret = net_context_recv(net_ctx, udp_receive, 0, NULL);
+	ret = net_context_recv(client_ctx->net_ctx, udp_receive, 0, NULL);
 	if (ret) {
 		SYS_LOG_ERR("Could not set receive for net context (err:%d)",
 			    ret);

--- a/subsys/net/lib/lwm2m/lwm2m_engine.c
+++ b/subsys/net/lib/lwm2m/lwm2m_engine.c
@@ -2236,8 +2236,7 @@ int lwm2m_udp_sendto(struct net_pkt *pkt, const struct sockaddr *dst_addr)
 				  NULL, K_NO_WAIT, NULL, NULL);
 }
 
-void lwm2m_udp_receive(struct lwm2m_ctx *client_ctx,
-		       struct net_context *net_ctx, struct net_pkt *pkt,
+void lwm2m_udp_receive(struct lwm2m_ctx *client_ctx, struct net_pkt *pkt,
 		       bool handle_separate_response,
 		       int (*udp_request_handler)(struct zoap_packet *,
 						  struct zoap_packet *,
@@ -2313,7 +2312,8 @@ void lwm2m_udp_receive(struct lwm2m_ctx *client_ctx,
 		if (udp_request_handler &&
 		    zoap_header_get_type(&response) == ZOAP_TYPE_CON) {
 			/* Create a response packet if we reach this point */
-			r = lwm2m_init_message(net_ctx, &response2, &pkt2,
+			r = lwm2m_init_message(client_ctx->net_ctx,
+					       &response2, &pkt2,
 					       ZOAP_TYPE_ACK,
 					       zoap_header_get_code(&response),
 					       zoap_header_get_id(&response),
@@ -2375,7 +2375,7 @@ static void udp_receive(struct net_context *net_ctx, struct net_pkt *pkt,
 						    struct lwm2m_ctx,
 						    net_ctx);
 
-	lwm2m_udp_receive(client_ctx, net_ctx, pkt, false, handle_request);
+	lwm2m_udp_receive(client_ctx, pkt, false, handle_request);
 }
 
 static void retransmit_request(struct k_work *work)

--- a/subsys/net/lib/lwm2m/lwm2m_engine.h
+++ b/subsys/net/lib/lwm2m/lwm2m_engine.h
@@ -51,10 +51,9 @@ int  lwm2m_get_or_create_engine_obj(struct lwm2m_engine_context *context,
 int lwm2m_init_message(struct net_context *net_ctx, struct zoap_packet *zpkt,
 		       struct net_pkt **pkt, u8_t type, u8_t code, u16_t mid,
 		       const u8_t *token, u8_t tkl);
-struct zoap_pending *lwm2m_init_message_pending(struct zoap_packet *zpkt,
-						struct sockaddr *addr,
-						struct zoap_pending *zpendings,
-						int num_zpendings);
+struct zoap_pending *lwm2m_init_message_pending(struct lwm2m_ctx *client_ctx,
+						struct zoap_packet *zpkt,
+						struct sockaddr *addr);
 void lwm2m_init_message_cleanup(struct net_pkt *pkt,
 				struct zoap_pending *pending,
 				struct zoap_reply *reply);
@@ -67,9 +66,8 @@ int lwm2m_write_handler(struct lwm2m_engine_obj_inst *obj_inst,
 			struct lwm2m_engine_context *context);
 
 int lwm2m_udp_sendto(struct net_pkt *pkt, const struct sockaddr *dst_addr);
-void lwm2m_udp_receive(struct net_context *ctx, struct net_pkt *pkt,
-		       struct zoap_pending *zpendings, int num_zpendings,
-		       struct zoap_reply *zreplies, int num_zreplies,
+void lwm2m_udp_receive(struct lwm2m_ctx *client_ctx,
+		       struct net_context *ctx, struct net_pkt *pkt,
 		       bool handle_separate_response,
 		       int (*udp_request_handler)(struct zoap_packet *request,
 				struct zoap_packet *response,

--- a/subsys/net/lib/lwm2m/lwm2m_engine.h
+++ b/subsys/net/lib/lwm2m/lwm2m_engine.h
@@ -48,7 +48,7 @@ int  lwm2m_get_or_create_engine_obj(struct lwm2m_engine_context *context,
 				    struct lwm2m_engine_obj_inst **obj_inst,
 				    u8_t *created);
 
-int lwm2m_init_message(struct net_context *net_ctx, struct zoap_packet *zpkt,
+int lwm2m_init_message(struct net_app_ctx *app_ctx, struct zoap_packet *zpkt,
 		       struct net_pkt **pkt, u8_t type, u8_t code, u16_t mid,
 		       const u8_t *token, u8_t tkl);
 struct zoap_pending *lwm2m_init_message_pending(struct lwm2m_ctx *client_ctx,
@@ -65,11 +65,11 @@ int lwm2m_write_handler(struct lwm2m_engine_obj_inst *obj_inst,
 			struct lwm2m_engine_obj_field *obj_field,
 			struct lwm2m_engine_context *context);
 
-int lwm2m_udp_sendto(struct net_context *net_ctx, struct net_pkt *pkt,
+int lwm2m_udp_sendto(struct net_app_ctx *app_ctx, struct net_pkt *pkt,
 		     const struct sockaddr *dst_addr);
 void lwm2m_udp_receive(struct lwm2m_ctx *client_ctx, struct net_pkt *pkt,
 		       bool handle_separate_response,
-		       int (*udp_request_handler)(struct net_context *net_ctx,
+		       int (*udp_request_handler)(struct net_app_ctx *app_ctx,
 				struct zoap_packet *request,
 				struct zoap_packet *response,
 				struct sockaddr *from_addr));

--- a/subsys/net/lib/lwm2m/lwm2m_engine.h
+++ b/subsys/net/lib/lwm2m/lwm2m_engine.h
@@ -52,8 +52,7 @@ int lwm2m_init_message(struct net_app_ctx *app_ctx, struct zoap_packet *zpkt,
 		       struct net_pkt **pkt, u8_t type, u8_t code, u16_t mid,
 		       const u8_t *token, u8_t tkl);
 struct zoap_pending *lwm2m_init_message_pending(struct lwm2m_ctx *client_ctx,
-						struct zoap_packet *zpkt,
-						struct sockaddr *addr);
+						struct zoap_packet *zpkt);
 void lwm2m_init_message_cleanup(struct net_pkt *pkt,
 				struct zoap_pending *pending,
 				struct zoap_reply *reply);
@@ -65,13 +64,11 @@ int lwm2m_write_handler(struct lwm2m_engine_obj_inst *obj_inst,
 			struct lwm2m_engine_obj_field *obj_field,
 			struct lwm2m_engine_context *context);
 
-int lwm2m_udp_sendto(struct net_app_ctx *app_ctx, struct net_pkt *pkt,
-		     const struct sockaddr *dst_addr);
+int lwm2m_udp_sendto(struct net_app_ctx *app_ctx, struct net_pkt *pkt);
 void lwm2m_udp_receive(struct lwm2m_ctx *client_ctx, struct net_pkt *pkt,
 		       bool handle_separate_response,
 		       int (*udp_request_handler)(struct net_app_ctx *app_ctx,
 				struct zoap_packet *request,
-				struct zoap_packet *response,
-				struct sockaddr *from_addr));
+				struct zoap_packet *response));
 
 #endif /* LWM2M_ENGINE_H */

--- a/subsys/net/lib/lwm2m/lwm2m_engine.h
+++ b/subsys/net/lib/lwm2m/lwm2m_engine.h
@@ -65,10 +65,12 @@ int lwm2m_write_handler(struct lwm2m_engine_obj_inst *obj_inst,
 			struct lwm2m_engine_obj_field *obj_field,
 			struct lwm2m_engine_context *context);
 
-int lwm2m_udp_sendto(struct net_pkt *pkt, const struct sockaddr *dst_addr);
+int lwm2m_udp_sendto(struct net_context *net_ctx, struct net_pkt *pkt,
+		     const struct sockaddr *dst_addr);
 void lwm2m_udp_receive(struct lwm2m_ctx *client_ctx, struct net_pkt *pkt,
 		       bool handle_separate_response,
-		       int (*udp_request_handler)(struct zoap_packet *request,
+		       int (*udp_request_handler)(struct net_context *net_ctx,
+				struct zoap_packet *request,
 				struct zoap_packet *response,
 				struct sockaddr *from_addr));
 

--- a/subsys/net/lib/lwm2m/lwm2m_engine.h
+++ b/subsys/net/lib/lwm2m/lwm2m_engine.h
@@ -66,8 +66,7 @@ int lwm2m_write_handler(struct lwm2m_engine_obj_inst *obj_inst,
 			struct lwm2m_engine_context *context);
 
 int lwm2m_udp_sendto(struct net_pkt *pkt, const struct sockaddr *dst_addr);
-void lwm2m_udp_receive(struct lwm2m_ctx *client_ctx,
-		       struct net_context *ctx, struct net_pkt *pkt,
+void lwm2m_udp_receive(struct lwm2m_ctx *client_ctx, struct net_pkt *pkt,
 		       bool handle_separate_response,
 		       int (*udp_request_handler)(struct zoap_packet *request,
 				struct zoap_packet *response,

--- a/subsys/net/lib/lwm2m/lwm2m_obj_firmware_pull.c
+++ b/subsys/net/lib/lwm2m/lwm2m_obj_firmware_pull.c
@@ -40,7 +40,7 @@ static void
 firmware_udp_receive(struct net_context *ctx, struct net_pkt *pkt, int status,
 		     void *user_data)
 {
-	lwm2m_udp_receive(&firmware_ctx, ctx, pkt, true, NULL);
+	lwm2m_udp_receive(&firmware_ctx, pkt, true, NULL);
 }
 
 static void retransmit_request(struct k_work *work)

--- a/subsys/net/lib/lwm2m/lwm2m_obj_firmware_pull.c
+++ b/subsys/net/lib/lwm2m/lwm2m_obj_firmware_pull.c
@@ -57,8 +57,7 @@ static void retransmit_request(struct k_work *work)
 		return;
 	}
 
-	r = lwm2m_udp_sendto(&firmware_ctx.net_app_ctx,
-			     pending->pkt, &pending->addr);
+	r = lwm2m_udp_sendto(&firmware_ctx.net_app_ctx, pending->pkt);
 	if (r < 0) {
 		return;
 	}
@@ -104,8 +103,7 @@ static int transfer_request(struct zoap_block_context *ctx,
 		goto cleanup;
 	}
 
-	pending = lwm2m_init_message_pending(&firmware_ctx, &request,
-					     &firmware_addr);
+	pending = lwm2m_init_message_pending(&firmware_ctx, &request);
 	if (!pending) {
 		ret = -ENOMEM;
 		goto cleanup;
@@ -126,8 +124,7 @@ static int transfer_request(struct zoap_block_context *ctx,
 	}
 
 	/* send request */
-	ret = lwm2m_udp_sendto(&firmware_ctx.net_app_ctx,
-			       pkt, &firmware_addr);
+	ret = lwm2m_udp_sendto(&firmware_ctx.net_app_ctx, pkt);
 	if (ret < 0) {
 		SYS_LOG_ERR("Error sending LWM2M packet (err:%d).",
 			    ret);

--- a/subsys/net/lib/lwm2m/lwm2m_obj_firmware_pull.c
+++ b/subsys/net/lib/lwm2m/lwm2m_obj_firmware_pull.c
@@ -54,7 +54,8 @@ static void retransmit_request(struct k_work *work)
 		return;
 	}
 
-	r = lwm2m_udp_sendto(pending->pkt, &pending->addr);
+	r = lwm2m_udp_sendto(firmware_ctx.net_ctx,
+			     pending->pkt, &pending->addr);
 	if (r < 0) {
 		return;
 	}
@@ -122,7 +123,8 @@ static int transfer_request(struct zoap_block_context *ctx,
 	}
 
 	/* send request */
-	ret = lwm2m_udp_sendto(pkt, &firmware_addr);
+	ret = lwm2m_udp_sendto(firmware_ctx.net_ctx,
+			       pkt, &firmware_addr);
 	if (ret < 0) {
 		SYS_LOG_ERR("Error sending LWM2M packet (err:%d).",
 			    ret);

--- a/subsys/net/lib/lwm2m/lwm2m_obj_firmware_pull.c
+++ b/subsys/net/lib/lwm2m/lwm2m_obj_firmware_pull.c
@@ -325,6 +325,7 @@ int lwm2m_firmware_start_transfer(char *package_uri)
 	}
 
 	if (transfer_state == STATE_IDLE) {
+		memset(&firmware_ctx, 0, sizeof(struct lwm2m_ctx));
 		k_work_init(&firmware_work, firmware_transfer);
 		k_delayed_work_init(&retransmit_work, retransmit_request);
 

--- a/subsys/net/lib/lwm2m/lwm2m_rd_client.c
+++ b/subsys/net/lib/lwm2m/lwm2m_rd_client.c
@@ -433,7 +433,8 @@ static int sm_do_bootstrap(int index)
 			    lwm2m_sprint_ip_addr(&clients[index].bs_server),
 			    query_buffer);
 
-		ret = lwm2m_udp_sendto(pkt, &clients[index].bs_server);
+		ret = lwm2m_udp_sendto(clients[index].ctx->net_ctx,
+				       pkt, &clients[index].bs_server);
 		if (ret < 0) {
 			SYS_LOG_ERR("Error sending LWM2M packet (err:%d).",
 				    ret);
@@ -585,7 +586,8 @@ static int sm_send_registration(int index, bool send_obj_support_data,
 	SYS_LOG_DBG("registration sent [%s]",
 		    lwm2m_sprint_ip_addr(&clients[index].reg_server));
 
-	ret = lwm2m_udp_sendto(pkt, &clients[index].reg_server);
+	ret = lwm2m_udp_sendto(clients[index].ctx->net_ctx,
+			       pkt, &clients[index].reg_server);
 	if (ret < 0) {
 		SYS_LOG_ERR("Error sending LWM2M packet (err:%d).",
 			    ret);
@@ -684,7 +686,8 @@ static int sm_do_deregister(int index)
 
 	SYS_LOG_INF("Deregister from '%s'", clients[index].server_ep);
 
-	ret = lwm2m_udp_sendto(pkt, &clients[index].reg_server);
+	ret = lwm2m_udp_sendto(clients[index].ctx->net_ctx,
+			       pkt, &clients[index].reg_server);
 	if (ret < 0) {
 		SYS_LOG_ERR("Error sending LWM2M packet (err:%d).",
 			    ret);

--- a/subsys/net/lib/lwm2m/lwm2m_rd_client.c
+++ b/subsys/net/lib/lwm2m/lwm2m_rd_client.c
@@ -121,7 +121,6 @@ struct k_thread lwm2m_rd_client_thread_data;
 
 extern struct zoap_pending pendings[NUM_PENDINGS];
 extern struct zoap_reply replies[NUM_REPLIES];
-extern struct k_delayed_work retransmit_work;
 
 /* buffers */
 static char query_buffer[64]; /* allocate some data for queries and updates */
@@ -448,7 +447,8 @@ static int sm_do_bootstrap(int index)
 		}
 
 		zoap_pending_cycle(pending);
-		k_delayed_work_submit(&retransmit_work, pending->timeout);
+		k_delayed_work_submit(&clients[index].ctx->retransmit_work,
+				      pending->timeout);
 		set_sm_state(index, ENGINE_BOOTSTRAP_SENT);
 	}
 	return ret;
@@ -599,7 +599,8 @@ static int sm_send_registration(int index, bool send_obj_support_data,
 	}
 
 	zoap_pending_cycle(pending);
-	k_delayed_work_submit(&retransmit_work, pending->timeout);
+	k_delayed_work_submit(&clients[index].ctx->retransmit_work,
+			      pending->timeout);
 	return ret;
 
 cleanup:
@@ -697,7 +698,8 @@ static int sm_do_deregister(int index)
 	}
 
 	zoap_pending_cycle(pending);
-	k_delayed_work_submit(&retransmit_work, pending->timeout);
+	k_delayed_work_submit(&clients[index].ctx->retransmit_work,
+			      pending->timeout);
 	set_sm_state(index, ENGINE_DEREGISTER_SENT);
 	return ret;
 

--- a/subsys/net/lib/lwm2m/lwm2m_rd_client.c
+++ b/subsys/net/lib/lwm2m/lwm2m_rd_client.c
@@ -93,7 +93,7 @@ enum sm_engine_state {
 
 struct lwm2m_rd_client_info {
 	u16_t lifetime;
-	struct net_context *net_ctx;
+	struct lwm2m_ctx *ctx;
 	struct sockaddr bs_server;
 	struct sockaddr reg_server;
 	u8_t engine_state;
@@ -402,7 +402,7 @@ static int sm_do_bootstrap(int index)
 	    clients[index].bootstrapped == 0 &&
 	    clients[index].has_bs_server_info) {
 
-		ret = lwm2m_init_message(clients[index].net_ctx,
+		ret = lwm2m_init_message(clients[index].ctx->net_ctx,
 					 &request, &pkt, ZOAP_TYPE_CON,
 					 ZOAP_METHOD_POST, 0, NULL, 0);
 		if (ret) {
@@ -516,7 +516,7 @@ static int sm_send_registration(int index, bool send_obj_support_data,
 
 	/* remember the last reg time */
 	clients[index].last_update = k_uptime_get();
-	ret = lwm2m_init_message(clients[index].net_ctx,
+	ret = lwm2m_init_message(clients[index].ctx->net_ctx,
 				 &request, &pkt, ZOAP_TYPE_CON,
 				 ZOAP_METHOD_POST, 0, NULL, 0);
 	if (ret) {
@@ -658,7 +658,7 @@ static int sm_do_deregister(int index)
 	struct zoap_reply *reply = NULL;
 	int ret;
 
-	ret = lwm2m_init_message(clients[index].net_ctx,
+	ret = lwm2m_init_message(clients[index].ctx->net_ctx,
 				 &request, &pkt, ZOAP_TYPE_CON,
 				 ZOAP_METHOD_DELETE, 0, NULL, 0);
 	if (ret) {
@@ -846,7 +846,7 @@ static void set_ep_ports(int index)
 #endif
 }
 
-int lwm2m_rd_client_start(struct net_context *net_ctx,
+int lwm2m_rd_client_start(struct lwm2m_ctx *client_ctx,
 			  struct sockaddr *peer_addr,
 			  const char *ep_name)
 {
@@ -864,7 +864,7 @@ int lwm2m_rd_client_start(struct net_context *net_ctx,
 	/* TODO: use server URI data from security */
 	index = client_count;
 	client_count++;
-	clients[index].net_ctx = net_ctx;
+	clients[index].ctx = client_ctx;
 	memcpy(&clients[index].reg_server, peer_addr, sizeof(struct sockaddr));
 	memcpy(&clients[index].bs_server, peer_addr, sizeof(struct sockaddr));
 	set_ep_ports(index);


### PR DESCRIPTION
This patchset moves the internals of the LwM2M library to the net_app API.  To facilitate this we establish an lwm2m_context structure and use this to pass around various objects needed for app control.  Also remove / cleanup fields which are now unused as a result.