### PR TITLE
drivers: flash: stm32f4x: `rc` should be declared as `int`

### DIFF
--- a/drivers/flash/flash_stm32f4x.c
+++ b/drivers/flash/flash_stm32f4x.c
@@ -88,7 +88,8 @@ int flash_stm32_block_erase_loop(struct device *dev, unsigned int offset,
 {
 	struct flash_pages_info info;
 	u32_t start_sector, end_sector;
-	u32_t i, rc = 0;
+	u32_t i;
+	int rc = 0;
 
 	rc = flash_get_page_info_by_offs(dev, offset, &info);
 	if (rc) {
@@ -110,7 +111,6 @@ int flash_stm32_block_erase_loop(struct device *dev, unsigned int offset,
 
 	return rc;
 }
-
 
 int flash_stm32_write_range(struct device *dev, unsigned int offset,
 			    const void *data, unsigned int len)


### PR DESCRIPTION
`rc` gets assigned values from function returning `int` and not
`u32_t`.

Fixes #4051.

Coverity-ID: 177219
Signed-off-by: Leandro Pereira <leandro.pereira@intel.com>