### PR TITLE
subsys: net: http: Send "Internal Server Error" on unknown error code

### DIFF
--- a/subsys/net/lib/http/http_server.c
+++ b/subsys/net/lib/http/http_server.c
@@ -34,6 +34,8 @@
 
 #define HTTP_STATUS_400_BR	"HTTP/1.1 400 Bad Request\r\n" \
 				"\r\n"
+#define HTTP_STATUS_500_BR	"HTTP/1.1 500 Internal Server Error\r\n" \
+				"\r\n"
 
 #if defined(CONFIG_NET_DEBUG_HTTP_CONN)
 /** List of http connections */
@@ -179,6 +181,9 @@ int http_send_error(struct http_ctx *ctx, int code,
 	switch (code) {
 	case 400:
 		msg = HTTP_STATUS_400_BR;
+		break;
+	default:
+		msg = HTTP_STATUS_500_BR;
 		break;
 	}
 


### PR DESCRIPTION
Avoid using an uninitialized pointer when adding headers to the HTTP
context.

Coverity-CID: 178792
Signed-off-by: Leandro Pereira <leandro.pereira@intel.com>