### PR TITLE
net: lib: app: trigger TLS closure when connection is closed

### DIFF
--- a/subsys/net/lib/app/net_app.c
+++ b/subsys/net/lib/app/net_app.c
@@ -1014,6 +1014,12 @@ int net_app_close(struct net_app_ctx *ctx)
 		ctx->cb.close(ctx, 0, ctx->user_data);
 	}
 
+#if defined(CONFIG_NET_APP_TLS) || defined(CONFIG_NET_APP_DTLS)
+	if (ctx->is_tls) {
+		_net_app_tls_trigger_close(ctx);
+	}
+#endif
+
 #if defined(CONFIG_NET_APP_SERVER) && defined(CONFIG_NET_TCP)
 	if (net_ctx && ctx->app_type == NET_APP_SERVER) {
 		int i;


### PR DESCRIPTION
When testing TLS connections on production web server, it was noticed
that the TLS mainloop was getting "hung" after a connection was made
via HTTPS and then closed by the server.  The TLS mainloop was never
being notified that the connection was closed and was stuck waiting
for more data.

The next time that connection was used, TLS would fail to start.

Let's force trigger a closure of the TLS process when the net-app layer
is notified of the connection closure.  This allows the connection to
be successfully reused later.

Signed-off-by: Michael Scott <michael@opensourcefoundries.com>