### PR TITLE
 board: arm: olimexino_stm32: Add PWM1

### DIFF
--- a/boards/arm/olimexino_stm32/Kconfig.defconfig
+++ b/boards/arm/olimexino_stm32/Kconfig.defconfig
@@ -34,4 +34,11 @@ config SPI_1
 
 endif # SPI
 
+if PWM
+
+config PWM_STM32_1
+	default y
+
+endif # PWM
+
 endif # BOARD_OLIMEXINO_STM32

--- a/boards/arm/olimexino_stm32/pinmux.c
+++ b/boards/arm/olimexino_stm32/pinmux.c
@@ -36,6 +36,9 @@ static const struct pin_config pinconf[] = {
 	{STM32_PIN_PA6, STM32F1_PINMUX_FUNC_PA6_SPI1_MASTER_MISO},
 	{STM32_PIN_PA7, STM32F1_PINMUX_FUNC_PA7_SPI1_MASTER_MOSI},
 #endif
+#ifdef CONFIG_PWM_STM32_1
+	{STM32_PIN_PA8, STM32F1_PINMUX_FUNC_PA8_PWM1_CH1},
+#endif /* CONFIG_PWM_STM32_1 */
 };
 
 static int pinmux_stm32_init(struct device *port)

--- a/boards/arm/olimexino_stm32/pinmux.c
+++ b/boards/arm/olimexino_stm32/pinmux.c
@@ -12,7 +12,7 @@
 
 #include <pinmux/stm32/pinmux_stm32.h>
 
-/* pin assignments for NUCLEO-F103RB board */
+/* pin assignments for OLIMEXINO-STM32 board */
 static const struct pin_config pinconf[] = {
 #ifdef CONFIG_UART_STM32_PORT_1
 	{STM32_PIN_PA9,  STM32F1_PINMUX_FUNC_PA9_USART1_TX},


### PR DESCRIPTION
Adds PWM1 on olimexino_stm32. Tested it using sample basic/fade_led.
It also updates a comment in pinmux.c with the correct board name.
