### PR TITLE
net: lib: http: Fix invalid pointer body_start

### DIFF
--- a/subsys/net/lib/http/http_client.c
+++ b/subsys/net/lib/http/http_client.c
@@ -292,7 +292,8 @@ static int on_body(struct http_parser *parser, const char *at, size_t length)
 
 	NET_DBG("Processed %zd length %zd", ctx->rsp.processed, length);
 
-	if (!ctx->rsp.body_start) {
+	if ((u8_t *)at != (u8_t *)ctx->rsp.response_buf) {
+		/* This fragment contains the start of the body */
 		ctx->rsp.body_start = (u8_t *)at;
 	}
 
@@ -309,6 +310,7 @@ static int on_body(struct http_parser *parser, const char *at, size_t length)
 
 		/* Re-use the result buffer and start to fill it again */
 		ctx->rsp.data_len = 0;
+		ctx->rsp.body_start = NULL;
 	}
 
 	return 0;


### PR DESCRIPTION
The body_start field at http_client_ctx.rsp is used to check if this
fragment contains (a part of) headers or not.

If the device recived more than one fragment in one http response,
may cause re-use of the result buffer in function on_body().

Once the device re-use the result buffer, the body_start that point
to this buffer address will no longer be valid.

Signed-off-by: Ding Tao <miyatsu@qq.com>