### PR TITLE
Bluetooth: Mesh: Fix Replay Protection List handling

### DIFF
--- a/subsys/bluetooth/host/mesh/shell.c
+++ b/subsys/bluetooth/host/mesh/shell.c
@@ -749,6 +749,12 @@ static int cmd_iv_update_test(int argc, char *argv[])
 	return 0;
 }
 
+static int cmd_rpl_clear(int argc, char *argv[])
+{
+	bt_mesh_rpl_clear();
+	return 0;
+}
+
 static int cmd_beacon(int argc, char *argv[])
 {
 	u8_t status;
@@ -1857,6 +1863,7 @@ static const struct shell_cmd mesh_commands[] = {
 	{ "net-send", cmd_net_send, "<hex string>" },
 	{ "iv-update", cmd_iv_update, NULL },
 	{ "iv-update-test", cmd_iv_update_test, "<value: off, on>" },
+	{ "rpl-clear", cmd_rpl_clear, NULL },
 
 	/* Configuration Client Model operations */
 	{ "get-comp", cmd_get_comp, "[page]" },

--- a/subsys/bluetooth/host/mesh/transport.c
+++ b/subsys/bluetooth/host/mesh/transport.c
@@ -515,7 +515,8 @@ static bool is_replay(struct bt_mesh_net_rx *rx)
 				return true;
 			}
 
-			if (rpl->seq < rx->seq) {
+			if ((!rx->old_iv && rpl->old_iv) ||
+			    rpl->seq < rx->seq) {
 				rpl->seq = rx->seq;
 				rpl->old_iv = rx->old_iv;
 				return false;

--- a/subsys/bluetooth/host/mesh/transport.c
+++ b/subsys/bluetooth/host/mesh/transport.c
@@ -1373,3 +1373,9 @@ void bt_mesh_trans_init(void)
 		k_delayed_work_init(&seg_rx[i].ack, seg_ack);
 	}
 }
+
+void bt_mesh_rpl_clear(void)
+{
+	BT_DBG("");
+	memset(bt_mesh.rpl, 0, sizeof(bt_mesh.rpl));
+}

--- a/subsys/bluetooth/host/mesh/transport.h
+++ b/subsys/bluetooth/host/mesh/transport.h
@@ -93,3 +93,5 @@ int bt_mesh_trans_send(struct bt_mesh_net_tx *tx, struct net_buf_simple *msg,
 int bt_mesh_trans_recv(struct net_buf_simple *buf, struct bt_mesh_net_rx *rx);
 
 void bt_mesh_trans_init(void);
+
+void bt_mesh_rpl_clear(void);


### PR DESCRIPTION
These two patches are essential for proper handling of the RPL, and makes it possible to pass all Transport layer PTS tests.