### PR TITLE
net: sockets: Simplify if logic in sendto(), fix warning

### DIFF
--- a/subsys/net/lib/sockets/sockets.c
+++ b/subsys/net/lib/sockets/sockets.c
@@ -266,10 +266,8 @@ ssize_t zsock_sendto(int sock, const void *buf, size_t len, int flags,
 	if (sock_type == SOCK_DGRAM) {
 		err = net_context_sendto(send_pkt, dest_addr, addrlen, NULL,
 					 timeout, NULL, NULL);
-	} else if (sock_type == SOCK_STREAM) {
-		err = net_context_send(send_pkt, NULL, timeout, NULL, NULL);
 	} else {
-		__ASSERT(0, "Unknown socket type");
+		err = net_context_send(send_pkt, NULL, timeout, NULL, NULL);
 	}
 
 	if (err < 0) {


### PR DESCRIPTION
send()/sendto() aren't "front facing" functions, so when user calls
them, context type hopefully should be already validated by other
functions. They are also on critical path of app/network performance,
so getting rid of extra check helps a little bit too. This also
fixes a warning of "err" possibly being used non-initialized.

Fixes #4162

Signed-off-by: Paul Sokolovsky <paul.sokolovsky@linaro.org>