### PR TITLE
boards: frdm_k64f: give name to fxos8700 node

### DIFF
--- a/boards/arm/frdm_k64f/frdm_k64f.dts
+++ b/boards/arm/frdm_k64f/frdm_k64f.dts
@@ -52,7 +52,7 @@
 &i2c0 {
 	status = "ok";
 
-	fxos8700@1d {
+	fxos8700: fxos8700@1d {
 		compatible = "nxp,fxos8700";
 		reg = <0x1d>;
 		label = "FXOS8700";


### PR DESCRIPTION
This is useful to make it convenient for application overlays to set
any of the node's properties.

For example, with this patch, applications can configure the node's
label the way it was previously possible to do with
CONFIG_FXOS8700_NAME, by adding this content in an overlay file:

```
    &fxos8700 {
            label = "some-custom-label";
    };
```