### PR TITLE
tests: 6lo: convert legacy test to ztest with cleanup

### DIFF
--- a/tests/net/6lo/prj.conf
+++ b/tests/net/6lo/prj.conf
@@ -25,3 +25,4 @@ CONFIG_NET_DEBUG_NET_PKT=y
 CONFIG_NET_6LO_CONTEXT=y
 #Before modifying this value, add respective code in src/main.c
 CONFIG_NET_MAX_6LO_CONTEXTS=2
+CONFIG_ZTEST=y

--- a/tests/net/6lo/src/Makefile
+++ b/tests/net/6lo/src/Makefile
@@ -1,3 +1,4 @@
 obj-y = main.o
 ccflags-y += -I${ZEPHYR_BASE}/subsys/net/ip
 ccflags-y += -I${ZEPHYR_BASE}/tests/include
+include $(ZEPHYR_BASE)/tests/Makefile.test

--- a/tests/net/6lo/src/main.c
+++ b/tests/net/6lo/src/main.c
@@ -7,6 +7,7 @@
  */
 
 #include <zephyr.h>
+#include <ztest.h>
 #include <linker/sections.h>
 
 #include <zephyr/types.h>
@@ -33,8 +34,7 @@
 #define SIZE_OF_SMALL_DATA 40
 #define SIZE_OF_LARGE_DATA 120
 
-/**
-  * IPv6 Source and Destination address
+ /* IPv6 Source and Destination address
   * Example addresses are based on SAC (Source Address Compression),
   * SAM (Source Address Mode), DAC (Destination Address Compression),
   * DAM (Destination Address Mode) and also if the destination address
@@ -353,7 +353,8 @@ static struct net_pkt *create_pkt(struct net_6lo_data *data)
 	}
 
 	/* length is not set in net_6lo_data data pointer, calculate and set
-	 * in ipv6, udp and in data pointer too (it's required in comparison) */
+	 * in ipv6, udp and in data pointer too (it's required in comparison)
+	 */
 	frag->data[4] = len >> 8;
 	frag->data[5] = (u8_t) len;
 
@@ -851,27 +852,20 @@ static struct net_6lo_data test_data_25 = {
 
 #endif
 
-static int test_6lo(struct net_6lo_data *data)
+static void test_6lo(struct net_6lo_data *data)
 {
 	struct net_pkt *pkt;
-	int result = TC_FAIL;
 
 	pkt = create_pkt(data);
-	if (!pkt) {
-		TC_PRINT("%s: failed to create buffer\n", __func__);
-		goto end;
-	}
-
+	zassert_not_null(pkt, "failed to create buffer");
 #if DEBUG > 0
 	TC_PRINT("length before compression %zu\n",
 		 net_pkt_get_len(pkt));
 	net_hexdump_frags("before-compression", pkt, false);
 #endif
 
-	if (!net_6lo_compress(pkt, data->iphc, NULL)) {
-		TC_PRINT("compression failed\n");
-		goto end;
-	}
+	zassert_true(net_6lo_compress(pkt, data->iphc, NULL),
+		     "compression failed");
 
 #if DEBUG > 0
 	TC_PRINT("length after compression %zu\n",
@@ -879,24 +873,17 @@ static int test_6lo(struct net_6lo_data *data)
 	net_hexdump_frags("after-compression", pkt, false);
 #endif
 
-	if (!net_6lo_uncompress(pkt)) {
-		TC_PRINT("uncompression failed\n");
-		goto end;
-	}
-
+	zassert_true(net_6lo_uncompress(pkt),
+		     "uncompression failed");
 #if DEBUG > 0
 	TC_PRINT("length after uncompression %zu\n",
 	       net_pkt_get_len(pkt));
 	net_hexdump_frags("after-uncompression", pkt, false);
 #endif
 
-	if (compare_data(pkt, data)) {
-		result = TC_PASS;
-	}
+	zassert_true(compare_data(pkt, data), NULL);
 
-end:
 	net_pkt_unref(pkt);
-	return result;
 }
 
 /* tests names are based on traffic class, flow label, source address mode
@@ -936,9 +923,9 @@ static const struct {
 #endif
 };
 
-void main(void)
+void test_loop(void)
 {
-	int count, pass;
+	int count;
 
 	k_thread_priority_set(k_current_get(), K_PRIO_COOP(7));
 
@@ -947,18 +934,17 @@ void main(void)
 	net_6lo_set_context(net_if_get_default(), &ctx2);
 #endif
 
-	for (count = 0, pass = 0; count < ARRAY_SIZE(tests); count++) {
+	for (count = 0; count < ARRAY_SIZE(tests); count++) {
 		TC_START(tests[count].name);
 
-		if (test_6lo(tests[count].data)) {
-			TC_END(FAIL, "failed\n");
-		} else {
-			TC_END(PASS, "passed\n");
-			pass++;
-		}
+		test_6lo(tests[count].data);
 	}
-
 	net_pkt_print();
+}
 
-	TC_END_REPORT(((pass != ARRAY_SIZE(tests)) ? TC_FAIL : TC_PASS));
+/*test case main entry*/
+void test_main(void)
+{
+	ztest_test_suite(test_6lo, ztest_unit_test(test_loop));
+	ztest_run_test_suite(test_6lo);
 }


### PR DESCRIPTION
Test uses ztest and coding cleaup errors along with
warnings are removed through this patch

Signed-off-by: Punit Vara <punit.vara@intel.com>