### PR TITLE
doc: Add shell doc for kernel module

### DIFF
--- a/doc/subsystems/shell.rst
+++ b/doc/subsystems/shell.rst
@@ -17,16 +17,6 @@ Using shell commands
 
 Use one of the following formats:
 
-Specific module's commands
-==========================
-
-A shell interface exposing subsystem features is a shell module, multiple
-modules can be available at the same time.
-
-``MODULE_NAME COMMAND``
- One of the available modules is "KERNEL", for the Kernel module.  More
- information can be found in :c:macro:`SHELL_REGISTER`.
-
 Help commands
 =============
 
@@ -37,21 +27,72 @@ Help commands
  Prints the names of the available commands for the module.
 
 ``help MODULE_NAME COMMAND``
- Prints help for the module's command (the help should show function
- goal and required parameters).
+ Prints help for the module's command (the help describes the available
+ module commands and required parameters).
+
+
+Specific module's commands
+==========================
+
+A shell interface exposing subsystem features is a shell module, multiple
+modules can be available at the same time.
+
+``MODULE_NAME COMMAND``
+ One of the available modules is "KERNEL", for `Kernel module commands`_.
+ Information about registering a new module and its commands can be
+ found in :c:macro:`SHELL_REGISTER` documentation.
+
 
 Select module commands
 ======================
 
 ``select MODULE_NAME``
  Use this command when using the shell only for one module. After entering this
- command, you will not need to enter module name in further commands. If
+ command, you will not need to enter the module name in further commands. If
  the selected module has set a default shell prompt during its initialization,
  the prompt will be changed to that one. Otherwise, the prompt will be
  changed to the selected module's name to reflect the current module in use.
 
 ``select``
  Clears selected module. Restores prompt as well.
+
+
+Kernel module commands
+======================
+
+When enabled through option :option:`CONFIG_KERNEL_SHELL`, the Kernel
+shell module commands display useful kernel-specific information.
+
+You can issue these Kernel module shell commands by specifying
+the module and command::
+
+   shell> kernel version
+
+or by first selecting the kernel module, and then issuing the specific
+command::
+
+   shell> select kernel
+   kernel> version
+
+Here are the Kernel module shell commands:
+
+``version``
+ Displays the kernel version number
+
+``uptime``
+ Displays the system uptime in milliseconds
+
+``cycles``
+ Displays the current time (in cycles), as measured by the system’s hardware clock
+
+``threads``
+ Displays information about the running threads (if
+ :option:`CONFIG_OBJECT_TRACING` and :option:`CONFIG_THREAD_MONITOR` are
+ enabled).
+
+``stacks``
+ Displays size and use information about the main, idle, interrupt and system
+ workqueue call stacks (if :option:`CONFIG_INIT_STACKS` is enabled)
 
 Other commands
 ==============
@@ -106,10 +147,11 @@ behavior and settings:
 
 * :c:func:`shell_register_prompt_handler`
 
-In case of a sample applications as well as test environment, user can choose to
+In case of a sample applications as well as the test environment, you can choose to
 set a default module in code level. In this case, the function
-shell_register_default_module should be called after calling SHELL_REGISTER in
-application level.  If the function shell_register_prompt_handler was called as
+:c:func:`shell_register_default_module` should be called after calling SHELL_REGISTER in
+application level.  If the function
+:c:func:`shell_register_prompt_handler` was called as
 well, the prompt will be changed to that one.  Otherwise, the prompt will be
 changed to the selected module's name, in order to reflect the current module in
 use.


### PR DESCRIPTION
Issue #5996 mentions the need for a shell feature that is somewhat
implemented already, but not documented: the "kernel" module has
commands to display information about the kernel version, uptime,
cycles, threads, and stacks, so add that to the subsystem/shell doc.

Signed-off-by: David B. Kinder <david.b.kinder@intel.com>