### PR TITLE
Bluetooth: controller: Disable PA/LNA for nRF51x

### DIFF
--- a/subsys/bluetooth/controller/Kconfig
+++ b/subsys/bluetooth/controller/Kconfig
@@ -401,6 +401,7 @@ comment "BLE Controller hardware configuration"
 
 menuconfig BT_CTLR_GPIO_PA
 	bool "Power Amplifier GPIO interface"
+	depends on !SOC_SERIES_NRF51X
 	help
 	  Enable GPIO interface to a Power Amplifier. This allows hardware
 	  designs using PA to let the Controller toggle their state based on
@@ -431,6 +432,7 @@ endif # BT_CTLR_GPIO_PA
 
 menuconfig BT_CTLR_GPIO_LNA
 	bool "Low Noise Amplifier GPIO interface"
+	depends on !SOC_SERIES_NRF51X
 	help
 	  Enable GPIO interface to a Low Noise Amplifier. This allows hardware
 	  designs using LNAs to let the Controller toggle their state based on


### PR DESCRIPTION
The PA/LNA feature is not functional on nRF51x series due to added
interrupt latency. Disable this feature unconditionally for those ICs to
avoid unexpected behavior.

Signed-off-by: Carles Cufi <carles.cufi@nordicsemi.no>