### PR TITLE
x86: fix _arch_syscall_invoke6()

### DIFF
--- a/include/arch/x86/arch.h
+++ b/include/arch/x86/arch.h
@@ -576,7 +576,7 @@ static inline u32_t _arch_syscall_invoke6(u32_t arg1, u32_t arg2, u32_t arg3,
 #endif
 			 : "S" (call_id), "a" (arg1), "d" (arg2),
 			   "c" (arg3), "b" (arg4), "D" (arg5),
-			   [arg6] "r" (arg6));
+			   [arg6] "m" (arg6));
 	return ret;
 }
 


### PR DESCRIPTION
The compiler was complaining about impossible constraints since register
constraint was provided, but there are no general purpose registers left
available.

Signed-off-by: Andrew Boie <andrew.p.boie@intel.com>