### PR TITLE
doc: Fix misspellings in header/doxygen comments

### DIFF
--- a/arch/arc/include/kernel_arch_thread.h
+++ b/arch/arc/include/kernel_arch_thread.h
@@ -8,7 +8,7 @@
  * @file
  * @brief Per-arch thread definition
  *
- * This file contains defintions for
+ * This file contains definitions for
  *
  *  struct _thread_arch
  *  struct _callee_saved

--- a/arch/arm/include/kernel_arch_thread.h
+++ b/arch/arm/include/kernel_arch_thread.h
@@ -8,7 +8,7 @@
  * @file
  * @brief Per-arch thread definition
  *
- * This file contains defintions for
+ * This file contains definitions for
  *
  *  struct _thread_arch
  *  struct _callee_saved

--- a/arch/arm/soc/atmel_sam/sam4s/soc.c
+++ b/arch/arm/soc/atmel_sam/sam4s/soc.c
@@ -25,7 +25,7 @@
  *
  * Setup the SoC clocks according to section 28.12 in datasheet.
  *
- * Setup Slow, Main, PLLA, Procesor and Master clocks during the device boot.
+ * Setup Slow, Main, PLLA, Processor and Master clocks during the device boot.
  * It is assumed that the relevant registers are at their reset value.
  */
 static ALWAYS_INLINE void clock_init(void)

--- a/arch/nios2/include/kernel_arch_thread.h
+++ b/arch/nios2/include/kernel_arch_thread.h
@@ -8,7 +8,7 @@
  * @file
  * @brief Per-arch thread definition
  *
- * This file contains defintions for
+ * This file contains definitions for
  *
  *  struct _thread_arch
  *  struct _callee_saved

--- a/arch/riscv32/include/kernel_arch_thread.h
+++ b/arch/riscv32/include/kernel_arch_thread.h
@@ -8,7 +8,7 @@
  * @file
  * @brief Per-arch thread definition
  *
- * This file contains defintions for
+ * This file contains definitions for
  *
  *  struct _thread_arch
  *  struct _callee_saved

--- a/arch/x86/include/kernel_arch_thread.h
+++ b/arch/x86/include/kernel_arch_thread.h
@@ -8,7 +8,7 @@
  * @file
  * @brief Per-arch thread definition
  *
- * This file contains defintions for
+ * This file contains definitions for
  *
  *  struct _thread_arch
  *  struct _callee_saved

--- a/arch/xtensa/include/kernel_arch_thread.h
+++ b/arch/xtensa/include/kernel_arch_thread.h
@@ -8,7 +8,7 @@
  * @file
  * @brief Per-arch thread definition
  *
- * This file contains defintions for
+ * This file contains definitions for
  *
  *  struct _thread_arch
  *  struct _callee_saved

--- a/drivers/i2c/i2c_bitbang.h
+++ b/drivers/i2c/i2c_bitbang.h
@@ -32,9 +32,9 @@ struct i2c_bitbang {
 };
 
 /**
- * @brief Initialise an i2c_bitbang instance
+ * @brief Initialize an i2c_bitbang instance
  *
- * @param bitbang	The instance to initialise
+ * @param bitbang	The instance to initialize
  * @param io		Functions to use for controlling I2C bus lines
  * @param io_context	Context pointer to pass to i/o functions when then are
  *			called.

--- a/drivers/i2c/i2c_gpio.c
+++ b/drivers/i2c/i2c_gpio.c
@@ -15,7 +15,7 @@
  * is read it must return the state of the physical hardware line, not just the
  * last state written to it for output.
  *
- * The SCL pin should be configued in the same manner as SDA, or, if it is known
+ * The SCL pin should be configured in the same manner as SDA, or, if it is known
  * that the hardware attached to pin doesn't attempt clock stretching, then the
  * SCL pin may be a push/pull output.
  */

--- a/drivers/timer/nrf_rtc_timer.c
+++ b/drivers/timer/nrf_rtc_timer.c
@@ -215,9 +215,9 @@ void _timer_idle_enter(s32_t sys_ticks)
 #ifdef CONFIG_TICKLESS_KERNEL
 
 /**
- * @brief provides total systicks programed.
+ * @brief provides total systicks programmed.
  *
- * returns : total number of sys ticks programed.
+ * returns : total number of sys ticks programmed.
  */
 
 uint32_t _get_program_time(void)
@@ -226,9 +226,9 @@ uint32_t _get_program_time(void)
 }
 
 /**
- * @brief provides total systicks remaining since last programing of RTC.
+ * @brief provides total systicks remaining since last programming of RTC.
  *
- * returns : total number of sys ticks remaining since last RTC programing.
+ * returns : total number of sys ticks remaining since last RTC programming.
  */
 
 uint32_t _get_remaining_program_time(void)
@@ -242,9 +242,9 @@ uint32_t _get_remaining_program_time(void)
 }
 
 /**
- * @brief provides total systicks passed since last programing of RTC.
+ * @brief provides total systicks passed since last programming of RTC.
  *
- * returns : total number of sys ticks passed since last RTC programing.
+ * returns : total number of sys ticks passed since last RTC programming.
  */
 
 uint32_t _get_elapsed_program_time(void)
@@ -305,7 +305,7 @@ void _set_time(uint32_t time)
  * @brief provides time remaining to reach rtc count overflow.
  *
  * This function returns how many sys RTC remaining for rtc to overflow.
- * This will be required when we will programe RTC compare value to maximum
+ * This will be required when we will program RTC compare value to maximum
  * possible value.
  *
  * returns : difference between current systick and Maximum possible systick.
