### PR TITLE
drivers: gpio: nrf5: Add support for port P1 in nRF52840 SoC

### DIFF
--- a/boards/arm/nrf51_pca10028/board.h
+++ b/boards/arm/nrf51_pca10028/board.h
@@ -1,4 +1,5 @@
 /*
+ * Copyright (c) 2018 Nordic Semiconductor ASA.
  * Copyright (c) 2016 Linaro Limited.
  *
  * SPDX-License-Identifier: Apache-2.0
@@ -10,35 +11,39 @@
 #include <soc.h>
 
 /* Push button switch 0 */
-#define SW0_GPIO_PIN	17
-#define SW0_GPIO_NAME	CONFIG_GPIO_NRF5_P0_DEV_NAME
+#define SW0_GPIO_PIN     17
+#define SW0_GPIO_NAME    CONFIG_GPIO_NRF5_P0_DEV_NAME
+#define SW0_GPIO_PIN_PUD GPIO_PUD_PULL_UP
 
 /* Push button switch 1 */
-#define SW1_GPIO_PIN	18
-#define SW1_GPIO_NAME	CONFIG_GPIO_NRF5_P0_DEV_NAME
+#define SW1_GPIO_PIN     18
+#define SW1_GPIO_NAME    CONFIG_GPIO_NRF5_P0_DEV_NAME
+#define SW1_GPIO_PIN_PUD GPIO_PUD_PULL_UP
 
 /* Push button switch 2 */
-#define SW2_GPIO_PIN	19
-#define SW2_GPIO_NAME	CONFIG_GPIO_NRF5_P0_DEV_NAME
+#define SW2_GPIO_PIN     19
+#define SW2_GPIO_NAME    CONFIG_GPIO_NRF5_P0_DEV_NAME
+#define SW2_GPIO_PIN_PUD GPIO_PUD_PULL_UP
 
 /* Push button switch 3 */
-#define SW3_GPIO_PIN	20
-#define SW3_GPIO_NAME	CONFIG_GPIO_NRF5_P0_DEV_NAME
+#define SW3_GPIO_PIN     20
+#define SW3_GPIO_NAME    CONFIG_GPIO_NRF5_P0_DEV_NAME
+#define SW3_GPIO_PIN_PUD GPIO_PUD_PULL_UP
 
 /* Onboard GREEN LED 0 */
-#define LED0_GPIO_PIN   21
-#define LED0_GPIO_PORT  CONFIG_GPIO_NRF5_P0_DEV_NAME
+#define LED0_GPIO_PIN  21
+#define LED0_GPIO_PORT CONFIG_GPIO_NRF5_P0_DEV_NAME
 
 /* Onboard GREEN LED 1 */
-#define LED1_GPIO_PIN   22
-#define LED1_GPIO_PORT  CONFIG_GPIO_NRF5_P0_DEV_NAME
+#define LED1_GPIO_PIN  22
+#define LED1_GPIO_PORT CONFIG_GPIO_NRF5_P0_DEV_NAME
 
 /* Onboard GREEN LED 2 */
-#define LED2_GPIO_PIN   23
-#define LED2_GPIO_PORT  CONFIG_GPIO_NRF5_P0_DEV_NAME
+#define LED2_GPIO_PIN  23
+#define LED2_GPIO_PORT CONFIG_GPIO_NRF5_P0_DEV_NAME
 
 /* Onboard GREEN LED 3 */
-#define LED3_GPIO_PIN   24
-#define LED3_GPIO_PORT  CONFIG_GPIO_NRF5_P0_DEV_NAME
+#define LED3_GPIO_PIN  24
+#define LED3_GPIO_PORT CONFIG_GPIO_NRF5_P0_DEV_NAME
 
 #endif /* __INC_BOARD_H */

--- a/boards/arm/nrf52840_pca10056/board.h
+++ b/boards/arm/nrf52840_pca10056/board.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016 Nordic Semiconductor ASA.
+ * Copyright (c) 2016-2018 Nordic Semiconductor ASA.
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -10,35 +10,39 @@
 #include <soc.h>
 
 /* Push button switch 0 */
-#define SW0_GPIO_PIN	11
-#define SW0_GPIO_NAME	CONFIG_GPIO_NRF5_P0_DEV_NAME
+#define SW0_GPIO_PIN     11
+#define SW0_GPIO_NAME    CONFIG_GPIO_NRF5_P0_DEV_NAME
+#define SW0_GPIO_PIN_PUD GPIO_PUD_PULL_UP
 
 /* Push button switch 1 */
