### PR TITLE
checkpatch: add NANO_ESF as a typedef to avoid spacing errors

### DIFF
--- a/scripts/checkpatch/typedefsfile
+++ b/scripts/checkpatch/typedefsfile
@@ -1,1 +1,2 @@
 mbedtls_pk_context
+NANO_ESF


### PR DESCRIPTION
Signed-off-by: Anas Nashif <anas.nashif@intel.com>