### PR TITLE
sanitycheck: device handler, allow running tests on real hw

### DIFF
--- a/.shippable.yml
+++ b/.shippable.yml
@@ -36,7 +36,6 @@ build:
         fi
       - source zephyr-env.sh
       - ccache -c -s --max-size=2000M
-      - pip3 install --user pyserial
       - >
           if [ "$MATRIX_BUILD" = "5" -a "$IS_PULL_REQUEST" = "true" ]; then
             export COMMIT_RANGE=origin/${PULL_REQUEST_BASE_BRANCH}..HEAD

--- a/.shippable.yml
+++ b/.shippable.yml
@@ -36,6 +36,7 @@ build:
         fi
       - source zephyr-env.sh
       - ccache -c -s --max-size=2000M
+      - pip3 install --user pyserial
       - >
           if [ "$MATRIX_BUILD" = "5" -a "$IS_PULL_REQUEST" = "true" ]; then
             export COMMIT_RANGE=origin/${PULL_REQUEST_BASE_BRANCH}..HEAD

--- a/scripts/requirements.txt
+++ b/scripts/requirements.txt
@@ -9,6 +9,7 @@ ply==3.10
 hub==2.0
 gitlint
 pyelftools==0.24
+pyserial
 pykwalify
 # "win32" is used for 64-bit Windows as well
 windows-curses; sys_platform == "win32"

--- a/scripts/sanity_chk/harness.py
+++ b/scripts/sanity_chk/harness.py
@@ -54,7 +54,7 @@ class Test(Harness):
     RUN_FAILED = "PROJECT EXECUTION FAILED"
 
     def handle(self, line):
-        result = re.compile("(PASS|FAIL) - test_(.*).")
+        result = re.compile("(PASS|FAIL) - test_(.*)")
         match = result.match(line)
         if match:
             self.tests[match.group(2)] = match.group(1)

--- a/scripts/sanity_chk/harness.py
+++ b/scripts/sanity_chk/harness.py
@@ -10,9 +10,11 @@ class Harness:
         self.ordered = True
         self.repeat = 1
         self.tests = {}
+        self.id = None
 
     def configure(self, instance):
         config = instance.test.harness_config
+        self.id = instance.test.id
         if config:
             self.type = config.get('type', None)
             self.regex = config.get('regex', [] )
@@ -54,10 +56,11 @@ class Test(Harness):
     RUN_FAILED = "PROJECT EXECUTION FAILED"
 
     def handle(self, line):
-        result = re.compile("(PASS|FAIL) - test_(.*)")
+        result = re.compile("(PASS|FAIL|SKIP) - (test_)?(.*)")
         match = result.match(line)
         if match:
-            self.tests[match.group(2)] = match.group(1)
+            name = "{}.{}".format(self.id, match.group(3))
+            self.tests[name] = match.group(1)
 
         if self.RUN_PASSED in line:
             self.state = "passed"

--- a/scripts/sanity_chk/harness.py
+++ b/scripts/sanity_chk/harness.py
@@ -9,6 +9,7 @@ class Harness:
         self.matches = OrderedDict()
         self.ordered = True
         self.repeat = 1
+        self.tests = {}
 
     def configure(self, instance):
         config = instance.test.harness_config
@@ -48,13 +49,16 @@ class Console(Harness):
                 else:
                     self.state = "failed"
 
-
-
 class Test(Harness):
     RUN_PASSED = "PROJECT EXECUTION SUCCESSFUL"
     RUN_FAILED = "PROJECT EXECUTION FAILED"
 
     def handle(self, line):
+        result = re.compile("(PASS|FAIL) - test_(.*).")
+        match = result.match(line)
+        if match:
+            self.tests[match.group(2)] = match.group(1)
+
         if self.RUN_PASSED in line:
             self.state = "passed"
 

--- a/scripts/sanitycheck
+++ b/scripts/sanitycheck
@@ -342,7 +342,11 @@ class DeviceHandler(Handler):
         log_out_fp = open(self.handler_log, "wt")
 
         while ser.isOpen():
