### PR TITLE
boards: nios2: altera_max10: Add default Kconfig options for Disk

### DIFF
--- a/boards/nios2/altera_max10/Kconfig.defconfig
+++ b/boards/nios2/altera_max10/Kconfig.defconfig
@@ -3,5 +3,41 @@ if BOARD_ALTERA_MAX10
 config BOARD
 	default "altera_max10"
 
-endif
+if FLASH
+
+config SOC_FLASH_NIOS2_QSPI
+	def_bool y
+
+if SOC_FLASH_NIOS2_QSPI
+
+config SOC_FLASH_NIOS2_QSPI_DEV_NAME
+	default "NIOS2_QSPI_FLASH"
+
+if DISK_ACCESS_FLASH
+
+config DISK_FLASH_DEV_NAME
+	default SOC_FLASH_NIOS2_QSPI_DEV_NAME
+
+config DISK_FLASH_START
+	default 0x0
+
+config DISK_FLASH_MAX_RW_SIZE
+	default 256
+
+config DISK_ERASE_BLOCK_SIZE
+	default 0x10000
+
+config DISK_FLASH_ERASE_ALIGNMENT
+	default 0x10000
+
+config DISK_VOLUME_SIZE
+	default 0x4000000
+
+endif # DISK_ACCESS_FLASH
+
+endif # SOC_FLASH_NIOS2_QSPI
+
+endif # FLASH
+
+endif # BOARD_ALTERA_MAX10
 


### PR DESCRIPTION

Add default Kconfig settings for Nios-II flash device on Altera MAX10 board.

Signed-off-by: Ramakrishna Pallala <ramakrishna.pallala@intel.com>