### PR TITLE
Cmake fix cxx cc option

### DIFF
--- a/cmake/extensions.cmake
+++ b/cmake/extensions.cmake
@@ -644,6 +644,8 @@ endfunction()
 #
 # lang must be C or CXX
 #
+# TODO: Support ASM
+#
 # Usage:
 #
 # check_compiler_flag(C "-Wall" my_check)
@@ -667,20 +669,36 @@ function(check_compiler_flag lang option ok)
 endfunction()
 
 function(target_cc_option target scope option)
-  string(MAKE_C_IDENTIFIER check${option} check)
-  check_c_compiler_flag(${option} ${check})
-  target_compile_option_ifdef(${check} ${target} ${scope} ${option})
+  target_cc_option_fallback(${target} ${scope} ${option} "")
 endfunction()
 
-# Support an optional second option for when the first option is
-# not supported.
+# Support an optional second option for when the first option is not
+# supported.
 function(target_cc_option_fallback target scope option1 option2)
-  string(MAKE_C_IDENTIFIER check${option1} check)
-  check_c_compiler_flag(${option1} ${check})
-  if(${check})
-    target_compile_options(${target} ${scope} ${option1})
+  if(CONFIG_CPLUSPLUS)
+    foreach(lang C CXX)
+      # For now, we assume that all flags that apply to C/CXX also
+      # apply to ASM.
+      check_compiler_flag(${lang} ${option1} check)
+      if(${check})
+        target_compile_options(${target} ${scope}
+          $<$<COMPILE_LANGUAGE:${lang}>:${option1}>
+          $<$<COMPILE_LANGUAGE:ASM>:${option1}>
+          )
+      elseif(option2)
+        target_compile_options(${target} ${scope}
+          $<$<COMPILE_LANGUAGE:${lang}>:${option2}>
+          $<$<COMPILE_LANGUAGE:ASM>:${option2}>
+          )
+      endif()
+    endforeach()
   else()
-    target_compile_options(${target} ${scope} ${option2})
+    check_compiler_flag(C ${option1} check)
+    if(${check})
+      target_compile_options(${target} ${scope} ${option1})
+    elseif(option2)
+      target_compile_options(${target} ${scope} ${option2})
+    endif()
   endif()
 endfunction()
 

--- a/cmake/extensions.cmake
+++ b/cmake/extensions.cmake
@@ -1,4 +1,5 @@
 include(CheckCCompilerFlag)
+include(CheckCXXCompilerFlag)
 
 ########################################################
 # Table of contents
@@ -637,7 +638,34 @@ endfunction()
 # compiler lacks support. *_cc_option was ported from KBuild, see
 # cc-option in
 # https://www.kernel.org/doc/Documentation/kbuild/makefiles.txt
+
+# Writes 1 to the output variable 'ok' for the language 'lang' if
+# the flag is supported, otherwise writes 0.
 #
+# lang must be C or CXX
+#
+# Usage:
+#
+# check_compiler_flag(C "-Wall" my_check)
+# print(my_check) # my_check is now 1
+function(check_compiler_flag lang option ok)
+  string(MAKE_C_IDENTIFIER check${option}_${lang} ${ok})
+
+  if(${lang} STREQUAL C)
+    check_c_compiler_flag(${option} ${${ok}})
+  else()
+    check_cxx_compiler_flag(${option} ${${ok}})
+  endif()
+
+  if(${${${ok}}})
+    set(ret 1)
+  else()
+    set(ret 0)
+  endif()
+
+  set(${ok} ${ret} PARENT_SCOPE)
+endfunction()
+
 function(target_cc_option target scope option)
   string(MAKE_C_IDENTIFIER check${option} check)
   check_c_compiler_flag(${option} ${check})


### PR DESCRIPTION
The target_cc_option[_fallback]() CMake extentions are now C++
aware. This means that they will now test options with both C and C++
compiler and include flags appropriately.

This fixes a warning that was issued when -Wno-pointer-sign was used
 with .cpp files. The warning can be observed when running the 
cpp_synchronization sample.

cc1plus: warning: command line option ‘-Wno-pointer-sign’ is valid for
C/ObjC but not for C++

NB: This patch is designed to only affect CONFIG_CPLUSPLUS builds in
case there are any adverse affects with using generator expressions.