### PR TITLE
samples: net: echo-client: Fix compile warning

### DIFF
--- a/samples/net/echo_client/src/udp.c
+++ b/samples/net/echo_client/src/udp.c
@@ -254,7 +254,7 @@ static void udp_connected(struct net_app_ctx *ctx,
 static int connect_udp(struct net_app_ctx *ctx, const char *peer,
 		       void *user_data, u8_t *dtls_result_buf,
 		       size_t dtls_result_buf_len,
-		       u8_t *stack, size_t stack_size)
+		       k_thread_stack_t *stack, size_t stack_size)
 {
 	struct data *data = user_data;
 	int ret;


### PR DESCRIPTION
This is similar fix as in commit 643cc4a22c but this one fixes
the thread parameter in UDP DTLS thread.

Fixes this function parameter datatype warning:

expected ‘k_thread_stack_t * {aka struct _k_thread_stack_element *}’
 but argument is of type ‘u8_t * {aka unsigned char *}’

Signed-off-by: Jukka Rissanen <jukka.rissanen@linux.intel.com>