### PR TITLE
USB: refactor and move CDC and MSC Class Header files to include/usb, add usb descriptors

### DIFF
--- a/include/usb/class/usb_cdc.h
+++ b/include/usb/class/usb_cdc.h
@@ -1,0 +1,164 @@
+/* usb_cdc.h - USB CDC-ACM and CDC-ECM public header */
+
+/*
+ * Copyright (c) 2017 PHYTEC Messtechnik GmbH
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+
+/**
+ * @file
+ * @brief USB Communicatons Device Class (CDC) public header
+ *
+ * Header follows the Class Definitions for
+ * Communications Devices Specification (CDC120-20101103-track.pdf),
+ * PSTN Devices Specification (PSTN120.pdf) and
+ * Ethernet Control Model Devices Specification (ECM120.pdf).
+ * Header is limited to ACM and ECM Subclasses.
+ */
+
+#ifndef __USB_CDC_H__
+#define __USB_CDC_H__
+
+/** CDC Specification release number in BCD format */
+#define CDC_SRN_1_20			0x0120
+
+/** CDC Class Code */
+#define COMMUNICATION_DEVICE_CLASS	0x02
+
+/** Communications Class Subclass Codes */
+#define ACM_SUBCLASS			0x02
+#define ECM_SUBCLASS			0x06
+
+/** Communications Class Protocol Codes */
+#define AT_CMD_V250_PROTOCOL		0x01
+
+/**
+ * @brief Data Class Interface Codes
+ * @note CDC120-20101103-track.pdf, 4.5, Table 6
+ */
+#define DATA_INTERFACE_CLASS		0x0A
+
+/**
+ * @brief Values for the bDescriptorType Field
+ * @note CDC120-20101103-track.pdf, 5.2.3, Table 12
+ */
+#define CS_INTERFACE			0x24
+#define CS_ENDPOINT			0x25
+
+/**
+ * @brief bDescriptor SubType for Communications
+ * Class Functional Descriptors
+ * @note CDC120-20101103-track.pdf, 5.2.3, Table 13
+ */
+#define HEADER_FUNC_DESC		0x00
+#define CALL_MANAGEMENT_FUNC_DESC	0x01
+#define ACM_FUNC_DESC			0x02
+#define UNION_FUNC_DESC			0x06
+#define ETHERNET_FUNC_DESC		0x0F
+
+/**
+ * @brief PSTN Subclass Specific Requests
+ * for ACM devices
+ * @note PSTN120.pdf, 6.3, Table 13
+ */
+#define SET_LINE_CODING			0x20
+#define GET_LINE_CODING			0x21
+#define SET_CONTROL_LINE_STATE		0x22
+
+/** Control Signal Bitmap Values for SetControlLineState */
+#define SET_CONTROL_LINE_STATE_RTS	0x02
+#define SET_CONTROL_LINE_STATE_DTR	0x01
+
+/** UART State Bitmap Values */
+#define SERIAL_STATE_OVERRUN		0x40
+#define SERIAL_STATE_PARITY		0x20
+#define SERIAL_STATE_FRAMING		0x10
+#define SERIAL_STATE_RING		0x08
+#define SERIAL_STATE_BREAK		0x04
+#define SERIAL_STATE_TX_CARRIER		0x02
+#define SERIAL_STATE_RX_CARRIER		0x01
+
+/**
+ * @brief Class-Specific Request Codes for Ethernet subclass
+ * @note ECM120.pdf, 6.2, Table 6
+ */
+#define SET_ETHERNET_MULTICAST_FILTERS	0x40
+#define SET_ETHERNET_PM_FILTER		0x41
+#define GET_ETHERNET_PM_FILTER		0x42
+#define SET_ETHERNET_PACKET_FILTER	0x43
+#define GET_ETHERNET_STATISTIC		0x44
+
+/** Ethernet Packet Filter Bitmap */
+#define PACKET_TYPE_MULTICAST		0x10
+#define PACKET_TYPE_BROADCAST		0x08
+#define PACKET_TYPE_DIRECTED		0x04
+#define PACKET_TYPE_ALL_MULTICAST	0x02
+#define PACKET_TYPE_PROMISCUOUS		0x01
+
+/** Header Functional Descriptor */
+struct cdc_header_descriptor {
+	u8_t bFunctionLength;
+	u8_t bDescriptorType;
+	u8_t bDescriptorSubtype;
+	u16_t bcdCDC;
+} __packed;
+
+/** Union Interface Functional Descriptor */
+struct cdc_union_descriptor {
+	u8_t bFunctionLength;
+	u8_t bDescriptorType;
+	u8_t bDescriptorSubtype;
+	u8_t bControlInterface;
+	u8_t bSubordinateInterface0;
+} __packed;
+
+/** Call Management Functional Descriptor */
+struct cdc_cm_descriptor {
+	u8_t bFunctionLength;
+	u8_t bDescriptorType;
+	u8_t bDescriptorSubtype;
+	u8_t bmCapabilities;
+	u8_t bDataInterface;
+} __packed;
+
+/** Abstract Control Management Functional Descriptor */
+struct cdc_acm_descriptor {
+	u8_t bFunctionLength;
+	u8_t bDescriptorType;
+	u8_t bDescriptorSubtype;
+	u8_t bmCapabilities;
+} __packed;
+
+/** Data structure for GET_LINE_CODING / SET_LINE_CODING class requests */
+struct cdc_acm_line_coding {
+	u32_t dwDTERate;
+	u8_t bCharFormat;
+	u8_t bParityType;
+	u8_t bDataBits;
+} __packed;
+
+/** Data structure for the notification about SerialState */
+struct cdc_acm_notification {
+	u8_t bmRequestType;
+	u8_t bNotificationType;
+	u16_t wValue;
+	u16_t wIndex;
+	u16_t wLength;
+	u16_t data;
+} __packed;
+
+/** Ethernet Networking Functional Descriptor */
+struct cdc_ecm_descriptor {
+	u8_t bFunctionLength;
+	u8_t bDescriptorType;
+	u8_t bDescriptorSubtype;
+	u8_t iMACAddress;
+	u32_t bmEthernetStatistics;
+	u16_t wMaxSegmentSize;
+	u16_t wNumberMCFilters;
+	u8_t bNumberPowerFilters;
+} __packed;
+
+#endif /* __USB_CDC_H__ */

