### PR TITLE
Use quote include instead of system include

### DIFF
--- a/drivers/flash/flash_stm32.c
+++ b/drivers/flash/flash_stm32.c
@@ -12,7 +12,7 @@
 #include <init.h>
 #include <soc.h>
 
-#include <flash_stm32.h>
+#include "flash_stm32.h"
 
 #define STM32_FLASH_TIMEOUT	((u32_t) 0x000B0000)
 

--- a/drivers/flash/flash_stm32f4x.c
+++ b/drivers/flash/flash_stm32f4x.c
@@ -11,7 +11,7 @@
 #include <init.h>
 #include <soc.h>
 
-#include <flash_stm32.h>
+#include "flash_stm32.h"
 
 #define STM32F4X_SECTOR_MASK		((u32_t) 0xFFFFFF07)
 

--- a/drivers/spi/spi_dw_legacy.c
+++ b/drivers/spi/spi_dw_legacy.c
@@ -21,7 +21,7 @@
 #include <misc/util.h>
 
 #include <spi.h>
-#include <spi_dw.h>
+#include "spi_dw.h"
 
 #ifdef CONFIG_IOAPIC
 #include <drivers/ioapic.h>

--- a/drivers/spi/spi_ll_stm32.c
+++ b/drivers/spi/spi_ll_stm32.c
@@ -16,7 +16,7 @@
 #include <clock_control/stm32_clock_control.h>
 #include <clock_control.h>
 
-#include <spi_ll_stm32.h>
+#include "spi_ll_stm32.h"
 
 #define CONFIG_CFG(cfg)						\
 ((const struct spi_stm32_config * const)(cfg)->dev->config->config_info)

--- a/subsys/net/lib/sntp/sntp.c
+++ b/subsys/net/lib/sntp/sntp.c
@@ -11,7 +11,7 @@
 #endif
 
 #include <net/sntp.h>
-#include <sntp_pkt.h>
+#include "sntp_pkt.h"
 
 #define SNTP_LI_MAX 3
 #define SNTP_VERSION_NUMBER 3

--- a/tests/drivers/aon_counter/aon_api/src/main.c
+++ b/tests/drivers/aon_counter/aon_api/src/main.c
@@ -11,7 +11,7 @@
  * @}
  */
 
-#include <test_aon.h>
+#include "test_aon.h"
 
 void test_main(void)
 {

--- a/tests/drivers/aon_counter/aon_api/src/test_aon_counter.c
+++ b/tests/drivers/aon_counter/aon_api/src/test_aon_counter.c
@@ -23,7 +23,7 @@
  * @}
  */
 
-#include <test_aon.h>
+#include "test_aon.h"
 
 static int test_counter(void)
 {

--- a/tests/drivers/aon_counter/aon_api/src/test_aon_periodic_timer.c
+++ b/tests/drivers/aon_counter/aon_api/src/test_aon_periodic_timer.c
@@ -24,7 +24,7 @@
  * @}
  */
 
-#include <test_aon.h>
+#include "test_aon.h"
 
 #define ALARM_CNT 32768 /* about 1s */
 #define SLEEP_TIME 3050 /* a little longer than 3s */

--- a/tests/drivers/rtc/rtc_basic_api/src/main.c
+++ b/tests/drivers/rtc/rtc_basic_api/src/main.c
@@ -11,7 +11,7 @@
  * @}
  */
 
-#include <test_rtc.h>
+#include "test_rtc.h"
 
 void test_main(void)
 {

--- a/tests/drivers/rtc/rtc_basic_api/src/test_rtc_alarm.c
+++ b/tests/drivers/rtc/rtc_basic_api/src/test_rtc_alarm.c
@@ -24,7 +24,7 @@
  * @}
  */
 
-#include <test_rtc.h>
+#include "test_rtc.h"
 
 static bool rtc_alarm_up;
 

--- a/tests/drivers/rtc/rtc_basic_api/src/test_rtc_calendar.c
+++ b/tests/drivers/rtc/rtc_basic_api/src/test_rtc_calendar.c
@@ -21,7 +21,7 @@
  * @}
  */
 
-#include <test_rtc.h>
+#include "test_rtc.h"
 
 static int test_task(void)
 {

--- a/tests/drivers/uart/uart_basic_api/src/main.c
+++ b/tests/drivers/uart/uart_basic_api/src/main.c
@@ -11,7 +11,7 @@
  * @}
  */
 
-#include <test_uart.h>
+#include "test_uart.h"
 
 #ifdef CONFIG_CONSOLE_SHELL
 TC_CMD_DEFINE(test_uart_fifo_read)

