### PR TITLE
CMake: add and use Sphinx directive for generating build documentation

### DIFF
--- a/boards/x86/arduino_101/doc/board.rst
+++ b/boards/x86/arduino_101/doc/board.rst
@@ -227,17 +227,12 @@ Flashing
 
 The ``dfu-util`` flashing application will only recognize the Arduino 101 as a
 DFU-capable device within five seconds after the Master Reset button is pressed
-on the board. You can run this application, either manually, or with the help of
-``make``:
+on the board. You can run this application with the help of the Zephyr build
+system by defining the environment variable ``ZEPHYR_FLASH_OVER_DFU=y`` before
+flashing Zephyr applications (as described in :ref:`application_run`).
 
-* Manual method: Type the ``dfu-util`` command line, press the Master Reset
-  button, and then quickly press Return to execute the dfu-util command. If
-  dfu-util fails saying "No DFU capable USB device available", try again more
-  quickly after pressing the Master Reset button.
-* Make method: Define the environment variable ``ZEPHYR_FLASH_OVER_DFU=y`` and
-  run ``make flash``. You will be prompted to reset the board when make is ready
-  to flash it. If you regularly use this method, you can add the following line
-  into your ``~/.zephyrrc`` file:
+If you regularly use this method, you can add the following line into your
+``~/.zephyrrc`` file:
 
 .. code-block:: console
 
@@ -248,52 +243,29 @@ Flashing the Sensor Subsystem Core
 When building for the ARC processor, the board type is listed as
 ``arduino_101_sss``.
 
-The sample application :ref:`hello_world` is used for this tutorial.
-Change directories to your local checkout copy of Zephyr, and run:
+The sample application :ref:`hello_world` is used for this tutorial.  To build
+and flash this application using ``dfu-util``, first set
+``ZEPHYR_FLASH_OVER_DFU=y`` in the environment as described above, then run:
 
-.. code-block:: console
-
-   $ cd $ZEPHYR_BASE/samples/hello_world
-   $ make BOARD=arduino_101_sss
-
-Once the image has been built, flash it with either this command using the
-manual method:
-
-.. code-block:: console
-
-   $ dfu-util -a sensor_core -D outdir/arduino_101_sss/zephyr.bin
-
-or with this command using the make-assisted method:
-
-.. code-block:: console
-
-   $ ZEPHYR_FLASH_OVER_DFU=y make BOARD=arduino_101_sss flash
+.. zephyr-app-commands::
+   :zephyr-app: samples/hello_world
+   :board: arduino_101_sss
+   :build-dir: arduino_101_sss
+   :goals: build flash
 
 Flashing the x86 Application Core
 ---------------------------------
 
 When building for the x86 processor, the board type is listed as
-``arduino_101``.
+``arduino_101``.  To build and flash the :ref:`hello_world` application to this
+board using ``dfu-util``, first set ``ZEPHYR_FLASH_OVER_DFU=y`` in the
+environment as described above, then run:
 
-Change directories to your local checkout copy of Zephyr, and run:
-
-.. code-block:: console
-
-   $ cd $ZEPHYR_BASE/samples/hello_world
-   $ make BOARD=arduino_101
-
-Once the image has been built, flash it with either this command using the
-manual method:
-
-.. code-block:: console
-
-   $ dfu-util -a x86_app -D outdir/arduino_101/zephyr.bin
-
-or with this command using the make-assisted method:
-
-.. code-block:: console
-
-   $ ZEPHYR_FLASH_OVER_DFU=y make BOARD=arduino_101 flash
+.. zephyr-app-commands::
+   :zephyr-app: samples/hello_world
+   :board: arduino_101
+   :build-dir: arduino_101
+   :goals: build flash
 
 .. _bluetooth_firmware_arduino_101:
 
@@ -311,25 +283,14 @@ Luckily, starting with Zephyr 1.6, Zephyr itself is able to act as the firmware
 for the controller. The application you need is ``samples/bluetooth/hci_uart`` and
 the target board is called ``arduino_101_ble``.
 
-To build the Bluetooth controller image, follow the instructions below:
+To build the Bluetooth controller image and flash it using ``dfu-util``, first
+set ``ZEPHYR_FLASH_OVER_DFU=y`` in the environment as described above, then
+run:
 
