### PR TITLE
spi: stm32: Correctly apply CPOL and CPHA settings

### DIFF
--- a/drivers/spi/spi_ll_stm32.c
+++ b/drivers/spi/spi_ll_stm32.c
@@ -266,13 +266,13 @@ static int spi_stm32_configure(struct spi_config *config)
 	LL_SPI_Disable(spi);
 	LL_SPI_SetBaudRatePrescaler(spi, scaler[br - 1]);
 
-	if (SPI_MODE_GET(config->operation) ==  SPI_MODE_CPOL) {
+	if (SPI_MODE_GET(config->operation) & SPI_MODE_CPOL) {
 		LL_SPI_SetClockPolarity(spi, LL_SPI_POLARITY_HIGH);
 	} else {
 		LL_SPI_SetClockPolarity(spi, LL_SPI_POLARITY_LOW);
 	}
 
-	if (SPI_MODE_GET(config->operation) == SPI_MODE_CPHA) {
+	if (SPI_MODE_GET(config->operation) & SPI_MODE_CPHA) {
 		LL_SPI_SetClockPhase(spi, LL_SPI_PHASE_2EDGE);
 	} else {
 		LL_SPI_SetClockPhase(spi, LL_SPI_PHASE_1EDGE);


### PR DESCRIPTION
SPI_MODE_GET() returns a bitfield. It is thus wrong to test if a bit is
set using the equality operator. The bit-wise AND operator must be used
instead.

This can be tested by setting the SPI in mode 3 (CPOL + CPHA). Currently
both tests will fail and the result is a SPI configured in mode 0. This
was confirmed using an oscilloscope. Applying the patch fixes the
polarity.