### PR TITLE
net: pkt: net_pkt_append: Use only TCP MSS to cap packet size

### DIFF
--- a/subsys/net/ip/net_pkt.c
+++ b/subsys/net/ip/net_pkt.c
@@ -1194,19 +1194,8 @@ u16_t net_pkt_append(struct net_pkt *pkt, u16_t len, const u8_t *data,
 #if defined(CONFIG_NET_TCP)
 		if (ctx->tcp) {
 			max_len = ctx->tcp->send_mss;
-		} else
-#endif
-		{
-			struct net_if *iface = net_context_get_iface(ctx);
-			max_len = net_if_get_mtu(iface);
-			/* Optimize for number of jumps in the code ("if"
-			 * instead of "if/else").
-			 */
-			max_len -= NET_IPV4TCPH_LEN;
-			if (net_context_get_family(ctx) != AF_INET) {
-				max_len -= NET_IPV6TCPH_LEN - NET_IPV4TCPH_LEN;
-			}
 		}
+#endif
 	}
 
 	if (len > max_len) {


### PR DESCRIPTION
Previously, there was also check for UDP case using an interface MTU,
but that led to problems due to unclear definition of MTU in Zephyr
interfaces. The original patch assumed it's IP-level MTU, as
prescribed by RFC 791 (IPv4) and RFC 2460 (IPv6). But turns out,
it was originally intended to be a max frame size for the
underlying hardware driver (which for 6LoWPAN technologies may be
smaller than IP-level MTU).

Signed-off-by: Paul Sokolovsky <paul.sokolovsky@linaro.org>