### PR TITLE
USB STM32 fixes

### DIFF
--- a/drivers/usb/device/usb_dc_stm32.c
+++ b/drivers/usb/device/usb_dc_stm32.c
@@ -481,7 +481,9 @@ int usb_dc_ep_write(const u8_t ep, const u8_t *const data,
 		irq_enable(STM32F4_IRQ_OTG_FS);
 	}
 
-	*ret_bytes = data_len;
+	if (ret_bytes) {
+		*ret_bytes = data_len;
+	}
 
 	return ret;
 }


### PR DESCRIPTION
- Fix TX FIFO overwrite causing failure with (at least) USB ECM
- Fix potential null pointer dereference on ret_bytes parameter