### PR TITLE
arch: arc: quark_se_c1000_ss: Fix DCCM_SIZE

### DIFF
--- a/arch/arc/soc/quark_se_c1000_ss/dts.fixup
+++ b/arch/arc/soc/quark_se_c1000_ss/dts.fixup
@@ -15,6 +15,6 @@
 #define FLASH_SIZE      		CONFIG_FLASH_SIZE
 
 #define CONFIG_DCCM_BASE_ADDRESS       ARC_DCCM_80000000_BASE_ADDRESS
-#define CONFIG_DCCM_SIZE               ARC_DCCM_80000000_SIZE
+#define CONFIG_DCCM_SIZE               (ARC_DCCM_80000000_SIZE >> 10)
 
 /* End of SoC Level DTS fixup file */


### PR DESCRIPTION
The DCCM_SIZE is defined in terms of K, not bytes, so we need to adjust
it from bytes (generated from dts) to K (used by e CONFIG_DCCM_SIZE).

Signed-off-by: Kumar Gala <kumar.gala@linaro.org>