### PR TITLE
net: sockets: Handle EINTR return from k_poll()

### DIFF
--- a/subsys/net/lib/sockets/sockets.c
+++ b/subsys/net/lib/sockets/sockets.c
@@ -298,7 +298,8 @@ static inline ssize_t zsock_recv_stream(struct net_context *ctx,
 		}
 
 		res = _k_fifo_wait_non_empty(&ctx->recv_q, timeout);
-		if (res && res != -EAGAIN) {
+		/* EAGAIN when timeout expired, EINTR when cancelled */
+		if (res && res != -EAGAIN && res != -EINTR) {
 			errno = -res;
 			return -1;
 		}


### PR DESCRIPTION
In 90b471fe4, there was a change to make k_poll() return EINTR error
if it was cancelled with k_fifo_cancel_wait(). Handle this change, or
otherwise sockets EOF handling was broken.

Signed-off-by: Paul Sokolovsky <paul.sokolovsky@linaro.org>