### PR TITLE
RFC net: arp: Enable logging if CONFIG_NET_LOG_GLOBAL is set

### DIFF
--- a/subsys/net/ip/l2/arp.c
+++ b/subsys/net/ip/l2/arp.c
@@ -8,7 +8,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#if defined(CONFIG_NET_DEBUG_ARP)
+#if defined(CONFIG_NET_DEBUG_ARP) || defined(CONFIG_NET_LOG_GLOBAL)
 #define SYS_LOG_DOMAIN "net/arp"
 #define NET_LOG_ENABLED 1
 #endif


### PR DESCRIPTION
CONFIG_NET_LOG_GLOBAL is implemented in net/ip/Kconfig by explicitly
enabling various components' logging. But such approach doesn't
scale, e.g. to component which are related to net (and there're many)
but which aren't in the same dir. Approach used in this patch is
more scalable.

Signed-off-by: Paul Sokolovsky <paul.sokolovsky@linaro.org>