### PR TITLE
Run real networking tests via sanitycheck

### DIFF
--- a/tests/net/socket/tcp/testcase.yaml
+++ b/tests/net/socket/tcp/testcase.yaml
@@ -1,5 +1,7 @@
 tests:
   - test:
-      build_only: true
+      extra_configs:
+        - CONFIG_NET_TEST=y
+        - CONFIG_NET_LOOPBACK=y
       min_ram: 32
       tags: net

--- a/tests/net/socket/udp/testcase.yaml
+++ b/tests/net/socket/udp/testcase.yaml
@@ -1,5 +1,7 @@
 tests:
   - test:
-      build_only: true
-      min_ram: 16
+      extra_configs:
+        - CONFIG_NET_TEST=y
+        - CONFIG_NET_LOOPBACK=y
+      min_ram: 21
       tags: net


### PR DESCRIPTION
This patch combines:

* network loopback interface, #4461
* support for running "network" QEMU without connecting to host for networking (instead using just the internal loopback iface), https://github.com/zephyrproject-rtos/zephyr/pull/4457
* suitable testcase.yaml settings (thanks to @nashif for hints)

- to allow to run "real", "full IP stack" networking tests via sanitycheck and thus standard CI systems.
