### PR TITLE
tests: test_build: Added test for compiling with -O0

### DIFF
--- a/tests/kernel/test_build/testcase.yaml
+++ b/tests/kernel/test_build/testcase.yaml
@@ -12,3 +12,7 @@ tests:
       build_only: true
       extra_args: CONF_FILE=runtime_nmi.conf
       tags: apps
+  - test_optimize_O0:
+      build_only: true
+      extra_args: EXTRA_CFLAGS=-O0
+      tags: apps


### PR DESCRIPTION
Janne Karhunen discovered that building with -O0 failed the
build. Having this test in CI ensures that when the issue is fixed, it
will not re-appear.

Signed-off-by: Sebastian Bøe <sebastian.boe@nordicsemi.no>