### PR TITLE
Bluetooth: Introduce Bluetooth Testing API

### DIFF
--- a/subsys/bluetooth/host/CMakeLists.txt
+++ b/subsys/bluetooth/host/CMakeLists.txt
@@ -12,6 +12,7 @@ zephyr_library_sources_ifdef(CONFIG_BT_TINYCRYPT_ECC    hci_ecc.c)
 zephyr_library_sources_ifdef(CONFIG_BT_A2DP             a2dp.c)
 zephyr_library_sources_ifdef(CONFIG_BT_AVDTP            avdtp.c)
 zephyr_library_sources_ifdef(CONFIG_BT_RFCOMM           rfcomm.c)
+zephyr_library_sources_ifdef(CONFIG_BT_TESTING          testing.c)
 
 zephyr_library_sources_ifdef(
   CONFIG_BT_BREDR

--- a/subsys/bluetooth/host/Kconfig
+++ b/subsys/bluetooth/host/Kconfig
@@ -444,6 +444,12 @@ config BT_DEBUG_SDP
 		This option enables debug support for the Bluetooth
 		Service Discovery Protocol (SDP).
 
+config BT_TESTING
+	bool "Bluetooth Testing"
+	help
+	  This option enables custom Bluetooth testing interface.
+	  Shall only be used for testing purposes.
+
 endif # BT_DEBUG
 
 config BT_BREDR

--- a/subsys/bluetooth/host/mesh/transport.c
+++ b/subsys/bluetooth/host/mesh/transport.c
@@ -30,6 +30,7 @@
 #include "access.h"
 #include "foundation.h"
 #include "transport.h"
+#include "../testing.h"
 
 #define AID_MASK                    ((u8_t)(BIT_MASK(6)))
 
@@ -1275,6 +1276,11 @@ int bt_mesh_trans_recv(struct net_buf_simple *buf, struct bt_mesh_net_rx *rx)
 	net_buf_simple_pull(buf, BT_MESH_NET_HDR_LEN);
 
 	BT_DBG("Payload %s", bt_hex(buf->data, buf->len));
+
+	if (IS_ENABLED(CONFIG_BT_TESTING)) {
+		bt_test_mesh_net_recv(rx->ctx.recv_ttl, rx->ctl, rx->ctx.addr,
+				      rx->dst, buf->data, buf->len);
+	}
 
 	/* If LPN mode is enabled messages are only accepted when we've
 	 * requested the Friend to send them. The messages must also

--- a/subsys/bluetooth/host/testing.c
+++ b/subsys/bluetooth/host/testing.c
@@ -1,0 +1,35 @@
+/*
+ * Copyright (c) 2017 Intel Corporation
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <zephyr.h>
+#include <stddef.h>
+
+#include "testing.h"
+
+static sys_slist_t cb_slist;
+
+void bt_test_cb_register(struct bt_test_cb *cb)
+{
+	sys_slist_append(&cb_slist, &cb->node);
+}
+
+void bt_test_cb_unregister(struct bt_test_cb *cb)
+{
+	sys_slist_find_and_remove(&cb_slist, &cb->node);
+}
+
+void bt_test_mesh_net_recv(u8_t ttl, u8_t ctl, u16_t src, u16_t dst,
+			   const void *payload, size_t payload_len)
+{
+	struct bt_test_cb *cb;
+
+	SYS_SLIST_FOR_EACH_CONTAINER(&cb_slist, cb, node) {
+		if (cb->mesh_net_recv) {
+			cb->mesh_net_recv(ttl, ctl, src, dst, payload,
+					  payload_len);
+		}
+	}
+}

--- a/subsys/bluetooth/host/testing.h
+++ b/subsys/bluetooth/host/testing.h
@@ -1,0 +1,23 @@
+/**
+ * @file testing.h
+ * @brief Internal API for Bluetooth testing.
+ */
+
+/*
+ * Copyright (c) 2017 Intel Corporation
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+struct bt_test_cb {
+	void (*mesh_net_recv)(u8_t ttl, u8_t ctl, u16_t src, u16_t dst,
+			      const void *payload, size_t payload_len);
+
+	sys_snode_t node;
+};
+
+void bt_test_cb_register(struct bt_test_cb *cb);
+void bt_test_cb_unregister(struct bt_test_cb *cb);
+
+void bt_test_mesh_net_recv(u8_t ttl, u8_t ctl, u16_t src, u16_t dst,
+			   const void *payload, size_t payload_len);


### PR DESCRIPTION
This introduces Bluetooth internal API intended to be used for
qualification purposes. Application may register callbacks to get
data that is not exposed by public API.

Signed-off-by: Mariusz Skamra <mariusz.skamra@codecoup.pl>