### PR TITLE
scripts: sanitycheck: If error happens accessing YAML data, go on

### DIFF
--- a/scripts/sanitycheck
+++ b/scripts/sanitycheck
@@ -1437,17 +1437,19 @@ class TestSuite:
                 try:
                     parsed_data = SanityConfigParser(
                         yaml_path, self.yaml_tc_schema)
-                except RuntimeError as e:
-                    error("E: %s: can't load: %s" % (yaml_path, e))
 
-                workdir = os.path.relpath(dirpath, testcase_root)
+                    workdir = os.path.relpath(dirpath, testcase_root)
 
-                for name in parsed_data.tests.keys():
-                    tc_dict = parsed_data.get_test(name, testcase_valid_keys)
-                    tc = TestCase(testcase_root, workdir, name, tc_dict,
-                                  yaml_path)
+                    for name in parsed_data.tests.keys():
+                        tc_dict = parsed_data.get_test(name, testcase_valid_keys)
+                        tc = TestCase(testcase_root, workdir, name, tc_dict,
+                                      yaml_path)
 
-                    self.testcases[tc.name] = tc
+                        self.testcases[tc.name] = tc
+
+                except Exception as e:
+                    error("E: %s: can't load (skipping): %s" % (yaml_path, e))
+
 
         for board_root in board_root_list:
             board_root = os.path.abspath(board_root)


### PR DESCRIPTION
Extend exception handling to cover not just YAML loading, but any
error while accessing parsed data too. That may catch e.g. schema
mismatch errors (for folks who don't have pykwalify installed, which
is optional). So, now error will be logged, but processing of other
tests will continue.

For example, I had a local, uncommitted test which wasn't converted
per 23f81eeb42668e and caused:

Traceback (most recent call last):
  File "./scripts/sanitycheck", line 2456, in <module>
    main()
  File "./scripts/sanitycheck", line 2324, in main
    options.outdir, options.coverage)
  File "./scripts/sanitycheck", line 1445, in __init__
    for name in parsed_data.tests.keys():
AttributeError: 'list' object has no attribute 'keys'

Signed-off-by: Paul Sokolovsky <paul.sokolovsky@linaro.org>