### PR TITLE
native: native_posix accept command line arguments

### DIFF
--- a/boards/posix/native_posix/CMakeLists.txt
+++ b/boards/posix/native_posix/CMakeLists.txt
@@ -7,4 +7,5 @@ zephyr_library_sources(
 	irq_ctrl.c
 	main.c
 	tracing.c
+	cmdline.c
 	)

--- a/boards/posix/native_posix/cmdline.c
+++ b/boards/posix/native_posix/cmdline.c
@@ -1,0 +1,30 @@
+/*
+ * Copyright (c) 2018 Oticon A/S
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+
+static int s_argc;
+static char **s_argv;
+
+/**
+ * Store the command line arguments for later use.
+ * If this board already handles any, we do so here
+ */
+void native_handle_cmd_line(int argc, char *argv[])
+{
+	s_argv = argv;
+	s_argc = argc;
+}
+
+
+/**
+ * The application/test can use this function to inspect the command line
+ * arguments
+ */
+void native_get_cmd_line_args(int *argc, char ***argv)
+{
+	*argc = s_argc;
+	*argv = s_argv;
+}

--- a/boards/posix/native_posix/cmdline.h
+++ b/boards/posix/native_posix/cmdline.h
@@ -1,0 +1,14 @@
+/*
+ * Copyright (c) 2018 Oticon A/S
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef _NATIVE_POSIX_CMDLINE_H
+#define _NATIVE_POSIX_CMDLINE_H
+
+
+void native_handle_cmd_line(int argc, char *argv[]);
+void native_get_cmd_line_args(int *argc, char ***argv);
+
+#endif /* _NATIVE_POSIX_CMDLINE_H */

--- a/boards/posix/native_posix/main.c
+++ b/boards/posix/native_posix/main.c
@@ -23,6 +23,7 @@
 #include "hw_models_top.h"
 #include <stdlib.h>
 #include "misc/util.h"
+#include "cmdline.h"
 
 #define STOP_AFTER_5_SECONDS 0
 
@@ -54,8 +55,10 @@ void main_clean_up(int exit_code)
  * apps (hello world, synchronization, philosophers) and run the sanity-check
  * regression
  */
-int main(void)
+int main(int argc, char *argv[])
 {
+
+	native_handle_cmd_line(argc, argv);
 
 	hwm_init();
 


### PR DESCRIPTION
The native_posix board will accept command line arguments
which the application / test may pick by calling
native_get_cmd_line_args()

Signed-off-by: Alberto Escolar Piedras <alpi@oticon.com>

Fixes #5483 