### PR TITLE
[RFC] Fix jailhouse build

### DIFF
--- a/boards/x86/x86_jailhouse/x86_jailhouse.dts
+++ b/boards/x86/x86_jailhouse/x86_jailhouse.dts
@@ -1,4 +1,43 @@
-#include <qemu_x86.dts>
+/dts-v1/;
+
+#define DT_FLASH_SIZE		__SIZE_K(4092)
+
+#if XIP
+	#define DT_SRAM_SIZE		__SIZE_K(4096)
+#else
+	#define DT_SRAM_SIZE		__SIZE_K(8188)
+#endif
+
+#include <ia32.dtsi>
+
+/ {
+	model = "QEMU X86";
+	compatible = "intel,ia32";
+
+	aliases {
+		uart_0 = &uart0;
+		uart_1 = &uart1;
+	};
+
+	chosen {
+		zephyr,sram = &sram0;
+		zephyr,flash = &flash0;
+		zephyr,console = &uart0;
+		zephyr,bt-uart = &uart1;
+		zephyr,uart-pipe = &uart1;
+		zephyr,bt-mon-uart = &uart1;
+	};
+};
+
+&uart0 {
+	status = "ok";
+	current-speed = <115200>;
+};
+
+&uart1 {
+	status = "ok";
+	current-speed = <115200>;
+};
 
 &flash0 {
 	reg = <0x0 DT_SRAM_SIZE>;
@@ -7,4 +46,3 @@
 &sram0 {
 	reg = <0x0 DT_SRAM_SIZE>;
 };
-


### PR DESCRIPTION
The jailhouse board's build is currently broken.

It wants to depend on the qemu board's devicetree, but can no longer
do so since the board-level dts files were moved into individual board
directories.

To restore the build, dts/x86/ia32_qemu.dtsi, and include it from
qemu_x86.dts as well as x86_jailhouse.dts.
