### PR TITLE
k_object_access API adjustments

### DIFF
--- a/include/kernel.h
+++ b/include/kernel.h
@@ -229,6 +229,23 @@ void _k_object_init(void *obj);
  */
 void k_object_access_grant(void *object, struct k_thread *thread);
 
+
+/**
+ * grant all present and future threads access to an object
+ *
+ * If the caller is from supervisor mode, or the caller is from user mode and
+ * have sufficient permissions on the object, then that object will have
+ * permissions granted to it for *all* current and future threads running in
+ * the system, effectively becoming a public kernel object.
+ *
+ * Use of this API should be avoided on systems that are running untrusted code
+ * as it is possible for such code to derive the addresses of kernel objects
+ * and perform unwanted operations on them.
+ *
+ * @param object Address of kernel object
+ */
+void k_object_access_all_grant(void *object);
+
 #else
 static inline int _k_object_validate(void *obj, enum k_objects otype, int init)
 {

--- a/include/kernel.h
+++ b/include/kernel.h
@@ -227,7 +227,7 @@ void _k_object_init(void *obj);
  * @param object Address of kernel object
  * @param thread Thread to grant access to the object
  */
-void k_object_grant_access(void *object, struct k_thread *thread);
+void k_object_access_grant(void *object, struct k_thread *thread);
 
 #else
 static inline int _k_object_validate(void *obj, enum k_objects otype, int init)
@@ -244,7 +244,7 @@ static inline void _k_object_init(void *obj)
 	ARG_UNUSED(obj);
 }
 
-static inline void k_object_grant_access(void *object, struct k_thread *thread)
+static inline void k_object_access_grant(void *object, struct k_thread *thread)
 {
 	ARG_UNUSED(object);
 	ARG_UNUSED(thread);

--- a/include/kernel.h
+++ b/include/kernel.h
@@ -215,7 +215,33 @@ int _k_object_validate(void *obj, enum k_objects otype, int init);
  * @param object Address of the kernel object
  */
 void _k_object_init(void *obj);
+#else
+static inline int _k_object_validate(void *obj, enum k_objects otype, int init)
+{
+	ARG_UNUSED(obj);
+	ARG_UNUSED(otype);
+	ARG_UNUSED(init);
 
+	return 0;
+}
+
+static inline void _k_object_init(void *obj)
+{
+	ARG_UNUSED(obj);
+}
+
+static inline void _impl_k_object_access_grant(void *object,
+					       struct k_thread *thread)
+{
+	ARG_UNUSED(object);
+	ARG_UNUSED(thread);
+}
+
+static inline void _impl_k_object_access_all_grant(void *object)
+{
+	ARG_UNUSED(object);
+}
+#endif /* !CONFIG_USERSPACE */
 
 /**
  * grant a thread access to a kernel object
@@ -227,7 +253,7 @@ void _k_object_init(void *obj);
  * @param object Address of kernel object
  * @param thread Thread to grant access to the object
  */
-void k_object_access_grant(void *object, struct k_thread *thread);
+__syscall void k_object_access_grant(void *object, struct k_thread *thread);
 
 
 /**
@@ -244,29 +270,7 @@ void k_object_access_grant(void *object, struct k_thread *thread);
  *
  * @param object Address of kernel object
  */
-void k_object_access_all_grant(void *object);
-
-#else
-static inline int _k_object_validate(void *obj, enum k_objects otype, int init)
-{
-	ARG_UNUSED(obj);
-	ARG_UNUSED(otype);
-	ARG_UNUSED(init);
-
-	return 0;
-}
-
-static inline void _k_object_init(void *obj)
-{
-	ARG_UNUSED(obj);
-}
-
-static inline void k_object_access_grant(void *object, struct k_thread *thread)
-{
-	ARG_UNUSED(object);
-	ARG_UNUSED(thread);
-}
-#endif /* CONFIG_USERSPACE */
+__syscall void k_object_access_all_grant(void *object);
 
 /* timeouts */
 

--- a/kernel/Makefile
+++ b/kernel/Makefile
@@ -37,4 +37,4 @@ lib-$(CONFIG_SYS_CLOCK_EXISTS) += timer.o
 lib-$(CONFIG_ATOMIC_OPERATIONS_C) += atomic_c.o
 lib-$(CONFIG_POLL) += poll.o
 lib-$(CONFIG_PTHREAD_IPC) += pthread.o
-lib-$(CONFIG_USERSPACE) += userspace.o mem_domain.o
+lib-$(CONFIG_USERSPACE) += userspace.o userspace_handler.o mem_domain.o

--- a/kernel/thread.c
+++ b/kernel/thread.c
@@ -270,7 +270,7 @@ void _setup_new_thread(struct k_thread *new_thread,
 	_k_object_init(new_thread);
 
 	/* Any given thread has access to itself */
-	k_object_grant_access(new_thread, new_thread);
+	k_object_access_grant(new_thread, new_thread);
 #endif
 }
 

--- a/kernel/userspace.c
+++ b/kernel/userspace.c
@@ -174,7 +174,7 @@ static struct _k_object *access_check(void *object)
 	return ko;
 }
 
