### PR TITLE
Arch arm secure fault handler implementation cm23 and rework

### DIFF
--- a/arch/arm/core/fault.c
+++ b/arch/arm/core/fault.c
@@ -37,6 +37,64 @@
 	} while ((0))
 #endif
 
+#if defined(CONFIG_ARM_SECURE_FIRMWARE)
+
+/* Exception Return (EXC_RETURN) is provided in LR upon exception entry.
+ * It is used to perform an exception return and to detect possible state
+ * transition upon exception.
+ */
+
+/* Prefix. Indicates that this is an EXC_RETURN value.
+ * This field reads as 0b11111111.
+ */
+#define EXC_RETURN_INDICATOR_PREFIX     (0xFF << 24)
+/* bit[0]: Exception Secure. The security domain the exception was taken to. */
+#define EXC_RETURN_EXCEPTION_SECURE_Pos 0
+#define EXC_RETURN_EXCEPTION_SECURE_Msk \
+		(1 << EXC_RETURN_EXCEPTION_SECURE_Pos)
+#define EXC_RETURN_EXCEPTION_SECURE_Non_Secure 0
+#define EXC_RETURN_EXCEPTION_SECURE_Secure EXC_RETURN_EXCEPTION_SECURE_Msk
+/* bit[2]: Stack Pointer selection. */
+#define EXC_RETURN_SPSEL_Pos 2
+#define EXC_RETURN_SPSEL_Msk (1 << EXC_RETURN_SPSEL_Pos)
+#define EXC_RETURN_SPSEL_MAIN 0
+#define EXC_RETURN_SPSEL_PROCESS EXC_RETURN_SPSEL_Msk
+/* bit[3]: Mode. Indicates the Mode that was stacked from. */
+#define EXC_RETURN_MODE_Pos 3
+#define EXC_RETURN_MODE_Msk (1 << EXC_RETURN_MODE_Pos)
+#define EXC_RETURN_MODE_HANDLER 0
+#define EXC_RETURN_MODE_THREAD EXC_RETURN_MODE_Msk
+/* bit[4]: Stack frame type. Indicates whether the stack frame is a standard
+ * integer only stack frame or an extended floating-point stack frame.
+ */
+#define EXC_RETURN_STACK_FRAME_TYPE_Pos 4
+#define EXC_RETURN_STACK_FRAME_TYPE_Msk (1 << EXC_RETURN_STACK_FRAME_TYPE_Pos)
+#define EXC_RETURN_STACK_FRAME_TYPE_EXTENDED 0
+#define EXC_RETURN_STACK_FRAME_TYPE_STANDARD EXC_RETURN_STACK_FRAME_TYPE_Msk
+/* bit[5]: Default callee register stacking. Indicates whether the default
+ * stacking rules apply, or whether the callee registers are already on the
+ * stack.
+ */
+#define EXC_RETURN_CALLEE_STACK_Pos 5
+#define EXC_RETURN_CALLEE_STACK_Msk (1 << EXC_RETURN_CALLEE_STACK_Pos)
+#define EXC_RETURN_CALLEE_STACK_SKIPPED 0
+#define EXC_RETURN_CALLEE_STACK_DEFAULT EXC_RETURN_CALLEE_STACK_Msk
+/* bit[6]: Secure or Non-secure stack. Indicates whether a Secure or
+ * Non-secure stack is used to restore stack frame on exception return.
+ */
+#define EXC_RETURN_RETURN_STACK_Pos 6
+#define EXC_RETURN_RETURN_STACK_Msk (1 << EXC_RETURN_RETURN_STACK_Pos)
+#define EXC_RETURN_RETURN_STACK_Non_Secure 0
+#define EXC_RETURN_RETURN_STACK_Secure EXC_RETURN_RETURN_STACK_Msk
+
+/* Integrity signature for an ARMv8-M implementation */
+#define INTEGRITY_SIGNATURE 0xFEFA125BUL
+/* Size (in words) of the additional state context that is pushed
+ * to the Secure stack during a Non-Secure exception entry.
+ */
+#define ADDITIONAL_STATE_CONTEXT_WORDS 10
+#endif /* CONFIG_ARM_SECURE_FIRMWARE */
+
 #if (CONFIG_FAULT_DUMP == 1)
 /**
  *
@@ -338,19 +396,6 @@ static void _SecureFault(const NANO_ESF *esf)
 		PR_EXC("  Lazy state error\n");
 	}
 
-	/* SecureFault is never banked between security states. Therefore,
-	 * we may wish to, additionally, inspect the state of the Non-Secure
-	 * execution (program counter), to gain more information regarding
-	 * the root cause of the fault.
-	 */
-	NANO_ESF *esf_ns;
-	if (SCB_NS->ICSR & SCB_ICSR_RETTOBASE_Msk) {
-		esf_ns = (NANO_ESF *)__TZ_get_PSP_NS();
-	} else {
-		esf_ns = (NANO_ESF *)__TZ_get_MSP_NS();
-	}
-	PR_EXC("  NS instruction address:  0x%x\n", esf_ns->pc);
-
 	/* clear SFSR sticky bits */
 	SAU->SFSR |= 0xFF;
 }
