### PR TITLE
Bluetooth: controller: Rename radio_*_is_enabled to ll_*_is_enabled

### DIFF
--- a/subsys/bluetooth/controller/ll_sw/ctrl.c
+++ b/subsys/bluetooth/controller/ll_sw/ctrl.c
@@ -10213,7 +10213,7 @@ u32_t radio_adv_disable(void)
 	return status ? BT_HCI_ERR_CMD_DISALLOWED : 0;
 }
 
-u32_t radio_adv_is_enabled(void)
+u32_t ll_adv_is_enabled(void)
 {
 	return _radio.advertiser.is_enabled;
 }
@@ -10372,7 +10372,7 @@ u32_t radio_scan_disable(void)
 	return status ? BT_HCI_ERR_CMD_DISALLOWED : 0;
 }
 
-u32_t radio_scan_is_enabled(void)
+u32_t ll_scan_is_enabled(void)
 {
 	/* NOTE: BIT(0) - passive scanning enabled
 	 *       BIT(1) - active scanning enabled

--- a/subsys/bluetooth/controller/ll_sw/ctrl.h
+++ b/subsys/bluetooth/controller/ll_sw/ctrl.h
@@ -352,14 +352,14 @@ u32_t radio_adv_enable(u16_t interval, u8_t chan_map, u8_t filter_policy,
 #endif /* !CONFIG_BT_CTLR_ADV_EXT */
 
 u32_t radio_adv_disable(void);
-u32_t radio_adv_is_enabled(void);
+u32_t ll_adv_is_enabled(void);
 u32_t radio_adv_filter_pol_get(void);
 /* Downstream - Scanner */
 u32_t radio_scan_enable(u8_t type, u8_t init_addr_type, u8_t *init_addr,
 			u16_t interval, u16_t window, u8_t filter_policy,
 			u8_t rpa_gen, u8_t rl_idx);
 u32_t radio_scan_disable(void);
-u32_t radio_scan_is_enabled(void);
+u32_t ll_scan_is_enabled(void);
 u32_t radio_scan_filter_pol_get(void);
 
 u32_t radio_connect_enable(u8_t adv_addr_type, u8_t *adv_addr,

--- a/subsys/bluetooth/controller/ll_sw/ll_addr.c
+++ b/subsys/bluetooth/controller/ll_sw/ll_addr.c
@@ -42,8 +42,8 @@ u8_t *ll_addr_get(u8_t addr_type, u8_t *bdaddr)
 
 u32_t ll_addr_set(u8_t addr_type, u8_t const *const bdaddr)
 {
-	if (radio_adv_is_enabled() ||
-	    (radio_scan_is_enabled() & (BIT(1) | BIT(2)))) {
+	if (ll_adv_is_enabled() ||
+	    (ll_scan_is_enabled() & (BIT(1) | BIT(2)))) {
 		return BT_HCI_ERR_CMD_DISALLOWED;
 	}
 

--- a/subsys/bluetooth/controller/ll_sw/ll_adv.c
+++ b/subsys/bluetooth/controller/ll_sw/ll_adv.c
@@ -57,7 +57,7 @@ u32_t ll_adv_params_set(u16_t interval, u8_t adv_type,
 	struct radio_adv_data *radio_adv_data;
 	struct pdu_adv *pdu;
 
-	if (radio_adv_is_enabled()) {
+	if (ll_adv_is_enabled()) {
 		return BT_HCI_ERR_CMD_DISALLOWED;
 	}
 
@@ -341,7 +341,7 @@ u32_t ll_adv_enable(u8_t enable)
 
 	if (!enable) {
 		return radio_adv_disable();
-	} else if (radio_adv_is_enabled()) {
+	} else if (ll_adv_is_enabled()) {
 		return 0;
 	}
 

--- a/subsys/bluetooth/controller/ll_sw/ll_filter.c
+++ b/subsys/bluetooth/controller/ll_sw/ll_filter.c
@@ -394,7 +394,7 @@ void ll_filters_adv_update(u8_t adv_fp)
 		filter_wl_update();
 	}
 
-	if (rl_enable && !radio_scan_is_enabled()) {
+	if (rl_enable && !ll_scan_is_enabled()) {
 		/* rl not in use, update resolving list LUT */
 		filter_rl_update();
 	}
@@ -408,7 +408,7 @@ void ll_filters_scan_update(u8_t scan_fp)
 		filter_wl_update();
 	}
 
-	if (rl_enable && !radio_adv_is_enabled()) {
+	if (rl_enable && !ll_adv_is_enabled()) {
 		/* rl not in use, update resolving list LUT */
 		filter_rl_update();
 	}
@@ -610,7 +610,7 @@ static int rl_access_check(bool check_ar)
 		}
 	}
 
-	return (radio_adv_is_enabled() || radio_scan_is_enabled()) ? 0 : 1;
+	return (ll_adv_is_enabled() || ll_scan_is_enabled()) ? 0 : 1;
 }
 
 void ll_rl_rpa_update(bool timeout)
@@ -659,7 +659,7 @@ void ll_rl_rpa_update(bool timeout)
 
 	if (timeout) {
 #if defined(CONFIG_BT_BROADCASTER)
-		if (radio_adv_is_enabled()) {
+		if (ll_adv_is_enabled()) {
 			rpa_adv_refresh();
 		}
 #endif

--- a/subsys/bluetooth/controller/ll_sw/ll_master.c
+++ b/subsys/bluetooth/controller/ll_sw/ll_master.c
@@ -25,7 +25,7 @@ u32_t ll_create_connection(u16_t scan_interval, u16_t scan_window,
 	u8_t  rpa_gen = 0;
 	u8_t  rl_idx = FILTER_IDX_NONE;
 
-	if (radio_scan_is_enabled()) {
+	if (ll_scan_is_enabled()) {
 		return BT_HCI_ERR_CMD_DISALLOWED;
 	}
 

--- a/subsys/bluetooth/controller/ll_sw/ll_scan.c
+++ b/subsys/bluetooth/controller/ll_sw/ll_scan.c
@@ -32,7 +32,7 @@ static struct {
 u32_t ll_scan_params_set(u8_t type, u16_t interval, u16_t window,
 			 u8_t own_addr_type, u8_t filter_policy)
 {
-	if (radio_scan_is_enabled()) {
+	if (ll_scan_is_enabled()) {
 		return BT_HCI_ERR_CMD_DISALLOWED;
 	}
 
@@ -64,7 +64,7 @@ u32_t ll_scan_enable(u8_t enable)
 
 	if (!enable) {
 		return radio_scan_disable();
-	} else if (radio_scan_is_enabled()) {
+	} else if (ll_scan_is_enabled()) {
 		/* Duplicate filtering is processed in the HCI layer */
 		return 0;
 	}


### PR DESCRIPTION
In preparation towards a refactored controller, rename the
old radio_*_is_enabled() function to ll_*_is_enabled().

Signed-off-by: Vinayak Kariappa Chettimada <vich@nordicsemi.no>