### PR TITLE
mempool: add k_calloc()

### DIFF
--- a/include/kernel.h
+++ b/include/kernel.h
@@ -3705,6 +3705,19 @@ extern void *k_malloc(size_t size);
 extern void k_free(void *ptr);
 
 /**
+ * @brief Allocate memory from heap, array style
+ *
+ * This routine provides traditional calloc() semantics. Memory is
+ * allocated from the heap memory pool and zeroed.
+ *
+ * @param nmemb Number of elements in the requested array
+ * @param size Size of each array element (in bytes).
+ *
+ * @return Address of the allocated memory if successful; otherwise NULL.
+ */
+extern void *k_calloc(size_t nmemb, size_t size);
+
+/**
  * @} end defgroup heap_apis
  */
 

--- a/kernel/mempool.c
+++ b/kernel/mempool.c
@@ -405,4 +405,17 @@ void k_free(void *ptr)
 		k_mem_pool_free(ptr);
 	}
 }
+
+void *k_calloc(size_t nmemb, size_t size)
+{
+	void *ret;
+	size_t bounds;
+
+	bounds = nmemb * size;
+	ret = k_malloc(bounds);
+	if (ret) {
+		memset(ret, 0, bounds);
+	}
+	return ret;
+}
 #endif


### PR DESCRIPTION
This uses the kernel heap to implement traditional calloc()
semantics.

Signed-off-by: Andrew Boie <andrew.p.boie@intel.com>