### PR TITLE
net: lwm2m: add max device power source config option

### DIFF
--- a/subsys/net/lib/lwm2m/Kconfig
+++ b/subsys/net/lib/lwm2m/Kconfig
@@ -171,6 +171,15 @@ config LWM2M_RW_JSON_SUPPORT
 	help
 	  Include support for writing JSON data
 
+config LWM2M_DEVICE_PWRSRC_MAX
+	int "Maximum # of device power source records"
+	default 5
+	range 1 20
+	help
+	  This value sets the maximum number of power source data that a device
+	  can store.  These are displayed via the "Device" object /3/0/6,
+	  /3/0/7 and /3/0/8 resources.
+
 config LWM2M_DEVICE_ERROR_CODE_MAX
 	int "Maximum # of device obj error codes to store"
 	default 10


### PR DESCRIPTION
The code in the LwM2M "Device" object was checking for this max
power source config value, except that it was never added as a
Kconfig option.  Let's go ahead and add it so apps can set the
value appropriately.

Signed-off-by: Michael Scott <michael@opensourcefoundries.com>