### PR TITLE
Kconfig: Fix warnings after rebase to latest Kconfiglib

### DIFF
--- a/drivers/console/Kconfig
+++ b/drivers/console/Kconfig
@@ -208,7 +208,7 @@ config NATIVE_POSIX_CONSOLE
 	  Use native stdin and stdout to print messages and get input
 
 config NATIVE_POSIX_STDIN_CONSOLE
-	bool "Use native stdin for console"
+	bool
 	prompt "Read from native stdin for console"
 	depends on NATIVE_POSIX_CONSOLE
 	default y
@@ -232,7 +232,7 @@ config NATIVE_STDIN_PRIO
 	  Prioriry of the native stdin polling thread
 
 config NATIVE_POSIX_STDOUT_CONSOLE
-	bool "Use native stdout for console"
+	bool
 	prompt "Print to native stdout"
 	depends on NATIVE_POSIX_CONSOLE
 	default y

--- a/drivers/sensor/adxl362/Kconfig
+++ b/drivers/sensor/adxl362/Kconfig
@@ -36,7 +36,7 @@ config ADXL362_SPI_DEV_SLAVE
 choice
 	prompt "Accelerometer range setting"
 	depends on ADXL362
-	default BMI160_ACCEL_RANGE_RUNTIME
+	default ADXL362_ACCEL_RANGE_RUNTIME
 
 config ADXL362_ACCEL_RANGE_RUNTIME
 	bool "Set at runtime."

--- a/drivers/sensor/vl53l0x/Kconfig
+++ b/drivers/sensor/vl53l0x/Kconfig
@@ -26,7 +26,7 @@ config VL53L0X_NAME
 	  Device name with which the VL53L0X sensor is identified.
 
 config VL53L0X_I2C_ADDR
-	int
+	hex
 	prompt "Vl53l0x I2C address"
 	default 0x29
 	depends on VL53L0X

--- a/subsys/fs/Kconfig
+++ b/subsys/fs/Kconfig
@@ -18,7 +18,7 @@ choice
 	prompt "Supported file systems"
 	default NO_FILE_SYSTEM
 
-config NO_FS
+config NO_FILE_SYSTEM
 	bool "No File System"
 	help
 	  No file system chosen.


### PR DESCRIPTION
NATIVE_POSIX_STDIN_CONSOLE and NATIVE_POSIX_STDOUT_CONSOLE have more
than one prompts, this will cause warnings when run kconfig checks.

Remove one of two prompts.

Signed-off-by: Ding Tao <miyatsu@qq.com>