### PR TITLE
Bluetooth: shell: Add controller DTM commands

### DIFF
--- a/subsys/bluetooth/shell/bt.c
+++ b/subsys/bluetooth/shell/bt.c
@@ -2048,6 +2048,11 @@ static const struct shell_cmd bt_commands[] = {
 	{ "advx", cmd_advx, "<on off> [coded] [anon] [txp]" },
 	{ "scanx", cmd_scanx, "<on passive off> [coded]" },
 #endif /* CONFIG_BT_CTLR_ADV_EXT */
+#if defined(CONFIG_BT_CTLR_DTM)
+	{ "test_tx", cmd_test_tx, "<chan> <len> <type> <phy>" },
+	{ "test_rx", cmd_test_rx, "<chan> <phy> <mod_idx>" },
+	{ "test_end", cmd_test_end, HELP_NONE},
+#endif /* CONFIG_BT_CTLR_ADV_EXT */
 	{ NULL, NULL, NULL }
 };
 

--- a/subsys/bluetooth/shell/ll.c
+++ b/subsys/bluetooth/shell/ll.c
@@ -9,6 +9,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+#include <stdlib.h>
 #include <string.h>
 #include <zephyr.h>
 #include <shell/shell.h>
@@ -17,6 +18,72 @@
 #include <bluetooth/hci.h>
 
 #include "../controller/include/ll.h"
+
+#if defined(CONFIG_BT_CTLR_DTM)
+#include "../controller/ll_sw/ll_test.h"
+
+int cmd_test_tx(int argc, char *argv[])
+{
+	u8_t chan, len, type, phy;
+	u32_t err;
+
+	if (argc < 5) {
+		return -EINVAL;
+	}
+
+	chan = strtoul(argv[1], NULL, 16);
+	len  = strtoul(argv[2], NULL, 16);
+	type = strtoul(argv[3], NULL, 16);
+	phy  = strtoul(argv[4], NULL, 16);
+
+	err = ll_test_tx(chan, len, type, phy);
+	if (err) {
+		return -EINVAL;
+	}
+
+	printk("test_tx...\n");
+
+	return 0;
+}
+
+int cmd_test_rx(int argc, char *argv[])
+{
+	u8_t chan, phy, mod_idx;
+	u32_t err;
+
+	if (argc < 4) {
+		return -EINVAL;
+	}
+
+	chan    = strtoul(argv[1], NULL, 16);
+	phy     = strtoul(argv[2], NULL, 16);
+	mod_idx = strtoul(argv[3], NULL, 16);
+
+	err = ll_test_rx(chan, phy, mod_idx);
+	if (err) {
+		return -EINVAL;
+	}
+
+	printk("test_rx...\n");
+
+	return 0;
+}
+
+int cmd_test_end(int argc, char *argv[])
+{
+	u16_t num_rx;
+	u32_t err;
+
+	err = ll_test_end(&num_rx);
+	if (err) {
+		return -EINVAL;
+	}
+
+	printk("num_rx= %u.\n", num_rx);
+
+	return 0;
+}
+#endif /* CONFIG_BT_CTLR_DTM */
 
 #if defined(CONFIG_BT_CTLR_ADV_EXT)
 #define ADV_INTERVAL 0x000020

--- a/subsys/bluetooth/shell/ll.h
+++ b/subsys/bluetooth/shell/ll.h
@@ -16,4 +16,8 @@
 int cmd_advx(int argc, char *argv[]);
 int cmd_scanx(int argc, char *argv[]);
 
+int cmd_test_tx(int argc, char *argv[]);
+int cmd_test_rx(int argc, char *argv[]);
+int cmd_test_end(int argc, char *argv[]);
+
 #endif /* __LL_H */


### PR DESCRIPTION
Add controller Direct Test Mode commands to bt shell module.

Signed-off-by: Vinayak Kariappa Chettimada <vich@nordicsemi.no>