### PR TITLE
drivers: console: Fix crash in shell

### DIFF
--- a/drivers/console/uart_console.c
+++ b/drivers/console/uart_console.c
@@ -513,8 +513,8 @@ void uart_console_isr(struct device *unused)
 			continue;
 		}
 
+		/* Handle special control characters */
 		if (!isprint(byte)) {
-			/* Handle special control characters */
 			switch (byte) {
 			case DEL:
 				if (cur > 0) {
@@ -541,6 +541,8 @@ void uart_console_isr(struct device *unused)
 			default:
 				break;
 			}
+
+			continue;
 		}
 
 		/* Ignore characters if there's no more buffer space */


### PR DESCRIPTION
Shell crashes when enter is pressed. This commit reverts relevant
changes from 14735116d1fe24713aa444e4e38e313b7f117c89 that cause
this issue.

Fixes #6322 
Fixes #6312

Signed-off-by: Ruslan Mstoi <ruslan.mstoi@intel.com>