### PR TITLE
Zephyr project USB Vendor and Product IDs

### DIFF
--- a/doc/subsystems/usb/usb.rst
+++ b/doc/subsystems/usb/usb.rst
@@ -1,3 +1,18 @@
+USB Vendor and Product identifiers
+##################################
+
+The USB Vendor ID for the Zephyr project is 0x2FE3. The default USB Product
+ID for the Zephyr project is 0x100. The USB bcdDevice Device Release Number
+represents the Zephyr kernel major and minor versions as a binary coded
+decimal value. When a vendor integrates the Zephyr USB subsystem into a
+product, the vendor must use the USB Vendor and Product ID assigned to them.
+A vendor integrating the Zephyr USB subsystem in a product must not use the
+Vendor ID of the Zephyr project.
+
+The USB maintainer, if one is assigned, or otherwise the Zephyr Technical
+Steering Committee, may allocate other USB Product IDs based on well-motivated
+and documented requests.
+
 USB device stack
 ################
 

--- a/include/usb/usb_common.h
+++ b/include/usb/usb_common.h
@@ -39,8 +39,12 @@
  * This file contains useful constants and macros for the USB applications.
  */
 
+#include <version.h>
+
 #ifndef USB_COMMON_H_
 #define USB_COMMON_H_
+
+#define BCD(x) ((((x) / 10) << 4) | ((x) / 10))
 
 /* Descriptor size in bytes */
 #define USB_DEVICE_DESC_SIZE		18
@@ -72,7 +76,8 @@
 /* Set USB version to 2.1 so that the host will request the BOS descriptor */
 #define USB_2_1				0x0210
 
-#define BCDDEVICE_RELNUM		0x0100
+#define BCDDEVICE_RELNUM		(BCD(KERNEL_VERSION_MAJOR) << 8 | \
+					BCD(KERNEL_VERSION_MINOR))
 
 /* 100mA max power, per 2mA units */
 /* USB 1.1 spec indicates 100mA(max) per unit load, up to 5 loads */

--- a/subsys/usb/CMakeLists.txt
+++ b/subsys/usb/CMakeLists.txt
@@ -13,16 +13,17 @@ if(CONFIG_USB_COMPOSITE_DEVICE)
     )
 endif()
 
-if(CONFIG_USB_DEVICE_VID EQUAL 0xDEAD)
+if(CONFIG_USB_DEVICE_VID EQUAL 0x2FE3)
   message(WARNING
-    "CONFIG_USB_DEVICE_VID has default test value 0xDEAD.
+    "CONFIG_USB_DEVICE_VID has default value 0x2FE3.
 This value is only for testing and MUST be configured for USB products."
     )
-endif()
 
-if(CONFIG_USB_DEVICE_PID EQUAL 0xBEEF)
-  message(WARNING
-    "CONFIG_USB_DEVICE_PID has default test value 0xBEEF.
+  if(CONFIG_USB_DEVICE_PID EQUAL 0x100)
+    message(WARNING
+      "CONFIG_USB_DEVICE_PID has default value 0x100.
 This value is only for testing and MUST be configured for USB products."
-    )
+      )
+  endif()
+
 endif()

--- a/subsys/usb/Kconfig
+++ b/subsys/usb/Kconfig
@@ -39,14 +39,14 @@ config SYS_LOG_USB_LEVEL
 config USB_DEVICE_VID
 	hex
 	prompt "USB Vendor ID"
-	default 0xDEAD
+	default 0x2FE3
 	help
 	  USB device vendor ID. MUST be configured by vendor.
 
 config USB_DEVICE_PID
 	hex
 	prompt "USB Product ID"
-	default 0xBEEF
+	default 0x100
 	help
 	  USB device product ID. MUST be configured by vendor.
 


### PR DESCRIPTION
This change updates the USB Vendor ID to the value recently assigned to the Zephyr project.

The Product ID is set to 0x100, and the device descriptor bcdDevice Device Release Number now follows Linux by setting it to the Zephyr kernel major and minor version number. The first iteration of an USB ID policy is also described.

Please review, comment and check that the version number is correct with 'lsusb -v' in Linux.