### PR TITLE
cmake: Ported CONFIG_ASSERT and CONFIG_BOARD_DEPRECATED warnings

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -672,3 +672,19 @@ add_subdirectory(cmake/usage)
 add_subdirectory(cmake/reports)
 
 include(cmake/ccache.cmake)
+
+if(CONFIG_ASSERT)
+  message(WARNING "
+      ------------------------------------------------------------
+      --- WARNING:  __ASSERT() statements are globally ENABLED ---
+      --- The kernel will run more slowly and uses more memory ---
+      ------------------------------------------------------------"
+)
+endif()
+
+if(CONFIG_BOARD_DEPRECATED)
+  message(WARNING "
+      WARNING:  The board '${BOARD}' is deprecated and will be
+      removed in version ${CONFIG_BOARD_DEPRECATED}"
+)
+endif()


### PR DESCRIPTION
Signed-off-by: Sebastian Boe <sebastian.boe@nordicsemi.no>