### PR TITLE
CI: also generate coverage for unit tests

### DIFF
--- a/.shippable.yml
+++ b/.shippable.yml
@@ -78,7 +78,7 @@ build:
       - >
          if [ "$MATRIX_BUILD" = "1" ]; then
             gcovr -r ${ZEPHYR_BASE} -x > shippable/codecoverage/coverage.xml;
-            lcov --capture --directory sanity-out/native_posix/ --output-file lcov.pre.info -q --rc lcov_branch_coverage=1;
+            lcov --capture --directory sanity-out/native_posix/ --directory sanity-out/unit_testing/ --output-file lcov.pre.info -q --rc lcov_branch_coverage=1;
             lcov -q --remove lcov.pre.info *generated* -o lcov.info --rc lcov_branch_coverage=1;
             rm lcov.pre.info;
             rm -rf sanity-out out-2nd-pass;
@@ -103,7 +103,7 @@ build:
       - >
          if [ "$MATRIX_BUILD" = "1" ]; then
             gcovr -r ${ZEPHYR_BASE} -x > shippable/codecoverage/coverage.xml;
-            lcov --capture --directory sanity-out/native_posix/ --output-file lcov.pre.info -q --rc lcov_branch_coverage=1;
+            lcov --capture --directory sanity-out/native_posix/ --directory sanity-out/unit_testing/ --output-file lcov.pre.info -q --rc lcov_branch_coverage=1;
             lcov -q --remove lcov.pre.info *generated* -o lcov.info --rc lcov_branch_coverage=1;
             rm lcov.pre.info;
             rm -rf sanity-out out-2nd-pass;

--- a/scripts/sanitycheck
+++ b/scripts/sanitycheck
@@ -950,8 +950,8 @@ class MakeGenerator:
         build_logfile = os.path.join(outdir, "build.log")
         run_logfile = os.path.join(outdir, "run.log")
         handler_logfile = os.path.join(outdir, "handler.log")
-        if coverage:
-            args += ["COVERAGE=1"]
+
+        args += ["COVERAGE=1", "EXTRA_LDFLAGS=--coverage"]
 
         # we handle running in the UnitHandler class
         text = (self._get_rule_header(name) +
@@ -2393,15 +2393,15 @@ def main():
                     reason))
 
 
-    def native_posix_first(a, b):
-        if a[0].startswith('native_posix'):
+    def native_posix_and_unit_first(a, b):
+        if a[0].startswith('native_posix') or a[0].startswith('unit_testing'):
             return -1
-        if b[0].startswith('native_posix'):
+        if b[0].startswith('native_posix') or b[0].startswith('unit_testing'):
             return 1
         return (a > b) - (a < b)
 
     ts.instances = OrderedDict(sorted(ts.instances.items(),
-                               key=cmp_to_key(native_posix_first)))
+                               key=cmp_to_key(native_posix_and_unit_first)))
 
     if options.save_tests:
         ts.run_report(options.save_tests)


### PR DESCRIPTION
sanitycheck: Compile unit tests with coverage enabled always. + Run first also unit tests (together with native_posix tests).
shippable: also include unit_testing coverage into report to codecov

Signed-off-by: Alberto Escolar Piedras <alpi@oticon.com>