### PR TITLE
Revert "sanitycheck: Default to using Ninja"

### DIFF
--- a/scripts/sanitycheck
+++ b/scripts/sanitycheck
@@ -830,14 +830,14 @@ class MakeGenerator:
         if not "native_posix" in args:
             ldflags="-Wl,--fatal-warnings"
 
-        if options.make:
-            generator = "Unix Makefiles"
-            generator_cmd = "$(MAKE)"
-            verb = "VERBOSE=1" if VERBOSE else "VERBOSE=0"
-        else:
+        if options.ninja:
             generator = "Ninja"
             generator_cmd = "ninja"
             verb = "-v" if VERBOSE else ""
+        else:
+            generator = "Unix Makefiles"
+            generator_cmd = "$(MAKE)"
+            verb = "VERBOSE=1" if VERBOSE else "VERBOSE=0"
 
         return MakeGenerator.MAKE_RULE_TMPL.format(
             generator=generator,
@@ -2099,12 +2099,7 @@ def parse_arguments():
 
     parser.add_argument(
         "-N", "--ninja", action="store_true",
-        help="Use the Ninja generator with CMake. "
-        "This option is deprecated as Ninja is now the default.")
-
-    parser.add_argument(
-        "-M", "--make", action="store_true",
-        help="Use the 'Unix Makefiles' generator with CMake")
+        help="Use the Ninja generator with CMake")
 
     parser.add_argument(
         "-y", "--dry-run", action="store_true",


### PR DESCRIPTION
This reverts commit 0e6689d559c5ca97e366045bba74174a69607dd9.

Parallel builds are broken due to a mix of Make/Ninja and the job server
not being operational.

See https://github.com/ninja-build/ninja/issues/1139

Signed-off-by: Anas Nashif <anas.nashif@intel.com>