### PR TITLE
usb: dc_dw: Improve TX perf and reliability

### DIFF
--- a/drivers/usb/device/usb_dc_dw.c
+++ b/drivers/usb/device/usb_dc_dw.c
@@ -400,16 +400,15 @@ static int usb_dw_tx(u8_t ep, const u8_t *const data,
 	unsigned int key;
 	u32_t i;
 
-
-	/* Check if FIFO space available */
-	avail_space = usb_dw_tx_fifo_avail(ep_idx);
-	if (avail_space != usb_dw_ctrl.in_ep_ctrl[ep_idx].fifo_size) {
-		SYS_LOG_DBG("USB IN EP%d fifo not empty: %d",
-			    ep_idx, avail_space);
-		k_sleep(20);
-		usb_dw_flush_tx_fifo(ep_idx);
+	/* Wait for FIFO space available */
+	do {
 		avail_space = usb_dw_tx_fifo_avail(ep_idx);
-	}
+		if (avail_space == usb_dw_ctrl.in_ep_ctrl[ep_idx].fifo_size) {
+			break;
+		}
+		/* Make sure we don't hog the CPU */
+		k_yield();
+	} while (1);
 
 	key = irq_lock();
 


### PR DESCRIPTION
During large USB transfer it's pretty common to call ep_write whereas
the previous TX transfer is not achieved and so the TX FIFO space is
not available. Sleeping 20ms in this case introduce a relatively high
latency and reduce the throughput.

This can be observed when pinging the board with CDC-ECM net class.
ping reply is split into 2 USB TX transfer, the second one is only
triggered after 20ms, making ping latency > 20ms.

To fix this, just continuously read the FIFO availabilty and fire TX
as soon as possible.

Signed-off-by: Loic Poulain <loic.poulain@linaro.org>