### PR TITLE
Fix nucleo flash support

### DIFF
--- a/boards/arm/nucleo_f412zg/board.cmake
+++ b/boards/arm/nucleo_f412zg/board.cmake
@@ -1,0 +1,1 @@
+include(${ZEPHYR_BASE}/boards/common/openocd.board.cmake)

--- a/boards/arm/nucleo_f412zg/doc/nucleo412zg.rst
+++ b/boards/arm/nucleo_f412zg/doc/nucleo412zg.rst
@@ -148,8 +148,7 @@ Programming and Debugging
 *************************
 
 Nucleo F412ZG board includes an ST-LINK/V2-1 embedded debug tool interface.
-However this interface is currently not supported by OpenOCD. You will need
-to use ST tools or an external JTAG probe.
+This interface is supported by the openocd version included in Zephyr SDK.
 
 
 .. _Nucleo F412ZG website:

--- a/boards/arm/nucleo_f412zg/support/openocd.cfg
+++ b/boards/arm/nucleo_f412zg/support/openocd.cfg
@@ -1,0 +1,12 @@
+source [find board/st_nucleo_f4.cfg]
+
+$_TARGETNAME configure -event gdb-attach {
+        echo "Debugger attaching: halting execution"
+        reset halt
+        gdb_breakpoint_override hard
+}
+
+$_TARGETNAME configure -event gdb-detach {
+        echo "Debugger detaching: resuming execution"
+        resume
+}

--- a/boards/arm/nucleo_f413zh/board.cmake
+++ b/boards/arm/nucleo_f413zh/board.cmake
@@ -1,0 +1,1 @@
+include(${ZEPHYR_BASE}/boards/common/openocd.board.cmake)

--- a/boards/arm/nucleo_f413zh/doc/nucleof413zh.rst
+++ b/boards/arm/nucleo_f413zh/doc/nucleof413zh.rst
@@ -148,8 +148,7 @@ Programming and Debugging
 *************************
 
 Nucleo F413ZH board includes an ST-LINK/V2-1 embedded debug tool interface.
-However this interface is currently not supported by OpenOCD. You will need
-to use ST tools or an external JTAG probe.
+This interface is supported by the openocd version included in Zephyr SDK.
 
 
 .. _Nucleo F413ZH website:

--- a/boards/arm/nucleo_f413zh/support/openocd.cfg
+++ b/boards/arm/nucleo_f413zh/support/openocd.cfg
@@ -1,0 +1,12 @@
+source [find board/st_nucleo_f4.cfg]
+
+$_TARGETNAME configure -event gdb-attach {
+        echo "Debugger attaching: halting execution"
+        reset halt
+        gdb_breakpoint_override hard
+}
+
+$_TARGETNAME configure -event gdb-detach {
+        echo "Debugger detaching: resuming execution"
+        resume
+}

--- a/boards/arm/nucleo_f429zi/doc/nucleof429zi.rst
+++ b/boards/arm/nucleo_f429zi/doc/nucleof429zi.rst
@@ -168,8 +168,7 @@ Programming and Debugging
 *************************
 
 The Nucleo F429ZI board includes an ST-LINK/V2-1 embedded debug tool interface.
-However this interface is currently not supported by OpenOCD. You will need
-to use ST tools or an external JTAG probe.
+This interface is supported by the openocd version included in Zephyr SDK.
 
 
 .. _Nucleo F429ZI website:


### PR DESCRIPTION
Some nucleo boards were missing config files for openocd support.
Fix this and update doc

Fixes #5766