### PR TITLE
tests: obj_validation: only run if HW supported

### DIFF
--- a/tests/kernel/mem_protect/obj_validation/testcase.yaml
+++ b/tests/kernel/mem_protect/obj_validation/testcase.yaml
@@ -1,4 +1,4 @@
 tests:
 -   test:
         tags: core security
-        arch_whitelist: x86
+        filter: CONFIG_ARCH_HAS_USERSPACE


### PR DESCRIPTION
The test should only run on platforms where CONFIG_USERSPACE
dependencies are met.

Remove the whitelist, the filter will capture the right platforms.

Fixes: #4050

Signed-off-by: Andrew Boie <andrew.p.boie@intel.com>