### PR TITLE
scripts: extract_dts_inculdes: Fix reg prop size/addr cell calculation

### DIFF
--- a/scripts/dts/extract_dts_includes.py
+++ b/scripts/dts/extract_dts_includes.py
@@ -272,7 +272,7 @@ def extract_reg_prop(node_address, names, defs, def_label, div, post_label):
     address_cells = reduced['/']['props'].get('#address-cells')
     size_cells = reduced['/']['props'].get('#size-cells')
     address = ''
-    for comp in node_address.split('/')[1:]:
+    for comp in node_address.split('/')[1:-1]:
         address += '/' + comp
         address_cells = reduced[address]['props'].get(
             '#address-cells', address_cells)


### PR DESCRIPTION
When we determine the address and size cells to determine how to parse a
reg property, we need to stop at the parent of the node, not at the node
itself.  If we have #address-cells or #size-cells in a node its meant
for the children of that node and not the node itself.

Fixes #4568

Signed-off-by: Kumar Gala <kumar.gala@linaro.org>