### PR TITLE
tests: bluetooth/at: Fix string signedness issues

### DIFF
--- a/subsys/bluetooth/host/at.c
+++ b/subsys/bluetooth/host/at.c
@@ -92,7 +92,7 @@ static int get_cmd_value(struct at_client *at, struct net_buf *buf,
 {
 	int cmd_len = 0;
 	u8_t pos = at->pos;
-	const unsigned char *str = buf->data;
+	const char *str = (char *)buf->data;
 
 	while (cmd_len < buf->len && at->pos != at->buf_max_len) {
 		if (*str != stop_byte) {
@@ -122,7 +122,7 @@ static int get_response_string(struct at_client *at, struct net_buf *buf,
 {
 	int cmd_len = 0;
 	u8_t pos = at->pos;
-	const unsigned char *str = buf->data;
+	const char *str = (char *)buf->data;
 
 	while (cmd_len < buf->len && at->pos != at->buf_max_len) {
 		if (*str != stop_byte) {

--- a/subsys/bluetooth/host/at.h
+++ b/subsys/bluetooth/host/at.h
@@ -89,7 +89,7 @@ typedef int (*handle_cmd_input_t)(struct at_client *at, struct net_buf *buf,
 				  enum at_cmd_type type);
 
 struct at_client {
-	unsigned char *buf;
+	char *buf;
 	u8_t pos;
 	u8_t buf_max_len;
 	u8_t state;


### PR DESCRIPTION
To avoid signedness issues with some compilers, like icx, use 'char *'
instead of 'unsigned char *' for the at_client buffer.

Fixes #3600

Signed-off-by: Johan Hedberg <johan.hedberg@intel.com>