### PR TITLE
arm: cortex_m: Use new ARMV6_M_ARMV8_M_BASELINE in vector relay

### DIFF
--- a/arch/arm/core/cortex_m/Kconfig
+++ b/arch/arm/core/cortex_m/Kconfig
@@ -235,14 +235,15 @@ config ZERO_LATENCY_IRQS
 
 config SW_VECTOR_RELAY
 	bool
-	prompt "Enable ARMv6-M Vector Table soft relay"
+	prompt "Enable Software Vector Relay"
 	default n
 	default y if BOOTLOADER_MCUBOOT
-	depends on ARMV6_M && !(CPU_CORTEX_M0_HAS_VECTOR_TABLE_REMAP || CPU_CORTEX_M_HAS_VTOR)
+	depends on ARMV6_M_ARMV8_M_BASELINE && !(CPU_CORTEX_M0_HAS_VECTOR_TABLE_REMAP || CPU_CORTEX_M_HAS_VTOR)
 	help
-	  Add ARMv6-M Vector Table relay handler and relay vector table, to
+	  Add Vector Table relay handler and relay vector table, to
 	  relay interrupts based on a vector table pointer. This is only
-	  required for Cortex-M0 with no hardware vector table relocation
-	  mechanisms or for Cortex-M0+ with no VTOR and no other hardware
+	  required for Cortex-M0 (or an Armv8-M baseline core) with no hardware
+	  vector table relocation mechanisms or for Cortex-M0+
+	  (or an Armv8-M baseline core) with no VTOR and no other hardware
 	  relocation table mechanisms.
 endmenu

--- a/arch/arm/core/irq_relay.S
+++ b/arch/arm/core/irq_relay.S
@@ -7,15 +7,16 @@
 /**
  * @file irq_relay.S
  *
- * @brief IRQ relay vector table and relay handler for Cortex-M0 SoC
+ * @brief IRQ relay vector table and relay handler for Cortex-M0 or
+ *        Armv8-M baseline SoCs
  *
- * In Cortex-M0, the vector table address can not be changed. Once the
- * vector table is occupied by bootloader, there will be no IRQ support
- * in chainloaded image.
+ * In certain ARMv6-M and Armv8-M baseline cores the vector table address can
+ * not be changed. Once the * vector table is occupied by bootloader, there
+ * will be no IRQ support in the chainloaded image.
  *
  * This program will link into bootloader, once an interrupt is coming,
- * bootloader can forward the interrupt to the chainloaded image. This
- * will support DFU on Cortex-M0 plantform.
+ * the bootloader can forward the interrupt to the chainloaded image. This
+ * will support DFU on those cores.
  *
  * Note: Currently support mcuboot only.
  * */

--- a/misc/Kconfig
+++ b/misc/Kconfig
@@ -323,8 +323,8 @@ config BOOTLOADER_MCUBOOT
 
 	    * Setting TEXT_LOAD_OFFSET to a default value that allows space for
 	      the MCUboot image header
-	    * Activating SW_VECTOR_RELAY on Cortex-M0 targets with no built-in
-	      vector relocation mechanisms
+	    * Activating SW_VECTOR_RELAY on Cortex-M0 (or Armv8-M baseline)
+	      targets with no built-in vector relocation mechanisms
 	    * Including dts/common/mcuboot.overlay when building the Device
 	      Tree in order to place and link the image at the slot0 offset
 


### PR DESCRIPTION
The old ARMV6_M Kconfig option has been removed, and so to correctly set
the dependencies for SW_VECTOR_RELAY we need to use the new
ARMV6_M_ARMV8_M_BASELINE.

Signed-off-by: Carles Cufi <carles.cufi@nordicsemi.no>