### PR TITLE
kconfig: Use UTF-8 to decode sources instead of the system locale

### DIFF
--- a/scripts/kconfig/kconfiglib.py
+++ b/scripts/kconfig/kconfiglib.py
@@ -1077,7 +1077,7 @@ class Kconfig(object):
         """
         filename = self._resolve(filename, False)[0]
         try:
-            return open(filename, _UNIVERSAL_NEWLINES_MODE)
+            return open(filename, _UNIVERSAL_NEWLINES_MODE, encoding="utf-8")
         except IOError as e:
             raise IOError(
                 "Could not open '{}' ({}: {})."


### PR DESCRIPTION
We want to read the sources in the same way independent of what the
system locale is. To this end we now explicitly use UTF-8 to decode
Kconfig sources.

This resolves an issue that can be reproduced like this:

$ export LANG=C
$ cmake -DBOARD=nrf52_pca10040 -H$ZEPHYR_BASE/samples/hello_world -Boe

When the LANG (system locale) is 'C' parsing the Kconfig source
'Kconfig.defconfig.stm32f446xe' will trigger a python exception unless
this patch is applied.

Alternatively, one could explicitly decode as ascii and have the parsing
fail for all platforms when UTF-8 is entered into Kconfig sources.

Signed-off-by: Sebastian Bøe <sebastian.boe@nordicsemi.no>