### PR TITLE
drivers: net: loopback: Fix possible double unref

### DIFF
--- a/drivers/net/loopback.c
+++ b/drivers/net/loopback.c
@@ -81,9 +81,9 @@ static int loopback_send(struct net_if *iface, struct net_pkt *pkt)
 		goto out;
 	}
 
-out:
 	net_pkt_unref(pkt);
 
+out:
 	/* Let the receiving thread run now */
 	k_yield();
 


### PR DESCRIPTION
If we could not send the packet, then do not release the net_pkt
as that will be released in net_if.c:net_if_tx() if driver send()
fails.

Signed-off-by: Jukka Rissanen <jukka.rissanen@linux.intel.com>