### PR TITLE
net: buf: Add slist helpers

### DIFF
--- a/doc/subsystems/networking/buffers.rst
+++ b/doc/subsystems/networking/buffers.rst
@@ -45,7 +45,11 @@ passed from one thread to another. However, since a net_buf may have a
 fragment chain attached to it, instead of using the :c:func:`k_fifo_put`
 and :c:func:`k_fifo_get` APIs, special :c:func:`net_buf_put` and
 :c:func:`net_buf_get` APIs must be used when passing buffers through
-FIFOs. These APIs ensure that the buffer chains stay intact.
+FIFOs. These APIs ensure that the buffer chains stay intact. The same
+applies for passing buffers through a singly linked list, in which case
+the :c:func:`net_buf_slist_put` and :c:func:`net_buf_slist_get`
+functions must be used instead of :c:func:`sys_slist_append` and
+:c:func:`sys_slist_get`.
 
 Common Operations
 *****************

--- a/include/net/buf.h
+++ b/include/net/buf.h
@@ -647,6 +647,31 @@ void net_buf_reset(struct net_buf *buf);
 void net_buf_reserve(struct net_buf *buf, size_t reserve);
 
 /**
+ *  @brief Put a buffer into a list
+ *
+ *  Put a buffer to the end of a list. If the buffer contains follow-up
+ *  fragments this function will take care of inserting them as well
+ *  into the list.
+ *
+ *  @param list Which list to append the buffer to.
+ *  @param buf Buffer.
+ */
+void net_buf_slist_put(sys_slist_t *list, struct net_buf *buf);
+
+/**
+ *  @brief Get a buffer from a list.
+ *
+ *  Get buffer from a list. If the buffer had any fragments, these will
+ *  automatically be recovered from the list as well and be placed to
+ *  the buffer's fragment list.
+ *
+ *  @param list Which list to take the buffer from.
+ *
+ *  @return New buffer or NULL if the FIFO is empty.
+ */
+struct net_buf *net_buf_slist_get(sys_slist_t *list);
+
+/**
  *  @brief Put a buffer into a FIFO
  *
  *  Put a buffer to the end of a FIFO. If the buffer contains follow-up


### PR DESCRIPTION
Now that net_buf has "native" support for sys_slist_t in the form of
the sys_snode_t member, there's a danger people will forget to clear
out buf->frags when getting buffers from a list directly with
sys_slist_get(). This is analogous to the reason why we have
net_buf_get/put APIs instead of using k_fifo_get/put.

Signed-off-by: Johan Hedberg <johan.hedberg@intel.com>