### PR TITLE
cmake: Add default openocd path to flash command

### DIFF
--- a/cmake/flash/CMakeLists.txt
+++ b/cmake/flash/CMakeLists.txt
@@ -8,6 +8,7 @@ list(APPEND ENV_VARS
        BOARD_NAME=${BOARD}
               GDB=${CMAKE_GDB}
           OPENOCD=${OPENOCD}
+	  OPENOCD_DEFAULT_PATH=${TOOLCHAIN_HOME}/usr/share/openocd/scripts
   )
 
 foreach(target flash debug debugserver)


### PR DESCRIPTION
This piece of info is missing to flash stm32 boards using
STLink-V2 and openocd

Signed-off-by: Erwan Gouriou <erwan.gouriou@linao.org>