### PR TITLE
Revert "ztest: cleanup phase should reset the timeout queue."

### DIFF
--- a/tests/ztest/src/ztest.c
+++ b/tests/ztest/src/ztest.c
@@ -6,9 +6,6 @@
 
 #include <ztest.h>
 #include <stdio.h>
-#ifdef KERNEL
-__kernel static struct k_thread ztest_thread;
-#endif
 
 enum {
 	TEST_PHASE_SETUP,
@@ -26,15 +23,6 @@ static int cleanup_test(struct unit_test *test)
 	int mock_status;
 
 	mock_status = _cleanup_mock();
-
-#ifdef KERNEL
-	/* we need to remove the ztest_thread information from the timeout_q.
-	 * Because we reuse the same k_thread structure this would
-	 * causes some problems.
-	 */
-	k_thread_abort(&ztest_thread);
-#endif
-
 	if (!ret && mock_status == 1) {
 		PRINT("Test %s failed: Unused mock parameter values\n",
 		      test->name);
@@ -151,7 +139,7 @@ out:
 #if CONFIG_ZTEST_STACKSIZE & (STACK_ALIGN - 1)
     #error "CONFIG_ZTEST_STACKSIZE must be a multiple of the stack alignment"
 #endif
-
+__kernel static struct k_thread ztest_thread;
 static K_THREAD_STACK_DEFINE(thread_stack, CONFIG_ZTEST_STACKSIZE +
 			     CONFIG_TEST_EXTRA_STACKSIZE);
 


### PR DESCRIPTION
This reverts commit 5e545e47fb1ea288d41503b2ceb3f513669c7f47.

This is breaking some tests, needs to be retested with latest master.

Signed-off-by: Anas Nashif <anas.nashif@intel.com>