### PR TITLE
boards: arm: improve Nucleo boards documentation formatting

### DIFF
--- a/boards/arm/nucleo_f030r8/doc/nucleof030r8.rst
+++ b/boards/arm/nucleo_f030r8/doc/nucleof030r8.rst
@@ -21,10 +21,10 @@ The STM32 Nucleo board comes with the STM32 comprehensive software HAL library t
 with various packaged software examples.
 
 .. image:: img/nucleo_f030r8_board.jpg
-     :width: 500px
-     :height: 367px
-     :align: center
-     :alt: Nucleo F030R8
+   :width: 500px
+   :height: 367px
+   :align: center
+   :alt: Nucleo F030R8
 
 More information about the board can be found at the `Nucleo F030R8 website`_.
 
@@ -34,28 +34,39 @@ Nucleo F030R8 provides the following hardware components:
 
 - STM32 microcontroller in QFP64 package
 - Two types of extension resources:
-    - Arduino* Uno V3 connectivity
-    - ST morpho extension pin headers for full access to all STM32 I/Os
+
+  - Arduino* Uno V3 connectivity
+  - ST morpho extension pin headers for full access to all STM32 I/Os
+
 - ARM* mbed*
 - On-board ST-LINK/V2-1 debugger/programmer with SWD connector:
-    - Selection-mode switch to use the kit as a standalone ST-LINK/V2-1
+
+  - Selection-mode switch to use the kit as a standalone ST-LINK/V2-1
+
 - Flexible board power supply:
-    - USB VBUS or external source (3.3V, 5V, 7 - 12V)
-    - Power management access point
+
+  - USB VBUS or external source (3.3V, 5V, 7 - 12V)
+  - Power management access point
+
 - Three LEDs:
-    - USB communication (LD1), user LED (LD2), power LED (LD3)
+
+  - USB communication (LD1), user LED (LD2), power LED (LD3)
+
 - Two push-buttons: USER and RESET
 - USB re-enumeration capability. Three different interfaces supported on USB:
-    - Virtual COM port
-    - Mass storage
-    - Debug port
-- Support of wide choice of Integrated Development Environments (IDEs) including:
-    - IAR
-    - ARM Keil
-    - GCC-based IDEs
 
-More information about STM32F030R8 can be found here:
-       - `STM32F030 reference manual`_
+  - Virtual COM port
+  - Mass storage
+  - Debug port
+
+- Support of wide choice of Integrated Development Environments (IDEs) including:
+
+  - IAR
+  - ARM Keil
+  - GCC-based IDEs
+
+More information about STM32F030R8 can be found in the
+`STM32F030 reference manual`_
 
 
 Supported Features
@@ -100,13 +111,14 @@ capable except for analog inputs.
 Board connectors:
 -----------------
 .. image:: img/nucleo_f030r8_connectors.png
-     :width: 800px
-     :align: center
-     :height: 619px
-     :alt: Nucleo F030R8 connectors
+   :width: 800px
+   :align: center
+   :height: 619px
+   :alt: Nucleo F030R8 connectors
 
 Default Zephyr Peripheral Mapping:
 ----------------------------------
+
 - UART_1_TX : PA9
 - UART_1_RX : PA10
 - UART_2_TX : PA2

--- a/boards/arm/nucleo_f091rc/doc/nucleof091rc.rst
+++ b/boards/arm/nucleo_f091rc/doc/nucleof091rc.rst
@@ -21,10 +21,10 @@ The STM32 Nucleo board comes with the STM32 comprehensive software HAL library t
 with various packaged software examples.
 
 .. image:: img/nucleo_f091rc_board.jpg
-     :width: 500px
-     :height: 367px
-     :align: center
-     :alt: Nucleo F091RC
+   :width: 500px
+   :height: 367px
+   :align: center
+   :alt: Nucleo F091RC
 
 More information about the board can be found at the `Nucleo F091RC website`_.
 
@@ -34,28 +34,39 @@ Nucleo F091RC provides the following hardware components:
 
 - STM32 microcontroller in QFP64 package
 - Two types of extension resources:
-    - Arduino* Uno V3 connectivity
-    - ST morpho extension pin headers for full access to all STM32 I/Os
+
+  - Arduino* Uno V3 connectivity
+  - ST morpho extension pin headers for full access to all STM32 I/Os
+
 - ARM* mbed*
 - On-board ST-LINK/V2-1 debugger/programmer with SWD connector:
-    - Selection-mode switch to use the kit as a standalone ST-LINK/V2-1
+
+  - Selection-mode switch to use the kit as a standalone ST-LINK/V2-1
+
 - Flexible board power supply:
-    - USB VBUS or external source (3.3V, 5V, 7 - 12V)
-    - Power management access point
+
+  - USB VBUS or external source (3.3V, 5V, 7 - 12V)
+  - Power management access point
+
 - Three LEDs:
-    - USB communication (LD1), user LED (LD2), power LED (LD3)
+
+  - USB communication (LD1), user LED (LD2), power LED (LD3)
+
 - Two push-buttons: USER and RESET
 - USB re-enumeration capability. Three different interfaces supported on USB:
-    - Virtual COM port
-    - Mass storage
-    - Debug port
-- Support of wide choice of Integrated Development Environments (IDEs) including:
-    - IAR
-    - ARM Keil
-    - GCC-based IDEs
 
-More information about STM32F091RC can be found here:
-       - `STM32F091 reference manual`_
+  - Virtual COM port
+  - Mass storage
+  - Debug port
+
+- Support of wide choice of Integrated Development Environments (IDEs) including:
+
+  - IAR
+  - ARM Keil
+  - GCC-based IDEs
+
+More information about STM32F091RC can be found in the
+`STM32F091 reference manual`_
 
 
 Supported Features
@@ -102,13 +113,14 @@ capable except for analog inputs.
 Board connectors:
 -----------------
 .. image:: img/nucleo_f091rc_connectors.png
-     :width: 800px
-     :align: center
-     :height: 619px
-     :alt: Nucleo F091RC connectors
+   :width: 800px
+   :align: center
+   :height: 619px
+   :alt: Nucleo F091RC connectors
 
 Default Zephyr Peripheral Mapping:
 ----------------------------------
+
 - UART_1_TX : PB6
 - UART_1_RX : PB7
 - UART_2_TX : PA2

