### PR TITLE
Bluetooth: controller: Fix diff proc collision with enc proc

### DIFF
--- a/subsys/bluetooth/controller/ll_sw/ctrl.c
+++ b/subsys/bluetooth/controller/ll_sw/ctrl.c
@@ -2609,10 +2609,12 @@ isr_rx_conn_pkt_ctrl(struct radio_pdu_node_rx *radio_pdu_node_rx,
 					PDU_DATA_LLCTRL_TYPE_CONN_PARAM_REQ,
 					0x23);
 #if defined(CONFIG_BT_CTLR_PHY)
-			} else if ((conn->llcp_req != conn->llcp_ack) ||
+			} else if (((conn->llcp_req != conn->llcp_ack) &&
+				    (conn->llcp_type != LLCP_ENCRYPTION)) ||
 				   (conn->llcp_phy.req != conn->llcp_phy.ack)) {
 #else /* !CONFIG_BT_CTLR_PHY */
-			} else if (conn->llcp_req != conn->llcp_ack) {
+			} else if ((conn->llcp_req != conn->llcp_ack) &&
+				   (conn->llcp_type != LLCP_ENCRYPTION)) {
 #endif /* !CONFIG_BT_CTLR_PHY */
 				/* Different procedure collision */
 				nack = reject_ext_ind_send(_radio.conn_curr,
@@ -2931,13 +2933,17 @@ isr_rx_conn_pkt_ctrl(struct radio_pdu_node_rx *radio_pdu_node_rx,
 					PDU_DATA_LLCTRL_TYPE_PHY_REQ,
 					0x23);
 #if defined(CONFIG_BT_CTLR_CONN_PARAM_REQ)
-			} else if ((_radio.conn_curr->llcp_req !=
-				    _radio.conn_curr->llcp_ack) ||
+			} else if (((_radio.conn_curr->llcp_req !=
+				     _radio.conn_curr->llcp_ack) &&
+				    (_radio.conn_curr->llcp_type !=
+				     LLCP_ENCRYPTION)) ||
 				   (_radio.conn_curr->llcp_conn_param.req !=
 				    _radio.conn_curr->llcp_conn_param.ack)) {
 #else /* !CONFIG_BT_CTLR_CONN_PARAM_REQ */
 			} else if ((_radio.conn_curr->llcp_req !=
-				    _radio.conn_curr->llcp_ack)) {
+				    _radio.conn_curr->llcp_ack) &&
+				   (_radio.conn_curr->llcp_type !=
+				    LLCP_ENCRYPTION)) {
 #endif /* !CONFIG_BT_CTLR_CONN_PARAM_REQ */
 				/* Different procedure collision */
 				nack = reject_ext_ind_send(_radio.conn_curr,


### PR DESCRIPTION
Fixes the following conformance test regression failure
introduced in commit 7dd5fbee26fc ("Bluetooth: controller:
Fix MIC error due to parallel Enc Proc")

TP/CON/MAS/BV-28-C [Initiating Connection Parameter Request
different procedure collision encryption]

Signed-off-by: Vinayak Kariappa Chettimada <vich@nordicsemi.no>