### PR TITLE
cmake: do not set CMAKE_SKIP_INSTALL_RULES to ON

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -17,9 +17,6 @@ enable_language(C CXX ASM)
 check_c_compiler_flag("" toolchain_is_ok)
 assert(toolchain_is_ok "The toolchain is unable to build a dummy C file. See CMakeError.log.")
 
-# Do not generate make install target.
-set(CMAKE_SKIP_INSTALL_RULES ON)
-
 set(CMAKE_EXECUTABLE_SUFFIX .elf)
 
 set(SOC_NAME ${CONFIG_SOC})


### PR DESCRIPTION
This CMakeLists.txt is added via add_subdirectory() to the app's
CMakeLists.txt. If the app-CMakeLists.txt has install() rules and
wants to use them, setting CMAKE_SKIP_INSTALL_RULES to ON breaks
the 'make install' call.

Not setting this variable does not harm zephyr because zephyr does
not use install().

Sorry for my ignorance in advance if this variable was set to ON for a good reason. 