### PR TITLE
net: lwm2m: do not unref pkt when pending timeout

### DIFF
--- a/subsys/net/lib/lwm2m/lwm2m_engine.c
+++ b/subsys/net/lib/lwm2m/lwm2m_engine.c
@@ -2725,8 +2725,6 @@ static void retransmit_request(struct k_work *work)
 			msg->message_timeout_cb(msg);
 		}
 
-		/* final unref to release pkt */
-		net_pkt_unref(pending->pkt);
 		lwm2m_release_message(msg);
 		return;
 	}


### PR DESCRIPTION
Revert "net: lwm2m: fix packet leak in timeout work"
This reverts commit 0b0fd5515d11dd2c2d1f3797944619005422e3d8.

The original patch introduces a double free error  

Tested against master branch with network debug messages turned on and ipv4-only
commit 4600c37ff1ff214a189205e3b1970c009b78398d
Author: David B. Kinder <david.b.kinder@intel.com>
Date:   Tue Oct 17 15:55:47 2017 -0700

Debug messages:
----
```
lib/lwm2m_rd_client] [WRN] do_registration_timeout_cb: Registration Timeout
[lwm2m-client] [DBG] rd_client_event: Disconnected
[lwm2m-client] [DBG] rd_client_event: Registration failure!
[net/pkt] [DBG] net_pkt_unref_debug: (0x00407bd0): TX [49] pkt 0x004126f8 ref 0 frags 0x00408190 (retransmit_request():2728)
[net/pkt] [DBG] net_pkt_unref_debug: (0x00407bd0): TDATA (tx_bufs) [49] frag 0x00408190 ref 0 frags 0x00000000 (retransmit_request():2728)
[net/pkt] [DBG] net_pkt_frag_unref_debug: (0x00407bd0): TDATA (tx_bufs) [49] frag 0x00408190 ref 0 (net_pkt_unref_debug():750)
[net/pkt] [ERR] net_pkt_unref_debug: *** ERROR *** pkt 0x004126f8 is freed already by retransmit_request():2728 (zoap_pending_clear():484)
```


@mike-scott I check the description of 0b0fd5515d11dd2c2d1f3797944619005422e3d8. It seems that you are trying to fix a packet leaking issue. But I'm not sure where is the code that "add a ref to the packet". 
