### PR TITLE
soc: arm: stm32: fix startup SystemCoreClock values

### DIFF
--- a/arch/arm/soc/st_stm32/stm32f0/soc.c
+++ b/arch/arm/soc/st_stm32/stm32f0/soc.c
@@ -86,8 +86,8 @@ static int stm32f0_init(struct device *arg)
 	irq_unlock(key);
 
 	/* Update CMSIS SystemCoreClock variable (HCLK) */
-	/* At reset, System core clock is set to 4MHz */
-	SystemCoreClock = 4000000;
+	/* At reset, system core clock is set to 8 MHz from HSI */
+	SystemCoreClock = 8000000;
 
 	return 0;
 }

--- a/arch/arm/soc/st_stm32/stm32f1/soc.c
+++ b/arch/arm/soc/st_stm32/stm32f1/soc.c
@@ -52,7 +52,8 @@ static int stm32f1_init(struct device *arg)
 
 	irq_unlock(key);
 
-	/* At reset, SystemCoreClock is set to HSI()8MHz */
+	/* Update CMSIS SystemCoreClock variable (HCLK) */
+	/* At reset, system core clock is set to 8 MHz from HSI */
 	SystemCoreClock = 8000000;
 
 	return 0;

--- a/arch/arm/soc/st_stm32/stm32f3/soc.c
+++ b/arch/arm/soc/st_stm32/stm32f3/soc.c
@@ -53,8 +53,8 @@ static int stm32f3_init(struct device *arg)
 	irq_unlock(key);
 
 	/* Update CMSIS SystemCoreClock variable (HCLK) */
-	/* At reset, System core clock is set to 4MHz */
-	SystemCoreClock = 4000000;
+	/* At reset, system core clock is set to 8 MHz from HSI */
+	SystemCoreClock = 8000000;
 
 	return 0;
 }

--- a/arch/arm/soc/st_stm32/stm32f4/soc.c
+++ b/arch/arm/soc/st_stm32/stm32f4/soc.c
@@ -53,14 +53,9 @@ static int st_stm32f4_init(struct device *arg)
 
 	irq_unlock(key);
 
-#ifdef CONFIG_CLOCK_CONTROL_STM32_CUBE
 	/* Update CMSIS SystemCoreClock variable (HCLK) */
-	/* At reset, System core clock is set to 4MHz */
-	SystemCoreClock = 4000000;
-#else
-	/* Update CMSIS SystemCoreClock variable (HCLK) */
-	SystemCoreClock = CONFIG_SYS_CLOCK_HW_CYCLES_PER_SEC;
-#endif /* CONFIG_CLOCK_CONTROL_STM32_CUBE */
+	/* At reset, system core clock is set to 16 MHz from HSI */
+	SystemCoreClock = 16000000;
 
 	return 0;
 }

--- a/arch/arm/soc/st_stm32/stm32l4/soc.c
+++ b/arch/arm/soc/st_stm32/stm32l4/soc.c
@@ -54,7 +54,7 @@ static int stm32l4_init(struct device *arg)
 	irq_unlock(key);
 
 	/* Update CMSIS SystemCoreClock variable (HCLK) */
-	/* At reset, System core clock is set to 4MHz */
+	/* At reset, system core clock is set to 4 MHz from MSI */
 	SystemCoreClock = 4000000;
 
 	return 0;


### PR DESCRIPTION
Current STM32 SoC initialization code sets really weird startup values to
SystemCoreClock. It should be consistent with Reference Manuals after
this change.

Signed-off-by: Ilya Tagunov <tagunil@gmail.com>