### PR TITLE
doc: boards: stm32f3_disco: update Documentation to match pinmux.c

### DIFF
--- a/boards/arm/stm32f3_disco/doc/stm32f3_disco.rst
+++ b/boards/arm/stm32f3_disco/doc/stm32f3_disco.rst
@@ -108,8 +108,8 @@ For mode details please refer to `STM32F3DISCOVERY board User Manual`_.
 
 Default Zephyr Peripheral Mapping:
 ----------------------------------
-- UART_1_TX : PA9
-- UART_1_RX : PA10
+- UART_1_TX : PC4
+- UART_1_RX : PC5
 - UART_2_TX : PA2
 - UART_2_RX : PA3
 - USER_PB : PA0


### PR DESCRIPTION
Pinmux and Documentation were outof sync and there was a conflicting use of I2C1 and UART1 peripheral both assigned to PB6 and PB7 bins.