### PR TITLE
samples: sockets: http_get: Include Host: header in request

### DIFF
--- a/samples/net/sockets/http_get/src/http_get.c
+++ b/samples/net/sockets/http_get/src/http_get.c
@@ -33,7 +33,7 @@
 #define SSTRLEN(s) (sizeof(s) - 1)
 #define CHECK(r) { if (r == -1) { printf("Error: " #r "\n"); } }
 
-#define REQUEST "GET " HTTP_PATH " HTTP/1.0\r\n\r\n"
+#define REQUEST "GET " HTTP_PATH " HTTP/1.0\r\nHost: " HTTP_HOST "\r\n\r\n"
 
 static char response[1024];
 


### PR DESCRIPTION
The Host header is even mandatory in HTTP 1.1, and indeed without
it, many virtual hosting setups don't work (which are many), so to
be faithful to what README says: "You can edit the source code to
issue a request to any other site on the Internet", let's
complicate the sample by including it.

Signed-off-by: Paul Sokolovsky <paul.sokolovsky@linaro.org>