--- a/boards/arm/nucleo_f103rb/doc/nucleof103rb.rst
+++ b/boards/arm/nucleo_f103rb/doc/nucleof103rb.rst
@@ -21,10 +21,10 @@ The STM32 Nucleo board comes with the STM32 comprehensive software HAL library t
 with various packaged software examples.
 
 .. image:: img/nucleo_f103rb_board.jpg
-     :width: 500px
-     :height: 367px
-     :align: center
-     :alt: Nucleo F103RB
+   :width: 500px
+   :height: 367px
+   :align: center
+   :alt: Nucleo F103RB
 
 More information about the board can be found at the `Nucleo F103RB website`_.
 
@@ -34,29 +34,41 @@ Nucleo F103RB provides the following hardware components:
 
 - STM32 microcontroller in QFP64 package
 - Two types of extension resources:
-    - Arduino* Uno V3 connectivity
-    - ST morpho extension pin headers for full access to all STM32 I/Os
+
+  - Arduino* Uno V3 connectivity
+  - ST morpho extension pin headers for full access to all STM32 I/Os
+
 - ARM* mbed*
 - On-board ST-LINK/V2-1 debugger/programmer with SWD connector:
-    - Selection-mode switch to use the kit as a standalone ST-LINK/V2-1
+
+  - Selection-mode switch to use the kit as a standalone ST-LINK/V2-1
+
 - Flexible board power supply:
-    - USB VBUS or external source (3.3V, 5V, 7 - 12V)
-    - Power management access point
+
+  - USB VBUS or external source (3.3V, 5V, 7 - 12V)
+  - Power management access point
+
 - Three LEDs:
-    - USB communication (LD1), user LED (LD2), power LED (LD3)
+
+  - USB communication (LD1), user LED (LD2), power LED (LD3)
+
 - Two push-buttons: USER and RESET
 - USB re-enumeration capability. Three different interfaces supported on USB:
-    - Virtual COM port
-    - Mass storage
-    - Debug port
+
+  - Virtual COM port
+  - Mass storage
+  - Debug port
+
 - Support of wide choice of Integrated Development Environments (IDEs) including:
-    - IAR
-    - ARM Keil
-    - GCC-based IDEs
+
+  - IAR
+  - ARM Keil
+  - GCC-based IDEs
 
 More information about STM32F103RB can be found here:
-       - `STM32F103 reference manual`_
-       - `STM32F103 data sheet`_
+
+- `STM32F103 reference manual`_
+- `STM32F103 data sheet`_
 
 Supported Features
 ==================
@@ -98,13 +110,14 @@ capable except for analog inputs.
 Board connectors:
 -----------------
 .. image:: img/nucleo_f103rb_connectors.png
-     :width: 800px
-     :align: center
-     :height: 619px
-     :alt: Nucleo F103RB connectors
+   :width: 800px
+   :align: center
+   :height: 619px
+   :alt: Nucleo F103RB connectors
 
 Default Zephyr Peripheral Mapping:
 ----------------------------------
+
 - UART_1_TX : PA9
 - UART_1_RX : PA10
 - UART_2_TX : PA2

--- a/boards/arm/nucleo_f334r8/doc/nucleof334r8.rst
+++ b/boards/arm/nucleo_f334r8/doc/nucleof334r8.rst
@@ -22,10 +22,10 @@ The STM32 Nucleo board comes with the STM32 comprehensive software HAL library t
 with various packaged software examples.
 
 .. image:: img/nucleo_f334r8_board.jpg
-     :width: 500px
-     :height: 367px
-     :align: center
-     :alt: Nucleo F334R8
+   :width: 500px
+   :height: 367px
+   :align: center
+   :alt: Nucleo F334R8
 
 More information about the board can be found at the `Nucleo F334R8 website`_.
 
@@ -35,28 +35,39 @@ Nucleo F334R8 provides the following hardware components:
 
 - STM32 microcontroller in QFP64 package
 - Two types of extension resources:
-    - Arduino* Uno V3 connectivity
-    - ST morpho extension pin headers for full access to all STM32 I/Os
+
+  - Arduino* Uno V3 connectivity
+  - ST morpho extension pin headers for full access to all STM32 I/Os
+
 - ARM* mbed*
 - On-board ST-LINK/V2-1 debugger/programmer with SWD connector:
-    - Selection-mode switch to use the kit as a standalone ST-LINK/V2-1
+
+  - Selection-mode switch to use the kit as a standalone ST-LINK/V2-1
+
 - Flexible board power supply:
-    - USB VBUS or external source (3.3V, 5V, 7 - 12V)
-    - Power management access point
+
+  - USB VBUS or external source (3.3V, 5V, 7 - 12V)
+  - Power management access point
+
 - Three LEDs:
-    - USB communication (LD1), user LED (LD2), power LED (LD3)
+
+  - USB communication (LD1), user LED (LD2), power LED (LD3)
+
 - Two push-buttons: USER and RESET
 - USB re-enumeration capability. Three different interfaces supported on USB:
-    - Virtual COM port
-    - Mass storage
-    - Debug port
-- Support of wide choice of Integrated Development Environments (IDEs) including:
-    - IAR
-    - ARM Keil
-    - GCC-based IDEs
 
-More information about STM32F334R8 can be found here:
-       - `STM32F334 reference manual`_
+  - Virtual COM port
+  - Mass storage
+  - Debug port
+
+- Support of wide choice of Integrated Development Environments (IDEs) including:
+
+  - IAR
+  - ARM Keil
+  - GCC-based IDEs
+
+More information about STM32F334R8 can be found in the
+`STM32F334 reference manual`_
 
 
 Supported Features
@@ -99,13 +110,14 @@ capable except for analog inputs.
 Board connectors:
 -----------------
 .. image:: img/nucleo_f334r8_connectors.png
-     :width: 800px
-     :align: center
-     :height: 619px
-     :alt: Nucleo F334R8 connectors
+   :width: 800px
+   :align: center
+   :height: 619px
+   :alt: Nucleo F334R8 connectors
 
 Default Zephyr Peripheral Mapping:
 ----------------------------------
+
 - UART_1_TX : PA9
 - UART_1_RX : PA10
 - UART_2_TX : PA2

