### PR TITLE
doc: replace UTF-8 chars

### DIFF
--- a/arch/arm/soc/atmel_sam/common/soc_gpio.h
+++ b/arch/arm/soc/atmel_sam/common/soc_gpio.h
@@ -163,7 +163,7 @@ static inline u32_t soc_gpio_get(const struct soc_gpio_pin *pin)
  * or may not be taken into account, depending on the precise timing of its
  * occurrence.
  *
- * tdiv_slck = ((div + 1) × 2) × tslck
+ * tdiv_slck = ((div + 1) x 2) x tslck
  * where tslck is the slow clock, typically 32.768 kHz.
  *
  * Setting the length of the debounce window is only meaningful if the pin is

--- a/arch/arm/soc/st_stm32/stm32f1/flash_registers.h
+++ b/arch/arm/soc/st_stm32/stm32f1/flash_registers.h
@@ -12,7 +12,7 @@
  *
  * Based on reference manual:
  *   STM32F101xx, STM32F102xx, STM32F103xx, STM32F105xx and STM32F107xx
- *   advanced ARM ® -based 32-bit MCUs
+ *   advanced ARM(r)-based 32-bit MCUs
  *
  * Chapter 3.3.3: Embedded Flash Memory
  */

--- a/arch/arm/soc/st_stm32/stm32f1/gpio_registers.h
+++ b/arch/arm/soc/st_stm32/stm32f1/gpio_registers.h
@@ -12,7 +12,7 @@
  *
  * Based on reference manual:
  *   STM32F101xx, STM32F102xx, STM32F103xx, STM32F105xx and STM32F107xx
- *   advanced ARM ® -based 32-bit MCUs
+ *   advanced ARM(r)-based 32-bit MCUs
  *
  * Chapter 9: General-purpose and alternate-function I/Os
  *            (GPIOs and AFIOs)

--- a/arch/arm/soc/st_stm32/stm32f1/soc.h
+++ b/arch/arm/soc/st_stm32/stm32f1/soc.h
@@ -9,7 +9,7 @@
  *
  * Based on reference manual:
  *   STM32F101xx, STM32F102xx, STM32F103xx, STM32F105xx and STM32F107xx
- *   advanced ARM ® -based 32-bit MCUs
+ *   advanced ARM(r)-based 32-bit MCUs
  *
  * Chapter 3.3: Memory Map
  */

--- a/arch/arm/soc/st_stm32/stm32f1/soc_irq.h
+++ b/arch/arm/soc/st_stm32/stm32f1/soc_irq.h
@@ -9,7 +9,7 @@
  *
  * Based on reference manual:
  *   STM32F101xx, STM32F102xx, STM32F103xx, STM32F105xx and STM32F107xx
- *   advanced ARM ® -based 32-bit MCUs
+ *   advanced ARM(r)-based 32-bit MCUs
  *
  * Chapter 10.1.2: Interrupt and exception vectors
  */

--- a/arch/arm/soc/st_stm32/stm32f3/flash_registers.h
+++ b/arch/arm/soc/st_stm32/stm32f3/flash_registers.h
@@ -14,9 +14,9 @@
  *
  * Based on reference manual:
  *   STM32F101xx, STM32F102xx, STM32F103xx, STM32F105xx and STM32F107xx
- *   advanced ARM ® -based 32-bit MCUs
+ *   advanced ARM(r)-based 32-bit MCUs
  *   &
- *   STM32F334xx advanced ARM ® -based 32-bit MCUs
+ *   STM32F334xx advanced ARM(r)-based 32-bit MCUs
  *
  * Chapter 3.3.3: Embedded Flash Memory
  */

--- a/arch/arm/soc/st_stm32/stm32f3/gpio_registers.h
+++ b/arch/arm/soc/st_stm32/stm32f3/gpio_registers.h
@@ -12,7 +12,7 @@
  *
  * Based on reference manual:
  *   STM32F303xB/C/D/E, STM32F303x6/8, STM32F328x8, STM32F358xC,
- *   STM32F398xE advanced ARM ® -based MCUs
+ *   STM32F398xE advanced ARM(r)-based MCUs
  *
  * Chapter 11: General-purpose I/Os
  */

--- a/arch/arm/soc/st_stm32/stm32f3/soc.h
+++ b/arch/arm/soc/st_stm32/stm32f3/soc.h
@@ -9,8 +9,8 @@
  *
  * Based on reference manual:
  *   STM32F303xB/C/D/E, STM32F303x6/8, STM32F328x8, STM32F358xC,
- *   STM32F398xE advanced ARM ® -based MCUs
- *   STM32F37xx advanced ARM ® -based MCUs
+ *   STM32F398xE advanced ARM(r)-based MCUs
+ *   STM32F37xx advanced ARM(r)-based MCUs
  *
  * Chapter 3.3: Memory organization
  */

