### PR TITLE
doc: Sanitycheck command line options fixup

### DIFF
--- a/doc/subsystems/test/sanitycheck.rst
+++ b/doc/subsystems/test/sanitycheck.rst
@@ -44,12 +44,6 @@ The sanitycheck script accepts the following optional arguments:
                         the platforms specified. If this option is not used,
                         then platforms marked as default in the platform
                         metadata file will be chosen to build and test.
-  -L N, --platform-limit N
-                        Controls what platforms are tested if --platform or
-                        --all are not used. For each architecture specified by
-                        --arch (defaults to all of them), choose the first N
-                        platforms to test in the arch-specific .yaml file
-                        'platforms' list. Defaults to 1.
   -a ARCH, --arch ARCH  Arch filter for testing. Takes precedence over
                         --platform. If unspecified, test all arches. Multiple
                         invocations are treated as a logical 'or' relationship
@@ -84,12 +78,12 @@ The sanitycheck script accepts the following optional arguments:
                         skipped and why
   --compare-report COMPARE_REPORT
                         Use this report file for size comparison
-  --ccache              Enable the use of ccache when building
   -B SUBSET, --subset SUBSET
                         Only run a subset of the tests, 1/4 for running the
                         first 25%, 3/5 means run the 3rd fifth of the total.
                         This option is useful when running a large number of
                         tests on different hosts to speed up execution time.
+  -N, --ninja           Use the Ninja generator with CMake
   -y, --dry-run         Create the filtered list of test cases, but don't
                         actually run them. Useful if you're just interested in
                         --discard-report
@@ -110,6 +104,8 @@ The sanitycheck script accepts the following optional arguments:
                         invocation
   -u, --no-update       do not update the results of the last run of the
                         sanity checks
+  -F, --load-tests      Load list of tests to be run from file
+  -E, --save_tests      Save list of tests to be run to file
   -b, --build-only      Only build the code, do not execute any of it in QEMU
   -j JOBS, --jobs JOBS  Number of cores to use when building, defaults to
                         number of CPUs * 2
@@ -129,8 +125,8 @@ The sanitycheck script accepts the following optional arguments:
                         All testcase.yaml files under here will be processed.
                         May be called multiple times. Defaults to the
                         'samples' and 'tests' directories in the Zephyr tree.
-  -A ARCH_ROOT, --arch-root ARCH_ROOT
-                        Directory to search for arch configuration files. All
+  -A BOARD_ROOT, --board-root BOARD_ROOT
+                        Directory to search for board configuration files. All
                         .yaml files in the directory will be processed.
   -z SIZE, --size SIZE  Don't run sanity checks. Instead, produce a report to
                         stdout detailing RAM/ROM sizes on the specified
@@ -139,13 +135,15 @@ The sanitycheck script accepts the following optional arguments:
                         marked as 'slow' in testcase.yaml. Normally these are
                         only built.
   -R, --enable-asserts  Build all test cases with assertions enabled.
+  --disable-asserts     Build all test cases with assertions disabled.
   -Q, --error-on-deprecations
                         Error on deprecation warnings.
   -x EXTRA_ARGS, --extra-args EXTRA_ARGS
                         Extra arguments to pass to the build when compiling
                         test cases. May be called multiple times. These will
                         be passed in after any sanitycheck-supplied options.
-  -C, --coverage        Scan for unit test coverage with gcov + lcov.
+  -C, --coverage        Generate coverage report for unit tests, and tests and
+                        samples run in native_posix.
 
 
 Board Configuration

--- a/scripts/sanitycheck
+++ b/scripts/sanitycheck
@@ -2203,8 +2203,8 @@ def parse_arguments():
 
     parser.add_argument(
         "-x", "--extra-args", action="append", default=[],
-        help="""Extra CMake cache entries to define when building test cases. May
-        be called multiple times. The key-value entries will be
+        help="""Extra CMake cache entries to define when building test cases.
+        May be called multiple times. The key-value entries will be
         prefixed with -D before being passed to CMake.
 
         E.g
@@ -2217,7 +2217,8 @@ def parse_arguments():
     )
 
     parser.add_argument("-C", "--coverage", action="store_true",
-                        help="Scan for unit test coverage with gcov + lcov.")
+                        help="Generate coverage report for unit tests, and"
+                        " tests and samples run in native_posix.")
 
     return parser.parse_args()
 


### PR DESCRIPTION
Aligned sanitycheck command line options in doc with the actual ones.
+
Minor fix in --coverage description.

Signed-off-by: Alberto Escolar Piedras <alpi@oticon.com>