### PR TITLE
net: tcp: Do not run expire function in ISR context

### DIFF
--- a/subsys/net/ip/tcp.h
+++ b/subsys/net/ip/tcp.h
@@ -108,7 +108,7 @@ struct net_tcp {
 	struct k_delayed_work fin_timer;
 
 	/** Retransmit timer */
-	struct k_timer retry_timer;
+	struct k_delayed_work retry_timer;
 
 	/** List pointer used for TCP retransmit buffering */
 	sys_slist_t sent_list;


### PR DESCRIPTION
The expire function can call net_context_unref() which tries to
get a semaphore with K_FOREVER. This is not allowed in interrupt
context. To overcome this, run the expire functionality from
system work queue instead.

Fixes #4683

Signed-off-by: Jukka Rissanen <jukka.rissanen@linux.intel.com>