### PR TITLE
net: tcp: Use larger default MSS until its negotiation is fully implemented (1.10 release workaround)

### DIFF
--- a/subsys/net/ip/tcp.h
+++ b/subsys/net/ip/tcp.h
@@ -79,7 +79,12 @@ enum net_tcp_state {
 /* RFC 1122 4.2.2.6 "If an MSS option is not received at connection
  * setup, TCP MUST assume a default send MSS of 536"
  */
-#define NET_TCP_DEFAULT_MSS   536
+/*#define NET_TCP_DEFAULT_MSS   536*/
+/* TODO: We don't yet implement full MSS negotiation in Zephyr,
+ * but have tests which rely on being able to send "full" IPv6
+ * (MTU 1280) packets, so for now set default MSS to higher value
+ */
+#define NET_TCP_DEFAULT_MSS   1280
 
 /* TCP max window size */
 #define NET_TCP_MAX_WIN   (4 * 1024)


### PR DESCRIPTION
We don't yet implement MSS negotiation for all directions (client vs
server), and yet have tests/samples which assume that it's possible
to transfer more than default MSS of 536 in a single packet.

So, until negotiation is fully implemented, bump default MSS to be
higher.

Signed-off-by: Paul Sokolovsky <paul.sokolovsky@linaro.org>