### PR TITLE
doc: device: dts: Explanation for flash partitions

### DIFF
--- a/doc/devices/dts/device_tree.rst
+++ b/doc/devices/dts/device_tree.rst
@@ -173,6 +173,10 @@ The following is a more precise list of required files:
   * Add a board level .dts file that includes the SoC family .dtsi files
     and enables the nodes required for that specific board.
   * Board .dts file should specify the SRAM and FLASH devices, if present.
+
+    * Flash device node might specify flash partitions. For more details see
+      :ref:'flash_partitions'
+
   * Add board-specific YAML files, if required.  This would occur if the
     board has additional hardware that is not covered by the SoC family
     .dtsi/.yaml files.

--- a/doc/devices/dts/flash_partitions.rst
+++ b/doc/devices/dts/flash_partitions.rst
@@ -1,0 +1,49 @@
+.. _flash_partitions:
+
+Flash partitions nodes explanation
+##################################
+
+In each of the <boards>.dts files, the flash partitions layout can be described.
+It must be put inside the 'partitions' node in the 'flash0' node.
+
+Mcuboot related partitions
+**************************
+
+**boot_partition**
+  This is the partition where the bootloader is expected to be
+  placed. mcuboot is linked into this partition.
+
+**slot0_partition**
+  This is the partition where the current, executable
+  application image is expected to be placed. Any bootable application must be
+  linked into this area.
+
+**slot1_partition**
+  This is the partition where the downloaded application image
+  is collected. Mcuboot can load this image to slot0_partition and run it.
+  The slot0_partition and slot1_partition must be the same size.
+
+**scratch_partition**
+  This partition is used for images swapping support.
+  See the  `mcuboot documentation`_ for more details.
+
+.. _mcuboot documentation: https://github.com/runtimeco/mcuboot/blob/master/docs/design.md#image-slots
+
+By default a code-partition to link into is not selected.
+
+If Zephyr code-partition is not chosen, the image will be linked into the entire
+flash device. If code-partition points to an individual partition, the code will be linked
+to, and be restricted to that partition.
+
+File system related partitions
+******************************
+**nffs_partition**
+  This is the area where NFFS expects its partition.
+
+Example
+*******
+
+For an example of a DTS file containing such a description,
+see the `nrf52840_pca10056.dts`_ file.
+
+.. _nrf52840_pca10056.dts: https://github.com/zephyrproject-rtos/zephyr/blob/master/boards/arm/nrf52840_pca10056/nrf52840_pca10056.dts

--- a/doc/devices/index.rst
+++ b/doc/devices/index.rst
@@ -8,3 +8,4 @@ Device and Driver Support
 
    drivers/drivers.rst
    dts/device_tree.rst
+   dts/flash_partitions.rst


### PR DESCRIPTION
This documentation is needed for developers who are porting new boards.
Fixing #5577


Signed-off-by: Andrzej Puzdrowski <andrzej.puzdrowski@nordicsemi.no>