### PR TITLE
doc: release notes: Add notes for ESP32 SoCs

### DIFF
--- a/doc/release-notes-1.11.rst
+++ b/doc/release-notes-1.11.rst
@@ -59,6 +59,8 @@ Boards
 Drivers and Sensors
 *******************
 
+* New LED PWM driver for ESP32 SoC
+* Fixed ESP32 I2C driver
 
 Networking
 **********


### PR DESCRIPTION
Note that the I2C driver is now operational and there's a new driver
for the PWM LED controller.

Signed-off-by: Leandro Pereira <leandro.pereira@intel.com>