-#define SW1_GPIO_PIN	12
-#define SW1_GPIO_NAME	CONFIG_GPIO_NRF5_P0_DEV_NAME
+#define SW1_GPIO_PIN     12
+#define SW1_GPIO_NAME    CONFIG_GPIO_NRF5_P0_DEV_NAME
+#define SW1_GPIO_PIN_PUD GPIO_PUD_PULL_UP
 
 /* Push button switch 2 */
-#define SW2_GPIO_PIN	24
-#define SW2_GPIO_NAME	CONFIG_GPIO_NRF5_P0_DEV_NAME
+#define SW2_GPIO_PIN     24
+#define SW2_GPIO_NAME    CONFIG_GPIO_NRF5_P0_DEV_NAME
+#define SW2_GPIO_PIN_PUD GPIO_PUD_PULL_UP
 
 /* Push button switch 3 */
-#define SW3_GPIO_PIN	25
-#define SW3_GPIO_NAME	CONFIG_GPIO_NRF5_P0_DEV_NAME
+#define SW3_GPIO_PIN     25
+#define SW3_GPIO_NAME    CONFIG_GPIO_NRF5_P0_DEV_NAME
+#define SW3_GPIO_PIN_PUD GPIO_PUD_PULL_UP
 
 /* Onboard GREEN LED 0 */
-#define LED0_GPIO_PIN   13
-#define LED0_GPIO_PORT  CONFIG_GPIO_NRF5_P0_DEV_NAME
+#define LED0_GPIO_PIN  13
+#define LED0_GPIO_PORT CONFIG_GPIO_NRF5_P0_DEV_NAME
 
 /* Onboard GREEN LED 1 */
-#define LED1_GPIO_PIN   14
-#define LED1_GPIO_PORT  CONFIG_GPIO_NRF5_P0_DEV_NAME
+#define LED1_GPIO_PIN  14
+#define LED1_GPIO_PORT CONFIG_GPIO_NRF5_P0_DEV_NAME
 
 /* Onboard GREEN LED 2 */
-#define LED2_GPIO_PIN   15
-#define LED2_GPIO_PORT  CONFIG_GPIO_NRF5_P0_DEV_NAME
+#define LED2_GPIO_PIN  15
+#define LED2_GPIO_PORT CONFIG_GPIO_NRF5_P0_DEV_NAME
 
 /* Onboard GREEN LED 3 */
-#define LED3_GPIO_PIN   16
-#define LED3_GPIO_PORT  CONFIG_GPIO_NRF5_P0_DEV_NAME
+#define LED3_GPIO_PIN  16
+#define LED3_GPIO_PORT CONFIG_GPIO_NRF5_P0_DEV_NAME
 
 #endif /* __INC_BOARD_H */

--- a/boards/arm/nrf52_pca10040/board.h
+++ b/boards/arm/nrf52_pca10040/board.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016 Nordic Semiconductor ASA.
+ * Copyright (c) 2016-2018 Nordic Semiconductor ASA.
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -10,36 +10,39 @@
 #include <soc.h>
 
 /* Push button switch 0 */
-#define SW0_GPIO_PIN	13
-#define SW0_GPIO_NAME	CONFIG_GPIO_NRF5_P0_DEV_NAME
+#define SW0_GPIO_PIN     13
+#define SW0_GPIO_NAME    CONFIG_GPIO_NRF5_P0_DEV_NAME
 #define SW0_GPIO_PIN_PUD GPIO_PUD_PULL_UP
 
 /* Push button switch 1 */
-#define SW1_GPIO_PIN	14
-#define SW1_GPIO_NAME	CONFIG_GPIO_NRF5_P0_DEV_NAME
+#define SW1_GPIO_PIN     14
+#define SW1_GPIO_NAME    CONFIG_GPIO_NRF5_P0_DEV_NAME
+#define SW1_GPIO_PIN_PUD GPIO_PUD_PULL_UP
 
 /* Push button switch 2 */
-#define SW2_GPIO_PIN	15
-#define SW2_GPIO_NAME	CONFIG_GPIO_NRF5_P0_DEV_NAME
+#define SW2_GPIO_PIN     15
+#define SW2_GPIO_NAME    CONFIG_GPIO_NRF5_P0_DEV_NAME
+#define SW2_GPIO_PIN_PUD GPIO_PUD_PULL_UP
 
 /* Push button switch 3 */
-#define SW3_GPIO_PIN	16
-#define SW3_GPIO_NAME	CONFIG_GPIO_NRF5_P0_DEV_NAME
+#define SW3_GPIO_PIN     16
+#define SW3_GPIO_NAME    CONFIG_GPIO_NRF5_P0_DEV_NAME
+#define SW3_GPIO_PIN_PUD GPIO_PUD_PULL_UP
 
 /* Onboard GREEN LED 0 */
