### PR TITLE
Bluetooth: controller: Fix disabling of Coded PHY feature

### DIFF
--- a/subsys/bluetooth/controller/hal/nrf5/radio/radio_nrf52840.h
+++ b/subsys/bluetooth/controller/hal/nrf5/radio/radio_nrf52840.h
@@ -404,28 +404,39 @@ static inline u32_t hal_radio_phy_mode_get(u8_t phy, u8_t flags)
 	case BIT(0):
 	default:
 		mode = RADIO_MODE_MODE_Ble_1Mbit;
+
+#if defined(CONFIG_BT_CTLR_PHY_CODED)
 		/* Workaround: nRF52840 Engineering A Errata ID 164 */
 		*(volatile u32_t *)0x4000173c &= ~0x80000000;
+#endif /* CONFIG_BT_CTLR_PHY_CODED */
+
 		break;
 
 	case BIT(1):
+		mode = RADIO_MODE_MODE_Ble_2Mbit;
+
+#if defined(CONFIG_BT_CTLR_PHY_CODED)
 		/* Workaround: nRF52840 Engineering A Errata ID 164 */
 		*(volatile u32_t *)0x4000173c &= ~0x80000000;
-		mode = RADIO_MODE_MODE_Ble_2Mbit;
+#endif /* CONFIG_BT_CTLR_PHY_CODED */
+
 		break;
 
+#if defined(CONFIG_BT_CTLR_PHY_CODED)
 	case BIT(2):
 		if (flags & 0x01) {
 			mode = RADIO_MODE_MODE_Ble_LR125Kbit;
 		} else {
 			mode = RADIO_MODE_MODE_Ble_LR500Kbit;
 		}
+
 		/* Workaround: nRF52840 Engineering A Errata ID 164 */
 		*(volatile u32_t *)0x4000173c |= 0x80000000;
 		*(volatile u32_t *)0x4000173c =
 				((*(volatile u32_t *)0x4000173c) & 0xFFFFFF00) |
 				0x5C;
 		break;
+#endif /* CONFIG_BT_CTLR_PHY_CODED */
 	}
 
 	return mode;
@@ -439,12 +450,15 @@ static inline u32_t hal_radio_tx_ready_delay_us_get(u8_t phy, u8_t flags)
 		return HAL_RADIO_NRF52840_TXEN_TXIDLE_TX_1M_US;
 	case BIT(1):
 		return HAL_RADIO_NRF52840_TXEN_TXIDLE_TX_2M_US;
+
+#if defined(CONFIG_BT_CTLR_PHY_CODED)
 	case BIT(2):
 		if (flags & 0x01) {
 			return HAL_RADIO_NRF52840_TXEN_TXIDLE_TX_S8_US;
 		} else {
 			return HAL_RADIO_NRF52840_TXEN_TXIDLE_TX_S2_US;
 		}
+#endif /* CONFIG_BT_CTLR_PHY_CODED */
 	}
 }
 
@@ -456,12 +470,15 @@ static inline u32_t hal_radio_rx_ready_delay_us_get(u8_t phy, u8_t flags)
 		return HAL_RADIO_NRF52840_RXEN_RXIDLE_RX_1M_US;
 	case BIT(1):
 		return HAL_RADIO_NRF52840_RXEN_RXIDLE_RX_2M_US;
+
+#if defined(CONFIG_BT_CTLR_PHY_CODED)
 	case BIT(2):
 		if (flags & 0x01) {
 			return HAL_RADIO_NRF52840_RXEN_RXIDLE_RX_S8_US;
 		} else {
 			return HAL_RADIO_NRF52840_RXEN_RXIDLE_RX_S2_US;
 		}
+#endif /* CONFIG_BT_CTLR_PHY_CODED */
 	}
 }
 
@@ -473,12 +490,15 @@ static inline u32_t hal_radio_tx_chain_delay_us_get(u8_t phy, u8_t flags)
 		return HAL_RADIO_NRF52840_TX_CHAIN_DELAY_1M_US;
 	case BIT(1):
 		return HAL_RADIO_NRF52840_TX_CHAIN_DELAY_2M_US;
+
+#if defined(CONFIG_BT_CTLR_PHY_CODED)
 	case BIT(2):
 		if (flags & 0x01) {
 			return HAL_RADIO_NRF52840_TX_CHAIN_DELAY_S8_US;
 		} else {
 			return HAL_RADIO_NRF52840_TX_CHAIN_DELAY_S2_US;
 		}
+#endif /* CONFIG_BT_CTLR_PHY_CODED */
 	}
 }
 
