### PR TITLE
x86: fix crash in _x86_mmu_get_flags

### DIFF
--- a/arch/x86/core/x86_mmu.c
+++ b/arch/x86/core/x86_mmu.c
@@ -36,7 +36,11 @@ void _x86_mmu_get_flags(void *addr, u32_t *pde_flags, u32_t *pte_flags)
 {
 
 	*pde_flags = X86_MMU_GET_PDE(addr)->value & ~MMU_PDE_PAGE_TABLE_MASK;
-	*pte_flags = X86_MMU_GET_PTE(addr)->value & ~MMU_PTE_PAGE_MASK;
+	if (*pde_flags & MMU_ENTRY_PRESENT) {
+		*pte_flags = X86_MMU_GET_PTE(addr)->value & ~MMU_PTE_PAGE_MASK;
+	} else {
+		*pte_flags = 0;
+	}
 }
 
 


### PR DESCRIPTION
Looking up the PTE flags was page faulting if the address wasn't
marked as present in the page directory, since there is no page table
for that directory entry.

Signed-off-by: Andrew Boie <andrew.p.boie@intel.com>