### PR TITLE
[RFC][DNM]Pinmux configuration code generated from Device tree

### DIFF
--- a/boards/arm/disco_l475_iot1/disco_l475_iot1.dts
+++ b/boards/arm/disco_l475_iot1/disco_l475_iot1.dts
@@ -35,11 +35,15 @@
 &i2c1 {
 	status = "ok";
 	clock-frequency = <I2C_BITRATE_FAST>;
+	pinctrl-0 = <&i2c1_pins_a>;
+	pinctrl-names = "default";
 };
 
 &i2c2 {
 	status = "ok";
 	clock-frequency = <I2C_BITRATE_FAST>;
+	pinctrl-0 = <&i2c2_pins_a>;
+	pinctrl-names = "default";
 };
 
 &flash0 {

--- a/boards/arm/disco_l475_iot1/pinmux.c
+++ b/boards/arm/disco_l475_iot1/pinmux.c
@@ -12,21 +12,11 @@
 
 #include <pinmux/stm32/pinmux_stm32.h>
 
+/* Include pinmux configuration generated file */
+#include <st_stm32_pinmux_init.h>
+
 /* pin assignments for Disco L475 IOT1 board */
 static const struct pin_config pinconf[] = {
-#ifdef CONFIG_UART_STM32_PORT_1
-	{STM32_PIN_PB6, STM32L4X_PINMUX_FUNC_PB6_USART1_TX},
-	{STM32_PIN_PB7, STM32L4X_PINMUX_FUNC_PB7_USART1_RX},
-#endif	/* CONFIG_UART_STM32_PORT_1 */
-#ifdef CONFIG_I2C_1
-	{STM32_PIN_PB8, STM32L4X_PINMUX_FUNC_PB8_I2C1_SCL},
-	{STM32_PIN_PB9, STM32L4X_PINMUX_FUNC_PB9_I2C1_SDA},
-#endif /* CONFIG_I2C_1 */
-#ifdef CONFIG_I2C_2
-	/* I2C2 is used for NFC, STSAFE, ToF & MEMS sensors */
-	{STM32_PIN_PB10, STM32L4X_PINMUX_FUNC_PB10_I2C2_SCL},
-	{STM32_PIN_PB11, STM32L4X_PINMUX_FUNC_PB11_I2C2_SDA},
-#endif /* CONFIG_I2C_2 */
 #ifdef CONFIG_SPI_1
 	{STM32_PIN_PA5, STM32L4X_PINMUX_FUNC_PA5_SPI1_SCK},
 	{STM32_PIN_PA6, STM32L4X_PINMUX_FUNC_PA6_SPI1_MISO},
@@ -54,7 +44,13 @@ static int pinmux_stm32_init(struct device *port)
 {
 	ARG_UNUSED(port);
 
+	/* Parse pinconf array provided above */
 	stm32_setup_pins(pinconf, ARRAY_SIZE(pinconf));
+
+	/* Parse st_stm32_pinmux_pinconf array provided */
+	/* in dts based generated file st_stm32_pinmux_init.h */
+	stm32_setup_pins(st_stm32_pinmux_pinconf,
+			 ARRAY_SIZE(st_stm32_pinmux_pinconf));
 
 	return 0;
 }

--- a/boards/arm/frdm_k64f/pinmux.c
+++ b/boards/arm/frdm_k64f/pinmux.c
@@ -8,9 +8,17 @@
 #include <pinmux.h>
 #include <fsl_port.h>
 
+#include "pinmux/pinmux.h"
+#include "pinmux_nxp.h"
+
+/* Include pinmux configuration generated file */
+#include <nxp_kinetis_pinmux_init.h>
+
 static int frdm_k64f_pinmux_init(struct device *dev)
 {
 	ARG_UNUSED(dev);
+
+	struct device *port;
 
 #ifdef CONFIG_PINMUX_MCUX_PORTA
 	struct device *porta =
@@ -31,12 +39,6 @@ static int frdm_k64f_pinmux_init(struct device *dev)
 #ifdef CONFIG_PINMUX_MCUX_PORTE
 	struct device *porte =
 		device_get_binding(CONFIG_PINMUX_MCUX_PORTE_NAME);
-#endif
-
-#ifdef CONFIG_UART_MCUX_0
-	/* UART0 RX, TX */
-	pinmux_pin_set(portb, 16, PORT_PCR_MUX(kPORT_MuxAlt3));
-	pinmux_pin_set(portb, 17, PORT_PCR_MUX(kPORT_MuxAlt3));
 #endif
 
 #ifdef CONFIG_UART_MCUX_3
@@ -111,6 +113,30 @@ static int frdm_k64f_pinmux_init(struct device *dev)
 	pinmux_pin_set(portc, 18, PORT_PCR_MUX(kPORT_MuxAlt4));
 	pinmux_pin_set(portc, 19, PORT_PCR_MUX(kPORT_MuxAlt4));
 #endif
+
+
+	/* Parse nxp_kinetis_pinmux_instances array provided */
+	/* in dts based generated file nxp_kinetis_pinmux_instances.h */
+	/* Array holds instances_pinconfig structures which contain */
+	/* pin configuration for each pinmux instance */
+	for (int i = 0; i < ARRAY_SIZE(nxp_kinetis_pinmux_instances); i++) {
+
+		int size = nxp_kinetis_pinmux_instances[i].instance_npins;
+		const struct pin_config *pinconf =
+			nxp_kinetis_pinmux_instances[i].instance_pins;
+
+		/* For each pinmux instance, get device binding */
+		/* and set each pin individually */
+
+		port =
+		   device_get_binding(nxp_kinetis_pinmux_instances[i].instance);
+
+		for (int p = 0; p < size; p++) {
+			pinmux_pin_set(port,
+				       pinconf[p].pin_num,
+				       pinconf[p].mode);
+		}
+	}
 
 	return 0;
 }

--- a/boards/arm/frdm_k64f/pinmux_nxp.h
+++ b/boards/arm/frdm_k64f/pinmux_nxp.h
@@ -1,0 +1,18 @@
+/*
+ * Copyright (c) 2017 Linaro Limited.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+ #ifndef PINMUX_H
+ #define PINMUX_H
+
+/* Struct used to hold pinmux instances configuration  */
+struct instances_pinconfig {
+	char *instance;
+	const struct pin_config *instance_pins;
+	size_t instance_npins;
+};
+
+
+#endif /* PINMUX_H */

--- a/dts/arm/nxp/nxp_k6x.dtsi
+++ b/dts/arm/nxp/nxp_k6x.dtsi
@@ -1,6 +1,7 @@
 #include <arm/armv7-m.dtsi>
 #include <dt-bindings/clock/kinetis_sim.h>
 #include <dt-bindings/i2c/i2c.h>
+#include <dt-bindings/pinctrl/mcux-pinctrl.h>
 
 / {
 	cpus {
@@ -200,21 +201,21 @@
 			uart0_default: uart0_default {
 				rx-tx {
 					pins = <16>, <17>;
-					function = <3>;
+					function = <MCUX_FUNC_ALT_3>;
 				};
 			};
 
 			uart0_lpm: uart0_lpm {
 				rx-tx {
 					pins = <16>, <17>;
-					function = <0>;
+					function = <MCUX_FUNC_ALT_0>;
 				};
 			};
 
 			spi0_default: spi0_default {
 				miso-mosi-clk {
 					pins = <10>, <9>;
-					function = <2>;
+					function = <MCUX_FUNC_ALT_2>;
 				};
 			};
 		};

--- a/dts/arm/nxp/nxp_k6x.dtsi
+++ b/dts/arm/nxp/nxp_k6x.dtsi
@@ -189,12 +189,14 @@
 			compatible = "nxp,kinetis-pinmux";
 			reg = <0x40049000 0xd0>;
 			clocks = <&sim KINETIS_SIM_BUS_CLK 0x1038 9>;
+			label = "porta";
 		};
 
 		pinmux_b: pinmux@4004a000 {
 			compatible = "nxp,kinetis-pinmux";
 			reg = <0x4004a000 0xd0>;
 			clocks = <&sim KINETIS_SIM_BUS_CLK 0x1038 10>;
+			label = "portb";
 			uart0_default: uart0_default {
 				rx-tx {
 					pins = <16>, <17>;
@@ -221,18 +223,21 @@
 			compatible = "nxp,kinetis-pinmux";
 			reg = <0x4004b000 0xd0>;
 			clocks = <&sim KINETIS_SIM_BUS_CLK 0x1038 11>;
+			label = "portc";
 		};
 
 		pinmux_d: pinmux@4004c000 {
 			compatible = "nxp,kinetis-pinmux";
 			reg = <0x4004c000 0xd0>;
 			clocks = <&sim KINETIS_SIM_BUS_CLK 0x1038 12>;
+			label = "portd";
 		};
 
 		pinmux_e: pinmux@4004d000 {
 			compatible = "nxp,kinetis-pinmux";
 			reg = <0x4004d000 0xd0>;
 			clocks = <&sim KINETIS_SIM_BUS_CLK 0x1038 13>;
+			label = "porte";
 		};
 
 		gpioa: gpio@400ff000 {

--- a/dts/arm/nxp/nxp_kl25z.dtsi
+++ b/dts/arm/nxp/nxp_kl25z.dtsi
@@ -1,6 +1,7 @@
 #include "armv6-m.dtsi"
 #include <dt-bindings/clock/kinetis_sim.h>
 #include <dt-bindings/i2c/i2c.h>
+#include <dt-bindings/pinctrl/mcux-pinctrl.h>
 
 / {
 	cpus {

--- a/dts/arm/nxp/nxp_kw2xd.dtsi
+++ b/dts/arm/nxp/nxp_kw2xd.dtsi
@@ -136,6 +136,7 @@
 			compatible = "nxp,kinetis-pinmux";
 			reg = <0x40049000 0xd0>;
 			clocks = <&sim KINETIS_SIM_BUS_CLK 0x1038 9>;
+			label = "porta";
 
 			uart0_default: uart0_default {
 				rx-tx {
@@ -149,6 +150,7 @@
 			compatible = "nxp,kinetis-pinmux";
 			reg = <0x4004a000 0xd0>;
 			clocks = <&sim KINETIS_SIM_BUS_CLK 0x1038 10>;
+			label = "portb";
 
 			spi1_default: spi1_default {
 				miso-mosi-clk {
@@ -162,12 +164,14 @@
 			compatible = "nxp,kinetis-pinmux";
 			reg = <0x4004b000 0xd0>;
 			clocks = <&sim KINETIS_SIM_BUS_CLK 0x1038 11>;
+			label = "portc";
 		};
 
 		pinmux_d: pinmux@4004c000 {
 			compatible = "nxp,kinetis-pinmux";
 			reg = <0x4004c000 0xd0>;
 			clocks = <&sim KINETIS_SIM_BUS_CLK 0x1038 12>;
+			label = "portd";
 
 			uart2_default: uart2_default {
 				rx-tx {
@@ -181,6 +185,7 @@
 			compatible = "nxp,kinetis-pinmux";
 			reg = <0x4004d000 0xd0>;
 			clocks = <&sim KINETIS_SIM_BUS_CLK 0x1038 13>;
+			label = "porte";
 		};
 
 		gpioa: gpio@400ff000 {

--- a/dts/arm/nxp/nxp_kw2xd.dtsi
+++ b/dts/arm/nxp/nxp_kw2xd.dtsi
@@ -1,6 +1,7 @@
 #include <arm/armv7-m.dtsi>
 #include <dt-bindings/clock/kinetis_sim.h>
 #include <dt-bindings/i2c/i2c.h>
+#include <dt-bindings/pinctrl/mcux-pinctrl.h>
 
 / {
 	cpus {
@@ -141,7 +142,7 @@
 			uart0_default: uart0_default {
 				rx-tx {
 					pins = <1>, <2>;
-					function = <2>;
+					function = <MCUX_FUNC_ALT_2>;
 				};
 			};
 		};
@@ -155,7 +156,7 @@
 			spi1_default: spi1_default {
 				miso-mosi-clk {
 					pins = <17>, <16>, <11>;
-					function = <2>;
+					function = <MCUX_FUNC_ALT_2>;
 				};
 			};
 		};
@@ -176,7 +177,7 @@
 			uart2_default: uart2_default {
 				rx-tx {
 					pins = <2>, <3>;
-					function = <3>;
+					function = <MCUX_FUNC_ALT_3>;
 				};
 			};
 		};

--- a/dts/arm/nxp/nxp_kw40z.dtsi
+++ b/dts/arm/nxp/nxp_kw40z.dtsi
@@ -1,6 +1,7 @@
 #include "armv6-m.dtsi"
 #include <dt-bindings/clock/kinetis_sim.h>
 #include <dt-bindings/i2c/i2c.h>
+#include <dt-bindings/pinctrl/mcux-pinctrl.h>
 
 / {
 	cpus {
@@ -99,7 +100,7 @@
 			spi1_default: spi1_default {
 				mosi-miso-sck-pcs0 {
 					pins = <16>, <17>, <18>, <19>;
-					function = <2>;
+					function = <MCUX_FUNC_ALT_2>;
 				};
 			};
 		};
@@ -120,28 +121,28 @@
 			lpuart0_default: lpuart0_default {
 				rx-tx {
 					pins = <6>, <7>;
-					function = <4>;
+					function = <MCUX_FUNC_ALT_4>;
 				};
 			};
 
 			lpuart0_alt1: lpuart0_alt1 {
 				rx-tx {
 					pins = <17>, <18>;
-					function = <4>;
+					function = <MCUX_FUNC_ALT_4>;
 				};
 			};
 
 			lpuart0_alt2: lpuart0_alt2 {
 				rx-tx-cts-rts {
 					pins = <2>, <3>, <0>, <1>;
-					function = <4>;
+					function = <MCUX_FUNC_ALT_4>;
 				};
 			};
 
 			spi0_default: spi0_default {
 				mosi-miso-clk-pcs0 {
 					pins = <18>, <17>, <16>, <19>;
-					function = <2>;
+					function = <MCUX_FUNC_ALT_2>;
 				};
 			};
 		};

--- a/dts/arm/nxp/nxp_kw40z.dtsi
+++ b/dts/arm/nxp/nxp_kw40z.dtsi
@@ -94,6 +94,7 @@
 			compatible = "nxp,kinetis-pinmux";
 			reg = <0x40049000 0xa4>;
 			clocks = <&sim KINETIS_SIM_BUS_CLK 0x1038 9>;
+			label = "porta";
 
 			spi1_default: spi1_default {
 				mosi-miso-sck-pcs0 {
@@ -107,12 +108,14 @@
 			compatible = "nxp,kinetis-pinmux";
 			reg = <0x4004a000 0xa4>;
 			clocks = <&sim KINETIS_SIM_BUS_CLK 0x1038 10>;
+			label = "portb";
 		};
 
 		pinmux_c: pinmux@4004b000 {
 			compatible = "nxp,kinetis-pinmux";
 			reg = <0x4004b000 0xa4>;
 			clocks = <&sim KINETIS_SIM_BUS_CLK 0x1038 11>;
+			label = "portc";
 
 			lpuart0_default: lpuart0_default {
 				rx-tx {

--- a/dts/arm/nxp/nxp_kw41z.dtsi
+++ b/dts/arm/nxp/nxp_kw41z.dtsi
@@ -1,6 +1,7 @@
 #include <arm/armv6-m.dtsi>
 #include <dt-bindings/clock/kinetis_sim.h>
 #include <dt-bindings/i2c/i2c.h>
+#include <dt-bindings/pinctrl/mcux-pinctrl.h>
 
 / {
 	cpus {
@@ -99,7 +100,7 @@
 			spi1_default: spi1_default {
 				mosi-miso-sck-pcs0 {
 					pins = <16>, <17>, <18>, <19>;
-					function = <2>;
+					function = <MCUX_FUNC_ALT_2>;
 				};
 			};
 		};
@@ -120,28 +121,28 @@
 			lpuart0_default: lpuart0_default {
 				rx-tx {
 					pins = <6>, <7>;
-					function = <4>;
+					function = <MCUX_FUNC_ALT_4>;
 				};
 			};
 
 			lpuart0_alt1: lpuart0_alt1 {
 				rx-tx {
 					pins = <17>, <18>;
-					function = <4>;
+					function = <MCUX_FUNC_ALT_4>;
 				};
 			};
 
 			lpuart0_alt2: lpuart0_alt2 {
 				rx-tx-cts-rts {
 					pins = <2>, <3>, <0>, <1>;
-					function = <4>;
+					function = <MCUX_FUNC_ALT_4>;
 				};
 			};
 
 			spi0_default: spi0_default {
 				mosi-miso-clk-pcs0 {
 					pins = <18>, <17>, <16>, <19>;
-					function = <2>;
+					function = <MCUX_FUNC_ALT_2>;
 				};
 			};
 		};

--- a/dts/arm/nxp/nxp_kw41z.dtsi
+++ b/dts/arm/nxp/nxp_kw41z.dtsi
@@ -94,6 +94,7 @@
 			compatible = "nxp,kinetis-pinmux";
 			reg = <0x40049000 0xa4>;
 			clocks = <&sim KINETIS_SIM_BUS_CLK 0x1038 9>;
+			label = "porta";
 
 			spi1_default: spi1_default {
 				mosi-miso-sck-pcs0 {
@@ -107,12 +108,14 @@
 			compatible = "nxp,kinetis-pinmux";
 			reg = <0x4004a000 0xa4>;
 			clocks = <&sim KINETIS_SIM_BUS_CLK 0x1038 10>;
+			label = "portb";
 		};
 
 		pinmux_c: pinmux@4004b000 {
 			compatible = "nxp,kinetis-pinmux";
 			reg = <0x4004b000 0xa4>;
 			clocks = <&sim KINETIS_SIM_BUS_CLK 0x1038 11>;
+			label = "portc";
 
 			lpuart0_default: lpuart0_default {
 				rx-tx {

--- a/dts/arm/nxp/nxp_rt.dtsi
+++ b/dts/arm/nxp/nxp_rt.dtsi
@@ -6,6 +6,7 @@
 
 #include <arm/armv7-m.dtsi>
 #include <dt-bindings/clock/imx_ccm.h>
+#include <dt-bindings/pinctrl/mcux-pinctrl.h>
 
 / {
 	cpus {

--- a/dts/arm/st/stm32l4-pinctrl.dtsi
+++ b/dts/arm/st/stm32l4-pinctrl.dtsi
@@ -57,6 +57,18 @@
 					tx = <STM32_PIN_PB10 (STM32_PINMUX_ALT_FUNC_7 | STM32_PUSHPULL_NOPULL)>;
 				};
 			};
+			i2c1_pins_a: i2c1@0 {
+				sda_scl {
+					scl = <STM32_PIN_PB8 (STM32_PINMUX_ALT_FUNC_4 | STM32_OPENDRAIN_PULLUP)>;
+					sda = <STM32_PIN_PB9 (STM32_PINMUX_ALT_FUNC_4 | STM32_OPENDRAIN_PULLUP)>;
+				};
+			};
+			i2c2_pins_a: i2c2@0 {
+				sda_scl {
+					scl = <STM32_PIN_PB10 (STM32_PINMUX_ALT_FUNC_4 | STM32_OPENDRAIN_PULLUP)>;
+					sda = <STM32_PIN_PB11 (STM32_PINMUX_ALT_FUNC_4 | STM32_OPENDRAIN_PULLUP)>;
+				};
+			};
 		};
 	};
 };

--- a/dts/bindings/i2c/i2c.yaml
+++ b/dts/bindings/i2c/i2c.yaml
@@ -30,4 +30,9 @@ properties:
       category: required
       description: Human readable string describing the device (used by Zephyr for API name)
       generation: define
+    pinctrl-\d+:
+      type: array
+      category: optional
+      description: pinmux information for SCL, SDA
+      generation: define
 ...

--- a/dts/bindings/pinctrl/nxp,kinetis-pinmux.yaml
+++ b/dts/bindings/pinctrl/nxp,kinetis-pinmux.yaml
@@ -5,18 +5,12 @@ version: 0.1
 description: >
     This is a representation of the Kinetis Pinmux node
 
+inherits:
+    !include pinmux.yaml
+
 properties:
     compatible:
-      type: string
-      category: required
-      description: compatible strings
       constraint: "nxp,kinetis-pinmux"
-
-    reg:
-      type: int
-      description: mmio register space
-      generation: define
-      category: required
 
     clocks:
       type: array
@@ -24,9 +18,7 @@ properties:
       generation: define
       category: required
 
-cell_string: PINMUX
-
 "#cells":
-  - pin
+  - pins
   - function
 ...

--- a/dts/bindings/pinctrl/pinmux.yaml
+++ b/dts/bindings/pinctrl/pinmux.yaml
@@ -1,0 +1,27 @@
+---
+title: PINMUX Base structure
+id: pinmux
+version: 0.1
+
+description: >
+    This binding gives the base structures for all PINMUX devices
+
+properties:
+    compatible:
+      type: string
+      category: required
+      description: compatible strings
+    reg:
+      type: int
+      description: mmio register space
+      generation: define
+      category: required
+    label:
+      type: string
+      category: required
+      description: Human readable string describing the device (used by Zephyr for API name)
+      generation: define
+
+cell_string: PINMUX
+
+...

--- a/dts/bindings/pinctrl/st,stm32-pinmux.yaml
+++ b/dts/bindings/pinctrl/st,stm32-pinmux.yaml
@@ -6,23 +6,14 @@ version: 0.1
 description: >
     This binding gives a base representation of the STM32 PINMUX
 
+inherits:
+    !include pinmux.yaml
+
 properties:
     compatible:
-      type: string
-      category: required
-      description: compatible strings
       constraint: "st,stm32-pinmux"
 
-    reg:
-      type: int
-      description: mmio register space
-      generation: define
-      category: required
-
-cell_string: PINMUX
-
 "#cells":
-  - pin
-  - function
+  - pin,function
 
 ...

--- a/dts/bindings/pinctrl/ti,cc2650-pinmux.yaml
+++ b/dts/bindings/pinctrl/ti,cc2650-pinmux.yaml
@@ -6,18 +6,12 @@ version: 0.1
 description: >
     This is a representation of the TI CC2650 pinmux node
 
+inherits:
+    !include pinmux.yaml
+
 properties:
     compatible:
-      type: string
-      category: required
-      description: compatible strings
       constraint: "ti,cc2650-pinmux"
-
-    reg:
-      type: int
-      description: mmio register space
-      generation: define
-      category: required
 
 cell_string: PINMUX
 

--- a/dts/dts.cmake
+++ b/dts/dts.cmake
@@ -93,6 +93,7 @@ if(CONFIG_HAS_DTS)
     --dts ${BOARD_FAMILY}.dts_compiled
     --yaml ${PROJECT_SOURCE_DIR}/dts/bindings
     ${DTS_BOARD_FIXUP}
+    -s ${PROJECT_BINARY_DIR}/include/generated
     )
   execute_process(
     COMMAND ${CMD_EXTRACT_DTS_INCLUDES}

--- a/include/dt-bindings/pinctrl/mcux-pinctrl.h
+++ b/include/dt-bindings/pinctrl/mcux-pinctrl.h
@@ -1,0 +1,80 @@
+/*
+ * Copyright (c) 2017 Linaro Limited
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef _MCUX_PINCTRL_H_
+#define _MCUX_PINCTRL_H_
+
+
+/*! @name PCR - Pin Control Register n */
+#define PORT_PCR_PS_MASK                         (0x1U)
+#define PORT_PCR_PS_SHIFT                        (0U)
+#define PORT_PCR_PS(x)                           ((x << PORT_PCR_PS_SHIFT) & PORT_PCR_PS_MASK)
+#define PORT_PCR_PE_MASK                         (0x2U)
+#define PORT_PCR_PE_SHIFT                        (1U)
+#define PORT_PCR_PE(x)                           ((x << PORT_PCR_PE_SHIFT) & PORT_PCR_PE_MASK)
+#define PORT_PCR_SRE_MASK                        (0x4U)
+#define PORT_PCR_SRE_SHIFT                       (2U)
+#define PORT_PCR_SRE(x)                          ((x << PORT_PCR_SRE_SHIFT) & PORT_PCR_SRE_MASK)
+#define PORT_PCR_PFE_MASK                        (0x10U)
+#define PORT_PCR_PFE_SHIFT                       (4U)
+#define PORT_PCR_PFE(x)                          ((x << PORT_PCR_PFE_SHIFT) & PORT_PCR_PFE_MASK)
+#define PORT_PCR_ODE_MASK                        (0x20U)
+#define PORT_PCR_ODE_SHIFT                       (5U)
+#define PORT_PCR_ODE(x)                          ((x << PORT_PCR_ODE_SHIFT) & PORT_PCR_ODE_MASK)
+#define PORT_PCR_DSE_MASK                        (0x40U)
+#define PORT_PCR_DSE_SHIFT                       (6U)
+#define PORT_PCR_DSE(x)                          ((x << PORT_PCR_DSE_SHIFT) & PORT_PCR_DSE_MASK)
+#define PORT_PCR_MUX_MASK                        (0x700U)
+#define PORT_PCR_MUX_SHIFT                       (8U)
+#define PORT_PCR_MUX(x)                          ((x << PORT_PCR_MUX_SHIFT) & PORT_PCR_MUX_MASK)
+#define PORT_PCR_LK_MASK                         (0x8000U)
+#define PORT_PCR_LK_SHIFT                        (15U)
+#define PORT_PCR_LK(x)                           ((x << PORT_PCR_LK_SHIFT) & PORT_PCR_LK_MASK)
+#define PORT_PCR_IRQC_MASK                       (0xF0000U)
+#define PORT_PCR_IRQC_SHIFT                      (16U)
+#define PORT_PCR_IRQC(x)                         ((x << PORT_PCR_IRQC_SHIFT) & PORT_PCR_IRQC_MASK)
+#define PORT_PCR_ISF_MASK                        (0x1000000U)
+#define PORT_PCR_ISF_SHIFT                       (24U)
+#define PORT_PCR_ISF(x)                          ((x << PORT_PCR_ISF_SHIFT) & PORT_PCR_ISF_MASK)
+
+/* Alternate functions */
+#define FUNC_ALT_0                0
+#define FUNC_ALT_1                1
+#define FUNC_ALT_2                2
+#define FUNC_ALT_3                3
+#define FUNC_ALT_4                4
+#define FUNC_ALT_5                5
+#define FUNC_ALT_6                6
+#define FUNC_ALT_7                7
+#define FUNC_ALT_8                8
+#define FUNC_ALT_9                9
+#define FUNC_ALT_10               10
+#define FUNC_ALT_11               11
+#define FUNC_ALT_12               12
+#define FUNC_ALT_13               13
+#define FUNC_ALT_14               14
+#define FUNC_ALT_15               15
+
+/* Alternate functions */
+#define MCUX_FUNC_ALT_0                PORT_PCR_MUX(FUNC_ALT_0)
+#define MCUX_FUNC_ALT_1                PORT_PCR_MUX(FUNC_ALT_1)
+#define MCUX_FUNC_ALT_2                PORT_PCR_MUX(FUNC_ALT_2)
+#define MCUX_FUNC_ALT_3                PORT_PCR_MUX(FUNC_ALT_3)
+#define MCUX_FUNC_ALT_4                PORT_PCR_MUX(FUNC_ALT_4)
+#define MCUX_FUNC_ALT_5                PORT_PCR_MUX(FUNC_ALT_5)
+#define MCUX_FUNC_ALT_6                PORT_PCR_MUX(FUNC_ALT_6)
+#define MCUX_FUNC_ALT_7                PORT_PCR_MUX(FUNC_ALT_7)
+#define MCUX_FUNC_ALT_8                PORT_PCR_MUX(FUNC_ALT_8)
+#define MCUX_FUNC_ALT_9                PORT_PCR_MUX(FUNC_ALT_9)
+#define MCUX_FUNC_ALT_10               PORT_PCR_MUX(FUNC_ALT_10)
+#define MCUX_FUNC_ALT_11               PORT_PCR_MUX(FUNC_ALT_11)
+#define MCUX_FUNC_ALT_12               PORT_PCR_MUX(FUNC_ALT_12)
+#define MCUX_FUNC_ALT_13               PORT_PCR_MUX(FUNC_ALT_13)
+#define MCUX_FUNC_ALT_14               PORT_PCR_MUX(FUNC_ALT_14)
+#define MCUX_FUNC_ALT_15               PORT_PCR_MUX(FUNC_ALT_15)
+
+
+#endif	/* _MCUX_PINCTRL_H_ */

--- a/scripts/dts/extract_dts_includes.py
+++ b/scripts/dts/extract_dts_includes.py
@@ -707,15 +707,20 @@ def dict_merge(dct, merge_dct):
         else:
             dct[k] = merge_dct[k]
 
+
 def yaml_traverse_inherited(node):
     """ Recursive overload procedure inside ``node``
     ``inherits`` section is searched for and used as node base when found.
     Base values are then overloaded by node values
+    Additionally, 'id' key of 'inherited' dict is converted to 'gen_type'
     :param node:
     :return: node
     """
 
     if 'inherits' in node.keys():
+        if 'id' in node['inherits'].keys():
+            node['inherits']['gen_type'] = node['inherits']['id']
+            node['inherits'].pop('id')
         try:
             yaml_traverse_inherited(node['inherits']['inherits'])
         except KeyError:


### PR DESCRIPTION
**GOAL:**
Aim of this PR is to enable generation of pinmux configuration code based on information extracted 
from device tree files.
At compilation, board device tree is parsed and a pinmux dedicated header file is generated
under ${PROJECT_BINARY_DIR}/include/generated.
This file holds a pinmux array. It is included by board pinmux code and parsed at pinmux init.
File name and array name are based on pinmux node compatible.

**STATUS:**
- Supports single and mutli pinmux instances
- Currently tested on disco_l475_iot1 (single instance pinmux) and frdm_k64f (multi instance pinmux)
- Tested on samples/hello_world (both) and samples/sensors/hts221 (disco_l475_iot1)
- Limited to UART and I2C nodes (because  only thse nodes contrain pinmux information on above boards dts files)

**Preliminary work:**
Some preliminary work was needed to enable this:
- extract_dts_include.py: generate struct dictionary that store all decive nodes information into structs (@agross-linaro)
- yaml: Add yaml pinmux base file
- dts: nxp: add label to pinmux nodes
- nxp: move PORT_PCR_MUX to pinmux_mcux driver

**TODO:**
- So far, extract_dts_includes flies knows it deals with a pinmux node by checking "pin" string is contained in node yaml description. Instanciate a yaml information to store node type as "pinmux", so this type could be checked against.