### PR TITLE
Improve get api and fix ld script issue

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -517,7 +517,20 @@ add_custom_target(
   DEPENDS
   linker.cmd
   offsets_h
-)
+  )
+
+# Give the 'linker_script' target all of the include directories so
+# that cmake can successfully find the linker_script's header
+# dependencies.
+zephyr_get_include_directories_for_lang(C
+  ZEPHYR_INCLUDE_DIRS
+  STRIP_PREFIX # Don't use a -I prefix
+  )
+set_property(TARGET
+  linker_script
+  PROPERTY INCLUDE_DIRECTORIES
+  ${ZEPHYR_INCLUDE_DIRS}
+  )
 
 set(zephyr_lnk
   ${LINKERFLAGPREFIX},-Map=${PROJECT_BINARY_DIR}/${KERNEL_MAP_NAME}
@@ -709,6 +722,11 @@ if(GKOF OR GKSF)
     linker_pass2.cmd
     offsets_h
     )
+  set_property(TARGET
+    linker_pass2_script
+    PROPERTY INCLUDE_DIRECTORIES
+    ${ZEPHYR_INCLUDE_DIRS}
+  )
 
   add_executable(       kernel_elf misc/empty_file.c ${GKSF})
   target_link_libraries(kernel_elf ${GKOF} -T${PROJECT_BINARY_DIR}/linker_pass2.cmd ${zephyr_lnk})


### PR DESCRIPTION
Usually the zephyr_get_* API returns values prefixed with tokens like
-I -system, -D. But sometimes we need the values without these
prefixes, so we introduce the optional SKIP_PREFIX argument.

This PR also fixes #5010. CMake has a
simple parser that can parse C-like files to find header
dependencies. But the parser needs to know what the include
directories are to be able to follow #include pragmas.