### PR TITLE
drivers: flash: atmel sam0: Convert to use device tree

### DIFF
--- a/arch/arm/soc/atmel_sam0/samd/dts.fixup
+++ b/arch/arm/soc/atmel_sam0/samd/dts.fixup
@@ -1,0 +1,6 @@
+/* SoC level DTS fixup file */
+
+#define FLASH_DEV_BASE_ADDRESS		ATMEL_SAM0_NVMCTRL_41004000_BASE_ADDRESS_0
+#define FLASH_DEV_NAME			ATMEL_SAM0_NVMCTRL_41004000_LABEL
+
+/* End of SoC Level DTS fixup file */

--- a/drivers/flash/Kconfig.sam0
+++ b/drivers/flash/Kconfig.sam0
@@ -13,13 +13,6 @@ menuconfig SOC_FLASH_SAM0
 	help
 	 Enable the Atmel SAM0 series internal flash driver.
 
-config SOC_FLASH_SAM0_DEV_NAME
-	string "Flash device name"
-	depends on SOC_FLASH_SAM0
-	default "FLASH_0"
-	help
-	 Specify the device name for the flash driver.
-
 config SOC_FLASH_SAM0_EMULATE_BYTE_PAGES
 	bool
 	prompt "Emulate byte-sized pages"

--- a/drivers/flash/flash_sam0.c
+++ b/drivers/flash/flash_sam0.c
@@ -371,6 +371,6 @@ static const struct flash_driver_api flash_sam0_api = {
 
 static struct flash_sam0_data flash_sam0_data_0;
 
-DEVICE_AND_API_INIT(flash_sam0, CONFIG_SOC_FLASH_SAM0_DEV_NAME,
+DEVICE_AND_API_INIT(flash_sam0, FLASH_DEV_NAME,
 		    flash_sam0_init, &flash_sam0_data_0, NULL, POST_KERNEL,
 		    CONFIG_KERNEL_INIT_PRIORITY_DEVICE, &flash_sam0_api);

--- a/dts/arm/atmel/samd21.dtsi
+++ b/dts/arm/atmel/samd21.dtsi
@@ -18,13 +18,6 @@
 		};
 	};
 
-	flash0: flash@0 {
-		compatible = "soc-nv-flash";
-		label = "FLASH_0";
-		reg = <0 0x40000>;
-		write-block-size = <64>;
-	};
-
 	sram0: memory@20000000 {
 		device_type = "memory";
 		compatible = "mmio-sram";
@@ -32,6 +25,23 @@
 	};
 
 	soc {
+		nvmctrl: nvmctrl@41004000  {
+			compatible = "atmel,sam0-nvmctrl";
+			label = "FLASH_CTRL";
+			reg = <0x40022000 0x22>;
+			interrupts = <5 0>;
+
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			flash0: flash@0 {
+				compatible = "soc-nv-flash";
+				label = "FLASH_0";
+				reg = <0 0x40000>;
+				write-block-size = <64>;
+			};
+		};
+
 		wdog: watchdog@40001000 {
 			compatible = "atmel,sam0-watchdog";
 			reg = <0x40001000 9>;

--- a/dts/bindings/flash_controller/atmel,sam0-nvmctrl.yaml
+++ b/dts/bindings/flash_controller/atmel,sam0-nvmctrl.yaml
@@ -1,0 +1,19 @@
+---
+title: Atmel SAM0 Non-Volatile Memory Controller
+id: atmel,sam0-nvmctrl
+version: 0.1
+
+description: >
+    This binding gives a base representation of the Atmel SAM0 NVMC
+
+inherits:
+    !include flash-controller.yaml
+
+properties:
+    compatible:
+      type: string
+      category: required
+      description: compatible strings
+      constraint: "atmel,sam0-nvmctrl"
+
+...


### PR DESCRIPTION
Convert Atmel SAM0 flash driver to use device tree to get the flash
controller name and base address.

Signed-off-by: Kumar Gala <kumar.gala@linaro.org>