### PR TITLE
drivers: sensor: clean up Kconfig files

### DIFF
--- a/drivers/sensor/Kconfig
+++ b/drivers/sensor/Kconfig
@@ -13,32 +13,30 @@ menuconfig SENSOR
 	help
 	  Include sensor drivers in system config
 
+if SENSOR
+
 config SYS_LOG_SENSOR_LEVEL
 	int "Sensor Log level"
-	depends on SYS_LOG && SENSOR
+	depends on SYS_LOG
 	default 0
 	range 0 4
 	help
-	Sets log level for sensor driver.
-	Levels are:
-
-	- 0 OFF: do not write
-
-	- 1 ERROR: only write SYS_LOG_ERR
-
-	- 2 WARNING: write SYS_LOG_WRN in addition to previous level
-
-	- 3 INFO: write SYS_LOG_INF in addition to previous levels
-
-	- 4 DEBUG: write SYS_LOG_DBG in addition to previous levels
+	  Sets log level for Sensor Device Drivers.
+	  Levels are:
+	  0 OFF, do not write
+	  1 ERROR, only write SYS_LOG_ERR
+	  2 WARNING, write SYS_LOG_WRN in addition to previous level
+	  3 INFO, write SYS_LOG_INF in addition to previous levels
+	  4 DEBUG, write SYS_LOG_DBG in addition to previous levels
 
 config SENSOR_INIT_PRIORITY
 	int
 	prompt "Sensor init priority"
-	depends on SENSOR
 	default 90
 	help
-	 Sensor initialization priority.
+	  Sensor initialization priority.
+
+comment "Device Drivers"
 
 source "drivers/sensor/adxl362/Kconfig"
 
@@ -111,3 +109,5 @@ source "drivers/sensor/th02/Kconfig"
 source "drivers/sensor/tmp007/Kconfig"
 
 source "drivers/sensor/tmp112/Kconfig"
+
+endif # SENSOR

--- a/drivers/sensor/adxl362/Kconfig
+++ b/drivers/sensor/adxl362/Kconfig
@@ -7,7 +7,7 @@
 #
 menuconfig ADXL362
 	bool "ADXL362 sensor"
-	depends on SENSOR && SPI
+	depends on SPI
 	default n
 	help
 	  Enable driver for ADXL362 Three-Axis Digital Accelerometers.

--- a/drivers/sensor/ak8975/Kconfig
+++ b/drivers/sensor/ak8975/Kconfig
@@ -9,7 +9,7 @@
 menuconfig AK8975
 	bool
 	prompt "AK8975 Magnetometer"
-	depends on SENSOR && I2C
+	depends on I2C
 	default n
 	help
 	  Enable driver for AK8975 magnetometer.

--- a/drivers/sensor/apds9960/Kconfig
+++ b/drivers/sensor/apds9960/Kconfig
@@ -6,7 +6,7 @@
 
 menuconfig APDS9960
 	bool "APDS9960 Sensor"
-	depends on SENSOR && I2C
+	depends on I2C
 	default n
 	help
 	  Enable driver for APDS9960 sensors.

--- a/drivers/sensor/bma280/Kconfig
+++ b/drivers/sensor/bma280/Kconfig
@@ -9,7 +9,7 @@
 menuconfig BMA280
 	bool
 	prompt "BMA280 Three Axis Accelerometer Family"
-	depends on SENSOR && I2C
+	depends on I2C
 	default n
 	help
 	  Enable driver for BMA280 I2C-based triaxial accelerometer sensor

--- a/drivers/sensor/bmc150_magn/Kconfig
+++ b/drivers/sensor/bmc150_magn/Kconfig
@@ -8,7 +8,7 @@
 
 menuconfig BMC150_MAGN
 	bool "BMC150_MAGN I2C Magnetometer Chip"
-	depends on SENSOR && I2C
+	depends on I2C
 	default n
 	help
 	  Enable driver for BMC150 I2C-based magnetometer sensor.

--- a/drivers/sensor/bme280/Kconfig
+++ b/drivers/sensor/bme280/Kconfig
@@ -8,7 +8,7 @@
 #
 menuconfig BME280
 	bool "BME280/BMP280 sensor"
-	depends on SENSOR && (I2C || SPI)
+	depends on I2C || SPI
 	default n
 	help
 	 Enable driver for BME280 I2C-based or SPI-based temperature and pressure sensor.

