### PR TITLE
POSIX tests misc fixes

### DIFF
--- a/scripts/sanitycheck
+++ b/scripts/sanitycheck
@@ -358,11 +358,11 @@ class NativeHandler(Handler):
         with open(self.run_log, "r") as rl:
             for line in rl.readlines():
                 line = line.strip()
-                if line == self.RUN_PASSED:
+                if self.RUN_PASSED in line:
                     out_state = "passed"
                     break
 
-                if line == self.RUN_FAILED:
+                if self.RUN_FAILED in line:
                     out_state = "failed"
                     break
 

--- a/tests/drivers/ipm/testcase.yaml
+++ b/tests/drivers/ipm/testcase.yaml
@@ -1,5 +1,5 @@
 tests:
   test:
     filter: not CONFIG_SOC_QUARK_SE_C1000_SS
-    platform_exclude: native_posix
+    arch_exclude: posix
     tags: drivers ipc

--- a/tests/kernel/context/src/context.c
+++ b/tests/kernel/context/src/context.c
@@ -65,8 +65,15 @@
  * The Cortex-M use the SYSTICK exception for the system timer, which is
  * not considered an IRQ by the irq_enable/Disable APIs.
  */
-#elif defined(CONFIG_ARCH_POSIX) && defined(CONFIG_BOARD_NATIVE_POSIX)
+#elif defined(CONFIG_ARCH_POSIX)
+#if  defined(CONFIG_BOARD_NATIVE_POSIX)
 #define TICK_IRQ TIMER_TICK_IRQ
+#else
+/*
+ * Other POSIX arch boards will skip the irq_disable() and irq_enable() test
+ * unless TICK_IRQ is defined here for them
+ */
+#endif /* defined(CONFIG_ARCH_POSIX) */
 #else
 /* generate an error */
 #error Timer type is not defined for this platform
@@ -922,6 +929,9 @@ void testing_context(void)
 	rv = test_kernel_interrupts(irq_disable_wrapper, irq_enable_wrapper,
 				    TICK_IRQ);
 	zassert_equal(rv, TC_PASS, "kernel interrpt failure");
+#else
+	TC_PRINT("Test of irq_disable() and irq_enable() skipped "
+		"(TICK_IRQ not defined in this platform)\n");
 #endif
 
 	TC_PRINT("Testing some kernel context routines\n");


### PR DESCRIPTION
* Sanitycheck: Allow prefixes or postfixes around the PROJECT EXECUTION SUCCESSFUL/FAILED message
* tests/driver/ipm blacklisted for POSIX arch in general, not just for native_posix board
* tests: kernel/context support other POSIX boards by default (just without one small part of the test, and a warning)
