### PR TITLE
kernel: fix k_thread_stack_t definition

### DIFF
--- a/arch/arc/core/thread.c
+++ b/arch/arc/core/thread.c
@@ -54,7 +54,7 @@ struct init_stack_frame {
  *
  * @return N/A
  */
-void _new_thread(struct k_thread *thread, k_thread_stack_t stack,
+void _new_thread(struct k_thread *thread, k_thread_stack_t *stack,
 		 size_t stackSize, k_thread_entry_t pEntry,
 		 void *parameter1, void *parameter2, void *parameter3,
 		 int priority, unsigned int options)

--- a/arch/arm/core/thread.c
+++ b/arch/arm/core/thread.c
@@ -49,7 +49,7 @@
  * @return N/A
  */
 
-void _new_thread(struct k_thread *thread, k_thread_stack_t stack,
+void _new_thread(struct k_thread *thread, k_thread_stack_t *stack,
 		 size_t stackSize, k_thread_entry_t pEntry,
 		 void *parameter1, void *parameter2, void *parameter3,
 		 int priority, unsigned int options)

--- a/arch/arm/include/kernel_arch_func.h
+++ b/arch/arm/include/kernel_arch_func.h
@@ -39,7 +39,7 @@ static ALWAYS_INLINE void kernel_arch_init(void)
 
 static ALWAYS_INLINE void
 _arch_switch_to_main_thread(struct k_thread *main_thread,
-			    k_thread_stack_t main_stack,
+			    k_thread_stack_t *main_stack,
 			    size_t main_stack_size, k_thread_entry_t _main)
 {
 	/* get high address of the stack, i.e. its start (stack grows down) */

--- a/arch/nios2/core/thread.c
+++ b/arch/nios2/core/thread.c
@@ -31,7 +31,7 @@ struct init_stack_frame {
 };
 
 
-void _new_thread(struct k_thread *thread, k_thread_stack_t stack,
+void _new_thread(struct k_thread *thread, k_thread_stack_t *stack,
 		 size_t stack_size, k_thread_entry_t thread_func,
 		 void *arg1, void *arg2, void *arg3,
 		 int priority, unsigned int options)

--- a/arch/riscv32/core/thread.c
+++ b/arch/riscv32/core/thread.c
@@ -15,7 +15,7 @@ void _thread_entry_wrapper(k_thread_entry_t thread,
 			   void *arg2,
 			   void *arg3);
 
-void _new_thread(struct k_thread *thread, k_thread_stack_t stack,
+void _new_thread(struct k_thread *thread, k_thread_stack_t *stack,
 		 size_t stack_size, k_thread_entry_t thread_func,
 		 void *arg1, void *arg2, void *arg3,
 		 int priority, unsigned int options)

--- a/arch/x86/core/thread.c
+++ b/arch/x86/core/thread.c
@@ -72,7 +72,7 @@ struct _x86_initial_frame {
  * @param priority thread priority
  * @param options thread options: K_ESSENTIAL, K_FP_REGS, K_SSE_REGS
  */
-void _new_thread(struct k_thread *thread, k_thread_stack_t stack,
+void _new_thread(struct k_thread *thread, k_thread_stack_t *stack,
 		 size_t stack_size, k_thread_entry_t entry,
 		 void *parameter1, void *parameter2, void *parameter3,
 		 int priority, unsigned int options)

--- a/arch/xtensa/core/thread.c
+++ b/arch/xtensa/core/thread.c
@@ -42,7 +42,7 @@ extern void _xt_user_exit(void);
  * @return N/A
  */
 
-void _new_thread(struct k_thread *thread, k_thread_stack_t stack,
+void _new_thread(struct k_thread *thread, k_thread_stack_t *stack,
 		size_t stackSize, k_thread_entry_t pEntry,
 		void *p1, void *p2, void *p3,
 		int priority, unsigned int options)

--- a/include/drivers/console/ipm_console.h
+++ b/include/drivers/console/ipm_console.h
@@ -35,7 +35,7 @@ struct ipm_console_receiver_config_info {
 	 * Stack for the receiver's thread, which prints out messages as
 	 * they come in. Should be sized CONFIG_IPM_CONSOLE_STACK_SIZE
 	 */
-	k_thread_stack_t thread_stack;
+	k_thread_stack_t *thread_stack;
 
 	/**
 	 * Ring buffer data area for stashing characters from the interrupt

--- a/include/net/http.h
+++ b/include/net/http.h
@@ -330,7 +330,7 @@ struct http_client_ctx {
 #if defined(CONFIG_HTTPS)
 	struct {
 		/** HTTPS stack for mbedtls library. */
-		k_thread_stack_t stack;
+		k_thread_stack_t *stack;
 
 		/** HTTPS stack size. */
 		int stack_size;
@@ -586,7 +586,7 @@ int https_client_init(struct http_client_ctx *http_ctx,
 		      const char *cert_host,
 		      https_entropy_src_cb_t entropy_src_cb,
 		      struct k_mem_pool *pool,
-		      k_thread_stack_t https_stack,
+		      k_thread_stack_t *https_stack,
 		      size_t https_stack_size);
 #endif /* CONFIG_HTTPS */
 
@@ -790,7 +790,7 @@ struct http_server_ctx {
 #if defined(CONFIG_HTTPS)
 	struct {
 		/** HTTPS stack for mbedtls library. */
-		k_thread_stack_t stack;
+		k_thread_stack_t *stack;
 
 		/** HTTPS stack size. */
 		int stack_size;
@@ -922,7 +922,7 @@ int https_server_init(struct http_server_ctx *http_ctx,
 		      https_server_cert_cb_t cert_cb,
 		      https_entropy_src_cb_t entropy_src_cb,
 		      struct k_mem_pool *pool,
-		      k_thread_stack_t https_stack,
+		      k_thread_stack_t *https_stack,
 		      size_t https_stack_len);
 #endif /* CONFIG_HTTPS */
 

--- a/include/net/mqtt.h
+++ b/include/net/mqtt.h
@@ -81,7 +81,7 @@ struct mqtt_ctx {
 
 	/** TLS thread parameters */
 	struct k_mem_pool *tls_mem_pool;
-	k_thread_stack_t tls_stack;
+	k_thread_stack_t *tls_stack;
 	size_t tls_stack_size;
 
 	/** TLS callback */

--- a/include/net/net_app.h
+++ b/include/net/net_app.h
@@ -336,7 +336,7 @@ struct net_app_ctx {
 #if defined(CONFIG_NET_APP_TLS) || defined(CONFIG_NET_APP_DTLS)
 	struct {
 		/** TLS stack for mbedtls library. */
-		k_thread_stack_t stack;
+		k_thread_stack_t *stack;
 
 		/** TLS stack size. */
 		int stack_size;
@@ -914,7 +914,7 @@ int net_app_client_tls(struct net_app_ctx *ctx,
 		       const char *cert_host,
 		       net_app_entropy_src_cb_t entropy_src_cb,
 		       struct k_mem_pool *pool,
-		       k_thread_stack_t stack,
+		       k_thread_stack_t *stack,
 		       size_t stack_size);
 #endif /* CONFIG_NET_APP_CLIENT */
 
@@ -950,7 +950,7 @@ int net_app_server_tls(struct net_app_ctx *ctx,
 		       net_app_cert_cb_t cert_cb,
 		       net_app_entropy_src_cb_t entropy_src_cb,
 		       struct k_mem_pool *pool,
-		       k_thread_stack_t stack,
+		       k_thread_stack_t *stack,
 		       size_t stack_len);
 
 #endif /* CONFIG_NET_APP_SERVER */

--- a/include/net/net_core.h
+++ b/include/net/net_core.h
@@ -95,7 +95,7 @@ int net_recv_data(struct net_if *iface, struct net_pkt *pkt);
 int net_send_data(struct net_pkt *pkt);
 
 struct net_stack_info {
-	k_thread_stack_t stack;
+	k_thread_stack_t *stack;
 	const char *pretty_name;
 	const char *name;
 	size_t orig_size;

--- a/kernel/include/nano_internal.h
+++ b/kernel/include/nano_internal.h
@@ -44,13 +44,13 @@ extern FUNC_NORETURN void _thread_entry(k_thread_entry_t entry,
 			  void *p1, void *p2, void *p3);
 
 /* Implemented by architectures. Only called from _setup_new_thread. */
-extern void _new_thread(struct k_thread *thread, k_thread_stack_t pStack,
+extern void _new_thread(struct k_thread *thread, k_thread_stack_t *pStack,
 			size_t stackSize, k_thread_entry_t entry,
 			void *p1, void *p2, void *p3,
 			int prio, unsigned int options);
 
 extern void _setup_new_thread(struct k_thread *new_thread,
-			      k_thread_stack_t stack, size_t stack_size,
+			      k_thread_stack_t *stack, size_t stack_size,
 			      k_thread_entry_t entry,
 			      void *p1, void *p2, void *p3,
 			      int prio, u32_t options);

--- a/kernel/thread.c
+++ b/kernel/thread.c
@@ -316,7 +316,7 @@ static void schedule_new_thread(struct k_thread *thread, s32_t delay)
 #endif
 
 void _setup_new_thread(struct k_thread *new_thread,
-		       k_thread_stack_t stack, size_t stack_size,
+		       k_thread_stack_t *stack, size_t stack_size,
 		       k_thread_entry_t entry,
 		       void *p1, void *p2, void *p3,
 		       int prio, u32_t options)
@@ -340,7 +340,7 @@ void _setup_new_thread(struct k_thread *new_thread,
 
 #ifdef CONFIG_MULTITHREADING
 k_tid_t _impl_k_thread_create(struct k_thread *new_thread,
-			      k_thread_stack_t stack,
+			      k_thread_stack_t *stack,
 			      size_t stack_size, k_thread_entry_t entry,
 			      void *p1, void *p2, void *p3,
 			      int prio, u32_t options, s32_t delay)
@@ -366,7 +366,7 @@ _SYSCALL_HANDLER(k_thread_create,
 	struct k_thread *new_thread = (struct k_thread *)new_thread_p;
 	volatile struct _syscall_10_args *margs =
 		(volatile struct _syscall_10_args *)more_args;
-	k_thread_stack_t stack = (k_thread_stack_t)stack_p;
+	k_thread_stack_t *stack = (k_thread_stack_t *)stack_p;
 
 	/* The thread and stack objects *must* be in an uninitialized state */
 	_SYSCALL_OBJ_NEVER_INIT(new_thread, K_OBJ_THREAD);

--- a/kernel/work_q.c
+++ b/kernel/work_q.c
@@ -46,7 +46,7 @@ static void work_q_main(void *work_q_ptr, void *p2, void *p3)
 	}
 }
 
-void k_work_q_start(struct k_work_q *work_q, k_thread_stack_t stack,
+void k_work_q_start(struct k_work_q *work_q, k_thread_stack_t *stack,
 		    size_t stack_size, int prio)
 {
 	k_queue_init(&work_q->queue);

--- a/subsys/net/lib/app/client.c
+++ b/subsys/net/lib/app/client.c
@@ -696,7 +696,7 @@ int net_app_client_tls(struct net_app_ctx *ctx,
 		       const char *cert_host,
 		       net_app_entropy_src_cb_t entropy_src_cb,
 		       struct k_mem_pool *pool,
-		       k_thread_stack_t stack,
+		       k_thread_stack_t *stack,
 		       size_t stack_size)
 {
 	if (!request_buf || request_buf_len == 0) {

--- a/subsys/net/lib/app/server.c
+++ b/subsys/net/lib/app/server.c
@@ -378,7 +378,7 @@ int net_app_server_tls(struct net_app_ctx *ctx,
 		       net_app_cert_cb_t cert_cb,
 		       net_app_entropy_src_cb_t entropy_src_cb,
 		       struct k_mem_pool *pool,
-		       k_thread_stack_t stack,
+		       k_thread_stack_t *stack,
 		       size_t stack_size)
 {
 	if (!request_buf || request_buf_len == 0) {

--- a/subsys/net/lib/http/http_client.c
+++ b/subsys/net/lib/http/http_client.c
@@ -1664,7 +1664,7 @@ int https_client_init(struct http_client_ctx *ctx,
 		      const char *cert_host,
 		      https_entropy_src_cb_t entropy_src_cb,
 		      struct k_mem_pool *pool,
-		      k_thread_stack_t https_stack,
+		      k_thread_stack_t *https_stack,
 		      size_t https_stack_size)
 {
 	int ret;

--- a/subsys/net/lib/http/http_server.c
+++ b/subsys/net/lib/http/http_server.c
@@ -1618,7 +1618,7 @@ int https_server_init(struct http_server_ctx *ctx,
 		      https_server_cert_cb_t cert_cb,
 		      https_entropy_src_cb_t entropy_src_cb,
 		      struct k_mem_pool *pool,
-		      k_thread_stack_t https_stack,
+		      k_thread_stack_t *https_stack,
 		      size_t https_stack_size)
 {
 	int ret;

--- a/tests/kernel/fatal/src/main.c
+++ b/tests/kernel/fatal/src/main.c
@@ -17,7 +17,7 @@ static K_THREAD_STACK_DEFINE(alt_stack, STACKSIZE);
 
 #ifdef CONFIG_STACK_SENTINEL
 #define OVERFLOW_STACKSIZE 1024
-static k_thread_stack_t overflow_stack =
+static k_thread_stack_t *overflow_stack =
 		alt_stack + (STACKSIZE - OVERFLOW_STACKSIZE);
 #else
 #define OVERFLOW_STACKSIZE STACKSIZE


### PR DESCRIPTION
Currently this is defined as a struct _k_thread_stack_element pointer.
However this isn't correct, stacks are defined as arrays of that type. Extern
references to k_thread_stack_t doesn't work properly as the compiler
treats it as a pointer to the stack array and not the array itself.

Declaring as an unsized array of struct _k_thread_stack_element doesn't work
well either. The least amount of confusion is to leave out the
pointer/array status completely, use pointers for function prototypes,
and define K_THREAD_STACK_EXTERN() to properly create an extern
reference.

The definitions for all functions and structs that use
k_thread_stack_t need to be updated, but code that uses them should
be unchanged.

Signed-off-by: Andrew Boie <andrew.p.boie@intel.com>