### PR TITLE
drivers: sensors: Enable LSM6DS0 GYRO sampling rate

### DIFF
--- a/drivers/sensor/lsm6ds0/Kconfig
+++ b/drivers/sensor/lsm6ds0/Kconfig
@@ -114,7 +114,7 @@ config LSM6DS0_GYRO_FULLSCALE
 config LSM6DS0_GYRO_SAMPLING_RATE
 	int
 	prompt "Output data rate"
-	depends on LIS3MDL
+	depends on LSM6DS0
 	default 15
 	help
 	  Specify the default gyroscope output data rate expressed in samples


### PR DESCRIPTION
The dependency in Kconfig to choose the GYRO sampling rate is using the wrong sensor, resulting in the sampling rate being not configurable.

Signed-off-by: Philémon Jaermann <p.jaermann@gmail.com>