### PR TITLE
ext: nordic: Move configuration from cmake to cpp

### DIFF
--- a/ext/hal/nordic/drivers/CMakeLists.txt
+++ b/ext/hal/nordic/drivers/CMakeLists.txt
@@ -1,38 +1,3 @@
 if(CONFIG_IEEE802154_NRF5 OR CONFIG_IEEE802154_NRF5_RAW)
   zephyr_sources(nrf_drv_radio802154.c)
-
-  if(     CONFIG_IEEE802154_NRF5_CCA_MODE_ED)
-    set(radio_cca_mode NRF_RADIO_CCA_MODE_ED)
-
-  elseif( CONFIG_IEEE802154_NRF5_CCA_MODE_CARRIER)
-    set(radio_cca_mode NRF_RADIO_CCA_MODE_CARRIER)
-
-  elseif( CONFIG_IEEE802154_NRF5_CCA_MODE_CARRIER_AND_ED)
-    set(radio_cca_mode NRF_RADIO_CCA_MODE_CARRIER_AND_ED)
-
-  elseif( CONFIG_IEEE802154_NRF5_CCA_MODE_CARRIER_OR_ED)
-    set(radio_cca_mode NRF_RADIO_CCA_MODE_CARRIER_OR_ED)
-
-  endif()
-
-  zephyr_compile_definitions(
-    # Number of slots containing short addresses of nodes for which
-    # pending data is stored.
-    RADIO_PENDING_SHORT_ADDRESSES=1
-
-    # Number of slots containing extended addresses of nodes for which
-    # pending data is stored.
-    RADIO_PENDING_EXTENDED_ADDRESSES=1
-
-    # Number of buffers in receive queue.
-    RADIO_RX_BUFFERS=1
-
-    # CCA mode
-    RADIO_CCA_MODE=${radio_cca_mode}
-
-    # CCA mode options
-    RADIO_CCA_CORR_LIMIT=${CONFIG_IEEE802154_NRF5_CCA_CORR_LIMIT}
-    RADIO_CCA_CORR_THRESHOLD=${CONFIG_IEEE802154_NRF5_CCA_CORR_THRESHOLD}
-    RADIO_CCA_ED_THRESHOLD=${CONFIG_IEEE802154_NRF5_CCA_ED_THRESHOLD}
-    )
 endif()

--- a/ext/hal/nordic/drivers/nrf_drv_radio802154.c
+++ b/ext/hal/nordic/drivers/nrf_drv_radio802154.c
@@ -34,32 +34,10 @@
  *
  */
 
-// Number of slots containing short addresses of nodes for which
-// pending data is stored.
-#define RADIO_PENDING_SHORT_ADDRESSES 1
 
-// Number of slots containing extended addresses of nodes for which
-// pending data is stored.
-#define RADIO_PENDING_EXTENDED_ADDRESSES 1
-
-// Number of buffers in receive queue.
-#define RADIO_RX_BUFFERS 1
-
-// CCA mode
-#if defined(CONFIG_IEEE802154_NRF5_CCA_MODE_ED)
-#define RADIO_CCA_MODE NRF_RADIO_CCA_MODE_ED
-#elif defined(CONFIG_IEEE802154_NRF5_CCA_MODE_CARRIER)
-#define RADIO_CCA_MODE NRF_RADIO_CCA_MODE_CARRIER
-#elif defined(CONFIG_IEEE802154_NRF5_CCA_MODE_CARRIER_AND_ED)
-#define RADIO_CCA_MODE  NRF_RADIO_CCA_MODE_CARRIER_AND_ED
-#elif defined(CONFIG_IEEE802154_NRF5_CCA_MODE_CARRIER_OR_ED)
-#define RADIO_CCA_MODE  NRF_RADIO_CCA_MODE_CARRIER_OR_ED
+#ifdef __ZEPHYR__
+#include "nrf_drv_radio802154_zephyr_config.h"
 #endif
-
-// CCA mode options
-#define RADIO_CCA_CORR_LIMIT     CONFIG_IEEE802154_NRF5_CCA_CORR_LIMIT
-#define RADIO_CCA_CORR_THRESHOLD CONFIG_IEEE802154_NRF5_CCA_CORR_THRESHOLD
-#define RADIO_CCA_ED_THRESHOLD   CONFIG_IEEE802154_NRF5_CCA_ED_THRESHOLD
 
 #include "nrf_drv_radio802154.h"
 

--- a/ext/hal/nordic/drivers/nrf_drv_radio802154.c
+++ b/ext/hal/nordic/drivers/nrf_drv_radio802154.c
@@ -34,6 +34,33 @@
  *
  */
 
