### PR TITLE
drivers: dma: remove deprecated API functions

### DIFF
--- a/drivers/dma/dma_stm32f4x.c
+++ b/drivers/dma/dma_stm32f4x.c
@@ -70,6 +70,9 @@ struct dma_stm32_config {
 	void (*config)(struct dma_stm32_device *);
 };
 
+/* DMA burst length */
+#define BURST_TRANS_LENGTH_1			0
+
 /* DMA direction */
 #define DMA_STM32_DEV_TO_MEM			0
 #define DMA_STM32_MEM_TO_DEV			1


### PR DESCRIPTION
Zephyr release 1.7  introduced a new DMA API and deprecated the old one. Since we are already a few releases ahead I propose to remove the old deprecated API functions and data types from dma.h file as well as the device drivers.

Signed-off-by: Piotr Mienkowski <piotr.mienkowski@gmail.com>