### PR TITLE
doc: fix misspellings in Kconfig files

### DIFF
--- a/drivers/ieee802154/Kconfig.cc1200
+++ b/drivers/ieee802154/Kconfig.cc1200
@@ -141,7 +141,7 @@ config IEEE802154_CC1200_RF_SET_1
 	bool "920MHz - 50Kbps - 2-GFSK - IEEE 802.15.4g compliant - ARIB"
 
 config IEEE802154_CC1200_RF_SET_2
-	bool "434MHz - 50Kbjt - 2-GFSK - IEEE 802.15.4g compliant - ETSI"
+	bool "434MHz - 50Kbps - 2-GFSK - IEEE 802.15.4g compliant - ETSI"
 
 endchoice
 

--- a/subsys/net/ip/l2/openthread/Kconfig
+++ b/subsys/net/ip/l2/openthread/Kconfig
@@ -159,7 +159,7 @@ config OPENTHREAD_DIAG
 
 config OPENTHREAD_COMMISSIONER
 	bool
-	prompt "Commisioner functions support"
+	prompt "Commissioner functions support"
 	help
 	  Enable commissioner capability in OpenThread stack
 


### PR DESCRIPTION
Signed-off-by: David B. Kinder <david.b.kinder@intel.com>