### PR TITLE
libc: add EILSEQ for use in reporting checksum failure.

### DIFF
--- a/lib/libc/minimal/include/errno.h
+++ b/lib/libc/minimal/include/errno.h
@@ -126,6 +126,8 @@ extern int *__errno(void);
 #define ETIME 79   /* STREAMS timeout occurred */
 #define ENOMSG 80  /* Unexpected message type */
 
+#define EILSEQ 138 /* Illegal byte sequence */
+
 #ifdef __cplusplus
 }
 #endif


### PR DESCRIPTION
This code is commonly used in the Linux kernel for reporting a failed CRC.  This name and value is already present in Linux and newlib.

This is needed as part of #5457 to add support for SDHC cards.  I'm using this so the higher level layers can tell a fatal error from a retryable CRC or IO error.