### PR TITLE
Sample/Test syntax changes and sanitycheck script cleanup

### DIFF
--- a/boards/arc/panther_ss/panther_ss.yaml
+++ b/boards/arc/panther_ss/panther_ss.yaml
@@ -7,6 +7,6 @@ flash: 152
 toolchain:
   - zephyr
 testing:
-        ignore_tags:
-          - net
-          - bluetooth
+  ignore_tags:
+    - net
+    - bluetooth

--- a/boards/nios2/qemu_nios2/qemu_nios2.yaml
+++ b/boards/nios2/qemu_nios2/qemu_nios2.yaml
@@ -5,7 +5,7 @@ arch: nios2
 toolchain:
   - zephyr
 testing:
-        default: true
-        ignore_tags:
-          - net
-          - bluetooth
+  default: true
+  ignore_tags:
+    - net
+    - bluetooth

--- a/boards/riscv32/qemu_riscv32/qemu_riscv32.yaml
+++ b/boards/riscv32/qemu_riscv32/qemu_riscv32.yaml
@@ -5,7 +5,7 @@ arch: riscv32
 toolchain:
   - zephyr
 testing:
-        default: true
-        ignore_tags:
-          - net
-          - bluetooth
+  default: true
+  ignore_tags:
+    - net
+    - bluetooth

--- a/boards/x86/quark_d2000_crb/quark_d2000_crb.yaml
+++ b/boards/x86/quark_d2000_crb/quark_d2000_crb.yaml
@@ -16,6 +16,6 @@ supported:
   - rtc
   - watchdog
 testing:
-        ignore_tags:
-          - net
-          - bluetooth
+  ignore_tags:
+     - net
+     - bluetooth

--- a/doc/subsystems/test/sanitycheck.rst
+++ b/doc/subsystems/test/sanitycheck.rst
@@ -253,17 +253,17 @@ explained in this document.
 ::
 
         tests:
-          - test:
-              build_only: true
-              platform_whitelist: qemu_cortex_m3 qemu_x86 arduino_101
-              tags: bluetooth
-          - test_br:
-              build_only: true
-              extra_args: CONF_FILE="prj_br.conf"
-              filter: not CONFIG_DEBUG
-              platform_exclude: quark_d2000_crb
-              platform_whitelist: qemu_cortex_m3 qemu_x86
-              tags: bluetooth
+          test:
+            build_only: true
+            platform_whitelist: qemu_cortex_m3 qemu_x86 arduino_101
+            tags: bluetooth
+          test_br:
+            build_only: true
+            extra_args: CONF_FILE="prj_br.conf"
+            filter: not CONFIG_DEBUG
+            platform_exclude: quark_d2000_crb
+            platform_whitelist: qemu_cortex_m3 qemu_x86
+            tags: bluetooth
 
 
 A sample with tests will have the same structure with additional information
@@ -276,16 +276,16 @@ related to the sample and what is being demonstrated:
           description: Hello World sample, the simplest Zephyr application
           platforms: all
         tests:
-          - test:
-              build_only: true
-              tags: samples tests
-              min_ram: 16
-          - singlethread:
-              build_only: true
-              extra_args: CONF_FILE=prj_single.conf
-              filter: not CONFIG_BT and not CONFIG_GPIO_SCH
-              tags: samples tests
-              min_ram: 16
+          test:
+            build_only: true
+            tags: samples tests
+            min_ram: 16
+          singlethread:
+            build_only: true
+            extra_args: CONF_FILE=prj_single.conf
+            filter: not CONFIG_BT and not CONFIG_GPIO_SCH
+            tags: samples tests
+            min_ram: 16
 
 The full canonical name for each test case is:
 
@@ -321,13 +321,13 @@ extra_configs: <list of extra configurations>
         common:
           tags: drivers adc
         tests:
-          - test:
-              depends_on: adc
-          - test_resolution_6:
-              extra_configs:
-                - CONFIG_ADC_QMSI_SAMPLE_WIDTH=6
-              platform_whitelist: quark_se_c1000_ss_devboard
-              tags: hwtest
+          test:
+            depends_on: adc
+          test_resolution_6:
+            extra_configs:
+              - CONFIG_ADC_QMSI_SAMPLE_WIDTH=6
+            platform_whitelist: quark_se_c1000_ss_devboard
+            tags: hwtest
 
 
 build_only: <True|False> (default False)

--- a/samples/application_development/external_lib/sample.yaml
+++ b/samples/application_development/external_lib/sample.yaml
@@ -2,7 +2,7 @@ sample:
   description: TBD
   name: TBD
 tests:
-  - test:
-      build_only: true
-      platform_whitelist: qemu_x86
-      tags: appdev
+  test:
+    build_only: true
+    platform_whitelist: qemu_x86
+    tags: appdev

--- a/samples/basic/blink_led/sample.yaml
+++ b/samples/basic/blink_led/sample.yaml
@@ -2,8 +2,8 @@ sample:
   description: TBD
   name: TBD
 tests:
-  - test:
-      build_only: true
-      platform_whitelist: arduino_101 quark_d2000_crb
+  test:
+    build_only: true
+    platform_whitelist: arduino_101 quark_d2000_crb
         nucleo_f103rb nucleo_f401re nucleo_l476rg stm32f4_disco hexiwear_k64
-      tags: apps
+    tags: apps

--- a/samples/basic/blinky/sample.yaml
+++ b/samples/basic/blinky/sample.yaml
@@ -2,7 +2,7 @@ sample:
   description: TBD
   name: TBD
 tests:
-  - test:
-      build_only: true
-      platform_whitelist: arduino_101
-      tags: samples
+  test:
+    build_only: true
+    platform_whitelist: arduino_101
+    tags: samples

--- a/samples/basic/button/sample.yaml
+++ b/samples/basic/button/sample.yaml
@@ -2,7 +2,7 @@ sample:
   description: TBD
   name: TBD
 tests:
-  - test:
-      build_only: true
-      platform_whitelist: nucleo_f103rb quark_se_c1000_devboard
-      tags: samples
+  test:
+    build_only: true
+    platform_whitelist: nucleo_f103rb quark_se_c1000_devboard
+    tags: samples

--- a/samples/basic/disco/sample.yaml
+++ b/samples/basic/disco/sample.yaml
@@ -2,7 +2,7 @@ sample:
   description: TBD
   name: TBD
 tests:
-  - test:
-      build_only: true
-      platform_whitelist: nucleo_f103rb nucleo_f401re
-      tags: samples
+  test:
+    build_only: true
+    platform_whitelist: nucleo_f103rb nucleo_f401re
+    tags: samples

--- a/samples/basic/fade_led/sample.yaml
+++ b/samples/basic/fade_led/sample.yaml
@@ -2,8 +2,8 @@ sample:
   description: TBD
   name: TBD
 tests:
-  - test:
-      build_only: true
-      platform_whitelist: arduino_101 quark_d2000_crb
+  test:
+    build_only: true
+    platform_whitelist: arduino_101 quark_d2000_crb
         nucleo_f103rb nucleo_f401re nucleo_l476rg hexiwear_k64
-      tags: apps
+    tags: apps

--- a/samples/basic/rgb_led/sample.yaml
+++ b/samples/basic/rgb_led/sample.yaml
@@ -2,7 +2,7 @@ sample:
   description: TBD
   name: TBD
 tests:
-  - test:
-      build_only: true
-      platform_whitelist: arduino_101 hexiwear_k64
-      tags: apps
+  test:
+    build_only: true
+    platform_whitelist: arduino_101 hexiwear_k64
+    tags: apps

--- a/samples/basic/servo_motor/sample.yaml
+++ b/samples/basic/servo_motor/sample.yaml
@@ -2,7 +2,7 @@ sample:
   description: TBD
   name: TBD
 tests:
-  - test:
-      build_only: true
-      platform_whitelist: arduino_101 quark_d2000_crb
-      tags: apps
+  test:
+    build_only: true
+    platform_whitelist: arduino_101 quark_d2000_crb
+    tags: apps

--- a/samples/basic/threads/sample.yaml
+++ b/samples/basic/threads/sample.yaml
@@ -1,8 +1,9 @@
 sample:
-  description: A basic demo to showcase multi-threading using K_THREAD_DEFINE
+  description: A basic demo to showcase multi-threading
+    using K_THREAD_DEFINE
   name: Basic Thread Demo
 tests:
-  - test:
-      build_only: true
-      platform_whitelist: 96b_carbon
-      tags: samples
+  test:
+    build_only: true
+    platform_whitelist: 96b_carbon
+    tags: samples

--- a/samples/bluetooth/beacon/sample.yaml
+++ b/samples/bluetooth/beacon/sample.yaml
@@ -2,7 +2,7 @@ sample:
   description: TBD
   name: TBD
 tests:
-  - test:
-      build_only: true
-      platform_whitelist: qemu_cortex_m3 qemu_x86 nrf52_pca10040
-      tags: bluetooth
+  test:
+    build_only: true
+    platform_whitelist: qemu_cortex_m3 qemu_x86 nrf52_pca10040
+    tags: bluetooth

--- a/samples/bluetooth/central/sample.yaml
+++ b/samples/bluetooth/central/sample.yaml
@@ -2,7 +2,7 @@ sample:
   description: TBD
   name: TBD
 tests:
-  - test:
-      build_only: true
-      platform_whitelist: qemu_cortex_m3 qemu_x86
-      tags: bluetooth
+  test:
+    build_only: true
+    platform_whitelist: qemu_cortex_m3 qemu_x86
+    tags: bluetooth

--- a/samples/bluetooth/central_hr/sample.yaml
+++ b/samples/bluetooth/central_hr/sample.yaml
@@ -2,7 +2,7 @@ sample:
   description: TBD
   name: TBD
 tests:
-  - test:
-      arch_whitelist: x86
-      build_only: true
-      tags: bluetooth
+  test:
+    arch_whitelist: x86
+    build_only: true
+    tags: bluetooth

--- a/samples/bluetooth/eddystone/sample.yaml
+++ b/samples/bluetooth/eddystone/sample.yaml
@@ -2,7 +2,7 @@ sample:
   description: TBD
   name: TBD
 tests:
-  - test:
-      build_only: true
-      platform_whitelist: qemu_cortex_m3 qemu_x86
-      tags: bluetooth
+  test:
+    build_only: true
+    platform_whitelist: qemu_cortex_m3 qemu_x86
+    tags: bluetooth

--- a/samples/bluetooth/handsfree/sample.yaml
+++ b/samples/bluetooth/handsfree/sample.yaml
@@ -2,7 +2,7 @@ sample:
   description: TBD
   name: TBD
 tests:
-  - test:
-      build_only: true
-      platform_whitelist: qemu_cortex_m3 qemu_x86
-      tags: bluetooth
+  test:
+    build_only: true
+    platform_whitelist: qemu_cortex_m3 qemu_x86
+    tags: bluetooth

--- a/samples/bluetooth/hci_spi/sample.yaml
+++ b/samples/bluetooth/hci_spi/sample.yaml
@@ -3,7 +3,7 @@ sample:
     via SPI.
   name: Bluetooth HCI SPI
 tests:
-  - test:
-      build_only: true
-      platform_whitelist: 96b_carbon_nrf51 nrf51_pca10028
-      tags: samples bluetooth spi
+  test:
+    build_only: true
+    platform_whitelist: 96b_carbon_nrf51 nrf51_pca10028
+    tags: samples bluetooth spi

--- a/samples/bluetooth/hci_uart/sample.yaml
+++ b/samples/bluetooth/hci_uart/sample.yaml
@@ -2,14 +2,14 @@ sample:
   description: TBD
   name: TBD
 tests:
-  - test_arm:
-      build_only: true
-      platform_whitelist: 96b_nitrogen nrf51_pca10028
-        nrf52_pca10040 bbc_microbit
-      tags: uart bluetooth
-  - test_nrf5:
-      build_only: true
-      extra_args: CONF_FILE="nrf5.conf"
-      platform_whitelist: 96b_nitrogen nrf51_pca10028
-        nrf52_pca10040 arduino_101_ble
-      tags: uart bluetooth
+  test_arm:
+    build_only: true
+    platform_whitelist: 96b_nitrogen nrf51_pca10028
+      nrf52_pca10040 bbc_microbit
+    tags: uart bluetooth
+  test_nrf5:
+    build_only: true
+    extra_args: CONF_FILE="nrf5.conf"
+    platform_whitelist: 96b_nitrogen nrf51_pca10028
+      nrf52_pca10040 arduino_101_ble
+    tags: uart bluetooth

--- a/samples/bluetooth/hci_usb/sample.yaml
+++ b/samples/bluetooth/hci_usb/sample.yaml
@@ -2,11 +2,11 @@ sample:
   description: TBD
   name: TBD
 tests:
-  - test_x86:
-      extra_configs:
-        - CONFIG_USB_DEVICE_VID=0xDEAD
-        - CONFIG_USB_DEVICE_PID=0xBEEF
-      build_only: true
-      depends_on: usb_device
-      platform_whitelist: quark_se_c1000_devboard
-      tags: usb bluetooth
+  test_x86:
+    build_only: true
+    depends_on: usb_device
+    extra_configs:
+      - CONFIG_USB_DEVICE_VID=0xDEAD
+      - CONFIG_USB_DEVICE_PID=0xBEEF
+    platform_whitelist: quark_se_c1000_devboard
+    tags: usb bluetooth

--- a/samples/bluetooth/ipsp/sample.yaml
+++ b/samples/bluetooth/ipsp/sample.yaml
@@ -2,12 +2,12 @@ sample:
   description: TBD
   name: TBD
 tests:
-  - test:
-      build_only: true
-      platform_whitelist: qemu_x86 qemu_cortex_m3
-      tags: bluetooth net
-  - test_zep1656:
-      build_only: true
-      extra_args: CONF_FILE="prj_zep1656.conf"
-      platform_whitelist: qemu_x86 qemu_cortex_m3
-      tags: bluetooth net
+  test:
+    build_only: true
+    platform_whitelist: qemu_x86 qemu_cortex_m3
+    tags: bluetooth net
+  test_zep1656:
+    build_only: true
+    extra_args: CONF_FILE="prj_zep1656.conf"
+    platform_whitelist: qemu_x86 qemu_cortex_m3
+    tags: bluetooth net

--- a/samples/bluetooth/mesh/sample.yaml
+++ b/samples/bluetooth/mesh/sample.yaml
@@ -1,8 +1,7 @@
 sample:
   name: Bluetooth Mesh
 tests:
-  - test:
-      build_only: true
-      platform_whitelist: bbc_microbit nrf51_blenano
-        qemu_x86
-      tags: bluetooth
+  test:
+    build_only: true
+    platform_whitelist: bbc_microbit nrf51_blenano qemu_x86
+    tags: bluetooth

--- a/samples/bluetooth/mesh_demo/sample.yaml
+++ b/samples/bluetooth/mesh_demo/sample.yaml
@@ -1,8 +1,7 @@
 sample:
   name: Bluetooth Mesh Demo
 tests:
-  - test:
-      build_only: true
-      platform_whitelist: bbc_microbit nrf51_blenano
-        qemu_x86
-      tags: bluetooth
+  test:
+    build_only: true
+    platform_whitelist: bbc_microbit nrf51_blenano qemu_x86
+    tags: bluetooth

--- a/samples/bluetooth/peripheral/sample.yaml
+++ b/samples/bluetooth/peripheral/sample.yaml
@@ -2,7 +2,7 @@ sample:
   description: TBD
   name: TBD
 tests:
-  - test:
-      build_only: true
-      platform_whitelist: qemu_cortex_m3 qemu_x86
-      tags: bluetooth
+  test:
+    build_only: true
+    platform_whitelist: qemu_cortex_m3 qemu_x86
+    tags: bluetooth

--- a/samples/bluetooth/peripheral_csc/sample.yaml
+++ b/samples/bluetooth/peripheral_csc/sample.yaml
@@ -2,7 +2,7 @@ sample:
   description: TBD
   name: TBD
 tests:
-  - test:
-      build_only: true
-      platform_whitelist: qemu_cortex_m3 qemu_x86
-      tags: bluetooth
+  test:
+    build_only: true
+    platform_whitelist: qemu_cortex_m3 qemu_x86
+    tags: bluetooth

--- a/samples/bluetooth/peripheral_dis/sample.yaml
+++ b/samples/bluetooth/peripheral_dis/sample.yaml
@@ -2,7 +2,7 @@ sample:
   description: TBD
   name: TBD
 tests:
-  - test:
-      build_only: true
-      platform_whitelist: qemu_cortex_m3 qemu_x86
-      tags: bluetooth
+  test:
+    build_only: true
+    platform_whitelist: qemu_cortex_m3 qemu_x86
+    tags: bluetooth

--- a/samples/bluetooth/peripheral_esp/sample.yaml
+++ b/samples/bluetooth/peripheral_esp/sample.yaml
@@ -2,7 +2,7 @@ sample:
   description: TBD
   name: TBD
 tests:
-  - test:
-      build_only: true
-      platform_whitelist: qemu_cortex_m3 qemu_x86
-      tags: bluetooth
+  test:
+    build_only: true
+    platform_whitelist: qemu_cortex_m3 qemu_x86
+    tags: bluetooth

--- a/samples/bluetooth/peripheral_hids/sample.yaml
+++ b/samples/bluetooth/peripheral_hids/sample.yaml
@@ -2,7 +2,7 @@ sample:
   description: TBD
   name: TBD
 tests:
-  - test:
-      build_only: true
-      platform_whitelist: qemu_cortex_m3 qemu_x86
-      tags: bluetooth
+  test:
+    build_only: true
+    platform_whitelist: qemu_cortex_m3 qemu_x86
+    tags: bluetooth

--- a/samples/bluetooth/peripheral_hr/sample.yaml
+++ b/samples/bluetooth/peripheral_hr/sample.yaml
@@ -2,7 +2,7 @@ sample:
   description: TBD
   name: TBD
 tests:
-  - test:
-      build_only: true
-      platform_whitelist: qemu_cortex_m3 qemu_x86
-      tags: bluetooth
+  test:
+    build_only: true
+    platform_whitelist: qemu_cortex_m3 qemu_x86
+    tags: bluetooth

--- a/samples/bluetooth/peripheral_sc_only/sample.yaml
+++ b/samples/bluetooth/peripheral_sc_only/sample.yaml
@@ -2,7 +2,7 @@ sample:
   description: TBD
   name: TBD
 tests:
-  - test:
-      build_only: true
-      platform_whitelist: qemu_cortex_m3 qemu_x86
-      tags: bluetooth
+  test:
+    build_only: true
+    platform_whitelist: qemu_cortex_m3 qemu_x86
+    tags: bluetooth

--- a/samples/bluetooth/scan_adv/sample.yaml
+++ b/samples/bluetooth/scan_adv/sample.yaml
@@ -2,7 +2,7 @@ sample:
   description: TBD
   name: TBD
 tests:
-  - test:
-      build_only: true
-      platform_whitelist: qemu_cortex_m3 qemu_x86
-      tags: bluetooth
+  test:
+    build_only: true
+    platform_whitelist: qemu_cortex_m3 qemu_x86
+    tags: bluetooth

--- a/samples/boards/arduino_101/environmental_sensing/ap/sample.yaml
+++ b/samples/boards/arduino_101/environmental_sensing/ap/sample.yaml
@@ -6,7 +6,7 @@ sample:
   name: Environmental Sensing (Application Processor
     Part)
 tests:
-  - test:
-      build_only: true
-      platform_whitelist: arduino_101
-      tags: samples
+  test:
+    build_only: true
+    platform_whitelist: arduino_101
+    tags: samples

--- a/samples/boards/arduino_101/environmental_sensing/sensor/sample.yaml
+++ b/samples/boards/arduino_101/environmental_sensing/sensor/sample.yaml
@@ -5,7 +5,7 @@ sample:
     '
   name: Environmental Sensing (Sensor Subsystem Part)
 tests:
-  - test:
-      build_only: true
-      platform_whitelist: arduino_101_sss
-      tags: samples sensor
+  test:
+    build_only: true
+    platform_whitelist: arduino_101_sss
+    tags: samples sensor

--- a/samples/boards/microbit/display/sample.yaml
+++ b/samples/boards/microbit/display/sample.yaml
@@ -2,7 +2,7 @@ sample:
   description: TBD
   name: TBD
 tests:
-  - test:
-      build_only: true
-      platform_whitelist: bbc_microbit
-      tags: samples
+  test:
+    build_only: true
+    platform_whitelist: bbc_microbit
+    tags: samples

--- a/samples/boards/microbit/pong/sample.yaml
+++ b/samples/boards/microbit/pong/sample.yaml
@@ -1,7 +1,7 @@
 sample:
   name: Pong game using BBC Micro:bit
 tests:
-  - test:
-      build_only: true
-      platform_whitelist: bbc_microbit
-      tags: samples
+  test:
+    build_only: true
+    platform_whitelist: bbc_microbit
+    tags: samples

--- a/samples/boards/microbit/sound/sample.yaml
+++ b/samples/boards/microbit/sound/sample.yaml
@@ -2,7 +2,7 @@ sample:
   description: TBD
   name: TBD
 tests:
-  - test:
-      build_only: true
-      platform_whitelist: bbc_microbit
-      tags: samples
+  test:
+    build_only: true
+    platform_whitelist: bbc_microbit
+    tags: samples

--- a/samples/boards/nrf52/power_mgr/sample.yaml
+++ b/samples/boards/nrf52/power_mgr/sample.yaml
@@ -1,8 +1,9 @@
 sample:
-    description: Low Power state Sample for nrf52
-    name: _nrf52-power-mgr-sample
+  description: Low Power state Sample for nrf52
+  name: _nrf52-power-mgr-sample
 tests:
--   test:
-        build_only: true
-        tags: nrf52 samples power
-        platform_whitelist: nrf52_vbluno52 nrf52840_pca10056 nrf52_pca10040
+  test:
+    build_only: true
+    platform_whitelist: nrf52_vbluno52 nrf52840_pca10056
+      nrf52_pca10040
+    tags: nrf52 samples power

--- a/samples/boards/quark_se_c1000/power_mgr/sample.yaml
+++ b/samples/boards/quark_se_c1000/power_mgr/sample.yaml
@@ -2,7 +2,7 @@ sample:
   description: TBD
   name: TBD
 tests:
-  - test:
-      build_only: true
-      filter: (CONFIG_SOC_QUARK_SE_C1000 or CONFIG_SOC_QUARK_SE_C1000_SS)
-      tags: samples power
+  test:
+    build_only: true
+    filter: (CONFIG_SOC_QUARK_SE_C1000 or CONFIG_SOC_QUARK_SE_C1000_SS)
+    tags: samples power

--- a/samples/cpp_synchronization/sample.yaml
+++ b/samples/cpp_synchronization/sample.yaml
@@ -2,7 +2,7 @@ sample:
   description: TBD
   name: TBD
 tests:
-  - test:
-      build_only: true
-      tags: apps
-      toolchain_exclude: issm
+  test:
+    build_only: true
+    tags: apps
+    toolchain_exclude: issm

--- a/samples/drivers/aio_comparator/sample.yaml
+++ b/samples/drivers/aio_comparator/sample.yaml
@@ -2,7 +2,7 @@ sample:
   description: TBD
   name: TBD
 tests:
-  - test:
-      build_only: true
-      platform_whitelist: arduino_101
-      tags: drivers
+  test:
+    build_only: true
+    platform_whitelist: arduino_101
+    tags: drivers

--- a/samples/drivers/crypto/sample.yaml
+++ b/samples/drivers/crypto/sample.yaml
@@ -1,13 +1,14 @@
 sample:
-  description: An example to illustrate the usage of crypto APIs
+  description: An example to illustrate the usage of
+    crypto APIs
   name: Crypto APIs
 tests:
-  - test-micro:
-      platform_whitelist: qemu_x86
-      build_only: true
-      tags: crypto
-  - test-mbedtls:
-      platform_whitelist: qemu_x86
-      build_only: true
-      extra_args: CONF_FILE=prj_mtls_shim.conf
-      tags: crypto
+  test-mbedtls:
+    build_only: true
+    extra_args: CONF_FILE=prj_mtls_shim.conf
+    platform_whitelist: qemu_x86
+    tags: crypto
+  test-micro:
+    build_only: true
+    platform_whitelist: qemu_x86
+    tags: crypto

--- a/samples/drivers/current_sensing/sample.yaml
+++ b/samples/drivers/current_sensing/sample.yaml
@@ -2,7 +2,7 @@ sample:
   description: TBD
   name: TBD
 tests:
-  - test:
-      build_only: true
-      platform_whitelist: arduino_101_sss quark_d2000_crb
-      tags: sensors
+  test:
+    build_only: true
+    platform_whitelist: arduino_101_sss quark_d2000_crb
+    tags: sensors

--- a/samples/drivers/entropy/sample.yaml
+++ b/samples/drivers/entropy/sample.yaml
@@ -2,6 +2,6 @@ sample:
   description: TBD
   name: TBD
 tests:
-  - test:
-      build_only: true
-      tags: samples
+  test:
+    build_only: true
+    tags: samples

--- a/samples/drivers/flash_shell/sample.yaml
+++ b/samples/drivers/flash_shell/sample.yaml
@@ -3,7 +3,7 @@ sample:
     behavior
   name: Flash shell
 tests:
-  - test:
-      build_only: true
-      platform_whitelist: 96b_carbon
-      tags: apps
+  test:
+    build_only: true
+    platform_whitelist: 96b_carbon
+    tags: apps

--- a/samples/drivers/gpio/sample.yaml
+++ b/samples/drivers/gpio/sample.yaml
@@ -2,8 +2,8 @@ sample:
   description: TBD
   name: TBD
 tests:
-  - test:
-      build_only: true
-      platform_whitelist: quark_se_c1000_devboard arduino_101
-        arduino_101_sss arduino_due
-      tags: drivers
+  test:
+    build_only: true
+    platform_whitelist: quark_se_c1000_devboard arduino_101
+      arduino_101_sss arduino_due
+    tags: drivers

--- a/samples/drivers/i2c_fujitsu_fram/sample.yaml
+++ b/samples/drivers/i2c_fujitsu_fram/sample.yaml
@@ -2,8 +2,8 @@ sample:
   description: TBD
   name: TBD
 tests:
-  - test:
-      build_only: true
-      platform_whitelist: arduino_101_sss quark_d2000_crb
-        arduino_due
-      tags: drivers
+  test:
+    build_only: true
+    platform_whitelist: arduino_101_sss quark_d2000_crb
+      arduino_due
+    tags: drivers

--- a/samples/drivers/lcd_hd44780/sample.yaml
+++ b/samples/drivers/lcd_hd44780/sample.yaml
@@ -2,7 +2,7 @@ sample:
   description: TBD
   name: TBD
 tests:
-  - test:
-      build_only: true
-      filter: CONFIG_SOC_ATMEL_SAM3
-      tags: samples
+  test:
+    build_only: true
+    filter: CONFIG_SOC_ATMEL_SAM3
+    tags: samples

--- a/samples/drivers/led_apa102c/sample.yaml
+++ b/samples/drivers/led_apa102c/sample.yaml
@@ -2,7 +2,7 @@ sample:
   description: TBD
   name: TBD
 tests:
-  - test:
-      build_only: true
-      platform_whitelist: arduino_101
-      tags: samples
+  test:
+    build_only: true
+    platform_whitelist: arduino_101
+    tags: samples

--- a/samples/drivers/led_lpd8806/sample.yaml
+++ b/samples/drivers/led_lpd8806/sample.yaml
@@ -3,7 +3,7 @@ sample:
   name: LPD880x sample
   platforms: all
 tests:
-  - test:
-      platform_whitelist: 96b_carbon
-      build_only: true
-      tags: samples
+  test:
+    build_only: true
+    platform_whitelist: 96b_carbon
+    tags: samples

--- a/samples/drivers/led_ws2812/sample.yaml
+++ b/samples/drivers/led_ws2812/sample.yaml
@@ -3,7 +3,7 @@ sample:
   name: WS2812 sample
   platforms: all
 tests:
-  - test:
-      platform_whitelist: 96b_carbon
-      build_only: true
-      tags: samples
+  test:
+    build_only: true
+    platform_whitelist: 96b_carbon
+    tags: samples

--- a/samples/drivers/rtc/sample.yaml
+++ b/samples/drivers/rtc/sample.yaml
@@ -2,8 +2,8 @@ sample:
   description: TBD
   name: TBD
 tests:
-  - test:
-      build_only: true
-      platform_whitelist: quark_d2000_crb quark_se_c1000_devboard
-        arduino_101
-      tags: drivers
+  test:
+    build_only: true
+    platform_whitelist: quark_d2000_crb quark_se_c1000_devboard
+      arduino_101
+    tags: drivers

--- a/samples/drivers/soc_flash_nrf5/sample.yaml
+++ b/samples/drivers/soc_flash_nrf5/sample.yaml
@@ -2,7 +2,7 @@ sample:
   description: TBD
   name: TBD
 tests:
-  - test:
-      build_only: true
-      platform_whitelist: nrf52_pca10040
-      tags: apps
+  test:
+    build_only: true
+    platform_whitelist: nrf52_pca10040
+    tags: apps

--- a/samples/drivers/spi_flash/sample.yaml
+++ b/samples/drivers/spi_flash/sample.yaml
@@ -2,7 +2,7 @@ sample:
   description: TBD
   name: TBD
 tests:
-  - test:
-      build_only: true
-      platform_whitelist: arduino_101
-      tags: apps
+  test:
+    build_only: true
+    platform_whitelist: arduino_101
+    tags: apps

