### PR TITLE
scripts: fix ram_reports and generate bin file if missing

### DIFF
--- a/cmake/reports/CMakeLists.txt
+++ b/cmake/reports/CMakeLists.txt
@@ -8,6 +8,7 @@ foreach(report ram_report rom_report)
     ${ZEPHYR_BASE}/scripts/footprint/size_report
     ${flag_for_${report}}
     --objdump ${CMAKE_OBJDUMP}
+    --objcopy ${CMAKE_OBJCOPY}
     --nm      ${CMAKE_NM}
     -o ${PROJECT_BINARY_DIR}
     DEPENDS ${logical_target_for_zephyr_elf}

--- a/scripts/footprint/size_report
+++ b/scripts/footprint/size_report
@@ -31,6 +31,8 @@ parser.add_option("-F", "--rom",
                   help="print ROM statistics")
 parser.add_option("-s", "--objdump", type="string", dest="bin_objdump",
                   help="Path to the GNU binary utility objdump")
+parser.add_option("-c", "--objcopy", type="string", dest="bin_objcopy",
+                  help="Path to the GNU binary utility objcopy")
 parser.add_option("-n", "--nm", type="string", dest="bin_nm",
                   help="Path to the GNU binary utility nm")
 
@@ -406,14 +408,18 @@ def print_tree(data, total, depth):
     print('{:92d}'.format(total))
     return totp
 
+bin_file = os.path.join(options.outdir, options.binary + ".bin")
+stat_file = os.path.join(options.outdir, options.binary + ".stat")
+elf_file = os.path.join(options.outdir, options.binary + ".elf")
 
-binary = os.path.join(options.outdir, options.binary + ".elf")
+if not os.path.exists(bin_file):
+    FNULL = open(os.devnull, 'w')
+    subprocess.call([options.bin_objcopy,"-S", "-Obinary", "-R", ".comment", "-R",
+                   "COMMON", "-R", ".eh_frame", elf_file, bin_file],
+                   stdout=FNULL, stderr=subprocess.STDOUT)
 
