### PR TITLE
disk: delete GET_DISK_SIZE IOCTL

### DIFF
--- a/ext/fs/fat/zfs_diskio.c
+++ b/ext/fs/fat/zfs_diskio.c
@@ -88,7 +88,6 @@ DRESULT disk_write(BYTE pdrv, const BYTE *buff, DWORD sector, UINT count)
 DRESULT disk_ioctl(BYTE pdrv, BYTE cmd, void *buff)
 {
 	int ret =  RES_OK;
-	uint32_t tmp = 0;
 
 	switch (cmd) {
 	case CTRL_SYNC:
@@ -98,11 +97,9 @@ DRESULT disk_ioctl(BYTE pdrv, BYTE cmd, void *buff)
 		break;
 
 	case GET_SECTOR_COUNT:
-		if (disk_access_ioctl(DISK_IOCTL_GET_DISK_SIZE, &tmp) != 0) {
+		if (disk_access_ioctl(DISK_IOCTL_GET_SECTOR_COUNT, buff) != 0) {
 			ret = RES_ERROR;
-		} else {
-			*(uint32_t *) buff = (tmp / _MIN_SS) ;
-		}
+                }
 		break;
 
 	case GET_BLOCK_SIZE:

--- a/include/disk_access.h
+++ b/include/disk_access.h
@@ -29,12 +29,12 @@ extern "C" {
 #define DISK_IOCTL_GET_SECTOR_COUNT		1
 /* Get the size of a disk SECTOR in bytes */
 #define DISK_IOCTL_GET_SECTOR_SIZE		2
-/* Get the size of the disk in bytes */
-#define DISK_IOCTL_GET_DISK_SIZE		3
 /* How many  sectors constitute a FLASH Erase block */
 #define DISK_IOCTL_GET_ERASE_BLOCK_SZ		4
 /* Commit any cached read/writes to disk */
 #define DISK_IOCTL_CTRL_SYNC			5
+
+/* 3 is reserved.  It used to be DISK_IOCTL_GET_DISK_SIZE */
 
 /* Possible return bitmasks for disk_status() */
 #define DISK_STATUS_OK			0x00

--- a/subsys/disk/disk_access_flash.c
+++ b/subsys/disk/disk_access_flash.c
@@ -268,9 +268,6 @@ int disk_access_ioctl(u8_t cmd, void *buff)
 	case DISK_IOCTL_GET_ERASE_BLOCK_SZ: /* in sectors */
 		*(u32_t *)buff = CONFIG_DISK_ERASE_BLOCK_SIZE / SECTOR_SIZE;
 		return 0;
-	case DISK_IOCTL_GET_DISK_SIZE:
-		*(u32_t *)buff = CONFIG_DISK_VOLUME_SIZE;
-		return 0;
 	default:
 		break;
 	}

--- a/subsys/disk/disk_access_ram.c
+++ b/subsys/disk/disk_access_ram.c
@@ -71,9 +71,6 @@ int disk_access_ioctl(u8_t cmd, void *buff)
 	case DISK_IOCTL_GET_ERASE_BLOCK_SZ:
 		*(u32_t *)buff  = 1;
 		break;
-	case DISK_IOCTL_GET_DISK_SIZE:
-		*(u32_t *)buff  = RAMDISK_VOLUME_SIZE;
-		break;
 	default:
 		return -EINVAL;
 	}


### PR DESCRIPTION
The argument is a u32_t which limits the maximum disk size to 4 GiB.  Rather than fix this, delete the ioctl and switch the only use to GET_SECTOR_COUNT instead.

This is needed as part of #5457 to add support for SDHC cards.