### PR TITLE
build: win: Add a new zephyr-env.cmd file

### DIFF
--- a/doc/getting_started/getting_started.rst
+++ b/doc/getting_started/getting_started.rst
@@ -111,7 +111,7 @@ To build an example application follow these steps:
       # On Linux/macOS
       source zephyr-env.sh
       # On Windows
-      set ZEPHYR_BASE=%cd%
+      zephyr-env.cmd
 
 #. Build the :ref:`hello_world` example for the `arduino_101` board, enter:
 
@@ -190,7 +190,7 @@ must be installed.
       set ZEPHYR_GCC_VARIANT=
       set ZEPHYR_SDK_INSTALL_DIR=
       cd <zephyr git clone location>
-      set ZEPHYR_BASE=%cd%
+      zephyr-env.cmd
 
 
 #. On UNIX platforms, Build Kconfig in :file:`$ZEPHYR_BASE/build` and add

--- a/doc/getting_started/installation_win.rst
+++ b/doc/getting_started/installation_win.rst
@@ -135,12 +135,16 @@ packages from their respective websites.
       set ZEPHYR_GCC_VARIANT=gccarmemb
       set GCCARMEMB_TOOLCHAIN_PATH=c:\gccarmemb
 
-   And for either, set the `ZEPHYR_BASE` environment variable to the root
-   of the Zephyr repository you cloned:
+   To use the same toolchain in new sessions in the future you can set the
+   variables in a ``.cmd`` file and run that every time you open a new
+   Command Prompt.
+
+   And for either, run the :file:`zephyr-env.cmd` file in order to set the
+   :makevar:`ZEPHYR_BASE` environment variable:
 
    .. code-block:: console
 
-      set ZEPHYR_BASE=%userprofile%\zephyr
+      zephyr-env.cmd
 
 #. Finally, you can try building the :ref:`hello_world` sample to check things
    out.

--- a/zephyr-env.cmd
+++ b/zephyr-env.cmd
@@ -1,0 +1,2 @@
+@echo off
+set ZEPHYR_BASE=%~dp0


### PR DESCRIPTION
Add a new zephyr-env.cmd that mirrors the functionality of zephyr-env.sh
but on Windows platforms. It sets ZEPHYR_BASE to the location of the
script and also runs an answer file named %userprofile%\zephyr.cmd if it
exists.

Fixes #5719
Signed-off-by: Carles Cufi <carles.cufi@nordicsemi.no>