### PR TITLE
LwM2M: content formatter cleanups

### DIFF
--- a/subsys/net/lib/lwm2m/lwm2m_engine.c
+++ b/subsys/net/lib/lwm2m/lwm2m_engine.c
@@ -1488,9 +1488,9 @@ static int lwm2m_engine_get(char *pathstr, void *buf, u16_t buflen)
 	return 0;
 }
 
-int lwm2m_engine_get_string(char *pathstr, void *str, u16_t strlen)
+int lwm2m_engine_get_string(char *pathstr, void *buf, u16_t buflen)
 {
-	return lwm2m_engine_get(pathstr, str, strlen);
+	return lwm2m_engine_get(pathstr, buf, buflen);
 }
 
 u8_t lwm2m_engine_get_u8(char *pathstr)

--- a/subsys/net/lib/lwm2m/lwm2m_object.h
+++ b/subsys/net/lib/lwm2m/lwm2m_object.h
@@ -218,7 +218,6 @@ struct lwm2m_input_context {
 	u8_t *inbuf;
 	u16_t insize;
 	s32_t inpos;
-	u16_t last_value_len;
 	const struct lwm2m_reader *reader;
 };
 

--- a/subsys/net/lib/lwm2m/lwm2m_object.h
+++ b/subsys/net/lib/lwm2m/lwm2m_object.h
@@ -246,7 +246,7 @@ struct lwm2m_writer {
 			  s64_t value);
 	size_t (*put_string)(struct lwm2m_output_context *out,
 			     struct lwm2m_obj_path *path,
-			     const char *value, size_t strlen);
+			     char *buf, size_t buflen);
 	size_t (*put_float32fix)(struct lwm2m_output_context *out,
 				 struct lwm2m_obj_path *path,
 				 float32_value_t *value);
