### PR TITLE
mem_domain: inherit from parent thread

### DIFF
--- a/doc/kernel/usermode/memory_domain.rst
+++ b/doc/kernel/usermode/memory_domain.rst
@@ -23,7 +23,8 @@ Memory partitions are defined by a set of underlying MPU regions
 or MMU tables. A thread belongs to a single memory domain at
 any point in time but a memory domain may contain multiple threads.
 Threads in the same memory domain have the same access permissions
-to the memory partitions belong to the memory domain.
+to the memory partitions belonging to the memory domain. New threads
+will inherit any memory domain configuration from the parent thread.
 
 Implementation
 **************

--- a/kernel/thread.c
+++ b/kernel/thread.c
@@ -273,6 +273,12 @@ void _setup_new_thread(struct k_thread *new_thread,
 	/* Any given thread has access to itself */
 	k_object_access_grant(new_thread, new_thread);
 
+	/* New threads inherit any memory domain membership by the parent */
+	if (_current->mem_domain_info.mem_domain) {
+		k_mem_domain_add_thread(_current->mem_domain_info.mem_domain,
+					new_thread);
+	}
+
 	if (options & K_INHERIT_PERMS) {
 		_thread_perms_inherit(_current, new_thread);
 	}


### PR DESCRIPTION
New threads inherit any memory domain membership held by the
parent thread.

Signed-off-by: Andrew Boie <andrew.p.boie@intel.com>