### PR TITLE
i2c: stm32_ll: Fix spurious error while reading using IRQ

### DIFF
--- a/drivers/i2c/i2c_ll_stm32_v2.c
+++ b/drivers/i2c/i2c_ll_stm32_v2.c
@@ -90,6 +90,7 @@ void stm32_i2c_event_isr(void *arg)
 			 * was transferred
 			 */
 			LL_I2C_DisableIT_TC(i2c);
+			LL_I2C_DisableIT_RX(i2c);
 
 			/* Issue stop condition if necessary */
 			if (data->current.msg->flags & I2C_MSG_STOP) {


### PR DESCRIPTION
We can have a spurious error while performing a transfer using IRQ. This
happens when the last message of the transfer is a read with a STOP
condition. We must disable the RX interrupt while waiting for the STOP
interrupt, otherwise we will get a spurious RX interrupt which will lead
to an error.