-void k_object_access_grant(void *object, struct k_thread *thread)
+void _impl_k_object_access_grant(void *object, struct k_thread *thread)
 {
 	struct _k_object *ko = access_check(object);
 
@@ -183,7 +183,7 @@ void k_object_access_grant(void *object, struct k_thread *thread)
 	}
 }
 
-void k_object_access_all_grant(void *object)
+void _impl_k_object_access_all_grant(void *object)
 {
 	struct _k_object *ko = access_check(object);
 

--- a/kernel/userspace.c
+++ b/kernel/userspace.c
@@ -131,8 +131,7 @@ static int test_thread_perms(struct _k_object *ko)
 	return 0;
 }
 
-
-void k_object_grant_access(void *object, struct k_thread *thread)
+void k_object_access_grant(void *object, struct k_thread *thread)
 {
 	struct _k_object *ko = _k_object_find(object);
 
@@ -163,7 +162,6 @@ void k_object_grant_access(void *object, struct k_thread *thread)
 	}
 	set_thread_perms(ko, thread);
 }
-
 
 int _k_object_validate(void *obj, enum k_objects otype, int init)
 {

--- a/kernel/userspace_handler.c
+++ b/kernel/userspace_handler.c
@@ -1,0 +1,34 @@
+/*
+ * Copyright (c) 2017 Intel Corporation
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <kernel.h>
+#include <syscall_handler.h>
+
+/* Normally these would be included in userspace.c, but the way
+ * syscall_dispatch.c declares weak handlers results in build errors if these
+ * are located in userspace.c. Just put in a separate file.
+ */
+
+u32_t _handler_k_object_access_grant(u32_t object, u32_t thread, u32_t arg3,
+				     u32_t arg4, u32_t arg5, u32_t arg6,
+				     void *ssf)
+{
+	_SYSCALL_ARG2;
+
+	_SYSCALL_IS_OBJ(thread, K_OBJ_THREAD, 0, ssf);
+	_impl_k_object_access_grant((void *)object, (struct k_thread *)thread);
+	return 0;
+}
+
+u32_t _handler_k_object_access_all_grant(u32_t object, u32_t arg2, u32_t arg3,
+					 u32_t arg4, u32_t arg5, u32_t arg6,
+					 void *ssf)
+{
+	_SYSCALL_ARG1;
+
+	_impl_k_object_access_all_grant((void *)object);
+	return 0;
+}


### PR DESCRIPTION
- Renamed k_object_grant_access() to conform to naming convention
- Added k_object_access_all_grant() API to make it simple to declare public objects
- k_object_access APIs declared as system calls so user threads may call them