### PR TITLE
yaml: fix properties syntax to 'mapping' instead of 'series'

### DIFF
--- a/dts/bindings/arc/arc,dccm.yaml
+++ b/dts/bindings/arc/arc,dccm.yaml
@@ -12,13 +12,13 @@ description: >
     This binding gives a base representation of the ARC DCCM
 
 properties:
-  - compatible:
+    compatible:
       type: string
       category: optional
       description: compatible strings
       constraint: "arc,dccm"
 
-  - reg:
+    reg:
       type: array
       description: DCCM memory mapped address space
       generation: define

--- a/dts/bindings/arc/arc,iccm.yaml
+++ b/dts/bindings/arc/arc,iccm.yaml
@@ -12,13 +12,13 @@ description: >
     This binding gives a base representation of the ARC ICCM
 
 properties:
-  - compatible:
+    compatible:
       type: string
       category: optional
       description: compatible strings
       constraint: "arc,iccm"
 
-  - reg:
+    reg:
       type: array
       description: ICCM memory mapped address space
       generation: define

--- a/dts/bindings/arm/nxp,kinetis-sim.yaml
+++ b/dts/bindings/arm/nxp,kinetis-sim.yaml
@@ -12,19 +12,19 @@ description: >
     This is a representation of the Kinetis SIM IP node
 
 properties:
-  - compatible:
+    compatible:
       type: string
       category: required
       description: compatible strings
       constraint: "nxp,kinetis-sim"
 
-  - reg:
+    reg:
       type: int
       description: mmio register space
       generation: define
       category: required
 
-  - label:
+    label:
       type: string
       category: required
       description: Human readable string describing the device (used by Zephyr for API name)

--- a/dts/bindings/arm/nxp,kw41z-sim.yaml
+++ b/dts/bindings/arm/nxp,kw41z-sim.yaml
@@ -6,13 +6,13 @@ description: >
     This is a representation of the KW41Z SIM IP node
 
 properties:
-  - compatible:
+    compatible:
       type: string
       category: required
       description: compatible strings
       constraint: "nxp,kw41z-sim"
 
-  - reg:
+    reg:
       type: int
       description: mmio register space
       generation: define

--- a/dts/bindings/arm/ti,cc2650-prcm.yaml
+++ b/dts/bindings/arm/ti,cc2650-prcm.yaml
@@ -8,13 +8,13 @@ description: >
     Power, Reset, and Clock control Module.
 
 properties:
-  - compatible:
+    compatible:
       type: string
       category: required
       description: compatible strings
       constraint: "ti,cc2650-prcm"
 
-  - reg:
+    reg:
       type: array
       description: mmio register space
       generation: define

--- a/dts/bindings/clock/nxp,imx-ccm.yaml
+++ b/dts/bindings/clock/nxp,imx-ccm.yaml
@@ -12,19 +12,19 @@ description: >
     This is a representation of the i.MX CCM IP node
 
 properties:
-  - compatible:
+    compatible:
       type: string
       category: required
       description: compatible strings
       constraint: "nxp,imx-ccm"
 
-  - reg:
+    reg:
       type: int
       description: mmio register space
       generation: define
       category: required
 
-  - label:
+    label:
       type: string
       category: required
       description: Human readable string describing the device (used by Zephyr for API name)

--- a/dts/bindings/clock/st,stm32-rcc.yaml
+++ b/dts/bindings/clock/st,stm32-rcc.yaml
@@ -7,13 +7,13 @@ description: >
     This binding gives a base representation of the STM32 Clock control
 
 properties:
-  - compatible:
+    compatible:
       type: string
       category: required
       description: compatible strings
       constraint: "st,stm32-rcc"
 
-  - reg:
+    reg:
       type: array
       description: mmio register space
       generation: define

--- a/dts/bindings/device_node.yaml.template
+++ b/dts/bindings/device_node.yaml.template
@@ -12,27 +12,27 @@ description: >
 properties:
 
 # A typical property entry will look like the following
-# - <name of property as it is in device tree>
+#   <name of property as it is in device tree>
 #     category: <required | optional>
 #     type: <string | int | array>
 #     description: <description of property>
 #     generation: <define | structure>
 
 # At a minimum, the compatible is required for matching nodes
-  - compatible: <list of string compatible matches>
+    compatible: <list of string compatible matches>
       category: required
       type: string
       description: compatible of node
 
 # reg is used to denote mmio registers
-  - reg:
+    reg:
       type: array
       description: mmio register space
       generation: define
       category: required
 
 # interrupts specifies the interrupts that the driver may utilize