-.. code-block:: console
-
-   $ cd $ZEPHYR_BASE/samples/bluetooth/hci_uart
-   $ make BOARD=arduino_101_ble
-
-Once the image has been built, flash it with either this command using the
-manual method:
-
-.. code-block:: console
-
-   $ dfu-util -a ble_core -D outdir/arduino_101_ble/zephyr.bin
-
-or with this command using the make-assisted method:
-
-.. code-block:: console
-
-   $ ZEPHYR_FLASH_OVER_DFU=y make BOARD=arduino_101_ble flash
+.. zephyr-app-commands::
+   :zephyr-app: samples/bluetooth/hci_uart
+   :board: arduino_101_ble
+   :goals: build flash
 
 After successfully completing these steps your Arduino 101 should now have a HCI
 compatible BLE firmware.
@@ -424,25 +385,20 @@ the ARC core, respectively.
 Application Core (x86)
 ----------------------
 
-Build and flash the x86 application with the following commands:
+Build and flash an x86 application, then launch a debugging server with the
+following commands:
 
-.. code-block:: console
-
-   $ cd <my x86 app>
-   $ make BOARD=arduino_101 flash
-
-Launch the debug server on the x86 core:
-
-.. code-block:: console
-
-   $ make BOARD=arduino_101 debugserver
+.. zephyr-app-commands::
+   :app: <my x86 app>
+   :board: arduino_101
+   :goals: build flash debugserver
 
 Connect to the debug server at the x86 core from a second console:
 
 .. code-block:: console
 
    $ cd <my x86 app>
-   $ $ZEPHYR_SDK_INSTALL_DIR/sysroots/x86_64-pokysdk-linux/usr/bin/i586-zephyr-elfiamcu/i586-zephyr-elfiamcu-gdb outdir/arduino_101/zephyr.elf
+   $ $ZEPHYR_SDK_INSTALL_DIR/sysroots/x86_64-pokysdk-linux/usr/bin/i586-zephyr-elfiamcu/i586-zephyr-elfiamcu-gdb build/zephyr/zephyr.elf
    (gdb) target remote localhost:3333
    (gdb) b main
    (gdb) c
@@ -452,32 +408,27 @@ Sensor Subsystem Core (ARC)
 
 Enable ARC INIT from the x86 core. This can be done by flashing an x86
 application that sets the ``CONFIG_ARC_INIT=y`` option, such as the booting stub
-provided with the Zephyr Test Framework.
+provided with the Zephyr Test Framework, like so:
 
-.. code-block:: console
+.. zephyr-app-commands::
+   :zephyr-app: tests/booting/stub
+   :board: arduino_101
+   :goals: flash
 
-   $ cd $ZEPHYR_BASE/tests/booting/stub
-   $ make BOARD=arduino_101 flash
+Then build the ARC application, flash it, and launch a debug server with the
+following commands:
 
-Build and flash the ARC application with the following commands:
-
-.. code-block:: console
-
-   $ cd <my arc app>
-   $ make BOARD=arduino_101_sss flash
-
-Launch the debug server on the ARC core:
-
-.. code-block:: console
-
-   $ make BOARD=arduino_101_sss debugserver
+.. zephyr-app-commands::
+   :app: <my arc app>
+   :board: arduino_101_sss
+   :goals: flash debugserver
 
 Connect to the debug server at the ARC core from a second console:
 
 .. code-block:: console
 
    $ cd <my arc app>
-   $ $ZEPHYR_SDK_INSTALL_DIR/sysroots/x86_64-pokysdk-linux/usr/bin/arc-zephyr-elf/arc-zephyr-elf-gdb outdir/arduino_101_sss/zephyr.elf
+   $ $ZEPHYR_SDK_INSTALL_DIR/sysroots/x86_64-pokysdk-linux/usr/bin/arc-zephyr-elf/arc-zephyr-elf-gdb build/zephyr/zephyr.elf
    (gdb) target remote localhost:3334
    (gdb) b main
    (gdb) c

--- a/boards/x86/galileo/doc/galileo.rst
+++ b/boards/x86/galileo/doc/galileo.rst
@@ -232,18 +232,19 @@ application image on a Galileo board. The following instructions apply to both
 devices.
 
 
-#. Set the board configuration to Galileo by changing the
-   :command:`make` command that is executed in the app directory
-   (e.g. :file:`$ZEPHYR_BASE/samples/hello_world`) to:
+#. Build a Zephyr application; for instance, to build the ``hello_world``
+   application:
 
