### PR TITLE
ci: upload coverage data to codecov.io

### DIFF
--- a/.shippable.yml
+++ b/.shippable.yml
@@ -68,6 +68,8 @@ build:
       - rm test_file.txt
       - ccache -s
     on_failure:
+      - rm -rf ccache
+      - bash <(curl -s https://codecov.io/bash) -f '!*.lst' -X coveragepy
       - mkdir -p shippable/testresults
       - mkdir -p shippable/codecoverage
       - source zephyr-env.sh
@@ -82,6 +84,8 @@ build:
             cp ./scripts/sanity_chk/last_sanity.xml shippable/testresults/;
           fi;
     on_success:
+      - rm -rf ccache
+      - bash <(curl -s https://codecov.io/bash) -f '!*.lst' -X coveragepy
       - mkdir -p shippable/testresults
       - mkdir -p shippable/codecoverage
       - source zephyr-env.sh


### PR DESCRIPTION
Use codecov.io to track test coverage.

See https://codecov.io/gh/zephyrproject-rtos/zephyr

Signed-off-by: Anas Nashif <anas.nashif@intel.com>