### PR TITLE
x86 : Memory domain implementation for x86

### DIFF
--- a/arch/arm/core/cortex_m/mpu/arm_core_mpu.c
+++ b/arch/arm/core/cortex_m/mpu/arm_core_mpu.c
@@ -52,4 +52,31 @@ int _arch_mem_domain_max_partitions_get(void)
 {
 	return arm_core_mpu_get_max_domain_partition_regions();
 }
+
+/*
+ * Reset MPU region for a single memory partition
+ */
+void _arch_mem_domain_partition_remove(struct k_mem_domain *domain,
+				       u32_t  partition_id)
+{
+	ARG_UNUSED(domain);
+
+	arm_core_mpu_disable();
+	arm_core_mpu_mem_partition_remove(partition_id);
+	arm_core_mpu_enable();
+
+}
+
+/*
+ * Destroy MPU regions for the mem domain
+ */
+void _arch_mem_domain_destroy(struct k_mem_domain *domain)
+{
+	ARG_UNUSED(domain);
+
+	arm_core_mpu_disable();
+	arm_core_mpu_configure_mem_domain(NULL);
+	arm_core_mpu_enable();
+}
+
 #endif

--- a/arch/arm/core/cortex_m/mpu/arm_mpu.c
+++ b/arch/arm/core/cortex_m/mpu/arm_mpu.c
@@ -263,6 +263,23 @@ void arm_core_mpu_configure_mem_partition(u32_t part_index,
 }
 
 /**
+ * @brief Reset MPU region for a single memory partition
+ *
+ * @param   part_index  memory partition index
+ */
+void arm_core_mpu_mem_partition_remove(u32_t part_index)
+{
+	u32_t region_index =
+		_get_region_index_by_type(THREAD_DOMAIN_PARTITION_REGION);
+
+	SYS_LOG_DBG("disable region 0x%x", region_index + part_index);
+	/* Disable region */
+	ARM_MPU_DEV->rnr = region_index + part_index;
+	ARM_MPU_DEV->rbar = 0;
+	ARM_MPU_DEV->rasr = 0;
+}
+
+/**
  * @brief get the maximum number of free regions for memory domain partitions
  */
 int arm_core_mpu_get_max_domain_partition_regions(void)

--- a/arch/arm/core/cortex_m/mpu/nxp_mpu.c
+++ b/arch/arm/core/cortex_m/mpu/nxp_mpu.c
@@ -290,6 +290,24 @@ void arm_core_mpu_configure_mem_partition(u32_t part_index,
 }
 
 /**
+ * @brief Reset MPU region for a single memory partition
+ *
+ * @param   part_index  memory partition index
+ */
+void arm_core_mpu_mem_partition_remove(u32_t part_index)
+{
+	u32_t region_index =
+		_get_region_index_by_type(THREAD_DOMAIN_PARTITION_REGION);
+
+	SYS_LOG_DBG("disable region 0x%x", region_index);
+	/* Disable region */
+	SYSMPU->WORD[region_index + part_index][0] = 0;
+	SYSMPU->WORD[region_index + part_index][1] = 0;
+	SYSMPU->WORD[region_index + part_index][2] = 0;
+	SYSMPU->WORD[region_index + part_index][3] = 0;
+}
+
+/**
  * @brief get the maximum number of free regions for memory domain partitions
  */
 int arm_core_mpu_get_max_domain_partition_regions(void)

--- a/arch/x86/core/thread.c
+++ b/arch/x86/core/thread.c
@@ -164,9 +164,18 @@ void _x86_swap_update_page_tables(struct k_thread *incoming,
 	 */
 	_main_tss.esp0 = incoming->stack_info.start;
 
-	/* TODO: if either thread defines different memory domains, efficiently
+	/* If either thread defines different memory domains, efficiently
 	 * switch between them
 	 */
+	if (incoming->mem_domain_info.mem_domain !=
+	   outgoing->mem_domain_info.mem_domain){
+
+		 /* Ensure that the outgoing mem domain configuration
+		  * is set back to default state.
+		  */
+		_arch_mem_domain_destroy(outgoing->mem_domain_info.mem_domain);
+		_x86_mmu_mem_domain_load(incoming);
+	}
 }
 
 

