### PR TITLE
boards: efm32wg_stk3800: Fix boards dts file copyright

### DIFF
--- a/boards/arm/efm32wg_stk3800/efm32wg_stk3800.dts
+++ b/boards/arm/efm32wg_stk3800/efm32wg_stk3800.dts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 I-SENSE group of ICCS
+ * Copyright (c) 2017 Christian Taedcke
  *
  * SPDX-License-Identifier: Apache-2.0
  */


### PR DESCRIPTION
Christian Taedcke is the author of this file according to
PR #271.

Signed-off-by: Yannis Damigos <giannis.damigos@gmail.com>