### PR TITLE
dma: define and document the source and dest adjust enum.

### DIFF
--- a/include/dma.h
+++ b/include/dma.h
@@ -34,6 +34,13 @@ enum dma_channel_direction {
 	PERIPHERAL_TO_MEMORY
 };
 
+/** Valid values for @a source_addr_adj and @a dest_addr_adj */
+enum dma_addr_adj {
+	DMA_ADDR_ADJ_INCREMENT,
+	DMA_ADDR_ADJ_DECREMENT,
+	DMA_ADDR_ADJ_NO_CHANGE,
+};
+
 /**
  * @brief DMA block configuration structure.
  *


### PR DESCRIPTION
This is used in #6306 to make the driver more readable.

Signed-off-by: Michael Hope <mlhx@google.com>