### PR TITLE
doc: fix misspellings in Kconfig files

### DIFF
--- a/arch/arc/Kconfig
+++ b/arch/arc/Kconfig
@@ -154,7 +154,7 @@ config ARC_HAS_SECURE
 	#  a hidden option
 	default n
 	help
-	  This opiton is enabled when ARC core supports secure mode
+	  This option is enabled when ARC core supports secure mode
 
 menu "ARC MPU Options"
 depends on CPU_HAS_MPU

--- a/arch/posix/soc/inf_clock/Kconfig.soc
+++ b/arch/posix/soc/inf_clock/Kconfig.soc
@@ -3,11 +3,11 @@
 config SOC_POSIX
 	bool "Native POSIX port"
 	help
-	SOC for to the POSIX arch. It emulates a CPU running at an infinitely high
+	SOC for to the POSIX arch. It emulates a CPU running at an infinitely fast
 	clock. That means the CPU will always run in zero time until completion after
 	each wake reason (e.g. interrupts), before going back to idle. Note that an
 	infinite loop in the code which does not sleep the CPU will cause the process
-	to apeared "hang", as simulated time does not advance while the cpu does not
+	to appear "hung", as simulated time does not advance while the CPU does not
 	sleep. Therefore do not use busy waits while waiting for something to happen
 	(if needed use k_busy_wait()).
 	Note that the interrupt handling is provided by the board.

--- a/boards/posix/native_posix/Kconfig
+++ b/boards/posix/native_posix/Kconfig
@@ -4,7 +4,7 @@ if BOARD_NATIVE_POSIX
 comment "Simple process (POSIX) Options"
 
 config NATIVE_POSIX_SLOWDOWN_TO_REAL_TIME
-	bool "Slow down exectution to real time"
+	bool "Slow down execution to real time"
 	depends on BOARD_NATIVE_POSIX
 	default y
 	help
@@ -12,7 +12,7 @@ config NATIVE_POSIX_SLOWDOWN_TO_REAL_TIME
 	  (if there is a lot of load it may be slower than real time)
 	  If deselected, the process will run as fast as possible.
 	  Note that this only decouples simulated time from real/wall time. In either
-	  case the zephyr kernel and application cannot tell the diffence unless they
+	  case the zephyr kernel and application cannot tell the difference unless they
 	  interact with some other driver/device which runs at real time.
 
 endif


### PR DESCRIPTION
periodic scan for typos missed during normal reviews

Signed-off-by: David B. Kinder <david.b.kinder@intel.com>