### PR TITLE
boards: arm: 96b_neonkey: doc: Remove flash goal

### DIFF
--- a/boards/arm/96b_neonkey/doc/96b_neonkey.rst
+++ b/boards/arm/96b_neonkey/doc/96b_neonkey.rst
@@ -134,7 +134,7 @@ Here is an example for building the :ref:`hello_world` application.
 .. zephyr-app-commands::
    :zephyr-app: samples/hello_world
    :board: 96b_neonkey
-   :goals: build flash
+   :goals: build
 
 Flashing
 ========


### PR DESCRIPTION
This board doesn't support `make flash` way of programming.
So, remove that from documentation.

Signed-off-by: Manivannan Sadhasivam <manivannan.sadhasivam@linaro.org>