### PR TITLE
cmake: Don't assert that imported zephyr libraries have source files

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -381,18 +381,20 @@ foreach(zephyr_lib ${ZEPHYR_LIBS_PROPERTY})
   # TODO: Could this become an INTERFACE property of zephyr_interface?
   add_dependencies(${zephyr_lib} offsets_h)
 
-  # Verify that all libraries have source files. Libraries without
-  # source files are not supported because they are an indication that
-  # something has been misconfigured.
-  get_target_property(lib_sources ${zephyr_lib} SOURCES)
+  # Verify that all (non-imported) libraries have source
+  # files. Libraries without source files are not supported because
+  # they are an indication that something has been misconfigured.
+  get_target_property(lib_imported ${zephyr_lib} IMPORTED)
+  get_target_property(lib_sources  ${zephyr_lib} SOURCES)
   if(lib_sources STREQUAL lib_sources-NOTFOUND
       AND (NOT (${zephyr_lib} STREQUAL app))
+      AND (NOT lib_imported)
       )
     # app is not checked because it's sources are added to it after
     # this CMakeLists.txt file has been processed
     message(FATAL_ERROR "\
 The Zephyr library '${zephyr_lib}' was created without source files. \
-Empty libraries are not supported. \
+Empty (non-imported) libraries are not supported. \
 Either make sure that the library has the sources it should have, \
 or make sure it is not created when it has no source files.")
   endif()


### PR DESCRIPTION
A Zephyr library not having source files is usually due to a
misconfiguration and will lead to an obscure error message. But
imported Zephyr libraries don't have source files so we need to skip
the source file check when a library is imported.

An imported Zephyr library is normally used to reference externally
built code, either prebuilt or recursively built through an external
build system.

This fixes #5497

Signed-off-by: Sebastian Bøe <sebastian.boe@nordicsemi.no>