### PR TITLE
drivers/ieee802154: Fix coverity #178236, #178237 Out of bounds access

### DIFF
--- a/drivers/ieee802154/ieee802154_mcr20a.c
+++ b/drivers/ieee802154/ieee802154_mcr20a.c
@@ -200,7 +200,7 @@ bool _mcr20a_write_burst(struct mcr20a_spi *spi, bool dreg, u16_t addr,
 {
 	bool retval;
 
-	if ((len + 2) > sizeof(spi->cmd_buf)) {
+	if ((len + 2) >= sizeof(spi->cmd_buf)) {
 		SYS_LOG_ERR("cmd buffer too small");
 		return false;
 	}
@@ -230,7 +230,7 @@ bool _mcr20a_write_burst(struct mcr20a_spi *spi, bool dreg, u16_t addr,
 bool _mcr20a_read_burst(struct mcr20a_spi *spi, bool dreg, u16_t addr,
 			u8_t *data_buf, u8_t len)
 {
-	if ((len + 2) > sizeof(spi->cmd_buf)) {
+	if ((len + 2) >= sizeof(spi->cmd_buf)) {
 		SYS_LOG_ERR("cmd buffer too small");
 		return false;
 	}


### PR DESCRIPTION
Fixed the exposure to an out of bounds access of data structure due to
improper size test ("off by one") in two places.

Fixes #4592
Fixes #4591

Signed-off-by: David Leach <david.leach@nxp.com>