### PR TITLE
boards: add openocd support for nucleo_l476rg and stm32l496g_disco

### DIFF
--- a/boards/arm/nucleo_l476rg/board.cmake
+++ b/boards/arm/nucleo_l476rg/board.cmake
@@ -1,0 +1,1 @@
+include($ENV{ZEPHYR_BASE}/boards/common/openocd.board.cmake)

--- a/boards/arm/nucleo_l476rg/doc/nucleol476rg.rst
+++ b/boards/arm/nucleo_l476rg/doc/nucleol476rg.rst
@@ -199,7 +199,7 @@ Connect the Nucleo L476RG to your host computer using the USB port.
 Then build and flash an application. Here is an example for the
 :ref:`hello_world` application.
 
-Run a serial host program to connect with your Nucleo board.
+Run a serial host program to connect with your Nucleo board:
 
 .. code-block:: console
 
@@ -216,7 +216,7 @@ You should see the following message  on the console:
 
 .. code-block:: console
 
-   $ Hello World! arm
+   Hello World! arm
 
 Debugging
 =========

--- a/boards/arm/nucleo_l476rg/support/openocd.cfg
+++ b/boards/arm/nucleo_l476rg/support/openocd.cfg
@@ -1,0 +1,12 @@
+source [find board/st_nucleo_l476rg.cfg]
+
+$_TARGETNAME configure -event gdb-attach {
+	echo "Debugger attaching: halting execution"
+	reset halt
+	gdb_breakpoint_override hard
+}
+
+$_TARGETNAME configure -event gdb-detach {
+	echo "Debugger detaching: resuming execution"
+	resume
+}

--- a/boards/arm/stm32l496g_disco/board.cmake
+++ b/boards/arm/stm32l496g_disco/board.cmake
@@ -1,0 +1,1 @@
+include($ENV{ZEPHYR_BASE}/boards/common/openocd.board.cmake)

--- a/boards/arm/stm32l496g_disco/doc/stm32l496g_disco.rst
+++ b/boards/arm/stm32l496g_disco/doc/stm32l496g_disco.rst
@@ -172,8 +172,8 @@ Default Zephyr Peripheral Mapping:
 System Clock
 ------------
 
-STM32L496G Discovery System Clock could be driven by internal or external oscillator,
-as well as main PLL clock. By default System clock is driven by PLL clock at 80MHz,
+STM32L496G Discovery System Clock could be driven by an internal or external oscillator,
+as well as the main PLL clock. By default the System clock is driven by the PLL clock at 80MHz,
 driven by 16MHz high speed internal oscillator.
 
 Serial Port
@@ -220,7 +220,7 @@ You should see the following message on the console:
 
 .. code-block:: console
 
-   $ Hello World! arm
+   Hello World! arm
 
 Debugging
 =========

--- a/boards/arm/stm32l496g_disco/support/openocd.cfg
+++ b/boards/arm/stm32l496g_disco/support/openocd.cfg
@@ -1,0 +1,12 @@
+source [find board/stm32l4discovery.cfg]
+
+$_TARGETNAME configure -event gdb-attach {
+	echo "Debugger attaching: halting execution"
+	reset halt
+	gdb_breakpoint_override hard
+}
+
+$_TARGETNAME configure -event gdb-detach {
+	echo "Debugger detaching: resuming execution"
+	resume
+}


### PR DESCRIPTION
The current zephyr sdk now includes openocd configurations for l4
boards, so we can now flash/debug these boards using the zephyr
makefiles

Signed-off-by: Arthur SFEZ <arthur.sfez@gmail.com>