### PR TITLE
drivers/interrupt_controller: Introduce multi-level interrupt support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -630,6 +630,7 @@ if(CONFIG_GEN_ISR_TABLES)
     COMMAND ${PYTHON_EXECUTABLE}
     ${ZEPHYR_BASE}/arch/common/gen_isr_tables.py
     --output-source isr_tables.c
+    --kernel $<TARGET_FILE:zephyr_prebuilt>
     --intlist isrList.bin
     $<$<BOOL:${CMAKE_VERBOSE_MAKEFILE}>:--debug>
     --sw-isr-table

--- a/doc/kernel/other/interrupts.rst
+++ b/doc/kernel/other/interrupts.rst
@@ -57,6 +57,58 @@ nesting support is enabled.
     alter its behavior depending on whether it is executing as part of
     a thread or as part of an ISR.
 
+Multi-level Interrupt handling
+==============================
+
+A hardware platform can support more interrupt lines than natively-provided
+through the use of one or more nested interrupt controllers.  Sources of
+hardware interrupts are combined into one line that is then routed to
+the parent controller.
+
+If nested interrupt controllers are supported, :option:`CONFIG_MULTI_LEVEL_INTERRUPTS`
+should be set to 1, and :option:`CONFIG_2ND_LEVEL_INTERRUPTS` and
+:option:`CONFIG_3RD_LEVEL_INTERRUPTS` configured as well, based on the
+hardware architecture.
+
+A unique 32-bit interrupt number is assigned with information
+embedded in it to select and invoke the correct Interrupt
+Service Routine (ISR). Each interrupt level is given a byte within this 32-bit
+number, providing support for up to four interrupt levels using this arch, as
+illustrated and explained below:
+
+.. code-block:: none
+
+                 9             2   0
+           _ _ _ _ _ _ _ _ _ _ _ _ _         (LEVEL 1)
+         5       |         A   |
+       _ _ _ _ _ _ _         _ _ _ _ _ _ _   (LEVEL 2)
+         |   C                       B
+       _ _ _ _ _ _ _                         (LEVEL 3)
+               D
+
+There are three interrupt levels shown here.
+
+* LEVEL 1 has 12 interrupt lines, with two lines (2 and 9) connected
+  to nested controllers.
+* One of the LEVEL 2 controllers has interrupt line 5 connected to
+  a LEVEL 3 nested controller.
+* The other LEVEL 2 controller has no nested controllers.
+
+Here's how unique interrupt numbers are generated for each
+hardware interrupt.  Let's consider four interrupts shown above
+as A, B, C, and D:
+
+.. code-block:: none
+
+   A -> 0x00000004
+   B -> 0x00000302
+   C -> 0x00000409
+   D -> 0x00030609
+
+.. note::
+   The bit positions for LEVEL 2 and onward are offset by 1, as 0 means that
+   interrupt number is not present for that level.
+
 Preventing Interruptions
 ========================
 

--- a/drivers/interrupt_controller/Kconfig
+++ b/drivers/interrupt_controller/Kconfig
@@ -128,4 +128,6 @@ config PLIC_FE310
 
 source "drivers/interrupt_controller/Kconfig.stm32"
 
+source "drivers/interrupt_controller/Kconfig.multilevel"
+
 endmenu

