### PR TITLE
cmake: Add PROJECT_BINARY_DIR to the linker search path

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -500,6 +500,7 @@ set(zephyr_lnk
   ${OFFSETS_O_PATH}
   ${LINKERFLAGPREFIX},--end-group
   ${LIB_INCLUDE_DIR}
+  -L${PROJECT_BINARY_DIR}
   ${TOOLCHAIN_LIBS}
   )
 


### PR DESCRIPTION
This resolves the bug reported by @mbolivar here: https://github.com/zephyrproject-rtos/zephyr/pull/4692#pullrequestreview-74171554

The linker scripts are making references to archive files relative to
the PROJECT_BINARY_DIR. To make them resolve we add this dir to the
linker search path.

This resolves an issue where qemu_x86:samples/hello_world would not
build on Ninja. It is not clear why this issue only triggered with
Ninja.

Signed-off-by: Sebastian Boe <sebastian.boe@nordicsemi.no>