### PR TITLE
Syscall handler cleanups

### DIFF
--- a/include/kernel.h
+++ b/include/kernel.h
@@ -178,28 +178,6 @@ struct _k_object {
 } __packed;
 
 #define K_OBJ_FLAG_INITIALIZED	BIT(0)
-/**
- * Ensure a system object is a valid object of the expected type
- *
- * Searches for the object and ensures that it is indeed an object
- * of the expected type, that the caller has the right permissions on it,
- * and that the object has been initialized.
- *
- * This function is intended to be called on the kernel-side system
- * call handlers to validate kernel object pointers passed in from
- * userspace.
- *
- * @param obj Address of the kernel object
- * @param otype Expected type of the kernel object
- * @param init If true, this is for an init function and we will not error
- *	   out if the object is not initialized
- * @return 0 If the object is valid
- *         -EBADF if not a valid object of the specified type
- *         -EPERM If the caller does not have permissions
- *         -EINVAL Object is not initialized
- */
-int _k_object_validate(void *obj, enum k_objects otype, int init);
-
 
 /**
  * Lookup a kernel object and init its metadata if it exists
@@ -212,15 +190,6 @@ int _k_object_validate(void *obj, enum k_objects otype, int init);
  */
 void _k_object_init(void *obj);
 #else
-static inline int _k_object_validate(void *obj, enum k_objects otype, int init)
-{
-	ARG_UNUSED(obj);
-	ARG_UNUSED(otype);
-	ARG_UNUSED(init);
-
-	return 0;
-}
-
 static inline void _k_object_init(void *obj)
 {
 	ARG_UNUSED(obj);

--- a/kernel/alert.c
+++ b/kernel/alert.c
@@ -97,7 +97,7 @@ u32_t _handler_k_alert_send(u32_t alert, u32_t arg2, u32_t arg3,
 {
 	_SYSCALL_ARG1;
 
-	_SYSCALL_IS_OBJ(alert, K_OBJ_ALERT, 0, ssf);
+	_SYSCALL_OBJ(alert, K_OBJ_ALERT, ssf);
 	_impl_k_alert_send((struct k_alert *)alert);
 
 	return 0;
@@ -115,7 +115,7 @@ u32_t _handler_k_alert_recv(u32_t alert, u32_t timeout, u32_t arg3,
 {
 	_SYSCALL_ARG2;
 
-	_SYSCALL_IS_OBJ(alert, K_OBJ_ALERT, 0, ssf);
+	_SYSCALL_OBJ(alert, K_OBJ_ALERT, ssf);
 	return _impl_k_alert_recv((struct k_alert *)alert, timeout);
 }
 #endif

--- a/kernel/include/syscall_handler.h
+++ b/kernel/include/syscall_handler.h
@@ -18,6 +18,28 @@
 extern const _k_syscall_handler_t _k_syscall_table[K_SYSCALL_LIMIT];
 
 /**
+ * Ensure a system object is a valid object of the expected type
+ *
+ * Searches for the object and ensures that it is indeed an object
+ * of the expected type, that the caller has the right permissions on it,
+ * and that the object has been initialized.
+ *
+ * This function is intended to be called on the kernel-side system
+ * call handlers to validate kernel object pointers passed in from
+ * userspace.
+ *
+ * @param obj Address of the kernel object
+ * @param otype Expected type of the kernel object
+ * @param init If true, this is for an init function and we will not error
+ *	   out if the object is not initialized
+ * @return 0 If the object is valid
+ *         -EBADF if not a valid object of the specified type
+ *         -EPERM If the caller does not have permissions
+ *         -EINVAL Object is not initialized
+ */
+int _k_object_validate(void *obj, enum k_objects otype, int init);
+
+/**
  * @brief Runtime expression check for system call arguments
  *
  * Used in handler functions to perform various runtime checks on arguments,

--- a/kernel/include/syscall_handler.h
+++ b/kernel/include/syscall_handler.h
@@ -116,6 +116,47 @@ int _k_object_validate(void *obj, enum k_objects otype, int init);
 #define _SYSCALL_MEMORY_WRITE(ptr, size, ssf) \
 	_SYSCALL_MEMORY(ptr, size, 1, ssf)
 
+#define _SYSCALL_MEMORY_ARRAY(ptr, nmemb, size, write, ssf) \
+	do { \
+		u32_t product; \
+		_SYSCALL_VERIFY_MSG(!__builtin_umul_overflow((u32_t)(nmemb), \
+							     (u32_t)(size), \
+							     &product), ssf, \
+				    "%ux%u array is too large", \
+				    (u32_t)(nmemb), (u32_t)(size)); \
+		_SYSCALL_MEMORY(ptr, product, write, ssf); \
+	} while (0)
+
+/**
+ * @brief Validate user thread has read permission for sized array
+ *
+ * Used when the memory region is expressed in terms of number of elements and
+ * each element size, handles any overflow issues with computing the total
+ * array bounds. Otherwise see _SYSCALL_MEMORY_READ.
+ *
+ * @param ptr Memory area to examine
+ * @param nmemb Number of elements in the array
+ * @param size Size of each array element
+ * @param ssf Syscall stack frame argument passed to the handler function
+ */
+#define _SYSCALL_MEMORY_ARRAY_READ(ptr, nmemb, size, ssf) \
+	_SYSCALL_MEMORY_ARRAY(ptr, nmemb, size, 0, ssf)
+
+/**
+ * @brief Validate user thread has read/write permission for sized array
+ *
+ * Used when the memory region is expressed in terms of number of elements and
+ * each element size, handles any overflow issues with computing the total
+ * array bounds. Otherwise see _SYSCALL_MEMORY_WRITE.
+ *
+ * @param ptr Memory area to examine
+ * @param nmemb Number of elements in the array
+ * @param size Size of each array element
+ * @param ssf Syscall stack frame argument passed to the handler function
+ */
+#define _SYSCALL_MEMORY_ARRAY_WRITE(ptr, nmemb, size, ssf) \
+	_SYSCALL_MEMORY_ARRAY(ptr, nmemb, size, 1, ssf)
+
 #define _SYSCALL_IS_OBJ(ptr, type, init, ssf) \
 	_SYSCALL_VERIFY_MSG(!_k_object_validate((void *)ptr, type, init), ssf, \
 			    "object %p access denied", (void *)(ptr))

--- a/kernel/msg_q.c
+++ b/kernel/msg_q.c
@@ -70,7 +70,7 @@ u32_t _handler_k_msgq_init(u32_t q, u32_t buffer, u32_t msg_size,
 	_SYSCALL_ARG4;
 
 	_SYSCALL_OBJ_INIT(q, K_OBJ_MSGQ, ssf);
-	_SYSCALL_MEMORY_WRITE(buffer, msg_size * max_msgs, ssf);
+	_SYSCALL_MEMORY_ARRAY_WRITE(buffer, max_msgs, msg_size, ssf);
 
 	_impl_k_msgq_init((struct k_msgq *)q, (char *)buffer, msg_size,
 			  max_msgs);

--- a/kernel/msg_q.c
+++ b/kernel/msg_q.c
@@ -69,8 +69,8 @@ u32_t _handler_k_msgq_init(u32_t q, u32_t buffer, u32_t msg_size,
 {
 	_SYSCALL_ARG4;
 
-	_SYSCALL_IS_OBJ(q, K_OBJ_MSGQ, 1, ssf);
-	_SYSCALL_MEMORY(buffer, msg_size * max_msgs, 1, ssf);
+	_SYSCALL_OBJ_INIT(q, K_OBJ_MSGQ, ssf);
+	_SYSCALL_MEMORY_WRITE(buffer, msg_size * max_msgs, ssf);
 
 	_impl_k_msgq_init((struct k_msgq *)q, (char *)buffer, msg_size,
 			  max_msgs);
@@ -133,8 +133,8 @@ u32_t _handler_k_msgq_put(u32_t msgq_p, u32_t data, u32_t timeout,
 	struct k_msgq *q = (struct k_msgq *)msgq_p;
 	_SYSCALL_ARG3;
 
-	_SYSCALL_IS_OBJ(q, K_OBJ_MSGQ, 0, ssf);
-	_SYSCALL_MEMORY(data, q->msg_size, 0, ssf);
+	_SYSCALL_OBJ(q, K_OBJ_MSGQ, ssf);
+	_SYSCALL_MEMORY_READ(data, q->msg_size, ssf);
 
 	return _impl_k_msgq_put(q, (void *)data, timeout);
 }
@@ -201,8 +201,8 @@ u32_t _handler_k_msgq_get(u32_t msgq_p, u32_t data, u32_t timeout,
 	struct k_msgq *q = (struct k_msgq *)msgq_p;
 	_SYSCALL_ARG3;
 
-	_SYSCALL_IS_OBJ(q, K_OBJ_MSGQ, 0, ssf);
-	_SYSCALL_MEMORY(data, q->msg_size, 1, ssf);
+	_SYSCALL_OBJ(q, K_OBJ_MSGQ, ssf);
+	_SYSCALL_MEMORY_WRITE(data, q->msg_size, ssf);
 
 	return _impl_k_msgq_get(q, (void *)data, timeout);
 }
@@ -232,7 +232,7 @@ u32_t _handler_k_msgq_purge(u32_t q, u32_t arg2, u32_t arg3,
 {
 	_SYSCALL_ARG1;
 
-	_SYSCALL_IS_OBJ(q, K_OBJ_MSGQ, 0, ssf);
+	_SYSCALL_OBJ(q, K_OBJ_MSGQ, ssf);
 
 	_impl_k_msgq_purge((struct k_msgq *)q);
 	return 0;
@@ -243,7 +243,7 @@ u32_t _handler_k_msgq_num_free_get(u32_t q, u32_t arg2, u32_t arg3, u32_t arg4,
 {
 	_SYSCALL_ARG1;
 
-	_SYSCALL_IS_OBJ(q, K_OBJ_MSGQ, 0, ssf);
+	_SYSCALL_OBJ(q, K_OBJ_MSGQ, ssf);
 
 	return _impl_k_msgq_num_free_get((struct k_msgq *)q);
 }
@@ -253,7 +253,7 @@ u32_t _handler_k_msgq_num_used_get(u32_t q, u32_t arg2, u32_t arg3, u32_t arg4,
 {
 	_SYSCALL_ARG1;
 
-	_SYSCALL_IS_OBJ(q, K_OBJ_MSGQ, 0, ssf);
+	_SYSCALL_OBJ(q, K_OBJ_MSGQ, ssf);
 
 	return _impl_k_msgq_num_used_get((struct k_msgq *)q);
 }

--- a/kernel/mutex.c
+++ b/kernel/mutex.c
@@ -87,7 +87,7 @@ u32_t _handler_k_mutex_init(u32_t mutex, u32_t arg2, u32_t arg3,
 {
 	_SYSCALL_ARG1;
 
-	_SYSCALL_IS_OBJ(mutex, K_OBJ_MUTEX, 1, ssf);
+	_SYSCALL_OBJ_INIT(mutex, K_OBJ_MUTEX, ssf);
 	_impl_k_mutex_init((struct k_mutex *)mutex);
 
 	return 0;
@@ -208,7 +208,7 @@ u32_t _handler_k_mutex_lock(u32_t mutex, u32_t timeout, u32_t arg3,
 {
 	_SYSCALL_ARG2;
 
-	_SYSCALL_IS_OBJ(mutex, K_OBJ_MUTEX, 0, ssf);
+	_SYSCALL_OBJ(mutex, K_OBJ_MUTEX, ssf);
 	return _impl_k_mutex_lock((struct k_mutex *)mutex, (s32_t)timeout);
 }
 #endif
@@ -272,7 +272,7 @@ u32_t _handler_k_mutex_unlock(u32_t mutex, u32_t arg2, u32_t arg3,
 {
 	_SYSCALL_ARG1;
 
-	_SYSCALL_IS_OBJ(mutex, K_OBJ_MUTEX, 0, ssf);
+	_SYSCALL_OBJ(mutex, K_OBJ_MUTEX, ssf);
 	_impl_k_mutex_unlock((struct k_mutex *)mutex);
 	return 0;
 }

--- a/kernel/pipes.c
+++ b/kernel/pipes.c
@@ -146,8 +146,8 @@ u32_t _handler_k_pipe_init(u32_t pipe, u32_t buffer, u32_t size,
 {
 	_SYSCALL_ARG3;
 
-	_SYSCALL_IS_OBJ(pipe, K_OBJ_PIPE, 1, ssf);
-	_SYSCALL_MEMORY(buffer, size, 1, ssf);
+	_SYSCALL_OBJ_INIT(pipe, K_OBJ_PIPE, ssf);
+	_SYSCALL_MEMORY_WRITE(buffer, size, ssf);
 
 	_impl_k_pipe_init((struct k_pipe *)pipe, (unsigned char *)buffer,
 			  size);
@@ -694,9 +694,9 @@ u32_t _handler_k_pipe_get(u32_t pipe, u32_t data, u32_t bytes_to_read,
 	size_t *bytes_read = (size_t *)bytes_read_p;
 	size_t min_xfer = (size_t)min_xfer_p;
 
-	_SYSCALL_IS_OBJ(pipe, K_OBJ_PIPE, 0, ssf);
-	_SYSCALL_MEMORY(bytes_read, sizeof(*bytes_read), 1, ssf);
-	_SYSCALL_MEMORY((void *)data, bytes_to_read, 1, ssf);
+	_SYSCALL_OBJ(pipe, K_OBJ_PIPE, ssf);
+	_SYSCALL_MEMORY_WRITE(bytes_read, sizeof(*bytes_read), ssf);
+	_SYSCALL_MEMORY_WRITE((void *)data, bytes_to_read, ssf);
 	_SYSCALL_VERIFY(min_xfer <= bytes_to_read, ssf);
 
 	return _impl_k_pipe_get((struct k_pipe *)pipe, (void *)data,
@@ -724,9 +724,9 @@ u32_t _handler_k_pipe_put(u32_t pipe, u32_t data, u32_t bytes_to_write,
 	size_t *bytes_written = (size_t *)bytes_written_p;
 	size_t min_xfer = (size_t)min_xfer_p;
 
-	_SYSCALL_IS_OBJ(pipe, K_OBJ_PIPE, 0, ssf);
-	_SYSCALL_MEMORY(bytes_written, sizeof(*bytes_written), 1, ssf);
-	_SYSCALL_MEMORY((void *)data, bytes_to_write, 0, ssf);
+	_SYSCALL_OBJ(pipe, K_OBJ_PIPE, ssf);
+	_SYSCALL_MEMORY_WRITE(bytes_written, sizeof(*bytes_written), ssf);
+	_SYSCALL_MEMORY_READ((void *)data, bytes_to_write,  ssf);
 	_SYSCALL_VERIFY(min_xfer <= bytes_to_write, ssf);
 
 	return _impl_k_pipe_put((struct k_pipe *)pipe, (void *)data,

--- a/kernel/sched.c
+++ b/kernel/sched.c
@@ -273,7 +273,7 @@ u32_t _handler_k_thread_priority_get(u32_t arg1, u32_t arg2, u32_t arg3,
 	_SYSCALL_ARG1;
 
 	thread = (struct k_thread *)arg1;
-	_SYSCALL_IS_OBJ(thread, K_OBJ_THREAD, 0, ssf);
+	_SYSCALL_OBJ(thread, K_OBJ_THREAD, ssf);
 	return (u32_t)_impl_k_thread_priority_get(thread);
 }
 #endif
@@ -301,8 +301,9 @@ u32_t _handler_k_thread_priority_set(u32_t thread, u32_t prio, u32_t arg3,
 {
 	_SYSCALL_ARG2;
 
-	_SYSCALL_IS_OBJ(thread, K_OBJ_THREAD, 0, ssf);
-	_SYSCALL_VERIFY(_VALID_PRIO(prio, NULL), ssf);
+	_SYSCALL_OBJ(thread, K_OBJ_THREAD, ssf);
+	_SYSCALL_VERIFY_MSG(_VALID_PRIO(prio, NULL), ssf,
+			    "invalid thread priority %d", (int)prio);
 	_impl_k_thread_priority_set((k_tid_t)thread, prio);
 	return 0;
 }
@@ -399,7 +400,8 @@ u32_t _handler_k_sleep(u32_t arg1, u32_t arg2, u32_t arg3,
 {
 	_SYSCALL_ARG1;
 
-	_SYSCALL_VERIFY(arg1 != K_FOREVER, ssf);
+	_SYSCALL_VERIFY_MSG(arg1 != K_FOREVER, ssf,
+			    "sleeping forever not allowed");
 	_impl_k_sleep(arg1);
 
 	return 0;
@@ -436,7 +438,7 @@ u32_t _handler_k_wakeup(u32_t thread, u32_t arg2, u32_t arg3,
 {
 	_SYSCALL_ARG1;
 
-	_SYSCALL_IS_OBJ(thread, K_OBJ_THREAD, 0, ssf);
+	_SYSCALL_OBJ(thread, K_OBJ_THREAD, ssf);
 	_impl_k_wakeup((k_tid_t)thread);
 	return 0;
 }

--- a/kernel/sem.c
+++ b/kernel/sem.c
@@ -76,7 +76,7 @@ u32_t _handler_k_sem_init(u32_t sem_ptr, u32_t initial_count, u32_t limit,
 {
 	_SYSCALL_ARG3;
 
-	_SYSCALL_IS_OBJ(sem_ptr, K_OBJ_SEM, 1, ssf);
+	_SYSCALL_OBJ_INIT(sem_ptr, K_OBJ_SEM, ssf);
 	_SYSCALL_VERIFY(limit != 0, ssf);
 	_impl_k_sem_init((struct k_sem *)sem_ptr, initial_count, limit);
 	return 0;
@@ -161,7 +161,7 @@ u32_t _handler_k_sem_give(u32_t sem_ptr, u32_t arg2, u32_t arg3,
 {
 	_SYSCALL_ARG1;
 
-	_SYSCALL_IS_OBJ(sem_ptr, K_OBJ_SEM, 0, ssf);
+	_SYSCALL_OBJ(sem_ptr, K_OBJ_SEM, ssf);
 	_impl_k_sem_give((struct k_sem *)sem_ptr);
 
 	return 0;
@@ -196,7 +196,7 @@ u32_t _handler_k_sem_take(u32_t sem_ptr, u32_t timeout, u32_t arg3,
 {
 	_SYSCALL_ARG2;
 
-	_SYSCALL_IS_OBJ(sem_ptr, K_OBJ_SEM, 0, ssf);
+	_SYSCALL_OBJ(sem_ptr, K_OBJ_SEM, ssf);
 	return _impl_k_sem_take((struct k_sem *)sem_ptr, timeout);
 }
 
@@ -205,7 +205,7 @@ u32_t _handler_k_sem_reset(u32_t sem_ptr, u32_t arg2, u32_t arg3,
 {
 	_SYSCALL_ARG1;
 
-	_SYSCALL_IS_OBJ(sem_ptr, K_OBJ_SEM, 0, ssf);
+	_SYSCALL_OBJ(sem_ptr, K_OBJ_SEM, ssf);
 	_impl_k_sem_reset((struct k_sem *)sem_ptr);
 
 	return 0;
@@ -216,7 +216,7 @@ u32_t _handler_k_sem_count_get(u32_t sem_ptr, u32_t arg2, u32_t arg3,
 {
 	_SYSCALL_ARG1;
 
-	_SYSCALL_IS_OBJ(sem_ptr, K_OBJ_SEM, 0, ssf);
+	_SYSCALL_OBJ(sem_ptr, K_OBJ_SEM, ssf);
 	return _impl_k_sem_count_get((struct k_sem *)sem_ptr);
 }
 #endif /* CONFIG_USERSPACE */

--- a/kernel/stack.c
+++ b/kernel/stack.c
@@ -63,8 +63,8 @@ u32_t _handler_k_stack_init(u32_t stack, u32_t buffer, u32_t num_entries_p,
 
 	/* FIXME why is 'num_entries' signed?? */
 	_SYSCALL_VERIFY(num_entries > 0, ssf);
-	_SYSCALL_IS_OBJ(stack, K_OBJ_STACK, 1, ssf);
-	_SYSCALL_MEMORY(buffer, num_entries * sizeof(u32_t), 1, ssf);
+	_SYSCALL_OBJ_INIT(stack, K_OBJ_STACK, ssf);
+	_SYSCALL_MEMORY_WRITE(buffer, num_entries * sizeof(u32_t), ssf);
 
 	_impl_k_stack_init((struct k_stack *)stack, (u32_t *)buffer,
 			   num_entries);
@@ -109,8 +109,8 @@ u32_t _handler_k_stack_push(u32_t stack_p, u32_t data, u32_t arg3,
 	struct k_stack *stack = (struct k_stack *)stack_p;
 	_SYSCALL_ARG2;
 
-	_SYSCALL_IS_OBJ(stack, K_OBJ_STACK, 0, ssf);
-	_SYSCALL_VERIFY(stack->next != stack->top, ssf);
+	_SYSCALL_OBJ(stack, K_OBJ_STACK, ssf);
+	_SYSCALL_VERIFY_MSG(stack->next != stack->top, ssf, "stack is full");
 
 	_impl_k_stack_push(stack, data);
 	return 0;
@@ -151,8 +151,8 @@ u32_t _handler_k_stack_pop(u32_t stack, u32_t data, u32_t timeout,
 {
 	_SYSCALL_ARG3;
 
-	_SYSCALL_IS_OBJ(stack, K_OBJ_STACK, 0, ssf);
-	_SYSCALL_MEMORY(data, sizeof(u32_t), 1, ssf);
+	_SYSCALL_OBJ(stack, K_OBJ_STACK, ssf);
+	_SYSCALL_MEMORY_WRITE(data, sizeof(u32_t), ssf);
 
 	return _impl_k_stack_pop((struct k_stack *)stack, (u32_t *)data,
 				 timeout);

--- a/kernel/stack.c
+++ b/kernel/stack.c
@@ -64,7 +64,7 @@ u32_t _handler_k_stack_init(u32_t stack, u32_t buffer, u32_t num_entries_p,
 	/* FIXME why is 'num_entries' signed?? */
 	_SYSCALL_VERIFY(num_entries > 0, ssf);
 	_SYSCALL_OBJ_INIT(stack, K_OBJ_STACK, ssf);
-	_SYSCALL_MEMORY_WRITE(buffer, num_entries * sizeof(u32_t), ssf);
+	_SYSCALL_MEMORY_ARRAY_WRITE(buffer, num_entries, sizeof(u32_t), ssf);
 
 	_impl_k_stack_init((struct k_stack *)stack, (u32_t *)buffer,
 			   num_entries);

--- a/kernel/thread.c
+++ b/kernel/thread.c
@@ -264,7 +264,7 @@ u32_t _handler_k_thread_start(u32_t thread, u32_t arg2, u32_t arg3,
 {
 	_SYSCALL_ARG1;
 
-	_SYSCALL_IS_OBJ(thread, K_OBJ_THREAD, 0, ssf);
+	_SYSCALL_OBJ(thread, K_OBJ_THREAD, ssf);
 	_impl_k_thread_start((struct k_thread *)thread);
 	return 0;
 }
@@ -352,7 +352,7 @@ u32_t _handler_k_thread_cancel(u32_t thread, u32_t arg2, u32_t arg3,
 {
 	_SYSCALL_ARG1;
 
-	_SYSCALL_IS_OBJ(thread, K_OBJ_THREAD, 0, ssf);
+	_SYSCALL_OBJ(thread, K_OBJ_THREAD, ssf);
 	return _impl_k_thread_cancel((struct k_thread *)thread);
 }
 #endif
@@ -433,7 +433,7 @@ u32_t _handler_k_thread_suspend(u32_t thread, u32_t arg2, u32_t arg3,
 {
 	_SYSCALL_ARG1;
 
-	_SYSCALL_IS_OBJ(thread, K_OBJ_THREAD, 0, ssf);
+	_SYSCALL_OBJ(thread, K_OBJ_THREAD, ssf);
 	_impl_k_thread_suspend((k_tid_t)thread);
 	return 0;
 }
@@ -463,7 +463,7 @@ u32_t _handler_k_thread_resume(u32_t thread, u32_t arg2, u32_t arg3,
 {
 	_SYSCALL_ARG1;
 
-	_SYSCALL_IS_OBJ(thread, K_OBJ_THREAD, 0, ssf);
+	_SYSCALL_OBJ(thread, K_OBJ_THREAD, ssf);
 	_impl_k_thread_resume((k_tid_t)thread);
 	return 0;
 }

--- a/kernel/thread_abort.c
+++ b/kernel/thread_abort.c
@@ -51,8 +51,9 @@ u32_t _handler_k_thread_abort(u32_t thread_p, u32_t arg2, u32_t arg3,
 			      u32_t arg4, u32_t arg5, u32_t arg6, void *ssf)
 {
 	struct k_thread *thread = (struct k_thread *)thread_p;
-	_SYSCALL_IS_OBJ(thread, K_OBJ_THREAD, 0, ssf);
-	_SYSCALL_VERIFY(!(thread->base.user_options & K_ESSENTIAL), ssf);
+	_SYSCALL_OBJ(thread, K_OBJ_THREAD, ssf);
+	_SYSCALL_VERIFY_MSG(!(thread->base.user_options & K_ESSENTIAL), ssf,
+		"aborting essential thread %p", thread);
 
 	_impl_k_thread_abort((struct k_thread *)thread);
 	return 0;

--- a/kernel/timer.c
+++ b/kernel/timer.c
@@ -143,7 +143,7 @@ u32_t _handler_k_timer_start(u32_t timer, u32_t duration_p, u32_t period_p,
 
 	_SYSCALL_VERIFY(duration >= 0 && period >= 0 &&
 			(duration != 0 || period != 0), ssf);
-	_SYSCALL_IS_OBJ(timer, K_OBJ_TIMER, 0, ssf);
+	_SYSCALL_OBJ(timer, K_OBJ_TIMER, ssf);
 	_impl_k_timer_start((struct k_timer *)timer, duration, period);
 	return 0;
 }
@@ -184,7 +184,7 @@ u32_t _handler_k_timer_stop(u32_t timer, u32_t arg2, u32_t arg3,
 {
 	_SYSCALL_ARG1;
 
-	_SYSCALL_IS_OBJ(timer, K_OBJ_TIMER, 0, ssf);
+	_SYSCALL_OBJ(timer, K_OBJ_TIMER, ssf);
 	_impl_k_timer_stop((struct k_timer *)timer);
 	return 0;
 }
@@ -208,7 +208,7 @@ u32_t _handler_k_timer_status_get(u32_t timer, u32_t arg2, u32_t arg3,
 {
 	_SYSCALL_ARG1;
 
-	_SYSCALL_IS_OBJ(timer, K_OBJ_TIMER, 0, ssf);
+	_SYSCALL_OBJ(timer, K_OBJ_TIMER, ssf);
 	return _impl_k_timer_status_get((struct k_timer *)timer);
 }
 #endif
@@ -249,7 +249,7 @@ u32_t _handler_k_timer_status_sync(u32_t timer, u32_t arg2, u32_t arg3,
 {
 	_SYSCALL_ARG1;
 
-	_SYSCALL_IS_OBJ(timer, K_OBJ_TIMER, 0, ssf);
+	_SYSCALL_OBJ(timer, K_OBJ_TIMER, ssf);
 	return _impl_k_timer_status_sync((struct k_timer *)timer);
 }
 #endif

--- a/kernel/userspace_handler.c
+++ b/kernel/userspace_handler.c
@@ -18,7 +18,7 @@ u32_t _handler_k_object_access_grant(u32_t object, u32_t thread, u32_t arg3,
 {
 	_SYSCALL_ARG2;
 
-	_SYSCALL_IS_OBJ(thread, K_OBJ_THREAD, 0, ssf);
+	_SYSCALL_OBJ(thread, K_OBJ_THREAD, ssf);
 	_impl_k_object_access_grant((void *)object, (struct k_thread *)thread);
 	return 0;
 }

--- a/subsys/driver_handlers/sensor.c
+++ b/subsys/driver_handlers/sensor.c
@@ -12,8 +12,8 @@ u32_t _handler_sensor_attr_set(u32_t dev, u32_t chan, u32_t attr,
 {
 	_SYSCALL_ARG4;
 
-	_SYSCALL_IS_OBJ(dev, K_OBJ_DRIVER_SENSOR, 0, ssf);
-	_SYSCALL_MEMORY(val, sizeof(struct sensor_value), 0, ssf);
+	_SYSCALL_OBJ(dev, K_OBJ_DRIVER_SENSOR, ssf);
+	_SYSCALL_MEMORY_READ(val, sizeof(struct sensor_value), ssf);
 	return _impl_sensor_attr_set((struct device *)dev, chan, attr,
 				     (const struct sensor_value *)val);
 }
@@ -24,7 +24,7 @@ u32_t _handler_sensor_sample_fetch(u32_t dev, u32_t arg2, u32_t arg3,
 {
 	_SYSCALL_ARG1;
 
-	_SYSCALL_IS_OBJ(dev, K_OBJ_DRIVER_SENSOR, 0, ssf);
+	_SYSCALL_OBJ(dev, K_OBJ_DRIVER_SENSOR, ssf);
 	return _impl_sensor_sample_fetch((struct device *)dev);
 }
 
@@ -35,7 +35,7 @@ u32_t _handler_sensor_sample_fetch_chan(u32_t dev, u32_t type, u32_t arg3,
 {
 	_SYSCALL_ARG2;
 
-	_SYSCALL_IS_OBJ(dev, K_OBJ_DRIVER_SENSOR, 0, ssf);
+	_SYSCALL_OBJ(dev, K_OBJ_DRIVER_SENSOR, ssf);
 	return _impl_sensor_sample_fetch_chan((struct device *)dev, type);
 }
 
@@ -45,8 +45,8 @@ u32_t _handler_sensor_channel_get(u32_t dev, u32_t chan, u32_t val,
 {
 	_SYSCALL_ARG3;
 
-	_SYSCALL_IS_OBJ(dev, K_OBJ_DRIVER_SENSOR, 0, ssf);
-	_SYSCALL_MEMORY(val, sizeof(struct sensor_value), 1, ssf);
+	_SYSCALL_OBJ(dev, K_OBJ_DRIVER_SENSOR, ssf);
+	_SYSCALL_MEMORY_WRITE(val, sizeof(struct sensor_value), ssf);
 	return _impl_sensor_channel_get((struct device *)dev, chan,
 					(struct sensor_value *)val);
 }

--- a/tests/kernel/mem_protect/obj_validation/src/main.c
+++ b/tests/kernel/mem_protect/obj_validation/src/main.c
@@ -8,6 +8,7 @@
 #include <tc_util.h>
 #include <kernel_structs.h>
 #include <irq_offload.h>
+#include <syscall_handler.h>
 
 #define SEM_ARRAY_SIZE	16
 


### PR DESCRIPTION
The macros in syscall_handler.h have been updated and extended for clarity.

A C API only used in handlers moved to the proper header.

Syscall handlers updated to use the new macros.