### PR TITLE
netusb: wait for the transfer to complete before retrying.

### DIFF
--- a/subsys/usb/class/netusb/function_ecm.c
+++ b/subsys/usb/class/netusb/function_ecm.c
@@ -165,6 +165,7 @@ static void ecm_bulk_in(u8_t ep, enum usb_dc_ep_cb_status_code ep_status)
 #if VERBOSE_DEBUG
 	SYS_LOG_DBG("EP 0x%x status %d", ep, ep_status);
 #endif
+	netusb_bulk_in(ep, ep_status);
 }
 
 /*

--- a/subsys/usb/class/netusb/netusb.h
+++ b/subsys/usb/class/netusb/netusb.h
@@ -20,6 +20,7 @@ struct netusb_function {
 };
 
 void netusb_recv(struct net_pkt *pkt);
+void netusb_bulk_in(u8_t ep, enum usb_dc_ep_cb_status_code ep_status);
 int try_write(u8_t ep, u8_t *data, u16_t len);
 
 #if defined(CONFIG_USB_DEVICE_NETWORK_ECM)


### PR DESCRIPTION
In the same way as cdc_acm, set a semaphore in the transfer complete
interrupt and wait for it in the main loop before retrying.

This fixes a bug with >= 64 byte frames when logging is off.  If
logging is on, then the time to print logging is enough for the
transmit to complete.  If logging is off, then the 10 retries complete
quickly and try_write() gives up.

Signed-off-by: Michael Hope <mlhx@google.com>