### PR TITLE
gen_kobject_list.py: device driver support

### DIFF
--- a/include/kernel.h
+++ b/include/kernel.h
@@ -124,7 +124,12 @@ struct k_timer;
 struct k_poll_event;
 struct k_poll_signal;
 
+/* This enumeration needs to be kept in sync with the lists of kernel objects
+ * and subsystems in scripts/gen_kobject_list.py, as well as the otype_to_str()
+ * function in kernel/userspace.c
+ */
 enum k_objects {
+	/* Core kernel objects */
 	K_OBJ_ALERT,
 	K_OBJ_DELAYED_WORK,
 	K_OBJ_MEM_SLAB,
@@ -137,6 +142,29 @@ enum k_objects {
 	K_OBJ_TIMER,
 	K_OBJ_WORK,
 	K_OBJ_WORK_Q,
+
+	/* Driver subsystems */
+	K_OBJ_DRIVER_ADC,
+	K_OBJ_DRIVER_AIO_CMP,
+	K_OBJ_DRIVER_CLOCK_CONTROL,
+	K_OBJ_DRIVER_COUNTER,
+	K_OBJ_DRIVER_CRYPTO,
+	K_OBJ_DRIVER_DMA,
+	K_OBJ_DRIVER_ETH,
+	K_OBJ_DRIVER_FLASH,
+	K_OBJ_DRIVER_GPIO,
+	K_OBJ_DRIVER_I2C,
+	K_OBJ_DRIVER_I2S,
+	K_OBJ_DRIVER_IPM,
+	K_OBJ_DRIVER_PINMUX,
+	K_OBJ_DRIVER_PWM,
+	K_OBJ_DRIVER_RANDOM,
+	K_OBJ_DRIVER_RTC,
+	K_OBJ_DRIVER_SENSOR,
+	K_OBJ_DRIVER_SHARED_IRQ,
+	K_OBJ_DRIVER_SPI,
+	K_OBJ_DRIVER_UART,
+	K_OBJ_DRIVER_WDT,
 
 	K_OBJ_LAST
 };

--- a/kernel/device.c
+++ b/kernel/device.c
@@ -52,6 +52,7 @@ void _sys_device_do_config_level(int level)
 		struct device_config *device = info->config;
 
 		device->init(info);
+		_k_object_init(info);
 	}
 }
 

--- a/kernel/userspace.c
+++ b/kernel/userspace.c
@@ -33,6 +33,7 @@ const char *otype_to_str(enum k_objects otype)
 	 */
 #ifdef CONFIG_PRINTK
 	switch (otype) {
+	/* Core kernel objects */
 	case K_OBJ_ALERT:
 		return "k_alert";
 	case K_OBJ_DELAYED_WORK:
@@ -57,6 +58,50 @@ const char *otype_to_str(enum k_objects otype)
 		return "k_work";
 	case K_OBJ_WORK_Q:
 		return "k_work_q";
+
+	/* Driver subsystems */
+	case K_OBJ_DRIVER_ADC:
+		return "adc driver";
+	case K_OBJ_DRIVER_AIO_CMP:
+		return "aio comparator driver";
+	case K_OBJ_DRIVER_CLOCK_CONTROL:
+		return "clock control driver";
+	case K_OBJ_DRIVER_COUNTER:
+		return "counter driver";
+	case K_OBJ_DRIVER_CRYPTO:
+		return "crypto driver";
+	case K_OBJ_DRIVER_DMA:
+		return "dma driver";
+	case K_OBJ_DRIVER_ETH:
+		return "ethernet driver";
+	case K_OBJ_DRIVER_FLASH:
+		return "flash driver";
+	case K_OBJ_DRIVER_GPIO:
+		return "gpio driver";
+	case K_OBJ_DRIVER_I2C:
+		return "i2c driver";
+	case K_OBJ_DRIVER_I2S:
+		return "i2s driver";
+	case K_OBJ_DRIVER_IPM:
+		return "ipm driver";
+	case K_OBJ_DRIVER_PINMUX:
+		return "pinmux driver";
+	case K_OBJ_DRIVER_PWM:
+		return "pwm driver";
+	case K_OBJ_DRIVER_RANDOM:
+		return "random driver";
+	case K_OBJ_DRIVER_RTC:
+		return "realtime clock driver";
+	case K_OBJ_DRIVER_SENSOR:
+		return "sensor driver";
+	case K_OBJ_DRIVER_SHARED_IRQ:
+		return "shared irq driver";
+	case K_OBJ_DRIVER_SPI:
+		return "spi driver";
+	case K_OBJ_DRIVER_UART:
+		return "uart driver";
+	case K_OBJ_DRIVER_WDT:
+		return "watchdog timer driver";
 	default:
 		return "?";
 	}


### PR DESCRIPTION
Device drivers need to be treated like other kernel objects, with
thread-level permissions and validation of struct device pointers passed
in from userspace when making API calls.

However it's not sufficient to identify an object as a driver, we need
to know what subsystem it belongs to (if any) so that userspace cannot,
for example, make Ethernet driver API calls using a UART driver object.

Upon encountering a variable representing a device struct, we look at
the value of its driver_api member. If that corresponds to an instance
of a driver API struct belonging to a known subsystem, the proper
K_OBJ_DRIVER_* enumeration type will be associated with this device in
the generated gperf table.

If there is no API struct or it doesn't correspond to a known subsystem,
the device is omitted from the table; it's presumably used internally
by the kernel or is a singleton with specific APIs for it that do not
take a struct device parameter.

The list of kobjects and subsystems in the script is simplified since
the enumeration type name is strongly derived from the name of the data
structure.

A device objects is marked as initialized after its init function has
been run at boot.

Signed-off-by: Andrew Boie <andrew.p.boie@intel.com>