### PR TITLE
doc: boards: Fixed doc. output with hello_world sample

### DIFF
--- a/boards/arm/sam_e70_xplained/doc/sam_e70_xplained.rst
+++ b/boards/arm/sam_e70_xplained/doc/sam_e70_xplained.rst
@@ -127,7 +127,7 @@ Flashing
       :board: sam_e70_xplained
       :goals: build flash
 
-   You should see "Hello World!" in your terminal.
+   You should see "Hello World! arm" in your terminal.
 
 You can flash the image using an external debug adapter such as J-Link
 or ULINK, connected to the 20-pin JTAG header. Supply the name of the


### PR DESCRIPTION
Fixed the output string in the documentation for
the SAM E70 Xplained. The output for the hello_world
sample wasn't correct.

Signed-off-by: Justin Watson <jwatson5@gmail.com>