### PR TITLE
Bluetooth: controller: Coded PHY timing fixes

### DIFF
--- a/subsys/bluetooth/controller/hal/nrf5/radio.c
+++ b/subsys/bluetooth/controller/hal/nrf5/radio.c
@@ -516,7 +516,7 @@ static void sw_switch(u8_t dir, u8_t phy_curr, u8_t flags_curr, u8_t phy_next,
 			       &(NRF_TIMER1->EVENTS_COMPARE[sw_tifs_toggle]);
 	if (dir) {
 		delay = radio_tx_ready_delay_get(phy_next, flags_next) +
-			radio_rx_chain_delay_get(phy_curr, flags_curr);
+			radio_rx_chain_delay_get(phy_curr, 1);
 
 		NRF_PPI->CH[ppi].TEP = (u32_t)&(NRF_RADIO->TASKS_TXEN);
 	} else {

--- a/subsys/bluetooth/controller/ll_sw/ctrl.c
+++ b/subsys/bluetooth/controller/ll_sw/ctrl.c
@@ -3450,8 +3450,7 @@ static inline void isr_rx_conn(u8_t crc_ok, u8_t trx_done,
 #if defined(CONFIG_BT_CTLR_PHY)
 	radio_gpio_pa_lna_enable(radio_tmr_end_get() + RADIO_TIFS -
 				 radio_rx_chain_delay_get(
-					 _radio.conn_curr->phy_rx,
-					 _radio.conn_curr->phy_flags) -
+					 _radio.conn_curr->phy_rx, 1) -
 				 CONFIG_BT_CTLR_GPIO_PA_OFFSET);
 #else /* !CONFIG_BT_CTLR_PHY */
 	radio_gpio_pa_lna_enable(radio_tmr_end_get() + RADIO_TIFS -

--- a/subsys/bluetooth/controller/ll_sw/ctrl.c
+++ b/subsys/bluetooth/controller/ll_sw/ctrl.c
@@ -709,8 +709,7 @@ static inline void isr_radio_state_tx(void)
 		LL_ASSERT(!radio_is_ready());
 
 #if defined(CONFIG_BT_CTLR_PHY)
-		hcto += radio_rx_chain_delay_get(_radio.conn_curr->phy_rx,
-						 _radio.conn_curr->phy_flags);
+		hcto += radio_rx_chain_delay_get(_radio.conn_curr->phy_rx, 1);
 		hcto += addr_us_get(_radio.conn_curr->phy_rx);
 		hcto -= radio_tx_chain_delay_get(_radio.conn_curr->phy_tx,
 						 _radio.conn_curr->phy_flags);
@@ -7999,9 +7998,11 @@ static void event_slave(u32_t ticks_at_expire, u32_t remainder, u16_t lazy,
 #if defined(CONFIG_BT_CTLR_PHY)
 	hcto += radio_rx_ready_delay_get(conn->phy_rx);
 	hcto += addr_us_get(conn->phy_rx);
+	hcto += radio_rx_chain_delay_get(conn->phy_rx, 1);
 #else /* !CONFIG_BT_CTLR_PHY */
 	hcto += radio_rx_ready_delay_get(0);
 	hcto += addr_us_get(0);
+	hcto += radio_rx_chain_delay_get(0, 0);
 #endif /* !CONFIG_BT_CTLR_PHY */
 
 	radio_tmr_hcto_configure(hcto);


### PR DESCRIPTION
While performing manual ad-hoc testing of Coded PHY connections, connection disconnected with supervision timeouts. Two issues was observed, header complete timeout implementation for slave window widening did not include rx chain delay (in all PHYs), and header complete timeout inside tIFS should always use S8 rx chain delay (in Coded PHY).