### PR TITLE
net: pkt: Compute TX payload data length 

### DIFF
--- a/include/net/net_ip.h
+++ b/include/net/net_ip.h
@@ -179,6 +179,7 @@ extern const struct in6_addr in6addr_loopback;
 #define INADDR_ANY_INIT { { { INADDR_ANY } } }
 
 #define NET_IPV6_MTU 1280
+#define NET_IPV4_MTU  576
 
 /** IPv6 extension headers types */
 #define NET_IPV6_NEXTHDR_HBHO        0

--- a/include/net/net_pkt.h
+++ b/include/net/net_pkt.h
@@ -73,6 +73,8 @@ struct net_pkt {
 	struct net_linkaddr lladdr_src;
 	struct net_linkaddr lladdr_dst;
 
+	u16_t data_len;         /* amount of payload data that can be added */
+
 	u16_t appdatalen;
 	u8_t ll_reserve;	/* link layer header length */
 	u8_t ip_hdr_len;	/* pre-filled in order to avoid func call */


### PR DESCRIPTION
Compute the length of the TX payload that is transported in one IPv4 or IPv6 datagram taking into account UDP, ICMP or TCP headers in addition to any IPv6 extension headers added by RPL. The TCP implementation in Zephyr is known to currently carry at maximum 8 bytes of options. If the protocol is not known to the stack, assume that the application handles any protocol headers as well as the data. Also, if the net_pkt does not have a context associated, length check on the data is omitted when appending.
    
Although payload length is calculated also for TCP, the TCP MSS value is used as before.
    
Define IPv4 minimum MTU as 576 octets, See RFC 791, Sections 3.1. and 3.2.
    
Signed-off-by: Patrik Flykt <patrik.flykt@intel.com>