### PR TITLE
arch: arm: cmsis: cleanup cmsis.h and update error-code macros

### DIFF
--- a/arch/arm/core/fault.c
+++ b/arch/arm/core/fault.c
@@ -143,11 +143,11 @@ static void _MpuFault(const NANO_ESF *esf, int fromHardFault)
 
 	_FaultThreadShow(esf);
 
-	if (SCB->CFSR & CFSR_MSTKERR_Msk) {
+	if (SCB->CFSR & SCB_CFSR_MSTKERR_Msk) {
 		PR_EXC("  Stacking error\n");
-	} else if (SCB->CFSR & CFSR_MUNSTKERR_Msk) {
+	} else if (SCB->CFSR & SCB_CFSR_MUNSTKERR_Msk) {
 		PR_EXC("  Unstacking error\n");
-	} else if (SCB->CFSR & CFSR_DACCVIOL_Msk) {
+	} else if (SCB->CFSR & SCB_CFSR_DACCVIOL_Msk) {
 		PR_EXC("  Data Access Violation\n");
 		/* In a fault handler, to determine the true faulting address:
 		 * 1. Read and save the MMFAR value.
@@ -159,14 +159,14 @@ static void _MpuFault(const NANO_ESF *esf, int fromHardFault)
 		 */
 		STORE_xFAR(mmfar, SCB->MMFAR);
 
-		if (SCB->CFSR & CFSR_MMARVALID_Msk) {
+		if (SCB->CFSR & SCB_CFSR_MMARVALID_Msk) {
 			PR_EXC("  Address: 0x%x\n", mmfar);
 			if (fromHardFault) {
-				/* clear MMAR[VALID] to reset */
-				SCB->CFSR &= ~CFSR_MMARVALID_Msk;
+				/* clear SCB_MMAR[VALID] to reset */
+				SCB->CFSR &= ~SCB_CFSR_MMARVALID_Msk;
 			}
 		}
-	} else if (SCB->CFSR & CFSR_IACCVIOL_Msk) {
+	} else if (SCB->CFSR & SCB_CFSR_IACCVIOL_Msk) {
 		PR_EXC("  Instruction Access Violation\n");
 	}
 }
@@ -185,11 +185,11 @@ static void _BusFault(const NANO_ESF *esf, int fromHardFault)
 
 	_FaultThreadShow(esf);
 
-	if (SCB->CFSR & CFSR_STKERR_Msk) {
+	if (SCB->CFSR & SCB_CFSR_STKERR_Msk) {
 		PR_EXC("  Stacking error\n");
-	} else if (SCB->CFSR & CFSR_UNSTKERR_Msk) {
+	} else if (SCB->CFSR & SCB_CFSR_UNSTKERR_Msk) {
 		PR_EXC("  Unstacking error\n");
-	} else if (SCB->CFSR & CFSR_PRECISERR_Msk) {
+	} else if (SCB->CFSR & SCB_CFSR_PRECISERR_Msk) {
 		PR_EXC("  Precise data bus error\n");
 		/* In a fault handler, to determine the true faulting address:
 		 * 1. Read and save the BFAR value.
@@ -201,20 +201,20 @@ static void _BusFault(const NANO_ESF *esf, int fromHardFault)
 		 */
 		STORE_xFAR(bfar, SCB->BFAR);
 
-		if (SCB->CFSR & CFSR_BFARVALID_Msk) {
+		if (SCB->CFSR & SCB_CFSR_BFARVALID_Msk) {
 			PR_EXC("  Address: 0x%x\n", bfar);
 			if (fromHardFault) {
-				/* clear CFSR_BFAR[VALID] to reset */
-				SCB->CFSR &= ~CFSR_BFARVALID_Msk;
+				/* clear SCB_CFSR_BFAR[VALID] to reset */
+				SCB->CFSR &= ~SCB_CFSR_BFARVALID_Msk;
 			}
 		}
 		/* it's possible to have both a precise and imprecise fault */
-		if (SCB->CFSR & CFSR_IMPRECISERR_Msk) {
+		if (SCB->CFSR & SCB_CFSR_IMPRECISERR_Msk) {
 			PR_EXC("  Imprecise data bus error\n");
 		}
-	} else if (SCB->CFSR & CFSR_IMPRECISERR_Msk) {
+	} else if (SCB->CFSR & SCB_CFSR_IMPRECISERR_Msk) {
 		PR_EXC("  Imprecise data bus error\n");
-	} else if (SCB->CFSR & CFSR_IBUSERR_Msk) {
+	} else if (SCB->CFSR & SCB_CFSR_IBUSERR_Msk) {
 		PR_EXC("  Instruction bus error\n");
 	}
 }
@@ -234,22 +234,22 @@ static void _UsageFault(const NANO_ESF *esf)
 	_FaultThreadShow(esf);
 
 	/* bits are sticky: they stack and must be reset */
-	if (SCB->CFSR & CFSR_DIVBYZERO_Msk) {
+	if (SCB->CFSR & SCB_CFSR_DIVBYZERO_Msk) {
 		PR_EXC("  Division by zero\n");
 	}
-	if (SCB->CFSR & CFSR_UNALIGNED_Msk) {
+	if (SCB->CFSR & SCB_CFSR_UNALIGNED_Msk) {
 		PR_EXC("  Unaligned memory access\n");
 	}
-	if (SCB->CFSR & CFSR_NOCP_Msk) {
+	if (SCB->CFSR & SCB_CFSR_NOCP_Msk) {
 		PR_EXC("  No coprocessor instructions\n");
 	}
-	if (SCB->CFSR & CFSR_INVPC_Msk) {
+	if (SCB->CFSR & SCB_CFSR_INVPC_Msk) {
 		PR_EXC("  Illegal load of EXC_RETURN into PC\n");
 	}
-	if (SCB->CFSR & CFSR_INVSTATE_Msk) {
+	if (SCB->CFSR & SCB_CFSR_INVSTATE_Msk) {
 		PR_EXC("  Illegal use of the EPSR\n");
 	}
-	if (SCB->CFSR & CFSR_UNDEFINSTR_Msk) {
+	if (SCB->CFSR & SCB_CFSR_UNDEFINSTR_Msk) {
 		PR_EXC("  Attempt to execute undefined instruction\n");
 	}
 

--- a/include/arch/arm/cortex_m/cmsis.h
+++ b/include/arch/arm/cortex_m/cmsis.h
@@ -40,51 +40,6 @@ extern "C" {
 #define SCB_BFSR  (*((__IOM u8_t *) &SCB->CFSR + 1))
 #define SCB_MMFSR (*((__IOM u8_t *) &SCB->CFSR))
 
-/* CFSR[UFSR] */
-#define CFSR_DIVBYZERO_Pos		(25U)
-#define CFSR_DIVBYZERO_Msk		(0x1U << CFSR_DIVBYZERO_Pos)
-#define CFSR_UNALIGNED_Pos		(24U)
-#define CFSR_UNALIGNED_Msk		(0x1U << CFSR_UNALIGNED_Pos)
-#define CFSR_NOCP_Pos			(19U)
-#define CFSR_NOCP_Msk			(0x1U << CFSR_NOCP_Pos)
-#define CFSR_INVPC_Pos			(18U)
-#define CFSR_INVPC_Msk			(0x1U << CFSR_INVPC_Pos)
-#define CFSR_INVSTATE_Pos		(17U)
-#define CFSR_INVSTATE_Msk		(0x1U << CFSR_INVSTATE_Pos)
-#define CFSR_UNDEFINSTR_Pos		(16U)
-#define CFSR_UNDEFINSTR_Msk		(0x1U << CFSR_UNDEFINSTR_Pos)
-
-/* CFSR[BFSR] */
-#define CFSR_BFARVALID_Pos		(15U)
-#define CFSR_BFARVALID_Msk		(0x1U << CFSR_BFARVALID_Pos)
-#define CFSR_LSPERR_Pos			(13U)
-#define CFSR_LSPERR_Msk			(0x1U << CFSR_LSPERR_Pos)
-#define CFSR_STKERR_Pos			(12U)
-#define CFSR_STKERR_Msk			(0x1U << CFSR_STKERR_Pos)
-#define CFSR_UNSTKERR_Pos		(11U)
-#define CFSR_UNSTKERR_Msk		(0x1U << CFSR_UNSTKERR_Pos)
-#define CFSR_IMPRECISERR_Pos		(10U)
-#define CFSR_IMPRECISERR_Msk		(0x1U << CFSR_IMPRECISERR_Pos)
-#define CFSR_PRECISERR_Pos		(9U)
-#define CFSR_PRECISERR_Msk		(0x1U << CFSR_PRECISERR_Pos)
-#define CFSR_IBUSERR_Pos		(8U)
-#define CFSR_IBUSERR_Msk		(0x1U << CFSR_IBUSERR_Pos)
-
-/* CFSR[MMFSR] */
-#define CFSR_MMARVALID_Pos		(7U)
-#define CFSR_MMARVALID_Msk		(0x1U << CFSR_MMARVALID_Pos)
-#define CFSR_MLSPERR_Pos		(5U)
-#define CFSR_MLSPERR_Msk		(0x1U << CFSR_MLSPERR_Pos)
-#define CFSR_MSTKERR_Pos		(4U)
-#define CFSR_MSTKERR_Msk		(0x1U << CFSR_MSTKERR_Pos)
-#define CFSR_MUNSTKERR_Pos		(3U)
-#define CFSR_MUNSTKERR_Msk		(0x1U << CFSR_MUNSTKERR_Pos)
-#define CFSR_DACCVIOL_Pos		(1U)
-#define CFSR_DACCVIOL_Msk		(0x1U << CFSR_DACCVIOL_Pos)
-#define CFSR_IACCVIOL_Pos		(0U)
-#define CFSR_IACCVIOL_Msk		(0x1U << CFSR_IACCVIOL_Pos)
-
-
 /* Fill in CMSIS required values for non-CMSIS compliant SoCs.
  * Use __NVIC_PRIO_BITS as it is required and simple to check, but
  * ultimately all SoCs will define their own CMSIS types and constants.


### PR DESCRIPTION
This commit removes the macros for ARM fault flags from
include/arch/arm/cortex_m/cmsis.h header, since they are
defined in the respective core_cmXX.h header files. It also
modifies fault.c to use the updated fault macros taken directly
from ARM CMSIS headers.

Signed-off-by: Ioannis Glaropoulos <Ioannis.Glaropoulos@nordicsemi.no>