### PR TITLE
[RFC] CMake: generate application management commands automatically

### DIFF
--- a/boards/x86/arduino_101/doc/board.rst
+++ b/boards/x86/arduino_101/doc/board.rst
@@ -227,17 +227,12 @@ Flashing
 
 The ``dfu-util`` flashing application will only recognize the Arduino 101 as a
 DFU-capable device within five seconds after the Master Reset button is pressed
-on the board. You can run this application, either manually, or with the help of
-``make``:
+on the board. You can run this application with the help of the Zephyr build
+system by defining the environment variable ``ZEPHYR_FLASH_OVER_DFU=y`` before
+flashing Zephyr applications (as described in :ref:`application_run`).
 
-* Manual method: Type the ``dfu-util`` command line, press the Master Reset
-  button, and then quickly press Return to execute the dfu-util command. If
-  dfu-util fails saying "No DFU capable USB device available", try again more
-  quickly after pressing the Master Reset button.
-* Make method: Define the environment variable ``ZEPHYR_FLASH_OVER_DFU=y`` and
-  run ``make flash``. You will be prompted to reset the board when make is ready
-  to flash it. If you regularly use this method, you can add the following line
-  into your ``~/.zephyrrc`` file:
+If you regularly use this method, you can add the following line into your
+``~/.zephyrrc`` file:
 
 .. code-block:: console
 
@@ -248,52 +243,27 @@ Flashing the Sensor Subsystem Core
 When building for the ARC processor, the board type is listed as
 ``arduino_101_sss``.
 
-The sample application :ref:`hello_world` is used for this tutorial.
-Change directories to your local checkout copy of Zephyr, and run:
+The sample application :ref:`hello_world` is used for this tutorial.  To build
+and flash this application using ``dfu-util``, first set
+``ZEPHYR_FLASH_OVER_DFU=y`` in the environment as described above, then run:
 
-.. code-block:: console
-
-   $ cd $ZEPHYR_BASE/samples/hello_world
-   $ make BOARD=arduino_101_sss
-
-Once the image has been built, flash it with either this command using the
-manual method:
-
-.. code-block:: console
-
-   $ dfu-util -a sensor_core -D outdir/arduino_101_sss/zephyr.bin
-
-or with this command using the make-assisted method:
-
-.. code-block:: console
-
-   $ ZEPHYR_FLASH_OVER_DFU=y make BOARD=arduino_101_sss flash
+.. zephyr-app-commands::
+   :zephyr-app: samples/hello_world
+   :board: arduino_101_sss
+   :goals: build flash
 
 Flashing the x86 Application Core
 ---------------------------------
 
 When building for the x86 processor, the board type is listed as
-``arduino_101``.
+``arduino_101``.  To build and flash the :ref:`hello_world` application to this
+board using ``dfu-util``, first set ``ZEPHYR_FLASH_OVER_DFU=y`` in the
+environment as described above, then run:
 
-Change directories to your local checkout copy of Zephyr, and run:
-
-.. code-block:: console
-
-   $ cd $ZEPHYR_BASE/samples/hello_world
-   $ make BOARD=arduino_101
-
-Once the image has been built, flash it with either this command using the
-manual method:
-
-.. code-block:: console
-
-   $ dfu-util -a x86_app -D outdir/arduino_101/zephyr.bin
-
-or with this command using the make-assisted method:
-
-.. code-block:: console
-
-   $ ZEPHYR_FLASH_OVER_DFU=y make BOARD=arduino_101 flash
+.. zephyr-app-commands::
+   :zephyr-app: samples/hello_world
+   :board: arduino_101
+   :goals: build flash
 
 .. _bluetooth_firmware_arduino_101:
 
@@ -311,25 +281,14 @@ Luckily, starting with Zephyr 1.6, Zephyr itself is able to act as the firmware
 for the controller. The application you need is ``samples/bluetooth/hci_uart`` and
 the target board is called ``arduino_101_ble``.
 
