### PR TITLE
kconfig: Removed source "[...]mgmt/mcumgr/mgmt/port/zephyr/Kconfig"

### DIFF
--- a/ext/lib/mgmt/mcumgr/Kconfig
+++ b/ext/lib/mgmt/mcumgr/Kconfig
@@ -24,7 +24,6 @@ config MCUMGR
       This option enables the mcumgr management library.
 
 if MCUMGR
-source "ext/lib/mgmt/mcumgr/mgmt/port/zephyr/Kconfig"
 source "ext/lib/mgmt/mcumgr/cmd/Kconfig"
 
 config APP_LINK_WITH_MCUMGR


### PR DESCRIPTION
This Kconfig 'source' statement had no effect as it was referencing a
non-existing Kconfig file. It is not clear if the intention is to
include-if-exists, but I presume not.

Signed-off-by: Sebastian Bøe <sebastian.boe@nordicsemi.no>