### PR TITLE
net: lwm2m: increase rd client stack size when NET_LOG_GLOBAL=y

### DIFF
--- a/subsys/net/lib/lwm2m/Kconfig
+++ b/subsys/net/lib/lwm2m/Kconfig
@@ -96,6 +96,7 @@ config LWM2M_RD_CLIENT_SUPPORT
 config LWM2M_RD_CLIENT_STACK_SIZE
 	int "LWM2M RD client stack size"
 	default 1024
+	default 1536 if NET_LOG_GLOBAL
 	help
 	  Set the stack size for the LWM2M RD client
 


### PR DESCRIPTION
The stack of rd client is exhausted while running lwm2m client w/ IPv6
and network log global enabled. Increase the stack size to 1536 when
NET_LOG_GLOBAL is enabled.

Fixes #4424

Signed-off-by: Robert Chou <robert.ch.chou@acer.com>