### PR TITLE
usb: netusb: Add missing ethernet dependency

### DIFF
--- a/subsys/usb/class/netusb/Kconfig
+++ b/subsys/usb/class/netusb/Kconfig
@@ -8,6 +8,7 @@
 
 menu "USB Device Networking support"
 	depends on USB_DEVICE_STACK
+	depends on NET_L2_ETHERNET
 
 config USB_DEVICE_NETWORK
 	bool


### PR DESCRIPTION
usb networking depends on Ethernet support (NET_L2_ETHERNET).

Signed-off-by: Loic Poulain <loic.poulain@linaro.org>