### PR TITLE
tests: bitfield: Convert legacy test case to ztest

### DIFF
--- a/tests/kernel/bitfield/Makefile
+++ b/tests/kernel/bitfield/Makefile
@@ -1,3 +1,4 @@
 BOARD ?= qemu_x86
+CONF_FILE = prj.conf
 
 include $(ZEPHYR_BASE)/Makefile.test

--- a/tests/kernel/bitfield/prj.conf
+++ b/tests/kernel/bitfield/prj.conf
@@ -1,0 +1,1 @@
+CONFIG_ZTEST=y

--- a/tests/kernel/bitfield/src/Makefile
+++ b/tests/kernel/bitfield/src/Makefile
@@ -1,3 +1,3 @@
 ccflags-y += -I${ZEPHYR_BASE}/tests/include
-
+include $(ZEPHYR_BASE)/tests/Makefile.test
 obj-y = bitfield.o

--- a/tests/kernel/bitfield/src/bitfield.c
+++ b/tests/kernel/bitfield/src/bitfield.c
@@ -5,6 +5,7 @@
  */
 
 #include <zephyr.h>
+#include <ztest.h>
 #include <arch/cpu.h>
 
 #include <tc_util.h>
@@ -13,12 +14,10 @@
 #define BIT_VAL(bit)    (1 << (bit & 0x7))
 #define BITFIELD_SIZE   512
 
