### PR TITLE
Arch arm stack overflow fault dump

### DIFF
--- a/arch/arm/core/cortex_m/Kconfig
+++ b/arch/arm/core/cortex_m/Kconfig
@@ -56,7 +56,7 @@ config CPU_CORTEX_M33
 	bool
 	select CPU_CORTEX_M
 	# Omit prompt to signify "hidden" option
-	select ARMV7_M_ARMV8_M_MAINLINE
+	select ARMV8_M_MAINLINE
 	help
 	  This option signifies the use of a Cortex-M33 CPU
 
@@ -172,6 +172,17 @@ config ARMV7_M_ARMV8_M_MAINLINE
 	  From https://developer.arm.com/products/architecture/m-profile:
 	  The Main Extension provides backwards compatibility
 	  with ARMv7-M.
+
+config ARMV8_M_MAINLINE
+	bool
+	# Omit prompt to signify "hidden" option
+	select ARMV7_M_ARMV8_M_MAINLINE
+	help
+	  This option signifies the use of an ARMv8-M processor
+	  implementation, supporting the Main Extension.
+
+	  ARMv8-M Main Extension includes additional features
+	  not present in the ARMv7-M architecture.
 
 config ARMV7_M_ARMV8_M_FP
 	bool

--- a/arch/arm/core/cortex_m/Kconfig
+++ b/arch/arm/core/cortex_m/Kconfig
@@ -117,6 +117,7 @@ config CPU_CORTEX_M_HAS_VTOR
 config CPU_CORTEX_M_HAS_PROGRAMMABLE_FAULT_PRIOS
 	bool
 	# Omit prompt to signify "hidden" option
+	depends on ARMV7_M_ARMV8_M_MAINLINE
 	default n
 	help
 	  This option signifies the CPU faults other than the hard fault, and

--- a/arch/arm/core/fault.c
+++ b/arch/arm/core/fault.c
@@ -252,6 +252,11 @@ static void _UsageFault(const NANO_ESF *esf)
 	if (SCB->CFSR & SCB_CFSR_UNALIGNED_Msk) {
 		PR_EXC("  Unaligned memory access\n");
 	}
+#if defined(CONFIG_ARMV8_M_MAINLINE)
+	if (SCB->CFSR & SCB_CFSR_STKOF_Msk) {
+		PR_EXC("  Stack overflow\n");
+	}
+#endif /* CONFIG_ARMV8_M_MAINLINE */
 	if (SCB->CFSR & SCB_CFSR_NOCP_Msk) {
 		PR_EXC("  No coprocessor instructions\n");
 	}


### PR DESCRIPTION
This PR contributes the Stack-Overflow dump utility in ARMv8-M USageFault handler.
It defines the ARMV8_M_MAINLINE K-option for this purpose.

Additionally, it introduces a dependency check for programmable priorities in Cortex-M MCUs.

ARM documentation: http://infocenter.arm.com/help/index.jsp?topic=/com.arm.doc.100235_0002_00_en/ric1454421154895.html