### PR TITLE
checkpatch: define typedefsfile to deal with a few false positives

### DIFF
--- a/.checkpatch.conf
+++ b/.checkpatch.conf
@@ -5,6 +5,7 @@
 --show-types
 --max-line-length=80
 --min-conf-desc-length=1
+--typedefsfile=scripts/checkpatch/typedefsfile
 
 --ignore BRACES
 --ignore PRINTK_WITHOUT_KERN_LEVEL

--- a/scripts/checkpatch/typedefsfile
+++ b/scripts/checkpatch/typedefsfile
@@ -1,0 +1,1 @@
+mbedtls_pk_context


### PR DESCRIPTION
checkpatch expects typedefs to be suffixed with _t and has different
rules when typedefs are being used as arguments of a function. This
seems to be a known issue and defining typedefs in a file resolves this
issue.

Signed-off-by: Anas Nashif <anas.nashif@intel.com>