### PR TITLE
cmake: fix guessing where 'conf' is for other toolchains

### DIFF
--- a/cmake/host-tools.cmake
+++ b/cmake/host-tools.cmake
@@ -1,5 +1,13 @@
 include($ENV{ZEPHYR_BASE}/cmake/host-tools-${ZEPHYR_GCC_VARIANT}.cmake OPTIONAL)
 
+# This allows to find 'conf' below if the Zephyr 0.9.2 SDK is installed,
+# even if we are using another toolchain (like ISSM)
+if(NOT $ENV{ZEPHYR_SDK_INSTALL_DIR} STREQUAL "")
+  list(APPEND CMAKE_PROGRAM_PATH $ENV{ZEPHYR_SDK_INSTALL_DIR}/sysroots/x86_64-pokysdk-linux/usr/bin)
+endif()
+
+# This allows to find 'conf' below if we have pre-built it and set
+# environ variable PREBUILT_HOST_TOOLS
 if(PREBUILT_HOST_TOOLS)
   list(APPEND CMAKE_PROGRAM_PATH ${PREBUILT_HOST_TOOLS}/kconfig)
 endif()


### PR DESCRIPTION
When building with other toolchains (like ISSM), default to be able to
find 'conf' if ZEPHYR_SDK_INSTALL_DIR is available (even if we are
building with the other toolchain).

Signed-off-by: Inaky Perez-Gonzalez <inaky.perez-gonzalez@intel.com>