### PR TITLE
lib: remove TinyCrypt Kconfig menu

### DIFF
--- a/lib/Kconfig
+++ b/lib/Kconfig
@@ -4,11 +4,6 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 
-
-menu "Cryptography"
-source "lib/crypto/tinycrypt/Kconfig"
-endmenu
-
 source "lib/libc/Kconfig"
 
 source "lib/json/Kconfig"


### PR DESCRIPTION
Remove the TinyCrypt Kconfig menu as it is moved
under /ext/lib/crypto/

Signed-off-by: Ramakrishna Pallala <ramakrishna.pallala@intel.com>