### PR TITLE
cmake: Use --sysroot instead of -nostdinc and -isystem

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -201,12 +201,7 @@ if(IS_TEST)
 endif()
 
 set_ifndef(LINKERFLAGPREFIX -Wl)
-zephyr_link_libraries(
-  ${LINKERFLAGPREFIX},-X
-  ${LINKERFLAGPREFIX},-N
-  ${LINKERFLAGPREFIX},--gc-sections
-  ${LINKERFLAGPREFIX},--build-id=none
-  )
+zephyr_link_libraries(${LINKERFLAGPREFIX},-X,-N,--gc-sections,--build-id=none)
 
 if(CONFIG_HAVE_CUSTOM_LINKER_SCRIPT)
   set(LINKER_SCRIPT ${PROJECT_BASE}/${CONFIG_CUSTOM_LINKER_SCRIPT})

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -78,6 +78,7 @@ zephyr_compile_options(
   -Wno-main
   -ffreestanding
   -include ${AUTOCONF_H}
+  --sysroot=${SYSROOT_DIR}
 )
 
 zephyr_compile_options(
@@ -185,9 +186,6 @@ endif()
 
 zephyr_cc_option_ifdef(CONFIG_DEBUG_SECTION_MISMATCH -fno-inline-functions-called-once)
 zephyr_cc_option_ifdef(CONFIG_STACK_USAGE            -fstack-usage)
-
-zephyr_compile_options(-nostdinc)
-zephyr_system_include_directories(${NOSTDINC})
 
 # Force an error when things like SYS_INIT(foo, ...) occur with a missing header.
 zephyr_cc_option(-Werror=implicit-int)

--- a/cmake/toolchain-zephyr.cmake
+++ b/cmake/toolchain-zephyr.cmake
@@ -127,20 +127,6 @@ set(CMAKE_OBJDUMP      ${CROSS_COMPILE}objdump CACHE INTERNAL " " FORCE)
 set(CMAKE_AR           ${CROSS_COMPILE}ar      CACHE INTERNAL " " FORCE)
 set(CMAKE_RANLILB      ${CROSS_COMPILE}ranlib  CACHE INTERNAL " " FORCE)
 
-execute_process(
-  COMMAND ${CMAKE_C_COMPILER} --print-file-name=include
-  OUTPUT_VARIABLE _OUTPUT
-)
-string(REGEX REPLACE "\n" "" _OUTPUT ${_OUTPUT})
-set(NOSTDINC ${_OUTPUT})
-
-execute_process(
-  COMMAND ${CMAKE_C_COMPILER} --print-file-name=include-fixed
-  OUTPUT_VARIABLE _OUTPUT
-)
-string(REGEX REPLACE "\n" "" _OUTPUT ${_OUTPUT})
-list(APPEND NOSTDINC ${_OUTPUT})
-
 set(SYSROOT_DIR ${ZEPHYR_SDK_INSTALL_DIR}/sysroots/${SYSROOT_TARGET})
 
 execute_process(


### PR DESCRIPTION
Signed-off-by: Sebastian Boe <sebastian.boe@nordicsemi.no>