### PR TITLE
kernel: device: Remove the redundant device name check

### DIFF
--- a/kernel/device.c
+++ b/kernel/device.c
@@ -65,10 +65,6 @@ struct device *device_get_binding(const char *name)
 			continue;
 		}
 
-		if (name == info->config->name) {
-			return info;
-		}
-
 		if (!strcmp(name, info->config->name)) {
 			return info;
 		}


### PR DESCRIPTION
Remove the redundant device name match check in device_get_binding().

Signed-off-by: Ramakrishna Pallala <ramakrishna.pallala@intel.com>