### PR TITLE
cmake: do not error on missing 'config'

### DIFF
--- a/cmake/host-tools.cmake
+++ b/cmake/host-tools.cmake
@@ -17,9 +17,6 @@ if (NOT WIN32)
     KCONFIG_CONF
     conf
     )
-  if(${KCONFIG_CONF} STREQUAL KCONFIG_CONF-NOTFOUND)
-    message(FATAL_ERROR "Unable to find the Kconfig program 'conf'")
-  endif()
 endif()
 
 find_program(


### PR DESCRIPTION
'conf' is part of the zephyr SDK or need to be built and installed in
the path. We now using python for Kconfig processing, so this is not a
strict requirement and we should be able to build without it. If the
binary is not found, just go on with our business.