@@ -264,7 +264,7 @@ struct lwm2m_reader {
 	size_t (*get_s64)(struct lwm2m_input_context *in,
 			  s64_t *value);
 	size_t (*get_string)(struct lwm2m_input_context *in,
-			     u8_t *value, size_t strlen);
+			     u8_t *buf, size_t buflen);
 	size_t (*get_float32fix)(struct lwm2m_input_context *in,
 				 float32_value_t *value);
 	size_t (*get_float64fix)(struct lwm2m_input_context *in,
@@ -353,9 +353,9 @@ static inline size_t engine_put_s64(struct lwm2m_output_context *out,
 
 static inline size_t engine_put_string(struct lwm2m_output_context *out,
 				       struct lwm2m_obj_path *path,
-				       const char *value, size_t strlen)
+				       char *buf, size_t buflen)
 {
-	return out->writer->put_string(out, path, value, strlen);
+	return out->writer->put_string(out, path, buf, buflen);
 }
 
 static inline size_t engine_put_float32fix(struct lwm2m_output_context *out,
@@ -392,9 +392,9 @@ static inline size_t engine_get_s64(struct lwm2m_input_context *in,
 }
 
 static inline size_t engine_get_string(struct lwm2m_input_context *in,
-				       u8_t *value, size_t strlen)
+				       u8_t *buf, size_t buflen)
 {
-	return in->reader->get_string(in, value, strlen);
+	return in->reader->get_string(in, buf, buflen);
 }
 
 static inline size_t engine_get_float32fix(struct lwm2m_input_context *in,

--- a/subsys/net/lib/lwm2m/lwm2m_rw_json.c
+++ b/subsys/net/lib/lwm2m/lwm2m_rw_json.c
@@ -85,6 +85,13 @@
 #define MODE_VALUE     2
 #define MODE_READY     3
 
+struct json_data {
+	u8_t *name;
+	u8_t *value;
+	u8_t name_len;
+	u8_t value_len;
+};
+
 /* Simlified JSON style reader for reading in values from a LWM2M JSON string */
 int json_next_token(struct lwm2m_input_context *in, struct json_data *json)
 {

--- a/subsys/net/lib/lwm2m/lwm2m_rw_json.c
+++ b/subsys/net/lib/lwm2m/lwm2m_rw_json.c
@@ -64,6 +64,7 @@
 #include <stddef.h>
 #include <stdint.h>
 #include <inttypes.h>
+#include <ctype.h>
 
 #include "lwm2m_object.h"
 #include "lwm2m_rw_json.h"
@@ -527,7 +528,7 @@ static int parse_path(const u8_t *buf, u16_t buflen,
 		val = 0;
 		c = buf[pos];
 		/* we should get a value first - consume all numbers */
-		while (pos < buflen && c >= '0' && c <= '9') {
+		while (pos < buflen && isdigit(c)) {
 			val = val * 10 + (c - '0');
 			c = buf[++pos];
 		}

--- a/subsys/net/lib/lwm2m/lwm2m_rw_json.c
+++ b/subsys/net/lib/lwm2m/lwm2m_rw_json.c
@@ -73,10 +73,9 @@
 #define T_NONE		0
 #define T_STRING_B	1
 #define T_STRING	2
-#define T_NAME		4
-#define T_VNUM		5
-#define T_OBJ		6
-#define T_VAL		7
+#define T_NAME		3
+#define T_OBJ		4
+#define T_VAL		5
 
 #define SEPARATOR(f)	((f & WRITER_OUTPUT_VALUE) ? "," : "")
 

--- a/subsys/net/lib/lwm2m/lwm2m_rw_json.h
+++ b/subsys/net/lib/lwm2m/lwm2m_rw_json.h
@@ -44,17 +44,7 @@
 
 #include "lwm2m_object.h"
 
-struct json_data {
-	u8_t type; /* S,B,V */
-	u8_t *name;
-	u8_t *value;
-	u8_t name_len;
-	u8_t value_len;
-};
-
 extern const struct lwm2m_writer json_writer;
-
-int json_next_token(struct lwm2m_input_context *in, struct json_data *json);
 
 int do_write_op_json(struct lwm2m_engine_obj *obj,
 		     struct lwm2m_engine_context *context);

--- a/subsys/net/lib/lwm2m/lwm2m_rw_oma_tlv.c
+++ b/subsys/net/lib/lwm2m/lwm2m_rw_oma_tlv.c
@@ -436,8 +436,6 @@ static size_t get_s32(struct lwm2m_input_context *in, s32_t *value)
 			size = 0;
 			tlv.length = 0;
 		}
-
-		in->last_value_len = tlv.length;
 	}
 
 	return size;
@@ -469,8 +467,6 @@ static size_t get_s64(struct lwm2m_input_context *in, s64_t *value)
 			size = 0;
 			tlv.length = 0;
 		}
-
-		in->last_value_len = tlv.length;
 	}
 
 	return size;
@@ -493,7 +489,6 @@ static size_t get_string(struct lwm2m_input_context *in,
 
 		memcpy(buf, tlv.value, tlv.length);
 		buf[tlv.length] = '\0';
-		in->last_value_len = tlv.length;
 	}
 
 	return size;
@@ -541,7 +536,6 @@ static size_t get_float32fix(struct lwm2m_input_context *in,
 		 * HACK BELOW: hard code the decimal value 0
 		 */
 		value->val2 = 0;
-		in->last_value_len = tlv.length;
 	}
 
 	return size;
@@ -560,8 +554,6 @@ static size_t get_float64fix(struct lwm2m_input_context *in,
 		}
 
 		/* TODO */
-
-		in->last_value_len = tlv.length;
 	}
 
 	return size;
@@ -580,7 +572,6 @@ static size_t get_bool(struct lwm2m_input_context *in, bool *value)
 			temp = (temp << 8) | tlv.value[i];
 		}
 		*value = (temp != 0);
-		in->last_value_len = tlv.length;
 	}
 
 	return size;

--- a/subsys/net/lib/lwm2m/lwm2m_rw_oma_tlv.c
+++ b/subsys/net/lib/lwm2m/lwm2m_rw_oma_tlv.c
@@ -66,6 +66,20 @@
 #include "lwm2m_rw_oma_tlv.h"
 #include "lwm2m_engine.h"
 
