### PR TITLE
samples: crypto: increase min_ram for sample

### DIFF
--- a/samples/drivers/crypto/sample.yaml
+++ b/samples/drivers/crypto/sample.yaml
@@ -5,6 +5,7 @@ sample:
 common:
   tags: crypto
   harness: console
+  min_ram: 16
 tests:
   test-mbedtls:
     extra_args: CONF_FILE=prj_mtls_shim.conf


### PR DESCRIPTION
This samples does not fit on platforms with 8k RAM, increase minimal
requirements.

Signed-off-by: Anas Nashif <anas.nashif@intel.com>