### PR TITLE
doc: Add security issue tracking information

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -75,11 +75,14 @@ support systems:
   the Github issues system: https://github.com/zephyrproject-rtos/zephyr/issues.
   You can browse through the reported issues and submit issues of your own.
 
-* **Security-related Issue Reporting**: For security-related inquiries or
-  reporting suspected security-related bugs in the Zephyr OS, please
-  send email to vulnerabilities@zephyrproject.org.  We will assess and fix
-  flaws according to our security policy outlined in the Zephyr Project
+* **Security-related Issue Reporting and Tracking**: For security-related
+  inquiries or reporting suspected security-related bugs in the Zephyr OS,
+  please send email to vulnerabilities@zephyrproject.org.  We will assess and
+  fix flaws according to our security policy outlined in the Zephyr Project
   `Security Overview`_.
+
+  Security related issue tracking is done in JIRA.  The location of this JIRA
+  is https://zephyrprojectsec.atlassian.net.
 
 * **Mailing List**: The `Zephyr Mailing Lists`_ are perhaps the most convenient
   way to track developer discussions and to ask your own support questions to


### PR DESCRIPTION
This patch adds information about the security related issue
tracking.

Signed-off-by: Andy Gross <andy.gross@linaro.org>