### PR TITLE
libc: include: Add dummy math.h header file

### DIFF
--- a/lib/libc/minimal/include/math.h
+++ b/lib/libc/minimal/include/math.h
@@ -1,0 +1,10 @@
+/*
+ * Copyright (c) 2018 Intel Corporation
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+
+/* Dummy math.h to fulfill the requirements of some libraries
+ * i.e. User application
+ */


### PR DESCRIPTION
Dummy math.h to fulfill the compilations requirements of some libraries.

Signed-off-by: Ding Tao <miyatsu@qq.com>