### PR TITLE
Bluetooth: Fix available LPN groups count

### DIFF
--- a/subsys/bluetooth/host/mesh/net.h
+++ b/subsys/bluetooth/host/mesh/net.h
@@ -114,7 +114,7 @@ struct bt_mesh_friend {
 };
 
 #if defined(CONFIG_BT_MESH_LOW_POWER)
-#define LPN_GROUPS CONFIG_BT_MESH_LOW_POWER
+#define LPN_GROUPS CONFIG_BT_MESH_LPN_GROUPS
 #else
 #define LPN_GROUPS 0
 #endif


### PR DESCRIPTION
This fixes the LPN_GROUPS define.

Signed-off-by: Mariusz Skamra <mariusz.skamra@codecoup.pl>