### PR TITLE
doc: fix misspelling in kernel.h API doc

### DIFF
--- a/include/kernel.h
+++ b/include/kernel.h
@@ -169,7 +169,7 @@ struct _k_object {
  * @return 0 If the object is valid
  *         -EBADF if not a valid object of the specified type
  *         -EPERM If the caller does not have permissions
- *         -EINVAL Object is not intitialized
+ *         -EINVAL Object is not initialized
  */
 int _k_object_validate(void *obj, enum k_objects otype, int init);
 


### PR DESCRIPTION
Signed-off-by: David B. Kinder <david.b.kinder@intel.com>