### PR TITLE
[WIP] kconfig: fix help syntax and add spaces

### DIFF
--- a/arch/Kconfig
+++ b/arch/Kconfig
@@ -42,42 +42,42 @@ config HW_STACK_PROTECTION
 	bool "Hardware Stack Protection"
 	depends on ARCH_HAS_STACK_PROTECTION
 	help
-	Select this option to enable hardware-based platform features to
-	catch stack overflows when the system is running in privileged
-	mode. If CONFIG_USERSPACE is not enabled, the system is always
-	running in privileged mode.
+	  Select this option to enable hardware-based platform features to
+	  catch stack overflows when the system is running in privileged
+	  mode. If CONFIG_USERSPACE is not enabled, the system is always
+	  running in privileged mode.
 
-	Note that this does not necessarily prevent corruption and assertions
-	about the overall system state when a fault is triggered cannot be
-	made.
+	  Note that this does not necessarily prevent corruption and assertions
+	  about the overall system state when a fault is triggered cannot be
+	  made.
 
 config USERSPACE
 	bool "User mode threads (EXPERIMENTAL)"
 	depends on ARCH_HAS_USERSPACE
 	help
-	When enabled, threads may be created or dropped down to user mode,
-	which has significantly restricted permissions and must interact
-	with the kernel via system calls. See Zephyr documentation for more
-	details	about this feature.
+	  When enabled, threads may be created or dropped down to user mode,
+	  which has significantly restricted permissions and must interact
+	  with the kernel via system calls. See Zephyr documentation for more
+	  details	about this feature.
 
-	If a user thread overflows its stack, this will be caught and the
-	kernel itself will be shielded from harm. Enabling this option
-	may or may not catch stack overflows when the system is in
-	privileged mode or handling a system call; to ensure these are always
-	caught, enable CONFIG_HW_STACK_PROTECTION.
+	  If a user thread overflows its stack, this will be caught and the
+	  kernel itself will be shielded from harm. Enabling this option
+	  may or may not catch stack overflows when the system is in
+	  privileged mode or handling a system call; to ensure these are always
+	  caught, enable CONFIG_HW_STACK_PROTECTION.
 
-	This feature is under heavy development and APIs related to it are
-	subject to change, even if declared non-private.
+	  This feature is under heavy development and APIs related to it are
+	  subject to change, even if declared non-private.
 
 config MAX_THREAD_BYTES
 	int "Bytes to use when tracking object thread permissions"
 	default 2
 	depends on USERSPACE
 	help
-	Every kernel object will have an associated bitfield to store
-	thread permissions for that object. This controls the size of the
-	bitfield (in bytes) and imposes a limit on how many threads can
-	be created in the system.
+	  Every kernel object will have an associated bitfield to store
+	  thread permissions for that object. This controls the size of the
+	  bitfield (in bytes) and imposes a limit on how many threads can
+	  be created in the system.
 
 config SIMPLE_FATAL_ERROR_HANDLER
 	prompt "Simple system fatal error handler"
@@ -85,10 +85,10 @@ config SIMPLE_FATAL_ERROR_HANDLER
 	default n
 	default y if !MULTITHREADING
 	help
-	Provides an implementation of _SysFatalErrorHandler() that hard hangs
-	instead of aborting the faulting thread, and does not print anything,
-	for footprint-concerned systems. Only enable this option if you do not
-	want debug capabilities in case of system fatal error.
+	  Provides an implementation of _SysFatalErrorHandler() that hard hangs
+	  instead of aborting the faulting thread, and does not print anything,
+	  for footprint-concerned systems. Only enable this option if you do not
+	  want debug capabilities in case of system fatal error.
 
 menu "Interrupt Configuration"
 #
@@ -99,9 +99,9 @@ config GEN_ISR_TABLES
 	prompt "Use generated IRQ tables"
 	default n
 	help
-	This option controls whether a platform uses the gen_isr_tables
-	script to generate its interrupt tables. This mechanism will create
-	an appropriate hardware vector table and/or software IRQ table.
+	  This option controls whether a platform uses the gen_isr_tables
+	  script to generate its interrupt tables. This mechanism will create
+	  an appropriate hardware vector table and/or software IRQ table.
 
 config GEN_IRQ_VECTOR_TABLE
 	bool
@@ -109,12 +109,12 @@ config GEN_IRQ_VECTOR_TABLE
 	default y
 	depends on GEN_ISR_TABLES
 	help
-	This option controls whether a platform using gen_isr_tables
-	needs an interrupt vector table created. Only disable this if the
-	platform does not use a vector table at all, or requires the vector
-	table to be in a format that is not an array of function pointers
-	indexed by IRQ line. In the latter case, the vector table must be
-	supplied by the application or architecture code.
+	  This option controls whether a platform using gen_isr_tables
+	  needs an interrupt vector table created. Only disable this if the
+	  platform does not use a vector table at all, or requires the vector
+	  table to be in a format that is not an array of function pointers
+	  indexed by IRQ line. In the latter case, the vector table must be
+	  supplied by the application or architecture code.
 
 config GEN_SW_ISR_TABLE
 	bool
@@ -122,22 +122,22 @@ config GEN_SW_ISR_TABLE
 	default y
 	depends on GEN_ISR_TABLES
 	help
-	This option controls whether a platform using gen_isr_tables
-	needs a software ISR table table created. This is an array of struct
-	_isr_table_entry containing the interrupt service routine and supplied
-	parameter.
+	  This option controls whether a platform using gen_isr_tables
+	  needs a software ISR table table created. This is an array of struct
+	  _isr_table_entry containing the interrupt service routine and supplied
+	  parameter.
 
 config GEN_IRQ_START_VECTOR
 	int
 	default 0
 	depends on GEN_ISR_TABLES
 	help
-	On some architectures, part of the vector table may be reserved for
-	system exceptions and is declared separately from the tables
-	created by gen_isr_tables.py. When creating these tables, this value
-	will be subtracted from CONFIG_NUM_IRQS to properly size them.
-	This is a hidden option which needs to be set per architecture and
-	left alone.
+	  On some architectures, part of the vector table may be reserved for
+	  system exceptions and is declared separately from the tables
+	  created by gen_isr_tables.py. When creating these tables, this value
+	  will be subtracted from CONFIG_NUM_IRQS to properly size them.
+	  This is a hidden option which needs to be set per architecture and
+	  left alone.
 
 
 config IRQ_OFFLOAD
@@ -172,24 +172,24 @@ config SYS_POWER_LOW_POWER_STATE_SUPPORTED
 	bool
 	default n
 	help
-	This option signifies that the target supports the SYS_POWER_LOW_POWER_STATE
-	configuration option.
+	  This option signifies that the target supports the SYS_POWER_LOW_POWER_STATE
+	  configuration option.
 
 config SYS_POWER_DEEP_SLEEP_SUPPORTED
 	# Hidden
 	bool
 	default n
 	help
-	This option signifies that the target supports the SYS_POWER_DEEP_SLEEP
-	configuration option.
+	  This option signifies that the target supports the SYS_POWER_DEEP_SLEEP
+	  configuration option.
 
 config BOOTLOADER_CONTEXT_RESTORE_SUPPORTED
 	# Hidden
 	bool
 	default n
 	help
-	This option signifies that the target has options of bootloaders
-	that support context restore upon resume from deep sleep
+	  This option signifies that the target has options of bootloaders
+	  that support context restore upon resume from deep sleep
 
 
 # End hidden CPU family configs
@@ -217,11 +217,11 @@ config FLOAT
 	prompt "Floating point registers"
 	default n
 	help
-	This option allows threads to use the floating point registers.
-	By default, only a single thread may use the registers.
+	  This option allows threads to use the floating point registers.
+	  By default, only a single thread may use the registers.
 
-	Disabling this option means that any thread that uses a
-	floating point register will get a fatal exception.
+	  Disabling this option means that any thread that uses a
+	  floating point register will get a fatal exception.
 
 config FP_SHARING
 	bool
@@ -229,8 +229,8 @@ config FP_SHARING
 	depends on FLOAT
 	default n
 	help
-	This option allows multiple threads to use the floating point
-	registers.
+	  This option allows multiple threads to use the floating point
+	  registers.
 
 endmenu
 
@@ -248,38 +248,38 @@ config FLASH_HAS_PAGE_LAYOUT
 config ARCH
 	string
 	help
-	System architecture string.
+	  System architecture string.
 
 config SOC
 	string
 	help
-	SoC name which can be found under arch/<arch>/soc/<soc name>.
-	This option holds the directory name used by the build system to locate
-	the correct linker and header files for the SoC. This option will go away
-	once all SoCs are using family/series structure.
+	  SoC name which can be found under arch/<arch>/soc/<soc name>.
+	  This option holds the directory name used by the build system to locate
+	  the correct linker and header files for the SoC. This option will go away
+	  once all SoCs are using family/series structure.
 
 config SOC_SERIES
 	string
 	help
-	SoC series name which can be found under arch/<arch>/soc/<family>/<series>.
-	This option holds the directory name used by the build system to locate
-	the correct linker and header files.
+	  SoC series name which can be found under arch/<arch>/soc/<family>/<series>.
+	  This option holds the directory name used by the build system to locate
+	  the correct linker and header files.
 
 config SOC_FAMILY
 	string
 	help
-	SoC family name which can be found under arch/<arch>/soc/<family>.
-	This option holds the directory name used by the build system to locate
-	the correct linker and header files.
+	  SoC family name which can be found under arch/<arch>/soc/<family>.
+	  This option holds the directory name used by the build system to locate
+	  the correct linker and header files.
 
 config BOARD
 	string
 	help
-	This option holds the name of the board and is used to locate the files
-	related to the board in the source tree (under boards/).
-	The Board is the first location where we search for a linker.ld file,
-	if not found we look for the linker file in
-	arch/<arch>/soc/<family>/<series>
+	  This option holds the name of the board and is used to locate the files
+	  related to the board in the source tree (under boards/).
+	  The Board is the first location where we search for a linker.ld file,
+	  if not found we look for the linker file in
+	  arch/<arch>/soc/<family>/<series>
 
 
 source "arch/*/Kconfig"

--- a/arch/arc/Kconfig
+++ b/arch/arc/Kconfig
@@ -32,7 +32,7 @@ config	CPU_ARCEM4
 	select CPU_ARCV2
 	select ATOMIC_OPERATIONS_C
 	help
-	This option signifies the use of an ARC EM4 CPU
+	  This option signifies the use of an ARC EM4 CPU
 
 endmenu
 
@@ -82,12 +82,12 @@ config	RGF_NUM_BANKS
 	range 1 2
 	default 2
 	help
-	The ARC CPU can be configured to have more than one register
-	bank. If fast interrupts are supported (FIRQ), the 2nd
-	register bank, in the set, will be used by FIRQ interrupts.
-	If fast interrupts are supported but there is only 1
-	register bank, the fast interrupt handler must save
-	and restore general purpose registers.
+	  The ARC CPU can be configured to have more than one register
+	  bank. If fast interrupts are supported (FIRQ), the 2nd
+	  register bank, in the set, will be used by FIRQ interrupts.
+	  If fast interrupts are supported but there is only 1
+	  register bank, the fast interrupt handler must save
+	  and restore general purpose registers.
 
 config	ARC_STACK_CHECKING
 	bool
@@ -103,15 +103,15 @@ config	FAULT_DUMP
 	default 2
 	range 0 2
 	help
-	Different levels for display information when a fault occurs.
+	  Different levels for display information when a fault occurs.
 
-	2: The default. Display specific and verbose information. Consumes
+	  2: The default. Display specific and verbose information. Consumes
 		the most memory (long strings).
 
-	1: Display general and short information. Consumes less memory
+	  1: Display general and short information. Consumes less memory
 		(short strings).
 
-	0: Off.
+	  0: Off.
 
 config	XIP
 	default n if NSIM
@@ -128,15 +128,15 @@ config HARVARD
 	bool
 	default n
 	help
-	The ARC CPU can be configured to have two busses;
-	one for instruction fetching and another that serves as a data bus.
+	  The ARC CPU can be configured to have two busses;
+	  one for instruction fetching and another that serves as a data bus.
 
 config CODE_DENSITY
 	prompt "Code Density Option"
 	bool
 	default n
 	help
-	Enable code density option to get better code density
+	  Enable code density option to get better code density
 
 menu "ARC MPU Options"
 depends on CPU_HAS_MPU
@@ -157,58 +157,58 @@ if !HAS_DTS
 config ICCM_SIZE
 	int "ICCM Size in kB"
 	help
-	This option specifies the size of the ICCM in kB.  It is normally set by
-	the board's defconfig file and the user should generally avoid modifying
-	it via the menu configuration.
+	  This option specifies the size of the ICCM in kB.  It is normally set by
+	  the board's defconfig file and the user should generally avoid modifying
+	  it via the menu configuration.
 
 config ICCM_BASE_ADDRESS
 	hex "ICCM Base Address"
 	help
-	This option specifies the base address of the ICCM on the board.  It is
-	normally set by the board's defconfig file and the user should generally
-	avoid modifying it via the menu configuration.
+	  This option specifies the base address of the ICCM on the board.  It is
+	  normally set by the board's defconfig file and the user should generally
+	  avoid modifying it via the menu configuration.
 
 config DCCM_SIZE
 	int "DCCM Size in kB"
 	help
-	This option specifies the size of the DCCM in kB.  It is normally set by
-	the board's defconfig file and the user should generally avoid modifying
-	it via the menu configuration.
+	  This option specifies the size of the DCCM in kB.  It is normally set by
+	  the board's defconfig file and the user should generally avoid modifying
+	  it via the menu configuration.
 
 config DCCM_BASE_ADDRESS
 	hex "DCCM Base Address"
 	help
-	This option specifies the base address of the DCCM on the board.  It is
-	normally set by the board's defconfig file and the user should generally
-	avoid modifying it via the menu configuration.
+	  This option specifies the base address of the DCCM on the board.  It is
+	  normally set by the board's defconfig file and the user should generally
+	  avoid modifying it via the menu configuration.
 
 config SRAM_SIZE
 	int "SRAM Size in kB"
 	help
-	This option specifies the size of the SRAM in kB.  It is normally set by
-	the board's defconfig file and the user should generally avoid modifying
-	it via the menu configuration.
+	  This option specifies the size of the SRAM in kB.  It is normally set by
+	  the board's defconfig file and the user should generally avoid modifying
+	  it via the menu configuration.
 
 config SRAM_BASE_ADDRESS
 	hex "SRAM Base Address"
 	help
-	This option specifies the base address of the SRAM on the board.  It is
-	normally set by the board's defconfig file and the user should generally
-	avoid modifying it via the menu configuration.
+	  This option specifies the base address of the SRAM on the board.  It is
+	  normally set by the board's defconfig file and the user should generally
+	  avoid modifying it via the menu configuration.
 
 config FLASH_SIZE
 	int "Flash Size in kB"
 	help
-	This option specifies the size of the flash in kB.  It is normally set by
-	the board's defconfig file and the user should generally avoid modifying
-	it via the menu configuration.
+	  This option specifies the size of the flash in kB.  It is normally set by
+	  the board's defconfig file and the user should generally avoid modifying
+	  it via the menu configuration.
 
 config FLASH_BASE_ADDRESS
 	hex "Flash Base Address"
 	help
-	This option specifies the base address of the flash on the board.  It is
-	normally set by the board's defconfig file and the user should generally
-	avoid modifying it via the menu configuration.
+	  This option specifies the base address of the flash on the board.  It is
+	  normally set by the board's defconfig file and the user should generally
+	  avoid modifying it via the menu configuration.
 endif
 
 config CACHE_LINE_SIZE_DETECT
@@ -216,21 +216,21 @@ config CACHE_LINE_SIZE_DETECT
 	prompt "Detect d-cache line size at runtime"
 	default n
 	help
-	This option enables querying the d-cache build register for finding
-	the d-cache line size at the expense of taking more memory and code
-	and a slightly increased boot time.
+	  This option enables querying the d-cache build register for finding
+	  the d-cache line size at the expense of taking more memory and code
+	  and a slightly increased boot time.
 
-	If the CPU's d-cache line size is known in advance, disable this
-	option and manually enter the value for CACHE_LINE_SIZE.
+	  If the CPU's d-cache line size is known in advance, disable this
+	  option and manually enter the value for CACHE_LINE_SIZE.
 
 config CACHE_LINE_SIZE
 	int
 	prompt "Cache line size" if !CACHE_LINE_SIZE_DETECT
 	default 32
 	help
-	Size in bytes of a CPU d-cache line.
+	  Size in bytes of a CPU d-cache line.
 
-	Detect automatically at runtime by selecting CACHE_LINE_SIZE_DETECT.
+	  Detect automatically at runtime by selecting CACHE_LINE_SIZE_DETECT.
 
 config ARCH_CACHE_FLUSH_DETECT
 	bool
@@ -241,10 +241,10 @@ config CACHE_FLUSHING
 	default n
 	prompt "Enable d-cache flushing mechanism"
 	help
-	This links in the sys_cache_flush() function, which provides a
-	way to flush multiple lines of the d-cache.
-	If the d-cache is present, set this to y.
-	If the d-cache is NOT present, set this to n.
+	  This links in the sys_cache_flush() function, which provides a
+	  way to flush multiple lines of the d-cache.
+	  If the d-cache is present, set this to y.
+	  If the d-cache is NOT present, set this to n.
 
 endmenu
 

--- a/arch/arc/core/mpu/Kconfig
+++ b/arch/arc/core/mpu/Kconfig
@@ -11,8 +11,8 @@ config ARC_MPU_VER
 	range 2 4
 	default 2
 	help
-	ARC MPU has several versions. For MPU v2, the minimum region is 2048 bytes;
-	For MPU v3, the minimum region is 32 bytes
+	  ARC MPU has several versions. For MPU v2, the minimum region is 2048 bytes;
+	  For MPU v3, the minimum region is 32 bytes
 
 config ARC_CORE_MPU
 	bool "ARC Core MPU functionalities"

--- a/arch/arc/soc/quark_se_c1000_ss/Kconfig
+++ b/arch/arc/soc/quark_se_c1000_ss/Kconfig
@@ -11,8 +11,8 @@ config QUARK_SE_SS_IPM_IRQ_PRI
 	int "IPM interrupt priority"
 	default 1
 	help
-	Priority level for interrupts coming in from the inter-processor
-	mailboxes.
+	  Priority level for interrupts coming in from the inter-processor
+	  mailboxes.
 
 endif # IPM
 endif # SOC_QUARK_SE_C1000_SS

--- a/arch/arm/core/Kconfig
+++ b/arch/arm/core/Kconfig
@@ -11,7 +11,7 @@ config CPU_CORTEX
 	# Omit prompt to signify "hidden" option
 	default n
 	help
-	This option signifies the use of a CPU of the Cortex family.
+	  This option signifies the use of a CPU of the Cortex family.
 
 config CPU_CORTEX_M
 	bool
@@ -25,30 +25,30 @@ config CPU_CORTEX_M
 	select ARCH_HAS_STACK_PROTECTION if ARM_CORE_MPU
 	select ARCH_HAS_USERSPACE if ARM_CORE_MPU
 	help
-	This option signifies the use of a CPU of the Cortex-M family.
+	  This option signifies the use of a CPU of the Cortex-M family.
 
 config CPU_HAS_SYSTICK
 	bool
 	# Omit prompt to signify "hidden" option
 	default n
 	help
-	This option is enabled when the CPU has systick timer implemented.
+	  This option is enabled when the CPU has systick timer implemented.
 
 config ARM_STACK_PROTECTION
 	bool
 	default y if HW_STACK_PROTECTION
 	select MPU_STACK_GUARD if ARM_CORE_MPU
 	help
-	This option enables MPU stack guard to cause a system fatal error
-	if the bounds of the current process stack are overflowed.
+	  This option enables MPU stack guard to cause a system fatal error
+	  if the bounds of the current process stack are overflowed.
 
 config ARM_USERSPACE
 	bool
 	default y if USERSPACE
 	help
-	This option enables APIs to drop a thread's privileges,	supporting
-	user-level threads that are protected from each other and from
-	crashing the kernel.
+	  This option enables APIs to drop a thread's privileges,	supporting
+	  user-level threads that are protected from each other and from
+	  crashing the kernel.
 
 menu "Architectue Floating Point Options"
 depends on CPU_HAS_FPU
@@ -62,16 +62,16 @@ config FP_HARDABI
 	bool "Floating point Hard ABI"
 	depends on FLOAT
 	help
-	This option selects the Floating point ABI in which hardware floating
-	point instructions are generated and uses FPU-specific calling
-	conventions
+	  This option selects the Floating point ABI in which hardware floating
+	  point instructions are generated and uses FPU-specific calling
+	  conventions
 
 config FP_SOFTABI
 	bool "Floating point Soft ABI"
 	depends on FLOAT
 	help
-	This option selects the Floating point ABI in which hardware floating
-	point instructions are generated but soft-float calling conventions.
+	  This option selects the Floating point ABI in which hardware floating
+	  point instructions are generated but soft-float calling conventions.
 
 endchoice
 

--- a/arch/arm/core/cortex_m/Kconfig
+++ b/arch/arm/core/cortex_m/Kconfig
@@ -11,44 +11,44 @@ config ISA_THUMB2
 	# Omit prompt to signify "hidden" option
 	default n
 	help
-	From: http://www.arm.com/products/processors/technologies/instruction-set-architectures.php
+	  From: http://www.arm.com/products/processors/technologies/instruction-set-architectures.php
 
-	Thumb-2 technology is the instruction set underlying the ARM Cortex
-	architecture which provides enhanced levels of performance, energy
-	efficiency, and code density for a wide range of embedded
-	applications.
+	  Thumb-2 technology is the instruction set underlying the ARM Cortex
+	  architecture which provides enhanced levels of performance, energy
+	  efficiency, and code density for a wide range of embedded
+	  applications.
 
-	Thumb-2 technology builds on the success of Thumb, the innovative
-	high code density instruction set for ARM microprocessor cores, to
-	increase the power of the ARM microprocessor core available to
-	developers of low cost, high performance systems.
+	  Thumb-2 technology builds on the success of Thumb, the innovative
+	  high code density instruction set for ARM microprocessor cores, to
+	  increase the power of the ARM microprocessor core available to
+	  developers of low cost, high performance systems.
 
-	The technology is backwards compatible with existing ARM and Thumb
-	solutions, while significantly extending the features available to
-	the Thumb instructions set. This allows more of the application to
-	benefit from the best in class code density of Thumb.
+	  The technology is backwards compatible with existing ARM and Thumb
+	  solutions, while significantly extending the features available to
+	  the Thumb instructions set. This allows more of the application to
+	  benefit from the best in class code density of Thumb.
 
-	For performance optimized code Thumb-2 technology uses 31 percent
-	less memory to reduce system cost, while providing up to 38 percent
-	higher performance than existing high density code, which can be used
-	to prolong battery-life or to enrich the product feature set. Thumb-2
-	technology is featured in the  processor, and in all ARMv7
-	architecture-based processors.
+	  For performance optimized code Thumb-2 technology uses 31 percent
+	  less memory to reduce system cost, while providing up to 38 percent
+	  higher performance than existing high density code, which can be used
+	  to prolong battery-life or to enrich the product feature set. Thumb-2
+	  technology is featured in the  processor, and in all ARMv7
+	  architecture-based processors.
 
 config CPU_CORTEX_M_HAS_BASEPRI
 	bool
 	# Omit prompt to signify "hidden" option
 	default n
 	help
-	This option signifies the CPU has the BASEPRI register.
+	  This option signifies the CPU has the BASEPRI register.
 
 config CPU_CORTEX_M_HAS_PROGRAMMABLE_FAULT_PRIOS
 	bool
 	# Omit prompt to signify "hidden" option
 	default n
 	help
-	This option signifies the CPU faults other than the hard fault, and
-	needs to reserve a priority for them.
+	  This option signifies the CPU faults other than the hard fault, and
+	  needs to reserve a priority for them.
 
 config ARMV6_M
 	bool
@@ -57,7 +57,7 @@ config ARMV6_M
 	select ATOMIC_OPERATIONS_C
 	select ISA_THUMB2
 	help
-	This option signifies the use of an ARMv6-M processor implementation.
+	  This option signifies the use of an ARMv6-M processor implementation.
 
 config ARMV7_M
 	bool
@@ -68,35 +68,35 @@ config ARMV7_M
 	select CPU_CORTEX_M_HAS_BASEPRI
 	select CPU_CORTEX_M_HAS_PROGRAMMABLE_FAULT_PRIOS
 	help
-	This option signifies the use of an ARMv7-M processor implementation.
+	  This option signifies the use of an ARMv7-M processor implementation.
 
 config CPU_CORTEX_M0
 	bool
 	# Omit prompt to signify "hidden" option
 	select ARMV6_M
 	help
-	This option signifies the use of a Cortex-M0 CPU
+	  This option signifies the use of a Cortex-M0 CPU
 
 config CPU_CORTEX_M0PLUS
 	bool
 	# Omit prompt to signify "hidden" option
 	select ARMV6_M
 	help
-	This option signifies the use of a Cortex-M0+ CPU
+	  This option signifies the use of a Cortex-M0+ CPU
 
 config CPU_CORTEX_M3
 	bool
 	# Omit prompt to signify "hidden" option
 	select ARMV7_M
 	help
-	This option signifies the use of a Cortex-M3 CPU
+	  This option signifies the use of a Cortex-M3 CPU
 
 config CPU_CORTEX_M4
 	bool
 	# Omit prompt to signify "hidden" option
 	select ARMV7_M
 	help
-	This option signifies the use of a Cortex-M4 CPU
+	  This option signifies the use of a Cortex-M4 CPU
 
 config CPU_CORTEX_M7
 	bool
@@ -104,7 +104,7 @@ config CPU_CORTEX_M7
 	select ARMV7_M
 	default n
 	help
-	This option signifies the use of a Cortex-M7 CPU
+	  This option signifies the use of a Cortex-M7 CPU
 
 menu "ARM Cortex-M options"
 	depends on CPU_CORTEX_M
@@ -117,17 +117,17 @@ config DATA_ENDIANNESS_LITTLE
 	bool
 	default y
 	help
-	This is driven by the processor implementation, since it is fixed in
-	hardware. The board should set this value to 'n' if the data is
-	implemented as big endian.
+	  This is driven by the processor implementation, since it is fixed in
+	  hardware. The board should set this value to 'n' if the data is
+	  implemented as big endian.
 
 config STACK_ALIGN_DOUBLE_WORD
 	bool
 	prompt "Align stacks on double-words (8 octets)"
 	default y
 	help
-	This is needed to conform to AAPCS, the procedure call standard for
-	the ARM. It wastes stack space.
+	  This is needed to conform to AAPCS, the procedure call standard for
+	  the ARM. It wastes stack space.
 
 config RUNTIME_NMI
 	bool
@@ -135,10 +135,10 @@ config RUNTIME_NMI
 	select REBOOT
 	default n
 	help
-	The kernel provides a simple NMI handler that simply hangs in a tight
-	loop if triggered. This fills the requirement that there must be an
-	NMI handler installed when the CPU boots. If a custom handler is
-	needed, enable this option and attach it via _NmiHandlerSet().
+	  The kernel provides a simple NMI handler that simply hangs in a tight
+	  loop if triggered. This fills the requirement that there must be an
+	  NMI handler installed when the CPU boots. If a custom handler is
+	  needed, enable this option and attach it via _NmiHandlerSet().
 
 config FAULT_DUMP
 	int
@@ -146,15 +146,15 @@ config FAULT_DUMP
 	default 2
 	range 0 2
 	help
-	Different levels for display information when a fault occurs.
+	  Different levels for display information when a fault occurs.
 
-	2: The default. Display specific and verbose information. Consumes
+	  2: The default. Display specific and verbose information. Consumes
 		the most memory (long strings).
 
-	1: Display general and short information. Consumes less memory
+	  1: Display general and short information. Consumes less memory
 		(short strings).
 
-	0: Off.
+	  0: Off.
 
 config XIP
 	default y
@@ -172,15 +172,15 @@ config ZERO_LATENCY_IRQS
 	default n
 	depends on CPU_CORTEX_M_HAS_BASEPRI
 	help
-	Interrupt locking is done by setting exception masking to priority
-	one, thus allowing exception of priority zero to still come in. By
-	default, the kernel verifies, via __ASSERT() statements, that the
-	interrupt priority is not set to zero when either connecting them or
-	setting their priority. Enabling this option disables the check,
-	thus allowing setting the priority of interrupts to zero.
+	  Interrupt locking is done by setting exception masking to priority
+	  one, thus allowing exception of priority zero to still come in. By
+	  default, the kernel verifies, via __ASSERT() statements, that the
+	  interrupt priority is not set to zero when either connecting them or
+	  setting their priority. Enabling this option disables the check,
+	  thus allowing setting the priority of interrupts to zero.
 
-	Note that this is a somewhat dangerous option: ISRs of priority zero
-	interrupts cannot use any kernel functionality.
+	  Note that this is a somewhat dangerous option: ISRs of priority zero
+	  interrupts cannot use any kernel functionality.
 
 config ARCH_HAS_THREAD_ABORT
 	bool

--- a/arch/nios2/Kconfig
+++ b/arch/nios2/Kconfig
@@ -28,7 +28,7 @@ config CPU_NIOS2_GEN2
 	default y
 	select BUILD_OUTPUT_HEX
 	help
-	This option signifies the use of a Nios II Gen 2 CPU
+	  This option signifies the use of a Nios II Gen 2 CPU
 
 endmenu
 
@@ -64,20 +64,20 @@ config INCLUDE_RESET_VECTOR
 	bool "Include Reset vector"
 	default y
 	help
-	Include the reset vector stub, which enables instruction/data caches
-	and then jumps to __start. This code is typically located at the very
-	beginning of flash memory. You may need to omit this if using the
-	nios2-download tool since it refuses to load data anywhere other than
-	RAM.
+	  Include the reset vector stub, which enables instruction/data caches
+	  and then jumps to __start. This code is typically located at the very
+	  beginning of flash memory. You may need to omit this if using the
+	  nios2-download tool since it refuses to load data anywhere other than
+	  RAM.
 
 config EXTRA_EXCEPTION_INFO
 	bool "Extra exception debug information"
 	default n
 	help
-	Have exceptions print additional useful debugging information in
-	human-readable form, at the expense of code size. For example,
-	the cause code for an exception will be supplemented by a string
-	describing what that cause code means.
+	  Have exceptions print additional useful debugging information in
+	  human-readable form, at the expense of code size. For example,
+	  the cause code for an exception will be supplemented by a string
+	  describing what that cause code means.
 
 choice
 prompt "Global Pointer options"
@@ -86,28 +86,28 @@ default GP_GLOBAL
 config GP_NONE
 	bool "No global pointer"
 	help
-	Do not use global pointer relative offsets at all
+	  Do not use global pointer relative offsets at all
 
 config GP_LOCAL
 	bool "Local data global pointer references"
 	help
-	Use global pointer relative offsets for small globals declared in the
-	same C file as the code that uses it.
+	  Use global pointer relative offsets for small globals declared in the
+	  same C file as the code that uses it.
 
 config GP_GLOBAL
 	bool "Global data global pointer references"
 	help
