### PR TITLE
net: fix the build rules for drivers/net.

### DIFF
--- a/drivers/net/Makefile
+++ b/drivers/net/Makefile
@@ -1,2 +1,2 @@
-obj-$(CONFIG_SLIP) = slip.o
-obj-$(CONFIG_NET_LOOPBACK) = loopback.o
+obj-$(CONFIG_SLIP) += slip.o
+obj-$(CONFIG_NET_LOOPBACK) += loopback.o


### PR DESCRIPTION
The Makefile was using the obj-$FOO = form instead of the ob-$FOO +=
form, so if both slip and loopback are enabled then only loopback will
get built.

Signed-off-by: Michael Hope <mlhx@google.com>