### PR TITLE
samples: net: sockets: Print incoming connection number

### DIFF
--- a/samples/net/sockets/dumb_http_server/src/socket_dumb_http.c
+++ b/samples/net/sockets/dumb_http_server/src/socket_dumb_http.c
@@ -35,6 +35,7 @@ int main(void)
 {
 	int serv;
 	struct sockaddr_in bind_addr;
+	static int counter;
 
 	serv = socket(AF_INET, SOCK_STREAM, IPPROTO_TCP);
 
@@ -57,7 +58,7 @@ int main(void)
 				    &client_addr_len);
 		inet_ntop(client_addr.sin_family, &client_addr.sin_addr,
 			  addr_str, sizeof(addr_str));
-		printf("Connection from %s\n", addr_str);
+		printf("Connection #%d from %s\n", counter++, addr_str);
 
 		/* Discard HTTP request (or otherwise client will get
 		 * connection reset error).

--- a/samples/net/sockets/echo/src/socket_echo.c
+++ b/samples/net/sockets/echo/src/socket_echo.c
@@ -25,6 +25,7 @@ int main(void)
 {
 	int serv;
 	struct sockaddr_in bind_addr;
+	static int counter;
 
 	serv = socket(AF_INET, SOCK_STREAM, IPPROTO_TCP);
 
@@ -43,7 +44,7 @@ int main(void)
 				    &client_addr_len);
 		inet_ntop(client_addr.sin_family, &client_addr.sin_addr,
 			  addr_str, sizeof(addr_str));
-		printf("Connection from %s\n", addr_str);
+		printf("Connection #%d from %s\n", counter++, addr_str);
 
 		while (1) {
 			char buf[128];

--- a/samples/net/sockets/echo_async/src/socket_echo.c
+++ b/samples/net/sockets/echo_async/src/socket_echo.c
@@ -77,6 +77,7 @@ void pollfds_del(int fd)
 int main(void)
 {
 	int res;
+	static int counter;
 	int serv4, serv6;
 	struct sockaddr_in bind_addr4 = {
 		.sin_family = AF_INET,
@@ -144,7 +145,8 @@ int main(void)
 
 				inet_ntop(client_addr.ss_family, addr,
 					  addr_str, sizeof(addr_str));
-				printf("Connection from %s fd=%d\n", addr_str, client);
+				printf("Connection #%d from %s fd=%d\n", counter++,
+				       addr_str, client);
 				if (pollfds_add(client) < 0) {
 					static char msg[] = "Too many connections\n";
 					send(client, msg, sizeof(msg) - 1, 0);


### PR DESCRIPTION
This helps to debug issues with mass connection handling (e.g. when
issues happen at ~500th connection).

Signed-off-by: Paul Sokolovsky <paul.sokolovsky@linaro.org>