### PR TITLE
Docs: convert boards to cmake

### DIFF
--- a/boards/arc/em_starterkit/doc/board.rst
+++ b/boards/arc/em_starterkit/doc/board.rst
@@ -197,14 +197,18 @@ You can try many of the sample applications or tests, but let us discuss
 the one called :ref:`hello_world`.
 It is found in :file:`$ZEPHYR_BASE/samples/hello_world`.
 
+Configuring
+-----------
+
 You may need to write a prj_arc.conf file if the sample doesn't have one.
-Next, you can use the make menuconfig rule to configure the target. By
-providing the argument "BOARD=em_starterkit", you can select the ARC
+Next, you can use the menuconfig rule to configure the target. By
+specifying ``em_starterkit`` as the board configuration, you can select the ARC
 EM Starter Kit board support for Zephyr.
 
-.. code-block:: console
-
-   $ make menuconfig BOARD=em_starterkit
+.. zephyr-app-commands::
+   :board: em_starterkit
+   :zephyr-app: samples/hello_world
+   :goals: menuconfig
 
 On this board you will also need to consider the "ARC SoC Selection" and set
 it either to EM9D or EM11D. To boot up the EM9D on the board, all dip
@@ -213,11 +217,18 @@ are made in the normal way. To boot up the EM11D on the board,
 all dip switches should be UP except for switch 2. Next press the button
 above the letter C in the "ARC" logo on the silkscreen.
 
-To build the application, execute make:
+Building
+--------
 
-.. code-block:: console
+You can build application in the usual way.  Refer to
+:ref:`build_an_application` for more details. Here is an example for
+:ref:`hello_world`.
 
-   $ make BOARD=em_starterkit
+.. zephyr-app-commands::
+   :board: em_starterkit
+   :zephyr-app: samples/hello_world
+   :maybe-skip-config:
+   :goals: build
 
 Connecting Serial Output
 =========================
@@ -247,29 +258,32 @@ Debugging
 Using the latest version of Zephyr SDK(>=0.9), you can debug and flash
 EM Starterkit directly.
 
-Build and debug the application with the following commands:
+One option is to build and debug the application using the usual
+Zephyr build system commands.
 
-.. code-block:: console
-
-   $ cd <my app>
-   $ make BOARD=em_starterkit debug
+.. zephyr-app-commands::
+   :board: em_starterkit
+   :app: <my app>
+   :goals: debug
 
 At this point you can do your normal debug session. Set breakpoints and then
 'c' to continue into the program.
 
-Launch the debug server on the EM Starter Kit:
+The other option is to launch a debug server, as follows.
 
-.. code-block:: console
+.. zephyr-app-commands::
+   :board: em_starterkit
+   :app: <my app>
+   :goals: debugserver
 
-   $ make BOARD=em_starterkit debugserver
-
-Connect to the debug server at the EM Starter Kit from a second console:
+Then connect to the debug server at the EM Starter Kit from a second
+console, from the build directory containing the output :file:`zephyr.elf`.
 
 .. code-block:: console
 
    $ cd <my app>
    $ $ZEPHYR_SDK_INSTALL_DIR/sysroots/x86_64-pokysdk-linux/usr/bin/arc-zephyr-elf/arc-zephyr-elf-gdb \
-      outdir/em_starterkit/zephyr.elf
+      zephyr.elf
    (gdb) target remote localhost:3333
    (gdb) load
    (gdb) b main
@@ -279,11 +293,11 @@ Flashing
 ========
 
 If you just want to download the application to the EM Starter Kit's CCM
-or DDR and run, you can also use this command to achieve this.
+or DDR and run, you can do so in the usual way.
 
-.. code-block:: console
-
-   $ make BOARD=em_starterkit flash
+.. zephyr-app-commands::
+   :board: em_starterkit
+   :goals: flash
 
 This command still uses openocd and gdb to load application elf file
 to EM Starter Kit, but it will load application and then run immediately.

--- a/boards/arm/96b_carbon/doc/96b_carbon.rst
+++ b/boards/arm/96b_carbon/doc/96b_carbon.rst
@@ -239,21 +239,6 @@ debian/ubuntu can be quite old, so you might have to build dfu-util from source.
 Flashing an Application to 96Boards Carbon
 ------------------------------------------
 
-The sample application :ref:`hello_world` is being used in this tutorial:
-
-.. code-block:: console
-
-   $<zephyr_root_path>/samples/hello_world
-
-To build the Zephyr kernel and application, enter:
-
-.. code-block:: console
-
-   $ cd <zephyr_root_path>
-   $ source zephyr-env.sh
-   $ cd $ZEPHYR_BASE/samples/hello_world/
-   $ make BOARD=96b_carbon
-
 Connect the micro-USB cable to the USB OTG Carbon port and to your computer.
 The board should power ON. Force the board into DFU mode by keeping the BOOT0
 switch pressed while pressing and releasing the RST switch.
@@ -286,11 +271,13 @@ You should see following confirmation on your Linux host:
    usb 1-2.1: Manufacturer: STMicroelectronics
    usb 1-2.1: SerialNumber: 3574364C3034
 
-Flash a new application to the board:
+Then build and flash an application. Here is an example for the
+:ref:`hello_world` application.
 
-.. code-block:: console
-
-   $ sudo dfu-util -d [0483:df11] -a 0 -D outdir/96b_carbon/zephyr.bin -s 0x08000000
+.. zephyr-app-commands::
+   :zephyr-app: samples/hello_world
+   :board: 96b_carbon
+   :goals: build flash
 
 Connect the micro-USB cable to the USB UART (FTDI) port and to your computer.
 Run your favorite terminal program to listen for output.
@@ -324,18 +311,14 @@ in general, see :ref:`build_an_application`.
 
 2. Install the dfu-util flashing app, as described above.
 
-3. Build the ``samples/bluetooth/ipsp`` application for 96b_carbon::
+3. Build and flash the ``samples/bluetooth/ipsp`` application for
+   96b_carbon. See the instructions above for how to put your board
+   into DFU mode if you haven't done this before:
 
-     $ cd <zephyr_root_path>
-     $ source zephyr-env.sh
-     $ cd $ZEPHYR_BASE/samples/bluetooth/ipsp/
-     $ make BOARD=96b_carbon
-
-4. Flash the compiled application using dfu-util. See the instructions
-   above for how to put your board into DFU mode if you haven't done
-   this before::
-
-     $ make BOARD=96b_carbon flash
+   .. zephyr-app-commands::
+      :zephyr-app: samples/bluetooth/ipsp
+      :board: 96b_carbon
+      :goals: build flash
 
 5. Refer to the instructions in :ref:`bluetooth-ipsp-sample` for how
    to verify functionality.

--- a/boards/arm/96b_neonkey/doc/96b_neonkey.rst
+++ b/boards/arm/96b_neonkey/doc/96b_neonkey.rst
@@ -129,14 +129,12 @@ Programming and Debugging
 Building
 ========
 
-Build the Zephyr kernel and application with:
+Here is an example for building the :ref:`hello_world` application.
 
-.. code-block:: console
-
-   $ cd <zephyr_root_path>
-   $ source zephyr-env.sh
-   $ cd $ZEPHYR_BASE/samples/hello_world/
-   $ make BOARD=96b_neonkey
+.. zephyr-app-commands::
+   :zephyr-app: samples/hello_world
+   :board: 96b_neonkey
+   :goals: build flash
 
 Flashing
 ========

--- a/boards/arm/96b_nitrogen/doc/96b_nitrogen.rst
+++ b/boards/arm/96b_nitrogen/doc/96b_nitrogen.rst
@@ -267,37 +267,13 @@ and install a more recent version of pyOCD.
 Flashing an Application to 96Boards Nitrogen
 ============================================
 
-This example uses the :ref:`hello_world` sample with the
-:ref:`nxp_opensda_pyocd` tools. Use the ``make flash`` build target to build
-your Zephyr application, invoke the pyOCD flash tool and program your Zephyr
-application to flash.
+Here is an example for the :ref:`hello_world` application. This
+requires installing the :ref:`nxp_opensda_pyocd` tools.
 
-.. code-block:: console
-
-   $ cd <zephyr_root_path>
-   $ . zephyr-env.sh
-   $ cd samples/hello_world/
-   $ make BOARD=96b_nitrogen
-
-You can either flash the board by using the ``make flash`` target:
-
-.. code-block:: console
-
-   $ make flash
-
-or you can invoke the pyocd commands directly, as described below.
-
-Erase the flash memory in the nRF52832:
-
-.. code-block:: console
-
-   $ pyocd-flashtool -d debug -t nrf52 -ce
-
-Flash the application using the pyocd-flashtool tool:
-
-.. code-block:: console
-
-   $ pyocd-flashtool -d debug -t nrf52 outdir/96b_nitrogen/zephyr.hex
+.. zephyr-app-commands::
+   :zephyr-app: samples/hello_world
+   :board: 96b_nitrogen
+   :goals: build flash
 
 Run your favorite terminal program to listen for output.
 
@@ -319,23 +295,14 @@ terminal:
 Debugging with GDB
 ==================
 
-To debug Zephyr with GDB launch the GDB server on a terminal:
+You can debug an application in the usual way.  Here is an example for the
+:ref:`hello_world` application. This also requires pyOCD.
 
-.. code-block:: console
-
-   $ pyocd-gdbserver
-
-and then launch GDB against the .elf file you built:
-
-.. code-block:: console
-
-   $ arm-none-eabi-gdb outdir/96b_nitrogen/zephyr.elf
-
-And finally connect GDB to the GDB Server:
-
-.. code-block:: console
-
-   (gdb) target remote localhost:3333
+.. zephyr-app-commands::
+   :zephyr-app: samples/hello_world
+   :board: 96b_nitrogen
+   :maybe-skip-config:
+   :goals: debug
 
 .. _pyOCD:
     https://github.com/mbedmicro/pyOCD

--- a/boards/arm/arduino_due/doc/board.rst
+++ b/boards/arm/arduino_due/doc/board.rst
@@ -169,44 +169,32 @@ To build the bossa tool, follow these steps:
 Flashing an Application to Arduino Due
 --------------------------------------
 
-The sample application :ref:`hello_world` will be used in this tutorial, which can
-be found in :file:`$ZEPHYR_BASE/samples/hello_world`.
+Applications for the ``arduino_due`` board configuration can be built
+and flashed in the usual way (see :ref:`build_an_application` and
+:ref:`application_run` for more details).
 
-#. To build the Zephyr kernel, enter:
+Here is an example for the :ref:`hello_world` application. After
+building the application, press the Reset button before running the
+flash command, so the board will boot into the SAM-BA bootloader and
+be prepared to receive the new program.
 
-   .. code-block:: console
+.. zephyr-app-commands::
+   :zephyr-app: samples/hello_world
+   :board: arduino_due
+   :goals: build flash
 
-      $ cd $ZEPHYR_BASE
-      $ make -C samples/hello_world BOARD=arduino_due
+After flashing the application, run your favorite terminal program to
+listen for output. For example, under Linux, the terminal should be
+:code:`/dev/ttyACM0`. For example:
 
-#. Connect the Arduino Due to your host computer using the programming port.
+.. code-block:: console
 
-#. Press the Erase button for more than 220 ms.
+   $ minicom -D /dev/ttyACM0 -o
 
-#. Press the Reset button so the board will boot into the SAM-BA bootloader.
+The -o option tells minicom not to send the modem initialization
+string.
 
-#. To flash the kernel onto Arduino Due, assuming the bossa tool already
-   exists. Using the command line version of bossa, enter:
-
-   .. code-block:: console
-
-      $ bossac -p <tty_device> -e -w -v -b outdir/arduino_due/zephyr.bin
-
-   Where :code:`<tty_device>` is where the Arduino Due can be found. For
-   example, under Linux, :code:`<tty_device>` should be :code:`ttyACM0`.
-   Note that the path :file:`/dev/` is omitted.
-
-#. Run your favorite terminal program to listen for output. For example, under
-   Linux, the terminal should be :code:`/dev/ttyACM0`. For example:
-
-   .. code-block:: console
-
-      $ minicom -D /dev/ttyACM0 -o
-
-   The -o option tells minicom not to send the modem initialization
-   string.
-
-#. Press the Reset button and you should see "Hello World!" in your terminal.
+Now press the Reset button and you should see "Hello World!" in your terminal.
 
 .. note::
    Make sure your terminal program is closed before flashing the binary image,

--- a/boards/arm/cc2650_sensortag/doc/cc2650_sensortag.rst
+++ b/boards/arm/cc2650_sensortag/doc/cc2650_sensortag.rst
@@ -140,12 +140,13 @@ the CCFG content, see :file:`arch/arm/soc/ti_simplelink/cc2650/soc.c`.
 Building
 ========
 
-Building does not require anything more than Zephyr already provides.
-To build your current configuration and code:
+You can build an application in the usual way. Here is an example for
+the :ref:`hello_world` application.
 
-.. code-block:: console
-
-  $ make BOARD=cc2650_sensortag
+.. zephyr-app-commands::
+   :zephyr-app: samples/hello_world
+   :board: cc2650_sensortag
+   :goals: build flash
 
 Flashing
 ========
@@ -177,8 +178,8 @@ operation, then light up again upon completion.
 Debugging
 =========
 
-Debugging can be done with OpenOCD 0.10, which is currently not supported
-by the latest Zephyr SDK version. A basic configuration file for the
+Debugging can be done with OpenOCD 0.10, which is supported
+by the Zephyr SDK since v0.9.2. A basic configuration file for the
 SensorTag board would be:
 
 .. code-block:: console

--- a/boards/arm/disco_l475_iot1/doc/disco_l475_iot1.rst
+++ b/boards/arm/disco_l475_iot1/doc/disco_l475_iot1.rst
@@ -173,65 +173,53 @@ Default settings are 115200 8N1.
 Programming and Debugging
 *************************
 
+Applications for the ``disco_l475_iot1`` board configuration can be built and
+flashed in the usual way (see :ref:`build_an_application` and
+:ref:`application_run` for more details).
+
 Flashing
 ========
 
-Disco L475 IoT board includes an ST-LINK/V2-1 embedded debug tool interface.
-This interface is not supported by the openocd version 0.9 included by the Zephyr SDK v0.9.
-Until we update the Zephyr SDK, use openocd v0.10.0 from the openocd-stm32 project on GitHub
-to get the minimum set of scripts needed to flash and debug STM32 development boards.
-
-.. code-block:: console
-
-   $ git clone  https://github.com/erwango/openocd-stm32.git
-
-Then follow instructions in README.md
-
+Disco L475 IoT board includes an ST-LINK/V2-1 embedded debug tool
+interface.  This interface is supported by the openocd version
+included in the Zephyr SDK since v0.9.2.
 
 Flashing an application to Disco L475 IoT
 -----------------------------------------
 
