### PR TITLE
tests/booting/stub: disable banner

### DIFF
--- a/tests/booting/stub/prj.conf
+++ b/tests/booting/stub/prj.conf
@@ -1,3 +1,4 @@
 # Our only mission is to start the ARC in an Arduino platform so we
 # can pipe its output to the serial port.
 CONFIG_ARC_INIT=y
+CONFIG_BOOT_BANNER=n


### PR DESCRIPTION
The stub is supposed to be there to bring up a CPU that needs to be
brought up because the platform requires so, but it needs to be as
practically quiet in terms of printing to the serial port as possible.

Thus, disable  printing the boot banner by default.

Signed-off-by: Inaky Perez-Gonzalez <inaky.perez-gonzalez@intel.com>
Signed-off-by: Anas Nashif <anas.nashif@intel.com>