### PR TITLE
net: shell: Fix net mem command output

### DIFF
--- a/subsys/net/ip/net_shell.c
+++ b/subsys/net/ip/net_shell.c
@@ -1534,9 +1534,8 @@ static void context_info(struct net_context *context, void *user_data)
 		}
 
 #if defined(CONFIG_NET_DEBUG_NET_PKT)
-		printk("%p\t%zu\t%u\t%u\tETX\n",
-		       slab, slab->num_blocks * slab->block_size,
-		       slab->num_blocks, k_mem_slab_num_free_get(slab));
+		printk("%p\t%u\t%u\tETX\n",
+		       slab, slab->num_blocks, k_mem_slab_num_free_get(slab));
 #else
 		printk("%p\t%d\tETX\n", slab, slab->num_blocks);
 #endif
@@ -1552,8 +1551,8 @@ static void context_info(struct net_context *context, void *user_data)
 		}
 
 #if defined(CONFIG_NET_DEBUG_NET_PKT)
-		printk("%p\t%d\t%d\t%d\tEDATA (%s)\n",
-		       pool, pool->pool_size, pool->buf_count,
+		printk("%p\t%d\t%d\tEDATA (%s)\n",
+		       pool, pool->buf_count,
 		       pool->avail_count, pool->name);
 #else
 		printk("%p\t%d\tEDATA\n", pool, pool->buf_count);
@@ -1581,22 +1580,20 @@ int net_shell_cmd_mem(int argc, char *argv[])
 	printk("Network buffer pools:\n");
 
 #if defined(CONFIG_NET_BUF_POOL_USAGE)
-	printk("Address\t\tSize\tTotal\tAvail\tName\n");
+	printk("Address\t\tTotal\tAvail\tName\n");
 
-	printk("%p\t%zu\t%d\t%u\tRX\n",
-	       rx, rx->num_blocks * rx->block_size,
-	       rx->num_blocks, k_mem_slab_num_free_get(rx));
+	printk("%p\t%d\t%u\tRX\n",
+	       rx, rx->num_blocks, k_mem_slab_num_free_get(rx));
 
-	printk("%p\t%zu\t%d\t%u\tTX\n",
-	       tx, tx->num_blocks * tx->block_size,
-	       tx->num_blocks, k_mem_slab_num_free_get(tx));
+	printk("%p\t%d\t%u\tTX\n",
+	       tx, tx->num_blocks, k_mem_slab_num_free_get(tx));
 
-	printk("%p\t%d\t%d\t%d\tRX DATA (%s)\n",
-	       rx_data, rx_data->pool_size, rx_data->buf_count,
+	printk("%p\t%d\t%d\tRX DATA (%s)\n",
+	       rx_data, rx_data->buf_count,
 	       rx_data->avail_count, rx_data->name);
 
-	printk("%p\t%d\t%d\t%d\tTX DATA (%s)\n",
-	       tx_data, tx_data->pool_size, tx_data->buf_count,
+	printk("%p\t%d\t%d\tTX DATA (%s)\n",
+	       tx_data, tx_data->buf_count,
 	       tx_data->avail_count, tx_data->name);
 #else
 	printk("(CONFIG_NET_BUF_POOL_USAGE to see free #s)\n");


### PR DESCRIPTION
Pool size is no longer available so it is no use trying to print
its value. This change was introduced in commit dd09cbc1c455ab1e
("net: buf: Redesigned API with split data and meta-data")

Signed-off-by: Jukka Rissanen <jukka.rissanen@linux.intel.com>