### PR TITLE
net: l2: ieee802154: Automatically select CONFIG_NET_6LO

### DIFF
--- a/subsys/net/ip/l2/ieee802154/Kconfig
+++ b/subsys/net/ip/l2/ieee802154/Kconfig
@@ -6,6 +6,7 @@
 
 menuconfig NET_L2_IEEE802154
 	bool "Enable IEEE 802.15.4 Radio"
+	select NET_6LO
 	default n
 	help
 	  Add support for low rate WPAN IEEE 802.15.4 technology.


### PR DESCRIPTION
802.15.4 IP-based networking requires 6LoWPAN layer and won't work
correctly without it. So, if NET_L2_IEEE802154 is select,
automatically select NET_6LO. This is similar to what BLE L2
does (NET_L2_BT causes selection of NET_6LO).

Signed-off-by: Paul Sokolovsky <paul.sokolovsky@linaro.org>