### PR TITLE
tests: timer_monotonic: Migrate legacy test to ztest

### DIFF
--- a/tests/kernel/timer/timer_monotonic/prj.conf
+++ b/tests/kernel/timer/timer_monotonic/prj.conf
@@ -1,0 +1,1 @@
+CONFIG_ZTEST=y

--- a/tests/kernel/timer/timer_monotonic/src/main.c
+++ b/tests/kernel/timer/timer_monotonic/src/main.c
@@ -6,6 +6,7 @@
 
 #include <zephyr.h>
 #include <tc_util.h>
+#include <ztest.h>
 
 int test_frequency(void)
 {
@@ -33,11 +34,10 @@ int test_frequency(void)
 }
 
 
-void main(void)
+void test_timer(void)
 {
 	u32_t t_last, t_now, i, errors;
 	s32_t diff;
-	int rv = TC_PASS;
 
 	errors = 0;
 
@@ -63,17 +63,13 @@ void main(void)
 		t_last = t_now;
 	}
 
-	if (errors) {
-		TC_PRINT("errors = %d\n", errors);
-		rv = TC_FAIL;
-	} else {
-		TC_PRINT("Cycle results appear to be monotonic\n");
-	}
+	zassert_false(errors, "errors = %d\n", errors);
 
-	if (test_frequency()) {
-		rv = TC_FAIL;
-	}
-
-	TC_END_REPORT(rv);
+	zassert_false(test_frequency(), "test frequency failed");
 }
 
+void test_main(void)
+{
+	ztest_test_suite(test_timer_fn, ztest_unit_test(test_timer));
+	ztest_run_test_suite(test_timer_fn);
+}


### PR DESCRIPTION
Use ztest macros and apis in legacy test to support ztest
framework.

Signed-off-by: Punit Vara <punit.vara@intel.com>