### PR TITLE
tests/drivers/build_all: use tc_util to unify test output

### DIFF
--- a/tests/drivers/build_all/src/Makefile
+++ b/tests/drivers/build_all/src/Makefile
@@ -1,0 +1,3 @@
+ccflags-y += -I${ZEPHYR_BASE}/tests/include
+
+obj-y += main.o

--- a/tests/drivers/build_all/src/main.c
+++ b/tests/drivers/build_all/src/main.c
@@ -6,6 +6,7 @@
 
 #include <zephyr.h>
 #include <misc/printk.h>
+#include <tc_util.h>
 
 
 /*
@@ -16,6 +17,11 @@
 
 void main(void)
 {
+	TC_START("test_build");
+
 	printk("Hello World!\n");
+
+	TC_END_RESULT(TC_PASS);
+	TC_END_REPORT(TC_PASS);
 }
 


### PR DESCRIPTION
Use the macros defined in tc_util.h to print unified test start and
result output so that test automation tool can parse test output in the
same way.

Signed-off-by: Chase Qi <chase.qi@linaro.org>