### PR TITLE
gitlint: do not allow title-only commit messages

### DIFF
--- a/.gitlint
+++ b/.gitlint
@@ -15,6 +15,9 @@ extra-path=scripts/gitlint
 [title-max-length-no-revert]
 line-length=72
 
+[body-min-line-count]
+min-line-count=1
+
 [body-max-line-count]
 max-line-count=200
 

--- a/scripts/gitlint/zephyr_commit_rules.py
+++ b/scripts/gitlint/zephyr_commit_rules.py
@@ -15,6 +15,23 @@ While every LineRule can be implemented as a CommitRule, it's usually easier and
 that fits your needs.
 """
 
+class BodyMinLineCount(CommitRule):
+    # A rule MUST have a human friendly name
+    name = "body-min-line-count"
+
+    # A rule MUST have an *unique* id, we recommend starting with UC (for User-defined Commit-rule).
+    id = "UC6"
+
+    # A rule MAY have an option_spec if its behavior should be configurable.
+    options_spec = [IntOption('min-line-count', 2, "Minimum body line count excluding Signed-off-by")]
+
+    def validate(self, commit):
+        filtered = [x for x in commit.message.body if not x.lower().startswith("signed-off-by") and x != '']
+        line_count = len(filtered)
+        min_line_count = self.options['min-line-count'].value
+        if line_count <= min_line_count:
+            message = "Body has no content, should at least have {} line.".format(min_line_count)
+            return [RuleViolation(self.id, message, line_nr=1)]
 
 class BodyMaxLineCount(CommitRule):
     # A rule MUST have a human friendly name


### PR DESCRIPTION
It has been agreed in the project TSC to reject commit messages without
any content. Every commit message needs some explaination beyond what
was put in the title, even the most trivial ones.

Signed-off-by: Anas Nashif <anas.nashif@intel.com>