### PR TITLE
drivers: sensor: ccs811: Fix value conversion

### DIFF
--- a/drivers/sensor/ccs811/ccs811.c
+++ b/drivers/sensor/ccs811/ccs811.c
@@ -66,21 +66,18 @@ static int ccs811_channel_get(struct device *dev,
 
 	switch (chan) {
 	case SENSOR_CHAN_CO2:
-		uval = drv_data->co2 * 1000000;
-		val->val1 = uval / 1000000;
-		val->val2 = uval % 1000000;
+		val->val1 = drv_data->co2;
+		val->val2 = 0;
 
 		break;
 	case SENSOR_CHAN_VOC:
-		uval = drv_data->voc * 1000000;
-		val->val1 = uval / 1000000;
-		val->val2 = uval % 1000000;
+		val->val1 = drv_data->voc;
+		val->val2 = 0;
 
 		break;
 	case SENSOR_CHAN_VOLTAGE:
 		/*
-		 * Voltage readings are contained in least
-		 * significant 10 bits in volts
+		 * Raw ADC readings are contained in least significant 10 bits
 		 */
 		uval = (drv_data->resistance & CCS811_VOLTAGE_MASK)
 					* CCS811_VOLTAGE_SCALE;


### PR DESCRIPTION
The arithmetic performed on the CO2 and VOC measurements is pointless as
the units of the sensor already match those of the API, furthermore the
multiplication will overflow the u32_t with CO2 or VOC readings greater
than 4294 ppm or ppb. This CO2 concentration is achievable by breathing
at the sensor.

Signed-off-by: Aapo Vienamo <aapo.vienamo@iki.fi>