### PR TITLE
tests: net: lib: dns_resolve: bump min memory to over 20k

### DIFF
--- a/tests/net/lib/dns_resolve/testcase.yaml
+++ b/tests/net/lib/dns_resolve/testcase.yaml
@@ -1,6 +1,6 @@
 tests:
   - test:
-      min_ram: 16
+      min_ram: 21
       tags: dns net
       timeout: 600
   - test-no-ipv6:


### PR DESCRIPTION
We are failing on all systems with 20k of memory so bump up the limit
needed to build this test.

Signed-off-by: Kumar Gala <kumar.gala@linaro.org>