### PR TITLE
net: ipv6: Fix IPv6 address parameters when sending NA

### DIFF
--- a/subsys/net/ip/ipv6.c
+++ b/subsys/net/ip/ipv6.c
@@ -1148,8 +1148,8 @@ static inline void handle_ns_neighbor(struct net_pkt *pkt, u8_t ll_len,
 	nbr_add(pkt, &nbr_lladdr, false, NET_IPV6_NBR_STATE_INCOMPLETE);
 }
 
-int net_ipv6_send_na(struct net_if *iface, struct in6_addr *src,
-		     struct in6_addr *dst, struct in6_addr *tgt,
+int net_ipv6_send_na(struct net_if *iface, const struct in6_addr *src,
+		     const struct in6_addr *dst, const struct in6_addr *tgt,
 		     u8_t flags)
 {
 	struct net_icmpv6_na_hdr hdr, *na_hdr;

--- a/subsys/net/ip/ipv6.h
+++ b/subsys/net/ip/ipv6.h
@@ -130,8 +130,8 @@ int net_ipv6_send_ns(struct net_if *iface, struct net_pkt *pending,
 int net_ipv6_send_rs(struct net_if *iface);
 int net_ipv6_start_rs(struct net_if *iface);
 
-int net_ipv6_send_na(struct net_if *iface, struct in6_addr *src,
-		     struct in6_addr *dst, struct in6_addr *tgt,
+int net_ipv6_send_na(struct net_if *iface, const struct in6_addr *src,
+		     const struct in6_addr *dst, const struct in6_addr *tgt,
 		     u8_t flags);
 
 /**


### PR DESCRIPTION
The IPv6 address parameters in net_ipv6_send_na() can be const
as the function will not modify them. This avoids compile warning
about parameter constness.

Signed-off-by: Jukka Rissanen <jukka.rissanen@linux.intel.com>