### PR TITLE
samples: mesh_demo: Use second button to change target address

### DIFF
--- a/samples/bluetooth/mesh_demo/src/board.h
+++ b/samples/bluetooth/mesh_demo/src/board.h
@@ -7,7 +7,7 @@
  */
 
 void board_button_1_pressed(void);
-bool board_toggle_relay(void);
+u16_t board_set_target(void);
 void board_play(const char *str);
 
 #if defined(CONFIG_BOARD_BBC_MICROBIT)

--- a/samples/bluetooth/mesh_demo/src/main.c
+++ b/samples/bluetooth/mesh_demo/src/main.c
@@ -249,13 +249,15 @@ static void bt_ready(int err)
 	configure();
 }
 
+static u16_t target = GROUP_ADDR;
+
 void board_button_1_pressed(void)
 {
 	struct net_buf_simple *msg = NET_BUF_SIMPLE(3 + 4);
 	struct bt_mesh_msg_ctx ctx = {
 		.net_idx = net_idx,
 		.app_idx = app_idx,
-		.addr = GROUP_ADDR,
+		.addr = target,
 		.send_ttl = BT_MESH_TTL_DEFAULT,
 	};
 
@@ -269,15 +271,21 @@ void board_button_1_pressed(void)
 	printk("Button message sent with OpCode 0x%08x\n", OP_VENDOR_BUTTON);
 }
 
-bool board_toggle_relay(void)
+u16_t board_set_target(void)
 {
-	if (cfg_srv.relay == BT_MESH_RELAY_ENABLED) {
-		cfg_srv.relay = BT_MESH_RELAY_DISABLED;
-		return false;
+	switch (target) {
+	case GROUP_ADDR:
+		target = 1;
+		break;
+	case 9:
+		target = GROUP_ADDR;
+		break;
+	default:
+		target++;
+		break;
 	}
 
-	cfg_srv.relay = BT_MESH_RELAY_ENABLED;
-	return true;
+	return target;
 }
 
 static struct k_sem tune_sem = _K_SEM_INITIALIZER(tune_sem, 0, 1);

--- a/samples/bluetooth/mesh_demo/src/microbit.c
+++ b/samples/bluetooth/mesh_demo/src/microbit.c
@@ -128,12 +128,14 @@ static void button_pressed(struct device *dev, struct gpio_callback *cb,
 	if (pins & BIT(SW0_GPIO_PIN)) {
 		k_work_submit(&button_work);
 	} else {
-		if (board_toggle_relay()) {
-			mb_display_print(disp, MB_DISPLAY_MODE_DEFAULT,
-					 SCROLL_SPEED, "R on");
+		u16_t target = board_set_target();
+
+		if (target > 0x0009) {
+			mb_display_print(disp, MB_DISPLAY_MODE_SINGLE,
+					 K_SECONDS(2), "A");
 		} else {
-			mb_display_print(disp, MB_DISPLAY_MODE_DEFAULT,
-					 SCROLL_SPEED, "R off");
+			mb_display_print(disp, MB_DISPLAY_MODE_SINGLE,
+					 K_SECONDS(2), "%X", (target & 0xf));
 		}
 	}
 }


### PR DESCRIPTION
It's been observed that that the relay toggling functionality is not
very useful, and that it's better left enabled always. Change the
purpose of the second button to instead modify the target address that
messages sent through the first button get directed to. By default the
destination is the group address, i.e. all nodes receive the message.

Signed-off-by: Johan Hedberg <johan.hedberg@intel.com>