--- a/tests/drivers/uart/uart_basic_api/src/test_uart_fifo.c
+++ b/tests/drivers/uart/uart_basic_api/src/test_uart_fifo.c
@@ -32,7 +32,7 @@
  * @}
  */
 
-#include <test_uart.h>
+#include "test_uart.h"
 
 static volatile bool data_transmitted;
 static volatile bool data_received;

--- a/tests/drivers/uart/uart_basic_api/src/test_uart_poll.c
+++ b/tests/drivers/uart/uart_basic_api/src/test_uart_poll.c
@@ -26,7 +26,7 @@
  * @}
  */
 
-#include <test_uart.h>
+#include "test_uart.h"
 
 static const char *poll_data = "This is a POLL test.\r\n";
 

--- a/tests/kernel/fp_sharing/src/main.c
+++ b/tests/kernel/fp_sharing/src/main.c
@@ -48,15 +48,15 @@
 
 #if defined(CONFIG_ISA_IA32)
 #if defined(__GNUC__)
-#include <float_regs_x86_gcc.h>
+#include "float_regs_x86_gcc.h"
 #else
-#include <float_regs_x86_other.h>
+#include "float_regs_x86_other.h"
 #endif /* __GNUC__ */
 #elif defined(CONFIG_CPU_CORTEX_M4)
 #if defined(__GNUC__)
-#include <float_regs_arm_gcc.h>
+#include "float_regs_arm_gcc.h"
 #else
-#include <float_regs_arm_other.h>
+#include "float_regs_arm_other.h"
 #endif /* __GNUC__ */
 #endif
 

--- a/tests/kernel/fp_sharing/src/pi.c
+++ b/tests/kernel/fp_sharing/src/pi.c
@@ -33,7 +33,7 @@
 #include <stdio.h>
 #include <tc_util.h>
 
-#include <float_context.h>
+#include "float_context.h"
 
 /*
  * PI_NUM_ITERATIONS: This macro is defined in the project's Makefile and

--- a/tests/kernel/static_idt/src/static_idt.c
+++ b/tests/kernel/static_idt/src/static_idt.c
@@ -17,9 +17,9 @@
 
 #include <kernel_structs.h>
 #if defined(__GNUC__)
-#include <test_asm_inline_gcc.h>
+#include "test_asm_inline_gcc.h"
 #else
-#include <test_asm_inline_other.h>
+#include "test_asm_inline_other.h"
 #endif
 
 /* These vectors are somewhat arbitrary. We try and use unused vectors */

--- a/tests/subsys/fs/fat_fs_api/src/common.c
+++ b/tests/subsys/fs/fat_fs_api/src/common.c
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <test_fat.h>
+#include "test_fat.h"
 
 const char test_str[] = "hello world!";
 

--- a/tests/subsys/fs/fat_fs_api/src/main.c
+++ b/tests/subsys/fs/fat_fs_api/src/main.c
@@ -11,7 +11,7 @@
  * @}
  */
 
-#include <test_fat.h>
+#include "test_fat.h"
 
 void test_main(void)
 {

--- a/tests/subsys/fs/fat_fs_api/src/test_fat_dir.c
+++ b/tests/subsys/fs/fat_fs_api/src/test_fat_dir.c
@@ -10,7 +10,7 @@
  * Demonstrates the ZEPHYR File System APIs
  */
 
-#include <test_fat.h>
+#include "test_fat.h"
 #include <stdio.h>
 
 extern int test_file_write(void);

--- a/tests/subsys/fs/fat_fs_api/src/test_fat_file.c
+++ b/tests/subsys/fs/fat_fs_api/src/test_fat_file.c
@@ -10,7 +10,7 @@
  * Demonstrates the ZEPHYR File System APIs
  */
 
-#include <test_fat.h>
+#include "test_fat.h"
 #include <string.h>
 
 static int test_file_open(void)

--- a/tests/subsys/fs/fat_fs_api/src/test_fat_fs.c
+++ b/tests/subsys/fs/fat_fs_api/src/test_fat_fs.c
@@ -10,7 +10,7 @@
  * to demonstrates the ZEPHYR File System APIs
  */
 
-#include <test_fat.h>
+#include "test_fat.h"
 
 static int test_statvfs(void)
 {


### PR DESCRIPTION
When the header file is located in the same directory as the source
file it is better to use a relative quote-include.

Avoiding the use of system includes in these cases is beneficial
because;

* The source code will be easier to build because there will be fewer
system include paths.

* It is easier for a user to determine where a quote-include header
  file is located than where a system include is located.

* You are less likely to encounter aliasing issues if the list of
  system include paths is minimized.

Authors:
Anas Nashif
Sebastian Bøe

Signed-off-by: Sebastian Boe <sebastian.boe@nordicsemi.no>