### PR TITLE
boards: fix type of BOARD_DEPRECATED

### DIFF
--- a/boards/Kconfig
+++ b/boards/Kconfig
@@ -1,6 +1,7 @@
 
 config BOARD_DEPRECATED
-	string
+	bool
+	default n
 	help
 	This hidden option is set in the board configuration and indicates
 	the Zephyr release that the board configuration will be removed.


### PR DESCRIPTION
Proposed fix for the following message I'm seeing:

```
scripts/kconfig/conf --silentoldconfig Kconfig
/home/mbolivar/src/zephyr/boards/arm/stm32_mini_a15/Kconfig.board:11:warning: 'BOARD_DEPRECATED' has wrong type. 'select' only accept arguments of boolean and tristate type
```