### PR TITLE
subsys: storage: flash_map - Use correct macro

### DIFF
--- a/subsys/storage/flash_map/flash_map.c
+++ b/subsys/storage/flash_map/flash_map.c
@@ -32,7 +32,7 @@ struct driver_map_entry {
 };
 
 static const struct driver_map_entry  flash_drivers_map[] = {
-#ifdef FLASH_DRIVER_NAME /* SoC embedded flash driver */
+#ifdef FLASH_DEV_NAME /* SoC embedded flash driver */
 	{SOC_FLASH_0_ID, FLASH_DEV_NAME},
 #endif
 #ifdef CONFIG_SPI_FLASH_W25QXXDV


### PR DESCRIPTION
Prior to this commit, the old `FLASH_DRIVER_NAME` macro was being used in the definition of the flash drivers array.  This caused the array to have a size of 0.

This commit changes the code to use the newer `FLASH_DEV_NAME` macro, causing the configured flash device to be present in the table.