### PR TITLE
samples: mesh/onoff-app: fix whitelist typo

### DIFF
--- a/samples/boards/nrf52/mesh/onoff-app/sample.yaml
+++ b/samples/boards/nrf52/mesh/onoff-app/sample.yaml
@@ -2,5 +2,5 @@ sample:
   name: Bluetooth Mesh
 tests:
   test:
-    platform_whitelist: nrf52840-pca10056
+    platform_whitelist: nrf52840_pca10056
     tags: bluetooth


### PR DESCRIPTION
Board name is nrf52840_pca10056 (with an underscore) instead of
nrf52840-pca10056 (with a dash).

Signed-off-by: Kumar Gala <kumar.gala@linaro.org>