### PR TITLE
mimxrt1050_evk: Fix setting of JLINK_DEVICE

### DIFF
--- a/boards/arm/mimxrt1050_evk/board.cmake
+++ b/boards/arm/mimxrt1050_evk/board.cmake
@@ -10,6 +10,8 @@ if(OPENSDA_FW STREQUAL jlink)
   set_ifndef(DEBUG_SCRIPT jlink.sh)
 endif()
 
+set(JLINK_DEVICE Cortex-M7)
+
 set_property(GLOBAL APPEND PROPERTY FLASH_SCRIPT_ENV_VARS
-  JLINK_DEVICE=Cortex-M7
+  JLINK_DEVICE
   )


### PR DESCRIPTION
The '=' character was incorrectly getting passed to the JLinkGDBServer
device argument, and caused the server to fail to connect to the target.

Signed-off-by: Maureen Helm <maureen.helm@nxp.com>