### PR TITLE
drivers: eth: mcux: Fix buffer overflow

### DIFF
--- a/drivers/ethernet/eth_mcux.c
+++ b/drivers/ethernet/eth_mcux.c
@@ -81,8 +81,11 @@ struct eth_context {
 	 * in Zephyr, and adding needed interface to MCUX (or
 	 * bypassing it and writing a more complex driver working
 	 * directly with hardware).
+	 *
+	 * Note that we do not copy FCS into this buffer thus the
+	 * size is 1514 bytes.
 	 */
-	u8_t frame_buf[1500];
+	u8_t frame_buf[1500 + 14]; /* Max MTU + ethernet header size */
 };
 
 static void eth_0_config_func(void);


### PR DESCRIPTION
If we were trying to send max MTU size data, then the temporary
frame_buf was overflowing because it only allocated 1500 bytes
for the buffer but then copied 1514 bytes into it (max mtu +
ethernet header).

Signed-off-by: Jukka Rissanen <jukka.rissanen@linux.intel.com>