### PR TITLE
codecov: ignore ext/hal and ext/crypto

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -12,10 +12,11 @@ coverage:
     patch: yes
     changes: no
 
-#ignore:
+ignore:
 #  - "tests/**/*"
 #  - "samples/**/*"
-#  - "ext/hal/**/*"
+  - "ext/hal/**/*"
+  - "ext/crypto/**/*"
 
 parsers:
   gcov:


### PR DESCRIPTION
The coverage of those library is left to upstream. We do not use
everything they provide and we should not cover this as part of Zephyr
code coverage.

Signed-off-by: Anas Nashif <anas.nashif@intel.com>