### PR TITLE
arm_core_mpu_dev.h: include proper headers

### DIFF
--- a/include/arch/arm/cortex_m/mpu/arm_core_mpu_dev.h
+++ b/include/arch/arm/cortex_m/mpu/arm_core_mpu_dev.h
@@ -6,6 +6,8 @@
 #ifndef _ARM_CORE_MPU_DEV_H_
 #define _ARM_CORE_MPU_DEV_H_
 
+#include <zephyr/types.h>
+
 #ifdef __cplusplus
 extern "C" {
 #endif
@@ -33,6 +35,9 @@ extern "C" {
 #define THREAD_DOMAIN_PARTITION_REGION 0x3
 
 #if defined(CONFIG_ARM_CORE_MPU)
+struct k_mem_domain;
+struct k_mem_partition;
+
 /* ARM Core MPU Driver API */
 
 /*


### PR DESCRIPTION
This header needs Zephyr's specific type definitions. It also
needs struct k_mem_partition and struct k_mem_domain, but they
are defined opaquely here instead of pulling in kernel.h (which
would create nasty dependency loops)

Signed-off-by: Andrew Boie <andrew.p.boie@intel.com>