### PR TITLE
Bluetooth: btp: Add Enable advertising with Node Identity cmd

### DIFF
--- a/tests/bluetooth/tester/btp_spec.txt
+++ b/tests/bluetooth/tester/btp_spec.txt
@@ -1536,6 +1536,14 @@ Commands and responses:
 
 		In case of an error, the error response will be returned.
 
+	Opcode 0x12 - Clear Replay Protection List Cache
+		Controller Index:	<controller id>
+		Command parameters:	<none>
+
+		This command is used to clear Replay Protection List Cache.
+
+		In case of an error, the error response will be returned.
+
 Events:
 	Opcode 0x80 - Output number action Event
 

--- a/tests/bluetooth/tester/btp_spec.txt
+++ b/tests/bluetooth/tester/btp_spec.txt
@@ -1544,6 +1544,15 @@ Commands and responses:
 
 		In case of an error, the error response will be returned.
 
+	Opcode 0x13 - Enable advertising with Node Identity
+		Controller Index:	<controller id>
+		Command parameters:	<none>
+
+		This command is used to start advertising on each subnet using
+		Node Identity for the next 60 seconds.
+
+		In case of an error, the error response will be returned.
+
 Events:
 	Opcode 0x80 - Output number action Event
 

--- a/tests/bluetooth/tester/src/bttester.h
+++ b/tests/bluetooth/tester/src/bttester.h
@@ -766,6 +766,7 @@ struct mesh_lpn_unsubscribe_cmd {
 } __packed;
 
 #define MESH_RPL_CLEAR			0x12
+#define MESH_PROXY_IDENTITY		0x13
 
 /* events */
 #define MESH_EV_OUT_NUMBER_ACTION	0x80

--- a/tests/bluetooth/tester/src/mesh.c
+++ b/tests/bluetooth/tester/src/mesh.c
@@ -90,6 +90,7 @@ static void supported_commands(u8_t *data, u16_t len)
 	tester_set_bit(buf->data, MESH_LPN_UNSUBSCRIBE);
 	tester_set_bit(buf->data, MESH_RPL_CLEAR);
 #endif /* CONFIG_BT_TESTING */
+	tester_set_bit(buf->data, MESH_PROXY_IDENTITY);
 
 	tester_send(BTP_SERVICE_ID_MESH, MESH_READ_SUPPORTED_COMMANDS,
 		    CONTROLLER_INDEX, buf->data, buf->len);
@@ -734,6 +735,21 @@ static void rpl_clear(u8_t *data, u16_t len)
 }
 #endif /* CONFIG_BT_TESTING */
 
+static void proxy_identity_enable(u8_t *data, u16_t len)
+{
+	int err;
+
+	SYS_LOG_DBG("");
+
+	err = bt_mesh_proxy_identity_enable();
+	if (err) {
+		SYS_LOG_ERR("Failed to enable proxy identity (err %d)", err);
+	}
+
+	tester_rsp(BTP_SERVICE_ID_MESH, MESH_PROXY_IDENTITY, CONTROLLER_INDEX,
+		   err ? BTP_STATUS_FAILED : BTP_STATUS_SUCCESS);
+}
+
 void tester_handle_mesh(u8_t opcode, u8_t index, u8_t *data, u16_t len)
 {
 	switch (opcode) {
@@ -793,6 +809,9 @@ void tester_handle_mesh(u8_t opcode, u8_t index, u8_t *data, u16_t len)
 		rpl_clear(data, len);
 		break;
 #endif /* CONFIG_BT_TESTING */
+	case MESH_PROXY_IDENTITY:
+		proxy_identity_enable(data, len);
+		break;
 	default:
 		tester_rsp(BTP_SERVICE_ID_MESH, opcode, index,
 			   BTP_STATUS_UNKNOWN_CMD);


### PR DESCRIPTION
This adds Enable advertising with Node Identity BTP command and it's implementation and missing Clear Replay Protection List Cache BTP command.
This command is needed to pass PTS MESH/NODE/CFG/NID/BV-02-C test case.