### PR TITLE
[RFC] arch: nrf: Panic when building for the wrong board

### DIFF
--- a/arch/arm/soc/nordic_nrf5/nrf52/CMakeLists.txt
+++ b/arch/arm/soc/nordic_nrf5/nrf52/CMakeLists.txt
@@ -5,4 +5,5 @@ zephyr_sources(
   mpu_regions.c
   power.c
   soc.c
+  soc_post_kernel.c
   )

--- a/arch/arm/soc/nordic_nrf5/nrf52/soc_post_kernel.c
+++ b/arch/arm/soc/nordic_nrf5/nrf52/soc_post_kernel.c
@@ -1,0 +1,53 @@
+/*
+ * Copyright (c) 2016 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * @file
+ * @brief System/hardware module for Nordic Semiconductor nRF52 family processor
+ *
+ * This module provides routines that rely on kernel services
+ * (POST_KERNEL) to initialize and support board-level hardware for
+ * the Nordic Semiconductor nRF52 family processor.
+ */
+
+#include <init.h>
+#include "nrf.h"
+
+static void check_build_soc_matches_runtime_soc(void);
+
+static int nordicsemi_nrf52_init_post_kernel(struct device *arg)
+{
+	ARG_UNUSED(arg);
+
+	check_build_soc_matches_runtime_soc();
+
+	return 0;
+}
+
+#if !(defined(CONFIG_SOC_NRF52832) || defined(CONFIG_SOC_NRF52840))
+#error "An SoC was not specified"
+/* When more SoCs are added the check_build_soc_matches_runtime_soc
+ * function needs to be updated
+ */
+#endif
+
+static void check_build_soc_matches_runtime_soc(void)
+{
+	u32_t soc = IS_ENABLED(CONFIG_SOC_NRF52832) ? 0x52832UL : 0x52840UL;
+
+	if (NRF_FICR->INFO.PART != soc) {
+		/* Wrong BOARD.
+		 *
+		 * The FW has been built for an SoC that does not match the
+		 * detected SoC, to prevent hard-to-debug undefined behaviour
+		 * we panic.
+		 */
+
+		k_panic();
+	}
+}
+
+SYS_INIT(nordicsemi_nrf52_init_post_kernel, POST_KERNEL, 0);


### PR DESCRIPTION
There are no safety mechanisms to give the user feedback that he might
have choosen a BOARD that doesn't match the connected board. Running
FW for one board on another can lead to obscure debugging.

This patch uses 16 bytes of code to block the application from running
when it is detected that the user has selected the wrong board. After
this patch the user can use his debugger to see why his application is
hanging and it will be obvious what the user error is.

If this method is OK'd I'll port this to nrf51.

Well thought out suggestions for better ways to solve the same usability 
problem are welcome.

PS: I'll make an effort to get this upstreamed as well.