### PR TITLE
Btp gatt read value

### DIFF
--- a/tests/bluetooth/tester/btp_spec.txt
+++ b/tests/bluetooth/tester/btp_spec.txt
@@ -1111,6 +1111,18 @@ Commands and responses:
 
 		In case of an error, the error response will be returned.
 
+	Opcode 0x1c - Read Local Attribute Value
+
+		Controller Index:	<controller id>
+		Command parameters:	Attribute_ID (2 octets)
+		Response parameters:	Value_Length (2 octet)
+					Value (1-512 octets)
+
+		This command is used to query local GATT Server of
+		characteristic/descriptor value.
+
+		In case of an error, the error response will be returned.
+
 Events:
 	Opcode 0x80 - Notification/Indication Received
 

--- a/tests/bluetooth/tester/src/bttester.h
+++ b/tests/bluetooth/tester/src/bttester.h
@@ -516,6 +516,15 @@ struct gatt_cfg_notify_cmd {
 	u16_t ccc_handle;
 } __packed;
 
+#define GATT_READ_LOCAL_ATTR_VAL	0x1c
+struct gatt_read_local_attr_cmd {
+	u16_t handle;
+} __packed;
+struct gatt_read_local_attr_rp {
+	u16_t value_length;
+	u8_t value[0];
+} __packed;
+
 /* GATT events */
 #define GATT_EV_NOTIFICATION		0x80
 struct gatt_notification_ev {


### PR DESCRIPTION
Read Local Attribute Value will be used to query GATT Server database
for current attribute value.
This is needed to verify if the write procedure was performed properly.