-The sample application :ref:`hello_world` is being used in this tutorial:
+Here is an example for the :ref:`hello_world` application.
 
-To build the Zephyr kernel and application, enter:
-
-.. code-block:: console
-
-   $ cd <zephyr_root_path>
-   $ source zephyr-env.sh
-   $ cd $ZEPHYR_BASE/samples/hello_world/
-   $ make BOARD=disco_l475_iot1
-
-Connect the Disco L475 IoT to your host computer using the USB port.
-Then, enter the following command:
-
-.. code-block:: console
-
-   $ cd <openocd-stm32_path>
-   $ stm32_flsh l4 $ZEPHYR_BASE/samples/hello_world/outdir/disco_l475_iot1/zephyr.bin
-
-Run a serial host program to connect with your Nucleo board.
+Connect the Disco L475 IoT to your host computer using the USB port, then
+run a serial host program to connect with your Nucleo board. For example:
 
 .. code-block:: console
 
    $ minicom -D /dev/ttyACM0
 
-You should see the following message:
+Then build and flash the application:
+
+.. zephyr-app-commands::
+   :zephyr-app: samples/hello_world
+   :board: disco_l475_iot1
+   :goals: build flash
+
+You should see the following message on the console:
 
 .. code-block:: console
 
    $ Hello World! arm
 
-
 Debugging
 =========
 
-Access gdb with the following make command:
+You can debug an application in the usual way.  Here is an example for the
+:ref:`hello_world` application.
 
-.. code-block:: console
-
-   $ cd <openocd-stm32_path>
-   $ stm32_dbg l4 $ZEPHYR_BASE/samples/hello_world/outdir/disco_l475_iot1/zephyr.elf
+.. zephyr-app-commands::
+   :zephyr-app: samples/hello_world
+   :board: disco_l475_iot1
+   :maybe-skip-config:
+   :goals: debug
 
 .. _Disco L475 IoT1 website:
    http://www.st.com/content/st_com/en/products/evaluation-tools/product-evaluation-tools/mcu-eval-tools/stm32-mcu-eval-tools/stm32-mcu-discovery-kits/b-l475e-iot01a.html

--- a/boards/arm/efm32wg_stk3800/doc/efm32wg_stk3800.rst
+++ b/boards/arm/efm32wg_stk3800/doc/efm32wg_stk3800.rst
@@ -102,9 +102,8 @@ UART0 is connected to the board controller and is used for the console.
 Programming and Debugging
 *************************
 
-.. note::
-
-   Before using the kit the first time, you should update the J-Link firmware
+.. note:
+   Before useing the kit the first time, you should update the J-Link firmware
    from `J-Link-Downloads`_
 
 Flashing
@@ -124,12 +123,10 @@ Flashing an application to EFM32-STK3800
 The sample application :ref:`hello_world` is used for this example.
 Build the Zephyr kernel and application:
 
-.. code-block:: console
-
-   $ cd <zephyr_root_path>
-   $ . zephyr-env.sh
-   $ cd samples/hello_world/
-   $ make BOARD=efm32wg_stk3800
+.. zephyr-app-commands::
+   :zephyr-app: samples/hello_world
+   :board: efm32wg_stk3800
+   :goals: build
 
 Connect the EFM32WG-STK3800 to your host computer using the USB port and you
 should see a USB connection which exposes a Mass Storage (STK3800) and a

--- a/boards/arm/efm32wg_stk3800/doc/efm32wg_stk3800.rst
+++ b/boards/arm/efm32wg_stk3800/doc/efm32wg_stk3800.rst
@@ -102,8 +102,9 @@ UART0 is connected to the board controller and is used for the console.
 Programming and Debugging
 *************************
 
-.. note:
-   Before useing the kit the first time, you should update the J-Link firmware
+.. note::
+
+   Before using the kit the first time, you should update the J-Link firmware
    from `J-Link-Downloads`_
 
 Flashing

--- a/boards/arm/frdm_k64f/doc/frdm_k64f.rst
+++ b/boards/arm/frdm_k64f/doc/frdm_k64f.rst
@@ -198,29 +198,30 @@ communication over USB.
 To use the pyOCD tools with OpenSDA, follow the instructions in the
 :ref:`nxp_opensda_pyocd` page using the `DAPLink FRDM-K64F Firmware`_. The
 pyOCD tools are the default for this board, therefore it is not necessary to
-set ``OPENSDA_FW=daplink`` explicitly when you invoke ``make flash`` or ``make
-debug``.
+set ``OPENSDA_FW=daplink`` explicitly when using the default flash and debug
+mechanisms.
+
+With these mechanisms, applications for the ``frdm_k64f`` board
+configuration can be built and flashed in the usual way (see
+:ref:`build_an_application` and :ref:`application_run` for more
+details).
 
 To use the Segger J-Link tools with OpenSDA, follow the instructions in the
 :ref:`nxp_opensda_jlink` page using the `Segger J-Link OpenSDA V2.1 Firmware`_.
 The Segger J-Link tools are not the default for this board, therefore it is
-necessary to set ``OPENSDA_FW=jlink`` explicitly when you invoke ``make
-debug``.
+necessary to set ``OPENSDA_FW=jlink`` explicitly in the environment before
+programming and debugging.
 
 Flashing
 ========
 
 This example uses the :ref:`hello_world` sample with the
-:ref:`nxp_opensda_pyocd` tools. Use the ``make flash`` build target to build
-your Zephyr application, invoke the pyOCD flash tool and program your Zephyr
-application to flash.
+:ref:`nxp_opensda_pyocd` tools.
 
-.. code-block:: console
-
-   $ cd <zephyr_root_path>
-   $ . zephyr-env.sh
-   $ cd samples/hello_world/
-   $ make BOARD=frdm_k64f flash
+.. zephyr-app-commands::
+   :zephyr-app: samples/hello_world
+   :board: frdm_k64f
+   :goals: flash
 
 Open a serial terminal (minicom, putty, etc.) with the following settings:
 
@@ -239,18 +240,14 @@ the following message:
 Debugging
 =========
 
-This example uses the :ref:`hello_world` sample with the
-:ref:`nxp_opensda_pyocd` tools. Use the ``make debug`` build target to build
-your Zephyr application, invoke the pyOCD GDB server, attach a GDB client, and
-program your Zephyr application to flash. It will leave you at a gdb prompt.
+You can debug an application in the usual way.  Here is an example for the
+:ref:`hello_world` application.
 
-.. code-block:: console
-
-   $ cd <zephyr_root_path>
-   $ . zephyr-env.sh
-   $ cd samples/hello_world/
-   $ make BOARD=frdm_k64f debug
-
+.. zephyr-app-commands::
+   :zephyr-app: samples/hello_world
+   :board: frdm_k64f
+   :maybe-skip-config:
+   :goals: debug
 
 .. _FRDM-K64F Website:
    http://www.nxp.com/products/software-and-tools/hardware-development-tools/freedom-development-boards/freedom-development-platform-for-kinetis-k64-k63-and-k24-mcus:FRDM-K64F

--- a/boards/arm/frdm_kl25z/doc/frdm_kl25z.rst
+++ b/boards/arm/frdm_kl25z/doc/frdm_kl25z.rst
@@ -126,29 +126,29 @@ communication over USB.
 To use the pyOCD tools with OpenSDA, follow the instructions in the
 :ref:`nxp_opensda_pyocd` page using the `DAPLink FRDM-KL25Z Firmware`_. The
 pyOCD tools are the default for this board, therefore it is not necessary to
-set ``OPENSDA_FW=daplink`` explicitly when you invoke ``make flash`` or ``make
-debug``.
+set ``OPENSDA_FW=daplink`` explicitly when programming and debugging.
 
-To use the Segger J-Link tools with OpenSDA, follow the instructions in the
-:ref:`nxp_opensda_jlink` page using the `Segger J-Link OpenSDA V2.1 Firmware`_.
-The Segger J-Link tools are not the default for this board, therefore it is
-necessary to set ``OPENSDA_FW=jlink`` explicitly when you invoke ``make
-debug``.
+With these mechanisms, applications for the ``frdm_kl25z`` board
+configuration can be built and flashed in the usual way (see
+:ref:`build_an_application` and :ref:`application_run` for more
+details).
+
+To use the Segger J-Link tools with OpenSDA, follow the instructions
+in the :ref:`nxp_opensda_jlink` page using the `Segger J-Link OpenSDA
+V2.1 Firmware`_.  The Segger J-Link tools are not the default for this
+board, therefore it is necessary to set ``OPENSDA_FW=jlink``
+explicitly in the environment before programming and debugging.
 
 Flashing
 ========
 
 This example uses the :ref:`hello_world` sample with the
-:ref:`nxp_opensda_pyocd` tools. Use the ``make flash`` build target to build
-your Zephyr application, invoke the pyOCD flash tool and program your Zephyr
-application to flash.
+:ref:`nxp_opensda_pyocd` tools.
 
-.. code-block:: console
-
-   $ cd <zephyr_root_path>
-   $ . zephyr-env.sh
-   $ cd samples/hello_world/
-   $ make BOARD=frdm_kl25z flash
+.. zephyr-app-commands::
+   :zephyr-app: samples/hello_world
+   :board: frdm_kl25z
+   :goals: flash
 
 Open a serial terminal (minicom, putty, etc.) with the following settings:
 
@@ -167,18 +167,14 @@ the following message:
 Debugging
 =========
 
-This example uses the :ref:`hello_world` sample with the
-:ref:`nxp_opensda_pyocd` tools. Use the ``make debug`` build target to build
-your Zephyr application, invoke the pyOCD GDB server, attach a GDB client, and
-program your Zephyr application to flash. It will leave you at a gdb prompt.
+You can debug an application in the usual way.  Here is an example for the
+:ref:`hello_world` application.
 
-.. code-block:: console
-
-   $ cd <zephyr_root_path>
-   $ . zephyr-env.sh
-   $ cd samples/hello_world/
-   $ make BOARD=frdm_kl25z debug
-
+.. zephyr-app-commands::
+   :zephyr-app: samples/hello_world
+   :board: frdm_kl25z
+   :maybe-skip-config:
+   :goals: debug
 
 .. _FRDM-KL25Z Website:
    http://www.nxp.com/products/software-and-tools/hardware-development-tools/freedom-development-boards/freedom-development-platform-for-kinetis-kl14-kl15-kl24-kl25-mcus:FRDM-KL25Z?tid=vanFRDM-KL25Z

--- a/boards/arm/frdm_kw41z/doc/frdm_kw41z.rst
+++ b/boards/arm/frdm_kw41z/doc/frdm_kw41z.rst
@@ -136,41 +136,43 @@ communication over USB.
 To use the pyOCD tools with OpenSDA, follow the instructions in the
 :ref:`nxp_opensda_pyocd` page using the `DAPLink FRDM-KW41Z Firmware`_. The
 pyOCD tools are not the default for this board, therefore it is necessary to
-set ``OPENSDA_FW=daplink`` explicitly when you invoke ``make flash`` or ``make
-debug``.
+set ``OPENSDA_FW=daplink`` explicitly when using the default flash and debug
+mechanisms.
 
 .. note::
-   pyOCD added support for KW41Z recently and has not yet tagged a release,
-   therefore you must build pyOCD from source based on the current master
-   branch (f21d43d).
+   pyOCD added support for KW41Z after support for this board was added to
+   Zephyr, so you may need to build pyOCD from source based on the current
+   master branch (f21d43d).
 
 To use the Segger J-Link tools with OpenSDA, follow the instructions in the
 :ref:`nxp_opensda_jlink` page using the `Segger J-Link OpenSDA V2.1 Firmware`_.
 The Segger J-Link tools are the default for this board, therefore it is not
-necessary to set ``OPENSDA_FW=jlink`` explicitly when you invoke ``make
-debug``.
+necessary to set ``OPENSDA_FW=jlink`` explicitly in the environment before
+programming and debugging.
+
+With these mechanisms, applications for the ``frdm_kw41z`` board
+configuration can be built and debugged in the usual way (see
+:ref:`build_an_application` and :ref:`application_run` for more
+details).
 
 Flashing
 ========
 
 The Segger J-Link firmware does not support command line flashing, therefore
-the ``make flash`` build target is not supported.
+the usual ``flash`` build system target is not supported.
 
 Debugging
 =========
 
 This example uses the :ref:`hello_world` sample with the
-:ref:`nxp_opensda_jlink` tools. Use the ``make debug`` build target to build
+:ref:`nxp_opensda_jlink` tools. Run the following to build
 your Zephyr application, invoke the J-Link GDB server, attach a GDB client, and
 program your Zephyr application to flash. It will leave you at a gdb prompt.
 
-.. code-block:: console
-
-   $ cd <zephyr_root_path>
-   $ . zephyr-env.sh
-   $ cd samples/hello_world/
-   $ make BOARD=frdm_kw41z DEBUG_SCRIPT=jlink.sh debug
-
+.. zephyr-app-commands::
+   :zephyr-app: samples/hello_world
+   :board: frdm_kw41z
+   :goals: debug
 
 .. _FRDM-KW41Z Website:
    http://www.nxp.com/products/microcontrollers-and-processors/more-processors/application-specific-mcus-mpus/bluetooth-low-energy-ble/nxp-freedom-development-kit-for-kinetis-kw41z-31z-21z-mcus:FRDM-KW41Z

--- a/boards/arm/hexiwear_k64/doc/hexiwear_k64.rst
+++ b/boards/arm/hexiwear_k64/doc/hexiwear_k64.rst
@@ -157,14 +157,19 @@ serial communication over USB.
 To use the pyOCD tools with OpenSDA, follow the instructions in the
 :ref:`nxp_opensda_pyocd` page using the `DAPLink Hexiwear Firmware`_. The pyOCD
 tools are the default for this board, therefore it is not necessary to set
