### PR TITLE
net: lwm2m: add support for coap2coap proxy

### DIFF
--- a/subsys/net/lib/lwm2m/Kconfig
+++ b/subsys/net/lib/lwm2m/Kconfig
@@ -163,14 +163,6 @@ config LWM2M_FIRMWARE_UPDATE_PULL_COAP_PROXY_ADDR
 	help
 	  Network address of the CoAP proxy server.
 
-config LWM2M_FIRMWARE_UPDATE_PULL_COAP_PROXY_URI_PATH
-	string "CoAP URI path element used by the proxy"
-	default "coap2http"
-	help
-	  CoAP URI path element exported by the CoAP proxy server.
-	  Defaults to coap2http, which is the URI path used by the
-	  Californium CoAP-HTTP proxy.
-
 endif # LWM2M_FIRMWARE_UPDATE_PULL_COAP_PROXY_SUPPORT
 
 config LWM2M_RW_JSON_SUPPORT


### PR DESCRIPTION
Currently, LwM2M firmware download only supports coap2http proxy.
Let's add support for coap2coap proxy as well.

This was tested using Californium demo app cf-proxy with the following
setting changed in Californum.properties:
MAX_RESOURCE_BODY_SIZE=524288

This allows the proxy to get the firmware resource from a remote
server and then deliver it to the requesting device.

Signed-off-by: Michael Scott <michael@opensourcefoundries.com>