### PR TITLE
doc: fix handling of OPTION directive in genrest

### DIFF
--- a/doc/scripts/genrest/genrest.py
+++ b/doc/scripts/genrest/genrest.py
@@ -47,7 +47,7 @@ def print_items(items, outdir, indent):
                 config = open("%s/%s.rst" % (outdir, var), "w")
                 config.write(":orphan:\n\n")
                 config.write(".. title:: %s\n\n" %item.get_name())
-                config.write(".. option:: CONFIG_%s:\n" %item.get_name())
+                config.write(".. option:: CONFIG_%s\n" %item.get_name())
                 config.write(".. _CONFIG_%s:\n" %item.get_name())
                 if text:
                     config.write("\n%s\n\n" %text)


### PR DESCRIPTION
The genrest.py script used to create configuration options documentation
from the KConfig files generates slightly incorrect OPTION directives
(with an extra colon at the end).  Sphinx 1.5 didn't care, but Sphinx
1.6 does, so fix this now in preparation for upgrading Sphinx to the
current version.

Signed-off-by: David B. Kinder <david.b.kinder@intel.com>