### PR TITLE
drivers: i2c: nrf5: Make pins for Port 1 configurable

### DIFF
--- a/boards/arm/bbc_microbit/Kconfig.defconfig
+++ b/boards/arm/bbc_microbit/Kconfig.defconfig
@@ -44,7 +44,7 @@ if I2C_NRF5
 config I2C_NRF5_GPIO_SCL_PIN
 	default 0
 
-config I2C_NRF5_GPIO_SCA_PIN
+config I2C_NRF5_GPIO_SDA_PIN
 	default 30
 
 config I2C_0_DEFAULT_CFG

--- a/boards/arm/bbc_microbit/Kconfig.defconfig
+++ b/boards/arm/bbc_microbit/Kconfig.defconfig
@@ -41,10 +41,10 @@ endif # I2C
 
 if I2C_NRF5
 
-config I2C_NRF5_GPIO_SCL_PIN
+config I2C_NRF5_0_GPIO_SCL_PIN
 	default 0
 
-config I2C_NRF5_GPIO_SDA_PIN
+config I2C_NRF5_0_GPIO_SDA_PIN
 	default 30
 
 config I2C_0_DEFAULT_CFG

--- a/boards/arm/nrf51_vbluno51/Kconfig.defconfig
+++ b/boards/arm/nrf51_vbluno51/Kconfig.defconfig
@@ -47,10 +47,10 @@ endif # I2C
 
 if I2C_NRF5
 
-config I2C_NRF5_GPIO_SCL_PIN
+config I2C_NRF5_0_GPIO_SCL_PIN
 	default 30
 
-config I2C_NRF5_GPIO_SDA_PIN
+config I2C_NRF5_0_GPIO_SDA_PIN
 	default 29
 
 config I2C_0_DEFAULT_CFG

--- a/boards/arm/nrf51_vbluno51/Kconfig.defconfig
+++ b/boards/arm/nrf51_vbluno51/Kconfig.defconfig
@@ -50,7 +50,7 @@ if I2C_NRF5
 config I2C_NRF5_GPIO_SCL_PIN
 	default 30
 
-config I2C_NRF5_GPIO_SCA_PIN
+config I2C_NRF5_GPIO_SDA_PIN
 	default 29
 
 config I2C_0_DEFAULT_CFG

--- a/boards/arm/nrf52_vbluno52/Kconfig.defconfig
+++ b/boards/arm/nrf52_vbluno52/Kconfig.defconfig
@@ -47,10 +47,10 @@ endif # I2C
 
 if I2C_NRF5
 
-config I2C_NRF5_GPIO_SCL_PIN
+config I2C_NRF5_0_GPIO_SCL_PIN
 	default 27
 
-config I2C_NRF5_GPIO_SDA_PIN
+config I2C_NRF5_0_GPIO_SDA_PIN
 	default 26
 
 config I2C_0_DEFAULT_CFG

--- a/boards/arm/nrf52_vbluno52/Kconfig.defconfig
+++ b/boards/arm/nrf52_vbluno52/Kconfig.defconfig
@@ -50,7 +50,7 @@ if I2C_NRF5
 config I2C_NRF5_GPIO_SCL_PIN
 	default 27
 
-config I2C_NRF5_GPIO_SCA_PIN
+config I2C_NRF5_GPIO_SDA_PIN
 	default 26
 
 config I2C_0_DEFAULT_CFG

--- a/drivers/i2c/Kconfig
+++ b/drivers/i2c/Kconfig
@@ -97,12 +97,12 @@ config I2C_CC32XX
 	help
 	  Enable the CC32XX I2C driver.
 
-config I2C_NRF5_GPIO_SCA_PIN
-	int "SCA Pin Number"
+config I2C_NRF5_GPIO_SDA_PIN
+	int "SDA Pin Number"
 	range 0 31
 	depends on I2C_NRF5
 	help
-	  The GPIO pin to use for SCA.
+	  The GPIO pin to use for SDA.
 
 config I2C_NRF5_GPIO_SCL_PIN
 	int "SCL Pin Number"

