### PR TITLE
ci: move doc.warnings up to be evaluated

### DIFF
--- a/.shippable.yml
+++ b/.shippable.yml
@@ -44,6 +44,7 @@ build:
             make htmldocs
             if [ -s doc/doc.warnings ]; then
               echo " => New documentation warnings/errors";
+              cp doc/doc.warnings doc.warnings
             fi;
             echo "- Verify commit message, coding style, doc build";
             ./scripts/ci/check-compliance.py --commits ${COMMIT_RANGE} || true;


### PR DESCRIPTION
The file is now generated under doc/, so move it up for evaluation.

Signed-off-by: Anas Nashif <anas.nashif@intel.com>