### PR TITLE
LwM2M 1.10 changes: LwM2M library migrate to lwm2m_message + msg timeout callbacks

### DIFF
--- a/include/net/lwm2m.h
+++ b/include/net/lwm2m.h
@@ -27,9 +27,19 @@
 #define IPSO_OBJECT_LIGHT_CONTROL_ID			3311
 
 /**
- * LwM2M context structure
+ * @brief LwM2M context structure
  *
  * @details Context structure for the LwM2M high-level API.
+ *
+ * @param net_app_ctx Related network application context.
+ * @param net_init_timeout Used if the net_app API needs to do some time
+ *    consuming operation, like resolving DNS address.
+ * @param net_timeout How long to wait for the network connection before
+ *    giving up.
+ * @param tx_slab Network packet (net_pkt) memory pool for network contexts
+ *    attached to this LwM2M context.
+ * @param data_pool Network data net_buf pool for network contexts attached
+ *    to this LwM2M context.
  */
 struct lwm2m_ctx {
 	/** Net app context structure */
@@ -38,14 +48,7 @@ struct lwm2m_ctx {
 	s32_t net_timeout;
 
 #if defined(CONFIG_NET_CONTEXT_NET_PKT_POOL)
-	/** Network packet (net_pkt) memory pool for network contexts attached
-	 * to this LwM2M context.
-	 */
 	net_pkt_get_slab_func_t tx_slab;
-
-	/** Network data net_buf pool for network contexts attached to this
-	 * LwM2M context.
-	 */
 	net_pkt_get_pool_func_t data_pool;
 #endif /* CONFIG_NET_CONTEXT_NET_PKT_POOL */
 

--- a/subsys/net/lib/lwm2m/Kconfig
+++ b/subsys/net/lib/lwm2m/Kconfig
@@ -58,6 +58,7 @@ config LWM2M_ENGINE_MAX_OBSERVER
 config LWM2M_ENGINE_DEFAULT_LIFETIME
 	int "LWM2M engine default server connection lifetime"
 	default 30
+	range 15 65535
 	help
 	  Set the default lifetime (in seconds) for the LWM2M library engine
 

--- a/subsys/net/lib/lwm2m/Kconfig
+++ b/subsys/net/lib/lwm2m/Kconfig
@@ -29,6 +29,12 @@ config LWM2M_ENGINE_STACK_SIZE
 	 Set the stack size for the LWM2M library engine (used for handling
 	 OBSERVE and NOTIFY events)
 
+config LWM2M_ENGINE_MAX_MESSAGES
+	int "LWM2M engine max. message object"
+	default 10
+	help
+	  Set the maximum message objects for the LWM2M library client
+
 config LWM2M_ENGINE_MAX_PENDING
 	int "LWM2M engine max. pending objects"
 	default 5

--- a/subsys/net/lib/lwm2m/lwm2m_engine.h
+++ b/subsys/net/lib/lwm2m/lwm2m_engine.h
@@ -32,6 +32,9 @@
 #define NOTIFY_OBSERVER(o, i, r)	lwm2m_notify_observer(o, i, r)
 #define NOTIFY_OBSERVER_PATH(path)	lwm2m_notify_observer_path(path)
 
+/* Use this value to skip token generation */
+#define LWM2M_MSG_TOKEN_LEN_SKIP	0xFF
+
 char *lwm2m_sprint_ip_addr(const struct sockaddr *addr);
 
 int lwm2m_notify_observer(u16_t obj_id, u16_t obj_inst_id, u16_t res_id);


### PR DESCRIPTION
Patch set 2 of 7(or so).

This next patchset introduces the lwm2m_message structure which will simplify sending messages as it contains all the needed information to track an LwM2M message end to end.  This is needed to add a timeout callback function for if the message is never ACK'd.  Currently, if the registration server is down or goes down during any time the client will hang and never react accordingly.  The last patch is a result of the timeout change to make sure that we don't set the lifetime too low (<15 seconds) as this is the minimum needed time for a message to expire.  If set any lower we end up sending updates faster than we can handle timeouts.