### PR TITLE
Bluetooth: controller: Fix to restrict addr set in initiator

### DIFF
--- a/subsys/bluetooth/controller/ll_sw/ctrl.c
+++ b/subsys/bluetooth/controller/ll_sw/ctrl.c
@@ -10186,8 +10186,10 @@ u32_t radio_scan_is_enabled(void)
 {
 	/* NOTE: BIT(0) - passive scanning enabled
 	 *       BIT(1) - active scanning enabled
+	 *       BIT(2) - initiator enabled
 	 */
-	return (u32_t)_radio.scanner.is_enabled << _radio.scanner.type;
+	return ((u32_t)_radio.scanner.is_enabled << _radio.scanner.type) |
+	       (_radio.scanner.conn ? BIT(2) : 0);
 }
 
 u32_t radio_scan_filter_pol_get(void)

--- a/subsys/bluetooth/controller/ll_sw/ll_addr.c
+++ b/subsys/bluetooth/controller/ll_sw/ll_addr.c
@@ -43,7 +43,7 @@ u8_t *ll_addr_get(u8_t addr_type, u8_t *bdaddr)
 u32_t ll_addr_set(u8_t addr_type, u8_t const *const bdaddr)
 {
 	if (radio_adv_is_enabled() ||
-	    (radio_scan_is_enabled() & BIT(1))) {
+	    (radio_scan_is_enabled() & (BIT(1) | BIT(2)))) {
 		return BT_HCI_ERR_CMD_DISALLOWED;
 	}
 


### PR DESCRIPTION
Fix controller implementation to restrict HCI LE Set Random
Address command when advertising and/or active scanning
and/or initiator state is enable.

Fixes LL.TS.5.0.2 conformance tests:
LL/CON/INI/BV-01-C [Connection Initiation]
LL/SEC/ADV/BV-01-C [Advertising With Static Address]
LL/SEC/SCN/BV-01-C [Random Address Scanning]

Signed-off-by: Vinayak Kariappa Chettimada <vich@nordicsemi.no>