### PR TITLE
cmake: Fix missing braces around interface

### DIFF
--- a/cmake/extensions.cmake
+++ b/cmake/extensions.cmake
@@ -418,7 +418,7 @@ endmacro()
 
 
 function(zephyr_link_interface interface)
-  target_link_libraries(interface INTERFACE zephyr_interface)
+  target_link_libraries(${interface} INTERFACE zephyr_interface)
 endfunction()
 
 #


### PR DESCRIPTION
Error occurred when using target_link_libraries in CMakeLists.txt:

Cannot specify link libraries for target "interface" which is not built
by this project.

Replace "interface" with "${interface}".

Signed-off-by: Ding Tao <miyatsu@qq.com>