-	Use global pointer relative offsets for small globals declared
-	anywhere in the executable. Note that if any small globals that are put
-	in alternate sections (such as _k_task_list_ptr) they must be declared
-	in headers with proper __attribute__((section)) or the linker will
-	error out.
+	  Use global pointer relative offsets for small globals declared
+	  anywhere in the executable. Note that if any small globals that are put
+	  in alternate sections (such as _k_task_list_ptr) they must be declared
+	  in headers with proper __attribute__((section)) or the linker will
+	  error out.
 
 config GP_ALL_DATA
 	bool "All data global pointer references"
 	help
-	Use GP relative access for all data in the program, not just
-	small data. Use this if your board has 64K or less of RAM.
+	  Use GP relative access for all data in the program, not just
+	  small data. Use this if your board has 64K or less of RAM.
 
 endchoice
 

--- a/arch/riscv32/Kconfig
+++ b/arch/riscv32/Kconfig
@@ -27,35 +27,35 @@ config INCLUDE_RESET_VECTOR
 	bool "Include Reset vector"
 	default n
 	help
-	Include the reset vector stub that inits CPU and then jumps to __start
+	  Include the reset vector stub that inits CPU and then jumps to __start
 
 config RISCV_SOC_CONTEXT_SAVE
 	bool "Enable SOC-based context saving in IRQ handler"
 	default n
 	help
-	Enable SOC-based context saving, for SOCS which require saving of
-	extra registers when entering an interrupt/exception
+	  Enable SOC-based context saving, for SOCS which require saving of
+	  extra registers when entering an interrupt/exception
 
 config RISCV_SOC_INTERRUPT_INIT
 	bool "Enable SOC-based interrupt initialization"
 	default n
 	help
-	Enable SOC-based interrupt initialization
-	(call soc_interrupt_init, within _IntLibInit when enabled)
+	  Enable SOC-based interrupt initialization
+	  (call soc_interrupt_init, within _IntLibInit when enabled)
 
 config RISCV_GENERIC_TOOLCHAIN
 	bool "Compile using generic riscv32 toolchain"
 	default y
 	help
-	Compile using generic riscv32 toolchain.
-	Allow SOCs that have custom extended riscv ISA to still
-	compile with generic riscv32 toolchain.
+	  Compile using generic riscv32 toolchain.
+	  Allow SOCs that have custom extended riscv ISA to still
+	  compile with generic riscv32 toolchain.
 
 config RISCV_HAS_CPU_IDLE
 	bool "Does SOC has CPU IDLE instruction"
 	default n
 	help
-	Does SOC has CPU IDLE instruction
+	  Does SOC has CPU IDLE instruction
 
 config GEN_ISR_TABLES
 	default y

--- a/arch/riscv32/soc/riscv-privilege/Kconfig
+++ b/arch/riscv32/soc/riscv-privilege/Kconfig
@@ -21,7 +21,7 @@ config RISCV_HAS_PLIC
 	default n
 	depends on SOC_FAMILY_RISCV_PRIVILEGE
 	help
-	Does the SOC provide support for a Platform Level Interrupt Controller
+	  Does the SOC provide support for a Platform Level Interrupt Controller
 
 
 source "arch/riscv32/soc/riscv-privilege/*/Kconfig.soc"

--- a/arch/x86/Kconfig
+++ b/arch/x86/Kconfig
@@ -37,7 +37,7 @@ config CPU_ATOM
 	select ARCH_HAS_STACK_PROTECTION if X86_MMU
 	select ARCH_HAS_USERSPACE if X86_MMU
 	help
-	This option signifies the use of a CPU from the Atom family.
+	  This option signifies the use of a CPU from the Atom family.
 
 config CPU_MINUTEIA
 	# Hidden
@@ -45,7 +45,7 @@ config CPU_MINUTEIA
 	select ARCH_HAS_USERSPACE if X86_MMU
 	bool
 	help
-	This option signifies the use of a CPU from the Minute IA family.
+	  This option signifies the use of a CPU from the Minute IA family.
 
 menu "Processor Capabilities"
 
@@ -54,12 +54,12 @@ config X86_IAMCU
 	default n
 	prompt "IAMCU calling convention"
 	help
-	The IAMCU calling convention changes the X86 C calling convention to
-	pass some arguments via registers allowing for code size and performance
-	improvements.  Great care needs to be taken if you have assembly code
-	that will be called from C or C code called from assembly code, the
-	assembly code will need to be updated to conform to the new calling
-	convention.  If in doubt say N
+	  The IAMCU calling convention changes the X86 C calling convention to
+	  pass some arguments via registers allowing for code size and performance
+	  improvements.  Great care needs to be taken if you have assembly code
+	  that will be called from C or C code called from assembly code, the
+	  assembly code will need to be updated to conform to the new calling
+	  convention.  If in doubt say N
 
 menu "Memory Management"
 config X86_MMU
@@ -67,8 +67,8 @@ config X86_MMU
 	default n
 	prompt "Enable Memory Management Unit"
 	help
-	This options enables the memory management unit present in x86. Enabling
-	this will create boot time page table structure.
+	  This options enables the memory management unit present in x86. Enabling
+	  this will create boot time page table structure.
 
 config X86_PAE_MODE
 	bool
@@ -76,23 +76,23 @@ config X86_PAE_MODE
 	default n
 	prompt "Enable PAE page tables"
 	help
-	When selected the Page address extension mode is enabled. The PAE
-	page tables provides a mechanism to selectively disable execution.
-	So any Page Table Entry (PTE) that sets the XD bit will have all
-	instruction fetches disabled in that 4KB region. The amount of RAM
-	needed for PAE tables is more than twice that of 32-Bit paging
-	because each PAE entry is 64bits wide.
-	Note: Do not enable in RAM constrained devices.
+	  When selected the Page address extension mode is enabled. The PAE
+	  page tables provides a mechanism to selectively disable execution.
+	  So any Page Table Entry (PTE) that sets the XD bit will have all
+	  instruction fetches disabled in that 4KB region. The amount of RAM
+	  needed for PAE tables is more than twice that of 32-Bit paging
+	  because each PAE entry is 64bits wide.
+	  Note: Do not enable in RAM constrained devices.
 endmenu
 
 config X86_ENABLE_TSS
 	bool
 	help
-	This hidden option enables defining a Task State Segment (TSS) for
-	kernel execution. This is needed to handle double-faults or
-	do privilege elevation. It also defines a special TSS and handler
-	for correctly handling double-fault exceptions, instead of just
-	letting the system triple-fault and reset.
+	  This hidden option enables defining a Task State Segment (TSS) for
+	  kernel execution. This is needed to handle double-faults or
+	  do privilege elevation. It also defines a special TSS and handler
+	  for correctly handling double-fault exceptions, instead of just
+	  letting the system triple-fault and reset.
 
 config X86_STACK_PROTECTION
 	bool
@@ -101,9 +101,9 @@ config X86_STACK_PROTECTION
 	select GDT_DYNAMIC
 	select X86_ENABLE_TSS
 	help
-	This option leverages the MMU to cause a system fatal error if the
-	bounds of the current process stack are overflowed. This is done
-	by preceding all stack areas with a 4K guard page.
+	  This option leverages the MMU to cause a system fatal error if the
+	  bounds of the current process stack are overflowed. This is done
+	  by preceding all stack areas with a 4K guard page.
 
 config X86_USERSPACE
 	bool
@@ -113,9 +113,9 @@ config X86_USERSPACE
 	select GDT_DYNAMIC
 	select X86_ENABLE_TSS
 	help
-	This option enables APIs to drop a thread's privileges down to ring 3,
-	supporting user-level threads that are protected from each other and
-	from crashing the kernel.
+	  This option enables APIs to drop a thread's privileges down to ring 3,
+	  supporting user-level threads that are protected from each other and
+	  from crashing the kernel.
 
 menu "Architecture Floating Point Options"
 depends on CPU_HAS_FPU
@@ -126,7 +126,7 @@ config SSE
 	depends on FLOAT
 	default n
 	help
-	This option enables the use of SSE registers by threads.
+	  This option enables the use of SSE registers by threads.
 
 config SSE_FP_MATH
 	bool
@@ -134,15 +134,15 @@ config SSE_FP_MATH
 	depends on SSE
 	default n
 	help
-	This option allows the compiler to generate SSEx instructions for
-	performing floating point math. This can greatly improve performance
-	when exactly the same operations are to be performed on multiple
-	data objects; however, it can also significantly reduce performance
-	when preemptive task switches occur because of the larger register
-	set that must be saved and restored.
+	  This option allows the compiler to generate SSEx instructions for
+	  performing floating point math. This can greatly improve performance
+	  when exactly the same operations are to be performed on multiple
+	  data objects; however, it can also significantly reduce performance
+	  when preemptive task switches occur because of the larger register
+	  set that must be saved and restored.
 
-	Disabling this option means that the compiler utilizes only the
-	x87 instruction set for floating point operations.
+	  Disabling this option means that the compiler utilizes only the
+	  x87 instruction set for floating point operations.
 endmenu
 
 choice
@@ -154,7 +154,7 @@ config REBOOT_RST_CNT
 	bool
 	prompt "Reboot via RST_CNT register"
 	help
-	Reboot via the RST_CNT register, going back to BIOS.
+	  Reboot via the RST_CNT register, going back to BIOS.
 
 endchoice
 
@@ -163,8 +163,8 @@ config ISA_IA32
 	bool
 	default y
 	help
-	This option signifies the use of a CPU based on the Intel IA-32
-	instruction set architecture.
+	  This option signifies the use of a CPU based on the Intel IA-32
+	  instruction set architecture.
 
 config IA32_LEGACY_IO_PORTS
 	bool
@@ -172,26 +172,26 @@ config IA32_LEGACY_IO_PORTS
 	default n
 	depends on ISA_IA32
 	help
-	This option enables IA32 legacy IO ports. Note these are much slower
-	than memory access, so they should be used in last resort.
+	  This option enables IA32 legacy IO ports. Note these are much slower
+	  than memory access, so they should be used in last resort.
 
 config CMOV
 	def_bool n
 	help
-	This option signifies the use of an Intel CPU that supports
-	the CMOV instruction.
+	  This option signifies the use of an Intel CPU that supports
+	  the CMOV instruction.
 
 config CACHE_LINE_SIZE_DETECT
 	bool
 	prompt "Detect cache line size at runtime"
 	default y
 	help
-	This option enables querying the CPUID register for finding the cache line
-	size at the expense of taking more memory and code and a slightly increased
-	boot time.
+	  This option enables querying the CPUID register for finding the cache line
+	  size at the expense of taking more memory and code and a slightly increased
+	  boot time.
 
-	If the CPU's cache line size is known in advance, disable this option and
-	manually enter the value for CACHE_LINE_SIZE.
+	  If the CPU's cache line size is known in advance, disable this option and
+	  manually enter the value for CACHE_LINE_SIZE.
 
 config CACHE_LINE_SIZE
 	int
@@ -200,9 +200,9 @@ config CACHE_LINE_SIZE
 	default 64 if CPU_ATOM
 	default 0
 	help
-	Size in bytes of a CPU cache line.
+	  Size in bytes of a CPU cache line.
 
-	Detect automatically at runtime by selecting CACHE_LINE_SIZE_DETECT.
+	  Detect automatically at runtime by selecting CACHE_LINE_SIZE_DETECT.
 
 config CLFLUSH_INSTRUCTION_SUPPORTED
 	bool
@@ -210,12 +210,12 @@ config CLFLUSH_INSTRUCTION_SUPPORTED
 	depends on !CLFLUSH_DETECT && CACHE_FLUSHING
 	default n
 	help
-	An implementation of sys_cache_flush() that uses CLFLUSH is made
-	available, instead of the one using WBINVD.
+	  An implementation of sys_cache_flush() that uses CLFLUSH is made
+	  available, instead of the one using WBINVD.
 
-	This option should only be enabled if it is known in advance that the
-	CPU supports the CLFLUSH instruction. It disables runtime detection of
-	CLFLUSH support thereby reducing both memory footprint and boot time.
+	  This option should only be enabled if it is known in advance that the
+	  CPU supports the CLFLUSH instruction. It disables runtime detection of
+	  CLFLUSH support thereby reducing both memory footprint and boot time.
 
 config CLFLUSH_DETECT
 	bool
@@ -223,15 +223,15 @@ config CLFLUSH_DETECT
 	depends on CACHE_FLUSHING
 	default n
 	help
-	This option should be enabled if it is not known in advance whether the
-	CPU supports the CLFLUSH instruction or not.
+	  This option should be enabled if it is not known in advance whether the
+	  CPU supports the CLFLUSH instruction or not.
 
-	The CPU is queried at boot time to determine which of the multiple
-	implementations of sys_cache_flush() linked into the image is the
-	correct one to use.
+	  The CPU is queried at boot time to determine which of the multiple
+	  implementations of sys_cache_flush() linked into the image is the
+	  correct one to use.
 
-	If the CPU's support (or lack thereof) of CLFLUSH is known in advance, then
-	disable this option and set CLFLUSH_INSTRUCTION_SUPPORTED as appropriate.
+	  If the CPU's support (or lack thereof) of CLFLUSH is known in advance, then
+	  disable this option and set CLFLUSH_INSTRUCTION_SUPPORTED as appropriate.
 
 config ARCH_CACHE_FLUSH_DETECT
 	bool
@@ -243,24 +243,24 @@ config CACHE_FLUSHING
 	default n
 	prompt "Enable cache flushing mechanism"
 	help
-	This links in the sys_cache_flush() function. A mechanism for flushing the
-	cache must be selected as well. By default, that mechanism is discovered at
-	runtime.
+	  This links in the sys_cache_flush() function. A mechanism for flushing the
+	  cache must be selected as well. By default, that mechanism is discovered at
+	  runtime.
 
 config PIC_DISABLE
 	bool "Disable PIC"
 	default n
 	help
-	This option disables all interrupts on the PIC
+	  This option disables all interrupts on the PIC
 
 
 config X86_KERNEL_OOPS
 	bool "Enable handling of kernel oops as an exception"
 	default y
 	help
-	Enable handling of k_oops() API as a CPU exception, which will provide
-	extra debugging information such as program counter and register
-	values when the oops is triggered. Requires an entry in the IDT.
+	  Enable handling of k_oops() API as a CPU exception, which will provide
+	  extra debugging information such as program counter and register
+	  values when the oops is triggered. Requires an entry in the IDT.
 
 config X86_KERNEL_OOPS_VECTOR
 	int "IDT vector to use for kernel oops"
@@ -269,10 +269,10 @@ config X86_KERNEL_OOPS_VECTOR
 	range 32 255
 	depends on X86_KERNEL_OOPS
 	help
-	Specify the IDT vector to use for the kernel oops exception handler.
-	The default should be fine for most arches, but on systems like MVIC
-	where there is a fixed IRQ-to-vector mapping another value may be
-	needed to avoid collision.
+	  Specify the IDT vector to use for the kernel oops exception handler.
+	  The default should be fine for most arches, but on systems like MVIC
+	  where there is a fixed IRQ-to-vector mapping another value may be
+	  needed to avoid collision.
 
 config IRQ_OFFLOAD_VECTOR
 	int "IDT vector to use for IRQ offload"
@@ -281,10 +281,10 @@ config IRQ_OFFLOAD_VECTOR
 	range 32 255
 	depends on IRQ_OFFLOAD
 	help
-	Specify the IDT vector to use for the IRQ offload interrupt handler.
-	The default should be fine for most arches, but on systems like MVIC
-	where there is a fixed IRQ-to-vector mapping another value may be
-	needed to avoid collision.
+	  Specify the IDT vector to use for the IRQ offload interrupt handler.
+	  The default should be fine for most arches, but on systems like MVIC
+	  where there is a fixed IRQ-to-vector mapping another value may be
+	  needed to avoid collision.
 
 
 config XIP
@@ -294,8 +294,8 @@ config X86_FIXED_IRQ_MAPPING
 	bool
 	default n
 	help
-	Specify whether the current interrupt controller in use has a fixed
-	mapping between IDT vectors and IRQ lines.
+	  Specify whether the current interrupt controller in use has a fixed
+	  mapping between IDT vectors and IRQ lines.
 
 endmenu
 

--- a/arch/x86/core/Kconfig
+++ b/arch/x86/core/Kconfig
@@ -11,7 +11,7 @@ config NESTED_INTERRUPTS
 	prompt "Enable nested interrupts"
 	default y
 	help
-	This option enables support for nested interrupts.
+	  This option enables support for nested interrupts.
 
 config EXCEPTION_DEBUG
 	bool
@@ -19,10 +19,10 @@ config EXCEPTION_DEBUG
 	default y
 	depends on PRINTK
 	help
-	Install handlers for various CPU exception/trap vectors to
-	make debugging them easier, at a small expense in code size.
-	This prints out the specific exception vector and any associated
-	error codes.
+	  Install handlers for various CPU exception/trap vectors to
+	  make debugging them easier, at a small expense in code size.
+	  This prints out the specific exception vector and any associated
+	  error codes.
 
 menu "Memory Layout Options"
 
@@ -32,9 +32,9 @@ config IDT_NUM_VECTORS
 	default 256
 	range 32 256
 	help
-	This option specifies the number of interrupt vector entries in the
-	Interrupt Descriptor Table (IDT). By default all 256 vectors are
-	supported in an IDT requiring 2048 bytes of memory.
+	  This option specifies the number of interrupt vector entries in the
+	  Interrupt Descriptor Table (IDT). By default all 256 vectors are
+	  supported in an IDT requiring 2048 bytes of memory.
 
 config MAX_IRQ_LINES
 	int
@@ -42,18 +42,18 @@ config MAX_IRQ_LINES
 	default 128
 	range 0 256
 	help
-	This option specifies the number of IRQ lines in the system.
-	It can be tuned to save some bytes in ROM, as it determines the
-	size of the _irq_to_interrupt_vector_table, which is used at runtime
-	to program to the PIC the association between vectors and
-	interrupts.
+	  This option specifies the number of IRQ lines in the system.
+	  It can be tuned to save some bytes in ROM, as it determines the
+	  size of the _irq_to_interrupt_vector_table, which is used at runtime
+	  to program to the PIC the association between vectors and
+	  interrupts.
 
 if !HAS_DTS
 config PHYS_LOAD_ADDR
 	hex "Physical load address"
 	# Default value must be supplied by platform
 	help
-	This option specifies the physical address where the kernel is loaded.
+	  This option specifies the physical address where the kernel is loaded.
 endif
 
 if !HAS_DTS
@@ -61,39 +61,39 @@ config PHYS_RAM_ADDR
 	hex "Physical RAM address"
 	# Default value must be supplied by platform
 	help
-	This option specifies the physical RAM address of the selected SoC.
+	  This option specifies the physical RAM address of the selected SoC.
 endif
 
 config RAM_SIZE
 	int "Amount of RAM given to the kernel (in kB)"
 	help
-	This option specifies the amount of RAM given to the kernel. It must
-	not exceed the amount available on the target.  When running an XIP
-	kernel, it must be large enough to contain the data, bss and noinit
-	sections.  When not running an XIP kernel, it must be large enough to
-	contain the full image.
+	  This option specifies the amount of RAM given to the kernel. It must
+	  not exceed the amount available on the target.  When running an XIP
+	  kernel, it must be large enough to contain the data, bss and noinit
+	  sections.  When not running an XIP kernel, it must be large enough to
+	  contain the full image.
 
-	The default value is specified by the board.
+	  The default value is specified by the board.
 
 config ROM_SIZE
 	int "Amount of ROM given to the kernel (in kB)" if XIP
 	help
-	This option specifies the amount of ROM given to the kernel. It must
-	not exceed the amount available on the target.  It must also be large
-	enough to contain the full image.
+	  This option specifies the amount of ROM given to the kernel. It must
+	  not exceed the amount available on the target.  It must also be large
+	  enough to contain the full image.
 
-	The default value is specified by the board.
+	  The default value is specified by the board.
 
 config SET_GDT
 	bool
 	prompt "Setup GDT as part of boot process"
 	default y
 	help
-	This option sets up the GDT as part of the boot process. However,
-	this may conflict with some security scenarios where the GDT is
-	already appropriately set by an earlier bootloader stage, in which
-	case this should be disabled. If disabled, the global _gdt pointer
-	will not be available.
+	  This option sets up the GDT as part of the boot process. However,
+	  this may conflict with some security scenarios where the GDT is
+	  already appropriately set by an earlier bootloader stage, in which
+	  case this should be disabled. If disabled, the global _gdt pointer
+	  will not be available.
 
 config GDT_DYNAMIC
 	bool
@@ -101,7 +101,7 @@ config GDT_DYNAMIC
 	depends on SET_GDT
 	default n
 	help
-	This option stores the GDT in RAM instead of ROM, so that it may
-	be modified at runtime at the expense of some memory.
+	  This option stores the GDT in RAM instead of ROM, so that it may
+	  be modified at runtime at the expense of some memory.
 
 endmenu

--- a/arch/x86/soc/intel_quark/quark_d2000/Kconfig
+++ b/arch/x86/soc/intel_quark/quark_d2000/Kconfig
@@ -12,15 +12,15 @@ config BSP_SHARED_GDT_RAM_ADDR
 	hex "Address of the shared RAM with the QMSI Bootloader"
 	default 0x00281FE0
 	help
-	Address of the memory shared between the BSP and the Bootloader in order
-	to store the GDT.
+	  Address of the memory shared between the BSP and the Bootloader in order
+	  to store the GDT.
 
 config BSP_SHARED_GDT_RAM_SIZE
 	hex "Size of the shared RAM with the QMSI Bootloader"
 	depends on !SET_GDT
 	default 0x20
 	help
-	Size of the memory shared between the BSP and the Bootloader in order
-	to store the GDT.
+	  Size of the memory shared between the BSP and the Bootloader in order
+	  to store the GDT.
 
 endif #SOC_QUARK_D2000_X86

--- a/arch/x86/soc/intel_quark/quark_se/Kconfig
+++ b/arch/x86/soc/intel_quark/quark_se/Kconfig
@@ -12,21 +12,21 @@ config EOI_FORWARDING_BUG
 	bool
 	default y
 	help
-	Quark SE LOAPIC has issues with forwarding EOI to the IOAPIC for level
-	triggered interrupts, this is a SW workaround.
+	  Quark SE LOAPIC has issues with forwarding EOI to the IOAPIC for level
+	  triggered interrupts, this is a SW workaround.
 
 config SS_RESET_VECTOR
 	hex "Sensor Subsystem Reset Vector"
 	default 0x40000000
 	help
-	Sensor subsystem reset vector. This value is needed to init the ARC
-	system on the SoC.
+	  Sensor subsystem reset vector. This value is needed to init the ARC
+	  system on the SoC.
 
 config ARC_INIT
 	bool "Quark SE ARC Kickoff"
 	default n
 	help
-	Allows x86 processor to kickoff the ARC slave processor.
+	  Allows x86 processor to kickoff the ARC slave processor.
 
 config SYS_LOG_ARC_INIT_LEVEL
 	int
@@ -34,45 +34,45 @@ config SYS_LOG_ARC_INIT_LEVEL
 	depends on SYS_LOG
 	default 0
 	help
-	Sets log level for the boot initialization and boot process of the sensor
-	sub-system.
+	  Sets log level for the boot initialization and boot process of the sensor
+	  sub-system.
 
-	Levels are:
+	  Levels are:
 
-	- 0 OFF, do not write
+	  - 0 OFF, do not write
 
-	- 1 ERROR, only write SYS_LOG_ERR
+	  - 1 ERROR, only write SYS_LOG_ERR
 
-	- 2 WARNING, write SYS_LOG_WRN in addition to previous level
+	  - 2 WARNING, write SYS_LOG_WRN in addition to previous level
 
-	- 3 INFO, write SYS_LOG_INF in addition to previous levels
+	  - 3 INFO, write SYS_LOG_INF in addition to previous levels
 
-	- 4 DEBUG, write SYS_LOG_DBG in addition to previous levels
+	  - 4 DEBUG, write SYS_LOG_DBG in addition to previous levels
 
 config ARC_GDB_ENABLE
 	bool "Allows the usage of GDB with the ARC processor."
 	depends on ARC_INIT
 	default n
 	help
-	This option will stop the master processor from boot-strapping
-	the ARC slave processor. This will allow GDB to halt and
-	engage the ARC processor to proceed step by step execution.
+	  This option will stop the master processor from boot-strapping
+	  the ARC slave processor. This will allow GDB to halt and
+	  engage the ARC processor to proceed step by step execution.
 
 if IPM
 config QUARK_SE_IPM_IRQ_PRI
 	int "IPM interrupt priority"
 	default 2
 	help
-	Priority level for interrupts coming in from the inter-processor
-	mailboxes.
+	  Priority level for interrupts coming in from the inter-processor
+	  mailboxes.
 
 if IPM_CONSOLE_RECEIVER
 config QUARK_SE_IPM_CONSOLE_RING_BUF_SIZE32
 	int "IPM Console Ring Buffer Size"
 	default 256
 	help
-	Size of the buffer for the console receiver, for incoming
-	console messages from the ARC side. Must be a power of 2.
+	  Size of the buffer for the console receiver, for incoming
+	  console messages from the ARC side. Must be a power of 2.
 endif
 endif
 
@@ -80,28 +80,28 @@ config BSP_SHARED_RESTORE_INFO_RAM_ADDR
 	hex "Address of the restore information in RAM shared with the QMSI Bootloader"
 	default 0xA8013FDC
 	help
-	Address of the memory shared between the BSP and the Bootloader in order
-	to store restore information.
+	  Address of the memory shared between the BSP and the Bootloader in order
+	  to store restore information.
 
 config BSP_SHARED_RESTORE_INFO_SIZE
 	hex "Size of the restore information in RAM shared with the QMSI Bootloader"
 	default 0x4
 	help
-	Size of the memory shared between the BSP and the Bootloader in order
-	to store restore information.
+	  Size of the memory shared between the BSP and the Bootloader in order
+	  to store restore information.
 
 config BSP_SHARED_GDT_RAM_ADDR
 	hex "Address of the GDT in RAM shared with the QMSI Bootloader"
 	default 0xA8013FE0
 	help
-	Address of the memory shared between the BSP and the Bootloader in order
-	to store the GDT.
+	  Address of the memory shared between the BSP and the Bootloader in order
+	  to store the GDT.
 
 config BSP_SHARED_GDT_RAM_SIZE
 	hex "Size of the GDT in RAM shared with the QMSI Bootloader"
 	default 0x20
 	help
-	Size of the memory shared between the BSP and the Bootloader in order
-	to store the GDT.
+	  Size of the memory shared between the BSP and the Bootloader in order
+	  to store the GDT.
 
 endif #SOC_QUARK_SE_C1000_X86

--- a/arch/xtensa/Kconfig
+++ b/arch/xtensa/Kconfig
@@ -28,42 +28,42 @@ config SYS_CLOCK_HW_CYCLES_PER_SEC
 	default 2000000
 	range 1000000 1000000000
 	help
-	This option specifies hardware clock.
+	  This option specifies hardware clock.
 
 config XTENSA_NO_IPC
 	bool "Core has no IPC support"
 	select ATOMIC_OPERATIONS_C
 	default n
 	help
-	Uncheck this if you core does not implement "SCOMPARE1" register and "s32c1i"
-	instruction.
+	  Uncheck this if you core does not implement "SCOMPARE1" register and "s32c1i"
+	  instruction.
 
 config SW_ISR_TABLE
 	bool
 	prompt "Enable software interrupt handler table"
 	default y
 	help
-	Enable an interrupt handler table implemented in software. This
-	table, unlike ISRs connected directly in the vector table, allow
-	a parameter to be passed to the interrupt handlers. Also, invoking
-	the exception/interrupt exit stub is automatically done.
+	  Enable an interrupt handler table implemented in software. This
+	  table, unlike ISRs connected directly in the vector table, allow
+	  a parameter to be passed to the interrupt handlers. Also, invoking
+	  the exception/interrupt exit stub is automatically done.
 
 config XTENSA_RESET_VECTOR
 	bool
 	prompt "Build reset vector code"
 	default y
 	help
-	This option controls whether the initial reset vector code is built.
-	This is always needed for the simulator. Real boards may already
-	implement this in boot ROM.
+	  This option controls whether the initial reset vector code is built.
+	  This is always needed for the simulator. Real boards may already
+	  implement this in boot ROM.
 
 config XTENSA_USE_CORE_CRT1
 	bool
 	prompt "Use crt1.S from core"
 	default y
 	help
-	SoC or boards might define their own __start by setting this setting
-	to false.
+	  SoC or boards might define their own __start by setting this setting
+	  to false.
 
 menu "Specific core configuration"
 

--- a/boards/Kconfig
+++ b/boards/Kconfig
@@ -2,10 +2,10 @@
 config BOARD_DEPRECATED
 	string
 	help
-	This hidden option is set in the board configuration and indicates
-	the Zephyr release that the board configuration will be removed.
-	When set, any build for that board will generate a clearly visible
-	deprecation warning.
+	  This hidden option is set in the board configuration and indicates
+	  the Zephyr release that the board configuration will be removed.
+	  When set, any build for that board will generate a clearly visible
+	  deprecation warning.
 
 config QEMU_TARGET
 	bool

--- a/boards/x86/galileo/Kconfig
+++ b/boards/x86/galileo/Kconfig
@@ -14,49 +14,49 @@ config PINMUX_GALILEO_EXP0_NAME
 	depends on PINMUX && BOARD_GALILEO
 	default "EXP0"
 	help
-	The name of the GPIO expander labeled as EXP0 in the schematic.
+	  The name of the GPIO expander labeled as EXP0 in the schematic.
 
 config PINMUX_GALILEO_EXP1_NAME
 	string "Name of the GPIO expander 1"
 	depends on PINMUX && BOARD_GALILEO
 	default "EXP1"
 	help
-	The name of the GPIO expander labeled as EXP1 in the schematic.
+	  The name of the GPIO expander labeled as EXP1 in the schematic.
 
 config PINMUX_GALILEO_EXP2_NAME
 	string "Name of the GPIO expander 2"
 	depends on PINMUX && BOARD_GALILEO
 	default "EXP2"
 	help
-	The name of the GPIO expander labeled as EXP2 in the schematic.
+	  The name of the GPIO expander labeled as EXP2 in the schematic.
 
 config PINMUX_GALILEO_PWM0_NAME
 	string "Name of the PWM LED expander 0"
 	depends on PINMUX && BOARD_GALILEO
 	default "PWM0"
 	help
-	The name of the PWM LED expander labeled as PWM0 in the schematic.
+	  The name of the PWM LED expander labeled as PWM0 in the schematic.
 
 config PINMUX_GALILEO_GPIO_DW_NAME
 	string "Name of the DesignWare GPIO"
 	depends on PINMUX && BOARD_GALILEO
 	default "GPIO_0"
 	help
-	The name of the DesignWare GPIO with GPIO<0>..GPIO<7> in the schematic.
+	  The name of the DesignWare GPIO with GPIO<0>..GPIO<7> in the schematic.
 
 config PINMUX_GALILEO_GPIO_INTEL_CW_NAME
 	string "Name of the Legacy Bridge Core Well GPIO"
 	depends on PINMUX && BOARD_GALILEO
 	default "GPIO_M0"
 	help
