### PR TITLE
net: sockets: Support MSG_PEEK flag in zsock_recvfrom

### DIFF
--- a/include/net/socket.h
+++ b/include/net/socket.h
@@ -40,6 +40,7 @@ struct zsock_pollfd {
 #define ZSOCK_POLLIN 1
 #define ZSOCK_POLLOUT 4
 
+#define ZSOCK_MSG_PEEK 0x02
 #define ZSOCK_MSG_DONTWAIT 0x40
 
 struct zsock_addrinfo {
@@ -142,6 +143,7 @@ static inline int poll(struct zsock_pollfd *fds, int nfds, int timeout)
 #define POLLIN ZSOCK_POLLIN
 #define POLLOUT ZSOCK_POLLOUT
 
+#define MSG_PEEK ZSOCK_MSG_PEEK
 #define MSG_DONTWAIT ZSOCK_MSG_DONTWAIT
 
 static inline char *inet_ntop(sa_family_t family, const void *src, char *dst,

--- a/subsys/net/lib/sockets/sockets.c
+++ b/subsys/net/lib/sockets/sockets.c
@@ -304,7 +304,21 @@ static inline ssize_t zsock_recv_dgram(struct net_context *ctx,
 		timeout = K_NO_WAIT;
 	}
 
-	pkt = k_fifo_get(&ctx->recv_q, timeout);
+	if (flags & ZSOCK_MSG_PEEK) {
+		int res;
+
+		res = _k_fifo_wait_non_empty(&ctx->recv_q, timeout);
+		/* EAGAIN when timeout expired, EINTR when cancelled */
+		if (res && res != -EAGAIN && res != -EINTR) {
+			errno = -res;
+			return -1;
+		}
+
+		pkt = k_fifo_peek_head(&ctx->recv_q);
+	} else {
+		pkt = k_fifo_get(&ctx->recv_q, timeout);
+	}
+
 	if (!pkt) {
 		errno = EAGAIN;
 		return -1;
@@ -332,17 +346,21 @@ static inline ssize_t zsock_recv_dgram(struct net_context *ctx,
 		}
 	}
 
-	/* Remove packet header since we've handled src addr and port */
+	/* Set starting point behind packet header since we've
+	 * handled src addr and port.
+	 */
 	header_len = net_pkt_appdata(pkt) - pkt->frags->data;
-	net_buf_pull(pkt->frags, header_len);
 
 	recv_len = net_pkt_appdatalen(pkt);
 	if (recv_len > max_len) {
 		recv_len = max_len;
 	}
 
-	net_frag_linearize(buf, recv_len, pkt, 0, recv_len);
-	net_pkt_unref(pkt);
+	net_frag_linearize(buf, recv_len, pkt, header_len, recv_len);
+
+	if (!(flags & ZSOCK_MSG_PEEK)) {
+		net_pkt_unref(pkt);
+	}
 
 	return recv_len;
 }
@@ -406,24 +424,29 @@ static inline ssize_t zsock_recv_stream(struct net_context *ctx,
 		/* Actually copy data to application buffer */
 		memcpy(buf, frag->data, recv_len);
 
-		if (recv_len != frag_len) {
-			net_buf_pull(frag, recv_len);
-		} else {
-			frag = net_pkt_frag_del(pkt, NULL, frag);
-			if (!frag) {
-				/* Finished processing head pkt in
-				 * the fifo. Drop it from there.
-				 */
-				k_fifo_get(&ctx->recv_q, K_NO_WAIT);
-				if (net_pkt_eof(pkt)) {
-					sock_set_eof(ctx);
+		if (!(flags & ZSOCK_MSG_PEEK)) {
+			if (recv_len != frag_len) {
+				net_buf_pull(frag, recv_len);
+			} else {
+				frag = net_pkt_frag_del(pkt, NULL, frag);
+				if (!frag) {
+					/* Finished processing head pkt in
+					 * the fifo. Drop it from there.
+					 */
+					k_fifo_get(&ctx->recv_q, K_NO_WAIT);
+					if (net_pkt_eof(pkt)) {
+						sock_set_eof(ctx);
+					}
+
+					net_pkt_unref(pkt);
 				}
-				net_pkt_unref(pkt);
 			}
 		}
 	} while (recv_len == 0);
 
-	net_context_update_recv_wnd(ctx, recv_len);
+	if (!(flags & ZSOCK_MSG_PEEK)) {
+		net_context_update_recv_wnd(ctx, recv_len);
+	}
 
 	return recv_len;
 }

--- a/tests/net/socket/tcp/src/main.c
+++ b/tests/net/socket/tcp/src/main.c
@@ -101,12 +101,12 @@ static void test_accept(int sock, int *new_sock, struct sockaddr *addr,
 	zassert_true(*new_sock >= 0, "accept failed");
 }
 
-static void test_recv(int sock)
+static void test_recv(int sock, int flags)
 {
 	ssize_t recved = 0;
 	char rx_buf[30] = {0};
 
-	recved = recv(sock, rx_buf, sizeof(rx_buf), 0);
+	recved = recv(sock, rx_buf, sizeof(rx_buf), flags);
 	zassert_equal(recved,
 		      strlen(TEST_STR_SMALL),
 		      "unexpected received bytes");
@@ -116,6 +116,7 @@ static void test_recv(int sock)
 }
 
 static void test_recvfrom(int sock,
+			  int flags,
 			  struct sockaddr *addr,
 			  socklen_t *addrlen)
 {
@@ -125,7 +126,7 @@ static void test_recvfrom(int sock,
 	recved = recvfrom(sock,
 			  rx_buf,
 			  sizeof(rx_buf),
-			  0,
+			  flags,
 			  addr,
 			  addrlen);
 	zassert_equal(recved,
@@ -173,7 +174,8 @@ void test_v4_send_recv(void)
 	test_accept(s_sock, &new_sock, &addr, &addrlen);
 	zassert_equal(addrlen, sizeof(struct sockaddr_in), "wrong addrlen");
 
-	test_recv(new_sock);
+	test_recv(new_sock, MSG_PEEK);
+	test_recv(new_sock, 0);
 
 	test_close(new_sock);
 	test_close(c_sock);
@@ -212,7 +214,8 @@ void test_v6_send_recv(void)
 	test_accept(s_sock, &new_sock, &addr, &addrlen);
 	zassert_equal(addrlen, sizeof(struct sockaddr_in6), "wrong addrlen");
 
-	test_recv(new_sock);
+	test_recv(new_sock, MSG_PEEK);
+	test_recv(new_sock, 0);
 
 	test_close(new_sock);
 	test_close(s_sock);
@@ -251,7 +254,10 @@ void test_v4_sendto_recvfrom(void)
 	test_accept(s_sock, &new_sock, &addr, &addrlen);
 	zassert_equal(addrlen, sizeof(struct sockaddr_in), "wrong addrlen");
 
-	test_recvfrom(new_sock, &addr, &addrlen);
+	test_recvfrom(new_sock, MSG_PEEK, &addr, &addrlen);
+	zassert_equal(addrlen, sizeof(struct sockaddr_in), "wrong addrlen");
+
+	test_recvfrom(new_sock, 0, &addr, &addrlen);
 	zassert_equal(addrlen, sizeof(struct sockaddr_in), "wrong addrlen");
 
 	test_close(new_sock);
@@ -291,7 +297,10 @@ void test_v6_sendto_recvfrom(void)
 	test_accept(s_sock, &new_sock, &addr, &addrlen);
 	zassert_equal(addrlen, sizeof(struct sockaddr_in6), "wrong addrlen");
 
-	test_recvfrom(new_sock, &addr, &addrlen);
+	test_recvfrom(new_sock, MSG_PEEK, &addr, &addrlen);
+	zassert_equal(addrlen, sizeof(struct sockaddr_in6), "wrong addrlen");
+
+	test_recvfrom(new_sock, 0, &addr, &addrlen);
 	zassert_equal(addrlen, sizeof(struct sockaddr_in6), "wrong addrlen");
 
 	test_close(new_sock);
@@ -332,7 +341,7 @@ void test_v4_sendto_recvfrom_null_dest(void)
 	test_accept(s_sock, &new_sock, &addr, &addrlen);
 	zassert_equal(addrlen, sizeof(struct sockaddr_in), "wrong addrlen");
 
-	test_recvfrom(new_sock, NULL, NULL);
+	test_recvfrom(new_sock, 0, NULL, NULL);
 
 	test_close(new_sock);
 	test_close(s_sock);
@@ -372,7 +381,7 @@ void test_v6_sendto_recvfrom_null_dest(void)
 	test_accept(s_sock, &new_sock, &addr, &addrlen);
 	zassert_equal(addrlen, sizeof(struct sockaddr_in6), "wrong addrlen");
 
-	test_recvfrom(new_sock, NULL, NULL);
+	test_recvfrom(new_sock, 0, NULL, NULL);
 
 	test_close(new_sock);
 	test_close(s_sock);

--- a/tests/net/socket/udp/src/main.c
+++ b/tests/net/socket/udp/src/main.c
@@ -86,6 +86,19 @@ static void test_sendto_recvfrom(int client_sock,
 	recved = recvfrom(server_sock,
 			  rx_buf,
 			  sizeof(rx_buf),
+			  MSG_PEEK,
+			  &addr,
+			  &addrlen);
+	zassert_true(recved > 0, "recvfrom fail");
+	zassert_equal(recved,
+		      strlen(TEST_STR_SMALL),
+		      "unexpected received bytes");
+	zassert_equal(strncmp(rx_buf, TEST_STR_SMALL, strlen(TEST_STR_SMALL)),
+		      0,
+		      "unexpected data");
+	recved = recvfrom(server_sock,
+			  rx_buf,
+			  sizeof(rx_buf),
 			  0,
 			  &addr,
 			  &addrlen);
@@ -285,6 +298,11 @@ void test_send_recv_2_sock(void)
 	connect(sock2, (struct sockaddr *)&conn_addr, sizeof(conn_addr));
 
 	send(sock2, BUF_AND_SIZE(TEST_STR_SMALL), 0);
+
+	len = recv(sock1, buf, sizeof(buf), MSG_PEEK);
+	zassert_equal(len, 4, "Invalid recv len");
+	cmp = memcmp(buf, TEST_STR_SMALL, STRLEN(TEST_STR_SMALL));
+	zassert_equal(cmp, 0, "Invalid recv data");
 
 	len = recv(sock1, buf, sizeof(buf), 0);
 	zassert_equal(len, 4, "Invalid recv len");


### PR DESCRIPTION
Add support for MSG_PEEK flag in recv and recvfrom.

This flag is needed when using non-zephyr embedded applications with
Zephyr's socket API.

Signed-off-by: Stig Bjørlykke <stig.bjorlykke@nordicsemi.no>