### PR TITLE
doc: application: fix KCONFIG_ROOT example file

### DIFF
--- a/doc/application/application-kconfig.include
+++ b/doc/application/application-kconfig.include
@@ -4,10 +4,6 @@ config ZEPHYR_BASE
 	string
 	option env="ZEPHYR_BASE"
 
-config APPLICATION_BASE
-	string
-	option env="PROJECT_BASE"
-
 source "$ZEPHYR_BASE/Kconfig.zephyr"
 
 # Your application configuration options go here.


### PR DESCRIPTION
This is a quick fix for a copy/paste mistake I made in a file included by the application development primer documentation.

I'm posting it for master but think it should be cherry-picked into any subsequent 1.10.1 branch or point release, if there will be one, hence the Milestone setting.