### PR TITLE
gen_kobject_list: fix on ARM targets

### DIFF
--- a/scripts/gen_kobject_list.py
+++ b/scripts/gen_kobject_list.py
@@ -417,11 +417,12 @@ def find_kobjects(elf, syms):
             addr = (loc.value[1] | (loc.value[2] << 8) | (loc.value[3] << 16) |
                     (loc.value[4] << 24))
 
+        if addr == 0:
+            # Never linked; gc-sections deleted it
+            continue
+
         if ((addr < kram_start or addr >= kram_end)
                 and (addr < krom_start or addr >= krom_end)):
-            if addr == 0:
-                # Never linked; gc-sections deleted it
-                continue
 
             debug_die(die, "object '%s' found in invalid location %s" %
                     (name, hex(addr)));


### PR DESCRIPTION
On ARM, a zero memory address actually falls within the expected bounds
of kernel memory.

Move the NULL check outside the bounds check, so that kernel objects
with NULL memory addresses in the DWARF info (because gc-sections
discarded them) won't confound the script's logic.

Signed-off-by: Andrew Boie <andrew.p.boie@intel.com>