### PR TITLE
doc: fix misspellings in boards and samples docs

### DIFF
--- a/boards/arm/arduino_zero/doc/arduino_zero.rst
+++ b/boards/arm/arduino_zero/doc/arduino_zero.rst
@@ -86,7 +86,7 @@ Programming and Debugging
 *************************
 
 The Arduino Zero comes with a Atmel Embedded Debugger (EDBG).  This
-provices a debug interface to the SAMD21 chip and is supported by
+provides a debug interface to the SAMD21 chip and is supported by
 OpenOCD.
 
 Flashing

--- a/boards/posix/native_posix/doc/board.rst
+++ b/boards/posix/native_posix/doc/board.rst
@@ -167,7 +167,7 @@ you may add a conditionally compiled (:option:`CONFIG_ARCH_POSIX`) call to
 Debugging
 =========
 
-Since the Zephyr executable is a native application, it can be debuged and
+Since the Zephyr executable is a native application, it can be debugged and
 instrumented as any other native program. The program is compiled with debug
 information, so it can be run directly in, for example, ``gdb`` or instrumented
 with ``valgrind``.
@@ -334,7 +334,7 @@ depending on interrupt priorities, masking, and locking state.
 
 Normally the resulting executable runs fully decoupled from the real host time.
 That is, simulated time will advance as fast as it can. This is desirable when
-running in a debuger or testing in batch, but not if one wants to interact
+running in a debugger or testing in batch, but not if one wants to interact
 with external interfaces which are based on the real host time.
 
 Peripherals

--- a/samples/sensor/amg88xx/README.rst
+++ b/samples/sensor/amg88xx/README.rst
@@ -20,8 +20,8 @@ only in a SMD design. Here are two sources for easily working with this sensor:
 - `AMG88xx Evaluation Kit`_
 - `Adafruit AMG8833 8x8 Thermal Camera Sensor`_
 
-We used the Evalutation Kit mounted on FRDM-K64F board.
-On the Evalutation Kit, all jumpers except the J11 must be removed.
+We used the Evaluation Kit mounted on FRDM-K64F board.
+On the Evaluation Kit, all jumpers except the J11 must be removed.
 
 This sample uses the sensor APIs and the provided driver for the AMG88xx sensor.
 


### PR DESCRIPTION
Fix misspellings found in board and sample docs missed during regular
reviews.

Signed-off-by: David B. Kinder <david.b.kinder@intel.com>