### PR TITLE
tests/kernel/mem_protect/protection: fix test_main arguments

### DIFF
--- a/tests/kernel/mem_protect/protection/src/main.c
+++ b/tests/kernel/mem_protect/protection/src/main.c
@@ -173,7 +173,7 @@ static void exec_heap(void)
 #endif
 #endif /* NO_EXECUTE_SUPPORT */
 
-void test_main(void *unused1, void *unused2, void *unused3)
+void test_main(void)
 {
 	ztest_test_suite(test_protection,
 #ifdef NO_EXECUTE_SUPPORT


### PR DESCRIPTION
test_main() takes no arguments, so this was causing a fault
after returning from test_main due to the stack canary checking.

Before, the test run ends with:
PROJECT EXECUTION SUCCESSFUL
***** CPU Page Fault (error code 0x00000011)
Supervisor thread executed address 0x00400000
PDE: 0x027 Present, Writable, User, Execute Enabled
PTE: 0x80000000267 Present, Writable, User, Execute Disable
Current thread ID = 0x00401080
Faulting segment:address = 0x0008:0x00400000
eax: 0x00000000, ebx: 0x00000000, ecx: 0x0040b19c, edx: 0x000056df
esi: 0x00000000, edi: 0x00000000, ebp: 0x000051c0, esp: 0x0040b1d8
eflags: 0x246
Caught system error -- reason 6

After, the test run ends with:
PROJECT EXECUTION SUCCESSFUL

Reported-by: Joshua Domagalski <jedomag@tycho.ncsc.mil>
Signed-off-by: Stephen Smalley <sds@tycho.nsa.gov>