### PR TITLE
flash: minor documentation improvements.

### DIFF
--- a/drivers/flash/Kconfig
+++ b/drivers/flash/Kconfig
@@ -1,4 +1,4 @@
-# Kconfig - flash driver configuration options
+# Kconfig - Flash driver configuration options
 
 #
 # Copyright (c) 2016 Intel Corporation
@@ -7,11 +7,11 @@
 #
 
 #
-# flash driver
+# Flash driver
 #
 menuconfig FLASH
 	bool
-	prompt "flash hardware support"
+	prompt "Flash hardware support"
 	default n
 	help
 	  Enable support for the flash hardware.
@@ -30,13 +30,13 @@ config SPI_FLASH_W25QXXDV
 
 config SPI_FLASH_W25QXXDV_SPI_NAME
 	string
-	prompt "spi controller device name"
+	prompt "SPI controller device name"
 	depends on SPI_FLASH_W25QXXDV
 	default ""
 
 config SPI_FLASH_W25QXXDV_DRV_NAME
 	string
-	prompt "spi flash device name"
+	prompt "SPI flash device name"
 	depends on SPI_FLASH_W25QXXDV
 	default "W25QXXDV"
 
@@ -59,14 +59,14 @@ config SPI_FLASH_W25QXXDV_SPI_FREQ_0
 	  clock.
 
 config	SPI_FLASH_W25QXXDV_SPI_SLAVE
-	int "SPI slave linked to spi flash"
+	int "SPI slave linked to SPI flash"
 	depends on SPI_FLASH_W25QXXDV
 	help
 	  This option sets the SPI slave number the SPI controller has to switch
 	  to when dealing with WinBond SPI flash chip.
 
 config SPI_FLASH_W25QXXDV_FLASH_SIZE
-	int "flash size in bytes"
+	int "Flash size in bytes"
 	depends on SPI_FLASH_W25QXXDV
 	default 2097152
 	help
@@ -96,7 +96,7 @@ config SOC_FLASH_QMSI_DEV_NAME
 	  Specify the device name for the flash driver.
 
 config SOC_FLASH_QMSI_CLK_COUNT_US
-	int "system clk count per microsecond"
+	int "System clk count per microsecond"
 	depends on SOC_FLASH_QMSI
 	default 32
 	help

--- a/include/flash.h
+++ b/include/flash.h
@@ -48,8 +48,8 @@ typedef int (*flash_api_write_protection)(struct device *dev, bool enable);
  * @brief Retrieve a flash device's layout.
  *
  * A flash device layout is a run-length encoded description of the
- * pages on the device. (Here, "pages" means the smallest erasable
- * areas on the flash device.)
+ * pages on the device. (Here, "page" means the smallest erasable
+ * area on the flash device.)
  *
  * For flash memories which have uniform page sizes, this routine
  * returns an array of length 1, which specifies the page size and
@@ -191,7 +191,7 @@ struct flash_pages_info {
 
 #if defined(CONFIG_FLASH_PAGE_LAYOUT)
 /**
- *  @brief  Get size and start offset of flash page at certain flash offset.
+ *  @brief  Get the size and start offset of flash page at certain flash offset.
  *
  *  @param  dev flash device
  *  @param  offset Offset within the page
@@ -203,7 +203,7 @@ __syscall int flash_get_page_info_by_offs(struct device *dev, off_t offset,
 					  struct flash_pages_info *info);
 
 /**
- *  @brief  Get size and start offset of flash page of certain index.
+ *  @brief  Get the size and start offset of flash page of certain index.
  *
  *  @param  dev flash device
  *  @param  page_index Index of the page. Index are counted from 0.
@@ -215,7 +215,7 @@ __syscall int flash_get_page_info_by_idx(struct device *dev, u32_t page_index,
 					 struct flash_pages_info *info);
 
 /**
- *  @brief  Get number of flash pages.
+ *  @brief  Get the total number of flash pages.
  *
  *  @param  dev flash device
  *
@@ -236,7 +236,7 @@ __syscall size_t flash_get_page_count(struct device *dev);
 typedef bool (*flash_page_cb)(const struct flash_pages_info *info, void *data);
 
 /**
- * @brief Iterate over flash pages on a device
+ * @brief Iterate over all flash pages on a device
  *
  * This routine iterates over all flash pages on the given device,
  * ordered by increasing start offset. For each page, it invokes the
@@ -253,13 +253,13 @@ void flash_page_foreach(struct device *dev, flash_page_cb cb, void *data);
 /**
  *  @brief  Get the minimum write block size supported by the driver
  *
- *  The Write block size supported by the driver might defer from the write
+ *  The write block size supported by the driver might differ from the write
  *  block size of memory used because the driver might implements write-modify
  *  algorithm.
  *
  *  @param  dev flash device
  *
- *  @return  write block size in Bytes.
+ *  @return  write block size in bytes.
  */
 __syscall size_t flash_get_write_block_size(struct device *dev);
 


### PR DESCRIPTION
This patch makes minor improvements to the flash documentation including:

* spi -> SPI
* Capitialise the first word in a sentance
* Adding the, and, all, etc where appropriate.

Signed-off-by: Michael Hope <mlhx@google.com>