### PR TITLE
samples: subsys: mgmt: mcumgr: Fix FS part of smp_svr example

### DIFF
--- a/samples/subsys/mgmt/mcumgr/smp_svr/prj.conf
+++ b/samples/subsys/mgmt/mcumgr/smp_svr/prj.conf
@@ -42,4 +42,4 @@ CONFIG_MCUMGR_CMD_STAT_MGMT=y
 ### nRF5 specific settings
 
 # Specify the location of the NFFS file system.
-CONFIG_FS_NFFS_FLASH_DEV_NAME="NRF5_FLASH"
+CONFIG_FS_NFFS_FLASH_DEV_NAME="NRF5_FLASH_DRV_NAME"


### PR DESCRIPTION
After introducing of Virtual File System Switch (#6318
it i required to mount file system in order to use it.
This patch add to the example code which mounts NFFS
file system in the example.

Signed-off-by: Andrzej Puzdrowski <andrzej.puzdrowski@nordicsemi.no>