-``OPENSDA_FW=daplink`` explicitly when you invoke ``make flash`` or ``make
-debug``.
+``OPENSDA_FW=daplink`` explicitly when using the default flash and debug
+mechanisms.
+
+With these mechanisms, applications for the ``hexiwear_k64`` board
+configuration can be built and flashed in the usual way (see
+:ref:`build_an_application` and :ref:`application_run` for more
+details).
 
 To use the Segger J-Link tools with OpenSDA, follow the instructions in the
 :ref:`nxp_opensda_jlink` page using the `Segger J-Link OpenSDA V2.1 Firmware`_.
 The Segger J-Link tools are not the default for this board, therefore it is
-necessary to set ``OPENSDA_FW=jlink`` explicitly when you invoke ``make
-debug``.
+necessary to set ``OPENSDA_FW=jlink`` explicitly in the environment before
+programming and debugging.
 
 .. note::
    The OpenSDA adapter is shared between the K64 and the KW40Z via switches,
@@ -198,16 +203,12 @@ Flashing
 ========
 
 This example uses the :ref:`hello_world` sample with the
-:ref:`nxp_opensda_pyocd` tools. Use the ``make flash`` build target to build
-your Zephyr application, invoke the pyOCD flash tool and program your Zephyr
-application to flash.
+:ref:`nxp_opensda_pyocd` tools.
 
-.. code-block:: console
-
-   $ cd <zephyr_root_path>
-   $ . zephyr-env.sh
-   $ cd samples/hello_world/
-   $ make BOARD=hexiwear_k64 flash
+.. zephyr-app-commands::
+   :zephyr-app: samples/hello_world
+   :board: hexiwear_k64
+   :goals: flash
 
 Open a serial terminal (minicom, putty, etc.) with the following settings:
 
@@ -226,17 +227,14 @@ the following message:
 Debugging
 =========
 
-This example uses the :ref:`hello_world` sample with the
-:ref:`nxp_opensda_pyocd` tools. Use the ``make debug`` build target to build
-your Zephyr application, invoke the pyOCD GDB server, attach a GDB client, and
-program your Zephyr application to flash. It will leave you at a gdb prompt.
+You can debug an application in the usual way.  Here is an example for the
+:ref:`hello_world` application.
 
-.. code-block:: console
-
-   $ cd <zephyr_root_path>
-   $ . zephyr-env.sh
-   $ cd samples/hello_world/
-   $ make BOARD=hexiwear_k64 debug
+.. zephyr-app-commands::
+   :zephyr-app: samples/hello_world
+   :board: hexiwear_k64
+   :maybe-skip-config:
+   :goals: debug
 
 Using Bluetooth
 ***************
@@ -257,15 +255,16 @@ host application to the K64.
 
 Peripheral Heart Rate Sensor
 ============================
-Navigate to the Zephyr sample application and build it for the Hexiwear K64.
 
-.. code-block:: console
+Navigate to the Zephyr ``samples/bluetooth/peripheral_hr`` sample
+application, then build and flash it to the Hexiwear K64. Make sure
+the OpenSDA switches on the docking station are configured for the
+K64.
 
-   $ cd samples/bluetooth/peripheral_hr
-   $ make BOARD=hexiwear_k64
-
-Flash the application to the Hexiwear K64. Make sure the OpenSDA switches on
-the docking station are configured for the K64.
+.. zephyr-app-commands::
+   :zephyr-app: samples/bluetooth/peripheral_hr
+   :board: hexiwear_k64
+   :goals: build flash
 
 Reset the KW40Z and the K64 using the push buttons on the docking station.
 

--- a/boards/arm/hexiwear_kw40z/doc/hexiwear_kw40z.rst
+++ b/boards/arm/hexiwear_kw40z/doc/hexiwear_kw40z.rst
@@ -86,14 +86,19 @@ serial communication over USB.
 To use the pyOCD tools with OpenSDA, follow the instructions in the
 :ref:`nxp_opensda_pyocd` page using the `DAPLink Hexiwear Firmware`_. The pyOCD
 tools are not the default for this board, therefore it is necessary to set
-``OPENSDA_FW=daplink`` explicitly when you invoke ``make flash`` or ``make
-debug``.
+``OPENSDA_FW=daplink`` explicitly in the environment when programming and
+debugging.
 
 To use the Segger J-Link tools with OpenSDA, follow the instructions in the
 :ref:`nxp_opensda_jlink` page using the `Segger J-Link OpenSDA V2.1 Firmware`_.
 The Segger J-Link tools are the default for this board, therefore it is not
-necessary to set ``OPENSDA_FW=jlink`` explicitly when you invoke ``make
-debug``.
+necessary to set ``OPENSDA_FW=jlink`` explicitly when using the usual
+programming and debugging mechanisms.
+
+With these mechanisms, applications for the ``hexiwear_kw40z`` board
+configuration can be built and flashed in the usual way (see
+:ref:`build_an_application` and :ref:`application_run` for more
+details).
 
 Because `Segger RTT`_ is required for a console to KW40Z, the J-Link tools are
 recommended.
@@ -102,23 +107,20 @@ Flashing
 ========
 
 The Segger J-Link firmware does not support command line flashing, therefore
-the ``make flash`` build target is not supported.
+the usual ``flash`` build target is not supported.
 
 Debugging
 =========
 
 This example uses the :ref:`hello_world` sample with the
-:ref:`nxp_opensda_jlink` tools. Use the ``make debug`` build target to build
-your Zephyr application, invoke the J-Link GDB server, attach a GDB client, and
-program your Zephyr application to flash. It will leave you at a gdb prompt.
+:ref:`nxp_opensda_jlink` tools. This builds the Zephyr application,
+invokes the J-Link GDB server, attaches a GDB client, and programs the
+application to flash. It will leave you at a gdb prompt.
 
-.. code-block:: console
-
-   $ cd <zephyr_root_path>
-   $ . zephyr-env.sh
-   $ cd samples/hello_world/
-   $ make BOARD=hexiwear_kw40z debug
-
+.. zephyr-app-commands::
+   :zephyr-app: samples/hello_world
+   :board: hexiwear_kw40z
+   :goals: debug
 
 In a second terminal, open telnet:
 

--- a/boards/arm/mps2_an385/doc/mps2_an385.rst
+++ b/boards/arm/mps2_an385/doc/mps2_an385.rst
@@ -247,20 +247,12 @@ V2M MPS2 provides:
 Flashing an application to V2M MPS2
 -----------------------------------
 
-The sample application :ref:`hello_world` is being used in this tutorial:
+Here is an example for the :ref:`hello_world` application.
 
-.. code-block:: console
-
-   $ZEPHYR_BASE/samples/hello_world
-
-To build the Zephyr kernel and application, enter:
-
-.. code-block:: console
-
-   $ cd $ZEPHYR_BASE
-   $ . zephyr-env.sh
-   $ cd $ZEPHYR_BASE/samples/hello_world/
-   $ make BOARD=mps2_an385
+.. zephyr-app-commands::
+   :zephyr-app: samples/hello_world
+   :board: mps2_an385
+   :goals: build
 
 Connect the V2M MPS2 to your host computer using the USB port and you should
 see a USB connection which exposes a Mass Storage and a USB Serial Port.

--- a/boards/arm/msp_exp432p401r_launchxl/doc/msp_exp432p401r_launchxl.rst
+++ b/boards/arm/msp_exp432p401r_launchxl/doc/msp_exp432p401r_launchxl.rst
@@ -63,14 +63,16 @@ Building
 Follow the :ref:`getting_started` instructions for Zephyr application
 development.
 
-To build for the MSP-EXP432P401R LaunchXL:
+For example, to build the :ref:`hello_world` application for the
+MSP-EXP432P401R LaunchXL:
 
-.. code-block:: console
+.. zephyr-app-commands::
+   :zephyr-app: samples/hello_world
+   :board: msp_exp432p401r_launchxl
+   :goals: build
 
-	$ make -C samples/hello_world BOARD=msp_exp432p401r_launchxl
-
-The resulting ``zephyr.elf`` binary can be flashed onto MSP-EXP432P401R LaunchXL
-using the command line utility mentioned below.
+The resulting ``zephyr.elf`` binary in the build directory can be flashed onto
+MSP-EXP432P401R LaunchXL using the command line utility mentioned below.
 
 Flashing
 ========

--- a/boards/arm/nrf51_pca10028/doc/nrf51_pca10028.rst
+++ b/boards/arm/nrf51_pca10028/doc/nrf51_pca10028.rst
@@ -91,49 +91,29 @@ Programming and Debugging
 Flashing
 ========
 
-Follow the instructions in the :ref:`nordic_segger` page to install and configure
-all the necessary software.
+Follow the instructions in the :ref:`nordic_segger` page to install
+and configure all the necessary software. Further information can be
+found in :ref:`nordic_segger_flashing`. Then build and flash
+applications as usual (see :ref:`build_an_application` and
+:ref:`application_run` for more details).
 
-This tutorial uses the sample application
-shell :file:`$ZEPHYR_BASE/samples/subsys/shell/shell`, and uses the information that can be found in
-:ref:`nordic_segger_flashing`.
+Here is an example for the :ref:`hello_world` application.
 
-#. To build the Zephyr kernel, enter:
+First, run your favorite terminal program to listen for output.
 
-   .. code-block:: console
+.. code-block:: console
 
-      $ cd $ZEPHYR_BASE
-      $ make -C samples/subsys/shell/shell BOARD=nrf51_pca10028
+   $ minicom -D <tty_device> -b 115200
 
-#. Connect the micro-USB cable to the nRF51 DK and to your computer.
+Replace :code:`<tty_device>` with the port where the board nRF51 DK
+can be found. For example, under Linux, :code:`/dev/ttyACM0`.
 
-#. Erase the flash memory in the nRF51822:
+Then build and flash the application in the usual way.
 
-   .. code-block:: console
-
-      $ nrfjprog --eraseall -f nrf51
-
-#. Flash the application using the nrfjprog tool:
-
-   .. code-block:: console
-
-      $ nrfjprog --program outdir/zephyr.hex -f nrf51
-
-#. Run your favorite terminal program to listen for output.
-
-   .. code-block:: console
-
-      $ minicom -D <tty_device> -b 115200
-
-   Replace :code:`<tty_device>` with the port where the board
-   nRF51 DK can be found. For example, under Linux,
-   :code:`/dev/ttyACM0`.
-
-   The ``-b`` option sets baudrate ignoring the value
-   from config.
-
-#. Press the Reset button and you should see the output of
-   shell application in your terminal.
+.. zephyr-app-commands::
+   :zephyr-app: samples/hello_world
+   :board: nrf51_pca10028
+   :goals: build flash
 
 Debugging
 =========

--- a/boards/arm/nrf51_vbluno51/doc/nrf51_vbluno51.rst
+++ b/boards/arm/nrf51_vbluno51/doc/nrf51_vbluno51.rst
@@ -95,6 +95,10 @@ More details
 Programming and Debugging
 *************************
 
+Applications for the ``nrf51_vbluno51`` board configuration can be
+built and flashed in the usual way (see :ref:`build_an_application`
+and :ref:`application_run` for more details).
+
 Flashing
 ========
 
