### PR TITLE
samples: environmental_sensing: fix the data type for read_u32()

### DIFF
--- a/samples/boards/arduino_101/environmental_sensing/ap/src/main.c
+++ b/samples/boards/arduino_101/environmental_sensing/ap/src/main.c
@@ -42,7 +42,7 @@ static ssize_t read_u32(struct bt_conn *conn, const struct bt_gatt_attr *attr,
 			void *buf, u16_t len, u16_t offset)
 {
 	const u32_t *u32 = attr->user_data;
-	u16_t value = sys_cpu_to_le32(*u32);
+	u32_t value = sys_cpu_to_le32(*u32);
 
 	return bt_gatt_attr_read(conn, attr, buf, len, offset, &value,
 				 sizeof(value));


### PR DESCRIPTION
Fix the data type for read_u32()

The data format for pressure is u32.

Reference:
https://www.bluetooth.com/specifications/gatt/viewer?attributeXmlFile=org.bluetooth.characteristic.pressure.xml