### PR TITLE
kernel: Name of static functions should not begin with an underscore

### DIFF
--- a/kernel/idle.c
+++ b/kernel/idle.c
@@ -63,7 +63,7 @@ static void set_kernel_idle_time_in_ticks(s32_t ticks)
 #define set_kernel_idle_time_in_ticks(x) do { } while (0)
 #endif
 
-static void _sys_power_save_idle(s32_t ticks)
+static void sys_power_save_idle(s32_t ticks)
 {
 #ifdef CONFIG_TICKLESS_KERNEL
 	if (ticks != K_FOREVER) {
@@ -180,7 +180,7 @@ void idle(void *unused1, void *unused2, void *unused3)
 
 	for (;;) {
 		(void)irq_lock();
-		_sys_power_save_idle(_get_next_timeout_expiry());
+		sys_power_save_idle(_get_next_timeout_expiry());
 
 		IDLE_YIELD_IF_COOP();
 	}

--- a/kernel/init.c
+++ b/kernel/init.c
@@ -208,14 +208,14 @@ void _data_copy(void)
 
 /**
  *
- * @brief Mainline for kernel's background task
+ * @brief Mainline for kernel's background thread
  *
  * This routine completes kernel initialization by invoking the remaining
  * init functions, then invokes application's main() routine.
  *
  * @return N/A
  */
-static void _main(void *unused1, void *unused2, void *unused3)
+static void bg_thread_main(void *unused1, void *unused2, void *unused3)
 {
 	ARG_UNUSED(unused1);
 	ARG_UNUSED(unused2);
@@ -348,7 +348,8 @@ static void prepare_multithreading(struct k_thread *dummy_thread)
 #endif
 
 	_setup_new_thread(_main_thread, _main_stack,
-			  MAIN_STACK_SIZE, _main, NULL, NULL, NULL,
+			  MAIN_STACK_SIZE, bg_thread_main,
+			  NULL, NULL, NULL,
 			  CONFIG_MAIN_THREAD_PRIORITY, K_ESSENTIAL);
 	_mark_thread_as_started(_main_thread);
 	_add_thread_to_ready_q(_main_thread);
@@ -389,7 +390,7 @@ static void switch_to_main_thread(void)
 {
 #ifdef CONFIG_ARCH_HAS_CUSTOM_SWAP_TO_MAIN
 	_arch_switch_to_main_thread(_main_thread, _main_stack, MAIN_STACK_SIZE,
-				    _main);
+				    bg_thread_main);
 #else
 	/*
 	 * Context switch to main task (entry function is _main()): the

--- a/kernel/poll.c
+++ b/kernel/poll.c
@@ -267,7 +267,7 @@ int k_poll(struct k_poll_event *events, int num_events, s32_t timeout)
 }
 
 /* must be called with interrupts locked */
-static int _signal_poll_event(struct k_poll_event *event, u32_t state,
+static int signal_poll_event(struct k_poll_event *event, u32_t state,
 			      int *must_reschedule)
 {
 	*must_reschedule = 0;
@@ -318,7 +318,7 @@ int _handle_obj_poll_events(sys_dlist_t *events, u32_t state)
 		return 0;
 	}
 
-	(void)_signal_poll_event(poll_event, state, &must_reschedule);
+	(void) signal_poll_event(poll_event, state, &must_reschedule);
 	return must_reschedule;
 }
 
@@ -344,7 +344,7 @@ int k_poll_signal(struct k_poll_signal *signal, int result)
 		return 0;
 	}
 
-	int rc = _signal_poll_event(poll_event, K_POLL_STATE_SIGNALED,
+	int rc = signal_poll_event(poll_event, K_POLL_STATE_SIGNALED,
 				    &must_reschedule);
 
 	if (must_reschedule) {

--- a/kernel/smp.c
+++ b/kernel/smp.c
@@ -56,7 +56,7 @@ extern k_thread_stack_t _interrupt_stack2[];
 extern k_thread_stack_t _interrupt_stack3[];
 
 #ifdef CONFIG_SMP
-static void _smp_init_top(int key, void *arg)
+static void smp_init_top(int key, void *arg)
 {
 	atomic_t *start_flag = arg;
 
@@ -90,17 +90,17 @@ void smp_init(void)
 
 #if defined(CONFIG_SMP) && CONFIG_MP_NUM_CPUS > 1
 	_arch_start_cpu(1, _interrupt_stack1, CONFIG_ISR_STACK_SIZE,
-			_smp_init_top, &start_flag);
+			smp_init_top, &start_flag);
 #endif
 
 #if defined(CONFIG_SMP) && CONFIG_MP_NUM_CPUS > 2
 	_arch_start_cpu(2, _interrupt_stack2, CONFIG_ISR_STACK_SIZE,
-			_smp_init_top, &start_flag);
+			smp_init_top, &start_flag);
 #endif
 
 #if defined(CONFIG_SMP) && CONFIG_MP_NUM_CPUS > 3
 	_arch_start_cpu(3, _interrupt_stack3, CONFIG_ISR_STACK_SIZE,
-			_smp_init_top, &start_flag);
+			smp_init_top, &start_flag);
 #endif
 
 	atomic_set(&start_flag, 1);

--- a/kernel/userspace.c
+++ b/kernel/userspace.c
@@ -304,7 +304,7 @@ void _k_object_uninit(void *object)
 	ko->flags &= ~K_OBJ_FLAG_INITIALIZED;
 }
 
-static u32_t _handler_bad_syscall(u32_t bad_id, u32_t arg2, u32_t arg3,
+static u32_t handler_bad_syscall(u32_t bad_id, u32_t arg2, u32_t arg3,
 				  u32_t arg4, u32_t arg5, u32_t arg6, void *ssf)
 {
 	printk("Bad system call id %u invoked\n", bad_id);
@@ -312,7 +312,7 @@ static u32_t _handler_bad_syscall(u32_t bad_id, u32_t arg2, u32_t arg3,
 	CODE_UNREACHABLE;
 }
 
-static u32_t _handler_no_syscall(u32_t arg1, u32_t arg2, u32_t arg3,
+static u32_t handler_no_syscall(u32_t arg1, u32_t arg2, u32_t arg3,
 				 u32_t arg4, u32_t arg5, u32_t arg6, void *ssf)
 {
 	printk("Unimplemented system call\n");

--- a/scripts/gen_syscalls.py
+++ b/scripts/gen_syscalls.py
@@ -75,7 +75,7 @@ extern u32_t %s(u32_t arg1, u32_t arg2, u32_t arg3,
 """
 
 weak_template = """
-__weak ALIAS_OF(_handler_no_syscall)
+__weak ALIAS_OF(handler_no_syscall)
 u32_t %s(u32_t arg1, u32_t arg2, u32_t arg3,
          u32_t arg4, u32_t arg5, u32_t arg6, void *ssf);
 """
@@ -117,7 +117,7 @@ def main():
         handlers.append(handler)
 
     with open(args.syscall_dispatch, "w") as fp:
-        table_entries.append("[K_SYSCALL_BAD] = _handler_bad_syscall")
+        table_entries.append("[K_SYSCALL_BAD] = handler_bad_syscall")
 
         weak_defines = "".join([weak_template % name for name in handlers])
 


### PR DESCRIPTION
Names that begin with an underscore are reserved by the C standard.
This patch does not change names of functions defined and implemented
in header files.

Signed-off-by: Leandro Pereira <leandro.pereira@intel.com>