### PR TITLE
Net: Add RTO config option

### DIFF
--- a/subsys/net/ip/Kconfig
+++ b/subsys/net/ip/Kconfig
@@ -148,6 +148,15 @@ config NET_TCP_ACK_TIMEOUT
 	various TCP states. The value is in milliseconds. Note that
 	having a very low value here could prevent connectivity.
 
+config NET_TCP_INIT_RETRANSMISSION_TIMEOUT
+	int "Initial value of Retransmission Timeout (RTO) (in milliseconds)"
+	depends on NET_TCP
+	default 200
+	range 100 2000
+	help
+	This value affects the timeout between initial retransmission
+	of TCP data packets. The value is in milliseconds.
+
 config NET_TCP_RETRY_COUNT
 	int "Maximum number of TCP segment retransmissions"
 	depends on NET_TCP
@@ -156,7 +165,7 @@ config NET_TCP_RETRY_COUNT
 	The following formula can be used to determine the time (in ms)
 	that a segment will be be buffered awaiting retransmission:
 	n=NET_TCP_RETRY_COUNT
-	Sum((1<<n) * 200)
+	Sum((1<<n) * NET_TCP_INIT_RETRANSMISSION_TIMEOUT)
 	n=0
 	With the default value of 9, the IP stack will try to
 	retransmit for up to 1:42 minutes.  This is as close as possible

--- a/subsys/net/ip/tcp.c
+++ b/subsys/net/ip/tcp.c
@@ -45,8 +45,6 @@
 #define NET_MAX_TCP_CONTEXT CONFIG_NET_MAX_CONTEXTS
 static struct net_tcp tcp_context[NET_MAX_TCP_CONTEXT];
 
-#define INIT_RETRY_MS 200
-
 /* 2MSL timeout, where "MSL" is arbitrarily 2 minutes in the RFC */
 #if defined(CONFIG_NET_TCP_2MSL_TIME)
 #define TIME_WAIT_MS K_SECONDS(CONFIG_NET_TCP_2MSL_TIME)
@@ -121,7 +119,8 @@ static void net_tcp_trace(struct net_pkt *pkt, struct net_tcp *tcp)
 
 static inline u32_t retry_timeout(const struct net_tcp *tcp)
 {
-	return ((u32_t)1 << tcp->retry_timeout_shift) * INIT_RETRY_MS;
+	return ((u32_t)1 << tcp->retry_timeout_shift) *
+				CONFIG_NET_TCP_INIT_RETRANSMISSION_TIMEOUT;
 }
 
 #define is_6lo_technology(pkt)						    \


### PR DESCRIPTION
Add option to set initial RTO value. The value is different from
NET_TCP_ACK_TIMEOUT since latter affects TCP states ACK timeout only.

Signed-off-by: Andrei Emeltchenko <andrei.emeltchenko@intel.com>