### PR TITLE
Move Kconfig options from nxp_kinetis to mcux

### DIFF
--- a/arch/arm/soc/nxp_kinetis/Kconfig
+++ b/arch/arm/soc/nxp_kinetis/Kconfig
@@ -40,12 +40,6 @@ config HAS_MCG
 	help
 	  Set if the multipurpose clock generator (MCG) module is present in the SoC.
 
-config HAS_RNGA
-	bool
-	default n
-	help
-	  Set if the random number generator accelerator (RNGA) module is present in the SoC.
-
 config HAS_TRNG
 	bool
 	default n

--- a/arch/arm/soc/nxp_kinetis/Kconfig
+++ b/arch/arm/soc/nxp_kinetis/Kconfig
@@ -58,12 +58,6 @@ config HAS_FTM
 	help
 	  Set if the FlexTimer (FTM) module is present in the SoC.
 
-config HAS_LPUART
-	bool
-	default n
-	help
-	  Set if the low power uart (LPUART) module is present in the SoC.
-
 config HAS_LPSCI
 	bool
 	default n

--- a/arch/arm/soc/nxp_kinetis/Kconfig
+++ b/arch/arm/soc/nxp_kinetis/Kconfig
@@ -58,12 +58,6 @@ config HAS_FTM
 	help
 	  Set if the FlexTimer (FTM) module is present in the SoC.
 
-config HAS_ADC16
-	bool
-	default n
-	help
-	  Set if the 16-bit ADC (ADC16) module is present in the SoC.
-
 config HAS_SYSMPU
 	bool "Enable MPU"
 	depends on CPU_HAS_MPU

--- a/arch/arm/soc/nxp_kinetis/Kconfig
+++ b/arch/arm/soc/nxp_kinetis/Kconfig
@@ -58,12 +58,6 @@ config HAS_FTM
 	help
 	  Set if the FlexTimer (FTM) module is present in the SoC.
 
-config HAS_LPSCI
-	bool
-	default n
-	help
-	  Set if the low power uart (LPSCI) module is present in the SoC.
-
 config HAS_ADC16
 	bool
 	default n

--- a/arch/arm/soc/nxp_kinetis/Kconfig
+++ b/arch/arm/soc/nxp_kinetis/Kconfig
@@ -40,12 +40,6 @@ config HAS_MCG
 	help
 	  Set if the multipurpose clock generator (MCG) module is present in the SoC.
 
-config HAS_TRNG
-	bool
-	default n
-	help
-	  Set if the true random number generator (TRNG) module is present in the SoC.
-
 config HAS_SYSMPU
 	bool "Enable MPU"
 	depends on CPU_HAS_MPU

--- a/arch/arm/soc/nxp_kinetis/Kconfig
+++ b/arch/arm/soc/nxp_kinetis/Kconfig
@@ -52,12 +52,6 @@ config HAS_TRNG
 	help
 	  Set if the true random number generator (TRNG) module is present in the SoC.
 
-config HAS_FTM
-	bool
-	default n
-	help
-	  Set if the FlexTimer (FTM) module is present in the SoC.
-
 config HAS_SYSMPU
 	bool "Enable MPU"
 	depends on CPU_HAS_MPU

--- a/arch/arm/soc/nxp_kinetis/k6x/Kconfig.soc
+++ b/arch/arm/soc/nxp_kinetis/k6x/Kconfig.soc
@@ -14,9 +14,9 @@ config SOC_MK64F12
 	select HAS_MCUX
 	select HAS_MCUX_ADC16
 	select HAS_MCUX_FTM
+	select HAS_MCUX_RNGA
 	select HAS_OSC
 	select HAS_MCG
-	select HAS_RNGA
 	select CPU_HAS_FPU
 
 endchoice

--- a/arch/arm/soc/nxp_kinetis/k6x/Kconfig.soc
+++ b/arch/arm/soc/nxp_kinetis/k6x/Kconfig.soc
@@ -13,6 +13,7 @@ config SOC_MK64F12
 	bool "SOC_MK64F12"
 	select HAS_MCUX
 	select HAS_MCUX_ADC16
+	select HAS_MCUX_FTM
 	select HAS_OSC
 	select HAS_MCG
 	select HAS_RNGA

--- a/arch/arm/soc/nxp_kinetis/k6x/Kconfig.soc
+++ b/arch/arm/soc/nxp_kinetis/k6x/Kconfig.soc
@@ -12,10 +12,10 @@ depends on SOC_SERIES_KINETIS_K6X
 config SOC_MK64F12
 	bool "SOC_MK64F12"
 	select HAS_MCUX
+	select HAS_MCUX_ADC16
 	select HAS_OSC
 	select HAS_MCG
 	select HAS_RNGA
-	select HAS_ADC16
 	select CPU_HAS_FPU
 
 endchoice

