### PR TITLE
Drivers: flash: Assert implementation of Flash Page Layout API extensin

### DIFF
--- a/drivers/flash/soc_flash_mcux.c
+++ b/drivers/flash/soc_flash_mcux.c
@@ -16,6 +16,10 @@
 #include "fsl_common.h"
 #include "fsl_flash.h"
 
+#ifdef CONFIG_FLASH_PAGE_LAYOUT
+#error FLASH_PAGE_LAYOUT extension is not implemented for this driver.
+#endif
+
 struct flash_priv {
 	flash_config_t config;
 };

--- a/drivers/flash/soc_flash_qmsi.c
+++ b/drivers/flash/soc_flash_qmsi.c
@@ -15,6 +15,10 @@
 #include "qm_flash.h"
 #include "qm_soc_regs.h"
 
+#ifdef CONFIG_FLASH_PAGE_LAYOUT
+#error FLASH_PAGE_LAYOUT extension is not implemented for this driver.
+#endif
+
 struct soc_flash_data {
 #ifdef CONFIG_SOC_FLASH_QMSI_API_REENTRANCY
 	struct k_sem sem;

--- a/drivers/flash/spi_flash_w25qxxdv.c
+++ b/drivers/flash/spi_flash_w25qxxdv.c
@@ -13,6 +13,10 @@
 #include "spi_flash_w25qxxdv_defs.h"
 #include "spi_flash_w25qxxdv.h"
 
+#ifdef CONFIG_FLASH_PAGE_LAYOUT
+#error FLASH_PAGE_LAYOUT extension is not implemented for this driver.
+#endif
+
 static inline int spi_flash_wb_id(struct device *dev)
 {
 	struct spi_flash_data *const driver_data = dev->driver_data;


### PR DESCRIPTION
Some drivers doesn't implement flash API page layout extension
which is causing the application crash once the API was calling.
This patch introduce preprocessor check for this in drivers
which doesn't implement extension.

Remark: It is possible to have enabled a flash driver which support (e.g. NRF5) and second one which not support mentioned extension (W25Qxxx)- that the reason why this is asserted in code files.

Signed-off-by: Andrzej Puzdrowski andrzej.puzdrowski@nordicsemi.no