### PR TITLE
net: buf: Make net_buf_simple_init() forward compatible

### DIFF
--- a/include/net/buf.h
+++ b/include/net/buf.h
@@ -124,16 +124,14 @@ struct net_buf_simple {
  *
  *  @param buf Buffer to initialize.
  *  @param reserve_head Headroom to reserve.
- *
- *  @warning This API should *only* be used when the net_buf_simple object
- *           has been created using the NET_BUF_SIMPLE() macro. For any other
- *           kinf of creation there is no need to call this API (in fact,
- *           it will result in undefined behavior).
  */
 static inline void net_buf_simple_init(struct net_buf_simple *buf,
 				       size_t reserve_head)
 {
-	buf->__buf = (u8_t *)buf + sizeof(*buf);
+	if (!buf->__buf) {
+		buf->__buf = (u8_t *)buf + sizeof(*buf);
+	}
+
 	buf->data = buf->__buf + reserve_head;
 	buf->len = 0;
 }


### PR DESCRIPTION
Make it safe to call net_buf_simple_init() even if the buffer was
created using the new macros. This is possible to detect since with
the new macros buf->__buf will be non-NULL and with the old
NET_BUF_SIMPLE() macro it will be NULL.