### PR TITLE
doc: environment setup needs zephyr clone first

### DIFF
--- a/doc/getting_started/getting_started.rst
+++ b/doc/getting_started/getting_started.rst
@@ -6,6 +6,26 @@ Getting Started Guide
 Use this guide to get started with your :ref:`Zephyr <introducing_zephyr>`
 development.
 
+Checking Out the Source Code Anonymously
+****************************************
+
+The Zephyr source code is hosted in a GitHub repo that supports
+anonymous cloning via git. There are scripts and such in this repo that
+you'll need to set up your development environment, and we'll be using
+Git to get this repo.  (If you don't have Git installed, see the
+beginning of the OS-specific instructions below for help.)
+
+We'll begin by
+using Git to clone the repository anonymously. Enter:
+
+.. code-block:: console
+
+   $ cd ~
+   $ git clone https://github.com/zephyrproject-rtos/zephyr.git
+
+You have successfully checked out a copy of the source code to your local
+machine in the ~/zephyr folder.
+
 Set Up the Development Environment
 **********************************
 
@@ -24,21 +44,6 @@ Use the following procedures to create a new development environment.
    installation_mac.rst
    installation_win.rst
 
-
-Checking Out the Source Code Anonymously
-========================================
-
-The code is hosted in a GitHub repo that supports
-anonymous cloning via git.
-
-To clone the repository anonymously, enter:
-
-.. code-block:: console
-
-   $ git clone https://github.com/zephyrproject-rtos/zephyr.git
-
-You have successfully checked out a copy of the source code to your local
-machine.
 
 .. _getting_started_run_sample:
 

--- a/doc/getting_started/installation_linux.rst
+++ b/doc/getting_started/installation_linux.rst
@@ -67,6 +67,7 @@ Install the required packages in a Fedora host system with:
 
 Install additional packages required for development with Zephyr::
 
+   $ cd ~/zephyr  # or to your directory where zephyr is cloned
    $ pip3 install --user -r scripts/requirements.txt
 
 CMake version 3.8.2 or higher is required. Check what version you have using

--- a/doc/getting_started/installation_mac.rst
+++ b/doc/getting_started/installation_mac.rst
@@ -61,6 +61,7 @@ Install tools to build Zephyr binaries:
    $ curl -O 'https://bootstrap.pypa.io/get-pip.py'
    $ ./get-pip.py
    $ rm get-pip.py
+   $ cd ~/zephyr   # or to the folder where you cloned the zephyr repo
    $ pip3 install --user -r scripts/requirements.txt
 
 Source :file:`zephyr-env.sh` wherever you have cloned the Zephyr Git repository:

--- a/doc/getting_started/installation_win.rst
+++ b/doc/getting_started/installation_win.rst
@@ -73,6 +73,7 @@ environment for Windows. Follow the steps below to set it up:
       $ curl -O 'https://bootstrap.pypa.io/get-pip.py'
       $ ./get-pip.py
       $ rm get-pip.py
+      $ cd ~/zephyr   # or to the folder where you cloned the zephyr repo
       $ pip install --user -r scripts/requirements.txt
 
 #. The build system should now be ready to work with any toolchain installed in


### PR DESCRIPTION
There are files in the cloned copy of the Zephyr tree needed to setup
the development environment, so there's a bit of chicken and egg
problem.

Signed-off-by: David B. Kinder <david.b.kinder@intel.com>