### PR TITLE
sanitycheck: tone down verbose output

### DIFF
--- a/scripts/sanitycheck
+++ b/scripts/sanitycheck
@@ -2112,7 +2112,7 @@ def main():
     if args.discard_report:
         ts.discard_report(args.discard_report)
 
-    if VERBOSE:
+    if VERBOSE > 1:
         for i, reason in discards.items():
             debug("{:<25} {:<50} {}SKIPPED{}: {}".format(i.platform.name,
                   i.test.name, COLOR_YELLOW, COLOR_NORMAL, reason))


### PR DESCRIPTION
We only had a few hundred tests run when sanitycheck was first written,
and printing out the reasoning why tests were skipped seemed reasonable
at the time. Now that we are running tens of thousands of tests, this
is too much information.

The dump of what tests were skipped and why now requires two instances
of --verbose on the command line.

Signed-off-by: Andrew Boie <andrew.p.boie@intel.com>