### PR TITLE
fs: only select the disk subsystem if the filesystem needs it.

### DIFF
--- a/subsys/fs/Kconfig
+++ b/subsys/fs/Kconfig
@@ -8,7 +8,6 @@ menu "File Systems"
 
 config FILE_SYSTEM
 	bool "File system support"
-	select DISK_ACCESS
 	default n
 	help
 	  Enables support for file system.
@@ -26,6 +25,7 @@ config NO_FS
 
 config FAT_FILESYSTEM_ELM
 	bool "ELM FAT File System"
+	select DISK_ACCESS
 	help
 	  Use the ELM FAT File system implementation.
 


### PR DESCRIPTION
Of the filesystems under subsys/fs/, only the ELM FAT filesystem needs
the disk layer as others (like NFFS) talk directly to the flash API.

This removes the need to define CONFIG_DISK_ERASE_BLOCK_SIZE and
similar which are used by the disk subsystem but not by NFFS.

Signed-off-by: Michael Hope <mlhx@google.com>