### PR TITLE
doc: filter-known-issues.py and empty files

### DIFF
--- a/scripts/filter-known-issues.py
+++ b/scripts/filter-known-issues.py
@@ -185,6 +185,8 @@ def report_warning(data):
         warnings.write(data)
 
 for filename in args.FILENAMEs:
+    if os.stat(filename).st_size == 0:
+       continue  # skip empty log files
     try:
         with open(filename, "r+b") as f:
             logging.info("%s: filtering", filename)


### PR DESCRIPTION
filter-known-issues (used to remove "expected" messages from log files
during doc and test builds) now properly handles an empty log file
(there won't be anything to filter).

Signed-off-by: David B. Kinder <david.b.kinder@intel.com>