### PR TITLE
boards: stm32_mini_a15: fix how we deprecate the board

### DIFF
--- a/boards/arm/stm32_mini_a15/Kconfig.board
+++ b/boards/arm/stm32_mini_a15/Kconfig.board
@@ -8,4 +8,3 @@
 config BOARD_STM32_MINI_A15
 	bool "STM32 MINI A15 Development Board"
 	depends on SOC_STM32F103XE
-	select BOARD_DEPRECATED

--- a/boards/arm/stm32_mini_a15/Kconfig.defconfig
+++ b/boards/arm/stm32_mini_a15/Kconfig.defconfig
@@ -10,4 +10,7 @@ if BOARD_STM32_MINI_A15
 config BOARD
 	default stm32_mini_a15
 
+config BOARD_DEPRECATED
+	default "1.11"
+
 endif # BOARD_STM32_MINI_A15


### PR DESCRIPTION
We shouldn't select BOARD_DEPRECATED but set a string with the release
version that the board will get removed in.

Signed-off-by: Kumar Gala <kumar.gala@linaro.org>