### PR TITLE
doc: getting_started: Add note for Windows env vars

### DIFF
--- a/doc/getting_started/installation_win.rst
+++ b/doc/getting_started/installation_win.rst
@@ -42,6 +42,12 @@ environment for Windows. Follow the steps below to set it up:
         Make sure you start ``MSYS2 MSYS Shell``, not ``MSYS2 MinGW Shell``.
 
    .. note::
+
+        If you need to inherit the existing Windows environment variables into
+        MSYS2 you will need to create a **Windows** environment variable like so::
+        ``MSYS2_PATH_TYPE=inherit``.
+
+   .. note::
         There are multiple ``export`` statements in this tutorial. You can avoid
         typing them every time by placing them at the bottom of your
         ``~/.bash_profile`` file.


### PR DESCRIPTION
Some users might want to inherit their already existing Windows
environment variables into the MSYS2 system. This note explains how to
achieve this.

Signed-off-by: Carles Cufi <carles.cufi@nordicsemi.no>