### PR TITLE
cmake: external_lib: Specify that the library should be GLOBAL

### DIFF
--- a/samples/application_development/external_lib/CMakeLists.txt
+++ b/samples/application_development/external_lib/CMakeLists.txt
@@ -47,7 +47,7 @@ ExternalProject_Add(
   )
 
 # Create a wrapper CMake library that our app can link with
-add_library(mylib_lib STATIC IMPORTED)
+add_library(mylib_lib STATIC IMPORTED GLOBAL)
 add_dependencies(
   mylib_lib
   mylib_project


### PR DESCRIPTION
Having a library being GLOBAL, although not default behaviour, or
necessary for the sample, is expected behaviour for a library. It is
expected that like normal libraries, the target name will be
accessible from outside of the CMakeLists.txt file that created it.

Since samples are used as reference code, we specify GLOBAL so that
libraries are created with this intuitive behaviour.

PS: Copy-pasting this library code has confused me on multiple occasions as I have expected
the library name to be global like normal libraries are.

Signed-off-by: Sebastian Bøe <sebastian.boe@nordicsemi.no>