### PR TITLE
ci: use updated docker v0.3-rc1

### DIFF
--- a/.shippable.yml
+++ b/.shippable.yml
@@ -23,12 +23,11 @@ build:
         - ${SHIPPABLE_BUILD_DIR}/ccache
     pre_ci_boot:
         image_name: zephyrprojectrtos/ci
-        image_tag: v0.2
+        image_tag: v0.3-rc1
         pull: true
         options: "-e HOME=/home/buildslave --privileged=true --tty --net=bridge --user buildslave"
 
     ci:
-      - sudo apt-get install gcovr gcc-6-multilib
       - export CCACHE_DIR=${SHIPPABLE_BUILD_DIR}/ccache/.ccache
       - >
         if [ "$IS_PULL_REQUEST" = "true" ]; then


### PR DESCRIPTION
This new image has new documentation and build dependencies and added
tools for dealing with coverage reports.

Signed-off-by: Anas Nashif <anas.nashif@intel.com>