### PR TITLE
x86: arch.h: remove reverse dependency

### DIFF
--- a/include/arch/x86/arch.h
+++ b/include/arch/x86/arch.h
@@ -482,6 +482,9 @@ extern void	_arch_irq_disable(unsigned int irq);
  * @{
  */
 
+struct k_thread;
+typedef struct k_thread *k_tid_t;
+
 /**
  * @brief Enable preservation of floating point context information.
  *


### PR DESCRIPTION
kernel.h depends on arch.h, and reverse dependencies need to be
removed. Define k_tid_t as some opaque pointer type so that arch.h
doesn't have to pull in kernel.h.

Signed-off-by: Andrew Boie <andrew.p.boie@intel.com>