### PR TITLE
doc: fix missing bluetooth mesh API docs

### DIFF
--- a/.known-issues/doc/bluetooth.conf
+++ b/.known-issues/doc/bluetooth.conf
@@ -36,3 +36,15 @@
 ^(?P=filename):(?P=lineno): WARNING: Invalid definition: Expected end of definition. \[error at [0-9]+]
 ^.*bt_gatt_read_params.__unnamed__.*
 ^[- \t]*\^
+#
+# Bluetooth mesh unnamed struct definition
+#
+^(?P<filename>[-._/\w]+/doc/api/bluetooth.rst):(?P<lineno>[0-9]+): WARNING: Invalid definition: Expected identifier in nested name. \[error at [0-9]+]
+^[ \t]*
+^[ \t]*\^
+^(?P=filename):(?P=lineno): WARNING: Invalid definition: Expected identifier in nested name. \[error at [0-9]+]
+^[ \t]*
+^[ \t]*\^
+^(?P=filename):(?P=lineno): WARNING: Invalid definition: Expected end of definition. \[error at [0-9]+]
+^.*bt_mesh_model.__unnamed__.*
+^[- \t]*\^

--- a/doc/api/bluetooth.rst
+++ b/doc/api/bluetooth.rst
@@ -4,7 +4,7 @@ Bluetooth API
 #############
 
 .. contents::
-   :depth: 1
+   :depth: 2
    :local:
    :backlinks: top
 
@@ -38,6 +38,43 @@ Mesh Profile
 
 .. doxygengroup:: bt_mesh
    :project: Zephyr
+
+Bluetooth Mesh Access Layer
+===========================
+
+.. doxygengroup:: bt_mesh_access
+   :project: Zephyr
+
+Bluetooth Mesh Configuration Client Model
+=========================================
+
+.. doxygengroup:: bt_mesh_cfg_cli
+   :project: Zephyr
+
+Bluetooth Mesh Configuration Server Model
+=========================================
+
+.. doxygengroup:: bt_mesh_cfg_srv
+   :project: Zephyr
+
+Bluetooth Mesh Health Server Model
+==================================
+
+.. doxygengroup:: bt_mesh_health_srv
+   :project: Zephyr
+
+Bluetooth Mesh Provisioning
+===========================
+
+.. doxygengroup:: bt_mesh_prov
+   :project: Zephyr
+
+Bluetooth Mesh Proxy
+====================
+
+.. doxygengroup:: bt_mesh_proxy
+   :project: Zephyr
+
 
 Universal Unique Identifiers (UUIDs)
 ************************************


### PR DESCRIPTION
Sphinx/breathe doesn't support showing nested groups, so explicitly add
the nested groups in the API documentation (for Bluetooth Mesh).

Also, added an ignore pattern for a nested unnamed type known issue.

fixes: issue #5040

Signed-off-by: David B. Kinder <david.b.kinder@intel.com>