@@ -102,23 +106,28 @@ The VBLUno51 board has on-board DAPLink (CMSIS-DAP) interface for flashing and d
 You do not need any other programming device.
 You only need to install pyOCD tool (https://pypi.python.org/pypi/pyOCD)
 
-This tutorial uses the blinky application :ref:`blinky-sample`
+This tutorial uses the blinky application :ref:`blinky-sample`.
 
 See the :ref:`getting_started` for general information on setting up
- your development environment.
+your development environment. Then build and flash the application in
+the usual way.
 
-#. To build the Zephyr kernel along with the blinky sample app, enter:
+.. zephyr-app-commands::
+   :zephyr-app: samples/basic/blinky
+   :board: nrf51_vbluno51
+   :goals: build flash
 
-   .. code-block:: console
+Debugging
+=========
 
-      $ cd $ZEPHYR_BASE/samples/basic/blinky
-      $ make BOARD=nrf51_vbluno51
+You can debug an application in the usual way.  Here is an example for the
+:ref:`blinky-sample` application.
 
-#. To build and flash the generated binary image to the board, enter:
-
-   .. code-block:: console
-
-      $ make BOARD=nrf51_vbluno51 flash
+.. zephyr-app-commands::
+   :zephyr-app: samples/basic/blinky
+   :board: nrf51_vbluno51
+   :maybe-skip-config:
+   :goals: debug
 
 Testing the VBLUno51 with Zephyr: buttons, LEDs, UART, BLE
 **********************************************************

--- a/boards/arm/nrf52840_pca10056/doc/nrf52840_pca10056.rst
+++ b/boards/arm/nrf52840_pca10056/doc/nrf52840_pca10056.rst
@@ -89,52 +89,37 @@ Push buttons
 Programming and Debugging
 *************************
 
+Applications for the ``nrf52840_pca10056`` board configuration can be
+built and flashed in the usual way (see :ref:`build_an_application`
+and :ref:`application_run` for more details); however, the standard
+debugging targets are not currently available.
+
 Flashing
 ========
 
-Follow the instructions in the :ref:`nordic_segger` page to install and configure
-all the necessary software.
+Follow the instructions in the :ref:`nordic_segger` page to install
+and configure all the necessary software. Further information can be
+found in :ref:`nordic_segger_flashing`. Then build and flash
+applications as usual (see :ref:`build_an_application` and
+:ref:`application_run` for more details).
 
-This tutorial uses the sample application
-shell :file:`$ZEPHYR_BASE/samples/subsys/shell/shell`, and uses the information that can be found in
-:ref:`nordic_segger_flashing`.
+Here is an example for the :ref:`hello_world` application.
 
-#. To build the Zephyr kernel, enter:
+First, run your favorite terminal program to listen for output.
 
-   .. code-block:: console
+.. code-block:: console
 
-      $ cd $ZEPHYR_BASE
-      $ make -C samples/subsys/shell/shell BOARD=nrf52840_pca10056
+   $ minicom -D <tty_device> -b 115200
 
-#. Connect the micro-USB cable to the nRF52840 PDK and to your computer.
+Replace :code:`<tty_device>` with the port where the board nRF52 DK
+can be found. For example, under Linux, :code:`/dev/ttyACM0`.
 
-#. Erase the flash memory in the nRF52840:
+Then build and flash the application in the usual way.
 
-   .. code-block:: console
-
-      $ nrfjprog --eraseall -f nrf52
-
-#. Flash the application using the nrfjprog tool:
-
-   .. code-block:: console
-
-      $ nrfjprog --program outdir/zephyr.hex -f nrf52
-
-#. Run your favorite terminal program to listen for output.
-
-   .. code-block:: console
-
-      $ minicom -D <tty_device> -b 115200
-
-   Replace :code:`<tty_device>` with the port where the board
-   nRF52840 PDK can be found. For example, under Linux,
-   :code:`/dev/ttyACM0`.
-
-   The ``-b`` option sets baudrate ignoring the value
-   from config.
-
-#. Press the Reset button and you should see the output of
-   shell application in your terminal.
+.. zephyr-app-commands::
+   :zephyr-app: samples/hello_world
+   :board: nrf52840_pca10056
+   :goals: build flash
 
 Debugging
 =========

--- a/boards/arm/nrf52_blenano2/doc/nrf52_blenano2.rst
+++ b/boards/arm/nrf52_blenano2/doc/nrf52_blenano2.rst
@@ -64,22 +64,42 @@ It also regulates 5V from USB to 3.3V via the onboard LDO to power Nano v2.
 Programming and Debugging
 *************************
 
+Applications for the ``nrf52_blenano2`` board configuration can be built and
+flashed in the usual way (see :ref:`build_an_application` and
+:ref:`application_run` for more details).
+
 Flashing
 ========
 
-Build the Zephyr kernel and BLE sample application:
+To flash an application, you'll need to connect your BLE Nano 2 with the
+DAPLink board, then attach that to your computer via USB.
 
-.. code-block:: console
+.. warning::
 
-   $ cd $ZEPHYR_BASE
-   $ . zephyr-env.sh
-   $ make -C samples/bluetooth/beacon BOARD=nrf52_blenano2
+   Be careful to mount the BLE Nano 2 correctly! The side of the board
+   with the VIN and GND pins should face **towards** the USB
+   connector.
 
-- Mount your BLE Nano v2 onto the DAPLink USB dongle correctly.
-- Connect DAPLink USB dongle to your host computer.
-- The PC will prompt a new mass storage disk.
-- Copy the generated file zephyr.bin on folder samples/bluetooth/beacon/outdir/nrf52_blenano2 to the DAPLink drive.
-- Open nRF Connect application to check advertising packets.
+Now build and flash applications as usual. Here is an example for the
+:ref:`hello_world` application.
+
+.. zephyr-app-commands::
+   :zephyr-app: samples/hello_world
+   :board: nrf52_blenano2
+   :goals: build flash
+
+Debugging
+=========
+
+After mounting the BLE Nano 2 on its DAPLink board as described above,
+you can debug an application in the usual way.  Here is an example for
+the :ref:`hello_world` application.
+
+.. zephyr-app-commands::
+   :zephyr-app: samples/hello_world
+   :board: nrf52_blenano2
+   :maybe-skip-config:
+   :goals: debug
 
 References
 **********

--- a/boards/arm/nrf52_pca10040/doc/nrf52_pca10040.rst
+++ b/boards/arm/nrf52_pca10040/doc/nrf52_pca10040.rst
@@ -332,49 +332,29 @@ Programming and Debugging
 Flashing
 ========
 
-Follow the instructions in the :ref:`nordic_segger` page to install and configure
-all the necessary software.
+Follow the instructions in the :ref:`nordic_segger` page to install
+and configure all the necessary software. Further information can be
+found in :ref:`nordic_segger_flashing`. Then build and flash
+applications as usual (see :ref:`build_an_application` and
+:ref:`application_run` for more details).
 
-This tutorial uses the sample application
-shell :file:`$ZEPHYR_BASE/samples/subsys/shell/shell`, and uses the information that can be found in
-:ref:`nordic_segger_flashing`.
+Here is an example for the :ref:`hello_world` application.
 
-#. To build the Zephyr kernel, enter:
+First, run your favorite terminal program to listen for output.
 
-   .. code-block:: console
+.. code-block:: console
 
-      $ cd $ZEPHYR_BASE
-      $ make -C samples/subsys/shell/shell BOARD=nrf52_pca10040
+   $ minicom -D <tty_device> -b 115200
 
-#. Connect the micro-USB cable to the nRF52 DK and to your computer.
+Replace :code:`<tty_device>` with the port where the board nRF52 DK
+can be found. For example, under Linux, :code:`/dev/ttyACM0`.
 
-#. Erase the flash memory in the nRF52832:
+Then build and flash the application in the usual way.
 
-   .. code-block:: console
-
-      $ nrfjprog --eraseall -f nrf52
-
-#. Flash the application using the nrfjprog tool:
-
-   .. code-block:: console
-
-      $ nrfjprog --program outdir/zephyr.hex -f nrf52
-
-#. Run your favorite terminal program to listen for output.
-
-   .. code-block:: console
-
-      $ minicom -D <tty_device> -b 115200
-
-   Replace :code:`<tty_device>` with the port where the board
-   nRF52 DK can be found. For example, under Linux,
-   :code:`/dev/ttyACM0`.
-
-   The ``-b`` option sets baudrate ignoring the value
-   from config.
-
-#. Press the Reset button and you should see the output of
-   shell application in your terminal.
+.. zephyr-app-commands::
+   :zephyr-app: samples/hello_world
+   :board: nrf52840_pca10056
+   :goals: build flash
 
 Debugging
 =========

--- a/boards/arm/nrf52_vbluno52/doc/nrf52_vbluno52.rst
+++ b/boards/arm/nrf52_vbluno52/doc/nrf52_vbluno52.rst
@@ -83,23 +83,16 @@ The VBLUno52 board has an on-board DAPLink (CMSIS-DAP) interface for flashing an
 You do not need any other programming device.
 You only need to install the pyOCD tool (https://pypi.python.org/pypi/pyOCD)
 
-This tutorial uses the blinky application :ref:`blinky-sample`
-
 See the :ref:`getting_started` for general information on setting up
 your development environment.
 
-#. To build the Zephyr kernel along with the blinky sample app, enter:
+You can build and flash applications in the usual way. Here is an
+example for the :ref:`hello_world` application.
 
-   .. code-block:: console
-
-      $ cd $ZEPHYR_BASE/samples/basic/blinky
-      $ make BOARD=nrf52_vbluno52
-
-#. To build and flash the generated binary image to the board, enter:
-
-   .. code-block:: console
-
-      $ make BOARD=nrf52_vbluno52 flash
+.. zephyr-app-commands::
+   :zephyr-app: samples/hello_world
+   :board: nrf52_vbluno52
+   :goals: build flash
 
 Testing the VBLUno52 with Zephyr: buttons, LEDs, UART, BLE
 **********************************************************

--- a/boards/arm/nucleo_f030r8/doc/nucleof030r8.rst
+++ b/boards/arm/nucleo_f030r8/doc/nucleof030r8.rst
@@ -115,6 +115,10 @@ For mode details please refer to `STM32 Nucleo-64 board User Manual`_.
 Programming and Debugging
 *************************
 
+Applications for the ``nucleo_f030r8`` board configuration can be built and
+flashed in the usual way (see :ref:`build_an_application` and
+:ref:`application_run` for more details).
+
 Flashing
 ========
 
@@ -124,33 +128,26 @@ This interface is supported by the openocd version included in the Zephyr SDK.
 Flashing an application to Nucleo F030R8
 ----------------------------------------
 
-The sample application :ref:`blinky-sample` is being used in this tutorial.
+Here is an example for the :ref:`blinky-sample` application.
 
-.. code-block:: console
-
-   $ cd <zephyr_root_path>
-   $ source zephyr-env.sh
-   $ cd $ZEPHYR_BASE/samples/basic/blinky
-   $ make BOARD=nucleo_f030r8
-
-Connect the Nucleo F030R8 to your host computer using the USB port.
-Then, enter the following command:
-
-.. code-block:: console
-
-   $ make BOARD=nucleo_f030r8 flash
+.. zephyr-app-commands::
+   :zephyr-app: samples/basic/blinky
+   :board: nucleo_f030r8
+   :goals: build flash
 
 You will see the LED blinking every second.
 
 Debugging
 =========
 
-Access gdb with the following make command:
+You can debug an application in the usual way.  Here is an example for the
+:ref:`blinky-sample` application.
 
-.. code-block:: console
-
-   $ make BOARD=nucleo_f030r8 debug
-
+.. zephyr-app-commands::
+   :zephyr-app: samples/basic/blinky
+   :board: nucleo_f030r8
+   :maybe-skip-config:
+   :goals: debug
 
 References
 **********

--- a/boards/arm/nucleo_f091rc/doc/nucleof091rc.rst
+++ b/boards/arm/nucleo_f091rc/doc/nucleof091rc.rst
@@ -115,6 +115,10 @@ For mode details please refer to `STM32 Nucleo-64 board User Manual`_.
 Programming and Debugging
 *************************
 
+Applications for the ``nucleo_f091rc`` board configuration can be built and
+flashed in the usual way (see :ref:`build_an_application` and
+:ref:`application_run` for more details).
+
 Flashing
 ========
 
@@ -124,33 +128,26 @@ This interface is supported by the openocd version included in the Zephyr SDK.
 Flashing an application to Nucleo F091RC
 ----------------------------------------
 
-The sample application :ref:`blinky-sample` is being used in this tutorial.
+Here is an example for the :ref:`blinky-sample` application.
 
-.. code-block:: console
-
-   $ cd <zephyr_root_path>
-   $ source zephyr-env.sh
-   $ cd $ZEPHYR_BASE/samples/basic/blinky
-   $ make BOARD=nucleo_f091rc
-
-Connect the Nucleo F091RC to your host computer using the USB port.
-Then, enter the following command:
-
-.. code-block:: console
-
-   $ make BOARD=nucleo_f091rc flash
+.. zephyr-app-commands::
+   :zephyr-app: samples/basic/blinky
+   :board: nucleo_f091rc
+   :goals: build flash
 
 You will see the LED blinking every second.
 
 Debugging
 =========
 
-Access gdb with the following make command:
+You can debug an application in the usual way.  Here is an example for the
+:ref:`hello_world` application.
 
-.. code-block:: console
-
-   $ make BOARD=nucleo_f091rc debug
-
+.. zephyr-app-commands::
+   :zephyr-app: samples/hello_world
+   :board: nucleo_f091rc
+   :maybe-skip-config:
+   :goals: debug
 
 References
 **********

--- a/boards/arm/nucleo_f103rb/doc/nucleof103rb.rst
+++ b/boards/arm/nucleo_f103rb/doc/nucleof103rb.rst
@@ -115,6 +115,10 @@ For mode details please refer to `STM32 Nucleo-64 board User Manual`_.
 Programming and Debugging
 *************************
 
+Applications for the ``nucleo_f103rb`` board configuration can be built and
+flashed in the usual way (see :ref:`build_an_application` and
+:ref:`application_run` for more details).
+
 Flashing
 ========
 
@@ -124,33 +128,26 @@ This interface is supported by the openocd version included in the Zephyr SDK.
 Flashing an application to Nucleo F103RB
 ----------------------------------------
 
-The sample application :ref:`blinky-sample` is being used in this tutorial.
+Here is an example for the :ref:`blinky-sample` application.
 
-.. code-block:: console
-
-   $ cd <zephyr_root_path>
-   $ source zephyr-env.sh
-   $ cd $ZEPHYR_BASE/samples/basic/blinky
-   $ make BOARD=nucleo_f103rb
-
-Connect the Nucleo F103RB to your host computer using the USB port.
-Then, enter the following command:
-
-.. code-block:: console
-
-   $ make BOARD=nucleo_f103rb flash
+.. zephyr-app-commands::
+   :zephyr-app: samples/basic/blinky
+   :board: nucleo_f103rb
+   :goals: build flash
 
 You will see the LED blinking every second.
 
 Debugging
 =========
 
-Access gdb with the following make command:
+You can debug an application in the usual way.  Here is an example for the
+:ref:`blinky-sample` application.
 
-.. code-block:: console
-
-   $ make BOARD=nucleo_f103rb debug
-
+.. zephyr-app-commands::
+   :zephyr-app: samples/basic-blinky
+   :board: nucleo_f103rb
+   :maybe-skip-config:
+   :goals: debug
 
 References
 **********

--- a/boards/arm/nucleo_f334r8/doc/nucleof334r8.rst
+++ b/boards/arm/nucleo_f334r8/doc/nucleof334r8.rst
@@ -119,6 +119,10 @@ For mode details please refer to `STM32 Nucleo-64 board User Manual`_.
 Programming and Debugging
 *************************
 
+Applications for the ``nucleo_f334r8`` board configuration can be built and
+flashed in the usual way (see :ref:`build_an_application` and
+:ref:`application_run` for more details).
+
 Flashing
 ========
 
@@ -128,45 +132,28 @@ This interface is supported by the openocd version included in Zephyr SDK.
 Flashing an application to Nucleo F334R8
 ----------------------------------------
 
-The sample application :ref:`blinky-sample` is being used in this tutorial:
+Connect the Nucleo F334R8 to your host computer using the USB port,
+then build and flash an application. Here is an example for the
+:ref:`blinky-sample` application.
 
-.. code-block:: console
-
-   $<zephyr_root_path>/samples/basic/blinky
-
-To build the Zephyr kernel and application, enter:
-
-.. code-block:: console
-
-   $ cd <zephyr_root_path>
-   $ source zephyr-env.sh
-   $ cd $ZEPHYR_BASE/samples/basic/blinky
-   $ make BOARD=nucleo_f334r8
-
-Connect the Nucleo F334R8 to your host computer using the USB port.
-Then, enter the following command:
-
-.. code-block:: console
-
-   $ make BOARD=nucleo_f334r8 flash
-
-Run a serial host program to connect with your Nucleo board:
-
-.. code-block:: console
-
-   $ minicom -D /dev/ttyACM0
+.. zephyr-app-commands::
+   :zephyr-app: samples/basic/blinky
+   :board: nucleo_f334r8
+   :goals: build flash
 
 You will see the LED blinking every second.
 
 Debugging
 =========
 
-Access gdb with the following make command:
+You can debug an application in the usual way.  Here is an example for
+the :ref:`blinky-sample` application.
 
-.. code-block:: console
-
-   $ make BOARD=nucleo_f334r8 debug
-
+.. zephyr-app-commands::
+   :zephyr-app: samples/basic/blinky
+   :board: nucleo_f334r8
+   :maybe-skip-config:
+   :goals: debug
 
 References
 **********

--- a/boards/arm/nucleo_f401re/doc/nucleof401re.rst
+++ b/boards/arm/nucleo_f401re/doc/nucleof401re.rst
@@ -142,6 +142,10 @@ Nucleo F401RE board has up to 3 I2Cs. The default I2C mapping for Zephyr is:
 Programming and Debugging
 *************************
 
+Applications for the ``nucleo_f401re`` board configuration can be built and
+flashed in the usual way (see :ref:`build_an_application` and
+:ref:`application_run` for more details).
+
 Flashing
 ========
 
@@ -151,35 +155,22 @@ This interface is supported by the openocd version included in Zephyr SDK.
 Flashing an application to Nucleo F401RE
 ----------------------------------------
 
-The sample application :ref:`hello_world` is being used in this tutorial:
-
-.. code-block:: console
-
-   $<zephyr_root_path>/samples/hello_world
-
-To build the Zephyr kernel and application, enter:
-
-.. code-block:: console
-
-   $ cd <zephyr_root_path>
-   $ source zephyr-env.sh
-   $ cd $ZEPHYR_BASE/samples/hello_world/
-   $ make BOARD=nucleo_f401re
-
-Connect the Nucleo F401RE to your host computer using the USB port.
-Then, enter the following command:
-
-.. code-block:: console
-
-   $ make BOARD=nucleo_f401re flash
-
-Run a serial host program to connect with your Nucleo board:
+Connect the Nucleo F401RE to your host computer using the USB port,
+then run a serial host program to connect with your Nucleo board:
 
 .. code-block:: console
 
    $ minicom -D /dev/ttyACM0
 
-You should see the following message:
+Now build and flash an application. Here is an example for
+:ref:`hello_world`.
+
+.. zephyr-app-commands::
+   :zephyr-app: samples/hello_world
+   :board: nucleo_f401re
+   :goals: build flash
+
+You should see the following message on the console:
 
 .. code-block:: console
 
@@ -189,12 +180,14 @@ You should see the following message:
 Debugging
 =========
 
-Access gdb with the following make command:
+You can debug an application in the usual way.  Here is an example for the
+:ref:`hello_world` application.
 
-.. code-block:: console
-
-   $ make BOARD=nucleo_f411re debug
-
+.. zephyr-app-commands::
+   :zephyr-app: samples/hello_world
+   :board: nucleo_f401re
+   :maybe-skip-config:
+   :goals: debug
 
 .. _Nucleo F401RE website:
    http://www.st.com/en/evaluation-tools/nucleo-f401re.html

--- a/boards/arm/nucleo_f411re/doc/nucleof411re.rst
+++ b/boards/arm/nucleo_f411re/doc/nucleof411re.rst
@@ -134,6 +134,10 @@ Default settings are 115200 8N1.
 Programming and Debugging
 *************************
 
+Applications for the ``nucleo_f411re`` board configuration can be built and
+flashed in the usual way (see :ref:`build_an_application` and
+:ref:`application_run` for more details).
+
 Flashing
 ========
 
@@ -143,27 +147,7 @@ This interface is supported by the openocd version included in Zephyr SDK.
 Flashing an application to Nucleo F411RE
 ----------------------------------------
 
-The sample application :ref:`hello_world` is being used in this tutorial:
-
-.. code-block:: console
-
-   $<zephyr_root_path>/samples/hello_world
-
-To build the Zephyr kernel and application, enter:
-
-.. code-block:: console
-
-   $ cd <zephyr_root_path>
-   $ source zephyr-env.sh
-   $ cd $ZEPHYR_BASE/samples/hello_world/
-   $ make BOARD=nucleo_f411re
-
-Connect the Nucleo F411RE to your host computer using the USB port.
-Then, enter the following command:
-
-.. code-block:: console
-
-   $ make BOARD=nucleo_f411re flash
+Here is an example for the :ref:`hello_world` application.
 
 Run a serial host program to connect with your Nucleo board.
 
@@ -171,22 +155,30 @@ Run a serial host program to connect with your Nucleo board.
 
    $ minicom -D /dev/ttyACM0
 
-You should see the following message:
+Build and flash the application:
+
+.. zephyr-app-commands::
+   :zephyr-app: samples/hello_world
+   :board: nucleo_f411re
+   :goals: build flash
+
+You should see the following message on the console:
 
 .. code-block:: console
 
    $ Hello World! arm
 
-
 Debugging
 =========
 
-Access gdb with the following make command:
+You can debug an application in the usual way.  Here is an example for the
+:ref:`hello_world` application.
 
-.. code-block:: console
-
-   $ make BOARD=nucleo_f411re debug
-
+.. zephyr-app-commands::
+   :zephyr-app: samples/hello_world
+   :board: nucleo_f411re
+   :maybe-skip-config:
+   :goals: debug
 
 .. _Nucleo F411RE website:
    http://www.st.com/en/evaluation-tools/nucleo-f411re.html

--- a/boards/arm/nucleo_l432kc/doc/nucleol432kc.rst
+++ b/boards/arm/nucleo_l432kc/doc/nucleol432kc.rst
@@ -168,50 +168,36 @@ Default settings are 115200 8N1.
 Programming and Debugging
 *************************
 
+Applications for the ``nucleo_l432kc`` board configuration can be built and
+flashed in the usual way (see :ref:`build_an_application` and
+:ref:`application_run` for more details).
+
 Flashing
 ========
 
-Nucleo L432KC board includes an ST-LINK/V2-1 embedded debug tool interface.
-This interface is not supported by the openocd version 0.9 included by the Zephyr SDK v0.9.
-Until we update the Zephyr SDK, use openocd v0.10.0 from the openocd-stm32 project on GitHub
-to get the minimum set of scripts needed to flash and debug STM32 development boards.
-
-.. code-block:: console
-
-   $ git clone  https://github.com/erwango/openocd-stm32.git
-
-Then follow instructions in README.md
-
+Nucleo L432KC board includes an ST-LINK/V2-1 embedded debug tool
+interface.  This interface is supported by the openocd version
+included in the Zephyr SDK since v0.9.2.
 
 Flashing an application to Nucleo L432KC
 ----------------------------------------
 
-The sample application :ref:`hello_world` is being used in this tutorial:
-
-To build the Zephyr kernel and application, enter:
-
-.. code-block:: console
-
-   $ cd <zephyr_root_path>
-   $ source zephyr-env.sh
-   $ cd $ZEPHYR_BASE/samples/hello_world/
-   $ make BOARD=nucleo_l432kc
-
-Connect the Nucleo L432KC to your host computer using the USB port.
-Then, enter the following command:
-
-.. code-block:: console
-
-   $ cd <openocd-stm32_path>
-   $ stm32_flsh l4 $ZEPHYR_BASE/samples/hello_world/outdir/nucleo_l432kc/zephyr.bin
-
-Run a serial host program to connect with your Nucleo board.
+Connect the Nucleo L432KC to your host computer using the USB port,
+then run a serial host program to connect with your Nucleo board.
 
 .. code-block:: console
 
    $ minicom -D /dev/ttyACM0
 
-You should see the following message:
+Now build and flash an application. Here is an example for
+:ref:`hello_world`.
+
+.. zephyr-app-commands::
+   :zephyr-app: samples/hello_world
+   :board: nucleo_l432kc
+   :goals: build flash
+
+You should see the following message on the console:
 
 .. code-block:: console
 
@@ -221,12 +207,14 @@ You should see the following message:
 Debugging
 =========
 
-Access gdb with the following make command:
+You can debug an application in the usual way.  Here is an example for the
+:ref:`hello_world` application.
 
-.. code-block:: console
-
-   $ cd <openocd-stm32_path>
-   $ stm32_dbg l4 $ZEPHYR_BASE/samples/hello_world/outdir/nucleo_l432kc/zephyr.elf
+.. zephyr-app-commands::
+   :zephyr-app: samples/hello_world
+   :board: nucleo_l432kc
+   :maybe-skip-config:
+   :goals: debug
 
 .. _Nucleo L432KC website:
    http://www.st.com/en/evaluation-tools/nucleo-l432kc.html

--- a/boards/arm/nucleo_l476rg/doc/nucleol476rg.rst
+++ b/boards/arm/nucleo_l476rg/doc/nucleol476rg.rst
@@ -181,42 +181,23 @@ Default settings are 115200 8N1.
 Programming and Debugging
 *************************
 
+Applications for the ``nucleo_l476rg`` board configuration can be built and
+flashed in the usual way (see :ref:`build_an_application` and
+:ref:`application_run` for more details).
+
 Flashing
 ========
 
-Nucleo L476RG board includes an ST-LINK/V2-1 embedded debug tool interface.
-This interface is not supported by the openocd version 0.9 included by the Zephyr SDK v0.9.
-Until we update the Zephyr SDK, use openocd v0.10.0 from the openocd-stm32 project on GitHub
-to get the minimum set of scripts needed to flash and debug STM32 development boards.
-
-.. code-block:: console
-
-   $ git clone  https://github.com/erwango/openocd-stm32.git
-
-Then follow instructions in README.md
-
+Nucleo L476RG board includes an ST-LINK/V2-1 embedded debug tool
+interface.  This interface is supported by the openocd version
+included in the Zephyr SDK since v0.9.2.
 
 Flashing an application to Nucleo L476RG
 ----------------------------------------
 
-The sample application :ref:`hello_world` is being used in this tutorial:
-
-To build the Zephyr kernel and application, enter:
-
-.. code-block:: console
-
-   $ cd <zephyr_root_path>
-   $ source zephyr-env.sh
-   $ cd $ZEPHYR_BASE/samples/hello_world/
-   $ make BOARD=nucleo_l476rg
-
 Connect the Nucleo L476RG to your host computer using the USB port.
-Then, enter the following command:
-
-.. code-block:: console
-
-   $ cd <openocd-stm32_path>
-   $ stm32_flsh l4 $ZEPHYR_BASE/samples/hello_world/outdir/nucleo_l476rg/zephyr.bin
+Then build and flash an application. Here is an example for the
+:ref:`hello_world` application.
 
 Run a serial host program to connect with your Nucleo board.
 
@@ -224,22 +205,30 @@ Run a serial host program to connect with your Nucleo board.
 
    $ minicom -D /dev/ttyACM0
 
-You should see the following message:
+Then build and flash the application.
+
+.. zephyr-app-commands::
+   :zephyr-app: samples/hello_world
+   :board: nucleo_l476rg
+   :goals: build flash
+
+You should see the following message  on the console:
 
 .. code-block:: console
 
    $ Hello World! arm
 
-
 Debugging
 =========
 
-Access gdb with the following make command:
+You can debug an application in the usual way.  Here is an example for the
+:ref:`hello_world` application.
 
-.. code-block:: console
-
-   $ cd <openocd-stm32_path>
-   $ stm32_dbg l4 $ZEPHYR_BASE/samples/hello_world/outdir/nucleo_l476rg/zephyr.elf
+.. zephyr-app-commands::
+   :zephyr-app: samples/hello_world
+   :board: nucleo_l476rg
+   :maybe-skip-config:
+   :goals: debug
 
 .. _Nucleo L476RG website:
    http://www.st.com/en/evaluation-tools/nucleo-l476rg.html

--- a/boards/arm/olimex_stm32_e407/doc/olimex_stm32_e407.rst
+++ b/boards/arm/olimex_stm32_e407/doc/olimex_stm32_e407.rst
@@ -353,7 +353,7 @@ Run a serial host program to connect with your board:
 
    $ minicom -D /dev/ttyACM0
 
-After reseting the board you should see the following message:
+After resetting the board, you should see the following message:
 
 .. code-block:: console
 

--- a/boards/arm/olimex_stm32_e407/doc/olimex_stm32_e407.rst
+++ b/boards/arm/olimex_stm32_e407/doc/olimex_stm32_e407.rst
@@ -326,26 +326,23 @@ The OLIMEX-STM32-E407 board does not include an embedded debug tool
 interface. You will need to use ST tools or an external JTAG probe.
 In the following examples a ST-Link V2 USB dongle is used.
 
+If you have an external JTAG probe compliant with the default Zephyr OpenOCD
+configuration, however, then applications for the ``olimex_stm32_e407`` board
+configuration can be built and flashed in the usual way (see
+:ref:`build_an_application` and :ref:`application_run` for more details).
+
 Flashing an application to the Olimex-STM32-E407
 ================================================
 
-The sample application :ref:`hello_world` is being used in this tutorial. To
-build the Zephyr kernel and application, enter:
-
-.. code-block:: console
-
-   $ cd <zephyr_root_path>
-   $ source zephyr-env.sh
-   $ cd $ZEPHYR_BASE/samples/hello_world/
-   $ make BOARD=olimex_stm32_e407
-
 Connect the ST-Link USB dongle to your host computer and to the JTAG port of
-the OLIMEX-STM32-E407 board.
-Then, enter the following command:
+the OLIMEX-STM32-E407 board. Then build and flash an application.
 
-.. code-block:: console
+Here is an example for the :ref:`hello_world` application.
 
-   $ make BOARD=olimex_stm32_e407 flash
+.. zephyr-app-commands::
+   :zephyr-app: samples/hello_world
+   :board: olimex_stm32_e407
+   :goals: build flash
 
 Run a serial host program to connect with your board:
 
@@ -363,12 +360,14 @@ After resetting the board, you should see the following message:
 Debugging
 =========
 
-Access gdb with the following make command:
+Provided that you have a JTAG probe, you can debug an application in the usual
+way.  Here is an example for the :ref:`hello_world` application.
 
-.. code-block:: console
-
-   $ make BOARD=olimex_stm32_e407 debug
-
+.. zephyr-app-commands::
+   :zephyr-app: samples/hello_world
+   :board: olimex_stm32_e407
+   :maybe-skip-config:
+   :goals: debug
 
 .. _OLIMEX-STM32-E407 website:
    https://www.olimex.com/Products/ARM/ST/STM32-E407/open-source-hardware

--- a/boards/arm/olimex_stm32_p405/doc/olimex_stm32_p405.rst
+++ b/boards/arm/olimex_stm32_p405/doc/olimex_stm32_p405.rst
@@ -221,23 +221,17 @@ In the following examples a ST-Link V2 USB dongle is used.
 Flashing an application to the Olimex-STM32-P405
 ================================================
 
-The sample application :ref:`hello_world` is being used in this tutorial. To
-build the Zephyr kernel and application, enter:
-
-.. code-block:: console
-
-   $ cd <zephyr_root_path>
-   $ source zephyr-env.sh
-   $ cd $ZEPHYR_BASE/samples/hello_world/
-   $ make BOARD=olimex_stm32_p405
+The sample application :ref:`hello_world` is being used in this tutorial.
 
 Connect the ST-Link USB dongle to your host computer and to the JTAG port of
 the OLIMEX-STM32-P405 board.
-Then, enter the following command:
 
-.. code-block:: console
+Now build and flash the application.
 
-   $ make BOARD=olimex_stm32_p405 flash
+.. zephyr-app-commands::
+   :zephyr-app: samples/hello_world
+   :board: olimex_stm32_p405
+   :goals: build flash
 
 Run a serial host program to connect with your board:
 
@@ -255,12 +249,14 @@ After resetting the board, you should see the following message:
 Debugging
 =========
 
-Access gdb with the following make command:
+You can debug an application in the usual way.  Here is an example for the
+:ref:`hello_world` application.
 
-.. code-block:: console
-
-   $ make BOARD=olimex_stm32_p405 debug
-
+.. zephyr-app-commands::
+   :zephyr-app: samples/hello_world
+   :board: olimex_stm32_p405
+   :maybe-skip-config:
+   :goals: debug
 
 .. _OLIMEX-STM32-P405 website:
    https://www.olimex.com/Products/ARM/ST/STM32-P405/

--- a/boards/arm/olimex_stm32_p405/doc/olimex_stm32_p405.rst
+++ b/boards/arm/olimex_stm32_p405/doc/olimex_stm32_p405.rst
@@ -245,7 +245,7 @@ Run a serial host program to connect with your board:
 
    $ minicom -D /dev/ttyACM0
 
-After reseting the board you should see the following message:
+After resetting the board, you should see the following message:
 
 .. code-block:: console
 

--- a/boards/arm/olimexino_stm32/doc/olimexino_stm32.rst
+++ b/boards/arm/olimexino_stm32/doc/olimexino_stm32.rst
@@ -367,16 +367,15 @@ Flashing an Application to OLIMEXINO-STM32
 ==========================================
 
 To upload an application to the OLIMEXINO-STM32 board a TTL(3.3V)
-serial adapter is required. This tutorial uses sample application
-:ref:`button-sample`
+serial adapter is required. This tutorial uses the
+:ref:`button-sample` sample application.
 
 #. To build the Zephyr kernel and application, enter:
 
-   .. code-block:: console
-
-      $ cd $<zephyr_root_path>
-      $ source zephyr-env.sh
-      $ make -C samples/basic/button BOARD=olimexino_stm32
+   .. zephyr-app-commands::
+      :zephyr-app: samples/basic/button
+      :board: olimexino_stm32
+      :goals: build
 
 #. Connect the serial cable to the UEXT lines of the UART
    interface (pin #3=TX and pin #4=RX).
@@ -385,12 +384,12 @@ serial adapter is required. This tutorial uses sample application
 
 #. Reset the board while holding the button (BUT).
 
-#. Flash the application using the stm32flash tool:
+#. Flash the application using the stm32flash tool. Start
+   by navigating to the build directory containing zephyr.bin.
 
    .. code-block:: console
 
-      $ cd samples/basic/button
-      $ stm32flash -w outdir/olimexino_stm32/zephyr.bin -v -g 0x0 <tty_device>
+      $ stm32flash -w zephyr.bin -v -g 0x0 <tty_device>
 
    Replace :code:`<tty_device>` with the port where the board
    OLIMEXINO-STM32 can be found. For example, under Linux,

--- a/boards/arm/qemu_cortex_m3/doc/board.rst
+++ b/boards/arm/qemu_cortex_m3/doc/board.rst
@@ -71,9 +71,10 @@ Programming and Debugging
 Use this configuration to run basic Zephyr applications and kernel tests in the QEMU
 emulated environment, for example, with the :ref:`synchronization_sample`:
 
-.. code-block:: console
-
-        $ make -C samples/synchronization BOARD=qemu_cortex_m3 run
+.. zephyr-app-commands::
+   :zephyr-app: samples/synchronization
+   :board: qemu_cortex_m3
+   :goals: run
 
 This will build an image with the synchronization sample app, boot it using
 QEMU, and display the following console output:

--- a/boards/arm/sam4s_xplained/doc/sam4s_xplained.rst
+++ b/boards/arm/sam4s_xplained/doc/sam4s_xplained.rst
@@ -82,10 +82,10 @@ Flashing
 
 #. Build the Zephyr kernel and the :ref:`hello_world` sample application:
 
-   .. code-block:: console
-
-      $ cd $ZEPHYR_BASE/samples/hello_world/
-      $ make BOARD=sam4s_xplained
+   .. zephyr-app-commands::
+      :zephyr-app: samples/hello_world
+      :board: sam4s_xplained
+      :goals: build
 
 #. Connect the SAM4S Xplained board to your host computer using the USB debug
    port.

--- a/boards/arm/sam_e70_xplained/doc/sam_e70_xplained.rst
+++ b/boards/arm/sam_e70_xplained/doc/sam_e70_xplained.rst
@@ -83,11 +83,7 @@ Programming and Debugging
 
 Flashing the Zephyr project onto SAM E70 MCU requires the `OpenOCD tool`_.
 Support for Atmel SAM E microcontroller series was added in OpenOCD release
-0.10.0. The current OpenOCD version available in the Zephyr SDK is 0.9 and
-unfortunately it does not support Atmel SAM E microcontrollers. Since few, if
-any major Linux distributions currently offer OpenOCD version 0.10.0 as a
-package you will have to compile and install it yourself. Make sure to enable
-CMSIS-DAP support as this is the debug interface used by the on board EDBG chip.
+0.10.0, which was added in Zephyr SDK 0.9.2.
 
 By default a factory new SAM E70 chip will boot SAM-BA boot loader located in
 the ROM, not the flashed image. This is determined by the value of GPNVM1
@@ -107,16 +103,6 @@ contents of the SAM E70 flash memory:
 Flashing
 ========
 
-#. Build the Zephyr kernel and the application:
-
-   .. code-block:: console
-
-      $ cd $ZEPHYR_BASE/samples/hello_world/
-      $ make BOARD=sam_e70_xplained
-
-#. Connect the SAM E70 Xplained board to your host computer using the USB debug
-   port.
-
 #. Run your favorite terminal program to listen for output. Under Linux the
    terminal should be :code:`/dev/ttyACM0`. For example:
 
@@ -132,41 +118,35 @@ Flashing
    - Parity: None
    - Stop bits: 1
 
-#. To flash the image, assuming the OpenOCD tool is already installed, enter:
+#. Connect the SAM E70 Xplained board to your host computer using the
+   USB debug port. Then build and flash the :ref:`hello_world`
+   application.
 
-   .. code-block:: console
-
-      $ make BOARD=sam_e70_xplained flash
-
-   The command will also verify that the image was programmed correctly, reset
-   the board and run the Zephyr application.
-
-   You can flash the image using an external debug adapter such as J-Link or
-   ULINK, connected to the 20-pin JTAG header. Supply the name of the debug
-   adapter (e.g., ``jlink``) to the make command via an OPENOCD_INTERFACE
-   variable. OpenOCD will look for the appropriate interface configuration in an
-   ``interface/$(OPENOCD_INTERFACE).cfg`` file on its internal search path.
-
-   .. code-block:: console
-
-      $ make BOARD=sam_e70_xplained OPENOCD_INTERFACE=jlink flash
+   .. zephyr-app-commands::
+      :zephyr-app: samples/hello_world
+      :board: sam_e70_xplained
+      :goals: build flash
 
    You should see "Hello World!" in your terminal.
+
+You can flash the image using an external debug adapter such as J-Link
+or ULINK, connected to the 20-pin JTAG header. Supply the name of the
+debug adapter (e.g., ``jlink``) via an OPENOCD_INTERFACE environment
+variable. OpenOCD will look for the appropriate interface
+configuration in an ``interface/$(OPENOCD_INTERFACE).cfg`` file on its
+internal search path.
 
 Debugging
 =========
 
-#. Connect the SAM E70 Xplained board to your host computer using the USB debug
-   port.
+You can debug an application in the usual way.  Here is an example for the
+:ref:`hello_world` application.
 
-#. Start GDB server on your host computer
-
-   .. code-block:: console
-
-      $ openocd -f board/atmel_same70_xplained.cfg&
-
-#. You can now use GDB remote debugging to connect to the target board. By
-   default GDB server will listen on port 3333.
+.. zephyr-app-commands::
+   :zephyr-app: samples/hello_world
+   :board: sam_e70_xplained
+   :maybe-skip-config:
+   :goals: debug
 
 References
 **********

--- a/boards/arm/stm3210c_eval/doc/stm3210c_eval.rst
+++ b/boards/arm/stm3210c_eval/doc/stm3210c_eval.rst
@@ -119,48 +119,43 @@ At power-on, the board is in firmware-upgrade mode (also called DFU for
 "Device Firmware Upgrade"), allowing the firmware to be updated through the USB.
 This interface is supported by the openocd version included in Zephyr SDK.
 
+Applications for the ``stm3210c_eval`` board configuration can be built and
+flashed in the usual way (see :ref:`build_an_application` and
+:ref:`application_run` for more details).
+
 Flashing an application to STM3210C-EVAL
 ----------------------------------------
 
-The sample application :ref:`blinky-sample` is being used in this tutorial:
+Connect the STM3210C-EVAL to your host computer using the USB port, then build
+and flash an application in the usual way.
 
-.. code-block:: console
+Here is an example for the :ref:`blinky-sample` application.
 
-   $<zephyr_root_path>/samples/basic/blinky
-
-To build the Zephyr kernel and application, enter:
-
-.. code-block:: console
-
-   $ cd <zephyr_root_path>
-   $ source zephyr-env.sh
-   $ cd $ZEPHYR_BASE/samples/basic/blinky
-   $ make BOARD=stm3210c_eval
-
-Connect the STM3210C-EVAL to your host computer using the USB port.
-Then, enter the following command:
-
-.. code-block:: console
-
-   $ make BOARD=stm3210c_eval flash
-
-Run a serial host program to connect with your STM3210C-EVAL board:
-
-.. code-block:: console
-
-   $ minicom -D /dev/ttyACM0
+.. zephyr-app-commands::
+   :zephyr-app: samples/basic/blinky
+   :board: stm3210c_eval
+   :goals: build flash
 
 You will see the LED blinking every second.
 
 Debugging
 =========
 
-Access gdb with the following make command:
+You can run a serial host program to connect with your STM3210C-EVAL board. For
+example, on Linux:
 
 .. code-block:: console
 
-   $ make BOARD=stm3210c_eval debug
+   $ minicom -D /dev/ttyACM0
 
+You can debug an application in the usual way.  Here is an example for the
+:ref:`hello_world` application.
+
+.. zephyr-app-commands::
+   :zephyr-app: samples/hello_world
+   :board: stm3210c_eval
+   :maybe-skip-config:
+   :goals: debug
 
 References
 **********

--- a/boards/arm/stm32373c_eval/doc/stm32373c_eval.rst
+++ b/boards/arm/stm32373c_eval/doc/stm32373c_eval.rst
@@ -115,6 +115,10 @@ Default Zephyr Peripheral Mapping:
 Programming and Debugging
 *************************
 
+Applications for the ``stm32373c_eval`` board configuration can be built and
+flashed in the usual way (see :ref:`build_an_application` and
+:ref:`application_run` for more details).
+
 Flashing
 ========
 
@@ -126,45 +130,26 @@ This interface is supported by the openocd version included in Zephyr SDK.
 Flashing an application to STM32373C-EVAL
 -----------------------------------------
 
-The sample application :ref:`blinky-sample` is being used in this tutorial:
+Here is an example for the :ref:`blinky-sample` application.
 
-.. code-block:: console
-
-   $<zephyr_root_path>/samples/basic/blinky
-
-To build the Zephyr kernel and application, enter:
-
-.. code-block:: console
-
-   $ cd <zephyr_root_path>
-   $ source zephyr-env.sh
-   $ cd $ZEPHYR_BASE/samples/basic/blinky
-   $ make BOARD=stm32373c_eval
-
-Connect the STM32373C-EVAL to your host computer using the USB port.
-Then, enter the following command:
-
-.. code-block:: console
-
-   $ make BOARD=stm32373c_eval flash
-
-Run a serial host program to connect with your STM32373C-EVAL board:
-
-.. code-block:: console
-
-   $ minicom -D /dev/ttyACM0
+.. zephyr-app-commands::
+   :zephyr-app: samples/basic/blinky
+   :board: stm32373c_eval
+   :goals: build flash
 
 You will see the LED blinking every second.
 
 Debugging
 =========
 
-Access gdb with the following make command:
+You can debug an application in the usual way.  Here is an example for the
+:ref:`blinky-sample` application.
 
-.. code-block:: console
-
-   $ make BOARD=stm32373c_eval debug
-
+.. zephyr-app-commands::
+   :zephyr-app: samples/basic/blinky
+   :board: stm32373c_eval
+   :maybe-skip-config:
+   :goals: debug
 
 References
 **********

--- a/boards/arm/stm32_min_dev/doc/stm32_min_dev.rst
+++ b/boards/arm/stm32_min_dev/doc/stm32_min_dev.rst
@@ -94,24 +94,35 @@ The stm32_min_dev board configuration supports the following hardware features:
 
 Other hardware features are not supported by the Zephyr kernel.
 
-Building and Flashing Zephyr onto stm32_min_dev
-***********************************************
 
-You can build any of the Zephyr samples with,
+Programming and Debugging
+*************************
 
-.. code-block:: console
+Applications for the ``stm32_min_dev`` board configuration can be built and
+flashed in the usual way (see :ref:`build_an_application` and
+:ref:`application_run` for more details).
 
-   $ cd $<zephyr_root_path>
-   $ source zephyr-env.sh
-   $ make -C samples/basic/blinky BOARD=stm32_min_dev
+Flashing
+========
 
-Flashing the Zephyr kernel onto stm32_min_dev requires the popular ST-Link
-debugger/programmer. This port comes with support for doing just that with the
-flash target.
+Here is an example for the :ref:`blinky-sample` application.
 
-.. code-block:: console
+.. zephyr-app-commands::
+   :zephyr-app: samples/basic/blinky
+   :board: stm32_min_dev
+   :goals: build flash
 
-   $ make -C samples/basic/blinky BOARD=stm32_min_dev flash
+Debugging
+=========
+
+You can debug an application in the usual way.  Here is an example for the
+:ref:`hello_world` application.
+
+.. zephyr-app-commands::
+   :zephyr-app: samples/hello_world
+   :board: stm32_min_dev
+   :maybe-skip-config:
+   :goals: debug
 
 .. _STM32F103x8:
         http://www.st.com/resource/en/datasheet/stm32f103c8.pdf

--- a/boards/arm/stm32f3_disco/doc/stm32f3_disco.rst
+++ b/boards/arm/stm32f3_disco/doc/stm32f3_disco.rst
@@ -153,33 +153,24 @@ Flashing
 ========
 
 STM32F3DISCOVERY Discovery kit includes a ST-LINK/V2 or ST-LINK/V2-B embedded
-debug tool interface. This interface is supported by the openocd version
-included in Zephyr SDK.
+debug tool interface.
+
+Applications for the ``stm32f3_disco`` board configuration can be built and
+flashed in the usual way (see :ref:`build_an_application` and
+:ref:`application_run` for more details).
 
 Flashing an application to STM32F3DISCOVERY
 -------------------------------------------
 
-The sample application :ref:`hello_world` is being used in this tutorial:
+First, connect the STM32F3DISCOVERY Discovery kit to your host computer using
+the USB port to prepare it for flashing. Then build and flash your application.
 
-.. code-block:: console
+Here is an example for the :ref:`hello_world` application.
 
-   $<zephyr_root_path>/samples/hello_world
-
-To build the Zephyr kernel and application, enter:
-
-.. code-block:: console
-
-   $ cd <zephyr_root_path>
-   $ source zephyr-env.sh
-   $ cd $ZEPHYR_BASE/samples/hello_world/
-   $ make BOARD=stm32f3_disco
-
-Connect the STM32F3DISCOVERY Discovery kit to your host computer using the USB
-ST-LINK port. Then, enter the following command:
-
-.. code-block:: console
-
-   $ make BOARD=stm32f3_disco flash
+.. zephyr-app-commands::
+   :zephyr-app: samples/hello_world
+   :board: stm32f3_disco
+   :goals: build flash
 
 Run a serial host program to connect with your board. For PCB version A or B a
 TTL(3.3V) serial adapter is required. For PCB version C and newer a Virtual Com
@@ -192,7 +183,7 @@ Port (VCP) is available on the  USB ST-LINK port.
 Replace <tty_device> with the port where the STM32F3DISCOVERY board can be
 found. For example, under Linux, /dev/ttyUSB0.
 
-You should see the following message:
+You should see the following message on the console:
 
 .. code-block:: console
 
@@ -202,12 +193,13 @@ You should see the following message:
 Debugging
 =========
 
-Access gdb with the following make command:
+You can debug an application in the usual way.  Here is an example for the
+:ref:`hello_world` application.
 
-.. code-block:: console
-
-   $ make BOARD=stm32f3_disco debug
-
+.. zephyr-app-commands::
+   :zephyr-app: samples/hello_world
+   :board: stm32f3_disco
+   :goals: debug
 
 .. _STM32F3DISCOVERY website:
    http://www.st.com/en/evaluation-tools/stm32f3discovery.html

--- a/boards/arm/stm32f411e_disco/doc/stm32f411e_disco.rst
+++ b/boards/arm/stm32f411e_disco/doc/stm32f411e_disco.rst
@@ -124,6 +124,10 @@ assigned to UART2. Default settings are 115200 8N1.
 Programming and Debugging
 *************************
 
+Applications for the ``stm32f411e_disco`` board configuration can be built and
+flashed in the usual way (see :ref:`build_an_application` and
+:ref:`application_run` for more details).
+
 Flashing
 ========
 
@@ -134,39 +138,29 @@ Zephyr SDK.
 Flashing an application to STM32F411E-DISCO
 -------------------------------------------
 
-The sample application :ref:`blinky-sample` is being used in this tutorial:
-
-.. code-block:: console
-
-   $<zephyr_root_path>/samples/basic/blinky
-
-To build the Zephyr kernel and application, enter:
-
-.. code-block:: console
-
-   $ cd <zephyr_root_path>
-   $ source zephyr-env.sh
-   $ cd $ZEPHYR_BASE/samples/basic/blinky/
-   $ make BOARD=stm32f411e_disco
-
 Connect the STM32F411E-DISCO Discovery kit to your host computer using the
-USB port. Then, enter the following command:
+USB port. Then build and flash an application.
 
-.. code-block:: console
+Here is an example for the :ref:`blinky-sample` application.
 
-   $ make BOARD=stm32f411e_disco flash
+.. zephyr-app-commands::
+   :zephyr-app: samples/basic/blinky
+   :board: stm32f411e_disco
+   :goals: build flash
 
 You should see the orange led (LD3) blinking every second.
 
 Debugging
 =========
 
-Access gdb with the following make command:
+You can debug applications in the usual way. Here is an example for
+the :ref:`blinky-sample` application.
 
-.. code-block:: console
-
-   $ make BOARD=stm32f411e_disco debug
-
+.. zephyr-app-commands::
+   :zephyr-app: samples/basic/blinky
+   :board: stm32f411e_disco
+   :maybe-skip-config:
+   :goals: debug
 
 References
 **********

--- a/boards/arm/stm32f412g_disco/doc/stm32f412g_disco.rst
+++ b/boards/arm/stm32f412g_disco/doc/stm32f412g_disco.rst
@@ -137,6 +137,10 @@ Default settings are 115200 8N1.
 Programming and Debugging
 *************************
 
+Applications for the ``stm32f412g_disco`` board configuration can be built and
+flashed in the usual way (see :ref:`build_an_application` and
+:ref:`application_run` for more details).
+
 Flashing
 ========
 
@@ -146,35 +150,23 @@ This interface is supported by the openocd version included in Zephyr SDK.
 Flashing an application to STM32F412G-DISCO
 -------------------------------------------
 
-The sample application :ref:`hello_world` is being used in this tutorial:
-
-.. code-block:: console
-
-   $<zephyr_root_path>/samples/hello_world
-
-To build the Zephyr kernel and application, enter:
-
-.. code-block:: console
-
-   $ cd <zephyr_root_path>
-   $ source zephyr-env.sh
-   $ cd $ZEPHYR_BASE/samples/hello_world/
-   $ make BOARD=stm32f412g_disco
-
-Connect the STM32F412G-DISCO Discovery kit to your host computer using the USB port.
-Then, enter the following command:
-
-.. code-block:: console
-
-   $ make BOARD=stm32f412g_disco flash
-
-Run a serial host program to connect with your board:
+Connect the STM32F412G-DISCO Discovery kit to your host computer using
+the USB port, then run a serial host program to connect with your
+board:
 
 .. code-block:: console
 
    $ minicom -D /dev/ttyACM0
 
-You should see the following message:
+Then build and flash an application. Here is an example for the
+:ref:`hello_world` application.
+
+.. zephyr-app-commands::
+   :zephyr-app: samples/hello_world
+   :board: stm32f412g_disco
+   :goals: build flash
+
+You should see the following message on the console:
 
 .. code-block:: console
 
@@ -184,12 +176,14 @@ You should see the following message:
 Debugging
 =========
 
-Access gdb with the following make command:
+You can debug an application in the usual way.  Here is an example for the
+:ref:`hello_world` application.
 
-.. code-block:: console
-
-   $ make BOARD=stm32f412g_disco debug
-
+.. zephyr-app-commands::
+   :zephyr-app: samples/hello_world
+   :board: stm32f412g_disco
+   :maybe-skip-config:
+   :goals: debug
 
 .. _32F412GDISCOVERY website:
    http://www.st.com/en/evaluation-tools/32f412gdiscovery.html

--- a/boards/arm/stm32f429i_disc1/doc/stm32f429i_disc1.rst
+++ b/boards/arm/stm32f429i_disc1/doc/stm32f429i_disc1.rst
@@ -136,6 +136,10 @@ The default communication settings are 115200 8N1.
 Programming and Debugging
 *************************
 
+Applications for the ``stm32f429i_disc1`` board configuration can be built
+and flashed in the usual way (see :ref:`build_an_application` and
+:ref:`application_run` for more details).
+
 Flashing
 ========
 
@@ -145,27 +149,15 @@ This interface is supported by the openocd version included in Zephyr SDK.
 Flashing an application to STM32F429I-DISC1
 -------------------------------------------
 
-The sample application :ref:`hello_world` is being used in this tutorial:
+First, connect the STM32F429I-DISC1 Discovery kit to your host computer using
+the USB port to prepare it for flashing. Then build and flash your application.
 
-.. code-block:: console
+Here is an example for the :ref:`hello_world` application.
 
-   $<zephyr_root_path>/samples/hello_world
-
-To build the Zephyr kernel and application, enter:
-
-.. code-block:: console
-
-   $ cd <zephyr_root_path>
-   $ source zephyr-env.sh
-   $ cd $ZEPHYR_BASE/samples/hello_world/
-   $ make BOARD=stm32f429i_disc1
-
-Connect the STM32F429I-DISC1 Discovery kit to your host computer using the USB port.
-Then, enter the following command:
-
-.. code-block:: console
-
-   $ make BOARD=stm32f429i_disc1 flash
+.. zephyr-app-commands::
+   :zephyr-app: samples/hello_world
+   :board: stm32f429i_disc1
+   :goals: build flash
 
 Run a serial host program to connect with your board:
 
@@ -183,12 +175,13 @@ Then, press the RESET button (The black one), you should see the following messa
 Debugging
 =========
 
-Access gdb with the following make command:
+You can debug an application in the usual way.  Here is an example for the
+:ref:`hello_world` application.
 
-.. code-block:: console
-
-   $ make BOARD=stm32f429i_disc1 debug
-
+.. zephyr-app-commands::
+   :zephyr-app: samples/hello_world
+   :board: stm32f429i_disc1
+   :goals: debug
 
 .. _STM32F429I-DISC1 website:
    http://www.st.com/en/evaluation-tools/32f429idiscovery.html

--- a/boards/arm/stm32f469i_disco/doc/stm32f469i_disco.rst
+++ b/boards/arm/stm32f469i_disco/doc/stm32f469i_disco.rst
@@ -142,6 +142,10 @@ Default settings are 115200 8N1.
 Programming and Debugging
 *************************
 
+Applications for the ``stm32f469i_disco`` board configuration can be built and
+flashed in the usual way (see :ref:`build_an_application` and
+:ref:`application_run` for more details).
+
 Flashing
 ========
 
@@ -151,27 +155,15 @@ This interface is supported by the openocd version included in Zephyr SDK.
 Flashing an application to STM32F469I-DISCO
 -------------------------------------------
 
-The sample application :ref:`hello_world` is being used in this tutorial:
+First, connect the STM32F469I-DISCO Discovery kit to your host computer using
+the USB port to prepare it for flashing. Then build and flash your application.
 
-.. code-block:: console
+Here is an example for the :ref:`hello_world` application.
 
-   $<zephyr_root_path>/samples/hello_world
-
-To build the Zephyr kernel and application, enter:
-
-.. code-block:: console
-
-   $ cd <zephyr_root_path>
-   $ source zephyr-env.sh
-   $ cd $ZEPHYR_BASE/samples/hello_world/
-   $ make BOARD=stm32f469i_disco
-
-Connect the STM32F469I-DISCO Discovery kit to your host computer using the USB port.
-Then, enter the following command:
-
-.. code-block:: console
-
-   $ make BOARD=stm32f469i_disco flash
+.. zephyr-app-commands::
+   :zephyr-app: samples/hello_world
+   :board: stm32f469i_disco
+   :goals: build flash
 
 Run a serial host program to connect with your board:
 
@@ -179,7 +171,7 @@ Run a serial host program to connect with your board:
 
    $ minicom -D /dev/ttyACM0
 
-You should see the following message:
+You should see the following message on the console:
 
 .. code-block:: console
 
@@ -189,11 +181,13 @@ You should see the following message:
 Debugging
 =========
 
-Access gdb with the following make command:
+You can debug an application in the usual way.  Here is an example for the
+:ref:`hello_world` application.
 
-.. code-block:: console
-
-   $ make BOARD=stm32f469i_disco debug
+.. zephyr-app-commands::
+   :zephyr-app: samples/hello_world
+   :board: stm32f469i_disco
+   :goals: debug
 
 
 .. _32F469IDISCOVERY website:

--- a/boards/arm/stm32f4_disco/doc/stm32f4_disco.rst
+++ b/boards/arm/stm32f4_disco/doc/stm32f4_disco.rst
@@ -139,6 +139,10 @@ Default settings are 115200 8N1.
 Programming and Debugging
 *************************
 
+Applications for the ``stm32f4_disco`` board configuration can be built and
+flashed in the usual way (see :ref:`build_an_application` and
+:ref:`application_run` for more details).
+
 Flashing
 ========
 
@@ -148,27 +152,7 @@ This interface is supported by the openocd version included in Zephyr SDK.
 Flashing an application to STM32F4DISCOVERY
 -------------------------------------------
 
-The sample application :ref:`hello_world` is being used in this tutorial:
-
-.. code-block:: console
-
-   $<zephyr_root_path>/samples/hello_world
-
-To build the Zephyr kernel and application, enter:
-
-.. code-block:: console
-
-   $ cd <zephyr_root_path>
-   $ source zephyr-env.sh
-   $ cd $ZEPHYR_BASE/samples/hello_world/
-   $ make BOARD=stm32f4_disco
-
-Connect the STM32F4DISCOVERY Discovery kit to your host computer using the USB port.
-Then, enter the following command:
-
-.. code-block:: console
-
-   $ make BOARD=stm32f4_disco flash
+Here is an example for the :ref:`hello_world` application.
 
 Run a serial host program to connect with your board:
 
@@ -176,7 +160,14 @@ Run a serial host program to connect with your board:
 
    $ minicom -D /dev/ttyACM0
 
-You should see the following message:
+Build and flash the application:
+
+.. zephyr-app-commands::
+   :zephyr-app: samples/hello_world
+   :board: stm32f4_disco
+   :goals: build flash
+
+You should see the following message on the console:
 
 .. code-block:: console
 
@@ -186,12 +177,14 @@ You should see the following message:
 Debugging
 =========
 
-Access gdb with the following make command:
+You can debug an application in the usual way.  Here is an example for the
+:ref:`hello_world` application.
 
-.. code-block:: console
-
-   $ make BOARD=stm32f4_disco debug
-
+.. zephyr-app-commands::
+   :zephyr-app: samples/hello_world
+   :board: stm32f4_disco
+   :maybe-skip-config:
+   :goals: debug
 
 .. _STM32F4DISCOVERY website:
    http://www.st.com/en/evaluation-tools/stm32f4discovery.html

--- a/boards/arm/stm32l496g_disco/doc/stm32l496g_disco.rst
+++ b/boards/arm/stm32l496g_disco/doc/stm32l496g_disco.rst
@@ -189,62 +189,50 @@ Programming and Debugging
 Flashing
 ========
 
-STM32L496G Discovery board includes an ST-LINK/V2-1 embedded debug tool interface.
-This interface is not supported by the openocd version 0.9 included by the Zephyr SDK v0.9,
-use openocd v0.10.0 from the openocd-stm32 project on GitHub to get the minimum set of scripts
-needed to flash and debug STM32 development boards.
+STM32L496G Discovery board includes an ST-LINK/V2-1 embedded debug
+tool interface.  This interface is supported by openocd version
+v0.10.0, which has been available since Zephyr SDK v0.9.2.
 
-.. code-block:: console
-
-   $ git clone  https://github.com/erwango/openocd-stm32.git
-
-Then follow instructions in README.md
-
+Applications for the ``stm32l496g_disco`` board configuration can be
+built and flashed in the usual way (see :ref:`build_an_application`
+and :ref:`application_run` for more details).
 
 Flashing an application to STM32L496G Discovery
 -----------------------------------------------
 
-The sample application :ref:`hello_world` is being used in this tutorial:
-
-To build the Zephyr kernel and application, enter:
-
-.. code-block:: console
-
-   $ cd <zephyr_root_path>
-   $ source zephyr-env.sh
-   $ cd $ZEPHYR_BASE/samples/hello_world/
-   $ make BOARD=stm32l496g_disco
-
-Connect the STM32L496G Discovery to your host computer using the USB port.
-Then, enter the following command:
-
-.. code-block:: console
-
-   $ cd <openocd-stm32_path>
-   $ stm32_flsh l4 $ZEPHYR_BASE/samples/hello_world/outdir/stm32l496g_disco/zephyr.bin
-
-Run a serial host program to connect with your Discovery board.
+Connect the STM32L496G Discovery to your host computer using the USB
+port, then run a serial host program to connect with your Discovery
+board. For example:
 
 .. code-block:: console
 
    $ minicom -D /dev/ttyACM0
 
-You should see the following message:
+Then, build and flash in the usual way. Here is an example for the
+:ref:`hello_world` application.
+
+.. zephyr-app-commands::
+   :zephyr-app: samples/hello_world
+   :board: stm32l496g_disco
+   :goals: build flash
+
+You should see the following message on the console:
 
 .. code-block:: console
 
    $ Hello World! arm
 
-
 Debugging
 =========
 
-Access gdb with the following make command:
+You can debug an application in the usual way.  Here is an example for the
+:ref:`hello_world` application.
 
-.. code-block:: console
-
-   $ cd <openocd-stm32_path>
-   $ stm32_dbg l4 $ZEPHYR_BASE/samples/hello_world/outdir/stm32l496g_disco/zephyr.elf
+.. zephyr-app-commands::
+   :zephyr-app: samples/hello_world
+   :board: stm32l496g_disco
+   :maybe-skip-config:
+   :goals: debug
 
 .. _STM32L496G Discovery website:
    http://www.st.com/en/evaluation-tools/32l496gdiscovery.html

--- a/boards/arm/usb_kw24d512/doc/usb_kw24d512.rst
+++ b/boards/arm/usb_kw24d512/doc/usb_kw24d512.rst
@@ -125,23 +125,20 @@ Flashing
 ========
 
 The Segger J-Link firmware does not support command line flashing, therefore
-the ``make flash`` build target is not supported.
+the usual ``flash`` build target is not supported.
 
 Debugging
 =========
 
 This example uses the :ref:`hello_world` sample with the
-:ref:`nxp_opensda_jlink` tools. Use the ``make debug`` build target to build
-your Zephyr application, invoke the J-Link GDB server, attach a GDB client, and
-program your Zephyr application to flash. It will leave you at a gdb prompt.
+:ref:`nxp_opensda_jlink` tools. This builds the Zephyr application,
+invokes the J-Link GDB server, attaches a GDB client, and programs the
+application to flash. It will leave you at a gdb prompt.
 
-.. code-block:: console
-
-   $ cd <zephyr_root_path>
-   $ . zephyr-env.sh
-   $ cd samples/hello_world/
-   $ make BOARD=usb_kw24d512 debug
-
+.. zephyr-app-commands::
+   :zephyr-app: samples/hello_world
+   :board: usb_kw24d512
+   :goals: debug
 
 In a second terminal, open telnet:
 

--- a/boards/arm/v2m_beetle/doc/v2m_beetle.rst
+++ b/boards/arm/v2m_beetle/doc/v2m_beetle.rst
@@ -231,20 +231,13 @@ to `CMSIS-DAP Website`_.
 Flashing an application to V2M Beetle
 -------------------------------------
 
-The sample application :ref:`hello_world` is being used in this tutorial:
+You can build applications in the usual way. Here is an example for
+the :ref:`hello_world` application.
 
-.. code-block:: console
-
-   $ZEPHYR_BASE/samples/hello_world
-
-To build the Zephyr kernel and application, enter:
-
-.. code-block:: console
-
-   $ cd $ZEPHYR_BASE
-   $ . zephyr-env.sh
-   $ cd $ZEPHYR_BASE/samples/hello_world/
-   $ make BOARD=v2m_beetle
+.. zephyr-app-commands::
+   :zephyr-app: samples/hello_world
+   :board: v2m_beetle
+   :goals: build flash
 
 Connect the V2M Beetle to your host computer using the USB port and you should
 see a USB connection which exposes a Mass Storage (MBED) and a USB Serial Port.

--- a/boards/nios2/altera_max10/doc/board.rst
+++ b/boards/nios2/altera_max10/doc/board.rst
@@ -145,11 +145,18 @@ Flashing
 
 Flashing Kernel into UFM
 ------------------------
-This is as simple as:
 
-.. code-block:: console
+The usual ``flash`` target will work with the ``altera_max10`` board
+configuration. Here is an example for the :ref:`hello_world`
+application.
 
-   $ make flash
+.. zephyr-app-commands::
+   :zephyr-app: samples/hello_world
+   :board: altera_max10
+   :goals: flash
+
+Refer to :ref:`build_an_application` and :ref:`application_run` for
+more details.
 
 This provisions the Zephyr kernel and the CPU configuration onto the board,
 using the scripts/support/quartus-flash.py script. After it completes the kernel
@@ -170,11 +177,12 @@ the following config options are disabled:
    CONFIG_XIP=n
    CONFIG_INCLUDE_RESET_VECTOR=n
 
-Then, after building your kernel, push it into device's RAM:
+Then, after building your kernel, push it into device's RAM by running
+this from the build directory:
 
 .. code-block:: console
 
-   $ nios2-download --go outdir/zephyr.elf
+   $ nios2-download --go zephyr/zephyr.elf
 
 If you have a console session running (either minicom or nios2-terminal) you
 should see the application's output. There are additional arguments you can pass
@@ -191,18 +199,17 @@ Flash Memory (UFM), or load an image over the JTAG using GDB.
 Debugging With UFM Flashed Image
 --------------------------------
 
-This can be accomplished with the "make debug" build target:
+You can debug an application in the usual way.  Here is an example.
+
+.. zephyr-app-commands::
+   :zephyr-app: tests/crypto/test_sha256
+   :board: altera_max10
+   :goals: debug
+
+You will see output similar to the following:
 
 .. code-block:: console
 
-   $ make debug
-   make[1]: Entering directory '/projects/zephyr2'
-   make[2]: Entering directory '/projects/zephyr2/tests/crypto/test_sha256/outdir'
-     Using /projects/zephyr2 as source for kernel
-     GEN     ./Makefile
-     CHK     include/generated/version.h
-     CHK     misc/generated/configs.c
-     CHK     include/generated/offsets.h
    Nios II GDB server running on port 14777
    Ignoring --stop option because --tcpport also specified
    Python Exception <type 'exceptions.ImportError'> No module named gdb:
@@ -254,12 +261,12 @@ To start debugging manually:
 
    nios2-gdb-server --tcpport 1234 --stop --reset-target
 
-And then connect with GDB:
+And then connect with GDB from the build directory:
 
 
 .. code-block:: console
 
-   nios2-poky-elf-gdb  outdir/zephyr.elf -ex "target remote :1234"
+   nios2-poky-elf-gdb  zephyr/zephyr.elf -ex "target remote :1234"
 
 Debugging With JTAG Flashed Image
 ---------------------------------
@@ -285,11 +292,11 @@ nios2-configure-sof. You can leave this process running.
    $ nios2-gdb-server --tcpport 1234 --tcppersist --init-cache --reset-target
 
 Build your Zephyr kernel, and load it into a GDB built for Nios II (included in
-the Zephyr SDK):
+the Zephyr SDK) from the build directory:
 
 .. code-block:: console
 
-   $ nios2-poky-elf-gdb outdir/zephyr.elf
+   $ nios2-poky-elf-gdb zephyr/zephyr.elf
 
 Then connect to the GDB server:
 

--- a/boards/xtensa/esp32/doc/esp32.rst
+++ b/boards/xtensa/esp32/doc/esp32.rst
@@ -92,9 +92,21 @@ of ESP-IDF:
 Flashing
 ========
 
-Issuing ``make BOARD=esp32 flash`` should work as usual.  Environment
-variables can be set to set the serial port device, baud rate, and
-other options.  Please refer to the following table for details.
+The usual ``flash`` target will work with the ``esp32`` board
+configuration. Here is an example for the :ref:`hello_world`
+application.
+
+.. zephyr-app-commands::
+   :zephyr-app: samples/hello_world
+   :board: esp32
+   :goals: flash
+
+Refer to :ref:`build_an_application` and :ref:`application_run` for
+more details.
+
+Environment variables can be set to set the serial port device, baud
+rate, and other options.  Please refer to the following table for
+details.
 
 +----------------+---------------+
 | Variable       | Default value |

--- a/boards/xtensa/qemu_xtensa/doc/board.rst
+++ b/boards/xtensa/qemu_xtensa/doc/board.rst
@@ -15,9 +15,10 @@ Programming and Debugging
 Use this configuration to run basic Zephyr applications and kernel tests in the QEMU
 emulated environment, for example, with the :ref:`synchronization_sample`:
 
-.. code-block:: console
-
-        $ make -C samples/synchronization BOARD=qemu_xtensa run
+.. zephyr-app-commands::
+   :zephyr-app: samples/synchronization
+   :board: qemu_xtensa
+   :goals: run
 
 This will build an image with the synchronization sample app, boot it using
 QEMU, and display the following console output:

--- a/boards/xtensa/xt-sim/doc/xt-sim.rst
+++ b/boards/xtensa/xt-sim/doc/xt-sim.rst
@@ -151,10 +151,9 @@ The linker script should be named ``linker.ld`` and placed in the directory
 Configuring build
 =================
 
-.. code-block:: console
-
-    $ cd tests/kernel/test_build
-    $ make menuconfig
+.. zephyr-app-commands::
+   :zephyr-app: tests/kernel/test_build
+   :goals: menuconfig
 
 Below is an example of usage for typical configuration:
 
@@ -183,11 +182,10 @@ Compiling and running
 The Xtensa executable can be run in the simulator either with a standalone core,
 or with a core connected to simulated peripherals.
 
-Use make to build and run as follows:
+Build and run as follows:
 
-.. code-block:: console
-
-    $ make run
+.. zephyr-app-commands::
+   :goals: run
 
 References
 **********

--- a/doc/extensions/zephyr/application.py
+++ b/doc/extensions/zephyr/application.py
@@ -175,10 +175,10 @@ class ZephyrAppCommandsDirective(Directive):
         content = []
         content.extend([
             '$ cmake{}{}{} {}'.format(board_arg, conf_arg, gen_args,
-            source_dir)])
+                                      source_dir)])
         if not compact:
             content.extend(['',
-                '# Now run make on the generated build system:'])
+                            '# Now run make on the generated build system:'])
         if 'build' in goals:
             content.append('$ make{}'.format(build_args))
         if 'flash' in goals:
