### PR TITLE
dts: add support for application level dts.fixup

### DIFF
--- a/dts/dts.cmake
+++ b/dts/dts.cmake
@@ -93,10 +93,13 @@ if(CONFIG_HAS_DTS)
   if(EXISTS ${DTS_SOC_FIXUP_FILE})
     set(DTS_SOC_FIXUP -f ${DTS_SOC_FIXUP_FILE})
   endif()
+  if(EXISTS ${APPLICATION_SOURCE_DIR}/dts.fixup)
+    set(DTS_APP_FIXUP -f ${APPLICATION_SOURCE_DIR}/dts.fixup)
+  endif()
   set(CMD_EXTRACT_DTS_INCLUDES ${PYTHON_EXECUTABLE} ${PROJECT_SOURCE_DIR}/scripts/dts/extract_dts_includes.py
     --dts ${BOARD_FAMILY}.dts_compiled
     --yaml ${PROJECT_SOURCE_DIR}/dts/bindings
-    ${DTS_SOC_FIXUP} ${DTS_BOARD_FIXUP}
+    ${DTS_SOC_FIXUP} ${DTS_BOARD_FIXUP} ${DTS_APP_FIXUP}
     )
   execute_process(
     COMMAND ${CMD_EXTRACT_DTS_INCLUDES}


### PR DESCRIPTION
We allow the application to have its own dts.fixup.  The main use for
this right now is for the build all test to define dummy values for
defines we expect to be generated.

Signed-off-by: Kumar Gala <kumar.gala@linaro.org>