--- a/arch/arm/soc/nxp_kinetis/kl2x/Kconfig.soc
+++ b/arch/arm/soc/nxp_kinetis/kl2x/Kconfig.soc
@@ -13,10 +13,10 @@ config SOC_MKL25Z4
 	bool "SOC_MKL25Z4"
 	select CPU_CORTEX_M0PLUS
 	select HAS_MCUX
+	select HAS_MCUX_ADC16
 	select HAS_MCUX_LPSCI
 	select HAS_OSC
 	select HAS_MCG
-	select HAS_ADC16
 
 endchoice
 

--- a/arch/arm/soc/nxp_kinetis/kl2x/Kconfig.soc
+++ b/arch/arm/soc/nxp_kinetis/kl2x/Kconfig.soc
@@ -13,9 +13,9 @@ config SOC_MKL25Z4
 	bool "SOC_MKL25Z4"
 	select CPU_CORTEX_M0PLUS
 	select HAS_MCUX
+	select HAS_MCUX_LPSCI
 	select HAS_OSC
 	select HAS_MCG
-	select HAS_LPSCI
 	select HAS_ADC16
 
 endchoice

--- a/arch/arm/soc/nxp_kinetis/kwx/Kconfig.soc
+++ b/arch/arm/soc/nxp_kinetis/kwx/Kconfig.soc
@@ -13,10 +13,10 @@ config SOC_MKW40Z4
 	bool "SOC_MKW40Z4"
 	select CPU_CORTEX_M0PLUS
 	select HAS_MCUX
+	select HAS_MCUX_ADC16
 	select HAS_MCUX_LPUART
 	select HAS_OSC
 	select HAS_MCG
-	select HAS_ADC16
 	select HAS_TRNG
 	select HAS_SEGGER_RTT
 
@@ -24,10 +24,10 @@ config SOC_MKW41Z4
 	bool "SOC_MKW41Z4"
 	select CPU_CORTEX_M0PLUS
 	select HAS_MCUX
+	select HAS_MCUX_ADC16
 	select HAS_MCUX_LPUART
 	select HAS_OSC
 	select HAS_MCG
-	select HAS_ADC16
 	select HAS_TRNG
 
 endchoice

--- a/arch/arm/soc/nxp_kinetis/kwx/Kconfig.soc
+++ b/arch/arm/soc/nxp_kinetis/kwx/Kconfig.soc
@@ -13,9 +13,9 @@ config SOC_MKW40Z4
 	bool "SOC_MKW40Z4"
 	select CPU_CORTEX_M0PLUS
 	select HAS_MCUX
+	select HAS_MCUX_LPUART
 	select HAS_OSC
 	select HAS_MCG
-	select HAS_LPUART
 	select HAS_ADC16
 	select HAS_TRNG
 	select HAS_SEGGER_RTT
@@ -24,9 +24,9 @@ config SOC_MKW41Z4
 	bool "SOC_MKW41Z4"
 	select CPU_CORTEX_M0PLUS
 	select HAS_MCUX
+	select HAS_MCUX_LPUART
 	select HAS_OSC
 	select HAS_MCG
-	select HAS_LPUART
 	select HAS_ADC16
 	select HAS_TRNG
 

--- a/arch/arm/soc/nxp_kinetis/kwx/Kconfig.soc
+++ b/arch/arm/soc/nxp_kinetis/kwx/Kconfig.soc
@@ -15,9 +15,9 @@ config SOC_MKW40Z4
 	select HAS_MCUX
 	select HAS_MCUX_ADC16
 	select HAS_MCUX_LPUART
+	select HAS_MCUX_TRNG
 	select HAS_OSC
 	select HAS_MCG
-	select HAS_TRNG
 	select HAS_SEGGER_RTT
 
 config SOC_MKW41Z4
@@ -26,9 +26,9 @@ config SOC_MKW41Z4
 	select HAS_MCUX
 	select HAS_MCUX_ADC16
 	select HAS_MCUX_LPUART
+	select HAS_MCUX_TRNG
 	select HAS_OSC
 	select HAS_MCG
-	select HAS_TRNG
 
 endchoice
 

--- a/drivers/adc/Kconfig.mcux
+++ b/drivers/adc/Kconfig.mcux
@@ -8,7 +8,7 @@
 
 config ADC_MCUX_ADC16
 	bool "MCUX ADC16 driver"
-	depends on HAS_MCUX && HAS_ADC16
+	depends on HAS_MCUX_ADC16
 	select HAS_DTS_ADC
 	default n
 	help

--- a/drivers/pwm/Kconfig.mcux_ftm
+++ b/drivers/pwm/Kconfig.mcux_ftm
@@ -8,7 +8,7 @@
 menuconfig PWM_MCUX_FTM
 	bool
 	prompt "MCUX FTM PWM driver"
-	depends on HAS_MCUX && HAS_FTM
+	depends on HAS_MCUX_FTM
 	default n
 	help
 	  Enable support for mcux ftm pwm driver.

