### PR TITLE
Miscellaneous net fixes

### DIFF
--- a/subsys/net/ip/6lo.c
+++ b/subsys/net/ip/6lo.c
@@ -759,7 +759,10 @@ static inline bool compress_IPHC_header(struct net_pkt *pkt,
 		struct net_udp_hdr hdr, *udp;
 
 		udp = net_udp_get_hdr(pkt, &hdr);
-		NET_ASSERT(udp);
+		if (!udp) {
+			NET_ERR("could not get UDP header");
+			return false;
+		}
 
 		IPHC[offset] = NET_6LO_NHC_UDP_BARE;
 		offset = compress_nh_udp(udp, frag, offset);

--- a/subsys/net/ip/ipv6.c
+++ b/subsys/net/ip/ipv6.c
@@ -110,7 +110,10 @@ static inline bool net_is_solicited(struct net_pkt *pkt)
 	struct net_icmpv6_na_hdr hdr, *na_hdr;
 
 	na_hdr = net_icmpv6_get_na_hdr(pkt, &hdr);
-	NET_ASSERT(na_hdr);
+	if (!na_hdr) {
+		NET_ERR("could not get na_hdr");
+		return false;
+	}
 
 	return na_hdr->flags & NET_ICMPV6_NA_FLAG_SOLICITED;
 }
@@ -120,7 +123,10 @@ static inline bool net_is_router(struct net_pkt *pkt)
 	struct net_icmpv6_na_hdr hdr, *na_hdr;
 
 	na_hdr = net_icmpv6_get_na_hdr(pkt, &hdr);
-	NET_ASSERT(na_hdr);
+	if (!na_hdr) {
+		NET_ERR("could not get na_hdr");
+		return false;
+	}
 
 	return na_hdr->flags & NET_ICMPV6_NA_FLAG_ROUTER;
 }
@@ -130,7 +136,10 @@ static inline bool net_is_override(struct net_pkt *pkt)
 	struct net_icmpv6_na_hdr hdr, *na_hdr;
 
 	na_hdr = net_icmpv6_get_na_hdr(pkt, &hdr);
-	NET_ASSERT(na_hdr);
+	if (!na_hdr) {
+		NET_ERR("could not get na_hdr");
+		return false;
+	}
 
 	return na_hdr->flags & NET_ICMPV6_NA_FLAG_OVERRIDE;
 }
