### PR TITLE
CODEOWNERS: add @anangl for ADC and counter drivers

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -63,8 +63,10 @@ doc/*                                    @dbkinder
 doc/subsystems/bluetooth/*               @sjanc @jhedberg @Vudentz
 drivers/*/*qmsi*                         @nashif
 drivers/*/*stm32*                        @erwango
+drivers/adc/*                            @anangl
 drivers/bluetooth/*                      @sjanc @jhedberg @Vudentz
 drivers/clock_control/*stm32f4*          @rsalveti @idlethread
+drivers/counter/*                        @anangl
 drivers/ethernet/*                       @jukkar @tbursztyka
 drivers/flash/*                          @nashif
 drivers/flash/*stm32*                    @superna9999
@@ -94,6 +96,7 @@ ext/hal/qmsi/*                           @nashif
 ext/hal/st/stm32cube/*                   @erwango
 ext/lib/crypto/mbedtls/*                 @nashif
 ext/lib/crypto/tinycrypt/*               @lpereira
+include/adc.h                            @anangl
 include/arch/arc/*                       @cjordan44 @ruuddw
 include/arch/arc/arch.h                  @andrewboie
 include/arch/arc/v2/irq.h                @andrewboie
@@ -108,6 +111,7 @@ include/arch/xtensa/*                    @andrewboie
 include/atomic.h                         @andrewboie @andyross
 include/bluetooth/*                      @sjanc @jhedberg @Vudentz
 include/cache.h                          @andrewboie @andyross
+include/counter.h                        @anangl
 include/device.h                         @youvedeep @nashif
 include/drivers/bluetooth/*              @sjanc @jhedberg @Vudentz
 include/drivers/ioapic.h                 @andrewboie


### PR DESCRIPTION
As agreed on the recent APIs dedicated call, I will be working on
improving APIs for these two drivers.

Signed-off-by: Andrzej Głąbek <andrzej.glabek@nordicsemi.no>