### PR TITLE
Bluetooth: Mesh: GATT Proxy advertising support for multiple subnets

### DIFF
--- a/include/bluetooth/mesh/cfg_cli.h
+++ b/include/bluetooth/mesh/cfg_cli.h
@@ -58,6 +58,9 @@ int bt_mesh_cfg_relay_get(u16_t net_idx, u16_t addr, u8_t *status,
 int bt_mesh_cfg_relay_set(u16_t net_idx, u16_t addr, u8_t new_relay,
 			  u8_t new_transmit, u8_t *status, u8_t *transmit);
 
+int bt_mesh_cfg_net_key_add(u16_t net_idx, u16_t addr, u16_t key_net_idx,
+			    const u8_t net_key[16], u8_t *status);
+
 int bt_mesh_cfg_app_key_add(u16_t net_idx, u16_t addr, u16_t key_net_idx,
 			    u16_t key_app_idx, const u8_t app_key[16],
 			    u8_t *status);

--- a/subsys/bluetooth/host/mesh/cfg_srv.c
+++ b/subsys/bluetooth/host/mesh/cfg_srv.c
@@ -801,8 +801,7 @@ static void gatt_proxy_set(struct bt_mesh_model *model,
 			struct bt_mesh_subnet *sub = &bt_mesh.sub[i];
 
 			if (sub->net_idx != BT_MESH_KEY_UNUSED) {
-				sub->node_id = BT_MESH_NODE_IDENTITY_STOPPED;
-				sub->node_id_start = 0;
+				bt_mesh_proxy_identity_stop(sub);
 			}
 		}
 
@@ -2234,8 +2233,11 @@ static void node_identity_set(struct bt_mesh_model *model,
 		 */
 		if (IS_ENABLED(CONFIG_BT_MESH_GATT_PROXY) &&
 		    bt_mesh_gatt_proxy_get() == BT_MESH_GATT_PROXY_ENABLED) {
-			sub->node_id = node_id;
-			sub->node_id_start = node_id ? k_uptime_get_32() : 0;
+			if (node_id) {
+				bt_mesh_proxy_identity_start(sub);
+			} else {
+				bt_mesh_proxy_identity_stop(sub);
+			}
 			bt_mesh_adv_update();
 		}
 

--- a/subsys/bluetooth/host/mesh/proxy.c
+++ b/subsys/bluetooth/host/mesh/proxy.c
@@ -656,8 +656,6 @@ int bt_mesh_proxy_prov_disable(void)
 
 #endif /* CONFIG_BT_MESH_PB_GATT */
 
-
-
 #if defined(CONFIG_BT_MESH_GATT_PROXY)
 static ssize_t proxy_ccc_write(struct bt_conn *conn,
 			       const struct bt_gatt_attr *attr,

--- a/subsys/bluetooth/host/mesh/proxy.c
+++ b/subsys/bluetooth/host/mesh/proxy.c
@@ -357,8 +357,7 @@ void bt_mesh_proxy_identity_stop(struct bt_mesh_subnet *sub)
 
 int bt_mesh_proxy_identity_enable(void)
 {
-	/* FIXME: Add support for multiple subnets */
-	struct bt_mesh_subnet *sub = &bt_mesh.sub[0];
+	int i, count = 0;
 
 	BT_DBG("");
 
@@ -366,20 +365,24 @@ int bt_mesh_proxy_identity_enable(void)
 		return -EAGAIN;
 	}
 
-	if (sub->net_idx == BT_MESH_KEY_UNUSED) {
-		return -ENOENT;
+	for (i = 0; i < ARRAY_SIZE(bt_mesh.sub); i++) {
+		struct bt_mesh_subnet *sub = &bt_mesh.sub[i];
+
+		if (sub->net_idx == BT_MESH_KEY_UNUSED) {
+			continue;
+		}
+
+		if (sub->node_id == BT_MESH_NODE_IDENTITY_NOT_SUPPORTED) {
+			continue;
+		}
+
+		bt_mesh_proxy_identity_start(sub);
+		count++;
 	}
 
-	if (sub->node_id == BT_MESH_NODE_IDENTITY_NOT_SUPPORTED) {
-		return -ENOTSUP;
+	if (count) {
+		bt_mesh_adv_update();
 	}
-
-	if (sub->node_id == BT_MESH_NODE_IDENTITY_RUNNING) {
-		return 0;
-	}
-
-	bt_mesh_proxy_identity_start(sub);
-	bt_mesh_adv_update();
 
 	return 0;
 }

--- a/subsys/bluetooth/host/mesh/proxy.c
+++ b/subsys/bluetooth/host/mesh/proxy.c
@@ -337,6 +337,18 @@ void bt_mesh_proxy_beacon_send(struct bt_mesh_subnet *sub)
 	}
 }
 
+void bt_mesh_proxy_identity_start(struct bt_mesh_subnet *sub)
+{
+	sub->node_id = BT_MESH_NODE_IDENTITY_RUNNING;
+	sub->node_id_start = k_uptime_get_32();
+}
+
+void bt_mesh_proxy_identity_stop(struct bt_mesh_subnet *sub)
+{
+	sub->node_id = BT_MESH_NODE_IDENTITY_STOPPED;
+	sub->node_id_start = 0;
+}
+
 int bt_mesh_proxy_identity_enable(void)
 {
 	/* FIXME: Add support for multiple subnets */
@@ -360,8 +372,7 @@ int bt_mesh_proxy_identity_enable(void)
 		return 0;
 	}
 
-	sub->node_id = BT_MESH_NODE_IDENTITY_RUNNING;
-	sub->node_id_start = k_uptime_get_32();
+	bt_mesh_proxy_identity_start(sub);
 	bt_mesh_adv_update();
 
 	return 0;
@@ -1081,8 +1092,7 @@ static s32_t gatt_proxy_advertise(struct bt_mesh_subnet *sub)
 			       active, remaining);
 			node_id_adv(sub);
 		} else {
-			sub->node_id = BT_MESH_NODE_IDENTITY_STOPPED;
-			sub->node_id_start = 0;
+			bt_mesh_proxy_identity_stop(sub);
 			BT_DBG("Node ID stopped");
 		}
 	}

