### PR TITLE
Bluetooth: controller: Replace void * with memq_link_t

### DIFF
--- a/subsys/bluetooth/controller/ll_sw/ctrl.c
+++ b/subsys/bluetooth/controller/ll_sw/ctrl.c
@@ -198,12 +198,11 @@ static struct {
 	u8_t  packet_rx_acquire;
 
 	/* Controller to Host event-cum-data queue */
-	void  *link_rx_pool;
-	void  *link_rx_free;
-	void  *link_rx_head;
-
-	void  *volatile link_rx_tail;
-	u8_t  link_rx_data_quota;
+	void        *link_rx_pool;
+	void        *link_rx_free;
+	memq_link_t *link_rx_head;
+	memq_link_t *volatile link_rx_tail;
+	u8_t        link_rx_data_quota;
 
 	/* Connections common Tx ctrl and data pool */
 	void  *pkt_tx_ctrl_pool;
@@ -412,8 +411,8 @@ u32_t radio_init(void *hf_clock, u8_t sca, u8_t connection_count_max,
 
 	/* initialise rx link pool memory */
 	_radio.link_rx_pool = mem_radio;
-	mem_radio += (sizeof(void *) * 2 * (_radio.packet_rx_count +
-					    _radio.connection_count));
+	mem_radio += (sizeof(memq_link_t) * (_radio.packet_rx_count +
+					     _radio.connection_count));
 
 	/* initialise tx ctrl pool memory */
 	_radio.pkt_tx_ctrl_pool = mem_radio;
@@ -508,7 +507,7 @@ void ll_reset(void)
 
 static void common_init(void)
 {
-	void *link;
+	memq_link_t *link;
 
 	/* initialise connection pool. */
 	if (_radio.connection_count) {
@@ -526,7 +525,7 @@ static void common_init(void)
 		 &_radio.pkt_rx_data_free);
 
 	/* initialise rx link pool. */
-	mem_init(_radio.link_rx_pool, (sizeof(void *) * 2),
+	mem_init(_radio.link_rx_pool, (sizeof(memq_link_t)),
 		 (_radio.packet_rx_count + _radio.connection_count),
 		 &_radio.link_rx_free);
 
@@ -4309,8 +4308,8 @@ static void mayfly_radio_active(void *params)
 static void event_active(u32_t ticks_at_expire, u32_t remainder,
 			 u16_t lazy, void *context)
 {
-	static void *s_link[2];
-	static struct mayfly s_mfy_radio_active = {0, 0, s_link, (void *)1,
+	static memq_link_t s_link;
+	static struct mayfly s_mfy_radio_active = {0, 0, &s_link, (void *)1,
 						   mayfly_radio_active};
 	u32_t retval;
 
@@ -4337,8 +4336,8 @@ static void mayfly_radio_inactive(void *params)
 static void event_inactive(u32_t ticks_at_expire, u32_t remainder,
 			   u16_t lazy, void *context)
 {
-	static void *s_link[2];
-	static struct mayfly s_mfy_radio_inactive = {0, 0, s_link, NULL,
+	static memq_link_t s_link;
+	static struct mayfly s_mfy_radio_inactive = {0, 0, &s_link, NULL,
 						     mayfly_radio_inactive};
 	u32_t retval;
 
@@ -4364,8 +4363,8 @@ static void mayfly_xtal_start(void *params)
 static void event_xtal(u32_t ticks_at_expire, u32_t remainder,
 		       u16_t lazy, void *context)
 {
-	static void *s_link[2];
-	static struct mayfly s_mfy_xtal_start = {0, 0, s_link, NULL,
+	static memq_link_t s_link;
+	static struct mayfly s_mfy_xtal_start = {0, 0, &s_link, NULL,
 						 mayfly_xtal_start};
 	u32_t retval;
 
@@ -4396,8 +4395,8 @@ static void mayfly_xtal_retain(u8_t caller_id, u8_t retain)
 
 	if (retain) {
 		if (!s_xtal_retained) {
-			static void *s_link[2];
-			static struct mayfly s_mfy_xtal_start = {0, 0, s_link,
+			static memq_link_t s_link;
+			static struct mayfly s_mfy_xtal_start = {0, 0, &s_link,
 				NULL, mayfly_xtal_start};
 			u32_t retval;
 
@@ -4413,10 +4412,10 @@ static void mayfly_xtal_retain(u8_t caller_id, u8_t retain)
 		}
 	} else {
 		if (s_xtal_retained) {
-			static void *s_link[2][2];
+			static memq_link_t s_link[2];
 			static struct mayfly s_mfy_xtal_stop[2] = {
-				{0, 0, s_link[0], NULL, mayfly_xtal_stop},
-				{0, 0, s_link[1], NULL, mayfly_xtal_stop}
+				{0, 0, &s_link[0], NULL, mayfly_xtal_stop},
+				{0, 0, &s_link[1], NULL, mayfly_xtal_stop}
 			};
 			struct mayfly *p_mfy_xtal_stop = NULL;
 			u32_t retval;
@@ -5181,8 +5180,8 @@ static void mayfly_radio_stop(void *params)
 static void event_stop(u32_t ticks_at_expire, u32_t remainder,
 		       u16_t lazy, void *context)
 {
-	static void *s_link[2];
-	static struct mayfly s_mfy_radio_stop = {0, 0, s_link, NULL,
+	static memq_link_t s_link;
+	static struct mayfly s_mfy_radio_stop = {0, 0, &s_link, NULL,
 						 mayfly_radio_stop};
 	u32_t retval;
 
@@ -5345,8 +5344,8 @@ static void event_common_prepare(u32_t ticks_at_expire,
 #if defined(CONFIG_BT_CTLR_XTAL_ADVANCED)
 	/* calc whether xtal needs to be retained after this event */
 	{
-		static void *s_link[2];
-		static struct mayfly s_mfy_xtal_stop_calc = {0, 0, s_link, NULL,
+		static memq_link_t s_link;
+		static struct mayfly s_mfy_xtal_stop_calc = {0, 0, &s_link, NULL,
 			mayfly_xtal_stop_calc};
 		u32_t retval;
 
@@ -5879,8 +5878,8 @@ static void mayfly_adv_stop(void *param)
 
 static inline void ticker_stop_adv_stop_active(void)
 {
-	static void *s_link[2];
-	static struct mayfly s_mfy_radio_inactive = {0, 0, s_link, NULL,
+	static memq_link_t s_link;
+	static struct mayfly s_mfy_radio_inactive = {0, 0, &s_link, NULL,
 		mayfly_radio_inactive};
 	u32_t volatile ret_cb = TICKER_STATUS_BUSY;
 	u32_t ret;
@@ -5901,8 +5900,8 @@ static inline void ticker_stop_adv_stop_active(void)
 	}
 
 	if (ret_cb == TICKER_STATUS_SUCCESS) {
-		static void *s_link[2];
-		static struct mayfly s_mfy_xtal_stop = {0, 0, s_link, NULL,
+		static memq_link_t s_link;
+		static struct mayfly s_mfy_xtal_stop = {0, 0, &s_link, NULL,
 			mayfly_xtal_stop};
 		u32_t volatile ret_cb = TICKER_STATUS_BUSY;
 		u32_t ret;
@@ -5980,8 +5979,8 @@ static inline void ticker_stop_adv_stop_active(void)
 		 * (role dependent)
 		 */
 		if (_radio.role != ROLE_NONE) {
-			static void *s_link[2];
-			static struct mayfly s_mfy_radio_stop = {0, 0, s_link,
+			static memq_link_t s_link;
+			static struct mayfly s_mfy_radio_stop = {0, 0, &s_link,
 				NULL, mayfly_radio_stop};
 			u32_t retval;
 
@@ -6006,8 +6005,8 @@ static inline void ticker_stop_adv_stop_active(void)
 
 static void ticker_stop_adv_stop(u32_t status, void *params)
 {
-	static void *s_link[2];
-	static struct mayfly s_mfy_adv_stop = {0, 0, s_link, NULL,
+	static memq_link_t s_link;
+	static struct mayfly s_mfy_adv_stop = {0, 0, &s_link, NULL,
 					       mayfly_adv_stop};
 	u32_t retval;
 
@@ -6079,9 +6078,9 @@ static void event_scan_prepare(u32_t ticks_at_expire, u32_t remainder,
 	 * to be placed
 	 */
 	if (_radio.scanner.conn) {
-		static void *s_link[2];
+		static memq_link_t s_link;
 		static struct mayfly s_mfy_sched_after_mstr_free_offset_get = {
-			0, 0, s_link, NULL,
+			0, 0, &s_link, NULL,
 			mayfly_sched_after_mstr_free_offset_get};
 		u32_t ticks_at_expire_normal = ticks_at_expire;
 		u32_t retval;
@@ -6329,9 +6328,9 @@ static inline u32_t event_conn_upd_prep(struct connection *conn,
 			  0xffff;
 	if (conn->llcp.conn_upd.state != LLCP_CUI_STATE_INPROG) {
 #if defined(CONFIG_BT_CTLR_SCHED_ADVANCED)
-		static void *s_link[2];
+		static memq_link_t s_link;
 		static struct mayfly s_mfy_sched_offset = {0, 0,
-			s_link, 0, 0 };
+			&s_link, 0, 0 };
 		void (*fp_mayfly_select_or_use)(void *) = NULL;
 #endif /* CONFIG_BT_CTLR_SCHED_ADVANCED */
 		struct radio_pdu_node_tx *node_tx;
@@ -6985,8 +6984,8 @@ static inline void event_conn_param_req(struct connection *conn,
 
 #if defined(CONFIG_BT_CTLR_SCHED_ADVANCED)
 	{
-		static void *s_link[2];
-		static struct mayfly s_mfy_sched_offset = {0, 0, s_link, NULL,
+		static memq_link_t s_link;
+		static struct mayfly s_mfy_sched_offset = {0, 0, &s_link, NULL,
 			mayfly_sched_free_win_offset_calc};
 		u32_t retval;
 
@@ -8487,8 +8486,8 @@ static void packet_rx_callback(void)
 #if (RADIO_TICKER_USER_ID_WORKER_PRIO == RADIO_TICKER_USER_ID_JOB_PRIO)
 	radio_event_callback();
 #else
-	static void *s_link[2];
-	static struct mayfly s_mfy_callback = {0, 0, s_link, NULL,
+	static memq_link_t s_link;
+	static struct mayfly s_mfy_callback = {0, 0, &s_link, NULL,
 		(void *)radio_event_callback};
 
 	mayfly_enqueue(RADIO_TICKER_USER_ID_WORKER, RADIO_TICKER_USER_ID_JOB, 1,
@@ -8498,8 +8497,8 @@ static void packet_rx_callback(void)
 
 static void packet_rx_enqueue(void)
 {
-	void *link;
 	struct radio_pdu_node_rx *radio_pdu_node_rx;
+	memq_link_t *link;
 	u8_t last;
 
 	LL_ASSERT(_radio.packet_rx_last != _radio.packet_rx_acquire);
@@ -8807,7 +8806,7 @@ static void connection_release(struct connection *conn)
 static void terminate_ind_rx_enqueue(struct connection *conn, u8_t reason)
 {
 	struct radio_pdu_node_rx *radio_pdu_node_rx;
-	void *link;
+	memq_link_t *link;
 
 	/* Prepare the rx packet structure */
 	radio_pdu_node_rx = (void *)&conn->llcp_terminate.radio_pdu_node_rx;
@@ -9474,8 +9473,8 @@ static inline void role_active_disable(u8_t ticker_id_stop,
 				       u32_t ticks_xtal_to_start,
 				       u32_t ticks_active_to_start)
 {
-	static void *s_link[2];
-	static struct mayfly s_mfy_radio_inactive = {0, 0, s_link, NULL,
+	static memq_link_t s_link;
+	static struct mayfly s_mfy_radio_inactive = {0, 0, &s_link, NULL,
 		mayfly_radio_inactive};
 	u32_t volatile ret_cb = TICKER_STATUS_BUSY;
 	u32_t ret;
@@ -9493,8 +9492,8 @@ static inline void role_active_disable(u8_t ticker_id_stop,
 	}
 
 	if (ret_cb == TICKER_STATUS_SUCCESS) {
-		static void *s_link[2];
-		static struct mayfly s_mfy_xtal_stop = {0, 0, s_link, NULL,
+		static memq_link_t s_link;
+		static struct mayfly s_mfy_xtal_stop = {0, 0, &s_link, NULL,
 			mayfly_xtal_stop};
 		u32_t volatile ret_cb = TICKER_STATUS_BUSY;
 		u32_t ret;
@@ -9598,8 +9597,8 @@ static inline void role_active_disable(u8_t ticker_id_stop,
 
 		/* Force Radio ISR execution and wait for role to stop */
 		if (_radio.role != ROLE_NONE) {
-			static void *s_link[2];
-			static struct mayfly s_mfy_radio_stop = {0, 0, s_link,
+			static memq_link_t s_link;
+			static struct mayfly s_mfy_radio_stop = {0, 0, &s_link,
 				NULL, mayfly_radio_stop};
 			u32_t retval;
 
@@ -10890,7 +10889,7 @@ u8_t radio_rx_get(struct radio_pdu_node_rx **radio_pdu_node_rx, u16_t *handle)
 	if (_radio.link_rx_head != _radio.link_rx_tail) {
 		struct radio_pdu_node_rx *_radio_pdu_node_rx;
 
-		_radio_pdu_node_rx = *((void **)_radio.link_rx_head + 1);
+		_radio_pdu_node_rx = _radio.link_rx_head->mem;
 
 		cmplt = tx_cmplt_get(handle,
 				&_radio.packet_release_first,
@@ -10926,7 +10925,7 @@ u8_t radio_rx_get(struct radio_pdu_node_rx **radio_pdu_node_rx, u16_t *handle)
 void radio_rx_dequeue(void)
 {
 	struct radio_pdu_node_rx *radio_pdu_node_rx = NULL;
-	void *link;
+	memq_link_t *link;
 
 	link = memq_dequeue(_radio.link_rx_tail, &_radio.link_rx_head,
 			    (void **)&radio_pdu_node_rx);

--- a/subsys/bluetooth/controller/ll_sw/ll.c
+++ b/subsys/bluetooth/controller/ll_sw/ll.c
@@ -28,6 +28,7 @@
 
 #include "util/util.h"
 #include "util/mem.h"
+#include "util/memq.h"
 #include "util/mayfly.h"
 
 #include "ticker/ticker.h"

--- a/subsys/bluetooth/controller/ticker/ticker.c
+++ b/subsys/bluetooth/controller/ticker/ticker.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016 Nordic Semiconductor ASA
+ * Copyright (c) 2016-2017 Nordic Semiconductor ASA
  * Copyright (c) 2016 Vinayak Kariappa Chettimada
  *
  * SPDX-License-Identifier: Apache-2.0
@@ -9,6 +9,7 @@
 #include <soc.h>
 
 #include "hal/cntr.h"
+#include "memq.h"
 #include "ticker.h"
 
 #include "common/log.h"
@@ -1190,9 +1191,9 @@ static void ticker_instance0_sched(u8_t caller_id, u8_t callee_id, u8_t chain)
 		switch (callee_id) {
 		case CALL_ID_WORKER:
 		{
-			static void *link[2];
+			static memq_link_t link;
 			static struct mayfly m = {
-				0, 0, link,
+				0, 0, &link,
 				&_instance[0],
 				(void *)ticker_worker
 			};
@@ -1214,9 +1215,9 @@ static void ticker_instance0_sched(u8_t caller_id, u8_t callee_id, u8_t chain)
 		switch (callee_id) {
 		case CALL_ID_JOB:
 		{
-			static void *link[2];
+			static memq_link_t link;
 			static struct mayfly m = {
-				0, 0, link,
+				0, 0, &link,
 				(void *)&_instance[0],
 				(void *)ticker_job
 			};
@@ -1238,9 +1239,9 @@ static void ticker_instance0_sched(u8_t caller_id, u8_t callee_id, u8_t chain)
 		switch (callee_id) {
 		case CALL_ID_WORKER:
 		{
-			static void *link[2];
+			static memq_link_t link;
 			static struct mayfly m = {
-				0, 0, link,
+				0, 0, &link,
 				(void *)&_instance[0],
 				(void *)ticker_worker
 			};
@@ -1254,9 +1255,9 @@ static void ticker_instance0_sched(u8_t caller_id, u8_t callee_id, u8_t chain)
 
 		case CALL_ID_JOB:
 		{
-			static void *link[2];
+			static memq_link_t link;
 			static struct mayfly m = {
-				0, 0, link,
+				0, 0, &link,
 				(void *)&_instance[0],
 				(void *)ticker_job
 			};
@@ -1278,9 +1279,9 @@ static void ticker_instance0_sched(u8_t caller_id, u8_t callee_id, u8_t chain)
 		switch (callee_id) {
 		case CALL_ID_JOB:
 		{
-			static void *link[2];
+			static memq_link_t link;
 			static struct mayfly m = {
-				0, 0, link,
+				0, 0, &link,
 				(void *)&_instance[0],
 				(void *)ticker_job
 			};
@@ -1316,9 +1317,9 @@ static void ticker_instance1_sched(u8_t caller_id, u8_t callee_id, u8_t chain)
 		switch (callee_id) {
 		case CALL_ID_WORKER:
 		{
-			static void *link[2];
+			static memq_link_t link;
 			static struct mayfly m = {
-				0, 0, link,
+				0, 0, &link,
 				&_instance[1],
 				(void *)ticker_worker
 			};
@@ -1340,9 +1341,9 @@ static void ticker_instance1_sched(u8_t caller_id, u8_t callee_id, u8_t chain)
 		switch (callee_id) {
 		case CALL_ID_JOB:
 		{
-			static void *link[2];
+			static memq_link_t link;
 			static struct mayfly m = {
-				0, 0, link,
+				0, 0, &link,
 				(void *)&_instance[1],
 				(void *)ticker_job
 			};
@@ -1364,9 +1365,9 @@ static void ticker_instance1_sched(u8_t caller_id, u8_t callee_id, u8_t chain)
 		switch (callee_id) {
 		case CALL_ID_WORKER:
 		{
-			static void *link[2];
+			static memq_link_t link;
 			static struct mayfly m = {
-				0, 0, link,
+				0, 0, &link,
 				(void *)&_instance[1],
 				(void *)ticker_worker
 			};
@@ -1380,9 +1381,9 @@ static void ticker_instance1_sched(u8_t caller_id, u8_t callee_id, u8_t chain)
 
 		case CALL_ID_JOB:
 		{
-			static void *link[2];
+			static memq_link_t link;
 			static struct mayfly m = {
-				0, 0, link,
+				0, 0, &link,
 				(void *)&_instance[1],
 				(void *)ticker_job
 			};
@@ -1404,9 +1405,9 @@ static void ticker_instance1_sched(u8_t caller_id, u8_t callee_id, u8_t chain)
 		switch (callee_id) {
 		case CALL_ID_JOB:
 		{
-			static void *link[2];
+			static memq_link_t link;
 			static struct mayfly m = {
-				0, 0, link,
+				0, 0, &link,
 				(void *)&_instance[1],
 				(void *)ticker_job
 			};

--- a/subsys/bluetooth/controller/util/mayfly.c
+++ b/subsys/bluetooth/controller/util/mayfly.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016 Nordic Semiconductor ASA
+ * Copyright (c) 2016-2017 Nordic Semiconductor ASA
  * Copyright (c) 2016 Vinayak Kariappa Chettimada
  *
  * SPDX-License-Identifier: Apache-2.0
@@ -10,15 +10,15 @@
 #include "mayfly.h"
 
 static struct {
-	void *head;
-	void *tail;
-	u8_t enable_req;
-	u8_t enable_ack;
-	u8_t disable_req;
-	u8_t disable_ack;
+	memq_link_t *head;
+	memq_link_t *tail;
+	u8_t        enable_req;
+	u8_t        enable_ack;
+	u8_t        disable_req;
+	u8_t        disable_ack;
 } mft[MAYFLY_CALLEE_COUNT][MAYFLY_CALLER_COUNT];
 
-static void *mfl[MAYFLY_CALLEE_COUNT][MAYFLY_CALLER_COUNT][2];
+static memq_link_t mfl[MAYFLY_CALLEE_COUNT][MAYFLY_CALLER_COUNT];
 
 void mayfly_init(void)
 {
@@ -30,7 +30,7 @@ void mayfly_init(void)
 
 		caller_id = MAYFLY_CALLER_COUNT;
 		while (caller_id--) {
-			memq_init(mfl[callee_id][caller_id],
+			memq_init(&mfl[callee_id][caller_id],
 				  &mft[callee_id][caller_id].head,
 				  &mft[callee_id][caller_id].tail);
 		}
@@ -119,7 +119,7 @@ void mayfly_run(u8_t callee_id)
 	/* iterate through each caller queue to this callee_id */
 	caller_id = MAYFLY_CALLER_COUNT;
 	while (caller_id--) {
-		void *link;
+		memq_link_t *link;
 		struct mayfly *m = 0;
 
 		/* fetch mayfly in callee queue, if any */

--- a/subsys/bluetooth/controller/util/mayfly.h
+++ b/subsys/bluetooth/controller/util/mayfly.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016 Nordic Semiconductor ASA
+ * Copyright (c) 2016-2017 Nordic Semiconductor ASA
  * Copyright (c) 2016 Vinayak Kariappa Chettimada
  *
  * SPDX-License-Identifier: Apache-2.0
@@ -18,7 +18,7 @@
 struct mayfly {
 	u8_t volatile _req;
 	u8_t _ack;
-	void *_link;
+	memq_link_t *_link;
 	void *param;
 	void (*fp)(void *);
 };

--- a/subsys/bluetooth/controller/util/memq.c
+++ b/subsys/bluetooth/controller/util/memq.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016 Nordic Semiconductor ASA
+ * Copyright (c) 2016-2017 Nordic Semiconductor ASA
  * Copyright (c) 2016 Vinayak Kariappa Chettimada
  *
  * SPDX-License-Identifier: Apache-2.0
@@ -8,23 +8,25 @@
 #include <zephyr/types.h>
 #include <stddef.h>
 
-inline void *memq_peek(void *head, void *tail, void **mem);
+#include "memq.h"
 
-void *memq_init(void *link, void **head, void **tail)
+inline memq_link_t *memq_peek(memq_link_t *head, memq_link_t *tail, void **mem);
+
+memq_link_t *memq_init(memq_link_t *link, memq_link_t **head, memq_link_t **tail)
 {
-	/* head and tail pointer to the initial link node */
+	/* head and tail pointer to the initial link */
 	*head = *tail = link;
 
 	return link;
 }
 
-void *memq_enqueue(void *link, void *mem, void **tail)
+memq_link_t *memq_enqueue(memq_link_t *link, void *mem, memq_link_t **tail)
 {
-	/* make the current tail link node point to new link node */
-	*((void **)*tail) = link;
+	/* make the current tail link's next point to new link */
+	(*tail)->next = link;
 
-	/* assign mem to current tail link node */
-	*((void **)*tail + 1) = mem;
+	/* assign mem to current tail link's mem */
+	(*tail)->mem = mem;
 
 	/* increment the tail! */
 	*tail = link;
@@ -32,29 +34,24 @@ void *memq_enqueue(void *link, void *mem, void **tail)
 	return link;
 }
 
-void *memq_peek(void *head, void *tail, void **mem)
+memq_link_t *memq_peek(memq_link_t *head, memq_link_t *tail, void **mem)
 {
-	void *link;
-
 	/* if head and tail are equal, then queue empty */
 	if (head == tail) {
 		return NULL;
 	}
 
-	/* pick the head link node */
-	link = head;
-
-	/* extract the element node */
+	/* extract the link's mem */
 	if (mem) {
-		*mem = *((void **)link + 1);
+		*mem = head->mem;
 	}
 
-	return link;
+	return head;
 }
 
-void *memq_dequeue(void *tail, void **head, void **mem)
+memq_link_t *memq_dequeue(memq_link_t *tail, memq_link_t **head, void **mem)
 {
-	void *link;
+	memq_link_t *link;
 
 	/* use memq peek to get the link and mem */
 	link = memq_peek(*head, tail, mem);
@@ -63,40 +60,7 @@ void *memq_dequeue(void *tail, void **head, void **mem)
 	}
 
 	/* increment the head to next link node */
-	*head = *((void **)link);
+	*head = link->next;
 
 	return link;
-}
-
-u32_t memq_ut(void)
-{
-	void *head;
-	void *tail;
-	void *link;
-	void *link_0[2];
-	void *link_1[2];
-
-	link = memq_init(&link_0[0], &head, &tail);
-	if ((link != &link_0[0]) || (head != &link_0[0])
-	    || (tail != &link_0[0])) {
-		return 1;
-	}
-
-	link = memq_dequeue(tail, &head, NULL);
-	if ((link) || (head != &link_0[0])) {
-		return 2;
-	}
-
-	link = memq_enqueue(&link_1[0], 0, &tail);
-	if ((link != &link_1[0]) || (tail != &link_1[0])) {
-		return 3;
-	}
-
-	link = memq_dequeue(tail, &head, NULL);
-	if ((link != &link_0[0]) || (tail != &link_1[0])
-	    || (head != &link_1[0])) {
-		return 4;
-	}
-
-	return 0;
 }

--- a/subsys/bluetooth/controller/util/memq.h
+++ b/subsys/bluetooth/controller/util/memq.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016 Nordic Semiconductor ASA
+ * Copyright (c) 2016-2017 Nordic Semiconductor ASA
  * Copyright (c) 2016 Vinayak Kariappa Chettimada
  *
  * SPDX-License-Identifier: Apache-2.0
@@ -8,9 +8,17 @@
 #ifndef _MEMQ_H_
 #define _MEMQ_H_
 
-void *memq_init(void *link, void **head, void **tail);
-void *memq_enqueue(void *link, void *mem, void **tail);
-void *memq_peek(void *head, void *tail, void **mem);
-void *memq_dequeue(void *tail, void **head, void **mem);
+struct _memq_link {
+	struct _memq_link *next;
+	void              *mem;
+};
 
-#endif
+typedef struct _memq_link memq_link_t;
+
+memq_link_t *memq_init(memq_link_t *link, memq_link_t **head,
+		       memq_link_t **tail);
+memq_link_t *memq_enqueue(memq_link_t *link, void *mem, memq_link_t **tail);
+memq_link_t *memq_peek(memq_link_t *head, memq_link_t *tail, void **mem);
+memq_link_t *memq_dequeue(memq_link_t *tail, memq_link_t **head, void **mem);
+
+#endif /* _MEMQ_H_ */


### PR DESCRIPTION
Replace use if void * declaration related to memq links with
more readable memq_link_t.

Signed-off-by: Carles Cufi <carles.cufi@nordicsemi.no>
Signed-off-by: Vinayak Kariappa Chettimada <vich@nordicsemi.no>