### PR TITLE
boards: olimexino_stm32: add supported features

### DIFF
--- a/boards/arm/olimexino_stm32/olimexino_stm32.yaml
+++ b/boards/arm/olimexino_stm32/olimexino_stm32.yaml
@@ -6,3 +6,7 @@ toolchain:
   - zephyr
   - gccarmemb
 ram: 20
+supported:
+  - gpio
+  - i2c
+  - spi


### PR DESCRIPTION
Add gpio, i2c and spi as supported feaures.

Signed-off-by: Yannis Damigos <giannis.damigos@gmail.com>