### PR TITLE
Bluetooth: Fix BT_TESTING option dependency

### DIFF
--- a/subsys/bluetooth/host/Kconfig
+++ b/subsys/bluetooth/host/Kconfig
@@ -444,13 +444,13 @@ config BT_DEBUG_SDP
 		This option enables debug support for the Bluetooth
 		Service Discovery Protocol (SDP).
 
+endif # BT_DEBUG
+
 config BT_TESTING
 	bool "Bluetooth Testing"
 	help
 	  This option enables custom Bluetooth testing interface.
 	  Shall only be used for testing purposes.
-
-endif # BT_DEBUG
 
 config BT_BREDR
 	bool "Bluetooth BR/EDR support [EXPERIMENTAL]"


### PR DESCRIPTION
This removes BT_DEBUG dependency on BT_TESTING flag.

Signed-off-by: Mariusz Skamra <mariusz.skamra@codecoup.pl>