### PR TITLE
samples: net: echo-server: Fix compilation with mbedtls

### DIFF
--- a/samples/net/echo_server/CMakeLists.txt
+++ b/samples/net/echo_server/CMakeLists.txt
@@ -6,3 +6,5 @@ target_sources_ifdef(CONFIG_NET_UDP app PRIVATE src/udp.c)
 target_sources_ifdef(CONFIG_NET_TCP app PRIVATE src/tcp.c)
 
 include($ENV{ZEPHYR_BASE}/samples/net/common/common.cmake)
+
+target_link_libraries_ifdef(CONFIG_MBEDTLS app mbedTLS)


### PR DESCRIPTION
The echo-server compilation failed because mbedtls config file
was not found. Added suitable magic to CMakeLists.txt fixing that.

Signed-off-by: Jukka Rissanen <jukka.rissanen@linux.intel.com>