### PR TITLE
cmake: indicate single precision floating-point for Cortex-M33

### DIFF
--- a/cmake/fpu-for-gcc-m-cpu.cmake
+++ b/cmake/fpu-for-gcc-m-cpu.cmake
@@ -2,4 +2,4 @@
 
 set(FPU_FOR_cortex-m4      fpv4-sp-d16)
 set(FPU_FOR_cortex-m7      fpv5-d16)
-set(FPU_FOR_cortex-m33     fpv5-d16)
+set(FPU_FOR_cortex-m33     fpv5-sp-d16)


### PR DESCRIPTION
ARM Cortex-M33 may implement an optional Floating Point Unit
(FPU) supporting single-precision arithmetic. This commit
modifies the respective GCC_M_CPU flag to comply with Cortex-M33.

From ARM Cortex-M33 Processor (Technical Reference Manual):
"The Cortex-M33 processor with FPU supports single-precision arithmetic as defined by the FPv5 architecture that is part of the ARMv8-M architecture." [Section A1.6 - Compliance]

Signed-off-by: Ioannis Glaropoulos <Ioannis.Glaropoulos@nordicsemi.no>