### PR TITLE
net: app: client: set remote port after DNS lookup

### DIFF
--- a/subsys/net/lib/app/client.c
+++ b/subsys/net/lib/app/client.c
@@ -373,17 +373,6 @@ int net_app_init_client(struct net_app_ctx *ctx,
 					   strlen(base_peer_addr),
 					   &remote_addr);
 
-#if defined(CONFIG_NET_IPV6)
-		if (remote_addr.sa_family == AF_INET6) {
-			net_sin6(&remote_addr)->sin6_port = htons(peer_port);
-		}
-#endif
-#if defined(CONFIG_NET_IPV4)
-		if (remote_addr.sa_family == AF_INET) {
-			net_sin(&remote_addr)->sin_port = htons(peer_port);
-		}
-#endif
-
 		/* The remote_addr will be used by set_remote_addr() to
 		 * set the actual peer address.
 		 */
@@ -458,6 +447,22 @@ int net_app_init_client(struct net_app_ctx *ctx,
 	    ctx->default_ctx->remote.sa_family == AF_UNSPEC) {
 		NET_ERR("Unknown protocol family.");
 		return -EPFNOSUPPORT;
+	}
+
+	/* Set the port now that we know the sa_family */
+	if (!peer_addr) {
+#if defined(CONFIG_NET_IPV6)
+		if (ctx->default_ctx->remote.sa_family == AF_INET6) {
+			net_sin6(&ctx->default_ctx->remote)->sin6_port =
+				htons(peer_port);
+		}
+#endif
+#if defined(CONFIG_NET_IPV4)
+		if (ctx->default_ctx->remote.sa_family == AF_INET) {
+			net_sin(&ctx->default_ctx->remote)->sin_port =
+				htons(peer_port);
+		}
+#endif
 	}
 
 	ret = bind_local(ctx);


### PR DESCRIPTION
In net_app_init_client(), the remote port is set after an initial
set of checks based on the remote_addr's assigned family.

However, if the peer_addr_str is a host name which needs to be
resolved via DNS, the family won't be set yet, and the port is
left as 0.

To fix this behavior let's move the port assignment after the
DNS lookup section to be sure that the remote sa_family is set.

Signed-off-by: Michael Scott <michael@opensourcefoundries.com>