### PR TITLE
Bluetooth: controller: Fix memq_dequeue function

### DIFF
--- a/subsys/bluetooth/controller/util/memq.c
+++ b/subsys/bluetooth/controller/util/memq.c
@@ -38,7 +38,7 @@ void *memq_peek(void *tail, void *head, void **mem)
 
 	/* if head and tail are equal, then queue empty */
 	if (head == tail) {
-		return 0;
+		return NULL;
 	}
 
 	/* pick the head link node */
@@ -58,6 +58,9 @@ void *memq_dequeue(void *tail, void **head, void **mem)
 
 	/* use memq peek to get the link and mem */
 	link = memq_peek(tail, *head, mem);
+	if (!link) {
+		return link;
+	}
 
 	/* increment the head to next link node */
 	*head = *((void **)link);


### PR DESCRIPTION
When testing memq implementation used by controller, a
missing check on NULL pointer return could lead to NULL
pointer deferencing.

Current implementation of controller and mayfly do not
by design lead to NULL pointer dereferencing, this fix
is only for correct-ness and complete-ness.

Signed-off-by: Vinayak Kariappa Chettimada <vich@nordicsemi.no>