### PR TITLE
arch: arm: SecureFault Handling for Cortex-M33

### DIFF
--- a/arch/arm/core/Kconfig
+++ b/arch/arm/core/Kconfig
@@ -42,6 +42,23 @@ config ARM_STACK_PROTECTION
 	  This option enables MPU stack guard to cause a system fatal error
 	  if the bounds of the current process stack are overflowed.
 
+config ARM_SECURE_FIRMWARE
+	bool
+	default n
+	help
+	  This option enables Zephyr to include code that executes in
+	  Secure state, as well as to exclude code that is designed to
+	  execute only in Non-secure state. The option is only applicable
+	  to ARMv8-M MCUs that implement the Security Extension.
+
+	  Code executing in Secure state has access to both the Secure
+	  and Non-Secure resources of the Cortex-M MCU.
+
+	  Code executing in Non-Secure state may trigger Secure Faults,
+	  if Secure MCU resources are accessed from the Non-Secure state.
+	  Secure Faults may only be handled by code executing in Secure
+	  state.
+
 menu "Architectue Floating Point Options"
 depends on CPU_HAS_FPU
 

--- a/arch/arm/core/cortex_m/vector_table.S
+++ b/arch/arm/core/cortex_m/vector_table.S
@@ -53,7 +53,11 @@ SECTION_SUBSEC_FUNC(exc_vector_table,_vector_table_section,_vector_table)
     .word __mpu_fault
     .word __bus_fault
     .word __usage_fault
+#if defined(CONFIG_ARM_SECURE_FIRMWARE)
+    .word __secure_fault
+#else
     .word __reserved
+#endif /* CONFIG_ARM_SECURE_FIRMWARE */
     .word __reserved
     .word __reserved
     .word __reserved

--- a/arch/arm/core/cortex_m/vector_table.h
+++ b/arch/arm/core/cortex_m/vector_table.h
@@ -44,6 +44,9 @@ GTEXT(__svc)
 GTEXT(__mpu_fault)
 GTEXT(__bus_fault)
 GTEXT(__usage_fault)
+#if defined(CONFIG_ARM_SECURE_FIRMWARE)
+GTEXT(__secure_fault)
+#endif /* CONFIG_ARM_SECURE_FIRMWARE */
 GTEXT(__svc)
 GTEXT(__debug_monitor)
 #else

--- a/arch/arm/core/fault_s.S
+++ b/arch/arm/core/fault_s.S
@@ -26,6 +26,9 @@ GTEXT(__hard_fault)
 GTEXT(__mpu_fault)
 GTEXT(__bus_fault)
 GTEXT(__usage_fault)
+#if defined(CONFIG_ARM_SECURE_FIRMWARE)
+GTEXT(__secure_fault)
+#endif /* CONFIG_ARM_SECURE_FIRMWARE*/
 GTEXT(__debug_monitor)
 #else
 #error Unknown ARM architecture
@@ -51,6 +54,7 @@ GTEXT(__reserved)
  *   __mpu_fault
  *   __bus_fault
  *   __usage_fault
+ *   __secure_fault
  *   __debug_monitor
  *   __reserved
  */
@@ -62,6 +66,9 @@ SECTION_SUBSEC_FUNC(TEXT,__fault,__hard_fault)
 SECTION_SUBSEC_FUNC(TEXT,__fault,__mpu_fault)
 SECTION_SUBSEC_FUNC(TEXT,__fault,__bus_fault)
 SECTION_SUBSEC_FUNC(TEXT,__fault,__usage_fault)
+#if defined(CONFIG_ARM_SECURE_FIRMWARE)
+SECTION_SUBSEC_FUNC(TEXT,__fault,__secure_fault)
+#endif /* CONFIG_ARM_SECURE_FIRMWARE */
 SECTION_SUBSEC_FUNC(TEXT,__fault,__debug_monitor)
 #else
 #error Unknown ARM architecture

--- a/arch/arm/include/cortex_m/exc.h
+++ b/arch/arm/include/cortex_m/exc.h
@@ -102,10 +102,24 @@ static ALWAYS_INLINE void _ExcSetup(void)
 	NVIC_SetPriority(MemoryManagement_IRQn, _EXC_FAULT_PRIO);
 	NVIC_SetPriority(BusFault_IRQn, _EXC_FAULT_PRIO);
 	NVIC_SetPriority(UsageFault_IRQn, _EXC_FAULT_PRIO);
+#if defined(CONFIG_ARM_SECURE_FIRMWARE)
+	NVIC_SetPriority(SecureFault_IRQn, _EXC_FAULT_PRIO);
+#endif /* CONFIG_ARM_SECURE_FIRMWARE */
 
 	/* Enable Usage, Mem, & Bus Faults */
 	SCB->SHCSR |= SCB_SHCSR_USGFAULTENA_Msk | SCB_SHCSR_MEMFAULTENA_Msk |
 		      SCB_SHCSR_BUSFAULTENA_Msk;
+#if defined(CONFIG_ARM_SECURE_FIRMWARE)
+	/* Enable Secure Fault */
+	SCB->SHCSR |= SCB_SHCSR_SECUREFAULTENA_Msk;
+	/* Clear BFAR before setting BusFaults to target Non-Secure state. */
+	SCB->BFAR = 0;
+	/* Set NMI, Hard, and Bus Faults as Non-Secure.
+	 * NMI and Bus Faults targeting the Secure state will
+	 * escalate to a SecureFault or SecureHardFault.
+	 */
+	SCB->AIRCR |= SCB_AIRCR_BFHFNMINS_Msk;
+#endif /* CONFIG_ARM_SECURE_FIRMWARE */
 #endif
 }
 


### PR DESCRIPTION
This pull request contributes the implementation of the SecureFault
handling for ARMv8-M-based Cortex-M33. The implementation is
compiled conditionally with compile-time directive
CONFIG_ARM_SECURE_FIRMWARE, which is to signify the intention to
build a Secure image on ARMv8-M with Security Extensions.

This PR implements #6372 for Cortex-M33. 
Consult #6372 for further details.

Signed-off-by: Ioannis Glaropoulos <Ioannis.Glaropoulos@nordicsemi.no>