### PR TITLE
native: minor fixes (2)

### DIFF
--- a/arch/posix/soc/inf_clock/posix_board_if.h
+++ b/arch/posix/soc/inf_clock/posix_board_if.h
@@ -22,7 +22,7 @@ extern "C" {
 #endif
 
 void posix_irq_handler(void);
-void main_clean_up(int exit_code);
+void posix_exit(int exit_code);
 
 #if defined(CONFIG_ARCH_HAS_CUSTOM_BUSY_WAIT)
 void k_busy_wait(u32_t usec_to_wait);

--- a/arch/posix/soc/inf_clock/soc.c
+++ b/arch/posix/soc/inf_clock/soc.c
@@ -124,7 +124,7 @@ void posix_interrupt_raised(void)
 	 * we stop immediately.
 	 */
 	if (soc_terminate) {
-		main_clean_up(0);
+		posix_exit(0);
 	}
 }
 
@@ -225,7 +225,7 @@ void posix_boot_cpu(void)
 	}
 
 	if (soc_terminate) {
-		main_clean_up(0);
+		posix_exit(0);
 	}
 }
 

--- a/boards/posix/native_posix/doc/board.rst
+++ b/boards/posix/native_posix/doc/board.rst
@@ -160,9 +160,6 @@ Note that the Zephyr kernel does not actually exit once the application is
 finished. It simply goes into the idle loop forever.
 Therefore you must stop the application manually (Ctrl+C in Linux).
 
-Application tests using the ``ztest`` framework will exit after all
-tests have completed.
-
 If you want your application to gracefully finish when it reaches some point,
 you may add a conditionally compiled (:option:`CONFIG_ARCH_POSIX`) call to
 ``posix_exit(int status)`` at that point.

--- a/boards/posix/native_posix/doc/board.rst
+++ b/boards/posix/native_posix/doc/board.rst
@@ -92,14 +92,16 @@ Therefore these limitations apply:
 
      /* We expect the peripheral done and ready to do something else */
 
+
 - This port is not meant to, and could not possibly help debug races between
   HW and SW, or similar timing related issues.
 
 - You may not use hard coded memory addresses because there is no I/O or
   MMU emulation.
 
+
 Working around these limitations
-==================================
+================================
 
 If a busy wait loop exists, it will become evident as the application will be
 stalled in it. To find the loop, you can run the binary in a debugger and
@@ -162,8 +164,8 @@ Application tests using the ``ztest`` framework will exit after all
 tests have completed.
 
 If you want your application to gracefully finish when it reaches some point,
-you may add a conditionally compiled (CONFIG_BOARD_NATIVE_POSIX) call to
-``main_clean_up(exit_code)`` at that point.
+you may add a conditionally compiled (:option:`CONFIG_ARCH_POSIX`) call to
+``posix_exit(int status)`` at that point.
 
 Debugging
 =========

--- a/boards/posix/native_posix/hw_models_top.c
+++ b/boards/posix/native_posix/hw_models_top.c
@@ -103,7 +103,7 @@ static void hwm_sleep_until_next_timer(void)
 		posix_print_trace("\nStopped after %.3Lfs\n",
 				((long double)device_time)/1.0e6);
 
-		main_clean_up(0);
+		posix_exit(0);
 	}
 }
 

--- a/boards/posix/native_posix/main.c
+++ b/boards/posix/native_posix/main.c
@@ -28,14 +28,14 @@
 #define STOP_AFTER_5_SECONDS 0
 
 
-void main_clean_up(int exit_code)
+void posix_exit(int exit_code)
 {
 	static int max_exit_code;
 
 	max_exit_code = max(exit_code, max_exit_code);
 	/*
 	 * posix_soc_clean_up may not return if this is called from a SW thread,
-	 * but instead it would get main_clean_up() recalled again
+	 * but instead it would get posix_exit() recalled again
 	 * ASAP from the HW thread
 	 */
 	posix_soc_clean_up();

--- a/boards/posix/native_posix/tracing.c
+++ b/boards/posix/native_posix/tracing.c
@@ -22,7 +22,7 @@ void posix_print_error_and_exit(const char *format, ...)
 	va_start(variable_args, format);
 	vfprintf(stderr, format, variable_args);
 	va_end(variable_args);
-	main_clean_up(1);
+	posix_exit(1);
 }
 
 void posix_print_warning(const char *format, ...)


### PR DESCRIPTION
1. Tests using ztest do not stop anymore since commit
   07c9163f67dbbb937cf29680b8243cdc3ed65c07
   => fixed documentation

2. Rename main_clean_up() to posix_exit() for consistencywith all other global functions of this architecture