### PR TITLE
Bluetooth: Mesh: Fix typo in Kconfig help message

### DIFF
--- a/subsys/bluetooth/host/mesh/Kconfig
+++ b/subsys/bluetooth/host/mesh/Kconfig
@@ -291,7 +291,7 @@ config BT_MESH_LPN_INIT_POLL_TIMEOUT
 	  gets established for the first time. After this the timeout
 	  will gradually grow toward the actual PollTimeout, doubling
 	  in value for each iteration. The value is in units of 100
-	  milliseconds, so e.g. a value of 300 means 3 seconds.
+	  milliseconds, so e.g. a value of 300 means 30 seconds.
 
 config BT_MESH_LPN_SCAN_LATENCY
 	int "Latency for enabling scanning"


### PR DESCRIPTION
300 * 100 ms = 30000 ms = 30 s

Signed-off-by: Michał Narajowski <michal.narajowski@codecoup.pl>