### PR TITLE
kernel: userspace: API to check the permissions.

### DIFF
--- a/include/kernel.h
+++ b/include/kernel.h
@@ -239,6 +239,14 @@ static inline void _impl_k_object_access_revoke(void *object,
 	ARG_UNUSED(thread);
 }
 
+static inline s32_t _impl_k_object_access_check(void *object,
+						struct k_thread *thread)
+{
+	ARG_UNUSED(object);
+	ARG_UNUSED(thread);
+	return 0;
+}
+
 static inline void k_object_access_all_grant(void *object)
 {
 	ARG_UNUSED(object);
@@ -287,6 +295,19 @@ __syscall void k_object_access_revoke(void *object, struct k_thread *thread);
  * @param object Address of kernel object
  */
 void k_object_access_all_grant(void *object);
+
+/**
+ * Check thread access to a kernel object
+ *
+ * This API checks if the thread has the permission for the kernel object.
+ *
+ * @param object Address of kernel object
+ * @param thread Thread whose permissions need to be checked.
+ *
+ * @retval 0 Thread has the permissions.
+ * @retval -EPERM Thread has no permissions for the given object.
+ */
+__syscall s32_t k_object_access_check(void *object, struct k_thread *thread);
 
 /* Using typedef deliberately here, this is quite intended to be an opaque
  * type. K_THREAD_STACK_BUFFER() should be used to access the data within.

--- a/kernel/userspace.c
+++ b/kernel/userspace.c
@@ -207,6 +207,30 @@ void _dump_object_error(int retval, void *obj, struct _k_object *ko,
 	}
 }
 
+s32_t _impl_k_object_access_check(void *object, struct k_thread *thread)
+{
+	int index;
+	s32_t permission = -EPERM;
+	struct _k_object *ko = _k_object_find(object);
+
+	if (ko) {
+
+		index = thread_index_get(thread);
+		if (index != -1) {
+			permission =
+				(
+				 sys_bitfield_test_bit((mem_addr_t)&ko->perms,
+						      index) == 0) ? -EPERM : 0;
+		}
+
+		if (ko->flags & K_OBJ_FLAG_PUBLIC) {
+			permission = 0;
+		}
+	}
+
+	return permission;
+}
+
 void _impl_k_object_access_grant(void *object, struct k_thread *thread)
 {
 	struct _k_object *ko = _k_object_find(object);

--- a/kernel/userspace_handler.c
+++ b/kernel/userspace_handler.c
@@ -58,3 +58,15 @@ _SYSCALL_HANDLER(k_object_access_revoke, object, thread)
 
 	return 0;
 }
+
+_SYSCALL_HANDLER(k_object_access_check, object, thread)
+{
+	struct _k_object *ko;
+
+	_SYSCALL_OBJ_INIT(thread, K_OBJ_THREAD);
+	ko = validate_any_object((void *)object);
+	_SYSCALL_VERIFY_MSG(ko, "object %p access denied", (void *)object);
+	return (_impl_k_object_access_check((void *)object,
+					    (struct k_thread *)thread));
+
+}


### PR DESCRIPTION
A thread can now check if it has access to a specific k_object.
This can also be called from userspace. If called from the user
thread it needs to have access to the both the k_object and the
thread id.

Signed-off-by: Adithya Baglody <adithya.nagaraj.baglody@intel.com>