### PR TITLE
x86: forbid user mode on meltdown-enabled boards

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -909,12 +909,3 @@ if(CONFIG_BOARD_DEPRECATED)
       removed in version ${CONFIG_BOARD_DEPRECATED}"
 )
 endif()
-
-if(CONFIG_X86 AND CONFIG_USERSPACE AND NOT CONFIG_X86_NO_MELTDOWN)
-  message(WARNING "
-      WARNING: You have enabled CONFIG_USERSPACE on an x86-based target.
-      If your CPU is vulnerable to the Meltdown CPU bug, security of
-      supervisor-only memory pages is not guaranteed. This version of Zephyr
-      does not contain a fix for this issue."
-)
-endif()

--- a/arch/x86/Kconfig
+++ b/arch/x86/Kconfig
@@ -35,14 +35,14 @@ config CPU_ATOM
 	select CMOV
 	select CPU_HAS_FPU
 	select ARCH_HAS_STACK_PROTECTION if X86_MMU
-	select ARCH_HAS_USERSPACE if X86_MMU
+	select ARCH_HAS_USERSPACE if X86_MMU && X86_NO_MELTDOWN
 	help
 	  This option signifies the use of a CPU from the Atom family.
 
 config CPU_MINUTEIA
 	# Hidden
 	select ARCH_HAS_STACK_PROTECTION if X86_MMU
-	select ARCH_HAS_USERSPACE if X86_MMU
+	select ARCH_HAS_USERSPACE if X86_MMU && X86_NO_MELTDOWN
 	bool
 	help
 	  This option signifies the use of a CPU from the Minute IA family.

--- a/arch/x86/core/thread.c
+++ b/arch/x86/core/thread.c
@@ -145,6 +145,11 @@ void _new_thread(struct k_thread *thread, k_thread_stack_t *stack,
 }
 
 #ifdef CONFIG_X86_USERSPACE
+
+#ifndef CONFIG_X86_NO_MELTDOWN
+#error "Enabling user mode on platforms known to be vulnerable to Meltdown is forbidden"
+#endif
+
 void _x86_swap_update_page_tables(struct k_thread *incoming,
 				  struct k_thread *outgoing)
 {

--- a/boards/x86/qemu_x86/Kconfig.board
+++ b/boards/x86/qemu_x86/Kconfig.board
@@ -5,3 +5,4 @@ config BOARD_QEMU_X86
 	select QEMU_TARGET
 	select HAS_DTS
 	select CPU_HAS_FPU if !X86_IAMCU
+	select X86_NO_MELTDOWN


### PR DESCRIPTION
We plan to ultimately fix this by introducing virtual memory in the kernel and then protect the page tables with KPTI techniques, but this will take some time (1.13 most likely for a mature solution) and meanwhile we will not allow user mode to be enabled unless a board is specifically noted in its SOC or board configuration as being not vulnerable to this CPU bug.

The qemu_x86 family of boards is added to the white-list as it is an emulated target used for sanitycheck and CI.