### PR TITLE
drivers: flash: Fix Nios-II QSPI flash Coverity issue

### DIFF
--- a/drivers/flash/soc_flash_nios2_qspi.c
+++ b/drivers/flash/soc_flash_nios2_qspi.c
@@ -209,8 +209,14 @@ static int flash_nios2_qspi_write_block(struct device *dev, int block_offset,
 			}
 		}
 
+		/* Check memcpy lentgh is with in NIOS2_WRITE_BLOCK_SIZE */
+		if (padding + bytes_to_copy > NIOS2_WRITE_BLOCK_SIZE) {
+			rc = -EINVAL;
+			goto qspi_write_block_err;
+		}
+
 		/* prepare the word to be written */
-		memcpy(&word_to_write + padding,
+		memcpy((u8_t *)&word_to_write + padding,
 				data + buffer_offset, bytes_to_copy);
 
 		/* enable write */


### PR DESCRIPTION
Fix Coverity "Memory - corruptions (ARRAY_VS_SINGLETON)"
issue by type casting word_to_write to u8_t pointer and
adding a length check before memcpy operation.

Coverity CID: 182779

Fixed #6092

Signed-off-by: Ramakrishna Pallala <ramakrishna.pallala@intel.com>