### PR TITLE
config: bootloader: Add support for MCUboot

### DIFF
--- a/arch/arm/core/cortex_m/Kconfig
+++ b/arch/arm/core/cortex_m/Kconfig
@@ -194,6 +194,7 @@ config SW_VECTOR_RELAY
 	bool
 	prompt "Enable Cortex-M0 Vector Table soft relay"
 	default n
+	default y if BOOTLOADER_MCUBOOT
 	depends on CPU_CORTEX_M0 && !CPU_CORTEX_M0_HAS_VECTOR_TABLE_REMAP
 	help
 	  Add Cortex-M0 Vector Table relay handler and relay vector table, to

--- a/misc/Kconfig
+++ b/misc/Kconfig
@@ -44,9 +44,16 @@ endif
 config TEXT_SECTION_OFFSET
 	hex "TEXT section offset"
 	default 0
+	default 0x200 if BOOTLOADER_MCUBOOT
 	help
-	  This sets and offset before the text section and allows booting images
-	  with custom headers that are inserted at the beginning of the image.
+	  If the application is built for chain-loading by a bootloader this
+	  variable is required to be set to value that leaves sufficient
+	  space between the beginning of the image and the start of the .text
+	  section to store an image header or any other metadata.
+	  In the particular case of the MCUboot bootloader this reserves enough
+	  space to store the image header, which should also meet vector table
+	  alignment requirements on most ARM targets, although some targets
+	  may require smaller or larger values.
 
 config HAVE_CUSTOM_LINKER_SCRIPT
 	prompt "Custom linker scripts provided"
@@ -272,6 +279,16 @@ config BOOTLOADER_SRAM_SIZE
 	help
 	  This option specifies the amount of SRAM (measure in kB) reserved for
 	  when Zephyr is to act as a bootloader.
+
+config BOOTLOADER_MCUBOOT
+	bool
+	prompt "MCUboot bootloader support"
+	default n
+	help
+	  This option signifies that the target uses MCUboot as a bootloader,
+	  or in other words that the image is to be chain-loaded by MCUboot.
+	  This sets several required options in order for the image generated
+	  to be bootable using the MCUboot open source bootloader.
 
 config BOOTLOADER_KEXEC
 	bool


### PR DESCRIPTION
Add a new Kconfig option, BOOTLOADER_MCUBOOT, that automatically sets
the required options necessary to make the resulting image bootable by
the MCUboot open source bootloader. This includes the text section
offset and the vector relay table for Cortex-M0, and in the future it
might also add the DTS overlay required to link at slot0 offset in
flash.

Signed-off-by: Carles Cufi <carles.cufi@nordicsemi.no>