@@ -498,12 +543,85 @@ static void _FaultDump(const NANO_ESF *esf, int fault)
  *
  * @param esf ESF on the stack, either MSP or PSP depending at what processor
  *            state the exception was taken.
+ *
+ * @param exc_return EXC_RETURN value present in LR after exception entry.
+ *
+ * Note: exc_return argument shall only be used by the Fault handler if we are
+ * building Secure Firmware.
  */
-void _Fault(const NANO_ESF *esf)
+void _Fault(const NANO_ESF *esf, u32_t exc_return)
 {
 	int fault = SCB->ICSR & SCB_ICSR_VECTACTIVE_Msk;
 
+#if defined(CONFIG_ARM_SECURE_FIRMWARE)
+	if ((exc_return & EXC_RETURN_INDICATOR_PREFIX) !=
+			EXC_RETURN_INDICATOR_PREFIX) {
+		/* Invalid EXC_RETURN value */
+		_SysFatalErrorHandler(_NANO_ERR_HW_EXCEPTION, esf);
+	}
+	if ((exc_return & EXC_RETURN_EXCEPTION_SECURE_Secure) == 0) {
+		/* Secure Firmware shall only handle Secure Exceptions.
+		 * This is a fatal error.
+		 */
+		_SysFatalErrorHandler(_NANO_ERR_HW_EXCEPTION, esf);
+	}
+
+	if (exc_return & EXC_RETURN_RETURN_STACK_Secure) {
+		/* Exception entry occurred in Secure stack. */
+		FAULT_DUMP(esf, fault);
+	} else {
+		/* Exception entry occurred in Non-Secure stack. Therefore, the
+		 * exception stack frame is located in the Non-Secure stack.
+		 */
+		NANO_ESF *esf_ns;
+		if (exc_return & EXC_RETURN_MODE_THREAD) {
+			esf_ns = (NANO_ESF *)__TZ_get_PSP_NS();
+			if ((SCB->ICSR & SCB_ICSR_RETTOBASE_Msk) == 0) {
+				PR_EXC("RETTOBASE does not match EXC_RETURN\n");
+				_SysFatalErrorHandler(_NANO_ERR_HW_EXCEPTION, esf);
+			}
+		} else {
+			esf_ns = (NANO_ESF *)__TZ_get_MSP_NS();
+			if ((SCB->ICSR & SCB_ICSR_RETTOBASE_Msk) != 0) {
+				PR_EXC("RETTOBASE does not match EXC_RETURN\n");
+				_SysFatalErrorHandler(_NANO_ERR_HW_EXCEPTION, esf);
+			}
+		}
+		FAULT_DUMP(esf_ns, fault);
+
+		/* Dumping the Secure Stack, too.
+		 * In case a Non-Secure exception interrupted the Secure
+		 * execution, the Secure state has stacked the additional
+		 * state context and the top of the stack contains the
+		 * integrity signature.
+		 *
+		 * In case of a Non-Secure function call the top of the
+		 * stack contains the return address to Secure state.
+		 */
+		u32_t *top_of_sec_stack = (u32_t *)esf;
+		u32_t sec_ret_addr;
+		if (*top_of_sec_stack == INTEGRITY_SIGNATURE) {
+			/* Secure state interrupted by a Non-Secure exception.
+			 * The return address after the additional state
+			 * context, stacked by the Secure code upon
+			 * Non-Secure exception entry.
+			 */
+			top_of_sec_stack += ADDITIONAL_STATE_CONTEXT_WORDS;
+			esf = (const NANO_ESF *)top_of_sec_stack;
+			sec_ret_addr = esf->pc;
+
+		} else {
+			/* Exception during Non-Secure function call.
+			 * The return address is located on top of stack.
+			 */
+			sec_ret_addr = *top_of_sec_stack;
+		}
+		PR_EXC("  S instruction address:  0x%x\n", sec_ret_addr);
+	}
+#else
+	(void) exc_return;
 	FAULT_DUMP(esf, fault);
+#endif /* CONFIG_ARM_SECURE_FIRMWARE*/
 
 	_SysFatalErrorHandler(_NANO_ERR_HW_EXCEPTION, esf);
 }

