### PR TITLE
Makefile: put tests/ under libs-y

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -605,8 +605,8 @@ include/config/auto.conf: ;
 endif # $(dot-config)
 
 # kernel objects are built as a static library
-libs-y := lib/
-core-y := kernel/ drivers/ misc/ boards/ ext/ subsys/ tests/ arch/
+libs-y := lib/ tests/
+core-y := kernel/ drivers/ misc/ boards/ ext/ subsys/ arch/
 
 ARCH = $(subst $(DQUOTE),,$(CONFIG_ARCH))
 export ARCH


### PR DESCRIPTION
ztest framework doesn't do anything privileged, it interacts with the
kernel using system calls like other application code and should be
considered runtime logic.

Signed-off-by: Andrew Boie <andrew.p.boie@intel.com>