### PR TITLE
native: added more proper command line parameters parsing

### DIFF
--- a/arch/posix/include/posix_arch_internal.h
+++ b/arch/posix/include/posix_arch_internal.h
@@ -7,6 +7,8 @@
 #ifndef _POSIX_INTERNAL_H
 #define _POSIX_INTERNAL_H
 
+#include "toolchain.h"
+
 #define _SAFE_CALL(a) _safe_call(a, #a)
 
 #ifdef __cplusplus
@@ -16,7 +18,7 @@ extern "C" {
 static inline void _safe_call(int test, const char *test_str)
 {
 	/* LCOV_EXCL_START */ /* See Note1 */
-	if (test) {
+	if (unlikely(test)) {
 		posix_print_error_and_exit("POSIX arch: Error on: %s\n",
 					   test_str);
 	}

--- a/boards/posix/native_posix/CMakeLists.txt
+++ b/boards/posix/native_posix/CMakeLists.txt
@@ -7,5 +7,6 @@ zephyr_library_sources(
 	irq_ctrl.c
 	main.c
 	tracing.c
+	cmdline_common.c
 	cmdline.c
 	)

--- a/boards/posix/native_posix/cmdline.c
+++ b/boards/posix/native_posix/cmdline.c
@@ -4,27 +4,113 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+#include <stdbool.h>
+#include "cmdline_common.h"
+#include "zephyr/types.h"
+#include "hw_models_top.h"
+#include "cmdline.h"
+#include "toolchain.h"
 
-static int s_argc;
-static char **s_argv;
+static int s_argc, test_argc;
+static char **s_argv, **test_argv;
+
+static struct args_t args;
+
+static void cmd_stop_at_found(char *argv, int offset)
+{
+	ARG_UNUSED(offset);
+	if (args.stop_at < 0) {
+		posix_print_error_and_exit("Error: stop-at must be positive "
+					   "(%s)\n", argv);
+	}
+	hwm_set_end_of_time(args.stop_at*1e6);
+}
+
+#if defined(CONFIG_ENTROPY_NATIVE_POSIX)
+extern void entropy_native_posix_set_seed(unsigned int seed_i);
+static void cmd_seed_found(char *argv, int offset)
+{
+	ARG_UNUSED(argv);
+	ARG_UNUSED(offset);
+	entropy_native_posix_set_seed(args.seed);
+}
+#endif
 
 /**
- * Store the command line arguments for later use.
- * If this board already handles any, we do so here
+ * Handle possible command line arguments.
+ *
+ * We also store them for later use by possible test applications
  */
 void native_handle_cmd_line(int argc, char *argv[])
 {
+	int i;
+
+	struct args_struct_t args_struct[] = {
+		/*
+		 * Fields:
+		 * manual, mandatory, switch,
+		 * option_name, var_name ,type,
+		 * destination, callback,
+		 * description
+		 */
+		{false, false, false,
+		  "stop_at", "time", 'd',
+		(void *)&args.stop_at, cmd_stop_at_found,
+		"In simulated seconds, when to stop automatically"},
+
+#if defined(CONFIG_ENTROPY_NATIVE_POSIX)
+		{false, false, false,
+		  "seed", "r_seed", 'u',
+		(void *)&args.seed, cmd_seed_found,
+		"Seed for the entropy device"},
+#endif
+
+		{true, false, false,
+		 "testargs", "arg", 'l',
+		(void *)NULL, NULL,
+		"Any argument that follows will be ignored by the top level, "
+		"and made available for possible tests"},
+
+		ARG_TABLE_ENDMARKER
+	};
+
 	s_argv = argv;
 	s_argc = argc;
+
+	cmd_args_set_defaults(args_struct);
+
+	for (i = 1; i < argc; i++) {
+
+		if ((cmd_is_option(argv[i], "testargs", 0))) {
+			test_argc = argc - i - 1;
+			test_argv = &argv[i+1];
+			break;
+		}
+
+		if (!cmd_parse_one_arg(argv[i], args_struct)) {
+			cmd_print_switches_help(args_struct);
+			posix_print_error_and_exit("Incorrect option '%s'\n",
+						   argv[i]);
+		}
+	}
 }
 
-
 /**
- * The application/test can use this function to inspect the command line
+ * The application/test can use this function to inspect all the command line
  * arguments
  */
 void native_get_cmd_line_args(int *argc, char ***argv)
 {
 	*argc = s_argc;
 	*argv = s_argv;
+}
+
+/**
+ * The application/test can use this function to inspect the command line
+ * arguments received after --testargs
+ */
+void native_get_test_cmd_line_args(int *argc, char ***argv)
+{
+	*argc = test_argc;
+	*argv = test_argv;
 }

--- a/boards/posix/native_posix/cmdline.h
+++ b/boards/posix/native_posix/cmdline.h
@@ -7,8 +7,23 @@
 #ifndef _NATIVE_POSIX_CMDLINE_H
 #define _NATIVE_POSIX_CMDLINE_H
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+struct args_t {
+	double stop_at;
+#if defined(CONFIG_ENTROPY_NATIVE_POSIX)
+	u32_t seed;
+#endif
+};
 
 void native_handle_cmd_line(int argc, char *argv[]);
 void native_get_cmd_line_args(int *argc, char ***argv);
+void native_get_test_cmd_line_args(int *argc, char ***argv);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* _NATIVE_POSIX_CMDLINE_H */

--- a/boards/posix/native_posix/cmdline_common.c
+++ b/boards/posix/native_posix/cmdline_common.c
@@ -1,0 +1,410 @@
+/*
+ * Copyright (c) 2018 Oticon A/S
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <string.h>
+#include <strings.h>
+#include <stdbool.h>
+#include <stdlib.h>
+#include <stdio.h>
+#include <math.h>
+#include "posix_soc_if.h"
+#include "zephyr/types.h"
+#include "cmdline_common.h"
+
+/**
+ * Check if <arg> is the option <option>
+ * The accepted syntax is:
+ *   * For options without a value following:
+ *       [-[-]]<option>
+ *   * For options with value:
+ *       [-[-]]<option>{:|=}<value>
+ *
+ * Returns 0 if it is not, or a number > 0 if it is.
+ * The returned number is the number of characters it went through
+ * to find the end of the option including the ':' or '=' character in case of
+ * options with value
+ */
+int cmd_is_option(const char *arg, const char *option, int with_value)
+{
+	int of = 0;
+	size_t to_match_len = strlen(option);
+
+	if (arg[of] == '-') {
+		of++;
+	}
+	if (arg[of] == '-') {
+		of++;
+	}
+
+	if (strncmp(&arg[of], option, to_match_len) != 0) {
+		return 0;
+	}
+
+	of += to_match_len;
+
+	if (with_value) {
+		if ((arg[of] == ':') || (arg[of] == '=')) {
+			of++;
+			if (arg[of] == 0) { /* we need a value to follow */
+				of = 0;
+			}
+		} else {
+			of = 0;
+		}
+	} else {
+		if (arg[of] != 0) { /* we don't accept any extra characters */
+			of = 0;
+		}
+	}
+	if (of == 0) {
+		posix_print_error_and_exit("Incorrect option syntax '%s'. Run "
+					   "with --help for more information\n",
+					   arg);
+	}
+
+	return of;
+}
+
+/**
+ * Return 1 if <arg> matches an accepted help option.
+ * 0 otherwise
+ *
+ * Valid help options are [-[-]]{?|h|help}
+ * with the h or help in any case combination
+ */
+int cmd_is_help_option(const char *arg)
+{
+	if (arg[0] == '-') {
+		arg++;
+	}
+	if (arg[0] == '-') {
+		arg++;
+	}
+	if ((strcasecmp(arg, "?") == 0) ||
+	    (strcasecmp(arg, "h") == 0) ||
+	    (strcasecmp(arg, "help") == 0)) {
+		return 1;
+	} else {
+		return 0;
+	}
+}
+
+#define CMD_TYPE_ERROR "Coding error: type %c not understood"
+#define CMD_ERR_BOOL_SWI "Programming error: I only know how to "\
+	"automatically read boolean switches\n"
+
+/**
+ * Read out a the value following an option from str, and store it into
+ * <dest>
+ * <type> indicates the type of parameter (and type of dest pointer)
+ *   'b' : boolean
+ *   's' : string (char *)
+ *   'u' : 32 bit unsigned integer
+ *   'U' : 64 bit unsigned integer
+ *   'i' : 32 bit signed integer
+ *   'I' : 64 bit signed integer
+ *   'd' : *double* float
+ *
+ * Note: list type ('l') cannot be handled by this function and must always be
+ *       manual
+ *
+ *  <long_d> is the long name of the option
+ */
+void cmd_read_option_value(const char *str, void *dest, const char type,
+			   const char *option)
+{
+	int error = 0;
+	char *endptr;
+
+	switch (type) {
+	case 'b':
+		if (strcasecmp(str, "false") == 0) {
+			*(bool *)dest = false;
+			endptr = (char *)str + 5;
+		} else if (strcmp(str, "0") == 0) {
+			*(bool *)dest = false;
+			endptr = (char *)str + 1;
+		} else if (strcasecmp(str, "true") == 0) {
+			*(bool *)dest = true;
+			endptr = (char *)str + 4;
+		} else if (strcmp(str, "1") == 0) {
+			*(bool *)dest = true;
+			endptr = (char *)str + 1;
+		} else {
+			error = 1;
+		}
+		break;
+	case 's':
+		*(char **)dest = (char *)str;
+		break;
+	case 'u':
+		*(u32_t *)dest = strtoul(str, &endptr, 0);
+		break;
+	case 'U':
+		*(u64_t *)dest = strtoull(str, &endptr, 0);
+		break;
+	case 'i':
+		*(s32_t *)dest = strtol(str, &endptr, 0);
+		break;
+	case 'I':
+		*(s64_t *)dest = strtoll(str, &endptr, 0);
+		break;
+	case 'd':
+		*(double *)dest = strtod(str, &endptr);
+		break;
+	default:
+		posix_print_error_and_exit(CMD_TYPE_ERROR, type);
+		break;
+	}
+
+	if (*endptr != 0) {
+		error = 1;
+	}
+
+	if (error) {
+		posix_print_error_and_exit("Error reading value %s '%s'. Use "
+					   "--help for usage information\n",
+					   option, str);
+	}
+}
+
+/**
+ * Initialize existing dest* to defaults based on type
+ */
+void cmd_args_set_defaults(struct args_struct_t args_struct[])
+{
+	int count = 0;
+
+	while (args_struct[count].option != NULL) {
+
+		if (args_struct[count].dest == NULL) {
+			count++;
+			continue;
+		}
+
+		switch (args_struct[count].type) {
+		case 0: /* does not have storage */
+			break;
+		case 'b':
+			*(bool *)args_struct[count].dest = false;
+			break;
+		case 's':
+			*(char **)args_struct[count].dest = NULL;
+			break;
+		case 'u':
+			*(u32_t *)args_struct[count].dest = UINT32_MAX;
+			break;
+		case 'U':
+			*(u64_t *)args_struct[count].dest = UINT64_MAX;
+			break;
+		case 'i':
+			*(s32_t *)args_struct[count].dest = INT32_MAX;
+			break;
+		case 'I':
+			*(s64_t *)args_struct[count].dest = INT64_MAX;
+			break;
+		case 'd':
+			*(double *)args_struct[count].dest = NAN;
+			break;
+		default:
+			posix_print_error_and_exit(CMD_TYPE_ERROR,
+						   args_struct[count].type);
+			break;
+		}
+		count++;
+	}
+}
+
+/**
+ * For the help messages:
+ * Generate a string containing how the option described by <args_s_el>
+ * should be used
+ *
+ * The string is saved in <buf> which has been allocated <size> bytes by the
+ * caller
+ */
+static void cmd_gen_switch_syntax(char *buf, int size,
+				  struct args_struct_t *args_s_el)
+{
+	int ret = 0;
+
+	if (size <= 0) {
+		return;
+	}
+
+	if (args_s_el->is_mandatory == false) {
+		*buf++ = '[';
+		size--;
+	}
+
+	if (args_s_el->is_switch == true) {
+		ret = snprintf(buf, size, "-%s", args_s_el->option);
+	} else {
+		if (args_s_el->type != 'l') {
+			ret = snprintf(buf, size, "-%s=<%s>",
+					args_s_el->option, args_s_el->name);
+		} else {
+			ret = snprintf(buf, size, "-%s <%s>...",
+					args_s_el->option, args_s_el->name);
+		}
+	}
+
+	if (ret < 0) {
+		posix_print_error_and_exit("Unexpected error in %s %i\n",
+					   __FILE__, __LINE__);
+	}
+	if (size - ret < 0) {
+		/*
+		 * If we run out of space we can just stop,
+		 * this is not critical
+		 */
+		return;
+	}
+	buf += ret;
+	size -= ret;
+
+	if (args_s_el->is_mandatory == false) {
+		snprintf(buf, size, "] ");
+	} else {
+		snprintf(buf, size, " ");
+	}
+}
+
+/**
+ * Print short list of available switches
+ */
+void cmd_print_switches_help(struct args_struct_t args_struct[])
+{
+	int count = 0;
+	int printed_in_line = strlen(_HELP_SWITCH) + 1;
+
+	fprintf(stdout, "%s ", _HELP_SWITCH);
+
+	while (args_struct[count].option != NULL) {
+		char stringy[_MAX_STRINGY_LEN];
+
+		cmd_gen_switch_syntax(stringy, _MAX_STRINGY_LEN,
+				      &args_struct[count]);
+
+		if (printed_in_line + strlen(stringy) > _MAX_LINE_WIDTH) {
+			fprintf(stdout, "\n");
+			printed_in_line = 0;
+		}
+
+		fprintf(stdout, "%s", stringy);
+		printed_in_line += strlen(stringy);
+		count++;
+	}
+
+	fprintf(stdout, "\n");
+}
+
+/**
+ * Print the long help message of the program
+ */
+void cmd_print_long_help(struct args_struct_t args_struct[])
+{
+	int ret;
+	int count = 0;
+	int printed_in_line = 0;
+	char stringy[_MAX_STRINGY_LEN];
+
+	cmd_print_switches_help(args_struct);
+
+	fprintf(stdout, "\n %-*s:%s\n", _LONG_HELP_ALIGN-1,
+		_HELP_SWITCH, _HELP_DESCR);
+
+	while (args_struct[count].option != NULL) {
+		int printed_right;
+		char *toprint;
+		int total_to_print;
+
+		cmd_gen_switch_syntax(stringy, _MAX_STRINGY_LEN,
+				      &args_struct[count]);
+
+		ret = fprintf(stdout, " %-*s:", _LONG_HELP_ALIGN-1, stringy);
+		printed_in_line = ret;
+		printed_right = 0;
+		toprint = args_struct[count].descript;
+		total_to_print = strlen(toprint);
+		ret = fprintf(stdout, "%.*s\n",
+				_MAX_LINE_WIDTH - printed_in_line,
+				&toprint[printed_right]);
+		printed_right += ret - 1;
+
+		while (printed_right < total_to_print) {
+			fprintf(stdout, "%*s", _LONG_HELP_ALIGN, "");
+			ret = fprintf(stdout, "%.*s\n",
+				      _MAX_LINE_WIDTH - _LONG_HELP_ALIGN,
+				      &toprint[printed_right]);
+			printed_right += ret - 1;
+		}
+		count++;
+	}
+	fprintf(stdout, "\n");
+}
+
+/*
+ * <argv> matched the argument described in <arg_element>
+ *
+ * If arg_element->dest points to a place to store a possible value, read it
+ * If there is a callback registered, call it after
+ */
+static void cmd_handle_this_matched_arg(char *argv, int offset,
+					struct args_struct_t *arg_element)
+{
+	if (arg_element->dest != NULL) {
+		if (arg_element->is_switch) {
+			if (arg_element->type == 'b') {
+				*(bool *)arg_element->dest = true;
+			} else {
+				posix_print_error_and_exit(CMD_ERR_BOOL_SWI);
+			}
+		} else { /* if not a switch we need to read its value */
+			cmd_read_option_value(&argv[offset],
+					      arg_element->dest,
+					      arg_element->type,
+					      arg_element->name);
+		}
+	}
+
+	if (arg_element->call_when_found) {
+		arg_element->call_when_found(argv, offset);
+	}
+}
+
+/**
+ * Try to find if this argument is in the list (and it is not manual)
+ * if it does, try to parse it, set its dest accordingly, and return true
+ * if it is not found, return false
+ */
+bool cmd_parse_one_arg(char *argv, struct args_struct_t args_struct[])
+{
+	int count = 0;
+	int ret;
+
+	if (cmd_is_help_option(argv)) {
+		cmd_print_long_help(args_struct);
+		posix_exit(0);
+	}
+
+	while (args_struct[count].option != NULL) {
+		if (args_struct[count].manual) {
+			count++;
+			continue;
+		}
+		ret = cmd_is_option(argv, args_struct[count].option,
+				       !args_struct[count].is_switch);
+		if (ret) {
+			cmd_handle_this_matched_arg(argv,
+						    ret,
+						    &args_struct[count]);
+			return true;
+		}
+		count++;
+	}
+	return false;
+}

--- a/boards/posix/native_posix/cmdline_common.h
+++ b/boards/posix/native_posix/cmdline_common.h
@@ -1,0 +1,83 @@
+/*
+ * Copyright (c) 2018 Oticon A/S
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+#ifndef _CMDLINE_COMMON_H
+#define _CMDLINE_COMMON_H
+
+#include <stdbool.h>
+#include <stddef.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#define _MAX_LINE_WIDTH 100 /*Total width of the help message*/
+/* Horizontal alignment of the 2nd column of the help message */
+#define _LONG_HELP_ALIGN 30
+
+#define _MAXOPT_SWITCH_LEN  32 /* Maximum allowed length for a switch name */
+#define _MAXOPT_NAME_LEN    32 /* Maximum allowed length for a variable name */
+
+#define _HELP_SWITCH  "[-h] [--h] [--help] [-?]"
+#define _HELP_DESCR   "Display this help"
+
+#define _MAX_STRINGY_LEN (_MAXOPT_SWITCH_LEN + _MAXOPT_NAME_LEN + 2 + 1 + 2 + 1)
+
+
+/**
+ * Prototype for a callback function when an option is found:
+ * inputs:
+ *  argv: Whole argv[i] option as received in main
+ *  offset: Offset to the end of the option string
+ *          (including a possible ':' or '=')
+ *  If the option had a value, it would be placed in &argv[offset]
+ */
+typedef void (*option_found_callback_f)(char *argv, int offset);
+
+/*
+ * Structure defining each command line option
+ */
+struct args_struct_t {
+	/*
+	 * if manual is set cmd_args_parse*() will ignore it except for
+	 * displaying it the help messages and initializing <dest> to its
+	 * default
+	 */
+	bool manual;
+	/* For help messages, should it be wrapped in "[]" */
+	bool is_mandatory;
+	/* It is just a switch: it does not have something to store after */
+	bool is_switch;
+	/* Option name we search for: --<option> */
+	char *option;
+	/*
+	 * Name of the option destination in the help messages:
+	 * "--<option>=<name>"
+	 */
+	char *name;
+	/* Type of option (see cmd_read_option_value()) */
+	char type;
+	/* Pointer to where the read value will be stored (may be NULL) */
+	void *dest;
+	/* Optional callback to be called when the switch is found */
+	option_found_callback_f call_when_found;
+	/* Long description for the help messages */
+	char *descript;
+};
+
+#define ARG_TABLE_ENDMARKER \
+	{false, false, false, NULL, NULL, 0, NULL, NULL, NULL}
+
+int cmd_is_option(const char *arg, const char *option, int with_value);
+int cmd_is_help_option(const char *arg);
+void cmd_read_option_value(const char *str, void *dest, const char type,
+			   const char *option);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* _CMDLINE_COMMON_H */
+

--- a/boards/posix/native_posix/main.c
+++ b/boards/posix/native_posix/main.c
@@ -25,9 +25,6 @@
 #include "misc/util.h"
 #include "cmdline.h"
 
-#define STOP_AFTER_5_SECONDS 0
-
-
 void posix_exit(int exit_code)
 {
 	static int max_exit_code;
@@ -42,7 +39,6 @@ void posix_exit(int exit_code)
 	hwm_cleanup();
 	exit(exit_code);
 }
-
 
 /**
  * This is the actual main for the Linux process,
@@ -61,10 +57,6 @@ int main(int argc, char *argv[])
 	native_handle_cmd_line(argc, argv);
 
 	hwm_init();
-
-#if (STOP_AFTER_5_SECONDS)
-	hwm_set_end_of_time(5e6);
-#endif
 
 	posix_boot_cpu();
 


### PR DESCRIPTION
Added a basic command line parameter parsing framework

Added the following options by now:
```
--help
--stop-at=<time> : Auto-stop after <time> seconds
--seed=<seed>    : random seed for entropy device
--testargs [args]: Any argument that follows is ignored in the top level but made
                   available thru native_get_test_cmd_line_args()
```
All command line parameters are still avaliable by calling
`native_get_cmd_line_args()`, but now you can also call
`native_get_test_cmd_line_args()` to get whatever was set after `--testargs`

Related to #5483