### PR TITLE
Bluetooth: Mesh: Various Low Power Node fixes

### DIFF
--- a/include/bluetooth/mesh/main.h
+++ b/include/bluetooth/mesh/main.h
@@ -278,6 +278,24 @@ int bt_mesh_provision(const u8_t net_key[16], u16_t net_idx,
  */
 int bt_mesh_lpn_set(bool enable);
 
+/** @brief Send out a Friend Poll message.
+ *
+ *  Send a Friend Poll message to the Friend of this node. If there is no
+ *  established Friendship the function will return an error.
+ *
+ *  @return Zero on success or (negative) error code otherwise.
+ */
+int bt_mesh_lpn_poll(void);
+
+/** @brief Register a callback for Friendship changes.
+ *
+ *  Registers a callback that will be called whenever Friendship gets
+ *  established or is lost.
+ *
+ *  @param cb Function to call when the Friendship status changes.
+ */
+void bt_mesh_lpn_set_cb(void (*cb)(u16_t friend_addr, bool established));
+
 /**
  * @}
  */

--- a/subsys/bluetooth/host/mesh/Kconfig
+++ b/subsys/bluetooth/host/mesh/Kconfig
@@ -259,15 +259,27 @@ config BT_MESH_LPN_RECV_DELAY
 	  is in units of milliseconds.
 
 config BT_MESH_LPN_POLL_TIMEOUT
-	int "The initial value of the PollTimeout timer"
+	int "The value of the PollTimeout timer"
 	range 10 244735
-	default 100
+	default 300
 	help
 	  PollTimeout timer is used to measure time between two
 	  consecutive requests sent by the Low Power node. If no
 	  requests are received by the Friend node before the
 	  PollTimeout timer expires, then the friendship is considered
-	  terminated. The value is in units of 100 milliseconds.
+	  terminated. The value is in units of 100 milliseconds, so e.g.
+	  a value of 300 means 3 seconds.
+
+config BT_MESH_LPN_INIT_POLL_TIMEOUT
+	int "The starting value of the PollTimeout timer"
+	range 10 BT_MESH_LPN_POLL_TIMEOUT
+	default BT_MESH_LPN_POLL_TIMEOUT
+	help
+	  The initial value of the PollTimeout timer when Friendship
+	  gets established for the first time. After this the timeout
+	  will gradually grow toward the actual PollTimeout, doubling
+	  in value for each iteration. The value is in units of 100
+	  milliseconds, so e.g. a value of 300 means 3 seconds.
 
 config BT_MESH_LPN_SCAN_LATENCY
 	int "Latency for enabling scanning"

--- a/subsys/bluetooth/host/mesh/lpn.c
+++ b/subsys/bluetooth/host/mesh/lpn.c
@@ -48,6 +48,7 @@
 #define REQ_RETRY_DURATION(lpn)  (4 * (LPN_RECV_DELAY + (lpn)->adv_duration + \
 				       (lpn)->recv_win + POLL_RETRY_TIMEOUT))
 
+#define POLL_TIMEOUT_INIT     (CONFIG_BT_MESH_LPN_INIT_POLL_TIMEOUT * 100)
 #define POLL_TIMEOUT_MAX(lpn) ((CONFIG_BT_MESH_LPN_POLL_TIMEOUT * 100) - \
 			       REQ_RETRY_DURATION(lpn))
 
@@ -964,7 +965,8 @@ int bt_mesh_lpn_friend_update(struct bt_mesh_net_rx *rx,
 		}
 
 		/* Set initial poll timeout */
-		lpn->poll_timeout = min(POLL_TIMEOUT_MAX(lpn), K_SECONDS(1));
+		lpn->poll_timeout = min(POLL_TIMEOUT_MAX(lpn),
+					POLL_TIMEOUT_INIT);
 	}
 
 	friend_response_received(lpn);

--- a/subsys/bluetooth/host/mesh/lpn.c
+++ b/subsys/bluetooth/host/mesh/lpn.c
@@ -310,8 +310,8 @@ static void req_sent(u16_t duration, int err, void *user_data)
 	struct bt_mesh_lpn *lpn = &bt_mesh.lpn;
 
 #if defined(CONFIG_BT_MESH_DEBUG_LOW_POWER)
-	BT_DBG("duration %u err %d state %s",
-	       duration, err, state2str(lpn->state));
+	BT_DBG("req 0x%02x duration %u err %d state %s",
+	       lpn->sent_req, duration, err, state2str(lpn->state));
 #endif
 
 	if (err) {
@@ -652,6 +652,8 @@ static bool sub_update(u8_t op)
 	struct bt_mesh_ctl_friend_sub req;
 	size_t i, g;
 
+	BT_DBG("op 0x%02x sent_req 0x%02x", op, lpn->sent_req);
+
 	if (lpn->sent_req) {
 		return false;
 	}
@@ -704,8 +706,6 @@ static bool sub_update(u8_t op)
 
 static void update_timeout(struct bt_mesh_lpn *lpn)
 {
-	lpn->sent_req = 0;
-
 	if (lpn->established) {
 		BT_WARN("No response from Friend during ReceiveWindow");
 		bt_mesh_scan_disable();
@@ -718,6 +718,7 @@ static void update_timeout(struct bt_mesh_lpn *lpn)
 
 		if (lpn->req_attempts < 6) {
 			BT_WARN("Retrying first Friend Poll");
+			lpn->sent_req = 0;
 			if (send_friend_poll() == 0) {
 				return;
 			}

--- a/subsys/bluetooth/host/mesh/lpn.h
+++ b/subsys/bluetooth/host/mesh/lpn.h
@@ -52,8 +52,6 @@ static inline bool bt_mesh_lpn_timer(void)
 #endif
 }
 
-void bt_mesh_lpn_friend_poll(void);
-
 void bt_mesh_lpn_msg_received(struct bt_mesh_net_rx *rx);
 
 void bt_mesh_lpn_group_add(u16_t group);

--- a/subsys/bluetooth/host/mesh/transport.c
+++ b/subsys/bluetooth/host/mesh/transport.c
@@ -383,7 +383,7 @@ static int send_seg(struct bt_mesh_net_tx *net_tx, struct net_buf_simple *sdu,
 	}
 
 	if (bt_mesh_lpn_established()) {
-		bt_mesh_lpn_friend_poll();
+		bt_mesh_lpn_poll();
 	}
 
 	return 0;


### PR DESCRIPTION
These are needed for correct operation, and to pass the qualification test cases for mesh. There is one erratum that's preventing one test case from passing however:

https://www.bluetooth.org/tse/errata_view.cfm?errata_id=10145

Because of the effect on qualification, I'd recommend these for 1.10