### PR TITLE
Bluetooth: Remove redundant AD parsing check

### DIFF
--- a/samples/bluetooth/central_hr/src/main.c
+++ b/samples/bluetooth/central_hr/src/main.c
@@ -178,7 +178,7 @@ static void ad_parse(struct net_buf_simple *ad,
 			return;
 		}
 
-		if (len > ad->len || ad->len < 1) {
+		if (len > ad->len) {
 			printk("AD malformed\n");
 			return;
 		}

--- a/samples/boards/microbit/pong/src/ble.c
+++ b/samples/boards/microbit/pong/src/ble.c
@@ -376,7 +376,7 @@ static void device_found(const bt_addr_le_t *addr, s8_t rssi, u8_t type,
 			return;
 		}
 
-		if (len > ad->len || ad->len < 1) {
+		if (len > ad->len) {
 			printk("AD malformed\n");
 			return;
 		}

--- a/subsys/bluetooth/host/mesh/adv.c
+++ b/subsys/bluetooth/host/mesh/adv.c
@@ -249,7 +249,7 @@ static void bt_mesh_scan_cb(const bt_addr_le_t *addr, s8_t rssi,
 			return;
 		}
 
-		if (len > buf->len || buf->len < 1) {
+		if (len > buf->len) {
 			BT_WARN("AD malformed");
 			return;
 		}

--- a/subsys/bluetooth/shell/bt.c
+++ b/subsys/bluetooth/shell/bt.c
@@ -147,7 +147,7 @@ static void device_found(const bt_addr_le_t *addr, s8_t rssi, u8_t evtype,
 		}
 
 		/* Check if field length is correct */
-		if (len > buf->len || buf->len < 1) {
+		if (len > buf->len) {
 			break;
 		}
 

--- a/subsys/net/ip/l2/bluetooth.c
+++ b/subsys/net/ip/l2/bluetooth.c
@@ -401,7 +401,7 @@ static bool ad_parse(struct net_buf_simple *ad,
 			return false;
 		}
 
-		if (len > ad->len || ad->len < 1) {
+		if (len > ad->len) {
 			NET_ERR("AD malformed\n");
 			return false;
 		}


### PR DESCRIPTION
A few lines earlier the code bails out in case len is 0. Checking for
buf->len < 1 is the same as checking for buf->len == 0. Since len is
guaranteed to be > 0 here the check len > buf->len implicitly checks
for buf->len == 0, i.e. the second test can be removed.

Signed-off-by: Johan Hedberg <johan.hedberg@intel.com>