### PR TITLE
Bluetooth: SMP: Send Pairing failed if there's no key space

### DIFF
--- a/subsys/bluetooth/host/smp.c
+++ b/subsys/bluetooth/host/smp.c
@@ -4338,6 +4338,7 @@ void bt_smp_update_keys(struct bt_conn *conn)
 	if (!conn->le.keys) {
 		BT_ERR("Unable to get keys for %s",
 		       bt_addr_le_str(&conn->le.dst));
+		smp_error(smp, BT_SMP_ERR_UNSPECIFIED);
 		return;
 	}
 


### PR DESCRIPTION
If there's no more room to store new pairings, send a proper error
instead of letting the SMP timeout expire.

Signed-off-by: Johan Hedberg <johan.hedberg@intel.com>