### PR TITLE
base64 librariy for support mcuboot serial FWU 

### DIFF
--- a/dts/arm/nrf52840_pca10056.dts
+++ b/dts/arm/nrf52840_pca10056.dts
@@ -42,19 +42,19 @@
 
 		boot_partition: partition@0 {
 			label = "mcuboot";
-			reg = <0x000000000 0x00008000>;
+			reg = <0x000000000 0x0000C000>;
 		};
 		slot0_partition: partition@8000 {
 			label = "image-0";
-			reg = <0x00008000 0x00006c000>;
+			reg = <0x0000C000 0x000069000>;
 		};
 		slot1_partition: partition@74000 {
 			label = "image-1";
-			reg = <0x00074000 0x00006c000>;
+			reg = <0x00075000 0x000069000>;
 		};
 		scratch_partition: partition@e0000 {
 			label = "image-scratch";
-			reg = <0x000e0000 0x0001d000>;
+			reg = <0x000de000 0x0001e000>;
 		};
 
 		/*

--- a/ext/Kconfig
+++ b/ext/Kconfig
@@ -14,4 +14,6 @@ source "ext/lib/crypto/Kconfig"
 
 source "ext/debug/Kconfig"
 
+source "ext/lib/base64/Kconfig"
+
 endmenu

--- a/ext/lib/Kbuild
+++ b/ext/lib/Kbuild
@@ -1,1 +1,2 @@
 obj-y += crypto/
+obj-$(CONFIG_BASE64) += base64/

--- a/ext/lib/Makefile
+++ b/ext/lib/Makefile
@@ -10,3 +10,7 @@ endif
 ifdef CONFIG_MBEDTLS_LIBRARY
 include $(srctree)/ext/lib/crypto/mbedtls/Makefile
 endif
+
+ifdef CONFIG_BASE64
+ZEPHYRINCLUDE += -I$(srctree)/ext/lib/base64/include
+endif

--- a/ext/lib/base64/Kconfig
+++ b/ext/lib/base64/Kconfig
@@ -1,0 +1,16 @@
+# Kconfig - tinycbor library support configuration options
+#
+# Copyright (c) 2017 Nordic Semiconductor ASA
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+
+#
+# BASE64
+#
+
+config BASE64
+	bool
+	prompt "base64"
+	help
+	  Enable support for RFC 1521 base64 encoding/decoding.

--- a/ext/lib/base64/Makefile
+++ b/ext/lib/base64/Makefile
@@ -1,0 +1,1 @@
+obj-$(CONFIG_BASE64) += src/

--- a/ext/lib/base64/include/base64/base64.h
+++ b/ext/lib/base64/include/base64/base64.h
@@ -1,0 +1,40 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+#ifndef __UTIL_BASE64_H
+#define __UTIL_BASE64_H
+
+#include <stdint.h>
+#include <string.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+int base64_encode(const void *, int, char *, uint8_t);
+int base64_decode(const char *, void *buf);
+int base64_pad(char *, int);
+int base64_decode_len(const char *str);
+
+#define BASE64_ENCODE_SIZE(__size) (((((__size) - 1) / 3) * 4) + 4)
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* __UTIL_BASE64_H__ */

--- a/ext/lib/base64/include/base64/hex.h
+++ b/ext/lib/base64/include/base64/hex.h
@@ -1,0 +1,33 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+#ifndef _UTIL_HEX_H_
+#define _UTIL_HEX_H_
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+char *hex_format(void *src_v, int src_len, char *dst, int dst_len);
+int hex_parse(const char *src, int src_len, void *dst_v, int dst_len);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* _UTIL_HEX_H_ */

--- a/ext/lib/base64/src/Makefile
+++ b/ext/lib/base64/src/Makefile
@@ -1,0 +1,3 @@
+obj-$(CONFIG_BASE64) += base64.o hex.o
+
+ccflags-$(CONFIG_BASE64) += -I${ZEPHYR_BASE}/ext/lib/base64/include

