### PR TITLE
doc: add robots.txt excluding old docs from search

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -190,7 +190,7 @@ html_static_path = ['static']
 # Add any extra paths that contain custom files (such as robots.txt or
 # .htaccess) here, relative to this directory. These files are copied
 # directly to the root of the documentation.
-#html_extra_path = []
+html_extra_path = ['root']
 
 # If not '', a 'Last updated on:' timestamp is inserted at every page bottom,
 # using the given strftime format.

--- a/doc/root/robots.txt
+++ b/doc/root/robots.txt
@@ -1,0 +1,8 @@
+User-agent: *
+Disallow: /1.2.0/
+Disallow: /1.3.0/
+Disallow: /1.4.0/
+Disallow: /1.5.0/
+Disallow: /1.6.0/
+Disallow: /1.7.0/
+Disallow: /1.8.0/


### PR DESCRIPTION
Google and other search crawlers should focus on the current and
one-previous version of the documentation, so add a robots.txt to
exclude robots from older archived doc versions.  (Update this as
quarterly releases are made.)

Signed-off-by: David B. Kinder <david.b.kinder@intel.com>