### PR TITLE
boards: nucleo_l432kc: provide flash support

### DIFF
--- a/boards/arm/nucleo_l432kc/board.cmake
+++ b/boards/arm/nucleo_l432kc/board.cmake
@@ -1,0 +1,1 @@
+include(${ZEPHYR_BASE}/boards/common/openocd.board.cmake)

--- a/boards/arm/nucleo_l432kc/support/openocd.cfg
+++ b/boards/arm/nucleo_l432kc/support/openocd.cfg
@@ -1,0 +1,7 @@
+source [find interface/stlink-v2-1.cfg]
+
+transport select hla_swd
+
+source [find target/stm32l4x.cfg]
+
+reset_config srst_only


### PR DESCRIPTION
Unlike documented, openocd support was not implemented
for this board. Fix this


Signed-off-by: Erwan Gouriou <erwan.gouriou@linaro.org>