### PR TITLE
usb: Allow changing USB manifacturer, product, serialnumber strings

### DIFF
--- a/subsys/usb/Kconfig
+++ b/subsys/usb/Kconfig
@@ -52,21 +52,24 @@ config USB_DEVICE_PID
 
 config USB_DEVICE_MANUFACTURER
 	string
+	prompt "USB manufacturer name"
 	default "ZEPHYR"
 	help
-	  USB device Manufacturer string
+	  USB device Manufacturer string. MUST be configured by vendor.
 
 config USB_DEVICE_PRODUCT
 	string
+	prompt "USB product name"
 	default "USB-DEV"
 	help
-	  USB device Product string
+	  USB device Product string. MUST be configured by vendor.
 
 config USB_DEVICE_SN
 	string
+	prompt "USB serial number"
 	default "0.01"
 	help
-	  USB device SerialNumber string
+	  USB device SerialNumber string. MUST be configured by vendor.
 
 config USB_COMPOSITE_DEVICE
 	bool


### PR DESCRIPTION
Make it possible to change USB manufacturer, product and
serial number strings by forcing prompt in the kconfig files.

If `prompt` is not specified, and a developer writes a `CONFIG_USB_DEVICE_PRODUCT="foobar"` line in the `prj.conf`  file, a warning will be thrown during compilation. Furthermore, the default config value (`ZEPHYR`) takes precedence over the developer-supplied config value.

Signed-off-by: Iván Sánchez Ortega <ivan@sanchezortega.es>