### PR TITLE
samples: external_lib: Build binaries in the build directory

### DIFF
--- a/samples/application_development/external_lib/CMakeLists.txt
+++ b/samples/application_development/external_lib/CMakeLists.txt
@@ -25,21 +25,23 @@ include(ExternalProject)
 # Add an external project to be able download and build the third
 # party library. In this case downloading is not necessary as it has
 # been committed to the repository.
-set(mylib_dir ${CMAKE_CURRENT_SOURCE_DIR}/mylib)
+set(mylib_src_dir   ${CMAKE_CURRENT_SOURCE_DIR}/mylib)
+set(mylib_build_dir ${CMAKE_CURRENT_BINARY_DIR}/mylib)
 ExternalProject_Add(
-  mylib_project           # Name for custom target
-  PREFIX     ${mylib_dir} # Root dir for entire project
-  SOURCE_DIR ${mylib_dir}
-  BINARY_DIR ${mylib_dir} # This particular build system is invoked from the root
+  mylib_project                 # Name for custom target
+  PREFIX     ${mylib_build_dir} # Root dir for entire project
+  SOURCE_DIR ${mylib_src_dir}
+  BINARY_DIR ${mylib_src_dir} # This particular build system is invoked from the root
   CONFIGURE_COMMAND ""    # Skip configuring the project, e.g. with autoconf
   BUILD_COMMAND
   make
+  PREFIX=${mylib_build_dir}
   CC=${CMAKE_C_COMPILER}
   CFLAGS=${external_project_cflags}
   INSTALL_COMMAND ""      # This particular build system has no install command
   )
-set(MYLIB_INCLUDE_DIR ${mylib_dir}/include)
-set(MYLIB_LIB_DIR     ${mylib_dir}/lib)
+set(MYLIB_INCLUDE_DIR ${mylib_src_dir}/include)
+set(MYLIB_LIB_DIR     ${mylib_build_dir}/lib)
 
 # Create a wrapper CMake library that our app can link with
 add_library(mylib_lib STATIC IMPORTED)

--- a/samples/application_development/external_lib/mylib/Makefile
+++ b/samples/application_development/external_lib/mylib/Makefile
@@ -4,11 +4,14 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 
+PREFIX ?= .
+OBJ_DIR ?= $(PREFIX)/obj
+LIB_DIR ?= $(PREFIX)/lib
+
 all:
-	mkdir -p obj lib
-	$(CC) -c $(CFLAGS) -Iinclude src/mylib.c -o obj/mylib.o
-	$(AR) -rcs lib/libmylib.a obj/mylib.o
+	mkdir -p $(OBJ_DIR) $(LIB_DIR)
+	$(CC) -c $(CFLAGS) -Iinclude src/mylib.c -o $(OBJ_DIR)/mylib.o
+	$(AR) -rcs $(LIB_DIR)/libmylib.a $(OBJ_DIR)/mylib.o
 
 clean:
-	rm -rf obj lib
-
+	rm -rf $(OBJ_DIR) $(LIB_DIR)


### PR DESCRIPTION
The "external" Makefile in the sample "external_lib" did not support out-of-source builds. This meant hat the working directory would get polluted with source files when the sample was built. This commit rewrites the Makefile to support out-of-source builds and updates the sample's CMakeLists.txt to
specify where the build directory should be.

The working directory is no longer polluted with untracked files when the sample is built.

This fixes #4925

Signed-off-by: Sebastian Boe <sebastian.boe@nordicsemi.no>