### PR TITLE
doc: fix Kconfig misspellings

### DIFF
--- a/arch/Kconfig
+++ b/arch/Kconfig
@@ -47,7 +47,7 @@ config HW_STACK_PROTECTION
 	mode. If CONFIG_USERSPACE is not enabled, the system is always
 	running in privileged mode.
 
-	Note that this does not necessarily prevent corruptuon and assertions
+	Note that this does not necessarily prevent corruption and assertions
 	about the overall system state when a fault is triggered cannot be
 	made.
 

--- a/drivers/led_strip/Kconfig.ws2812
+++ b/drivers/led_strip/Kconfig.ws2812
@@ -19,7 +19,7 @@ menuconfig WS2812_STRIP
 		These devices have a one-wire communications interface
 		which encodes bits using pulses. Short pulses indicate
 		zero bits, and long pulses indicate ones; refer to the
-		chip datsheets for precise specifications. To implement
+		chip datasheets for precise specifications. To implement
 		this in a multitasking operating system, this driver
 		generates the pulses using a SPI peripheral.
 

--- a/subsys/bluetooth/host/Kconfig
+++ b/subsys/bluetooth/host/Kconfig
@@ -306,7 +306,7 @@ config BT_SCAN_WITH_IDENTITY
 	depends on !BT_PRIVACY && (BT_CENTRAL || BT_OBSERVER)
 	help
 	  Enable this if you want to perform active scanning using the local
-	  identy address as the scanner address. By default the stack will
+	  identity address as the scanner address. By default the stack will
 	  always use a non-resolvable private address (NRPA) in order to avoid
 	  disclosing local identity information. However, if the use case
 	  requires disclosing it then enable this option.


### PR DESCRIPTION
Kconfig files are processed to create configuration
option documentation.

Signed-off-by: David B. Kinder <david.b.kinder@intel.com>