### PR TITLE
net: ipv6: Drop ICMPv6 packet if NA header is NULL

### DIFF
--- a/subsys/net/ip/ipv6.c
+++ b/subsys/net/ip/ipv6.c
@@ -1927,7 +1927,10 @@ static enum net_verdict handle_na_input(struct net_pkt *pkt)
 	size_t left_len;
 
 	na_hdr = net_icmpv6_get_na_hdr(pkt, &nahdr);
-	NET_ASSERT(na_hdr);
+	if (!na_hdr) {
+		NET_ERR("NULL NA header - dropping");
+		goto drop;
+	}
 
 	dbg_addr_recv_tgt("Neighbor Advertisement",
 			  &NET_IPV6_HDR(pkt)->src,


### PR DESCRIPTION
This commit fixes the crash of echo_server from malformed 
ICMPv6 NA packet.

Fixes #6315

Signed-off-by: Ruslan Mstoi <ruslan.mstoi@intel.com>