### PR TITLE
subsys: storage: flash_map: Fix warning

### DIFF
--- a/include/flash_map.h
+++ b/include/flash_map.h
@@ -74,7 +74,7 @@ u8_t flash_area_align(const struct flash_area *fa);
 /*
  * Given flash area ID, return info about sectors within the area.
  */
-int flash_area_get_sectors(int fa_id, uint32_t *count,
+int flash_area_get_sectors(int fa_id, u32_t *count,
 			   struct flash_sector *sectors);
 
 #ifdef __cplusplus

--- a/subsys/storage/flash_map/flash_map.c
+++ b/subsys/storage/flash_map/flash_map.c
@@ -133,7 +133,7 @@ static bool should_bail(const struct flash_pages_info *info,
  * flash_area_get_sectors(). A lot of this can be inlined once
  * flash_area_to_sectors() is removed.
  */
-static int flash_area_layout(int idx, int *cnt, void *ret,
+static int flash_area_layout(int idx, u32_t *cnt, void *ret,
 flash_page_cb cb, struct layout_data *cb_data)
 {
 	struct device *flash_dev;
@@ -184,7 +184,7 @@ static bool get_sectors_cb(const struct flash_pages_info *info, void *datav)
 	return true;
 }
 
-int flash_area_get_sectors(int idx, uint32_t *cnt, struct flash_sector *ret)
+int flash_area_get_sectors(int idx, u32_t *cnt, struct flash_sector *ret)
 {
 	struct layout_data data;
 

--- a/tests/subsys/storage/flash_map/src/main.c
+++ b/tests/subsys/storage/flash_map/src/main.c
@@ -25,7 +25,7 @@ struct flash_sector fs_sectors[256];
 void flash_map_test_case_2(void)
 {
 	const struct flash_area *fa;
-	int sec_cnt;
+	u32_t sec_cnt;
 	int i;
 	int rc;
 	off_t off;


### PR DESCRIPTION
Prior to this commit, `flash_area_layout()` was being passed a pointer to the incorrect type (`uint32_t *` where `int *` was expected).  This caused the following warning to be reported:

```
[...]/subsys/storage/flash_map/flash_map.c: In function 'flash_area_get_sectors':
[...]/subsys/storage/flash_map/flash_map.c:191:32: warning: passing argument 2 of 'flash_area_layout' from incompatible pointer type [-Wincompatible-pointer-types]
  return flash_area_layout(idx, cnt, ret, get_sectors_cb, &data);
                                ^~~
[...]/subsys/storage/flash_map/flash_map.c:136:12: note: expected 'int *' but argument is of type 'uint32_t * {aka long unsigned int *}'
 static int flash_area_layout(int idx, int *cnt, void *ret,
            ^~~~~~~~~~~~~~~~~
```

This commit changes the argument type to `u32_t` for both functions.

Signed-off-by: Christopher Collins <ccollins@apache.org>