### PR TITLE
Bluetooth: Mesh: Improve Network Message Cache behavior

### DIFF
--- a/subsys/bluetooth/host/mesh/net.h
+++ b/subsys/bluetooth/host/mesh/net.h
@@ -202,7 +202,6 @@ enum bt_mesh_net_if {
 struct bt_mesh_net_rx {
 	struct bt_mesh_subnet *sub;
 	struct bt_mesh_msg_ctx ctx;
-	u64_t  hash;       /* Hash for the relay cache */
 	u32_t  seq;        /* Sequence Number */
 	u16_t  dst;        /* Destination address */
 	u8_t   old_iv:1,   /* iv_index - 1 was used */


### PR DESCRIPTION
The implementation of the Network Message Cache has so far been
suboptimal, since it has treated the same packet with different TTL
values as different packets. Since one of the purposes of this cache
is to prevent unnecessary relaying, it's important that we don't let
the TTL value influence the "hash" that's used for matching messages.

This patch changes the hash to consist of most of the IV Index (three
least significant bytes of it), the sequence number and the source
address, which should give fairly optimal matching behavior.

Signed-off-by: Johan Hedberg <johan.hedberg@intel.com>