### PR TITLE
net: sockets: Support ipv6 wildcard and loopback address

### DIFF
--- a/include/net/net_ip.h
+++ b/include/net/net_ip.h
@@ -168,6 +168,9 @@ struct net_addr {
 #define IN6ADDR_LOOPBACK_INIT { { { 0, 0, 0, 0, 0, 0, 0, \
 				0, 0, 0, 0, 0, 0, 0, 0, 1 } } }
 
+extern const struct in6_addr in6addr_any;
+extern const struct in6_addr in6addr_loopback;
+
 #define INET6_ADDRSTRLEN 46
 #define NET_IPV6_ADDR_LEN sizeof("xxxx:xxxx:xxxx:xxxx:xxxx:xxxx:xxxx:xxxx")
 #define NET_IPV4_ADDR_LEN sizeof("xxx.xxx.xxx.xxx")

--- a/subsys/net/ip/ipv6.c
+++ b/subsys/net/ip/ipv6.c
@@ -36,6 +36,10 @@
 #include "rpl.h"
 #include "net_stats.h"
 
+/* IPv6 wildcard and loopback address defined by RFC2553 */
+const struct in6_addr in6addr_any = IN6ADDR_ANY_INIT;
+const struct in6_addr in6addr_loopback = IN6ADDR_LOOPBACK_INIT;
+
 #if defined(CONFIG_NET_IPV6_ND)
 static void nd_reachable_timeout(struct k_work *work);
 #endif
@@ -626,9 +630,7 @@ fail:
 
 const struct in6_addr *net_ipv6_unspecified_address(void)
 {
-	static const struct in6_addr addr = IN6ADDR_ANY_INIT;
-
-	return &addr;
+	return &in6addr_any;
 }
 
 struct net_pkt *net_ipv6_create_raw(struct net_pkt *pkt,

--- a/tests/net/tcp/src/main.c
+++ b/tests/net/tcp/src/main.c
@@ -44,10 +44,10 @@ static struct net_context *v4_ctx;
 static struct net_context *reply_v4_ctx;
 
 static struct sockaddr_in6 any_addr6;
-static const struct in6_addr in6addr_any = IN6ADDR_ANY_INIT;
+static const struct in6_addr sin6_addr_any = IN6ADDR_ANY_INIT;
 
 static struct sockaddr_in any_addr4;
-static const struct in_addr in4addr_any = { { { 0 } } };
+static const struct in_addr sin_addr_any = INADDR_ANY_INIT;
 
 static struct in6_addr my_v6_inaddr = { { { 0x20, 0x01, 0x0d, 0xb8, 0, 0, 0, 0,
 					  0, 0, 0, 0, 0, 0, 0, 0x2a } } };
@@ -1698,10 +1698,10 @@ static bool test_init(void)
 		return false;
 	}
 
-	net_ipaddr_copy(&any_addr6.sin6_addr, &in6addr_any);
+	net_ipaddr_copy(&any_addr6.sin6_addr, &sin6_addr_any);
 	any_addr6.sin6_family = AF_INET6;
 
-	net_ipaddr_copy(&any_addr4.sin_addr, &in4addr_any);
+	net_ipaddr_copy(&any_addr4.sin_addr, &sin_addr_any);
 	any_addr4.sin_family = AF_INET;
 
 	k_sem_init(&wait_connect, 0, UINT_MAX);


### PR DESCRIPTION
Add in6addr_any and in6addr_loopback which are defined in RFC2553 Basic
Socket Interface Extensions for IPv6.

Signed-off-by: Aska Wu <aska.wu@linaro.org>