### PR TITLE
cmake: Introduce Zephyr interface libraries

### DIFF
--- a/cmake/extensions.cmake
+++ b/cmake/extensions.cmake
@@ -7,6 +7,7 @@ include(CheckCXXCompilerFlag)
 # 1. Zephyr-aware extensions
 # 1.1. zephyr_*
 # 1.2. zephyr_library_*
+# 1.2.1 zephyr_interface_library_*
 # 1.3. generate_inc_*
 # 1.4. board_*
 # 2. Kconfig-aware extensions
@@ -436,6 +437,36 @@ endfunction()
 function(zephyr_append_cmake_library library)
   set_property(GLOBAL APPEND PROPERTY ZEPHYR_LIBS ${library})
 endfunction()
+
+# 1.2.1 zephyr_interface_library_*
+#
+# A Zephyr interface library is a thin wrapper over a CMake INTERFACE
+# library. The most important responsibility of this abstraction is to
+# ensure that when a user KConfig-enables a library then the header
+# files of this library will be accessible to the 'app' library.
+#
+# This is done because when a user uses Kconfig to enable a library he
+# expects to be able to include it's header files and call it's
+# functions out-of-the box.
+#
+# A Zephyr interface library should be used when there exists some
+# build information (include directories, defines, compiler flags,
+# etc.) that should be applied to a set of Zephyr libraries and 'app'
+# might be one of these libraries.
+#
+# Zephyr libraries must explicitly call
+# zephyr_library_link_libraries(<interface_library>) to use this build
+# information. 'app' is treated as a special case for usability
+# reasons; a Kconfig option (CONFIG_APP_LINK_WITH_<interface_library>)
+# should exist for each interface_library and will determine if 'app'
+# links with the interface_library.
+#
+# This API has a constructor like the zephyr_library API has, but it
+# does not have wrappers over the other cmake target functions.
+macro(zephyr_interface_library_named name)
+  add_library(${name} INTERFACE)
+  set_property(GLOBAL APPEND PROPERTY ZEPHYR_INTERFACE_LIBS ${name})
+endmacro()
 
 # 1.4. board_*
 #

--- a/ext/lib/crypto/mbedtls/CMakeLists.txt
+++ b/ext/lib/crypto/mbedtls/CMakeLists.txt
@@ -1,4 +1,4 @@
-add_library(mbedTLS INTERFACE)
+zephyr_interface_library_named(mbedTLS)
 target_compile_definitions(mbedTLS INTERFACE
 	MBEDTLS_CONFIG_FILE="${CONFIG_MBEDTLS_CFG_FILE}"
 	)

--- a/ext/lib/crypto/mbedtls/Kconfig
+++ b/ext/lib/crypto/mbedtls/Kconfig
@@ -98,3 +98,12 @@ config MBEDTLS_HEAP_SIZE
 	  application. For server application 15000 bytes should be enough.
 	  For some dedicated and specific usage of mbedtls API, the 1000 bytes
 	  might be ok.
+
+config APP_LINK_WITH_MBEDTLS
+	bool "Link 'app' with MBEDTLS"
+	default y
+	depends on MBEDTLS
+	help
+	  Add MBEDTLS header files to the 'app' include path. It may be
+	  disabled if the include paths for MBEDTLS are causing aliasing
+	  issues for 'app'.

--- a/samples/net/coaps_client/CMakeLists.txt
+++ b/samples/net/coaps_client/CMakeLists.txt
@@ -1,7 +1,5 @@
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
 project(NONE)
 
