### PR TITLE
cmake: Add LANG-aware versions to the zephyr_get_* API

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -324,7 +324,7 @@ add_custom_target(offsets_h DEPENDS ${OFFSETS_H_PATH})
 
 zephyr_include_directories(${TOOLCHAIN_INCLUDES})
 
-zephyr_get_include_directories(ZEPHYR_INCLUDES)
+zephyr_get_include_directories_for_lang(C ZEPHYR_INCLUDES)
 
 add_subdirectory(kernel)
 

--- a/samples/application_development/external_lib/CMakeLists.txt
+++ b/samples/application_development/external_lib/CMakeLists.txt
@@ -11,13 +11,13 @@ target_sources(app PRIVATE src/main.c)
 # do not need any build information from zephyr. Or they may be
 # incompatible with certain zephyr options and need them to be
 # filtered out.
-zephyr_get_include_directories_as_string(includes)
-zephyr_get_system_include_directories_as_string(system_includes)
-zephyr_get_compile_definitions_as_string(definitions)
-zephyr_get_compile_options_as_string(options)
+zephyr_get_include_directories_for_lang_as_string(       C includes)
+zephyr_get_system_include_directories_for_lang_as_string(C system_includes)
+zephyr_get_compile_definitions_for_lang_as_string(       C definitions)
+zephyr_get_compile_options_for_lang_as_string(           C options)
 
 set(external_project_cflags
-  ${includes}${definitions}${options}${system_includes}
+  "${includes} ${definitions} ${options} ${system_includes}"
   )
 
 include(ExternalProject)


### PR DESCRIPTION
When exporting flags to an external build system we need to deal with
the fact that we sometimes use generator expressions. Specifically, we
use generator expressions that look like this:

$<$<COMPILE_LANGUAGE:CXX>:-fno-exceptions>

This patch introduces an API where users can ask for compile options
for specific languages, like this:

zephyr_get_compile_options_for_lang_as_string(CXX x)

This deprecates the existing API.

Because today the existing API will either crash or silently omit
flags when a COMPILE_LANG generator expression is present.

The existing API is kept for the time being to allow users that are
not affected by the above issues to update cleanly.

Signed-off-by: Sebastian Bøe <sebastian.boe@nordicsemi.no>