### PR TITLE
Posix code coverage

### DIFF
--- a/kernel/posix/pthread.c
+++ b/kernel/posix/pthread.c
@@ -250,7 +250,7 @@ int pthread_cancel(pthread_t pthread)
 int pthread_setschedparam(pthread_t pthread, int policy,
 			  const struct sched_param *param)
 {
-	k_tid_t *thread = (k_tid_t *)pthread;
+	k_tid_t thread = (k_tid_t)pthread;
 	int new_prio;
 
 	if (thread == NULL) {
@@ -267,7 +267,7 @@ int pthread_setschedparam(pthread_t pthread, int policy,
 		return EINVAL;
 	}
 
-	k_thread_priority_set(*thread, new_prio);
+	k_thread_priority_set(thread, new_prio);
 	return 0;
 }
 

--- a/kernel/posix/timer.c
+++ b/kernel/posix/timer.c
@@ -101,9 +101,9 @@ int timer_gettime(timer_t timerid, struct itimerspec *its)
 
 	if (timer->status == ACTIVE) {
 		remaining = k_timer_remaining_get(&timer->ztimer);
-		secs =  remaining / sys_clock_ticks_per_sec;
-		leftover = remaining - (secs * sys_clock_ticks_per_sec);
-		nsecs = leftover * NSEC_PER_SEC / sys_clock_ticks_per_sec;
+		secs =  remaining / MSEC_PER_SEC;
+		leftover = remaining - (secs * MSEC_PER_SEC);
+		nsecs = leftover * NSEC_PER_MSEC;
 		its->it_value.tv_sec = (s32_t) secs;
 		its->it_value.tv_nsec = (s32_t) nsecs;
 	} else {

--- a/tests/posix/pthread_rwlock/src/posix_rwlock.c
+++ b/tests/posix/pthread_rwlock/src/posix_rwlock.c
@@ -74,15 +74,9 @@ static void test_rw_lock(void)
 
 	zassert_false(pthread_rwlock_init(&rwlock, NULL),
 		      "Failed to create rwlock");
-
 	printk("\nmain acquire WR lock and 3 threads acquire RD lock\n");
-	ret = pthread_rwlock_timedwrlock(&rwlock, &time);
-
-	if (ret != 0) {
-		printk("Parent thread acquiring WR lock\n");
-		zassert_false(pthread_rwlock_timedwrlock(&rwlock, &time),
-			      "Failed to acquire write lock");
-	}
+	zassert_false(pthread_rwlock_timedwrlock(&rwlock, &time),
+		      "Failed to acquire write lock");
 
 	/* Creating N premptive threads in increasing order of priority */
 	for (i = 0; i < N_THR; i++) {

--- a/tests/posix/timer/src/posix_timer.c
+++ b/tests/posix/timer/src/posix_timer.c
@@ -47,6 +47,19 @@ void test_timer(void)
 	value.it_interval.tv_sec = PERIOD_SECS;
 	value.it_interval.tv_nsec = PERIOD_NSECS;
 	ret = timer_settime(timerid, 0, &value, &ovalue);
+	usleep(100 * USEC_PER_MSEC);
+	ret = timer_gettime(timerid, &value);
+	zassert_false(ret, "Failed to get time to expire.\n");
+
+	if (ret == 0) {
+		printk("Timer fires every %d secs and  %d nsecs\n",
+		       (int) value.it_interval.tv_sec,
+		       (int) value.it_interval.tv_nsec);
+		printk("Time remaining to fire %d secs and  %d nsecs\n",
+		       (int) value.it_value.tv_sec,
+		       (int) value.it_value.tv_nsec);
+	}
+
 	clock_gettime(CLOCK_MONOTONIC, &ts);
 
 	/*TESTPOINT: Check if timer has started successfully*/


### PR DESCRIPTION
Added some  APIs into posix test cases to incease code coverage into : 
1. POSIX  timer test
2. POSIX pthread  RW Lock
3. there was a bug in timing calculation for timer_gettime, it was also fixed .
4. Adding APIs into pthread_cancel test for more coverage.
5. Bug inside pthread_setschedpriority.