@@ -208,10 +208,10 @@ class ZephyrAppCommandsDirective(Directive):
         content = []
         content.extend([
             '$ cmake -GNinja{}{}{} {}'.format(board_arg, conf_arg, gen_args,
-            source_dir)])
+                                              source_dir)])
         if not compact:
-            content.extend([ '',
-                '# Now run ninja on the generated build system:'])
+            content.extend(['',
+                            '# Now run ninja on the generated build system:'])
         if 'build' in goals:
             content.append('$ ninja{}'.format(build_args))
         if 'flash' in goals:

--- a/doc/extensions/zephyr/application.py
+++ b/doc/extensions/zephyr/application.py
@@ -181,14 +181,10 @@ class ZephyrAppCommandsDirective(Directive):
                             '# Now run make on the generated build system:'])
         if 'build' in goals:
             content.append('$ make{}'.format(build_args))
-        if 'flash' in goals:
-            content.append('$ make flash')
-        if 'debug' in goals:
-            content.append('$ make debug')
-        if 'debugserver' in goals:
-            content.append('$ make debugserver')
-        if 'run' in goals:
-            content.append('$ make run')
+        for goal in goals:
+            if goal == 'build':
+                continue
+            content.append('$ make {}'.format(goal))
         return content
 
     def _generate_ninja(self, **kwargs):
@@ -214,14 +210,10 @@ class ZephyrAppCommandsDirective(Directive):
                             '# Now run ninja on the generated build system:'])
         if 'build' in goals:
             content.append('$ ninja{}'.format(build_args))
-        if 'flash' in goals:
-            content.append('$ ninja flash')
-        if 'debug' in goals:
-            content.append('$ ninja debug')
-        if 'debugserver' in goals:
-            content.append('$ ninja debugserver')
-        if 'run' in goals:
-            content.append('$ ninja run')
+        for goal in goals:
+            if goal == 'build':
+                continue
+            content.append('$ ninja {}'.format(goal))
         return content
 
 


### PR DESCRIPTION
Convert the ARM boards' usage of "make" commands to cmake using zephyr-app-commands.

With x86 done, this leaves ARC, NIOS II, RISC V 32, and XTensa. That's actually not very much work, since those arches don't have very many boards. That will come next, and boards/ will be converted.

Note that there are a few cases where "make" commands were deliberately left when building other tools.