### PR TITLE
various: Update/fix some textual material and code comments.

### DIFF
--- a/boards/arm/disco_l475_iot1/board.h
+++ b/boards/arm/disco_l475_iot1/board.h
@@ -25,7 +25,7 @@
 /* PC_9 output: 1: LD2 off, LD3 on */
 /* PC_9 output: 0: LD2 on, LD3 off */
 /* PC_9 input: LD3 off, LD3 off */
-/* LD3 yelllow: Wifi activity */
+/* LD3 yellow: Wifi activity */
 #define LD3_GPIO_PORT	"GPIOC"
 #define LD3_GPIO_PIN	9
 /* LD4 blue: BT activity */

--- a/drivers/console/Kconfig
+++ b/drivers/console/Kconfig
@@ -91,7 +91,7 @@ config USB_UART_CONSOLE
 	  can be viewed from the USB host via /dev/ttyACM* port. Note that console
 	  inputs from the USB UART are not functional yet. Also since the USB
 	  layer currently doesn't support multiple interfaces, this shouldn't be
-	  selected in conjunction with say USB Mass Storage.
+	  selected in conjunction with, say, USB Mass Storage.
 
 config USB_UART_DTR_WAIT
 	bool

--- a/include/kernel.h
+++ b/include/kernel.h
@@ -2417,7 +2417,7 @@ static inline int k_delayed_work_submit(struct k_delayed_work *work,
  *
  * This routine computes the (approximate) time remaining before a
  * delayed work gets executed. If the delayed work is not waiting to be
- * schedules, it returns zero.
+ * scheduled, it returns zero.
  *
  * @param work     Delayed work item.
  *

--- a/include/net/net_context.h
+++ b/include/net/net_context.h
@@ -729,7 +729,7 @@ int net_context_sendto(struct net_pkt *pkt,
  * This is similar as BSD recv() function.
  * Note that net_context_bind() should be called before net_context_recv().
  * Default random port number is assigned to local port. Only bind() will
- * updates connection information from context. If recv() is called before
+ * update connection information from context. If recv() is called before
  * bind() call, it may refuse to bind to a context which already has
  * a connection associated.
  *

--- a/include/net/net_pkt.h
+++ b/include/net/net_pkt.h
@@ -1095,7 +1095,7 @@ struct net_buf *net_frag_read(struct net_buf *frag, u16_t offset,
  * length of data is placed in multiple fragments, this function will skip from
  * all fragments until it reaches N number of bytes. This function is useful
  * when unwanted data (e.g. reserved or not supported data in message) is part
- * of fragment and want to skip it.
+ * of fragment and we want to skip it.
  *
  * @param frag Network buffer fragment.
  * @param offset Offset of input buffer.

--- a/subsys/disk/Kconfig
+++ b/subsys/disk/Kconfig
@@ -21,7 +21,7 @@ config DISK_ACCESS_RAM
 	bool "RAM Disk"
 	help
 	  RAM buffer used to emulate storage disk.
-	  This option can used to test the file
+	  This option can be used to test the file
 	  system.
 
 config DISK_ACCESS_FLASH
@@ -47,7 +47,7 @@ config DISK_FLASH_MAX_RW_SIZE
 	int
 	help
 	  This is the maximum number of bytes that the
-	  flash_write API can do per invocation.
+	  flash_write API can accept per invocation.
 	  API.
 
 config DISK_FLASH_ERASE_ALIGNMENT

--- a/subsys/net/ip/ipv6.h
+++ b/subsys/net/ip/ipv6.h
@@ -89,7 +89,7 @@ struct net_ipv6_nbr_data {
 	/** Reachable timer. */
 	struct k_delayed_work reachable;
 
-	/** Neighbor Solicitation timer for DAD */
+	/** Neighbor Solicitation reply timer */
 	struct k_delayed_work send_ns;
 
 	/** State of the neighbor discovery */

--- a/subsys/net/ip/l2/ethernet.c
+++ b/subsys/net/ip/l2/ethernet.c
@@ -227,8 +227,8 @@ static enum net_verdict ethernet_send(struct net_if *iface,
 			NET_DBG("Sending arp pkt %p (orig %p) to iface %p",
 				arp_pkt, pkt, iface);
 
-			/* Either pkt went to ARP pending queue
-			 * or there was not space in the queue anymore
+			/* Either pkt went to ARP pending queue or
+			 * there was no space in the queue anymore.
 			 */
 			net_pkt_unref(pkt);
 

--- a/subsys/net/lib/app/init.c
+++ b/subsys/net/lib/app/init.c
@@ -295,7 +295,7 @@ int net_app_init(const char *app_info, u32_t flags, s32_t timeout)
 		count = timeout / 1000 + 1;
 	}
 
-	/* Loop here until until we are ready to continue. As we might need
+	/* Loop here until we are ready to continue. As we might need
 	 * to wait multiple events, sleep smaller amounts of data.
 	 */
 	while (count--) {

--- a/tests/bluetooth/tester/btp_spec.txt
+++ b/tests/bluetooth/tester/btp_spec.txt
@@ -12,7 +12,7 @@ and implementation under test (IUT).
 
 The protocol is SOCK_STREAM based and follows a strict PDU specification
 with a generic header and initial registration exchange. The communication is
-driver from tester with commands/response exchange. The protocol is single PDU
+driven from tester with commands/response exchange. The protocol is single PDU
 exchanged based, meaning every command requires a response. IUT will use events
 to signal notifications.
 


### PR DESCRIPTION
Of these, only struct net_ipv6_nbr_data::send_ns is a descriptive
change:

send_ns is used for timing Neighbor Solicitations in general, not
just for DAD.

The rest are typo/grammar fixes.

Signed-off-by: Paul Sokolovsky <paul.sokolovsky@linaro.org>