### PR TITLE
x86: fix CONFIG_DEBUG_INFO build error

### DIFF
--- a/arch/x86/core/swap.S
+++ b/arch/x86/core/swap.S
@@ -464,7 +464,7 @@ SECTION_FUNC(TEXT, _x86_thread_entry_wrapper)
 	pop	%ecx
 	push	$0	 /* Null return address */
 #elif defined(CONFIG_GDB_INFO) || defined(CONFIG_DEBUG_INFO)
-	mov	$0, (%esp) /* zero initialEFLAGS location */
+	movl	$0, (%esp) /* zero initialEFLAGS location */
 #endif
 	jmp	*%edi
 #endif


### PR DESCRIPTION
This doesn't have any register operands and needs a size suffix.
Fixes: #4480

Signed-off-by: Andrew Boie <andrew.p.boie@intel.com>