### PR TITLE
bluetooth: controller: nrf5: fix to IC-specific reset function

### DIFF
--- a/subsys/bluetooth/controller/hal/nrf5/radio/radio_nrf52832.h
+++ b/subsys/bluetooth/controller/hal/nrf5/radio/radio_nrf52832.h
@@ -205,9 +205,11 @@
 
 static inline void hal_radio_reset(void)
 {
+#if !defined(CONFIG_BOARD_NRFXX_NWTSIM)
 	/* Anomalies 102, 106 and 107 */
 	*(volatile u32_t *)0x40001774 = ((*(volatile u32_t *)0x40001774) &
 					 0xfffffffe) | 0x01000000;
+#endif /* !CONFIG_BOARD_NRFXX_NWTSIM */
 }
 
 static inline void hal_radio_ram_prio_setup(void)


### PR DESCRIPTION
Fix of 80210198ad80fc4390f76a3356c4eb6faff9b778 so it does not cause a segfault in simulated boards

Signed-off-by: Alberto Escolar Piedras <alpi@oticon.com>