### PR TITLE
drivers: i2c: i2c_nios2: Fix format specifiers in log messages

### DIFF
--- a/drivers/i2c/i2c_nios2.c
+++ b/drivers/i2c/i2c_nios2.c
@@ -106,7 +106,7 @@ static int i2c_nios2_transfer(struct device *dev, struct i2c_msg *msgs,
 		 * start successfully e.g., if the bus was busy
 		 */
 		if (status != ALT_AVALON_I2C_SUCCESS) {
-			SYS_LOG_ERR("i2c transfer error %d\n", status);
+			SYS_LOG_ERR("i2c transfer error %lu\n", status);
 			rc = -EIO;
 			goto i2c_transfer_err;
 		}
@@ -123,7 +123,7 @@ static int i2c_nios2_transfer(struct device *dev, struct i2c_msg *msgs,
 		}
 
 		if (timeout <= 0) {
-			SYS_LOG_ERR("i2c busy or timeout error %d\n", status);
+			SYS_LOG_ERR("i2c busy or timeout error %lu\n", status);
 			rc = -EIO;
 			goto i2c_transfer_err;
 		}

--- a/include/logging/sys_log.h
+++ b/include/logging/sys_log.h
@@ -37,8 +37,6 @@ extern "C" {
  */
 #if defined(CONFIG_SYS_LOG) && (SYS_LOG_LEVEL > SYS_LOG_LEVEL_OFF)
 
-#define IS_SYS_LOG_ACTIVE 1
-
 extern void (*syslog_hook)(const char *fmt, ...);
 void syslog_hook_install(void (*hook)(const char *, ...));
 
@@ -123,15 +121,6 @@ void syslog_hook_install(void (*hook)(const char *, ...));
 #endif
 
 #else
-/**
- * @def IS_SYS_LOG_ACTIVE
- *
- * @brief Specifies whether SYS_LOG is in use or not.
- *
- * @details This macro expands to 1 if SYS_LOG was activated for current .c
- * file, 0 otherwise.
- */
-#define IS_SYS_LOG_ACTIVE 0
 /**
  * @def SYS_LOG_ERR
  *


### PR DESCRIPTION
Fix format specifiers in SYS_LOG_ERR messages.

Signed-off-by: Ramakrishna Pallala <ramakrishna.pallala@intel.com>