### PR TITLE
libc: Kconfig: Move STDOUT_CONSOLE from subsys/debug

### DIFF
--- a/lib/libc/Kconfig
+++ b/lib/libc/Kconfig
@@ -32,4 +32,14 @@ config NEWLIB_LIBC_FLOAT_SCANF
 	  Build with floating point scanf enabled. This will increase the size of
 	  the image.
 
+config STDOUT_CONSOLE
+	bool
+	prompt "Send stdout to console"
+	depends on CONSOLE_HAS_DRIVER
+	default n
+	help
+	  This option directs standard output (e.g. printf) to the console
+	  device, rather than suppressing it entirely. See also EARLY_CONSOLE
+	  option.
+
 endmenu

--- a/subsys/debug/Kconfig
+++ b/subsys/debug/Kconfig
@@ -70,15 +70,6 @@ config PRINTK_BUFFER_SIZE
 	  not have to make a system call for every character emitted. Specify
 	  the size of this buffer.
 
-config STDOUT_CONSOLE
-	bool
-	prompt "Send stdout to console"
-	depends on CONSOLE_HAS_DRIVER
-	default n
-	help
-	  This option directs standard output (e.g. printf) to the console
-	  device, rather than suppressing it entirely.
-
 config EARLY_CONSOLE
 	bool
 	prompt "Send stdout at the earliest stage possible"


### PR DESCRIPTION
This option is clearly not related to debugging, but affects libc
features.

Fixes: #5566

Signed-off-by: Paul Sokolovsky <paul.sokolovsky@linaro.org>