### PR TITLE
doc: filter doc gen warnings

### DIFF
--- a/.shippable.yml
+++ b/.shippable.yml
@@ -40,16 +40,7 @@ build:
             echo "Building a Pull Request";
             echo "- Building Documentation";
             echo "Commit range:" ${COMMIT_RANGE}
-            make htmldocs > doc.log 2>&1;
-            ./scripts/filter-known-issues.py --config-dir .known-issues/doc/ doc.log > doc.warnings;
-
-            if [ "$?" != 0 ]; then
-              echo " ==> Error running filter script"
-              exit 1
-            fi;
-            if [ -s doc.warnings ]; then
-              echo " => New documentation warnings/errors";
-            fi;
+            make htmldocs
             echo "- Verify commit message and coding style";
             ./scripts/ci/check-compliance.py --commits ${COMMIT_RANGE} || true;
           fi;

--- a/doc/Makefile
+++ b/doc/Makefile
@@ -81,15 +81,8 @@ prep: doxy content kconfig
 
 html: content kconfig
 	$(Q)$(SPHINXBUILD) -t $(DOC_TAG) -b html $(ALLSPHINXOPTS) \
-      $(BUILDDIR)/html > /tmp/doc-$(TMP_EXT) 2>&1;
-	$(Q)../scripts/filter-known-issues.py --config-dir \
-      ../.known-issues/doc /tmp/doc-$(TMP_EXT) > /tmp/doc-warnings-$(TMP_EXT) || \
-      (echo " ==> Error running filter-known-issues"; exit 1); \
-      if [ -s /tmp/doc-warnings-$(TMP_EXT) ]; then \
-        echo " => New documentation warnings/errors"; \
-        cat /tmp/doc-warnings-$(TMP_EXT); \
-        exit 1; \
-      fi;
+             $(BUILDDIR)/html > /tmp/doc-$(TMP_EXT) 2>&1;
+	$(Q)scripts/filter-doc-log.sh /tmp/doc-$(TMP_EXT)
 	@rm -rf samples
 	@rm -rf boards
 

--- a/doc/Makefile
+++ b/doc/Makefile
@@ -10,6 +10,7 @@ SPHINXBUILD   = sphinx-build
 PAPER         =
 BUILDDIR     ?= _build
 DOC_TAG      ?= development
+TMP_EXT       = $$PPID.log
 
 # User-friendly check for sphinx-build
 ifeq ($(shell which $(SPHINXBUILD) >/dev/null 2>&1; echo $$?), 1)
@@ -79,7 +80,16 @@ kconfig: scripts/genrest/genrest.py
 prep: doxy content kconfig
 
 html: content kconfig
-	$(Q)$(SPHINXBUILD) -t $(DOC_TAG) -b html $(ALLSPHINXOPTS) $(BUILDDIR)/html
+	$(Q)$(SPHINXBUILD) -t $(DOC_TAG) -b html $(ALLSPHINXOPTS) \
+      $(BUILDDIR)/html > /tmp/doc-$(TMP_EXT) 2>&1;
+	$(Q)../scripts/filter-known-issues.py --config-dir \
+      ../.known-issues/doc /tmp/doc-$(TMP_EXT) > /tmp/doc-warnings-$(TMP_EXT) || \
+      (echo " ==> Error running filter-known-issues"; exit 1); \
+      if [ -s /tmp/doc-warnings-$(TMP_EXT) ]; then \
+        echo " => New documentation warnings/errors"; \
+        cat /tmp/doc-warnings-$(TMP_EXT); \
+        exit 1; \
+      fi;
 	@rm -rf samples
 	@rm -rf boards
 

--- a/doc/scripts/filter-doc-log.sh
+++ b/doc/scripts/filter-doc-log.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+# run the filter-known-issues.py script to remove "expected" warning
+# messages from the output of the document build process
+# Only argument is the name of the log file saved by the build.
+
+$ZEPHYR_BASE/scripts/filter-known-issues.py --config-dir \
+      $ZEPHYR_BASE/.known-issues/doc $1 > $1.warn || \
+      (echo " ==> Error running filter-known-issues"; exit 1); \
+      if [ -s $1.warn ]; then \
+        echo " => New documentation warnings/errors"; \
+        cat $1.warn;
+        exit 1; \
+      fi;


### PR DESCRIPTION
Because of known issues with Sphinx/Breathe tools we're using
to generate doxygen-based comments for our API documentation,
we're getting a bevy of warning messages written out.  As a
workaround for our CI system, we created a filter-known-issues
script to remove "expected" warnings from the output.  This patch
includes calling that filter script as part of the doc generation
so folks making local builds of the docs won't be tripped up by
all the warning messages.

(See https://github.com/sphinx-doc/sphinx/issue/2682 and
https://github.com/sphinx-doc/sphinx/issues/2683)

Fixes #1527

Signed-off-by: David B. Kinder <david.b.kinder@intel.com>