### PR TITLE
doc: add links to 1.10 docs and release notes

### DIFF
--- a/doc/index.rst
+++ b/doc/index.rst
@@ -21,10 +21,10 @@ Zephyr Project Documentation
    versions are available:
 
    `Zephyr 1.5.0`_ | `Zephyr 1.6.1`_ | `Zephyr 1.7.1`_ | `Zephyr 1.8.0`_ |
-   `Zephyr 1.9.2`_
+   `Zephyr 1.9.2`_ | `Zephyr 1.10.0`_
 
-For more information about previous releases, please consult the published
-:ref:`zephyr_release_notes`.
+For information about the changes and additions for releases, please
+consult the published :ref:`zephyr_release_notes` documentation.
 
 The Zephyr OS is provided under the `Apache 2.0 license`_ (as found in
 the LICENSE file in the project's `GitHub repo`_).  The Zephyr OS also
@@ -63,6 +63,7 @@ Indices and Tables
 
 * :ref:`genindex`
 
+.. _Zephyr 1.10.0: https://www.zephyrproject.org/doc/1.10.0/
 .. _Zephyr 1.9.2: https://www.zephyrproject.org/doc/1.9.0/
 .. _Zephyr 1.8.0: https://www.zephyrproject.org/doc/1.8.0/
 .. _Zephyr 1.7.1: https://www.zephyrproject.org/doc/1.7.0/

--- a/doc/release-notes.rst
+++ b/doc/release-notes.rst
@@ -9,19 +9,20 @@ Zephyr project is provided as source code and build scripts for different
 target architectures and configurations, and not as a binary image. Updated
 versions of the Zephyr project are released approximately every three-months.
 
-All Zephyr project source code is maintained in a GitHub repository; you can
-either download source as a tar.gz file (see the bottom of the GitHub release
-notes pages listed below), or use Git clone and checkout commands, such as:
+All Zephyr project source code is maintained in a `GitHub repository`_;
+you can either download source as a tar.gz file (see the bottom of the
+`GitHub tagged releases`_ page corresponding to each release), or use
+Git clone and checkout commands, such as:
 
 .. code-block:: shell
 
    git clone https://github.com/zephyrproject-rtos/zephyr
    cd zephyr
-   git checkout tags/v1.9.0
+   git checkout tags/v1.10.0
 
 
 The project's technical documentation is also tagged to correspond with a
-specific release and can be found at https://www.zephyrproject.org/doc/.
+specific release and can be found at https://docs.zephyrproject.org/.
 
 Zephyr Kernel Releases
 **********************
@@ -29,8 +30,12 @@ Zephyr Kernel Releases
 .. toctree::
    :maxdepth: 1
 
+   release-notes-1.10
    release-notes-1.9
    release-notes-1.8
    release-notes-1.7
    release-notes-1.6
    release-notes-1.5
+
+.. _`GitHub repository`: https://github.com/zephyrproject-rtos/zephyr
+.. _`GitHub tagged releases`: https://github.com/zephyrproject-rtos/zephyr/tags


### PR DESCRIPTION
Add link to the 1.10 technical docs to the available tech docs listed in
the documentation home page. Add the 1.10 release notes to the list of
available release notes in the release notes page.

Also update description of where to get Zephyr source code (downloadable
archives listed in the GitHub tagged releases page).

Signed-off-by: David B. Kinder <david.b.kinder@intel.com>