### PR TITLE
stack debug: Fixed Stack debug SENTINEL in ARM Cortex-M issue #4503

### DIFF
--- a/arch/arm/core/cortex_m/reset.S
+++ b/arch/arm/core/cortex_m/reset.S
@@ -78,6 +78,11 @@ SECTION_SUBSEC_FUNC(TEXT,_reset_section,__start)
     ldr r2, =CONFIG_ISR_STACK_SIZE
     bl memset
 #endif
+#ifdef CONFIG_STACK_SENTINEL
+    ldr r0, =_interrupt_stack
+    ldr r1, =0xF0F0F0F0
+    str r1, [r0]
+#endif
 
     /*
      * Set PSP and use it to boot without using MSP, so that it


### PR DESCRIPTION
- Add initialization of the CONF_STACK_SENTINEL to the _interrupt stack
- Fixed _stack_unused_space_get() to account for SENTINEL markers

Signed-off-by: David Leach <david.leach@nxp.com>