### PR TITLE
cmake: Support disjoint toolchain and SDK locations

### DIFF
--- a/cmake/host-tools-espressif.cmake
+++ b/cmake/host-tools-espressif.cmake
@@ -1,0 +1,1 @@
+include($ENV{ZEPHYR_BASE}/cmake/host-tools-zephyr.cmake)

--- a/cmake/host-tools-issm.cmake
+++ b/cmake/host-tools-issm.cmake
@@ -1,0 +1,1 @@
+include($ENV{ZEPHYR_BASE}/cmake/host-tools-zephyr.cmake)


### PR DESCRIPTION
Some toolchains, such as the one provided by Espressif for the ESP32,
or ISSM provided by Intel, will contain only the compiler, linker, and
supporting tools.  Other binaries needed by the build system that are
provided by the Zephyr SDK need to be found somewhere else.

Signed-off-by: Leandro Pereira <leandro.pereira@intel.com>