### PR TITLE
cmake: Fix the dependency between qemu and the elf file

### DIFF
--- a/cmake/qemu/CMakeLists.txt
+++ b/cmake/qemu/CMakeLists.txt
@@ -159,6 +159,7 @@ if(EMU_PLATFORM)
       ${QEMU_EXTRA_FLAGS}
       ${MORE_FLAGS_FOR_${target}}
       -kernel $<TARGET_FILE:${logical_target_for_zephyr_elf}>
+      DEPENDS ${logical_target_for_zephyr_elf}
       WORKING_DIRECTORY ${APPLICATION_BINARY_DIR}
       COMMENT "${QEMU_PIPE_COMMENT}[QEMU] CPU: ${QEMU_CPU_TYPE_${ARCH}}"
       USES_TERMINAL


### PR DESCRIPTION
I can't explain why "make run" worked before, but after this patch it
should definitely work.

Issues were observed with the jailhouse target when this DEPENDS was missing.

Signed-off-by: Sebastian Bøe <sebastian.boe@nordicsemi.no>