### PR TITLE
[WIP] tests: bluetooth/bluetooth can also be run in native_posix

### DIFF
--- a/tests/bluetooth/bluetooth/testcase.yaml
+++ b/tests/bluetooth/bluetooth/testcase.yaml
@@ -1,4 +1,4 @@
 tests:
   test:
-    platform_whitelist: qemu_x86_iamcu qemu_cortex_m3
+    platform_whitelist: qemu_x86_iamcu qemu_cortex_m3 native_posix
     tags: bluetooth


### PR DESCRIPTION
The test bluetooth/bluetooth can also be run in the native_posix
board

Signed-off-by: Alberto Escolar Piedras <alpi@oticon.com>