-  - interrupts:
+    interrupts:
       type: array
       category: required
       description: required interrupts

--- a/dts/bindings/gpio/arm,cmsdk-gpio.yaml
+++ b/dts/bindings/gpio/arm,cmsdk-gpio.yaml
@@ -7,19 +7,19 @@ description: >
     This binding gives a base representation of the ARM CMSDK GPIO
 
 properties:
-  - compatible:
+    compatible:
       type: string
       category: required
       description: compatible strings
       constraint: "arm,cmsdk-gpio"
 
-  - reg:
+    reg:
       type: array
       description: mmio register space
       generation: define
       category: required
 
-  - interrupts:
+    interrupts:
       type: array
       category: required
       description: required interrupts

--- a/dts/bindings/gpio/nxp,imx-gpio.yaml
+++ b/dts/bindings/gpio/nxp,imx-gpio.yaml
@@ -11,25 +11,25 @@ description: >
     This is a representation of the i.MX GPIO nodes
 
 properties:
-  - compatible:
+    compatible:
       type: string
       category: required
       description: compatible strings
       constraint: "nxp,imx-gpio"
 
-  - reg:
+    reg:
       type: int
       description: mmio register space
       generation: define
       category: required
 
-  - interrupts:
+    interrupts:
       type: compound
       category: required
       description: required interrupts
       generation: define
 
-  - label:
+    label:
       type: string
       category: required
       description: Human readable string describing the device (used by Zephyr for API name)

--- a/dts/bindings/gpio/nxp,kinetis-gpio.yaml
+++ b/dts/bindings/gpio/nxp,kinetis-gpio.yaml
@@ -6,19 +6,19 @@ description: >
     This is a representation of the Kinetis GPIO nodes
 
 properties:
-  - compatible:
+    compatible:
       type: string
       category: required
       description: compatible strings
       constraint: "nxp,kinetis-gpio"
 
-  - reg:
+    reg:
       type: int
       description: mmio register space
       generation: define
       category: required
 
-  - interrupts:
+    interrupts:
       type: compound
       category: required
       description: required interrupts

--- a/dts/bindings/gpio/ti,cc2650-gpio.yaml
+++ b/dts/bindings/gpio/ti,cc2650-gpio.yaml
@@ -7,19 +7,19 @@ description: >
     This is a representation of the TI CC2650 GPIO node
 
 properties:
-  - compatible:
+    compatible:
       type: string
       category: required
       description: compatible strings
       constraint: "ti,cc2650-gpio"
 
-  - reg:
+    reg:
       type: int
       description: mmio register space
       generation: define
       category: required
 
-  - interrupts:
+    interrupts:
       type: compound
       category: required
       description: required interrupts

--- a/dts/bindings/i2c/atmel,sam-i2c-twi.yaml
+++ b/dts/bindings/i2c/atmel,sam-i2c-twi.yaml
@@ -7,28 +7,28 @@ description: >
     This is a representation of the Atmel SAM Family I2C (TWI) node
 
 inherits:
-  - !include i2c.yaml
+    !include i2c.yaml
 
 properties:
-  - compatible:
+    compatible:
       type: string
       category: required
       description: compatible strings
       constraint: "atmel,sam-i2c-twi"
 
-  - reg:
+    reg:
       type: array
       description: mmio register space
       generation: define
       category: required
 
-  - interrupts:
+    interrupts:
       type: array
       category: required
       description: required interrupts
       generation: define
 
-  - peripheral-id:
+    peripheral-id:
       type: int
       description: peripheral ID
       generation: define

--- a/dts/bindings/i2c/atmel,sam-i2c-twihs.yaml
+++ b/dts/bindings/i2c/atmel,sam-i2c-twihs.yaml
@@ -12,28 +12,28 @@ description: >
     This is a representation of the Atmel SAM Family I2C (TWIHS) node
 
 inherits:
-  - !include i2c.yaml
+    !include i2c.yaml
 
 properties:
-  - compatible:
+    compatible:
       type: string
       category: required
       description: compatible strings
       constraint: "atmel,sam-i2c-twihs"
 
-  - reg:
+    reg:
       type: array
       description: mmio register space
       generation: define
       category: required
 
-  - interrupts:
+    interrupts:
       type: array
       category: required
       description: required interrupts
       generation: define
 
-  - peripheral-id:
+    peripheral-id:
       type: int
       description: peripheral ID
       generation: define

--- a/dts/bindings/i2c/i2c.yaml
+++ b/dts/bindings/i2c/i2c.yaml
@@ -7,25 +7,25 @@ description: >
     This binding gives the base structures for all I2C devices
 
 properties:
