### PR TITLE
net: Exit early on zero gateway provided

### DIFF
--- a/subsys/net/ip/l2/arp.c
+++ b/subsys/net/ip/l2/arp.c
@@ -223,10 +223,8 @@ struct net_pkt *net_arp_prepare(struct net_pkt *pkt)
 				       &NET_IPV4_HDR(pkt)->dst)) {
 		addr = &net_pkt_iface(pkt)->ipv4.gw;
 		if (net_is_ipv4_addr_unspecified(addr)) {
-			if (IS_ENABLED(CONFIG_NET_DEBUG_ARP)) {
-				NET_ERR("Gateway not set for iface %p",
-					net_pkt_iface(pkt));
-			}
+			NET_ERR("Gateway not set for iface %p",
+				net_pkt_iface(pkt));
 
 			return NULL;
 		}

--- a/subsys/net/ip/l2/arp.c
+++ b/subsys/net/ip/l2/arp.c
@@ -222,9 +222,13 @@ struct net_pkt *net_arp_prepare(struct net_pkt *pkt)
 	if (!net_if_ipv4_addr_mask_cmp(net_pkt_iface(pkt),
 				       &NET_IPV4_HDR(pkt)->dst)) {
 		addr = &net_pkt_iface(pkt)->ipv4.gw;
-		if (IS_ENABLED(CONFIG_NET_DEBUG_ARP)
-		    && net_is_ipv4_addr_unspecified(addr)) {
-			NET_ERR("Gateway not set for iface %p", net_pkt_iface(pkt));
+		if (net_is_ipv4_addr_unspecified(addr)) {
+			if (IS_ENABLED(CONFIG_NET_DEBUG_ARP)) {
+				NET_ERR("Gateway not set for iface %p",
+					net_pkt_iface(pkt));
+			}
+
+			return NULL;
 		}
 	} else {
 		addr = &NET_IPV4_HDR(pkt)->dst;


### PR DESCRIPTION
In a case gateway is not set drop packet early otherwise bogus
ARPs for 0.0.0.0 are sent.

...
[net/arp] [DBG] find_entry: (0xa8006720): dst 0.0.0.0
[net/arp] [DBG] find_entry: (0xa8006720): [0] iface 0xa800cd80 dst
0.0.0.0 ll 00:00:00:00:00:00 pending 0xa800a7c0
[net/arp] [DBG] find_entry: (0xa8006720): ARP already pending to
0.0.0.0 ll 00:00:00:00:00:00
[net/arp] [DBG] net_arp_prepare: (0xa8006720): Resending ARP
0xa800a380
...

Signed-off-by: Andrei Emeltchenko <andrei.emeltchenko@intel.com>