### PR TITLE
kconfig: 802154: nrf: Fix kconfig

### DIFF
--- a/drivers/ieee802154/Kconfig.nrf5
+++ b/drivers/ieee802154/Kconfig.nrf5
@@ -9,6 +9,7 @@
 menuconfig IEEE802154_NRF5
 	bool "nRF52 series IEEE 802.15.4 Driver"
 	depends on NETWORKING && SOC_NRF52840
+	select HAS_NORDIC_DRIVERS
 	default n
 
 if IEEE802154_NRF5

--- a/samples/net/echo_server/sample.yaml
+++ b/samples/net/echo_server/sample.yaml
@@ -13,6 +13,9 @@ tests:
   - test_mcr20a:
       extra_args: CONF_FILE="prj_frdm_k64f_mcr20a.conf"
       platform_whitelist: frdm_k64f
+  - test_nrf:
+      extra_args: CONF_FILE="prj_nrf5.conf"
+      platform_whitelist: nrf52840_pca10056
   - test_bt:
       extra_args: CONF_FILE="prj_bt.conf"
       platform_whitelist: qemu_x86


### PR DESCRIPTION
This fixes a regression from
https://github.com/zephyrproject-rtos/zephyr/pull/5018

The ieee802154 driver wouldn't build because nrf drivers/ieee802154
depends on the nordic ext drivers to build.

Signed-off-by: Sebastian Bøe <sebastian.boe@nordicsemi.no>