### PR TITLE
cmake: generate_inc: Change how the target name is constructed

### DIFF
--- a/cmake/extensions.cmake
+++ b/cmake/extensions.cmake
@@ -301,12 +301,17 @@ function(generate_inc_file_for_target
   # targets
 
   # But first create a unique name for the custom target
-  # Replace / with _ (driver/serial => driver_serial) and . with _
-  set(generated_target_name ${generated_file})
+  string(
+    RANDOM
+    LENGTH 8
+    random_chars
+    )
 
-  string(REPLACE "/" "_" generated_target_name ${generated_target_name})
-  string(REPLACE "." "_" generated_target_name ${generated_target_name})
-  string(REPLACE "@" "_" generated_target_name ${generated_target_name})
+  get_filename_component(basename ${generated_file} NAME)
+  string(REPLACE "." "_" basename ${basename})
+  string(REPLACE "@" "_" basename ${basename})
+
+  set(generated_target_name "gen_${basename}_${random_chars}")
 
   add_custom_target(${generated_target_name} DEPENDS ${generated_file})
   add_dependencies(${target} ${generated_target_name})


### PR DESCRIPTION
The generate_inc_file_for_target() extension is a useful wrapper
around the more low-level generate_inc_file(). It ensures
 that the generated file depends on it's source.

To do so it needs to name and define a custom_target, the name must be
unique, so it was constructed based on the path to the generated file,
but this caused multiple issues:

https://github.com/zephyrproject-rtos/zephyr/issues/5466
https://github.com/zephyrproject-rtos/zephyr/commit/2e9064b7d646e97336f9aaa867487bd9651482b1

This patch fixes #5466 by only using the basename instead of the full path
to the generated file. Also, it adds some random chars to ensure uniqueness.

Signed-off-by: Sebastian Bøe <sebastian.boe@nordicsemi.no>