### PR TITLE
Bluetooth: controller: Fix missing PHY update procedure reset

### DIFF
--- a/subsys/bluetooth/controller/ll_sw/ctrl.c
+++ b/subsys/bluetooth/controller/ll_sw/ctrl.c
@@ -8955,16 +8955,20 @@ static inline u32_t phy_upd_ind(struct radio_pdu_node_rx *radio_pdu_node_rx,
 	if (!((p->m_to_s_phy | p->s_to_m_phy) & 0x07)) {
 		struct radio_le_phy_upd_cmplt *p;
 
-		/* Ignore event generation if not local cmd initiated */
+		/* Not in PHY Update Procedure or PDU in wrong state */
 		if ((conn->llcp_phy.ack == conn->llcp_phy.req) ||
-		    (conn->llcp_phy.state != LLCP_PHY_STATE_RSP_WAIT) ||
-		    (!conn->llcp_phy.cmd)) {
+		    (conn->llcp_phy.state != LLCP_PHY_STATE_RSP_WAIT)) {
 			return 0;
 		}
 
 		/* Procedure complete */
 		conn->llcp_phy.ack = conn->llcp_phy.req;
 		conn->procedure_expire = 0;
+
+		/* Ignore event generation if not local cmd initiated */
+		if (!conn->llcp_phy.cmd) {
+			return 0;
+		}
 
 		/* generate phy update complete event */
 		radio_pdu_node_rx->hdr.type = NODE_RX_TYPE_PHY_UPDATE;


### PR DESCRIPTION
When a peer master performed a PHY update procedure with no
change, the state machine was not released. This blocked
any future local initiation of the procedure and also
leading to termination of connection with reason LMP
response timeout.

Signed-off-by: Vinayak Kariappa Chettimada <vich@nordicsemi.no>