### PR TITLE
drivers/spi: Properly check for rx/tx and buffering on

### DIFF
--- a/drivers/spi/spi_context.h
+++ b/drivers/spi/spi_context.h
@@ -227,7 +227,13 @@ void spi_context_update_tx(struct spi_context *ctx, u8_t dfs, u32_t len)
 static ALWAYS_INLINE
 bool spi_context_tx_on(struct spi_context *ctx)
 {
-	return !!(ctx->tx_buf || ctx->tx_len);
+	return !!(ctx->tx_len);
+}
+
+static ALWAYS_INLINE
+bool spi_context_tx_buf_on(struct spi_context *ctx)
+{
+	return !!(ctx->tx_buf && ctx->tx_len);
 }
 
 static ALWAYS_INLINE
@@ -263,7 +269,13 @@ void spi_context_update_rx(struct spi_context *ctx, u8_t dfs, u32_t len)
 static ALWAYS_INLINE
 bool spi_context_rx_on(struct spi_context *ctx)
 {
-	return !!(ctx->rx_buf || ctx->rx_len);
+	return !!(ctx->rx_len);
+}
+
+static ALWAYS_INLINE
+bool spi_context_rx_buf_on(struct spi_context *ctx)
+{
+	return !!(ctx->rx_buf && ctx->rx_len);
 }
 
 static inline size_t spi_context_longest_current_buf(struct spi_context *ctx)

--- a/drivers/spi/spi_dw.c
+++ b/drivers/spi/spi_dw.c
@@ -96,7 +96,7 @@ static void push_data(struct device *dev)
 	}
 
 	while (f_tx) {
-		if (spi_context_tx_on(&spi->ctx)) {
+		if (spi_context_tx_buf_on(&spi->ctx)) {
 			switch (spi->dfs) {
 			case 1:
 				data = UNALIGNED_GET((u8_t *)
@@ -155,7 +155,7 @@ static void pull_data(struct device *dev)
 
 		DBG_COUNTER_INC();
 
-		if (spi_context_rx_on(&spi->ctx)) {
+		if (spi_context_rx_buf_on(&spi->ctx)) {
 			switch (spi->dfs) {
 			case 1:
 				UNALIGNED_PUT(data, (u8_t *)spi->ctx.rx_buf);


### PR DESCRIPTION
Current buffers might be configured to skip data, thus only len will be
set, buf will be NULL. Buffer should be used if only len is > 0 and
buffer is valid as well.

tx/rx are "on" if len is > 0
tx/rx buf should be touched if only len is > 0 _and_ buf != NULL.

Signed-off-by: Tomasz Bursztyka <tomasz.bursztyka@linux.intel.com>