### PR TITLE
scripts/dts/extract_dts_includes.py: Fix tab calculation

### DIFF
--- a/scripts/dts/extract_dts_includes.py
+++ b/scripts/dts/extract_dts_includes.py
@@ -641,7 +641,12 @@ def generate_include_file(defs, args):
         sys.stdout.write('/* ' + node.split('/')[-1] + ' */')
         sys.stdout.write("\n")
 
-        maxlength = max(len(s + '#define ') for s in defs[node].keys())
+        max_dict_key = lambda d: max(len(k) for k in d.keys())
+        maxlength = 0
+        if defs[node].get('aliases'):
+            maxlength = max_dict_key(defs[node]['aliases'])
+        maxlength = max(maxlength, max_dict_key(defs[node])) + len('#define ')
+
         if maxlength % 8:
             maxtabstop = (maxlength + 7) >> 3
         else:


### PR DESCRIPTION
If there's any key in the alias which length is larger than other keys
in the node, the include file will be incorrect, there will be no tap
between the key and value.

We need to take into account the max length of alias keys.

Signed-off-by: Aska Wu <aska.wu@linaro.org>