### PR TITLE
Bluetooth: central_hr: Fix assigning temporary UUID to discovery

### DIFF
--- a/samples/bluetooth/central_hr/src/main.c
+++ b/samples/bluetooth/central_hr/src/main.c
@@ -110,7 +110,7 @@ static void connected(struct bt_conn *conn, u8_t conn_err)
 
 	if (conn == default_conn) {
 		memcpy(&uuid, BT_UUID_HRS, sizeof(uuid));
-		discover_params.uuid = BT_UUID_HRS;
+		discover_params.uuid = &uuid.uuid;
 		discover_params.func = discover_func;
 		discover_params.start_handle = 0x0001;
 		discover_params.end_handle = 0xffff;


### PR DESCRIPTION
bt_gatt_discover_params parameter shall remain valid as long as the
procedure is in place.

Signed-off-by: Luiz Augusto von Dentz <luiz.von.dentz@intel.com>