-  - "#address-cells":
+    "#address-cells":
       type: int
       category: required
       description: should be 1.
-  - "#size-cells":
+    "#size-cells":
       type: int
       category: required
       description: should be 0.
-  - clock-frequency :
+    clock-frequency :
       type: int
       category: optional
       description: Initial clock frequency in Hz
       generation: define
-  - clocks:
+    clocks:
       type: array
       category: required
       description: Clock gate information
       generation: define
-  - label:
+    label:
       type: string
       category: required
       description: Human readable string describing the device (used by Zephyr for API name)

--- a/dts/bindings/i2c/nxp,kinetis-i2c.yaml
+++ b/dts/bindings/i2c/nxp,kinetis-i2c.yaml
@@ -6,22 +6,22 @@ description: >
     This is a representation of the Kinetis I2C nodes
 
 inherits:
-  - !include i2c.yaml
+    !include i2c.yaml
 
 properties:
-  - compatible:
+    compatible:
       type: string
       category: required
       description: compatible strings
       constraint: "nxp,kinetis-i2c"
 
-  - reg:
+    reg:
       type: int
       description: mmio register space
       generation: define
       category: required
 
-  - interrupts:
+    interrupts:
       type: compound
       category: required
       description: required interrupts

--- a/dts/bindings/i2c/st,stm32-i2c-v1.yaml
+++ b/dts/bindings/i2c/st,stm32-i2c-v1.yaml
@@ -7,34 +7,34 @@ description: >
     This binding gives a base representation of the STM32 I2C V1 controller
 
 inherits:
-  - !include i2c.yaml
+    !include i2c.yaml
 
 properties:
-  - compatible:
+    compatible:
       type: string
       category: required
       description: compatible strings
       constraint: "st,stm32-i2c-v1"
 
-  - reg:
+    reg:
       type: array
       description: mmio register space
       generation: define
       category: required
 
-  - interrupts:
+    interrupts:
       type: array
       category: required
       description: required interrupts
       generation: define
 
-  - interrupt-names:
+    interrupt-names:
       type: stringlist
       category: optional
       description: readable string describing the interrupts
       generation: define
 
-  - clocks:
+    clocks:
       type: array
       category: required
       description: Clock gate control information

--- a/dts/bindings/i2c/st,stm32-i2c-v2.yaml
+++ b/dts/bindings/i2c/st,stm32-i2c-v2.yaml
@@ -7,34 +7,34 @@ description: >
     This binding gives a base representation of the STM32 I2C V2 controller
 
 inherits:
-  - !include i2c.yaml
+    !include i2c.yaml
 
 properties:
-  - compatible:
+    compatible:
       type: string
       category: required
       description: compatible strings
       constraint: "st,stm32-i2c-v2"
 
-  - reg:
+    reg:
       type: array
       description: mmio register space
       generation: define
       category: required
 
-  - interrupts:
+    interrupts:
       type: array
       category: required
       description: required interrupts
       generation: define
 
-  - interrupt-names:
+    interrupt-names:
       type: stringlist
       category: optional
       description: readable string describing the interrupts
       generation: define
 
-  - clocks:
+    clocks:
       type: array
       category: required
       description: Clock gate control information

--- a/dts/bindings/iio/adc/adc.yaml
+++ b/dts/bindings/iio/adc/adc.yaml
@@ -12,13 +12,13 @@ description: >
     This binding gives the base structures for all ADC devices
 
 properties:
-  - clocks:
+    clocks:
       type: array
       category: required
       description: Clock gate information
       generation: define
 
-  - label:
+    label:
       type: string
       category: required
       description: Human readable string describing the device (used by Zephyr for API name)

--- a/dts/bindings/iio/adc/atmel,sam-afec.yaml
+++ b/dts/bindings/iio/adc/atmel,sam-afec.yaml
@@ -7,28 +7,28 @@ description: >
     This binding gives a base representation of the Atmel SAM AFEC
 
 inherits:
-  - !include adc.yaml
+    !include adc.yaml
 
 properties:
-  - compatible:
+    compatible:
       type: string
       category: required
       description: compatible strings
       constraint: "atmel,sam-afec"
 
-  - reg:
+    reg:
       type: array
       description: mmio register space
       generation: define
       category: required
 
-  - interrupts:
+    interrupts:
       type: array
       category: required
       description: required interrupts
       generation: define
 
-  - peripheral-id:
+    peripheral-id:
       type: int
       description: peripheral ID
       generation: define

