### PR TITLE
net: ieee802154: Check reassembly return value properly

### DIFF
--- a/subsys/net/ip/l2/ieee802154/ieee802154.c
+++ b/subsys/net/ip/l2/ieee802154/ieee802154.c
@@ -140,7 +140,7 @@ enum net_verdict ieee802154_manage_recv_packet(struct net_if *iface,
 
 #ifdef CONFIG_NET_L2_IEEE802154_FRAGMENT
 	verdict = ieee802154_reassemble(pkt);
-	if (verdict == NET_DROP) {
+	if (verdict != NET_CONTINUE) {
 		goto out;
 	}
 #else


### PR DESCRIPTION
If IEEE 802.15.4 reassembly function ieee802154_reassemble() returns
anything other than NET_CONTINUE, then drop that packet. Earlier
it only dropped the packet if NET_DROP was returned but the reassembly
might also return NET_OK. In that case the pkt is freed already and
pkt->frags pointer is NULL. This caused NULL pointer access in L2 when
packet was received.

Fixes #4377

Signed-off-by: Jukka Rissanen <jukka.rissanen@linux.intel.com>
Signed-off-by: Ravi kumar Veeramally <ravikumar.veeramally@linux.intel.com>