### PR TITLE
posix: semaphore: fix bugs and simplify code

### DIFF
--- a/include/posix/semaphore.h
+++ b/include/posix/semaphore.h
@@ -14,10 +14,10 @@ extern "C" {
 #include <time.h>
 
 int sem_destroy(sem_t *semaphore);
-int sem_getvalue(sem_t *semaphore, int *value);
+int sem_getvalue(sem_t *restrict semaphore, int *restrict value);
 int sem_init(sem_t *semaphore, int pshared, unsigned int value);
 int sem_post(sem_t *semaphore);
-int sem_timedwait(sem_t *semaphore, struct timespec *abstime);
+int sem_timedwait(sem_t *restrict semaphore, struct timespec *restrict abstime);
 int sem_trywait(sem_t *semaphore);
 int sem_wait(sem_t *semaphore);
 

--- a/tests/posix/semaphore/src/sem.c
+++ b/tests/posix/semaphore/src/sem.c
@@ -18,8 +18,7 @@ static K_THREAD_STACK_DEFINE(stack, STACK_SIZE);
 
 static void *foo_func(void *p1)
 {
-	zassert_false(sem_wait(&sema), "sem_wait failed\n");
-	printk("Print me after taking semaphore!\n");
+	printk("Child thread running\n");
 	zassert_false(sem_post(&sema), "sem_post failed\n");
 	return NULL;
 }
@@ -39,26 +38,19 @@ static void test_sema(void)
 	pthread_attr_setschedpolicy(&attr, schedpolicy);
 	pthread_attr_setschedparam(&attr, &schedparam);
 
-	zassert_equal(sem_init(&sema, 1, 1), -1, "pshared is not 0\n");
-	zassert_equal(errno, ENOSYS, NULL);
-
 	zassert_equal(sem_init(&sema, 0, (CONFIG_SEM_VALUE_MAX + 1)), -1,
 		      "value larger than %d\n", CONFIG_SEM_VALUE_MAX);
 	zassert_equal(errno, EINVAL, NULL);
 
-	zassert_false(sem_init(&sema, 0, 1), "sem_init failed\n");
+	zassert_false(sem_init(&sema, 0, 0), "sem_init failed\n");
 
 	zassert_equal(sem_getvalue(&sema, &val), 0, NULL);
-	zassert_equal(val, 1, NULL);
+	zassert_equal(val, 0, NULL);
 
 	pthread_create(&newthread, &attr, foo_func, NULL);
+	zassert_false(sem_wait(&sema), "sem_wait failed\n");
 
-	printk("after releasing sem\n");
-	zassert_false(sem_trywait(&sema), "sem_wait failed\n");
-	printk("After taking semaphore second time\n");
-
-	zassert_false(sem_post(&sema), "sem_post failed\n");
-
+	printk("Parent thread unlocked\n");
 	zassert_false(sem_destroy(&sema), "sema is not destroyed\n");
 }
 


### PR DESCRIPTION
Modifies several functions that are causing wrong
behaviour.

 * semaphore.h: add missing restrict keyword.
 * sem_destroy(): check that nobody is waiting
   before destroying the object.
 * sem_timedwait(): simpify function logic and
   fix a bug when abstime > currtime, that passed
   ticks instead of ms to k_sem_take().
 * sem_wait(): avoid unnecessary checks.

Signed-off-by: Juan Manuel Torres Palma <j.m.torrespalma@gmail.com>