### PR TITLE
Enable 15.4 packet display only

### DIFF
--- a/subsys/net/ip/l2/ieee802154/Kconfig
+++ b/subsys/net/ip/l2/ieee802154/Kconfig
@@ -35,6 +35,31 @@ config NET_DEBUG_L2_IEEE802154_DISPLAY_PACKET
 	  Enable printing out in/out 802.15.4 packets. This is extremely
 	  verbose, do not enable this unless you know what you are doing.
 
+if NET_DEBUG_L2_IEEE802154_DISPLAY_PACKET
+
+choice
+	prompt "Which packet do you want to print-out?"
+	default NET_DEBUG_L2_IEEE802154_DISPLAY_PACKET_FULL
+
+config NET_DEBUG_L2_IEEE802154_DISPLAY_PACKET_FULL
+	bool "Print-out both RX and TX packets"
+	help
+	  This will print-out both received and transmitted packets.
+
+config NET_DEBUG_L2_IEEE802154_DISPLAY_PACKET_RX
+	bool "Print-out only RX packets"
+	help
+	  This will print-out received packets only.
+
+config NET_DEBUG_L2_IEEE802154_DISPLAY_PACKET_TX
+	bool "Print-out only TX packets"
+	help
+	  This will print-out transmitted packets only.
+
+endchoice
+
+endif # NET_DEBUG_L2_IEEE802154_DISPLAY_PACKET
+
 config NET_L2_IEEE802154_ACK_REPLY
 	bool "Enable IEEE 802.15.4 ACK reply logic"
 	default n

--- a/subsys/net/ip/l2/ieee802154/Kconfig
+++ b/subsys/net/ip/l2/ieee802154/Kconfig
@@ -30,7 +30,7 @@ config NET_DEBUG_L2_IEEE802154
 config NET_DEBUG_L2_IEEE802154_DISPLAY_PACKET
 	bool "Enable IEEE 802.15.4 packet display"
 	default n
-	depends on NET_DEBUG_L2_IEEE802154
+	depends on NET_LOG
 	help
 	  Enable printing out in/out 802.15.4 packets. This is extremely
 	  verbose, do not enable this unless you know what you are doing.

--- a/subsys/net/ip/l2/ieee802154/ieee802154.c
+++ b/subsys/net/ip/l2/ieee802154/ieee802154.c
@@ -4,7 +4,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#if defined(CONFIG_NET_DEBUG_L2_IEEE802154)
+#if defined(CONFIG_NET_DEBUG_L2_IEEE802154) || \
+	defined(CONFIG_NET_DEBUG_L2_IEEE802154_DISPLAY_PACKET)
 #define SYS_LOG_DOMAIN "net/ieee802154"
 #define NET_LOG_ENABLED 1
 #endif
@@ -44,6 +45,10 @@ static inline void pkt_hexdump(const char *title, struct net_pkt *pkt,
 {
 	net_hexdump_frags(title, pkt, full);
 }
+
+#ifndef CONFIG_NET_DEBUG_L2_IEEE802154
+#undef NET_LOG_ENABLED
+#endif /* CONFIG_NET_DEBUG_L2_IEEE802154 */
 
 #else
 #define pkt_hexdump(...)


### PR DESCRIPTION
If more improvements are need, more features will be added then.
(i.e.: you don't want to see before/after 6lo, things like that)