-To build the Bluetooth controller image, follow the instructions below:
+To build the Bluetooth controller image and flash it using ``dfu-util``, first
+set ``ZEPHYR_FLASH_OVER_DFU=y`` in the environment as described above, then
+run:
 
-.. code-block:: console
-
-   $ cd $ZEPHYR_BASE/samples/bluetooth/hci_uart
-   $ make BOARD=arduino_101_ble
-
-Once the image has been built, flash it with either this command using the
-manual method:
-
-.. code-block:: console
-
-   $ dfu-util -a ble_core -D outdir/arduino_101_ble/zephyr.bin
-
-or with this command using the make-assisted method:
-
-.. code-block:: console
-
-   $ ZEPHYR_FLASH_OVER_DFU=y make BOARD=arduino_101_ble flash
+.. zephyr-app-commands::
+   :zephyr-app: samples/bluetooth/hci_uart
+   :board: arduino_101_ble
+   :goals: build flash
 
 After successfully completing these steps your Arduino 101 should now have a HCI
 compatible BLE firmware.
@@ -424,18 +383,13 @@ the ARC core, respectively.
 Application Core (x86)
 ----------------------
 
-Build and flash the x86 application with the following commands:
+Build and flash an x86 application, then launch a debugging server with the
+following commands:
 
-.. code-block:: console
-
-   $ cd <my x86 app>
-   $ make BOARD=arduino_101 flash
-
-Launch the debug server on the x86 core:
-
-.. code-block:: console
-
-   $ make BOARD=arduino_101 debugserver
+.. zephyr-app-commands::
+   :app: <my x86 app>
+   :board: arduino_101
+   :goals: build flash debugserver
 
 Connect to the debug server at the x86 core from a second console:
 
@@ -452,25 +406,20 @@ Sensor Subsystem Core (ARC)
 
 Enable ARC INIT from the x86 core. This can be done by flashing an x86
 application that sets the ``CONFIG_ARC_INIT=y`` option, such as the booting stub
-provided with the Zephyr Test Framework.
+provided with the Zephyr Test Framework, like so:
 
-.. code-block:: console
+.. zephyr-app-commands::
+   :zephyr-app: tests/booting/stub
+   :board: arduino_101
+   :goals: flash
 
-   $ cd $ZEPHYR_BASE/tests/booting/stub
-   $ make BOARD=arduino_101 flash
+Then build the ARC application, flash it, and launch a debug server with the
+following commands:
 
-Build and flash the ARC application with the following commands:
-
-.. code-block:: console
-
-   $ cd <my arc app>
-   $ make BOARD=arduino_101_sss flash
-
-Launch the debug server on the ARC core:
-
-.. code-block:: console
-
-   $ make BOARD=arduino_101_sss debugserver
+.. zephyr-app-commands::
+   :app: <my arc app>
+   :board: arduino_101_sss
+   :goals: flash debugserver
 
 Connect to the debug server at the ARC core from a second console:
 

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -16,10 +16,9 @@ import sys
 import os
 import shlex
 
-# If extensions (or modules to document with autodoc) are in another directory,
-# add these directories to sys.path here. If the directory is relative to the
-# documentation root, use os.path.abspath to make it absolute, like shown here.
-#sys.path.insert(0, os.path.abspath('.'))
+# Add the 'extensions' directory to sys.path, to enable finding Sphinx
+# extensions within.
+sys.path.insert(0, os.path.join(os.path.abspath('.'), 'extensions'))
 
 # -- General configuration ------------------------------------------------
 
@@ -31,7 +30,8 @@ import shlex
 # ones.
 extensions = [
     'sphinx.ext.autodoc', 'breathe', 'sphinx.ext.todo',
-    'sphinx.ext.extlinks'
+    'sphinx.ext.extlinks',
+    'zephyr.application',
 ]
 
 # Add any paths that contain templates here, relative to this directory.

