### PR TITLE
boards: stm32f072b_disco: add supported features

### DIFF
--- a/boards/arm/stm32f072b_disco/stm32f072b_disco.yaml
+++ b/boards/arm/stm32f072b_disco/stm32f072b_disco.yaml
@@ -7,6 +7,10 @@ flash: 128
 toolchain:
   - zephyr
   - gccarmemb
+supported:
+  - gpio
+  - i2c
+  - spi
 testing:
   ignore_tags:
     - net


### PR DESCRIPTION
Add gpio, i2c and spi as supported feaures.

Signed-off-by: Daniel Wagenknecht <wagenknecht.daniel@gmail.com>