### PR TITLE
doc: cmake: Unify getting started guides

### DIFF
--- a/doc/getting_started/getting_started.rst
+++ b/doc/getting_started/getting_started.rst
@@ -86,8 +86,7 @@ To build an example application follow these steps:
    .. code-block:: console
 
       $ cd $ZEPHYR_BASE/samples/hello_world
-      $ mkdir build
-      $ cd build
+      $ mkdir build && cd build
       $ cmake ..
 
 The above will generate project files that can build the
@@ -106,10 +105,8 @@ with one of the supported boards, for example:
 .. code-block:: console
 
    $ cd $ZEPHYR_BASE/samples/hello_world
-   $ export BOARD=arduino_101
-   $ mkdir build_101
-   $ cd build_101
-   $ cmake ..
+   $ mkdir build_101 && cd build_101
+   $ cmake -DBOARD=arduino_101 ..
    $ make
 
 For further information on the supported boards go see
@@ -148,35 +145,28 @@ follow the steps below to build with any custom or 3rd party cross-compilers:
 
       $ unset ZEPHYR_GCC_VARIANT
       $ unset ZEPHYR_SDK_INSTALL_DIR
+      $ cd <zephyr git clone location>
+      $ source zephyr-env.sh
 
-#. Build Kconfig and add it to path
+#. Build Kconfig in :file:`$ZEPHYR_BASE/build` and add it to path
 
    .. code-block:: console
 
-      $ mkdir ~/kconfig_build_dir && cd ~/kconfig_build_dir
+      $ cd $ZEPHYR_BASE
+      $ mkdir build && cd build
       $ cmake $ZEPHYR_BASE/scripts
       $ make
       $ echo "export PATH=$PWD/kconfig:\$PATH" >> $HOME/.zephyrrc
-      $ bash
-      $ which conf
+      $ source $ZEPHYR_BASE/zephyr-env.sh
+
+.. note::
+
+   You only need to do this once after cloning the git repository.
 
 #. We will use the `GCC ARM Embedded`_ compiler for this example, download the
    package suitable for your operating system from the `GCC ARM Embedded`_ website
    and extract it on your file system. This example assumes the compiler was
    extracted to: :file:`~/gcc-arm-none-eabi-5_3-2016q1/`.
-
-#. Navigate to the main project directory (where you cloned the Zephyr source from GitHub):
-
-   .. code-block:: console
-
-      $ cd zephyr-project
-
-#. Source the project environment file to set the project environment
-   variables:
-
-   .. code-block:: console
-
-      $ source zephyr-env.sh
 
 #. Build the example :ref:`hello_world` project, enter:
 
@@ -184,7 +174,10 @@ follow the steps below to build with any custom or 3rd party cross-compilers:
 
       $ export GCCARMEMB_TOOLCHAIN_PATH="~/gcc-arm-none-eabi-5_3-2016q1/"
       $ export ZEPHYR_GCC_VARIANT=gccarmemb
-      $ cmake -DBOARD=arduino_due -H$ZEPHYR_BASE/samples/hello_world -Bbld && cmake --build bld
+      $ cd $ZEPHYR_BASE/samples/hello_world
+      $ mkdir build && cd build
+      $ cmake -DBOARD=arduino_due ..
+      $ make
 
 Running a Sample Application in QEMU
 ====================================
@@ -201,10 +194,8 @@ type:
 .. code-block:: console
 
    $ cd $ZEPHYR_BASE/samples/hello_world
-   $ export BOARD=qemu_x86
-   $ mkdir qemu_build
-   $ cd qemu_build
-   $ cmake ..
+   $ mkdir qemu_build && cd qemu_build
+   $ cmake -DBOARD=qemu_x86 ..
    $ make run
 
 To run an application using the ARM qemu_cortex_m3 board configuration

--- a/doc/getting_started/installation_mac.rst
+++ b/doc/getting_started/installation_mac.rst
@@ -68,16 +68,19 @@ Source :file:`zephyr-env.sh` wherever you have cloned the Zephyr Git repository:
 .. code-block:: console
 
    $ unset ZEPHYR_SDK_INSTALL_DIR
