### PR TITLE
ext: hal: stm32cube: Fix LSI_VALUE

### DIFF
--- a/ext/hal/st/stm32cube/stm32f1xx/README
+++ b/ext/hal/st/stm32cube/stm32f1xx/README
@@ -12,3 +12,8 @@ Patch List:
 Impacted files:
    drivers/include/stm32f1xx_hal_conf.h
 ST Bug tracker ID: NA. Not a stm32cube issue
+
+*Update LSI_VALUE to 40 KHz
+Impacted files:
+  drivers/include/stm32f1xx_ll_rcc.h
+ST Bug tracker ID: 37419

--- a/ext/hal/st/stm32cube/stm32f1xx/drivers/include/stm32f1xx_ll_rcc.h
+++ b/ext/hal/st/stm32cube/stm32f1xx/drivers/include/stm32f1xx_ll_rcc.h
@@ -122,7 +122,7 @@ typedef struct
 #endif /* LSE_VALUE */
 
 #if !defined  (LSI_VALUE)
-#define LSI_VALUE    32000U    /*!< Value of the LSI oscillator in Hz */
+#define LSI_VALUE    40000U    /*!< Value of the LSI oscillator in Hz */
 #endif /* LSI_VALUE */
 /**
   * @}

--- a/ext/hal/st/stm32cube/stm32f3xx/README
+++ b/ext/hal/st/stm32cube/stm32f3xx/README
@@ -17,3 +17,8 @@ Patch List:
 Impacted files:
   drivers/include/stm32f3xx_ll_spi.h
 ST Bug tracker ID: 13359
+
+*Update LSI_VALUE to 40 KHz
+Impacted files:
+  drivers/include/stm32f3xx_ll_rcc.h
+ST Bug tracker ID: 37418

--- a/ext/hal/st/stm32cube/stm32f3xx/drivers/include/stm32f3xx_ll_rcc.h
+++ b/ext/hal/st/stm32cube/stm32f3xx/drivers/include/stm32f3xx_ll_rcc.h
@@ -146,7 +146,7 @@ typedef struct
 #endif /* LSE_VALUE */
 
 #if !defined  (LSI_VALUE)
-#define LSI_VALUE    32000U    /*!< Value of the LSI oscillator in Hz */
+#define LSI_VALUE    40000U    /*!< Value of the LSI oscillator in Hz */
 #endif /* LSI_VALUE */
 /**
   * @}


### PR DESCRIPTION
This patch sets the correct LSI_VALUE, according to
STM32F3 reference manual's (RM0316) section 9.2.5 and
STM32F1 reference manual's (RM0008) section 7.2.5..

Signed-off-by: Yannis Damigos <giannis.damigos@gmail.com>