### PR TITLE
doc: fix broken links in nucleo board docs

### DIFF
--- a/boards/arm/nucleo_f030r8/doc/nucleof030r8.rst
+++ b/boards/arm/nucleo_f030r8/doc/nucleof030r8.rst
@@ -164,7 +164,7 @@ References
    http://www.st.com/content/st_com/en/products/microcontrollers/stm32-32-bit-arm-cortex-mcus/stm32-mainstream-mcus/stm32f0-series/stm32f0x0-value-line/stm32f030r8.html
 
 .. _STM32F030 reference manual:
-   www.st.com/resource/en/reference_manual/dm00091010.pdf
+   http://www.st.com/resource/en/reference_manual/dm00091010.pdf
 
 .. _STM32 Nucleo-64 board User Manual:
    http://www.st.com/resource/en/user_manual/dm00105823.pdf

--- a/boards/arm/nucleo_f091rc/doc/nucleof091rc.rst
+++ b/boards/arm/nucleo_f091rc/doc/nucleof091rc.rst
@@ -172,7 +172,7 @@ References
    http://www.st.com/en/evaluation-tools/nucleo-f091rc.html
 
 .. _STM32F091 reference manual:
-   www.st.com/resource/en/reference_manual/dm00031936.pdf
+   http://www.st.com/resource/en/reference_manual/dm00031936.pdf
 
 .. _STM32 Nucleo-64 board User Manual:
    http://www.st.com/resource/en/user_manual/dm00105823.pdf


### PR DESCRIPTION
references to pdf files (e.g.,
www.st.com/resource/en/reference_manual/dm00091010.pdf)
were missing the http:// prefix so looked like a relative reference.

Signed-off-by: David B. Kinder <david.b.kinder@intel.com>