-            serial_line = ser.readline()
+            try:
+                serial_line = ser.readline()
+            except TypeError:
+                pass
+
             if serial_line:
                 sl = serial_line.decode('utf-8', 'ignore')
                 verbose("DEVICE: {0}".format(sl.rstrip()))
@@ -386,7 +390,10 @@ class DeviceHandler(Handler):
         t = threading.Thread(target=self.monitor_serial, args=(ser, harness))
         t.start()
 
-        subprocess.check_output(command, stderr=subprocess.PIPE)
+        try:
+            subprocess.check_output(command, stderr=subprocess.PIPE)
+        except subprocess.CalledProcessError:
+            pass
 
         t.join(self.timeout)
         if t.is_alive():
@@ -400,9 +407,8 @@ class DeviceHandler(Handler):
             for c in self.instance.test.cases:
                 if c not in harness.tests:
                     harness.tests[c] = "BLOCK"
-            self.instance.results = harness.tests
-        else:
-            self.instance.results = harness.tests
+
+        self.instance.results = harness.tests
 
         if harness.state:
             self.set_state(harness.state, {})
@@ -1666,6 +1672,7 @@ class TestSuite:
                     filename = 'testcase.yaml'
                 else:
                     continue
+
                 verbose("Found possible test case in " + dirpath)
                 dirnames[:] = []
                 yaml_path = os.path.join(dirpath, filename)
@@ -2155,26 +2162,27 @@ class TestSuite:
                     passes += 1
                 elif ti.results[k] == 'BLOCK':
                     errors += 1
+                elif ti.results[k] == 'SKIP':
+                    skips += 1
                 else:
                     fails += 1
-
 
         eleTestsuites = ET.Element('testsuites')
         eleTestsuite = ET.SubElement(eleTestsuites, 'testsuite',
                                      name=run, time="%d" % duration,
                                      tests="%d" % (errors + passes + fails),
                                      failures="%d" % fails,
-                                     errors="%d" % errors, skip="%d" %skips)
+                                     errors="%d" % errors, skipped="%d" %skips)
 
         handler_time = "0"
+
         # print out test results
         for identifier, ti in self.instances.items():
             for k in ti.results.keys():
-                tname = os.path.basename(ti.test.name)  + "." + k
 
                 eleTestcase = ET.SubElement(
                         eleTestsuite, 'testcase', classname="%s:%s" %(ti.platform.name, os.path.basename(ti.test.name)),
-                        name="%s" % (tname), time=handler_time)
+                        name="%s" % (k), time=handler_time)
                 if ti.results[k] in ['FAIL', 'BLOCK']:
                     el = None
 
@@ -2197,6 +2205,11 @@ class TestSuite:
                         with open(bl, "rb") as f:
                             log = f.read().decode("utf-8")
                             el.text = self.encode_for_xml(log)
+
+                elif ti.results[k] == 'SKIP':
+                    el = ET.SubElement(
+                        eleTestcase,
+                        'skipped')
 
         result = ET.tostring(eleTestsuites)
         f = open(report_file, 'wb')

--- a/scripts/sanitycheck
+++ b/scripts/sanitycheck
@@ -173,6 +173,7 @@ import threading
 import time
 import csv
 import glob
+import serial
 import concurrent
 import concurrent.futures
 import xml.etree.ElementTree as ET
@@ -317,6 +318,86 @@ class Handler:
         ret = (self.state, self.metrics)
         self.lock.release()
         return ret
