### PR TITLE
Revert "Bluetooth: Mesh: Fix ignoring invalid Transport OpCode as LPN"

### DIFF
--- a/subsys/bluetooth/host/mesh/transport.c
+++ b/subsys/bluetooth/host/mesh/transport.c
@@ -1323,16 +1323,12 @@ int bt_mesh_trans_recv(struct net_buf_simple *buf, struct bt_mesh_net_rx *rx)
 	 * bt_mesh_lpn_waiting_update() function will return false:
 	 * we still need to go through the actual sending to the bearer and
 	 * wait for ReceiveDelay before transitioning to WAIT_UPDATE state.
-	 *
 	 * Another situation where we want to notify the LPN state machine
 	 * is if it's configured to use an automatic Friendship establishment
 	 * timer, in which case we want to reset the timer at this point.
 	 *
-	 * ENOENT is a special condition that's only used to indicate that
-	 * the Transport OpCode was invalid, in which case we should ignore
-	 * the PDU completely, as per MESH/NODE/FRND/LPN/BI-02-C.
 	 */
-	if (IS_ENABLED(CONFIG_BT_MESH_LOW_POWER) && err != -ENOENT &&
+	if (IS_ENABLED(CONFIG_BT_MESH_LOW_POWER) &&
 	    (bt_mesh_lpn_timer() ||
 	     (bt_mesh_lpn_established() && bt_mesh_lpn_waiting_update()))) {
 		bt_mesh_lpn_msg_received(rx);


### PR DESCRIPTION
This reverts commit ada5771d7c0f48dfebc74afa46bd73b695d72f1b.

MESH/NODE/FRND/LPN/BI-02-C in Mesh Test Specification 1.0.1
has been fixed according to TSE #9774.

IUT shall ignore the message with an RFU Transport Control Opcode
but another Friend Poll message shall be sent with an alternating
FSN value.

Signed-off-by: Mariusz Skamra <mariusz.skamra@codecoup.pl>