### PR TITLE
Bluetooth: controller: Fix slave from initiating conn upd ind

### DIFF
--- a/subsys/bluetooth/controller/ll_sw/ctrl.c
+++ b/subsys/bluetooth/controller/ll_sw/ctrl.c
@@ -1918,7 +1918,7 @@ isr_rx_conn_pkt_ctrl_rej_conn_upd(struct radio_pdu_node_rx *radio_pdu_node_rx,
 	conn = _radio.conn_curr;
 
 	/* Unsupported remote feature */
-	if (rej_ext_ind->error_code == 0x1a) {
+	if (!conn->role && (rej_ext_ind->error_code == 0x1a)) {
 		LL_ASSERT(conn->llcp_req == conn->llcp_ack);
 
 		conn->llcp_conn_param.state = LLCP_CPR_STATE_UPD;


### PR DESCRIPTION
If a peer master role has support for Connection Parameter
Request Procedure set in its supported features but would
send an Extended Reject Ind as response to the procedure
then the controller incorrectly initiated a Connection
Update Procedure which is not permitted in a slave role.

This would lead to connection timeout after the used instant
in the invalid Connection Update Procedure.

This is fixed by initiating a Connection Update Procedure
only if in a master role.

Signed-off-by: Vinayak Kariappa Chettimada <vich@nordicsemi.no>