### PR TITLE
ld: Introduce --print-memory-usage

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -774,6 +774,18 @@ add_custom_command(
   # NB: COMMENT only works for some CMake-Generators
 )
 
+if(CONFIG_OUTPUT_PRINT_MEMORY_USAGE)
+  # Use --print-memory-usage with the first link.
+  #
+  # Don't use this option with the second link because seeing it twice
+  # could confuse users and using it on the second link would suppress
+  # it when the first link has a ram/flash-usage issue.
+  set(option ${LINKERFLAGPREFIX},--print-memory-usage)
+  string(MAKE_C_IDENTIFIER check${option} check)
+  check_c_compiler_flag(${option} ${check})
+  target_link_libraries_ifdef(${check} zephyr_prebuilt ${option})
+endif()
+
 add_subdirectory(cmake/qemu)
 add_subdirectory(cmake/flash)
 

--- a/misc/Kconfig
+++ b/misc/Kconfig
@@ -162,6 +162,20 @@ config OUTPUT_DISASSEMBLY
 	help
 	  Create an .lst file with the assembly listing of the firmware.
 
+config OUTPUT_PRINT_MEMORY_USAGE
+	bool "Print memory usage to stdout"
+	default y
+	help
+	  If the toolchain supports it, this option will pass
+	  --print-memory-region to the linker when it is doing it's first
+	  linker pass. Note that the memory regions are symbolic concepts
+	  defined by the linker scripts and do not necessarily map
+	  directly to the real physical address space. Take also note that
+	  some platforms do two passes of the linker so the results do not
+	  match exactly to the final elf file. See also rom_report,
+	  ram_report and
+	  https://sourceware.org/binutils/docs/ld/MEMORY.html
+
 config BUILD_OUTPUT_HEX
 	bool "Build a binary in HEX format"
 	default n


### PR DESCRIPTION
Pass the --print-memory-usage flag to the linker on the first link if the
toolchain supports it.

Don't use this option with the second link because seeing it twice
could confuse users and using it on the second link would suppress it
when the first link has a ram/flash-usage issue.

Note that the memory regions are symbolic concepts defined by the
linker scripts and do not necessarily map directly to the real
physical address space. Take also note that some platforms do two
passes of the linker so the results do not match exactly to the final
elf file. See also rom_report, ram_report and
https://sourceware.org/binutils/docs/ld/MEMORY.html

This is particularly useful when the linker fails due to excessive
flash/ram usage. When a section does not fit into a memory region the
linker will exit with an error code and will state how big the
overflow was. But it doesn't state what the memory region size is, or
what memory regions exist, which is good to know when debugging
overflow issues.

Example overflow output:
```
[ 95%] Linking C executable zephyr_prebuilt.elf
Memory region         Used Size  Region Size  %age Used
        INSTRRAM:       70312 B        32 KB    214.58%
         DATARAM:       42048 B        32 KB    128.32%
        IDT_LIST:          69 B         2 KB      3.37%
/home/sebo/zephyr-sdk-0.9.2-rc5/sysroots/x86_64-pokysdk-linux/usr/bin/riscv32-zephyr-elf/../../libexec/riscv32-zephyr-elf/gcc/riscv32-zephyr-elf/6.1.0/real-ld: zephyr_prebuilt.elf section `text' will not fit in region `INSTRRAM'
/home/sebo/zephyr-sdk-0.9.2-rc5/sysroots/x86_64-pokysdk-linux/usr/bin/riscv32-zephyr-elf/../../libexec/riscv32-zephyr-elf/gcc/riscv32-zephyr-elf/6.1.0/real-ld: zephyr_prebuilt.elf section `noinit' will not fit in region `DATARAM'
/home/sebo/zephyr-sdk-0.9.2-rc5/sysroots/x86_64-pokysdk-linux/usr/bin/riscv32-zephyr-elf/../../libexec/riscv32-zephyr-elf/gcc/riscv32-zephyr-elf/6.1.0/real-ld: region `INSTRRAM' overflowed by 37544 bytes
/home/sebo/zephyr-sdk-0.9.2-rc5/sysroots/x86_64-pokysdk-linux/usr/bin/riscv32-zephyr-elf/../../libexec/riscv32-zephyr-elf/gcc/riscv32-zephyr-elf/6.1.0/real-ld: region `DATARAM' overflowed by 9280 bytes
collect2: error: ld returned 1 exit status
zephyr/CMakeFiles/zephyr_prebuilt.dir/build.make:103: recipe for target 'zephyr/zephyr_prebuilt.elf' failed
make[2]: *** [zephyr/zephyr_prebuilt.elf] Error 1
CMakeFiles/Makefile2:568: recipe for target 'zephyr/CMakeFiles/zephyr_prebuilt.dir/all' failed
make[1]: *** [zephyr/CMakeFiles/zephyr_prebuilt.dir/all] Error 2
Makefile:83: recipe for target 'all' failed
make: *** [all] Error 2

```

Signed-off-by: Sebastian Bøe <sebastian.boe@nordicsemi.no>