### PR TITLE
doc: fix duplicate sample doc titles

### DIFF
--- a/samples/boards/nrf52/power_mgr/README.rst
+++ b/samples/boards/nrf52/power_mgr/README.rst
@@ -1,7 +1,7 @@
 .. _nrf52-power-mgr-sample:
 
-Power management demo
-#####################
+nRF52 Power management demo
+###########################
 
 Overview
 ********

--- a/samples/boards/quark_se_c1000/power_mgr/README.rst
+++ b/samples/boards/quark_se_c1000/power_mgr/README.rst
@@ -1,7 +1,7 @@
 .. _power-mgr-sample:
 
-Power management demo
-#####################
+Intel® Quark™ SE Microcontroller C1000 Power management demo
+############################################################
 
 Overview
 ********
@@ -23,7 +23,7 @@ It will cycle through the following states:
 Requirements
 ************
 
-This application uses Intel Quark SE Microcontroller C1000 board for
+This application uses an Intel® Quark™ SE Microcontroller C1000 board for
 the demo. It demonstrates power operations on the x86 and ARC cores in
 the board.
 


### PR DESCRIPTION
Two docs listed in the Samples an Demos TOC had the same title displayed
in the board-specific samples section, "Power Management Demo".  Give
both sample docs a more specific title.

Signed-off-by: David B. Kinder <david.b.kinder@intel.com>