### PR TITLE
scripts: allow "title" in commit titles

### DIFF
--- a/.gitlint
+++ b/.gitlint
@@ -25,7 +25,7 @@ regex = ^(([^:]+):)(\s([^:]+):)*\s(.+)$
 # Comma-separated list of words that should not occur in the title. Matching is case
 # insensitive. It's fine if the keyword occurs as part of a larger word (so "WIPING"
 # will not cause a violation, but "WIP: my title" will.
-words=wip,title
+words=wip
 
 [title-match-regex]
 # python like regex (https://docs.python.org/2/library/re.html) that the


### PR DESCRIPTION
gitlint was complaining about use of the word "title"
in PR #1512 doc: fix link title in linux installation guide

Signed-off-by: David B. Kinder <david.b.kinder@intel.com>