### PR TITLE
kernel: boot_delay: change to busy wait instaed of wait

### DIFF
--- a/kernel/init.c
+++ b/kernel/init.c
@@ -196,7 +196,7 @@ static void _main(void *unused1, void *unused2, void *unused3)
 	if (boot_delay > 0) {
 		printk("***** delaying boot " STRINGIFY(CONFIG_BOOT_DELAY)
 		       "ms (per build configuration) *****\n");
-		k_sleep(CONFIG_BOOT_DELAY);
+		k_busy_wait(CONFIG_BOOT_DELAY * USEC_PER_MSEC);
 	}
 	PRINT_BOOT_BANNER();
 


### PR DESCRIPTION
Intention of CONFIG_BOOT_DELAY is to delay booting of system for certain
time. Currently it is only delaying start of _main thread as delay is
created using k_sleep. This leads to putting _main thread into timeout
queue and continue kernel boot. This is causing some of undesirable
effects in some of test Automation usecase.
This patch changes k_sleep to k_busy_wait which result in delay in OS
boot instaed of delaying start of _main.

Signed-off-by: Youvedeep Singh <youvedeep.singh@intel.com>