### PR TITLE
kernel: posix: separating posix APIs according to their types.

### DIFF
--- a/kernel/CMakeLists.txt
+++ b/kernel/CMakeLists.txt
@@ -28,8 +28,8 @@ target_sources_ifdef(CONFIG_INT_LATENCY_BENCHMARK kernel PRIVATE int_latency_ben
 target_sources_ifdef(CONFIG_STACK_CANARIES        kernel PRIVATE compiler_stack_protect.c)
 target_sources_ifdef(CONFIG_SYS_CLOCK_EXISTS      kernel PRIVATE timer.c)
 target_sources_ifdef(CONFIG_ATOMIC_OPERATIONS_C   kernel PRIVATE atomic_c.c)
-target_sources_ifdef(CONFIG_PTHREAD_IPC           kernel PRIVATE pthread.c)
 target_sources_if_kconfig(                        kernel PRIVATE poll.c)
+add_subdirectory_ifdef(CONFIG_PTHREAD_IPC   posix)
 
 # The last 2 files inside the target_sources_ifdef should be
 # userspace_handler.c and userspace.c. If not the linker would complain.

--- a/kernel/posix/CMakeLists.txt
+++ b/kernel/posix/CMakeLists.txt
@@ -1,0 +1,4 @@
+target_sources(kernel PRIVATE posix/pthread_common.c)
+target_sources(kernel PRIVATE posix/pthread_cond.c)
+target_sources(kernel PRIVATE posix/pthread_mutex.c)
+target_sources(kernel PRIVATE posix/pthread_barrier.c)

--- a/kernel/posix/pthread_barrier.c
+++ b/kernel/posix/pthread_barrier.c
@@ -1,0 +1,36 @@
+/*
+ * Copyright (c) 2017 Intel Corporation
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <kernel.h>
+#include <pthread.h>
+#include "ksched.h"
+#include "wait_q.h"
+
+void ready_one_thread(_wait_q_t *wq);
+
+int pthread_barrier_wait(pthread_barrier_t *b)
+{
+	int key = irq_lock();
+
+	b->count++;
+
+	if (b->count >= b->max) {
+		b->count = 0;
+
+		while (!sys_dlist_is_empty(&b->wait_q)) {
+			ready_one_thread(&b->wait_q);
+		}
+
+		if (!__must_switch_threads()) {
+			irq_unlock(key);
+			return 0;
+		}
+	} else {
+		_pend_current_thread(&b->wait_q, K_FOREVER);
+	}
+
+	return _Swap(key);
+}

--- a/kernel/posix/pthread_common.c
+++ b/kernel/posix/pthread_common.c
@@ -1,0 +1,20 @@
+/*
+ * Copyright (c) 2017 Intel Corporation
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <kernel.h>
+#include <pthread.h>
+#include "ksched.h"
+#include "wait_q.h"
+
+void ready_one_thread(_wait_q_t *wq)
+{
+	struct k_thread *th = _unpend_first_thread(wq);
+
+	if (th) {
+		_abort_thread_timeout(th);
+		_ready_thread(th);
+	}
+}

--- a/kernel/posix/pthread_mutex.c
+++ b/kernel/posix/pthread_mutex.c
@@ -1,0 +1,24 @@
+/*
+ * Copyright (c) 2017 Intel Corporation
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <kernel.h>
+#include <pthread.h>
+#include "ksched.h"
+#include "wait_q.h"
+
+int pthread_mutex_trylock(pthread_mutex_t *m)
+{
+	int key = irq_lock(), ret = -EBUSY;
+
+	if (m->sem->count) {
+		m->sem->count = 0;
+		ret = 0;
+	}
+
+	irq_unlock(key);
+
+	return ret;
+}


### PR DESCRIPTION
Currently all posix APIs are put into single files (pthread.c).
This patch creates separate files for different API areas.

Signed-off-by: Youvedeep Singh <youvedeep.singh@intel.com>