### PR TITLE
Bluetooth: Mesh: Fix use of uninitialized value

### DIFF
--- a/subsys/bluetooth/host/mesh/net.c
+++ b/subsys/bluetooth/host/mesh/net.c
@@ -989,7 +989,7 @@ static int net_find_and_decrypt(const u8_t *data, size_t data_len,
 				struct net_buf_simple *buf)
 {
 	struct bt_mesh_subnet *sub;
-	int i;
+	unsigned int i;
 
 	BT_DBG("");
 


### PR DESCRIPTION
arm-none-eabi-gcc in version 6.3.1 couldn't figure out that
the loop will run at least once when the i variable was of type int.

Signed-off-by: Michał Narajowski <michal.narajowski@codecoup.pl>