### PR TITLE
dts/arm/st: Fix SPI1 interrupt priority for STM32F0

### DIFF
--- a/dts/arm/st/stm32f0.dtsi
+++ b/dts/arm/st/stm32f0.dtsi
@@ -109,7 +109,7 @@
 			#address-cells = <1>;
 			#size-cells = <0>;
 			reg = <0x40013000 0x400>;
-			interrupts = <25 5>;
+			interrupts = <25 3>;
 			status = "disabled";
 			label = "SPI_1";
 		};


### PR DESCRIPTION
STM32F0 family has only 2 interrupt priority bits.

Fixes #6238

Signed-off-by: Yannis Damigos <giannis.damigos@gmail.com>