### PR TITLE
net: http: Add error status string to HTTP server error

### DIFF
--- a/include/net/http_app.h
+++ b/include/net/http_app.h
@@ -944,13 +944,14 @@ int http_send_flush(struct http_ctx *ctx, void *user_send_data);
  *
  * @param ctx Http context.
  * @param code HTTP error code
+ * @param description HTTP error description
  * @param html_payload Extra payload, can be null
  * @param html_len Payload length
  *
  * @return 0 if ok, <0 if error.
  */
-int http_send_error(struct http_ctx *ctx, int code, u8_t *html_payload,
-		    size_t html_len);
+int http_send_error(struct http_ctx *ctx, int code, const char *description,
+		    u8_t *html_payload, size_t html_len);
 
 /**
  * @brief Add HTTP header field to the message.


### PR DESCRIPTION
Add status error string when sending a error message from
HTTP server to client as described in RFC 2616 ch 6.1.
Previously only error code was sent except for 400 (Bad Request).

This also fixes uninitialized memory access in error message.

Coverity-CID: 178792
Fixes #4782

Signed-off-by: Jukka Rissanen <jukka.rissanen@linux.intel.com>