### PR TITLE
net: sockets: Fix Coverity false positive

### DIFF
--- a/subsys/net/lib/sockets/sockets.c
+++ b/subsys/net/lib/sockets/sockets.c
@@ -108,7 +108,8 @@ static void zsock_accepted_cb(struct net_context *new_ctx,
 			      int status, void *user_data) {
 	struct net_context *parent = user_data;
 
-	net_context_recv(new_ctx, zsock_received_cb, K_NO_WAIT, NULL);
+	/* This just installs a callback, so cannot fail. */
+	(void)net_context_recv(new_ctx, zsock_received_cb, K_NO_WAIT, NULL);
 	k_fifo_init(&new_ctx->recv_q);
 
 	NET_DBG("parent=%p, ctx=%p, st=%d", parent, new_ctx, status);


### PR DESCRIPTION
Due to parameters used, net_context_recv() call cannot fail (it just
installs a callback, no I/O performed).

Coverity-CID: 178247
Fixes: #4581

Signed-off-by: Paul Sokolovsky <paul.sokolovsky@linaro.org>