### PR TITLE
doc: eliminate many "expected" doc gen warnings

### DIFF
--- a/doc/zephyr.doxyfile
+++ b/doc/zephyr.doxyfile
@@ -279,6 +279,7 @@ PREDEFINED             = "CONFIG_SYS_CLOCK_EXISTS=y" \
 			 "CONFIG_DEVICE_POWER_MANAGEMENT=y" \
 			 "CONFIG_BT_SMP=y" \
 			 "CONFIG_BT_BREDR=y" \
+			 "NET_MGMT_DEFINE_REQUEST_HANDLER(x)=" \
 			 "__deprecated=" \
 			 "__packed=" \
 			 "__aligned(x)=" \


### PR DESCRIPTION
Adding NET_MGMT_DEFINE_REQUEST_HANDLER to the doxygen configuration
list of pre-defined macros eliminates 800 lines of "expected" warning
messages from the document generation output.  Generated API docs
are unchanged. Cool.

Remember this if/when other macros pop up as a problem for the
doxygen/breathe/sphinx API generation tools.

Signed-off-by: David B. Kinder <david.b.kinder@intel.com>