### PR TITLE
boards: arc: default board with MPU enabled

### DIFF
--- a/boards/arc/em_starterkit/em_starterkit.yaml
+++ b/boards/arc/em_starterkit/em_starterkit.yaml
@@ -4,5 +4,3 @@ type: mcu
 arch: arc
 toolchain:
   - zephyr
-testing:
-  default: true

--- a/boards/arc/em_starterkit/em_starterkit_em7d.yaml
+++ b/boards/arc/em_starterkit/em_starterkit_em7d.yaml
@@ -4,3 +4,5 @@ type: mcu
 arch: arc
 toolchain:
   - zephyr
+testing:
+  default: true


### PR DESCRIPTION
em_starterkit_em7d has MPU enabled, so make it default for better test
coverage.

Signed-off-by: Anas Nashif <anas.nashif@intel.com>