### PR TITLE
drivers: gpio: Fix typo on esp32

### DIFF
--- a/drivers/gpio/gpio_esp32.c
+++ b/drivers/gpio/gpio_esp32.c
@@ -312,7 +312,7 @@ static struct gpio_esp32_data gpio_data_pins_0_to_31 = {
 #endif
 
 #if defined(CONFIG_GPIO_ESP32_1)
-static struct gpio_esp32_data gpio_data_pins_32_to_63 = {
+static struct gpio_esp32_data gpio_data_pins_32_to_39 = {
 	.port = {
 		.write = {
 			.set_reg = (u32_t *)GPIO_OUT1_W1TS_REG,
@@ -349,7 +349,7 @@ GPIO_DEVICE_INIT(CONFIG_GPIO_ESP32_0_NAME, 0_to_31);
 #endif
 
 #if defined(CONFIG_GPIO_ESP32_1)
-GPIO_DEVICE_INIT(CONFIG_GPIO_ESP32_1_NAME, 32_to_63);
+GPIO_DEVICE_INIT(CONFIG_GPIO_ESP32_1_NAME, 32_to_39);
 #endif
 
 static void gpio_esp32_isr(void *param)
@@ -358,7 +358,7 @@ static void gpio_esp32_isr(void *param)
 	gpio_esp32_fire_callbacks(DEVICE_GET(gpio_esp32_0_to_31));
 #endif
 #if defined(CONFIG_GPIO_ESP32_1)
-	gpio_esp32_fire_callbacks(DEVICE_GET(gpio_esp32_32_to_63));
+	gpio_esp32_fire_callbacks(DEVICE_GET(gpio_esp32_32_to_39));
 #endif
 
 	ARG_UNUSED(param);


### PR DESCRIPTION
esp32 has 40 gpio ports but some ranges are wrote 32_63 instead of 32_39.

Signed-off-by: Vitor Massaru Iha <vitor@massaru.org>