### PR TITLE
cmake: Added missing zephyr_sources() calls for esp32 drivers uart & I2C

### DIFF
--- a/drivers/i2c/CMakeLists.txt
+++ b/drivers/i2c/CMakeLists.txt
@@ -1,6 +1,7 @@
 zephyr_sources_ifdef(CONFIG_I2C_ATMEL_SAM3	i2c_atmel_sam3.c)
 zephyr_sources_ifdef(CONFIG_I2C_BITBANG		i2c_bitbang.c)
 zephyr_sources_ifdef(CONFIG_I2C_DW	        i2c_dw.c)
+zephyr_sources_ifdef(CONFIG_I2C_ESP32       i2c_esp32.c)
 zephyr_sources_ifdef(CONFIG_I2C_GPIO		i2c_gpio.c)
 zephyr_sources_ifdef(CONFIG_I2C_MCUX		i2c_mcux.c)
 zephyr_sources_ifdef(CONFIG_I2C_NRF5		i2c_nrf5.c)

--- a/drivers/serial/CMakeLists.txt
+++ b/drivers/serial/CMakeLists.txt
@@ -1,6 +1,7 @@
 zephyr_sources_if_kconfig(uart_altera_jtag.c)
 zephyr_sources_if_kconfig(uart_cc32xx.c)
 zephyr_sources_if_kconfig(uart_cmsdk_apb.c)
+zephyr_sources_if_kconfig(uart_esp32.c)
 zephyr_sources_if_kconfig(uart_gecko.c)
 zephyr_sources_if_kconfig(uart_mcux.c)
 zephyr_sources_if_kconfig(uart_mcux_lpuart.c)


### PR DESCRIPTION
Signed-off-by: Sebastian Boe <sebastian.boe@nordicsemi.no>