### PR TITLE
net: Enable logging in more modules if CONFIG_NET_LOG_GLOBAL defined

### DIFF
--- a/subsys/net/ip/l2/Kconfig
+++ b/subsys/net/ip/l2/Kconfig
@@ -25,6 +25,7 @@ config NET_L2_ETHERNET
 config NET_DEBUG_L2_ETHERNET
 	bool "Debug Ethernet L2 layer"
 	default n
+	default y if NET_LOG_GLOBAL
 	depends on NET_LOG
 	help
 	Enables Ethernet L2 output debug messages
@@ -38,6 +39,7 @@ config NET_OFFLOAD
 config NET_DEBUG_NET_OFFLOAD
 	bool "Debug Net Offload Layer"
 	default n
+	default y if NET_LOG_GLOBAL
 	depends on NET_LOG
 	depends on NET_OFFLOAD
 	help
@@ -83,6 +85,7 @@ config NET_L2_BT_SEC_LEVEL
 config NET_DEBUG_L2_BT
 	bool "Debug Bluetooth L2 layer"
 	default n
+	default y if NET_LOG_GLOBAL
 	depends on NET_LOG
 	depends on NET_L2_BT
 	help
@@ -125,6 +128,7 @@ config NET_DEBUG_ARP
 	bool "Debug IPv4 ARP"
 	depends on NET_ARP && NET_LOG
 	default n
+	default y if NET_LOG_GLOBAL
 	help
 	Enables core ARP code part to output debug messages
 

--- a/subsys/net/ip/l2/ieee802154/Kconfig
+++ b/subsys/net/ip/l2/ieee802154/Kconfig
@@ -21,6 +21,7 @@ config NET_L2_IEEE802154_MGMT
 config NET_DEBUG_L2_IEEE802154
 	bool "Enable IEEE 802.15.4 stack debug messages"
 	default n
+	default y if NET_LOG_GLOBAL
 	depends on NET_LOG
 	help
 	  Enable it if you want to see what's happening. Only useful
@@ -90,6 +91,7 @@ config  NET_DEBUG_L2_IEEE802154_FRAGMENT
 	bool "Enable debug support for IEEE 802.15.4 fragmentation"
 	depends on NET_L2_IEEE802154_FRAGMENT && NET_LOG
 	default n
+	default y if NET_LOG_GLOBAL
 
 config NET_L2_IEEE802154_SECURITY
 	bool "Enable IEEE 802.15.4 security [EXPERIMENTAL]"

--- a/subsys/net/lib/dns/Kconfig
+++ b/subsys/net/lib/dns/Kconfig
@@ -105,6 +105,7 @@ config DNS_NUM_CONCUR_QUERIES
 config NET_DEBUG_DNS_RESOLVE
 	bool "Debug DNS resolver"
 	default n
+	default y if NET_LOG_GLOBAL
 	help
 	Enables DNS resolver code to output debug messages
 

--- a/subsys/net/lib/sockets/Kconfig
+++ b/subsys/net/lib/sockets/Kconfig
@@ -35,6 +35,7 @@ config NET_SOCKETS_POLL_MAX
 config NET_DEBUG_SOCKETS
 	bool "Debug BSD Sockets compatible API calls"
 	default n
+	default y if NET_LOG_GLOBAL
 	help
 	Enables logging for sockets code. (Logging level is defined by
 	SYS_LOG_NET_LEVEL setting).


### PR DESCRIPTION
This is useful to enable error/warning logging across the net
codebase (less useful for debug level logging, but that's true
for CONFIG_NET_LOG_GLOBAL already).

Implementation-wise, instead of keeping adding to long list of
"select"'s in CONFIG_NET_LOG_GLOBAL and thus introduce component
inter-dependencies, add "default y if NET_LOG_GLOBAL" to
individual components' logging options.

Signed-off-by: Paul Sokolovsky <paul.sokolovsky@linaro.org>