### PR TITLE
arch: arm: feature consistency checks for Cortex M regs

### DIFF
--- a/arch/arm/core/cortex_m/Kconfig
+++ b/arch/arm/core/cortex_m/Kconfig
@@ -181,8 +181,9 @@ config ARMV7_M_ARMV8_M_MAINLINE
 	select CPU_CORTEX_M_HAS_PROGRAMMABLE_FAULT_PRIOS
 	help
 	  This option signifies the use of an ARMv7-M processor
-	  implementation, or the use of an ARMv8-M processor
-	  implementation supporting the Main Extension.
+	  implementation, or the use of a backwards-compatible
+	  ARMv8-M processor implementation supporting the Main
+	  Extension.
 
 	  Notes:
 	  - A Processing Element (PE) with the Main Extension is also

--- a/arch/arm/core/cortex_m/Kconfig
+++ b/arch/arm/core/cortex_m/Kconfig
@@ -106,16 +106,31 @@ config ISA_THUMB2
 config CPU_CORTEX_M_HAS_BASEPRI
 	bool
 	# Omit prompt to signify "hidden" option
+	depends on ARMV7_M_ARMV8_M_MAINLINE
 	default n
 	help
 	  This option signifies the CPU has the BASEPRI register.
 
+	  The BASEPRI register defines the minimum priority for
+	  exception processing. When BASEPRI is set to a nonzero
+	  value, it prevents the activation of all exceptions with
+	  the same or lower priority level as the BASEPRI value.
+	  Always present in CPUs that implement the ARMv7-M or
+	  ARM8-M Mainline architectures.
+
 config CPU_CORTEX_M_HAS_VTOR
 	bool
 	# Omit prompt to signify "hidden" option
+	depends on !CPU_CORTEX_M0
 	default n
 	help
 	  This option signifies the CPU has the VTOR register.
+	  The VTOR indicates the offset of the vector table base
+	  address from memory address 0x00000000. Always present
+	  in CPUs implementing the ARMv7-M or ARMv8-M architetures.
+	  Optional in CPUs implementing ARMv6-M, ARMv8-M Baseline
+	  architetures (except for Cortex-M0, where it is never
+	  implemented).
 
 config CPU_CORTEX_M_HAS_SPLIM
 	bool


### PR DESCRIPTION
This commit implements consistency checks for the core registers
in ARMv6-M, ARMv7-M, and ARMv8-M architectures, ensuring that
the user cannot accidentally select registers that are not
implemented by the selected Cortex M processor.

Signed-off-by: Ioannis Glaropoulos <Ioannis.Glaropoulos@nordicsemi.no>