### PR TITLE
USB:Flush tx fifo when available space not enough

### DIFF
--- a/drivers/usb/device/usb_dc_dw.c
+++ b/drivers/usb/device/usb_dc_dw.c
@@ -41,7 +41,7 @@
 struct usb_ep_ctrl_prv {
 	u8_t ep_ena;
 	u8_t fifo_num;
-	u8_t fifo_size;
+	u32_t fifo_size;
 	u16_t mps;         /* Max ep pkt size */
 	usb_dc_ep_callback cb;/* Endpoint callback function */
 	u32_t data_len;
@@ -405,6 +405,8 @@ static int usb_dw_tx(u8_t ep, const u8_t *const data,
 		avail_space = usb_dw_tx_fifo_avail(ep_idx);
 		if (avail_space == usb_dw_ctrl.in_ep_ctrl[ep_idx].fifo_size) {
 			break;
+		} else {
+			usb_dw_flush_tx_fifo(ep_idx);
 		}
 		/* Make sure we don't hog the CPU */
 		k_yield();


### PR DESCRIPTION
This patch set does following changes

1. Flush the tx fifo when available fifo size is not same as the
    fifo size saved during IN endpoint configuration

2 .fifo_size variable type changed from u8_t to u32_t as the
    available fifo sapce read from reg range from 0 to 32768
