### PR TITLE
sanitycheck: move native_posix to the top of the list

### DIFF
--- a/.shippable.yml
+++ b/.shippable.yml
@@ -72,10 +72,16 @@ build:
       - mkdir -p shippable/testresults
       - mkdir -p shippable/codecoverage
       - source zephyr-env.sh
-      - gcovr -r ${ZEPHYR_BASE} -x > shippable/codecoverage/coverage.xml
-      - mv sanity-out/native_posix/ coverage_native_posix/
-      - rm -rf sanity-out out-2nd-pass
-      - bash <(curl -s https://codecov.io/bash) -f '!*.lst' -X coveragepy -X fixes
+      - >
+         if [ "$MATRIX_BUILD" = "1" ]; then
+            gcovr -r ${ZEPHYR_BASE} -x > shippable/codecoverage/coverage.xml;
+            mv sanity-out/native_posix/ coverage_native_posix/;
+            rm -rf sanity-out out-2nd-pass;
+            bash <(curl -s https://codecov.io/bash) -f '!*.lst' -X coveragepy -X fixes;
+            rm -rf coverage_native_posix/;
+         else
+            rm -rf sanity-out out-2nd-pass;
+         fi;
       - >
           if [ -e compliance.xml ]; then
             cp compliance.xml shippable/testresults/;
@@ -89,10 +95,16 @@ build:
       - mkdir -p shippable/testresults
       - mkdir -p shippable/codecoverage
       - source zephyr-env.sh
-      - gcovr -r ${ZEPHYR_BASE} -x > shippable/codecoverage/coverage.xml
-      - mv sanity-out/native_posix/ coverage_native_posix/
-      - rm -rf sanity-out out-2nd-pass
-      - bash <(curl -s https://codecov.io/bash) -f '!*.lst' -X coveragepy -X fixes
+      - >
+         if [ "$MATRIX_BUILD" = "1" ]; then
+            gcovr -r ${ZEPHYR_BASE} -x > shippable/codecoverage/coverage.xml;
+            mv sanity-out/native_posix/ coverage_native_posix/;
+            rm -rf sanity-out out-2nd-pass;
+            bash <(curl -s https://codecov.io/bash) -f '!*.lst' -X coveragepy -X fixes;
+            rm -rf coverage_native_posix/;
+         else
+            rm -rf sanity-out out-2nd-pass;
+         fi;
       - >
           if [ -e compliance.xml ]; then
             cp compliance.xml shippable/testresults/;

--- a/scripts/sanitycheck
+++ b/scripts/sanitycheck
@@ -177,6 +177,7 @@ import xml.etree.ElementTree as ET
 from xml.sax.saxutils import escape
 from collections import OrderedDict
 from itertools import islice
+from functools import cmp_to_key
 
 import logging
 from sanity_chk import scl
@@ -2344,14 +2345,23 @@ def main():
                     COLOR_NORMAL,
                     reason))
 
-    ts.instances = OrderedDict(
-        sorted(ts.instances.items(), key=lambda t: t[0]))
+
+    def native_posix_first(a, b):
+        if a[0].startswith('native_posix'):
+            return -1
+        if b[0].startswith('native_posix'):
+            return 1
+        return (a > b) - (a < b)
+
+    ts.instances = OrderedDict(sorted(ts.instances.items(),
+                               key=cmp_to_key(native_posix_first)))
 
     if options.save_tests:
         ts.run_report(options.save_tests)
         return
 
     if options.subset:
+
         subset, sets = options.subset.split("/")
         total = len(ts.instances)
         per_set = round(total / int(sets))


### PR DESCRIPTION
Generating coverage data is split over two CI jobs which means the service
will need to merge results and reports wrong coverage data when only 1 job
is finished. This puts the native_posix board first making sure we run on
the first job and generate data in one place.