### PR TITLE
Bluetooth: Mesh: Fix coverity warning with unchecked error return

### DIFF
--- a/subsys/bluetooth/host/mesh/beacon.c
+++ b/subsys/bluetooth/host/mesh/beacon.c
@@ -172,9 +172,8 @@ static int unprovisioned_beacon_send(void)
 	net_buf_add_u8(buf, BEACON_TYPE_UNPROVISIONED);
 	net_buf_add_mem(buf, prov->uuid, 16);
 
-	if (prov->uri) {
+	if (prov->uri && bt_mesh_s1(prov->uri, uri_hash) == 0) {
 		oob_info = prov->oob_info | BT_MESH_PROV_OOB_URI;
-		bt_mesh_s1(prov->uri, uri_hash);
 	} else {
 		oob_info = prov->oob_info;
 	}


### PR DESCRIPTION
This fixes Coverity CID 182769.

Fixes #6102

Signed-off-by: Johan Hedberg <johan.hedberg@intel.com>