### PR TITLE
Python-based flashing

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1374,9 +1374,15 @@ run:
 endif
 
 ifneq ($(FLASH_SCRIPT),)
+ifeq ($(USE_ZEPHYR_FLASH_DEBUG_SHELL),)
+flash: zephyr
+	@echo "Flashing $(BOARD_NAME)"
+	$(Q)$(srctree)/scripts/support/zephyr_flash_debug.py flash $(srctree)/scripts/support/$(FLASH_SCRIPT)
+else
 flash: zephyr
 	@echo "Flashing $(BOARD_NAME)"
 	$(Q)$(CONFIG_SHELL) $(srctree)/scripts/support/$(FLASH_SCRIPT) flash
+endif
 else
 flash: FORCE
 	@echo Flashing not supported with this board.

--- a/scripts/support/arc-helper.py
+++ b/scripts/support/arc-helper.py
@@ -1,0 +1,14 @@
+#!/usr/bin/env python3
+
+'''ARC architecture helper script for zephyr_flash_debug.py
+
+FIXME: This is not portable; a better solution is needed.
+       See zephyr_flash_debug.py for details.'''
+
+import os
+import subprocess
+import sys
+
+os.setsid()
+command = sys.argv[1:]
+subprocess.call(command)

--- a/scripts/support/zephyr_flash_debug.py
+++ b/scripts/support/zephyr_flash_debug.py
@@ -1,0 +1,105 @@
+#! /usr/bin/env python3
+
+# Copyright (c) 2017 Linaro Limited.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Zephyr board flashing script
+
+This script is a transparent replacement for an existing Zephyr flash
+script. If it can invoke the flashing tools natively, it will do so; otherwise,
+it delegates to the shell script passed as second argument."""
+
+import abc
+from os import path
+import os
+import sys
+import subprocess
+
+
+def get_env_bool_or(env_var, default_value):
+    try:
+        return bool(int(os.environ[env_var]))
+    except KeyError:
+        return default_value
+
+
+def check_call(cmd, debug):
+    if debug:
+        print(' '.join(cmd))
+    subprocess.check_call(cmd)
+
+
+class ZephyrBinaryFlasher(abc.ABC):
+    '''Abstract superclass for flasher objects.'''
+
+    def __init__(self, debug=False):
+        self.debug = debug
+
+    @staticmethod
+    def create_for_shell_script(shell_script, debug):
+        '''Factory for using as a drop-in replacement to a shell script.
+
+        Get flasher instance to use in place of shell_script, deriving
+        flasher configuration from the environment.'''
+        for sub_cls in ZephyrBinaryFlasher.__subclasses__():
+            if sub_cls.replaces_shell_script(shell_script):
+                return sub_cls.create_from_env(debug)
+        raise ValueError('no flasher replaces script {}'.format(shell_script))
+
+    @staticmethod
+    @abc.abstractmethod
+    def replaces_shell_script(shell_script):
+        '''Check if this flasher class replaces FLASH_SCRIPT=shell_script.'''
+
+    @staticmethod
+    @abc.abstractmethod
+    def create_from_env(debug):
+        '''Create new flasher instance from environment variables.
+
+        This class must be able to replace the current FLASH_SCRIPT. The
+        environment variables expected by that script are used to build
+        the flasher in a backwards-compatible manner.'''
+
+    @abc.abstractmethod
+    def flash(self, **kwargs):
+        '''Flash the board.'''
+
+
+# TODO: Stop using environment variables.
+#
+# Migrate the build system so we can use an argparse.ArgumentParser and
+# per-flasher subparsers, so invoking the script becomes something like:
+#
+#   python zephyr_flash_debug.py openocd --openocd-bin=/openocd/path ...
+#
+# For now, maintain compatibility.
+def flash(shell_script_full, debug):
+    shell_script = path.basename(shell_script_full)
+    try:
+        flasher = ZephyrBinaryFlasher.create_for_shell_script(shell_script,
+                                                              debug)
+    except ValueError:
+        # Can't create a flasher; fall back on shell script.
+        check_call([shell_script_full, 'flash'], debug)
+        return
+
+    flasher.flash()
+
+
+if __name__ == '__main__':
+    debug = True
+    try:
+        debug = get_env_bool_or('KBUILD_VERBOSE', False)
+        if len(sys.argv) != 3 or sys.argv[1] != 'flash':
+            raise ValueError('usage: {} flash path-to-script'.format(
+                sys.argv[0]))
+        flash(sys.argv[2], debug)
+    except Exception as e:
+        if debug:
+            raise
+        else:
+            print('Error: {}'.format(e), file=sys.stderr)
+            print('Re-run with KBUILD_VERBOSE=1 for a stack trace.',
+                  file=sys.stderr)
+            sys.exit(1)

--- a/scripts/support/zephyr_flash_debug.py
+++ b/scripts/support/zephyr_flash_debug.py
@@ -191,6 +191,80 @@ class DfuUtilBinaryFlasher(ZephyrBinaryFlasher):
             print('Now reset your board again to switch back to runtime mode.')
 
 
+class Esp32BinaryFlasher(ZephyrBinaryFlasher):
+    '''Flasher front-end for espidf.'''
+
+    def __init__(self, elf, device, baud=921600, flash_size='detect',
+                 flash_freq='40m', flash_mode='dio', espdif='espidf',
+                 debug=False):
+        super(Esp32BinaryFlasher, self).__init__(debug=debug)
+        self.elf = elf
+        self.device = device
+        self.baud = baud
+        self.flash_size = flash_size
+        self.flash_freq = flash_freq
+        self.flash_mode = flash_mode
+        self.espdif = espdif
+
+    def replaces_shell_script(shell_script):
+        return shell_script == 'esp32.sh'
+
+    def create_from_env(debug):
+        '''Create flasher from environment.
+
+        Required:
+
+        - O: build output directory
+        - KERNEL_ELF_NAME: name of kernel binary in ELF format
+
+        Optional:
+
+        - ESP_DEVICE: serial port to flash, default /dev/ttyUSB0
+        - ESP_BAUD_RATE: serial baud rate, default 921600
+        - ESP_FLASH_SIZE: flash size, default 'detect'
+        - ESP_FLASH_FREQ: flash frequency, default '40m'
+        - ESP_FLASH_MODE: flash mode, default 'dio'
+        - ESP_TOOL: complete path to espdif, or set to 'espidf' to look for it
+          in $ESP_IDF_PATH/components/esptool_py/esptool/esptool.py
+        '''
+        elf = path.join(get_env_or_bail('O'),
+                        get_env_or_bail('KERNEL_ELF_NAME'))
+
+        # TODO add sane device defaults on other platforms than Linux.
+        device = os.environ.get('ESP_DEVICE', '/dev/ttyUSB0')
+        baud = os.environ.get('ESP_BAUD_RATE', '921600')
+        flash_size = os.environ.get('ESP_FLASH_SIZE', 'detect')
+        flash_freq = os.environ.get('ESP_FLASH_FREQ', '40m')
+        flash_mode = os.environ.get('ESP_FLASH_MODE', 'dio')
+        espdif = os.environ.get('ESP_TOOL', 'espidf')
+
+        if espdif == 'espdif':
+            idf_path = get_env_or_bail('ESP_IDF_PATH')
+            espdif = path.join(idf_path, 'components', 'esptool_py', 'esptool',
+                               'esptool.py')
+
+        return Esp32BinaryFlasher(elf, device, baud=baud,
+                                  flash_size=flash_size, flash_freq=flash_freq,
+                                  flash_mode=flash_mode, espdif=espdif,
+                                  debug=debug)
+
+    def flash(self, **kwargs):
+        bin_name = path.splitext(self.elf)[0] + path.extsep + 'bin'
+        cmd_convert = [self.espdif, '--chip', 'esp32', 'elf2image', self.elf]
+        cmd_flash = [self.espdif, '--chip', 'esp32', '--port', self.device,
+                     '--baud', self.baud, '--before', 'default_reset',
+                     '--after', 'hard_reset', 'write_flash', '-u',
+                     '--flash_mode', self.flash_mode,
+                     '--flash_freq', self.flash_freq,
+                     '--flash_size', self.flash_size,
+                     '0x1000', bin_name]
+
+        print("Converting ELF to BIN")
+        check_call(cmd_convert, self.debug)
+
+        print("Flashing ESP32 on {} ({}bps)".format(self.device, self.baud))
+        check_call(cmd_flash, self.debug)
+
 class PyOcdBinaryFlasher(ZephyrBinaryFlasher):
     '''Flasher front-end for pyocd-flashtool.'''
 


### PR DESCRIPTION
Reimplement the flash scripts in pure Python, and use this in the flash target. This is a step towards removing the dependency on a shell when flashing and debugging, which will help on Windows post-CMake.

To fall back on the shell scripts, set USE_ZEPHYR_FLASH_DEBUG_SHELL to any nonempty value for now.

The Python script initially behaves as much as possible like the shell scripts. It thus uses the current environment variables, and contains Linux-specific behavior for some flash backends (those used in em_starterkit, arduino_due, and boards using nrfjprog).

This series enables the following future work:

- reimplement 'debug' and 'debugserver' in Python, to allow deleting the shell scripts
- make the script DT-aware (critical in some situations, e.g. when CONFIG_FLASH_LOAD_OFFSET is used)
- call the script with command line arguments rather than using environment variables