### PR TITLE
usb: netusb: Use lower addresses for default endpoint config

### DIFF
--- a/subsys/usb/class/netusb/Kconfig
+++ b/subsys/usb/class/netusb/Kconfig
@@ -36,21 +36,21 @@ if USB_DEVICE_NETWORK_ECM
 
 config CDC_ECM_INT_EP_ADDR
 	hex "CDC ECM Interrupt Endpoint address"
-	default 0x84
+	default 0x83
 	range 0x81 0x8F
 	help
 	CDC ECM class interrupt endpoint address
 
 config CDC_ECM_IN_EP_ADDR
 	hex "CDC ECM BULK IN Endpoint address"
-	default 0x83
+	default 0x82
 	range 0x81 0x8F
 	help
 	CDC ECM class IN endpoint address
 
 config CDC_ECM_OUT_EP_ADDR
 	hex "CDC ECM BULK OUT Endpoint address"
-	default 0x02
+	default 0x01
 	range 0x01 0x0F
 	help
 	CDC ECM class OUT endpoint address


### PR DESCRIPTION
Even if endpoint addresses are configurable by each platform,
it would be better to make the default configuration compatible
with a larger board range.

e.g. STM32 OTG FS device has only four endpoints (0x84 is out).

Signed-off-by: Loic Poulain <loic.poulain@linaro.org>