### PR TITLE
subsys: random: Fix semaphore initial count of xoroshiro128

### DIFF
--- a/subsys/random/rand32_xoroshiro128.c
+++ b/subsys/random/rand32_xoroshiro128.c
@@ -43,7 +43,7 @@
 static u64_t state[2];
 static bool initialized;
 
-K_SEM_DEFINE(state_sem, 0, 1);
+K_SEM_DEFINE(state_sem, 1, 1);
 
 static inline u64_t rotl(const u64_t x, int k)
 {


### PR DESCRIPTION
Fix semaphore initial count of rand32_xoroshiro128

Signed-off-by: Ramakrishna Pallala <ramakrishna.pallala@intel.com>