### PR TITLE
doc: remove use of sphinx autodoc extension

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -29,7 +29,7 @@ sys.path.insert(0, os.path.join(os.path.abspath('.'), 'extensions'))
 # extensions coming with Sphinx (named 'sphinx.ext.*') or your custom
 # ones.
 extensions = [
-    'sphinx.ext.autodoc', 'breathe', 'sphinx.ext.todo',
+    'breathe', 'sphinx.ext.todo',
     'sphinx.ext.extlinks',
     'zephyr.application',
 ]


### PR DESCRIPTION
Looks like newer versions of Sphinx have a problem with the autodoc
extension.  Since we're not usine Sphinx to process python source for
documentation, removing use of autodoc eliminates the problem.

Signed-off-by: David B. Kinder <david.b.kinder@intel.com>