--- a/arch/arm/soc/st_stm32/stm32f3/soc_irq.h
+++ b/arch/arm/soc/st_stm32/stm32f3/soc_irq.h
@@ -9,7 +9,7 @@
  *
  * Based on reference manual:
  *   STM32F303xB/C/D/E, STM32F303x6/8, STM32F328x8, STM32F358xC,
- *   STM32F398xE advanced ARM ® -based MCUs
+ *   STM32F398xE advanced ARM(r)-based MCUs
  *
  * Chapter 14.1.3: Interrupt and exception vectors
  */

--- a/arch/arm/soc/st_stm32/stm32f4/gpio_registers.h
+++ b/arch/arm/soc/st_stm32/stm32f4/gpio_registers.h
@@ -12,7 +12,7 @@
  *
  * Based on reference manual:
  *   RM0368 Reference manual STM32F401xB/C and STM32F401xD/E
- *   advanced ARM ® -based 32-bit MCUs
+ *   advanced ARM(r)-based 32-bit MCUs
  *
  * Chapter 8: General-purpose I/Os (GPIOs)
  */

--- a/arch/arm/soc/st_stm32/stm32f4/soc.h
+++ b/arch/arm/soc/st_stm32/stm32f4/soc.h
@@ -10,7 +10,7 @@
  *
  * Based on reference manual:
  *   RM0368 Reference manual STM32F401xB/C and STM32F401xD/E
- *   advanced ARM ® -based 32-bit MCUs
+ *   advanced ARM(r)-based 32-bit MCUs
  *
  * Chapter 2.3: Memory Map
  */

--- a/arch/arm/soc/st_stm32/stm32f4/soc_irq.h
+++ b/arch/arm/soc/st_stm32/stm32f4/soc_irq.h
@@ -9,7 +9,7 @@
  *
  * Based on reference manual:
  *   RM0368 Reference manual STM32F401xB/C and STM32F401xD/E
- *   advanced ARM-based 32-bit MCUs
+ *   advanced ARM(r)-based 32-bit MCUs
  *
  * Chapter 10.1.3: Interrupt and exception vectors
  */

--- a/arch/arm/soc/st_stm32/stm32l4/soc.h
+++ b/arch/arm/soc/st_stm32/stm32l4/soc.h
@@ -10,7 +10,7 @@
  *
  * Based on reference manual:
  *   STM32L4x1, STM32L4x2, STM32L431xx STM32L443xx STM32L433xx, STM32L4x5,
- *   STM32l4x6 advanced ARM ® -based 32-bit MCUs
+ *   STM32l4x6 advanced ARM(r)-based 32-bit MCUs
  *
  * Chapter 2.2.2: Memory map and register boundary addresses
  */

