### PR TITLE
scripts: jlink: Add flash command support to the jlink runner

### DIFF
--- a/boards/arm/frdm_k64f/board.cmake
+++ b/boards/arm/frdm_k64f/board.cmake
@@ -2,6 +2,7 @@ set_ifndef(OPENSDA_FW daplink)
 
 if(OPENSDA_FW STREQUAL jlink)
   set_ifndef(BOARD_DEBUG_RUNNER jlink)
+  set_ifndef(BOARD_FLASH_RUNNER jlink)
 elseif(OPENSDA_FW STREQUAL daplink)
   set_ifndef(BOARD_DEBUG_RUNNER pyocd)
   set_ifndef(BOARD_FLASH_RUNNER pyocd)

--- a/boards/arm/frdm_kl25z/board.cmake
+++ b/boards/arm/frdm_kl25z/board.cmake
@@ -2,6 +2,7 @@ set_ifndef(OPENSDA_FW daplink)
 
 if(OPENSDA_FW STREQUAL jlink)
   set_ifndef(BOARD_DEBUG_RUNNER jlink)
+  set_ifndef(BOARD_FLASH_RUNNER jlink)
 elseif(OPENSDA_FW STREQUAL daplink)
   set_ifndef(BOARD_DEBUG_RUNNER pyocd)
   set_ifndef(BOARD_FLASH_RUNNER pyocd)

--- a/boards/arm/frdm_kw41z/board.cmake
+++ b/boards/arm/frdm_kw41z/board.cmake
@@ -2,6 +2,7 @@ set_ifndef(OPENSDA_FW jlink)
 
 if(OPENSDA_FW STREQUAL jlink)
   set_ifndef(BOARD_DEBUG_RUNNER jlink)
+  set_ifndef(BOARD_FLASH_RUNNER jlink)
 elseif(OPENSDA_FW STREQUAL daplink)
   set_ifndef(BOARD_DEBUG_RUNNER pyocd)
   set_ifndef(BOARD_FLASH_RUNNER pyocd)

--- a/boards/arm/hexiwear_k64/board.cmake
+++ b/boards/arm/hexiwear_k64/board.cmake
@@ -2,6 +2,7 @@ set_ifndef(OPENSDA_FW daplink)
 
 if(OPENSDA_FW STREQUAL jlink)
   set_ifndef(BOARD_DEBUG_RUNNER jlink)
+  set_ifndef(BOARD_FLASH_RUNNER jlink)
 elseif(OPENSDA_FW STREQUAL daplink)
   set_ifndef(BOARD_DEBUG_RUNNER pyocd)
   set_ifndef(BOARD_FLASH_RUNNER pyocd)

--- a/boards/arm/hexiwear_kw40z/board.cmake
+++ b/boards/arm/hexiwear_kw40z/board.cmake
@@ -2,6 +2,7 @@ set_ifndef(OPENSDA_FW jlink)
 
 if(OPENSDA_FW STREQUAL jlink)
   set_ifndef(BOARD_DEBUG_RUNNER jlink)
+  set_ifndef(BOARD_FLASH_RUNNER jlink)
 elseif(OPENSDA_FW STREQUAL daplink)
   set_ifndef(BOARD_DEBUG_RUNNER pyocd)
   set_ifndef(BOARD_FLASH_RUNNER pyocd)

--- a/boards/arm/lpcxpresso54114/board.cmake
+++ b/boards/arm/lpcxpresso54114/board.cmake
@@ -8,6 +8,7 @@ set_ifndef(LPCLINK_FW jlink)
 
 if(LPCLINK_FW STREQUAL jlink)
   set_ifndef(BOARD_DEBUG_RUNNER jlink)
+  set_ifndef(BOARD_FLASH_RUNNER jlink)
 endif()
 
 board_runner_args(jlink "--device=LPC54114J256_M4")

--- a/boards/arm/usb_kw24d512/board.cmake
+++ b/boards/arm/usb_kw24d512/board.cmake
@@ -1,3 +1,3 @@
-board_runner_args(jlink "--device=MKW24D512xxx5")
+board_runner_args(jlink "--device=MKW24D512xxx5" "--speed=4000")
 
 include(${ZEPHYR_BASE}/boards/common/jlink.board.cmake)

--- a/boards/common/jlink.board.cmake
+++ b/boards/common/jlink.board.cmake
@@ -1,2 +1,3 @@
+set_ifndef(BOARD_FLASH_RUNNER jlink)
 set_ifndef(BOARD_DEBUG_RUNNER jlink)
