### PR TITLE
net: ieee802154_shell: get_pan_id: Print ID in hex too

### DIFF
--- a/subsys/net/ip/l2/ieee802154/ieee802154_shell.c
+++ b/subsys/net/ip/l2/ieee802154/ieee802154_shell.c
@@ -306,7 +306,7 @@ static int shell_cmd_get_pan_id(int argc, char *argv[])
 		     &pan_id, sizeof(u16_t))) {
 		printk("Could not get PAN ID\n");
 	} else {
-		printk("PAN ID %u\n", pan_id);
+		printk("PAN ID %u (0x%x)\n", pan_id, pan_id);
 	}
 
 	return 0;


### PR DESCRIPTION
Oftentimes, 15.4 PAN IDs are specified in hex. For example, that's
how Zephyr config specifies the default value. So, print them also
in hex, to avoid confusion.

Signed-off-by: Paul Sokolovsky <paul.sokolovsky@linaro.org>