@@ -334,7 +334,7 @@ int32_t _get_max_clock_time(void)
 /**
  * @brief Enable sys Clock.
  *
- * This is used to programe RTC clock to maximum Clock time incase Clock to
+ * This is used to program RTC clock to maximum Clock time in case Clock to
  * remain On.
  */
 void _enable_sys_clock(void)

--- a/drivers/usb/device/usb_dc_stm32.c
+++ b/drivers/usb/device/usb_dc_stm32.c
@@ -17,7 +17,7 @@
  * There is a bit of an impedance mismatch between the Zephyr
  * usb_device and the STM32 Cube HAL layer where higher levels make
  * assumptions about the low level drivers that don't quite match how
- * the low level drivers actuall work.
+ * the low level drivers actually work.
  *
  * The usb_dc_ep_read function expects to get the data it wants
  * immediately while the HAL_PCD_EP_Receive function only starts a

--- a/include/net/coap.h
+++ b/include/net/coap.h
@@ -788,7 +788,7 @@ static inline u16_t coap_next_id(void)
  *
  * @return the net_buf fragment pointer and offset value if payload exists
  *         NULL pointer and offset set to 0 in case there is no payload
- *         NULL pointer and offset value 0xffff incase of an error
+ *         NULL pointer and offset value 0xffff in case of an error
  */
 struct net_buf *coap_packet_get_payload(const struct coap_packet *cpkt,
 					u16_t *offset,

--- a/include/net/net_pkt.h
+++ b/include/net/net_pkt.h
@@ -1396,7 +1396,7 @@ void net_pkt_get_info(struct k_mem_slab **rx,
 /**
  * @brief Get source socket address.
  *
- * @param pkt Nework packet
+ * @param pkt Network packet
  * @param addr Source socket address
  * @param addrlen The length of source socket address
  * @return 0 on success, <0 otherwise.

--- a/include/usb/class/usb_cdc.h
+++ b/include/usb/class/usb_cdc.h
@@ -9,7 +9,7 @@
 
 /**
  * @file
- * @brief USB Communicatons Device Class (CDC) public header
+ * @brief USB Communications Device Class (CDC) public header
  *
  * Header follows the Class Definitions for
  * Communications Devices Specification (CDC120-20101103-track.pdf),

--- a/kernel/include/syscall_handler.h
+++ b/kernel/include/syscall_handler.h
@@ -266,7 +266,7 @@ static inline int _obj_validation_check(struct _k_object *ko,
  *
  * Calls _k_object_validate and triggers a kernel oops if the check files.
  * For use in system call handlers which are not init functions; a fatal
- * error will occur if the object is not intiailized.
+ * error will occur if the object is not initialized.
  *
  * @param ptr Untrusted kernel object pointer
  * @param type Expected kernel object type

--- a/samples/drivers/gpio/src/main.c
+++ b/samples/drivers/gpio/src/main.c
@@ -15,7 +15,7 @@
  * BUTTON1 is on DIO_4
  * BUTTON2 is on DIO_0
  *
- * This sample toogles LED1 and wait interrupt on BUTTON1.
+ * This sample toggles LED1 and wait interrupt on BUTTON1.
  * Note that an internet pull-up is set on BUTTON1 as the button
  * only drives low when pressed.
  *

--- a/tests/kernel/mem_heap/mheap_api_concept/src/test_mheap_concept.c
+++ b/tests/kernel/mem_heap/mheap_api_concept/src/test_mheap_concept.c
@@ -12,7 +12,7 @@
  * @details All TESTPOINTs extracted from kernel documentation.
  * https://www.zephyrproject.org/doc/kernel/memory/heap.html#concepts
  *
- * TESTPOINTs cover testable kernel behaviours that preserve across internal
+ * TESTPOINTs cover testable kernel behaviors that preserve across internal
  * implementation change or kernel version change.
  * As a black-box test, TESTPOINTs do not cover internal operations.
  * @}

--- a/tests/kernel/mem_pool/mem_pool_threadsafe/src/test_mpool_threadsafe.c
+++ b/tests/kernel/mem_pool/mem_pool_threadsafe/src/test_mpool_threadsafe.c
@@ -9,7 +9,7 @@
  * @{
  * @defgroup t_mpool_threadsafe test_mpool_threadsafe
  * @brief TestPurpose: verify API thread safe in multi-threads environment.
- * @details This's an extensive test. Multiple threads in same priority are
+ * @details This is an extensive test. Multiple threads in same priority are
  * created, with time slice scheduling enabled in a very small slicing size:
  * 1 millisecond (refer to prj.conf).
  * All threads share a same entry function to invoke same kernel APIs.

--- a/tests/net/6lo/src/main.c
+++ b/tests/net/6lo/src/main.c
@@ -35,7 +35,7 @@
 
 /**
   * IPv6 Source and Destination address
-  * Example addresses are based on SAC (Source Adddress Compression),
+  * Example addresses are based on SAC (Source Address Compression),
   * SAM (Source Address Mode), DAC (Destination Address Compression),
   * DAM (Destination Address Mode) and also if the destination address
   * is Multicast address.

--- a/tests/net/ieee802154/fragment/src/main.c
+++ b/tests/net/ieee802154/fragment/src/main.c
@@ -33,7 +33,7 @@
 
 /**
   * IPv6 Source and Destination address
-  * Example addresses are based on SAC (Source Adddress Compression),
+  * Example addresses are based on SAC (Source Address Compression),
   * SAM (Source Address Mode), DAC (Destination Address Compression),
   * DAM (Destination Address Mode) and also if the destination address
   * is Multicast address.


### PR DESCRIPTION
Occasional scan for misspellings missed during PR reviews

Signed-off-by: David B. Kinder <david.b.kinder@intel.com>