### PR TITLE
userspace: ARM: Fixed Kconfig for ARM_USERSPACE

### DIFF
--- a/arch/arm/core/Kconfig
+++ b/arch/arm/core/Kconfig
@@ -23,7 +23,7 @@ config CPU_CORTEX_M
 	select HAS_FLASH_LOAD_OFFSET
 	select HAS_DTS
 	select ARCH_HAS_STACK_PROTECTION if ARM_CORE_MPU
-	select ARCH_HAS_USERSPACE if ARM_CORE_MPU
+	select ARCH_HAS_USERSPACE if ARM_USERSPACE
 	help
 	  This option signifies the use of a CPU of the Cortex-M family.
 
@@ -44,7 +44,7 @@ config ARM_STACK_PROTECTION
 
 config ARM_USERSPACE
 	bool
-	default y if USERSPACE
+	default n
 	help
 	  This option enables APIs to drop a thread's privileges,	supporting
 	  user-level threads that are protected from each other and from


### PR DESCRIPTION
Currently in zephyr the support for the arm userspace has not be
merged. But the Kconfig always sets the userspace flag and causes a
build failure. This is blocking the test cases for userspace.

Signed-off-by: Adithya Baglody <adithya.nagaraj.baglody@intel.com>