### PR TITLE
kernel: make 'static inline' implicit to __syscall

### DIFF
--- a/include/kernel.h
+++ b/include/kernel.h
@@ -2505,9 +2505,8 @@ struct k_sem {
  *
  * @return N/A
  */
-__syscall static inline void k_sem_init(struct k_sem *sem,
-					unsigned int initial_count,
-					unsigned int limit);
+__syscall void k_sem_init(struct k_sem *sem, unsigned int initial_count,
+			  unsigned int limit);
 
 /**
  * @brief Take a semaphore.
@@ -2530,7 +2529,7 @@ __syscall static inline void k_sem_init(struct k_sem *sem,
  * @retval -EBUSY Returned without waiting.
  * @retval -EAGAIN Waiting period timed out.
  */
-__syscall static inline int k_sem_take(struct k_sem *sem, s32_t timeout);
+__syscall int k_sem_take(struct k_sem *sem, s32_t timeout);
 
 /**
  * @brief Give a semaphore.
@@ -2544,7 +2543,7 @@ __syscall static inline int k_sem_take(struct k_sem *sem, s32_t timeout);
  *
  * @return N/A
  */
-__syscall static inline void k_sem_give(struct k_sem *sem);
+__syscall void k_sem_give(struct k_sem *sem);
 
 /**
  * @brief Reset a semaphore's count to zero.
@@ -2555,7 +2554,7 @@ __syscall static inline void k_sem_give(struct k_sem *sem);
  *
  * @return N/A
  */
-__syscall_inline static inline void k_sem_reset(struct k_sem *sem);
+__syscall_inline void k_sem_reset(struct k_sem *sem);
 
 static inline void _impl_k_sem_reset(struct k_sem *sem)
 {
@@ -2571,7 +2570,7 @@ static inline void _impl_k_sem_reset(struct k_sem *sem)
  *
  * @return Current semaphore count.
  */
-__syscall_inline static inline unsigned int k_sem_count_get(struct k_sem *sem);
+__syscall_inline unsigned int k_sem_count_get(struct k_sem *sem);
 
 static inline unsigned int _impl_k_sem_count_get(struct k_sem *sem)
 {

--- a/include/toolchain/common.h
+++ b/include/toolchain/common.h
@@ -106,6 +106,12 @@
 #define _DO_CONCAT(x, y) x ## y
 #define _CONCAT(x, y) _DO_CONCAT(x, y)
 
+/* Additionally used as a sentinel by gen_syscalls.py to identify what
+ * functions are system calls
+ */
+#define __syscall static inline
+#define __syscall_inline static inline
+
 #ifndef BUILD_ASSERT
 /* compile-time assertion that makes the build fail */
 #define BUILD_ASSERT(EXPR) typedef char __build_assert_failure[(EXPR) ? 1 : -1]

--- a/include/toolchain/gcc.h
+++ b/include/toolchain/gcc.h
@@ -95,10 +95,6 @@ do {                                                                    \
 #define __deprecated	__attribute__((deprecated))
 #define ARG_UNUSED(x) (void)(x)
 
-/* Only used by gen_syscalls.py */
-#define __syscall
-#define __syscall_inline
-
 #define likely(x)   __builtin_expect((long)!!(x), 1L)
 #define unlikely(x) __builtin_expect((long)!!(x), 0L)
 


### PR DESCRIPTION
The fact that these are all static inline functions internally is an
implementation detail.

Signed-off-by: Andrew Boie <andrew.p.boie@intel.com>