### PR TITLE
Misc cxx fixes

### DIFF
--- a/include/bluetooth/buf.h
+++ b/include/bluetooth/buf.h
@@ -82,7 +82,7 @@ static inline void bt_buf_set_type(struct net_buf *buf, enum bt_buf_type type)
  */
 static inline enum bt_buf_type bt_buf_get_type(struct net_buf *buf)
 {
-	return *(u8_t *)net_buf_user_data(buf);
+	return *((enum bt_buf_type *)net_buf_user_data(buf));
 }
 
 /**

--- a/include/bluetooth/gatt.h
+++ b/include/bluetooth/gatt.h
@@ -895,7 +895,7 @@ struct bt_gatt_read_params {
 	bt_gatt_read_func_t func;
 	size_t handle_count;
 	union {
-		struct __single {
+		struct {
 			u16_t handle;
 			u16_t offset;
 		} single;


### PR DESCRIPTION
Port misc. constructs that caused compilation errors when included into CXX code. See commit messages for details.

I was under the impression that we compiled our C and CXX code in such a way that when it built with GCC, it was guaranteed to build with CXX as well. But these examples seem to disprove this.

Long term, for each of these constructs it should be investigated how to either:

Trigger a compilation error when compiling with GCC.
Make the CXX accept the construct as GCC does.

These cases were found by building the cpp sample with all bluetooth headers included.