### PR TITLE
tests: test sys_kernel_version_get()

### DIFF
--- a/include/kernel_version.h
+++ b/include/kernel_version.h
@@ -26,9 +26,9 @@ extern "C" {
  *
  * Part 2: The least significant byte is reserved for future use.
  */
-#define SYS_KERNEL_VER_MAJOR(ver) ((ver >> 24) & 0xFF)
-#define SYS_KERNEL_VER_MINOR(ver) ((ver >> 16) & 0xFF)
-#define SYS_KERNEL_VER_PATCHLEVEL(ver) ((ver >> 8) & 0xFF)
+#define SYS_KERNEL_VER_MAJOR(ver) (((ver) >> 24) & 0xFF)
+#define SYS_KERNEL_VER_MINOR(ver) (((ver) >> 16) & 0xFF)
+#define SYS_KERNEL_VER_PATCHLEVEL(ver) (((ver) >> 8) & 0xFF)
 
 /* kernel version routines */
 

--- a/tests/kernel/common/src/main.c
+++ b/tests/kernel/common/src/main.c
@@ -6,7 +6,8 @@
 
 
 #include <ztest.h>
-
+#include <kernel_version.h>
+#include "version.h"
 
 extern void byteorder_test_memcpy_swap(void);
 extern void byteorder_test_mem_swap(void);
@@ -20,6 +21,20 @@ extern void dlist_test(void);
 extern void rand32_test(void);
 extern void timeout_order_test(void);
 extern void clock_test(void);
+
+
+static void test_version(void)
+{
+	u32_t version = sys_kernel_version_get();
+
+	zassert_true(SYS_KERNEL_VER_MAJOR(version) == KERNEL_VERSION_MAJOR,
+		     "major version mismatch");
+	zassert_true(SYS_KERNEL_VER_MINOR(version) == KERNEL_VERSION_MINOR,
+		     "minor version mismatch");
+	zassert_true(SYS_KERNEL_VER_PATCHLEVEL(version) == KERNEL_PATCHLEVEL,
+		     "patchlevel version match");
+
+}
 
 void test_main(void)
 {
@@ -36,7 +51,8 @@ void test_main(void)
 			 ztest_unit_test(rand32_test),
 			 ztest_unit_test(intmath_test),
 			 ztest_unit_test(timeout_order_test),
-			 ztest_unit_test(clock_test)
+			 ztest_unit_test(clock_test),
+			 ztest_unit_test(test_version)
 			 );
 
 	ztest_run_test_suite(common_test);


### PR DESCRIPTION
Basic test for sys_kernel_version_get verifying macros work correctly
and we get the expected version parts using the macros.

Signed-off-by: Anas Nashif <anas.nashif@intel.com>