### PR TITLE
usb: Add USB Device Language Identifier

### DIFF
--- a/subsys/usb/Kconfig
+++ b/subsys/usb/Kconfig
@@ -50,6 +50,13 @@ config USB_DEVICE_PID
 	help
 	  USB device product ID. MUST be configured by vendor.
 
+config USB_DEVICE_LANG_ID
+	hex
+	prompt "USB Language ID"
+	default 0x0409
+	help
+	  USB device strings language identifier.
+
 config USB_DEVICE_MANUFACTURER
 	string
 	default "ZEPHYR"

--- a/subsys/usb/composite.c
+++ b/subsys/usb/composite.c
@@ -54,9 +54,14 @@ static int composite_class_handler(struct usb_setup_packet *pSetup,
 static int composite_custom_handler(struct usb_setup_packet *pSetup,
 		s32_t *len, u8_t **data)
 {
-	if (pSetup->wIndex >= NUMOF_IFACES) {
-		SYS_LOG_DBG("unknown request 0x%x, value 0x%x",
-			pSetup->bRequest, pSetup->wValue);
+	/*
+	 * wIndex can be Zero, Interface endpoint number or Language ID.
+	 * At the moment only one language is specified in Kconfig
+	 */
+	if (pSetup->wIndex >= NUMOF_IFACES &&
+	    pSetup->wIndex != CONFIG_USB_DEVICE_LANG_ID) {
+		SYS_LOG_DBG("unknown request 0x%x, value 0x%x iface %d",
+			pSetup->bRequest, pSetup->wValue, pSetup->wIndex);
 		return -ENOTSUP;
 	}
 

--- a/subsys/usb/usb_descriptor.c
+++ b/subsys/usb/usb_descriptor.c
@@ -599,7 +599,7 @@ static struct dev_common_descriptor common_desc = {
 		.lang_descr = {
 			.bLength = sizeof(struct usb_string_descriptor),
 			.bDescriptorType = USB_STRING_DESC,
-			.bString = sys_cpu_to_le16(0x0409),
+			.bString = sys_cpu_to_le16(CONFIG_USB_DEVICE_LANG_ID),
 		},
 		/* Manufacturer String Descriptor */
 		.unicode_mfr = {


### PR DESCRIPTION
Add configuration option CONFIG_USB_DEVICE_LANG_ID and check for the
language id in composite_custom_handler().

Is it enough to have one Language ID?

Signed-off-by: Andrei Emeltchenko <andrei.emeltchenko@intel.com>