### PR TITLE
doc: fix broken notes directives

### DIFF
--- a/boards/arm/efm32wg_stk3800/doc/efm32wg_stk3800.rst
+++ b/boards/arm/efm32wg_stk3800/doc/efm32wg_stk3800.rst
@@ -102,8 +102,8 @@ UART0 is connected to the board controller and is used for the console.
 Programming and Debugging
 *************************
 
-.. note:
-   Before useing the kit the first time, you should update the J-Link firmware
+.. note::
+   Before using the kit the first time, you should update the J-Link firmware
    from `J-Link-Downloads`_
 
 Flashing

--- a/doc/kernel/threads/scheduling.rst
+++ b/doc/kernel/threads/scheduling.rst
@@ -171,7 +171,7 @@ action that makes it unready, the scheduler will switch the locking thread out
 and allow other threads to execute. When the locking thread again
 becomes the current thread, its non-preemptible status is maintained.
 
-.. note:
+.. note::
     Locking out the scheduler is a more efficient way for a preemptible thread
     to inhibit preemption than changing its priority level to a negative value.
 


### PR DESCRIPTION
Fix two docs using ".. note:" instead of ".. note::" (missing a colon).

Signed-off-by: David B. Kinder <david.b.kinder@intel.com>