### PR TITLE
cmake: net: qemu: Don't pass "-serial none" to qemu

### DIFF
--- a/cmake/emu/qemu.cmake
+++ b/cmake/emu/qemu.cmake
@@ -54,10 +54,6 @@ if(QEMU_NET_STACK)
     server
     )
 
-  list(APPEND QEMU_FLAGS
-    -serial none
-    )
-
   foreach(target ${qemu_targets})
     if((${target} STREQUAL client) OR (${target} STREQUAL server))
       list(APPEND MORE_FLAGS_FOR_${target}


### PR DESCRIPTION
I don't know why we have been passing "-serial none" to qemu but it
does not seem to be doing anything useful. So I propose we remove it.

According to the qemu documenation it should be disabling all serial
ports;

> "-serial dev
> Redirect the virtual serial port to host character device dev. The
> default device is vc in graphical mode and stdio in non graphical
> mode.
> 
> This option can be used several times to simulate up to 4 serial
> ports.
> 
> Use -serial none to disable all serial ports."

But when we use "-serial none", we always combine it with "-serial
pipe", or "-serial unix", to redirect the serial port, so clearly it
is not disabling all serial ports as it attempting to do.

"-serial none" was first introduced to Zephyr in this commit:
0b54f984b8a456041d458b5b2b004af86d152161

As far I can tell, pinging an echo_server works fine without it, so I
suspect that our second -serial flag is overriding it and that it has
no effect.

Signed-off-by: Sebastian Bøe <sebastian.boe@nordicsemi.no>