### PR TITLE
gitlint: use custom rule for line length violations

### DIFF
--- a/.gitlint
+++ b/.gitlint
@@ -1,6 +1,6 @@
 # All these sections are optional, edit this file as you like.
 [general]
-ignore=title-trailing-punctuation, T3, title-max-length, T1, body-hard-tab, B3
+ignore=title-trailing-punctuation, T3, title-max-length, T1, body-hard-tab, B3, B1
 # verbosity should be a value between 1 and 3, the commandline -v flags take precedence over this
 verbosity = 3
 # By default gitlint will ignore merge commits. Set to 'false' to disable.


### PR DESCRIPTION
Custom rule has some exceptions for long urls and long names in
signed-off-by.

Signed-off-by: Anas Nashif <anas.nashif@intel.com>