### PR TITLE
tests: power: Added build only tag to yaml file.

### DIFF
--- a/tests/power/multicore/arc/testcase.yaml
+++ b/tests/power/multicore/arc/testcase.yaml
@@ -1,4 +1,5 @@
 tests:
   - test:
       tags: pm
+      build_only: true
       platform_whitelist: quark_se_c1000_ss_devboard

--- a/tests/power/multicore/lmt/testcase.yaml
+++ b/tests/power/multicore/lmt/testcase.yaml
@@ -1,4 +1,5 @@
 tests:
   - test:
       tags: pm
+      build_only: true
       platform_whitelist: quark_se_c1000_devboard


### PR DESCRIPTION
This testcase involve image to be flashed on lmt and arc core
and then the result need to be evaluated. Hence multicore
testcase on lmt and arc cannot be executed independently and
therefore making it as build only in yaml.

Signed-off-by: Nirmala Devi <nirmala.devix.m@intel.com>