### PR TITLE
doc: fix doxy syntax for hiding internal symbols

### DIFF
--- a/doc/zephyr.doxyfile
+++ b/doc/zephyr.doxyfile
@@ -832,7 +832,7 @@ EXCLUDE_PATTERNS       =
 
 # Hide internal names (starting with an underscore, and doxygen-generated names
 # for nested unnamed unions that don't generate meaningful sphinx output anyway.
-EXCLUDE_SYMBOLS        = _*, *.__unnamed__
+EXCLUDE_SYMBOLS        = _*  *.__unnamed__
 
 # The EXAMPLE_PATH tag can be used to specify one or more files or directories
 # that contain example code fragments that are included (see the \include


### PR DESCRIPTION
EXCLUDE_SYMBOLS uses spaces as seperator and not commas.

Signed-off-by: David B. Kinder <david.b.kinder@intel.com>