### PR TITLE
Bluetooth: Fix build failure with -Wshadow CFLAGS

### DIFF
--- a/subsys/bluetooth/controller/ticker/ticker.c
+++ b/subsys/bluetooth/controller/ticker/ticker.c
@@ -1524,7 +1524,7 @@ void ticker_trigger(u8_t instance_index)
 u32_t ticker_start(u8_t instance_index, u8_t user_id, u8_t ticker_id,
 		   u32_t ticks_anchor, u32_t ticks_first, u32_t ticks_periodic,
 		   u32_t remainder_periodic, u16_t lazy, u16_t ticks_slot,
-		   ticker_timeout_func ticker_timeout_func, void *context,
+		   ticker_timeout_func fp_timeout_func, void *context,
 		   ticker_op_func fp_op_func, void *op_context)
 {
 	struct ticker_instance *instance = &_instance[instance_index];
@@ -1552,7 +1552,7 @@ u32_t ticker_start(u8_t instance_index, u8_t user_id, u8_t ticker_id,
 	user_op->params.start.remainder_periodic = remainder_periodic;
 	user_op->params.start.ticks_slot = ticks_slot;
 	user_op->params.start.lazy = lazy;
-	user_op->params.start.fp_timeout_func = ticker_timeout_func;
+	user_op->params.start.fp_timeout_func = fp_timeout_func;
 	user_op->params.start.context = context;
 	user_op->status = TICKER_STATUS_BUSY;
 	user_op->fp_op_func = fp_op_func;

--- a/subsys/bluetooth/controller/ticker/ticker.h
+++ b/subsys/bluetooth/controller/ticker/ticker.h
@@ -101,7 +101,7 @@ void ticker_trigger(u8_t instance_index);
 u32_t ticker_start(u8_t instance_index, u8_t user_id, u8_t ticker_id,
 		   u32_t ticks_anchor, u32_t ticks_first, u32_t ticks_periodic,
 		   u32_t remainder_periodic, u16_t lazy, u16_t ticks_slot,
-		   ticker_timeout_func ticker_timeout_func, void *context,
+		   ticker_timeout_func fp_timeout_func, void *context,
 		   ticker_op_func fp_op_func, void *op_context);
 u32_t ticker_update(u8_t instance_index, u8_t user_id, u8_t ticker_id,
 		    u16_t ticks_drift_plus, u16_t ticks_drift_minus,

--- a/subsys/bluetooth/shell/gatt.c
+++ b/subsys/bluetooth/shell/gatt.c
@@ -106,7 +106,7 @@ static u8_t discover_func(struct bt_conn *conn,
 	struct bt_gatt_service_val *gatt_service;
 	struct bt_gatt_chrc *gatt_chrc;
 	struct bt_gatt_include *gatt_include;
-	char uuid[37];
+	char str[37];
 
 	if (!attr) {
 		printk("Discover complete\n");
@@ -118,27 +118,27 @@ static u8_t discover_func(struct bt_conn *conn,
 	case BT_GATT_DISCOVER_SECONDARY:
 	case BT_GATT_DISCOVER_PRIMARY:
 		gatt_service = attr->user_data;
-		bt_uuid_to_str(gatt_service->uuid, uuid, sizeof(uuid));
+		bt_uuid_to_str(gatt_service->uuid, str, sizeof(str));
 		printk("Service %s found: start handle %x, end_handle %x\n",
-		       uuid, attr->handle, gatt_service->end_handle);
+		       str, attr->handle, gatt_service->end_handle);
 		break;
 	case BT_GATT_DISCOVER_CHARACTERISTIC:
 		gatt_chrc = attr->user_data;
-		bt_uuid_to_str(gatt_chrc->uuid, uuid, sizeof(uuid));
-		printk("Characteristic %s found: handle %x\n", uuid,
+		bt_uuid_to_str(gatt_chrc->uuid, str, sizeof(str));
+		printk("Characteristic %s found: handle %x\n", str,
 		       attr->handle);
 		print_chrc_props(gatt_chrc->properties);
 		break;
 	case BT_GATT_DISCOVER_INCLUDE:
 		gatt_include = attr->user_data;
-		bt_uuid_to_str(gatt_include->uuid, uuid, sizeof(uuid));
+		bt_uuid_to_str(gatt_include->uuid, str, sizeof(str));
 		printk("Include %s found: handle %x, start %x, end %x\n",
-		       uuid, attr->handle, gatt_include->start_handle,
+		       str, attr->handle, gatt_include->start_handle,
 		       gatt_include->end_handle);
 		break;
 	default:
-		bt_uuid_to_str(attr->uuid, uuid, sizeof(uuid));
-		printk("Descriptor %s found: handle %x\n", uuid, attr->handle);
+		bt_uuid_to_str(attr->uuid, str, sizeof(str));
+		printk("Descriptor %s found: handle %x\n", str, attr->handle);
 		break;
 	}
 


### PR DESCRIPTION
Fixes many instances of errors similar to below:
zephyr/subsys/bluetooth/controller/ll_sw/ctrl.c:5927:22:
	error: declaration of ‘s_link’ shadows a previous
			local [-Werror=shadow]
		static memq_link_t s_link;
				   ^~~~~~
zephyr/subsys/bluetooth/controller/ll_sw/ctrl.c:5905:21:
	note: shadowed declaration is here
		static memq_link_t s_link;
				   ^~~~~~

Signed-off-by: Vinayak Kariappa Chettimada <vich@nordicsemi.no>