### PR TITLE
Fix malformed packet retransmission of coap_client/coap_server

### DIFF
--- a/samples/net/coap_server/src/coap-server.c
+++ b/samples/net/coap_server/src/coap-server.c
@@ -65,6 +65,24 @@ static struct coap_resource *resource_to_notify;
 
 struct k_delayed_work retransmit_work;
 
+static void strip_headers(struct net_pkt *pkt)
+{
+	/* Get rid of IP + UDP/TCP header if it is there. The IP header
+	 * will be put back just before sending the packet.
+	 */
+	if (net_pkt_appdatalen(pkt) > 0) {
+		int header_len;
+
+		header_len = net_buf_frags_len(pkt->frags) -
+			     net_pkt_appdatalen(pkt);
+		if (header_len > 0) {
+			net_buf_pull(pkt->frags, header_len);
+		}
+	} else {
+		net_pkt_set_appdatalen(pkt, net_buf_frags_len(pkt->frags));
+	}
+}
+
 static void get_from_ip_addr(struct coap_packet *cpkt,
 			     struct sockaddr_in6 *from)
 {
@@ -613,6 +631,9 @@ done:
 		k_delayed_work_submit(&retransmit_work, pending->timeout);
 	}
 
+	/* setup appdatalen */
+	strip_headers(pkt);
+
 	return net_context_sendto(pkt, (const struct sockaddr *)&from,
 				  sizeof(struct sockaddr_in6),
 				  NULL, 0, NULL, NULL);
@@ -974,6 +995,9 @@ static int send_notification_packet(const struct sockaddr *addr, u16_t age,
 		k_delayed_work_submit(&retransmit_work, pending->timeout);
 	}
 
+	/* setup appdatalen */
+	strip_headers(pkt);
+
 	return net_context_sendto(pkt, addr, addrlen, NULL, 0, NULL, NULL);
 }
 
@@ -1285,6 +1309,9 @@ static void retransmit_request(struct k_work *work)
 	if (!pending) {
 		return;
 	}
+
+	/* drop IP + UDP headers */
+	strip_headers(pending->pkt);
 
 	r = net_context_sendto(pending->pkt, &pending->addr,
 			       sizeof(struct sockaddr_in6),


### PR DESCRIPTION
1. A malformed packet is sent during the retransmission for both coap_client/coap_server. This is because the "appdatalen" is not set and ID + UDP headers are not dropped when retransmit. Fix the issue by doing it correctly.
1. Call net_pkt_ref() and net_pkt_unref() explicitly at retransmit_request() to avoid packet being freed right after net_context_sendto() is called.