### PR TITLE
sanitycheck: remove hack for running only on migrated tests

### DIFF
--- a/samples/drivers/entropy/CMakeLists.txt
+++ b/samples/drivers/entropy/CMakeLists.txt
@@ -1,0 +1,5 @@
+include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
+project(NONE)
+
+FILE(GLOB app_sources src/*.c)
+target_sources(app PRIVATE ${app_sources})

--- a/scripts/sanitycheck
+++ b/scripts/sanitycheck
@@ -1310,9 +1310,6 @@ class TestSuite:
             for dirpath, dirnames, filenames in os.walk(testcase_root,
                                                         topdown=True):
                 verbose("scanning %s" % dirpath)
-                # FIXME: To only run on ported tests and samples when migrating to cmake
-                if 'CMakeLists.txt' not in filenames:
-                    continue
                 if 'sample.yaml' in filenames:
                     filename = 'sample.yaml'
                 elif 'testcase.yaml' in filenames:

--- a/tests/net/socket/tcp/CMakeLists.txt
+++ b/tests/net/socket/tcp/CMakeLists.txt
@@ -1,0 +1,6 @@
+include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
+project(NONE)
+
+target_include_directories(app PRIVATE $ENV{ZEPHYR_BASE}/subsys/net/ip)
+FILE(GLOB app_sources src/*.c)
+target_sources(app PRIVATE ${app_sources})

--- a/tests/power/multicore/arc/CMakeLists.txt
+++ b/tests/power/multicore/arc/CMakeLists.txt
@@ -1,0 +1,6 @@
+include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
+project(NONE)
+
+target_include_directories(app PRIVATE $ENV{ZEPHYR_BASE}/drivers)
+FILE(GLOB app_sources src/*.c)
+target_sources(app PRIVATE ${app_sources})

--- a/tests/power/multicore/lmt/CMakeLists.txt
+++ b/tests/power/multicore/lmt/CMakeLists.txt
@@ -1,0 +1,6 @@
+include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
+project(NONE)
+
+target_include_directories(app PRIVATE $ENV{ZEPHYR_BASE}/drivers)
+FILE(GLOB app_sources src/*.c)
+target_sources(app PRIVATE ${app_sources})


### PR DESCRIPTION
Signed-off-by: Anas Nashif <anas.nashif@intel.com>