### PR TITLE
ci: add .codecov.yml for codecov.io configuration/ build with -O0

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,0 +1,31 @@
+codecov:
+  notify:
+    require_ci_to_pass: yes
+
+coverage:
+  precision: 2
+  round: down
+  range: "70...100"
+
+  status:
+    project: yes
+    patch: yes
+    changes: no
+
+#ignore:
+#  - "tests/**/*"
+#  - "samples/**/*"
+#  - "ext/hal/**/*"
+
+parsers:
+  gcov:
+    branch_detection:
+      conditional: yes
+      loop: yes
+      method: no
+      macro: no
+
+comment:
+  layout: "reach, diff, flags, files, footer"
+  behavior: default
+  require_changes: no

--- a/.shippable.yml
+++ b/.shippable.yml
@@ -69,12 +69,13 @@ build:
       - ccache -s
     on_failure:
       - rm -rf ccache
-      - bash <(curl -s https://codecov.io/bash) -f '!*.lst' -X coveragepy
       - mkdir -p shippable/testresults
       - mkdir -p shippable/codecoverage
       - source zephyr-env.sh
       - gcovr -r ${ZEPHYR_BASE} -x > shippable/codecoverage/coverage.xml
+      - mv sanity-out/native_posix/ coverage_native_posix/
       - rm -rf sanity-out out-2nd-pass
+      - bash <(curl -s https://codecov.io/bash) -f '!*.lst' -X coveragepy
       - >
           if [ -e compliance.xml ]; then
             cp compliance.xml shippable/testresults/;
@@ -85,12 +86,13 @@ build:
           fi;
     on_success:
       - rm -rf ccache
-      - bash <(curl -s https://codecov.io/bash) -f '!*.lst' -X coveragepy
       - mkdir -p shippable/testresults
       - mkdir -p shippable/codecoverage
       - source zephyr-env.sh
       - gcovr -r ${ZEPHYR_BASE} -x > shippable/codecoverage/coverage.xml
+      - mv sanity-out/native_posix/ coverage_native_posix/
       - rm -rf sanity-out out-2nd-pass
+      - bash <(curl -s https://codecov.io/bash) -f '!*.lst' -X coveragepy
       - >
           if [ -e compliance.xml ]; then
             cp compliance.xml shippable/testresults/;

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -67,8 +67,13 @@ zephyr_include_directories(
 zephyr_compile_definitions(
   KERNEL
   __ZEPHYR__=1
+)
+
+if(NOT CONFIG_COVERAGE)
+zephyr_compile_definitions(
   _FORTIFY_SOURCE=2
 )
+endif()
 
 # We need to set an optimization level.
 # Default to -Os
@@ -79,10 +84,13 @@ zephyr_compile_definitions(
 #
 # Finally, the user can use Kconfig to add compiler options that will
 # come after these options and override them
-set_ifndef(OPTIMIZE_FOR_SIZE_FLAG  "-Os")
-set_ifndef(OPTIMIZE_FOR_DEBUG_FLAG "-Og")
+set_ifndef(OPTIMIZE_FOR_SIZE_FLAG     "-Os")
+set_ifndef(OPTIMIZE_FOR_DEBUG_FLAG    "-Og")
+set_ifndef(OPTIMIZE_FOR_COVERAGE_FLAG "-O0")
 if(CONFIG_DEBUG)
   set(OPTIMIZATION_FLAG ${OPTIMIZE_FOR_DEBUG_FLAG})
+elseif(CONFIG_COVERAGE)
+  set(OPTIMIZATION_FLAG ${OPTIMIZE_FOR_COVERAGE_FLAG})
 else()
   set(OPTIMIZATION_FLAG ${OPTIMIZE_FOR_SIZE_FLAG}) # Default
 endif()

--- a/tests/Kconfig
+++ b/tests/Kconfig
@@ -15,6 +15,7 @@ config TEST_EXTRA_STACKSIZE
 
 config COVERAGE
 	bool "Create coverage data"
+	depends on NATIVE_APPLICATION
 	default n
 	help
 	  This option will build your application with the -coverage option


### PR DESCRIPTION
This is the default config for codecov.io, we will exclude unrelated data once we have a good baseline.

Also build with -O0 to get more information. 
 
Fixes #5548
  