### PR TITLE
net: pkt: adjust_offset: Simplify and optimize code

### DIFF
--- a/subsys/net/ip/net_pkt.c
+++ b/subsys/net/ip/net_pkt.c
@@ -1215,11 +1215,7 @@ static inline struct net_buf *adjust_offset(struct net_buf *frag,
 	}
 
 	while (frag) {
-		if (offset == frag->len) {
-			*pos = 0;
-
-			return frag->frags;
-		} else if (offset < frag->len) {
+		if (offset < frag->len) {
 			*pos = offset;
 
 			return frag;


### PR DESCRIPTION
An edge condition was handled in a special way, even though the main
condition covered it well. More code, more jumps == slower code,
bigger binaries.

Signed-off-by: Paul Sokolovsky <paul.sokolovsky@linaro.org>