### PR TITLE
pwm: nrf5_sw: Fix configuration for nRF51

### DIFF
--- a/drivers/pwm/pwm_nrf5_sw.c
+++ b/drivers/pwm/pwm_nrf5_sw.c
@@ -232,11 +232,15 @@ static int pwm_nrf5_sw_init(struct device *dev)
  * NOTE: If PA/LNA feature is enabled for nRF52x, then additional two PPI
  * channels 14-15 are used by BLE controller.
  */
-/* FIXME: For nRF51, use .timer = NRF_TIMER1, .ppi_base = 7 */
 static const struct pwm_config pwm_nrf5_sw_0_config = {
+#if defined(CONFIG_SOC_SERIES_NRF51X)
+	.timer = NRF_TIMER1,
+	.ppi_base = 7,
+#else
 	.timer = NRF_TIMER2,
-	.gpiote_base = 0,
 	.ppi_base = 14,
+#endif
+	.gpiote_base = 0,
 	.map_size = PWM_0_MAP_SIZE,
 };
 


### PR DESCRIPTION
nRF51 boards require different values for the timer and ppi_base.

Signed-off-by: Johan Hedberg <johan.hedberg@intel.com>