### PR TITLE
Bluetooth: Mesh: Use a single transmission from Friend to LPN

### DIFF
--- a/subsys/bluetooth/host/mesh/friend.c
+++ b/subsys/bluetooth/host/mesh/friend.c
@@ -37,6 +37,12 @@
 #define FRIEND_ADV(buf)     CONTAINER_OF(BT_MESH_ADV(buf), \
 					 struct friend_adv, adv)
 
+/* PDUs from Friend to the LPN should only be transmitted once with the
+ * smallest possible interval (20ms).
+ */
+#define FRIEND_XMIT_COUNT   0
+#define FRIEND_XMIT_INT     20
+
 struct friend_pdu_info {
 	u16_t  src;
 	u16_t  dst;
@@ -83,7 +89,6 @@ static void discard_buffer(void)
 
 static struct net_buf *friend_buf_alloc(u16_t src)
 {
-	u8_t xmit = bt_mesh_net_transmit_get();
 	struct net_buf *buf;
 
 	BT_DBG("src 0x%04x", src);
@@ -91,9 +96,8 @@ static struct net_buf *friend_buf_alloc(u16_t src)
 	do {
 		buf = bt_mesh_adv_create_from_pool(&friend_buf_pool, adv_alloc,
 						   BT_MESH_ADV_DATA,
-						   BT_MESH_TRANSMIT_COUNT(xmit),
-						   BT_MESH_TRANSMIT_INT(xmit),
-						   K_NO_WAIT);
+						   FRIEND_XMIT_COUNT,
+						   FRIEND_XMIT_INT, K_NO_WAIT);
 		if (!buf) {
 			discard_buffer();
 		}


### PR DESCRIPTION
As per TSE 10009 the TS will enforce that a Friend ever only uses a
single transmission when sending packets to an LPN. Make sure that our
implementation follows this.

https://www.bluetooth.org/tse/errata_view.cfm?errata_id=10009

Signed-off-by: Johan Hedberg <johan.hedberg@intel.com>