### PR TITLE
drivers: i2c: stm32f4: Add check for BTF flag before reading N-2 byte

### DIFF
--- a/drivers/i2c/i2c_ll_stm32_v1.c
+++ b/drivers/i2c/i2c_ll_stm32_v1.c
@@ -461,6 +461,9 @@ s32_t stm32_i2c_msg_read(struct device *dev, struct i2c_msg *msg,
 
 			break;
 		case 3:
+			while (!LL_I2C_IsActiveFlag_BTF(i2c)) {
+				;
+			}
 			/* Set NACK before reading N-2 byte*/
 			LL_I2C_AcknowledgeNextData(i2c, LL_I2C_NACK);
 			/* Fall through */


### PR DESCRIPTION
According to STM32F4 reference manual, software should wait for BTF=1
before reading N-2 data byte.

Without this check, multi byte reception stalls at BTF check at the start of
`case 2` of `stm32_i2c_msg_read` function in polling mode.

Tested on 96Boards Carbon connected to CCS811 sensor.

Reference:

"For N >2 -byte reception, from N-2 data reception" section, page
853 of STM32F4 Reference manual.

Signed-off-by: Manivannan Sadhasivam <manivannan.sadhasivam@linaro.org>