### PR TITLE
Bluetooth: Mesh: Fix missing initialization of bt_mesh.local_queue

### DIFF
--- a/subsys/bluetooth/host/mesh/net.c
+++ b/subsys/bluetooth/host/mesh/net.c
@@ -68,6 +68,7 @@ static u16_t msg_cache_next;
 
 /* Singleton network context (the implementation only supports one) */
 struct bt_mesh_net bt_mesh = {
+	.local_queue = _K_FIFO_INITIALIZER(bt_mesh.local_queue),
 	.sub = {
 		[0 ... (CONFIG_BT_MESH_SUBNET_COUNT - 1)] = {
 			.net_idx = BT_MESH_KEY_UNUSED,


### PR DESCRIPTION
The local_queue was never being initialized.

Signed-off-by: Johan Hedberg <johan.hedberg@intel.com>