### PR TITLE
kernel: add K_STACK_RELEASE

### DIFF
--- a/include/kernel.h
+++ b/include/kernel.h
@@ -504,6 +504,13 @@ extern void k_call_stacks_analyze(void);
  */
 #define K_USER (1 << 2)
 
+/* This thread should make its stack memory permissions universally accessible
+ * if and when the thread aborts. Allows for re-use of stack memory areas
+ * if CONFIG_USERSPACE is enabled. Only use this with K_USER, and if you are
+ * sure that the released stack memory will not have any sensitive information.
+ */
+#define K_STACK_RELEASE (1 << 3)
+
 #ifdef CONFIG_X86
 /* x86 Bitmask definitions for threads user options */
 

--- a/kernel/include/nano_internal.h
+++ b/kernel/include/nano_internal.h
@@ -151,6 +151,23 @@ void _arch_user_mode_enter(k_thread_entry_t user_entry, void *p1, void *p2,
  *            architecture specific.
  */
 extern FUNC_NORETURN void _arch_syscall_oops(void *ssf);
+
+/**
+ * @brief Free a thread's stack memory for universal use
+ *
+ * Used by k_thread_abort() for threads that were started with K_STACK_RELEASE.
+ * The entire stack region for the thread, including any guard pages, will
+ * be configured as memory that can be read/written by user mode threads, such
+ * that this stack memory may be re-used for another thread stack or other
+ * purposes.
+ *
+ * Threads this gets called on may be swapped out if they were the currently
+ * running thread, but never swapped in again, and will always be marked as
+ * _THREAD_DEAD.
+ *
+ * @param thread The thread whose stack will be released
+ */
+extern void _arch_release_thread_stack(struct k_thread *thread);
 #endif /* CONFIG_USERSPACE */
 
 /* set and clear essential fiber/task flag */

--- a/kernel/thread.c
+++ b/kernel/thread.c
@@ -417,6 +417,12 @@ void _k_thread_single_abort(struct k_thread *thread)
 		}
 	}
 	_mark_thread_as_dead(thread);
+
+#ifdef CONFIG_USERSPACE
+	if (thread->base.user_options & K_STACK_RELEASE) {
+		_arch_release_thread_stack(thread);
+	}
+#endif
 }
 
 #ifdef CONFIG_MULTITHREADING


### PR DESCRIPTION
This is intended for threads that do not process sensitive data that
need their stack memory re-used, a common idiom in Zephyr test cases,
but generally applicable since otherwise once a chunk of memory is used
for a thread stack, a user thread could never re-use it even after that
thread terminates.

Signed-off-by: Andrew Boie <andrew.p.boie@intel.com>