### PR TITLE
net: net-app: fix data_len check in net_pkt_append() correctly

### DIFF
--- a/subsys/net/ip/net_pkt.c
+++ b/subsys/net/ip/net_pkt.c
@@ -1203,7 +1203,7 @@ u16_t net_pkt_append(struct net_pkt *pkt, u16_t len, const u8_t *data,
 		    s32_t timeout)
 {
 	struct net_buf *frag;
-	struct net_context *ctx;
+	struct net_context *ctx = NULL;
 	u16_t max_len, appended;
 
 	if (!pkt || !data) {
@@ -1219,7 +1219,10 @@ u16_t net_pkt_append(struct net_pkt *pkt, u16_t len, const u8_t *data,
 		net_pkt_frag_add(pkt, frag);
 	}
 
-	ctx = net_pkt_context(pkt);
+	if (pkt->slab != &rx_pkts) {
+		ctx = net_pkt_context(pkt);
+	}
+
 	if (ctx) {
 		/* Make sure we don't send more data in one packet than
 		 * protocol or MTU allows when there is a context for the

--- a/subsys/net/lib/app/net_app.c
+++ b/subsys/net/lib/app/net_app.c
@@ -2068,7 +2068,6 @@ reset:
 				ctx->tls.mbedtls.ssl_ctx.hdr = NULL;
 			}
 
-			pkt->data_len = len;
 			ret = net_pkt_append_all(pkt, len,
 						 ctx->tls.request_buf,
 						 BUF_ALLOC_TIMEOUT);


### PR DESCRIPTION
Commit 3599d793c2fa3f3520ad8b51df64018dad1fe6d0 attempted to fix an issue where net_pkt_append() was checking a packet's data_len setting to see if data was allowed to be appended to the packet.  Specifically this is an issue in the net-app TLS RX path where the packet's data_len was not being set.

After more testing, the current fix doesn't work.  The net_context's TCP context has a setting "send_mss" which is set to the maximum TX packet size.  In net_pkt_append this setting will cause larger packets to fail regardless of what the data_len value is.

The correct fix is to skip the data_len check in net_pkt_append for RX packets.

Apologies for not getting this right the first time.