### PR TITLE
dts/arm: Move i2c2 node inside stm32fxxx dtsi file

### DIFF
--- a/dts/arm/st/stm32f3.dtsi
+++ b/dts/arm/st/stm32f3.dtsi
@@ -99,18 +99,6 @@
 			label= "I2C_1";
 		};
 
-		i2c2: i2c@40005800 {
-			compatible = "st,stm32-i2c-v2";
-			clock-frequency = <I2C_BITRATE_STANDARD>;
-			#address-cells = <1>;
-			#size-cells = <0>;
-			reg = <0x40005800 0x400>;
-			interrupts = <33 0>, <34 0>;
-			interrupt-names = "event", "error";
-			status = "disabled";
-			label= "I2C_2";
-		};
-
 		spi1: spi@40013000 {
 			compatible = "st,stm32-spi-fifo";
 			#address-cells = <1>;

--- a/dts/arm/st/stm32f303.dtsi
+++ b/dts/arm/st/stm32f303.dtsi
@@ -8,6 +8,18 @@
 
 / {
 	soc {
+		i2c2: i2c@40005800 {
+			compatible = "st,stm32-i2c-v2";
+			clock-frequency = <I2C_BITRATE_STANDARD>;
+			#address-cells = <1>;
+			#size-cells = <0>;
+			reg = <0x40005800 0x400>;
+			interrupts = <33 0>, <34 0>;
+			interrupt-names = "event", "error";
+			status = "disabled";
+			label= "I2C_2";
+		};
+
 		spi2: spi@40003800 {
 			compatible = "st,stm32-spi-fifo";
 			#address-cells = <1>;

--- a/dts/arm/st/stm32f334.dtsi
+++ b/dts/arm/st/stm32f334.dtsi
@@ -4,4 +4,4 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <st/stm32f303.dtsi>
+#include <st/stm32f3.dtsi>

--- a/dts/arm/st/stm32f373.dtsi
+++ b/dts/arm/st/stm32f373.dtsi
@@ -5,3 +5,19 @@
  */
 
 #include <st/stm32f3.dtsi>
+
+/ {
+	soc {
+		i2c2: i2c@40005800 {
+			compatible = "st,stm32-i2c-v2";
+			clock-frequency = <I2C_BITRATE_STANDARD>;
+			#address-cells = <1>;
+			#size-cells = <0>;
+			reg = <0x40005800 0x400>;
+			interrupts = <33 0>, <34 0>;
+			interrupt-names = "event", "error";
+			status = "disabled";
+			label= "I2C_2";
+		};
+	};
+};


### PR DESCRIPTION
SoC stm32f334x8 doesn't support I2C2 port. This
patch moves i2c2 node inside stm32f303 and
stm32f373 dtsi files.

Signed-off-by: Yannis Damigos <giannis.damigos@gmail.com>