### PR TITLE
tests: benchmarks: latency_measure: Fix build issue with abs()

### DIFF
--- a/tests/benchmarks/latency_measure/src/thread_switch_yield.c
+++ b/tests/benchmarks/latency_measure/src/thread_switch_yield.c
@@ -12,14 +12,9 @@
  */
 
 #include <zephyr.h>
+#include <stdlib.h>
 #include <timestamp.h>  /* reading time */
 #include "utils.h"      /* PRINT () and other macros */
-
-/* <stdlib.h> is not supported */
-static int abs(int i)
-{
-	return (i >= 0) ? i : -i;
-}
 
 /* context switch enough time so our measurement is precise */
 #define NB_OF_YIELD     1000


### PR DESCRIPTION
We now have a define for abs() in stdlib, so we can remove the version
implemented in the test.

Signed-off-by: Kumar Gala <kumar.gala@linaro.org>