### PR TITLE
cmake: fix 'ninja flash' et al with multiple boards plugged in

### DIFF
--- a/cmake/flash/CMakeLists.txt
+++ b/cmake/flash/CMakeLists.txt
@@ -70,5 +70,6 @@ foreach(target flash debug debugserver)
     ${cmd}
     COMMENT
     ${comment}
+    USES_TERMINAL
     )
 endforeach()


### PR DESCRIPTION
Fixes: #5958 

Ninja by default will suppress command output and input. This is a
problem for the 'flash', 'debug', etc. targets, which may need to
interact with the user (and which display interactive output like
progress bars).

To fix this, add the USES_TERMINAL option to their target
definitions. This puts them in the console pool on Ninja, allowing the
commands to interact with the console.

References:

https://ninja-build.org/manual.html#_the_literal_console_literal_pool
https://cmake.org/cmake/help/v3.8/command/add_custom_target.html
