### PR TITLE
Add string padding support to printk, and use it in the shell

### DIFF
--- a/misc/printk.c
+++ b/misc/printk.c
@@ -190,9 +190,17 @@ void _vprintk(out_func_t out, void *ctx, const char *fmt, va_list ap)
 			}
 			case 's': {
 				char *s = va_arg(ap, char *);
+				char *start = s;
 
 				while (*s)
 					out((int)(*s++), ctx);
+
+				if (padding == PAD_SPACE_AFTER) {
+					int remaining = min_width - (s - start);
+					while (remaining-- > 0) {
+						out(' ', ctx);
+					}
+				}
 				break;
 			}
 			case 'c': {

--- a/subsys/shell/shell.c
+++ b/subsys/shell/shell.c
@@ -216,7 +216,10 @@ static void print_module_commands(const int module)
 	printk("help\n");
 
 	for (i = 0; shell_module->commands[i].cmd_name; i++) {
-		printk("%s\n", shell_module->commands[i].cmd_name);
+		printk("%-28s %s\n",
+		       shell_module->commands[i].cmd_name,
+		       shell_module->commands[i].help ?
+		       shell_module->commands[i].help : "");
 	}
 }
 


### PR DESCRIPTION
One of my pet peeves with the shell code was that you'd get a list of commands with "help" but would need to type "help cmd" to see the exact parameters the command takes, even though all these help strings would easily fit on the same line. The hardcoded padding value of 28 is chosen based on the "bt" shell module's longest command name.