### PR TITLE
samples: net: sockets: Reinstate POSIX Makefiles.

### DIFF
--- a/samples/net/sockets/dumb_http_server/Makefile.posix
+++ b/samples/net/sockets/dumb_http_server/Makefile.posix
@@ -1,0 +1,7 @@
+# This makefile builds socket_echo sample for POSIX system, like Linux
+#
+# Before using this Makefile, run Zephyr build process once to generate
+# include files.
+
+socket_dumb_http: src/socket_dumb_http.c
+	$(CC) $^ -o $@

--- a/samples/net/sockets/echo/Makefile.posix
+++ b/samples/net/sockets/echo/Makefile.posix
@@ -1,0 +1,4 @@
+# This makefile builds socket_echo sample for POSIX system, like Linux
+
+socket_echo: src/socket_echo.c
+	$(CC) $^ -o $@

--- a/samples/net/sockets/echo_async/Makefile.posix
+++ b/samples/net/sockets/echo_async/Makefile.posix
@@ -1,0 +1,4 @@
+# This makefile builds sample for POSIX system, like Linux
+
+socket_echo: src/socket_echo.c
+	$(CC) $^ -o $@

--- a/samples/net/sockets/http_get/Makefile.posix
+++ b/samples/net/sockets/http_get/Makefile.posix
@@ -1,0 +1,4 @@
+# This makefile builds the sample for a POSIX system, like Linux
+
+http_get: src/http_get.c
+	$(CC) $^ -o $@


### PR DESCRIPTION
All current socket samples as one of the points show portability to
POSIX platforms, and provide POSIX makefiles to let user build such
a version of application easily. These Makefiles were lost during
CMake conversion.

Signed-off-by: Paul Sokolovsky <paul.sokolovsky@linaro.org>