### PR TITLE
[RFC][DNM]samples: bluetooth: nRF51: peripheral with battery level

### DIFF
--- a/samples/bluetooth/gatt/bas.c
+++ b/samples/bluetooth/gatt/bas.c
@@ -22,14 +22,19 @@
 #include <bluetooth/uuid.h>
 #include <bluetooth/gatt.h>
 
+#if defined(CONFIG_SOC_SERIES_NRF51X)
+#include <soc.h>
+#include "bat.h"
+#endif
+
 static struct bt_gatt_ccc_cfg  blvl_ccc_cfg[BT_GATT_CCC_MAX] = {};
-static u8_t simulate_blvl;
+static u8_t is_notify_enabled;
 static u8_t battery = 100;
 
 static void blvl_ccc_cfg_changed(const struct bt_gatt_attr *attr,
 				 u16_t value)
 {
-	simulate_blvl = (value == BT_GATT_CCC_NOTIFY) ? 1 : 0;
+	is_notify_enabled = (value == BT_GATT_CCC_NOTIFY) ? 1 : 0;
 }
 
 static ssize_t read_blvl(struct bt_conn *conn, const struct bt_gatt_attr *attr,
@@ -39,6 +44,13 @@ static ssize_t read_blvl(struct bt_conn *conn, const struct bt_gatt_attr *attr,
 
 	return bt_gatt_attr_read(conn, attr, buf, len, offset, value,
 				 sizeof(*value));
+}
+
+static void isr_nrf51_adc(void *arg)
+{
+	extern void C_ADC_IRQHandler(void);
+
+	C_ADC_IRQHandler();
 }
 
 /* Battery Service Declaration */
@@ -56,19 +68,31 @@ static struct bt_gatt_service bas_svc = BT_GATT_SERVICE(attrs);
 void bas_init(void)
 {
 	bt_gatt_service_register(&bas_svc);
+
+#if defined(CONFIG_SOC_SERIES_NRF51X)
+	IRQ_CONNECT(NRF5_IRQ_ADC_IRQn, 1, isr_nrf51_adc, NULL, 0);
+	bat_acquire();
+#endif
 }
 
 void bas_notify(void)
 {
-	if (!simulate_blvl) {
+	if (!is_notify_enabled) {
 		return;
 	}
 
+#if defined(CONFIG_SOC_SERIES_NRF51X)
+	/* TODO: Notify on fresh sample.*/
+	/* NOTE: Below implementation acquires previous captured levels */
+	battery = bat_level_get(BAT_LEVELS_CR2023, c_bat_levels_cr2032);
+	bat_acquire();
+#else
 	battery--;
 	if (!battery) {
 		/* Software eco battery charger */
 		battery = 100;
 	}
+#endif
 
 	bt_gatt_notify(NULL, &attrs[2], &battery, sizeof(battery));
 }

--- a/samples/bluetooth/gatt/bat.c
+++ b/samples/bluetooth/gatt/bat.c
@@ -1,0 +1,92 @@
+/*
+Copyright (c) 2012, Vinayak Kariappa Chettimada
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in the documentation and/or other materials provided with the distribution.
+
+3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote products derived from this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*/
+#include "nrf.h"
+
+#include "bat.h"
+
+#ifdef NRF51
+
+#define BAT_VBG         (1200)
+#define BAT_PRESCALER   (3)
+#define BAT_DIODE_DROP  (270)
+
+const uint16_t c_bat_levels_cr2032[BAT_LEVELS_CR2023] = {2800, 2700, 2600, 2500};
+static volatile uint32_t gs_result;
+
+void bat_acquire(void)
+{
+  NRF_ADC->CONFIG = (ADC_CONFIG_RES_8bit                        << ADC_CONFIG_RES_Pos)
+                    | (ADC_CONFIG_INPSEL_SupplyOneThirdPrescaling << ADC_CONFIG_INPSEL_Pos)
+                    | (ADC_CONFIG_REFSEL_VBG                      << ADC_CONFIG_REFSEL_Pos)
+                    | (ADC_CONFIG_PSEL_Disabled                   << ADC_CONFIG_PSEL_Pos)
+                    | (ADC_CONFIG_EXTREFSEL_None                  << ADC_CONFIG_EXTREFSEL_Pos);
+
+  NRF_ADC->ENABLE = 1;
+
+  NRF_ADC->INTENSET = ADC_INTENSET_END_Msk;
+
+  NVIC_SetPriority(ADC_IRQn, 3);
+  NVIC_EnableIRQ(ADC_IRQn);
+
+  NRF_ADC->EVENTS_END = 0;
+  NRF_ADC->TASKS_START = 1;
+}
+
+uint32_t bat_get(void)
+{
+  /** @todo may be use NRF_ADC->BUSY? */
+
+  return (((gs_result * BAT_VBG * BAT_PRESCALER) >> 8) + BAT_DIODE_DROP);
+}
+
+uint8_t bat_level_get(uint8_t levels, uint16_t const * const p_levels)
+{
+  uint8_t index;
+  uint16_t mv;
+
+  mv = bat_get();
+
+  index = levels;
+  while (index)
+  {
+    index--;
+    if (mv < p_levels[index])
+    {
+      index++;
+      break;
+    }
+  }
+
+  return(100 - (index * (100 / (levels + 1))));
+}
+
+void C_ADC_IRQHandler(void)
+{
+  if (NRF_ADC->EVENTS_END != 0)
+  {
+    NRF_ADC->EVENTS_END = 0;
+
+    gs_result = NRF_ADC->RESULT;
+
+    NRF_ADC->TASKS_STOP = 1;
+    NRF_ADC->ENABLE = 0;
+
+    //NVIC_DisableIRQ(ADC_IRQn);
+    //NRF_ADC->INTENCLR = ADC_INTENSET_END_Msk;
+  }
+}
+
+#endif
+

--- a/samples/bluetooth/gatt/bat.h
+++ b/samples/bluetooth/gatt/bat.h
@@ -1,0 +1,26 @@
+/*
+Copyright (c) 2012, Vinayak Kariappa Chettimada
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in the documentation and/or other materials provided with the distribution.
+
+3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote products derived from this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*/
+#ifndef _BAT_H_
+#define _BAT_H_
+
+#define BAT_LEVELS_CR2023 (4)
+
+void bat_acquire(void);
+uint32_t bat_get(void);
+uint8_t bat_level_get(uint8_t levels, uint16_t const * const p_levels);
+
+extern const uint16_t c_bat_levels_cr2032[BAT_LEVELS_CR2023];
+
+#endif /* _BAT_H_ */

--- a/samples/bluetooth/peripheral/CMakeLists.txt
+++ b/samples/bluetooth/peripheral/CMakeLists.txt
@@ -9,4 +9,11 @@ target_sources(app PRIVATE
   src/cts.c
 )
 
+target_sources_ifdef(
+  CONFIG_SOC_SERIES_NRF51X
+  app
+  PRIVATE
+  ../gatt/bat.c
+  )
+
 zephyr_library_include_directories($ENV{ZEPHYR_BASE}/samples/bluetooth)


### PR DESCRIPTION
This is only for RFC and inspirational purposes only. The PR
will be closed soon thereafter.

Illustrates use of nRF51 ADC to acquire internal battery
voltage when supplied by a coin cell.

nRF51 Product specification can be referenced to adapt the
ADC peripheral usage for analog signal acquisitions as
needed.

NOTE: included code would not pass checkpatch! and author
intends to not fix it due to the reasons mentioned above.

Signed-off-by: Vinayak Kariappa Chettimada <vich@nordicsemi.no>