### PR TITLE
Port ram report to native windows

### DIFF
--- a/scripts/footprint/size_report
+++ b/scripts/footprint/size_report
@@ -14,6 +14,7 @@ import subprocess
 import json
 import operator
 import platform
+from pathlib import Path
 
 parser = OptionParser()
 parser.add_option("-d", "--depth", dest="depth", type="int",
@@ -35,34 +36,76 @@ parser.add_option("-n", "--nm", type="string", dest="bin_nm",
 
 (options, args) = parser.parse_args()
 
-# Return a dict containing symbol_name: path/to/file/where/it/originates
-# for all symbols from the .elf file. Optionnaly strips the path according
+# Return a dict containing {
+#   symbol_name: {:,path/to/file}/symbol
+# }
+# for all symbols from the .elf file. Optionaly strips the path according
 # to the passed sub-path
-
-
-def load_symbols_and_paths(bin_nm, elf_file, path_to_strip=None):
-    symbols_paths = {}
+def load_symbols_and_paths(bin_nm, elf_file, path_to_strip=""):
     nm_out = subprocess.check_output(
         [bin_nm, elf_file, "-S", "-l", "--size-sort", "--radix=d"],
         universal_newlines=True
     )
     for line in nm_out.splitlines():
-        fields = line.replace('\t', ' ').split(' ')
-        # Get rid of trailing empty field
-        if len(fields) == 1 and fields[0] == '':
+        if not line:
+            # Get rid of trailing empty field
             continue
-        assert len(fields) >= 4
-        if len(fields) < 5:
-            path = ":/" + fields[3]
+
+        symbol, path = parse_symbol_path_pair(line)
+
+        if path:
+            processed_path = Path(path).relative_to(Path(path_to_strip))
         else:
-            path = fields[4].split(':')[0]
-        if path_to_strip is not None:
-            if path_to_strip in path:
-                path = path.replace(path_to_strip, "") + '/' + fields[3]
-            else:
-                path = ":/" + fields[3]
-        symbols_paths[fields[3]] = path
-    return symbols_paths
+            processed_path = Path(":")
+
+        pathlike_string = processed_path / symbol
+
+        yield symbol, pathlike_string
+
+# Return a pair containing either
+#
+#   (symbol_name, "path/to/file")
+#   or
+#   (symbol_name, "")
+#
+#   depending on if the file is found or not
+# }
+def parse_symbol_path_pair(line):
+    # Line's output from nm might look like this:
+    # '536871152 00000012 b gpio_e	/absolute/path/gpio.c:247'
+    #
+    # We are only trying to extract the symbol and the filename.
+    #
+    # In general lines look something like this:
+    #
+    # 'number number string symbol[\t<absolute_path>:line]
+    #
+    # The file is optional, nm might not find out where a symbol came from.
+    #
+    # NB: <absolute_path> looks different on Windows and Linux
+
+    # Replace tabs with spaces to easily split up the fields (NB:
+    # Whitespace in paths is not supported)
+    line_without_tabs = line.replace('\t', ' ')
+
+    fields = line_without_tabs.split()
+
+    assert len(fields) >= 4
+
+    symbol = fields[3]
+
+    file_is_missing = len(fields) == 4
+
+    if file_is_missing:
+        path = ""
+    else:
+        path_with_line_number = fields[4]
+
+        # Remove the trailing line number, e.g. 'C:\file.c:237'
+        line_number_index = path_with_line_number.rfind(':')
+        path = path_with_line_number[:line_number_index]
+
+    return (symbol, path)
 
 
 def get_section_size(f, section_name):
@@ -148,25 +191,24 @@ def generate_target_memory_section(
     bin_size = os.stat(bin_file_abs).st_size
 
     # Get the path associated to each symbol
-    symbols_paths = load_symbols_and_paths(bin_nm, elf_file_abs, source_dir)
+    symbols_paths = dict(load_symbols_and_paths(bin_nm, elf_file_abs, source_dir))
 
     # A set of helper function for building a simple tree with a path-like
     # hierarchy.
     def _insert_one_elem(tree, path, size):
-        splitted_path = path.split('/')
         cur = None
-        for p in splitted_path:
+        for p in path.parts:
             if cur is None:
                 cur = p
             else:
-                cur = cur + '/' + p
+                cur = cur + os.path.sep + p
             if cur in tree:
                 tree[cur] += size
             else:
                 tree[cur] = size
 
     def _parent_for_node(e):
-        parent = "root" if len(e.split('/')) == 1 else e.rsplit('/', 1)[0]
+        parent = "root" if len(os.path.sep) == 1 else e.rsplit(os.path.sep, 1)[0]
         if e == "root":
             parent = None
         return parent
@@ -340,7 +382,7 @@ def print_tree(data, total, depth):
         bcolors["FAIL"] + "Path", "Size", "%" + bcolors["ENDC"]))
     print("'='*110i")
     for i in sorted(data):
-        p = i.split("/")
+        p = i.split(os.path.sep)
         if depth and len(p) > depth:
             continue
 

--- a/scripts/footprint/size_report
+++ b/scripts/footprint/size_report
@@ -13,18 +13,7 @@ from optparse import OptionParser
 import subprocess
 import json
 import operator
-
-
-class bcolors:
-    HEADER = '\033[95m'
-    OKBLUE = '\033[94m'
-    OKGREEN = '\033[92m'
-    WARNING = '\033[93m'
-    FAIL = '\033[91m'
-    ENDC = '\033[0m'
-    BOLD = '\033[1m'
-    UNDERLINE = '\033[4m'
-
+import platform
 
 parser = OptionParser()
 parser.add_option("-d", "--depth", dest="depth", type="int",
@@ -318,8 +307,28 @@ def generate_target_memory_section(
 def print_tree(data, total, depth):
     base = os.environ['ZEPHYR_BASE']
     totp = 0
+
+    bcolors_ansi = {
+        "HEADER"    : '\033[95m',
+        "OKBLUE"    : '\033[94m',
+        "OKGREEN"   : '\033[92m',
+        "WARNING"   : '\033[93m',
+        "FAIL"      : '\033[91m',
+        "ENDC"      : '\033[0m',
+        "BOLD"      : '\033[1m',
+        "UNDERLINE" : '\033[4m'
+    }
+    if platform.system() == "Windows":
+        # Set all color codes to empty string on Windows
+        #
+        # TODO: Use an approach like the pip package 'colorama' to
+        # support colors on Windows
+        bcolors = dict.fromkeys(bcolors_ansi, '')
+    else:
+        bcolors = bcolors_ansi
+
     print('{:92s} {:10s} {:8s}'.format(
-        bcolors.FAIL + "Path", "Size", "%" + bcolors.ENDC))
+        bcolors["FAIL"] + "Path", "Size", "%" + bcolors["ENDC"]))
     print("'='*110i")
     for i in sorted(data):
         p = i.split("/")
@@ -333,14 +342,14 @@ def print_tree(data, total, depth):
 
         if len(p) > 1:
             if not os.path.exists(os.path.join(base, i)):
-                s = bcolors.WARNING + p[-1] + bcolors.ENDC
+                s = bcolors["WARNING"] + p[-1] + bcolors["ENDC"]
             else:
-                s = bcolors.OKBLUE + p[-1] + bcolors.ENDC
+                s = bcolors["OKBLUE"] + p[-1] + bcolors["ENDC"]
             print('{:80s} {:20d} {:8.2f}%'.format(
                 "  " * (len(p) - 1) + s, data[i], percent_c))
         else:
             print('{:80s} {:20d} {:8.2f}%'.format(
-                bcolors.OKBLUE + i + bcolors.ENDC, data[i], percent_c))
+                bcolors["OKBLUE"] + i + bcolors["ENDC"], data[i], percent_c))
 
     print('=' * 110)
     print('{:92d}'.format(total))

