### PR TITLE
cmake: Fix "make VERBOSE=1"

### DIFF
--- a/scripts/gen_gdt.py
+++ b/scripts/gen_gdt.py
@@ -129,6 +129,8 @@ def parse_args():
     parser.add_argument("-o", "--output-gdt", required=True,
                         help="output GDT binary")
     args = parser.parse_args()
+    if "VERBOSE" in os.environ:
+        args.verbose = 1
 
 
 def main():

--- a/scripts/gen_idt.py
+++ b/scripts/gen_idt.py
@@ -240,6 +240,8 @@ def parse_args():
     parser.add_argument("-v", "--verbose", action="store_true",
                         help="Print extra debugging information")
     args = parser.parse_args()
+    if "VERBOSE" in os.environ:
+        args.verbose = 1
 
 
 def main():

--- a/scripts/gen_kobject_list.py
+++ b/scripts/gen_kobject_list.py
@@ -608,6 +608,8 @@ def parse_args():
     parser.add_argument("-v", "--verbose", action="store_true",
                         help="Print extra debugging information")
     args = parser.parse_args()
+    if "VERBOSE" in os.environ:
+        args.verbose = 1
 
 
 def main():

--- a/scripts/gen_mmu_x86.py
+++ b/scripts/gen_mmu_x86.py
@@ -1114,6 +1114,8 @@ def parse_args():
                         help="Print debugging information. Multiple "
                              "invocations increase verbosity")
     args = parser.parse_args()
+    if "VERBOSE" in os.environ:
+        args.verbose = 1
 
 
 # the format for writing in the binary file would be decided by the

--- a/scripts/process_gperf.py
+++ b/scripts/process_gperf.py
@@ -145,7 +145,8 @@ def parse_args():
     parser.add_argument("-v", "--verbose", action="store_true",
                         help="Print extra debugging information")
     args = parser.parse_args()
-
+    if "VERBOSE" in os.environ:
+        args.verbose = 1
 
 def main():
     parse_args()

--- a/scripts/support/zephyr_flash_debug.py
+++ b/scripts/support/zephyr_flash_debug.py
@@ -17,6 +17,7 @@ such as OpenOCD, pyOCD, etc.
 import argparse
 import functools
 import sys
+import os
 
 from runner.core import ZephyrBinaryRunner
 
@@ -83,6 +84,9 @@ def main():
         handlers[cls.name()] = functools.partial(runner_handler, cls)
 
     args = top_parser.parse_args()
+    if "VERBOSE" in os.environ:
+        args.verbose = 1
+
     if args.top_command is None:
         choices = ', '.join(handlers.keys())
         print('Missing command or runner; choices: {}'.format(choices),


### PR DESCRIPTION
It is desired behaviour that when 'make VERBOSE=1' is invoked, the
underlying scripts will be invoked in 'verbose mode', e.g. they have
the flag --verbose passed to them.

This patch modifies all the underlying scripts in the build system to
inject --verbose into the command line when the environment variable
VERBOSE is set.

The environment variable VERBOSE is a CMake concept. CMake will
generate Makefile's that read this environment variable and try to
behave accordingly. Unfortunately, the generated ninja build systems
behave differently and will have to be invoked like this:

VERBOSE=1 ninja -v

This fixes #4851

Signed-off-by: Sebastian Bøe <sebastian.boe@nordicsemi.no>