### PR TITLE
Improve external project build time

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1090,8 +1090,6 @@ add_subdirectory(cmake/flash)
 add_subdirectory(cmake/usage)
 add_subdirectory(cmake/reports)
 
-include(cmake/ccache.cmake)
-
 if(CONFIG_ASSERT)
   message(WARNING "
       ------------------------------------------------------------

--- a/cmake/app/boilerplate.cmake
+++ b/cmake/app/boilerplate.cmake
@@ -88,6 +88,8 @@ include(${ZEPHYR_BASE}/cmake/extensions.cmake)
 
 find_package(PythonInterp 3.4)
 
+include(${ZEPHYR_BASE}/cmake/ccache.cmake)
+
 if(${CMAKE_CURRENT_SOURCE_DIR} STREQUAL ${CMAKE_CURRENT_BINARY_DIR})
   message(FATAL_ERROR "Source directory equals build directory.\
  In-source builds are not supported.\

--- a/subsys/net/lib/openthread/CMakeLists.txt
+++ b/subsys/net/lib/openthread/CMakeLists.txt
@@ -96,11 +96,13 @@ set(commoncflags "-DOPENTHREAD_CONFIG_LOG_LEVEL=${CONFIG_OPENTHREAD_LOG_LEVEL}")
 set(commoncflags "${commoncflags} -DOPENTHREAD_PROJECT_CORE_CONFIG_FILE=\\\"openthread-core-zephyr-config.h\\\"")
 set(commoncflags "${commoncflags} -I${CMAKE_CURRENT_LIST_DIR}/platform")
 
+get_property(RULE_LAUNCH_COMPILE GLOBAL PROPERTY RULE_LAUNCH_COMPILE)
+
 set(configure_flags
   "INSTALL=${INSTALL} -p"
   "CPP=${CMAKE_C_COMPILER} -E"                 # TODO: Find CPP in toolchain-gcc.cmake and use that instead?
-  "CC=${CMAKE_C_COMPILER}"
-  "CXX=${CMAKE_CXX_COMPILER}"
+  "CC=${RULE_LAUNCH_COMPILE} ${CMAKE_C_COMPILER}"
+  "CXX=${RULE_LAUNCH_COMPILE} ${CMAKE_CXX_COMPILER}"
   OBJC=""                      # TODO: Omit this?
   "OBJCXX=${OBJCXX}"           # TODO: Omit this?
   "AR=${CMAKE_AR}"


### PR DESCRIPTION
Use ccache when building OpenThread. When the cache is warm, I was
able to observe that this patch sped up a clean build from 45 seconds
to 33 seconds.