-	The name of the Legacy Bridge Core Well GPIO with GPIO<8>..GPIO<9>
-	in the schematic.
+	  The name of the Legacy Bridge Core Well GPIO with GPIO<8>..GPIO<9>
+	  in the schematic.
 
 config PINMUX_GALILEO_GPIO_INTEL_RW_NAME
 	string "Name of the Legacy Bridge Resume Well GPIO"
 	depends on PINMUX && BOARD_GALILEO
 	default "GPIO_M1"
 	help
-	The name of the Legacy Bridge Resume Well GPIO with
-	GPIO_SUS<0>..GPIO_SUS<5> in the schematic.
+	  The name of the Legacy Bridge Resume Well GPIO with
+	  GPIO_SUS<0>..GPIO_SUS<5> in the schematic.
 endif

--- a/boards/xtensa/xt-sim/Kconfig
+++ b/boards/xtensa/xt-sim/Kconfig
@@ -7,6 +7,6 @@ config XTENSA_XTSC_INC
 	string "Xtensa XTSC extension include file"
 	depends on SIMULATOR_XTENSA
 	help
-	If you want to use xtsc-run with an extended core, then you can put here the
-	path to the include file of the extension model. This path can either be
-	absolute or relative to the execution directory.
+	  If you want to use xtsc-run with an extended core, then you can put here the
+	  path to the include file of the extension model. This path can either be
+	  absolute or relative to the execution directory.

--- a/drivers/console/Kconfig
+++ b/drivers/console/Kconfig
@@ -17,15 +17,15 @@ config CONSOLE_INPUT_MAX_LINE_LEN
 	int "Console maximum input line length"
 	default 128
 	help
-	This option can be used to modify the maximum length a console input
-	can be.
+	  This option can be used to modify the maximum length a console input
+	  can be.
 
 config CONSOLE_HAS_DRIVER
 	bool
 	default n
 	help
-	This is an option to be enabled by console drivers to signal
-	that some kind of console exists.
+	  This is an option to be enabled by console drivers to signal
+	  that some kind of console exists.
 
 config CONSOLE_HANDLER
 	bool
@@ -34,8 +34,8 @@ config CONSOLE_HANDLER
 	select UART_INTERRUPT_DRIVEN
 	default n
 	help
-	This option enables console input handler allowing to write simple
-	interaction between serial console and the OS.
+	  This option enables console input handler allowing to write simple
+	  interaction between serial console and the OS.
 
 config UART_CONSOLE
 	bool
@@ -44,8 +44,8 @@ config UART_CONSOLE
 	depends on SERIAL && SERIAL_HAS_DRIVER
 	select CONSOLE_HAS_DRIVER
 	help
-	Enable this option to use one UART for console. Make sure
-	CONFIG_UART_CONSOLE_ON_DEV_NAME is also set correctly.
+	  Enable this option to use one UART for console. Make sure
+	  CONFIG_UART_CONSOLE_ON_DEV_NAME is also set correctly.
 
 if !HAS_DTS
 config UART_CONSOLE_ON_DEV_NAME
@@ -53,8 +53,8 @@ config UART_CONSOLE_ON_DEV_NAME
 	default "UART_0"
 	depends on UART_CONSOLE
 	help
-	This option specifies the name of UART device to be used for
-	UART console.
+	  This option specifies the name of UART device to be used for
+	  UART console.
 endif
 
 config UART_CONSOLE_INIT_PRIORITY
@@ -73,11 +73,11 @@ config UART_CONSOLE_DEBUG_SERVER_HOOKS
 	default n
 	depends on UART_CONSOLE
 	help
-	This option allows a debug server agent such as GDB to take over the
-	handling of traffic that goes through the console logic. The debug
-	server looks at characters received and decides to handle them itself if
-	they are some sort of control characters, or let the regular console
-	code handle them if they are of no special significance to it.
+	  This option allows a debug server agent such as GDB to take over the
+	  handling of traffic that goes through the console logic. The debug
+	  server looks at characters received and decides to handle them itself if
+	  they are some sort of control characters, or let the regular console
+	  code handle them if they are of no special significance to it.
 
 config USB_UART_CONSOLE
 	bool
@@ -87,11 +87,11 @@ config USB_UART_CONSOLE
 	select USB_CDC_ACM
 	default n
 	help
-	Enable this option to use the USB UART for console output. The output
-	can be viewed from the USB host via /dev/ttyACM* port. Note that console
-	inputs from the USB UART are not functional yet. Also since the USB
-	layer currently doesn't support multiple interfaces, this shouldn't be
-	selected in conjunction with say USB Mass Storage.
+	  Enable this option to use the USB UART for console output. The output
+	  can be viewed from the USB host via /dev/ttyACM* port. Note that console
+	  inputs from the USB UART are not functional yet. Also since the USB
+	  layer currently doesn't support multiple interfaces, this shouldn't be
+	  selected in conjunction with say USB Mass Storage.
 
 config USB_UART_DTR_WAIT
 	bool
@@ -99,9 +99,9 @@ config USB_UART_DTR_WAIT
 	default n
 	depends on USB_UART_CONSOLE
 	help
-	Enable this option to use flow control on the console. The uart console
-	waits until the DTR is asserted by the host.
-	Note: Disabling this might lead to missing console prints.
+	  Enable this option to use flow control on the console. The uart console
+	  waits until the DTR is asserted by the host.
+	  Note: Disabling this might lead to missing console prints.
 
 config RAM_CONSOLE
 	bool
@@ -109,17 +109,17 @@ config RAM_CONSOLE
 	select CONSOLE_HAS_DRIVER
 	default n
 	help
-	Emit console messages to a RAM buffer "ram_console" which can
-	be examined at runtime with a debugger. Useful in board bring-up
-	if there aren't any working serial drivers.
+	  Emit console messages to a RAM buffer "ram_console" which can
+	  be examined at runtime with a debugger. Useful in board bring-up
+	  if there aren't any working serial drivers.
 
 config RAM_CONSOLE_BUFFER_SIZE
 	int "Ram Console buffer size"
 	default 1024
 	depends on RAM_CONSOLE
 	help
-	Size of the RAM console buffer. Messages will wrap around if the
-	length is exceeded.
+	  Size of the RAM console buffer. Messages will wrap around if the
+	  length is exceeded.
 
 config RTT_CONSOLE
 	bool
@@ -128,9 +128,9 @@ config RTT_CONSOLE
 	select CONSOLE_HAS_DRIVER
 	default n
 	help
-	Emit console messages to a RAM buffer that is then read by the
-	Segger J-Link software and displayed on a computer in real-time.
-	Requires support for Segger J-Link on the companion IC onboard.
+	  Emit console messages to a RAM buffer that is then read by the
+	  Segger J-Link software and displayed on a computer in real-time.
+	  Requires support for Segger J-Link on the companion IC onboard.
 
 config IPM_CONSOLE_SENDER
 	bool
@@ -138,7 +138,7 @@ config IPM_CONSOLE_SENDER
 	select CONSOLE_HAS_DRIVER
 	default n
 	help
-	Enable the sending side of IPM console
+	  Enable the sending side of IPM console
 
 config IPM_CONSOLE_RECEIVER
 	bool
@@ -146,7 +146,7 @@ config IPM_CONSOLE_RECEIVER
 	select RING_BUFFER
 	default n
 	help
-	Enable the receiving side of IPM console
+	  Enable the receiving side of IPM console
 
 config IPM_CONSOLE_STACK_SIZE
 	int
@@ -154,9 +154,9 @@ config IPM_CONSOLE_STACK_SIZE
 	depends on IPM_CONSOLE_RECEIVER
 	default 512
 	help
-	Each instance of the IPM console receiver driver creates a worker
-	thread to print out incoming messages from the remote CPU. Specify the
-	stack size for these threads here.
+	  Each instance of the IPM console receiver driver creates a worker
+	  thread to print out incoming messages from the remote CPU. Specify the
+	  stack size for these threads here.
 
 config IPM_CONSOLE_INIT_PRIORITY
 	int
@@ -174,10 +174,10 @@ config	UART_PIPE
 	select UART_INTERRUPT_DRIVEN
 	default n
 	help
-	Enable pipe UART driver. This driver allows application to communicate
-	over UART with custom defined protocol. Driver doesn't inspect received
-	data (as contrary to console UART driver) and all aspects of received
-	protocol data are handled by application provided callback.
+	  Enable pipe UART driver. This driver allows application to communicate
+	  over UART with custom defined protocol. Driver doesn't inspect received
+	  data (as contrary to console UART driver) and all aspects of received
+	  protocol data are handled by application provided callback.
 
 if !HAS_DTS
 config UART_PIPE_ON_DEV_NAME
@@ -185,8 +185,8 @@ config UART_PIPE_ON_DEV_NAME
 	default "UART_0"
 	depends on UART_PIPE
 	help
-	This option specifies the name of UART device to be used
-	for pipe UART.
+	  This option specifies the name of UART device to be used
+	  for pipe UART.
 endif
 
 config XTENSA_SIM_CONSOLE
@@ -196,7 +196,7 @@ config XTENSA_SIM_CONSOLE
 	select CONSOLE_HAS_DRIVER
 	default y
 	help
-	Use simulator console to print messages.
+	  Use simulator console to print messages.
 
 config XTENSA_CONSOLE_INIT_PRIORITY
 	int

--- a/drivers/crypto/Kconfig
+++ b/drivers/crypto/Kconfig
@@ -20,26 +20,26 @@ config CRYPTO_INIT_PRIORITY
 	int "Crypto devices init priority"
 	default 90
 	help
-	Crypto devices initialization priority.
+	  Crypto devices initialization priority.
 
 config SYS_LOG_CRYPTO_LEVEL
 	int "Crypto drivers log level"
 	default 0
 	depends on SYS_LOG
 	help
-	Sets log level for crypto drivers
+	  Sets log level for crypto drivers
 
-	Levels are:
+	  Levels are:
 
-	- 0 OFF, do not write
+	  - 0 OFF, do not write
 
-	- 1 ERROR, only write SYS_LOG_ERR
+	  - 1 ERROR, only write SYS_LOG_ERR
 
-	- 2 WARNING, write SYS_LOG_WRN in addition to previous level
+	  - 2 WARNING, write SYS_LOG_WRN in addition to previous level
 
-	- 3 INFO, write SYS_LOG_INF in addition to previous levels
+	  - 3 INFO, write SYS_LOG_INF in addition to previous levels
 
-	- 4 DEBUG, write SYS_LOG_DBG in addition to previous levels
+	  - 4 DEBUG, write SYS_LOG_DBG in addition to previous levels
 
 config CRYPTO_TINYCRYPT_SHIM
 	bool "Enable TinyCrypt shim driver [EXPERIMENTAL] "
@@ -51,22 +51,22 @@ config CRYPTO_TINYCRYPT_SHIM
 	select TINYCRYPT_AES_CCM
 	select TINYCRYPT_AES_CMAC
 	help
-	Enable TinyCrypt shim layer compliant with crypto APIs.
+	  Enable TinyCrypt shim layer compliant with crypto APIs.
 
 config CRYPTO_TINYCRYPT_SHIM_MAX_SESSION
 	int "Maximum of sessions TinyCrypt shim driver can handle"
 	default 2
 	depends on CRYPTO_TINYCRYPT_SHIM
 	help
-	This can be used to tweak the amount of sessions the driver
-	can handle in parallel.
+	  This can be used to tweak the amount of sessions the driver
+	  can handle in parallel.
 
 config CRYPTO_TINYCRYPT_SHIM_DRV_NAME
 	string "Device name for TinyCrypt Pseudo device"
 	default "CRYPTO_TC"
 	depends on CRYPTO_TINYCRYPT_SHIM
 	help
-	Device name for TinyCrypt Pseudo device.
+	  Device name for TinyCrypt Pseudo device.
 
 config CRYPTO_MBEDTLS_SHIM
 	bool "Enable mbedTLS shim driver [EXPERIMENTAL] "
@@ -75,23 +75,23 @@ config CRYPTO_MBEDTLS_SHIM
 	select MBEDTLS_BUILTIN
 	select MBEDTLS_ENABLE_HEAP
 	help
-	Enable mbedTLS shim layer compliant with crypto APIs. You will need
-	to fill in a relevant value to CONFIG_MBEDTLS_HEAP_SIZE.
+	  Enable mbedTLS shim layer compliant with crypto APIs. You will need
+	  to fill in a relevant value to CONFIG_MBEDTLS_HEAP_SIZE.
 
 config CRYPTO_MBEDTLS_SHIM_DRV_NAME
 	string "Device name for mbedTLS Pseudo device"
 	default "CRYPTO_MTLS"
 	depends on CRYPTO_MBEDTLS_SHIM
 	help
-	Device name for mbedTLS Pseudo device.
+	  Device name for mbedTLS Pseudo device.
 
 config CRYPTO_MBEDTLS_SHIM_MAX_SESSION
 	int "Maximum of sessions mbedTLS shim driver can handle"
 	default 2
 	depends on CRYPTO_MBEDTLS_SHIM
 	help
-	This can be used to tweak the amount of sessions the driver
-	can handle in parallel.
+	  This can be used to tweak the amount of sessions the driver
+	  can handle in parallel.
 
 source "drivers/crypto/Kconfig.ataes132a"
 

--- a/drivers/dma/Kconfig
+++ b/drivers/dma/Kconfig
@@ -19,37 +19,37 @@ config DMA_0_NAME
 	string "Device name for DMA Controller 0"
 	default "DMA_0"
 	help
-	Device name for DMA Controller 0.
+	  Device name for DMA Controller 0.
 
 config DMA_0_IRQ_PRI
 	int "IRQ Priority for DMA Controller 0"
 	default 3
 	help
-	IRQ Priority for the DMA Controller.
+	  IRQ Priority for the DMA Controller.
 
 config DMA_1_NAME
 	string "Device name for DMA Controller 1"
 	default "DMA_1"
 	help
-	Device name for DMA Controller 1.
+	  Device name for DMA Controller 1.
 
 config DMA_1_IRQ_PRI
 	int "IRQ Priority for DMA Controller 1"
 	default 3
 	help
-	IRQ Priority for DMA Controller 1.
+	  IRQ Priority for DMA Controller 1.
 
 config DMA_2_NAME
 	string "Device name for DMA Controller 2"
 	default "DMA_2"
 	help
-	Device name for DMA Controller 2.
+	  Device name for DMA Controller 2.
 
 config DMA_2_IRQ_PRI
 	int "IRQ Priority for DMA Controller 2"
 	default 3
 	help
-	IRQ Priority for DMA Controller 2.
+	  IRQ Priority for DMA Controller 2.
 
 config SYS_LOG_DMA_LEVEL
 	int

--- a/drivers/gpio/Kconfig
+++ b/drivers/gpio/Kconfig
@@ -21,19 +21,19 @@ config SYS_LOG_GPIO_LEVEL
 	default 0
 	depends on SYS_LOG
 	help
-	Sets log level for GPIO drivers
+	  Sets log level for GPIO drivers
 
-	Levels are:
+	  Levels are:
 
-	- 0 OFF, do not write
+	  - 0 OFF, do not write
 
-	- 1 ERROR, only write SYS_LOG_ERR
+	  - 1 ERROR, only write SYS_LOG_ERR
 
-	- 2 WARNING, write SYS_LOG_WRN in addition to previous level
+	  - 2 WARNING, write SYS_LOG_WRN in addition to previous level
 
-	- 3 INFO, write SYS_LOG_INF in addition to previous levels
+	  - 3 INFO, write SYS_LOG_INF in addition to previous levels
 
-	- 4 DEBUG, write SYS_LOG_DBG in addition to previous levels
+	  - 4 DEBUG, write SYS_LOG_DBG in addition to previous levels
 
 source "drivers/gpio/Kconfig.dw"
 

--- a/drivers/grove/Kconfig
+++ b/drivers/grove/Kconfig
@@ -36,16 +36,16 @@ config GROVE_LCD_RGB
 	depends on GROVE
 	prompt "Enable the Seeed Grove LCD RGB Backlight"
 	help
-	Setting this value will enable driver support for the Groove-LCD RGB
-	Backlight.
+	  Setting this value will enable driver support for the Groove-LCD RGB
+	  Backlight.
 
 config GROVE_LCD_RGB_I2C_MASTER_DEV_NAME
 	string "I2C Master where Grove LCD is connected"
 	depends on GROVE_LCD_RGB
 	default "I2C_0"
 	help
-	Specify the device name of the I2C master device to which the
-	Grove LCD is connected.
+	  Specify the device name of the I2C master device to which the
+	  Grove LCD is connected.
 
 config GROVE_LIGHT_SENSOR
 	bool

--- a/drivers/ieee802154/Kconfig
+++ b/drivers/ieee802154/Kconfig
@@ -17,29 +17,29 @@ config SYS_LOG_IEEE802154_DRIVER_LEVEL
 	depends on SYS_LOG
 	default 0
 	help
-	Sets log level for 802.15.4 drivers.
+	  Sets log level for 802.15.4 drivers.
 
-	Levels are:
+	  Levels are:
 
-	- 0 OFF, do not write
+	  - 0 OFF, do not write
 
-	- 1 ERROR, only write SYS_LOG_ERR
+	  - 1 ERROR, only write SYS_LOG_ERR
 
-	- 2 WARNING, write SYS_LOG_WRN in addition to previous level
+	  - 2 WARNING, write SYS_LOG_WRN in addition to previous level
 
-	- 3 INFO, write SYS_LOG_INF in addition to previous levels
+	  - 3 INFO, write SYS_LOG_INF in addition to previous levels
 
-	- 4 DEBUG, write SYS_LOG_DBG in addition to previous levels
+	  - 4 DEBUG, write SYS_LOG_DBG in addition to previous levels
 
 config IEEE802154_RAW_MODE
 	bool "Use IEEE 802.15.4 driver without the MAC stack"
 	default n if NET_L2_IEEE802154
 	select NET_RAW_MODE
 	help
-	This option enables using the drivers in a so-called "raw" mode,
-	i.e. without a MAC stack (the net L2 layer for 802.15.4 will not
-	be built). Used only for very specific cases, such as wpan_serial
-	and wpanusb samples.
+	  This option enables using the drivers in a so-called "raw" mode,
+	  i.e. without a MAC stack (the net L2 layer for 802.15.4 will not
+	  be built). Used only for very specific cases, such as wpan_serial
+	  and wpanusb samples.
 
 source "drivers/ieee802154/Kconfig.cc2520"
 

--- a/drivers/interrupt_controller/Kconfig
+++ b/drivers/interrupt_controller/Kconfig
@@ -15,81 +15,81 @@ config LOAPIC
 	select IOAPIC
 	depends on X86
 	help
-	This option selects local APIC as the interrupt controller.
+	  This option selects local APIC as the interrupt controller.
 
 config LOAPIC_BASE_ADDRESS
 	hex "Local APIC Base Address"
 	default 0xFEE00000
 	depends on LOAPIC
 	help
-	This option specifies the base address of the Local APIC device.
+	  This option specifies the base address of the Local APIC device.
 
 config LOAPIC_SPURIOUS_VECTOR
 	bool "Handle LOAPIC spurious interrupts"
 	default n
 	depends on LOAPIC
 	help
-	A special situation may occur when a processor raises its task
-	priority to be greater than or equal to the level of the
-	interrupt for which the processor INTR signal is currently being
-	asserted. If at the time the INTA cycle is issued, the
-	interrupt that was to be dispensed has become masked (programmed
-	by software), the local APIC will deliver a spurious-interrupt
-	vector. Dispensing the spurious-interrupt vector does not affect
-	the ISR, so the handler for this vector should return without an EOI.
-	From x86 manual Volume 3 Section 10.9.
+	  A special situation may occur when a processor raises its task
+	  priority to be greater than or equal to the level of the
+	  interrupt for which the processor INTR signal is currently being
+	  asserted. If at the time the INTA cycle is issued, the
+	  interrupt that was to be dispensed has become masked (programmed
+	  by software), the local APIC will deliver a spurious-interrupt
+	  vector. Dispensing the spurious-interrupt vector does not affect
+	  the ISR, so the handler for this vector should return without an EOI.
+	  From x86 manual Volume 3 Section 10.9.
 
 config LOAPIC_SPURIOUS_VECTOR_ID
 	int "LOAPIC spurious vector ID"
 	default -1
 	depends on LOAPIC_SPURIOUS_VECTOR
 	help
-	IDT vector to use for spurious LOAPIC interrupts. Note that some
-	arches (P6, Pentium) ignore the low 4 bits and fix them at 0xF.
-	If this value is left at -1 the last entry in the IDT will be used.
+	  IDT vector to use for spurious LOAPIC interrupts. Note that some
+	  arches (P6, Pentium) ignore the low 4 bits and fix them at 0xF.
+	  If this value is left at -1 the last entry in the IDT will be used.
 
 config IOAPIC
 	bool "IO-APIC"
 	default y
 	depends on LOAPIC
 	help
-	This option signifies that the target has an IO-APIC device. This
-	capability allows IO-APIC-dependent code to be included.
+	  This option signifies that the target has an IO-APIC device. This
+	  capability allows IO-APIC-dependent code to be included.
 
 config IOAPIC_DEBUG
 	bool "IO-APIC Debugging"
 	default n
 	depends on IOAPIC
 	help
-	Enable debugging for IO-APIC driver.
+	  Enable debugging for IO-APIC driver.
 
 config IOAPIC_BASE_ADDRESS
 	hex "IO-APIC Base Address"
 	default 0xFEC00000
 	depends on IOAPIC
 	help
-	This option specifies the base address of the IO-APIC device.
+	  This option specifies the base address of the IO-APIC device.
 
 config IOAPIC_NUM_RTES
 	int "Number of Redirection Table Entries available"
 	default 24
 	depends on IOAPIC
 	help
-	This option indicates the maximum number of Redirection Table Entries
-	(RTEs) (one per IRQ available to the IO-APIC) made available to the
-	kernel, regardless of the number provided by the hardware itself. For
-	most efficient usage of memory, it should match the number of IRQ lines
-	needed by devices connected to the IO-APIC.
+	  This option indicates the maximum number of Redirection Table Entries
+	  (RTEs) (one per IRQ available to the IO-APIC) made available to the
+	  kernel, regardless of the number provided by the hardware itself. For
+	  most efficient usage of memory, it should match the number of IRQ lines
+	  needed by devices connected to the IO-APIC.
 
 config IOAPIC_MASK_RTE
 	bool "Mask out RTE entries on boot"
 	default y
 	depends on IOAPIC
 	help
-	At boot, mask all IOAPIC RTEs if they may be in an undefined state.
-	You don't need this if the RTEs are either all guaranteed to be masked
-	when the OS starts up, or a previous boot stage has done some IOAPIC
-	configuration that needs to be preserved.
+	  At boot, mask all IOAPIC RTEs if they may be in an undefined state.
+	  You don't need this if the RTEs are either all guaranteed to be masked
+	  when the OS starts up, or a previous boot stage has done some IOAPIC
+	  configuration that needs to be preserved.
 
 config MVIC
 	bool "Intel Quark D2000 Interrupt Controller (MVIC)"
@@ -97,11 +97,11 @@ config MVIC
 	depends on X86
 	select X86_FIXED_IRQ_MAPPING
 	help
-	The MVIC (Intel Quark microcontroller D2000 Interrupt Controller) is
-	configured by default to support 32 external interrupt lines. Unlike the
-	traditional IA LAPIC/IOAPIC, the interrupt vectors in MVIC are fixed and
-	not programmable. In addition, the priorities of these interrupt
-	lines are also fixed.
+	  The MVIC (Intel Quark microcontroller D2000 Interrupt Controller) is
+	  configured by default to support 32 external interrupt lines. Unlike the
+	  traditional IA LAPIC/IOAPIC, the interrupt vectors in MVIC are fixed and
+	  not programmable. In addition, the priorities of these interrupt
+	  lines are also fixed.
 
 config MVIC_TIMER_IRQ
 	int "IRQ line to use for timer interrupt"
@@ -109,20 +109,20 @@ config MVIC_TIMER_IRQ
 	default 10
 	depends on MVIC
 	help
-	Specify the IRQ line to use for the timer interrupt. This should be
-	an IRQ line unused by any hardware. If nested interrupts are enabled,
-	higher interrupt lines have priority.
+	  Specify the IRQ line to use for the timer interrupt. This should be
+	  an IRQ line unused by any hardware. If nested interrupts are enabled,
+	  higher interrupt lines have priority.
 
 config ARCV2_INTERRUPT_UNIT
 	bool "ARCv2 Interrupt Unit"
 	default y
 	depends on ARC
 	help
-	The ARCv2 interrupt unit has 16 allocated exceptions associated with
-	vectors 0 to 15 and 240 interrupts associated with vectors 16 to 255.
-	The interrupt unit is optional in the ARCv2-based processors. When
-	building a processor, you can configure the processor to include an
-	interrupt unit. The ARCv2 interrupt unit is highly programmable.
+	  The ARCv2 interrupt unit has 16 allocated exceptions associated with
+	  vectors 0 to 15 and 240 interrupts associated with vectors 16 to 255.
+	  The interrupt unit is optional in the ARCv2-based processors. When
+	  building a processor, you can configure the processor to include an
+	  interrupt unit. The ARCv2 interrupt unit is highly programmable.
 
 config PLIC_FE310
 	bool "SiFive Freedom E310 Platform Level Interrupt Controller (PLIC)"
@@ -130,8 +130,8 @@ config PLIC_FE310
 	depends on SOC_RISCV32_FE310
 	select RISCV_HAS_PLIC
 	help
-	SiFive Freedom E310 Platform Level Interrupt Controller provides support
-	for external interrupt lines defined by the FE310 SOC;
+	  SiFive Freedom E310 Platform Level Interrupt Controller provides support
+	  for external interrupt lines defined by the FE310 SOC;
 
 source "drivers/interrupt_controller/Kconfig.stm32"
 

--- a/drivers/ipm/Kconfig
+++ b/drivers/ipm/Kconfig
@@ -3,22 +3,22 @@ menuconfig IPM
 	prompt "IPM drivers"
 	default n
 	help
-	Include interrupt-based inter-processor mailboxes
-	drivers in system configuration
+	  Include interrupt-based inter-processor mailboxes
+	  drivers in system configuration
 
 config IPM_QUARK_SE
 	bool "Quark SE IPM driver"
 	default n
 	depends on IPM
 	help
-	Driver for Quark SE mailboxes
+	  Driver for Quark SE mailboxes
 
 config IPM_QUARK_SE_MASTER
 	bool "Quark SE IPM master controller"
 	default n
 	depends on IPM_QUARK_SE
 	help
-	Enable this for the first CPU that initializes IPM.
-	Sets up the initial interrupt mask and clears out all
-	channels. Should be turned on for one CPU only.
+	  Enable this for the first CPU that initializes IPM.
+	  Sets up the initial interrupt mask and clears out all
+	  channels. Should be turned on for one CPU only.
 

--- a/drivers/pci/Kconfig
+++ b/drivers/pci/Kconfig
@@ -12,7 +12,7 @@ menuconfig PCI
 	prompt "PCI Settings"
 	depends on X86
 	help
-	This options enables support of PCI bus for device drivers.
+	  This options enables support of PCI bus for device drivers.
 
 if PCI
 config PCI_ENUMERATION
@@ -20,20 +20,20 @@ config PCI_ENUMERATION
 	prompt "Enable PCI device enumeration"
 	default n
 	help
-	This option enables the PCI enumeration for device drivers.
-	This might be useful along with PCI_DEBUG to find out which
-	are the PCI settings of the devices. Once those are known and
-	statically set in every relevant driver's configuration, it
-	might be wise to disable this option to remove useless code.
+	  This option enables the PCI enumeration for device drivers.
+	  This might be useful along with PCI_DEBUG to find out which
+	  are the PCI settings of the devices. Once those are known and
+	  statically set in every relevant driver's configuration, it
+	  might be wise to disable this option to remove useless code.
 
 config PCI_LEGACY_BRIDGE
 	bool
 	prompt "PCI legacy bridge device support"
 	default n
 	help
-	This option adds support for PCI legacy bridge device, that
-	allows direct setup of the PCI interrupt pin to IRQ number
-	mapping.
+	  This option adds support for PCI legacy bridge device, that
+	  allows direct setup of the PCI interrupt pin to IRQ number
+	  mapping.
 
 config PCI_LEGACY_BRIDGE_BUS
 	int "PCI Legacy Bridge Bus number"
@@ -60,7 +60,7 @@ config PCI_DEBUG
 	prompt "Enable PCI debugging"
 	default n
 	help
-	This options enables PCI debugging functions
+	  This options enables PCI debugging functions
 
 endif
 

--- a/drivers/pinmux/Kconfig
+++ b/drivers/pinmux/Kconfig
@@ -22,7 +22,7 @@ config PINMUX_NAME
 	depends on PINMUX
 	default "PINMUX"
 	help
-	The name of the pinmux driver.
+	  The name of the pinmux driver.
 
 config PINMUX_INIT_PRIORITY
 	int

--- a/drivers/pinmux/dev/Kconfig
+++ b/drivers/pinmux/dev/Kconfig
@@ -11,36 +11,36 @@ config PINMUX_DEV
 	depends on PINMUX
 	default n
 	help
-	Enables the use of the pinmux_set and pinmux_get functions for early
-	prototyping on new hardware.  WARNING: When using these options, it
-	is possible to permanently damage the hardware.
+	  Enables the use of the pinmux_set and pinmux_get functions for early
+	  prototyping on new hardware.  WARNING: When using these options, it
+	  is possible to permanently damage the hardware.
 
 config PINMUX_DEV_NAME
 	string "Configure pinmux for early board testing"
 	depends on PINMUX_DEV
 	default "PINMUX_DEV"
 	help
-	The name of the pinmux dev driver.
+	  The name of the pinmux dev driver.
 
 config PINMUX_DEV_ATMEL_SAM3X
 	bool "Enable pinmux dev driver for Atmel SAM3X boards"
 	depends on PINMUX_DEV && SOC_SERIES_SAM3X
 	help
-	Enables the pinmux dev driver for boards based on the
-	Atmel SAM3X family of microcontrollers.
-	default n
+	  Enables the pinmux dev driver for boards based on the
+	  Atmel SAM3X family of microcontrollers.
+	  default n
 
 config PINMUX_DEV_STM32
 	bool "Enable pinmux dev driver for the ST STM32 family."
 	depends on PINMUX_DEV && SOC_FAMILY_STM32
 	help
-	Enables the STM32 pinmux dev driver.
-	default n
+	  Enables the STM32 pinmux dev driver.
+	  default n
 
 config PINMUX_DEV_ARM_V2M_BEETLE
 	bool "Enable pinmux dev driver for ARM V2M Beetle boards"
 	depends on PINMUX_DEV && SOC_SERIES_BEETLE
 	help
-	Enables the pinmux dev driver for boards based on the
-	ARM Beetle SoC MCUs.
-	default n
+	  Enables the pinmux dev driver for boards based on the
+	  ARM Beetle SoC MCUs.
+	  default n

--- a/drivers/rtc/Kconfig
+++ b/drivers/rtc/Kconfig
@@ -13,7 +13,7 @@ menuconfig RTC
 	bool "Real-Time Clock"
 	default n
 	help
-	Enable options for Real-Time Clock drivers.
+	  Enable options for Real-Time Clock drivers.
 
 if RTC
 
@@ -23,26 +23,26 @@ config RTC_QMSI
 	depends on QMSI
 	default n
 	help
-	Build QMSI RTC driver.
+	  Build QMSI RTC driver.
 
 config RTC_0_NAME
 	string "Driver instance name"
 	default "RTC_0"
 	depends on RTC
 	help
