### PR TITLE
net: Only enable QEMU_NET_STACK with CONFIG_NET_SLIP_TAP

### DIFF
--- a/cmake/qemu/CMakeLists.txt
+++ b/cmake/qemu/CMakeLists.txt
@@ -35,7 +35,7 @@ if(EMU_PLATFORM)
   # pass data between them. The QEMU flags are not set for standalone
   # tests defined by CONFIG_NET_TEST.
   if(CONFIG_NETWORKING)
-    if(NOT CONFIG_NET_TEST)
+    if(CONFIG_NET_SLIP_TAP)
       set(QEMU_NET_STACK 1)
     endif()
   endif()


### PR DESCRIPTION
If CONFIG_NET_SLIP_TAP is not selected QEMU_NET_STACK will not work
which happen when CONFIG_NET_L2_BT is selected.

Signed-off-by: Luiz Augusto von Dentz <luiz.von.dentz@intel.com>