### PR TITLE
soc: esp32: Fix compile warnings when redefining BIT() macro

### DIFF
--- a/arch/xtensa/soc/esp32/esp32-mp.c
+++ b/arch/xtensa/soc/esp32/esp32-mp.c
@@ -3,9 +3,12 @@
  *
  * SPDX-License-Identifier: Apache-2.0
  */
+
+/* Include esp-idf headers first to avoid redefining BIT() macro */
+#include <soc.h>
+
 #include <zephyr.h>
 #include <kernel_structs.h>
-#include <soc.h>
 
 #define _REG(base, off) (*(volatile u32_t *)((base) + (off)))
 


### PR DESCRIPTION
Include `soc.h` first, which will include the ESP-IDF headers -- which
will define the `BIT()` macro without checking if they're already
defined, like the Zephyr headers do.

Signed-off-by: Leandro Pereira <leandro.pereira@intel.com>