### PR TITLE
codeowners: Fix CODEOWNERS for $ZEPHYR_BASE/CMakeLists.txt

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -59,7 +59,7 @@ boards/x86/quark_se_c1000_devboard/*     @nashif
 boards/xtensa/*                          @andrewboie
 # All cmake related files
 cmake/*                                  @nashif @SebastianBoe
-CMakeLists.txt                           @nashif @SebastianBoe
+/CMakeLists.txt                          @nashif @SebastianBoe
 doc/*                                    @dbkinder
 doc/subsystems/bluetooth/*               @sjanc @jhedberg @Vudentz
 drivers/*/*qmsi*                         @nashif


### PR DESCRIPTION
CMakeLists.txt @nashif @SebastianBoe

was supposed to reference only the root file, but was referencing all
files. This commit patches CODEOWNERS to behave as intended.

See https://help.github.com/articles/about-codeowners/

Signed-off-by: Sebastian Bøe <sebastian.boe@nordicsemi.no>