### PR TITLE
samples: dump_http_server: Change where the .inc file is written

### DIFF
--- a/samples/net/sockets/dumb_http_server/CMakeLists.txt
+++ b/samples/net/sockets/dumb_http_server/CMakeLists.txt
@@ -4,11 +4,7 @@ project(NONE)
 FILE(GLOB app_sources src/*.c)
 target_sources(app PRIVATE ${app_sources})
 
-# Write the generated file into the include/generated directory, which
-# is already in the system path
-set(gen_dir ${ZEPHYR_BINARY_DIR}/include/generated/)
-
-generate_inc_file_for_target(app src/response_small.html.bin ${gen_dir}/response_small.html.bin.inc)
-generate_inc_file_for_target(app src/response_big.html.bin   ${gen_dir}/response_big.html.bin.inc)
+generate_inc_file_for_target(app src/response_small.html.bin src/response_small.html.bin.inc)
+generate_inc_file_for_target(app src/response_big.html.bin   src/response_big.html.bin.inc)
 
 include($ENV{ZEPHYR_BASE}/samples/net/common/common.cmake)

--- a/samples/net/sockets/dumb_http_server/src/socket_dumb_http.c
+++ b/samples/net/sockets/dumb_http_server/src/socket_dumb_http.c
@@ -29,9 +29,9 @@
 
 static const char content[] = {
 #if USE_BIG_PAYLOAD
-    #include <response_big.html.bin.inc>
+    #include "response_big.html.bin.inc"
 #else
-    #include <response_small.html.bin.inc>
+    #include "response_small.html.bin.inc"
 #endif
 };
 


### PR DESCRIPTION
KBuild would write the .inc file to the source directory, this was
changed during the CMake migration because whenever possible it should
be avoided to write files outside of the build directory.

But Makefile.posix assumes that these files are generated in the
source directory so we need to keep generating them there for now.

Signed-off-by: Sebastian Boe <sebastian.boe@nordicsemi.no>