### PR TITLE
samples: net: http-server: Do not set Content-Length

### DIFF
--- a/samples/net/http_server/src/main.c
+++ b/samples/net/http_server/src/main.c
@@ -110,25 +110,11 @@ static int http_response(struct http_ctx *ctx, const char *header,
 			 const char *payload, size_t payload_len,
 			 char *str)
 {
-	char content_length[6];
 	int ret;
 
 	ret = http_add_header(ctx, header, str);
 	if (ret < 0) {
 		NET_ERR("Cannot add HTTP header (%d)", ret);
-		return ret;
-	}
-
-	ret = snprintk(content_length, sizeof(content_length), "%zd",
-		       payload_len);
-	if (ret <= 0 || ret >= sizeof(content_length)) {
-		ret = -ENOMEM;
-		return ret;
-	}
-
-	ret = http_add_header_field(ctx, "Content-Length", content_length, str);
-	if (ret < 0) {
-		NET_ERR("Cannot add Content-Length HTTP header (%d)", ret);
 		return ret;
 	}
 


### PR DESCRIPTION
As per https://tools.ietf.org/html/rfc7230#section-3.3.2:
"A sender MUST NOT send a Content-Length header field in any
message that contains a Transfer-Encoding header field."

Signed-off-by: Jukka Rissanen <jukka.rissanen@linux.intel.com>