### PR TITLE
boards: disco_l475_iot1: Enable I2C_1 in default config

### DIFF
--- a/boards/arm/disco_l475_iot1/Kconfig.defconfig
+++ b/boards/arm/disco_l475_iot1/Kconfig.defconfig
@@ -48,11 +48,8 @@ endif # SERIAL
 
 if I2C
 
-config I2C_0
-	def_bool n
-
 config I2C_1
-	def_bool n
+	def_bool y
 
 config I2C_2
 	def_bool y


### PR DESCRIPTION
I2C_1 is enabled in board's DT file but we need to enable
it also in boards default config.

I2C_0 doesn't exist in STM32L475 SOC.

Signed-off-by: Yannis Damigos <giannis.damigos@gmail.com>