### PR TITLE
Bluetooth: Mesh: Clearly document the magic 18 byte minimum length

### DIFF
--- a/subsys/bluetooth/host/mesh/net.c
+++ b/subsys/bluetooth/host/mesh/net.c
@@ -34,6 +34,14 @@
 #include "foundation.h"
 #include "beacon.h"
 
+/* Minimum valid Mesh Network PDU length. The Network headers
+ * themselves take up 9 bytes. After that there is a minumum of 1 byte
+ * payload for both CTL=1 and CTL=0 PDUs (smallest OpCode is 1 byte). CTL=1
+ * PDUs must use a 64-bit (8 byte) NetMIC, whereas CTL=0 PDUs have at least
+ * a 32-bit (4 byte) NetMIC and AppMIC giving again a total of 8 bytes.
+ */
+#define BT_MESH_NET_MIN_PDU_LEN (BT_MESH_NET_HDR_LEN + 1 + 8)
+
 /* Seq limit after IV Update is triggered */
 #define IV_UPDATE_SEQ_LIMIT 8000000
 
@@ -1175,7 +1183,7 @@ done:
 int bt_mesh_net_decode(struct net_buf_simple *data, enum bt_mesh_net_if net_if,
 		       struct bt_mesh_net_rx *rx, struct net_buf_simple *buf)
 {
-	if (data->len < 18) {
+	if (data->len < BT_MESH_NET_MIN_PDU_LEN) {
 		BT_WARN("Dropping too short mesh packet (len %u)", data->len);
 		BT_WARN("%s", bt_hex(data->data, data->len));
 		return -EINVAL;


### PR DESCRIPTION
This makes it clear why 18 is a valid minimum network PDU length to
enforce. This is particularly important since as of writing this patch
there's at least one PTS test case which sends too small PDUs, which
could potentially lead to people thinking the implementation is at
fault (it's not).

Signed-off-by: Johan Hedberg <johan.hedberg@intel.com>