### PR TITLE
net: lwm2m: response to peer with correct error code when write fail

### DIFF
--- a/subsys/net/lib/lwm2m/lwm2m_engine.c
+++ b/subsys/net/lib/lwm2m/lwm2m_engine.c
@@ -2666,6 +2666,8 @@ error:
 		msg->code = COAP_RESPONSE_CODE_NOT_ALLOWED;
 	} else if (r == -EEXIST) {
 		msg->code = COAP_RESPONSE_CODE_BAD_REQUEST;
+	} else if (r == -EFAULT) {
+		msg->code = COAP_RESPONSE_CODE_INCOMPLETE;
 	} else if (r == -EFBIG) {
 		msg->code = COAP_RESPONSE_CODE_REQUEST_TOO_LARGE;
 	} else {


### PR DESCRIPTION
Update the firmware update_result accordingly by checking return
value of the firmware data writes callback registered by the application.
Also, set response code according.

