### PR TITLE
doc: add version info on Latest docs

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -171,7 +171,7 @@ if tags.has('release'):
     docs_title = 'Docs / %s' %(version)
 else:
     is_release = False
-    docs_title = 'Docs'
+    docs_title = 'Docs / Latest'
 
 # The name for this set of Sphinx documents.  If None, it defaults to
 # "<project> v<release> documentation".


### PR DESCRIPTION
All Sphinx-generated pages for tagged release documentation include the
release version number in the breadcrumb header.  This patch adds this
to the "Latest" daily doc build results that are the default pages seen when
visiting docs.zephyrproject.org

Fixes: #6432
Signed-off-by: David B. Kinder <david.b.kinder@intel.com>