### PR TITLE
drivers/ieee802154: Fix regression in uart pipe driver

### DIFF
--- a/drivers/ieee802154/ieee802154_uart_pipe.c
+++ b/drivers/ieee802154/ieee802154_uart_pipe.c
@@ -93,7 +93,7 @@ flush:
 done:
 	*off = 0;
 
-	return pkt;
+	return buf;
 }
 
 static int upipe_cca(struct device *dev)


### PR DESCRIPTION
A wrong name replacement was applied during commit
db11fcd1747c5c34a26e984f1483eaee1ee16fc1

Fixes issue #4165

Signed-off-by: Tomasz Bursztyka <tomasz.bursztyka@linux.intel.com>