### PR TITLE
usb: Rename unicode into UTF16LE

### DIFF
--- a/include/usb/usb_common.h
+++ b/include/usb/usb_common.h
@@ -144,7 +144,7 @@ struct usb_device_descriptor {
 	u8_t bNumConfigurations;
 } __packed;
 
-/** UNICODE String Descriptor */
+/** Unicode (UTF16LE) String Descriptor */
 struct usb_string_descriptor {
 	u8_t bLength;
 	u8_t bDescriptorType;

--- a/samples/subsys/usb/webusb/src/webusb_serial.c
+++ b/samples/subsys/usb/webusb/src/webusb_serial.c
@@ -143,19 +143,19 @@ struct dev_common_descriptor {
 			u8_t bLength;
 			u8_t bDescriptorType;
 			u8_t bString[0x0C - 2];
-		} __packed unicode_mfr;
+		} __packed utf16le_mfr;
 
 		struct usb_product_descriptor {
 			u8_t bLength;
 			u8_t bDescriptorType;
 			u8_t bString[0x0E - 2];
-		} __packed unicode_product;
+		} __packed utf16le_product;
 
 		struct usb_sn_descriptor {
 			u8_t bLength;
 			u8_t bDescriptorType;
 			u8_t bString[0x0C - 2];
-		} __packed unicode_sn;
+		} __packed utf16le_sn;
 	} __packed string_descr;
 	struct usb_desc_header term_descr;
 } __packed;
@@ -328,20 +328,20 @@ static struct dev_common_descriptor webusb_serial_usb_description = {
 			.bString = sys_cpu_to_le16(0x0409),
 		},
 		/* Manufacturer String Descriptor */
