### PR TITLE
Bluetooth: ipsp: Remov ipss.c

### DIFF
--- a/samples/bluetooth/ipsp/src/ipss.c
+++ b/samples/bluetooth/ipsp/src/ipss.c
@@ -1,2 +1,0 @@
-/* Workaround build system bug that will put objects in source dir */
-#include "../../../bluetooth/gatt/ipss.c"


### PR DESCRIPTION
This file is no longer needed as IPSS service is already enabled with
CONFIG_NET_L2_BT.

Signed-off-by: Luiz Augusto von Dentz <luiz.von.dentz@intel.com>