### PR TITLE
net: http: HTTP library bugfixes

### DIFF
--- a/include/net/http.h
+++ b/include/net/http.h
@@ -767,7 +767,7 @@ static inline int http_client_send_get_req(struct http_ctx *http_ctx,
 		.method = HTTP_GET,
 		.url = url,
 		.host = host,
-		.protocol = " " HTTP_PROTOCOL HTTP_CRLF,
+		.protocol = " " HTTP_PROTOCOL,
 		.header_fields = extra_header_fields,
 	};
 

--- a/subsys/net/lib/http/http.c
+++ b/subsys/net/lib/http/http.c
@@ -149,16 +149,14 @@ int http_prepare_and_send(struct http_ctx *ctx,
 		payload_len -= added;
 		if (payload_len) {
 			payload += added;
+			/* Not all data could be added, send what we have now
+			 * and allocate new stuff to be sent.
+			 */
+			ret = http_send_flush(ctx, user_send_data);
+			if (ret < 0) {
+				goto error;
+			}
 		}
-
-		/* Not all data could be added, send what we have now
-		 * and allocate new stuff to be sent.
-		 */
-		ret = http_send_flush(ctx, user_send_data);
-		if (ret < 0) {
-			goto error;
-		}
-
 	} while (payload_len);
 
 	return 0;

--- a/subsys/net/lib/http/http_client.c
+++ b/subsys/net/lib/http/http_client.c
@@ -38,6 +38,9 @@
 #define HTTP_CONTENT_LEN   "Content-Length"
 #define HTTP_CONT_LEN_SIZE 6
 
+/* Default network activity timeout in seconds */
+#define HTTP_NETWORK_TIMEOUT	K_SECONDS(CONFIG_HTTP_CLIENT_NETWORK_TIMEOUT)
+
 int client_reset(struct http_ctx *ctx)
 {
 	http_parser_init(&ctx->http.parser, HTTP_RESPONSE);
@@ -235,7 +238,7 @@ int http_client_send_req(struct http_ctx *ctx,
 
 	ctx->http.rsp.cb = cb;
 
-	ret = net_app_connect(&ctx->app_ctx, timeout);
+	ret = net_app_connect(&ctx->app_ctx, HTTP_NETWORK_TIMEOUT);
 	if (ret < 0) {
 		NET_DBG("Cannot connect to server (%d)", ret);
 		return ret;
@@ -244,7 +247,7 @@ int http_client_send_req(struct http_ctx *ctx,
 	/* We might wait longer than timeout if the first connection
 	 * establishment takes long time (like with HTTPS)
 	 */
-	if (k_sem_take(&ctx->http.connect_wait, timeout)) {
+	if (k_sem_take(&ctx->http.connect_wait, HTTP_NETWORK_TIMEOUT)) {
 		NET_DBG("Connection timed out");
 		ret = -ETIMEDOUT;
 		goto out;

--- a/subsys/net/lib/http/http_client.c
+++ b/subsys/net/lib/http/http_client.c
@@ -123,7 +123,6 @@ int http_request(struct http_ctx *ctx, struct http_request *req, s32_t timeout,
 
 	if (req->payload && req->payload_size) {
 		char content_len_str[HTTP_CONT_LEN_SIZE];
-		int i;
 
 		ret = snprintk(content_len_str, HTTP_CONT_LEN_SIZE,
 			       "%u", req->payload_size);
@@ -143,17 +142,10 @@ int http_request(struct http_ctx *ctx, struct http_request *req, s32_t timeout,
 			goto out;
 		}
 
-		for (i = 0; i < req->payload_size;) {
-			ret = http_send_chunk(ctx,
-					      req->payload + i,
-					      req->payload_size - i,
-					      user_data);
-			if (ret < 0) {
-				NET_ERR("Cannot send data to peer (%d)", ret);
-				return ret;
-			}
-
-			i += ret;
+		ret = http_prepare_and_send(ctx, req->payload,
+					    req->payload_size, user_data);
+		if (ret < 0) {
+			goto out;
 		}
 	} else {
 		ret = http_add_header(ctx, HTTP_EOF, user_data);

--- a/subsys/net/lib/http/http_client.c
+++ b/subsys/net/lib/http/http_client.c
@@ -423,6 +423,13 @@ static int on_headers_complete(struct http_parser *parser)
 		return 1;
 	}
 
+	if ((ctx->http.req.method == HTTP_PUT ||
+	     ctx->http.req.method == HTTP_POST)
+	    && ctx->http.rsp.content_length == 0) {
+		NET_DBG("No body expected");
+		return 1;
+	}
+
 	NET_DBG("Headers complete");
 
 	return 0;


### PR DESCRIPTION
This patch series cleans up several issues w/ the new API (some of which were fixed in the previous API but not carried forward):
- When HTTP server responds to PUT/POST requests with no body (IE: status code in headers only) the request will timeout
- The "timeout" parameter in http_client_send_req() was being used for TCP connection.  In some cases users call this with K_NO_WAIT so that it was immediately returning an -ETIMEDOUT error.  Previous API used a different value to avoid that behavior.
- Patch 9489fa54cc3c0225b094886a1a04e02508d56704 ("net: http: Fix http_prepare_and_send") added incorrect http_send_flush() logic so that every incoming data will be flushed.
- When using http_client_send_get_req() an additional CRLF would be added to the protocol header letting servers think that the headers ended there.