### PR TITLE
_setup_new_thread: fix crash on ARM

### DIFF
--- a/kernel/thread.c
+++ b/kernel/thread.c
@@ -273,6 +273,12 @@ void _setup_new_thread(struct k_thread *new_thread,
 	/* Any given thread has access to itself */
 	k_object_access_grant(new_thread, new_thread);
 
+#ifdef CONFIG_ARCH_HAS_CUSTOM_SWAP_TO_MAIN
+	/* _current may be null if the dummy thread is not used */
+	if (!_current) {
+		return;
+	}
+#endif
 	/* New threads inherit any memory domain membership by the parent */
 	if (_current->mem_domain_info.mem_domain) {
 		k_mem_domain_add_thread(_current->mem_domain_info.mem_domain,


### PR DESCRIPTION
On arches which have custom logic to do the initial swap into
the main thread, _current may be NULL. This happens when
instantiating the idle and main threads.

If this is the case, skip checks for memory domain and object
permission inheritance, in this case there is never anything to
inherit.

Signed-off-by: Andrew Boie <andrew.p.boie@intel.com>