### PR TITLE
net/samples: Build cc2520 frdm's common code only when relevant

### DIFF
--- a/samples/net/common/Makefile.common
+++ b/samples/net/common/Makefile.common
@@ -6,10 +6,12 @@
 
 # Common routines used in net samples
 
-ifeq ($(CONFIG_BOARD_FRDM_K64F),y)
+ifeq ($(CONFIG_BOARD_FRDM_K64F), y)
+ifeq ($(CONFIG_IEEE802154_CC2520), y)
 ccflags-y +=-I${ZEPHYR_BASE}/drivers/
 ccflags-y +=-I${ZEPHYR_BASE}/include/drivers/
 obj-y += ../../common/cc2520_frdm_k64f.o
+endif
 endif
 
 ifeq ($(CONFIG_NET_TESTING), y)


### PR DESCRIPTION
If cc2520 is not selected, there won't be any need for that part.

Signed-off-by: Tomasz Bursztyka <tomasz.bursztyka@linux.intel.com>