### PR TITLE
Bluetooth: controller: Fix CPR initiation while in Enc. setup

### DIFF
--- a/subsys/bluetooth/controller/ll_sw/ctrl.c
+++ b/subsys/bluetooth/controller/ll_sw/ctrl.c
@@ -7705,8 +7705,10 @@ static void event_connection_prepare(u32_t ticks_at_expire,
 	event_counter = conn->event_counter + conn->latency_prepare;
 
 #if defined(CONFIG_BT_CTLR_CONN_PARAM_REQ) || defined(CONFIG_BT_CTLR_PHY)
-	/* Check if no other procedure with instant is requested */
-	if (conn->llcp_ack == conn->llcp_req) {
+	/* Check if no other procedure with instant is requested and not in
+	 * Encryption setup.
+	 */
+	if ((conn->llcp_ack == conn->llcp_req) && !conn->pause_rx) {
 
 #if defined(CONFIG_BT_CTLR_CONN_PARAM_REQ)
 		/* check if CPR procedure is requested */


### PR DESCRIPTION
Fixes a bug where in Connection Parameter Request was
initiated by slave role while Encryption Setup had been
started by the peer master.

Fixes: #5823

Signed-off-by: Vinayak Kariappa Chettimada <vich@nordicsemi.no>