### PR TITLE
doc: restore doc build filtering of warnings

### DIFF
--- a/.shippable.yml
+++ b/.shippable.yml
@@ -41,7 +41,7 @@ build:
             echo "Building a Pull Request";
             echo "- Building Documentation";
             echo "Commit range:" ${COMMIT_RANGE}
-            make htmldocs
+            make htmldocs > doc.warnings 2>&1;
             if [ -s doc/doc.warnings ]; then
               echo " => New documentation warnings/errors";
             fi;

--- a/doc/Makefile
+++ b/doc/Makefile
@@ -79,8 +79,8 @@ kconfig: scripts/genrest/genrest.py
 prep: doxy content kconfig
 
 html: content kconfig
-	$(Q)$(SPHINXBUILD) -t $(DOC_TAG) -b html $(ALLSPHINXOPTS) $(BUILDDIR)/html 2>&1 | tee doc.log;
-	$(Q)./scripts/filter-doc-log.sh doc.log > doc.warnings 2>&1;
+	-$(Q)$(SPHINXBUILD) -t $(DOC_TAG) -b html $(ALLSPHINXOPTS) $(BUILDDIR)/html > doc.log 2>&1;
+	$(Q)./scripts/filter-doc-log.sh doc.log
 	@rm -rf samples
 	@rm -rf boards
 


### PR DESCRIPTION
PR #4875 caused previously filtered warning messages to display
even though they're "known" messages that were intended to be
filtered out of the doc build output.  We only want to display
"unknown" messages from the doc building step.

Problem that PR #4875 attempted to fix (I think) was when the
sphinx-build step fails with an error, make does not continue
with the next step in the list of make commands (and that step
would have displayed the error message sphinx-build encountered).

By prefixing the sphinx-build step with a "-", we tell make to
continue in the presence of errors, and the filter-doc-log.sh
script on the next line can write out any "unknown" messages.

Signed-off-by: David B. Kinder <david.b.kinder@intel.com>