-	RTC driver instance name
+	  RTC driver instance name
 
 config RTC_0_IRQ_PRI
 	int "RTC Driver Interrupt priority"
 	depends on RTC_QMSI
 	help
-	RTC interrupt priority.
+	  RTC interrupt priority.
 
 config RTC_QMSI_API_REENTRANCY
 	bool
 	prompt "RTC shim driver API reentrancy"
 	default n
 	help
-	Enable support for RTC shim driver API reentrancy.
+	  Enable support for RTC shim driver API reentrancy.
 
 endif # RTC

--- a/drivers/sensor/bmi160/Kconfig
+++ b/drivers/sensor/bmi160/Kconfig
@@ -12,8 +12,8 @@ menuconfig BMI160
 	depends on SPI_LEGACY_API
 	default n
 	help
-	Enable Bosch BMI160 inertial measurement unit that provides acceleration
-	and angular rate measurements.
+	  Enable Bosch BMI160 inertial measurement unit that provides acceleration
+	  and angular rate measurements.
 
 config BMI160_NAME
 	string "Driver's name"

--- a/drivers/sensor/hmc5883l/Kconfig
+++ b/drivers/sensor/hmc5883l/Kconfig
@@ -10,7 +10,7 @@ menuconfig HMC5883L
 	depends on I2C
 	default n
 	help
-	Enable driver for HMC5883L I2C-based magnetometer.
+	  Enable driver for HMC5883L I2C-based magnetometer.
 
 config HMC5883L_NAME
 	string
@@ -18,7 +18,7 @@ config HMC5883L_NAME
 	default "HMC5883L"
 	depends on HMC5883L
 	help
-	Device name with which the HMC5883L sensor is identified.
+	  Device name with which the HMC5883L sensor is identified.
 
 config HMC5883L_I2C_MASTER_DEV_NAME
 	string
@@ -26,15 +26,15 @@ config HMC5883L_I2C_MASTER_DEV_NAME
 	depends on HMC5883L
 	default "I2C_0"
 	help
-	Specify the device name of the I2C master device to which HMC5883L
-	is connected.
+	  Specify the device name of the I2C master device to which HMC5883L
+	  is connected.
 
 choice
 	prompt "Trigger mode"
 	depends on HMC5883L
 	default HMC5883L_TRIGGER_GLOBAL_THREAD
 	help
-	Specify the type of triggering to be used by the driver.
+	  Specify the type of triggering to be used by the driver.
 
 config HMC5883L_TRIGGER_NONE
 	bool
@@ -64,8 +64,8 @@ config HMC5883L_GPIO_DEV_NAME
 	default "GPIO_0"
 	depends on HMC5883L && HMC5883L_TRIGGER
 	help
-	The device name of the GPIO device to which the HMC5883L interrupt
-	pin is connected.
+	  The device name of the GPIO device to which the HMC5883L interrupt
+	  pin is connected.
 
 config HMC5883L_GPIO_PIN_NUM
 	int
@@ -73,8 +73,8 @@ config HMC5883L_GPIO_PIN_NUM
 	default 0
 	depends on HMC5883L && HMC5883L_TRIGGER
 	help
-	The number of the GPIO on which the interrupt signal from the
-	HMC5883L chip will be received.
+	  The number of the GPIO on which the interrupt signal from the
+	  HMC5883L chip will be received.
 
 config HMC5883L_THREAD_PRIORITY
 	int
@@ -82,7 +82,7 @@ config HMC5883L_THREAD_PRIORITY
 	depends on HMC5883L && HMC5883L_TRIGGER_OWN_THREAD
 	default 10
 	help
-	Priority of thread used by the driver to handle interrupts.
+	  Priority of thread used by the driver to handle interrupts.
 
 config HMC5883L_THREAD_STACK_SIZE
 	int
@@ -90,7 +90,7 @@ config HMC5883L_THREAD_STACK_SIZE
 	depends on HMC5883L && HMC5883L_TRIGGER_OWN_THREAD
 	default 1024
 	help
-	Stack size of thread used by the driver to handle interrupts.
+	  Stack size of thread used by the driver to handle interrupts.
 
 config HMC5883L_ODR
 	string
@@ -98,9 +98,9 @@ config HMC5883L_ODR
 	depends on HMC5883L
 	default "15"
 	help
-	Magnetometer output data rate expressed in samples per second.
-	Data rates supported by the chip are 0.75, 1.5, 3, 7.5, 15, 30
-	and 75.
+	  Magnetometer output data rate expressed in samples per second.
+	  Data rates supported by the chip are 0.75, 1.5, 3, 7.5, 15, 30
+	  and 75.
 
 config HMC5883L_FS
 	string
@@ -108,6 +108,6 @@ config HMC5883L_FS
 	depends on HMC5883L
 	default "1.3"
 	help
-	Magnetometer full-scale range.
-	An X value for the config represents a range of +/- X gauss. Valid
-	values are 0.88, 1.3, 1.9, 2.5, 4, 4.7, 5.6 and 8.1.
+	  Magnetometer full-scale range.
+	  An X value for the config represents a range of +/- X gauss. Valid
+	  values are 0.88, 1.3, 1.9, 2.5, 4, 4.7, 5.6 and 8.1.

--- a/drivers/sensor/lps25hb/Kconfig
+++ b/drivers/sensor/lps25hb/Kconfig
@@ -10,8 +10,8 @@ menuconfig LPS25HB
 	depends on I2C
 	default n
 	help
-	Enable driver for LPS25HB I2C-based pressure and temperature
-	sensor.
+	  Enable driver for LPS25HB I2C-based pressure and temperature
+	  sensor.
 
 config LPS25HB_DEV_NAME
 	string
@@ -19,7 +19,7 @@ config LPS25HB_DEV_NAME
 	default "lps25hb"
 	depends on LPS25HB
 	help
-	Device name with which the LPS25HB sensor is identified.
+	  Device name with which the LPS25HB sensor is identified.
 
 config LPS25HB_I2C_ADDR
 	hex
@@ -27,9 +27,9 @@ config LPS25HB_I2C_ADDR
 	depends on LPS25HB
 	default "0x5C"
 	help
-	I2C address of the LPS25HB sensor.
-	Use 0x5C if the SA0 pin is pulled to GND or 0x5D if the SA0
-	pin is pulled to VDD.
+	  I2C address of the LPS25HB sensor.
+	  Use 0x5C if the SA0 pin is pulled to GND or 0x5D if the SA0
+	  pin is pulled to VDD.
 
 config LPS25HB_I2C_MASTER_DEV_NAME
 	string
@@ -37,8 +37,8 @@ config LPS25HB_I2C_MASTER_DEV_NAME
 	depends on LPS25HB
 	default "I2C_0"
 	help
-	Specify the device name of the I2C master device to which
-	LPS25HB is connected.
+	  Specify the device name of the I2C master device to which
+	  LPS25HB is connected.
 
 menu "Attributes"
 	depends on LPS25HB
@@ -49,7 +49,7 @@ config LPS25HB_SAMPLING_RATE
 	depends on LPS25HB
 	default 25
 	help
-	Sensor output data rate expressed in samples per second.
-	Data rates supported by the chip are 1, 7, 13, 25.
+	  Sensor output data rate expressed in samples per second.
+	  Data rates supported by the chip are 1, 7, 13, 25.
 
 endmenu

--- a/drivers/sensor/max44009/Kconfig
+++ b/drivers/sensor/max44009/Kconfig
@@ -12,7 +12,7 @@ menuconfig MAX44009
 	depends on I2C
 	default n
 	help
-	Enable driver for MAX44009 light sensors.
+	  Enable driver for MAX44009 light sensors.
 
 config MAX44009_DRV_NAME
 	string
@@ -20,7 +20,7 @@ config MAX44009_DRV_NAME
 	default "MAX44009"
 	depends on MAX44009
 	help
-	Device name with which the MAX44009 light is identified.
+	  Device name with which the MAX44009 light is identified.
 
 
 config MAX44009_I2C_ADDR
@@ -29,10 +29,10 @@ config MAX44009_I2C_ADDR
 	depends on MAX44009
 	default "0x4a"
 	help
-	I2C address of the MAX44009 sensor. Possible configurations:
+	  I2C address of the MAX44009 sensor. Possible configurations:
 
-	0x4a: A0 connected to GND.
-	0x4b: A0 connected to VCC.
+	  0x4a: A0 connected to GND.
+	  0x4b: A0 connected to VCC.
 
 config MAX44009_I2C_DEV_NAME
 	string
@@ -40,5 +40,5 @@ config MAX44009_I2C_DEV_NAME
 	depends on MAX44009
 	default "I2C_0"
 	help
-	Specify the device name of the I2C master device to which the
-	MAX44009 chip is connected.
+	  Specify the device name of the I2C master device to which the
+	  MAX44009 chip is connected.

--- a/drivers/sensor/tmp112/Kconfig
+++ b/drivers/sensor/tmp112/Kconfig
@@ -12,7 +12,7 @@ menuconfig TMP112
 	depends on I2C
 	default n
 	help
-	Enable driver for TMP112 infrared thermopile sensors.
+	  Enable driver for TMP112 infrared thermopile sensors.
 
 config TMP112_NAME
 	string
@@ -20,19 +20,19 @@ config TMP112_NAME
 	default "TMP112"
 	depends on TMP112
 	help
-	Device name with which the TMP112 sensor is identified.
+	  Device name with which the TMP112 sensor is identified.
 
 config TMP112_I2C_ADDR
 	hex "I2C address for TMP112"
 	depends on TMP112
 	default 0x48
 	help
-	I2C address of the TMP112 sensor.
+	  I2C address of the TMP112 sensor.
 
-	0x48: A0 connected GND and A1 connected to GND.
-	0x49: A0 connected VDD and A1 connected to GND.
-	0x4A: A0 connected SDA and A1 connected to GND.
-	0x4B: A0 connected SCL and A1 connected to GND.
+	  0x48: A0 connected GND and A1 connected to GND.
+	  0x49: A0 connected VDD and A1 connected to GND.
+	  0x4A: A0 connected SDA and A1 connected to GND.
+	  0x4B: A0 connected SCL and A1 connected to GND.
 
 
 config TMP112_I2C_MASTER_DEV_NAME
@@ -41,5 +41,5 @@ config TMP112_I2C_MASTER_DEV_NAME
 	depends on TMP112
 	default "I2C_0"
 	help
-	Specify the device name of the I2C master device to which the
-	TMP112 chip is connected.
+	  Specify the device name of the I2C master device to which the
+	  TMP112 chip is connected.

--- a/drivers/serial/Kconfig
+++ b/drivers/serial/Kconfig
@@ -11,7 +11,7 @@ menuconfig SERIAL
 	prompt "Serial Drivers"
 	default n
 	help
-	Enable options for serial drivers.
+	  Enable options for serial drivers.
 
 if SERIAL
 
@@ -21,16 +21,16 @@ config SERIAL_HAS_DRIVER
 	bool
 	default n
 	help
-	This is an option to be enabled by individual serial driver
-	to signal that there is a serial driver. This is being used
-	by other drivers which are dependent on serial.
+	  This is an option to be enabled by individual serial driver
+	  to signal that there is a serial driver. This is being used
+	  by other drivers which are dependent on serial.
 
 config SERIAL_SUPPORT_INTERRUPT
 	bool
 	default n
 	help
-	This is an option to be enabled by individual serial driver
-	to signal that the driver and hardware supports interrupts.
+	  This is an option to be enabled by individual serial driver
+	  to signal that the driver and hardware supports interrupts.
 
 config UART_INTERRUPT_DRIVEN
 	bool
@@ -38,28 +38,28 @@ config UART_INTERRUPT_DRIVEN
 	default n
 	depends on SERIAL_SUPPORT_INTERRUPT
 	help
-	This option enables interrupt support for UART allowing console
-	input and other UART based drivers.
+	  This option enables interrupt support for UART allowing console
+	  input and other UART based drivers.
 
 config UART_LINE_CTRL
 	bool "Enable Serial Line Control API"
 	default n
 	help
-	This enables the API for apps to control the serial line,
-	such as baud rate, CTS and RTS.
+	  This enables the API for apps to control the serial line,
+	  such as baud rate, CTS and RTS.
 
-	Implementation is up to individual driver.
+	  Implementation is up to individual driver.
 
-	Says no if not sure.
+	  Says no if not sure.
 
 config UART_DRV_CMD
 	bool "Enable driver commands API"
 	default n
 	help
-	This enables the API to send extra commands to drivers.
-	This allows drivers to expose hardware specific functions.
+	  This enables the API to send extra commands to drivers.
+	  This allows drivers to expose hardware specific functions.
 
-	Says no if not sure.
+	  Says no if not sure.
 
 comment "Serial Drivers"
 

--- a/drivers/timer/Kconfig
+++ b/drivers/timer/Kconfig
@@ -18,45 +18,45 @@ config HPET_TIMER
 	select LOAPIC
 	select TIMER_READS_ITS_FREQUENCY_AT_RUNTIME
 	help
-	This option selects High Precision Event Timer (HPET) as a
-	system timer.
+	  This option selects High Precision Event Timer (HPET) as a
+	  system timer.
 
 config HPET_TIMER_LEGACY_EMULATION
 	bool "HPET timer legacy emulation mode"
 	default n
 	depends on HPET_TIMER
 	help
-	This option switches HPET to legacy emulation mode.
-	In this mode 8254 PIT is disabled, HPET timer0 is connected
-	to IOAPIC IRQ2, timer1 -- to IOAPIC IRQ8.
+	  This option switches HPET to legacy emulation mode.
+	  In this mode 8254 PIT is disabled, HPET timer0 is connected
+	  to IOAPIC IRQ2, timer1 -- to IOAPIC IRQ8.
 
 config HPET_TIMER_DEBUG
 	bool "Enable HPET debug output"
 	default n
 	depends on HPET_TIMER && PRINTK
 	help
-	This option enables HPET debugging output.
+	  This option enables HPET debugging output.
 
 config HPET_TIMER_BASE_ADDRESS
 	hex "HPET Base Address"
 	default 0xFED00000
 	depends on HPET_TIMER
 	help
-	This options specifies the base address of the HPET timer device.
+	  This options specifies the base address of the HPET timer device.
 
 config HPET_TIMER_IRQ
 	int "HPET Timer IRQ"
 	default 20
 	depends on HPET_TIMER
 	help
-	This option specifies the IRQ used by the HPET timer.
+	  This option specifies the IRQ used by the HPET timer.
 
 config HPET_TIMER_IRQ_PRIORITY
 	int "HPET Timer IRQ Priority"
 	default 4
 	depends on HPET_TIMER
 	help
-	This option specifies the IRQ priority used by the HPET timer.
+	  This option specifies the IRQ priority used by the HPET timer.
 
 choice
 depends on HPET_TIMER
@@ -66,22 +66,22 @@ default HPET_TIMER_FALLING_EDGE
 config HPET_TIMER_FALLING_EDGE
 	bool "Falling Edge"
 	help
-	This option signifies that the HPET timer uses falling edge interrupts.
+	  This option signifies that the HPET timer uses falling edge interrupts.
 
 config HPET_TIMER_RISING_EDGE
 	bool "Rising Edge"
 	help
-	This option signifies that the HPET timer uses rising edge interrupts.
+	  This option signifies that the HPET timer uses rising edge interrupts.
 
 config HPET_TIMER_LEVEL_HIGH
 	bool "Level High"
 	help
-	This option signifies that the HPET timer uses level high interrupts.
+	  This option signifies that the HPET timer uses level high interrupts.
 
 config HPET_TIMER_LEVEL_LOW
 	bool "Level Low"
 	help
-	This option signifies that the HPET timer uses level low interrupts.
+	  This option signifies that the HPET timer uses level low interrupts.
 
 endchoice
 
@@ -90,21 +90,21 @@ config LOAPIC_TIMER
 	depends on (LOAPIC || MVIC) && X86
 	default n
 	help
-	This option selects LOAPIC timer as a system timer.
+	  This option selects LOAPIC timer as a system timer.
 
 config LOAPIC_TIMER_IRQ
 	int "Local APIC Timer IRQ"
 	default 24
 	depends on LOAPIC_TIMER
 	help
-	This option specifies the IRQ used by the LOAPIC timer.
+	  This option specifies the IRQ used by the LOAPIC timer.
 
 config LOAPIC_TIMER_IRQ_PRIORITY
 	int "Local APIC Timer IRQ Priority"
 	default 2
 	depends on LOAPIC_TIMER
 	help
-	This options specifies the IRQ priority used by the LOAPIC timer.
+	  This options specifies the IRQ priority used by the LOAPIC timer.
 
 config TSC_CYCLES_PER_SEC
 	int
@@ -112,92 +112,92 @@ config TSC_CYCLES_PER_SEC
 	default 0
 	depends on LOAPIC_TIMER
 	help
-	The x86 implementation of LOAPIC k_cycle_get_32() relies on the x86 TSC.
-	This runs at the CPU speed and not the bus speed. If set to 0, the
-	value of CONFIG_SYS_CLOCK_HW_CYCLES_PER_SEC will be used instead;
-	many MCUs these values are the same.
+	  The x86 implementation of LOAPIC k_cycle_get_32() relies on the x86 TSC.
+	  This runs at the CPU speed and not the bus speed. If set to 0, the
+	  value of CONFIG_SYS_CLOCK_HW_CYCLES_PER_SEC will be used instead;
+	  many MCUs these values are the same.
 
 config ARCV2_TIMER
 	bool "ARC Timer"
 	default y
 	depends on ARC
 	help
-	This module implements a kernel device driver for the ARCv2 processor timer 0
-	and provides the standard "system clock driver" interfaces.
+	  This module implements a kernel device driver for the ARCv2 processor timer 0
+	  and provides the standard "system clock driver" interfaces.
 
 config ARCV2_TIMER_IRQ_PRIORITY
 	int "ARC timer interrupt priority"
 	default 0
 	depends on ARCV2_TIMER
 	help
-	This option specifies the IRQ priority used by the ARC timer. Lower
-	values have higher priority.
+	  This option specifies the IRQ priority used by the ARC timer. Lower
+	  values have higher priority.
 
 config CORTEX_M_SYSTICK
 	bool "Cortex-M SYSTICK timer"
 	default y
 	depends on CPU_HAS_SYSTICK
 	help
-	This module implements a kernel device driver for the Cortex-M processor
-	SYSTICK timer and provides the standard "system clock driver" interfaces.
+	  This module implements a kernel device driver for the Cortex-M processor
+	  SYSTICK timer and provides the standard "system clock driver" interfaces.
 
 config ALTERA_AVALON_TIMER
 	bool "Altera Avalon Interval Timer"
 	default y
 	depends on NIOS2
 	help
-	This module implements a kernel device driver for the Altera Avalon
-	Interval Timer as described in the Embedded IP documentation, for use
-	with Nios II and possibly other Altera soft CPUs. It provides the
-	standard "system clock driver" interfaces.
+	  This module implements a kernel device driver for the Altera Avalon
+	  Interval Timer as described in the Embedded IP documentation, for use
+	  with Nios II and possibly other Altera soft CPUs. It provides the
+	  standard "system clock driver" interfaces.
 
 config NRF_RTC_TIMER
 	bool "nRF Real Time Counter (NRF_RTC1) Timer"
 	default y
 	depends on SOC_FAMILY_NRF5 && CLOCK_CONTROL_NRF5
 	help
-	This module implements a kernel device driver for the nRF Real Time
-	Counter NRF_RTC1 and provides the standard "system clock driver"
-	interfaces.
+	  This module implements a kernel device driver for the nRF Real Time
+	  Counter NRF_RTC1 and provides the standard "system clock driver"
+	  interfaces.
 
 config PULPINO_TIMER
 	bool "pulpino Timer"
 	default y
 	depends on SOC_RISCV32_PULPINO
 	help
-	This module implements a kernel device driver for the pulpino processor
-	timer driver. It provides the standard "system clock driver" interfaces.
+	  This module implements a kernel device driver for the pulpino processor
+	  timer driver. It provides the standard "system clock driver" interfaces.
 
 config RISCV_MACHINE_TIMER
 	bool "RISCV Machine Timer"
 	default n
 	depends on SOC_FAMILY_RISCV_PRIVILEGE
 	help
-	This module implements a kernel device driver for the generic RISCV machine
-	timer driver. It provides the standard "system clock driver" interfaces.
+	  This module implements a kernel device driver for the generic RISCV machine
+	  timer driver. It provides the standard "system clock driver" interfaces.
 
 config XTENSA_TIMER
 	bool "Xtensa timer support"
 	depends on XTENSA
 	default y
 	help
-	This module implements a kernel device driver for the Xtensa processor and
-	provides the standard "system clock driver" interfaces.
-	If unchecked, no timer will be used.
-	If checked it will use either an internal timer (default option) or an
-	external timer. In that case one shall unselect XTENSA_INTERNAL_TIMER and
-	define XTENSA_TIMER_IRQ and XTENSA_TIMER_IRQ_PRIORITY.
+	  This module implements a kernel device driver for the Xtensa processor and
+	  provides the standard "system clock driver" interfaces.
+	  If unchecked, no timer will be used.
+	  If checked it will use either an internal timer (default option) or an
+	  external timer. In that case one shall unselect XTENSA_INTERNAL_TIMER and
+	  define XTENSA_TIMER_IRQ and XTENSA_TIMER_IRQ_PRIORITY.
 
 config XTENSA_INTERNAL_TIMER
 	bool "Xtensa internal timer"
 	depends on XTENSA_TIMER
 	default y
 	help
-	This module implements a kernel device driver for the Xtensa processor
-	internal timer and provides the standard "system clock driver" interfaces.
-	If unchecked, an external timer will be used. It will rely on a tick
-	interrupt connected to an IRQ line. In this case one shall define
-	both XTENSA_TIMER_IRQ and XTENSA_TIMER_IRQ_PRIORITY.
+	  This module implements a kernel device driver for the Xtensa processor
+	  internal timer and provides the standard "system clock driver" interfaces.
+	  If unchecked, an external timer will be used. It will rely on a tick
+	  interrupt connected to an IRQ line. In this case one shall define
+	  both XTENSA_TIMER_IRQ and XTENSA_TIMER_IRQ_PRIORITY.
 
 config XTENSA_TIMER_IRQ
 	int "Xtensa external timer interrupt number"
@@ -205,10 +205,10 @@ config XTENSA_TIMER_IRQ
 	range -1 31
 	default -1
 	help
-	This is the number of interrupt line used by the external timer.
-	The special value of -1 allows using the internal timer in order to
-	emulate an external timer. This is generally useful for running the project on
-	a simulator	where it is hard to emulate an external interrupt.
+	  This is the number of interrupt line used by the external timer.
+	  The special value of -1 allows using the internal timer in order to
+	  emulate an external timer. This is generally useful for running the project on
+	  a simulator	where it is hard to emulate an external interrupt.
 
 config XTENSA_TIMER_IRQ_PRIORITY
 	int "Xtensa external timer interrupt priority"
@@ -216,29 +216,29 @@ config XTENSA_TIMER_IRQ_PRIORITY
 	range 1 6
 	default 1
 	help
-	This is the priority of interrupt line.
+	  This is the priority of interrupt line.
 
 config SYSTEM_CLOCK_DISABLE
 	bool "API to disable system clock"
 	default n
 	help
-	This option enables the sys_clock_disable() API in the kernel. It is
-	needed by some subsystems (which will automatically select it), but is
-	rarely needed by applications.
+	  This option enables the sys_clock_disable() API in the kernel. It is
+	  needed by some subsystems (which will automatically select it), but is
+	  rarely needed by applications.
 
 config TIMER_READS_ITS_FREQUENCY_AT_RUNTIME
 	bool "Timer queries its hardware to find its frequency at runtime"
 	default n
 	help
-	The drivers select this option automatically when needed. Do not modify
-	this unless you have a very good reason for it.
+	  The drivers select this option automatically when needed. Do not modify
+	  this unless you have a very good reason for it.
 
 config SYSTEM_CLOCK_INIT_PRIORITY
 	int "System clock driver initialization priority"
 	default 0
 	help
-	This options can be used to set a specific initialization priority
-	value for the system clock driver. As driver initialization  might need
-	the clock to be running already, you should let the default value as it
-	is (0).
+	  This options can be used to set a specific initialization priority
+	  value for the system clock driver. As driver initialization  might need
+	  the clock to be running already, you should let the default value as it
+	  is (0).
 endmenu

--- a/drivers/usb/Kconfig
+++ b/drivers/usb/Kconfig
@@ -10,6 +10,6 @@ menuconfig USB
 	bool "USB"
 	default n
 	help
-	Enable USB drivers.
+	  Enable USB drivers.
 
 source "drivers/usb/device/Kconfig"

--- a/drivers/usb/device/Kconfig
+++ b/drivers/usb/device/Kconfig
@@ -13,13 +13,13 @@ config USB_DW
 	prompt "Designware USB Device Controller Driver"
 	default n
 	help
-	Designware USB Device Controller Driver.
+	  Designware USB Device Controller Driver.
 
 config USB_DW_IRQ_PRI
 	int "DesignWare USB Driver Interrupt priority"
 	depends on USB_DW
 	help
-	USB interrupt priority.
+	  USB interrupt priority.
 
 config USB_DC_STM32
 	bool
@@ -28,30 +28,30 @@ config USB_DC_STM32
 	depends on SOC_SERIES_STM32F4X
 	default n
 	help
-	STM32 family USB device controller Driver.
+	  STM32 family USB device controller Driver.
 
 config USB_DC_STM32_IRQ_PRI
 	int "USB STM32 Driver Interrupt priority"
 	depends on USB_DC_STM32
 	default 3
 	help
-	USB interrupt priority.
+	  USB interrupt priority.
 
 config USB_DC_STM32_EP_NUM
 	int
 	depends on USB_DC_STM32
 	default 4
 	help
-	Number of supported endpoints (including ep0).
+	  Number of supported endpoints (including ep0).
 
 config USB_DC_STM32_RAM_SIZE
 	int
 	depends on USB_DC_STM32
 	default 512
 	help
-	Total size in bytes for RX/TX buffering (FIFO, PMA...)
-	In case of USB-OTG-FS controller, datasheet defines a shared FIFO size.
-	For USB device controller, datasheet defines USB packet SRAM size.
+	  Total size in bytes for RX/TX buffering (FIFO, PMA...)
+	  In case of USB-OTG-FS controller, datasheet defines a shared FIFO size.
+	  For USB device controller, datasheet defines USB packet SRAM size.
 
 config SYS_LOG_USB_DRIVER_LEVEL
 	int
@@ -59,18 +59,18 @@ config SYS_LOG_USB_DRIVER_LEVEL
 	depends on SYS_LOG
 	default 0
 	help
-	Sets log level for USB driver
+	  Sets log level for USB driver
 
-	Levels are:
+	  Levels are:
 
-	- 0 OFF, do not write
+	  - 0 OFF, do not write
 
-	- 1 ERROR, only write SYS_LOG_ERR
+	  - 1 ERROR, only write SYS_LOG_ERR
 
-	- 2 WARNING, write SYS_LOG_WRN in addition to previous level
+	  - 2 WARNING, write SYS_LOG_WRN in addition to previous level
 
-	- 3 INFO, write SYS_LOG_INF in addition to previous levels
+	  - 3 INFO, write SYS_LOG_INF in addition to previous levels
 
-	- 4 DEBUG, write SYS_LOG_DBG in addition to previous levels
+	  - 4 DEBUG, write SYS_LOG_DBG in addition to previous levels
 
 endif # USB

--- a/dts/Kconfig
+++ b/dts/Kconfig
@@ -1,21 +1,21 @@
 config HAS_DTS
 	bool
 	help
-	This option specifies that the target platform supports device tree
-	configuration.
+	  This option specifies that the target platform supports device tree
+	  configuration.
 
 config HAS_DTS_ADC
 	bool
 	depends on HAS_DTS
 	help
-	This option specifies that the target platform supports device tree
-	configuration for ADC.
+	  This option specifies that the target platform supports device tree
+	  configuration for ADC.
 
 config HAS_DTS_I2C
 	bool
 	default n
 	depends on HAS_DTS
 	help
-	This option specifies that the target platform supports device tree
-	configuration for I2c.
+	  This option specifies that the target platform supports device tree
+	  configuration for I2c.
 

--- a/ext/hal/qmsi/Kconfig
+++ b/ext/hal/qmsi/Kconfig
@@ -14,8 +14,8 @@ menuconfig QMSI
 	default n
 	depends on HAS_QMSI
 	help
-	automatically set when either of QMSI_LIBRARY or QMSI_BUILTIN
-	is selected.
+	  automatically set when either of QMSI_LIBRARY or QMSI_BUILTIN
+	  is selected.
 
 if HAS_QMSI
 
@@ -24,31 +24,31 @@ config QMSI_BUILTIN
 	default n
 	select QMSI
 	help
-	Link with local QMSI sources instead of external library.
+	  Link with local QMSI sources instead of external library.
 
 config QMSI_LIBRARY
 	bool "Enable QMSI drivers using external library"
 	default n
 	select QMSI
 	help
-	This option enables QMSI device drivers. These drivers are actually shim
-	drivers based on drivers provided by QMSI BSP. The BSP provides a static
-	library (libqmsi) which implements several drivers for peripherals from
-	Intel MCUs (e.g. Quark SE and Quark D2000).
+	  This option enables QMSI device drivers. These drivers are actually shim
+	  drivers based on drivers provided by QMSI BSP. The BSP provides a static
+	  library (libqmsi) which implements several drivers for peripherals from
+	  Intel MCUs (e.g. Quark SE and Quark D2000).
 
 config QMSI_INSTALL_PATH
 	depends on QMSI_LIBRARY
 	string "QMSI install path"
 	help
-	This option holds the path where the QMSI library and headers are
-	installed. Make sure this option is properly set when QMSI_LIBRARY
-	is enabled otherwise the build will fail.
+	  This option holds the path where the QMSI library and headers are
+	  installed. Make sure this option is properly set when QMSI_LIBRARY
+	  is enabled otherwise the build will fail.
 
 config SOC_WATCH
 	bool "Enable SoCWatch drivers and related instrumentation"
 	default n
 	depends on KERNEL_EVENT_LOGGER
 	help
-	This option enables the SoCWatch driver and related instrumentation.
+	  This option enables the SoCWatch driver and related instrumentation.
 
 endif

--- a/ext/hal/ti/simplelink/Kconfig
+++ b/ext/hal/ti/simplelink/Kconfig
@@ -14,7 +14,7 @@ config SIMPLELINK_HOST_DRIVER
 	depends on NEWLIB_LIBC
 	select ERRNO
 	help
-	Build the SimpleLink host driver
+	  Build the SimpleLink host driver
 
 # Kconfig - MSP432 SDK HAL configuration
 

--- a/ext/lib/crypto/mbedtls/Kconfig
+++ b/ext/lib/crypto/mbedtls/Kconfig
@@ -29,72 +29,72 @@ config MBEDTLS_BUILTIN
 	depends on MBEDTLS
 	default n
 	help
-	Link with local mbedTLS sources instead of external library.
+	  Link with local mbedTLS sources instead of external library.
 
 config MBEDTLS_CFG_FILE
 	string "mbed TLS configuration file"
 	depends on MBEDTLS_BUILTIN
 	default "config-threadnet.h"
 	help
