### PR TITLE
boards: nios2: fix nios2 flashing issue

### DIFF
--- a/arch/nios2/soc/nios2f-zephyr/CMakeLists.txt
+++ b/arch/nios2/soc/nios2f-zephyr/CMakeLists.txt
@@ -1,2 +1,0 @@
-
-set($ENV{NIOS2_CPU_SOF} $ENV{ZEPHYR_BASE}/arch/nios2/soc/nios2f-zephyr/cpu/ghrd_10m50da.sof)

--- a/boards/nios2/altera_max10/board.cmake
+++ b/boards/nios2/altera_max10/board.cmake
@@ -1,2 +1,4 @@
 set(FLASH_SCRIPT nios2.sh)
 set(DEBUG_SCRIPT nios2.sh)
+set(NIOS2_CPU_SOF $ENV{ZEPHYR_BASE}/arch/nios2/soc/nios2f-zephyr/cpu/ghrd_10m50da.sof)
+set_property(GLOBAL APPEND PROPERTY FLASH_SCRIPT_ENV_VARS NIOS2_CPU_SOF)


### PR DESCRIPTION
'make flash' is failing for altera_max10 board due to the
missing NIOS2_CPU_SOF environment variable. Though it is set
in arch/nios2/soc/nios2f-zephyr/CMakeLists.txt but it is not
taking effect when flashing script is run. The reason could be
following whichis mentioned in https://itk.org/Wiki/CMake_FAQ

"environment variables SET in the CMakeLists.txt only
take effect for cmake itself (configure-time), so you cannot use
this method to set an environment variable that a custom command
might need (build-time)."

Now, NIOS2_CPU_SOF is set from boards/nios2/altera_max10/board.cmake
file which is more logical because all the FLASH related environment
variables are being set from board.cmake

Signed-off-by: Ramakrishna Pallala <ramakrishna.pallala@intel.com>