### PR TITLE
net: Allow user to tweak IPv4 TTL per packet

### DIFF
--- a/include/net/net_pkt.h
+++ b/include/net/net_pkt.h
@@ -95,8 +95,15 @@ struct net_pkt {
 	u8_t family     : 4;	/* IPv4 vs IPv6 */
 	u8_t _unused    : 3;
 
+	union {
+		/* IPv6 hop limit or IPv4 ttl for this network packet.
+		 * The value is shared between IPv6 and IPv4.
+		 */
+		u8_t ipv6_hop_limit;
+		u8_t ipv4_ttl;
+	};
+
 #if defined(CONFIG_NET_IPV6)
-	u8_t ipv6_hop_limit;	/* IPv6 hop limit for this network packet. */
 	u8_t ipv6_ext_len;	/* length of extension headers */
 	u8_t ipv6_ext_opt_len; /* IPv6 ND option length */
 
@@ -246,6 +253,19 @@ static inline void net_pkt_set_forwarding(struct net_pkt *pkt, bool forward)
 static inline bool net_pkt_forwarding(struct net_pkt *pkt)
 {
 	return false;
+}
+#endif
+
+#if defined(CONFIG_NET_IPV4)
+static inline u8_t net_pkt_ipv4_ttl(struct net_pkt *pkt)
+{
+	return pkt->ipv4_ttl;
+}
+
+static inline void net_pkt_set_ipv4_ttl(struct net_pkt *pkt,
+					u8_t ttl)
+{
+	pkt->ipv4_ttl = ttl;
 }
 #endif
 

--- a/subsys/net/ip/ipv4.c
+++ b/subsys/net/ip/ipv4.c
@@ -42,7 +42,12 @@ struct net_pkt *net_ipv4_create_raw(struct net_pkt *pkt,
 	NET_IPV4_HDR(pkt)->tos = 0x00;
 	NET_IPV4_HDR(pkt)->proto = 0;
 
-	NET_IPV4_HDR(pkt)->ttl = net_if_ipv4_get_ttl(iface);
+	/* User can tweak the default TTL if needed */
+	NET_IPV4_HDR(pkt)->ttl = net_pkt_ipv4_ttl(pkt);
+	if (NET_IPV4_HDR(pkt)->ttl == 0) {
+		NET_IPV4_HDR(pkt)->ttl = net_if_ipv4_get_ttl(iface);
+	}
+
 	NET_IPV4_HDR(pkt)->offset[0] = NET_IPV4_HDR(pkt)->offset[1] = 0;
 	NET_IPV4_HDR(pkt)->id[0] = NET_IPV4_HDR(pkt)->id[1] = 0;
 


### PR DESCRIPTION
User was able to tweak IPv6 hop-limit so introduce similar
feature for IPv4 Time-To-Live value.

Signed-off-by: Jukka Rissanen <jukka.rissanen@linux.intel.com>