### PR TITLE
timers: Added a test to check periodicity

### DIFF
--- a/tests/kernel/timer/timer_api/src/main.c
+++ b/tests/kernel/timer/timer_api/src/main.c
@@ -22,6 +22,7 @@ void test_main(void)
 			 ztest_unit_test(test_timer_duration_period),
 			 ztest_unit_test(test_timer_period_0),
 			 ztest_unit_test(test_timer_expirefn_null),
+			 ztest_unit_test(test_timer_periodicity),
 			 ztest_unit_test(test_timer_status_get),
 			 ztest_unit_test(test_timer_status_get_anytime),
 			 ztest_unit_test(test_timer_status_sync),

--- a/tests/kernel/timer/timer_api/src/test_timer.h
+++ b/tests/kernel/timer/timer_api/src/test_timer.h
@@ -17,6 +17,7 @@ struct timer_data {
 void test_timer_duration_period(void);
 void test_timer_period_0(void);
 void test_timer_expirefn_null(void);
+void test_timer_periodicity(void);
 void test_timer_status_get(void);
 void test_timer_status_get_anytime(void);
 void test_timer_status_sync(void);

--- a/tests/kernel/timer/timer_api/src/test_timer_api.c
+++ b/tests/kernel/timer/timer_api/src/test_timer_api.c
@@ -10,6 +10,9 @@
 #define DURATION 100
 #define PERIOD 50
 #define EXPIRE_TIMES 4
+#define WITHIN_ERROR(var, target, epsilon)       \
+		(((var) >= (target)) && ((var) <= (target) + (epsilon)))
+
 static void duration_expire(struct k_timer *timer);
 static void duration_stop(struct k_timer *timer);
 
@@ -130,6 +133,37 @@ void test_timer_expirefn_null(void)
 	TIMER_ASSERT(tdata.expire_cnt == 0, &timer);
 	/** TESTPOINT: stop handler is invoked */
 	TIMER_ASSERT(tdata.stop_cnt == 1, &timer);
+
+	/* cleanup environment */
+	k_timer_stop(&timer);
+}
+
+void test_timer_periodicity(void)
+{
+	s64_t delta;
+
+	init_timer_data();
+	/** TESTPOINT: set duration 0 */
+	k_timer_init(&timer, NULL, NULL);
+	k_timer_start(&timer, 0, PERIOD);
+
+	/* clear the expiration that would have happenned due to
+	 * whatever duration that was set.
+	 */
+	k_timer_status_sync(&timer);
+	tdata.timestamp = k_uptime_get();
+
+	for (int i = 0; i < EXPIRE_TIMES; i++) {
+		/** TESTPOINT: expired times returned by status sync */
+		TIMER_ASSERT(k_timer_status_sync(&timer) == 1, &timer);
+
+		delta = k_uptime_delta(&tdata.timestamp);
+
+		/** TESTPOINT: check if timer fired within 1ms of the
+		 *  expected period (firing time)
+		 */
+		TIMER_ASSERT(WITHIN_ERROR(delta, PERIOD, 1), &timer);
+	}
 
 	/* cleanup environment */
 	k_timer_stop(&timer);


### PR DESCRIPTION
Added a test to check for the predictability with which
the timer expires depending on the period configured.

Signed-off-by: Rajavardhan Gundi <rajavardhan.gundi@intel.com>