### PR TITLE
net: lib: net app: restore IP header length when DTLS is used.

### DIFF
--- a/subsys/net/lib/app/net_app.c
+++ b/subsys/net/lib/app/net_app.c
@@ -1709,6 +1709,18 @@ reset:
 			if (ctx->tls.mbedtls.ssl_ctx.hdr) {
 				net_pkt_frag_add(pkt,
 						 ctx->tls.mbedtls.ssl_ctx.hdr);
+#if defined(CONFIG_NET_IPV6)
+				if (net_pkt_family(pkt) == AF_INET6) {
+					net_pkt_set_ip_hdr_len(pkt,
+						sizeof(struct net_ipv6_hdr));
+				}
+#endif
+#if defined(CONFIG_NET_IPV4)
+				if (net_pkt_family(pkt) == AF_INET) {
+					net_pkt_set_ip_hdr_len(pkt,
+						sizeof(struct net_ipv4_hdr));
+				}
+#endif
 				ctx->tls.mbedtls.ssl_ctx.hdr = NULL;
 			}
 


### PR DESCRIPTION
Other parts of the networking subsystem may use net_pkt_ip_hdr_len() on
a packet that has been encrypted for use with DTLS.  Let's restore that
value here so those areas don't receive an erroneous 0 value.

Signed-off-by: Michael Scott <michael.scott@linaro.org>