### PR TITLE
crc: make crc8_ccitt() match the other CRC functions.

### DIFF
--- a/include/crc8.h
+++ b/include/crc8.h
@@ -9,6 +9,7 @@
 #define __CRC8_H_
 
 #include <zephyr/types.h>
+#include <stddef.h>
 
 #ifdef __cplusplus
 extern "C" {
@@ -30,7 +31,7 @@ extern "C" {
  *
  * @return The computed CRC8 value
  */
-u8_t crc8_ccitt(u8_t initial_value, void *buf, int len);
+u8_t crc8_ccitt(u8_t initial_value, const void *buf, size_t len);
 
 #ifdef __cplusplus
 }

--- a/lib/crc/crc8_sw.c
+++ b/lib/crc/crc8_sw.c
@@ -5,17 +5,17 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include "crc8.h"
+#include <crc8.h>
 
 static u8_t crc8_ccitt_small_table[16] = {
 	0x00, 0x07, 0x0e, 0x09, 0x1c, 0x1b, 0x12, 0x15,
 	0x38, 0x3f, 0x36, 0x31, 0x24, 0x23, 0x2a, 0x2d
 };
 
-u8_t crc8_ccitt(u8_t val, void *buf, int cnt)
+u8_t crc8_ccitt(u8_t val, const void *buf, size_t cnt)
 {
 	int i;
-	u8_t *p = buf;
+	const u8_t *p = buf;
 
 	for (i = 0; i < cnt; i++) {
 		val ^= p[i];


### PR DESCRIPTION
This is a minor change that makes the data pointer const and shifts
the length to a size_t to match the other CRC functions.

Signed-off-by: Michael Hope <mlhx@google.com>