### PR TITLE
samples: fix mem_domain_apis_test doesn't be built during sanitycheck

### DIFF
--- a/samples/mpu/mem_domain_apis_test/sample.yaml
+++ b/samples/mpu/mem_domain_apis_test/sample.yaml
@@ -3,7 +3,6 @@ sample:
   name: TBD
 tests:
   - test:
-      arch_whitelist: arm
       build_only: true
-      filter: USERSPACE
+      platform_whitelist: frdm_k64f stm32f4_disco
       tags: samples


### PR DESCRIPTION
Use platform_whitelist to specify supported boards to make sure
mem_domain_apis_test sample will be built during sanitycheck.

Fixes #4289

Signed-off-by: Chunlin Han <chunlin.han@linaro.org>