### PR TITLE
script: extract_dts_includes: fix recursive inclusion

### DIFF
--- a/scripts/dts/extract_dts_includes.py
+++ b/scripts/dts/extract_dts_includes.py
@@ -579,18 +579,11 @@ def yaml_traverse_inherited(node):
     """
 
     if 'inherits' in node.keys():
-        try:
-            yaml_traverse_inherited(node['inherits']['inherits'])
-        except KeyError:
-            dict_merge(node['inherits'], node)
-            node = node['inherits']
-            node.pop('inherits')
-        except TypeError:
-            #'node['inherits']['inherits'] type is 'list' instead of
-            #expected type 'dtc'
-            #Likely due to use of "-" before attribute in yaml file
-            raise Exception("Element '" + str(node['title']) +
-                            "' uses yaml 'series' instead of 'mapping'")
+        if 'inherits' in node['inherits'].keys():
+            node['inherits'] = yaml_traverse_inherited(node['inherits'])
+        dict_merge(node['inherits'], node)
+        node = node['inherits']
+        node.pop('inherits')
     return node
 
 


### PR DESCRIPTION
extract_dts_includes script was not handling correctly
recursive inclusions. Fix it.

Signed-off-by: Erwan Gouriou <erwan.gouriou@linaro.org>