### PR TITLE
sensor: bmi160: Update Kconfig dependancy for SPI

### DIFF
--- a/drivers/sensor/bmi160/Kconfig
+++ b/drivers/sensor/bmi160/Kconfig
@@ -10,6 +10,7 @@ menuconfig BMI160
 	bool "Bosch BMI160 inertial measurement unit"
 	depends on SENSOR
 	depends on SPI
+	depends on SPI_LEGACY_API
 	default n
 	help
 	Enable Bosch BMI160 inertial measurement unit that provides acceleration


### PR DESCRIPTION
The driver uses the SPI legacy API so make it depend on the SPI legacy
API being enabled.

Signed-off-by: Kumar Gala <kumar.gala@linaro.org>