### PR TITLE
cmake: Give descriptive error to user when cloned with core.autocrlf

### DIFF
--- a/cmake/app/boilerplate.cmake
+++ b/cmake/app/boilerplate.cmake
@@ -114,6 +114,18 @@ add_custom_target(
   # Equivalent to rm -rf build/*
   )
 
+# Must be run before kconfig.cmake
+if(MSYS)
+  execute_process(
+    COMMAND
+    ${PYTHON_EXECUTABLE} $ENV{ZEPHYR_BASE}/scripts/check_host_is_ok.py
+    RESULT_VARIABLE ret
+    )
+  if(NOT "${ret}" STREQUAL "0")
+    message(FATAL_ERROR "command failed with return code: ${ret}")
+  endif()
+endif()
+
 # The BOARD can be set by 3 sources. Through environment variables,
 # through the cmake CLI, and through CMakeLists.txt.
 #

--- a/scripts/check_host_is_ok.py
+++ b/scripts/check_host_is_ok.py
@@ -1,0 +1,16 @@
+import os
+
+
+def crash_if_zephyr_was_cloned_with_wrong_line_endings():
+    f = open('{}/Kconfig'.format(os.environ["ZEPHYR_BASE"]), 'U')
+    f.readline()
+
+    error_msg = "Re-clone with autocrlf false. $ git config --global core.autocrlf false"
+
+    assert f.newlines == '\n', error_msg
+
+def main():
+    crash_if_zephyr_was_cloned_with_wrong_line_endings()
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
The windows git client is often configured to
convert the line endings from LF to CRLF when cloning repo's. This
breaks at least one of Zephyr's tools (Kconfig).

Kconfig breaks with an obscure error message that leaves users with
a bad first-impression of Zephyr ...

This patch introduces a sanity check of the environment for MSYS
users.

This fixes #5557 

Signed-off-by: Sebastian Bøe <sebastian.boe@nordicsemi.no>