### PR TITLE
native posix: fix in tickless mode + more tests can be run

### DIFF
--- a/arch/posix/core/cpuhalt.c
+++ b/arch/posix/core/cpuhalt.c
@@ -19,6 +19,7 @@
 
 #include "posix_core.h"
 #include "posix_soc_if.h"
+#include "logging/kernel_event_logger.h"
 
 /**
  *
@@ -34,6 +35,7 @@
  */
 void k_cpu_idle(void)
 {
+	_sys_k_event_logger_enter_sleep();
 	posix_irq_full_unlock();
 	posix_halt_cpu();
 }
@@ -60,5 +62,6 @@ void k_cpu_idle(void)
 
 void k_cpu_atomic_idle(unsigned int imask)
 {
+	_sys_k_event_logger_enter_sleep();
 	posix_atomic_halt_cpu(imask);
 }

--- a/arch/posix/core/swap.c
+++ b/arch/posix/core/swap.c
@@ -102,3 +102,17 @@ void _arch_switch_to_main_thread(struct k_thread *main_thread,
 }
 #endif
 
+#ifdef CONFIG_SYS_POWER_MANAGEMENT
+/**
+ * If the kernel is in idle mode, take it out
+ */
+void posix_irq_check_idle_exit(void)
+{
+	if (_kernel.idle) {
+		s32_t idle_val = _kernel.idle;
+
+		_kernel.idle = 0;
+		_sys_power_save_idle_exit(idle_val);
+	}
+}
+#endif

--- a/arch/posix/core/swap.c
+++ b/arch/posix/core/swap.c
@@ -99,7 +99,7 @@ void _arch_switch_to_main_thread(struct k_thread *main_thread,
 	_kernel.current = _kernel.ready_q.cache;
 
 	posix_main_thread_start(ready_thread_ptr->thread_idx);
-}
+} /* LCOV_EXCL_LINE */
 #endif
 
 #ifdef CONFIG_SYS_POWER_MANAGEMENT

--- a/arch/posix/include/posix_core.h
+++ b/arch/posix/include/posix_core.h
@@ -42,6 +42,7 @@ void posix_init_multithreading(void);
 void posix_core_clean_up(void);
 
 void posix_new_thread_pre_start(void); /* defined in thread.c */
+void posix_irq_check_idle_exit(void);
 
 #ifdef __cplusplus
 }

--- a/arch/posix/soc/inf_clock/posix_board_if.h
+++ b/arch/posix/soc/inf_clock/posix_board_if.h
@@ -23,6 +23,7 @@ extern "C" {
 
 void posix_irq_handler(void);
 void posix_exit(int exit_code);
+u64_t posix_get_hw_cycle(void);
 
 #if defined(CONFIG_ARCH_HAS_CUSTOM_BUSY_WAIT)
 void k_busy_wait(u32_t usec_to_wait);

--- a/boards/posix/native_posix/board_irq.h
+++ b/boards/posix/native_posix/board_irq.h
@@ -50,12 +50,17 @@ void _irq_priority_set(unsigned int irq, unsigned int prio, u32_t flags);
 	irq_p; \
 })
 
-
 /**
- * The return of "name(void)" is the indicaton of the interrupt
+ * POSIX Architecture (board) specific ISR_DIRECT_DECLARE(),
+ * See include/irq.h for more information.
+ *
+ * The return of "name##_body(void)" is the indication of the interrupt
  * (maybe) having caused a kernel decision to context switch
  *
  * Note that this convention is changed relative to the ARM and x86 archs
+ *
+ * All pre/post irq work of the interrupt is handled in the board
+ * posix_irq_handler() both for direct and normal interrupts together
  */
 #define _ARCH_ISR_DIRECT_DECLARE(name) \
 	static inline int name##_body(void); \
@@ -67,7 +72,15 @@ void _irq_priority_set(unsigned int irq, unsigned int prio, u32_t flags);
 	} \
 	static inline int name##_body(void)
 
-#define _ARCH_ISR_DIRECT_PM()
+#define _ARCH_ISR_DIRECT_HEADER()   do { } while (0)
+#define _ARCH_ISR_DIRECT_FOOTER(a)  do { } while (0)
+
+#ifdef CONFIG_SYS_POWER_MANAGEMENT
+extern void posix_irq_check_idle_exit(void);
+#define _ARCH_ISR_DIRECT_PM() posix_irq_check_idle_exit()
+#else
+#define _ARCH_ISR_DIRECT_PM() do { } while (0)
+#endif
 
 #ifdef __cplusplus
 }