-if options.outdir and os.path.exists(binary):
-    fp = get_footprint_from_bin_and_statfile(
-        "%s/%s.bin" % (options.outdir, options.binary),
-        "%s/%s.stat" % (options.outdir, options.binary),
-        0, 0)
+if options.outdir and os.path.exists(elf_file):
+    fp = get_footprint_from_bin_and_statfile(bin_file, stat_file, 0, 0)
     base = os.environ['ZEPHYR_BASE']
     ram, data = generate_target_memory_section(
         options.bin_objdump, options.bin_nm, options.outdir, options.binary,
@@ -424,4 +430,4 @@ if options.outdir and os.path.exists(binary):
         print_tree(ram, fp['total_ram'], options.depth)
 
 else:
-    print("%s does not exist." % (binary))
+    print("%s does not exist." % (elf_file))

--- a/scripts/footprint/size_report
+++ b/scripts/footprint/size_report
@@ -16,27 +16,6 @@ import operator
 import platform
 from pathlib import Path
 
-parser = OptionParser()
-parser.add_option("-d", "--depth", dest="depth", type="int",
-                  help="How deep should we go into the tree", metavar="DEPTH")
-parser.add_option("-o", "--outdir", dest="outdir",
-                  help="read files from directory OUT", metavar="OUT")
-parser.add_option("-k", "--kernel-name", dest="binary", default="zephyr",
-                  help="kernel binary name")
-parser.add_option("-r", "--ram",
-                  action="store_true", dest="ram", default=False,
-                  help="print RAM statistics")
-parser.add_option("-F", "--rom",
-                  action="store_true", dest="rom", default=False,
-                  help="print ROM statistics")
-parser.add_option("-s", "--objdump", type="string", dest="bin_objdump",
-                  help="Path to the GNU binary utility objdump")
-parser.add_option("-c", "--objcopy", type="string", dest="bin_objcopy",
-                  help="Path to the GNU binary utility objcopy")
-parser.add_option("-n", "--nm", type="string", dest="bin_nm",
-                  help="Path to the GNU binary utility nm")
-
-(options, args) = parser.parse_args()
 
 # Return a dict containing {
 #   symbol_name: {:,path/to/file}/symbol
@@ -408,26 +387,54 @@ def print_tree(data, total, depth):
     print('{:92d}'.format(total))
     return totp
 
-bin_file = os.path.join(options.outdir, options.binary + ".bin")
-stat_file = os.path.join(options.outdir, options.binary + ".stat")
-elf_file = os.path.join(options.outdir, options.binary + ".elf")
 
-if not os.path.exists(bin_file):
-    FNULL = open(os.devnull, 'w')
-    subprocess.call([options.bin_objcopy,"-S", "-Obinary", "-R", ".comment", "-R",
-                   "COMMON", "-R", ".eh_frame", elf_file, bin_file],
-                   stdout=FNULL, stderr=subprocess.STDOUT)
+def main():
+    parser = OptionParser()
+    parser.add_option("-d", "--depth", dest="depth", type="int",
+                      help="How deep should we go into the tree", metavar="DEPTH")
+    parser.add_option("-o", "--outdir", dest="outdir",
+                      help="read files from directory OUT", metavar="OUT")
+    parser.add_option("-k", "--kernel-name", dest="binary", default="zephyr",
+                      help="kernel binary name")
+    parser.add_option("-r", "--ram",
+                      action="store_true", dest="ram", default=False,
+                      help="print RAM statistics")
+    parser.add_option("-F", "--rom",
+                      action="store_true", dest="rom", default=False,
+                      help="print ROM statistics")
+    parser.add_option("-s", "--objdump", type="string", dest="bin_objdump",
+                      help="Path to the GNU binary utility objdump")
+    parser.add_option("-c", "--objcopy", type="string", dest="bin_objcopy",
+                      help="Path to the GNU binary utility objcopy")
+    parser.add_option("-n", "--nm", type="string", dest="bin_nm",
+                      help="Path to the GNU binary utility nm")
 
-if options.outdir and os.path.exists(elf_file):
-    fp = get_footprint_from_bin_and_statfile(bin_file, stat_file, 0, 0)
-    base = os.environ['ZEPHYR_BASE']
-    ram, data = generate_target_memory_section(
-        options.bin_objdump, options.bin_nm, options.outdir, options.binary,
-        base + '/', None)
-    if options.rom:
-        print_tree(data, fp['total_flash'], options.depth)
-    if options.ram:
-        print_tree(ram, fp['total_ram'], options.depth)
+    (options, args) = parser.parse_args()
 
-else:
-    print("%s does not exist." % (elf_file))
+    bin_file = os.path.join(options.outdir, options.binary + ".bin")
+    stat_file = os.path.join(options.outdir, options.binary + ".stat")
+    elf_file = os.path.join(options.outdir, options.binary + ".elf")
+
+    if not os.path.exists(bin_file):
+        FNULL = open(os.devnull, 'w')
+        subprocess.call([options.bin_objcopy,"-S", "-Obinary", "-R", ".comment", "-R",
+                       "COMMON", "-R", ".eh_frame", elf_file, bin_file],
+                       stdout=FNULL, stderr=subprocess.STDOUT)
+
+    if options.outdir and os.path.exists(elf_file):
+        fp = get_footprint_from_bin_and_statfile(bin_file, stat_file, 0, 0)
+        base = os.environ['ZEPHYR_BASE']
+        ram, data = generate_target_memory_section(
+            options.bin_objdump, options.bin_nm, options.outdir, options.binary,
+            base + '/', None)
+        if options.rom:
+            print_tree(data, fp['total_flash'], options.depth)
+        if options.ram:
+            print_tree(ram, fp['total_ram'], options.depth)
+
+    else:
+        print("%s does not exist." % (elf_file))
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Some boards do not generate .bin files by default, this file is however
needed when generating ram/rom reports, so in case it is not present, create
it.

Fixes #5784

Signed-off-by: Anas Nashif <anas.nashif@intel.com>