+
+
+class DeviceHandler(Handler):
+
+    def __init__(self, instance):
+        """Constructor
+
+        @param instance Test Instance
+        """
+        super().__init__(instance)
+
+        self.instance = instance
+        self.timeout = instance.test.timeout
+        self.sourcedir = instance.test.code_location
+        self.outdir = instance.outdir
+        self.run_log = os.path.join(self.outdir, "run.log")
+        self.handler_log = os.path.join(self.outdir, "handler.log")
+        self.returncode = 0
+        self.set_state("running", {})
+
+    def monitor_serial(self, ser, harness):
+        log_out_fp = open(self.handler_log, "wt")
+
+        while ser.isOpen():
+            serial_line = ser.readline().decode('utf-8', 'ignore')
+            if serial_line:
+                verbose("DEVICE: {0}".format(serial_line.rstrip()))
+            log_out_fp.write(serial_line)
+            log_out_fp.flush()
+            harness.handle(serial_line.rstrip())
+            if harness.state:
+                ser.close()
+                break
+
+        log_out_fp.close()
+
+    def handle(self):
+        out_state = "failed"
+
+        device = options.device_serial
+        ser = serial.Serial(
+                device,
+                baudrate=115200,
+                parity=serial.PARITY_NONE,
+                stopbits=serial.STOPBITS_ONE,
+                bytesize=serial.EIGHTBITS,
+                timeout=self.timeout
+                )
+
+        ser.flush()
+
+        harness_name = self.instance.test.harness.capitalize()
+        harness_import = HarnessImporter(harness_name)
+        harness = harness_import.instance
+        harness.configure(self.instance)
+
+        t = threading.Thread(target=self.monitor_serial, args=(ser, harness))
+        t.start()
+
+        if options.ninja:
+            generator_cmd = "ninja"
+        else:
+            generator_cmd = "make"
+
+        command = [generator_cmd, "-C", self.outdir, "flash"]
+
+        subprocess.check_output(command, stderr=subprocess.PIPE)
+
+        t.join(self.timeout)
+        if t.is_alive():
+            out_state = "timeout"
+            ser.close()
+
+        if ser.isOpen():
+            ser.close()
+
+        if harness.state:
+            self.set_state(harness.state, {})
+        else:
+            self.set_state(out_state, {})
 
 class NativeHandler(Handler):
     def __init__(self, instance):
@@ -1002,6 +1083,27 @@ class MakeGenerator:
         self.goals[name] = MakeGoal(name, text, native_handler, self.logfile, build_logfile,
                                     run_logfile, handler_logfile)
 
+    def add_device_goal(self, instance, args):
+
+        outdir = instance.outdir
+        timeout = instance.test.timeout
+        name = instance.name
+        directory = instance.test.code_location
+
+        self._add_goal(outdir)
+        build_logfile = os.path.join(outdir, "build.log")
+        run_logfile = os.path.join(outdir, "run.log")
+        handler_logfile = os.path.join(outdir, "handler.log")
+
+        # we handle running in the NativeHandler class
+        text = (self._get_rule_header(name) +
+                self._get_sub_make(name, "building", directory,
+                                   outdir, build_logfile, args) +
+                self._get_rule_footer(name))
+        handler = DeviceHandler(instance)
+        self.goals[name] = MakeGoal(name, text, handler, self.logfile, build_logfile,
+                                    run_logfile, handler_logfile)
+
     def add_test_instance(self, ti, build_only=False, enable_slow=False, coverage=False,
                           extra_args=[]):
         """Add a goal to build/test a TestInstance object
@@ -1030,6 +1132,8 @@ class MakeGenerator:
 
         elif ti.platform.type == "native" and do_run:
             self.add_native_goal(ti, args, coverage)
+        elif options.device_testing and (not ti.build_only) and (not build_only):
+            self.add_device_goal(ti, args)
         else:
             self.add_instance_build_goal(ti, args, "build.log")
 
@@ -2281,6 +2385,14 @@ def parse_arguments():
         "-j", "--jobs", type=int,
         help="Number of cores to use when building, defaults to "
         "number of CPUs * 2")
+
+    parser.add_argument(
+        "--device-testing", action="store_true",
+        help="Test on device directly. You need to specify the serial"
+			 "using --device-serial option")
+    parser.add_argument(
+        "--device-serial",
+		help="Serial device the board can be accessed through")
     parser.add_argument(
             "--show-footprint", action="store_true",
             help="Show footprint statistics and deltas since last release."
@@ -2489,6 +2601,11 @@ def main():
         for fn in options.size:
             size_report(SizeCalculator(fn, []))
         sys.exit(0)
+
+
+    if options.device_testing:
+        if options.device_serial is None or len(options.platform) != 1:
+            sys.exit(1)
 
     VERBOSE += options.verbose
     INLINE_LOGS = options.inline_logs

--- a/scripts/sanitycheck
+++ b/scripts/sanitycheck
@@ -866,7 +866,7 @@ class MakeGenerator:
     re_make = re.compile(
         "sanity_test_([A-Za-z0-9]+) (.+)|$|make[:] \*\*\* \[(.+:.+: )?(.+)\] Error.+$")
 
-    def __init__(self, base_outdir, asserts=False, deprecations=False):
+    def __init__(self, base_outdir):
         """MakeGenerator constructor
 
         @param base_outdir Intended to be the base out directory. A make.log
