### PR TITLE
dts: x86: RAM start address needs to be page aligned for arduino 101.

### DIFF
--- a/arch/arc/soc/quark_se_c1000_ss/Kconfig.defconfig
+++ b/arch/arc/soc/quark_se_c1000_ss/Kconfig.defconfig
@@ -40,7 +40,7 @@ config SRAM_BASE_ADDRESS
 
 config SRAM_SIZE
 	default 16 if NSIM
-	default 24
+	default 27
 
 config ICCM_BASE_ADDRESS
 	default 0xFFFFFFFF

--- a/arch/x86/soc/intel_quark/quark_se/Kconfig.defconfig.series
+++ b/arch/x86/soc/intel_quark/quark_se/Kconfig.defconfig.series
@@ -27,7 +27,7 @@ config PHYS_LOAD_ADDR
 endif
 
 config RAM_SIZE
-	default 55
+	default 52
 
 config ROM_SIZE
 	default 144

--- a/dts/x86/intel_curie.dtsi
+++ b/dts/x86/intel_curie.dtsi
@@ -27,12 +27,11 @@
 		reg = <0x40030000 DT_FLASH_SIZE>;
 	};
 
-	sram0: memory@a8006400 {
+	sram0: memory@a8007000 {
 		device_type = "memory";
 		compatible = "mmio-sram";
-		reg = <0xa8006400 DT_SRAM_SIZE>;
+		reg = <0xa8007000 DT_SRAM_SIZE>;
 	};
-
 
 	soc {
 		#address-cells = <1>;

--- a/dts/x86/mem.h
+++ b/dts/x86/mem.h
@@ -5,7 +5,7 @@
 
 #if defined(CONFIG_SOC_QUARK_SE_C1000)
 #define DT_FLASH_SIZE		__SIZE_K(144)
-#define DT_SRAM_SIZE		__SIZE_K(55)
+#define DT_SRAM_SIZE		__SIZE_K(52)
 #elif defined(CONFIG_SOC_QUARK_D2000)
 #define DT_FLASH_SIZE		__SIZE_K(32)
 #define DT_SRAM_SIZE		__SIZE_K(8)


### PR DESCRIPTION
When CONFIG_X86_MMU is enabled for arduino 101 the start address
should be aligned to 4kB. If not aligned the page tables would not
be created and the build fails.

Signed-off-by: Adithya Baglody <adithya.nagaraj.baglody@intel.com>