@@ -1308,7 +1317,10 @@ int net_ipv6_send_na(struct net_if *iface, const struct in6_addr *src,
 	net_buf_add(frag, sizeof(struct net_icmpv6_na_hdr) + llao_len);
 
 	na_hdr = net_icmpv6_get_na_hdr(pkt, &hdr);
-	NET_ASSERT_INFO(na_hdr, "Too short fragment for NA");
+	if (!na_hdr) {
+		NET_ERR("fragment too short for NA");
+		goto drop;
+	}
 
 	net_ipaddr_copy(&NET_IPV6_HDR(pkt)->src, src);
 	net_ipaddr_copy(&NET_IPV6_HDR(pkt)->dst, dst);

--- a/subsys/net/ip/ipv6.c
+++ b/subsys/net/ip/ipv6.c
@@ -254,15 +254,6 @@ static struct net_nbr *nbr_lookup(struct net_nbr_table *table,
 	return NULL;
 }
 
-struct net_ipv6_nbr_data *net_ipv6_get_nbr_by_index(u8_t idx)
-{
-	struct net_nbr *nbr = get_nbr(idx);
-
-	NET_ASSERT_INFO(nbr, "Invalid ll index %d", idx);
-
-	return net_ipv6_nbr_data(nbr);
-}
-
 static inline void nbr_clear_ns_pending(struct net_ipv6_nbr_data *data)
 {
 	k_delayed_work_cancel(&data->send_ns);

--- a/subsys/net/ip/ipv6.c
+++ b/subsys/net/ip/ipv6.c
@@ -2071,7 +2071,13 @@ int net_ipv6_send_ns(struct net_if *iface,
 	net_buf_add(frag, sizeof(struct net_icmpv6_ns_hdr));
 
 	ns_hdr = net_icmpv6_get_ns_hdr(pkt, &hdr);
-	NET_ASSERT(ns_hdr);
+	if (!ns_hdr) {
+		NET_ERR("could not get ns_hdr");
+
+		net_pkt_unref(pkt);
+
+		return -EINVAL;
+	}
 
 	if (!dst) {
 		net_ipv6_addr_create_solicited_node(tgt,

--- a/subsys/net/ip/ipv6.c
+++ b/subsys/net/ip/ipv6.c
@@ -2594,7 +2594,10 @@ static enum net_verdict handle_ra_input(struct net_pkt *pkt)
 	}
 
 	ra_hdr = net_icmpv6_get_ra_hdr(pkt, &hdr);
-	NET_ASSERT(ra_hdr);
+	if (!ra_hdr) {
+		NET_ERR("could not get ra_hdr");
+		goto drop;
+	}
 
 	if (reachable_time &&
 	    (net_if_ipv6_get_reachable_time(net_pkt_iface(pkt)) !=

--- a/subsys/net/ip/ipv6.h
+++ b/subsys/net/ip/ipv6.h
@@ -110,15 +110,6 @@ static inline struct net_ipv6_nbr_data *net_ipv6_nbr_data(struct net_nbr *nbr)
 	return (struct net_ipv6_nbr_data *)nbr->data;
 }
 
-/**
- * @brief Return IPv6 neighbor according to ll index.
- *
- * @param idx Neighbor index in link layer table.
- *
- * @return Return IPv6 neighbor information.
- */
-struct net_ipv6_nbr_data *net_ipv6_get_nbr_by_index(u8_t idx);
-
 #if defined(CONFIG_NET_IPV6_DAD)
 int net_ipv6_start_dad(struct net_if *iface, struct net_if_addr *ifaddr);
 #endif

--- a/subsys/net/ip/l2/ieee802154/ieee802154_fragment.c
+++ b/subsys/net/ip/l2/ieee802154/ieee802154_fragment.c
@@ -324,12 +324,13 @@ static void update_protocol_header_lengths(struct net_pkt *pkt, u16_t size)
 		struct net_udp_hdr hdr, *udp_hdr;
 
 		udp_hdr = net_udp_get_hdr(pkt, &hdr);
+		if (udp_hdr) {
+			udp_hdr->len = htons(size - NET_IPV6H_LEN);
 
-		NET_ASSERT(udp_hdr);
-
-		udp_hdr->len = htons(size - NET_IPV6H_LEN);
-
-		net_udp_set_hdr(pkt, udp_hdr);
+			net_udp_set_hdr(pkt, udp_hdr);
+		} else {
+			NET_ERR("could not get UDP header");
+		}
 	}
 }
 

--- a/subsys/net/ip/net_pkt.c
+++ b/subsys/net/ip/net_pkt.c
@@ -503,8 +503,10 @@ static struct net_pkt *net_pkt_get(struct k_mem_slab *slab,
 	}
 
 	iface = net_context_get_iface(context);
-
-	NET_ASSERT(iface);
+	if (!iface) {
+		NET_ERR("Context has no interface");
+		return NULL;
+	}
 
 	if (net_context_get_family(context) == AF_INET6) {
 		addr6 = &((struct sockaddr_in6 *) &context->remote)->sin6_addr;
@@ -589,8 +591,10 @@ static struct net_buf *_pkt_get_data(struct net_buf_pool *pool,
 	}
 
 	iface = net_context_get_iface(context);
-
-	NET_ASSERT(iface);
+	if (!iface) {
+		NET_ERR("Context has no interface");
+		return NULL;
+	}
 
 	if (net_context_get_family(context) == AF_INET6) {
 		addr6 = &((struct sockaddr_in6 *) &context->remote)->sin6_addr;

--- a/subsys/net/ip/route.c
+++ b/subsys/net/ip/route.c
@@ -595,12 +595,14 @@ struct in6_addr *net_route_get_nexthop(struct net_route_entry *route)
 		}
 
 		ipv6_nbr_data = net_ipv6_nbr_data(nexthop_route->nbr);
-		NET_ASSERT(ipv6_nbr_data);
+		if (ipv6_nbr_data) {
+			addr = &ipv6_nbr_data->addr;
+			NET_ASSERT(addr);
 
-		addr = &ipv6_nbr_data->addr;
-		NET_ASSERT(addr);
-
-		return addr;
+			return addr;
+		} else {
+			NET_ERR("could not get neighbor data from next hop");
+		}
 	}
 
 	return NULL;

--- a/subsys/net/lib/app/net_app.c
+++ b/subsys/net/lib/app/net_app.c
@@ -2121,7 +2121,18 @@ reset:
 				u16_t pos;
 
 				frag = net_frag_get_pos(pkt, hdr_len, &pos);
-				NET_ASSERT(frag);
+				if (!frag) {
+					/* FIXME: if pos is 0 here, hdr_len
+					 * bytes were successfully skipped.
+					 * Is closing the connection here the
+					 * right thing?
+					 */
+					NET_ERR("could not skip %zu bytes",
+						hdr_len);
+					net_pkt_unref(pkt);
+					ret = -EINVAL;
+					goto close;
+				}
 
 				net_pkt_set_appdata(pkt, frag->data + pos);
 			} else {

--- a/subsys/net/lib/sockets/sockets.c
+++ b/subsys/net/lib/sockets/sockets.c
@@ -324,8 +324,12 @@ static inline ssize_t zsock_recv_stream(struct net_context *ctx,
 		}
 
 		frag = pkt->frags;
-		__ASSERT(frag != NULL,
-			 "net_pkt has empty fragments on start!");
+		if (!frag) {
+			NET_ERR("net_pkt has empty fragments on start!");
+			errno = EAGAIN;
+			return -1;
+		}
+
 		frag_len = frag->len;
 		recv_len = frag_len;
 		if (recv_len > max_len) {


### PR DESCRIPTION
After taking a look at recent patches sent by @rmstoi, I took a look at the network layer looking for assertions that were not used to test invariants -- that could very much fail during runtime -- and changed those to runtime checks.  Some of these might be bugs waiting to happen (e.g. packets are read from L2 and assertions are made on contents/size), some of these I'm not sure if are actual issues.