### PR TITLE
scripts: zephyr_flash_debug.py: swallow exceptions by default

### DIFF
--- a/scripts/support/zephyr_flash_debug.py
+++ b/scripts/support/zephyr_flash_debug.py
@@ -91,8 +91,15 @@ def main():
     try:
         handlers[args.top_command](args)
     except Exception as e:
-        print('Error: {}'.format(e), file=sys.stderr)
-        raise
+        if args.verbose:
+            raise
+        else:
+            print('Error: {}'.format(e), file=sys.stderr)
+            print(('(Re-run as "{} --verbose {} ..." '
+                   'or set CMAKE_VERBOSE_MAKEFILE for a stack trace.)').format(
+                       sys.argv[0], args.top_command),
+                  file=sys.stderr)
+            sys.exit(1)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
For readability, swallow exceptions raised by the runner package unless --verbose is given on the zephyr_flash_debug.py command line. Add a printline to direct the user how to ensure that's set in case more information out of the flash script is desired.
