### PR TITLE
boards: 96b_carbon: add supported features

### DIFF
--- a/boards/arm/96b_carbon/96b_carbon.yaml
+++ b/boards/arm/96b_carbon/96b_carbon.yaml
@@ -5,3 +5,9 @@ arch: arm
 toolchain:
   - zephyr
   - gccarmemb
+supported:
+  - gpio
+  - ble
+  - i2c
+  - spi
+  - usb_device


### PR DESCRIPTION
add i2c, spi and usb_device as supported feaures.

Signed-off-by: Anas Nashif <anas.nashif@intel.com>