### PR TITLE
scripts: extract_dts_includes: Fix path handling in Windows

### DIFF
--- a/scripts/dts/extract_dts_includes.py
+++ b/scripts/dts/extract_dts_includes.py
@@ -137,8 +137,7 @@ class Loader(yaml.Loader):
         if not os.path.isfile(filepath):
             # we need to look in bindings/* directories
             # take path and back up 1 directory and parse in '/bindings/*'
-            filepath = os.path.dirname(self._root).split('/')
-            filepath = '/'.join(filepath[:-1])
+            filepath = os.path.dirname(os.path.dirname(self._root))
             for root, dirnames, file in os.walk(filepath):
                 if fnmatch.filter(file, filename):
                     filepath = os.path.join(root, filename)


### PR DESCRIPTION
When building in Windows, extract_dts_includes.py failed with an
exception on boards that have dts sensor bindings. This was caused by
path handling to search for i2c-device.yaml that worked in Linux, but
not in Windows.

Affected boards were disco_l475_iot1, frdm_k64f, frdm_kw41z, and
hexiwear_k64.

Signed-off-by: Maureen Helm <maureen.helm@nxp.com>