### PR TITLE
drivers: eth: mcux: Use correct Kconfig option for RX bufs

### DIFF
--- a/drivers/ethernet/eth_mcux.c
+++ b/drivers/ethernet/eth_mcux.c
@@ -92,7 +92,7 @@ struct eth_context {
 static void eth_0_config_func(void);
 
 static enet_rx_bd_struct_t __aligned(ENET_BUFF_ALIGNMENT)
-rx_buffer_desc[CONFIG_ETH_MCUX_TX_BUFFERS];
+rx_buffer_desc[CONFIG_ETH_MCUX_RX_BUFFERS];
 
 static enet_tx_bd_struct_t __aligned(ENET_BUFF_ALIGNMENT)
 tx_buffer_desc[CONFIG_ETH_MCUX_TX_BUFFERS];


### PR DESCRIPTION
The mcux ethernet driver was using TX buf count when allocating
RX buffers.

Signed-off-by: Jukka Rissanen <jukka.rissanen@linux.intel.com>