### PR TITLE
drivers: entropy: stm32: Remove STM32F411XE from building

### DIFF
--- a/arch/arm/soc/st_stm32/stm32f4/Kconfig.defconfig.stm32f411xe
+++ b/arch/arm/soc/st_stm32/stm32f4/Kconfig.defconfig.stm32f411xe
@@ -15,11 +15,4 @@ config NUM_IRQS
 	int
 	default 85
 
-if ENTROPY_GENERATOR
-
-config ENTROPY_STM32_RNG
-	def_bool y
-
-endif # ENTROPY_GENERATOR
-
 endif # SOC_STM32F411XE

--- a/drivers/entropy/entropy_stm32.c
+++ b/drivers/entropy/entropy_stm32.c
@@ -21,6 +21,8 @@
 #error RNG only available on STM32F4 and STM32L4 series
 #elif defined(CONFIG_SOC_STM32F401XE)
 #error RNG not available on STM32F401 based SoCs
+#elif defined(CONFIG_SOC_STM32F411XE)
+#error RNG not available on STM32F411 based SoCs
 #else
 
 struct entropy_stm32_rng_dev_cfg {


### PR DESCRIPTION
It appears the STM32F411XE doesn't support RNG so remove enabling it
from the SoC defconfig and flag an error if attempting to build the
driver on that SoC.

Signed-off-by: Kumar Gala <kumar.gala@linaro.org>