### PR TITLE
sys: slist, dlist: Document APIs as not threadsafe

### DIFF
--- a/include/misc/dlist.h
+++ b/include/misc/dlist.h
@@ -6,9 +6,11 @@
 
 /**
  * @file
- * @brief Doubly-linked list inline implementation
+ * @brief Doubly-linked list implementation
  *
- * Doubly-linked list implementation.
+ * Doubly-linked list implementation using inline macros/functions.
+ * This API is not threadsafe, and thus if a list is used across threads,
+ * calls to functions must be protected with synchronization primitives.
  *
  * The lists are expected to be initialized such that both the head and tail
  * pointers point to the list itself.  Initializing the lists in such a fashion
@@ -229,6 +231,8 @@ static inline int sys_dlist_is_empty(sys_dlist_t *list)
 /**
  * @brief check if more than one node present
  *
+ * This function and most other sys_dlist_*() functions are not threadsafe.
+ *
  * @param list the doubly-linked list to operate on
  *
  * @return 1 if multiple nodes, 0 otherwise
@@ -316,6 +320,8 @@ static inline sys_dnode_t *sys_dlist_peek_tail(sys_dlist_t *list)
 /**
  * @brief add node to tail of list
  *
+ * This function and most other sys_dlist_*() functions are not threadsafe.
+ *
  * @param list the doubly-linked list to operate on
  * @param node the element to append
  *
@@ -333,6 +339,8 @@ static inline void sys_dlist_append(sys_dlist_t *list, sys_dnode_t *node)
 
 /**
  * @brief add node to head of list
+ *
+ * This function and most other sys_dlist_*() functions are not threadsafe.
  *
  * @param list the doubly-linked list to operate on
  * @param node the element to append
@@ -353,6 +361,7 @@ static inline void sys_dlist_prepend(sys_dlist_t *list, sys_dnode_t *node)
  * @brief insert node after a node
  *
  * Insert a node after a specified node in a list.
+ * This function and most other sys_dlist_*() functions are not threadsafe.
  *
  * @param list the doubly-linked list to operate on
  * @param insert_point the insert point in the list: if NULL, insert at head
@@ -378,6 +387,7 @@ static inline void sys_dlist_insert_after(sys_dlist_t *list,
  * @brief insert node before a node
  *
  * Insert a node before a specified node in a list.
+ * This function and most other sys_dlist_*() functions are not threadsafe.
  *
  * @param list the doubly-linked list to operate on
  * @param insert_point the insert point in the list: if NULL, insert at tail
@@ -405,6 +415,7 @@ static inline void sys_dlist_insert_before(sys_dlist_t *list,
  * Insert a node in a location depending on a external condition. The cond()
  * function checks if the node is to be inserted _before_ the current node
  * against which it is checked.
+ * This function and most other sys_dlist_*() functions are not threadsafe.
  *
  * @param list the doubly-linked list to operate on
  * @param node the element to insert
@@ -434,6 +445,7 @@ static inline void sys_dlist_insert_at(sys_dlist_t *list, sys_dnode_t *node,
  * @brief remove a specific node from a list
  *
  * The list is implicit from the node. The node must be part of a list.
+ * This function and most other sys_dlist_*() functions are not threadsafe.
  *
  * @param node the node to remove
  *
@@ -448,6 +460,8 @@ static inline void sys_dlist_remove(sys_dnode_t *node)
 
 /**
  * @brief get the first node in a list
+ *
+ * This function and most other sys_dlist_*() functions are not threadsafe.
  *
  * @param list the doubly-linked list to operate on
  *

--- a/include/misc/slist.h
+++ b/include/misc/slist.h
@@ -7,7 +7,11 @@
 /**
  * @file
  *
- * @brief Header where single linked list utility code is found
+ * @brief Single-linked list implementation
+ *
+ * Single-linked list implementation using inline macros/functions.
+ * This API is not threadsafe, and thus if a list is used across threads,
+ * calls to functions must be protected with synchronization primitives.
  */
 
 #ifndef __SLIST_H__
@@ -252,6 +256,8 @@ static inline sys_snode_t *sys_slist_peek_next(sys_snode_t *node)
 /**
  * @brief Prepend a node to the given list
  *
+ * This function and most other sys_slist_*() functions are not threadsafe.
+ *
  * @param list A pointer on the list to affect
  * @param node A pointer on the node to prepend
  */
@@ -268,6 +274,8 @@ static inline void sys_slist_prepend(sys_slist_t *list,
 
 /**
  * @brief Append a node to the given list
+ *
+ * This function and most other sys_slist_*() functions are not threadsafe.
  *
  * @param list A pointer on the list to affect
  * @param node A pointer on the node to append
@@ -291,6 +299,7 @@ static inline void sys_slist_append(sys_slist_t *list,
  *
  * Append a singly-linked, NULL-terminated list consisting of nodes containing
  * the pointer to the next node as the first element of a node, to @a list.
+ * This function and most other sys_slist_*() functions are not threadsafe.
  *
  * @param list A pointer on the list to affect
  * @param head A pointer to the first element of the list to append
@@ -327,6 +336,8 @@ static inline void sys_slist_merge_slist(sys_slist_t *list,
 /**
  * @brief Insert a node to the given list
  *
+ * This function and most other sys_slist_*() functions are not threadsafe.
+ *
  * @param list A pointer on the list to affect
  * @param prev A pointer on the previous node
  * @param node A pointer on the node to insert
@@ -349,6 +360,7 @@ static inline void sys_slist_insert(sys_slist_t *list,
  * @brief Fetch and remove the first node of the given list
  *
  * List must be known to be non-empty.
+ * This function and most other sys_slist_*() functions are not threadsafe.
  *
  * @param list A pointer on the list to affect
  *
@@ -369,6 +381,8 @@ static inline sys_snode_t *sys_slist_get_not_empty(sys_slist_t *list)
 /**
  * @brief Fetch and remove the first node of the given list
  *
+ * This function and most other sys_slist_*() functions are not threadsafe.
+ *
  * @param list A pointer on the list to affect
  *
  * @return A pointer to the first node of the list (or NULL if empty)
@@ -380,6 +394,8 @@ static inline sys_snode_t *sys_slist_get(sys_slist_t *list)
 
 /**
  * @brief Remove a node
+ *
+ * This function and most other sys_slist_*() functions are not threadsafe.
  *
  * @param list A pointer on the list to affect
  * @param prev_node A pointer on the previous node
@@ -411,6 +427,8 @@ static inline void sys_slist_remove(sys_slist_t *list,
 
 /**
  * @brief Find and remove a node from a list
+ *
+ * This function and most other sys_slist_*() functions are not threadsafe.
  *
  * @param list A pointer on the list to affect
  * @param node A pointer on the node to remove from the list


### PR DESCRIPTION
These headers provide an efficient, inline implementations of single-
and double- linked lists, and thus not threadsafe. They are intended
to be used as internal kernel APIs (and currently for example not
documented at https://www.zephyrproject.org/doc/). However, to avoid
issues when doing kernel programming (e.g. #4350), it makes sense
to explicitly, even verbosely, document these functions as not
threadsafe.

Signed-off-by: Paul Sokolovsky <paul.sokolovsky@linaro.org>