### PR TITLE
Fix assert compliance

### DIFF
--- a/lib/libc/minimal/include/assert.h
+++ b/lib/libc/minimal/include/assert.h
@@ -12,6 +12,8 @@
 
 #ifdef __cplusplus
 extern "C" {
+#else
+#define static_assert _Static_assert
 #endif
 
 #ifndef NDEBUG

--- a/lib/libc/minimal/include/assert.h
+++ b/lib/libc/minimal/include/assert.h
@@ -20,7 +20,7 @@ extern "C" {
 #endif
 #else
 #ifndef assert
-#define assert(test)
+#define assert(test) ((void)0)
 #endif
 #endif
 


### PR DESCRIPTION
This fixes compliance of the assert.h header with C99, C11 and C++11.