### PR TITLE
LwM2M migrate to new CoAP API

### DIFF
--- a/include/net/lwm2m.h
+++ b/include/net/lwm2m.h
@@ -8,7 +8,7 @@
 #define __LWM2M_H__
 
 #include <net/net_app.h>
-#include <net/zoap.h>
+#include <net/coap.h>
 
 /* LWM2M Objects defined by OMA */
 
@@ -52,9 +52,9 @@ struct lwm2m_ctx {
 	net_pkt_get_pool_func_t data_pool;
 #endif /* CONFIG_NET_CONTEXT_NET_PKT_POOL */
 
-	/** Private ZoAP and networking structures */
-	struct zoap_pending pendings[CONFIG_LWM2M_ENGINE_MAX_PENDING];
-	struct zoap_reply replies[CONFIG_LWM2M_ENGINE_MAX_REPLIES];
+	/** Private CoAP and networking structures */
+	struct coap_pending pendings[CONFIG_LWM2M_ENGINE_MAX_PENDING];
+	struct coap_reply replies[CONFIG_LWM2M_ENGINE_MAX_REPLIES];
 	struct k_delayed_work retransmit_work;
 };
 

--- a/subsys/net/lib/lwm2m/Kconfig
+++ b/subsys/net/lib/lwm2m/Kconfig
@@ -7,7 +7,8 @@
 menuconfig LWM2M
 	bool "OMA LWM2M protocol stack"
 	default n
-	select ZOAP
+	select COAP
+	select COAP_EXTENDED_OPTIONS_LEN
 	select NET_APP_CLIENT
 	select HTTP_PARSER_URL
 	help

