### PR TITLE
doc: Fix K_ALERT_DEFINE in a code example

### DIFF
--- a/doc/kernel/synchronization/alerts.rst
+++ b/doc/kernel/synchronization/alerts.rst
@@ -125,7 +125,7 @@ to indicate that a key press has occurred.
 
     extern int my_alert_handler(struct k_alert *alert);
 
-    K_ALERT_DEFINE(my_alert, my_alert_handler);
+    K_ALERT_DEFINE(my_alert, my_alert_handler, 10);
 
     void keypress_interrupt_handler(void *arg)
     {


### PR DESCRIPTION
Add the missing 'max_num_pending_alerts' argument to the
K_ALERT_DEFINE used in the "Signaling an Alert" code example.

Signed-off-by: Stig Bjørlykke <stig.bjorlykke@nordicsemi.no>