### PR TITLE
samples: bluetooth/ipsp: Update multicast address

### DIFF
--- a/samples/bluetooth/ipsp/src/main.c
+++ b/samples/bluetooth/ipsp/src/main.c
@@ -22,8 +22,8 @@
 #include <net/udp.h>
 
 /* admin-local, dynamically allocated multicast address */
-#define MCAST_IP6ADDR { { { 0xff, 0x84, 0, 0, 0, 0, 0, 0, \
-			    0, 0, 0, 0, 0, 0, 0, 0x2 } } }
+#define MCAST_IP6ADDR { { { 0xff, 0x02, 0, 0, 0, 0, 0, 0, \
+			    0, 0, 0, 0, 0, 0, 0, 0x1 } } }
 
 struct in6_addr in6addr_mcast = MCAST_IP6ADDR;
 


### PR DESCRIPTION
With current value of IPV6 Multicast address, IPV6 mcast bind
does not succeed and IPSP use case could not work.
Change use case multicast address to match IPV6 address and
enable binding

fixes: #6050

Signed-off-by: Erwan Gouriou <erwan.gouriou@linaro.org>