### PR TITLE
subsys: cdc_acm: Fix out of range endpoint addresses

### DIFF
--- a/subsys/usb/class/Kconfig
+++ b/subsys/usb/class/Kconfig
@@ -25,7 +25,8 @@ config CDC_ACM_PORT_NAME
 config CDC_ACM_INT_EP_ADDR
 	hex
 	depends on USB_CDC_ACM
-	default 0x85
+	default 0x85 if USB_COMPOSITE_DEVICE
+	default 0x81 if !USB_COMPOSITE_DEVICE
 	range 0x81 0x8f
 	help
 	CDC ACM class interrupt endpoint address
@@ -33,7 +34,8 @@ config CDC_ACM_INT_EP_ADDR
 config CDC_ACM_IN_EP_ADDR
 	hex
 	depends on USB_CDC_ACM
-	default 0x84
+	default 0x84 if USB_COMPOSITE_DEVICE
+	default 0x82 if !USB_COMPOSITE_DEVICE
 	range 0x81 0x8f
 	help
 	CDC ACM class IN endpoint address


### PR DESCRIPTION
Some USB controllers support only four endpoints, causing cdc_acm
sample failure with out of range cdc_acm ep addresses (0x84, 0x85).

This patch fixes this by using low addresses first in case we are
not configured as a composite USB device.

Ideally we should introduce a kind of endpoint autoconfiguration
to keep function driver hardware agnostic (e.g. introducing ep_alloc).
The function driver does not really care about the address.

Signed-off-by: Loic Poulain <loic.poulain@linaro.org>