### PR TITLE
boards: galileo and minnowboard require zephyr.strip

### DIFF
--- a/boards/x86/galileo/Kconfig.defconfig
+++ b/boards/x86/galileo/Kconfig.defconfig
@@ -1,6 +1,9 @@
 
 if BOARD_GALILEO
 
+config BUILD_OUTPUT_STRIPPED
+	def_bool y
+
 config BOARD
 	default galileo
 

--- a/boards/x86/minnowboard/Kconfig.defconfig
+++ b/boards/x86/minnowboard/Kconfig.defconfig
@@ -4,4 +4,7 @@ if BOARD_MINNOWBOARD
 config BOARD
 	default minnowboard
 
+config BUILD_OUTPUT_STRIPPED
+	def_bool y
+
 endif # BOARD_MINNOWBOARD


### PR DESCRIPTION
Restore creation of those binaries for galileo and minnowboard.