### PR TITLE
net: lwm2m: fix reporting attributes with negative fraction

### DIFF
--- a/subsys/net/lib/lwm2m/lwm2m_engine.c
+++ b/subsys/net/lib/lwm2m/lwm2m_engine.c
@@ -2725,13 +2725,17 @@ static int print_attr(struct net_pkt *pkt, char *buf, u16_t buflen,
 
 	SYS_SLIST_FOR_EACH_CONTAINER(attr_list, attr, node) {
 		/* assuming integer will have float_val.val2 set as 0 */
-		used = snprintk(buf, buflen, ";%s=%d%s",
+
+		used = snprintk(buf, buflen, ";%s=%s%d%s",
 				LWM2M_ATTR_STR[attr->type],
+				attr->float_val.val1 == 0 &&
+				attr->float_val.val2 < 0 ? "-" : "",
 				attr->float_val.val1,
-				attr->float_val.val2 > 0 ? "." : "");
+				attr->float_val.val2 != 0 ? "." : "");
 
 		base = 100000;
-		fraction = attr->float_val.val2;
+		fraction = attr->float_val.val2 < 0 ?
+			   -attr->float_val.val2 : attr->float_val.val2;
 		while (fraction && used < buflen && base > 0) {
 			digit = fraction / base;
 			buf[used++] = '0' + digit;


### PR DESCRIPTION
Fraction could be stored with negative value.
The implementation was only considering the positive value case.
Therefore, we have to modify the code to take care of the case.

Signed-off-by: Robert Chou <robert.ch.chou@acer.com>