### PR TITLE
misc: Use braces in infinite for loop

### DIFF
--- a/include/misc/__assert.h
+++ b/include/misc/__assert.h
@@ -82,8 +82,9 @@
 			       __FILE__,                           \
 			       __LINE__);                          \
 			printk(fmt, ##__VA_ARGS__);                \
-			for (;;)                                   \
-				; /* spin thread */                \
+			for (;;) {                                 \
+				/* spin thread */                  \
+			}				           \
 		}                                                  \
 	} while ((0))
 


### PR DESCRIPTION
Be consistent with the style of always having braces even if a compound
statement isn't required.  Avoids some warnings from static analysis
tools.

Signed-off-by: Leandro Pereira <leandro.pereira@intel.com>