### PR TITLE
Scheduler API cleanup

### DIFF
--- a/kernel/include/ksched.h
+++ b/kernel/include/ksched.h
@@ -418,21 +418,6 @@ static inline void _mark_thread_as_started(struct k_thread *thread)
  */
 static inline void _ready_thread(struct k_thread *thread)
 {
-	__ASSERT(_is_prio_higher(thread->base.prio, K_LOWEST_THREAD_PRIO) ||
-		 ((thread->base.prio == K_LOWEST_THREAD_PRIO) &&
-		  (thread == _idle_thread)),
-		 "thread %p prio too low (is %d, cannot be lower than %d)",
-		 thread, thread->base.prio,
-		 thread == _idle_thread ? K_LOWEST_THREAD_PRIO :
-					  K_LOWEST_APPLICATION_THREAD_PRIO);
-
-	__ASSERT(!_is_prio_higher(thread->base.prio, K_HIGHEST_THREAD_PRIO),
-		 "thread %p prio too high (id %d, cannot be higher than %d)",
-		 thread, thread->base.prio, K_HIGHEST_THREAD_PRIO);
-
-	/* needed to handle the start-with-delay case */
-	_mark_thread_as_started(thread);
-
 	if (_is_thread_ready(thread)) {
 		_add_thread_to_ready_q(thread);
 	}

--- a/kernel/include/ksched.h
+++ b/kernel/include/ksched.h
@@ -541,4 +541,10 @@ static inline int _is_thread_user(void)
 #endif
 }
 #endif /* CONFIG_USERSPACE */
+
+/**
+ * Returns the switch_handle of the next thread to run following an interrupt.
+ */
+void *_get_next_switch_handle(void *interrupted);
+
 #endif /* _ksched__h_ */

--- a/kernel/include/timeout_q.h
+++ b/kernel/include/timeout_q.h
@@ -90,6 +90,7 @@ static inline void _handle_one_expired_timeout(struct _timeout *timeout)
 	K_DEBUG("timeout %p\n", timeout);
 	if (thread) {
 		_unpend_thread_timing_out(thread, timeout);
+		_mark_thread_as_started(thread);
 		_ready_thread(thread);
 		irq_unlock(key);
 	} else {

--- a/kernel/init.c
+++ b/kernel/init.c
@@ -274,7 +274,7 @@ static void init_idle_thread(struct k_thread *thr, k_thread_stack_t *stack)
 			  IDLE_STACK_SIZE, idle, NULL, NULL, NULL,
 			  K_LOWEST_THREAD_PRIO, K_ESSENTIAL);
 	_mark_thread_as_started(thr);
-	_add_thread_to_ready_q(thr);
+	_ready_thread(thr);
 }
 #endif
 
@@ -352,7 +352,7 @@ static void prepare_multithreading(struct k_thread *dummy_thread)
 			  NULL, NULL, NULL,
 			  CONFIG_MAIN_THREAD_PRIORITY, K_ESSENTIAL);
 	_mark_thread_as_started(_main_thread);
-	_add_thread_to_ready_q(_main_thread);
+	_ready_thread(_main_thread);
 
 #ifdef CONFIG_MULTITHREADING
 	init_idle_thread(_idle_thread, _idle_stack);

--- a/kernel/poll.c
+++ b/kernel/poll.c
@@ -299,7 +299,7 @@ static int signal_poll_event(struct k_poll_event *event, u32_t state,
 		goto ready_event;
 	}
 
-	_add_thread_to_ready_q(thread);
+	_ready_thread(thread);
 	*must_reschedule = !_is_in_isr() && _must_switch_threads();
 
 ready_event:

--- a/kernel/sched.c
+++ b/kernel/sched.c
@@ -189,10 +189,16 @@ s32_t _ms_to_ticks(s32_t ms)
 }
 #endif
 
