### PR TITLE
dts: Update soc-nv-flash nodes

### DIFF
--- a/dts/arm/atmel/sam3x.dtsi
+++ b/dts/arm/atmel/sam3x.dtsi
@@ -26,6 +26,8 @@
 	};
 
 	flash0: flash@80000 {
+		compatible = "soc-nv-flash";
+		label = "FLASH_0";
 		reg = <0x00080000 0x80000>;
 	};
 

--- a/dts/arm/atmel/sam4s.dtsi
+++ b/dts/arm/atmel/sam4s.dtsi
@@ -26,6 +26,8 @@
 	};
 
 	flash0: flash@400000 {
+		compatible = "soc-nv-flash";
+		label = "FLASH_0";
 		reg = <0x00400000 0x100000>;
 	};
 

--- a/dts/arm/atmel/samd21.dtsi
+++ b/dts/arm/atmel/samd21.dtsi
@@ -20,6 +20,7 @@
 
 	flash0: flash@0 {
 		compatible = "soc-nv-flash";
+		label = "FLASH_0";
 		reg = <0 0x40000>;
 		write-block-size = <64>;
 	};

--- a/dts/arm/atmel/same70.dtsi
+++ b/dts/arm/atmel/same70.dtsi
@@ -22,6 +22,8 @@
 	};
 
 	flash0: flash@400000 {
+		compatible = "soc-nv-flash";
+		label = "FLASH_0";
 		reg = <0x00400000 DT_FLASH_SIZE>;
 	};
 

--- a/dts/arm/nordic/nrf51822.dtsi
+++ b/dts/arm/nordic/nrf51822.dtsi
@@ -22,6 +22,7 @@
 
 			flash0: flash@0 {
 				compatible = "soc-nv-flash";
+				label = "NRF5_FLASH";
 				reg = <0x00000000 DT_FLASH_SIZE>;
 				write-block-size = <4>;
 			};

--- a/dts/arm/nordic/nrf52832.dtsi
+++ b/dts/arm/nordic/nrf52832.dtsi
@@ -22,6 +22,7 @@
 
 			flash0: flash@0 {
 				compatible = "soc-nv-flash";
+				label = "NRF5_FLASH";
 				reg = <0x00000000 DT_FLASH_SIZE>;
 				write-block-size = <4>;
 			};

--- a/dts/arm/nordic/nrf52840.dtsi
+++ b/dts/arm/nordic/nrf52840.dtsi
@@ -22,6 +22,7 @@
 
 			flash0: flash@0 {
 				compatible = "soc-nv-flash";
+				label = "NRF5_FLASH";
 				reg = <0x00000000 DT_FLASH_SIZE>;
 				write-block-size = <4>;
 			};

--- a/dts/arm/nxp/nxp_k6x.dtsi
+++ b/dts/arm/nxp/nxp_k6x.dtsi
@@ -74,6 +74,7 @@
 
 			flash0: flash@0 {
 				compatible = "soc-nv-flash";
+				label = "MCUX_FLASH";
 				reg = <0 0x100000>;
 
 				write-block-size = <8>;

--- a/dts/arm/nxp/nxp_kl25z.dtsi
+++ b/dts/arm/nxp/nxp_kl25z.dtsi
@@ -22,6 +22,8 @@
 
 	soc {
 		flash0: flash@0 {
+			compatible = "soc-nv-flash";
+			label = "MCUX_FLASH";
 			reg = <0 0x20000>;
 		};
 

--- a/dts/arm/nxp/nxp_kw2xd.dtsi
+++ b/dts/arm/nxp/nxp_kw2xd.dtsi
@@ -65,6 +65,8 @@
 			#size-cells = <1>;
 
 			flash0: flash@0 {
+				compatible = "soc-nv-flash";
+				label = "MCUX_FLASH";
 				reg = <0 0x80000>;
 			};
 		};

--- a/dts/arm/nxp/nxp_kw40z.dtsi
+++ b/dts/arm/nxp/nxp_kw40z.dtsi
@@ -50,6 +50,8 @@
 		};
 
 		flash0: flash@0 {
+			compatible = "soc-nv-flash";
+			label = "MCUX_FLASH";
 			reg = <0 0x80000>;
 		};
 

--- a/dts/arm/nxp/nxp_kw41z.dtsi
+++ b/dts/arm/nxp/nxp_kw41z.dtsi
@@ -50,6 +50,8 @@
 		};
 
 		flash0: flash@0 {
+			compatible = "soc-nv-flash";
+			label = "MCUX_FLASH";
 			reg = <0 0x80000>;
 		};
 

--- a/dts/arm/silabs/efm32wg.dtsi
+++ b/dts/arm/silabs/efm32wg.dtsi
@@ -9,6 +9,8 @@
 	};
 
 	flash0: flash {
+		compatible = "soc-nv-flash";
+		label = "FLASH_0";
 		reg = <0 DT_FLASH_SIZE>;
 	};
 

--- a/dts/arm/st/stm32f0.dtsi
+++ b/dts/arm/st/stm32f0.dtsi
@@ -24,6 +24,7 @@
 
 	flash0: flash@8000000 {
 		compatible = "soc-nv-flash";
+		label = "FLASH_STM32";
 		reg = <0x08000000 DT_FLASH_SIZE>;
 
 		write-block-size = <2>;

--- a/dts/arm/st/stm32f1.dtsi
+++ b/dts/arm/st/stm32f1.dtsi
@@ -23,6 +23,8 @@
 	};
 
 	flash0: flash@8000000 {
+		compatible = "soc-nv-flash";
+		label = "FLASH_STM32";
 		reg = <0x08000000 DT_FLASH_SIZE>;
 	};
 

--- a/dts/arm/st/stm32f3.dtsi
+++ b/dts/arm/st/stm32f3.dtsi
@@ -23,6 +23,8 @@
 	};
 
 	flash0: flash@8000000 {
+		compatible = "soc-nv-flash";
+		label = "FLASH_STM32";
 		reg = <0x08000000 DT_FLASH_SIZE>;
 	};
 

--- a/dts/arm/st/stm32f4.dtsi
+++ b/dts/arm/st/stm32f4.dtsi
@@ -24,6 +24,7 @@
 
 	flash0: flash@8000000 {
 		compatible = "soc-nv-flash";
+		label = "FLASH_STM32";
 		reg = <0x08000000 DT_FLASH_SIZE>;
 
 		write-block-size = <1>;

--- a/dts/arm/st/stm32l4.dtsi
+++ b/dts/arm/st/stm32l4.dtsi
@@ -25,6 +25,7 @@
 
 	flash0: flash@8000000 {
 		compatible = "soc-nv-flash";
+		label = "FLASH_STM32";
 		reg = <0x08000000 DT_FLASH_SIZE>;
 
 		write-block-size = <8>;

--- a/dts/arm/ti/cc32xx.dtsi
+++ b/dts/arm/ti/cc32xx.dtsi
@@ -38,6 +38,8 @@
 
 #if defined(CONFIG_SOC_CC3220SF)
 	flash1: flash@1000000 {
+		compatible = "soc-nv-flash";
+		label = "FLASH_1";
 		reg = <0x01000000 DT_FLASH_SIZE>;
 	};
 #endif


### PR DESCRIPTION
Where missing add compatible = "soc-nv-flash".  Also added a label for
all the soc-nv-flash that we might use in the future.

Signed-off-by: Kumar Gala <kumar.gala@linaro.org>