### PR TITLE
userspace: lock irqs in init function handlers

### DIFF
--- a/kernel/msg_q.c
+++ b/kernel/msg_q.c
@@ -66,11 +66,15 @@ void _impl_k_msgq_init(struct k_msgq *q, char *buffer,
 #ifdef CONFIG_USERSPACE
 _SYSCALL_HANDLER(k_msgq_init, q, buffer, msg_size, max_msgs)
 {
+	int key;
+
 	_SYSCALL_OBJ_INIT(q, K_OBJ_MSGQ);
 	_SYSCALL_MEMORY_ARRAY_WRITE(buffer, max_msgs, msg_size);
 
+	key = irq_lock();
 	_impl_k_msgq_init((struct k_msgq *)q, (char *)buffer, msg_size,
 			  max_msgs);
+	irq_unlock(key);
 	return 0;
 }
 #endif

--- a/kernel/mutex.c
+++ b/kernel/mutex.c
@@ -84,8 +84,12 @@ void _impl_k_mutex_init(struct k_mutex *mutex)
 #ifdef CONFIG_USERSPACE
 _SYSCALL_HANDLER(k_mutex_init, mutex)
 {
+	int key;
+
 	_SYSCALL_OBJ_INIT(mutex, K_OBJ_MUTEX);
+	key = irq_lock();
 	_impl_k_mutex_init((struct k_mutex *)mutex);
+	irq_unlock(key);
 
 	return 0;
 }

--- a/kernel/pipes.c
+++ b/kernel/pipes.c
@@ -143,11 +143,15 @@ void _impl_k_pipe_init(struct k_pipe *pipe, unsigned char *buffer, size_t size)
 #ifdef CONFIG_USERSPACE
 _SYSCALL_HANDLER(k_pipe_init, pipe, buffer, size)
 {
+	int key;
+
 	_SYSCALL_OBJ_INIT(pipe, K_OBJ_PIPE);
 	_SYSCALL_MEMORY_WRITE(buffer, size);
 
+	key = irq_lock();
 	_impl_k_pipe_init((struct k_pipe *)pipe, (unsigned char *)buffer,
 			  size);
+	irq_unlock(key);
 	return 0;
 }
 #endif

--- a/kernel/sem.c
+++ b/kernel/sem.c
@@ -74,9 +74,15 @@ void _impl_k_sem_init(struct k_sem *sem, unsigned int initial_count,
 #ifdef CONFIG_USERSPACE
 _SYSCALL_HANDLER(k_sem_init, sem, initial_count, limit)
 {
+	int key;
+
 	_SYSCALL_OBJ_INIT(sem, K_OBJ_SEM);
 	_SYSCALL_VERIFY(limit != 0);
+
+	key = irq_lock();
 	_impl_k_sem_init((struct k_sem *)sem, initial_count, limit);
+	irq_unlock(key);
+
 	return 0;
 }
 #endif

--- a/kernel/stack.c
+++ b/kernel/stack.c
@@ -59,11 +59,16 @@ void _impl_k_stack_init(struct k_stack *stack, u32_t *buffer,
 #ifdef CONFIG_USERSPACE
 _SYSCALL_HANDLER(k_stack_init, stack, buffer, num_entries)
 {
+	int key;
+
 	_SYSCALL_OBJ_INIT(stack, K_OBJ_STACK);
 	_SYSCALL_MEMORY_ARRAY_WRITE(buffer, num_entries, sizeof(u32_t));
 
+	key = irq_lock();
 	_impl_k_stack_init((struct k_stack *)stack, (u32_t *)buffer,
 			   num_entries);
+	irq_unlock(key);
+
 	return 0;
 }
 #endif

--- a/kernel/thread.c
+++ b/kernel/thread.c
@@ -307,13 +307,15 @@ k_tid_t _impl_k_thread_create(struct k_thread *new_thread,
 _SYSCALL_HANDLER(k_thread_create,
 		 new_thread_p, stack_p, stack_size, entry, p1, more_args)
 {
-	int prio;
+	int prio, key;
 	u32_t options, delay, guard_size, total_size;
 	struct _k_object *stack_object;
 	struct k_thread *new_thread = (struct k_thread *)new_thread_p;
 	volatile struct _syscall_10_args *margs =
 		(volatile struct _syscall_10_args *)more_args;
 	k_thread_stack_t *stack = (k_thread_stack_t *)stack_p;
+
+	key = irq_lock();
 
 	/* The thread and stack objects *must* be in an uninitialized state */
 	_SYSCALL_OBJ_NEVER_INIT(new_thread, K_OBJ_THREAD);
@@ -339,13 +341,9 @@ _SYSCALL_HANDLER(k_thread_create,
 	/* Verify the struct containing args 6-10 */
 	_SYSCALL_MEMORY_READ(margs, sizeof(*margs));
 
-	/* Stash struct arguments in local variables to prevent switcheroo
-	 * attacks
-	 */
 	prio = margs->arg8;
 	options = margs->arg9;
 	delay = margs->arg10;
-	compiler_barrier();
 
 	/* User threads may only create other user threads and they can't
 	 * be marked as essential
@@ -363,6 +361,7 @@ _SYSCALL_HANDLER(k_thread_create,
 			  (k_thread_entry_t)entry, (void *)p1,
 			  (void *)margs->arg6, (void *)margs->arg7, prio,
 			  options);
+	irq_unlock(key);
 
 	if (delay != K_FOREVER) {
 		schedule_new_thread(new_thread, delay);


### PR DESCRIPTION
There's no concurrency control in kernel object init functions,
presumably because races to initialize and use objects is
considered buggy behavior.

However, if we let user mode intialize these objects, we need to
account for this possibility. Lock interrupts around initializing
objects in the system call handlers to make these operations atomic.

Thread objects have the additional constraint that the object is
always in an uninitialized state, so we lock interrupts before
doing any checks to prevent multiple threads trying to init the
same thread from both initializing it.

This doesn't prevent problems where one or more threads are waiting
on an object that then gets re-initialized. Such threads will be
in limbo (off the ready queue) forever. However since threads have
to have permission granted on them to begin with, this can be viewed
as a logical error in the application. We are just trying to guard
against corruption/crashes in kernel mode when handling these
calls on behalf of user mode.

In the fullness of time, these irq locking calls should be replaced
with specific, non-global spinlocks.

Signed-off-by: Andrew Boie <andrew.p.boie@intel.com>