### PR TITLE
board: frdm_k64f, frdm_kw41z: Define LED1

### DIFF
--- a/boards/arm/frdm_k64f/board.h
+++ b/boards/arm/frdm_k64f/board.h
@@ -30,10 +30,16 @@
 #define BLUE_GPIO_PIN	21
 
 /* LED0. There is no physical LED on the board with this name, so create an
- * alias to the green LED to make the basic blinky sample work.
+ * alias to the green LED to make various samples work.
  */
 #define LED0_GPIO_PORT	GREEN_GPIO_NAME
 #define LED0_GPIO_PIN	GREEN_GPIO_PIN
+
+/* LED1. There is no physical LED on the board with this name, so create an
+ * alias to the blue LED to make various samples work.
+ */
+#define LED1_GPIO_PORT	BLUE_GPIO_NAME
+#define LED1_GPIO_PIN 	BLUE_GPIO_PIN
 
 /* Push button switch 0. There is no physical switch on the board with this
  * name, so create an alias to SW3 to make the basic button sample work.

--- a/boards/arm/frdm_kl25z/board.h
+++ b/boards/arm/frdm_kl25z/board.h
@@ -30,10 +30,16 @@
 #define BLUE_GPIO_PIN	1
 
 /* LED0. There is no physical LED on the board with this name, so create an
- * alias to the green LED to make the basic blinky sample work.
+ * alias to the green LED to make various samples work.
  */
 #define LED0_GPIO_PORT	GREEN_GPIO_NAME
 #define LED0_GPIO_PIN	GREEN_GPIO_PIN
+
+/* LED1. There is no physical LED on the board with this name, so create an
+ * alias to the blue LED to make various samples work.
+ */
+#define LED1_GPIO_PORT	BLUE_GPIO_NAME
+#define LED1_GPIO_PIN	BLUE_GPIO_PIN
 
 /* Push button switch 0. There is no physical switch on the board,
  * so an push button must be added to such pins for basic button sample work.

--- a/boards/arm/frdm_kw41z/board.h
+++ b/boards/arm/frdm_kw41z/board.h
@@ -30,10 +30,16 @@
 #define BLUE_GPIO_PIN	18
 
 /* LED0. There is no physical LED on the board with this name, so create an
- * alias to the green LED to make the basic blinky sample work.
+ * alias to the green LED to make various samples work.
  */
 #define LED0_GPIO_PORT	GREEN_GPIO_NAME
 #define LED0_GPIO_PIN	GREEN_GPIO_PIN
+
+/* LED1. There is no physical LED on the board with this name, so create an
+ * alias to the blue LED to make various samples work.
+ */
+#define LED1_GPIO_PORT	BLUE_GPIO_NAME
+#define LED1_GPIO_PIN	BLUE_GPIO_PIN
 
 /* Push button switch 0. There is no physical switch on the board with this
  * name, so create an alias to SW3 to make the basic button sample work.


### PR DESCRIPTION
To make more cross-board samples work.

Signed-off-by: Paul Sokolovsky <paul.sokolovsky@linaro.org>