### PR TITLE
bossa: add support for specifying the port

### DIFF
--- a/scripts/support/bossa-flash.sh
+++ b/scripts/support/bossa-flash.sh
@@ -4,10 +4,11 @@
 # by RIOT-OS (https://github.com/RIOT-OS/RIOT)
 
 BOSSAC_CMD="${BOSSAC:-bossac}"
+BOSSAC_PORT=${BOSSAC_PORT:-"/dev/ttyACM0"}
 if [ `uname` = "Linux" ]; then
-    stty -F /dev/ttyACM0 raw ispeed 1200 ospeed 1200 cs8 \
+    stty -F ${BOSSAC_PORT} raw ispeed 1200 ospeed 1200 cs8 \
 -cstopb ignpar eol 255 eof 255
-    ${BOSSAC_CMD} -R -e -w -v -b "${O}/${KERNEL_BIN_NAME}"
+    ${BOSSAC_CMD} -p ${BOSSAC_PORT} -R -e -w -v -b "${O}/${KERNEL_BIN_NAME}"
 else
     echo "CAUTION: No flash tool for your host system found!"
 fi


### PR DESCRIPTION
Now that we have a newer version of bossa in the SDK we can use a
version where there -p option works properly.

Signed-off-by: Kumar Gala <kumar.gala@linaro.org>