### PR TITLE
codeowners: add additional owners for riscv32

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -20,7 +20,7 @@ arch/arm/soc/ti_simplelink/msp432p4xx    @Mani-Sadhasivam
 arch/nios2/*                             @andrewboie
 arch/nios2/core/*                        @andrewboie
 arch/posix/*                             @aescolar-ot
-arch/riscv32                             @fractalclone
+arch/riscv32                             @fractalclone @kgugala @pgielda
 arch/x86/*                               @andrewboie @youvedeep
 arch/x86/core/*                          @andrewboie
 arch/x86/core/crt0.S                     @youvedeep @nashif
@@ -54,7 +54,7 @@ boards/arm/stm32f3_disco/*               @ydamigos
 boards/nios2/*                           @ramakrishnapallala
 boards/nios2/altera_max10/*              @ramakrishnapallala
 boards/posix/*                           @aescolar-ot
-boards/riscv32                           @fractalclone
+boards/riscv32                           @fractalclone @kgugala @pgielda
 boards/x86/*                             @andrewboie @youvedeep
 boards/x86/arduino_101/*                 @nashif
 boards/x86/galileo/*                     @nashif
@@ -77,20 +77,20 @@ drivers/ethernet/*                       @jukkar @tbursztyka
 drivers/flash/*                          @nashif
 drivers/flash/*stm32*                    @superna9999
 drivers/gpio/*stm32*                     @rsalveti @idlethread
-drivers/gpio/gpio_pulpino.c              @fractalclone
+drivers/gpio/gpio_pulpino.c              @fractalclone @kgugala @pgielda
 drivers/ieee802154/*                     @jukkar @tbursztyka
 drivers/interrupt_controller/*           @andrewboie
 drivers/led_strip/*                      @mbolivar
 drivers/pinmux/stm32/*                   @rsalveti @idlethread
 drivers/sensor/*                         @bogdan-davidoaia
 drivers/serial/uart_altera_jtag.c        @ramakrishnapallala
-drivers/serial/uart_riscv_qemu.c         @fractalclone
+drivers/serial/uart_riscv_qemu.c         @fractalclone @kgugala @pgielda
 drivers/net/slip/*                       @jukkar @tbursztyka
 drivers/spi/*                            @tbursztyka
 drivers/spi/spi_ll_stm32.*               @superna9999
 drivers/timer/altera_avalon_timer.c      @ramakrishnapallala
-drivers/timer/pulpino_timer.c            @fractalclone
-drivers/timer/riscv_machine_timer.c      @fractalclone
+drivers/timer/pulpino_timer.c            @fractalclone @kgugala @pgielda
+drivers/timer/riscv_machine_timer.c      @fractalclone @kgugala @pgielda
 drivers/usb                              @youvedeep @andyross
 drivers/usb/device/usb_dc_stm32.c        @ydamigos @loicpoulain
 drivers/i2c/i2c_ll_stm32*                @ldts @ydamigos
@@ -111,7 +111,7 @@ include/arch/arm/*                       @MaureenHelm @galak
 include/arch/arm/cortex_m/irq.h          @andrewboie
 include/arch/nios2/*                     @andrewboie
 include/arch/nios2/arch.h                @andrewboie
-include/arch/riscv32                     @fractalclone
+include/arch/riscv32                     @fractalclone @kgugala @pgielda
 include/arch/x86/*                       @andrewboie @youvedeep
 include/arch/x86/arch.h                  @andrewboie
 include/arch/xtensa/*                    @andrewboie


### PR DESCRIPTION
Add new owners for the RISCV32 architecture and all associated drivers
and boards.

Signed-off-by: Anas Nashif <anas.nashif@intel.com>