--- a/dts/bindings/iio/adc/nxp,kinetis-adc16.yaml
+++ b/dts/bindings/iio/adc/nxp,kinetis-adc16.yaml
@@ -12,22 +12,22 @@ description: >
     This binding gives a base representation of the Kinetis ADC16
 
 inherits:
-  - !include adc.yaml
+    !include adc.yaml
 
 properties:
-  - compatible:
+    compatible:
       type: string
       category: required
       description: compatible strings
       constraint: "nxp,kinetis-adc16"
 
-  - reg:
+    reg:
       type: array
       description: mmio register space
       generation: define
       category: required
 
-  - interrupts:
+    interrupts:
       type: array
       category: required
       description: required interrupts

--- a/dts/bindings/interrupt-controller/arm,v6m-nvic.yaml
+++ b/dts/bindings/interrupt-controller/arm,v6m-nvic.yaml
@@ -6,19 +6,19 @@ description: >
     This binding describes the ARM Cortex M0+ NVIC IRQ controller
 
 properties:
-  - compatible:
+    compatible:
       category: required
       type: string
       description: compatible strings
       constraint: "arm,v6m-nvic"
 
-  - reg:
+    reg:
       category: required
       type: int
       description: mmio register space
       generation: define
 
-  - arm,num-irq-priority-bits:
+    arm,num-irq-priority-bits:
       category: required
       type: int
       description: number of bits of IRQ priorities

--- a/dts/bindings/interrupt-controller/arm,v7m-nvic.yaml
+++ b/dts/bindings/interrupt-controller/arm,v7m-nvic.yaml
@@ -6,19 +6,19 @@ description: >
     This binding describes the ARM Cortex M4 NVIC IRQ controller
 
 properties:
-  - compatible:
+    compatible:
       category: required
       type: string
       description: compatible strings
       constraint: "arm,v7m-nvic"
 
-  - reg:
+    reg:
       category: required
       type: int
       description: mmio register space
       generation: define
 
-  - arm,num-irq-priority-bits:
+    arm,num-irq-priority-bits:
       category: required
       type: int
       description: number of bits of IRQ priorities

--- a/dts/bindings/interrupt-controller/snps,arcv2-intc.yaml
+++ b/dts/bindings/interrupt-controller/snps,arcv2-intc.yaml
@@ -11,19 +11,19 @@ description: >
     This binding describes the ARCV2 IRQ controller
 
 properties:
-  - compatible:
+    compatible:
       category: required
       type: string
       description: compatible strings
       constraint: "snps,arcv2-intc"
 
-  - reg:
+    reg:
       category: required
       type: int
       description: mmio register space
       generation: define
 
-  - arm,num-irq-priority-bits:
+    arm,num-irq-priority-bits:
       category: required
       type: int
       description: number of bits of IRQ priorities

--- a/dts/bindings/mtd/partition.yaml
+++ b/dts/bindings/mtd/partition.yaml
@@ -7,31 +7,31 @@ description: >
     This binding gives a base FLASH partition description
 
 properties:
-  - compatible:
+    compatible:
       type: string
       category: required
       description: compatible strings
       constraint: "fixed-partitions"
 
-  - partition\d+:
+    partition\d+:
       type: string
       generation: define
 
       properties:
-        - reg:
+          reg:
             type: array
             description: partition offset and size from flash bank
             generation: define
             category: required
             label: offset
 
-        - label:
+          label:
             type: string
             description: Partition label
             generation: define
             category: required
 
-        - read-only:
+          read-only:
             type: boolean
             category: optional
             description: Denotes read only partition

--- a/dts/bindings/mtd/soc-nv-flash.yaml
+++ b/dts/bindings/mtd/soc-nv-flash.yaml
@@ -7,13 +7,13 @@ description: >
     This binding gives a base FLASH description
 
 properties:
-  - compatible:
+    compatible:
       type: string
       category: optional
       description: compatible strings
       constraint: "soc-nv-flash"
 
-  - write-block-size:
+    write-block-size:
      type: int
      description: address alignment required by flash write operations
      generation: define

--- a/dts/bindings/pinctrl/nxp,kinetis-pinmux.yaml
+++ b/dts/bindings/pinctrl/nxp,kinetis-pinmux.yaml
@@ -6,19 +6,19 @@ description: >
     This is a representation of the Kinetis Pinmux node
 
 properties:
-  - compatible:
+    compatible:
       type: string
       category: required
       description: compatible strings
       constraint: "nxp,kinetis-pinmux"
 
-  - reg:
+    reg:
       type: int
       description: mmio register space
       generation: define
       category: required
 
-  - clocks:
+    clocks:
       type: array
       description: clock gate information
       generation: define

