### PR TITLE
tests: kernel: alert: Add testcases

### DIFF
--- a/tests/kernel/alert/alert_api/src/test_alert_contexts.c
+++ b/tests/kernel/alert/alert_api/src/test_alert_contexts.c
@@ -17,6 +17,11 @@
 #define TIMEOUT 100
 #define STACK_SIZE 512
 #define PENDING_MAX 2
+#define SEM_INITIAL 0
+#define SEM_LIMIT 1
+
+K_SEM_DEFINE(sync_sema, SEM_INITIAL, SEM_LIMIT);
+
 static int alert_handler0(struct k_alert *);
 static int alert_handler1(struct k_alert *);
 
@@ -32,11 +37,15 @@ enum handle_type {
 };
 
 static K_THREAD_STACK_DEFINE(tstack, STACK_SIZE);
+static K_THREAD_STACK_DEFINE(sync_tstack, STACK_SIZE);
 __kernel struct k_thread tdata;
+__kernel struct k_thread sync_tdata;
 __kernel struct k_alert thread_alerts[4];
 static struct k_alert *palert;
 static enum handle_type htype;
-static volatile int handler_executed;
+static volatile u32_t handler_executed;
+static volatile u32_t handler_val;
+
 
 /*handlers*/
 static int alert_handler0(struct k_alert *alt)
@@ -111,6 +120,11 @@ static void thread_alert(void)
 static void tisr_entry(void *p)
 {
 	alert_send();
+}
+
+static void sync_entry(void *p)
+{
+	k_alert_send(palert);
 }
 
 static void isr_alert(void)
@@ -224,6 +238,144 @@ void test_isr_kinit_alert(void)
 	isr_alert();
 }
 
+
+/**
+ * This test checks alert_recv(timeout) against the following cases:
+ *  1. The current task times out while waiting for the event.
+ *  2. There is already an event waiting (signalled from a task).
+ *  3. The current task must wait on the event until it is signalled
+ *     from either another task or an ISR.
+ */
+void test_thread_alert_timeout(void)
+{
+	/**TESTPOINT: alert handler ignore*/
+	struct k_alert alert;
+	int ret, i;
+
+	/**TESTPOINT: init via k_alert_init*/
+	k_alert_init(&alert, K_ALERT_DEFAULT, PENDING_MAX);
+
+	palert = &alert;
+
+	ret = k_alert_recv(&alert, TIMEOUT);
+
+	zassert_equal(ret, -EAGAIN, NULL);
+
+	k_alert_send(&alert);
+
+	ret = k_alert_recv(&alert, TIMEOUT);
+
+	zassert_equal(ret, 0, NULL);
+
+	k_sem_give(&sync_sema);
+
+	for (i = 0; i < 2; i++) {
+		ret = k_alert_recv(&alert, TIMEOUT);
+
+		zassert_equal(ret, 0, NULL);
+	}
+}
+
+/**
+ * This test checks alert_recv(K_FOREVER) against
+ * the following cases:
+ *  1. There is already an event waiting (signalled from a task and ISR).
+ *  2. The current task must wait on the event until it is signalled
+ *     from either another task or an ISR.
+ */
+void test_thread_alert_wait(void)
+{
+	/**TESTPOINT: alert handler ignore*/
+	struct k_alert alert;
+	int ret, i;
+
+	/**TESTPOINT: init via k_alert_init*/
+	k_alert_init(&alert, K_ALERT_DEFAULT, PENDING_MAX);
+
+	palert = &alert;
+
+	k_alert_send(&alert);
+
+	ret = k_alert_recv(&alert, K_FOREVER);
+
+	zassert_equal(ret, 0, NULL);
+
+	irq_offload(sync_entry, NULL);
+
+	ret = k_alert_recv(&alert, K_FOREVER);
+
+	zassert_equal(ret, 0, NULL);
+
+	k_sem_give(&sync_sema);
+
+	for (i = 0; i < 2; i++) {
+		ret = k_alert_recv(&alert, K_FOREVER);
+
+		zassert_equal(ret, 0, NULL);
+	}
+}
+
+int eventHandler(struct k_alert *alt)
+{
+	return handler_val;
+}
+
+/**
+ * This test checks that the event handler is set up properly when
+ * alert_event_handler_set() is called.  It shows that event handlers
+ * are tied to the specified event and that the return value from the
+ * handler affects whether the event wakes a task waiting upon that
+ * event.
+ */
+void test_thread_alert_handler(void)
+{
+	/**TESTPOINT: alert handler ignore*/
+	struct k_alert alert;
+	int ret;
+
+	/**TESTPOINT: init via k_alert_init*/
+	k_alert_init(&alert, eventHandler, PENDING_MAX);
+
+	palert = &alert;
+
+	k_sem_give(&sync_sema);
+
+	ret = k_alert_recv(&alert, TIMEOUT);
+
+	zassert_equal(ret, -EAGAIN, NULL);
+
+	k_sem_give(&sync_sema);
+
+	ret = k_alert_recv(&alert, TIMEOUT);
+
+	zassert_equal(ret, 0, NULL);
+}
+
+
+/**
+ * Signal various events to a waiting task
+ */
+void signal_task(void *p1, void *p2, void *p3)
+{
+	k_sem_init(&sync_sema, 0, 1);
+
+	k_sem_take(&sync_sema, K_FOREVER);
+	k_alert_send(palert);
+	irq_offload(sync_entry, NULL);
+
+	k_sem_take(&sync_sema, K_FOREVER);
+	k_alert_send(palert);
+	irq_offload(sync_entry, NULL);
+
+	k_sem_take(&sync_sema, K_FOREVER);
+	handler_val = 0;
+	k_alert_send(palert);
+
+	k_sem_take(&sync_sema, K_FOREVER);
+	handler_val = 1;
+	k_alert_send(palert);
+}
+
 /*test case main entry*/
 void test_main(void)
 {
@@ -241,7 +393,15 @@ void test_main(void)
 	k_alert_init(&thread_alerts[HANDLER_0], alert_handler0, PENDING_MAX);
 	k_alert_init(&thread_alerts[HANDLER_1], alert_handler1, PENDING_MAX);
 
+	/**TESTPOINT: thread-thread sync via alert*/
+	k_thread_create(&sync_tdata, sync_tstack, STACK_SIZE,
+				      signal_task, NULL, NULL, NULL,
+				      K_PRIO_PREEMPT(0), 0, 0);
+
 	ztest_test_suite(test_alert_api,
+			 ztest_unit_test(test_thread_alert_timeout),
+			 ztest_unit_test(test_thread_alert_wait),
+			 ztest_unit_test(test_thread_alert_handler),
 			 ztest_user_unit_test(test_thread_alert_default),
 			 ztest_user_unit_test(test_thread_alert_ignore),
 			 ztest_user_unit_test(test_thread_alert_consumed),


### PR DESCRIPTION
Add testcases for following scenario

Test to check alert_recv(timeout) against the following cases

1. The current task times out while waiting for the event.
2. There is already an event waiting (signalled from a task).
3. The current task must wait on the event until it is signalled
   from either another task or an ISR

Test to check alert_recv(K_FOREVER) against the following cases:

1. There is already an event waiting (signalled from a task and ISR).
2. The current task must wait on the event until it is signalled
   from either another task or an ISR

Test to checks that the event handler is set up properly when
alert_event_handler_set() is called.  It shows that event handlers
are tied to the specified event and that the return value from the
handler affects whether the event wakes a task waiting upon that
event

Signed-off-by: Savinay Dharmappa <savinay.dharmappa@intel.com>