### PR TITLE
net: if: Lack of default interface is an error, not warning.

### DIFF
--- a/subsys/net/ip/net_if.c
+++ b/subsys/net/ip/net_if.c
@@ -1773,7 +1773,7 @@ void net_if_init(struct k_sem *startup_sync)
 	}
 
 	if (iface == __net_if_start) {
-		NET_WARN("There is no network interface to work with!");
+		NET_ERR("There is no network interface to work with!");
 		return;
 	}
 


### PR DESCRIPTION
Because a next networking API call will lead to a crash. Given that
logging can be easily disabled (disabled by default so far!), don't
be shy and call by the name (i.e. error).

Jira: ZEP-2105

Signed-off-by: Paul Sokolovsky <paul.sokolovsky@linaro.org>