### PR TITLE
Cmake sync and fix dts

### DIFF
--- a/dts/dts.cmake
+++ b/dts/dts.cmake
@@ -61,7 +61,7 @@ if(CONFIG_HAS_DTS)
   endif()
   set(CMD_EXTRACT_DTS_INCLUDES ${PYTHON_EXECUTABLE} ${PROJECT_SOURCE_DIR}/scripts/dts/extract_dts_includes.py
     --dts ${BOARD_FAMILY}.dts_compiled
-    --yaml ${PROJECT_SOURCE_DIR}/dts/${ARCH}/yaml
+    --yaml ${PROJECT_SOURCE_DIR}/dts/bindings
     ${FIXUP}
     )
   execute_process(


### PR DESCRIPTION
@nashif : Hi I took cmake_migration, rebased it onto master (yesterday, so 1efce2b) and fixed the dts issue.

Force-pushing this to cmake_migration will give us something that we can continue to work with (fix/port other upstream changes and then put up for review).