### PR TITLE
x86: swap: save the scratch pad registers.

### DIFF
--- a/arch/x86/core/swap.S
+++ b/arch/x86/core/swap.S
@@ -143,7 +143,9 @@ SECTION_FUNC(TEXT, __swap)
 
 #ifdef CONFIG_KERNEL_EVENT_LOGGER_CONTEXT_SWITCH
 	/* Register the context switch */
+	push %edx
 	call	_sys_k_event_logger_context_switch
+	pop %edx
 #endif
 	movl	_kernel_offset_to_ready_q_cache(%edi), %eax
 


### PR DESCRIPTION
Save the required scratch pad register (in this case only edx)
before calling the C function.

Signed-off-by: Adithya Baglody <adithya.nagaraj.baglody@intel.com>