### PR TITLE
doc: update links to new zephyrproject.org site

### DIFF
--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -32,7 +32,7 @@ this, check out articles such as `Why choose Apache 2.0 licensing`_ and
 `Top 10 Apache License Questions Answered`_).
 
 .. _Why choose Apache 2.0 licensing:
-   https://www.zephyrproject.org/about/faq/what-rationale-choosing-apache-20-license
+   https://www.zephyrproject.org/about/#faq
 
 .. _Top 10 Apache License Questions Answered:
    https://www.whitesourcesoftware.com/whitesource-blog/top-10-apache-license-questions-answered/

--- a/README.rst
+++ b/README.rst
@@ -51,7 +51,7 @@ support systems:
   `Zephyr Introduction`_ and `Getting Started Guide`_.
 
 * **Releases**: Source code for Zephyr kernel releases are available at
-  https://zephyrproject.org/downloads. On this page,
+  https://zephyrproject.org/developers/#downloads. On this page,
   you'll find release information, and links to download or clone source
   code from our GitHub repository.  You'll also find links for the Zephyr
   SDK, a moderated collection of tools and libraries used to develop your

--- a/doc/404.rst
+++ b/doc/404.rst
@@ -20,4 +20,4 @@ If you got this error by following a link, please let us know by sending
 us a message using this `contact us form`_, or send an email message to
 info@zephyrproject.org
 
-.. _contact us form: https://www.zephyrproject.org/about/contact
+.. _contact us form: https://www.zephyrproject.org/about/#contact-us

--- a/doc/getting_started/installation_linux.rst
+++ b/doc/getting_started/installation_linux.rst
@@ -148,4 +148,4 @@ Follow these steps to install the SDK on your Linux host system.
      EOF
 
 .. _Zephyr SDK archive:
-    https://www.zephyrproject.org/downloads#Zephyr_SDK_Tools
+    https://www.zephyrproject.org/developers/#downloads


### PR DESCRIPTION
Fix links to content on the new version of zephyrproject.org that moved.

Signed-off-by: David B. Kinder <david.b.kinder@intel.com>