### PR TITLE
net: context: fix semaphore for offload in in net_context_put()

### DIFF
--- a/subsys/net/ip/net_context.c
+++ b/subsys/net/ip/net_context.c
@@ -658,6 +658,7 @@ int net_context_put(struct net_context *context)
 	if (net_if_is_ip_offloaded(net_context_get_iface(context))) {
 		k_sem_take(&contexts_lock, K_FOREVER);
 		context->flags &= ~NET_CONTEXT_IN_USE;
+		k_sem_give(&contexts_lock);
 		return net_offload_put(
 			net_context_get_iface(context), context);
 	}


### PR DESCRIPTION
We're missing a k_sem_give for contexts_lock in the
CONFIG_NET_OFFLOAD path of net_context_put().

This fixes a network hang which occurs after any http_close()
call when CONFIG_NET_OFFLOAD is enabled.

Signed-off-by: Michael Scott <michael@opensourcefoundries.com>