### PR TITLE
doc: fix doc Makefile dependency on python

### DIFF
--- a/doc/Makefile
+++ b/doc/Makefile
@@ -73,7 +73,7 @@ content: scripts/extract_content.py
 	$(Q)$<
 
 kconfig: scripts/genrest/genrest.py
-	$(Q)srctree=../ KERNELVERSION=1.9.99 SRCARCH=x86 python $< ../Kconfig reference/kconfig/
+	$(Q)srctree=../ KERNELVERSION=1.9.99 SRCARCH=x86 python3 $< ../Kconfig reference/kconfig/
 
 
 prep: doxy content kconfig


### PR DESCRIPTION
With a clean Ubuntu install,  following the getting started page
instructions for linux, only python3 is installed.  Apparently (by
design), a python3 install does not create the symbolic link for
/usr/bin/python so the doc/Makefile complains.

Signed-off-by: David B. Kinder <david.b.kinder@intel.com>