### PR TITLE
net: tcp Remove recv_max_ack field from struct net_tcp

### DIFF
--- a/subsys/net/ip/net_context.c
+++ b/subsys/net/ip/net_context.c
@@ -96,7 +96,6 @@ static int send_reset(struct net_context *context, struct sockaddr *remote);
 static struct tcp_backlog_entry {
 	struct net_tcp *tcp;
 	struct sockaddr remote;
-	u32_t recv_max_ack;
 	u32_t send_seq;
 	u32_t send_ack;
 	u16_t send_mss;
@@ -200,7 +199,6 @@ static int tcp_backlog_syn(struct net_pkt *pkt, struct net_context *context,
 		return ret;
 	}
 
-	tcp_backlog[empty_slot].recv_max_ack = context->tcp->recv_max_ack;
 	tcp_backlog[empty_slot].send_seq = context->tcp->send_seq;
 	tcp_backlog[empty_slot].send_ack = context->tcp->send_ack;
 	tcp_backlog[empty_slot].send_mss = send_mss;
@@ -235,7 +233,6 @@ static int tcp_backlog_ack(struct net_pkt *pkt, struct net_context *context)
 
 	memcpy(&context->remote, &tcp_backlog[r].remote,
 		sizeof(struct sockaddr));
-	context->tcp->recv_max_ack = tcp_backlog[r].recv_max_ack;
 	context->tcp->send_seq = tcp_backlog[r].send_seq + 1;
 	context->tcp->send_ack = tcp_backlog[r].send_ack;
 	context->tcp->send_mss = tcp_backlog[r].send_mss;
@@ -1299,7 +1296,6 @@ NET_CONN_CB(tcp_synack_received)
 	if (NET_TCP_FLAGS(tcp_hdr) & NET_TCP_SYN) {
 		context->tcp->send_ack =
 			sys_get_be32(tcp_hdr->seq) + 1;
-		context->tcp->recv_max_ack = context->tcp->send_seq + 1;
 	}
 	/*
 	 * If we receive SYN, we send SYN-ACK and go to SYN_RCVD state.
@@ -1674,7 +1670,6 @@ NET_CONN_CB(tcp_syn_rcvd)
 		context->tcp->send_seq = tcp_init_isn();
 		context->tcp->send_ack =
 			sys_get_be32(tcp_hdr->seq) + 1;
-		context->tcp->recv_max_ack = context->tcp->send_seq + 1;
 
 		/* Get MSS from TCP options here*/
 

--- a/subsys/net/ip/tcp.c
+++ b/subsys/net/ip/tcp.c
@@ -236,7 +236,6 @@ struct net_tcp *net_tcp_alloc(struct net_context *context)
 	tcp_context[i].context = context;
 
 	tcp_context[i].send_seq = tcp_init_isn();
-	tcp_context[i].recv_max_ack = tcp_context[i].send_seq + 1u;
 	tcp_context[i].recv_wnd = min(NET_TCP_MAX_WIN, NET_TCP_BUF_MAX_LEN);
 	tcp_context[i].send_mss = NET_TCP_DEFAULT_MSS;
 
@@ -521,10 +520,6 @@ int net_tcp_prepare_segment(struct net_tcp *tcp, u8_t flags,
 	}
 
 	tcp->send_seq = seq;
-
-	if (net_tcp_seq_greater(tcp->send_seq, tcp->recv_max_ack)) {
-		tcp->recv_max_ack = tcp->send_seq;
-	}
 
 	return 0;
 }

--- a/subsys/net/ip/tcp.h
+++ b/subsys/net/ip/tcp.h
@@ -133,9 +133,6 @@ struct net_tcp {
 	/** List pointer used for TCP retransmit buffering */
 	sys_slist_t sent_list;
 
-	/** Max acknowledgment. */
-	u32_t recv_max_ack;
-
 	/** Current sequence number. */
 	u32_t send_seq;
 


### PR DESCRIPTION
This field is set and maintained, but not actually used for anything.
The only purpose for it would be to validate ACK numbers from peer,
but such a validation is now implemented by using send_seq field
directly.

Fixes: #4653

Signed-off-by: Paul Sokolovsky <paul.sokolovsky@linaro.org>