### PR TITLE
Bluetooth: controller: Fix incorrect master role scheduling

### DIFF
--- a/subsys/bluetooth/controller/hal/nrf5/ticker.h
+++ b/subsys/bluetooth/controller/hal/nrf5/ticker.h
@@ -28,6 +28,9 @@
 #define HAL_TICKER_TICKS_TO_US(x) \
 	((u32_t)(((u64_t) (x) * 30517578125UL) / 1000000000UL))
 
+/* Macro defines the h/w supported most significant bit */
+#define HAL_TICKER_MSBIT 23
+
 /* Exported integration interfaces */
 u8_t hal_ticker_instance0_caller_id_get(u8_t user_id);
 void hal_ticker_instance0_sched(u8_t caller_id, u8_t callee_id, u8_t chain,

--- a/subsys/bluetooth/controller/ticker/ticker.c
+++ b/subsys/bluetooth/controller/ticker/ticker.c
@@ -9,6 +9,11 @@
 #include <soc.h>
 
 #include "hal/cntr.h"
+
+#if defined(CONFIG_SOC_FAMILY_NRF5)
+#include "hal/nrf5/ticker.h"
+#endif /* CONFIG_SOC_FAMILY_NRF5 */
+
 #include "ticker.h"
 
 #include "common/log.h"
@@ -417,7 +422,7 @@ static void ticks_to_expire_prep(struct ticker_node *ticker,
 	u32_t ticks_to_expire_minus = ticker->ticks_to_expire_minus;
 
 	/* Calculate ticks to expire for this new node */
-	if (((ticks_at_start - ticks_current) & BIT(23)) == 0) {
+	if (!((ticks_at_start - ticks_current) & BIT(HAL_TICKER_MSBIT))) {
 		ticks_to_expire += ticker_ticks_diff_get(ticks_at_start,
 							 ticks_current);
 	} else {


### PR DESCRIPTION
Revert incorrect calculation introduced in
commit ec5a787da2ab ("Bluetooth: controller: Fix multiple
master role event scheduling") and revert a related
incorrect fix in commit a02606cbf9d2 ("Bluetooth:
controller: Fix missing ticks to us conversion").

Relates to: #5486

Fixes the controller assert in ctrl.c line number 1477. A
64-bit arithmetic took ~35 us in Radio ISR for nRF51 causing
the ISR to take too much time before packet buffer could be
set.

Signed-off-by: Vinayak Kariappa Chettimada <vich@nordicsemi.no>