### PR TITLE
break header dependency cycles

### DIFF
--- a/include/arch/nios2/asm_inline_gcc.h
+++ b/include/arch/nios2/asm_inline_gcc.h
@@ -19,6 +19,7 @@ extern "C" {
 #ifndef _ASMLANGUAGE
 
 #include <sys_io.h>
+#include <toolchain.h>
 
 /**
  *

--- a/include/arch/x86/irq_controller.h
+++ b/include/arch/x86/irq_controller.h
@@ -33,6 +33,7 @@
 #define IRQ_POLARITY_LOW	_IRQ_POLARITY_LOW
 
 #ifndef _ASMLANGUAGE
+#include <zephyr/types.h>
 
 #if CONFIG_X86_FIXED_IRQ_MAPPING
 /**

--- a/include/drivers/ioapic.h
+++ b/include/drivers/ioapic.h
@@ -9,8 +9,6 @@
 #ifndef __INCioapich
 #define __INCioapich
 
-#include <drivers/loapic.h>
-
 #ifdef __cplusplus
 extern "C" {
 #endif
@@ -37,7 +35,6 @@ extern "C" {
 #define IOAPIC_EXTINT 0x00000700
 
 #ifndef _ASMLANGUAGE
-#include <device.h>
 void _ioapic_irq_enable(unsigned int irq);
 void _ioapic_irq_disable(unsigned int irq);
 void _ioapic_int_vec_set(unsigned int irq, unsigned int vector);

--- a/include/drivers/loapic.h
+++ b/include/drivers/loapic.h
@@ -45,7 +45,6 @@ extern "C" {
 #define LOAPIC_LVT_MASKED 0x00010000   /* mask */
 
 #ifndef _ASMLANGUAGE
-#include <device.h>
 
 extern void _loapic_int_vec_set(unsigned int irq, unsigned int vector);
 extern void _loapic_irq_enable(unsigned int irq);

--- a/include/drivers/sysapic.h
+++ b/include/drivers/sysapic.h
@@ -7,7 +7,6 @@
 #ifndef __INC_SYS_APIC_H
 #define __INC_SYS_APIC_H
 
-#include <drivers/ioapic.h>
 #include <drivers/loapic.h>
 
 #define _IRQ_TRIGGER_EDGE	IOAPIC_EDGE
@@ -17,6 +16,7 @@
 #define _IRQ_POLARITY_LOW	IOAPIC_LOW
 
 #ifndef _ASMLANGUAGE
+#include <zephyr/types.h>
 
 #define LOAPIC_IRQ_BASE  CONFIG_IOAPIC_NUM_RTES
 #define LOAPIC_IRQ_COUNT 6  /* Default to LOAPIC_TIMER to LOAPIC_ERROR */

--- a/include/kernel.h
+++ b/include/kernel.h
@@ -29,6 +29,8 @@
 #include <random/rand32.h>
 #include <kernel_arch_thread.h>
 #include <syscall.h>
+#include <misc/printk.h>
+#include <arch/cpu.h>
 
 #ifdef __cplusplus
 extern "C" {
@@ -42,7 +44,6 @@ extern "C" {
  */
 
 #ifdef CONFIG_KERNEL_DEBUG
-#include <misc/printk.h>
 #define K_DEBUG(fmt, ...) printk("[%s]  " fmt, __func__, ##__VA_ARGS__)
 #else
 #define K_DEBUG(fmt, ...)
@@ -4003,14 +4004,10 @@ extern void k_cpu_atomic_idle(unsigned int key);
 
 extern void _sys_power_save_idle_exit(s32_t ticks);
 
-#include <arch/cpu.h>
-
 #ifdef _ARCH_EXCEPT
 /* This archtecture has direct support for triggering a CPU exception */
 #define _k_except_reason(reason)	_ARCH_EXCEPT(reason)
 #else
-
-#include <misc/printk.h>
 
 /* NOTE: This is the implementation for arches that do not implement
  * _ARCH_EXCEPT() to generate a real CPU exception.

--- a/include/sys_io.h
+++ b/include/sys_io.h
@@ -13,7 +13,6 @@
 extern "C" {
 #endif
 
-#include <kernel.h>
 #include <zephyr/types.h>
 #include <stddef.h>
 


### PR DESCRIPTION
This patch series attempts to remove dependency cycles between include/kernel.h and arch/cpu.h.
The policy will be that kernel.h includes arch/cpu.h, and that the reverse shouldn't happen.