### PR TITLE
clock_control: nrf5: Return -EBUSY on turning off if still in use

### DIFF
--- a/drivers/clock_control/nrf5_power_clock.c
+++ b/drivers/clock_control/nrf5_power_clock.c
@@ -115,7 +115,7 @@ static int _m16src_stop(struct device *dev, clock_control_subsys_t sub_system)
 
 	if (--m16src_ref) {
 		irq_unlock(imask);
-		return 0;
+		return -EBUSY;
 	}
 
 	if (m16src_grd) {


### PR DESCRIPTION
Fix return value to -EBUSY instead of 0 when releasing a
reference but not physically turning off the clock.

Signed-off-by: Vinayak Kariappa Chettimada <vich@nordicsemi.no>