### PR TITLE
samples: bluetooth: mesh: Add basic documentation

### DIFF
--- a/samples/bluetooth/mesh/README.rst
+++ b/samples/bluetooth/mesh/README.rst
@@ -1,0 +1,39 @@
+.. _ble_mesh:
+
+Bluetooth: Mesh
+###############
+
+Overview
+********
+
+This sample demonstrates Bluetooth Mesh functionality. It has several
+standard Mesh models, and supports provisioning over both the
+Advertising and the GATT Provisioning Bearers (i.e. PB-ADV and PB-GATT).
+The application also needs a functioning serial console, since that's
+used for the Out-of-Band provisioning procedure.
+
+Requirements
+************
+
+* A board with Bluetooth LE support, or
+* QEMU with BlueZ running on the host
+
+Building and Running
+********************
+
+This sample can be found under :file:`samples/bluetooth/mesh` in the
+Zephyr tree.
+
+See :ref:`bluetooth setup section <bluetooth_setup>` for details on how
+to run the sample inside QEMU.
+
+For other boards, build and flash the application as follows:
+
+.. zephyr-app-commands::
+   :zephyr-app: samples/bluetooth/mesh
+   :board: <board>
+   :goals: flash
+   :compact:
+
+Refer to your :ref:`board's documentation <boards>` for alternative
+flash instructions if your board doesn't support the ``flash`` target.

--- a/samples/bluetooth/mesh_demo/README.rst
+++ b/samples/bluetooth/mesh_demo/README.rst
@@ -1,0 +1,56 @@
+.. _ble_mesh_demo:
+
+Bluetooth: Mesh Demo
+####################
+
+Overview
+********
+
+This sample is a Bluetooth Mesh application intended for demonstration
+purposes only. The application provisions and configures itself (i.e. no
+external provisioner needed) with hard-coded network and application key
+values. The local unicast address can be set using a NODE_ADDR build
+variable (e.g. NODE_ADDR=0x0001 for unicast address 0x0001), or by
+manually editing the value in the ``board.h`` file.
+
+Because of the hard-coded values, the application is not suitable for
+production use, but is quite convenient for quick demonstrations of Mesh
+functionality.
+
+The application has some features especially designed for the BBC
+micro:bit boards, such as the ability to send messages using the board's
+buttons as well as showing information of received messages on the
+board's 5x5 LED display. It's generally recommended to use unicast
+addresses in the range of 0x0001-0x0009 for the micro:bit since these
+map nicely to displayed addresses and the list of destination addresses
+which can be cycled with a button press.
+
+A special address, 0x000f, will make the application become a heart-beat
+publisher and enable the other nodes to show information of the received
+heartbeat messages.
+
+Requirements
+************
+
+* A board with Bluetooth LE support, or
+* QEMU with BlueZ running on the host
+
+Building and Running
+********************
+
+This sample can be found under :file:`samples/bluetooth/mesh_demo` in
+the Zephyr tree.
+
+See :ref:`bluetooth setup section <bluetooth_setup>` for details on how
+to run the sample inside QEMU.
+
+For other boards, build and flash the application as follows:
+
+.. zephyr-app-commands::
+   :zephyr-app: samples/bluetooth/mesh_demo
+   :board: <board>
+   :goals: flash
+   :compact:
+
+Refer to your :ref:`board's documentation <boards>` for alternative
+flash instructions if your board doesn't support the ``flash`` target.


### PR DESCRIPTION
Add documentation for the mesh and mesh_demo sample applications.

Fixes #6279

Signed-off-by: Johan Hedberg <johan.hedberg@intel.com>