### PR TITLE
boards: Add "ram" and "flash" properties for a number of boards

### DIFF
--- a/boards/arm/96b_carbon/96b_carbon.yaml
+++ b/boards/arm/96b_carbon/96b_carbon.yaml
@@ -11,3 +11,5 @@ supported:
   - i2c
   - spi
   - usb_device
+ram: 96
+flash: 512

--- a/boards/arm/96b_nitrogen/96b_nitrogen.yaml
+++ b/boards/arm/96b_nitrogen/96b_nitrogen.yaml
@@ -7,3 +7,5 @@ toolchain:
   - gccarmemb
 supported:
   - ble
+ram: 64
+flash: 512

--- a/boards/arm/disco_l475_iot1/disco_l475_iot1.yaml
+++ b/boards/arm/disco_l475_iot1/disco_l475_iot1.yaml
@@ -8,3 +8,5 @@ toolchain:
 supported:
   - i2c
   - hts221
+ram: 96
+flash: 1024

--- a/boards/arm/mimxrt1050_evk/mimxrt1050_evk.yaml
+++ b/boards/arm/mimxrt1050_evk/mimxrt1050_evk.yaml
@@ -11,3 +11,5 @@ arch: arm
 toolchain:
   - zephyr
   - gccarmemb
+ram: 128
+flash: 128

--- a/boards/arm/msp_exp432p401r_launchxl/msp_exp432p401r_launchxl.yaml
+++ b/boards/arm/msp_exp432p401r_launchxl/msp_exp432p401r_launchxl.yaml
@@ -5,3 +5,5 @@ arch: arm
 toolchain:
   - zephyr
   - gccarmemb
+ram: 64
+flash: 256

--- a/boards/arm/nrf52_blenano2/nrf52_blenano2.yaml
+++ b/boards/arm/nrf52_blenano2/nrf52_blenano2.yaml
@@ -5,3 +5,5 @@ arch: arm
 toolchain:
   - zephyr
   - gccarmemb
+ram: 64
+flash: 512

--- a/boards/arm/nrf52_pca10040/nrf52_pca10040.yaml
+++ b/boards/arm/nrf52_pca10040/nrf52_pca10040.yaml
@@ -5,3 +5,5 @@ arch: arm
 toolchain:
   - zephyr
   - gccarmemb
+ram: 64
+flash: 512

--- a/boards/arm/nrf52_sparkfun/nrf52_sparkfun.yaml
+++ b/boards/arm/nrf52_sparkfun/nrf52_sparkfun.yaml
@@ -5,3 +5,5 @@ arch: arm
 toolchain:
   - zephyr
   - gccarmemb
+ram: 64
+flash: 512

--- a/boards/arm/nrf52_vbluno52/nrf52_vbluno52.yaml
+++ b/boards/arm/nrf52_vbluno52/nrf52_vbluno52.yaml
@@ -5,3 +5,5 @@ arch: arm
 toolchain:
   - zephyr
   - gccarmemb
+ram: 64
+flash: 512

--- a/boards/arm/nucleo_f401re/nucleo_f401re.yaml
+++ b/boards/arm/nucleo_f401re/nucleo_f401re.yaml
@@ -7,3 +7,5 @@ toolchain:
   - gccarmemb
 supported:
   - pwm
+ram: 96
+flash: 512

--- a/boards/arm/nucleo_l432kc/nucleo_l432kc.yaml
+++ b/boards/arm/nucleo_l432kc/nucleo_l432kc.yaml
@@ -5,3 +5,5 @@ arch: arm
 toolchain:
   - zephyr
   - gccarmemb
+ram: 64
+flash: 256

--- a/boards/arm/nucleo_l476rg/nucleo_l476rg.yaml
+++ b/boards/arm/nucleo_l476rg/nucleo_l476rg.yaml
@@ -7,3 +7,5 @@ toolchain:
   - gccarmemb
 supported:
   - pwm
+ram: 96
+flash: 1024

--- a/boards/arm/qemu_cortex_m3/qemu_cortex_m3.yaml
+++ b/boards/arm/qemu_cortex_m3/qemu_cortex_m3.yaml
@@ -8,5 +8,7 @@ toolchain:
   - gccarmemb
 supported:
   - netif:slip
+ram: 64
+flash: 256
 testing:
         default: true

--- a/boards/arm/stm3210c_eval/stm3210c_eval.yaml
+++ b/boards/arm/stm3210c_eval/stm3210c_eval.yaml
@@ -5,3 +5,5 @@ arch: arm
 toolchain:
   - zephyr
   - gccarmemb
+ram: 64
+flash: 256

--- a/boards/arm/stm32_mini_a15/stm32_mini_a15.yaml
+++ b/boards/arm/stm32_mini_a15/stm32_mini_a15.yaml
@@ -5,3 +5,5 @@ arch: arm
 toolchain:
   - zephyr
   - gccarmemb
+ram: 64
+flash: 512

--- a/boards/arm/stm32l476g_disco/stm32l476g_disco.yaml
+++ b/boards/arm/stm32l476g_disco/stm32l476g_disco.yaml
@@ -5,3 +5,5 @@ arch: arm
 toolchain:
   - zephyr
   - gccarmemb
+ram: 96
+flash: 1024

--- a/boards/x86/arduino_101/arduino_101.yaml
+++ b/boards/x86/arduino_101/arduino_101.yaml
@@ -14,3 +14,5 @@ supported:
   - dma
   - gpio
   - pwm
+ram: 52
+flash: 144

--- a/boards/x86/minnowboard/minnowboard.yaml
+++ b/boards/x86/minnowboard/minnowboard.yaml
@@ -4,3 +4,4 @@ type: mcu
 arch: x86
 toolchain:
   - zephyr
+ram: 256

--- a/boards/x86/quark_se_c1000_devboard/quark_se_c1000_devboard.yaml
+++ b/boards/x86/quark_se_c1000_devboard/quark_se_c1000_devboard.yaml
@@ -15,3 +15,5 @@ supported:
   - aio
   - watchdog
   - dma
+ram: 52
+flash: 144

--- a/boards/x86/tinytile/tinytile.yaml
+++ b/boards/x86/tinytile/tinytile.yaml
@@ -7,3 +7,5 @@ toolchain:
   - issm
 supported:
   - usb_device
+ram: 52
+flash: 192

--- a/tests/bluetooth/shell/testcase.yaml
+++ b/tests/bluetooth/shell/testcase.yaml
@@ -3,6 +3,7 @@ tests:
     platform_whitelist: qemu_cortex_m3 qemu_x86 arduino_101 native_posix
     tags: bluetooth
     harness: keyboard
+    min_flash: 145
   test_br:
     extra_args: CONF_FILE="prj_br.conf"
     platform_whitelist: qemu_cortex_m3 qemu_x86 native_posix


### PR DESCRIPTION
Currently, it seems that only boards with smaller amount of RAM
get a value for "ram" property, and very few boards have "flash"
defined. However, to test bigger sample applications, it's helpful
to have these properties universally defined.

Signed-off-by: Paul Sokolovsky <paul.sokolovsky@linaro.org>