### PR TITLE
arm: nxp_mpu: Fix build issue when asserts enabled

### DIFF
--- a/arch/arm/core/cortex_m/mpu/nxp_mpu.c
+++ b/arch/arm/core/cortex_m/mpu/nxp_mpu.c
@@ -54,11 +54,11 @@ static void _region_init(u32_t index, u32_t region_base,
 		 */
 		__ASSERT(region_base == SYSMPU->WORD[index][0],
 			 "Region %d base address got 0x%08x expected 0x%08x",
-			 index, region_base, SYSMPU->WORD[index][0]);
+			 index, region_base, (u32_t)SYSMPU->WORD[index][0]);
 
 		__ASSERT(region_end == SYSMPU->WORD[index][1],
 			 "Region %d end address got 0x%08x expected 0x%08x",
-			 index, region_end, SYSMPU->WORD[index][1]);
+			 index, region_end, (u32_t)SYSMPU->WORD[index][1]);
 
 		/* Changes to the RGD0_WORD2 alterable fields should be done
 		 * via a write to RGDAAC0.


### PR DESCRIPTION
When asserts are enabled we run into an issue with newlib and types of
printf style formatters not matching.  The easy fix to this is to cast
the uint32_t to u32_t to make things consistent with or without newlib
enabled.

This fixes #5645

Signed-off-by: Kumar Gala <kumar.gala@linaro.org>