### PR TITLE
net: if: No need for L2 BT interfaces to join solicited-node

### DIFF
--- a/subsys/net/ip/net_if.c
+++ b/subsys/net/ip/net_if.c
@@ -410,6 +410,13 @@ static void join_mcast_solicit_node(struct net_if *iface,
 	struct in6_addr addr;
 	int ret;
 
+#if defined(CONFIG_NET_L2_BT)
+	/* No need to join solicited-node, RFC 7668 ch 3.2.2 */
+	if (iface->l2 == &NET_L2_GET_NAME(BLUETOOTH)) {
+		return;
+	}
+#endif
+
 	/* Join to needed multicast groups, RFC 4291 ch 2.8 */
 	net_ipv6_addr_create_solicited_node(my_addr, &addr);
 


### PR DESCRIPTION
From https://tools.ietf.org/html/rfc7668#section-3.2.2 :

"""
There is no need for 6LN to join the solicited-node multicast address,
since 6LBR will know device addresses and hence link-local addresses
of all connected 6LNs.
"""

Signed-off-by: Ricardo Salveti <ricardo@opensourcefoundries.com>