### PR TITLE
subsys: dfu: boot: Remove unused version query code.

### DIFF
--- a/include/dfu/mcuboot.h
+++ b/include/dfu/mcuboot.h
@@ -30,13 +30,6 @@
 
 #define BOOT_IMG_VER_STRLEN_MAX 25  /* 255.255.65535.4294967295\0 */
 
-struct image_version {
-	u8_t iv_major;
-	u8_t iv_minor;
-	u16_t iv_revision;
-	u32_t iv_build_num;
-};
-
 /**
  * @brief MCUboot image header representation for image version
  *
@@ -145,8 +138,6 @@ bool boot_is_img_confirmed(void);
  * @return 0 on success, negative errno code on fail.
  */
 int boot_write_img_confirmed(void);
-
-int boot_current_image_version(struct image_version *out_ver);
 
 /**
  * @brief Determines the action, if any, that mcuboot will take on the next

--- a/subsys/dfu/boot/mcuboot.c
+++ b/subsys/dfu/boot/mcuboot.c
@@ -76,7 +76,6 @@ struct mcuboot_v1_raw_header {
 #define FLASH_STATE_OFFSET (FLASH_AREA_IMAGE_SCRATCH_OFFSET +\
 			    FLASH_AREA_IMAGE_SCRATCH_SIZE)
 
-#define VERSION_OFFSET(bank_offs) (bank_offs + 20)
 #define COPY_DONE_OFFS(bank_offs) (bank_offs + FLASH_BANK_SIZE -\
 				   BOOT_MAGIC_SZ - BOOT_MAX_ALIGN * 2)
 
@@ -253,14 +252,6 @@ static int boot_copy_done_read(u32_t bank_offs)
 	return boot_flag_read(BOOT_FLAG_COPY_DONE, bank_offs);
 }
 
-static int boot_version_read(u32_t bank_offs, struct image_version *out_ver)
-{
-	u32_t offs;
-
-	offs = VERSION_OFFSET(bank_offs);
-	return flash_read(flash_dev, offs, out_ver, sizeof(*out_ver));
-}
-
 static int boot_magic_write(u32_t bank_offs)
 {
 	u32_t offs;
@@ -410,11 +401,6 @@ static int boot_read_swap_state(u32_t bank_offs, struct boot_swap_state *state)
 	state->image_ok = rc;
 
 	return 0;
-}
-
-int boot_current_image_version(struct image_version *out_ver)
-{
-	return boot_version_read(FLASH_BANK0_OFFSET, out_ver);
 }
 
 int boot_swap_type(void)


### PR DESCRIPTION
Duplicate code to query was mistakenly added in commit 2ad7ccdb2de8c1ccf3ba94a2eb05b3a679f0cad5.  This code is redundant; the existing `boot_read_bank_header()` function can read the version from both image banks.