### PR TITLE
net: coap: Fix null pointer dereference when parsing packet

### DIFF
--- a/subsys/net/lib/coap/coap.c
+++ b/subsys/net/lib/coap/coap.c
@@ -305,7 +305,11 @@ int coap_packet_parse(struct coap_packet *cpkt, struct net_pkt *pkt,
 				   net_pkt_ip_hdr_len(pkt) +
 				   NET_UDPH_LEN +
 				   net_pkt_ipv6_ext_len(pkt));
-	if (!cpkt->frag && cpkt->offset == 0xffff) {
+	if (!cpkt->frag) {
+		return -EINVAL;
+	}
+
+	if (cpkt->offset == 0xffff) {
 		return -EINVAL;
 	}
 


### PR DESCRIPTION
Caling get_header_len() will dereference `cpkt->frag`, which might be
NULL given the check before the call.  Break the if statement into
two, so that -EINVAL is returned if either `cpkg->frag` is NULL, or if
offset is 0xFFFF.

Fixes #4396.

Coverity-ID: 178060
Signed-off-by: Leandro Pereira <leandro.pereira@intel.com>