### PR TITLE
Bluetooth: controller: Fix to use CPR preferred periodicity value

### DIFF
--- a/subsys/bluetooth/controller/ll_sw/ctrl.c
+++ b/subsys/bluetooth/controller/ll_sw/ctrl.c
@@ -7079,7 +7079,16 @@ static inline void event_conn_param_rsp(struct connection *conn)
 		/* Initiate connection update procedure */
 		conn->llcp.conn_upd.win_size = 1;
 		conn->llcp.conn_upd.win_offset_us = 0;
-		conn->llcp.conn_upd.interval = conn->llcp_conn_param.interval;
+		if (conn->llcp_conn_param.preferred_periodicity) {
+			conn->llcp.conn_upd.interval =
+				((conn->llcp_conn_param.interval /
+				  conn->llcp_conn_param.preferred_periodicity) +
+				 1) *
+				conn->llcp_conn_param.preferred_periodicity;
+		} else {
+			conn->llcp.conn_upd.interval =
+				conn->llcp_conn_param.interval;
+		}
 		conn->llcp.conn_upd.latency = conn->llcp_conn_param.latency;
 		conn->llcp.conn_upd.timeout = conn->llcp_conn_param.timeout;
 		/* conn->llcp.conn_upd.instant     = 0; */


### PR DESCRIPTION
Fixed implementation to use Connection Parameter Request
Procedure Preferred Periodicity value in calculating the new
connection interval used by the master role in Connection
Update Indication.

Fixes LL.TS.5.0.2 conformance tests:
LL/CON/MAS/BV-32-C [Accepting Connection Parameter Request –
	Preferred_Periodicity]
LL/CON/MAS/BV-33-C [Accepting Connection Parameter Request –
	Preferred_Periodicity and preferred anchor points]

Signed-off-by: Vinayak Kariappa Chettimada <vich@nordicsemi.no>