### PR TITLE
qemu: cleanup qemu configurations

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -786,8 +786,6 @@ ifdef MAKEFILE_TOOLCHAIN_DO_PASS2
 include $(srctree)/scripts/Makefile.toolchain.$(ZEPHYR_GCC_VARIANT)
 endif
 
-QEMU		= $(addsuffix /,$(QEMU_BIN_PATH))$(QEMU_$(ARCH))
-
 # The all: target is the default when no target is given on the
 # command line.
 # This allow a user to issue only 'make' to build a kernel including modules

--- a/arch/xtensa/Makefile
+++ b/arch/xtensa/Makefile
@@ -19,10 +19,3 @@ cflags-$(CONFIG_LTO) += $(call cc-option,-flto,)
 
 KBUILD_CFLAGS += $(cflags-y)
 KBUILD_CXXFLAGS += $(cflags-y)
-
-QEMU_CPU_TYPE_xtensa ?= unsupported
-QEMU_FLAGS_xtensa = -cpu $(QEMU_CPU_TYPE_xtensa) \
-                    -machine sim -semihosting -nographic
-QEMU_xtensa = qemu-system-xtensa
-
-export QEMU_FLAGS_xtensa QEMU_xtensa

--- a/arch/xtensa/soc/D_233L/Makefile
+++ b/arch/xtensa/soc/D_233L/Makefile
@@ -1,3 +1,1 @@
 obj- = soc.o
-
-QEMU_CPU_TYPE_xtensa = dc233c

--- a/arch/xtensa/soc/sample_controller/Makefile
+++ b/arch/xtensa/soc/sample_controller/Makefile
@@ -1,3 +1,2 @@
 obj- = soc.o
 
-QEMU_CPU_TYPE_xtensa = sample_controller

--- a/boards/arm/qemu_cortex_m3/Makefile.board
+++ b/boards/arm/qemu_cortex_m3/Makefile.board
@@ -9,6 +9,6 @@ QEMU_arm = qemu-system-arm
 DEBUG_SCRIPT = qemu.sh
 
 debugserver: QEMU_EXTRA_FLAGS += -s -S
-debugserver: qemu
+debugserver: run
 
 export QEMU_FLAGS_arm QEMU_arm

--- a/boards/nios2/qemu_nios2/Makefile.board
+++ b/boards/nios2/qemu_nios2/Makefile.board
@@ -8,4 +8,4 @@ QEMU_nios2 = qemu-system-nios2
 DEBUG_SCRIPT = qemu.sh
 
 debugserver: QEMU_EXTRA_FLAGS += -s -S
-debugserver: qemu
+debugserver: run

--- a/boards/riscv32/qemu_riscv32/Makefile.board
+++ b/boards/riscv32/qemu_riscv32/Makefile.board
@@ -8,4 +8,4 @@ QEMU_riscv32 = qemu-system-riscv32
 DEBUG_SCRIPT = qemu.sh
 
 debugserver: QEMU_EXTRA_FLAGS += -s -S
-debugserver: qemu
+debugserver: run

--- a/boards/x86/qemu_x86/Makefile.board
+++ b/boards/x86/qemu_x86/Makefile.board
@@ -17,6 +17,6 @@ QEMU_x86 = qemu-system-i386
 DEBUG_SCRIPT = qemu.sh
 
 debugserver: QEMU_EXTRA_FLAGS += -s -S
-debugserver: qemu
+debugserver: run
 
 export QEMU_FLAGS_x86 QEMU_x86 QEMU_CPU_TYPE_x86

--- a/boards/xtensa/qemu_xtensa/Makefile.board
+++ b/boards/xtensa/qemu_xtensa/Makefile.board
@@ -1,2 +1,13 @@
 EMU_PLATFORM ?= qemu
 
+QEMU_CPU_TYPE_xtensa = sample_controller
+QEMU_FLAGS_xtensa = -cpu $(QEMU_CPU_TYPE_xtensa) \
+                    -machine sim -semihosting -nographic
+QEMU_xtensa = qemu-system-xtensa
+
+DEBUG_SCRIPT = qemu.sh
+
+debugserver: QEMU_EXTRA_FLAGS += -s -S
+debugserver: run
+
+export QEMU_FLAGS_xtensa QEMU_xtensa

--- a/scripts/Makefile.qemu
+++ b/scripts/Makefile.qemu
@@ -9,6 +9,7 @@
 # QEMU_INSTANCE is a command line argument to make. By appending the instance
 # name to the pid file we can easily run more instances of the same sample.
 QEMU_FLAGS = $(QEMU_FLAGS_$(ARCH)) -pidfile qemu$(QEMU_INSTANCE).pid
+QEMU		= $(addsuffix /,$(QEMU_BIN_PATH))$(QEMU_$(ARCH))
 
 ifneq ($(QEMU_PTY),)
     QEMU_FLAGS += -serial pty


### PR DESCRIPTION
Move all QEMU related defines to the boards and cleanup xtensa platforms
which were marked to be QEMU capable by mistake.

Fixes #1510 

Signed-off-by: Anas Nashif <anas.nashif@intel.com>