--- a/subsys/bluetooth/host/mesh/proxy.c
+++ b/subsys/bluetooth/host/mesh/proxy.c
@@ -113,6 +113,9 @@ static struct bt_mesh_proxy_client *find_client(struct bt_conn *conn)
 }
 
 #if defined(CONFIG_BT_MESH_GATT_PROXY)
+/* Next subnet in queue to be advertised */
+static int next_idx;
+
 static int proxy_segment_and_send(struct bt_conn *conn, u8_t type,
 				  struct net_buf_simple *msg);
 
@@ -341,6 +344,9 @@ void bt_mesh_proxy_identity_start(struct bt_mesh_subnet *sub)
 {
 	sub->node_id = BT_MESH_NODE_IDENTITY_RUNNING;
 	sub->node_id_start = k_uptime_get_32();
+
+	/* Prioritize the recently enabled subnet */
+	next_idx = sub - bt_mesh.sub;
 }
 
 void bt_mesh_proxy_identity_stop(struct bt_mesh_subnet *sub)
@@ -1041,7 +1047,6 @@ static bool advertise_subnet(struct bt_mesh_subnet *sub)
 
 static struct bt_mesh_subnet *next_sub(void)
 {
-	static int next_idx;
 	int i;
 
 	for (i = 0; i < ARRAY_SIZE(bt_mesh.sub); i++) {

--- a/subsys/bluetooth/host/mesh/proxy.h
+++ b/subsys/bluetooth/host/mesh/proxy.h
@@ -28,6 +28,9 @@ struct net_buf_simple *bt_mesh_proxy_get_buf(void);
 s32_t bt_mesh_proxy_adv_start(void);
 void bt_mesh_proxy_adv_stop(void);
 
+void bt_mesh_proxy_identity_start(struct bt_mesh_subnet *sub);
+void bt_mesh_proxy_identity_stop(struct bt_mesh_subnet *sub);
+
 bool bt_mesh_proxy_relay(struct net_buf_simple *buf, u16_t dst);
 void bt_mesh_proxy_addr_add(struct net_buf_simple *buf, u16_t addr);
 

--- a/subsys/bluetooth/host/mesh/shell.c
+++ b/subsys/bluetooth/host/mesh/shell.c
@@ -895,6 +895,44 @@ static int cmd_relay(int argc, char *argv[])
 	return 0;
 }
 
+static int cmd_net_key_add(int argc, char *argv[])
+{
+	u8_t key_val[16];
+	u16_t key_net_idx;
+	u8_t status;
+	int err;
+
+	if (argc < 2) {
+		return -EINVAL;
+	}
+
+	key_net_idx = strtoul(argv[1], NULL, 0);
+
+	if (argc > 2) {
+		size_t len;
+
+		len = hex2bin(argv[3], key_val, sizeof(key_val));
+		memset(key_val, 0, sizeof(key_val) - len);
+	} else {
+		memcpy(key_val, default_key, sizeof(key_val));
+	}
+
+	err = bt_mesh_cfg_net_key_add(net.net_idx, net.dst, key_net_idx,
+				      key_val, &status);
+	if (err) {
+		printk("Unable to send NetKey Add (err %d)\n", err);
+		return 0;
+	}
+
+	if (status) {
+		printk("NetKeyAdd failed with status 0x%02x\n", status);
+	} else {
+		printk("NetKey added with NetKey Index 0x%03x\n", key_net_idx);
+	}
+
+	return 0;
+}
+
 static int cmd_app_key_add(int argc, char *argv[])
 {
 	u8_t key_val[16];
@@ -1870,6 +1908,7 @@ static const struct shell_cmd mesh_commands[] = {
 	{ "friend", cmd_friend, "[val: off, on]" },
 	{ "gatt-proxy", cmd_gatt_proxy, "[val: off, on]" },
 	{ "relay", cmd_relay, "[val: off, on] [count: 0-7] [interval: 0-32]" },
+	{ "net-key-add", cmd_net_key_add, "<NetKeyIndex> [val]" },
 	{ "app-key-add", cmd_app_key_add, "<NetKeyIndex> <AppKeyIndex> [val]" },
 	{ "mod-app-bind", cmd_mod_app_bind,
 		"<addr> <AppIndex> <Model ID> [Company ID]" },


### PR DESCRIPTION
Until now the Mesh implementation hasn't satisfied the following requirements in the Mesh Profile Specification:

For Network Identity:

> When a server is a member of multiple subnets, it shall interleave the advertising of each subnet.

For Node Identity:

> When the server starts advertising as a result of user interaction, the server shall interleave the
advertising of each subnet it is a member of.

This PR aims to fix both of these scenarios. The extra patch for NetKey Add is so that the right behavior can conveniently be tested without needing an external tester.

Due to the fix being about specification conformance, I'd consider this for 1.10 inclusion.