### PR TITLE
drivers: i2c: remove usage of bitfield access for cfg

### DIFF
--- a/drivers/i2c/i2c_bitbang.c
+++ b/drivers/i2c/i2c_bitbang.c
@@ -51,15 +51,13 @@ static const u32_t delays_standard[] = {
 
 int i2c_bitbang_configure(struct i2c_bitbang *context, u32_t dev_config)
 {
-	union dev_config config = { .raw = dev_config };
-
 	/* Check for features we don't support */
-	if (config.bits.use_10_bit_addr) {
+	if (I2C_ADDR_10_BITS & dev_config) {
 		return -ENOTSUP;
 	}
 
 	/* Setup speed to use */
-	switch (config.bits.speed) {
+	switch (I2C_SPEED_GET(dev_config)) {
 	case I2C_SPEED_STANDARD:
 		context->delays = delays_standard;
 		break;
@@ -268,9 +266,7 @@ finish:
 void i2c_bitbang_init(struct i2c_bitbang *context,
 			const struct i2c_bitbang_io *io, void *io_context)
 {
-	union dev_config dev_config = { .bits.speed = I2C_SPEED_STANDARD };
-
 	context->io = io;
 	context->io_context = io_context;
-	i2c_bitbang_configure(context, dev_config.raw);
+	i2c_bitbang_configure(context, I2C_SPEED_STANDARD << I2C_SPEED_SHIFT);
 }

--- a/drivers/i2c/i2c_dw.h
+++ b/drivers/i2c/i2c_dw.h
@@ -98,7 +98,7 @@ struct i2c_dw_rom_config {
 struct i2c_dw_dev_config {
 	u32_t base_address;
 	struct k_sem		device_sync_sem;
-	union dev_config	app_config;
+	u32_t app_config;
 
 
 	u8_t			*xfr_buf;

--- a/drivers/i2c/i2c_ll_stm32.c
+++ b/drivers/i2c/i2c_ll_stm32.c
@@ -25,7 +25,7 @@ static int i2c_stm32_runtime_configure(struct device *dev, u32_t config)
 	I2C_TypeDef *i2c = cfg->i2c;
 	u32_t clock;
 
-	data->dev_config.raw = config;
+	data->dev_config = config;
 
 	clock_control_get_rate(device_get_binding(STM32_CLOCK_CONTROL_NAME),
 			(clock_control_subsys_t *) &cfg->pclken, &clock);

--- a/drivers/i2c/i2c_ll_stm32.h
+++ b/drivers/i2c/i2c_ll_stm32.h
@@ -24,7 +24,7 @@ struct i2c_stm32_data {
 #ifdef CONFIG_I2C_STM32_INTERRUPT
 	struct k_sem device_sync_sem;
 #endif
-	union dev_config dev_config;
+	u32_t dev_config;
 #ifdef CONFIG_I2C_STM32_V1
 	u16_t slave_address;
 #endif

--- a/drivers/i2c/i2c_ll_stm32_v1.c
+++ b/drivers/i2c/i2c_ll_stm32_v1.c
@@ -30,7 +30,7 @@ static inline void handle_sb(I2C_TypeDef *i2c, struct i2c_stm32_data *data)
 	u16_t saddr = data->slave_address;
 	u8_t slave;
 
-	if (data->dev_config.bits.use_10_bit_addr) {
+	if (I2C_ADDR_10_BITS & data->dev_config) {
 		slave = (((saddr & 0x0300) >> 7) & 0xFF);
 		u8_t header = slave | HEADER;
 
@@ -54,7 +54,7 @@ static inline void handle_sb(I2C_TypeDef *i2c, struct i2c_stm32_data *data)
 
 static inline void handle_addr(I2C_TypeDef *i2c, struct i2c_stm32_data *data)
 {
-	if (data->dev_config.bits.use_10_bit_addr) {
+	if (I2C_ADDR_10_BITS & data->dev_config) {
 		if (!data->current.is_write && data->current.is_restart) {
 			data->current.is_restart = 0;
 			LL_I2C_ClearFlag_ADDR(i2c);
@@ -307,7 +307,8 @@ s32_t stm32_i2c_msg_write(struct device *dev, struct i2c_msg *msg,
 	while (!LL_I2C_IsActiveFlag_SB(i2c)) {
 		;
 	}
-	if (data->dev_config.bits.use_10_bit_addr) {
+
+	if (I2C_ADDR_10_BITS & data->dev_config) {
 		u8_t slave = (((saddr & 0x0300) >> 7) & 0xFF);
 		u8_t header = slave | HEADER;
 
@@ -366,7 +367,8 @@ s32_t stm32_i2c_msg_read(struct device *dev, struct i2c_msg *msg,
 	while (!LL_I2C_IsActiveFlag_SB(i2c)) {
 		;
 	}
-	if (data->dev_config.bits.use_10_bit_addr) {
+
+	if (I2C_ADDR_10_BITS & data->dev_config) {
 		u8_t slave = (((saddr &	0x0300) >> 7) & 0xFF);
 		u8_t header = slave | HEADER;
 
@@ -457,7 +459,7 @@ s32_t stm32_i2c_configure_timing(struct device *dev, u32_t clock)
 	struct i2c_stm32_data *data = DEV_DATA(dev);
 	I2C_TypeDef *i2c = cfg->i2c;
 
-	switch (data->dev_config.bits.speed) {
+	switch (I2C_SPEED_GET(data->dev_config)) {
 	case I2C_SPEED_STANDARD:
 		LL_I2C_ConfigSpeed(i2c, clock, 100000, LL_I2C_DUTYCYCLE_2);
 		break;

--- a/drivers/i2c/i2c_ll_stm32_v2.c
+++ b/drivers/i2c/i2c_ll_stm32_v2.c
@@ -28,7 +28,7 @@ static inline void msg_init(struct device *dev, struct i2c_msg *msg,
 	I2C_TypeDef *i2c = cfg->i2c;
 	unsigned int len = msg->len;
 
-	if (data->dev_config.bits.use_10_bit_addr) {
+	if (I2C_ADDR_10_BITS & data->dev_config) {
 		LL_I2C_SetMasterAddressingMode(i2c,
 						LL_I2C_ADDRESSING_MODE_10BIT);
 		LL_I2C_SetSlaveAddr(i2c, (uint32_t) slave);
@@ -264,7 +264,7 @@ int stm32_i2c_configure_timing(struct device *dev, u32_t clock)
 	u32_t presc = 1;
 	u32_t timing = 0;
 
-	switch (data->dev_config.bits.speed) {
+	switch (I2C_SPEED_GET(data->dev_config)) {
 	case I2C_SPEED_STANDARD:
 		i2c_h_min_time = 4000;
 		i2c_l_min_time = 4700;

--- a/drivers/i2c/i2c_mcux.c
+++ b/drivers/i2c/i2c_mcux.c
@@ -36,19 +36,18 @@ static int i2c_mcux_configure(struct device *dev, u32_t dev_config_raw)
 {
 	I2C_Type *base = DEV_BASE(dev);
 	const struct i2c_mcux_config *config = DEV_CFG(dev);
-	union dev_config dev_config = (union dev_config)dev_config_raw;
 	u32_t clock_freq;
 	u32_t baudrate;
 
-	if (!dev_config.bits.is_master_device) {
+	if (!(I2C_MODE_MASTER & dev_config_raw)) {
 		return -EINVAL;
 	}
 
-	if (dev_config.bits.use_10_bit_addr) {
+	if (I2C_ADDR_10_BITS & dev_config_raw) {
 		return -EINVAL;
 	}
 
-	switch (dev_config.bits.speed) {
+	switch (I2C_SPEED_GET(dev_config_raw)) {
 	case I2C_SPEED_STANDARD:
 		baudrate = KHZ(100);
 		break;

--- a/drivers/i2c/i2c_nrf5.c
+++ b/drivers/i2c/i2c_nrf5.c
@@ -33,7 +33,7 @@
 struct i2c_nrf5_config {
 	volatile NRF_TWI_Type *base;
 	void (*irq_config_func)(struct device *dev);
-	union dev_config default_cfg;
+	u32_t default_cfg;
 };
 
 
@@ -50,16 +50,15 @@ struct i2c_nrf5_data {
 static int i2c_nrf5_configure(struct device *dev, u32_t dev_config_raw)
 {
 	const struct i2c_nrf5_config *config = dev->config->config_info;
-	union dev_config dev_config = (union dev_config)dev_config_raw;
 	volatile NRF_TWI_Type *twi = config->base;
 
 	SYS_LOG_DBG("");
 
-	if (dev_config.bits.use_10_bit_addr) {
+	if (I2C_ADDR_10_BITS & dev_config_raw) {
 		return -EINVAL;
 	}
 
-	switch (dev_config.bits.speed) {
+	switch (I2C_SPEED_GET(dev_config_raw)) {
 	case I2C_SPEED_STANDARD:
 		twi->FREQUENCY = TWI_FREQUENCY_FREQUENCY_K100;
 		break;
@@ -311,7 +310,7 @@ static int i2c_nrf5_init(struct device *dev)
 			 | NRF5_TWI_INT_ERROR
 			 | NRF5_TWI_INT_STOPPED);
 
-	status = i2c_nrf5_configure(dev, config->default_cfg.raw);
+	status = i2c_nrf5_configure(dev, config->default_cfg);
 	if (status) {
 		return status;
 	}
@@ -333,7 +332,7 @@ static void i2c_nrf5_config_func_0(struct device *dev);
 static const struct i2c_nrf5_config i2c_nrf5_config_0 = {
 	.base = NRF_TWI0,
 	.irq_config_func = i2c_nrf5_config_func_0,
-	.default_cfg.raw = CONFIG_I2C_0_DEFAULT_CFG,
+	.default_cfg = CONFIG_I2C_0_DEFAULT_CFG,
 };
 
 static struct i2c_nrf5_data i2c_nrf5_data_0;
@@ -358,7 +357,7 @@ static void i2c_nrf5_config_func_1(struct device *dev);
 static const struct i2c_nrf5_config i2c_nrf5_config_1 = {
 	.base = NRF_TWI1,
 	.irq_config_func = i2c_nrf5_config_func_1,
-	.default_cfg.raw = CONFIG_I2C_1_DEFAULT_CFG,
+	.default_cfg = CONFIG_I2C_1_DEFAULT_CFG,
 };
 
 static struct i2c_nrf5_data i2c_nrf5_data_1;

--- a/drivers/i2c/i2c_qmsi.c
+++ b/drivers/i2c/i2c_qmsi.c
@@ -25,7 +25,7 @@
 
 struct i2c_qmsi_config_info {
 	qm_i2c_t instance; /* Controller instance. */
-	union dev_config default_cfg;
+	u32_t default_cfg;
 	clk_periph_t clock_gate;
 };
 
@@ -113,7 +113,7 @@ static struct i2c_qmsi_driver_data driver_data_0;
 
 static const struct i2c_qmsi_config_info config_info_0 = {
 	.instance = QM_I2C_0,
-	.default_cfg.raw = CONFIG_I2C_0_DEFAULT_CFG,
+	.default_cfg = CONFIG_I2C_0_DEFAULT_CFG,
 	.clock_gate = CLK_PERIPH_I2C_M0_REGISTER | CLK_PERIPH_CLK,
 };
 
@@ -129,7 +129,7 @@ static struct i2c_qmsi_driver_data driver_data_1;
 
 static const struct i2c_qmsi_config_info config_info_1 = {
 	.instance = QM_I2C_1,
-	.default_cfg.raw = CONFIG_I2C_1_DEFAULT_CFG,
+	.default_cfg = CONFIG_I2C_1_DEFAULT_CFG,
 	.clock_gate = CLK_PERIPH_I2C_M1_REGISTER | CLK_PERIPH_CLK,
 };
 
@@ -144,21 +144,21 @@ static int i2c_qmsi_configure(struct device *dev, u32_t config)
 	qm_i2c_t instance = GET_CONTROLLER_INSTANCE(dev);
 	struct i2c_qmsi_driver_data *driver_data = GET_DRIVER_DATA(dev);
 	qm_i2c_reg_t *const controller = QM_I2C[instance];
-	union dev_config cfg;
 	int rc;
 	qm_i2c_config_t qm_cfg;
 
-	cfg.raw = config;
-
 	/* This driver only supports master mode. */
-	if (!cfg.bits.is_master_device)
+	if (!(I2C_MODE_MASTER & config))
 		return -EINVAL;
 
 	qm_cfg.mode = QM_I2C_MASTER;
-	qm_cfg.address_mode = (cfg.bits.use_10_bit_addr) ? QM_I2C_10_BIT :
-							   QM_I2C_7_BIT;
+	if (I2C_ADDR_10_BITS & config) {
+		qm_cfg.address_mode = QM_I2C_10_BIT;
+	} else {
+		qm_cfg.address_mode = QM_I2C_7_BIT;
+	}
 
-	switch (cfg.bits.speed) {
+	switch (I2C_SPEED_GET(config)) {
 	case I2C_SPEED_STANDARD:
 		qm_cfg.speed = QM_I2C_SPEED_STD;
 		break;
@@ -293,7 +293,7 @@ static int i2c_qmsi_init(struct device *dev)
 
 	clk_periph_enable(config->clock_gate);
 
-	err = i2c_qmsi_configure(dev, config->default_cfg.raw);
+	err = i2c_qmsi_configure(dev, config->default_cfg);
 	if (err < 0) {
 		return err;
 	}

--- a/drivers/i2c/i2c_qmsi_ss.c
+++ b/drivers/i2c/i2c_qmsi_ss.c
@@ -22,7 +22,7 @@
 
 struct i2c_qmsi_ss_config_info {
 	qm_ss_i2c_t instance; /* Controller instance. */
-	union dev_config default_cfg;
+	u32_t default_cfg;
 	void (*irq_cfg)(void);
 };
 
@@ -113,7 +113,7 @@ static void i2c_qmsi_ss_config_irq_0(void);
 
 static const struct i2c_qmsi_ss_config_info config_info_0 = {
 	.instance = QM_SS_I2C_0,
-	.default_cfg.raw = CONFIG_I2C_SS_0_DEFAULT_CFG,
+	.default_cfg = CONFIG_I2C_SS_0_DEFAULT_CFG,
 	.irq_cfg = i2c_qmsi_ss_config_irq_0,
 };
 
@@ -170,7 +170,7 @@ static void i2c_qmsi_ss_config_irq_1(void);
 
 static const struct i2c_qmsi_ss_config_info config_info_1 = {
 	.instance = QM_SS_I2C_1,
-	.default_cfg.raw = CONFIG_I2C_SS_1_DEFAULT_CFG,
+	.default_cfg = CONFIG_I2C_SS_1_DEFAULT_CFG,
 	.irq_cfg = i2c_qmsi_ss_config_irq_1,
 };
 
@@ -223,21 +223,21 @@ static int i2c_qmsi_ss_configure(struct device *dev, u32_t config)
 {
 	qm_ss_i2c_t instance = GET_CONTROLLER_INSTANCE(dev);
 	struct i2c_qmsi_ss_driver_data *driver_data = GET_DRIVER_DATA(dev);
-	union dev_config cfg;
 	qm_ss_i2c_config_t qm_cfg;
 	u32_t i2c_base = QM_SS_I2C_0_BASE;
 
-	cfg.raw = config;
-
 	/* This driver only supports master mode. */
-	if (!cfg.bits.is_master_device) {
+	if (!(I2C_MODE_MASTER & config)) {
 		return -EINVAL;
 	}
 
-	qm_cfg.address_mode = (cfg.bits.use_10_bit_addr) ? QM_SS_I2C_10_BIT :
-							   QM_SS_I2C_7_BIT;
+	if (I2C_ADDR_10_BITS & config) {
+		qm_cfg.address_mode = QM_SS_I2C_10_BIT;
+	} else {
+		qm_cfg.address_mode = QM_SS_I2C_7_BIT;
+	}
 
-	switch (cfg.bits.speed) {
+	switch (I2C_SPEED_GET(config)) {
 	case I2C_SPEED_STANDARD:
 		qm_cfg.speed = QM_SS_I2C_SPEED_STD;
 		break;
@@ -352,7 +352,7 @@ static int i2c_qmsi_ss_init(struct device *dev)
 
 	k_sem_init(&driver_data->sem, 1, UINT_MAX);
 
-	err = i2c_qmsi_ss_configure(dev, config->default_cfg.raw);
+	err = i2c_qmsi_ss_configure(dev, config->default_cfg);
 
 	if (err < 0) {
 		return err;

--- a/drivers/i2c/twihs_sam.c
+++ b/drivers/i2c/twihs_sam.c
@@ -54,7 +54,7 @@ struct twihs_msg {
 /* Device run time data */
 struct twihs_sam_dev_data {
 	struct k_sem sem;
-	union dev_config mode_config;
+	u32_t mode_config;
 	struct twihs_msg msg;
 };
 
@@ -103,10 +103,10 @@ static int twihs_sam_configure(struct device *dev, u32_t config)
 		return -EIO;
 	}
 
-	dev_data->mode_config.raw = config;
+	dev_data->mode_config = config;
 
 	/* Configure clock */
-	switch ((dev_data->mode_config.bits.speed)) {
+	switch (I2C_SPEED_GET(dev_data->dev_config)) {
 	case I2C_SPEED_STANDARD:
 		i2c_speed = BUS_SPEED_STANDARD_HZ;
 		break;
@@ -275,7 +275,7 @@ static int twihs_sam_initialize(struct device *dev)
 	/* Reset TWI module */
 	twihs->TWIHS_CR = TWIHS_CR_SWRST;
 
-	result = twihs_sam_configure(dev, dev_data->mode_config.raw);
+	result = twihs_sam_configure(dev, dev_data->mode_config);
 	if (result < 0) {
 		return result;
 	}
@@ -314,7 +314,7 @@ static const struct twihs_sam_dev_cfg i2c0_sam_config = {
 };
 
 static struct twihs_sam_dev_data i2c0_sam_data = {
-	.mode_config.raw = CONFIG_I2C_0_DEFAULT_CFG,
+	.mode_config = CONFIG_I2C_0_DEFAULT_CFG,
 };
 
 DEVICE_AND_API_INIT(i2c0_sam, CONFIG_I2C_0_NAME, &twihs_sam_initialize,
@@ -345,7 +345,7 @@ static const struct twihs_sam_dev_cfg i2c1_sam_config = {
 };
 
 static struct twihs_sam_dev_data i2c1_sam_data = {
-	.mode_config.raw = CONFIG_I2C_1_DEFAULT_CFG,
+	.mode_config = CONFIG_I2C_1_DEFAULT_CFG,
 };
 
 DEVICE_AND_API_INIT(i2c1_sam, CONFIG_I2C_1_NAME, &twihs_sam_initialize,
@@ -376,7 +376,7 @@ static const struct twihs_sam_dev_cfg i2c2_sam_config = {
 };
 
 static struct twihs_sam_dev_data i2c2_sam_data = {
-	.mode_config.raw = CONFIG_I2C_2_DEFAULT_CFG,
+	.mode_config = CONFIG_I2C_2_DEFAULT_CFG,
 };
 
 DEVICE_AND_API_INIT(i2c2_sam, CONFIG_I2C_2_NAME, &twihs_sam_initialize,

--- a/include/i2c.h
+++ b/include/i2c.h
@@ -48,6 +48,8 @@ extern "C" {
 /** @cond INTERNAL_HIDDEN */
 #define I2C_SPEED_SHIFT			(1)
 #define I2C_SPEED_MASK			(0x7 << I2C_SPEED_SHIFT) /* 3 bits */
+#define I2C_SPEED_GET(cfg) 		(((cfg) & I2C_SPEED_MASK) \
+						>> I2C_SPEED_SHIFT)
 /** @endcond  */
 
 /** Use 10-bit addressing. */


### PR DESCRIPTION
Cleanup I2C drivers to not use bitfield access for config information
and instead use accessor macros that use shifts & masks.  This is
cleanup towards removing the bitfield access in the future.

Signed-off-by: Kumar Gala <kumar.gala@linaro.org>