### PR TITLE
cmake: Don't specify a C standard when building Kconfig

### DIFF
--- a/scripts/kconfig/CMakeLists.txt
+++ b/scripts/kconfig/CMakeLists.txt
@@ -4,7 +4,6 @@ add_compile_options(
   -Wstrict-prototypes
   -O2
   -fomit-frame-pointer
-  -std=gnu89
   -Wno-format-security
   -DKBUILD_NO_NLS
 )


### PR DESCRIPTION
Specifying a C standard triggered a compiler warning on Ubuntu (gcc
5.4.0) and a compiler error on Mac OS 10.12.6. Omit specifying the
standard and let the host toolchain use it's default instead. Tested
on Mac OS and Ubuntu 16.04.3.

This fixes #5640

Signed-off-by: Sebastian Bøe <sebastian.boe@nordicsemi.no>