### PR TITLE
tests/kernel/pipe: fix uninitialized semaphore

### DIFF
--- a/include/kernel.h
+++ b/include/kernel.h
@@ -3532,23 +3532,28 @@ struct k_mem_pool {
 
 #define _MPOOL_HAVE_LVL(max, min, l) (((max) >> (2*(l))) >= (min) ? 1 : 0)
 
-#define _MPOOL_LVLS(maxsz, minsz)		\
-	(_MPOOL_HAVE_LVL(maxsz, minsz, 0) +	\
-	_MPOOL_HAVE_LVL(maxsz, minsz, 1) +	\
-	_MPOOL_HAVE_LVL(maxsz, minsz, 2) +	\
-	_MPOOL_HAVE_LVL(maxsz, minsz, 3) +	\
-	_MPOOL_HAVE_LVL(maxsz, minsz, 4) +	\
-	_MPOOL_HAVE_LVL(maxsz, minsz, 5) +	\
-	_MPOOL_HAVE_LVL(maxsz, minsz, 6) +	\
-	_MPOOL_HAVE_LVL(maxsz, minsz, 7) +	\
-	_MPOOL_HAVE_LVL(maxsz, minsz, 8) +	\
-	_MPOOL_HAVE_LVL(maxsz, minsz, 9) +	\
-	_MPOOL_HAVE_LVL(maxsz, minsz, 10) +	\
-	_MPOOL_HAVE_LVL(maxsz, minsz, 11) +	\
-	_MPOOL_HAVE_LVL(maxsz, minsz, 12) +	\
-	_MPOOL_HAVE_LVL(maxsz, minsz, 13) +	\
-	_MPOOL_HAVE_LVL(maxsz, minsz, 14) +	\
-	_MPOOL_HAVE_LVL(maxsz, minsz, 15))
+#define __MPOOL_LVLS(maxsz, minsz)		\
+	(_MPOOL_HAVE_LVL((maxsz), (minsz), 0) +	\
+	_MPOOL_HAVE_LVL((maxsz), (minsz), 1) +	\
+	_MPOOL_HAVE_LVL((maxsz), (minsz), 2) +	\
+	_MPOOL_HAVE_LVL((maxsz), (minsz), 3) +	\
+	_MPOOL_HAVE_LVL((maxsz), (minsz), 4) +	\
+	_MPOOL_HAVE_LVL((maxsz), (minsz), 5) +	\
+	_MPOOL_HAVE_LVL((maxsz), (minsz), 6) +	\
+	_MPOOL_HAVE_LVL((maxsz), (minsz), 7) +	\
+	_MPOOL_HAVE_LVL((maxsz), (minsz), 8) +	\
+	_MPOOL_HAVE_LVL((maxsz), (minsz), 9) +	\
+	_MPOOL_HAVE_LVL((maxsz), (minsz), 10) +	\
+	_MPOOL_HAVE_LVL((maxsz), (minsz), 11) +	\
+	_MPOOL_HAVE_LVL((maxsz), (minsz), 12) +	\
+	_MPOOL_HAVE_LVL((maxsz), (minsz), 13) +	\
+	_MPOOL_HAVE_LVL((maxsz), (minsz), 14) +	\
+	_MPOOL_HAVE_LVL((maxsz), (minsz), 15))
+
+#define _MPOOL_MINBLK sizeof(sys_dnode_t)
+
+#define _MPOOL_LVLS(max, min)		\
+	__MPOOL_LVLS((max), (min) >= _MPOOL_MINBLK ? (min) : _MPOOL_MINBLK)
 
 /* Rounds the needed bits up to integer multiples of u32_t */
 #define _MPOOL_LBIT_WORDS_UNCLAMPED(n_max, l) \

--- a/tests/kernel/pipe/pipe_api/src/test_pipe_contexts.c
+++ b/tests/kernel/pipe/pipe_api/src/test_pipe_contexts.c
@@ -30,8 +30,8 @@ K_PIPE_DEFINE(kpipe, PIPE_LEN, 4);
 static struct k_pipe pipe;
 
 static K_THREAD_STACK_DEFINE(tstack, STACK_SIZE);
-static struct k_thread tdata;
-static struct k_sem end_sema;
+struct k_thread tdata;
+K_SEM_DEFINE(end_sema, 0, 1);
 
 static void tpipe_put(struct k_pipe *ppipe)
 {
@@ -100,8 +100,6 @@ static void tThread_block_put(void *p1, void *p2, void *p3)
 
 static void tpipe_thread_thread(struct k_pipe *ppipe)
 {
-	k_sem_init(&end_sema, 0, 1);
-
 	/**TESTPOINT: thread-thread data passing via pipe*/
 	k_tid_t tid = k_thread_create(&tdata, tstack, STACK_SIZE,
 				      tThread_entry, ppipe, NULL, NULL,


### PR DESCRIPTION
The end_sema k_sem was only initialized on one of the several paths
that used it, leading to some crazy clobber-the-run-queue behavior
that was dependent on linkage order (see the linked bug) when end_sema
and the pipe object were made non-static..

Adding a k_sem_init() call fixes the corrupt issue, but really the
right thing is to use the DEFINE macro, so do that instead.  Note that
that the initializer changes the linkage order too (by putting the
semaphore in a separate segment), so... yeah, it's actually impossible
to prove that this patch in isolation resolves the issue seen without
manual validation.

Fixes #4366

Signed-off-by: Andy Ross <andrew.j.ross@intel.com>