--- a/samples/drivers/spi_fujitsu_fram/sample.yaml
+++ b/samples/drivers/spi_fujitsu_fram/sample.yaml
@@ -2,7 +2,7 @@ sample:
   description: TBD
   name: TBD
 tests:
-  - test:
-      build_only: true
-      platform_whitelist: arduino_101
-      tags: apps
+  test:
+    build_only: true
+    platform_whitelist: arduino_101
+    tags: apps

--- a/samples/drivers/watchdog/sample.yaml
+++ b/samples/drivers/watchdog/sample.yaml
@@ -2,8 +2,8 @@ sample:
   description: TBD
   name: TBD
 tests:
-  - test:
-      build_only: true
-      platform_whitelist: quark_d2000_crb quark_se_test_board
-        v2m_beetle nucleo_f334r8 96b_carbon
-      tags: drivers
+  test:
+    build_only: true
+    platform_whitelist: quark_d2000_crb quark_se_test_board
+      v2m_beetle nucleo_f334r8 96b_carbon
+    tags: drivers

--- a/samples/grove/lcd/sample.yaml
+++ b/samples/grove/lcd/sample.yaml
@@ -2,8 +2,8 @@ sample:
   description: TBD
   name: TBD
 tests:
-  - test:
-      build_only: true
-      platform_whitelist: arduino_101_sss quark_d2000_crb
-        arduino_due
-      tags: drivers
+  test:
+    build_only: true
+    platform_whitelist: arduino_101_sss quark_d2000_crb
+      arduino_due
+    tags: drivers

--- a/samples/grove/light/sample.yaml
+++ b/samples/grove/light/sample.yaml
@@ -2,8 +2,8 @@ sample:
   description: TBD
   name: TBD
 tests:
-  - test:
-      build_only: true
-      platform_whitelist: arduino_101_sss quark_d2000_crb
-        arduino_due
-      tags: drivers
+  test:
+    build_only: true
+    platform_whitelist: arduino_101_sss quark_d2000_crb
+      arduino_due
+    tags: drivers

--- a/samples/grove/temperature/sample.yaml
+++ b/samples/grove/temperature/sample.yaml
@@ -2,9 +2,9 @@ sample:
   description: TBD
   name: TBD
 tests:
-  - test:
-      build_only: true
-      min_flash: 33
-      platform_whitelist: arduino_101_sss quark_d2000_crb
-        arduino_due
-      tags: drivers
+  test:
+    build_only: true
+    min_flash: 33
+    platform_whitelist: arduino_101_sss quark_d2000_crb
+      arduino_due
+    tags: drivers

--- a/samples/hello_world/sample.yaml
+++ b/samples/hello_world/sample.yaml
@@ -4,11 +4,11 @@ sample:
   name: hello world
   platforms: all
 tests:
-  - test:
-      build_only: true
-      tags: samples tests
-  - singlethread:
-      build_only: true
-      extra_args: CONF_FILE=prj_single.conf
-      filter: not CONFIG_BT and not CONFIG_GPIO_SCH
-      tags: samples tests
+  singlethread:
+    build_only: true
+    extra_args: CONF_FILE=prj_single.conf
+    filter: not CONFIG_BT and not CONFIG_GPIO_SCH
+    tags: samples tests
+  test:
+    build_only: true
+    tags: samples tests

--- a/samples/mpu/mem_domain_apis_test/sample.yaml
+++ b/samples/mpu/mem_domain_apis_test/sample.yaml
@@ -2,7 +2,7 @@ sample:
   description: TBD
   name: TBD
 tests:
-  - test:
-      build_only: true
-      tags: samples
-      filter: CONFIG_ARCH_HAS_USERSPACE
+  test:
+    build_only: true
+    filter: CONFIG_ARCH_HAS_USERSPACE
+    tags: samples

--- a/samples/mpu/mpu_stack_guard_test/sample.yaml
+++ b/samples/mpu/mpu_stack_guard_test/sample.yaml
@@ -2,12 +2,12 @@ sample:
   description: TBD
   name: TBD
 tests:
-  - test:
-      build_only: true
-      tags: apps
-  - test_stack_guard:
-      arch_whitelist: arm
-      build_only: true
-      extra_args: CONF_FILE=prj_stack_guard.conf
-      filter: CONFIG_MPU_STACK_GUARD
-      tags: apps
+  test:
+    build_only: true
+    tags: apps
+  test_stack_guard:
+    arch_whitelist: arm
+    build_only: true
+    extra_args: CONF_FILE=prj_stack_guard.conf
+    filter: CONFIG_MPU_STACK_GUARD
+    tags: apps

--- a/samples/mpu/mpu_test/sample.yaml
+++ b/samples/mpu/mpu_test/sample.yaml
@@ -2,8 +2,8 @@ sample:
   description: TBD
   name: TBD
 tests:
-  - test:
-      arch_whitelist: arm
-      build_only: true
-      filter: CONFIG_CPU_HAS_MPU
-      tags: samples
+  test:
+    arch_whitelist: arm
+    build_only: true
+    filter: CONFIG_CPU_HAS_MPU
+    tags: samples

--- a/samples/net/coap_client/sample.yaml
+++ b/samples/net/coap_client/sample.yaml
@@ -2,13 +2,13 @@ sample:
   description: TBD
   name: TBD
 tests:
-  - test:
-      build_only: true
-      platform_whitelist: quark_se_c1000_devboard galileo
-        frdm_k64f
-      tags: net
-  - test_bt:
-      build_only: true
-      extra_args: CONF_FILE="prj_bt.conf"
-      platform_whitelist: qemu_x86
-      tags: net bluetooth
+  test:
+    build_only: true
+    platform_whitelist: quark_se_c1000_devboard galileo
+      frdm_k64f
+    tags: net
+  test_bt:
+    build_only: true
+    extra_args: CONF_FILE="prj_bt.conf"
+    platform_whitelist: qemu_x86
+    tags: net bluetooth

--- a/samples/net/coap_server/sample.yaml
+++ b/samples/net/coap_server/sample.yaml
@@ -2,17 +2,17 @@ sample:
   description: TBD
   name: TBD
 tests:
-  - test:
-      arch_whitelist: x86
-      build_only: true
-      tags: net
-  - test_bt:
-      build_only: true
-      extra_args: CONF_FILE="prj_bt.conf"
-      platform_whitelist: qemu_x86
-      tags: net bluetooth
-  - test_net:
-      build_only: true
-      extra_args: CONF_FILE="prj_cc2520.conf"
-      platform_whitelist: quark_se_c1000_devboard
-      tags: net
+  test:
+    arch_whitelist: x86
+    build_only: true
+    tags: net
+  test_bt:
+    build_only: true
+    extra_args: CONF_FILE="prj_bt.conf"
+    platform_whitelist: qemu_x86
+    tags: net bluetooth
+  test_net:
+    build_only: true
+    extra_args: CONF_FILE="prj_cc2520.conf"
+    platform_whitelist: quark_se_c1000_devboard
+    tags: net

--- a/samples/net/coaps_client/sample.yaml
+++ b/samples/net/coaps_client/sample.yaml
@@ -1,7 +1,7 @@
 sample:
   name: COAP Client with DTLS
 tests:
-  - test:
-      build_only: true
-      depends_on: netif
-      tags: net coap dtls
+  test:
+    build_only: true
+    depends_on: netif
+    tags: net coap dtls

--- a/samples/net/coaps_server/sample.yaml
+++ b/samples/net/coaps_server/sample.yaml
@@ -1,7 +1,7 @@
 sample:
   name: COAP Server with DTLS
 tests:
-  - test:
-      build_only: true
-      depends_on: netif
-      tags: net coap
+  test:
+    build_only: true
+    depends_on: netif
+    tags: net coap

--- a/samples/net/dhcpv4_client/sample.yaml
+++ b/samples/net/dhcpv4_client/sample.yaml
@@ -1,7 +1,7 @@
 sample:
   name: DHCP Client
 tests:
-  - test:
-      build_only: true
-      depends_on: netif
-      tags: net http
+  test:
+    build_only: true
+    depends_on: netif
+    tags: net http

--- a/samples/net/dns_resolve/sample.yaml
+++ b/samples/net/dns_resolve/sample.yaml
@@ -2,7 +2,7 @@ sample:
   description: TBD
   name: DNS Resolver
 tests:
-  - test:
-      build_only: true
-      depends_on: netif
-      tags: net dns
+  test:
+    build_only: true
+    depends_on: netif
+    tags: net dns

--- a/samples/net/echo_client/sample.yaml
+++ b/samples/net/echo_client/sample.yaml
@@ -1,19 +1,21 @@
-sample:
-  description: Test core network features using a client/server sample
-  name: Echo Client
 common:
-  tags: net
   build_only: true
+  tags: net
+sample:
+  description: Test core network features using a client/server
+    sample
+  name: Echo Client
 tests:
-  - test:
-      platform_whitelist: qemu_x86 frdm_k64f sam_e70_xplained qemu_cortex_m3 arduino_101
-  - test_802154:
-      extra_args: CONF_FILE="prj_qemu_802154.conf"
-      platform_whitelist: qemu_x86
-  - test_bt:
-      extra_args: CONF_FILE="prj_bt.conf"
-      platform_whitelist: qemu_x86
-      tags: bluetooth
-  - test_cc2520:
-      extra_args: CONF_FILE="prj_frdm_k64f_cc2520.conf"
-      platform_whitelist: frdm_k64f
+  test:
+    platform_whitelist: qemu_x86 frdm_k64f sam_e70_xplained
+      qemu_cortex_m3 arduino_101
+  test_802154:
+    extra_args: CONF_FILE="prj_qemu_802154.conf"
+    platform_whitelist: qemu_x86
+  test_bt:
+    extra_args: CONF_FILE="prj_bt.conf"
+    platform_whitelist: qemu_x86
+    tags: bluetooth
+  test_cc2520:
+    extra_args: CONF_FILE="prj_frdm_k64f_cc2520.conf"
+    platform_whitelist: frdm_k64f

--- a/samples/net/echo_server/sample.yaml
+++ b/samples/net/echo_server/sample.yaml
@@ -1,39 +1,41 @@
-sample:
-  name: Echo Server
-  description: Test core network features using a client/server sample
 common:
-  tags: net
   build_only: true
+  tags: net
+sample:
+  description: Test core network features using a client/server
+    sample
+  name: Echo Server
 tests:
-  - test:
-      platform_whitelist: qemu_x86 sam_e70_xplained frdm_k64f qemu_cortex_m3 arduino_101
-  - test_802154:
-      extra_args: CONF_FILE="prj_qemu_802154.conf"
-      platform_whitelist: qemu_x86
-  - test_mcr20a:
-      extra_args: CONF_FILE="prj_frdm_k64f_mcr20a.conf"
-      platform_whitelist: frdm_k64f
-  - test_nrf:
-      extra_args: CONF_FILE="prj_nrf5.conf"
-      platform_whitelist: nrf52840_pca10056
-  - test_bt:
-      extra_args: CONF_FILE="prj_bt.conf"
-      platform_whitelist: qemu_x86
-      tags: bluetooth
-  - test_usbnet:
-      build_only: true
-      extra_args: CONF_FILE="prj_netusb.conf"
-      extra_configs:
-        - CONFIG_USB_DEVICE_VID=0xDEAD
-        - CONFIG_USB_DEVICE_PID=0xBEEF
-      platform_whitelist: quark_se_c1000_devboard 96b_carbon
-      tags: net usb
-  - test_usbnet_composite:
-      build_only: true
-      extra_args: CONF_FILE="prj_netusb.conf"
-      extra_configs:
-        - CONFIG_USB_COMPOSITE_DEVICE=y
-        - CONFIG_USB_DEVICE_VID=0xDEAD
-        - CONFIG_USB_DEVICE_PID=0xBEEF
-      platform_whitelist: quark_se_c1000_devboard 96b_carbon
-      tags: net usb
+  test:
+    platform_whitelist: qemu_x86 sam_e70_xplained frdm_k64f
+      qemu_cortex_m3 arduino_101
+  test_802154:
+    extra_args: CONF_FILE="prj_qemu_802154.conf"
+    platform_whitelist: qemu_x86
+  test_bt:
+    extra_args: CONF_FILE="prj_bt.conf"
+    platform_whitelist: qemu_x86
+    tags: bluetooth
+  test_mcr20a:
+    extra_args: CONF_FILE="prj_frdm_k64f_mcr20a.conf"
+    platform_whitelist: frdm_k64f
+  test_nrf:
+    extra_args: CONF_FILE="prj_nrf5.conf"
+    platform_whitelist: nrf52840_pca10056
+  test_usbnet:
+    build_only: true
+    extra_args: CONF_FILE="prj_netusb.conf"
+    extra_configs:
+      - CONFIG_USB_DEVICE_VID=0xDEAD
+      - CONFIG_USB_DEVICE_PID=0xBEEF
+    platform_whitelist: quark_se_c1000_devboard 96b_carbon
+    tags: net usb
+  test_usbnet_composite:
+    build_only: true
+    extra_args: CONF_FILE="prj_netusb.conf"
+    extra_configs:
+      - CONFIG_USB_COMPOSITE_DEVICE=y
+      - CONFIG_USB_DEVICE_VID=0xDEAD
+      - CONFIG_USB_DEVICE_PID=0xBEEF
+    platform_whitelist: quark_se_c1000_devboard 96b_carbon
+    tags: net usb

--- a/samples/net/http_client/sample.yaml
+++ b/samples/net/http_client/sample.yaml
@@ -1,12 +1,12 @@
 sample:
   name: HTTP Client
 tests:
-  - test:
-      build_only: true
-      depends_on: netif
-      tags: net http
-  - test_bt:
-      build_only: true
-      extra_args: CONF_FILE="prj_bt.conf"
-      platform_whitelist: qemu_x86 qemu_cortex_m3
-      tags: net http
+  test:
+    build_only: true
+    depends_on: netif
+    tags: net http
+  test_bt:
+    build_only: true
+    extra_args: CONF_FILE="prj_bt.conf"
+    platform_whitelist: qemu_x86 qemu_cortex_m3
+    tags: net http

--- a/samples/net/http_server/sample.yaml
+++ b/samples/net/http_server/sample.yaml
@@ -1,20 +1,20 @@
 sample:
   name: HTTP Server
 tests:
-  - test:
-      build_only: true
-      depends_on: netif
-      tags: net http
-  - test_bt:
-      build_only: true
-      extra_args: CONF_FILE="prj_bt.conf"
-      platform_whitelist: qemu_x86
-      tags: net http
-  - test_usbnet:
-      build_only: true
-      extra_args: CONF_FILE="prj_netusb.conf"
-      extra_configs:
-        - CONFIG_USB_DEVICE_VID=0xDEAD
-        - CONFIG_USB_DEVICE_PID=0xBEEF
-      platform_whitelist: quark_se_c1000_devboard
-      tags: net usb
+  test:
+    build_only: true
+    depends_on: netif
+    tags: net http
+  test_bt:
+    build_only: true
+    extra_args: CONF_FILE="prj_bt.conf"
+    platform_whitelist: qemu_x86
+    tags: net http
+  test_usbnet:
+    build_only: true
+    extra_args: CONF_FILE="prj_netusb.conf"
+    extra_configs:
+      - CONFIG_USB_DEVICE_VID=0xDEAD
+      - CONFIG_USB_DEVICE_PID=0xBEEF
+    platform_whitelist: quark_se_c1000_devboard
+    tags: net usb

--- a/samples/net/irc_bot/sample.yaml
+++ b/samples/net/irc_bot/sample.yaml
@@ -1,7 +1,7 @@
 sample:
   name: IRC Bot
 tests:
-  - test:
-      build_only: true
-      depends_on: netif
-      tags: net irc
+  test:
+    build_only: true
+    depends_on: netif
+    tags: net irc

--- a/samples/net/leds_demo/sample.yaml
+++ b/samples/net/leds_demo/sample.yaml
@@ -2,7 +2,7 @@ sample:
   description: TBD
   name: TBD
 tests:
-  - test:
-      arch_whitelist: x86
-      build_only: true
-      tags: net coap
+  test:
+    arch_whitelist: x86
+    build_only: true
+    tags: net coap

--- a/samples/net/lwm2m_client/sample.yaml
+++ b/samples/net/lwm2m_client/sample.yaml
@@ -2,7 +2,7 @@ sample:
   description: TBD
   name: TBD
 tests:
-  - test:
-      build_only: true
-      platform_whitelist: qemu_x86
-      tags: net lwm2m
+  test:
+    build_only: true
+    platform_whitelist: qemu_x86
+    tags: net lwm2m

--- a/samples/net/mbedtls_dtlsclient/sample.yaml
+++ b/samples/net/mbedtls_dtlsclient/sample.yaml
@@ -1,7 +1,7 @@
 sample:
   name: mBED DTLS Client
 tests:
-  - test:
-      build_only: true
-      depends_on: netif
-      tags: net
+  test:
+    build_only: true
+    depends_on: netif
+    tags: net

--- a/samples/net/mbedtls_dtlsserver/sample.yaml
+++ b/samples/net/mbedtls_dtlsserver/sample.yaml
@@ -1,7 +1,7 @@
 sample:
   name: DTLS Server
 tests:
-  - test:
-      build_only: true
-      depends_on: netif
-      tags: net
+  test:
+    build_only: true
+    depends_on: netif
+    tags: net

--- a/samples/net/mbedtls_sslclient/sample.yaml
+++ b/samples/net/mbedtls_sslclient/sample.yaml
@@ -2,7 +2,7 @@ sample:
   description: TBD
   name: TBD
 tests:
-  - test:
-      build_only: true
-      platform_whitelist: galileo
-      tags: net
+  test:
+    build_only: true
+    platform_whitelist: galileo
+    tags: net

--- a/samples/net/mdns_responder/sample.yaml
+++ b/samples/net/mdns_responder/sample.yaml
@@ -1,7 +1,7 @@
 sample:
-    name: mDNS responder
+  name: mDNS responder
 tests:
--   test:
-        build_only: true
-        platform_whitelist: qemu_x86 qemu_cortex_m3
-        tags: net mdns
+  test:
+    build_only: true
+    platform_whitelist: qemu_x86 qemu_cortex_m3
+    tags: net mdns

--- a/samples/net/mqtt_publisher/sample.yaml
+++ b/samples/net/mqtt_publisher/sample.yaml
@@ -2,11 +2,11 @@ sample:
   description: TBD
   name: TBD
 tests:
-  - test:
-      build_only: true
-      platform_whitelist: frdm_k64f qemu_x86
-      tags: net mqtt
-  - test_bt:
-      build_only: true
-      platform_whitelist: 96b_nitrogen
-      tags: net mqtt bluetooth
+  test:
+    build_only: true
+    platform_whitelist: frdm_k64f qemu_x86
+    tags: net mqtt
+  test_bt:
+    build_only: true
+    platform_whitelist: 96b_nitrogen
+    tags: net mqtt bluetooth

--- a/samples/net/nats/sample.yaml
+++ b/samples/net/nats/sample.yaml
@@ -1,7 +1,7 @@
 sample:
   name: NATS Client
 tests:
-  - test:
-      build_only: true
-      depends_on: netif
-      tags: net nats
+  test:
+    build_only: true
+    depends_on: netif
+    tags: net nats

--- a/samples/net/rpl-node/sample.yaml
+++ b/samples/net/rpl-node/sample.yaml
@@ -1,12 +1,13 @@
-sample:
-  name: RPL node demo application
-  description: Can be used to test RPL network. Needs to be run in real device.
-    This cannot be run in QEMU.
 common:
-  tags: net rpl ieee802154
-  depends_on: ieee802154
   build_only: true
+  depends_on: ieee802154
+  tags: net rpl ieee802154
+sample:
+  description: Can be used to test RPL network. Needs
+    to be run in real device. This cannot be run in
+    QEMU.
+  name: RPL node demo application
 tests:
-  - test_quark_se_c1000_devboard:
-      platform_whitelist: quark_se_c1000_devboard
-      extra_args: CONF_FILE="prj_quark_se_c1000_devboard.conf"
+  test_quark_se_c1000_devboard:
+    extra_args: CONF_FILE="prj_quark_se_c1000_devboard.conf"
+    platform_whitelist: quark_se_c1000_devboard

--- a/samples/net/sntp_client/sample.yaml
+++ b/samples/net/sntp_client/sample.yaml
@@ -2,7 +2,7 @@ sample:
   description: SNTP client sample
   name: sntp_client
 tests:
-  - test:
-      build_only: true
-      platform_whitelist: qemu_x86
-      tags: net
+  test:
+    build_only: true
+    platform_whitelist: qemu_x86
+    tags: net

--- a/samples/net/sockets/dumb_http_server/sample.yaml
+++ b/samples/net/sockets/dumb_http_server/sample.yaml
@@ -2,7 +2,7 @@ sample:
   description: BSD Sockets API dumb HTTP server example
   name: socket_dumb_http_server
 tests:
-  - test:
-      build_only: true
-      min_ram: 32
-      tags: net
+  test:
+    build_only: true
+    min_ram: 32
+    tags: net

--- a/samples/net/sockets/echo/sample.yaml
+++ b/samples/net/sockets/echo/sample.yaml
@@ -2,7 +2,7 @@ sample:
   description: BSD Sockets API TCP echo server sample
   name: socket_echo
 tests:
-  - test:
-      build_only: true
-      platform_whitelist: qemu_x86
-      tags: net
+  test:
+    build_only: true
+    platform_whitelist: qemu_x86
+    tags: net

--- a/samples/net/sockets/echo_async/sample.yaml
+++ b/samples/net/sockets/echo_async/sample.yaml
@@ -3,7 +3,7 @@ sample:
     using non-blocking sockets
   name: socket_echo_async
 tests:
-  - test:
-      build_only: true
-      platform_whitelist: qemu_x86
-      tags: net
+  test:
+    build_only: true
+    platform_whitelist: qemu_x86
+    tags: net

--- a/samples/net/sockets/http_get/sample.yaml
+++ b/samples/net/sockets/http_get/sample.yaml
@@ -2,7 +2,7 @@ sample:
   description: BSD Sockets API HTTP GET example
   name: socket_http_get
 tests:
-  - test:
-      build_only: true
-      min_ram: 32
-      tags: net
+  test:
+    build_only: true
+    min_ram: 32
+    tags: net

--- a/samples/net/telnet/sample.yaml
+++ b/samples/net/telnet/sample.yaml
@@ -1,7 +1,7 @@
 sample:
   name: Telnet Server
 tests:
-  - test:
-      build_only: true
-      depends_on: netif
-      tags: net telnet
+  test:
+    build_only: true
+    depends_on: netif
+    tags: net telnet

--- a/samples/net/wpan_serial/sample.yaml
+++ b/samples/net/wpan_serial/sample.yaml
@@ -2,11 +2,11 @@ sample:
   description: TBD
   name: TBD
 tests:
-  - test_x86:
-      extra_configs:
-        - CONFIG_USB_DEVICE_VID=0xDEAD
-        - CONFIG_USB_DEVICE_PID=0xBEEF
-      build_only: true
-      depends_on: usb_device
-      platform_whitelist: quark_se_c1000_devboard
-      tags: usb
+  test_x86:
+    build_only: true
+    depends_on: usb_device
+    extra_configs:
+      - CONFIG_USB_DEVICE_VID=0xDEAD
+      - CONFIG_USB_DEVICE_PID=0xBEEF
+    platform_whitelist: quark_se_c1000_devboard
+    tags: usb

--- a/samples/net/wpanusb/sample.yaml
+++ b/samples/net/wpanusb/sample.yaml
@@ -2,10 +2,10 @@ sample:
   description: TBD
   name: TBD
 tests:
-  - test_15_4:
-      build_only: true
-      extra_configs:
-        - CONFIG_USB_DEVICE_VID=0xDEAD
-        - CONFIG_USB_DEVICE_PID=0xBEEF
-      depends_on: ieee802154 usb_device
-      tags: net ieee802154 usb
+  test_15_4:
+    build_only: true
+    depends_on: ieee802154 usb_device
+    extra_configs:
+      - CONFIG_USB_DEVICE_VID=0xDEAD
+      - CONFIG_USB_DEVICE_PID=0xBEEF
+    tags: net ieee802154 usb

--- a/samples/net/zperf/sample.yaml
+++ b/samples/net/zperf/sample.yaml
@@ -2,15 +2,15 @@ sample:
   description: TBD
   name: TBD
 tests:
-  - test:
-      build_only: true
-      platform_whitelist: qemu_x86
-      tags: samples net
-  - test_netusb:
-      build_only: true
-      extra_args: CONF_FILE="prj_netusb.conf"
-      extra_configs:
-        - CONFIG_USB_DEVICE_VID=0xDEAD
-        - CONFIG_USB_DEVICE_PID=0xBEEF
-      platform_whitelist: quark_se_c1000_devboard 96b_carbon
-      tags: samples usb net
+  test:
+    build_only: true
+    platform_whitelist: qemu_x86
+    tags: samples net
+  test_netusb:
+    build_only: true
+    extra_args: CONF_FILE="prj_netusb.conf"
+    extra_configs:
+      - CONFIG_USB_DEVICE_VID=0xDEAD
+      - CONFIG_USB_DEVICE_PID=0xBEEF
+    platform_whitelist: quark_se_c1000_devboard 96b_carbon
+    tags: samples usb net

--- a/samples/nfc/nfc_hello/sample.yaml
+++ b/samples/nfc/nfc_hello/sample.yaml
@@ -2,8 +2,8 @@ sample:
   description: TBD
   name: TBD
 tests:
-  - test:
-      arch_whitelist: x86 arm
-      build_only: true
-      filter: CONFIG_SERIAL_SUPPORT_INTERRUPT
-      tags: apps
+  test:
+    arch_whitelist: x86 arm
+    build_only: true
+    filter: CONFIG_SERIAL_SUPPORT_INTERRUPT
+    tags: apps

--- a/samples/philosophers/sample.yaml
+++ b/samples/philosophers/sample.yaml
@@ -2,6 +2,6 @@ sample:
   description: TBD
   name: TBD
 tests:
-  - test:
-      build_only: true
-      tags: apps
+  test:
+    build_only: true
+    tags: apps

--- a/samples/sensor/apds9960/sample.yaml
+++ b/samples/sensor/apds9960/sample.yaml
@@ -2,7 +2,7 @@ sample:
   description: TBD
   name: TBD
 tests:
-  - test:
-      build_only: true
-      platform_whitelist: arduino_101_sss
-      tags: samples
+  test:
+    build_only: true
+    platform_whitelist: arduino_101_sss
+    tags: samples

--- a/samples/sensor/bme280/sample.yaml
+++ b/samples/sensor/bme280/sample.yaml
@@ -2,7 +2,7 @@ sample:
   description: TBD
   name: TBD
 tests:
-  - test:
-      build_only: true
-      platform_whitelist: frdm_k64f quark_d2000_crb
-      tags: samples sensor
+  test:
+    build_only: true
+    platform_whitelist: frdm_k64f quark_d2000_crb
+    tags: samples sensor

--- a/samples/sensor/bmg160/sample.yaml
+++ b/samples/sensor/bmg160/sample.yaml
@@ -2,7 +2,7 @@ sample:
   description: TBD
   name: TBD
 tests:
-  - test:
-      build_only: true
-      platform_whitelist: arduino_101_sss
-      tags: sensors
+  test:
+    build_only: true
+    platform_whitelist: arduino_101_sss
+    tags: sensors

--- a/samples/sensor/bmi160/sample.yaml
+++ b/samples/sensor/bmi160/sample.yaml
@@ -2,7 +2,7 @@ sample:
   description: TBD
   name: TBD
 tests:
-  - test:
-      build_only: true
-      platform_whitelist: arduino_101_sss
-      tags: sensors
+  test:
+    build_only: true
+    platform_whitelist: arduino_101_sss
+    tags: sensors

--- a/samples/sensor/bmm150/sample.yaml
+++ b/samples/sensor/bmm150/sample.yaml
@@ -2,7 +2,7 @@ sample:
   description: TBD
   name: TBD
 tests:
-  - test:
-      build_only: true
-      platform_whitelist: arduino_101
-      tags: samples sensor
+  test:
+    build_only: true
+    platform_whitelist: arduino_101
+    tags: samples sensor

--- a/samples/sensor/fxas21002/sample.yaml
+++ b/samples/sensor/fxas21002/sample.yaml
@@ -2,7 +2,7 @@ sample:
   description: TBD
   name: TBD
 tests:
-  - test:
-      build_only: true
-      platform_whitelist: hexiwear_k64
-      tags: samples sensor
+  test:
+    build_only: true
+    platform_whitelist: hexiwear_k64
+    tags: samples sensor

--- a/samples/sensor/fxos8700/sample.yaml
+++ b/samples/sensor/fxos8700/sample.yaml
@@ -2,7 +2,7 @@ sample:
   description: TBD
   name: TBD
 tests:
-  - test:
-      build_only: true
-      platform_whitelist: frdm_k64f hexiwear_k64
-      tags: samples sensor
+  test:
+    build_only: true
+    platform_whitelist: frdm_k64f hexiwear_k64
+    tags: samples sensor

--- a/samples/sensor/hts221/sample.yaml
+++ b/samples/sensor/hts221/sample.yaml
@@ -2,7 +2,7 @@ sample:
   description: TBD
   name: TBD
 tests:
-  - test:
-      build_only: true
-      platform_whitelist: disco_l475_iot1
-      tags: samples sensor
+  test:
+    build_only: true
+    platform_whitelist: disco_l475_iot1
+    tags: samples sensor