-#define LED0_GPIO_PIN   17
-#define LED0_GPIO_PORT  CONFIG_GPIO_NRF5_P0_DEV_NAME
+#define LED0_GPIO_PIN  17
+#define LED0_GPIO_PORT CONFIG_GPIO_NRF5_P0_DEV_NAME
 
 /* Onboard GREEN LED 1 */
-#define LED1_GPIO_PIN   18
-#define LED1_GPIO_PORT  CONFIG_GPIO_NRF5_P0_DEV_NAME
+#define LED1_GPIO_PIN  18
+#define LED1_GPIO_PORT CONFIG_GPIO_NRF5_P0_DEV_NAME
 
 /* Onboard GREEN LED 2 */
-#define LED2_GPIO_PIN   19
-#define LED2_GPIO_PORT  CONFIG_GPIO_NRF5_P0_DEV_NAME
+#define LED2_GPIO_PIN  19
+#define LED2_GPIO_PORT CONFIG_GPIO_NRF5_P0_DEV_NAME
 
 /* Onboard GREEN LED 3 */
-#define LED3_GPIO_PIN   20
-#define LED3_GPIO_PORT  CONFIG_GPIO_NRF5_P0_DEV_NAME
+#define LED3_GPIO_PIN  20
+#define LED3_GPIO_PORT CONFIG_GPIO_NRF5_P0_DEV_NAME
 
 #endif /* __INC_BOARD_H */

--- a/drivers/gpio/Kconfig.nrf5
+++ b/drivers/gpio/Kconfig.nrf5
@@ -1,4 +1,4 @@
-# Kconfig.nrf5 - Nordic Semiconductor nRF5X GPIO configuration options
+# Kconfig.nrf5 - Nordic Semiconductor nRF5x GPIO configuration options
 #
 # Copyright (c) 2016-2018 Nordic Semiconductor ASA
 #
@@ -6,17 +6,15 @@
 #
 
 menuconfig GPIO_NRF5
-	bool "Nordic Semiconductor nRF5X-based GPIO driver"
+	bool "Nordic Semiconductor nRF5x-based GPIO driver"
 	depends on GPIO && SOC_FAMILY_NRF
-	default n
 	help
 	  Enable GPIO driver for nRF5 line of MCUs.
 
 if GPIO_NRF5
 
 config GPIO_NRF5_P0
-	bool "nRF5x GPIO Port P0 options"
-	default n
+	bool "nRF5x GPIO Port P0"
 	help
 	  Enable nRF5 GPIO port P0 config options.
 
@@ -27,14 +25,27 @@ config GPIO_NRF5_P0_DEV_NAME
 	help
 	  Specify the device name to be used for the GPIO port.
 
-config GPIO_NRF5_PORT_P0_PRI
-	int "GPIOTE P0 interrupt priority"
-	depends on GPIO_NRF5_P0
+config GPIO_NRF5_P1
+	bool "nRF5x GPIO Port P1"
+	depends on SOC_NRF52840
+	help
+	  Enable nRF5 GPIO port P1 config options.
+
+config GPIO_NRF5_P1_DEV_NAME
+	string "GPIO Port P1 Device Name"
+	depends on GPIO_NRF5_P1
+	default "GPIO_1"
+	help
+	  Specify the device name to be used for the GPIO port.
+
+config GPIOTE_NRF5_PRI
+	int "GPIOTE interrupt priority"
+	depends on GPIO_NRF5_P0 || GPIO_NRF5_P1
 	range 0 2 if SOC_SERIES_NRF51X
 	range 0 5 if SOC_SERIES_NRF52X
 	default 2 if SOC_SERIES_NRF51X
 	default 5 if SOC_SERIES_NRF52X
 	help
-	  nRF5X Port P0 IRQ priority.
+	  nRF5 GPIOTE IRQ priority.
 
 endif # GPIO_NRF5

--- a/drivers/gpio/Kconfig.nrf5
+++ b/drivers/gpio/Kconfig.nrf5
@@ -1,6 +1,6 @@
 # Kconfig.nrf5 - Nordic Semiconductor nRF5X GPIO configuration options
 #
-# Copyright (c) 2016 Nordic Semiconductor ASA
+# Copyright (c) 2016-2018 Nordic Semiconductor ASA
 #
 # SPDX-License-Identifier: Apache-2.0
 #
@@ -30,9 +30,10 @@ config GPIO_NRF5_P0_DEV_NAME
 config GPIO_NRF5_PORT_P0_PRI
 	int "GPIOTE P0 interrupt priority"
 	depends on GPIO_NRF5_P0
