### PR TITLE
Do not merge: DTC compiler in Python

### DIFF
--- a/scripts/dts/devicetree.py
+++ b/scripts/dts/devicetree.py
@@ -18,6 +18,7 @@
 import os
 import sys
 import pprint
+import collections
 
 def read_until(line, fd, end):
   out = [line]
@@ -191,6 +192,14 @@ def open_with_include_path(file_path, mode, include_path):
 
   raise IOError("Could not find %s in %s" % (file_path, include_path))
 
+def update_node(node, new_node):
+  for k, v in new_node.items():
+    if isinstance(v, collections.Mapping):
+      node[k] = update_node(node.get(k, {}), v)
+    else:
+      node[k] = v
+  return node
+
 def parse_file(fd, ignore_dts_version=False, include_path=[]):
   include_path.append(os.getcwd())
 
@@ -229,7 +238,7 @@ def parse_file(fd, ignore_dts_version=False, include_path=[]):
         raise SyntaxError("parse_file: Missing /dts-v1/ tag")
 
       new_node = parse_node(line, fd)
-      nodes[new_node['name']] = new_node
+      nodes[new_node['name']] = update_node(nodes.get(new_node['name'], {}), new_node)
     else:
       raise SyntaxError("parse_file: Couldn't understand the line: %s" % line)
   return nodes

--- a/scripts/dts/devicetree.py
+++ b/scripts/dts/devicetree.py
@@ -46,8 +46,16 @@ def remove_comment(line, fd):
     out.append(line[:idx])
     line = read_until(line[idx:], fd, '*/')[-1]
 
+def remove_preprocessor_directives(line):
+  if line.startswith('# '):
+    return ''
+  return line
+
 def clean_line(line, fd):
-  return remove_comment(line, fd).strip()
+  line = remove_preprocessor_directives(line)
+  line = remove_comment(line, fd)
+  line = line.strip()
+  return line
 
 def parse_node_name(line):
   line = line[:-1]

--- a/scripts/dts/devicetree.py
+++ b/scripts/dts/devicetree.py
@@ -168,7 +168,7 @@ def parse_property(property, fd):
   if not property.endswith(';'):
     raise SyntaxError("parse_property: missing semicolon: %s" % property)
 
-  return property[:-1].strip(), True
+  return property[:-1].strip(), {'empty': True}
 
 def build_node_name(name, addr):
   if addr is None:

