### PR TITLE
boards: quark_d2000: openocd: Fixed load image command for D2000.

### DIFF
--- a/boards/x86/quark_d2000_crb/board.cmake
+++ b/boards/x86/quark_d2000_crb/board.cmake
@@ -1,1 +1,7 @@
 include($ENV{ZEPHYR_BASE}/boards/common/openocd.board.cmake)
+
+set(OPENOCD_LOAD_CMD "load_image     ${PROJECT_BINARY_DIR}/${KERNEL_BIN_NAME} ${CONFIG_FLASH_BASE_ADDRESS}")
+
+set_property(GLOBAL APPEND PROPERTY FLASH_SCRIPT_ENV_VARS
+  OPENOCD_LOAD_CMD
+  )


### PR DESCRIPTION
During cmake migration the load image was not correctly set.
This was causing flash failures.

Signed-off-by: Adithya Baglody <adithya.nagaraj.baglody@intel.com>