### PR TITLE
[RFC][DNM]: Bluetooth: controller: pwm_nrf5_sw co-existence

### DIFF
--- a/drivers/pwm/pwm_nrf5_sw.c
+++ b/drivers/pwm/pwm_nrf5_sw.c
@@ -204,10 +204,19 @@ static int pwm_nrf5_sw_init(struct device *dev)
 }
 
 #define PWM_0_MAP_SIZE 3
+/* NOTE: nRF51x BLE controller use HW tIFS hence using only PPI channels 0-6.
+ * nRF52x BLE controller implements SW tIFS and uses addition 6 PPI channels.
+ * Also, nRF52x requires one additional PPI channel for decryption rate boost.
+ * Hence, nRF52x BLE controller uses PPI channels 0-13.
+ *
+ * NOTE: If PA/LNA feature is enabled for nRF52x, then additional two PPI
+ * channels 14-15 are used by BLE controller.
+ */
+/* FIXME: For nRF51, use .timer = NRF_TIMER1, .ppi_base = 7 */
 static const struct pwm_config pwm_nrf5_sw_0_config = {
-	.timer = NRF_TIMER1,
+	.timer = NRF_TIMER2,
 	.gpiote_base = 0,
-	.ppi_base = 8,
+	.ppi_base = 14,
 	.map_size = PWM_0_MAP_SIZE,
 };
 

--- a/subsys/bluetooth/controller/hal/nrf5/radio.c
+++ b/subsys/bluetooth/controller/hal/nrf5/radio.c
@@ -429,7 +429,7 @@ void radio_tx_enable(void)
 void radio_disable(void)
 {
 #if !defined(CONFIG_BT_CTLR_TIFS_HW)
-	NRF_PPI->CHENCLR = PPI_CHEN_CH9_Msk | PPI_CHEN_CH12_Msk;
+	NRF_PPI->CHENCLR = PPI_CHEN_CH7_Msk | PPI_CHEN_CH10_Msk;
 	NRF_PPI->TASKS_CHG[0].DIS = 1;
 	NRF_PPI->TASKS_CHG[1].DIS = 1;
 #endif /* !CONFIG_BT_CTLR_TIFS_HW */
@@ -504,13 +504,13 @@ static u8_t sw_tifs_toggle;
 static void sw_switch(u8_t dir, u8_t phy_curr, u8_t flags_curr, u8_t phy_next,
 		      u8_t flags_next)
 {
-	u8_t ppi = 13 + sw_tifs_toggle;
+	u8_t ppi = 11 + sw_tifs_toggle;
 	u32_t delay;
 
 	NRF_TIMER1->EVENTS_COMPARE[sw_tifs_toggle] = 0;
 
-	NRF_PPI->CH[12].EEP = (u32_t)&(NRF_RADIO->EVENTS_END);
-	NRF_PPI->CH[12].TEP = (u32_t)&(NRF_PPI->TASKS_CHG[sw_tifs_toggle].EN);
+	NRF_PPI->CH[10].EEP = (u32_t)&(NRF_RADIO->EVENTS_END);
+	NRF_PPI->CH[10].TEP = (u32_t)&(NRF_PPI->TASKS_CHG[sw_tifs_toggle].EN);
 
 	NRF_PPI->CH[ppi].EEP = (u32_t)
 			       &(NRF_TIMER1->EVENTS_COMPARE[sw_tifs_toggle]);
@@ -533,7 +533,7 @@ static void sw_switch(u8_t dir, u8_t phy_curr, u8_t flags_curr, u8_t phy_next,
 		NRF_TIMER1->CC[sw_tifs_toggle] = 1;
 	}
 
-	NRF_PPI->CHENSET = PPI_CHEN_CH9_Msk | PPI_CHEN_CH12_Msk;
+	NRF_PPI->CHENSET = PPI_CHEN_CH7_Msk | PPI_CHEN_CH10_Msk;
 
 	sw_tifs_toggle += 1;
 	sw_tifs_toggle &= 1;
@@ -573,7 +573,7 @@ void radio_switch_complete_and_disable(void)
 	    (RADIO_SHORTS_READY_START_Msk | RADIO_SHORTS_END_DISABLE_Msk);
 
 #if !defined(CONFIG_BT_CTLR_TIFS_HW)
-	NRF_PPI->CHENCLR = PPI_CHEN_CH9_Msk | PPI_CHEN_CH12_Msk;
+	NRF_PPI->CHENCLR = PPI_CHEN_CH7_Msk | PPI_CHEN_CH10_Msk;
 #endif /* !CONFIG_BT_CTLR_TIFS_HW */
 }
 
@@ -659,7 +659,7 @@ void radio_tmr_status_reset(void)
 	NRF_PPI->CHENCLR =
 	    (PPI_CHEN_CH0_Msk | PPI_CHEN_CH1_Msk | PPI_CHEN_CH2_Msk |
 	     PPI_CHEN_CH3_Msk | PPI_CHEN_CH4_Msk | PPI_CHEN_CH5_Msk |
-	     PPI_CHEN_CH6_Msk | PPI_CHEN_CH15_Msk);
+	     PPI_CHEN_CH6_Msk | PPI_CHEN_CH13_Msk);
 }
 
 void radio_tmr_tifs_set(u32_t tifs)
@@ -707,17 +707,17 @@ u32_t radio_tmr_start(u8_t trx, u32_t ticks_start, u32_t remainder)
 	NRF_TIMER1->BITMODE = 0; /* 16 bit */
 	NRF_TIMER1->TASKS_START = 1;
 
