### PR TITLE
Bluetooth: Mesh: Fix creating initial beacon data

### DIFF
--- a/subsys/bluetooth/host/mesh/cfg_srv.c
+++ b/subsys/bluetooth/host/mesh/cfg_srv.c
@@ -1936,6 +1936,9 @@ static void net_key_add(struct bt_mesh_model *model,
 
 	sub->net_idx = idx;
 
+	/* Make sure we have valid beacon data to be sent */
+	bt_mesh_net_beacon_update(sub);
+
 	if (IS_ENABLED(CONFIG_BT_MESH_GATT_PROXY)) {
 		sub->node_id = BT_MESH_NODE_IDENTITY_STOPPED;
 		bt_mesh_proxy_beacon_send(sub);

--- a/subsys/bluetooth/host/mesh/net.c
+++ b/subsys/bluetooth/host/mesh/net.c
@@ -477,6 +477,9 @@ int bt_mesh_net_create(u16_t idx, u8_t flags, const u8_t key[16],
 	/* Set initial IV Update procedure state time-stamp */
 	bt_mesh.last_update = k_uptime_get();
 
+	/* Make sure we have valid beacon data to be sent */
+	bt_mesh_net_beacon_update(sub);
+
 	return 0;
 }
 


### PR DESCRIPTION
There was a chance that initial beacons for subnets would be sent with
uninitialized data. Make sure we initialize the beacon data each time
when we create a new subnet.

Signed-off-by: Johan Hedberg <johan.hedberg@intel.com>