### PR TITLE
Ext stm32cube readme fix

### DIFF
--- a/ext/hal/st/stm32cube/stm32f0xx/README
+++ b/ext/hal/st/stm32cube/stm32f0xx/README
@@ -1,15 +1,48 @@
-The current version supported in Zephyr for STM32F0 Cube is V1.9.0
+STM32CubeF0
+###########
+
+Origin:
+   ST Microelectronics
+   http://www.st.com/en/embedded-software/stm32cubef0.html
+
+Status:
+   version 1.9.0
+
+Purpose:
+   ST Microelectronics official MCU package for STM32F0 series.
+
+Description:
+   This package is an extract of official STM32CubeF0 package written by ST Microelectronics.
+   It is composed of STM32Cube hardware abstraction layer (HAL) and low layer (LL) plus a set
+   of CMSIS headers files, one for each SoC in STM32F0 series.
+
+Dependencies:
+    None.
+
+URL:
+   http://www.st.com/en/embedded-software/stm32cubef0.html
+
+commit:
+   version 1.9.0
+
+Maintained-by:
+   External
+
+License:
+   BSD-3-Clause
+
+License Link:
+   http://www.st.com/resource/en/license_agreement/dm00218346.pdf
 
 Patch List:
-===========
 
-*Current implementation of LL_SPI_TransmitData16 on F0 family
-  generates following warning:
-  "warning: dereferencing type-punned pointer will break strict-aliasing
-  rules [-Wstrict-aliasing]"
-  Besides being forbidden by rule, this cast is not needed, as register is
-  16 bits wide. Modification has been tested on F0 SoC.
-  stm32yyxx_ll_spi.h being included in soc.h file, warning is generated
-  at each compiled object, this commit allows a clean build.
-Impacted files:
-  drivers/include/stm32f0xx_ll_spi.h
+   *Current implementation of LL_SPI_TransmitData16 on F0 family
+    generates following warning:
+    "warning: dereferencing type-punned pointer will break strict-aliasing
+    rules [-Wstrict-aliasing]"
+    Besides being forbidden by rule, this cast is not needed, as register is
+    16 bits wide. Modification has been tested on F0 SoC.
+    stm32yyxx_ll_spi.h being included in soc.h file, warning is generated
+    at each compiled object, this commit allows a clean build.
+    Impacted files:
+      drivers/include/stm32f0xx_ll_spi.h

--- a/ext/hal/st/stm32cube/stm32f1xx/README
+++ b/ext/hal/st/stm32cube/stm32f1xx/README
@@ -1,19 +1,50 @@
-The current version supported in Zephyr for STM32F1 Cube is V1.6.0
+STM32CubeF1
+###########
 
+Origin:
+   ST Microelectronics
+   http://www.st.com/en/embedded-software/stm32cubef1.html
 
+Status:
+   version 1.6.0
+
+Purpose:
+   ST Microelectronics official MCU package for STM32F1 series.
+
+Description:
+   This package is an extract of official STM32CubeF1 package written by ST Microelectronics.
+   It is composed of STM32Cube hardware abstraction layer (HAL) and low layer (LL) plus a set
+   of CMSIS headers files, one for each SoC in STM32F1 series.
+
+Dependencies:
+    None.
+
+URL:
+   http://www.st.com/en/embedded-software/stm32cubef1.html
+
+commit:
+   version 1.6.0
+
+Maintained-by:
+   External
+
+License:
+   BSD-3-Clause
+
+License Link:
+   http://www.st.com/resource/en/license_agreement/dm00218346.pdf
 
 Patch List:
-===========
 
-*Disable i2c HAL
-   Due to conflict with zephyr i2c.h (I2C_SPEED_STANDARD and I2C_SPEED_FAST
-   redefinition), deactivate STM32Cube I2C HAL. This raises no issue since
-   LL API is currently used for stm32 I2C driver.
-Impacted files:
-   drivers/include/stm32f1xx_hal_conf.h
-ST Bug tracker ID: NA. Not a stm32cube issue
+   *Disable i2c HAL
+     Due to conflict with zephyr i2c.h (I2C_SPEED_STANDARD and I2C_SPEED_FAST
+     redefinition), deactivate STM32Cube I2C HAL. This raises no issue since
+     LL API is currently used for stm32 I2C driver.
+     Impacted files:
+      drivers/include/stm32f1xx_hal_conf.h
+     ST Bug tracker ID: NA. Not a stm32cube issue
 
-*Update LSI_VALUE to 40 KHz
-Impacted files:
-  drivers/include/stm32f1xx_ll_rcc.h
-ST Bug tracker ID: 37419
+    *Update LSI_VALUE to 40 KHz
+     Impacted files:
+      drivers/include/stm32f1xx_ll_rcc.h
+     ST Bug tracker ID: 37419