--- a/boards/arm/nucleo_f401re/doc/nucleof401re.rst
+++ b/boards/arm/nucleo_f401re/doc/nucleof401re.rst
@@ -10,23 +10,26 @@ The Nucleo F401RE board features an ARM Cortex-M4 based STM32F401RE MCU
 with a wide range of connectivity support and configurations Here are
 some highlights of the Nucleo F401RE board:
 
-
 - STM32 microcontroller in QFP64 package
 - Two types of extension resources:
-       - Arduino Uno V3 connectivity
-       - ST morpho extension pin headers for full access to all STM32 I/Os
+
+  - Arduino Uno V3 connectivity
+  - ST morpho extension pin headers for full access to all STM32 I/Os
+
 - On-board ST-LINK/V2-1 debugger/programmer with SWD connector
 - Flexible board power supply:
-       - USB VBUS or external source(3.3V, 5V, 7 - 12V)
-       - Power management access point
+
+  - USB VBUS or external source(3.3V, 5V, 7 - 12V)
+  - Power management access point
+
 - Three LEDs: USB communication (LD1), user LED (LD2), power LED (LD3)
 - Two push-buttons: USER and RESET
 
 .. image:: img/nucleo64_perf_logo_1024.png
-     :width: 720px
-     :align: center
-     :height: 720px
-     :alt: Nucleo F401RE
+   :width: 720px
+   :align: center
+   :height: 720px
+   :alt: Nucleo F401RE
 
 More information about the board can be found at the `Nucleo F401RE website`_.
 
@@ -55,8 +58,9 @@ Nucleo F401RE provides the following hardware components:
 - DMA Controller
 
 More information about STM32F401RE can be found here:
-       - `STM32F401RE on www.st.com`_
-       - `STM32F401 reference manual`_
+
+- `STM32F401RE on www.st.com`_
+- `STM32F401 reference manual`_
 
 Supported Features
 ==================
@@ -83,8 +87,7 @@ The Zephyr nucleo_401re board configuration supports the following hardware feat
 Other hardware features are not yet supported on Zephyr porting.
 
 The default configuration can be found in the defconfig file:
-
-	``boards/arm/nucleo_f401re/nucleo_f401re_defconfig``
+``boards/arm/nucleo_f401re/nucleo_f401re_defconfig``
 
 
 Pin Mapping
@@ -96,20 +99,21 @@ input/output, pull-up, etc.
 Available pins:
 ---------------
 .. image:: img/nucleo_f401re_arduino.png
-     :width: 720px
-     :align: center
-     :height: 540px
-     :alt: Nucleo F401RE Arduino connectors
+   :width: 720px
+   :align: center
+   :height: 540px
+   :alt: Nucleo F401RE Arduino connectors
 .. image:: img/nucleo_f401re_morpho.png
-     :width: 720px
-     :align: center
-     :height: 540px
-     :alt: Nucleo F401RE Morpho connectors
+   :width: 720px
+   :align: center
+   :height: 540px
+   :alt: Nucleo F401RE Morpho connectors
 
 For mode details please refer to `STM32 Nucleo-64 board User Manual`_.
 
 Default Zephyr Peripheral Mapping:
 ----------------------------------
+
 - UART_1_TX : PB6
 - UART_1_RX : PB7
 - UART_2_TX : PA2

--- a/boards/arm/nucleo_f411re/doc/nucleof411re.rst
+++ b/boards/arm/nucleo_f411re/doc/nucleof411re.rst
@@ -10,23 +10,26 @@ The Nucleo F411RE board features an ARM Cortex-M4 based STM32F411RE MCU
 with a wide range of connectivity support and configurations. Here are
 some highlights of the Nucleo F411RE board:
 
-
 - STM32 microcontroller in QFP64 package
 - Two types of extension resources:
-       - Arduino Uno V3 connectivity
-       - ST morpho extension pin headers for full access to all STM32 I/Os
+
+  - Arduino Uno V3 connectivity
+  - ST morpho extension pin headers for full access to all STM32 I/Os
+
 - On-board ST-LINK/V2-1 debugger/programmer with SWD connector
 - Flexible board power supply:
-       - USB VBUS or external source(3.3V, 5V, 7 - 12V)
-       - Power management access point
+
+  - USB VBUS or external source(3.3V, 5V, 7 - 12V)
+  - Power management access point
+
 - Three LEDs: USB communication (LD1), user LED (LD2), power LED (LD3)
 - Two push-buttons: USER and RESET
 
 .. image:: img/nucleo64_perf_logo_1024.png
-     :width: 720px
-     :align: center
-     :height: 720px
-     :alt: Nucleo F411RE
+   :width: 720px
+   :align: center
+   :height: 720px
+   :alt: Nucleo F411RE
 
 More information about the board can be found at the `Nucleo F411RE website`_.
 
@@ -56,8 +59,9 @@ Nucleo F411RE provides the following hardware components:
 - CRC calculation unit
 
 More information about STM32F411RE can be found here:
-       - `STM32F411RE on www.st.com`_
-       - `STM32F411 reference manual`_
+
+- `STM32F411RE on www.st.com`_
+- `STM32F411 reference manual`_
 
 Supported Features
 ==================
@@ -83,8 +87,7 @@ The Zephyr nucleo_f411re board configuration supports the following hardware fea
 Other hardware features are not yet supported on this Zephyr port.
 
 The default configuration can be found in the defconfig file:
-
-	``boards/arm/nucleo_f411re/nucleo_f411re_defconfig``
+``boards/arm/nucleo_f411re/nucleo_f411re_defconfig``
 
 
 Connections and IOs
@@ -96,20 +99,21 @@ input/output, pull-up, etc.
 Available pins:
 ---------------
 .. image:: img/nucleo_f411re_arduino.png
-     :width: 720px
-     :align: center
-     :height: 540px
-     :alt: Nucleo F411RE Arduino connectors
+   :width: 720px
+   :align: center
+   :height: 540px
+   :alt: Nucleo F411RE Arduino connectors
 .. image:: img/nucleo_f411re_morpho.png
-     :width: 720px
-     :align: center
-     :height: 540px
-     :alt: Nucleo F411RE Morpho connectors
+   :width: 720px
+   :align: center
+   :height: 540px
+   :alt: Nucleo F411RE Morpho connectors
 
 For mode details please refer to `STM32 Nucleo-64 board User Manual`_.
 
 Default Zephyr Peripheral Mapping:
 ----------------------------------