@@ -490,12 +510,15 @@ static inline u32_t hal_radio_rx_chain_delay_us_get(u8_t phy, u8_t flags)
 		return HAL_RADIO_NRF52840_RX_CHAIN_DELAY_1M_US;
 	case BIT(1):
 		return HAL_RADIO_NRF52840_RX_CHAIN_DELAY_2M_US;
+
+#if defined(CONFIG_BT_CTLR_PHY_CODED)
 	case BIT(2):
 		if (flags & 0x01) {
 			return HAL_RADIO_NRF52840_RX_CHAIN_DELAY_S8_US;
 		} else {
 			return HAL_RADIO_NRF52840_RX_CHAIN_DELAY_S2_US;
 		}
+#endif /* CONFIG_BT_CTLR_PHY_CODED */
 	}
 }
 
@@ -507,12 +530,15 @@ static inline u32_t hal_radio_tx_ready_delay_ns_get(u8_t phy, u8_t flags)
 		return HAL_RADIO_NRF52840_TXEN_TXIDLE_TX_1M_NS;
 	case BIT(1):
 		return HAL_RADIO_NRF52840_TXEN_TXIDLE_TX_2M_NS;
+
+#if defined(CONFIG_BT_CTLR_PHY_CODED)
 	case BIT(2):
 		if (flags & 0x01) {
 			return HAL_RADIO_NRF52840_TXEN_TXIDLE_TX_S8_NS;
 		} else {
 			return HAL_RADIO_NRF52840_TXEN_TXIDLE_TX_S2_NS;
 		}
+#endif /* CONFIG_BT_CTLR_PHY_CODED */
 	}
 }
 
@@ -524,12 +550,15 @@ static inline u32_t hal_radio_rx_ready_delay_ns_get(u8_t phy, u8_t flags)
 		return HAL_RADIO_NRF52840_RXEN_RXIDLE_RX_1M_NS;
 	case BIT(1):
 		return HAL_RADIO_NRF52840_RXEN_RXIDLE_RX_2M_NS;
+
+#if defined(CONFIG_BT_CTLR_PHY_CODED)
 	case BIT(2):
 		if (flags & 0x01) {
 			return HAL_RADIO_NRF52840_RXEN_RXIDLE_RX_S8_NS;
 		} else {
 			return HAL_RADIO_NRF52840_RXEN_RXIDLE_RX_S2_NS;
 		}
+#endif /* CONFIG_BT_CTLR_PHY_CODED */
 	}
 }
 
@@ -541,12 +570,15 @@ static inline u32_t hal_radio_tx_chain_delay_ns_get(u8_t phy, u8_t flags)
 		return HAL_RADIO_NRF52840_TX_CHAIN_DELAY_1M_NS;
 	case BIT(1):
 		return HAL_RADIO_NRF52840_TX_CHAIN_DELAY_2M_NS;
+
+#if defined(CONFIG_BT_CTLR_PHY_CODED)
 	case BIT(2):
 		if (flags & 0x01) {
 			return HAL_RADIO_NRF52840_TX_CHAIN_DELAY_S8_NS;
 		} else {
 			return HAL_RADIO_NRF52840_TX_CHAIN_DELAY_S2_NS;
 		}
+#endif /* CONFIG_BT_CTLR_PHY_CODED */
 	}
 }
 
@@ -558,11 +590,14 @@ static inline u32_t hal_radio_rx_chain_delay_ns_get(u8_t phy, u8_t flags)
 		return HAL_RADIO_NRF52840_RX_CHAIN_DELAY_1M_NS;
 	case BIT(1):
 		return HAL_RADIO_NRF52840_RX_CHAIN_DELAY_2M_NS;
+
+#if defined(CONFIG_BT_CTLR_PHY_CODED)
 	case BIT(2):
 		if (flags & 0x01) {
 			return HAL_RADIO_NRF52840_RX_CHAIN_DELAY_S8_NS;
 		} else {
 			return HAL_RADIO_NRF52840_RX_CHAIN_DELAY_S2_NS;
 		}
+#endif /* CONFIG_BT_CTLR_PHY_CODED */
 	}
 }


### PR DESCRIPTION
Fix conditional compilation in nRF5 radio interface so that
when Coded PHY feature is not selected then it does not use
the PPIs required for supporting the feature.

This will allow pwm_nrf5_sw driver to use PPI channels 14 to
19 and support 3 PWM channels. Without the Coded PHY feature
disabled, only PPI 14, 15, 18 and 19 are available for PWM.

Signed-off-by: Vinayak Kariappa Chettimada <vich@nordicsemi.no>