### PR TITLE
drivers: flash: Add API for retrieve driver write-block-size requirement

### DIFF
--- a/drivers/flash/flash_stm32.c
+++ b/drivers/flash/flash_stm32.c
@@ -205,6 +205,11 @@ static const struct flash_driver_api flash_stm32_api = {
 #ifdef CONFIG_FLASH_PAGE_LAYOUT
 	.page_layout = flash_stm32_page_layout,
 #endif
+#if defined(CONFIG_SOC_SERIES_STM32F4X)
+	.write_block_size = 1,
+#elif defined(CONFIG_SOC_SERIES_STM32L4X)
+	.write_block_size = 8,
+#endif
 };
 
 static int stm32_flash_init(struct device *dev)

--- a/drivers/flash/flash_stm32f3x.c
+++ b/drivers/flash/flash_stm32f3x.c
@@ -129,6 +129,7 @@ static const struct flash_driver_api flash_stm32_api = {
 	.write = flash_stm32_write,
 	.erase = flash_stm32_erase,
 	.write_protection = flash_stm32_protection_set,
+	.write_block_size = 2,
 };
 
 static const struct flash_stm32_dev_config flash_device_config = {

--- a/drivers/flash/soc_flash_mcux.c
+++ b/drivers/flash/soc_flash_mcux.c
@@ -92,6 +92,7 @@ static const struct flash_driver_api flash_mcux_api = {
 	.erase = flash_mcux_erase,
 	.write = flash_mcux_write,
 	.read = flash_mcux_read,
+	.write_block_size = FSL_FEATURE_FLASH_PFLASH_BLOCK_WRITE_UNIT_SIZE,
 };
 
 static int flash_mcux_init(struct device *dev)

--- a/drivers/flash/soc_flash_nrf5.c
+++ b/drivers/flash/soc_flash_nrf5.c
@@ -209,8 +209,9 @@ static const struct flash_driver_api flash_nrf5_api = {
 	.erase = flash_nrf5_erase,
 	.write_protection = flash_nrf5_write_protection,
 #if defined(CONFIG_FLASH_PAGE_LAYOUT)
-	.page_layout = flash_nrf5_pages_layout
+	.page_layout = flash_nrf5_pages_layout,
 #endif
+	.write_block_size = 1,
 };
 
 static int nrf5_flash_init(struct device *dev)

--- a/drivers/flash/soc_flash_qmsi.c
+++ b/drivers/flash/soc_flash_qmsi.c
@@ -253,6 +253,7 @@ static const struct flash_driver_api flash_qmsi_api = {
 	.write = flash_qmsi_write,
 	.erase = flash_qmsi_erase,
 	.write_protection = flash_qmsi_write_protection,
+	.write_block_size = 4,
 };
 
 #ifdef CONFIG_DEVICE_POWER_MANAGEMENT

--- a/drivers/flash/spi_flash_w25qxxdv.c
+++ b/drivers/flash/spi_flash_w25qxxdv.c
@@ -344,6 +344,7 @@ static const struct flash_driver_api spi_flash_api = {
 	.write = spi_flash_wb_write,
 	.erase = spi_flash_wb_erase,
 	.write_protection = spi_flash_wb_write_protection_set,
+	.write_block_size = 1,
 };
 
 static int spi_flash_init(struct device *dev)

--- a/include/flash.h
+++ b/include/flash.h
@@ -78,6 +78,7 @@ struct flash_driver_api {
 #if defined(CONFIG_FLASH_PAGE_LAYOUT)
 	flash_api_pages_layout page_layout;
 #endif /* CONFIG_FLASH_PAGE_LAYOUT */
+	const size_t write_block_size;
 };
 
 /**
@@ -206,6 +207,24 @@ int flash_get_page_info_by_idx(struct device *dev, u32_t page_index,
  */
 size_t flash_get_page_count(struct device *dev);
 #endif /* CONFIG_FLASH_PAGE_LAYOUT */
+
+/**
+ *  @brief  Get the minimum write block size supported by the driver
+ *
+ *  The Write block size supported by the driver might defer from the write
+ *  block size of memory used because the driver might implements write-modify
+ *  algorithm.
+ *
+ *  @param  dev flash device
+ *
+ *  @return  write block size in Bytes.
+ */
+static inline size_t flash_get_write_block_size(struct device *dev)
+{
+	const struct flash_driver_api *api = dev->driver_api;
+
+	return api->write_block_size;
+}
 
 #ifdef __cplusplus
 }

--- a/samples/drivers/soc_flash_nrf5/src/main.c
+++ b/samples/drivers/soc_flash_nrf5/src/main.c
@@ -185,4 +185,8 @@ void main(void)
 	       flash_get_page_count(flash_dev));
 
 #endif
+
+	printf("\nTest 8: Write block size API\n");
+	printf("   write-block-size = %u\n",
+	       flash_get_write_block_size(flash_dev));
 }


### PR DESCRIPTION
This path introduce API for retrieve minimum write-block-size supported by the flash driver.
This value can defer from hardware alignment requirement (as for nrf5x is).
It is not expected that this value changes in run-time so constant value was chosen.

As the driver has certain requirement for alignment
on the writing, it is necessary to export this value for upper modules which
needs to know the write-block-size (for instance NFFS needs this).

Appropriate values was specified for nRF5x, STM32,  w25qxxdv and QMSI SoCs.