### PR TITLE
scripts: Fix ESP_TOOL detection in zephyr_flash_debug.py

### DIFF
--- a/scripts/support/zephyr_flash_debug.py
+++ b/scripts/support/zephyr_flash_debug.py
@@ -340,7 +340,7 @@ class Esp32BinaryFlasher(ZephyrBinaryFlasher):
     '''Flasher front-end for espidf.'''
 
     def __init__(self, elf, device, baud=921600, flash_size='detect',
-                 flash_freq='40m', flash_mode='dio', espdif='espidf',
+                 flash_freq='40m', flash_mode='dio', espidf='espidf',
                  debug=False):
         super(Esp32BinaryFlasher, self).__init__(debug=debug)
         self.elf = elf
@@ -349,7 +349,7 @@ class Esp32BinaryFlasher(ZephyrBinaryFlasher):
         self.flash_size = flash_size
         self.flash_freq = flash_freq
         self.flash_mode = flash_mode
-        self.espdif = espdif
+        self.espidf = espidf
 
     def replaces_shell_script(shell_script):
         return shell_script == 'esp32.sh'
@@ -369,7 +369,7 @@ class Esp32BinaryFlasher(ZephyrBinaryFlasher):
         - ESP_FLASH_SIZE: flash size, default 'detect'
         - ESP_FLASH_FREQ: flash frequency, default '40m'
         - ESP_FLASH_MODE: flash mode, default 'dio'
-        - ESP_TOOL: complete path to espdif, or set to 'espidf' to look for it
+        - ESP_TOOL: complete path to espidf, or set to 'espidf' to look for it
           in $ESP_IDF_PATH/components/esptool_py/esptool/esptool.py
         '''
         elf = path.join(get_env_or_bail('O'),
@@ -381,22 +381,22 @@ class Esp32BinaryFlasher(ZephyrBinaryFlasher):
         flash_size = os.environ.get('ESP_FLASH_SIZE', 'detect')
         flash_freq = os.environ.get('ESP_FLASH_FREQ', '40m')
         flash_mode = os.environ.get('ESP_FLASH_MODE', 'dio')
-        espdif = os.environ.get('ESP_TOOL', 'espidf')
+        espidf = os.environ.get('ESP_TOOL', 'espidf')
 
-        if espdif == 'espdif':
+        if espidf == 'espidf':
             idf_path = get_env_or_bail('ESP_IDF_PATH')
-            espdif = path.join(idf_path, 'components', 'esptool_py', 'esptool',
+            espidf = path.join(idf_path, 'components', 'esptool_py', 'esptool',
                                'esptool.py')
 
         return Esp32BinaryFlasher(elf, device, baud=baud,
                                   flash_size=flash_size, flash_freq=flash_freq,
-                                  flash_mode=flash_mode, espdif=espdif,
+                                  flash_mode=flash_mode, espidf=espidf,
                                   debug=debug)
 
     def flash(self, **kwargs):
         bin_name = path.splitext(self.elf)[0] + path.extsep + 'bin'
-        cmd_convert = [self.espdif, '--chip', 'esp32', 'elf2image', self.elf]
-        cmd_flash = [self.espdif, '--chip', 'esp32', '--port', self.device,
+        cmd_convert = [self.espidf, '--chip', 'esp32', 'elf2image', self.elf]
+        cmd_flash = [self.espidf, '--chip', 'esp32', '--port', self.device,
                      '--baud', self.baud, '--before', 'default_reset',
                      '--after', 'hard_reset', 'write_flash', '-u',
                      '--flash_mode', self.flash_mode,


### PR DESCRIPTION
`espidf` was written as `espdif`, causing auto-detection to fail.

Signed-off-by: Leandro Pereira <leandro.pereira@intel.com>