### PR TITLE
Bluetooth: Mesh: Convert to new net_buf_simple APIs

### DIFF
--- a/include/bluetooth/mesh/access.h
+++ b/include/bluetooth/mesh/access.h
@@ -256,7 +256,11 @@ struct bt_mesh_model_op {
  */
 #define BT_MESH_PUB_TRANSMIT_INT(transmit) ((((transmit) >> 3) + 1) * 50)
 
-/** Model publication context. */
+/** Model publication context.
+ *
+ *  The context should primarily be created using the
+ *  BT_MESH_MODEL_PUB_DEFINE macro.
+ */
 struct bt_mesh_model_pub {
 	/** The model the context belongs to. Initialized by the stack. */
 	struct bt_mesh_model *mod;
@@ -275,20 +279,10 @@ struct bt_mesh_model_pub {
 
 	/** @brief Publication buffer, containing the publication message.
 	 *
-	 *  The application is expected to initialize this with
-	 *  a valid net_buf_simple pointer, with the help of e.g.
-	 *  the NET_BUF_SIMPLE() macro. The publication buffer must
-	 *  contain a valid publication message before calling the
-	 *  bt_mesh_model_publish() API or after the publication's
-	 *  @ref bt_mesh_model_pub.update callback has been called
-	 *  and returned success. The buffer must be created outside
-	 *  of function context, i.e. it must not be on the stack.
-	 *  This is most conveniently acheived by creating it inline
-	 *  when declaring the publication context:
+	 *  This will get correctly created when the publication context
+	 *  has been defined using the BT_MESH_MODEL_PUB_DEFINE macro.
 	 *
-	 *      static struct bt_mesh_model_pub my_pub = {
-	 *              .msg = NET_BUF_SIMPLE(size),
-	 *      };
+	 *	BT_MESH_MODEL_PUB_DEFINE(name, update, size);
 	 */
 	struct net_buf_simple *msg;
 
@@ -309,6 +303,21 @@ struct bt_mesh_model_pub {
 	/** Publish Period Timer. Only for stack-internal use. */
 	struct k_delayed_work timer;
 };
+
+/** @def BT_MESH_MODEL_PUB_DEFINE
+ *
+ *  Define a model publication context.
+ *
+ *  @param _name Variable name given to the context.
+ *  @param _update Optional message update callback (may be NULL).
+ *  @param _msg_len Length of the publication message.
+ */
+#define BT_MESH_MODEL_PUB_DEFINE(_name, _update, _msg_len) \
+	NET_BUF_SIMPLE_DEFINE_STATIC(bt_mesh_pub_msg_##_name, _msg_len); \
+	static struct bt_mesh_model_pub _name = { \
+		.update = _update, \
+		.msg = &bt_mesh_pub_msg_##_name, \
+	}
 
 /** Abstraction that describes a Mesh Model instance */
 struct bt_mesh_model {

--- a/include/bluetooth/mesh/health_srv.h
+++ b/include/bluetooth/mesh/health_srv.h
@@ -42,16 +42,15 @@ struct bt_mesh_health_srv_cb {
 	void (*attn_off)(struct bt_mesh_model *model);
 };
 
-/** @def BT_MESH_HEALTH_FAULT_MSG
+/** @def BT_MESH_HEALTH_PUB_DEFINE
  *
- *  A helper to define a health fault message.
+ *  A helper to define a health publication context
  *
- *  @param max_faults Maximum number of faults the element can have.
- *
- *  @return a New net_buf_simple of the needed size.
+ *  @param _name Name given to the publication context variable.
+ *  @param _max_faults Maximum number of faults the element can have.
  */
-#define BT_MESH_HEALTH_FAULT_MSG(max_faults) \
-	NET_BUF_SIMPLE(1 + 3 + (max_faults))
+#define BT_MESH_HEALTH_PUB_DEFINE(_name, _max_faults) \
+	BT_MESH_MODEL_PUB_DEFINE(_name, NULL, (1 + 3 + (_max_faults)))
 
 /** Mesh Health Server Model Context */
 struct bt_mesh_health_srv {

--- a/samples/bluetooth/mesh/src/main.c
+++ b/samples/bluetooth/mesh/src/main.c
@@ -38,9 +38,7 @@ static struct bt_mesh_cfg_srv cfg_srv = {
 static struct bt_mesh_health_srv health_srv = {
 };
 
-static struct bt_mesh_model_pub health_pub = {
-	.msg  = BT_MESH_HEALTH_FAULT_MSG(0),
-};
+BT_MESH_HEALTH_PUB_DEFINE(health_pub, 0);
 
 static struct bt_mesh_model_pub gen_level_pub;
 static struct bt_mesh_model_pub gen_onoff_pub;

--- a/samples/bluetooth/mesh_demo/src/main.c
+++ b/samples/bluetooth/mesh_demo/src/main.c
@@ -89,9 +89,7 @@ static struct bt_mesh_health_srv health_srv = {
 	.cb = &health_srv_cb,
 };
 
-static struct bt_mesh_model_pub health_pub = {
-	.msg  = BT_MESH_HEALTH_FAULT_MSG(0),
-};
+BT_MESH_HEALTH_PUB_DEFINE(health_pub, 0);
 
 static struct bt_mesh_model root_models[] = {
 	BT_MESH_MODEL_CFG_SRV(&cfg_srv),
@@ -222,7 +220,7 @@ static u16_t target = GROUP_ADDR;
 
 void board_button_1_pressed(void)
 {
-	struct net_buf_simple *msg = NET_BUF_SIMPLE(3 + 4);
+	NET_BUF_SIMPLE_DEFINE(msg, 3 + 4);
 	struct bt_mesh_msg_ctx ctx = {
 		.net_idx = net_idx,
 		.app_idx = app_idx,
@@ -231,9 +229,9 @@ void board_button_1_pressed(void)
 	};
 
 	/* Bind to Health model */
-	bt_mesh_model_msg_init(msg, OP_VENDOR_BUTTON);
+	bt_mesh_model_msg_init(&msg, OP_VENDOR_BUTTON);
 
-	if (bt_mesh_model_send(&vnd_models[0], &ctx, msg, NULL, NULL)) {
+	if (bt_mesh_model_send(&vnd_models[0], &ctx, &msg, NULL, NULL)) {
 		printk("Unable to send Vendor Button message\n");
 	}
 

--- a/samples/boards/nrf52/mesh/onoff-app/src/main.c
+++ b/samples/boards/nrf52/mesh/onoff-app/src/main.c
@@ -126,8 +126,6 @@ static struct bt_mesh_health_srv health_srv = {
  * The publication messages are initialized to the
  * the size of the opcode + content
  *
- * The messages are in static storage because NET_BUF_SIMPLE()
- * only allocates on the stack if called within a function.
  * For publication, the message must be in static or global as
  * it is re-transmitted several times. This occurs
  * after the function that called bt_mesh_model_publish() has
@@ -139,34 +137,16 @@ static struct bt_mesh_health_srv health_srv = {
  *
  */
 
-static struct bt_mesh_model_pub health_pub = {
-	.msg  = BT_MESH_HEALTH_FAULT_MSG(0),
-};
+BT_MESH_HEALTH_PUB_DEFINE(health_pub, 0);
 
-static struct bt_mesh_model_pub gen_onoff_pub_srv = {
-	.msg = NET_BUF_SIMPLE(2 + 2),
-};
-static struct bt_mesh_model_pub gen_onoff_pub_cli = {
-	.msg = NET_BUF_SIMPLE(2 + 2),
-};
-static struct bt_mesh_model_pub gen_onoff_pub_srv_s_0 = {
-	.msg = NET_BUF_SIMPLE(2 + 2),
-};
-static struct bt_mesh_model_pub gen_onoff_pub_cli_s_0 = {
-	.msg = NET_BUF_SIMPLE(2 + 2),
-};
-static struct bt_mesh_model_pub gen_onoff_pub_srv_s_1 = {
-	.msg = NET_BUF_SIMPLE(2 + 2),
-};
-static struct bt_mesh_model_pub gen_onoff_pub_cli_s_1 = {
-	.msg = NET_BUF_SIMPLE(2 + 2),
-};
-static struct bt_mesh_model_pub gen_onoff_pub_srv_s_2 = {
-	.msg = NET_BUF_SIMPLE(2 + 2),
-};
-static struct bt_mesh_model_pub gen_onoff_pub_cli_s_2 = {
-	.msg = NET_BUF_SIMPLE(2 + 2),
-};
+BT_MESH_MODEL_PUB_DEFINE(gen_onoff_pub_srv, NULL, 2 + 2);
+BT_MESH_MODEL_PUB_DEFINE(gen_onoff_pub_cli, NULL, 2 + 2);
+BT_MESH_MODEL_PUB_DEFINE(gen_onoff_pub_srv_s_0, NULL, 2 + 2);
+BT_MESH_MODEL_PUB_DEFINE(gen_onoff_pub_cli_s_0, NULL, 2 + 2);
+BT_MESH_MODEL_PUB_DEFINE(gen_onoff_pub_srv_s_1, NULL, 2 + 2);
+BT_MESH_MODEL_PUB_DEFINE(gen_onoff_pub_cli_s_1, NULL, 2 + 2);
+BT_MESH_MODEL_PUB_DEFINE(gen_onoff_pub_srv_s_2, NULL, 2 + 2);
+BT_MESH_MODEL_PUB_DEFINE(gen_onoff_pub_cli_s_2, NULL, 2 + 2);
 
 /*
  * Models in an element must have unique op codes.
@@ -337,15 +317,15 @@ static void gen_onoff_get(struct bt_mesh_model *model,
 			  struct bt_mesh_msg_ctx *ctx,
 			  struct net_buf_simple *buf)
 {
-	struct net_buf_simple *msg = NET_BUF_SIMPLE(2 + 1 + 4);
+	NET_BUF_SIMPLE_DEFINE(msg, 2 + 1 + 4);
 	struct onoff_state *onoff_state = model->user_data;
 
 	SYS_LOG_INF("addr 0x%04x onoff 0x%02x",
 		    model->elem->addr, onoff_state->current);
-	bt_mesh_model_msg_init(msg, BT_MESH_MODEL_OP_GEN_ONOFF_STATUS);
-	net_buf_simple_add_u8(msg, onoff_state->current);
+	bt_mesh_model_msg_init(&msg, BT_MESH_MODEL_OP_GEN_ONOFF_STATUS);
+	net_buf_simple_add_u8(&msg, onoff_state->current);
 
-	if (bt_mesh_model_send(model, ctx, msg, NULL, NULL)) {
+	if (bt_mesh_model_send(model, ctx, &msg, NULL, NULL)) {
 		SYS_LOG_ERR("Unable to send On Off Status response");
 	}
 }
@@ -536,7 +516,7 @@ static void button_pressed_worker(struct k_work *work)
 	 */
 
 	if (primary_addr == BT_MESH_ADDR_UNASSIGNED) {
-		struct net_buf_simple *msg = NET_BUF_SIMPLE(1);
+		NET_BUF_SIMPLE_DEFINE(msg, 1);
 		struct bt_mesh_msg_ctx ctx = {
 			.addr = sw_idx + primary_addr,
 		};
@@ -545,9 +525,8 @@ static void button_pressed_worker(struct k_work *work)
 		 * for the led server
 		 */
 
-		net_buf_simple_init(msg, 0);
-		net_buf_simple_add_u8(msg, sw->onoff_state);
-		gen_onoff_set_unack(mod_srv, &ctx, msg);
+		net_buf_simple_add_u8(&msg, sw->onoff_state);
+		gen_onoff_set_unack(mod_srv, &ctx, &msg);
 		return;
 	}
 

--- a/subsys/bluetooth/host/mesh/cfg_cli.c
+++ b/subsys/bluetooth/host/mesh/cfg_cli.c
@@ -508,7 +508,7 @@ static int cli_wait(void *param, u32_t op)
 int bt_mesh_cfg_comp_data_get(u16_t net_idx, u16_t addr, u8_t page,
 			      u8_t *status, struct net_buf_simple *comp)
 {
-	struct net_buf_simple *msg = NET_BUF_SIMPLE(2 + 1 + 4);
+	NET_BUF_SIMPLE_DEFINE(msg, 2 + 1 + 4);
 	struct bt_mesh_msg_ctx ctx = {
 		.net_idx = net_idx,
 		.app_idx = BT_MESH_KEY_DEV,
@@ -526,10 +526,10 @@ int bt_mesh_cfg_comp_data_get(u16_t net_idx, u16_t addr, u8_t page,
 		return err;
 	}
 
-	bt_mesh_model_msg_init(msg, OP_DEV_COMP_DATA_GET);
-	net_buf_simple_add_u8(msg, page);
+	bt_mesh_model_msg_init(&msg, OP_DEV_COMP_DATA_GET);
+	net_buf_simple_add_u8(&msg, page);
 
-	err = bt_mesh_model_send(cli->model, &ctx, msg, NULL, NULL);
+	err = bt_mesh_model_send(cli->model, &ctx, &msg, NULL, NULL);
 	if (err) {
 		BT_ERR("model_send() failed (err %d)", err);
 		return err;
@@ -541,7 +541,7 @@ int bt_mesh_cfg_comp_data_get(u16_t net_idx, u16_t addr, u8_t page,
 static int get_state_u8(u16_t net_idx, u16_t addr, u32_t op, u32_t rsp,
 			u8_t *val)
 {
-	struct net_buf_simple *msg = NET_BUF_SIMPLE(2 + 0 + 4);
+	NET_BUF_SIMPLE_DEFINE(msg, 2 + 0 + 4);
 	struct bt_mesh_msg_ctx ctx = {
 		.net_idx = net_idx,
 		.app_idx = BT_MESH_KEY_DEV,
@@ -555,9 +555,9 @@ static int get_state_u8(u16_t net_idx, u16_t addr, u32_t op, u32_t rsp,
 		return err;
 	}
 
-	bt_mesh_model_msg_init(msg, op);
+	bt_mesh_model_msg_init(&msg, op);
 
-	err = bt_mesh_model_send(cli->model, &ctx, msg, NULL, NULL);
+	err = bt_mesh_model_send(cli->model, &ctx, &msg, NULL, NULL);
 	if (err) {
 		BT_ERR("model_send() failed (err %d)", err);
 		return err;
@@ -569,7 +569,7 @@ static int get_state_u8(u16_t net_idx, u16_t addr, u32_t op, u32_t rsp,
 static int set_state_u8(u16_t net_idx, u16_t addr, u32_t op, u32_t rsp,
 			u8_t new_val, u8_t *val)
 {
-	struct net_buf_simple *msg = NET_BUF_SIMPLE(2 + 1 + 4);
+	NET_BUF_SIMPLE_DEFINE(msg, 2 + 1 + 4);
 	struct bt_mesh_msg_ctx ctx = {
 		.net_idx = net_idx,
 		.app_idx = BT_MESH_KEY_DEV,
@@ -583,10 +583,10 @@ static int set_state_u8(u16_t net_idx, u16_t addr, u32_t op, u32_t rsp,
 		return err;
 	}
 
-	bt_mesh_model_msg_init(msg, op);
-	net_buf_simple_add_u8(msg, new_val);
+	bt_mesh_model_msg_init(&msg, op);
+	net_buf_simple_add_u8(&msg, new_val);
 
-	err = bt_mesh_model_send(cli->model, &ctx, msg, NULL, NULL);
+	err = bt_mesh_model_send(cli->model, &ctx, &msg, NULL, NULL);
 	if (err) {
 		BT_ERR("model_send() failed (err %d)", err);
 		return err;
@@ -647,7 +647,7 @@ int bt_mesh_cfg_gatt_proxy_set(u16_t net_idx, u16_t addr, u8_t val,
 int bt_mesh_cfg_relay_get(u16_t net_idx, u16_t addr, u8_t *status,
 			  u8_t *transmit)
 {
-	struct net_buf_simple *msg = NET_BUF_SIMPLE(2 + 0 + 4);
+	NET_BUF_SIMPLE_DEFINE(msg, 2 + 0 + 4);
 	struct bt_mesh_msg_ctx ctx = {
 		.net_idx = net_idx,
 		.app_idx = BT_MESH_KEY_DEV,
@@ -665,9 +665,9 @@ int bt_mesh_cfg_relay_get(u16_t net_idx, u16_t addr, u8_t *status,
 		return err;
 	}
 
-	bt_mesh_model_msg_init(msg, OP_RELAY_GET);
+	bt_mesh_model_msg_init(&msg, OP_RELAY_GET);
 
-	err = bt_mesh_model_send(cli->model, &ctx, msg, NULL, NULL);
+	err = bt_mesh_model_send(cli->model, &ctx, &msg, NULL, NULL);
 	if (err) {
 		BT_ERR("model_send() failed (err %d)", err);
 		return err;
@@ -679,7 +679,7 @@ int bt_mesh_cfg_relay_get(u16_t net_idx, u16_t addr, u8_t *status,
 int bt_mesh_cfg_relay_set(u16_t net_idx, u16_t addr, u8_t new_relay,
 			  u8_t new_transmit, u8_t *status, u8_t *transmit)
 {
-	struct net_buf_simple *msg = NET_BUF_SIMPLE(2 + 2 + 4);
+	NET_BUF_SIMPLE_DEFINE(msg, 2 + 2 + 4);
 	struct bt_mesh_msg_ctx ctx = {
 		.net_idx = net_idx,
 		.app_idx = BT_MESH_KEY_DEV,
@@ -697,11 +697,11 @@ int bt_mesh_cfg_relay_set(u16_t net_idx, u16_t addr, u8_t new_relay,
 		return err;
 	}
 
-	bt_mesh_model_msg_init(msg, OP_RELAY_SET);
-	net_buf_simple_add_u8(msg, new_relay);
-	net_buf_simple_add_u8(msg, new_transmit);
+	bt_mesh_model_msg_init(&msg, OP_RELAY_SET);
+	net_buf_simple_add_u8(&msg, new_relay);
+	net_buf_simple_add_u8(&msg, new_transmit);
 
-	err = bt_mesh_model_send(cli->model, &ctx, msg, NULL, NULL);
+	err = bt_mesh_model_send(cli->model, &ctx, &msg, NULL, NULL);
 	if (err) {
 		BT_ERR("model_send() failed (err %d)", err);
 		return err;
@@ -713,7 +713,7 @@ int bt_mesh_cfg_relay_set(u16_t net_idx, u16_t addr, u8_t new_relay,
 int bt_mesh_cfg_net_key_add(u16_t net_idx, u16_t addr, u16_t key_net_idx,
 			    const u8_t net_key[16], u8_t *status)
 {
-	struct net_buf_simple *msg = NET_BUF_SIMPLE(2 + 18 + 4);
+	NET_BUF_SIMPLE_DEFINE(msg, 2 + 18 + 4);
 	struct bt_mesh_msg_ctx ctx = {
 		.net_idx = net_idx,
 		.app_idx = BT_MESH_KEY_DEV,
@@ -731,11 +731,11 @@ int bt_mesh_cfg_net_key_add(u16_t net_idx, u16_t addr, u16_t key_net_idx,
 		return err;
 	}
 
-	bt_mesh_model_msg_init(msg, OP_NET_KEY_ADD);
-	net_buf_simple_add_le16(msg, key_net_idx);
-	net_buf_simple_add_mem(msg, net_key, 16);
+	bt_mesh_model_msg_init(&msg, OP_NET_KEY_ADD);
+	net_buf_simple_add_le16(&msg, key_net_idx);
+	net_buf_simple_add_mem(&msg, net_key, 16);
 
-	err = bt_mesh_model_send(cli->model, &ctx, msg, NULL, NULL);
+	err = bt_mesh_model_send(cli->model, &ctx, &msg, NULL, NULL);
 	if (err) {
 		BT_ERR("model_send() failed (err %d)", err);
 		return err;
@@ -752,7 +752,7 @@ int bt_mesh_cfg_app_key_add(u16_t net_idx, u16_t addr, u16_t key_net_idx,
 			    u16_t key_app_idx, const u8_t app_key[16],
 			    u8_t *status)
 {
-	struct net_buf_simple *msg = NET_BUF_SIMPLE(1 + 19 + 4);
+	NET_BUF_SIMPLE_DEFINE(msg, 1 + 19 + 4);
 	struct bt_mesh_msg_ctx ctx = {
 		.net_idx = net_idx,
 		.app_idx = BT_MESH_KEY_DEV,
@@ -771,11 +771,11 @@ int bt_mesh_cfg_app_key_add(u16_t net_idx, u16_t addr, u16_t key_net_idx,
 		return err;
 	}
 
-	bt_mesh_model_msg_init(msg, OP_APP_KEY_ADD);
-	key_idx_pack(msg, key_net_idx, key_app_idx);
-	net_buf_simple_add_mem(msg, app_key, 16);
+	bt_mesh_model_msg_init(&msg, OP_APP_KEY_ADD);
+	key_idx_pack(&msg, key_net_idx, key_app_idx);
+	net_buf_simple_add_mem(&msg, app_key, 16);
 
-	err = bt_mesh_model_send(cli->model, &ctx, msg, NULL, NULL);
+	err = bt_mesh_model_send(cli->model, &ctx, &msg, NULL, NULL);
 	if (err) {
 		BT_ERR("model_send() failed (err %d)", err);
 		return err;
@@ -792,7 +792,7 @@ static int mod_app_bind(u16_t net_idx, u16_t addr, u16_t elem_addr,
 			u16_t mod_app_idx, u16_t mod_id, u16_t cid,
 			u8_t *status)
 {
-	struct net_buf_simple *msg = NET_BUF_SIMPLE(2 + 8 + 4);
+	NET_BUF_SIMPLE_DEFINE(msg, 2 + 8 + 4);
 	struct bt_mesh_msg_ctx ctx = {
 		.net_idx = net_idx,
 		.app_idx = BT_MESH_KEY_DEV,
@@ -813,17 +813,17 @@ static int mod_app_bind(u16_t net_idx, u16_t addr, u16_t elem_addr,
 		return err;
 	}
 
-	bt_mesh_model_msg_init(msg, OP_MOD_APP_BIND);
-	net_buf_simple_add_le16(msg, elem_addr);
-	net_buf_simple_add_le16(msg, mod_app_idx);
+	bt_mesh_model_msg_init(&msg, OP_MOD_APP_BIND);
+	net_buf_simple_add_le16(&msg, elem_addr);
+	net_buf_simple_add_le16(&msg, mod_app_idx);
 
 	if (cid != CID_NVAL) {
-		net_buf_simple_add_le16(msg, cid);
+		net_buf_simple_add_le16(&msg, cid);
 	}
 
-	net_buf_simple_add_le16(msg, mod_id);
+	net_buf_simple_add_le16(&msg, mod_id);
 
-	err = bt_mesh_model_send(cli->model, &ctx, msg, NULL, NULL);
+	err = bt_mesh_model_send(cli->model, &ctx, &msg, NULL, NULL);
 	if (err) {
 		BT_ERR("model_send() failed (err %d)", err);
 		return err;
@@ -858,7 +858,7 @@ int bt_mesh_cfg_mod_app_bind_vnd(u16_t net_idx, u16_t addr, u16_t elem_addr,
 static int mod_sub(u32_t op, u16_t net_idx, u16_t addr, u16_t elem_addr,
 		   u16_t sub_addr, u16_t mod_id, u16_t cid, u8_t *status)
 {
-	struct net_buf_simple *msg = NET_BUF_SIMPLE(2 + 8 + 4);
+	NET_BUF_SIMPLE_DEFINE(msg, 2 + 8 + 4);
 	struct bt_mesh_msg_ctx ctx = {
 		.net_idx = net_idx,
 		.app_idx = BT_MESH_KEY_DEV,
@@ -879,17 +879,17 @@ static int mod_sub(u32_t op, u16_t net_idx, u16_t addr, u16_t elem_addr,
 		return err;
 	}
 
-	bt_mesh_model_msg_init(msg, op);
-	net_buf_simple_add_le16(msg, elem_addr);
-	net_buf_simple_add_le16(msg, sub_addr);
+	bt_mesh_model_msg_init(&msg, op);
+	net_buf_simple_add_le16(&msg, elem_addr);
+	net_buf_simple_add_le16(&msg, sub_addr);
 
 	if (cid != CID_NVAL) {
-		net_buf_simple_add_le16(msg, cid);
+		net_buf_simple_add_le16(&msg, cid);
 	}
 
-	net_buf_simple_add_le16(msg, mod_id);
+	net_buf_simple_add_le16(&msg, mod_id);
 
-	err = bt_mesh_model_send(cli->model, &ctx, msg, NULL, NULL);
+	err = bt_mesh_model_send(cli->model, &ctx, &msg, NULL, NULL);
 	if (err) {
 		BT_ERR("model_send() failed (err %d)", err);
 		return err;
@@ -963,7 +963,7 @@ static int mod_sub_va(u32_t op, u16_t net_idx, u16_t addr, u16_t elem_addr,
 		      const u8_t label[16], u16_t mod_id, u16_t cid,
 		      u16_t *virt_addr, u8_t *status)
 {
-	struct net_buf_simple *msg = NET_BUF_SIMPLE(2 + 22 + 4);
+	NET_BUF_SIMPLE_DEFINE(msg, 2 + 22 + 4);
 	struct bt_mesh_msg_ctx ctx = {
 		.net_idx = net_idx,
 		.app_idx = BT_MESH_KEY_DEV,
@@ -988,17 +988,17 @@ static int mod_sub_va(u32_t op, u16_t net_idx, u16_t addr, u16_t elem_addr,
 	       net_idx, addr, elem_addr, label);
 	BT_DBG("mod_id 0x%04x cid 0x%04x", mod_id, cid);
 
-	bt_mesh_model_msg_init(msg, op);
-	net_buf_simple_add_le16(msg, elem_addr);
-	net_buf_simple_add_mem(msg, label, 16);
+	bt_mesh_model_msg_init(&msg, op);
+	net_buf_simple_add_le16(&msg, elem_addr);
+	net_buf_simple_add_mem(&msg, label, 16);
 
 	if (cid != CID_NVAL) {
-		net_buf_simple_add_le16(msg, cid);
+		net_buf_simple_add_le16(&msg, cid);
 	}
 
-	net_buf_simple_add_le16(msg, mod_id);
+	net_buf_simple_add_le16(&msg, mod_id);
 
-	err = bt_mesh_model_send(cli->model, &ctx, msg, NULL, NULL);
+	err = bt_mesh_model_send(cli->model, &ctx, &msg, NULL, NULL);
 	if (err) {
 		BT_ERR("model_send() failed (err %d)", err);
 		return err;
@@ -1077,7 +1077,7 @@ static int mod_pub_get(u16_t net_idx, u16_t addr, u16_t elem_addr,
 		       u16_t mod_id, u16_t cid,
 		       struct bt_mesh_cfg_mod_pub *pub, u8_t *status)
 {
-	struct net_buf_simple *msg = NET_BUF_SIMPLE(2 + 6 + 4);
+	NET_BUF_SIMPLE_DEFINE(msg, 2 + 6 + 4);
 	struct bt_mesh_msg_ctx ctx = {
 		.net_idx = net_idx,
 		.app_idx = BT_MESH_KEY_DEV,
@@ -1098,17 +1098,17 @@ static int mod_pub_get(u16_t net_idx, u16_t addr, u16_t elem_addr,
 		return err;
 	}
 
-	bt_mesh_model_msg_init(msg, OP_MOD_PUB_GET);
+	bt_mesh_model_msg_init(&msg, OP_MOD_PUB_GET);
 
-	net_buf_simple_add_le16(msg, elem_addr);
+	net_buf_simple_add_le16(&msg, elem_addr);
 
 	if (cid != CID_NVAL) {
-		net_buf_simple_add_le16(msg, cid);
+		net_buf_simple_add_le16(&msg, cid);
 	}
 
-	net_buf_simple_add_le16(msg, mod_id);
+	net_buf_simple_add_le16(&msg, mod_id);
 
-	err = bt_mesh_model_send(cli->model, &ctx, msg, NULL, NULL);
+	err = bt_mesh_model_send(cli->model, &ctx, &msg, NULL, NULL);
 	if (err) {
 		BT_ERR("model_send() failed (err %d)", err);
 		return err;
@@ -1144,7 +1144,7 @@ static int mod_pub_set(u16_t net_idx, u16_t addr, u16_t elem_addr,
 		       u16_t mod_id, u16_t cid,
 		       struct bt_mesh_cfg_mod_pub *pub, u8_t *status)
 {
-	struct net_buf_simple *msg = NET_BUF_SIMPLE(2 + 13 + 4);
+	NET_BUF_SIMPLE_DEFINE(msg, 2 + 13 + 4);
 	struct bt_mesh_msg_ctx ctx = {
 		.net_idx = net_idx,
 		.app_idx = BT_MESH_KEY_DEV,
@@ -1165,22 +1165,22 @@ static int mod_pub_set(u16_t net_idx, u16_t addr, u16_t elem_addr,
 		return err;
 	}
 
-	bt_mesh_model_msg_init(msg, OP_MOD_PUB_SET);
+	bt_mesh_model_msg_init(&msg, OP_MOD_PUB_SET);
 
-	net_buf_simple_add_le16(msg, elem_addr);
-	net_buf_simple_add_le16(msg, pub->addr);
-	net_buf_simple_add_le16(msg, (pub->app_idx & (pub->cred_flag << 12)));
-	net_buf_simple_add_u8(msg, pub->ttl);
-	net_buf_simple_add_u8(msg, pub->period);
-	net_buf_simple_add_u8(msg, pub->transmit);
+	net_buf_simple_add_le16(&msg, elem_addr);
+	net_buf_simple_add_le16(&msg, pub->addr);
+	net_buf_simple_add_le16(&msg, (pub->app_idx & (pub->cred_flag << 12)));
+	net_buf_simple_add_u8(&msg, pub->ttl);
+	net_buf_simple_add_u8(&msg, pub->period);
+	net_buf_simple_add_u8(&msg, pub->transmit);
 
 	if (cid != CID_NVAL) {
-		net_buf_simple_add_le16(msg, cid);
+		net_buf_simple_add_le16(&msg, cid);
 	}
 
-	net_buf_simple_add_le16(msg, mod_id);
+	net_buf_simple_add_le16(&msg, mod_id);
 
-	err = bt_mesh_model_send(cli->model, &ctx, msg, NULL, NULL);
+	err = bt_mesh_model_send(cli->model, &ctx, &msg, NULL, NULL);
 	if (err) {
 		BT_ERR("model_send() failed (err %d)", err);
 		return err;
@@ -1215,7 +1215,7 @@ int bt_mesh_cfg_mod_pub_set_vnd(u16_t net_idx, u16_t addr, u16_t elem_addr,
 int bt_mesh_cfg_hb_sub_set(u16_t net_idx, u16_t addr,
 			   struct bt_mesh_cfg_hb_sub *sub, u8_t *status)
 {
-	struct net_buf_simple *msg = NET_BUF_SIMPLE(2 + 5 + 4);
+	NET_BUF_SIMPLE_DEFINE(msg, 2 + 5 + 4);
 	struct bt_mesh_msg_ctx ctx = {
 		.net_idx = net_idx,
 		.app_idx = BT_MESH_KEY_DEV,
@@ -1233,12 +1233,12 @@ int bt_mesh_cfg_hb_sub_set(u16_t net_idx, u16_t addr,
 		return err;
 	}
 
-	bt_mesh_model_msg_init(msg, OP_HEARTBEAT_SUB_SET);
-	net_buf_simple_add_le16(msg, sub->src);
-	net_buf_simple_add_le16(msg, sub->dst);
-	net_buf_simple_add_u8(msg, sub->period);
+	bt_mesh_model_msg_init(&msg, OP_HEARTBEAT_SUB_SET);
+	net_buf_simple_add_le16(&msg, sub->src);
+	net_buf_simple_add_le16(&msg, sub->dst);
+	net_buf_simple_add_u8(&msg, sub->period);
 
-	err = bt_mesh_model_send(cli->model, &ctx, msg, NULL, NULL);
+	err = bt_mesh_model_send(cli->model, &ctx, &msg, NULL, NULL);
 	if (err) {
 		BT_ERR("model_send() failed (err %d)", err);
 		return err;
@@ -1254,7 +1254,7 @@ int bt_mesh_cfg_hb_sub_set(u16_t net_idx, u16_t addr,
 int bt_mesh_cfg_hb_sub_get(u16_t net_idx, u16_t addr,
 			   struct bt_mesh_cfg_hb_sub *sub, u8_t *status)
 {
-	struct net_buf_simple *msg = NET_BUF_SIMPLE(2 + 0 + 4);
+	NET_BUF_SIMPLE_DEFINE(msg, 2 + 0 + 4);
 	struct bt_mesh_msg_ctx ctx = {
 		.net_idx = net_idx,
 		.app_idx = BT_MESH_KEY_DEV,
@@ -1272,9 +1272,9 @@ int bt_mesh_cfg_hb_sub_get(u16_t net_idx, u16_t addr,
 		return err;
 	}
 
-	bt_mesh_model_msg_init(msg, OP_HEARTBEAT_SUB_GET);
+	bt_mesh_model_msg_init(&msg, OP_HEARTBEAT_SUB_GET);
 
-	err = bt_mesh_model_send(cli->model, &ctx, msg, NULL, NULL);
+	err = bt_mesh_model_send(cli->model, &ctx, &msg, NULL, NULL);
 	if (err) {
 		BT_ERR("model_send() failed (err %d)", err);
 		return err;
@@ -1290,7 +1290,7 @@ int bt_mesh_cfg_hb_sub_get(u16_t net_idx, u16_t addr,
 int bt_mesh_cfg_hb_pub_set(u16_t net_idx, u16_t addr,
 			   const struct bt_mesh_cfg_hb_pub *pub, u8_t *status)
 {
-	struct net_buf_simple *msg = NET_BUF_SIMPLE(2 + 9 + 4);
+	NET_BUF_SIMPLE_DEFINE(msg, 2 + 9 + 4);
 	struct bt_mesh_msg_ctx ctx = {
 		.net_idx = net_idx,
 		.app_idx = BT_MESH_KEY_DEV,
@@ -1307,15 +1307,15 @@ int bt_mesh_cfg_hb_pub_set(u16_t net_idx, u16_t addr,
 		return err;
 	}
 
-	bt_mesh_model_msg_init(msg, OP_HEARTBEAT_PUB_SET);
-	net_buf_simple_add_le16(msg, pub->dst);
-	net_buf_simple_add_u8(msg, pub->count);
-	net_buf_simple_add_u8(msg, pub->period);
-	net_buf_simple_add_u8(msg, pub->ttl);
-	net_buf_simple_add_le16(msg, pub->feat);
-	net_buf_simple_add_le16(msg, pub->net_idx);
+	bt_mesh_model_msg_init(&msg, OP_HEARTBEAT_PUB_SET);
+	net_buf_simple_add_le16(&msg, pub->dst);
+	net_buf_simple_add_u8(&msg, pub->count);
+	net_buf_simple_add_u8(&msg, pub->period);
+	net_buf_simple_add_u8(&msg, pub->ttl);
+	net_buf_simple_add_le16(&msg, pub->feat);
+	net_buf_simple_add_le16(&msg, pub->net_idx);
 
-	err = bt_mesh_model_send(cli->model, &ctx, msg, NULL, NULL);
+	err = bt_mesh_model_send(cli->model, &ctx, &msg, NULL, NULL);
 	if (err) {
 		BT_ERR("model_send() failed (err %d)", err);
 		return err;
@@ -1331,7 +1331,7 @@ int bt_mesh_cfg_hb_pub_set(u16_t net_idx, u16_t addr,
 int bt_mesh_cfg_hb_pub_get(u16_t net_idx, u16_t addr,
 			   struct bt_mesh_cfg_hb_pub *pub, u8_t *status)
 {
-	struct net_buf_simple *msg = NET_BUF_SIMPLE(2 + 0 + 4);
+	NET_BUF_SIMPLE_DEFINE(msg, 2 + 0 + 4);
 	struct bt_mesh_msg_ctx ctx = {
 		.net_idx = net_idx,
 		.app_idx = BT_MESH_KEY_DEV,
@@ -1349,9 +1349,9 @@ int bt_mesh_cfg_hb_pub_get(u16_t net_idx, u16_t addr,
 		return err;
 	}
 
-	bt_mesh_model_msg_init(msg, OP_HEARTBEAT_PUB_GET);
+	bt_mesh_model_msg_init(&msg, OP_HEARTBEAT_PUB_GET);
 
-	err = bt_mesh_model_send(cli->model, &ctx, msg, NULL, NULL);
+	err = bt_mesh_model_send(cli->model, &ctx, &msg, NULL, NULL);
 	if (err) {
 		BT_ERR("model_send() failed (err %d)", err);
 		return err;

--- a/subsys/bluetooth/host/mesh/cfg_srv.c
+++ b/subsys/bluetooth/host/mesh/cfg_srv.c
@@ -172,7 +172,7 @@ static void dev_comp_data_get(struct bt_mesh_model *model,
 			      struct bt_mesh_msg_ctx *ctx,
 			      struct net_buf_simple *buf)
 {
-	struct net_buf_simple *sdu = NET_BUF_SIMPLE(BT_MESH_TX_SDU_MAX);
+	NET_BUF_SIMPLE_DEFINE(sdu, BT_MESH_TX_SDU_MAX);
 	u8_t page;
 
 	BT_DBG("net_idx 0x%04x app_idx 0x%04x src 0x%04x len %u: %s",
@@ -185,15 +185,15 @@ static void dev_comp_data_get(struct bt_mesh_model *model,
 		page = 0;
 	}
 
-	bt_mesh_model_msg_init(sdu, OP_DEV_COMP_DATA_STATUS);
+	bt_mesh_model_msg_init(&sdu, OP_DEV_COMP_DATA_STATUS);
 
-	net_buf_simple_add_u8(sdu, page);
-	if (comp_get_page_0(sdu) < 0) {
+	net_buf_simple_add_u8(&sdu, page);
+	if (comp_get_page_0(&sdu) < 0) {
 		BT_ERR("Unable to get composition page 0");
 		return;
 	}
 
-	if (bt_mesh_model_send(model, ctx, sdu, NULL, NULL)) {
+	if (bt_mesh_model_send(model, ctx, &sdu, NULL, NULL)) {
 		BT_ERR("Unable to send Device Composition Status response");
 	}
 }
@@ -457,7 +457,7 @@ static void app_key_add(struct bt_mesh_model *model,
 			struct bt_mesh_msg_ctx *ctx,
 			struct net_buf_simple *buf)
 {
-	struct net_buf_simple *msg = NET_BUF_SIMPLE(2 + 4 + 4);
+	NET_BUF_SIMPLE_DEFINE(msg, 2 + 4 + 4);
 	u16_t key_net_idx, key_app_idx;
 	u8_t status;
 
@@ -465,15 +465,15 @@ static void app_key_add(struct bt_mesh_model *model,
 
 	BT_DBG("AppIdx 0x%04x NetIdx 0x%04x", key_app_idx, key_net_idx);
 
-	bt_mesh_model_msg_init(msg, OP_APP_KEY_STATUS);
+	bt_mesh_model_msg_init(&msg, OP_APP_KEY_STATUS);
 
 	status = app_key_set(key_net_idx, key_app_idx, buf->data, false);
 	BT_DBG("status 0x%02x", status);
-	net_buf_simple_add_u8(msg, status);
+	net_buf_simple_add_u8(&msg, status);
 
-	key_idx_pack(msg, key_net_idx, key_app_idx);
+	key_idx_pack(&msg, key_net_idx, key_app_idx);
 
-	if (bt_mesh_model_send(model, ctx, msg, NULL, NULL)) {
+	if (bt_mesh_model_send(model, ctx, &msg, NULL, NULL)) {
 		BT_ERR("Unable to send App Key Status response");
 	}
 }
@@ -482,7 +482,7 @@ static void app_key_update(struct bt_mesh_model *model,
 			   struct bt_mesh_msg_ctx *ctx,
 			   struct net_buf_simple *buf)
 {
-	struct net_buf_simple *msg = NET_BUF_SIMPLE(2 + 4 + 4);
+	NET_BUF_SIMPLE_DEFINE(msg, 2 + 4 + 4);
 	u16_t key_net_idx, key_app_idx;
 	u8_t status;
 
@@ -490,15 +490,15 @@ static void app_key_update(struct bt_mesh_model *model,
 
 	BT_DBG("AppIdx 0x%04x NetIdx 0x%04x", key_app_idx, key_net_idx);
 
-	bt_mesh_model_msg_init(msg, OP_APP_KEY_STATUS);
+	bt_mesh_model_msg_init(&msg, OP_APP_KEY_STATUS);
 
 	status = app_key_set(key_net_idx, key_app_idx, buf->data, true);
 	BT_DBG("status 0x%02x", status);
-	net_buf_simple_add_u8(msg, status);
+	net_buf_simple_add_u8(&msg, status);
 
-	key_idx_pack(msg, key_net_idx, key_app_idx);
+	key_idx_pack(&msg, key_net_idx, key_app_idx);
 
-	if (bt_mesh_model_send(model, ctx, msg, NULL, NULL)) {
+	if (bt_mesh_model_send(model, ctx, &msg, NULL, NULL)) {
 		BT_ERR("Unable to send App Key Status response");
 	}
 }
@@ -523,7 +523,7 @@ static void app_key_del(struct bt_mesh_model *model,
 			struct bt_mesh_msg_ctx *ctx,
 			struct net_buf_simple *buf)
 {
-	struct net_buf_simple *msg = NET_BUF_SIMPLE(2 + 4 + 4);
+	NET_BUF_SIMPLE_DEFINE(msg, 2 + 4 + 4);
 	u16_t key_net_idx, key_app_idx;
 	struct bt_mesh_app_key *key;
 	u8_t status;
@@ -555,13 +555,13 @@ static void app_key_del(struct bt_mesh_model *model,
 	status = STATUS_SUCCESS;
 
 send_status:
-	bt_mesh_model_msg_init(msg, OP_APP_KEY_STATUS);
+	bt_mesh_model_msg_init(&msg, OP_APP_KEY_STATUS);
 
-	net_buf_simple_add_u8(msg, status);
+	net_buf_simple_add_u8(&msg, status);
 
-	key_idx_pack(msg, key_net_idx, key_app_idx);
+	key_idx_pack(&msg, key_net_idx, key_app_idx);
 
-	if (bt_mesh_model_send(model, ctx, msg, NULL, NULL)) {
+	if (bt_mesh_model_send(model, ctx, &msg, NULL, NULL)) {
 		BT_ERR("Unable to send App Key Status response");
 	}
 }
@@ -573,9 +573,8 @@ static void app_key_get(struct bt_mesh_model *model,
 			struct bt_mesh_msg_ctx *ctx,
 			struct net_buf_simple *buf)
 {
-	struct net_buf_simple *msg =
-		NET_BUF_SIMPLE(2 + 3 + 4 +
-			       IDX_LEN(CONFIG_BT_MESH_APP_KEY_COUNT));
+	NET_BUF_SIMPLE_DEFINE(msg, 2 + 3 + 4 +
+			      IDX_LEN(CONFIG_BT_MESH_APP_KEY_COUNT));
 	u16_t get_idx, i, prev;
 	u8_t status;
 
@@ -587,7 +586,7 @@ static void app_key_get(struct bt_mesh_model *model,
 
 	BT_DBG("idx 0x%04x", get_idx);
 
-	bt_mesh_model_msg_init(msg, OP_APP_KEY_LIST);
+	bt_mesh_model_msg_init(&msg, OP_APP_KEY_LIST);
 
 	if (!bt_mesh_subnet_get(get_idx)) {
 		status = STATUS_INVALID_NETKEY;
@@ -595,8 +594,8 @@ static void app_key_get(struct bt_mesh_model *model,
 		status = STATUS_SUCCESS;
 	}
 
-	net_buf_simple_add_u8(msg, status);
-	net_buf_simple_add_le16(msg, get_idx);
+	net_buf_simple_add_u8(&msg, status);
+	net_buf_simple_add_le16(&msg, get_idx);
 
 	if (status != STATUS_SUCCESS) {
 		goto send_status;
@@ -615,16 +614,16 @@ static void app_key_get(struct bt_mesh_model *model,
 			continue;
 		}
 
-		key_idx_pack(msg, prev, key->app_idx);
+		key_idx_pack(&msg, prev, key->app_idx);
 		prev = BT_MESH_KEY_UNUSED;
 	}
 
 	if (prev != BT_MESH_KEY_UNUSED) {
-		net_buf_simple_add_le16(msg, prev);
+		net_buf_simple_add_le16(&msg, prev);
 	}
 
 send_status:
-	if (bt_mesh_model_send(model, ctx, msg, NULL, NULL)) {
+	if (bt_mesh_model_send(model, ctx, &msg, NULL, NULL)) {
 		BT_ERR("Unable to send AppKey List");
 	}
 }
@@ -634,16 +633,16 @@ static void beacon_get(struct bt_mesh_model *model,
 		       struct net_buf_simple *buf)
 {
 	/* Needed size: opcode (2 bytes) + msg + MIC */
-	struct net_buf_simple *msg = NET_BUF_SIMPLE(2 + 1 + 4);
+	NET_BUF_SIMPLE_DEFINE(msg, 2 + 1 + 4);
 
 	BT_DBG("net_idx 0x%04x app_idx 0x%04x src 0x%04x len %u: %s",
 	       ctx->net_idx, ctx->app_idx, ctx->addr, buf->len,
 	       bt_hex(buf->data, buf->len));
 
-	bt_mesh_model_msg_init(msg, OP_BEACON_STATUS);
-	net_buf_simple_add_u8(msg, bt_mesh_beacon_get());
+	bt_mesh_model_msg_init(&msg, OP_BEACON_STATUS);
+	net_buf_simple_add_u8(&msg, bt_mesh_beacon_get());
 
-	if (bt_mesh_model_send(model, ctx, msg, NULL, NULL)) {
+	if (bt_mesh_model_send(model, ctx, &msg, NULL, NULL)) {
 		BT_ERR("Unable to send Config Beacon Status response");
 	}
 }
@@ -653,7 +652,7 @@ static void beacon_set(struct bt_mesh_model *model,
 		       struct net_buf_simple *buf)
 {
 	/* Needed size: opcode (2 bytes) + msg + MIC */
-	struct net_buf_simple *msg = NET_BUF_SIMPLE(2 + 1 + 4);
+	NET_BUF_SIMPLE_DEFINE(msg, 2 + 1 + 4);
 	struct bt_mesh_cfg_srv *cfg = model->user_data;
 
 	BT_DBG("net_idx 0x%04x app_idx 0x%04x src 0x%04x len %u: %s",
@@ -677,10 +676,10 @@ static void beacon_set(struct bt_mesh_model *model,
 		return;
 	}
 
-	bt_mesh_model_msg_init(msg, OP_BEACON_STATUS);
-	net_buf_simple_add_u8(msg, bt_mesh_beacon_get());
+	bt_mesh_model_msg_init(&msg, OP_BEACON_STATUS);
+	net_buf_simple_add_u8(&msg, bt_mesh_beacon_get());
 
-	if (bt_mesh_model_send(model, ctx, msg, NULL, NULL)) {
+	if (bt_mesh_model_send(model, ctx, &msg, NULL, NULL)) {
 		BT_ERR("Unable to send Config Beacon Status response");
 	}
 }
@@ -690,16 +689,16 @@ static void default_ttl_get(struct bt_mesh_model *model,
 			    struct net_buf_simple *buf)
 {
 	/* Needed size: opcode (2 bytes) + msg + MIC */
-	struct net_buf_simple *msg = NET_BUF_SIMPLE(2 + 1 + 4);
+	NET_BUF_SIMPLE_DEFINE(msg, 2 + 1 + 4);
 
 	BT_DBG("net_idx 0x%04x app_idx 0x%04x src 0x%04x len %u: %s",
 	       ctx->net_idx, ctx->app_idx, ctx->addr, buf->len,
 	       bt_hex(buf->data, buf->len));
 
-	bt_mesh_model_msg_init(msg, OP_DEFAULT_TTL_STATUS);
-	net_buf_simple_add_u8(msg, bt_mesh_default_ttl_get());
+	bt_mesh_model_msg_init(&msg, OP_DEFAULT_TTL_STATUS);
+	net_buf_simple_add_u8(&msg, bt_mesh_default_ttl_get());
 
-	if (bt_mesh_model_send(model, ctx, msg, NULL, NULL)) {
+	if (bt_mesh_model_send(model, ctx, &msg, NULL, NULL)) {
 		BT_ERR("Unable to send Default TTL Status response");
 	}
 }
@@ -709,7 +708,7 @@ static void default_ttl_set(struct bt_mesh_model *model,
 			    struct net_buf_simple *buf)
 {
 	/* Needed size: opcode (2 bytes) + msg + MIC */
-	struct net_buf_simple *msg = NET_BUF_SIMPLE(2 + 1 + 4);
+	NET_BUF_SIMPLE_DEFINE(msg, 2 + 1 + 4);
 	struct bt_mesh_cfg_srv *cfg = model->user_data;
 
 	BT_DBG("net_idx 0x%04x app_idx 0x%04x src 0x%04x len %u: %s",
@@ -725,10 +724,10 @@ static void default_ttl_set(struct bt_mesh_model *model,
 		return;
 	}
 
-	bt_mesh_model_msg_init(msg, OP_DEFAULT_TTL_STATUS);
-	net_buf_simple_add_u8(msg, bt_mesh_default_ttl_get());
+	bt_mesh_model_msg_init(&msg, OP_DEFAULT_TTL_STATUS);
+	net_buf_simple_add_u8(&msg, bt_mesh_default_ttl_get());
 
-	if (bt_mesh_model_send(model, ctx, msg, NULL, NULL)) {
+	if (bt_mesh_model_send(model, ctx, &msg, NULL, NULL)) {
 		BT_ERR("Unable to send Default TTL Status response");
 	}
 }
@@ -737,12 +736,12 @@ static void send_gatt_proxy_status(struct bt_mesh_model *model,
 				   struct bt_mesh_msg_ctx *ctx)
 {
 	/* Needed size: opcode (2 bytes) + msg + MIC */
-	struct net_buf_simple *msg = NET_BUF_SIMPLE(2 + 1 + 4);
+	NET_BUF_SIMPLE_DEFINE(msg, 2 + 1 + 4);
 
-	bt_mesh_model_msg_init(msg, OP_GATT_PROXY_STATUS);
-	net_buf_simple_add_u8(msg, bt_mesh_gatt_proxy_get());
+	bt_mesh_model_msg_init(&msg, OP_GATT_PROXY_STATUS);
+	net_buf_simple_add_u8(&msg, bt_mesh_gatt_proxy_get());
 
-	if (bt_mesh_model_send(model, ctx, msg, NULL, NULL)) {
+	if (bt_mesh_model_send(model, ctx, &msg, NULL, NULL)) {
 		BT_ERR("Unable to send GATT Proxy Status");
 	}
 }
@@ -829,16 +828,16 @@ static void net_transmit_get(struct bt_mesh_model *model,
 			     struct net_buf_simple *buf)
 {
 	/* Needed size: opcode (2 bytes) + msg + MIC */
-	struct net_buf_simple *msg = NET_BUF_SIMPLE(2 + 1 + 4);
+	NET_BUF_SIMPLE_DEFINE(msg, 2 + 1 + 4);
 
 	BT_DBG("net_idx 0x%04x app_idx 0x%04x src 0x%04x len %u: %s",
 	       ctx->net_idx, ctx->app_idx, ctx->addr, buf->len,
 	       bt_hex(buf->data, buf->len));
 
-	bt_mesh_model_msg_init(msg, OP_NET_TRANSMIT_STATUS);
-	net_buf_simple_add_u8(msg, bt_mesh_net_transmit_get());
+	bt_mesh_model_msg_init(&msg, OP_NET_TRANSMIT_STATUS);
+	net_buf_simple_add_u8(&msg, bt_mesh_net_transmit_get());
 
-	if (bt_mesh_model_send(model, ctx, msg, NULL, NULL)) {
+	if (bt_mesh_model_send(model, ctx, &msg, NULL, NULL)) {
 		BT_ERR("Unable to send Config Network Transmit Status");
 	}
 }
@@ -848,7 +847,7 @@ static void net_transmit_set(struct bt_mesh_model *model,
 			     struct net_buf_simple *buf)
 {
 	/* Needed size: opcode (2 bytes) + msg + MIC */
-	struct net_buf_simple *msg = NET_BUF_SIMPLE(2 + 1 + 4);
+	NET_BUF_SIMPLE_DEFINE(msg, 2 + 1 + 4);
 	struct bt_mesh_cfg_srv *cfg = model->user_data;
 
 	BT_DBG("net_idx 0x%04x app_idx 0x%04x src 0x%04x len %u: %s",
@@ -865,10 +864,10 @@ static void net_transmit_set(struct bt_mesh_model *model,
 		cfg->net_transmit = buf->data[0];
 	}
 
-	bt_mesh_model_msg_init(msg, OP_NET_TRANSMIT_STATUS);
-	net_buf_simple_add_u8(msg, bt_mesh_net_transmit_get());
+	bt_mesh_model_msg_init(&msg, OP_NET_TRANSMIT_STATUS);
+	net_buf_simple_add_u8(&msg, bt_mesh_net_transmit_get());
 
-	if (bt_mesh_model_send(model, ctx, msg, NULL, NULL)) {
+	if (bt_mesh_model_send(model, ctx, &msg, NULL, NULL)) {
 		BT_ERR("Unable to send Network Transmit Status");
 	}
 }
@@ -878,17 +877,17 @@ static void relay_get(struct bt_mesh_model *model,
 		      struct net_buf_simple *buf)
 {
 	/* Needed size: opcode (2 bytes) + msg + MIC */
-	struct net_buf_simple *msg = NET_BUF_SIMPLE(2 + 2 + 4);
+	NET_BUF_SIMPLE_DEFINE(msg, 2 + 2 + 4);
 
 	BT_DBG("net_idx 0x%04x app_idx 0x%04x src 0x%04x len %u: %s",
 	       ctx->net_idx, ctx->app_idx, ctx->addr, buf->len,
 	       bt_hex(buf->data, buf->len));
 
-	bt_mesh_model_msg_init(msg, OP_RELAY_STATUS);
-	net_buf_simple_add_u8(msg, bt_mesh_relay_get());
-	net_buf_simple_add_u8(msg, bt_mesh_relay_retransmit_get());
+	bt_mesh_model_msg_init(&msg, OP_RELAY_STATUS);
+	net_buf_simple_add_u8(&msg, bt_mesh_relay_get());
+	net_buf_simple_add_u8(&msg, bt_mesh_relay_retransmit_get());
 
-	if (bt_mesh_model_send(model, ctx, msg, NULL, NULL)) {
+	if (bt_mesh_model_send(model, ctx, &msg, NULL, NULL)) {
 		BT_ERR("Unable to send Config Relay Status response");
 	}
 }
@@ -898,7 +897,7 @@ static void relay_set(struct bt_mesh_model *model,
 		      struct net_buf_simple *buf)
 {
 	/* Needed size: opcode (2 bytes) + msg + MIC */
-	struct net_buf_simple *msg = NET_BUF_SIMPLE(2 + 2 + 4);
+	NET_BUF_SIMPLE_DEFINE(msg, 2 + 2 + 4);
 	struct bt_mesh_cfg_srv *cfg = model->user_data;
 
 	BT_DBG("net_idx 0x%04x app_idx 0x%04x src 0x%04x len %u: %s",
@@ -934,11 +933,11 @@ static void relay_set(struct bt_mesh_model *model,
 		return;
 	}
 
-	bt_mesh_model_msg_init(msg, OP_RELAY_STATUS);
-	net_buf_simple_add_u8(msg, bt_mesh_relay_get());
-	net_buf_simple_add_u8(msg, bt_mesh_relay_retransmit_get());
+	bt_mesh_model_msg_init(&msg, OP_RELAY_STATUS);
+	net_buf_simple_add_u8(&msg, bt_mesh_relay_get());
+	net_buf_simple_add_u8(&msg, bt_mesh_relay_retransmit_get());
 
-	if (bt_mesh_model_send(model, ctx, msg, NULL, NULL)) {
+	if (bt_mesh_model_send(model, ctx, &msg, NULL, NULL)) {
 		BT_ERR("Unable to send Relay Status response");
 	}
 }
@@ -950,34 +949,34 @@ static void send_mod_pub_status(struct bt_mesh_model *cfg_mod,
 				u8_t status, u8_t *mod_id)
 {
 	/* Needed size: opcode (2 bytes) + msg + MIC */
-	struct net_buf_simple *msg = NET_BUF_SIMPLE(2 + 14 + 4);
+	NET_BUF_SIMPLE_DEFINE(msg, 2 + 14 + 4);
 
-	bt_mesh_model_msg_init(msg, OP_MOD_PUB_STATUS);
+	bt_mesh_model_msg_init(&msg, OP_MOD_PUB_STATUS);
 
-	net_buf_simple_add_u8(msg, status);
-	net_buf_simple_add_le16(msg, elem_addr);
+	net_buf_simple_add_u8(&msg, status);
+	net_buf_simple_add_le16(&msg, elem_addr);
 
 	if (status != STATUS_SUCCESS) {
-		memset(net_buf_simple_add(msg, 7), 0, 7);
+		memset(net_buf_simple_add(&msg, 7), 0, 7);
 	} else {
 		u16_t idx_cred;
 
-		net_buf_simple_add_le16(msg, pub_addr);
+		net_buf_simple_add_le16(&msg, pub_addr);
 
 		idx_cred = mod->pub->key | (u16_t)mod->pub->cred << 12;
-		net_buf_simple_add_le16(msg, idx_cred);
-		net_buf_simple_add_u8(msg, mod->pub->ttl);
-		net_buf_simple_add_u8(msg, mod->pub->period);
-		net_buf_simple_add_u8(msg, mod->pub->retransmit);
+		net_buf_simple_add_le16(&msg, idx_cred);
+		net_buf_simple_add_u8(&msg, mod->pub->ttl);
+		net_buf_simple_add_u8(&msg, mod->pub->period);
+		net_buf_simple_add_u8(&msg, mod->pub->retransmit);
 	}
 
 	if (vnd) {
-		memcpy(net_buf_simple_add(msg, 4), mod_id, 4);
+		memcpy(net_buf_simple_add(&msg, 4), mod_id, 4);
 	} else {
-		memcpy(net_buf_simple_add(msg, 2), mod_id, 2);
+		memcpy(net_buf_simple_add(&msg, 2), mod_id, 2);
 	}
 
-	if (bt_mesh_model_send(cfg_mod, ctx, msg, NULL, NULL)) {
+	if (bt_mesh_model_send(cfg_mod, ctx, &msg, NULL, NULL)) {
 		BT_ERR("Unable to send Model Publication Status");
 	}
 }
@@ -1281,24 +1280,24 @@ static void send_mod_sub_status(struct bt_mesh_model *model,
 				bool vnd)
 {
 	/* Needed size: opcode (2 bytes) + msg + MIC */
-	struct net_buf_simple *msg = NET_BUF_SIMPLE(2 + 9 + 4);
+	NET_BUF_SIMPLE_DEFINE(msg, 2 + 9 + 4);
 
 	BT_DBG("status 0x%02x elem_addr 0x%04x sub_addr 0x%04x", status,
 	       elem_addr, sub_addr);
 
-	bt_mesh_model_msg_init(msg, OP_MOD_SUB_STATUS);
+	bt_mesh_model_msg_init(&msg, OP_MOD_SUB_STATUS);
 
-	net_buf_simple_add_u8(msg, status);
-	net_buf_simple_add_le16(msg, elem_addr);
-	net_buf_simple_add_le16(msg, sub_addr);
+	net_buf_simple_add_u8(&msg, status);
+	net_buf_simple_add_le16(&msg, elem_addr);
+	net_buf_simple_add_le16(&msg, sub_addr);
 
 	if (vnd) {
-		memcpy(net_buf_simple_add(msg, 4), mod_id, 4);
+		memcpy(net_buf_simple_add(&msg, 4), mod_id, 4);
 	} else {
-		memcpy(net_buf_simple_add(msg, 2), mod_id, 2);
+		memcpy(net_buf_simple_add(&msg, 2), mod_id, 2);
 	}
 
-	if (bt_mesh_model_send(model, ctx, msg, NULL, NULL)) {
+	if (bt_mesh_model_send(model, ctx, &msg, NULL, NULL)) {
 		BT_ERR("Unable to send Model Subscription Status");
 	}
 }
@@ -1534,9 +1533,8 @@ static void mod_sub_get(struct bt_mesh_model *model,
 			struct bt_mesh_msg_ctx *ctx,
 			struct net_buf_simple *buf)
 {
-	struct net_buf_simple *msg =
-		NET_BUF_SIMPLE(2 + 5 + 4 +
-			       CONFIG_BT_MESH_MODEL_GROUP_COUNT * 2);
+	NET_BUF_SIMPLE_DEFINE(msg, 2 + 5 + 4 +
+			      CONFIG_BT_MESH_MODEL_GROUP_COUNT * 2);
 	struct bt_mesh_model *mod;
 	struct bt_mesh_elem *elem;
 	u16_t addr, id;
@@ -1547,37 +1545,37 @@ static void mod_sub_get(struct bt_mesh_model *model,
 
 	BT_DBG("addr 0x%04x id 0x%04x", addr, id);
 
-	bt_mesh_model_msg_init(msg, OP_MOD_SUB_LIST);
+	bt_mesh_model_msg_init(&msg, OP_MOD_SUB_LIST);
 
 	elem = bt_mesh_elem_find(addr);
 	if (!elem) {
-		net_buf_simple_add_u8(msg, STATUS_INVALID_ADDRESS);
-		net_buf_simple_add_le16(msg, addr);
-		net_buf_simple_add_le16(msg, id);
+		net_buf_simple_add_u8(&msg, STATUS_INVALID_ADDRESS);
+		net_buf_simple_add_le16(&msg, addr);
+		net_buf_simple_add_le16(&msg, id);
 		goto send_list;
 	}
 
 	mod = bt_mesh_model_find(elem, id);
 	if (!mod) {
-		net_buf_simple_add_u8(msg, STATUS_INVALID_MODEL);
-		net_buf_simple_add_le16(msg, addr);
-		net_buf_simple_add_le16(msg, id);
+		net_buf_simple_add_u8(&msg, STATUS_INVALID_MODEL);
+		net_buf_simple_add_le16(&msg, addr);
+		net_buf_simple_add_le16(&msg, id);
 		goto send_list;
 	}
 
-	net_buf_simple_add_u8(msg, STATUS_SUCCESS);
+	net_buf_simple_add_u8(&msg, STATUS_SUCCESS);
 
-	net_buf_simple_add_le16(msg, addr);
-	net_buf_simple_add_le16(msg, id);
+	net_buf_simple_add_le16(&msg, addr);
+	net_buf_simple_add_le16(&msg, id);
 
 	for (i = 0; i < ARRAY_SIZE(mod->groups); i++) {
 		if (mod->groups[i] != BT_MESH_ADDR_UNASSIGNED) {
-			net_buf_simple_add_le16(msg, mod->groups[i]);
+			net_buf_simple_add_le16(&msg, mod->groups[i]);
 		}
 	}
 
 send_list:
-	if (bt_mesh_model_send(model, ctx, msg, NULL, NULL)) {
+	if (bt_mesh_model_send(model, ctx, &msg, NULL, NULL)) {
 		BT_ERR("Unable to send Model Subscription List");
 	}
 }
@@ -1586,9 +1584,8 @@ static void mod_sub_get_vnd(struct bt_mesh_model *model,
 			    struct bt_mesh_msg_ctx *ctx,
 			    struct net_buf_simple *buf)
 {
-	struct net_buf_simple *msg =
-		NET_BUF_SIMPLE(2 + 7 + 4 +
-			       CONFIG_BT_MESH_MODEL_GROUP_COUNT * 2);
+	NET_BUF_SIMPLE_DEFINE(msg, 2 + 7 + 4 +
+			      CONFIG_BT_MESH_MODEL_GROUP_COUNT * 2);
 	struct bt_mesh_model *mod;
 	struct bt_mesh_elem *elem;
 	u16_t company, addr, id;
@@ -1600,40 +1597,40 @@ static void mod_sub_get_vnd(struct bt_mesh_model *model,
 
 	BT_DBG("addr 0x%04x company 0x%04x id 0x%04x", addr, company, id);
 
-	bt_mesh_model_msg_init(msg, OP_MOD_SUB_LIST_VND);
+	bt_mesh_model_msg_init(&msg, OP_MOD_SUB_LIST_VND);
 
 	elem = bt_mesh_elem_find(addr);
 	if (!elem) {
-		net_buf_simple_add_u8(msg, STATUS_INVALID_ADDRESS);
-		net_buf_simple_add_le16(msg, addr);
-		net_buf_simple_add_le16(msg, company);
-		net_buf_simple_add_le16(msg, id);
+		net_buf_simple_add_u8(&msg, STATUS_INVALID_ADDRESS);
+		net_buf_simple_add_le16(&msg, addr);
+		net_buf_simple_add_le16(&msg, company);
+		net_buf_simple_add_le16(&msg, id);
 		goto send_list;
 	}
 
 	mod = bt_mesh_model_find_vnd(elem, company, id);
 	if (!mod) {
-		net_buf_simple_add_u8(msg, STATUS_INVALID_MODEL);
-		net_buf_simple_add_le16(msg, addr);
-		net_buf_simple_add_le16(msg, company);
-		net_buf_simple_add_le16(msg, id);
+		net_buf_simple_add_u8(&msg, STATUS_INVALID_MODEL);
+		net_buf_simple_add_le16(&msg, addr);
+		net_buf_simple_add_le16(&msg, company);
+		net_buf_simple_add_le16(&msg, id);
 		goto send_list;
 	}
 
-	net_buf_simple_add_u8(msg, STATUS_SUCCESS);
+	net_buf_simple_add_u8(&msg, STATUS_SUCCESS);
 
-	net_buf_simple_add_le16(msg, addr);
-	net_buf_simple_add_le16(msg, company);
-	net_buf_simple_add_le16(msg, id);
+	net_buf_simple_add_le16(&msg, addr);
+	net_buf_simple_add_le16(&msg, company);
+	net_buf_simple_add_le16(&msg, id);
 
 	for (i = 0; i < ARRAY_SIZE(mod->groups); i++) {
 		if (mod->groups[i] != BT_MESH_ADDR_UNASSIGNED) {
-			net_buf_simple_add_le16(msg, mod->groups[i]);
+			net_buf_simple_add_le16(&msg, mod->groups[i]);
 		}
 	}
 
 send_list:
-	if (bt_mesh_model_send(model, ctx, msg, NULL, NULL)) {
+	if (bt_mesh_model_send(model, ctx, &msg, NULL, NULL)) {
 		BT_ERR("Unable to send Vendor Model Subscription List");
 	}
 }
@@ -1936,14 +1933,14 @@ static void send_net_key_status(struct bt_mesh_model *model,
 				u16_t idx, u8_t status)
 {
 	/* Needed size: opcode (2 bytes) + msg + MIC */
-	struct net_buf_simple *msg = NET_BUF_SIMPLE(2 + 3 + 4);
+	NET_BUF_SIMPLE_DEFINE(msg, 2 + 3 + 4);
 
-	bt_mesh_model_msg_init(msg, OP_NET_KEY_STATUS);
+	bt_mesh_model_msg_init(&msg, OP_NET_KEY_STATUS);
 
-	net_buf_simple_add_u8(msg, status);
-	net_buf_simple_add_le16(msg, idx);
+	net_buf_simple_add_u8(&msg, status);
+	net_buf_simple_add_le16(&msg, idx);
 
-	if (bt_mesh_model_send(model, ctx, msg, NULL, NULL)) {
+	if (bt_mesh_model_send(model, ctx, &msg, NULL, NULL)) {
 		BT_ERR("Unable to send NetKey Status");
 	}
 }
@@ -2158,11 +2155,11 @@ static void net_key_get(struct bt_mesh_model *model,
 			struct bt_mesh_msg_ctx *ctx,
 			struct net_buf_simple *buf)
 {
-	struct net_buf_simple *msg =
-		NET_BUF_SIMPLE(2 + 4 + IDX_LEN(CONFIG_BT_MESH_SUBNET_COUNT));
+	NET_BUF_SIMPLE_DEFINE(msg,
+			      2 + 4 + IDX_LEN(CONFIG_BT_MESH_SUBNET_COUNT));
 	u16_t prev, i;
 
-	bt_mesh_model_msg_init(msg, OP_NET_KEY_LIST);
+	bt_mesh_model_msg_init(&msg, OP_NET_KEY_LIST);
 
 	prev = BT_MESH_KEY_UNUSED;
 	for (i = 0; i < ARRAY_SIZE(bt_mesh.sub); i++) {
@@ -2177,15 +2174,15 @@ static void net_key_get(struct bt_mesh_model *model,
 			continue;
 		}
 
-		key_idx_pack(msg, prev, sub->net_idx);
+		key_idx_pack(&msg, prev, sub->net_idx);
 		prev = BT_MESH_KEY_UNUSED;
 	}
 
 	if (prev != BT_MESH_KEY_UNUSED) {
-		net_buf_simple_add_le16(msg, prev);
+		net_buf_simple_add_le16(&msg, prev);
 	}
 
-	if (bt_mesh_model_send(model, ctx, msg, NULL, NULL)) {
+	if (bt_mesh_model_send(model, ctx, &msg, NULL, NULL)) {
 		BT_ERR("Unable to send NetKey List");
 	}
 }
@@ -2195,7 +2192,7 @@ static void node_identity_get(struct bt_mesh_model *model,
 			      struct net_buf_simple *buf)
 {
 	/* Needed size: opcode (2 bytes) + msg + MIC */
-	struct net_buf_simple *msg = NET_BUF_SIMPLE(2 + 4 + 4);
+	NET_BUF_SIMPLE_DEFINE(msg, 2 + 4 + 4);
 	struct bt_mesh_subnet *sub;
 	u8_t node_id;
 	u16_t idx;
@@ -2210,21 +2207,21 @@ static void node_identity_get(struct bt_mesh_model *model,
 		return;
 	}
 
-	bt_mesh_model_msg_init(msg, OP_NODE_IDENTITY_STATUS);
+	bt_mesh_model_msg_init(&msg, OP_NODE_IDENTITY_STATUS);
 
 	sub = bt_mesh_subnet_get(idx);
 	if (!sub) {
-		net_buf_simple_add_u8(msg, STATUS_INVALID_NETKEY);
+		net_buf_simple_add_u8(&msg, STATUS_INVALID_NETKEY);
 		node_id = 0x00;
 	} else {
-		net_buf_simple_add_u8(msg, STATUS_SUCCESS);
+		net_buf_simple_add_u8(&msg, STATUS_SUCCESS);
 		node_id = sub->node_id;
 	}
 
-	net_buf_simple_add_le16(msg, idx);
-	net_buf_simple_add_u8(msg, node_id);
+	net_buf_simple_add_le16(&msg, idx);
+	net_buf_simple_add_u8(&msg, node_id);
 
-	if (bt_mesh_model_send(model, ctx, msg, NULL, NULL)) {
+	if (bt_mesh_model_send(model, ctx, &msg, NULL, NULL)) {
 		BT_ERR("Unable to send Node Identity Status");
 	}
 }
@@ -2234,7 +2231,7 @@ static void node_identity_set(struct bt_mesh_model *model,
 			      struct net_buf_simple *buf)
 {
 	/* Needed size: opcode (2 bytes) + msg + MIC */
-	struct net_buf_simple *msg = NET_BUF_SIMPLE(2 + 4 + 4);
+	NET_BUF_SIMPLE_DEFINE(msg, 2 + 4 + 4);
 	struct bt_mesh_subnet *sub;
 	u8_t node_id;
 	u16_t idx;
@@ -2255,16 +2252,16 @@ static void node_identity_set(struct bt_mesh_model *model,
 		return;
 	}
 
-	bt_mesh_model_msg_init(msg, OP_NODE_IDENTITY_STATUS);
+	bt_mesh_model_msg_init(&msg, OP_NODE_IDENTITY_STATUS);
 
 	sub = bt_mesh_subnet_get(idx);
 	if (!sub) {
-		net_buf_simple_add_u8(msg, STATUS_INVALID_NETKEY);
-		net_buf_simple_add_le16(msg, idx);
-		net_buf_simple_add_u8(msg, node_id);
+		net_buf_simple_add_u8(&msg, STATUS_INVALID_NETKEY);
+		net_buf_simple_add_le16(&msg, idx);
+		net_buf_simple_add_u8(&msg, node_id);
 	} else  {
-		net_buf_simple_add_u8(msg, STATUS_SUCCESS);
-		net_buf_simple_add_le16(msg, idx);
+		net_buf_simple_add_u8(&msg, STATUS_SUCCESS);
+		net_buf_simple_add_le16(&msg, idx);
 
 		/* Section 4.2.11.1: "When the GATT Proxy state is set to
 		 * 0x00, the Node Identity state for all subnets shall be set
@@ -2280,10 +2277,10 @@ static void node_identity_set(struct bt_mesh_model *model,
 			bt_mesh_adv_update();
 		}
 
-		net_buf_simple_add_u8(msg, sub->node_id);
+		net_buf_simple_add_u8(&msg, sub->node_id);
 	}
 
-	if (bt_mesh_model_send(model, ctx, msg, NULL, NULL)) {
+	if (bt_mesh_model_send(model, ctx, &msg, NULL, NULL)) {
 		BT_ERR("Unable to send Node Identity Status");
 	}
 }
@@ -2310,7 +2307,7 @@ static void mod_app_bind(struct bt_mesh_model *model,
 			 struct bt_mesh_msg_ctx *ctx,
 			 struct net_buf_simple *buf)
 {
-	struct net_buf_simple *msg = NET_BUF_SIMPLE(2 + 9 + 4);
+	NET_BUF_SIMPLE_DEFINE(msg, 2 + 9 + 4);
 	u16_t elem_addr, key_app_idx;
 	struct bt_mesh_model *mod;
 	struct bt_mesh_elem *elem;
@@ -2350,10 +2347,10 @@ static void mod_app_bind(struct bt_mesh_model *model,
 
 send_status:
 	BT_DBG("status 0x%02x", status);
-	create_mod_app_status(msg, mod, vnd, elem_addr, key_app_idx, status,
+	create_mod_app_status(&msg, mod, vnd, elem_addr, key_app_idx, status,
 			      mod_id);
 
-	if (bt_mesh_model_send(model, ctx, msg, NULL, NULL)) {
+	if (bt_mesh_model_send(model, ctx, &msg, NULL, NULL)) {
 		BT_ERR("Unable to send Model App Bind Status response");
 	}
 }
@@ -2362,7 +2359,7 @@ static void mod_app_unbind(struct bt_mesh_model *model,
 			   struct bt_mesh_msg_ctx *ctx,
 			   struct net_buf_simple *buf)
 {
-	struct net_buf_simple *msg = NET_BUF_SIMPLE(2 + 9 + 4);
+	NET_BUF_SIMPLE_DEFINE(msg, 2 + 9 + 4);
 	u16_t elem_addr, key_app_idx;
 	struct bt_mesh_model *mod;
 	struct bt_mesh_elem *elem;
@@ -2395,10 +2392,10 @@ static void mod_app_unbind(struct bt_mesh_model *model,
 
 send_status:
 	BT_DBG("status 0x%02x", status);
-	create_mod_app_status(msg, mod, vnd, elem_addr, key_app_idx, status,
+	create_mod_app_status(&msg, mod, vnd, elem_addr, key_app_idx, status,
 			      mod_id);
 
-	if (bt_mesh_model_send(model, ctx, msg, NULL, NULL)) {
+	if (bt_mesh_model_send(model, ctx, &msg, NULL, NULL)) {
 		BT_ERR("Unable to send Model App Unbind Status response");
 	}
 }
@@ -2409,7 +2406,7 @@ static void mod_app_get(struct bt_mesh_model *model,
 			struct bt_mesh_msg_ctx *ctx,
 			struct net_buf_simple *buf)
 {
-	struct net_buf_simple *msg = NET_BUF_SIMPLE(2 + 9 + KEY_LIST_LEN + 4);
+	NET_BUF_SIMPLE_DEFINE(msg, 2 + 9 + KEY_LIST_LEN + 4);
 	struct bt_mesh_model *mod;
 	struct bt_mesh_elem *elem;
 	u8_t *mod_id, status;
@@ -2439,18 +2436,18 @@ static void mod_app_get(struct bt_mesh_model *model,
 
 send_list:
 	if (vnd) {
-		bt_mesh_model_msg_init(msg, OP_VND_MOD_APP_LIST);
+		bt_mesh_model_msg_init(&msg, OP_VND_MOD_APP_LIST);
 	} else {
-		bt_mesh_model_msg_init(msg, OP_SIG_MOD_APP_LIST);
+		bt_mesh_model_msg_init(&msg, OP_SIG_MOD_APP_LIST);
 	}
 
-	net_buf_simple_add_u8(msg, status);
-	net_buf_simple_add_le16(msg, elem_addr);
+	net_buf_simple_add_u8(&msg, status);
+	net_buf_simple_add_le16(&msg, elem_addr);
 
 	if (vnd) {
-		net_buf_simple_add_mem(msg, mod_id, 4);
+		net_buf_simple_add_mem(&msg, mod_id, 4);
 	} else {
-		net_buf_simple_add_mem(msg, mod_id, 2);
+		net_buf_simple_add_mem(&msg, mod_id, 2);
 	}
 
 	if (mod) {
@@ -2458,12 +2455,12 @@ send_list:
 
 		for (i = 0; i < ARRAY_SIZE(mod->keys); i++) {
 			if (mod->keys[i] != BT_MESH_KEY_UNUSED) {
-				net_buf_simple_add_le16(msg, mod->keys[i]);
+				net_buf_simple_add_le16(&msg, mod->keys[i]);
 			}
 		}
 	}
 
-	if (bt_mesh_model_send(model, ctx, msg, NULL, NULL)) {
+	if (bt_mesh_model_send(model, ctx, &msg, NULL, NULL)) {
 		BT_ERR("Unable to send Model Application List message");
 	}
 }
@@ -2473,19 +2470,19 @@ static void node_reset(struct bt_mesh_model *model,
 		       struct net_buf_simple *buf)
 {
 	/* Needed size: opcode (2 bytes) + msg + MIC */
-	struct net_buf_simple *msg = NET_BUF_SIMPLE(2 + 0 + 4);
+	NET_BUF_SIMPLE_DEFINE(msg, 2 + 0 + 4);
 
 	BT_DBG("net_idx 0x%04x app_idx 0x%04x src 0x%04x len %u: %s",
 	       ctx->net_idx, ctx->app_idx, ctx->addr, buf->len,
 	       bt_hex(buf->data, buf->len));
 
 
-	bt_mesh_model_msg_init(msg, OP_NODE_RESET_STATUS);
+	bt_mesh_model_msg_init(&msg, OP_NODE_RESET_STATUS);
 
 	/* Send the response first since we wont have any keys left to
 	 * send it later.
 	 */
-	if (bt_mesh_model_send(model, ctx, msg, NULL, NULL)) {
+	if (bt_mesh_model_send(model, ctx, &msg, NULL, NULL)) {
 		BT_ERR("Unable to send Node Reset Status");
 	}
 
@@ -2496,13 +2493,13 @@ static void send_friend_status(struct bt_mesh_model *model,
 			       struct bt_mesh_msg_ctx *ctx)
 {
 	/* Needed size: opcode (2 bytes) + msg + MIC */
-	struct net_buf_simple *msg = NET_BUF_SIMPLE(2 + 1 + 4);
+	NET_BUF_SIMPLE_DEFINE(msg, 2 + 1 + 4);
 	struct bt_mesh_cfg_srv *cfg = model->user_data;
 
-	bt_mesh_model_msg_init(msg, OP_FRIEND_STATUS);
-	net_buf_simple_add_u8(msg, cfg->frnd);
+	bt_mesh_model_msg_init(&msg, OP_FRIEND_STATUS);
+	net_buf_simple_add_u8(&msg, cfg->frnd);
 
-	if (bt_mesh_model_send(model, ctx, msg, NULL, NULL)) {
+	if (bt_mesh_model_send(model, ctx, &msg, NULL, NULL)) {
 		BT_ERR("Unable to send Friend Status");
 	}
 }
@@ -2567,7 +2564,7 @@ static void lpn_timeout_get(struct bt_mesh_model *model,
 			    struct net_buf_simple *buf)
 {
 	/* Needed size: opcode (2 bytes) + msg + MIC */
-	struct net_buf_simple *msg = NET_BUF_SIMPLE(2 + 5 + 4);
+	NET_BUF_SIMPLE_DEFINE(msg, 2 + 5 + 4);
 	struct bt_mesh_friend *frnd;
 	u16_t lpn_addr;
 	s32_t timeout;
@@ -2582,8 +2579,8 @@ static void lpn_timeout_get(struct bt_mesh_model *model,
 		return;
 	}
 
-	bt_mesh_model_msg_init(msg, OP_LPN_TIMEOUT_STATUS);
-	net_buf_simple_add_le16(msg, lpn_addr);
+	bt_mesh_model_msg_init(&msg, OP_LPN_TIMEOUT_STATUS);
+	net_buf_simple_add_le16(&msg, lpn_addr);
 
 	if (!IS_ENABLED(CONFIG_BLUETOOTH_MESH_FRIEND)) {
 		timeout = 0;
@@ -2599,11 +2596,11 @@ static void lpn_timeout_get(struct bt_mesh_model *model,
 	timeout = k_delayed_work_remaining_get(&frnd->timer) / 100;
 
 send_rsp:
-	net_buf_simple_add_u8(msg, timeout);
-	net_buf_simple_add_u8(msg, timeout >> 8);
-	net_buf_simple_add_u8(msg, timeout >> 16);
+	net_buf_simple_add_u8(&msg, timeout);
+	net_buf_simple_add_u8(&msg, timeout >> 8);
+	net_buf_simple_add_u8(&msg, timeout >> 16);
 
-	if (bt_mesh_model_send(model, ctx, msg, NULL, NULL)) {
+	if (bt_mesh_model_send(model, ctx, &msg, NULL, NULL)) {
 		BT_ERR("Unable to send LPN PollTimeout Status");
 	}
 }
@@ -2613,15 +2610,15 @@ static void send_krp_status(struct bt_mesh_model *model,
 			    u16_t idx, u8_t phase, u8_t status)
 {
 	/* Needed size: opcode (2 bytes) + msg + MIC */
-	struct net_buf_simple *msg = NET_BUF_SIMPLE(2 + 4 + 4);
+	NET_BUF_SIMPLE_DEFINE(msg, 2 + 4 + 4);
 
-	bt_mesh_model_msg_init(msg, OP_KRP_STATUS);
+	bt_mesh_model_msg_init(&msg, OP_KRP_STATUS);
 
-	net_buf_simple_add_u8(msg, status);
-	net_buf_simple_add_le16(msg, idx);
-	net_buf_simple_add_u8(msg, phase);
+	net_buf_simple_add_u8(&msg, status);
+	net_buf_simple_add_le16(&msg, idx);
+	net_buf_simple_add_u8(&msg, phase);
 
-	if (bt_mesh_model_send(model, ctx, msg, NULL, NULL)) {
+	if (bt_mesh_model_send(model, ctx, &msg, NULL, NULL)) {
 		BT_ERR("Unable to send Key Refresh State Status");
 	}
 }
@@ -2751,30 +2748,30 @@ static void hb_pub_send_status(struct bt_mesh_model *model,
 			       struct hb_pub_param *orig_msg)
 {
 	/* Needed size: opcode (1 byte) + msg + MIC */
-	struct net_buf_simple *msg = NET_BUF_SIMPLE(1 + 10 + 4);
+	NET_BUF_SIMPLE_DEFINE(msg, 1 + 10 + 4);
 	struct bt_mesh_cfg_srv *cfg = model->user_data;
 
 	BT_DBG("src 0x%04x status 0x%02x", ctx->addr, status);
 
-	bt_mesh_model_msg_init(msg, OP_HEARTBEAT_PUB_STATUS);
+	bt_mesh_model_msg_init(&msg, OP_HEARTBEAT_PUB_STATUS);
 
-	net_buf_simple_add_u8(msg, status);
+	net_buf_simple_add_u8(&msg, status);
 
 	if (orig_msg) {
-		memcpy(net_buf_simple_add(msg, sizeof(*orig_msg)), orig_msg,
+		memcpy(net_buf_simple_add(&msg, sizeof(*orig_msg)), orig_msg,
 		       sizeof(*orig_msg));
 		goto send;
 	}
 
-	net_buf_simple_add_le16(msg, cfg->hb_pub.dst);
-	net_buf_simple_add_u8(msg, hb_pub_count_log(cfg->hb_pub.count));
-	net_buf_simple_add_u8(msg, cfg->hb_pub.period);
-	net_buf_simple_add_u8(msg, cfg->hb_pub.ttl);
-	net_buf_simple_add_le16(msg, cfg->hb_pub.feat);
-	net_buf_simple_add_le16(msg, cfg->hb_pub.net_idx);
+	net_buf_simple_add_le16(&msg, cfg->hb_pub.dst);
+	net_buf_simple_add_u8(&msg, hb_pub_count_log(cfg->hb_pub.count));
+	net_buf_simple_add_u8(&msg, cfg->hb_pub.period);
+	net_buf_simple_add_u8(&msg, cfg->hb_pub.ttl);
+	net_buf_simple_add_le16(&msg, cfg->hb_pub.feat);
+	net_buf_simple_add_le16(&msg, cfg->hb_pub.net_idx);
 
 send:
-	if (bt_mesh_model_send(model, ctx, msg, NULL, NULL)) {
+	if (bt_mesh_model_send(model, ctx, &msg, NULL, NULL)) {
 		BT_ERR("Unable to send Heartbeat Publication Status");
 	}
 }
@@ -2871,7 +2868,7 @@ static void hb_sub_send_status(struct bt_mesh_model *model,
 			       struct bt_mesh_msg_ctx *ctx, u8_t status)
 {
 	/* Needed size: opcode (2 bytes) + msg + MIC */
-	struct net_buf_simple *msg = NET_BUF_SIMPLE(2 + 9 + 4);
+	NET_BUF_SIMPLE_DEFINE(msg, 2 + 9 + 4);
 	struct bt_mesh_cfg_srv *cfg = model->user_data;
 	u16_t period;
 	s64_t uptime;
@@ -2885,24 +2882,24 @@ static void hb_sub_send_status(struct bt_mesh_model *model,
 		period = (cfg->hb_sub.expiry - uptime) / 1000;
 	}
 
-	bt_mesh_model_msg_init(msg, OP_HEARTBEAT_SUB_STATUS);
+	bt_mesh_model_msg_init(&msg, OP_HEARTBEAT_SUB_STATUS);
 
-	net_buf_simple_add_u8(msg, status);
+	net_buf_simple_add_u8(&msg, status);
 
-	net_buf_simple_add_le16(msg, cfg->hb_sub.src);
-	net_buf_simple_add_le16(msg, cfg->hb_sub.dst);
+	net_buf_simple_add_le16(&msg, cfg->hb_sub.src);
+	net_buf_simple_add_le16(&msg, cfg->hb_sub.dst);
 
 	if (cfg->hb_sub.src == BT_MESH_ADDR_UNASSIGNED ||
 	    cfg->hb_sub.dst == BT_MESH_ADDR_UNASSIGNED) {
-		memset(net_buf_simple_add(msg, 4), 0, 4);
+		memset(net_buf_simple_add(&msg, 4), 0, 4);
 	} else {
-		net_buf_simple_add_u8(msg, hb_log(period));
-		net_buf_simple_add_u8(msg, hb_log(cfg->hb_sub.count));
-		net_buf_simple_add_u8(msg, cfg->hb_sub.min_hops);
-		net_buf_simple_add_u8(msg, cfg->hb_sub.max_hops);
+		net_buf_simple_add_u8(&msg, hb_log(period));
+		net_buf_simple_add_u8(&msg, hb_log(cfg->hb_sub.count));
+		net_buf_simple_add_u8(&msg, cfg->hb_sub.min_hops);
+		net_buf_simple_add_u8(&msg, cfg->hb_sub.max_hops);
 	}
 
-	if (bt_mesh_model_send(model, ctx, msg, NULL, NULL)) {
+	if (bt_mesh_model_send(model, ctx, &msg, NULL, NULL)) {
 		BT_ERR("Unable to send Heartbeat Subscription Status");
 	}
 }

--- a/subsys/bluetooth/host/mesh/health_cli.c
+++ b/subsys/bluetooth/host/mesh/health_cli.c
@@ -200,7 +200,7 @@ static int cli_wait(void *param, u32_t op)
 int bt_mesh_health_attention_get(u16_t net_idx, u16_t addr, u16_t app_idx,
 				 u8_t *attention)
 {
-	struct net_buf_simple *msg = NET_BUF_SIMPLE(2 + 0 + 4);
+	NET_BUF_SIMPLE_DEFINE(msg, 2 + 0 + 4);
 	struct bt_mesh_msg_ctx ctx = {
 		.net_idx = net_idx,
 		.app_idx = app_idx,
@@ -217,9 +217,9 @@ int bt_mesh_health_attention_get(u16_t net_idx, u16_t addr, u16_t app_idx,
 		return err;
 	}
 
-	bt_mesh_model_msg_init(msg, OP_ATTENTION_GET);
+	bt_mesh_model_msg_init(&msg, OP_ATTENTION_GET);
 
-	err = bt_mesh_model_send(health_cli->model, &ctx, msg, NULL, NULL);
+	err = bt_mesh_model_send(health_cli->model, &ctx, &msg, NULL, NULL);
 	if (err) {
 		BT_ERR("model_send() failed (err %d)", err);
 		return err;
@@ -231,7 +231,7 @@ int bt_mesh_health_attention_get(u16_t net_idx, u16_t addr, u16_t app_idx,
 int bt_mesh_health_attention_set(u16_t net_idx, u16_t addr, u16_t app_idx,
 				 u8_t attention, u8_t *updated_attention)
 {
-	struct net_buf_simple *msg = NET_BUF_SIMPLE(2 + 1 + 4);
+	NET_BUF_SIMPLE_DEFINE(msg, 2 + 1 + 4);
 	struct bt_mesh_msg_ctx ctx = {
 		.net_idx = net_idx,
 		.app_idx = app_idx,
@@ -249,14 +249,14 @@ int bt_mesh_health_attention_set(u16_t net_idx, u16_t addr, u16_t app_idx,
 	}
 
 	if (updated_attention) {
-		bt_mesh_model_msg_init(msg, OP_ATTENTION_SET);
+		bt_mesh_model_msg_init(&msg, OP_ATTENTION_SET);
 	} else {
-		bt_mesh_model_msg_init(msg, OP_ATTENTION_SET_UNREL);
+		bt_mesh_model_msg_init(&msg, OP_ATTENTION_SET_UNREL);
 	}
 
-	net_buf_simple_add_u8(msg, attention);
+	net_buf_simple_add_u8(&msg, attention);
 
-	err = bt_mesh_model_send(health_cli->model, &ctx, msg, NULL, NULL);
+	err = bt_mesh_model_send(health_cli->model, &ctx, &msg, NULL, NULL);
 	if (err) {
 		BT_ERR("model_send() failed (err %d)", err);
 		return err;
@@ -272,7 +272,7 @@ int bt_mesh_health_attention_set(u16_t net_idx, u16_t addr, u16_t app_idx,
 int bt_mesh_health_period_get(u16_t net_idx, u16_t addr, u16_t app_idx,
 			      u8_t *divisor)
 {
-	struct net_buf_simple *msg = NET_BUF_SIMPLE(2 + 0 + 4);
+	NET_BUF_SIMPLE_DEFINE(msg, 2 + 0 + 4);
 	struct bt_mesh_msg_ctx ctx = {
 		.net_idx = net_idx,
 		.app_idx = app_idx,
@@ -289,9 +289,9 @@ int bt_mesh_health_period_get(u16_t net_idx, u16_t addr, u16_t app_idx,
 		return err;
 	}
 
-	bt_mesh_model_msg_init(msg, OP_HEALTH_PERIOD_GET);
+	bt_mesh_model_msg_init(&msg, OP_HEALTH_PERIOD_GET);
 
-	err = bt_mesh_model_send(health_cli->model, &ctx, msg, NULL, NULL);
+	err = bt_mesh_model_send(health_cli->model, &ctx, &msg, NULL, NULL);
 	if (err) {
 		BT_ERR("model_send() failed (err %d)", err);
 		return err;
@@ -303,7 +303,7 @@ int bt_mesh_health_period_get(u16_t net_idx, u16_t addr, u16_t app_idx,
 int bt_mesh_health_period_set(u16_t net_idx, u16_t addr, u16_t app_idx,
 			      u8_t divisor, u8_t *updated_divisor)
 {
-	struct net_buf_simple *msg = NET_BUF_SIMPLE(2 + 1 + 4);
+	NET_BUF_SIMPLE_DEFINE(msg, 2 + 1 + 4);
 	struct bt_mesh_msg_ctx ctx = {
 		.net_idx = net_idx,
 		.app_idx = app_idx,
@@ -321,14 +321,14 @@ int bt_mesh_health_period_set(u16_t net_idx, u16_t addr, u16_t app_idx,
 	}
 
 	if (updated_divisor) {
-		bt_mesh_model_msg_init(msg, OP_HEALTH_PERIOD_SET);
+		bt_mesh_model_msg_init(&msg, OP_HEALTH_PERIOD_SET);
 	} else {
-		bt_mesh_model_msg_init(msg, OP_HEALTH_PERIOD_SET_UNREL);
+		bt_mesh_model_msg_init(&msg, OP_HEALTH_PERIOD_SET_UNREL);
 	}
 
-	net_buf_simple_add_u8(msg, divisor);
+	net_buf_simple_add_u8(&msg, divisor);
 
-	err = bt_mesh_model_send(health_cli->model, &ctx, msg, NULL, NULL);
+	err = bt_mesh_model_send(health_cli->model, &ctx, &msg, NULL, NULL);
 	if (err) {
 		BT_ERR("model_send() failed (err %d)", err);
 		return err;
@@ -345,7 +345,7 @@ int bt_mesh_health_fault_test(u16_t net_idx, u16_t addr, u16_t app_idx,
 			      u16_t cid, u8_t test_id, u8_t *faults,
 			      size_t *fault_count)
 {
-	struct net_buf_simple *msg = NET_BUF_SIMPLE(2 + 3 + 4);
+	NET_BUF_SIMPLE_DEFINE(msg, 2 + 3 + 4);
 	struct bt_mesh_msg_ctx ctx = {
 		.net_idx = net_idx,
 		.app_idx = app_idx,
@@ -366,15 +366,15 @@ int bt_mesh_health_fault_test(u16_t net_idx, u16_t addr, u16_t app_idx,
 	}
 
 	if (faults) {
-		bt_mesh_model_msg_init(msg, OP_HEALTH_FAULT_TEST);
+		bt_mesh_model_msg_init(&msg, OP_HEALTH_FAULT_TEST);
 	} else {
-		bt_mesh_model_msg_init(msg, OP_HEALTH_FAULT_TEST_UNREL);
+		bt_mesh_model_msg_init(&msg, OP_HEALTH_FAULT_TEST_UNREL);
 	}
 
-	net_buf_simple_add_u8(msg, test_id);
-	net_buf_simple_add_le16(msg, cid);
+	net_buf_simple_add_u8(&msg, test_id);
+	net_buf_simple_add_le16(&msg, cid);
 
-	err = bt_mesh_model_send(health_cli->model, &ctx, msg, NULL, NULL);
+	err = bt_mesh_model_send(health_cli->model, &ctx, &msg, NULL, NULL);
 	if (err) {
 		BT_ERR("model_send() failed (err %d)", err);
 		return err;
@@ -391,7 +391,7 @@ int bt_mesh_health_fault_clear(u16_t net_idx, u16_t addr, u16_t app_idx,
 			       u16_t cid, u8_t *test_id, u8_t *faults,
 			       size_t *fault_count)
 {
-	struct net_buf_simple *msg = NET_BUF_SIMPLE(2 + 2 + 4);
+	NET_BUF_SIMPLE_DEFINE(msg, 2 + 2 + 4);
 	struct bt_mesh_msg_ctx ctx = {
 		.net_idx = net_idx,
 		.app_idx = app_idx,
@@ -412,14 +412,14 @@ int bt_mesh_health_fault_clear(u16_t net_idx, u16_t addr, u16_t app_idx,
 	}
 
 	if (test_id) {
-		bt_mesh_model_msg_init(msg, OP_HEALTH_FAULT_CLEAR);
+		bt_mesh_model_msg_init(&msg, OP_HEALTH_FAULT_CLEAR);
 	} else {
-		bt_mesh_model_msg_init(msg, OP_HEALTH_FAULT_CLEAR_UNREL);
+		bt_mesh_model_msg_init(&msg, OP_HEALTH_FAULT_CLEAR_UNREL);
 	}
 
-	net_buf_simple_add_le16(msg, cid);
+	net_buf_simple_add_le16(&msg, cid);
 
-	err = bt_mesh_model_send(health_cli->model, &ctx, msg, NULL, NULL);
+	err = bt_mesh_model_send(health_cli->model, &ctx, &msg, NULL, NULL);
 	if (err) {
 		BT_ERR("model_send() failed (err %d)", err);
 		return err;
@@ -436,7 +436,7 @@ int bt_mesh_health_fault_get(u16_t net_idx, u16_t addr, u16_t app_idx,
 			     u16_t cid, u8_t *test_id, u8_t *faults,
 			     size_t *fault_count)
 {
-	struct net_buf_simple *msg = NET_BUF_SIMPLE(2 + 2 + 4);
+	NET_BUF_SIMPLE_DEFINE(msg, 2 + 2 + 4);
 	struct bt_mesh_msg_ctx ctx = {
 		.net_idx = net_idx,
 		.app_idx = app_idx,
@@ -456,10 +456,10 @@ int bt_mesh_health_fault_get(u16_t net_idx, u16_t addr, u16_t app_idx,
 		return err;
 	}
 
-	bt_mesh_model_msg_init(msg, OP_HEALTH_FAULT_GET);
-	net_buf_simple_add_le16(msg, cid);
+	bt_mesh_model_msg_init(&msg, OP_HEALTH_FAULT_GET);
+	net_buf_simple_add_le16(&msg, cid);
 
-	err = bt_mesh_model_send(health_cli->model, &ctx, msg, NULL, NULL);
+	err = bt_mesh_model_send(health_cli->model, &ctx, &msg, NULL, NULL);
 	if (err) {
 		BT_ERR("model_send() failed (err %d)", err);
 		return err;

--- a/subsys/bluetooth/host/mesh/health_srv.c
+++ b/subsys/bluetooth/host/mesh/health_srv.c
@@ -109,16 +109,16 @@ static void health_fault_get(struct bt_mesh_model *model,
 			     struct bt_mesh_msg_ctx *ctx,
 			     struct net_buf_simple *buf)
 {
-	struct net_buf_simple *sdu = NET_BUF_SIMPLE(BT_MESH_TX_SDU_MAX);
+	NET_BUF_SIMPLE_DEFINE(sdu, BT_MESH_TX_SDU_MAX);
 	u16_t company_id;
 
 	company_id = net_buf_simple_pull_le16(buf);
 
 	BT_DBG("company_id 0x%04x", company_id);
 
-	health_get_registered(model, company_id, sdu);
+	health_get_registered(model, company_id, &sdu);
 
-	if (bt_mesh_model_send(model, ctx, sdu, NULL, NULL)) {
+	if (bt_mesh_model_send(model, ctx, &sdu, NULL, NULL)) {
 		BT_ERR("Unable to send Health Current Status response");
 	}
 }
@@ -143,7 +143,7 @@ static void health_fault_clear(struct bt_mesh_model *model,
 			       struct bt_mesh_msg_ctx *ctx,
 			       struct net_buf_simple *buf)
 {
-	struct net_buf_simple *sdu = NET_BUF_SIMPLE(BT_MESH_TX_SDU_MAX);
+	NET_BUF_SIMPLE_DEFINE(sdu, BT_MESH_TX_SDU_MAX);
 	struct bt_mesh_health_srv *srv = model->user_data;
 	u16_t company_id;
 
@@ -155,9 +155,9 @@ static void health_fault_clear(struct bt_mesh_model *model,
 		srv->cb->fault_clear(model, company_id);
 	}
 
-	health_get_registered(model, company_id, sdu);
+	health_get_registered(model, company_id, &sdu);
 
-	if (bt_mesh_model_send(model, ctx, sdu, NULL, NULL)) {
+	if (bt_mesh_model_send(model, ctx, &sdu, NULL, NULL)) {
 		BT_ERR("Unable to send Health Current Status response");
 	}
 }
@@ -184,7 +184,7 @@ static void health_fault_test(struct bt_mesh_model *model,
 			      struct bt_mesh_msg_ctx *ctx,
 			      struct net_buf_simple *buf)
 {
-	struct net_buf_simple *sdu = NET_BUF_SIMPLE(BT_MESH_TX_SDU_MAX);
+	NET_BUF_SIMPLE_DEFINE(sdu, BT_MESH_TX_SDU_MAX);
 	struct bt_mesh_health_srv *srv = model->user_data;
 	u16_t company_id;
 	u8_t test_id;
@@ -206,9 +206,9 @@ static void health_fault_test(struct bt_mesh_model *model,
 		}
 	}
 
-	health_get_registered(model, company_id, sdu);
+	health_get_registered(model, company_id, &sdu);
 
-	if (bt_mesh_model_send(model, ctx, sdu, NULL, NULL)) {
+	if (bt_mesh_model_send(model, ctx, &sdu, NULL, NULL)) {
 		BT_ERR("Unable to send Health Current Status response");
 	}
 }
@@ -217,18 +217,18 @@ static void send_attention_status(struct bt_mesh_model *model,
 				  struct bt_mesh_msg_ctx *ctx)
 {
 	/* Needed size: opcode (2 bytes) + msg + MIC */
-	struct net_buf_simple *msg = NET_BUF_SIMPLE(2 + 1 + 4);
+	NET_BUF_SIMPLE_DEFINE(msg, 2 + 1 + 4);
 	struct bt_mesh_health_srv *srv = model->user_data;
 	u8_t time;
 
 	time = k_delayed_work_remaining_get(&srv->attn_timer) / 1000;
 	BT_DBG("%u second%s", time, (time == 1) ? "" : "s");
 
-	bt_mesh_model_msg_init(msg, OP_ATTENTION_STATUS);
+	bt_mesh_model_msg_init(&msg, OP_ATTENTION_STATUS);
 
-	net_buf_simple_add_u8(msg, time);
+	net_buf_simple_add_u8(&msg, time);
 
-	if (bt_mesh_model_send(model, ctx, msg, NULL, NULL)) {
+	if (bt_mesh_model_send(model, ctx, &msg, NULL, NULL)) {
 		BT_ERR("Unable to send Attention Status");
 	}
 }
@@ -270,13 +270,13 @@ static void send_health_period_status(struct bt_mesh_model *model,
 				      struct bt_mesh_msg_ctx *ctx)
 {
 	/* Needed size: opcode (2 bytes) + msg + MIC */
-	struct net_buf_simple *msg = NET_BUF_SIMPLE(2 + 1 + 4);
+	NET_BUF_SIMPLE_DEFINE(msg, 2 + 1 + 4);
 
-	bt_mesh_model_msg_init(msg, OP_HEALTH_PERIOD_STATUS);
+	bt_mesh_model_msg_init(&msg, OP_HEALTH_PERIOD_STATUS);
 
-	net_buf_simple_add_u8(msg, model->pub->period_div);
+	net_buf_simple_add_u8(&msg, model->pub->period_div);
 
-	if (bt_mesh_model_send(model, ctx, msg, NULL, NULL)) {
+	if (bt_mesh_model_send(model, ctx, &msg, NULL, NULL)) {
 		BT_ERR("Unable to send Health Period Status");
 	}
 }

--- a/subsys/bluetooth/host/mesh/prov.c
+++ b/subsys/bluetooth/host/mesh/prov.c
@@ -177,10 +177,11 @@ struct prov_rx {
 #define PROV_BUF_HEADROOM 5
 #else
 #define PROV_BUF_HEADROOM 0
-static struct net_buf_simple *rx_buf = NET_BUF_SIMPLE(65);
+NET_BUF_SIMPLE_DEFINE_STATIC(rx_buf, 65);
 #endif
 
-#define PROV_BUF(len) NET_BUF_SIMPLE(PROV_BUF_HEADROOM + len)
+#define PROV_BUF(name, len) \
+	NET_BUF_SIMPLE_DEFINE(name, PROV_BUF_HEADROOM + len)
 
 static struct prov_link link;
 
@@ -249,8 +250,8 @@ static void reset_link(void)
 #if defined(CONFIG_BT_MESH_PB_GATT)
 	link.rx.buf = bt_mesh_proxy_get_buf();
 #else
-	net_buf_simple_init(rx_buf, 0);
-	link.rx.buf = rx_buf;
+	net_buf_simple_reset(&rx_buf);
+	link.rx.buf = &rx_buf;
 #endif
 
 	/* Disable Attention Timer if it was set */
@@ -475,22 +476,22 @@ static inline int prov_send(struct net_buf_simple *buf)
 
 static void prov_buf_init(struct net_buf_simple *buf, u8_t type)
 {
-	net_buf_simple_init(buf, PROV_BUF_HEADROOM);
+	net_buf_simple_reserve(buf, PROV_BUF_HEADROOM);
 	net_buf_simple_add_u8(buf, type);
 }
 
 static void prov_send_fail_msg(u8_t err)
 {
-	struct net_buf_simple *buf = PROV_BUF(2);
+	PROV_BUF(buf, 2);
 
-	prov_buf_init(buf, PROV_FAILED);
-	net_buf_simple_add_u8(buf, err);
-	prov_send(buf);
+	prov_buf_init(&buf, PROV_FAILED);
+	net_buf_simple_add_u8(&buf, err);
+	prov_send(&buf);
 }
 
 static void prov_invite(const u8_t *data)
 {
-	struct net_buf_simple *buf = PROV_BUF(12);
+	PROV_BUF(buf, 12);
 
 	BT_DBG("Attention Duration: %u seconds", data[0]);
 
@@ -500,35 +501,35 @@ static void prov_invite(const u8_t *data)
 
 	link.conf_inputs[0] = data[0];
 
-	prov_buf_init(buf, PROV_CAPABILITIES);
+	prov_buf_init(&buf, PROV_CAPABILITIES);
 
 	/* Number of Elements supported */
-	net_buf_simple_add_u8(buf, bt_mesh_elem_count());
+	net_buf_simple_add_u8(&buf, bt_mesh_elem_count());
 
 	/* Supported algorithms - FIPS P-256 Eliptic Curve */
-	net_buf_simple_add_be16(buf, BIT(PROV_ALG_P256));
+	net_buf_simple_add_be16(&buf, BIT(PROV_ALG_P256));
 
 	/* Public Key Type */
-	net_buf_simple_add_u8(buf, 0x00);
+	net_buf_simple_add_u8(&buf, 0x00);
 
 	/* Static OOB Type */
-	net_buf_simple_add_u8(buf, prov->static_val ? BIT(0) : 0x00);
+	net_buf_simple_add_u8(&buf, prov->static_val ? BIT(0) : 0x00);
 
 	/* Output OOB Size */
-	net_buf_simple_add_u8(buf, prov->output_size);
+	net_buf_simple_add_u8(&buf, prov->output_size);
 
 	/* Output OOB Action */
-	net_buf_simple_add_be16(buf, prov->output_actions);
+	net_buf_simple_add_be16(&buf, prov->output_actions);
 
 	/* Input OOB Size */
-	net_buf_simple_add_u8(buf, prov->input_size);
+	net_buf_simple_add_u8(&buf, prov->input_size);
 
 	/* Input OOB Action */
-	net_buf_simple_add_be16(buf, prov->input_actions);
+	net_buf_simple_add_be16(&buf, prov->input_actions);
 
-	memcpy(&link.conf_inputs[1], &buf->data[1], 11);
+	memcpy(&link.conf_inputs[1], &buf.data[1], 11);
 
-	if (prov_send(buf)) {
+	if (prov_send(&buf)) {
 		BT_ERR("Failed to send capabilities");
 		close_link(PROV_ERR_RESOURCES, CLOSE_REASON_FAILED);
 		return;
@@ -726,7 +727,7 @@ static void prov_start(const u8_t *data)
 
 static void send_confirm(void)
 {
-	struct net_buf_simple *cfm = PROV_BUF(17);
+	PROV_BUF(cfm, 17);
 
 	BT_DBG("ConfInputs[0]   %s", bt_hex(link.conf_inputs, 64));
 	BT_DBG("ConfInputs[64]  %s", bt_hex(&link.conf_inputs[64], 64));
@@ -756,16 +757,16 @@ static void send_confirm(void)
 
 	BT_DBG("LocalRandom: %s", bt_hex(link.rand, 16));
 
-	prov_buf_init(cfm, PROV_CONFIRM);
+	prov_buf_init(&cfm, PROV_CONFIRM);
 
 	if (bt_mesh_prov_conf(link.conf_key, link.rand, link.auth,
-			      net_buf_simple_add(cfm, 16))) {
+			      net_buf_simple_add(&cfm, 16))) {
 		BT_ERR("Unable to generate confirmation value");
 		close_link(PROV_ERR_UNEXP_ERR, CLOSE_REASON_FAILED);
 		return;
 	}
 
-	if (prov_send(cfm)) {
+	if (prov_send(&cfm)) {
 		BT_ERR("Failed to send Provisioning Confirm");
 		close_link(PROV_ERR_RESOURCES, CLOSE_REASON_FAILED);
 		return;
@@ -776,10 +777,10 @@ static void send_confirm(void)
 
 static void send_input_complete(void)
 {
-	struct net_buf_simple *buf = PROV_BUF(1);
+	PROV_BUF(buf, 1);
 
-	prov_buf_init(buf, PROV_INPUT_COMPLETE);
-	prov_send(buf);
+	prov_buf_init(&buf, PROV_INPUT_COMPLETE);
+	prov_send(&buf);
 }
 
 int bt_mesh_input_number(u32_t num)
@@ -856,7 +857,7 @@ static void prov_dh_key_cb(const u8_t key[32])
 
 static void send_pub_key(void)
 {
-	struct net_buf_simple *buf = PROV_BUF(65);
+	PROV_BUF(buf, 65);
 	const u8_t *key;
 
 	key = bt_pub_key_get();
@@ -868,24 +869,24 @@ static void send_pub_key(void)
 
 	BT_DBG("Local Public Key: %s", bt_hex(key, 64));
 
-	prov_buf_init(buf, PROV_PUB_KEY);
+	prov_buf_init(&buf, PROV_PUB_KEY);
 
 	/* Swap X and Y halves independently to big-endian */
-	sys_memcpy_swap(net_buf_simple_add(buf, 32), key, 32);
-	sys_memcpy_swap(net_buf_simple_add(buf, 32), &key[32], 32);
+	sys_memcpy_swap(net_buf_simple_add(&buf, 32), key, 32);
+	sys_memcpy_swap(net_buf_simple_add(&buf, 32), &key[32], 32);
 
-	memcpy(&link.conf_inputs[81], &buf->data[1], 64);
+	memcpy(&link.conf_inputs[81], &buf.data[1], 64);
 
-	prov_send(buf);
+	prov_send(&buf);
 
 	/* Copy remote key in little-endian for bt_dh_key_gen().
 	 * X and Y halves are swapped independently.
 	 */
-	net_buf_simple_init(buf, 0);
-	sys_memcpy_swap(buf->data, &link.conf_inputs[17], 32);
-	sys_memcpy_swap(&buf->data[32], &link.conf_inputs[49], 32);
+	net_buf_simple_reset(&buf);
+	sys_memcpy_swap(buf.data, &link.conf_inputs[17], 32);
+	sys_memcpy_swap(&buf.data[32], &link.conf_inputs[49], 32);
 
-	if (bt_dh_key_gen(buf->data, prov_dh_key_cb)) {
+	if (bt_dh_key_gen(buf.data, prov_dh_key_cb)) {
 		BT_ERR("Failed to generate DHKey");
 		close_link(PROV_ERR_UNEXP_ERR, CLOSE_REASON_FAILED);
 		return;
@@ -952,7 +953,7 @@ static void prov_confirm(const u8_t *data)
 
 static void prov_random(const u8_t *data)
 {
-	struct net_buf_simple *rnd = PROV_BUF(16);
+	PROV_BUF(rnd, 16);
 	u8_t conf_verify[16];
 
 	BT_DBG("Remote Random: %s", bt_hex(data, 16));
@@ -971,10 +972,10 @@ static void prov_random(const u8_t *data)
 		return;
 	}
 
-	prov_buf_init(rnd, PROV_RANDOM);
-	net_buf_simple_add_mem(rnd, link.rand, 16);
+	prov_buf_init(&rnd, PROV_RANDOM);
+	net_buf_simple_add_mem(&rnd, link.rand, 16);
 
-	if (prov_send(rnd)) {
+	if (prov_send(&rnd)) {
 		BT_ERR("Failed to send Provisioning Random");
 		close_link(PROV_ERR_RESOURCES, CLOSE_REASON_FAILED);
 		return;
@@ -994,7 +995,7 @@ static void prov_random(const u8_t *data)
 
 static void prov_data(const u8_t *data)
 {
-	struct net_buf_simple *msg = PROV_BUF(1);
+	PROV_BUF(msg, 1);
 	u8_t session_key[16];
 	u8_t nonce[13];
 	u8_t dev_key[16];
@@ -1049,8 +1050,8 @@ static void prov_data(const u8_t *data)
 	BT_DBG("net_idx %u iv_index 0x%08x, addr 0x%04x",
 	       net_idx, iv_index, addr);
 
-	prov_buf_init(msg, PROV_COMPLETE);
-	prov_send(msg);
+	prov_buf_init(&msg, PROV_COMPLETE);
+	prov_send(&msg);
 
 	/* Ignore any further PDUs on this link */
 	link.expect = 0;
@@ -1175,7 +1176,7 @@ static void link_open(struct prov_rx *rx, struct net_buf_simple *buf)
 
 	link.id = rx->link_id;
 	atomic_set_bit(link.flags, LINK_ACTIVE);
-	net_buf_simple_init(link.rx.buf, 0);
+	net_buf_simple_reset(link.rx.buf);
 
 	bearer_ctl_send(LINK_ACK, NULL, 0);
 
@@ -1556,8 +1557,8 @@ int bt_mesh_prov_init(const struct bt_mesh_prov *prov_info)
 #if defined(CONFIG_BT_MESH_PB_GATT)
 	link.rx.buf = bt_mesh_proxy_get_buf();
 #else
-	net_buf_simple_init(rx_buf, 0);
-	link.rx.buf = rx_buf;
+	net_buf_simple_reset(&rx_buf);
+	link.rx.buf = &rx_buf;
 #endif
 
 #endif /* CONFIG_BT_MESH_PB_ADV */

--- a/subsys/bluetooth/host/mesh/proxy.c
+++ b/subsys/bluetooth/host/mesh/proxy.c
@@ -206,7 +206,8 @@ static void send_filter_status(struct bt_mesh_proxy_client *client,
 	/* Configuration messages always have dst unassigned */
 	tx.ctx->addr = BT_MESH_ADDR_UNASSIGNED;
 
-	net_buf_simple_init(buf, 10);
+	net_buf_simple_reset(buf);
+	net_buf_simple_reserve(buf, 10);
 
 	net_buf_simple_add_u8(buf, CFG_FILTER_STATUS);
 
@@ -240,51 +241,51 @@ static void send_filter_status(struct bt_mesh_proxy_client *client,
 
 static void proxy_cfg(struct bt_mesh_proxy_client *client)
 {
-	struct net_buf_simple *buf = NET_BUF_SIMPLE(29);
+	NET_BUF_SIMPLE_DEFINE(buf, 29);
 	struct bt_mesh_net_rx rx;
 	u8_t opcode;
 	int err;
 
 	err = bt_mesh_net_decode(&client->buf, BT_MESH_NET_IF_PROXY_CFG,
-				 &rx, buf);
+				 &rx, &buf);
 	if (err) {
 		BT_ERR("Failed to decode Proxy Configuration (err %d)", err);
 		return;
 	}
 
 	/* Remove network headers */
-	net_buf_simple_pull(buf, BT_MESH_NET_HDR_LEN);
+	net_buf_simple_pull(&buf, BT_MESH_NET_HDR_LEN);
 
-	BT_DBG("%u bytes: %s", buf->len, bt_hex(buf->data, buf->len));
+	BT_DBG("%u bytes: %s", buf.len, bt_hex(buf.data, buf.len));
 
-	if (buf->len < 1) {
+	if (buf.len < 1) {
 		BT_WARN("Too short proxy configuration PDU");
 		return;
 	}
 
-	opcode = net_buf_simple_pull_u8(buf);
+	opcode = net_buf_simple_pull_u8(&buf);
 	switch (opcode) {
 	case CFG_FILTER_SET:
-		filter_set(client, buf);
-		send_filter_status(client, &rx, buf);
+		filter_set(client, &buf);
+		send_filter_status(client, &rx, &buf);
 		break;
 	case CFG_FILTER_ADD:
-		while (buf->len >= 2) {
+		while (buf.len >= 2) {
 			u16_t addr;
 
-			addr = net_buf_simple_pull_be16(buf);
+			addr = net_buf_simple_pull_be16(&buf);
 			filter_add(client, addr);
 		}
-		send_filter_status(client, &rx, buf);
+		send_filter_status(client, &rx, &buf);
 		break;
 	case CFG_FILTER_REMOVE:
-		while (buf->len >= 2) {
+		while (buf.len >= 2) {
 			u16_t addr;
 
-			addr = net_buf_simple_pull_be16(buf);
+			addr = net_buf_simple_pull_be16(&buf);
 			filter_remove(client, addr);
 		}
-		send_filter_status(client, &rx, buf);
+		send_filter_status(client, &rx, &buf);
 		break;
 	default:
 		BT_WARN("Unhandled configuration OpCode 0x%02x", opcode);
@@ -294,12 +295,12 @@ static void proxy_cfg(struct bt_mesh_proxy_client *client)
 
 static int beacon_send(struct bt_conn *conn, struct bt_mesh_subnet *sub)
 {
-	struct net_buf_simple *buf = NET_BUF_SIMPLE(23);
+	NET_BUF_SIMPLE_DEFINE(buf, 23);
 
-	net_buf_simple_init(buf, 1);
-	bt_mesh_beacon_create(sub, buf);
+	net_buf_simple_reserve(&buf, 1);
+	bt_mesh_beacon_create(sub, &buf);
 
-	return proxy_segment_and_send(conn, BT_MESH_PROXY_BEACON, buf);
+	return proxy_segment_and_send(conn, BT_MESH_PROXY_BEACON, &buf);
 }
 
 static void proxy_send_beacons(struct k_work *work)
@@ -417,7 +418,7 @@ static void proxy_complete_pdu(struct bt_mesh_proxy_client *client)
 		break;
 	}
 
-	net_buf_simple_init(&client->buf, 0);
+	net_buf_simple_reset(&client->buf);
 }
 
 #define ATTR_IS_PROV(attr) (attr->user_data != NULL)
@@ -537,7 +538,7 @@ static void proxy_connected(struct bt_conn *conn, u8_t err)
 	client->conn = bt_conn_ref(conn);
 	client->filter_type = NONE;
 	memset(client->filter, 0, sizeof(client->filter));
-	net_buf_simple_init(&client->buf, 0);
+	net_buf_simple_reset(&client->buf);
 }
 
 static void proxy_disconnected(struct bt_conn *conn, u8_t reason)
@@ -570,7 +571,7 @@ struct net_buf_simple *bt_mesh_proxy_get_buf(void)
 {
 	struct net_buf_simple *buf = &clients[0].buf;
 
-	net_buf_simple_init(buf, 0);
+	net_buf_simple_reset(buf);
 
 	return buf;
 }
@@ -847,7 +848,7 @@ bool bt_mesh_proxy_relay(struct net_buf_simple *buf, u16_t dst)
 
 	for (i = 0; i < ARRAY_SIZE(clients); i++) {
 		struct bt_mesh_proxy_client *client = &clients[i];
-		struct net_buf_simple *msg = NET_BUF_SIMPLE(32);
+		NET_BUF_SIMPLE_DEFINE(msg, 32);
 
 		if (!client->conn) {
 			continue;
@@ -860,10 +861,10 @@ bool bt_mesh_proxy_relay(struct net_buf_simple *buf, u16_t dst)
 		/* Proxy PDU sending modifies the original buffer,
 		 * so we need to make a copy.
 		 */
-		net_buf_simple_init(msg, 1);
-		net_buf_simple_add_mem(msg, buf->data, buf->len);
+		net_buf_simple_reserve(&msg, 1);
+		net_buf_simple_add_mem(&msg, buf->data, buf->len);
 
-		bt_mesh_proxy_send(client->conn, BT_MESH_PROXY_NET_PDU, msg);
+		bt_mesh_proxy_send(client->conn, BT_MESH_PROXY_NET_PDU, &msg);
 		relayed = true;
 	}
 

--- a/tests/bluetooth/mesh/src/main.c
+++ b/tests/bluetooth/mesh/src/main.c
@@ -116,9 +116,7 @@ static struct bt_mesh_health_srv health_srv = {
 	.cb = &health_srv_cb,
 };
 
-static struct bt_mesh_model_pub health_pub = {
-	.msg = BT_MESH_HEALTH_FAULT_MSG(MAX_FAULT),
-};
+BT_MESH_HEALTH_PUB_DEFINE(health_pub, MAX_FAULT);
 
 static struct bt_mesh_model root_models[] = {
 	BT_MESH_MODEL_CFG_SRV(&cfg_srv),
@@ -131,14 +129,9 @@ static int vnd_publish(struct bt_mesh_model *mod)
 	return 0;
 }
 
-static struct bt_mesh_model_pub vnd_pub = {
-	.update = vnd_publish,
-	.msg = NET_BUF_SIMPLE(4),
-};
+BT_MESH_MODEL_PUB_DEFINE(vnd_pub, vnd_publish, 4);
 
-static struct bt_mesh_model_pub vnd_pub2 = {
-	.msg = NET_BUF_SIMPLE(4),
-};
+BT_MESH_MODEL_PUB_DEFINE(vnd_pub2, NULL, 4);
 
 static const struct bt_mesh_model_op vnd_ops[] = {
 	BT_MESH_MODEL_OP_END,
@@ -215,9 +208,7 @@ static void bt_ready(int err)
 	}
 
 	/* Initialize publication messages with dummy data */
-	net_buf_simple_init(vnd_pub.msg, 0);
 	net_buf_simple_add_le32(vnd_pub.msg, UINT32_MAX);
-	net_buf_simple_init(vnd_pub2.msg, 0);
 	net_buf_simple_add_le32(vnd_pub2.msg, UINT32_MAX);
 
 	bt_mesh_prov_enable(BT_MESH_PROV_ADV | BT_MESH_PROV_GATT);


### PR DESCRIPTION
Convert the mesh code to use the new net_buf_siple APIs. This has the
benefit of saving 4 bytes off the stack due to the not needed pointer.
Also update the publication context helpers to map to the new
net_buf_simple API in an intuitive way.

Signed-off-by: Johan Hedberg <johan.hedberg@intel.com>