### PR TITLE
sanitycheck: Flush stdout in info()

### DIFF
--- a/scripts/sanitycheck
+++ b/scripts/sanitycheck
@@ -245,6 +245,7 @@ log_file = None
 # Debug Functions
 def info(what):
     sys.stdout.write(what + "\n")
+    sys.stdout.flush()
     if log_file:
         log_file.write(what + "\n")
         log_file.flush()


### PR DESCRIPTION
This makes piped output work as the user expects. And looking at the
piped output is the only way to use sanitycheck normally because
of #4603.

Signed-off-by: Paul Sokolovsky <paul.sokolovsky@linaro.org>