### PR TITLE
drivers: i2c: remove usage of bitfield access for cfg

### DIFF
--- a/drivers/i2c/i2c_atmel_sam3.c
+++ b/drivers/i2c/i2c_atmel_sam3.c
@@ -85,7 +85,7 @@ static u32_t clk_div_calc(struct device *dev)
 	 */
 	struct i2c_sam3_dev_data * const dev_data = dev->driver_data;
 
-	switch ((dev_data->dev_config.bits.speed)) {
+	switch (I2C_GET_SPEED(dev_data->dev_config.raw)) {
 	case I2C_SPEED_STANDARD:
 		/* CKDIV = 1
 		 * CHDIV = CLDIV = 208 = 0xD0
@@ -125,7 +125,7 @@ static u32_t clk_div_calc(struct device *dev)
 	 *
 	 * So use these to calculate chdiv_min and cldiv_min.
 	 */
-	switch ((dev_data->dev_config.bits.speed)) {
+	switch (I2C_GET_SPEED(dev_data->dev_config.raw)) {
 	case I2C_SPEED_STANDARD:
 		i2c_clk = 100000 * 2;
 		i2c_h_min_time = 4000;
@@ -271,7 +271,7 @@ static inline void transfer_setup(struct device *dev, u16_t slave_address)
 	u32_t iadr;
 
 	/* Set slave address */
-	if (dev_data->dev_config.bits.use_10_bit_addr) {
+	if (I2C_GET_ADDR_10_BITS(dev_data->dev_config.raw)) {
 		/* 10-bit slave addressing:
 		 * first two bits goes to MMR/DADR, other 8 to IADR.
 		 *

--- a/drivers/i2c/i2c_bitbang.c
+++ b/drivers/i2c/i2c_bitbang.c
@@ -51,15 +51,13 @@ static const u32_t delays_standard[] = {
 
 int i2c_bitbang_configure(struct i2c_bitbang *context, u32_t dev_config)
 {
-	union dev_config config = { .raw = dev_config };
-
 	/* Check for features we don't support */
-	if (config.bits.use_10_bit_addr) {
+	if (I2C_GET_ADDR_10_BITS(dev_config)) {
 		return -ENOTSUP;
 	}
 
 	/* Setup speed to use */
-	switch (config.bits.speed) {
+	switch (I2C_GET_SPEED(dev_config)) {
 	case I2C_SPEED_STANDARD:
 		context->delays = delays_standard;
 		break;

--- a/drivers/i2c/i2c_dw.c
+++ b/drivers/i2c/i2c_dw.c
@@ -292,7 +292,7 @@ static int _i2c_dw_setup(struct device *dev, u16_t slave_address)
 	value = regs->ic_clr_intr;
 
 	/* Set master or slave mode - (initialization = slave) */
-	if (dw->app_config.bits.is_master_device) {
+	if (I2C_GET_MODE_MASTER(dw->app_config.raw)) {
 		/*
 		 * Make sure to set both the master_mode and slave_disable_bit
 		 * to both 0 or both 1
@@ -307,14 +307,14 @@ static int _i2c_dw_setup(struct device *dev, u16_t slave_address)
 	ic_con.bits.restart_en = 1;
 
 	/* Set addressing mode - (initialization = 7 bit) */
-	if (dw->app_config.bits.use_10_bit_addr) {
+	if (I2C_GET_ADDR_10_BITS(dw->app_config.raw)) {
 		SYS_LOG_DBG("I2C: using 10-bit address");
 		ic_con.bits.addr_master_10bit = 1;
 		ic_con.bits.addr_slave_10bit = 1;
 	}
 
 	/* Setup the clock frequency and speed mode */
-	switch (dw->app_config.bits.speed) {
+	switch (I2C_GET_SPEED(dw->app_config.raw)) {
 	case I2C_SPEED_STANDARD:
 		SYS_LOG_DBG("I2C: speed set to STANDARD");
 		regs->ic_ss_scl_lcnt = dw->lcnt;
@@ -508,7 +508,7 @@ static int i2c_dw_runtime_configure(struct device *dev, u32_t config)
 
 	/* Make sure we have a supported speed for the DesignWare model */
 	/* and have setup the clock frequency and speed mode */
-	switch (dw->app_config.bits.speed) {
+	switch (I2C_GET_SPEED(dw->app_config.raw)) {
 	case I2C_SPEED_STANDARD:
 		/* Following the directions on DW spec page 59, IC_SS_SCL_LCNT
 		 * must have register values larger than IC_FS_SPKLEN + 7
@@ -595,7 +595,7 @@ static int i2c_dw_runtime_configure(struct device *dev, u32_t config)
 	 * currently.  This "hack" forces us to always be configured for master
 	 * mode, until we can verify that Slave mode works correctly.
 	 */
-	dw->app_config.bits.is_master_device = 1;
+	dw->app_config.raw |= I2C_MODE_MASTER;
 
 	return rc;
 }

--- a/drivers/i2c/i2c_ll_stm32_v1.c
+++ b/drivers/i2c/i2c_ll_stm32_v1.c
@@ -30,7 +30,7 @@ static inline void handle_sb(I2C_TypeDef *i2c, struct i2c_stm32_data *data)
 	u16_t saddr = data->slave_address;
 	u8_t slave;
 
-	if (data->dev_config.bits.use_10_bit_addr) {
+	if (I2C_GET_ADDR_10_BITS(data->dev_config.raw)) {
 		slave = (((saddr & 0x0300) >> 7) & 0xFF);
 		u8_t header = slave | HEADER;
 
@@ -54,7 +54,7 @@ static inline void handle_sb(I2C_TypeDef *i2c, struct i2c_stm32_data *data)
 
 static inline void handle_addr(I2C_TypeDef *i2c, struct i2c_stm32_data *data)
 {
-	if (data->dev_config.bits.use_10_bit_addr) {
+	if (I2C_GET_ADDR_10_BITS(data->dev_config.raw)) {
 		if (!data->current.is_write && data->current.is_restart) {
 			data->current.is_restart = 0;
 			LL_I2C_ClearFlag_ADDR(i2c);
@@ -307,7 +307,7 @@ s32_t stm32_i2c_msg_write(struct device *dev, struct i2c_msg *msg,
 	while (!LL_I2C_IsActiveFlag_SB(i2c)) {
 		;
 	}
-	if (data->dev_config.bits.use_10_bit_addr) {
+	if (I2C_GET_ADDR_10_BITS(data->dev_config.raw)) {
 		u8_t slave = (((saddr & 0x0300) >> 7) & 0xFF);
 		u8_t header = slave | HEADER;
 
@@ -366,7 +366,7 @@ s32_t stm32_i2c_msg_read(struct device *dev, struct i2c_msg *msg,
 	while (!LL_I2C_IsActiveFlag_SB(i2c)) {
 		;
 	}
-	if (data->dev_config.bits.use_10_bit_addr) {
+	if (I2C_GET_ADDR_10_BITS(data->dev_config.raw)) {
 		u8_t slave = (((saddr &	0x0300) >> 7) & 0xFF);
 		u8_t header = slave | HEADER;
 
@@ -457,7 +457,7 @@ s32_t stm32_i2c_configure_timing(struct device *dev, u32_t clock)
 	struct i2c_stm32_data *data = DEV_DATA(dev);
 	I2C_TypeDef *i2c = cfg->i2c;
 
-	switch (data->dev_config.bits.speed) {
+	switch (I2C_GET_SPEED(data->dev_config.raw)) {
 	case I2C_SPEED_STANDARD:
 		LL_I2C_ConfigSpeed(i2c, clock, 100000, LL_I2C_DUTYCYCLE_2);
 		break;

--- a/drivers/i2c/i2c_ll_stm32_v2.c
+++ b/drivers/i2c/i2c_ll_stm32_v2.c
@@ -28,7 +28,7 @@ static inline void msg_init(struct device *dev, struct i2c_msg *msg,
 	I2C_TypeDef *i2c = cfg->i2c;
 	unsigned int len = msg->len;
 
-	if (data->dev_config.bits.use_10_bit_addr) {
+	if (I2C_GET_ADDR_10_BITS(data->dev_config.raw)) {
 		LL_I2C_SetMasterAddressingMode(i2c,
 						LL_I2C_ADDRESSING_MODE_10BIT);
 		LL_I2C_SetSlaveAddr(i2c, (uint32_t) slave);
@@ -264,7 +264,7 @@ int stm32_i2c_configure_timing(struct device *dev, u32_t clock)
 	u32_t presc = 1;
 	u32_t timing = 0;
 
-	switch (data->dev_config.bits.speed) {
+	switch (I2C_GET_SPEED(data->dev_config.raw)) {
 	case I2C_SPEED_STANDARD:
 		i2c_h_min_time = 4000;
 		i2c_l_min_time = 4700;

--- a/drivers/i2c/i2c_mcux.c
+++ b/drivers/i2c/i2c_mcux.c
@@ -36,19 +36,18 @@ static int i2c_mcux_configure(struct device *dev, u32_t dev_config_raw)
 {
 	I2C_Type *base = DEV_BASE(dev);
 	const struct i2c_mcux_config *config = DEV_CFG(dev);
-	union dev_config dev_config = (union dev_config)dev_config_raw;
 	u32_t clock_freq;
 	u32_t baudrate;
 
-	if (!dev_config.bits.is_master_device) {
+	if (!I2C_GET_MODE_MASTER(dev_config_raw)) {
 		return -EINVAL;
 	}
 
-	if (dev_config.bits.use_10_bit_addr) {
+	if (I2C_GET_ADDR_10_BITS(dev_config_raw)) {
 		return -EINVAL;
 	}
 
-	switch (dev_config.bits.speed) {
+	switch (I2C_GET_SPEED(dev_config_raw)) {
 	case I2C_SPEED_STANDARD:
 		baudrate = KHZ(100);
 		break;

--- a/drivers/i2c/i2c_nrf5.c
+++ b/drivers/i2c/i2c_nrf5.c
@@ -50,16 +50,15 @@ struct i2c_nrf5_data {
 static int i2c_nrf5_configure(struct device *dev, u32_t dev_config_raw)
 {
 	const struct i2c_nrf5_config *config = dev->config->config_info;
-	union dev_config dev_config = (union dev_config)dev_config_raw;
 	volatile NRF_TWI_Type *twi = config->base;
 
 	SYS_LOG_DBG("");
 
-	if (dev_config.bits.use_10_bit_addr) {
+	if (I2C_GET_ADDR_10_BITS(dev_config_raw)) {
 		return -EINVAL;
 	}
 
-	switch (dev_config.bits.speed) {
+	switch (I2C_GET_SPEED(dev_config_raw)) {
 	case I2C_SPEED_STANDARD:
 		twi->FREQUENCY = TWI_FREQUENCY_FREQUENCY_K100;
 		break;

--- a/drivers/i2c/i2c_qmsi.c
+++ b/drivers/i2c/i2c_qmsi.c
@@ -144,21 +144,21 @@ static int i2c_qmsi_configure(struct device *dev, u32_t config)
 	qm_i2c_t instance = GET_CONTROLLER_INSTANCE(dev);
 	struct i2c_qmsi_driver_data *driver_data = GET_DRIVER_DATA(dev);
 	qm_i2c_reg_t *const controller = QM_I2C[instance];
-	union dev_config cfg;
 	int rc;
 	qm_i2c_config_t qm_cfg;
 
-	cfg.raw = config;
-
 	/* This driver only supports master mode. */
-	if (!cfg.bits.is_master_device)
+	if (!I2C_GET_MODE_MASTER(config))
 		return -EINVAL;
 
 	qm_cfg.mode = QM_I2C_MASTER;
-	qm_cfg.address_mode = (cfg.bits.use_10_bit_addr) ? QM_I2C_10_BIT :
-							   QM_I2C_7_BIT;
+	if (I2C_GET_ADDR_10_BITS(config)) {
+		qm_cfg.address_mode = QM_I2C_10_BIT;
+	} else {
+		qm_cfg.address_mode = QM_I2C_7_BIT;
+	}
 
-	switch (cfg.bits.speed) {
+	switch (I2C_GET_SPEED(config)) {
 	case I2C_SPEED_STANDARD:
 		qm_cfg.speed = QM_I2C_SPEED_STD;
 		break;

--- a/drivers/i2c/i2c_qmsi_ss.c
+++ b/drivers/i2c/i2c_qmsi_ss.c
@@ -223,21 +223,21 @@ static int i2c_qmsi_ss_configure(struct device *dev, u32_t config)
 {
 	qm_ss_i2c_t instance = GET_CONTROLLER_INSTANCE(dev);
 	struct i2c_qmsi_ss_driver_data *driver_data = GET_DRIVER_DATA(dev);
-	union dev_config cfg;
 	qm_ss_i2c_config_t qm_cfg;
 	u32_t i2c_base = QM_SS_I2C_0_BASE;
 
-	cfg.raw = config;
-
 	/* This driver only supports master mode. */
-	if (!cfg.bits.is_master_device) {
+	if (!I2C_GET_MODE_MASTER(config)) {
 		return -EINVAL;
 	}
 
-	qm_cfg.address_mode = (cfg.bits.use_10_bit_addr) ? QM_SS_I2C_10_BIT :
-							   QM_SS_I2C_7_BIT;
+	if (I2C_GET_ADDR_10_BITS(config)) {
+		qm_cfg.address_mode = QM_I2C_10_BIT;
+	} else {
+		qm_cfg.address_mode = QM_I2C_7_BIT;
+	}
 
-	switch (cfg.bits.speed) {
+	switch (I2C_GET_SPEED(config)) {
 	case I2C_SPEED_STANDARD:
 		qm_cfg.speed = QM_SS_I2C_SPEED_STD;
 		break;

--- a/drivers/i2c/twihs_sam.c
+++ b/drivers/i2c/twihs_sam.c
@@ -106,7 +106,7 @@ static int twihs_sam_configure(struct device *dev, u32_t config)
 	dev_data->mode_config.raw = config;
 
 	/* Configure clock */
-	switch ((dev_data->mode_config.bits.speed)) {
+	switch (I2C_GET_SPEED(dev_data->dev_config.raw)) {
 	case I2C_SPEED_STANDARD:
 		i2c_speed = BUS_SPEED_STANDARD_HZ;
 		break;

--- a/include/i2c.h
+++ b/include/i2c.h
@@ -48,13 +48,25 @@ extern "C" {
 /** @cond INTERNAL_HIDDEN */
 #define I2C_SPEED_SHIFT			(1)
 #define I2C_SPEED_MASK			(0x7 << I2C_SPEED_SHIFT) /* 3 bits */
+#define I2C_GET_SPEED(x) 		(((x) & I2C_SPEED_MASK) \
+						>> I2C_SPEED_SHIFT)
 /** @endcond  */
 
 /** Use 10-bit addressing. */
 #define I2C_ADDR_10_BITS		(1 << 0)
 
+/** @cond INTERNAL_HIDDEN */
+#define I2C_GET_ADDR_10_BITS(x)		((x) & I2C_ADDR_10_BITS)
+/** @endcond  */
+
 /** Controller to act as Master. */
 #define I2C_MODE_MASTER			(1 << 4)
+
+/** @cond INTERNAL_HIDDEN */
+#define I2C_MODE_MASTER_SHIFT		4
+#define I2C_GET_MODE_MASTER(x)		(((x) & I2C_MODE_MASTER) \
+						>> I2C_MODE_MASTER_SHIFT)
+/** @endcond  */
 
 /*
  * I2C_MSG_* are I2C Message flags.


### PR DESCRIPTION
Cleanup I2C drivers to not use bitfield access for config information
and instead use accessor macros that use shifts & masks.  This is
cleanup towards removing the bitfield access in the future.

Signed-off-by: Kumar Gala <kumar.gala@linaro.org>