### PR TITLE
WIP: service: Added ping service

### DIFF
--- a/Kconfig.zephyr
+++ b/Kconfig.zephyr
@@ -30,6 +30,8 @@ source "ext/Kconfig"
 
 source "tests/Kconfig"
 
+source "service/Kconfig"
+
 #
 # The following are for Kconfig files for default values only.
 # These should be parsed at the end.

--- a/Makefile
+++ b/Makefile
@@ -606,7 +606,7 @@ endif # $(dot-config)
 
 # kernel objects are built as a static library
 libs-y := lib/ tests/
-core-y := kernel/ drivers/ misc/ boards/ ext/ subsys/ arch/
+core-y := kernel/ drivers/ misc/ boards/ ext/ subsys/ arch/ service/
 
 ARCH = $(subst $(DQUOTE),,$(CONFIG_ARCH))
 export ARCH

--- a/service/Kconfig
+++ b/service/Kconfig
@@ -1,0 +1,12 @@
+# Kconfig - Service configuration options
+#
+# Copyright (c) 2017 Intel Corporation
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+
+menu "Service Configuration"
+
+source "service/ping/Kconfig"
+
+endmenu

--- a/service/Makefile
+++ b/service/Makefile
@@ -1,0 +1,1 @@
+obj-y += ping/

--- a/service/ping/Kconfig
+++ b/service/ping/Kconfig
@@ -1,0 +1,46 @@
+#
+# Copyright (c) 2017 Intel Corporation
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+
+menu "Ping Server"
+
+config PING_SERVER
+	bool "Ping Server"
+	default n
+	help
+	Provides a ping service running on a TCP or UDP port. When the service
+	is sent ping it responds with pong.
+
+menu "Ping Server Settings"
+	visible if PING_SERVER
+
+config PING_SERVER_RESPONSE
+	string "Send this in response to a ping"
+	default "pong"
+
+config PING_SERVER_PORT
+	int "Port to host on"
+	range 0 65535
+	default 34861
+
+choice
+	prompt "Protocol to listen on"
+	default PING_SERVER_UDP
+
+config PING_SERVER_UDP
+	bool "UDP"
+	help
+	Listen for UDP pings
+
+config PING_SERVER_TCP
+	bool "TCP"
+	help
+	Listen for TCP pings
+
+endchoice
+
+endmenu
+
+endmenu

--- a/service/ping/Makefile
+++ b/service/ping/Makefile
@@ -1,0 +1,1 @@
+obj-$(CONFIG_PING_SERVER) += ping.o

--- a/service/ping/ping.c
+++ b/service/ping/ping.c
@@ -1,0 +1,84 @@
+#define SYS_LOG_DOMAIN "ping"
+#define SYS_LOG_LEVEL SYS_LOG_LEVEL_DEBUG
+#define NET_DEBUG 1
+
+#error "Ping service"
+
+#include <zephyr.h>
+
+#include <net/net_pkt.h>
+#include <net/net_mgmt.h>
+#include <net/net_core.h>
+#include <net/net_context.h>
+
+/* Port to bind to */
+#define PING_PORT 58473
+/* Timeout for all timeout operations */
+#define PING_TIMEOUT K_SECONDS(2)
+/* Size of stack area used by each thread */
+#define STACKSIZE 1024
+/* Scheduling priority used by each thread */
+#define PRIORITY 7
+/* Delay between greetings (in ms) */
+#define SLEEPTIME 500
+
+NET_MGMT_REGISTER_REQUEST_HANDLER(NET_EVENT_IPV4_ADDR_ADD, ping_service_start);
+
+static int ping_service_start(u32_t mgmt_event, struct net_if *iface,
+			      void *data, size_t len)
+{
+	int socket;
+
+	NET_INFO("ping service started\n");
+
+	/* Context get */
+	socket = zsock_socket(AF_INET, SOCK_DGRAM, IPPROTO_UDP);
+	if (socket < 0) {
+		NET_ERR("Failed to create socket (%d)", socket);
+		return;
+	}
+
+	/* Context bind */
+	// net_ipaddr_copy(&addr.sin_addr, iface_addr);
+	// addr.sin_family = AF_INET;
+	// addr.sin_port = htons(PING_PORT);
+
+	// ret = net_context_bind(context,
+	// 		       (const struct sockaddr *)&addr, sizeof(addr));
+	// if (ret < 0) {
+	// 	NET_ERR("Cannot bind IPv4 UDP port %d (%d)",
+	// 		ntohs(addr.sin_port), ret);
+	// 	return;
+	// }
+}
+
+void ping_ping()
+{
+	/*
+	pkt = net_pkt_get_tx(context, PING_TIMEOUT);
+	if (!pkt) {
+		ret = -ENOMEM;
+		goto quit;
+	}
+
+	ret = net_pkt_append_all(pkt, 6, "alive", PING_TIMEOUT);
+	if (ret < 0) {
+		ret = -ENOMEM;
+		goto quit;
+	}
+
+	if (server->sa_family == AF_INET) {
+		server_addr_len = sizeof(struct sockaddr_in);
+	} else {
+		server_addr_len = sizeof(struct sockaddr_in6);
+	}
+
+	ret = net_context_sendto(pkt, server, server_addr_len, NULL,
+				 PING_TIMEOUT, NULL, NULL);
+	if (ret < 0) {
+		NET_DBG("Cannot send query (%d)", ret);
+		net_pkt_unref(pkt);
+		goto quit;
+	}
+	*/
+}


### PR DESCRIPTION
I want to have something for the purposes of fuzzing that runs in the background so that I know the device is still alive (#3368 would also suffice). I thought we could add services that are sort of pre-baked. For instance they can be configured with the rest of the kernel and manage themselves.

## Ping Service

This should run as soon as it can bind to something and then listen for TCP
or UDP packets and reply to all of them with `ping` or some defined string.

## Problem

I don't know why I am never seeing the `printk` that ping started. I don't think
that it is getting the network management event as expected.

> More details coming soon I'm pressed for time as i write this

Signed-off-by: John Andersen <john.s.andersen@intel.com>