### PR TITLE
boards: make em_starterkit the defaule for ARC

### DIFF
--- a/boards/arc/arduino_101_sss/arduino_101_sss.yaml
+++ b/boards/arc/arduino_101_sss/arduino_101_sss.yaml
@@ -13,7 +13,6 @@ supported:
   - rtc
   - watchdog
 testing:
-  default: true
   ignore_tags:
     - net
     - bluetooth

--- a/boards/arc/em_starterkit/em_starterkit.yaml
+++ b/boards/arc/em_starterkit/em_starterkit.yaml
@@ -4,3 +4,5 @@ type: mcu
 arch: arc
 toolchain:
   - zephyr
+testing:
+  default: true


### PR DESCRIPTION
When testing, make em_starterkit the default for sanitycheck to test new
features such as MPU.

Signed-off-by: Anas Nashif <anas.nashif@intel.com>