### PR TITLE
cmake: ld: add application source dir to linker script cpp command

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -284,6 +284,13 @@ if(NOT EXISTS ${LINKER_SCRIPT})
   message(FATAL_ERROR "Could not find linker script: '${LINKER_SCRIPT}'. Corrupted configuration?")
 endif()
 
+# Custom section support in linker scripts requires that the application source
+# directory is in the preprocessor search path, in order to find the custom
+# linker script fragments.
+if(CONFIG_CUSTOM_RODATA_LD OR CONFIG_CUSTOM_RWDATA_LD OR CONFIG_CUSTOM_SECTIONS_LD)
+  zephyr_include_directories(${APPLICATION_SOURCE_DIR})
+endif()
+
 configure_file(version.h.in ${PROJECT_BINARY_DIR}/include/generated/version.h)
 
 # Unfortunately, the order in which CMakeLists.txt code is processed


### PR DESCRIPTION
To enable using application-defined sections in linker scripts, the application source directory must be included in the search path when running the preprocessor to generate linker scripts.

This prevents build failures when using any of the configuration options CONFIG_CUSTOM_RODATA_LD, CONFIG_CUSTOM_RWDATA_LD and CONFIG_CUSTOM_SECTIONS_LD.