### PR TITLE
net: app: server: Allow IPv4 connections if IPv6 is enabled

### DIFF
--- a/subsys/net/lib/app/net_app.c
+++ b/subsys/net/lib/app/net_app.c
@@ -387,7 +387,6 @@ int _net_app_config_local_ctx(struct net_app_ctx *ctx,
 
 		if (!ret) {
 			select_default_ctx(ctx);
-			return 0;
 		}
 #endif
 
@@ -402,9 +401,9 @@ int _net_app_config_local_ctx(struct net_app_ctx *ctx,
 
 		if (!ret) {
 			select_default_ctx(ctx);
-			return 0;
 		}
 #endif
+		return ret;
 	} else {
 		if (addr->sa_family == AF_INET6) {
 #if defined(CONFIG_NET_IPV6)


### PR DESCRIPTION
A regression by commit 9728179757 ("Allow net_context re-connect").
The code did not create IPv4 listener if IPv6 listener was successfully
created.

Fixes #4697

Signed-off-by: Jukka Rissanen <jukka.rissanen@linux.intel.com>