### PR TITLE
gen_syscall_header: use compiler barrier

### DIFF
--- a/scripts/gen_syscall_header.py
+++ b/scripts/gen_syscall_header.py
@@ -95,6 +95,11 @@ def gen_defines_inner(ret, argc, kernel_only=False, user_only=False):
         sys.stdout.write("\t\t} else {")
         newline()
 
+        # Prevent memory access issues if the implementation function gets
+        # inlined
+        sys.stdout.write("\t\t\tcompiler_barrier();");
+        newline()
+
         sys.stdout.write("\t\t\t")
         gen_call_impl(ret, argc)
         sys.stdout.write("\t\t}")


### PR DESCRIPTION
We need to enforce that if the implementation function is inlined,
and we are using a syscall declaration macro where a runtime check
is performed, that all memory access in the inlined implementation
function is done after the user context check is performed.

Fixes bad memory access issues observed due to the compiler fetching
member data from a kernel object when the calling context was in
user mode.

Signed-off-by: Andrew Boie <andrew.p.boie@intel.com>