### PR TITLE
Bluetooth: controller: Merge 2 more commits into v1.9-branch for 1.9.1

### DIFF
--- a/subsys/bluetooth/common/Kconfig
+++ b/subsys/bluetooth/common/Kconfig
@@ -8,6 +8,13 @@
 
 if BT_HCI
 
+config BT_HCI_VS_EXT
+	bool "Zephyr HCI Vendor-Specific Extensions"
+	default y
+	help
+	  Enable support for the Zephyr HCI Vendor-Specific Extensions in the
+	  Host and/or Controller.
+
 config BT_RPA
 	# Virtual/hidden option
 	bool

--- a/subsys/bluetooth/controller/Kconfig
+++ b/subsys/bluetooth/controller/Kconfig
@@ -30,17 +30,10 @@ endchoice
 
 comment "BLE Controller configuration"
 
-config BT_CTLR_HCI_VS_EXT
-	bool "Zephyr HCI Vendor-Specific Extensions"
-	default y
-	help
-	  Enable support for the Zephyr HCI Vendor-Specific Extensions in the
-	  Controller.
-
 config BT_CTLR_HCI_VS_BUILD_INFO
 	string "Zephyr HCI VS Build Info string"
 	default ""
-	depends on BT_CTLR_HCI_VS_EXT
+	depends on BT_HCI_VS_EXT
 	help
 	  User-defined string that will be returned by the Zephyr VS Read Build
 	  Information command after the Zephyr version and build time. When

--- a/subsys/bluetooth/controller/Kconfig
+++ b/subsys/bluetooth/controller/Kconfig
@@ -401,6 +401,7 @@ comment "BLE Controller hardware configuration"
 
 menuconfig BT_CTLR_GPIO_PA
 	bool "Power Amplifier GPIO interface"
+	depends on !SOC_SERIES_NRF51X
 	help
 	  Enable GPIO interface to a Power Amplifier. This allows hardware
 	  designs using PA to let the Controller toggle their state based on
@@ -431,6 +432,7 @@ endif # BT_CTLR_GPIO_PA
 
 menuconfig BT_CTLR_GPIO_LNA
 	bool "Low Noise Amplifier GPIO interface"
+	depends on !SOC_SERIES_NRF51X
 	help
 	  Enable GPIO interface to a Low Noise Amplifier. This allows hardware
 	  designs using LNAs to let the Controller toggle their state based on

--- a/subsys/bluetooth/controller/hci/hci.c
+++ b/subsys/bluetooth/controller/hci/hci.c
@@ -1673,12 +1673,12 @@ static void vs_read_supported_commands(struct net_buf *buf,
 
 	/* Set Version Information, Supported Commands, Supported Features. */
 	rp->commands[0] |= BIT(0) | BIT(1) | BIT(2);
-#if defined(CONFIG_BT_CTLR_HCI_VS_EXT)
+#if defined(CONFIG_BT_HCI_VS_EXT)
 	/* Write BD_ADDR, Read Build Info */
 	rp->commands[0] |= BIT(5) | BIT(7);
 	/* Read Static Addresses, Read Key Hierarchy Roots */
 	rp->commands[1] |= BIT(0) | BIT(1);
-#endif /* CONFIG_BT_CTLR_HCI_VS_EXT */
+#endif /* CONFIG_BT_HCI_VS_EXT */
 }
 
 static void vs_read_supported_features(struct net_buf *buf,
@@ -1692,7 +1692,7 @@ static void vs_read_supported_features(struct net_buf *buf,
 	memset(&rp->features[0], 0x00, sizeof(rp->features));
 }
 
-#if defined(CONFIG_BT_CTLR_HCI_VS_EXT)
+#if defined(CONFIG_BT_HCI_VS_EXT)
 static void vs_write_bd_addr(struct net_buf *buf, struct net_buf **evt)
 {
 	struct bt_hci_cp_vs_write_bd_addr *cmd = (void *)buf->data;
@@ -1813,7 +1813,7 @@ static void vs_read_key_hierarchy_roots(struct net_buf *buf,
 #endif /* CONFIG_SOC_FAMILY_NRF5 */
 }
 
-#endif /* CONFIG_BT_CTLR_HCI_VS_EXT */
+#endif /* CONFIG_BT_HCI_VS_EXT */
 
 static int vendor_cmd_handle(u16_t ocf, struct net_buf *cmd,
 			     struct net_buf **evt)
@@ -1831,7 +1831,7 @@ static int vendor_cmd_handle(u16_t ocf, struct net_buf *cmd,
 		vs_read_supported_features(cmd, evt);
 		break;
 
-#if defined(CONFIG_BT_CTLR_HCI_VS_EXT)
+#if defined(CONFIG_BT_HCI_VS_EXT)
 	case BT_OCF(BT_HCI_OP_VS_READ_BUILD_INFO):
 		vs_read_build_info(cmd, evt);
 		break;
@@ -1847,7 +1847,7 @@ static int vendor_cmd_handle(u16_t ocf, struct net_buf *cmd,
 	case BT_OCF(BT_HCI_OP_VS_READ_KEY_HIERARCHY_ROOTS):
 		vs_read_key_hierarchy_roots(cmd, evt);
 		break;
-#endif /* CONFIG_BT_CTLR_HCI_VS_EXT */
+#endif /* CONFIG_BT_HCI_VS_EXT */
 
 	default:
 		return -EINVAL;


### PR DESCRIPTION
The PA/LNA feature is not functional on nRF51x series due to added
interrupt latency. Disable this feature unconditionally for those ICs to
avoid unexpected behavior.

Signed-off-by: Carles Cufi <carles.cufi@nordicsemi.no>