### PR TITLE
drivers/spi: Use sync_status relevantly in DW driver

### DIFF
--- a/drivers/spi/spi_dw.c
+++ b/drivers/spi/spi_dw.c
@@ -63,8 +63,6 @@ out:
 	while (test_bit_sr_busy(info->regs)) {
 	}
 
-	spi->error = error;
-
 	/* Disabling interrupts */
 	write_imr(DW_SPI_IMR_MASK, info->regs);
 	/* Disabling the controller */
@@ -308,11 +306,7 @@ static int transceive(struct spi_config *config,
 	/* Enable the controller */
 	set_bit_ssienr(info->regs);
 
-	spi_context_wait_for_completion(&spi->ctx);
-
-	if (spi->error) {
-		ret = -EIO;
-	}
+	ret = spi_context_wait_for_completion(&spi->ctx);
 out:
 	spi_context_release(&spi->ctx, ret);
 

--- a/drivers/spi/spi_dw.h
+++ b/drivers/spi/spi_dw.h
@@ -52,10 +52,9 @@ struct spi_dw_data {
 	struct device *clock;
 #endif /* CONFIG_SPI_DW_CLOCK_GATE */
 	struct spi_context ctx;
-	u8_t error;
 	u8_t dfs;	/* dfs in bytes: 1,2 or 4 */
 	u8_t fifo_diff;	/* cannot be bigger than FIFO depth */
-	u8_t _unused;
+	u16_t _unused;
 };
 #endif /* CONFIG_SPI_LEGACY_API */
 


### PR DESCRIPTION
Removing internal boolean in order to use the proper error code hold in
spi_context which was relevantly added in commit 6c717095b8.

Signed-off-by: Tomasz Bursztyka <tomasz.bursztyka@linux.intel.com>