### PR TITLE
Bluetooth: Remove bogus return statements for BR/EDR connections

### DIFF
--- a/subsys/bluetooth/host/conn.c
+++ b/subsys/bluetooth/host/conn.c
@@ -254,7 +254,6 @@ struct bt_conn *bt_conn_create_br(const bt_addr_t *peer,
 	conn = bt_conn_lookup_addr_br(peer);
 	if (conn) {
 		switch (conn->state) {
-			return conn;
 		case BT_CONN_CONNECT:
 		case BT_CONN_CONNECTED:
 			return conn;
@@ -306,7 +305,6 @@ struct bt_conn *bt_conn_create_sco(const bt_addr_t *peer)
 	sco_conn = bt_conn_lookup_addr_sco(peer);
 	if (sco_conn) {
 		switch (sco_conn->state) {
-			return sco_conn;
 		case BT_CONN_CONNECT:
 		case BT_CONN_CONNECTED:
 			return sco_conn;


### PR DESCRIPTION
Having these in the beginning of a switch statement without any case
statement makes no sense.

Fixes #6135

Signed-off-by: Johan Hedberg <johan.hedberg@intel.com>