-	NRF_PPI->CH[9].EEP = (u32_t)&(NRF_RADIO->EVENTS_END);
-	NRF_PPI->CH[9].TEP = (u32_t)&(NRF_TIMER1->TASKS_CLEAR);
+	NRF_PPI->CH[7].EEP = (u32_t)&(NRF_RADIO->EVENTS_END);
+	NRF_PPI->CH[7].TEP = (u32_t)&(NRF_TIMER1->TASKS_CLEAR);
 
-	NRF_PPI->CH[10].EEP = (u32_t)&(NRF_TIMER1->EVENTS_COMPARE[0]);
-	NRF_PPI->CH[10].TEP = (u32_t)&(NRF_PPI->TASKS_CHG[0].DIS);
+	NRF_PPI->CH[8].EEP = (u32_t)&(NRF_TIMER1->EVENTS_COMPARE[0]);
+	NRF_PPI->CH[8].TEP = (u32_t)&(NRF_PPI->TASKS_CHG[0].DIS);
 
-	NRF_PPI->CH[11].EEP = (u32_t)&(NRF_TIMER1->EVENTS_COMPARE[1]);
-	NRF_PPI->CH[11].TEP = (u32_t)&(NRF_PPI->TASKS_CHG[1].DIS);
+	NRF_PPI->CH[9].EEP = (u32_t)&(NRF_TIMER1->EVENTS_COMPARE[1]);
+	NRF_PPI->CH[9].TEP = (u32_t)&(NRF_PPI->TASKS_CHG[1].DIS);
 
-	NRF_PPI->CHG[0] = PPI_CHG_CH10_Msk | PPI_CHG_CH13_Msk;
-	NRF_PPI->CHG[1] = PPI_CHG_CH11_Msk | PPI_CHG_CH14_Msk;
+	NRF_PPI->CHG[0] = PPI_CHG_CH8_Msk | PPI_CHG_CH11_Msk;
+	NRF_PPI->CHG[1] = PPI_CHG_CH9_Msk | PPI_CHG_CH12_Msk;
 #endif /* !CONFIG_BT_CTLR_TIFS_HW */
 
 	return remainder;
@@ -908,20 +908,20 @@ void radio_gpio_pa_lna_enable(u32_t trx_us)
 	NRF_TIMER0->CC[2] = trx_us;
 	NRF_TIMER0->EVENTS_COMPARE[2] = 0;
 
-	NRF_PPI->CH[7].EEP = (u32_t)&(NRF_TIMER0->EVENTS_COMPARE[2]);
-	NRF_PPI->CH[7].TEP = (u32_t)
+	NRF_PPI->CH[14].EEP = (u32_t)&(NRF_TIMER0->EVENTS_COMPARE[2]);
+	NRF_PPI->CH[14].TEP = (u32_t)
 		&(NRF_GPIOTE->TASKS_OUT[CONFIG_BT_CTLR_PA_LNA_GPIOTE_CHAN]);
 
-	NRF_PPI->CH[8].EEP = (u32_t)&(NRF_RADIO->EVENTS_DISABLED);
-	NRF_PPI->CH[8].TEP = (u32_t)
+	NRF_PPI->CH[15].EEP = (u32_t)&(NRF_RADIO->EVENTS_DISABLED);
+	NRF_PPI->CH[15].TEP = (u32_t)
 		&(NRF_GPIOTE->TASKS_OUT[CONFIG_BT_CTLR_PA_LNA_GPIOTE_CHAN]);
 
-	NRF_PPI->CHENSET = PPI_CHEN_CH7_Msk | PPI_CHEN_CH8_Msk;
+	NRF_PPI->CHENSET = PPI_CHEN_CH14_Msk | PPI_CHEN_CH15_Msk;
 }
 
 void radio_gpio_pa_lna_disable(void)
 {
-	NRF_PPI->CHENCLR = PPI_CHEN_CH7_Msk | PPI_CHEN_CH8_Msk;
+	NRF_PPI->CHENCLR = PPI_CHEN_CH14_Msk | PPI_CHEN_CH15_Msk;
 }
 #endif /* CONFIG_BT_CTLR_GPIO_PA_PIN || CONFIG_BT_CTLR_GPIO_LNA_PIN */
 
@@ -966,9 +966,9 @@ void *radio_ccm_rx_pkt_set(struct ccm *ccm, u8_t phy, void *pkt)
 			 CCM_RATEOVERRIDE_RATEOVERRIDE_Pos) &
 			CCM_RATEOVERRIDE_RATEOVERRIDE_Msk;
 
-		NRF_PPI->CH[15].EEP = (u32_t)&(NRF_RADIO->EVENTS_RATEBOOST);
-		NRF_PPI->CH[15].TEP = (u32_t)&(NRF_CCM->TASKS_RATEOVERRIDE);
-		NRF_PPI->CHENSET = PPI_CHEN_CH15_Msk;
+		NRF_PPI->CH[13].EEP = (u32_t)&(NRF_RADIO->EVENTS_RATEBOOST);
+		NRF_PPI->CH[13].TEP = (u32_t)&(NRF_CCM->TASKS_RATEOVERRIDE);
+		NRF_PPI->CHENSET = PPI_CHEN_CH13_Msk;
 		break;
 #endif /* CONFIG_SOC_NRF52840 */
 	}


### PR DESCRIPTION
This is a PR to welcome comments from users of nRF5 SoC with both BLE and pwm_nrf5_sw implementation.

Due to recent changes in BLE controller implementation, PPI channels used overlap the ones used by pwm_nrf5_sw. This PR tries to address the issues.