### PR TITLE
net: ip: net_pkt: set pkt context, iface and family in net_pkt_get()

### DIFF
--- a/subsys/net/ip/net_pkt.c
+++ b/subsys/net/ip/net_pkt.c
@@ -499,6 +499,7 @@ static struct net_pkt *net_pkt_get(struct k_mem_slab *slab,
 	struct in6_addr *addr6 = NULL;
 	struct net_if *iface;
 	struct net_pkt *pkt;
+	sa_family_t family;
 
 	if (!context) {
 		return NULL;
@@ -520,18 +521,20 @@ static struct net_pkt *net_pkt_get(struct k_mem_slab *slab,
 	pkt = net_pkt_get_reserve(slab, net_if_get_ll_reserve(iface, addr6),
 				  timeout);
 #endif
-	if (pkt && slab != &rx_pkts) {
-		sa_family_t family;
+	if (!pkt) {
+		return NULL;
+	}
+
+	net_pkt_set_context(pkt, context);
+	net_pkt_set_iface(pkt, iface);
+	family = net_context_get_family(context);
+	net_pkt_set_family(pkt, family);
+
+	if (slab != &rx_pkts) {
 		uint16_t iface_len, data_len = 0;
 		enum net_ip_protocol proto;
 
-		net_pkt_set_context(pkt, context);
-		net_pkt_set_iface(pkt, iface);
-
 		iface_len = net_if_get_mtu(iface);
-
-		family = net_context_get_family(context);
-		net_pkt_set_family(pkt, family);
 
 		if (IS_ENABLED(CONFIG_NET_IPV6) && family == AF_INET6) {
 			data_len = max(iface_len, NET_IPV6_MTU);

--- a/subsys/net/lib/app/net_app.c
+++ b/subsys/net/lib/app/net_app.c
@@ -2084,6 +2084,7 @@ reset:
 				ctx->tls.mbedtls.ssl_ctx.hdr = NULL;
 			}
 
+			pkt->data_len = len;
 			ret = net_pkt_append_all(pkt, len,
 						 ctx->tls.request_buf,
 						 BUF_ALLOC_TIMEOUT);


### PR DESCRIPTION
Commit 753daa6 ("net: pkt: Compute TX payload data length")
removed the default packet setup on incoming packets when they
belong to the rx_pkt pool.

Let's restore this behavior, as MBEDTLS processing in net_app library
needs to use packet family to determine IP header length on
incoming packets.

Also, due to the way MTU is checked in net_pkt_append, let's set the
packet's data_len field to a nice high value so that it doesn't get
in the way.

NOTE: A future cleanup patch could set the IP header length based
on the context IP family.  However, there are many places in the code
where this is being set, so care should be taken.

Signed-off-by: Michael Scott <michael@opensourcefoundries.com>