+
 - UART_1_TX : PB6
 - UART_1_RX : PB7
 - UART_2_TX : PA2

--- a/boards/arm/nucleo_f412zg/doc/nucleof412zg.rst
+++ b/boards/arm/nucleo_f412zg/doc/nucleof412zg.rst
@@ -10,26 +10,29 @@ The Nucleo F412ZG board features an ARM Cortex-M4 based STM32F412ZG MCU
 with a wide range of connectivity support and configurations. Here are
 some highlights of the Nucleo F412ZG board:
 
-
 - STM32 microcontroller in LQFP144 package
 - Two types of extension resources:
-       - ST Zio connector including: support for Arduino* Uno V3 connectivity
-         (A0 to A5, D0 to D15) and additional signals exposing a wide range of
-         peripherals
-       - ST morpho extension pin headers for full access to all STM32 I/Os
+
+  - ST Zio connector including: support for Arduino* Uno V3 connectivity
+    (A0 to A5, D0 to D15) and additional signals exposing a wide range of
+    peripherals
+  - ST morpho extension pin headers for full access to all STM32 I/Os
+
 - On-board ST-LINK/V2-1 debugger/programmer with SWD connector
 - Flexible board power supply:
-       - 5 V from ST-LINK/V2-1 USB VBUS
-       - External power sources: 3.3 V and 7 - 12 V on ST Zio or ST morpho
-         connectors, 5 V on ST morpho connector
+
+  - 5 V from ST-LINK/V2-1 USB VBUS
+  - External power sources: 3.3 V and 7 - 12 V on ST Zio or ST morpho
+    connectors, 5 V on ST morpho connector
+
 - Three user LEDs
 - Two push-buttons: USER and RESET
 
 .. image:: img/Nucleo144_perf_logo_1024.png
-     :width: 720px
-     :align: center
-     :height: 720px
-     :alt: Nucleo F412ZG
+   :width: 720px
+   :align: center
+   :height: 720px
+   :alt: Nucleo F412ZG
 
 More information about the board can be found at the `Nucleo F412ZG website`_.
 
@@ -59,8 +62,9 @@ Nucleo F412ZG provides the following hardware components:
 - CRC calculation unit
 
 More information about STM32F412ZG can be found here:
-       - `STM32F412ZG on www.st.com`_
-       - `STM32F412 reference manual`_
+
+- `STM32F412ZG on www.st.com`_
+- `STM32F412 reference manual`_
 
 Supported Features
 ==================
@@ -89,8 +93,7 @@ The Zephyr nucleo_412zg board configuration supports the following hardware feat
 Other hardware features are not yet supported on this Zephyr port.
 
 The default configuration can be found in the defconfig file:
-
-	``boards/arm/nucleo_f412zg/nucleo_f412zg_defconfig``
+``boards/arm/nucleo_f412zg/nucleo_f412zg_defconfig``
 
 
 Connections and IOs
@@ -102,30 +105,31 @@ input/output, pull-up, etc.
 Available pins:
 ---------------
 .. image:: img/nucleo_f412zg_zio_left.png
-     :width: 720px
-     :align: center
-     :height: 540px
-     :alt: Nucleo F412ZG ZIO connectors (left)
+   :width: 720px
+   :align: center
+   :height: 540px
+   :alt: Nucleo F412ZG ZIO connectors (left)
 .. image:: img/nucleo_f412zg_zio_right.png
-     :width: 720px
-     :align: center
-     :height: 540px
-     :alt: Nucleo F412ZG ZIO connectors (right)
+   :width: 720px
+   :align: center
+   :height: 540px
+   :alt: Nucleo F412ZG ZIO connectors (right)
 .. image:: img/nucleo_f412zg_morpho_left.png
-     :width: 720px
-     :align: center
-     :height: 540px
-     :alt: Nucleo F412ZG Morpho connectors (left)
+   :width: 720px
+   :align: center
+   :height: 540px
+   :alt: Nucleo F412ZG Morpho connectors (left)
 .. image:: img/nucleo_f412zg_morpho_right.png
-     :width: 720px
-     :align: center
-     :height: 540px
-     :alt: Nucleo F412ZG Morpho connectors (right)
+   :width: 720px
+   :align: center
+   :height: 540px
+   :alt: Nucleo F412ZG Morpho connectors (right)
 
 For more details please refer to `STM32 Nucleo-144 board User Manual`_.
 
 Default Zephyr Peripheral Mapping:
 ----------------------------------
+
 - UART_3_TX : PD8
 - UART_3_RX : PD9
 - PWM_2_CH1 : PA0

--- a/boards/arm/nucleo_f413zh/doc/nucleof413zh.rst
+++ b/boards/arm/nucleo_f413zh/doc/nucleof413zh.rst
@@ -10,26 +10,29 @@ The Nucleo F413ZH board features an ARM Cortex-M4 based STM32F413ZH MCU
 with a wide range of connectivity support and configurations. Here are
 some highlights of the Nucleo F413ZH board:
 
-
 - STM32 microcontroller in LQFP144 package
 - Two types of extension resources:
-       - ST Zio connector including: support for Arduino* Uno V3 connectivity
-         (A0 to A5, D0 to D15) and additional signals exposing a wide range of
-         peripherals
-       - ST morpho extension pin headers for full access to all STM32 I/Os
+
+  - ST Zio connector including: support for Arduino* Uno V3 connectivity
+    (A0 to A5, D0 to D15) and additional signals exposing a wide range of
+    peripherals
+  - ST morpho extension pin headers for full access to all STM32 I/Os
+
 - On-board ST-LINK/V2-1 debugger/programmer with SWD connector
 - Flexible board power supply:
-       - 5 V from ST-LINK/V2-1 USB VBUS
-       - External power sources: 3.3 V and 7 - 12 V on ST Zio or ST morpho
-         connectors, 5 V on ST morpho connector
+
+  - 5 V from ST-LINK/V2-1 USB VBUS
+  - External power sources: 3.3 V and 7 - 12 V on ST Zio or ST morpho
+    connectors, 5 V on ST morpho connector
+
 - Three user LEDs
 - Two push-buttons: USER and RESET
 
 .. image:: img/Nucleo144_perf_logo_1024.png
