### PR TITLE
arch: arm: Add one hardware platform to default testing

### DIFF
--- a/boards/arm/frdm_k64f/frdm_k64f.yaml
+++ b/boards/arm/frdm_k64f/frdm_k64f.yaml
@@ -11,3 +11,5 @@ supported:
   - i2c
   - spi
   - gpio
+testing:
+        default: true


### PR DESCRIPTION
The arm qemu platform has limitiations as we get into more complicated
features like userspace support.  Add one hardware platform to catch
issues in sanitycheck for development of such features.

Signed-off-by: Kumar Gala <kumar.gala@linaro.org>