-		.unicode_mfr = {
+		.utf16le_mfr = {
 			.bLength = 0x0C,
 			.bDescriptorType = USB_STRING_DESC,
 			.bString = {'I', 0, 'n', 0, 't', 0, 'e', 0, 'l', 0,},
 		},
 		/* Product String Descriptor */
-		.unicode_product = {
+		.utf16le_product = {
 			.bLength = 0x0E,
 			.bDescriptorType = USB_STRING_DESC,
 			.bString = {'W', 0, 'e', 0, 'b', 0, 'U', 0, 'S', 0,
 				    'B', 0,},
 		},
 		/* Serial Number String Descriptor */
-		.unicode_sn = {
+		.utf16le_sn = {
 			.bLength = 0x0C,
 			.bDescriptorType = USB_STRING_DESC,
 			.bString = {'0', 0, '0', 0, '.', 0, '0', 0, '1', 0,},

--- a/subsys/usb/usb_descriptor.c
+++ b/subsys/usb/usb_descriptor.c
@@ -8,6 +8,7 @@
  */
 
 #include <misc/byteorder.h>
+#include <misc/__assert.h>
 #include <usb/usbstruct.h>
 #include <usb/usb_device.h>
 #include <usb/usb_common.h>
@@ -20,11 +21,13 @@
 #include <logging/sys_log.h>
 
 /*
- * The USB Unicode bString is twice as long as initializer_string
+ * The USB Unicode bString is encoded in UTF16LE, which means it takes up
+ * twice the amount of bytes than the same string encoded in ASCII7.
+ *
  * without null character:
- *   uc_length = (sizeof(initializer_string) - 1) * 2
+ *   utf16_length = (sizeof(initializer_string) - 1) * 2
  * or:
- *   uc_length = sizeof(initializer_string) * 2 - 2
+ *   utf16_length = sizeof(initializer_string) * 2 - 2
  * the last index of the bString is:
  *   idx_max = sizeof(initializer_string) * 2 - 2 - 1
  * and the last index of the initializer_string without null character is:
@@ -33,8 +36,8 @@
  *
  * The length of the string descriptor is calculated from the
  * size of the two octets bLength and bDescriptorType plus the
- * length of the Unicode string:
- *   descr_length = 2 + uc_length
+ * length of the UTF16LE string:
+ *   descr_length = 2 + utf16_length
  *   descr_length = 2 + sizeof(initializer-string) * 2 - 2
  *   descr_length = sizeof(initializer-string) * 2
  *
@@ -116,25 +119,25 @@ struct dev_common_descriptor {
 			u8_t bLength;
 			u8_t bDescriptorType;
 			u8_t bString[MFR_DESC_LENGTH - 2];
-		} __packed unicode_mfr;
+		} __packed utf16le_mfr;
 
 		struct usb_product_descriptor {
 			u8_t bLength;
 			u8_t bDescriptorType;
 			u8_t bString[PRODUCT_DESC_LENGTH - 2];
-		} __packed unicode_product;
+		} __packed utf16le_product;
 
 		struct usb_sn_descriptor {
 			u8_t bLength;
 			u8_t bDescriptorType;
 			u8_t bString[SN_DESC_LENGTH - 2];
-		} __packed unicode_sn;
+		} __packed utf16le_sn;
 #ifdef CONFIG_USB_DEVICE_NETWORK_ECM
 		struct usb_cdc_ecm_mac_descriptor {
 			u8_t bLength;
 			u8_t bDescriptorType;
 			u8_t bString[ECM_MAC_DESC_LENGTH - 2];
-		} __packed unicode_mac;
+		} __packed utf16le_mac;
 #endif /* CONFIG_USB_DEVICE_NETWORK_ECM */
 	} __packed string_descr;
 	struct usb_desc_header term_descr;
@@ -602,25 +605,25 @@ static struct dev_common_descriptor common_desc = {
 			.bString = sys_cpu_to_le16(0x0409),
 		},
 		/* Manufacturer String Descriptor */
-		.unicode_mfr = {
+		.utf16le_mfr = {
 			.bLength = MFR_DESC_LENGTH,
 			.bDescriptorType = USB_STRING_DESC,
 			.bString = CONFIG_USB_DEVICE_MANUFACTURER,
 		},
 		/* Product String Descriptor */
-		.unicode_product = {
+		.utf16le_product = {
 			.bLength = PRODUCT_DESC_LENGTH,
 			.bDescriptorType = USB_STRING_DESC,
 			.bString = CONFIG_USB_DEVICE_PRODUCT,
 		},
 		/* Serial Number String Descriptor */
-		.unicode_sn = {
+		.utf16le_sn = {
 			.bLength = SN_DESC_LENGTH,
 			.bDescriptorType = USB_STRING_DESC,
 			.bString = CONFIG_USB_DEVICE_SN,
 		},
 #ifdef CONFIG_USB_DEVICE_NETWORK_ECM
-		.unicode_mac = {
+		.utf16le_mac = {
 			.bLength = ECM_MAC_DESC_LENGTH,
 			.bDescriptorType = USB_STRING_DESC,
 			.bString = CONFIG_USB_DEVICE_NETWORK_ECM_MAC
@@ -634,13 +637,19 @@ static struct dev_common_descriptor common_desc = {
 };
 
 
-void usb_fix_unicode_string(int idx_max, int asci_idx_max, u8_t *buf)
+/*
+ * Utility function: Inline conversion an ASCII-7 string of length asci_idx_max
+ * into a UTF16-LE string of idx_max bytes.
+ */
+void ascii7_to_utf16le(int idx_max, int asci_idx_max, u8_t *buf)
 {
 	for (int i = idx_max; i >= 0; i -= 2) {
 		SYS_LOG_DBG("char %c : %x, idx %d -> %d",
 			    buf[asci_idx_max],
 			    buf[asci_idx_max],
 			    asci_idx_max, i);
+		__ASSERT(buf[asci_idx_max] > 0x1F && buf[asci_idx_max] < 0x7F,
+			 "Only printable ascii-7 characters are allowed in USB string descriptors");
 		buf[i] = 0;
 		buf[i - 1] = buf[asci_idx_max--];
 	}
@@ -648,18 +657,18 @@ void usb_fix_unicode_string(int idx_max, int asci_idx_max, u8_t *buf)
 
 u8_t *usb_get_device_descriptor(void)
 {
-	usb_fix_unicode_string(MFR_UC_IDX_MAX, MFR_STRING_IDX_MAX,
-		(u8_t *)common_desc.string_descr.unicode_mfr.bString);
+	ascii7_to_utf16le(MFR_UC_IDX_MAX, MFR_STRING_IDX_MAX,
+			  (u8_t *)common_desc.string_descr.utf16le_mfr.bString);
 
-	usb_fix_unicode_string(PRODUCT_UC_IDX_MAX, PRODUCT_STRING_IDX_MAX,
-		(u8_t *)common_desc.string_descr.unicode_product.bString);
+	ascii7_to_utf16le(PRODUCT_UC_IDX_MAX, PRODUCT_STRING_IDX_MAX,
+			  (u8_t *)common_desc.string_descr.utf16le_product.bString);
 
-	usb_fix_unicode_string(SN_UC_IDX_MAX, SN_STRING_IDX_MAX,
-		(u8_t *)common_desc.string_descr.unicode_sn.bString);
+	ascii7_to_utf16le(SN_UC_IDX_MAX, SN_STRING_IDX_MAX,
+			  (u8_t *)common_desc.string_descr.utf16le_sn.bString);
 
 #ifdef CONFIG_USB_DEVICE_NETWORK_ECM
-	usb_fix_unicode_string(ECM_MAC_UC_IDX_MAX, ECM_STRING_IDX_MAX,
-		(u8_t *)common_desc.string_descr.unicode_mac.bString);
+	ascii7_to_utf16le(ECM_MAC_UC_IDX_MAX, ECM_STRING_IDX_MAX,
+			  (u8_t *)common_desc.string_descr.utf16le_mac.bString);
 #endif
 
 	return (u8_t *) &common_desc;


### PR DESCRIPTION
Fixes #6594. cc @carlescufi @jfischer-phytec-iot

In order to avoid confusion between "Unicode", UTF8, UTF16, UTF32,
and endianess of these encodings, rename all instances of "Unicode"
in the USB subsystem and samples into "UTF16LE".

Signed-off-by: Iván Sánchez Ortega <ivan@sanchezortega.es>