### PR TITLE
misc: userspace support for printk()

### DIFF
--- a/include/kernel.h
+++ b/include/kernel.h
@@ -4261,6 +4261,14 @@ extern void k_mem_domain_remove_thread(k_tid_t thread);
  * @} end defgroup mem_domain_apis
  */
 
+/**
+ * @brief Emit a character buffer to the console device
+ *
+ * @param c String of characters to print
+ * @param n The length of the string
+ */
+__syscall void k_str_out(char *c, size_t n);
+
 #ifdef __cplusplus
 }
 #endif

--- a/subsys/debug/Kconfig
+++ b/subsys/debug/Kconfig
@@ -59,6 +59,17 @@ config PRINTK
 	of printk() output entirely. Output is sent immediately, without
 	any mutual exclusion or buffering.
 
+config PRINTK_BUFFER_SIZE
+	int
+	prompt "printk() buffer size"
+	depends on PRINTK
+	depends on USERSPACE
+	default 32
+	help
+	If userspace is enabled, printk() calls are buffered so that we do
+	not have to make a system call for every character emitted. Specify
+	the size of this buffer.
+
 config STDOUT_CONSOLE
 	bool
 	prompt "Send stdout to console"


### PR DESCRIPTION
To avoid making a system call for every character emitted, there is now
a small line buffer if userspace is enabled. The interface to the kernel
is a new system call which takes a sized buffer of console data.

If userspace is not enabled this work exactly like before.

Signed-off-by: Andrew Boie <andrew.p.boie@intel.com>