### PR TITLE
Bluetooth: controller: Fix BT_CTLR_DEBUG_PINS Kconfig help text

### DIFF
--- a/subsys/bluetooth/controller/Kconfig
+++ b/subsys/bluetooth/controller/Kconfig
@@ -488,7 +488,6 @@ config BT_CTLR_DEBUG_PINS
 	help
 	  Turn on debug GPIO toggling for the BLE Controller. This is useful
 	  when debugging with a logic analyzer or profiling certain sections of
-	  the code. When enabled, pins P0.16 to P0.25 are taken over exclusively
-	  by the controller and cannot be used outside of it.
+	  the code.
 
 endif # BT_CTLR


### PR DESCRIPTION
Help text for BT_CTLR_DEBUG_PINS incorrectly mentioned
specific GPIO pins being reserved for this feature, but in
reality the pins reserved vary on the SoC selected, hence
any specific mention of pin details is removed from help
text.

Fixes: #5499

Signed-off-by: Vinayak Kariappa Chettimada <vich@nordicsemi.no>