### PR TITLE
kernel: sched: Fix validation of priority levels

### DIFF
--- a/kernel/sched.c
+++ b/kernel/sched.c
@@ -302,7 +302,7 @@ _SYSCALL_HANDLER(k_thread_priority_set, thread_p, prio)
 	struct k_thread *thread = (struct k_thread *)thread_p;
 
 	_SYSCALL_OBJ(thread, K_OBJ_THREAD);
-	_SYSCALL_VERIFY_MSG(_VALID_PRIO(prio, NULL),
+	_SYSCALL_VERIFY_MSG(_is_valid_prio(prio, NULL),
 			    "invalid thread priority %d", (int)prio);
 	_SYSCALL_VERIFY_MSG((s8_t)prio >= thread->base.prio,
 			    "thread priority may only be downgraded (%d < %d)",

--- a/kernel/thread.c
+++ b/kernel/thread.c
@@ -405,7 +405,7 @@ _SYSCALL_HANDLER(k_thread_create,
 	/* Check validity of prio argument; must be the same or worse priority
 	 * than the caller
 	 */
-	_SYSCALL_VERIFY(_VALID_PRIO(prio, NULL));
+	_SYSCALL_VERIFY(_is_valid_prio(prio, NULL));
 	_SYSCALL_VERIFY(_is_prio_lower_or_equal(prio, _current->base.prio));
 
 	_setup_new_thread((struct k_thread *)new_thread, stack, stack_size,


### PR DESCRIPTION
A priority value cannot be simultaneously higher than the maximum
possible value and smaller than the minimum value.  Rewrite the
_VALID_PRIO() macro as a function so that this if either of these
invariants are invalid, the priority is considered invalid.

Coverity-CID: 182584
Coverity-CID: 182585
Signed-off-by: Leandro Pereira <leandro.pereira@intel.com>