### PR TITLE
cmake: Don't link with subsys__bluetooth unnecessarily

### DIFF
--- a/samples/bluetooth/beacon/CMakeLists.txt
+++ b/samples/bluetooth/beacon/CMakeLists.txt
@@ -1,6 +1,4 @@
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
 project(NONE)
 
-target_link_libraries(app subsys__bluetooth)
-
 target_sources(app PRIVATE src/main.c)

--- a/samples/bluetooth/hci_uart/CMakeLists.txt
+++ b/samples/bluetooth/hci_uart/CMakeLists.txt
@@ -7,6 +7,4 @@ endif()
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
 project(NONE)
 
-target_link_libraries(app subsys__bluetooth)
-
 target_sources(app PRIVATE src/main.c)

--- a/samples/bluetooth/hci_usb/CMakeLists.txt
+++ b/samples/bluetooth/hci_usb/CMakeLists.txt
@@ -1,6 +1,4 @@
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
 project(NONE)
 
-target_link_libraries(app subsys__bluetooth)
-
 target_sources(app PRIVATE src/main.c)

--- a/samples/bluetooth/mesh/CMakeLists.txt
+++ b/samples/bluetooth/mesh/CMakeLists.txt
@@ -3,7 +3,5 @@ set(QEMU_EXTRA_FLAGS -s)
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
 project(NONE)
 
-target_link_libraries(app subsys__bluetooth)
-
 target_sources(app PRIVATE src/main.c)
 target_sources_ifdef(CONFIG_BOARD_BBC_MICROBIT app PRIVATE src/microbit.c)

--- a/samples/bluetooth/mesh_demo/CMakeLists.txt
+++ b/samples/bluetooth/mesh_demo/CMakeLists.txt
@@ -4,8 +4,6 @@ set(IS_TEST 1)
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
 project(NONE)
 
-target_link_libraries(app subsys__bluetooth)
-
 target_sources(app PRIVATE src/main.c)
 target_sources_ifdef(CONFIG_BOARD_BBC_MICROBIT app PRIVATE src/microbit.c)
 

--- a/samples/boards/nrf52/mesh/onoff-app/CMakeLists.txt
+++ b/samples/boards/nrf52/mesh/onoff-app/CMakeLists.txt
@@ -3,6 +3,4 @@ set(QEMU_EXTRA_FLAGS -s)
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
 project(NONE)
 
-target_link_libraries(app subsys__bluetooth)
-
 target_sources(app PRIVATE src/main.c)


### PR DESCRIPTION
It is only necessary to link with subsys__bluetooth if the path
"subsys/bluetooth" is needed as an include directory. None of the
samples have this need.

Signed-off-by: Sebastian Bøe <sebastian.boe@nordicsemi.no>