### PR TITLE
syslog: enable INFO by default [RFC]

### DIFF
--- a/arch/x86/soc/intel_quark/quark_se/soc.c
+++ b/arch/x86/soc/intel_quark/quark_se/soc.c
@@ -15,13 +15,14 @@
 #include <errno.h>
 
 #include <kernel.h>
-#include <misc/printk.h>
 #include <misc/__assert.h>
 #include "soc.h"
 #include <uart.h>
 #include <init.h>
 #include "shared_mem.h"
 #include <mmustructs.h>
+#define SYS_LOG_LEVEL CONFIG_SYS_LOG_ARC_INIT_LEVEL
+#include <logging/sys_log.h>
 
 
 #ifdef CONFIG_X86_MMU
@@ -50,9 +51,6 @@ MMU_BOOT_REGION(0xB0500000, 256*1024, MMU_ENTRY_WRITE);
 #define SCSS_REG_VAL(offset) \
 	(*((volatile u32_t *)(SCSS_REGISTER_BASE+offset)))
 
-#define SYS_LOG_LEVEL CONFIG_SYS_LOG_ARC_INIT_LEVEL
-#include <logging/sys_log.h>
-
 /**
  *
  * @brief ARC Init
@@ -70,7 +68,7 @@ int _arc_init(struct device *arg)
 
 	if (!SCSS_REG_VAL(SCSS_SS_STS)) {
 		/* ARC shouldn't already be running! */
-		printk("ARC core already running!");
+		SYS_LOG_ERR("ARC core already running!");
 		return -EIO;
 	}
 

--- a/arch/x86/soc/intel_quark/quark_x1000/soc.c
+++ b/arch/x86/soc/intel_quark/quark_x1000/soc.c
@@ -18,7 +18,6 @@
 #include <kernel.h>
 #include <init.h>
 #include <device.h>
-#include <misc/printk.h>
 #include <misc/__assert.h>
 #include "soc.h"
 #include <uart.h>

--- a/boards/arm/efm32wg_stk3800/board.c
+++ b/boards/arm/efm32wg_stk3800/board.c
@@ -7,7 +7,7 @@
 #include <init.h>
 #include <board.h>
 #include <gpio.h>
