### PR TITLE
samples: Don't read board from cmake -DBOARD=x

### DIFF
--- a/samples/net/mbedtls_sslclient/CMakeLists.txt
+++ b/samples/net/mbedtls_sslclient/CMakeLists.txt
@@ -1,5 +1,3 @@
-set(CONF_FILE "prj_${BOARD}.conf")
-
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
 project(NONE)
 

--- a/samples/net/mbedtls_sslclient/README
+++ b/samples/net/mbedtls_sslclient/README
@@ -24,7 +24,7 @@ b) From a terminal window, type:
 
     $ cd $ZEPHYR_BASE/samples/net/mbedtls_sslclient
     $ mkdir qemu_build && cd qemu_build
-    $ cmake -DBOARD=<board to use> -DCONF_FILE=<your desired conf file> ..
+    $ cmake -DBOARD=<board to use> ..
 
 c) Copy the binary (outdir/zephyr.strip) to the Galileo's boot
    device. Insert the boot device.

--- a/samples/net/mqtt_publisher/CMakeLists.txt
+++ b/samples/net/mqtt_publisher/CMakeLists.txt
@@ -1,5 +1,3 @@
-set(CONF_FILE "prj_${BOARD}.conf")
-
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
 project(NONE)
 


### PR DESCRIPTION
The CMakeLists.txt file was reading ${BOARD}, but this means the user
must set BOARD like this cmake -DBOARD=foo. The user must be allowed
to set BOARD from the environment.

The code was unnecessary anyway because the convention
prj_${BOARD}.conf is known by boilerplate and therefore not necessary
to specify.

Signed-off-by: Sebastian Bøe <sebastian.boe@nordicsemi.no>