### PR TITLE
samples: mesh_demo: Enable relay by default for the micro:bit

### DIFF
--- a/samples/bluetooth/mesh_demo/src/main.c
+++ b/samples/bluetooth/mesh_demo/src/main.c
@@ -54,7 +54,7 @@ static void heartbeat(u8_t hops, u16_t feat)
 
 static struct bt_mesh_cfg cfg_srv = {
 #if defined(CONFIG_BOARD_BBC_MICROBIT)
-	.relay = BT_MESH_RELAY_DISABLED,
+	.relay = BT_MESH_RELAY_ENABLED,
 	.beacon = BT_MESH_BEACON_DISABLED,
 #else
 	.relay = BT_MESH_RELAY_ENABLED,


### PR DESCRIPTION
The relay functionality was supposed to be always enabled rather than
always disabled on the micro:bit.

Signed-off-by: Johan Hedberg <johan.hedberg@intel.com>