### PR TITLE
Fix tmp112 driver for stm32 v1 i2c

### DIFF
--- a/drivers/sensor/tmp112/Kconfig
+++ b/drivers/sensor/tmp112/Kconfig
@@ -12,7 +12,11 @@ menuconfig TMP112
 	depends on I2C
 	default n
 	help
-	  Enable driver for TMP112 infrared thermopile sensors.
+	  Enable the driver for Texas Instruments TMP112 High-Accuracy Digital
+	  Temperature Sensors.
+
+	  The TMP102 is compatible with the TMP112 but is less accurate and has
+	  been successfully tested with this driver.
 
 config TMP112_NAME
 	string

--- a/drivers/sensor/tmp112/tmp112.c
+++ b/drivers/sensor/tmp112/tmp112.c
@@ -37,20 +37,8 @@ struct tmp112_data {
 static int tmp112_reg_read(struct tmp112_data *drv_data,
 			   u8_t reg, u16_t *val)
 {
-	struct i2c_msg msgs[2] = {
-		{
-			.buf = &reg,
-			.len = 1,
-			.flags = I2C_MSG_WRITE | I2C_MSG_RESTART,
-		},
-		{
-			.buf = (u8_t *)val,
-			.len = 2,
-			.flags = I2C_MSG_READ | I2C_MSG_STOP,
-		},
-	};
-
-	if (i2c_transfer(drv_data->i2c, msgs, 2, TMP112_I2C_ADDRESS) < 0) {
+	if (i2c_burst_read(drv_data->i2c, TMP112_I2C_ADDRESS,
+			   reg, (u8_t *) val, 2) < 0) {
 		return -EIO;
 	}
 
@@ -62,10 +50,10 @@ static int tmp112_reg_read(struct tmp112_data *drv_data,
 static int tmp112_reg_write(struct tmp112_data *drv_data,
 			    u8_t reg, u16_t val)
 {
-	u8_t tx_buf[3] = {reg, val >> 8, val & 0xFF};
+	u16_t val_be = sys_cpu_to_be16(val);
 
-	return i2c_write(drv_data->i2c, tx_buf, sizeof(tx_buf),
-			 TMP112_I2C_ADDRESS);
+	return i2c_burst_write(drv_data->i2c, TMP112_I2C_ADDRESS,
+			       reg, (u8_t *)&val_be, 2);
 }
 
 static int tmp112_reg_update(struct tmp112_data *drv_data, u8_t reg,


### PR DESCRIPTION
I have been testing a TMP102 SparkFun breakout board on a STM32F411RE Nucleo board with this TMP112 driver and run into some problems. Apparently the STM32 v1 I2C driver i2c_transfer() implementation does not allow the first message to have a restart condition flag set which makes sense.

This patch set fixes that and adds some comments on the use of this driver for the a TMP102 device.
  