### PR TITLE
usb: Remove default Vendor and Product ID

### DIFF
--- a/boards/x86/tinytile/Kconfig.defconfig
+++ b/boards/x86/tinytile/Kconfig.defconfig
@@ -21,6 +21,12 @@ config USB_DW
 config USB_DEVICE_STACK
 	def_bool y
 
+config USB_DEVICE_VID
+	default 0x8087
+
+config USB_DEVICE_PID
+	default 0x0AB6
+
 if USB_UART_CONSOLE
 
 config UART_INTERRUPT_DRIVEN

--- a/samples/bluetooth/hci_usb/sample.yaml
+++ b/samples/bluetooth/hci_usb/sample.yaml
@@ -3,6 +3,9 @@ sample:
   name: TBD
 tests:
   - test_x86:
+      extra_configs:
+        - CONFIG_USB_DEVICE_VID=0xDEAD
+        - CONFIG_USB_DEVICE_PID=0xBEEF
       build_only: true
       depends_on: usb_device
       platform_whitelist: quark_se_c1000_devboard

--- a/samples/net/wpan_serial/sample.yaml
+++ b/samples/net/wpan_serial/sample.yaml
@@ -3,6 +3,9 @@ sample:
   name: TBD
 tests:
   - test_x86:
+      extra_configs:
+        - CONFIG_USB_DEVICE_VID=0xDEAD
+        - CONFIG_USB_DEVICE_PID=0xBEEF
       build_only: true
       depends_on: usb_device
       platform_whitelist: quark_se_c1000_devboard

--- a/samples/subsys/usb/cdc_acm/sample.yaml
+++ b/samples/subsys/usb/cdc_acm/sample.yaml
@@ -3,6 +3,9 @@ sample:
   name: TBD
 tests:
   - test_x86:
+      extra_configs:
+        - CONFIG_USB_DEVICE_VID=0xDEAD
+        - CONFIG_USB_DEVICE_PID=0xBEEF
       build_only: true
       depends_on: usb_device
       platform_whitelist: arduino_101

--- a/samples/subsys/usb/console/sample.yaml
+++ b/samples/subsys/usb/console/sample.yaml
@@ -3,6 +3,9 @@ sample:
   name: TBD
 tests:
   - test:
+      extra_configs:
+        - CONFIG_USB_DEVICE_VID=0xDEAD
+        - CONFIG_USB_DEVICE_PID=0xBEEF
       build_only: true
       depends_on: usb_device
       platform_whitelist: arduino_101

--- a/samples/subsys/usb/dfu/sample.yaml
+++ b/samples/subsys/usb/dfu/sample.yaml
@@ -3,6 +3,9 @@ sample:
   name: TBD
 tests:
   - test_x86:
+      extra_configs:
+        - CONFIG_USB_DEVICE_VID=0xDEAD
+        - CONFIG_USB_DEVICE_PID=0xBEEF
       build_only: true
       depends_on: usb_device
       platform_whitelist: quark_se_c1000_devboard

--- a/samples/subsys/usb/mass/sample.yaml
+++ b/samples/subsys/usb/mass/sample.yaml
@@ -8,4 +8,4 @@ tests:
         - CONFIG_USB_DEVICE_PID=0xBEEF
       build_only: true
       platform_whitelist: arduino_101
-      tags: msd
+      tags: msd usb

--- a/samples/subsys/usb/mass/sample.yaml
+++ b/samples/subsys/usb/mass/sample.yaml
@@ -3,6 +3,9 @@ sample:
   name: TBD
 tests:
   - test:
+      extra_configs:
+        - CONFIG_USB_DEVICE_VID=0xDEAD
+        - CONFIG_USB_DEVICE_PID=0xBEEF
       build_only: true
       platform_whitelist: arduino_101
       tags: msd

--- a/samples/subsys/usb/webusb/sample.yaml
+++ b/samples/subsys/usb/webusb/sample.yaml
@@ -3,6 +3,9 @@ sample:
   name: TBD
 tests:
   - test_x86:
+      extra_configs:
+        - CONFIG_USB_DEVICE_VID=0xDEAD
+        - CONFIG_USB_DEVICE_PID=0xBEEF
       build_only: true
       depends_on: usb_device
       platform_whitelist: quark_se_c1000_devboard

--- a/scripts/sanitycheck
+++ b/scripts/sanitycheck
@@ -1216,8 +1216,7 @@ class TestInstance:
             os.makedirs(self.outdir, exist_ok=True)
             f = open(file, "w")
             content = ""
-            for c in self.test.extra_configs:
-                content += c
+            content = "\n".join(self.test.extra_configs)
             f.write(content)
             f.close()
 

--- a/subsys/usb/Kconfig
+++ b/subsys/usb/Kconfig
@@ -38,13 +38,13 @@ config SYS_LOG_USB_LEVEL
 
 config USB_DEVICE_VID
 	hex
-	default 0x8086 #Intel vendor ID
+	prompt "USB Vendor ID"
 	help
 	USB device vendor ID
 
 config USB_DEVICE_PID
 	hex
-	default 0xF8A1
+	prompt "USB Product ID"
 	help
 	USB device product ID
 


### PR DESCRIPTION
Settings configuration allows to set Vendor and Product IDs. These
configuration options should be used when building USB gadget
applications.

Signed-off-by: Andrei Emeltchenko <andrei.emeltchenko@intel.com>