### PR TITLE
zephyr-make: A tool to abstract away CMake-based initialization

### DIFF
--- a/zephyr-make
+++ b/zephyr-make
@@ -1,0 +1,23 @@
+#!/usr/bin/make -rf
+
+BOARD ?= qemu_x86
+CONF_FILE = prj.conf
+
+TARGETS = run flash debug debugserver ram_report rom_report
+
+all: outdir/${BOARD}/zephyr.elf
+
+outdir/${BOARD}/Makefile: CMakeLists.txt $(CONF_FILE)
+	mkdir -p outdir/${BOARD} && cmake -DCONF_FILE=${CONF_FILE} -DBOARD=${BOARD} -Boutdir/${BOARD} -H.
+
+outdir/${BOARD}/zephyr.elf: outdir/${BOARD}/Makefile
+	$(MAKE) -s -C outdir/${BOARD}
+
+pristine:
+	rm -rf outdir
+
+clean:
+	rm -rf outdir/${BOARD}/
+
+$(TARGETS): outdir/${BOARD}/zephyr.elf
+	$(MAKE) -s -C outdir/${BOARD} $@


### PR DESCRIPTION
This is a simple wrapper makefile which makes the development
workflow post CMake migration largely similar to that of prior
to it. It's just "zephyr-make" (added to PATH first) should be
used where previously just "make" was used. Examples:

    cd samples/hello_world

    # Build for default board, which is always qemu_x86
    zephyr-make
    # Build for a give board with a specific config
    zephyr-make BOARD=qemu_cortex_m3 CONF_FILE=prj_my.conf
    # Run (default config) in an emulator
    zephyr-make run
    # Start debug server
    zephyr-make debugserver

Signed-off-by: Paul Sokolovsky <paul.sokolovsky@linaro.org>