### PR TITLE
new HTTP API bugfixes

### DIFF
--- a/include/net/http_app.h
+++ b/include/net/http_app.h
@@ -767,7 +767,7 @@ static inline int http_client_send_get_req(struct http_ctx *http_ctx,
 		.method = HTTP_GET,
 		.url = url,
 		.host = host,
-		.protocol = " " HTTP_PROTOCOL HTTP_CRLF,
+		.protocol = " " HTTP_PROTOCOL,
 		.header_fields = extra_header_fields,
 	};
 

--- a/samples/net/http_client/src/main.c
+++ b/samples/net/http_client/src/main.c
@@ -160,7 +160,7 @@ static int do_sync_http_req(struct http_ctx *ctx,
 
 	req.method = method;
 	req.url = url;
-	req.protocol = " " HTTP_PROTOCOL HTTP_CRLF;
+	req.protocol = " " HTTP_PROTOCOL;
 
 	NET_INFO("[%d] Send %s", count, url);
 
@@ -295,7 +295,7 @@ static int do_async_http_req(struct http_ctx *ctx,
 
 	req.method = method;
 	req.url = url;
-	req.protocol = " " HTTP_PROTOCOL HTTP_CRLF;
+	req.protocol = " " HTTP_PROTOCOL;
 
 	k_sem_init(&waiter.wait, 0, 1);
 

--- a/subsys/net/lib/http/http_app_client.c
+++ b/subsys/net/lib/http/http_app_client.c
@@ -38,6 +38,9 @@
 #define HTTP_CONTENT_LEN   "Content-Length"
 #define HTTP_CONT_LEN_SIZE 6
 
+/* Default network activity timeout in seconds */
+#define HTTP_NETWORK_TIMEOUT	K_SECONDS(CONFIG_HTTP_CLIENT_NETWORK_TIMEOUT)
+
 int client_reset(struct http_ctx *ctx)
 {
 	http_parser_init(&ctx->http.parser, HTTP_RESPONSE);
@@ -235,7 +238,7 @@ int http_client_send_req(struct http_ctx *ctx,
 
 	ctx->http.rsp.cb = cb;
 
-	ret = net_app_connect(&ctx->app_ctx, timeout);
+	ret = net_app_connect(&ctx->app_ctx, HTTP_NETWORK_TIMEOUT);
 	if (ret < 0) {
 		NET_DBG("Cannot connect to server (%d)", ret);
 		return ret;
@@ -244,7 +247,7 @@ int http_client_send_req(struct http_ctx *ctx,
 	/* We might wait longer than timeout if the first connection
 	 * establishment takes long time (like with HTTPS)
 	 */
-	if (k_sem_take(&ctx->http.connect_wait, timeout)) {
+	if (k_sem_take(&ctx->http.connect_wait, HTTP_NETWORK_TIMEOUT)) {
 		NET_DBG("Connection timed out");
 		ret = -ETIMEDOUT;
 		goto out;

--- a/subsys/net/lib/http/http_app_client.c
+++ b/subsys/net/lib/http/http_app_client.c
@@ -123,7 +123,6 @@ int http_request(struct http_ctx *ctx, struct http_request *req, s32_t timeout,
 
 	if (req->payload && req->payload_size) {
 		char content_len_str[HTTP_CONT_LEN_SIZE];
-		int i;
 
 		ret = snprintk(content_len_str, HTTP_CONT_LEN_SIZE,
 			       "%u", req->payload_size);
@@ -143,17 +142,10 @@ int http_request(struct http_ctx *ctx, struct http_request *req, s32_t timeout,
 			goto out;
 		}
 
-		for (i = 0; i < req->payload_size;) {
-			ret = http_send_chunk(ctx,
-					      req->payload + i,
-					      req->payload_size - i,
-					      user_data);
-			if (ret < 0) {
-				NET_ERR("Cannot send data to peer (%d)", ret);
-				return ret;
-			}
-
-			i += ret;
+		ret = http_prepare_and_send(ctx, req->payload,
+					    req->payload_size, user_data);
+		if (ret < 0) {
+			goto out;
 		}
 	} else {
 		ret = http_add_header(ctx, HTTP_EOF, user_data);


### PR DESCRIPTION
- fixup http_client sample and include which still has CRLF being appended to protocol in places
- honor the CONFIG_HTTP_CLIENT_NETWORK_TIMEOUT setting in net_app_client.c
- remove the HTTP client chunked payload processing as it's currently broken and not compatible with Content-Length header setting