+// Number of slots containing short addresses of nodes for which
+// pending data is stored.
+#define RADIO_PENDING_SHORT_ADDRESSES 1
+
+// Number of slots containing extended addresses of nodes for which
+// pending data is stored.
+#define RADIO_PENDING_EXTENDED_ADDRESSES 1
+
+// Number of buffers in receive queue.
+#define RADIO_RX_BUFFERS 1
+
+// CCA mode
+#if defined(CONFIG_IEEE802154_NRF5_CCA_MODE_ED)
+#define RADIO_CCA_MODE NRF_RADIO_CCA_MODE_ED
+#elif defined(CONFIG_IEEE802154_NRF5_CCA_MODE_CARRIER)
+#define RADIO_CCA_MODE NRF_RADIO_CCA_MODE_CARRIER
+#elif defined(CONFIG_IEEE802154_NRF5_CCA_MODE_CARRIER_AND_ED)
+#define RADIO_CCA_MODE  NRF_RADIO_CCA_MODE_CARRIER_AND_ED
+#elif defined(CONFIG_IEEE802154_NRF5_CCA_MODE_CARRIER_OR_ED)
+#define RADIO_CCA_MODE  NRF_RADIO_CCA_MODE_CARRIER_OR_ED
+#endif
+
+// CCA mode options
+#define RADIO_CCA_CORR_LIMIT     CONFIG_IEEE802154_NRF5_CCA_CORR_LIMIT
+#define RADIO_CCA_CORR_THRESHOLD CONFIG_IEEE802154_NRF5_CCA_CORR_THRESHOLD
+#define RADIO_CCA_ED_THRESHOLD   CONFIG_IEEE802154_NRF5_CCA_ED_THRESHOLD
+
 #include "nrf_drv_radio802154.h"
 
 #include <assert.h>

--- a/ext/hal/nordic/drivers/nrf_drv_radio802154_zephyr_config.h
+++ b/ext/hal/nordic/drivers/nrf_drv_radio802154_zephyr_config.h
@@ -1,0 +1,61 @@
+/* Copyright (c) 2016, Nordic Semiconductor ASA
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ *   1. Redistributions of source code must retain the above copyright notice, this
+ *      list of conditions and the following disclaimer.
+ *
+ *   2. Redistributions in binary form must reproduce the above copyright notice,
+ *      this list of conditions and the following disclaimer in the documentation
+ *      and/or other materials provided with the distribution.
+ *
+ *   3. Neither the name of Nordic Semiconductor ASA nor the names of its
+ *      contributors may be used to endorse or promote products derived from
+ *      this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ */
+
+#ifndef NRF_RADIO802154_ZEPHYR_CONFIG_H_
+#define NRF_RADIO802154_ZEPHYR_CONFIG_H_
+
+// Number of slots containing short addresses of nodes for which
+// pending data is stored.
+#define RADIO_PENDING_SHORT_ADDRESSES 1
+
+// Number of slots containing extended addresses of nodes for which
+// pending data is stored.
+#define RADIO_PENDING_EXTENDED_ADDRESSES 1
+
+// Number of buffers in receive queue.
+#define RADIO_RX_BUFFERS 1
+
+// CCA mode
+#if defined(CONFIG_IEEE802154_NRF5_CCA_MODE_ED)
+#define RADIO_CCA_MODE NRF_RADIO_CCA_MODE_ED
+#elif defined(CONFIG_IEEE802154_NRF5_CCA_MODE_CARRIER)
+#define RADIO_CCA_MODE NRF_RADIO_CCA_MODE_CARRIER
+#elif defined(CONFIG_IEEE802154_NRF5_CCA_MODE_CARRIER_AND_ED)
+#define RADIO_CCA_MODE  NRF_RADIO_CCA_MODE_CARRIER_AND_ED
+#elif defined(CONFIG_IEEE802154_NRF5_CCA_MODE_CARRIER_OR_ED)
+#define RADIO_CCA_MODE  NRF_RADIO_CCA_MODE_CARRIER_OR_ED
+#endif
+
+// CCA mode options
+#define RADIO_CCA_CORR_LIMIT     CONFIG_IEEE802154_NRF5_CCA_CORR_LIMIT
+#define RADIO_CCA_CORR_THRESHOLD CONFIG_IEEE802154_NRF5_CCA_CORR_THRESHOLD
+#define RADIO_CCA_ED_THRESHOLD   CONFIG_IEEE802154_NRF5_CCA_ED_THRESHOLD
+
+#endif


### PR DESCRIPTION
There are several issues with this driver. Firstly, it is polluting
the global space of defines instead of just locally where it is
needed. Also, it is using CMakeLists.txt for something that can be done
with the preprocessor. As a general principle, it is better to do
something with the preprocessor than with build script code.

Signed-off-by: Sebastian Bøe <sebastian.boe@nordicsemi.no>