### PR TITLE
kernel: USERSPACE implies HW_STACK_PROTECTION

### DIFF
--- a/arch/Kconfig
+++ b/arch/Kconfig
@@ -47,7 +47,7 @@ config HW_STACK_PROTECTION
 config USERSPACE
 	bool "User mode threads"
 	depends on ARCH_HAS_USERSPACE
-	depends on HW_STACK_PROTECTION
+	select HW_STACK_PROTECTION
 	help
 	When enabled, threads may be created or dropped down to user mode,
 	which has significantly restricted permissions and must interact


### PR DESCRIPTION
Userspace is built on top of hardware stack protection and assumes
it is there. We can't enable this unless ARCH_HAS_USERSPACE is defined
anyway.

Signed-off-by: Andrew Boie <andrew.p.boie@intel.com>