### PR TITLE
Fixes and improvements to net_buf user data handling

### DIFF
--- a/subsys/bluetooth/common/dummy.c
+++ b/subsys/bluetooth/common/dummy.c
@@ -25,10 +25,10 @@ BUILD_ASSERT(CONFIG_SYSTEM_WORKQUEUE_PRIORITY < 0);
  */
 BUILD_ASSERT(CONFIG_BT_HCI_TX_PRIO < CONFIG_BT_RX_PRIO);
 
-/* The Bluetooth subsystem requires network buffers to have at least 8 bytes
+/* The Bluetooth subsystem requires network buffers to have at least 4 bytes
  * reserved for user data.
  */
-BUILD_ASSERT(CONFIG_NET_BUF_USER_DATA_SIZE >= 8);
+BUILD_ASSERT(CONFIG_NET_BUF_USER_DATA_SIZE >= 4);
 
 #if defined(CONFIG_BT_CTLR)
 /* The Bluetooth Controller's priority receive thread priority shall be higher

--- a/subsys/bluetooth/host/Kconfig
+++ b/subsys/bluetooth/host/Kconfig
@@ -187,13 +187,6 @@ config BT_CONN_TX_MAX
 	  Maximum number of pending TX buffers that have not yet
 	  been acknowledged by the controller.
 
-config BT_L2CAP_TX_USER_DATA_SIZE
-	int "Maximum supported user data size for L2CAP TX buffers"
-	default 4
-	range 4 65535
-	help
-	  Maximum supported user data size for L2CAP TX buffers.
-
 config BT_ATT_ENFORCE_FLOW
 	bool "Enforce strict flow control semantics for incoming PDUs"
 	default y

--- a/subsys/bluetooth/host/conn.c
+++ b/subsys/bluetooth/host/conn.c
@@ -35,7 +35,7 @@
 
 NET_BUF_POOL_DEFINE(acl_tx_pool, CONFIG_BT_L2CAP_TX_BUF_COUNT,
 		    BT_L2CAP_BUF_SIZE(CONFIG_BT_L2CAP_TX_MTU),
-		    CONFIG_BT_L2CAP_TX_USER_DATA_SIZE, NULL);
+		    BT_BUF_USER_DATA_MIN, NULL);
 
 /* How long until we cancel HCI_LE_Create_Connection */
 #define CONN_TIMEOUT	K_SECONDS(3)

--- a/subsys/bluetooth/host/hci_core.c
+++ b/subsys/bluetooth/host/hci_core.c
@@ -93,9 +93,6 @@ static size_t discovery_results_count;
 #endif /* CONFIG_BT_BREDR */
 
 struct cmd_data {
-	/** BT_BUF_CMD */
-	u8_t  type;
-
 	/** HCI status of the command completion */
 	u8_t  status;
 
@@ -117,7 +114,9 @@ struct acl_data {
 	u16_t handle;
 };
 
-#define cmd(buf) ((struct cmd_data *)net_buf_user_data(buf))
+static struct cmd_data cmd_data[CONFIG_BT_HCI_CMD_COUNT];
+
+#define cmd(buf) (&cmd_data[net_buf_id(buf)])
 #define acl(buf) ((struct acl_data *)net_buf_user_data(buf))
 
 /* HCI command buffers. Derive the needed size from BT_BUF_RX_SIZE since
@@ -125,7 +124,7 @@ struct acl_data {
  */
 #define CMD_BUF_SIZE BT_BUF_RX_SIZE
 NET_BUF_POOL_DEFINE(hci_cmd_pool, CONFIG_BT_HCI_CMD_COUNT,
-		    CMD_BUF_SIZE, sizeof(struct cmd_data), NULL);
+		    CMD_BUF_SIZE, BT_BUF_USER_DATA_MIN, NULL);
 
 NET_BUF_POOL_DEFINE(hci_rx_pool, CONFIG_BT_RX_BUF_COUNT,
 		    BT_BUF_RX_SIZE, BT_BUF_USER_DATA_MIN, NULL);
@@ -199,7 +198,8 @@ struct net_buf *bt_hci_cmd_create(u16_t opcode, u8_t param_len)
 
 	net_buf_reserve(buf, CONFIG_BT_HCI_RESERVE);
 
-	cmd(buf)->type = BT_BUF_CMD;
+	bt_buf_set_type(buf, BT_BUF_CMD);
+
 	cmd(buf)->opcode = opcode;
 	cmd(buf)->sync = NULL;
 

--- a/subsys/net/Kconfig
+++ b/subsys/net/Kconfig
@@ -19,8 +19,8 @@ if NET_BUF
 
 config NET_BUF_USER_DATA_SIZE
 	int "Size of user_data available in every network buffer"
-	default 0
-	range 8 65535
+	default 4
+	range 0 65535
 	help
 	  Amount of memory reserved in each network buffer for user data. In
 	  most cases this can be left as the default value.


### PR DESCRIPTION
Reduce and clean up user data handling on the Bluetooth side, and reduce the default from 8 bytes to 4 bytes (as Bluetooth was the only subsystem requiring 8 bytes).