### PR TITLE
doc: update package dependencies for Linux

### DIFF
--- a/doc/getting_started/installation_linux.rst
+++ b/doc/getting_started/installation_linux.rst
@@ -54,16 +54,19 @@ Install the required packages in a Ubuntu host system with:
 
    sudo apt-get install --no-install-recommends git cmake ninja-build gperf \
      ccache doxygen dfu-util device-tree-compiler \
-     python3-ply python3-pip python3-setuptools xz-utils file make gcc-multilib
+     python3-ply python3-pip python3-setuptools xz-utils file make gcc-multilib \
+     autoconf automake libtool
 
 Install the required packages in a Fedora host system with:
 
 .. code-block:: console
 
-   sudo dnf group install "Development Tools"
+   sudo dnf group install "Development Tools" "C Development Tools and Libraries"
    sudo dnf install git cmake ninja-build gperf ccache\
 	 doxygen dfu-util dtc python3-pip \
-	 python3-ply python3-yaml dfu-util dtc python3-pykwalify
+	 python3-ply python3-yaml dfu-util dtc python3-pykwalify \
+         glibc-devel.i686 libstdc++-devel.i686 autoconf automake libtool \
+         gcc-c++.i686
 
 Install additional packages required for development with Zephyr::
 


### PR DESCRIPTION
We now require host compiler for building Zephyr in 32bit mode.

Fixes #5989