### PR TITLE
dts: nxp: Add add addr/size cell to spi nodes

### DIFF
--- a/dts/arm/nxp/nxp_k6x.dtsi
+++ b/dts/arm/nxp/nxp_k6x.dtsi
@@ -288,6 +288,8 @@
 			reg = <0x4002c000 0x88>;
 			interrupts = <26 0>;
 			clocks = <&sim KINETIS_SIM_BUS_CLK 0x103C 12>;
+			#address-cells = <1>;
+			#size-cells = <0>;
 
 			cs = <&gpiob 10 0>, <&gpiob 9 0>;
 			pinctrl-0 = <&spi0_default>;
@@ -299,6 +301,8 @@
 			reg = <0x4002d000 0x88>;
 			interrupts = <0 0>;
 			clocks = <&sim KINETIS_SIM_BUS_CLK 0x103C 13>;
+			#address-cells = <1>;
+			#size-cells = <0>;
 			status = "disabled";
 		};
 

--- a/dts/arm/nxp/nxp_kw2xd.dtsi
+++ b/dts/arm/nxp/nxp_kw2xd.dtsi
@@ -240,6 +240,8 @@
 			interrupts = <26 0>;
 			clocks = <&sim KINETIS_SIM_BUS_CLK 0x103C 12>;
 			status = "disabled";
+			#address-cells = <1>;
+			#size-cells = <0>;
 		};
 
 		spi1: spi@4002d000 {
@@ -251,6 +253,8 @@
 			cs = <&gpiob 10 0>;
 			pinctrl-0 = <&spi1_default>;
 			pinctrl-names = "default";
+			#address-cells = <1>;
+			#size-cells = <0>;
 		};
 
 		wdog: watchdog@40052000 {

--- a/dts/arm/nxp/nxp_kw40z.dtsi
+++ b/dts/arm/nxp/nxp_kw40z.dtsi
@@ -190,6 +190,8 @@
 			cs = <&gpiob 18 0>, <&gpiob 17 0>;
 			pinctrl-0 = <&spi0_default>;
 			pinctrl-names = "default";
+			#address-cells = <1>;
+			#size-cells = <0>;
 		};
 
 		spi1: spi@4002d000 {
@@ -198,6 +200,8 @@
 			interrupts = <29 0>;
 			clocks = <&sim KINETIS_SIM_BUS_CLK 0x103C 13>;
 			status = "disabled";
+			#address-cells = <1>;
+			#size-cells = <0>;
 		};
 
 		pwm0: pwm@40038000 {

--- a/dts/arm/nxp/nxp_kw41z.dtsi
+++ b/dts/arm/nxp/nxp_kw41z.dtsi
@@ -190,6 +190,8 @@
 			cs = <&gpiob 18 0>, <&gpiob 17 0>;
 			pinctrl-0 = <&spi0_default>;
 			pinctrl-names = "default";
+			#address-cells = <1>;
+			#size-cells = <0>;
 		};
 
 		spi1: spi@4002d000 {
@@ -198,6 +200,8 @@
 			interrupts = <29 0>;
 			clocks = <&sim KINETIS_SIM_BUS_CLK 0x103C 13>;
 			status = "disabled";
+			#address-cells = <1>;
+			#size-cells = <0>;
 		};
 
 		pwm0: pwm@40038000 {


### PR DESCRIPTION
The spi nodes should have #address-cells and #size-cells properties much
like i2c does.  Add these missing properties.

Signed-off-by: Kumar Gala <kumar.gala@linaro.org>