### PR TITLE
boards: olimexino_stm32: Use standard openocd.board.cmake

### DIFF
--- a/boards/arm/olimexino_stm32/board.cmake
+++ b/boards/arm/olimexino_stm32/board.cmake
@@ -1,12 +1,1 @@
-set(FLASH_SCRIPT openocd.sh)
-set(DEBUG_SCRIPT openocd.sh)
-
-set(FLASH_BASE_ADDRESS 0x08000000)
-
-set(OPENOCD_LOAD_CMD "flash write_image erase ${PROJECT_BINARY_DIR}/${KERNEL_BIN_NAME} ${FLASH_BASE_ADDRESS}")
-set(OPENOCD_VERIFY_CMD "verify_image          ${PROJECT_BINARY_DIR}/${KERNEL_BIN_NAME} ${FLASH_BASE_ADDRESS}")
-
-set_property(GLOBAL APPEND PROPERTY FLASH_SCRIPT_ENV_VARS
-  OPENOCD_LOAD_CMD
-  OPENOCD_VERIFY_CMD
-  )
+include($ENV{ZEPHYR_BASE}/boards/common/openocd.board.cmake)


### PR DESCRIPTION
olimexino_stm32 was not getting the flash base address from the Kconfig
variable.  Since the board uses DTS that will get set, so we can use the
standard openocd.board.cmake.

Signed-off-by: Kumar Gala <kumar.gala@linaro.org>