--- a/include/usb/class/usb_msc.h
+++ b/include/usb/class/usb_msc.h
@@ -1,0 +1,110 @@
+/* usb_msc.h - USB MSC public header */
+
+/*
+ * Copyright (c) 2017 PHYTEC Messtechnik GmbH
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * This file is based on mass_storage.h
+ *
+ * This file are derived from material that is
+ * Copyright (c) 2010-2011 mbed.org, MIT License
+ * Copyright (c) 2016 Intel Corporation.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ */
+
+
+/**
+ * @file
+ * @brief USB Mass Storage Class public header
+ *
+ * Header follows the Mass Storage Class Specification
+ * (Mass_Storage_Specification_Overview_v1.4_2-19-2010.pdf) and
+ * Mass Storage Class Bulk-Only Transport Specification
+ * (usbmassbulk_10.pdf).
+ * Header is limited to Bulk-Only Transfer protocol.
+ */
+
+#ifndef __USB_MSC_H__
+#define __USB_MSC_H__
+
+/** MSC Class, Subclass and Protocol Codes */
+#define MASS_STORAGE_CLASS		0x08
+#define SCSI_TRANSPARENT_SUBCLASS	0x06
+#define BULK_ONLY_TRANSPORT_PROTOCOL	0x50
+
+/** MSC Request Codes for Bulk-Only Transport */
+#define MSC_REQUEST_GET_MAX_LUN		0xFE
+#define MSC_REQUEST_RESET		0xFF
+
+/** MSC Command Block Wrapper (CBW) Signature */
+#define CBW_Signature			0x43425355
+
+/** MSC Command Block Wrapper Flags */
+#define CBW_DIRECTION_DATA_IN		0x80
+
+/** MSC Bulk-Only Command Block Wrapper (CBW) */
+struct CBW {
+	u32_t Signature;
+	u32_t Tag;
+	u32_t DataLength;
+	u8_t  Flags;
+	u8_t  LUN;
+	u8_t  CBLength;
+	u8_t  CB[16];
+} __packed;
+
+/** MSC Command Status Wrapper (CBW) Signature */
+#define CSW_Signature			0x53425355
+
+/** MSC Command Block Status Values */
+#define CSW_STATUS_CMD_PASSED		0x00
+#define CSW_STATUS_CMD_FAILED		0x01
+#define CSW_STATUS_PHASE_ERROR		0x02
+
+/** MSC Bulk-Only Command Status Wrapper (CSW) */
+struct CSW {
+	u32_t Signature;
+	u32_t Tag;
+	u32_t DataResidue;
+	u8_t  Status;
+} __packed;
+
+/** SCSI transparent command set used by MSC */
+#define TEST_UNIT_READY			0x00
+#define REQUEST_SENSE			0x03
+#define FORMAT_UNIT			0x04
+#define INQUIRY				0x12
+#define MODE_SELECT6			0x15
+#define MODE_SENSE6			0x1A
+#define START_STOP_UNIT			0x1B
+#define MEDIA_REMOVAL			0x1E
+#define READ_FORMAT_CAPACITIES		0x23
+#define READ_CAPACITY			0x25
+#define READ10				0x28
+#define WRITE10				0x2A
+#define VERIFY10			0x2F
+#define READ12				0xA8
+#define WRITE12				0xAA
+#define MODE_SELECT10			0x55
+#define MODE_SENSE10			0x5A
+
+#endif /* __USB_MSC_H__ */