--- a/scripts/dts/devicetree.py
+++ b/scripts/dts/devicetree.py
@@ -154,7 +154,6 @@ def parse_node(line, fd):
 
   node = {
     'label': label,
-    'type': type,
     'addr': numeric_addr,
     'children': {},
     'props': {},
@@ -227,7 +226,6 @@ def parse_file(fd, ignore_dts_version=False, include_path=[]):
       end = int(end[:-1], 16)
       label = "reserved_memory_0x%x_0x%x" % (start, end)
       nodes[label] = {
-        'type': 'memory',
         'reg': [start, end],
         'label': label,
         'addr': start,

--- a/scripts/dts/flatten.py
+++ b/scripts/dts/flatten.py
@@ -1,0 +1,203 @@
+#!/usr/bin/env python3
+#
+# Copyright (c) 2017 Intel Corporation
+#
+
+import argparse
+import devicetree
+import pprint
+import sys
+
+
+def find_phandle(root, label):
+    def recurse(root, label):
+        if not root or not 'label' in root:
+            return False
+
+        if label == root['label']:
+            return '0x%x' % root['props']['phandle']
+
+        for k, v in root['children'].items():
+            phandle = recurse(v, label)
+            if phandle:
+                return phandle
+
+    return recurse(root, label)
+
+
+def is_number(v):
+    if isinstance(v, int):
+        return True
+    if isinstance(v, str):
+        return v.isdigit() or v.startswith('0x')
+    if isinstance(v, dict):
+        return 'ref' in v
+    return False
+
+
+def to_dts_value(root, value):
+    if isinstance(value, list):
+        formatted = (to_dts_value(root, item) for item in value)
+        if all(is_number(v) for v in value):
+            return '<%s>' % ' '.join(formatted)
+
+        return ', '.join(formatted)
+
+    if isinstance(value, int):
+        return '0x%x' % value
+
+    if isinstance(value, dict) and 'ref' in value:
+        return find_phandle(root, value['ref'])
+
+    return '"%s"' % value
+
+
+def dump_tree(root, tree, output, indent=0):
+    indent_str = '    ' * indent
+
+    for k, v in tree.items():
+        if not v or not 'label' in v:
+            continue
+
+        prop_indent = '    ' * (indent + 1)
+
+        output.write(indent_str)
+
+        if v['label'] and v['label'] != k:
+            output.write('%s: %s {\n' % (v['label'], k))
+        else:
+            output.write('%s {\n' % k)
+
+        for prop, value in v['props'].items():
+            if isinstance(value, dict) and value.get('empty', False):
+                output.write('%s%s;\n' % (prop_indent, prop))
+            else:
+                value = to_dts_value(root, value)
+                output.write('%s%s = %s;\n' % (prop_indent, prop, value))
+
+        if v['children']:
+            dump_tree(root, v['children'], output, indent + 1)
+
+        output.write('%s};\n\n' % indent_str)
+
+
+def fixup_tree(tree):
+    state = { 'phandle': 1 }
+
+    def fixup_tree_item(root, label, value, state):
+        if not root:
+            return
+        if not 'children' or not 'label' in root:
+            return
+
+        if label[0] == '&':
+            label = label[1:]
+
+        if root['label'] == label:
+            root['children'] = devicetree.update_node(root['children'],
+                                                      value['children'])
+            root['props'] = devicetree.update_node(root['props'],
+                                                   value['props'])
+            return
+
+        root['props']['phandle'] = state['phandle']
+        state['phandle'] += 1
+
+        for k, v in root['children'].items():
+            fixup_tree_item(v, label, value, state)
+
+
+    output = {'/': tree['/']}
+
+    del tree['/']
+
+    for k, v in tree.items():
+        fixup_tree_item(output['/'], k, v, state)
+
+    return output
+
+
+def resolve_refs(tree):
+    def build_path_traverse(root, ref):
+        if not root or not 'label' in root:
+            return False
+
+        if ref == root['label']:
+            return True
+
+        for k, v in root['children'].items():
+            path = build_path_traverse(v, ref)
+            if path:
+                if path == True:
+                    return [k]
+
+                return [k, path]
+
+
+    def flatten(lst):
+        for item in lst:
+            if isinstance(item, str):
+                yield item
+            else:
+                yield from flatten(item)
+
+
+    def build_path(root, ref):
+        built = build_path_traverse(root, ref)
+        if not built:
+            return '&%s' % ref
+
+        return '/' + '/'.join(flatten(built))
+
+
+    def resolve_refs_items(root, branch):
+        if not branch:
+            return
+
+        for k, v in branch.get('props', {}).items():
+            if isinstance(v, dict) and 'ref' in v:
+                branch['props'][k] = build_path(root, v['ref'])
+        for k, v in branch.get('children', {}).items():
+            if isinstance(v, dict):
+                resolve_refs_items(root, v)
+
+    resolve_refs_items(tree['/'], tree['/'])
+
+    return tree
+
+
+def flatten(input, output, boot_cpu, include_path):
+    output.write('/dts-v1/;\n')
+
+    tree = devicetree.parse_file(input, include_path=include_path)
+
+    tree = fixup_tree(tree)
+
+    tree = resolve_refs(tree)
+
+    dump_tree(tree['/'], tree, output)
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        formatter_class=argparse.RawDescriptionHelpFormatter)
+
+    parser.add_argument('-b', '--boot-cpu',
+                        required=True, help="Boot CPU number")
+    parser.add_argument('-I', '--include-path',
+                        required=True, action='append',
+                        help="Add directory to include path")
+    parser.add_argument('-i', '--input-dts',
+                        required=True, help="Input DTS path")
+    parser.add_argument('-o', '--output-dts',
+                        required=True, help="Output DTS path")
+
+    args = parser.parse_args()
+
+    with open(args.input_dts, 'r') as input_file:
+        with open(args.output_dts, 'w') as output_file:
+            return flatten(input_file, output_file,
+                           args.boot_cpu, args.include_path)
+
+if __name__ == '__main__':
+    sys.exit(main())


### PR DESCRIPTION
DTS files are flattened by the dtc compiler, which is a host tool that is tricky to work on Windows without mingw or other similar environment.  Since we have our own DTS parser anyway, write a tool to flatten it out and generate the same output.

I've tested the script only with the preprocessed DTS for a frdm-k64f (found in outdir/frdm-k64f/dts/arm), and it seems to be generating  a file that seems sane compared to what dtc generates when targeting dts.

I don't know much about devicetree (for instance, a phandle property is being generated for every node, even though it's not exactly needed), so some review here would be welcomed.

This has not been hooked up to the build system yet.