### PR TITLE
kernel: abolish __syscall_inline

### DIFF
--- a/include/kernel.h
+++ b/include/kernel.h
@@ -2571,7 +2571,7 @@ __syscall void k_sem_give(struct k_sem *sem);
  *
  * @return N/A
  */
-__syscall_inline void k_sem_reset(struct k_sem *sem);
+__syscall void k_sem_reset(struct k_sem *sem);
 
 static inline void _impl_k_sem_reset(struct k_sem *sem)
 {
@@ -2587,7 +2587,7 @@ static inline void _impl_k_sem_reset(struct k_sem *sem)
  *
  * @return Current semaphore count.
  */
-__syscall_inline unsigned int k_sem_count_get(struct k_sem *sem);
+__syscall unsigned int k_sem_count_get(struct k_sem *sem);
 
 static inline unsigned int _impl_k_sem_count_get(struct k_sem *sem)
 {

--- a/include/toolchain/common.h
+++ b/include/toolchain/common.h
@@ -110,7 +110,6 @@
  * functions are system calls
  */
 #define __syscall static inline
-#define __syscall_inline static inline
 
 #ifndef BUILD_ASSERT
 /* compile-time assertion that makes the build fail */

--- a/scripts/gen_syscall_header.py
+++ b/scripts/gen_syscall_header.py
@@ -6,9 +6,9 @@
 
 import sys
 
-def gen_macro(ret, argc, inline=False):
-    sys.stdout.write("K_SYSCALL_DECLARE%d%s%s(id, name" % (argc,
-        ("" if ret else "_VOID"), ("_INLINE" if inline else "")))
+def gen_macro(ret, argc):
+    sys.stdout.write("K_SYSCALL_DECLARE%d%s(id, name" % (argc,
+        ("" if ret else "_VOID")))
     if (ret):
         sys.stdout.write(", ret")
     for i in range(argc):
@@ -53,8 +53,13 @@ def newline():
 
 def gen_defines_inner(ret, argc, kernel_only=False, user_only=False):
     sys.stdout.write("#define ")
-    gen_macro(ret, argc, inline=True)
+    gen_macro(ret, argc)
     newline()
+
+    if not user_only:
+        gen_fn(ret, argc, "_impl_##name", extern=True)
+        sys.stdout.write(";")
+        newline()
 
     gen_fn(ret, argc, "name");
     newline()
@@ -83,18 +88,6 @@ def gen_defines_inner(ret, argc, kernel_only=False, user_only=False):
         newline()
 
     sys.stdout.write("\t}\n\n")
-
-    sys.stdout.write("#define ")
-    gen_macro(ret, argc)
-    newline()
-
-    if not user_only:
-        gen_fn(ret, argc, "_impl_##name", extern=True)
-        sys.stdout.write(";")
-        newline()
-    sys.stdout.write("\t")
-    gen_macro(ret, argc, inline=True)
-    sys.stdout.write(";\n\n")
 
 def gen_defines(argc, kernel_only=False, user_only=False):
     gen_defines_inner(False, argc, kernel_only, user_only)

--- a/scripts/gen_syscalls.py
+++ b/scripts/gen_syscalls.py
@@ -11,7 +11,7 @@ import os
 
 
 api_regex = re.compile(r'''
-__(syscall|syscall_inline)\s+   # __syscall or __syscall_inline
+__syscall\s+                    # __syscall attribute, must be first
 ([^(]+)                         # type and name of system call (split later)
 [(]                             # Function opening parenthesis
 ([^)]*)                         # Arg list (split later)
@@ -41,7 +41,7 @@ def typename_split(item):
 
 
 def analyze_fn(match_group, fn):
-    variant, func, args = match_group
+    func, args = match_group
 
     try:
         if args == "void":
@@ -60,9 +60,7 @@ def analyze_fn(match_group, fn):
     # Get the proper system call macro invocation, which depends on the
     # number of arguments, the return type, and whether the implementation
     # is an inline function
-    macro = "K_SYSCALL_DECLARE%d%s%s" % (len(args),
-            "_VOID" if is_void else "",
-            "_INLINE" if variant == "syscall_inline" else "")
+    macro = "K_SYSCALL_DECLARE%d%s" % (len(args), "_VOID" if is_void else "")
 
     # Flatten the argument lists and generate a comma separated list
     # of t0, p0, t1, p1, ... tN, pN as expected by the macros


### PR DESCRIPTION
This used to exist because in earlier versions of the system call
interfaces, an "extern" declaration of the system call implementation
function would precede the real inline version of the implementation.
The compiler would not like this and would throw "static declaration
of ‘foo’ follows non-static declaration". So alternate macros were
needed which declare the implementation function as 'static inline'
instead of extern.

However, currently the inline version of these system call
implementations appear first, the K_SYSCALL_DECLARE() macros appear in
the header generated by gen_syscalls.py, which is always included at the
end of the header file. The compiler does not complain if a
static inline function is succeeded by an extern prototype of the
same function. This lets us simplify the generated system call
macros and just use __syscall everywhere.

The disassembly of this was checked on x86 to ensure that for
kernel-only or CONFIG_USERSPACE=n scenarios, everything is still being
inlined as expected.

Signed-off-by: Andrew Boie <andrew.p.boie@intel.com>