### PR TITLE
mem_domain: fix warning when assertions enabled

### DIFF
--- a/kernel/mem_domain.c
+++ b/kernel/mem_domain.c
@@ -18,7 +18,7 @@ void k_mem_domain_init(struct k_mem_domain *domain, u32_t num_parts,
 {
 	unsigned int key;
 
-	__ASSERT(domain && !num_parts || parts, "");
+	__ASSERT(domain && (!num_parts || parts), "");
 	__ASSERT(num_parts <= max_partitions, "");
 
 	key = irq_lock();


### PR DESCRIPTION
Warning was "suggest parentheses around ‘&&’ within ‘||’"

Signed-off-by: Andrew Boie <andrew.p.boie@intel.com>