### PR TITLE
LD: Sort wildcard input sections by alignment

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -760,6 +760,7 @@ LDFLAGS_zephyr += $(call cc-ldoption,$(LINKFLAGPREFIX)-X)
 LDFLAGS_zephyr += $(call cc-ldoption,$(LINKFLAGPREFIX)-N)
 LDFLAGS_zephyr += $(call cc-ldoption,$(LINKFLAGPREFIX)--gc-sections)
 LDFLAGS_zephyr += $(call cc-ldoption,$(LINKFLAGPREFIX)--build-id=none)
+LDFLAGS_zephyr += $(call cc-ldoption,$(LINKFLAGPREFIX)--sort-section=alignment)
 
 LD_TOOLCHAIN ?= -D__GCC_LINKER_CMD__
 

--- a/include/arch/arm/cortex_m/scripts/linker.ld
+++ b/include/arch/arm/cortex_m/scripts/linker.ld
@@ -115,6 +115,14 @@ SECTIONS
 	_vector_end = .;
 	_image_text_start = .;
 	*(.text)
+
+    /* Place _reset_section next to _PrepC because _reset_section
+    jumps to _PrepC and this jump must be within R_ARM_THM_JUMP11
+    bytes of each other to be done in the branch instruction in
+    _reset_section. */
+    *(.text._reset_section)
+    *(.text._PrepC)
+
 	*(".text.*")
 	*(.gnu.linkonce.t.*)
 

--- a/include/arch/nios2/linker.ld
+++ b/include/arch/nios2/linker.ld
@@ -131,10 +131,21 @@ SECTIONS
 #include <custom-rodata.ld>
 #endif
 
+        /*
+        * For XIP images, in order to avoid the situation when __data_rom_start
+        * is 32-bit aligned, but the actual data is placed right after rodata
+        * section, which may not end exactly at 32-bit border, pad rodata
+        * section, so __data_rom_start points at data and it is 32-bit aligned.
+        *
+        * On non-XIP images this may enlarge image size up to 3 bytes. This
+        * generally is not an issue, since modern ROM and FLASH memory is
+        * usually 4k aligned.
+        */
+    	. = ALIGN(4);
         } GROUP_LINK_IN(ROMABLE_REGION)
 
     _image_rom_end = .;
-    __data_rom_start = ALIGN(4);    /* XIP imaged DATA ROM start addr */
+    __data_rom_start = .;
 
     GROUP_END(ROMABLE_REGION)
 


### PR DESCRIPTION
When the linker sees wildcard patterns like

>  \*(.data.\*)

in the linker script it will place symbols into the output section
"in the order in which they are seen during the link". This policy,
which is currently used in Zephyr, forces the linker to put in
unnecessary *fill* sections to comply with alignment constraints.

Sorting by alignment instead of the arbitrary order that we pass in
sections to the linker will

- reduce the amount of filling used
- reduce the likelihood that a refactor changes the binary size

My primary motivation is the second point, in my CMake branch I am
observing that the binary size is different by a percent or so between
the branches. But upon examining the binary it is made clear that this
is all due to filler sections. Sorting the input sections makes it
easier to compare the KBuild and CMake binaries.

I have not bothered to do any proper benchmarking, but here is one
result of the change:

size before this patch
   text	   data	    bss	    dec	    hex	filename
  72426	  31204	  92424	 196054	  2fdd6	outdir/qemu_x86/zephyr.elf

size after this patch
   text	   data	    bss	    dec	    hex	filename
  72426	  31180	  88316	 191922	  2edb2	outdir/qemu_x86/zephyr.elf

docs:
https://sourceware.org/binutils/docs/ld/Input-Section-Wildcards.html

Signed-off-by: Sebastian Boe <sebastian.boe@nordicsemi.no>