### PR TITLE
cmake: Fix the -Wl,--print-memory-usage compatibility test

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -782,7 +782,12 @@ if(CONFIG_OUTPUT_PRINT_MEMORY_USAGE)
   # it when the first link has a ram/flash-usage issue.
   set(option ${LINKERFLAGPREFIX},--print-memory-usage)
   string(MAKE_C_IDENTIFIER check${option} check)
-  check_c_compiler_flag(${option} ${check})
+
+  set(SAVED_CMAKE_REQUIRED_FLAGS CMAKE_REQUIRED_FLAGS)
+  set(CMAKE_REQUIRED_FLAGS "${CMAKE_REQUIRED_FLAGS} ${option}")
+  check_c_compiler_flag("" ${check})
+  set(CMAKE_REQUIRED_FLAGS SAVED_CMAKE_REQUIRED_FLAGS)
+
   target_link_libraries_ifdef(${check} zephyr_prebuilt ${option})
 endif()
 


### PR DESCRIPTION
-Wl,--print-memory-usage is a relatively new LD feature (2015) and is
not supported by the espressif toolchain. Unfortunately the toolchain
compatibility test was broken as it was not using the flag when
linking.

The root cause lies in how we test LD compatibility and this same fix
must be applied again in e.g. target_ld_options().

This patch fixes #5458

Signed-off-by: Sebastian Bøe <sebastian.boe@nordicsemi.no>