### PR TITLE
syscalls: implicit cast for _SYSCALL_MEMORY

### DIFF
--- a/kernel/include/syscall_handler.h
+++ b/kernel/include/syscall_handler.h
@@ -51,7 +51,7 @@ extern const _k_syscall_handler_t _k_syscall_table[K_SYSCALL_LIMIT];
  * @param ssf Syscall stack frame argument passed to the handler function
  */
 #define _SYSCALL_MEMORY(ptr, size, write, ssf) \
-	_SYSCALL_VERIFY(!_arch_buffer_validate(ptr, size, write), ssf)
+	_SYSCALL_VERIFY(!_arch_buffer_validate((void *)ptr, size, write), ssf)
 
 /**
  * @brief Runtime check that a pointer is a kernel object of expected type


### PR DESCRIPTION
Everything get passed to handlers as u32_t, make it simpler to check
something that is known to be a pointer, like we already do with
_SYSCALL_IS_OBJ().

Signed-off-by: Andrew Boie <andrew.p.boie@intel.com>