### PR TITLE
Bluetooth: Mesh: shell: Declare mandatory dependency on BT_MESH_CFG_CLI

### DIFF
--- a/subsys/bluetooth/host/mesh/Kconfig
+++ b/subsys/bluetooth/host/mesh/Kconfig
@@ -344,6 +344,7 @@ config BT_MESH_CFG_CLI
 config BT_MESH_SHELL
 	bool "Enable Bluetooth Mesh shell"
 	select CONSOLE_SHELL
+	depends on BT_MESH_CFG_CLI
 	help
 	  Activate shell module that provides Bluetooth Mesh commands to
 	  the console.


### PR DESCRIPTION
The Configuration Client is such a generally useful feature for the
shell that it makes sense to have it as a mandatory dependency (the
shell wasn't anyway compiling at the moment without it).

Signed-off-by: Johan Hedberg <johan.hedberg@intel.com>