--- a/drivers/i2c/Kconfig
+++ b/drivers/i2c/Kconfig
@@ -80,15 +80,6 @@ config I2C_MCUX
 	help
 	  Enable the mcux I2C driver.
 
-config I2C_NRF5
-	bool "NRF5 I2C driver"
-	depends on SOC_FAMILY_NRF5
-	select GPIO
-	default n
-	help
-	  This option enables the I2C driver for Nordic Semiconductor nRF5
-	  family processors.
-
 config I2C_CC32XX
 	bool "CC32XX I2C driver"
 	depends on SOC_SERIES_CC32XX
@@ -96,20 +87,6 @@ config I2C_CC32XX
 	default n
 	help
 	  Enable the CC32XX I2C driver.
-
-config I2C_NRF5_GPIO_SDA_PIN
-	int "SDA Pin Number"
-	range 0 31
-	depends on I2C_NRF5
-	help
-	  The GPIO pin to use for SDA.
-
-config I2C_NRF5_GPIO_SCL_PIN
-	int "SCL Pin Number"
-	range 0 31
-	depends on I2C_NRF5
-	help
-	  The GPIO pin to use for SCL.
 
 config I2C_STM32_V1
 	bool "STM32 V1 Driver (F1/F4X)"
@@ -398,5 +375,7 @@ config I2C_SDA_RX_HOLD
 	  while i2c acts as receiver. The unit is i2c module base clock.
 
 source "drivers/i2c/Kconfig.esp32"
+
+source "drivers/i2c/Kconfig.nrf5"
 
 endif # I2C

--- a/drivers/i2c/Kconfig.nrf5
+++ b/drivers/i2c/Kconfig.nrf5
@@ -1,0 +1,57 @@
+# Kconfig.nrf5 - NRF5 I2C configuration options
+#
+#
+# Copyright (c) 2018 Aapo Vienamo
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+
+
+config I2C_NRF5
+	bool "NRF5 I2C driver"
+	depends on SOC_FAMILY_NRF5
+	select GPIO
+	default n
+	help
+	  This option enables the I2C driver for Nordic Semiconductor nRF5
+	  family processors.
+
+if I2C_NRF5
+
+if I2C_0
+
+config I2C_NRF5_0_GPIO_SDA_PIN
+	int "Port 0 SDA Pin Number"
+	range 0 31
+	depends on I2C_NRF5
+	help
+	  The GPIO pin to use for SDA.
+
+config I2C_NRF5_0_GPIO_SCL_PIN
+	int "Port 0 SCL Pin Number"
+	range 0 31
+	depends on I2C_NRF5
+	help
+	  The GPIO pin to use for SCL.
+
+endif # I2C_0
+
+if I2C_1
+
+config I2C_NRF5_1_GPIO_SDA_PIN
+	int "Port 1 SDA Pin Number"
+	range 0 31
+	depends on I2C_NRF5
+	help
+	  The GPIO pin to use for SDA.
+
+config I2C_NRF5_1_GPIO_SCL_PIN
+	int "Port 1 SCL Pin Number"
+	range 0 31
+	depends on I2C_NRF5
+	help
+	  The GPIO pin to use for SCL.
+
+endif # I2C_1
+
+endif # I2C_NRF5

--- a/drivers/i2c/i2c_nrf5.c
+++ b/drivers/i2c/i2c_nrf5.c
@@ -293,14 +293,14 @@ static int i2c_nrf5_init(struct device *dev)
 				    | GPIO_DS_DISCONNECT_HIGH);
 	__ASSERT_NO_MSG(status == 0);
 