--- a/include/usb/usb_common.h
+++ b/include/usb/usb_common.h
@@ -2,6 +2,7 @@
  *
  *
  * Copyright(c) 2015,2016 Intel Corporation.
+ * Copyright(c) 2017 PHYTEC Messtechnik GmbH
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -42,40 +43,41 @@
 #define USB_COMMON_H_
 
 /* Descriptor size in bytes */
-#define USB_DEVICE_DESC_SIZE            18
-#define USB_CONFIGURATION_DESC_SIZE     9
-#define USB_INTERFACE_DESC_SIZE         9
-#define USB_ENDPOINT_DESC_SIZE          7
-#define USB_STRING_DESC_SIZE            4
-#define USB_HID_DESC_SIZE               9
-#define USB_DFU_DESC_SIZE               9
-#define USB_DEVICE_QUAL_DESC_SIZE       10
-#define USB_INTERFACE_ASSOC_DESC_SIZE   8
+#define USB_DEVICE_DESC_SIZE		18
+#define USB_CONFIGURATION_DESC_SIZE	9
+#define USB_INTERFACE_DESC_SIZE		9
+#define USB_ENDPOINT_DESC_SIZE		7
+#define USB_STRING_DESC_SIZE		4
+#define USB_HID_DESC_SIZE		9
+#define USB_DFU_DESC_SIZE		9
+#define USB_DEVICE_QUAL_DESC_SIZE	10
+#define USB_INTERFACE_ASSOC_DESC_SIZE	8
 
 /* Descriptor type */
