### PR TITLE
kconfig: sort fragment inclusion

### DIFF
--- a/Makefile.inc
+++ b/Makefile.inc
@@ -142,7 +142,7 @@ help:
 $(DOTCONFIG): $(BOARDCONFIG) $(KBUILD_DEFCONFIG_PATH) $(CONF_FILE)
 	$(Q)$(CONFIG_SHELL) $(ZEPHYR_BASE)/scripts/kconfig/merge_config.sh \
 		-q -m -O $(O) $(KBUILD_DEFCONFIG_PATH) $(OVERLAY_CONFIG) $(CONF_FILE) \
-			      $(wildcard $(O)/*.conf)
+			      $(sort $(wildcard $(O)/*.conf))
 	$(Q)$(MAKE) $(S) -C $(ZEPHYR_BASE) O=$(O) PROJECT=$(PROJECT_BASE) oldnoconfig
 
 pristine:


### PR DESCRIPTION
Now we are including fragments in whichever order glob gives is to us,
which is filesystem and any other things dependant.

Explicitly sort them, so we can reliable override things (when needed)
by specifying config file names that will be included in an well-known
specific order.

Signed-off-by: Inaky Perez-Gonzalez <inaky.perez-gonzalez@intel.com>