### PR TITLE
drivers: console: fix NULL ptr deref in uart console

### DIFF
--- a/drivers/console/uart_console.c
+++ b/drivers/console/uart_console.c
@@ -532,7 +532,7 @@ void uart_console_isr(struct device *unused)
 				end = 0;
 				k_fifo_put(lines_queue, cmd);
 				cmd = NULL;
-				break;
+				continue;
 			case '\t':
 				if (completion_cb && !end) {
 					cur += completion_cb(cmd->line, cur);


### PR DESCRIPTION
When the user presses enter the command is put in a fifo, and the
local cmd ptr is set to NULL. Nevertheless few lines below a check
for buffer-full condition is still performed causing the cmd->line
deref.

This causes a crash on my nrf52840 board.

Zephyr Shell, Zephyr version: 1.10.99
Type 'help' for a list of available commands
shell> help
***** MPU FAULT *****
  Executing thread ID (thread): 0x20001918
  Faulting instruction address:  0x1f9c
  Data Access Violation
  Address: 0x5
Fatal fault in ISR! Spinning...

This patch skips the buffer-full test when a cmd has been just
processed.

Signed-off-by: Andrea Merello <andrea.merello@gmail.com>