### PR TITLE
nrfjprog_py: Use RuntimeError instead of Exception

### DIFF
--- a/scripts/support/runner/nrfjprog.py
+++ b/scripts/support/runner/nrfjprog.py
@@ -41,11 +41,11 @@ class NrfJprogBinaryRunner(ZephyrBinaryRunner):
         snrs = snrs.decode(sys.getdefaultencoding()).strip().splitlines()
 
         if len(snrs) == 0:
-            raise Exception('"nrfjprog --ids" did not find a board; Is the board connected?')
+            raise RuntimeError('"nrfjprog --ids" did not find a board; Is the board connected?')
         elif len(snrs) == 1:
             board_snr = snrs[0]
             if board_snr == '0':
-                raise Exception('"nrfjprog --ids" returned 0; is a debugger already connected?')
+                raise RuntimeError('"nrfjprog --ids" returned 0; is a debugger already connected?')
             return board_snr
 
         print('There are multiple boards connected.')


### PR DESCRIPTION
Be more specific with the exception type.

https://github.com/zephyrproject-rtos/zephyr/pull/5432#issuecomment-352492089

Signed-off-by: Sebastian Bøe <sebastian.boe@nordicsemi.no>