### PR TITLE
drivers: entropy: stm32: extend support to L4 and prevent compilation when not supported

### DIFF
--- a/arch/arm/soc/st_stm32/stm32f4/Kconfig.defconfig.stm32f405xx
+++ b/arch/arm/soc/st_stm32/stm32f4/Kconfig.defconfig.stm32f405xx
@@ -15,4 +15,11 @@ config NUM_IRQS
 	int
 	default 82
 
+if ENTROPY_GENERATOR
+
+config ENTROPY_STM32_RNG
+	def_bool y
+
+endif # ENTROPY_GENERATOR
+
 endif # SOC_STM32F405XG

--- a/arch/arm/soc/st_stm32/stm32f4/Kconfig.defconfig.stm32f407xx
+++ b/arch/arm/soc/st_stm32/stm32f4/Kconfig.defconfig.stm32f407xx
@@ -15,4 +15,11 @@ config NUM_IRQS
 	int
 	default 82
 
+if ENTROPY_GENERATOR
+
+config ENTROPY_STM32_RNG
+	def_bool y
+
+endif # ENTROPY_GENERATOR
+
 endif # SOC_STM32F407XG

--- a/arch/arm/soc/st_stm32/stm32f4/Kconfig.defconfig.stm32f411xe
+++ b/arch/arm/soc/st_stm32/stm32f4/Kconfig.defconfig.stm32f411xe
@@ -15,4 +15,11 @@ config NUM_IRQS
 	int
 	default 85
 
+if ENTROPY_GENERATOR
+
+config ENTROPY_STM32_RNG
+	def_bool y
+
+endif # ENTROPY_GENERATOR
+
 endif # SOC_STM32F411XE

--- a/arch/arm/soc/st_stm32/stm32f4/Kconfig.defconfig.stm32f412zg
+++ b/arch/arm/soc/st_stm32/stm32f4/Kconfig.defconfig.stm32f412zg
@@ -15,4 +15,11 @@ config NUM_IRQS
 	int
 	default 97
 
+if ENTROPY_GENERATOR
+
+config ENTROPY_STM32_RNG
+	def_bool y
+
+endif # ENTROPY_GENERATOR
+
 endif # SOC_STM32F412ZG

--- a/arch/arm/soc/st_stm32/stm32f4/Kconfig.defconfig.stm32f413xx
+++ b/arch/arm/soc/st_stm32/stm32f4/Kconfig.defconfig.stm32f413xx
@@ -15,4 +15,11 @@ config NUM_IRQS
 	int
 	default 102
 
+if ENTROPY_GENERATOR
+
+config ENTROPY_STM32_RNG
+	def_bool y
+
+endif # ENTROPY_GENERATOR
+
 endif # SOC_STM32F413XH

--- a/arch/arm/soc/st_stm32/stm32f4/Kconfig.defconfig.stm32f417xx
+++ b/arch/arm/soc/st_stm32/stm32f4/Kconfig.defconfig.stm32f417xx
@@ -15,4 +15,11 @@ config NUM_IRQS
 	int
 	default 82
 
+if ENTROPY_GENERATOR
+
+config ENTROPY_STM32_RNG
+	def_bool y
+
+endif # ENTROPY_GENERATOR
+
 endif # SOC_STM32F417XE || SOC_STM32F417XG

--- a/arch/arm/soc/st_stm32/stm32f4/Kconfig.defconfig.stm32f429xx
+++ b/arch/arm/soc/st_stm32/stm32f4/Kconfig.defconfig.stm32f429xx
@@ -15,4 +15,11 @@ config NUM_IRQS
 	int
 	default 91
 
+if ENTROPY_GENERATOR
+
+config ENTROPY_STM32_RNG
+	def_bool y
+
+endif # ENTROPY_GENERATOR
+
 endif # SOC_STM32F429XI

--- a/arch/arm/soc/st_stm32/stm32f4/Kconfig.defconfig.stm32f469xi
+++ b/arch/arm/soc/st_stm32/stm32f4/Kconfig.defconfig.stm32f469xi
@@ -15,4 +15,11 @@ config NUM_IRQS
 	int
 	default 93
 
