### PR TITLE
Fix exti configuration on STM32F0

### DIFF
--- a/arch/arm/soc/st_stm32/stm32f0/gpio_registers.h
+++ b/arch/arm/soc/st_stm32/stm32f0/gpio_registers.h
@@ -66,6 +66,7 @@ union syscfg__exticr {
 
 struct stm32f0x_syscfg {
 	union syscfg_cfgr1 cfgr1;
+	u32_t rsvd;
 	union syscfg__exticr exticr1;
 	union syscfg__exticr exticr2;
 	union syscfg__exticr exticr3;


### PR DESCRIPTION
The exticrX registers were shifted by a word, so configuring an EXTI line on a port different of PA misconfigured the EXTI line source and could flood with unwanted events.
