### PR TITLE
crypto: Update TinyCrypt to 0.2.8

### DIFF
--- a/ext/lib/crypto/tinycrypt/source/ccm_mode.c
+++ b/ext/lib/crypto/tinycrypt/source/ccm_mode.c
@@ -202,8 +202,7 @@ int tc_ccm_decryption_verification(uint8_t *out, unsigned int olen,
 {
 
 	/* input sanity check: */
-	if ((plen <= alen) ||
-	    (out == (uint8_t *) 0) ||
+	if ((out == (uint8_t *) 0) ||
 	    (c == (TCCcmMode_t) 0) ||
 	    ((plen > 0) && (payload == (uint8_t *) 0)) ||
 	    ((alen > 0) && (associated_data == (uint8_t *) 0)) ||


### PR DESCRIPTION
Version 0.2.8 of this library has been released on Aug 29, and this
patch updates the library from version 0.2.7.  A summary of changes
is available at the official repository at:

    https://github.com/01org/tinycrypt/releases/tag/v0.2.8

A number of the changes we already had in tree, so the import to sync
with v0.2.8 is pretty minor.

Signed-off-by: Kumar Gala <kumar.gala@linaro.org>