### PR TITLE
cmake: Support disjoint toolchain and SDK locations

### DIFF
--- a/cmake/host-tools-gccarmemb.cmake
+++ b/cmake/host-tools-gccarmemb.cmake
@@ -1,0 +1,1 @@
+include($ENV{ZEPHYR_BASE}/cmake/host-tools-zephyr.cmake)

--- a/cmake/host-tools-xtools.cmake
+++ b/cmake/host-tools-xtools.cmake
@@ -1,0 +1,1 @@
+include($ENV{ZEPHYR_BASE}/cmake/host-tools-zephyr.cmake)


### PR DESCRIPTION
Make more toolchains use the tools provided by the Zephyr SDK.

Signed-off-by: Anas Nashif <anas.nashif@intel.com>