### PR TITLE
cmake: misc. posix fixes

### DIFF
--- a/boards/posix/native_posix/Kconfig.defconfig
+++ b/boards/posix/native_posix/Kconfig.defconfig
@@ -7,6 +7,9 @@ config BUILD_OUTPUT_BIN
 config BUILD_OUTPUT_EXE
 	default y
 
+config OUTPUT_PRINT_MEMORY_USAGE
+	default n
+
 config BOARD
 	default "native_posix"
 

--- a/cmake/usage/usage.cmake
+++ b/cmake/usage/usage.cmake
@@ -7,6 +7,7 @@ set(arch_list
   arm
   nios2
   riscv32
+  posix
   x86
   xtensa
   )


### PR DESCRIPTION
Added posix to the list of arch's with boards. Usage will now show
native_posix as one of the available boards.

Signed-off-by: Sebastian Bøe <sebastian.boe@nordicsemi.no>