### PR TITLE
slip: fix a bug when in non-TAP mode.

### DIFF
--- a/drivers/net/slip.c
+++ b/drivers/net/slip.c
@@ -211,7 +211,7 @@ static int slip_send(struct net_if *iface, struct net_pkt *pkt)
 #if SYS_LOG_LEVEL >= SYS_LOG_LEVEL_DEBUG
 		SYS_LOG_DBG("sent data %d bytes",
 			    frag->len + net_pkt_ll_reserve(pkt));
-		if (frag->len + ll_reserve) {
+		if (frag->len + net_pkt_ll_reserve(pkt)) {
 			char msg[8 + 1];
 
 			snprintf(msg, sizeof(msg), "<slip %2d", frag_count++);


### PR DESCRIPTION
Read up to an (arbitrary) 32 bytes at once from the port.  This improves
performance with the USB CDC ACM driver which may have 64 bytes
available at a time.

Tested on arduino_zero and qemu_cortex_m3.

Signed-off-by: Michael Hope <mlhx@google.com>