### PR TITLE
Bluetooth: controller: Fix Conn Param Req response timeout

### DIFF
--- a/subsys/bluetooth/controller/ll_sw/ctrl.c
+++ b/subsys/bluetooth/controller/ll_sw/ctrl.c
@@ -6419,6 +6419,9 @@ static inline u32_t event_conn_upd_prep(struct connection *conn,
 		if ((conn->llcp_conn_param.req != conn->llcp_conn_param.ack) &&
 		    (conn->llcp_conn_param.state == LLCP_CPR_STATE_UPD)) {
 			conn->llcp_conn_param.ack = conn->llcp_conn_param.req;
+
+			/* Stop procedure timeout */
+			conn->procedure_expire = 0;
 		}
 #endif /* CONFIG_BT_CTLR_CONN_PARAM_REQ */
 		/* Reset ticker_id_prepare as role is not continued further


### PR DESCRIPTION
When the peer slave rejects a Connection Parameter Request
Procedure, the controller proceeds to perform a Connection
Update Procedure without clearing the procedure timer that
causes the connection to terminate eventually. This is
fixed by clearing the procedure timeout when the Connection
Update Procedure completes.

Signed-off-by: Vinayak Kariappa Chettimada <vich@nordicsemi.no>