### PR TITLE
boards: update STM32 disco boards name yaml property

### DIFF
--- a/boards/arm/disco_l475_iot1/disco_l475_iot1.yaml
+++ b/boards/arm/disco_l475_iot1/disco_l475_iot1.yaml
@@ -1,5 +1,5 @@
 identifier: disco_l475_iot1
-name: ST Disco L475 IOT01
+name: B-L475E-IOT01A
 type: mcu
 arch: arm
 toolchain:

--- a/boards/arm/stm32f412g_disco/stm32f412g_disco.yaml
+++ b/boards/arm/stm32f412g_disco/stm32f412g_disco.yaml
@@ -1,5 +1,5 @@
 identifier: stm32f412g_disco
-name: 32F412GDISCOVERY
+name: STM32F412G-DISCO
 type: mcu
 arch: arm
 toolchain:

--- a/boards/arm/stm32f429i_disc1/stm32f429i_disc1.yaml
+++ b/boards/arm/stm32f429i_disc1/stm32f429i_disc1.yaml
@@ -1,5 +1,5 @@
 identifier: stm32f429i_disc1
-name: STM32F429I_DISC1
+name: STM32F429I-DISC1
 type: mcu
 arch: arm
 toolchain:

--- a/boards/arm/stm32f469i_disco/stm32f469i_disco.yaml
+++ b/boards/arm/stm32f469i_disco/stm32f469i_disco.yaml
@@ -1,5 +1,5 @@
 identifier: stm32f469i_disco
-name: 32F469IDISCOVERY
+name: STM32F469I-DISCO
 type: mcu
 arch: arm
 toolchain:

--- a/boards/arm/stm32f4_disco/stm32f4_disco.yaml
+++ b/boards/arm/stm32f4_disco/stm32f4_disco.yaml
@@ -1,5 +1,5 @@
 identifier: stm32f4_disco
-name: STM32F4DISCOVERY
+name: STM32F407G-DISC1
 type: mcu
 arch: arm
 toolchain:

--- a/boards/arm/stm32l496g_disco/stm32l496g_disco.yaml
+++ b/boards/arm/stm32l496g_disco/stm32l496g_disco.yaml
@@ -1,5 +1,5 @@
 identifier: stm32l496g_disco
-name: 32L496GDISCOVERY
+name: STM32L496G-DISCO
 type: mcu
 arch: arm
 toolchain:


### PR DESCRIPTION
Update yaml property for STM32 Disco boards.
It is set to silkscreen name

Signed-off-by: Erwan Gouriou <erwan.gouriou@linaro.org>