### PR TITLE
stack debug: Fixed Stack debug SENTINEL issue #4503

### DIFF
--- a/arch/arm/core/cortex_m/reset.S
+++ b/arch/arm/core/cortex_m/reset.S
@@ -78,6 +78,12 @@ SECTION_SUBSEC_FUNC(TEXT,_reset_section,__start)
     ldr r2, =CONFIG_ISR_STACK_SIZE
     bl memset
 #endif
+#ifdef CONFIG_STACK_SENTINEL
+    ldr r0, =_interrupt_stack
+    ldr r1, =0xF0
+    ldr r2, =0x04
+    bl  memset
+#endif
 
     /*
      * Set PSP and use it to boot without using MSP, so that it

--- a/include/misc/stack.h
+++ b/include/misc/stack.h
@@ -27,15 +27,34 @@ static inline size_t stack_unused_space_get(const char *stack, size_t size)
 	 * that correct Kconfig option is used.
 	 */
 #if defined(STACK_GROWS_UP)
+#if defined(CONFIG_STACK_SENTINEL)
+	if (*((u32_t*)&stack[size-4]) != 0xF0F0F0F0) {
+		return unused;
+	}
+		
+	for (i = size - 5; i >= 0; i--) {
+#else
 	for (i = size - 1; i >= 0; i--) {
+#endif
 		if ((unsigned char)stack[i] == 0xaa) {
 			unused++;
 		} else {
 			break;
 		}
 	}
+	
+#else
+
+#if defined(CONFIG_STACK_SENTINEL)
+
+	if (*((u32_t *)stack) != 0xF0F0F0F0) {
+		return unused;
+	}
+		
+	for (i = 4; i < size; i++) {
 #else
 	for (i = 0; i < size; i++) {
+#endif
 		if ((unsigned char)stack[i] == 0xaa) {
 			unused++;
 		} else {

--- a/kernel/init.c
+++ b/kernel/init.c
@@ -125,6 +125,17 @@ void k_call_stacks_analyze(void)
 	STACK_ANALYZE("idle     ", _idle_stack);
 	STACK_ANALYZE("interrupt", _interrupt_stack);
 	STACK_ANALYZE("workqueue", sys_work_q_stack);
+
+#if defined(CONFIG_THREAD_MONITOR)
+	printk("\nApplication stacks:\n");
+	struct k_thread *tmp;
+	for (tmp = _kernel.threads; tmp != NULL; tmp = tmp->next_thread)
+	{
+		stack_analyze("<tbd>", (const char *)tmp->stack_info.start,
+			 tmp->stack_info.size);
+	}
+#endif
+
 }
 #else
 void k_call_stacks_analyze(void) { }


### PR DESCRIPTION
- Add initialization of the CONF_STACK_SENTINEL to the _interrupt stack
- Fixed _stack_unused_space_get() to account for SENTINEL markers
- Added walk through for all thread stack analysis in k_call_stacks_analyze() after kernel stacks

Fixes #4503

Signed-off-by: David Leach <david.leach@nxp.com>