### PR TITLE
drivers: eth_mcux: Implement IPv6 multicast group joining/leaving

### DIFF
--- a/drivers/ethernet/eth_mcux.c
+++ b/drivers/ethernet/eth_mcux.c
@@ -22,6 +22,7 @@
 #include <kernel.h>
 #include <net/net_pkt.h>
 #include <net/net_if.h>
+#include <net/ethernet.h>
 
 #include "fsl_enet.h"
 #include "fsl_phy.h"
@@ -578,7 +579,15 @@ static void net_if_mcast_cb(struct net_if *iface,
 			    const struct in6_addr *addr,
 			    bool is_joined)
 {
-	/* TBD */
+	struct net_eth_addr mac_addr;
+
+	net_eth_ipv6_mcast_to_mac_addr(addr, &mac_addr);
+
+	if (is_joined) {
+		ENET_AddMulticastGroup(ENET, mac_addr.addr);
+	} else {
+		ENET_LeaveMulticastGroup(ENET, mac_addr.addr);
+	}
 }
 #endif /* CONFIG_NET_IPV6 */
 

--- a/include/net/ethernet.h
+++ b/include/net/ethernet.h
@@ -85,6 +85,15 @@ static inline bool net_eth_is_addr_multicast(struct net_eth_addr *addr)
 
 const struct net_eth_addr *net_eth_broadcast_addr(void);
 
+/**
+ * @brief Convert IPv6 multicast address to Ethernet address.
+ *
+ * @param ipv6_addr IPv6 multicast address
+ * @param mac_addr Output buffer for Ethernet address
+ */
+void net_eth_ipv6_mcast_to_mac_addr(const struct in6_addr *ipv6_addr,
+				    struct net_eth_addr *mac_addr);
+
 #ifdef __cplusplus
 }
 #endif

--- a/subsys/net/ip/l2/ethernet.c
+++ b/subsys/net/ip/l2/ethernet.c
@@ -31,6 +31,20 @@ const struct net_eth_addr *net_eth_broadcast_addr(void)
 	return &broadcast_eth_addr;
 }
 
+void net_eth_ipv6_mcast_to_mac_addr(const struct in6_addr *ipv6_addr,
+				    struct net_eth_addr *mac_addr)
+{
+	/* RFC 2464 7. Address Mapping -- Multicast
+	 * "An IPv6 packet with a multicast destination address DST,
+	 * consisting of the sixteen octets DST[1] through DST[16],
+	 * is transmitted to the Ethernet multicast address whose
+	 * first two octets are the value 3333 hexadecimal and whose
+	 * last four octets are the last four octets of DST."
+	 */
+	mac_addr->addr[0] = mac_addr->addr[1] = 0x33;
+	memcpy(mac_addr->addr + 2, &ipv6_addr->s6_addr[12], 4);
+}
+
 #if defined(CONFIG_NET_DEBUG_L2_ETHERNET)
 #define print_ll_addrs(pkt, type, len)					   \
 	do {								   \


### PR DESCRIPTION
IPv6 mcast addr to MAC mcast conversion was factored out to
subsys/net/ip/l2/ethernet.c for reuse by other drivers.

Signed-off-by: Paul Sokolovsky <paul.sokolovsky@linaro.org>