### PR TITLE
Coverage report fixes

### DIFF
--- a/.shippable.yml
+++ b/.shippable.yml
@@ -78,10 +78,12 @@ build:
       - >
          if [ "$MATRIX_BUILD" = "1" ]; then
             gcovr -r ${ZEPHYR_BASE} -x > shippable/codecoverage/coverage.xml;
-            mv sanity-out/native_posix/ coverage_native_posix/;
+            lcov --capture --directory sanity-out/native_posix/ --output-file lcov.pre.info -q --rc lcov_branch_coverage=1;
+            lcov -q --remove lcov.pre.info *generated* -o lcov.info --rc lcov_branch_coverage=1;
+            rm lcov.pre.info;
             rm -rf sanity-out out-2nd-pass;
-            bash <(curl -s https://codecov.io/bash) -f '!*.lst' -X coveragepy -X fixes;
-            rm -rf coverage_native_posix/;
+            bash <(curl -s https://codecov.io/bash) -f "lcov.info" -X coveragepy -X fixes;
+            rm lcov.info;
          else
             rm -rf sanity-out out-2nd-pass;
          fi;
@@ -101,10 +103,12 @@ build:
       - >
          if [ "$MATRIX_BUILD" = "1" ]; then
             gcovr -r ${ZEPHYR_BASE} -x > shippable/codecoverage/coverage.xml;
-            mv sanity-out/native_posix/ coverage_native_posix/;
+            lcov --capture --directory sanity-out/native_posix/ --output-file lcov.pre.info -q --rc lcov_branch_coverage=1;
+            lcov -q --remove lcov.pre.info *generated* -o lcov.info --rc lcov_branch_coverage=1;
+            rm lcov.pre.info;
             rm -rf sanity-out out-2nd-pass;
-            bash <(curl -s https://codecov.io/bash) -f '!*.lst' -X coveragepy -X fixes;
-            rm -rf coverage_native_posix/;
+            bash <(curl -s https://codecov.io/bash) -f "lcov.info" -X coveragepy -X fixes;
+            rm lcov.info;
          else
             rm -rf sanity-out out-2nd-pass;
          fi;

--- a/arch/posix/core/posix_core.c
+++ b/arch/posix/core/posix_core.c
@@ -43,6 +43,7 @@
 #include <string.h>
 
 #include "posix_core.h"
+#include "posix_arch_internal.h"
 #include "posix_soc_if.h"
 #include "kernel_internal.h"
 #include "kernel_structs.h"
@@ -57,7 +58,6 @@
 #else
 #define PC_DEBUG(...)
 #endif
-
 
 #define PC_ALLOC_CHUNK_SIZE 64
 #define PC_REUSE_ABORTED_ENTRIES 0
@@ -165,9 +165,7 @@ static void posix_let_run(int next_allowed_th)
 	 * Note that as we hold the mutex, they are going to be blocked until
 	 * we reach our own posix_wait_until_allowed() while loop
 	 */
-	if (pthread_cond_broadcast(&cond_threads)) {
-		posix_print_error_and_exit(ERPREFIX"pthread_cond_signal()\n");
-	}
+	_SAFE_CALL(pthread_cond_broadcast(&cond_threads));
 }
 
 
@@ -176,9 +174,7 @@ static void posix_preexit_cleanup(void)
 	/*
 	 * Release the mutex so the next allowed thread can run
 	 */
-	if (pthread_mutex_unlock(&mtx_threads)) {
-		posix_print_error_and_exit(ERPREFIX"pthread_mutex_unlock()\n");
-	}
+	_SAFE_CALL(pthread_mutex_unlock(&mtx_threads));
 
 	/* We detach ourselves so nobody needs to join to us */
 	pthread_detach(pthread_self());
@@ -249,9 +245,7 @@ static void posix_cleanup_handler(void *arg)
 #endif
 
 
-	if (pthread_mutex_unlock(&mtx_threads)) {
-		posix_print_error_and_exit(ERPREFIX"pthread_mutex_unlock()\n");
-	}
+	_SAFE_CALL(pthread_mutex_unlock(&mtx_threads));
 
 	/* We detach ourselves so nobody needs to join to us */
 	pthread_detach(pthread_self());
@@ -276,9 +270,7 @@ static void *posix_thread_starter(void *arg)
 	 * We block until all other running threads reach the while loop
 	 * in posix_wait_until_allowed() and they release the mutex
 	 */
-	if (pthread_mutex_lock(&mtx_threads)) {
-		posix_print_error_and_exit(ERPREFIX"pthread_mutex_lock()\n");
-	}
+	_SAFE_CALL(pthread_mutex_lock(&mtx_threads));
 
 	/*
 	 * The program may have been finished before this thread ever got to run
@@ -311,6 +303,7 @@ static void *posix_thread_starter(void *arg)
 	 * We only reach this point if the thread actually returns which should
 	 * not happen. But we handle it gracefully just in case
 	 */
+	/* LCOV_EXCL_START */
 	posix_print_trace(PREFIX"Thread [%i] %i [%lu] ended!?!\n",
 			threads_table[ptr->thread_idx].thead_cnt,
 			ptr->thread_idx,
@@ -323,6 +316,7 @@ static void *posix_thread_starter(void *arg)
 	pthread_cleanup_pop(1);
 
 	return NULL;
+	/* LCOV_EXCL_STOP */
 }
 
 /**
@@ -347,8 +341,8 @@ static int ttable_get_empty_slot(void)
 	threads_table = realloc(threads_table,
 				(threads_table_size + PC_ALLOC_CHUNK_SIZE)
 				* sizeof(struct threads_table_el));
-	if (threads_table == NULL) {
-		posix_print_error_and_exit(NO_MEM_ERR);
+	if (threads_table == NULL) { /* LCOV_EXCL_BR_LINE */
+		posix_print_error_and_exit(NO_MEM_ERR); /* LCOV_EXCL_LINE */
 	}
 
 	/* Clear new piece of table */
@@ -378,13 +372,10 @@ void posix_new_thread(posix_thread_status_t *ptr)
 	threads_table[t_slot].thead_cnt = thread_create_count++;
 	ptr->thread_idx = t_slot;
 
-	if (pthread_create(&threads_table[t_slot].thread,
-			   NULL,
-			   posix_thread_starter,
-			   (void *)ptr)) {
-
-		posix_print_error_and_exit(ERPREFIX"pthread_create()\n");
-	}
+	_SAFE_CALL(pthread_create(&threads_table[t_slot].thread,
+				  NULL,
+				  posix_thread_starter,
+				  (void *)ptr));
 
 	PC_DEBUG("created thread [%i] %i [%lu]\n",
 		threads_table[t_slot].thead_cnt,
@@ -405,16 +396,14 @@ void posix_init_multithreading(void)
 
 	threads_table = calloc(PC_ALLOC_CHUNK_SIZE,
 				sizeof(struct threads_table_el));
-	if (threads_table == NULL) {
-		posix_print_error_and_exit(NO_MEM_ERR);
+	if (threads_table == NULL) { /* LCOV_EXCL_BR_LINE */
+		posix_print_error_and_exit(NO_MEM_ERR); /* LCOV_EXCL_LINE */
 	}
 
 	threads_table_size = PC_ALLOC_CHUNK_SIZE;
 
 
-	if (pthread_mutex_lock(&mtx_threads)) {
-		posix_print_error_and_exit(ERPREFIX"pthread_mutex_lock()\n");
-	}
+	_SAFE_CALL(pthread_mutex_lock(&mtx_threads));
 }
 
 /**
@@ -434,8 +423,8 @@ void posix_init_multithreading(void)
 void posix_core_clean_up(void)
 {
 
-	if (!threads_table) {
-		return;
+	if (!threads_table) { /* LCOV_EXCL_BR_LINE */
+		return; /* LCOV_EXCL_LINE */
 	}
 
 	terminate = true;
@@ -445,11 +434,13 @@ void posix_core_clean_up(void)
 			continue;
 		}
 
+		/* LCOV_EXCL_START */
 		if (pthread_cancel(threads_table[i].thread)) {
 			posix_print_warning(
 				PREFIX"cleanup: could not stop thread %i\n",
 				i);
 		}
+		/* LCOV_EXCL_STOP */
 	}
 
 	free(threads_table);
