### PR TITLE
net: ieee802154: Add more information when hexdumping the pkt

### DIFF
--- a/subsys/net/ip/l2/ieee802154/ieee802154.c
+++ b/subsys/net/ip/l2/ieee802154/ieee802154.c
@@ -31,13 +31,18 @@
 #include "ieee802154_security.h"
 #include "ieee802154_utils.h"
 
+#define PKT_TITLE      "IEEE 802.15.4 packet content:"
+#define TX_PKT_TITLE   "> " PKT_TITLE
+#define RX_PKT_TITLE   "< " PKT_TITLE
+
 #ifdef CONFIG_NET_DEBUG_L2_IEEE802154_DISPLAY_PACKET
 
 #include "net_private.h"
 
-static inline void pkt_hexdump(struct net_pkt *pkt, bool full)
+static inline void pkt_hexdump(const char *title, struct net_pkt *pkt,
+			       bool full)
 {
-	net_hexdump_frags("IEEE 802.15.4 packet content:", pkt, full);
+	net_hexdump_frags(title, pkt, full);
 }
 
 #else
@@ -153,7 +158,7 @@ enum net_verdict ieee802154_manage_recv_packet(struct net_if *iface,
 	net_pkt_ll_src(pkt)->addr = src ? net_pkt_ll(pkt) + src : NULL;
 	net_pkt_ll_dst(pkt)->addr = dst ? net_pkt_ll(pkt) + dst : NULL;
 
-	pkt_hexdump(pkt, false);
+	pkt_hexdump(RX_PKT_TITLE, pkt, false);
 out:
 	return verdict;
 }
@@ -163,7 +168,7 @@ static inline bool ieee802154_manage_send_packet(struct net_if *iface,
 {
 	bool ret;
 
-	pkt_hexdump(pkt, false);
+	pkt_hexdump(TX_PKT_TITLE " (before 6lo)", pkt, false);
 
 #ifdef CONFIG_NET_L2_IEEE802154_FRAGMENT
 	ret = net_6lo_compress(pkt, true, ieee802154_fragment);
@@ -171,7 +176,7 @@ static inline bool ieee802154_manage_send_packet(struct net_if *iface,
 	ret = net_6lo_compress(pkt, true, NULL);
 #endif
 
-	pkt_hexdump(pkt, false);
+	pkt_hexdump(TX_PKT_TITLE " (after 6lo)", pkt, false);
 
 	return ret;
 }
@@ -223,7 +228,7 @@ static enum net_verdict ieee802154_recv(struct net_if *iface,
 		return NET_DROP;
 	}
 
-	pkt_hexdump(pkt, true);
+	pkt_hexdump(RX_PKT_TITLE " (with ll)", pkt, true);
 
 	return ieee802154_manage_recv_packet(iface, pkt);
 }
@@ -259,7 +264,7 @@ static enum net_verdict ieee802154_send(struct net_if *iface,
 		frag = frag->frags;
 	}
 
-	pkt_hexdump(pkt, true);
+	pkt_hexdump(TX_PKT_TITLE " (with ll)", pkt, true);
 
 	net_if_queue_tx(iface, pkt);
 


### PR DESCRIPTION
When hexdumping the packet, print also information if we
received / transmitted packet. Also print information if the
hexdump is before compression or not.

Signed-off-by: Jukka Rissanen <jukka.rissanen@linux.intel.com>