### PR TITLE
Bluetooth: Mesh: Fix ignoring prohibited ReceiveWindow value

### DIFF
--- a/subsys/bluetooth/host/mesh/lpn.c
+++ b/subsys/bluetooth/host/mesh/lpn.c
@@ -406,6 +406,11 @@ int bt_mesh_lpn_friend_offer(struct bt_mesh_net_rx *rx,
 		return 0;
 	}
 
+	if (!msg->recv_win) {
+		BT_WARN("Prohibited ReceiveWindow value");
+		return -EINVAL;
+	}
+
 	frnd_counter = sys_be16_to_cpu(msg->frnd_counter);
 
 	BT_DBG("recv_win %u queue_size %u sub_list_size %u rssi %d counter %u",


### PR DESCRIPTION
According to the Mesh Spec value 0x00 of ReceiveWindow parameter is
prohibited. This is needed to pass MESH/NODE/FRND/LPN/BI-03-C.

Signed-off-by: Johan Hedberg <johan.hedberg@intel.com>