### PR TITLE
drivers: sensor: lsm6dsl: add SPI support

### DIFF
--- a/drivers/sensor/lsm6dsl/CMakeLists.txt
+++ b/drivers/sensor/lsm6dsl/CMakeLists.txt
@@ -1,1 +1,3 @@
-zephyr_sources_ifdef(CONFIG_LSM6DSL lsm6dsl.c)
+zephyr_sources_ifdef(CONFIG_LSM6DSL         lsm6dsl.c)
+zephyr_sources_ifdef(CONFIG_LSM6DSL_SPI     lsm6dsl_spi.c)
+zephyr_sources_ifdef(CONFIG_LSM6DSL_I2C     lsm6dsl_i2c.c)

--- a/drivers/sensor/lsm6dsl/Kconfig
+++ b/drivers/sensor/lsm6dsl/Kconfig
@@ -8,24 +8,41 @@
 #
 
 menuconfig LSM6DSL
-	bool "LSM6DSL I2C accelerometer and gyroscope Chip"
-	depends on I2C
+	bool "LSM6DSL I2C/SPI accelerometer and gyroscope Chip"
+	depends on SENSOR && (I2C || SPI)
 	default n
 	help
-	  Enable driver for LSM6DSL I2C-based accelerometer and gyroscope
+	  Enable driver for LSM6DSL accelerometer and gyroscope
 	  sensor.
 
-if !HAS_DTS_I2C_DEVICE
+choice
+	prompt "Interface to AP"
+	depends on LSM6DSL
+	default LSM6DSL_I2C
+	help
+	  Select interface the LSM6DSL driver is connected to AP
+
+config LSM6DSL_SPI
+	depends on SPI
+	bool "SPI Interface"
+
+config LSM6DSL_I2C
+	depends on I2C
+	bool "I2C Interface"
+
+endchoice
 
 config LSM6DSL_DEV_NAME
 	string "LSM6DSL device name"
-	depends on LSM6DSL
+	depends on (LSM6DSL_I2C && !HAS_DTS_I2C_DEVICE) || LSM6DSL_SPI
 	default "LSM6DSL"
+
+if !HAS_DTS_I2C_DEVICE
 
 config LSM6DSL_I2C_ADDR
 	hex
 	prompt "LSM6DSL I2C address"
-	depends on LSM6DSL
+	depends on LSM6DSL && LSM6DSL_I2C
 	default 0x6A
 	range 0x6A 0x6B
 	help
@@ -34,14 +51,61 @@ config LSM6DSL_I2C_ADDR
 	  is pulled to VCC.
 
 config LSM6DSL_I2C_MASTER_DEV_NAME
-	string "I2C master where LSM6DSL chip is connected"
-	depends on LSM6DSL
-	default I2C_0_NAME
+	string "I2C master name where LSM6DSL chip is connected"
+	depends on LSM6DSL && LSM6DSL_I2C
+	default "I2C_2"
 	help
 	  Specify the device name of the I2C master device to which LSM6DSL is
 	  connected.
 
