### PR TITLE
Bluetooth: Add missing check prior sending LE Set Privacy Mode cmd

### DIFF
--- a/subsys/bluetooth/host/hci_core.c
+++ b/subsys/bluetooth/host/hci_core.c
@@ -2301,6 +2301,12 @@ static int le_set_privacy_mode(const bt_addr_le_t *addr, u8_t mode)
 	struct net_buf *buf;
 	int err;
 
+	/* Check if set privacy mode command is supported */
+	if (!BT_CMD_TEST(bt_dev.supported_commands, 39, 2)) {
+		BT_WARN("Set privacy mode command is not supported");
+		return 0;
+	}
+
 	BT_DBG("addr %s mode 0x%02x", bt_addr_le_str(addr), mode);
 
 	bt_addr_le_copy(&cp.id_addr, addr);


### PR DESCRIPTION
This check is needed to not send command that is not supported
by controller. LE Set Privacy Mode command was introduced in
Bluetooth 5.0 so that it will fail on older controllers.

Signed-off-by: Mariusz Skamra <mariusz.skamra@codecoup.pl>