-	range 0 1 if SOC_SERIES_NRF51X
+	range 0 2 if SOC_SERIES_NRF51X
 	range 0 5 if SOC_SERIES_NRF52X
-	default 1
+	default 2 if SOC_SERIES_NRF51X
+	default 5 if SOC_SERIES_NRF52X
 	help
 	  nRF5X Port P0 IRQ priority.
 

--- a/drivers/gpio/gpio_nrf5.c
+++ b/drivers/gpio/gpio_nrf5.c
@@ -245,8 +245,7 @@ static int gpio_nrf5_config(struct device *dev,
 			/*@todo: use SENSE for this? */
 			return -ENOTSUP;
 		}
-		if (__builtin_popcount(gpiote_chan_mask) ==
-				GPIOTE_CHAN_COUNT) {
+		if (popcount(gpiote_chan_mask) == GPIOTE_CHAN_COUNT) {
 			return -EIO;
 		}
 
@@ -255,7 +254,7 @@ static int gpio_nrf5_config(struct device *dev,
 
 		if (i < 0) {
 			/* allocate a GPIOTE channel */
-			i = __builtin_ffs(~gpiote_chan_mask) - 1;
+			i = find_lsb_set(~gpiote_chan_mask) - 1;
 		}
 
 		gpiote_chan_mask |= BIT(i);

--- a/drivers/gpio/gpio_nrf5.c
+++ b/drivers/gpio/gpio_nrf5.c
@@ -1,6 +1,6 @@
 /*
+ * Copyright (c) 2016-2018 Nordic Semiconductor ASA
  * Copyright (c) 2017 ARM Ltd
- * Copyright (c) 2016 Nordic Semiconductor ASA
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -65,14 +65,15 @@ struct _gpiote {
 	__IO u32_t CONFIG[8];
 };
 
+/*@todo: move GPIOTE channel management to a separate module */
+static u32_t gpiote_chan_mask;
+
 /** Configuration data */
 struct gpio_nrf5_config {
 	/* GPIO module base address */
 	u32_t gpio_base_addr;
-	/* Port Control module base address */
-	u32_t port_base_addr;
-	/* GPIO Task Event base address */
-	u32_t gpiote_base_addr;
+	/* GPIO port */
+	u8_t gpio_port;
 };
 
 struct gpio_nrf5_data {
@@ -80,9 +81,6 @@ struct gpio_nrf5_data {
 	sys_slist_t callbacks;
 	/* pin callback routine enable flags, by pin number */
 	u32_t pin_callback_enables;
-
-	/*@todo: move GPIOTE channel management to a separate module */
-	u32_t gpiote_chan_mask;
 };
 
 /* convenience defines for GPIO */
@@ -92,26 +90,31 @@ struct gpio_nrf5_data {
 	((struct gpio_nrf5_data * const)(dev)->driver_data)
 #define GPIO_STRUCT(dev) \
 	((volatile struct _gpio *)(DEV_GPIO_CFG(dev))->gpio_base_addr)
-
-/* convenience defines for GPIOTE */
-#define GPIOTE_STRUCT(dev) \
-	((volatile struct _gpiote *)(DEV_GPIO_CFG(dev))->gpiote_base_addr)
-
+#define GPIO_PORT(dev) \
+	(DEV_GPIO_CFG(dev)->gpio_port)
 
 #define GPIO_SENSE_DISABLE    (GPIO_PIN_CNF_SENSE_Disabled << \
 			       GPIO_PIN_CNF_SENSE_Pos)
-#define GPIO_SENSE_LOW        (GPIO_PIN_CNF_SENSE_Low << GPIO_PIN_CNF_SENSE_Pos)
+#define GPIO_SENSE_LOW        (GPIO_PIN_CNF_SENSE_Low << \
+			       GPIO_PIN_CNF_SENSE_Pos)
 #define GPIO_SENSE_HIGH       (GPIO_PIN_CNF_SENSE_High << \
 			       GPIO_PIN_CNF_SENSE_Pos)
 #define GPIO_SENSE_INVALID    (GPIO_PIN_CNF_SENSE_Invalid << \
 			       GPIO_PIN_CNF_SENSE_Pos)
