### PR TITLE
Reduce verbosity of gen isr tables

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -617,7 +617,7 @@ if(CONFIG_GEN_ISR_TABLES)
     $ENV{ZEPHYR_BASE}/arch/common/gen_isr_tables.py
     --output-source isr_tables.c
     --intlist isrList.bin
-    --debug
+    $<$<BOOL:${CMAKE_VERBOSE_MAKEFILE}>:--debug>
     --sw-isr-table
     --vector-table
     DEPENDS zephyr_prebuilt

--- a/arch/common/gen_isr_tables.py
+++ b/arch/common/gen_isr_tables.py
@@ -12,9 +12,8 @@ import os
 ISR_FLAG_DIRECT = (1 << 0)
 
 def debug(text):
-    if not args.debug:
-        return
-    sys.stdout.write(os.path.basename(sys.argv[0]) + ": " + text + "\n")
+    if args.debug:
+        sys.stdout.write(os.path.basename(sys.argv[0]) + ": " + text + "\n")
 
 def error(text):
     sys.stderr.write(os.path.basename(sys.argv[0]) + ": " + text + "\n")


### PR DESCRIPTION
gen_isr_tables.py's --debug flag causes it to spit out a verbose
log. Normal builds don't need to see this information.

This patch will remove this from the build log:

gen_isr_tables.py: (4041, 4477, 46, 0, 7)
gen_isr_tables.py: spurious handler: 0xfc9
gen_isr_tables.py: Configured interrupt routing
gen_isr_tables.py: handler    irq flags param
gen_isr_tables.py: --------------------------
gen_isr_tables.py: 0x14bd     0   0     0x0
gen_isr_tables.py: 0x16a1     6   0     0x20002bac
gen_isr_tables.py: 0x1975     17  0     0x0
gen_isr_tables.py: 0x7e5b     13  0     0x0
gen_isr_tables.py: 0x7e55     24  0     0x0
gen_isr_tables.py: 0x7e21     11  0     0x0
gen_isr_tables.py: 0x7e5f     1   1     0x0
