### PR TITLE
arm: stm32l4: include RNG ll header

### DIFF
--- a/arch/arm/soc/st_stm32/stm32l4/soc.h
+++ b/arch/arm/soc/st_stm32/stm32l4/soc.h
@@ -51,6 +51,10 @@
 #include <stm32l4xx_ll_iwdg.h>
 #endif
 
+#ifdef CONFIG_ENTROPY_STM32_RNG
+#include <stm32l4xx_ll_rng.h>
+#endif
+
 /* For IMG_MANAGER */
 #if defined(CONFIG_SOC_FLASH_STM32)
 #define FLASH_DRIVER_NAME	CONFIG_SOC_FLASH_STM32_DEV_NAME


### PR DESCRIPTION
Include low level random generator header in case stm32 random number
generator should be used by entropy driver

Signed-off-by: Jan Van Winkel <jan.van_winkel@dxplore.eu>