### PR TITLE
Group networking and display drivers API Documentation and cleanup

### DIFF
--- a/include/display/grove_lcd.h
+++ b/include/display/grove_lcd.h
@@ -11,6 +11,20 @@
 extern "C" {
 #endif
 
+/**
+ * @brief Display Drivers
+ * @defgroup display_interfaces Display Drivers
+ * @{
+ * @}
+ */
+
+/**
+ * @brief Grove display APIs
+ * @defgroup grove_display Grove display APIs
+ * @ingroup display_interfaces
+ * @{
+ */
+
 #define GROVE_LCD_NAME			"GLCD"
 
 /**
@@ -155,6 +169,11 @@ void glcd_color_set(struct device *port, u8_t r, u8_t g, u8_t b);
  *  @return Returns 0 if all passes
  */
 int glcd_initialize(struct device *port);
+
+
+/**
+ * @}
+ */
 
 #ifdef __cplusplus
 }

--- a/include/display/mb_display.h
+++ b/include/display/mb_display.h
@@ -14,6 +14,7 @@
 /**
  * @brief BBC micro:bit display APIs
  * @defgroup mb_display BBC micro:bit display APIs
+ * @ingroup display_interfaces
  * @{
  */
 

--- a/include/net/arp.h
+++ b/include/net/arp.h
@@ -24,6 +24,7 @@ extern "C" {
 /**
  * @brief Address resolution (ARP) library
  * @defgroup arp ARP Library
+ * @ingroup networking
  * @{
  */
 

--- a/include/net/buf.h
+++ b/include/net/buf.h
@@ -22,6 +22,7 @@ extern "C" {
 /**
  * @brief Network buffer library
  * @defgroup net_buf Network Buffer Library
+ * @ingroup networking
  * @{
  */
 

--- a/include/net/coap.h
+++ b/include/net/coap.h
@@ -26,7 +26,8 @@ extern "C" {
 
 /**
  * @brief COAP library
- * @defgroup COAP Library
+ * @defgroup coap COAP Library
+ * @ingroup networking
  * @{
  */
 

--- a/include/net/dhcpv4.h
+++ b/include/net/dhcpv4.h
@@ -18,6 +18,7 @@ extern "C" {
 /**
  * @brief DHCPv4
  * @defgroup dhcpv4 DHCPv4
+ * @ingroup networking
  * @{
  */
 

--- a/include/net/dns_resolve.h
+++ b/include/net/dns_resolve.h
@@ -23,6 +23,7 @@ extern "C" {
 /**
  * @brief DNS resolving library
  * @defgroup dns_resolve DNS Resolve Library
+ * @ingroup networking
  * @{
  */
 

--- a/include/net/ethernet.h
+++ b/include/net/ethernet.h
@@ -27,6 +27,7 @@ extern "C" {
 /**
  * @brief Ethernet support functions
  * @defgroup ethernet Ethernet Support Functions
+ * @ingroup networking
  * @{
  */
 

--- a/include/net/hostname.h
+++ b/include/net/hostname.h
@@ -18,6 +18,7 @@ extern "C" {
 /**
  * @brief Network hostname configuration library
  * @defgroup net_hostname Network Hostname Library
+ * @ingroup networking
  * @{
  */
 

--- a/include/net/http_app.h
+++ b/include/net/http_app.h
@@ -39,6 +39,7 @@ extern "C" {
 /**
  * @brief HTTP client and server library
  * @defgroup http HTTP Library
+ * @ingroup networking
  * @{
  */
 

--- a/include/net/http_legacy.h
+++ b/include/net/http_legacy.h
@@ -16,6 +16,7 @@ extern "C" {
 /**
  * @brief HTTP client and server library
  * @defgroup http_legacy HTTP Library
+ * @ingroup networking
  * @deprecated This library is deprecated.
  * @{
  */

--- a/include/net/ieee802154.h
+++ b/include/net/ieee802154.h
@@ -22,6 +22,7 @@ extern "C" {
 /**
  * @brief IEEE 802.15.4 library
  * @defgroup ieee802154 IEEE 802.15.4 Library
+ * @ingroup networking
  * @{
  */
 

--- a/include/net/mqtt.h
+++ b/include/net/mqtt.h
@@ -18,6 +18,7 @@ extern "C" {
 /**
  * @brief MQTT library
  * @defgroup mqtt MQTT library
+ * @ingroup networking
  * @{
  */
 

--- a/include/net/net_app.h
+++ b/include/net/net_app.h
@@ -51,6 +51,7 @@ extern "C" {
 /**
  * @brief Network application library
  * @defgroup net_app Network Application Library
+ * @ingroup networking
  * @{
  */
 

--- a/include/net/net_context.h
+++ b/include/net/net_context.h
@@ -16,6 +16,7 @@
 /**
  * @brief Application network context
  * @defgroup net_context Application network context
+ * @ingroup networking
  * @{
  */
 

--- a/include/net/net_core.h
+++ b/include/net/net_core.h
@@ -18,8 +18,16 @@ extern "C" {
 #endif
 
 /**
+ * @brief Networking
+ * @defgroup networking Networking
+ * @{
+ * @}
+ */
+
+/**
  * @brief Network core library
  * @defgroup net_core Network Core Library
+ * @ingroup networking
  * @{
  */
 

--- a/include/net/net_if.h
+++ b/include/net/net_if.h
@@ -15,6 +15,7 @@
 /**
  * @brief Network Interface abstraction layer
  * @defgroup net_if Network Interface abstraction layer
+ * @ingroup networking
  * @{
  */
 

--- a/include/net/net_ip.h
+++ b/include/net/net_ip.h
@@ -16,6 +16,7 @@
 /**
  * @brief IPv4/IPv6 primitives and helpers
  * @defgroup ip_4_6 IPv4/IPv6 primitives and helpers
+ * @ingroup networking
  * @{
  */
 

--- a/include/net/net_l2.h
+++ b/include/net/net_l2.h
@@ -21,6 +21,7 @@ extern "C" {
 /**
  * @brief Network Layer 2 abstraction layer
  * @defgroup net_l2 Network L2 Abstraction Layer
+ * @ingroup networking
  * @{
  */
 

--- a/include/net/net_linkaddr.h
+++ b/include/net/net_linkaddr.h
@@ -23,6 +23,7 @@ extern "C" {
 /**
  * @brief Network link address library
  * @defgroup net_linkaddr Network Link Address Library
+ * @ingroup networking
  * @{
  */
 

--- a/include/net/net_mgmt.h
+++ b/include/net/net_mgmt.h
@@ -19,6 +19,7 @@ extern "C" {
 /**
  * @brief Network Management
  * @defgroup net_mgmt Network Management
+ * @ingroup networking
  * @{
  */
 

--- a/include/net/net_offload.h
+++ b/include/net/net_offload.h
@@ -15,6 +15,7 @@
 /**
  * @brief Network offloading interface
  * @defgroup net_offload Network Offloading Interface
+ * @ingroup networking
  * @{
  */
 

--- a/include/net/net_pkt.h
+++ b/include/net/net_pkt.h
@@ -34,6 +34,7 @@ extern "C" {
 /**
  * @brief Network packet management library
  * @defgroup net_pkt Network Packet Library
+ * @ingroup networking
  * @{
  */
 

--- a/include/net/net_stats.h
+++ b/include/net/net_stats.h
@@ -23,6 +23,7 @@ extern "C" {
 /**
  * @brief Network statistics library
  * @defgroup net_stats Network Statistics Library
+ * @ingroup networking
  * @{
  */
 

--- a/include/net/socket.h
+++ b/include/net/socket.h
@@ -17,6 +17,7 @@
 /**
  * @brief BSD Sockets compatible API
  * @defgroup bsd_sockets BSD Sockets compatible API
+ * @ingroup networking
  * @{
  */
 

--- a/include/net/trickle.h
+++ b/include/net/trickle.h
@@ -26,6 +26,7 @@ extern "C" {
 /**
  * @brief Trickle algorithm library
  * @defgroup trickle Trickle Algorithm Library
+ * @ingroup networking
  * @{
  */
 

--- a/include/net/udp.h
+++ b/include/net/udp.h
@@ -24,6 +24,7 @@ extern "C" {
 /**
  * @brief UDP library
  * @defgroup udp UDP Library
+ * @ingroup networking
  * @{
  */
 

--- a/include/net/zoap.h
+++ b/include/net/zoap.h
@@ -27,6 +27,7 @@ extern "C" {
 /**
  * @brief COAP library
  * @defgroup zoap COAP Library
+ * @ingroup networking
  * @{
  */
 


### PR DESCRIPTION
Clean doxygen generated structure and group networking APIs under 'Networking'.
Also move display driver into their own category.