-     :width: 720px
-     :align: center
-     :height: 720px
-     :alt: Nucleo F413ZH
+   :width: 720px
+   :align: center
+   :height: 720px
+   :alt: Nucleo F413ZH
 
 More information about the board can be found at the `Nucleo F413ZH website`_.
 
@@ -59,8 +62,9 @@ Nucleo F413ZH provides the following hardware components:
 - CRC calculation unit
 
 More information about STM32F413ZH can be found here:
-       - `STM32F413ZH on www.st.com`_
-       - `STM32F413/423 reference manual`_
+
+- `STM32F413ZH on www.st.com`_
+- `STM32F413/423 reference manual`_
 
 Supported Features
 ==================
@@ -85,8 +89,7 @@ The Zephyr nucleo_413zh board configuration supports the following hardware feat
 Other hardware features are not yet supported on this Zephyr port.
 
 The default configuration can be found in the defconfig file:
-
-	``boards/arm/nucleo_f413zh/nucleo_f413zh_defconfig``
+``boards/arm/nucleo_f413zh/nucleo_f413zh_defconfig``
 
 
 Connections and IOs
@@ -98,30 +101,31 @@ input/output, pull-up, etc.
 Available pins:
 ---------------
 .. image:: img/nucleo_f412zg_zio_left.png
-     :width: 720px
-     :align: center
-     :height: 540px
-     :alt: Nucleo F413ZH ZIO connectors (left)
+   :width: 720px
+   :align: center
+   :height: 540px
+   :alt: Nucleo F413ZH ZIO connectors (left)
 .. image:: img/nucleo_f412zg_zio_right.png
-     :width: 720px
-     :align: center
-     :height: 540px
-     :alt: Nucleo F413ZH ZIO connectors (right)
+   :width: 720px
+   :align: center
+   :height: 540px
+   :alt: Nucleo F413ZH ZIO connectors (right)
 .. image:: img/nucleo_f412zg_morpho_left.png
-     :width: 720px
-     :align: center
-     :height: 540px
-     :alt: Nucleo F413ZH Morpho connectors (left)
+   :width: 720px
+   :align: center
+   :height: 540px
+   :alt: Nucleo F413ZH Morpho connectors (left)
 .. image:: img/nucleo_f412zg_morpho_right.png
-     :width: 720px
-     :align: center
-     :height: 540px
-     :alt: Nucleo F413ZH Morpho connectors (right)
+   :width: 720px
+   :align: center
+   :height: 540px
+   :alt: Nucleo F413ZH Morpho connectors (right)
 
 For mode details please refer to `STM32 Nucleo-144 board User Manual`_.
 
 Default Zephyr Peripheral Mapping:
 ----------------------------------
+
 - UART_3_TX : PD8
 - UART_3_RX : PD9
 - PWM_2_CH1 : PA0

--- a/boards/arm/nucleo_f429zi/doc/nucleof429zi.rst
+++ b/boards/arm/nucleo_f429zi/doc/nucleof429zi.rst
@@ -10,31 +10,32 @@ The Nucleo F429ZI board features an ARM Cortex-M4 based STM32F429ZI MCU
 with a wide range of connectivity support and configurations. Here are
 some highlights of the Nucleo F429ZI board:
 
-
 - STM32 microcontroller in LQFP144 package
 - LSE crystal: 32.768 kHz crystal oscillator
 - USB OTG
 - Ethernet compliant with IEEE-802.3-2002
 - Two types of extension resources:
 
-       - ST Zio connector including: support for Arduino* Uno V3 connectivity
-         (A0 to A5, D0 to D15) and additional signals exposing a wide range of
-         peripherals
-       - ST morpho extension pin headers for full access to all STM32 I/Os
+  - ST Zio connector including: support for Arduino* Uno V3 connectivity
+    (A0 to A5, D0 to D15) and additional signals exposing a wide range of
+    peripherals
+  - ST morpho extension pin headers for full access to all STM32 I/Os
+
 - On-board ST-LINK/V2-1 debugger/programmer with SWD connector
 - Flexible board power supply:
 
-       - 5 V from ST-LINK/V2-1 USB VBUS
-       - External power sources: 3.3 V and 7 - 12 V on ST Zio or ST morpho
-         connectors, 5 V on ST morpho connector
+  - 5 V from ST-LINK/V2-1 USB VBUS
+  - External power sources: 3.3 V and 7 - 12 V on ST Zio or ST morpho
+    connectors, 5 V on ST morpho connector
+
 - Three user LEDs
 - Two push-buttons: USER and RESET
 
 .. image:: img/Nucleo144_perf_logo_1024.png
-     :width: 720px
-     :align: center
-     :height: 720px
-     :alt: Nucleo F429ZI
+   :width: 720px
+   :align: center
+   :height: 720px
+   :alt: Nucleo F429ZI
 
 More information about the board can be found at the `Nucleo F429ZI website`_.
 
@@ -70,9 +71,10 @@ The Nucleo F429ZI provides the following hardware components:
 - DMA Controller
 
 More information about STM32F429ZI can be found here:
-       - `STM32F429ZI on www.st.com`_
-       - `STM32F429 reference manual`_
-       - `STM32F429 datasheet`_
+
+- `STM32F429ZI on www.st.com`_
+- `STM32F429 reference manual`_
+- `STM32F429 datasheet`_
 
 Supported Features
 ==================
@@ -102,8 +104,7 @@ The Zephyr nucleo_f249zi board configuration supports the following hardware fea
 Other hardware features are not yet supported on this Zephyr port.
 
 The default configuration can be found in the defconfig file:
-
-	``boards/arm/nucleo_f429zi/nucleo_f429zi_defconfig``
+``boards/arm/nucleo_f429zi/nucleo_f429zi_defconfig``
 
 
 Connections and IOs
@@ -115,25 +116,25 @@ input/output, pull-up, etc.
 Available pins:
 ---------------
 .. image:: img/nucleo_f429zi_cn8.png
-     :width: 720px
-     :align: center
-     :height: 540px
-     :alt: Nucleo F429ZI ZIO connectors (left)
+   :width: 720px
+   :align: center
+   :height: 540px
+   :alt: Nucleo F429ZI ZIO connectors (left)
 .. image:: img/nucleo_f429zi_cn7.png
