### PR TITLE
arch: arc: use default optimization flag

### DIFF
--- a/cmake/toolchain-zephyr.cmake
+++ b/cmake/toolchain-zephyr.cmake
@@ -30,11 +30,6 @@ elseif("${ARCH}" STREQUAL "xtensa")
 
   LIST(APPEND TOOLCHAIN_LIBS hal)
   LIST(APPEND LIB_INCLUDE_DIR -L${SYSROOT_DIR}/lib)
-
-elseif("${ARCH}" STREQUAL "arc")
-  # https://github.com/zephyrproject-rtos/zephyr/issues/3797
-  # -Os is broken on arc
-  set(OPTIMIZE_FOR_SIZE_FLAG "-O2")
 endif()
 
 set(CROSS_COMPILE ${TOOLCHAIN_HOME}/usr/bin/${CROSS_COMPILE_TARGET}/${CROSS_COMPILE_TARGET}-)


### PR DESCRIPTION
The work-around previously setting ARC builds to use -O2 to fix an
ADC bug #3797 is no longer needed, we should this patch and revert
to the default -Os flag to optimize for smaller size.

Signed-off-by: Jimmy Huang <jimmy.huang@intel.com>