### PR TITLE
kernel: posix: typedef should be defined into types.h file.

### DIFF
--- a/include/posix/pthread.h
+++ b/include/posix/pthread.h
@@ -17,28 +17,14 @@ struct timespec {
 	s32_t tv_sec;
 	s32_t tv_nsec;
 };
-#endif
+#endif	/* CONFIG_NEWLIB_LIBC */
+
+#include "sys/types.h"
 
 static inline s32_t _ts_to_ms(const struct timespec *to)
 {
 	return (to->tv_sec * 1000) + (to->tv_nsec / 1000000);
 }
-
-typedef struct pthread_mutex {
-	struct k_sem *sem;
-} pthread_mutex_t;
-
-typedef struct pthread_mutexattr {
-	int unused;
-} pthread_mutexattr_t;
-
-typedef struct pthread_cond {
-	_wait_q_t wait_q;
-} pthread_cond_t;
-
-typedef struct pthread_condattr {
-	int unused;
-} pthread_condattr_t;
 
 /**
  * @brief Declare a pthread condition variable
@@ -259,16 +245,6 @@ static inline int pthread_mutexattr_destroy(pthread_mutexattr_t *m)
  */
 /* #define PTHREAD_MUTEX_INITIALIZER */
 /* #define PTHREAD_COND_INITIALIZER */
-
-typedef struct pthread_barrier {
-	_wait_q_t wait_q;
-	int max;
-	int count;
-} pthread_barrier_t;
-
-typedef struct pthread_barrierattr {
-	int unused;
-} pthread_barrierattr_t;
 
 /**
  * @brief Declare a pthread barrier

--- a/include/posix/sys/types.h
+++ b/include/posix/sys/types.h
@@ -1,0 +1,55 @@
+/*
+ * Copyright (c) 2018 Intel Corporation
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef __POSIX_TYPES_H__
+#define __POSIX_TYPES_H__
+
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#ifdef CONFIG_NEWLIB_LIBC
+#include_next <sys/types.h>
+#endif	/* CONFIG_NEWLIB_LIBC */
+
+#ifdef CONFIG_PTHREAD_IPC
+/* Mutex */
+typedef struct pthread_mutex {
+	struct k_sem *sem;
+} pthread_mutex_t;
+
+typedef struct pthread_mutexattr {
+	int unused;
+} pthread_mutexattr_t;
+
+/* Confition Variables */
+typedef struct pthread_cond {
+	_wait_q_t wait_q;
+} pthread_cond_t;
+
+typedef struct pthread_condattr {
+	int unused;
+} pthread_condattr_t;
+
+/* Barrier */
+typedef struct pthread_barrier {
+	_wait_q_t wait_q;
+	int max;
+	int count;
+} pthread_barrier_t;
+
+typedef struct pthread_barrierattr {
+	int unused;
+} pthread_barrierattr_t;
+
+#endif /* CONFIG_PTHREAD_IPC */
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif	/* __POSIX_TYPES_H__ */


### PR DESCRIPTION
As per POSIX standard typedef should be defined into sys/types.h file
So moving typedef from pthread.h to sys/types.h file (http://pubs.opengroup.org/onlinepubs/7908799/xsh/systypes.h.html)

Signed-off-by: Youvedeep Singh <youvedeep.singh@intel.com>