### PR TITLE
drivers: serial: stm32: report only unmasked irq

### DIFF
--- a/drivers/serial/uart_stm32.c
+++ b/drivers/serial/uart_stm32.c
@@ -197,8 +197,10 @@ static int uart_stm32_irq_is_pending(struct device *dev)
 {
 	USART_TypeDef *UartInstance = UART_STRUCT(dev);
 
-	return (LL_USART_IsActiveFlag_RXNE(UartInstance) ||
-		LL_USART_IsActiveFlag_TXE(UartInstance));
+	return ((LL_USART_IsActiveFlag_RXNE(UartInstance) &&
+		 LL_USART_IsEnabledIT_RXNE(UartInstance)) ||
+		(LL_USART_IsActiveFlag_TXE(UartInstance) &&
+		 LL_USART_IsEnabledIT_TXE(UartInstance)));
 }
 
 static int uart_stm32_irq_update(struct device *dev)


### PR DESCRIPTION
Fix #5298
irq_is_pending function returned TXE/RXNE flag status
even if IRQ was masked, which led to enless loop
in uart_pipe when no TX was performed. Fix by reporting status only when
IRQ is unmasked.

Signed-Off-by: Erwan Gouriou <erwan.gouriou@linaro.org>