### PR TITLE
samples: sockets: dumb_http_server: Use big payload by default

### DIFF
--- a/samples/net/sockets/dumb_http_server/README.rst
+++ b/samples/net/sockets/dumb_http_server/README.rst
@@ -45,20 +45,21 @@ the documentation at :ref:`boards`.
 
 After the sample starts, it expects connections at 192.0.2.1, port 8080.
 The easiest way to connect is by opening a following URL in a web
-browser: http://192.0.2.1:8080/ . You should see a page with content
-"Plain-text example.". Alternatively, a tool like ``curl`` can be used:
+browser: http://192.0.2.1:8080/ . You should see a page with a sample
+content about Zephyr (captured at a particular time from Zephyr's web
+site, note that it may differ from the content on the live Zephyr site).
+Alternatively, a tool like ``curl`` can be used:
 
 .. code-block:: console
 
     $ curl http://192.0.2.1:8080/
-    Plain-text example.
 
 Finally, you can run an HTTP profiling/load tool like Apache Bench
 (``ab``) against the server:
 
     $ ab -n10 http://192.0.2.1:8080/
 
-``-n`` parameter specified the number of HTTP requests to issue against
+``-n`` parameter specifies the number of HTTP requests to issue against
 a server.
 
 Running application on POSIX Host

--- a/samples/net/sockets/dumb_http_server/src/socket_dumb_http.c
+++ b/samples/net/sockets/dumb_http_server/src/socket_dumb_http.c
@@ -23,8 +23,12 @@
 
 #endif
 
+#ifndef USE_BIG_PAYLOAD
+#define USE_BIG_PAYLOAD 1
+#endif
+
 static const char content[] = {
-#if 0
+#if USE_BIG_PAYLOAD
     #include "response_big.html.bin.inc"
 #else
     #include "response_small.html.bin.inc"


### PR DESCRIPTION
This sends out 2KB+ payload (i.e. guaranteedly more than 1 network
packet). When this sample was initially written, using such payload
quickly let to a deadlock somewhere in the network stack. However
as of now, running with such payload can sustain testing with
"ab -n10000" (10000 consecutive HTTP requests using Apache Bench),
so set is as a default, to serve as a mark point against possible
future regressions.

Signed-off-by: Paul Sokolovsky <paul.sokolovsky@linaro.org>