### PR TITLE
samples: net: sockets: Clean up/improve socket samples

### DIFF
--- a/samples/net/sockets/dumb_http_server/prj.conf
+++ b/samples/net/sockets/dumb_http_server/prj.conf
@@ -12,9 +12,6 @@ CONFIG_NET_SOCKETS_POSIX_NAMES=y
 # Network driver config
 CONFIG_TEST_RANDOM_GENERATOR=y
 
-# Without CONFIG_NET_BUF_LOG printf() doesn't work
-CONFIG_NET_BUF_LOG=y
-
 # Network address config
 CONFIG_NET_APP_SETTINGS=y
 CONFIG_NET_APP_NEED_IPV4=y

--- a/samples/net/sockets/dumb_http_server/src/socket_dumb_http.c
+++ b/samples/net/sockets/dumb_http_server/src/socket_dumb_http.c
@@ -23,6 +23,8 @@
 
 #endif
 
+#define PORT 8080
+
 #ifndef USE_BIG_PAYLOAD
 #define USE_BIG_PAYLOAD 1
 #endif
@@ -45,10 +47,12 @@ int main(void)
 
 	bind_addr.sin_family = AF_INET;
 	bind_addr.sin_addr.s_addr = htonl(INADDR_ANY);
-	bind_addr.sin_port = htons(8080);
+	bind_addr.sin_port = htons(PORT);
 	bind(serv, (struct sockaddr *)&bind_addr, sizeof(bind_addr));
 
 	listen(serv, 5);
+
+	printf("Single-threaded dumb HTTP server waits for a connection on port %d...\n", PORT);
 
 	while (1) {
 		struct sockaddr_in client_addr;

--- a/samples/net/sockets/echo/prj.conf
+++ b/samples/net/sockets/echo/prj.conf
@@ -12,9 +12,6 @@ CONFIG_NET_SOCKETS_POSIX_NAMES=y
 # Network driver config
 CONFIG_TEST_RANDOM_GENERATOR=y
 
-# Without CONFIG_NET_BUF_LOG printf() doesn't work
-CONFIG_NET_BUF_LOG=y
-
 # Network address config
 CONFIG_NET_APP_SETTINGS=y
 CONFIG_NET_APP_NEED_IPV4=y

--- a/samples/net/sockets/echo/src/socket_echo.c
+++ b/samples/net/sockets/echo/src/socket_echo.c
@@ -21,6 +21,8 @@
 
 #endif
 
+#define PORT 4242
+
 int main(void)
 {
 	int serv;
@@ -31,10 +33,12 @@ int main(void)
 
 	bind_addr.sin_family = AF_INET;
 	bind_addr.sin_addr.s_addr = htonl(INADDR_ANY);
-	bind_addr.sin_port = htons(4242);
+	bind_addr.sin_port = htons(PORT);
 	bind(serv, (struct sockaddr *)&bind_addr, sizeof(bind_addr));
 
 	listen(serv, 5);
+
+	printf("Single-threaded TCP echo server waits for a connection on port %d...\n", PORT);
 
 	while (1) {
 		struct sockaddr_in client_addr;

--- a/samples/net/sockets/echo_async/prj.conf
+++ b/samples/net/sockets/echo_async/prj.conf
@@ -13,9 +13,6 @@ CONFIG_NET_SOCKETS_POLL_MAX=5
 # Network driver config
 CONFIG_TEST_RANDOM_GENERATOR=y
 
-# Without CONFIG_NET_BUF_LOG printf() doesn't work
-CONFIG_NET_BUF_LOG=y
-
 # Network address config
 CONFIG_NET_APP_SETTINGS=y
 CONFIG_NET_APP_NEED_IPV4=y

--- a/samples/net/sockets/echo_async/src/socket_echo.c
+++ b/samples/net/sockets/echo_async/src/socket_echo.c
@@ -32,6 +32,8 @@
 #define NUM_FDS 5
 #endif
 
+#define PORT 4242
+
 /* Number of simultaneous client connections will be NUM_FDS be minus 2 */
 struct pollfd pollfds[NUM_FDS];
 int pollnum;
@@ -81,14 +83,14 @@ int main(void)
 	int serv4, serv6;
 	struct sockaddr_in bind_addr4 = {
 		.sin_family = AF_INET,
-		.sin_port = htons(4242),
+		.sin_port = htons(PORT),
 		.sin_addr = {
 			.s_addr = htonl(INADDR_ANY),
 		},
 	};
 	struct sockaddr_in6 bind_addr6 = {
 		.sin6_family = AF_INET6,
-		.sin6_port = htons(4242),
+		.sin6_port = htons(PORT),
 		.sin6_addr = IN6ADDR_ANY_INIT,
 	};
 
@@ -119,7 +121,7 @@ int main(void)
 	pollfds_add(serv4);
 	pollfds_add(serv6);
 
-	printf("Listening on port 4242...\n");
+	printf("Asynchronous TCP echo server waits for connections on port %d...\n", PORT);
 
 	while (1) {
 		struct sockaddr_storage client_addr;

--- a/samples/net/sockets/http_get/prj.conf
+++ b/samples/net/sockets/http_get/prj.conf
@@ -16,9 +16,6 @@ CONFIG_DNS_SERVER1="192.0.2.2"
 # Network driver config
 CONFIG_TEST_RANDOM_GENERATOR=y
 
-# Without CONFIG_NET_BUF_LOG printf() doesn't work
-CONFIG_NET_BUF_LOG=y
-
 # Network address config
 CONFIG_NET_APP_SETTINGS=y
 CONFIG_NET_APP_NEED_IPV4=y


### PR DESCRIPTION
With 323e8cf0699d4a applied and printf() working out of the box,
CONFIG_NET_BUF_LOG=y workarounds can be removed from configs of
all samples.

Also, print an intro message at the start of each server sample,
to give a user hint that the app didn't just hang and what to do
next. (The port waiting for connection is printed. We can't (easily)
print host address, because the samples should run on both Zephyr
and POSIX systems, and finding out local host address would require
hairy #ifdef's undermining the purpose of these samples (that is,
showing that the *same* code can be used on both types of systems)).

Fixes: #5379

Signed-off-by: Paul Sokolovsky <paul.sokolovsky@linaro.org>