-endif
+endif #HAS_DTS_I2C_DEVICE
+
+config LSM6DSL_SPI_SELECT_SLAVE
+	hex "LSM6DSL SPI slave select pin"
+	depends on LSM6DSL && LSM6DSL_SPI
+	default 1
+	help
+	  LSM6DSL SPI chip select pin (active low).
+
+config LSM6DSL_SPI_BUS_FREQ
+	int "LSM6DSL SPI bus speed in Hz"
+	default 8000000
+	depends on LSM6DSL && LSM6DSL_SPI
+	help
+	  This is the maximum supported SPI bus frequency. The chip supports a
+	  frequency up to 10MHz.
+
+config LSM6DSL_SPI_MASTER_DEV_NAME
+	string "SPI master name where LSM6DSL chip is connected"
+	depends on LSM6DSL && LSM6DSL_SPI
+	default "SPI_2"
+	help
+	  Specify the device name of the spi master device to which LSM6DSL is
+	  connected.
+
+config LSM6DSL_SPI_GPIO_CS
+	bool "LSM6DSL SPI CS through a GPIO pin"
+	default n
+	depends on LSM6DSL && LSM6DSL_SPI
+	help
+	  This option is useful if one needs to manage SPI CS through a GPIO
+	  pin to by-pass the SPI controller's CS logic.
+
+config LSM6DSL_SPI_GPIO_CS_DRV_NAME
+	string "GPIO driver's name to use to drive SPI CS through"
+	default ""
+	depends on LSM6DSL_SPI_GPIO_CS
+	help
+	  This option is mandatory to set which GPIO controller to use in order
+	  to actually emulate the SPI CS.
+
+config LSM6DSL_SPI_GPIO_CS_PIN
+	int "GPIO PIN to use to drive SPI CS through"
+	default 0
+	depends on LSM6DSL_SPI_GPIO_CS
+	help
+	  This option is mandatory to set which GPIO pin to use in order
+	  to actually emulate the SPI CS.
 
 config LSM6DSL_ENABLE_TEMP
 	bool "Enable temperature"

--- a/drivers/sensor/lsm6dsl/lsm6dsl.h
+++ b/drivers/sensor/lsm6dsl/lsm6dsl.h
@@ -12,7 +12,6 @@
 #define __SENSOR_LSM6DSL_H__
 
 #include <zephyr/types.h>
-#include <i2c.h>
 #include <misc/util.h>
 
 
