### PR TITLE
codeowners: Add anaz and sebo as codeowner to zephyr/CMakeLists.txt

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -59,6 +59,7 @@ boards/x86/quark_se_c1000_devboard/*     @nashif
 boards/xtensa/*                          @andrewboie
 # All cmake related files
 cmake/*                                  @nashif @SebastianBoe
+CMakeLists.txt                           @nashif @SebastianBoe
 doc/*                                    @dbkinder
 doc/subsystems/bluetooth/*               @sjanc @jhedberg @Vudentz
 drivers/*/*qmsi*                         @nashif


### PR DESCRIPTION
The toplevel CMakeLists.txt file is a core build system file akin to
the files in cmake/* and whoever is codeowner for cmake/* should also
be code owner for this file.

Signed-off-by: Sebastian Bøe <sebastian.boe@nordicsemi.no>