+if ENTROPY_GENERATOR
+
+config ENTROPY_STM32_RNG
+	def_bool y
+
+endif # ENTROPY_GENERATOR
+
 endif # SOC_STM32F469XI

--- a/arch/arm/soc/st_stm32/stm32l4/Kconfig.defconfig.series
+++ b/arch/arm/soc/st_stm32/stm32l4/Kconfig.defconfig.series
@@ -20,4 +20,11 @@ config IWDG_STM32
 
 endif # WATCHDOG
 
+if ENTROPY_GENERATOR
+
+config ENTROPY_STM32_RNG
+	def_bool y
+
+endif # ENTROPY_GENERATOR
+
 endif # SOC_SERIES_STM32L4X

--- a/drivers/entropy/entropy_stm32.c
+++ b/drivers/entropy/entropy_stm32.c
@@ -158,6 +158,29 @@ static int entropy_stm32_rng_init(struct device *dev)
 	__ASSERT_NO_MSG(dev_data != NULL);
 	__ASSERT_NO_MSG(dev_cfg != NULL);
 
+#if CONFIG_SOC_SERIES_STM32L4X
+	/* Configure PLLSA11 to enable 48M domain */
+	LL_RCC_PLLSAI1_ConfigDomain_48M(LL_RCC_PLLSOURCE_MSI,
+					LL_RCC_PLLM_DIV_1,
+					24, LL_RCC_PLLSAI1Q_DIV_2);
+
+	/* Enable PLLSA1 */
+	LL_RCC_PLLSAI1_Enable();
+
+	/*  Enable PLLSAI1 output mapped on 48MHz domain clock */
+	LL_RCC_PLLSAI1_EnableDomain_48M();
+
+	/* Wait for PLLSA1 ready flag */
+	while (LL_RCC_PLLSAI1_IsReady() != 1) {
+	}
+
+	/*  Write the peripherals independent clock configuration register :
+	 *  choose PLLSAI1 source as the 48 MHz clock is needed for the RNG
+	 *  Linear Feedback Shift Register
+	 */
+	 LL_RCC_SetRNGClockSource(LL_RCC_RNG_CLKSOURCE_PLLSAI1);
+#endif /* CONFIG_SOC_SERIES_STM32L4X */
+
 	dev_data->clock = device_get_binding(STM32_CLOCK_CONTROL_NAME);
 	__ASSERT_NO_MSG(dev_data->clock != NULL);
 

--- a/drivers/entropy/entropy_stm32.c
+++ b/drivers/entropy/entropy_stm32.c
@@ -17,6 +17,12 @@
 #include <clock_control.h>
 #include <clock_control/stm32_clock_control.h>
 
+#if !defined(CONFIG_SOC_SERIES_STM32L4X) && !defined(CONFIG_SOC_SERIES_STM32F4X)
+#error RNG only available on STM32F4 and STM32L4 series
+#elif defined(CONFIG_SOC_STM32F401XE)
+#error RNG not available on STM32F401 based SoCs
+#else
+
 struct entropy_stm32_rng_dev_cfg {
 	struct stm32_pclken pclken;
 };
@@ -181,3 +187,5 @@ DEVICE_AND_API_INIT(entropy_stm32_rng, CONFIG_ENTROPY_NAME,
 		    &entropy_stm32_rng_data, &entropy_stm32_rng_config,
 		    PRE_KERNEL_2, CONFIG_KERNEL_INIT_PRIORITY_DEVICE,
 		    &entropy_stm32_rng_api);
+
+#endif


### PR DESCRIPTION
This PR requires prior merge of #5420

Enable RNG support on L4 boards by activating 48M clock on which it depends.
Tested successfully on 3 (out of 5 available in Zephyr) STM32L4 based devices.

Enable default support on devices supporting RNG IP.
Prevent compilation on devices not supporting the IP.

Fixes: #5448