### PR TITLE
net: lib: http: fix CONFIG_HTTPS for client use

### DIFF
--- a/include/net/http_app.h
+++ b/include/net/http_app.h
@@ -507,7 +507,7 @@ int http_server_init(struct http_ctx *ctx,
 		     const char *server_banner,
 		     void *user_data);
 
-#if defined(CONFIG_HTTPS)
+#if defined(CONFIG_HTTPS) && defined(CONFIG_NET_APP_SERVER)
 /**
  * @brief Initialize TLS support for this http context
  *
@@ -537,7 +537,7 @@ int http_server_set_tls(struct http_ctx *ctx,
 			k_thread_stack_t *stack,
 			size_t stack_len);
 
-#endif /* CONFIG_HTTPS */
+#endif /* CONFIG_HTTPS && CONFIG_NET_APP_SERVER */
 
 /**
  * @brief Enable HTTP server that is related to this context.
@@ -635,7 +635,7 @@ static inline int http_server_init(struct http_ctx *ctx,
 	return -ENOTSUP;
 }
 
-#if defined(CONFIG_HTTPS)
+#if defined(CONFIG_HTTPS) && defined(CONFIG_NET_APP_SERVER)
 static inline int http_server_set_tls(struct http_ctx *ctx,
 				      const char *server_banner,
 				      u8_t *personalization_data,
@@ -658,7 +658,7 @@ static inline int http_server_set_tls(struct http_ctx *ctx,
 
 	return -ENOTSUP;
 }
-#endif /* CONFIG_HTTPS */
+#endif /* CONFIG_HTTPS && CONFIG_NET_APP_SERVER */
 
 static inline int http_server_enable(struct http_ctx *ctx)
 {


### PR DESCRIPTION
Fix build break when enabling CONFIG_HTTPS w/o CONFIG_NET_APP_SERVER

This error can be seen when building sample/net/http_client like so:
$ cd samples/net/http_client
$ mkdir build && cd build
$ cmake -DBOARD=qemu_x86 -DCONF_FILE=prj_tls.conf ..
$ make run

In file included from /home/<user>/zephyr/include/net/http.h:11:0,
                 from /home/<user>/zephyr/samples/net/http_client/src/main.c:19:
/home/<user>/zephyr/include/net/http_app.h:643:11: error: unknown type name ‘net_app_cert_cb_t’
           net_app_cert_cb_t cert_cb,
           ^~~~~~~~~~~~~~~~~
CMakeFiles/app.dir/build.make:302: recipe for target 'CMakeFiles/app.dir/src/main.c.obj' failed

Signed-off-by: Michael Scott <michael@opensourcefoundries.com>