### PR TITLE
Bluetooth: SMP: Fix responding to Pairing Failed PDUs

### DIFF
--- a/subsys/bluetooth/host/smp.c
+++ b/subsys/bluetooth/host/smp.c
@@ -3432,7 +3432,10 @@ static void bt_smp_recv(struct bt_l2cap_chan *chan, struct net_buf *buf)
 
 	if (!atomic_test_and_clear_bit(&smp->allowed_cmds, hdr->code)) {
 		BT_WARN("Unexpected SMP code 0x%02x", hdr->code);
-		smp_error(smp, BT_SMP_ERR_UNSPECIFIED);
+		/* Don't send error responses to error PDUs */
+		if (hdr->code != BT_SMP_CMD_PAIRING_FAIL) {
+			smp_error(smp, BT_SMP_ERR_UNSPECIFIED);
+		}
 		return;
 	}
 


### PR DESCRIPTION
It makes no sense to respond with Pairing Failed PDU to another
Pairing Failed PDU.

Jira: ZEP-2620

Signed-off-by: Johan Hedberg <johan.hedberg@intel.com>