@@ -880,8 +880,8 @@ class MakeGenerator:
             os.makedirs(base_outdir)
         self.logfile = os.path.join(base_outdir, "make.log")
         self.makefile = os.path.join(base_outdir, "Makefile")
-        self.asserts = asserts
-        self.deprecations = deprecations
+        self.asserts = options.enable_asserts
+        self.deprecations = options.error_on_deprecations
 
     def _get_rule_header(self, name):
         return MakeGenerator.GOAL_HEADER_TMPL.format(goal=name)
@@ -1028,7 +1028,7 @@ class MakeGenerator:
         self.goals[name] = MakeGoal(name, text, qemu_handler, self.logfile, build_logfile,
                                     run_logfile, handler_logfile)
 
-    def add_unit_goal(self, instance, args, timeout=30, coverage=False):
+    def add_unit_goal(self, instance, args, timeout=30):
         outdir = instance.outdir
         timeout = instance.test.timeout
         name = instance.name
@@ -1050,7 +1050,7 @@ class MakeGenerator:
         self.goals[name] = MakeGoal(name, text, unit_handler, self.logfile, build_logfile,
                                     run_logfile, handler_logfile)
 
-    def add_native_goal(self, instance, args, coverage=False):
+    def add_native_goal(self, instance, args):
 
         outdir = instance.outdir
         timeout = instance.test.timeout
@@ -1092,8 +1092,7 @@ class MakeGenerator:
         self.goals[name] = MakeGoal(name, text, handler, self.logfile, build_logfile,
                                     run_logfile, handler_logfile)
 
-    def add_test_instance(self, ti, build_only=False, enable_slow=False, coverage=False,
-                          extra_args=[]):
+    def add_test_instance(self, ti, extra_args=[]):
         """Add a goal to build/test a TestInstance object
 
         @param ti TestInstance object to build. The status dictionary returned
@@ -1107,21 +1106,22 @@ class MakeGenerator:
         args.append("BOARD={}".format(ti.platform.name))
         args.extend(extra_args)
 
-        do_run_slow = enable_slow or not ti.test.slow
-        do_build_only = ti.build_only or build_only
+        do_run_slow = options.enable_slow or not ti.test.slow
+        do_build_only = ti.build_only or options.build_only
         do_run = (not do_build_only) and do_run_slow
-
 
         if ti.platform.qemu_support and do_run:
             self.add_qemu_goal(ti, args)
 
         elif ti.test.type == "unit":
-            self.add_unit_goal(ti, args, coverage)
+            self.add_unit_goal(ti, args)
 
         elif ti.platform.type == "native" and do_run:
-            self.add_native_goal(ti, args, coverage)
-        elif options.device_testing and (not ti.build_only) and (not build_only):
+            self.add_native_goal(ti, args)
+
+        elif options.device_testing and (not ti.build_only) and (not options.build_only):
             self.add_device_goal(ti, args)
+
         else:
             self.add_instance_build_goal(ti, args, "build.log")
 
@@ -1581,13 +1581,12 @@ class TestInstance:
         out directory used is <outdir>/<platform>/<test case name>
     """
 
-    def __init__(self, test, platform, base_outdir, build_only=False,
-                 slow=False, coverage=False):
+    def __init__(self, test, platform, base_outdir):
         self.test = test
         self.platform = platform
         self.name = os.path.join(platform.name, test.name)
         self.outdir = os.path.join(base_outdir, platform.name, test.path)
-        self.build_only = build_only or test.build_only or (test.harness and test.harness != 'console')
+        self.build_only = options.build_only or test.build_only or (test.harness and test.harness != 'console')
         self.results = {}
 
     def create_overlay(self):
