### PR TITLE
cmake: provide aliases for zephyr build commands

### DIFF
--- a/zephyr-env.sh
+++ b/zephyr-env.sh
@@ -65,5 +65,20 @@ zephyr_answer_file=~/zephyr-env_install.bash
 }
 unset zephyr_answer_file
 zephyr_answer_file=~/.zephyrrc
+zaliases="\n#Zephyr build aliases
+\nzcmake () { rm -rf builds/\$1 && mkdir -p builds/\$1 && cd builds/\$1 
+&& cmake -DBOARD=\$1 ../.. && make \${@:2} && cd ../..; }
+\nzmake () { cd builds/\$1 && make \${@:2} && cd ../..; }
+\nzclean () { rm -rf builds/* ; }"
+if [ -f ${zephyr_answer_file} ]; then
+        if ! grep "#Zephyr build aliases" $zephyr_answer_file > /dev/null; then
+                echo -e $zaliases >> $zephyr_answer_file
+        fi;
+else
+        echo -e $zaliases > $zephyr_answer_file
+fi
 [ -f ${zephyr_answer_file} ] &&  . ${zephyr_answer_file};
+unset zaliases
 unset zephyr_answer_file
+
+


### PR DESCRIPTION
With introduction of cmake, I felt annoying having 4 commands when we used to have one to build.
Following discussion during cmake PR review, here is a proposal to provide short set of aliases for usual build commands, and maybe avoid some basic build issues.

I introduced "builds" subdir to ease full build directories cleaning. I could have use a prefix such as build_<board>, but having a 'builds' subdir does the same thing, is safer and easier to manipulate with in line commands.
Aliases are populated once for all in ~/zephyrrc file when sourcing zephy-env.sh 

Provide zcmake, zmake and zclean aliases to ~/.zephyrrc file
Binaries are build under builds/<board>
Usage:
zcmake <board> <flash/debug .. KOPTION>: clean build
zcake <board> <flash/debug .. KOPTION>: make
zclean: erase builds dir

This is purely based on my day to day usage and then might not fit all needs.
It does not intend to replace official commands as it's better for users to learn full commands. 