### PR TITLE
subsys: fs: Fix fs_file_t and fs_dir_t usage

### DIFF
--- a/ext/lib/mgmt/mcumgr/cmd/fs_mgmt/port/zephyr/src/zephyr_fs_mgmt.c
+++ b/ext/lib/mgmt/mcumgr/cmd/fs_mgmt/port/zephyr/src/zephyr_fs_mgmt.c
@@ -45,7 +45,7 @@ int
 fs_mgmt_impl_read(const char *path, size_t offset, size_t len,
                   void *out_data, size_t *out_len)
 {
-    fs_file_t file;
+    struct fs_file_t file;
     ssize_t bytes_read;
     int rc;
 
@@ -109,7 +109,7 @@ int
 fs_mgmt_impl_write(const char *path, size_t offset, const void *data,
                    size_t len)
 {
-    fs_file_t file;
+    struct fs_file_t file;
     int rc;
  
     /* Truncate the file before writing the first chunk.  This is done to

--- a/subsys/bluetooth/host/storage.c
+++ b/subsys/bluetooth/host/storage.c
@@ -40,7 +40,7 @@ enum storage_access {
 };
 
 static int storage_open(const bt_addr_le_t *addr, u16_t key,
-			enum storage_access access, fs_file_t *file)
+			enum storage_access access, struct fs_file_t *file)
 {
 	char path[STORAGE_PATH_MAX];
 
@@ -82,7 +82,7 @@ static int storage_open(const bt_addr_le_t *addr, u16_t key,
 static ssize_t storage_read(const bt_addr_le_t *addr, u16_t key, void *data,
 			    size_t length)
 {
-	fs_file_t file;
+	struct fs_file_t file;
 	ssize_t ret;
 
 	ret = storage_open(addr, key, STORAGE_READ, &file);
@@ -99,7 +99,7 @@ static ssize_t storage_read(const bt_addr_le_t *addr, u16_t key, void *data,
 static ssize_t storage_write(const bt_addr_le_t *addr, u16_t key,
 			     const void *data, size_t length)
 {
-	fs_file_t file;
+	struct fs_file_t file;
 	ssize_t ret;
 
 	ret = storage_open(addr, key, STORAGE_WRITE, &file);
@@ -116,7 +116,7 @@ static ssize_t storage_write(const bt_addr_le_t *addr, u16_t key,
 static int unlink_recursive(char path[STORAGE_PATH_MAX])
 {
 	size_t path_len;
-	fs_dir_t dir;
+	struct fs_dir_t dir;
 	int err;
 
 	err = fs_opendir(&dir, path);

--- a/subsys/fs/shell.c
+++ b/subsys/fs/shell.c
@@ -85,7 +85,7 @@ static int cmd_read(int argc, char *argv[])
 {
 	char path[MAX_PATH_LEN];
 	struct fs_dirent dirent;
-	fs_file_t file;
+	struct fs_file_t file;
 	int count;
 	off_t offset;
 	int err;
@@ -177,7 +177,7 @@ static int cmd_write(int argc, char *argv[])
 	u8_t buf[BUF_CNT];
 	u8_t buf_len;
 	int arg_offset;
-	fs_file_t file;
+	struct fs_file_t file;
 	off_t offset = -1;
 	int err;
 
@@ -242,7 +242,7 @@ static int cmd_write(int argc, char *argv[])
 static int cmd_ls(int argc, char *argv[])
 {
 	char path[MAX_PATH_LEN];
-	fs_dir_t dir;
+	struct fs_dir_t dir;
 	int err;
 
 	if (argc < 2) {
@@ -334,7 +334,7 @@ static int cmd_cd(int argc, char *argv[])
 static int cmd_trunc(int argc, char *argv[])
 {
 	char path[MAX_PATH_LEN];
-	fs_file_t file;
+	struct fs_file_t file;
 	int length;
 	int err;
 


### PR DESCRIPTION
With the introduce of VFS the typedef for fs_file_t & fs_dir_t don't
exist anymore so we need to use 'struct fs_dir_t' or 'struct fs_file_t'.
Fix up some places that got missed in the VFS conversion.

Signed-off-by: Kumar Gala <kumar.gala@linaro.org>