### PR TITLE
Bluetooth: controller: Remove assert on invalid LL id

### DIFF
--- a/subsys/bluetooth/controller/ll_sw/ctrl.c
+++ b/subsys/bluetooth/controller/ll_sw/ctrl.c
@@ -3278,7 +3278,7 @@ isr_rx_conn_pkt(struct radio_pdu_node_rx *radio_pdu_node_rx,
 				break;
 			case PDU_DATA_LLID_RESV:
 			default:
-				LL_ASSERT(0);
+				/* Invalid LL id, drop it. */
 				break;
 			}
 


### PR DESCRIPTION
Remove an assert on receiving invalid LL id, drop these
invalid PDUs.

Signed-off-by: Vinayak Kariappa Chettimada <vich@nordicsemi.no>