### PR TITLE
kernel: have k_sched_lock call _sched_lock

### DIFF
--- a/kernel/include/ksched.h
+++ b/kernel/include/ksched.h
@@ -239,12 +239,8 @@ static inline int _must_switch_threads(void)
 }
 
 /*
- * Internal equivalent to k_sched_lock so that it does not incur a function
- * call penalty in the kernel guts.
- *
- * Must be kept in sync until the header files are cleaned-up and the
- * applications have access to the kernel internal deta structures (through
- * APIs of course).
+ * Called directly by other internal kernel code.
+ * Exposed to applications via k_sched_lock(), which just calls this
  */
 static inline void _sched_lock(void)
 {

--- a/kernel/sched.c
+++ b/kernel/sched.c
@@ -137,20 +137,7 @@ void _reschedule_threads(int key)
 
 void k_sched_lock(void)
 {
-#ifdef CONFIG_PREEMPT_ENABLED
-	__ASSERT(_current->base.sched_locked != 1, "");
-	__ASSERT(!_is_in_isr(), "");
-
-	--_current->base.sched_locked;
-
-	/* Probably not needed since we're in a real function,
-	 * but it doesn't hurt.
-	 */
-	compiler_barrier();
-
-	K_DEBUG("scheduler locked (%p:%d)\n",
-		_current, _current->base.sched_locked);
-#endif
+	_sched_lock();
 }
 
 void k_sched_unlock(void)


### PR DESCRIPTION
Having two implementations of the same thing is bad,
especially when one can just call the other inline version.

Signed-off-by: Andrew Boie <andrew.p.boie@intel.com>