### PR TITLE
sanitycheck: fix crashes with symlinks in path

### DIFF
--- a/scripts/sanitycheck
+++ b/scripts/sanitycheck
@@ -1374,8 +1374,10 @@ class TestCase:
         self.min_flash = tc_dict["min_flash"]
         self.extra_sections = tc_dict["extra_sections"]
 
-        self.path = os.path.normpath(os.path.join(os.path.abspath(
-            testcase_root).replace(ZEPHYR_BASE + "/", ''), workdir, name))
+        self.path = os.path.normpath(os.path.join(os.path.realpath(
+            testcase_root).replace(os.path.realpath(ZEPHYR_BASE) + "/", ''),
+            workdir, name))
+
         self.name = os.path.join(self.path)
         self.defconfig = {}
         self.yamlfile = yamlfile


### PR DESCRIPTION
When building the testcase path, replace symlinks in path
with the realpath both in the testcase root and in ZEPHYR_BASE

For more info see issue #5772

Fixes: #5772

Signed-off-by: Alberto Escolar Piedras <alpi@oticon.com>