### PR TITLE
dts: stm32f1: Fix pinctrl node base address

### DIFF
--- a/dts/arm/st/stm32f1.dtsi
+++ b/dts/arm/st/stm32f1.dtsi
@@ -45,7 +45,7 @@
 			compatible = "st,stm32-pinmux";
 			#address-cells = <1>;
 			#size-cells = <1>;
-			reg = <0x40018000 0x1C00>;
+			reg = <0x40010800 0x1C00>;
 
 		};
 


### PR DESCRIPTION
Fix pinctrl node base address.

Fixes: #5085

Signed-off-by: Yannis Damigos <giannis.damigos@gmail.com>