### PR TITLE
net: coap: Improve options parsing helper functions

### DIFF
--- a/tests/net/lib/coap/src/main.c
+++ b/tests/net/lib/coap/src/main.c
@@ -193,6 +193,7 @@ static const unsigned char ipv6_empty_pdu[] = {
 	/* CoAP */
 };
 
+/* No options, No payload */
 static int test_parse_empty_pdu(void)
 {
 	u8_t pdu[] = { 0x40, 0x01, 0, 0 };
@@ -270,23 +271,113 @@ done:
 }
 
 /* IPv6 + UDP frame (48 bytes) */
-static const unsigned char ipv6_simple_pdu[] = {
+static const unsigned char ipv6_empty_pdu_1[] = {
 	/* IPv6 header starts here */
-	0x60, 0x00, 0x00, 0x00, 0x00, 0x15, 0x11, 0xFF,
+	0x60, 0x00, 0x00, 0x00, 0x00, 0x0D, 0x11, 0xFF,
 	0x20, 0x01, 0x0D, 0xB8, 0x00, 0x00, 0x00, 0x00,
 	0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02,
 	0x20, 0x01, 0x0D, 0xB8, 0x00, 0x00, 0x00, 0x00,
 	0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x01,
 	/* UDP */
-	0xd8, 0xb4, 0x16, 0x33, 0x00, 0x15, 0x00, 0x00,
+	0xd8, 0xb4, 0x16, 0x33, 0x00, 0x0D, 0x00, 0x00,
+	/* CoAP */
+};
+
+/* 1 option, No payload (No payload marker) */
+static int test_parse_empty_pdu_1(void)
+{
+	u8_t pdu[] = { 0x40, 0x01, 0, 0, 0x40};
+	struct net_pkt *pkt;
+	struct net_buf *frag;
+	struct coap_packet cpkt;
+	u8_t ver, type, code;
+	u16_t id;
+	int result = TC_FAIL;
+	int r;
+
+	pkt = net_pkt_get_reserve(&coap_pkt_slab, 0, K_NO_WAIT);
+	if (!pkt) {
+		TC_PRINT("Could not get packet from pool\n");
+		goto done;
+	}
+
+	frag = net_buf_alloc(&coap_data_pool, K_NO_WAIT);
+	if (!frag) {
+		TC_PRINT("Could not get buffer from pool\n");
+		goto done;
+	}
+
+	net_pkt_frag_add(pkt, frag);
+
+	net_pkt_append_all(pkt, sizeof(ipv6_empty_pdu_1),
+			   (u8_t *)ipv6_empty_pdu_1, K_FOREVER);
+	net_pkt_append_all(pkt, sizeof(pdu), (u8_t *)pdu, K_FOREVER);
+
+	net_pkt_set_ip_hdr_len(pkt, NET_IPV6H_LEN);
+	net_pkt_set_ipv6_ext_len(pkt, 0);
+
+	memcpy(frag->data, pdu, sizeof(pdu));
+	frag->len = NET_IPV6UDPH_LEN + sizeof(pdu);
+
+	r = coap_packet_parse(&cpkt, pkt, NULL, 0);
+	if (r) {
+		TC_PRINT("Could not parse packet\n");
+		goto done;
+	}
+
+	ver = coap_header_get_version(&cpkt);
+	type = coap_header_get_type(&cpkt);
+	code = coap_header_get_code(&cpkt);
+	id = coap_header_get_id(&cpkt);
+
+	if (ver != 1) {
+		TC_PRINT("Invalid version for parsed packet\n");
+		goto done;
+	}
+
+	if (type != COAP_TYPE_CON) {
+		TC_PRINT("Packet type doesn't match reference\n");
+		goto done;
+	}
+
+	if (code != COAP_METHOD_GET) {
+		TC_PRINT("Packet code doesn't match reference\n");
+		goto done;
+	}
+
+	if (id != 0) {
+		TC_PRINT("Packet id doesn't match reference\n");
+		goto done;
+	}
+
+	result = TC_PASS;
+
+done:
+	net_pkt_unref(pkt);
+
+	TC_END_RESULT(result);
+
+	return result;
+}
+
+/* IPv6 + UDP frame (48 bytes) */
+static const unsigned char ipv6_simple_pdu[] = {
+	/* IPv6 header starts here */
+	0x60, 0x00, 0x00, 0x00, 0x00, 0x1D, 0x11, 0xFF,
+	0x20, 0x01, 0x0D, 0xB8, 0x00, 0x00, 0x00, 0x00,
+	0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02,
+	0x20, 0x01, 0x0D, 0xB8, 0x00, 0x00, 0x00, 0x00,
+	0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x01,
+	/* UDP */
+	0xd8, 0xb4, 0x16, 0x33, 0x00, 0x1D, 0x00, 0x00,
 	/* CoAP */
 };
 
 static int test_parse_simple_pdu(void)
 {
-	u8_t pdu[] = { 0x55, 0xA5, 0x12, 0x34, 't', 'o', 'k', 'e',
-			  'n',  0x00, 0xc1, 0x00, 0xff, 'p', 'a', 'y',
-			  'l', 'o', 'a', 'd', 0x00 };
+	u8_t pdu[] = { 0x55, 0xA5, 0x12, 0x34, 't', 'o', 'k', 'e', 'n',
+		       0x00, 0xc1, 0x00, 0xff, 'p', 'a', 'y', 'l', 'o',
+		       'a', 'd', 0x00 };
 	struct coap_packet cpkt;
 	struct net_pkt *pkt;
 	struct net_buf *frag;
@@ -1171,6 +1262,234 @@ out:
 
 }
 
+/* IPv6 + UDP frame (48 bytes) */
+static const unsigned char ipv6_wrong_opt[] = {
+	/* IPv6 header starts here */
+	0x60, 0x00, 0x00, 0x00, 0x00, 0x12, 0x11, 0xFF,
+	0x20, 0x01, 0x0D, 0xB8, 0x00, 0x00, 0x00, 0x00,
+	0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02,
+	0x20, 0x01, 0x0D, 0xB8, 0x00, 0x00, 0x00, 0x00,
+	0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x01,
+	/* UDP */
+	0xd8, 0xb4, 0x16, 0x33, 0x00, 0x12, 0x00, 0x00,
+	/* CoAP */
+};
+
+static int test_parse_malformed_opt(void)
+{
+	u8_t opt[] = { 0x55, 0xA5, 0x12, 0x34, 't', 'o', 'k', 'e', 'n',
+		       0xD0 };
+	struct coap_packet cpkt;
+	struct net_pkt *pkt;
+	struct net_buf *frag;
+	int result = TC_FAIL;
+	int r;
+
+	pkt = net_pkt_get_reserve(&coap_pkt_slab, 0, K_NO_WAIT);
+	if (!pkt) {
+		TC_PRINT("Could not get packet from pool\n");
+		goto done;
+	}
+
+	frag = net_buf_alloc(&coap_data_pool, K_NO_WAIT);
+	if (!frag) {
+		TC_PRINT("Could not get buffer from pool\n");
+		goto done;
+	}
+
+	net_pkt_frag_add(pkt, frag);
+
+	net_pkt_append_all(pkt, sizeof(ipv6_wrong_opt),
+			   (u8_t *)ipv6_wrong_opt, K_FOREVER);
+	net_pkt_append_all(pkt, sizeof(opt), (u8_t *)opt, K_FOREVER);
+
+	net_pkt_set_ip_hdr_len(pkt, NET_IPV6H_LEN);
+	net_pkt_set_ipv6_ext_len(pkt, 0);
+
+	r = coap_packet_parse(&cpkt, pkt, NULL, 0);
+	if (r < 0) {
+		result = TC_PASS;
+	}
+
+done:
+	net_pkt_unref(pkt);
+
+	TC_END_RESULT(result);
+
+	return result;
+}
+
+/* IPv6 + UDP frame (48 bytes) */
+static const unsigned char ipv6_wrong_opt_len[] = {
+	/* IPv6 header starts here */
+	0x60, 0x00, 0x00, 0x00, 0x00, 0x12, 0x11, 0xFF,
+	0x20, 0x01, 0x0D, 0xB8, 0x00, 0x00, 0x00, 0x00,
+	0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02,
+	0x20, 0x01, 0x0D, 0xB8, 0x00, 0x00, 0x00, 0x00,
+	0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x01,
+	/* UDP */
+	0xd8, 0xb4, 0x16, 0x33, 0x00, 0x12, 0x00, 0x00,
+	/* CoAP */
+};
+
+static int test_parse_malformed_opt_len(void)
+{
+	u8_t opt[] = { 0x55, 0xA5, 0x12, 0x34, 't', 'o', 'k', 'e', 'n',
+		       0xC1 };
+	struct coap_packet cpkt;
+	struct net_pkt *pkt;
+	struct net_buf *frag;
+	int result = TC_FAIL;
+	int r;
+
+	pkt = net_pkt_get_reserve(&coap_pkt_slab, 0, K_NO_WAIT);
+	if (!pkt) {
+		TC_PRINT("Could not get packet from pool\n");
+		goto done;
+	}
+
+	frag = net_buf_alloc(&coap_data_pool, K_NO_WAIT);
+	if (!frag) {
+		TC_PRINT("Could not get buffer from pool\n");
+		goto done;
+	}
+
+	net_pkt_frag_add(pkt, frag);
+
+	net_pkt_append_all(pkt, sizeof(ipv6_wrong_opt_len),
+			   (u8_t *)ipv6_wrong_opt_len, K_FOREVER);
+	net_pkt_append_all(pkt, sizeof(opt), (u8_t *)opt, K_FOREVER);
+
+	net_pkt_set_ip_hdr_len(pkt, NET_IPV6H_LEN);
+	net_pkt_set_ipv6_ext_len(pkt, 0);
+
+	r = coap_packet_parse(&cpkt, pkt, NULL, 0);
+	if (r < 0) {
+		result = TC_PASS;
+	}
+
+done:
+	net_pkt_unref(pkt);
+
+	TC_END_RESULT(result);
+
+	return result;
+}
+
+/* IPv6 + UDP frame (48 bytes) */
+static const unsigned char ipv6_wrong_opt_ext[] = {
+	/* IPv6 header starts here */
+	0x60, 0x00, 0x00, 0x00, 0x00, 0x13, 0x11, 0xFF,
+	0x20, 0x01, 0x0D, 0xB8, 0x00, 0x00, 0x00, 0x00,
+	0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02,
+	0x20, 0x01, 0x0D, 0xB8, 0x00, 0x00, 0x00, 0x00,
+	0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x01,
+	/* UDP */
+	0xd8, 0xb4, 0x16, 0x33, 0x00, 0x13, 0x00, 0x00,
+	/* CoAP */
+};
+
+static int test_parse_malformed_opt_ext(void)
+{
+	u8_t opt[] = { 0x55, 0xA5, 0x12, 0x34, 't', 'o', 'k', 'e', 'n',
+		       0xE0, 0x01 };
+	struct coap_packet cpkt;
+	struct net_pkt *pkt;
+	struct net_buf *frag;
+	int result = TC_FAIL;
+	int r;
+
+	pkt = net_pkt_get_reserve(&coap_pkt_slab, 0, K_NO_WAIT);
+	if (!pkt) {
+		TC_PRINT("Could not get packet from pool\n");
+		goto done;
+	}
+
+	frag = net_buf_alloc(&coap_data_pool, K_NO_WAIT);
+	if (!frag) {
+		TC_PRINT("Could not get buffer from pool\n");
+		goto done;
+	}
+
+	net_pkt_frag_add(pkt, frag);
+
+	net_pkt_append_all(pkt, sizeof(ipv6_wrong_opt_ext),
+			   (u8_t *)ipv6_wrong_opt_ext, K_FOREVER);
+	net_pkt_append_all(pkt, sizeof(opt), (u8_t *)opt, K_FOREVER);
+
+	net_pkt_set_ip_hdr_len(pkt, NET_IPV6H_LEN);
+	net_pkt_set_ipv6_ext_len(pkt, 0);
+
+	r = coap_packet_parse(&cpkt, pkt, NULL, 0);
+	if (r < 0) {
+		result = TC_PASS;
+	}
+
+done:
+	net_pkt_unref(pkt);
+
+	TC_END_RESULT(result);
+
+	return result;
+}
+
+/* IPv6 + UDP frame (48 bytes) */
+static const unsigned char ipv6_wrong_opt_len_ext[] = {
+	/* IPv6 header starts here */
+	0x60, 0x00, 0x00, 0x00, 0x00, 0x15, 0x11, 0xFF,
+	0x20, 0x01, 0x0D, 0xB8, 0x00, 0x00, 0x00, 0x00,
+	0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02,
+	0x20, 0x01, 0x0D, 0xB8, 0x00, 0x00, 0x00, 0x00,
+	0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x01,
+	/* UDP */
+	0xd8, 0xb4, 0x16, 0x33, 0x00, 0x15, 0x00, 0x00,
+	/* CoAP */
+};
+
+static int test_parse_malformed_opt_len_ext(void)
+{
+	u8_t opt[] = { 0x55, 0xA5, 0x12, 0x34, 't', 'o', 'k', 'e', 'n',
+		       0xEE, 0x01, 0x02, 0x01};
+	struct coap_packet cpkt;
+	struct net_pkt *pkt;
+	struct net_buf *frag;
+	int result = TC_FAIL;
+	int r;
+
+	pkt = net_pkt_get_reserve(&coap_pkt_slab, 0, K_NO_WAIT);
+	if (!pkt) {
+		TC_PRINT("Could not get packet from pool\n");
+		goto done;
+	}
+
+	frag = net_buf_alloc(&coap_data_pool, K_NO_WAIT);
+	if (!frag) {
+		TC_PRINT("Could not get buffer from pool\n");
+		goto done;
+	}
+
+	net_pkt_frag_add(pkt, frag);
+
+	net_pkt_append_all(pkt, sizeof(ipv6_wrong_opt_len_ext),
+			   (u8_t *)ipv6_wrong_opt_len_ext, K_FOREVER);
+	net_pkt_append_all(pkt, sizeof(opt), (u8_t *)opt, K_FOREVER);
+
+	net_pkt_set_ip_hdr_len(pkt, NET_IPV6H_LEN);
+	net_pkt_set_ipv6_ext_len(pkt, 0);
+
+	r = coap_packet_parse(&cpkt, pkt, NULL, 0);
+	if (r < 0) {
+		result = TC_PASS;
+	}
+
+done:
+	net_pkt_unref(pkt);
+
+	TC_END_RESULT(result);
+
+	return result;
+}
+
 static const struct {
 	const char *name;
 	int (*func)(void);
@@ -1178,12 +1497,18 @@ static const struct {
 	{ "Build empty PDU test", test_build_empty_pdu, },
 	{ "Build simple PDU test", test_build_simple_pdu, },
 	{ "Parse emtpy PDU test", test_parse_empty_pdu, },
+	{ "Parse empty PDU test no marker", test_parse_empty_pdu_1, },
 	{ "Parse simple PDU test", test_parse_simple_pdu, },
 	{ "Test retransmission", test_retransmit_second_round, },
 	{ "Test observer server", test_observer_server, },
 	{ "Test observer client", test_observer_client, },
 	{ "Test block sized transfer", test_block_size, },
 	{ "Test match path uri", test_match_path_uri, },
+	{ "Parse malformed option", test_parse_malformed_opt },
+	{ "Parse malformed option length", test_parse_malformed_opt_len },
+	{ "Parse malformed option ext", test_parse_malformed_opt_ext },
+	{ "Parse malformed option length ext",
+		test_parse_malformed_opt_len_ext },
 };
 
 int main(int argc, char *argv[])


### PR DESCRIPTION
Options parsing helpers functions unable to handle the malformed
packets and dropping it. Improved parsing functionality to handle
malformed packets. Also payload marker is not mandatory in CoAP
packets when there is no payload. Exit gracefully when CoAP
packet contains only options.