### PR TITLE
Boot delay

### DIFF
--- a/tests/kernel/common/testcase.yaml
+++ b/tests/kernel/common/testcase.yaml
@@ -2,3 +2,6 @@ tests:
   kernel.common:
     tags: kernel
     min_ram: 16
+  kernel.common.bootdelay:
+    extra_configs:
+      - CONFIG_BOOT_DELAY=10

--- a/tests/kernel/profiling/profiling_api/testcase.yaml
+++ b/tests/kernel/profiling/profiling_api/testcase.yaml
@@ -3,3 +3,8 @@ tests:
     arch_exclude: nios2 riscv32
     platform_exclude: em_starterkit
     tags: kernel
+  kernel.profiling.initstack:
+    arch_exclude: nios2 riscv32
+    platform_exclude: em_starterkit
+    extra_configs:
+      - CONFIG_INIT_STACKS=n


### PR DESCRIPTION
Add boot_delay and CONFIG_INIT_STACKS=n tests to improve code coverage for init.c.