### PR TITLE
cmake: Fix dependencies between kobject_hash files

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -676,7 +676,7 @@ if(CONFIG_USERSPACE)
     ${GPERF}
     --output-file ${OUTPUT_SRC_PRE}
     ${OBJ_LIST}
-    DEPENDS obj_list
+    DEPENDS obj_list ${OBJ_LIST}
     WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
     )
   add_custom_target(output_src_pre DEPENDS ${CMAKE_CURRENT_BINARY_DIR}/${OUTPUT_SRC_PRE})
@@ -693,7 +693,7 @@ if(CONFIG_USERSPACE)
     -i ${OUTPUT_SRC_PRE}
     -o ${OUTPUT_SRC}
     $<$<BOOL:${CMAKE_VERBOSE_MAKEFILE}>:--verbose>
-    DEPENDS output_src_pre
+    DEPENDS output_src_pre ${OUTPUT_SRC_PRE}
     WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
     )
   add_custom_target(output_src DEPENDS ${CMAKE_CURRENT_BINARY_DIR}/${OUTPUT_SRC})


### PR DESCRIPTION
CMake's custom_command support is not great. It is technically
supported, but it is not easy to get it right.

As explained in "5. File-level dependencies of custom targets are not
propagated" from http://bit.ly/2GvwwEy. When a custom_command uses a
custom_target as input, the custom_command must DEPEND on both the
custom_target and the underlying file.

Longterm we need to do something more sofisticated to prevent these
issues from popping up. Like add some static analysis to detect badly
written CMake code or introduce an abstraction for custom commands
that is not affect by this issue.

This fixes #5881

Signed-off-by: Sebastian Bøe <sebastian.boe@nordicsemi.no>