### PR TITLE
arch: arm: conditionally select FP extension in cortex-m MCUs

### DIFF
--- a/arch/arm/core/cortex_m/Kconfig
+++ b/arch/arm/core/cortex_m/Kconfig
@@ -41,6 +41,7 @@ config CPU_CORTEX_M4
 	select CPU_CORTEX_M
 	# Omit prompt to signify "hidden" option
 	select ARMV7_M_ARMV8_M_MAINLINE
+	select ARMV7_M_ARMV8_M_FP if CPU_HAS_FPU
 	help
 	  This option signifies the use of a Cortex-M4 CPU
 
@@ -57,6 +58,7 @@ config CPU_CORTEX_M33
 	select CPU_CORTEX_M
 	# Omit prompt to signify "hidden" option
 	select ARMV8_M_MAINLINE
+	select ARMV7_M_ARMV8_M_FP if CPU_HAS_FPU
 	help
 	  This option signifies the use of a Cortex-M33 CPU
 
@@ -65,6 +67,7 @@ config CPU_CORTEX_M7
 	select CPU_CORTEX_M
 	# Omit prompt to signify "hidden" option
 	select ARMV7_M_ARMV8_M_MAINLINE
+	select ARMV7_M_ARMV8_M_FP if CPU_HAS_FPU
 	default n
 	help
 	  This option signifies the use of a Cortex-M7 CPU


### PR DESCRIPTION
This commit conditionally selects the ARMV7_M_ARMV8_M_FP option
in ARMv7-M/ARMv8-M Mainline processors, when the Floating Point
Extension is implemented (CPU_HAS_FPU is selected).

Note: this change was originally brought in by #6390 but was accidentally discarded by 
https://github.com/zephyrproject-rtos/zephyr/pull/6506/commits/3a90161ef94af9c80fa8d7a03271ed56817cff77

Signed-off-by: Ioannis Glaropoulos <Ioannis.Glaropoulos@nordicsemi.no>