### PR TITLE
usb: ateml: samd21: enable usb controller in board dts not soc

### DIFF
--- a/boards/arm/adafruit_trinket_m0/adafruit_trinket_m0.dts
+++ b/boards/arm/adafruit_trinket_m0/adafruit_trinket_m0.dts
@@ -77,3 +77,7 @@
 #endif
 	};
 };
+
+&usb0 {
+	status = "ok";
+};

--- a/boards/arm/arduino_zero/arduino_zero.dts
+++ b/boards/arm/arduino_zero/arduino_zero.dts
@@ -54,3 +54,7 @@
 #endif
 	};
 };
+
+&usb0 {
+	status = "ok";
+};

--- a/dts/arm/atmel/samd21.dtsi
+++ b/dts/arm/atmel/samd21.dtsi
@@ -123,6 +123,7 @@
 
 		usb0: usb@41005000 {
 			compatible = "atmel,sam0-usb";
+			status = "disabled";
 			reg = <0x41005000 0x1000>;
 			interrupts = <7 0>;
 			num-bidir-endpoints = <8>;


### PR DESCRIPTION
Since not all boards enable all devices, we typically have the SoC dtsi
file have a device marked with status = "disabled" and have the
board.dts explicitly enable with status = "ok".  Update it so USB on
Atmel SAMD21 work this way.

Signed-off-by: Kumar Gala <kumar.gala@linaro.org>