### PR TITLE
net: buf: Make NET_BUF_POOL_USAGE independent of NET_BUF_LOG again

### DIFF
--- a/subsys/net/Kconfig
+++ b/subsys/net/Kconfig
@@ -66,6 +66,8 @@ config NET_BUF_SIMPLE_LOG
 	help
 	  Enable extra debug logs and checks for the generic network buffers.
 
+endif # NET_BUF_LOG
+
 config NET_BUF_POOL_USAGE
 	bool "Network buffer pool usage tracking"
 	default n
@@ -75,7 +77,6 @@ config NET_BUF_POOL_USAGE
 	  * total size of the pool is calculated
 	  * pool name is stored and can be shown in debugging prints
 
-endif # NET_BUF_LOG
 endif # NET_BUF
 
 config  NETWORKING


### PR DESCRIPTION
This is a small regression from dd09cbc1c, where additional net buf
pool metadata collection was made dependent on net buf logging. They
aren't related, e.g. 3rd-party apps may want to collect/show such
metadata without relying on Zephyr's logging. (The issue found by
building MicroPython Zephyr port, which offers a function to query
the number of free/total no. of buffers.)

Fixes: #6127

Signed-off-by: Paul Sokolovsky <paul.sokolovsky@linaro.org>