-#include <misc/printk.h>
+#include <logging/sys_log.h>
 
 static int efm32wg_stk3800_init(struct device *dev)
 {
@@ -19,7 +19,7 @@ static int efm32wg_stk3800_init(struct device *dev)
 	bce_dev = device_get_binding(BC_ENABLE_GPIO_NAME);
 
 	if (!bce_dev) {
-		printk("Board controller gpio port was not found!\n");
+		SYS_LOG_ERR("Board controller gpio port was not found!");
 		return -ENODEV;
 	}
 

--- a/drivers/console/ipm_console_receiver.c
+++ b/drivers/console/ipm_console_receiver.c
@@ -10,11 +10,12 @@
 
 #include <kernel.h>
 #include <ring_buffer.h>
-#include <misc/printk.h>
 #include <stdio.h>
 #include <ipm.h>
 #include <console/ipm_console.h>
 #include <misc/__assert.h>
+#include <misc/printk.h>
+#include <logging/sys_log.h>
 
 static void ipm_console_thread(void *arg1, void *arg2, void *arg3)
 {
@@ -41,7 +42,7 @@ static void ipm_console_thread(void *arg1, void *arg2, void *arg3)
 				       NULL, &size32);
 		if (ret) {
 			/* Shouldn't ever happen... */
-			printk("ipm console ring buffer error: %d\n", ret);
+			SYS_LOG_ERR("ipm console ring buffer error: %d", ret);
 			size32 = 0;
 			continue;
 		}
@@ -125,13 +126,13 @@ int ipm_console_receiver_init(struct device *d)
 	ipm = device_get_binding(config_info->bind_to);
 
 	if (!ipm) {
-		printk("unable to bind IPM console receiver to '%s'\n",
+		SYS_LOG_ERR("unable to bind IPM console receiver to '%s'",
 		       config_info->bind_to);
 		return -EINVAL;
 	}
 
 	if (ipm_max_id_val_get(ipm) < 0xFF) {
-		printk("IPM driver %s doesn't support 8-bit id values",
+		SYS_LOG_ERR("IPM driver %s doesn't support 8-bit id values",
 		       config_info->bind_to);
 		return -EINVAL;
 	}

--- a/drivers/console/ipm_console_sender.c
+++ b/drivers/console/ipm_console_sender.c
@@ -9,7 +9,7 @@
 #include <errno.h>
 
 #include <kernel.h>
-#include <misc/printk.h>
+#include <logging/sys_log.h>
 #include <ipm.h>
 #include <console/ipm_console.h>
 
@@ -41,7 +41,7 @@ int ipm_console_sender_init(struct device *d)
 	ipm_console_device = device_get_binding(config_info->bind_to);
 
 	if (!ipm_console_device) {
-		printk("unable to bind IPM console sender to '%s'\n",
+		SYS_LOG_ERR("unable to bind IPM console sender to '%s'",
 		       config_info->bind_to);
 		return -EINVAL;
 	}

--- a/drivers/console/ram_console.c
+++ b/drivers/console/ram_console.c
@@ -8,7 +8,6 @@
 
 
 #include <kernel.h>
-#include <misc/printk.h>
 #include <device.h>
 #include <init.h>
 

--- a/drivers/console/rtt_console.c
+++ b/drivers/console/rtt_console.c
@@ -10,7 +10,6 @@
 
 
 #include <kernel.h>
-#include <misc/printk.h>
 #include <device.h>
 #include <init.h>
 #include <rtt/SEGGER_RTT.h>

--- a/drivers/console/uart_pipe.c
+++ b/drivers/console/uart_pipe.c
@@ -12,12 +12,9 @@
  */
 
 #include <kernel.h>
-
 #include <board.h>
 #include <uart.h>
-
 #include <console/uart_pipe.h>
-#include <misc/printk.h>
 
 static struct device *uart_pipe_dev;
 

--- a/drivers/entropy/entropy_stm32.c
+++ b/drivers/entropy/entropy_stm32.c
@@ -13,7 +13,6 @@
 #include <misc/util.h>
 #include <errno.h>
 #include <soc.h>
-#include <misc/printk.h>
 #include <clock_control.h>
 #include <clock_control/stm32_clock_control.h>
 

--- a/drivers/ethernet/eth_stm32_hal.c
+++ b/drivers/ethernet/eth_stm32_hal.c
@@ -16,7 +16,6 @@
 #include <net/net_pkt.h>
 #include <net/net_if.h>
 #include <soc.h>
-#include <misc/printk.h>
 #include <clock_control.h>
 #include <clock_control/stm32_clock_control.h>
 

--- a/drivers/ipm/ipm_quark_se.c
+++ b/drivers/ipm/ipm_quark_se.c
@@ -13,7 +13,6 @@
 #include <init.h>
 #include <ipm.h>
 #include <arch/cpu.h>
-#include <misc/printk.h>
 #include <misc/__assert.h>
 #include <errno.h>
 #include "ipm_quark_se.h"

--- a/drivers/net/loopback.c
+++ b/drivers/net/loopback.c
@@ -14,9 +14,6 @@
 #define SYS_LOG_DOMAIN "netlo"
 #define SYS_LOG_LEVEL CONFIG_SYS_LOG_NETLO_LEVEL
 #include <logging/sys_log.h>
-
-#include <misc/printk.h>
-
 #include <net/net_pkt.h>
 #include <net/buf.h>
 #include <net/net_ip.h>

--- a/drivers/pci/pci.c
+++ b/drivers/pci/pci.c
@@ -71,11 +71,11 @@
 
 #include <kernel.h>
 #include <arch/cpu.h>
-#include <misc/printk.h>
 #include <toolchain.h>
 #include <linker/sections.h>
 
 #include <board.h>
+#include <logging/sys_log.h>
 
 #include <pci/pci_mgr.h>
 #include <pci/pci.h>
@@ -419,9 +419,7 @@ static void pci_set_command_bits(struct pci_dev_info *dev_info, u32_t bits)
 	pci_ctrl_addr.field.device = dev_info->dev;
 	pci_ctrl_addr.field.reg = 1;
 
-#ifdef CONFIG_PCI_DEBUG
-	printk("pci_set_command_bits 0x%x\n", pci_ctrl_addr.value);
-#endif
+	SYS_LOG_DBG("pci_set_command_bits 0x%x", pci_ctrl_addr.value);
 
 	pci_read(DEFAULT_PCI_CONTROLLER,
 			pci_ctrl_addr,
@@ -458,9 +456,9 @@ void pci_enable_bus_master(struct pci_dev_info *dev_info)
 
 void pci_show(struct pci_dev_info *dev_info)
 {
-	printk("PCI device:\n");
-	printk("%u:%u %X:%X class: 0x%X, %u, %u, %s,"
-		"addrs: 0x%X-0x%X, IRQ %d\n",
+	SYS_LOG_INF("PCI device:");
+	SYS_LOG_INF("%u:%u %X:%X class: 0x%X, %u, %u, %s,"
+		"addrs: 0x%X-0x%X, IRQ %d",
 		dev_info->bus,
 		dev_info->dev,
 		dev_info->vendor_id,

--- a/drivers/sensor/adxl362/adxl362.c
+++ b/drivers/sensor/adxl362/adxl362.c
@@ -10,9 +10,7 @@
 #include <sensor.h>
 #include <init.h>
 #include <gpio.h>
-#include <misc/printk.h>
 #include <misc/byteorder.h>
-#include <misc/__assert.h>
 #include <spi.h>
 
 #include "adxl362.h"

--- a/drivers/timer/Kconfig
+++ b/drivers/timer/Kconfig
@@ -30,13 +30,6 @@ config HPET_TIMER_LEGACY_EMULATION
 	  In this mode 8254 PIT is disabled, HPET timer0 is connected
 	  to IOAPIC IRQ2, timer1 -- to IOAPIC IRQ8.
 
-config HPET_TIMER_DEBUG
-	bool "Enable HPET debug output"
-	default n
-	depends on HPET_TIMER && PRINTK
-	help
-	  This option enables HPET debugging output.
-
 config HPET_TIMER_BASE_ADDRESS
 	hex "HPET Base Address"
 	default 0xFED00000

--- a/drivers/timer/hpet.c
+++ b/drivers/timer/hpet.c
@@ -48,6 +48,7 @@
 #include <drivers/ioapic.h>
 #include <drivers/system_timer.h>
 #include <kernel_structs.h>
+#include <logging/sys_log.h>
 
 #include <board.h>
 
@@ -164,13 +165,6 @@
 static u32_t main_count_first_irq_value;
 static u32_t main_count_expected_value;
 extern u32_t _hw_irq_to_c_handler_latency;
-#endif
-
-#ifdef CONFIG_HPET_TIMER_DEBUG
-#include <misc/printk.h>
-#define DBG(...) printk(__VA_ARGS__)
-#else
-#define DBG(...)
 #endif
 
 #ifdef CONFIG_TICKLESS_IDLE
@@ -604,11 +598,11 @@ int _sys_clock_driver_init(struct device *device)
 
 	counter_load_value = (u32_t)(tickFempto / hpetClockPeriod);
 
-	DBG("\n\nHPET: configuration: 0x%x, clock period: 0x%x (%d pico-s)\n",
+	SYS_LOG_DBG("configuration: 0x%x, clock period: 0x%x (%d pico-s)",
 	       (u32_t)(*_HPET_GENERAL_CAPS),
 	       (u32_t)hpetClockPeriod, (u32_t)hpetClockPeriod / 1000);
 
-	DBG("HPET: timer0: available interrupts mask 0x%x\n",
+	SYS_LOG_DBG("timer0: available interrupts mask 0x%x",
 	       (u32_t)(*_HPET_TIMER0_CONFIG_CAPS >> 32));
 
 	/* Initialize sys_clock_hw_cycles_per_tick/sec */

--- a/drivers/watchdog/wdog_cmsdk_apb.c
+++ b/drivers/watchdog/wdog_cmsdk_apb.c
@@ -11,8 +11,8 @@
 #include <errno.h>
 #include <soc.h>
 #include <watchdog.h>
-#include <misc/printk.h>
 #include <misc/reboot.h>
+#include <logging/sys_log.h>
 
 struct wdog_cmsdk_apb {
 	/* offset: 0x000 (r/w) watchdog load register */
@@ -165,7 +165,7 @@ static void wdog_cmsdk_apb_isr(void)
 	 * and if not, exit immediately
 	 */
 	if (!wdog_cmsdk_apb_has_fired()) {
-		printk("NMI received! Rebooting...\n");
+		SYS_LOG_INF("NMI received! Rebooting...");
 		/* In ARM implementation sys_reboot ignores the parameter */
 		sys_reboot(0);
 	} else {

--- a/kernel/include/boot.h
+++ b/kernel/include/boot.h
@@ -1,0 +1,39 @@
+/*
+ * Boot banner handling
+ */
+
+#ifndef __BOOT_H
+#define __BOOT_H
+
+/* kernel build timestamp items */
+
+#define BUILD_TIMESTAMP "BUILD: " __DATE__ " " __TIME__
+
+#ifdef CONFIG_BUILD_TIMESTAMP
+const char * const build_timestamp = BUILD_TIMESTAMP;
+#endif
+
+/* boot banner items */
+
+static const unsigned int boot_delay;
+#if defined(CONFIG_BOOT_DELAY) && CONFIG_BOOT_DELAY > 0
+#define BOOT_DELAY_BANNER " (delayed boot "	\
+	STRINGIFY(CONFIG_BOOT_DELAY) "ms)"
+static const unsigned int boot_delay = CONFIG_BOOT_DELAY;
+#else
+#define BOOT_DELAY_BANNER ""
+static const unsigned int boot_delay;
+#endif
+#define BOOT_BANNER "BOOTING ZEPHYR OS v"	\
+	KERNEL_VERSION_STRING BOOT_DELAY_BANNER
+
+#if !defined(CONFIG_BOOT_BANNER)
+#define PRINT_BOOT_BANNER() do { } while (0)
+#elif !defined(CONFIG_BUILD_TIMESTAMP)
+#define PRINT_BOOT_BANNER() printk("***** " BOOT_BANNER " *****\n")
+#else
+#define PRINT_BOOT_BANNER() \
+	printk("***** " BOOT_BANNER " - %s *****\n", build_timestamp)
+#endif
+
+#endif

--- a/kernel/include/boot.h
+++ b/kernel/include/boot.h
@@ -7,7 +7,7 @@
 
 /* kernel build timestamp items */
 
-#define BUILD_TIMESTAMP "BUILD: " __DATE__ " " __TIME__
+#define BUILD_TIMESTAMP __DATE__ " " __TIME__
 
 #ifdef CONFIG_BUILD_TIMESTAMP
 const char * const build_timestamp = BUILD_TIMESTAMP;
@@ -15,25 +15,14 @@ const char * const build_timestamp = BUILD_TIMESTAMP;
 
 /* boot banner items */
 
-static const unsigned int boot_delay;
+#ifdef CONFIG_BOOT_BANNER
+const char * const kernel_version = KERNEL_VERSION_STRING;
+#endif
+
 #if defined(CONFIG_BOOT_DELAY) && CONFIG_BOOT_DELAY > 0
-#define BOOT_DELAY_BANNER " (delayed boot "	\
-	STRINGIFY(CONFIG_BOOT_DELAY) "ms)"
 static const unsigned int boot_delay = CONFIG_BOOT_DELAY;
 #else
-#define BOOT_DELAY_BANNER ""
 static const unsigned int boot_delay;
-#endif
-#define BOOT_BANNER "BOOTING ZEPHYR OS v"	\
-	KERNEL_VERSION_STRING BOOT_DELAY_BANNER
-
-#if !defined(CONFIG_BOOT_BANNER)
-#define PRINT_BOOT_BANNER() do { } while (0)
-#elif !defined(CONFIG_BUILD_TIMESTAMP)
-#define PRINT_BOOT_BANNER() printk("***** " BOOT_BANNER " *****\n")
-#else
-#define PRINT_BOOT_BANNER() \
-	printk("***** " BOOT_BANNER " - %s *****\n", build_timestamp)
 #endif
 
 #endif

--- a/kernel/init.c
+++ b/kernel/init.c
@@ -27,37 +27,8 @@
 #include <version.h>
 #include <string.h>
 #include <misc/dlist.h>
+#include <boot.h>
 
-/* kernel build timestamp items */
-
-#define BUILD_TIMESTAMP "BUILD: " __DATE__ " " __TIME__
-
-#ifdef CONFIG_BUILD_TIMESTAMP
-const char * const build_timestamp = BUILD_TIMESTAMP;
-#endif
-
-/* boot banner items */
-
-static const unsigned int boot_delay;
-#if defined(CONFIG_BOOT_DELAY) && CONFIG_BOOT_DELAY > 0
-#define BOOT_DELAY_BANNER " (delayed boot "	\
-	STRINGIFY(CONFIG_BOOT_DELAY) "ms)"
-static const unsigned int boot_delay = CONFIG_BOOT_DELAY;
-#else
-#define BOOT_DELAY_BANNER ""
-static const unsigned int boot_delay;
-#endif
-#define BOOT_BANNER "BOOTING ZEPHYR OS v"	\
-	KERNEL_VERSION_STRING BOOT_DELAY_BANNER
-
-#if !defined(CONFIG_BOOT_BANNER)
-#define PRINT_BOOT_BANNER() do { } while (0)
-#elif !defined(CONFIG_BUILD_TIMESTAMP)
-#define PRINT_BOOT_BANNER() printk("***** " BOOT_BANNER " *****\n")
-#else
-#define PRINT_BOOT_BANNER() \
-	printk("***** " BOOT_BANNER " - %s *****\n", build_timestamp)
-#endif
 
 /* boot time measurement items */
 

--- a/kernel/init.c
+++ b/kernel/init.c
@@ -14,7 +14,7 @@
 #include <zephyr.h>
 #include <offsets_short.h>
 #include <kernel.h>
-#include <misc/printk.h>
+#include <logging/sys_log.h>
 #include <misc/stack.h>
 #include <random/rand32.h>
 #include <linker/sections.h>
@@ -28,6 +28,7 @@
 #include <string.h>
 #include <misc/dlist.h>
 #include <boot.h>
+#include <misc/printk.h>
 
 
 /* boot time measurement items */
@@ -157,11 +158,17 @@ static void _main(void *unused1, void *unused2, void *unused3)
 
 	_sys_device_do_config_level(_SYS_INIT_LEVEL_POST_KERNEL);
 	if (boot_delay > 0) {
-		printk("***** delaying boot " STRINGIFY(CONFIG_BOOT_DELAY)
-		       "ms (per build configuration) *****\n");
+		SYS_LOG_INF("delaying boot %d "
+		       "ms (per build configuration)", boot_delay);
 		k_busy_wait(CONFIG_BOOT_DELAY * USEC_PER_MSEC);
+		SYS_LOG_INF("delayed boot of %d ms done.", boot_delay);
 	}
-	PRINT_BOOT_BANNER();
+#if defined(CONFIG_BOOT_BANNER)
+	SYS_LOG_INF("Welcome to Zephyr v%s", KERNEL_VERSION_STRING);
+#if CONFIG_BUILD_TIMESTAMP
+	SYS_LOG_INF("Built on: %s", build_timestamp);
+#endif
+#endif
 
 	/* Final init level before app starts */
 	_sys_device_do_config_level(_SYS_INIT_LEVEL_APPLICATION);

--- a/misc/reboot.c
+++ b/misc/reboot.c
@@ -12,7 +12,7 @@
 
 #include <kernel.h>
 #include <drivers/system_timer.h>
-#include <misc/printk.h>
+#include <logging/sys_log.h>
 #include <misc/reboot.h>
 
 extern void sys_arch_reboot(int type);
@@ -25,7 +25,7 @@ void sys_reboot(int type)
 	sys_arch_reboot(type);
 
 	/* should never get here */
-	printk("Failed to reboot: spinning endlessly...\n");
+	SYS_LOG_ERR("Failed to reboot: spinning endlessly...");
 	for (;;) {
 		k_cpu_idle();
 	}

--- a/subsys/bluetooth/common/log.h
+++ b/subsys/bluetooth/common/log.h
@@ -57,7 +57,9 @@ __printf_like(2, 3) void bt_log(int prio, const char *fmt, ...);
 #if !defined(SYS_LOG_DOMAIN)
 #define SYS_LOG_DOMAIN "bt"
 #endif
+#if !defined(SYS_LOG_LEVEL)
 #define SYS_LOG_LEVEL SYS_LOG_LEVEL_DEBUG
+#endif
 #include <logging/sys_log.h>
 
 #define BT_DBG(fmt, ...) \

--- a/subsys/fs/nffs_fs.c
+++ b/subsys/fs/nffs_fs.c
@@ -13,7 +13,6 @@
 #include <fs.h>
 #include <crc16.h>
 #include <misc/__assert.h>
-#include <misc/printk.h>
 #include <nffs/nffs.h>
 #include <nffs/os.h>
 

--- a/subsys/logging/Kconfig
+++ b/subsys/logging/Kconfig
@@ -9,7 +9,7 @@ config SYS_LOG
 	bool
 	prompt "Enable Logging"
 	depends on PRINTK
-	default n
+	default y
 	help
 	  Global switch for logging, when turned off log calls will not be
 	  executed.
@@ -35,7 +35,7 @@ config SYS_LOG_DEFAULT_LEVEL
 	int
 	prompt "Default log level"
 	depends on SYS_LOG
-	default 0
+	default 3
 	range 0 4
 	help
 	  Sets log level for modules which don't specify it explicitly. When

--- a/subsys/shell/shell_service.c
+++ b/subsys/shell/shell_service.c
@@ -12,7 +12,6 @@
  * Includes also adding basic framework commands to shell commands.
  */
 
-#include <misc/printk.h>
 #include <shell/shell.h>
 #include <init.h>
 


### PR DESCRIPTION
Using printk for logging errors and warnings and even for informative
messages is all great when you have a console connected and are able to
view those messages but in many cases this will not be the case and in a
production environment such messages will need to be managed differently,
i.e. cached into a buffer, written to a filesystem or sent via the network.

This enabled syslog by default to encourage using SYS_LOG_XXX for any
messages with the benefit of being able to implement a logger hook that
would make it possible to view those messages on demand and using other
means than just a connected console.

The cost is minimal as by default those macros just redirect to printk.

This also moves debug/information output from printk to syslog making this type
of information available to any syslog backend we might have in the system,
not only to the serial console.