### PR TITLE
netusb: drop the extra zero byte on multiple-of-packet-length frames

### DIFF
--- a/subsys/usb/class/netusb/function_ecm.c
+++ b/subsys/usb/class/netusb/function_ecm.c
@@ -21,6 +21,7 @@
 #include <usb_common.h>
 
 #include <net/net_pkt.h>
+#include <net/ethernet.h>
 
 #include "netusb.h"
 
@@ -60,6 +61,35 @@ static void ecm_int_in(u8_t ep, enum usb_dc_ep_cb_status_code ep_status)
 	SYS_LOG_DBG("EP 0x%x status %d", ep, ep_status);
 }
 
+/* Returns true if the given packet is long enough to hold the whole payload */
+static bool ecm_have_payload(struct net_pkt *pkt)
+{
+	struct net_eth_hdr *hdr = NET_ETH_HDR(pkt);
+	int len = net_pkt_get_len(pkt);
+	u8_t *ip_data = pkt->frags->data + sizeof(struct net_eth_hdr);
+	u16_t ip_len;
+
+	if (len < NET_IPV6H_LEN + sizeof(struct net_eth_hdr)) {
+		/* Too short to tell */
+		return false;
+	}
+
+	switch (ntohs(hdr->type)) {
+	case NET_ETH_PTYPE_IP:
+	case NET_ETH_PTYPE_ARP:
+		ip_len = sys_get_be16(((struct net_ipv4_hdr *)ip_data)->len);
+		break;
+	case NET_ETH_PTYPE_IPV6:
+		ip_len = sys_get_be16(((struct net_ipv6_hdr *)ip_data)->len);
+		break;
+	default:
+		SYS_LOG_DBG("Unknown hdr type 0x%04x", hdr->type);
+		return false;
+	}
+
+	return sizeof(struct net_eth_hdr) + ip_len <= len;
+}
+
 /* Host to device data out */
 static void ecm_bulk_out(u8_t ep, enum usb_dc_ep_cb_status_code ep_status)
 {
@@ -84,28 +114,6 @@ static void ecm_bulk_out(u8_t ep, enum usb_dc_ep_cb_status_code ep_status)
 	 * usb_read().
 	 */
 	usb_read(ep, buffer, len, NULL);
-
-	/*
-	 * Zero packet is send to mark frame delimeter
-	 */
-	if (len == 1 && !buffer[0]) {
-		SYS_LOG_DBG("Got frame delimeter, ECM pkt received, len %u",
-			    net_pkt_get_len(in_pkt));
-
-		if (skip) {
-			SYS_LOG_WRN("End skipping fragments");
-			skip = false;
-
-			return;
-		}
-
-		net_hexdump_frags(">", in_pkt);
-
-		netusb_recv(in_pkt);
-		in_pkt = NULL;
-
-		return;
-	}
 
 	if (skip) {
 		SYS_LOG_WRN("Skipping %u bytes", len);
@@ -139,6 +147,16 @@ static void ecm_bulk_out(u8_t ep, enum usb_dc_ep_cb_status_code ep_status)
 		net_pkt_frag_insert(pkt, buf);
 
 		in_pkt = pkt;
+	}
+
+	/* The ECM spec says that the end of a packet is marked by
+	 * a short frame.  If the packet is a multiple of the endpoint
+	 * size then the host should send a zero length packet.
+	 * Linux, however, sends a one byte packet instead.  Handle by
+	 * checking the IP header length and dropping the extra byte.
+	 */
+	if (len == 1 && ecm_have_payload(in_pkt)) {
+		len = 0;
 	}
 
 	if (!net_pkt_append_all(in_pkt, len, buffer, K_FOREVER)) {


### PR DESCRIPTION
This fixes a bug in the cdc_ecm Ethernet over USB driver.  The ECM
spec (section 3.3.1) says that the end of an Ethernet frame is marked
using the USB short packet mechanisim, where the last packet is less
than the maximum packet size.  If the Ethernet frame is a multiple of
the USB maximum packet size then a final zero length packet must be
sent.

However, Linux sends a one byte packet instead (usbnet.c:1393) to work
around hardware issues with zero length packets.

The current Zephyr driver works most of the time except when you send
an Ethernet frame of the right length where the last byte is zero,
such as:

$ ping 192.0.2.1 -s 23 -p 0

Zephyr then drops the last byte, creating a short frame which gets
dropped higher up in the stack.

Signed-off-by: Michael Hope <mlhx@google.com>