--- a/arch/x86/include/mmustructs.h
+++ b/arch/x86/include/mmustructs.h
@@ -243,6 +243,61 @@
 
 #endif	/* CONFIG_X86_PAE_MODE */
 
+#ifdef CONFIG_X86_USERSPACE
+
+/* Flags which are only available for PAE mode page tables  */
+#ifdef CONFIG_X86_PAE_MODE
+
+/* memory partition arch/soc independent attribute */
+#define K_MEM_PARTITION_P_RW_U_RW   (MMU_ENTRY_WRITE | \
+				     MMU_ENTRY_USER  | \
+				     MMU_ENTRY_EXECUTE_DISABLE)
+
+#define K_MEM_PARTITION_P_RW_U_NA   (MMU_ENTRY_WRITE | \
+				     MMU_ENTRY_SUPERVISOR | \
+				     MMU_ENTRY_EXECUTE_DISABLE)
+
+#define K_MEM_PARTITION_P_RO_U_RO   (MMU_ENTRY_READ | \
+				     MMU_ENTRY_USER | \
+				     MMU_ENTRY_EXECUTE_DISABLE)
+
+#define K_MEM_PARTITION_P_RO_U_NA   (MMU_ENTRY_READ  | \
+				     MMU_ENTRY_SUPERVISOR | \
+				     MMU_ENTRY_EXECUTE_DISABLE)
+
+/* Execution-allowed attributes */
+#define K_MEM_PARTITION_P_RWX_U_RWX (MMU_ENTRY_WRITE | MMU_ENTRY_USER)
+
+#define K_MEM_PARTITION_P_RWX_U_NA  (MMU_ENTRY_WRITE | MMU_ENTRY_SUPERVISOR)
+
+#define K_MEM_PARTITION_P_RX_U_RX   (MMU_ENTRY_READ | MMU_ENTRY_USER)
+
+#define K_MEM_PARTITION_P_RX_U_NA   (MMU_ENTRY_READ | MMU_ENTRY_SUPERVISOR)
+
+
+ /* memory partition access permission mask */
+#define K_MEM_PARTITION_PERM_MASK   (MMU_PTE_RW_MASK |\
+				     MMU_PTE_US_MASK |\
+				     MMU_PTE_XD_MASK)
+
+
+#else  /* 32-bit paging mode enabled */
+
+/* memory partition arch/soc independent attribute */
+#define K_MEM_PARTITION_P_RW_U_RW   (MMU_ENTRY_WRITE | MMU_ENTRY_USER)
+
+#define K_MEM_PARTITION_P_RW_U_NA   (MMU_ENTRY_WRITE | MMU_ENTRY_SUPERVISOR)
+
+#define K_MEM_PARTITION_P_RO_U_RO   (MMU_ENTRY_READ | MMU_ENTRY_USER)
+
+#define K_MEM_PARTITION_P_RO_U_NA   (MMU_ENTRY_READ  | MMU_ENTRY_SUPERVISOR)
+
+/* memory partition access permission mask */
+#define K_MEM_PARTITION_PERM_MASK   (MMU_PTE_RW_MASK | MMU_PTE_US_MASK)
+
+#endif	/* CONFIG_X86_PAE_MODE */
+
+#endif	 /* CONFIG_X86_USERSPACE */
 
 #ifndef _ASMLANGUAGE
 #include <zephyr/types.h>
@@ -684,6 +739,8 @@ typedef u64_t x86_page_entry_data_t;
 #else
 typedef u32_t x86_page_entry_data_t;
 #endif
