### PR TITLE
Benchmark missing KPIs

### DIFF
--- a/tests/benchmarks/timing_info/src/thread_bench.c
+++ b/tests/benchmarks/timing_info/src/thread_bench.c
@@ -93,7 +93,7 @@ u32_t benchmarking_overhead_swap(void)
 #if CONFIG_ARM
 void read_timer_start_of_swap(void)
 {
-	__start_swap_time = GET_CURRENT_TIME();
+	__start_swap_time = (u32_t) GET_TIMER_VALUE();
 }
 
 void read_timer_end_of_swap(void)
@@ -109,22 +109,22 @@ void read_timer_end_of_swap(void)
  */
 void read_timer_start_of_isr(void)
 {
-	__start_intr_time  = (u32_t)SysTick->VAL;
+	__start_intr_time  = (u32_t) GET_TIMER_VALUE();
 }
 
 void read_timer_end_of_isr(void)
 {
-	__end_intr_time  = (u32_t)SysTick->VAL;
+	__end_intr_time  = (u32_t) GET_TIMER_VALUE();
 }
 
 void read_timer_start_of_tick_handler(void)
 {
-	__start_tick_time  = (u32_t)SysTick->VAL;
+	__start_tick_time  = (u32_t)GET_TIMER_VALUE();
 }
 
 void read_timer_end_of_tick_handler(void)
 {
-	 __end_tick_time  = (u32_t)SysTick->VAL;
+	 __end_tick_time  = (u32_t) GET_TIMER_VALUE();
 }
 
 #endif /* CONFIG_ARM */

--- a/tests/benchmarks/timing_info/src/timing_info.h
+++ b/tests/benchmarks/timing_info/src/timing_info.h
@@ -50,7 +50,7 @@ static inline void benchmark_timer_init(void)
 	NRF_TIMER2->TASKS_CLEAR = 1;	/* Clear Timer */
 	NRF_TIMER2->MODE = 0;		/* Timer Mode */
 	NRF_TIMER2->PRESCALER = 0;	/* 16M Hz */
-	NRF_TIMER2->BITMODE = 2;	/* 24 - bit */
+	NRF_TIMER2->BITMODE = 3;	/* 32 - bit */
 }
 
 /* Stop the timer */

--- a/tests/benchmarks/timing_info/src/timing_info.h
+++ b/tests/benchmarks/timing_info/src/timing_info.h
@@ -42,6 +42,7 @@ extern u64_t __end_tick_time;
 #define CYCLES_TO_NS(x) ((x) * (NANOSECS_PER_SEC/CYCLES_PER_SEC))
 #define PRINT_STATS(x, y, z)   PRINT_F(x, (y*((SystemCoreClock)/	\
 							CYCLES_PER_SEC)), z)
+#define GET_TIMER_VALUE()	GET_CURRENT_TIME()
 
 /* Configure Timer parameters */
 static inline void benchmark_timer_init(void)
@@ -73,6 +74,7 @@ static inline u32_t get_core_freq_MHz(void)
 #else
 #define GET_CURRENT_TIME()  OS_GET_TIME()
 #define CYCLES_TO_NS(x) SYS_CLOCK_HW_CYCLES_TO_NS(x)
+#define GET_TIMER_VALUE()	SysTick->VAL
 /* Dummy functions for timer */
 static inline void benchmark_timer_init(void)  {       }
 static inline void benchmark_timer_stop(void)  {       }

--- a/tests/benchmarks/timing_info/src/yield_bench.c
+++ b/tests/benchmarks/timing_info/src/yield_bench.c
@@ -57,7 +57,7 @@ void yield_bench(void)
 	/*read the time of start of the sleep till the swap happens */
 	__read_swap_end_time_value = 1;
 
-	thread_sleep_start_time =   OS_GET_TIME();
+	thread_sleep_start_time =   GET_CURRENT_TIME();
 	k_sleep(1000);
 	thread_sleep_end_time =   ((u32_t)__common_var_swap_end_time);
 
@@ -75,12 +75,12 @@ void yield_bench(void)
 void thread_yield0_test(void *p1, void *p2, void *p3)
 {
 	k_sem_take(&yield_sem, 10);
-	thread_start_time =  OS_GET_TIME();
+	thread_start_time =  GET_CURRENT_TIME();
 	while (count != 1000) {
 		count++;
 		k_yield();
 	}
-	thread_end_time =  OS_GET_TIME();
+	thread_end_time =  GET_CURRENT_TIME();
 	k_thread_abort(yield1_tid);
 }
 


### PR DESCRIPTION
This is composed of 2 patches 
1. Configure External timer to 32 bit mode for nrf SOCs to avoid overflow.
2. Some of KPIs were not reported in case of nrf and ARM due to bug in the code, So fixed the bugs.