@@ -1642,7 +1641,7 @@ class TestSuite:
         os.path.join(os.environ['ZEPHYR_BASE'],
                      "scripts", "sanity_chk", "sanitycheck-tc-schema.yaml"))
 
-    def __init__(self, board_root_list, testcase_roots, outdir, coverage):
+    def __init__(self, board_root_list, testcase_roots, outdir):
         # Keep track of which test cases we've filtered out and why
         self.arches = {}
         self.testcases = {}
@@ -1651,7 +1650,6 @@ class TestSuite:
         self.instances = {}
         self.goals = None
         self.discards = None
-        self.coverage = coverage
         self.load_errors = 0
 
         for testcase_root in testcase_roots:
@@ -2042,8 +2040,7 @@ class TestSuite:
         for ti in ti_list:
             self.instances[ti.name] = ti
 
-    def execute(self, cb, cb_context, build_only, enable_slow,
-                enable_asserts, enable_deprecations, extra_args):
+    def execute(self, cb, cb_context):
 
         def calc_one_elf_size(name, goal):
             if not goal.failed:
@@ -2053,11 +2050,9 @@ class TestSuite:
                 goal.metrics["rom_size"] = sc.get_rom_size()
                 goal.metrics["unrecognized"] = sc.unrecognized_sections()
 
-        mg = MakeGenerator(self.outdir, asserts=enable_asserts,
-                           deprecations=enable_deprecations)
+        mg = MakeGenerator(self.outdir)
         for i in self.instances.values():
-            mg.add_test_instance(i, build_only, enable_slow,
-                                 self.coverage, extra_args)
+            mg.add_test_instance(i, options.extra_args)
         self.goals = mg.execute(cb, cb_context)
 
         # Parallelize size calculation
@@ -2697,8 +2692,7 @@ def main():
         options.testcase_root = [os.path.join(ZEPHYR_BASE, "tests"),
                               os.path.join(ZEPHYR_BASE, "samples")]
 
-    ts = TestSuite(options.board_root, options.testcase_root,
-                   options.outdir, options.coverage)
+    ts = TestSuite(options.board_root, options.testcase_root, options.outdir)
 
     if ts.load_errors:
         sys.exit(1)
@@ -2787,21 +2781,11 @@ def main():
     if VERBOSE or not TERMINAL:
         goals = ts.execute(
             chatty_test_cb,
-            ts.instances,
-            options.build_only,
-            options.enable_slow,
-            options.enable_asserts,
-            options.error_on_deprecations,
-            options.extra_args)
+            ts.instances)
     else:
         goals = ts.execute(
             terse_test_cb,
-            ts.instances,
-            options.build_only,
-            options.enable_slow,
-            options.enable_asserts,
-            options.error_on_deprecations,
-            options.extra_args)
+            ts.instances)
         info("")
 
     if options.detailed_report:

--- a/scripts/sanitycheck
+++ b/scripts/sanitycheck
@@ -394,6 +394,8 @@ class DeviceHandler(Handler):
         if ser.isOpen():
             ser.close()
 
+        self.instance.results = harness.tests
+
         if harness.state:
             self.set_state(harness.state, {})
         else:
@@ -460,6 +462,8 @@ class NativeHandler(Handler):
 
         returncode = subprocess.call(["GCOV_PREFIX=" + self.outdir, "gcov", self.sourcedir, "-b", "-s", self.outdir], shell=True)
 
+
+        self.instance.results = harness.tests
         if harness.state:
             self.set_state(harness.state, {})
         else:
@@ -619,6 +623,7 @@ class QEMUHandler(Handler):
 
 
         super().__init__(instance)
+        self.instance = instance
         outdir = instance.outdir
         timeout = instance.test.timeout
         name = instance.name
@@ -644,6 +649,8 @@ class QEMUHandler(Handler):
                                        args=(self, timeout, outdir,
                                              self.log_fn, self.fifo_fn,
                                              self.pid_fn, self.results, harness))
+
+        self.instance.results = harness.tests
         self.thread.daemon = True
         verbose("Spawning QEMU process for %s" % name)
         self.thread.start()