--- a/drivers/sensor/bmg160/Kconfig
+++ b/drivers/sensor/bmg160/Kconfig
@@ -8,7 +8,6 @@
 
 menuconfig BMG160
 	bool "Bosch BMG160 gyroscope support"
-	depends on SENSOR
 	depends on I2C
 	default n
 	help

--- a/drivers/sensor/bmi160/Kconfig
+++ b/drivers/sensor/bmi160/Kconfig
@@ -8,7 +8,6 @@
 
 menuconfig BMI160
 	bool "Bosch BMI160 inertial measurement unit"
-	depends on SENSOR
 	depends on SPI
 	depends on SPI_LEGACY_API
 	default n

--- a/drivers/sensor/bmm150/Kconfig
+++ b/drivers/sensor/bmm150/Kconfig
@@ -8,7 +8,7 @@
 
 menuconfig BMM150
 	bool "BMM150 I2C Geomagnetic Chip"
-	depends on SENSOR && I2C
+	depends on I2C
 	default n
 	help
 	  Enable driver for BMM150 I2C-based Geomagnetic sensor.

--- a/drivers/sensor/dht/Kconfig
+++ b/drivers/sensor/dht/Kconfig
@@ -9,7 +9,7 @@
 menuconfig DHT
 	bool
 	prompt "DHT Temperature and Humidity Sensor"
-	depends on SENSOR && GPIO
+	depends on GPIO
 	default n
 	help
 	  Enable driver for the DHT temperature and humidity sensor family.

--- a/drivers/sensor/fxas21002/Kconfig
+++ b/drivers/sensor/fxas21002/Kconfig
@@ -7,7 +7,7 @@
 
 menuconfig FXAS21002
 	bool "FXAS21002 gyroscope driver"
-	depends on SENSOR && I2C
+	depends on I2C
 	default n
 	help
 	  Enable driver for the FXAS21002 gyroscope

--- a/drivers/sensor/fxos8700/Kconfig
+++ b/drivers/sensor/fxos8700/Kconfig
@@ -7,7 +7,7 @@
 
 menuconfig FXOS8700
 	bool "FXOS8700 accelerometer/magnetometer driver"
-	depends on SENSOR && I2C
+	depends on I2C
 	default n
 	help
 	  Enable driver for the FXOS8700 accelerometer/magnetometer

--- a/drivers/sensor/hdc1008/Kconfig
+++ b/drivers/sensor/hdc1008/Kconfig
@@ -9,7 +9,7 @@
 menuconfig HDC1008
 	bool
 	prompt "HDC1008 Temperature and Humidity Sensor"
-	depends on SENSOR && I2C && GPIO
+	depends on I2C && GPIO
 	default n
 	help
 	  Enable driver for HDC1008 temperature and humidity sensors.

--- a/drivers/sensor/hmc5883l/Kconfig
+++ b/drivers/sensor/hmc5883l/Kconfig
@@ -7,7 +7,7 @@
 menuconfig HMC5883L
 	bool
 	prompt "HMC5883L magnetometer"
-	depends on SENSOR && I2C
+	depends on I2C
 	default n
 	help
 	Enable driver for HMC5883L I2C-based magnetometer.

--- a/drivers/sensor/hp206c/Kconfig
+++ b/drivers/sensor/hp206c/Kconfig
@@ -7,7 +7,6 @@
 #
 menuconfig HP206C
 	bool "HopeRF HP206C precision barometer and altimeter sensor"
-	depends on SENSOR
 	depends on I2C
 	default n
 	help

--- a/drivers/sensor/hts221/Kconfig
+++ b/drivers/sensor/hts221/Kconfig
@@ -7,7 +7,7 @@
 menuconfig HTS221
 	bool
 	prompt "HTS221 temperature and humidity sensor"
-	depends on SENSOR && I2C
+	depends on I2C
 	default n
 	help
 	  Enable driver for HTS221 I2C-based temperature and humidity sensor.

--- a/drivers/sensor/isl29035/Kconfig
+++ b/drivers/sensor/isl29035/Kconfig
@@ -10,7 +10,7 @@ menuconfig ISL29035
 	bool
 	prompt "ISL29035 light sensor"
 	default n
-	depends on SENSOR && I2C
+	depends on I2C
 	help
 	  Enable driver for the ISL29035 light sensor.
 

