### PR TITLE
sanitycheck: Honor ${USE_CCACHE} environment variable

### DIFF
--- a/scripts/sanitycheck
+++ b/scripts/sanitycheck
@@ -1823,6 +1823,14 @@ class TestSuite:
                 cw.writerow(rowdict)
 
 
+def is_ccache_enabled_in_environ():
+    try:
+        value = os.environ["USE_CCACHE"]
+        return int(value)
+    except:
+        return 0
+
+
 def parse_arguments():
 
     parser = argparse.ArgumentParser(description = __doc__,
@@ -1880,7 +1888,8 @@ def parse_arguments():
     parser.add_argument("--compare-report",
             help="Use this report file for size comparison")
 
-    parser.add_argument("--ccache", action="store_const", const=1, default=0,
+    parser.add_argument("--ccache", action="store_const", const=1,
+            default=is_ccache_enabled_in_environ(),
             help="Enable the use of ccache when building")
 
     parser.add_argument("-B", "--subset",


### PR DESCRIPTION
Sanitycheck will only enable the use of ccache if `--ccache' is passed
to the command line.  The Zephyr build system uses the USE_CCACHE
environment variable instead.

If this variable is set to a true-ish value, sanitycheck will work as
if `--ccache' has been passed.

Signed-off-by: Leandro Pereira <leandro.pereira@intel.com>