### PR TITLE
Bluetooth: controller: Fix missing reset of FC feature

### DIFF
--- a/subsys/bluetooth/controller/ll_sw/ctrl.c
+++ b/subsys/bluetooth/controller/ll_sw/ctrl.c
@@ -487,8 +487,13 @@ void ll_reset(void)
 	_radio.packet_release_first = 0;
 	_radio.packet_release_last = 0;
 
+	/* reset FC feature */
+	/* TODO: remove this feature related all code in the future */
+	_radio.fc_ack = _radio.fc_req;
+
 	/* reset whitelist and resolving list */
 	ll_filter_reset(false);
+
 	/* memory allocations */
 	common_init();
 }


### PR DESCRIPTION
Fixed a missing reset of FC feature on HCI reset. This
feature provided a simple connection handle based event
exclusions, but this is no longer needed with the
support for controller to host flow control. This feature
should be removed in the future.

Signed-off-by: Vinayak Kariappa Chettimada <vich@nordicsemi.no>