### PR TITLE
Bluetooth: Mesh: Switch to using Linux Foundation Company ID

### DIFF
--- a/include/bluetooth/hci.h
+++ b/include/bluetooth/hci.h
@@ -18,6 +18,9 @@
 extern "C" {
 #endif
 
+/* Company Identifiers (see Bluetooth Assigned Numbers) */
+#define BT_COMP_ID_LF           0x05f1
+
 #define BT_ADDR_LE_PUBLIC       0x00
 #define BT_ADDR_LE_RANDOM       0x01
 #define BT_ADDR_LE_PUBLIC_ID    0x02

--- a/samples/bluetooth/mesh/src/main.c
+++ b/samples/bluetooth/mesh/src/main.c
@@ -13,8 +13,6 @@
 
 #include "board.h"
 
-#define CID_INTEL 0x0002
-
 static struct bt_mesh_cfg_srv cfg_srv = {
 	.relay = BT_MESH_RELAY_DISABLED,
 	.beacon = BT_MESH_BEACON_ENABLED,
@@ -135,7 +133,7 @@ static struct bt_mesh_elem elements[] = {
 };
 
 static const struct bt_mesh_comp comp = {
-	.cid = CID_INTEL,
+	.cid = BT_COMP_ID_LF,
 	.elem = elements,
 	.elem_count = ARRAY_SIZE(elements),
 };

--- a/samples/bluetooth/mesh_demo/src/main.c
+++ b/samples/bluetooth/mesh_demo/src/main.c
@@ -13,13 +13,12 @@
 
 #include "board.h"
 
-#define CID_INTEL 0x0002
-#define MOD_INTEL 0x0000
+#define MOD_LF 0x0000
 
 #define GROUP_ADDR 0xc000
 #define PUBLISHER_ADDR  0x000f
 
-#define OP_VENDOR_BUTTON BT_MESH_MODEL_OP_3(0x00, CID_INTEL)
+#define OP_VENDOR_BUTTON BT_MESH_MODEL_OP_3(0x00, BT_COMP_ID_LF)
 
 static const u8_t net_key[16] = {
 	0x01, 0x23, 0x45, 0x67, 0x89, 0xab, 0xcd, 0xef,
@@ -117,7 +116,7 @@ static const struct bt_mesh_model_op vnd_ops[] = {
 };
 
 static struct bt_mesh_model vnd_models[] = {
-	BT_MESH_MODEL_VND(CID_INTEL, MOD_INTEL, vnd_ops, NULL, NULL),
+	BT_MESH_MODEL_VND(BT_COMP_ID_LF, MOD_LF, vnd_ops, NULL, NULL),
 };
 
 static struct bt_mesh_elem elements[] = {
@@ -125,7 +124,7 @@ static struct bt_mesh_elem elements[] = {
 };
 
 static const struct bt_mesh_comp comp = {
-	.cid = CID_INTEL,
+	.cid = BT_COMP_ID_LF,
 	.elem = elements,
 	.elem_count = ARRAY_SIZE(elements),
 };
@@ -139,7 +138,7 @@ static void configure(void)
 
 	/* Bind to vendor model */
 	bt_mesh_cfg_mod_app_bind_vnd(net_idx, addr, addr, app_idx,
-				     MOD_INTEL, CID_INTEL, NULL);
+				     MOD_LF, BT_COMP_ID_LF, NULL);
 
 	/* Bind to Health model */
 	bt_mesh_cfg_mod_app_bind(net_idx, addr, addr, app_idx,
@@ -147,7 +146,7 @@ static void configure(void)
 
 	/* Add model subscription */
 	bt_mesh_cfg_mod_sub_add_vnd(net_idx, addr, addr, GROUP_ADDR,
-				    MOD_INTEL, CID_INTEL, NULL);
+				    MOD_LF, BT_COMP_ID_LF, NULL);
 
 #if NODE_ADDR == PUBLISHER_ADDR
 	{

--- a/samples/boards/nrf52/mesh/onoff-app/src/main.c
+++ b/samples/boards/nrf52/mesh/onoff-app/src/main.c
@@ -50,8 +50,6 @@
 
 #include <board.h>
 
-#define CID_INTEL 0x0002
-
 /*
  * The include must follow the define for it to take effect.
  * If it isn't, the domain defaults to "general"
@@ -281,7 +279,7 @@ static struct bt_mesh_elem elements[] = {
 };
 
 static const struct bt_mesh_comp comp = {
-	.cid = CID_INTEL,
+	.cid = BT_COMP_ID_LF,
 	.elem = elements,
 	.elem_count = ARRAY_SIZE(elements),
 };

--- a/subsys/bluetooth/host/mesh/shell.c
+++ b/subsys/bluetooth/host/mesh/shell.c
@@ -25,7 +25,6 @@
 #include "foundation.h"
 
 #define CID_NVAL   0xffff
-#define CID_LOCAL  0x0002
 
 /* Default net, app & dev key values, unless otherwise specified */
 static const u8_t default_key[16] = {
@@ -87,7 +86,7 @@ static int fault_get_cur(struct bt_mesh_model *model, u8_t *test_id,
 	printk("Sending current faults\n");
 
 	*test_id = 0x00;
-	*company_id = CID_LOCAL;
+	*company_id = BT_COMP_ID_LF;
 
 	get_faults(cur_faults, sizeof(cur_faults), faults, fault_count);
 
@@ -97,7 +96,7 @@ static int fault_get_cur(struct bt_mesh_model *model, u8_t *test_id,
 static int fault_get_reg(struct bt_mesh_model *model, u16_t cid,
 			 u8_t *test_id, u8_t *faults, u8_t *fault_count)
 {
-	if (cid != CID_LOCAL) {
+	if (cid != BT_COMP_ID_LF) {
 		printk("Faults requested for unknown Company ID 0x%04x\n", cid);
 		return -EINVAL;
 	}
@@ -113,7 +112,7 @@ static int fault_get_reg(struct bt_mesh_model *model, u16_t cid,
 
 static int fault_clear(struct bt_mesh_model *model, uint16_t cid)
 {
-	if (cid != CID_LOCAL) {
+	if (cid != BT_COMP_ID_LF) {
 		return -EINVAL;
 	}
 
@@ -125,7 +124,7 @@ static int fault_clear(struct bt_mesh_model *model, uint16_t cid)
 static int fault_test(struct bt_mesh_model *model, uint8_t test_id,
 		      uint16_t cid)
 {
-	if (cid != CID_LOCAL) {
+	if (cid != BT_COMP_ID_LF) {
 		return -EINVAL;
 	}
 
@@ -196,7 +195,7 @@ static struct bt_mesh_elem elements[] = {
 };
 
 static const struct bt_mesh_comp comp = {
-	.cid = CID_LOCAL,
+	.cid = BT_COMP_ID_LF,
 	.elem = elements,
 	.elem_count = ARRAY_SIZE(elements),
 };

--- a/tests/bluetooth/mesh/src/main.c
+++ b/tests/bluetooth/mesh/src/main.c
@@ -13,8 +13,6 @@
 
 #include "board.h"
 
-#define CID_INTEL 0x0002
-
 #define MAX_FAULT 24
 
 static bool has_reg_fault = true;
@@ -51,7 +49,7 @@ static int fault_get_cur(struct bt_mesh_model *model, u8_t *test_id,
 	printk("fault_get_cur() has_reg_fault %u\n", has_reg_fault);
 
 	*test_id = 0x00;
-	*company_id = CID_INTEL;
+	*company_id = BT_COMP_ID_LF;
 	memcpy(faults, reg_faults, sizeof(reg_faults));
 	*fault_count = sizeof(reg_faults);
 
@@ -61,7 +59,7 @@ static int fault_get_cur(struct bt_mesh_model *model, u8_t *test_id,
 static int fault_get_reg(struct bt_mesh_model *model, u16_t company_id,
 			 u8_t *test_id, u8_t *faults, u8_t *fault_count)
 {
-	if (company_id != CID_INTEL) {
+	if (company_id != BT_COMP_ID_LF) {
 		return -EINVAL;
 	}
 
@@ -83,7 +81,7 @@ static int fault_get_reg(struct bt_mesh_model *model, u16_t company_id,
 
 static int fault_clear(struct bt_mesh_model *model, uint16_t company_id)
 {
-	if (company_id != CID_INTEL) {
+	if (company_id != BT_COMP_ID_LF) {
 		return -EINVAL;
 	}
 
@@ -95,7 +93,7 @@ static int fault_clear(struct bt_mesh_model *model, uint16_t company_id)
 static int fault_test(struct bt_mesh_model *model, uint8_t test_id,
 		      uint16_t company_id)
 {
-	if (company_id != CID_INTEL) {
+	if (company_id != BT_COMP_ID_LF) {
 		return -EINVAL;
 	}
 
@@ -138,8 +136,8 @@ static const struct bt_mesh_model_op vnd_ops[] = {
 };
 
 static struct bt_mesh_model vnd_models[] = {
-	BT_MESH_MODEL_VND(CID_INTEL, 0x1234, vnd_ops, &vnd_pub, NULL),
-	BT_MESH_MODEL_VND(CID_INTEL, 0x4321, vnd_ops, &vnd_pub2, NULL),
+	BT_MESH_MODEL_VND(BT_COMP_ID_LF, 0x1234, vnd_ops, &vnd_pub, NULL),
+	BT_MESH_MODEL_VND(BT_COMP_ID_LF, 0x4321, vnd_ops, &vnd_pub2, NULL),
 };
 
 static struct bt_mesh_elem elements[] = {
@@ -147,7 +145,7 @@ static struct bt_mesh_elem elements[] = {
 };
 
 static const struct bt_mesh_comp comp = {
-	.cid = CID_INTEL,
+	.cid = BT_COMP_ID_LF,
 	.elem = elements,
 	.elem_count = ARRAY_SIZE(elements),
 };


### PR DESCRIPTION
The Linux Foundation now has an assigned Company Identifier, so switch
to using that.

Signed-off-by: Johan Hedberg <johan.hedberg@intel.com>