### PR TITLE
tests: subsys: dfu: mcuboot: fix return value not handling issue

### DIFF
--- a/tests/subsys/dfu/mcuboot/src/main.c
+++ b/tests/subsys/dfu/mcuboot/src/main.c
@@ -28,7 +28,8 @@ void test_bank_erase(void)
 	for (offs = FLASH_AREA_IMAGE_1_OFFSET;
 	     offs <= FLASH_AREA_IMAGE_1_OFFSET + FLASH_AREA_IMAGE_1_SIZE;
 	     offs += sizeof(temp)) {
-		flash_read(flash_dev, offs, &temp, sizeof(temp));
+		ret = flash_read(flash_dev, offs, &temp, sizeof(temp));
+		zassert_true(ret == 0, "Reading from flash");
 		if (temp != 0xFFFFFFFF) {
 			ret = flash_write_protection_set(flash_dev, false);
 			zassert_true(ret == 0, "Disabling flash protection");


### PR DESCRIPTION
Function flash_read was calling without checking return value.
(Coverity CID: 178794)
This patch cover this issue.

Signed-off-by: Andrzej Puzdrowski <andrzej.puzdrowski@nordicsemi.no>