### PR TITLE
sensors: dts: cleanup usage of HAS_DTS_I2C_DEVICE

### DIFF
--- a/drivers/sensor/lis3mdl/Kconfig
+++ b/drivers/sensor/lis3mdl/Kconfig
@@ -12,18 +12,20 @@ menuconfig LIS3MDL
 	help
 	  Enable driver for LIS3MDL I2C-based magnetometer.
 
+if !HAS_DTS_I2C_DEVICE
+
 config LIS3MDL_NAME
 	string
 	prompt "Driver name"
 	default "LIS3MDL"
-	depends on LIS3MDL && !HAS_DTS_I2C_DEVICE
+	depends on LIS3MDL
 	help
 	  Device name with which the LIS3MDL sensor is identified.
 
 config LIS3MDL_I2C_ADDR
 	hex
 	prompt "I2C address"
-	depends on LIS3MDL && !HAS_DTS_I2C_DEVICE
+	depends on LIS3MDL
 	default 0x1C
 	help
 	  I2C address of the LIS3MDL sensor.
@@ -33,11 +35,13 @@ config LIS3MDL_I2C_ADDR
 config LIS3MDL_I2C_MASTER_DEV_NAME
 	string
 	prompt "I2C master where LIS3MDL is connected"
-	depends on LIS3MDL && !HAS_DTS_I2C_DEVICE
+	depends on LIS3MDL
 	default "I2C_0"
 	help
 	  Specify the device name of the I2C master device to which LIS3MDL is
 	  connected.
+
+endif
 
 choice
 	prompt "Trigger mode"

--- a/drivers/sensor/lps22hb/Kconfig
+++ b/drivers/sensor/lps22hb/Kconfig
@@ -13,18 +13,20 @@ menuconfig LPS22HB
 	  Enable driver for LPS22HB I2C-based pressure and temperature
 	  sensor.
 
+if !HAS_DTS_I2C_DEVICE
+
 config LPS22HB_DEV_NAME
 	string
 	prompt "Device name"
 	default "LPS22HB"
-	depends on LPS22HB && !HAS_DTS_I2C_DEVICE
+	depends on LPS22HB
 	help
 	  Device name used for LPS22HB sensor identification.
 
 config LPS22HB_I2C_ADDR
 	hex
 	prompt "I2C address"
-	depends on LPS22HB && !HAS_DTS_I2C_DEVICE
+	depends on LPS22HB
 	default 0x5D
 	range 0x5C 0x5D
 	help
@@ -35,11 +37,13 @@ config LPS22HB_I2C_ADDR
 config LPS22HB_I2C_MASTER_DEV_NAME
 	string
 	prompt "I2C master where LPS22HB is connected"
-	depends on LPS22HB && !HAS_DTS_I2C_DEVICE
+	depends on LPS22HB
 	default I2C_0_NAME
 	help
 	  Specify the device name of the I2C master device to which
 	  LPS22HB is connected.
+
+endif
 
 menu "Attributes"
 	depends on LPS22HB

--- a/drivers/sensor/lsm6dsl/Kconfig
+++ b/drivers/sensor/lsm6dsl/Kconfig
@@ -15,15 +15,17 @@ menuconfig LSM6DSL
 	  Enable driver for LSM6DSL I2C-based accelerometer and gyroscope
 	  sensor.
 
+if !HAS_DTS_I2C_DEVICE
+
 config LSM6DSL_DEV_NAME
 	string "LSM6DSL device name"
-	depends on LSM6DSL && !HAS_DTS_I2C_DEVICE
+	depends on LSM6DSL
 	default "LSM6DSL"
 
 config LSM6DSL_I2C_ADDR
 	hex
 	prompt "LSM6DSL I2C address"
-	depends on LSM6DSL && !HAS_DTS_I2C_DEVICE
+	depends on LSM6DSL
 	default 0x6A
 	range 0x6A 0x6B
 	help
@@ -33,11 +35,13 @@ config LSM6DSL_I2C_ADDR
 
 config LSM6DSL_I2C_MASTER_DEV_NAME
 	string "I2C master where LSM6DSL chip is connected"
-	depends on LSM6DSL && !HAS_DTS_I2C_DEVICE
+	depends on LSM6DSL
 	default I2C_0_NAME
 	help
 	  Specify the device name of the I2C master device to which LSM6DSL is
 	  connected.
+
+endif
 
 config LSM6DSL_ENABLE_TEMP
 	bool "Enable temperature"

--- a/drivers/sensor/vl53l0x/Kconfig
+++ b/drivers/sensor/vl53l0x/Kconfig
@@ -15,11 +15,13 @@ menuconfig VL53L0X
 	help
 	  Enable driver for VL53L0X I2C-based time of flight sensor.
 
+if !HAS_DTS_I2C_DEVICE
+
 config VL53L0X_NAME
 	string
 	prompt "Driver name"
 	default "VL53L0X"
-	depends on VL53L0X && !HAS_DTS_I2C_DEVICE
+	depends on VL53L0X
 	help
 	  Device name with which the VL53L0X sensor is identified.
 
@@ -27,18 +29,20 @@ config VL53L0X_I2C_ADDR
 	int
 	prompt "Vl53l0x I2C address"
 	default 0x29
-	depends on VL53L0X && !HAS_DTS_I2C_DEVICE
+	depends on VL53L0X
 	help
 	  address of the i2c used for the vl53l0x sensor
 
 config VL53L0X_I2C_MASTER_DEV_NAME
 	string
 	prompt "I2C master where VL53L0X is connected"
-	depends on VL53L0X && !HAS_DTS_I2C_DEVICE
+	depends on VL53L0X
 	default "I2C_0"
 	help
 	  Specify the device name of the I2C master device to which VL53L0X is
 	  connected.
+
+endif
 
 config VL53L0X_XSHUT_GPIO_DEV_NAME
 	string


### PR DESCRIPTION
Move to new Kconfig pattern in which we use an if !HAS_DTS_I2C_DEVICE
block for the Kconfig symbols that can now come from DT generation.
This pattern is useful to allow us to define default values for the
generated symbols for build-all testing.

Fixes: #5877

Signed-off-by: Kumar Gala <kumar.gala@linaro.org>