### PR TITLE
boards: Remove USB VID/PID from tinytile

### DIFF
--- a/boards/x86/tinytile/Kconfig.defconfig
+++ b/boards/x86/tinytile/Kconfig.defconfig
@@ -21,12 +21,6 @@ config USB_DW
 config USB_DEVICE_STACK
 	def_bool y
 
-config USB_DEVICE_VID
-	default 0x8087
-
-config USB_DEVICE_PID
-	default 0x0AB6
-
 if USB_UART_CONSOLE
 
 config UART_INTERRUPT_DRIVEN


### PR DESCRIPTION
According to a conversation with @carlescufi and @finikorg, the
zephyr codebase should only use the Linux Foundation USB vendor
ID. The USB vendor IDs and product IDs in the board definitions
are an obsolete leftover from old code and no longer needed.

Signed-off-by: Iván Sánchez Ortega <ivan@sanchezortega.es>