### PR TITLE
Bluetooth: Mesh: Fixes for issues reported by the icx compiler

### DIFF
--- a/subsys/bluetooth/host/mesh/prov.c
+++ b/subsys/bluetooth/host/mesh/prov.c
@@ -617,7 +617,8 @@ static int prov_auth(u8_t method, u8_t action, u8_t size)
 		}
 
 		if (output == BT_MESH_DISPLAY_STRING) {
-			u8_t i, str[9];
+			char str[9];
+			u8_t i;
 
 			bt_rand(str, size);
 

--- a/subsys/bluetooth/host/mesh/transport.c
+++ b/subsys/bluetooth/host/mesh/transport.c
@@ -980,7 +980,7 @@ static int trans_seg(struct net_buf_simple *buf, struct bt_mesh_net_rx *net_rx)
 	}
 
 	/* Bail out early if we're not ready to receive such a large SDU */
-	if (!sdu_len_is_ok(&net_rx->ctx, seg_n)) {
+	if (!sdu_len_is_ok(net_rx->ctl, seg_n)) {
 		BT_ERR("Too big incoming SDU length");
 		send_ack(net_rx->sub, net_rx->dst, net_rx->ctx.addr,
 			 net_rx->ctx.send_ttl, seq_zero, 0);


### PR DESCRIPTION
A couple of compiler warning fixes. The SDU length check is actually fairly important, and may be worthy for inclusion in 1.9.1.