### PR TITLE
sw_isr_table.h: fix includes

### DIFF
--- a/include/sw_isr_table.h
+++ b/include/sw_isr_table.h
@@ -14,8 +14,6 @@
 #ifndef _SW_ISR_TABLE__H_
 #define _SW_ISR_TABLE__H_
 
-#include <arch/cpu.h>
-
 #ifdef __cplusplus
 extern "C" {
 #endif


### PR DESCRIPTION
This header doesn't need arch/cpu.h for anything in it, remove
to ease inclusion dependencies.

Signed-off-by: Andrew Boie <andrew.p.boie@intel.com>