### PR TITLE
usb: Fix USB Device dependency

### DIFF
--- a/drivers/usb/device/Kconfig
+++ b/drivers/usb/device/Kconfig
@@ -8,9 +8,14 @@
 
 if USB
 
+config USB_DEVICE_DRIVER
+	bool
+	default n
+
 config USB_DW
 	bool
 	prompt "Designware USB Device Controller Driver"
+	select USB_DEVICE_DRIVER
 	default n
 	help
 	Designware USB Device Controller Driver.
@@ -26,6 +31,7 @@ config USB_DC_STM32
 	prompt "USB device controller driver for STM32 devices"
 	depends on HAS_STM32CUBE
 	depends on SOC_SERIES_STM32F4X
+	select USB_DEVICE_DRIVER
 	default n
 	help
 	STM32 family USB device controller Driver.

--- a/subsys/usb/Kconfig
+++ b/subsys/usb/Kconfig
@@ -9,7 +9,7 @@
 menuconfig USB_DEVICE_STACK
 	bool
 	prompt "USB device stack"
-	depends on USB
+	depends on USB_DEVICE_DRIVER
 	default n
 	help
 	Enable USB device stack.


### PR DESCRIPTION
USB Device stack should depend on supported drivers not on menuconfig
option.

Fixes: #5177

Signed-off-by: Andrei Emeltchenko <andrei.emeltchenko@intel.com>