### PR TITLE
tests: crypto: mbedtls: enabled test for esp32

### DIFF
--- a/tests/crypto/mbedtls/testcase.yaml
+++ b/tests/crypto/mbedtls/testcase.yaml
@@ -3,6 +3,5 @@ tests:
     filter: not CONFIG_DEBUG
     min_flash: 33
     min_ram: 32
-    platform_exclude: esp32
     tags: crypto mbedtls
     timeout: 200


### PR DESCRIPTION
Removed esp32 platform exclusion to allow test
to run on esp32 hardware.

Signed-off-by: Praful Swarnakar <praful.swarnakar@intel.com>