### PR TITLE
Bluetooth: samples: Remove references to Kbuild-style building

### DIFF
--- a/samples/bluetooth/bluetooth.rst
+++ b/samples/bluetooth/bluetooth.rst
@@ -3,15 +3,16 @@
 Bluetooth
 ##########
 
-To build any of the Bluetooth samples, follow the instructions below:
+To build any of the Bluetooth samples, follow the same steps as building
+any other Zephyr application. Refer to the
+:ref:`Getting Started Guide <getting_started>` for more information.
 
-.. code-block:: console
-
-   $ make -C samples/bluetooth/<app>
-
-Host Bluetooth controller is connected to the second QEMU serial line through a
-Unix socket (QEMU option -serial unix:/tmp/bt-server-bredr).  This option is
-already added to QEMU through QEMU_EXTRA_FLAGS in Makefile.
+When building for qemu (e.g. BOARD=qemu_x86 or BOARD=qemu_cortex_m3),
+the setup assumes that the host's Bluetooth controller is connected to
+the second QEMU serial line through a Unix socket (QEMU option -serial
+unix:/tmp/bt-server-bredr). This option is automatically added to the
+qemu command line whenever building for a qemu target and Bluetooth
+support has been enabled.
 
 On the host side BlueZ allows to "connect" Bluetooth controller through a
 so-called user channel. Use the btproxy tool for that:


### PR DESCRIPTION
Update the documentation for the Bluetooth samples not to refer to the
old style of building using make. Instead, simply refer to the general
instructions.

Signed-off-by: Johan Hedberg <johan.hedberg@intel.com>