-#define GPIO_PULL_DISABLE     (GPIO_PIN_CNF_PULL_Disabled << GPIO_PIN_CNF_PULL_Pos)
-#define GPIO_PULL_DOWN        (GPIO_PIN_CNF_PULL_Pulldown << GPIO_PIN_CNF_PULL_Pos)
-#define GPIO_PULL_UP          (GPIO_PIN_CNF_PULL_Pullup << GPIO_PIN_CNF_PULL_Pos)
-#define GPIO_INPUT_CONNECT    (GPIO_PIN_CNF_INPUT_Connect << GPIO_PIN_CNF_INPUT_Pos)
-#define GPIO_INPUT_DISCONNECT (GPIO_PIN_CNF_INPUT_Disconnect << GPIO_PIN_CNF_INPUT_Pos)
-#define GPIO_DIR_INPUT        (GPIO_PIN_CNF_DIR_Input << GPIO_PIN_CNF_DIR_Pos)
-#define GPIO_DIR_OUTPUT       (GPIO_PIN_CNF_DIR_Output << GPIO_PIN_CNF_DIR_Pos)
+#define GPIO_PULL_DISABLE     (GPIO_PIN_CNF_PULL_Disabled << \
+			       GPIO_PIN_CNF_PULL_Pos)
+#define GPIO_PULL_DOWN        (GPIO_PIN_CNF_PULL_Pulldown << \
+			       GPIO_PIN_CNF_PULL_Pos)
+#define GPIO_PULL_UP          (GPIO_PIN_CNF_PULL_Pullup << \
+			       GPIO_PIN_CNF_PULL_Pos)
+#define GPIO_INPUT_CONNECT    (GPIO_PIN_CNF_INPUT_Connect << \
+			       GPIO_PIN_CNF_INPUT_Pos)
+#define GPIO_INPUT_DISCONNECT (GPIO_PIN_CNF_INPUT_Disconnect << \
+			       GPIO_PIN_CNF_INPUT_Pos)
+#define GPIO_DIR_INPUT        (GPIO_PIN_CNF_DIR_Input << \
+			       GPIO_PIN_CNF_DIR_Pos)
+#define GPIO_DIR_OUTPUT       (GPIO_PIN_CNF_DIR_Output << \
+			       GPIO_PIN_CNF_DIR_Pos)
 
 #define GPIO_DRIVE_S0S1 (GPIO_PIN_CNF_DRIVE_S0S1 << GPIO_PIN_CNF_DRIVE_Pos)
 #define GPIO_DRIVE_H0S1 (GPIO_PIN_CNF_DRIVE_H0S1 << GPIO_PIN_CNF_DRIVE_Pos)
@@ -122,24 +125,40 @@ struct gpio_nrf5_data {
 #define GPIO_DRIVE_S0D1 (GPIO_PIN_CNF_DRIVE_S0D1 << GPIO_PIN_CNF_DRIVE_Pos)
 #define GPIO_DRIVE_H0D1 (GPIO_PIN_CNF_DRIVE_H0D1 << GPIO_PIN_CNF_DRIVE_Pos)
 
-#define GPIOTE_CFG_EVT (GPIOTE_CONFIG_MODE_Event << GPIOTE_CONFIG_MODE_Pos)
+#define GPIOTE_CFG_EVT  (GPIOTE_CONFIG_MODE_Event << GPIOTE_CONFIG_MODE_Pos)
 #define GPIOTE_CFG_TASK (GPIOTE_CONFIG_MODE_Task << GPIOTE_CONFIG_MODE_Pos)
-#define GPIOTE_CFG_POL_L2H (GPIOTE_CONFIG_POLARITY_LoToHi << GPIOTE_CONFIG_POLARITY_Pos)
-#define GPIOTE_CFG_POL_H2L (GPIOTE_CONFIG_POLARITY_HiToLo << GPIOTE_CONFIG_POLARITY_Pos)
-#define GPIOTE_CFG_POL_TOGG (GPIOTE_CONFIG_POLARITY_Toggle << GPIOTE_CONFIG_POLARITY_Pos)
-#define GPIOTE_CFG_PIN(pin) ((pin << GPIOTE_CONFIG_PSEL_Pos) & GPIOTE_CONFIG_PSEL_Msk)
-#define GPIOTE_CFG_PIN_GET(config) ((config & GPIOTE_CONFIG_PSEL_Msk) >> \
-				GPIOTE_CONFIG_PSEL_Pos)
 
