### PR TITLE
i2c: deprecate use of union dev_config

### DIFF
--- a/drivers/crypto/crypto_ataes132a.c
+++ b/drivers/crypto/crypto_ataes132a.c
@@ -167,7 +167,7 @@ int ataes132a_init(struct device *dev)
 {
 	struct ataes132a_device_data *ataes132a = dev->driver_data;
 	const struct ataes132a_device_config *cfg = dev->config->config_info;
-	union dev_config i2c_cfg;
+	u32_t i2c_cfg;
 
 	SYS_LOG_DBG("ATAES132A INIT");
 
@@ -177,11 +177,9 @@ int ataes132a_init(struct device *dev)
 		return -EINVAL;
 	}
 
-	i2c_cfg.raw = 0;
-	i2c_cfg.bits.is_master_device = 1;
-	i2c_cfg.bits.speed = ATAES132A_BUS_SPEED;
+	i2c_cfg = I2C_MODE_MASTER | I2C_SPEED_SET(ATAES132A_BUS_SPEED);
 
-	i2c_configure(ataes132a->i2c, i2c_cfg.raw);
+	i2c_configure(ataes132a->i2c, i2c_cfg);
 
 	k_sem_init(&ataes132a->device_sem, 1, UINT_MAX);
 

--- a/drivers/sensor/bmg160/bmg160.c
+++ b/drivers/sensor/bmg160/bmg160.c
@@ -21,13 +21,11 @@ static inline int bmg160_bus_config(struct device *dev)
 {
 	const struct bmg160_device_config *dev_cfg = dev->config->config_info;
 	struct bmg160_device_data *bmg160 = dev->driver_data;
-	union dev_config i2c_cfg;
+	u32_t i2c_cfg;
 
-	i2c_cfg.raw = 0;
-	i2c_cfg.bits.is_master_device = 1;
-	i2c_cfg.bits.speed = dev_cfg->i2c_speed;
+	i2c_cfg = I2C_MODE_MASTER | I2C_SPEED_SET(dev_cfg->i2c_speed);
 
-	return i2c_configure(bmg160->i2c, i2c_cfg.raw);
+	return i2c_configure(bmg160->i2c, i2c_cfg);
 }
 
 int bmg160_read(struct device *dev, u8_t reg_addr, u8_t *data,

--- a/drivers/sensor/hp206c/hp206c.c
+++ b/drivers/sensor/hp206c/hp206c.c
@@ -20,13 +20,11 @@
 static inline int hp206c_bus_config(struct device *dev)
 {
 	struct hp206c_device_data *hp206c = dev->driver_data;
-	union dev_config i2c_cfg;
+	u32_t i2c_cfg;
 
-	i2c_cfg.raw = 0;
-	i2c_cfg.bits.is_master_device = 1;
-	i2c_cfg.bits.speed = I2C_SPEED_STANDARD;
+	i2c_cfg = I2C_MODE_MASTER | I2C_SPEED_SET(I2C_SPEED_STANDARD);
 
-	return i2c_configure(hp206c->i2c, i2c_cfg.raw);
+	return i2c_configure(hp206c->i2c, i2c_cfg);
 }
 
 static int hp206c_read(struct device *dev, u8_t cmd, u8_t *data,

--- a/include/i2c.h
+++ b/include/i2c.h
@@ -45,12 +45,12 @@ extern "C" {
 /** I2C Ultra Fast Speed */
 #define I2C_SPEED_ULTRA			(0x5)
 
-/** @cond INTERNAL_HIDDEN */
 #define I2C_SPEED_SHIFT			(1)
+#define I2C_SPEED_SET(speed)		(((speed) << I2C_SPEED_SHIFT) \
+						& I2C_SPEED_MASK)
 #define I2C_SPEED_MASK			(0x7 << I2C_SPEED_SHIFT) /* 3 bits */
 #define I2C_SPEED_GET(cfg) 		(((cfg) & I2C_SPEED_MASK) \
 						>> I2C_SPEED_SHIFT)
-/** @endcond  */
 
 /** Use 10-bit addressing. */
 #define I2C_ADDR_10_BITS		(1 << 0)
@@ -94,7 +94,7 @@ struct i2c_msg {
 	u8_t		flags;
 };
 
-union dev_config {
+union __deprecated dev_config {
 	u32_t raw;
 	struct __bits {
 		u32_t        use_10_bit_addr : 1;

--- a/tests/drivers/i2c/i2c_api/src/test_i2c.c
+++ b/tests/drivers/i2c/i2c_api/src/test_i2c.c
@@ -22,14 +22,7 @@
 #define I2C_DEV_NAME CONFIG_I2C_0_NAME
 #endif
 
-static union dev_config i2c_cfg = {
-	.raw = 0,
-	.bits = {
-		.use_10_bit_addr = 0,
-		.is_master_device = 1,
-		.speed = I2C_SPEED_STANDARD,
-	},
-};
+u32_t i2c_cfg = I2C_SPEED_SET(I2C_SPEED_STANDARD) | I2C_MODE_MASTER;
 
 static int test_gy271(void)
 {
@@ -42,7 +35,7 @@ static int test_gy271(void)
 	}
 
 	/* 1. Verify i2c_configure() */
-	if (i2c_configure(i2c_dev, i2c_cfg.raw)) {
+	if (i2c_configure(i2c_dev, i2c_cfg)) {
 		TC_PRINT("I2C config failed\n");
 		return TC_FAIL;
 	}
@@ -97,7 +90,7 @@ static int test_burst_gy271(void)
 	}
 
 	/* 1. verify i2c_configure() */
-	if (i2c_configure(i2c_dev, i2c_cfg.raw)) {
+	if (i2c_configure(i2c_dev, i2c_cfg)) {
 		TC_PRINT("I2C config failed\n");
 		return TC_FAIL;
 	}


### PR DESCRIPTION
There are several issues with the dev_config union used as a
convenience when calling the i2c_configure api.  One, the union is well
name spaced protected and doesn't convey use with just i2c.  Second
there are assumptions of how the bits might get packed by the union
which can't be guaranteed.  Since the API takes a u32_t lets change in
tree uses to using the macros to setup a u32_t and make the union as
deprecated.

Signed-off-by: Kumar Gala <kumar.gala@linaro.org>