### PR TITLE
boards: nucleo_f091rc: fix cmake build

### DIFF
--- a/boards/arm/nucleo_f091rc/CMakeLists.txt
+++ b/boards/arm/nucleo_f091rc/CMakeLists.txt
@@ -1,0 +1,3 @@
+zephyr_library()
+zephyr_library_sources(pinmux.c)
+zephyr_library_include_directories(${PROJECT_SOURCE_DIR}/drivers)

--- a/boards/arm/nucleo_f091rc/board.cmake
+++ b/boards/arm/nucleo_f091rc/board.cmake
@@ -1,0 +1,1 @@
+include($ENV{ZEPHYR_BASE}/boards/common/openocd.board.cmake)


### PR DESCRIPTION
Add missing CMake files to the nucleo_f091rc board.