### PR TITLE
[DNM] Delayed sanitycheck test failure due to ROM overflow

### DIFF
--- a/tests/bluetooth/shell/CMakeLists.txt
+++ b/tests/bluetooth/shell/CMakeLists.txt
@@ -5,3 +5,4 @@ zephyr_library_include_directories($ENV{ZEPHYR_BASE}/samples/bluetooth)
 
 target_sources(app PRIVATE src/main.c)
 target_sources_ifdef(CONFIG_BT_CONN app PRIVATE src/hrs.c)
+


### PR DESCRIPTION
This PR demonstrates "delayed" regression due to growing code size. Some patches grew size of various parts of code. But apparently, we don't run the entire testsuite for each PR, so some cases of samples/tests failing for particular boards due to code/RAM size were "skipped". But later, other PRs which cause samples/tests to build may start to fail, even though these PRs don't contain any changes causing the failure.

The issue can be reproduced on the master branch even without dummy changes like this PR does, using:

~~~
scripts/sanitycheck -s tests/bluetooth/shell/test -p arduino_101
~~~
