### PR TITLE
doc: update doc tools versions

### DIFF
--- a/scripts/requirements.txt
+++ b/scripts/requirements.txt
@@ -1,7 +1,7 @@
 wheel==0.30.0
-breathe==4.6.0
-sphinx==1.5.5
-docutils==0.13.1
+breathe==4.7.3
+sphinx==1.6.5
+docutils==0.14
 sphinx_rtd_theme
 junit2html
 PyYAML==3.12


### PR DESCRIPTION
I've been successfully using the latest sphinx/breathe/docutils
and doxygen versions for local doc build testing. The CI system
already uses the latest doxygen, so this patch updates the
pip-installed sphinx, breathe, and docutils tools too.

Signed-off-by: David B. Kinder <david.b.kinder@intel.com>