### PR TITLE
net: pkt: net_pkt_tcp/udp_data: Better document caveats

### DIFF
--- a/subsys/net/ip/net_private.h
+++ b/subsys/net/ip/net_private.h
@@ -57,6 +57,9 @@ struct net_icmp_hdr *net_icmp_header_fits(struct net_pkt *pkt,
 	return NULL;
 }
 
+/* Header may be split between data fragments. In most cases,
+ * net_udp_get_hdr() should be used instead.
+ */
 struct net_udp_hdr *net_pkt_udp_data(struct net_pkt *pkt);
 
 static inline
@@ -70,6 +73,9 @@ struct net_udp_hdr *net_udp_header_fits(struct net_pkt *pkt,
 	return NULL;
 }
 
+/* Header may be split between data fragments. In most cases,
+ * net_tcp_get_hdr() should be used instead.
+ */
 struct net_tcp_hdr *net_pkt_tcp_data(struct net_pkt *pkt);
 
 static inline


### PR DESCRIPTION
Explicitly note that while these functions return pointers to
headers, the headers themselves may be fragmented into different
data fragments. 1a2f24f920a0 is an example where this might have
been overlooked.

Signed-off-by: Paul Sokolovsky <paul.sokolovsky@linaro.org>