### PR TITLE
Bluetooth: Mesh: Fix NULL pointer access with GATT Proxy

### DIFF
--- a/subsys/bluetooth/host/mesh/proxy.c
+++ b/subsys/bluetooth/host/mesh/proxy.c
@@ -538,7 +538,7 @@ static void proxy_connected(struct bt_conn *conn, u8_t err)
 	client->conn = bt_conn_ref(conn);
 	client->filter_type = NONE;
 	memset(client->filter, 0, sizeof(client->filter));
-	net_buf_simple_reset(&client->buf);
+	net_buf_simple_init(&client->buf, 0);
 }
 
 static void proxy_disconnected(struct bt_conn *conn, u8_t reason)


### PR DESCRIPTION
The conversion to the new net_buf_simple API was done incorrectly
here. The buffer initialization should use net_buf_simple_init()
instead of net_buf_simple_reset(), so that buf->__buf gets properly
initialized (and not left pointing at NULL).

Signed-off-by: Johan Hedberg <johan.hedberg@intel.com>