### PR TITLE
cmake: Fix "make usage" regression from the ZEPHYR_BASE change

### DIFF
--- a/cmake/usage/usage.cmake
+++ b/cmake/usage/usage.cmake
@@ -12,7 +12,7 @@ set(arch_list
   xtensa
   )
 
-set(board_dir ${ZEPHYR_BASE}/boards)
+set(board_dir $ENV{ZEPHYR_BASE}/boards)
 
 foreach(arch ${arch_list})
   set(board_arch_dir ${board_dir}/${arch})


### PR DESCRIPTION
$ENV{ZEPHYR_BASE} was recently search-replaced with ${ZEPHYR_BASE},
but some CMake code, like usage.cmake, is run by a seperate CMake
build system that does not have access to the CMake variable
ZEPHYR_BASE.

This patch reverts the usage of ${ZEPHYR_BASE} back to use
$ENV{ZEPHYR_BASE} in usage.cmake.

This has been proven to work on both Windows and Linux.

Signed-off-by: Sebastian Bøe <sebastian.boe@nordicsemi.no>