### PR TITLE
boards: arm: stm32_mini_a15: Mark board as deprecated

### DIFF
--- a/boards/arm/stm32_mini_a15/Kconfig.board
+++ b/boards/arm/stm32_mini_a15/Kconfig.board
@@ -8,3 +8,4 @@
 config BOARD_STM32_MINI_A15
 	bool "STM32 MINI A15 Development Board"
 	depends on SOC_STM32F103XE
+	select BOARD_DEPRECATED


### PR DESCRIPTION
The original developer no longer has a working board and isn't
interested in maintaining support for the board.  Mark the board
deprecated for now and see if anyone wants to pick it up, otherwise will
remove it in a future release.

Signed-off-by: Kumar Gala <kumar.gala@linaro.org>