### PR TITLE
kernel: implement k_thread_create() as a syscall

### DIFF
--- a/include/arch/arm/arch.h
+++ b/include/arch/arm/arch.h
@@ -135,7 +135,7 @@ extern "C" {
  * @param size Size of the stack memory region
  */
 #define _ARCH_THREAD_STACK_DEFINE(sym, size) \
-	struct _k_thread_stack_element __noinit __aligned(STACK_ALIGN) \
+	struct _k_thread_stack_element __kernel_noinit __aligned(STACK_ALIGN) \
 		sym[size+MPU_GUARD_ALIGN_AND_SIZE]
 
 /**
@@ -152,7 +152,7 @@ extern "C" {
  * @param size Size of the stack memory region
  */
 #define _ARCH_THREAD_STACK_ARRAY_DEFINE(sym, nmemb, size) \
-	struct _k_thread_stack_element __noinit __aligned(STACK_ALIGN) \
+	struct _k_thread_stack_element __kernel_noinit __aligned(STACK_ALIGN) \
 		sym[nmemb][size+MPU_GUARD_ALIGN_AND_SIZE]
 
 /**

--- a/include/arch/x86/arch.h
+++ b/include/arch/x86/arch.h
@@ -718,12 +718,12 @@ static inline int _arch_is_user_context(void)
 #endif /* CONFIG_X86_STACK_PROTECTION */
 
 #define _ARCH_THREAD_STACK_DEFINE(sym, size) \
-	struct _k_thread_stack_element __noinit \
+	struct _k_thread_stack_element __kernel_noinit \
 		__aligned(_STACK_BASE_ALIGN) \
 		sym[(size) + _STACK_GUARD_SIZE]
 
 #define _ARCH_THREAD_STACK_ARRAY_DEFINE(sym, nmemb, size) \
-	struct _k_thread_stack_element __noinit \
+	struct _k_thread_stack_element __kernel_noinit \
 		__aligned(_STACK_BASE_ALIGN) \
 		sym[nmemb][ROUND_UP(size, _STACK_BASE_ALIGN) + \
 			   _STACK_GUARD_SIZE]

--- a/include/kernel.h
+++ b/include/kernel.h
@@ -567,12 +567,12 @@ extern void k_call_stacks_analyze(void);
  *
  * @return ID of new thread.
  */
-extern k_tid_t k_thread_create(struct k_thread *new_thread,
-			       k_thread_stack_t stack,
-			       size_t stack_size,
-			       k_thread_entry_t entry,
-			       void *p1, void *p2, void *p3,
-			       int prio, u32_t options, s32_t delay);
+__syscall k_tid_t k_thread_create(struct k_thread *new_thread,
+				  k_thread_stack_t stack,
+				  size_t stack_size,
+				  k_thread_entry_t entry,
+				  void *p1, void *p2, void *p3,
+				  int prio, u32_t options, s32_t delay);
 
 /**
  * @brief Drop a thread's privileges permanently to user mode

--- a/include/linker/kobject-text.ld
+++ b/include/linker/kobject-text.ld
@@ -2,7 +2,7 @@
 #if defined(CONFIG_DEBUG) || defined(CONFIG_STACK_CANARIES)
 #define KOBJECT_TEXT_AREA	256
 #else
-#define KOBJECT_TEXT_AREA	118
+#define KOBJECT_TEXT_AREA	128
 #endif
 #endif
 

--- a/kernel/thread.c
+++ b/kernel/thread.c
@@ -326,6 +326,8 @@ void _setup_new_thread(struct k_thread *new_thread,
 #ifdef CONFIG_USERSPACE
 	new_thread->base.perm_index = get_next_thread_index();
 	_k_object_init(new_thread);
+	_k_object_init(stack);
+	new_thread->stack_obj = stack;
 
 	/* Any given thread has access to itself */
 	k_object_access_grant(new_thread, new_thread);
@@ -501,6 +503,7 @@ void _k_thread_single_abort(struct k_thread *thread)
 	 * and triggers errors if API calls are made on it from user threads
 	 */
 	_k_object_uninit(thread);
+	_k_object_uninit(thread->stack_obj);
 
 	if (thread->base.perm_index != -1) {
 		free_thread_index(thread->base.perm_index);

--- a/kernel/userspace.c
+++ b/kernel/userspace.c
@@ -41,6 +41,8 @@ const char *otype_to_str(enum k_objects otype)
 		return "k_thread";
 	case K_OBJ_TIMER:
 		return "k_timer";
+	case K_OBJ__THREAD_STACK_ELEMENT:
+		return "k_thread_stack_t";
 
 	/* Driver subsystems */
 	case K_OBJ_DRIVER_ADC:

--- a/kernel/userspace_handler.c
+++ b/kernel/userspace_handler.c
@@ -17,7 +17,7 @@ static struct _k_object *validate_any_object(void *obj)
 	/* This can be any kernel object and it doesn't have to be
 	 * initialized
 	 */
-	ret = _k_object_validate(ko, K_OBJ_ANY, 1);
+	ret = _k_object_validate(ko, K_OBJ_ANY, _OBJ_INIT_ANY);
 	if (ret) {
 #ifdef CONFIG_PRINTK
 		_dump_object_error(ret, obj, ko, K_OBJ_ANY);

--- a/tests/kernel/mem_protect/obj_validation/src/main.c
+++ b/tests/kernel/mem_protect/obj_validation/src/main.c
@@ -26,7 +26,8 @@ static int test_object(struct k_sem *sem, int retval)
 		 */
 		ret = _k_object_validate(_k_object_find(sem), K_OBJ_SEM, 0);
 	} else {
-		ret = _obj_validation_check(sem, K_OBJ_SEM, 0);
+		ret = _obj_validation_check(_k_object_find(sem), sem,
+					    K_OBJ_SEM, 0);
 	}
 
 	if (ret != retval) {


### PR DESCRIPTION
- for purposes of permission tracking, thread stacks are now treated like other kernel objects
- userspace handlers can now assert that objects passed in are strictly uninitialized
- added k_thread_create() as a system call