### PR TITLE
usb: netusb: Allow to select Endpoint numbers

### DIFF
--- a/subsys/usb/class/netusb/Kconfig
+++ b/subsys/usb/class/netusb/Kconfig
@@ -32,26 +32,24 @@ config USB_DEVICE_NETWORK_RNDIS
 	Remote NDIS (RNDIS) is commonly used Microsoft vendor protocol with
 	Specification available from Microsoft web site.
 
-endmenu
-
 if USB_DEVICE_NETWORK_ECM
 
 config CDC_ECM_INT_EP_ADDR
-	hex
+	hex "CDC ECM Interrupt Endpoint address"
 	default 0x84
 	range 0x81 0x8F
 	help
 	CDC ECM class interrupt endpoint address
 
 config CDC_ECM_IN_EP_ADDR
-	hex
+	hex "CDC ECM BULK IN Endpoint address"
 	default 0x83
 	range 0x81 0x8F
 	help
 	CDC ECM class IN endpoint address
 
 config CDC_ECM_OUT_EP_ADDR
-	hex
+	hex "CDC ECM BULK OUT Endpoint address"
 	default 0x02
 	range 0x01 0x0F
 	help
@@ -79,3 +77,5 @@ config USB_DEVICE_NETWORK_ECM_MAC
 	default MAC.
 
 endif # USB_DEVICE_NETWORK_ECM
+
+endmenu # USB Device Networking support


### PR DESCRIPTION
Add support for selecting Endpoint numbers and move it under USB
Device Networking menu.

Signed-off-by: Andrei Emeltchenko <andrei.emeltchenko@intel.com>