### PR TITLE
boards: arm: NRF52 PCA10040: fix scratch slot size to fix mcuboot compatibility

### DIFF
--- a/boards/arm/nrf52_pca10040/nrf52_pca10040.dts
+++ b/boards/arm/nrf52_pca10040/nrf52_pca10040.dts
@@ -54,20 +54,20 @@
 		};
 		scratch_partition: partition@70000 {
 			label = "image-scratch";
-			reg = <0x00070000 0xD000>;
+			reg = <0x00070000 0xa000>;
 		};
 
 		/*
-		 * The flash starting at 0x0007d000 and ending at
-		 * 0x0007ffff (sectors 125-127) is reserved for use
+		 * The flash starting at 0x0007a000 and ending at
+		 * 0x0007ffff (sectors 122-127) is reserved for use
 		 * by the application. If enabled, partition for NFFS
 		 * will be created in this area.
 		 */
 
 #if defined(CONFIG_FILE_SYSTEM_NFFS)
-		nffs_partition: partition@7d000 {
+		nffs_partition: partition@7a000 {
 			label = "nffs";
-			reg = <0x0007d000 0x00003000>;
+			reg = <0x0007a000 0x00006000>;
 		};
 #endif
 	};


### PR DESCRIPTION
Current scratch size given in board `NRF52 PCA10040` does not work with mcuboot as it does not fulfill the constraints of the flash memory layout.

Applying this fix, the following two constraints are fulfilled that are needed for mcuboot to upgrade partitions correctly:
- [x] slot x size must be a multiple of scratch slot size
- [x] scratch slot size must be a multiple of flash page erase size