### PR TITLE
scripts: Add support for passing daparg argument to pyocd commands

### DIFF
--- a/scripts/support/pyocd.sh
+++ b/scripts/support/pyocd.sh
@@ -14,6 +14,11 @@ if [ -n "${PYOCD_BOARD_ID}" ]; then
 	PYOCD_BOARD_ID_ARG="-b ${PYOCD_BOARD_ID}"
 fi
 
+PYOCD_DAPARG_ARG=""
+if [ -n "${PYOCD_DAPARG}" ]; then
+	PYOCD_DAPARG_ARG="-da ${PYOCD_DAPARG}"
+fi
+
 test_config() {
     if ! which ${PYOCD_FLASHTOOL} >/dev/null 2>&1; then
         echo "Error: Unable to locate pyOCD flash tool: ${PYOCD_FLASHTOOL}"
@@ -38,7 +43,8 @@ do_flash() {
 
     # flash device with specified image
     echo "Flashing Target Device"
-    ${PYOCD_FLASHTOOL} -t ${PYOCD_TARGET} ${PYOCD_BOARD_ID_ARG} ${BIN_NAME}
+    ${PYOCD_FLASHTOOL} ${PYOCD_DAPARG_ARG} -t ${PYOCD_TARGET} \
+	${PYOCD_BOARD_ID_ARG} ${BIN_NAME}
 }
 
 
@@ -64,7 +70,8 @@ do_debugserver() {
         SETSID=
     fi
     echo "pyOCD GDB server running on port ${GDB_PORT}"
-    ${SETSID} ${PYOCD_GDBSERVER} -p ${GDB_PORT} -t ${PYOCD_TARGET} ${PYOCD_BOARD_ID_ARG}
+    ${SETSID} ${PYOCD_GDBSERVER} ${PYOCD_DAPARG_ARG} -p ${GDB_PORT} \
+	-t ${PYOCD_TARGET} ${PYOCD_BOARD_ID_ARG}
 }
 
 CMD="$1"


### PR DESCRIPTION
pyocd occasionally throws USB timeout exceptions when running in
VirtualBox, and recently added a command-line option to limit the USB
packet count as a workaround. Introduce an environment variable
PYOCD_DAPARG so Zephyr can pass the argument to pyocd. For example:

$ make -C samples/hello_world/ BOARD=frdm_k64f \
	PYOCD_DAPARG='limit_packets=True' flash

This workound comes with a performance penalty when flashing and
debugging with pyocd, so it should only be used when running pyocd in
VirtualBox.

Signed-off-by: Maureen Helm <maureen.helm@nxp.com>