-   $ source ~/zephyr/zephyr-env.sh
+   $ cd <zephyr git clone location>
+   $ source zephyr-env.sh
 
-Within the shell, build the required host tools:
+Build Kconfig in :file:`$ZEPHYR_BASE/build` and add it to path
 
 .. code-block:: console
 
    $ cd $ZEPHYR_BASE
-   $ cmake -Bbuild -Hscripts/
-   $ cd build
+   $ mkdir build && cd build
+   $ cmake $ZEPHYR_BASE/scripts
    $ make
+   $ echo "export PATH=$PWD/kconfig:\$PATH" >> $HOME/.zephyrrc
+   $ source $ZEPHYR_BASE/zephyr-env.sh
 
 .. note::
 
@@ -90,8 +93,8 @@ To build for the ARM-based Nordic nRF52 Development Kit:
 .. code-block:: console
 
    $ cd $ZEPHYR_BASE/samples/hello_world
-   $ cmake -Bbuild -H. -DPREBUILT_HOST_TOOLS=$ZEPHYR_BASE/build  -DBOARD=nrf52_pca10040
-   $ cd build
+   $ mkdir build && cd build
+   $ cmake -DBOARD=nrf52_pca10040 ..
    $ make
 
 .. _setting_up_mac_toolchain:

--- a/doc/getting_started/installation_win.rst
+++ b/doc/getting_started/installation_win.rst
@@ -130,21 +130,24 @@ environment for Windows. Follow the steps below to set it up:
    .. code-block:: console
 
       $ unset ZEPHYR_SDK_INSTALL_DIR
-      $ source ~/zephyr/zephyr-env.sh
+      $ cd <zephyr git clone location>
+      $ source zephyr-env.sh
 
-#. Within the MSYS console, build the required host tools:
+ #. Within the MSYS console, build Kconfig in :file:`$ZEPHYR_BASE/build` and
+    add it to path
 
-    .. code-block:: console
+   .. code-block:: console
 
       $ cd $ZEPHYR_BASE
-      $ cmake -Bbuild -Hscripts/
-      $ cd build
+      $ mkdir build && cd build
+      $ cmake $ZEPHYR_BASE/scripts
       $ make
+      $ echo "export PATH=$PWD/kconfig:\$PATH" >> $HOME/.zephyrrc
+      $ source $ZEPHYR_BASE/zephyr-env.sh
 
     .. note::
 
         You only need to do this once after cloning the git repository.
-
 
 #. Finally, you can try building the :ref:`hello_world` sample to check things
    out.
@@ -154,8 +157,8 @@ environment for Windows. Follow the steps below to set it up:
     .. code-block:: console
 
        $ cd $ZEPHYR_BASE/samples/hello_world
-       $ cmake -Bbuild -H. -DPREBUILT_HOST_TOOLS=$ZEPHYR_BASE/build  -DBOARD=arduino_101
-       $ cd build
+       $ mkdir build && cd build
+       $ cmake -DBOARD=arduino_101 ..
        $ make
 
    To build for the ARM-based Nordic nRF52 Development Kit:
@@ -163,8 +166,8 @@ environment for Windows. Follow the steps below to set it up:
     .. code-block:: console
 
        $ cd $ZEPHYR_BASE/samples/hello_world
-       $ cmake -Bbuild -H. -DPREBUILT_HOST_TOOLS=$ZEPHYR_BASE/build  -DBOARD=nrf52_pca10040
-       $ cd build
+       $ mkdir build && cd build
+       $ cmake -DBOARD=nrf52_pca10040 ..
        $ make
 
     This should check that all the tools and toolchain are set up correctly for


### PR DESCRIPTION
Unify the format and mechanisms used in the different Getting Started
guides so that they are consistent in:

- The way Kconfig is built
- Avoiding using -B and -H CMake options
- -DBOARD instead of export

Signed-off-by: Carles Cufi <carles.cufi@nordicsemi.no>