### PR TITLE
net: Do not try to parse empty IP address string

### DIFF
--- a/subsys/net/ip/utils.c
+++ b/subsys/net/ip/utils.c
@@ -683,6 +683,15 @@ bool net_ipaddr_parse(const char *str, size_t str_len, struct sockaddr *addr)
 {
 	int i, count;
 
+	if (!str || str_len == 0) {
+		return false;
+	}
+
+	/* We cannot accept empty string here */
+	if (*str == '\0') {
+		return false;
+	}
+
 	if (*str == '[') {
 #if defined(CONFIG_NET_IPV6)
 		return parse_ipv6(str, str_len, addr, true);


### PR DESCRIPTION
If the IP address string is empty, then it is no use trying
to parse it. This was seen when handling DNS server strings when
user has made a mistake and defined the DNS server addresses
incorrectly.

Signed-off-by: Jukka Rissanen <jukka.rissanen@linux.intel.com>