### PR TITLE
Bluetooth: tester: Add Core Unregister Service command

### DIFF
--- a/tests/bluetooth/tester/src/bttester.h
+++ b/tests/bluetooth/tester/src/bttester.h
@@ -57,6 +57,11 @@ struct core_register_service_cmd {
 	u8_t id;
 } __packed;
 
+#define CORE_UNREGISTER_SERVICE		0x04
+struct core_unregister_service_cmd {
+	u8_t id;
+} __packed;
+
 /* events */
 #define CORE_EV_IUT_READY		0x80
 
@@ -780,19 +785,23 @@ void tester_send(u8_t service, u8_t opcode, u8_t index, u8_t *data,
 		 size_t len);
 
 u8_t tester_init_gap(void);
+u8_t tester_unregister_gap(void);
 void tester_handle_gap(u8_t opcode, u8_t index, u8_t *data,
 		       u16_t len);
 u8_t tester_init_gatt(void);
+u8_t tester_unregister_gatt(void);
 void tester_handle_gatt(u8_t opcode, u8_t index, u8_t *data,
 			u16_t len);
 
 #if defined(CONFIG_BT_L2CAP_DYNAMIC_CHANNEL)
 u8_t tester_init_l2cap(void);
+u8_t tester_unregister_l2cap(void);
 void tester_handle_l2cap(u8_t opcode, u8_t index, u8_t *data,
 			 u16_t len);
 #endif /* CONFIG_BT_L2CAP_DYNAMIC_CHANNEL */
 
 #if defined(CONFIG_BT_MESH)
 u8_t tester_init_mesh(void);
+u8_t tester_unregister_mesh(void);
 void tester_handle_mesh(u8_t opcode, u8_t index, u8_t *data, u16_t len);
 #endif /* CONFIG_BT_MESH */

--- a/tests/bluetooth/tester/src/gap.c
+++ b/tests/bluetooth/tester/src/gap.c
@@ -742,3 +742,8 @@ u8_t tester_init_gap(void)
 
 	return BTP_STATUS_SUCCESS;
 }
+
+u8_t tester_unregister_gap(void)
+{
+	return BTP_STATUS_SUCCESS;
+}

--- a/tests/bluetooth/tester/src/gatt.c
+++ b/tests/bluetooth/tester/src/gatt.c
@@ -1940,3 +1940,8 @@ u8_t tester_init_gatt(void)
 
 	return BTP_STATUS_SUCCESS;
 }
+
+u8_t tester_unregister_gatt(void)
+{
+	return BTP_STATUS_SUCCESS;
+}

--- a/tests/bluetooth/tester/src/l2cap.c
+++ b/tests/bluetooth/tester/src/l2cap.c
@@ -350,3 +350,8 @@ u8_t tester_init_l2cap(void)
 {
 	return BTP_STATUS_SUCCESS;
 }
+
+u8_t tester_unregister_l2cap(void)
+{
+	return BTP_STATUS_SUCCESS;
+}

--- a/tests/bluetooth/tester/src/mesh.c
+++ b/tests/bluetooth/tester/src/mesh.c
@@ -636,3 +636,8 @@ u8_t tester_init_mesh(void)
 
 	return BTP_STATUS_SUCCESS;
 }
+
+u8_t tester_unregister_mesh(void)
+{
+	return BTP_STATUS_SUCCESS;
+}


### PR DESCRIPTION
This adds stubs for Core Unregister Service command implementation.
It will be used to clean up the stack and tester after test case
execution.