### PR TITLE
Bluetooth: mesh: Fix status returned from mod_unbind

### DIFF
--- a/subsys/bluetooth/host/mesh/cfg_srv.c
+++ b/subsys/bluetooth/host/mesh/cfg_srv.c
@@ -348,11 +348,9 @@ static u8_t mod_unbind(struct bt_mesh_model *model, u16_t key_idx)
 			_mod_pub_set(model, BT_MESH_ADDR_UNASSIGNED,
 				     0, 0, 0, 0, 0);
 		}
-
-		return STATUS_SUCCESS;
 	}
 
-	return STATUS_CANNOT_BIND;
+	return STATUS_SUCCESS;
 }
 
 static struct bt_mesh_app_key *app_key_alloc(u16_t app_idx)


### PR DESCRIPTION
According to Mesh Specification v1.0 4.3.2.48 Config Model App Status:
"The Status Code shall be Success if the received request was redundant
(bind request of existing binding, or unbind of a non-existing binding),
with no further action taken."

Signed-off-by: Mariusz Skamra <mariusz.skamra@codecoup.pl>