### PR TITLE
tests: power: Fix compiler definition flag

### DIFF
--- a/tests/power/multicore/README.rst
+++ b/tests/power/multicore/README.rst
@@ -103,13 +103,15 @@ commands:
 
 ::
 
-    $ cd tests/power/multicore/lmt TEST_CASE=sleep-success
+    $ cd tests/power/multicore/lmt
+    $ mkdir build && cd build
+    $ cmake -DBOARD=quark_se_c1000_devboard -DTEST_CASE=sleep-success ..
     $ make
 
-When 'TEST_CASE=sleep-fail', application is busy for 5 seconds and idle for 15
-seconds. This means that ARC core will be busy when LMT core tries to enter in
-DEEP_SLEEP, and it will fail. In this case the output on your console should
-look like this:
+When test case compiled with no flags enabled, the application is busy
+for 5 seconds and idle for 15 seconds. This means that ARC core will be
+busy when LMT core tries to enter in DEEP_SLEEP, and it will fail.
+In this case the output on your console should look like this:
 
 ::
 
@@ -134,7 +136,9 @@ commands:
 ::
 
     $ cd tests/power/multicore/lmt
-    $ make TEST_CASE=sleep-fail
+    $ mkdir build && cd build
+    $ cmake -DBOARD=quark_se_c1000_devboard ..
+    $ make
 
 The application uses UART_1 device as console output device, which is the
 default console device.

--- a/tests/power/multicore/lmt/CMakeLists.txt
+++ b/tests/power/multicore/lmt/CMakeLists.txt
@@ -4,3 +4,8 @@ project(NONE)
 target_include_directories(app PRIVATE $ENV{ZEPHYR_BASE}/drivers)
 FILE(GLOB app_sources src/*.c)
 target_sources(app PRIVATE ${app_sources})
+if(TEST_CASE STREQUAL sleep-success)
+    target_compile_definitions(app PRIVATE
+	    -DTEST_CASE_SLEEP_SUCCESS
+	)
+endif()

--- a/tests/power/multicore/lmt/testcase.yaml
+++ b/tests/power/multicore/lmt/testcase.yaml
@@ -1,4 +1,5 @@
 tests:
   test:
     platform_whitelist: quark_se_c1000_devboard
+    extra_args: TEST_CASE=sleep-success
     tags: pm


### PR DESCRIPTION
Enabled compiler definition flag TEST_CASE_SLEEP_SUCCESS
which was missing on migrating to cmake.

Signed-off-by: Nirmala Devi <nirmala.devix.m@intel.com>