### PR TITLE
arm: cortex_m: linker.ld: fix relocate by moving _vector_start before CONFIG_TEXT_SECTION_OFFSET

### DIFF
--- a/include/arch/arm/cortex_m/scripts/linker.ld
+++ b/include/arch/arm/cortex_m/scripts/linker.ld
@@ -94,8 +94,8 @@ SECTIONS
 	KEEP(*(.dbghdr))
 	KEEP(*(".dbghdr.*"))
 #endif
-	_vector_start = .;
 	. = CONFIG_TEXT_SECTION_OFFSET;
+	_vector_start = .;
 	KEEP(*(.exc_vector_table))
 	KEEP(*(".exc_vector_table.*"))
 


### PR DESCRIPTION
arm: cortex_m: linker.ld: fix relocate by moving _vector_start before CONFIG_TEXT_SECTION_OFFSET.

The _vector_start was placed before the CONFIG_TEXT_SECTION_OFFSET, thus adding the offset in the relocated vector table, making the table invalid when relocated with a non null CONFIG_TEXT_SECTION_OFFSET.
    
This was tested using MCUboot with a 0x200 offset for the image header.