### PR TITLE
arch: arm: add missing floating-point fault logging

### DIFF
--- a/arch/arm/core/cortex_m/Kconfig
+++ b/arch/arm/core/cortex_m/Kconfig
@@ -107,6 +107,15 @@ config ARMV7_M_ARMV8_M_MAINLINE
 	  The Main Extension provides backwards compatibility
 	  with ARMv7-M.
 
+config ARMV7_M_ARMV8_M_FP
+	bool
+	# Omit prompt to signify "hidden" option
+	depends on ARMV7_M_ARMV8_M_MAINLINE && !CPU_CORTEX_M3
+	help
+	  This option signifies the use of an ARMv7-M processor
+	  implementation, or the use of an ARMv8-M processor
+	  implementation supporting the Floating-Point Extension.
+
 config CPU_CORTEX_M0
 	bool
 	# Omit prompt to signify "hidden" option
@@ -132,6 +141,7 @@ config CPU_CORTEX_M4
 	bool
 	# Omit prompt to signify "hidden" option
 	select ARMV7_M_ARMV8_M_MAINLINE
+	select ARMV7_M_ARMV8_M_FP if CPU_HAS_FPU
 	help
 	  This option signifies the use of a Cortex-M4 CPU
 
@@ -146,6 +156,7 @@ config CPU_CORTEX_M33
 	bool
 	# Omit prompt to signify "hidden" option
 	select ARMV7_M_ARMV8_M_MAINLINE
+	select ARMV7_M_ARMV8_M_FP if CPU_HAS_FPU
 	help
 	  This option signifies the use of a Cortex-M33 CPU
 
@@ -153,6 +164,7 @@ config CPU_CORTEX_M7
 	bool
 	# Omit prompt to signify "hidden" option
 	select ARMV7_M_ARMV8_M_MAINLINE
+	select ARMV7_M_ARMV8_M_FP if CPU_HAS_FPU
 	default n
 	help
 	  This option signifies the use of a Cortex-M7 CPU

--- a/arch/arm/core/fault.c
+++ b/arch/arm/core/fault.c
@@ -168,7 +168,13 @@ static void _MpuFault(const NANO_ESF *esf, int fromHardFault)
 		}
 	} else if (SCB->CFSR & SCB_CFSR_IACCVIOL_Msk) {
 		PR_EXC("  Instruction Access Violation\n");
+#if !defined(CONFIG_ARMV7_M_ARMV8_M_FP)
 	}
+#else
+	} else if (SCB->CFSR & SCB_CFSR_MLSPERR_Msk) {
+		PR_EXC("  Floating-point lazy state preservation error\n");
+	}
+#endif /* !defined(CONFIG_ARMV7_M_ARMV8_M_FP) */
 }
 
 /**
@@ -216,7 +222,13 @@ static void _BusFault(const NANO_ESF *esf, int fromHardFault)
 		PR_EXC("  Imprecise data bus error\n");
 	} else if (SCB->CFSR & SCB_CFSR_IBUSERR_Msk) {
 		PR_EXC("  Instruction bus error\n");
+#if !defined(CONFIG_ARMV7_M_ARMV8_M_FP)
 	}
+#else
+	} else if (SCB->CFSR & SCB_CFSR_LSPERR_Msk) {
+		PR_EXC("  Floating-point lazy state preservation error\n");
+	}
+#endif /* !defined(CONFIG_ARMV7_M_ARMV8_M_FP) */
 }
 
 /**


### PR DESCRIPTION
This commit adds the missing fault-dumping for MemManage or Bus
fault occuring during floating-point lazy state preservation. In
addition, it introduces a Kconfig option for the ARMv7-M/ARMv8-M
Floating Point Extension.

Signed-off-by: Ioannis Glaropoulos <Ioannis.Glaropoulos@nordicsemi.no>