### PR TITLE
syscalls: clean up warnings when building unit tests

### DIFF
--- a/include/toolchain/common.h
+++ b/include/toolchain/common.h
@@ -108,8 +108,18 @@
 
 /* Additionally used as a sentinel by gen_syscalls.py to identify what
  * functions are system calls
+ *
+ * Note POSIX unit tests don't still generate the system call stubs, so
+ * until https://github.com/zephyrproject-rtos/zephyr/issues/5006 is
+ * fixed via possibly #4174, we introduce this hack -- which will
+ * disallow us to test system calls in POSIX unit testing (currently
+ * not used).
  */
+#ifndef ZTEST_UNITTEST
 #define __syscall static inline
+#else
+#define __syscall
+#endif /* #ifndef ZTEST_UNITTEST */
 
 #ifndef BUILD_ASSERT
 /* compile-time assertion that makes the build fail */


### PR DESCRIPTION
Unit testing (BOARD == unit_testing) doesn't need the system call
definitions. Because we foward declare with __syscall them as "static
inline" (from common.h), the compilers will complain that the
definition is missing.

Change to only define __syscall as "static inline" if we are not
builing a unit test to avoid said warnings.

Signed-off-by: Inaky Perez-Gonzalez <inaky.perez-gonzalez@intel.com>