### PR TITLE
i2c: stm32f3: Cleanup how we enable the specific I2C driver

### DIFF
--- a/arch/arm/soc/st_stm32/stm32f3/Kconfig.series
+++ b/arch/arm/soc/st_stm32/stm32f3/Kconfig.series
@@ -15,6 +15,5 @@ config SOC_SERIES_STM32F3X
 	select CPU_HAS_SYSTICK
 	select HAS_STM32CUBE
 	select CLOCK_CONTROL_STM32_CUBE if CLOCK_CONTROL
-	select I2C_STM32_V2 if I2C
 	help
 	 Enable support for STM32F3 MCU series

--- a/boards/arm/stm32f3_disco/stm32f3_disco_defconfig
+++ b/boards/arm/stm32f3_disco/stm32f3_disco_defconfig
@@ -23,6 +23,7 @@ CONFIG_UART_CONSOLE=y
 
 #enable I2C
 CONFIG_I2C=y
+CONFIG_I2C_STM32_V2=y
 
 # enable pinmux
 CONFIG_PINMUX=y


### PR DESCRIPTION
Match change we made to how I2C is enabled for other stm32 platforms:

Right now we allow for the I2C subsystem to be built without any drivers
enabled that utilize it.  When we added support for the new STM32 I2C
driver we forced the I2C driver to be enabled if the I2C subsystem was
enabled.  While this makes a reasonable amount of sense, it breaks
current assumptions for various testcases that we need to cleanup.

Signed-off-by: Kumar Gala <kumar.gala@linaro.org>