### PR TITLE
arch: arm: Enable stack guard before starting main

### DIFF
--- a/arch/arm/include/kernel_arch_func.h
+++ b/arch/arm/include/kernel_arch_func.h
@@ -68,6 +68,16 @@ _arch_switch_to_main_thread(struct k_thread *main_thread,
 #error Unknown ARM architecture
 #endif /* CONFIG_ARMV6_M_ARMV8_M_BASELINE */
 
+#ifdef CONFIG_MPU_STACK_GUARD
+		/*
+		 * if guard is enabled, make sure to set it before jumping to thread
+		 * entry function
+		*/
+		"mov %%r0, %3 \t\n"
+		"push {r2, lr} \t\n"
+		"blx configure_mpu_stack_guard \t\n"
+		"pop {r2, lr} \t\n"
+#endif
 		/* branch to _thread_entry(_main, 0, 0, 0) */
 		"mov %%r0, %1 \n\t"
 		"bx %2 \t\n"
@@ -76,7 +86,8 @@ _arch_switch_to_main_thread(struct k_thread *main_thread,
 
 		:
 		: "r"(start_of_main_stack),
-		  "r"(_main), "r"(_thread_entry)
+		  "r"(_main), "r"(_thread_entry),
+		  "r"(main_thread)
 
 		: "r0", "r1", "sp"
 	);


### PR DESCRIPTION
This patch fixes a hole in the stack guard configuration.  The initial
branch to main is missing the stack guard configuration.

Fixes #3718

Signed-off-by: Andy Gross <andy.gross@linaro.org>