### PR TITLE
net: ip: shell: Fix ipv4 echo reply callback to unref packet

### DIFF
--- a/subsys/net/ip/net_shell.c
+++ b/subsys/net/ip/net_shell.c
@@ -1861,6 +1861,7 @@ static enum net_verdict _handle_ipv4_echo_reply(struct net_pkt *pkt)
 	k_sem_give(&ping_timeout);
 	_remove_ipv4_ping_handler();
 
+	net_pkt_unref(pkt);
 	return NET_OK;
 }
 


### PR DESCRIPTION
The ICMPv4 handler needs to unref the received echo reply packet
because we are returning NET_OK to caller. Similar change was done
for IPv6 earlier.

Signed-off-by: Jukka Rissanen <jukka.rissanen@linux.intel.com>