### PR TITLE
drivers: i2c: esp32: Fix crash when enabling second I2C device

### DIFF
--- a/drivers/i2c/i2c_esp32.c
+++ b/drivers/i2c/i2c_esp32.c
@@ -650,7 +650,7 @@ DEVICE_DECLARE(i2c_esp32_1);
 
 static void i2c_esp32_connect_irq_1(void)
 {
-	IRQ_CONNECT(CONFIG_I2C_ESP32_0_IRQ, 1, i2c_esp32_isr,
+	IRQ_CONNECT(CONFIG_I2C_ESP32_1_IRQ, 1, i2c_esp32_isr,
 		    DEVICE_GET(i2c_esp32_1), 0);
 }
 


### PR DESCRIPTION
IRQ_CONNECT() was being expanded with the IRQ line for the first device
twice, causing spurious IRQs.

Should fix #4398.

Signed-off-by: Leandro Pereira <leandro.pereira@intel.com>