### PR TITLE
doc: fix doxygen handling of  __attribute__(x)

### DIFF
--- a/doc/zephyr.doxyfile
+++ b/doc/zephyr.doxyfile
@@ -280,8 +280,10 @@ PREDEFINED             = "CONFIG_SYS_CLOCK_EXISTS=y" \
 			 "CONFIG_BT_SMP=y" \
 			 "CONFIG_BT_BREDR=y" \
 			 "__deprecated=" \
+			 "__packed=" \
+			 "__aligned(x)=" \
 			 "__printf_like(x, y)=" \
-			 "__attribute(x)__=" \
+			 "__attribute__(x)=" \
 			 "__syscall=" \
 			 "__syscall_inline="
 EXPAND_AS_DEFINED      =


### PR DESCRIPTION
The predefined macro list for doxygen processing had a typo error
causing __attribute__(x) to not be handled correctly.

kernel.h was recently updated to include use of __attribute__((sentinel))
and doxygen wasn't happy about processing the API doc comments for the
affected function.

Added a couple of other macros used in Zephyr here too.

Signed-off-by: David B. Kinder <david.b.kinder@intel.com>