### PR TITLE
sanitycheck: make schema for toolchains more flexible

### DIFF
--- a/scripts/sanity_chk/sanitycheck-platform-schema.yaml
+++ b/scripts/sanity_chk/sanitycheck-platform-schema.yaml
@@ -28,7 +28,6 @@ mapping:
     seq:
       -
         type: str
-        enum: [ 'gccarmemb', 'issm', 'xcc', 'zephyr', 'espressif', 'host']
   "ram":
     type: int
   "flash":


### PR DESCRIPTION
Allow for any toolchain variants to be useable with sanitycheck without
the need for them to be registered.

Signed-off-by: Anas Nashif <anas.nashif@intel.com>