### PR TITLE
net: sockets: Support MSG_DONTWAIT flag in zsock_recvfrom

### DIFF
--- a/include/net/socket.h
+++ b/include/net/socket.h
@@ -40,6 +40,8 @@ struct zsock_pollfd {
 #define ZSOCK_POLLIN 1
 #define ZSOCK_POLLOUT 4
 
+#define ZSOCK_MSG_DONTWAIT 0x40
+
 struct zsock_addrinfo {
 	struct zsock_addrinfo *ai_next;
 	int ai_flags;
@@ -139,6 +141,8 @@ static inline int poll(struct zsock_pollfd *fds, int nfds, int timeout)
 #define pollfd zsock_pollfd
 #define POLLIN ZSOCK_POLLIN
 #define POLLOUT ZSOCK_POLLOUT
+
+#define MSG_DONTWAIT ZSOCK_MSG_DONTWAIT
 
 static inline char *inet_ntop(sa_family_t family, const void *src, char *dst,
 			      size_t size)

--- a/subsys/net/lib/sockets/sockets.c
+++ b/subsys/net/lib/sockets/sockets.c
@@ -295,13 +295,12 @@ static inline ssize_t zsock_recv_dgram(struct net_context *ctx,
 				       struct sockaddr *src_addr,
 				       socklen_t *addrlen)
 {
-	ARG_UNUSED(flags);
 	size_t recv_len = 0;
 	s32_t timeout = K_FOREVER;
 	unsigned int header_len;
 	struct net_pkt *pkt;
 
-	if (sock_is_nonblock(ctx)) {
+	if ((flags & ZSOCK_MSG_DONTWAIT) || sock_is_nonblock(ctx)) {
 		timeout = K_NO_WAIT;
 	}
 
@@ -353,12 +352,11 @@ static inline ssize_t zsock_recv_stream(struct net_context *ctx,
 					size_t max_len,
 					int flags)
 {
-	ARG_UNUSED(flags);
 	size_t recv_len = 0;
 	s32_t timeout = K_FOREVER;
 	int res;
 
-	if (sock_is_nonblock(ctx)) {
+	if ((flags & ZSOCK_MSG_DONTWAIT) || sock_is_nonblock(ctx)) {
 		timeout = K_NO_WAIT;
 	}
 


### PR DESCRIPTION
Add support for MSG_DONTWAIT flag in recv and recvfrom.

This flag is needed when using non-zephyr embedded applications with
Zephyr's socket API.

Signed-off-by: Stig Bjørlykke <stig.bjorlykke@nordicsemi.no>