-     :width: 720px
-     :align: center
-     :height: 540px
-     :alt: Nucleo F429ZI ZIO connectors (right)
+   :width: 720px
+   :align: center
+   :height: 540px
+   :alt: Nucleo F429ZI ZIO connectors (right)
 .. image:: img/nucleo_f429zi_cn11.png
-     :width: 720px
-     :align: center
-     :height: 540px
-     :alt: Nucleo F429ZI Morpho connectors (left)
+   :width: 720px
+   :align: center
+   :height: 540px
+   :alt: Nucleo F429ZI Morpho connectors (left)
 .. image:: img/nucleo_f429zi_cn12.png
-     :width: 720px
-     :align: center
-     :height: 540px
-     :alt: Nucleo F429ZI Morpho connectors (right)
+   :width: 720px
+   :align: center
+   :height: 540px
+   :alt: Nucleo F429ZI Morpho connectors (right)
 
 For mode details please refer to `STM32 Nucleo-144 board User Manual`_.
 

--- a/boards/arm/nucleo_f446re/doc/nucleof446re.rst
+++ b/boards/arm/nucleo_f446re/doc/nucleof446re.rst
@@ -10,25 +10,26 @@ The Nucleo F446RE board features an ARM Cortex-M4 based STM32F446RE MCU
 with a wide range of connectivity support and configurations. Here are
 some highlights of the Nucleo F446RE board:
 
-
 - STM32 microcontroller in QFP64 package
 - Two types of extension resources:
 
   - Arduino Uno V3 connectivity
   - ST morpho extension pin headers for full access to all STM32 I/Os
+
 - On-board ST-LINK/V2-1 debugger/programmer with SWD connector
 - Flexible board power supply:
 
   - USB VBUS or external source(3.3V, 5V, 7 - 12V)
   - Power management access point
+
 - Three LEDs: USB communication (LD1), user LED (LD2), power LED (LD3)
 - Two push-buttons: USER and RESET
 
 .. image:: img/nucleo64_perf_logo_1024.png
-     :width: 720px
-     :align: center
-     :height: 720px
-     :alt: Nucleo F446RE
+   :width: 720px
+   :align: center
+   :height: 720px
+   :alt: Nucleo F446RE
 
 More information about the board can be found at the `Nucleo F446RE website`_.
 
@@ -62,8 +63,6 @@ Nucleo F446RE provides the following hardware components:
 - 12-bit ADC(3) with 16 channels
 - 12-bit DAC with 2 channels
 
-
-
 More information about STM32F446RE can be found here:
 
 - `STM32F446RE on www.st.com`_
@@ -93,8 +92,7 @@ The Zephyr nucleo_f446re board configuration supports the following hardware fea
 Other hardware features are not yet supported on this Zephyr port.
 
 The default configuration can be found in the defconfig file:
-
-	``boards/arm/nucleo_f446re/nucleo_f446re_defconfig``
+``boards/arm/nucleo_f446re/nucleo_f446re_defconfig``
 
 
 Connections and IOs
@@ -106,30 +104,31 @@ input/output, pull-up, etc.
 Available pins:
 ---------------
 .. image:: img/nucleo_f446re_arduino_top_left.png
-     :width: 720px
-     :align: center
-     :height: 540px
-     :alt: Nucleo F446RE Arduino connectors (top left)
+   :width: 720px
+   :align: center
+   :height: 540px
+   :alt: Nucleo F446RE Arduino connectors (top left)
 .. image:: img/nucleo_f446re_arduino_top_right.png
-     :width: 720px
-     :align: center
-     :height: 540px
-     :alt: Nucleo F446RE Arduino connectors (top right)
+   :width: 720px
+   :align: center
+   :height: 540px
+   :alt: Nucleo F446RE Arduino connectors (top right)
 .. image:: img/nucleo_f446re_morpho_top_left.png
-     :width: 720px
-     :align: center
-     :height: 540px
-     :alt: Nucleo F446RE Morpho connectors (top left)
+   :width: 720px
+   :align: center
+   :height: 540px
+   :alt: Nucleo F446RE Morpho connectors (top left)
 .. image:: img/nucleo_f446re_morpho_top_right.png
-     :width: 720px
-     :align: center
-     :height: 540px
-     :alt: Nucleo F446RE Morpho connectors (top right)
+   :width: 720px
+   :align: center
+   :height: 540px
+   :alt: Nucleo F446RE Morpho connectors (top right)
 
 For mode details please refer to `STM32 Nucleo-64 board User Manual`_.
 
 Default Zephyr Peripheral Mapping:
 ----------------------------------
+
 - UART_1_TX : PB6
 - UART_1_RX : PB7
 - UART_2_TX : PA2

--- a/boards/arm/nucleo_l432kc/doc/nucleol432kc.rst
+++ b/boards/arm/nucleo_l432kc/doc/nucleol432kc.rst
@@ -15,17 +15,17 @@ some highlights of the Nucleo L432KC board:
 - On-board ST-LINK/V2-1 debugger/programmer with SWD connector
 - Flexible board power supply:
 
-       - USB VBUS or external source(3.3V, 5V, 7 - 12V)
-       - Power management access point
+  - USB VBUS or external source(3.3V, 5V, 7 - 12V)
+  - Power management access point
 
 - Three LEDs: USB communication (LD1), user LED (LD2), power LED (LD3)
 - One push-button: RESET
 
 .. image:: img/nucleo32_ulp_logo.jpg
-     :width: 250px
-     :align: center
-     :height: 188px
-     :alt: Nucleo L432KC
+  :width: 250px
+  :align: center
+  :height: 188px
+  :alt: Nucleo L432KC
 
 More information about the board can be found at the `Nucleo L432KC website`_.
 
@@ -40,49 +40,49 @@ The STM32L432KC SoC provides the following hardware IPs:
   100DMIPS/1.25DMIPS/MHz (Dhrystone 2.1)
 - Clock Sources:
 
