### PR TITLE
generate artifacts based on Kconfig defined by SoC/Board

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -667,16 +667,6 @@ set_target_properties(${logical_target_for_zephyr_elf} PROPERTIES OUTPUT_NAME ${
 
 set(post_build_commands "")
 
-# TODO: Write a KConfig for these options instead
-set(CONFIG_CHECK_LINK_MAP 1)
-
-set(CONFIG_BUILD_OUTPUT_HEX 1)
-set(CONFIG_BUILD_OUTPUT_BIN 1)
-set(CONFIG_BUILD_OUTPUT_S19 1)
-set(CONFIG_BUILD_OUTPUT_DISASSEMBLY 1)
-set(CONFIG_BUILD_OUTPUT_STAT 1)
-set(CONFIG_BUILD_OUTPUT_STRIPPED 1)
-
 list_append_ifdef(CONFIG_CHECK_LINK_MAP
   post_build_commands
   COMMAND ${PYTHON_EXECUTABLE} $ENV{ZEPHYR_BASE}/scripts/check_link_map.py ${KERNEL_MAP_NAME}
@@ -700,13 +690,13 @@ list_append_ifdef(
   )
 
 list_append_ifdef(
-  CONFIG_BUILD_OUTPUT_DISASSEMBLY
+  CONFIG_OUTPUT_DISASSEMBLY
   post_build_commands
   COMMAND ${CMAKE_OBJDUMP} -S ${KERNEL_ELF_NAME} >  ${KERNEL_LST_NAME}
   )
 
 list_append_ifdef(
-  CONFIG_BUILD_OUTPUT_STAT
+  CONFIG_OUTPUT_STAT
   post_build_commands
   COMMAND ${CMAKE_READELF} -e ${KERNEL_ELF_NAME} >  ${KERNEL_STAT_NAME}
   )

--- a/arch/arm/soc/nordic_nrf5/Kconfig.defconfig
+++ b/arch/arm/soc/nordic_nrf5/Kconfig.defconfig
@@ -7,6 +7,9 @@
 
 if SOC_FAMILY_NRF5
 
+config BUILD_OUTPUT_HEX
+	default y
+
 if SERIAL
 
 config GPIO

--- a/arch/arm/soc/st_stm32/Kconfig
+++ b/arch/arm/soc/st_stm32/Kconfig
@@ -11,6 +11,10 @@ config SOC_FAMILY_STM32
 	default n
 
 if SOC_FAMILY_STM32
+
+config BUILD_OUTPUT_HEX
+        default y
+
 config SOC_FAMILY
 	string
 	default st_stm32

--- a/arch/nios2/Kconfig
+++ b/arch/nios2/Kconfig
@@ -26,6 +26,7 @@ menu "Nios II Gen 2 Processor Options"
 config CPU_NIOS2_GEN2
 	bool
 	default y
+	select BUILD_OUTPUT_HEX
 	help
 	This option signifies the use of a Nios II Gen 2 CPU
 

--- a/boards/arm/qemu_cortex_m3/Kconfig.defconfig
+++ b/boards/arm/qemu_cortex_m3/Kconfig.defconfig
@@ -1,6 +1,9 @@
 
 if BOARD_QEMU_CORTEX_M3
 
+config BUILD_OUTPUT_BIN
+        default n
+
 config BOARD
 	default qemu_cortex_m3
 

--- a/boards/nios2/qemu_nios2/Kconfig.defconfig
+++ b/boards/nios2/qemu_nios2/Kconfig.defconfig
@@ -1,5 +1,8 @@
 if BOARD_QEMU_NIOS2
 
+config BUILD_OUTPUT_BIN
+        default n
+
 config BOARD
 	default "qemu_nios2"
 

--- a/boards/riscv32/qemu_riscv32/Kconfig.defconfig
+++ b/boards/riscv32/qemu_riscv32/Kconfig.defconfig
@@ -1,5 +1,8 @@
 if BOARD_QEMU_RISCV32
 
+config BUILD_OUTPUT_BIN
+        default n
+
 config BOARD
 	default "qemu_riscv32"
 

--- a/boards/riscv32/zedboard_pulpino/Kconfig.board
+++ b/boards/riscv32/zedboard_pulpino/Kconfig.board
@@ -2,3 +2,4 @@
 config BOARD_ZEDBOARD_PULPINO
 	bool "Zedboard pulpino target"
 	depends on SOC_RISCV32_PULPINO
+	select BUILD_OUTPUT_S19

--- a/boards/x86/qemu_x86/Kconfig.defconfig
+++ b/boards/x86/qemu_x86/Kconfig.defconfig
@@ -1,6 +1,10 @@
 
 if BOARD_QEMU_X86
 
+
+config BUILD_OUTPUT_BIN
+        default n
+
 config BOARD
 	default qemu_x86
 

--- a/boards/xtensa/qemu_xtensa/Kconfig.defconfig
+++ b/boards/xtensa/qemu_xtensa/Kconfig.defconfig
@@ -4,6 +4,9 @@
 
 if BOARD_QEMU_XTENSA
 
+config BUILD_OUTPUT_BIN
+        default n
+
 config BOARD
 	default qemu_xtensa
 

--- a/drivers/ieee802154/Kconfig.nrf5
+++ b/drivers/ieee802154/Kconfig.nrf5
@@ -7,7 +7,7 @@
 #
 
 menuconfig IEEE802154_NRF5
-	prompt "nRF52 series IEEE 802.15.4 Driver"
+	bool "nRF52 series IEEE 802.15.4 Driver"
 	depends on NETWORKING && SOC_NRF52840
 	default n
 

--- a/misc/Kconfig
+++ b/misc/Kconfig
@@ -6,7 +6,7 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 
-menu "Compile and Link Features"
+menu "Build and Link Features"
 
 menu "Linker Options"
 config HAS_FLASH_LOAD_OFFSET
@@ -104,9 +104,16 @@ config KERNEL_ENTRY
 	help
 	Code entry symbol, to be set at linking phase.
 
+config CHECK_LINK_MAP
+	bool "Check linker map"
+	default y
+	help
+	  Run a linker address generation validity checker at the end of the
+	  build.
 endmenu
 
 menu "Compiler Options"
+
 config CROSS_COMPILE
 	string "Cross-compiler tool prefix"
 	help
@@ -144,12 +151,49 @@ config GDB_INFO
 	  during interrupts, exceptions, and context switches. This information
 	  is required for task-aware debugging with GDB.
 
+menu "Build Options"
+
 config KERNEL_BIN_NAME
 	string "The kernel binary name"
 	default "zephyr"
 	help
-	This option sets the name of the generated kernel binary.
+	  This option sets the name of the generated kernel binary.
 
+config OUTPUT_STAT
+	bool "Create a statistics file"
+	default y
+	help
+	  Create a stat file using readelf -e <elf>
+
+config BUILD_OUTPUT_HEX
+	bool "Build a binary in HEX format"
+	default n
+	help
+	  Build a binary in HEX format. This will build a zephyr.hex file need
+	  by some platforms.
+
+config BUILD_OUTPUT_BIN
+	bool "Build a binary in BIN format"
+	default y
+	help
+	  Build a binary in BIN format. This will build a zephyr.bin file need
+	  by some platforms.
+
+config BUILD_OUTPUT_S19
+	bool "Build a binary in S19 format"
+	default n
+	help
+	  Build a binary in S19 format. This will build a zephyr.s19 file need
+	  by some platforms.
+
+config BUILD_OUTPUT_STRIPPED
+	bool "Build a stripped binary"
+	default n
+	help
+	  Build a stripped binary. This will build a zephyr.stripped file need
+	  by some platforms.
+
+endmenu
 endmenu
 
 menu "System Monitoring Options"


### PR DESCRIPTION
Not all boards require the various binary formats zephyr generates. So be
selective based on the arch, SoC or board and only geenrate the binaries
actually needed.

Fixes #5009