### PR TITLE
kernel: expose API when userspace not enabled

### DIFF
--- a/include/kernel.h
+++ b/include/kernel.h
@@ -539,7 +539,6 @@ extern k_tid_t k_thread_create(struct k_thread *new_thread,
 			       void *p1, void *p2, void *p3,
 			       int prio, u32_t options, s32_t delay);
 
-#ifdef CONFIG_USERSPACE
 /**
  * @brief Drop a thread's privileges permanently to user mode
  *
@@ -551,7 +550,6 @@ extern k_tid_t k_thread_create(struct k_thread *new_thread,
 extern FUNC_NORETURN void k_thread_user_mode_enter(k_thread_entry_t entry,
 						   void *p1, void *p2,
 						   void *p3);
-#endif
 
 /**
  * @brief Put the current thread to sleep.

--- a/kernel/thread.c
+++ b/kernel/thread.c
@@ -500,13 +500,15 @@ void _k_thread_group_leave(u32_t groups, struct k_thread *thread)
 	thread_data->init_groups &= groups;
 }
 
-
-#ifdef CONFIG_USERSPACE
 FUNC_NORETURN void k_thread_user_mode_enter(k_thread_entry_t entry,
 					    void *p1, void *p2, void *p3)
 {
 	_current->base.user_options |= K_USER;
 	_thread_essential_clear();
+#ifdef CONFIG_USERSPACE
 	_arch_user_mode_enter(entry, p1, p2, p3);
+#else
+	/* XXX In this case we do not reset the stack */
+	_thread_entry(entry, p1, p2, p3);
+#endif
 }
-#endif /* CONFIG_USERSPACE */


### PR DESCRIPTION
We want applications to be able to enable and disable userspace without
changing any code. k_thread_user_mode_enter() now just jumps into the
entry point if CONFIG_USERSPACE is disabled.

Signed-off-by: Andrew Boie <andrew.p.boie@intel.com>