### PR TITLE
arch: arm: fix bug in escalated HF dump

### DIFF
--- a/include/arch/arm/cortex_m/cmsis.h
+++ b/include/arch/arm/cortex_m/cmsis.h
@@ -36,7 +36,7 @@ extern "C" {
 #define CPACR_CP11_RESERVED     (2UL << CPACR_CP11_Pos)
 #define CPACR_CP11_FULL_ACCESS  (3UL << CPACR_CP11_Pos)
 
-#define SCB_UFSR  (*((__IOM u16_t *) &SCB->CFSR + 2))
+#define SCB_UFSR  (*((__IOM u16_t *) &SCB->CFSR + 1))
 #define SCB_BFSR  (*((__IOM u8_t *) &SCB->CFSR + 1))
 #define SCB_MMFSR (*((__IOM u8_t *) &SCB->CFSR))
 


### PR DESCRIPTION
This commit fixes a bug in the ARM HardFAult handler, which
prevented from dumping the right UsageFault flags, after a
UsageFault had escalated to HardFault.

The bug was due to pointer arithmetic.

Signed-off-by: Ioannis Glaropoulos <Ioannis.Glaropoulos@nordicsemi.no>