### PR TITLE
cmake: Use Make for examples instead of Ninja

### DIFF
--- a/doc/application/application.rst
+++ b/doc/application/application.rst
@@ -172,8 +172,8 @@ Basics
 
        $ mkdir build
        $ cd build
-       $ cmake -GNinja ..
-       $ ninja
+       $ cmake ..
+       $ make
 
    If desired, you can build the application using the configuration settings
    specified in an alternate :file:`.conf` file using the :code:`CONF_FILE`
@@ -184,8 +184,8 @@ Basics
 
 
        $ export CONF_FILE=prj.alternate.conf
-       $ cmake -GNinja ..
-       $ ninja
+       $ cmake ..
+       $ make
 
    If desired, you can generate project files for a different board
    type than the one specified in the application's
@@ -200,7 +200,8 @@ Build Directory Contents
 ========================
 
 
-When using the Ninja backend, a build directory looks like this:
+When using the Ninja backend instead of the Make backend, a build
+directory looks like this:
 
 .. code-block:: none
 
@@ -267,7 +268,7 @@ following procedure:
 
    .. code-block:: console
 
-       $ ninja clean
+       $ make clean
 
    Alternatively, enter the following command to delete *all*
    generated files, including the :file:`.config` files that contain
@@ -276,7 +277,7 @@ following procedure:
 
    .. code-block:: console
 
-       $ ninja pristine
+       $ make pristine
 
 #. Rebuild the application normally following the steps specified
    in :ref:`build_an_application` above.
@@ -310,7 +311,7 @@ hardware:
 
    .. code-block:: console
 
-      $ ninja flash
+      $ make flash
 
 The Zephyr build system integrates with the board support files to
 use hardware-specific tools to flash the Zephyr binary to your
@@ -353,7 +354,7 @@ run an application via QEMU:
 
    .. code-block:: console
 
-      $ ninja run
+      $ make run
 
 #. Press :kbd:`Ctrl A, X` to stop the application from running
    in QEMU.
@@ -416,7 +417,7 @@ the following inside the build directory of an application:
 
 .. code-block:: bash
 
-   ninja debugserver
+   make debugserver
 
 The build system will start a QEMU instance with the CPU halted at startup
 and with a GDB server instance listening at the TCP port 1234.
@@ -732,12 +733,11 @@ application's :file:`.config` manually, using a configurator tool is
 preferred, since it correctly handles dependencies between options.
 
 
-#. Generate a Ninja build system, and use it to run ``ninja
+#. Generate a Make build system, and use it to run ``make
    menuconfig`` as follows.
 
    a) Using CMake, create a build directory (:file:`~/app/build`) from
-      your application directory (:file:`~/app`) with a Ninja build
-      system.
+      your application directory (:file:`~/app`).
 
       For example, on a Unix shell:
 
@@ -745,16 +745,16 @@ preferred, since it correctly handles dependencies between options.
 
          $ cd ~/app
          $ mkdir build && cd build
-         $ cmake -GNinja ..
+         $ cmake ..
 
-   b) Run ``ninja menuconfig`` from the build directory
+   b) Run ``make menuconfig`` from the build directory
       (:file:`~/app/build`).
 
       Continuing the above Unix shell example:
 
       .. code-block:: bash
 
-          $ ninja menuconfig
+          $ make menuconfig
 
       A question-based menu opens that allows you to set individual
       configuration options.

--- a/doc/getting_started/getting_started.rst
+++ b/doc/getting_started/getting_started.rst
@@ -88,7 +88,7 @@ To build an example application follow these steps:
       $ cd $ZEPHYR_BASE/samples/hello_world
       $ mkdir build
       $ cd build
-      $ cmake -GNinja ..
+      $ cmake ..
 
 The above will generate project files that can build the
 :ref:`hello_world` sample application using the default settings
@@ -98,7 +98,7 @@ enter:
 .. code-block:: console
 
    $ cd $ZEPHYR_BASE/samples/hello_world/build
-   $ ninja
+   $ make
 
 You can build for a different board by defining the variable BOARD
 with one of the supported boards, for example:
@@ -109,8 +109,8 @@ with one of the supported boards, for example:
    $ export BOARD=arduino_101
    $ mkdir build_101
    $ cd build_101
-   $ cmake -GNinja ..
-   $ ninja
+   $ cmake ..
+   $ make
 
 For further information on the supported boards go see
 :ref:`here <boards>`. Alternatively, run the following command to obtain a list
@@ -118,7 +118,7 @@ of the supported boards:
 
 .. code-block:: console
 
-   $ ninja usage
+   $ make usage
 
 Sample projects for different features of the project are available at
 at :file:`$ZEPHYR_BASE/samples`.
@@ -154,9 +154,9 @@ follow the steps below to build with any custom or 3rd party cross-compilers:
    .. code-block:: console
 
       $ mkdir ~/kconfig_build_dir && cd ~/kconfig_build_dir
-      $ cmake -GNinja $ZEPHYR_BASE/scripts
-      $ ninja
-      $ echo "export PATH=$PWD/kconfig:\$PATH" >> $HOME/.bashrc
+      $ cmake $ZEPHYR_BASE/scripts
+      $ make
+      $ echo "export PATH=$PWD/kconfig:\$PATH" >> $HOME/.zephyrrc
       $ bash
       $ which conf
 
@@ -184,7 +184,7 @@ follow the steps below to build with any custom or 3rd party cross-compilers:
 
       $ export GCCARMEMB_TOOLCHAIN_PATH="~/gcc-arm-none-eabi-5_3-2016q1/"
       $ export ZEPHYR_GCC_VARIANT=gccarmemb
-      $ cmake -DBOARD=arduino_due -H$ZEPHYR_BASE/samples/hello_world -Bbld -GNinja && cmake --build bld
+      $ cmake -DBOARD=arduino_due -H$ZEPHYR_BASE/samples/hello_world -Bbld && cmake --build bld
 
 Running a Sample Application in QEMU
 ====================================
@@ -204,8 +204,8 @@ type:
    $ export BOARD=qemu_x86
    $ mkdir qemu_build
    $ cd qemu_build
-   $ cmake -GNinja ..
-   $ ninja run
+   $ cmake ..
+   $ make run
 
 To run an application using the ARM qemu_cortex_m3 board configuration
 specify the qemu_cortex_m3 board instead.

--- a/doc/getting_started/installation_linux.rst
+++ b/doc/getting_started/installation_linux.rst
@@ -74,7 +74,7 @@ Install exactly version 3.8.2 of CMake::
    $ mkdir $HOME/work_dir && cd $HOME/work_dir
    $ wget https://cmake.org/files/v3.8/cmake-3.8.2-Linux-x86_64.sh
    $ yes | sh cmake-3.8.2-Linux-x86_64.sh | cat
-   $ echo "export PATH=$PWD/cmake-3.8.2-Linux-x86_64/bin:\$PATH" >> $HOME/.bashrc
+   $ echo "export PATH=$PWD/cmake-3.8.2-Linux-x86_64/bin:\$PATH" >> $HOME/.zephyrrc
    $ bash
    $ cmake --version
 


### PR DESCRIPTION
Ninja is not tested as well as Make yet, so for now, recommend using
Make.

Signed-off-by: Sebastian Boe <sebastian.boe@nordicsemi.no>