### PR TITLE
tests: kernel: posix: stop relying on path for naming

### DIFF
--- a/tests/kernel/posix/clock/testcase.yaml
+++ b/tests/kernel/posix/clock/testcase.yaml
@@ -1,3 +1,3 @@
 tests:
-  test:
+  kernel.posix.clock:
     tags: core

--- a/tests/kernel/posix/pthread/testcase.yaml
+++ b/tests/kernel/posix/pthread/testcase.yaml
@@ -1,3 +1,3 @@
 tests:
-  test:
+  kernel.posix.pthread:
     tags: core

--- a/tests/kernel/posix/pthread_cancel/testcase.yaml
+++ b/tests/kernel/posix/pthread_cancel/testcase.yaml
@@ -1,4 +1,4 @@
 tests:
-  test:
+  kernel.posix.pthread_cancel:
     min_ram: 16
     tags: core

--- a/tests/kernel/posix/pthread_equal/testcase.yaml
+++ b/tests/kernel/posix/pthread_equal/testcase.yaml
@@ -1,3 +1,3 @@
 tests:
-  test:
+  kernel.posix.pthread_equal:
     tags: core

--- a/tests/kernel/posix/pthread_join/testcase.yaml
+++ b/tests/kernel/posix/pthread_join/testcase.yaml
@@ -1,3 +1,3 @@
 tests:
-  test:
+  kernel.posix.pthread_join:
     tags: core

--- a/tests/kernel/posix/timer/testcase.yaml
+++ b/tests/kernel/posix/timer/testcase.yaml
@@ -1,3 +1,3 @@
 tests:
-  test:
+  kernel.posix.timer:
     tags: core


### PR DESCRIPTION
Use proper test names instead of relying on path name where the test is
located. Fixed the _testcase.yaml_ files for POSIX tests.

Signed-off-by: Niranjhana N <niranjhana.n@intel.com>