### PR TITLE
soc: esp32: Enable building with newer ESP-IDF

### DIFF
--- a/arch/xtensa/soc/esp32/sdkconfig.h
+++ b/arch/xtensa/soc/esp32/sdkconfig.h
@@ -1,0 +1,5 @@
+/*
+ * This file is intentionally empty.  It is required to build Zephyr with
+ * esp-idf newer than git revision cb31222e.
+ */
+


### PR DESCRIPTION
ESP-IDF commit cb31222e added the dependency on a file named
"sdkconfig.h", which is equivalent to "autoconf.h" generated by kbuild
used in Zephyr.  It does not depend on anything from that file, though,
so just provide an empty file to keep the compiler from complaining.

Fixes #6439

Signed-off-by: Leandro Pereira <leandro.pereira@intel.com>