### PR TITLE
mbedtls: config-tls1_2.h: Extended TLS 1.2 config

### DIFF
--- a/ext/lib/crypto/mbedtls/configs/config-tls1_2.h
+++ b/ext/lib/crypto/mbedtls/configs/config-tls1_2.h
@@ -1,0 +1,31 @@
+/*
+ * Copyright (c) 2018 Linaro Limited.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * More complete mbedTLS configuration for TLS 1.2 (RFC 5246) for Zephyr,
+ * extending config-mini-tls1_2.h.
+ */
+
+#ifndef MBEDTLS_CONFIG_TLS1_2_H
+#define MBEDTLS_CONFIG_TLS1_2_H
+
+#if 1
+
+/* DHE config - slow but moderate code size impact (~5K x86) */
+#define MBEDTLS_KEY_EXCHANGE_DHE_RSA_ENABLED
+#define MBEDTLS_DHM_C
+
+#else
+
+/* ECDHE config - faster but higher code size impact (~15K x86) */
+#define MBEDTLS_KEY_EXCHANGE_ECDHE_RSA_ENABLED
+#define MBEDTLS_ECP_DP_SECP256R1_ENABLED
+#define MBEDTLS_ECDH_C
+#define MBEDTLS_ECP_C
+
+#endif
+
+#include <config-mini-tls1_2.h>
+
+#endif /* MBEDTLS_CONFIG_TLS1_2_H */


### PR DESCRIPTION
A number of (HTTPS) sites on the modern Internet mandate use of
forward secrecy via ephemeral key exchange (DHE and ECDHE
cyphersuites). Elabling such cyphersuites how leads to increased
code size, mbedTLS heap usage, and runtime overheads, so enabling
them in the existing config-mini-tls1_2.h doesn't seem like a good
idea. Instead, create a new config, config-tls1_2.h, which includes
config-mini-tls1_2.h, and enables more options. The idea of this
file is to provide configuration as compatible as possible with
modern state of TLS 1.2 usage on the Internet, so more options
can be enabled in the future.

In the meantime, this config enables DHE by default, because it
leads to a moderate code size increase (~5K x86). However, DHE
cyphersuites are known to be slow during handshake phase (up to
3 times slower than with ephemeral key exchanges, based on
reports for OpenSSL). ECDHE is known to be faster (~50% time
overhead), but leads to much higher code impact (~15K). So, for
now only DHE is enabled.

Signed-off-by: Paul Sokolovsky <paul.sokolovsky@linaro.org>