### PR TITLE
Bluetooth: controller: Fix missing CPR procedure reset

### DIFF
--- a/subsys/bluetooth/controller/ll_sw/ctrl.c
+++ b/subsys/bluetooth/controller/ll_sw/ctrl.c
@@ -5155,6 +5155,9 @@ static void mayfly_sched_win_offset_select(void *params)
 		/* procedure request acked */
 		conn->llcp_ack = conn->llcp_req;
 
+		/* CPR request acked */
+		conn->llcp_conn_param.ack = conn->llcp_conn_param.req;
+
 		/* reset mutex */
 		_radio.conn_upd = NULL;
 


### PR DESCRIPTION
When connection parameter request procedure was responded
by master role with Unsupported Link Layer Parameter Value,
a missing reset of the connection parameter request
procedure state caused next connection parameter request to
be incorrectly responded with same procedure collision
extended reject ind PDU. This caused an eventual connection
disconnection with reason LMP response timeout. This is now
fixed by reseting the state correctly.

Signed-off-by: Vinayak Kariappa Chettimada <vich@nordicsemi.no>