-	Enable custom mbed TLS configuration
+	  Enable custom mbed TLS configuration
 
 config MBEDTLS_DEBUG
 	bool "mbed TLS debug activation"
 	depends on MBEDTLS_BUILTIN
 	default n
 	help
-	Enable debugging activation for mbed TLS configuration. Note that this
-	does not directly cause any debug print output. For that you need to
-	call
-	mbedtls_debug_set_threshold(level);
-	and
-	mbedtls_ssl_conf_dbg(&mbedtls.conf, my_debug, NULL);
-	functions in your application, and create the my_debug() function to
-	actually print something useful.
+	  Enable debugging activation for mbed TLS configuration. Note that this
+	  does not directly cause any debug print output. For that you need to
+	  call
+	  mbedtls_debug_set_threshold(level);
+	  and
+	  mbedtls_ssl_conf_dbg(&mbedtls.conf, my_debug, NULL);
+	  functions in your application, and create the my_debug() function to
+	  actually print something useful.
 
 config MBEDTLS_TEST
 	bool "Compile internal self test functions"
 	depends on MBEDTLS_BUILTIN
 	default n
 	help
-	Enable self test function for the crypto algorithms
+	  Enable self test function for the crypto algorithms
 
 config MBEDTLS_LIBRARY
 	bool "Enable mbedTLS external library"
 	depends on MBEDTLS
 	default n
 	help
-	This option enables mbedTLS library.
+	  This option enables mbedTLS library.
 
 config MBEDTLS_INSTALL_PATH
 	string "mbedTLS install path"
 	depends on MBEDTLS_LIBRARY
 	help
-	This option holds the path where the mbedTLS libraries and headers are
-	installed. Make sure this option is properly set when MBEDTLS_LIBRARY
-	is enabled otherwise the build will fail.
+	  This option holds the path where the mbedTLS libraries and headers are
+	  installed. Make sure this option is properly set when MBEDTLS_LIBRARY
+	  is enabled otherwise the build will fail.
 
 config MBEDTLS_ENABLE_HEAP
 	bool "Enable global heap for mbed TLS"
 	default n
 	depends on MBEDTLS
 	help
-	This option enables the mbedtls to use the heap. This setting must
-	be global so that various applications and libraries in Zephyr do not
-	try to do this themselves as there can be only one heap defined
-	in mbedtls. If this is enabled, then the Zephyr will, during the device
-	startup, initialize the heap automatically.
+	  This option enables the mbedtls to use the heap. This setting must
+	  be global so that various applications and libraries in Zephyr do not
+	  try to do this themselves as there can be only one heap defined
+	  in mbedtls. If this is enabled, then the Zephyr will, during the device
+	  startup, initialize the heap automatically.
 
 config MBEDTLS_HEAP_SIZE
 	int "Heap size for mbed TLS"
 	default 512
 	depends on MBEDTLS_ENABLE_HEAP
 	help
-	The mbedtls routines will use this heap if enabled.
-	See ext/lib/crypto/mbedtls/include/mbedtls/config.h and
-	MBEDTLS_MEMORY_BUFFER_ALLOC_C option for details. That option is not
-	enabled by default.
-	Default value for the heap size is not set as it depends on the
-	application. For server application 15000 bytes should be enough.
-	For some dedicated and specific usage of mbedtls API, the 1000 bytes
-	might be ok.
+	  The mbedtls routines will use this heap if enabled.
+	  See ext/lib/crypto/mbedtls/include/mbedtls/config.h and
+	  MBEDTLS_MEMORY_BUFFER_ALLOC_C option for details. That option is not
+	  enabled by default.
+	  Default value for the heap size is not set as it depends on the
+	  application. For server application 15000 bytes should be enough.
+	  For some dedicated and specific usage of mbedtls API, the 1000 bytes
+	  might be ok.

--- a/ext/lib/crypto/tinycrypt/Kconfig
+++ b/ext/lib/crypto/tinycrypt/Kconfig
@@ -11,7 +11,7 @@ config TINYCRYPT
 	prompt "TinyCrypt Support"
 	default n
 	help
-	This option enables the TinyCrypt cryptography library.
+	  This option enables the TinyCrypt cryptography library.
 
 config TINYCRYPT_CTR_PRNG
 	bool
@@ -19,8 +19,8 @@ config TINYCRYPT_CTR_PRNG
 	depends on TINYCRYPT
 	default n
 	help
-	This option enables support for the pseudo-random number
-	generator in counter mode.
+	  This option enables support for the pseudo-random number
+	  generator in counter mode.
 
 config TINYCRYPT_SHA256
 	bool
@@ -28,8 +28,8 @@ config TINYCRYPT_SHA256
 	depends on TINYCRYPT
 	default n
 	help
-	This option enables support for SHA-256
-	hash function primitive.
+	  This option enables support for SHA-256
+	  hash function primitive.
 
 config TINYCRYPT_SHA256_HMAC
 	bool
@@ -37,8 +37,8 @@ config TINYCRYPT_SHA256_HMAC
 	depends on TINYCRYPT_SHA256
 	default n
 	help
-	This option enables support for HMAC using SHA-256
-	message authentication code.
+	  This option enables support for HMAC using SHA-256
+	  message authentication code.
 
 config TINYCRYPT_SHA256_HMAC_PRNG
 	bool
@@ -46,8 +46,8 @@ config TINYCRYPT_SHA256_HMAC_PRNG
 	depends on TINYCRYPT_SHA256_HMAC
 	default n
 	help
-	This option enables support for pseudo-random number
-	generator.
+	  This option enables support for pseudo-random number
+	  generator.
 
 config TINYCRYPT_ECC_DH
 	bool
@@ -56,11 +56,11 @@ config TINYCRYPT_ECC_DH
 	select ENTROPY_GENERATOR
 	default n
 	help
-	This option enables support for the Elliptic curve
-	Diffie-Hellman anonymous key agreement protocol.
+	  This option enables support for the Elliptic curve
+	  Diffie-Hellman anonymous key agreement protocol.
 
-	Enabling ECC requires a cryptographically secure random number
-	generator.
+	  Enabling ECC requires a cryptographically secure random number
+	  generator.
 
 config TINYCRYPT_ECC_DSA
 	bool
@@ -69,11 +69,11 @@ config TINYCRYPT_ECC_DSA
 	select ENTROPY_GENERATOR
 	default n
 	help
-	This option enables support for the Elliptic Curve Digital
-	Signature Algorithm (ECDSA).
+	  This option enables support for the Elliptic Curve Digital
+	  Signature Algorithm (ECDSA).
 
-	Enabling ECC requires a cryptographically secure random number
-	generator.
+	  Enabling ECC requires a cryptographically secure random number
+	  generator.
 
 config TINYCRYPT_AES
 	bool
@@ -81,7 +81,7 @@ config TINYCRYPT_AES
 	depends on TINYCRYPT
 	default n
 	help
-	This option enables support for AES-128 decrypt and encrypt.
+	  This option enables support for AES-128 decrypt and encrypt.
 
 config TINYCRYPT_AES_CBC
 	bool
@@ -89,7 +89,7 @@ config TINYCRYPT_AES_CBC
 	depends on TINYCRYPT_AES
 	default n
 	help
-	This option enables support for AES-128 block cipher mode.
+	  This option enables support for AES-128 block cipher mode.
 
 config TINYCRYPT_AES_CTR
 	bool
@@ -97,7 +97,7 @@ config TINYCRYPT_AES_CTR
 	depends on TINYCRYPT_AES
 	default n
 	help
-	This option enables support for AES-128 counter mode.
+	  This option enables support for AES-128 counter mode.
 
 config TINYCRYPT_AES_CCM
 	bool
@@ -105,7 +105,7 @@ config TINYCRYPT_AES_CCM
 	depends on TINYCRYPT_AES
 	default n
 	help
-	This option enables support for AES-128 CCM mode.
+	  This option enables support for AES-128 CCM mode.
 
 config TINYCRYPT_AES_CMAC
 	bool
@@ -113,4 +113,4 @@ config TINYCRYPT_AES_CMAC
 	depends on TINYCRYPT_AES
 	default n
 	help
-	This option enables support for AES-128 CMAC mode.
+	  This option enables support for AES-128 CMAC mode.

--- a/kernel/Kconfig
+++ b/kernel/Kconfig
@@ -14,14 +14,14 @@ config MULTITHREADING
 	prompt "Multi-threading"
 	default y
 	help
-	If disabled, only the main thread is available, so a main() function
-	must be provided. Interrupts are available. Kernel objects will most
-	probably not behave as expected, especially with regards to pending,
-	since the main thread cannot pend, it being the only thread in the
-	system.
+	  If disabled, only the main thread is available, so a main() function
+	  must be provided. Interrupts are available. Kernel objects will most
+	  probably not behave as expected, especially with regards to pending,
+	  since the main thread cannot pend, it being the only thread in the
+	  system.
 
-	Many drivers and subsystems will not work with this option; use only
-	when you REALLY know what you are doing.
+	  Many drivers and subsystems will not work with this option; use only
+	  when you REALLY know what you are doing.
 
 config NUM_COOP_PRIORITIES
 	int
@@ -30,28 +30,28 @@ config NUM_COOP_PRIORITIES
 	default 1 if !MULTITHREADING
 	range 0 128
 	help
-	Number of cooperative priorities configured in the system. Gives access
-	to priorities:
+	  Number of cooperative priorities configured in the system. Gives access
+	  to priorities:
 
 		K_PRIO_COOP(0) to K_PRIO_COOP(CONFIG_NUM_COOP_PRIORITIES - 1)
 
-	or seen another way, priorities:
+	  or seen another way, priorities:
 
 		-CONFIG_NUM_COOP_PRIORITIES to -1
 
-	This can be set to zero to disable cooperative scheduling. Cooperative
-	threads always preempt preemptible threads.
+	  This can be set to zero to disable cooperative scheduling. Cooperative
+	  threads always preempt preemptible threads.
 
-	Each priority requires an extra 8 bytes of RAM. Each set of 32 extra
-	total priorities require an extra 4 bytes and add one possible
-	iteration to loops that search for the next thread to run.
+	  Each priority requires an extra 8 bytes of RAM. Each set of 32 extra
+	  total priorities require an extra 4 bytes and add one possible
+	  iteration to loops that search for the next thread to run.
 
-	The total number of priorities is
+	  The total number of priorities is
 
 	   NUM_COOP_PRIORITIES + NUM_PREEMPT_PRIORITIES + 1
 
-	The extra one is for the idle thread, which must run at the lowest
-	priority, and be the only thread at that priority.
+	  The extra one is for the idle thread, which must run at the lowest
+	  priority, and be the only thread at that priority.
 
 config NUM_PREEMPT_PRIORITIES
 	int
@@ -60,21 +60,21 @@ config NUM_PREEMPT_PRIORITIES
 	default 0 if !MULTITHREADING
 	range 0 128
 	help
-	Number of preemptible priorities available in the system. Gives access
-	to priorities 0 to CONFIG_NUM_PREEMPT_PRIORITIES - 1.
+	  Number of preemptible priorities available in the system. Gives access
+	  to priorities 0 to CONFIG_NUM_PREEMPT_PRIORITIES - 1.
 
-	This can be set to 0 to disable preemptible scheduling.
+	  This can be set to 0 to disable preemptible scheduling.
 
-	Each priority requires an extra 8 bytes of RAM. Each set of 32 extra
-	total priorities require an extra 4 bytes and add one possible
-	iteration to loops that search for the next thread to run.
+	  Each priority requires an extra 8 bytes of RAM. Each set of 32 extra
+	  total priorities require an extra 4 bytes and add one possible
+	  iteration to loops that search for the next thread to run.
 
-	The total number of priorities is
+	  The total number of priorities is
 
 	   NUM_COOP_PRIORITIES + NUM_PREEMPT_PRIORITIES + 1
 
-	The extra one is for the idle thread, which must run at the lowest
-	priority, and be the only thread at that priority.
+	  The extra one is for the idle thread, which must run at the lowest
+	  priority, and be the only thread at that priority.
 
 config MAIN_THREAD_PRIORITY
 	int
@@ -82,8 +82,8 @@ config MAIN_THREAD_PRIORITY
 	default 0
 	default -2 if !PREEMPT_ENABLED
 	help
-	Priority at which the initialization thread runs, including the start
-	of the main() function. main() can then change its priority if desired.
+	  Priority at which the initialization thread runs, including the start
+	  of the main() function. main() can then change its priority if desired.
 
 config COOP_ENABLED
 	bool
@@ -106,11 +106,11 @@ config MAIN_STACK_SIZE
 	default 1024
 	default 512 if ZTEST
 	help
-	When the initialization is complete, the thread executing it then
-	executes the main() routine, so as to reuse the stack used by the
-	initialization, which would be wasted RAM otherwise.
+	  When the initialization is complete, the thread executing it then
+	  executes the main() routine, so as to reuse the stack used by the
+	  initialization, which would be wasted RAM otherwise.
 
-	After initialization is complete, the thread runs main().
+	  After initialization is complete, the thread runs main().
 
 config IDLE_STACK_SIZE
 	int
@@ -120,54 +120,54 @@ config IDLE_STACK_SIZE
 	default 512 if RISCV32
 	default 1024 if XTENSA
 	help
-	Depending on the work that the idle task must do, most likely due to
-	power management but possibly to other features like system event
-	logging (e.g. logging when the system goes to sleep), the idle thread
-	may need more stack space than the default value.
+	  Depending on the work that the idle task must do, most likely due to
+	  power management but possibly to other features like system event
+	  logging (e.g. logging when the system goes to sleep), the idle thread
+	  may need more stack space than the default value.
 
 config ISR_STACK_SIZE
 	int
 	prompt "ISR and initialization stack size (in bytes)"
 	default 2048
 	help
-	This option specifies the size of the stack used by interrupt
-	service routines (ISRs), and during kernel initialization.
+	  This option specifies the size of the stack used by interrupt
+	  service routines (ISRs), and during kernel initialization.
 
 config THREAD_STACK_INFO
 	bool
 	prompt "Thread stack info"
 	default n
 	help
-	This option allows each thread to store the thread stack info into
-	the k_thread data structure.
+	  This option allows each thread to store the thread stack info into
+	  the k_thread data structure.
 
 config  THREAD_CUSTOM_DATA
 	bool
 	prompt "Thread custom data"
 	default n
 	help
-	This option allows each thread to store 32 bits of custom data,
-	which can be accessed using the k_thread_custom_data_xxx() APIs.
+	  This option allows each thread to store 32 bits of custom data,
+	  which can be accessed using the k_thread_custom_data_xxx() APIs.
 
 config ERRNO
 	bool
 	prompt "Enable errno support"
 	default y
 	help
-	Enable per-thread errno in the kernel. Application and library code must
-	include errno.h provided by the C library (libc) to use the errno
-	symbol. The C library must access the per-thread errno via the
-	_get_errno() symbol.
+	  Enable per-thread errno in the kernel. Application and library code must
+	  include errno.h provided by the C library (libc) to use the errno
+	  symbol. The C library must access the per-thread errno via the
+	  _get_errno() symbol.
 
 config APPLICATION_MEMORY
 	bool
 	prompt "Split kernel and application memory"
 	default n
 	help
-	For all read-write memory sections (namely bss, noinit, data),
-	separate them into application and kernel areas. The application area
-	will have the project-level application objects and any libraries
-	including the C library in it.
+	  For all read-write memory sections (namely bss, noinit, data),
+	  separate them into application and kernel areas. The application area
+	  will have the project-level application objects and any libraries
+	  including the C library in it.
 
 menu "Kernel Debugging and Metrics"
 config KERNEL_DEBUG
@@ -197,20 +197,20 @@ config BOOT_DELAY
 	prompt "Boot delay in milliseconds"
 	default 0
 	help
-	This option delays bootup for the specified amount of
-	milliseconds. This is used to allow serial ports to get ready
-	before starting to print information on them during boot, as
-	some systems might boot to fast for a receiving endpoint to
-	detect the new USB serial bus, enumerate it and get ready to
-	receive before it actually gets data. A similar effect can be
-	achieved by waiting for DCD on the serial port--however, not
-	all serial ports have DCD.
+	  This option delays bootup for the specified amount of
+	  milliseconds. This is used to allow serial ports to get ready
+	  before starting to print information on them during boot, as
+	  some systems might boot to fast for a receiving endpoint to
+	  detect the new USB serial bus, enumerate it and get ready to
+	  receive before it actually gets data. A similar effect can be
+	  achieved by waiting for DCD on the serial port--however, not
+	  all serial ports have DCD.
 
 config BUILD_TIMESTAMP
 	bool
 	prompt "Build Timestamp"
 	help
-	Build timestamp and add it to the boot banner.
+	  Build timestamp and add it to the boot banner.
 
 config INT_LATENCY_BENCHMARK
 	bool
@@ -218,21 +218,21 @@ config INT_LATENCY_BENCHMARK
 	default n
 	depends on ARCH="x86"
 	help
-	This option enables the tracking of interrupt latency metrics;
-	the exact set of metrics being tracked is board-dependent.
-	Tracking begins when int_latency_init() is invoked by an application.
-	The metrics are displayed (and a new sampling interval is started)
-	each time int_latency_show() is called thereafter.
+	  This option enables the tracking of interrupt latency metrics;
+	  the exact set of metrics being tracked is board-dependent.
+	  Tracking begins when int_latency_init() is invoked by an application.
+	  The metrics are displayed (and a new sampling interval is started)
+	  each time int_latency_show() is called thereafter.
 
 config EXECUTION_BENCHMARKING
 	bool
 	prompt "Timing metrics "
 	default n
 	help
-	This option enables the tracking of various times inside the kernel
-	the exact set of metrics being tracked is board-dependent.
-	All timing measurements are enabled for X86 and ARM based architectures.
-	In other architectures only a subset are enabled.
+	  This option enables the tracking of various times inside the kernel
+	  the exact set of metrics being tracked is board-dependent.
+	  All timing measurements are enabled for X86 and ARM based architectures.
+	  In other architectures only a subset are enabled.
 
 config THREAD_MONITOR
 	bool
@@ -269,24 +269,24 @@ menu "Atomic Operations"
 config ATOMIC_OPERATIONS_BUILTIN
 	bool
 	help
-	Use the compiler builtin functions for atomic operations. This is
-	the preferred method. However, support for all arches in GCC is
-	incomplete.
+	  Use the compiler builtin functions for atomic operations. This is
+	  the preferred method. However, support for all arches in GCC is
+	  incomplete.
 
 config ATOMIC_OPERATIONS_CUSTOM
 	bool
 	help
-	Use when there isn't support for compiler built-ins, but you have
-	written optimized assembly code under arch/ which implements these.
+	  Use when there isn't support for compiler built-ins, but you have
+	  written optimized assembly code under arch/ which implements these.
 
 config ATOMIC_OPERATIONS_C
 	bool
 	help
-	Use atomic operations routines that are implemented entirely
-	in C by locking interrupts. Selected by architectures which either
-	do not have support for atomic operations in their instruction
-	set, or haven't been implemented yet during bring-up, and also
-	the compiler does not have support for the atomic __sync_* builtins.
+	  Use atomic operations routines that are implemented entirely
+	  in C by locking interrupts. Selected by architectures which either
+	  do not have support for atomic operations in their instruction
+	  set, or haven't been implemented yet during bring-up, and also
+	  the compiler does not have support for the atomic __sync_* builtins.
 endmenu
 
 menu "Timer API Options"
@@ -296,8 +296,8 @@ config TIMESLICING
 	default y
 	depends on SYS_CLOCK_EXISTS && (NUM_PREEMPT_PRIORITIES != 0)
 	help
-	This option enables time slicing between preemptible threads of
-	equal priority.
+	  This option enables time slicing between preemptible threads of
+	  equal priority.
 
 config TIMESLICE_SIZE
 	int "Time slice size (in ms)"
@@ -305,10 +305,10 @@ config TIMESLICE_SIZE
 	range 0 2147483647
 	depends on TIMESLICING
 	help
-	This option specifies the maximum amount of time a thread can execute
-	before other threads of equal priority are given an opportunity to run.
-	A time slice size of zero means "no limit" (i.e. an infinitely large
-	time slice).
+	  This option specifies the maximum amount of time a thread can execute
+	  before other threads of equal priority are given an opportunity to run.
+	  A time slice size of zero means "no limit" (i.e. an infinitely large
+	  time slice).
 
 config TIMESLICE_PRIORITY
 	int "Time slicing thread priority ceiling"
@@ -316,19 +316,19 @@ config TIMESLICE_PRIORITY
 	range 0 NUM_PREEMPT_PRIORITIES
 	depends on TIMESLICING
 	help
-	This option specifies the thread priority level at which time slicing
-	takes effect; threads having a higher priority than this ceiling are
-	not subject to time slicing.
+	  This option specifies the thread priority level at which time slicing
+	  takes effect; threads having a higher priority than this ceiling are
+	  not subject to time slicing.
 
 config POLL
 	bool
 	prompt "async I/O framework"
 	default n
 	help
-	Asynchronous notification framework. Enable the k_poll() and
-	k_poll_signal() APIs.  The former can wait on multiple events
-	concurrently, which can be either directly triggered or triggered by
-	the availability of some kernel objects (semaphores and fifos).
+	  Asynchronous notification framework. Enable the k_poll() and
+	  k_poll_signal() APIs.  The former can wait on multiple events
+	  concurrently, which can be either directly triggered or triggered by
+	  the availability of some kernel objects (semaphores and fifos).
 
 endmenu
 
@@ -338,23 +338,23 @@ config NUM_MBOX_ASYNC_MSGS
 	int "Maximum number of in-flight asynchronous mailbox messages"
 	default 10
 	help
-	This option specifies the total number of asynchronous mailbox
-	messages that can exist simultaneously, across all mailboxes
-	in the system.
+	  This option specifies the total number of asynchronous mailbox
+	  messages that can exist simultaneously, across all mailboxes
+	  in the system.
 
-	Setting this option to 0 disables support for asynchronous
-	mailbox messages.
+	  Setting this option to 0 disables support for asynchronous
+	  mailbox messages.
 
 config NUM_PIPE_ASYNC_MSGS
 	int "Maximum number of in-flight asynchronous pipe messages"
 	default 10
 	help
-	This option specifies the total number of asynchronous pipe
-	messages that can exist simultaneously, across all pipes in
-	the system.
+	  This option specifies the total number of asynchronous pipe
+	  messages that can exist simultaneously, across all pipes in
+	  the system.
 
-	Setting this option to 0 disables support for asynchronous
-	pipe messages.
+	  Setting this option to 0 disables support for asynchronous
+	  pipe messages.
 
 endmenu
 
@@ -364,10 +364,10 @@ config HEAP_MEM_POOL_SIZE
 	prompt "Heap memory pool size (in bytes)"
 	default 0
 	help
-	This option specifies the size of the heap memory pool used when
-	dynamically allocating memory using k_malloc(). Supported values
-	are: 256, 1024, 4096, and 16384. A size of zero means that no
-	heap memory pool is defined.
+	  This option specifies the size of the heap memory pool used when
+	  dynamically allocating memory using k_malloc(). Supported values
+	  are: 256, 1024, 4096, and 16384. A size of zero means that no
+	  heap memory pool is defined.
 endmenu
 
 
@@ -376,42 +376,42 @@ config ARCH_HAS_CUSTOM_SWAP_TO_MAIN
 	# hidden
 	default n
 	help
-	It's possible that an architecture port cannot use _Swap() to swap to
-	the _main() thread, but instead must do something custom. It must
-	enable this option in that case.
+	  It's possible that an architecture port cannot use _Swap() to swap to
+	  the _main() thread, but instead must do something custom. It must
+	  enable this option in that case.
 
 config SYS_CLOCK_TICKS_PER_SEC
 	int
 	prompt "System tick frequency (in ticks/second)"
 	default 100
 	help
-	This option specifies the frequency of the system clock in Hz.
+	  This option specifies the frequency of the system clock in Hz.
 
-	Depending on the choice made, an amount of possibly expensive math must
-	occur when converting ticks to milliseconds and vice-versa. Some values
-	are optimized, and yield significantly less math.
+	  Depending on the choice made, an amount of possibly expensive math must
+	  occur when converting ticks to milliseconds and vice-versa. Some values
+	  are optimized, and yield significantly less math.
 
-	The optimal values from a computational point-of-view are 1000, 500,
-	250 and 125, since in these cases there is either no computation
-	required, or it is all done via bit-shifting. These also give a
-	granularity from 1ms to 8ms.
+	  The optimal values from a computational point-of-view are 1000, 500,
+	  250 and 125, since in these cases there is either no computation
+	  required, or it is all done via bit-shifting. These also give a
+	  granularity from 1ms to 8ms.
 
-	Other good values are 100, 50, 25, 20 and 10. In this case, some math
-	is required but is minimized. These are also values that necessitate a
-	reduced number of clock interrupts per second, at the cost of
-	granularity (10ms to 100ms).
+	  Other good values are 100, 50, 25, 20 and 10. In this case, some math
+	  is required but is minimized. These are also values that necessitate a
+	  reduced number of clock interrupts per second, at the cost of
+	  granularity (10ms to 100ms).
 
-	All other values require some extensive 64-bit math, and in some
-	configurations even require calls to compiler built-in functions, and
-	can require a non-trivial extra amount of stack space (e.g. around 80
-	bytes on x86).
+	  All other values require some extensive 64-bit math, and in some
+	  configurations even require calls to compiler built-in functions, and
+	  can require a non-trivial extra amount of stack space (e.g. around 80
+	  bytes on x86).
 
 config SYS_CLOCK_HW_CYCLES_PER_SEC
 	int "System clock's h/w timer frequency"
 	help
-	This option specifies the frequency of the hardware timer used for the
-	system clock (in Hz). This option is set by the board's Kconfig file
-	and the user should generally avoid modifying it via the menu configuration.
+	  This option specifies the frequency of the hardware timer used for the
+	  system clock (in Hz). This option is set by the board's Kconfig file
+	  and the user should generally avoid modifying it via the menu configuration.
 
 config SYS_CLOCK_EXISTS
 	bool
@@ -419,17 +419,17 @@ config SYS_CLOCK_EXISTS
 	default y
 	default n if (SYS_CLOCK_TICKS_PER_SEC = 0)
 	help
-	This option specifies that the kernel lacks timer support.
+	  This option specifies that the kernel lacks timer support.
 
 config INIT_STACKS
 	bool
 	prompt "Initialize stack areas"
 	default n
 	help
-	This option instructs the kernel to initialize stack areas with a
-	known value (0xaa) before they are first used, so that the high
-	water mark can be easily determined. This applies to the stack areas
-	for threads.
+	  This option instructs the kernel to initialize stack areas with a
+	  known value (0xaa) before they are first used, so that the high
+	  water mark can be easily determined. This applies to the stack areas
+	  for threads.
 
 config XIP
 	bool
@@ -446,9 +446,9 @@ config RING_BUFFER
 	prompt "Enable ring buffers"
 	default n
 	help
-	Enable usage of ring buffers. This is similar to kernel FIFOs but ring
-	buffers manage their own buffer memory and can store arbitrary data.
-	For optimal performance, use buffer sizes that are a power of 2.
+	  Enable usage of ring buffers. This is similar to kernel FIFOs but ring
+	  buffers manage their own buffer memory and can store arbitrary data.
+	  For optimal performance, use buffer sizes that are a power of 2.
 
 menu "Initialization Priorities"
 
@@ -457,33 +457,33 @@ config KERNEL_INIT_PRIORITY_OBJECTS
 	prompt "Kernel objects initialization priority"
 	default 30
 	help
-	Kernel objects use this priority for initialization. This
-	priority needs to be higher than minimal default initialization
-	priority.
+	  Kernel objects use this priority for initialization. This
+	  priority needs to be higher than minimal default initialization
+	  priority.
 
 config KERNEL_INIT_PRIORITY_DEFAULT
 	int
 	prompt "Default init priority"
 	default 40
 	help
-	Default minimal init priority for each init level.
+	  Default minimal init priority for each init level.
 
 config KERNEL_INIT_PRIORITY_DEVICE
 	int
 	prompt "Default init priority for device drivers"
 	default 50
 	help
-	Device driver, that depends on common components, such as
-	interrupt controller, but does not depend on other devices,
-	uses this init priority.
+	  Device driver, that depends on common components, such as
+	  interrupt controller, but does not depend on other devices,
+	  uses this init priority.
 
 config APPLICATION_INIT_PRIORITY
 	int
 	prompt "Default init priority for application level drivers"
 	default 90
 	help
-	This priority level is for end-user drivers such as sensors and display
-	which have no inward dependencies.
+	  This priority level is for end-user drivers such as sensors and display
+	  which have no inward dependencies.
 
 config PTHREAD_IPC
 	bool
@@ -502,18 +502,18 @@ config STACK_CANARIES
 	prompt "Compiler stack canaries"
 	default n
 	help
-	This option enables compiler stack canaries support kernel functions.
+	  This option enables compiler stack canaries support kernel functions.
 
-	If stack canaries are supported by the compiler, it will emit
-	extra code that inserts a canary value into the stack frame when
-	a function is entered and validates this value upon exit.
-	Stack corruption (such as that caused by buffer overflow) results
-	in a fatal error condition for the running entity.
-	Enabling this option can result in a significant increase
-	in footprint and an associated decrease in performance.
+	  If stack canaries are supported by the compiler, it will emit
+	  extra code that inserts a canary value into the stack frame when
+	  a function is entered and validates this value upon exit.
+	  Stack corruption (such as that caused by buffer overflow) results
+	  in a fatal error condition for the running entity.
+	  Enabling this option can result in a significant increase
+	  in footprint and an associated decrease in performance.
 
-	If stack canaries are not supported by the compiler, enabling this
-	option has no effect.
+	  If stack canaries are not supported by the compiler, enabling this
+	  option has no effect.
 
 config EXECUTE_XOR_WRITE
 	bool "Enable W^X for memory partitions"
@@ -521,12 +521,12 @@ config EXECUTE_XOR_WRITE
 	depends on ARCH_HAS_EXECUTABLE_PAGE_BIT
 	default y
 	help
-	When enabled, will enforce that a writable page isn't executable
-	and vice versa.  This might not be acceptable in all scenarios,
-	so this option is given for those unafraid of shooting themselves
-	in the foot.
+	  When enabled, will enforce that a writable page isn't executable
+	  and vice versa.  This might not be acceptable in all scenarios,
+	  so this option is given for those unafraid of shooting themselves
+	  in the foot.
 
-	If unsure, say Y.
+	  If unsure, say Y.
 
 endmenu
 
@@ -537,7 +537,7 @@ config MAX_DOMAIN_PARTITIONS
 	range 0 255
 	depends on USERSPACE
 	help
-	Configure the maximum number of partitions per memory domain.
+	  Configure the maximum number of partitions per memory domain.
 
 source "kernel/Kconfig.event_logger"
 

--- a/lib/json/Kconfig
+++ b/lib/json/Kconfig
@@ -13,7 +13,7 @@ config JSON_LIBRARY
 	default N
 	prompt "Build JSON library"
 	help
-	Build a minimal JSON parsing/encoding library. Used by sample
-	applications such as the NATS client.
+	  Build a minimal JSON parsing/encoding library. Used by sample
+	  applications such as the NATS client.
 
 endmenu

