### PR TITLE
drivers: gpio: deprecate GPIO_PIN_ENABLE, GPIO_PIN_DISABLE

### DIFF
--- a/drivers/gpio/gpio_atmel_sam3.c
+++ b/drivers/gpio/gpio_atmel_sam3.c
@@ -37,12 +37,6 @@ static void _config(struct device *dev, u32_t mask, int flags)
 {
 	const struct gpio_sam3_config *cfg = dev->config->config_info;
 
-	/* Disable the pin and return as setup is meaningless now */
-	if (flags & GPIO_PIN_DISABLE) {
-		cfg->port->PIO_PDR = mask;
-		return;
-	}
-
 	/* Setup the pin direction */
 	if ((flags & GPIO_DIR_MASK) == GPIO_DIR_OUT) {
 		cfg->port->PIO_OER = mask;
@@ -89,10 +83,7 @@ static void _config(struct device *dev, u32_t mask, int flags)
 		cfg->port->PIO_SCIFSR = mask;
 	}
 
-	/* Enable the pin last after pin setup */
-	if (flags & GPIO_PIN_ENABLE) {
-		cfg->port->PIO_PER = mask;
-	}
+	cfg->port->PIO_PER = mask;
 }
 
 /**

--- a/drivers/gpio/gpio_cc2650.c
+++ b/drivers/gpio/gpio_cc2650.c
@@ -111,11 +111,6 @@ static int gpio_cc2650_config_pin(int pin, int flags)
 		 CC2650_IOC_IOCFGX_IE_MASK |
 		 CC2650_IOC_IOCFGX_HYST_EN_MASK);
 
-	if (flags & GPIO_PIN_DISABLE) {
-		disconnect(pin, &gpio_doe31_0_config, &iocfg_config);
-		goto commit_config;
-	}
-
 	if (flags & GPIO_DIR_OUT) {
 		gpio_doe31_0_config |= BIT(pin);
 		iocfg_config |= CC2650_IOC_INPUT_DISABLED;
@@ -181,7 +176,6 @@ static int gpio_cc2650_config_pin(int pin, int flags)
 	}
 
 	/* Commit changes */
-commit_config:
 	sys_write32(iocfg_config, iocfg);
 	sys_write32(gpio_doe31_0_config, doe31_0);
 	return 0;

--- a/drivers/gpio/gpio_cmsdk_ahb.c
+++ b/drivers/gpio/gpio_cmsdk_ahb.c
@@ -42,12 +42,6 @@ static void cmsdk_ahb_gpio_config(struct device *dev, u32_t mask, int flags)
 {
 	const struct gpio_cmsdk_ahb_cfg * const cfg = dev->config->config_info;
 
-	/* Disable the pin and return as setup is meaningless now */
-	if (flags & GPIO_PIN_DISABLE) {
-		cfg->port->altfuncset = mask;
-		return;
-	}
-
 	/*
 	 * Setup the pin direction
 	 * Output Enable:
@@ -88,10 +82,7 @@ static void cmsdk_ahb_gpio_config(struct device *dev, u32_t mask, int flags)
 		}
 	}
 
-	/* Enable the pin last after pin setup */
-	if (flags & GPIO_PIN_ENABLE) {
-		cfg->port->altfuncclr = mask;
-	}
+	cfg->port->altfuncclr = mask;
 }
 
 /**

--- a/include/gpio.h
+++ b/include/gpio.h
@@ -108,18 +108,11 @@ extern "C" {
 #define GPIO_PUD_MASK		(3 << GPIO_PUD_POS)
 /** @endcond */
 
-/*
- * GPIO_PIN_(EN-/DIS-)ABLE are for pin enable / disable.
- *
- * Individual pins can be enabled or disabled
- * if the controller supports this operation.
- */
+/** Deprecated, do not use - Enable GPIO pin. */
+#define GPIO_PIN_ENABLE		(0 __DEPRECATED_MACRO)
 
-/** Enable GPIO pin. */
-#define GPIO_PIN_ENABLE		(1 << 10)
-
-/** Disable GPIO pin. */
-#define GPIO_PIN_DISABLE	(1 << 11)
+/** Deprecated, do not use - Disable GPIO pin. */
+#define GPIO_PIN_DISABLE	(0 __DEPRECATED_MACRO)
 
 /* GPIO_DS_* are for pin drive strength configuration.
  *


### PR DESCRIPTION
According to the existing implementation - but not necessarily description - the GPIO_PIN_ENABLE, GPIO_PIN_DISABLE configuration constants are meant to give control over the pin to the GPIO module or let the pin be controlled by a peripheral. However, this overlaps functionality provided by the pinmux driver.

Especially GPIO_PIN_DISABLE seems a dangerous option to have since it gives back control over the pin to a peripheral however gives no way to choose which peripheral it should be. Pin could become an input or an output. Pinmux driver handles this in a clean way.

It may be the case that the original meaning of the two constant was different and they were simply incorrectly implemented. E.g. GPIO_PIN_DISABLE could mean disconnect pin from the pad. I believe some SoC support this. If this is the case such option still should go to the pinmux driver not GPIO one.

In any case the both constants are almost universally ignored by the existing GPIO device drivers. Out of 17 drivers only 2 take GPIO_PIN_ENABLE option into account. So in the majority case running gpio_*_configure function always sets the pin in GPIO mode.

To remove current inconsistencies I propose to deprecate GPIO_PIN_ENABLE, GPIO_PIN_DISABLE configuration constants.