### PR TITLE
userspace: object policy updates

### DIFF
--- a/include/kernel.h
+++ b/include/kernel.h
@@ -180,6 +180,7 @@ struct _k_object {
 } __packed;
 
 #define K_OBJ_FLAG_INITIALIZED	BIT(0)
+#define K_OBJ_FLAG_PUBLIC	BIT(1)
 
 /**
  * Lookup a kernel object and init its metadata if it exists
@@ -252,6 +253,9 @@ __syscall void k_object_access_revoke(void *object, struct k_thread *thread);
  * Use of this API should be avoided on systems that are running untrusted code
  * as it is possible for such code to derive the addresses of kernel objects
  * and perform unwanted operations on them.
+ *
+ * It is not possible to revoke permissions on public objects; once public,
+ * any thread may use it.
  *
  * @param object Address of kernel object
  */

--- a/include/kernel.h
+++ b/include/kernel.h
@@ -212,7 +212,7 @@ static inline void _impl_k_object_access_revoke(void *object,
 	ARG_UNUSED(thread);
 }
 
-static inline void _impl_k_object_access_all_grant(void *object)
+static inline void k_object_access_all_grant(void *object)
 {
 	ARG_UNUSED(object);
 }
@@ -259,7 +259,7 @@ __syscall void k_object_access_revoke(void *object, struct k_thread *thread);
  *
  * @param object Address of kernel object
  */
-__syscall void k_object_access_all_grant(void *object);
+void k_object_access_all_grant(void *object);
 
 /* timeouts */
 

--- a/kernel/include/kernel_structs.h
+++ b/kernel/include/kernel_structs.h
@@ -118,6 +118,11 @@ struct _kernel {
 	struct k_thread *threads; /* singly linked list of ALL fiber+tasks */
 #endif
 
+#if defined(CONFIG_USERSPACE)
+	/* 0 bits for ids currently in use, 1 for free ids */
+	u8_t free_thread_ids[CONFIG_MAX_THREAD_BYTES];
+#endif
+
 	/* arch-specific part of _kernel */
 	struct _kernel_arch arch;
 };

--- a/kernel/include/ksched.h
+++ b/kernel/include/ksched.h
@@ -431,20 +431,6 @@ static inline void _ready_thread(struct k_thread *thread)
 #endif
 }
 
-/**
- * @brief Mark thread as dead
- *
- * This routine must be called with interrupts locked.
- */
-static inline void _mark_thread_as_dead(struct k_thread *thread)
-{
-	thread->base.thread_state |= _THREAD_DEAD;
-
-#ifdef CONFIG_KERNEL_EVENT_LOGGER_THREAD
-	_sys_k_event_logger_thread_exit(thread);
-#endif
-}
-
 /*
  * Set a thread's priority. If the thread is ready, place it in the correct
  * queue.

--- a/kernel/include/syscall_handler.h
+++ b/kernel/include/syscall_handler.h
@@ -98,12 +98,12 @@ extern void _thread_perms_set(struct _k_object *ko, struct k_thread *thread);
  */
 extern void _thread_perms_clear(struct _k_object *ko, struct k_thread *thread);
 
-/**
- * Grant all current and future threads access to a kernel object
+/*
+ * Revoke access to all objects for the provided thread
  *
- * @param ko Kernel object metadata to update
+ * @param thread Thread object to revoke access
  */
-extern void _thread_perms_all_set(struct _k_object *ko);
+extern void _thread_perms_all_clear(struct k_thread *thread);
 
 /**
  * Clear initialization state of a kernel object

--- a/kernel/include/syscall_handler.h
+++ b/kernel/include/syscall_handler.h
@@ -106,6 +106,16 @@ extern void _thread_perms_clear(struct _k_object *ko, struct k_thread *thread);
 extern void _thread_perms_all_set(struct _k_object *ko);
 
 /**
+ * Clear initialization state of a kernel object
+ *
+ * Intended for thread objects upon thread exit, or for other kernel objects
+ * that were released back to an object pool.
+ *
+ * @param object Address of the kernel object
+ */
+void _k_object_uninit(void *obj);
+
+/**
  * @brief Runtime expression check for system call arguments
  *
  * Used in handler functions to perform various runtime checks on arguments,

--- a/kernel/init.c
+++ b/kernel/init.c
@@ -274,6 +274,10 @@ static void prepare_multithreading(struct k_thread *dummy_thread)
 
 	/* _kernel.ready_q is all zeroes */
 
+#ifdef CONFIG_USERSPACE
+	/* Mark all potential IDs as available */
+	memset(_kernel.free_thread_ids, 0xFF, CONFIG_MAX_THREAD_BYTES);
+#endif
 
 	/*
 	 * The interrupt library needs to be initialized early since a series

--- a/kernel/thread.c
+++ b/kernel/thread.c
@@ -447,7 +447,18 @@ void _k_thread_single_abort(struct k_thread *thread)
 			_abort_thread_timeout(thread);
 		}
 	}
-	_mark_thread_as_dead(thread);
+
+	thread->base.thread_state |= _THREAD_DEAD;
+#ifdef CONFIG_KERNEL_EVENT_LOGGER_THREAD
+	_sys_k_event_logger_thread_exit(thread);
+#endif
+
+#ifdef CONFIG_USERSPACE
+	/* Clear initailized state so that this thread object may be re-used
+	 * and triggers errors if API calls are made on it from user threads
+	 */
+	_k_object_uninit(thread);
+#endif
 }
 
 #ifdef CONFIG_MULTITHREADING

--- a/kernel/userspace.c
+++ b/kernel/userspace.c
@@ -211,7 +211,7 @@ void _impl_k_object_access_revoke(void *object, struct k_thread *thread)
 	}
 }
 
