### PR TITLE
kernel: include: Change the included header file.

### DIFF
--- a/include/sw_isr_table.h
+++ b/include/sw_isr_table.h
@@ -14,6 +14,8 @@
 #ifndef _SW_ISR_TABLE__H_
 #define _SW_ISR_TABLE__H_
 
+#include <kernel.h>
+
 #ifdef __cplusplus
 extern "C" {
 #endif

--- a/lib/libc/newlib/libc-hooks.c
+++ b/lib/libc/newlib/libc-hooks.c
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <arch/cpu.h>
+#include <kernel.h>
 #include <errno.h>
 #include <stdio.h>
 #include <sys/stat.h>


### PR DESCRIPTION
Changing the included header from arch/cpu.h to kernel.h.
Currently the build will take up the arch specific header file.
So for example consider the include sequence, first arch/cpu.h
then arch.h and so on until all the required files are included. But in
the course of this sequence there may be a chance that the kernel.h gets
included. But the kernel.h needs arch/cpu.h. This arch/cpu.h file
will not get included due to the header file guard macros.
Thus a compilation would fail. So by making sw_isr_table.h to take up
the kernel.h we eliminate this issue.

Signed-off-by: Adithya Baglody <adithya.nagaraj.baglody@intel.com>