### PR TITLE
bt: Don't rely on 'enum bt_buf_type' being 1 byte

### DIFF
--- a/include/bluetooth/buf.h
+++ b/include/bluetooth/buf.h
@@ -82,7 +82,13 @@ static inline void bt_buf_set_type(struct net_buf *buf, enum bt_buf_type type)
  */
 static inline enum bt_buf_type bt_buf_get_type(struct net_buf *buf)
 {
-	return *((enum bt_buf_type *)net_buf_user_data(buf));
+	/* De-referencing the pointer from net_buf_user_data(buf) as a
+	 * pointer to an enum causes issues on qemu_x86 because the true
+	 * size is 8-bit, but the enum is 32-bit on qemu_x86. So we put in
+	 * a temporary cast to 8-bit to ensure only 8 bits are read from
+	 * the pointer.
+	 */
+	return (enum bt_buf_type)(*(u8_t *)net_buf_user_data(buf));
 }
 
 /**


### PR DESCRIPTION
De-referencing the pointer from net_buf_user_data(buf) as a pointer to
an enum causes issues on qemu_x86 because the true size is 8-bit, but
the enum is 32-bit on qemu_x86. So we put in a temporary cast to 8-bit
to ensure only 8 bits are read from the pointer.

This fixes a regression from d3304dc50863ffe5dbc89daa2793c557cf9edd25
that broke BT on qemu_x86.

Signed-off-by: Sebastian Bøe <sebastian.boe@nordicsemi.no>