### PR TITLE
Bluetooth: Don't use acl_in_pool if controller lacks flow control

### DIFF
--- a/subsys/bluetooth/host/hci_core.c
+++ b/subsys/bluetooth/host/hci_core.c
@@ -4849,10 +4849,10 @@ struct net_buf *bt_buf_get_rx(enum bt_buf_type type, s32_t timeout)
 		 "Invalid buffer type requested");
 
 #if defined(CONFIG_BT_HCI_ACL_FLOW_CONTROL)
-	if (type == BT_BUF_EVT) {
-		buf = net_buf_alloc(&hci_rx_pool, timeout);
-	} else {
+	if ((bt_dev.supported_commands[10] & 0x20) && (type != BT_BUF_EVT)) {
 		buf = net_buf_alloc(&acl_in_pool, timeout);
+	} else {
+		buf = net_buf_alloc(&hci_rx_pool, timeout);
 	}
 #else
 	buf = net_buf_alloc(&hci_rx_pool, timeout);


### PR DESCRIPTION
In case BT_HCI_ACL_FLOW_CONTROL is enabled but the controller does not
support flow control, allocate from hci_rx_pool instead of acl_in_pool.

Fixes: #5207 

Signed-off-by: Vakul Garg <vakul.garg@nxp.com>