### PR TITLE
tests: driver: adc: change the sampling delay

### DIFF
--- a/tests/drivers/adc/adc_simple/src/main.c
+++ b/tests/drivers/adc/adc_simple/src/main.c
@@ -36,7 +36,7 @@
 static u32_t seq_buffer[2][BUFFER_SIZE];
 
 static struct adc_seq_entry sample = {
-	.sampling_delay = 12,
+	.sampling_delay = 30,
 	.channel_id = CHANNEL,
 	.buffer_length = BUFFER_SIZE * sizeof(seq_buffer[0][0])
 };


### PR DESCRIPTION
patch fix the issue of unable to read from adc by setting
appropriate sampling delay.

Signed-off-by: Savinay Dharmappa <savinay.dharmappa@intel.com>