### PR TITLE
 Bluetooth: btp: Add GATT Get Attribute command and implementation

### DIFF
--- a/tests/bluetooth/tester/btp_spec.txt
+++ b/tests/bluetooth/tester/btp_spec.txt
@@ -1111,6 +1111,32 @@ Commands and responses:
 
 		In case of an error, the error response will be returned.
 
+	Opcode 0x1c - Get Attributes
+
+		Controller Index:	<controller id>
+		Command parameters:	Start Handle (2 octets)
+					End Handle (2 octets)
+					Type_Length (1 octet)
+					Type (2 or 16 octets)
+		Response parameters:	Attributes_Count (1 octet)
+					[array] Attribute (variable)
+
+		Object Attribute is defined as:
+					Handle (2 octets)
+					Permission (1 octet)
+					Type_Length (1 octet)
+					Type (2 or 16 octets)
+
+		Valid Type_Length parameter values:
+					0x02 = UUID16
+					0x10 = UUID128
+
+		This procedure is used to query GATT Server for attributes based
+		on given search pattern. Attributes can be searched using
+		Attribute Handle range and Attribute Type.
+
+		In case of an error, the error response will be returned.
+
 Events:
 	Opcode 0x80 - Notification/Indication Received
 

--- a/tests/bluetooth/tester/btp_spec.txt
+++ b/tests/bluetooth/tester/btp_spec.txt
@@ -1137,6 +1137,21 @@ Commands and responses:
 
 		In case of an error, the error response will be returned.
 
+	Opcode 0x1d - Get Attribute Value
+
+		Controller Index:	<controller id>
+		Command parameters:	Handle (2 octets)
+		Response parameters:	ATT_Response (1 octet)
+					Value_Length (2 octet)
+					Value (variable)
+
+		This procedure is used to query GATT Server for attribute value.
+		In case of long attribute value, multiple responses will be
+		sent. BTP_STATUS_SUCCESS response indicates the procedure is
+		finished.
+
+		In case of an error, the error response will be returned.
+
 Events:
 	Opcode 0x80 - Notification/Indication Received
 

--- a/tests/bluetooth/tester/src/bttester.h
+++ b/tests/bluetooth/tester/src/bttester.h
@@ -535,6 +535,16 @@ struct gatt_attr {
 	u8_t type[0];
 } __packed;
 
+#define GATT_GET_ATTRIBUTE_VALUE	0x1d
+struct gatt_get_attribute_value_cmd {
+	u16_t handle;
+} __packed;
+struct gatt_get_attribute_value_rp {
+	u8_t att_response;
+	u16_t value_length;
+	u8_t value[0];
+} __packed;
+
 /* GATT events */
 #define GATT_EV_NOTIFICATION		0x80
 struct gatt_notification_ev {

--- a/tests/bluetooth/tester/src/bttester.h
+++ b/tests/bluetooth/tester/src/bttester.h
@@ -9,6 +9,7 @@
 #include <misc/util.h>
 
 #define BTP_MTU 1024
+#define BTP_DATA_MAX_SIZE (BTP_MTU - sizeof(struct btp_hdr))
 
 #define BTP_INDEX_NONE		0xff
 
@@ -514,6 +515,24 @@ struct gatt_cfg_notify_cmd {
 	u8_t address[6];
 	u8_t enable;
 	u16_t ccc_handle;
+} __packed;
+
+#define GATT_GET_ATTRIBUTES		0x1c
+struct gatt_get_attributes_cmd {
+	u16_t start_handle;
+	u16_t end_handle;
+	u8_t type_length;
+	u8_t type[0];
+} __packed;
+struct gatt_get_attributes_rp {
+	u8_t attrs_count;
+	u8_t attrs[0];
+} __packed;
+struct gatt_attr {
+	u16_t handle;
+	u8_t permission;
+	u8_t type_length;
+	u8_t type[0];
 } __packed;
 
 /* GATT events */


### PR DESCRIPTION
This will be used for verification in GATT test cases.
Get Attributes procedure will be used to query local GATT Server for attribute based on given search pattern. Attributes can be searched using Attribute Handle range and Attribute Type.
Get Attribute Value command is used to read GATT Attribute Value (in format defined in Core GATT specification).