### PR TITLE
drivers: i2c_ll_stm32: Use I2C API flags

### DIFF
--- a/drivers/i2c/i2c_ll_stm32.h
+++ b/drivers/i2c/i2c_ll_stm32.h
@@ -42,9 +42,9 @@ struct i2c_stm32_data {
 	} current;
 };
 
-s32_t stm32_i2c_msg_write(struct device *dev, struct i2c_msg *msg, u32_t flg,
+s32_t stm32_i2c_msg_write(struct device *dev, struct i2c_msg *msg, u8_t *flg,
 			  u16_t sadr);
-s32_t stm32_i2c_msg_read(struct device *dev, struct i2c_msg *msg, u32_t flg,
+s32_t stm32_i2c_msg_read(struct device *dev, struct i2c_msg *msg, u8_t *flg,
 			 u16_t sadr);
 s32_t stm32_i2c_configure_timing(struct device *dev, u32_t clk);
 

--- a/drivers/i2c/i2c_ll_stm32_v2.c
+++ b/drivers/i2c/i2c_ll_stm32_v2.c
@@ -82,14 +82,14 @@ void stm32_i2c_event_isr(void *arg)
 	I2C_TypeDef *i2c = cfg->i2c;
 
 	if (data->current.is_write) {
-		if (data->current.len && LL_I2C_IsEnabledIT_TX(i2c)) {
+		if (data->current.len && LL_I2C_IsActiveFlag_TXIS(i2c)) {
 			LL_I2C_TransmitData8(i2c, *data->current.buf);
 		} else {
 			LL_I2C_DisableIT_TX(i2c);
 			goto error;
 		}
 	} else {
-		if (data->current.len && LL_I2C_IsEnabledIT_RX(i2c)) {
+		if (data->current.len && LL_I2C_IsActiveFlag_RXNE(i2c)) {
 			*data->current.buf = LL_I2C_ReceiveData8(i2c);
 		} else {
 			LL_I2C_DisableIT_RX(i2c);


### PR DESCRIPTION
STM32 I2C driver doesn't use the I2C API flags STOP/RESTART,
instead it uses its own RESTART flag. As a result, I2C API's
i2c_burst_write* funtions doesn't work. This patch makes
STM32 I2C driver to use I2C API flags.

Tested on: 96b_carbon, olimexino_stm32 (i2c_ll_stm32_v1)
Tested on: stm32f3_disco, disco_l475_iot1 (i2c_ll_stm32_v2)

Fixes: #4459

Signed-off-by: Yannis Damigos <giannis.damigos@gmail.com>
Signed-off-by: Daniel Wagenknecht <wagenknecht@clage.de>