### PR TITLE
pwm: stm32: Fix check for APB prescale

### DIFF
--- a/drivers/pwm/pwm_stm32.c
+++ b/drivers/pwm/pwm_stm32.c
@@ -38,7 +38,13 @@ static u32_t __get_tim_clk(u32_t bus_clk,
 		apb_psc = CONFIG_CLOCK_STM32_APB2_PRESCALER;
 	}
 
-	if (apb_psc == RCC_HCLK_DIV1) {
+	/*
+	 * If the APB prescaler equals 1, the timer clock frequencies
+	 * are set to the same frequency as that of the APB domain.
+	 * Otherwise, they are set to twice (×2) the frequency of the
+	 * APB domain.
+	 */
+	if (apb_psc == 1) {
 		tim_clk = bus_clk;
 	} else	{
 		tim_clk = 2 * bus_clk;


### PR DESCRIPTION
RCC_HCLK_DIV1 translates to 0x0 while apb_psc uses the value defined
by CONFIG_CLOCK_STM32_APB1/2_PRESCALER (range from 1 to 16).

Manually check if the defined prescaler is 1 or not and use that to
calculate the correct timer clock.

Signed-off-by: Ricardo Salveti <ricardo.salveti@linaro.org>