--- a/dts/bindings/pinctrl/st,stm32-pinmux.yaml
+++ b/dts/bindings/pinctrl/st,stm32-pinmux.yaml
@@ -7,13 +7,13 @@ description: >
     This binding gives a base representation of the STM32 PINMUX
 
 properties:
-  - compatible:
+    compatible:
       type: string
       category: required
       description: compatible strings
       constraint: "st,stm32-pinmux"
 
-  - reg:
+    reg:
       type: int
       description: mmio register space
       generation: define

--- a/dts/bindings/pinctrl/ti,cc2650-pinmux.yaml
+++ b/dts/bindings/pinctrl/ti,cc2650-pinmux.yaml
@@ -7,13 +7,13 @@ description: >
     This is a representation of the TI CC2650 pinmux node
 
 properties:
-  - compatible:
+    compatible:
       type: string
       category: required
       description: compatible strings
       constraint: "ti,cc2650-pinmux"
 
-  - reg:
+    reg:
       type: int
       description: mmio register space
       generation: define

--- a/dts/bindings/pwm/nxp,kinetis-ftm.yaml
+++ b/dts/bindings/pwm/nxp,kinetis-ftm.yaml
@@ -12,22 +12,22 @@ description: >
     This binding gives a base representation of the Kinetis FTM
 
 inherits:
-  - !include pwm.yaml
+    !include pwm.yaml
 
 properties:
-  - compatible:
+    compatible:
       type: string
       category: required
       description: compatible strings
       constraint: "nxp,kinetis-ftm"
 
-  - reg:
+    reg:
       type: array
       description: mmio register space
       generation: define
       category: required
 
-  - interrupts:
+    interrupts:
       type: array
       category: required
       description: required interrupts

--- a/dts/bindings/pwm/pwm.yaml
+++ b/dts/bindings/pwm/pwm.yaml
@@ -12,13 +12,13 @@ description: >
     This binding gives the base structures for all PWM devices
 
 properties:
-  - clocks:
+    clocks:
       type: array
       category: required
       description: Clock gate information
       generation: define
 
-  - label:
+    label:
       type: string
       category: required
       description: Human readable string describing the device (used by Zephyr for API name)

--- a/dts/bindings/serial/arm,cmsdk-uart.yaml
+++ b/dts/bindings/serial/arm,cmsdk-uart.yaml
@@ -7,22 +7,22 @@ description: >
     This binding gives a base representation of the ARM CMSDK UART
 
 inherits:
-  - !include uart.yaml
+    !include uart.yaml
 
 properties:
-  - compatible:
+    compatible:
       type: string
       category: required
       description: compatible strings
       constraint: "arm,cmsdk-uart"
 
-  - reg:
+    reg:
       type: array
       description: mmio register space
       generation: define
       category: required
 
-  - interrupts:
+    interrupts:
       type: array
       category: required
       description: required interrupts

--- a/dts/bindings/serial/atmel,sam-uart.yaml
+++ b/dts/bindings/serial/atmel,sam-uart.yaml
@@ -7,28 +7,28 @@ description: >
     This binding gives a base representation of the SAM UART
 
 inherits:
-  - !include uart.yaml
+    !include uart.yaml
 
 properties:
-  - compatible:
+    compatible:
       type: string
       category: required
       description: compatible strings
       constraint: "atmel,sam-uart"
 
-  - reg:
+    reg:
       type: array
       description: mmio register space
       generation: define
       category: required
 
-  - interrupts:
+    interrupts:
       type: array
       category: required
       description: required interrupts
       generation: define
 
-  - peripheral-id:
+    peripheral-id:
       type: int
       description: peripheral ID
       generation: define

--- a/dts/bindings/serial/atmel,sam-usart.yaml
+++ b/dts/bindings/serial/atmel,sam-usart.yaml
@@ -7,28 +7,28 @@ description: >
     This binding gives a base representation of the Atmel SAM USART
 
 inherits:
-  - !include uart.yaml
+    !include uart.yaml
 
 properties:
-  - compatible:
+    compatible:
       type: string
       category: required
       description: compatible strings
       constraint: "atmel,sam-usart"
 
-  - reg:
+    reg:
       type: array
       description: mmio register space
       generation: define
       category: required
 
-  - interrupts:
+    interrupts:
       type: array
       category: required
       description: required interrupts
       generation: define
 
-  - peripheral-id:
+    peripheral-id:
       type: int
       description: peripheral ID
       generation: define

--- a/dts/bindings/serial/intel,qmsi-uart.yaml
+++ b/dts/bindings/serial/intel,qmsi-uart.yaml
@@ -7,34 +7,34 @@ description: >
     This binding gives a base representation of the INTEL QMSI UART
 
 inherits:
