### PR TITLE
kernel: rename k_object_grant_access()

### DIFF
--- a/include/kernel.h
+++ b/include/kernel.h
@@ -227,7 +227,7 @@ void _k_object_init(void *obj);
  * @param object Address of kernel object
  * @param thread Thread to grant access to the object
  */
-void k_object_grant_access(void *object, struct k_thread *thread);
+void k_object_access_grant(void *object, struct k_thread *thread);
 
 #else
 static inline int _k_object_validate(void *obj, enum k_objects otype, int init)
@@ -244,7 +244,7 @@ static inline void _k_object_init(void *obj)
 	ARG_UNUSED(obj);
 }
 
-static inline void k_object_grant_access(void *object, struct k_thread *thread)
+static inline void k_object_access_grant(void *object, struct k_thread *thread)
 {
 	ARG_UNUSED(object);
 	ARG_UNUSED(thread);

--- a/kernel/thread.c
+++ b/kernel/thread.c
@@ -270,7 +270,7 @@ void _setup_new_thread(struct k_thread *new_thread,
 	_k_object_init(new_thread);
 
 	/* Any given thread has access to itself */
-	k_object_grant_access(new_thread, new_thread);
+	k_object_access_grant(new_thread, new_thread);
 #endif
 }
 

--- a/kernel/userspace.c
+++ b/kernel/userspace.c
@@ -131,8 +131,7 @@ static int test_thread_perms(struct _k_object *ko)
 	return 0;
 }
 
-
-void k_object_grant_access(void *object, struct k_thread *thread)
+void k_object_access_grant(void *object, struct k_thread *thread)
 {
 	struct _k_object *ko = _k_object_find(object);
 
@@ -163,7 +162,6 @@ void k_object_grant_access(void *object, struct k_thread *thread)
 	}
 	set_thread_perms(ko, thread);
 }
-
 
 int _k_object_validate(void *obj, enum k_objects otype, int init)
 {


### PR DESCRIPTION
Zephyr naming convention is to have the verb last.

Signed-off-by: Andrew Boie <andrew.p.boie@intel.com>