### PR TITLE
net: lib: app: If NET_LOG_GLOBAL is enabled, enable NET_DEBUG_APP

### DIFF
--- a/subsys/net/lib/app/Kconfig
+++ b/subsys/net/lib/app/Kconfig
@@ -69,6 +69,7 @@ config NET_APP_NEED_IPV4
 config NET_DEBUG_APP
 	bool "Debug net app library"
 	default n
+	default y if NET_LOG_GLOBAL
 	help
 	Enables net app library to output debug messages
 


### PR DESCRIPTION
This is similar to the changes made previously to other network
components: if user selected NET_LOG_GLOBAL, they really mean
they want logging (first of all, error/warning logging) across
the entire network stack.

Signed-off-by: Paul Sokolovsky <paul.sokolovsky@linaro.org>