### PR TITLE
 net: app: Allow to specify both static IP settings and DHCPv4.

### DIFF
--- a/include/net/net_ip.h
+++ b/include/net/net_ip.h
@@ -208,6 +208,7 @@ enum net_addr_type {
 	NET_ADDR_AUTOCONF,
 	NET_ADDR_DHCP,
 	NET_ADDR_MANUAL,
+	NET_ADDR_OVERRIDABLE,
 };
 
 #if NET_LOG_ENABLED > 0
@@ -220,6 +221,8 @@ static inline char *net_addr_type2str(enum net_addr_type type)
 		return "DHCP";
 	case NET_ADDR_MANUAL:
 		return "MANUAL";
+	case NET_ADDR_OVERRIDABLE:
+		return "OVERRIDE";
 	case NET_ADDR_ANY:
 	default:
 		break;

--- a/subsys/net/ip/net_if.c
+++ b/subsys/net/ip/net_if.c
@@ -1583,32 +1583,43 @@ struct net_if_addr *net_if_ipv4_addr_add(struct net_if *iface,
 
 	ifaddr = ipv4_addr_find(iface, addr);
 	if (ifaddr) {
+		/* TODO: should set addr_type/vlifetime */
 		return ifaddr;
 	}
 
 	for (i = 0; i < NET_IF_MAX_IPV4_ADDR; i++) {
-		if (iface->ipv4.unicast[i].is_used) {
-			continue;
+		struct net_if_addr *cur = &iface->ipv4.unicast[i];
+		if (addr_type == NET_ADDR_DHCP
+		    && cur->addr_type == NET_ADDR_OVERRIDABLE) {
+			ifaddr = cur;
+			break;
 		}
 
-		iface->ipv4.unicast[i].is_used = true;
-		iface->ipv4.unicast[i].address.family = AF_INET;
-		iface->ipv4.unicast[i].address.in_addr.s4_addr32[0] =
+		if (!iface->ipv4.unicast[i].is_used) {
+			ifaddr = cur;
+			break;
+		}
+	}
+
+	if (ifaddr) {
+		ifaddr->is_used = true;
+		ifaddr->address.family = AF_INET;
+		ifaddr->address.in_addr.s4_addr32[0] =
 						addr->s4_addr32[0];
-		iface->ipv4.unicast[i].addr_type = addr_type;
+		ifaddr->addr_type = addr_type;
 
 		/* Caller has to take care of timers and their expiry */
 		if (vlifetime) {
-			iface->ipv4.unicast[i].is_infinite = false;
+			ifaddr->is_infinite = false;
 		} else {
-			iface->ipv4.unicast[i].is_infinite = true;
+			ifaddr->is_infinite = true;
 		}
 
 		/**
 		 *  TODO: Handle properly PREFERRED/DEPRECATED state when
 		 *  address in use, expired and renewal state.
 		 */
-		iface->ipv4.unicast[i].addr_state = NET_ADDR_PREFERRED;
+		ifaddr->addr_state = NET_ADDR_PREFERRED;
 
 		NET_DBG("[%d] interface %p address %s type %s added", i, iface,
 			net_sprint_ipv4_addr(addr),
@@ -1616,7 +1627,7 @@ struct net_if_addr *net_if_ipv4_addr_add(struct net_if *iface,
 
 		net_mgmt_event_notify(NET_EVENT_IPV4_ADDR_ADD, iface);
 
-		return &iface->ipv4.unicast[i];
+		return ifaddr;
 	}
 
 	return NULL;

--- a/subsys/net/ip/net_shell.c
+++ b/subsys/net/ip/net_shell.c
@@ -74,6 +74,8 @@ static inline const char *addrtype2str(enum net_addr_type addr_type)
 		return "DHCP";
 	case NET_ADDR_MANUAL:
 		return "manual";
+	case NET_ADDR_OVERRIDABLE:
+		return "overridable";
 	}
 
 	return "<invalid type>";

--- a/subsys/net/lib/app/init.c
+++ b/subsys/net/lib/app/init.c
@@ -90,11 +90,12 @@ static void setup_dhcpv4(struct net_if *iface)
 #define setup_dhcpv4(...)
 #endif /* CONFIG_NET_DHCPV4 */
 
-#if defined(CONFIG_NET_IPV4) && !defined(CONFIG_NET_DHCPV4)
-
-#if !defined(CONFIG_NET_APP_MY_IPV4_ADDR)
+#if defined(CONFIG_NET_IPV4) && !defined(CONFIG_NET_DHCPV4) && \
+    !defined(CONFIG_NET_APP_MY_IPV4_ADDR)
 #error "You need to define an IPv4 address or enable DHCPv4!"
 #endif
+
+#if defined(CONFIG_NET_IPV4) && defined(CONFIG_NET_APP_MY_IPV4_ADDR)
 
 static void setup_ipv4(struct net_if *iface)
 {

--- a/subsys/net/lib/app/init.c
+++ b/subsys/net/lib/app/init.c
@@ -114,7 +114,21 @@ static void setup_ipv4(struct net_if *iface)
 		return;
 	}
 
+#if defined(CONFIG_NET_DHCPV4)
+	/* In case DHCP is enabled, make the static address tentative,
+	 * to allow DHCP address to override it. This covers a usecase
+	 * of "there should be a static IP address for DHCP-less setups",
+	 * but DHCP should override it (to use it, NET_IF_MAX_IPV4_ADDR
+	 * should be set to 1). There is another usecase: "there should
+	 * always be static IP address, and optionally, DHCP address".
+	 * For that to work, NET_IF_MAX_IPV4_ADDR should be 2 (or more).
+	 * (In this case, an app will need to bind to the needed addr
+	 * explicitly.)
+	 */
+	net_if_ipv4_addr_add(iface, &addr, NET_ADDR_OVERRIDABLE, 0);
+#else
 	net_if_ipv4_addr_add(iface, &addr, NET_ADDR_MANUAL, 0);
+#endif
 
 #if defined(CONFIG_NET_DEBUG_APP) && CONFIG_SYS_LOG_NET_LEVEL > 1
 	NET_INFO("IPv4 address: %s",


### PR DESCRIPTION
~~~
The idea is that static config is used unless/until DHCP values
arrive. This allows to have the same network configuration values
for both a case of direct board - workstation connection (where
DHCP is usually not available), and a case where both a board and
workstation connect to a router (which serves DHCP).

The changes in this commit however take care of netmask and gateway
settings, but not about IP address itself. This is addressed in the
next patch.

Signed-off-by: Paul Sokolovsky <paul.sokolovsky@linaro.org>
~~~