### PR TITLE
mem_domain: add arch specfic implementation for k_mem_domain_remove_thread and add_thread

### DIFF
--- a/arch/arm/core/cortex_m/mpu/arm_core_mpu.c
+++ b/arch/arm/core/cortex_m/mpu/arm_core_mpu.c
@@ -48,6 +48,11 @@ void configure_mpu_mem_domain(struct k_thread *thread)
 	arm_core_mpu_enable();
 }
 
+void _arch_mem_domain_configure(struct k_thread *thread)
+{
+	configure_mpu_mem_domain(thread);
+}
+
 int _arch_mem_domain_max_partitions_get(void)
 {
 	return arm_core_mpu_get_max_domain_partition_regions();

--- a/arch/x86/core/thread.c
+++ b/arch/x86/core/thread.c
@@ -174,7 +174,7 @@ void _x86_swap_update_page_tables(struct k_thread *incoming,
 		  * is set back to default state.
 		  */
 		_arch_mem_domain_destroy(outgoing->mem_domain_info.mem_domain);
-		_x86_mmu_mem_domain_load(incoming);
+		_arch_mem_domain_configure(incoming);
 	}
 }
 

--- a/arch/x86/core/x86_mmu.c
+++ b/arch/x86/core/x86_mmu.c
@@ -262,10 +262,16 @@ static inline void _x86_mem_domain_pages_update(struct k_mem_domain *mem_domain,
 
 
 /* Load the required parttions of the new incoming thread */
-void _x86_mmu_mem_domain_load(struct k_thread *thread)
+static inline void _x86_mmu_mem_domain_load(struct k_thread *thread)
 {
 	_x86_mem_domain_pages_update(thread->mem_domain_info.mem_domain,
 				     X86_MEM_DOMAIN_SET_PAGES);
+}
+
+/* Load the partitions of the thread. */
+void _arch_mem_domain_configure(struct k_thread *thread)
+{
+	_x86_mmu_mem_domain_load(thread);
 }
 
 /* Destroy or reset the mmu page tables when necessary.

--- a/arch/x86/core/x86_mmu.c
+++ b/arch/x86/core/x86_mmu.c
@@ -260,18 +260,11 @@ static inline void _x86_mem_domain_pages_update(struct k_mem_domain *mem_domain,
 	return;
 }
 
-
-/* Load the required parttions of the new incoming thread */
-static inline void _x86_mmu_mem_domain_load(struct k_thread *thread)
-{
-	_x86_mem_domain_pages_update(thread->mem_domain_info.mem_domain,
-				     X86_MEM_DOMAIN_SET_PAGES);
-}
-
 /* Load the partitions of the thread. */
 void _arch_mem_domain_configure(struct k_thread *thread)
 {
-	_x86_mmu_mem_domain_load(thread);
+	_x86_mem_domain_pages_update(thread->mem_domain_info.mem_domain,
+				     X86_MEM_DOMAIN_SET_PAGES);
 }
 
 /* Destroy or reset the mmu page tables when necessary.

--- a/include/arch/x86/arch.h
+++ b/include/arch/x86/arch.h
@@ -813,18 +813,6 @@ void _x86_mmu_set_flags(void *ptr,
 			x86_page_entry_data_t flags,
 			x86_page_entry_data_t mask);
 
-#ifdef CONFIG_USERSPACE
-/**
- * @brief Load the memory domain for the thread.
- *
- * If the memory domain is used this API will configure the page tables
- * according to the memory domain partition attributes.
- *
- * @param thread k_thread structure for the thread which is to configured.
- */
-void _x86_mmu_mem_domain_load(struct k_thread *thread);
-#endif
-
 #endif /* CONFIG_X86_MMU */
 
 #endif /* !_ASMLANGUAGE */

--- a/kernel/include/nano_internal.h
+++ b/kernel/include/nano_internal.h
@@ -97,6 +97,18 @@ static inline unsigned int _Swap(unsigned int key)
 extern int _arch_mem_domain_max_partitions_get(void);
 
 /**
+ * @brief Configure the memory domain of the thread.
+ *
+ * A memory domain is a container data structure containing some number of
+ * memory partitions, where each partition represents a memory range with
+ * access policies. This api will configure the appropriate hardware
+ * registers to make it work.
+ *
+ * @param thread Thread which needs to be configured.
+ */
+extern void _arch_mem_domain_configure(struct k_thread *thread);
+
+/**
  * @brief Remove a partition from the memory domain
  *
  * A memory domain contains multiple partitions and this API provides the

--- a/kernel/mem_domain.c
+++ b/kernel/mem_domain.c
@@ -158,6 +158,10 @@ void k_mem_domain_add_thread(struct k_mem_domain *domain, k_tid_t thread)
 			 &thread->mem_domain_info.mem_domain_q_node);
 	thread->mem_domain_info.mem_domain = domain;
 
+	if (_current == thread) {
+		_arch_mem_domain_configure(thread);
+	}
+
 	irq_unlock(key);
 }
 

--- a/kernel/mem_domain.c
+++ b/kernel/mem_domain.c
@@ -168,6 +168,9 @@ void k_mem_domain_remove_thread(k_tid_t thread)
 	__ASSERT(thread && thread->mem_domain_info.mem_domain, "");
 
 	key = irq_lock();
+	if (_current == thread) {
+		_arch_mem_domain_destroy(thread->mem_domain_info.mem_domain);
+	}
 
 	sys_dlist_remove(&thread->mem_domain_info.mem_domain_q_node);
 	thread->mem_domain_info.mem_domain = NULL;


### PR DESCRIPTION
If the thread id is same as current then handle the cleanup of the
memory domain.

Signed-off-by: Adithya Baglody <adithya.nagaraj.baglody@intel.com>