### PR TITLE
nRF52_pca10040: Fix button sample GPIO

### DIFF
--- a/boards/arm/nrf52_pca10040/board.h
+++ b/boards/arm/nrf52_pca10040/board.h
@@ -12,6 +12,7 @@
 /* Push button switch 0 */
 #define SW0_GPIO_PIN	13
 #define SW0_GPIO_NAME	CONFIG_GPIO_NRF5_P0_DEV_NAME
+#define SW0_GPIO_PIN_PUD GPIO_PUD_PULL_UP
 
 /* Push button switch 1 */
 #define SW1_GPIO_PIN	14

--- a/samples/basic/button/src/main.c
+++ b/samples/basic/button/src/main.c
@@ -37,7 +37,11 @@
 #endif
 
 /* change this to enable pull-up/pull-down */
+#ifdef SW0_GPIO_PIN_PUD
+#define PULL_UP SW0_GPIO_PIN_PUD
+#else
 #define PULL_UP 0
+#endif
 
 /* Sleep time */
 #define SLEEP_TIME	500


### PR DESCRIPTION
Applies to #4008 and #5159 for this board. Problem is that the
button interrupt callback was only firing once. Solution is to
set the pin pull up flag to GPIO_PUD_PULL_UP.

Signed-off-by: Anders Pitman <tapitman11@gmail.com>