### PR TITLE
net: nbr: Add NET_IPV6_NBR_STATE_STATIC

### DIFF
--- a/subsys/net/ip/ipv6.c
+++ b/subsys/net/ip/ipv6.c
@@ -74,6 +74,8 @@ const char *net_ipv6_nbr_state2str(enum net_ipv6_nbr_state state)
 		return "delay";
 	case NET_IPV6_NBR_STATE_PROBE:
 		return "probe";
+	case NET_IPV6_NBR_STATE_STATIC:
+		return "static";
 	}
 
 	return "<invalid state>";
@@ -82,7 +84,8 @@ const char *net_ipv6_nbr_state2str(enum net_ipv6_nbr_state state)
 static void ipv6_nbr_set_state(struct net_nbr *nbr,
 			       enum net_ipv6_nbr_state new_state)
 {
-	if (new_state == net_ipv6_nbr_data(nbr)->state) {
+	if (new_state == net_ipv6_nbr_data(nbr)->state ||
+	    net_ipv6_nbr_data(nbr)->state == NET_IPV6_NBR_STATE_STATIC) {
 		return;
 	}
 
@@ -427,7 +430,8 @@ struct net_nbr *net_ipv6_nbr_add(struct net_if *iface,
 		}
 	}
 
-	if (net_nbr_link(nbr, iface, lladdr) == -EALREADY) {
+	if (net_nbr_link(nbr, iface, lladdr) == -EALREADY &&
+	    net_ipv6_nbr_data(nbr)->state != NET_IPV6_NBR_STATE_STATIC) {
 		/* Update the lladdr if the node was already known */
 		struct net_linkaddr_storage *cached_lladdr;
 
@@ -1417,6 +1421,9 @@ static void nd_reachable_timeout(struct k_work *work)
 	}
 
 	switch (data->state) {
+	case NET_IPV6_NBR_STATE_STATIC:
+		NET_ASSERT_INFO(false, "Static entry shall never timeout");
+		break;
 
 	case NET_IPV6_NBR_STATE_INCOMPLETE:
 		if (data->ns_count >= MAX_MULTICAST_SOLICIT) {

--- a/subsys/net/ip/ipv6.h
+++ b/subsys/net/ip/ipv6.h
@@ -71,6 +71,7 @@ enum net_ipv6_nbr_state {
 	NET_IPV6_NBR_STATE_STALE,
 	NET_IPV6_NBR_STATE_DELAY,
 	NET_IPV6_NBR_STATE_PROBE,
+	NET_IPV6_NBR_STATE_STATIC,
 };
 
 const char *net_ipv6_nbr_state2str(enum net_ipv6_nbr_state state);

--- a/subsys/net/ip/l2/bluetooth.c
+++ b/subsys/net/ip/l2/bluetooth.c
@@ -150,7 +150,7 @@ static void ipsp_connected(struct bt_l2cap_chan *chan)
 	 */
 	net_ipv6_addr_create_iid(&in6, &ll);
 	net_ipv6_nbr_add(ctxt->iface, &in6, &ll, false,
-			 NET_IPV6_NBR_STATE_REACHABLE);
+			 NET_IPV6_NBR_STATE_STATIC);
 
 	/* Set iface up */
 	net_if_up(ctxt->iface);


### PR DESCRIPTION
This adds a new state NET_IPV6_NBR_STATE_STATIC which never timeouts
which is required in case of RFC 7668 which doesn't allow publishing
the address:

https://tools.ietf.org/html/rfc7668#section-3.2.3

Signed-off-by: Luiz Augusto von Dentz <luiz.von.dentz@intel.com>