### PR TITLE
arch: arm: add initial support for CONFIG_USERSPACE

### DIFF
--- a/arch/arm/core/Kconfig
+++ b/arch/arm/core/Kconfig
@@ -22,6 +22,8 @@ config CPU_CORTEX_M
 	select HAS_CMSIS
 	select HAS_FLASH_LOAD_OFFSET
 	select HAS_DTS
+	select ARCH_HAS_STACK_PROTECTION if ARM_CORE_MPU
+	select ARCH_HAS_USERSPACE if ARM_CORE_MPU
 	help
 	This option signifies the use of a CPU of the Cortex-M family.
 
@@ -46,6 +48,22 @@ config CPU_HAS_FPU
 	help
 	This option is enabled when the CPU has a hardware floating point
 	unit.
+
+config ARM_STACK_PROTECTION
+	bool
+	default y if HW_STACK_PROTECTION
+	select MPU_STACK_GUARD if ARM_CORE_MPU
+	help
+	This option enables MPU stack guard to cause a system fatal error
+	if the bounds of the current process stack are overflowed.
+
+config ARM_USERSPACE
+	bool
+	default y if USERSPACE
+	help
+	This option enables APIs to drop a thread's privileges,	supporting
+	user-level threads that are protected from each other and from
+	crashing the kernel.
 
 menu "Floating Point Options"
 depends on CPU_HAS_FPU

--- a/include/arch/arm/arch.h
+++ b/include/arch/arm/arch.h
@@ -200,6 +200,60 @@ extern "C" {
 #define _ARCH_THREAD_STACK_BUFFER(sym) \
 		((char *)(sym) + MPU_GUARD_ALIGN_AND_SIZE)
 
+#ifdef CONFIG_ARM_USERSPACE
+#ifndef _ASMLANGUAGE
+/* Syscall invocation macros. arm-specific machine constraints used to ensure
+ * args land in the proper registers. Currently, they are all stub functions
+ * just for enabling CONFIG_USERSPACE on arm w/o errors.
+ */
+
+static inline u32_t _arch_syscall_invoke6(u32_t arg1, u32_t arg2, u32_t arg3,
+					  u32_t arg4, u32_t arg5, u32_t arg6,
+					  u32_t call_id)
+{
+	return 0;
+}
+
+static inline u32_t _arch_syscall_invoke5(u32_t arg1, u32_t arg2, u32_t arg3,
+					  u32_t arg4, u32_t arg5, u32_t call_id)
+{
+	return 0;
+}
+
+static inline u32_t _arch_syscall_invoke4(u32_t arg1, u32_t arg2, u32_t arg3,
+					  u32_t arg4, u32_t call_id)
+{
+	return 0;
+}
+
+static inline u32_t _arch_syscall_invoke3(u32_t arg1, u32_t arg2, u32_t arg3,
+					  u32_t call_id)
+{
+	return 0;
+}
+
+static inline u32_t _arch_syscall_invoke2(u32_t arg1, u32_t arg2, u32_t call_id)
+{
+	return 0;
+}
+
+static inline u32_t _arch_syscall_invoke1(u32_t arg1, u32_t call_id)
+{
+	return 0;
+}
+
+static inline u32_t _arch_syscall_invoke0(u32_t call_id)
+{
+	return 0;
+}
+
+static inline int _arch_is_user_context(void)
+{
+	return 0;
+}
+#endif /* _ASMLANGUAGE */
+#endif /* CONFIG_ARM_USERSPACE */
+
 #ifdef __cplusplus
 }
 #endif

--- a/include/arch/arm/cortex_m/sys_io.h
+++ b/include/arch/arm/cortex_m/sys_io.h
@@ -64,6 +64,34 @@ static inline void sys_clear_bit(mem_addr_t addr, unsigned int bit)
 	*(volatile u32_t *)addr = temp & ~(1 << bit);
 }
 
+static inline int sys_test_bit(mem_addr_t addr, unsigned int bit)
+{
+	u32_t temp = *(volatile u32_t *)addr;
+
+	return temp & (1 << bit);
+}
+
+static ALWAYS_INLINE
+	void sys_bitfield_set_bit(mem_addr_t addr, unsigned int bit)
+{
+	/* Doing memory offsets in terms of 32-bit values to prevent
+	 * alignment issues
+	 */
+	sys_set_bit(addr + ((bit >> 5) << 2), bit & 0x1F);
+}
+
+static ALWAYS_INLINE
+	void sys_bitfield_clear_bit(mem_addr_t addr, unsigned int bit)
+{
+	sys_clear_bit(addr + ((bit >> 5) << 2), bit & 0x1F);
+}
+
+static ALWAYS_INLINE
+	int sys_bitfield_test_bit(mem_addr_t addr, unsigned int bit)
+{
+	return sys_test_bit(addr + ((bit >> 5) << 2), bit & 0x1F);
+}
+
 #endif /* !_ASMLANGUAGE */
 
 #endif /* _CORTEX_M_SYS_IO_H_ */

--- a/kernel/include/ksched.h
+++ b/kernel/include/ksched.h
@@ -526,7 +526,18 @@ static inline struct k_thread *_unpend_first_thread(_wait_q_t *wait_q)
  */
 static inline int _is_thread_user(void)
 {
+#ifdef CONFIG_ARCH_HAS_CUSTOM_SWAP_TO_MAIN
+	/* the _current might be NULL before the first thread is scheduled if
+	 * CONFIG_ARCH_HAS_CUSTOM_SWAP_TO_MAIN is enabled.
+	 */
+	if (!_current) {
+		return 0;
+	}
+
 	return _current->base.user_options & K_USER;
+#else
+	return _current->base.user_options & K_USER;
+#endif
 }
 #endif /* CONFIG_USERSPACE */
 #endif /* _ksched__h_ */


### PR DESCRIPTION
add related configs & (stub) functions for enabling
CONFIG_USERSPACE on arm w/o build errors.

Signed-off-by: Chunlin Han <chunlin.han@linaro.org>