+enum {
+	OMA_TLV_TYPE_OBJECT_INSTANCE   = 0,
+	OMA_TLV_TYPE_RESOURCE_INSTANCE = 1,
+	OMA_TLV_TYPE_MULTI_RESOURCE    = 2,
+	OMA_TLV_TYPE_RESOURCE          = 3
+};
+
+struct oma_tlv {
+	u8_t  type;
+	u16_t id; /* can be 8-bit or 16-bit when serialized */
+	u32_t length;
+	const u8_t *value;
+};
+
 static u8_t get_len_type(const struct oma_tlv *tlv)
 {
 	if (tlv->length < 8) {

--- a/subsys/net/lib/lwm2m/lwm2m_rw_oma_tlv.h
+++ b/subsys/net/lib/lwm2m/lwm2m_rw_oma_tlv.h
@@ -43,31 +43,7 @@
 #ifndef LWM2M_RW_OMA_TLV_H_
 #define LWM2M_RW_OMA_TLV_H_
 
-#include <stdint.h>
-#include <stddef.h>
-
 #include "lwm2m_object.h"
-
-enum {
-	OMA_TLV_TYPE_OBJECT_INSTANCE   = 0,
-	OMA_TLV_TYPE_RESOURCE_INSTANCE = 1,
-	OMA_TLV_TYPE_MULTI_RESOURCE    = 2,
-	OMA_TLV_TYPE_RESOURCE          = 3
-};
-
-enum {
-	OMA_TLV_LEN_TYPE_NO_LEN    = 0,
-	OMA_TLV_LEN_TYPE_8BIT_LEN  = 1,
-	OMA_TLV_LEN_TYPE_16BIT_LEN = 2,
-	OMA_TLV_LEN_TYPE_24BIT_LEN = 3
-};
-
-struct oma_tlv {
-	u8_t  type;
-	u16_t id; /* can be 8-bit or 16-bit when serialized */
-	u32_t length;
-	const u8_t *value;
-};
 
 extern const struct lwm2m_writer oma_tlv_writer;
 extern const struct lwm2m_reader oma_tlv_reader;

--- a/subsys/net/lib/lwm2m/lwm2m_rw_plain_text.c
+++ b/subsys/net/lib/lwm2m/lwm2m_rw_plain_text.c
@@ -237,7 +237,6 @@ static size_t get_s32(struct lwm2m_input_context *in, s32_t *value)
 		*value = -*value;
 	}
 
-	in->last_value_len = i;
 	return i;
 }
 
@@ -261,7 +260,6 @@ static size_t get_s64(struct lwm2m_input_context *in, s64_t *value)
 		*value = -*value;
 	}
 
-	in->last_value_len = i;
 	return i;
 }
 
@@ -275,7 +273,6 @@ static size_t get_string(struct lwm2m_input_context *in,
 
 	memcpy(value, in->inbuf, in->insize);
 	value[in->insize] = '\0';
-	in->last_value_len = in->insize;
 	return in->insize;
 }
 
@@ -314,7 +311,6 @@ static size_t get_float32fix(struct lwm2m_input_context *in,
 		value->val1 = -value->val1;
 	}
 
-	in->last_value_len = i;
 	return i;
 }
 
@@ -353,7 +349,6 @@ static size_t get_float64fix(struct lwm2m_input_context *in,
 		value->val1 = -value->val1;
 	}
 
-	in->last_value_len = i;
 	return i;
 }
 
@@ -363,7 +358,6 @@ static size_t get_bool(struct lwm2m_input_context *in,
 	if (in->insize > 0) {
 		if (*in->inbuf == '1' || *in->inbuf == '0') {
 			*value = (*in->inbuf == '1') ? true : false;
-			in->last_value_len = 1;
 			return 1;
 		}
 	}

--- a/subsys/net/lib/lwm2m/lwm2m_rw_plain_text.c
+++ b/subsys/net/lib/lwm2m/lwm2m_rw_plain_text.c
@@ -187,16 +187,16 @@ static size_t put_float64fix(struct lwm2m_output_context *out,
 
 static size_t put_string(struct lwm2m_output_context *out,
 			 struct lwm2m_obj_path *path,
-			 const char *value, size_t strlen)
+			 char *buf, size_t buflen)
 {
-	if (strlen >= (out->outsize - out->outlen)) {
+	if (buflen >= (out->outsize - out->outlen)) {
 		return 0;
 	}
 
-	memmove(&out->outbuf[out->outlen], value, strlen);
-	out->outbuf[strlen] = '\0';
-	out->outlen += strlen;
-	return strlen;
+	memmove(&out->outbuf[out->outlen], buf, buflen);
+	out->outbuf[buflen] = '\0';
+	out->outlen += buflen;
+	return buflen;
 }
 
 static size_t put_bool(struct lwm2m_output_context *out,
@@ -266,10 +266,10 @@ static size_t get_s64(struct lwm2m_input_context *in, s64_t *value)
 }
 
 static size_t get_string(struct lwm2m_input_context *in,
-			 u8_t *value, size_t strlen)
+			 u8_t *value, size_t buflen)
 {
 	/* The outbuffer can't contain the full string including ending zero */
-	if (strlen <= in->insize) {
+	if (buflen <= in->insize) {
 		return 0;
 	}
 


### PR DESCRIPTION
This patch series includes a set of cleanup patches to content formatter code.
- Naming in the formatter functions was often confusing such as parameters called "strlen"
- Cleaning up unused defines and structure members
- Use cytpe.h functions like isdigit() when appropriate
- Data that was exposed in semi-public .h files but never used externally move back into source .c files