### PR TITLE
helper functions for granting a thread permission to a list of objects

### DIFF
--- a/include/kernel.h
+++ b/include/kernel.h
@@ -616,6 +616,22 @@ extern FUNC_NORETURN void k_thread_user_mode_enter(k_thread_entry_t entry,
 						   void *p3);
 
 /**
+ * @brief Grant a thread access to a NULL-terminated  set of kernel objects
+ *
+ * This is a convenience function. For the provided thread, grant access to
+ * the remaining arguments, which must be pointers to kernel objects.
+ * The final argument must be a NULL.
+ *
+ * The thread object must be initialized (i.e. running). The objects don't
+ * need to be.
+ *
+ * @param thread Thread to grant access to objects
+ * @param ... NULL-terminated list of kernel object pointers
+ */
+extern void __attribute__((sentinel))
+	k_thread_access_grant(struct k_thread *thread, ...);
+
+/**
  * @brief Put the current thread to sleep.
  *
  * This routine puts the current thread to sleep for @a duration

--- a/include/linker/common-rom.ld
+++ b/include/linker/common-rom.ld
@@ -24,7 +24,17 @@
 		__init_array_end = .;
 	} GROUP_LINK_IN(ROMABLE_REGION)
 #endif
-
+#ifdef CONFIG_USERSPACE
+	/* Build-time assignment of permissions to kernel objects to
+	 * threads declared with K_THREAD_DEFINE()
+	 */
+	SECTION_PROLOGUE(object_access, (OPTIONAL),)
+	{
+		__object_access_start = .;
+		KEEP(*(".object_access.*"))
+		__object_access_end = .;
+	}
+#endif
 	SECTION_PROLOGUE (devconfig, (OPTIONAL),)
 	{
 		__devconfig_start = .;

--- a/kernel/thread.c
+++ b/kernel/thread.c
@@ -590,6 +590,25 @@ void _k_thread_single_abort(struct k_thread *thread)
 }
 
 #ifdef CONFIG_MULTITHREADING
+#ifdef CONFIG_USERSPACE
+extern char __object_access_start[];
+extern char __object_access_end[];
+
+static void grant_static_access(void)
+{
+	struct _k_object_assignment *pos;
+
+	for (pos = (struct _k_object_assignment *)__object_access_start;
+	     pos < (struct _k_object_assignment *)__object_access_end;
+	     pos++) {
+		for (int i = 0; pos->objects[i] != NULL; i++) {
+			k_object_access_grant(pos->objects[i],
+					      pos->thread);
+		}
+	}
+}
+#endif /* CONFIG_USERSPACE */
+
 void _init_static_threads(void)
 {
 	unsigned int  key;
@@ -609,6 +628,9 @@ void _init_static_threads(void)
 		thread_data->init_thread->init_data = thread_data;
 	}
 
+#ifdef CONFIG_USERSPACE
+	grant_static_access();
+#endif
 	_sched_lock();
 
 	/*

--- a/kernel/thread.c
+++ b/kernel/thread.c
@@ -692,6 +692,25 @@ void _k_thread_group_leave(u32_t groups, struct k_thread *thread)
 	thread_data->init_groups &= groups;
 }
 
+void k_thread_access_grant(struct k_thread *thread, ...)
+{
+#ifdef CONFIG_USERSPACE
+	va_list args;
+	va_start(args, thread);
+
+	while (1) {
+		void *object = va_arg(args, void *);
+		if (object == NULL) {
+			break;
+		}
+		k_object_access_grant(object, thread);
+	}
+	va_end(args);
+#else
+	ARG_UNUSED(thread);
+#endif
+}
+
 FUNC_NORETURN void k_thread_user_mode_enter(k_thread_entry_t entry,
 					    void *p1, void *p2, void *p3)
 {

--- a/scripts/sanitycheck
+++ b/scripts/sanitycheck
@@ -489,7 +489,7 @@ class SizeCalculator:
                    "_k_queue_area", "_net_buf_pool_area", "app_datas",
                    "kobject_data", "mmu_tables"]
     # These get copied into RAM only on non-XIP
-    ro_sections = ["text", "ctors", "init_array", "reset",
+    ro_sections = ["text", "ctors", "init_array", "reset", "object_access",
                    "rodata", "devconfig", "net_l2", "vector"]
 
     def __init__(self, filename, extra_sections):


### PR DESCRIPTION
These patches solve two problems:

1. For static threads, they do not inherit any permissions and if started as K_USER, can do very little because of this. K_THREAD_GRANT_ACCESS() populates some data structures in ROM that are used to grant thread permission to objects at boot, so they start up with the permissions they need.

2. For runtime threads, it's very common to want to grant a thread access a whole list of objects. k_thread_grant_access() does this, calling k_object_grant_access() for each object passed in. This function can run in user mode.