### PR TITLE
net: tcp: net_tcp_parse_opts: Convert MSS value to host byte order

### DIFF
--- a/subsys/net/ip/tcp.c
+++ b/subsys/net/ip/tcp.c
@@ -1293,8 +1293,8 @@ int net_tcp_parse_opts(struct net_pkt *pkt, int opt_totlen,
 			if (optlen != 2) {
 				goto error;
 			}
-			frag = net_frag_read(frag, pos, &pos,
-					     optlen, (u8_t *)&opts->mss);
+			frag = net_frag_read_be16(frag, pos, &pos,
+						  &opts->mss);
 			break;
 		default:
 			frag = net_frag_skip(frag, pos, &pos, optlen);


### PR DESCRIPTION
Signed-off-by: Paul Sokolovsky <paul.sokolovsky@linaro.org>