@@ -1600,6 +1607,7 @@ class TestInstance:
         self.name = os.path.join(platform.name, test.name)
         self.outdir = os.path.join(base_outdir, platform.name, test.path)
         self.build_only = build_only or test.build_only or (test.harness and test.harness != 'console')
+        self.results = {}
 
     def create_overlay(self):
         if len(self.test.extra_configs) > 0:
@@ -2147,6 +2155,79 @@ class TestSuite:
                                 lower_better))
         return results
 
+
+
+    def encode_for_xml(self, unicode_data, encoding='ascii'):
+        unicode_data = unicode_data.replace('\x00', '')
+        return unicode_data
+
+    def testcase_target_report(self, report_file):
+
+        run = "Sanitycheck"
+        eleTestsuite = None
+        append = options.only_failed
+
+        errors = 0
+        passes = 0
+        fails = 0
+        duration = 0
+        skips = 0
+
+        for identifier, ti in self.instances.items():
+            for k in ti.results.keys():
+                if ti.results[k] == 'PASS':
+                    passes += 1
+                elif ti.results[k] == 'BLOCK':
+                    errors += 1
+                else:
+                    fails += 1
+
+
+        eleTestsuites = ET.Element('testsuites')
+        eleTestsuite = ET.SubElement(eleTestsuites, 'testsuite',
+                                     name=run, time="%d" % duration,
+                                     tests="%d" % (errors + passes + fails),
+                                     failures="%d" % fails,
+                                     errors="%d" % errors, skip="%d" %skips)
+
+        handler_time = "0"
+        # print out test results
+        for identifier, ti in self.instances.items():
+            for k in ti.results.keys():
+                tname = os.path.basename(ti.test.name)  + "." + k
+
+                eleTestcase = ET.SubElement(
+                        eleTestsuite, 'testcase', classname="%s:%s" %(ti.platform.name, os.path.basename(ti.test.name)),
+                        name="%s" % (tname), time=handler_time)
+                if ti.results[k] in ['FAIL', 'BLOCK']:
+                    el = None
+
+                    if ti.results[k] == 'FAIL':
+                        el = ET.SubElement(
+                            eleTestcase,
+                            'failure',
+                            type="failure",
+                            message="failed")
+                    elif ti.results[k] == 'BLOCK':
+                        el = ET.SubElement(
+                            eleTestcase,
+                            'error',
+                            type="failure",
+                            message="failed")
+                    p = os.path.join(options.outdir, ti.platform.name, ti.test.name)
+                    bl = os.path.join(p, "handler.log")
+
+                    if os.path.exists(bl):
+                        with open(bl, "rb") as f:
+                            log = f.read().decode("utf-8")
+                            el.text = self.encode_for_xml(log)
+
+        result = ET.tostring(eleTestsuites)
+        f = open(report_file, 'wb')
+        f.write(result)
+        f.close()
+
+
     def testcase_xunit_report(self, filename, duration):
         if self.goals is None:
             raise SanityRuntimeError("execute() hasn't been run!")
@@ -2331,6 +2412,11 @@ def parse_arguments():
 
     parser.add_argument("--list-tests", action="store_true",
             help="list all tests.")
+
+    parser.add_argument("--detailed-report",
+            action="store",
+            metavar="FILENAME",
+            help="Generate a junit report with detailed testcase results.")
 
     parser.add_argument(
         "-r", "--release", action="store_true",
@@ -2736,6 +2822,9 @@ def main():
             options.error_on_deprecations,
             options.extra_args)
         info("")
+
+    if options.detailed_report:
+        ts.testcase_target_report(options.detailed_report)
 
     # figure out which report to use for size comparison
     if options.compare_report:

--- a/scripts/sanitycheck
+++ b/scripts/sanitycheck
@@ -2709,11 +2709,14 @@ def main():
 
     if options.list_tests:
         cnt = 0
+        unq = []
         for n,tc in ts.testcases.items():
             for c in tc.cases:
-                cnt = cnt + 1
-                print(" - {}".format(c))
+                unq.append(c)
 
+        for u in sorted(set(unq)):
+            cnt = cnt + 1
+            print(" - {}".format(u))
         print("{} total.".format(cnt))
         return
 

