### PR TITLE
arm: nxp: kw41z: Select IEEE802154_KW41Z driver for networking

### DIFF
--- a/arch/arm/soc/nxp_kinetis/kwx/Kconfig.defconfig.mkw41z4
+++ b/arch/arm/soc/nxp_kinetis/kwx/Kconfig.defconfig.mkw41z4
@@ -64,4 +64,17 @@ config SOC_FLASH_MCUX
 
 endif # FLASH
 
+if NETWORKING
+
+config NET_L2_IEEE802154
+        def_bool y
+
+config IEEE802154_KW41Z
+        def_bool y
+
+config NET_APP_IEEE802154_DEV_NAME
+        default IEEE802154_KW41Z_DRV_NAME
+
+endif # NETWORKING
+
 endif # SOC_MKW41Z4

--- a/drivers/ieee802154/Kconfig.kw41z
+++ b/drivers/ieee802154/Kconfig.kw41z
@@ -19,13 +19,14 @@ config IEEE802154_KW41Z_DRV_NAME
 	string "NXP KW41Z Driver's name"
 	default "KW41Z"
 	help
-	  This option sets the driver name
+	  This option sets the driver name. Do not change it unless
+	  you know what you are doing.
 
 config IEEE802154_KW41Z_INIT_PRIO
 	int "KW41Z initialization priority"
 	default 80
 	help
-	  Set the initialization priority number. Do not mess with it unless
+	  Set the initialization priority number. Do not change it unless
 	  you know what you are doing. It has to start before the net stack.
 
 endif


### PR DESCRIPTION
802.15.4 is the networking hardware on frdm_kw41z. So, if networking
in enabled, automatically select the corresponding driver. This is
similar to how frdm_k64f automatically selects Ethernet driver,
96b_carbon selects BLE/IPSP drivers, etc.

Signed-off-by: Paul Sokolovsky <paul.sokolovsky@linaro.org>