### PR TITLE
samples: net: wpanusb: Fix build error due to missing USB device vid/pid

### DIFF
--- a/samples/net/wpanusb/sample.yaml
+++ b/samples/net/wpanusb/sample.yaml
@@ -4,5 +4,8 @@ sample:
 tests:
   - test_15_4:
       build_only: true
+      extra_configs:
+        - CONFIG_USB_DEVICE_VID=0xDEAD
+        - CONFIG_USB_DEVICE_PID=0xBEEF
       depends_on: ieee802154 usb_device
       tags: net ieee802154 usb


### PR DESCRIPTION
We removed the default values for:
* CONFIG_USB_DEVICE_VID
* CONFIG_USB_DEVICE_PID

So put some dummy values in the sample.yaml to get things building
again.

Signed-off-by: Kumar Gala <kumar.gala@linaro.org>