-	status = gpio_pin_configure(data->gpio, CONFIG_I2C_NRF5_GPIO_SCA_PIN,
+	status = gpio_pin_configure(data->gpio, CONFIG_I2C_NRF5_GPIO_SDA_PIN,
 				    GPIO_DIR_IN
 				    | GPIO_PUD_PULL_UP
 				    | GPIO_DS_DISCONNECT_HIGH);
 	__ASSERT_NO_MSG(status == 0);
 
 	twi->PSELSCL = CONFIG_I2C_NRF5_GPIO_SCL_PIN;
-	twi->PSELSDA = CONFIG_I2C_NRF5_GPIO_SCA_PIN;
+	twi->PSELSDA = CONFIG_I2C_NRF5_GPIO_SDA_PIN;
 	twi->ERRORSRC = twi->ERRORSRC;
 	twi->EVENTS_TXDSENT = 0;
 	twi->EVENTS_RXDREADY = 0;

--- a/drivers/i2c/i2c_nrf5.c
+++ b/drivers/i2c/i2c_nrf5.c
@@ -34,6 +34,8 @@ struct i2c_nrf5_config {
 	volatile NRF_TWI_Type *base;
 	void (*irq_config_func)(struct device *dev);
 	u32_t default_cfg;
+	u32_t sda_pin;
+	u32_t scl_pin;
 };
 
 
@@ -287,20 +289,20 @@ static int i2c_nrf5_init(struct device *dev)
 
 	twi->ENABLE = TWI_ENABLE_ENABLE_Disabled;
 
-	status = gpio_pin_configure(data->gpio, CONFIG_I2C_NRF5_GPIO_SCL_PIN,
+	status = gpio_pin_configure(data->gpio, config->scl_pin,
 				    GPIO_DIR_IN
 				    | GPIO_PUD_PULL_UP
 				    | GPIO_DS_DISCONNECT_HIGH);
 	__ASSERT_NO_MSG(status == 0);
 
-	status = gpio_pin_configure(data->gpio, CONFIG_I2C_NRF5_GPIO_SDA_PIN,
+	status = gpio_pin_configure(data->gpio, config->sda_pin,
 				    GPIO_DIR_IN
 				    | GPIO_PUD_PULL_UP
 				    | GPIO_DS_DISCONNECT_HIGH);
 	__ASSERT_NO_MSG(status == 0);
 
-	twi->PSELSCL = CONFIG_I2C_NRF5_GPIO_SCL_PIN;
-	twi->PSELSDA = CONFIG_I2C_NRF5_GPIO_SDA_PIN;
+	twi->PSELSCL = config->scl_pin;
+	twi->PSELSDA = config->sda_pin;
 	twi->ERRORSRC = twi->ERRORSRC;
 	twi->EVENTS_TXDSENT = 0;
 	twi->EVENTS_RXDREADY = 0;
@@ -333,6 +335,8 @@ static const struct i2c_nrf5_config i2c_nrf5_config_0 = {
 	.base = NRF_TWI0,
 	.irq_config_func = i2c_nrf5_config_func_0,
 	.default_cfg = CONFIG_I2C_0_DEFAULT_CFG,
+	.sda_pin = CONFIG_I2C_NRF5_0_GPIO_SDA_PIN,
+	.scl_pin = CONFIG_I2C_NRF5_0_GPIO_SCL_PIN,
 };
 
 static struct i2c_nrf5_data i2c_nrf5_data_0;
@@ -358,6 +362,8 @@ static const struct i2c_nrf5_config i2c_nrf5_config_1 = {
 	.base = NRF_TWI1,
 	.irq_config_func = i2c_nrf5_config_func_1,
 	.default_cfg = CONFIG_I2C_1_DEFAULT_CFG,
+	.sda_pin = CONFIG_I2C_NRF5_1_GPIO_SDA_PIN,
+	.scl_pin = CONFIG_I2C_NRF5_1_GPIO_SCL_PIN,
 };
 
 static struct i2c_nrf5_data i2c_nrf5_data_1;


### PR DESCRIPTION
CONFIG_I2C_NRF5_GPIO_SCA_PIN and CONFIG_I2C_NRF5_GPIO_SCL_PIN are
replaced with port specific versions. Board defconfigs relying on the
original names are updated. The driver is also modified to pass the
configure values to registers.

Signed-off-by: Aapo Vienamo <aapo.vienamo@iki.fi>