--- a/ext/hal/st/stm32cube/stm32f3xx/README
+++ b/ext/hal/st/stm32cube/stm32f3xx/README
@@ -1,24 +1,58 @@
-The current version supported in Zephyr for STM32F3 Cube is V1.9.0
+STM32CubeF3
+###########
+
+Origin:
+   ST Microelectronics
+   http://www.st.com/en/embedded-software/stm32cubef3.html
+
+Status:
+   version 1.9.0
+
+Purpose:
+   ST Microelectronics official MCU package for STM32F3 series.
+
+Description:
+   This package is an extract of official STM32CubeF3 package written by ST Microelectronics.
+   It is composed of STM32Cube hardware abstraction layer (HAL) and low layer (LL) plus a set
+   of CMSIS headers files, one for each SoC in STM32F3 series.
+
+Dependencies:
+    None.
+
+URL:
+   http://www.st.com/en/embedded-software/stm32cubef3.html
+
+commit:
+   version 1.9.0
+
+Maintained-by:
+   External
+
+License:
+   BSD-3-Clause
+
+License Link:
+   http://www.st.com/resource/en/license_agreement/dm00218346.pdf
 
 Patch List:
-===========
-*Changes from official delivery:
--dos2unix applied
--trailing white spaces removed
 
-*Current implementation of LL_SPI_TransmitData16 on F3/F7/L4 family
-  generates following warning:
-  "warning: dereferencing type-punned pointer will break strict-aliasing
-  rules [-Wstrict-aliasing]"
-  Besides being forbidden by rule, this cast is not needed, as register is
-  16 bits wide. Modification has been tested on L4 SoC.
-  stm32yyxx_ll_spi.h being included in soc.h file, warning is generated
-  at each compiled object, this commit allows a clean build.
-Impacted files:
-  drivers/include/stm32f3xx_ll_spi.h
-ST Bug tracker ID: 13359
+   *Changes from official delivery:
+    -dos2unix applied
+    -trailing white spaces removed
 
-*Update LSI_VALUE to 40 KHz
-Impacted files:
-  drivers/include/stm32f3xx_ll_rcc.h
-ST Bug tracker ID: 37418
+    *Update LSI_VALUE to 40 KHz
+     Impacted files:
+      drivers/include/stm32f3xx_ll_rcc.h
+     ST Bug tracker ID: 37418
+
+    *Current implementation of LL_SPI_TransmitData16 on F3/F7/L4 family
+     generates following warning:
+      "warning: dereferencing type-punned pointer will break strict-aliasing
+      rules [-Wstrict-aliasing]"
+     Besides being forbidden by rule, this cast is not needed, as register is
+     16 bits wide. Modification has been tested on L4 SoC.
+     stm32yyxx_ll_spi.h being included in soc.h file, warning is generated
+     at each compiled object, this commit allows a clean build.
+     Impacted files:
+      drivers/include/stm32f3xx_ll_spi.h
+     ST Bug tracker ID: 13359

--- a/ext/hal/st/stm32cube/stm32f4xx/README
+++ b/ext/hal/st/stm32cube/stm32f4xx/README
@@ -1,12 +1,45 @@
-The current version supported in Zephyr for STM32F4 Cube is V1.18.0
+STM32CubeF4
+###########
 
+Origin:
+   ST Microelectronics
+   http://www.st.com/en/embedded-software/stm32cubef4.html
+
+Status:
+   version 1.18.0
+
+Purpose:
+   ST Microelectronics official MCU package for STM32F4 series.
+
+Description:
+   This package is an extract of official STM32CubeF4 package written by ST Microelectronics.
+   It is composed of STM32Cube hardware abstraction layer (HAL) and low layer (LL) plus a set
+   of CMSIS headers files, one for each SoC in STM32F4 series.
+
+Dependencies:
+    None.
+
+URL:
+   http://www.st.com/en/embedded-software/stm32cubef4.html
+
+commit:
+   version 1.18.0
+
+Maintained-by:
+   External
+
+License:
+   BSD-3-Clause
+
+License Link:
+   http://www.st.com/resource/en/license_agreement/dm00218346.pdf
 
 Patch List:
-===========
-*Disable i2c HAL
-   Due to conflict with zephyr i2c.h (I2C_SPEED_STANDARD and I2C_SPEED_FAST
-   redefinition), deactivate STM32Cube I2C HAL. This raises no issue since
-   LL API is currently used for stm32 I2C driver.
-Impacted files:
-   drivers/include/stm32f1xx_hal_conf.h
-ST Bug tracker ID: NA. Not a stm32cube issue
+
+   *Disable i2c HAL
+     Due to conflict with zephyr i2c.h (I2C_SPEED_STANDARD and I2C_SPEED_FAST
+     redefinition), deactivate STM32Cube I2C HAL. This raises no issue since
+     LL API is currently used for stm32 I2C driver.
+    Impacted files:
+     drivers/include/stm32f1xx_hal_conf.h
+    ST Bug tracker ID: NA. Not a stm32cube issue

