### PR TITLE
subsys/random: Add _ASSERT() test on returned device_get_binding

### DIFF
--- a/subsys/random/rand32_entropy_device.c
+++ b/subsys/random/rand32_entropy_device.c
@@ -21,6 +21,10 @@ u32_t sys_rand32_get(void)
 		 * if the whole operation isn't atomic.
 		 */
 		dev = device_get_binding(CONFIG_ENTROPY_NAME);
+		__ASSERT((dev != NULL),
+			"Device driver for %s (CONFIG_ENTROPY_NAME) not found. "
+			"Check your build configuration!",
+			CONFIG_ENTROPY_NAME);
 		atomic_set(&entropy_driver, (atomic_t)(uintptr_t)dev);
 	}
 


### PR DESCRIPTION
If there is a build setup problem where a device driver has not been
setup for the entropy driver then the call to device_get_binding()
will return a NULL value and the code will continue to use this NULL
value. The result is a hard fault later in code execution.

Note that CONFIG_ASSERT is by default off so one has to turn this
configuration on to catch this problem.

Signed-off-by: David Leach <david.leach@nxp.com>