### PR TITLE
Bluetooth: shell: Fix compile error due to missing memq.h include

### DIFF
--- a/subsys/bluetooth/shell/ticker.c
+++ b/subsys/bluetooth/shell/ticker.c
@@ -13,6 +13,7 @@
 #include <shell/shell.h>
 #include <misc/printk.h>
 
+#include "../controller/util/memq.h"
 #include "../controller/util/mayfly.h"
 #include "../controller/ticker/ticker.h"
 


### PR DESCRIPTION
Fixes the following compile error when building
tests/bluetooth/shell application:

In file included from subsys/bluetooth/shell/ticker.c:16:0:
subsys/bluetooth/shell/../controller/util/mayfly.h:21:2:
error: unknown type name 'memq_link_t'
  memq_link_t *_link;
  ^~~~~~~~~~~

Signed-off-by: Vinayak Kariappa Chettimada <vich@nordicsemi.no>