### PR TITLE
sanitycheck: better coverage report generation

### DIFF
--- a/scripts/sanitycheck
+++ b/scripts/sanitycheck
@@ -2311,22 +2311,37 @@ def generate_coverage(outdir, ignores):
         coveragefile = os.path.join(outdir, "coverage.info")
         ztestfile = os.path.join(outdir, "ztest.info")
         subprocess.call(["lcov", "--capture", "--directory", outdir,
+                         "--rc", "lcov_branch_coverage=1",
                          "--output-file", coveragefile], stdout=coveragelog)
         # We want to remove tests/* and tests/ztest/test/* but save tests/ztest
         subprocess.call(["lcov", "--extract", coveragefile,
                          os.path.join(ZEPHYR_BASE, "tests", "ztest", "*"),
-                         "--output-file", ztestfile], stdout=coveragelog)
-        subprocess.call(["lcov", "--remove", ztestfile,
-                         os.path.join(ZEPHYR_BASE, "tests/ztest/test/*"),
-                         "--output-file", ztestfile], stdout=coveragelog)
+                         "--output-file", ztestfile,
+                         "--rc", "lcov_branch_coverage=1"], stdout=coveragelog)
+
+        if os.path.getsize(ztestfile) > 0:
+            subprocess.call(["lcov", "--remove", ztestfile,
+                             os.path.join(ZEPHYR_BASE, "tests/ztest/test/*"),
+                             "--output-file", ztestfile,
+                             "--rc", "lcov_branch_coverage=1"],
+                             stdout=coveragelog)
+            files = [coveragefile, ztestfile];
+        else:
+            files = [coveragefile];
+
         for i in ignores:
             subprocess.call(
                 ["lcov", "--remove", coveragefile, i, "--output-file",
-                 coveragefile],
+                 coveragefile, "--rc", "lcov_branch_coverage=1"],
                 stdout=coveragelog)
-        subprocess.call(["genhtml", "--legend", "-output-directory",
-                         os.path.join(outdir, "coverage"),
-                         coveragefile, ztestfile], stdout=coveragelog)
+
+        ret = subprocess.call(["genhtml", "--legend", "--branch-coverage",
+                               "-output-directory",
+                               os.path.join(outdir, "coverage")] + files,
+                               stdout=coveragelog)
+        if ret==0:
+            info("HTML report generated: %s"%
+                 os.path.join(outdir, "coverage","index.html"));
 
 
 def main():


### PR DESCRIPTION
When generating coverage report:
* Also generate branch coverage
* If the report is properly generated tell user where to find it
* Handle case in which no ztests are run (it would crash before)

Signed-off-by: Alberto Escolar Piedras <alpi@oticon.com>