-        - 32 kHz crystal oscillator for RTC (LSE)
-        - Internal 16 MHz factory-trimmed RC ( |plusminus| 1%)
-        - Internal low-power 32 kHz RC ( |plusminus| 5%)
-        - Internal multispeed 100 kHz to 48 MHz oscillator, auto-trimmed by
-          LSE (better than |plusminus| 0.25 % accuracy)
-        - 2 PLLs for system clock, USB, audio, ADC
+  - 32 kHz crystal oscillator for RTC (LSE)
+  - Internal 16 MHz factory-trimmed RC ( |plusminus| 1%)
+  - Internal low-power 32 kHz RC ( |plusminus| 5%)
+  - Internal multispeed 100 kHz to 48 MHz oscillator, auto-trimmed by
+    LSE (better than |plusminus| 0.25 % accuracy)
+  - 2 PLLs for system clock, USB, audio, ADC
 
 - RTC with HW calendar, alarms and calibration
 - Up to 3 capacitive sensing channels: support touchkey, linear and rotary touch sensors
 - 11x timers:
 
-        - 1x 16-bit advanced motor-control
-        - 1x 32-bit and 2x 16-bit general purpose
-        - 2x 16-bit basic
-        - 2x low-power 16-bit timers (available in Stop mode)
-        - 2x watchdogs
-        - SysTick timer
+  - 1x 16-bit advanced motor-control
+  - 1x 32-bit and 2x 16-bit general purpose
+  - 2x 16-bit basic
+  - 2x low-power 16-bit timers (available in Stop mode)
+  - 2x watchdogs
+  - SysTick timer
 
 - Up to 26 fast I/Os, most 5 V-tolerant
 - Memories
 
-        - Up to 256 KB single bank Flash, proprietary code readout protection
-        - Up to 64 KB of SRAM including 16 KB with hardware parity check
-        - Quad SPI memory interface
+  - Up to 256 KB single bank Flash, proprietary code readout protection
+  - Up to 64 KB of SRAM including 16 KB with hardware parity check
+  - Quad SPI memory interface
 
 - Rich analog peripherals (independent supply)
 
-        - 1x 12-bit ADC 5 MSPS, up to 16-bit with hardware oversampling, 200
-          |micro| A/MSPS
-        - 2x 12-bit DAC, low-power sample and hold
-        - 1x operational amplifiers with built-in PGA
-        - 2x ultra-low-power comparators
+  - 1x 12-bit ADC 5 MSPS, up to 16-bit with hardware oversampling, 200
+    |micro| A/MSPS
+  - 2x 12-bit DAC, low-power sample and hold
+  - 1x operational amplifiers with built-in PGA
+  - 2x ultra-low-power comparators
 
 - 13x communication interfaces
 
-        - USB OTG 2.0 full-speed crystal less solution with LPM and BCD
-        - 1x SAIs (serial audio interface)
-        - 2x I2C FM+(1 Mbit/s), SMBus/PMBus
-        - 3x USARTs (ISO 7816, LIN, IrDA, modem)
-        - 2x SPIs (3x SPIs with the Quad SPI)
-        - CAN (2.0B Active)
-        - SWPMI single wire protocol master I/F
-        - IRTIM (Infrared interface)
+  - USB OTG 2.0 full-speed crystal less solution with LPM and BCD
+  - 1x SAIs (serial audio interface)
+  - 2x I2C FM+(1 Mbit/s), SMBus/PMBus
+  - 3x USARTs (ISO 7816, LIN, IrDA, modem)
+  - 2x SPIs (3x SPIs with the Quad SPI)
+  - CAN (2.0B Active)
+  - SWPMI single wire protocol master I/F
+  - IRTIM (Infrared interface)
 
 - 14-channel DMA controller
 - True random number generator
@@ -91,8 +91,9 @@ The STM32L432KC SoC provides the following hardware IPs:
 
 
 More information about STM32L432KC can be found here:
-       - `STM32L432KC on www.st.com`_
-       - `STM32L432 reference manual`_
+
+- `STM32L432KC on www.st.com`_
+- `STM32L432 reference manual`_
 
 Supported Features
 ==================
@@ -119,8 +120,7 @@ The Zephyr nucleo_l432kc board configuration supports the following hardware fea
 Other hardware features are not yet supported on this Zephyr port.
 
 The default configuration can be found in the defconfig file:
-
-	``boards/arm/nucleo_l432kc/nucleo_l432kc_defconfig``
+``boards/arm/nucleo_l432kc/nucleo_l432kc_defconfig``
 
 
 Connections and IOs
@@ -132,10 +132,10 @@ input/output, pull-up, etc.
 Available pins:
 ---------------
 .. image:: img/nucleo_l432kc_arduino_nano.png
-     :width: 960px
-     :align: center
-     :height: 720px
-     :alt: Nucleo L432KC Arduino connectors
+   :width: 960px
+   :align: center
+   :height: 720px
+   :alt: Nucleo L432KC Arduino connectors
 
 For mode details please refer to `STM32 Nucleo-32 board User Manual`_.
 

--- a/boards/arm/nucleo_l476rg/doc/nucleol476rg.rst
+++ b/boards/arm/nucleo_l476rg/doc/nucleol476rg.rst
@@ -13,20 +13,24 @@ some highlights of the Nucleo L476RG board:
 
 - STM32 microcontroller in QFP64 package
 - Two types of extension resources:
-       - Arduino Uno V3 connectivity
-       - ST morpho extension pin headers for full access to all STM32 I/Os
+
+  - Arduino Uno V3 connectivity
+  - ST morpho extension pin headers for full access to all STM32 I/Os
+
 - On-board ST-LINK/V2-1 debugger/programmer with SWD connector
 - Flexible board power supply:
-       - USB VBUS or external source(3.3V, 5V, 7 - 12V)
-       - Power management access point
+
+   - USB VBUS or external source(3.3V, 5V, 7 - 12V)
+   - Power management access point
+
 - Three LEDs: USB communication (LD1), user LED (LD2), power LED (LD3)
 - Two push-buttons: USER and RESET
 
 .. image:: img/nucleo64_ulp_logo_1024.jpg
-     :width: 250px
-     :align: center
-     :height: 250px
-     :alt: Nucleo L476RG
+   :width: 250px
+   :align: center
+   :height: 250px
+   :alt: Nucleo L476RG
 
 More information about the board can be found at the `Nucleo L476RG website`_.
 
@@ -38,43 +42,53 @@ The STM32L476RG SoC provides the following hardware IPs:
 - Ultra-low-power with FlexPowerControl (down to 130 nA Standby mode and 100 uA/MHz run mode)
 - Core: ARM |reg| 32-bit Cortex |reg|-M4 CPU with FPU, frequency up to 80 MHz, 100DMIPS/1.25DMIPS/MHz (Dhrystone 2.1)
 - Clock Sources:
