### PR TITLE
kconfig: Sort the glob results

### DIFF
--- a/scripts/kconfig/kconfiglib.py
+++ b/scripts/kconfig/kconfiglib.py
@@ -1055,7 +1055,11 @@ class Kconfig(object):
 
         if globbing:
             # Try globbing
-            return glob.glob(filename)
+            files =  glob.glob(filename)
+
+            # Glob results have an arbitrary order, so sort them to
+            # have consistent results across platforms.
+            return sorted(files)
 
         raise IOError(
             "Could not find '{}'. Perhaps the $srctree "


### PR DESCRIPTION
Sort the glob results when Kconfig sources do 'source
"/path/*/Kconfig"' to ensure that the resulting dotconfig file is the
same for all platforms.

This fixes #5743

Credit goes to @ulfalizer.

Signed-off-by: Carles Cufi <carles.cufi@nordicsemi.no>