### PR TITLE
Bluetooth: controller: Fix CPR procedure's Conn Upd initiation

### DIFF
--- a/subsys/bluetooth/controller/ll_sw/ctrl.c
+++ b/subsys/bluetooth/controller/ll_sw/ctrl.c
@@ -1929,7 +1929,7 @@ isr_rx_conn_pkt_ctrl_rej_conn_upd(struct radio_pdu_node_rx *radio_pdu_node_rx,
 		conn->llcp.conn_upd.latency = conn->llcp_conn_param.latency;
 		conn->llcp.conn_upd.timeout = conn->llcp_conn_param.timeout;
 		/* conn->llcp.conn_upd.instant     = 0; */
-		conn->llcp.conn_upd.state = LLCP_CUI_STATE_SELECT;
+		conn->llcp.conn_upd.state = LLCP_CUI_STATE_USE;
 		conn->llcp.conn_upd.is_internal = !conn->llcp_conn_param.cmd;
 		conn->llcp_type = LLCP_CONN_UPD;
 		conn->llcp_ack--;


### PR DESCRIPTION
Fix Connection Parameter Request Procedure's Connection
Update Procedure initiation to calculate the offset rather
than selecting offsets from an out-of-bound memory area.

The symptoms of the bug was noticed as a supervision timeout
due to use of incorrect offset communicated to peer and a
wrong offset used in scheduling the connection events.

Signed-off-by: Vinayak Kariappa Chettimada <vich@nordicsemi.no>