### PR TITLE
Bluetooth: controller: Optimise memq interface

### DIFF
--- a/subsys/bluetooth/controller/ll_sw/ctrl.c
+++ b/subsys/bluetooth/controller/ll_sw/ctrl.c
@@ -8522,7 +8522,7 @@ static void packet_rx_enqueue(void)
 	_radio.packet_rx_last = last;
 
 	/* Enqueue into event-cum-data queue */
-	link = memq_enqueue(radio_pdu_node_rx, link,
+	link = memq_enqueue(link, radio_pdu_node_rx,
 			    (void *)&_radio.link_rx_tail);
 	LL_ASSERT(link);
 
@@ -8827,7 +8827,7 @@ static void terminate_ind_rx_enqueue(struct connection *conn, u8_t reason)
 	    _radio.packet_release_last;
 
 	/* Enqueue into event-cum-data queue */
-	link = memq_enqueue(radio_pdu_node_rx, link,
+	link = memq_enqueue(link, radio_pdu_node_rx,
 			    (void *)&_radio.link_rx_tail);
 	LL_ASSERT(link);
 

--- a/subsys/bluetooth/controller/util/mayfly.c
+++ b/subsys/bluetooth/controller/util/mayfly.c
@@ -102,7 +102,7 @@ u32_t mayfly_enqueue(u8_t caller_id, u8_t callee_id, u8_t chain,
 
 	/* new, add as ready in the queue */
 	m->_req = ack + 1;
-	memq_enqueue(m, m->_link, &mft[callee_id][caller_id].tail);
+	memq_enqueue(m->_link, m, &mft[callee_id][caller_id].tail);
 
 	/* pend the callee for execution */
 	mayfly_pend(caller_id, callee_id);
@@ -123,8 +123,8 @@ void mayfly_run(u8_t callee_id)
 		struct mayfly *m = 0;
 
 		/* fetch mayfly in callee queue, if any */
-		link = memq_peek(mft[callee_id][caller_id].tail,
-				 mft[callee_id][caller_id].head,
+		link = memq_peek(mft[callee_id][caller_id].head,
+				 mft[callee_id][caller_id].tail,
 				 (void **)&m);
 		while (link) {
 			u8_t state;
@@ -156,8 +156,8 @@ void mayfly_run(u8_t callee_id)
 			}
 
 			/* fetch next mayfly in callee queue, if any */
-			link = memq_peek(mft[callee_id][caller_id].tail,
-					 mft[callee_id][caller_id].head,
+			link = memq_peek(mft[callee_id][caller_id].head,
+					 mft[callee_id][caller_id].tail,
 					 (void **)&m);
 
 			/* yield out of mayfly_run if a mayfly function was

--- a/subsys/bluetooth/controller/util/memq.c
+++ b/subsys/bluetooth/controller/util/memq.c
@@ -8,7 +8,7 @@
 #include <zephyr/types.h>
 #include <stddef.h>
 
-inline void *memq_peek(void *tail, void *head, void **mem);
+inline void *memq_peek(void *head, void *tail, void **mem);
 
 void *memq_init(void *link, void **head, void **tail)
 {
@@ -18,7 +18,7 @@ void *memq_init(void *link, void **head, void **tail)
 	return link;
 }
 
-void *memq_enqueue(void *mem, void *link, void **tail)
+void *memq_enqueue(void *link, void *mem, void **tail)
 {
 	/* make the current tail link node point to new link node */
 	*((void **)*tail) = link;
@@ -32,7 +32,7 @@ void *memq_enqueue(void *mem, void *link, void **tail)
 	return link;
 }
 
-void *memq_peek(void *tail, void *head, void **mem)
+void *memq_peek(void *head, void *tail, void **mem)
 {
 	void *link;
 
@@ -57,7 +57,7 @@ void *memq_dequeue(void *tail, void **head, void **mem)
 	void *link;
 
 	/* use memq peek to get the link and mem */
-	link = memq_peek(tail, *head, mem);
+	link = memq_peek(*head, tail, mem);
 	if (!link) {
 		return link;
 	}
@@ -87,7 +87,7 @@ u32_t memq_ut(void)
 		return 2;
 	}
 
-	link = memq_enqueue(0, &link_1[0], &tail);
+	link = memq_enqueue(&link_1[0], 0, &tail);
 	if ((link != &link_1[0]) || (tail != &link_1[0])) {
 		return 3;
 	}

--- a/subsys/bluetooth/controller/util/memq.h
+++ b/subsys/bluetooth/controller/util/memq.h
@@ -9,8 +9,8 @@
 #define _MEMQ_H_
 
 void *memq_init(void *link, void **head, void **tail);
-void *memq_enqueue(void *mem, void *link, void **tail);
-void *memq_peek(void *tail, void *head, void **mem);
+void *memq_enqueue(void *link, void *mem, void **tail);
+void *memq_peek(void *head, void *tail, void **mem);
 void *memq_dequeue(void *tail, void **head, void **mem);
 
 #endif


### PR DESCRIPTION
Optimised the parameter passing order of memq interface such
that the compiled code uses less space and execution time.

Having a parameter that gets returned as the first parameter
passed to a function avoids instructions required to have
the result in the return register.

Signed-off-by: Vinayak Kariappa Chettimada <vich@nordicsemi.no>