### PR TITLE
doc: memory_domain: Update memory domain API's documentation

### DIFF
--- a/doc/kernel/usermode/memory_domain.rst
+++ b/doc/kernel/usermode/memory_domain.rst
@@ -54,7 +54,7 @@ The following code defines and initializes an empty memory domain.
 
     struct k_mem_domain app0_domain;
 
-    k_mem_domain_init(&app0_domain, "app0_domain", 0, NULL);
+    k_mem_domain_init(&app0_domain, 0, NULL);
 
 Add Memory Partitions into a Memory Domain
 ==========================================
@@ -115,7 +115,7 @@ The following code shows how to add threads into a memory domain.
 
 .. code-block:: c
 
-    k_mem_domain_add_thread(&app0_domain, &app_thread_id);
+    k_mem_domain_add_thread(&app0_domain, app_thread_id);
 
 Remove a Memory Partition from a Memory Domain
 ==============================================
@@ -138,7 +138,7 @@ The following code shows how to remove a thread from the memory domain.
 
 .. code-block:: c
 
-    k_mem_domain_remove_thread(&app0_domain, &app_thread_id);
+    k_mem_domain_remove_thread(app_thread_id);
 
 Destroy a Memory Domain
 =======================


### PR DESCRIPTION
Remove thread from memory domain API (k_mem_domain_remove_thread())has
only one argument which is thread ID as per the implementation whereas
documentation says there has to be two arguments, memory domain and thread ID.
Memory domain argument is not required as a thread belongs to single memory
domain at any point in time. Also memory domain initialisation function
(k_mem_domain_init()) should accept only 3 arguments i.e, memory domain
name, number of parts and array of pointers to the memory domain,
instead of 4.

Fixes #5992

Signed-off-by: Spoorthi K <spoorthi.k@intel.com>