### PR TITLE
drivers: system_apic: Correctly assert interrupt line number

### DIFF
--- a/drivers/interrupt_controller/system_apic.c
+++ b/drivers/interrupt_controller/system_apic.c
@@ -47,7 +47,7 @@
 void __irq_controller_irq_config(unsigned int vector, unsigned int irq,
 				 u32_t flags)
 {
-	__ASSERT(irq >= 0 && irq <= HARDWARE_IRQ_LIMIT, "invalid irq line");
+	__ASSERT(irq <= HARDWARE_IRQ_LIMIT, "invalid irq line");
 
 	if (IS_IOAPIC_IRQ(irq)) {
 		_ioapic_irq_set(irq, vector, flags);


### PR DESCRIPTION
The interrupt line number is an unsigned integer; it makes no sense to
compare if it is greater than or equal to 0.

Fixes #5886
Coverity-CID: 182602
Signed-off-by: Leandro Pereira <leandro.pereira@intel.com>