### PR TITLE
drivers: i2c: stm32f4: Fix incorrect buffer assignment

### DIFF
--- a/drivers/i2c/i2c_ll_stm32_v1.c
+++ b/drivers/i2c/i2c_ll_stm32_v1.c
@@ -455,7 +455,7 @@ s32_t stm32_i2c_msg_read(struct device *dev, struct i2c_msg *msg,
 
 			for (u32_t counter = 2; counter > 0; counter--) {
 				len--;
-				*data->current.buf = LL_I2C_ReceiveData8(i2c);
+				*buf = LL_I2C_ReceiveData8(i2c);
 				buf++;
 			}
 


### PR DESCRIPTION
Wrong buffer assigned for receiving the last 2 bytes in multi
byte reception of STM32F4 i2c driver. Change the buffer to
correct one.

Tested on: 96Boards Carbon

Signed-off-by: Manivannan Sadhasivam <manivannan.sadhasivam@linaro.org>