### PR TITLE
drivers: gpio: Nios-II: Fix condition on gpio_nios2_config_oput_port()

### DIFF
--- a/drivers/gpio/gpio_altera_nios2.c
+++ b/drivers/gpio/gpio_altera_nios2.c
@@ -30,7 +30,7 @@ struct gpio_nios2_config {
 static int gpio_nios2_config_oput_port(struct device *dev, int access_op,
 				       u32_t pin, int flags)
 {
-	if ((flags & GPIO_DIR_IN) || (flags & GPIO_INT)) {
+	if (((flags & GPIO_DIR_MASK) == GPIO_DIR_IN) || (flags & GPIO_INT)) {
 		return -ENOTSUP;
 	}
 


### PR DESCRIPTION
(flags & GPIO_DIR_IN) is always zero because GPIO_DIR_IN is 0, then
we have to use GPIO_DIR_MASK.

Signed-off-by: Vitor Massaru Iha <vitor@massaru.org>