### PR TITLE
doc: add starter for 1.10 release notes

### DIFF
--- a/doc/release-notes-1.10.rst
+++ b/doc/release-notes-1.10.rst
@@ -1,0 +1,82 @@
+:orphan:
+
+.. _zephyr_1.10:
+
+Zephyr Kernel 1.10.0
+#####################
+
+DRAFT: We are pleased to announce the release of Zephyr kernel version 1.10.0.
+
+Major enhancements with this release include:
+
+* Integration with MCUBOOT Bootloader
+* Additional implementation of MMU/MPU support
+* Build and Configuration System (CMake)
+* Newtron Flash Filesystem (NFFS) Support
+* Increased testsuite coverage
+
+The following sections provide detailed lists of changes by component.
+
+Kernel
+******
+
+* details ...
+
+Architectures
+*************
+
+* details ...
+
+
+Boards
+******
+
+* details ...
+
+Drivers and Sensors
+*******************
+
+* details ...
+
+Networking
+**********
+
+* details ...
+
+Bluetooth
+*********
+
+* details ...
+
+Build and Infrastructure
+************************
+
+* details ...
+
+Libraries
+*********
+
+* details ...
+
+HALs
+****
+
+* details ...
+
+Documentation
+*************
+
+* details ...
+
+Tests and Samples
+*****************
+
+* details ...
+
+Issue Related Items
+*******************
+
+.. comment  List derived from Jira/GitHub Issue query: ...
+
+* :jira:`ZEP-248` - reference a (public) Jira issue
+* :github:`1234` - reference a GitHub issue


### PR DESCRIPTION
Note we've added a new Sphinx inline role for references to GitHub
issues, ``:github:`1234` `` (along with the existing inline role for Jira
issues `` :jira:`ZEP-1234` ``)

Signed-off-by: David B. Kinder <david.b.kinder@intel.com>