### PR TITLE
net: dhcp: Implement DNS server setting

### DIFF
--- a/include/net/dns_resolve.h
+++ b/include/net/dns_resolve.h
@@ -176,7 +176,8 @@ struct dns_resolve_context {
  * @brief Init DNS resolving context.
  *
  * @details This function sets the DNS server address and initializes the
- * DNS context that is used by the actual resolver.
+ * DNS context that is used by the actual resolver. DNS server addresses
+ * can be specified either in textual form, or as struct sockaddr (or both).
  * Note that the recommended way to resolve DNS names is to use
  * the dns_get_addr_info() API. In that case user does not need to
  * call dns_resolve_init() as the DNS servers are already setup by the system.
@@ -185,18 +186,22 @@ struct dns_resolve_context {
  * the stack, then the variable needs to be valid for the whole duration of
  * the resolving. Caller does not need to fill the variable beforehand or
  * edit the context afterwards.
- * @param dns_servers DNS server addresses. The array is null terminated.
- * The port number can be given in the string.
+ * @param dns_servers_str DNS server addresses using textual strings. The
+ * array is NULL terminated. The port number can be given in the string.
  * Syntax for the server addresses with or without port numbers:
  *    IPv4        : 10.0.9.1
  *    IPv4 + port : 10.0.9.1:5353
  *    IPv6        : 2001:db8::22:42
  *    IPv6 + port : [2001:db8::22:42]:5353
+ * @param dns_servers_sa DNS server addresses as struct sockaddr. The array
+ * is NULL terminated. Port numbers are optional in struct sockaddr, the
+ * default will be used if set to 0.
  *
  * @return 0 if ok, <0 if error.
  */
 int dns_resolve_init(struct dns_resolve_context *ctx,
-		     const char *dns_servers[]);
+		     const char *dns_servers_str[],
+		     const struct sockaddr *dns_servers_sa[]);
 
 /**
  * @brief Close DNS resolving context.

--- a/subsys/net/lib/dns/resolve.c
+++ b/subsys/net/lib/dns/resolve.c
@@ -837,6 +837,8 @@ int dns_resolve_close(struct dns_resolve_context *ctx)
 		}
 	}
 
+	ctx->is_used = false;
+
 	return 0;
 }
 

--- a/subsys/net/lib/dns/resolve.c
+++ b/subsys/net/lib/dns/resolve.c
@@ -77,7 +77,50 @@ NET_BUF_POOL_DEFINE(dns_qname_pool, DNS_RESOLVER_BUF_CTR, DNS_MAX_NAME_LEN,
 
 static struct dns_resolve_context dns_default_ctx;
 
-int dns_resolve_init(struct dns_resolve_context *ctx, const char *servers[])
+static void dns_postprocess_server(struct dns_resolve_context *ctx, int idx)
+{
+	struct sockaddr *addr = &ctx->servers[idx].dns_server;
+
+	if (addr->sa_family == AF_INET) {
+		if (net_is_ipv4_addr_mcast(&net_sin(addr)->sin_addr)) {
+			ctx->servers[idx].is_mdns = true;
+		} else {
+			ctx->servers[idx].is_mdns = false;
+		}
+
+		if (net_sin(addr)->sin_port == 0) {
+			if (IS_ENABLED(CONFIG_MDNS_RESOLVER) &&
+			    ctx->servers[idx].is_mdns) {
+				/* We only use 5353 as a default port
+				 * if mDNS support is enabled. User can
+				 * override this by defining the port
+				 * in config file.
+				 */
+				net_sin(addr)->sin_port = htons(5353);
+			} else {
+				net_sin(addr)->sin_port = htons(53);
+			}
+		}
+	} else {
+		if (net_is_ipv6_addr_mcast(&net_sin6(addr)->sin6_addr)) {
+			ctx->servers[idx].is_mdns = true;
+		} else {
+			ctx->servers[idx].is_mdns = false;
+		}
+
+		if (net_sin6(addr)->sin6_port == 0) {
+			if (IS_ENABLED(CONFIG_MDNS_RESOLVER) &&
+			    ctx->servers[idx].is_mdns) {
+				net_sin6(addr)->sin6_port = htons(5353);
+			} else {
+				net_sin6(addr)->sin6_port = htons(53);
+			}
+		}
+	}
+}
+
+int dns_resolve_init(struct dns_resolve_context *ctx, const char *servers[],
+		     const struct sockaddr *servers_sa[])
 {
 #if defined(CONFIG_NET_IPV6)
 	struct sockaddr_in6 local_addr6 = {
@@ -100,66 +143,39 @@ int dns_resolve_init(struct dns_resolve_context *ctx, const char *servers[])
 		return -ENOENT;
 	}
 
-	if (!servers || !*servers) {
-		return -ENOENT;
-	}
-
 	if (ctx->is_used) {
 		return -ENOTEMPTY;
 	}
 
 	memset(ctx, 0, sizeof(*ctx));
 
-	for (i = 0; i < SERVER_COUNT && servers[i]; i++) {
-		struct sockaddr *addr = &ctx->servers[idx].dns_server;
+	if (servers) {
+		for (i = 0; idx < SERVER_COUNT && servers[i]; i++) {
+			struct sockaddr *addr = &ctx->servers[idx].dns_server;
 
-		memset(addr, 0, sizeof(*addr));
+			memset(addr, 0, sizeof(*addr));
 
-		ret = net_ipaddr_parse(servers[i], strlen(servers[i]), addr);
-		if (!ret) {
-			continue;
+			ret = net_ipaddr_parse(servers[i], strlen(servers[i]),
+					       addr);
+			if (!ret) {
+				continue;
+			}
+
+			dns_postprocess_server(ctx, idx);
+
+			NET_DBG("[%d] %s", i, servers[i]);
+
+			idx++;
 		}
+	}
 
-		if (addr->sa_family == AF_INET) {
-			if (net_is_ipv4_addr_mcast(&net_sin(addr)->sin_addr)) {
-				ctx->servers[idx].is_mdns = true;
-			} else {
-				ctx->servers[idx].is_mdns = false;
-			}
-
-			if (net_sin(addr)->sin_port == 0) {
-				if (IS_ENABLED(CONFIG_MDNS_RESOLVER) &&
-				    ctx->servers[idx].is_mdns) {
-					/* We only use 5353 as a default port
-					 * if mDNS support is enabled. User can
-					 * override this by defining the port
-					 * in config file.
-					 */
-					net_sin(addr)->sin_port = htons(5353);
-				} else {
-					net_sin(addr)->sin_port = htons(53);
-				}
-			}
-		} else {
-			if (net_is_ipv6_addr_mcast(&net_sin6(addr)->sin6_addr)) {
-				ctx->servers[idx].is_mdns = true;
-			} else {
-				ctx->servers[idx].is_mdns = false;
-			}
-
-			if (net_sin6(addr)->sin6_port == 0) {
-				if (IS_ENABLED(CONFIG_MDNS_RESOLVER) &&
-				    ctx->servers[idx].is_mdns) {
-					net_sin6(addr)->sin6_port = htons(5353);
-				} else {
-					net_sin6(addr)->sin6_port = htons(53);
-				}
-			}
+	if (servers_sa) {
+		for (i = 0; idx < SERVER_COUNT && servers_sa[i]; i++) {
+			memcpy(&ctx->servers[idx].dns_server, servers_sa[i],
+			       sizeof(ctx->servers[idx].dns_server));
+			dns_postprocess_server(ctx, idx);
+			idx++;
 		}
-
-		NET_DBG("[%d] %s", i, servers[i]);
-
-		idx++;
 	}
 
 	for (i = 0, count = 0;
@@ -904,7 +920,7 @@ void dns_init_resolver(void)
 
 	dns_servers[SERVER_COUNT] = NULL;
 
-	ret = dns_resolve_init(dns_resolve_get_default(), dns_servers);
+	ret = dns_resolve_init(dns_resolve_get_default(), dns_servers, NULL);
 	if (ret < 0) {
 		NET_WARN("Cannot initialize DNS resolver (%d)", ret);
 	}


### PR DESCRIPTION
~~~
net: ip: dhcpv4: Handle DHCPV4_OPTIONS_DNS_SERVER

Actually set Zephyr's default DNS server based on the corresponding
DHCP option received. This makes DHCP-based setup Zephyr complete:
now it's possible to connect Zephyr DHCP-enabled system to a typical
router, and it will fully auto-configure to access Internet.

This initial implementation uses just first DNS server address as
returned in DHCP message, it may need to be extended in the future
based on the need.

Signed-off-by: John Andersen <john.s.andersen@intel.com>
Signed-off-by: Paul Sokolovsky <paul.sokolovsky@linaro.org>
~~~
