### PR TITLE
tests: kernel: Test for essential thread set/clear

### DIFF
--- a/tests/kernel/threads/lifecycle/lifecycle_api/src/main.c
+++ b/tests/kernel/threads/lifecycle/lifecycle_api/src/main.c
@@ -26,6 +26,7 @@ extern void test_threads_abort_self(void);
 extern void test_threads_abort_others(void);
 extern void test_threads_abort_repeat(void);
 extern void test_abort_handler(void);
+extern void test_essential_thread_operation(void);
 
 __kernel struct k_thread tdata;
 #define STACK_SIZE (256 + CONFIG_TEST_EXTRA_STACKSIZE)
@@ -41,15 +42,18 @@ void test_main(void)
 			 ztest_unit_test(test_threads_spawn_priority),
 			 ztest_user_unit_test(test_threads_spawn_delay),
 			 ztest_unit_test(test_threads_spawn_forever),
-			 ztest_unit_test(test_threads_suspend_resume_cooperative),
-			 ztest_unit_test(test_threads_suspend_resume_preemptible),
+			 ztest_unit_test(
+				 test_threads_suspend_resume_cooperative),
+			 ztest_unit_test(
+				 test_threads_suspend_resume_preemptible),
 			 ztest_user_unit_test(test_threads_cancel_undelayed),
 			 ztest_user_unit_test(test_threads_cancel_delayed),
 			 ztest_user_unit_test(test_threads_cancel_started),
 			 ztest_user_unit_test(test_threads_abort_self),
 			 ztest_user_unit_test(test_threads_abort_others),
 			 ztest_unit_test(test_threads_abort_repeat),
-			 ztest_unit_test(test_abort_handler)
+			 ztest_unit_test(test_abort_handler),
+			 ztest_unit_test(test_essential_thread_operation)
 			 );
 	ztest_run_test_suite(test_threads_lifecycle);
 }

--- a/tests/kernel/threads/lifecycle/lifecycle_api/src/test_essential_thread.c
+++ b/tests/kernel/threads/lifecycle/lifecycle_api/src/test_essential_thread.c
@@ -1,0 +1,42 @@
+/*
+ * Copyright (c) 2016 Intel Corporation
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+#include <ztest.h>
+#include <kernel.h>
+#include <kernel_structs.h>
+
+__kernel struct k_thread kthread_thread;
+
+#define STACKSIZE 1024
+K_THREAD_STACK_DEFINE(kthread_stack, STACKSIZE);
+K_SEM_DEFINE(sync_sem, 0, 1);
+
+static void thread_entry(void *p1, void *p2, void *p3)
+{
+	_thread_essential_set();
+
+	if (_is_thread_essential()) {
+		k_busy_wait(100);
+	} else {
+		zassert_unreachable("The thread is not set as essential\n");
+	}
+
+	_thread_essential_clear();
+	zassert_false(_is_thread_essential(),
+			"Essential flag of the thread is not cleared\n");
+
+	k_sem_give(&sync_sem);
+}
+
+/* The test to validate essential flag set/clear */
+void test_essential_thread_operation(void)
+{
+	k_tid_t tid = k_thread_create(&kthread_thread, kthread_stack,
+			STACKSIZE, (k_thread_entry_t)thread_entry, NULL,
+			NULL, NULL, K_PRIO_PREEMPT(0), 0, 0);
+
+	k_sem_take(&sync_sem, K_FOREVER);
+	k_thread_abort(tid);
+}


### PR DESCRIPTION
The test verifies the API functionality of _thread_essential_clear(),
    _thread_essential_set() and _is_thread_essential()

Signed-off-by: Spoorthi K <spoorthi.k@intel.com>