### PR TITLE
Enable PCI enumration on minnowboard and Atom in general

### DIFF
--- a/arch/x86/soc/atom/soc.h
+++ b/arch/x86/soc/atom/soc.h
@@ -29,17 +29,53 @@
  */
 #define UART_NS16550_ACCESS_IOPORT
 
-#define UART_NS16550_PORT_0_BASE_ADDR		0x03F8
-#define UART_NS16550_PORT_0_IRQ			4
-#define UART_NS16550_PORT_0_CLK_FREQ		1843200
+#define UART_NS16550_PORT_0_BASE_ADDR           0x03F8
+#define UART_NS16550_PORT_0_IRQ                 4
+#define UART_NS16550_PORT_0_CLK_FREQ            1843200
 
-#define UART_NS16550_PORT_1_BASE_ADDR		0x02F8
-#define UART_NS16550_PORT_1_IRQ			3
-#define UART_NS16550_PORT_1_CLK_FREQ		1843200
+#define UART_NS16550_PORT_1_BASE_ADDR           0x02F8
+#define UART_NS16550_PORT_1_IRQ                 3
+#define UART_NS16550_PORT_1_CLK_FREQ            1843200
 
 #ifdef CONFIG_IOAPIC
 #include <drivers/ioapic.h>
-#define UART_IRQ_FLAGS				(IOAPIC_EDGE | IOAPIC_HIGH)
+#define UART_IRQ_FLAGS                          (IOAPIC_EDGE | IOAPIC_HIGH)
 #endif /* CONFIG_IOAPIC */
+
+
+/* PCI definitions */
+/* FIXME: The values below copied from generic ia32 soc, we need to get the
+ * correct numbers for Atom and the minnowboard
+ *
+ * This is added now to get basic enumartion of devices and verify that PCI
+ * driver is functional.
+ */
+#define PCI_BUS_NUMBERS 1
+
+#define PCI_CTRL_ADDR_REG 0xCF8
+#define PCI_CTRL_DATA_REG 0xCFC
+
+#define PCI_INTA 1
+#define PCI_INTB 2
+#define PCI_INTC 3
+#define PCI_INTD 4
+
+/**
+ *
+ * @brief Convert PCI interrupt PIN to IRQ
+ *
+ * @return IRQ number, -1 if the result is incorrect
+ *
+ */
+
+static inline int pci_pin2irq(int bus, int dev, int pin)
+{
+	ARG_UNUSED(bus);
+
+	if ((pin < PCI_INTA) || (pin > PCI_INTD)) {
+		return -1;
+	}
+	return 10 + (((pin + dev - 1) >> 1) & 1);
+}
 
 #endif /* __SOC_H_ */

--- a/drivers/pci/pci.c
+++ b/drivers/pci/pci.c
@@ -458,7 +458,6 @@ void pci_enable_bus_master(struct pci_dev_info *dev_info)
 
 void pci_show(struct pci_dev_info *dev_info)
 {
-	printk("PCI device:\n");
 	printk("%u:%u %X:%X class: 0x%X, %u, %u, %s,"
 		"addrs: 0x%X-0x%X, IRQ %d\n",
 		dev_info->bus,


### PR DESCRIPTION
on the minnowboard this now returns:

```
starting test - pci_enumerate

0:2 8086:f31 class: 0x3, 0, 0, MEM,addrs: 0x90000000-0x903fffff, IRQ 11
0:2 8086:f31 class: 0x3, 0, 2, MEM,addrs: 0x80000000-0x8fffffff, IRQ 11
0:2 8086:f31 class: 0x3, 0, 4, I/O,addrs: 0x2050-0x2057, IRQ 11
0:20 8086:f35 class: 0xc, 0, 0, MEM,addrs: 0x90700000-0x9070ffff, IRQ 10
0:26 8086:f18 class: 0x10, 0, 0, MEM,addrs: 0x90600000-0x906fffff, IRQ 11
0:26 8086:f18 class: 0x10, 0, 1, MEM,addrs: 0x90500000-0x905fffff, IRQ 11
0:27 8086:f04 class: 0x4, 0, 0, MEM,addrs: 0x90710000-0x90713fff, IRQ 11
0:31 8086:f12 class: 0xc, 3, 0, MEM,addrs: 0x9071c000-0x9071c01f, IRQ 10
0:31 8086:f12 class: 0xc, 3, 4, I/O,addrs: 0x2000-0x201f, IRQ 10
PASS - pci_enumerate.
```