### PR TITLE
adafruit_feather_m0_basic_proto: Enable usb controller in board dts

### DIFF
--- a/boards/arm/adafruit_feather_m0_basic_proto/adafruit_feather_m0_basic_proto.dts
+++ b/boards/arm/adafruit_feather_m0_basic_proto/adafruit_feather_m0_basic_proto.dts
@@ -64,3 +64,7 @@
 #endif
 	};
 };
+
+&usb0 {
+	status = "ok";
+};


### PR DESCRIPTION
This was missing from commit 34a38816f6339f15fd268906290206bf8bd2d590,
causing CI failures.

Signed-off-by: Maureen Helm <maureen.helm@nxp.com>