-void main(void)
+void testing_bitfield(void)
 {
 	u32_t b1 = 0;
 	unsigned char b2[BITFIELD_SIZE >> 3] = { 0 };
-	int failed = 0;
-	int test_rv;
 	unsigned int bit;
 	int ret;
 
@@ -26,173 +25,93 @@ void main(void)
 
 	for (bit = 0; bit < 32; ++bit) {
 		sys_set_bit((mem_addr_t)&b1, bit);
-		if (b1 != (1 << bit)) {
-			b1 = (1 << bit);
-			TC_PRINT("sys_set_bit failed on bit %d\n",
-				 bit);
-			failed++;
-		}
 
-		if (!sys_test_bit((mem_addr_t)&b1, bit)) {
-			TC_PRINT("sys_test_bit did not detect bit %d\n",
-				 bit);
-			failed++;
-		}
+		zassert_equal(b1, (1 << bit),
+			      "sys_set_bit failed on bit %d\n", bit);
+
+		zassert_true(sys_test_bit((mem_addr_t)&b1, bit),
+			     "sys_test_bit did not detect bit %d\n", bit);
 
 		sys_clear_bit((mem_addr_t)&b1, bit);
-		if (b1 != 0) {
-			b1 = 0;
-			TC_PRINT("sys_clear_bit failed for bit %d\n",
-				 bit);
-			failed++;
-		}
+		zassert_equal(b1, 0, "sys_clear_bit failed for bit %d\n", bit);
 
-		if (sys_test_bit((mem_addr_t)&b1, bit)) {
-			TC_PRINT("sys_test_bit erroneously detected bit %d\n",
-				 bit);
-			failed++;
-		}
+		zassert_false(sys_test_bit((mem_addr_t)&b1, bit),
+			      "sys_test_bit erroneously detected bit %d\n",
+			      bit);
 
-		ret = sys_test_and_set_bit((mem_addr_t)&b1, bit);
-		if (ret) {
-			TC_PRINT("sys_test_and_set_bit erroneously detected bit %d\n",
-				 bit);
-			failed++;
-		}
-		if (b1 != (1 << bit)) {
-			b1 = (1 << bit);
-			TC_PRINT("sys_test_and_set_bit did not set bit %d\n",
-				 bit);
-			failed++;
-		}
-		ret = sys_test_and_set_bit((mem_addr_t)&b1, bit);
-		if (!ret) {
-			TC_PRINT("sys_test_and_set_bit did not detect bit %d\n",
-				 bit);
-			failed++;
-		}
-		if (b1 != (1 << bit)) {
-			b1 = (1 << bit);
-			TC_PRINT("sys_test_and_set_bit cleared bit %d\n",
-				 bit);
-			failed++;
-		}
+		zassert_false(sys_test_and_set_bit((mem_addr_t)&b1, bit),
+			      "sys_test_and_set_bit erroneously"
+			      " detected bit %d\n", bit);
+		zassert_equal(b1, (1 << bit),
+			      "sys_test_and_set_bit did not set bit %d\n",
+			      bit);
+		zassert_true(sys_test_and_set_bit((mem_addr_t)&b1, bit),
+			     "sys_test_and_set_bit did not detect bit %d\n",
+			     bit);
+		zassert_equal(b1, (1 << bit),
+			      "sys_test_and_set_bit cleared bit %d\n", bit);
 
-		ret = sys_test_and_clear_bit((mem_addr_t)&b1, bit);
-		if (!ret) {
-			TC_PRINT("sys_test_and_clear_bit did not detect bit %d\n",
-				 bit);
-			failed++;
-		}
-		if (b1 != 0) {
-			b1 = 0;
-			TC_PRINT("sys_test_and_clear_bit did not clear bit %d\n",
-				 bit);
-			failed++;
-		}
-		ret = sys_test_and_clear_bit((mem_addr_t)&b1, bit);
-		if (ret) {
-			TC_PRINT("sys_test_and_clear_bit erroneously detected bit %d\n",
-				 bit);
-			failed++;
-		}
-		if (b1 != 0) {
-			b1 = 0;
-			TC_PRINT("sys_test_and_clear_bit set bit %d\n",
-				 bit);
-			failed++;
-		}
+		zassert_true(sys_test_and_clear_bit((mem_addr_t)&b1, bit),
+			     "sys_test_and_clear_bit did not detect bit %d\n",
+			     bit);
+		zassert_equal(b1, 0, "sys_test_and_clear_bit did not clear"
+			      " bit %d\n", bit);
+		zassert_false(sys_test_and_clear_bit((mem_addr_t)&b1, bit),
+			      "sys_test_and_clear_bit erroneously detected"
+			      " bit %d\n", bit);
+		zassert_equal(b1, 0, "sys_test_and_clear_bit set bit %d\n",
+			      bit);
 	}
 
 	for (bit = 0; bit < BITFIELD_SIZE; ++bit) {
 		sys_bitfield_set_bit((mem_addr_t)b2, bit);
-		if (b2[BIT_INDEX(bit)] != BIT_VAL(bit)) {
-			TC_PRINT("got %d expected %d\n", b2[BIT_INDEX(bit)],
-				 BIT_VAL(bit));
-			TC_PRINT("sys_bitfield_set_bit failed for bit %d\n",
-				 bit);
-			b2[BIT_INDEX(bit)] = BIT_VAL(bit);
-			failed++;
-		}
-
-		if (!sys_bitfield_test_bit((mem_addr_t)b2, bit)) {
-			TC_PRINT("sys_bitfield_test_bit did not detect bit %d\n",
-				 bit);
-			failed++;
-		}
+		zassert_equal(b2[BIT_INDEX(bit)], BIT_VAL(bit),
+			      "sys_bitfield_set_bit failed for bit %d\n",
+			      bit);
+		zassert_true(sys_bitfield_test_bit((mem_addr_t)b2, bit),
+			     "sys_bitfield_test_bit did not detect bit %d\n",
+			     bit);
 
 		sys_bitfield_clear_bit((mem_addr_t)b2, bit);
-		if (b2[BIT_INDEX(bit)] != 0) {
-			b2[BIT_INDEX(bit)] = 0;
-			TC_PRINT("sys_bitfield_clear_bit failed for bit %d\n",
-				 bit);
-			failed++;
-		}
-
-		if (sys_bitfield_test_bit((mem_addr_t)b2, bit)) {
-			TC_PRINT("sys_bitfield_test_bit erroneously detected bit %d\n",
-				 bit);
-			failed++;
-		}
+		zassert_equal(b2[BIT_INDEX(bit)], 0,
+			      "sys_bitfield_clear_bit failed for bit %d\n",
+			      bit);
+		zassert_false(sys_bitfield_test_bit((mem_addr_t)b2, bit),
+			      "sys_bitfield_test_bit erroneously detected"
+			      " bit %d\n", bit);
 
 		ret = sys_bitfield_test_and_set_bit((mem_addr_t)b2, bit);
-		if (ret) {
-			TC_PRINT("sys_bitfield_test_and_set_bit erroneously detected bit %d\n",
-				 bit);
-			failed++;
-		}
-		if (b2[BIT_INDEX(bit)] != BIT_VAL(bit)) {
-			b2[BIT_INDEX(bit)] = BIT_VAL(bit);
-			TC_PRINT("sys_bitfield_test_and_set_bit did not set bit %d\n",
-				 bit);
-			failed++;
-		}
-		ret = sys_bitfield_test_and_set_bit((mem_addr_t)b2, bit);
-		if (!ret) {
-			TC_PRINT("sys_bitfield_test_and_set_bit did not detect bit %d\n",
-				 bit);
-			failed++;
-		}
-		if (b2[BIT_INDEX(bit)] != BIT_VAL(bit)) {
-			b2[BIT_INDEX(bit)] = BIT_VAL(bit);
-			TC_PRINT("sys_bitfield_test_and_set_bit cleared bit %d\n",
-				 bit);
-			failed++;
-		}
+		zassert_false(ret, "sys_bitfield_test_and_set_bit erroneously"
+			      " detected bit %d\n", bit);
 
-		ret = sys_bitfield_test_and_clear_bit((mem_addr_t)b2, bit);
-		if (!ret) {
-			TC_PRINT("sys_bitfield_test_and_clear_bit did not detect bit %d\n",
-				 bit);
-			failed++;
-		}
-		if (b2[BIT_INDEX(bit)] != 0) {
-			b2[BIT_INDEX(bit)] = 0;
-			TC_PRINT("sys_bitfield_test_and_clear_bit did not clear bit %d\n",
-				 bit);
-			failed++;
-		}
-		ret = sys_bitfield_test_and_clear_bit((mem_addr_t)b2, bit);
-		if (ret) {
-			TC_PRINT("sys_bitfield_test_and_clear_bit erroneously detected bit %d\n",
-				 bit);
-			failed++;
-		}
-		if (b2[BIT_INDEX(bit)] != 0) {
-			b2[BIT_INDEX(bit)] = 0;
-			TC_PRINT("sys_bitfield_test_and_clear_bit set bit %d\n",
-				 bit);
-			failed++;
-		}
+		zassert_equal(b2[BIT_INDEX(bit)], BIT_VAL(bit),
+			      "sys_bitfield_test_and_set_bit did not set"
+			      " bit %d\n", bit);
+		zassert_true(sys_bitfield_test_and_set_bit((mem_addr_t)b2, bit),
+			     "sys_bitfield_test_and_set_bit did not detect bit"
+			     " %d\n", bit);
+		zassert_equal(b2[BIT_INDEX(bit)], BIT_VAL(bit),
+			      "sys_bitfield_test_and_set_bit cleared bit %d\n",
+			      bit);
+
+		zassert_true(sys_bitfield_test_and_clear_bit((mem_addr_t)b2,
+							     bit), "sys_bitfield_test_and_clear_bit did not"
+			     " detect bit %d\n", bit);
+		zassert_equal(b2[BIT_INDEX(bit)], 0,
+			      "sys_bitfield_test_and_clear_bit did not"
+			      " clear bit %d\n", bit);
+		zassert_false(sys_bitfield_test_and_clear_bit((mem_addr_t)b2,
+							      bit), "sys_bitfield_test_and_clear_bit"
+			      " erroneously detected bit %d\n", bit);
+		zassert_equal(b2[BIT_INDEX(bit)], 0,
+			      "sys_bitfield_test_and_clear_bit set bit %d\n",
+			      bit);
 	}
+}
 
-	if (failed) {
-		TC_PRINT("%d tests failed\n", failed);
-		test_rv = TC_FAIL;
-	} else {
-		test_rv = TC_PASS;
-	}
-
-	TC_END_RESULT(test_rv);
-	TC_END_REPORT(test_rv);
+/*test case main entry*/
+void test_main(void)
+{
+	ztest_test_suite(test_bitfield, ztest_unit_test(testing_bitfield));
+	ztest_run_test_suite(test_bitfield);
 }


### PR DESCRIPTION
Add ztest apis and make test case align to use ztest
framework.

Signed-off-by: Punit Vara <punit.vara@intel.com>