### PR TITLE
scripts: jlink: Do not mass erase flash by default

### DIFF
--- a/scripts/support/runner/jlink.py
+++ b/scripts/support/runner/jlink.py
@@ -61,8 +61,8 @@ class JLinkBinaryRunner(ZephyrBinaryRunner):
                                 DEFAULT_JLINK_GDB_PORT))
         parser.add_argument('--commander', default='JLinkExe',
                             help='J-Link Commander, default is JLinkExe')
-        parser.add_argument('--erase', default=True, action='store_false',
-                            help='erase flash before loading, default is true')
+        parser.add_argument('--erase', default=False, action='store_true',
+                            help='if given, mass erase flash before loading')
 
     @classmethod
     def create_from_args(cls, args):


### PR DESCRIPTION
When adding support for the 'flash' command to the jlink runner, it was
not clear if the jlink commander would erase flash before programming,
therefore an explicit mass erase was implemented in the jlink runner as
a precaution and enabled by default.

The Segger folks later confirmed that the jlink commander does an
implicit erase of relevant flash sectors with the loadbin command,
therefore the explicit mass erase is not required.

Keep the mass erase option available in the jlink runner, but change the
default to false.

Signed-off-by: Maureen Helm <maureen.helm@nxp.com>