### PR TITLE
samples: net: Remove references to ZoAP

### DIFF
--- a/samples/net/coaps_client/src/coaps_client.c
+++ b/samples/net/coaps_client/src/coaps_client.c
@@ -184,7 +184,7 @@ void dtls_client(void)
 	int ret;
 	struct udp_context ctx;
 	struct dtls_timing_context timer;
-	struct coap_packet request, zpkt;
+	struct coap_packet request, cpkt;
 	struct coap_reply *reply;
 	struct net_pkt *pkt;
 	struct net_buf *frag;
@@ -385,13 +385,13 @@ retry:
 	len = ret;
 	frag->len = len;
 
-	ret = coap_packet_parse(&zpkt, pkt, NULL, 0);
+	ret = coap_packet_parse(&cpkt, pkt, NULL, 0);
 	if (ret) {
 		mbedtls_printf("Could not parse packet\n");
 		goto exit;
 	}
 
-	reply = coap_response_received(&zpkt, NULL, replies, NUM_REPLIES);
+	reply = coap_response_received(&cpkt, NULL, replies, NUM_REPLIES);
 	if (!reply) {
 		mbedtls_printf("No handler for response (%d)\n", ret);
 	}

--- a/samples/net/coaps_server/src/coaps_server.c
+++ b/samples/net/coaps_server/src/coaps_server.c
@@ -419,7 +419,7 @@ void dtls_server(void)
 	int len, ret = 0;
 	struct udp_context ctx;
 	struct dtls_timing_context timer;
-	struct coap_packet zpkt;
+	struct coap_packet cpkt;
 	struct net_pkt *pkt;
 	struct net_buf *frag;
 	struct coap_option options[16];
@@ -620,13 +620,13 @@ reset:
 		ip->frags = pkt->frags;
 		pkt->frags = ip;
 
-		ret = coap_packet_parse(&zpkt, pkt, options, opt_num);
+		ret = coap_packet_parse(&cpkt, pkt, options, opt_num);
 		if (ret) {
 			mbedtls_printf("Could not parse packet\n");
 			goto exit;
 		}
 
-		ret = coap_handle_request(&zpkt, resources, options, opt_num);
+		ret = coap_handle_request(&cpkt, resources, options, opt_num);
 		if (ret < 0) {
 			mbedtls_printf("No handler for such request (%d)\n",
 				       ret);

--- a/tests/net/lib/zoap/CMakeLists.txt
+++ b/tests/net/lib/zoap/CMakeLists.txt
@@ -1,5 +1,0 @@
-include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
-project(NONE)
-
-FILE(GLOB app_sources src/*.c)
-target_sources(app PRIVATE ${app_sources})


### PR DESCRIPTION
Rename variable zpkt to cpkt to complete the move from ZoAP to CoAP.

Remove unused tests/net/lib/zoap/CMakeLists.txt file.

Signed-off-by: Stig Bjørlykke <stig.bjorlykke@nordicsemi.no>