--- a/drivers/sensor/lis2dh/Kconfig
+++ b/drivers/sensor/lis2dh/Kconfig
@@ -9,7 +9,7 @@
 menuconfig LIS2DH
 	bool
 	prompt "LIS2DH Three Axis Accelerometer"
-	depends on SENSOR && (I2C || SPI)
+	depends on I2C || SPI
 	default n
 	help
 	  Enable driver for LIS2DH SPI/I2C-based triaxial accelerometer sensor.

--- a/drivers/sensor/lis3dh/Kconfig
+++ b/drivers/sensor/lis3dh/Kconfig
@@ -9,7 +9,7 @@
 menuconfig LIS3DH
 	bool
 	prompt "LIS3DH Three Axis Accelerometer"
-	depends on SENSOR && I2C
+	depends on I2C
 	default n
 	help
 	  Enable driver for LIS3DH I2C-based triaxial accelerometer sensor.

--- a/drivers/sensor/lis3mdl/Kconfig
+++ b/drivers/sensor/lis3mdl/Kconfig
@@ -7,7 +7,7 @@
 menuconfig LIS3MDL
 	bool
 	prompt "LIS3MDL magnetometer"
-	depends on SENSOR && I2C
+	depends on I2C
 	default n
 	help
 	  Enable driver for LIS3MDL I2C-based magnetometer.

--- a/drivers/sensor/lps22hb/Kconfig
+++ b/drivers/sensor/lps22hb/Kconfig
@@ -7,7 +7,7 @@
 menuconfig LPS22HB
 	bool
 	prompt "LPS22HB pressure and temperature"
-	depends on SENSOR && I2C
+	depends on I2C
 	default n
 	help
 	  Enable driver for LPS22HB I2C-based pressure and temperature

--- a/drivers/sensor/lps25hb/Kconfig
+++ b/drivers/sensor/lps25hb/Kconfig
@@ -7,7 +7,7 @@
 menuconfig LPS25HB
 	bool
 	prompt "LPS25HB pressure and temperature"
-	depends on SENSOR && I2C
+	depends on I2C
 	default n
 	help
 	Enable driver for LPS25HB I2C-based pressure and temperature

--- a/drivers/sensor/lsm6ds0/Kconfig
+++ b/drivers/sensor/lsm6ds0/Kconfig
@@ -9,7 +9,7 @@
 
 menuconfig LSM6DS0
 	bool "LSM6DS0 I2C accelerometer and gyroscope Chip"
-	depends on SENSOR && I2C
+	depends on I2C
 	default n
 	help
 	  Enable driver for LSM6DS0 I2C-based accelerometer and gyroscope

--- a/drivers/sensor/lsm6dsl/Kconfig
+++ b/drivers/sensor/lsm6dsl/Kconfig
@@ -9,7 +9,7 @@
 
 menuconfig LSM6DSL
 	bool "LSM6DSL I2C accelerometer and gyroscope Chip"
-	depends on SENSOR && I2C
+	depends on I2C
 	default n
 	help
 	  Enable driver for LSM6DSL I2C-based accelerometer and gyroscope

--- a/drivers/sensor/lsm9ds0_gyro/Kconfig
+++ b/drivers/sensor/lsm9ds0_gyro/Kconfig
@@ -8,7 +8,7 @@
 
 menuconfig LSM9DS0_GYRO
 	bool "LSM9DS0 I2C gyroscope Chip"
-	depends on SENSOR && I2C
+	depends on I2C
 	default n
 	help
 	  Enable driver for LSM9DS0 I2C-based gyroscope sensor.

--- a/drivers/sensor/lsm9ds0_mfd/Kconfig
+++ b/drivers/sensor/lsm9ds0_mfd/Kconfig
@@ -9,7 +9,7 @@
 
 menuconfig LSM9DS0_MFD
 	bool "LSM9DS0 I2C accelerometer, magnetometer and temperature sensor chip"
-	depends on SENSOR && I2C
+	depends on I2C
 	default n
 	help
 	  Enable driver for LSM9DS0 I2C-based MFD sensor.

--- a/drivers/sensor/max30101/Kconfig
+++ b/drivers/sensor/max30101/Kconfig
@@ -8,7 +8,7 @@
 menuconfig MAX30101
 	bool
 	prompt "MAX30101 Pulse Oximeter and Heart Rate Sensor"
