### PR TITLE
net: lwm2m: replace instances of s*printf with snprintk

### DIFF
--- a/subsys/net/lib/lwm2m/lwm2m_engine.c
+++ b/subsys/net/lib/lwm2m/lwm2m_engine.c
@@ -162,7 +162,7 @@ static char *sprint_token(const u8_t *token, u8_t tkl)
 		int i;
 
 		for (i = 0; i < tkl; i++) {
-			pos += snprintf(&buf[pos], 31 - pos, "%x", token[i]);
+			pos += snprintk(&buf[pos], 31 - pos, "%x", token[i]);
 		}
 
 		buf[pos] = '\0';
@@ -590,10 +590,12 @@ int lwm2m_create_obj_inst(u16_t obj_id, u16_t obj_inst_id,
 	obj->instance_count++;
 	(*obj_inst)->obj = obj;
 	(*obj_inst)->obj_inst_id = obj_inst_id;
-	sprintf((*obj_inst)->path, "%u/%u", obj_id, obj_inst_id);
+	snprintk((*obj_inst)->path, MAX_RESOURCE_LEN, "%u/%u",
+		 obj_id, obj_inst_id);
 	for (i = 0; i < (*obj_inst)->resource_count; i++) {
-		sprintf((*obj_inst)->resources[i].path, "%u/%u/%u",
-			obj_id, obj_inst_id, (*obj_inst)->resources[i].res_id);
+		snprintk((*obj_inst)->resources[i].path, MAX_RESOURCE_LEN,
+			 "%u/%u/%u", obj_id, obj_inst_id,
+			 (*obj_inst)->resources[i].res_id);
 	}
 
 	engine_register_obj_inst(*obj_inst);
@@ -935,7 +937,7 @@ u16_t lwm2m_get_rd_data(u8_t *client_data, u16_t size)
 
 		/* Only report <OBJ_ID> when no instance available */
 		if (obj->instance_count == 0) {
-			len = snprintf(temp, sizeof(temp), "%s</%u>",
+			len = snprintk(temp, sizeof(temp), "%s</%u>",
 				       (pos > 0) ? "," : "", obj->obj_id);
 			if (pos + len >= size) {
 				/* full buffer -- exit loop */
@@ -950,7 +952,7 @@ u16_t lwm2m_get_rd_data(u8_t *client_data, u16_t size)
 		SYS_SLIST_FOR_EACH_CONTAINER(&engine_obj_inst_list,
 					     obj_inst, node) {
 			if (obj_inst->obj->obj_id == obj->obj_id) {
-				len = snprintf(temp, sizeof(temp),
+				len = snprintk(temp, sizeof(temp),
 					       "%s</%s>",
 					       (pos > 0) ? "," : "",
 					       obj_inst->path);
@@ -2257,16 +2259,19 @@ static int do_discover_op(struct lwm2m_engine_context *context)
 			continue;
 		}
 
-		out->outlen += sprintf(&out->outbuf[out->outlen], ",</%u/%u>",
-				       obj_inst->obj->obj_id,
-				       obj_inst->obj_inst_id);
+		out->outlen += snprintk(&out->outbuf[out->outlen],
+					out->outsize - out->outlen,
+					",</%u/%u>",
+					obj_inst->obj->obj_id,
+					obj_inst->obj_inst_id);
 
 		for (i = 0; i < obj_inst->resource_count; i++) {
-			out->outlen += sprintf(&out->outbuf[out->outlen],
-					       ",</%u/%u/%u>",
-					       obj_inst->obj->obj_id,
-					       obj_inst->obj_inst_id,
-					       obj_inst->resources[i].res_id);
+			out->outlen += snprintk(&out->outbuf[out->outlen],
+						out->outsize - out->outlen,
+						",</%u/%u/%u>",
+						obj_inst->obj->obj_id,
+						obj_inst->obj_inst_id,
+						obj_inst->resources[i].res_id);
 		}
 	}
 

--- a/subsys/net/lib/lwm2m/lwm2m_rd_client.c
+++ b/subsys/net/lib/lwm2m/lwm2m_rd_client.c
@@ -532,7 +532,7 @@ static int sm_do_bootstrap(int index)
 		coap_packet_append_option(&msg->cpkt, COAP_OPTION_URI_PATH,
 					  "bs", strlen("bs"));
 
-		snprintf(query_buffer, sizeof(query_buffer) - 1,
+		snprintk(query_buffer, sizeof(query_buffer) - 1,
 			 "ep=%s", clients[index].ep_name);
 		/* TODO: handle return error */
 		coap_packet_append_option(&msg->cpkt, COAP_OPTION_URI_QUERY,
@@ -644,12 +644,12 @@ static int sm_send_registration(int index, bool send_obj_support_data,
 		/* include client endpoint in URI QUERY on 1st registration */
 		coap_append_option_int(&msg->cpkt, COAP_OPTION_CONTENT_FORMAT,
 				       LWM2M_FORMAT_APP_LINK_FORMAT);
-		snprintf(query_buffer, sizeof(query_buffer) - 1,
+		snprintk(query_buffer, sizeof(query_buffer) - 1,
 			 "lwm2m=%s", LWM2M_PROTOCOL_VERSION);
 		/* TODO: handle return error */
 		coap_packet_append_option(&msg->cpkt, COAP_OPTION_URI_QUERY,
 					  query_buffer, strlen(query_buffer));
-		snprintf(query_buffer, sizeof(query_buffer) - 1,
+		snprintk(query_buffer, sizeof(query_buffer) - 1,
 			 "ep=%s", clients[index].ep_name);
 		/* TODO: handle return error */
 		coap_packet_append_option(&msg->cpkt, COAP_OPTION_URI_QUERY,
@@ -662,7 +662,7 @@ static int sm_send_registration(int index, bool send_obj_support_data,
 					  strlen(clients[index].server_ep));
 	}
 
-	snprintf(query_buffer, sizeof(query_buffer) - 1,
+	snprintk(query_buffer, sizeof(query_buffer) - 1,
 		 "lt=%d", clients[index].lifetime);
 	/* TODO: handle return error */
 	coap_packet_append_option(&msg->cpkt, COAP_OPTION_URI_QUERY,

--- a/subsys/net/lib/lwm2m/lwm2m_rw_json.c
+++ b/subsys/net/lib/lwm2m/lwm2m_rw_json.c
@@ -201,7 +201,7 @@ static size_t put_begin(struct lwm2m_output_context *out,
 {
 	int len;
 
-	len = snprintf(&out->outbuf[out->outlen],
+	len = snprintk(&out->outbuf[out->outlen],
 		       out->outsize - out->outlen,
 		       "{\"bn\":\"/%u/%u/\",\"e\":[",
 		       path->obj_id, path->obj_inst_id);
@@ -219,7 +219,7 @@ static size_t put_end(struct lwm2m_output_context *out,
 {
 	int len;
 
-	len = snprintf(&out->outbuf[out->outlen],
+	len = snprintk(&out->outbuf[out->outlen],
 		       out->outsize - out->outlen, "]}");
 	if (len < 0 || len >= (out->outsize - out->outlen)) {
 		return 0;
@@ -255,10 +255,10 @@ static size_t put_s32(struct lwm2m_output_context *out,
 	outlen = out->outsize - out->outlen;
 	sep = SEPARATOR(out->writer_flags);
 	if (out->writer_flags & WRITER_RESOURCE_INSTANCE) {
-		len = snprintf(outbuf, outlen, "%s{\"n\":\"%u/%u\",\"v\":%d}",
+		len = snprintk(outbuf, outlen, "%s{\"n\":\"%u/%u\",\"v\":%d}",
 			       sep, path->res_id, path->res_inst_id, value);
 	} else {
-		len = snprintf(outbuf, outlen, "%s{\"n\":\"%u\",\"v\":%d}",
+		len = snprintk(outbuf, outlen, "%s{\"n\":\"%u\",\"v\":%d}",
 			       sep, path->res_id, value);
 	}
 
@@ -296,10 +296,10 @@ static size_t put_s64(struct lwm2m_output_context *out,
 	outlen = out->outsize - out->outlen;
 	sep = SEPARATOR(out->writer_flags);
 	if (out->writer_flags & WRITER_RESOURCE_INSTANCE) {
-		len = snprintf(outbuf, outlen, "%s{\"n\":\"%u/%u\",\"v\":%lld}",
+		len = snprintk(outbuf, outlen, "%s{\"n\":\"%u/%u\",\"v\":%lld}",
 			       sep, path->res_id, path->res_inst_id, value);
 	} else {
-		len = snprintf(outbuf, outlen, "%s{\"n\":\"%u\",\"v\":%lld}",
+		len = snprintk(outbuf, outlen, "%s{\"n\":\"%u\",\"v\":%lld}",
 			       sep, path->res_id, value);
 	}
 
@@ -328,10 +328,10 @@ static size_t put_string(struct lwm2m_output_context *out,
 	outlen = out->outsize - out->outlen;
 	sep = SEPARATOR(out->writer_flags);
 	if (out->writer_flags & WRITER_RESOURCE_INSTANCE) {
-		res = snprintf(outbuf, outlen, "%s{\"n\":\"%u/%u\",\"sv\":\"",
+		res = snprintk(outbuf, outlen, "%s{\"n\":\"%u/%u\",\"sv\":\"",
 			       sep, path->res_id, path->res_inst_id);
 	} else {
-		res = snprintf(outbuf, outlen, "%s{\"n\":\"%u\",\"sv\":\"",
+		res = snprintk(outbuf, outlen, "%s{\"n\":\"%u\",\"sv\":\"",
 			       sep, path->res_id);
 	}
 
@@ -344,7 +344,7 @@ static size_t put_string(struct lwm2m_output_context *out,
 		/* Escape special characters */
 		/* TODO: Handle UTF-8 strings */
 		if (buf[i] < '\x20') {
-			res = snprintf(&outbuf[len], outlen - len, "\\x%x",
+			res = snprintk(&outbuf[len], outlen - len, "\\x%x",
 				       buf[i]);
 
 			if (res < 0 || res >= (outlen - len)) {
@@ -368,7 +368,7 @@ static size_t put_string(struct lwm2m_output_context *out,
 		}
 	}
 
-	res = snprintf(&outbuf[len], outlen - len, "\"}");
+	res = snprintk(&outbuf[len], outlen - len, "\"}");
 	if (res < 0 || res >= (outlen - len)) {
 		return 0;
 	}
@@ -394,10 +394,10 @@ static size_t put_float32fix(struct lwm2m_output_context *out,
 	outlen = out->outsize - out->outlen;
 	sep = SEPARATOR(out->writer_flags);
 	if (out->writer_flags & WRITER_RESOURCE_INSTANCE) {
-		res = snprintf(outbuf, outlen, "%s{\"n\":\"%u/%u\",\"v\":",
+		res = snprintk(outbuf, outlen, "%s{\"n\":\"%u/%u\",\"v\":",
 			       sep, path->res_id, path->res_inst_id);
 	} else {
-		res = snprintf(outbuf, outlen, "%s{\"n\":\"%u\",\"v\":",
+		res = snprintk(outbuf, outlen, "%s{\"n\":\"%u\",\"v\":",
 			       sep, path->res_id);
 	}
 
@@ -414,7 +414,7 @@ static size_t put_float32fix(struct lwm2m_output_context *out,
 
 	len += res;
 	outlen -= res;
-	res = snprintf(&outbuf[len], outlen, "}");
+	res = snprintk(&outbuf[len], outlen, "}");
 	if (res <= 0 || res >= outlen) {
 		return 0;
 	}
@@ -439,10 +439,10 @@ static size_t put_float64fix(struct lwm2m_output_context *out,
 	outlen = out->outsize - out->outlen;
 	sep = SEPARATOR(out->writer_flags);
 	if (out->writer_flags & WRITER_RESOURCE_INSTANCE) {
-		res = snprintf(outbuf, outlen, "%s{\"n\":\"%u/%u\",\"v\":",
+		res = snprintk(outbuf, outlen, "%s{\"n\":\"%u/%u\",\"v\":",
 			       sep, path->res_id, path->res_inst_id);
 	} else {
-		res = snprintf(outbuf, outlen, "%s{\"n\":\"%u\",\"v\":",
+		res = snprintk(outbuf, outlen, "%s{\"n\":\"%u\",\"v\":",
 			       sep, path->res_id);
 	}
 
@@ -459,7 +459,7 @@ static size_t put_float64fix(struct lwm2m_output_context *out,
 
 	len += res;
 	outlen -= res;
-	res = snprintf(&outbuf[len], outlen, "}");
+	res = snprintk(&outbuf[len], outlen, "}");
 	if (res <= 0 || res >= outlen) {
 		return 0;
 	}
@@ -483,11 +483,11 @@ static size_t put_bool(struct lwm2m_output_context *out,
 	outlen = out->outsize - out->outlen;
 	sep = SEPARATOR(out->writer_flags);
 	if (out->writer_flags & WRITER_RESOURCE_INSTANCE) {
-		len = snprintf(outbuf, outlen, "%s{\"n\":\"%u/%u\",\"bv\":%s}",
+		len = snprintk(outbuf, outlen, "%s{\"n\":\"%u/%u\",\"bv\":%s}",
 			       sep, path->res_id, path->res_inst_id,
 			       value ? "true" : "false");
 	} else {
-		len = snprintf(outbuf, outlen, "%s{\"n\":\"%u\",\"bv\":%s}",
+		len = snprintk(outbuf, outlen, "%s{\"n\":\"%u\",\"bv\":%s}",
 			       sep, path->res_id, value ? "true" : "false");
 	}
 

--- a/subsys/net/lib/lwm2m/lwm2m_rw_plain_text.c
+++ b/subsys/net/lib/lwm2m/lwm2m_rw_plain_text.c
@@ -83,7 +83,7 @@ size_t plain_text_put_float32fix(u8_t *outbuf, size_t outlen,
 		value->val1 = -value->val1;
 	}
 
-	n = snprintf(outbuf, outlen, "%d.%d", value->val1, value->val2);
+	n = snprintk(outbuf, outlen, "%d.%d", value->val1, value->val2);
 
 	if (n < 0 || n >= outlen) {
 		return 0;
@@ -108,7 +108,7 @@ size_t plain_text_put_float64fix(u8_t *outbuf, size_t outlen,
 		value->val1 = -value->val1;
 	}
 
-	n = snprintf(outbuf, outlen, "%lld.%lld", value->val1, value->val2);
+	n = snprintk(outbuf, outlen, "%lld.%lld", value->val1, value->val2);
 
 	if (n < 0 || n >= outlen) {
 		return 0;
@@ -122,7 +122,7 @@ static size_t put_s32(struct lwm2m_output_context *out,
 {
 	int len;
 
-	len = snprintf(&out->outbuf[out->outlen], out->outsize - out->outlen,
+	len = snprintk(&out->outbuf[out->outlen], out->outsize - out->outlen,
 		       "%d", value);
 	if (len < 0 || len >= (out->outsize - out->outlen)) {
 		return 0;
@@ -149,7 +149,7 @@ static size_t put_s64(struct lwm2m_output_context *out,
 {
 	int len;
 
-	len = snprintf(&out->outbuf[out->outlen], out->outsize - out->outlen,
+	len = snprintk(&out->outbuf[out->outlen], out->outsize - out->outlen,
 		       "%lld", value);
 	if (len < 0 || len >= (out->outsize - out->outlen)) {
 		return 0;


### PR DESCRIPTION
Let's use snprintk for simple formatting to allow for possible disabling
of printf and protect calls to sprintf from string overruns.