### PR TITLE
doc: add sphinx/breathe conf to eliminate warnings

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -342,13 +342,21 @@ breathe_projects = {
 }
 breathe_default_project = "Zephyr"
 
+# Qualifiers to a function are causing Sphihx/Breathe to warn about
+# Error when parsing function declaration and more.  This is a list
+# of strings that the parser additionally should accept as
+# attributes.
+cpp_id_attributes = ['__syscall', '__syscall_inline', '__deprecated' ]
+
 # docs_title is used in the breadcrumb title in the zephyr docs theme
 html_context = {
     'show_license': html_show_license,
     'docs_title': docs_title,
 }
 
-extlinks = {'jira': ('https://jira.zephyrproject.org/browse/%s', '')}
+extlinks = {'jira': ('https://jira.zephyrproject.org/browse/%s', ''),
+            'github': ('https://github.com/zephyrproject-rtos/zephyr/issues/%s', '')
+           }
 
 # some configuration for linkcheck builder
 #   noticed that we're getting false-positive link errors on JIRA, I suspect


### PR DESCRIPTION
The doxygen/sphinx/breathe processing for API documentation has some
known issues and we've been using a post-processing filter to eliminate
"expected" warnings.  Sphinx/Breathe 5.0 was updated to support
identifying attributes causing these warnings, so this PR adds a
starting list to get around warnings recently introduced with __syscall
and __syscall_inline (PR #4103).

Signed-off-by: David B. Kinder <david.b.kinder@intel.com>