### PR TITLE
stack_unused_space_get: account for sentinel

### DIFF
--- a/include/misc/stack.h
+++ b/include/misc/stack.h
@@ -20,6 +20,13 @@ static inline size_t stack_unused_space_get(const char *stack, size_t size)
 	size_t unused = 0;
 	int i;
 
+#ifdef CONFIG_STACK_SENTINEL
+	/* First 4 bytes of the stack buffer reserved for the sentinel
+	 * value, it won't be 0xAAAAAAAA for thread stacks.
+	 */
+	stack += 4;
+#endif
+
 	/* TODO Currently all supported platforms have stack growth down and
 	 * there is no Kconfig option to configure it so this always build
 	 * "else" branch.  When support for platform with stack direction up


### PR DESCRIPTION
This function wasn't working on systems that enabled the stack
sentinel as the first 4 bytes of the stack buffer contain the
sentinel value for thread stacks.

Signed-off-by: Andrew Boie <andrew.p.boie@intel.com>