### PR TITLE
bluetooth: controller: nrf5: Add IC-specific reset function

### DIFF
--- a/subsys/bluetooth/controller/hal/nrf5/radio/radio.c
+++ b/subsys/bluetooth/controller/hal/nrf5/radio/radio.c
@@ -97,6 +97,8 @@ void radio_reset(void)
 #if defined(CONFIG_BOARD_NRFXX_NWTSIM)
 	NRF_RADIO_regw_sideeffects_POWER();
 #endif
+
+	hal_radio_reset();
 }
 
 void radio_phy_set(u8_t phy, u8_t flags)

--- a/subsys/bluetooth/controller/hal/nrf5/radio/radio_nrf51.h
+++ b/subsys/bluetooth/controller/hal/nrf5/radio/radio_nrf51.h
@@ -23,6 +23,10 @@
 #define HAL_RADIO_NRF51_RX_CHAIN_DELAY_US 3 /* ceil(3.0) */
 #define HAL_RADIO_NRF51_RX_CHAIN_DELAY_NS 3000 /* 3.0 */
 
+static inline void hal_radio_reset(void)
+{
+}
+
 static inline void hal_radio_ram_prio_setup(void)
 {
 }

--- a/subsys/bluetooth/controller/hal/nrf5/radio/radio_nrf52832.h
+++ b/subsys/bluetooth/controller/hal/nrf5/radio/radio_nrf52832.h
@@ -203,6 +203,13 @@
 #define SW_SWITCH_TIMER_TASK_GROUP_BASE 0
 #endif /* !CONFIG_BT_CTLR_TIFS_HW */
 
+static inline void hal_radio_reset(void)
+{
+	/* Anomalies 102, 106 and 107 */
+	*(volatile u32_t *)0x40001774 = ((*(volatile u32_t *)0x40001774) &
+					 0xfffffffe) | 0x01000000;
+}
+
 static inline void hal_radio_ram_prio_setup(void)
 {
 #if !defined(CONFIG_BOARD_NRFXX_NWTSIM)

--- a/subsys/bluetooth/controller/hal/nrf5/radio/radio_nrf52840.h
+++ b/subsys/bluetooth/controller/hal/nrf5/radio/radio_nrf52840.h
@@ -356,6 +356,13 @@
 #define SW_SWITCH_TIMER_TASK_GROUP_BASE 0
 #endif /* !CONFIG_BT_CTLR_TIFS_HW */
 
+static inline void hal_radio_reset(void)
+{
+	/* Anomalies 102, 106 and 107 */
+	*(volatile u32_t *)0x40001774 = ((*(volatile u32_t *)0x40001774) &
+					 0xfffffffe) | 0x01000000;
+}
+
 static inline void hal_radio_ram_prio_setup(void)
 {
 	struct {


### PR DESCRIPTION
In order to address anomaly 182 in the nRF52832, add a generic
hal_radio_reset() that does additional processing when required by a
particular IC or IC family. Implement the fix for the nRF52832.

Signed-off-by: Carles Cufi <carles.cufi@nordicsemi.no>