### PR TITLE
object_tracing: remove tracing from ring_buffer

### DIFF
--- a/include/debug/object_tracing.h
+++ b/include/debug/object_tracing.h
@@ -28,8 +28,6 @@ extern struct k_msgq     *_trace_list_k_msgq;
 extern struct k_mbox     *_trace_list_k_mbox;
 extern struct k_pipe     *_trace_list_k_pipe;
 
-extern struct ring_buf   *_trace_list_sys_ring_buf;
-
 /**
  * @def SYS_TRACING_HEAD
  *

--- a/include/debug/object_tracing_common.h
+++ b/include/debug/object_tracing_common.h
@@ -97,9 +97,5 @@
 	}						      \
 	while (0)
 
-struct ring_buf;
-
-extern struct ring_buf   *_trace_list_sys_ring_buf;
-
 #endif  /*CONFIG_OBJECT_TRACING*/
 #endif  /*_OBJECT_TRACING_COMMON_H_*/

--- a/include/ring_buffer.h
+++ b/include/ring_buffer.h
@@ -11,7 +11,6 @@
 #define __RING_BUFFER_H__
 
 #include <kernel.h>
-#include <debug/object_tracing_common.h>
 #include <misc/util.h>
 #include <errno.h>
 
@@ -33,9 +32,6 @@ struct ring_buf {
 	u32_t size;   /**< Size of buf in 32-bit chunks */
 	u32_t *buf;	 /**< Memory region for stored entries */
 	u32_t mask;   /**< Modulo mask if size is a power of 2 */
-#ifdef CONFIG_OBJECT_TRACING
-	struct ring_buf *__next;
-#endif
 };
 
 /**
@@ -118,7 +114,6 @@ static inline void sys_ring_buf_init(struct ring_buf *buf, u32_t size,
 		buf->mask = 0;
 	}
 
-	SYS_TRACING_OBJ_INIT(sys_ring_buf, buf);
 }
 
 /**


### PR DESCRIPTION
The ring buffer was missing the needed hooks needed for object tracing.
Removed rather than fixing, ring_buffer is not a kernel object and does not require tracing support

Signed-off-by: Anas Nashif <anas.nashif@intel.com>