### PR TITLE
ci: update docker image for CI builds

### DIFF
--- a/.shippable.yml
+++ b/.shippable.yml
@@ -23,12 +23,11 @@ build:
         - ${SHIPPABLE_BUILD_DIR}/ccache
     pre_ci_boot:
         image_name: zephyrprojectrtos/ci
-        image_tag: v0.2
+        image_tag: v0.3
         pull: true
         options: "-e HOME=/home/buildslave --privileged=true --tty --net=bridge --user buildslave"
 
     ci:
-      - sudo apt-get install gcovr gcc-6-multilib ninja-build
       - export CCACHE_DIR=${SHIPPABLE_BUILD_DIR}/ccache/.ccache
       - >
         if [ "$IS_PULL_REQUEST" = "true" ]; then


### PR DESCRIPTION
The new images has package updates including:
- ninja-build
- lcov
- new versions of doc generations packages
- gcovr
- gcc-6-multilib
