### PR TITLE
net: buf: Remove incorrect dependency for NET_BUF_POOL_USAGE

### DIFF
--- a/subsys/net/Kconfig
+++ b/subsys/net/Kconfig
@@ -66,6 +66,8 @@ config NET_BUF_SIMPLE_LOG
 	help
 	  Enable extra debug logs and checks for the generic network buffers.
 
+endif # NET_BUF_LOG
+
 config NET_BUF_POOL_USAGE
 	bool "Network buffer pool usage tracking"
 	default n
@@ -75,7 +77,6 @@ config NET_BUF_POOL_USAGE
 	  * total size of the pool is calculated
 	  * pool name is stored and can be shown in debugging prints
 
-endif # NET_BUF_LOG
 endif # NET_BUF
 
 config  NETWORKING


### PR DESCRIPTION
NET_BUF_POOL_USAGE was never supposed to depend on NET_BUF_LOG.

Fixes #6127

Signed-off-by: Johan Hedberg <johan.hedberg@intel.com>