### PR TITLE
LwM2M: add data validation callback and set transport binding of server object as read-writable

### DIFF
--- a/subsys/net/lib/lwm2m/ipso_light_control.c
+++ b/subsys/net/lib/lwm2m/ipso_light_control.c
@@ -152,7 +152,7 @@ static struct lwm2m_engine_obj_inst *light_control_create(u16_t obj_inst_id)
 		&dimmer_value[avail], sizeof(*dimmer_value));
 	INIT_OBJ_RES(res[avail], i, LIGHT_ON_TIME_ID, 0, &on_time_value[avail],
 		sizeof(*on_time_value), on_time_read_cb,
-		NULL, on_time_post_write_cb, NULL);
+		NULL, on_time_post_write_cb, NULL, NULL);
 	INIT_OBJ_RES_DATA(res[avail], i, LIGHT_CUMULATIVE_ACTIVE_POWER_ID,
 		&cumulative_active_value[avail],
 		sizeof(*cumulative_active_value));

--- a/subsys/net/lib/lwm2m/ipso_temp_sensor.c
+++ b/subsys/net/lib/lwm2m/ipso_temp_sensor.c
@@ -172,7 +172,7 @@ static struct lwm2m_engine_obj_inst *temp_sensor_create(u16_t obj_inst_id)
 	/* initialize instance resource data */
 	INIT_OBJ_RES(res[index], i, TEMP_SENSOR_VALUE_ID, 0,
 		     &sensor_value[index], sizeof(*sensor_value),
-		     NULL, NULL, sensor_value_write_cb, NULL);
+		     NULL, NULL, sensor_value_write_cb, NULL, NULL);
 	INIT_OBJ_RES_DATA(res[index], i, TEMP_UNITS_ID,
 			  units[index], TEMP_STRING_SHORT);
 	INIT_OBJ_RES_DATA(res[index], i, TEMP_MIN_MEASURED_VALUE_ID,

--- a/subsys/net/lib/lwm2m/lwm2m_obj_device.c
+++ b/subsys/net/lib/lwm2m/lwm2m_obj_device.c
@@ -311,7 +311,7 @@ static struct lwm2m_engine_obj_inst *device_create(u16_t obj_inst_id)
 			     reset_error_list_cb);
 	INIT_OBJ_RES(res, i, DEVICE_CURRENT_TIME_ID, 0, NULL, 0,
 		     current_time_read_cb, current_time_pre_write_cb,
-		     current_time_post_write_cb, NULL);
+		     current_time_post_write_cb, NULL, NULL);
 	INIT_OBJ_RES_DATA(res, i, DEVICE_SUPPORTED_BINDING_MODES_ID,
 			  binding_mode, DEVICE_STRING_SHORT);
 	INIT_OBJ_RES_DATA(res, i, DEVICE_TYPE_ID,

--- a/subsys/net/lib/lwm2m/lwm2m_obj_firmware.c
+++ b/subsys/net/lib/lwm2m/lwm2m_obj_firmware.c
@@ -298,10 +298,10 @@ static struct lwm2m_engine_obj_inst *firmware_create(u16_t obj_inst_id)
 
 	/* initialize instance resource data */
 	INIT_OBJ_RES(res, i, FIRMWARE_PACKAGE_ID, 0, NULL, 0,
-		     NULL, NULL, package_write_cb, NULL);
+		     NULL, NULL, package_write_cb, NULL, NULL);
 	INIT_OBJ_RES(res, i, FIRMWARE_PACKAGE_URI_ID, 0,
 		     package_uri, PACKAGE_URI_LEN,
-		     NULL, NULL, package_uri_write_cb, NULL);
+		     NULL, NULL, package_uri_write_cb, NULL, NULL);
 	INIT_OBJ_RES_EXECUTE(res, i, FIRMWARE_UPDATE_ID,
 			     firmware_update_cb);
 	INIT_OBJ_RES_DATA(res, i, FIRMWARE_STATE_ID,

--- a/subsys/net/lib/lwm2m/lwm2m_object.h
+++ b/subsys/net/lib/lwm2m/lwm2m_object.h
@@ -156,7 +156,8 @@ struct lwm2m_engine_obj {
 };
 
 #define INIT_OBJ_RES(res_var, index_var, id_val, multi_var, \
-		     data_val, data_val_len, r_cb, pre_w_cb, post_w_cb, ex_cb) \
+		     data_val, data_val_len, r_cb, pre_w_cb, post_w_cb, \
+		     ex_cb, v_cb) \
 	res_var[index_var].res_id = id_val; \
 	res_var[index_var].multi_count_var = multi_var; \
 	res_var[index_var].data_ptr = data_val; \
@@ -164,12 +165,13 @@ struct lwm2m_engine_obj {
 	res_var[index_var].read_cb = r_cb; \
 	res_var[index_var].pre_write_cb = pre_w_cb; \
 	res_var[index_var].post_write_cb = post_w_cb; \
+	res_var[index_var].validate_cb = v_cb; \
 	res_var[index_var++].execute_cb = ex_cb
 
 #define INIT_OBJ_RES_MULTI_DATA(res_var, index_var, id_val, multi_var, \
 				data_val, data_val_len) \
 	INIT_OBJ_RES(res_var, index_var, id_val, multi_var, data_val, \
-		     data_val_len, NULL, NULL, NULL, NULL)
+		     data_val_len, NULL, NULL, NULL, NULL, NULL)
 
 #define INIT_OBJ_RES_DATA(res_var, index_var, id_val, data_val, data_val_len) \
 	INIT_OBJ_RES_MULTI_DATA(res_var, index_var, id_val, NULL, \
@@ -180,7 +182,7 @@ struct lwm2m_engine_obj {
 
 #define INIT_OBJ_RES_EXECUTE(res_var, index_var, id_val, ex_cb) \
 	INIT_OBJ_RES(res_var, index_var, id_val, NULL, NULL, 0, \
-		     NULL, NULL, NULL, ex_cb)
+		     NULL, NULL, NULL, ex_cb, NULL)
 
 
 #define LWM2M_ATTR_PMIN	0
@@ -217,6 +219,7 @@ struct lwm2m_engine_res_inst {
 	lwm2m_engine_get_data_cb_t	pre_write_cb;
 	lwm2m_engine_set_data_cb_t	post_write_cb;
 	lwm2m_engine_exec_cb_t		execute_cb;
+	lwm2m_engine_set_data_cb_t	validate_cb;
 };
 
 struct lwm2m_engine_obj_inst {


### PR DESCRIPTION
Per issue #3931, it's a good idea that we validate incoming data before we made it permanent.

The idea to support this is to simply add a callback to struct lwm2m_engine_res_inst.
Combining with pre_write_cb and post_write_cb we can validate the incoming data.

Here's how
First, pre_write_cb() is registered to return a buffer to store the data for later validation.
Second, validate_cb() is called after the data is copied from packet buffer to the temporary buffer returned from pre_write_cb()
Finally, post_write_cb() is registered and called to make the validated data permanent.

With validation support added to LwM2M, we could set "transport binding" resource of server object as read-writable.

The server binding mode was read-only for we only support UDP.
However, it seems that we do support UDP with queue mode (UQ) as well.
For queue mode should be a server side implementation.

Set server binding mode back to read-writable (as defined by OMA) and add binding mode related definition, validation functions to server object to allow server to change the binding mode to either UDP or UDP with queue mode.
