### PR TITLE
arch: x86: fix integer stub comments

### DIFF
--- a/arch/x86/core/intstub.S
+++ b/arch/x86/core/intstub.S
@@ -56,13 +56,7 @@
  * "application" interrupt service routine).
  *
  * Only the volatile integer registers are saved since ISRs are assumed not to
- * utilize floating point (or SSE) instructions.  If an ISR requires the usage
- * of floating point (or SSE) instructions, it must first invoke nanoCpuFpSave()
- * (or nanoCpuSseSave()) at the beginning of the ISR.  A subsequent
- * nanoCpuFpRestore() (or nanoCpuSseRestore()) is needed just prior to returning
- * from the ISR.  Note that the nanoCpuFpSave(), nanoCpuSseSave(),
- * nanoCpuFpRestore(), and nanoCpuSseRestore() APIs have not been
- * implemented yet.
+ * utilize floating point (or SSE) instructions.
  *
  * WARNINGS
  *


### PR DESCRIPTION
The comment was obsolete; we simply do not allow use of the FPU or
vector math in ISRs. There is no desire to add such support, doing
this is properly offloaded to a worker thread.

Fixes #5283.

Signed-off-by: Andrew Boie <andrew.p.boie@intel.com>