-#define USB_DEVICE_DESC                 0x01
-#define USB_CONFIGURATION_DESC          0x02
-#define USB_STRING_DESC                 0x03
-#define USB_INTERFACE_DESC              0x04
-#define USB_ENDPOINT_DESC               0x05
-#define USB_DEVICE_QUAL_DESC            0x06
-#define USB_INTERFACE_ASSOC_DESC        0x0B
-#define USB_HID_DESC                    0x21
-#define USB_HID_REPORT_DESC             0x22
-#define USB_DFU_FUNCTIONAL_DESC         0x21
+#define USB_DEVICE_DESC			0x01
+#define USB_CONFIGURATION_DESC		0x02
+#define USB_STRING_DESC			0x03
+#define USB_INTERFACE_DESC		0x04
+#define USB_ENDPOINT_DESC		0x05
+#define USB_DEVICE_QUAL_DESC		0x06
+#define USB_INTERFACE_ASSOC_DESC	0x0B
+#define USB_HID_DESC			0x21
+#define USB_HID_REPORT_DESC		0x22
+#define USB_DFU_FUNCTIONAL_DESC		0x21
+#define USB_ASSOCIATION_DESC		0x0B
 
 /* Useful define */
-#define USB_1_1                         0x0110
-#define USB_2_0                         0x0200
+#define USB_1_1				0x0110
+#define USB_2_0				0x0200
 /* Set USB version to 2.1 so that the host will request the BOS descriptor */
 #define USB_2_1				0x0210
 
-#define BCDDEVICE_RELNUM                0x0100
+#define BCDDEVICE_RELNUM		0x0100
 
 /* 100mA max power, per 2mA units */
 /* USB 1.1 spec indicates 100mA(max) per unit load, up to 5 loads */
-#define MAX_LOW_POWER                   0x32
-#define MAX_HIGH_POWER                  0xFA
+#define MAX_LOW_POWER			0x32
+#define MAX_HIGH_POWER			0xFA
 
 /* bmAttributes:
  * D7:Reserved, always 1,
@@ -83,40 +85,112 @@
  * D5:Remote Wakeup -> 0,
  * D4...0:Reserved -> 0
  */
-#define USB_CONFIGURATION_ATTRIBUTES    0xC0
+#define USB_CONFIGURATION_ATTRIBUTES	0xC0
 
 /* Classes */
-#define COMMUNICATION_DEVICE_CLASS      0x02
-#define COMMUNICATION_DEVICE_CLASS_DATA 0x0A
-#define HID_CLASS                       0x03
-#define MASS_STORAGE_CLASS              0x08
-#define WIRELESS_DEVICE_CLASS           0xE0
-#define MISC_CLASS                      0xEF
-#define CUSTOM_CLASS                    0xFF
-#define DFU_CLASS                       0xFE
+#define COMMUNICATION_DEVICE_CLASS	0x02
+#define COMMUNICATION_DEVICE_CLASS_DATA	0x0A
+#define HID_CLASS			0x03
+#define MASS_STORAGE_CLASS		0x08
+#define WIRELESS_DEVICE_CLASS		0xE0
+#define MISC_CLASS			0xEF
+#define CUSTOM_CLASS			0xFF
+#define DFU_CLASS			0xFE
 
 /* Sub-classes */
-#define ACM_SUBCLASS                    0x02
-#define CDC_ECM_SUBCLASS                0x06
-#define CDC_NCM_SUBCLASS                0x0d
-#define BOOT_INTERFACE_SUBCLASS         0x01
-#define SCSI_TRANSPARENT_SUBCLASS       0x06
-#define DFU_INTERFACE_SUBCLASS          0x01
-#define RF_SUBCLASS                     0x01
-#define CUSTOM_SUBCLASS                 0xFF
+#define ACM_SUBCLASS			0x02
+#define CDC_ECM_SUBCLASS		0x06
+#define CDC_NCM_SUBCLASS		0x0d
+#define BOOT_INTERFACE_SUBCLASS		0x01
+#define SCSI_TRANSPARENT_SUBCLASS	0x06
+#define DFU_INTERFACE_SUBCLASS		0x01
+#define RF_SUBCLASS			0x01
+#define CUSTOM_SUBCLASS			0xFF
 /* Misc subclasses */
