### PR TITLE
Usb: Add composite configuration to HID and cleanups

### DIFF
--- a/samples/bluetooth/hci_usb/sample.yaml
+++ b/samples/bluetooth/hci_usb/sample.yaml
@@ -5,8 +5,5 @@ tests:
   test_x86:
     harness: bluetooth
     depends_on: usb_device
-    extra_configs:
-      - CONFIG_USB_DEVICE_VID=0xDEAD
-      - CONFIG_USB_DEVICE_PID=0xBEEF
     platform_whitelist: quark_se_c1000_devboard nrf52840_pca10056
     tags: usb bluetooth

--- a/samples/net/echo_server/sample.yaml
+++ b/samples/net/echo_server/sample.yaml
@@ -25,9 +25,6 @@ tests:
   test_usbnet:
     harness: net
     extra_args: CONF_FILE="prj_netusb.conf"
-    extra_configs:
-      - CONFIG_USB_DEVICE_VID=0xDEAD
-      - CONFIG_USB_DEVICE_PID=0xBEEF
     platform_whitelist: quark_se_c1000_devboard 96b_carbon
     tags: net usb
   test_usbnet_composite:
@@ -35,8 +32,6 @@ tests:
     extra_args: CONF_FILE="prj_netusb.conf"
     extra_configs:
       - CONFIG_USB_COMPOSITE_DEVICE=y
-      - CONFIG_USB_DEVICE_VID=0xDEAD
-      - CONFIG_USB_DEVICE_PID=0xBEEF
     platform_whitelist: quark_se_c1000_devboard 96b_carbon
     tags: net usb
   test_openthread:

--- a/samples/net/http_server/sample.yaml
+++ b/samples/net/http_server/sample.yaml
@@ -13,8 +13,5 @@ tests:
   test_usbnet:
     harness: net
     extra_args: CONF_FILE="prj_netusb.conf"
-    extra_configs:
-      - CONFIG_USB_DEVICE_VID=0xDEAD
-      - CONFIG_USB_DEVICE_PID=0xBEEF
     platform_whitelist: quark_se_c1000_devboard
     tags: net usb

--- a/samples/net/wpan_serial/sample.yaml
+++ b/samples/net/wpan_serial/sample.yaml
@@ -5,8 +5,5 @@ tests:
   test_x86:
     harness: net
     depends_on: usb_device
-    extra_configs:
-      - CONFIG_USB_DEVICE_VID=0xDEAD
-      - CONFIG_USB_DEVICE_PID=0xBEEF
     platform_whitelist: quark_se_c1000_devboard
     tags: usb

--- a/samples/net/wpanusb/sample.yaml
+++ b/samples/net/wpanusb/sample.yaml
@@ -6,7 +6,4 @@ tests:
     harness: net
     platform_exclude: nrf52840_pca10056
     depends_on: ieee802154 usb_device
-    extra_configs:
-      - CONFIG_USB_DEVICE_VID=0xDEAD
-      - CONFIG_USB_DEVICE_PID=0xBEEF
     tags: net ieee802154 usb

--- a/samples/subsys/usb/hid/sample.yaml
+++ b/samples/subsys/usb/hid/sample.yaml
@@ -3,9 +3,18 @@ sample:
 tests:
   test_hid:
     depends_on: usb_device
+    platform_whitelist: quark_se_c1000_devboard
     tags: usb
   test_hid_composite:
     depends_on: usb_device
     extra_configs:
       - CONFIG_USB_COMPOSITE_DEVICE=y
+    platform_whitelist: quark_se_c1000_devboard
+    tags: usb
+  test_hid_msc_composite:
+    depends_on: usb_device
+    extra_configs:
+      - CONFIG_USB_COMPOSITE_DEVICE=y
+      - CONFIG_USB_MASS_STORAGE=y
+    platform_whitelist: quark_se_c1000_devboard
     tags: usb

--- a/samples/subsys/usb/hid/sample.yaml
+++ b/samples/subsys/usb/hid/sample.yaml
@@ -4,3 +4,8 @@ tests:
   test_hid:
     depends_on: usb_device
     tags: usb
+  test_hid_composite:
+    depends_on: usb_device
+    extra_configs:
+      - CONFIG_USB_COMPOSITE_DEVICE=y
+    tags: usb

--- a/subsys/usb/class/hid/core.c
+++ b/subsys/usb/class/hid/core.c
@@ -16,6 +16,10 @@
 #include <usb_descriptor.h>
 #include <class/usb_hid.h>
 
+#ifdef CONFIG_USB_COMPOSITE_DEVICE
+#include <composite.h>
+#endif
+
 static struct hid_device_info {
 	const u8_t *report_desc;
 	size_t report_size;
@@ -159,6 +163,11 @@ int usb_hid_init(void)
 
 	SYS_LOG_DBG("Iinitializing HID Device");
 
+	/*
+	 * Modify Report Descriptor Size
+	 */
+	usb_set_hid_report_size(hid_device.report_size);
+
 #ifdef CONFIG_USB_COMPOSITE_DEVICE
 	ret = composite_add_function(&hid_config, FIRST_IFACE_HID);
 	if (ret < 0) {
@@ -168,11 +177,6 @@ int usb_hid_init(void)
 #else
 	hid_config.interface.payload_data = interface_data;
 	hid_config.usb_device_description = usb_get_device_descriptor();
-
-	/*
-	 * Modify Report Descriptor Size
-	 */
-	usb_set_hid_report_size(hid_device.report_size);
 
 	/* Initialize the USB driver with the right configuration */
 	ret = usb_set_config(&hid_config);


### PR DESCRIPTION
There is one questionable way to set pre_init() in the main "user" application. Commit 9e63e9527d46506109022161b5bf6087853c5aee