### PR TITLE
net: shell: stacks: Print config option needed for full info

### DIFF
--- a/subsys/net/ip/net_shell.c
+++ b/subsys/net/ip/net_shell.c
@@ -2168,6 +2168,8 @@ int net_shell_cmd_stacks(int argc, char *argv[])
 	       CONFIG_SYSTEM_WORKQUEUE_STACK_SIZE, unused,
 	       CONFIG_SYSTEM_WORKQUEUE_STACK_SIZE - unused,
 	       CONFIG_SYSTEM_WORKQUEUE_STACK_SIZE, pcnt);
+#else
+	printk("Enable CONFIG_INIT_STACKS to see usage information.\n");
 #endif
 
 	return 0;


### PR DESCRIPTION
This is similar to how few commands already behave if they can
provide additional info to the user if particular config options
are enabled.

Signed-off-by: Paul Sokolovsky <paul.sokolovsky@linaro.org>