### PR TITLE
kernel: mem_domain: k_mem_partition is now placed in kernel memory.

### DIFF
--- a/include/kernel.h
+++ b/include/kernel.h
@@ -4238,11 +4238,11 @@ static inline char *K_THREAD_STACK_BUFFER(k_thread_stack_t *sym)
 #ifdef _ARCH_MEM_PARTITION_ALIGN_CHECK
 #define K_MEM_PARTITION_DEFINE(name, start, size, attr) \
 	_ARCH_MEM_PARTITION_ALIGN_CHECK(start, size); \
-	struct k_mem_partition name = \
+	__kernel struct k_mem_partition name =\
 		MEM_PARTITION_ENTRY((u32_t)start, size, attr)
 #else
 #define K_MEM_PARTITION_DEFINE(name, start, size, attr) \
-	struct k_mem_partition name = \
+	__kernel struct k_mem_partition name =\
 		MEM_PARTITION_ENTRY((u32_t)start, size, attr)
 #endif /* _ARCH_MEM_PARTITION_ALIGN_CHECK */
 
@@ -4258,7 +4258,9 @@ struct k_mem_partition {
 #endif	/* CONFIG_USERSPACE */
 };
 
-/* memory domian */
+/* memory domian
+ * Note: Always declare this structure with __kernel prefix
+ */
 struct k_mem_domain {
 #ifdef CONFIG_USERSPACE
 	/* partitions in the domain */

--- a/samples/mpu/mem_domain_apis_test/src/main.c
+++ b/samples/mpu/mem_domain_apis_test/src/main.c
@@ -23,7 +23,7 @@ K_THREAD_STACK_ARRAY_DEFINE(app_stack, 3, STACKSIZE);
 
 struct k_thread app_thread_id[3];
 
-struct k_mem_domain app_domain[2];
+__kernel struct k_mem_domain app_domain[2];
 
 /* the start address of the MPU region needs to align with its size */
 #ifdef CONFIG_ARM


### PR DESCRIPTION
The k_mem_partition structs need to be placed in the kernel memory.
This patch ensures that these structs are placed correctly.
Also when a struct k_mem_domain is declared it is advised to add
__kernel.

Signed-off-by: Adithya Baglody <adithya.nagaraj.baglody@intel.com>