### PR TITLE
net: Exit early on zero length packet append

### DIFF
--- a/subsys/net/ip/net_pkt.c
+++ b/subsys/net/ip/net_pkt.c
@@ -1203,7 +1203,7 @@ u16_t net_pkt_append(struct net_pkt *pkt, u16_t len, const u8_t *data,
 	struct net_context *ctx = NULL;
 	u16_t max_len, appended;
 
-	if (!pkt || !data) {
+	if (!pkt || !data || !len) {
 		return 0;
 	}
 


### PR DESCRIPTION
Shorten exit path on zero length data append to a packet.

Signed-off-by: Andrei Emeltchenko <andrei.emeltchenko@intel.com>