--- a/subsys/net/lib/lwm2m/lwm2m_engine.c
+++ b/subsys/net/lib/lwm2m/lwm2m_engine.c
@@ -2448,10 +2448,11 @@ static int handle_request(struct coap_packet *request,
 		if (path.level < 2) {
 			/* write/create a object instance */
 			context.operation = LWM2M_OP_CREATE;
+			msg->code = COAP_RESPONSE_CODE_CREATED;
 		} else {
 			context.operation = LWM2M_OP_EXECUTE;
+			msg->code = COAP_RESPONSE_CODE_CHANGED;
 		}
-		msg->code = COAP_RESPONSE_CODE_CHANGED;
 		break;
 
 	case COAP_METHOD_PUT:

--- a/subsys/net/lib/lwm2m/lwm2m_engine.h
+++ b/subsys/net/lib/lwm2m/lwm2m_engine.h
@@ -25,8 +25,8 @@
 #define LWM2M_FORMAT_OMA_JSON		11543
 
 
-#define ZOAP_RESPONSE_CODE_CLASS(x)	(x >> 5)
-#define ZOAP_RESPONSE_CODE_DETAIL(x)	(x & 0x1F)
+#define COAP_RESPONSE_CODE_CLASS(x)	(x >> 5)
+#define COAP_RESPONSE_CODE_DETAIL(x)	(x & 0x1F)
 
 /* TODO: */
 #define NOTIFY_OBSERVER(o, i, r)	lwm2m_notify_observer(o, i, r)
@@ -45,16 +45,16 @@ struct lwm2m_message {
 	/** LwM2M context related to this message */
 	struct lwm2m_ctx *ctx;
 
-	/** ZoAP packet data related to this message */
-	struct zoap_packet zpkt;
+	/** CoAP packet data related to this message */
+	struct coap_packet cpkt;
 
 	/** Message transmission handling for TYPE_CON */
-	struct zoap_pending *pending;
-	struct zoap_reply *reply;
+	struct coap_pending *pending;
+	struct coap_reply *reply;
 
 	/** Message configuration */
-	const u8_t *token;
-	zoap_reply_t reply_cb;
+	u8_t *token;
+	coap_reply_t reply_cb;
 	lwm2m_message_timeout_cb_t message_timeout_cb;
 	u16_t mid;
 	u8_t type;
@@ -66,7 +66,7 @@ struct lwm2m_message {
 };
 
 /* Establish a request handler callback type */
-typedef int (*udp_request_handler_cb_t)(struct zoap_packet *request,
+typedef int (*udp_request_handler_cb_t)(struct coap_packet *request,
 					struct lwm2m_message *msg);
 
 char *lwm2m_sprint_ip_addr(const struct sockaddr *addr);
@@ -101,11 +101,16 @@ int lwm2m_write_handler(struct lwm2m_engine_obj_inst *obj_inst,
 			struct lwm2m_engine_obj_field *obj_field,
 			struct lwm2m_engine_context *context);
 
+/* CoAP payload functions */
+u8_t *coap_packet_get_payload_ptr(struct coap_packet *cpkt, u16_t *len,
+				  bool start_marker);
+int coap_packet_set_used(struct coap_packet *cpkt, u16_t len);
+
 void lwm2m_udp_receive(struct lwm2m_ctx *client_ctx, struct net_pkt *pkt,
 		       bool handle_separate_response,
 		       udp_request_handler_cb_t udp_request_handler);
 
-enum zoap_block_size lwm2m_default_block_size(void);
+enum coap_block_size lwm2m_default_block_size(void);
 
 #if defined(CONFIG_LWM2M_FIRMWARE_UPDATE_OBJ_SUPPORT)
 u8_t lwm2m_firmware_get_update_state(void);

--- a/subsys/net/lib/lwm2m/lwm2m_engine.h
+++ b/subsys/net/lib/lwm2m/lwm2m_engine.h
@@ -90,7 +90,7 @@ void lwm2m_engine_context_init(struct lwm2m_ctx *client_ctx);
 
 /* LwM2M message functions */
 struct lwm2m_message *lwm2m_get_message(struct lwm2m_ctx *client_ctx);
-void lwm2m_release_message(struct lwm2m_message *msg);
+void lwm2m_reset_message(struct lwm2m_message *msg, bool release);
 int lwm2m_init_message(struct lwm2m_message *msg);
 int lwm2m_send_message(struct lwm2m_message *msg);
 

--- a/subsys/net/lib/lwm2m/lwm2m_obj_firmware.c
+++ b/subsys/net/lib/lwm2m/lwm2m_obj_firmware.c
@@ -7,7 +7,7 @@
 #define SYS_LOG_DOMAIN "lwm2m_obj_firmware"
 #define SYS_LOG_LEVEL CONFIG_SYS_LOG_LWM2M_LEVEL
 #include <logging/sys_log.h>
-#include <net/zoap.h>
+#include <net/coap.h>
 #include <string.h>
 #include <init.h>
 

--- a/subsys/net/lib/lwm2m/lwm2m_obj_firmware_pull.c
+++ b/subsys/net/lib/lwm2m/lwm2m_obj_firmware_pull.c
@@ -166,7 +166,7 @@ static int transfer_request(struct coap_block_context *ctx,
 	return 0;
 
 cleanup:
-	lwm2m_release_message(msg);
+	lwm2m_reset_message(msg, true);
 
 	if (ret == -ENOMEM) {
 		lwm2m_firmware_set_update_result(RESULT_OUT_OF_MEM);
@@ -207,7 +207,7 @@ static int transfer_empty_ack(u16_t mid)
 	return 0;
 
 cleanup:
-	lwm2m_release_message(msg);
+	lwm2m_reset_message(msg, true);
 	return ret;
 }
 

--- a/subsys/net/lib/lwm2m/lwm2m_object.h
+++ b/subsys/net/lib/lwm2m/lwm2m_object.h
@@ -47,7 +47,7 @@
 #include <zephyr/types.h>
 #include <stddef.h>
 #include <net/net_ip.h>
-#include <net/zoap.h>
+#include <net/coap.h>
 #include <net/lwm2m.h>
 #include <misc/printk.h>
 #include <kernel.h>
@@ -204,7 +204,7 @@ struct lwm2m_engine_obj_inst {
 };
 
 struct lwm2m_output_context {
-	struct zoap_packet *out_zpkt;
+	struct coap_packet *out_cpkt;
 	u8_t writer_flags;	/* flags for reader/writer */
 	u8_t *outbuf;
 	u16_t outsize;
@@ -214,7 +214,7 @@ struct lwm2m_output_context {
 };
 
 struct lwm2m_input_context {
-	struct zoap_packet *in_zpkt;
+	struct coap_packet *in_cpkt;
 	u8_t *inbuf;
 	u16_t insize;
 	s32_t inpos;

--- a/subsys/net/lib/lwm2m/lwm2m_rd_client.c
+++ b/subsys/net/lib/lwm2m/lwm2m_rd_client.c
@@ -556,7 +556,7 @@ static int sm_do_bootstrap(int index)
 	return 0;
 
 cleanup:
-	lwm2m_release_message(msg);
+	lwm2m_reset_message(msg, true);
 	return ret;
 }
 
@@ -701,7 +701,7 @@ static int sm_send_registration(int index, bool send_obj_support_data,
 	return 0;
 
 cleanup:
-	lwm2m_release_message(msg);
+	lwm2m_reset_message(msg, true);
 	return ret;
 }
 
@@ -792,7 +792,7 @@ static int sm_do_deregister(int index)
 	return 0;
 
 cleanup:
-	lwm2m_release_message(msg);
+	lwm2m_reset_message(msg, true);
 	return ret;
 }
 

--- a/subsys/net/lib/lwm2m/lwm2m_rw_oma_tlv.c
+++ b/subsys/net/lib/lwm2m/lwm2m_rw_oma_tlv.c
@@ -716,8 +716,8 @@ int do_write_op_tlv(struct lwm2m_engine_obj *obj,
 				pos += len2;
 			}
 
-			zoap_header_set_code(context->out->out_zpkt,
-					     ZOAP_RESPONSE_CODE_CREATED);
+			/* TODO: Fix me */
+			/* context->out->out_msg->code = COAP_RESPONSE_CODE_CREATED; */
 		} else if (tlv.type == OMA_TLV_TYPE_RESOURCE) {
 			path->res_id = tlv.id;
 			path->level = 3;

--- a/subsys/net/lib/lwm2m/lwm2m_rw_oma_tlv.c
+++ b/subsys/net/lib/lwm2m/lwm2m_rw_oma_tlv.c
@@ -715,9 +715,6 @@ int do_write_op_tlv(struct lwm2m_engine_obj *obj,
 
 				pos += len2;
 			}
-
-			/* TODO: Fix me */
-			/* context->out->out_msg->code = COAP_RESPONSE_CODE_CREATED; */
 		} else if (tlv.type == OMA_TLV_TYPE_RESOURCE) {
 			path->res_id = tlv.id;
 			path->level = 3;


### PR DESCRIPTION
This patch moves from the ZoAP API in subsys/net/lib/zoap to
the CoAP API in subsys/net/lib/coap which handles multiple
fragments for sending / receiving data.

NOTE: This patch moves the LwM2M library over to the CoAP APIs
but there will be a follow-up patch which re-writes the content
formatter reader / writers to use net_pkt APIs for parsing
across multiple net buffers. The current implementation assumes
all of the data will land in 1 buffer.

Samples using the library still need a fairly large NET_BUF_DATA_SIZE
setting. (Example: CONFIG_NET_BUF_DATA_SIZE=384)