### PR TITLE
Bluetooth: controller: Fix to restrict addr set in active scan

### DIFF
--- a/subsys/bluetooth/controller/ll_sw/ctrl.c
+++ b/subsys/bluetooth/controller/ll_sw/ctrl.c
@@ -10184,7 +10184,10 @@ u32_t radio_scan_disable(void)
 
 u32_t radio_scan_is_enabled(void)
 {
-	return _radio.scanner.is_enabled;
+	/* NOTE: BIT(0) - passive scanning enabled
+	 *       BIT(1) - active scanning enabled
+	 */
+	return (u32_t)_radio.scanner.is_enabled << _radio.scanner.type;
 }
 
 u32_t radio_scan_filter_pol_get(void)

--- a/subsys/bluetooth/controller/ll_sw/ll_addr.c
+++ b/subsys/bluetooth/controller/ll_sw/ll_addr.c
@@ -42,7 +42,8 @@ u8_t *ll_addr_get(u8_t addr_type, u8_t *bdaddr)
 
 u32_t ll_addr_set(u8_t addr_type, u8_t const *const bdaddr)
 {
-	if (radio_adv_is_enabled() || radio_scan_is_enabled()) {
+	if (radio_adv_is_enabled() ||
+	    (radio_scan_is_enabled() & BIT(1))) {
 		return BT_HCI_ERR_CMD_DISALLOWED;
 	}
 


### PR DESCRIPTION
Fix controller implementation to only restrict HCI LE Set
Random Address command when advertising and/or active
scanning is enable.

Continues to pass the following LL.TS.5.0.2 conformance
test:
LL/SEC/SCN/BV-01-C [Random Address Scanning]

Signed-off-by: Vinayak Kariappa Chettimada <vich@nordicsemi.no>