### PR TITLE
dma: Fix building when system calls are disabled

### DIFF
--- a/include/dma.h
+++ b/include/dma.h
@@ -297,4 +297,6 @@ static inline u32_t dma_burst_index(u32_t burst)
 }
 #endif
 
+#include <syscalls/dma.h>
+
 #endif /* _DMA_H_ */


### PR DESCRIPTION
When we added system call support to dma_start/dma_stop we forgot to
include <syscalls/dma.h> to get the full proper magic implemented.
Adding the header in fixes builds when system call support is not
enabled and using dma support.

Signed-off-by: Kumar Gala <kumar.gala@linaro.org>