### PR TITLE
Bluetooth: Fix memory leak of command response buffer

### DIFF
--- a/subsys/bluetooth/host/hci_core.c
+++ b/subsys/bluetooth/host/hci_core.c
@@ -3731,10 +3731,12 @@ static int set_static_addr(void)
 		if (rp->num_addrs) {
 			bt_dev.id_addr.type = BT_ADDR_LE_RANDOM;
 			bt_addr_copy(&bt_dev.id_addr.a, &rp->a[0].bdaddr);
+			net_buf_unref(rsp);
 			goto set_addr;
-		} else {
-			BT_WARN("No static addresses stored in controller");
 		}
+
+		BT_WARN("No static addresses stored in controller");
+		net_buf_unref(rsp);
 	} else {
 		BT_WARN("Read Static Addresses command not available");
 	}


### PR DESCRIPTION
There was a missing net_buf_unref() for the response to reading the
controller static addresses.

Signed-off-by: Johan Hedberg <johan.hedberg@intel.com>