### PR TITLE
net/arp: Fixing a leak when there is no pending entries left

### DIFF
--- a/subsys/net/ip/l2/arp.c
+++ b/subsys/net/ip/l2/arp.c
@@ -299,16 +299,8 @@ static inline void send_pending(struct net_if *iface, struct net_pkt **pkt)
 	*pkt = NULL;
 
 	if (net_if_send_data(iface, pending) == NET_DROP) {
-		/* This is to unref the original ref */
 		net_pkt_unref(pending);
 	}
-
-	/* The pending pkt was referenced when
-	 * it was added to cache so we need to
-	 * unref it now when it is removed from
-	 * the cache.
-	 */
-	net_pkt_unref(pending);
 }
 
 static inline void arp_update(struct net_if *iface,

--- a/subsys/net/ip/l2/ethernet.c
+++ b/subsys/net/ip/l2/ethernet.c
@@ -203,6 +203,13 @@ static enum net_verdict ethernet_send(struct net_if *iface,
 		NET_DBG("Sending arp pkt %p (orig %p) to iface %p",
 			arp_pkt, pkt, iface);
 
+		if (pkt != arp_pkt) {
+			/* Either pkt went to ARP pending queue
+			 * or there was not space in the queue anymore
+			 */
+			net_pkt_unref(pkt);
+		}
+
 		pkt = arp_pkt;
 
 		net_pkt_ll_src(pkt)->addr = (u8_t *)&NET_ETH_HDR(pkt)->src;


### PR DESCRIPTION
Commit cd35742a2 missed one unref too many on pending packet which was
triggering a crash which commit 0b8434f08 tried to fix, but it generates
a leak when there is not pending entries left in arp core. Finally,
fixing what cd35742a2 should have done: removing the extra unecessary
unref after sending the pending packet.

Signed-off-by: Tomasz Bursztyka <tomasz.bursztyka@linux.intel.com>