### PR TITLE
Bluetooth: controller: Fix to use random CRC init value 

### DIFF
--- a/subsys/bluetooth/controller/ll_sw/ctrl.c
+++ b/subsys/bluetooth/controller/ll_sw/ctrl.c
@@ -10393,7 +10393,7 @@ u32_t radio_connect_enable(u8_t adv_addr_type, u8_t *adv_addr, u16_t interval,
 	conn->llcp_features = RADIO_BLE_FEAT;
 	access_addr = access_addr_get();
 	memcpy(&conn->access_addr[0], &access_addr, sizeof(conn->access_addr));
-	memcpy(&conn->crc_init[0], &conn, 3);
+	bt_rand(&conn->crc_init[0], 3);
 	memcpy(&conn->data_chan_map[0], &_radio.data_chan_map[0],
 	       sizeof(conn->data_chan_map));
 	conn->data_chan_count = _radio.data_chan_count;

--- a/subsys/bluetooth/controller/ll_sw/ctrl.c
+++ b/subsys/bluetooth/controller/ll_sw/ctrl.c
@@ -5759,20 +5759,13 @@ static u32_t access_addr_get(void)
 	u8_t transitions;
 	u8_t bit_idx;
 	u8_t retry;
-	u8_t len;
 
 	retry = 3;
 again:
 	LL_ASSERT(retry);
 	retry--;
 
-	len = sizeof(u32_t);
-	while (len) {
-		len = rand_get(len, (u8_t *)&access_addr);
-		if (len) {
-			cpu_sleep();
-		}
-	}
+	bt_rand(&access_addr, sizeof(u32_t));
 
 	bit_idx = 31;
 	transitions = 0;


### PR DESCRIPTION
Fixed controller implementation to use random CRC init value.

Fixes: #6204

Signed-off-by: Vinayak Kariappa Chettimada <vich@nordicsemi.no>