### PR TITLE
mesh: Reset Heartbeat Publication timer before sending message

### DIFF
--- a/subsys/bluetooth/host/mesh/cfg_srv.c
+++ b/subsys/bluetooth/host/mesh/cfg_srv.c
@@ -3062,7 +3062,7 @@ static void hb_publish(struct k_work *work)
 	}
 
 	period_ms = hb_pwr2(cfg->hb_pub.period, 1) * 1000;
-	if (period_ms) {
+	if (period_ms && cfg->hb_pub.count > 1) {
 		k_delayed_work_submit(&cfg->hb_pub.timer, period_ms);
 	}
 

--- a/subsys/bluetooth/host/mesh/cfg_srv.c
+++ b/subsys/bluetooth/host/mesh/cfg_srv.c
@@ -3057,19 +3057,19 @@ static void hb_publish(struct k_work *work)
 		return;
 	}
 
-	hb_send(model);
-
 	if (cfg->hb_pub.count == 0) {
 		return;
-	}
-
-	if (cfg->hb_pub.count != 0xffff) {
-		cfg->hb_pub.count--;
 	}
 
 	period_ms = hb_pwr2(cfg->hb_pub.period, 1) * 1000;
 	if (period_ms) {
 		k_delayed_work_submit(&cfg->hb_pub.timer, period_ms);
+	}
+
+	hb_send(model);
+
+	if (cfg->hb_pub.count != 0xffff) {
+		cfg->hb_pub.count--;
 	}
 }
 


### PR DESCRIPTION
The timer should be reset before sending to ensure correct publication period.

This patch allows to pass MESH/NODE/CFG/HBP/BV-02-C.

This patch is ported from mynewt:
Commit: d4b84638df47e7ea21629e6919f547f5dcd47285

Signed-off-by: Mariusz Skamra <mariusz.skamra@codecoup.pl>