### PR TITLE
cmake: Fix drivers/serial/CMakeLists.txt to build uart_cc32xx.c

### DIFF
--- a/drivers/serial/CMakeLists.txt
+++ b/drivers/serial/CMakeLists.txt
@@ -1,6 +1,6 @@
 zephyr_sources_if_kconfig(uart_altera_jtag.c)
 zephyr_sources_if_kconfig(uart_atmel_sam3.c)
-zephyr_sources_if_kconfig(uart_cc32.c)
+zephyr_sources_if_kconfig(uart_cc32xx.c)
 zephyr_sources_if_kconfig(uart_cmsdk_apb.c)
 zephyr_sources_if_kconfig(uart_gecko.c)
 zephyr_sources_if_kconfig(uart_mcux.c)


### PR DESCRIPTION
Previously, a typo prevented UART from working for any program
built for BOARD=cc3220sf_launchxl.

Signed-off-by: Gil Pitney <gil.pitney@linaro.org>