### PR TITLE
doc: warnings from doxygen not being reported

### DIFF
--- a/doc/Makefile
+++ b/doc/Makefile
@@ -26,7 +26,7 @@ I18NSPHINXOPTS  = $(PAPEROPT_$(PAPER)) $(SPHINXOPTS) .
 .PHONY: help clean html dirhtml singlehtml pickle json htmlhelp qthelp devhelp epub latex latexpdf text man changes linkcheck doctest coverage gettext
 
 doxy-code:
-	$(Q)doxygen zephyr.doxyfile
+	$(Q)doxygen zephyr.doxyfile 2>&1 | tee doc.log
 
 doxy: doxy-code
 
@@ -79,7 +79,7 @@ kconfig: scripts/genrest/genrest.py
 prep: doxy content kconfig
 
 html: content kconfig
-	$(Q)$(SPHINXBUILD) -t $(DOC_TAG) -b html $(ALLSPHINXOPTS) $(BUILDDIR)/html 2>&1 | tee doc.log;
+	$(Q)$(SPHINXBUILD) -t $(DOC_TAG) -b html $(ALLSPHINXOPTS) $(BUILDDIR)/html 2>&1 | tee -a doc.log;
 	$(Q)./scripts/filter-doc-log.sh doc.log
 	@rm -rf samples
 	@rm -rf boards


### PR DESCRIPTION
While sphinx-build messages are captured to a file (and tee'd to
stdout), messages from doxygen weren't captured to the file and so were
missed as an error that needed fixing.  (You can see the message if you
run 'make htmldocs' locally and in shippable script output, but the
message filtering tool that throws an error if unexpected messages
appear, didn't get to see those.  This fixes that.

Signed-off-by: David B. Kinder <david.b.kinder@intel.com>