### PR TITLE
Bluetooth: tester: Add Attribute Value Changed Event

### DIFF
--- a/tests/bluetooth/tester/btp_spec.txt
+++ b/tests/bluetooth/tester/btp_spec.txt
@@ -1129,6 +1129,18 @@ Events:
 		This event indicates that IUT has received notification
 		or notification.
 
+	Opcode 0x81 - Attribute Value Changed
+
+		Controller Index:	<controller id>
+		Event parameters:	Attribute_ID (2 octets)
+					Data_Length (2 octet)
+					Data (1-512 octets)
+
+		This event command is used to indicate attribute
+		(characteristic or descriptor) value changed.
+		Event is triggered when ATT Write operation to Tester GATT
+		Server has been performed successfully.
+
 L2CAP Service (ID 3)
 ==================
 

--- a/tests/bluetooth/tester/src/bttester.h
+++ b/tests/bluetooth/tester/src/bttester.h
@@ -527,6 +527,13 @@ struct gatt_notification_ev {
 	u8_t data[0];
 } __packed;
 
+#define GATT_EV_ATTR_VALUE_CHANGED	0x81
+struct gatt_attr_value_changed_ev {
+	u16_t handle;
+	u16_t data_length;
+	u8_t data[0];
+} __packed;
+
 static inline void tester_set_bit(u8_t *addr, unsigned int bit)
 {
 	u8_t *p = addr + (bit / 8);


### PR DESCRIPTION
    Attribute Value Changed Event will be used to indicate characteristic
    or descriptor value change in local GATT Server database.
    Event will be triggered when PTS performed ATT Write operation successfully.