### PR TITLE
sanitycheck: check for deprecated variant variable

### DIFF
--- a/scripts/sanitycheck
+++ b/scripts/sanitycheck
@@ -1546,7 +1546,12 @@ class TestSuite:
 
     def apply_filters(self):
 
-        toolchain = os.environ.get("ZEPHYR_TOOLCHAIN_VARIANT", None)
+        toolchain = os.environ.get("ZEPHYR_TOOLCHAIN_VARIANT", None) or \
+                    os.environ.get("ZEPHYR_GCC_VARIANT", None)
+        if not toolchain:
+            raise SanityRuntimeError("E: Variable ZEPHYR_TOOLCHAIN_VARIANT is not defined")
+
+
         instances = []
         discards = {}
         platform_filter = options.platform

--- a/tests/subsys/fs/fcb/testcase.yaml
+++ b/tests/subsys/fs/fcb/testcase.yaml
@@ -1,5 +1,4 @@
 tests:
   test:
-    build_only: true
-    platform_whitelist: nrf52840_pca10056, nrf52_pca10040, nrf51_pca10028
+    platform_whitelist: nrf52840_pca10056 nrf52_pca10040 nrf51_pca10028
     tags: flash_circural_buffer

--- a/tests/subsys/storage/flash_map/testcase.yaml
+++ b/tests/subsys/storage/flash_map/testcase.yaml
@@ -1,5 +1,4 @@
 tests:
   test:
-    build_only: true
-    platform_whitelist: nrf52840_pca10056, nrf52_pca10040, nrf51_pca10028
+    platform_whitelist: nrf52840_pca10056 nrf52_pca10040 nrf51_pca10028
     tags: flash_map


### PR DESCRIPTION
For those still using old variable ZEPHYR_GCC_VARIANT. raise an error if
the variable is not defined.

platform_whitelist does not deal with comma separated strings. Also remove
build_only option, this should also run on those devices.