### PR TITLE
[REGRESSION-FIX] net: lib: http: fix check for invalid body_start pointer

### DIFF
--- a/subsys/net/lib/http/http_client.c
+++ b/subsys/net/lib/http/http_client.c
@@ -292,7 +292,8 @@ static int on_body(struct http_parser *parser, const char *at, size_t length)
 
 	NET_DBG("Processed %zd length %zd", ctx->rsp.processed, length);
 
-	if ((u8_t *)at != (u8_t *)ctx->rsp.response_buf) {
+	if (!ctx->rsp.body_start &&
+	    (u8_t *)at != (u8_t *)ctx->rsp.response_buf) {
 		/* This fragment contains the start of the body */
 		ctx->rsp.body_start = (u8_t *)at;
 	}


### PR DESCRIPTION
Recent commit fb7f6cfa972d ("net: lib: http: Fix invalid pointer
body_start") introduced logic to reset the response body_start pointer
when the response buffer was reused.

This check needs to be fixed so that it doesn't arbitrarily change
body_start when not needed.

The problem with the current check can be demonstrated by not setting
a response callback for request which generates a large response spanning
multiple packets.

In this case body_start is still valid (not reusing the response buffer
because there is no callback set), but it will be changed when the 2nd
packet is received and the "at" marker is located at the head of the new
packet (!= response_buffer).

Signed-off-by: Michael Scott <michael.scott@linaro.org>