### PR TITLE
Provide a Kconfig option to select default network interface

### DIFF
--- a/subsys/net/ip/Kconfig
+++ b/subsys/net/ip/Kconfig
@@ -349,6 +349,39 @@ config NET_BUF_USER_DATA_SIZE
 	  Example: For Bluetooth, the user_data shall be at least 4 bytes as
 	  that is used for identifying the type of data they are carrying.
 
+choice
+	prompt "Default Network Interface"
+	default NET_DEFAULT_IF_FIRST
+	help
+	  If system has multiple interfaces enabled, then user shall be able
+	  to choose default interface. Otherwise first interface will be the
+	  default interface.
+
+config NET_DEFAULT_IF_FIRST
+	bool "First available interface"
+
+config NET_DEFAULT_IF_ETHERNET
+	bool "Ethernet"
+	depends on NET_L2_ETHERNET
+
+config NET_DEFAULT_IF_BLUETOOTH
+	bool "Bluetooth"
+	depends on NET_L2_BT
+
+config NET_DEFAULT_IF_IEEE802154
+	bool "IEEE 802.15.4"
+	depends on NET_L2_IEEE802154
+
+config NET_DEFAULT_IF_OFFLOAD
+	bool "Offloaded interface"
+	depends on NET_L2_OFFLOAD
+
+config NET_DEFAULT_IF_DUMMY
+	bool "Dummy testing interface"
+	depends on NET_L2_DUMMY
+
+endchoice
+
 source "subsys/net/ip/Kconfig.stack"
 
 source "subsys/net/ip/l2/Kconfig"

--- a/subsys/net/ip/net_if.c
+++ b/subsys/net/ip/net_if.c
@@ -367,11 +367,29 @@ struct net_if *net_if_lookup_by_dev(struct device *dev)
 
 struct net_if *net_if_get_default(void)
 {
+	struct net_if *iface = NULL;
+
 	if (__net_if_start == __net_if_end) {
 		return NULL;
 	}
 
-	return __net_if_start;
+#if defined(CONFIG_NET_DEFAULT_IF_ETHERNET)
+	iface = net_if_get_first_by_type(&NET_L2_GET_NAME(ETHERNET));
+#endif
+#if defined(CONFIG_NET_DEFAULT_IF_IEEE802154)
+	iface = net_if_get_first_by_type(&NET_L2_GET_NAME(IEEE802154));
+#endif
+#if defined(CONFIG_NET_DEFAULT_IF_BLUETOOTH)
+	iface = net_if_get_first_by_type(&NET_L2_GET_NAME(BLUETOOTH));
+#endif
+#if defined(CONFIG_NET_DEFAULT_IF_DUMMY)
+	iface = net_if_get_first_by_type(&NET_L2_GET_NAME(DUMMY));
+#endif
+#if defined(CONFIG_NET_DEFAULT_IF_OFFLOAD)
+	iface = net_if_get_first_by_type(&NET_L2_GET_NAME(OFFLOAD_IP));
+#endif
+
+	return iface ? iface : __net_if_start;
 }
 
 struct net_if *net_if_get_first_by_type(const struct net_l2 *l2)


### PR DESCRIPTION
Default network interface is the first interface if there are multiple
interfaces exist. But this creates an issue when different parts of
the network subsystem wants to choose particular default interface.
At-least with this Kconfig option user can select default network
interface.