### PR TITLE
net/ieee802154: Fixing a typo in ieee15_4 shell module

### DIFF
--- a/subsys/net/ip/l2/ieee802154/ieee802154_shell.c
+++ b/subsys/net/ip/l2/ieee802154/ieee802154_shell.c
@@ -42,7 +42,7 @@ static int shell_cmd_ack(int argc, char *argv[])
 	}
 
 	if (!strcmp(argv[1], "unset") || !strcmp(argv[1], "0")) {
-		net_mgmt(NET_REQUEST_IEEE802154_SET_ACK, iface, NULL, 0);
+		net_mgmt(NET_REQUEST_IEEE802154_UNSET_ACK, iface, NULL, 0);
 		printk("ACK flag unset on outgoing packets\n");
 
 		return 0;


### PR DESCRIPTION
Obviously unset ACK requires NET_REQUEST_IEEE802154_UNSET_ACK request.

Signed-off-by: Tomasz Bursztyka <tomasz.bursztyka@linux.intel.com>