-   .. code-block:: console
-
-      $ make BOARD=galileo
+   .. zephyr-app-commands::
+      :zephyr-app: samples/hello_world
+      :board: galileo
+      :goals: build
 
    .. note::
-      A stripped project image file named :file:`zephyr.strip` is
-      automatically created when the project is built. This image has
-      removed debug information from the :file:`zephyr.elf` file.
+
+      A stripped project image file named :file:`zephyr.strip` is automatically
+      created in the build directory after the application is built. This image
+      has removed debug information from the :file:`zephyr.elf` file.
 
 #. Use one of these cables for serial output:
 

--- a/boards/x86/qemu_x86/doc/board.rst
+++ b/boards/x86/qemu_x86/doc/board.rst
@@ -69,12 +69,21 @@ The following platform features are unsupported:
 Programming and Debugging
 *************************
 
-Use this configuration to run basic Zephyr applications and kernel tests in the QEMU
-emulated environment, for example, with the :ref:`synchronization_sample`:
+Applications for the ``qemu_x86`` board configuration can be built and run in
+the usual way for emulated boards (see :ref:`build_an_application` and
+:ref:`application_run` for more details).
 
-.. code-block:: console
+Flashing
+========
 
-        $ make -C samples/synchronization BOARD=qemu_x86 run
+While this board is emulated and you can't "flash" it, you can use this
+configuration to run basic Zephyr applications and kernel tests in the QEMU
+emulated environment. For example, with the :ref:`synchronization_sample`:
+
+.. zephyr-app-commands::
+   :zephyr-app: samples/synchronization
+   :board: qemu_x86
+   :goals: run
 
 This will build an image with the synchronization sample app, boot it using
 QEMU, and display the following console output:

--- a/boards/x86/quark_d2000_crb/doc/quark_d2000_crb.rst
+++ b/boards/x86/quark_d2000_crb/doc/quark_d2000_crb.rst
@@ -71,11 +71,9 @@ Programming and Debugging
 The D2000 board configuration details are found in the project's tree at
 :file:`boards/x86/quark_d2000_crb`.
 
-To build an application for this board, the following call is needed:
-
-.. code-block:: console
-
-   $ make BOARD=quark_d2000_crb <make target>
+Applications for the ``quark_d2000_crb`` board configuration can be built and
+flashed in the usual way (see :ref:`build_an_application` and
+:ref:`application_run` for more details).
 
 Flashing
 ========
@@ -99,32 +97,25 @@ Flashing
 
 #. Connect the D2000 via USB to the host computer.
 
-#. Once the binary is built, it can be flashed to the device by:
+#. Build and flash a Zephyr application. Here is an example for the
+   :ref:`hello_world` application.
 
-   .. code-block:: console
-
-      $ make BOARD=quark_d2000_crb flash
+   .. zephyr-app-commands::
+      :zephyr-app: samples/hello_world
+      :board: quark_d2000_crb
+      :goals: build flash
 
 Debugging
 =========
 
-To debug an application on the Quark D2000 board, follow these steps.  As an
-example, we are using the :ref:`hello_world` application.
+You can debug an application in the usual way.  Here is an example for the
+:ref:`hello_world` application.
 
-#. Go to the application's folder:.
-
-   .. code-block:: console
-
-      $ cd $ZEPHYR_BASE/samples/hello_world
-
-#. Verify the final binary is in :file:`outdir/quark_d2000_crb/zephyr.elf`.
-
-#. To enable the debug process, enter:
-
-   .. code-block:: console
-
-      $ make BOARD=quark_d2000_crb debug
-
+.. zephyr-app-commands::
+   :zephyr-app: samples/hello_world
+   :board: quark_d200_crb
+   :maybe-skip-config:
+   :goals: debug
 
 .. _Intel Website:
    http://www.intel.com/content/www/us/en/embedded/products/quark/mcu/d2000/quark-d2000-crb-user-guide.html

--- a/boards/x86/x86_jailhouse/doc/board.rst
+++ b/boards/x86/x86_jailhouse/doc/board.rst
@@ -63,11 +63,14 @@ tests in a QEMU emulated environment (we assume the same QEMU
 configuration used to accomodate Jailhouse's configs/qemu-x86.c root
 cell configuration).
 
