### PR TITLE
Bluetooth: controller: Fix redundant length update event

### DIFF
--- a/subsys/bluetooth/controller/ll_sw/ctrl.c
+++ b/subsys/bluetooth/controller/ll_sw/ctrl.c
@@ -2296,8 +2296,20 @@ static inline u8_t isr_rx_conn_pkt_ctrl_dle(struct pdu_data *pdu_data_rx,
 				nack = 1;
 			}
 		} else {
+			/* Procedure complete */
+			_radio.conn_curr->llcp_length.ack =
+				_radio.conn_curr->llcp_length.req;
+			_radio.conn_curr->procedure_expire = 0;
+
 			/* resume data packet tx */
 			_radio.conn_curr->pause_tx = 0;
+
+			/* No change in effective octets or time */
+			if (eff_tx_octets == _radio.conn_curr->max_tx_octets &&
+			    eff_tx_time == _radio.conn_curr->max_tx_time &&
+			    eff_rx_time == _radio.conn_curr->max_rx_time) {
+				goto send_length_resp;
+			}
 
 			/* accept the effective tx */
 			_radio.conn_curr->max_tx_octets = eff_tx_octets;
@@ -2309,11 +2321,6 @@ static inline u8_t isr_rx_conn_pkt_ctrl_dle(struct pdu_data *pdu_data_rx,
 			/* accept the effective tx time */
 			_radio.conn_curr->max_tx_time = eff_tx_time;
 #endif /* CONFIG_BT_CTLR_PHY */
-
-			/* Procedure complete */
-			_radio.conn_curr->llcp_length.ack =
-				_radio.conn_curr->llcp_length.req;
-			_radio.conn_curr->procedure_expire = 0;
 
 			/* prepare event params */
 			lr->max_rx_octets = eff_rx_octets;
@@ -2338,6 +2345,7 @@ static inline u8_t isr_rx_conn_pkt_ctrl_dle(struct pdu_data *pdu_data_rx,
 			  PDU_DATA_LLCTRL_TYPE_LENGTH_RSP);
 	}
 
+send_length_resp:
 	if (node_tx) {
 		if (nack) {
 			mem_release(node_tx, &_radio.pkt_tx_ctrl_free);


### PR DESCRIPTION
Fix generation of redundant length update event when no
change in effective octets or time.

Fixes LL.TS.5.0.2 conformance tests:
LL/CON/MAS/BV-73-C [Master Data Length Update - Responding
	to Data Length Update Procedure; LE 1M PHY]
LL/CON/MAS/BV-74-C [Master Data Length Update - Initiating
	Data Length Update Procedure; LE 1M PHY]
LL/CON/MAS/BV-76-C [Master Data Length Update - Responding
	to Data Length Update Procedure; LE 2M PHY]
LL/CON/MAS/BV-77-C [Master Data Length Update - Initiating
	Data Length Update Procedure; LE 2M PHY]
LL/CON/SLA/BV-77-C [Slave Data Length Update - Responding
	to Data Length Update Procedure; LE 1M PHY]
LL/CON/SLA/BV-78-C [Slave Data Length Update - Initiating
	Data Length Update Procedure; LE 1M PHY]
LL/CON/SLA/BV-80-C [Slave Data Length Update - Responding
	to Data Length Update Procedure; LE 2M PHY]
LL/CON/SLA/BV-81-C [Slave Data Length Update - Initiating
	Data Length Update Procedure; LE 2M PHY]

Signed-off-by: Vinayak Kariappa Chettimada <vich@nordicsemi.no>