### PR TITLE
kernel: Add option to ensure writable pages are not executable

### DIFF
--- a/arch/Kconfig
+++ b/arch/Kconfig
@@ -140,6 +140,9 @@ config ARCH_HAS_STACK_PROTECTION
 config ARCH_HAS_USERSPACE
 	bool
 
+config ARCH_HAS_EXECUTABLE_PAGE_BIT
+	bool
+
 #
 # Hidden PM feature configs which are to be selected by
 # individual SoC.

--- a/arch/arm/core/cortex_m/mpu/Kconfig
+++ b/arch/arm/core/cortex_m/mpu/Kconfig
@@ -26,6 +26,7 @@ config ARM_MPU
 	depends on CPU_HAS_MPU
 	depends on SOC_FAMILY_ARM || SOC_FAMILY_STM32 || SOC_FAMILY_NRF5
 	select ARM_CORE_MPU
+	select ARCH_HAS_EXECUTABLE_PAGE_BIT
 	default n
 	help
 	  MCU has ARM MPU
@@ -35,6 +36,7 @@ config NXP_MPU
 	depends on CPU_HAS_MPU
 	depends on SOC_FAMILY_KINETIS
 	select ARM_CORE_MPU
+	select ARCH_HAS_EXECUTABLE_PAGE_BIT
 	default n
 	help
 	  MCU has NXP MPU

--- a/include/arch/arm/arch.h
+++ b/include/arch/arm/arch.h
@@ -216,6 +216,24 @@ extern "C" {
 #define K_MEM_PARTITION_P_RWX_U_RWX	(P_RW_U_RW)
 #define K_MEM_PARTITION_P_RWX_U_RX	(P_RW_U_RO)
 #define K_MEM_PARTITION_P_RX_U_RX	(P_RO_U_RO)
+
+#define K_MEM_PARTITION_IS_WRITABLE(attr) \
+	({ \
+		int __is_writable__; \
+		switch (attr) { \
+		case P_RW_U_RW: \
+		case P_RW_U_RO: \
+		case P_RW_U_NA: \
+			__is_writable__ = 1; \
+			break; \
+		default: \
+			__is_writable__ = 0; \
+		} \
+		__is_writable__; \
+	})
+#define K_MEM_PARTITION_IS_EXECUTABLE(attr) \
+	(!((attr) & (NOT_EXEC)))
+
 #endif /* _ASMLANGUAGE */
 #define _ARCH_MEM_PARTITION_ALIGN_CHECK(start, size) \
 	BUILD_ASSERT_MSG(!(((size) & ((size) - 1))) && (size) >= 32 && \
@@ -243,6 +261,34 @@ extern "C" {
 					 MPU_REGION_SU_RWX)
 #define K_MEM_PARTITION_P_RX_U_RX	(MPU_REGION_READ | MPU_REGION_EXEC | \
 					 MPU_REGION_SU)
+
+#define K_MEM_PARTITION_IS_WRITABLE(attr) \
+	({ \
+		int __is_writable__; \
+		switch (attr) { \
+		case MPU_REGION_WRITE: \
+		case MPU_REGION_SU_RW: \
+			__is_writable__ = 1; \
+			break; \
+		default: \
+			__is_writable__ = 0; \
+		} \
+		__is_writable__; \
+	})
+#define K_MEM_PARTITION_IS_EXECUTABLE(attr) \
+	({ \
+		int __is_executable__; \
+		switch (attr) { \
+		case MPU_REGION_SU_RX: \
+		case MPU_REGION_EXEC: \
+			__is_executable__ = 1; \
+			break; \
+		default: \
+			__is_executable__ = 0; \
+		} \
+		__is_executable__; \
+	})
+
 #endif /* _ASMLANGUAGE */
 #define _ARCH_MEM_PARTITION_ALIGN_CHECK(start, size) \
 	BUILD_ASSERT_MSG((size) % 32 == 0 && (size) >= 32 && \

--- a/kernel/Kconfig
+++ b/kernel/Kconfig
@@ -555,6 +555,20 @@ config STACK_CANARIES
 
 	If stack canaries are not supported by the compiler, enabling this
 	option has no effect.
+
+config EXECUTE_XOR_WRITE
+	bool "Enable W^X for memory partitions"
+	depends on USERSPACE
+	depends on ARCH_HAS_EXECUTABLE_PAGE_BIT
+	default y
+	help
+	When enabled, will enforce that a writable page isn't executable
+	and vice versa.  This might not be acceptable in all scenarios,
+	so this option is given for those unafraid of shooting themselves
+	in the foot.
+
+	If unsure, say Y.
+
 endmenu
 
 config MAX_DOMAIN_PARTITIONS


### PR DESCRIPTION
This adds CONFIG_EXECUTE_XOR_WRITE, which is enabled by default on
systems that support controlling whether a page can contain executable
code.  This is also known as W^X[1].

Trying to add a memory domain with a page that is both executable and
writable, either for supervisor mode threads, or for user mode threads,
will result in a kernel panic.

There are few cases where a writable page should also be executable
(JIT compilers, which are most likely out of scope for Zephyr), so an
option is provided to disable the check.

Since the memory domain APIs are executed in supervisor mode, a
determined person could bypass these checks with ease.  This is seen
more as a way to avoid people shooting themselves in the foot.

[1] https://en.wikipedia.org/wiki/W%5EX

Signed-off-by: Leandro Pereira <leandro.pereira@intel.com>