--- a/samples/sensor/magn_polling/sample.yaml
+++ b/samples/sensor/magn_polling/sample.yaml
@@ -2,7 +2,7 @@ sample:
   description: TBD
   name: TBD
 tests:
-  - test:
-      build_only: true
-      platform_whitelist: quark_d2000_crb
-      tags: samples
+  test:
+    build_only: true
+    platform_whitelist: quark_d2000_crb
+    tags: samples

--- a/samples/sensor/max30101/sample.yaml
+++ b/samples/sensor/max30101/sample.yaml
@@ -2,7 +2,7 @@ sample:
   description: TBD
   name: TBD
 tests:
-  - test:
-      build_only: true
-      platform_whitelist: hexiwear_k64
-      tags: samples sensor
+  test:
+    build_only: true
+    platform_whitelist: hexiwear_k64
+    tags: samples sensor

--- a/samples/sensor/max44009/sample.yaml
+++ b/samples/sensor/max44009/sample.yaml
@@ -2,7 +2,7 @@ sample:
   description: TBD
   name: TBD
 tests:
-  - test:
-      build_only: true
-      platform_whitelist: frdm_k64f quark_d2000_crb
-      tags: apps
+  test:
+    build_only: true
+    platform_whitelist: frdm_k64f quark_d2000_crb
+    tags: apps

--- a/samples/sensor/mcp9808/sample.yaml
+++ b/samples/sensor/mcp9808/sample.yaml
@@ -2,7 +2,7 @@ sample:
   description: TBD
   name: TBD
 tests:
-  - test:
-      build_only: true
-      platform_whitelist: frdm_k64f quark_d2000_crb
-      tags: samples sensor
+  test:
+    build_only: true
+    platform_whitelist: frdm_k64f quark_d2000_crb
+    tags: samples sensor

--- a/samples/sensor/sx9500/sample.yaml
+++ b/samples/sensor/sx9500/sample.yaml
@@ -2,6 +2,6 @@ sample:
   description: TBD
   name: TBD
 tests:
-  - test:
-      build_only: true
-      tags: samples
+  test:
+    build_only: true
+    tags: samples

--- a/samples/sensor/th02/sample.yaml
+++ b/samples/sensor/th02/sample.yaml
@@ -2,7 +2,7 @@ sample:
   description: TBD
   name: TBD
 tests:
-  - test:
-      build_only: true
-      platform_whitelist: frdm_k64f quark_d2000_crb
-      tags: samples sensor
+  test:
+    build_only: true
+    platform_whitelist: frdm_k64f quark_d2000_crb
+    tags: samples sensor

--- a/samples/sensor/thermometer/sample.yaml
+++ b/samples/sensor/thermometer/sample.yaml
@@ -2,6 +2,6 @@ sample:
   description: TBD
   name: TBD
 tests:
-  - test:
-      build_only: true
-      tags: samples
+  test:
+    build_only: true
+    tags: samples

--- a/samples/sensor/tmp112/sample.yaml
+++ b/samples/sensor/tmp112/sample.yaml
@@ -2,7 +2,7 @@ sample:
   description: TBD
   name: TBD
 tests:
-  - test:
-      build_only: true
-      platform_whitelist: frdm_k64f quark_d2000_crb
-      tags: samples
+  test:
+    build_only: true
+    platform_whitelist: frdm_k64f quark_d2000_crb
+    tags: samples

--- a/samples/subsys/console/echo/sample.yaml
+++ b/samples/subsys/console/echo/sample.yaml
@@ -2,7 +2,7 @@ sample:
   description: TBD
   name: TBD
 tests:
-  - test:
-      build_only: true
-      filter: CONFIG_UART_CONSOLE and CONFIG_SERIAL_SUPPORT_INTERRUPT
-      tags: samples
+  test:
+    build_only: true
+    filter: CONFIG_UART_CONSOLE and CONFIG_SERIAL_SUPPORT_INTERRUPT
+    tags: samples

--- a/samples/subsys/console/getchar/sample.yaml
+++ b/samples/subsys/console/getchar/sample.yaml
@@ -2,7 +2,7 @@ sample:
   description: TBD
   name: TBD
 tests:
-  - test:
-      build_only: true
-      filter: CONFIG_UART_CONSOLE and CONFIG_SERIAL_SUPPORT_INTERRUPT
-      tags: samples
+  test:
+    build_only: true
+    filter: CONFIG_UART_CONSOLE and CONFIG_SERIAL_SUPPORT_INTERRUPT
+    tags: samples

--- a/samples/subsys/console/getline/sample.yaml
+++ b/samples/subsys/console/getline/sample.yaml
@@ -2,7 +2,7 @@ sample:
   description: TBD
   name: TBD
 tests:
-  - test:
-      build_only: true
-      filter: CONFIG_UART_CONSOLE and CONFIG_SERIAL_SUPPORT_INTERRUPT
-      tags: samples
+  test:
+    build_only: true
+    filter: CONFIG_UART_CONSOLE and CONFIG_SERIAL_SUPPORT_INTERRUPT
+    tags: samples

--- a/samples/subsys/debug/sysview/sample.yaml
+++ b/samples/subsys/debug/sysview/sample.yaml
@@ -1,7 +1,7 @@
 sample:
   name: Systemview Demo
 tests:
-  - test:
-      build_only: true
-      platform_whitelist: frdm_k64f
-      tags: apps debug
+  test:
+    build_only: true
+    platform_whitelist: frdm_k64f
+    tags: apps debug

--- a/samples/subsys/ipc/ipm_mailbox/ap/sample.yaml
+++ b/samples/subsys/ipc/ipm_mailbox/ap/sample.yaml
@@ -2,7 +2,7 @@ sample:
   description: TBD
   name: TBD
 tests:
-  - test:
-      build_only: true
-      filter: CONFIG_SOC_QUARK_SE_C1000
-      tags: samples ipm
+  test:
+    build_only: true
+    filter: CONFIG_SOC_QUARK_SE_C1000
+    tags: samples ipm

--- a/samples/subsys/ipc/ipm_mailbox/sensor/sample.yaml
+++ b/samples/subsys/ipc/ipm_mailbox/sensor/sample.yaml
@@ -2,7 +2,7 @@ sample:
   description: TBD
   name: TBD
 tests:
-  - test:
-      build_only: true
-      filter: CONFIG_SOC_QUARK_SE_C1000_SS
-      tags: samples ipm
+  test:
+    build_only: true
+    filter: CONFIG_SOC_QUARK_SE_C1000_SS
+    tags: samples ipm

--- a/samples/subsys/logging/kernel_event_logger/sample.yaml
+++ b/samples/subsys/logging/kernel_event_logger/sample.yaml
@@ -1,9 +1,9 @@
 sample:
-    description: A simple application that demonstrate use of
-        kernel event logging feature.
-    name: Kernel event logger Sample
+  description: A simple application that demonstrate
+    use of kernel event logging feature.
+  name: Kernel event logger Sample
 tests:
--   test:
-        build_only: true
-        tags: apps
-        platform_whitelist: qemu_x86
+  test:
+    build_only: true
+    platform_whitelist: qemu_x86
+    tags: apps

--- a/samples/subsys/logging/logger-hook/sample.yaml
+++ b/samples/subsys/logging/logger-hook/sample.yaml
@@ -2,6 +2,6 @@ sample:
   description: TBD
   name: TBD
 tests:
-  - test:
-      build_only: true
-      tags: apps
+  test:
+    build_only: true
+    tags: apps

--- a/samples/subsys/shell/shell/sample.yaml
+++ b/samples/subsys/shell/shell/sample.yaml
@@ -2,7 +2,7 @@ sample:
   description: TBD
   name: TBD
 tests:
-  - test:
-      build_only: true
-      filter: CONFIG_UART_CONSOLE and CONFIG_SERIAL_SUPPORT_INTERRUPT
-      tags: samples
+  test:
+    build_only: true
+    filter: CONFIG_UART_CONSOLE and CONFIG_SERIAL_SUPPORT_INTERRUPT
+    tags: samples

--- a/samples/subsys/usb/cdc_acm/sample.yaml
+++ b/samples/subsys/usb/cdc_acm/sample.yaml
@@ -2,8 +2,8 @@ sample:
   description: TBD
   name: TBD
 tests:
-  - test_x86:
-      build_only: true
-      depends_on: usb_device
-      platform_whitelist: arduino_101
-      tags: usb
+  test_x86:
+    build_only: true
+    depends_on: usb_device
+    platform_whitelist: arduino_101
+    tags: usb

--- a/samples/subsys/usb/console/sample.yaml
+++ b/samples/subsys/usb/console/sample.yaml
@@ -2,8 +2,8 @@ sample:
   description: TBD
   name: TBD
 tests:
-  - test:
-      build_only: true
-      depends_on: usb_device
-      platform_whitelist: arduino_101
-      tags: usb
+  test:
+    build_only: true
+    depends_on: usb_device
+    platform_whitelist: arduino_101
+    tags: usb

--- a/samples/subsys/usb/dfu/sample.yaml
+++ b/samples/subsys/usb/dfu/sample.yaml
@@ -2,8 +2,8 @@ sample:
   description: TBD
   name: TBD
 tests:
-  - test_x86:
-      build_only: true
-      depends_on: usb_device
-      platform_whitelist: quark_se_c1000_devboard
-      tags: usb
+  test_x86:
+    build_only: true
+    depends_on: usb_device
+    platform_whitelist: quark_se_c1000_devboard
+    tags: usb

--- a/samples/subsys/usb/mass/sample.yaml
+++ b/samples/subsys/usb/mass/sample.yaml
@@ -2,7 +2,7 @@ sample:
   description: TBD
   name: TBD
 tests:
-  - test:
-      build_only: true
-      platform_whitelist: arduino_101
-      tags: msd usb
+  test:
+    build_only: true
+    platform_whitelist: arduino_101
+    tags: msd usb

--- a/samples/subsys/usb/webusb/sample.yaml
+++ b/samples/subsys/usb/webusb/sample.yaml
@@ -2,8 +2,8 @@ sample:
   description: TBD
   name: TBD
 tests:
-  - test_x86:
-      build_only: true
-      depends_on: usb_device
-      platform_whitelist: quark_se_c1000_devboard
-      tags: usb
+  test_x86:
+    build_only: true
+    depends_on: usb_device
+    platform_whitelist: quark_se_c1000_devboard
+    tags: usb

--- a/samples/synchronization/sample.yaml
+++ b/samples/synchronization/sample.yaml
@@ -3,7 +3,7 @@ sample:
     basic sanity of the kernel.
   name: Synchronization Sample
 tests:
-  - test:
-      build_on_all: true
-      build_only: true
-      tags: apps
+  test:
+    build_on_all: true
+    build_only: true
+    tags: apps

--- a/samples/testing/integration/sample.yaml
+++ b/samples/testing/integration/sample.yaml
@@ -2,5 +2,5 @@ sample:
   description: TBD
   name: TBD
 tests:
-  - test:
-      tags: my_tags
+  test:
+    tags: my_tags

--- a/samples/testing/unit/sample.yaml
+++ b/samples/testing/unit/sample.yaml
@@ -2,6 +2,6 @@ sample:
   description: TBD
   name: TBD
 tests:
-  - test:
-      tags: buf
-      type: unit
+  test:
+    tags: buf
+    type: unit

--- a/scripts/sanity_chk/expr_parser.py
+++ b/scripts/sanity_chk/expr_parser.py
@@ -164,7 +164,7 @@ def p_error(p):
     else:
         raise SyntaxError("Unexpected end of expression")
 
-parser = yacc.yacc()
+parser = yacc.yacc(debug=0)
 
 def ast_sym(ast, env):
     if ast in env:

--- a/scripts/sanity_chk/expr_parser.py
+++ b/scripts/sanity_chk/expr_parser.py
@@ -164,7 +164,10 @@ def p_error(p):
     else:
         raise SyntaxError("Unexpected end of expression")
 
-parser = yacc.yacc(debug=0)
+if "PARSETAB_DIR" not in os.environ:
+    parser = yacc.yacc(debug=0)
+else:
+    parser = yacc.yacc(debug=0, outputdir=os.environ["PARSETAB_DIR"])
 
 def ast_sym(ast, env):
     if ast in env:

--- a/scripts/sanity_chk/sanitycheck-tc-schema.yaml
+++ b/scripts/sanity_chk/sanitycheck-tc-schema.yaml
@@ -89,12 +89,9 @@ mapping:
   # maps maps, shall just be a sequence of maps
   # maybe it is just an artifact?
   "tests":
-    type: seq
-    required: yes
-    sequence:
-      - type: map
-        matching-rule: "any"
-        mapping:
+      type: map
+      matching-rule: "any"
+      mapping:
           # The key for the testname is any, so
           # regex;(([a-zA-Z0-9_]+)) for this to work, note below we
           # make it required: no

--- a/scripts/sanitycheck
+++ b/scripts/sanitycheck
@@ -828,7 +828,7 @@ class MakeGenerator:
         run_logfile = os.path.join(outdir, "run.log")
         qemu_logfile = os.path.join(outdir, "qemu.log")
 
-        q = QEMUHandler(name, outdir, qemu_logfile, timeout)
+        qemu = QEMUHandler(name, outdir, qemu_logfile, timeout)
         args.append("QEMU_PIPE=%s" % q.get_fifo())
         text = (self._get_rule_header(name) +
                 self._get_sub_make(name, "building", directory,
@@ -837,7 +837,7 @@ class MakeGenerator:
                                    outdir, run_logfile,
                                    args, make_args="run") +
                 self._get_rule_footer(name))
