### PR TITLE
cmake: flash: Remove fake path to zephyr_flash_debug.py

### DIFF
--- a/cmake/flash/CMakeLists.txt
+++ b/cmake/flash/CMakeLists.txt
@@ -42,7 +42,7 @@ foreach(target flash debug debugserver)
       ${PYTHON_EXECUTABLE}
       $ENV{ZEPHYR_BASE}/scripts/support/zephyr_flash_debug.py
       ${target}
-      $ENV{ZEPHYR_BASE}/scripts/support/${script}
+      ${script}
       DEPENDS ${logical_target_for_zephyr_elf}
       WORKING_DIRECTORY ${APPLICATION_BINARY_DIR}
       )

--- a/scripts/support/zephyr_flash_debug.py
+++ b/scripts/support/zephyr_flash_debug.py
@@ -25,14 +25,13 @@ from runner.core import ZephyrBinaryRunner, get_env_bool_or
 #   python zephyr_flash_debug.py openocd --openocd-bin=/openocd/path ...
 #
 # For now, maintain compatibility.
-def run(shell_script_full, command, debug):
-    shell_script = path.basename(shell_script_full)
+def run(shell_script, command, debug):
     try:
         runner = ZephyrBinaryRunner.create_for_shell_script(shell_script,
                                                             command,
                                                             debug)
     except ValueError:
-        print('Unrecognized shell script {}'.format(shell_script_full),
+        print('Unrecognized shell script {}'.format(shell_script),
               file=sys.stderr)
         raise
 
@@ -45,7 +44,7 @@ if __name__ == '__main__':
     try:
         debug = get_env_bool_or('VERBOSE', False)
         if len(sys.argv) != 3 or sys.argv[1] not in commands:
-            raise ValueError('usage: {} <{}> path-to-script'.format(
+            raise ValueError('usage: {} <{}> script-name'.format(
                 sys.argv[0], '|'.join(commands)))
         run(sys.argv[2], sys.argv[1], debug)
     except Exception as e:


### PR DESCRIPTION
We append a path to the FLASH_SCRIPT/DEBUG_SCRIPT that was bogus and not
really needed by zephyr_flash_debug.py.  So lets remove it since its
just confusing.

Signed-off-by: Kumar Gala <kumar.gala@linaro.org>