--- a/ext/lib/base64/src/base64.c
+++ b/ext/lib/base64/src/base64.c
@@ -1,0 +1,181 @@
+/*
+ * This file is based on roken from the FreeBSD source.  It has been modified
+ * to not use malloc() and instead expect static buffers, and tabs have been
+ * replaced with spaces.  Also, instead of strlen() on the resulting string,
+ * pointer arithmitic is done, as p represents the end of the buffer.
+ */
+
+/*
+ * Copyright (c) 1995-2001 Kungliga Tekniska Högskolan
+ * (Royal Institute of Technology, Stockholm, Sweden).
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the Institute nor the names of its contributors
+ *    may be used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE INSTITUTE AND CONTRIBUTORS ``AS IS'' AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED.  IN NO EVENT SHALL THE INSTITUTE OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+ * SUCH DAMAGE.
+ */
+
+#include <stdlib.h>
+#include <string.h>
+
+#include <stdio.h>
+
+#include <base64/base64.h>
+
+static const char base64_chars[] =
+    "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/";
+
+static int
+pos(char c)
+{
+    const char *p;
+    for (p = base64_chars; *p; p++)
+        if (*p == c)
+            return p - base64_chars;
+    return -1;
+}
+
+int
+base64_encode(const void *data, int size, char *s, uint8_t should_pad)
+{
+    char *p;
+    int i;
+    int c;
+    const unsigned char *q;
+    char *last;
+    int diff;
+
+    p = s;
+
+    q = (const unsigned char *) data;
+    last = NULL;
+    i = 0;
+    while (i < size) {
+        c = q[i++];
+        c *= 256;
+        if (i < size)
+            c += q[i];
+        i++;
+        c *= 256;
+        if (i < size)
+            c += q[i];
+        i++;
+        p[0] = base64_chars[(c & 0x00fc0000) >> 18];
+        p[1] = base64_chars[(c & 0x0003f000) >> 12];
+        p[2] = base64_chars[(c & 0x00000fc0) >> 6];
+        p[3] = base64_chars[(c & 0x0000003f) >> 0];
+        last = p;
+        p += 4;
+    }
+
+    if (last) {
+        diff = i - size;
+        if (diff > 0) {
+            if (should_pad) {
+                memset(last + (4 - diff), '=', diff);
+            } else {
+                p = last + (4 - diff);
+            }
+        }
+    }
+
+    *p = 0;
+
+    return (p - s);
+}
+
+int
+base64_pad(char *buf, int len)
+{
+    int remainder;
+
+    remainder = len % 4;
+    if (remainder == 0) {
+        return (0);
+    }
+
+    memset(buf, '=', 4 - remainder);
+
+    return (4 - remainder);
+}
+
+#define DECODE_ERROR -1
+
+static unsigned int
+token_decode(const char *token)
+{
+    int i;
+    unsigned int val = 0;
+    int marker = 0;
+    if (strlen(token) < 4)
+        return DECODE_ERROR;
+    for (i = 0; i < 4; i++) {
+        val *= 64;
+        if (token[i] == '=')
+            marker++;
+        else if (marker > 0)
+            return DECODE_ERROR;
+        else
+            val += pos(token[i]);
+    }
+    if (marker > 2)
+        return DECODE_ERROR;
+    return (marker << 24) | val;
+}
+
+int
+base64_decode(const char *str, void *data)
+{
+    const char *p;
+    unsigned char *q;
+
+    q = data;
+    for (p = str; *p && (*p == '=' || strchr(base64_chars, *p)); p += 4) {
+        unsigned int val = token_decode(p);
+        unsigned int marker = (val >> 24) & 0xff;
+        if (val == DECODE_ERROR)
+            return -1;
+        *q++ = (val >> 16) & 0xff;
+        if (marker < 2)
+            *q++ = (val >> 8) & 0xff;
+        if (marker < 1)
+            *q++ = val & 0xff;
+    }
+    return q - (unsigned char *) data;
+}
+
+
+int
+base64_decode_len(const char *str)
+{
+    int len;
+
+    len = strlen(str);
+    while (len && str[len - 1] == '=') {
+        len--;
+    }
+    return len * 3 / 4;
+}

--- a/ext/lib/base64/src/hex.c
+++ b/ext/lib/base64/src/hex.c
@@ -1,0 +1,101 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+#include <inttypes.h>
+#include <ctype.h>
+#include <stddef.h>
+
+#include "base64/hex.h"
+
+static const char hex_bytes[] = "0123456789abcdef";
+
+/*
+ * Turn byte array into a printable array. I.e. "\x01" -> "01"
+ *
+ * @param src_v		Data to convert
+ * @param src_len	Number of bytes of input
+ * @param dst		String where to place the results
+ * @param dst_len	Size of the target string
+ *
+ * @return		Pointer to 'dst' if successful; NULL on failure
+ */
+char *
+hex_format(void *src_v, int src_len, char *dst, int dst_len)
+{
+    int i;
+    uint8_t *src = (uint8_t *)src_v;
+    char *tgt = dst;
+
+    if (dst_len <= src_len * 2) {
+        return NULL;
+    }
+    for (i = 0; i < src_len; i++) {
+        tgt[0] = hex_bytes[(src[i] >> 4) & 0xf];
+        tgt[1] = hex_bytes[src[i] & 0xf];
+        tgt += 2;
+        dst_len -= 2;
+    }
+    *tgt = '\0';
+    return dst;
+}
+
+/*
+ * Turn string of hex decimals into a byte array. I.e. "01" -> "\x01
+ *
+ * @param src		String to convert
+ * @param src_len	Number of bytes in input string
+ * @param dst_v		Memory location to place the result
+ * @param dst_len	Amount of space for the result
+ *
+ * @return		-1 on failure; number of bytes of input
+ */
+int
+hex_parse(const char *src, int src_len, void *dst_v, int dst_len)
+{
+    int i;
+    uint8_t *dst = (uint8_t *)dst_v;
+    char c;
+
+    if (src_len & 0x1) {
+        return -1;
+    }
+    if (dst_len * 2 < src_len) {
+        return -1;
+    }
+    for (i = 0; i < src_len; i++, src++) {
+        c = *src;
+        if (isdigit((int) c)) {
+            c -= '0';
+        } else if (c >= 'a' && c <= 'f') {
+            c -= ('a' - 10);
+        } else if (c >= 'A' && c <= 'F') {
+            c -= ('A' - 10);
+        } else {
+            return -1;
+        }
+        if (i & 1) {
+            *dst |= c;
+            dst++;
+            dst_len--;
+        } else {
+            *dst = c << 4;
+        }
+    }
+    return src_len >> 1;
+}


### PR DESCRIPTION
This patch introduce libraries which are need for support Mcuboot serial recovery mode.
These libraries are in usage by newtmgr protocol encoding and parsing. Mcuboot serial recovery protocol simply implements image related piece of newtmgr protocol.

Libraries:

    base64: base64 library

These libraries will be useful for future OTA DFU works as well.

As the serial recovery functionality consumes additional flash, the bootloader partition was extended as well for nRF52840 SoC.

Signed-off-by: Andrzej Puzdrowski andrzej.puzdrowski@nordicsemi.no