### PR TITLE
doc: fix broken link in contributing guidelines

### DIFF
--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -306,8 +306,8 @@ uncrustify
 ==========
 
 The `uncrustify tool <https://sourceforge.net/projects/uncrustify>`_ can
-be helpful to quickly reformat your source code to our `project coding
-standards <Coding Style>`_ together with a configuration file we've provided:
+be helpful to quickly reformat your source code to our `Coding Style`_
+standards together with a configuration file we've provided:
 
 .. code-block:: bash
 


### PR DESCRIPTION
Link to the implicit target of a doc title wasn't correct

Fixes: #6324
Signed-off-by: David B. Kinder <david.b.kinder@intel.com>