@@ -689,12 +688,24 @@
 #endif
 
 struct lsm6dsl_config {
-	char *i2c_master_dev_name;
-	u16_t i2c_slave_addr;
+	char *comm_master_dev_name;
+};
+
+struct lsm6dsl_data;
+
+struct lsm6dsl_transfer_function {
+	int (*read_data)(struct lsm6dsl_data *data, u8_t reg_addr,
+			 u8_t *value, u8_t len);
+	int (*write_data)(struct lsm6dsl_data *data, u8_t reg_addr,
+			  u8_t *value, u8_t len);
+	int (*read_reg)(struct lsm6dsl_data *data, u8_t reg_addr,
+			u8_t *value);
+	int (*update_reg)(struct lsm6dsl_data *data, u8_t reg_addr,
+			  u8_t mask, u8_t value);
 };
 
 struct lsm6dsl_data {
-	struct device *i2c_master;
+	struct device *comm_master;
 	int accel_sample_x;
 	int accel_sample_y;
 	int accel_sample_z;
@@ -704,7 +715,11 @@ struct lsm6dsl_data {
 #if defined(CONFIG_LSM6DSL_ENABLE_TEMP)
 	int temp_sample;
 #endif
+	const struct lsm6dsl_transfer_function *hw_tf;
 };
+
+int lsm6dsl_spi_init(struct device *dev);
+int lsm6dsl_i2c_init(struct device *dev);
 
 #define SYS_LOG_DOMAIN "LSM6DSL"
 #define SYS_LOG_LEVEL CONFIG_SYS_LOG_SENSOR_LEVEL

--- a/drivers/sensor/lsm6dsl/lsm6dsl_i2c.c
+++ b/drivers/sensor/lsm6dsl/lsm6dsl_i2c.c
@@ -1,0 +1,58 @@
+/* lsm6dsl_i2c.c - I2C routines for LSM6DSL driver
+ */
+
+/*
+ * Copyright (c) 2018 STMicroelectronics
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <string.h>
+#include <i2c.h>
+#include "lsm6dsl.h"
+
+static u16_t lsm6dsl_i2c_slave_addr = CONFIG_LSM6DSL_I2C_ADDR;
+
+static int lsm6dsl_i2c_read_data(struct lsm6dsl_data *data, u8_t reg_addr,
+				 u8_t *value, u8_t len)
+{
+	return i2c_burst_read(data->comm_master, lsm6dsl_i2c_slave_addr,
+			      reg_addr, value, len);
+}
+
+static int lsm6dsl_i2c_write_data(struct lsm6dsl_data *data, u8_t reg_addr,
+				  u8_t *value, u8_t len)
+{
+	return i2c_burst_write(data->comm_master, lsm6dsl_i2c_slave_addr,
+			       reg_addr, value, len);
+}
+
+static int lsm6dsl_i2c_read_reg(struct lsm6dsl_data *data, u8_t reg_addr,
+				u8_t *value)
+{
+	return i2c_reg_read_byte(data->comm_master, lsm6dsl_i2c_slave_addr,
+				 reg_addr, value);
+}
+
+static int lsm6dsl_i2c_update_reg(struct lsm6dsl_data *data, u8_t reg_addr,
+				  u8_t mask, u8_t value)
+{
+	return i2c_reg_update_byte(data->comm_master, lsm6dsl_i2c_slave_addr,
+				   reg_addr, mask, value);
+}
+
+static const struct lsm6dsl_transfer_function lsm6dsl_i2c_transfer_fn = {
+	.read_data = lsm6dsl_i2c_read_data,
+	.write_data = lsm6dsl_i2c_write_data,
+	.read_reg  = lsm6dsl_i2c_read_reg,
+	.update_reg = lsm6dsl_i2c_update_reg,
+};
+
+int lsm6dsl_i2c_init(struct device *dev)
+{
+	struct lsm6dsl_data *data = dev->driver_data;
+
+	data->hw_tf = &lsm6dsl_i2c_transfer_fn;
+
+	return 0;
+}

--- a/drivers/sensor/lsm6dsl/lsm6dsl_spi.c
+++ b/drivers/sensor/lsm6dsl/lsm6dsl_spi.c
@@ -1,0 +1,157 @@
+/* lsm6dsl_spi.c - SPI routines for LSM6DSL driver
+ */
+
+/*
+ * Copyright (c) 2018 STMicroelectronics
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <string.h>
+#include <spi.h>
+#include "lsm6dsl.h"
+
+#define LSM6DSL_SPI_READ		(1 << 7)
+
+#if defined(CONFIG_LSM6DSL_SPI_GPIO_CS)
+static struct spi_cs_control lsm6dsl_cs_ctrl;
+#endif
+
+#define SPI_CS NULL
+
+static struct spi_config lsm6dsl_spi_conf = {
+	.frequency = CONFIG_LSM6DSL_SPI_BUS_FREQ,
+	.operation = (SPI_OP_MODE_MASTER | SPI_MODE_CPOL |
+		      SPI_MODE_CPHA | SPI_WORD_SET(8) | SPI_LINES_SINGLE),
+	.slave     = CONFIG_LSM6DSL_SPI_SELECT_SLAVE,
+	.cs        = SPI_CS,
+};
+
+static int lsm6dsl_raw_read(struct spi_config *spi_cfg, u8_t reg_addr,
+			    u8_t *value, u8_t len)
+{
+	u8_t buffer_tx[2] = {reg_addr | LSM6DSL_SPI_READ, 0};
+	const struct spi_buf tx_buf = {
+			.buf = buffer_tx,
+			.len = 2,
+	};
+	struct spi_buf rx_buf[2] = {
+		{
+			.buf = NULL,
+			.len = 1,
+		},
+		{
+			.buf = value,
+			.len = len,
+		}
+	};
+
+	if (len > 64) {
+		return -EIO;
+	}
+
+	if (spi_transceive(spi_cfg, &tx_buf, 1, rx_buf, 2)) {
+		return -EIO;
+	}
+
+	return 0;
+}
+
+static int lsm6dsl_raw_write(struct spi_config *spi_cfg, u8_t reg_addr,
+			     u8_t *value, u8_t len)
+{
+	u8_t buffer_tx[1] = {reg_addr & ~LSM6DSL_SPI_READ};
+	struct spi_buf tx_buf[2] = {
+		{
+			.buf = buffer_tx,
+			.len = 1,
+		},
+		{
+			.buf = value,
+			.len = len,
+		}
+	};
+
+	if (len > 64) {
+		return -EIO;
+	}
+
+	if (spi_transceive(spi_cfg, tx_buf, 2, NULL, 0)) {
+		return -EIO;
+	}
+
+	return 0;
+}
+
+static int lsm6dsl_spi_read_data(struct lsm6dsl_data *data, u8_t reg_addr,
+				 u8_t *value, u8_t len)
+{
+	struct spi_config *spi_cfg = &lsm6dsl_spi_conf;
+
+	return lsm6dsl_raw_read(spi_cfg, reg_addr, value, len);
+}
+
+static int lsm6dsl_spi_write_data(struct lsm6dsl_data *data, u8_t reg_addr,
+				  u8_t *value, u8_t len)
+{
+	struct spi_config *spi_cfg = &lsm6dsl_spi_conf;
+
+	return lsm6dsl_raw_write(spi_cfg, reg_addr, value, len);
+}
+
+static int lsm6dsl_spi_read_reg(struct lsm6dsl_data *data, u8_t reg_addr,
+				u8_t *value)
+{
+	struct spi_config *spi_cfg = &lsm6dsl_spi_conf;
+
+	return lsm6dsl_raw_read(spi_cfg, reg_addr, value, 1);
+}
+
+static int lsm6dsl_spi_update_reg(struct lsm6dsl_data *data, u8_t reg_addr,
+				  u8_t mask, u8_t value)
+{
+	struct spi_config *spi_cfg = &lsm6dsl_spi_conf;
+	u8_t tmp_val;
+
+	lsm6dsl_raw_read(spi_cfg, reg_addr, &tmp_val, 1);
+	tmp_val = (tmp_val & ~mask) | (value & mask);
+	return lsm6dsl_raw_write(spi_cfg, reg_addr, &tmp_val, 1);
+}
+
+static const struct lsm6dsl_transfer_function lsm6dsl_spi_transfer_fn = {
+	.read_data = lsm6dsl_spi_read_data,
+	.write_data = lsm6dsl_spi_write_data,
+	.read_reg  = lsm6dsl_spi_read_reg,
+	.update_reg = lsm6dsl_spi_update_reg,
+};
+
+int lsm6dsl_spi_init(struct device *dev)
+{
+	struct lsm6dsl_data *data = dev->driver_data;
+
+	lsm6dsl_spi_conf.dev = data->comm_master;
+	data->hw_tf = &lsm6dsl_spi_transfer_fn;
+
+#if defined(CONFIG_LSM6DSL_SPI_GPIO_CS)
+	/* handle SPI CS thru GPIO if it is the case */
+	if (IS_ENABLED(CONFIG_LSM6DSL_SPI_GPIO_CS)) {
+		lsm6dsl_cs_ctrl.gpio_dev = device_get_binding(
+			CONFIG_LSM6DSL_SPI_GPIO_CS_DRV_NAME);
+		if (!lsm6dsl_cs_ctrl.gpio_dev) {
+			SYS_LOG_ERR("Unable to get GPIO SPI CS device");
+			return -ENODEV;
+		}
+
+		lsm6dsl_cs_ctrl.gpio_pin = CONFIG_LSM6DSL_SPI_GPIO_CS_PIN;
+		lsm6dsl_cs_ctrl.delay = 0;
+
+		lsm6dsl_spi_conf.cs = &lsm6dsl_cs_ctrl;
+
+		SYS_LOG_DBG("SPI GPIO CS configured on %s:%u",
+			    CONFIG_LSM6DSL_SPI_GPIO_CS_DRV_NAME,
+			    CONFIG_LSM6DSL_SPI_GPIO_CS_PIN);
+	}
+#endif
+
+	return 0;
+}


### PR DESCRIPTION
Add SPI bus support to LSM6DSL sensor. The bus routines (i.e. I2C
and SPI) are defined in separate files, where proper r/w callbacks
are registered. SPI support in driver is currently not providing
the capability of using gpios as CS.

Signed-off-by: Armando Visconti <armando.visconti@st.com>