### PR TITLE
Bluetooth: controller: Fix connection update supervision timeout

### DIFF
--- a/subsys/bluetooth/controller/ll_sw/ctrl.c
+++ b/subsys/bluetooth/controller/ll_sw/ctrl.c
@@ -6563,7 +6563,7 @@ static inline u32_t event_conn_upd_prep(struct connection *conn,
 			 * ticker_start function for first interval; add a
 			 * tick so as to use the ceiled value.
 			 */
-			ticks_win_offset += TICKER_TICKS_TO_US(1);
+			ticks_win_offset += 1;
 		}
 		conn->conn_interval = conn->llcp.conn_upd.interval;
 		conn->latency = conn->llcp.conn_upd.latency;


### PR DESCRIPTION
In the commit dd52b8ea02da ("Bluetooth: controller: Fix
first connection interval timing"), instead of using just a
tick unit as workaround, microseconds corresponding to a
tick unit was used while calculating the window offset to be
used at the connection update instant. This introduced an
error in scheduling the first event with new connection
parameters, causing supervision timeout of connection update
procedure.

Signed-off-by: Vinayak Kariappa Chettimada <vich@nordicsemi.no>