### PR TITLE
boards: disco_l475_iot1: add ST reference to doc name

### DIFF
--- a/boards/arm/disco_l475_iot1/doc/disco_l475_iot1.rst
+++ b/boards/arm/disco_l475_iot1/doc/disco_l475_iot1.rst
@@ -1,7 +1,7 @@
 .. _disco_l475_iot1_board:
 
-ST Disco L475 IOT01
-###################
+ST Disco L475 IOT01 (B-L475E-IOT01A)
+####################################
 
 Overview
 ********


### PR DESCRIPTION
ST official reference for this board is B-L475E-IOT01A.
While not used in zephyr, add reference in documentaion title.

Signed-off-by: Erwan Gouriou <erwan.gouriou@linaro.org>