### PR TITLE
doc: fix misspelling in docs

### DIFF
--- a/doc/application/application.rst
+++ b/doc/application/application.rst
@@ -455,7 +455,7 @@ corresponds to :file:`zephyr.elf` file:
 
    The GDB version on the development system might not support the --tui
    option. Please make sure you use the GDB binary from the SDK which
-   corrosponds to the toolchain that has been used to build the binary.
+   corresponds to the toolchain that has been used to build the binary.
 
 If you are not using a .gdbinit file, issue the following command inside GDB to
 connect to the remote GDB server on port 1234:


### PR DESCRIPTION
Signed-off-by: David B. Kinder <david.b.kinder@intel.com>