### PR TITLE
documentation changes and clarfications

### DIFF
--- a/doc/application/application.rst
+++ b/doc/application/application.rst
@@ -449,12 +449,13 @@ corresponds to :file:`zephyr.elf` file:
 
 .. code-block:: bash
 
-   $ gdb --tui zephyr.elf
+   $ ..../path/to/gdb --tui zephyr.elf
 
 .. note::
 
    The GDB version on the development system might not support the --tui
-   option.
+   option. Please make sure you use the GDB binary from the SDK which
+   corrosponds to the toolchain that has been used to build the binary.
 
 If you are not using a .gdbinit file, issue the following command inside GDB to
 connect to the remote GDB server on port 1234:

--- a/doc/contribute/contribute_non-apache.rst
+++ b/doc/contribute/contribute_non-apache.rst
@@ -34,7 +34,7 @@ these additional steps must be followed:
 
 #. Complete a README for your code component and add it to your source
    code pull request (PR).  A recommended README template can be found in
-   :file:`doc/contributing/code_component_README` (and included
+   :file:`doc/contribute/code_component_README` (and included
    `below`_ for reference)
 
 #. The Zephyr Technical Steering Committee (TSC) will evaluate the code


### PR DESCRIPTION
- installed GDB on host might not be compatible with the binary generated
by Zephyr. Mention that we need to use the gdb that corrosponds to the
toolchain being used.

- Fix path to non APL code README

Fixes #4312

Signed-off-by: Anas Nashif <anas.nashif@intel.com>