### PR TITLE
doc: add 1.11 links for docs and release notes

### DIFF
--- a/doc/index.rst
+++ b/doc/index.rst
@@ -21,7 +21,7 @@ Zephyr Project Documentation
    versions are available:
 
    `Zephyr 1.5.0`_ | `Zephyr 1.6.1`_ | `Zephyr 1.7.1`_ | `Zephyr 1.8.0`_ |
-   `Zephyr 1.9.2`_ | `Zephyr 1.10.0`_
+   `Zephyr 1.9.2`_ | `Zephyr 1.10.0`_ | `Zephyr 1.11.0`_
 
 For information about the changes and additions for releases, please
 consult the published :ref:`zephyr_release_notes` documentation.
@@ -63,6 +63,7 @@ Indices and Tables
 
 * :ref:`genindex`
 
+.. _Zephyr 1.11.0: https://www.zephyrproject.org/doc/1.11.0/
 .. _Zephyr 1.10.0: https://www.zephyrproject.org/doc/1.10.0/
 .. _Zephyr 1.9.2: https://www.zephyrproject.org/doc/1.9.0/
 .. _Zephyr 1.8.0: https://www.zephyrproject.org/doc/1.8.0/

--- a/doc/release-notes.rst
+++ b/doc/release-notes.rst
@@ -18,7 +18,7 @@ Git clone and checkout commands, such as:
 
    git clone https://github.com/zephyrproject-rtos/zephyr
    cd zephyr
-   git checkout tags/v1.10.0
+   git checkout tags/v1.11.0
 
 
 The project's technical documentation is also tagged to correspond with a
@@ -30,6 +30,7 @@ Zephyr Kernel Releases
 .. toctree::
    :maxdepth: 1
 
+   release-notes-1.11
    release-notes-1.10
    release-notes-1.9
    release-notes-1.8


### PR DESCRIPTION
Update the home page to add a choice for the 1.11 docs and update the
release notes page to add the 1.11 release notes link.

Signed-off-by: David B. Kinder <david.b.kinder@intel.com>