-static int gpiote_find_channel(struct device *dev, u32_t pin)
+#define GPIOTE_CFG_POL_L2H  (GPIOTE_CONFIG_POLARITY_LoToHi << \
+			     GPIOTE_CONFIG_POLARITY_Pos)
+#define GPIOTE_CFG_POL_H2L  (GPIOTE_CONFIG_POLARITY_HiToLo << \
+			     GPIOTE_CONFIG_POLARITY_Pos)
+#define GPIOTE_CFG_POL_TOGG (GPIOTE_CONFIG_POLARITY_Toggle << \
+			     GPIOTE_CONFIG_POLARITY_Pos)
+
+#if defined(CONFIG_GPIO_NRF5_P1)
+#define GPIOTE_CFG_PORT(port)       ((port << GPIOTE_CONFIG_PORT_Pos) & \
+				     GPIOTE_CONFIG_PORT_Msk)
+#define GPIOTE_CFG_PORT_GET(config) ((config & GPIOTE_CONFIG_PORT_Msk) >> \
+				     GPIOTE_CONFIG_PORT_Pos)
+#else /* !CONFIG_GPIO_NRF5_P1 */
+#define GPIOTE_CFG_PORT(port)       0
+#define GPIOTE_CFG_PORT_GET(config) 0
+#endif /* !CONFIG_GPIO_NRF5_P1 */
+
+#define GPIOTE_CFG_PIN(pin)        ((pin << GPIOTE_CONFIG_PSEL_Pos) & \
+				    GPIOTE_CONFIG_PSEL_Msk)
+#define GPIOTE_CFG_PIN_GET(config) ((config & GPIOTE_CONFIG_PSEL_Msk) >> \
+				    GPIOTE_CONFIG_PSEL_Pos)
+
+static int gpiote_find_channel(struct device *dev, u32_t pin, u32_t port)
 {
-	volatile struct _gpiote *gpiote = GPIOTE_STRUCT(dev);
-	struct gpio_nrf5_data *data = DEV_GPIO_DATA(dev);
+	volatile struct _gpiote *gpiote = (void *)NRF_GPIOTE_BASE;
 	int i;
 
 	for (i = 0; i < GPIOTE_CHAN_COUNT; i++) {
-		if ((data->gpiote_chan_mask & BIT(i)) &&
-		    (GPIOTE_CFG_PIN_GET(gpiote->CONFIG[i]) == pin)) {
+		if ((gpiote_chan_mask & BIT(i)) &&
+		    (GPIOTE_CFG_PIN_GET(gpiote->CONFIG[i]) == pin) &&
+		    (GPIOTE_CFG_PORT_GET(gpiote->CONFIG[i]) == port)) {
 			return i;
 		}
 	}
@@ -160,8 +179,7 @@ static int gpio_nrf5_config(struct device *dev,
 		{0, 0, 0, 0},
 		{GPIO_DRIVE_D0S1, GPIO_DRIVE_D0H1, 0, GPIO_DRIVE_S0S1}
 	};
-	volatile struct _gpiote *gpiote = GPIOTE_STRUCT(dev);
-	struct gpio_nrf5_data *data = DEV_GPIO_DATA(dev);
+	volatile struct _gpiote *gpiote = (void *)NRF_GPIOTE_BASE;
 	volatile struct _gpio *gpio = GPIO_STRUCT(dev);
 
 	if (access_op == GPIO_ACCESS_BY_PIN) {
@@ -213,6 +231,7 @@ static int gpio_nrf5_config(struct device *dev,
 
 	if (flags & GPIO_INT) {
 		u32_t config = 0;
+		u32_t port = GPIO_PORT(dev);
 
 		if (flags & GPIO_INT_EDGE) {
 			if (flags & GPIO_INT_DOUBLE_EDGE) {
@@ -226,24 +245,25 @@ static int gpio_nrf5_config(struct device *dev,
 			/*@todo: use SENSE for this? */
 			return -ENOTSUP;
 		}
-		if (__builtin_popcount(data->gpiote_chan_mask) ==
+		if (__builtin_popcount(gpiote_chan_mask) ==
 				GPIOTE_CHAN_COUNT) {
 			return -EIO;
 		}
 
 		/* check if already allocated to replace */
-		int i = gpiote_find_channel(dev, pin);
+		int i = gpiote_find_channel(dev, pin, port);
 
 		if (i < 0) {
 			/* allocate a GPIOTE channel */
-			i = __builtin_ffs(~(data->gpiote_chan_mask)) - 1;
+			i = __builtin_ffs(~gpiote_chan_mask) - 1;
 		}
 
-		data->gpiote_chan_mask |= BIT(i);
+		gpiote_chan_mask |= BIT(i);
 
 		/* configure GPIOTE channel */
 		config |= GPIOTE_CFG_EVT;
 		config |= GPIOTE_CFG_PIN(pin);
+		config |= GPIOTE_CFG_PORT(port);
 
 		gpiote->CONFIG[i] = config;
 	}
@@ -292,17 +312,16 @@ static int gpio_nrf5_manage_callback(struct device *dev,
 	return 0;
 }
 
-
 static int gpio_nrf5_enable_callback(struct device *dev,
 				    int access_op, u32_t pin)
 {
-	volatile struct _gpiote *gpiote = GPIOTE_STRUCT(dev);
-	struct gpio_nrf5_data *data = DEV_GPIO_DATA(dev);
-	int i;
-
 	if (access_op == GPIO_ACCESS_BY_PIN) {
+		volatile struct _gpiote *gpiote = (void *)NRF_GPIOTE_BASE;
+		struct gpio_nrf5_data *data = DEV_GPIO_DATA(dev);
+		int port = GPIO_PORT(dev);
+		int i;
 
-		i = gpiote_find_channel(dev, pin);
+		i = gpiote_find_channel(dev, pin, port);
 		if (i < 0) {
 			return i;
 		}
@@ -319,16 +338,16 @@ static int gpio_nrf5_enable_callback(struct device *dev,
 	return 0;
 }
 
-
 static int gpio_nrf5_disable_callback(struct device *dev,
 				     int access_op, u32_t pin)
 {
-	volatile struct _gpiote *gpiote = GPIOTE_STRUCT(dev);
-	struct gpio_nrf5_data *data = DEV_GPIO_DATA(dev);
-	int i;
-
 	if (access_op == GPIO_ACCESS_BY_PIN) {
-		i = gpiote_find_channel(dev, pin);
+		volatile struct _gpiote *gpiote = (void *)NRF_GPIOTE_BASE;
+		struct gpio_nrf5_data *data = DEV_GPIO_DATA(dev);
+		int port = GPIO_PORT(dev);
+		int i;
+
+		i = gpiote_find_channel(dev, pin, port);
 		if (i < 0) {
 			return i;
 		}
@@ -343,7 +362,13 @@ static int gpio_nrf5_disable_callback(struct device *dev,
 	return 0;
 }
 
-
+/* NOTE: forward declarations to use in ISR below */
+#if defined(CONFIG_GPIO_NRF5_P0)
+DEVICE_DECLARE(gpio_nrf5_P0);
+#endif /* CONFIG_GPIO_NRF5_P0 */
+#if defined(CONFIG_GPIO_NRF5_P1)
+DEVICE_DECLARE(gpio_nrf5_P1);
+#endif /* CONFIG_GPIO_NRF5_P1 */
 
 /**
  * @brief Handler for port interrupts
@@ -353,28 +378,66 @@ static int gpio_nrf5_disable_callback(struct device *dev,
  */
 static void gpio_nrf5_port_isr(void *arg)
 {
-	struct device *dev = arg;
-	volatile struct _gpiote *gpiote = GPIOTE_STRUCT(dev);
-	struct gpio_nrf5_data *data = DEV_GPIO_DATA(dev);
-	u32_t enabled_int, int_status = 0;
+	volatile struct _gpiote *gpiote = (void *)NRF_GPIOTE_BASE;
+	struct gpio_nrf5_data *data;
+#if defined(CONFIG_GPIO_NRF5_P0)
+	u32_t int_status_p0 = 0;
+#endif /* CONFIG_GPIO_NRF5_P0 */
+#if defined(CONFIG_GPIO_NRF5_P1)
+	u32_t int_status_p1 = 0;
+#endif /* CONFIG_GPIO_NRF5_P1 */
+	struct device *dev;
+	u32_t enabled_int;
 	int i;
 
 	for (i = 0; i < GPIOTE_CHAN_COUNT; i++) {
 		if (gpiote->EVENTS_IN[i]) {
+			int port = GPIOTE_CFG_PORT_GET(gpiote->CONFIG[i]);
+			int pin = GPIOTE_CFG_PIN_GET(gpiote->CONFIG[i]);
+
 			gpiote->EVENTS_IN[i] = 0;
-			int_status |= BIT(GPIOTE_CFG_PIN_GET(gpiote->CONFIG[i]));
+
+			switch (port) {
+#if defined(CONFIG_GPIO_NRF5_P0)
+			case 0:
+				int_status_p0 |= BIT(pin);
+				break;
+#endif /* CONFIG_GPIO_NRF5_P0 */
+
+#if defined(CONFIG_GPIO_NRF5_P1)
+			case 1:
+				int_status_p1 |= BIT(pin);
+				break;
+#endif /* CONFIG_GPIO_NRF5_P1 */
+
+			default:
+				/* NOTE: unknown port, ignore it */
+				break;
+			}
 		}
 	}
 
-	enabled_int = int_status & data->pin_callback_enables;
+#if defined(CONFIG_GPIO_NRF5_P0)
+	dev = DEVICE_GET(gpio_nrf5_P0);
+	data = DEV_GPIO_DATA(dev);
 
-	irq_disable(NRF5_IRQ_GPIOTE_IRQn);
+	enabled_int = int_status_p0 & data->pin_callback_enables;
 
 	/* Call the registered callbacks */
 	_gpio_fire_callbacks(&data->callbacks, (struct device *)dev,
 			     enabled_int);
+#endif /* CONFIG_GPIO_NRF5_P0 */
 
-	irq_enable(NRF5_IRQ_GPIOTE_IRQn);
+#if defined(CONFIG_GPIO_NRF5_P1)
+	dev = DEVICE_GET(gpio_nrf5_P1);
+	data = DEV_GPIO_DATA(dev);
+
+	enabled_int = int_status_p1 & data->pin_callback_enables;
+
+	/* Call the registered callbacks */
+	_gpio_fire_callbacks(&data->callbacks, (struct device *)dev,
+			     enabled_int);
+#endif /* CONFIG_GPIO_NRF5_P1 */
 }
 
 static const struct gpio_driver_api gpio_nrf5_drv_api_funcs = {
@@ -385,6 +448,16 @@ static const struct gpio_driver_api gpio_nrf5_drv_api_funcs = {
 	.enable_callback = gpio_nrf5_enable_callback,
 	.disable_callback = gpio_nrf5_disable_callback,
 };
+
+static int gpio_nrf5_init(struct device *dev)
+{
+	IRQ_CONNECT(NRF5_IRQ_GPIOTE_IRQn, CONFIG_GPIOTE_NRF5_PRI,
+		    gpio_nrf5_port_isr, NULL, 0);
+
+	irq_enable(NRF5_IRQ_GPIOTE_IRQn);
+
+	return 0;
+}
 
 /* Enable GPIOTE Interrupt */
 void nrf_gpiote_interrupt_enable(uint32_t mask)
@@ -406,13 +479,16 @@ void nrf_gpiote_clear_port_event(void)
 
 /* Initialization for GPIO Port 0 */
 #ifdef CONFIG_GPIO_NRF5_P0
+static int gpio_nrf5_P0_init(struct device *dev)
+{
+	gpio_nrf5_init(dev);
 
-static int gpio_nrf5_P0_init(struct device *dev);
+	return 0;
+}
 
 static const struct gpio_nrf5_config gpio_nrf5_P0_cfg = {
-	.gpio_base_addr   = NRF_GPIO_BASE,
-	.port_base_addr   = NRF_GPIO_BASE,
-	.gpiote_base_addr = NRF_GPIOTE_BASE,
+	.gpio_base_addr = NRF_GPIO_BASE,
+	.gpio_port      = 0,
 };
 
 static struct gpio_nrf5_data gpio_data_P0;
@@ -422,14 +498,30 @@ DEVICE_AND_API_INIT(gpio_nrf5_P0, CONFIG_GPIO_NRF5_P0_DEV_NAME, gpio_nrf5_P0_ini
 		    POST_KERNEL, CONFIG_KERNEL_INIT_PRIORITY_DEFAULT,
 		    &gpio_nrf5_drv_api_funcs);
 
-static int gpio_nrf5_P0_init(struct device *dev)
-{
-	IRQ_CONNECT(NRF5_IRQ_GPIOTE_IRQn, CONFIG_GPIO_NRF5_PORT_P0_PRI,
-		    gpio_nrf5_port_isr, DEVICE_GET(gpio_nrf5_P0), 0);
+#endif /* CONFIG_GPIO_NRF5_P0 */
 
-	irq_enable(NRF5_IRQ_GPIOTE_IRQn);
+/* Initialization for GPIO Port 1 */
+#if defined(CONFIG_GPIO_NRF5_P1)
+static int gpio_nrf5_P1_init(struct device *dev)
+{
+#if !defined(CONFIG_GPIO_NRF5_P0)
+	gpio_nrf5_init(dev);
+#endif /* CONFIG_GPIO_NRF5_P0 */
 
 	return 0;
 }
 
-#endif /* CONFIG_GPIO_NRF5_P0 */
+static const struct gpio_nrf5_config gpio_nrf5_P1_cfg = {
+	.gpio_base_addr = NRF_P1_BASE,
+	.gpio_port      = 1,
+};
+
+static struct gpio_nrf5_data gpio_data_P1;
+
+
+DEVICE_AND_API_INIT(gpio_nrf5_P1, CONFIG_GPIO_NRF5_P1_DEV_NAME,
+		    gpio_nrf5_P1_init, &gpio_data_P1, &gpio_nrf5_P1_cfg,
+		    POST_KERNEL, CONFIG_KERNEL_INIT_PRIORITY_DEFAULT,
+		    &gpio_nrf5_drv_api_funcs);
+
+#endif /* CONFIG_GPIO_NRF5_P1 */


### PR DESCRIPTION
Added support for GPIO Port P1 in nRF52840 SoC.

Signed-off-by: Vinayak Kariappa Chettimada <vich@nordicsemi.no>