-	depends on SENSOR && I2C
+	depends on I2C
 	default n
 
 if MAX30101

--- a/drivers/sensor/max44009/Kconfig
+++ b/drivers/sensor/max44009/Kconfig
@@ -9,7 +9,7 @@
 menuconfig MAX44009
 	bool
 	prompt "MAX44009 Light Sensor"
-	depends on SENSOR && I2C
+	depends on I2C
 	default n
 	help
 	Enable driver for MAX44009 light sensors.

--- a/drivers/sensor/mcp9808/Kconfig
+++ b/drivers/sensor/mcp9808/Kconfig
@@ -8,7 +8,7 @@
 
 menuconfig MCP9808
 	bool "MCP9808 temperature sensor"
-	depends on SENSOR && I2C
+	depends on I2C
 	default n
 	help
 	 Enable driver for MCP9808 temperature sensor.

--- a/drivers/sensor/mpu6050/Kconfig
+++ b/drivers/sensor/mpu6050/Kconfig
@@ -9,7 +9,7 @@
 menuconfig MPU6050
 	bool
 	prompt "MPU6050 Six-Axis Motion Tracking Device"
-	depends on SENSOR && I2C
+	depends on I2C
 	default n
 	help
 	  Enable driver for MPU6050 I2C-based six-axis motion tracking device.

--- a/drivers/sensor/nrf5/Kconfig
+++ b/drivers/sensor/nrf5/Kconfig
@@ -9,7 +9,7 @@
 menuconfig TEMP_NRF5
 	bool
 	prompt "nRF5 Temperature Sensor"
-	depends on SENSOR && SOC_FAMILY_NRF5
+	depends on SOC_FAMILY_NRF5
 	default n
 	help
 	  Enable driver for nRF5 temperature sensor.

--- a/drivers/sensor/sht3xd/Kconfig
+++ b/drivers/sensor/sht3xd/Kconfig
@@ -9,7 +9,7 @@
 menuconfig SHT3XD
 	bool
 	prompt "SHT3xD Temperature and Humidity Sensor"
-	depends on SENSOR && I2C
+	depends on I2C
 	default n
 	help
 	  Enable driver for SHT3xD temperature and humidity sensors.

--- a/drivers/sensor/sx9500/Kconfig
+++ b/drivers/sensor/sx9500/Kconfig
@@ -8,7 +8,7 @@
 
 menuconfig SX9500
 	bool "SX9500 I2C SAR Proximity Chip"
-	depends on SENSOR && I2C
+	depends on I2C
 	default n
 	help
 	  Enable driver for SX9500 I2C-based SAR proximity sensor.

--- a/drivers/sensor/th02/Kconfig
+++ b/drivers/sensor/th02/Kconfig
@@ -8,7 +8,7 @@ menuconfig TH02
 	bool
 	prompt "TH02 Temperature Sensor"
 	default n
-	depends on SENSOR && I2C
+	depends on I2C
 	help
 	  Enable driver for the TH02 temperature sensor.
 

--- a/drivers/sensor/tmp007/Kconfig
+++ b/drivers/sensor/tmp007/Kconfig
@@ -9,7 +9,7 @@
 menuconfig TMP007
 	bool
 	prompt "TMP007 Infrared Thermopile Sensor"
-	depends on SENSOR && I2C
+	depends on I2C
 	default n
 	help
 	  Enable driver for TMP007 infrared thermopile sensors.

--- a/drivers/sensor/tmp112/Kconfig
+++ b/drivers/sensor/tmp112/Kconfig
@@ -9,7 +9,7 @@
 menuconfig TMP112
 	bool
 	prompt "TMP112 Temperature Sensor"
-	depends on SENSOR && I2C
+	depends on I2C
 	default n
 	help
 	Enable driver for TMP112 infrared thermopile sensors.


### PR DESCRIPTION
Several of sensors in sensor/*/Kconfig did not include dependencies on SENSOR option and as a result they were rendered flat in the main "Device Drivers" menu instead of "Sensor Drivers" submenu. This patch fixes this. In addition following minor changes are included in this clean-up patch:
- separate device drivers and common options with a comment line
- align help text

Signed-off-by: Piotr Mienkowski <piotr.mienkowski@gmail.com>