--- a/doc/extensions/zephyr/application.py
+++ b/doc/extensions/zephyr/application.py
@@ -1,0 +1,98 @@
+# Copyright (c) 2017 Open Source Foundries Limited.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+'''Sphinx extensions related to managing Zephyr applications.'''
+
+from docutils import nodes
+from docutils.parsers.rst import Directive
+from docutils.parsers.rst import directives
+
+
+# TODO: extend and modify this for Windows.
+#
+# This could be as simple as generating a couple of sets of instructions, one
+# for Unix environments, and another for Windows.
+class ZephyrAppCommandsDirective(Directive):
+    '''Zephyr directive for generating documentation with the shell commands needed
+    to manage (build, flash, etc.) an application.
+
+    For example, to generate commands to build samples/hello_world for
+    qemu_x86:
+
+    .. zephyr-app-commands::
+       :zephyr-app: samples/hello_world
+       :board: qemu_x86
+       :goals: build
+
+    Directive options:
+
+    - :app: if set, the commands will change directories to this path to the
+      application.
+
+    - :zephyr-app: like :app:, but includes instructions from the Zephyr base
+      directory. Cannot be given with :app:
+
+    - :board: if set, the application build will target the given board
+
+    - :goals: a whitespace-separated list of what to do with the app (in
+      'build', 'flash', 'debug', 'debugserver'). Commands to accomplish these
+      tasks will be generated in the right order.
+
+    '''
+    has_content = False
+    required_arguments = 0
+    optional_arguments = 0
+    final_argument_whitespace = False
+    option_spec = {
+        'app': directives.unchanged,
+        'zephyr-app': directives.unchanged,
+        'board': directives.unchanged,
+        'goals': directives.unchanged_required
+    }
+
+    def run(self):
+        # Parse directive options.
+        app = self.options.get('app', None)
+        zephyr_app = self.options.get('zephyr-app', None)
+        board = self.options.get('board', None)
+        goals = self.options.get('goals').split()
+
+        if app and zephyr_app:
+            raise self.error('Both app and zephyr-app options were given.')
+
+        # Build the command content as a list, then convert to string.
+        content = []
+        if zephyr_app:
+            content.append('$ cd $ZEPHYR_BASE/{}'.format(zephyr_app))
+        elif app:
+            content.append('$ cd {}'.format(app))
+        content.extend([
+            '$ mkdir build && cd build',
+            '$ cmake -GNinja{} ..'.format(' -DBOARD={}'.format(board)
+                                          if board else '')])
+        if 'build' in goals:
+            content.append('$ ninja')
+        if 'flash' in goals:
+            content.append('$ ninja flash')
+        if 'debug' in goals:
+            content.append('$ ninja debug')
+        if 'debugserver' in goals:
+            content.append('$ ninja debugserver')
+        content = '\n'.join(content)
+
+        # Create the nodes.
+        literal = nodes.literal_block(content, content)
+        self.add_name(literal)
+        literal['language'] = 'console'
+        return [literal]
+
+
+def setup(app):
+    app.add_directive('zephyr-app-commands', ZephyrAppCommandsDirective)
+
+    return {
+        'version': '1.0',
+        'parallel_read_safe': True,
+        'parallel_write_safe': True
+    }


### PR DESCRIPTION
(Please note my new employer's copyright, SOB, etc.)

This series adds a custom Sphinx directive named "zephyr-app-commands" to the Zephyr documentation. When inserted in the text, it generates CMake-based instructions (currently just Unix commands) to manage an application (build, flash, debug, etc.).

As an example, the arduino_101 documentation is updated to use this directive instead of manually written "make" commands.

The purpose of this is to make the global conversion of CMake-based commands happen once in a way that makes it easy to make future changes across the docs, simply by changing the implementation of the directive. In particular, that should make it possible to generate Windows-compatible documentation that doesn't need a Unix shell by changing one file or so.

I tried to do this using a Sphinx include directive, but that won't work for technical reasons I'll explain if anyone asks.

If this approach is acceptable, I'm happy to take on the task of updating the places in the documentation where "make" is called to manage applications to use this directive instead.