### PR TITLE
Bluetooth: Mesh: Fail init on keys generation error

### DIFF
--- a/subsys/bluetooth/host/mesh/main.c
+++ b/subsys/bluetooth/host/mesh/main.c
@@ -158,7 +158,10 @@ int bt_mesh_init(const struct bt_mesh_prov *prov,
 	}
 
 	if (IS_ENABLED(CONFIG_BT_MESH_PROV)) {
-		bt_mesh_prov_init(prov);
+		err = bt_mesh_prov_init(prov);
+		if (err) {
+			return err;
+		}
 	}
 
 	bt_mesh_net_init();

--- a/subsys/bluetooth/host/mesh/prov.c
+++ b/subsys/bluetooth/host/mesh/prov.c
@@ -1483,14 +1483,18 @@ bool bt_prov_active(void)
 	return atomic_test_bit(link.flags, LINK_ACTIVE);
 }
 
-void bt_mesh_prov_init(const struct bt_mesh_prov *prov_info)
+int bt_mesh_prov_init(const struct bt_mesh_prov *prov_info)
 {
+	int err;
+
 	static struct bt_pub_key_cb pub_key_cb = {
 		.func = pub_key_ready,
 	};
 
-	if (bt_pub_key_gen(&pub_key_cb)) {
-		BT_ERR("Failed to generate public key");
+	err = bt_pub_key_gen(&pub_key_cb);
+	if (err) {
+		BT_ERR("Failed to generate public key (%d)", err);
+		return err;
 	}
 
 	prov = prov_info;
@@ -1513,4 +1517,6 @@ void bt_mesh_prov_init(const struct bt_mesh_prov *prov_info)
 		memcpy(uuid.val, prov->uuid, 16);
 		BT_INFO("Device UUID: %s", bt_uuid_str(&uuid.uuid));
 	}
+
+	return 0;
 }

--- a/subsys/bluetooth/host/mesh/prov.h
+++ b/subsys/bluetooth/host/mesh/prov.h
@@ -16,4 +16,4 @@ int bt_mesh_pb_gatt_recv(struct bt_conn *conn, struct net_buf_simple *buf);
 
 const u8_t *bt_mesh_prov_get_uuid(void);
 
-void bt_mesh_prov_init(const struct bt_mesh_prov *prov);
+int bt_mesh_prov_init(const struct bt_mesh_prov *prov);


### PR DESCRIPTION
Fail on Mesh initialization if provisioning is enabled and keys were
not generated. This make it simpler to debug misconfigured devices.

Signed-off-by: Szymon Janc <szymon.janc@codecoup.pl>