### PR TITLE
eth: mcux: Enable ETH_MCUX_0 conditionally

### DIFF
--- a/boards/arm/frdm_k64f/Kconfig.defconfig
+++ b/boards/arm/frdm_k64f/Kconfig.defconfig
@@ -138,7 +138,7 @@ config NET_L2_ETHERNET
 	def_bool y
 
 config ETH_MCUX_0
-	def_bool y
+	def_bool y if NET_L2_ETHERNET
 
 endif # NETWORKING
 


### PR DESCRIPTION
ETH_MCUX_0 needs to be turned on when CONFIG_NET_L2_ETHERNET is enabled.
If CONFIG_NET_L2_ETHERNET is disabled (e.g. when configured for 6loble),
then ETH_MCUX_0 should remain disabled.

Signed-off-by: Vakul Garg <vakul.garg@nxp.com>