### PR TITLE
cmake: Fixed subsys/net/lib/http

### DIFF
--- a/subsys/net/lib/CMakeLists.txt
+++ b/subsys/net/lib/CMakeLists.txt
@@ -3,7 +3,13 @@ add_subdirectory_if_kconfig(lwm2m)
 add_subdirectory_if_kconfig(sntp)
 add_subdirectory_if_kconfig(zoap)
 add_subdirectory_ifdef(CONFIG_DNS_RESOLVER      dns)
-add_subdirectory_ifdef(CONFIG_HTTP              http)
 add_subdirectory_ifdef(CONFIG_MQTT_LIB          mqtt)
 add_subdirectory_ifdef(CONFIG_NET_APP_SETTINGS  app)
 add_subdirectory_ifdef(CONFIG_NET_SOCKETS       sockets)
+
+if(CONFIG_HTTP_PARSER_URL
+    OR CONFIG_HTTP_PARSER
+    OR CONFIG_HTTP)
+  add_subdirectory(http)
+endif()
+


### PR DESCRIPTION
This fixes the CI failure of the sample lwm2m_client.

Signed-off-by: Sebastian Boe <sebastian.boe@nordicsemi.no>