### PR TITLE
samples: nrf52: power_mgr:  Increase idleness for main thread

### DIFF
--- a/samples/boards/nrf52/power_mgr/src/main.c
+++ b/samples/boards/nrf52/power_mgr/src/main.c
@@ -13,7 +13,7 @@
 #include <device.h>
 #include <gpio.h>
 
-#define SECONDS_TO_SLEEP	1
+#define SECONDS_TO_SLEEP	60
 
 /* In Tickless Kernel mode, time is passed in milliseconds instead of ticks */
 #ifdef CONFIG_TICKLESS_KERNEL


### PR DESCRIPTION
Increase sleep time for main thread (1 sec to 1 minute) to keep SOC
in Low Power State for longer time. Currently nrf SOC is entering into
low power state and exiting immedately after 1 sec.
With this change SOC will wake stay in Low Power State till GPIO is
pressed or sleep time expired (whichever is earlier).

Signed-off-by: Youvedeep Singh <youvedeep.singh@intel.com>