### PR TITLE
gitlint: do not complain about hard tabs in body

### DIFF
--- a/.gitlint
+++ b/.gitlint
@@ -1,6 +1,6 @@
 # All these sections are optional, edit this file as you like.
 [general]
-ignore=title-trailing-punctuation, T3, title-max-length, T1
+ignore=title-trailing-punctuation, T3, title-max-length, T1, body-hard-tab, B3
 # verbosity should be a value between 1 and 3, the commandline -v flags take precedence over this
 verbosity = 3
 # By default gitlint will ignore merge commits. Set to 'false' to disable.


### PR DESCRIPTION
Was enabled by default in gitlint, nothing really bad about tabs,
especially when copy-pasting into commit messages.

Fixes #5453

Signed-off-by: Anas Nashif <anas.nashif@intel.com>