### PR TITLE
cmake: Fail with an error message when empty libraries exist

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -369,6 +369,22 @@ get_property(ZEPHYR_LIBS_PROPERTY GLOBAL PROPERTY ZEPHYR_LIBS)
 foreach(zephyr_lib ${ZEPHYR_LIBS_PROPERTY})
   # TODO: Could this become an INTERFACE property of zephyr_interface?
   add_dependencies(${zephyr_lib} offsets_h)
+
+  # Verify that all libraries have source files. Libraries without
+  # source files are not supported because they are an indication that
+  # something has been misconfigured.
+  get_target_property(lib_sources ${zephyr_lib} SOURCES)
+  if(lib_sources STREQUAL lib_sources-NOTFOUND
+      AND (NOT (${zephyr_lib} STREQUAL app))
+      )
+    # app is not checked because it's sources are added to it after
+    # this CMakeLists.txt file has been processed
+    message(FATAL_ERROR "\
+The Zephyr library '${zephyr_lib}' was created without source files. \
+Empty libraries are not supported. \
+Either make sure that the library has the sources it should have, \
+or make sure it is not created when it has no source files.")
+  endif()
 endforeach()
 
 get_property(OUTPUT_FORMAT        GLOBAL PROPERTY PROPERTY_OUTPUT_FORMAT)


### PR DESCRIPTION
A very annoying usability issue is that the error message is very
cryptic when you create a zephyr library that doesn't have any source
files. Creating such a library is very easy to do, so we should have a
good error message for it.

It was also considered to allow empty libraries to exist, but this was
decided against as they show up in the build output and can confuse
the end user.

Signed-off-by: Sebastian Bøe <sebastian.boe@nordicsemi.no>