### PR TITLE
net: Fix solicited-node multicast group handling for IPv6 address resolution

### DIFF
--- a/drivers/ethernet/Kconfig.mcux
+++ b/drivers/ethernet/Kconfig.mcux
@@ -17,10 +17,10 @@ menuconfig ETH_MCUX
 if ETH_MCUX
 config ETH_MCUX_PROMISCUOUS_MODE
 	bool "Enable promiscuous mode"
-	default n if !NET_IPV6
-	default y if NET_IPV6
+	default n
 	help
-	  Place the ethernet receiver in promiscuous mode.
+	  Place the Ethernet receiver in promiscuous mode. This may be useful
+	  for debugging and not needed for normal work.
 
 config ETH_MCUX_PHY_TICK_MS
 	int "PHY poll period (ms)"

--- a/drivers/ethernet/eth_mcux.c
+++ b/drivers/ethernet/eth_mcux.c
@@ -537,13 +537,6 @@ static int eth_0_init(struct device *dev)
 	enet_config.interrupt |= kENET_MiiInterrupt;
 
 #ifdef CONFIG_ETH_MCUX_PROMISCUOUS_MODE
-	/* FIXME: Workaround for lack of driver API support for multicast
-	 * management. So, instead we want to receive all multicast
-	 * frames "by default", or otherwise basic IPv6 features, like
-	 * address resolution, don't work. On Kinetis Ethernet controller,
-	 * that translates to enabling promiscuous mode. The real
-	 * fix depends on https://jira.zephyrproject.org/browse/ZEP-1673.
-	 */
 	enet_config.macSpecialConfig |= kENET_ControlPromiscuousEnable;
 #endif
 

--- a/tests/net/mld/src/main.c
+++ b/tests/net/mld/src/main.c
@@ -50,7 +50,7 @@ static bool is_leave_msg_ok;
 static bool is_query_received;
 static bool is_report_sent;
 static bool ignore_already;
-static struct k_sem wait_data;
+K_SEM_DEFINE(wait_data, 0, UINT_MAX);
 
 #define WAIT_TIME 500
 #define WAIT_TIME_LONG MSEC_PER_SEC
@@ -188,16 +188,14 @@ static void mld_setup(void)
 				      NET_ADDR_MANUAL, 0);
 
 	zassert_not_null(ifaddr, "Cannot add IPv6 address");
-
-	/* The semaphore is there to wait the data to be received. */
-	k_sem_init(&wait_data, 0, UINT_MAX);
 }
 
 static void join_group(void)
 {
 	int ret;
 
-	net_ipv6_addr_create(&mcast_addr, 0xff02, 0, 0, 0, 0, 0, 0, 0x0001);
+	/* Using adhoc multicast group outside standard range */
+	net_ipv6_addr_create(&mcast_addr, 0xff10, 0, 0, 0, 0, 0, 0, 0x0001);
 
 	ret = net_ipv6_mld_join(iface, &mcast_addr);
 
@@ -215,7 +213,7 @@ static void leave_group(void)
 {
 	int ret;
 
-	net_ipv6_addr_create(&mcast_addr, 0xff02, 0, 0, 0, 0, 0, 0, 0x0001);
+	net_ipv6_addr_create(&mcast_addr, 0xff10, 0, 0, 0, 0, 0, 0, 0x0001);
 
 	ret = net_ipv6_mld_leave(iface, &mcast_addr);
 


### PR DESCRIPTION
~~~

net: if: Join solicited-node multicast addr for each unicast addr  …
https://tools.ietf.org/html/rfc4862#section-5.4.2 :

"""
Before sending a Neighbor Solicitation, an interface MUST join the
all-nodes multicast address and the solicited-node multicast address
of the tentative address.
"""

So, joining should happen before sending DAD packets, and it should
happen for each unicast address added. This is achieved by joining
from net_if_ipv6_addr_add() call. Note that we already leave
solicited-node group from net_if_ipv6_addr_rm(). In particular, we
leave it if DAD fails (as that function is called in this case).

Fixes #5282.

Signed-off-by: Paul Sokolovsky <paul.sokolovsky@linaro.org>
~~~
