### PR TITLE
RFC: doc: Add some getting_started with Docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,7 @@ RUN apt-get update \
     && apt-get install -yq --no-install-recommends git cmake ninja-build gperf \
                ccache doxygen dfu-util device-tree-compiler \
                python3-ply python3-pip python3-setuptools xz-utils file \
-               wget make \
+               wget make vim-tiny \
     && rm -rf /var/lib/apt/lists/*
 
 # Zephyr SDK

--- a/Dockerfile
+++ b/Dockerfile
@@ -20,7 +20,7 @@ RUN wget -O /tmp/zephyr-setup https://github.com/zephyrproject-rtos/meta-zephyr-
     && rm /tmp/zephyr-setup
 
 # Zephyr Project repo and Python pre-requisites
-RUN git clone https://github.com/zephyrproject-rtos/zephyr.git $ZEPHYR_BASE \
+RUN git clone --depth 1 https://github.com/zephyrproject-rtos/zephyr.git $ZEPHYR_BASE \
     && cd $ZEPHYR_BASE \
     && pip3 install --user -r scripts/requirements.txt
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,30 @@
+FROM ubuntu:17.10
+
+ENV ZEPHYR_BASE=/zephyr
+ENV ZEPHYR_GCC_VARIANT=zephyr
+ENV ZEPHYR_SDK_INSTALL_DIR=/opt/zephyr-sdk
+
+# tools pre-requisites
+RUN apt-get update \
+    && apt-get install -yq --no-install-recommends git cmake ninja-build gperf \
+               ccache doxygen dfu-util device-tree-compiler \
+               python3-ply python3-pip python3-setuptools xz-utils file \
+               wget make \
+    && rm -rf /var/lib/apt/lists/*
+
+# Zephyr SDK
+ENV ZEPHYR_SDK_VERSION=0.9.2
+RUN wget -O /tmp/zephyr-setup https://github.com/zephyrproject-rtos/meta-zephyr-sdk/releases/download/${ZEPHYR_SDK_VERSION}/zephyr-sdk-${ZEPHYR_SDK_VERSION}-setup.run \
+    && chmod 755 /tmp/zephyr-setup \
+    && /tmp/zephyr-setup --quiet \
+    && rm /tmp/zephyr-setup
+
+# Zephyr Project repo and Python pre-requisites
+RUN git clone https://github.com/zephyrproject-rtos/zephyr.git $ZEPHYR_BASE \
+    && cd $ZEPHYR_BASE \
+    && pip3 install --user -r scripts/requirements.txt
+
+WORKDIR $ZEPHYR_BASE
+
+# make sure we've run the zephyr env setter
+RUN echo "source $ZEPHYR_BASE/zephyr-env.sh" >> /etc/bash.bashrc

--- a/boards/xtensa/esp32/Dockerfile
+++ b/boards/xtensa/esp32/Dockerfile
@@ -1,0 +1,28 @@
+
+# sample build:
+#
+# docker run --rm -it -w /arm svendowideit/zephyr-esp32 sh -c "cmake -DBOARD=esp32 /zephyr/samples/hello_world && make flash"
+
+FROM svendowideit/zephyr
+
+RUN apt-get update \
+    && apt-get install -yq git wget make libncurses-dev flex bison gperf python python-serial \
+    && rm -rf /var/lib/apt/lists/*
+
+ENV ZEPHYR_GCC_VARIANT="espressif"
+ENV ESP_IDF_PATH="/opt/esp-idf"
+ENV IDF_PATH="/opt/esp-idf"
+ENV ESPRESSIF_TOOLCHAIN_PATH="/opt/xtensa-esp32-elf/"
+
+# ESP-IDF SDK
+RUN git clone --recursive https://github.com/espressif/esp-idf.git $ESP_IDF_PATH \
+    && cd $ESP_IDF_PATH \
+    git checkout dc8c33892e0
+
+# xtensa esp32 toolchain
+RUN wget -O /tmp/xtensa-esp32-linux64.tgz https://dl.espressif.com/dl/xtensa-esp32-elf-linux64-1.22.0-73-ge28a011-5.2.0.tar.gz
+RUN mkdir -p $ESPRESSIF_TOOLCHAIN_PATH \
+    && cd $ESPRESSIF_TOOLCHAIN_PATH \
+    && tar --strip-components=1 -zxvf /tmp/xtensa-esp32-linux64.tgz \
+    && echo "export PATH=$PATH:${ESPRESSIF_TOOLCHAIN_PATH}bin" >> /etc/bash.bashrc
+

--- a/boards/xtensa/esp32/Dockerfile
+++ b/boards/xtensa/esp32/Dockerfile
@@ -1,7 +1,7 @@
 
 # sample build:
 #
-# docker run --rm -it -w /arm svendowideit/zephyr-esp32 sh -c "cmake -DBOARD=esp32 /zephyr/samples/hello_world && make flash"
+# docker run --rm -it --device /dev/ttyUSB0:/dev/ttyUSB0 -w /esp32 svendowideit/zephyr-esp32 sh -c "cmake -DBOARD=esp32 /zephyr/samples/hello_world && make flash"
 
 FROM svendowideit/zephyr
 

--- a/boards/xtensa/esp32/Dockerfile
+++ b/boards/xtensa/esp32/Dockerfile
@@ -17,7 +17,7 @@ ENV ESPRESSIF_TOOLCHAIN_PATH="/opt/xtensa-esp32-elf/"
 # ESP-IDF SDK
 RUN git clone --recursive https://github.com/espressif/esp-idf.git $ESP_IDF_PATH \
     && cd $ESP_IDF_PATH \
-    git checkout dc8c33892e0
+    && git checkout dc8c33892e0
 
 # xtensa esp32 toolchain
 RUN wget -O /tmp/xtensa-esp32-linux64.tgz https://dl.espressif.com/dl/xtensa-esp32-elf-linux64-1.22.0-73-ge28a011-5.2.0.tar.gz

--- a/boards/xtensa/esp32/doc/esp32.rst
+++ b/boards/xtensa/esp32/doc/esp32.rst
@@ -62,6 +62,19 @@ The toolchain is available for Linux, Windows, and Mac hosts and
 instructions to obtain and set them up are available in the ESP-IDF
 repository, using the toolchain and SDK links above.
 
+Docker container based builds
+=============================
+
+You can skip locally installing and configuring the Zephyr build system by
+using pre-made the ``svendowideit/zephyr-esp32`` Docker image.
+
+For example, to build the ``hello_world`` sample:
+
+.. code-block:: console
+
+   docker run --rm -it -w /arm svendowideit/zephyr-esp32 sh -c "cmake -DBOARD=esp32 /zephyr/samples/hello_world && make flash"
+
+
 Set up build environment
 ========================
 

--- a/boards/xtensa/esp32/doc/esp32.rst
+++ b/boards/xtensa/esp32/doc/esp32.rst
@@ -68,11 +68,11 @@ Docker container based builds
 You can skip locally installing and configuring the Zephyr build system by
 using pre-made the ``svendowideit/zephyr-esp32`` Docker image.
 
-For example, to build the ``hello_world`` sample:
+For example, to build the ``hello_world`` sample and flash it when its attached to ttyUSB0:
 
 .. code-block:: console
 
-   docker run --rm -it -w /arm svendowideit/zephyr-esp32 sh -c "cmake -DBOARD=esp32 /zephyr/samples/hello_world && make flash"
+   docker run --rm -it --device /dev/ttyUSB0:/dev/ttyUSB0 -w /esp32 svendowideit/zephyr-esp32 sh -c "cmake -DBOARD=esp32 /zephyr/samples/hello_world && make flash"
 
 
 Set up build environment

--- a/boards/xtensa/esp32/doc/esp32.rst
+++ b/boards/xtensa/esp32/doc/esp32.rst
@@ -72,7 +72,34 @@ For example, to build the ``hello_world`` sample and flash it when its attached 
 
 .. code-block:: console
 
-   docker run --rm -it --device /dev/ttyUSB0:/dev/ttyUSB0 -w /esp32 svendowideit/zephyr-esp32 sh -c "cmake -DBOARD=esp32 /zephyr/samples/hello_world && make flash"
+   $ docker run --rm -it --device /dev/ttyUSB0:/dev/ttyUSB0 -w /esp32 svendowideit/zephyr-esp32 sh -c "cmake -DBOARD=esp32 /zephyr/samples/hello_world && make flash"
+
+You can test that the ESP32 has hello_world running by attaching a serial console
+to ttyUSB0, and resetting the device:
+
+.. code-block:: console
+   $ screen /dev/ttyUSB0 115200
+   ts Jun  8 2016 00:22:57
+
+   rst:0x1 (POWERON_RESET),boot:0x13 (SPI_FAST_FLASH_BOOT)
+   ets Jun  8 2016 00:22:57
+   
+   rst:0x10 (RTCWDT_RTC_RESET),boot:0x13 (SPI_FAST_FLASH_BOOT)
+   configsip: 0, SPIWP:0xee
+   clk_drv:0x00,q_drv:0x00,d_drv:0x00,cs0_drv:0x00,hd_drv:0x00,wp_drv:0x00
+   mode:DIO, clock div:2
+   load:0x3ffb0000,len:96
+   load:0x3ffb0060,len:636
+   load:0x3ffb02e0,len:1816
+   load:0x40080000,len:1024
+   ho 0 tail 12 room 4
+   load:0x40080400,len:96
+   load:0x40080460,len:10028
+   load:0x400c0000,len:0
+   entry 0x40080688
+   ***** BOOTING ZEPHYR OS v1.9.99 - BUILD: Nov 19 2017 03:11:40 *****
+   Hello World! xtensa
+
 
 
 Set up build environment

--- a/doc/getting_started/getting_started.rst
+++ b/doc/getting_started/getting_started.rst
@@ -15,7 +15,8 @@ The Zephyr project supports these operating systems:
 * macOS
 * Windows 8.1
 
-Use the following procedures to create a new development environment.
+Use the following procedures to create a new development environment, or use
+a pre-made Docker image.
 
 .. toctree::
    :maxdepth: 1
@@ -23,8 +24,33 @@ Use the following procedures to create a new development environment.
    installation_linux.rst
    installation_mac.rst
    installation_win.rst
-   installation_docker.rst
 
+Docker based environment
+========================
+
+You can skip the OS based installation above, and the checkout and configuration
+steps by running everything in a Docker container.
+
+For example, to build and run the `hello_world` sample with x86:
+
+.. code-block:: console
+
+   $ docker run --rm -it -w /x86 svendowideit/zephyr sh -c "cmake -DBOARD=qemu_x86 /zephyr/samples/hello_world && make run"
+
+Or using the ARM cortext m4 board:
+
+.. code-block:: console
+
+   $ docker run --rm -it -w /arm svendowideit/zephyr sh -c "cmake -DBOARD=qemu_cortex_m3 /zephyr/samples/hello_world && make run"
+
+To build your own project, use a volume - in this example, I'm assuming that you're in
+the directory you want to build, with access to the code you need.
+
+.. code-block:: console
+
+   $ docker run --rm -it -w /source -v $(pwd):/source svendowideit/zephyr
+
+This will leave you in a bash shell with zephyr installed and set up ready to use.
 
 Checking Out the Source Code Anonymously
 ========================================

--- a/doc/getting_started/getting_started.rst
+++ b/doc/getting_started/getting_started.rst
@@ -23,6 +23,7 @@ Use the following procedures to create a new development environment.
    installation_linux.rst
    installation_mac.rst
    installation_win.rst
+   installation_docker.rst
 
 
 Checking Out the Source Code Anonymously


### PR DESCRIPTION
I don't know if this is desired, but it probably would have allowed me to get started faster.

I'm going to play with adding an ESP32 image to see if that works / makes sense

TODO:
* [x] use an docker-hub auto-build to build the Docker image, and use the `zephyrprojectrtos` user?


```
$ docker run --rm -it --device /dev/ttyUSB0:/dev/ttyUSB0 -w /esp32 svendowideit/zephyr-esp32 sh -c "cmake -DBOARD=esp32 /zephyr/samples/hello_world && make flash"
CMake Deprecation Warning at /zephyr/cmake/app/boilerplate.cmake:47 (cmake_policy):
  The OLD behavior for policy CMP0000 will be removed from a future version
  of CMake.

  The cmake-policies(7) manual explains that the OLD behaviors of all
  policies are deprecated and that a policy should be set to OLD only under
  specific short-term circumstances.  Projects should be ported to the NEW
  behavior and not rely on setting a policy to OLD.
Call Stack (most recent call first):
  CMakeLists.txt:3 (include)


-- Found PythonInterp: /usr/bin/python3 (found suitable version "3.6.3", minimum required is "3.4") 
-- Selected BOARD esp32
Using /zephyr/boards/xtensa/esp32/esp32_defconfig as base
Merging /zephyr/samples/hello_world/prj.conf
Merging /zephyr/tests/include/test.config
#
# configuration written to /esp32/zephyr/.config
#
-- Generating zephyr/include/generated/autoconf.h
-- Generating zephyr/include/generated/generated_dts_board.h
-- The C compiler identification is GNU 5.2.0
-- The CXX compiler identification is GNU 5.2.0
-- The ASM compiler identification is GNU
-- Found assembler: /opt/xtensa-esp32-elf/bin/xtensa-esp32-elf-gcc
-- Performing Test toolchain_is_ok
-- Performing Test toolchain_is_ok - Success
-- Performing Test check_nostartfiles
-- Performing Test check_nostartfiles - Success
-- Performing Test check_nodefaultlibs
-- Performing Test check_nodefaultlibs - Success
-- Performing Test check_nostdlib
-- Performing Test check_nostdlib - Success
-- Performing Test check_static
-- Performing Test check_static - Success
-- Performing Test check_no_pie
-- Performing Test check_no_pie - Failed
-- Performing Test check_fno_asynchronous_unwind_tables
-- Performing Test check_fno_asynchronous_unwind_tables - Success
-- Performing Test check_fno_pie
-- Performing Test check_fno_pie - Success
-- Performing Test check_fno_pic
-- Performing Test check_fno_pic - Success
-- Performing Test check_fno_strict_overflow
-- Performing Test check_fno_strict_overflow - Success
-- Performing Test check_Wno_pointer_sign
-- Performing Test check_Wno_pointer_sign - Success
-- Performing Test check_fno_stack_protector
-- Performing Test check_fno_stack_protector - Success
-- Performing Test check_Wno_unused_but_set_variable
-- Performing Test check_Wno_unused_but_set_variable - Success
-- Performing Test check_fno_reorder_functions
-- Performing Test check_fno_reorder_functions - Success
-- Performing Test check_fno_defer_pop
-- Performing Test check_fno_defer_pop - Success
-- Performing Test check_Werror_implicit_int
-- Performing Test check_Werror_implicit_int - Success
-- Performing Test check_Wl__X
-- Performing Test check_Wl__X - Success
-- Performing Test check_Wl__N
-- Performing Test check_Wl__N - Success
-- Performing Test check_Wl___gc_sections
-- Performing Test check_Wl___gc_sections - Success
-- Performing Test check_Wl___build_id_none
-- Performing Test check_Wl___build_id_none - Success
-- Performing Test check_ffunction_sections
-- Performing Test check_ffunction_sections - Success
-- Performing Test check_fdata_sections
-- Performing Test check_fdata_sections - Success
-- Performing Test check_mlongcalls
-- Performing Test check_mlongcalls - Success
-- Configuring done
-- Generating done
-- Build files have been written to: /esp32
Scanning dependencies of target offsets
[  1%] Building C object zephyr/CMakeFiles/offsets.dir/arch/xtensa/core/offsets/offsets.c.obj
[  2%] Linking C static library liboffsets.a
[  2%] Built target offsets
Scanning dependencies of target offsets_h
[  4%] Generating include/generated/offsets.h
[  4%] Built target offsets_h
Scanning dependencies of target kernel
[  5%] Building C object zephyr/kernel/CMakeFiles/kernel.dir/alert.c.obj
[  7%] Building C object zephyr/kernel/CMakeFiles/kernel.dir/device.c.obj
[  8%] Building C object zephyr/kernel/CMakeFiles/kernel.dir/errno.c.obj
[  9%] Building C object zephyr/kernel/CMakeFiles/kernel.dir/idle.c.obj
[ 11%] Building C object zephyr/kernel/CMakeFiles/kernel.dir/init.c.obj
[ 12%] Building C object zephyr/kernel/CMakeFiles/kernel.dir/mailbox.c.obj
[ 14%] Building C object zephyr/kernel/CMakeFiles/kernel.dir/mem_slab.c.obj
[ 15%] Building C object zephyr/kernel/CMakeFiles/kernel.dir/mempool.c.obj
[ 16%] Building C object zephyr/kernel/CMakeFiles/kernel.dir/msg_q.c.obj
[ 18%] Building C object zephyr/kernel/CMakeFiles/kernel.dir/mutex.c.obj
[ 19%] Building C object zephyr/kernel/CMakeFiles/kernel.dir/pipes.c.obj
[ 21%] Building C object zephyr/kernel/CMakeFiles/kernel.dir/queue.c.obj
[ 22%] Building C object zephyr/kernel/CMakeFiles/kernel.dir/sched.c.obj
[ 23%] Building C object zephyr/kernel/CMakeFiles/kernel.dir/sem.c.obj
[ 25%] Building C object zephyr/kernel/CMakeFiles/kernel.dir/stack.c.obj
[ 26%] Building C object zephyr/kernel/CMakeFiles/kernel.dir/sys_clock.c.obj
[ 28%] Building C object zephyr/kernel/CMakeFiles/kernel.dir/system_work_q.c.obj
[ 29%] Building C object zephyr/kernel/CMakeFiles/kernel.dir/thread.c.obj
[ 30%] Building C object zephyr/kernel/CMakeFiles/kernel.dir/thread_abort.c.obj
[ 32%] Building C object zephyr/kernel/CMakeFiles/kernel.dir/version.c.obj
[ 33%] Building C object zephyr/kernel/CMakeFiles/kernel.dir/work_q.c.obj
[ 35%] Building C object zephyr/kernel/CMakeFiles/kernel.dir/timer.c.obj
[ 36%] Linking C static library libkernel.a
[ 36%] Built target kernel
Scanning dependencies of target app
[ 38%] Building C object CMakeFiles/app.dir/zephyr/lib/libc/minimal/source/stdlib/atoi.c.obj
[ 39%] Building C object CMakeFiles/app.dir/zephyr/lib/libc/minimal/source/stdlib/strtol.c.obj
[ 40%] Building C object CMakeFiles/app.dir/zephyr/lib/libc/minimal/source/stdlib/strtoul.c.obj
[ 42%] Building C object CMakeFiles/app.dir/zephyr/lib/libc/minimal/source/string/strncasecmp.c.obj
[ 43%] Building C object CMakeFiles/app.dir/zephyr/lib/libc/minimal/source/string/strstr.c.obj
[ 45%] Building C object CMakeFiles/app.dir/zephyr/lib/libc/minimal/source/string/string.c.obj
[ 46%] Building C object CMakeFiles/app.dir/zephyr/lib/libc/minimal/source/stdout/prf.c.obj
[ 47%] Building C object CMakeFiles/app.dir/zephyr/lib/libc/minimal/source/stdout/stdout_console.c.obj
[ 49%] Building C object CMakeFiles/app.dir/zephyr/lib/libc/minimal/source/stdout/sprintf.c.obj
[ 50%] Building C object CMakeFiles/app.dir/zephyr/lib/libc/minimal/source/stdout/fprintf.c.obj
[ 52%] Building C object CMakeFiles/app.dir/src/main.c.obj
[ 53%] Linking C static library libapp.a
[ 53%] Built target app
Scanning dependencies of target linker_pass2_script
[ 54%] Generating linker_pass2.cmd
[ 54%] Built target linker_pass2_script
Scanning dependencies of target zephyr
[ 56%] Building C object zephyr/CMakeFiles/zephyr.dir/misc/printk.c.obj
[ 57%] Building C object zephyr/CMakeFiles/zephyr.dir/misc/generated/configs.c.obj
[ 59%] Building C object zephyr/CMakeFiles/zephyr.dir/arch/common/isr_tables.c.obj
[ 60%] Building C object zephyr/CMakeFiles/zephyr.dir/arch/xtensa/soc/esp32/soc.c.obj
[ 61%] Building C object zephyr/CMakeFiles/zephyr.dir/arch/xtensa/core/cpu_idle.c.obj
[ 63%] Building C object zephyr/CMakeFiles/zephyr.dir/arch/xtensa/core/fatal.c.obj
[ 64%] Building C object zephyr/CMakeFiles/zephyr.dir/arch/xtensa/core/irq_manage.c.obj
[ 66%] Building ASM object zephyr/CMakeFiles/zephyr.dir/arch/xtensa/core/swap.S.obj
[ 67%] Building C object zephyr/CMakeFiles/zephyr.dir/arch/xtensa/core/thread.c.obj
[ 69%] Building ASM object zephyr/CMakeFiles/zephyr.dir/arch/xtensa/core/xtensa_context.S.obj
[ 70%] Building ASM object zephyr/CMakeFiles/zephyr.dir/arch/xtensa/core/xtensa_intr_asm.S.obj
[ 71%] Building C object zephyr/CMakeFiles/zephyr.dir/arch/xtensa/core/xtensa_intr.c.obj
[ 73%] Building ASM object zephyr/CMakeFiles/zephyr.dir/arch/xtensa/core/xtensa_vectors.S.obj
[ 74%] Building ASM object zephyr/CMakeFiles/zephyr.dir/arch/xtensa/core/xt_zephyr.S.obj
[ 76%] Building ASM object zephyr/CMakeFiles/zephyr.dir/arch/xtensa/core/atomic.S.obj
[ 77%] Building C object zephyr/CMakeFiles/zephyr.dir/drivers/console/uart_console.c.obj
[ 78%] Building C object zephyr/CMakeFiles/zephyr.dir/drivers/crc/crc16_sw.c.obj
[ 80%] Building C object zephyr/CMakeFiles/zephyr.dir/drivers/gpio/gpio_esp32.c.obj
[ 81%] Building C object zephyr/CMakeFiles/zephyr.dir/drivers/i2c/i2c_esp32.c.obj
[ 83%] Building C object zephyr/CMakeFiles/zephyr.dir/drivers/pinmux/pinmux_esp32.c.obj
[ 84%] Building C object zephyr/CMakeFiles/zephyr.dir/drivers/serial/uart_esp32.c.obj
[ 85%] Building C object zephyr/CMakeFiles/zephyr.dir/drivers/timer/sys_clock_init.c.obj
[ 87%] Building C object zephyr/CMakeFiles/zephyr.dir/drivers/timer/xtensa_sys_timer.c.obj
[ 88%] Linking C static library libzephyr.a
[ 88%] Built target zephyr
Scanning dependencies of target linker_script
[ 90%] Generating linker.cmd
[ 90%] Built target linker_script
Scanning dependencies of target zephyr_prebuilt
[ 91%] Building C object zephyr/CMakeFiles/zephyr_prebuilt.dir/misc/empty_file.c.obj
[ 92%] Linking C executable zephyr_prebuilt.elf
[ 92%] Built target zephyr_prebuilt
[ 94%] Generating isr_tables.c
gen_isr_tables.py: (1074269828, 0, 32, 0, 3)
gen_isr_tables.py: spurious handler: 0x40080e84
gen_isr_tables.py: Configured interrupt routing
gen_isr_tables.py: handler    irq flags param
gen_isr_tables.py: --------------------------
gen_isr_tables.py: 0x40081430 10  0     0x0
gen_isr_tables.py: 0x400815e4 9   0     0x3ffb0048
gen_isr_tables.py: 0x400815e4 8   0     0x3ffb0054
Scanning dependencies of target kernel_elf
[ 95%] Building C object zephyr/CMakeFiles/kernel_elf.dir/misc/empty_file.c.obj
[ 97%] Building C object zephyr/CMakeFiles/kernel_elf.dir/isr_tables.c.obj
[ 98%] Linking C executable zephyr.elf
Generating zephyr.{hex,bin,lst,strip,stat,s19} from zephyr.elf for board: esp32
[ 98%] Built target kernel_elf
Scanning dependencies of target flash
[100%] Flashing esp32
Converting ELF to BIN
esptool.py v2.1
Flashing ESP32 on /dev/ttyUSB0 (921600bps)
esptool.py v2.1
Connecting....
Chip is ESP32D0WDQ6 (revision 0)
Uploading stub...
Running stub...
Stub running...
Changing baud rate to 921600
Changed.
Configuring flash size...
Auto-detected Flash size: 4MB
Flash params set to 0x0220
Wrote 16384 bytes at 0x00001000 in 0.2 seconds (525.0 kbit/s)...
Hash of data verified.

Leaving...
Hard resetting...
[100%] Built target flash

```
