### PR TITLE
drivers: flash: Implement flash page layout api in mcux driver

### DIFF
--- a/arch/arm/soc/nxp_kinetis/kl2x/soc.h
+++ b/arch/arm/soc/nxp_kinetis/kl2x/soc.h
@@ -27,6 +27,10 @@ extern "C" {
 #include <misc/util.h>
 #include <random/rand32.h>
 
+#if defined(CONFIG_SOC_FLASH_MCUX)
+#define FLASH_DRIVER_NAME	FLASH_DEV_NAME
+#endif
+
 #endif /* !_ASMLANGUAGE */
 
 #ifdef __cplusplus

--- a/arch/arm/soc/nxp_kinetis/kwx/soc.h
+++ b/arch/arm/soc/nxp_kinetis/kwx/soc.h
@@ -50,6 +50,10 @@ extern "C" {
 #include <misc/util.h>
 #include <random/rand32.h>
 
+#if defined(CONFIG_SOC_FLASH_MCUX)
+#define FLASH_DRIVER_NAME	FLASH_DEV_NAME
+#endif
+
 #endif /* !_ASMLANGUAGE */
 
 #ifdef __cplusplus

--- a/drivers/flash/Kconfig
+++ b/drivers/flash/Kconfig
@@ -141,6 +141,7 @@ config SOC_FLASH_NRF5_RADIO_SYNC
 config SOC_FLASH_MCUX
 	bool "MCUX flash shim driver"
 	depends on FLASH && HAS_MCUX
+	select FLASH_HAS_PAGE_LAYOUT
 	default n
 	help
 	  Enables the MCUX flash shim driver.

--- a/drivers/flash/soc_flash_mcux.c
+++ b/drivers/flash/soc_flash_mcux.c
@@ -86,6 +86,21 @@ static int flash_mcux_write_protection(struct device *dev, bool enable)
 	return -EIO;
 }
 
+#if defined(CONFIG_FLASH_PAGE_LAYOUT)
+static const struct flash_pages_layout dev_layout = {
+	.pages_count = KB(CONFIG_FLASH_SIZE) / FLASH_ERASE_BLOCK_SIZE,
+	.pages_size = FLASH_ERASE_BLOCK_SIZE,
+};
+
+static void flash_mcux_pages_layout(struct device *dev,
+									const struct flash_pages_layout **layout,
+									size_t *layout_size)
+{
+	*layout = &dev_layout;
+	*layout_size = 1;
+}
+#endif /* CONFIG_FLASH_PAGE_LAYOUT */
+
 static struct flash_priv flash_data;
 
 static const struct flash_driver_api flash_mcux_api = {
@@ -94,8 +109,7 @@ static const struct flash_driver_api flash_mcux_api = {
 	.write = flash_mcux_write,
 	.read = flash_mcux_read,
 #if defined(CONFIG_FLASH_PAGE_LAYOUT)
-	.page_layout = (flash_api_pages_layout)
-		       flash_page_layout_not_implemented,
+	.page_layout = flash_mcux_pages_layout,
 #endif
 	.write_block_size = FSL_FEATURE_FLASH_PFLASH_BLOCK_WRITE_UNIT_SIZE,
 };

--- a/dts/arm/nxp/nxp_k6x.dtsi
+++ b/dts/arm/nxp/nxp_k6x.dtsi
@@ -78,7 +78,7 @@
 				compatible = "soc-nv-flash";
 				label = "MCUX_FLASH";
 				reg = <0 0x100000>;
-
+				erase-block-size = <4096>;
 				write-block-size = <8>;
 			};
 		};

--- a/dts/arm/nxp/nxp_kl25z.dtsi
+++ b/dts/arm/nxp/nxp_kl25z.dtsi
@@ -34,6 +34,7 @@
 				compatible = "soc-nv-flash";
 				label = "MCUX_FLASH";
 				reg = <0 0x20000>;
+				erase-block-size = <1024>;
 				write-block-size = <4>;
 			};
 		};

--- a/dts/arm/nxp/nxp_kw2xd.dtsi
+++ b/dts/arm/nxp/nxp_kw2xd.dtsi
@@ -70,6 +70,7 @@
 				compatible = "soc-nv-flash";
 				label = "MCUX_FLASH";
 				reg = <0 0x80000>;
+				erase-block-size = <2048>;
 				write-block-size = <4>;
 			};
 		};

--- a/dts/arm/nxp/nxp_kw40z.dtsi
+++ b/dts/arm/nxp/nxp_kw40z.dtsi
@@ -62,6 +62,7 @@
 				compatible = "soc-nv-flash";
 				label = "MCUX_FLASH";
 				reg = <0 0x80000>;
+				erase-block-size = <1024>;
 				write-block-size = <4>;
 			};
 		};

--- a/dts/arm/nxp/nxp_kw41z.dtsi
+++ b/dts/arm/nxp/nxp_kw41z.dtsi
@@ -62,6 +62,7 @@
 				compatible = "soc-nv-flash";
 				label = "MCUX_FLASH";
 				reg = <0 0x80000>;
+				erase-block-size = <2048>;
 				write-block-size = <4>;
 			};
 		};

--- a/dts/bindings/mtd/soc-nv-flash.yaml
+++ b/dts/bindings/mtd/soc-nv-flash.yaml
@@ -13,6 +13,13 @@ properties:
       description: compatible strings
       constraint: "soc-nv-flash"
 
+    erase-block-size:
+     type: int
+     description: address alignment required by flash erase operations
+     generation: define
+     category: optional
+     label: alignment
+
     write-block-size:
      type: int
      description: address alignment required by flash write operations

--- a/samples/drivers/flash_shell/sample.yaml
+++ b/samples/drivers/flash_shell/sample.yaml
@@ -4,6 +4,6 @@ sample:
   name: Flash shell
 tests:
   test:
-    platform_whitelist: 96b_carbon
+    platform_whitelist: 96b_carbon frdm_k64f frdm_kw41z frdm_kl25z
     tags: apps
     harness: keyboard


### PR DESCRIPTION
Adds a new dts property to define the erase block size of a flash device, and uses it to implement the flash page layout api in the mcux driver.

Fixes #4633