### PR TITLE
drivers: i2c: i2c_nios2: Fix SYS_LOG warnings

### DIFF
--- a/drivers/i2c/i2c_nios2.c
+++ b/drivers/i2c/i2c_nios2.c
@@ -8,9 +8,11 @@
 #include <i2c.h>
 #include <soc.h>
 #include <misc/util.h>
-#include <logging/sys_log.h>
 #include <altera_common.h>
 #include "altera_avalon_i2c.h"
+
+#define SYS_LOG_LEVEL CONFIG_SYS_LOG_I2C_LEVEL
+#include <logging/sys_log.h>
 
 #define NIOS2_I2C_TIMEOUT_USEC		1000
 


### PR DESCRIPTION
Fix sys log compilation warnings by defining the
SYS_LOG_LEVEL to SYS_LOG_I2C_LEVEL in Nios-II i2c driver.

This commit fixes Issue #6062

Signed-off-by: Ramakrishna Pallala <ramakrishna.pallala@intel.com>