### PR TITLE
x86: fix build warning

### DIFF
--- a/arch/x86/core/excstub.S
+++ b/arch/x86/core/excstub.S
@@ -127,7 +127,7 @@ SECTION_FUNC(TEXT, _exception_enter)
 
 	orb	$_EXC_ACTIVE, _thread_offset_to_thread_state(%edx)
 
-#endif /* CONFIG_FP_SHARING
+#endif /* CONFIG_FP_SHARING */
 
 	/*
 	 * restore interrupt enable state, then call the handler


### PR DESCRIPTION
During compile of lwm2m_client using qemu_x86, the following build
warning was noticed:
zephyr/arch/x86/core/excstub.S:132:2: warning: "/*" within comment [-Wcomment]
  /*

In commit ff42bdd0a04f ("debug: remove option GDB_INFO"), the comment tag
was omitted.  Fix the comment end tag.

Signed-off-by: Michael Scott <michael@opensourcefoundries.com>