### PR TITLE
ext: mbedtls: change MBEDTLS_DEBUG config from string to bool

### DIFF
--- a/ext/lib/crypto/mbedtls/Kconfig
+++ b/ext/lib/crypto/mbedtls/Kconfig
@@ -39,7 +39,7 @@ config MBEDTLS_CFG_FILE
 	Enable custom mbed TLS configuration
 
 config MBEDTLS_DEBUG
-	string "mbed TLS debug activation"
+	bool "mbed TLS debug activation"
 	depends on MBEDTLS_BUILTIN
 	default n
 	help


### PR DESCRIPTION
When default "n" is selected (as it is by default) this sets:
CONFIG_MBEDTLS_DEBUG="n"

When checked by the existing logic (example shown below) will always
be true and debug will be enabled all the time:
#if defined(CONFIG_MBEDTLS_DEBUG)

Instead, let's change the config type to "bool" which will be
undefined when set to "n" (by default).  The existing #if defined()
checks will work correctly.

NOTE: This fix saves a lot of binary space when MBEDTLS is enabled
due to the amount debug output being compiled in.

Signed-off-by: Michael Scott <michael.scott@linaro.org>