### PR TITLE
kconfig: Don't source the non-existing zephyr/net/Kconfig

### DIFF
--- a/Kconfig.zephyr
+++ b/Kconfig.zephyr
@@ -26,8 +26,6 @@ source "dts/Kconfig"
 
 source "drivers/Kconfig"
 
-source "net/Kconfig"
-
 source "misc/Kconfig"
 
 source "lib/Kconfig"


### PR DESCRIPTION
Remove a source statement that is referencing a file that does not
exist. Presumably net/Kconfig was re-organized without this path being
updated so this statement is effectively dead code.

Signed-off-by: Sebastian Bøe <sebastian.boe@nordicsemi.no>