--- a/drivers/random/Kconfig.mcux
+++ b/drivers/random/Kconfig.mcux
@@ -6,7 +6,7 @@
 
 menuconfig RANDOM_MCUX_RNGA
 	bool "MCUX RNGA driver"
-	depends on RANDOM_GENERATOR && HAS_RNGA
+	depends on RANDOM_GENERATOR && HAS_MCUX_RNGA
 	default n
 	select RANDOM_HAS_DRIVER
 	help

--- a/drivers/random/Kconfig.mcux
+++ b/drivers/random/Kconfig.mcux
@@ -15,7 +15,7 @@ menuconfig RANDOM_MCUX_RNGA
 
 menuconfig RANDOM_MCUX_TRNG
 	bool "MCUX TRNG driver"
-	depends on RANDOM_GENERATOR && HAS_TRNG
+	depends on RANDOM_GENERATOR && HAS_MCUX_TRNG
 	default n
 	select RANDOM_HAS_DRIVER
 	help

--- a/drivers/serial/Kconfig.mcux_lpsci
+++ b/drivers/serial/Kconfig.mcux_lpsci
@@ -7,7 +7,7 @@
 
 menuconfig UART_MCUX_LPSCI
 	bool "MCUX LPSCI driver"
-	depends on HAS_MCUX && HAS_LPSCI
+	depends on HAS_MCUX_LPSCI
 	default n
 	select SERIAL_HAS_DRIVER
 	select SERIAL_SUPPORT_INTERRUPT

--- a/drivers/serial/Kconfig.mcux_lpuart
+++ b/drivers/serial/Kconfig.mcux_lpuart
@@ -7,7 +7,7 @@
 
 menuconfig UART_MCUX_LPUART
 	bool "MCUX LPUART driver"
-	depends on HAS_MCUX && HAS_LPUART
+	depends on HAS_MCUX_LPUART
 	default n
 	select SERIAL_HAS_DRIVER
 	select SERIAL_SUPPORT_INTERRUPT

--- a/ext/hal/nxp/mcux/Kconfig
+++ b/ext/hal/nxp/mcux/Kconfig
@@ -36,4 +36,11 @@ config HAS_MCUX_LPUART
 	help
 	  Set if the low power uart (LPUART) module is present in the SoC.
 
+config HAS_MCUX_RNGA
+	bool
+	default n
+	help
+	  Set if the random number generator accelerator (RNGA) module is
+	  present in the SoC.
+
 endif # HAS_MCUX

--- a/ext/hal/nxp/mcux/Kconfig
+++ b/ext/hal/nxp/mcux/Kconfig
@@ -43,4 +43,11 @@ config HAS_MCUX_RNGA
 	  Set if the random number generator accelerator (RNGA) module is
 	  present in the SoC.
 
+config HAS_MCUX_TRNG
+	bool
+	default n
+	help
+	  Set if the true random number generator (TRNG) module is present in
+	  the SoC.
+
 endif # HAS_MCUX

--- a/ext/hal/nxp/mcux/Kconfig
+++ b/ext/hal/nxp/mcux/Kconfig
@@ -12,6 +12,12 @@ config HAS_MCUX
 
 if HAS_MCUX
 
+config HAS_MCUX_LPSCI
+	bool
+	default n
+	help
+	  Set if the low power uart (LPSCI) module is present in the SoC.
+
 config HAS_MCUX_LPUART
 	bool
 	default n

--- a/ext/hal/nxp/mcux/Kconfig
+++ b/ext/hal/nxp/mcux/Kconfig
@@ -18,6 +18,12 @@ config HAS_MCUX_ADC16
 	help
 	  Set if the 16-bit ADC (ADC16) module is present in the SoC.
 
+config HAS_MCUX_FTM
+	bool
+	default n
+	help
+	  Set if the FlexTimer (FTM) module is present in the SoC.
+
 config HAS_MCUX_LPSCI
 	bool
 	default n

--- a/ext/hal/nxp/mcux/Kconfig
+++ b/ext/hal/nxp/mcux/Kconfig
@@ -12,6 +12,12 @@ config HAS_MCUX
 
 if HAS_MCUX
 
+config HAS_MCUX_ADC16
+	bool
+	default n
+	help
+	  Set if the 16-bit ADC (ADC16) module is present in the SoC.
+
 config HAS_MCUX_LPSCI
 	bool
 	default n

--- a/ext/hal/nxp/mcux/Kconfig
+++ b/ext/hal/nxp/mcux/Kconfig
@@ -9,3 +9,13 @@ config HAS_MCUX
 	bool
 	select HAS_CMSIS
 	depends on SOC_FAMILY_KINETIS
+
+if HAS_MCUX
+
+config HAS_MCUX_LPUART
+	bool
+	default n
+	help
+	  Set if the low power uart (LPUART) module is present in the SoC.
+
+endif # HAS_MCUX


### PR DESCRIPTION
Moves several Kconfig options from arch/arm/soc/nxp_kinetis to ext/hal/nxp/mcux so they can be used by SoCs outside the Kinetis family.