### PR TITLE
Bluetooth: Fix regression in mesh tests

### DIFF
--- a/subsys/bluetooth/controller/ll_sw/ctrl.c
+++ b/subsys/bluetooth/controller/ll_sw/ctrl.c
@@ -277,9 +277,10 @@ static void connection_release(struct connection *conn);
 static void terminate_ind_rx_enqueue(struct connection *conn, u8_t reason);
 static u32_t conn_update(struct connection *conn, struct pdu_data *pdu_data_rx);
 
-#if defined(CONFIG_BT_CTLR_SCHED_ADVANCED)
+#if defined(CONFIG_BT_CTLR_XTAL_ADVANCED) && \
+    defined(CONFIG_BT_CTLR_SCHED_ADVANCED)
 static u32_t conn_update_req(struct connection *conn);
-#endif /* CONFIG_BT_CTLR_SCHED_ADVANCED */
+#endif /* CONFIG_BT_CTLR_XTAL_ADVANCED && CONFIG_BT_CTLR_SCHED_ADVANCED */
 
 static u32_t chan_map_update(struct connection *conn,
 			     struct pdu_data *pdu_data_rx);
@@ -9050,7 +9051,8 @@ static u32_t conn_update(struct connection *conn, struct pdu_data *pdu_data_rx)
 	return 0;
 }
 
-#if defined(CONFIG_BT_CTLR_SCHED_ADVANCED)
+#if defined (CONFIG_BT_CTLR_XTAL_ADVANCED) && \
+    defined(CONFIG_BT_CTLR_SCHED_ADVANCED)
 static u32_t conn_update_req(struct connection *conn)
 {
 	if (conn->llcp_req != conn->llcp_ack) {
@@ -9103,7 +9105,7 @@ static u32_t conn_update_req(struct connection *conn)
 
 	return 2;
 }
-#endif /* CONFIG_BT_CTLR_SCHED_ADVANCED */
+#endif /* CONFIG_BT_CTLR_XTAL_ADVANCED && CONFIG_BT_CTLR_SCHED_ADVANCED */
 
 static u32_t chan_map_update(struct connection *conn,
 			     struct pdu_data *pdu_data_rx)

--- a/subsys/bluetooth/controller/ll_sw/ctrl.c
+++ b/subsys/bluetooth/controller/ll_sw/ctrl.c
@@ -3908,6 +3908,23 @@ static inline u32_t isr_close_adv(void)
 				  (_radio.ticker_id_stop ==
 				   RADIO_TICKER_ID_ADV));
 		}
+
+#if defined(CONFIG_BT_CTLR_ADV_INDICATION)
+		if (1) {
+			struct radio_pdu_node_rx *node_rx;
+
+			node_rx = packet_rx_reserve_get(3);
+			if (node_rx) {
+				node_rx->hdr.type = NODE_RX_TYPE_ADV_INDICATION;
+				node_rx->hdr.handle = 0xFFFF;
+				/* TODO: add other info by defining a payload
+				 * structure.
+				 */
+
+				packet_rx_enqueue();
+			}
+		}
+#endif /* CONFIG_BT_CTLR_ADV_INDICATION */
 	}
 
 	return dont_close;
