### PR TITLE
kernel: userspace: Fixed the issue of handlers getting dropped by linker

### DIFF
--- a/kernel/CMakeLists.txt
+++ b/kernel/CMakeLists.txt
@@ -31,12 +31,16 @@ target_sources_ifdef(CONFIG_ATOMIC_OPERATIONS_C   kernel PRIVATE atomic_c.c)
 target_sources_ifdef(CONFIG_PTHREAD_IPC           kernel PRIVATE pthread.c)
 target_sources_if_kconfig(                        kernel PRIVATE poll.c)
 
+# The last 2 files inside the target_sources_ifdef should be
+# userspace_handler.c and userspace.c. If not the linker would complain.
+# This order has to be maintained. Any new file should be placed
+# above these 2 files.
 target_sources_ifdef(
   CONFIG_USERSPACE
   kernel PRIVATE
-  userspace.c
-  userspace_handler.c
   mem_domain.c
+  userspace_handler.c
+  userspace.c
   )
 
 add_dependencies(kernel offsets_h)


### PR DESCRIPTION
The linker was always picking a weak handler over the actual one.
The linker always searches for the first definition of any function
weak or otherwise. When it finds this function it just links and
skips traversing through the full list.

In the context of userspace, we create the _handlers_ for each system
call in the respective file. And these _handlers_ would get linked to
a table defined in syscalls_dispatch.c. If for instance that this
handler is not defined then we link to a default error handler.

In the build procedure we create a library file from the kernel folder.
When creating this library file, we need to make sure that the file
syscalls_dispatch.c is the last to get linked(i.e userspace.c).
Because the table inside syscalls_dispatch.c would need all the
correct _handler_ definitions. If this is not handled then the system
call layer will not function correctly because of the linker feature.

Signed-off-by: Adithya Baglody <adithya.nagaraj.baglody@intel.com>