### PR TITLE
LwM2M: separate write operation from write-attributes op

### DIFF
--- a/subsys/net/lib/lwm2m/lwm2m_engine.c
+++ b/subsys/net/lib/lwm2m/lwm2m_engine.c
@@ -702,32 +702,16 @@ static u16_t atou16(u8_t *buf, u16_t buflen, u16_t *len)
 static int coap_options_to_path(struct coap_option *opt, int options_count,
 				struct lwm2m_obj_path *path)
 {
-	u16_t len;
+	u16_t len, *id[4] = { &path->obj_id, &path->obj_inst_id,
+			      &path->res_id, &path->res_inst_id };
 
 	path->level = options_count;
-	path->obj_id = atou16(opt[0].value, opt[0].len, &len);
-	if (len == 0 || opt[0].len != len) {
-		path->level = 0;
-	}
 
-	if (path->level > 1) {
-		path->obj_inst_id = atou16(opt[1].value, opt[1].len, &len);
-		if (len == 0 || opt[1].len != len) {
-			path->level = 1;
-		}
-	}
-
-	if (path->level > 2) {
-		path->res_id = atou16(opt[2].value, opt[2].len, &len);
-		if (len == 0 || opt[2].len != len) {
-			path->level = 2;
-		}
-	}
-
-	if (path->level > 3) {
-		path->res_inst_id = atou16(opt[3].value, opt[3].len, &len);
-		if (len == 0 || opt[3].len != len) {
-			path->level = 3;
+	for (int i = 0; i < options_count; i++) {
+		*id[i] = atou16(opt[i].value, opt[i].len, &len);
+		if (len == 0 || opt[i].len != len) {
+			path->level = i;
+			break;
 		}
 	}
 

--- a/subsys/net/lib/lwm2m/lwm2m_engine.h
+++ b/subsys/net/lib/lwm2m/lwm2m_engine.h
@@ -23,6 +23,8 @@
 #define LWM2M_FORMAT_OMA_OLD_OPAQUE	1544
 #define LWM2M_FORMAT_OMA_TLV		11542
 #define LWM2M_FORMAT_OMA_JSON		11543
+/* 65000 ~ 65535 inclusive are reserved for experiments */
+#define LWM2M_FORMAT_NONE		65535
 
 
 #define COAP_RESPONSE_CODE_CLASS(x)	(x >> 5)


### PR DESCRIPTION
Content-format is used to determine the type of the PUT/POST request.
Therefore, it's incorrect to assign default when the caller does not include one in the request.

Changes are listed below
1. Define LWM2M_FORMAT_NONE=65535 to indicate the format is missing.
    The 65000~65535 is reserved for experiments and should be safe for the purpose.
1.  Check content-type at PUT method to setup write/write-attrs operation accordingly.
1.  Add reporting write-attrs as not implemented to the caller.

One non-related patch is to re-write coap_options_to_path() to save some code size.

