### PR TITLE
runner: nrfjprog: Improve error messages

### DIFF
--- a/scripts/support/runner/nrfjprog.py
+++ b/scripts/support/runner/nrfjprog.py
@@ -40,8 +40,13 @@ class NrfJprogBinaryRunner(ZephyrBinaryRunner):
         snrs = self.check_output(['nrfjprog', '--ids'])
         snrs = snrs.decode(sys.getdefaultencoding()).strip().splitlines()
 
-        if len(snrs) == 1:
-            return snrs[0]
+        if len(snrs) == 0:
+            raise Exception('"nrfjprog --ids" did not find a board; Is the board connected?')
+        elif len(snrs) == 1:
+            board_snr = snrs[0]
+            if board_snr == '0':
+                raise Exception('"nrfjprog --ids" returned 0; is a debugger already connected?')
+            return board_snr
 
         print('There are multiple boards connected.')
         for i, snr in enumerate(snrs, 1):


### PR DESCRIPTION
When a debugger is already connected to the JLink debug adapter
nrfjprog.py would incorrectly detect that the snr is '0' and try to
flash a device with that snr.

Also, when there were no boards connected, nrfjprog.py would
incorrectly state that there were multiple boards connected.

This patch improves the error feedback so that a user can more easily
debug why he can't flash his device.

Signed-off-by: Sebastian Bøe <sebastian.boe@nordicsemi.no>