### PR TITLE
native: nrf52 changes to HAL to support running on simulated HW

### DIFF
--- a/subsys/bluetooth/controller/hal/nrf5/cntr.c
+++ b/subsys/bluetooth/controller/hal/nrf5/cntr.c
@@ -24,6 +24,9 @@ void cntr_init(void)
 			     RTC_EVTENSET_COMPARE1_Msk);
 	NRF_RTC->INTENSET = (RTC_INTENSET_COMPARE0_Msk |
 			     RTC_INTENSET_COMPARE1_Msk);
+#if defined(CONFIG_BOARD_NRFXX_NWTSIM)
+	NRF_RTC0_regw_sideeffects();
+#endif
 }
 
 u32_t cntr_start(void)
@@ -33,6 +36,9 @@ u32_t cntr_start(void)
 	}
 
 	NRF_RTC->TASKS_START = 1;
+#if defined(CONFIG_BOARD_NRFXX_NWTSIM)
+	NRF_RTC0_regw_sideeffects();
+#endif
 
 	return 0;
 }
@@ -46,6 +52,9 @@ u32_t cntr_stop(void)
 	}
 
 	NRF_RTC->TASKS_STOP = 1;
+#if defined(CONFIG_BOARD_NRFXX_NWTSIM)
+	NRF_RTC0_regw_sideeffects();
+#endif
 
 	return 0;
 }

--- a/subsys/bluetooth/controller/hal/nrf5/radio/radio_nrf5.h
+++ b/subsys/bluetooth/controller/hal/nrf5/radio/radio_nrf5.h
@@ -9,6 +9,9 @@
 #define HAL_RADIO_NS2US_ROUND(ns) ((ns + 500)/1000)
 
 #define EVENT_TIMER NRF_TIMER0
+#if defined(CONFIG_BOARD_NRFXX_NWTSIM)
+#define EVENT_TIMER_NBR 0
+#endif
 
 #if defined(CONFIG_SOC_SERIES_NRF51X)
 #include "radio_nrf51.h"

--- a/subsys/bluetooth/controller/hal/nrf5/radio/radio_nrf52832.h
+++ b/subsys/bluetooth/controller/hal/nrf5/radio/radio_nrf52832.h
@@ -7,6 +7,9 @@
 
 #if !defined(CONFIG_BT_CTLR_TIFS_HW)
 #define SW_SWITCH_TIMER NRF_TIMER1
+#if defined(CONFIG_BOARD_NRFXX_NWTSIM)
+#define SW_SWITCH_TIMER_NBR 1
+#endif
 #define SW_SWITCH_TIMER_EVTS_COMP_BASE 0
 #define SW_SWITCH_TIMER_TASK_GROUP_BASE 0
 #endif
@@ -198,6 +201,7 @@
 
 static inline void hal_radio_ram_prio_setup(void)
 {
+#if !defined(CONFIG_BOARD_NRFXX_NWTSIM)
 	struct {
 		u32_t volatile reserved_0[0x5a0 >> 2];
 		u32_t volatile bridge_type;
@@ -234,6 +238,7 @@ static inline void hal_radio_ram_prio_setup(void)
 	NRF_AMLI->RAMPRI.I2S     = 0xFFFFFFFFUL;
 	NRF_AMLI->RAMPRI.PDM     = 0xFFFFFFFFUL;
 	NRF_AMLI->RAMPRI.PWM     = 0xFFFFFFFFUL;
+#endif
 }
 
 static inline u32_t hal_radio_phy_mode_get(u8_t phy, u8_t flags)

--- a/subsys/bluetooth/controller/hal/nrf5/rand.c
+++ b/subsys/bluetooth/controller/hal/nrf5/rand.c
@@ -42,6 +42,9 @@ static void init(struct rand **rng, u8_t *context, u8_t len, u8_t threshold)
 		NRF_RNG->INTENSET = RNG_INTENSET_VALRDY_Msk;
 
 		NRF_RNG->TASKS_START = 1;
+#if defined(CONFIG_BOARD_NRFXX_NWTSIM)
+		NRF_RNG_regw_sideeffects();
+#endif
 	}
 }
 
@@ -133,6 +136,9 @@ static size_t get(struct rand *rng, size_t octets, u8_t *rand)
 
 	if (remaining < rng->threshold) {
 		NRF_RNG->TASKS_START = 1;
+#if defined(CONFIG_BOARD_NRFXX_NWTSIM)
+		NRF_RNG_regw_sideeffects();
+#endif
 	}
 
 	return octets;
@@ -203,6 +209,9 @@ void isr_rand(void *param)
 
 		if (ret != -EBUSY) {
 			NRF_RNG->TASKS_STOP = 1;
+#if defined(CONFIG_BOARD_NRFXX_NWTSIM)
+			NRF_RNG_regw_sideeffects();
+#endif
 		}
 	}
 }


### PR DESCRIPTION
Conditionally compiled changes to the NRF52 BT HAL so it can
run on simulated HW on the native port.
(HW models are not included in this commit)

All changes are under ifdefs and therefore will not have any
effect on normal builds

Signed-off-by: Alberto Escolar Piedras <alpi@oticon.com>