### PR TITLE
net: shell: Ping command needs target host set

### DIFF
--- a/subsys/net/ip/net_shell.c
+++ b/subsys/net/ip/net_shell.c
@@ -1905,6 +1905,11 @@ int net_shell_cmd_ping(int argc, char *argv[])
 		host = argv[2];
 	}
 
+	if (!host) {
+		printk("Target host missing\n");
+		return 0;
+	}
+
 	ret = _ping_ipv6(host);
 	if (!ret) {
 		goto wait_reply;


### PR DESCRIPTION
The ping command was not checking if the user gave target
host as a parameter. This would lead to NULL pointer access.

Fixes #4827

Signed-off-by: Jukka Rissanen <jukka.rissanen@linux.intel.com>