### PR TITLE
cmake: kobject: Fixed kobject text area overflow for optimization 0

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -705,6 +705,8 @@ if(CONFIG_USERSPACE)
     ${CMAKE_CURRENT_BINARY_DIR}/${OUTPUT_SRC}
     )
 
+  # always compile kobject_hash.c at optimization -Os
+  set_source_files_properties(${OUTPUT_SRC} PROPERTIES COMPILE_FLAGS -Os)
   target_link_libraries(output_lib zephyr_interface)
 
   # Turn off -ffunction-sections, etc.


### PR DESCRIPTION
We need to allocate extra memory region for the hash function
that the gperf generates. The linker will need to maintain
the same location counter between multiple linker stages. Reserving memory
will help in maintaing correct location counters between multiple stages.
The required memory varies with optimization level.
In order to keep the size of the compiled object consistent,
the kobject_hash.c is always compiled with -Os.

fixes #5226 

Signed-off-by: Adithya Baglody <adithya.nagaraj.baglody@intel.com>