### PR TITLE
sensors: move lps25hb and lsm6ds0 to dts

### DIFF
--- a/drivers/sensor/lps25hb/Kconfig
+++ b/drivers/sensor/lps25hb/Kconfig
@@ -13,6 +13,8 @@ menuconfig LPS25HB
 	  Enable driver for LPS25HB I2C-based pressure and temperature
 	  sensor.
 
+if !HAS_DTS_I2C_DEVICE
+
 config LPS25HB_DEV_NAME
 	string
 	prompt "Device name"
@@ -39,6 +41,8 @@ config LPS25HB_I2C_MASTER_DEV_NAME
 	help
 	  Specify the device name of the I2C master device to which
 	  LPS25HB is connected.
+
+endif
 
 menu "Attributes"
 	depends on LPS25HB

--- a/drivers/sensor/lsm6ds0/Kconfig
+++ b/drivers/sensor/lsm6ds0/Kconfig
@@ -15,6 +15,8 @@ menuconfig LSM6DS0
 	  Enable driver for LSM6DS0 I2C-based accelerometer and gyroscope
 	  sensor.
 
+if !HAS_DTS_I2C_DEVICE
+
 config LSM6DS0_DEV_NAME
 	string "LSM6DS0 device name"
 	depends on LSM6DS0
@@ -37,6 +39,8 @@ config LSM6DS0_I2C_MASTER_DEV_NAME
 	help
 	  Specify the device name of the I2C master device to which LSM6DS0 is
 	  connected.
+
+endif
 
 config LSM6DS0_ACCEL_ENABLE_X_AXIS
 	bool "Enable accelerometer X axis"

--- a/dts/bindings/sensor/st,lps25hb-press.yaml
+++ b/dts/bindings/sensor/st,lps25hb-press.yaml
@@ -1,0 +1,21 @@
+#
+# Copyright (c) 2018, Linaro Limited
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+---
+title: STMicroelectronics MEMS sensors LPS25HB
+id: st,lps25hb-press
+version: 0.1
+
+description: >
+    This binding gives a base representation of LPS25HB pressure sensor
+
+inherits:
+    !include i2c-device.yaml
+
+properties:
+    compatible:
+      constraint: "st,lps25hb-press"
+
+...

--- a/dts/bindings/sensor/st,lsm6ds0.yaml
+++ b/dts/bindings/sensor/st,lsm6ds0.yaml
@@ -1,0 +1,22 @@
+#
+# Copyright (c) 2018, Linaro Limited
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+---
+title: STMicroelectronics MEMS sensors LSM6DS0
+id: st,lsm6ds0
+version: 0.1
+
+description: >
+    This binding gives a base representation of LSM6DS0 6-axis accelerometer
+    and gyrometer
+
+inherits:
+    !include i2c-device.yaml
+
+properties:
+    compatible:
+      constraint: "st,lsm6ds0"
+
+...

--- a/dts/bindings/sensor/st,lsm6dsl.yaml
+++ b/dts/bindings/sensor/st,lsm6dsl.yaml
@@ -5,7 +5,7 @@
 #
 ---
 title: STMicroelectronics MEMS sensors LSM6DSL
-id: st,lps22hb-press
+id: st,lsm6dsl
 version: 0.1
 
 description: >


### PR DESCRIPTION
Introduce yaml binding files for sensors LPS25HB and LSM6DS0.
Fix description issue in lps22hb yaml file

Signed-off-by: Erwan Gouriou <erwan.gouriou@linaro.org>