-target_link_libraries(app mbedTLS)
-
 FILE(GLOB app_sources src/*.c)
 target_sources(app PRIVATE ${app_sources})

--- a/samples/net/coaps_server/CMakeLists.txt
+++ b/samples/net/coaps_server/CMakeLists.txt
@@ -1,7 +1,5 @@
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
 project(NONE)
 
-target_link_libraries(app mbedTLS)
-
 FILE(GLOB app_sources src/*.c)
 target_sources(app PRIVATE ${app_sources})

--- a/samples/net/echo_client/CMakeLists.txt
+++ b/samples/net/echo_client/CMakeLists.txt
@@ -6,5 +6,3 @@ target_sources_ifdef(CONFIG_NET_UDP app PRIVATE src/udp.c)
 target_sources_ifdef(CONFIG_NET_TCP app PRIVATE src/tcp.c)
 
 include($ENV{ZEPHYR_BASE}/samples/net/common/common.cmake)
-
-target_link_libraries_ifdef(CONFIG_MBEDTLS app mbedTLS)

--- a/samples/net/echo_server/CMakeLists.txt
+++ b/samples/net/echo_server/CMakeLists.txt
@@ -6,5 +6,3 @@ target_sources_ifdef(CONFIG_NET_UDP app PRIVATE src/udp.c)
 target_sources_ifdef(CONFIG_NET_TCP app PRIVATE src/tcp.c)
 
 include($ENV{ZEPHYR_BASE}/samples/net/common/common.cmake)
-
-target_link_libraries_ifdef(CONFIG_MBEDTLS app mbedTLS)

--- a/samples/net/http_server/CMakeLists.txt
+++ b/samples/net/http_server/CMakeLists.txt
@@ -19,5 +19,3 @@ foreach(inc_file
     ${ZEPHYR_BINARY_DIR}/include/generated/${inc_file}.inc
     )
 endforeach()
-
-target_link_libraries_ifdef(CONFIG_MBEDTLS app mbedTLS)

--- a/samples/net/lwm2m_client/CMakeLists.txt
+++ b/samples/net/lwm2m_client/CMakeLists.txt
@@ -5,5 +5,3 @@ FILE(GLOB app_sources src/*.c)
 target_sources(app PRIVATE ${app_sources})
 
 include($ENV{ZEPHYR_BASE}/samples/net/common/common.cmake)
-
-target_link_libraries_ifdef(CONFIG_MBEDTLS app mbedTLS)

--- a/samples/net/mbedtls_dtlsclient/CMakeLists.txt
+++ b/samples/net/mbedtls_dtlsclient/CMakeLists.txt
@@ -1,7 +1,5 @@
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
 project(NONE)
 
-target_link_libraries(app mbedTLS)
-
 FILE(GLOB app_sources src/*.c)
 target_sources(app PRIVATE ${app_sources})

--- a/samples/net/mbedtls_dtlsserver/CMakeLists.txt
+++ b/samples/net/mbedtls_dtlsserver/CMakeLists.txt
@@ -1,7 +1,5 @@
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
 project(NONE)
 
-target_link_libraries(app mbedTLS)
-
 FILE(GLOB app_sources src/*.c)
 target_sources(app PRIVATE ${app_sources})

--- a/samples/net/mbedtls_sslclient/CMakeLists.txt
+++ b/samples/net/mbedtls_sslclient/CMakeLists.txt
@@ -1,7 +1,5 @@
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
 project(NONE)
 
-target_link_libraries(app mbedTLS)
-
 FILE(GLOB app_sources src/*.c)
 target_sources(app PRIVATE ${app_sources})

--- a/tests/crypto/mbedtls/CMakeLists.txt
+++ b/tests/crypto/mbedtls/CMakeLists.txt
@@ -1,6 +1,5 @@
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
 project(NONE)
 
-target_link_libraries(app mbedTLS)
 FILE(GLOB app_sources src/*.c)
 target_sources(app PRIVATE ${app_sources})

--- a/tests/net/lib/mqtt_publisher/CMakeLists.txt
+++ b/tests/net/lib/mqtt_publisher/CMakeLists.txt
@@ -5,8 +5,5 @@ target_include_directories(app PRIVATE
 	$ENV{ZEPHYR_BASE}/subsys/net/ip
 	$ENV{ZEPHYR_BASE}/subsys/net/lib/mqtt
 	)
-if(CONFIG_MBEDTLS)
-target_link_libraries(app mbedTLS)
-endif()
 FILE(GLOB app_sources src/*.c)
 target_sources(app PRIVATE ${app_sources})


### PR DESCRIPTION
Introduce Zephyr interface libraries.

It is difficult to understand for which libraries an application's CMakeLists.txt will need to do
`target_link_libraries(app <some_lib>)`
`target_include_directories(app <path_to_some_other_libs_include_dir>)`
and for which it doesn't.

Intuitively, some SW components, when KConfig-enabled,
are expected to be in the 'app's include path.

This fixes #5351.

The user scenario for enabling SW components that have header files that may be 
included by app now looks like this:

1. Find and enable the component in the Kconfig menu.
2. Enable the newly visible component's Kconfig option APP_LINK_WITH_\<component> if it has not already defaulted to be enabled.
3. #include <<component_header_file>.h>

I have ported mbedTLS, as that has been causing the most issues. Porting libs to this
new scheme is backwards-compatible for apps and pretty straightforward to do.

Before Zephyr interface libraries the above use-case was covered by one of these techniques:

When a component is kconfig-enabled, globally modify the build environment with the zephyr_* API.
(This can cause aliasing issues longterm and generally might cause what should have been 
independent libraries to accidentally corrupt each other through the global environment)

Define a CMake interface library and require all zephyr libraries that use it (possibly including 'app') to call target_link_libraries(a b).

Modify the 'app' build environment, e.g. target_include_directories(app PRIVATE $ENV{ZEPHYR_BASE}/subsys/net/ip)