### PR TITLE
samples: fix amg88xx sample.yaml syntax

### DIFF
--- a/samples/sensor/amg88xx/sample.yaml
+++ b/samples/sensor/amg88xx/sample.yaml
@@ -1,8 +1,8 @@
 sample:
-    description: AMG88XX sensor sample
-    name: AMG88XX sample
+  description: AMG88XX sensor sample
+  name: AMG88XX sample
 tests:
--   test:
-        build_only: true
-        platform_whitelist: frdm_k64f
-        tags: samples sensor
+  test:
+    build_only: true
+    depends_on: i2c
+    tags: samples sensor


### PR DESCRIPTION
Was still using old synatx.

Signed-off-by: Anas Nashif <anas.nashif@intel.com>