--- a/lib/libc/Kconfig
+++ b/lib/libc/Kconfig
@@ -12,23 +12,23 @@ config NEWLIB_LIBC
 	bool
 	prompt "Build with newlib c library"
 	help
-	Build with newlib library. The newlib library is expected to be
-	part of the SDK in this case.
+	  Build with newlib library. The newlib library is expected to be
+	  part of the SDK in this case.
 
 config NEWLIB_LIBC_FLOAT_PRINTF
 	bool "Build with newlib float printf"
 	default n
 	depends on NEWLIB_LIBC
 	help
-	Build with floating point printf enabled. This will increase the size of
-	the image.
+	  Build with floating point printf enabled. This will increase the size of
+	  the image.
 
 config NEWLIB_LIBC_FLOAT_SCANF
 	bool "Build with newlib float scanf"
 	default n
 	depends on NEWLIB_LIBC
 	help
-	Build with floating point scanf enabled. This will increase the size of
-	the image.
+	  Build with floating point scanf enabled. This will increase the size of
+	  the image.
 
 endmenu

--- a/misc/Kconfig
+++ b/misc/Kconfig
@@ -12,8 +12,8 @@ menu "Linker Options"
 config HAS_FLASH_LOAD_OFFSET
 	bool
 	help
-	This option is selected by targets having a FLASH_LOAD_OFFSET
-	and FLASH_LOAD_SIZE.
+	  This option is selected by targets having a FLASH_LOAD_OFFSET
+	  and FLASH_LOAD_SIZE.
 
 if !HAS_DTS
 config FLASH_LOAD_OFFSET
@@ -21,88 +21,88 @@ config FLASH_LOAD_OFFSET
 	default 0
 	depends on HAS_FLASH_LOAD_OFFSET
 	help
-	This option specifies the byte offset from the beginning of flash that
-	the kernel should be loaded into. Changing this value from zero will
-	affect the Zephyr image's link, and will decrease the total amount of
-	flash available for use by application code.
+	  This option specifies the byte offset from the beginning of flash that
+	  the kernel should be loaded into. Changing this value from zero will
+	  affect the Zephyr image's link, and will decrease the total amount of
+	  flash available for use by application code.
 
-	If unsure, leave at the default value 0.
+	  If unsure, leave at the default value 0.
 
 config FLASH_LOAD_SIZE
 	hex "Kernel load size"
 	default 0
 	depends on HAS_FLASH_LOAD_OFFSET
 	help
-	If non-zero, this option specifies the size, in bytes, of the flash
-	area that the Zephyr image will be allowed to occupy.  If zero, the
-	image will be able to occupy from the FLASH_LOAD_OFFSET to the end of
-	the device.
+	  If non-zero, this option specifies the size, in bytes, of the flash
+	  area that the Zephyr image will be allowed to occupy.  If zero, the
+	  image will be able to occupy from the FLASH_LOAD_OFFSET to the end of
+	  the device.
 
-	If unsure, leave at the default value 0.
+	  If unsure, leave at the default value 0.
 endif
 
 config TEXT_SECTION_OFFSET
 	hex "TEXT section offset"
 	default 0
 	help
-	This sets and offset before the text section and allows booting images
-	with custom headers that are inserted at the beginning of the image.
+	  This sets and offset before the text section and allows booting images
+	  with custom headers that are inserted at the beginning of the image.
 
 config HAVE_CUSTOM_LINKER_SCRIPT
 	prompt "Custom linker scripts provided"
 	def_bool n
 	help
-	Set this option if you have a custom linker script which needed to
-	be define in CUSTOM_LINKER_SCRIPT.
+	  Set this option if you have a custom linker script which needed to
+	  be define in CUSTOM_LINKER_SCRIPT.
 
 config CUSTOM_LINKER_SCRIPT
 	string "Path to custom linker script"
 	default ""
 	depends on HAVE_CUSTOM_LINKER_SCRIPT
 	help
-	Path to the linker script to be used instead of the one define by the
-	board.
+	  Path to the linker script to be used instead of the one define by the
+	  board.
 
-	The linker script must be based on a version provided by Zephyr since
-	the kernel can expect a certain layout/certain regions.
+	  The linker script must be based on a version provided by Zephyr since
+	  the kernel can expect a certain layout/certain regions.
 
-	This is useful when an application needs to add sections into the
-	linker script and avoid having to change the script provided by
-	Zephyr.
+	  This is useful when an application needs to add sections into the
+	  linker script and avoid having to change the script provided by
+	  Zephyr.
 
 config CUSTOM_RODATA_LD
 	bool "Include custom-rodata.ld"
 	default n
 	help
-	Include a customized linker script fragment for inserting additional
-	data and linker directives into the rodata section.
+	  Include a customized linker script fragment for inserting additional
+	  data and linker directives into the rodata section.
 
 config CUSTOM_RWDATA_LD
 	bool "Include custom-rwdata.ld"
 	default n
 	help
-	Include a customized linker script fragment for inserting additional
-	data and linker directives into the data section.
+	  Include a customized linker script fragment for inserting additional
+	  data and linker directives into the data section.
 
 config CUSTOM_SECTIONS_LD
 	bool "Include custom-sections.ld"
 	default n
 	help
-	Include a customized linker script fragment for inserting additional
-	arbitrary sections.
+	  Include a customized linker script fragment for inserting additional
+	  arbitrary sections.
 
 config LINK_WHOLE_ARCHIVE
 	bool "Allow linking with --whole-archive"
 	default n
 	help
-	This options allows linking external libraries with the
-	--whole-archive option to keep all symbols.
+	  This options allows linking external libraries with the
+	  --whole-archive option to keep all symbols.
 
 config KERNEL_ENTRY
 	string "Kernel entry symbol"
 	default "__start"
 	help
-	Code entry symbol, to be set at linking phase.
+	  Code entry symbol, to be set at linking phase.
 
 config CHECK_LINK_MAP
 	bool "Check linker map"
@@ -117,28 +117,28 @@ menu "Compiler Options"
 config CROSS_COMPILE
 	string "Cross-compiler tool prefix"
 	help
-	Same as running 'make CROSS_COMPILE=prefix-' but stored for
-	default make runs in this kernel build directory.  You don't
-	need to set this unless you want the configured kernel build
-	directory to select the cross-compiler automatically.
+	  Same as running 'make CROSS_COMPILE=prefix-' but stored for
+	  default make runs in this kernel build directory.  You don't
+	  need to set this unless you want the configured kernel build
+	  directory to select the cross-compiler automatically.
 
 config COMPILER_OPT
 	string
 	prompt "Custom compiler options"
 	default ""
 	help
-	This option is a free-form string that is passed to the compiler
-	when building all parts of a project (i.e. kernel).
-	The compiler options specified by this string supplement the
-	predefined set of compiler supplied by the build system,
-	and can be used to change compiler optimization, warning and error
-	messages, and so on.
+	  This option is a free-form string that is passed to the compiler
+	  when building all parts of a project (i.e. kernel).
+	  The compiler options specified by this string supplement the
+	  predefined set of compiler supplied by the build system,
+	  and can be used to change compiler optimization, warning and error
+	  messages, and so on.
 
 config TOOLCHAIN_VARIANT
 	string "Cross-compiler variant name"
 	help
-	For optimized compilers with reduced features, specify the name
-	of the variant.
+	  For optimized compilers with reduced features, specify the name
+	  of the variant.
 
 endmenu
 
@@ -200,7 +200,7 @@ config PERFORMANCE_METRICS
 	prompt "Enable performance metrics [EXPERIMENTAL]"
 	default n
 	help
-	Enable Performance Metrics.
+	  Enable Performance Metrics.
 
 config BOOT_TIME_MEASUREMENT
 	bool
@@ -208,11 +208,11 @@ config BOOT_TIME_MEASUREMENT
 	default n
 	depends on PERFORMANCE_METRICS
 	help
-	This option enables the recording of timestamps during system start
-	up. The global variable __start_time_stamp records the time kernel begins
-	executing, while __main_time_stamp records when main() begins executing,
-	and __idle_time_stamp records when the CPU becomes idle. All values are
-	recorded in terms of CPU clock cycles since system reset.
+	  This option enables the recording of timestamps during system start
+	  up. The global variable __start_time_stamp records the time kernel begins
+	  executing, while __main_time_stamp records when main() begins executing,
+	  and __idle_time_stamp records when the CPU becomes idle. All values are
+	  recorded in terms of CPU clock cycles since system reset.
 
 config CPU_CLOCK_FREQ_MHZ
 	int
@@ -220,8 +220,8 @@ config CPU_CLOCK_FREQ_MHZ
 	default 20
 	depends on BOOT_TIME_MEASUREMENT
 	help
-	This option specifies the CPU Clock Frequency in MHz in order to
-	convert Intel RDTSC timestamp to microseconds.
+	  This option specifies the CPU Clock Frequency in MHz in order to
+	  convert Intel RDTSC timestamp to microseconds.
 
 endmenu
 
@@ -233,8 +233,8 @@ config IS_BOOTLOADER
 	depends on XIP
 	depends on ARM
 	help
-	This option indicates that Zephyr will act as a bootloader to execute
-	a separate Zephyr image payload.
+	  This option indicates that Zephyr will act as a bootloader to execute
+	  a separate Zephyr image payload.
 
 config BOOTLOADER_SRAM_SIZE
 	int "SRAM reserved for when Zephyr acts as a bootloader"
@@ -242,8 +242,8 @@ config BOOTLOADER_SRAM_SIZE
 	depends on !XIP || IS_BOOTLOADER
 	depends on ARM
 	help
-	This option specifies the amount of SRAM (measure in kB) reserved for
-	when Zephyr is to act as a bootloader.
+	  This option specifies the amount of SRAM (measure in kB) reserved for
+	  when Zephyr is to act as a bootloader.
 
 config BOOTLOADER_KEXEC
 	bool
@@ -251,8 +251,8 @@ config BOOTLOADER_KEXEC
 	depends on X86
 	default n
 	help
-	This option signifies that Linux boots the kernel using kexec system call
-	and utility. This method is used to boot the kernel over the network.
+	  This option signifies that Linux boots the kernel using kexec system call
+	  and utility. This method is used to boot the kernel over the network.
 
 config BOOTLOADER_UNKNOWN
 	bool
@@ -260,10 +260,10 @@ config BOOTLOADER_UNKNOWN
 	default n
 	depends on X86
 	help
-	This option signifies that the target has a generic bootloader
-	or that it supports multiple ways of booting and it isn't clear
-	at build time which method is to be used. When this option is enabled
-	the board may have to do extra work to ensure a proper startup.
+	  This option signifies that the target has a generic bootloader
+	  or that it supports multiple ways of booting and it isn't clear
+	  at build time which method is to be used. When this option is enabled
+	  the board may have to do extra work to ensure a proper startup.
 
 config BOOTLOADER_CONTEXT_RESTORE
 	bool
@@ -271,16 +271,16 @@ config BOOTLOADER_CONTEXT_RESTORE
 	default y
 	depends on SYS_POWER_DEEP_SLEEP && BOOTLOADER_CONTEXT_RESTORE_SUPPORTED
 	help
-	This option signifies that the target has a bootloader
-	that restores CPU context upon resuming from deep sleep
-	power state.
+	  This option signifies that the target has a bootloader
+	  that restores CPU context upon resuming from deep sleep
+	  power state.
 
 config REBOOT
 	bool "Reboot functionality"
 	default n
 	select SYSTEM_CLOCK_DISABLE
 	help
-	Enable the sys_reboot() API. Enabling this can drag in other subsystems
-	needed to perform a "safe" reboot (e.g. SYSTEM_CLOCK_DISABLE, to stop the
-	system clock before issuing a reset).
+	  Enable the sys_reboot() API. Enabling this can drag in other subsystems
+	  needed to perform a "safe" reboot (e.g. SYSTEM_CLOCK_DISABLE, to stop the
+	  system clock before issuing a reset).
 endmenu

--- a/subsys/bluetooth/shell/Kconfig
+++ b/subsys/bluetooth/shell/Kconfig
@@ -11,5 +11,5 @@ config BT_SHELL
 	default n
 	select CONSOLE_SHELL
 	help
-	Activate shell module that provides Bluetooth commands to the
-	console.
+	  Activate shell module that provides Bluetooth commands to the
+	  console.

--- a/subsys/console/Kconfig
+++ b/subsys/console/Kconfig
@@ -11,7 +11,7 @@ config CONSOLE_PULL
 	default n
 	prompt "Enable pull-style Console access"
 	help
-	Get data from console using getchar/getline calls
+	  Get data from console using getchar/getline calls
 
 if CONSOLE_PULL
 choice

--- a/subsys/cpp/Kconfig
+++ b/subsys/cpp/Kconfig
@@ -3,5 +3,5 @@ config CPLUSPLUS
 	bool "Enable C++ support for the application"
 	default n
 	help
-	This option enables the use of applications built with C++.
+	  This option enables the use of applications built with C++.
 

--- a/subsys/debug/Kconfig
+++ b/subsys/debug/Kconfig
@@ -12,41 +12,41 @@ config DEBUG
 	bool "Build kernel with debugging enabled"
 	default n
 	help
-	Build a kernel suitable for debugging.  Right now, this option
-	only disables optimization, more debugging variants can be selected
-	from here to allow more debugging.
+	  Build a kernel suitable for debugging.  Right now, this option
+	  only disables optimization, more debugging variants can be selected
+	  from here to allow more debugging.
 
 config STACK_USAGE
 	bool "Generate stack usage information"
 	default n
 	help
-	Generate an extra file that specifies the maximum amount of stack used,
-	on a per-function basis.
+	  Generate an extra file that specifies the maximum amount of stack used,
+	  on a per-function basis.
 
 config STACK_SENTINEL
 	bool "Enable stack sentinel"
 	select THREAD_STACK_INFO
 	default n
 	help
-	Store a magic value at the lowest addresses of a thread's stack.
-	Periodically check that this value is still present and kill the
-	thread gracefully if it isn't. This is currently checked in four
-	places:
+	  Store a magic value at the lowest addresses of a thread's stack.
+	  Periodically check that this value is still present and kill the
+	  thread gracefully if it isn't. This is currently checked in four
+	  places:
 
-	1) Upon any context switch for the outgoing thread
-	2) Any hardware interrupt that doesn't context switch, the check is
-	   performed for the interrupted thread
-	3) When a thread returns from its entry point
-	4) When a thread calls k_yield() but doesn't context switch
+	  1) Upon any context switch for the outgoing thread
+	  2) Any hardware interrupt that doesn't context switch, the check is
+	     performed for the interrupted thread
+	  3) When a thread returns from its entry point
+	  4) When a thread calls k_yield() but doesn't context switch
 
-	This feature doesn't prevent corruption and the system may be
-	in an unusable state. However, given the bizarre behavior associated
-	with stack overflows, knowledge that this is happening is very
-	useful.
+	  This feature doesn't prevent corruption and the system may be
+	  in an unusable state. However, given the bizarre behavior associated
+	  with stack overflows, knowledge that this is happening is very
+	  useful.
 
-	This feature is intended for those systems which lack hardware support
-	for stack overflow protection, or have insufficient system resources
-	to use that hardware support.
+	  This feature is intended for those systems which lack hardware support
+	  for stack overflow protection, or have insufficient system resources
+	  to use that hardware support.
 
 config PRINTK
 	bool
@@ -54,10 +54,10 @@ config PRINTK
 	depends on CONSOLE_HAS_DRIVER
 	default y
 	help
-	This option directs printk() debugging output to the supported
-	console device, rather than suppressing the generation
-	of printk() output entirely. Output is sent immediately, without
-	any mutual exclusion or buffering.
+	  This option directs printk() debugging output to the supported
+	  console device, rather than suppressing the generation
+	  of printk() output entirely. Output is sent immediately, without
+	  any mutual exclusion or buffering.
 
 config PRINTK_BUFFER_SIZE
 	int
@@ -66,9 +66,9 @@ config PRINTK_BUFFER_SIZE
 	depends on USERSPACE
 	default 32
 	help
-	If userspace is enabled, printk() calls are buffered so that we do
-	not have to make a system call for every character emitted. Specify
-	the size of this buffer.
+	  If userspace is enabled, printk() calls are buffered so that we do
+	  not have to make a system call for every character emitted. Specify
+	  the size of this buffer.
 
 config STDOUT_CONSOLE
 	bool
@@ -76,28 +76,28 @@ config STDOUT_CONSOLE
 	depends on CONSOLE_HAS_DRIVER
 	default n
 	help
-	This option directs standard output (e.g. printf) to the console
-	device, rather than suppressing it entirely.
+	  This option directs standard output (e.g. printf) to the console
+	  device, rather than suppressing it entirely.
 
 config EARLY_CONSOLE
 	bool
 	prompt "Send stdout at the earliest stage possible"
 	default n
 	help
-	This option will enable stdout as early as possible, for debugging
-	purpose. For instance, in case of STDOUT_CONSOLE being set it will
-	initialize its driver earlier than normal, in order to get the stdout
-	sent through the console at the earliest stage possible.
+	  This option will enable stdout as early as possible, for debugging
+	  purpose. For instance, in case of STDOUT_CONSOLE being set it will
+	  initialize its driver earlier than normal, in order to get the stdout
+	  sent through the console at the earliest stage possible.
 
 config ASSERT
 	bool
 	prompt "Enable __ASSERT() macro"
 	default n
 	help
-	This enables the __ASSERT() macro in the kernel code. If an assertion
-	fails, the calling thread is put on an infinite tight loop. Since
-	enabling this adds a significant footprint, it should only be enabled
-	in a non-production system.
+	  This enables the __ASSERT() macro in the kernel code. If an assertion
+	  fails, the calling thread is put on an infinite tight loop. Since
+	  enabling this adds a significant footprint, it should only be enabled
+	  in a non-production system.
 
 config ASSERT_LEVEL
 	int
@@ -106,38 +106,38 @@ config ASSERT_LEVEL
 	range 0 2
 	depends on ASSERT
 	help
-	This option specifies the assertion level used by the __ASSERT()
-	macro. It can be set to one of three possible values:
+	  This option specifies the assertion level used by the __ASSERT()
+	  macro. It can be set to one of three possible values:
 
-	Level 0: off
-	Level 1: on + warning in every file that includes __assert.h
-	Level 2: on + no warning
+	  Level 0: off
+	  Level 1: on + warning in every file that includes __assert.h
+	  Level 2: on + no warning
 
 config OBJECT_TRACING
 	bool
 	prompt "Kernel object tracing"
 	default n
 	help
-	This option enable the feature for tracing kernel objects. This option
-	is for debug purposes and increases the memory footprint of the kernel.
+	  This option enable the feature for tracing kernel objects. This option
+	  is for debug purposes and increases the memory footprint of the kernel.
 
 config OVERRIDE_FRAME_POINTER_DEFAULT
 	bool
 	prompt "Override compiler defaults for -fomit-frame-pointer"
 	default n
 	help
-	Omitting the frame pointer prevents the compiler from putting the stack
-	frame pointer into a register. Saves a few instructions in function
-	prologues/epilogues and frees up a register for general-purpose use,
-	which can provide good performance improvements on register-constrained
-	architectures like x86. On some architectures (including x86) omitting
-	frame pointers impedes debugging as local variables are harder to
-	locate. At -O1 and above gcc will enable -fomit-frame-pointer
-	automatically but only if the architecture does not require if for
-	effective debugging.
+	  Omitting the frame pointer prevents the compiler from putting the stack
+	  frame pointer into a register. Saves a few instructions in function
+	  prologues/epilogues and frees up a register for general-purpose use,
+	  which can provide good performance improvements on register-constrained
+	  architectures like x86. On some architectures (including x86) omitting
+	  frame pointers impedes debugging as local variables are harder to
+	  locate. At -O1 and above gcc will enable -fomit-frame-pointer
+	  automatically but only if the architecture does not require if for
+	  effective debugging.
 
-	Choose Y if you want to override the default frame pointer behavior
-	of your compiler, otherwise choose N.
+	  Choose Y if you want to override the default frame pointer behavior
+	  of your compiler, otherwise choose N.
 
 config OMIT_FRAME_POINTER
 	bool
@@ -145,15 +145,15 @@ config OMIT_FRAME_POINTER
 	default n
 	depends on OVERRIDE_FRAME_POINTER_DEFAULT
 	help
-	Choose Y for best performance. On some architectures (including x86)
-	this will favor code size and performance over debugability.
+	  Choose Y for best performance. On some architectures (including x86)
+	  this will favor code size and performance over debugability.
 
-	Choose N in you wish to retain the frame pointer. This option may
-	be useful if your application uses runtime backtracing and does not
-	support parsing unwind tables.
+	  Choose N in you wish to retain the frame pointer. This option may
+	  be useful if your application uses runtime backtracing and does not
+	  support parsing unwind tables.
 
-	If unsure, disable OVERRIDE_FRAME_POINTER_DEFAULT to allow the compiler
-	to adopt sensible defaults for your architecture.
+	  If unsure, disable OVERRIDE_FRAME_POINTER_DEFAULT to allow the compiler
+	  to adopt sensible defaults for your architecture.
 
 
 #
@@ -164,10 +164,10 @@ config DEBUG_INFO
 	default n
 	depends on X86
 	help
-	This option enables the addition of various information that can be used
-	by debuggers in debugging the system.
+	  This option enables the addition of various information that can be used
+	  by debuggers in debugging the system.
 
-	NOTE: Does not currently work with the x86 IAMCU ABI.
+	  NOTE: Does not currently work with the x86 IAMCU ABI.
 
 #
 # Miscellaneous debugging options

--- a/subsys/dfu/Kconfig
+++ b/subsys/dfu/Kconfig
@@ -47,16 +47,16 @@ config SYS_LOG_IMG_MANAGER_LEVEL
 	default 0
 	range 0 4
 	help
-	Sets log level for the image manager.
-	Levels are:
+	  Sets log level for the image manager.
+	  Levels are:
 
-	- 0 OFF: do not write
+	  - 0 OFF: do not write
 
-	- 1 ERROR: only write SYS_LOG_ERR
+	  - 1 ERROR: only write SYS_LOG_ERR
 
-	- 2 WARNING: write SYS_LOG_WRN in addition to previous level
+	  - 2 WARNING: write SYS_LOG_WRN in addition to previous level
 
-	- 3 INFO: write SYS_LOG_INF in addition to previous levels
+	  - 3 INFO: write SYS_LOG_INF in addition to previous levels
 
-	- 4 DEBUG: write SYS_LOG_DBG in addition to previous levels
+	  - 4 DEBUG: write SYS_LOG_DBG in addition to previous levels
 endmenu

--- a/subsys/disk/Kconfig
+++ b/subsys/disk/Kconfig
@@ -11,7 +11,7 @@ config DISK_ACCESS
 	default n
 	prompt "Enable Disk Interface"
 	help
-	Enable disk access over a supported media backend like FLASH or RAM
+	  Enable disk access over a supported media backend like FLASH or RAM
 
 if DISK_ACCESS
 choice
@@ -20,15 +20,15 @@ choice
 config DISK_ACCESS_RAM
 	bool "RAM Disk"
 	help
-	RAM buffer used to emulate storage disk.
-	This option can used to test the file
-	system.
+	  RAM buffer used to emulate storage disk.
+	  This option can used to test the file
+	  system.
 
 config DISK_ACCESS_FLASH
 	bool "Flash"
 	select FLASH
 	help
-	Flash device is used for the file system.
+	  Flash device is used for the file system.
 
 endchoice
 
@@ -41,31 +41,31 @@ config DISK_FLASH_DEV_NAME
 config DISK_FLASH_START
 	hex
 	help
-	This is start address of the flash to be used as storage backend.
+	  This is start address of the flash to be used as storage backend.
 
 config DISK_FLASH_MAX_RW_SIZE
 	int
 	help
-	This is the maximum number of bytes that the
-	flash_write API can do per invocation.
-	API.
+	  This is the maximum number of bytes that the
+	  flash_write API can do per invocation.
+	  API.
 
 config DISK_FLASH_ERASE_ALIGNMENT
 	hex
 	help
-	This is the start address alignment required by
-	the flash component.
+	  This is the start address alignment required by
+	  the flash component.
 
 config DISK_ERASE_BLOCK_SIZE
 	hex
 	help
-	This is typically the minimum block size that
-	is erased at one time in flash storage.
+	  This is typically the minimum block size that
+	  is erased at one time in flash storage.
 
 config DISK_VOLUME_SIZE
 	hex
 	help
-	This is the file system volume size in bytes.
+	  This is the file system volume size in bytes.
 
 endif # DISK_ACCESS_FLASH
 endif # DISK_ACCESS

--- a/subsys/fs/Kconfig
+++ b/subsys/fs/Kconfig
@@ -11,7 +11,7 @@ config FILE_SYSTEM
 	select DISK_ACCESS
 	default n
 	help
-	Enables support for file system.
+	  Enables support for file system.
 
 if FILE_SYSTEM
 
@@ -27,15 +27,15 @@ config NO_FS
 config FAT_FILESYSTEM_ELM
 	bool "ELM FAT File System"
 	help
-	Use the ELM FAT File system implementation.
+	  Use the ELM FAT File system implementation.
 
 config FILE_SYSTEM_NFFS
 	bool "NFFS file system support"
 	select FLASH_PAGE_LAYOUT
 	help
-	Enables NFFS file system support.
-	Note: NFFS requires 1-byte unaligned access to flash thus it
-	will not work on devices that support only aligned flash access.
+	  Enables NFFS file system support.
+	  Note: NFFS requires 1-byte unaligned access to flash thus it
+	  will not work on devices that support only aligned flash access.
 
 endchoice
 
@@ -43,8 +43,8 @@ config FILE_SYSTEM_SHELL
 	bool "Enable file system shell"
 	depends on CONSOLE_SHELL
 	help
-	This shell provides basic browsing of the contents of the
-	file system.
+	  This shell provides basic browsing of the contents of the
+	  file system.
 
 
 menu "NFFS Settings"

--- a/subsys/logging/Kconfig
+++ b/subsys/logging/Kconfig
@@ -71,6 +71,6 @@ config SYS_LOG_EXT_HOOK
 	depends on SYS_LOG
 	default n
 	help
-	Use external hook function for logging.
+	  Use external hook function for logging.
 endmenu
 

--- a/subsys/net/Kconfig
+++ b/subsys/net/Kconfig
@@ -12,8 +12,8 @@ config NET_BUF
 	bool "Network buffer support"
 	default n
 	help
-	This option enables support for generic network protocol
-	buffers.
+	  This option enables support for generic network protocol
+	  buffers.
 
 config NET_BUF_LOG
 	bool "Network buffer logging"
@@ -22,7 +22,7 @@ config NET_BUF_LOG
 	select SYS_LOG
 	default n
 	help
-	Enable logs and checks for the generic network buffers.
+	  Enable logs and checks for the generic network buffers.
 
 config SYS_LOG_NET_BUF_LEVEL
 	int
@@ -46,10 +46,10 @@ config NET_BUF_WARN_ALLOC_INTERVAL
 	default 1
 	range 0 60
 	help
-	Interval in seconds of Network buffer allocation warnings which are
-	generated when a buffer cannot immediately be allocated with K_FOREVER
-	which may lead to deadlocks. Setting it to 0 makes warnings to be
-	printed only once per allocation.
+	  Interval in seconds of Network buffer allocation warnings which are
+	  generated when a buffer cannot immediately be allocated with K_FOREVER
+	  which may lead to deadlocks. Setting it to 0 makes warnings to be
+	  printed only once per allocation.
 
 config NET_BUF_SIMPLE_LOG
 	bool "Network buffer memory debugging"
@@ -65,10 +65,10 @@ config NET_BUF_POOL_USAGE
 	depends on NET_BUF
 	default n
 	help
-	Enable network buffer pool tracking. This means that:
-	* amount of free buffers in the pool is remembered
-	* total size of the pool is calculated
-	* pool name is stored and can be shown in debugging prints
+	  Enable network buffer pool tracking. This means that:
+	  * amount of free buffers in the pool is remembered
+	  * total size of the pool is calculated
+	  * pool name is stored and can be shown in debugging prints
 
 config  NETWORKING
 	bool "Link layer and IP networking support"
@@ -77,7 +77,7 @@ config  NETWORKING
 	select ENTROPY_GENERATOR
 	default n
 	help
-	This option enabled generic link layer and IP networking support.
+	  This option enabled generic link layer and IP networking support.
 
 if NETWORKING
 

--- a/subsys/net/ip/Kconfig
+++ b/subsys/net/ip/Kconfig
@@ -14,11 +14,11 @@ config NET_RAW_MODE
 	bool
 	default n
 	help
-	This is a very specific option used to built only the very minimal
-	part of the net stack in order to get network drivers working without
-	any net stack above: core, L2 etc... Basically this will build only
-	net_pkt part. It is currently used only by IEEE 802.15.4 drivers,
-	though any type of net drivers could use it.
+	  This is a very specific option used to built only the very minimal
+	  part of the net stack in order to get network drivers working without
+	  any net stack above: core, L2 etc... Basically this will build only
+	  net_pkt part. It is currently used only by IEEE 802.15.4 drivers,
+	  though any type of net drivers could use it.
 
 if !NET_RAW_MODE
 
@@ -26,8 +26,8 @@ config NET_INIT_PRIO
 	int
 	default 90
 	help
-	Network initialization priority level. This number tells how
-	early in the boot the network stack is initialized.
+	  Network initialization priority level. This number tells how
+	  early in the boot the network stack is initialized.
 
 source "subsys/net/ip/Kconfig.debug"
 
@@ -40,15 +40,15 @@ config NET_SHELL
 	default n
 	select CONSOLE_SHELL
 	help
-	Activate shell module that provides network commands like
-	ping to the console.
+	  Activate shell module that provides network commands like
+	  ping to the console.
 
 config NET_IP_ADDR_CHECK
 	bool "Check IP address validity before sending IP packet"
 	default y
 	help
-	Check that either the source or destination address is
-	correct before sending either IPv4 or IPv6 network packet.
+	  Check that either the source or destination address is
+	  correct before sending either IPv4 or IPv6 network packet.
 
 config NET_MAX_ROUTERS
 	int "How many routers are supported"
@@ -57,7 +57,7 @@ config NET_MAX_ROUTERS
 	default 1 if !NET_IPV4 && NET_IPV6
 	range 1 254
 	help
-	The value depends on your network needs.
+	  The value depends on your network needs.
 
 # Normally the route support is enabled by RPL or similar technology
 # that needs to use the routing infrastructure.
@@ -72,14 +72,14 @@ config	NET_MAX_ROUTES
 	default NET_IPV6_MAX_NEIGHBORS
 	depends on NET_ROUTE
 	help
-	This determines how many entries can be stored in routing table.
+	  This determines how many entries can be stored in routing table.
 
 config	NET_MAX_NEXTHOPS
 	int "Max number of next hop entries stored."
 	default NET_MAX_ROUTES
 	depends on NET_ROUTE
 	help
-	This determines how many entries can be stored in nexthop table.
+	  This determines how many entries can be stored in nexthop table.
 
 config NET_ROUTE_MCAST
 	bool
@@ -91,29 +91,29 @@ config	NET_MAX_MCAST_ROUTES
 	default 1
 	depends on NET_ROUTE_MCAST
 	help
-	This determines how many entries can be stored in multicast
-	routing table.
+	  This determines how many entries can be stored in multicast
+	  routing table.
 
 config NET_TCP
 	bool "Enable TCP"
 	default n
 	help
