### PR TITLE
mbedtls: config-mini-tls1_2.h: Update stale comments

### DIFF
--- a/ext/lib/crypto/mbedtls/configs/config-mini-tls1_2.h
+++ b/ext/lib/crypto/mbedtls/configs/config-mini-tls1_2.h
@@ -4,10 +4,8 @@
  *
  * SPDX-License-Identifier: Apache-2.0
  *
- * Minimal configuration for TLS 1.1 (RFC 4346) for Zephyr, implementing only
- * the required ciphersuite: MBEDTLS_TLS_RSA_WITH_3DES_EDE_CBC_SHA
- *
- * See README.txt for usage instructions.
+ * Minimal configuration for TLS 1.2 (RFC 5246) for Zephyr, implementing only
+ * a few of the most popular ciphersuites.
  */
 
 #ifndef MBEDTLS_CONFIG_H


### PR DESCRIPTION
This config enables TLS 1.2 (only), as its name suggests, and
contrary to the (copy-pasted) comments in the file header, so
update these comments.

Fixes: #6131

Signed-off-by: Paul Sokolovsky <paul.sokolovsky@linaro.org>