### PR TITLE
Add missing license and copyright headers

### DIFF
--- a/boards/arm/stm32l476g_disco/pinmux.c
+++ b/boards/arm/stm32l476g_disco/pinmux.c
@@ -1,3 +1,9 @@
+/*
+ * Copyright (c) 2017 Arthur Sfez
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 #include <kernel.h>
 #include <device.h>
 #include <init.h>

--- a/samples/basic/threads/src/main.c
+++ b/samples/basic/threads/src/main.c
@@ -1,3 +1,9 @@
+/*
+ * Copyright (c) 2017 Linaro Limited
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 #include <zephyr.h>
 #include <device.h>
 #include <gpio.h>

--- a/tests/net/socket/tcp/src/main.c
+++ b/tests/net/socket/tcp/src/main.c
@@ -1,3 +1,9 @@
+/*
+ * Copyright (c) 2017 Linaro Limited
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 #include <ztest_assert.h>
 #include <net/socket.h>
 


### PR DESCRIPTION
The following files didn't have any copyright or license headers on them
when they got contributed.  So add the SPDX Apache license and
appropriate copyright info:

boards/arm/stm32l476g_disco/pinmux.c
samples/basic/threads/src/main.c
tests/net/socket/tcp/src/main.c

Fixes #5266

Signed-off-by: Kumar Gala <kumar.gala@linaro.org>