### PR TITLE
scrips/merge_config.sh: fix corner case \n-less last line

### DIFF
--- a/scripts/kconfig/merge_config.sh
+++ b/scripts/kconfig/merge_config.sh
@@ -132,6 +132,7 @@ for MERGE_FILE in $MERGE_LIST ; do
 	done
 	chmod u+w $TMP_FILE
 	cat $MERGE_FILE >> $TMP_FILE
+	echo >> $TMP_FILE
 done
 
 if [ "$RUNMAKE" = "false" ]; then


### PR DESCRIPTION
When a configuration file fragment ends in a line that is not
terminated by a \n, it will mange the pasting of the following
fragment. For example, in file1.prj:

  CONFIG_SETTING_A=34
  CONFIG_SETTING_B=12

and file2.prj:

  CONFIG_SETTING_C=56

would become:

  CONFIG_SETTING_A=34
  CONFIG_SETTING_B=12CONFIG_SETTING_C=56

because there was no \n at the end of CONFIG_SETTING_B=12. This makes
the kconfig parser to reject CONFIG_SETTING_B and to loose
CONFIG_SETTING_C, which then has random consequences.

So, to avoid that problem, always add a newline after a config fragment.

Signed-off-by: Inaky Perez-Gonzalez <inaky.perez-gonzalez@intel.com>