### PR TITLE
Bluetooth: controller: Add encrypted Coded PHY support

### DIFF
--- a/subsys/bluetooth/controller/hal/radio.h
+++ b/subsys/bluetooth/controller/hal/radio.h
@@ -88,7 +88,7 @@ void radio_gpio_lna_off(void);
 void radio_gpio_pa_lna_enable(u32_t trx_us);
 void radio_gpio_pa_lna_disable(void);
 
-void *radio_ccm_rx_pkt_set(struct ccm *ccm, void *pkt);
+void *radio_ccm_rx_pkt_set(struct ccm *ccm, u8_t phy, void *pkt);
 void *radio_ccm_tx_pkt_set(struct ccm *ccm, void *pkt);
 u32_t radio_ccm_is_done(void);
 u32_t radio_ccm_mic_is_valid(void);

--- a/subsys/bluetooth/controller/ll_sw/ctrl.c
+++ b/subsys/bluetooth/controller/ll_sw/ctrl.c
@@ -8286,7 +8286,7 @@ static void rx_packet_set(struct connection *conn, struct pdu_data *pdu_data_rx)
 	if (conn->enc_rx) {
 		radio_pkt_configure(8, (max_rx_octets + 4), (phy << 1) | 0x01);
 
-		radio_pkt_rx_set(radio_ccm_rx_pkt_set(&conn->ccm_rx,
+		radio_pkt_rx_set(radio_ccm_rx_pkt_set(&conn->ccm_rx, phy,
 						      pdu_data_rx));
 	} else {
 		radio_pkt_configure(8, max_rx_octets, (phy << 1) | 0x01);


### PR DESCRIPTION
Add support for encrypted Coded PHY connections on nRF52840
SoCs.

Signed-off-by: Vinayak Kariappa Chettimada <vich@nordicsemi.no>