--- a/scripts/sanitycheck
+++ b/scripts/sanitycheck
@@ -307,6 +307,15 @@ class Handler:
         self.metrics["ram_size"] = 0
         self.metrics["rom_size"] = 0
 
+        self.name = instance.name
+        self.instance = instance
+        self.timeout = instance.test.timeout
+        self.sourcedir = instance.test.code_location
+        self.outdir = instance.outdir
+        self.handler_log = os.path.join(self.outdir, "handler.log")
+        self.returncode = 0
+        self.set_state("running", {})
+
     def set_state(self, state, metrics):
         self.lock.acquire()
         self.state = state
@@ -329,25 +338,18 @@ class DeviceHandler(Handler):
         """
         super().__init__(instance)
 
-        self.instance = instance
-        self.timeout = instance.test.timeout
-        self.sourcedir = instance.test.code_location
-        self.outdir = instance.outdir
-        self.run_log = os.path.join(self.outdir, "run.log")
-        self.handler_log = os.path.join(self.outdir, "handler.log")
-        self.returncode = 0
-        self.set_state("running", {})
-
     def monitor_serial(self, ser, harness):
         log_out_fp = open(self.handler_log, "wt")
 
         while ser.isOpen():
-            serial_line = ser.readline().decode('utf-8', 'ignore')
+            serial_line = ser.readline()
             if serial_line:
-                verbose("DEVICE: {0}".format(serial_line.rstrip()))
-            log_out_fp.write(serial_line)
-            log_out_fp.flush()
-            harness.handle(serial_line.rstrip())
+                sl = serial_line.decode('utf-8', 'ignore')
+                verbose("DEVICE: {0}".format(sl.rstrip()))
+
+                log_out_fp.write(sl)
+                log_out_fp.flush()
+                harness.handle(sl.rstrip())
             if harness.state:
                 ser.close()
                 break
@@ -356,6 +358,13 @@ class DeviceHandler(Handler):
 
     def handle(self):
         out_state = "failed"
+
+        if options.ninja:
+            generator_cmd = "ninja"
+        else:
+            generator_cmd = "make"
+
+        command = [generator_cmd, "-C", self.outdir, "flash"]
 
         device = options.device_serial
         ser = serial.Serial(
@@ -377,13 +386,6 @@ class DeviceHandler(Handler):
         t = threading.Thread(target=self.monitor_serial, args=(ser, harness))
         t.start()
 
-        if options.ninja:
-            generator_cmd = "ninja"
-        else:
-            generator_cmd = "make"
-
-        command = [generator_cmd, "-C", self.outdir, "flash"]
-
         subprocess.check_output(command, stderr=subprocess.PIPE)
 
         t.join(self.timeout)
@@ -394,7 +396,13 @@ class DeviceHandler(Handler):
         if ser.isOpen():
             ser.close()
 
-        self.instance.results = harness.tests
+        if out_state == "timeout":
+            for c in self.instance.test.cases:
+                if c not in harness.tests:
+                    harness.tests[c] = "BLOCK"
+            self.instance.results = harness.tests
+        else:
+            self.instance.results = harness.tests
 
         if harness.state:
             self.set_state(harness.state, {})
@@ -409,15 +417,7 @@ class NativeHandler(Handler):
         """
         super().__init__(instance)
 
-        self.instance = instance
-        self.timeout = instance.test.timeout
-        self.sourcedir = instance.test.code_location
-        self.outdir = instance.outdir
-        self.run_log = os.path.join(self.outdir, "run.log")
-        self.handler_log = os.path.join(self.outdir, "handler.log")
         self.valgrind = False
-        self.returncode = 0
-        self.set_state("running", {})
 
     def _output_reader(self, proc, harness):
         log_out_fp = open(self.handler_log, "wt")
