### PR TITLE
doc: recent kconfig changes break doc generation

### DIFF
--- a/.shippable.yml
+++ b/.shippable.yml
@@ -42,6 +42,10 @@ build:
             echo "- Building Documentation";
             echo "Commit range:" ${COMMIT_RANGE}
             make htmldocs
+            if [ "$?" != "0" ]; then
+              echo "Documentation build failed";
+              exit 1;
+            fi
             if [ -s doc/doc.warnings ]; then
               echo " => New documentation warnings/errors";
               cp doc/doc.warnings doc.warnings

--- a/doc/Makefile
+++ b/doc/Makefile
@@ -73,7 +73,7 @@ content: scripts/extract_content.py
 	$(Q)$<
 
 kconfig: scripts/genrest/genrest.py
-	$(Q)srctree=../ KERNELVERSION=1.9.99 SRCARCH=x86 python3 $< ../Kconfig reference/kconfig/
+	$(Q)srctree=../ ENV_VAR_BOARD_DIR=boards/*/*/ ENV_VAR_ARCH=* KERNELVERSION=1.9.99 SRCARCH=x86 python3 $< ../Kconfig reference/kconfig/
 
 
 prep: doxy content kconfig


### PR DESCRIPTION
Instead of wildcards we now are using environment variables to set the
path to Kconfig files for board and architecture. This break
documentation generation for Kconfig variables.

Using the env variables, we now set the path to what it used to be to
restore previous behavior.

Also, when something like this happens in the future, we should abort on
doc creation failure.

Signed-off-by: Anas Nashif <anas.nashif@intel.com>