### PR TITLE
Bluetooth: controller: Fix conn param req procedure timeout

### DIFF
--- a/subsys/bluetooth/controller/ll_sw/ctrl.c
+++ b/subsys/bluetooth/controller/ll_sw/ctrl.c
@@ -2760,6 +2760,9 @@ isr_rx_conn_pkt_ctrl(struct radio_pdu_node_rx *radio_pdu_node_rx,
 				break;
 			}
 
+			/* Stop procedure timeout */
+			_radio.conn_curr->procedure_expire = 0;
+
 			/* save parameters to be used to select offset
 			 */
 			conn->llcp_conn_param.interval = cpr->interval_min;


### PR DESCRIPTION
Fixed a bug in the implementation of Connection Parameter
Request Procedure when initiated in master role caused the
connection to terminate with reason LL response timeout.

Signed-off-by: Vinayak Kariappa Chettimada <vich@nordicsemi.no>