### PR TITLE
drivers: gpio: esp32: Fix return function isn't handled

### DIFF
--- a/drivers/gpio/gpio_esp32.c
+++ b/drivers/gpio/gpio_esp32.c
@@ -154,8 +154,9 @@ static int gpio_esp32_config(struct device *dev, int access_op,
 	}
 
 	if (flags & GPIO_DIR_OUT) {
-		pinmux_pin_input_enable(data->pinmux, pin,
+		r = pinmux_pin_input_enable(data->pinmux, pin,
 					PINMUX_OUTPUT_ENABLED);
+		assert(r >= 0);
 	} else {
 		pinmux_pin_input_enable(data->pinmux, pin,
 					PINMUX_INPUT_ENABLED);


### PR DESCRIPTION
To know if the gpio was set correctly pinmux_pin_input_enable()'s
return and pinmux_pin_pullup()'s return must be handled in
gpio_esp32_config().

Signed-off-by: Vitor Massaru Iha <vitor@massaru.org>