### PR TITLE
pinmux: esp32: Unnecessary iteration in "for" loop

### DIFF
--- a/drivers/pinmux/pinmux_esp32.c
+++ b/drivers/pinmux/pinmux_esp32.c
@@ -160,7 +160,7 @@ static int pinmux_initialize(struct device *device)
 {
 	u32_t pin;
 
-	for (pin = 0; pin <= ARRAY_SIZE(pin_mux_off); pin++) {
+	for (pin = 0; pin < ARRAY_SIZE(pin_mux_off); pin++) {
 		pinmux_set(NULL, pin, 0);
 	}
 


### PR DESCRIPTION
In this case: "pin == ARRAY_SIZE(pin_mux_off)" is invalid and it
isn't necessary to iterate.

Signed-off-by: Vitor Massaru Iha <vitor@massaru.org>