### PR TITLE
dts: arm: st: Add Flash Controller Nodes for STM32{F0,F4,L4}

### DIFF
--- a/dts/arm/st/stm32f0.dtsi
+++ b/dts/arm/st/stm32f0.dtsi
@@ -22,14 +22,6 @@
 		};
 	};
 
-	flash0: flash@8000000 {
-		compatible = "soc-nv-flash";
-		label = "FLASH_STM32";
-		reg = <0x08000000 DT_FLASH_SIZE>;
-
-		write-block-size = <2>;
-	};
-
 	sram0: memory@20000000 {
 		device_type = "memory";
 		compatible = "mmio-sram";
@@ -37,6 +29,24 @@
 	};
 
 	soc {
+		flash-controller@40022000 {
+			compatible = "st,stm32f0-flash-controller";
+			label = "FLASH_CTRL";
+			reg = <0x40022000 0x400>;
+			interrupts = <3 0>;
+
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			flash0: flash@8000000 {
+				compatible = "soc-nv-flash";
+				label = "FLASH_STM32";
+				reg = <0x08000000 DT_FLASH_SIZE>;
+
+				write-block-size = <2>;
+			};
+		};
+
 		rcc: rcc@40021000 {
 			compatible = "st,stm32-rcc";
 			clocks-controller;

--- a/dts/arm/st/stm32f3.dtsi
+++ b/dts/arm/st/stm32f3.dtsi
@@ -22,12 +22,6 @@
 		};
 	};
 
-	flash0: flash@8000000 {
-		compatible = "soc-nv-flash";
-		label = "FLASH_STM32";
-		reg = <0x08000000 DT_FLASH_SIZE>;
-	};
-
 	sram0: memory@20000000 {
 		device_type = "memory";
 		compatible = "mmio-sram";
@@ -35,6 +29,22 @@
 	};
 
 	soc {
+		flash-controller@40022000 {
+			compatible = "st,stm32f3-flash-controller";
+			label = "FLASH_CTRL";
+			reg = <0x40022000 0x400>;
+			interrupts = <4 0>;
+
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			flash0: flash@8000000 {
+				compatible = "soc-nv-flash";
+				label = "FLASH_STM32";
+				reg = <0x08000000 DT_FLASH_SIZE>;
+			};
+		};
+
 		rcc: rcc@40021000 {
 			compatible = "st,stm32-rcc";
 			clocks-controller;

--- a/dts/arm/st/stm32f4.dtsi
+++ b/dts/arm/st/stm32f4.dtsi
@@ -22,14 +22,6 @@
 		};
 	};
 
-	flash0: flash@8000000 {
-		compatible = "soc-nv-flash";
-		label = "FLASH_STM32";
-		reg = <0x08000000 DT_FLASH_SIZE>;
-
-		write-block-size = <1>;
-	};
-
 	sram0: memory@20000000 {
 		device_type = "memory";
 		compatible = "mmio-sram";
@@ -37,6 +29,24 @@
 	};
 
 	soc {
+		flash-controller@40023c00 {
+			compatible = "st,stm32f4-flash-controller";
+			label = "FLASH_CTRL";
+			reg = <0x40023c00 0x400>;
+			interrupts = <4 0>;
+
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			flash0: flash@8000000 {
+				compatible = "soc-nv-flash";
+				label = "FLASH_STM32";
+				reg = <0x08000000 DT_FLASH_SIZE>;
+
+				write-block-size = <1>;
+			};
+		};
+
 		rcc: rcc@40023800 {
 			compatible = "st,stm32-rcc";
 			clocks-controller;

--- a/dts/arm/st/stm32l4.dtsi
+++ b/dts/arm/st/stm32l4.dtsi
@@ -23,14 +23,6 @@
 		};
 	};
 
-	flash0: flash@8000000 {
-		compatible = "soc-nv-flash";
-		label = "FLASH_STM32";
-		reg = <0x08000000 DT_FLASH_SIZE>;
-
-		write-block-size = <8>;
-	};
-
 	sram0: memory@20000000 {
 		device_type = "memory";
 		compatible = "mmio-sram";
@@ -38,6 +30,24 @@
 	};
 
 	soc {
+		flash-controller@40022000 {
+			compatible = "st,stm32l4-flash-controller";
+			label = "FLASH_CTRL";
+			reg = <0x40022000 0x400>;
+			interrupts = <4 0>;
+
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			flash0: flash@8000000 {
+				compatible = "soc-nv-flash";
+				label = "FLASH_STM32";
+				reg = <0x08000000 DT_FLASH_SIZE>;
+
+				write-block-size = <8>;
+			};
+		};
+
 		rcc: rcc@40021000 {
 			compatible = "st,stm32-rcc";
 			clocks-controller;

--- a/dts/bindings/flash_controller/st,stm32f0-flash-controller.yaml
+++ b/dts/bindings/flash_controller/st,stm32f0-flash-controller.yaml
@@ -1,0 +1,19 @@
+---
+title: STM32 F0 Flash Controller
+id: st,stm32f0-flash-controller
+version: 0.1
+
+description: >
+    This binding gives a base representation of the STM32 F0 Flash Controller
+
+inherits:
+    !include flash-controller.yaml
+
+properties:
+    compatible:
+      type: string
+      category: required
+      description: compatible strings
+      constraint: "st,stm32f0-flash-controller"
+
+...

--- a/dts/bindings/flash_controller/st,stm32f3-flash-controller.yaml
+++ b/dts/bindings/flash_controller/st,stm32f3-flash-controller.yaml
@@ -1,0 +1,19 @@
+---
+title: STM32 F3 Flash Controller
+id: st,stm32f3-flash-controller
+version: 0.1
+
+description: >
+    This binding gives a base representation of the STM32 F3 Flash Controller
+
+inherits:
+    !include flash-controller.yaml
+
+properties:
+    compatible:
+      type: string
+      category: required
+      description: compatible strings
+      constraint: "st,stm32f3-flash-controller"
+
+...

--- a/dts/bindings/flash_controller/st,stm32f4-flash-controller.yaml
+++ b/dts/bindings/flash_controller/st,stm32f4-flash-controller.yaml
@@ -1,0 +1,19 @@
+---
+title: STM32 F4 Flash Controller
+id: st,stm32f4-flash-controller
+version: 0.1
+
+description: >
+    This binding gives a base representation of the STM32 F4 Flash Controller
+
+inherits:
+    !include flash-controller.yaml
+
+properties:
+    compatible:
+      type: string
+      category: required
+      description: compatible strings
+      constraint: "st,stm32f4-flash-controller"
+
+...

--- a/dts/bindings/flash_controller/st,stm32l4-flash-controller.yaml
+++ b/dts/bindings/flash_controller/st,stm32l4-flash-controller.yaml
@@ -1,0 +1,19 @@
+---
+title: STM32 L4 Flash Controller
+id: st,stm32l4-flash-controller
+version: 0.1
+
+description: >
+    This binding gives a base representation of the STM32 L4 Flash Controller
+
+inherits:
+    !include flash-controller.yaml
+
+properties:
+    compatible:
+      type: string
+      category: required
+      description: compatible strings
+      constraint: "st,stm32l4-flash-controller"
+
+...


### PR DESCRIPTION
Introduce flash controller nodes for STM32 SoCs that are supported in
the flash driver.  This is a precusor to converting the flash driver on
stm32 over to using device tree.

Signed-off-by: Kumar Gala <kumar.gala@linaro.org>