### PR TITLE
Bluetooth: btp: Add events indicating provisioning link state

### DIFF
--- a/tests/bluetooth/tester/btp_spec.txt
+++ b/tests/bluetooth/tester/btp_spec.txt
@@ -1422,3 +1422,29 @@ Events:
 		Event parameters:	<none>
 
 		This event indicate that node was provisioned.
+
+	Opcode 0x84 - Link open Event
+
+		Controller Index:	<controller id>
+		Event parameters:	Bearer (1 octet)
+
+		Valid Bearer parameter values:
+
+					0x00 = PB-ADV
+					0x01 = PB-GATT
+
+		This event indicates that provisioning link has been opened on
+		given bearer.
+
+	Opcode 0x85 - Link closed Event
+
+		Controller Index:	<controller id>
+		Event parameters:	Bearer (1 octet)
+
+		Valid Bearer parameter values:
+
+					0x00 = PB-ADV
+					0x01 = PB-GATT
+
+		This event indicates that provisioning link has been closed on
+		given bearer.


### PR DESCRIPTION
This introduced two BTP events to indicate provisioning link state.
This is needed for testing purposes, since PTS requests tester to
confirm link state.

Signed-off-by: Mariusz Skamra <mariusz.skamra@codecoup.pl>