### PR TITLE
Bluetooth: controller: Refactor LL up and downstream interface

### DIFF
--- a/subsys/bluetooth/controller/hci/hci.c
+++ b/subsys/bluetooth/controller/hci/hci.c
@@ -1981,7 +1981,7 @@ int hci_acl_handle(struct net_buf *buf, struct net_buf **evt)
 	flags = bt_acl_flags(handle);
 	handle = bt_acl_handle(handle);
 
-	radio_pdu_node_tx = radio_tx_mem_acquire();
+	radio_pdu_node_tx = ll_tx_mem_acquire();
 	if (!radio_pdu_node_tx) {
 		BT_ERR("Tx Buffer Overflow");
 		data_buf_overflow(evt);
@@ -1997,9 +1997,9 @@ int hci_acl_handle(struct net_buf *buf, struct net_buf **evt)
 	pdu_data->len = len;
 	memcpy(&pdu_data->payload.lldata[0], buf->data, len);
 
-	if (radio_tx_mem_enqueue(handle, radio_pdu_node_tx)) {
+	if (ll_tx_mem_enqueue(handle, radio_pdu_node_tx)) {
 		BT_ERR("Invalid Tx Enqueue");
-		radio_tx_mem_release(radio_pdu_node_tx);
+		ll_tx_mem_release(radio_pdu_node_tx);
 		return -EINVAL;
 	}
 

--- a/subsys/bluetooth/controller/hci/hci_driver.c
+++ b/subsys/bluetooth/controller/hci/hci_driver.c
@@ -68,11 +68,11 @@ static s32_t hbuf_count;
 static void prio_recv_thread(void *p1, void *p2, void *p3)
 {
 	while (1) {
-		struct radio_pdu_node_rx *node_rx;
+		void *node_rx;
 		u8_t num_cmplt;
 		u16_t handle;
 
-		while ((num_cmplt = radio_rx_get(&node_rx, &handle))) {
+		while ((num_cmplt = ll_rx_get(&node_rx, &handle))) {
 #if defined(CONFIG_BT_CONN)
 			struct net_buf *buf;
 
@@ -86,7 +86,7 @@ static void prio_recv_thread(void *p1, void *p2, void *p3)
 
 		if (node_rx) {
 
-			radio_rx_dequeue();
+			ll_rx_dequeue();
 
 			BT_DBG("RX node enqueue");
 			k_fifo_put(&recv_fifo, node_rx);
@@ -144,7 +144,7 @@ static inline struct net_buf *encode_node(struct radio_pdu_node_rx *node_rx,
 #endif /* CONFIG_BT_LL_SW */
 
 	node_rx->hdr.onion.next = 0;
-	radio_rx_mem_release(&node_rx);
+	ll_rx_mem_release((void **)&node_rx);
 
 	return buf;
 }

--- a/subsys/bluetooth/controller/include/ll.h
+++ b/subsys/bluetooth/controller/include/ll.h
@@ -10,8 +10,7 @@
 
 int ll_init(struct k_sem *sem_rx);
 void ll_reset(void);
-void ll_radio_state_abort(void);
-u32_t ll_radio_state_is_idle(void);
+
 u8_t *ll_addr_get(u8_t addr_type, u8_t *p_bdaddr);
 void ll_addr_set(u8_t addr_type, u8_t const *const p_bdaddr);
 
@@ -71,7 +70,6 @@ u32_t ll_start_enc_req_send(u16_t handle, u8_t err_code,
 u32_t ll_feature_req_send(u16_t handle);
 u32_t ll_version_ind_send(u16_t handle);
 u32_t ll_terminate_ind_send(u16_t handle, u8_t reason);
-void ll_timeslice_ticker_id_get(u8_t * const instance_index, u8_t * const user_id);
 u32_t ll_rssi_get(u16_t handle, u8_t *rssi);
 u32_t ll_tx_pwr_lvl_get(u16_t handle, u8_t type, s8_t *tx_pwr_lvl);
 void ll_tx_pwr_get(s8_t *min, s8_t *max);
@@ -88,5 +86,20 @@ void ll_length_max_get(u16_t *max_tx_octets, u16_t *max_tx_time,
 u32_t ll_phy_get(u16_t handle, u8_t *tx, u8_t *rx);
 u32_t ll_phy_default_set(u8_t tx, u8_t rx);
 u32_t ll_phy_req_send(u16_t handle, u8_t tx, u8_t flags, u8_t rx);
+
+/* Downstream - Data */
+void *ll_tx_mem_acquire(void);
+void ll_tx_mem_release(void *node_tx);
+u32_t ll_tx_mem_enqueue(u16_t handle, void *node_tx);
+
+/* Upstream - Num. Completes, Events and Data */
+u8_t ll_rx_get(void **node_rx, u16_t *handle);
+void ll_rx_dequeue(void);
+void ll_rx_mem_release(void **node_rx);
+
+/* External co-operation */
+void ll_timeslice_ticker_id_get(u8_t * const instance_index, u8_t * const user_id);
+void ll_radio_state_abort(void);
+u32_t ll_radio_state_is_idle(void);
 
 #endif /* _LL_H_ */

--- a/subsys/bluetooth/controller/ll_sw/ctrl.h
+++ b/subsys/bluetooth/controller/ll_sw/ctrl.h
@@ -366,16 +366,9 @@ u32_t radio_connect_enable(u8_t adv_addr_type, u8_t *adv_addr,
 			   u16_t interval, u16_t latency,
 			   u16_t timeout);
 /* Upstream */
-u8_t radio_rx_get(struct radio_pdu_node_rx **radio_pdu_node_rx,
-		  u16_t *handle);
-void radio_rx_dequeue(void);
-void radio_rx_mem_release(struct radio_pdu_node_rx **radio_pdu_node_rx);
 u8_t radio_rx_fc_set(u16_t handle, u8_t fc);
 u8_t radio_rx_fc_get(u16_t *handle);
-struct radio_pdu_node_tx *radio_tx_mem_acquire(void);
-void radio_tx_mem_release(struct radio_pdu_node_tx *pdu_data_node_tx);
-u32_t radio_tx_mem_enqueue(u16_t handle,
-			   struct radio_pdu_node_tx *pdu_data_node_tx);
+
 /* Callbacks */
 extern void radio_active_callback(u8_t active);
 extern void radio_event_callback(void);


### PR DESCRIPTION
Rename some legacy upstream and downstream interfaces in
radio_* namespace to ll_* namespace for consistency.

Signed-off-by: Vinayak Kariappa Chettimada <vich@nordicsemi.no>