--- a/drivers/interrupt_controller/Kconfig.multilevel
+++ b/drivers/interrupt_controller/Kconfig.multilevel
@@ -1,0 +1,119 @@
+# Kconfig - Multilevel interrupt configuration
+#
+# Copyright (c) 2017 Intel Corporation
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+
+config MULTI_LEVEL_INTERRUPTS
+	bool "Multi-level Interrupts"
+	default n
+	depends on GEN_SW_ISR_TABLE
+	help
+	  Multiple levels of interrupts are normally used to increase the
+	  number of addressable interrupts in a system. For e.g., if 2 levels
+	  of interrupts are used, the 2nd level controller would combine all
+	  interrupts routed to it into one line which then gets routed to one
+	  of the lines in 1st level interrupt controller.
+
+config MAX_IRQ_PER_AGGREGATOR
+	int "Max IRQs per interrupt aggregator"
+	default 0
+	depends on MULTI_LEVEL_INTERRUPTS
+	help
+	  This represents the max number of interrupts that an aggregator
+	  can map.
+
+config 2ND_LEVEL_INTERRUPTS
+	bool "Second-level Interrupts"
+	default n
+	depends on MULTI_LEVEL_INTERRUPTS
+	help
+	  Second level interrupts are used to increase the number of
+	  addressable interrupts in a system.
+
+config 2ND_LVL_ISR_TBL_OFFSET
+	int "Offset in the SW ISR Table for 2nd level interrupt controller"
+	default 0
+	depends on MULTI_LEVEL_INTERRUPTS
+	help
+	  This is the offset in the SW ISR table beginning where the ISRs for
+	  2nd level interrupts are located. This typically is allocated after
+	  allocating first level interrupts.
+
+config NUM_2ND_LEVEL_AGGREGATORS
+	hex "Total Number of Second level Interrupt Aggregators"
+	default 0
+	depends on MULTI_LEVEL_INTERRUPTS
+	help
+	  This is the number of second level interrupt aggregators present
+	  in the system. Each of these interrupt aggregators can typically
+	  map MAX_IRQ_PER_AGGREGATOR second level interrupts to one first
+	  level interrupt.
+
+config 2ND_LVL_INTR_00_OFFSET
+	hex "Parent interrupt number to which controller_0 maps"
+	default 0x00
+	depends on 2ND_LEVEL_INTERRUPTS
+	help
+	  This is the interrupt number in the first level to which
+	  controller_0 of second level maps.
+
+config 2ND_LVL_INTR_01_OFFSET
+	hex "Parent interrupt number to which controller_1 maps"
+	default 0x00
+	depends on 2ND_LEVEL_INTERRUPTS
+	help
+	  This is the interrupt number in the first level to which
+	  controller_1 of second level maps.
+
+config 2ND_LVL_INTR_02_OFFSET
+	hex "Parent interrupt number to which controller_2 maps"
+	default 0x00
+	depends on 2ND_LEVEL_INTERRUPTS
+	help
+	  This is the interrupt number in the first level to which
+	  controller_2 of second level maps.
+
+config 2ND_LVL_INTR_03_OFFSET
+	hex "Parent interrupt number to which controller_3 maps"
+	default 0x00
+	depends on 2ND_LEVEL_INTERRUPTS
+	help
+	  This is the interrupt number in the first level to which
+	  controller_3 of second level maps.
+
+config 3RD_LEVEL_INTERRUPTS
+	bool "Third-level Interrupts"
+	default n
+	depends on 2ND_LEVEL_INTERRUPTS
+	help
+	  Third level interrupts are used to increase the number of
+	  addressable interrupts in a system.
+
+config NUM_3RD_LEVEL_AGGREGATORS
+	hex "Total Number of Third level Interrupt Aggregators"
+	default 0
+	depends on 3RD_LEVEL_INTERRUPTS
+	help
+	  These are the number of third level interrupt aggregators present
+	  in the system. Each of these interrupt aggregators can typically
+	  map MAX_IRQ_PER_AGGREGATOR third level interrupts to one second
+	  level interrupt.
+
+config 3RD_LVL_ISR_TBL_OFFSET
+	int "Offset in the SW ISR Table for 3rd level interrupt controller"
+	default 0
+	depends on 3RD_LEVEL_INTERRUPTS
+	help
+	  This is the offset in the SW ISR table beginning where the ISRs for
+	  3rd level interrupts are located. This typically is allocated after
+	  allocating first and second level interrupts.
+
+config 3RD_LVL_INTR_00_OFFSET
+	hex "Parent interrupt number to which controller_0 maps"
+	default 0x00
+	depends on 3RD_LEVEL_INTERRUPTS
+	help
+	  This is the interrupt number in the second level to which
+	  controller_0 of third level maps.


### PR DESCRIPTION
In a scenario where a platform harbours multiple interrupts to the
extent the core cannot support it, an interrupt controller is added
as an additional level of interrupt. It typically combines several
sources of interrupt into one line that is then routed to the parent
controller.

Signed-off-by: Rajavardhan Gundi <rajavardhan.gundi@intel.com>