### PR TITLE
net: pkt: Use standard macros to define system pkt slabs/pools

### DIFF
--- a/include/net/net_pkt.h
+++ b/include/net/net_pkt.h
@@ -460,18 +460,33 @@ static inline void net_pkt_set_src_ipv6_addr(struct net_pkt *pkt)
 /* @endcond */
 
 /**
- * @brief Create a TX net_pkt slab that is used when sending user
- * specified data to network.
+ * @brief Create a net_pkt slab
  *
- * @param name Name of the pool.
+ * A net_pkt slab is used to store meta-information about
+ * network packets. It must be coupled with a data fragment pool
+ * (:c:macro:`NET_PKT_DATA_POOL_DEFINE`) used to store the actual
+ * packet data. The macro can be used by an application to define
+ * additional custom per-context TX packet slabs (see
+ * :c:func:`net_context_setup_pools`).
+ *
+ * @param name Name of the slab.
  * @param count Number of net_pkt in this slab.
  */
-#define NET_PKT_TX_SLAB_DEFINE(name, count)				\
+#define NET_PKT_SLAB_DEFINE(name, count)				\
 	K_MEM_SLAB_DEFINE(name, sizeof(struct net_pkt), count, 4)
 
+/* Backward compatibility macro */
+#define NET_PKT_TX_SLAB_DEFINE(name, count) NET_PKT_SLAB_DEFINE(name, count)
+
 /**
- * @brief Create a DATA net_buf pool that is used when sending user
- * specified data to network.
+ * @brief Create a data fragment net_buf pool
+ *
+ * A net_buf pool is used to store actual data for
+ * network packets. It must be coupled with a net_pkt slab
+ * (:c:macro:`NET_PKT_SLAB_DEFINE`) used to store the packet
+ * meta-information. The macro can be used by an application to
+ * define additional custom per-context TX packet pools (see
+ * :c:func:`net_context_setup_pools`).
  *
  * @param name Name of the pool.
  * @param count Number of net_buf in this pool.

--- a/subsys/net/ip/net_pkt.c
+++ b/subsys/net/ip/net_pkt.c
@@ -37,14 +37,6 @@
 
 #include "net_private.h"
 
-/* Available (free) buffers queue */
-#define NET_PKT_RX_COUNT	CONFIG_NET_PKT_RX_COUNT
-#define NET_PKT_TX_COUNT	CONFIG_NET_PKT_TX_COUNT
-#define NET_BUF_RX_COUNT	CONFIG_NET_BUF_RX_COUNT
-#define NET_BUF_TX_COUNT	CONFIG_NET_BUF_TX_COUNT
-#define NET_BUF_DATA_LEN	CONFIG_NET_BUF_DATA_SIZE
-#define NET_BUF_USER_DATA_LEN	CONFIG_NET_BUF_USER_DATA_SIZE
-
 #if defined(CONFIG_NET_TCP)
 #define APP_PROTO_LEN NET_TCPH_LEN
 #else
@@ -71,7 +63,7 @@
  * fragment. This makes possible to cast a protocol header
  * struct into memory area.
  */
-#if NET_BUF_DATA_LEN < (IP_PROTO_LEN + APP_PROTO_LEN)
+#if CONFIG_NET_BUF_DATA_SIZE < (IP_PROTO_LEN + APP_PROTO_LEN)
 #if defined(STRING2)
 #undef STRING2
 #endif
@@ -80,20 +72,17 @@
 #endif
 #define STRING2(x) #x
 #define STRING(x) STRING2(x)
-#pragma message "Data len " STRING(NET_BUF_DATA_LEN)
+#pragma message "Data len " STRING(CONFIG_NET_BUF_DATA_SIZE)
 #pragma message "Minimum len " STRING(IP_PROTO_LEN + APP_PROTO_LEN)
 #error "Too small net_buf fragment size"
 #endif
 
-K_MEM_SLAB_DEFINE(rx_pkts, sizeof(struct net_pkt), NET_PKT_RX_COUNT, 4);
-K_MEM_SLAB_DEFINE(tx_pkts, sizeof(struct net_pkt), NET_PKT_TX_COUNT, 4);
+NET_PKT_SLAB_DEFINE(rx_pkts, CONFIG_NET_PKT_RX_COUNT);
+NET_PKT_SLAB_DEFINE(tx_pkts, CONFIG_NET_PKT_TX_COUNT);
 
 /* The data fragment pool is for storing network data. */
-NET_BUF_POOL_DEFINE(rx_bufs, NET_BUF_RX_COUNT, NET_BUF_DATA_LEN,
-		    NET_BUF_USER_DATA_LEN, NULL);
-
-NET_BUF_POOL_DEFINE(tx_bufs, NET_BUF_TX_COUNT, NET_BUF_DATA_LEN,
-		    NET_BUF_USER_DATA_LEN, NULL);
+NET_PKT_DATA_POOL_DEFINE(rx_bufs, CONFIG_NET_BUF_RX_COUNT);
+NET_PKT_DATA_POOL_DEFINE(tx_bufs, CONFIG_NET_BUF_TX_COUNT);
 
 #if defined(CONFIG_NET_DEBUG_NET_PKT)
 
@@ -119,8 +108,10 @@ struct net_pkt_alloc {
 	bool is_pkt;
 };
 
-#define MAX_NET_PKT_ALLOCS (NET_PKT_RX_COUNT + NET_PKT_TX_COUNT + \
-			    NET_BUF_RX_COUNT + NET_BUF_TX_COUNT + \
+#define MAX_NET_PKT_ALLOCS (CONFIG_NET_PKT_RX_COUNT + \
+			    CONFIG_NET_PKT_TX_COUNT + \
+			    CONFIG_NET_BUF_RX_COUNT + \
+			    CONFIG_NET_BUF_TX_COUNT + \
 			    CONFIG_NET_DEBUG_NET_PKT_EXTERNALS)
 
 static struct net_pkt_alloc net_pkt_allocs[MAX_NET_PKT_ALLOCS];


### PR DESCRIPTION
Previously net_pkt.h, defined macros NET_PKT_TX_SLAB_DEFINE,
NET_PKT_DATA_POOL_DEFINE, but advertised them as intended for
"user specified data". However, net_pkt.c effectively used the
same parameters for slabs/pools, but this wasn't obvious due
to extra config param redirection. So, make following changes:

1. Rename NET_PKT_TX_SLAB_DEFINE() to NET_PKT_SLAB_DEFINE()
as nothing in its definition is TX-specific.
2. Remove extra indirection for config params, and use
NET_PKT_SLAB_DEFINE and NET_PKT_DATA_POOL_DEFINE to define
system pools.
3. Update docstrings for NET_PKT_SLAB_DEFINE and
NET_PKT_DATA_POOL_DEFINE.

Overall, this change removes vail of magic in the definition of
system pkt slabs/pools, making obvious the fact that any packet
slabs/pools - whether default system or additional, custom - are
defined in exactly the same manner (and thus work in the same manner
too).

Fixes #4327

Signed-off-by: Paul Sokolovsky <paul.sokolovsky@linaro.org>