### PR TITLE
Bluetooth: Fix freeing up conn->tx_notify upon disconnect

### DIFF
--- a/subsys/bluetooth/host/conn.c
+++ b/subsys/bluetooth/host/conn.c
@@ -1280,6 +1280,8 @@ static void conn_cleanup(struct bt_conn *conn)
 
 	__ASSERT(sys_slist_is_empty(&conn->tx_pending), "Pending TX packets");
 
+	bt_conn_notify_tx(conn);
+
 	bt_conn_reset_rx_state(conn);
 
 	/* Release the reference we took for the very first


### PR DESCRIPTION
It's possible that tx_notify still contains items when a Disconnect
Complete happens. Since the normal path for processing tx_notify is
not taken when the connection is not in CONNECTED state, we must make
sure to process the list latest in conn_cleanup() that's called as one
last thing before the connection object is freed up.

Signed-off-by: Johan Hedberg <johan.hedberg@intel.com>