### PR TITLE
doc: win: Specify autocrlf=false when cloning

### DIFF
--- a/doc/getting_started/installation_win.rst
+++ b/doc/getting_started/installation_win.rst
@@ -72,7 +72,7 @@ environment for Windows. Follow the steps below to set it up:
    .. code-block:: console
 
       $ cd ~
-      $ git clone https://github.com/zephyrproject-rtos/zephyr.git
+      $ git clone --config core.autocrlf=false https://github.com/zephyrproject-rtos/zephyr.git
 
 #. Install pip and the required Python modules::
 


### PR DESCRIPTION
Certain parts of Zephyr require Unix-style line-endings. To make sure
the line endings are not converted to Windows-style line-endings we
explicitly specify core.autocrlf=false when cloning.

This fixes #5557

Signed-off-by: Sebastian Bøe <sebastian.boe@nordicsemi.no>