### PR TITLE
cmake: Fail when zephyr_sources() is called on a directory

### DIFF
--- a/cmake/extensions.cmake
+++ b/cmake/extensions.cmake
@@ -47,6 +47,11 @@ function(zephyr_sources)
     else()
       set(path ${CMAKE_CURRENT_SOURCE_DIR}/${arg})
     endif()
+
+    if(IS_DIRECTORY ${path})
+      message(FATAL_ERROR "zephyr_sources() was called on a directory")
+    endif()
+
     target_sources(zephyr PRIVATE ${path})
   endforeach()
 endfunction()


### PR DESCRIPTION
https://github.com/zephyrproject-rtos/zephyr/issues/4864 revealed that
calling zephyr_sources() on a directory will silently omit the
directory. This is a clear user error and should be immediately
flagged as such.

Signed-off-by: Sebastian Boe <sebastian.boe@nordicsemi.no>