### PR TITLE
samples: microbit/pong: Fix incorrect placement of parenthesis

### DIFF
--- a/samples/boards/microbit/pong/src/ble.c
+++ b/samples/boards/microbit/pong/src/ble.c
@@ -397,7 +397,7 @@ static u32_t adv_timeout(void)
 {
 	u32_t timeout;
 
-	if (bt_rand(&timeout, sizeof(timeout) < 0)) {
+	if (bt_rand(&timeout, sizeof(timeout)) < 0) {
 		return K_SECONDS(10);
 	}
 


### PR DESCRIPTION
The code was causing only one byte of data to be placed in timeout
instead of sizeof(timeout) as intended.

Coverity-CID: 170744

Fixes #4057 

Signed-off-by: Johan Hedberg <johan.hedberg@intel.com>