### PR TITLE
kernel: Compare pointers before strings when getting device binding

### DIFF
--- a/kernel/device.c
+++ b/kernel/device.c
@@ -61,7 +61,15 @@ struct device *device_get_binding(const char *name)
 	struct device *info;
 
 	for (info = __device_init_start; info != __device_init_end; info++) {
-		if (info->driver_api && !strcmp(name, info->config->name)) {
+		if (!info->driver_api) {
+			continue;
+		}
+
+		if (name == info->config->name) {
+			return info;
+		}
+
+		if (!strcmp(name, info->config->name)) {
 			return info;
 		}
 	}


### PR DESCRIPTION
Most calls to device_get_binding() will pass named constants generated
by Kconfig; these constants will all point to the same place, so
compare the pointer before attempting to match the whole string.

Signed-off-by: Leandro Pereira <leandro.pereira@intel.com>