### PR TITLE
Bluetooth: controller: Fix ticker to use u32_t ticks_slot

### DIFF
--- a/subsys/bluetooth/controller/ll_sw/ll.c
+++ b/subsys/bluetooth/controller/ll_sw/ll.c
@@ -157,9 +157,11 @@ int ll_init(struct k_sem *sem_rx)
 	_ticker_users[MAYFLY_CALL_ID_2][0] = 0;
 	_ticker_users[MAYFLY_CALL_ID_PROGRAM][0] = TICKER_USER_APP_OPS;
 
-	ticker_init(RADIO_TICKER_INSTANCE_ID_RADIO, TICKER_NODES,
-		    &_ticker_nodes[0], MAYFLY_CALLER_COUNT, &_ticker_users[0],
-		    TICKER_USER_OPS, &_ticker_user_ops[0]);
+	err = ticker_init(RADIO_TICKER_INSTANCE_ID_RADIO,
+			  TICKER_NODES, &_ticker_nodes[0],
+			  MAYFLY_CALLER_COUNT, &_ticker_users[0],
+			  TICKER_USER_OPS, &_ticker_user_ops[0]);
+	LL_ASSERT(!err);
 
 	clk_m16 = device_get_binding(CONFIG_CLOCK_CONTROL_NRF5_M16SRC_DRV_NAME);
 	if (!clk_m16) {

--- a/subsys/bluetooth/controller/ticker/ticker.c
+++ b/subsys/bluetooth/controller/ticker/ticker.c
@@ -40,8 +40,8 @@ struct ticker_node {
 	ticker_timeout_func timeout_func;
 	void  *context;
 
-	u16_t ticks_to_expire_minus;
-	u16_t ticks_slot;
+	u32_t ticks_to_expire_minus;
+	u32_t ticks_slot;
 	u16_t lazy_periodic;
 	u16_t lazy_current;
 	u32_t remainder_periodic;
@@ -63,7 +63,7 @@ struct ticker_user_op_start {
 	u32_t ticks_periodic;
 	u32_t remainder_periodic;
 	u16_t lazy;
-	u16_t ticks_slot;
+	u32_t ticks_slot;
 	ticker_timeout_func fp_timeout_func;
 	void  *context;
 };
@@ -113,9 +113,9 @@ struct ticker_instance {
 	u8_t  ticks_elapsed_last;
 	u32_t ticks_elapsed[DOUBLE_BUFFER_SIZE];
 	u32_t ticks_current;
-	u8_t  ticker_id_head;
+	u32_t ticks_slot_previous;
 	u8_t  ticker_id_slot_previous;
-	u16_t ticks_slot_previous;
+	u8_t  ticker_id_head;
 	u8_t  job_guard;
 	u8_t  worker_trigger;
 	u8_t  (*fp_caller_id_get)(u8_t user_id);
@@ -417,7 +417,7 @@ static void ticks_to_expire_prep(struct ticker_node *ticker,
 				 u32_t ticks_current, u32_t ticks_at_start)
 {
 	u32_t ticks_to_expire = ticker->ticks_to_expire;
-	u16_t ticks_to_expire_minus = ticker->ticks_to_expire_minus;
+	u32_t ticks_to_expire_minus = ticker->ticks_to_expire_minus;
 
 	/* Calculate ticks to expire for this new node */
 	if (((ticks_at_start - ticks_current) & BIT(23)) == 0) {
@@ -1523,7 +1523,7 @@ void ticker_trigger(u8_t instance_index)
 
 u32_t ticker_start(u8_t instance_index, u8_t user_id, u8_t ticker_id,
 		   u32_t ticks_anchor, u32_t ticks_first, u32_t ticks_periodic,
-		   u32_t remainder_periodic, u16_t lazy, u16_t ticks_slot,
+		   u32_t remainder_periodic, u16_t lazy, u32_t ticks_slot,
 		   ticker_timeout_func fp_timeout_func, void *context,
 		   ticker_op_func fp_op_func, void *op_context)
 {

--- a/subsys/bluetooth/controller/ticker/ticker.h
+++ b/subsys/bluetooth/controller/ticker/ticker.h
@@ -64,7 +64,7 @@
 
 /** \brief Timer node type size.
 */
-#define TICKER_NODE_T_SIZE	36
+#define TICKER_NODE_T_SIZE	40
 
 /** \brief Timer user type size.
 */
@@ -72,7 +72,7 @@
 
 /** \brief Timer user operation type size.
 */
-#define TICKER_USER_OP_T_SIZE	44
+#define TICKER_USER_OP_T_SIZE	48
 
 /** \brief Timer timeout function type.
 */
@@ -100,7 +100,7 @@ bool ticker_is_initialized(u8_t instance_index);
 void ticker_trigger(u8_t instance_index);
 u32_t ticker_start(u8_t instance_index, u8_t user_id, u8_t ticker_id,
 		   u32_t ticks_anchor, u32_t ticks_first, u32_t ticks_periodic,
-		   u32_t remainder_periodic, u16_t lazy, u16_t ticks_slot,
+		   u32_t remainder_periodic, u16_t lazy, u32_t ticks_slot,
 		   ticker_timeout_func fp_timeout_func, void *context,
 		   ticker_op_func fp_op_func, void *op_context);
 u32_t ticker_update(u8_t instance_index, u8_t user_id, u8_t ticker_id,


### PR DESCRIPTION
ticker timespace reservation can range up to 10.24 seconds,
needing 19-bits to represent in 32KHz clock units. Hence,
fix controller implementation to use u32_t to store ticks
slot values.

Without this fix, the controller is asserting in scan_adv
sample when using continuous scanning with 2 second interval
and window.

Signed-off-by: Vinayak Kariappa Chettimada <vich@nordicsemi.no>