### PR TITLE
boards: arm: Fix for STM32373C-EVAL

### DIFF
--- a/boards/arm/stm32373c_eval/doc/stm32373c_eval.rst
+++ b/boards/arm/stm32373c_eval/doc/stm32373c_eval.rst
@@ -118,9 +118,7 @@ Programming and Debugging
 Flashing
 ========
 
-STM32373C-EVAL board includes an ST-LINK/V2-1 embedded debug tool interface.
-At power-on, the board is in firmware-upgrade mode (also called DFU for
-"Device Firmware Upgrade"), allowing the firmware to be updated through the USB.
+The STM32373C-EVAL board includes an ST-LINK/V2 embedded debug tool interface.
 This interface is supported by the openocd version included in Zephyr SDK.
 
 Flashing an application to STM32373C-EVAL
@@ -147,12 +145,6 @@ Then, enter the following command:
 .. code-block:: console
 
    $ make BOARD=stm32373c_eval flash
-
-Run a serial host program to connect with your STM32373C-EVAL board:
-
-.. code-block:: console
-
-   $ minicom -D /dev/ttyACM0
 
 You will see the LED blinking every second.
 

--- a/boards/arm/stm32373c_eval/support/openocd.cfg
+++ b/boards/arm/stm32373c_eval/support/openocd.cfg
@@ -1,4 +1,4 @@
-source [find board/st_nucleo_f3.cfg]
+source [find board/stm32f3discovery.cfg]
 
 $_TARGETNAME configure -event gdb-attach {
         echo "Debugger attaching: halting execution"


### PR DESCRIPTION
This board has an ST-LINK/V2, but OpenOCD config for it seems incorrect,
nor it has an DFU bootloader like newer NUCLEO boards (maybe copy/paste
error in original implementation?)

Fixes #4295

Signed-off-by: Jose F. Fernandez <jffernandez@fenix-es.com>