### PR TITLE
net: arp: Log error if no gateway is set

### DIFF
--- a/subsys/net/ip/l2/arp.c
+++ b/subsys/net/ip/l2/arp.c
@@ -222,6 +222,10 @@ struct net_pkt *net_arp_prepare(struct net_pkt *pkt)
 	if (!net_if_ipv4_addr_mask_cmp(net_pkt_iface(pkt),
 				       &NET_IPV4_HDR(pkt)->dst)) {
 		addr = &net_pkt_iface(pkt)->ipv4.gw;
+		if (IS_ENABLED(CONFIG_NET_DEBUG_ARP)
+		    && net_is_ipv4_addr_unspecified(addr)) {
+			NET_ERR("Gateway not set for iface %p", net_pkt_iface(pkt));
+		}
 	} else {
 		addr = &NET_IPV4_HDR(pkt)->dst;
 	}


### PR DESCRIPTION
If no gateway is set, an ARP request for 0.0.0.0 will be sent out,
which is confusing, so log as an error. Of course, logging will
happen only if enabled.

Signed-off-by: Paul Sokolovsky <paul.sokolovsky@linaro.org>