### PR TITLE
native: don't slow down tests

### DIFF
--- a/boards/posix/native_posix/Kconfig
+++ b/boards/posix/native_posix/Kconfig
@@ -6,7 +6,8 @@ comment "Simple process (POSIX) Options"
 config NATIVE_POSIX_SLOWDOWN_TO_REAL_TIME
 	bool "Slow down execution to real time"
 	depends on BOARD_NATIVE_POSIX
-	default y
+	default y if !TEST
+	default n if TEST
 	help
 	  When selected the execution of the process will be slowed down to real time.
 	  (if there is a lot of load it may be slower than real time)


### PR DESCRIPTION
For tests (CONFIG_TESTS) do not slow down the execution to real time.

For samples, we assume they are interactive and therefore it is still preferred to run them at real time.

This speeds up the native_posix part of sanitycheck
by ~50% (more the faster the computer)

Signed-off-by: Alberto Escolar Piedras <alpi@oticon.com>