### PR TITLE
Bluetooth: Mesh: Fix enabling scanning after provisioning

### DIFF
--- a/subsys/bluetooth/host/mesh/lpn.c
+++ b/subsys/bluetooth/host/mesh/lpn.c
@@ -993,13 +993,19 @@ int bt_mesh_lpn_init(void)
 	if (lpn->state == BT_MESH_LPN_ENABLED) {
 		if (IS_ENABLED(CONFIG_BT_MESH_LPN_ESTABLISHMENT)) {
 			bt_mesh_scan_disable();
+		} else {
+			bt_mesh_scan_enable();
 		}
 
 		send_friend_req(lpn);
-	} else if (IS_ENABLED(CONFIG_BT_MESH_LPN_AUTO)) {
-		BT_DBG("Waiting %u ms for messages", LPN_AUTO_TIMEOUT);
-		lpn_set_state(BT_MESH_LPN_TIMER);
-		k_delayed_work_submit(&lpn->timer, LPN_AUTO_TIMEOUT);
+	} else {
+		bt_mesh_scan_enable();
+
+		if (IS_ENABLED(CONFIG_BT_MESH_LPN_AUTO)) {
+			BT_DBG("Waiting %u ms for messages", LPN_AUTO_TIMEOUT);
+			lpn_set_state(BT_MESH_LPN_TIMER);
+			k_delayed_work_submit(&lpn->timer, LPN_AUTO_TIMEOUT);
+		}
 	}
 
 	return 0;

--- a/subsys/bluetooth/host/mesh/main.c
+++ b/subsys/bluetooth/host/mesh/main.c
@@ -76,13 +76,10 @@ int bt_mesh_provision(const u8_t net_key[16], u16_t net_idx,
 		bt_mesh_adv_update();
 	}
 
-	/* If PB-ADV is disabled then scanning will have been disabled */
-	if (!IS_ENABLED(CONFIG_BT_MESH_PB_ADV)) {
-		bt_mesh_scan_enable();
-	}
-
 	if (IS_ENABLED(CONFIG_BT_MESH_LOW_POWER)) {
 		bt_mesh_lpn_init();
+	} else {
+		bt_mesh_scan_enable();
 	}
 
 	if (IS_ENABLED(CONFIG_BT_MESH_FRIEND)) {


### PR DESCRIPTION
There were some needed changes missing after the update to have manual
control of PB-ADV & PB-GATT provisioning bearers. E.g. the test for
CONFIG_BT_MESH_LOW_POWER in net.c was no-longer indicative of scanning
being on or not.

Do the scan enabling selection within the LPN module if LPN is
supported, or otherwise enable scanning unconditionally in
bt_mesh_provision().

Signed-off-by: Johan Hedberg <johan.hedberg@intel.com>