-        - 4 to 48 MHz crystal oscillator
-        - 32 kHz crystal oscillator for RTC (LSE)
-        - Internal 16 MHz factory-trimmed RC ( |plusminus| 1%)
-        - Internal low-power 32 kHz RC ( |plusminus| 5%)
-        - Internal multispeed 100 kHz to 48 MHz oscillator, auto-trimmed by
-          LSE (better than  |plusminus| 0.25 % accuracy)
-        - 3 PLLs for system clock, USB, audio, ADC
+
+  - 4 to 48 MHz crystal oscillator
+  - 32 kHz crystal oscillator for RTC (LSE)
+  - Internal 16 MHz factory-trimmed RC ( |plusminus| 1%)
+  - Internal low-power 32 kHz RC ( |plusminus| 5%)
+  - Internal multispeed 100 kHz to 48 MHz oscillator, auto-trimmed by
+    LSE (better than  |plusminus| 0.25 % accuracy)
+  - 3 PLLs for system clock, USB, audio, ADC
+
 - RTC with HW calendar, alarms and calibration
 - LCD 8 x 40 or 4 x 44 with step-up converter
 - Up to 24 capacitive sensing channels: support touchkey, linear and rotary touch sensors
 - 16x timers:
-        - 2x 16-bit advanced motor-control
-        - 2x 32-bit and 5x 16-bit general purpose
-        - 2x 16-bit basic
-        - 2x low-power 16-bit timers (available in Stop mode)
-        - 2x watchdogs
-        - SysTick timer
+
+  - 2x 16-bit advanced motor-control
+  - 2x 32-bit and 5x 16-bit general purpose
+  - 2x 16-bit basic
+  - 2x low-power 16-bit timers (available in Stop mode)
+  - 2x watchdogs
+  - SysTick timer
+
 - Up to 114 fast I/Os, most 5 V-tolerant, up to 14 I/Os with independent supply down to 1.08 V
 - Memories
-        - Up to 1 MB Flash, 2 banks read-while-write, proprietary code readout protection
-        - Up to 128 KB of SRAM including 32 KB with hardware parity check
-        - External memory interface for static memories supporting SRAM, PSRAM, NOR and NAND memories
-        - Quad SPI memory interface
+
+  - Up to 1 MB Flash, 2 banks read-while-write, proprietary code readout protection
+  - Up to 128 KB of SRAM including 32 KB with hardware parity check
+  - External memory interface for static memories supporting SRAM, PSRAM, NOR and NAND memories
+  - Quad SPI memory interface
+
 - 4x digital filters for sigma delta modulator
 - Rich analog peripherals (independent supply)
-        - 3x 12-bit ADC 5 MSPS, up to 16-bit with hardware oversampling, 200 uA/MSPS
-        - 2x 12-bit DAC, low-power sample and hold
-        - 2x operational amplifiers with built-in PGA
-        - 2x ultra-low-power comparators
+
+  - 3x 12-bit ADC 5 MSPS, up to 16-bit with hardware oversampling, 200 uA/MSPS
+  - 2x 12-bit DAC, low-power sample and hold
+  - 2x operational amplifiers with built-in PGA
+  - 2x ultra-low-power comparators
+
 - 18x communication interfaces
-        - USB OTG 2.0 full-speed, LPM and BCD
-        - 2x SAIs (serial audio interface)
-        - 3x I2C FM+(1 Mbit/s), SMBus/PMBus
-        - 6x USARTs (ISO 7816, LIN, IrDA, modem)
-        - 3x SPIs (4x SPIs with the Quad SPI)
-        - CAN (2.0B Active) and SDMMC interface
-        - SWPMI single wire protocol master I/F
+
+  - USB OTG 2.0 full-speed, LPM and BCD
+  - 2x SAIs (serial audio interface)
+  - 3x I2C FM+(1 Mbit/s), SMBus/PMBus
+  - 6x USARTs (ISO 7816, LIN, IrDA, modem)
+  - 3x SPIs (4x SPIs with the Quad SPI)
+  - CAN (2.0B Active) and SDMMC interface
+  - SWPMI single wire protocol master I/F
+
 - 14-channel DMA controller
 - True random number generator
 - CRC calculation unit, 96-bit unique ID
@@ -82,8 +96,9 @@ The STM32L476RG SoC provides the following hardware IPs:
 
 
 More information about STM32L476RG can be found here:
-       - `STM32L476RG on www.st.com`_
-       - `STM32L476 reference manual`_
+
+- `STM32L476RG on www.st.com`_
+- `STM32L476 reference manual`_
 
 Supported Features
 ==================
@@ -112,8 +127,7 @@ The Zephyr nucleo_l476rg board configuration supports the following hardware fea
 Other hardware features are not yet supported on this Zephyr port.
 
 The default configuration can be found in the defconfig file:
-
-	``boards/arm/nucleo_l476rg/nucleo_l476rg_defconfig``
+``boards/arm/nucleo_l476rg/nucleo_l476rg_defconfig``
 
 
 Connections and IOs
@@ -125,15 +139,15 @@ input/output, pull-up, etc.
 Available pins:
 ---------------
 .. image:: img/nucleo_l476rg_arduino.png
-     :width: 720px
-     :align: center
-     :height: 540px
-     :alt: Nucleo L476RG Arduino connectors
+   :width: 720px
+   :align: center
+   :height: 540px
+   :alt: Nucleo L476RG Arduino connectors
 .. image:: img/nucleo_l476rg_morpho.png
-     :width: 720px
-     :align: center
-     :height: 540px
-     :alt: Nucleo L476RG Morpho connectors
+   :width: 720px
+   :align: center
+   :height: 540px
+   :alt: Nucleo L476RG Morpho connectors
 
 For mode details please refer to `STM32 Nucleo-64 board User Manual`_.
 
@@ -212,7 +226,7 @@ Then build and flash the application.
    :board: nucleo_l476rg
    :goals: build flash
 
-You should see the following message  on the console:
+You should see the following message on the console:
 
 .. code-block:: console
 


### PR DESCRIPTION
Improve ReST formatting for copy-pasted Nucleo boards documentation.

Discussed in #6558.

Signed-off-by: Ilya Tagunov <tagunil@gmail.com>