### PR TITLE
net: tcp: Parse and store send MSS

### DIFF
--- a/subsys/net/ip/net_context.c
+++ b/subsys/net/ip/net_context.c
@@ -99,6 +99,7 @@ static struct tcp_backlog_entry {
 	u32_t recv_max_ack;
 	u32_t send_seq;
 	u32_t send_ack;
+	u16_t send_mss;
 	struct k_delayed_work ack_timer;
 } tcp_backlog[CONFIG_NET_TCP_BACKLOG_SIZE];
 
@@ -174,7 +175,8 @@ static int tcp_backlog_find(struct net_pkt *pkt, int *empty_slot)
 	return -EADDRNOTAVAIL;
 }
 
-static int tcp_backlog_syn(struct net_pkt *pkt, struct net_context *context)
+static int tcp_backlog_syn(struct net_pkt *pkt, struct net_context *context,
+			   u16_t send_mss)
 {
 	int empty_slot = -1;
 	int ret;
@@ -198,6 +200,7 @@ static int tcp_backlog_syn(struct net_pkt *pkt, struct net_context *context)
 	tcp_backlog[empty_slot].recv_max_ack = context->tcp->recv_max_ack;
 	tcp_backlog[empty_slot].send_seq = context->tcp->send_seq;
 	tcp_backlog[empty_slot].send_ack = context->tcp->send_ack;
+	tcp_backlog[empty_slot].send_mss = send_mss;
 
 	k_delayed_work_init(&tcp_backlog[empty_slot].ack_timer,
 			    backlog_ack_timeout);
@@ -232,6 +235,7 @@ static int tcp_backlog_ack(struct net_pkt *pkt, struct net_context *context)
 	context->tcp->recv_max_ack = tcp_backlog[r].recv_max_ack;
 	context->tcp->send_seq = tcp_backlog[r].send_seq + 1;
 	context->tcp->send_ack = tcp_backlog[r].send_ack;
+	context->tcp->send_mss = tcp_backlog[r].send_mss;
 
 	k_delayed_work_cancel(&tcp_backlog[r].ack_timer);
 	memset(&tcp_backlog[r], 0, sizeof(struct tcp_backlog_entry));
@@ -1610,6 +1614,7 @@ NET_CONN_CB(tcp_syn_rcvd)
 	 */
 	if (NET_TCP_FLAGS(tcp_hdr) == NET_TCP_SYN) {
 		int r;
+		u16_t send_mss = NET_TCP_DEFAULT_MSS;
 
 		net_tcp_print_recv_info("SYN", pkt, tcp_hdr->src_port);
 
@@ -1621,7 +1626,9 @@ NET_CONN_CB(tcp_syn_rcvd)
 			sys_get_be32(tcp_hdr->seq) + 1;
 		context->tcp->recv_max_ack = context->tcp->send_seq + 1;
 
-		r = tcp_backlog_syn(pkt, context);
+		/* Get MSS from TCP options here*/
+
+		r = tcp_backlog_syn(pkt, context, send_mss);
 		if (r < 0) {
 			if (r == -EADDRINUSE) {
 				NET_DBG("TCP connection already exists");

--- a/subsys/net/ip/net_context.c
+++ b/subsys/net/ip/net_context.c
@@ -1077,10 +1077,9 @@ static int tcp_hdr_len(struct net_pkt *pkt)
 {
 	struct net_tcp_hdr hdr, *tcp_hdr;
 
-	/* "Offset": 4-bit field in high nibble, units of dwords */
 	tcp_hdr = net_tcp_get_hdr(pkt, &hdr);
 	if (tcp_hdr) {
-		return 4 * (tcp_hdr->offset >> 4);
+		return NET_TCP_HDR_LEN(tcp_hdr);
 	}
 
 	return 0;

--- a/subsys/net/ip/tcp.c
+++ b/subsys/net/ip/tcp.c
@@ -238,6 +238,7 @@ struct net_tcp *net_tcp_alloc(struct net_context *context)
 	tcp_context[i].send_seq = tcp_init_isn();
 	tcp_context[i].recv_max_ack = tcp_context[i].send_seq + 1u;
 	tcp_context[i].recv_wnd = min(NET_TCP_MAX_WIN, NET_TCP_BUF_MAX_LEN);
+	tcp_context[i].send_mss = NET_TCP_DEFAULT_MSS;
 
 	tcp_context[i].accept_cb = NULL;
 

--- a/subsys/net/ip/tcp.h
+++ b/subsys/net/ip/tcp.h
@@ -72,6 +72,10 @@ enum net_tcp_state {
 
 #define NET_TCP_FLAGS(hdr) (hdr->flags & NET_TCP_CTL)
 
+/* Length of TCP header, including options */
+/* "offset": 4-bit field in high nibble, units of dwords */
+#define NET_TCP_HDR_LEN(hdr) (4 * ((hdr)->offset >> 4))
+
 /* RFC 1122 4.2.2.6 "If an MSS option is not received at connection
  * setup, TCP MUST assume a default send MSS of 536"
  */

--- a/subsys/net/ip/tcp.h
+++ b/subsys/net/ip/tcp.h
@@ -72,6 +72,11 @@ enum net_tcp_state {
 
 #define NET_TCP_FLAGS(hdr) (hdr->flags & NET_TCP_CTL)
 
+/* RFC 1122 4.2.2.6 "If an MSS option is not received at connection
+ * setup, TCP MUST assume a default send MSS of 536"
+ */
+#define NET_TCP_DEFAULT_MSS   536
+
 /* TCP max window size */
 #define NET_TCP_MAX_WIN   (4 * 1024)
 
@@ -148,7 +153,15 @@ struct net_tcp {
 	 */
 	struct k_sem connect_wait;
 
+	/**
+	 * Current TCP receive window for our side
+	 */
 	u16_t recv_wnd;
+
+	/**
+	 * Send MSS for the peer
+	 */
+	u16_t send_mss;
 };
 
 static inline bool net_tcp_is_used(struct net_tcp *tcp)

--- a/subsys/net/ip/tcp.h
+++ b/subsys/net/ip/tcp.h
@@ -89,11 +89,22 @@ enum net_tcp_state {
 
 #define NET_TCP_MAX_OPT_SIZE  8
 
-#define NET_TCP_MSS_HEADER    0x02040000 /* MSS option */
-#define NET_TCP_WINDOW_HEADER 0x30300    /* Window scale option */
+/* TCP Option codes */
+#define NET_TCP_END_OPT          0
+#define NET_TCP_NOP_OPT          1
+#define NET_TCP_MSS_OPT          2
+#define NET_TCP_WINDOW_SCALE_OPT 3
 
-#define NET_TCP_MSS_SIZE      4          /* MSS option size */
-#define NET_TCP_WINDOW_SIZE   3          /* Window scale option size */
+/* TCP Option sizes */
+#define NET_TCP_END_SIZE          1
+#define NET_TCP_NOP_SIZE          1
+#define NET_TCP_MSS_SIZE          4
+#define NET_TCP_WINDOW_SCALE_SIZE 3
+
+/** Parsed TCP option values for net_tcp_parse_opts()  */
+struct net_tcp_options {
+	u16_t mss;
+};
 
 /* Max received bytes to buffer internally */
 #define NET_TCP_BUF_MAX_LEN 1280
@@ -442,6 +453,23 @@ struct net_buf *net_tcp_set_chksum(struct net_pkt *pkt, struct net_buf *frag);
  * @return Return the checksum in host byte order.
  */
 u16_t net_tcp_get_chksum(struct net_pkt *pkt, struct net_buf *frag);
+
+/**
+ * @brief Parse TCP options from network packet.
+ *
+ * Parse TCP options, returning MSS value (as that the only one we
+ * handle so far).
+ *
+ * @param pkt Network packet
+ * @param opt_totlen Total length of options to parse
+ * @param opts Pointer to TCP options structure. (Each option is updated
+ * only if present, so the structure must be initialized with the default
+ * values.)
+ *
+ * @return 0 if no error, <0 in case of error
+ */
+int net_tcp_parse_opts(struct net_pkt *pkt, int opt_totlen,
+		       struct net_tcp_options *opts);
 
 #else
 


### PR DESCRIPTION
MSS is Maximum Segment Size (data payload) of TCP. In SYN packets,
each side of the connection shares an MSS it wants to use (receive)
via the corresponding TCP option. If the option is not available,
the RFC mandates use of the value 536.

This patchset is a prerequisite for proper implementing https://github.com/zephyrproject-rtos/zephyr/pull/119

Signed-off-by: Paul Sokolovsky <paul.sokolovsky@linaro.org>