### PR TITLE
subsys: bluetooth: host: mesh: shell: Fix IVIndex parsing

### DIFF
--- a/subsys/bluetooth/host/mesh/shell.c
+++ b/subsys/bluetooth/host/mesh/shell.c
@@ -1508,7 +1508,7 @@ static int cmd_provision(int argc, char *argv[])
 	addr = strtoul(argv[2], NULL, 0);
 
 	if (argc > 3) {
-		iv_index = strtoul(argv[1], NULL, 0);
+		iv_index = strtoul(argv[3], NULL, 0);
 	} else {
 		iv_index = 0;
 	}


### PR DESCRIPTION
Fix the parsing of IVIndex value from shell command line for
cmd_provision

Signed-off-by: Manivannan Sadhasivam <manivannan.sadhasivam@linaro.org>