### PR TITLE
boards: arduino_zero: Fix SPI pinmux configuration.

### DIFF
--- a/boards/arm/arduino_zero/pinmux.c
+++ b/boards/arm/arduino_zero/pinmux.c
@@ -40,8 +40,8 @@ static int board_pinmux_init(struct device *dev)
 #endif
 
 #if CONFIG_SPI_SAM0_SERCOM4_BASE_ADDRESS
-	/* SPI SERCOM4 on MISO=PB12/pad 0, MOSI=PB10/pad 2, SCK=PB11/pad 3 */
-	pinmux_pin_set(muxb, 12, PINMUX_FUNC_C);
+	/* SPI SERCOM4 on MISO=PA12/pad 0, MOSI=PB10/pad 2, SCK=PB11/pad 3 */
+	pinmux_pin_set(muxa, 12, PINMUX_FUNC_D);
 	pinmux_pin_set(muxb, 10, PINMUX_FUNC_D);
 	pinmux_pin_set(muxb, 11, PINMUX_FUNC_D);
 #endif


### PR DESCRIPTION
This commit changes the Arduino Zero pinmux configuration to use PA12
as MISO.

According to the schematic, the Arduino Zero provides a SPI bus on
SERCOM4 with the following pads/pins:
 - MISO: PA12/pad0 (pin 21)
 - MOSI: PB10/pad2 (pin 19)
 - SCK:  PB11/pad3 (pin 20)

The MISO signal is incorrectly labeled as PB12_S4_SPI_MISO on the
schematic. It should be labeled PA12_S4_SPI_MISO.

Signed-off-by: Henrik Brix Andersen <henrik@brixandersen.dk>