### PR TITLE
Show usage on invalid usage

### DIFF
--- a/cmake/app/boilerplate.cmake
+++ b/cmake/app/boilerplate.cmake
@@ -155,7 +155,8 @@ set(CACHED_BOARD ${BOARD} CACHE STRING "Selected board")
 # e.g. zephyr/boards/arm/96b_carbon_nrf51/96b_carbon_nrf51_defconfig. When
 # found, use that path to infer the ARCH we are building for.
 find_path(BOARD_DIR NAMES "${BOARD}_defconfig" PATHS $ENV{ZEPHYR_BASE}/boards/*/* NO_DEFAULT_PATH)
-assert(BOARD_DIR "No board named '${BOARD}' found")
+
+assert_with_usage(BOARD_DIR "No board named '${BOARD}' found")
 
 get_filename_component(BOARD_ARCH_DIR ${BOARD_DIR} DIRECTORY)
 get_filename_component(ARCH ${BOARD_ARCH_DIR} NAME)

--- a/cmake/extensions.cmake
+++ b/cmake/extensions.cmake
@@ -811,3 +811,21 @@ macro(assert_exists var)
     message(FATAL_ERROR "No such file or directory: ${var}: '${${var}}'")
   endif()
 endmacro()
+
+# Usage:
+#   assert_with_usage(BOARD_DIR "No board named '${BOARD}' found")
+#
+# will print an error message, show usage, and then end executioon
+# with a FATAL_ERROR if the test fails.
+macro(assert_with_usage test comment)
+  if(NOT ${test})
+    message(${comment})
+    message("see usage:")
+    execute_process(
+      COMMAND
+      ${CMAKE_COMMAND} -P $ENV{ZEPHYR_BASE}/cmake/usage/usage.cmake
+      )
+    message(FATAL_ERROR "Invalid usage")
+  endif()
+endmacro()
+


### PR DESCRIPTION
There is a catch-22 in that you need to run CMake to get a build
system that can show you usage, but you need to know the usage to be
able to get a build system.

This assert improves the usability somewhat. When an invalid board
is detected it will print usage, which includes the list of boards.
