### PR TITLE
scripts: extract_dts_includes: Sanitize interrupt names

### DIFF
--- a/scripts/dts/extract_dts_includes.py
+++ b/scripts/dts/extract_dts_includes.py
@@ -236,7 +236,7 @@ def extract_interrupts(node_address, yaml, y_key, names, defs, def_label):
             name = []
         else:
             try:
-                name = [names.pop(0).upper()]
+                name = [convert_string_to_label(names.pop(0)).upper()]
             except:
                 name = []
 


### PR DESCRIPTION
Its possible we have dashes in interrupt names that we need to convert
to underscores when we generate defines.  Make sure we do that otherwise
things aren't going to build.

Signed-off-by: Kumar Gala <kumar.gala@linaro.org>