### PR TITLE
drivers: gpio: esp32: Fix pin input config in gpio_esp32_config()

### DIFF
--- a/drivers/gpio/gpio_esp32.c
+++ b/drivers/gpio/gpio_esp32.c
@@ -157,7 +157,8 @@ static int gpio_esp32_config(struct device *dev, int access_op,
 		r = pinmux_pin_input_enable(data->pinmux, pin,
 					PINMUX_OUTPUT_ENABLED);
 		assert(r >= 0);
-	} else {
+	}
+	if (flags & GPIO_DIR_IN) {
 		pinmux_pin_input_enable(data->pinmux, pin,
 					PINMUX_INPUT_ENABLED);
 		config_polarity(pin, flags);


### PR DESCRIPTION
Pins can be configured as input and output at the same time.
Ex: SDA and SCL on I2C driver.

Signed-off-by: Vitor Massaru Iha <vitor@massaru.org>

OBS.: This is one of the commits to fix the I2C, the I2C driver commits I'll send in just one PR.