### PR TITLE
arm: mpu: nxp: Set bus master 3 to full access

### DIFF
--- a/include/arch/arm/cortex_m/mpu/nxp_mpu.h
+++ b/include/arch/arm/cortex_m/mpu/nxp_mpu.h
@@ -82,12 +82,14 @@
 
 /* Some helper defines for common regions */
 #if defined(CONFIG_MPU_ALLOW_FLASH_WRITE)
-#define REGION_RAM_ATTR	  (MPU_REGION_SU_RWX)
+#define REGION_RAM_ATTR	  ((MPU_REGION_SU_RWX) | \
+			   ((UM_READ | UM_WRITE | UM_EXEC) << BM3_UM_SHIFT))
 
 #define REGION_FLASH_ATTR (MPU_REGION_SU_RWX)
 
 #else
-#define REGION_RAM_ATTR	  (MPU_REGION_SU_RW)
+#define REGION_RAM_ATTR	  ((MPU_REGION_SU_RW) | \
+			   ((UM_READ | UM_WRITE) << BM3_UM_SHIFT))
 
 #define REGION_FLASH_ATTR (MPU_REGION_READ | \
 			   MPU_REGION_EXEC | \


### PR DESCRIPTION
This patch adjusts the default permissions on the bus master 3 (NET).
Recent changes restricted this to supervisor only, and this caused
issues with the network controllers access to memory.

Restrictions on access should really be enforced on the ARM core bus
master.

Fixes #6194

Signed-off-by: Andy Gross <andy.gross@linaro.org>