### PR TITLE
Cmake fix target ld options

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -783,10 +783,10 @@ if(CONFIG_OUTPUT_PRINT_MEMORY_USAGE)
   set(option ${LINKERFLAGPREFIX},--print-memory-usage)
   string(MAKE_C_IDENTIFIER check${option} check)
 
-  set(SAVED_CMAKE_REQUIRED_FLAGS CMAKE_REQUIRED_FLAGS)
+  set(SAVED_CMAKE_REQUIRED_FLAGS ${CMAKE_REQUIRED_FLAGS})
   set(CMAKE_REQUIRED_FLAGS "${CMAKE_REQUIRED_FLAGS} ${option}")
   check_c_compiler_flag("" ${check})
-  set(CMAKE_REQUIRED_FLAGS SAVED_CMAKE_REQUIRED_FLAGS)
+  set(CMAKE_REQUIRED_FLAGS ${SAVED_CMAKE_REQUIRED_FLAGS})
 
   target_link_libraries_ifdef(${check} zephyr_prebuilt ${option})
 endif()

--- a/cmake/extensions.cmake
+++ b/cmake/extensions.cmake
@@ -832,7 +832,12 @@ endfunction()
 function(target_ld_options target scope)
   foreach(option ${ARGN})
     string(MAKE_C_IDENTIFIER check${option} check)
-    check_c_compiler_flag(${option} ${check})
+
+    set(SAVED_CMAKE_REQUIRED_FLAGS ${CMAKE_REQUIRED_FLAGS})
+    set(CMAKE_REQUIRED_FLAGS "${CMAKE_REQUIRED_FLAGS} ${option}")
+    check_c_compiler_flag("" ${check})
+    set(CMAKE_REQUIRED_FLAGS ${SAVED_CMAKE_REQUIRED_FLAGS})
+
     target_link_libraries_ifdef(${check} ${target} ${scope} ${option})
   endforeach()
 endfunction()


### PR DESCRIPTION
target_ld_options() was only testing whether a flag could be passed to
the compiler driver when it was compiling an object file. Not whether
a flag could be passed to the compiler driver when it was linking an
elf file.

For most flags, these tests would have the same result, but it does
not for flags like -Wl,--print-memory-usage or -Wl,notaflag.

This patch fixes #5488 by re-using the method from #5459.

Also, fixed a bug in how --print-memory-usage was saving CMAKE_REQUIRED_FLAGS.