### PR TITLE
Bluetooth: controller: Fix PHY Update response state transition

### DIFF
--- a/subsys/bluetooth/controller/ll_sw/ctrl.c
+++ b/subsys/bluetooth/controller/ll_sw/ctrl.c
@@ -2995,11 +2995,22 @@ isr_rx_conn_pkt_ctrl(struct radio_pdu_node_rx *radio_pdu_node_rx,
 		} else {
 			phy_rsp_send(_radio.conn_curr);
 
-			/* Start Procedure Timeout (TODO: this shall not replace
-			 * terminate procedure).
-			 */
-			_radio.conn_curr->procedure_expire =
-				_radio.conn_curr->procedure_reload;
+			/* Wait for peer master to complete the procedure */
+			if (_radio.conn_curr->llcp_phy.ack ==
+			    _radio.conn_curr->llcp_phy.req) {
+				_radio.conn_curr->llcp_phy.ack--;
+
+				_radio.conn_curr->llcp_phy.state =
+					LLCP_PHY_STATE_RSP_WAIT;
+
+				_radio.conn_curr->llcp_phy.cmd = 0;
+
+				/* Start Procedure Timeout (TODO: this shall not
+				 * replace terminate procedure).
+				 */
+				_radio.conn_curr->procedure_expire =
+					_radio.conn_curr->procedure_reload;
+			}
 		}
 		break;
 


### PR DESCRIPTION
PHY Update procedure timeout was started without transition
to the state that waits for the procedure to complete. This
prevented the timeout from being reset on successful
completion of the procedure and eventually leading to a
connection termination with reason LMP Response Timeout.

Signed-off-by: Vinayak Kariappa Chettimada <vich@nordicsemi.no>