### PR TITLE
Bluetooth: controller: Move tIFS s/w switch PPI index up by one

### DIFF
--- a/subsys/bluetooth/controller/hal/nrf5/radio.c
+++ b/subsys/bluetooth/controller/hal/nrf5/radio.c
@@ -414,7 +414,7 @@ void radio_tx_enable(void)
 void radio_disable(void)
 {
 #if !defined(CONFIG_BT_CTLR_TIFS_HW)
-	NRF_PPI->CHENCLR = PPI_CHEN_CH8_Msk | PPI_CHEN_CH11_Msk;
+	NRF_PPI->CHENCLR = PPI_CHEN_CH9_Msk | PPI_CHEN_CH12_Msk;
 	NRF_PPI->TASKS_CHG[0].DIS = 1;
 	NRF_PPI->TASKS_CHG[1].DIS = 1;
 #endif /* !CONFIG_BT_CTLR_TIFS_HW */
@@ -489,13 +489,13 @@ static u8_t sw_tifs_toggle;
 static void sw_switch(u8_t dir, u8_t phy_curr, u8_t flags_curr, u8_t phy_next,
 		      u8_t flags_next)
 {
-	u8_t ppi = 12 + sw_tifs_toggle;
+	u8_t ppi = 13 + sw_tifs_toggle;
 	u32_t delay;
 
 	NRF_TIMER1->EVENTS_COMPARE[sw_tifs_toggle] = 0;
 
-	NRF_PPI->CH[11].EEP = (u32_t)&(NRF_RADIO->EVENTS_END);
-	NRF_PPI->CH[11].TEP = (u32_t)&(NRF_PPI->TASKS_CHG[sw_tifs_toggle].EN);
+	NRF_PPI->CH[12].EEP = (u32_t)&(NRF_RADIO->EVENTS_END);
+	NRF_PPI->CH[12].TEP = (u32_t)&(NRF_PPI->TASKS_CHG[sw_tifs_toggle].EN);
 
 	NRF_PPI->CH[ppi].EEP = (u32_t)
 			       &(NRF_TIMER1->EVENTS_COMPARE[sw_tifs_toggle]);
@@ -518,7 +518,7 @@ static void sw_switch(u8_t dir, u8_t phy_curr, u8_t flags_curr, u8_t phy_next,
 		NRF_TIMER1->CC[sw_tifs_toggle] = 1;
 	}
 
-	NRF_PPI->CHENSET = PPI_CHEN_CH8_Msk | PPI_CHEN_CH11_Msk;
+	NRF_PPI->CHENSET = PPI_CHEN_CH9_Msk | PPI_CHEN_CH12_Msk;
 
 	sw_tifs_toggle += 1;
 	sw_tifs_toggle &= 1;
@@ -558,7 +558,7 @@ void radio_switch_complete_and_disable(void)
 	    (RADIO_SHORTS_READY_START_Msk | RADIO_SHORTS_END_DISABLE_Msk);
 
 #if !defined(CONFIG_BT_CTLR_TIFS_HW)
-	NRF_PPI->CHENCLR = PPI_CHEN_CH8_Msk | PPI_CHEN_CH11_Msk;
+	NRF_PPI->CHENCLR = PPI_CHEN_CH9_Msk | PPI_CHEN_CH12_Msk;
 #endif /* !CONFIG_BT_CTLR_TIFS_HW */
 }
 
@@ -692,17 +692,17 @@ u32_t radio_tmr_start(u8_t trx, u32_t ticks_start, u32_t remainder)
 	NRF_TIMER1->BITMODE = 0; /* 16 bit */
 	NRF_TIMER1->TASKS_START = 1;
 
-	NRF_PPI->CH[8].EEP = (u32_t)&(NRF_RADIO->EVENTS_END);
-	NRF_PPI->CH[8].TEP = (u32_t)&(NRF_TIMER1->TASKS_CLEAR);
+	NRF_PPI->CH[9].EEP = (u32_t)&(NRF_RADIO->EVENTS_END);
+	NRF_PPI->CH[9].TEP = (u32_t)&(NRF_TIMER1->TASKS_CLEAR);
 
-	NRF_PPI->CH[9].EEP = (u32_t)&(NRF_TIMER1->EVENTS_COMPARE[0]);
-	NRF_PPI->CH[9].TEP = (u32_t)&(NRF_PPI->TASKS_CHG[0].DIS);
+	NRF_PPI->CH[10].EEP = (u32_t)&(NRF_TIMER1->EVENTS_COMPARE[0]);
+	NRF_PPI->CH[10].TEP = (u32_t)&(NRF_PPI->TASKS_CHG[0].DIS);
 
-	NRF_PPI->CH[10].EEP = (u32_t)&(NRF_TIMER1->EVENTS_COMPARE[1]);
-	NRF_PPI->CH[10].TEP = (u32_t)&(NRF_PPI->TASKS_CHG[1].DIS);
+	NRF_PPI->CH[11].EEP = (u32_t)&(NRF_TIMER1->EVENTS_COMPARE[1]);
+	NRF_PPI->CH[11].TEP = (u32_t)&(NRF_PPI->TASKS_CHG[1].DIS);
 
-	NRF_PPI->CHG[0] = PPI_CHG_CH9_Msk | PPI_CHG_CH12_Msk;
-	NRF_PPI->CHG[1] = PPI_CHG_CH10_Msk | PPI_CHG_CH13_Msk;
+	NRF_PPI->CHG[0] = PPI_CHG_CH10_Msk | PPI_CHG_CH13_Msk;
+	NRF_PPI->CHG[1] = PPI_CHG_CH11_Msk | PPI_CHG_CH14_Msk;
 #endif /* !CONFIG_BT_CTLR_TIFS_HW */
 
 	return remainder;


### PR DESCRIPTION
Move the use of tIFS software switching PPI index set up by
one position to make place for use of PA/LNA implementation.

Signed-off-by: Vinayak Kariappa Chettimada <vich@nordicsemi.no>