@@ -478,18 +478,11 @@ class UnitHandler(Handler):
         """
         super().__init__(instance)
 
-        self.timeout = instance.test.timeout
-        self.sourcedir = instance.test.code_location
-        self.outdir = instance.outdir
-        self.run_log = os.path.join(self.outdir, "run.log")
-        self.handler_log = os.path.join(self.outdir, "handler.log")
-        self.returncode = 0
-        self.set_state("running", {})
 
     def handle(self):
         out_state = "failed"
 
-        with open(self.run_log, "wt") as rl, open(self.handler_log, "wt") as vl:
+        with open(self.handler_log, "wt") as hl:
             try:
                 binary = os.path.join(self.outdir, "testbinary")
                 command = [binary]
@@ -497,7 +490,7 @@ class UnitHandler(Handler):
                     command = ["valgrind", "--error-exitcode=2",
                                "--leak-check=full"] + command
                 returncode = subprocess.call(command, timeout=self.timeout,
-                                             stdout=rl, stderr=vl)
+                                             stdout=hl, stderr=hl)
                 self.returncode = returncode
                 if returncode != 0:
                     if self.returncode == 1:
@@ -613,22 +606,10 @@ class QEMUHandler(Handler):
     def __init__(self, instance):
         """Constructor
 
-        @param name Arbitrary name of the created thread
-        @param outdir Working directory, should be where qemu.pid gets created
-            by the build system
-        @param log_fn Absolute path to write out QEMU's log data
-        @param timeout Kill the QEMU process if it doesn't finish up within
-            the given number of seconds
+        @param instance Test instance
         """
 
-
         super().__init__(instance)
-        self.instance = instance
-        outdir = instance.outdir
-        timeout = instance.test.timeout
-        name = instance.name
-        run_log = os.path.join(outdir, "run.log")
-        handler_log = os.path.join(outdir, "handler.log")
 
         self.results = {}
 
@@ -640,19 +621,19 @@ class QEMUHandler(Handler):
         if os.path.exists(self.pid_fn):
             os.unlink(self.pid_fn)
 
-        self.log_fn = handler_log
+        self.log_fn = self.handler_log
 
         harness_import = HarnessImporter(instance.test.harness.capitalize())
         harness = harness_import.instance
-        harness.configure(instance)
-        self.thread = threading.Thread(name=name, target=QEMUHandler._thread,
-                                       args=(self, timeout, outdir,
+        harness.configure(self.instance)
+        self.thread = threading.Thread(name=self.name, target=QEMUHandler._thread,
+                                       args=(self, self.timeout, self.outdir,
                                              self.log_fn, self.fifo_fn,
                                              self.pid_fn, self.results, harness))
 
         self.instance.results = harness.tests
         self.thread.daemon = True
-        verbose("Spawning QEMU process for %s" % name)
+        verbose("Spawning QEMU process for %s" % self.name)
         self.thread.start()
 
     def get_fifo(self):

--- a/tests/include/tc_util.h
+++ b/tests/include/tc_util.h
@@ -80,11 +80,11 @@
 #define _TC_END_RESULT(result, func)					\
 	do {								\
 		if ((result) == TC_PASS) {				\
-			TC_END(result, "%s - %s.\n", PASS, func);	\
+			TC_END(result, "%s - %s\n", PASS, func);	\
 		} else if ((result) == TC_FAIL) {			\
-			TC_END(result, "%s - %s.\n", FAIL, func);	\
+			TC_END(result, "%s - %s\n", FAIL, func);	\
 		} else {						\
-			TC_END(result, "%s - %s.\n", SKIP, func);	\
+			TC_END(result, "%s - %s\n", SKIP, func);	\
 		}							\
 		PRINT_LINE;						\
 	} while (0)


### PR DESCRIPTION
This will allow us to run sanitycheck on real devices and get reporting
out of it the same way we do that with Qemu.

To use this, run sanitycheck with the following new options:

 ```
scripts/sanitycheck --device-testing --device-serial /dev/ttyACM0 -p frdm_k64f  -T tests/crypto/ -T tests/kernel --detailed-report frdm_k64f.xml
junit2html frdm_k64f.xml
```

--device-serial denotes the serial device the board is connected to.
This needs to be accessible by the user running sanitycheck. You can
run this on one board only at a time, the board is specified using the
--platform option. (-p)

This was tested with only a few boards, some board will not work
because how they reset the serial device during flashing.

Signed-off-by: Anas Nashif <anas.nashif@intel.com>