### PR TITLE
Bluetooth: Mesh: Ignore segments of cancelled message

### DIFF
--- a/subsys/bluetooth/host/mesh/transport.c
+++ b/subsys/bluetooth/host/mesh/transport.c
@@ -1014,9 +1014,7 @@ static void seg_ack(struct k_work *work)
 
 	if (k_uptime_get_32() - rx->last > K_SECONDS(60)) {
 		BT_WARN("Incomplete timer expired");
-		send_ack(rx->sub, rx->dst, rx->src, rx->ttl,
-			 &rx->seq_auth, 0, rx->obo);
-		seg_rx_reset(rx, true);
+		seg_rx_reset(rx, false);
 
 		if (IS_ENABLED(CONFIG_BT_TESTING)) {
 			bt_test_mesh_trans_incomp_timer_exp();


### PR DESCRIPTION
This fixes the issue when after incomplete timer expiration
host sent ACK.
The host failed in two cases:
1. Sending ACK right after the incomplete timer expiration;
2. Sending ACK from new RX context. Now, seq_auth of cancelled
message is not cleaned on RX reset, so segments of cancelled message
will be discarded when resend.

According to the Mesh Profile v1.0
"When the incomplete timer expires, the lower transport layer
shall consider that the message being received has failed and
cancel the acknowledgment timer. Any segment of a canceled
message shall be ignored."

Fixes #6023

Signed-off-by: Mariusz Skamra <mariusz.skamra@codecoup.pl>