### PR TITLE
kernel: device: Only compare strings if pointer comparison fails

### DIFF
--- a/kernel/device.c
+++ b/kernel/device.c
@@ -60,6 +60,17 @@ struct device *device_get_binding(const char *name)
 {
 	struct device *info;
 
+	/* Split the search into two loops: in the common scenario, where
+	 * device names are stored in ROM (and are referenced by the user
+	 * with CONFIG_* macros), only cheap pointer comparisons will be
+	 * performed.  Reserve string comparisons for a fallback.
+	 */
+	for (info = __device_init_start; info != __device_init_end; info++) {
+		if (info->driver_api != NULL && info->config->name == name) {
+			return info;
+		}
+	}
+
 	for (info = __device_init_start; info != __device_init_end; info++) {
 		if (!info->driver_api) {
 			continue;

--- a/tests/kernel/device/src/main.c
+++ b/tests/kernel/device/src/main.c
@@ -28,6 +28,26 @@ void test_dummy_device(void)
 
 }
 
+static void test_dynamic_name(void)
+{
+	struct device *mux;
+	char name[sizeof(DUMMY_PORT_2)];
+
+	snprintk(name, sizeof(name), "%s", DUMMY_PORT_2);
+	mux = device_get_binding(name);
+	zassert_true(mux != NULL, NULL);
+}
+
+static void test_bogus_dynamic_name(void)
+{
+	struct device *mux;
+	char name[64];
+
+	snprintk(name, sizeof(name), "ANOTHER_BOGUS_NAME");
+	mux = device_get_binding(name);
+	zassert_true(mux == NULL, NULL);
+}
+
 #ifdef CONFIG_DEVICE_POWER_MANAGEMENT
 static void build_suspend_device_list(void)
 {
@@ -74,6 +94,8 @@ void test_main(void)
 			 ztest_unit_test(test_dummy_device_pm),
 			 ztest_unit_test(build_suspend_device_list),
 #endif
-			 ztest_unit_test(test_dummy_device));
+			 ztest_unit_test(test_dummy_device),
+			 ztest_unit_test(test_bogus_dynamic_name),
+			 ztest_unit_test(test_dynamic_name));
 	ztest_run_test_suite(test_device);
 }


### PR DESCRIPTION
Split the search into two loops: in the common scenario, where device names are stored in ROM (and are referenced by the user with CONFIG_* macros), only cheap pointer comparisons will be performed.

Reserve string comparisons for a fallback second pass.

Sending this patch after some discussion post-merge in #6192.