### PR TITLE
samples: drivers: crypto: Print correct buffer comparison on failure

### DIFF
--- a/samples/drivers/crypto/src/main.c
+++ b/samples/drivers/crypto/src/main.c
@@ -285,7 +285,7 @@ void ctr_mode(void)
 		SYS_LOG_ERR("CTR mode DECRYPT - Mismatch between plaintext "
 			    "and decypted cipher text");
 		print_buffer_comparison(plaintext,
-					encrypt.out_buf, sizeof(plaintext));
+					decrypt.out_buf, sizeof(plaintext));
 		goto out;
 	}
 


### PR DESCRIPTION
When testing whether the CTR mode decrypted the payload properly, a
comparison of `decrypt.out_buf` with the known plain text `plaintext`
is performed, but the buffer comparison that is printed uses
`plaintext` and `encrypt.out_buf` instead.

Fixes #5531
Coverity-CID: 181847

Signed-off-by: Leandro Pereira <leandro.pereira@intel.com>