### PR TITLE
doc: Fix regexp in .known-issues networking.conf file

### DIFF
--- a/.known-issues/doc/networking.conf
+++ b/.known-issues/doc/networking.conf
@@ -20,12 +20,12 @@
 # include/net/net_if.h warnings
 #
 ^(?P<filename>[-._/\w]+/doc/api/networking.rst):(?P<lineno>[0-9]+): WARNING: Error when parsing function declaration.
-^\If the function has no return type:
+^If the function has no return type:
 ^[ \t]*Error in declarator or parameters and qualifiers
 ^[ \t]*Invalid definition: Expected identifier in nested name, got keyword: struct \[error at [0-9]+]
 ^.*struct net_if __aligned\(32\)
 ^[- \t]*\^
-^\If the function has a return type:
+^If the function has a return type:
 ^[ \t]*Error in declarator or parameters and qualifiers
 ^[ \t]*If pointer to member declarator:
 ^[ \t]*Invalid definition: Expected \'::\' in pointer to member \(function\). \[error at [0-9]+]


### PR DESCRIPTION
This fixes following error:

ERROR: zephyr/.known-issues/doc/networking.conf: bytes 622-1441:
     bad regex: bad escape \I at position 119 (line 2, column 2)
ERROR: E: zephyr/.known-issues/doc/networking.conf: can't load
     config file: bad escape \I at position 119 (line 2, column 2)

Signed-off-by: Jukka Rissanen <jukka.rissanen@linux.intel.com>