### PR TITLE
doc: fix misspellings in Kconfig files

### DIFF
--- a/arch/Kconfig
+++ b/arch/Kconfig
@@ -83,7 +83,7 @@ config PRIVILEGED_STACK_SIZE
 	default 256
 	depends on ARCH_HAS_USERSPACE
 	help
-	This option sets the priviliged stack region size that will be used
+	This option sets the privileged stack region size that will be used
 	in addition to the user mode thread stack.  During normal execution,
 	this region will be inaccessible from user mode.  During system calls,
 	this region will be utilized by the system call.

--- a/drivers/console/Kconfig
+++ b/drivers/console/Kconfig
@@ -229,7 +229,7 @@ config NATIVE_STDIN_PRIO
 	depends on NATIVE_POSIX_STDIN_CONSOLE
 	default 4
 	help
-	  Prioriry of the native stdin polling thread
+	  Priority of the native stdin polling thread
 
 config NATIVE_POSIX_STDOUT_CONSOLE
 	bool


### PR DESCRIPTION
Missed some misspellings during regular reviews.

Signed-off-by: David B. Kinder <david.b.kinder@intel.com>