### PR TITLE
Remove cc option nocheck

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -195,7 +195,9 @@ zephyr_cc_option(-fno-strict-overflow)
 zephyr_cc_option(-Wno-pointer-sign)
 
 if(CONFIG_STACK_CANARIES)
-  zephyr_cc_option_nocheck(-fstack-protector-all)
+  zephyr_cc_option(-fstack-protector-all)
+else()
+  zephyr_cc_option(-fno-stack-protector)
 endif()
 
 if(CONFIG_OVERRIDE_FRAME_POINTER_DEFAULT)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -194,11 +194,7 @@ zephyr_cc_option(-fno-pic)
 zephyr_cc_option(-fno-strict-overflow)
 zephyr_cc_option(-Wno-pointer-sign)
 
-if(CONFIG_STACK_CANARIES)
-  zephyr_cc_option(-fstack-protector-all)
-else()
-  zephyr_cc_option(-fno-stack-protector)
-endif()
+zephyr_compile_options_ifdef(CONFIG_STACK_CANARIES -fstack-protector-all)
 
 if(CONFIG_OVERRIDE_FRAME_POINTER_DEFAULT)
   if(CONFIG_OMIT_FRAME_POINTER)

--- a/cmake/extensions.cmake
+++ b/cmake/extensions.cmake
@@ -103,12 +103,6 @@ function(zephyr_cc_option)
   endforeach()
 endfunction()
 
-function(zephyr_cc_option_nocheck)
-  foreach(arg ${ARGV})
-    target_compile_options(zephyr_interface INTERFACE ${arg})
-  endforeach()
-endfunction()
-
 function(zephyr_cc_option_fallback option1 option2)
     target_cc_option_fallback(zephyr_interface INTERFACE ${option1} ${option2})
 endfunction()


### PR DESCRIPTION
zephyr_cc_option_nocheck() is the same as zephyr_compile_definitions() so we don't need to introduce zephyr_cc_option_nocheck().