### PR TITLE
script: make gen_kobject_list.py compatible with dwarf-2

### DIFF
--- a/scripts/gen_kobject_list.py
+++ b/scripts/gen_kobject_list.py
@@ -450,7 +450,7 @@ def find_kobjects(elf, syms):
                 continue
 
             loc = die.attributes["DW_AT_location"]
-            if loc.form != "DW_FORM_exprloc":
+            if loc.form != "DW_FORM_exprloc" and loc.form != "DW_FORM_block1":
                 debug_die(
                     die,
                     "kernel object '%s' unexpected location format" %


### PR DESCRIPTION
This issuse is found in arch/arc's memory domain api support.
For arc, dwarf-2 is used to keep compatible with synopsys metaware
mdb debugger. However, the gen_kobject_list.py cannot generate the correct
information from dwarf-2, because loc.form's value is DW_FORM_block1.

If dwarf-4 is adopted, there is no issuse.

Other arch and tools may use dwarf-2 and face the same issuse, so this
commit is created.

Signed-off-by: Wayne Ren <wei.ren@synopsys.com>