### PR TITLE
tests: kernel: Add test to verify k_thread_start()

### DIFF
--- a/tests/kernel/threads/lifecycle/lifecycle_api/src/main.c
+++ b/tests/kernel/threads/lifecycle/lifecycle_api/src/main.c
@@ -17,6 +17,7 @@ extern void test_threads_spawn_params(void);
 extern void test_threads_spawn_priority(void);
 extern void test_threads_spawn_delay(void);
 extern void test_threads_spawn_forever(void);
+extern void test_thread_start(void);
 extern void test_threads_suspend_resume_cooperative(void);
 extern void test_threads_suspend_resume_preemptible(void);
 extern void test_threads_cancel_undelayed(void);
@@ -46,6 +47,9 @@ void test_main(void)
 				 test_threads_suspend_resume_cooperative),
 			 ztest_unit_test(
 				 test_threads_suspend_resume_preemptible),
+			 ztest_unit_test(test_thread_start),
+			 ztest_unit_test(test_threads_suspend_resume_cooperative),
+			 ztest_unit_test(test_threads_suspend_resume_preemptible),
 			 ztest_user_unit_test(test_threads_cancel_undelayed),
 			 ztest_user_unit_test(test_threads_cancel_delayed),
 			 ztest_user_unit_test(test_threads_cancel_started),

--- a/tests/kernel/threads/lifecycle/lifecycle_api/src/test_threads_spawn.c
+++ b/tests/kernel/threads/lifecycle/lifecycle_api/src/test_threads_spawn.c
@@ -94,3 +94,27 @@ void test_threads_spawn_forever(void)
 	zassert_true(tp2 == 100, NULL);
 	k_thread_abort(tid);
 }
+
+/* Test to validate behavior of multiple calls to k_thread_start() */
+void test_thread_start(void)
+{
+	tp2 = 5;
+
+	k_tid_t tid = k_thread_create(&tdata, tstack, STACK_SIZE,
+			thread_entry_delay, NULL, NULL, NULL,
+			K_HIGHEST_THREAD_PRIO,
+			K_USER, K_FOREVER);
+
+	k_thread_start(tid);
+	k_yield();
+	zassert_true(tp2 == 100, NULL);
+
+	/* checkpoint: k_thread_start() should not start the
+	 * terminated thread
+	 */
+
+	tp2 = 50;
+	k_thread_start(tid);
+	k_yield();
+	zassert_false(tp2 == 100, NULL);
+}


### PR DESCRIPTION
The test validates the behavior of calling k_thread_start() 
of thread which is already started. The thread has to start
execution only when its state is _THREAD_PRESTART.

Signed-off-by: Spoorthi K <spoorthi.k@intel.com>