### PR TITLE
Bluetooth: controller: Fix to enable Asym PHY on nRF52 Series

### DIFF
--- a/subsys/bluetooth/controller/Kconfig
+++ b/subsys/bluetooth/controller/Kconfig
@@ -338,7 +338,7 @@ config BT_CTLR_SCHED_ADVANCED
 config BT_CTLR_RADIO_ENABLE_FAST
 	bool "Use tTXEN/RXEN,FAST ramp-up"
 	depends on SOC_SERIES_NRF52X
-	default y if SOC_NRF52840
+	default y
 	help
 	  Enable use of fast radio ramp-up mode.
 


### PR DESCRIPTION
Fix the controller Kconfig to enable use of fast radio ramp
up by default, hence enabling support for Asym PHY updates
by default on nRF52 Series SoCs.

Signed-off-by: Vinayak Kariappa Chettimada <vich@nordicsemi.no>