### PR TITLE
samples: mesh/onoff-app: fix sample.yaml syntax

### DIFF
--- a/samples/boards/nrf52/mesh/onoff-app/sample.yaml
+++ b/samples/boards/nrf52/mesh/onoff-app/sample.yaml
@@ -1,7 +1,6 @@
 sample:
   name: Bluetooth Mesh
 tests:
-  - test:
-      build_only: true
-      platform_whitelist: nrf52840-pca10056
-      tags: bluetooth
+  test:
+    platform_whitelist: nrf52840-pca10056
+    tags: bluetooth


### PR DESCRIPTION
Also, remove build_only, we can run on the whitelisted platform.

Signed-off-by: Anas Nashif <anas.nashif@intel.com>