### PR TITLE
build: warn user about Meltdown vulnerability

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -912,3 +912,12 @@ if(CONFIG_BOARD_DEPRECATED)
       removed in version ${CONFIG_BOARD_DEPRECATED}"
 )
 endif()
+
+if(CONFIG_X86 AND CONFIG_USERSPACE AND NOT CONFIG_X86_NO_MELTDOWN)
+  message(WARNING "
+      WARNING: You have enabled CONFIG_USERSPACE on an x86-based target.
+      If your CPU is vulnerable to the Meltdown CPU bug, security of
+      supervisor-only memory pages is not guaranteed. This version of Zephyr
+      does not contain a fix for this issue."
+)
+endif()

--- a/arch/x86/Kconfig
+++ b/arch/x86/Kconfig
@@ -83,6 +83,12 @@ config X86_PAE_MODE
 	  needed for PAE tables is more than twice that of 32-Bit paging
 	  because each PAE entry is 64bits wide.
 	  Note: Do not enable in RAM constrained devices.
+
+config X86_NO_MELTDOWN
+	bool
+	help
+	  This hidden option should be set on a per-SOC basis to indicate that
+	  a particular SOC is not vulnerable to the Meltdown CPU vulnerability.
 endmenu
 
 config X86_ENABLE_TSS

--- a/arch/x86/soc/intel_quark/quark_se/Kconfig.defconfig.series
+++ b/arch/x86/soc/intel_quark/quark_se/Kconfig.defconfig.series
@@ -12,6 +12,9 @@ config SOC_SERIES
 config X86_IAMCU
 	def_bool y
 
+config X86_NO_MELTDOWN
+	def_bool y
+
 config TOOLCHAIN_VARIANT
 	default "iamcu" if X86_IAMCU
 	default "" if !X86_IAMCU


### PR DESCRIPTION
A fix for this issue is in progress, meanwhile warn the user that
they may be susceptible to this problem if they enable user mode on
an x86-based target.

Signed-off-by: Andrew Boie <andrew.p.boie@intel.com>