### PR TITLE
Bluetooth: Mesh: fix BT_MESH_LPN_POLL_TIMEOUT description

### DIFF
--- a/subsys/bluetooth/host/mesh/Kconfig
+++ b/subsys/bluetooth/host/mesh/Kconfig
@@ -280,7 +280,7 @@ config BT_MESH_LPN_POLL_TIMEOUT
 	  requests are received by the Friend node before the
 	  PollTimeout timer expires, then the friendship is considered
 	  terminated. The value is in units of 100 milliseconds, so e.g.
-	  a value of 300 means 3 seconds.
+	  a value of 300 means 30 seconds.
 
 config BT_MESH_LPN_INIT_POLL_TIMEOUT
 	int "The starting value of the PollTimeout timer"


### PR DESCRIPTION
The calculation was off by a factor of 10.

Signed-off-by: Johan Hedberg <johan.hedberg@intel.com>