### PR TITLE
CONFIG_EXCEPTION_DEBUG should depend on CONFIG_DEBUG

### DIFF
--- a/arch/x86/core/Kconfig
+++ b/arch/x86/core/Kconfig
@@ -17,7 +17,7 @@ config EXCEPTION_DEBUG
 	bool
 	prompt "Unhandled exception debugging"
 	default y
-	depends on PRINTK
+	depends on PRINTK && DEBUG
 	help
 	Install handlers for various CPU exception/trap vectors to
 	make debugging them easier, at a small expense in code size.


### PR DESCRIPTION
Signed-off-by: Leandro Pereira <leandro.pereira@intel.com>