### PR TITLE
Bluetooth: Mesh: Avoid using 64-bit storage & math for beacons

### DIFF
--- a/subsys/bluetooth/host/mesh/net.h
+++ b/subsys/bluetooth/host/mesh/net.h
@@ -43,7 +43,7 @@ struct bt_mesh_friend_cred {
 };
 
 struct bt_mesh_subnet {
-	s64_t beacon_sent;        /* Time stamp of last sent beacon */
+	u32_t beacon_sent;        /* Timestamp of last sent beacon */
 	u8_t  beacons_last;       /* Number of beacons during last
 				   * observation window
 				   */


### PR DESCRIPTION
It's in practice impossible for the time between two beacons to be
more than 50 hours (the approximate wrap-around time for a 32-bit
millisecond timer), so we can use a 32-bit timestamp instead of a
64-bit one for the beacon tracking.

Signed-off-by: Johan Hedberg <johan.hedberg@intel.com>