### PR TITLE
Bluetooth: GATT: Fix possible crash while resubscribing

### DIFF
--- a/subsys/bluetooth/host/gatt.c
+++ b/subsys/bluetooth/host/gatt.c
@@ -2064,7 +2064,7 @@ static void add_subscriptions(struct bt_conn *conn)
 		 * it properly.
 		 */
 		gatt_write_ccc(conn, params->ccc_handle, params->value,
-			       NULL, params);
+			       gatt_write_ccc_rsp, params);
 	}
 }
 


### PR DESCRIPTION
When reconnecting the code will attempt to recover the subscriptions
but it was not setting any callback causing the bt_att_req.func to be
NULL.

Fixes #5982

Signed-off-by: Luiz Augusto von Dentz <luiz.von.dentz@intel.com>