### PR TITLE
Bluetooth: controller: Fix S2 coding tIFS trx switching

### DIFF
--- a/subsys/bluetooth/controller/hal/nrf5/radio.c
+++ b/subsys/bluetooth/controller/hal/nrf5/radio.c
@@ -399,9 +399,9 @@ u32_t radio_rx_chain_delay_get(u8_t phy, u8_t flags)
 		return 5; /* ceil(5) */
 	case BIT(2):
 		if (flags & 0x01) {
-			return 30; /* ciel(29.6) */
+			return 30; /* ceil(29.6) */
 		} else {
-			return 20; /* ciel(19.6) */
+			return 25; /* this is manually measured approx. */
 		}
 	}
 #else /* !CONFIG_SOC_NRF52840 */


### PR DESCRIPTION
Add implementation to consider differing Rx chain delays for
S2 and S8 Coded PHY PDU reception. These changes are
required to meet tIFS timings for transmission after a
reception on S8 coding.

Fix the S2 coding Rx chain delay timing constant based on
manual observations.

Signed-off-by: Vinayak Kariappa Chettimada <vich@nordicsemi.no>