### PR TITLE
net: pkt: Remove unnecessary error print in adjust_offset

### DIFF
--- a/subsys/net/ip/net_pkt.c
+++ b/subsys/net/ip/net_pkt.c
@@ -1225,8 +1225,6 @@ static inline struct net_buf *adjust_offset(struct net_buf *frag,
 		frag = frag->frags;
 	}
 
-	NET_ERR("Invalid offset (%u), failed to adjust", offset);
-
 	return NULL;
 }
 


### PR DESCRIPTION
The commit 971da9d0 ("net: pkt: adjust_offset: Simplify and optimize
code") changed the adjust_offset() function but left the error print
intact. This print is now invoked even if there is no error which
looks bad in debug prints.

Signed-off-by: Jukka Rissanen <jukka.rissanen@linux.intel.com>