--- a/boards/posix/native_posix/hw_models_top.c
+++ b/boards/posix/native_posix/hw_models_top.c
@@ -167,6 +167,10 @@ u64_t hwm_get_time(void)
 	return device_time;
 }
 
+u64_t posix_get_hw_cycle(void)
+{
+	return hwm_get_time();
+}
 
 /**
  * Function to initialize the HW models

--- a/boards/posix/native_posix/hw_models_top.c
+++ b/boards/posix/native_posix/hw_models_top.c
@@ -17,6 +17,7 @@
 #include "irq_ctrl.h"
 #include "posix_board_if.h"
 #include "posix_soc_if.h"
+#include "posix_arch_internal.h"
 
 
 static u64_t device_time; /* The actual time as known by the device */
@@ -66,37 +67,29 @@ void hwm_signal_end_handler(int sig)
 void hwm_set_sig_handler(void)
 {
 	struct sigaction act;
-	int e;
 
 	act.sa_handler = hwm_signal_end_handler;
-	e = sigemptyset(&act.sa_mask);
-	if (e) {
-		posix_print_error_and_exit("Error on sigemptyset()\n");
-	}
+	_SAFE_CALL(sigemptyset(&act.sa_mask));
 
 	act.sa_flags = SA_RESETHAND;
 
-	e = sigaction(SIGTERM, &act, NULL);
-	if (e) {
-		posix_print_error_and_exit("Error on sigaction()\n");
-	}
-	e = sigaction(SIGINT, &act, NULL);
-	if (e) {
-		posix_print_error_and_exit("Error on sigaction()\n");
-	}
+	_SAFE_CALL(sigaction(SIGTERM, &act, NULL));
+	_SAFE_CALL(sigaction(SIGINT, &act, NULL));
 }
 
 
 static void hwm_sleep_until_next_timer(void)
 {
-	if (next_timer_time >= device_time) {
+	if (next_timer_time >= device_time) { /* LCOV_EXCL_BR_LINE */
 		device_time = next_timer_time;
 	} else {
+		/* LCOV_EXCL_START */
 		posix_print_warning("next_timer_time corrupted (%"PRIu64"<= %"
 				PRIu64", timer idx=%i)\n",
 				next_timer_time,
 				device_time,
 				next_timer_index);
+		/* LCOV_EXCL_STOP */
 	}
 
 	if (signaled_end || (device_time >= end_of_time)) {
@@ -134,7 +127,7 @@ void hwm_main_loop(void)
 	while (1) {
 		hwm_sleep_until_next_timer();
 
-		switch (next_timer_index) {
+		switch (next_timer_index) { /* LCOV_EXCL_BR_LINE */
 		case HWTIMER:
 			hwtimer_timer_reached();
 			break;
@@ -142,9 +135,11 @@ void hwm_main_loop(void)
 			hw_irq_ctrl_timer_triggered();
 			break;
 		default:
+			/* LCOV_EXCL_START */
 			posix_print_error_and_exit(
 					"next_timer_index corrupted\n");
 			break;
+			/* LCOV_EXCL_STOP */
 		}
 
 		hwm_find_next_timer();

--- a/boards/posix/native_posix/irq_handler.c
+++ b/boards/posix/native_posix/irq_handler.c
@@ -11,12 +11,13 @@
 #include "irq_handler.h"
 #include "irq_offload.h"
 #include "kernel_structs.h"
+#include "kernel_internal.h"
 #include "irq_ctrl.h"
 #include "posix_core.h"
 #include "board_soc.h"
 #include "sw_isr_table.h"
 #include "soc.h"
-
+#include "logging/kernel_event_logger.h"
 
 typedef void (*normal_irq_f_ptr)(void *);
 typedef int (*direct_irq_f_ptr)(void);
@@ -26,9 +27,15 @@ static isr_table_entry_t irq_vector_table[N_IRQS] = { { 0 } };
 
 static int currently_running_irq = -1;
 
-
 static inline void vector_to_irq(int irq_nbr, int *may_swap)
 {
+	/*
+	 * As in this architecture an irq (code) executes in 0 time,
+	 * it is a bit senseless to call _int_latency_start/stop()
+	 */
+	/* _int_latency_start(); */
+	_sys_k_event_logger_interrupt();
+
 	if (irq_vector_table[irq_nbr].func == NULL) {
 		posix_print_error_and_exit("Received irq %i without a "
 					"registered handler\n",
@@ -38,15 +45,15 @@ static inline void vector_to_irq(int irq_nbr, int *may_swap)
 			*may_swap |= ((direct_irq_f_ptr)
 					irq_vector_table[irq_nbr].func)();
 		} else {
+#ifdef CONFIG_SYS_POWER_MANAGEMENT
+			posix_irq_check_idle_exit();
+#endif
 			((normal_irq_f_ptr)irq_vector_table[irq_nbr].func)
 					(irq_vector_table[irq_nbr].param);
 			*may_swap = 1;
-			/*
-			 * TODO: look into how this kind of ISRs are meant
-			 * to be wrapped
-			 */
 		}
 	}
+	/* _int_latency_stop(); */
 }
 
 /**
@@ -61,7 +68,7 @@ void posix_irq_handler(void)
 {
 	uint64_t irq_lock;
 	int irq_nbr;
-	int may_swap = 0;
+	static int may_swap;
 
 	irq_lock = hw_irq_ctrl_get_current_lock();
 
@@ -70,7 +77,13 @@ void posix_irq_handler(void)
 		return;
 	}
 
+	if (_kernel.nested == 0) {
+		may_swap = 0;
+	}
+
 	_kernel.nested++;
+
+	_sys_k_event_logger_exit_sleep();
 
 	while ((irq_nbr = hw_irq_ctrl_get_highest_prio_irq()) != -1) {
 		int last_current_running_prio = hw_irq_ctrl_get_cur_prio();
@@ -94,15 +107,14 @@ void posix_irq_handler(void)
 	 * 3) Current thread is preemptible
 	 * 4) Next thread to run in the ready queue is not this thread
 	 */
-	if (may_swap &&
-		(hw_irq_ctrl_get_cur_prio() == 256) &&
-		(_current->base.preempt < _NON_PREEMPT_THRESHOLD) &&
-		(_kernel.ready_q.cache != _current)) {
+	if (may_swap
+		&& (hw_irq_ctrl_get_cur_prio() == 256)
+		&& (_current->base.preempt < _NON_PREEMPT_THRESHOLD)
+		&& (_kernel.ready_q.cache != _current)) {
 
-		__swap(irq_lock);
+		_Swap(irq_lock);
 	}
 }
-
 
 /**
  * Thru this function the IRQ controller can raise an immediate  interrupt which
@@ -125,7 +137,6 @@ void posix_irq_handler_im_from_sw(void)
 		posix_irq_handler();
 	}
 }
-
 
 /**
  * @brief Disable all interrupts on the CPU
@@ -222,8 +233,6 @@ int posix_get_current_irq(void)
 	return currently_running_irq;
 }
 
-
-
 /**
  * Configure a static interrupt.
  *
@@ -248,7 +257,6 @@ void _isr_declare(unsigned int irq_p, int flags, void isr_p(void *),
 	irq_vector_table[irq_p].flags = flags;
 }
 
-
 /*
  * @internal
  *
@@ -263,8 +271,6 @@ void _irq_priority_set(unsigned int irq, unsigned int prio, uint32_t flags)
 	hw_irq_ctrl_prio_set(irq, prio);
 }
 
-
-
 /**
  * Similar to ARM's NVIC_SetPendingIRQ
  * set a pending IRQ from SW
@@ -277,7 +283,6 @@ void posix_sw_set_pending_IRQ(unsigned int IRQn)
 {
 	hw_irq_ctrl_raise_im_from_sw(IRQn);
 }
-
 
 /**
  * Similar to ARM's NVIC_ClearPendingIRQ

--- a/boards/posix/native_posix/irq_handler.c
+++ b/boards/posix/native_posix/irq_handler.c
@@ -36,10 +36,12 @@ static inline void vector_to_irq(int irq_nbr, int *may_swap)
 	/* _int_latency_start(); */
 	_sys_k_event_logger_interrupt();
 
-	if (irq_vector_table[irq_nbr].func == NULL) {
+	if (irq_vector_table[irq_nbr].func == NULL) { /* LCOV_EXCL_BR_LINE */
+		/* LCOV_EXCL_START */
 		posix_print_error_and_exit("Received irq %i without a "
 					"registered handler\n",
 					irq_nbr);
+		/* LCOV_EXCL_STOP */
 	} else {
 		if (irq_vector_table[irq_nbr].flags & ISR_FLAG_DIRECT) {
 			*may_swap |= ((direct_irq_f_ptr)
@@ -129,10 +131,12 @@ void posix_irq_handler_im_from_sw(void)
 	 * handler
 	 */
 	if (hw_irq_ctrl_get_highest_prio_irq() != -1) {
-		if (!posix_is_cpu_running()) {
-			posix_print_error_and_exit("programming error: "
-					"nrf_irq_cont_handler_irq_im_from_sw() "
-					"called from a HW model thread\n");
+		if (!posix_is_cpu_running()) { /* LCOV_EXCL_BR_LINE */
+			/* LCOV_EXCL_START */
+			posix_print_error_and_exit("programming error: %s "
+					"called from a HW model thread\n",
+					__func__);
+			/* LCOV_EXCL_STOP */
 		}
 		posix_irq_handler();
 	}
@@ -221,11 +225,6 @@ void _arch_irq_disable(unsigned int irq)
 int _arch_irq_is_enabled(unsigned int irq)
 {
 	return hw_irq_ctrl_is_irq_enabled(irq);
-}
-
-void _arch_isr_direct_header(void)
-{
-	/* Nothing to be done */
 }
 
 int posix_get_current_irq(void)

--- a/boards/posix/native_posix/timer_model.c
+++ b/boards/posix/native_posix/timer_model.c
@@ -25,8 +25,8 @@ u64_t hw_timer_timer;
 u64_t hw_timer_tick_timer;
 u64_t hw_timer_awake_timer;
 
-static u64_t tick_p = 10000; /* period of the ticker */
-static unsigned int silent_ticks;
+static u64_t tick_p; /* Period of the ticker */
+static s64_t silent_ticks;
 
 #if (CONFIG_NATIVE_POSIX_SLOWDOWN_TO_REAL_TIME)
 #include <time.h>
@@ -35,16 +35,17 @@ static u64_t Boot_time;
 static struct timespec tv;
 #endif
 
+extern u64_t posix_get_hw_cycle(void);
+
 static void hwtimer_update_timer(void)
 {
 	hw_timer_timer = min(hw_timer_tick_timer, hw_timer_awake_timer);
 }
 
-
 void hwtimer_init(void)
 {
 	silent_ticks = 0;
-	hw_timer_tick_timer = tick_p;
+	hw_timer_tick_timer = NEVER;
 	hw_timer_awake_timer = NEVER;
 	hwtimer_update_timer();
 #if (CONFIG_NATIVE_POSIX_SLOWDOWN_TO_REAL_TIME)
@@ -53,10 +54,17 @@ void hwtimer_init(void)
 #endif
 }
 
-
 void hwtimer_cleanup(void)
 {
 
+}
+
+void hwtimer_enable(u64_t period)
+{
+	tick_p = period;
+	hw_timer_tick_timer = hwm_get_time() + tick_p;
+	hwtimer_update_timer();
+	hwm_find_next_timer();
 }
 
 static void hwtimer_tick_timer_reached(void)
@@ -90,7 +98,6 @@ static void hwtimer_tick_timer_reached(void)
 	}
 }
 
-
 static void hwtimer_awake_timer_reached(void)
 {
 	hw_timer_awake_timer = NEVER;
@@ -111,7 +118,6 @@ void hwtimer_timer_reached(void)
 	}
 }
 
-
 /**
  * The timer HW will awake the CPU (without an interrupt) at least when <time>
  * comes (it may awake it earlier)
@@ -128,10 +134,21 @@ void hwtimer_wake_in_time(u64_t time)
 	}
 }
 
-
-void hwtimer_set_silent_ticks(int sys_ticks)
+/**
+ * The kernel wants to skip the next sys_ticks tick interrupts
+ * If sys_ticks == 0, the next interrupt will be raised.
+ * A negative number will silence the tick interrupts effectively forever
+ */
+void hwtimer_set_silent_ticks(s64_t sys_ticks)
 {
-	silent_ticks = sys_ticks;
+	if (sys_ticks < 0) {
+		silent_ticks = INT64_MAX;
+	} else {
+		silent_ticks = sys_ticks;
+	}
 }
 
-
+s64_t hwtimer_get_pending_silent_ticks(void)
+{
+	return silent_ticks;
+}

--- a/boards/posix/native_posix/timer_model.h
+++ b/boards/posix/native_posix/timer_model.h
@@ -17,7 +17,9 @@ void hwtimer_init(void);
 void hwtimer_cleanup(void);
 void hwtimer_timer_reached(void);
 void hwtimer_wake_in_time(u64_t time);
-void hwtimer_set_silent_ticks(int sys_ticks);
+void hwtimer_set_silent_ticks(s64_t sys_ticks);
+void hwtimer_enable(u64_t period);
+s64_t hwtimer_get_pending_silent_ticks(void);
 
 #ifdef __cplusplus
 }

--- a/tests/benchmarks/boot_time/testcase.yaml
+++ b/tests/benchmarks/boot_time/testcase.yaml
@@ -1,4 +1,5 @@
 tests:
   test:
-    arch_whitelist: x86 arm
+    arch_whitelist: x86 arm posix
     tags: benchmark
+    filter: CONFIG_SYS_CLOCK_HW_CYCLES_PER_SEC >= 1000000

--- a/tests/crypto/sha256/testcase.yaml
+++ b/tests/crypto/sha256/testcase.yaml
@@ -1,6 +1,6 @@
 tests:
   test:
-    arch_whitelist: arm arc x86
+    arch_whitelist: arm arc x86 posix
     min_ram: 48
     tags: crypto sha256
     timeout: 600

--- a/tests/kernel/common/src/clock.c
+++ b/tests/kernel/common/src/clock.c
@@ -52,6 +52,7 @@ static void tclock_uptime(void)
 
 	/**TESTPOINT: uptime delta*/
 	d64 = k_uptime_delta(&d64);
+	/* Note: this will stall if the systick period < 5ms */
 	while (k_uptime_delta(&d64) < 5)
 #if defined(CONFIG_ARCH_POSIX)
 		posix_halt_cpu();
@@ -61,6 +62,7 @@ static void tclock_uptime(void)
 
 	/**TESTPOINT: uptime delta lower 32-bit*/
 	k_uptime_delta_32(&d64);
+	/* Note: this will stall if the systick period < 5ms */
 	while (k_uptime_delta_32(&d64) < 5)
 #if defined(CONFIG_ARCH_POSIX)
 		posix_halt_cpu();

--- a/tests/kernel/tickless/tickless/testcase.yaml
+++ b/tests/kernel/tickless/tickless/testcase.yaml
@@ -3,5 +3,5 @@ tests:
     arch_exclude: nios2 riscv32
     filter: CONFIG_X86 or (CONFIG_ARM and (CONFIG_SOC_MK64F12
       or CONFIG_SOC_SERIES_SAM3X)) or (CONFIG_ARC and
-      CONFIG_SOC_QUARK_SE_C1000_SS)
+      CONFIG_SOC_QUARK_SE_C1000_SS) or CONFIG_ARCH_POSIX
     tags: core

--- a/tests/kernel/tickless/tickless_concept/src/test_tickless_sysclock.c
+++ b/tests/kernel/tickless/tickless_concept/src/test_tickless_sysclock.c
@@ -25,14 +25,14 @@ static struct k_thread tdata[NUM_THREAD];
 #ifndef CONFIG_TICKLESS_IDLE
 #define CONFIG_TICKLESS_IDLE_THRESH 20
 #endif
-/*sleep duration tickless*/
-#define SLEEP_TICKLESS (CONFIG_TICKLESS_IDLE_THRESH)
-/*sleep duration with tick*/
-#define SLEEP_TICKFUL (CONFIG_TICKLESS_IDLE_THRESH-1)
-/*slice size is set as half of the sleep duration*/
-#define SLICE_SIZE (CONFIG_TICKLESS_IDLE_THRESH >> 1)
 /*millisecond per tick*/
 #define MSEC_PER_TICK (sys_clock_us_per_tick / USEC_PER_MSEC)
+/*sleep duration tickless*/
+#define SLEEP_TICKLESS (CONFIG_TICKLESS_IDLE_THRESH * MSEC_PER_TICK)
+/*sleep duration with tick*/
+#define SLEEP_TICKFUL ((CONFIG_TICKLESS_IDLE_THRESH-1) * MSEC_PER_TICK)
+/*slice size is set as half of the sleep duration*/
+#define SLICE_SIZE ((CONFIG_TICKLESS_IDLE_THRESH >> 1) * MSEC_PER_TICK)
 /*align to millisecond boundary*/
 #if defined(CONFIG_ARCH_POSIX)
 #define ALIGN_MS_BOUNDARY() \


### PR DESCRIPTION
A few things:
* native_posix: Fix in tickless mode
* native_posix: Allow different CONFIG_SYS_CLOCK_TICKS_PER_SEC for this arch (before it could only be 100) 
* native_posix: Minor fixes in IRQ wrapping
* Fixed tests/kernel/tickless/tickless_concept: Was actually never tickless
* Added note in test/kernel/common/ : clock part will stall if tick period < 5ms
* Added the following tests to also be run in this ARCH_POSIX:
  * crypto/sha256
  * test/kernel/tickless (including adding support for this arch in test)
  * kernel/benchmark/boot_time