@@ -4262,24 +4279,6 @@ static inline void isr_radio_state_close(void)
 	switch (_radio.role) {
 	case ROLE_ADV:
 		dont_close = isr_close_adv();
-
-#if defined(CONFIG_BT_CTLR_ADV_INDICATION)
-		if (!dont_close) {
-			struct radio_pdu_node_rx *node_rx;
-
-			node_rx = packet_rx_reserve_get(3);
-			if (node_rx) {
-				node_rx->hdr.type = NODE_RX_TYPE_ADV_INDICATION;
-				node_rx->hdr.handle = 0xFFFF;
-				/* TODO: add other info by defining a payload
-				 * structure.
-				 */
-
-				packet_rx_enqueue();
-			}
-		}
-#endif /* CONFIG_BT_CTLR_ADV_INDICATION */
-
 		break;
 
 	case ROLE_SCAN:

--- a/subsys/bluetooth/controller/ticker/ticker.c
+++ b/subsys/bluetooth/controller/ticker/ticker.c
@@ -834,6 +834,20 @@ static inline u32_t ticker_job_insert(struct ticker_instance *instance,
 			ticker->ticks_to_expire += ticker->ticks_periodic +
 						   ticker_remainder_inc(ticker);
 			ticker->lazy_current++;
+
+			/* Remove any accumulated drift (possibly added due to
+			 * ticker job execution latencies).
+			 */
+			if (ticker->ticks_to_expire >
+			    ticker->ticks_to_expire_minus) {
+				ticker->ticks_to_expire -=
+					ticker->ticks_to_expire_minus;
+				ticker->ticks_to_expire_minus = 0;
+			} else {
+				ticker->ticks_to_expire_minus -=
+					ticker->ticks_to_expire;
+				ticker->ticks_to_expire = 0;
+			}
 		} else {
 			return TICKER_STATUS_FAILURE;
 		}

--- a/subsys/bluetooth/host/mesh/adv.c
+++ b/subsys/bluetooth/host/mesh/adv.c
@@ -1,6 +1,7 @@
 /*  Bluetooth Mesh */
 
 /*
+ * Copyright (c) 2018 Nordic Semiconductor ASA
  * Copyright (c) 2017 Intel Corporation
  *
  * SPDX-License-Identifier: Apache-2.0
@@ -28,18 +29,20 @@
 #include "prov.h"
 #include "proxy.h"
 
-/* Window and Interval are equal for continuous scanning */
-#define MESH_SCAN_INTERVAL 0x10
-#define MESH_SCAN_WINDOW   0x10
-
 /* Convert from ms to 0.625ms units */
-#define ADV_INT(_ms) ((_ms) * 8 / 5)
+#define ADV_SCAN_UNIT(_ms) ((_ms) * 8 / 5)
+
+/* Window and Interval are equal for continuous scanning */
+#define MESH_SCAN_INTERVAL_MS 10
+#define MESH_SCAN_WINDOW_MS   10
+#define MESH_SCAN_INTERVAL    ADV_SCAN_UNIT(MESH_SCAN_INTERVAL_MS)
+#define MESH_SCAN_WINDOW      ADV_SCAN_UNIT(MESH_SCAN_WINDOW_MS)
 
 /* Pre-5.0 controllers enforce a minimum interval of 100ms
  * whereas 5.0+ controllers can go down to 20ms.
  */
-#define ADV_INT_DEFAULT  K_MSEC(100)
-#define ADV_INT_FAST     K_MSEC(20)
+#define ADV_INT_DEFAULT_MS 100
+#define ADV_INT_FAST_MS    20
 
 /* TinyCrypt PRNG consumes a lot of stack space, so we need to have
  * an increased call stack whenever it's used.
@@ -91,7 +94,7 @@ static inline void adv_send_end(int err, const struct bt_mesh_send_cb *cb,
 static inline void adv_send(struct net_buf *buf)
 {
 	const s32_t adv_int_min = ((bt_dev.hci_version >= BT_HCI_VERSION_5_0) ?
-				   ADV_INT_FAST : ADV_INT_DEFAULT);
+				   ADV_INT_FAST_MS : ADV_INT_DEFAULT_MS);
 	const struct bt_mesh_send_cb *cb = BT_MESH_ADV(buf)->cb;
 	void *cb_data = BT_MESH_ADV(buf)->cb_data;
 	struct bt_le_adv_param param;
@@ -100,7 +103,8 @@ static inline void adv_send(struct net_buf *buf)
 	int err;
 
 	adv_int = max(adv_int_min, BT_MESH_ADV(buf)->adv_int);
-	duration = (BT_MESH_ADV(buf)->count + 1) * (adv_int + 10);
+	duration = MESH_SCAN_WINDOW_MS +
+		   ((BT_MESH_ADV(buf)->count + 1) * (adv_int + 10));
 
 	BT_DBG("type %u len %u: %s", BT_MESH_ADV(buf)->type,
 	       buf->len, bt_hex(buf->data, buf->len));
@@ -112,7 +116,7 @@ static inline void adv_send(struct net_buf *buf)
 	ad.data = buf->data;
 
 	param.options = 0;
-	param.interval_min = ADV_INT(adv_int);
+	param.interval_min = ADV_SCAN_UNIT(adv_int);
 	param.interval_max = param.interval_min;
 	param.own_addr = NULL;
 
@@ -126,7 +130,7 @@ static inline void adv_send(struct net_buf *buf)
 
 	BT_DBG("Advertising started. Sleeping %u ms", duration);
 
-	k_sleep(duration);
+	k_sleep(K_MSEC(duration));
 
 	err = bt_le_adv_stop();
 	adv_send_end(err, cb, cb_data);


### PR DESCRIPTION
Related to, and fixes to #6083 

- Fix missing implementation in ticker to remove soft latencies in periodic ticker due to scheduling latencies.
- Account for scan window duration in advertising delay and hence advertising duration.
- Minor refactoring and compilation fixes.