### PR TITLE
dts: flash: Add support for flash labels

### DIFF
--- a/dts/bindings/mtd/soc-nv-flash.yaml
+++ b/dts/bindings/mtd/soc-nv-flash.yaml
@@ -13,6 +13,12 @@ properties:
       description: compatible strings
       constraint: "soc-nv-flash"
 
+    label:
+      type: string
+      category: optional
+      description: Human readable string describing the device (used by Zephyr for API name)
+      generation: define
+
     erase-block-size:
      type: int
      description: address alignment required by flash erase operations

--- a/scripts/dts/extract_dts_includes.py
+++ b/scripts/dts/extract_dts_includes.py
@@ -850,8 +850,15 @@ def main():
         raise Exception("No information parsed from dts file.")
 
     if 'zephyr,flash' in chosen:
+        node_addr = chosen['zephyr,flash']
         extract_reg_prop(chosen['zephyr,flash'], None,
                          defs, "CONFIG_FLASH", 1024, None)
+
+        flash_keys = ["label", "write-block-size", "erase-block-size"]
+        for key in flash_keys:
+            if key in reduced[node_addr]['props']:
+                prop = reduced[node_addr]['props'][key]
+                extract_single(node_addr, None, prop, key, None, defs, "FLASH")
     else:
         # We will add address/size of 0 for systems with no flash controller
         # This is what they already do in the Kconfig options anyway


### PR DESCRIPTION
Added a label for soc-nv-flash nodes.  Made some updates to the
generation to maintain creating defines for properties like
erase-block-size and write-block-size so they we get both
FLASH_ERASE_BLOCK_SIZE and FLASH_${LABEL}_ERASE_BLOCK_SIZE (same for
WRITE_BLOCK_SIZE).

Signed-off-by: Kumar Gala <kumar.gala@linaro.org>