### PR TITLE
toolchain: gcc/common: add header guard

### DIFF
--- a/include/toolchain/common.h
+++ b/include/toolchain/common.h
@@ -4,6 +4,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+#ifndef TOOLCHAIN_COMMON_H
+#define TOOLCHAIN_COMMON_H
 /**
  * @file
  * @brief Common toolchain abstraction
@@ -131,3 +133,5 @@
 /* build assertion with message -- common implementation swallows message. */
 #define BUILD_ASSERT_MSG(EXPR, MSG) BUILD_ASSERT(EXPR)
 #endif
+
+#endif /* TOOLCHAIN_COMMON_H */

--- a/include/toolchain/gcc.h
+++ b/include/toolchain/gcc.h
@@ -4,6 +4,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+#ifndef TOOLCHAIN_GCC_H
+#define TOOLCHAIN_GCC_H
 /**
  * @file
  * @brief GCC toolchain abstraction
@@ -331,3 +333,5 @@ A##a:
 #define compiler_barrier() do { \
 	__asm__ __volatile__ ("" ::: "memory"); \
 } while ((0))
+
+#endif /* TOOLCHAIN_GCC_H */


### PR DESCRIPTION
Added guards to the toolchain/gcc.h and toolchain/common.h

Those files should never be included directly, but a guard is useful
regardless.

Fixes #5130

Signed-off-by: Anas Nashif <anas.nashif@intel.com>