--- a/arch/x86/include/kernel_arch_thread.h
+++ b/arch/x86/include/kernel_arch_thread.h
@@ -110,7 +110,7 @@ typedef struct s_FpReg {
  * The following is the "normal" floating point register save area, or
  * more accurately the save area required by the 'fnsave' and 'frstor'
  * instructions.  The structure matches the layout described in the
- * "Intel® 64 and IA-32 Architectures Software Developer’s Manual
+ * "Intel(r) 64 and IA-32 Architectures Software Developer's Manual
  * Volume 1: Basic Architecture": Protected Mode x87 FPU State Image in
  * Memory, 32-Bit Format.
  */

--- a/boards/arm/nrf51_vbluno51/doc/nrf51_vbluno51.rst
+++ b/boards/arm/nrf51_vbluno51/doc/nrf51_vbluno51.rst
@@ -41,7 +41,7 @@ Supported Features
 	+ UART(1), I2C(2), SPI(1), PWM(3), SWD, Timer 16bit(3).
 	+ 21 digital channels, 6 ADC 10bit channels.
 	+ 1 Led and 1 Button onboard.
-	+ GPIO Voltage: 0 – 3.3V.
+	+ GPIO Voltage: 0 - 3.3V.
 - DAPLink (CMSIS-DAP) interface for program and debug:
 	+ USB MSD: Drag and Drop programming flash memory.
 	+ USB HID (DAP): CMSIS-DAP compliant debug channel.

--- a/boards/arm/stm32f412g_disco/doc/stm32f412g_disco.rst
+++ b/boards/arm/stm32f412g_disco/doc/stm32f412g_disco.rst
@@ -35,7 +35,7 @@ some highlights of the STM32F412G-DISCO board:
        - + 5 V from Arduino* connectors
 
 - Two power supplies for MCU: 2.0 V and 3.3 V
-- Compatible with Arduino™ Uno revision 3 connectors
+- Compatible with Arduino(tm) Uno revision 3 connectors
 - Extension connector for direct access to various features of STM32F412ZGT6 MCU
 - Comprehensive free software including a variety of examples, part of STM32Cube package
 

--- a/drivers/interrupt_controller/exti_stm32.h
+++ b/drivers/interrupt_controller/exti_stm32.h
@@ -9,10 +9,10 @@
  *
  * Based on reference manuals:
  *   RM0008 Reference Manual: STM32F101xx, STM32F102xx, STM32F103xx, STM32F105xx
- *   and STM32F107xx advanced ARM-based 32-bit MCUs
+ *   and STM32F107xx advanced ARM(r)-based 32-bit MCUs
  * and
  *   RM0368 Reference manual STM32F401xB/C and STM32F401xD/E
- *   advanced ARM-based 32-bit MCUs
+ *   advanced ARM(r)-based 32-bit MCUs
  *
  * Chapter 10.2: External interrupt/event controller (EXTI)
  *

--- a/drivers/watchdog/iwdg_stm32.h
+++ b/drivers/watchdog/iwdg_stm32.h
@@ -14,7 +14,7 @@
  *
  * Based on reference manual:
  *   STM32F101xx, STM32F102xx, STM32F103xx, STM32F105xx and STM32F107xx
- *   advanced ARM ® -based 32-bit MCUs
+ *   advanced ARM(r)-based 32-bit MCUs
  *
  * Chapter 19: Independent watchdog (IWDG)
  *

--- a/include/i2s.h
+++ b/include/i2s.h
@@ -44,7 +44,7 @@ typedef u8_t i2s_fmt_t;
 
 /** @brief Standard I2S Data Format.
  *
- * Serial data is transmitted in two’s complement with the MSB first. Both
+ * Serial data is transmitted in two's complement with the MSB first. Both
  * Word Select (WS) and Serial Data (SD) signals are sampled on the rising edge
  * of the clock signal (SCK). The MSB is always sent one clock period after the
  * WS changes. Left channel data are sent first indicated by WS = 0, followed
@@ -63,7 +63,7 @@ typedef u8_t i2s_fmt_t;
 
 /** @brief PCM Short Frame Sync Data Format.
  *
- * Serial data is transmitted in two’s complement with the MSB first. Both
+ * Serial data is transmitted in two's complement with the MSB first. Both
  * Word Select (WS) and Serial Data (SD) signals are sampled on the falling edge
  * of the clock signal (SCK). The falling edge of the frame sync signal (WS)
  * indicates the start of the PCM word. The frame sync is one clock cycle long.
@@ -82,7 +82,7 @@ typedef u8_t i2s_fmt_t;
 
 /** @brief PCM Long Frame Sync Data Format.
  *
- * Serial data is transmitted in two’s complement with the MSB first. Both
+ * Serial data is transmitted in two's complement with the MSB first. Both
  * Word Select (WS) and Serial Data (SD) signals are sampled on the falling edge
  * of the clock signal (SCK). The rising edge of the frame sync signal (WS)
  * indicates the start of the PCM word. The frame sync has an arbitrary length,
@@ -103,7 +103,7 @@ typedef u8_t i2s_fmt_t;
 /**
  * @brief Left Justified Data Format.
  *
- * Serial data is transmitted in two’s complement with the MSB first. Both
+ * Serial data is transmitted in two's complement with the MSB first. Both
  * Word Select (WS) and Serial Data (SD) signals are sampled on the rising edge
  * of the clock signal (SCK). The bits within the data word are left justified
  * such that the MSB is always sent in the clock period following the WS
@@ -124,7 +124,7 @@ typedef u8_t i2s_fmt_t;
 /**
  * @brief Right Justified Data Format.
  *
- * Serial data is transmitted in two’s complement with the MSB first. Both
+ * Serial data is transmitted in two's complement with the MSB first. Both
  * Word Select (WS) and Serial Data (SD) signals are sampled on the rising edge
  * of the clock signal (SCK). The bits within the data word are right justified
  * such that the LSB is always sent in the clock period preceding the WS

--- a/subsys/net/ip/Kconfig
+++ b/subsys/net/ip/Kconfig
@@ -156,7 +156,7 @@ config NET_TCP_RETRY_COUNT
 	The following formula can be used to determine the time (in ms)
 	that a segment will be be buffered awaiting retransmission:
 	n=NET_TCP_RETRY_COUNT
-	∑((1<<n) * 200)
+	Sum((1<<n) * 200)
 	n=0
 	With the default value of 9, the IP stack will try to
 	retransmit for up to 1:42 minutes.  This is as close as possible


### PR DESCRIPTION
Some of our Zephyr tools don't like seeing UTF-8 characters, as reported in
issue #4131) so a quick scan and replace for UTF-8 characters in .rst,
.h, and Kconfig files using "file --mime-encoding" (excluding the /ext
folders) finds these files to tweak.

Signed-off-by: David B. Kinder <david.b.kinder@intel.com>