### PR TITLE
[RFC][DNM]arm: atmel: sam3x: Cleanup flash node/controller in device tree

### DIFF
--- a/boards/arm/arduino_due/arduino_due.dts
+++ b/boards/arm/arduino_due/arduino_due.dts
@@ -15,6 +15,7 @@
 	chosen {
 		zephyr,sram = &sram0;
 		zephyr,flash = &flash0;
+		zephyr,code-partition = &boot_partition;
 		zephyr,console = &uart0;
 	};
 };

--- a/dts/arm/atmel/sam3x.dtsi
+++ b/dts/arm/atmel/sam3x.dtsi
@@ -25,13 +25,52 @@
 		reg = <0x20070000 0x18000>;
 	};
 
-	flash0: flash@80000 {
-		compatible = "soc-nv-flash";
-		label = "FLASH_0";
-		reg = <0x00080000 0x80000>;
-	};
-
 	soc {
+		eefc0: efc@400e0a00 {
+			compatible = "atmel,sam-efc";
+			label = "FLASH_CTRL_0";
+			reg = <0x400e0a00 0x10>;
+			interrupts = <6 0>;
+			peripheral-id = <6>;
+
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			flash0: flash@80000 {
+				compatible = "soc-nv-flash";
+				label = "FLASH_0";
+				reg = <0x00080000 0x40000>;
+			};
+		};
+
+		eefc1: efc@400e0c00 {
+			compatible = "atmel,sam-efc";
+			label = "FLASH_CTRL_1";
+			reg = <0x400e0c00 0x10>;
+			interrupts = <7 0>;
+			peripheral-id = <7>;
+
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			flash1: flash@c0000 {
+				compatible = "soc-nv-flash";
+				label = "FLASH_1";
+				reg = <0x000c0000 0x40000>;
+			};
+		};
+
+		partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			boot_partition: partition@0 {
+				label = "flash";
+				reg = <0x00080000 0x80000>;
+			};
+		};
+
 		i2c0: i2c@4008C000 {
 			compatible = "atmel,sam-i2c-twi";
 			clock-frequency = <I2C_BITRATE_STANDARD>;


### PR DESCRIPTION
The sam3x has 2 flash regions that we've been treating as a single
contiguous space.  Each region has its own flash controller.  We need to
represent this correctly in the device tree.

So we add each controller, put each flash region under that controller
and use a partition map to convey a single contiguous space to Zephyr.

Signed-off-by: Kumar Gala <kumar.gala@linaro.org>