### PR TITLE
Makefile.qemu: Support running net tests without host TAP connection

### DIFF
--- a/scripts/Makefile.qemu
+++ b/scripts/Makefile.qemu
@@ -26,4 +26,8 @@ run: zephyr
 	$(if $(QEMU_PIPE),,@echo "To exit from QEMU enter: 'CTRL+a, x'")
 	@echo '[QEMU] CPU: $(QEMU_CPU_TYPE_$(ARCH))'
 	$(if $(CONFIG_X86_IAMCU),$(ZEPHYR_BASE)/scripts/qemu-machine-hack.py $(KERNEL_ELF_NAME))
-	$(Q)$(QEMU) $(QEMU_FLAGS) $(QEMU_EXTRA_FLAGS) -kernel $(KERNEL_ELF_NAME)
+	$(Q)if [ "$(CONFIG_NET_TEST)" = "y" ]; then \
+	$(QEMU) $(QEMU_FLAGS) -kernel $(KERNEL_ELF_NAME); \
+	else \
+	$(QEMU) $(QEMU_FLAGS) $(QEMU_EXTRA_FLAGS) -kernel $(KERNEL_ELF_NAME); \
+	fi


### PR DESCRIPTION
If CONFIG_NET_TEST is defined, don't require QEMU to establish
connection to TAP daemon on the host side (from net-tools). This
will allow to run full-fledged network tests without any special
setup on the host, e.g. as part of normal sanitycheck running.

Signed-off-by: Paul Sokolovsky <paul.sokolovsky@linaro.org>