### PR TITLE
tests: x86_mmu_api: Fixed testcase crash.

### DIFF
--- a/tests/kernel/mem_protect/x86_mmu_api/src/userbuffer_validate.c
+++ b/tests/kernel/mem_protect/x86_mmu_api/src/userbuffer_validate.c
@@ -13,7 +13,7 @@
 #include <ztest.h>
 #include <nano_internal.h>
 
-#define SKIP_SIZE 2
+#define SKIP_SIZE 5
 #define BUFF_SIZE 10
 
 static int status;


### PR DESCRIPTION
Running this testcase on qemu without userspace enabled it
crashes. The testcase was modifing page table information
of the bss region. This in turn caused some variables to be
inaccessible. Fixed it by moving the page manipulation to a
different location.

Fixes GH-5646

Signed-off-by: Adithya Baglody <adithya.nagaraj.baglody@intel.com>