### PR TITLE
net: lwm2m: break the opaque write loop early when fail

### DIFF
--- a/subsys/net/lib/lwm2m/lwm2m_engine.c
+++ b/subsys/net/lib/lwm2m/lwm2m_engine.c
@@ -1903,6 +1903,9 @@ static int lwm2m_write_handler_opaque(struct lwm2m_engine_obj_inst *obj_inst,
 						 data_ptr, len,
 						 last_pkt_block && last_block,
 						 total_size);
+			if (ret < 0) {
+				return ret;
+			}
 		}
 	}
 


### PR DESCRIPTION
As title, check the return value from the write callback and break if an error is returned

