### PR TITLE
boards: nucleo_f412zg: Add USB support

### DIFF
--- a/boards/arm/nucleo_f412zg/Kconfig.defconfig
+++ b/boards/arm/nucleo_f412zg/Kconfig.defconfig
@@ -24,4 +24,17 @@ config I2C_1
 
 endif # I2C
 
+if NETWORKING
+
+config USB
+	default y
+
+config USB_DEVICE_STACK
+	default y
+
+config USB_DEVICE_NETWORK_ECM
+	default y
+
+endif # NETWORKING
+
 endif # BOARD_NUCLEO_F412ZG

--- a/boards/arm/nucleo_f412zg/doc/nucleo412zg.rst
+++ b/boards/arm/nucleo_f412zg/doc/nucleo412zg.rst
@@ -151,6 +151,10 @@ Serial Port
 Nucleo F412ZG board has 4 UARTs. The Zephyr console output is assigned to UART3.
 Default settings are 115200 8N1.
 
+Network interface
+-----------------
+
+Ethernet over USB is configured as the default network interface
 
 Programming and Debugging
 *************************

--- a/boards/arm/nucleo_f412zg/nucleo_f412zg.dts
+++ b/boards/arm/nucleo_f412zg/nucleo_f412zg.dts
@@ -29,3 +29,7 @@
 	status = "ok";
 	clock-frequency = <I2C_BITRATE_FAST>;
 };
+
+&usbotg_fs {
+	status = "ok";
+};


### PR DESCRIPTION
As USB port is present on the board, and pinmux configured,
add USB support in board dts file

Signed-off-by: Erwan Gouriou <erwan.gouriou@linaro.org>