### PR TITLE
Fix net_app_ctx issues

### DIFF
--- a/subsys/net/lib/app/net_app.c
+++ b/subsys/net/lib/app/net_app.c
@@ -396,6 +396,7 @@ int _net_app_config_local_ctx(struct net_app_ctx *ctx,
 
 		if (!ret) {
 			select_default_ctx(ctx);
+			return ret;
 		}
 #endif
 


### PR DESCRIPTION
In case of TCP and node acting as a APP_SERVER it can have multiple
concurrent connections. Calling close callback when there are still
active connections exists, causing an issue.

e.g. When a node acting as a HTTP server and can support multiple
TCP connections. Let's say one of the connection is in closing
state and the rest are still in active state. net_app_ctx is
calling close (http_closed) callback of registered upper layers.
HTTP assumes all the connections are closed and unref all the
connection related stuff.

Call the close callback only when there are no active connections.

Another patch provides a fix while configuring local context when IPv6 and IPv4 both are enabled.
