### PR TITLE
kernel: Remove dead or commented code from k_mutex_lock()

### DIFF
--- a/kernel/mutex.c
+++ b/kernel/mutex.c
@@ -14,7 +14,7 @@
  * priority thread waiting on the mutex.
  *
  * Each mutex that contributes to priority inheritance must be released in the
- * reverse order in which is was acquired.  Furthermore each subsequent mutex
+ * reverse order in which it was acquired.  Furthermore each subsequent mutex
  * that contributes to raising the owning thread's priority level must be
  * acquired at a point after the most recent "bumping" of the priority level.
  *
@@ -146,12 +146,6 @@ int _impl_k_mutex_lock(struct k_mutex *mutex, s32_t timeout)
 		return -EBUSY;
 	}
 
-#if 0
-	if (_is_prio_higher(_current->prio, mutex->owner->prio)) {
-		new_prio = _current->prio;
-	}
-	new_prio = _get_new_prio_with_ceiling(new_prio);
-#endif
 	new_prio = new_prio_for_inheritance(_current->base.prio,
 					    mutex->owner->base.prio);
 


### PR DESCRIPTION
Remove dead code from k_mutex_lock() function and
also fix typo in a comment block.

Signed-off-by: Ramakrishna Pallala <ramakrishna.pallala@intel.com>