### PR TITLE
drivers: stm32 clock control: fix HSI PLLSOURCE with PREDIV1 support

### DIFF
--- a/drivers/clock_control/stm32f0x_ll_clock.c
+++ b/drivers/clock_control/stm32f0x_ll_clock.c
@@ -36,7 +36,7 @@ void config_pll_init(LL_UTILS_PLLInitTypeDef *pllinit)
 	/* following SoCs: STM32F070x6, STM32F070xB and STM32F030xC */
 	/* cf Reference manual for more details */
 #if defined(CONFIG_CLOCK_STM32_PLL_SRC_HSI)
-	pllinit->PLLDiv = LL_RCC_PLLSOURCE_HSI_DIV_2;
+	pllinit->PLLDiv = LL_RCC_PLLSOURCE_HSI;
 #else
 	/*
 	 * PLL DIV

--- a/drivers/clock_control/stm32f3x_ll_clock.c
+++ b/drivers/clock_control/stm32f3x_ll_clock.c
@@ -36,7 +36,7 @@ void config_pll_init(LL_UTILS_PLLInitTypeDef *pllinit)
 	/* following SoCs: STM32F302XE, STM32F303xE and STM32F398xx */
 	/* cf Reference manual for more details */
 #if defined(CONFIG_CLOCK_STM32_PLL_SRC_HSI)
-	pllinit->PLLDiv = LL_RCC_PLLSOURCE_HSI_DIV_2;
+	pllinit->PLLDiv = LL_RCC_PLLSOURCE_HSI;
 #else
 	/*
 	 * PLL DIV


### PR DESCRIPTION
The combination of
CONFIG_CLOCK_STM32_SYSCLK_SRC_PLL and
CONFIG_CLOCK_STM32_PLL_SRC_HSI
on SOCs with PREDIV1 support made use of the LL define
LL_RCC_PLLSOURCE_HSI_DIV_2, which is not defined for SOCs with
PREDIV1 support.

This exchanges LL_RCC_PLLSOURCE_HSI_DIV_2 with LL_RCC_PLLSOURCE_HSI
which is the appropiate source according to stm32f0xx_ll_rcc.h
line 473 and stm32f3xx_ll_rcc.h line 795.

List of SOCs in F0/F3 line with PREDIV1 support, according to SOCs .h files in stm32cube
- stm32f030xc
- stm32f042x6
- stm32f048xx
- stm32f070x6
- stm32f070xb
- stm32f071xb
- stm32f072xb
- stm32f078xx
- **stm32f091xc**
- stm32f098xx
- stm32f302xe
- stm32f303xe
- stm32f398xx

Only stm32f091xc is implemented in Zephyr so far.

Tested by compiling hello world for nucleo_f091rc board with HSI as
PLLSOURCE.

fixes #5391 