### PR TITLE
drivers: sensor: lsm6ds0: Fix assert logical error (fix Coverity-CID: 182594)

### DIFF
--- a/drivers/sensor/lsm6ds0/lsm6ds0.c
+++ b/drivers/sensor/lsm6ds0/lsm6ds0.c
@@ -207,6 +207,10 @@ static int lsm6ds0_sample_fetch_temp(struct device *dev)
 static int lsm6ds0_sample_fetch(struct device *dev, enum sensor_channel chan)
 {
 	__ASSERT_NO_MSG(chan == SENSOR_CHAN_ALL ||
+			chan == SENSOR_CHAN_ACCEL_XYZ ||
+#if defined(CONFIG_LSM6DS0_ENABLE_TEMP)
+			chan == SENSOR_CHAN_TEMP ||
+#endif
 			chan == SENSOR_CHAN_GYRO_XYZ);
 
 	switch (chan) {


### PR DESCRIPTION
The assert for what chan can be was missing several cases.

Coverity-CID: 182594
Fixes #5888

Signed-off-by: Kumar Gala <kumar.gala@linaro.org>