### PR TITLE
userspace: assign thread IDs at build time

### DIFF
--- a/include/kernel.h
+++ b/include/kernel.h
@@ -398,11 +398,6 @@ struct _thread_base {
 	/* this thread's entry in a timeout queue */
 	struct _timeout timeout;
 #endif
-
-#ifdef CONFIG_USERSPACE
-	/* Bit position in kernel object permissions bitfield for this thread */
-	unsigned int perm_index;
-#endif
 };
 
 typedef struct _thread_base _thread_base_t;

--- a/kernel/include/kernel_structs.h
+++ b/kernel/include/kernel_structs.h
@@ -118,11 +118,6 @@ struct _kernel {
 	struct k_thread *threads; /* singly linked list of ALL threads */
 #endif
 
-#if defined(CONFIG_USERSPACE)
-	/* 0 bits for ids currently in use, 1 for free ids */
-	u8_t free_thread_ids[CONFIG_MAX_THREAD_BYTES];
-#endif
-
 	/* arch-specific part of _kernel */
 	struct _kernel_arch arch;
 };

--- a/kernel/init.c
+++ b/kernel/init.c
@@ -259,17 +259,9 @@ static void prepare_multithreading(struct k_thread *dummy_thread)
 	dummy_thread->stack_info.start = 0;
 	dummy_thread->stack_info.size = 0;
 #endif
-#ifdef CONFIG_USERSPACE
-	dummy_thread->base.perm_index = 0;
-#endif
 #endif
 
 	/* _kernel.ready_q is all zeroes */
-
-#ifdef CONFIG_USERSPACE
-	/* Mark all potential IDs as available */
-	memset(_kernel.free_thread_ids, 0xFF, CONFIG_MAX_THREAD_BYTES);
-#endif
 
 	/*
 	 * The interrupt library needs to be initialized early since a series

--- a/kernel/userspace_handler.c
+++ b/kernel/userspace_handler.c
@@ -39,7 +39,7 @@ _SYSCALL_HANDLER(k_object_access_grant, object, thread)
 {
 	struct _k_object *ko;
 
-	_SYSCALL_OBJ(thread, K_OBJ_THREAD);
+	_SYSCALL_OBJ_INIT(thread, K_OBJ_THREAD);
 	ko = validate_any_object((void *)object);
 	_SYSCALL_VERIFY_MSG(ko, "object %p access denied", (void *)object);
 	_thread_perms_set(ko, (struct k_thread *)thread);
@@ -51,7 +51,7 @@ _SYSCALL_HANDLER(k_object_access_revoke, object, thread)
 {
 	struct _k_object *ko;
 
-	_SYSCALL_OBJ(thread, K_OBJ_THREAD);
+	_SYSCALL_OBJ_INIT(thread, K_OBJ_THREAD);
 	ko = validate_any_object((void *)object);
 	_SYSCALL_VERIFY_MSG(ko, "object %p access denied", (void *)object);
 	_thread_perms_clear(ko, (struct k_thread *)thread);


### PR DESCRIPTION
Kernel object metadata had an extra data field added recently to
store bounds for stack objects. Use this data field to assign
IDs to thread objects at build time. This has numerous advantages:

* Threads can be granted permissions on kernel objects before the
  thread is initialized. Previously, it was necessary to call
  k_thread_create() with a K_FOREVER delay, assign permissions, then
  start the thread. Permissions are still completely cleared when
  a thread exits.

* No need for runtime logic to manage thread IDs

* Build error if CONFIG_MAX_THREAD_BYTES is set too low

Signed-off-by: Andrew Boie <andrew.p.boie@intel.com>