### PR TITLE
drivers: i2c_gpio: Use quoted #include directive for i2c_bitbang

### DIFF
--- a/drivers/i2c/i2c_gpio.c
+++ b/drivers/i2c/i2c_gpio.c
@@ -24,7 +24,7 @@
 #include <errno.h>
 #include <gpio.h>
 #include <i2c.h>
-#include <i2c_bitbang.h>
+#include "i2c_bitbang.h"
 
 /* Driver config */
 struct i2c_gpio_config {


### PR DESCRIPTION
i2c_bitbang.h is in drivers/i2c; it's not a system include.  Use quoted #include directive instead, otherwise it fails to build.