### PR TITLE
fix issue that 'test_unlock_preemptible' test case failure because pr…

### DIFF
--- a/tests/kernel/threads/scheduling/schedule_api/src/test_sched_timeslice_and_lock.c
+++ b/tests/kernel/threads/scheduling/schedule_api/src/test_sched_timeslice_and_lock.c
@@ -203,6 +203,7 @@ void test_lock_preemptible(void)
 	}
 	/* restore environment */
 	teardown_threads();
+	k_sched_unlock();
 }
 
 void test_unlock_preemptible(void)


### PR DESCRIPTION
…evious case 'test_lock_preemptible' did not unlock the scheduler

Signed-off-by: caozilong <caozilong@allwinnertech.com>