### PR TITLE
doc: fix misspellings in doxygen API comments

### DIFF
--- a/include/net/http_app.h
+++ b/include/net/http_app.h
@@ -517,7 +517,7 @@ int http_server_init(struct http_ctx *ctx,
  * @param personalization_data Personalization data (Device specific
  * identifiers) for random number generator. (Can be NULL).
  * @param personalization_data_len Length of the personalization data.
- * @param cert_cb User supplied callback that setups the certifacates.
+ * @param cert_cb User supplied callback that setups the certificates.
  * @param entropy_src_cb User supplied callback that setup the entropy. This
  * can be set to NULL, in which case default entropy source is used.
  * @param pool Memory pool for RX data reads.

--- a/include/net/udp.h
+++ b/include/net/udp.h
@@ -40,7 +40,7 @@ extern "C" {
  *
  * @param pkt Network packet
  * @param hdr Where to place the header if it does not fit in first fragment
- * of the network packet. This might not be pupulated if UDP header fits in
+ * of the network packet. This might not be populated if UDP header fits in
  * net_buf fragment.
  *
  * @return Return pointer to header or NULL if something went wrong.


### PR DESCRIPTION
Signed-off-by: David B. Kinder <david.b.kinder@intel.com>