### PR TITLE
tests: protection: Fix building on ARC

### DIFF
--- a/tests/kernel/mem_protect/protection/src/main.c
+++ b/tests/kernel/mem_protect/protection/src/main.c
@@ -50,6 +50,8 @@ void _SysFatalErrorHandler(unsigned int reason, const NANO_ESF *pEsf)
 
 #if defined(CONFIG_ARM)
 #define NO_EXECUTE_SUPPORT 1
+#elif defined(CONFIG_ARC)
+#define NO_EXECUTE_SUPPORT 1
 #elif defined(CONFIG_X86)
 #if defined(CONFIG_X86_PAE_MODE)
 #define NO_EXECUTE_SUPPORT 1


### PR DESCRIPTION
Added a case for ARC in the test so it builds.  ARC MPU has execute
permision bit so we can enable the NO_EXECUTE_SUPPORT testing.

Signed-off-by: Kumar Gala <kumar.gala@linaro.org>