### PR TITLE
Bluetooth: Kconfig: Introduce new BT_SCAN_WITH_IDENTITY option

### DIFF
--- a/subsys/bluetooth/host/Kconfig
+++ b/subsys/bluetooth/host/Kconfig
@@ -301,6 +301,16 @@ config BT_MAX_PAIRED
 
 endif # BT_CONN
 
+config BT_SCAN_WITH_IDENTITY
+	bool "Perform active scanning using local identity address"
+	depends on !BT_PRIVACY && (BT_CENTRAL || BT_OBSERVER)
+	help
+	  Enable this if you want to perform active scanning using the local
+	  identy address as the scanner address. By default the stack will
+	  always use a non-resolvable private address (NRPA) in order to avoid
+	  disclosing local identity information. However, if the use case
+	  requires disclosing it then enable this option.
+
 config BT_DEVICE_NAME
 	string "Bluetooth device name"
 	default "Zephyr"

--- a/subsys/bluetooth/host/hci_core.c
+++ b/subsys/bluetooth/host/hci_core.c
@@ -2923,8 +2923,11 @@ static int start_le_scan(u8_t scan_type, u16_t interval, u16_t window)
 	} else {
 		set_param->addr_type =  bt_dev.id_addr.type;
 
-		/* only set NRPA if there is no advertising ongoing */
-		if (scan_type == BT_HCI_LE_SCAN_ACTIVE &&
+		/* Use NRPA unless identity has been explicitly requested
+		 * (through Kconfig), or if there is no advertising ongoing.
+		 */
+		if (!IS_ENABLED(CONFIG_BT_SCAN_WITH_IDENTITY) &&
+		    scan_type == BT_HCI_LE_SCAN_ACTIVE &&
 		    !atomic_test_bit(bt_dev.flags, BT_DEV_ADVERTISING)) {
 			err = le_set_private_addr();
 			if (err) {


### PR DESCRIPTION
Even with the privacy feature disabled, the stack has so far defaulted
to using an NRPA for active scanning, in order to protect privacy.
This is mainly because it is not always clear that scanning for other
devices may risk revealing the local identity.

There may however be use cases where such revealing is actively
desired, so introduce a new option for this (which defaults to
disabled).

Signed-off-by: Johan Hedberg <johan.hedberg@intel.com>