### PR TITLE
samples: webusb: fix array length in Product and SN string descriptors

### DIFF
--- a/samples/subsys/usb/webusb/src/webusb_serial.c
+++ b/samples/subsys/usb/webusb/src/webusb_serial.c
@@ -148,13 +148,13 @@ struct dev_common_descriptor {
 		struct usb_product_descriptor {
 			u8_t bLength;
 			u8_t bDescriptorType;
-			u8_t bString[0x0E - 1];
+			u8_t bString[0x0E - 2];
 		} __packed unicode_product;
 
 		struct usb_sn_descriptor {
 			u8_t bLength;
 			u8_t bDescriptorType;
-			u8_t bString[0x0C - 1];
+			u8_t bString[0x0C - 2];
 		} __packed unicode_sn;
 	} __packed string_descr;
 	struct usb_desc_header term_descr;


### PR DESCRIPTION
I am testing webusb example on my stm32f4 board, but the demo can't run. next is the log:
```
[general] [DBG] usb_handle_std_device_req: REQ_GET_DESCRIPTOR
[general] [DBG] usb_get_descriptor: Desc 303 not found!
[general] [DBG] usb_handle_request: Handler Error 0
[general] [DBG] usb_print_setup: SETUP
[general] [DBG] usb_print_setup: 80 6 303 409 ff
```

The host reading string descriptor failed. next is the string descriptor dump by debug tool: 
```
04 03 09 04                                       # lang_desc
0C 03 49 00 6E 00 74 00 65 00 6C 00               # unicode_mfr
0E 03 57 00 65 00 62 00 55 00 53 00 42 00 00      # unicode_product
0C 03 30 00 30 00 2E 00 30 00 31 00 00            # unicode_sn
```

there was one more bytes(zero) at the end of unicode_product ans unicode_sn, that byte was treat as termination flag. so **usb_get_descriptor** can't found unicode_sn and report error.