--- a/ext/hal/st/stm32cube/stm32f7xx/README
+++ b/ext/hal/st/stm32cube/stm32f7xx/README
@@ -1,17 +1,49 @@
-The current version supported in Zephyr for STM32F7 Cube is V1.8.0
+TSTM32CubeF7
+###########
 
+Origin:
+   ST Microelectronics
+   http://www.st.com/en/embedded-software/stm32cubef7.html
+
+Status:
+   version 1.8.0
+
+Purpose:
+   ST Microelectronics official MCU package for STM32F7 series.
+
+Description:
+   This package is an extract of official STM32CubeF7 package written by ST Microelectronics.
+   It is composed of STM32Cube hardware abstraction layer (HAL) and low layer (LL) plus a set
+   of CMSIS headers files, one for each SoC in STM32F7 series.
+
+Dependencies:
+    None.
+
+URL:
+   http://www.st.com/en/embedded-software/stm32cubef7.html
+
+commit:
+   version 1.8.0
+
+Maintained-by:
+   External
+
+License:
+   BSD-3-Clause
+
+License Link:
+   http://www.st.com/resource/en/license_agreement/dm00218346.pdf
 
 Patch List:
-===========
 
-*Current implementation of LL_SPI_TransmitData16 on F3/F7/L4 family
-  generates following warning:
-  "warning: dereferencing type-punned pointer will break strict-aliasing
-  rules [-Wstrict-aliasing]"
-  Besides being forbidden by rule, this cast is not needed, as register is
-  16 bits wide. Modification has been tested on L4 SoC.
-  stm32yyxx_ll_spi.h being included in soc.h file, warning is generated
-  at each compiled object, this commit allows a clean build.
-Impacted files:
-  drivers/include/stm32f7xx_ll_spi.h
-ST Bug tracker ID: 13359
+   *Current implementation of LL_SPI_TransmitData16 on F3/F7/L4 family
+    generates following warning:
+    "warning: dereferencing type-punned pointer will break strict-aliasing
+    rules [-Wstrict-aliasing]"
+    Besides being forbidden by rule, this cast is not needed, as register is
+    16 bits wide. Modification has been tested on L4 SoC.
+    stm32yyxx_ll_spi.h being included in soc.h file, warning is generated
+    at each compiled object, this commit allows a clean build.
+    Impacted files:
+     drivers/include/stm32f7xx_ll_spi.h
+    ST Bug tracker ID: 13359

--- a/ext/hal/st/stm32cube/stm32l4xx/README
+++ b/ext/hal/st/stm32cube/stm32l4xx/README
@@ -1,17 +1,49 @@
-The current version supported in Zephyr for STM32L4 Cube is V1.10.0
+STM32CubeL4
+###########
 
+Origin:
+   ST Microelectronics
+   http://www.st.com/en/embedded-software/stm32cubel4.html
+
+Status:
+   version 1.10.0
+
+Purpose:
+   ST Microelectronics official MCU package for STM32L4 series.
+
+Description:
+   This package is an extract of official STM32CubeL4 package written by ST Microelectronics.
+   It is composed of STM32Cube hardware abstraction layer (HAL) and low layer (LL) plus a set
+   of CMSIS headers files, one for each SoC in STM32L4 series.
+
+Dependencies:
+    None.
+
+URL:
+   http://www.st.com/en/embedded-software/stm32cubel4.html
+
+commit:
+   version 1.10.0
+
+Maintained-by:
+   External
+
+License:
+   BSD-3-Clause
+
+License Link:
+   http://www.st.com/resource/en/license_agreement/dm00218346.pdf
 
 Patch List:
-===========
 
-*Current implementation of LL_SPI_TransmitData16 on F3/F7/L4 family
-  generates following warning:
-  "warning: dereferencing type-punned pointer will break strict-aliasing
-  rules [-Wstrict-aliasing]"
-  Besides being forbidden by rule, this cast is not needed, as register is
-  16 bits wide. Modification has been tested on L4 SoC.
-  stm32yyxx_ll_spi.h being included in soc.h file, warning is generated
-  at each compiled object, this commit allows a clean build.
-Impacted files:
-  drivers/include/stm32l4xx_ll_spi.h
-ST Bug tracker ID: 13359
+   *Current implementation of LL_SPI_TransmitData16 on F3/F7/L4 family
+    generates following warning:
+    "warning: dereferencing type-punned pointer will break strict-aliasing
+    rules [-Wstrict-aliasing]"
+    Besides being forbidden by rule, this cast is not needed, as register is
+    16 bits wide. Modification has been tested on L4 SoC.
+    stm32yyxx_ll_spi.h being included in soc.h file, warning is generated
+    at each compiled object, this commit allows a clean build.
+    Impacted files:
+     drivers/include/stm32l4xx_ll_spi.h
+    ST Bug tracker ID: 13359


### PR DESCRIPTION
To comply with Zephyr Contributing guidelines regarding
ext/ components, update README for each STM32 series