### PR TITLE
boards: arm: enable CLOCK_STM32_HSE_BYPASS in Nucleo F0/F3 defconfigs

### DIFF
--- a/boards/arm/nucleo_f030r8/nucleo_f030r8_defconfig
+++ b/boards/arm/nucleo_f030r8/nucleo_f030r8_defconfig
@@ -37,6 +37,9 @@ CONFIG_CLOCK_CONTROL=y
 CONFIG_CLOCK_STM32_SYSCLK_SRC_PLL=y
 # HSE configuration
 CONFIG_CLOCK_STM32_HSE_CLOCK=8000000
+# however, the board does not have an external oscillator, so just use
+# the 8MHz clock signal coming from integrated STLink
+CONFIG_CLOCK_STM32_HSE_BYPASS=y
 # PLL configuration
 CONFIG_CLOCK_STM32_PLL_SRC_HSE=y
 # produce 48MHz clock at PLL output

--- a/boards/arm/nucleo_f091rc/nucleo_f091rc_defconfig
+++ b/boards/arm/nucleo_f091rc/nucleo_f091rc_defconfig
@@ -29,6 +29,9 @@ CONFIG_CLOCK_CONTROL=y
 CONFIG_CLOCK_STM32_SYSCLK_SRC_PLL=y
 # HSE configuration
 CONFIG_CLOCK_STM32_HSE_CLOCK=8000000
+# however, the board does not have an external oscillator, so just use
+# the 8MHz clock signal coming from integrated STLink
+CONFIG_CLOCK_STM32_HSE_BYPASS=y
 # PLL configuration
 CONFIG_CLOCK_STM32_PLL_SRC_HSE=y
 # produce 48MHz clock at PLL output

--- a/boards/arm/nucleo_f334r8/nucleo_f334r8_defconfig
+++ b/boards/arm/nucleo_f334r8/nucleo_f334r8_defconfig
@@ -29,6 +29,9 @@ CONFIG_CLOCK_CONTROL=y
 CONFIG_CLOCK_STM32_SYSCLK_SRC_PLL=y
 # HSE configuration
 CONFIG_CLOCK_STM32_HSE_CLOCK=8000000
+# however, the board does not have an external oscillator, so just use
+# the 8MHz clock signal coming from integrated STLink
+CONFIG_CLOCK_STM32_HSE_BYPASS=y
 # PLL configuration
 CONFIG_CLOCK_STM32_PLL_SRC_HSE=y
 # produce 72MHz clock at PLL output


### PR DESCRIPTION
Nucleo-64 boards do not have X3 crystal by default, so HSE is clocked from MCO output of ST-LINK, and CONFIG_CLOCK_STM32_HSE_BYPASS should be enabled. STM32F0 HSE somehow magically works even without that, but to do so is the right thing.
Tested on Nucleo-F030R8.

Signed-off-by: Ilya Tagunov <tagunil@gmail.com>