+
+typedef x86_page_entry_data_t k_mem_partition_attr_t;
 
 #ifdef CONFIG_X86_PAE_MODE
 struct x86_mmu_page_directory_pointer {

--- a/include/arch/arm/arch.h
+++ b/include/arch/arm/arch.h
@@ -299,6 +299,11 @@ extern "C" {
 #endif  /* CONFIG_NXP_MPU */
 #endif /* CONFIG_USERSPACE */
 
+#ifndef _ASMLANGUAGE
+/* Typedef for the k_mem_partition attribute*/
+typedef u32_t k_mem_partition_attr_t;
+#endif /* _ASMLANGUAGE */
+
 #ifdef CONFIG_ARM_USERSPACE
 #ifndef _ASMLANGUAGE
 /* Syscall invocation macros. arm-specific machine constraints used to ensure

--- a/include/arch/arm/cortex_m/mpu/arm_core_mpu_dev.h
+++ b/include/arch/arm/cortex_m/mpu/arm_core_mpu_dev.h
@@ -81,6 +81,13 @@ void arm_core_mpu_configure_mem_partition(u32_t part_index,
 					  struct k_mem_partition *part);
 
 /**
+ * @brief Reset MPU region for a single memory partition
+ *
+ * @param   part_index  memory partition index
+ */
+void arm_core_mpu_mem_partition_remove(u32_t part_index);
+
+/**
  * @brief get the maximum number of free regions for memory domain partitions
  */
 int arm_core_mpu_get_max_domain_partition_regions(void);

--- a/include/arch/x86/arch.h
+++ b/include/arch/x86/arch.h
@@ -798,10 +798,23 @@ void _x86_mmu_get_flags(void *addr,
  * @mask Mask indicating which particular bits in the page table entries to
  *	 modify
  */
+
 void _x86_mmu_set_flags(void *ptr,
 			size_t size,
 			x86_page_entry_data_t flags,
 			x86_page_entry_data_t mask);
+
+#ifdef CONFIG_USERSPACE
+/**
+ * @brief Load the memory domain for the thread.
+ *
+ * If the memory domain is used this API will configure the page tables
+ * according to the memory domain partition attributes.
+ *
+ * @param thread k_thread structure for the thread which is to configured.
+ */
+void _x86_mmu_mem_domain_load(struct k_thread *thread);
+#endif
 
 #endif /* CONFIG_X86_MMU */
 

--- a/include/kernel.h
+++ b/include/kernel.h
@@ -4205,28 +4205,30 @@ static inline char *K_THREAD_STACK_BUFFER(k_thread_stack_t *sym)
 		MEM_PARTITION_ENTRY((u32_t)start, size, attr)
 #endif /* _ARCH_MEM_PARTITION_ALIGN_CHECK */
 
-
 /* memory partition */
 struct k_mem_partition {
 	/* start address of memory partition */
 	u32_t start;
 	/* size of memory partition */
 	u32_t size;
+#ifdef CONFIG_USERSPACE
 	/* attribute of memory partition */
-	u32_t attr;
+	k_mem_partition_attr_t attr;
+#endif	/* CONFIG_USERSPACE */
 };
 
-#if defined(CONFIG_USERSPACE)
 /* memory domian */
 struct k_mem_domain {
 	/* number of partitions in the domain */
 	u32_t num_partitions;
+#ifdef CONFIG_USERSPACE
 	/* partitions in the domain */
 	struct k_mem_partition partitions[CONFIG_MAX_DOMAIN_PARTITIONS];
+#endif	/* CONFIG_USERSPACE */
 	/* domain q */
 	sys_dlist_t mem_domain_q;
 };
-#endif /* CONFIG_USERSPACE */
+
 
 /**
  * @brief Initialize a memory domain.

--- a/kernel/include/nano_internal.h
+++ b/kernel/include/nano_internal.h
@@ -95,6 +95,30 @@ static inline unsigned int _Swap(unsigned int key)
  * @return Max number of free regions, or -1 if there is no limit
  */
 extern int _arch_mem_domain_max_partitions_get(void);
+
+/**
+ * @brief Remove a partition from the memory domain
+ *
+ * A memory domain contains multiple partitions and this API provides the
+ * freedom to remove a particular partition while keeping others intact.
+ * This API will handle any arch/HW specific changes that needs to be done.
+ *
+ * @param domain The memory domain structure
+ * @param partition_id The partition that needs to be deleted
+ */
+extern void _arch_mem_domain_partition_remove(struct k_mem_domain *domain,
+					      u32_t  partition_id);
+
+/**
+ * @brief Remove the memory domain
+ *
+ * A memory domain contains multiple partitions and this API will traverse
+ * all these to reset them back to default setting.
+ * This API will handle any arch/HW specific changes that needs to be done.
+ *
+ * @param domain The memory domain structure which needs to be deleted.
+ */
+extern void _arch_mem_domain_destroy(struct k_mem_domain *domain);
 #endif
 
 #ifdef CONFIG_USERSPACE

--- a/kernel/init.c
+++ b/kernel/init.c
@@ -259,6 +259,9 @@ static void prepare_multithreading(struct k_thread *dummy_thread)
 	dummy_thread->stack_info.start = 0;
 	dummy_thread->stack_info.size = 0;
 #endif
+#ifdef CONFIG_USERSPACE
+	dummy_thread->mem_domain_info.mem_domain = 0;
+#endif
 #endif
 
 	/* _kernel.ready_q is all zeroes */

--- a/kernel/mem_domain.c
+++ b/kernel/mem_domain.c
@@ -63,6 +63,11 @@ void k_mem_domain_destroy(struct k_mem_domain *domain)
 
 	key = irq_lock();
 
+	/* Handle architecture specifc destroy only if it is the current thread*/
+	if (_current->mem_domain_info.mem_domain == domain) {
+		_arch_mem_domain_destroy(domain);
+	}
+
 	SYS_DLIST_FOR_EACH_NODE_SAFE(&domain->mem_domain_q, node, next_node) {
 		struct k_thread *thread =
 			CONTAINER_OF(node, struct k_thread, mem_domain_info);
@@ -126,6 +131,11 @@ void k_mem_domain_remove_partition(struct k_mem_domain *domain,
 
 	/* Assert if not found */
 	__ASSERT(p_idx < max_partitions, "");
+
+	/* Handle architecture specifc remove only if it is the current thread*/
+	if (_current->mem_domain_info.mem_domain == domain) {
+		_arch_mem_domain_partition_remove(domain, p_idx);
+	}
 
 	domain->partitions[p_idx].start = 0;
 	domain->partitions[p_idx].size = 0;

--- a/samples/mpu/mem_domain_apis_test/src/main.c
+++ b/samples/mpu/mem_domain_apis_test/src/main.c
@@ -26,13 +26,23 @@ struct k_thread app_thread_id[3];
 struct k_mem_domain app_domain[2];
 
 /* the start address of the MPU region needs to align with its size */
+#ifdef CONFIG_ARM
 u8_t __aligned(32) app0_buf[32];
 u8_t __aligned(32) app1_buf[32];
+#else
+u8_t __aligned(4096) app0_buf[4096];
+u8_t __aligned(4096) app1_buf[4096];
+#endif
 
 K_MEM_PARTITION_DEFINE(app0_parts0, app0_buf, sizeof(app0_buf),
 		       K_MEM_PARTITION_P_RW_U_RW);
+#ifdef CONFIG_X86
+K_MEM_PARTITION_DEFINE(app0_parts1, app1_buf, sizeof(app1_buf),
+		       K_MEM_PARTITION_P_RO_U_RO);
+#else
 K_MEM_PARTITION_DEFINE(app0_parts1, app1_buf, sizeof(app1_buf),
 		       K_MEM_PARTITION_P_RW_U_RO);
+#endif
 
 struct k_mem_partition *app0_parts[] = {
 	&app0_parts0,
@@ -41,8 +51,13 @@ struct k_mem_partition *app0_parts[] = {
 
 K_MEM_PARTITION_DEFINE(app1_parts0, app1_buf, sizeof(app1_buf),
 		       K_MEM_PARTITION_P_RW_U_RW);
+#ifdef CONFIG_X86
+K_MEM_PARTITION_DEFINE(app1_parts1, app0_buf, sizeof(app0_buf),
+		       K_MEM_PARTITION_P_RO_U_RO);
+#else
 K_MEM_PARTITION_DEFINE(app1_parts1, app0_buf, sizeof(app0_buf),
 		       K_MEM_PARTITION_P_RW_U_RO);
+#endif
 
 struct k_mem_partition *app1_parts[] = {
 	&app1_parts0,


### PR DESCRIPTION
This PR shows the implementation of memory domain for x86.

P.S.
In the PR #1516 there were some build related issues which were not caught. This PR fixes that and also reverses the reverts that happened for the PR.

Delta from PR #1516 
1. Added prototype for arm_core_mpu_remove_mem_partition in include/arch/arm/cortex_m/mpu/arm_core_mpu_dev.h