### PR TITLE
cmake: honor again CONFIG_KERNEL_ENTRY

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -507,7 +507,7 @@ set(zephyr_lnk
   ${LINKERFLAGPREFIX},-Map=${PROJECT_BINARY_DIR}/${KERNEL_MAP_NAME}
   -u_OffsetAbsSyms
   -u_ConfigAbsSyms
-  -e__start
+  -e${CONFIG_KERNEL_ENTRY}
   ${LINKERFLAGPREFIX},--start-group
   ${LINKERFLAGPREFIX},--whole-archive
   ${ZEPHYR_LIBS_PROPERTY}


### PR DESCRIPTION
This was impacting Jailhouse port, at least.

Signed-off-by: Gustavo Lima Chaves <gustavo.lima.chaves@intel.com>