### PR TITLE
Bluetooth: Fix reporting packets for disconnected connections

### DIFF
--- a/subsys/bluetooth/host/conn.c
+++ b/subsys/bluetooth/host/conn.c
@@ -2060,6 +2060,28 @@ int bt_conn_auth_pairing_confirm(struct bt_conn *conn)
 }
 #endif /* CONFIG_BT_SMP || CONFIG_BT_BREDR */
 
+u8_t bt_conn_get_id(struct bt_conn *conn)
+{
+	return conn - conns;
+}
+
+struct bt_conn *bt_conn_lookup_id(u8_t id)
+{
+	struct bt_conn *conn;
+
+	if (id >= ARRAY_SIZE(conns)) {
+		return NULL;
+	}
+
+	conn = &conns[id];
+
+	if (!atomic_get(&conn->ref)) {
+		return NULL;
+	}
+
+	return bt_conn_ref(conn);
+}
+
 int bt_conn_init(void)
 {
 	int err, i;

--- a/subsys/bluetooth/host/conn_internal.h
+++ b/subsys/bluetooth/host/conn_internal.h
@@ -167,6 +167,15 @@ struct bt_conn *bt_conn_lookup_handle(u16_t handle);
 /* Compare an address with bt_conn destination address */
 int bt_conn_addr_le_cmp(const struct bt_conn *conn, const bt_addr_le_t *peer);
 
+
+/* Helpers for identifying & looking up connections based on the the index to
+ * the connection list. This is useful for O(1) lookups, but can't be used
+ * e.g. as the handle since that's assigned to us by the controller.
+ */
+#define BT_CONN_ID_INVALID 0xff
+u8_t bt_conn_get_id(struct bt_conn *conn);
+struct bt_conn *bt_conn_lookup_id(u8_t id);
+
 /* Look up a connection state. For BT_ADDR_LE_ANY, returns the first connection
  * with the specific state
  */


### PR DESCRIPTION
A connection might have gotten disconnected by the time that an ACL
buffer is free up, in which case there is no need to send a HCI
command for it.

Signed-off-by: Johan Hedberg <johan.hedberg@intel.com>