### PR TITLE
samples: net: Fix wrong error logging information in echo client.

### DIFF
--- a/samples/net/echo_client/src/tcp.c
+++ b/samples/net/echo_client/src/tcp.c
@@ -348,7 +348,7 @@ int start_tcp(void)
 				  K_THREAD_STACK_SIZEOF(
 					  net_app_tls_stack_ipv4));
 		if (ret < 0) {
-			NET_ERR("Cannot init IPv6 TCP client (%d)", ret);
+			NET_ERR("Cannot init IPv4 TCP client (%d)", ret);
 		}
 	}
 


### PR DESCRIPTION
When TCP connection over IPv4 could not be established there was
an error about TCP connection over IPv6.

Signed-off-by: Michał Kruszewski <michal.kruszewski@nordicsemi.no>