### PR TITLE
net: coap: parse_option() exit gracefully when no payload

### DIFF
--- a/subsys/net/lib/coap/coap.c
+++ b/subsys/net/lib/coap/coap.c
@@ -130,7 +130,7 @@ static int parse_option(const struct coap_packet *cpkt,
 	opt_len = 1;
 
 	/* This indicates that options have ended */
-	if (opt == COAP_MARKER) {
+	if (context->offset == 0 || opt == COAP_MARKER) {
 		return 0;
 	}
 


### PR DESCRIPTION
Instead of generating an EINVAL error when there's no payload let's
check for an offset == 0 and exit gracefully.

Signed-off-by: Michael Scott <michael.scott@linaro.org>