-board_finalize_runner_args(jlink) # No default arguments to provide.
+board_finalize_runner_args(jlink "--dt-flash=y")

--- a/scripts/support/runner/jlink.py
+++ b/scripts/support/runner/jlink.py
@@ -4,7 +4,9 @@
 
 '''Runner for debugging with J-Link.'''
 
-from .core import ZephyrBinaryRunner, RunnerCaps
+import os
+import tempfile
+from .core import ZephyrBinaryRunner, RunnerCaps, BuildConfiguration
 
 DEFAULT_JLINK_GDB_PORT = 2331
 
@@ -13,11 +15,17 @@ class JLinkBinaryRunner(ZephyrBinaryRunner):
     '''Runner front-end for the J-Link GDB server.'''
 
     def __init__(self, device,
+                 commander='JLinkExe', bin_name=None,
+                 flash_addr=0x0, erase=True,
                  gdbserver='JLinkGDBServer', iface='swd', speed='auto',
                  elf_name=None, gdb=None, gdb_port=DEFAULT_JLINK_GDB_PORT,
                  tui=False, debug=False):
         super(JLinkBinaryRunner, self).__init__(debug=debug)
         self.device = device
+        self.commander = commander
+        self.bin_name = bin_name
+        self.flash_addr = flash_addr
+        self.erase = erase
         self.gdbserver_cmd = [gdbserver]
         self.iface = iface
         self.speed = speed
@@ -32,7 +40,7 @@ class JLinkBinaryRunner(ZephyrBinaryRunner):
 
     @classmethod
     def capabilities(cls):
-        return RunnerCaps(commands={'debug', 'debugserver'})
+        return RunnerCaps(flash_addr=True)
 
     @classmethod
     def do_add_parser(cls, parser):
@@ -51,10 +59,19 @@ class JLinkBinaryRunner(ZephyrBinaryRunner):
         parser.add_argument('--gdb-port', default=DEFAULT_JLINK_GDB_PORT,
                             help='pyocd gdb port, defaults to {}'.format(
                                 DEFAULT_JLINK_GDB_PORT))
+        parser.add_argument('--commander', default='JLinkExe',
+                            help='J-Link Commander, default is JLinkExe')
+        parser.add_argument('--erase', default=True, action='store_false',
+                            help='erase flash before loading, default is true')
 
     @classmethod
     def create_from_args(cls, args):
+        build_conf = BuildConfiguration(os.getcwd())
+        flash_addr = cls.get_flash_address(args, build_conf)
         return JLinkBinaryRunner(args.device, gdbserver=args.gdbserver,
+                                 commander=args.commander,
+                                 bin_name=args.kernel_bin,
+                                 flash_addr=flash_addr, erase=args.erase,
                                  iface=args.iface, speed=args.speed,
                                  elf_name=args.kernel_elf,
                                  gdb=args.gdb, gdb_port=args.gdb_port,
@@ -73,7 +90,9 @@ class JLinkBinaryRunner(ZephyrBinaryRunner):
                        '-silent',
                        '-singlerun'])
 
-        if command == 'debugserver':
+        if command == 'flash':
+            self.flash(**kwargs)
+        elif command == 'debugserver':
             self.print_gdbserver_message()
             self.check_call(server_cmd)
         else:
@@ -90,3 +109,30 @@ class JLinkBinaryRunner(ZephyrBinaryRunner):
                            '-ex', 'load'])
             self.print_gdbserver_message()
             self.run_server_and_client(server_cmd, client_cmd)
+
+    def flash(self, **kwargs):
+        if self.bin_name is None:
+            raise ValueError('Cannot flash; bin_name is missing')
+
+        lines = ['r'] # Reset and halt the target
+
+        if self.erase:
+            lines.append('erase') # Erase all flash sectors
+
+        lines.append('loadfile {} 0x{:x}'.format(self.bin_name,
+                                                 self.flash_addr))
+        lines.append('g') # Start the CPU
+        lines.append('q') # Close the connection and quit
+
+        with tempfile.NamedTemporaryFile(suffix='.jlink') as f:
+            f.writelines(bytes(line + '\n', 'utf-8') for line in lines)
+            f.flush()
+
+            cmd = ([self.commander] +
+                   ['-if', self.iface,
+                    '-speed', self.speed,
+                    '-device', self.device,
+                    '-CommanderScript', f.name])
+
+            print('Flashing Target Device')
+            self.check_call(cmd)


### PR DESCRIPTION
Adds support for the 'flash' command to the jlink runner so we can flash
via 'make flash'. This works by generating a temporary jlink commander
script file and passing the script to the jlink commander executable.

Fixes #5755 