### PR TITLE
Bluetooth: Mesh: Various fixes

### DIFF
--- a/subsys/bluetooth/host/mesh/access.c
+++ b/subsys/bluetooth/host/mesh/access.c
@@ -103,14 +103,14 @@ static void mod_publish(struct k_work *work)
 
 	BT_DBG("");
 
-	if (pub->func) {
-		pub->func(pub->mod);
-	}
-
 	period_ms = bt_mesh_model_pub_period_get(pub->mod);
 	BT_DBG("period %u ms", period_ms);
 	if (period_ms) {
 		k_delayed_work_submit(&pub->timer, period_ms);
+	}
+
+	if (pub->func) {
+		pub->func(pub->mod);
 	}
 }
 

--- a/subsys/bluetooth/host/mesh/cfg.c
+++ b/subsys/bluetooth/host/mesh/cfg.c
@@ -2960,7 +2960,7 @@ int bt_mesh_conf_init(struct bt_mesh_model *model, bool primary)
 	}
 
 	if (!IS_ENABLED(CONFIG_BT_MESH_FRIEND)) {
-		cfg->frnd = BT_MESH_RELAY_NOT_SUPPORTED;
+		cfg->frnd = BT_MESH_FRIEND_NOT_SUPPORTED;
 	}
 
 	if (!IS_ENABLED(CONFIG_BT_MESH_GATT_PROXY)) {

--- a/subsys/bluetooth/host/mesh/health.c
+++ b/subsys/bluetooth/host/mesh/health.c
@@ -105,8 +105,8 @@ static size_t health_get_current(struct bt_mesh_model *mod,
 		}
 	} else {
 		BT_WARN("No callback for getting faults");
-		net_buf_simple_push_u8(msg, HEALTH_TEST_STANDARD);
-		net_buf_simple_push_le16(msg, 0);
+		sys_put_le16(0, company_ptr);
+		*test_id = HEALTH_TEST_STANDARD;
 		fault_count = 0;
 	}
 

--- a/subsys/bluetooth/host/mesh/health.c
+++ b/subsys/bluetooth/host/mesh/health.c
@@ -79,6 +79,7 @@ static size_t health_get_current(struct bt_mesh_model *mod,
 				 struct net_buf_simple *msg)
 {
 	struct bt_mesh_health *srv = mod->user_data;
+	const struct bt_mesh_comp *comp;
 	u8_t *test_id, *company_ptr;
 	u16_t company_id;
 	u8_t fault_count;
@@ -88,6 +89,7 @@ static size_t health_get_current(struct bt_mesh_model *mod,
 
 	test_id = net_buf_simple_add(msg, 1);
 	company_ptr = net_buf_simple_add(msg, sizeof(company_id));
+	comp = bt_mesh_comp_get();
 
 	fault_count = net_buf_simple_tailroom(msg) - 4;
 
@@ -97,7 +99,7 @@ static size_t health_get_current(struct bt_mesh_model *mod,
 					 &fault_count);
 		if (err) {
 			BT_ERR("Failed to get faults (err %d)", err);
-			sys_put_le16(0, company_ptr);
+			sys_put_le16(comp->cid, company_ptr);
 			*test_id = HEALTH_TEST_STANDARD;
 			fault_count = 0;
 		} else {
@@ -105,7 +107,7 @@ static size_t health_get_current(struct bt_mesh_model *mod,
 		}
 	} else {
 		BT_WARN("No callback for getting faults");
-		sys_put_le16(0, company_ptr);
+		sys_put_le16(comp->cid, company_ptr);
 		*test_id = HEALTH_TEST_STANDARD;
 		fault_count = 0;
 	}

--- a/subsys/bluetooth/host/mesh/mesh.h
+++ b/subsys/bluetooth/host/mesh/mesh.h
@@ -12,6 +12,7 @@
 #define BT_MESH_ADDR_IS_UNICAST(addr) ((addr) && (addr) < 0x8000)
 #define BT_MESH_ADDR_IS_GROUP(addr) ((addr) >= 0xc000 && (addr) <= 0xff00)
 #define BT_MESH_ADDR_IS_VIRTUAL(addr) ((addr) >= 0x8000 && (addr) < 0xc000)
+#define BT_MESH_ADDR_IS_RFU(addr) ((addr) >= 0xff00 && (addr) <= 0xfffb)
 
 struct bt_mesh_net;
 

--- a/subsys/bluetooth/host/mesh/net.c
+++ b/subsys/bluetooth/host/mesh/net.c
@@ -1135,6 +1135,16 @@ int bt_mesh_net_decode(struct net_buf_simple *data, enum bt_mesh_net_if net_if,
 
 	BT_DBG("Decryption successful. Payload len %u", buf->len);
 
+	if (rx->dst == BT_MESH_ADDR_UNASSIGNED) {
+		BT_ERR("Destination address is unassigned; dropping packet");
+		return -EBADMSG;
+	}
+
+	if (BT_MESH_ADDR_IS_RFU(rx->dst)) {
+		BT_ERR("Destination address is RFU; dropping packet");
+		return -EBADMSG;
+	}
+
 	if (net_if != BT_MESH_NET_IF_LOCAL && bt_mesh_elem_find(rx->ctx.addr)) {
 		BT_DBG("Dropping locally originated packet");
 		return -EBADMSG;

--- a/subsys/bluetooth/host/mesh/prov.c
+++ b/subsys/bluetooth/host/mesh/prov.c
@@ -1195,12 +1195,6 @@ static void prov_msg_recv(void)
 
 	BT_DBG("type 0x%02x len %u", type, link.rx.buf->len);
 
-	if (type != PROV_FAILED && type != link.expect) {
-		BT_WARN("Unexpected msg 0x%02x != 0x%02x", type, link.expect);
-		prov_send_fail_msg(PROV_ERR_UNEXP_PDU);
-		return;
-	}
-
 	if (!bt_mesh_fcs_check(link.rx.buf, link.rx.fcs)) {
 		BT_ERR("Incorrect FCS");
 		return;
@@ -1209,6 +1203,12 @@ static void prov_msg_recv(void)
 	gen_prov_ack_send(link.rx.id);
 	link.rx.prev_id = link.rx.id;
 	link.rx.id = 0;
+
+	if (type != PROV_FAILED && type != link.expect) {
+		BT_WARN("Unexpected msg 0x%02x != 0x%02x", type, link.expect);
+		prov_send_fail_msg(PROV_ERR_UNEXP_PDU);
+		return;
+	}
 
 	if (type >= ARRAY_SIZE(prov_handlers)) {
 		BT_ERR("Unknown provisioning PDU type 0x%02x", type);


### PR DESCRIPTION
These fixes have been ported from the following MyNewt pull request (MyNewt uses a copy of the Zephyr Mesh, so the code is almost identical): https://github.com/apache/mynewt-core/pull/563/commits