-  - !include uart.yaml
+    !include uart.yaml
 
 properties:
-  - compatible:
+    compatible:
       type: string
       category: required
       description: compatible strings
       constraint: "intel,qmsi-uart"
 
-  - reg:
+    reg:
       type: array
       description: mmio register space
       generation: define
       category: required
 
-  - interrupts:
+    interrupts:
       type: array
       category: required
       description: required interrupts
       generation: define
 
-  - pinctrl-\d+:
+    pinctrl-\d+:
       type: array
       category: optional
       description: pinmux information for RX, TX, CTS, RTS
       generation: define
 
-  - clocks:
+    clocks:
       type: array
       category: required
       description: Clock gate control information

--- a/dts/bindings/serial/nordic,nrf-uart.yaml
+++ b/dts/bindings/serial/nordic,nrf-uart.yaml
@@ -7,22 +7,22 @@ description: >
     This binding gives a base representation of the Nordic UART
 
 inherits:
-  - !include uart.yaml
+    !include uart.yaml
 
 properties:
-  - compatible:
+    compatible:
       type: string
       category: required
       description: compatible strings
       constraint: "nordic,nrf-uart"
 
-  - reg:
+    reg:
       type: array
       description: mmio register space
       generation: define
       category: required
 
-  - interrupts:
+    interrupts:
       type: array
       category: required
       description: required interrupts

--- a/dts/bindings/serial/nordic,nrf-uarte.yaml
+++ b/dts/bindings/serial/nordic,nrf-uarte.yaml
@@ -7,22 +7,22 @@ description: >
     This binding gives a base representation of the Nordic UARTE
 
 inherits:
-  - !include uart.yaml
+    !include uart.yaml
 
 properties:
-  - compatible:
+    compatible:
       type: string
       category: required
       description: compatible strings
       constraint: "nordic,nrf-uarte"
 
-  - reg:
+    reg:
       type: array
       description: mmio register space
       generation: define
       category: required
 
-  - interrupts:
+    interrupts:
       type: array
       category: required
       description: required interrupts

--- a/dts/bindings/serial/ns16550.yaml
+++ b/dts/bindings/serial/ns16550.yaml
@@ -7,28 +7,28 @@ description: >
     This binding gives a base representation of the ns16550 UART
 
 inherits:
-  - !include uart.yaml
+    !include uart.yaml
 
 properties:
-  - compatible:
+    compatible:
       type: string
       category: required
       description: compatible strings
       constraint: "ns16550"
 
-  - reg:
+    reg:
       type: array
       description: mmio register space
       generation: define
       category: required
 
-  - reg-shift:
+    reg-shift:
       type: int
       category: optional
       description: quantity to shift the register offsets by
       generation: define
 
-  - interrupts:
+    interrupts:
       type: array
       category: required
       description: required interrupts

--- a/dts/bindings/serial/nxp,kinetis-lpsci.yaml
+++ b/dts/bindings/serial/nxp,kinetis-lpsci.yaml
@@ -7,22 +7,22 @@ description: >
     This binding gives a base representation of the LPSCI UART
 
 inherits:
-  - !include uart.yaml
+    !include uart.yaml
 
 properties:
-  - compatible:
+    compatible:
       type: string
       category: required
       description: compatible strings
       constraint: "nxp,kinetis-lpsci"
 
-  - reg:
+    reg:
       type: array
       description: mmio register space
       generation: define
       category: required
 
-  - interrupts:
+    interrupts:
       type: array
       category: required
       description: required interrupts

--- a/dts/bindings/serial/nxp,kinetis-lpuart.yaml
+++ b/dts/bindings/serial/nxp,kinetis-lpuart.yaml
@@ -7,28 +7,28 @@ description: >
     This binding gives a base representation of the Kinetis LPUART
 
 inherits:
-  - !include uart.yaml
+    !include uart.yaml
 
 properties:
-  - compatible:
+    compatible:
       type: string
       category: required
       description: compatible strings
       constraint: "nxp,kinetis-lpuart"
 
-  - reg:
+    reg:
       type: array
       description: mmio register space
       generation: define
       category: required
 
-  - interrupts:
+    interrupts:
       type: array
       category: required
       description: required interrupts
       generation: define
 
-  - pinctrl-*:
+    pinctrl-*:
       type: array
       category: optional
       description: pinmux information for RX, TX, CTS, RTS

--- a/dts/bindings/serial/nxp,kinetis-uart.yaml
+++ b/dts/bindings/serial/nxp,kinetis-uart.yaml
@@ -7,34 +7,34 @@ description: >
     This binding gives a base representation of the Kinetis UART
 
 inherits:
