### PR TITLE
arch: arm: remove redundant dependence on ARM_CORE_MPU

### DIFF
--- a/arch/arm/core/Kconfig
+++ b/arch/arm/core/Kconfig
@@ -37,7 +37,7 @@ config CPU_HAS_SYSTICK
 config ARM_STACK_PROTECTION
 	bool
 	default y if HW_STACK_PROTECTION
-	select MPU_STACK_GUARD if ARM_CORE_MPU
+	select MPU_STACK_GUARD
 	help
 	  This option enables MPU stack guard to cause a system fatal error
 	  if the bounds of the current process stack are overflowed.


### PR DESCRIPTION
MPU_STACK_GUARD option has a direct dependence on ARM_CORE_MPU.
Therefore, it is not required to have a conditional selection
of the option (if ARM_CORE_MPU) in ARM_STACK_PROTECTION.

Signed-off-by: Ioannis Glaropoulos <Ioannis.Glaropoulos@nordicsemi.no>