### PR TITLE
Bluetooth: mesh: Do not set RFU bits in Heartbeat Publication Features

### DIFF
--- a/include/bluetooth/mesh/main.h
+++ b/include/bluetooth/mesh/main.h
@@ -218,6 +218,10 @@ int bt_mesh_prov_disable(bt_mesh_prov_bearer_t bearers);
 #define BT_MESH_FEAT_PROXY                  BIT(1)
 #define BT_MESH_FEAT_FRIEND                 BIT(2)
 #define BT_MESH_FEAT_LOW_POWER              BIT(3)
+#define BT_MESH_FEAT_SUPPORTED              (BT_MESH_FEAT_RELAY |   \
+					     BT_MESH_FEAT_PROXY |   \
+					     BT_MESH_FEAT_FRIEND |  \
+					     BT_MESH_FEAT_LOW_POWER)
 
 /** @brief Initialize Mesh support
  *

--- a/subsys/bluetooth/host/mesh/cfg_srv.c
+++ b/subsys/bluetooth/host/mesh/cfg_srv.c
@@ -2797,7 +2797,7 @@ static void heartbeat_pub_set(struct bt_mesh_model *model,
 
 	cfg->hb_pub.dst = dst;
 	cfg->hb_pub.period = param->period_log;
-	cfg->hb_pub.feat = feat;
+	cfg->hb_pub.feat = feat & BT_MESH_FEAT_SUPPORTED;
 	cfg->hb_pub.net_idx = idx;
 
 	if (dst == BT_MESH_ADDR_UNASSIGNED) {


### PR DESCRIPTION
Features received in Config Heartbeat Publication Set message can have
Feature bits set to RFU values.
This patch fixes setting this RFU bits in Heartbeat Publication
Features, so that those are not indicated in Config Heartbeat
Publication Status message.

Signed-off-by: Mariusz Skamra <mariusz.skamra@codecoup.pl>