### PR TITLE
Bluetooth: controller: Fix to restrict addr set in active states

### DIFF
--- a/subsys/bluetooth/controller/hci/hci.c
+++ b/subsys/bluetooth/controller/hci/hci.c
@@ -696,11 +696,12 @@ static void le_set_random_address(struct net_buf *buf, struct net_buf **evt)
 {
 	struct bt_hci_cp_le_set_random_address *cmd = (void *)buf->data;
 	struct bt_hci_evt_cc_status *ccst;
+	u32_t status;
 
-	ll_addr_set(1, &cmd->bdaddr.val[0]);
+	status = ll_addr_set(1, &cmd->bdaddr.val[0]);
 
 	ccst = cmd_complete(evt, sizeof(*ccst));
-	ccst->status = 0x00;
+	ccst->status = status;
 }
 
 #if defined(CONFIG_BT_CTLR_FILTER)

--- a/subsys/bluetooth/controller/include/ll.h
+++ b/subsys/bluetooth/controller/include/ll.h
@@ -12,7 +12,7 @@ int ll_init(struct k_sem *sem_rx);
 void ll_reset(void);
 
 u8_t *ll_addr_get(u8_t addr_type, u8_t *p_bdaddr);
-void ll_addr_set(u8_t addr_type, u8_t const *const p_bdaddr);
+u32_t ll_addr_set(u8_t addr_type, u8_t const *const p_bdaddr);
 
 #if defined(CONFIG_BT_CTLR_ADV_EXT)
 u32_t ll_adv_params_set(u8_t handle, u16_t evt_prop, u32_t interval,

--- a/subsys/bluetooth/controller/ll_sw/ll_addr.c
+++ b/subsys/bluetooth/controller/ll_sw/ll_addr.c
@@ -8,9 +8,13 @@
 #include <string.h>
 
 #include <zephyr/types.h>
-#include <toolchain.h>
+#include <bluetooth/hci.h>
+#include <misc/slist.h>
+
+#include "util/util.h"
 
 #include "ll_sw/pdu.h"
+#include "ll_sw/ctrl.h"
 
 static u8_t pub_addr[BDADDR_SIZE];
 static u8_t rnd_addr[BDADDR_SIZE];
@@ -36,11 +40,17 @@ u8_t *ll_addr_get(u8_t addr_type, u8_t *bdaddr)
 	return pub_addr;
 }
 
-void ll_addr_set(u8_t addr_type, u8_t const *const bdaddr)
+u32_t ll_addr_set(u8_t addr_type, u8_t const *const bdaddr)
 {
+	if (radio_adv_is_enabled() || radio_scan_is_enabled()) {
+		return BT_HCI_ERR_CMD_DISALLOWED;
+	}
+
 	if (addr_type) {
 		memcpy(rnd_addr, bdaddr, BDADDR_SIZE);
 	} else {
 		memcpy(pub_addr, bdaddr, BDADDR_SIZE);
 	}
+
+	return 0;
 }


### PR DESCRIPTION
Fixed implementation to disallow setting Bluetooth device
address under active advertising or scanning states.

Fixes LL.TS.5.0.2 conformance tests:
LL/CON/INI/BV-01-C [Connection Initiation]
LL/SEC/ADV/BV-01-C [Advertising With Static Address]
LL/SEC/SCN/BV-01-C [Random Address Scanning]

Signed-off-by: Vinayak Kariappa Chettimada <vich@nordicsemi.no>