--- a/arch/arm/core/fault.c
+++ b/arch/arm/core/fault.c
@@ -88,7 +88,12 @@
 #define EXC_RETURN_RETURN_STACK_Secure EXC_RETURN_RETURN_STACK_Msk
 
 /* Integrity signature for an ARMv8-M implementation */
+#if defined(CONFIG_ARMV7_M_ARMV8_M_FP)
+#define INTEGRITY_SIGNATURE_STD 0xFEFA125BUL
+#define INTEGRITY_SIGNATURE_EXT 0xFEFA125AUL
+#else
 #define INTEGRITY_SIGNATURE 0xFEFA125BUL
+#endif /* CONFIG_ARMV7_M_ARMV8_M_FP */
 /* Size (in words) of the additional state context that is pushed
  * to the Secure stack during a Non-Secure exception entry.
  */
@@ -600,7 +605,12 @@ void _Fault(const NANO_ESF *esf, u32_t exc_return)
 		 */
 		u32_t *top_of_sec_stack = (u32_t *)esf;
 		u32_t sec_ret_addr;
+#if defined(CONFIG_ARMV7_M_ARMV8_M_FP)
+		if ((*top_of_sec_stack == INTEGRITY_SIGNATURE_STD) ||
+			(*top_of_sec_stack == INTEGRITY_SIGNATURE_EXT)) {
+#else
 		if (*top_of_sec_stack == INTEGRITY_SIGNATURE) {
+#endif /* CONFIG_ARMV7_M_ARMV8_M_FP */
 			/* Secure state interrupted by a Non-Secure exception.
 			 * The return address after the additional state
 			 * context, stacked by the Secure code upon

--- a/arch/arm/core/fault_s.S
+++ b/arch/arm/core/fault_s.S
@@ -97,6 +97,7 @@ _stack_frame_endif:
 	eors.n r0, r0
 	msr BASEPRI, r0
 
+#if !defined(CONFIG_ARM_SECURE_FIRMWARE)
 	/* this checks to see if we are in a nested exception */
 	ldr ip, =_SCS_ICSR
 	ldr ip, [ip]
@@ -110,9 +111,34 @@ _stack_frame_endif:
 				 *  this is not a nested exception: the stack
 				 * frame is on the PSP */
 #else
+	/* RETTOBASE flag is not banked between security states.
+	 * Therefore, we cannot rely on this flag, to obtain the SP
+	 * in Secure state. Instead, we use the EXC_RETURN SPSEL flag.
+	 */
+ 	ldr r0, =0x4
+	mov r1, lr
+	tst r1, r0
+	beq _s_stack_frame_msp
+	mrs r0, PSP
+	bne _s_stack_frame_endif
+_s_stack_frame_msp:
+	mrs r0, MSP
+_s_stack_frame_endif:
+#endif /* CONFIG_ARM_SECURE_FIRMWARE */
+#else
 #error Unknown ARM architecture
 #endif /* CONFIG_ARMV6_M_ARMV8_M_BASELINE */
 
+#if defined(CONFIG_ARM_SECURE_FIRMWARE)
+	/* In ARM Secure firmware, the stack pointer that is retrieved
+	 * above points to the Secure stack. However, the exeption may
+	 * have occurred in Non-Secure state.
+	 * To determine this we need to inspect the EXC_RETURN value
+	 * located in the LR. Therefore, we supply the LR value as an
+	 * argument to the fault handler.
+	 */
+	mov r1, lr
+#endif /* CONFIG_ARM_SECURE_FIRMWARE */
 	push {lr}
 	bl _Fault
 

--- a/arch/arm/include/cortex_m/exc.h
+++ b/arch/arm/include/cortex_m/exc.h
@@ -114,13 +114,20 @@ static ALWAYS_INLINE void _ExcSetup(void)
 	SCB->SHCSR |= SCB_SHCSR_SECUREFAULTENA_Msk;
 	/* Clear BFAR before setting BusFaults to target Non-Secure state. */
 	SCB->BFAR = 0;
+#endif /* CONFIG_ARM_SECURE_FIRMWARE */
+#endif /* CONFIG_CPU_CORTEX_M_HAS_PROGRAMMABLE_FAULT_PRIOS */
+
+#if defined(CONFIG_ARM_SECURE_FIRMWARE)
 	/* Set NMI, Hard, and Bus Faults as Non-Secure.
 	 * NMI and Bus Faults targeting the Secure state will
 	 * escalate to a SecureFault or SecureHardFault.
 	 */
 	SCB->AIRCR |= SCB_AIRCR_BFHFNMINS_Msk;
+	/* Note: Fault conditions that would generate a SecureFault
+	 * in a PE with the Main Extension instead generate a
+	 * SecureHardFault in a PE without the Main Extension.
+	 */
 #endif /* CONFIG_ARM_SECURE_FIRMWARE */
-#endif
 }
 
 /**

--- a/arch/arm/include/cortex_m/exc.h
+++ b/arch/arm/include/cortex_m/exc.h
@@ -122,7 +122,10 @@ static ALWAYS_INLINE void _ExcSetup(void)
 	 * NMI and Bus Faults targeting the Secure state will
 	 * escalate to a SecureFault or SecureHardFault.
 	 */
-	SCB->AIRCR |= SCB_AIRCR_BFHFNMINS_Msk;
+	SCB->AIRCR =
+		(SCB->AIRCR & (~(SCB_AIRCR_VECTKEY_Msk)))
+		| SCB_AIRCR_BFHFNMINS_Msk
+		| ((0x5FAUL << SCB_AIRCR_VECTKEY_Pos) & SCB_AIRCR_VECTKEY_Msk);
 	/* Note: Fault conditions that would generate a SecureFault
 	 * in a PE with the Main Extension instead generate a
 	 * SecureHardFault in a PE without the Main Extension.

--- a/include/arch/arm/cortex_m/cmsis.h
+++ b/include/arch/arm/cortex_m/cmsis.h
@@ -54,7 +54,7 @@ typedef enum {
 	BusFault_IRQn                 = -11,
 	UsageFault_IRQn               = -10,
 #if defined(CONFIG_ARM_SECURE_FIRMWARE)
-	SecureFault_IRQn              = -7,
+	SecureFault_IRQn              = -9,
 #endif /* CONFIG_ARM_SECURE_FIRMWARE */
 #endif /* CONFIG_ARMV7_M_ARMV8_M_MAINLINE */
 	SVCall_IRQn                   =  -5,


### PR DESCRIPTION
This PR finalizes the implementation of Secure Fault handling for ARM CPUs that implement the ARMv8-m Security Extension.
- Contributes the implementation for CM23
- Reworks the fault dumping function to give more precise information to the user regarding what has occurred during a secure fault.

Addresses #6372 