### PR TITLE
boards: nucleo_f429zi: Configure I2C1

### DIFF
--- a/boards/arm/nucleo_f429zi/Kconfig.board
+++ b/boards/arm/nucleo_f429zi/Kconfig.board
@@ -7,4 +7,5 @@
 
 config BOARD_NUCLEO_F429ZI
 	bool "NUCLEO-144 F429ZI  Development Board"
+	select HAS_DTS_I2C_DEVICE
 	depends on SOC_STM32F429XI

--- a/boards/arm/nucleo_f429zi/Kconfig.defconfig
+++ b/boards/arm/nucleo_f429zi/Kconfig.defconfig
@@ -27,4 +27,11 @@ config ETH_STM32_HAL
 
 endif # NETWORKING
 
+if I2C
+
+config I2C_1
+	def_bool y
+
+endif # I2C
+
 endif # BOARD_NUCLEO_F429ZI

--- a/boards/arm/nucleo_f429zi/doc/nucleof429zi.rst
+++ b/boards/arm/nucleo_f429zi/doc/nucleof429zi.rst
@@ -95,6 +95,8 @@ The Zephyr nucleo_f249zi board configuration supports the following hardware fea
 +-----------+------------+-------------------------------------+
 | PWM       | on-chip    | pwm                                 |
 +-----------+------------+-------------------------------------+
+| I2C       | on-chip    | i2c                                 |
++-----------+------------+-------------------------------------+
 
 
 Other hardware features are not yet supported on this Zephyr port.
@@ -141,6 +143,8 @@ Default Zephyr Peripheral Mapping:
 - UART_3_TX : PD8
 - UART_3_RX : PD9
 - PWM_2_CH1 : PA0
+- I2C1_SCL : PB8
+- I2C1_SDA : PB9
 - USER_PB : PC13
 - LD1 : PB0
 - LD2 : PB7

--- a/boards/arm/nucleo_f429zi/nucleo_f429zi.dts
+++ b/boards/arm/nucleo_f429zi/nucleo_f429zi.dts
@@ -18,6 +18,11 @@
 	};
 };
 
+&i2c1 {
+	status = "ok";
+	clock-frequency = <I2C_BITRATE_FAST>;
+};
+
 &usart3 {
 	current-speed = <115200>;
 	pinctrl-0 = <&usart3_pins_b>;

--- a/boards/arm/nucleo_f429zi/nucleo_f429zi_defconfig
+++ b/boards/arm/nucleo_f429zi/nucleo_f429zi_defconfig
@@ -21,6 +21,9 @@ CONFIG_PINMUX=y
 # enable GPIO
 CONFIG_GPIO=y
 
+# enable I2C
+CONFIG_I2C=y
+
 # clock configuration
 CONFIG_CLOCK_CONTROL=y
 
@@ -32,7 +35,7 @@ CONFIG_CLOCK_STM32_PLL_SRC_HSE=y
 # however, the board does not have an external oscillator, so just use
 # the 8MHz clock signal coming from integrated STLink
 CONFIG_CLOCK_STM32_HSE_BYPASS=y
-# produce 96MHz clock at PLL output
+# produce 180MHz clock at PLL output
 CONFIG_CLOCK_STM32_PLL_M_DIVISOR=8
 CONFIG_CLOCK_STM32_PLL_N_MULTIPLIER=360
 CONFIG_CLOCK_STM32_PLL_P_DIVISOR=2

--- a/boards/arm/nucleo_f429zi/pinmux.c
+++ b/boards/arm/nucleo_f429zi/pinmux.c
@@ -34,6 +34,10 @@ static const struct pin_config pinconf[] = {
 	{STM32_PIN_PG13, STM32F4_PINMUX_FUNC_PG13_ETH},
 	{STM32_PIN_PB13, STM32F4_PINMUX_FUNC_PB13_ETH},
 #endif /* CONFIG_ETH_STM32_HAL */
+#ifdef CONFIG_I2C_1
+	{STM32_PIN_PB8, STM32F4_PINMUX_FUNC_PB8_I2C1_SCL},
+	{STM32_PIN_PB9, STM32F4_PINMUX_FUNC_PB9_I2C1_SDA},
+#endif
 };
 
 static int pinmux_stm32_init(struct device *port)


### PR DESCRIPTION
Enable and configure I2C1.
This configuration enables ready to use compatibility
with expansion shields based on Arduino type connectors

Additionally, fix comment on clock speed in board _defconfig

Signed-off-by: Erwan Gouriou <erwan.gouriou@linaro.org>