### PR TITLE
Bluetooth: Mesh: Fix revoking app keys

### DIFF
--- a/subsys/bluetooth/host/mesh/cfg.c
+++ b/subsys/bluetooth/host/mesh/cfg.c
@@ -2582,7 +2582,7 @@ static void krp_set(struct bt_mesh_model *model, struct bt_mesh_msg_ctx *ctx,
 	} else if ((sub->kr_phase == BT_MESH_KR_PHASE_1 ||
 		    sub->kr_phase == BT_MESH_KR_PHASE_2) &&
 		   phase == BT_MESH_KR_PHASE_3) {
-		memcpy(&sub->keys[0], &sub->keys[1], sizeof(sub->keys[0]));
+		bt_mesh_net_revoke_keys(sub);
 		if (IS_ENABLED(CONFIG_BT_MESH_LOW_POWER) ||
 		    IS_ENABLED(CONFIG_BT_MESH_FRIEND)) {
 			bt_mesh_friend_cred_refresh(ctx->net_idx);

--- a/subsys/bluetooth/host/mesh/net.h
+++ b/subsys/bluetooth/host/mesh/net.h
@@ -245,6 +245,8 @@ int bt_mesh_friend_cred_del(u16_t net_idx, u16_t addr);
 
 bool bt_mesh_kr_update(struct bt_mesh_subnet *sub, u8_t new_kr, bool new_key);
 
+void bt_mesh_net_revoke_keys(struct bt_mesh_subnet *sub);
+
 int bt_mesh_net_beacon_update(struct bt_mesh_subnet *sub);
 
 void bt_mesh_rpl_reset(void);


### PR DESCRIPTION
The needed code for taking updated app keys into use and revoking the
old ones was missing.

Signed-off-by: Johan Hedberg <johan.hedberg@intel.com>