### PR TITLE
Revert "boards: 96b_carbon: Enable NET_L2_BT by default"

### DIFF
--- a/boards/arm/96b_carbon/Kconfig.defconfig
+++ b/boards/arm/96b_carbon/Kconfig.defconfig
@@ -32,17 +32,4 @@ config SPI_LEGACY_API
 
 endif # BT
 
-if NETWORKING
-
-# BT is the only onboard network iface, so use it for IP networking
-# if it's enabled
-
-config NET_L2_BT
-	default y
-
-config NET_L2_BT_ZEP1656
-	default y
-
-endif # NETWORKING
-
 endif # BOARD_96B_CARBON


### PR DESCRIPTION
This reverts commit 6019bcaee58fd1362a18a32763d7ccadfa991a0d.

Bluetooth is no more the only network interface since Network
over usb is now operational (CDC-ECM). This fix network samples
with CDC-ECM where bluetooth is considered as the default iface.