### PR TITLE
tests: arm_runtime_nmi: Make test build on v8m

### DIFF
--- a/tests/kernel/arm_runtime_nmi/src/arm_runtime_nmi.c
+++ b/tests/kernel/arm_runtime_nmi/src/arm_runtime_nmi.c
@@ -15,6 +15,11 @@
 #include <ztest.h>
 #include <tc_util.h>
 
+/* on v8m arch the nmi pend bit is renamed to pend nmi map it to old name */
+#ifndef SCB_ICSR_NMIPENDSET_Msk
+#define SCB_ICSR_NMIPENDSET_Msk SCB_ICSR_PENDNMISET_Msk
+#endif
+
 extern void _NmiHandlerSet(void (*pHandler)(void));
 
 static void nmi_test_isr(void)


### PR DESCRIPTION
The ICSR[NMIPENDSET] bit got renamed to ICSR[PENDNMISET] in the v8m
architecture.  So we map SCB_ICSR_PENDNMISET_Msk to
SCB_ICSR_NMIPENDSET_Msk to the tests builds and functions.

Signed-off-by: Kumar Gala <kumar.gala@linaro.org>