### PR TITLE
net: pkt: Fix possible division by zero

### DIFF
--- a/subsys/net/ip/net_pkt.c
+++ b/subsys/net/ip/net_pkt.c
@@ -253,7 +253,7 @@ void net_pkt_print_frags(struct net_pkt *pkt)
 {
 	struct net_buf *frag;
 	size_t total = 0;
-	int count = -1, frag_size = 0, ll_overhead = 0;
+	int count = 0, frag_size = 0, ll_overhead = 0;
 
 	if (!pkt) {
 		NET_INFO("pkt %p", pkt);
@@ -286,7 +286,7 @@ void net_pkt_print_frags(struct net_pkt *pkt)
 	NET_INFO("Total data size %zu, occupied %d bytes, ll overhead %d, "
 		 "utilization %zu%%",
 		 total, count * frag_size - count * ll_overhead,
-		 count * ll_overhead, (total * 100) / (count * frag_size));
+		 count * ll_overhead, count ? (total * 100) / (count * frag_size) : 0);
 }
 
 struct net_pkt *net_pkt_get_reserve_debug(struct k_mem_slab *slab,


### PR DESCRIPTION
When net debugging is enabled, the count variable is initialized to -1.
This may cause division by zero if there is only one fragment in pkt.
Solve this by setting the count to 0 and checking the value before the
print at the end of the function.

Successfully tested on STM32F407 SoC.

Signed-off-by: Ding Tao <miyatsu@qq.com>