### PR TITLE
cmake: use zephyr_library_* for all boards

### DIFF
--- a/boards/arm/cc2650_sensortag/CMakeLists.txt
+++ b/boards/arm/cc2650_sensortag/CMakeLists.txt
@@ -1,1 +1,3 @@
-zephyr_sources_if_kconfig(pinmux.c)
+zephyr_library()
+zephyr_library_sources(pinmux.c)
+zephyr_library_include_directories(${PROJECT_SOURCE_DIR}/drivers)

--- a/boards/arm/cc3220sf_launchxl/CMakeLists.txt
+++ b/boards/arm/cc3220sf_launchxl/CMakeLists.txt
@@ -1,4 +1,6 @@
-zephyr_sources(
-  pinmux.c
-  dbghdr.c
-  )
+zephyr_library()
+zephyr_library_sources(
+    pinmux.c
+    dbghdr.c
+    )
+zephyr_library_include_directories(${PROJECT_SOURCE_DIR}/drivers)


### PR DESCRIPTION
Signed-off-by: Anas Nashif <anas.nashif@intel.com>