-#define MISC_RNDIS_SUBCLASS             0x04
+#define MISC_RNDIS_SUBCLASS		0x04
 
 /* Protocols */
-#define V25TER_PROTOCOL                 0x01
-#define MOUSE_PROTOCOL                  0x02
-#define BULK_ONLY_PROTOCOL              0x50
-#define DFU_RUNTIME_PROTOCOL            0x01
-#define DFU_MODE_PROTOCOL               0x02
-#define BLUETOOTH_PROTOCOL              0x01
+#define V25TER_PROTOCOL			0x01
+#define MOUSE_PROTOCOL			0x02
+#define BULK_ONLY_PROTOCOL		0x50
+#define DFU_RUNTIME_PROTOCOL		0x01
+#define DFU_MODE_PROTOCOL		0x02
+#define BLUETOOTH_PROTOCOL		0x01
 /* CDC ACM protocols */
-#define ACM_VENDOR_PROTOCOL             0xFF
+#define ACM_VENDOR_PROTOCOL		0xFF
 /* Misc protocols */
-#define MISC_ETHERNET_PROTOCOL          0x01
+#define MISC_ETHERNET_PROTOCOL		0x01
+
+/** Standard Device Descriptor */
+struct usb_device_descriptor {
+	u8_t bLength;
+	u8_t bDescriptorType;
+	u16_t bcdUSB;
+	u8_t bDeviceClass;
+	u8_t bDeviceSubClass;
+	u8_t bDeviceProtocol;
+	u8_t bMaxPacketSize0;
+	u16_t idVendor;
+	u16_t idProduct;
+	u16_t bcdDevice;
+	u8_t iManufacturer;
+	u8_t iProduct;
+	u8_t iSerialNumber;
+	u8_t bNumConfigurations;
+} __packed;
+
+/** UNICODE String Descriptor */
+struct usb_string_descriptor {
+	u8_t bLength;
+	u8_t bDescriptorType;
+	u16_t bString;
+} __packed;
+
+/** Association Descriptor */
+struct usb_association_descriptor {
+	u8_t bLength;
+	u8_t bDescriptorType;
+	u8_t bFirstInterface;
+	u8_t bInterfaceCount;
+	u8_t bFunctionClass;
+	u8_t bFunctionSubClass;
+	u8_t bFunctionProtocol;
+	u8_t iFunction;
+} __packed;
+
+/** Standard Configuration Descriptor */
+struct usb_cfg_descriptor {
+	u8_t bLength;
+	u8_t bDescriptorType;
+	u16_t wTotalLength;
+	u8_t bNumInterfaces;
+	u8_t bConfigurationValue;
+	u8_t iConfiguration;
+	u8_t bmAttributes;
+	u8_t bMaxPower;
+} __packed;
+
+/** Standard Interface Descriptor */
+struct usb_if_descriptor {
+	u8_t bLength;
+	u8_t bDescriptorType;
+	u8_t bInterfaceNumber;
+	u8_t bAlternateSetting;
+	u8_t bNumEndpoints;
+	u8_t bInterfaceClass;
+	u8_t bInterfaceSubClass;
+	u8_t bInterfaceProtocol;
+	u8_t iInterface;
+} __packed;
+
+/** Standard Endpoint Descriptor */
+struct usb_ep_descriptor {
+	u8_t bLength;
+	u8_t bDescriptorType;
+	u8_t bEndpointAddress;
+	u8_t bmAttributes;
+	u16_t wMaxPacketSize;
+	u8_t bInterval;
+} __packed;
 
 #endif /* USB_COMMON_H_ */


### PR DESCRIPTION
This PR adds USB standard descriptors,
USB Mass Storage Class header, limited to Bulk-Only Transfer protocol,
USB Communicatons Device Class (CDC) header, limited to ACM and ECM Subclasses.

The commits are separated from the PR #716 (see Class Header files and cleanup inside include/usb)