### PR TITLE
cmake: give an assert a useful message

### DIFF
--- a/cmake/toolchain.cmake
+++ b/cmake/toolchain.cmake
@@ -16,7 +16,7 @@ if(NOT ZEPHYR_GCC_VARIANT)
   endif()
 endif()
 set(ZEPHYR_GCC_VARIANT ${ZEPHYR_GCC_VARIANT} CACHE STRING "Zephyr GCC variant")
-assert(ZEPHYR_GCC_VARIANT "")
+assert(ZEPHYR_GCC_VARIANT "Zephyr GCC variant invalid: please set the ZEPHYR_GCC_VARIANT-variable")
 
 if(CONFIG_ARCH_POSIX OR (ZEPHYR_GCC_VARIANT STREQUAL "host"))
   set(COMPILER host-gcc)


### PR DESCRIPTION
When the ZEPHYR_GCC_VARIANT-variable is not set properly no
message is printed, whereas this small change will help users
to easier understand why things are not working. Here: they forgot
to set an ENV-variable.

Signed-off-by: Patrick Boettcher <patrick.boettcher@posteo.de>