### PR TITLE
doc/scripts/filter-doc-log: protect further against bad TERM env

### DIFF
--- a/doc/scripts/filter-doc-log.sh
+++ b/doc/scripts/filter-doc-log.sh
@@ -11,9 +11,6 @@ CONFIG_DIR=${ZEPHYR_BASE}/.known-issues/doc
 
 LOG_FILE=$1
 
-red='\E[31m'
-green='\e[32m'
-
 if [ -z "${LOG_FILE}" ]; then
         echo "Error in $0: missing input parameter <logfile>"
         exit 1
@@ -21,10 +18,14 @@ fi
 
 # When running in background, detached from terminal jobs, tput will
 # fail; we usually can tell because there is no TERM env variable.
-if [ -z "${TERM:-}" ]; then
+if [ -z "${TERM:-}" -o "${TERM:-}" = dumb ]; then
     TPUT="true"
+    red=''
+    green=''
 else
     TPUT="tput"
+    red='\E[31m'
+    green='\e[32m'
 fi
 
 if [ -s "${LOG_FILE}" ]; then


### PR DESCRIPTION
Checking for TERM being undefined before doing tput with colors is not
enough; if TERM is defined as 'dumb', this thing also behaves dumbly.

In fact, the whole trying to do colors thing is dumb and causes all
kinds of headache in corner cases, so just wrap anything smelling like
color in a check for TERM being undefined or 'dumb' and be done with
it.

It shall take care of different automation mechanisms that don't
invoke 'make htmldocs' from a user console.

Signed-off-by: Inaky Perez-Gonzalez <inaky.perez-gonzalez@intel.com>