### PR TITLE
boards: mps2-an385: this platform is supported by qemu

### DIFF
--- a/boards/arm/mps2_an385/board.cmake
+++ b/boards/arm/mps2_an385/board.cmake
@@ -1,0 +1,11 @@
+set(EMU_PLATFORM qemu)
+
+set(QEMU_CPU_TYPE_${ARCH} cortex-m3)
+set(QEMU_FLAGS_${ARCH}
+  -cpu ${QEMU_CPU_TYPE_${ARCH}}
+  -machine mps2-an385
+  -nographic
+  -vga none
+  )
+
+set(BOARD_DEBUG_RUNNER qemu)

--- a/boards/arm/qemu_cortex_m3/qemu_cortex_m3.yaml
+++ b/boards/arm/qemu_cortex_m3/qemu_cortex_m3.yaml
@@ -1,6 +1,7 @@
 identifier: qemu_cortex_m3
 name: QEMU Emulation for Cortex-M3
 type: qemu
+simulation: qemu
 arch: arm
 toolchain:
   - zephyr

--- a/boards/nios2/qemu_nios2/qemu_nios2.yaml
+++ b/boards/nios2/qemu_nios2/qemu_nios2.yaml
@@ -1,6 +1,7 @@
 identifier: qemu_nios2
 name: QEMU Emulation for NIOS II
 type: qemu
+simulation: qemu
 arch: nios2
 toolchain:
   - zephyr

--- a/boards/riscv32/qemu_riscv32/qemu_riscv32.yaml
+++ b/boards/riscv32/qemu_riscv32/qemu_riscv32.yaml
@@ -1,6 +1,7 @@
 identifier: qemu_riscv32
 name: QEMU Emulation for RISC V
 type: qemu
+simulation: qemu
 arch: riscv32
 toolchain:
   - zephyr

--- a/boards/x86/qemu_x86/qemu_x86.yaml
+++ b/boards/x86/qemu_x86/qemu_x86.yaml
@@ -1,6 +1,7 @@
 identifier: qemu_x86
 name: QEMU Emulation for X86
 type: qemu
+simulation: qemu
 arch: x86
 toolchain:
   - zephyr

--- a/boards/xtensa/qemu_xtensa/qemu_xtensa.yaml
+++ b/boards/xtensa/qemu_xtensa/qemu_xtensa.yaml
@@ -1,6 +1,7 @@
 identifier: qemu_xtensa
 name: QEMU Emulation for Xtensa
 type: qemu
+simulation: qemu
 arch: xtensa
 toolchain:
   - zephyr

--- a/scripts/sanity_chk/sanitycheck-platform-schema.yaml
+++ b/scripts/sanity_chk/sanitycheck-platform-schema.yaml
@@ -18,6 +18,9 @@ mapping:
   "type":
     type: str
     enum: [ 'mcu', 'qemu', 'sim', 'unit', 'native']
+  "simulation":
+    type: str
+    enum: [ 'qemu', 'simics', 'xt-sim', 'renode']
   "arch":
     type: str
   "toolchain":

--- a/scripts/sanitycheck
+++ b/scripts/sanitycheck
@@ -1247,9 +1247,10 @@ class Platform:
             for item in supp_feature.split(":"):
                 self.supported.add(item)
 
-        self.qemu_support = True if data.get('type', "na") == 'qemu' else False
+        self.qemu_support = True if data.get('simulation', "na") == 'qemu' else False
         self.arch = data['arch']
         self.type = data.get('type', "na")
+        self.simulation = data.get('simulation', "na")
         self.supported_toolchains = data.get("toolchain", [])
         self.defconfig = None
         pass


### PR DESCRIPTION
In Qemu 2.10 we can run this board configuration in Qemu directly. Make
this possible by setting the board configuration to allow emulation.

Until we have the latest QEMU in the SDK this can be used with a recent
QEMU like this:

$ mkdir build; cd build
$ cmake -DQEMU=/usr/bin/qemu-system-arm -DBOARD=mps2_an385 ..
$ make run