### PR TITLE
USB:  cdc_acm: Fixes sample

### DIFF
--- a/samples/subsys/usb/cdc_acm/src/main.c
+++ b/samples/subsys/usb/cdc_acm/src/main.c
@@ -43,10 +43,17 @@ static void write_data(struct device *dev, const char *buf, int len)
 {
 	uart_irq_tx_enable(dev);
 
-	data_transmitted = false;
-	uart_fifo_fill(dev, (const u8_t *)buf, len);
-	while (data_transmitted == false)
-		;
+	while (len) {
+		int written;
+
+		data_transmitted = false;
+		written = uart_fifo_fill(dev, (const u8_t *)buf, len);
+		while (data_transmitted == false)
+			;
+
+		len -= written;
+		buf += written;
+	}
 
 	uart_irq_tx_disable(dev);
 }

--- a/samples/subsys/usb/cdc_acm/src/main.c
+++ b/samples/subsys/usb/cdc_acm/src/main.c
@@ -48,8 +48,9 @@ static void write_data(struct device *dev, const char *buf, int len)
 
 		data_transmitted = false;
 		written = uart_fifo_fill(dev, (const u8_t *)buf, len);
-		while (data_transmitted == false)
-			;
+		while (data_transmitted == false) {
+			k_yield();
+		}
 
 		len -= written;
 		buf += written;

--- a/subsys/usb/class/cdc_acm.c
+++ b/subsys/usb/class/cdc_acm.c
@@ -286,7 +286,7 @@ static void cdc_acm_dev_status_cb(enum usb_dc_status_code status, u8_t *param)
 		SYS_LOG_DBG("USB device disconnected");
 		break;
 	case USB_DC_SUSPEND:
-		SYS_LOG_DBG("USB device supended");
+		SYS_LOG_DBG("USB device suspended");
 		break;
 	case USB_DC_RESUME:
 		SYS_LOG_DBG("USB device resumed");


### PR DESCRIPTION
Write all data in a loop fixing remaining data missing for the sample.