-        self.goals[name] = MakeGoal(name, text, q, self.logfile, build_logfile,
+        self.goals[name] = MakeGoal(name, text, qemu, self.logfile, build_logfile,
                                     run_logfile, qemu_logfile)
 
     def add_unit_goal(self, name, directory, outdir,
@@ -854,9 +854,9 @@ class MakeGenerator:
                 self._get_sub_make(name, "building", directory,
                                    outdir, build_logfile, args) +
                 self._get_rule_footer(name))
-        q = UnitHandler(name, directory, outdir, run_logfile,
+        unit = UnitHandler(name, directory, outdir, run_logfile,
                         valgrind_logfile, timeout)
-        self.goals[name] = MakeGoal(name, text, q, self.logfile, build_logfile,
+        self.goals[name] = MakeGoal(name, text, unit, self.logfile, build_logfile,
                                     run_logfile, valgrind_logfile)
 
     def add_test_instance(

--- a/scripts/sanitycheck
+++ b/scripts/sanitycheck
@@ -975,9 +975,14 @@ class SanityConfigParser:
 
         @param filename Source .yaml file to read
         """
-        cp = scl.yaml_load_verify(filename, schema)
+        self.data = scl.yaml_load_verify(filename, schema)
         self.filename = filename
-        self.cp = cp
+        self.tests = {}
+        self.common = {}
+        if 'tests' in self.data:
+            self.tests = self.data['tests']
+        if 'common' in self.data:
+            self.common = self.data['common']
 
     def _cast_value(self, value, typestr):
         if type(value) is str:
@@ -1014,17 +1019,9 @@ class SanityConfigParser:
             raise ConfigurationError(self.filename, "unknown type '%s'" % value)
 
     def section(self, name):
-        for s in self.sections():
-            if name in s:
-                return s.get(name, {})
+        return self.tests.get(name, {})
 
-    def sections(self):
-        """Get the set of test sections within the .yaml file
-
-        @return a list of string section names"""
-        return self.cp['tests']
-
-    def get_section(self, section, valid_keys, common):
+    def get_section(self, section, valid_keys):
         """Get a dictionary representing the keys/values within a section
 
         @param section The section in the .yaml file to retrieve data from
@@ -1050,7 +1047,7 @@ class SanityConfigParser:
         """
 
         d = {}
-        for k, v in common.items():
+        for k, v in self.common.items():
             d[k] = v
         for k, v in self.section(section).items():
             if k not in valid_keys:
@@ -1110,24 +1107,24 @@ class Platform:
             See the Architecture class.
         """
         scp = SanityConfigParser(cfile, self.yaml_platform_schema)
-        cp = scp.cp
+        data = scp.data
 
-        self.name = cp['identifier']
+        self.name = data['identifier']
         # if no RAM size is specified by the board, take a default of 128K
-        self.ram = cp.get("ram", 128)
-        testing = cp.get("testing", {})
+        self.ram = data.get("ram", 128)
+        testing = data.get("testing", {})
         self.ignore_tags = testing.get("ignore_tags", [])
         self.default = testing.get("default", False)
         # if no flash size is specified by the board, take a default of 512K
-        self.flash = cp.get("flash", 512)
+        self.flash = data.get("flash", 512)
         self.supported = set()
-        for supp_feature in cp.get("supported", []):
+        for supp_feature in data.get("supported", []):
             for item in supp_feature.split(":"):
                 self.supported.add(item)
 
-        self.qemu_support = True if cp.get('type', "na") == 'qemu' else False
-        self.arch = cp['arch']
-        self.supported_toolchains = cp.get("toolchain", [])
+        self.qemu_support = True if data.get('type', "na") == 'qemu' else False
+        self.arch = data['arch']
+        self.supported_toolchains = data.get("toolchain", [])
         self.defconfig = None
         pass
 
@@ -1310,19 +1307,15 @@ class TestSuite:
                 dirnames[:] = []
                 yaml_path = os.path.join(dirpath, filename)
                 try:
-                    cp = SanityConfigParser(yaml_path, self.yaml_tc_schema)
+                    parsed_data = SanityConfigParser(yaml_path, self.yaml_tc_schema)
                 except RuntimeError as e:
                     error("E: %s: can't load: %s" % (yaml_path, e))
 
                 workdir = os.path.relpath(dirpath, testcase_root)
 
-                common = {}
-                if 'common' in cp.cp:
-                    common = cp.cp['common']
-
-                for section in cp.sections():
-                    name = list(section.keys())[0]
-                    tc_dict = cp.get_section(name, testcase_valid_keys, common)
+                print(parsed_data.tests)
+                for name, section in parsed_data.tests.items():
+                    tc_dict = parsed_data.get_section(name, testcase_valid_keys)
                     tc = TestCase(testcase_root, workdir, name, tc_dict,
                                   yaml_path)
 

--- a/scripts/sanitycheck
+++ b/scripts/sanitycheck
@@ -1057,15 +1057,12 @@ class SanityConfigParser:
             raise ConfigurationError(
                 self.filename, "unknown type '%s'" % value)
 
-    def section(self, name):
-        return self.tests.get(name, {})
+    def get_test(self, name, valid_keys):
+        """Get a dictionary representing the keys/values within a test
 
-    def get_section(self, section, valid_keys):
-        """Get a dictionary representing the keys/values within a section
-
-        @param section The section in the .yaml file to retrieve data from
+        @param name The test in the .yaml file to retrieve data from
         @param valid_keys A dictionary representing the intended semantics
-            for this section. Each key in this dictionary is a key that could
+            for this test. Each key in this dictionary is a key that could
             be specified, if a key is given in the .yaml file which isn't in
             here, it will generate an error. Each value in this dictionary
             is another dictionary containing metadata:
@@ -1081,19 +1078,19 @@ class SanityConfigParser:
                 "required" - If true, raise an error if not defined. If false
                     and "default" isn't specified, a type conversion will be
                     done on an empty string
-        @return A dictionary containing the section key-value pairs with
+        @return A dictionary containing the test key-value pairs with
             type conversion and default values filled in per valid_keys
         """
 
         d = {}
         for k, v in self.common.items():
             d[k] = v
-        for k, v in self.section(section).items():
+        for k, v in self.tests[name].items():
             if k not in valid_keys:
                 raise ConfigurationError(
                     self.filename,
                     "Unknown config key '%s' in definition for '%s'" %
-                    (k, section))
+                    (k, name))
 
             if k in d:
                 if isinstance(d[k], str):
@@ -1110,8 +1107,8 @@ class SanityConfigParser:
                 if required:
                     raise ConfigurationError(
                         self.filename,
-                        "missing required value for '%s' in section '%s'" %
-                        (k, section))
+                        "missing required value for '%s' in test '%s'" %
+                        (k, name))
                 else:
                     if "default" in kinfo:
                         default = kinfo["default"]
@@ -1123,8 +1120,8 @@ class SanityConfigParser:
                     d[k] = self._cast_value(d[k], kinfo["type"])
                 except ValueError as ve:
                     raise ConfigurationError(
-                        self.filename, "bad %s value '%s' for key '%s' in section '%s'" %
-                        (kinfo["type"], d[k], k, section))
+                        self.filename, "bad %s value '%s' for key '%s' in name '%s'" %
+                        (kinfo["type"], d[k], k, name))
 
         return d
 
@@ -1358,7 +1355,7 @@ class TestSuite:
                 workdir = os.path.relpath(dirpath, testcase_root)
 
                 for name, section in parsed_data.tests.items():
-                    tc_dict = parsed_data.get_section(
+                    tc_dict = parsed_data.get_test(
                         name, testcase_valid_keys)
                     tc = TestCase(testcase_root, workdir, name, tc_dict,
                                   yaml_path)

--- a/scripts/sanitycheck
+++ b/scripts/sanitycheck
@@ -872,7 +872,6 @@ class MakeGenerator:
             args.append("OVERLAY_CONFIG=%s" %
                         os.path.join(ti.outdir, "overlay.conf"))
 
-        args.append("ARCH={}" .format(ti.platform.arch))
         args.append("BOARD={}".format(ti.platform.name))
         args.extend(extra_args)
         if (ti.platform.qemu_support and (not ti.build_only) and
@@ -1520,7 +1519,6 @@ class TestSuite:
                     if (tc.tc_filter and (plat.default or all_plats or platform_filter)
                             and toolchain in plat.supported_toolchains):
                         args = tc.extra_args[:]
-                        args.append("ARCH={}" .format(plat.arch))
                         args.append("BOARD={}".format(plat.name))
                         args.extend(extra_args)
                         # FIXME would be nice to use a common outdir for this so that

--- a/scripts/sanitycheck
+++ b/scripts/sanitycheck
@@ -1427,7 +1427,6 @@ class TestSuite:
         tag_filter = args.tag
         exclude_tag = args.exclude_tag
         config_filter = args.config
-        platform_limit = args.platform_limit
         extra_args = args.extra_args
         all_plats = args.all
 
@@ -1685,7 +1684,7 @@ class TestSuite:
                                 instance_list))
                         self.add_instances(instances)
                     else:
-                        self.add_instances(instance_list[:platform_limit])
+                        self.add_instances(instance_list[:1])
 
                     for instance in list(
                             filter(lambda tc: not tc.platform.default, instance_list)):
@@ -1909,14 +1908,6 @@ def parse_arguments():
         "specified. If this option is not used, then platforms marked "
         "as default in the platform metadata file will be chosen "
         "to build and test. ")
-    parser.add_argument(
-        "-L", "--platform-limit", action="store", type=int, metavar="N",
-        default=1,
-        help="Controls what platforms are tested if --platform or "
-        "--all are not used. For each architecture specified by "
-        "--arch (defaults to all of them), choose the first "
-        "N platforms to test in the arch-specific .yaml file "
-        "'platforms' list. Defaults to 1.")
     parser.add_argument(
         "-a", "--arch", action="append",
         help="Arch filter for testing. Takes precedence over --platform. "

--- a/scripts/sanitycheck
+++ b/scripts/sanitycheck
@@ -15,7 +15,8 @@ the test case, which only needs to be unique for the test cases specified in
 that testcase meta-data. The full canonical name for each test case is <path to
 test case>/<block>.
 
-Each test block in the testcase meta data can define the following key/value pairs:
+Each test block in the testcase meta data can define the following key/value
+pairs:
 
   tags: <list of tags> (required)
     A set of string tags for the testcase. Usually pertains to
@@ -160,9 +161,7 @@ Most everyday users will run with no arguments.
 import argparse
 import os
 import sys
-import configparser
 import re
-import tempfile
 import subprocess
 import multiprocessing
 import select
@@ -178,28 +177,28 @@ import xml.etree.ElementTree as ET
 from xml.sax.saxutils import escape
 from collections import OrderedDict
 from itertools import islice
-import yaml
 
 import logging
+from sanity_chk import scl
+from sanity_chk import expr_parser
+
 log_format = "%(levelname)s %(name)s::%(module)s.%(funcName)s():%(lineno)d: %(message)s"
-logging.basicConfig(format = log_format, level = 30)
+logging.basicConfig(format=log_format, level=30)
 
 if "ZEPHYR_BASE" not in os.environ:
     sys.stderr.write("$ZEPHYR_BASE environment variable undefined.\n")
     exit(1)
 ZEPHYR_BASE = os.environ["ZEPHYR_BASE"]
 
-from sanity_chk import scl
 
 sys.path.insert(0, os.path.join(ZEPHYR_BASE, "scripts/"))
 
-from sanity_chk import expr_parser
 
 VERBOSE = 0
 LAST_SANITY = os.path.join(ZEPHYR_BASE, "scripts", "sanity_chk",
                            "last_sanity.csv")
 LAST_SANITY_XUNIT = os.path.join(ZEPHYR_BASE, "scripts", "sanity_chk",
-                           "last_sanity.xml")
+                                 "last_sanity.xml")
 RELEASE_DATA = os.path.join(ZEPHYR_BASE, "scripts", "sanity_chk",
                             "sanity_last_release.csv")
 CPU_COUNTS = multiprocessing.cpu_count()
@@ -217,11 +216,14 @@ else:
     COLOR_GREEN = ""
     COLOR_YELLOW = ""
 
+
 class SanityCheckException(Exception):
     pass
 
+
 class SanityRuntimeError(SanityCheckException):
     pass
+
 
 class ConfigurationError(SanityCheckException):
     def __init__(self, cfile, message):
@@ -231,16 +233,21 @@ class ConfigurationError(SanityCheckException):
     def __str__(self):
         return repr(self.cfile + ": " + self.message)
 
+
 class MakeError(SanityCheckException):
     pass
+
 
 class BuildError(MakeError):
     pass
 
+
 class ExecutionError(MakeError):
     pass
 
+
 log_file = None
+
 
 # Debug Functions
 def info(what):
@@ -250,23 +257,28 @@ def info(what):
         log_file.write(what + "\n")
         log_file.flush()
 
+
 def error(what):
     sys.stderr.write(COLOR_RED + what + COLOR_NORMAL + "\n")
     if log_file:
         log_file(what + "\n")
         log_file.flush()
 
+
 def debug(what):
     if VERBOSE >= 1:
         info(what)
+
 
 def verbose(what):
     if VERBOSE >= 2:
         info(what)
 
+
 class Handler:
     RUN_PASSED = "PROJECT EXECUTION SUCCESSFUL"
     RUN_FAILED = "PROJECT EXECUTION FAILED"
+
     def __init__(self, name, outdir, log_fn, timeout, unit=False):
         """Constructor
 
@@ -297,8 +309,10 @@ class Handler:
         self.lock.release()
         return ret
 
+
 class UnitHandler(Handler):
-    def __init__(self, name, sourcedir, outdir, run_log, valgrind_log, timeout):
+    def __init__(self, name, sourcedir, outdir,
+                 run_log, valgrind_log, timeout):
         """Constructor
 
         @param name Arbitrary name of the created thread
@@ -342,9 +356,11 @@ class UnitHandler(Handler):
                 out_state = "timeout"
                 self.returncode = 1
 
-        returncode = subprocess.call(["GCOV_PREFIX=" + self.outdir, "gcov", self.sourcedir, "-s", self.outdir], shell=True)
+        returncode = subprocess.call(
+            ["GCOV_PREFIX=" + self.outdir, "gcov", self.sourcedir, "-s", self.outdir], shell=True)
 
         self.set_state(out_state, {})
+
 
 class QEMUHandler(Handler):
     """Spawns a thread to monitor QEMU output from pipes
@@ -476,6 +492,7 @@ class QEMUHandler(Handler):
     def get_fifo(self):
         return self.fifo_fn
 
+
 class SizeCalculator:
 
     alloc_sections = ["bss", "noinit", "app_bss", "app_noinit"]
@@ -507,10 +524,13 @@ class SizeCalculator:
             raise SanityRuntimeError("%s is not an ELF binary" % filename)
 
         # Search for CONFIG_XIP in the ELF's list of symbols using NM and AWK.
-        # GREP can not be used as it returns an error if the symbol is not found.
-        is_xip_command = "nm " + filename + " | awk '/CONFIG_XIP/ { print $3 }'"
-        is_xip_output = subprocess.check_output(is_xip_command, shell=True,
-                            stderr=subprocess.STDOUT).decode("utf-8").strip()
+        # GREP can not be used as it returns an error if the symbol is not
+        # found.
+        is_xip_command = "nm " + filename + \
+            " | awk '/CONFIG_XIP/ { print $3 }'"
+        is_xip_output = subprocess.check_output(
+            is_xip_command, shell=True, stderr=subprocess.STDOUT).decode(
+            "utf-8").strip()
         if is_xip_output.endswith("no symbols"):
             raise SanityRuntimeError("%s has no symbol information" % filename)
         self.is_xip = (len(is_xip_output) != 0)
@@ -551,8 +571,8 @@ class SizeCalculator:
     def _calculate_sizes(self):
         """ Calculate RAM and ROM usage by section """
         objdump_command = "objdump -h " + self.filename
-        objdump_output = subprocess.check_output(objdump_command,
-                                        shell=True).decode("utf-8").splitlines()
+        objdump_output = subprocess.check_output(
+            objdump_command, shell=True).decode("utf-8").splitlines()
 
         for line in objdump_output:
             words = line.split()
@@ -598,9 +618,9 @@ class SizeCalculator:
                 if name not in self.extra_sections:
                     recognized = False
 
-            self.sections.append({"name" : name, "load_addr" : load_addr,
-                                  "size" : size, "virt_addr" : virt_addr,
-                                  "type" : stype, "recognized" : recognized})
+            self.sections.append({"name": name, "load_addr": load_addr,
+                                  "size": size, "virt_addr": virt_addr,
+                                  "type": stype, "recognized": recognized})
 
 
 class MakeGoal:
@@ -611,6 +631,7 @@ class MakeGoal:
     MakeGenerator is used for tasks outside of building tests (such as
     defconfigs) which is why MakeGoal is a separate class from TestInstance.
     """
+
     def __init__(self, name, text, qemu, make_log, build_log, run_log,
                  qemu_log):
         self.name = name
@@ -688,9 +709,10 @@ class MakeGenerator:
 
     GOAL_FOOTER_TMPL = "\t@echo sanity_test_finished {goal} >&2\n\n"
 
-    re_make = re.compile("sanity_test_([A-Za-z0-9]+) (.+)|$|make[:] \*\*\* \[(.+:.+: )?(.+)\] Error.+$")
+    re_make = re.compile(
+        "sanity_test_([A-Za-z0-9]+) (.+)|$|make[:] \*\*\* \[(.+:.+: )?(.+)\] Error.+$")
 
-    def __init__(self, base_outdir, asserts=False,  deprecations=False):
+    def __init__(self, base_outdir, asserts=False, deprecations=False):
         """MakeGenerator constructor
 
         @param base_outdir Intended to be the base out directory. A make.log
@@ -710,20 +732,19 @@ class MakeGenerator:
     def _get_rule_header(self, name):
         return MakeGenerator.GOAL_HEADER_TMPL.format(goal=name)
 
-    def _get_sub_make(self, name, phase, workdir, outdir, logfile, args, make_args=""):
+    def _get_sub_make(self, name, phase, workdir, outdir,
+                      logfile, args, make_args=""):
         """
         @param      args Arguments given to CMake
         @param make_args Arguments given to the Makefile generated by CMake
         """
         verb = "1" if VERBOSE else "0"
-        args      = " ".join(["-D{}".format(a) for a in args])
-        #print(make_args)
-        #make_args = " ".join(make_args)
+        args = " ".join(["-D{}".format(a) for a in args])
 
         if self.asserts:
-            cflags="-DCONFIG_ASSERT=1 -D__ASSERT_ON=2"
+            cflags = "-DCONFIG_ASSERT=1 -D__ASSERT_ON=2"
         else:
-            cflags=""
+            cflags = ""
 
         if self.deprecations:
             cflags = cflags + "  -Wno-deprecated-declarations"
@@ -747,7 +768,8 @@ class MakeGenerator:
         if not os.path.exists(outdir):
             os.makedirs(outdir)
 
-    def add_build_goal(self, name, directory, outdir, args, buildlog, make_args=""):
+    def add_build_goal(self, name, directory, outdir,
+                       args, buildlog, make_args=""):
         """Add a goal to invoke a Kbuild session
 
         @param name A unique string name for this build goal. The results
@@ -761,12 +783,25 @@ class MakeGenerator:
         """
         self._add_goal(outdir)
         build_logfile = os.path.join(outdir, buildlog)
-        text = (self._get_rule_header(name) +
-                self._get_sub_make(name, "building", directory,
-                                   outdir, build_logfile, args, make_args=make_args) +
-                self._get_rule_footer(name))
-        self.goals[name] = MakeGoal(name, text, None, self.logfile, build_logfile,
-                                    None, None)
+        text = (
+            self._get_rule_header(name) +
+            self._get_sub_make(
+                name,
+                "building",
+                directory,
+                outdir,
+                build_logfile,
+                args,
+                make_args=make_args) +
+            self._get_rule_footer(name))
+        self.goals[name] = MakeGoal(
+            name,
+            text,
+            None,
+            self.logfile,
+            build_logfile,
+            None,
+            None)
 
     def add_qemu_goal(self, name, directory, outdir, args, timeout=30):
         """Add a goal to build a Zephyr project and then run it under QEMU
@@ -805,27 +840,28 @@ class MakeGenerator:
         self.goals[name] = MakeGoal(name, text, q, self.logfile, build_logfile,
                                     run_logfile, qemu_logfile)
 
-    def add_unit_goal(self, name, directory, outdir, args, timeout=30, coverage=False):
+    def add_unit_goal(self, name, directory, outdir,
+                      args, timeout=30, coverage=False):
         self._add_goal(outdir)
         build_logfile = os.path.join(outdir, "build.log")
         run_logfile = os.path.join(outdir, "run.log")
-        qemu_logfile = os.path.join(outdir, "qemu.log")
         valgrind_logfile = os.path.join(outdir, "valgrind.log")
         if coverage:
-                args += ["COVERAGE=1"]
+            args += ["COVERAGE=1"]
 
         # we handle running in the UnitHandler class
         text = (self._get_rule_header(name) +
                 self._get_sub_make(name, "building", directory,
                                    outdir, build_logfile, args) +
                 self._get_rule_footer(name))
-        q = UnitHandler(name, directory, outdir, run_logfile, valgrind_logfile, timeout)
+        q = UnitHandler(name, directory, outdir, run_logfile,
+                        valgrind_logfile, timeout)
         self.goals[name] = MakeGoal(name, text, q, self.logfile, build_logfile,
                                     run_logfile, valgrind_logfile)
 
-
-    def add_test_instance(self, ti, build_only=False, enable_slow=False, coverage=False,
-                          extra_args=[]):
+    def add_test_instance(
+            self, ti, build_only=False, enable_slow=False, coverage=False,
+            extra_args=[]):
         """Add a goal to build/test a TestInstance object
 
         @param ti TestInstance object to build. The status dictionary returned
@@ -833,13 +869,14 @@ class MakeGenerator:
         """
         args = ti.test.extra_args[:]
         if len(ti.test.extra_configs) > 0:
-            args.append("OVERLAY_CONFIG=%s" % os.path.join(ti.outdir, "overlay.conf"))
+            args.append("OVERLAY_CONFIG=%s" %
+                        os.path.join(ti.outdir, "overlay.conf"))
 
         args.append("ARCH={}" .format(ti.platform.arch))
         args.append("BOARD={}".format(ti.platform.name))
         args.extend(extra_args)
         if (ti.platform.qemu_support and (not ti.build_only) and
-            (not build_only) and (enable_slow or not ti.test.slow)):
+                (not build_only) and (enable_slow or not ti.test.slow)):
             self.add_qemu_goal(ti.name, ti.test.code_location, ti.outdir,
                                args, ti.test.timeout)
         elif ti.test.type == "unit":
@@ -847,7 +884,7 @@ class MakeGenerator:
                                args, ti.test.timeout, coverage)
         else:
             self.add_build_goal(ti.name, ti.test.code_location, ti.outdir,
-                    args, "build.log")
+                                args, "build.log")
 
     def execute(self, callback_fn=None, context=None):
         """Execute all the registered build goals
@@ -872,7 +909,8 @@ class MakeGenerator:
             tf.write("all: %s\n" % (" ".join(self.goals.keys())))
             tf.flush()
 
-            cmd = ["make", "-k", "-j", str(CPU_COUNTS * 2), "-f", tf.name, "all"]
+            cmd = ["make", "-k", "-j",
+                   str(CPU_COUNTS * 2), "-f", tf.name, "all"]
             p = subprocess.Popen(cmd, stderr=subprocess.PIPE,
                                  stdout=devnull)
 
@@ -890,7 +928,6 @@ class MakeGenerator:
                 else:
                     goal = self.goals[name]
                     goal.make_state = state
-
 
                 if error:
                     # Sometimes QEMU will run an image and then crash out, which
@@ -938,38 +975,39 @@ class MakeGenerator:
 
 # XXX Be sure to update __doc__ if you change any of this!!
 
-arch_valid_keys = {"name" : {"type" : "str", "required" : True},
-                   "platforms" : {"type" : "list", "required" : True},
-                   "supported_toolchains" : {"type" : "list", "required" : True}}
+arch_valid_keys = {"name": {"type": "str", "required": True},
+                   "platforms": {"type": "list", "required": True},
+                   "supported_toolchains": {"type": "list", "required": True}}
 
-platform_valid_keys = {"qemu_support" : {"type" : "bool", "default" : False},
-                       "supported_toolchains" : {"type" : "list", "default" : []}}
+platform_valid_keys = {"qemu_support": {"type": "bool", "default": False},
+                       "supported_toolchains": {"type": "list", "default": []}}
 
-testcase_valid_keys = {"tags" : {"type" : "set", "required" : False},
-                       "type" : {"type" : "str", "default": "integration"},
-                       "extra_args" : {"type" : "list"},
-                       "extra_configs" : {"type" : "list"},
-                       "build_only" : {"type" : "bool", "default" : False},
-                       "build_on_all" : {"type" : "bool", "default" : False},
-                       "skip" : {"type" : "bool", "default" : False},
-                       "slow" : {"type" : "bool", "default" : False},
-                       "timeout" : {"type" : "int", "default" : 60},
-                       "min_ram" : {"type" : "int", "default" : 8},
-                       "depends_on": {"type" : "set"},
-                       "min_flash" : {"type" : "int", "default" : 32},
-                       "arch_whitelist" : {"type" : "set"},
-                       "arch_exclude" : {"type" : "set"},
-                       "extra_sections" : {"type" : "list", "default" : []},
-                       "platform_exclude" : {"type" : "set"},
-                       "platform_whitelist" : {"type" : "set"},
-                       "toolchain_exclude" : {"type" : "set"},
-                       "toolchain_whitelist" : {"type" : "set"},
-                       "filter" : {"type" : "str"}}
+testcase_valid_keys = {"tags": {"type": "set", "required": False},
+                       "type": {"type": "str", "default": "integration"},
+                       "extra_args": {"type": "list"},
+                       "extra_configs": {"type": "list"},
+                       "build_only": {"type": "bool", "default": False},
+                       "build_on_all": {"type": "bool", "default": False},
+                       "skip": {"type": "bool", "default": False},
+                       "slow": {"type": "bool", "default": False},
+                       "timeout": {"type": "int", "default": 60},
+                       "min_ram": {"type": "int", "default": 8},
+                       "depends_on": {"type": "set"},
+                       "min_flash": {"type": "int", "default": 32},
+                       "arch_whitelist": {"type": "set"},
+                       "arch_exclude": {"type": "set"},
+                       "extra_sections": {"type": "list", "default": []},
+                       "platform_exclude": {"type": "set"},
+                       "platform_whitelist": {"type": "set"},
+                       "toolchain_exclude": {"type": "set"},
+                       "toolchain_whitelist": {"type": "set"},
+                       "filter": {"type": "str"}}
 
 
 class SanityConfigParser:
     """Class to read test case files with semantic checking
     """
+
     def __init__(self, filename, schema):
         """Instantiate a new SanityConfigParser object
 
@@ -985,7 +1023,7 @@ class SanityConfigParser:
             self.common = self.data['common']
 
     def _cast_value(self, value, typestr):
-        if type(value) is str:
+        if isinstance(value, str):
             v = value.strip()
         if typestr == "str":
             return v
@@ -999,9 +1037,9 @@ class SanityConfigParser:
         elif typestr == "bool":
             return value
 
-        elif typestr.startswith("list") and type(value) is list:
+        elif typestr.startswith("list") and isinstance(value, list):
             return value
-        elif typestr.startswith("list") and type(value) is str:
+        elif typestr.startswith("list") and isinstance(value, str):
             vs = v.split()
             if len(typestr) > 4 and typestr[4] == ":":
                 return [self._cast_value(vsi, typestr[5:]) for vsi in vs]
@@ -1016,7 +1054,8 @@ class SanityConfigParser:
                 return set(vs)
 
         else:
-            raise ConfigurationError(self.filename, "unknown type '%s'" % value)
+            raise ConfigurationError(
+                self.filename, "unknown type '%s'" % value)
 
     def section(self, name):
         return self.tests.get(name, {})
@@ -1051,12 +1090,13 @@ class SanityConfigParser:
             d[k] = v
         for k, v in self.section(section).items():
             if k not in valid_keys:
-                raise ConfigurationError(self.filename,
-                        "Unknown config key '%s' in definition for '%s'"
-                        % (k, section))
+                raise ConfigurationError(
+                    self.filename,
+                    "Unknown config key '%s' in definition for '%s'" %
+                    (k, section))
 
             if k in d:
-                if type(d[k]) is str:
+                if isinstance(d[k], str):
                     d[k] += " " + v
             else:
                 d[k] = v
@@ -1068,9 +1108,10 @@ class SanityConfigParser:
                     required = False
 
                 if required:
-                    raise ConfigurationError(self.filename,
-                                             "missing required value for '%s' in section '%s'"
-                                             % (k, section))
+                    raise ConfigurationError(
+                        self.filename,
+                        "missing required value for '%s' in section '%s'" %
+                        (k, section))
                 else:
                     if "default" in kinfo:
                         default = kinfo["default"]
@@ -1081,9 +1122,9 @@ class SanityConfigParser:
                 try:
                     d[k] = self._cast_value(d[k], kinfo["type"])
                 except ValueError as ve:
-                    raise ConfigurationError(self.filename,
-                                             "bad %s value '%s' for key '%s' in section '%s'"
-                                             % (kinfo["type"], d[k], k, section))
+                    raise ConfigurationError(
+                        self.filename, "bad %s value '%s' for key '%s' in section '%s'" %
+                        (kinfo["type"], d[k], k, section))
 
         return d
 
@@ -1094,8 +1135,11 @@ class Platform:
     Maps directly to BOARD when building"""
 
     yaml_platform_schema = scl.yaml_load(
-        os.path.join(os.environ['ZEPHYR_BASE'],
-                     "scripts", "sanity_chk", "sanitycheck-platform-schema.yaml"))
+        os.path.join(
+            os.environ['ZEPHYR_BASE'],
+            "scripts",
+            "sanity_chk",
+            "sanitycheck-platform-schema.yaml"))
 
     def __init__(self, cfile):
         """Constructor.
@@ -1135,6 +1179,7 @@ class Platform:
 class Architecture:
     """Class representing metadata for a particular architecture
     """
+
     def __init__(self, name, platforms):
         """Architecture constructor
 
@@ -1152,6 +1197,7 @@ class Architecture:
 class TestCase:
     """Class representing a test application
     """
+
     def __init__(self, testcase_root, workdir, name, tc_dict, yamlfile):
         """TestCase constructor.
 
@@ -1197,15 +1243,14 @@ class TestCase:
         self.min_flash = tc_dict["min_flash"]
         self.extra_sections = tc_dict["extra_sections"]
 
-        self.path = os.path.normpath(os.path.join(os.path.abspath(testcase_root).replace(ZEPHYR_BASE + "/",''), workdir, name))
+        self.path = os.path.normpath(os.path.join(os.path.abspath(
+            testcase_root).replace(ZEPHYR_BASE + "/", ''), workdir, name))
         self.name = os.path.join(self.path)
         self.defconfig = {}
         self.yamlfile = yamlfile
 
-
     def __repr__(self):
         return self.name
-
 
 
 class TestInstance:
@@ -1216,6 +1261,7 @@ class TestInstance:
     @param base_outdir Base directory for all test results. The actual
         out directory used is <outdir>/<platform>/<test case name>
     """
+
     def __init__(self, test, platform, base_outdir, build_only=False,
                  slow=False, coverage=False):
         self.test = test
@@ -1233,7 +1279,6 @@ class TestInstance:
             content = "\n".join(self.test.extra_configs)
             f.write(content)
             f.close()
-
 
     def calculate_sizes(self):
         """Get the RAM/ROM sizes of a test case.
@@ -1257,9 +1302,8 @@ def defconfig_cb(context, goals, goal):
     if not goal.failed:
         return
 
-
     info("%sCould not build defconfig for %s%s" %
-         (COLOR_RED, goal.name, COLOR_NORMAL));
+         (COLOR_RED, goal.name, COLOR_NORMAL))
     if INLINE_LOGS:
         with open(goal.get_error_log()) as fp:
             data = fp.read()
@@ -1279,7 +1323,6 @@ class TestSuite:
 
     def __init__(self, board_root_list, testcase_roots, outdir, coverage):
         # Keep track of which test cases we've filtered out and why
-        discards = {}
         self.arches = {}
         self.testcases = {}
         self.platforms = []
@@ -1307,15 +1350,16 @@ class TestSuite:
                 dirnames[:] = []
                 yaml_path = os.path.join(dirpath, filename)
                 try:
-                    parsed_data = SanityConfigParser(yaml_path, self.yaml_tc_schema)
+                    parsed_data = SanityConfigParser(
+                        yaml_path, self.yaml_tc_schema)
                 except RuntimeError as e:
                     error("E: %s: can't load: %s" % (yaml_path, e))
 
                 workdir = os.path.relpath(dirpath, testcase_root)
 
-                print(parsed_data.tests)
                 for name, section in parsed_data.tests.items():
-                    tc_dict = parsed_data.get_section(name, testcase_valid_keys)
+                    tc_dict = parsed_data.get_section(
+                        name, testcase_valid_keys)
                     tc = TestCase(testcase_root, workdir, name, tc_dict,
                                   yaml_path)
 
@@ -1324,7 +1368,9 @@ class TestSuite:
         for board_root in board_root_list:
             board_root = os.path.abspath(board_root)
 
-            debug("Reading platform configuration files under %s..." % board_root)
+            debug(
+                "Reading platform configuration files under %s..." %
+                board_root)
             for fn in glob.glob(os.path.join(board_root, "*", "*", "*.yaml")):
                 verbose("Found plaform configuration " + fn)
                 try:
@@ -1337,7 +1383,7 @@ class TestSuite:
         for p in self.platforms:
             arches.append(p.arch)
         for a in list(set(arches)):
-            aplatforms = [ p for p in self.platforms if p.arch == a ]
+            aplatforms = [p for p in self.platforms if p.arch == a]
             arch = Architecture(a, aplatforms)
             self.arches[a] = arch
 
@@ -1359,8 +1405,8 @@ class TestSuite:
 
     def load_from_file(self, file):
         if not os.path.exists(file):
-            raise SanityRuntimeError("Couldn't find input file with list of tests.")
-        result = []
+            raise SanityRuntimeError(
+                "Couldn't find input file with list of tests.")
         with open(file, "r") as fp:
             cr = csv.reader(fp)
             instance_list = []
@@ -1436,7 +1482,8 @@ class TestSuite:
                     if testcase_filter and tc_name not in testcase_filter:
                         continue
 
-                    if last_failed and (tc.name, plat.name) not in failed_tests:
+                    if last_failed and (
+                            tc.name, plat.name) not in failed_tests:
                         continue
 
                     if arch_filter and arch_name not in arch_filter:
@@ -1464,7 +1511,8 @@ class TestSuite:
                         continue
 
                     if tc.depends_on:
-                        dep_intersection = tc.depends_on.intersection(set(plat.supported))
+                        dep_intersection = tc.depends_on.intersection(
+                            set(plat.supported))
                         if dep_intersection != set(tc.depends_on):
                             continue
 
@@ -1477,8 +1525,8 @@ class TestSuite:
                     if tc.toolchain_whitelist and toolchain not in tc.toolchain_whitelist:
                         continue
 
-                    if (tc.tc_filter and (plat.default or all_plats or platform_filter) and
-                        toolchain in plat.supported_toolchains):
+                    if (tc.tc_filter and (plat.default or all_plats or platform_filter)
+                            and toolchain in plat.supported_toolchains):
                         args = tc.extra_args[:]
                         args.append("ARCH={}" .format(plat.arch))
                         args.append("BOARD={}".format(plat.name))
@@ -1486,13 +1534,19 @@ class TestSuite:
                         # FIXME would be nice to use a common outdir for this so that
                         # conf, gen_idt, etc aren't rebuilt for every  combination,
                         # need a way to avoid different Make processes from clobbering
-                        # each other since they all try to build them simultaneously
+                        # each other since they all try to build them
+                        # simultaneously
 
                         o = os.path.join(self.outdir, plat.name, tc.path)
-                        dlist[tc, plat, tc.name.split("/")[-1]] = os.path.join(o,"zephyr", ".config")
-                        goal = "_".join([plat.name, "_".join(tc.name.split("/")), "config-sanitycheck"])
-                        mg.add_build_goal(goal, os.path.join(ZEPHYR_BASE, tc.code_location), o,
-                                args, "config-sanitycheck.log", make_args="config-sanitycheck")
+                        dlist[tc, plat, tc.name.split(
+                            "/")[-1]] = os.path.join(o, "zephyr", ".config")
+                        goal = "_".join([plat.name, "_".join(
+                            tc.name.split("/")), "config-sanitycheck"])
+                        mg.add_build_goal(
+                            goal, os.path.join(
+                                ZEPHYR_BASE, tc.code_location),
+                            o, args, "config-sanitycheck.log",
+                            make_args="config-sanitycheck")
 
         info("Building testcase defconfigs...")
         results = mg.execute(defconfig_cb)
@@ -1543,7 +1597,8 @@ class TestSuite:
                         discards[instance] = "Testcase name filter"
                         continue
 
-                    if last_failed and (tc.name, plat.name) not in failed_tests:
+                    if last_failed and (
+                            tc.name, plat.name) not in failed_tests:
                         discards[instance] = "Passed or skipped during last run"
                         continue
 
@@ -1588,7 +1643,8 @@ class TestSuite:
                         continue
 
                     if tc.depends_on:
-                        dep_intersection = tc.depends_on.intersection(set(plat.supported))
+                        dep_intersection = tc.depends_on.intersection(
+                            set(plat.supported))
                         if dep_intersection != set(tc.depends_on):
                             discards[instance] = "No hardware support"
                             continue
@@ -1601,7 +1657,7 @@ class TestSuite:
                         discards[instance] = "Excluded tags per platform"
                         continue
 
-                    defconfig = {"ARCH" : arch.name, "PLATFORM" : plat.name}
+                    defconfig = {"ARCH": arch.name, "PLATFORM": plat.name}
                     defconfig.update(os.environ)
                     for p, tdefconfig in tc.defconfig.items():
                         if p == plat:
@@ -1612,11 +1668,13 @@ class TestSuite:
                         try:
                             res = expr_parser.parse(tc.tc_filter, defconfig)
                         except (ValueError, SyntaxError) as se:
-                            sys.stderr.write("Failed processing %s\n" % tc.yamlfile)
+                            sys.stderr.write(
+                                "Failed processing %s\n" % tc.yamlfile)
                             raise se
                         if not res:
-                            discards[instance] = ("defconfig doesn't satisfy expression '%s'" %
-                                    tc.tc_filter)
+                            discards[instance] = (
+                                "defconfig doesn't satisfy expression '%s'" %
+                                tc.tc_filter)
                             continue
 
                     instance.create_overlay()
@@ -1628,12 +1686,16 @@ class TestSuite:
 
                 if default_platforms and not tc.build_on_all:
                     if not tc.platform_whitelist:
-                        instances = list(filter(lambda tc: tc.platform.default, instance_list))
+                        instances = list(
+                            filter(
+                                lambda tc: tc.platform.default,
+                                instance_list))
                         self.add_instances(instances)
                     else:
                         self.add_instances(instance_list[:platform_limit])
 
-                    for instance in list(filter(lambda tc: not tc.platform.default, instance_list)):
+                    for instance in list(
+                            filter(lambda tc: not tc.platform.default, instance_list)):
                         discards[instance] = "Not a default test platform"
                 else:
                     self.add_instances(instance_list)
@@ -1644,8 +1706,8 @@ class TestSuite:
         for ti in ti_list:
             self.instances[ti.name] = ti
 
-    def execute(self, cb, cb_context, build_only, enable_slow, enable_asserts, enable_deprecations,
-                extra_args):
+    def execute(self, cb, cb_context, build_only, enable_slow,
+                enable_asserts, enable_deprecations, extra_args):
 
         def calc_one_elf_size(name, goal):
             if not goal.failed:
@@ -1655,15 +1717,17 @@ class TestSuite:
                 goal.metrics["rom_size"] = sc.get_rom_size()
                 goal.metrics["unrecognized"] = sc.unrecognized_sections()
 
-        mg = MakeGenerator(self.outdir, asserts=enable_asserts, deprecations=enable_deprecations)
+        mg = MakeGenerator(self.outdir, asserts=enable_asserts,
+                           deprecations=enable_deprecations)
         for i in self.instances.values():
-            mg.add_test_instance(i, build_only, enable_slow, self.coverage, extra_args)
+            mg.add_test_instance(i, build_only, enable_slow,
+                                 self.coverage, extra_args)
         self.goals = mg.execute(cb, cb_context)
 
         # Parallelize size calculation
         executor = concurrent.futures.ThreadPoolExecutor(CPU_COUNTS)
-        futures = [executor.submit(calc_one_elf_size, name, goal) \
-                        for name, goal in self.goals.items()]
+        futures = [executor.submit(calc_one_elf_size, name, goal)
+                   for name, goal in self.goals.items()]
         concurrent.futures.wait(futures)
 
         return self.goals
@@ -1674,26 +1738,26 @@ class TestSuite:
             cw = csv.DictWriter(csvfile, fieldnames, lineterminator=os.linesep)
             for instance in self.instances.values():
                 rowdict = {
-                           "path": os.path.dirname(instance.test.name),
-                           "test" : os.path.basename(instance.test.name),
-                           "platform" : instance.platform.name,
-                           "arch" : instance.platform.arch
-                           }
+                    "path": os.path.dirname(instance.test.name),
+                    "test": os.path.basename(instance.test.name),
+                    "platform": instance.platform.name,
+                    "arch": instance.platform.arch
+                }
                 cw.writerow(rowdict)
 
     def discard_report(self, filename):
-        if self.discards == None:
-            raise SanityRuntimeException("apply_filters() hasn't been run!")
+        if self.discards is None:
+            raise SanityRuntimeError("apply_filters() hasn't been run!")
 
         with open(filename, "wt") as csvfile:
             fieldnames = ["test", "arch", "platform", "reason"]
             cw = csv.DictWriter(csvfile, fieldnames, lineterminator=os.linesep)
             cw.writeheader()
             for instance, reason in self.discards.items():
-                rowdict = {"test" : instance.test.name,
-                           "arch" : instance.platform.arch,
-                           "platform" : instance.platform.name,
-                           "reason" : reason}
+                rowdict = {"test": instance.test.name,
+                           "arch": instance.platform.arch,
+                           "platform": instance.platform.name,
+                           "reason": reason}
                 cw.writerow(rowdict)
 
     def compare_metrics(self, filename):
@@ -1701,8 +1765,8 @@ class TestSuite:
         interesting_metrics = [("ram_size", int, True),
                                ("rom_size", int, True)]
 
-        if self.goals == None:
-            raise SanityRuntimeException("execute() hasn't been run!")
+        if self.goals is None:
+            raise SanityRuntimeError("execute() hasn't been run!")
 
         if not os.path.exists(filename):
             info("Cannot compare metrics, %s not found" % filename)
@@ -1737,8 +1801,8 @@ class TestSuite:
         return results
 
     def testcase_xunit_report(self, filename, duration, args):
-        if self.goals == None:
-            raise SanityRuntimeException("execute() hasn't been run!")
+        if self.goals is None:
+            raise SanityRuntimeError("execute() hasn't been run!")
 
         fails = 0
         passes = 0
@@ -1760,11 +1824,14 @@ class TestSuite:
         if os.path.exists(filename) and append:
             tree = ET.parse(filename)
             eleTestsuites = tree.getroot()
-            eleTestsuite =  tree.findall('testsuite')[0];
+            eleTestsuite = tree.findall('testsuite')[0]
         else:
             eleTestsuites = ET.Element('testsuites')
-            eleTestsuite = ET.SubElement(eleTestsuites, 'testsuite', name=run, time="%d" %duration,
-                    tests="%d" %(errors + passes + fails),  failures="%d" %fails,  errors="%d" %errors, skip="0")
+            eleTestsuite = ET.SubElement(eleTestsuites, 'testsuite',
+                                         name=run, time="%d" % duration,
+                                         tests="%d" % (errors + passes + fails),
+                                         failures="%d" % fails,
+                                         errors="%d" % errors, skip="0")
 
         handler_time = "0"
         for name, goal in self.goals.items():
@@ -1772,16 +1839,24 @@ class TestSuite:
             i = self.instances[name]
             if append:
                 for tc in eleTestsuite.findall('testcase'):
-                    if tc.get('classname') == "%s:%s" %(i.platform.name, i.test.name):
+                    if tc.get('classname') == "%s:%s" % (
+                            i.platform.name, i.test.name):
                         eleTestsuite.remove(tc)
 
             if not goal.failed and goal.qemu:
-                    handler_time = "%s" %(goal.metrics["handler_time"])
+                handler_time = "%s" % (goal.metrics["handler_time"])
 
-            eleTestcase = ET.SubElement(eleTestsuite, 'testcase', classname="%s:%s" %(i.platform.name, i.test.name), name="%s" %(name), time=handler_time)
+            eleTestcase = ET.SubElement(
+                eleTestsuite, 'testcase', classname="%s:%s" %
+                (i.platform.name, i.test.name), name="%s" %
+                (name), time=handler_time)
             if goal.failed:
-                failure = ET.SubElement(eleTestcase, 'failure', type="failure", message=goal.reason)
-                p = ("%s/%s/%s" %(args.outdir, i.platform.name, i.test.name))
+                failure = ET.SubElement(
+                    eleTestcase,
+                    'failure',
+                    type="failure",
+                    message=goal.reason)
+                p = ("%s/%s/%s" % (args.outdir, i.platform.name, i.test.name))
                 bl = os.path.join(p, "build.log")
                 if goal.reason != 'build_error':
                     bl = os.path.join(p, "qemu.log")
@@ -1799,8 +1874,8 @@ class TestSuite:
         f.close()
 
     def testcase_report(self, filename):
-        if self.goals == None:
-            raise SanityRuntimeException("execute() hasn't been run!")
+        if self.goals is None:
+            raise SanityRuntimeError("execute() hasn't been run!")
 
         with open(filename, "wt") as csvfile:
             fieldnames = ["test", "arch", "platform", "passed", "status",
@@ -1810,11 +1885,11 @@ class TestSuite:
             cw.writeheader()
             for name, goal in self.goals.items():
                 i = self.instances[name]
-                rowdict = {"test" : i.test.name,
-                           "arch" : i.platform.arch,
-                           "platform" : i.platform.name,
-                           "extra_args" : " ".join(i.test.extra_args),
-                           "qemu" : i.platform.qemu_support}
+                rowdict = {"test": i.test.name,
+                           "arch": i.platform.arch,
+                           "platform": i.platform.name,
+                           "extra_args": " ".join(i.test.extra_args),
+                           "qemu": i.platform.qemu_support}
                 if goal.failed:
                     rowdict["passed"] = False
                     rowdict["status"] = goal.reason
@@ -1829,139 +1904,181 @@ class TestSuite:
 
 def parse_arguments():
 
-    parser = argparse.ArgumentParser(description = __doc__,
-                                     formatter_class = argparse.RawDescriptionHelpFormatter)
+    parser = argparse.ArgumentParser(
+        description=__doc__,
+        formatter_class=argparse.RawDescriptionHelpFormatter)
     parser.fromfile_prefix_chars = "+"
 
-    parser.add_argument("-p", "--platform", action="append",
-            help="Platform filter for testing. This option may be used multiple "
-                 "times. Testcases will only be built/run on the platforms "
-                 "specified. If this option is not used, then platforms marked "
-                 "as default in the platform metadata file will be chosen "
-                 "to build and test. ")
-    parser.add_argument("-L", "--platform-limit", action="store", type=int,
-            metavar="N", default=1,
-            help="Controls what platforms are tested if --platform or "
-                 "--all are not used. For each architecture specified by "
-                 "--arch (defaults to all of them), choose the first "
-                 "N platforms to test in the arch-specific .yaml file "
-                 "'platforms' list. Defaults to 1.")
-    parser.add_argument("-a", "--arch", action="append",
-            help="Arch filter for testing. Takes precedence over --platform. "
-                 "If unspecified, test all arches. Multiple invocations "
-                 "are treated as a logical 'or' relationship")
-    parser.add_argument("-t", "--tag", action="append",
-            help="Specify tags to restrict which tests to run by tag value. "
-                 "Default is to not do any tag filtering. Multiple invocations "
-                 "are treated as a logical 'or' relationship")
+    parser.add_argument(
+        "-p", "--platform", action="append",
+        help="Platform filter for testing. This option may be used multiple "
+        "times. Testcases will only be built/run on the platforms "
+        "specified. If this option is not used, then platforms marked "
+        "as default in the platform metadata file will be chosen "
+        "to build and test. ")
+    parser.add_argument(
+        "-L", "--platform-limit", action="store", type=int, metavar="N",
+        default=1,
+        help="Controls what platforms are tested if --platform or "
+        "--all are not used. For each architecture specified by "
+        "--arch (defaults to all of them), choose the first "
+        "N platforms to test in the arch-specific .yaml file "
+        "'platforms' list. Defaults to 1.")
+    parser.add_argument(
+        "-a", "--arch", action="append",
+        help="Arch filter for testing. Takes precedence over --platform. "
+        "If unspecified, test all arches. Multiple invocations "
+        "are treated as a logical 'or' relationship")
+    parser.add_argument(
+        "-t", "--tag", action="append",
+        help="Specify tags to restrict which tests to run by tag value. "
+        "Default is to not do any tag filtering. Multiple invocations "
+        "are treated as a logical 'or' relationship")
     parser.add_argument("-e", "--exclude-tag", action="append",
-            help="Specify tags of tests that should not run. "
-                 "Default is to run all tests with all tags.")
-    parser.add_argument("-f", "--only-failed", action="store_true",
-            help="Run only those tests that failed the previous sanity check "
-                 "invocation.")
-    parser.add_argument("-c", "--config", action="append",
-            help="Specify platform configuration values filtering. This can be "
-                 "specified two ways: <config>=<value> or just <config>. The "
-                 "defconfig for all platforms will be "
-                 "checked. For the <config>=<value> case, only match defconfig "
-                 "that have that value defined. For the <config> case, match "
-                 "defconfig that have that value assigned to any value. "
-                 "Prepend a '!' to invert the match.")
-    parser.add_argument("-s", "--test", action="append",
-            help="Run only the specified test cases. These are named by "
-                 "<path to test project relative to "
-                 "--testcase-root>/<testcase.yaml section name>")
-    parser.add_argument("-l", "--all", action="store_true",
-            help="Build/test on all platforms. Any --platform arguments "
-                 "ignored.")
+                        help="Specify tags of tests that should not run. "
+                        "Default is to run all tests with all tags.")
+    parser.add_argument(
+        "-f",
+        "--only-failed",
+        action="store_true",
+        help="Run only those tests that failed the previous sanity check "
+        "invocation.")
+    parser.add_argument(
+        "-c", "--config", action="append",
+        help="Specify platform configuration values filtering. This can be "
+        "specified two ways: <config>=<value> or just <config>. The "
+        "defconfig for all platforms will be "
+        "checked. For the <config>=<value> case, only match defconfig "
+        "that have that value defined. For the <config> case, match "
+        "defconfig that have that value assigned to any value. "
+        "Prepend a '!' to invert the match.")
+    parser.add_argument(
+        "-s", "--test", action="append",
+        help="Run only the specified test cases. These are named by "
+        "<path to test project relative to "
+        "--testcase-root>/<testcase.yaml section name>")
+    parser.add_argument(
+        "-l", "--all", action="store_true",
+        help="Build/test on all platforms. Any --platform arguments "
+        "ignored.")
 
-    parser.add_argument("-o", "--testcase-report",
-            help="Output a CSV spreadsheet containing results of the test run")
-    parser.add_argument("-d", "--discard-report",
-            help="Output a CSV spreadsheet showing tests that were skipped "
-                 "and why")
+    parser.add_argument(
+        "-o", "--testcase-report",
+        help="Output a CSV spreadsheet containing results of the test run")
+    parser.add_argument(
+        "-d", "--discard-report",
+        help="Output a CSV spreadsheet showing tests that were skipped "
+        "and why")
     parser.add_argument("--compare-report",
-            help="Use this report file for size comparison")
+                        help="Use this report file for size comparison")
 
-    parser.add_argument("-B", "--subset",
-            help="Only run a subset of the tests, 1/4 for running the first 25%%, "
-                 "3/5 means run the 3rd fifth of the total. "
-                 "This option is useful when running a large number of tests on "
-                 "different hosts to speed up execution time.")
-    parser.add_argument("-y", "--dry-run", action="store_true",
-            help="Create the filtered list of test cases, but don't actually "
-                 "run them. Useful if you're just interested in "
-                 "--discard-report")
+    parser.add_argument(
+        "-B", "--subset",
+        help="Only run a subset of the tests, 1/4 for running the first 25%%, "
+        "3/5 means run the 3rd fifth of the total. "
+        "This option is useful when running a large number of tests on "
+        "different hosts to speed up execution time.")
+    parser.add_argument(
+        "-y", "--dry-run", action="store_true",
+        help="Create the filtered list of test cases, but don't actually "
+        "run them. Useful if you're just interested in "
+        "--discard-report")
 
-    parser.add_argument("-r", "--release", action="store_true",
-            help="Update the benchmark database with the results of this test "
-                 "run. Intended to be run by CI when tagging an official "
-                 "release. This database is used as a basis for comparison "
-                 "when looking for deltas in metrics such as footprint")
+    parser.add_argument(
+        "-r", "--release", action="store_true",
+        help="Update the benchmark database with the results of this test "
+        "run. Intended to be run by CI when tagging an official "
+        "release. This database is used as a basis for comparison "
+        "when looking for deltas in metrics such as footprint")
     parser.add_argument("-w", "--warnings-as-errors", action="store_true",
-            help="Treat warning conditions as errors")
-    parser.add_argument("-v", "--verbose", action="count", default=0,
-            help="Emit debugging information, call multiple times to increase "
-                 "verbosity")
-    parser.add_argument("-i", "--inline-logs", action="store_true",
-            help="Upon test failure, print relevant log data to stdout "
-                 "instead of just a path to it")
+                        help="Treat warning conditions as errors")
+    parser.add_argument(
+        "-v",
+        "--verbose",
+        action="count",
+        default=0,
+        help="Emit debugging information, call multiple times to increase "
+        "verbosity")
+    parser.add_argument(
+        "-i", "--inline-logs", action="store_true",
+        help="Upon test failure, print relevant log data to stdout "
+        "instead of just a path to it")
     parser.add_argument("--log-file", metavar="FILENAME", action="store",
-            help="log also to file")
-    parser.add_argument("-m", "--last-metrics", action="store_true",
-            help="Instead of comparing metrics from the last --release, "
-                 "compare with the results of the previous sanity check "
-                 "invocation")
-    parser.add_argument("-u", "--no-update", action="store_true",
-            help="do not update the results of the last run of the sanity "
-                 "checks")
-    parser.add_argument("-F", "--load-tests", metavar="FILENAME", action="store",
-            help="Load list of tests to be run from file.")
+                        help="log also to file")
+    parser.add_argument(
+        "-m", "--last-metrics", action="store_true",
+        help="Instead of comparing metrics from the last --release, "
+        "compare with the results of the previous sanity check "
+        "invocation")
+    parser.add_argument(
+        "-u",
+        "--no-update",
+        action="store_true",
+        help="do not update the results of the last run of the sanity "
+        "checks")
+    parser.add_argument(
+        "-F",
+        "--load-tests",
+        metavar="FILENAME",
+        action="store",
+        help="Load list of tests to be run from file.")
 
-    parser.add_argument("-E", "--save-tests", metavar="FILENAME", action="store",
-            help="Save list of tests to be run to file.")
+    parser.add_argument(
+        "-E",
+        "--save-tests",
+        metavar="FILENAME",
+        action="store",
+        help="Save list of tests to be run to file.")
 
-    parser.add_argument("-b", "--build-only", action="store_true",
-            help="Only build the code, do not execute any of it in QEMU")
-    parser.add_argument("-j", "--jobs", type=int,
-            help="Number of cores to use when building, defaults to "
-                 "number of CPUs * 2")
-    parser.add_argument("-H", "--footprint-threshold", type=float, default=5,
-            help="When checking test case footprint sizes, warn the user if "
-                 "the new app size is greater then the specified percentage "
-                 "from the last release. Default is 5. 0 to warn on any "
-                 "increase on app size")
-    parser.add_argument("-D", "--all-deltas", action="store_true",
-            help="Show all footprint deltas, positive or negative. Implies "
-                "--footprint-threshold=0")
+    parser.add_argument(
+        "-b", "--build-only", action="store_true",
+        help="Only build the code, do not execute any of it in QEMU")
+    parser.add_argument(
+        "-j", "--jobs", type=int,
+        help="Number of cores to use when building, defaults to "
+        "number of CPUs * 2")
+    parser.add_argument(
+        "-H", "--footprint-threshold", type=float, default=5,
+        help="When checking test case footprint sizes, warn the user if "
+        "the new app size is greater then the specified percentage "
+        "from the last release. Default is 5. 0 to warn on any "
+        "increase on app size")
+    parser.add_argument(
+        "-D", "--all-deltas", action="store_true",
+        help="Show all footprint deltas, positive or negative. Implies "
+        "--footprint-threshold=0")
     parser.add_argument("-O", "--outdir",
-            default="%s/sanity-out" % ZEPHYR_BASE,
-            help="Output directory for logs and binaries.")
-    parser.add_argument("-n", "--no-clean", action="store_true",
-            help="Do not delete the outdir before building. Will result in "
-                 "faster compilation since builds will be incremental")
-    parser.add_argument("-T", "--testcase-root", action="append", default=[],
-            help="Base directory to recursively search for test cases. All "
-                 "testcase.yaml files under here will be processed. May be "
-                 "called multiple times. Defaults to the 'samples' and "
-                 "'tests' directories in the Zephyr tree.")
-    board_root_list = ["%s/boards" % ZEPHYR_BASE , "%s/scripts/sanity_chk/boards" % ZEPHYR_BASE]
-    parser.add_argument("-A", "--board-root", action="append",
-            default=board_root_list,
-            help="Directory to search for board configuration files. All .yaml "
-                 "files in the directory will be processed.")
-    parser.add_argument("-z", "--size", action="append",
-            help="Don't run sanity  checks. Instead, produce a report to "
-                 "stdout detailing RAM/ROM sizes on the specified filenames. "
-                 "All other command line arguments ignored.")
-    parser.add_argument("-S", "--enable-slow", action="store_true",
-            help="Execute time-consuming test cases that have been marked "
-                 "as 'slow' in testcase.yaml. Normally these are only built.")
+                        default="%s/sanity-out" % ZEPHYR_BASE,
+                        help="Output directory for logs and binaries.")
+    parser.add_argument(
+        "-n", "--no-clean", action="store_true",
+        help="Do not delete the outdir before building. Will result in "
+        "faster compilation since builds will be incremental")
+    parser.add_argument(
+        "-T", "--testcase-root", action="append", default=[],
+        help="Base directory to recursively search for test cases. All "
+        "testcase.yaml files under here will be processed. May be "
+        "called multiple times. Defaults to the 'samples' and "
+        "'tests' directories in the Zephyr tree.")
+    board_root_list = ["%s/boards" % ZEPHYR_BASE,
+                       "%s/scripts/sanity_chk/boards" % ZEPHYR_BASE]
+    parser.add_argument(
+        "-A", "--board-root", action="append", default=board_root_list,
+        help="Directory to search for board configuration files. All .yaml "
+        "files in the directory will be processed.")
+    parser.add_argument(
+        "-z", "--size", action="append",
+        help="Don't run sanity  checks. Instead, produce a report to "
+        "stdout detailing RAM/ROM sizes on the specified filenames. "
+        "All other command line arguments ignored.")
+    parser.add_argument(
+        "-S", "--enable-slow", action="store_true",
+        help="Execute time-consuming test cases that have been marked "
+        "as 'slow' in testcase.yaml. Normally these are only built.")
     parser.add_argument("-R", "--enable-asserts", action="store_true",
-            help="Build all test cases with assertions enabled.")
+                        help="Build all test cases with assertions enabled.")
     parser.add_argument("-Q", "--error-on-deprecations", action="store_false",
-            help="Error on deprecation warnings.")
+                        help="Error on deprecation warnings.")
 
     parser.add_argument(
         "-x", "--extra-args", action="append", default=[],
@@ -1979,9 +2096,10 @@ def parse_arguments():
     )
 
     parser.add_argument("-C", "--coverage", action="store_true",
-            help="Scan for unit test coverage with gcov + lcov.")
+                        help="Scan for unit test coverage with gcov + lcov.")
 
     return parser.parse_args()
+
 
 def log_info(filename):
     filename = os.path.relpath(os.path.realpath(filename))
@@ -2001,6 +2119,7 @@ def log_info(filename):
     else:
         info("\tsee: " + COLOR_YELLOW + filename + COLOR_NORMAL)
 
+
 def terse_test_cb(instances, goals, goal):
     total_tests = len(goals)
     total_done = 0
@@ -2014,17 +2133,24 @@ def terse_test_cb(instances, goals, goal):
 
     if goal.failed:
         i = instances[goal.name]
-        info("\n\n{:<25} {:<50} {}FAILED{}: {}".format(i.platform.name,
-             i.test.name, COLOR_RED, COLOR_NORMAL, goal.reason))
+        info(
+            "\n\n{:<25} {:<50} {}FAILED{}: {}".format(
+                i.platform.name,
+                i.test.name,
+                COLOR_RED,
+                COLOR_NORMAL,
+                goal.reason))
         log_info(goal.get_error_log())
         info("")
 
-    sys.stdout.write("\rtotal complete: %s%4d/%4d%s  %2d%%  failed: %s%4d%s" % (
-                     COLOR_GREEN, total_done, total_tests, COLOR_NORMAL,
-                     int((float(total_done) / total_tests) * 100),
-                     COLOR_RED if total_failed > 0 else COLOR_NORMAL,
-                     total_failed, COLOR_NORMAL))
+    sys.stdout.write(
+        "\rtotal complete: %s%4d/%4d%s  %2d%%  failed: %s%4d%s" %
+        (COLOR_GREEN, total_done, total_tests, COLOR_NORMAL,
+         int((float(total_done) / total_tests) * 100),
+         COLOR_RED if total_failed > 0 else COLOR_NORMAL, total_failed,
+         COLOR_NORMAL))
     sys.stdout.flush()
+
 
 def chatty_test_cb(instances, goals, goal):
     i = instances[goal.name]
@@ -2055,8 +2181,9 @@ def size_report(sc):
               v["type"]))
 
     info("Totals: %d bytes (ROM), %d bytes (RAM)" %
-             (sc.rom_size, sc.ram_size))
+         (sc.rom_size, sc.ram_size))
     info("")
+
 
 def generate_coverage(outdir, ignores):
     with open(os.path.join(outdir, "coverage.log"), "a") as coveragelog:
@@ -2066,17 +2193,20 @@ def generate_coverage(outdir, ignores):
                          "--output-file", coveragefile], stdout=coveragelog)
         # We want to remove tests/* and tests/ztest/test/* but save tests/ztest
         subprocess.call(["lcov", "--extract", coveragefile,
-                        os.path.join(ZEPHYR_BASE, "tests", "ztest", "*"),
-                        "--output-file", ztestfile], stdout=coveragelog)
+                         os.path.join(ZEPHYR_BASE, "tests", "ztest", "*"),
+                         "--output-file", ztestfile], stdout=coveragelog)
         subprocess.call(["lcov", "--remove", ztestfile,
-                        os.path.join(ZEPHYR_BASE, "tests/ztest/test/*"),
-                        "--output-file", ztestfile], stdout=coveragelog)
+                         os.path.join(ZEPHYR_BASE, "tests/ztest/test/*"),
+                         "--output-file", ztestfile], stdout=coveragelog)
         for i in ignores:
-            subprocess.call(["lcov", "--remove", coveragefile, i,
-                            "--output-file", coveragefile], stdout=coveragelog)
+            subprocess.call(
+                ["lcov", "--remove", coveragefile, i, "--output-file",
+                 coveragefile],
+                stdout=coveragelog)
         subprocess.call(["genhtml", "-output-directory",
-                        os.path.join(outdir, "coverage"),
-                        coveragefile, ztestfile], stdout=coveragelog)
+                         os.path.join(outdir, "coverage"),
+                         coveragefile, ztestfile], stdout=coveragelog)
+
 
 def main():
     start_time = time.time()
@@ -2099,9 +2229,9 @@ def main():
     if args.subset:
         subset, sets = args.subset.split("/")
         if int(subset) > 0 and int(sets) >= int(subset):
-            info("Running only a subset: %s/%s" %(subset,sets))
+            info("Running only a subset: %s/%s" % (subset, sets))
         else:
-            error("You have provided a wrong subset value: %s." %args.subset)
+            error("You have provided a wrong subset value: %s." % args.subset)
             return
 
     if os.path.exists(args.outdir) and not args.no_clean:
@@ -2112,7 +2242,8 @@ def main():
         args.testcase_root = [os.path.join(ZEPHYR_BASE, "tests"),
                               os.path.join(ZEPHYR_BASE, "samples")]
 
-    ts = TestSuite(args.board_root, args.testcase_root, args.outdir, args.coverage)
+    ts = TestSuite(args.board_root, args.testcase_root,
+                   args.outdir, args.coverage)
 
     discards = []
     if args.load_tests:
@@ -2125,28 +2256,32 @@ def main():
 
     if VERBOSE > 1:
         for i, reason in discards.items():
-            debug("{:<25} {:<50} {}SKIPPED{}: {}".format(i.platform.name,
-                  i.test.name, COLOR_YELLOW, COLOR_NORMAL, reason))
+            debug(
+                "{:<25} {:<50} {}SKIPPED{}: {}".format(
+                    i.platform.name,
+                    i.test.name,
+                    COLOR_YELLOW,
+                    COLOR_NORMAL,
+                    reason))
 
-    ts.instances = OrderedDict(sorted(ts.instances.items(), key=lambda t: t[0]))
-
+    ts.instances = OrderedDict(
+        sorted(ts.instances.items(), key=lambda t: t[0]))
 
     if args.save_tests:
         ts.run_report(args.save_tests)
         return
 
-
     if args.subset:
         subset, sets = args.subset.split("/")
         total = len(ts.instances)
         per_set = round(total / int(sets))
-        start = (int(subset) - 1 ) * per_set
+        start = (int(subset) - 1) * per_set
         if subset == sets:
             end = total
         else:
             end = start + per_set
 
-        sliced_instances = islice(ts.instances.items(),start, end)
+        sliced_instances = islice(ts.instances.items(), start, end)
         ts.instances = OrderedDict(sliced_instances)
 
     info("%d tests selected, %d tests discarded due to filters" %
@@ -2156,13 +2291,23 @@ def main():
         return
 
     if VERBOSE or not TERMINAL:
-        goals = ts.execute(chatty_test_cb, ts.instances, args.build_only,
-                           args.enable_slow, args.enable_asserts, args.error_on_deprecations,
-                           args.extra_args)
+        goals = ts.execute(
+            chatty_test_cb,
+            ts.instances,
+            args.build_only,
+            args.enable_slow,
+            args.enable_asserts,
+            args.error_on_deprecations,
+            args.extra_args)
     else:
-        goals = ts.execute(terse_test_cb, ts.instances, args.build_only,
-                           args.enable_slow, args.enable_asserts, args.error_on_deprecations,
-                           args.extra_args)
+        goals = ts.execute(
+            terse_test_cb,
+            ts.instances,
+            args.build_only,
+            args.enable_slow,
+            args.enable_asserts,
+            args.error_on_deprecations,
+            args.extra_args)
         info("")
 
     # figure out which report to use for size comparison
@@ -2212,9 +2357,9 @@ def main():
 
     duration = time.time() - start_time
     info("%s%d of %d%s tests passed with %s%d%s warnings in %d seconds" %
-          (COLOR_RED if failed else COLOR_GREEN, len(goals) - failed,
-           len(goals), COLOR_NORMAL, COLOR_YELLOW if warnings else COLOR_NORMAL,
-           warnings, COLOR_NORMAL, duration))
+         (COLOR_RED if failed else COLOR_GREEN, len(goals) - failed,
+          len(goals), COLOR_NORMAL, COLOR_YELLOW if warnings else COLOR_NORMAL,
+          warnings, COLOR_NORMAL, duration))
 
     if args.testcase_report:
         ts.testcase_report(args.testcase_report)
@@ -2227,6 +2372,7 @@ def main():
         log_file.close()
     if failed or (warnings and args.warnings_as_errors):
         sys.exit(1)
+
 
 if __name__ == "__main__":
     main()

--- a/scripts/sanitycheck
+++ b/scripts/sanitycheck
@@ -632,15 +632,14 @@ class MakeGoal:
     defconfigs) which is why MakeGoal is a separate class from TestInstance.
     """
 
-    def __init__(self, name, text, qemu, make_log, build_log, run_log,
-                 qemu_log):
+    def __init__(self, name, text, handler, make_log, build_log, run_log, handler_log):
         self.name = name
         self.text = text
-        self.qemu = qemu
+        self.handler = handler
         self.make_log = make_log
         self.build_log = build_log
         self.run_log = run_log
-        self.qemu_log = qemu_log
+        self.handler_log = handler_log
         self.make_state = "waiting"
         self.failed = False
         self.finished = False
@@ -658,8 +657,8 @@ class MakeGoal:
             # Failure in sub-make for "make run", qemu probably failed to start
             return self.run_log
         elif self.make_state == "finished":
-            # QEMU finished, but timed out or otherwise wasn't successful
-            return self.qemu_log
+            # Handler finished, but timed out or otherwise wasn't successful
+            return self.handler_log
 
     def fail(self, reason):
         self.failed = True
@@ -828,8 +827,8 @@ class MakeGenerator:
         run_logfile = os.path.join(outdir, "run.log")
         qemu_logfile = os.path.join(outdir, "qemu.log")
 
-        qemu = QEMUHandler(name, outdir, qemu_logfile, timeout)
-        args.append("QEMU_PIPE=%s" % q.get_fifo())
+        qemu_handler = QEMUHandler(name, outdir, qemu_logfile, timeout)
+        args.append("QEMU_PIPE=%s" % qemu_handler.get_fifo())
         text = (self._get_rule_header(name) +
                 self._get_sub_make(name, "building", directory,
                                    outdir, build_logfile, args) +
@@ -837,7 +836,7 @@ class MakeGenerator:
                                    outdir, run_logfile,
                                    args, make_args="run") +
                 self._get_rule_footer(name))
-        self.goals[name] = MakeGoal(name, text, qemu, self.logfile, build_logfile,
+        self.goals[name] = MakeGoal(name, text, qemu_handler, self.logfile, build_logfile,
                                     run_logfile, qemu_logfile)
 
     def add_unit_goal(self, name, directory, outdir,
@@ -854,14 +853,13 @@ class MakeGenerator:
                 self._get_sub_make(name, "building", directory,
                                    outdir, build_logfile, args) +
                 self._get_rule_footer(name))
-        unit = UnitHandler(name, directory, outdir, run_logfile,
-                        valgrind_logfile, timeout)
-        self.goals[name] = MakeGoal(name, text, unit, self.logfile, build_logfile,
+        unit_handler = UnitHandler(name, directory, outdir, run_logfile, valgrind_logfile, timeout)
+        self.goals[name] = MakeGoal(name, text, unit_handler, self.logfile, build_logfile,
                                     run_logfile, valgrind_logfile)
 
-    def add_test_instance(
-            self, ti, build_only=False, enable_slow=False, coverage=False,
-            extra_args=[]):
+
+    def add_test_instance(self, ti, build_only=False, enable_slow=False, coverage=False,
+                          extra_args=[]):
         """Add a goal to build/test a TestInstance object
 
         @param ti TestInstance object to build. The status dictionary returned
@@ -933,21 +931,21 @@ class MakeGenerator:
                     # will cause the 'make run' invocation to exit with
                     # nonzero status.
                     # Need to distinguish this case from a compilation failure.
-                    if goal.qemu:
+                    if goal.handler:
                         goal.fail("qemu_crash")
                     else:
                         goal.fail("build_error")
                 else:
                     if state == "finished":
-                        if goal.qemu:
-                            if goal.qemu.unit:
+                        if goal.handler:
+                            if goal.handler.unit:
                                 # We can't run unit tests with Make
-                                goal.qemu.handle()
-                                if goal.qemu.returncode == 2:
-                                    goal.qemu_log = goal.qemu.valgrind_log
-                                elif goal.qemu.returncode:
-                                    goal.qemu_log = goal.qemu.run_log
-                            thread_status, metrics = goal.qemu.get_state()
+                                goal.handler.handle()
+                                if goal.handler.returncode == 2:
+                                    goal.handler_log = goal.handler.valgrind_log
+                                elif goal.handler.returncode:
+                                    goal.handler_log = goal.handler.run_log
+                            thread_status, metrics = goal.handler.get_state()
                             goal.metrics.update(metrics)
                             if thread_status == "passed":
                                 goal.success()
@@ -1833,8 +1831,8 @@ class TestSuite:
                             i.platform.name, i.test.name):
                         eleTestsuite.remove(tc)
 
-            if not goal.failed and goal.qemu:
-                handler_time = "%s" % (goal.metrics["handler_time"])
+            if not goal.failed and goal.handler:
+                handler_time = "%s" %(goal.metrics["handler_time"])
 
             eleTestcase = ET.SubElement(
                 eleTestsuite, 'testcase', classname="%s:%s" %
@@ -1885,7 +1883,7 @@ class TestSuite:
                     rowdict["status"] = goal.reason
                 else:
                     rowdict["passed"] = True
-                    if goal.qemu:
+                    if goal.handler:
                         rowdict["handler_time"] = goal.metrics["handler_time"]
                     rowdict["ram_size"] = goal.metrics["ram_size"]
                     rowdict["rom_size"] = goal.metrics["rom_size"]

--- a/scripts/sanitycheck
+++ b/scripts/sanitycheck
@@ -1141,11 +1141,8 @@ class Platform:
     def __init__(self, cfile):
         """Constructor.
 
-        @param arch Architecture object for this platform
-        @param name String name for this platform, same as BOARD
-        @param plat_dict SanityConfigParser output on the relevant section
-            in the architecture configuration file which has lots of metadata.
-            See the Architecture class.
+        @param cfile Path to platform configuration file, which gives
+            info about the platform to be added.
         """
         scp = SanityConfigParser(cfile, self.yaml_platform_schema)
         data = scp.data
@@ -1180,8 +1177,8 @@ class Architecture:
     def __init__(self, name, platforms):
         """Architecture constructor
 
-        @param cfile Path to Architecture configuration file, which gives
-            info about the arch and all the platforms for it
+        @param name String name for this architecture
+        @param platforms list of platforms belonging to this architecture
         """
         self.platforms = platforms
 
@@ -1198,9 +1195,9 @@ class TestCase:
     def __init__(self, testcase_root, workdir, name, tc_dict, yamlfile):
         """TestCase constructor.
 
-        This gets called by TestSuite as it finds and reads test yaml  files.
+        This gets called by TestSuite as it finds and reads test yaml files.
         Multiple TestCase instances may be generated from a single testcase.yaml,
-        each one corresponds to a section within that file.
+        each one corresponds to an entry within that file.
 
         We need to have a unique name for every single test case. Since
         a testcase.yaml can define multiple tests, the canonical name for
@@ -1210,12 +1207,12 @@ class TestCase:
             all the test cases live
         @param workdir Relative path to the project directory for this
             test application from the test_case root.
-        @param name Name of this test case, corresponding to the section name
+        @param name Name of this test case, corresponding to the entry name
             in the test case configuration file. For many test cases that just
             define one test, can be anything and is usually "test". This is
             really only used to distinguish between different cases when
             the testcase.yaml defines multiple tests
-        @param tc_dict Dictionary with section values for this test case
+        @param tc_dict Dictionary with test values for this test case
             from the testcase.yaml file
         """
         self.code_location = os.path.join(testcase_root, workdir)
@@ -1354,9 +1351,8 @@ class TestSuite:
 
                 workdir = os.path.relpath(dirpath, testcase_root)
 
-                for name, section in parsed_data.tests.items():
-                    tc_dict = parsed_data.get_test(
-                        name, testcase_valid_keys)
+                for name in parsed_data.tests.keys():
+                    tc_dict = parsed_data.get_test(name, testcase_valid_keys)
                     tc = TestCase(testcase_root, workdir, name, tc_dict,
                                   yaml_path)
 

--- a/tests/application_development/gen_inc_file/testcase.yaml
+++ b/tests/application_development/gen_inc_file/testcase.yaml
@@ -1,3 +1,3 @@
 tests:
-  - test:
-      tags: gen_inc_file
+  test:
+    tags: gen_inc_file

--- a/tests/benchmarks/app_kernel/testcase.yaml
+++ b/tests/benchmarks/app_kernel/testcase.yaml
@@ -1,7 +1,7 @@
 tests:
-  - test:
-      arch_whitelist: x86 arm
-      min_ram: 32
-      slow: true
-      tags: benchmark
-      timeout: 300
+  test:
+    arch_whitelist: x86 arm
+    min_ram: 32
+    slow: true
+    tags: benchmark
+    timeout: 300

--- a/tests/benchmarks/boot_time/testcase.yaml
+++ b/tests/benchmarks/boot_time/testcase.yaml
@@ -1,4 +1,4 @@
 tests:
-  - test:
-      arch_whitelist: x86 arm
-      tags: benchmark
+  test:
+    arch_whitelist: x86 arm
+    tags: benchmark

--- a/tests/benchmarks/footprint/testcase.yaml
+++ b/tests/benchmarks/footprint/testcase.yaml
@@ -1,24 +1,24 @@
 tests:
-  - footprint-min:
-      build_only: true
-      extra_args: TEST=min
-      tags: footprint
-  - footprint-reg:
-      arch_whitelist: x86 arm
-      build_only: true
-      extra_args: TEST=reg
-      min_ram: 8
-      platform_exclude: quark_d2000_crb
-      tags: footprint
-  - footprint-max:
-      arch_whitelist: x86 arm
-      build_only: true
-      extra_args: TEST=max
-      min_ram: 8
-      tags: footprint
-  - footprint-float:
-      arch_whitelist: x86 arm
-      build_only: true
-      extra_args: TEST=float
-      filter: CONFIG_FLOAT
-      tags: footprint
+  footprint-float:
+    arch_whitelist: x86 arm
+    build_only: true
+    extra_args: TEST=float
+    filter: CONFIG_FLOAT
+    tags: footprint
+  footprint-max:
+    arch_whitelist: x86 arm
+    build_only: true
+    extra_args: TEST=max
+    min_ram: 8
+    tags: footprint
+  footprint-min:
+    build_only: true
+    extra_args: TEST=min
+    tags: footprint
+  footprint-reg:
+    arch_whitelist: x86 arm
+    build_only: true
+    extra_args: TEST=reg
+    min_ram: 8
+    platform_exclude: quark_d2000_crb
+    tags: footprint

--- a/tests/benchmarks/latency_measure/testcase.yaml
+++ b/tests/benchmarks/latency_measure/testcase.yaml
@@ -1,5 +1,5 @@
 tests:
-  - test:
-      arch_whitelist: x86 arm
-      filter: CONFIG_PRINTK
-      tags: benchmark
+  test:
+    arch_whitelist: x86 arm
+    filter: CONFIG_PRINTK
+    tags: benchmark

--- a/tests/benchmarks/object_footprint/testcase.yaml
+++ b/tests/benchmarks/object_footprint/testcase.yaml
@@ -1,56 +1,56 @@
 tests:
-  - test_001:
-      build_only: true
-      extra_args: CONF_FILE=prj01.conf
-      platform_whitelist: qemu_x86
-      tags: footprint
-  - test_002:
-      build_only: true
-      extra_args: CONF_FILE=prj02.conf
-      platform_whitelist: qemu_x86
-      tags: footprint
-  - test_003:
-      build_only: true
-      extra_args: CONF_FILE=prj03.conf
-      platform_whitelist: qemu_x86
-      tags: footprint
-  - test_004:
-      build_only: true
-      extra_args: CONF_FILE=prj04.conf
-      platform_whitelist: qemu_x86
-      tags: footprint
-  - test_005:
-      build_only: true
-      extra_args: CONF_FILE=prj05.conf
-      platform_whitelist: qemu_x86
-      tags: footprint
-  - test_006:
-      build_only: true
-      extra_args: CONF_FILE=prj06.conf
-      platform_whitelist: qemu_x86
-      tags: footprint
-  - test_007:
-      build_only: true
-      extra_args: CONF_FILE=prj07.conf
-      platform_whitelist: qemu_x86
-      tags: footprint
-  - test_008:
-      build_only: true
-      extra_args: CONF_FILE=prj08.conf
-      platform_whitelist: qemu_x86
-      tags: footprint
-  - test_009:
-      build_only: true
-      extra_args: CONF_FILE=prj09.conf
-      platform_whitelist: qemu_x86
-      tags: footprint
-  - test_010:
-      build_only: true
-      extra_args: CONF_FILE=prj10.conf
-      platform_whitelist: qemu_x86
-      tags: footprint
-  - test_011:
-      build_only: true
-      extra_args: CONF_FILE=prj11.conf
-      platform_whitelist: qemu_x86
-      tags: footprint
+  test_001:
+    build_only: true
+    extra_args: CONF_FILE=prj01.conf
+    platform_whitelist: qemu_x86
+    tags: footprint
+  test_002:
+    build_only: true
+    extra_args: CONF_FILE=prj02.conf
+    platform_whitelist: qemu_x86
+    tags: footprint
+  test_003:
+    build_only: true
+    extra_args: CONF_FILE=prj03.conf
+    platform_whitelist: qemu_x86
+    tags: footprint
+  test_004:
+    build_only: true
+    extra_args: CONF_FILE=prj04.conf
+    platform_whitelist: qemu_x86
+    tags: footprint
+  test_005:
+    build_only: true
+    extra_args: CONF_FILE=prj05.conf
+    platform_whitelist: qemu_x86
+    tags: footprint
+  test_006:
+    build_only: true
+    extra_args: CONF_FILE=prj06.conf
+    platform_whitelist: qemu_x86
+    tags: footprint
+  test_007:
+    build_only: true
+    extra_args: CONF_FILE=prj07.conf
+    platform_whitelist: qemu_x86
+    tags: footprint
+  test_008:
+    build_only: true
+    extra_args: CONF_FILE=prj08.conf
+    platform_whitelist: qemu_x86
+    tags: footprint
+  test_009:
+    build_only: true
+    extra_args: CONF_FILE=prj09.conf
+    platform_whitelist: qemu_x86
+    tags: footprint
+  test_010:
+    build_only: true
+    extra_args: CONF_FILE=prj10.conf
+    platform_whitelist: qemu_x86
+    tags: footprint
+  test_011:
+    build_only: true
+    extra_args: CONF_FILE=prj11.conf
+    platform_whitelist: qemu_x86
+    tags: footprint

--- a/tests/benchmarks/sys_kernel/testcase.yaml
+++ b/tests/benchmarks/sys_kernel/testcase.yaml
@@ -1,5 +1,5 @@
 tests:
-  - test:
-      arch_whitelist: x86
-      min_ram: 32
-      tags: benchmark
+  test:
+    arch_whitelist: x86
+    min_ram: 32
+    tags: benchmark

--- a/tests/benchmarks/timing_info/testcase.yaml
+++ b/tests/benchmarks/timing_info/testcase.yaml
@@ -1,4 +1,4 @@
 tests:
-  - test:
-      arch_whitelist: x86 arm
-      tags: benchmark
+  test:
+    arch_whitelist: x86 arm
+    tags: benchmark

--- a/tests/bluetooth/bluetooth/testcase.yaml
+++ b/tests/bluetooth/bluetooth/testcase.yaml
@@ -1,4 +1,4 @@
 tests:
-  - test:
-      platform_whitelist: qemu_x86_iamcu qemu_cortex_m3
-      tags: bluetooth
+  test:
+    platform_whitelist: qemu_x86_iamcu qemu_cortex_m3
+    tags: bluetooth

--- a/tests/bluetooth/init/testcase.yaml
+++ b/tests/bluetooth/init/testcase.yaml
@@ -2,92 +2,92 @@ common:
   build_only: true
   tags: bluetooth
 tests:
-  - test:
-      platform_whitelist: qemu_cortex_m3
-  - test_controller:
-      extra_args: CONF_FILE=prj_controller.conf
-      platform_whitelist: nrf52840_pca10056 nrf52_pca10040
-        nrf51_pca10028 arduino_101_ble 96b_nitrogen
-  - test_controller_4_0:
-      extra_args: CONF_FILE=prj_controller_4_0.conf
-      platform_whitelist: nrf52840_pca10056 nrf52_pca10040
-        nrf51_pca10028 arduino_101_ble
-  - test_controller_dbg:
-      extra_args: CONF_FILE=prj_controller_dbg.conf
-      platform_whitelist: nrf52840_pca10056 nrf52_pca10040
-        nrf51_pca10028 96b_nitrogen
-  - test_h5:
-      extra_args: CONF_FILE=prj_h5.conf
-      platform_whitelist: qemu_cortex_m3
-  - test_h5_dbg:
-      extra_args: CONF_FILE=prj_h5_dbg.conf
-      platform_whitelist: qemu_cortex_m3
-  - test_0:
-      extra_args: CONF_FILE=prj_0.conf
-      platform_whitelist: qemu_cortex_m3
-  - test_1:
-      extra_args: CONF_FILE=prj_1.conf
-      platform_whitelist: qemu_cortex_m3
-  - test_2:
-      extra_args: CONF_FILE=prj_2.conf
-      platform_whitelist: qemu_cortex_m3
-  - test_3:
-      extra_args: CONF_FILE=prj_3.conf
-      platform_whitelist: qemu_cortex_m3
-  - test_4:
-      extra_args: CONF_FILE=prj_4.conf
-      platform_whitelist: qemu_cortex_m3
-  - test_5:
-      extra_args: CONF_FILE=prj_5.conf
-      platform_whitelist: qemu_cortex_m3
-  - test_6:
-      extra_args: CONF_FILE=prj_6.conf
-      platform_whitelist: qemu_cortex_m3
-  - test_7:
-      extra_args: CONF_FILE=prj_7.conf
-      platform_whitelist: qemu_cortex_m3
-  - test_8:
-      extra_args: CONF_FILE=prj_8.conf
-      platform_whitelist: qemu_cortex_m3
-  - test_9:
-      extra_args: CONF_FILE=prj_9.conf
-      platform_whitelist: qemu_cortex_m3
-  - test_10:
-      extra_args: CONF_FILE=prj_10.conf
-      platform_whitelist: qemu_cortex_m3
-  - test_11:
-      extra_args: CONF_FILE=prj_11.conf
-      platform_whitelist: qemu_cortex_m3
-  - test_12:
-      extra_args: CONF_FILE=prj_12.conf
-      platform_whitelist: qemu_cortex_m3
-  - test_13:
-      extra_args: CONF_FILE=prj_13.conf
-      platform_whitelist: qemu_cortex_m3
-  - test_14:
-      extra_args: CONF_FILE=prj_14.conf
-      platform_whitelist: qemu_cortex_m3
-  - test_15:
-      extra_args: CONF_FILE=prj_15.conf
-      platform_whitelist: qemu_cortex_m3
-  - test_16:
-      extra_args: CONF_FILE=prj_16.conf
-      platform_whitelist: qemu_cortex_m3
-  - test_17:
-      extra_args: CONF_FILE=prj_17.conf
-      platform_whitelist: qemu_cortex_m3
-  - test_18:
-      extra_args: CONF_FILE=prj_18.conf
-      platform_whitelist: qemu_cortex_m3
-  - test_19:
-      extra_args: CONF_FILE=prj_19.conf
-      platform_whitelist: qemu_cortex_m3
-  - test_20:
-      extra_args: CONF_FILE=prj_20.conf
-      platform_whitelist: qemu_cortex_m3
-  - test_21:
-      extra_args: CONF_FILE=prj_21.conf
-      platform_whitelist: qemu_cortex_m3
-  - test_22:
-      extra_args: CONF_FILE=prj_22.conf
-      platform_whitelist: qemu_cortex_m3
+  test:
+    platform_whitelist: qemu_cortex_m3
+  test_0:
+    extra_args: CONF_FILE=prj_0.conf
+    platform_whitelist: qemu_cortex_m3
+  test_1:
+    extra_args: CONF_FILE=prj_1.conf
+    platform_whitelist: qemu_cortex_m3
+  test_10:
+    extra_args: CONF_FILE=prj_10.conf
+    platform_whitelist: qemu_cortex_m3
+  test_11:
+    extra_args: CONF_FILE=prj_11.conf
+    platform_whitelist: qemu_cortex_m3
+  test_12:
+    extra_args: CONF_FILE=prj_12.conf
+    platform_whitelist: qemu_cortex_m3
+  test_13:
+    extra_args: CONF_FILE=prj_13.conf
+    platform_whitelist: qemu_cortex_m3
+  test_14:
+    extra_args: CONF_FILE=prj_14.conf
+    platform_whitelist: qemu_cortex_m3
+  test_15:
+    extra_args: CONF_FILE=prj_15.conf
+    platform_whitelist: qemu_cortex_m3
+  test_16:
+    extra_args: CONF_FILE=prj_16.conf
+    platform_whitelist: qemu_cortex_m3
+  test_17:
+    extra_args: CONF_FILE=prj_17.conf
+    platform_whitelist: qemu_cortex_m3
+  test_18:
+    extra_args: CONF_FILE=prj_18.conf
+    platform_whitelist: qemu_cortex_m3
+  test_19:
+    extra_args: CONF_FILE=prj_19.conf
+    platform_whitelist: qemu_cortex_m3
+  test_2:
+    extra_args: CONF_FILE=prj_2.conf
+    platform_whitelist: qemu_cortex_m3
+  test_20:
+    extra_args: CONF_FILE=prj_20.conf
+    platform_whitelist: qemu_cortex_m3
+  test_21:
+    extra_args: CONF_FILE=prj_21.conf
+    platform_whitelist: qemu_cortex_m3
+  test_22:
+    extra_args: CONF_FILE=prj_22.conf
+    platform_whitelist: qemu_cortex_m3
+  test_3:
+    extra_args: CONF_FILE=prj_3.conf
+    platform_whitelist: qemu_cortex_m3
+  test_4:
+    extra_args: CONF_FILE=prj_4.conf
+    platform_whitelist: qemu_cortex_m3
+  test_5:
+    extra_args: CONF_FILE=prj_5.conf
+    platform_whitelist: qemu_cortex_m3
+  test_6:
+    extra_args: CONF_FILE=prj_6.conf
+    platform_whitelist: qemu_cortex_m3
+  test_7:
+    extra_args: CONF_FILE=prj_7.conf
+    platform_whitelist: qemu_cortex_m3
+  test_8:
+    extra_args: CONF_FILE=prj_8.conf
+    platform_whitelist: qemu_cortex_m3
+  test_9:
+    extra_args: CONF_FILE=prj_9.conf
+    platform_whitelist: qemu_cortex_m3
+  test_controller:
+    extra_args: CONF_FILE=prj_controller.conf
+    platform_whitelist: nrf52840_pca10056 nrf52_pca10040
+      nrf51_pca10028 arduino_101_ble 96b_nitrogen
+  test_controller_4_0:
+    extra_args: CONF_FILE=prj_controller_4_0.conf
+    platform_whitelist: nrf52840_pca10056 nrf52_pca10040
+      nrf51_pca10028 arduino_101_ble
+  test_controller_dbg:
+    extra_args: CONF_FILE=prj_controller_dbg.conf
+    platform_whitelist: nrf52840_pca10056 nrf52_pca10040
+      nrf51_pca10028 96b_nitrogen
+  test_h5:
+    extra_args: CONF_FILE=prj_h5.conf
+    platform_whitelist: qemu_cortex_m3
+  test_h5_dbg:
+    extra_args: CONF_FILE=prj_h5_dbg.conf
+    platform_whitelist: qemu_cortex_m3

--- a/tests/bluetooth/mesh/testcase.yaml
+++ b/tests/bluetooth/mesh/testcase.yaml
@@ -1,40 +1,40 @@
 tests:
-  - test:
-      build_only: true
-      platform_whitelist: qemu_x86 nrf51_pca10028 nrf52840_pca10056
-      tags: bluetooth mesh
-  - test_dbg:
-      build_only: true
-      extra_args: CONF_FILE=dbg.conf
-      platform_whitelist: qemu_x86 nrf51_pca10028 nrf52840_pca10056
-      tags: bluetooth mesh
-  - test_friend:
-      build_only: true
-      extra_args: CONF_FILE=friend.conf
-      platform_whitelist: qemu_x86 nrf51_pca10028 nrf52840_pca10056
-      tags: bluetooth mesh
-  - test_lpn:
-      build_only: true
-      extra_args: CONF_FILE=lpn.conf
-      platform_whitelist: qemu_x86 nrf51_pca10028 nrf52840_pca10056
-      tags: bluetooth mesh
-  - test_pb_gatt:
-      build_only: true
-      extra_args: CONF_FILE=pb_gatt.conf
-      platform_whitelist: qemu_x86 nrf51_pca10028 nrf52840_pca10056
-      tags: bluetooth mesh
-  - test_gatt:
-      build_only: true
-      extra_args: CONF_FILE=gatt.conf
-      platform_whitelist: qemu_x86 nrf51_pca10028 nrf52840_pca10056
-      tags: bluetooth mesh
-  - test_proxy:
-      build_only: true
-      extra_args: CONF_FILE=proxy.conf
-      platform_whitelist: qemu_x86 nrf51_pca10028 nrf52840_pca10056
-      tags: bluetooth mesh
-  - test_microbit:
-      build_only: true
-      extra_args: CONF_FILE=microbit.conf
-      platform_whitelist: bbc_microbit
-      tags: bluetooth mesh
+  test:
+    build_only: true
+    platform_whitelist: qemu_x86 nrf51_pca10028 nrf52840_pca10056
+    tags: bluetooth mesh
+  test_dbg:
+    build_only: true
+    extra_args: CONF_FILE=dbg.conf
+    platform_whitelist: qemu_x86 nrf51_pca10028 nrf52840_pca10056
+    tags: bluetooth mesh
+  test_friend:
+    build_only: true
+    extra_args: CONF_FILE=friend.conf
+    platform_whitelist: qemu_x86 nrf51_pca10028 nrf52840_pca10056
+    tags: bluetooth mesh
+  test_gatt:
+    build_only: true
+    extra_args: CONF_FILE=gatt.conf
+    platform_whitelist: qemu_x86 nrf51_pca10028 nrf52840_pca10056
+    tags: bluetooth mesh
+  test_lpn:
+    build_only: true
+    extra_args: CONF_FILE=lpn.conf
+    platform_whitelist: qemu_x86 nrf51_pca10028 nrf52840_pca10056
+    tags: bluetooth mesh
+  test_microbit:
+    build_only: true
+    extra_args: CONF_FILE=microbit.conf
+    platform_whitelist: bbc_microbit
+    tags: bluetooth mesh
+  test_pb_gatt:
+    build_only: true
+    extra_args: CONF_FILE=pb_gatt.conf
+    platform_whitelist: qemu_x86 nrf51_pca10028 nrf52840_pca10056
+    tags: bluetooth mesh
+  test_proxy:
+    build_only: true
+    extra_args: CONF_FILE=proxy.conf
+    platform_whitelist: qemu_x86 nrf51_pca10028 nrf52840_pca10056
+    tags: bluetooth mesh

--- a/tests/bluetooth/mesh_shell/testcase.yaml
+++ b/tests/bluetooth/mesh_shell/testcase.yaml
@@ -1,5 +1,5 @@
 tests:
-  - test:
-      build_only: true
-      platform_whitelist: qemu_cortex_m3 qemu_x86 nrf51_pca10028
-      tags: bluetooth
+  test:
+    build_only: true
+    platform_whitelist: qemu_cortex_m3 qemu_x86 nrf51_pca10028
+    tags: bluetooth

--- a/tests/bluetooth/shell/testcase.yaml
+++ b/tests/bluetooth/shell/testcase.yaml
@@ -1,10 +1,10 @@
 tests:
-  - test:
-      build_only: true
-      platform_whitelist: qemu_cortex_m3 qemu_x86 arduino_101
-      tags: bluetooth
-  - test_br:
-      build_only: true
-      extra_args: CONF_FILE="prj_br.conf"
-      platform_whitelist: qemu_cortex_m3 qemu_x86
-      tags: bluetooth
+  test:
+    build_only: true
+    platform_whitelist: qemu_cortex_m3 qemu_x86 arduino_101
+    tags: bluetooth
+  test_br:
+    build_only: true
+    extra_args: CONF_FILE="prj_br.conf"
+    platform_whitelist: qemu_cortex_m3 qemu_x86
+    tags: bluetooth

--- a/tests/bluetooth/tester/testcase.yaml
+++ b/tests/bluetooth/tester/testcase.yaml
@@ -1,5 +1,5 @@
 tests:
-  - test:
-      build_only: true
-      platform_whitelist: qemu_x86_iamcu
-      tags: bluetooth
+  test:
+    build_only: true
+    platform_whitelist: qemu_x86_iamcu
+    tags: bluetooth

--- a/tests/crypto/aes/testcase.yaml
+++ b/tests/crypto/aes/testcase.yaml
@@ -1,3 +1,3 @@
 tests:
-  - test:
-      tags: crypto aes
+  test:
+    tags: crypto aes

--- a/tests/crypto/cbc_mode/testcase.yaml
+++ b/tests/crypto/cbc_mode/testcase.yaml
@@ -1,3 +1,3 @@
 tests:
-  - test:
-      tags: crypto aes cbc
+  test:
+    tags: crypto aes cbc

--- a/tests/crypto/ccm_mode/testcase.yaml
+++ b/tests/crypto/ccm_mode/testcase.yaml
@@ -1,3 +1,3 @@
 tests:
-  - test:
-      tags: crypto aes ccm
+  test:
+    tags: crypto aes ccm

--- a/tests/crypto/cmac_mode/testcase.yaml
+++ b/tests/crypto/cmac_mode/testcase.yaml
@@ -1,3 +1,3 @@
 tests:
-  - test:
-      tags: crypto aes cmac
+  test:
+    tags: crypto aes cmac

--- a/tests/crypto/ctr_mode/testcase.yaml
+++ b/tests/crypto/ctr_mode/testcase.yaml
@@ -1,3 +1,3 @@
 tests:
-  - test:
-      tags: crypto aes ctr
+  test:
+    tags: crypto aes ctr

--- a/tests/crypto/ctr_prng/testcase.yaml
+++ b/tests/crypto/ctr_prng/testcase.yaml
@@ -1,3 +1,3 @@
 tests:
-  - test:
-      tags: crypto ctr prng
+  test:
+    tags: crypto ctr prng

--- a/tests/crypto/ecc_dh/testcase.yaml
+++ b/tests/crypto/ecc_dh/testcase.yaml
@@ -1,6 +1,6 @@
 tests:
-  - test:
-      min_ram: 16
-      slow: true
-      tags: crypto ecc dh
-      timeout: 500
+  test:
+    min_ram: 16
+    slow: true
+    tags: crypto ecc dh
+    timeout: 500

--- a/tests/crypto/ecc_dsa/testcase.yaml
+++ b/tests/crypto/ecc_dsa/testcase.yaml
@@ -1,5 +1,5 @@
 tests:
-  - test:
-      min_ram: 16
-      tags: crypto ecc dsa
-      timeout: 180
+  test:
+    min_ram: 16
+    tags: crypto ecc dsa
+    timeout: 180

--- a/tests/crypto/hmac/testcase.yaml
+++ b/tests/crypto/hmac/testcase.yaml
@@ -1,4 +1,4 @@
 tests:
-  - test:
-      min_ram: 20
-      tags: crypto sha256 hmac
+  test:
+    min_ram: 20
+    tags: crypto sha256 hmac

--- a/tests/crypto/hmac_prng/testcase.yaml
+++ b/tests/crypto/hmac_prng/testcase.yaml
@@ -1,4 +1,4 @@
 tests:
-  - test:
-      min_ram: 48
-      tags: crypto sha256 hmac prng
+  test:
+    min_ram: 48
+    tags: crypto sha256 hmac prng

--- a/tests/crypto/mbedtls/testcase.yaml
+++ b/tests/crypto/mbedtls/testcase.yaml
@@ -1,8 +1,8 @@
 tests:
-  - test:
-      filter: not CONFIG_DEBUG
-      min_flash: 33
-      min_ram: 32
-      tags: crypto mbedtls
-      timeout: 200
-      platform_exclude: esp32
+  test:
+    filter: not CONFIG_DEBUG
+    min_flash: 33
+    min_ram: 32
+    platform_exclude: esp32
+    tags: crypto mbedtls
+    timeout: 200

--- a/tests/crypto/sha256/testcase.yaml
+++ b/tests/crypto/sha256/testcase.yaml
@@ -1,10 +1,10 @@
 tests:
-  - test:
-      arch_whitelist: arm arc x86
-      min_ram: 48
-      tags: crypto sha256
-      timeout: 600
-  - test_nios2:
-      arch_whitelist: nios2
-      tags: crypto sha256
-      timeout: 600
+  test:
+    arch_whitelist: arm arc x86
+    min_ram: 48
+    tags: crypto sha256
+    timeout: 600
+  test_nios2:
+    arch_whitelist: nios2
+    tags: crypto sha256
+    timeout: 600

--- a/tests/drivers/adc/adc_api/testcase.yaml
+++ b/tests/drivers/adc/adc_api/testcase.yaml
@@ -1,30 +1,30 @@
 common:
   tags: drivers adc
 tests:
-  - test:
-      depends_on: adc
-  - test_resolution_6:
-      extra_configs:
-        - CONFIG_ADC_QMSI_SAMPLE_WIDTH=6
-      platform_whitelist: quark_se_c1000_ss_devboard
-      tags: hwtest
-  - test_resolution_8:
-      extra_configs:
-        - CONFIG_ADC_QMSI_SAMPLE_WIDTH=8
-      platform_whitelist: quark_se_c1000_ss_devboard
-      tags: hwtest
-  - test_resolution_10:
-      extra_configs:
-        - CONFIG_ADC_QMSI_SAMPLE_WIDTH=10
-      platform_whitelist: quark_se_c1000_ss_devboard
-      tags: hwtest
-  - test_resolution_12:
-      extra_configs:
-        - CONFIG_ADC_QMSI_SAMPLE_WIDTH=12
-      platform_whitelist: quark_se_c1000_ss_devboard
-      tags: hwtest
-  - test_poll_mode:
-      extra_configs:
-        - CONFIG_ADC_QMSI_POLL=y
-      platform_whitelist: quark_se_c1000_ss_devboard
-      tags: hwtest
+  test:
+    depends_on: adc
+  test_poll_mode:
+    extra_configs:
+      - CONFIG_ADC_QMSI_POLL=y
+    platform_whitelist: quark_se_c1000_ss_devboard
+    tags: hwtest
+  test_resolution_10:
+    extra_configs:
+      - CONFIG_ADC_QMSI_SAMPLE_WIDTH=10
+    platform_whitelist: quark_se_c1000_ss_devboard
+    tags: hwtest
+  test_resolution_12:
+    extra_configs:
+      - CONFIG_ADC_QMSI_SAMPLE_WIDTH=12
+    platform_whitelist: quark_se_c1000_ss_devboard
+    tags: hwtest
+  test_resolution_6:
+    extra_configs:
+      - CONFIG_ADC_QMSI_SAMPLE_WIDTH=6
+    platform_whitelist: quark_se_c1000_ss_devboard
+    tags: hwtest
+  test_resolution_8:
+    extra_configs:
+      - CONFIG_ADC_QMSI_SAMPLE_WIDTH=8
+    platform_whitelist: quark_se_c1000_ss_devboard
+    tags: hwtest

--- a/tests/drivers/adc/adc_simple/testcase.yaml
+++ b/tests/drivers/adc/adc_simple/testcase.yaml
@@ -1,4 +1,4 @@
 tests:
-  - test:
-     depends_on: adc
-     tags: driver adc
+  test:
+    depends_on: adc
+    tags: driver adc

--- a/tests/drivers/aio/aio_basic_api/testcase.yaml
+++ b/tests/drivers/aio/aio_basic_api/testcase.yaml
@@ -1,5 +1,5 @@
 tests:
-  - test_aio:
-      build_only: true
-      depends_on: aio
-      tags: drivers
+  test_aio:
+    build_only: true
+    depends_on: aio
+    tags: drivers

--- a/tests/drivers/aon_counter/aon_api/testcase.yaml
+++ b/tests/drivers/aon_counter/aon_api/testcase.yaml
@@ -1,5 +1,5 @@
 tests:
-  - test_aon:
-      platform_whitelist: quark_se_c1000_devboard quark_se_c1000_ss_devboard
-        quark_d2000_crb arduino_101 arduino_101_sss
-      tags: drivers
+  test_aon:
+    platform_whitelist: quark_se_c1000_devboard quark_se_c1000_ss_devboard
+      quark_d2000_crb arduino_101 arduino_101_sss
+    tags: drivers

--- a/tests/drivers/build_all/testcase.yaml
+++ b/tests/drivers/build_all/testcase.yaml
@@ -1,29 +1,29 @@
 tests:
-  - test_build_drivers:
-      build_only: true
-      min_ram: 16
-      tags: drivers footprint
-  - test_build_sensors_a_m:
-      build_only: true
-      extra_args: CONF_FILE=sensors_a_m.conf
-      min_ram: 32
-      platform_exclude: zedboard_pulpino
-      tags: drivers footprint
-  - test_build_sensors_n_z:
-      build_only: true
-      extra_args: CONF_FILE=sensors_n_z.conf
-      min_ram: 32
-      platform_exclude: zedboard_pulpino
-      tags: drivers footprint
-  - test_build_sensor_triggers:
-      build_only: true
-      extra_args: CONF_FILE=sensors_trigger.conf
-      min_ram: 32
-      platform_exclude: zedboard_pulpino
-      tags: drivers footprint
-  - test_build_ethernet:
-      build_only: true
-      extra_args: CONF_FILE=ethernet.conf
-      min_ram: 32
-      platform_exclude: zedboard_pulpino
-      tags: drivers footprint
+  test_build_drivers:
+    build_only: true
+    min_ram: 16
+    tags: drivers footprint
+  test_build_ethernet:
+    build_only: true
+    extra_args: CONF_FILE=ethernet.conf
+    min_ram: 32
+    platform_exclude: zedboard_pulpino
+    tags: drivers footprint
+  test_build_sensor_triggers:
+    build_only: true
+    extra_args: CONF_FILE=sensors_trigger.conf
+    min_ram: 32
+    platform_exclude: zedboard_pulpino
+    tags: drivers footprint
+  test_build_sensors_a_m:
+    build_only: true
+    extra_args: CONF_FILE=sensors_a_m.conf
+    min_ram: 32
+    platform_exclude: zedboard_pulpino
+    tags: drivers footprint
+  test_build_sensors_n_z:
+    build_only: true
+    extra_args: CONF_FILE=sensors_n_z.conf
+    min_ram: 32
+    platform_exclude: zedboard_pulpino
+    tags: drivers footprint

--- a/tests/drivers/dma/chan_blen_transfer/testcase.yaml
+++ b/tests/drivers/dma/chan_blen_transfer/testcase.yaml
@@ -1,11 +1,11 @@
 tests:
-  - test_dma:
-      min_ram: 16
-      platform_whitelist: quark_se_c1000_devboard  quark_d2000_crb
-      tags: drivers dma
-  - test_dma_shell:
-      build_only: true
-      extra_args: CONF_FILE=prj_shell.conf
-      min_ram: 16
-      platform_whitelist: quark_se_c1000_devboard quark_d2000_crb
-      tags: drivers dma
+  test_dma:
+    min_ram: 16
+    platform_whitelist: quark_se_c1000_devboard  quark_d2000_crb
+    tags: drivers dma
+  test_dma_shell:
+    build_only: true
+    extra_args: CONF_FILE=prj_shell.conf
+    min_ram: 16
+    platform_whitelist: quark_se_c1000_devboard quark_d2000_crb
+    tags: drivers dma

--- a/tests/drivers/dma/loop_transfer/testcase.yaml
+++ b/tests/drivers/dma/loop_transfer/testcase.yaml
@@ -1,6 +1,6 @@
 tests:
-  - test:
-      build_only: true
-      platform_whitelist: arduino_101 quark_d2000_crb
-        quark_se_c1000_devboard
-      tags: apps
+  test:
+    build_only: true
+    platform_whitelist: arduino_101 quark_d2000_crb
+      quark_se_c1000_devboard
+    tags: apps

--- a/tests/drivers/enc28j60/testcase.yaml
+++ b/tests/drivers/enc28j60/testcase.yaml
@@ -1,5 +1,5 @@
 tests:
-  - test_enc28j60_build:
-      build_only: true
-      platform_whitelist: arduino_101
-      tags: drivers
+  test_enc28j60_build:
+    build_only: true
+    platform_whitelist: arduino_101
+    tags: drivers

--- a/tests/drivers/entropy/api/testcase.yaml
+++ b/tests/drivers/entropy/api/testcase.yaml
@@ -1,4 +1,4 @@
 tests:
-  - test_get_entropy:
-      filter: CONFIG_ENTROPY_HAS_DRIVER
-      tags: driver
+  test_get_entropy:
+    filter: CONFIG_ENTROPY_HAS_DRIVER
+    tags: driver

--- a/tests/drivers/gpio/gpio_basic_api/testcase.yaml
+++ b/tests/drivers/gpio/gpio_basic_api/testcase.yaml
@@ -1,5 +1,5 @@
 tests:
-  - test_gpio:
-      build_only: true
-      platform_whitelist: quark_se_c1000_devboard quark_d2000_crb
-      tags: drivers
+  test_gpio:
+    build_only: true
+    platform_whitelist: quark_se_c1000_devboard quark_d2000_crb
+    tags: drivers

--- a/tests/drivers/i2c/i2c_api/testcase.yaml
+++ b/tests/drivers/i2c/i2c_api/testcase.yaml
@@ -1,7 +1,7 @@
 tests:
-  - test_i2c_x86:
-      platform_whitelist: quark_se_c1000_devboard quark_d2000_crb
-      tags: drivers
-  - test_i2c_arc:
-      platform_whitelist: quark_se_c1000_ss_devboard
-      tags: drivers
+  test_i2c_arc:
+    platform_whitelist: quark_se_c1000_ss_devboard
+    tags: drivers
+  test_i2c_x86:
+    platform_whitelist: quark_se_c1000_devboard quark_d2000_crb
+    tags: drivers

--- a/tests/drivers/i2s/i2s_api/testcase.yaml
+++ b/tests/drivers/i2s/i2s_api/testcase.yaml
@@ -1,4 +1,4 @@
 tests:
-  - test:
-        depends_on: i2s
-        tags: drivers
+  test:
+    depends_on: i2s
+    tags: drivers

--- a/tests/drivers/i2s/i2s_speed/testcase.yaml
+++ b/tests/drivers/i2s/i2s_speed/testcase.yaml
@@ -1,4 +1,4 @@
 tests:
-  - test:
-        depends_on: i2s
-        tags: drivers
+  test:
+    depends_on: i2s
+    tags: drivers

--- a/tests/drivers/ipm/testcase.yaml
+++ b/tests/drivers/ipm/testcase.yaml
@@ -1,4 +1,4 @@
 tests:
-  - test:
-      filter: not CONFIG_SOC_QUARK_SE_C1000_SS
-      tags: core
+  test:
+    filter: not CONFIG_SOC_QUARK_SE_C1000_SS
+    tags: core

--- a/tests/drivers/nsim_uart/testcase.yaml
+++ b/tests/drivers/nsim_uart/testcase.yaml
@@ -1,5 +1,5 @@
 tests:
-  - test_pinmux_dev:
-      build_only: true
-      platform_whitelist: arduino_101_sss
-      tags: drivers
+  test_pinmux_dev:
+    build_only: true
+    platform_whitelist: arduino_101_sss
+    tags: drivers

--- a/tests/drivers/pci_enum/testcase.yaml
+++ b/tests/drivers/pci_enum/testcase.yaml
@@ -1,4 +1,4 @@
 tests:
-  - test:
-      depends_on: pci
-      tags: samples
+  test:
+    depends_on: pci
+    tags: samples

--- a/tests/drivers/pinmux/pinmux_basic_api/testcase.yaml
+++ b/tests/drivers/pinmux/pinmux_basic_api/testcase.yaml
@@ -1,4 +1,4 @@
 tests:
-  - test_pinmux:
-      platform_whitelist: quark_se_c1000_devboard quark_d2000_crb
-      tags: drivers
+  test_pinmux:
+    platform_whitelist: quark_se_c1000_devboard quark_d2000_crb
+    tags: drivers

--- a/tests/drivers/pwm/pwm_api/testcase.yaml
+++ b/tests/drivers/pwm/pwm_api/testcase.yaml
@@ -1,9 +1,9 @@
 tests:
-  - test_pwm:
-      platform_whitelist: quark_se_c1000_devboard quark_se_c1000_ss_devboard
-        arduino_101 arduino_101_sss
-      tags: drivers
-  - test_pwm_d2000_crb:
-      extra_args: CONF_FILE=prj_d2000.conf
-      platform_whitelist: quark_d2000_crb
-      tags: drivers
+  test_pwm:
+    platform_whitelist: quark_se_c1000_devboard quark_se_c1000_ss_devboard
+      arduino_101 arduino_101_sss
+    tags: drivers
+  test_pwm_d2000_crb:
+    extra_args: CONF_FILE=prj_d2000.conf
+    platform_whitelist: quark_d2000_crb
+    tags: drivers

--- a/tests/drivers/quark_clock/testcase.yaml
+++ b/tests/drivers/quark_clock/testcase.yaml
@@ -1,5 +1,5 @@
 tests:
-  - test_quark_clock_build:
-      build_only: true
-      platform_whitelist: arduino_101
-      tags: drivers
+  test_quark_clock_build:
+    build_only: true
+    platform_whitelist: arduino_101
+    tags: drivers

--- a/tests/drivers/rtc/rtc_basic_api/testcase.yaml
+++ b/tests/drivers/rtc/rtc_basic_api/testcase.yaml
@@ -1,4 +1,4 @@
 tests:
-  - test_rtc:
-      platform_whitelist: quark_se_c1000_devboard quark_d2000_crb
-      tags: drivers
+  test_rtc:
+    platform_whitelist: quark_se_c1000_devboard quark_d2000_crb
+    tags: drivers

--- a/tests/drivers/spi/spi_basic_api/testcase.yaml
+++ b/tests/drivers/spi/spi_basic_api/testcase.yaml
@@ -1,5 +1,5 @@
 tests:
-  - test_spi:
-      platform_whitelist: quark_se_c1000_devboard quark_d2000_crb
-        galileo frdm_k64f
-      tags: apps
+  test_spi:
+    platform_whitelist: quark_se_c1000_devboard quark_d2000_crb
+      galileo frdm_k64f
+    tags: apps

--- a/tests/drivers/uart/uart_basic_api/testcase.yaml
+++ b/tests/drivers/uart/uart_basic_api/testcase.yaml
@@ -1,15 +1,15 @@
 tests:
-  - test_uart:
-      build_only: true
-      platform_whitelist: quark_se_c1000_devboard quark_d2000_crb
-      tags: drivers
-  - test_uart_shell:
-      build_only: true
-      extra_args: CONF_FILE=prj_shell.conf
-      platform_whitelist: quark_se_c1000_devboard quark_d2000_crb
-      tags: drivers
-  - test_uart_poll:
-      build_only: true
-      extra_args: CONF_FILE=prj_poll.conf
-      platform_whitelist: qemu_x86
-      tags: drivers
+  test_uart:
+    build_only: true
+    platform_whitelist: quark_se_c1000_devboard quark_d2000_crb
+    tags: drivers
+  test_uart_poll:
+    build_only: true
+    extra_args: CONF_FILE=prj_poll.conf
+    platform_whitelist: qemu_x86
+    tags: drivers
+  test_uart_shell:
+    build_only: true
+    extra_args: CONF_FILE=prj_shell.conf
+    platform_whitelist: quark_se_c1000_devboard quark_d2000_crb
+    tags: drivers

--- a/tests/drivers/watchdog/wdt_basic_api/testcase.yaml
+++ b/tests/drivers/watchdog/wdt_basic_api/testcase.yaml
@@ -1,8 +1,8 @@
 tests:
-  - test_watchdog_reset:
-      platform_whitelist: quark_se_c1000_devboard quark_d2000_crb
-      tags: drivers
-  - test_watchdog_int_reset:
-      extra_args: CFLAGS=-DINT_RESET
-      platform_whitelist: quark_se_c1000_devboard quark_d2000_crb
-      tags: drivers
+  test_watchdog_int_reset:
+    extra_args: CFLAGS=-DINT_RESET
+    platform_whitelist: quark_se_c1000_devboard quark_d2000_crb
+    tags: drivers
+  test_watchdog_reset:
+    platform_whitelist: quark_se_c1000_devboard quark_d2000_crb
+    tags: drivers

--- a/tests/kernel/alert/alert_api/testcase.yaml
+++ b/tests/kernel/alert/alert_api/testcase.yaml
@@ -1,3 +1,3 @@
 tests:
-  - test:
-      tags: kernel userspace
+  test:
+    tags: kernel userspace

--- a/tests/kernel/arm_irq_vector_table/testcase.yaml
+++ b/tests/kernel/arm_irq_vector_table/testcase.yaml
@@ -1,4 +1,4 @@
 tests:
-  - test:
-      filter: CONFIG_ARMV7_M
-      tags: core bat_commit
+  test:
+    filter: CONFIG_ARMV7_M
+    tags: core bat_commit

--- a/tests/kernel/arm_runtime_nmi/testcase.yaml
+++ b/tests/kernel/arm_runtime_nmi/testcase.yaml
@@ -1,4 +1,4 @@
 tests:
-  - test:
-      arch_whitelist: arm
-      tags: core bat_commit
+  test:
+    arch_whitelist: arm
+    tags: core bat_commit

--- a/tests/kernel/bitfield/testcase.yaml
+++ b/tests/kernel/bitfield/testcase.yaml
@@ -1,4 +1,4 @@
 tests:
-  - test:
-      arch_exclude: arm
-      tags: core bat_commit
+  test:
+    arch_exclude: arm
+    tags: core bat_commit

--- a/tests/kernel/boot_page_table/testcase.yaml
+++ b/tests/kernel/boot_page_table/testcase.yaml
@@ -1,5 +1,5 @@
 tests:
--   test:
-        platform_whitelist: qemu_x86
-        platform_exclude: qemu_x86_nommu
-        tags: kernel
+  test:
+    platform_exclude: qemu_x86_nommu
+    platform_whitelist: qemu_x86
+    tags: kernel

--- a/tests/kernel/common/testcase.yaml
+++ b/tests/kernel/common/testcase.yaml
@@ -1,3 +1,3 @@
 tests:
-  - test:
-      tags: core
+  test:
+    tags: core

--- a/tests/kernel/context/testcase.yaml
+++ b/tests/kernel/context/testcase.yaml
@@ -1,3 +1,3 @@
 tests:
-  - test:
-      tags: core bat_commit
+  test:
+    tags: core bat_commit

--- a/tests/kernel/critical/testcase.yaml
+++ b/tests/kernel/critical/testcase.yaml
@@ -1,3 +1,3 @@
 tests:
-  - test:
-      tags: core bat_commit
+  test:
+    tags: core bat_commit

--- a/tests/kernel/errno/testcase.yaml
+++ b/tests/kernel/errno/testcase.yaml
@@ -3,8 +3,8 @@ common:
   min_ram: 32
   tags: core
 tests:
-  - test:
-      tags: core
-  - test_newlib:
-      extra_configs:
-        - CONFIG_NEWLIB_LIBC=y
+  test:
+    tags: core
+  test_newlib:
+    extra_configs:
+      - CONFIG_NEWLIB_LIBC=y

--- a/tests/kernel/fatal/testcase.yaml
+++ b/tests/kernel/fatal/testcase.yaml
@@ -1,9 +1,9 @@
 tests:
-  - stack-sentinel:
-      arch_exclude: arc
-      extra_args: CONF_FILE=sentinel.conf
-      tags: core ignore_faults
-  - stack-protection:
-      extra_args: CONF_FILE=prj.conf
-      filter: ARCH_HAS_STACK_PROTECTION
-      tags: core ignore_faults
+  stack-protection:
+    extra_args: CONF_FILE=prj.conf
+    filter: ARCH_HAS_STACK_PROTECTION
+    tags: core ignore_faults
+  stack-sentinel:
+    arch_exclude: arc
+    extra_args: CONF_FILE=sentinel.conf
+    tags: core ignore_faults

--- a/tests/kernel/fifo/fifo_api/testcase.yaml
+++ b/tests/kernel/fifo/fifo_api/testcase.yaml
@@ -1,6 +1,6 @@
 tests:
-  - test:
-      tags: kernel
-  - test_poll:
-      extra_args: CONF_FILE="prj_poll.conf"
-      tags: kernel
+  test:
+    tags: kernel
+  test_poll:
+    extra_args: CONF_FILE="prj_poll.conf"
+    tags: kernel

--- a/tests/kernel/fp_sharing/testcase.yaml
+++ b/tests/kernel/fp_sharing/testcase.yaml
@@ -1,12 +1,12 @@
 tests:
-  - test_x86:
-      platform_whitelist: qemu_x86
-      slow: true
-      tags: core
-      timeout: 600
-  - test_arm:
-      extra_args: PI_NUM_ITERATIONS=70000
-      platform_whitelist: frdm_k64f
-      slow: true
-      tags: core
-      timeout: 600
+  test_arm:
+    extra_args: PI_NUM_ITERATIONS=70000
+    platform_whitelist: frdm_k64f
+    slow: true
+    tags: core
+    timeout: 600
+  test_x86:
+    platform_whitelist: qemu_x86
+    slow: true
+    tags: core
+    timeout: 600

--- a/tests/kernel/gen_isr_table/testcase.yaml
+++ b/tests/kernel/gen_isr_table/testcase.yaml
@@ -1,4 +1,4 @@
 tests:
-  - test:
-      filter: CONFIG_GEN_ISR_TABLES and CONFIG_ARMV7_M
-      tags: core
+  test:
+    filter: CONFIG_GEN_ISR_TABLES and CONFIG_ARMV7_M
+    tags: core

--- a/tests/kernel/irq_offload/testcase.yaml
+++ b/tests/kernel/irq_offload/testcase.yaml
@@ -1,3 +1,3 @@
 tests:
-  - test:
-      tags: core
+  test:
+    tags: core

--- a/tests/kernel/libs/testcase.yaml
+++ b/tests/kernel/libs/testcase.yaml
@@ -1,3 +1,3 @@
 tests:
-  - test:
-      tags: bat_commit core
+  test:
+    tags: bat_commit core

--- a/tests/kernel/lifo/lifo_api/testcase.yaml
+++ b/tests/kernel/lifo/lifo_api/testcase.yaml
@@ -1,3 +1,3 @@
 tests:
-  - test:
-      tags: kernel
+  test:
+    tags: kernel

--- a/tests/kernel/mbox/mbox_api/testcase.yaml
+++ b/tests/kernel/mbox/mbox_api/testcase.yaml
@@ -1,3 +1,3 @@
 tests:
-  - test:
-      tags: kernel
+  test:
+    tags: kernel

--- a/tests/kernel/mem_heap/mheap_api_concept/testcase.yaml
+++ b/tests/kernel/mem_heap/mheap_api_concept/testcase.yaml
@@ -1,3 +1,3 @@
 tests:
-  - test:
-      tags: kernel
+  test:
+    tags: kernel

--- a/tests/kernel/mem_pool/mem_pool/testcase.yaml
+++ b/tests/kernel/mem_pool/mem_pool/testcase.yaml
@@ -1,7 +1,7 @@
 tests:
-  - test:
-      min_ram: 32
-      tags: bat_commit core
-  - test_nios2:
-      arch_whitelist: nios2
-      tags: bat_commit core
+  test:
+    min_ram: 32
+    tags: bat_commit core
+  test_nios2:
+    arch_whitelist: nios2
+    tags: bat_commit core

--- a/tests/kernel/mem_pool/mem_pool_api/testcase.yaml
+++ b/tests/kernel/mem_pool/mem_pool_api/testcase.yaml
@@ -1,3 +1,3 @@
 tests:
-  - test:
-      tags: kernel
+  test:
+    tags: kernel

--- a/tests/kernel/mem_pool/mem_pool_concept/testcase.yaml
+++ b/tests/kernel/mem_pool/mem_pool_concept/testcase.yaml
@@ -1,3 +1,3 @@
 tests:
-  - test:
-      tags: kernel
+  test:
+    tags: kernel

--- a/tests/kernel/mem_pool/mem_pool_threadsafe/testcase.yaml
+++ b/tests/kernel/mem_pool/mem_pool_threadsafe/testcase.yaml
@@ -1,3 +1,3 @@
 tests:
-  - test:
-      tags: kernel
+  test:
+    tags: kernel

--- a/tests/kernel/mem_protect/app_memory/testcase.yaml
+++ b/tests/kernel/mem_protect/app_memory/testcase.yaml
@@ -1,4 +1,4 @@
 tests:
-  - test:
-      arch_whitelist: x86 arm
-      tags: core security
+  test:
+    arch_whitelist: x86 arm
+    tags: core security

--- a/tests/kernel/mem_protect/obj_validation/testcase.yaml
+++ b/tests/kernel/mem_protect/obj_validation/testcase.yaml
@@ -1,4 +1,4 @@
 tests:
-  - test:
-      filter: CONFIG_ARCH_HAS_USERSPACE
-      tags: core security userspace
+  test:
+    filter: CONFIG_ARCH_HAS_USERSPACE
+    tags: core security userspace

--- a/tests/kernel/mem_protect/protection/testcase.yaml
+++ b/tests/kernel/mem_protect/protection/testcase.yaml
@@ -1,4 +1,4 @@
 tests:
-  - test:
-      filter: CONFIG_CPU_HAS_MPU or CONFIG_X86_MMU
-      tags: core security ignore_faults
+  test:
+    filter: CONFIG_CPU_HAS_MPU or CONFIG_X86_MMU
+    tags: core security ignore_faults

--- a/tests/kernel/mem_protect/stackprot/testcase.yaml
+++ b/tests/kernel/mem_protect/stackprot/testcase.yaml
@@ -1,4 +1,4 @@
 tests:
-  - test:
-      arch_exclude: nios2 xtensa
-      tags: bat_commit core ignore_faults
+  test:
+    arch_exclude: nios2 xtensa
+    tags: bat_commit core ignore_faults

--- a/tests/kernel/mem_protect/userspace/testcase.yaml
+++ b/tests/kernel/mem_protect/userspace/testcase.yaml
@@ -1,4 +1,4 @@
 tests:
-  - test:
-      filter: CONFIG_ARCH_HAS_USERSPACE
-      tags: core security userspace ignore_faults
+  test:
+    filter: CONFIG_ARCH_HAS_USERSPACE
+    tags: core security userspace ignore_faults

--- a/tests/kernel/mem_slab/mslab/testcase.yaml
+++ b/tests/kernel/mem_slab/mslab/testcase.yaml
@@ -1,3 +1,3 @@
 tests:
-  - test:
-      tags: bat_commit core
+  test:
+    tags: bat_commit core

--- a/tests/kernel/mem_slab/mslab_api/testcase.yaml
+++ b/tests/kernel/mem_slab/mslab_api/testcase.yaml
@@ -1,3 +1,3 @@
 tests:
-  - test:
-      tags: kernel
+  test:
+    tags: kernel

--- a/tests/kernel/mem_slab/mslab_concept/testcase.yaml
+++ b/tests/kernel/mem_slab/mslab_concept/testcase.yaml
@@ -1,3 +1,3 @@
 tests:
-  - test:
-      tags: kernel
+  test:
+    tags: kernel

--- a/tests/kernel/mem_slab/mslab_threadsafe/testcase.yaml
+++ b/tests/kernel/mem_slab/mslab_threadsafe/testcase.yaml
@@ -1,3 +1,3 @@
 tests:
-  - test:
-      tags: kernel
+  test:
+    tags: kernel

--- a/tests/kernel/msgq/msgq_api/testcase.yaml
+++ b/tests/kernel/msgq/msgq_api/testcase.yaml
@@ -1,3 +1,3 @@
 tests:
-  - test:
-      tags: kernel userspace
+  test:
+    tags: kernel userspace

--- a/tests/kernel/multilib/testcase.yaml
+++ b/tests/kernel/multilib/testcase.yaml
@@ -1,3 +1,3 @@
 tests:
-  - test:
-      tags: core
+  test:
+    tags: core

--- a/tests/kernel/mutex/mutex/testcase.yaml
+++ b/tests/kernel/mutex/mutex/testcase.yaml
@@ -1,3 +1,3 @@
 tests:
-  - test:
-      tags: bat_commit core userspace
+  test:
+    tags: bat_commit core userspace

--- a/tests/kernel/mutex/mutex_api/testcase.yaml
+++ b/tests/kernel/mutex/mutex_api/testcase.yaml
@@ -1,3 +1,3 @@
 tests:
-  - test:
-      tags: kernel
+  test:
+    tags: kernel

--- a/tests/kernel/obj_tracing/testcase.yaml
+++ b/tests/kernel/obj_tracing/testcase.yaml
@@ -1,4 +1,4 @@
 tests:
-  - test:
-      min_ram: 32
-      tags: core
+  test:
+    min_ram: 32
+    tags: core

--- a/tests/kernel/pending/testcase.yaml
+++ b/tests/kernel/pending/testcase.yaml
@@ -1,4 +1,4 @@
 tests:
-  - test:
-      min_ram: 16
-      tags: core bat_commit
+  test:
+    min_ram: 16
+    tags: core bat_commit

--- a/tests/kernel/pipe/pipe_api/testcase.yaml
+++ b/tests/kernel/pipe/pipe_api/testcase.yaml
@@ -1,3 +1,3 @@
 tests:
-  - test:
-      tags: kernel
+  test:
+    tags: kernel

--- a/tests/kernel/poll/testcase.yaml
+++ b/tests/kernel/poll/testcase.yaml
@@ -1,3 +1,3 @@
 tests:
-  - test:
-      tags: kernel
+  test:
+    tags: kernel

--- a/tests/kernel/profiling/profiling_api/testcase.yaml
+++ b/tests/kernel/profiling/profiling_api/testcase.yaml
@@ -1,5 +1,5 @@
 tests:
-  - test:
-      arch_exclude: nios2 riscv32
-      platform_exclude: em_starterkit
-      tags: kernel
+  test:
+    arch_exclude: nios2 riscv32
+    platform_exclude: em_starterkit
+    tags: kernel

--- a/tests/kernel/pthread/testcase.yaml
+++ b/tests/kernel/pthread/testcase.yaml
@@ -1,3 +1,3 @@
 tests:
-  - test:
-      tags: core
+  test:
+    tags: core

--- a/tests/kernel/queue/testcase.yaml
+++ b/tests/kernel/queue/testcase.yaml
@@ -1,6 +1,6 @@
 tests:
-  - test:
-      tags: kernel
-  - test_poll:
-      extra_args: CONF_FILE="prj_poll.conf"
-      tags: kernel
+  test:
+    tags: kernel
+  test_poll:
+    extra_args: CONF_FILE="prj_poll.conf"
+    tags: kernel

--- a/tests/kernel/semaphore/sema_api/testcase.yaml
+++ b/tests/kernel/semaphore/sema_api/testcase.yaml
@@ -1,3 +1,3 @@
 tests:
-  - test:
-      tags: kernel userspace
+  test:
+    tags: kernel userspace

--- a/tests/kernel/sleep/testcase.yaml
+++ b/tests/kernel/sleep/testcase.yaml
@@ -1,3 +1,3 @@
 tests:
-  - test:
-      tags: core bat_commit
+  test:
+    tags: core bat_commit

--- a/tests/kernel/sprintf/testcase.yaml
+++ b/tests/kernel/sprintf/testcase.yaml
@@ -1,3 +1,3 @@
 tests:
-  - test:
-      tags: core
+  test:
+    tags: core

--- a/tests/kernel/stack/stack_api/testcase.yaml
+++ b/tests/kernel/stack/stack_api/testcase.yaml
@@ -1,3 +1,3 @@
 tests:
-  - test:
-      tags: kernel userspace
+  test:
+    tags: kernel userspace

--- a/tests/kernel/static_idt/testcase.yaml
+++ b/tests/kernel/static_idt/testcase.yaml
@@ -1,4 +1,4 @@
 tests:
-  - test:
-      arch_whitelist: x86
-      tags: bat_commit core ignore_faults
+  test:
+    arch_whitelist: x86
+    tags: bat_commit core ignore_faults

--- a/tests/kernel/systhreads/testcase.yaml
+++ b/tests/kernel/systhreads/testcase.yaml
@@ -1,4 +1,4 @@
 tests:
-  - test:
-      arch_exclude: nios2 riscv32
-      tags: kernel
+  test:
+    arch_exclude: nios2 riscv32
+    tags: kernel

--- a/tests/kernel/test_build/testcase.yaml
+++ b/tests/kernel/test_build/testcase.yaml
@@ -1,14 +1,14 @@
 tests:
-  - test_debug:
-      build_only: true
-      extra_args: CONF_FILE=debug.conf
-      tags: apps
-  - test_newlib:
-      build_only: true
-      extra_args: CONF_FILE=newlib.conf
-      tags: apps
-  - test_runtime_nmi:
-      arch_whitelist: arm
-      build_only: true
-      extra_args: CONF_FILE=runtime_nmi.conf
-      tags: apps
+  test_debug:
+    build_only: true
+    extra_args: CONF_FILE=debug.conf
+    tags: apps
+  test_newlib:
+    build_only: true
+    extra_args: CONF_FILE=newlib.conf
+    tags: apps
+  test_runtime_nmi:
+    arch_whitelist: arm
+    build_only: true
+    extra_args: CONF_FILE=runtime_nmi.conf
+    tags: apps

--- a/tests/kernel/threads/custom_data/custom_data_api/testcase.yaml
+++ b/tests/kernel/threads/custom_data/custom_data_api/testcase.yaml
@@ -1,3 +1,3 @@
 tests:
-  - test:
-      tags: kernel threads userspace
+  test:
+    tags: kernel threads userspace

--- a/tests/kernel/threads/lifecycle/lifecycle_api/testcase.yaml
+++ b/tests/kernel/threads/lifecycle/lifecycle_api/testcase.yaml
@@ -1,4 +1,4 @@
 tests:
-  - test:
-      arch_exclude: nios2
-      tags: kernel threads userspace
+  test:
+    arch_exclude: nios2
+    tags: kernel threads userspace

--- a/tests/kernel/threads/lifecycle/thread_init/testcase.yaml
+++ b/tests/kernel/threads/lifecycle/thread_init/testcase.yaml
@@ -1,3 +1,3 @@
 tests:
-  - test:
-      tags: kernel threads userspace
+  test:
+    tags: kernel threads userspace

--- a/tests/kernel/threads/scheduling/schedule_api/testcase.yaml
+++ b/tests/kernel/threads/scheduling/schedule_api/testcase.yaml
@@ -1,4 +1,4 @@
 tests:
-  - test:
-      min_ram: 20
-      tags: kernel threads sched
+  test:
+    min_ram: 20
+    tags: kernel threads sched

--- a/tests/kernel/tickless/tickless/testcase.yaml
+++ b/tests/kernel/tickless/tickless/testcase.yaml
@@ -1,7 +1,7 @@
 tests:
-  - test:
-      arch_exclude: nios2 riscv32
-      filter: CONFIG_X86 or (CONFIG_ARM and (CONFIG_SOC_MK64F12
-        or CONFIG_SOC_SERIES_SAM3X)) or (CONFIG_ARC
-        and CONFIG_SOC_QUARK_SE_C1000_SS)
-      tags: core
+  test:
+    arch_exclude: nios2 riscv32
+    filter: CONFIG_X86 or (CONFIG_ARM and (CONFIG_SOC_MK64F12
+      or CONFIG_SOC_SERIES_SAM3X)) or (CONFIG_ARC and
+      CONFIG_SOC_QUARK_SE_C1000_SS)
+    tags: core

--- a/tests/kernel/tickless/tickless_concept/testcase.yaml
+++ b/tests/kernel/tickless/tickless_concept/testcase.yaml
@@ -1,4 +1,4 @@
 tests:
-  - test:
-      arch_exclude: riscv32 nios2
-      tags: kernel
+  test:
+    arch_exclude: riscv32 nios2
+    tags: kernel

--- a/tests/kernel/timer/timer_api/testcase.yaml
+++ b/tests/kernel/timer/timer_api/testcase.yaml
@@ -1,8 +1,8 @@
 tests:
-  - test:
-      tags: kernel
-  - test_tickless:
-      build_only: true
-      extra_args: CONF_FILE="prj_tickless.conf"
-      filter: CONFIG_BOARD_QEMU_X86
-      tags: kernel
+  test:
+    tags: kernel
+  test_tickless:
+    build_only: true
+    extra_args: CONF_FILE="prj_tickless.conf"
+    filter: CONFIG_BOARD_QEMU_X86
+    tags: kernel

--- a/tests/kernel/timer/timer_monotonic/testcase.yaml
+++ b/tests/kernel/timer/timer_monotonic/testcase.yaml
@@ -1,3 +1,3 @@
 tests:
-  - test:
-      tags: timer
+  test:
+    tags: timer

--- a/tests/kernel/userbufer_validate/testcase.yaml
+++ b/tests/kernel/userbufer_validate/testcase.yaml
@@ -1,4 +1,4 @@
 tests:
-     - test:
-        tags: kernel
-        platform_whitelist: qemu_x86 arduino_101
+  test:
+    platform_whitelist: qemu_x86 arduino_101
+    tags: kernel

--- a/tests/kernel/workq/work_queue/testcase.yaml
+++ b/tests/kernel/workq/work_queue/testcase.yaml
@@ -1,6 +1,6 @@
 tests:
-  - test:
-      tags: core bat_commit
-  - test_poll:
-      extra_args: CONF_FILE="prj_poll.conf"
-      tags: core bat_commit
+  test:
+    tags: core bat_commit
+  test_poll:
+    extra_args: CONF_FILE="prj_poll.conf"
+    tags: core bat_commit

--- a/tests/kernel/workq/work_queue_api/testcase.yaml
+++ b/tests/kernel/workq/work_queue_api/testcase.yaml
@@ -1,3 +1,3 @@
 tests:
-  - test:
-      tags: kernel
+  test:
+    tags: kernel

--- a/tests/kernel/xip/testcase.yaml
+++ b/tests/kernel/xip/testcase.yaml
@@ -1,6 +1,6 @@
 tests:
-  - test:
-      arch_exclude: xtensa
-      filter: not CONFIG_SOC_RISCV32_PULPINO
-      platform_exclude: cc3220sf_launchxl
-      tags: core bat_commit
+  test:
+    arch_exclude: xtensa
+    filter: not CONFIG_SOC_RISCV32_PULPINO
+    platform_exclude: cc3220sf_launchxl
+    tags: core bat_commit

--- a/tests/lib/json/testcase.yaml
+++ b/tests/lib/json/testcase.yaml
@@ -1,4 +1,4 @@
 tests:
-  - test:
-      filter: not CONFIG_NEWLIB_LIBC
-      tags: json
+  test:
+    filter: not CONFIG_NEWLIB_LIBC
+    tags: json

--- a/tests/net/6lo/testcase.yaml
+++ b/tests/net/6lo/testcase.yaml
@@ -1,4 +1,4 @@
 tests:
-  - test:
-      arch_whitelist: x86
-      tags: net
+  test:
+    arch_whitelist: x86
+    tags: net

--- a/tests/net/all/testcase.yaml
+++ b/tests/net/all/testcase.yaml
@@ -1,6 +1,6 @@
 tests:
-  - test:
-      build_only: true
-      min_ram: 32
-      platform_whitelist: qemu_x86 qemu_cortex_m3
-      tags: net
+  test:
+    build_only: true
+    min_ram: 32
+    platform_whitelist: qemu_x86 qemu_cortex_m3
+    tags: net

--- a/tests/net/app/testcase.yaml
+++ b/tests/net/app/testcase.yaml
@@ -1,16 +1,16 @@
 tests:
-  - test:
-      min_ram: 32
-      tags: net
-  - test-no-ipv6:
-      extra_args: CONF_FILE=prj-no-ipv6.conf
-      min_ram: 32
-      tags: net
-  - test-no-ipv4:
-      extra_args: CONF_FILE=prj-no-ipv4.conf
-      min_ram: 32
-      tags: net
-  - test-with-dns:
-      extra_args: CONF_FILE=prj-with-dns.conf
-      min_ram: 32
-      tags: net dns
+  test:
+    min_ram: 32
+    tags: net
+  test-no-ipv4:
+    extra_args: CONF_FILE=prj-no-ipv4.conf
+    min_ram: 32
+    tags: net
+  test-no-ipv6:
+    extra_args: CONF_FILE=prj-no-ipv6.conf
+    min_ram: 32
+    tags: net
+  test-with-dns:
+    extra_args: CONF_FILE=prj-with-dns.conf
+    min_ram: 32
+    tags: net dns

--- a/tests/net/arp/testcase.yaml
+++ b/tests/net/arp/testcase.yaml
@@ -1,11 +1,11 @@
 tests:
-  - test:
-      filter: not CONFIG_BT
-      min_ram: 12
-      platform_exclude: qemu_xtensa
-      tags: net
-  - test_with_bt:
-      filter: CONFIG_BT
-      min_ram: 16
-      platform_exclude: qemu_xtensa
-      tags: net
+  test:
+    filter: not CONFIG_BT
+    min_ram: 12
+    platform_exclude: qemu_xtensa
+    tags: net
+  test_with_bt:
+    filter: CONFIG_BT
+    min_ram: 16
+    platform_exclude: qemu_xtensa
+    tags: net

--- a/tests/net/buf/testcase.yaml
+++ b/tests/net/buf/testcase.yaml
@@ -1,5 +1,5 @@
 tests:
-  - test:
-      filter: not CONFIG_BT
-      min_ram: 16
-      tags: buf
+  test:
+    filter: not CONFIG_BT
+    min_ram: 16
+    tags: buf

--- a/tests/net/context/testcase.yaml
+++ b/tests/net/context/testcase.yaml
@@ -1,10 +1,10 @@
 tests:
-  - test:
-      filter: not CONFIG_BT
-      min_ram: 12
-      platform_exclude: hexiwear_kw40z
-      tags: net
-  - test_with_bt:
-      filter: CONFIG_BT
-      min_ram: 16
-      tags: net
+  test:
+    filter: not CONFIG_BT
+    min_ram: 12
+    platform_exclude: hexiwear_kw40z
+    tags: net
+  test_with_bt:
+    filter: CONFIG_BT
+    min_ram: 16
+    tags: net

--- a/tests/net/dhcpv4/testcase.yaml
+++ b/tests/net/dhcpv4/testcase.yaml
@@ -1,4 +1,4 @@
 tests:
-  - test:
-      arch_whitelist: x86
-      tags: net
+  test:
+    arch_whitelist: x86
+    tags: net

--- a/tests/net/icmpv6/testcase.yaml
+++ b/tests/net/icmpv6/testcase.yaml
@@ -1,9 +1,9 @@
 tests:
-  - test:
-      filter: not CONFIG_BT
-      min_ram: 12
-      tags: net
-  - test_with_bt:
-      filter: CONFIG_BT
-      min_ram: 16
-      tags: net
+  test:
+    filter: not CONFIG_BT
+    min_ram: 12
+    tags: net
+  test_with_bt:
+    filter: CONFIG_BT
+    min_ram: 16
+    tags: net

--- a/tests/net/ieee802154/crypto/testcase.yaml
+++ b/tests/net/ieee802154/crypto/testcase.yaml
@@ -1,5 +1,5 @@
 tests:
-  - test:
-      build_only: true
-      platform_whitelist: quark_se_c1000_devboard
-      tags: net
+  test:
+    build_only: true
+    platform_whitelist: quark_se_c1000_devboard
+    tags: net

--- a/tests/net/ieee802154/fragment/testcase.yaml
+++ b/tests/net/ieee802154/fragment/testcase.yaml
@@ -1,4 +1,4 @@
 tests:
-  - test:
-      arch_whitelist: x86
-      tags: net
+  test:
+    arch_whitelist: x86
+    tags: net

--- a/tests/net/ieee802154/l2/testcase.yaml
+++ b/tests/net/ieee802154/l2/testcase.yaml
@@ -1,5 +1,5 @@
 tests:
-  - test:
-      min_ram: 16
-      platform_exclude: qemu_xtensa
-      tags: net
+  test:
+    min_ram: 16
+    platform_exclude: qemu_xtensa
+    tags: net

--- a/tests/net/iface/testcase.yaml
+++ b/tests/net/iface/testcase.yaml
@@ -1,4 +1,4 @@
 tests:
-  - test:
-      min_ram: 16
-      tags: net
+  test:
+    min_ram: 16
+    tags: net

--- a/tests/net/ip-addr/testcase.yaml
+++ b/tests/net/ip-addr/testcase.yaml
@@ -1,9 +1,9 @@
 tests:
-  - test:
-      filter: not CONFIG_BT
-      min_ram: 12
-      tags: net
-  - test_with_bt:
-      filter: CONFIG_BT
-      min_ram: 16
-      tags: net
+  test:
+    filter: not CONFIG_BT
+    min_ram: 12
+    tags: net
+  test_with_bt:
+    filter: CONFIG_BT
+    min_ram: 16
+    tags: net

--- a/tests/net/ipv6/testcase.yaml
+++ b/tests/net/ipv6/testcase.yaml
@@ -1,4 +1,4 @@
 tests:
-  - test:
-      arch_whitelist: x86
-      tags: net
+  test:
+    arch_whitelist: x86
+    tags: net

--- a/tests/net/ipv6_fragment/testcase.yaml
+++ b/tests/net/ipv6_fragment/testcase.yaml
@@ -1,4 +1,4 @@
 tests:
-  - test:
-      arch_whitelist: x86
-      tags: net ipv6
+  test:
+    arch_whitelist: x86
+    tags: net ipv6

--- a/tests/net/lib/coap/testcase.yaml
+++ b/tests/net/lib/coap/testcase.yaml
@@ -1,4 +1,4 @@
 tests:
-  - test:
-      min_ram: 16
-      tags: net
+  test:
+    min_ram: 16
+    tags: net

--- a/tests/net/lib/dns_packet/testcase.yaml
+++ b/tests/net/lib/dns_packet/testcase.yaml
@@ -1,5 +1,5 @@
 tests:
-  - test:
-      min_ram: 16
-      tags: dns net
-      timeout: 200
+  test:
+    min_ram: 16
+    tags: dns net
+    timeout: 200

--- a/tests/net/lib/dns_resolve/testcase.yaml
+++ b/tests/net/lib/dns_resolve/testcase.yaml
@@ -1,10 +1,10 @@
 tests:
-  - test:
-      min_ram: 21
-      tags: dns net
-      timeout: 600
-  - test-no-ipv6:
-      extra_args: CONF_FILE=prj-no-ipv6.conf
-      min_ram: 16
-      tags: dns net
-      timeout: 600
+  test:
+    min_ram: 21
+    tags: dns net
+    timeout: 600
+  test-no-ipv6:
+    extra_args: CONF_FILE=prj-no-ipv6.conf
+    min_ram: 16
+    tags: dns net
+    timeout: 600

--- a/tests/net/lib/http_header_fields/testcase.yaml
+++ b/tests/net/lib/http_header_fields/testcase.yaml
@@ -1,10 +1,10 @@
 tests:
-  - test:
-      filter: not CONFIG_BT
-      min_ram: 12
-      platform_exclude: hexiwear_kw40z
-      tags: http net
-  - test_with_bt:
-      filter: CONFIG_BT
-      min_ram: 16
-      tags: http net
+  test:
+    filter: not CONFIG_BT
+    min_ram: 12
+    platform_exclude: hexiwear_kw40z
+    tags: http net
+  test_with_bt:
+    filter: CONFIG_BT
+    min_ram: 16
+    tags: http net

--- a/tests/net/lib/mqtt_packet/testcase.yaml
+++ b/tests/net/lib/mqtt_packet/testcase.yaml
@@ -1,4 +1,4 @@
 tests:
-  - test:
-      min_ram: 16
-      tags: mqtt net
+  test:
+    min_ram: 16
+    tags: mqtt net

--- a/tests/net/lib/mqtt_publisher/testcase.yaml
+++ b/tests/net/lib/mqtt_publisher/testcase.yaml
@@ -1,10 +1,10 @@
 tests:
-  - test:
-      build_only: true
-      min_ram: 16
-      tags: net mqtt
-  - test_tls:
-      build_only: true
-      extra_args: CONF_FILE="prj_tls.conf"
-      platform_whitelist: frdm_k64f qemu_x86
-      tags: net mqtt
+  test:
+    build_only: true
+    min_ram: 16
+    tags: net mqtt
+  test_tls:
+    build_only: true
+    extra_args: CONF_FILE="prj_tls.conf"
+    platform_whitelist: frdm_k64f qemu_x86
+    tags: net mqtt

--- a/tests/net/lib/mqtt_subscriber/testcase.yaml
+++ b/tests/net/lib/mqtt_subscriber/testcase.yaml
@@ -1,5 +1,5 @@
 tests:
-  - test:
-      build_only: true
-      min_ram: 16
-      tags: net mqtt
+  test:
+    build_only: true
+    min_ram: 16
+    tags: net mqtt

--- a/tests/net/mgmt/testcase.yaml
+++ b/tests/net/mgmt/testcase.yaml
@@ -1,9 +1,9 @@
 tests:
-  - test:
-      filter: not CONFIG_BT
-      min_ram: 12
-      tags: net
-  - test_with_bt:
-      filter: CONFIG_BT
-      min_ram: 16
-      tags: net
+  test:
+    filter: not CONFIG_BT
+    min_ram: 12
+    tags: net
+  test_with_bt:
+    filter: CONFIG_BT
+    min_ram: 16
+    tags: net

--- a/tests/net/mld/testcase.yaml
+++ b/tests/net/mld/testcase.yaml
@@ -1,4 +1,4 @@
 tests:
-  - test:
-      arch_whitelist: x86
-      tags: net
+  test:
+    arch_whitelist: x86
+    tags: net

--- a/tests/net/neighbor/testcase.yaml
+++ b/tests/net/neighbor/testcase.yaml
@@ -1,9 +1,9 @@
 tests:
-  - test:
-      filter: not CONFIG_BT
-      min_ram: 12
-      tags: net
-  - test_with_bt:
-      filter: CONFIG_BT
-      min_ram: 16
-      tags: net
+  test:
+    filter: not CONFIG_BT
+    min_ram: 12
+    tags: net
+  test_with_bt:
+    filter: CONFIG_BT
+    min_ram: 16
+    tags: net

--- a/tests/net/net_pkt/testcase.yaml
+++ b/tests/net/net_pkt/testcase.yaml
@@ -1,5 +1,5 @@
 tests:
-  - test:
-      depends_on: netif
-      min_ram: 20
-      tags: net
+  test:
+    depends_on: netif
+    min_ram: 20
+    tags: net

--- a/tests/net/route/testcase.yaml
+++ b/tests/net/route/testcase.yaml
@@ -1,10 +1,10 @@
 tests:
-  - test:
-      filter: not CONFIG_BT
-      min_ram: 12
-      platform_exclude: hexiwear_kw40z
-      tags: net
-  - test_with_bt:
-      filter: CONFIG_BT
-      min_ram: 16
-      tags: net
+  test:
+    filter: not CONFIG_BT
+    min_ram: 12
+    platform_exclude: hexiwear_kw40z
+    tags: net
+  test_with_bt:
+    filter: CONFIG_BT
+    min_ram: 16
+    tags: net

--- a/tests/net/rpl/testcase.yaml
+++ b/tests/net/rpl/testcase.yaml
@@ -1,4 +1,4 @@
 tests:
-  - test:
-      min_ram: 16
-      tags: net
+  test:
+    min_ram: 16
+    tags: net

--- a/tests/net/socket/tcp/testcase.yaml
+++ b/tests/net/socket/tcp/testcase.yaml
@@ -1,7 +1,7 @@
 tests:
-  - test:
-      extra_configs:
-        - CONFIG_NET_TEST=y
-        - CONFIG_NET_LOOPBACK=y
-      min_ram: 32
-      tags: net
+  test:
+    extra_configs:
+      - CONFIG_NET_TEST=y
+      - CONFIG_NET_LOOPBACK=y
+    min_ram: 32
+    tags: net

--- a/tests/net/socket/udp/testcase.yaml
+++ b/tests/net/socket/udp/testcase.yaml
@@ -1,7 +1,7 @@
 tests:
-  - test:
-      extra_configs:
-        - CONFIG_NET_TEST=y
-        - CONFIG_NET_LOOPBACK=y
-      min_ram: 21
-      tags: net
+  test:
+    extra_configs:
+      - CONFIG_NET_TEST=y
+      - CONFIG_NET_LOOPBACK=y
+    min_ram: 21
+    tags: net

--- a/tests/net/tcp/testcase.yaml
+++ b/tests/net/tcp/testcase.yaml
@@ -1,4 +1,4 @@
 tests:
-  - test:
-      arch_whitelist: x86
-      tags: net
+  test:
+    arch_whitelist: x86
+    tags: net

--- a/tests/net/trickle/testcase.yaml
+++ b/tests/net/trickle/testcase.yaml
@@ -1,4 +1,4 @@
 tests:
-  - test:
-      min_ram: 12
-      tags: net
+  test:
+    min_ram: 12
+    tags: net

--- a/tests/net/udp/testcase.yaml
+++ b/tests/net/udp/testcase.yaml
@@ -1,5 +1,5 @@
 tests:
-  - test:
-      depends_on: netif
-      min_ram: 20
-      tags: net
+  test:
+    depends_on: netif
+    min_ram: 20
+    tags: net

--- a/tests/net/utils/testcase.yaml
+++ b/tests/net/utils/testcase.yaml
@@ -1,4 +1,4 @@
 tests:
-  - test:
-      min_ram: 16
-      tags: net
+  test:
+    min_ram: 16
+    tags: net

--- a/tests/power/multicore/arc/testcase.yaml
+++ b/tests/power/multicore/arc/testcase.yaml
@@ -1,4 +1,4 @@
 tests:
-  - test:
-      tags: pm
-      platform_whitelist: quark_se_c1000_ss_devboard
+  test:
+    platform_whitelist: quark_se_c1000_ss_devboard
+    tags: pm

--- a/tests/power/multicore/lmt/testcase.yaml
+++ b/tests/power/multicore/lmt/testcase.yaml
@@ -1,4 +1,4 @@
 tests:
-  - test:
-      tags: pm
-      platform_whitelist: quark_se_c1000_devboard
+  test:
+    platform_whitelist: quark_se_c1000_devboard
+    tags: pm

--- a/tests/power/power_states/testcase.yaml
+++ b/tests/power/power_states/testcase.yaml
@@ -1,12 +1,12 @@
 tests:
-  - test:
-      build_only: true
-      filter: (CONFIG_SOC_QUARK_SE_C1000 or CONFIG_SOC_QUARK_SE_C1000_SS)
-      platform_exclude: tinytile panther
-      tags: samples power
-  - test_socwatch:
-      build_only: true
-      extra_args: CONF_FILE="prj_socwatch.conf"
-      filter: CONFIG_SOC_QUARK_SE_C1000
-      platform_exclude: tinytile panther
-      tags: samples power
+  test:
+    build_only: true
+    filter: (CONFIG_SOC_QUARK_SE_C1000 or CONFIG_SOC_QUARK_SE_C1000_SS)
+    platform_exclude: tinytile panther
+    tags: samples power
+  test_socwatch:
+    build_only: true
+    extra_args: CONF_FILE="prj_socwatch.conf"
+    filter: CONFIG_SOC_QUARK_SE_C1000
+    platform_exclude: tinytile panther
+    tags: samples power

--- a/tests/shell/testcase.yaml
+++ b/tests/shell/testcase.yaml
@@ -1,4 +1,4 @@
 tests:
-  - test:
-      filter: (CONFIG_UART_CONSOLE and CONFIG_SERIAL_SUPPORT_INTERRUPT)
-      tags: shell
+  test:
+    filter: (CONFIG_UART_CONSOLE and CONFIG_SERIAL_SUPPORT_INTERRUPT)
+    tags: shell

--- a/tests/subsys/debug/gdb_server/testcase.yaml
+++ b/tests/subsys/debug/gdb_server/testcase.yaml
@@ -1,5 +1,5 @@
 tests:
-  - test:
-      build_only: true
-      platform_whitelist: qemu_x86
-      tags: apps
+  test:
+    build_only: true
+    platform_whitelist: qemu_x86
+    tags: apps

--- a/tests/subsys/dfu/img_util/testcase.yaml
+++ b/tests/subsys/dfu/img_util/testcase.yaml
@@ -1,5 +1,5 @@
 tests:
-  - test:
-      build_only: true
-      platform_whitelist: nrf52840_pca10056
-      tags: dfu_image_util
+  test:
+    build_only: true
+    platform_whitelist: nrf52840_pca10056
+    tags: dfu_image_util

--- a/tests/subsys/dfu/mcuboot/testcase.yaml
+++ b/tests/subsys/dfu/mcuboot/testcase.yaml
@@ -1,5 +1,5 @@
 tests:
-  - test:
-      build_only: true
-      platform_whitelist: nrf52840_pca10056
-      tags: dfu_mcuboot
+  test:
+    build_only: true
+    platform_whitelist: nrf52840_pca10056
+    tags: dfu_mcuboot

--- a/tests/subsys/fs/fat_fs_api/testcase.yaml
+++ b/tests/subsys/fs/fat_fs_api/testcase.yaml
@@ -1,5 +1,5 @@
 tests:
-  - test:
-      build_only: true
-      platform_whitelist: arduino_101
-      tags: fs
+  test:
+    build_only: true
+    platform_whitelist: arduino_101
+    tags: fs

--- a/tests/subsys/fs/nffs_fs_api/testcase.yaml
+++ b/tests/subsys/fs/nffs_fs_api/testcase.yaml
@@ -1,15 +1,15 @@
 tests:
-  - test_basic:
-      platform_whitelist: qemu_x86
-      tags: nffs fs
-  - test_large:
-      extra_args: TEST=large
-      platform_whitelist: qemu_x86
-      tags: nffs fs
-  - test_cache:
-      extra_args: TEST=cache
-      extra_configs:
-        - CONFIG_FS_NFFS_NUM_CACHE_BLOCKS=64
-        - CONFIG_FS_NFFS_NUM_CACHE_INODES=4
-      platform_whitelist: qemu_x86
-      tags: nffs fs
+  test_basic:
+    platform_whitelist: qemu_x86
+    tags: nffs fs
+  test_cache:
+    extra_args: TEST=cache
+    extra_configs:
+      - CONFIG_FS_NFFS_NUM_CACHE_BLOCKS=64
+      - CONFIG_FS_NFFS_NUM_CACHE_INODES=4
+    platform_whitelist: qemu_x86
+    tags: nffs fs
+  test_large:
+    extra_args: TEST=large
+    platform_whitelist: qemu_x86
+    tags: nffs fs

--- a/tests/unit/bluetooth/at/testcase.yaml
+++ b/tests/unit/bluetooth/at/testcase.yaml
@@ -1,6 +1,6 @@
 tests:
-  - test:
-      build_only: true
-      min_ram: 16
-      platform_whitelist: qemu_x86_iamcu qemu_cortex_m3
-      tags: bluetooth
+  test:
+    build_only: true
+    min_ram: 16
+    platform_whitelist: qemu_x86_iamcu qemu_cortex_m3
+    tags: bluetooth

--- a/tests/unit/drivers/crc/testcase.yaml
+++ b/tests/unit/drivers/crc/testcase.yaml
@@ -1,5 +1,5 @@
 tests:
-  - test:
-      tags: net crc
-      timeout: 5
-      type: unit
+  test:
+    tags: net crc
+    timeout: 5
+    type: unit

--- a/tests/unit/net/buf/testcase.yaml
+++ b/tests/unit/net/buf/testcase.yaml
@@ -1,5 +1,5 @@
 tests:
-  - test:
-      tags: buf
-      timeout: 5
-      type: unit
+  test:
+    tags: buf
+    timeout: 5
+    type: unit

--- a/tests/ztest/test/base/testcase.yaml
+++ b/tests/ztest/test/base/testcase.yaml
@@ -1,13 +1,13 @@
 tests:
-  - test_verbose_0:
-      extra_args: CONF_FILE=prj_verbose_0.conf
-      tags: test_framework
-  - test_verbose_1:
-      extra_args: CONF_FILE=prj_verbose_1.conf
-      tags: test_framework
-  - test_verbose_2:
-      extra_args: CONF_FILE=prj_verbose_2.conf
-      tags: test_framework
-  - test:
-      tags: test_framework
-      type: unit
+  test:
+    tags: test_framework
+    type: unit
+  test_verbose_0:
+    extra_args: CONF_FILE=prj_verbose_0.conf
+    tags: test_framework
+  test_verbose_1:
+    extra_args: CONF_FILE=prj_verbose_1.conf
+    tags: test_framework
+  test_verbose_2:
+    extra_args: CONF_FILE=prj_verbose_2.conf
+    tags: test_framework

--- a/tests/ztest/test/mock/testcase.yaml
+++ b/tests/ztest/test/mock/testcase.yaml
@@ -1,7 +1,7 @@
 tests:
-  - test:
-      arch_exclude: arm
-      tags: test_framework
-  - test_unit:
-      tags: test_framework
-      type: unit
+  test:
+    arch_exclude: arm
+    tags: test_framework
+  test_unit:
+    tags: test_framework
+    type: unit


### PR DESCRIPTION
-  boards: fix board yaml syntax
-  tests/samples: fixed yaml syntax
-  sanitycheck: refactor data parsing in script
-  sanitycheck: flake8 fixes and move closer to pep8
-  sanitycheck: use test instead of section
-  sanitycheck: reworked Platform/Architecture classes
-  sanitycheck: remove platform-level option
-  sanitycheck: we do not need to pass ARCH= on command line
-  sanitycheck: descriptive variable names
-  sanitycheck: remove usage of qemu for generic handlers
-  sanitycheck: disable expr parser debug
-  sanitycheck: allow placing parsetab.py in a custom dir