-For example, with the :ref:`synchronization_sample`, one would issue:
+For example, with the :ref:`synchronization_sample`, first set
+``JAILHOUSE_QEMU_IMG_FILE`` to the path to the :file:`.qcow2` file.
+Then:
 
-.. code-block:: console
-
-        $ make -C samples/synchronization BOARD=x86_jailhouse JAILHOUSE_QEMU_IMG_FILE=path_to_image.qcow2 run
+.. zephyr-app-commands::
+   :zephyr-app: samples/synchronization
+   :board: x86_jailhouse
+   :goals: run
 
 This assumes the user has the binary qemu-system-x86_64 in their
 system (not provided by Zephyr's toolchain). This is because the base

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -16,10 +16,9 @@ import sys
 import os
 import shlex
 
-# If extensions (or modules to document with autodoc) are in another directory,
-# add these directories to sys.path here. If the directory is relative to the
-# documentation root, use os.path.abspath to make it absolute, like shown here.
-#sys.path.insert(0, os.path.abspath('.'))
+# Add the 'extensions' directory to sys.path, to enable finding Sphinx
+# extensions within.
+sys.path.insert(0, os.path.join(os.path.abspath('.'), 'extensions'))
 
 # -- General configuration ------------------------------------------------
 
@@ -31,7 +30,8 @@ import shlex
 # ones.
 extensions = [
     'sphinx.ext.autodoc', 'breathe', 'sphinx.ext.todo',
-    'sphinx.ext.extlinks'
+    'sphinx.ext.extlinks',
+    'zephyr.application',
 ]
 
 # Add any paths that contain templates here, relative to this directory.

--- a/doc/extensions/zephyr/application.py
+++ b/doc/extensions/zephyr/application.py
@@ -1,0 +1,186 @@
+# Copyright (c) 2017 Open Source Foundries Limited.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+'''Sphinx extensions related to managing Zephyr applications.'''
+
+from docutils import nodes
+from docutils.parsers.rst import Directive
+from docutils.parsers.rst import directives
+
+
+# TODO: extend and modify this for Windows.
+#
+# This could be as simple as generating a couple of sets of instructions, one
+# for Unix environments, and another for Windows.
+class ZephyrAppCommandsDirective(Directive):
+    '''Zephyr directive for generating documentation with the shell
+    commands needed to manage (build, flash, etc.) an application.
+
+    For example, to generate commands to build samples/hello_world for
+    qemu_x86:
+
+    .. zephyr-app-commands::
+       :zephyr-app: samples/hello_world
+       :board: qemu_x86
+       :goals: build
+
+    Directive options:
+
+    - :app: if set, the commands will change directories to this path to the
+      application.
+
+    - :zephyr-app: like :app:, but includes instructions from the Zephyr base
+      directory. Cannot be given with :app:.
+
+    - :generator: which build system to generate. Valid options are
+      currently 'ninja' and 'make'. The default is 'make'. This option
+      is not case sensitive.
+
+    - :board: if set, the application build will target the given board.
+
+    - :build-dir: if set, the application build directory will *APPEND* this
+      (relative, Unix-separated) path to the standard build directory. This is
+      mostly useful for distinguishing builds for one application within a
+      single page.
+
+    - :goals: a whitespace-separated list of what to do with the app (in
+      'build', 'flash', 'debug', 'debugserver'). Commands to accomplish these
+      tasks will be generated in the right order.
+
+    - :maybe-skip-config: if set, this indicates the reader may have already
+      created a build directory and changed there, and will tweak the text to
+      note that doing so again is not necessary.
+
+    '''
+    has_content = False
+    required_arguments = 0
+    optional_arguments = 0
+    final_argument_whitespace = False
+    option_spec = {
+        'app': directives.unchanged,
+        'zephyr-app': directives.unchanged,
+        'generator': directives.unchanged,
+        'board': directives.unchanged,
+        'build-dir': directives.unchanged,
+        'goals': directives.unchanged_required,
+        'maybe-skip-config': directives.flag
+    }
+
+    GENERATORS = ['make', 'ninja']
+
+    def run(self):
+        # Re-run on the current document if this directive's source changes.
+        self.state.document.settings.env.note_dependency(__file__)
+
+        # Parse directive options.  Don't use os.path.sep or os.path.join here!
+        # That would break if building the docs on Windows.
+        app = self.options.get('app', None)
+        zephyr_app = self.options.get('zephyr-app', None)
+        generator = self.options.get('generator', 'make').lower()
+        board = self.options.get('board', None)
+        build_dir_append = self.options.get('build-dir', '').strip('/')
+        goals = self.options.get('goals').split()
+        skip_config = 'maybe-skip-config' in self.options
+
+        if app and zephyr_app:
+            raise self.error('Both app and zephyr-app options were given.')
+
+        if generator not in self.GENERATORS:
+            raise self.error('Unknown generator {}; choose from: {}'.format(
+                generator, self.GENERATORS))
+
+        # Allow build directories which are nested.
+        build_dir = ('build' + '/' + build_dir_append).rstrip('/')
+        num_slashes = build_dir.count('/')
+        source_dir = '/'.join(['..' for i in range(num_slashes + 1)])
+        mkdir = 'mkdir' if num_slashes == 0 else 'mkdir -p'
+
+        run_config = {
+            'board': board,
+            'source_dir': source_dir,
+            'goals': goals
+            }
+
+        # Build the command content as a list, then convert to string.
+        content = []
+
+        if zephyr_app:
+            content.append('$ cd $ZEPHYR_BASE/{}'.format(zephyr_app))
+            content.append('')
+        elif app:
+            content.append('$ cd {}'.format(app))
+            content.append('')
+
+        if skip_config:
+            content.append("# If you already made a build directory ({}) and ran cmake, just 'cd {}' instead.".format(build_dir, build_dir))  # noqa: E501
+        else:
+            content.append('# Make a build directory, and use cmake to configure a {}-based build system:'.format(generator.capitalize()))  # noqa: E501
+        content.append('$ {} {} && cd {}'.format(mkdir, build_dir, build_dir))
+
+        if generator == 'make':
+            content.extend(self._generate_make(**run_config))
+        elif generator == 'ninja':
+            content.extend(self._generate_ninja(**run_config))
+
+        content = '\n'.join(content)
+
+        # Create the nodes.
+        literal = nodes.literal_block(content, content)
+        self.add_name(literal)
+        literal['language'] = 'console'
+        return [literal]
+
+    def _generate_make(self, **kwargs):
+        board = kwargs['board']
+        source_dir = kwargs['source_dir']
+        goals = kwargs['goals']
+
+        board_arg = ' BOARD={}'.format(board) if board else ''
+
+        content = []
+        content.extend([
+            '$ cmake{} {}'.format(board_arg, source_dir),
+            '',
+            '# Now run make on the generated build system:'])
+        if 'build' in goals:
+            content.append('$ make')
+        if 'flash' in goals:
+            content.append('$ make flash')
+        if 'debug' in goals:
+            content.append('$ make debug')
+        if 'debugserver' in goals:
+            content.append('$ make debugserver')
+        return content
+
+    def _generate_ninja(self, **kwargs):
+        board = kwargs['board']
+        source_dir = kwargs['source_dir']
+        goals = kwargs['goals']
+
+        board_arg = ' -DBOARD={}'.format(board) if board else ''
+
+        content = []
+        content.extend([
+            '$ cmake -GNinja{} {}'.format(board_arg, source_dir),
+            '',
+            '# Now run ninja on the generated build system:'])
+        if 'build' in goals:
+            content.append('$ ninja')
+        if 'flash' in goals:
+            content.append('$ ninja flash')
+        if 'debug' in goals:
+            content.append('$ ninja debug')
+        if 'debugserver' in goals:
+            content.append('$ ninja debugserver')
+        return content
+
+
+def setup(app):
+    app.add_directive('zephyr-app-commands', ZephyrAppCommandsDirective)
+
+    return {
+        'version': '1.0',
+        'parallel_read_safe': True,
+        'parallel_write_safe': True
+    }


### PR DESCRIPTION
This pull request builds upon the RFC in https://github.com/zephyrproject-rtos/zephyr/pull/4726.

It modifies and improves on the RFC as follows:

- add build-dir and maybe-skip-config options
- general improvements to the readability of the generated commands
- better dependency handling

Additionally, all x86-based boards are converted to use this directive.

In future work, I'll convert the rest of the boards (and hopefully some other areas too, though this might be left to SMEs in areas such as BT, net, etc.)