### PR TITLE
tests: kernel: timer: Fix TC_PRINT format specifiers

### DIFF
--- a/tests/kernel/timer/timer_monotonic/src/main.c
+++ b/tests/kernel/timer/timer_monotonic/src/main.c
@@ -5,7 +5,6 @@
  */
 
 #include <zephyr.h>
-#include <inttypes.h>
 #include <tc_util.h>
 
 int test_frequency(void)
@@ -57,9 +56,8 @@ void main(void)
 
 		if (t_now < t_last) {
 			diff = t_now - t_last;
-			TC_PRINT("diff = %" PRId32 " (t_last = %" PRIu32
-				 " : t_now = %" PRIu32 "); i = %u\n",
-				 diff, t_last, t_now, i);
+			TC_PRINT("diff = %d (t_last = %u : t_now = %u);"
+				"i = %u\n", diff, t_last, t_now, i);
 			errors++;
 		}
 		t_last = t_now;


### PR DESCRIPTION
Pass Zephyr type format specifiers to TC_PRINT().

Signed-off-by: Ramakrishna Pallala <ramakrishna.pallala@intel.com>