### PR TITLE
kernel: implement some system calls

### DIFF
--- a/arch/arm/core/thread_abort.c
+++ b/arch/arm/core/thread_abort.c
@@ -26,7 +26,7 @@
 
 extern void _k_thread_single_abort(struct k_thread *thread);
 
-void k_thread_abort(k_tid_t thread)
+void _impl_k_thread_abort(k_tid_t thread)
 {
 	unsigned int key;
 

--- a/include/kernel.h
+++ b/include/kernel.h
@@ -2862,8 +2862,8 @@ struct k_msgq {
  *
  * @return N/A
  */
-extern void k_msgq_init(struct k_msgq *q, char *buffer,
-			size_t msg_size, u32_t max_msgs);
+__syscall void k_msgq_init(struct k_msgq *q, char *buffer,
+			   size_t msg_size, u32_t max_msgs);
 
 /**
  * @brief Send a message to a message queue.
@@ -2881,7 +2881,7 @@ extern void k_msgq_init(struct k_msgq *q, char *buffer,
  * @retval -ENOMSG Returned without waiting or queue purged.
  * @retval -EAGAIN Waiting period timed out.
  */
-extern int k_msgq_put(struct k_msgq *q, void *data, s32_t timeout);
+__syscall int k_msgq_put(struct k_msgq *q, void *data, s32_t timeout);
 
 /**
  * @brief Receive a message from a message queue.
@@ -2900,7 +2900,7 @@ extern int k_msgq_put(struct k_msgq *q, void *data, s32_t timeout);
  * @retval -ENOMSG Returned without waiting.
  * @retval -EAGAIN Waiting period timed out.
  */
-extern int k_msgq_get(struct k_msgq *q, void *data, s32_t timeout);
+__syscall int k_msgq_get(struct k_msgq *q, void *data, s32_t timeout);
 
 /**
  * @brief Purge a message queue.
@@ -2913,7 +2913,7 @@ extern int k_msgq_get(struct k_msgq *q, void *data, s32_t timeout);
  *
  * @return N/A
  */
-extern void k_msgq_purge(struct k_msgq *q);
+__syscall void k_msgq_purge(struct k_msgq *q);
 
 /**
  * @brief Get the amount of free space in a message queue.
@@ -2925,7 +2925,9 @@ extern void k_msgq_purge(struct k_msgq *q);
  *
  * @return Number of unused ring buffer entries.
  */
-static inline u32_t k_msgq_num_free_get(struct k_msgq *q)
+__syscall u32_t k_msgq_num_free_get(struct k_msgq *q);
+
+static inline u32_t _impl_k_msgq_num_free_get(struct k_msgq *q)
 {
 	return q->max_msgs - q->used_msgs;
 }
@@ -2939,7 +2941,9 @@ static inline u32_t k_msgq_num_free_get(struct k_msgq *q)
  *
  * @return Number of messages.
  */
-static inline u32_t k_msgq_num_used_get(struct k_msgq *q)
+__syscall u32_t k_msgq_num_used_get(struct k_msgq *q);
+
+static inline u32_t _impl_k_msgq_num_used_get(struct k_msgq *q)
 {
 	return q->used_msgs;
 }

--- a/include/kernel.h
+++ b/include/kernel.h
@@ -620,7 +620,7 @@ extern void k_busy_wait(u32_t usec_to_wait);
  *
  * @return N/A
  */
-extern void k_yield(void);
+__syscall void k_yield(void);
 
 /**
  * @brief Wake up a sleeping thread.
@@ -633,7 +633,7 @@ extern void k_yield(void);
  *
  * @return N/A
  */
-extern void k_wakeup(k_tid_t thread);
+__syscall void k_wakeup(k_tid_t thread);
 
 /**
  * @brief Get thread ID of the current thread.
@@ -653,7 +653,7 @@ __syscall k_tid_t k_current_get(void);
  * @retval 0 Thread spawning canceled.
  * @retval -EINVAL Thread has already started executing.
  */
-extern int k_thread_cancel(k_tid_t thread);
+__syscall int k_thread_cancel(k_tid_t thread);
 
 /**
  * @brief Abort a thread.
@@ -669,7 +669,7 @@ extern int k_thread_cancel(k_tid_t thread);
  *
  * @return N/A
  */
-extern void k_thread_abort(k_tid_t thread);
+__syscall void k_thread_abort(k_tid_t thread);
 
 
 /**
@@ -681,7 +681,7 @@ extern void k_thread_abort(k_tid_t thread);
  *
  * @param thread thread to start
  */
-extern void k_thread_start(k_tid_t thread);
+__syscall void k_thread_start(k_tid_t thread);
 
 /**
  * @cond INTERNAL_HIDDEN
@@ -808,7 +808,7 @@ __syscall int k_thread_priority_get(k_tid_t thread);
  *
  * @return N/A
  */
-extern void k_thread_priority_set(k_tid_t thread, int prio);
+__syscall void k_thread_priority_set(k_tid_t thread, int prio);
 
 /**
  * @brief Suspend a thread.
@@ -824,7 +824,7 @@ extern void k_thread_priority_set(k_tid_t thread, int prio);
  *
  * @return N/A
  */
-extern void k_thread_suspend(k_tid_t thread);
+__syscall void k_thread_suspend(k_tid_t thread);
 
 /**
  * @brief Resume a suspended thread.
@@ -838,7 +838,7 @@ extern void k_thread_suspend(k_tid_t thread);
  *
  * @return N/A
  */
-extern void k_thread_resume(k_tid_t thread);
+__syscall void k_thread_resume(k_tid_t thread);
 
 /**
  * @brief Set time-slicing period and scope.
@@ -908,7 +908,7 @@ extern int k_is_in_isr(void);
  * @return 0 if invoked by an ISR or by a cooperative thread.
  * @return Non-zero if invoked by a preemptible thread.
  */
-extern int k_is_preempt_thread(void);
+__syscall int k_is_preempt_thread(void);
 
 /**
  * @} end addtogroup isr_apis
@@ -963,7 +963,7 @@ extern void k_sched_unlock(void);
  *
  * @return N/A
  */
-extern void k_thread_custom_data_set(void *value);
+__syscall void k_thread_custom_data_set(void *value);
 
 /**
  * @brief Get current thread's custom data.
@@ -972,7 +972,7 @@ extern void k_thread_custom_data_set(void *value);
  *
  * @return Current custom data value.
  */
-extern void *k_thread_custom_data_get(void);
+__syscall void *k_thread_custom_data_get(void);
 
 /**
  * @} end addtogroup thread_apis

--- a/include/kernel.h
+++ b/include/kernel.h
@@ -599,7 +599,7 @@ extern FUNC_NORETURN void k_thread_user_mode_enter(k_thread_entry_t entry,
  *
  * @return N/A
  */
-extern void k_sleep(s32_t duration);
+__syscall void k_sleep(s32_t duration);
 
 /**
  * @brief Cause the current thread to busy wait.
@@ -640,7 +640,7 @@ extern void k_wakeup(k_tid_t thread);
  *
  * @return ID of current thread.
  */
-extern k_tid_t k_current_get(void);
+__syscall k_tid_t k_current_get(void);
 
 /**
  * @brief Cancel thread performing a delayed start.
@@ -779,7 +779,7 @@ struct _static_thread_data {
  *
  * @return Priority of @a thread.
  */
-extern int  k_thread_priority_get(k_tid_t thread);
+__syscall int k_thread_priority_get(k_tid_t thread);
 
 /**
  * @brief Set a thread's priority.
@@ -1414,7 +1414,7 @@ static inline void k_disable_sys_clock_always_on(void)
  *
  * @return Current uptime.
  */
-extern u32_t k_uptime_get_32(void);
+__syscall u32_t k_uptime_get_32(void);
 
 /**
  * @brief Get elapsed time.

--- a/include/kernel.h
+++ b/include/kernel.h
@@ -2454,7 +2454,7 @@ struct k_mutex {
  *
  * @return N/A
  */
-extern void k_mutex_init(struct k_mutex *mutex);
+__syscall void k_mutex_init(struct k_mutex *mutex);
 
 /**
  * @brief Lock a mutex.
@@ -2474,7 +2474,7 @@ extern void k_mutex_init(struct k_mutex *mutex);
  * @retval -EBUSY Returned without waiting.
  * @retval -EAGAIN Waiting period timed out.
  */
-extern int k_mutex_lock(struct k_mutex *mutex, s32_t timeout);
+__syscall int k_mutex_lock(struct k_mutex *mutex, s32_t timeout);
 
 /**
  * @brief Unlock a mutex.
@@ -2490,7 +2490,7 @@ extern int k_mutex_lock(struct k_mutex *mutex, s32_t timeout);
  *
  * @return N/A
  */
-extern void k_mutex_unlock(struct k_mutex *mutex);
+__syscall void k_mutex_unlock(struct k_mutex *mutex);
 
 /**
  * @} end defgroup mutex_apis

--- a/include/kernel.h
+++ b/include/kernel.h
@@ -1243,8 +1243,8 @@ extern void k_timer_init(struct k_timer *timer,
  *
  * @return N/A
  */
-extern void k_timer_start(struct k_timer *timer,
-			  s32_t duration, s32_t period);
+__syscall void k_timer_start(struct k_timer *timer,
+			     s32_t duration, s32_t period);
 
 /**
  * @brief Stop a timer.
@@ -1262,7 +1262,7 @@ extern void k_timer_start(struct k_timer *timer,
  *
  * @return N/A
  */
-extern void k_timer_stop(struct k_timer *timer);
+__syscall void k_timer_stop(struct k_timer *timer);
 
 /**
  * @brief Read timer status.
@@ -1276,7 +1276,7 @@ extern void k_timer_stop(struct k_timer *timer);
  *
  * @return Timer status.
  */
-extern u32_t k_timer_status_get(struct k_timer *timer);
+__syscall u32_t k_timer_status_get(struct k_timer *timer);
 
 /**
  * @brief Synchronize thread to timer expiration.
@@ -1295,7 +1295,7 @@ extern u32_t k_timer_status_get(struct k_timer *timer);
  *
  * @return Timer status.
  */
-extern u32_t k_timer_status_sync(struct k_timer *timer);
+__syscall u32_t k_timer_status_sync(struct k_timer *timer);
 
 /**
  * @brief Get time remaining before a timer next expires.
@@ -1307,7 +1307,9 @@ extern u32_t k_timer_status_sync(struct k_timer *timer);
  *
  * @return Remaining time (in milliseconds).
  */
-static inline s32_t k_timer_remaining_get(struct k_timer *timer)
+__syscall s32_t k_timer_remaining_get(struct k_timer *timer);
+
+static inline s32_t _impl_k_timer_remaining_get(struct k_timer *timer)
 {
 	return _timeout_remaining_get(&timer->timeout);
 }
@@ -1326,8 +1328,10 @@ static inline s32_t k_timer_remaining_get(struct k_timer *timer)
  *
  * @return N/A
  */
-static inline void k_timer_user_data_set(struct k_timer *timer,
-					 void *user_data)
+__syscall void k_timer_user_data_set(struct k_timer *timer, void *user_data);
+
+static inline void _impl_k_timer_user_data_set(struct k_timer *timer,
+					       void *user_data)
 {
 	timer->user_data = user_data;
 }
@@ -1339,7 +1343,9 @@ static inline void k_timer_user_data_set(struct k_timer *timer,
  *
  * @return The user data.
  */
-static inline void *k_timer_user_data_get(struct k_timer *timer)
+__syscall void *k_timer_user_data_get(struct k_timer *timer);
+
+static inline void *_impl_k_timer_user_data_get(struct k_timer *timer)
 {
 	return timer->user_data;
 }

--- a/include/kernel.h
+++ b/include/kernel.h
@@ -2747,7 +2747,7 @@ extern void k_alert_init(struct k_alert *alert, k_alert_handler_t handler,
  * @retval -EBUSY Returned without waiting.
  * @retval -EAGAIN Waiting period timed out.
  */
-extern int k_alert_recv(struct k_alert *alert, s32_t timeout);
+__syscall int k_alert_recv(struct k_alert *alert, s32_t timeout);
 
 /**
  * @brief Signal an alert.
@@ -2763,7 +2763,7 @@ extern int k_alert_recv(struct k_alert *alert, s32_t timeout);
  *
  * @return N/A
  */
-extern void k_alert_send(struct k_alert *alert);
+__syscall void k_alert_send(struct k_alert *alert);
 
 /**
  * @} end addtogroup alert_apis

--- a/include/kernel.h
+++ b/include/kernel.h
@@ -3239,8 +3239,8 @@ struct k_pipe {
  *
  * @return N/A
  */
-extern void k_pipe_init(struct k_pipe *pipe, unsigned char *buffer,
-			size_t size);
+__syscall void k_pipe_init(struct k_pipe *pipe, unsigned char *buffer,
+			   size_t size);
 
 /**
  * @brief Write data to a pipe.
@@ -3261,9 +3261,9 @@ extern void k_pipe_init(struct k_pipe *pipe, unsigned char *buffer,
  * @retval -EAGAIN Waiting period timed out; between zero and @a min_xfer
  *                 minus one data bytes were written.
  */
-extern int k_pipe_put(struct k_pipe *pipe, void *data,
-		      size_t bytes_to_write, size_t *bytes_written,
-		      size_t min_xfer, s32_t timeout);
+__syscall int k_pipe_put(struct k_pipe *pipe, void *data,
+			 size_t bytes_to_write, size_t *bytes_written,
+			 size_t min_xfer, s32_t timeout);
 
 /**
  * @brief Read data from a pipe.
@@ -3284,9 +3284,9 @@ extern int k_pipe_put(struct k_pipe *pipe, void *data,
  * @retval -EAGAIN Waiting period timed out; between zero and @a min_xfer
  *                 minus one data bytes were read.
  */
-extern int k_pipe_get(struct k_pipe *pipe, void *data,
-		      size_t bytes_to_read, size_t *bytes_read,
-		      size_t min_xfer, s32_t timeout);
+__syscall int k_pipe_get(struct k_pipe *pipe, void *data,
+			 size_t bytes_to_read, size_t *bytes_read,
+			 size_t min_xfer, s32_t timeout);
 
 /**
  * @brief Write memory block to a pipe.

--- a/include/kernel.h
+++ b/include/kernel.h
@@ -133,8 +133,6 @@ struct k_mem_partition;
 enum k_objects {
 	/* Core kernel objects */
 	K_OBJ_ALERT,
-	K_OBJ_DELAYED_WORK,
-	K_OBJ_MEM_SLAB,
 	K_OBJ_MSGQ,
 	K_OBJ_MUTEX,
 	K_OBJ_PIPE,
@@ -142,8 +140,6 @@ enum k_objects {
 	K_OBJ_STACK,
 	K_OBJ_THREAD,
 	K_OBJ_TIMER,
-	K_OBJ_WORK,
-	K_OBJ_WORK_Q,
 
 	/* Driver subsystems */
 	K_OBJ_DRIVER_ADC,

--- a/include/kernel.h
+++ b/include/kernel.h
@@ -2032,8 +2032,8 @@ struct k_stack {
  *
  * @return N/A
  */
-extern void k_stack_init(struct k_stack *stack,
-			 u32_t *buffer, int num_entries);
+__syscall void k_stack_init(struct k_stack *stack,
+			    u32_t *buffer, int num_entries);
 
 /**
  * @brief Push an element onto a stack.
@@ -2047,7 +2047,7 @@ extern void k_stack_init(struct k_stack *stack,
  *
  * @return N/A
  */
-extern void k_stack_push(struct k_stack *stack, u32_t data);
+__syscall void k_stack_push(struct k_stack *stack, u32_t data);
 
 /**
  * @brief Pop an element from a stack.
@@ -2066,7 +2066,7 @@ extern void k_stack_push(struct k_stack *stack, u32_t data);
  * @retval -EBUSY Returned without waiting.
  * @retval -EAGAIN Waiting period timed out.
  */
-extern int k_stack_pop(struct k_stack *stack, u32_t *data, s32_t timeout);
+__syscall int k_stack_pop(struct k_stack *stack, u32_t *data, s32_t timeout);
 
 /**
  * @brief Statically define and initialize a stack

--- a/include/sensor.h
+++ b/include/sensor.h
@@ -265,10 +265,15 @@ struct sensor_driver_api {
  *
  * @return 0 if successful, negative errno code if failure.
  */
-static inline int sensor_attr_set(struct device *dev,
-				  enum sensor_channel chan,
-				  enum sensor_attribute attr,
-				  const struct sensor_value *val)
+__syscall int sensor_attr_set(struct device *dev,
+			      enum sensor_channel chan,
+			      enum sensor_attribute attr,
+			      const struct sensor_value *val);
+
+static inline int _impl_sensor_attr_set(struct device *dev,
+					enum sensor_channel chan,
+					enum sensor_attribute attr,
+					const struct sensor_value *val)
 {
 	const struct sensor_driver_api *api = dev->driver_api;
 
@@ -286,6 +291,8 @@ static inline int sensor_attr_set(struct device *dev,
  * safe.  However, the fiber's stack is limited and defined by the
  * driver.  It is currently up to the caller to ensure that the handler
  * does not overflow the stack.
+ *
+ * This API is not permitted for user threads.
  *
  * @param dev Pointer to the sensor device
  * @param trig The trigger to activate
@@ -323,7 +330,9 @@ static inline int sensor_trigger_set(struct device *dev,
  *
  * @return 0 if successful, negative errno code if failure.
  */
-static inline int sensor_sample_fetch(struct device *dev)
+__syscall int sensor_sample_fetch(struct device *dev);
+
+static inline int _impl_sensor_sample_fetch(struct device *dev)
 {
 	const struct sensor_driver_api *api = dev->driver_api;
 
@@ -349,8 +358,11 @@ static inline int sensor_sample_fetch(struct device *dev)
  *
  * @return 0 if successful, negative errno code if failure.
  */
-static inline int sensor_sample_fetch_chan(struct device *dev,
-					   enum sensor_channel type)
+__syscall int sensor_sample_fetch_chan(struct device *dev,
+				       enum sensor_channel type);
+
+static inline int _impl_sensor_sample_fetch_chan(struct device *dev,
+						 enum sensor_channel type)
 {
 	const struct sensor_driver_api *api = dev->driver_api;
 
@@ -378,9 +390,13 @@ static inline int sensor_sample_fetch_chan(struct device *dev,
  *
  * @return 0 if successful, negative errno code if failure.
  */
-static inline int sensor_channel_get(struct device *dev,
-				     enum sensor_channel chan,
-				     struct sensor_value *val)
+__syscall int sensor_channel_get(struct device *dev,
+				 enum sensor_channel chan,
+				 struct sensor_value *val);
+
+static inline int _impl_sensor_channel_get(struct device *dev,
+					   enum sensor_channel chan,
+					   struct sensor_value *val)
 {
 	const struct sensor_driver_api *api = dev->driver_api;
 
@@ -469,6 +485,7 @@ static inline double sensor_value_to_double(struct sensor_value *val)
 	return (double)val->val1 + (double)val->val2 / 1000000;
 }
 
+#include <syscalls/sensor.h>
 
 #ifdef __cplusplus
 }

--- a/kernel/include/ksched.h
+++ b/kernel/include/ksched.h
@@ -50,18 +50,22 @@ static inline int _is_idle_thread_ptr(k_tid_t thread)
 }
 
 #ifdef CONFIG_MULTITHREADING
-#define _ASSERT_VALID_PRIO(prio, entry_point) do { \
-	__ASSERT(((prio) == K_IDLE_PRIO && _is_idle_thread(entry_point)) || \
+#define _VALID_PRIO(prio, entry_point) \
+	(((prio) == K_IDLE_PRIO && _is_idle_thread(entry_point)) || \
 		 (_is_prio_higher_or_equal((prio), \
 			K_LOWEST_APPLICATION_THREAD_PRIO) && \
 		  _is_prio_lower_or_equal((prio), \
-			K_HIGHEST_APPLICATION_THREAD_PRIO)), \
+			K_HIGHEST_APPLICATION_THREAD_PRIO)))
+
+#define _ASSERT_VALID_PRIO(prio, entry_point) do { \
+	__ASSERT(_VALID_PRIO((prio), (entry_point)), \
 		 "invalid priority (%d); allowed range: %d to %d", \
 		 (prio), \
 		 K_LOWEST_APPLICATION_THREAD_PRIO, \
 		 K_HIGHEST_APPLICATION_THREAD_PRIO); \
 	} while ((0))
 #else
+#define _VALID_PRIO(prio, entry_point) ((prio) == -1)
 #define _ASSERT_VALID_PRIO(prio, entry_point) __ASSERT((prio) == -1, "")
 #endif
 

--- a/kernel/pipes.c
+++ b/kernel/pipes.c
@@ -18,6 +18,7 @@
 #include <wait_q.h>
 #include <misc/dlist.h>
 #include <init.h>
+#include <syscall_handler.h>
 
 struct k_pipe_desc {
 	unsigned char *buffer;           /* Position in src/dest buffer */
@@ -126,7 +127,7 @@ SYS_INIT(init_pipes_module, PRE_KERNEL_1, CONFIG_KERNEL_INIT_PRIORITY_OBJECTS);
 
 #endif /* CONFIG_NUM_PIPE_ASYNC_MSGS or CONFIG_OBJECT_TRACING */
 
-void k_pipe_init(struct k_pipe *pipe, unsigned char *buffer, size_t size)
+void _impl_k_pipe_init(struct k_pipe *pipe, unsigned char *buffer, size_t size)
 {
 	pipe->buffer = buffer;
 	pipe->size = size;
@@ -138,6 +139,21 @@ void k_pipe_init(struct k_pipe *pipe, unsigned char *buffer, size_t size)
 	SYS_TRACING_OBJ_INIT(k_pipe, pipe);
 	_k_object_init(pipe);
 }
+
+#ifdef CONFIG_USERSPACE
+u32_t _handler_k_pipe_init(u32_t pipe, u32_t buffer, u32_t size,
+			   u32_t arg4, u32_t arg5, u32_t arg6, void *ssf)
+{
+	_SYSCALL_ARG3;
+
+	_SYSCALL_IS_OBJ(pipe, K_OBJ_PIPE, 1, ssf);
+	_SYSCALL_MEMORY(buffer, size, 1, ssf);
+
+	_impl_k_pipe_init((struct k_pipe *)pipe, (unsigned char *)buffer,
+			  size);
+	return 0;
+}
+#endif
 
 /**
  * @brief Copy bytes from @a src to @a dest
@@ -527,8 +543,8 @@ int _k_pipe_put_internal(struct k_pipe *pipe, struct k_pipe_async *async_desc,
 				 bytes_to_write);
 }
 
-int k_pipe_get(struct k_pipe *pipe, void *data, size_t bytes_to_read,
-	       size_t *bytes_read, size_t min_xfer, s32_t timeout)
+int _impl_k_pipe_get(struct k_pipe *pipe, void *data, size_t bytes_to_read,
+		     size_t *bytes_read, size_t min_xfer, s32_t timeout)
 {
 	struct k_thread    *writer;
 	struct k_pipe_desc *desc;
@@ -670,8 +686,27 @@ int k_pipe_get(struct k_pipe *pipe, void *data, size_t bytes_to_read,
 				 bytes_to_read);
 }
 
-int k_pipe_put(struct k_pipe *pipe, void *data, size_t bytes_to_write,
-	       size_t *bytes_written, size_t min_xfer, s32_t timeout)
+#ifdef CONFIG_USERSPACE
+u32_t _handler_k_pipe_get(u32_t pipe, u32_t data, u32_t bytes_to_read,
+			  u32_t bytes_read_p, u32_t min_xfer_p,
+			  u32_t timeout, void *ssf)
+{
+	size_t *bytes_read = (size_t *)bytes_read_p;
+	size_t min_xfer = (size_t)min_xfer_p;
+
+	_SYSCALL_IS_OBJ(pipe, K_OBJ_PIPE, 0, ssf);
+	_SYSCALL_MEMORY(bytes_read, sizeof(*bytes_read), 1, ssf);
+	_SYSCALL_MEMORY((void *)data, bytes_to_read, 1, ssf);
+	_SYSCALL_VERIFY(min_xfer <= bytes_to_read, ssf);
+
+	return _impl_k_pipe_get((struct k_pipe *)pipe, (void *)data,
+				bytes_to_read, bytes_read, min_xfer,
+				timeout);
+}
+#endif
+
+int _impl_k_pipe_put(struct k_pipe *pipe, void *data, size_t bytes_to_write,
+		     size_t *bytes_written, size_t min_xfer, s32_t timeout)
 {
 	__ASSERT(min_xfer <= bytes_to_write, "");
 	__ASSERT(bytes_written != NULL, "");
@@ -680,6 +715,25 @@ int k_pipe_put(struct k_pipe *pipe, void *data, size_t bytes_to_write,
 				    bytes_to_write, bytes_written,
 				    min_xfer, timeout);
 }
+
+#ifdef CONFIG_USERSPACE
+u32_t _handler_k_pipe_put(u32_t pipe, u32_t data, u32_t bytes_to_write,
+			  u32_t bytes_written_p, u32_t min_xfer_p,
+			  u32_t timeout, void *ssf)
+{
+	size_t *bytes_written = (size_t *)bytes_written_p;
+	size_t min_xfer = (size_t)min_xfer_p;
+
+	_SYSCALL_IS_OBJ(pipe, K_OBJ_PIPE, 0, ssf);
+	_SYSCALL_MEMORY(bytes_written, sizeof(*bytes_written), 1, ssf);
+	_SYSCALL_MEMORY((void *)data, bytes_to_write, 0, ssf);
+	_SYSCALL_VERIFY(min_xfer <= bytes_to_write, ssf);
+
+	return _impl_k_pipe_put((struct k_pipe *)pipe, (void *)data,
+				bytes_to_write, bytes_written, min_xfer,
+				timeout);
+}
+#endif
 
 #if (CONFIG_NUM_PIPE_ASYNC_MSGS > 0)
 void k_pipe_block_put(struct k_pipe *pipe, struct k_mem_block *block,

--- a/kernel/sys_clock.c
+++ b/kernel/sys_clock.c
@@ -12,6 +12,7 @@
 #include <linker/sections.h>
 #include <wait_q.h>
 #include <drivers/system_timer.h>
+#include <syscall_handler.h>
 
 #ifdef CONFIG_SYS_CLOCK_EXISTS
 #ifdef _NON_OPTIMIZED_TICKS_PER_SEC
@@ -68,7 +69,7 @@ u32_t _tick_get_32(void)
 }
 FUNC_ALIAS(_tick_get_32, sys_tick_get_32, u32_t);
 
-u32_t k_uptime_get_32(void)
+u32_t _impl_k_uptime_get_32(void)
 {
 #ifdef CONFIG_TICKLESS_KERNEL
 	__ASSERT(_sys_clock_always_on,
@@ -76,6 +77,19 @@ u32_t k_uptime_get_32(void)
 #endif
 	return __ticks_to_ms(_tick_get_32());
 }
+
+#ifdef CONFIG_USERSPACE
+u32_t _handler_k_uptime_get_32(u32_t arg1, u32_t arg2, u32_t arg3,
+			       u32_t arg4, u32_t arg5, u32_t arg6, void *ssf)
+{
+	_SYSCALL_ARG0;
+
+#ifdef CONFIG_TICKLESS_KERNEL
+	_SYSCALL_VERIFY(_sys_clock_always_on, ssf);
+#endif
+	return _impl_k_uptime_get_32();
+}
+#endif
 
 /**
  *

--- a/kernel/userspace.c
+++ b/kernel/userspace.c
@@ -36,10 +36,6 @@ const char *otype_to_str(enum k_objects otype)
 	/* Core kernel objects */
 	case K_OBJ_ALERT:
 		return "k_alert";
-	case K_OBJ_DELAYED_WORK:
-		return "k_delayed_work";
-	case K_OBJ_MEM_SLAB:
-		return "k_mem_slab";
 	case K_OBJ_MSGQ:
 		return "k_msgq";
 	case K_OBJ_MUTEX:
@@ -54,10 +50,6 @@ const char *otype_to_str(enum k_objects otype)
 		return "k_thread";
 	case K_OBJ_TIMER:
 		return "k_timer";
-	case K_OBJ_WORK:
-		return "k_work";
-	case K_OBJ_WORK_Q:
-		return "k_work_q";
 
 	/* Driver subsystems */
 	case K_OBJ_DRIVER_ADC:

--- a/scripts/gen_kobject_list.py
+++ b/scripts/gen_kobject_list.py
@@ -22,8 +22,6 @@ if LooseVersion(elftools.__version__) < LooseVersion('0.24'):
 
 kobjects = [
         "k_alert",
-        "k_delayed_work",
-        "k_mem_slab",
         "k_msgq",
         "k_mutex",
         "k_pipe",
@@ -31,8 +29,6 @@ kobjects = [
         "k_stack",
         "k_thread",
         "k_timer",
-        "k_work",
-        "k_work_q",
         "device"
         ]
 

--- a/subsys/Makefile
+++ b/subsys/Makefile
@@ -9,3 +9,4 @@ obj-$(CONFIG_CPLUSPLUS) += cpp/
 obj-y += logging/
 obj-y += debug/
 obj-$(CONFIG_MCUBOOT_IMG_MANAGER) += dfu/
+obj-$(CONFIG_USERSPACE) += driver_handlers/

--- a/subsys/driver_handlers/Makefile
+++ b/subsys/driver_handlers/Makefile
@@ -1,0 +1,2 @@
+obj-$(CONFIG_SENSOR) += sensor.o
+

--- a/subsys/driver_handlers/sensor.c
+++ b/subsys/driver_handlers/sensor.c
@@ -1,0 +1,53 @@
+/*
+ * Copyright (c) 2017 Intel Corporation
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <sensor.h>
+#include <syscall_handler.h>
+
+u32_t _handler_sensor_attr_set(u32_t dev, u32_t chan, u32_t attr,
+			       u32_t val, u32_t arg5, u32_t arg6, void *ssf)
+{
+	_SYSCALL_ARG4;
+
+	_SYSCALL_IS_OBJ(dev, K_OBJ_DRIVER_SENSOR, 0, ssf);
+	_SYSCALL_MEMORY(val, sizeof(struct sensor_value), 0, ssf);
+	return _impl_sensor_attr_set((struct device *)dev, chan, attr,
+				     (const struct sensor_value *)val);
+}
+
+u32_t _handler_sensor_sample_fetch(u32_t dev, u32_t arg2, u32_t arg3,
+				   u32_t arg4, u32_t arg5, u32_t arg6,
+				   void *ssf)
+{
+	_SYSCALL_ARG1;
+
+	_SYSCALL_IS_OBJ(dev, K_OBJ_DRIVER_SENSOR, 0, ssf);
+	return _impl_sensor_sample_fetch((struct device *)dev);
+}
+
+
+u32_t _handler_sensor_sample_fetch_chan(u32_t dev, u32_t type, u32_t arg3,
+					u32_t arg4, u32_t arg5, u32_t arg6,
+					void *ssf)
+{
+	_SYSCALL_ARG2;
+
+	_SYSCALL_IS_OBJ(dev, K_OBJ_DRIVER_SENSOR, 0, ssf);
+	return _impl_sensor_sample_fetch_chan((struct device *)dev, type);
+}
+
+u32_t _handler_sensor_channel_get(u32_t dev, u32_t chan, u32_t val,
+				  u32_t arg4, u32_t arg5, u32_t arg6,
+				  void *ssf)
+{
+	_SYSCALL_ARG3;
+
+	_SYSCALL_IS_OBJ(dev, K_OBJ_DRIVER_SENSOR, 0, ssf);
+	_SYSCALL_MEMORY(val, sizeof(struct sensor_value), 1, ssf);
+	return _impl_sensor_channel_get((struct device *)dev, chan,
+					(struct sensor_value *)val);
+}
+


### PR DESCRIPTION
This PR shows system calls implemented for thread, alert, pipe, timer, stack, message queue, and mutex kernel objects. A few other miscellaneous kernel objects also converted to support Philosophers demo in user mode.

Finally, we demonstrate a driver subsystem by converting the Sensor driver APIs.