### PR TITLE
Various fixes for Ninja support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -467,7 +467,17 @@ if(CONFIG_APPLICATION_MEMORY)
       string(SUBSTRING ${fixed_path} 1 -1 fixed_path)
     endif()
 
-    list(APPEND ks "${fixed_path}lib${target_name}.a")
+    set(fixed_path "${fixed_path}lib${target_name}.a")
+
+    if(CMAKE_GENERATOR STREQUAL "Ninja")
+      # Ninja invokes the linker from the root of the build directory
+      # (APPLICATION_BINARY_DIR) instead of from the build/zephyr
+      # directory (PROJECT_BINARY_DIR). So for linker-defs.h to get
+      # the correct path we need to prefix with zephyr/.
+      set(fixed_path "zephyr/${fixed_path}")
+    endif()
+
+    list(APPEND ks ${fixed_path})
   endforeach()
 
   # We are done constructing kernel_object_file_list, now we inject this

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -540,7 +540,8 @@ function(construct_add_custom_command_for_linker_pass linker_pass_number output_
     ${ZEPHYR_INCLUDES}
     ${LINKER_SCRIPT_DEFINES}
     ${LINKER_PASS_DEFINE}
-    -E ${LINKER_SCRIPT} -P
+    -E ${LINKER_SCRIPT}
+    -P # Prevent generation of debug `#line' directives.
     -o ${linker_cmd_file_name}
     VERBATIM
     WORKING_DIRECTORY ${PROJECT_BINARY_DIR}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -500,24 +500,52 @@ if(CONFIG_APPLICATION_MEMORY)
   endforeach()
 endif() # CONFIG_APPLICATION_MEMORY
 
+function(construct_add_custom_command_for_linker_pass linker_pass_number output_variable)
+  if(linker_pass_number EQUAL 1)
+    set(is_first_pass 1)
+  elseif(linker_pass_number GREATER 1)
+    set(is_first_pass 0)
+  else()
+    assert(0 "Unreachable code")
+  endif()
+
+  if(is_first_pass)
+    set(linker_cmd_file_name linker.cmd)
+  else()
+    set(linker_cmd_file_name linker_pass${linker_pass_number}.cmd)
+  endif()
+
+  if(is_first_pass)
+    set(LINKER_PASS_DEFINE "")
+  else()
+    set(LINKER_PASS_DEFINE -DLINKER_PASS${linker_pass_number})
+  endif()
+
+  set(${output_variable}
+    OUTPUT ${linker_cmd_file_name}
+    DEPENDS ${LINKER_SCRIPT}
+    ${LINKER_SCRIPT_DEP}
+    COMMAND ${CMAKE_C_COMPILER}
+    -x assembler-with-cpp
+    ${NOSTDINC_F}
+    -undef
+    -MD -MF ${linker_cmd_file_name}.dep -MT ${BASE_NAME}/${linker_cmd_file_name}
+    ${ZEPHYR_INCLUDES}
+    ${LINKER_SCRIPT_DEFINES}
+    ${LINKER_PASS_DEFINE}
+    -E ${LINKER_SCRIPT} -P
+    -o ${linker_cmd_file_name}
+    VERBATIM
+    WORKING_DIRECTORY ${PROJECT_BINARY_DIR}
+
+    PARENT_SCOPE
+    )
+endfunction()
+
 get_filename_component(BASE_NAME ${CMAKE_CURRENT_BINARY_DIR} NAME)
+construct_add_custom_command_for_linker_pass(1 custom_command)
 add_custom_command(
-  OUTPUT linker.cmd
-  DEPENDS ${LINKER_SCRIPT}
-  ${LINKER_SCRIPT_DEP}
-  # NB: This COMMAND is copy-pasted to generate linker_pass2.cmd
-  # TODO: Remove duplication
-  COMMAND ${CMAKE_C_COMPILER}
-  -x assembler-with-cpp
-  ${NOSTDINC_F}
-  -undef
-  -MD -MF linker.cmd.dep -MT ${BASE_NAME}/linker.cmd
-  ${ZEPHYR_INCLUDES}
-  ${LINKER_SCRIPT_DEFINES}
-  -E ${LINKER_SCRIPT} -P
-  -o linker.cmd
-  VERBATIM
-  WORKING_DIRECTORY ${PROJECT_BINARY_DIR}
+  ${custom_command}
 )
 add_custom_target(
   linker_script
@@ -701,24 +729,11 @@ if(GKOF OR GKSF)
   set(logical_target_for_zephyr_elf kernel_elf)
 
   # The second linker pass uses the same source linker script of the
-  # first pass (LINKER_SCRIPT), but this time preprocessed with the
-  # define LINKER_PASS2.
+  # first pass (LINKER_SCRIPT), but this time with a different output
+  # file and preprocessed with the define LINKER_PASS2.
+  construct_add_custom_command_for_linker_pass(2 custom_command)
   add_custom_command(
-    OUTPUT linker_pass2.cmd
-    DEPENDS ${LINKER_SCRIPT}
-    ${LINKER_SCRIPT_DEP}
-    COMMAND ${CMAKE_C_COMPILER}
-    -x assembler-with-cpp
-    ${NOSTDINC_F}
-    -undef
-    -MD -MF linker_pass2.cmd.dep -MT ${BASE_NAME}/linker_pass2.cmd
-    ${ZEPHYR_INCLUDES}
-    ${LINKER_SCRIPT_DEFINES}
-    -DLINKER_PASS2
-    -E ${LINKER_SCRIPT} -P
-    -o linker_pass2.cmd
-    VERBATIM
-    WORKING_DIRECTORY ${PROJECT_BINARY_DIR}
+    ${custom_command}
     )
   add_custom_target(
     linker_pass2_script

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -396,25 +396,6 @@ endforeach()
 
 get_property(OUTPUT_FORMAT        GLOBAL PROPERTY PROPERTY_OUTPUT_FORMAT)
 
-# Run the pre-processor on the linker script
-#
-# Deal with the un-preprocessed linker scripts differently with
-# different generators.
-if(CMAKE_GENERATOR STREQUAL "Unix Makefiles")
-  # Note that the IMPLICIT_DEPENDS option is currently supported only
-  # for Makefile generators and will be ignored by other generators.
-  set(LINKER_SCRIPT_DEP IMPLICIT_DEPENDS C ${LINKER_SCRIPT})
-elseif(CMAKE_GENERATOR STREQUAL "Ninja")
-  # Using DEPFILE with other generators than Ninja is an error.
-  set(LINKER_SCRIPT_DEP DEPFILE ${PROJECT_BINARY_DIR}/linker.cmd.dep)
-else()
-  # TODO: How would the linker script dependencies work for non-linker
-  # script generators.
-  message(STATUS "Warning; this generator is not well supported. The
-  Linker script may not be regenerated when it should.")
-  set(LINKER_SCRIPT_DEP "")
-endif()
-
 get_property(LINKER_SCRIPT_DEFINES GLOBAL PROPERTY PROPERTY_LINKER_SCRIPT_DEFINES)
 
 if(CONFIG_APPLICATION_MEMORY)
@@ -519,6 +500,22 @@ function(construct_add_custom_command_for_linker_pass linker_pass_number output_
     set(LINKER_PASS_DEFINE "")
   else()
     set(LINKER_PASS_DEFINE -DLINKER_PASS${linker_pass_number})
+  endif()
+
+  # Different generators deal with depfiles differently.
+  if(CMAKE_GENERATOR STREQUAL "Unix Makefiles")
+    # Note that the IMPLICIT_DEPENDS option is currently supported only
+    # for Makefile generators and will be ignored by other generators.
+    set(LINKER_SCRIPT_DEP IMPLICIT_DEPENDS C ${LINKER_SCRIPT})
+  elseif(CMAKE_GENERATOR STREQUAL "Ninja")
+    # Using DEPFILE with other generators than Ninja is an error.
+    set(LINKER_SCRIPT_DEP DEPFILE ${PROJECT_BINARY_DIR}/${linker_cmd_file_name}.dep)
+  else()
+    # TODO: How would the linker script dependencies work for non-linker
+    # script generators.
+    message(STATUS "Warning; this generator is not well supported. The
+  Linker script may not be regenerated when it should.")
+    set(LINKER_SCRIPT_DEP "")
   endif()
 
   set(${output_variable}

--- a/include/linker/linker-defs.h
+++ b/include/linker/linker-defs.h
@@ -115,8 +115,8 @@
    archives like KBuild did.*/
 #endif
 
-#define X(i, j)  KERNEL_OBJECT_FILE_##i (j)
-#define Y(i, j) *KERNEL_OBJECT_FILE_##i
+#define X(i, j) KERNEL_OBJECT_FILE_##i (j)
+#define Y(i, j) KERNEL_OBJECT_FILE_##i
 
 #define KERNEL_INPUT_SECTION(sect) \
     UTIL_LISTIFY(NUM_KERNEL_OBJECT_FILES, X, sect)

--- a/samples/application_development/external_lib/CMakeLists.txt
+++ b/samples/application_development/external_lib/CMakeLists.txt
@@ -27,6 +27,10 @@ include(ExternalProject)
 # been committed to the repository.
 set(mylib_src_dir   ${CMAKE_CURRENT_SOURCE_DIR}/mylib)
 set(mylib_build_dir ${CMAKE_CURRENT_BINARY_DIR}/mylib)
+
+set(MYLIB_LIB_DIR     ${mylib_build_dir}/lib)
+set(MYLIB_INCLUDE_DIR ${mylib_src_dir}/include)
+
 ExternalProject_Add(
   mylib_project                 # Name for custom target
   PREFIX     ${mylib_build_dir} # Root dir for entire project
@@ -39,9 +43,8 @@ ExternalProject_Add(
   CC=${CMAKE_C_COMPILER}
   CFLAGS=${external_project_cflags}
   INSTALL_COMMAND ""      # This particular build system has no install command
+  BUILD_BYPRODUCTS ${MYLIB_LIB_DIR}/libmylib.a
   )
-set(MYLIB_INCLUDE_DIR ${mylib_src_dir}/include)
-set(MYLIB_LIB_DIR     ${mylib_build_dir}/lib)
 
 # Create a wrapper CMake library that our app can link with
 add_library(mylib_lib STATIC IMPORTED)


### PR DESCRIPTION
When building for Ninja we were accidentally using the wrong depfile
in the second pass. This commit moves the LINKER_SCRIPT_DEP logic into
the custom command function so that it can be linker-pass-aware and
set the depfile appropriately.

This should fix an issue where Ninja reported:

ninja: error: expected depfile 'zephyr/linker.cmd.dep' to mention
'zephyr/linker_pass2.cmd', got 'zephyr/linker.cmd'

But this has not been reproduced. It has however been confirmed that a
dependency issue with linker_pass2.cmd has been fixed because ninja no
longer regenerates linker_pass2.cmd on every build like this:

$ ninja
[1/79] Generating always_rebuild
Building for board qemu_x86
[2/3] Generating linker_pass2.cmd
[3/3] Linking C executable zephyr/zephyr.elf

Now:

$ ninja
[1/78] Generating always_rebuild
Building for board qemu_x86
