### PR TITLE
net: pkt: Account for IP header length for allowable payload data

### DIFF
--- a/subsys/net/ip/net_pkt.c
+++ b/subsys/net/ip/net_pkt.c
@@ -1225,7 +1225,7 @@ u16_t net_pkt_append(struct net_pkt *pkt, u16_t len, const u8_t *data,
 		max_len = pkt->data_len;
 
 #if defined(CONFIG_NET_TCP)
-		if (ctx->tcp) {
+		if (ctx->tcp && (ctx->tcp->send_mss < max_len)) {
 			max_len = ctx->tcp->send_mss;
 		}
 #endif

--- a/subsys/net/ip/net_pkt.c
+++ b/subsys/net/ip/net_pkt.c
@@ -535,10 +535,12 @@ static struct net_pkt *net_pkt_get(struct k_mem_slab *slab,
 
 		if (IS_ENABLED(CONFIG_NET_IPV6) && family == AF_INET6) {
 			data_len = max(iface_len, NET_IPV6_MTU);
+			data_len -= NET_IPV6H_LEN;
 		}
 
 		if (IS_ENABLED(CONFIG_NET_IPV4) && family == AF_INET) {
 			data_len = max(iface_len, NET_IPV4_MTU);
+			data_len -= NET_IPV4H_LEN;
 		}
 
 		proto = net_context_get_ip_proto(context);


### PR DESCRIPTION
For calculating amount of payload data that can be added in a packet,
we need to subtract IPv6 or IPv6 header lengths from MTU.

Signed-off-by: Vakul Garg <vakul.garg@nxp.com>