### PR TITLE
kernel: sem: fix k_sem_take return value

### DIFF
--- a/kernel/sem.c
+++ b/kernel/sem.c
@@ -197,9 +197,7 @@ u32_t _handler_k_sem_take(u32_t sem_ptr, u32_t timeout, u32_t arg3,
 	_SYSCALL_ARG2;
 
 	_SYSCALL_IS_OBJ(sem_ptr, K_OBJ_SEM, 0, ssf);
-	_impl_k_sem_take((struct k_sem *)sem_ptr, timeout);
-
-	return 0;
+	return _impl_k_sem_take((struct k_sem *)sem_ptr, timeout);
 }
 
 u32_t _handler_k_sem_reset(u32_t sem_ptr, u32_t arg2, u32_t arg3,


### PR DESCRIPTION
This API has a return value which was not being propagated back to the
caller if invoked as a system call.

Signed-off-by: Andrew Boie <andrew.p.boie@intel.com>