### PR TITLE
cmake: Fix build of entropy driver for MCUX TRNG

### DIFF
--- a/drivers/entropy/CMakeLists.txt
+++ b/drivers/entropy/CMakeLists.txt
@@ -1,5 +1,5 @@
 zephyr_sources_ifdef(CONFIG_ENTROPY_ESP32_RNG          entropy_esp32.c)
 zephyr_sources_ifdef(CONFIG_ENTROPY_MCUX_RNGA          entropy_mcux_rnga.c)
-zephyr_sources_ifdef(CONFIG_ENTROPY_MCUX_TNGA          entropy_mcux_trng.c)
+zephyr_sources_ifdef(CONFIG_ENTROPY_MCUX_TRNG          entropy_mcux_trng.c)
 zephyr_sources_ifdef(CONFIG_ENTROPY_STM32_RNG          entropy_stm32_rng.c)
 zephyr_sources_ifdef(CONFIG_USERSPACE                  entropy_handlers.c)


### PR DESCRIPTION
Signed-off-by: David Leach <david.leach@nxp.com>