### PR TITLE
net: shell: conn: Cross-ref TCP control block to owning context

### DIFF
--- a/subsys/net/ip/net_shell.c
+++ b/subsys/net/ip/net_shell.c
@@ -667,8 +667,8 @@ static void tcp_cb(struct net_tcp *tcp, void *user_data)
 	int *count = user_data;
 	u16_t recv_mss = net_tcp_get_recv_mss(tcp);
 
-	printk("%p    %5u     %5u %10u %10u %5u   %s\n",
-	       tcp,
+	printk("%p %p   %5u    %5u %10u %10u %5u   %s\n",
+	       tcp, tcp->context,
 	       ntohs(net_sin6_ptr(&tcp->context->local)->sin6_port),
 	       ntohs(net_sin6(&tcp->context->remote)->sin6_port),
 	       tcp->send_seq, tcp->send_ack, recv_mss,
@@ -1161,7 +1161,7 @@ int net_shell_cmd_conn(int argc, char *argv[])
 #endif
 
 #if defined(CONFIG_NET_TCP)
-	printk("\nTCP        Src port  Dst port   Send-Seq   Send-Ack  MSS"
+	printk("\nTCP        Context   Src port Dst port   Send-Seq   Send-Ack  MSS"
 	       "%s\n", IS_ENABLED(CONFIG_NET_DEBUG_TCP) ? "    State" : "");
 
 	count = 0;


### PR DESCRIPTION
Previously "conn" command dumped TCP control blocks without
referencing it to an owning context, making it hard to figure
out what happens. Now, dump context address.

Example before:

~~~
net> conn
     Context    Iface         Flags Local               Remote
[ 1] 0x00403360 0x0041fac0    6ST   [::]:4242   [::]:0
[ 2] 0x004033c8 0x0041fac0    4ST   0.0.0.0:4242        0.0.0.0:0
[ 3] 0x00403430 0x0041fac0    6DU   [::]:4242   [::]:0
[ 4] 0x00403498 0x0041fac0    4DU   0.0.0.0:4242        0.0.0.0:0
[ 5] 0x00403500 0x0041fac0    4ST   192.0.2.1:4242      192.0.2.2:55314

TCP        Src port  Dst port   Send-Seq   Send-Ack  MSS
0x00403c00     4242         0 2541690653          0  1440
0x00403cbc     4242         0 2797902539 3233948882  1460
0x00403d78     4242     55314 2797902539 3233948882  1460
~~~

Example after:

~~~
net> conn
     Context    Iface         Flags Local               Remote
[ 1] 0x00403360 0x0041fac0    6ST   [::]:4242   [::]:0
[ 2] 0x004033c8 0x0041fac0    4ST   0.0.0.0:4242        0.0.0.0:0
[ 3] 0x00403430 0x0041fac0    6DU   [::]:4242   [::]:0
[ 4] 0x00403498 0x0041fac0    4DU   0.0.0.0:4242        0.0.0.0:0
[ 5] 0x00403500 0x0041fac0    4ST   192.0.2.1:4242      192.0.2.2:55424

TCP        Context   Src port Dst port   Send-Seq   Send-Ack  MSS
0x00403c00 0x00403360    4242        0 1854382523          0  1440
0x00403cbc 0x004033c8    4242        0 1420360158 2064582979  1460
0x00403d78 0x00403500    4242    55424 1420360158 2064582979  1460
~~~

Signed-off-by: Paul Sokolovsky <paul.sokolovsky@linaro.org>