### PR TITLE
ci: sanitycheck: enable asserts again

### DIFF
--- a/.shippable.yml
+++ b/.shippable.yml
@@ -5,7 +5,7 @@ compiler: gcc
 env:
     global:
         - SDK=0.9.2
-        - SANITYCHECK_OPTIONS=" --inline-logs -N"
+        - SANITYCHECK_OPTIONS=" --inline-logs -R -N"
         - SANITYCHECK_OPTIONS_RETRY="${SANITYCHECK_OPTIONS} --only-failed --outdir=out-2nd-pass"
         - ZEPHYR_SDK_INSTALL_DIR=/opt/sdk/zephyr-sdk-0.9.2
         - ZEPHYR_GCC_VARIANT=zephyr

--- a/include/kernel.h
+++ b/include/kernel.h
@@ -1138,7 +1138,7 @@ static inline s64_t __ticks_to_ms(s64_t ticks)
 #endif
 
 #else
-	__ASSERT(ticks == 0, "");
+	__ASSERT(ticks == 0, "ticks not zero");
 	return 0;
 #endif
 }

--- a/samples/net/rpl-node/sample.yaml
+++ b/samples/net/rpl-node/sample.yaml
@@ -11,3 +11,4 @@ tests:
   test_quark_se_c1000_devboard:
     extra_args: CONF_FILE="prj_quark_se_c1000_devboard.conf"
     platform_whitelist: quark_se_c1000_devboard
+    filter: ASSERT == 0

--- a/scripts/sanitycheck
+++ b/scripts/sanitycheck
@@ -1743,7 +1743,11 @@ class TestSuite:
                         discards[instance] = "Excluded tags per platform"
                         continue
 
-                    defconfig = {"ARCH": arch.name, "PLATFORM": plat.name}
+                    defconfig = {
+                            "ASSERT": 1 if options.enable_asserts else 0,
+                            "ARCH": arch.name,
+                            "PLATFORM": plat.name
+                            }
                     defconfig.update(os.environ)
                     for p, tdefconfig in tc.defconfig.items():
                         if p == plat:

--- a/tests/Kconfig
+++ b/tests/Kconfig
@@ -11,6 +11,7 @@ source "tests/ztest/Kconfig"
 config TEST
 	bool "Mark project as a test"
 	default n
+	select COVERAGE if NATIVE_APPLICATION
 	help
 	  Mark a project or an application as a test. This will enable a few
 	  test defaults.


### PR DESCRIPTION
We were running without sanitycheck options in the final and important
run.

Signed-off-by: Anas Nashif <anas.nashif@intel.com>