### PR TITLE
flash: stm32f3xx: fixup byte write method

### DIFF
--- a/drivers/flash/flash_stm32f3x.c
+++ b/drivers/flash/flash_stm32f3x.c
@@ -91,7 +91,10 @@ static int flash_stm32_write(struct device *dev, off_t offset,
 	}
 
 	if (remainder) {
-		halfword = (*((u16_t *)data)) & 0x00FF;
+		/* Half word write operation */
+		/* Get the byte to write and add 0xFF00 */
+		/* to keep leading byte to erased value */
+		halfword = ((*((u16_t *)data)) & 0x00FF) | 0xFF00;
 		if (flash_stm32_program_halfword(dev, address, halfword)
 				!= FLASH_COMPLETE) {
 			return -EINVAL;


### PR DESCRIPTION
stm32f3xx flash could only be programmed 16 bits at a time.
For one byte programming, stm32f3xx flash driver applies AND
operation with 0x00FF to the byte to be written. This results
in programming 0x00 on leading byte of the half word, which
won't be writable anymore.
This commit forces leading byte to 0xFF (erase value) so it
could be written on a later write operation.

Signed-off-by: Erwan Gouriou <erwan.gouriou@linaro.org>