### PR TITLE
kconfig: fix CPU_HAS_FPU dependencies

### DIFF
--- a/boards/x86/qemu_x86/Kconfig.board
+++ b/boards/x86/qemu_x86/Kconfig.board
@@ -4,3 +4,4 @@ config BOARD_QEMU_X86
 	depends on SOC_IA32
 	select QEMU_TARGET
 	select HAS_DTS
+	select CPU_HAS_FPU if !X86_IAMCU

--- a/boards/x86/qemu_x86/Kconfig.defconfig
+++ b/boards/x86/qemu_x86/Kconfig.defconfig
@@ -8,7 +8,4 @@ config BUILD_OUTPUT_BIN
 config BOARD
 	default qemu_x86
 
-config CPU_HAS_FPU
-	def_bool y if !X86_IAMCU
-
 endif # BOARD_QEMU_X86

--- a/boards/x86/x86_jailhouse/Kconfig.board
+++ b/boards/x86/x86_jailhouse/Kconfig.board
@@ -4,3 +4,4 @@ config BOARD_X86_JAILHOUSE
 	depends on SOC_IA32
 	select QEMU_TARGET
 	select HAS_DTS
+	select CPU_HAS_FPU if !X86_IAMCU

--- a/boards/x86/x86_jailhouse/Kconfig.defconfig
+++ b/boards/x86/x86_jailhouse/Kconfig.defconfig
@@ -4,9 +4,6 @@ if BOARD_X86_JAILHOUSE
 config BOARD
 	default x86_jailhouse
 
-config CPU_HAS_FPU
-	def_bool y if !X86_IAMCU
-
 config JAILHOUSE
 	bool "Zephyr port to boot as a (x86) Jailhouse inmate cell payload"
 	default y


### PR DESCRIPTION
Getting warnings from Kconfig after generalising how CPU_HAS_FPU is
configured on the architecture level. 2 Boards were settings this value
in the wrong place.

Fixes #5211.

Signed-off-by: Anas Nashif <anas.nashif@intel.com>