### PR TITLE
usb: Add USB definitions for EEM device

### DIFF
--- a/include/usb/class/usb_cdc.h
+++ b/include/usb/class/usb_cdc.h
@@ -30,9 +30,11 @@
 /** Communications Class Subclass Codes */
 #define ACM_SUBCLASS			0x02
 #define ECM_SUBCLASS			0x06
+#define EEM_SUBCLASS			0x0c
 
 /** Communications Class Protocol Codes */
 #define AT_CMD_V250_PROTOCOL		0x01
+#define EEM_PROTOCOL			0x07
 
 /**
  * @brief Data Class Interface Codes


### PR DESCRIPTION
Add CDC Ethernet Emulation Model subclass and protocol codes.

Signed-off-by: Loic Poulain <loic.poulain@linaro.org>