### PR TITLE
drivers: serial: fix CMakeLists for Atmel SoCs

### DIFF
--- a/drivers/serial/CMakeLists.txt
+++ b/drivers/serial/CMakeLists.txt
@@ -1,5 +1,4 @@
 zephyr_sources_if_kconfig(uart_altera_jtag.c)
-zephyr_sources_if_kconfig(uart_atmel_sam3.c)
 zephyr_sources_if_kconfig(uart_cc32xx.c)
 zephyr_sources_if_kconfig(uart_cmsdk_apb.c)
 zephyr_sources_if_kconfig(uart_gecko.c)
@@ -12,6 +11,7 @@ zephyr_sources_if_kconfig(uart_nsim.c)
 zephyr_sources_if_kconfig(uart_qmsi.c)
 zephyr_sources_if_kconfig(uart_riscv_qemu.c)
 zephyr_sources_if_kconfig(uart_sam.c)
+zephyr_sources_if_kconfig(usart_sam.c)
 zephyr_sources_if_kconfig(uart_stellaris.c)
 zephyr_sources_if_kconfig(uart_stm32.c)
 


### PR DESCRIPTION
- added missing usart_sam.c entry
- removed outdated uart_atmel_sam3.c entry

Signed-off-by: Piotr Mienkowski <piotr.mienkowski@gmail.com>