### PR TITLE
sensors: css811: Use HAS_DTS_I2C_DEVICE in Kconfig

### DIFF
--- a/drivers/sensor/ccs811/Kconfig
+++ b/drivers/sensor/ccs811/Kconfig
@@ -14,6 +14,8 @@ menuconfig CCS811
 	help
 	  Enable driver for CCS811 Gas sensors.
 
+if !HAS_DTS_I2C_DEVICE
+
 config CCS811_NAME
 	string
 	prompt "Driver name"
@@ -41,6 +43,8 @@ config CCS811_I2C_MASTER_DEV_NAME
 	help
 	  Specify the device name of the I2C master device to which the
 	  CCS811 chip is connected.
+
+endif
 
 config CCS811_GPIO_DEV_NAME
 	string


### PR DESCRIPTION
A condition is added to the Kconfig file to disable config options which
will be supplied from the dts.

Signed-off-by: Aapo Vienamo <aapo.vienamo@iki.fi>