### PR TITLE
sensors: lis3dh: Fix i2c burst read

### DIFF
--- a/drivers/sensor/lis3dh/lis3dh.c
+++ b/drivers/sensor/lis3dh/lis3dh.c
@@ -61,7 +61,8 @@ int lis3dh_sample_fetch(struct device *dev, enum sensor_channel chan)
 	 * a burst read can be used to read all the samples
 	 */
 	if (i2c_burst_read(drv_data->i2c, LIS3DH_I2C_ADDRESS,
-			   LIS3DH_REG_ACCEL_X_LSB, buf, 6) < 0) {
+			   (LIS3DH_REG_ACCEL_X_LSB | LIS3DH_AUTOINCREMENT_ADDR),
+			   buf, 6) < 0) {
 		SYS_LOG_DBG("Could not read accel axis data");
 		return -EIO;
 	}


### PR DESCRIPTION
The sensor enables the readout of multiple consecutive registers if the MSb of the sub-address is set. Without this bit set, the burst read doesn't read the actual registers and only produces garbage data.