### PR TITLE
kconfig: Remove UTF-8 character from author's name

### DIFF
--- a/arch/arm/soc/st_stm32/stm32f4/Kconfig.defconfig.stm32f446xe
+++ b/arch/arm/soc/st_stm32/stm32f4/Kconfig.defconfig.stm32f446xe
@@ -1,6 +1,6 @@
 # Kconfig - ST STM32F446XE MCU configuration options
 #
-# Copyright (c) 2018 Philémon Jaermann.
+# Copyright (c) 2018 Philemon Jaermann.
 #
 # SPDX-License-Identifier: Apache-2.0
 #


### PR DESCRIPTION
Kconfiglib does not support UTF-8 properly yet, so avoid issues by
removing the UTF-8 character from the name until this is fixed.

See https://github.com/ulfalizer/Kconfiglib/pull/41

Signed-off-by: Carles Cufi <carles.cufi@nordicsemi.no>