### PR TITLE
Bluetooth: Added missing checks for whether CONFIG_BT_PRIVACY is enabled

### DIFF
--- a/subsys/bluetooth/host/hci_core.c
+++ b/subsys/bluetooth/host/hci_core.c
@@ -3532,7 +3532,8 @@ static int le_set_event_mask(void)
 	mask |= BT_EVT_MASK_LE_ADVERTISING_REPORT;
 
 	if (IS_ENABLED(CONFIG_BT_CONN)) {
-		if (BT_FEAT_LE_PRIVACY(bt_dev.le.features)) {
+		if (IS_ENABLED(CONFIG_BT_PRIVACY) &&
+		    BT_FEAT_LE_PRIVACY(bt_dev.le.features)) {
 			mask |= BT_EVT_MASK_LE_ENH_CONN_COMPLETE;
 		} else {
 			mask |= BT_EVT_MASK_LE_CONN_COMPLETE;
@@ -3673,7 +3674,8 @@ static int le_init(void)
 	}
 
 #if defined(CONFIG_BT_SMP)
-	if (BT_FEAT_LE_PRIVACY(bt_dev.le.features)) {
+	if (IS_ENABLED(CONFIG_BT_PRIVACY) &&
+	    BT_FEAT_LE_PRIVACY(bt_dev.le.features)) {
 		struct bt_hci_rp_le_read_rl_size *rp;
 		struct net_buf *rsp;
 


### PR DESCRIPTION
Fixes error encountered during connecting BLE endpoint.
[bt] [ERR] le_remote_feat_complete: Unable to lookup conn for handle 32

This is to work around a buggy controller that states support for
enhanced privacy, but misbehaves when it's enabled. This change
makes it possible to ensure the host doesn't try to enable the enhanced
event by simply disabling the privacy feature in Kconfig.

Signed-off-by: Vakul Garg <vakul.garg@nxp.com>