### PR TITLE
boards/arm/nucleo_l476rg: Fix usart1 node

### DIFF
--- a/boards/arm/nucleo_l476rg/nucleo_l476rg.dts
+++ b/boards/arm/nucleo_l476rg/nucleo_l476rg.dts
@@ -18,7 +18,7 @@
 	};
 };
 
-&usart2 {
+&usart1 {
 	current-speed = <115200>;
 	pinctrl-0 = <&usart1_pins_b>;
 	pinctrl-names = "default";


### PR DESCRIPTION
Fix usart1 node in boards dts file

Signed-off-by: Yannis Damigos <giannis.damigos@gmail.com>