### PR TITLE
cmake: s/CONFIG_I2C_STM32_V1x/CONFIG_I2C_STM32_V1/

### DIFF
--- a/drivers/i2c/CMakeLists.txt
+++ b/drivers/i2c/CMakeLists.txt
@@ -9,7 +9,7 @@ zephyr_sources_ifdef(CONFIG_I2C_QMSI_SS		i2c_qmsi_ss.c)
 zephyr_sources_ifdef(CONFIG_I2C_SAM_TWI     i2c_sam_twi.c)
 zephyr_sources_ifdef(CONFIG_I2C_SBCON		i2c_sbcon.c)
 
-zephyr_sources_ifdef(CONFIG_I2C_STM32_V1x
+zephyr_sources_ifdef(CONFIG_I2C_STM32_V1
 	i2c_ll_stm32_v1.c
 	i2c_ll_stm32.c
 	)


### PR DESCRIPTION
Fix typo in build scripts for STM's I2C driver. The typo was
introduced in the cmake migration.

Discovered by Dmitry:
https://lists.zephyrproject.org/pipermail/zephyr-devel/2017-November/008383.html

Signed-off-by: Sebastian Boe <sebastian.boe@nordicsemi.no>