### PR TITLE
doc: Add 'apt-get install python3-wheel' to linux installation docs

### DIFF
--- a/doc/getting_started/installation_linux.rst
+++ b/doc/getting_started/installation_linux.rst
@@ -54,8 +54,8 @@ Install the required packages in a Ubuntu host system with:
 
    sudo apt-get install --no-install-recommends git cmake ninja-build gperf \
      ccache doxygen dfu-util device-tree-compiler \
-     python3-ply python3-pip python3-setuptools xz-utils file make gcc-multilib \
-     autoconf automake libtool
+     python3-ply python3-pip python3-setuptools python3-wheel xz-utils file \
+     make gcc-multilib autoconf automake libtool
 
 Install the required packages in a Fedora host system with:
 


### PR DESCRIPTION
When going through the SDK install instructions at http://docs.zephyrproject.org/getting_started/installation_linux.html , I ran into error messages like:

```
  ----------------------------------------
  Failed building wheel for PyYAML
  Running setup.py clean for PyYAML
  Running setup.py bdist_wheel for hub ... error
  Complete output from command /usr/bin/python3 -u -c "import setuptools, tokenize;__file__='/tmp/pip-build-g71dzj01/hub/setup.py';f=getattr(tokenize, 'open', open)(__file__);code=f.read().replace('\r\n', '\n');f.close();exec(compile(code, __file__, 'exec'))" bdist_wheel -d /tmp/tmp5b8oqe1gpip-wheel- --python-tag cp36:
  usage: -c [global_opts] cmd1 [cmd1_opts] [cmd2 [cmd2_opts] ...]
     or: -c --help [cmd1 cmd2 ...]
     or: -c --help-commands
     or: -c cmd --help
  
  error: invalid command 'bdist_wheel'
```

After doing a bit of research about errors about `bdist_wheel` errors, I found that running a `apt-get install python3-wheel` solves the problem in my debian box. Therefore, this PR adds that package to the list of dependencies in ubuntu and debian-like systems.