@@ -459,9 +450,9 @@ void posix_core_clean_up(void)
 
 void posix_abort_thread(int thread_idx)
 {
-	if (threads_table[thread_idx].state != USED) {
+	if (threads_table[thread_idx].state != USED) { /* LCOV_EXCL_BR_LINE */
 		/* The thread may have been already aborted before */
-		return;
+		return; /* LCOV_EXCL_LINE */
 	}
 
 	PC_DEBUG("Aborting not scheduled thread [%i] %i\n",
@@ -503,10 +494,10 @@ void _impl_k_thread_abort(k_tid_t thread)
 	_thread_monitor_exit(thread);
 
 	if (_current == thread) {
-		if (tstatus->aborted == 0) {
+		if (tstatus->aborted == 0) { /* LCOV_EXCL_BR_LINE */
 			tstatus->aborted = 1;
 		} else {
-			posix_print_warning(
+			posix_print_warning(/* LCOV_EXCL_LINE */
 				PREFIX"The kernel is trying to abort and swap "
 				"out of an already aborted thread %i. This "
 				"should NOT have happened\n",
@@ -520,7 +511,7 @@ void _impl_k_thread_abort(k_tid_t thread)
 			__func__);
 
 		_Swap(key);
-		CODE_UNREACHABLE;
+		CODE_UNREACHABLE; /* LCOV_EXCL_LINE */
 	}
 
 	if (tstatus->aborted == 0) {
@@ -580,5 +571,10 @@ void _impl_k_thread_abort(k_tid_t thread)
  * would occur.
  * But as they are very atypical and only triggered with some host loads,
  * they will be covered in the coverage reports only rarely.
+ *
+ * Note2:
+ *
+ * Some other code will never or only very rarely trigger and is therefore
+ * excluded with LCOV_EXCL_LINE
  *
  */

--- a/arch/posix/include/posix_arch_internal.h
+++ b/arch/posix/include/posix_arch_internal.h
@@ -1,0 +1,37 @@
+/*
+ * Copyright (c) 2018 Oticon A/S
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef _POSIX_INTERNAL_H
+#define _POSIX_INTERNAL_H
+
+#define _SAFE_CALL(a) _safe_call(a, #a)
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+static inline void _safe_call(int test, const char *test_str)
+{
+	/* LCOV_EXCL_START */ /* See Note1 */
+	if (test) {
+		posix_print_error_and_exit("POSIX arch: Error on: %s\n",
+					   test_str);
+	}
+	/* LCOV_EXCL_STOP */
+}
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* _POSIX_INTERNAL_H */
+
+/*
+ * Note 1:
+ *
+ * All checks for the host pthreads functions which are wrapped by _SAFE_CALL
+ * are meant to never fail, and therefore will not be covered.
+ */

--- a/arch/posix/soc/inf_clock/soc.c
+++ b/arch/posix/soc/inf_clock/soc.c
@@ -236,6 +236,7 @@ void posix_boot_cpu(void)
  */
 void posix_soc_clean_up(void)
 {
+	/* LCOV_EXCL_START */ /* See Note1 */
 	/*
 	 * If we are being called from a HW thread we can cleanup
 	 *
@@ -273,5 +274,15 @@ void posix_soc_clean_up(void)
 			 */
 		}
 	}
+	/* LCOV_EXCL_STOP */
 }
 
+/*
+ * Notes about coverage:
+ *
+ * Note1: When the application is closed due to a SIGTERM, the path in this
+ * function will depend on when that signal was received. Typically during a
+ * regression run, both paths will be covered. But in some cases they won't.
+ * Therefore and to avoid confusing developers with spurious coverage changes
+ * we exclude this function from the coverage check
+ */

--- a/arch/posix/soc/inf_clock/soc.c
+++ b/arch/posix/soc/inf_clock/soc.c
@@ -32,6 +32,7 @@
 #include "posix_soc.h"
 #include "posix_board_if.h"
 #include "posix_core.h"
+#include "posix_arch_internal.h"
 #include "kernel_internal.h"
 
 #define POSIX_ARCH_SOC_DEBUG_PRINTS 0
@@ -74,19 +75,14 @@ int posix_is_cpu_running(void)
  */
 static void posix_change_cpu_state_and_wait(bool halted)
 {
-	if (pthread_mutex_lock(&mtx_cpu)) {
-		posix_print_error_and_exit(ERPREFIX"pthread_mutex_lock()\n");
-	}
+	_SAFE_CALL(pthread_mutex_lock(&mtx_cpu));
 
 	PS_DEBUG("Going to halted = %d\n", halted);
 
 	cpu_halted = halted;
 
 	/* We let the other side know the CPU has changed state */
-	if (pthread_cond_broadcast(&cond_cpu)) {
-		posix_print_error_and_exit(
-				ERPREFIX"pthread_cond_broadcast()\n");
-	}
+	_SAFE_CALL(pthread_cond_broadcast(&cond_cpu));
 
 	/* We wait until the CPU state has been changed. Either:
 	 * we just awoke it, and therefore wait until the CPU has run until
@@ -103,9 +99,7 @@ static void posix_change_cpu_state_and_wait(bool halted)
 
 	PS_DEBUG("Awaken after halted = %d\n", halted);
 
-	if (pthread_mutex_unlock(&mtx_cpu)) {
-		posix_print_error_and_exit(ERPREFIX"pthread_mutex_unlock()\n");
-	}
+	_SAFE_CALL(pthread_mutex_unlock(&mtx_cpu));
 }
 
 /**
@@ -174,12 +168,8 @@ void posix_atomic_halt_cpu(unsigned int imask)
 static void *zephyr_wrapper(void *a)
 {
 	/* Ensure posix_boot_cpu has reached the cond loop */
-	if (pthread_mutex_lock(&mtx_cpu)) {
-		posix_print_error_and_exit(ERPREFIX"pthread_mutex_lock()\n");
-	}
-	if (pthread_mutex_unlock(&mtx_cpu)) {
-		posix_print_error_and_exit(ERPREFIX"pthread_mutex_unlock()\n");
-	}
+	_SAFE_CALL(pthread_mutex_lock(&mtx_cpu));
+	_SAFE_CALL(pthread_mutex_unlock(&mtx_cpu));
 
 #if (POSIX_ARCH_SOC_DEBUG_PRINTS)
 		pthread_t zephyr_thread = pthread_self();
@@ -203,26 +193,20 @@ static void *zephyr_wrapper(void *a)
  */
 void posix_boot_cpu(void)
 {
-	if (pthread_mutex_lock(&mtx_cpu)) {
-		posix_print_error_and_exit(ERPREFIX"pthread_mutex_lock()\n");
-	}
+	_SAFE_CALL(pthread_mutex_lock(&mtx_cpu));
 
 	cpu_halted = false;
 
 	pthread_t zephyr_thread;
 
 	/* Create a thread for Zephyr init: */
-	if (pthread_create(&zephyr_thread, NULL, zephyr_wrapper, NULL)) {
-		posix_print_error_and_exit(ERPREFIX"pthread_create\n");
-	}
+	_SAFE_CALL(pthread_create(&zephyr_thread, NULL, zephyr_wrapper, NULL));
 
 	/* And we wait until Zephyr has run til completion (has gone to idle) */
 	while (cpu_halted == false) {
 		pthread_cond_wait(&cond_cpu, &mtx_cpu);
 	}
-	if (pthread_mutex_unlock(&mtx_cpu)) {
-		posix_print_error_and_exit(ERPREFIX"pthread_mutex_unlock()\n");
-	}
+	_SAFE_CALL(pthread_mutex_unlock(&mtx_cpu));
 
 	if (soc_terminate) {
 		posix_exit(0);
@@ -251,21 +235,13 @@ void posix_soc_clean_up(void)
 
 		soc_terminate = true;
 
-		if (pthread_mutex_lock(&mtx_cpu)) {
-			posix_print_error_and_exit(
-					ERPREFIX"pthread_mutex_lock()\n");
-		}
+		_SAFE_CALL(pthread_mutex_lock(&mtx_cpu));
 
 		cpu_halted = true;
 
-		if (pthread_cond_broadcast(&cond_cpu)) {
-			posix_print_error_and_exit(
-					ERPREFIX"pthread_cond_broadcast()\n");
-		}
-		if (pthread_mutex_unlock(&mtx_cpu)) {
-			posix_print_error_and_exit(
-					ERPREFIX"pthread_mutex_unlock()\n");
-		}
+		_SAFE_CALL(pthread_cond_broadcast(&cond_cpu));
+		_SAFE_CALL(pthread_mutex_unlock(&mtx_cpu));
+
 		while (1) {
 			sleep(1);
 			/* This SW thread will wait until being cancelled from
@@ -285,4 +261,5 @@ void posix_soc_clean_up(void)
  * regression run, both paths will be covered. But in some cases they won't.
  * Therefore and to avoid confusing developers with spurious coverage changes
  * we exclude this function from the coverage check
+ *
  */

--- a/boards/posix/native_posix/doc/board.rst
+++ b/boards/posix/native_posix/doc/board.rst
@@ -160,6 +160,9 @@ Note that the Zephyr kernel does not actually exit once the application is
 finished. It simply goes into the idle loop forever.
 Therefore you must stop the application manually (Ctrl+C in Linux).
 
+Application tests using the ``ztest`` framework will exit after all
+tests have completed.
+
 If you want your application to gracefully finish when it reaches some point,
 you may add a conditionally compiled (:option:`CONFIG_ARCH_POSIX`) call to
 ``posix_exit(int status)`` at that point.

--- a/tests/include/tc_util.h
+++ b/tests/include/tc_util.h
@@ -84,7 +84,11 @@
 #define TC_END_RESULT(result)                           \
 	_TC_END_RESULT((result), __func__)
 
-#define TC_END_POST
+#if defined(CONFIG_ARCH_POSIX)
+#define TC_END_POST(result) posix_exit(result)
+#else
+#define TC_END_POST(result)
+#endif /* CONFIG_ARCH_POSIX */
 
 #define TC_END_REPORT(result)                               \
 	do {                                                    \
@@ -93,7 +97,7 @@
 		TC_END(result,                                      \
 		       "PROJECT EXECUTION %s\n",               \
 		       (result) == TC_PASS ? "SUCCESSFUL" : "FAILED");	\
-		TC_END_POST;                                            \
+		TC_END_POST(result);                                    \
 	} while (0)
 
 #define TC_CMD_DEFINE(name)				\


### PR DESCRIPTION
Several fixes to avoid coverage reports from changing in mysterious ways in between runs:
* Autostop ztests once they pass or fail to avoid sanitycheck's SIGTERM racing possible code which will continue executing after.
* We post-process the gcov output with lcov and feed that to codecov (instead of the raw gcov files), and we avoid feeding the gcovr output meant for shipabble.
* Excluded from the coverage reports the code in ARCH_POSIX which is not deterministic (what is executed depends on exactly when SIGTERM arrives).
* Excluded from the coverage reports some of the ARCH_POSIX code which is only there to handle error responses from the host (and will therefore never be covered).

Should fix the worst of #5938 
Merging #5774 will help both to increase the reported coverage and to get the coverage make some more sense in quite many places.
Solving #5723 and using it from sanitycheck to set CONFIG_COVERAGE for `samples/` will help in the same way as #5774 does already for `tests/`.

If you want to reproduce it quickly locally:
```
sanitycheck -p native_posix
rm lcov.*info
lcov --capture --directory sanity-out/native_posix/ --output-file lcov.pre.info -q --rc lcov_branch_coverage=1
lcov -q --remove lcov.pre.info *generated* -o lcov.info -rc lcov_branch_coverage=1
genhtml lcov.info --output-directory lcov_html -q --ignore-errors source  --branch-coverage --highlight --legend 
x-www-browser ./lcov_html/index.html &> /dev/null &
```
