### PR TITLE
tests: userspace: fix read/write privileged stack tests

### DIFF
--- a/tests/ztest/src/ztest.c
+++ b/tests/ztest/src/ztest.c
@@ -152,8 +152,8 @@ out:
     #error "CONFIG_ZTEST_STACKSIZE must be a multiple of the stack alignment"
 #endif
 
-static K_THREAD_STACK_DEFINE(thread_stack, CONFIG_ZTEST_STACKSIZE +
-			     CONFIG_TEST_EXTRA_STACKSIZE);
+K_THREAD_STACK_DEFINE(ztest_thread_stack, CONFIG_ZTEST_STACKSIZE +
+		      CONFIG_TEST_EXTRA_STACKSIZE);
 
 static int test_result;
 __kernel static struct k_sem test_end_signal;
@@ -197,8 +197,8 @@ static int run_test(struct unit_test *test)
 	int ret = TC_PASS;
 
 	TC_START(test->name);
-	k_thread_create(&ztest_thread, thread_stack,
-			K_THREAD_STACK_SIZEOF(thread_stack),
+	k_thread_create(&ztest_thread, ztest_thread_stack,
+			K_THREAD_STACK_SIZEOF(ztest_thread_stack),
 			(k_thread_entry_t) test_cb, (struct unit_test *)test,
 			NULL, NULL, -1, test->thread_options | K_INHERIT_PERMS,
 			0);


### PR DESCRIPTION
The read/write_kernel_stack tests are confusingly named and incorrectly
implemented for ARM; they are intended to test that user mode threads
cannot read or write their privileged stacks.  The privileged stacks
on ARM are not relative to the user stack, and thus their location
cannot be computed from the user stack.  To find the privileged stack on
ARM, we have to use _k_priv_stack_find(), which we do during setup
in test_main() rather than from the usermode thread itself.  Accessing
thread_stack directly from the test function requires making it
non-static in ztest, so we also give it a ztest_ prefix to avoid
collisions with other test programs.  Rename the test functions and
global pointer variable to more accurately reflect their purpose.

Signed-off-by: Stephen Smalley <sds@tycho.nsa.gov>