### PR TITLE
scripts: extract_dts_inculdes: Fix issue if no zephyr,flash prop

### DIFF
--- a/scripts/dts/extract_dts_includes.py
+++ b/scripts/dts/extract_dts_includes.py
@@ -904,7 +904,8 @@ def main():
         load_defs['CONFIG_FLASH_LOAD_OFFSET'] = 0
         load_defs['CONFIG_FLASH_LOAD_SIZE'] = 0
 
-    insert_defs(chosen['zephyr,flash'], defs, load_defs, {})
+    if 'zephyr,flash' in chosen:
+        insert_defs(chosen['zephyr,flash'], defs, load_defs, {})
 
     # generate include file
     if args.keyvalue:


### PR DESCRIPTION
We should be able to run the script without requiring a zephyr,flash
property in the choosen node.  Qualify insert based on having the
choosen property.

Signed-off-by: Kumar Gala <kumar.gala@linaro.org>