### PR TITLE
driver: usb: code cleanup

### DIFF
--- a/drivers/usb/device/usb_dc_dw.c
+++ b/drivers/usb/device/usb_dc_dw.c
@@ -20,7 +20,9 @@
 #include <misc/byteorder.h>
 #include <usb/usb_dc.h>
 #include "usb_dw_registers.h"
+#ifdef CONFIG_QMSI
 #include "clk.h"
+#endif
 
 #define SYS_LOG_LEVEL CONFIG_SYS_LOG_USB_DRIVER_LEVEL
 #include <logging/sys_log.h>


### PR DESCRIPTION
include clk.h only for system that use QMSI.

Signed-off-by: Savinay Dharmappa <savinay.dharmappa@intel.com>