-void _impl_k_object_access_all_grant(void *object)
+void k_object_access_all_grant(void *object)
 {
 	struct _k_object *ko = _k_object_find(object);
 

--- a/kernel/userspace.c
+++ b/kernel/userspace.c
@@ -260,6 +260,19 @@ void _k_object_init(void *object)
 	ko->flags |= K_OBJ_FLAG_INITIALIZED;
 }
 
+void _k_object_uninit(void *object)
+{
+	struct _k_object *ko;
+
+	/* See comments in _k_object_init() */
+	ko = _k_object_find(object);
+	if (!ko) {
+		return;
+	}
+
+	ko->flags &= ~K_OBJ_FLAG_INITIALIZED;
+}
+
 static u32_t _handler_bad_syscall(u32_t bad_id, u32_t arg2, u32_t arg3,
 				  u32_t arg4, u32_t arg5, u32_t arg6, void *ssf)
 {

--- a/kernel/userspace.c
+++ b/kernel/userspace.c
@@ -14,6 +14,8 @@
 #include <syscall.h>
 #include <syscall_handler.h>
 
+#define MAX_THREAD_BITS		(CONFIG_MAX_THREAD_BYTES * 8)
+
 const char *otype_to_str(enum k_objects otype)
 {
 	/* -fdata-sections doesn't work right except in very very recent
@@ -116,15 +118,15 @@ void _thread_perms_inherit(struct k_thread *parent, struct k_thread *child)
 		parent
 	};
 
-	if ((ctx.parent_id < 8 * CONFIG_MAX_THREAD_BYTES) &&
-	    (ctx.child_id < 8 * CONFIG_MAX_THREAD_BYTES)) {
+	if ((ctx.parent_id < MAX_THREAD_BITS) &&
+	    (ctx.child_id < MAX_THREAD_BITS)) {
 		_k_object_wordlist_foreach(wordlist_cb, &ctx);
 	}
 }
 
 void _thread_perms_set(struct _k_object *ko, struct k_thread *thread)
 {
-	if (thread->base.perm_index < 8 * CONFIG_MAX_THREAD_BYTES) {
+	if (thread->base.perm_index < MAX_THREAD_BITS) {
 		sys_bitfield_set_bit((mem_addr_t)&ko->perms,
 				     thread->base.perm_index);
 	}
@@ -132,7 +134,7 @@ void _thread_perms_set(struct _k_object *ko, struct k_thread *thread)
 
 void _thread_perms_clear(struct _k_object *ko, struct k_thread *thread)
 {
-	if (thread->base.perm_index < 8 * CONFIG_MAX_THREAD_BYTES) {
+	if (thread->base.perm_index < MAX_THREAD_BITS) {
 		sys_bitfield_clear_bit((mem_addr_t)&ko->perms,
 				       thread->base.perm_index);
 	}
@@ -147,7 +149,7 @@ static void clear_perms_cb(struct _k_object *ko, void *ctx_ptr)
 
 void _thread_perms_all_clear(struct k_thread *thread)
 {
-	if (thread->base.perm_index < 8 * CONFIG_MAX_THREAD_BYTES) {
+	if (thread->base.perm_index < MAX_THREAD_BITS) {
 		_k_object_wordlist_foreach(clear_perms_cb,
 					   (void *)thread->base.perm_index);
 	}
@@ -159,7 +161,7 @@ static int thread_perms_test(struct _k_object *ko)
 		return 1;
 	}
 
-	if (_current->base.perm_index < 8 * CONFIG_MAX_THREAD_BYTES) {
+	if (_current->base.perm_index < MAX_THREAD_BITS) {
 		return sys_bitfield_test_bit((mem_addr_t)&ko->perms,
 					     _current->base.perm_index);
 	}

--- a/kernel/userspace.c
+++ b/kernel/userspace.c
@@ -250,12 +250,6 @@ void _k_object_init(void *object)
 		return;
 	}
 
-	/* Initializing an object implicitly grants access to the calling
-	 * thread and nobody else
-	 */
-	memset(ko->perms, 0, CONFIG_MAX_THREAD_BYTES);
-	_thread_perms_set(ko, _current);
-
 	/* Allows non-initialization system calls to be made on this object */
 	ko->flags |= K_OBJ_FLAG_INITIALIZED;
 }

--- a/kernel/userspace_handler.c
+++ b/kernel/userspace_handler.c
@@ -58,14 +58,3 @@ _SYSCALL_HANDLER(k_object_access_revoke, object, thread)
 
 	return 0;
 }
-
-_SYSCALL_HANDLER(k_object_access_all_grant, object)
-{
-	struct _k_object *ko;
-
-	ko = validate_any_object((void *)object);
-	_SYSCALL_VERIFY_MSG(ko, "object %p access denied", (void *)object);
-	ko->flags |= K_OBJ_FLAG_PUBLIC;
-
-	return 0;
-}

--- a/kernel/userspace_handler.c
+++ b/kernel/userspace_handler.c
@@ -65,7 +65,7 @@ _SYSCALL_HANDLER(k_object_access_all_grant, object)
 
 	ko = validate_any_object((void *)object);
 	_SYSCALL_VERIFY_MSG(ko, "object %p access denied", (void *)object);
-	_thread_perms_all_set(ko);
+	ko->flags |= K_OBJ_FLAG_PUBLIC;
 
 	return 0;
 }


### PR DESCRIPTION
- Private API added to clear initialization state for kernel objects
- Upon thread abort, thread objects are marked as uninitialized
- Initializing objects no longer resets permissions on that object
- Thread IDs may now be re-used by the kernel.
- k_object_access_all_grant() no longer a system call

Please see individual commit messages for more details and rationale for these changes.