-  - !include uart.yaml
+    !include uart.yaml
 
 properties:
-  - compatible:
+    compatible:
       type: string
       category: required
       description: compatible strings
       constraint: "nxp,kinetis-uart"
 
-  - reg:
+    reg:
       type: array
       description: mmio register space
       generation: define
       category: required
 
-  - interrupts:
+    interrupts:
       type: array
       category: required
       description: required interrupts
       generation: define
 
-  - pinctrl-\d+:
+    pinctrl-\d+:
       type: array
       category: optional
       description: pinmux information for RX, TX, CTS, RTS
       generation: define
 
-  - clocks:
+    clocks:
       type: array
       category: required
       description: Clock gate control information

--- a/dts/bindings/serial/silabs,efm32-uart.yaml
+++ b/dts/bindings/serial/silabs,efm32-uart.yaml
@@ -7,22 +7,22 @@ description: >
     This binding gives a base representation of the EFM32 UART
 
 inherits:
-  - !include uart.yaml
+    !include uart.yaml
 
 properties:
-  - compatible:
+    compatible:
       type: string
       category: required
       description: compatible strings
       constraint: "silabs,efm32-uart"
 
-  - reg:
+    reg:
       type: array
       description: mmio register space
       generation: define
       category: required
 
-  - interrupts:
+    interrupts:
       type: array
       category: required
       description: required interrupts

--- a/dts/bindings/serial/silabs,efm32-usart.yaml
+++ b/dts/bindings/serial/silabs,efm32-usart.yaml
@@ -7,22 +7,22 @@ description: >
     This binding gives a base representation of the EFM32 USART
 
 inherits:
-  - !include uart.yaml
+    !include uart.yaml
 
 properties:
-  - compatible:
+    compatible:
       type: string
       category: required
       description: compatible strings
       constraint: "silabs,efm32-usart"
 
-  - reg:
+    reg:
       type: array
       description: mmio register space
       generation: define
       category: required
 
-  - interrupts:
+    interrupts:
       type: array
       category: required
       description: required interrupts

--- a/dts/bindings/serial/st,stm32-uart.yaml
+++ b/dts/bindings/serial/st,stm32-uart.yaml
@@ -7,28 +7,28 @@ description: >
     This binding gives a base representation of the STM32 UART
 
 inherits:
-  - !include uart.yaml
+    !include uart.yaml
 
 properties:
-  - compatible:
+    compatible:
       type: string
       category: required
       description: compatible strings
       constraint: "st,stm32-uart"
 
-  - reg:
+    reg:
       type: array
       description: mmio register space
       generation: define
       category: required
 
-  - interrupts:
+    interrupts:
       type: array
       category: required
       description: required interrupts
       generation: define
 
-  - clocks:
+    clocks:
       type: array
       category: required
       description: Clock gate control information

--- a/dts/bindings/serial/st,stm32-usart.yaml
+++ b/dts/bindings/serial/st,stm32-usart.yaml
@@ -7,28 +7,28 @@ description: >
     This binding gives a base representation of the STM32 USART
 
 inherits:
-  - !include uart.yaml
+    !include uart.yaml
 
 properties:
-  - compatible:
+    compatible:
       type: string
       category: required
       description: compatible strings
       constraint: "st,stm32-usart"
 
-  - reg:
+    reg:
       type: array
       description: mmio register space
       generation: define
       category: required
 
-  - interrupts:
+    interrupts:
       type: array
       category: required
       description: required interrupts
       generation: define
 
-  - clocks:
+    clocks:
       type: array
       category: required
       description: Clock gate control information

--- a/dts/bindings/serial/ti,cc32xx-uart.yaml
+++ b/dts/bindings/serial/ti,cc32xx-uart.yaml
@@ -7,22 +7,22 @@ description: >
     This binding gives a base representation of the TI CC32XX UART
 
 inherits:
-  - !include uart.yaml
+    !include uart.yaml
 
 properties:
-  - compatible:
+    compatible:
       type: string
       category: required
       description: compatible strings
       constraint: "ti,cc32xx-uart"
 
-  - reg:
+    reg:
       type: array
       description: mmio register space
       generation: define
       category: required
 
-  - interrupts:
+    interrupts:
       type: array
       category: required
       description: required interrupts

--- a/dts/bindings/serial/ti,msp432p4xx-uart.yaml
+++ b/dts/bindings/serial/ti,msp432p4xx-uart.yaml
@@ -7,22 +7,22 @@ description: >
     This binding gives a base representation of the TI MSP432P4XX UART
 
 inherits:
