### PR TITLE
Revert "net: pkt: Take into account MTU when adding data to a packet"

### DIFF
--- a/samples/net/echo_client/src/common.h
+++ b/samples/net/echo_client/src/common.h
@@ -49,5 +49,5 @@ void stop_tcp(void);
 
 struct net_pkt *prepare_send_pkt(struct net_app_ctx *ctx,
 				 const char *name,
-				 int expecting_len);
+				 int *expecting_len);
 void panic(const char *msg);

--- a/samples/net/echo_client/src/echo-client.c
+++ b/samples/net/echo_client/src/echo-client.c
@@ -103,22 +103,16 @@ static inline int init_app(void)
 
 struct net_pkt *prepare_send_pkt(struct net_app_ctx *ctx,
 				 const char *name,
-				 int expecting_len)
+				 int *expecting_len)
 {
 	struct net_pkt *send_pkt;
-	bool status;
 
 	send_pkt = net_app_get_net_pkt(ctx, AF_UNSPEC, K_FOREVER);
 
 	NET_ASSERT(send_pkt);
 
-	status = net_pkt_append_all(send_pkt, expecting_len, lorem_ipsum,
-				    K_FOREVER);
-	if (!status) {
-		NET_ERR("%s: cannot create send pkt", name);
-		net_pkt_unref(send_pkt);
-		return NULL;
-	}
+	*expecting_len = net_pkt_append(send_pkt, *expecting_len, lorem_ipsum,
+					K_FOREVER);
 
 	return send_pkt;
 }

--- a/samples/net/echo_client/src/tcp.c
+++ b/samples/net/echo_client/src/tcp.c
@@ -151,7 +151,7 @@ static void send_tcp_data(struct net_app_ctx *ctx,
 
 	data->received_tcp = 0;
 
-	pkt = prepare_send_pkt(ctx, data->proto, data->expecting_tcp);
+	pkt = prepare_send_pkt(ctx, data->proto, &data->expecting_tcp);
 	if (!pkt) {
 		return;
 	}

--- a/samples/net/echo_client/src/udp.c
+++ b/samples/net/echo_client/src/udp.c
@@ -146,7 +146,7 @@ static void send_udp_data(struct net_app_ctx *ctx, struct data *data)
 
 	data->expecting_udp = sys_rand32_get() % ipsum_len;
 
-	pkt = prepare_send_pkt(ctx, data->proto, data->expecting_udp);
+	pkt = prepare_send_pkt(ctx, data->proto, &data->expecting_udp);
 	if (!pkt) {
 		return;
 	}


### PR DESCRIPTION
This reverts commit 4718dac5607cbc224e78d5ab551e661f94eda950.

This causes issues with echo-client and other programs that call
net_pkt_append() function. The MTU returned is too short in practice
as we only have function in net_if for HW MTU and this functionality
needs more of IP MTU selection which is currently not available.
So reverting this atm before we can figure out better solution.

Fixes #4934

Signed-off-by: Jukka Rissanen <jukka.rissanen@linux.intel.com>