### PR TITLE
Bluetooth: tester: Fix undeclared CONFIG_UART_PIPE_ON_DEV_NAME

### DIFF
--- a/tests/bluetooth/tester/nrf52840_pca10056.overlay
+++ b/tests/bluetooth/tester/nrf52840_pca10056.overlay
@@ -1,0 +1,11 @@
+/ {
+	chosen {
+		zephyr,uart-pipe = &uart0;
+	};
+};
+
+&uart0 {
+	compatible = "nordic,nrf-uart";
+	current-speed = <115200>;
+	status = "ok";
+};


### PR DESCRIPTION
This fixes build error due to undeclared CONFIG_UART_PIPE_ON_DEV_NAME
on nrf52840 board.

Signed-off-by: Mariusz Skamra <mariusz.skamra@codecoup.pl>