### PR TITLE
soc: ti_simplelink: cc32xx: Remove ARMV7_M guard from CMSIS_IRQn_Type

### DIFF
--- a/arch/arm/soc/ti_simplelink/cc32xx/soc.h
+++ b/arch/arm/soc/ti_simplelink/cc32xx/soc.h
@@ -21,11 +21,9 @@ enum {
 	Reset_IRQn                    = -15,
 	NonMaskableInt_IRQn           = -14,
 	HardFault_IRQn                = -13,
-#if defined(CONFIG_ARMV7_M)
 	MemoryManagement_IRQn         = -12,
 	BusFault_IRQn                 = -11,
 	UsageFault_IRQn               = -10,
-#endif /* CONFIG_ARMV7_M */
 	SVCall_IRQn                   =  -5,
 	DebugMonitor_IRQn             =  -4,
 	PendSV_IRQn                   =  -2,


### PR DESCRIPTION
Remove unnecesary #ifdef CONFIG_ARMV7_M guard in soc.h file.

Signed-off-by: Gil Pitney <gil.pitney@linaro.org>