--- a/scripts/footprint/size_report
+++ b/scripts/footprint/size_report
@@ -43,8 +43,10 @@ parser.add_option("-n", "--nm", type="string", dest="bin_nm",
 def load_symbols_and_paths(bin_nm, elf_file, path_to_strip=None):
     symbols_paths = {}
     nm_out = subprocess.check_output(
-        [bin_nm, elf_file, "-S", "-l", "--size-sort", "--radix=d"])
-    for line in nm_out.decode('utf8').splitlines():
+        [bin_nm, elf_file, "-S", "-l", "--size-sort", "--radix=d"],
+        universal_newlines=True
+    )
+    for line in nm_out.splitlines():
         fields = line.replace('\t', ' ').split(' ')
         # Get rid of trailing empty field
         if len(fields) == 1 and fields[0] == '':
@@ -120,14 +122,17 @@ def generate_target_memory_section(
 
     # First deal with size on flash. These are the symbols flagged as LOAD in
     # objdump output
-    size_out = subprocess.check_output([bin_objdump, "-hw", elf_file_abs])
+    size_out = subprocess.check_output(
+        [bin_objdump, "-hw", elf_file_abs],
+        universal_newlines=True
+    )
     loaded_section_total = 0
     loaded_section_names = []
     loaded_section_names_sizes = {}
     ram_section_total = 0
     ram_section_names = []
     ram_section_names_sizes = {}
-    for line in size_out.decode('utf8').splitlines():
+    for line in size_out.splitlines():
         if "LOAD" in line:
             loaded_section_total = loaded_section_total + \
                 int(line.split()[2], 16)
@@ -182,7 +187,11 @@ def generate_target_memory_section(
 
     # Extract the list of symbols a second time but this time using the objdump tool
     # which provides more info as nm
-    symbols_out = subprocess.check_output([bin_objdump, "-tw", elf_file_abs])
+
+    symbols_out = subprocess.check_output(
+        [bin_objdump, "-tw", elf_file_abs],
+        universal_newlines=True
+    )
     flash_symbols_total = 0
     data_nodes = {}
     data_nodes['root'] = 0
@@ -190,7 +199,7 @@ def generate_target_memory_section(
     ram_symbols_total = 0
     ram_nodes = {}
     ram_nodes['root'] = 0
-    for l in symbols_out.decode('utf8').splitlines():
+    for l in symbols_out.splitlines():
         line = l[0:9] + "......." + l[16:]
         fields = line.replace('\t', ' ').split(' ')
         # Get rid of trailing empty field

--- a/scripts/footprint/size_report
+++ b/scripts/footprint/size_report
@@ -55,7 +55,7 @@ def load_symbols_and_paths(bin_nm, elf_file, path_to_strip=None):
     symbols_paths = {}
     nm_out = subprocess.check_output(
         [bin_nm, elf_file, "-S", "-l", "--size-sort", "--radix=d"])
-    for line in nm_out.decode('utf8').split('\n'):
+    for line in nm_out.decode('utf8').splitlines():
         fields = line.replace('\t', ' ').split(' ')
         # Get rid of trailing empty field
         if len(fields) == 1 and fields[0] == '':
@@ -138,7 +138,7 @@ def generate_target_memory_section(
     ram_section_total = 0
     ram_section_names = []
     ram_section_names_sizes = {}
-    for line in size_out.decode('utf8').split('\n'):
+    for line in size_out.decode('utf8').splitlines():
         if "LOAD" in line:
             loaded_section_total = loaded_section_total + \
                 int(line.split()[2], 16)
@@ -201,7 +201,7 @@ def generate_target_memory_section(
     ram_symbols_total = 0
     ram_nodes = {}
     ram_nodes['root'] = 0
-    for l in symbols_out.decode('utf8').split('\n'):
+    for l in symbols_out.decode('utf8').splitlines():
         line = l[0:9] + "......." + l[16:]
         fields = line.replace('\t', ' ').split(' ')
         # Get rid of trailing empty field


### PR DESCRIPTION
size_report was assuming that the GNU Binutils programs were
generating files with the line ending '\n'. But on native Windows
binutils will generate files with the line ending \r\n.

This patches size_report to use so-called "Universal newlines"[0], so
that size_report can deal with any kind of newline on any kind of
platform.

Also, size_report was assuming Unix-style absolute paths and misbehaving
when paths had a colon ("C:\") in them.

Tested on Ubuntu and native Windows.

[0] https://www.python.org/dev/peps/pep-0278/