### PR TITLE
Fix CoAP option length checking and drop COAP_EXTENDED_OPTIONS_LEN from LwM2M

### DIFF
--- a/subsys/net/lib/lwm2m/Kconfig
+++ b/subsys/net/lib/lwm2m/Kconfig
@@ -8,7 +8,6 @@ menuconfig LWM2M
 	bool "OMA LWM2M protocol stack"
 	default n
 	select COAP
-	select COAP_EXTENDED_OPTIONS_LEN
 	select NET_APP_CLIENT
 	select HTTP_PARSER_URL
 	help


### PR DESCRIPTION
Currently, we check the length of an option value in the coap_packet_append_option() function.  This isn't required as we're appending to a net_pkt and not using struct coap_option where the limitation is imposed. Instead, we should check the option value length in parse_option() where we assign the value to a struct coap_option.

Also, when moving to the new CoAP API, I thought we would need to parse incoming option values longer than 12 characters. This hasn't proven to be true, so let's remove the auto-selection of this config.  If needed user can set this option later.