### PR TITLE
sensor: hts221: Cleanup Kconfig for driver & bus name

### DIFF
--- a/drivers/sensor/hts221/Kconfig
+++ b/drivers/sensor/hts221/Kconfig
@@ -12,22 +12,26 @@ menuconfig HTS221
 	help
 	  Enable driver for HTS221 I2C-based temperature and humidity sensor.
 
+if !HAS_DTS_I2C_DEVICE
+
 config HTS221_NAME
 	string
 	prompt "Driver name"
 	default "HTS221"
-	depends on HTS221 && !HAS_DTS_I2C_DEVICE
+	depends on HTS221
 	help
 	  Device name with which the HTS221 sensor is identified.
 
 config HTS221_I2C_MASTER_DEV_NAME
 	string
 	prompt "I2C master where HTS221 is connected"
-	depends on HTS221 && !HAS_DTS_I2C_DEVICE
+	depends on HTS221
 	default "I2C_0"
 	help
 	  Specify the device name of the I2C master device to which HTS221 is
 	  connected.
+
+endif
 
 choice
 	prompt "Trigger mode"


### PR DESCRIPTION
Move to use an if HAS_DTS_I2C_DEVICE instead of depends on so that the
Kconfig sybmols don't even show up if HAS_DTS_I2C_DEVICE is true.

Signed-off-by: Kumar Gala <kumar.gala@linaro.org>