-	The value depends on your network needs.
+	  The value depends on your network needs.
 
 config NET_TCP_CHECKSUM
 	bool "Check TCP checksum"
 	default y
 	depends on NET_TCP
 	help
-	Enables TCP handler to check TCP checksum. If the checksum is invalid,
-	then the packet is discarded.
+	  Enables TCP handler to check TCP checksum. If the checksum is invalid,
+	  then the packet is discarded.
 
 config NET_DEBUG_TCP
 	bool "Debug TCP"
 	default n
 	depends on NET_TCP && NET_LOG
 	help
-	Enables TCP handler output debug messages
+	  Enables TCP handler output debug messages
 
 config NET_TCP_BACKLOG_SIZE
 	int "Number of simultaneous incoming TCP connections"
@@ -121,28 +121,28 @@ config NET_TCP_BACKLOG_SIZE
 	default 1
 	range 1 128
 	help
-	The number of simultaneous TCP connection attempts, i.e. outstanding
-	TCP connections waiting for initial ACK.
+	  The number of simultaneous TCP connection attempts, i.e. outstanding
+	  TCP connections waiting for initial ACK.
 
 config NET_TCP_TIME_WAIT
 	bool "Enable TCP TIME_WAIT timeouts"
 	depends on NET_TCP
 	default n
 	help
-	Officially, the TCP standard requires a 4 minute timeout on
-	connection close before that particular port pair can be used
-	again.  This requires that the net_context and net_tcp structs
-	persist for the full duration, so has non-trivial memory costs
-	and is optional.  Modern systems with well-randomized sequence
-	numbers don't need this, but it is present for specification
-	compliance where needed.
+	  Officially, the TCP standard requires a 4 minute timeout on
+	  connection close before that particular port pair can be used
+	  again.  This requires that the net_context and net_tcp structs
+	  persist for the full duration, so has non-trivial memory costs
+	  and is optional.  Modern systems with well-randomized sequence
+	  numbers don't need this, but it is present for specification
+	  compliance where needed.
 
 config NET_TCP_2MSL_TIME
 	int "How long to wait in TIME_WAIT (in seconds)"
 	depends on NET_TCP_TIME_WAIT
 	default 240
 	help
-	The value is in seconds.
+	  The value is in seconds.
 
 config NET_TCP_ACK_TIMEOUT
 	int "How long to wait for ACK (in milliseconds)"
@@ -150,9 +150,9 @@ config NET_TCP_ACK_TIMEOUT
 	default 1000
 	range 1 2147483647
 	help
-	This value affects the timeout when waiting ACK to arrive in
-	various TCP states. The value is in milliseconds. Note that
-	having a very low value here could prevent connectivity.
+	  This value affects the timeout when waiting ACK to arrive in
+	  various TCP states. The value is in milliseconds. Note that
+	  having a very low value here could prevent connectivity.
 
 config NET_TCP_INIT_RETRANSMISSION_TIMEOUT
 	int "Initial value of Retransmission Timeout (RTO) (in milliseconds)"
@@ -160,48 +160,48 @@ config NET_TCP_INIT_RETRANSMISSION_TIMEOUT
 	default 200
 	range 100 60000
 	help
-	This value affects the timeout between initial retransmission
-	of TCP data packets. The value is in milliseconds.
+	  This value affects the timeout between initial retransmission
+	  of TCP data packets. The value is in milliseconds.
 
 config NET_TCP_RETRY_COUNT
 	int "Maximum number of TCP segment retransmissions"
 	depends on NET_TCP
 	default 9
 	help
-	The following formula can be used to determine the time (in ms)
-	that a segment will be be buffered awaiting retransmission:
-	n=NET_TCP_RETRY_COUNT
-	Sum((1<<n) * NET_TCP_INIT_RETRANSMISSION_TIMEOUT)
-	n=0
-	With the default value of 9, the IP stack will try to
-	retransmit for up to 1:42 minutes.  This is as close as possible
-	to the minimum value recommended by RFC1122 (1:40 minutes).
-	Only 5 bits are dedicated for the retransmission count, so accepted
-	values are in the 0-31 range.  It's highly recommended to not go
-	below 9, though.
-	Should a retransmission timeout occur, the receive callback is
-	called with -ECONNRESET error code and the context is dereferenced.
+	  The following formula can be used to determine the time (in ms)
+	  that a segment will be be buffered awaiting retransmission:
+	  n=NET_TCP_RETRY_COUNT
+	  Sum((1<<n) * NET_TCP_INIT_RETRANSMISSION_TIMEOUT)
+	  n=0
+	  With the default value of 9, the IP stack will try to
+	  retransmit for up to 1:42 minutes.  This is as close as possible
+	  to the minimum value recommended by RFC1122 (1:40 minutes).
+	  Only 5 bits are dedicated for the retransmission count, so accepted
+	  values are in the 0-31 range.  It's highly recommended to not go
+	  below 9, though.
+	  Should a retransmission timeout occur, the receive callback is
+	  called with -ECONNRESET error code and the context is dereferenced.
 
 config NET_UDP
 	bool "Enable UDP"
 	default y
 	help
-	The value depends on your network needs.
+	  The value depends on your network needs.
 
 config NET_UDP_CHECKSUM
 	bool "Check UDP checksum"
 	default y
 	depends on NET_UDP
 	help
-	Enables UDP handler to check UDP checksum. If the checksum is invalid,
-	then the packet is discarded.
+	  Enables UDP handler to check UDP checksum. If the checksum is invalid,
+	  then the packet is discarded.
 
 config NET_DEBUG_UDP
 	bool "Debug UDP"
 	default n
 	depends on NET_UDP && NET_LOG
 	help
-	Enables UDP handler output debug messages
+	  Enables UDP handler output debug messages
 
 config NET_MAX_CONN
 	int "How many network connections are supported"
@@ -209,50 +209,50 @@ config NET_MAX_CONN
 	default 4
 	default 8 if NET_IPV6 && NET_IPV4
 	help
-	The value depends on your network needs. The value
-	should include both UDP and TCP connections.
+	  The value depends on your network needs. The value
+	  should include both UDP and TCP connections.
 
 config NET_CONN_CACHE
 	bool "Cache network connections"
 	depends on NET_UDP || NET_TCP
 	default n
 	help
-	Caching takes slight more memory but will speedup connection
-	handling of UDP and TCP connections.
+	  Caching takes slight more memory but will speedup connection
+	  handling of UDP and TCP connections.
 
 config NET_MAX_CONTEXTS
 	int "Number of network contexts to allocate"
 	default 6
 	help
-	Each network context is used to describe a network 5-tuple that
-	is used when listening or sending network traffic. This is very
-	similar as one could call a network socket in some other systems.
+	  Each network context is used to describe a network 5-tuple that
+	  is used when listening or sending network traffic. This is very
+	  similar as one could call a network socket in some other systems.
 
 config NET_CONTEXT_NET_PKT_POOL
 	bool "Enable net_buf TX pool / context"
 	default n
 	default y if NET_TCP && NET_6LO
 	help
-	If enabled, then it is possible to fine-tune network packet pool
-	for each context when sending network data. If this setting is
-	enabled, then you should define the context pools in your application
-	using NET_PKT_TX_POOL_DEFINE() and NET_PKT_DATA_POOL_DEFINE()
-	macros and tie these pools to desired context using the
-	net_context_setup_pools() function.
+	  If enabled, then it is possible to fine-tune network packet pool
+	  for each context when sending network data. If this setting is
+	  enabled, then you should define the context pools in your application
+	  using NET_PKT_TX_POOL_DEFINE() and NET_PKT_DATA_POOL_DEFINE()
+	  macros and tie these pools to desired context using the
+	  net_context_setup_pools() function.
 
 config NET_CONTEXT_SYNC_RECV
 	bool "Support synchronous functionality in net_context_recv() API"
 	default y
 	help
-	You can disable sync support to save some memory if you are calling
-	net_context_recv() in async way only when timeout is set to 0.
+	  You can disable sync support to save some memory if you are calling
+	  net_context_recv() in async way only when timeout is set to 0.
 
 config NET_CONTEXT_CHECK
 	bool "Check options when calling various net_context functions"
 	default y
 	help
-	If you know that the options passed to net_context...() functions
-	are ok, then you can disable the checks to save some memory.
+	  If you know that the options passed to net_context...() functions
+	  are ok, then you can disable the checks to save some memory.
 
 config NET_TEST
 	bool "Network Testing"
@@ -279,15 +279,15 @@ config NET_TRICKLE
 	bool "Enable Trickle library"
 	default n
 	help
-	Normally this is enabled automatically if needed,
-	so say 'n' if unsure.
+	  Normally this is enabled automatically if needed,
+	  so say 'n' if unsure.
 
 config NET_DEBUG_TRICKLE
 	bool "Debug Trickle algorithm"
 	default n
 	depends on NET_TRICKLE && NET_LOG
 	help
-	Enables Trickle library output debug messages
+	  Enables Trickle library output debug messages
 
 endif # NET_RAW_MODE
 
@@ -295,51 +295,51 @@ config NET_PKT_RX_COUNT
 	int "How many packet receives can be pending at the same time"
 	default 4
 	help
-	Each RX buffer will occupy smallish amount of memory.
-	See include/net/net_pkt.h and the sizeof(struct net_pkt)
+	  Each RX buffer will occupy smallish amount of memory.
+	  See include/net/net_pkt.h and the sizeof(struct net_pkt)
 
 config NET_PKT_TX_COUNT
 	int "How many packet sends can be pending at the same time"
 	default 2
 	help
-	Each TX buffer will occupy smallish amount of memory.
-	See include/net/net_pkt.h and the sizeof(struct net_pkt)
+	  Each TX buffer will occupy smallish amount of memory.
+	  See include/net/net_pkt.h and the sizeof(struct net_pkt)
 
 config NET_BUF_RX_COUNT
 	int "How many network buffers are allocated for receiving data"
 	default 16
 	help
-	Each data buffer will occupy CONFIG_NET_BUF_DATA_SIZE + smallish
-	header (sizeof(struct net_buf)) amount of data.
+	  Each data buffer will occupy CONFIG_NET_BUF_DATA_SIZE + smallish
+	  header (sizeof(struct net_buf)) amount of data.
 
 config NET_BUF_TX_COUNT
 	int "How many network buffers are allocated for sending data"
 	default 16
 	help
-	Each data buffer will occupy CONFIG_NET_BUF_DATA_SIZE + smallish
-	header (sizeof(struct net_buf)) amount of data.
+	  Each data buffer will occupy CONFIG_NET_BUF_DATA_SIZE + smallish
+	  header (sizeof(struct net_buf)) amount of data.
 
 config NET_BUF_DATA_SIZE
 	int "Size of each network data fragment"
 	default 128
 	default 125 if NET_L2_IEEE802154
 	help
-	This value tells what is the size of the data fragment that is
-	received from the network.
-	Example: For IEEE 802.15.4, the network packet is 127 bytes long,
-	which leaves in worst case 81 bytes for user data (MTU).
-	In order to be able to receive at least full IPv6 packet which
-	has a size of 1280 bytes, the one should allocate 16 fragments here.
+	  This value tells what is the size of the data fragment that is
+	  received from the network.
+	  Example: For IEEE 802.15.4, the network packet is 127 bytes long,
+	  which leaves in worst case 81 bytes for user data (MTU).
+	  In order to be able to receive at least full IPv6 packet which
+	  has a size of 1280 bytes, the one should allocate 16 fragments here.
 
 config NET_BUF_USER_DATA_SIZE
 	int "Size of user_data reserved"
 	default 0
 	default 4 if NET_L2_BT
 	help
-	This is for drivers to set how much user_data shall be included in
-	each network data fragment.
-	Example: For Bluetooth, the user_data shall be at least 4 bytes as
-	that is used for identifying the type of data they are carrying.
+	  This is for drivers to set how much user_data shall be included in
+	  each network data fragment.
+	  Example: For Bluetooth, the user_data shall be at least 4 bytes as
+	  that is used for identifying the type of data they are carrying.
 
 source "subsys/net/ip/Kconfig.stack"
 

--- a/subsys/net/ip/l2/Kconfig
+++ b/subsys/net/ip/l2/Kconfig
@@ -11,16 +11,16 @@ config NET_L2_DUMMY
 	default n
 	default y if !NET_L2_ETHERNET && NET_TEST
 	help
-	Add a dummy L2 layer driver. This is usually only needed when
-	simulating a network interface when running network stack inside QEMU.
+	  Add a dummy L2 layer driver. This is usually only needed when
+	  simulating a network interface when running network stack inside QEMU.
 
 config NET_L2_ETHERNET
 	bool "Enable Ethernet support"
 	default n
 	help
-	Add support for Ethernet, enabling selecting relevant hardware drivers.
-	If NET_SLIP_TAP is selected, NET_L2_ETHERNET will enable to fully
-	simulate Ethernet through SLIP.
+	  Add support for Ethernet, enabling selecting relevant hardware drivers.
+	  If NET_SLIP_TAP is selected, NET_L2_ETHERNET will enable to fully
+	  simulate Ethernet through SLIP.
 
 config NET_DEBUG_L2_ETHERNET
 	bool "Debug Ethernet L2 layer"
@@ -28,13 +28,13 @@ config NET_DEBUG_L2_ETHERNET
 	default y if NET_LOG_GLOBAL
 	depends on NET_LOG
 	help
-	Enables Ethernet L2 output debug messages
+	  Enables Ethernet L2 output debug messages
 
 config NET_OFFLOAD
 	bool "Offload IP stack [EXPERIMENTAL]"
 	default n
 	help
-	Enables TCP/IP stack to be offload to a co-processor.
+	  Enables TCP/IP stack to be offload to a co-processor.
 
 config NET_DEBUG_NET_OFFLOAD
 	bool "Debug Net Offload Layer"
@@ -43,7 +43,7 @@ config NET_DEBUG_NET_OFFLOAD
 	depends on NET_LOG
 	depends on NET_OFFLOAD
 	help
-	Enables offload TCP/IP stack output debug messages.
+	  Enables offload TCP/IP stack output debug messages.
 
 config NET_L2_BT
 	bool "Enable Bluetooth support"
@@ -64,11 +64,11 @@ config NET_L2_BT_ZEP1656
 	depends on NET_L2_BT
 	default n
 	help
-	This workaround is necessary to interoperate with Linux up to 4.10 but
-	it might not be compliant with RFC 7668 as it cause the stack to skip
-	Neighbor Discovery cache causing the destination link address to be
-	omitted. For more details why this is needed see:
-	https://jira.zephyrproject.org/browse/ZEP-1656
+	  This workaround is necessary to interoperate with Linux up to 4.10 but
+	  it might not be compliant with RFC 7668 as it cause the stack to skip
+	  Neighbor Discovery cache causing the destination link address to be
+	  omitted. For more details why this is needed see:
+	  https://jira.zephyrproject.org/browse/ZEP-1656
 
 config NET_L2_BT_SEC_LEVEL
 	int "Security level of Bluetooth Link"
@@ -76,11 +76,11 @@ config NET_L2_BT_SEC_LEVEL
 	default 1
 	range 1 4
 	help
-	Security level of Bluetooth Link:
-	Level 1 (BT_SECURITY_LOW) = No encryption or authentication required
-	Level 2 (BT_SECURITY_MEDIUM) = Only encryption required
-	Level 3 (BT_SECURITY_HIGH) = Encryption and authentication required
-	Level 4 (BT_SECURITY_FIPS) = Secure connection required
+	  Security level of Bluetooth Link:
+	  Level 1 (BT_SECURITY_LOW) = No encryption or authentication required
+	  Level 2 (BT_SECURITY_MEDIUM) = Only encryption required
+	  Level 3 (BT_SECURITY_HIGH) = Encryption and authentication required
+	  Level 4 (BT_SECURITY_FIPS) = Secure connection required
 
 config NET_DEBUG_L2_BT
 	bool "Debug Bluetooth L2 layer"
@@ -89,7 +89,7 @@ config NET_DEBUG_L2_BT
 	depends on NET_LOG
 	depends on NET_L2_BT
 	help
-	Enables Bluetooth L2 output debug messages
+	  Enables Bluetooth L2 output debug messages
 
 config NET_L2_BT_MGMT
 	bool "Enable Bluetooth Network Management support"
@@ -104,8 +104,8 @@ config NET_L2_BT_SHELL
 	select CONSOLE_SHELL
 	select NET_L2_BT_MGMT
 	help
-	This can be used for testing Bluetooth management commands through the
-	console via a shell module named "net_bt".
+	  This can be used for testing Bluetooth management commands through the
+	  console via a shell module named "net_bt".
 
 source "subsys/net/ip/l2/ieee802154/Kconfig"
 
@@ -114,15 +114,15 @@ config NET_ARP
 	default y
 	depends on NET_IPV4 && NET_L2_ETHERNET
 	help
-	Enable ARP support. This is necessary on hardware that requires it to
-	get IPv4 working (like Ethernet devices).
+	  Enable ARP support. This is necessary on hardware that requires it to
+	  get IPv4 working (like Ethernet devices).
 
 config NET_ARP_TABLE_SIZE
 	int "Number of entries in ARP table."
 	depends on NET_ARP
 	default 2
 	help
-	Each entry in the ARP table consumes 22 bytes of memory.
+	  Each entry in the ARP table consumes 22 bytes of memory.
 
 config NET_DEBUG_ARP
 	bool "Debug IPv4 ARP"
@@ -130,6 +130,6 @@ config NET_DEBUG_ARP
 	default n
 	default y if NET_LOG_GLOBAL
 	help
-	Enables core ARP code part to output debug messages
+	  Enables core ARP code part to output debug messages
 
 endmenu

--- a/subsys/net/ip/l2/ieee802154/Kconfig
+++ b/subsys/net/ip/l2/ieee802154/Kconfig
@@ -91,8 +91,8 @@ config NET_L2_IEEE802154_SHELL
 	select CONSOLE_SHELL
 	depends on NET_L2_IEEE802154_RFD
 	help
-	This can be used for testing 15.4 through the console via exposing
-	a shell module named "ieee15_4".
+	  This can be used for testing 15.4 through the console via exposing
+	  a shell module named "ieee15_4".
 
 config NET_L2_IEEE802154_FRAGMENT
 	bool "Enable 802.15.4 fragmentation support"
@@ -130,17 +130,17 @@ config NET_L2_IEEE802154_SECURITY
 	bool "Enable IEEE 802.15.4 security [EXPERIMENTAL]"
 	default n
 	help
-	Enable 802.15.4 frame security handling, in order to bring data
-	confidentiality and authenticity.
+	  Enable 802.15.4 frame security handling, in order to bring data
+	  confidentiality and authenticity.
 
 config NET_L2_IEEE802154_SECURITY_CRYPTO_DEV_NAME
 	string "Crypto device name used for <en/de>cryption"
 	default ""
 	depends on NET_L2_IEEE802154_SECURITY
 	help
-	This option should be used to set the crypto device name that
-	IEEE 802.15.4 soft MAC will use to run authentication, encryption and
-	decryption operations on incoming/outgoing frames.
+	  This option should be used to set the crypto device name that
+	  IEEE 802.15.4 soft MAC will use to run authentication, encryption and
+	  decryption operations on incoming/outgoing frames.
 
 source "subsys/net/ip/l2/ieee802154/Kconfig.radio"
 

--- a/subsys/net/lib/app/Kconfig
+++ b/subsys/net/lib/app/Kconfig
@@ -12,8 +12,8 @@ menuconfig NET_APP
 	select NET_MGMT
 	select NET_MGMT_EVENT
 	help
-	Enable API that helps to create client/server network applications.
-	This API is experimental and subject to change.
+	  Enable API that helps to create client/server network applications.
+	  This API is experimental and subject to change.
 
 if NET_APP
 
@@ -21,9 +21,9 @@ config NET_APP_AUTO_INIT
 	bool "Init networking support automatically during device startup"
 	default y
 	help
-	If this option is set, then the net_app API is automatically
-	initialized when the device is started. If you do not wish to do
-	this, then disable this and call net_app_init() in your application.
+	  If this option is set, then the net_app API is automatically
+	  initialized when the device is started. If you do not wish to do
+	  this, then disable this and call net_app_init() in your application.
 
 config NET_APP_INIT_PRIO
 	int "Startup priority for the network application init"
@@ -35,64 +35,64 @@ config NET_APP_INIT_TIMEOUT
 	default 30
 	depends on NET_APP_AUTO_INIT
 	help
-	The value is in seconds. If for example IPv4 address from DHCPv4 is not
-	received within this limit, then the net_app_init() call will fail
-	during the device startup.
+	  The value is in seconds. If for example IPv4 address from DHCPv4 is not
+	  received within this limit, then the net_app_init() call will fail
+	  during the device startup.
 
 config NET_APP_NEED_IPV6
 	bool "This application wants IPv6 support"
 	depends on NET_APP_AUTO_INIT
 	select NET_IPV6
 	help
-	The network application needs IPv6 support to function properly.
-	This option makes sure the network application is initialized properly
-	in order to use IPv6.
+	  The network application needs IPv6 support to function properly.
+	  This option makes sure the network application is initialized properly
+	  in order to use IPv6.
 
 config NET_APP_NEED_IPV6_ROUTER
 	bool "This application wants IPv6 router to exists"
 	depends on NET_APP_AUTO_INIT
 	depends on NET_IPV6
 	help
-	The network application needs IPv6 router to exists before continuing.
-	What this means that the application wants to wait until it receives
-	IPv6 router advertisement message before continuing.
+	  The network application needs IPv6 router to exists before continuing.
+	  What this means that the application wants to wait until it receives
+	  IPv6 router advertisement message before continuing.
 
 config NET_APP_NEED_IPV4
 	bool "This application wants IPv4 support"
 	depends on NET_APP_AUTO_INIT
 	select NET_IPV4
 	help
-	The network application needs IPv4 support to function properly.
-	This option makes sure the network application is initialized properly
-	in order to use IPv4.
+	  The network application needs IPv4 support to function properly.
+	  This option makes sure the network application is initialized properly
+	  in order to use IPv4.
 
 config NET_DEBUG_APP
 	bool "Debug net app library"
 	default n
 	default y if NET_LOG_GLOBAL
 	help
-	Enables net app library to output debug messages
+	  Enables net app library to output debug messages
 
 config NET_APP_SERVER
 	bool "Enable server support"
 	default n
 	help
-	Enables net app library server APIs.
+	  Enables net app library server APIs.
 
 config NET_APP_SERVER_NUM_CONN
 	int "Number of simultaneous incoming connections"
 	default 1
 	depends on NET_APP_SERVER
 	help
-	Tells how many simultaneous incoming connections the server instance can
-	support. The value of CONFIG_NET_TCP_BACKLOG_SIZE must be greater than
-	or equal to CONFIG_NET_APP_SERVER_NUM_CONN.
+	  Tells how many simultaneous incoming connections the server instance can
+	  support. The value of CONFIG_NET_TCP_BACKLOG_SIZE must be greater than
+	  or equal to CONFIG_NET_APP_SERVER_NUM_CONN.
 
 config NET_APP_CLIENT
 	bool "Enable client support"
 	default n
 	help
-	Enables net app library client APIs.
+	  Enables net app library client APIs.
 
 config NET_APP_TLS
 	bool "Enable TLS support for TCP applications"
@@ -100,7 +100,7 @@ config NET_APP_TLS
 	depends on NET_TCP
 	select MBEDTLS
 	help
-	Enables net app library to use TLS for encrypted communication.
+	  Enables net app library to use TLS for encrypted communication.
 
 config NET_APP_DTLS
 	bool "Enable DTLS support for UDP applications"
@@ -108,15 +108,15 @@ config NET_APP_DTLS
 	select MBEDTLS
 	default n
 	help
-	Enables net app library to use DTLS for encrypted UDP communication.
+	  Enables net app library to use DTLS for encrypted UDP communication.
 
 config NET_APP_DTLS_TIMEOUT
 	int "DTLS session timeout"
 	depends on NET_APP_DTLS
 	default 15
 	help
-	If a DTLS session does not have any activity, then disconnect
-	the session. The value is in seconds.
+	  If a DTLS session does not have any activity, then disconnect
+	  the session. The value is in seconds.
 
 config NET_DEBUG_APP_TLS_LEVEL
 	int "Debug level for mbedtls in net app library"
@@ -124,21 +124,21 @@ config NET_DEBUG_APP_TLS_LEVEL
 	default 0
 	range 0 4
 	help
-	Sets log level for the mbedtls when debugging net_app library.
-	Levels are (from ext/lib/crypto/mbedtls/include/mbedtls/debug.h):
-	0 No debug
-	1 Error
-	2 State change
-	3 Information
-	4 Verbose
+	  Sets log level for the mbedtls when debugging net_app library.
+	  Levels are (from ext/lib/crypto/mbedtls/include/mbedtls/debug.h):
+	  0 No debug
+	  1 Error
+	  2 State change
+	  3 Information
+	  4 Verbose
 
 config NET_APP_TLS_STACK_SIZE
 	int "TLS handler thread stack size"
 	default 8192
 	depends on NET_APP_TLS || NET_APP_DTLS
 	help
-	TLS handler thread stack size. The mbedtls routines will use this stack
-	thus it is by default very large.
+	  TLS handler thread stack size. The mbedtls routines will use this stack
+	  thus it is by default very large.
 
 endif # NET_APP
 
@@ -147,11 +147,11 @@ menuconfig NET_APP_SETTINGS
 	default n
 	depends on NET_APP
 	help
-	Allow IP addresses to be set in config file for
-	networking client/server sample applications, or
-	some link-layer dedicated settings like the channel.
-	Beware this is not meant to be used for proper
-	provisioning but quick sampling/testing.
+	  Allow IP addresses to be set in config file for
+	  networking client/server sample applications, or
+	  some link-layer dedicated settings like the channel.
+	  Beware this is not meant to be used for proper
+	  provisioning but quick sampling/testing.
 
 if NET_APP_SETTINGS
 
@@ -267,8 +267,8 @@ config NET_APP_BT_NODE
 	default n
 	select NET_L2_BT_MGMT
 	help
-	Enables application to operate in node mode which requires GATT
-	service to be registered and start advertising as peripheral.
+	  Enables application to operate in node mode which requires GATT
+	  service to be registered and start advertising as peripheral.
 
 endif # NET_L2_BT
 

--- a/subsys/net/lib/coap/Kconfig
+++ b/subsys/net/lib/coap/Kconfig
@@ -11,7 +11,7 @@ config COAP
 	prompt "CoAP Support"
 	default n
 	help
-	This option enables the CoAP implementation.
+	  This option enables the CoAP implementation.
 
 # This setting is only used by unit test. Do not enable it in applications
 config COAP_TEST_API_ENABLE
@@ -19,7 +19,7 @@ config COAP_TEST_API_ENABLE
 	default n
 	depends on COAP
 	help
-	Do not enable this for normal use.
+	  Do not enable this for normal use.
 
 config COAP_WELL_KNOWN_BLOCK_WISE
 	bool
@@ -27,11 +27,11 @@ config COAP_WELL_KNOWN_BLOCK_WISE
 	default n
 	depends on COAP
 	help
-	This option enables the block wise support of CoAP response
-	to ./well-known/core request. Without this option all resource's
-	information will be sent in a single IP packet (can be multiple
-	fragments depends on MTU size). This will be useful in mesh kind
-	of networks.
+	  This option enables the block wise support of CoAP response
+	  to ./well-known/core request. Without this option all resource's
+	  information will be sent in a single IP packet (can be multiple
+	  fragments depends on MTU size). This will be useful in mesh kind
+	  of networks.
 
 config COAP_WELL_KNOWN_BLOCK_WISE_SIZE
 	int
@@ -39,32 +39,32 @@ config COAP_WELL_KNOWN_BLOCK_WISE_SIZE
 	default 32
 	depends on COAP_WELL_KNOWN_BLOCK_WISE
 	help
-	Maximum size of CoAP block. Valid values are 16, 32, 64, 128,
-	256, 512 and 1024.
+	  Maximum size of CoAP block. Valid values are 16, 32, 64, 128,
+	  256, 512 and 1024.
 
 config COAP_EXTENDED_OPTIONS_LEN
 	bool "Support for CoAP extended options"
 	default n
 	depends on COAP
 	help
-	This option enables the parsing of extended CoAP options length.
-	CoAP extended options length can be 2 byte value, which
-	requires more memory. User can save memory by disabling this.
-	That means only length of maximum 12 bytes are supported by default.
-	Enable this if length field going to bigger that 12.
+	  This option enables the parsing of extended CoAP options length.
+	  CoAP extended options length can be 2 byte value, which
+	  requires more memory. User can save memory by disabling this.
+	  That means only length of maximum 12 bytes are supported by default.
+	  Enable this if length field going to bigger that 12.
 
 config COAP_EXTENDED_OPTIONS_LEN_VALUE
 	int "CoAP extended options length value"
 	default 13
 	depends on COAP_EXTENDED_OPTIONS_LEN
 	help
-	This option specifies the maximum value of length field when
-	COAP_EXTENDED_OPTIONS_LEN is enabled. Define the value according to
-	user requirement.
+	  This option specifies the maximum value of length field when
+	  COAP_EXTENDED_OPTIONS_LEN is enabled. Define the value according to
+	  user requirement.
 
 config NET_DEBUG_COAP
 	bool "Debug COAP"
 	default n
 	depends on COAP && NET_LOG
 	help
-	Enables CoaP output debug messages
+	  Enables CoaP output debug messages

--- a/subsys/net/lib/dns/Kconfig
+++ b/subsys/net/lib/dns/Kconfig
@@ -9,7 +9,7 @@ config DNS_RESOLVER
 	prompt "DNS resolver"
 	default n
 	help
-	This option enables the DNS client side support for Zephyr
+	  This option enables the DNS client side support for Zephyr
 
 if DNS_RESOLVER
 
@@ -17,18 +17,18 @@ config MDNS_RESOLVER
 	bool "Enable mDNS support"
 	default n
 	help
-	This option enables multicast DNS client side support.
-	See RFC 6762 for details.
+	  This option enables multicast DNS client side support.
+	  See RFC 6762 for details.
 
 config DNS_RESOLVER_ADDITIONAL_BUF_CTR
 	int
 	prompt "Additional DNS buffers"
 	default 0
 	help
-	Number of additional buffers available for the DNS resolver.
-	The DNS resolver requires at least one buffer. This option
-	enables additional buffers required for multiple concurrent
-	DNS connections.
+	  Number of additional buffers available for the DNS resolver.
+	  The DNS resolver requires at least one buffer. This option
+	  enables additional buffers required for multiple concurrent
+	  DNS connections.
 
 config DNS_RESOLVER_ADDITIONAL_QUERIES
 	int
@@ -36,26 +36,26 @@ config DNS_RESOLVER_ADDITIONAL_QUERIES
 	range 0 2
 	default 1
 	help
-	Number of additional DNS queries that the DNS resolver may
-	generate when the RR ANSWER only contains CNAME(s).
-	The maximum value of this variable is constrained to avoid
-	'alias loops'.
+	  Number of additional DNS queries that the DNS resolver may
+	  generate when the RR ANSWER only contains CNAME(s).
+	  The maximum value of this variable is constrained to avoid
+	  'alias loops'.
 
 config DNS_RESOLVER_MAX_SERVERS
 	int "Number of DNS server addresses"
 	range 1 NET_MAX_CONTEXTS
 	default 1
 	help
