### PR TITLE
uart: fixing pin range being too tight for the nrf52840

### DIFF
--- a/drivers/serial/Kconfig.nrf5
+++ b/drivers/serial/Kconfig.nrf5
@@ -32,6 +32,7 @@ config UART_NRF5_FLOW_CONTROL
 
 config UART_NRF5_GPIO_TX_PIN
 	int "TX Pin Number"
+	range 0 47 if SOC_NRF52840_QIAA
 	range 0 31
 	depends on UART_NRF5
 	depends on GPIO_NRF5
@@ -40,6 +41,7 @@ config UART_NRF5_GPIO_TX_PIN
 
 config UART_NRF5_GPIO_RX_PIN
 	int "RX Pin Number"
+	range 0 47 if SOC_NRF52840_QIAA
 	range 0 31
 	depends on UART_NRF5
 	depends on GPIO_NRF5
@@ -48,6 +50,7 @@ config UART_NRF5_GPIO_RX_PIN
 
 config UART_NRF5_GPIO_RTS_PIN
 	int "RTS Pin Number"
+	range 0 47 if SOC_NRF52840_QIAA
 	range 0 31
 	depends on UART_NRF5
 	depends on GPIO_NRF5
@@ -57,6 +60,7 @@ config UART_NRF5_GPIO_RTS_PIN
 
 config UART_NRF5_GPIO_CTS_PIN
 	int "CTS Pin Number"
+	range 0 47 if SOC_NRF52840_QIAA
 	range 0 31
 	depends on UART_NRF5
 	depends on GPIO_NRF5


### PR DESCRIPTION
The nrf52840 has 2 gpio ports. The pin can go up to pin1.17,
meaning there are 49 available pins. The old range 0 .. 31 did
not allow to use any pins from port 1 in serial communication.

Signed-off-by: Giuliano Franchetto <giuliano.franchetto@intellinium.com>