### PR TITLE
cmake: Remove the PREBUILT_HOST_TOOLS variable

### DIFF
--- a/cmake/app/boilerplate.cmake
+++ b/cmake/app/boilerplate.cmake
@@ -76,14 +76,6 @@ execute_process(
   OUTPUT_FILE ${ZEPHYR_BINARY_DIR}/include/generated/syscall_macros.h
   )
 
-if(NOT PREBUILT_HOST_TOOLS)
-  set(PREBUILT_HOST_TOOLS $ENV{PREBUILT_HOST_TOOLS})
-  set(PREBUILT_HOST_TOOLS ${PREBUILT_HOST_TOOLS} CACHE PATH "")
-  if("${CMAKE_HOST_SYSTEM_NAME}" STREQUAL "Windows")
-    set(PREBUILT_HOST_TOOLS $ENV{ZEPHYR_BASE}/scripts/prebuilt)
-  endif()
-endif()
-
 if(NOT ZEPHYR_GCC_VARIANT)
   set(ZEPHYR_GCC_VARIANT $ENV{ZEPHYR_GCC_VARIANT})
 endif()

--- a/cmake/host-tools.cmake
+++ b/cmake/host-tools.cmake
@@ -1,9 +1,5 @@
 include($ENV{ZEPHYR_BASE}/cmake/host-tools-${ZEPHYR_GCC_VARIANT}.cmake OPTIONAL)
 
-if(PREBUILT_HOST_TOOLS)
-  list(APPEND CMAKE_PROGRAM_PATH ${PREBUILT_HOST_TOOLS}/kconfig)
-endif()
-
 # Search for the must-have program dtc on PATH and in
 # TOOLCHAIN_HOME. Usually DTC will be provided by an SDK, but for
 # SDK-less projects like gccarmemb, it is up to the user to install


### PR DESCRIPTION
The PREBUILT_HOST_TOOLS variable was used during the CMake migration
but is no longer documented or needed. As the docs demonstrate, adding
tools to path is an easy way to find prebuilt host tools.

Signed-off-by: Sebastian Boe <sebastian.boe@nordicsemi.no>