### PR TITLE
net: shell: mem: Use better config define and terminology

### DIFF
--- a/subsys/net/ip/net_shell.c
+++ b/subsys/net/ip/net_shell.c
@@ -1542,8 +1542,8 @@ int net_shell_cmd_mem(int argc, char *argv[])
 
 	printk("Network buffer pools:\n");
 
-#if defined(CONFIG_NET_DEBUG_NET_PKT)
-	printk("Address\t\tSize\tCount\tAvail\tName\n");
+#if defined(CONFIG_NET_BUF_POOL_USAGE)
+	printk("Address\t\tSize\tTotal\tAvail\tName\n");
 
 	printk("%p\t%zu\t%d\t%u\tRX\n",
 	       rx, rx->num_blocks * rx->block_size,
@@ -1561,13 +1561,14 @@ int net_shell_cmd_mem(int argc, char *argv[])
 	       tx_data, tx_data->pool_size, tx_data->buf_count,
 	       tx_data->avail_count, tx_data->name);
 #else
-	printk("Address\t\tCount\tName\n");
+	printk("(CONFIG_NET_BUF_POOL_USAGE to see free #s)\n");
+	printk("Address\t\tTotal\tName\n");
 
 	printk("%p\t%d\tRX\n", rx, rx->num_blocks);
 	printk("%p\t%d\tTX\n", tx, tx->num_blocks);
 	printk("%p\t%d\tRX DATA\n", rx_data, rx_data->buf_count);
 	printk("%p\t%d\tTX DATA\n", tx_data, tx_data->buf_count);
-#endif /* CONFIG_NET_DEBUG_NET_PKT */
+#endif /* CONFIG_NET_BUF_POOL_USAGE */
 
 	if (IS_ENABLED(CONFIG_NET_CONTEXT_NET_PKT_POOL)) {
 		struct ctx_info info;


### PR DESCRIPTION
It's possible to get number of free pkts/buffers with just
CONFIG_NET_BUF_POOL_USAGE, whereas CONFIG_NET_DEBUG_NET_PKT
depends on CONFIG_NET_LOG and adds quite a bunch of other
overhead. Also, give a hint that this option should be enabled
to get free buffer numbers.

Additionally, use unambiguous "Total" wording to represend the
maximum capacity of data structures, instead of previous "Count".
"Count" (or at least counter) is intuitively something which can
change, so not seeing any other numbers, it's very easy to assume
that it's actually number of free buffers (because that's the
information a user may be interested in in many cases).

Signed-off-by: Paul Sokolovsky <paul.sokolovsky@linaro.org>