### PR TITLE
Bluetooth: controller: Fix handling of Read Static Addrs cmd

### DIFF
--- a/subsys/bluetooth/controller/hci/hci.c
+++ b/subsys/bluetooth/controller/hci/hci.c
@@ -1707,6 +1707,7 @@ static void vs_read_static_addrs(struct net_buf *buf, struct net_buf **evt)
 		struct bt_hci_vs_static_addr *addr;
 
 		rp = cmd_complete(evt, sizeof(*rp) + sizeof(*addr));
+		rp->status = 0x00;
 		rp->num_addrs = 1;
 
 		addr = &rp->a[0];


### PR DESCRIPTION
The status in the Command Complete event was uninitialized, leading to
incorrect contents of the event parsed by the Host. Correctly initialize
the status to success.

Signed-off-by: Carles Cufi <carles.cufi@nordicsemi.no>