### PR TITLE
net: ipv6: Drop NS packet if LL address is too long

### DIFF
--- a/subsys/net/ip/ipv6.c
+++ b/subsys/net/ip/ipv6.c
@@ -1432,6 +1432,12 @@ static enum net_verdict handle_ns_input(struct net_pkt *pkt)
 				goto drop;
 			}
 
+			if (nd_opt_hdr->len > 2) {
+				NET_ERR("Too long source link-layer address "
+					"in NS option");
+				goto drop;
+			}
+
 			handle_ns_neighbor(pkt, nd_opt_hdr->len,
 					   net_pkt_ip_hdr_len(pkt) +
 					   net_pkt_ipv6_ext_len(pkt) +


### PR DESCRIPTION
This commit fixes the crash of echo_server from overflow in ICMPv6 NS
source link-layer address option.

Fixes #6235

Signed-off-by: Ruslan Mstoi <ruslan.mstoi@intel.com>