### PR TITLE
arch: arm: kinetis: Remove duplicate CLOCK_CONTROL config option

### DIFF
--- a/arch/arm/soc/nxp_kinetis/k6x/Kconfig.defconfig.mk64f12
+++ b/arch/arm/soc/nxp_kinetis/k6x/Kconfig.defconfig.mk64f12
@@ -19,9 +19,6 @@ config ADC_MCUX_ADC16
 
 endif # ADC
 
-config CLOCK_CONTROL
-	def_bool y
-
 if CLOCK_CONTROL
 
 config CLOCK_CONTROL_MCUX_SIM

--- a/arch/arm/soc/nxp_kinetis/k6x/Kconfig.series
+++ b/arch/arm/soc/nxp_kinetis/k6x/Kconfig.series
@@ -13,5 +13,6 @@ config SOC_SERIES_KINETIS_K6X
 	select SYS_POWER_LOW_POWER_STATE_SUPPORTED
 	select CPU_HAS_SYSTICK
 	select CPU_HAS_MPU
+	select CLOCK_CONTROL
 	help
 	  Enable support for Kinetis K6x MCU series

--- a/arch/arm/soc/nxp_kinetis/kl2x/Kconfig.defconfig.mkl25z4
+++ b/arch/arm/soc/nxp_kinetis/kl2x/Kconfig.defconfig.mkl25z4
@@ -22,9 +22,6 @@ config ADC_MCUX_ADC16
 
 endif # ADC
 
-config CLOCK_CONTROL
-	def_bool y
-
 if CLOCK_CONTROL
 
 config CLOCK_CONTROL_MCUX_SIM

--- a/arch/arm/soc/nxp_kinetis/kl2x/Kconfig.series
+++ b/arch/arm/soc/nxp_kinetis/kl2x/Kconfig.series
@@ -12,5 +12,6 @@ config SOC_SERIES_KINETIS_KL2X
 	select SOC_FAMILY_KINETIS
 	select SYS_POWER_LOW_POWER_STATE_SUPPORTED
 	select CPU_HAS_SYSTICK
+	select CLOCK_CONTROL
 	help
 	 Enable support for Kinetis KL2x MCU series

--- a/arch/arm/soc/nxp_kinetis/kwx/Kconfig.defconfig.mkw2xd512
+++ b/arch/arm/soc/nxp_kinetis/kwx/Kconfig.defconfig.mkw2xd512
@@ -34,9 +34,6 @@ config ADC_MCUX_ADC16
 
 endif # ADC
 
-config CLOCK_CONTROL
-	def_bool y
-
 if CLOCK_CONTROL
 
 config CLOCK_CONTROL_MCUX_SIM

--- a/arch/arm/soc/nxp_kinetis/kwx/Kconfig.defconfig.mkw40z4
+++ b/arch/arm/soc/nxp_kinetis/kwx/Kconfig.defconfig.mkw40z4
@@ -22,9 +22,6 @@ config ADC_MCUX_ADC16
 
 endif # ADC
 
-config CLOCK_CONTROL
-	def_bool y
-
 if CLOCK_CONTROL
 
 config CLOCK_CONTROL_MCUX_SIM

--- a/arch/arm/soc/nxp_kinetis/kwx/Kconfig.defconfig.mkw41z4
+++ b/arch/arm/soc/nxp_kinetis/kwx/Kconfig.defconfig.mkw41z4
@@ -22,9 +22,6 @@ config ADC_MCUX_ADC16
 
 endif # ADC
 
-config CLOCK_CONTROL
-	def_bool y
-
 if CLOCK_CONTROL
 
 config CLOCK_CONTROL_MCUX_SIM

--- a/arch/arm/soc/nxp_kinetis/kwx/Kconfig.series
+++ b/arch/arm/soc/nxp_kinetis/kwx/Kconfig.series
@@ -11,5 +11,6 @@ config SOC_SERIES_KINETIS_KWX
 	select SOC_FAMILY_KINETIS
 	select SYS_POWER_LOW_POWER_STATE_SUPPORTED
 	select CPU_HAS_SYSTICK
+	select CLOCK_CONTROL
 	help
 	  Enable support for Kinetis KWx MCU series


### PR DESCRIPTION
The CLOCK_CONTROL config option is already defined in
drivers/clock_control, so there's no need to redefine it in arch/.

Signed-off-by: Carles Cufi <carles.cufi@nordicsemi.no>