### PR TITLE
Fix selection process of net app server context

### DIFF
--- a/include/net/net_app.h
+++ b/include/net/net_app.h
@@ -856,6 +856,19 @@ struct net_pkt *net_app_get_net_pkt(struct net_app_ctx *ctx,
 				    s32_t timeout);
 
 /**
+ * @brief Create network packet based on dst address.
+ *
+ * @param ctx Network application context.
+ * @param dst Destination address to select net_context
+ * @param timeout How long to wait the send before giving up.
+ *
+ * @return valid net_pkt if ok, NULL if error.
+ */
+struct net_pkt *net_app_get_net_pkt_with_dst(struct net_app_ctx *ctx,
+					     const struct sockaddr *dst,
+					     s32_t timeout);
+
+/**
  * @brief Create network buffer that will hold network data.
  *
  * @details The returned net_buf is automatically appended to the

--- a/subsys/net/lib/app/net_app.c
+++ b/subsys/net/lib/app/net_app.c
@@ -963,6 +963,28 @@ struct net_pkt *net_app_get_net_pkt(struct net_app_ctx *ctx,
 	return net_pkt_get_tx(net_ctx, timeout);
 }
 
+struct net_pkt *net_app_get_net_pkt_with_dst(struct net_app_ctx *ctx,
+					     const struct sockaddr *dst,
+					     s32_t timeout)
+{
+	struct net_context *net_ctx;
+
+	if (!ctx || !dst) {
+		return NULL;
+	}
+
+	if (!ctx->is_init) {
+		return NULL;
+	}
+
+	net_ctx = _net_app_select_net_ctx(ctx, dst);
+	if (!net_ctx) {
+		return NULL;
+	}
+
+	return net_pkt_get_tx(net_ctx, timeout);
+}
+
 struct net_buf *net_app_get_net_buf(struct net_app_ctx *ctx,
 				    struct net_pkt *pkt,
 				    s32_t timeout)


### PR DESCRIPTION
When net_app_ctx has multiple net_contexts, selecting net_context based on dst address has some glitches. PR provides fixes and extra API for it.