### PR TITLE
tests: fatal: Fix incorrect filter on kernel.fatal.stack_protection

### DIFF
--- a/tests/kernel/fatal/testcase.yaml
+++ b/tests/kernel/fatal/testcase.yaml
@@ -1,7 +1,7 @@
 tests:
   kernel.fatal.stack_protection:
     extra_args: CONF_FILE=prj.conf
-    filter: ARCH_HAS_STACK_PROTECTION
+    filter: CONFIG_ARCH_HAS_STACK_PROTECTION
     tags: core ignore_faults
   kernel.fatal.stack_sentinel:
     arch_exclude: arc


### PR DESCRIPTION
The kernel.fatal.stack_protection was filtering on
ARCH_HAS_STACK_PROTECTION and that should be
CONFIG_ARCH_HAS_STACK_PROTECTION

Signed-off-by: Kumar Gala <kumar.gala@linaro.org>