### PR TITLE
tests/drivers/uart/uart_basic_api : Added build only tag

### DIFF
--- a/tests/drivers/uart/uart_basic_api/testcase.yaml
+++ b/tests/drivers/uart/uart_basic_api/testcase.yaml
@@ -1,5 +1,6 @@
 tests:
   - test_uart:
+      build_only: true
       platform_whitelist: quark_se_c1000_devboard quark_d2000_crb
       tags: drivers
   - test_uart_shell:


### PR DESCRIPTION
Testcase yaml requires some interactive inputs to be provided for
execution and hence fails on automation. Hence making it as build
only

Signed-off-by: ravishankar karkala Mallikarjunayya <ravix.shankar.km@intel.com>