### PR TITLE
cmake: esp32: Fix check for environment variable ESP_IDF_PATH

### DIFF
--- a/boards/common/esp32.board.cmake
+++ b/boards/common/esp32.board.cmake
@@ -1,7 +1,7 @@
 set(BOARD_FLASH_RUNNER esp32)
 
 if(NOT DEFINED ESP_IDF_PATH)
-  if($ENV{ESP_IDF_PATH})
+  if(DEFINED ENV{ESP_IDF_PATH})
     message(WARNING "Setting ESP_IDF_PATH in the environment is deprecated. Use cmake -DESP_IDF_PATH=... instead.")
     set(ESP_IDF_PATH $ENV{ESP_IDF_PATH})
   endif()


### PR DESCRIPTION
Environment variables should be checked with if(DEFINED
ENV{ESP_IDF_PATH}).

if($ENV{ESP_IDF_PATH}) was not evaluating to true as it should have
when env[ESP_IDF_PATH] was set.

Signed-off-by: Sebastian Bøe <sebastian.boe@nordicsemi.no>