### PR TITLE
Support cross compile

### DIFF
--- a/cmake/app/boilerplate.cmake
+++ b/cmake/app/boilerplate.cmake
@@ -88,14 +88,6 @@ include(${ZEPHYR_BASE}/cmake/extensions.cmake)
 
 find_package(PythonInterp 3.4)
 
-if(NOT ZEPHYR_GCC_VARIANT)
-  set(ZEPHYR_GCC_VARIANT $ENV{ZEPHYR_GCC_VARIANT})
-endif()
-set(ZEPHYR_GCC_VARIANT ${ZEPHYR_GCC_VARIANT} CACHE STRING "Zephyr GCC variant")
-if(NOT ZEPHYR_GCC_VARIANT)
-  message(FATAL_ERROR "ZEPHYR_GCC_VARIANT not set")
-endif()
-
 if(${CMAKE_CURRENT_SOURCE_DIR} STREQUAL ${CMAKE_CURRENT_BINARY_DIR})
   message(FATAL_ERROR "Source directory equals build directory.\
  In-source builds are not supported.\

--- a/cmake/toolchain-cross-compile.cmake
+++ b/cmake/toolchain-cross-compile.cmake
@@ -1,0 +1,40 @@
+# CROSS_COMPILE is a KBuild mechanism for specifying an external
+# toolchain with a single environment variable.
+#
+# It is a legacy mechanism that will in Zephyr translate to
+# specififying ZEPHYR_GCC_VARIANT to 'cross-compile' with the location
+# 'CROSS_COMPILE'.
+#
+# New users should set the env var 'ZEPHYR_GCC_VARIANT' to
+# 'cross-compile' and the 'CROSS_COMPILE' env var to the toolchain
+# prefix. This interface is consisent with the other non-"Zephyr SDK"
+# toolchains.
+#
+# It can be set from three sources, the KConfig option
+# CONFIG_CROSS_COMPILE, the CMake var CROSS_COMPILE, or the env var
+# CROSS_COMPILE.
+#
+# The env var has the lowest precedence.
+#
+# It is not clear what should have the highest precedence of a Kconfig
+# option and a CMake var so an error is triggered if they are both
+# defined, but are defined with different values.
+
+if(CONFIG_CROSS_COMPILE AND CROSS_COMPILE)
+  if(NOT (${CONFIG_CROSS_COMPILE} STREQUAL ${CROSS_COMPILE}))
+    message(FATAL_ERROR "The Kconfig and CMake var's must match when defined simultaneously:
+CONFIG_CROSS_COMPILE: ${CONFIG_CROSS_COMPILE}
+CROSS_COMPILE: ${CROSS_COMPILE}")
+  endif()
+endif()
+
+if(CONFIG_CROSS_COMPILE)
+  set(CROSS_COMPILE ${CONFIG_CROSS_COMPILE})
+elseif(DEFINED ENV{CROSS_COMPILE})
+  set(CROSS_COMPILE $ENV{CROSS_COMPILE})
+endif()
+
+set(   CROSS_COMPILE ${CROSS_COMPILE} CACHE PATH "")
+assert(CROSS_COMPILE "CROSS_COMPILE is not set")
+
+set(COMPILER gcc)

--- a/cmake/toolchain-gcc.cmake
+++ b/cmake/toolchain-gcc.cmake
@@ -93,8 +93,12 @@ assert(LIBGCC_DIR "LIBGCC_DIR not found")
 LIST(APPEND LIB_INCLUDE_DIR "-L\"${LIBGCC_DIR}\"")
 LIST(APPEND TOOLCHAIN_LIBS gcc)
 
-set(LIBC_INCLUDE_DIR ${SYSROOT_DIR}/include)
-set(LIBC_LIBRARY_DIR "\"${SYSROOT_DIR}\"/lib/${NEWLIB_DIR}")
+if(SYSROOT_DIR)
+  # The toolchain has specified a sysroot dir that we can use to set
+  # the libc path's
+  set(LIBC_INCLUDE_DIR ${SYSROOT_DIR}/include)
+  set(LIBC_LIBRARY_DIR "\"${SYSROOT_DIR}\"/lib/${NEWLIB_DIR}")
+endif()
 
 # For CMake to be able to test if a compiler flag is supported by the
 # toolchain we need to give CMake the necessary flags to compile and

--- a/cmake/toolchain-gcc.cmake
+++ b/cmake/toolchain-gcc.cmake
@@ -76,7 +76,7 @@ endif()
 
 execute_process(
   COMMAND ${CMAKE_C_COMPILER} ${TOOLCHAIN_C_FLAGS} --print-libgcc-file-name
-  OUTPUT_VARIABLE LIBGCC_DIR
+  OUTPUT_VARIABLE LIBGCC_FILE_NAME
   OUTPUT_STRIP_TRAILING_WHITESPACE
   )
 
@@ -86,9 +86,11 @@ execute_process(
   OUTPUT_STRIP_TRAILING_WHITESPACE
   )
 
-get_filename_component(LIBGCC_DIR ${LIBGCC_DIR} DIRECTORY)
+assert_exists(LIBGCC_FILE_NAME)
 
-assert(LIBGCC_DIR "LIBGCC_DIR not found")
+get_filename_component(LIBGCC_DIR ${LIBGCC_FILE_NAME} DIRECTORY)
+
+assert_exists(LIBGCC_DIR)
 
 LIST(APPEND LIB_INCLUDE_DIR "-L\"${LIBGCC_DIR}\"")
 LIST(APPEND TOOLCHAIN_LIBS gcc)

--- a/cmake/toolchain-host-gcc.cmake
+++ b/cmake/toolchain-host-gcc.cmake
@@ -1,5 +1,4 @@
-# Configures CMake for using GCC, this script is re-used by several
-# GCC-based toolchains
+# Configures CMake for using GCC
 
 set(CMAKE_C_COMPILER   gcc     CACHE INTERNAL " " FORCE)
 set(CMAKE_OBJCOPY      objcopy CACHE INTERNAL " " FORCE)
@@ -12,8 +11,6 @@ set(CMAKE_GDB          gdb     CACHE INTERNAL " " FORCE)
 set(CMAKE_C_FLAGS 	-m32   CACHE INTERNAL " " FORCE)
 set(CMAKE_CXX_FLAGS 	-m32   CACHE INTERNAL " " FORCE)
 set(CMAKE_SHARED_LINKER_FLAGS -m32 CACHE INTERNAL " " FORCE)
-
-#assert_exists(CMAKE_READELF)
 
 if(CONFIG_CPLUSPLUS)
   set(cplusplus_compiler g++)

--- a/cmake/toolchain.cmake
+++ b/cmake/toolchain.cmake
@@ -8,11 +8,23 @@ set(CMAKE_FIND_ROOT_PATH_MODE_LIBRARY ONLY)
 set(CMAKE_FIND_ROOT_PATH_MODE_INCLUDE ONLY)
 set(CMAKE_FIND_ROOT_PATH_MODE_PACKAGE ONLY)
 
+if(NOT ZEPHYR_GCC_VARIANT)
+  if(DEFINED ENV{ZEPHYR_GCC_VARIANT})
+    set(ZEPHYR_GCC_VARIANT $ENV{ZEPHYR_GCC_VARIANT})
+  elseif(CROSS_COMPILE OR CONFIG_CROSS_COMPILE OR (DEFINED ENV{CROSS_COMPILE}))
+    set(ZEPHYR_GCC_VARIANT cross-compile)
+  endif()
+endif()
+set(ZEPHYR_GCC_VARIANT ${ZEPHYR_GCC_VARIANT} CACHE STRING "Zephyr GCC variant")
+assert(ZEPHYR_GCC_VARIANT "")
+
+if(CONFIG_ARCH_POSIX OR (ZEPHYR_GCC_VARIANT STREQUAL "host"))
+  set(COMPILER host-gcc)
+endif()
+
 # Configure the toolchain based on what SDK/toolchain is in use.
-if(ZEPHYR_GCC_VARIANT STREQUAL "host" OR CONFIG_ARCH_POSIX)
-	set(COMPILER host-gcc)
-else()
-include(${ZEPHYR_BASE}/cmake/toolchain-${ZEPHYR_GCC_VARIANT}.cmake)
+if(NOT (COMPILER STREQUAL "host-gcc"))
+  include(${ZEPHYR_BASE}/cmake/toolchain-${ZEPHYR_GCC_VARIANT}.cmake)
 endif()
 
 # Configure the toolchain based on what toolchain technology is used

--- a/cmake/toolchain.cmake
+++ b/cmake/toolchain.cmake
@@ -16,5 +16,5 @@ include(${ZEPHYR_BASE}/cmake/toolchain-${ZEPHYR_GCC_VARIANT}.cmake)
 endif()
 
 # Configure the toolchain based on what toolchain technology is used
-# (gcc clang etc.)
+# (gcc, host-gcc etc.)
 include(${ZEPHYR_BASE}/cmake/toolchain-${COMPILER}.cmake OPTIONAL)

--- a/lib/libc/newlib/CMakeLists.txt
+++ b/lib/libc/newlib/CMakeLists.txt
@@ -1,11 +1,24 @@
 zephyr_library()
 zephyr_library_sources(libc-hooks.c)
 
-zephyr_include_directories(${LIBC_INCLUDE_DIR})
+# LIBC_*_DIR may or may not have been set by the toolchain. E.g. when
+# using ZEPHYR_GCC_VARIANT=cross-compile it will be either up to the
+# toolchain to know where it's libc implementation is, or if it is
+# unable to, it will be up to the user to specify LIBC_*_DIR vars to
+# point to a newlib implementation.
+
+if(LIBC_INCLUDE_DIR)
+  zephyr_include_directories(${LIBC_INCLUDE_DIR})
+endif()
+
+if(LIBC_LIBRARY_DIR)
+  set(LIBC_LIBRARY_DIR_FLAG -L${LIBC_LIBRARY_DIR})
+endif()
+
 zephyr_link_libraries(
   m
   c
-  -L${LIBC_LIBRARY_DIR}
+  ${LIBC_LIBRARY_DIR_FLAG} # NB: Optional
   $<$<BOOL:${CONFIG_NEWLIB_LIBC_FLOAT_PRINTF}>:-u_printf_float>
   $<$<BOOL:${CONFIG_NEWLIB_LIBC_FLOAT_SCANF}>:-u_scanf_float>
   gcc # Lib C depends on libgcc. e.g. libc.a(lib_a-fvwrite.o) references __aeabi_idiv


### PR DESCRIPTION
CROSS_COMPILE is a KBuild feature that was dropped during the CMake
migration. It is now re-introduced. Documentation for it is still
lacking, but at least it now behaves as expected.

This fixes #5589