### PR TITLE
kernel: mem_domain: Pass proper type to ensure_w_xor_x()

### DIFF
--- a/kernel/mem_domain.c
+++ b/kernel/mem_domain.c
@@ -12,7 +12,7 @@
 
 static u8_t max_partitions;
 
-static void ensure_w_xor_x(u32_t attrs)
+static void ensure_w_xor_x(k_mem_partition_attr_t attrs)
 {
 #if defined(CONFIG_EXECUTE_XOR_WRITE) && __ASSERT_ON
 	bool writable = K_MEM_PARTITION_IS_WRITABLE(attrs);


### PR DESCRIPTION
The attributes are an u32_t only on ARM and ARC; on x86, it's something
else entirely.  Use the proper type to avoid attributes being
truncated.

Signed-off-by: Leandro Pereira <leandro.pereira@intel.com>