### PR TITLE
Add USB OTG to the pinmux table for STM32x407 boards

### DIFF
--- a/arch/arm/soc/st_stm32/stm32f4/Kconfig.defconfig.series
+++ b/arch/arm/soc/st_stm32/stm32f4/Kconfig.defconfig.series
@@ -69,6 +69,19 @@ config USB_DC_STM32_RAM_SIZE
         int
         default 1280
 
+if USB_CDC_ACM
+
+config CDC_ACM_INT_EP_ADDR
+       default 0x81
+
+config CDC_ACM_IN_EP_ADDR
+       default 0x82
+
+config CDC_ACM_OUT_EP_ADDR
+       default 0x03
+
+endif # USB_CDC_ACM
+
 endif #USB
 
 if WATCHDOG

--- a/boards/arm/olimex_stm32_e407/pinmux.c
+++ b/boards/arm/olimex_stm32_e407/pinmux.c
@@ -40,6 +40,10 @@ static const struct pin_config pinconf[] = {
 	{STM32_PIN_PG13, STM32F4_PINMUX_FUNC_PG13_ETH},
 	{STM32_PIN_PG14, STM32F4_PINMUX_FUNC_PG14_ETH},
 #endif /* CONFIG_ETH_STM32_HAL */
+#ifdef CONFIG_USB_DC_STM32
+	{STM32_PIN_PA11, STM32F4_PINMUX_FUNC_PA11_OTG_FS_DM},
+	{STM32_PIN_PA12, STM32F4_PINMUX_FUNC_PA12_OTG_FS_DP},
+#endif  /* CONFIG_USB_DC_STM32 */
 };
 
 static int pinmux_stm32_init(struct device *port)

--- a/boards/arm/stm32f4_disco/pinmux.c
+++ b/boards/arm/stm32f4_disco/pinmux.c
@@ -25,6 +25,10 @@ static const struct pin_config pinconf[] = {
 #ifdef CONFIG_PWM_STM32_2
 	{STM32_PIN_PA0, STM32F4_PINMUX_FUNC_PA0_PWM2_CH1},
 #endif /* CONFIG_PWM_STM32_2 */
+#ifdef CONFIG_USB_DC_STM32
+	{STM32_PIN_PA11, STM32F4_PINMUX_FUNC_PA11_OTG_FS_DM},
+	{STM32_PIN_PA12, STM32F4_PINMUX_FUNC_PA12_OTG_FS_DP},
+#endif	/* CONFIG_USB_DC_STM32 */
 };
 
 static int pinmux_stm32_init(struct device *port)


### PR DESCRIPTION
Add USB OTG to the pinmux table for OLIMEX STM32-E407 and STM32F407G-DISC1 boards and also fix out of range endpoint addresses in CDC ACM case.

Tested with the CDC ACM and WebUSB samples on both the boards, and they are working fine.