### PR TITLE
kernel: Remove unnecessary old code

### DIFF
--- a/kernel/sem.c
+++ b/kernel/sem.c
@@ -135,9 +135,6 @@ void _sem_give_non_preemptible(struct k_sem *sem)
 		return;
 	}
 
-	_abort_thread_timeout(thread);
-
-	_ready_thread(thread);
 	_set_thread_return_value(thread, 0);
 }
 


### PR DESCRIPTION
_sem_give_non_preemptible is non preemptible and no need to move thread
to ready queue for any real use case. Remove old code. This is also not public
API

Signed-off-by: Punit Vara <punit.vara@intel.com>