### PR TITLE
kernel: Preprocessor Undef warning fix in kernel.h

### DIFF
--- a/include/kernel.h
+++ b/include/kernel.h
@@ -3776,10 +3776,6 @@ enum _poll_states_bits {
 	       + 1 /* modes */ \
 	      ))
 
-#if _POLL_EVENT_NUM_UNUSED_BITS < 0
-#error overflow of 32-bit word in struct k_poll_event
-#endif
-
 /* end of polling API - PRIVATE */
 
 


### PR DESCRIPTION
_POLL_NUM_TYPES & _POLL_NUM_STATES are values of an enum, which the
preprocessor does not know about.
But the first of the removed lines needs to be evaluated by the preprocessor
using them.

The result is that the preprocessor will treat _POLL_NUM_TYPES
and _POLL_NUM_STATES as 0 in that expression, which would not seem the
intended behavior. It will also produce 2 warnings about this in each
file which includes kernel.h (lots)

=> lines 3779-3781 are be removed.

The compiler warning:
```
include/kernel.h:3774:11: warning: "_POLL_NUM_TYPES" is not defined [-Wundef]
         + _POLL_NUM_TYPES \
           ^
include/kernel.h:3779:5: note: in expansion of macro ?_POLL_EVENT_NUM_UNUSED_BITS?
#if _POLL_EVENT_NUM_UNUSED_BITS < 0
     ^
include/kernel.h:3775:11: warning: "_POLL_NUM_STATES" is not defined [-Wundef]
         + _POLL_NUM_STATES \
           ^
include/kernel.h:3779:5: note: in expansion of macro ?_POLL_EVENT_NUM_UNUSED_BITS?
#if _POLL_EVENT_NUM_UNUSED_BITS < 0
     ^
```

Signed-off-by: Alberto Escolar Piedras <alpi@oticon.com>