-	Max number of DNS servers that we can connect to. Normally one
-	DNS server is enough. Each connection to DNS server will use one
-	network context.
+	  Max number of DNS servers that we can connect to. Normally one
+	  DNS server is enough. Each connection to DNS server will use one
+	  network context.
 
 menuconfig DNS_SERVER_IP_ADDRESSES
 	bool "Set DNS server IP addresses"
 	default n
 	help
-	Allow DNS IP addresses to be set in config file for
-	networking applications.
+	  Allow DNS IP addresses to be set in config file for
+	  networking applications.
 
 if DNS_SERVER_IP_ADDRESSES
 
@@ -63,42 +63,42 @@ config DNS_SERVER1
 	string "DNS server 1"
 	default ""
 	help
-	DNS server IP address 1. The address can be either IPv4 or IPv6
-	address. An optional port number can be given.
-	Following syntax is supported:
-	192.0.2.1
-	192.0.2.1:5353
-	2001:db8::1
-	[2001:db8::1]:5353
-	It is not mandatory to use this Kconfig option at all.
-	The one calling dns_resolve_init() can use this option or not
-	to populate the server list. If the DNS server addresses are
-	set here, then we automatically create default DNS context
-	for the user.
+	  DNS server IP address 1. The address can be either IPv4 or IPv6
+	  address. An optional port number can be given.
+	  Following syntax is supported:
+	  192.0.2.1
+	  192.0.2.1:5353
+	  2001:db8::1
+	  [2001:db8::1]:5353
+	  It is not mandatory to use this Kconfig option at all.
+	  The one calling dns_resolve_init() can use this option or not
+	  to populate the server list. If the DNS server addresses are
+	  set here, then we automatically create default DNS context
+	  for the user.
 
 config DNS_SERVER2
 	string "DNS server 2"
 	default ""
 	help
-	See help in "DNS server 1" option.
+	  See help in "DNS server 1" option.
 
 config DNS_SERVER3
 	string "DNS server 3"
 	default ""
 	help
-	See help in "DNS server 1" option.
+	  See help in "DNS server 1" option.
 
 config DNS_SERVER4
 	string "DNS server 4"
 	default ""
 	help
-	See help in "DNS server 1" option.
+	  See help in "DNS server 1" option.
 
 config DNS_SERVER5
 	string "DNS server 5"
 	default ""
 	help
-	See help in "DNS server 1" option.
+	  See help in "DNS server 1" option.
 
 endif # DNS_SERVER_IP_ADDRESSES
 
@@ -106,15 +106,15 @@ config DNS_NUM_CONCUR_QUERIES
 	int "Number of simultaneous DNS queries per one DNS context"
 	default 1
 	help
-	This defines how many concurrent DNS queries can be generated using
-	same DNS context. Normally 1 is a good default value.
+	  This defines how many concurrent DNS queries can be generated using
+	  same DNS context. Normally 1 is a good default value.
 
 config NET_DEBUG_DNS_RESOLVE
 	bool "Debug DNS resolver"
 	default n
 	default y if NET_LOG_GLOBAL
 	help
-	Enables DNS resolver code to output debug messages
+	  Enables DNS resolver code to output debug messages
 
 endif # DNS_RESOLVER
 
@@ -124,12 +124,12 @@ config MDNS_RESPONDER
 	select NET_IPV6_MLD if NET_IPV6
 	depends on NET_HOSTNAME_ENABLE
 	help
-	This option enables the mDNS responder support for Zephyr.
-	It will listen well-known address ff02::fb and 224.0.0.251.
-	Currently this only returns IP address information.
-	You must set CONFIG_NET_HOSTNAME to some meaningful value and
-	then mDNS will start to respond to <hostname>.local mDNS queries.
-	See RFC 6762 for more details about mDNS.
+	  This option enables the mDNS responder support for Zephyr.
+	  It will listen well-known address ff02::fb and 224.0.0.251.
+	  Currently this only returns IP address information.
+	  You must set CONFIG_NET_HOSTNAME to some meaningful value and
+	  then mDNS will start to respond to <hostname>.local mDNS queries.
+	  See RFC 6762 for more details about mDNS.
 
 if MDNS_RESPONDER
 
@@ -137,27 +137,27 @@ config MDNS_RESPONDER_TTL
 	int "Time-to-Live of returned DNS name"
 	default 600
 	help
-	DNS answers will use the TTL (in seconds).
+	  DNS answers will use the TTL (in seconds).
 
 config MDNS_RESPONDER_INIT_PRIO
 	int "Startup priority for the mDNS responder init"
 	default 96
 	help
-	Note that if NET_APP_AUTO_INIT is enabled, then this value
-	should be bigger than its value.
+	  Note that if NET_APP_AUTO_INIT is enabled, then this value
+	  should be bigger than its value.
 
 config NET_DEBUG_MDNS_RESPONDER
 	bool "Debug mDNS responder"
 	default n
 	default y if NET_LOG_GLOBAL
 	help
-	Enables mDNS responder code to output debug messages
+	  Enables mDNS responder code to output debug messages
 
 config MDNS_RESOLVER_ADDITIONAL_BUF_CTR
 	int
 	prompt "Additional DNS buffers"
 	default 0
 	help
-	Number of additional buffers available for the mDNS responder.
+	  Number of additional buffers available for the mDNS responder.
 
 endif # MDNS_RESPONDER

--- a/subsys/net/lib/http/Kconfig
+++ b/subsys/net/lib/http/Kconfig
@@ -7,7 +7,7 @@ config HTTP
 	bool "HTTP support"
 	default n
 	help
-	This option enables the HTTP library
+	  This option enables the HTTP library
 
 if HTTP
 
@@ -24,7 +24,7 @@ config HTTP_SERVER
 	select HTTP_PARSER_URL
 	select NET_APP_SERVER
 	help
-	Enables HTTP server routines.
+	  Enables HTTP server routines.
 
 config HTTP_CLIENT
 	bool "HTTP client support"
@@ -33,32 +33,32 @@ config HTTP_CLIENT
 	select HTTP_PARSER_URL
 	select NET_APP_CLIENT
 	help
-	Enables HTTP client routines.
+	  Enables HTTP client routines.
 
 config HTTP_HEADERS
 	int "HTTP header field max number of items"
 	depends on HTTP_SERVER
 	default 8
 	help
-	Number of HTTP header field items that an HTTP server
-	application will handle
+	  Number of HTTP header field items that an HTTP server
+	  application will handle
 
 config HTTPS
 	bool "HTTPS support"
 	default n
 	select NET_APP_TLS
 	help
-	Enables HTTPS support.
+	  Enables HTTPS support.
 
 config HTTP_SERVER_CONNECTIONS
 	int "Max number of concurrent HTTP server connections"
 	default NET_APP_SERVER_NUM_CONN
 	depends on HTTP_SERVER
 	help
-	This value determines how many simultaneous HTTP connections the
-	HTTP server can serve. Note that only 1 HTTPS connection can be
-	served at a time, so set CONFIG_NET_APP_SERVER_NUM_CONN and
-	CONFIG_NET_TCP_BACKLOG_SIZE to 1 in that case.
+	  This value determines how many simultaneous HTTP connections the
+	  HTTP server can serve. Note that only 1 HTTPS connection can be
+	  served at a time, so set CONFIG_NET_APP_SERVER_NUM_CONN and
+	  CONFIG_NET_TCP_BACKLOG_SIZE to 1 in that case.
 
 endif # HTTP_APP
 
@@ -70,7 +70,7 @@ config HTTP_SERVER
 	select HTTP_PARSER
 	select HTTP_PARSER_URL
 	help
-	Enables HTTP server routines.
+	  Enables HTTP server routines.
 
 config HTTP_CLIENT
 	bool "HTTP client support"
@@ -78,39 +78,39 @@ config HTTP_CLIENT
 	select HTTP_PARSER
 	select HTTP_PARSER_URL
 	help
-	Enables HTTP client routines.
+	  Enables HTTP client routines.
 
 config HTTP_HEADER_FIELD_ITEMS
 	int "HTTP header field max number of items"
 	depends on HTTP_SERVER
 	default 8
 	help
-	Number of HTTP header field items that an HTTP server
-	application will handle
+	  Number of HTTP header field items that an HTTP server
+	  application will handle
 
 config HTTPS
 	bool "HTTPS support"
 	default n
 	select MBEDTLS
 	help
-	Enables HTTPS support.
+	  Enables HTTPS support.
 
 config HTTPS_STACK_SIZE
 	int "HTTPS thread stack size"
 	default 8192
 	depends on HTTPS
 	help
-	HTTPS thread stack size. The mbedtls routines will use this stack
-	thus it is by default very large.
+	  HTTPS thread stack size. The mbedtls routines will use this stack
+	  thus it is by default very large.
 
 config HTTP_SERVER_CONNECTIONS
 	int "Max number of concurrent HTTP server connections"
 	default NET_MAX_CONTEXTS
 	depends on HTTP_SERVER
 	help
-	This value determines how many simultaneous HTTP connections the
-	HTTP server can serve. Note that only 1 HTTPS connection can be
-	served at a time.
+	  This value determines how many simultaneous HTTP connections the
+	  HTTP server can serve. Note that only 1 HTTPS connection can be
+	  served at a time.
 
 endif # !HTTP_APP
 
@@ -119,29 +119,29 @@ config HTTP_SERVER_NUM_URLS
 	default 8
 	depends on HTTP_SERVER
 	help
-	This value determines how many URLs this HTTP server can handle.
+	  This value determines how many URLs this HTTP server can handle.
 
 config HTTP_CLIENT_NETWORK_TIMEOUT
 	int "Default network activity timeout in seconds"
 	default 20
 	depends on HTTP_CLIENT
 	help
-	Default network activity timeout in seconds.  This setting is used
-	for TCP connection timeout.
+	  Default network activity timeout in seconds.  This setting is used
+	  for TCP connection timeout.
 
 config  NET_DEBUG_HTTP
 	bool "Debug HTTP"
 	default n
 	depends on HTTP && NET_LOG
 	help
-	Enables HTTP output debug messages
+	  Enables HTTP output debug messages
 
 config  NET_DEBUG_HTTP_CONN
 	bool "Debug HTTP connections"
 	default n
 	depends on HTTP && NET_LOG
 	help
-	Enables HTTP connection tracking.
+	  Enables HTTP connection tracking.
 
 endif # HTTP
 
@@ -150,21 +150,21 @@ config HTTP_PARSER
 	default n
 	select HTTP_PARSER_URL
 	help
-	This option enables the http_parser library from nodejs.
-	This parser requires some string-related routines commonly
-	provided by a libc implementation.
+	  This option enables the http_parser library from nodejs.
+	  This parser requires some string-related routines commonly
+	  provided by a libc implementation.
 
 config HTTP_PARSER_URL
 	bool "HTTP Parser for URL support"
 	default n
 	help
-	This option enables the URI parser library based on source from nodejs.
-	This parser requires some string-related routines commonly
-	provided by a libc implementation.
+	  This option enables the URI parser library based on source from nodejs.
+	  This parser requires some string-related routines commonly
+	  provided by a libc implementation.
 
 config HTTP_PARSER_STRICT
 	bool "HTTP strict parsing"
 	default n
 	depends on (HTTP_PARSER || HTTP_PARSER_URL)
 	help
-	This option enables the strict parsing option
+	  This option enables the strict parsing option

--- a/subsys/net/lib/mqtt/Kconfig
+++ b/subsys/net/lib/mqtt/Kconfig
@@ -11,7 +11,7 @@ config  MQTT_LIB
 	default n
 	select NET_APP_CLIENT
 	help
-	Enable the Zephyr MQTT Library
+	  Enable the Zephyr MQTT Library
 
 config MQTT_MSG_MAX_SIZE
 	int
@@ -20,8 +20,8 @@ config MQTT_MSG_MAX_SIZE
 	default 128
 	range 128 1024
 	help
-	Set the maximum size of the MQTT message. So, no messages
-	longer than CONFIG_MQTT_MSG_SIZE will be processed.
+	  Set the maximum size of the MQTT message. So, no messages
+	  longer than CONFIG_MQTT_MSG_SIZE will be processed.
 
 config MQTT_ADDITIONAL_BUFFER_CTR
 	int
@@ -29,9 +29,9 @@ config MQTT_ADDITIONAL_BUFFER_CTR
 	depends on MQTT_LIB
 	default 0
 	help
-	Set some additional buffers. When two or more concurrent contexts are
-	used in the same application, additional buffers may help to have a 1:1
-	relation between application contexts and internal buffers.
+	  Set some additional buffers. When two or more concurrent contexts are
+	  used in the same application, additional buffers may help to have a 1:1
+	  relation between application contexts and internal buffers.
 
 config MQTT_SUBSCRIBE_MAX_TOPICS
 	int
@@ -40,8 +40,8 @@ config MQTT_SUBSCRIBE_MAX_TOPICS
 	default 1
 	range 1 8
 	help
-	Set the maximum number of topics handled by the SUBSCRIBE/SUBACK
-	messages during reception.
+	  Set the maximum number of topics handled by the SUBSCRIBE/SUBACK
+	  messages during reception.
 
 config MQTT_LIB_TLS
 	bool
@@ -50,4 +50,4 @@ config MQTT_LIB_TLS
 	default n
 	select NET_APP_TLS
 	help
-	Enables MQTT library with TLS support
+	  Enables MQTT library with TLS support

--- a/subsys/net/lib/sntp/Kconfig
+++ b/subsys/net/lib/sntp/Kconfig
@@ -9,7 +9,7 @@ menuconfig SNTP
 	default n
 	select NET_APP_CLIENT
 	help
-	Enable SNTP client library
+	  Enable SNTP client library
 
 if SNTP
 
@@ -17,6 +17,6 @@ config NET_DEBUG_SNTP
 	bool "Debug SNTP"
 	default n
 	help
-	Enable debug message of SNTP client library
+	  Enable debug message of SNTP client library
 
 endif # SNTP

--- a/subsys/net/lib/sockets/Kconfig
+++ b/subsys/net/lib/sockets/Kconfig
@@ -10,7 +10,7 @@ menuconfig NET_SOCKETS
 	bool "BSD Sockets compatible API"
 	default n
 	help
-	Provide BSD Sockets like API on top of native Zephyr networking API.
+	  Provide BSD Sockets like API on top of native Zephyr networking API.
 
 if NET_SOCKETS
 
@@ -18,26 +18,26 @@ config NET_SOCKETS_POSIX_NAMES
 	bool "Standard POSIX names for Sockets API"
 	default n
 	help
-	By default, Sockets API function are prefixed with ``zsock_`` to avoid
-	namespacing issues. If this option is enabled, they will be provided
-	with standard POSIX names like socket(), recv(), and close(), to help
-	with porting existing code. Note that close() may require a special
-	attention, as in POSIX it closes any file descriptor, while with this
-	option enabled, it will still apply only to sockets.
+	  By default, Sockets API function are prefixed with ``zsock_`` to avoid
+	  namespacing issues. If this option is enabled, they will be provided
+	  with standard POSIX names like socket(), recv(), and close(), to help
+	  with porting existing code. Note that close() may require a special
+	  attention, as in POSIX it closes any file descriptor, while with this
+	  option enabled, it will still apply only to sockets.
 
 config NET_SOCKETS_POLL_MAX
 	int
 	prompt "Max number of supported poll() entries"
 	default 3
 	help
-	Maximum number of entries supported for poll() call.
+	  Maximum number of entries supported for poll() call.
 
 config NET_DEBUG_SOCKETS
 	bool "Debug BSD Sockets compatible API calls"
 	default n
 	default y if NET_LOG_GLOBAL
 	help
-	Enables logging for sockets code. (Logging level is defined by
-	SYS_LOG_NET_LEVEL setting).
+	  Enables logging for sockets code. (Logging level is defined by
+	  SYS_LOG_NET_LEVEL setting).
 
 endif # NET_SOCKETS

--- a/subsys/net/lib/zoap/Kconfig
+++ b/subsys/net/lib/zoap/Kconfig
@@ -11,7 +11,7 @@ config ZOAP
 	prompt "CoAP Support"
 	default n
 	help
-	This option enables the Zoap implementation of CoAP.
+	  This option enables the Zoap implementation of CoAP.
 
 # This setting is only used by unit test. Do not enable it in applications
 config ZOAP_TEST_API_ENABLE
@@ -19,7 +19,7 @@ config ZOAP_TEST_API_ENABLE
 	default n
 	depends on ZOAP
 	help
-	Do not enable this for normal use.
+	  Do not enable this for normal use.
 
 config ZOAP_WELL_KNOWN_BLOCK_WISE
 	bool
@@ -27,11 +27,11 @@ config ZOAP_WELL_KNOWN_BLOCK_WISE
 	default n
 	depends on ZOAP
 	help
-	This option enables the block wise support of CoAP response
-	to ./well-known/core request. Without this option all resource's
-	information will be sent in a single IP packet (can be multiple
-	fragments depends on MTU size). This will be useful in mesh kind
-	of networks.
+	  This option enables the block wise support of CoAP response
+	  to ./well-known/core request. Without this option all resource's
+	  information will be sent in a single IP packet (can be multiple
+	  fragments depends on MTU size). This will be useful in mesh kind
+	  of networks.
 
 config ZOAP_WELL_KNOWN_BLOCK_WISE_SIZE
 	int
@@ -39,5 +39,5 @@ config ZOAP_WELL_KNOWN_BLOCK_WISE_SIZE
 	default 32
 	depends on ZOAP_WELL_KNOWN_BLOCK_WISE
 	help
-	Maximum size of CoAP block. Valid values are 16, 32, 64, 128,
-	256, 512 and 1024.
+	  Maximum size of CoAP block. Valid values are 16, 32, 64, 128,
+	  256, 512 and 1024.

--- a/subsys/shell/Kconfig
+++ b/subsys/shell/Kconfig
@@ -14,7 +14,7 @@ config CONSOLE_SHELL
 	default n
 	select CONSOLE_HANDLER
 	help
-	Shell implementation based on CONSOLE_HANDLER.
+	  Shell implementation based on CONSOLE_HANDLER.
 
 
 if CONSOLE_SHELL
@@ -24,13 +24,13 @@ config CONSOLE_SHELL_STACKSIZE
 	prompt "Console handler shell stack size"
 	default 2000
 	help
-	Stack size for the console handler shell.
+	  Stack size for the console handler shell.
 
 config CONSOLE_SHELL_MAX_CMD_QUEUED
 	int "Shell's command queue size"
 	default 3
 	help
-	Maximum size of the queue for input commands.
+	  Maximum size of the queue for input commands.
 
 source "subsys/shell/modules/Kconfig"
 

--- a/subsys/usb/Kconfig
+++ b/subsys/usb/Kconfig
@@ -12,7 +12,7 @@ menuconfig USB_DEVICE_STACK
 	depends on USB
 	default n
 	help
-	Enable USB device stack.
+	  Enable USB device stack.
 
 if USB_DEVICE_STACK
 
@@ -22,51 +22,51 @@ config SYS_LOG_USB_LEVEL
 	default 0
 	depends on SYS_LOG
 	help
-	This option sets log level for the USB device stack.
+	  This option sets log level for the USB device stack.
 
-	Levels are:
+	  Levels are:
 
-	- 0 OFF, do not write
+	  - 0 OFF, do not write
 
-	- 1 ERROR, only write SYS_LOG_ERR
+	  - 1 ERROR, only write SYS_LOG_ERR
 
-	- 2 WARNING, write SYS_LOG_WRN in addition to previous level
+	  - 2 WARNING, write SYS_LOG_WRN in addition to previous level
 
-	- 3 INFO, write SYS_LOG_INF in addition to previous levels
+	  - 3 INFO, write SYS_LOG_INF in addition to previous levels
 
-	- 4 DEBUG, write SYS_LOG_DBG in addition to previous levels
+	  - 4 DEBUG, write SYS_LOG_DBG in addition to previous levels
 
 config USB_DEVICE_VID
 	hex
 	prompt "USB Vendor ID"
 	default 0xDEAD
 	help
-	USB device vendor ID. MUST be configured by vendor.
+	  USB device vendor ID. MUST be configured by vendor.
 
 config USB_DEVICE_PID
 	hex
 	prompt "USB Product ID"
 	default 0xBEEF
 	help
-	USB device product ID. MUST be configured by vendor.
+	  USB device product ID. MUST be configured by vendor.
 
 config USB_DEVICE_MANUFACTURER
 	string
 	default "ZEPHYR"
 	help
-	USB device Manufacturer string
+	  USB device Manufacturer string
 
 config USB_DEVICE_PRODUCT
 	string
 	default "USB-DEV"
 	help
-	USB device Product string
+	  USB device Product string
 
 config USB_DEVICE_SN
 	string
 	default "0.01"
 	help
-	USB device SerialNumber string
+	  USB device SerialNumber string
 
 config USB_COMPOSITE_DEVICE
 	bool
@@ -74,7 +74,7 @@ config USB_COMPOSITE_DEVICE
 	depends on USB
 	default n
 	help
-	Enable composite USB device driver.
+	  Enable composite USB device driver.
 
 config USB_COMPOSITE_BUFFER_SIZE
 	int

--- a/subsys/usb/class/Kconfig
+++ b/subsys/usb/class/Kconfig
@@ -13,14 +13,14 @@ config USB_CDC_ACM
 	prompt "USB CDC ACM Device Class Driver"
 	default n
 	help
-	USB CDC ACM device class driver
+	  USB CDC ACM device class driver
 
 config CDC_ACM_PORT_NAME
 	string "CDC ACM class device driver port name"
 	depends on USB_CDC_ACM
 	default "CDC_ACM"
 	help
-	Port name through which CDC ACM class device driver is accessed
+	  Port name through which CDC ACM class device driver is accessed
 
 config CDC_ACM_INT_EP_ADDR
 	hex "CDC ACM Interrupt Endpoint address"
@@ -28,7 +28,7 @@ config CDC_ACM_INT_EP_ADDR
 	default 0x85
 	range 0x81 0x8f
 	help
-	CDC ACM class interrupt endpoint address
+	  CDC ACM class interrupt endpoint address
 
 config CDC_ACM_IN_EP_ADDR
 	hex "CDC ACM BULK IN Endpoint address"
@@ -36,7 +36,7 @@ config CDC_ACM_IN_EP_ADDR
 	default 0x84
 	range 0x81 0x8f
 	help
-	CDC ACM class IN endpoint address
+	  CDC ACM class IN endpoint address
 
 config CDC_ACM_OUT_EP_ADDR
 	hex "CDC ACM BULK OUT Endpoint address"
@@ -44,21 +44,21 @@ config CDC_ACM_OUT_EP_ADDR
 	default 0x03
 	range 0x01 0x0f
 	help
-	CDC ACM class OUT endpoint address
+	  CDC ACM class OUT endpoint address
 
 config CDC_ACM_INTERRUPT_EP_MPS
 	int
 	depends on USB_CDC_ACM
 	default 16
 	help
-	CDC ACM class interrupt IN endpoint size
+	  CDC ACM class interrupt IN endpoint size
 
 config CDC_ACM_BULK_EP_MPS
 	int
 	depends on USB_CDC_ACM
 	default 64
 	help
-	CDC ACM class bulk endpoints size
+	  CDC ACM class bulk endpoints size
 
 config SYS_LOG_USB_CDC_ACM_LEVEL
 	int
@@ -66,19 +66,19 @@ config SYS_LOG_USB_CDC_ACM_LEVEL
 	depends on USB_CDC_ACM && SYS_LOG
 	default 0
 	help
-	Sets log level for USB CDC ACM device class driver
+	  Sets log level for USB CDC ACM device class driver
 
-	Levels are:
+	  Levels are:
 
-	- 0 OFF, do not write
+	  - 0 OFF, do not write
 
-	- 1 ERROR, only write SYS_LOG_ERR
+	  - 1 ERROR, only write SYS_LOG_ERR
 
-	- 2 WARNING, write SYS_LOG_WRN in addition to previous level
+	  - 2 WARNING, write SYS_LOG_WRN in addition to previous level
 
-	- 3 INFO, write SYS_LOG_INF in addition to previous levels
+	  - 3 INFO, write SYS_LOG_INF in addition to previous levels
 
-	- 4 DEBUG, write SYS_LOG_DBG in addition to previous levels
+	  - 4 DEBUG, write SYS_LOG_DBG in addition to previous levels
 
 config USB_MASS_STORAGE
 	bool
@@ -86,7 +86,7 @@ config USB_MASS_STORAGE
 	select DISK_ACCESS
 	default n
 	help
-	USB Mass Storage device class driver
+	  USB Mass Storage device class driver
 
 config MASS_STORAGE_IN_EP_ADDR
 	hex
@@ -94,7 +94,7 @@ config MASS_STORAGE_IN_EP_ADDR
 	default 0x82
 	range 0x81 0x8f
 	help
-	Mass storage device class IN endpoint address
+	  Mass storage device class IN endpoint address
 
 config MASS_STORAGE_OUT_EP_ADDR
 	hex
@@ -102,7 +102,7 @@ config MASS_STORAGE_OUT_EP_ADDR
 	default 0x01
 	range 0x01 0x0f
 	help
-	Mass storage device class OUT endpoint address
+	  Mass storage device class OUT endpoint address
 
 config MASS_STORAGE_BULK_EP_MPS
 	int
@@ -110,7 +110,7 @@ config MASS_STORAGE_BULK_EP_MPS
 	default 64
 	range 8 64
 	help
-	Mass storage device class bulk endpoints size
+	  Mass storage device class bulk endpoints size
 
 config SYS_LOG_USB_MASS_STORAGE_LEVEL
 	int
@@ -118,19 +118,19 @@ config SYS_LOG_USB_MASS_STORAGE_LEVEL
 	depends on USB_MASS_STORAGE && SYS_LOG
 	default 0
 	help
-	Sets log level for USB Mass Storage device class driver
+	  Sets log level for USB Mass Storage device class driver
 
-	Levels are:
+	  Levels are:
 
-	- 0 OFF, do not write
+	  - 0 OFF, do not write
 
-	- 1 ERROR, only write SYS_LOG_ERR
+	  - 1 ERROR, only write SYS_LOG_ERR
 
-	- 2 WARNING, write SYS_LOG_WRN in addition to previous level
+	  - 2 WARNING, write SYS_LOG_WRN in addition to previous level
 
-	- 3 INFO, write SYS_LOG_INF in addition to previous levels
+	  - 3 INFO, write SYS_LOG_INF in addition to previous levels
 
-	- 4 DEBUG, write SYS_LOG_DBG in addition to previous levels
+	  - 4 DEBUG, write SYS_LOG_DBG in addition to previous levels
 
 source "subsys/usb/class/netusb/Kconfig"
 

--- a/subsys/usb/class/netusb/Kconfig
+++ b/subsys/usb/class/netusb/Kconfig
@@ -20,8 +20,8 @@ config USB_DEVICE_NETWORK_ECM
 	select USB_DEVICE_NETWORK
 	default n
 	help
-	Ethernet Control Model (ECM) is a part of  Communications Device
-	Class (CDC) USB protocol specified by USB-IF.
+	  Ethernet Control Model (ECM) is a part of  Communications Device
+	  Class (CDC) USB protocol specified by USB-IF.
 
 config USB_DEVICE_NETWORK_RNDIS
 	bool
@@ -29,8 +29,8 @@ config USB_DEVICE_NETWORK_RNDIS
 	select USB_DEVICE_NETWORK
 	default n
 	help
-	Remote NDIS (RNDIS) is commonly used Microsoft vendor protocol with
-	Specification available from Microsoft web site.
+	  Remote NDIS (RNDIS) is commonly used Microsoft vendor protocol with
+	  Specification available from Microsoft web site.
 
 if USB_DEVICE_NETWORK_ECM
 
@@ -39,42 +39,42 @@ config CDC_ECM_INT_EP_ADDR
 	default 0x83
 	range 0x81 0x8F
 	help
-	CDC ECM class interrupt endpoint address
+	  CDC ECM class interrupt endpoint address
 
 config CDC_ECM_IN_EP_ADDR
 	hex "CDC ECM BULK IN Endpoint address"
 	default 0x82
 	range 0x81 0x8F
 	help
-	CDC ECM class IN endpoint address
+	  CDC ECM class IN endpoint address
 
 config CDC_ECM_OUT_EP_ADDR
 	hex "CDC ECM BULK OUT Endpoint address"
 	default 0x01
 	range 0x01 0x0F
 	help
-	CDC ECM class OUT endpoint address
+	  CDC ECM class OUT endpoint address
 
 config CDC_ECM_INTERRUPT_EP_MPS
 	int
 	default 16
 	help
-	CDC ECM class interrupt endpoint size
+	  CDC ECM class interrupt endpoint size
 
 config CDC_ECM_BULK_EP_MPS
 	int
 	default 64
 	help
-	CDC ECM class bulk endpoint size
+	  CDC ECM class bulk endpoint size
 
 config USB_DEVICE_NETWORK_ECM_MAC
 	string
 	default "00005E005301"
 	help
-	MAC Host OS Address string.
-	MAC Address which would be assigned to network device, created in
-	the Host's Operating System. Use RFC 7042 Documentation values as
-	default MAC.
+	  MAC Host OS Address string.
+	  MAC Address which would be assigned to network device, created in
+	  the Host's Operating System. Use RFC 7042 Documentation values as
+	  default MAC.
 
 endif # USB_DEVICE_NETWORK_ECM
 

--- a/tests/ztest/Kconfig
+++ b/tests/ztest/Kconfig
@@ -8,8 +8,8 @@ config ZTEST
 	bool "Zephyr testing framework"
 	default n
 	help
-	Enable the Zephyr testing framework. You should enable this only
-	if you're writing automated tests.
+	  Enable the Zephyr testing framework. You should enable this only
+	  if you're writing automated tests.
 
 config ZTEST_STACKSIZE
 	int "Test function thread stack size"
@@ -29,23 +29,23 @@ config ZTEST_ASSERT_VERBOSE
 	depends on ZTEST
 	default 1
 	help
-	Set verbosity level for assertions.
-	Assertion verbosity levels:
-	0 Write only file and line for failed assertions
-	1 Write file, line number, function and reason for failed assertions
-	2 Log also successful assertions
+	  Set verbosity level for assertions.
+	  Assertion verbosity levels:
+	  0 Write only file and line for failed assertions
+	  1 Write file, line number, function and reason for failed assertions
+	  2 Log also successful assertions
 
 config ZTEST_MOCKING
 	bool "Mocking support functions"
 	depends on ZTEST
 	default n
 	help
-	Enable mocking support for Ztest. This allows the test to set
-	return values and expected parameters to functions.
+	  Enable mocking support for Ztest. This allows the test to set
+	  return values and expected parameters to functions.
 
 config ZTEST_PARAMETER_COUNT
 	int "Count of parameters or return values reserved"
 	depends on ZTEST_MOCKING
 	default 1
 	help
-	Maximum amount of concurrent return values / expected parameters.
+	  Maximum amount of concurrent return values / expected parameters.


### PR DESCRIPTION
my not so great one-liner for doing this...

`find -name Kconfig.* -o -name Kconfig -exec sed  -i  '/\thelp/,/^\w/{ /\thelp/n;/^\w/!{ s/^\t\(\S\)/\t  \1/ }}' {} \;`

Signed-off-by: Anas Nashif <anas.nashif@intel.com>