### PR TITLE
net: use UNALIGNED_ACCESS when accessing s_addr on received packets.

### DIFF
--- a/include/net/net_ip.h
+++ b/include/net/net_ip.h
@@ -438,7 +438,7 @@ static inline bool net_is_ipv4_addr_loopback(struct in_addr *addr)
  */
 static inline bool net_is_ipv4_addr_unspecified(const struct in_addr *addr)
 {
-	return addr->s_addr == 0;
+	return UNALIGNED_GET(&addr->s_addr) == 0;
 }
 
 /**
@@ -450,7 +450,7 @@ static inline bool net_is_ipv4_addr_unspecified(const struct in_addr *addr)
  */
 static inline bool net_is_ipv4_addr_mcast(const struct in_addr *addr)
 {
-	return (ntohl(addr->s_addr) & 0xE0000000) == 0xE0000000;
+	return (ntohl(UNALIGNED_GET(&addr->s_addr)) & 0xE0000000) == 0xE0000000;
 }
 
 extern struct net_if_addr *net_if_ipv4_addr_lookup(const struct in_addr *addr,

--- a/subsys/net/ip/net_if.c
+++ b/subsys/net/ip/net_if.c
@@ -1507,7 +1507,7 @@ struct net_if_router *net_if_ipv4_router_add(struct net_if *iface,
 bool net_if_ipv4_addr_mask_cmp(struct net_if *iface,
 			       struct in_addr *addr)
 {
-	u32_t subnet = ntohl(addr->s_addr) &
+	u32_t subnet = ntohl(UNALIGNED_GET(&addr->s_addr)) &
 			ntohl(iface->ipv4.netmask.s_addr);
 	int i;
 


### PR DESCRIPTION
The offset of the IP header in a received packet depends on the L2
header size.  For Ethernet this is 14 bytes which puts the u32 IPv4
addresses on a non-u32 byte boundary.  This causes chips that don't
support unaligned access (like the Cortex-M0) to fault.

The fixes in this patch are enough to ping the board and run the
http_server sample.

Signed-off-by: Michael Hope <mlhx@google.com>