### PR TITLE
net: ip: shell: Fix ipv6 echo reply callback to unref packet

### DIFF
--- a/subsys/net/ip/net_shell.c
+++ b/subsys/net/ip/net_shell.c
@@ -1783,6 +1783,7 @@ static enum net_verdict _handle_ipv6_echo_reply(struct net_pkt *pkt)
 	k_sem_give(&ping_timeout);
 	_remove_ipv6_ping_handler();
 
+	net_pkt_unref(pkt);
 	return NET_OK;
 }
 


### PR DESCRIPTION
When testing ping6 with net shell, it was noticed that after some
sucessive calls the applications stopped to handle rx packets.
Analyzing other icmpv6 register callbacks it was verified that is
necessary to unref packets before returning NET_OK.

Signed-off-by: Pedro Martucci <pedropaulomartucci@gmail.com>