### PR TITLE
drivers: slip: Remove stale CMakeLists.txt

### DIFF
--- a/drivers/slip/CMakeLists.txt
+++ b/drivers/slip/CMakeLists.txt
@@ -1,1 +1,0 @@
-zephyr_sources_if_kconfig(slip.c)


### PR DESCRIPTION
The slip driver was moved to drivers/net around the same time as the
conversion to CMake,

Signed-off-by: Maureen Helm <maureen.helm@nxp.com>