### PR TITLE
net: lwm2m: return NOT_FOUND for unused multi-value resources

### DIFF
--- a/subsys/net/lib/lwm2m/lwm2m_engine.c
+++ b/subsys/net/lib/lwm2m/lwm2m_engine.c
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2017 Linaro Limited
- * Copyright (c) 2017 Open Source Foundries Limited.
+ * Copyright (c) 2018 Open Source Foundries Ltd.
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -1900,6 +1900,11 @@ static int lwm2m_read_handler(struct lwm2m_engine_obj_inst *obj_inst,
 	}
 
 	if (res->multi_count_var != NULL) {
+		/* if multi_count_var is 0 (none assigned) return NOT_FOUND */
+		if (*res->multi_count_var == 0) {
+			return -ENOENT;
+		}
+
 		engine_put_begin_ri(out, path);
 		loop_max = *res->multi_count_var;
 		res_inst_id_tmp = path->res_inst_id;


### PR DESCRIPTION
When attempting to read an unused multi-value resource such as
"Available Power Sources", lwm2m client return a successful coap packet
w/o any values.  This looks like a timeout to any lwm2m servers which
make sure a valid response is returned.

Let's fix this by returning the correct NOT_FOUND error code instead.

NOTE: To test this I commented out the portion of the lwm2m client
sample which initializes the LWM2M_DEVICE_PWR_SRC_TYPE_BAT_INT and
LWM2M_DEVICE_PWR_SRC_TYPE_USB values.  By default, the sample will
setup dummy values to be returned by the client.

Signed-off-by: Michael Scott <michael@opensourcefoundries.com>