### PR TITLE
samples: dump_http_server: move generated files into include/generated

### DIFF
--- a/samples/net/sockets/dumb_http_server/CMakeLists.txt
+++ b/samples/net/sockets/dumb_http_server/CMakeLists.txt
@@ -4,7 +4,9 @@ project(NONE)
 FILE(GLOB app_sources src/*.c)
 target_sources(app PRIVATE ${app_sources})
 
-generate_inc_file_for_target(app src/response_small.html.bin src/response_small.html.bin.inc)
-generate_inc_file_for_target(app src/response_big.html.bin   src/response_big.html.bin.inc)
+set(gen_dir ${ZEPHYR_BINARY_DIR}/include/generated/)
+
+generate_inc_file_for_target(app src/response_small.html.bin ${gen_dir}/response_small.html.bin.inc)
+generate_inc_file_for_target(app src/response_big.html.bin   ${gen_dir}/response_big.html.bin.inc)
 
 include($ENV{ZEPHYR_BASE}/samples/net/common/common.cmake)


### PR DESCRIPTION
Move the generated files into include/generated so they live with the
build and not in the zephyr source tree.

Fixes #4924

Signed-off-by: Kumar Gala <kumar.gala@linaro.org>