### PR TITLE
doc: fix typos and broken DCO link 

### DIFF
--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -56,8 +56,8 @@ Importing code into the Zephyr OS from other projects that use a license
 other than the Apache 2.0 license needs to be fully understood in
 context and approved by the Zephyr governing board.
 
-By carefully reviewing potential contributions and also enforcing
-`developer attestations <DCO>`_ for contributed code, we can ensure that
+By carefully reviewing potential contributions and also enforcing a
+:ref:`DCO` for contributed code, we can ensure that
 the Zephyr community can develop products with the Zephyr Project
 without concerns over patent or copyright issues.
 

--- a/doc/devices/drivers/drivers.rst
+++ b/doc/devices/drivers/drivers.rst
@@ -272,7 +272,7 @@ executed. Any driver will specify one of five initialization levels:
 ``PRE_KERNEL_1``
         Used for devices that have no dependencies, such as those that rely
         solely on hardware present in the processor/SOC. These devices cannot
-        use any kernel services during configuration, since the services are
+        use any kernel services during configuration, since the kernel services are
         not yet available. The interrupt subsystem will be configured however
         so it's OK to set up interrupts. Init functions at this level run on the
         interrupt stack.

--- a/doc/kernel/data_passing/message_queues.rst
+++ b/doc/kernel/data_passing/message_queues.rst
@@ -34,7 +34,7 @@ A message queue must be initialized before it can be used.
 This sets its ring buffer to empty.
 
 A data item can be **sent** to a message queue by a thread or an ISR.
-The data item a pointed at by the sending thread is copied to a waiting thread,
+The data item pointed at by the sending thread is copied to a waiting thread,
 if one exists; otherwise the item is copied to the message queue's ring buffer,
 if space is available. In either case, the size of the data area being sent
 *must* equal the message queue's data item size.


### PR DESCRIPTION
Corrected a few typos and a broken reference to the DCO in the contribution guidelines.