-/* pend the specified thread: it must *not* be in the ready queue */
-/* must be called with interrupts locked */
+/* Pend the specified thread: it must *not* be in the ready queue.  It
+ * must be either _current or a DUMMY thread (i.e. this is NOT an API
+ * for pending another thread that might be running!).  It must be
+ * called with interrupts locked
+ */
 void _pend_thread(struct k_thread *thread, _wait_q_t *wait_q, s32_t timeout)
 {
+	__ASSERT(thread == _current || _is_thread_dummy(thread),
+		 "Can only pend _current or DUMMY");
+
 #ifdef CONFIG_MULTITHREADING
 	sys_dlist_t *wait_q_list = (sys_dlist_t *)wait_q;
 	struct k_thread *pending;

--- a/kernel/sched.c
+++ b/kernel/sched.c
@@ -70,6 +70,18 @@ static struct k_thread *get_ready_q_head(void)
 
 void _add_thread_to_ready_q(struct k_thread *thread)
 {
+	__ASSERT(_is_prio_higher(thread->base.prio, K_LOWEST_THREAD_PRIO) ||
+		 ((thread->base.prio == K_LOWEST_THREAD_PRIO) &&
+		  (thread == _idle_thread)),
+		 "thread %p prio too low (is %d, cannot be lower than %d)",
+		 thread, thread->base.prio,
+		 thread == _idle_thread ? K_LOWEST_THREAD_PRIO :
+					  K_LOWEST_APPLICATION_THREAD_PRIO);
+
+	__ASSERT(!_is_prio_higher(thread->base.prio, K_HIGHEST_THREAD_PRIO),
+		 "thread %p prio too high (id %d, cannot be higher than %d)",
+		 thread, thread->base.prio, K_HIGHEST_THREAD_PRIO);
+
 #ifdef CONFIG_MULTITHREADING
 	int q_index = _get_ready_q_q_index(thread->base.prio);
 	sys_dlist_t *q = &_ready_q.q[q_index];

--- a/kernel/thread.c
+++ b/kernel/thread.c
@@ -227,16 +227,8 @@ void _impl_k_thread_start(struct k_thread *thread)
 	}
 
 	_mark_thread_as_started(thread);
-
-	if (_is_thread_ready(thread)) {
-		_add_thread_to_ready_q(thread);
-		if (_must_switch_threads()) {
-			_Swap(key);
-			return;
-		}
-	}
-
-	irq_unlock(key);
+	_ready_thread(thread);
+	_reschedule_threads(key);
 }
 
 #ifdef CONFIG_USERSPACE
@@ -449,10 +441,7 @@ _SYSCALL_HANDLER1_SIMPLE_VOID(k_thread_suspend, K_OBJ_THREAD, k_tid_t);
 void _k_thread_single_resume(struct k_thread *thread)
 {
 	_mark_thread_as_not_suspended(thread);
-
-	if (_is_thread_ready(thread)) {
-		_add_thread_to_ready_q(thread);
-	}
+	_ready_thread(thread);
 }
 
 void _impl_k_thread_resume(struct k_thread *thread)

--- a/subsys/logging/kernel_event_logger.c
+++ b/subsys/logging/kernel_event_logger.c
@@ -33,6 +33,8 @@ u32_t _sys_k_event_logger_sleep_start_time;
 int _sys_k_event_logger_mask;
 #endif
 
+static int initialized;
+
 /**
  * @brief Initialize the kernel event logger system.
  *
@@ -46,6 +48,8 @@ static int _sys_k_event_logger_init(struct device *arg)
 
 	sys_event_logger_init(&sys_k_event_logger, _sys_k_event_logger_buffer,
 		CONFIG_KERNEL_EVENT_LOGGER_BUFFER_SIZE);
+
+	initialized = 1;
 
 	return 0;
 }
@@ -143,6 +147,10 @@ void _sys_k_event_logger_interrupt(void)
 {
 	u32_t data[2];
 
+	if (!initialized) {
+		return;
+	}
+
 	if (!sys_k_must_log_event(KERNEL_EVENT_LOGGER_INTERRUPT_EVENT_ID)) {
 		return;
 	}
@@ -204,6 +212,10 @@ static void log_thread_event(enum sys_k_event_logger_thread_event event,
 			     struct k_thread *thread)
 {
 	u32_t data[3];
+
+	if (!initialized) {
+		return;
+	}
 
 	if (!sys_k_must_log_event(KERNEL_EVENT_LOGGER_THREAD_EVENT_ID)) {
 		return;


### PR DESCRIPTION
Getting started looking at the scheduler.  Step one is some work to reduce the external API footprint in the rest of the kernel, which was a little cluttered.  In theory all of this is just cleanup with at most minimal change to generated code.  No logic changes.