-  - !include uart.yaml
+    !include uart.yaml
 
 properties:
-  - compatible:
+    compatible:
       type: string
       category: required
       description: compatible strings
       constraint: "ti,msp432p4xx-uart"
 
-  - reg:
+    reg:
       type: array
       description: mmio register space
       generation: define
       category: required
 
-  - interrupts:
+    interrupts:
       type: array
       category: required
       description: required interrupts

--- a/dts/bindings/serial/ti,stellaris-uart.yaml
+++ b/dts/bindings/serial/ti,stellaris-uart.yaml
@@ -7,22 +7,22 @@ description: >
     This binding gives a base representation of the TI Stellaris UART
 
 inherits:
-  - !include uart.yaml
+    !include uart.yaml
 
 properties:
-  - compatible:
+    compatible:
       type: string
       category: required
       description: compatible strings
       constraint: "ti,stellaris-uart"
 
-  - reg:
+    reg:
       type: array
       description: mmio register space
       generation: define
       category: required
 
-  - interrupts:
+    interrupts:
       type: array
       category: required
       description: required interrupts

--- a/dts/bindings/serial/uart.yaml
+++ b/dts/bindings/serial/uart.yaml
@@ -7,32 +7,32 @@ description: >
     This binding gives the base structures for all UART devices
 
 properties:
-  - clock-frequency:
+    clock-frequency:
       type: int
       category: optional
       description: Clock frequency information for UART operation
       generation: define
-  - current-speed:
+    current-speed:
       type: int
       category: required
       description: Initial baud rate setting for UART
       generation: define
-  - clocks:
+    clocks:
       type: array
       category: required
       description: Clock gate information
       generation: define
-  - label:
+    label:
       type: string
       category: required
       description: Human readable string describing the device (used by Zephyr for API name)
       generation: define
-  - interrupt-names:
+    interrupt-names:
       type: stringlist
       category: optional
       description: names of required interrupts
       generation: define
-  - pinctrl-\d+:
+    pinctrl-\d+:
       type: array
       category: optional
       description: pinmux information for RX, TX, CTS, RTS

--- a/dts/bindings/timer/arm,cmsdk-dtimer.yaml
+++ b/dts/bindings/timer/arm,cmsdk-dtimer.yaml
@@ -7,19 +7,19 @@ description: >
     This binding gives a base representation of the ARM CMSDK DUALTIMER
 
 properties:
-  - compatible:
+    compatible:
       type: string
       category: required
       description: compatible strings
       constraint: "arm,cmsdk-dtimer"
 
-  - reg:
+    reg:
       type: array
       description: mmio register space
       generation: define
       category: required
 
-  - interrupts:
+    interrupts:
       type: array
       category: required
       description: required interrupts

--- a/dts/bindings/timer/arm,cmsdk-timer.yaml
+++ b/dts/bindings/timer/arm,cmsdk-timer.yaml
@@ -7,19 +7,19 @@ description: >
     This binding gives a base representation of the ARM CMSDK TIMER
 
 properties:
-  - compatible:
+    compatible:
       type: string
       category: required
       description: compatible strings
       constraint: "arm,cmsdk-timer"
 
-  - reg:
+    reg:
       type: array
       description: mmio register space
       generation: define
       category: required
 
-  - interrupts:
+    interrupts:
       type: array
       category: required
       description: required interrupts

--- a/dts/bindings/watchdog/arm,cmsdk-watchdog.yaml
+++ b/dts/bindings/watchdog/arm,cmsdk-watchdog.yaml
@@ -7,13 +7,13 @@ description: >
     This binding gives a base representation of the ARM CMSDK WATCHDOG
 
 properties:
-  - compatible:
+    compatible:
       type: string
       category: required
       description: compatible strings
       constraint: "arm,cmsdk-watchdog"
 
-  - reg:
+    reg:
       type: array
       description: mmio register space
       generation: define


### PR DESCRIPTION
According to yaml syntaxic rules, 'properties' described in dts
bindings yaml files could be seen as 'mapping'(key/value couple),
instead of 'series' (list of single elements).
Using mapping, yaml mappings will be converted by yaml python
library as python 'dict' which will ease treatment
(instead of current list as were before this commit).
Same treatment is applied to 'inherits'.

script extract_dts_inlcude is updated to take change of yaml_list
structre into account. This allows some code simplification. Largest
impact is yaml_collapse function which works now allow complete
overload method on all the attributes of a yaml nodes.

Signed-off-by: Erwan Gouriou <erwan.gouriou@linaro.org>