### PR TITLE
Revert "build: remove leftover qemu target"

### DIFF
--- a/scripts/Makefile.qemu
+++ b/scripts/Makefile.qemu
@@ -21,6 +21,7 @@ else
 endif
 endif
 
+qemu: run
 run: zephyr
 	$(if $(QEMU_PIPE),,@echo "To exit from QEMU enter: 'CTRL+a, x'")
 	@echo '[QEMU] CPU: $(QEMU_CPU_TYPE_$(ARCH))'


### PR DESCRIPTION
This reverts commit eb756c5d1a7eaf1f536290e92bcb16b59c841976.
The patch breaks 'make debugserver' for a large number of boards.

Signed-off-by: Andrew Boie <andrew.p.boie@intel.com>