### PR TITLE
samples: update the blinky sample to work with the Arduino Zero.

### DIFF
--- a/samples/basic/blinky/src/main.c
+++ b/samples/basic/blinky/src/main.c
@@ -10,7 +10,7 @@
 #include <gpio.h>
 
 /* Change this if you have an LED connected to a custom port */
-#define PORT	LED0_GPIO_PORT
+#define LED_PORT	LED0_GPIO_PORT
 
 /* Change this if you have an LED connected to a custom pin */
 #define LED	LED0_GPIO_PIN
@@ -23,7 +23,7 @@ void main(void)
 	int cnt = 0;
 	struct device *dev;
 
-	dev = device_get_binding(PORT);
+	dev = device_get_binding(LED_PORT);
 	/* Set LED pin as output */
 	gpio_pin_configure(dev, LED, GPIO_DIR_OUT);
 


### PR DESCRIPTION
The GPIO unit on the SAM0 is called 'PORT' which conflicts with the
name used in this sample.  Rename to LED_PORT instead.

Signed-off-by: Michael Hope <mlhx@google.com>