### PR TITLE
Bluetooth: Add option to use heuristics for VS HCI detection

### DIFF
--- a/subsys/bluetooth/common/Kconfig
+++ b/subsys/bluetooth/common/Kconfig
@@ -15,6 +15,16 @@ config BT_HCI_VS_EXT
 	  Enable support for the Zephyr HCI Vendor-Specific Extensions in the
 	  Host and/or Controller.
 
+config BT_HCI_VS_EXT_DETECT
+	bool "Use heuristics to guess HCI vendor extensions support in advance"
+	depends on BT_HCI_VS_EXT && !BT_CTLR
+	default y if BOARD_QEMU_X86 || BOARD_QEMU_CORTEX_M3
+	help
+	  Use some heuristics to try to guess in advance whether the controller
+	  supports the HCI vendor extensions in advance, in order to prevent
+	  sending vendor commands to controller which may interpret them in
+	  completely different ways.
+
 config BT_RPA
 	# Virtual/hidden option
 	bool

--- a/subsys/bluetooth/host/hci_core.c
+++ b/subsys/bluetooth/host/hci_core.c
@@ -3869,6 +3869,18 @@ static void hci_vs_init(void)
 	struct net_buf *rsp;
 	int err;
 
+	/* If heuristics is enabled, try to guess HCI VS support by looking
+	 * at the HCI version and identity address. We haven't tried to set
+	 * a static random address yet at this point, so the identity will
+	 * either be zeroes or a valid public address.
+	 */
+	if (IS_ENABLED(CONFIG_BT_HCI_VS_EXT_DETECT) &&
+	    (bt_dev.hci_version < BT_HCI_VERSION_5_0 ||
+	     bt_addr_le_cmp(&bt_dev.id_addr, BT_ADDR_LE_ANY))) {
+		BT_WARN("Controller doesn't seem to support Zephyr vendor HCI");
+		return;
+	}
+
 	err = bt_hci_cmd_send_sync(BT_HCI_OP_VS_READ_VERSION_INFO, NULL, &rsp);
 	if (err) {
 		BT_WARN("Vendor HCI extensions not available");


### PR DESCRIPTION
One targets where non-Zephyr controllers are likely, such as qemu, it
may be harmful to try to issue any of the vendor HCI commands, since
non-Zephyr controllers may interpret them in completely different
ways.

Introduce a Kconfig option that, when enabled, uses some simple
heuristics (HCI version & lack of public address) to try to guess in
advance whether the Zephyr HCI vendor extensions are supported or not.
The new option is available for any host-only configuration and is
enabled by default for the qemu targets.

Signed-off-by: Johan Hedberg <johan.hedberg@intel.com>