### PR TITLE
cmake: Move syscall_macros.h generation into the build stage

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -293,6 +293,17 @@ add_subdirectory(arch)
 add_subdirectory(drivers)
 add_subdirectory(tests)
 
+set(syscall_macros_h ${ZEPHYR_BINARY_DIR}/include/generated/syscall_macros.h)
+
+add_custom_target(syscall_macros_h_target DEPENDS ${syscall_macros_h})
+add_custom_command(                       OUTPUT  ${syscall_macros_h}
+  COMMAND
+  ${PYTHON_EXECUTABLE}
+  ${PROJECT_SOURCE_DIR}/scripts/gen_syscall_header.py
+  > ${syscall_macros_h}
+  DEPENDS ${PROJECT_SOURCE_DIR}/scripts/gen_syscall_header.py
+  )
+
 # Generate offsets.c.obj from offsets.c
 # Generate offsets.h     from offsets.c.obj
 
@@ -302,6 +313,7 @@ set(OFFSETS_H_PATH ${PROJECT_BINARY_DIR}/include/generated/offsets.h)
 
 add_library(offsets STATIC ${OFFSETS_C_PATH})
 target_link_libraries(offsets zephyr_interface)
+add_dependencies(offsets syscall_macros_h_target)
 
 add_custom_command(
   OUTPUT ${OFFSETS_H_PATH}

--- a/cmake/app/boilerplate.cmake
+++ b/cmake/app/boilerplate.cmake
@@ -66,16 +66,6 @@ include($ENV{ZEPHYR_BASE}/cmake/extensions.cmake)
 
 find_package(PythonInterp 3.4)
 
-# Generate syscall_macros.h at configure-time because it has virtually
-# no dependencies
-file(MAKE_DIRECTORY ${PROJECT_BINARY_DIR}/include/generated)
-execute_process(
-  COMMAND
-  ${PYTHON_EXECUTABLE}
-  $ENV{ZEPHYR_BASE}/scripts/gen_syscall_header.py
-  OUTPUT_FILE ${ZEPHYR_BINARY_DIR}/include/generated/syscall_macros.h
-  )
-
 if(NOT ZEPHYR_GCC_VARIANT)
   set(ZEPHYR_GCC_VARIANT $ENV{ZEPHYR_GCC_VARIANT})
 endif()

--- a/cmake/kconfig.cmake
+++ b/cmake/kconfig.cmake
@@ -2,6 +2,7 @@
 # conf/mconf needs to be run from a different directory because of: ZEP-1963
 file(MAKE_DIRECTORY ${PROJECT_BINARY_DIR}/kconfig/include/generated)
 file(MAKE_DIRECTORY ${PROJECT_BINARY_DIR}/kconfig/include/config)
+file(MAKE_DIRECTORY ${PROJECT_BINARY_DIR}/include/generated)
 
 set_ifndef(KCONFIG_ROOT ${PROJECT_SOURCE_DIR}/Kconfig)
 


### PR DESCRIPTION
This fixes https://github.com/zephyrproject-rtos/zephyr/issues/5186

The script that generates syscall_macros.h is moved from Configuration
time to build time. This allows us to express to the build system that
syscall_macros.h depends on the script that generates it.

Signed-off-by: Sebastian Bøe <sebastian.boe@nordicsemi.no>