### PR TITLE
add -fstack-protector-all without checks 

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -195,9 +195,7 @@ zephyr_cc_option(-fno-strict-overflow)
 zephyr_cc_option(-Wno-pointer-sign)
 
 if(CONFIG_STACK_CANARIES)
-  zephyr_cc_option(-fstack-protector-all)
-else()
-  zephyr_cc_option(-fno-stack-protector)
+  zephyr_cc_option_nocheck(-fstack-protector-all)
 endif()
 
 if(CONFIG_OVERRIDE_FRAME_POINTER_DEFAULT)

--- a/cmake/extensions.cmake
+++ b/cmake/extensions.cmake
@@ -103,6 +103,12 @@ function(zephyr_cc_option)
   endforeach()
 endfunction()
 
+function(zephyr_cc_option_nocheck)
+  foreach(arg ${ARGV})
+    target_compile_options(zephyr_interface INTERFACE ${arg})
+  endforeach()
+endfunction()
+
 function(zephyr_cc_option_fallback option1 option2)
     target_cc_option_fallback(zephyr_interface INTERFACE ${option1} ${option2})
 endfunction()


### PR DESCRIPTION
- kernel: stack: add -fstack-protector-all without checks 
- cmake: add zephyr_cc_option_nocheck

Fixes #5019