### PR TITLE
sensors: DHT22(AM2302) is not being read

### DIFF
--- a/drivers/sensor/dht/dht.c
+++ b/drivers/sensor/dht/dht.c
@@ -39,7 +39,7 @@ static s8_t dht_measure_signal_duration(struct dht_data *drv_data,
 		gpio_pin_read(drv_data->gpio, CONFIG_DHT_GPIO_PIN_NUM, &val);
 		elapsed_cycles = k_cycle_get_32() - start_cycles;
 
-		if (elapsed_cycles >= max_wait_cycles) {
+		if (elapsed_cycles > max_wait_cycles) {
 			return -1;
 		}
 	} while (val == signal_val);


### PR DESCRIPTION
I am using Zephyr + Nordic nRF52 SDK + AOSONG AM2302 Sensor (DHT22) in order to validate a PoC, but DHT driver available in Zephyr is not working properly. I note that the function dht_measure_signal_duration was returning -1 in every call of dht_sample_fetch procedure, and this was because of the condition to wait the configured PIN to be read was achieving the max cycles allowed. 

The Nordic board has CONFIG_SYS_CLOCK_HW_CYCLES_PER_SEC set as 32768, so the max_wait_cycles variable is defined as 3. Apparently, the DHT22 sensor needs one more iteration in the loop in order to get the read successfully.