### PR TITLE
net: sockets: Fix recv() return value

### DIFF
--- a/subsys/net/lib/sockets/sockets.c
+++ b/subsys/net/lib/sockets/sockets.c
@@ -303,7 +303,7 @@ static inline ssize_t zsock_recv_stream(struct net_context *ctx,
 		}
 
 		res = _k_fifo_wait_non_empty(&ctx->recv_q, timeout);
-		if (res && res != -EAGAIN) {
+		if (res && res != -EAGAIN && res != -EINTR) {
 			errno = -res;
 			return -1;
 		}


### PR DESCRIPTION
recv() might return -1 after the peer performs an orderly shutdown. The
reason is k_poll() might return -EINTR;

If zsock_recv_stream() is pending on k_poll(), k_poll() will return
-EINTR after k_fifo_cancel_wait(). If zsock_recv_stream() is not pending
on k_poll(), i.e. somewhere in the do-while loop, k_poll() will return 0
after k_fifo_cancel_wait().

This patch fixes the return value by handling the return value of
k_poll() correctly.

Signed-off-by: Aska Wu <aska.wu@linaro.org>