### PR TITLE
uncrustify: add space before name of typedef

### DIFF
--- a/scripts/uncrustify.cfg
+++ b/scripts/uncrustify.cfg
@@ -60,8 +60,9 @@ sp_inside_sparen    = remove    # remove spaces inside parens for if, while and 
 sp_brace_else       = add       # ignore/add/remove/force
 sp_before_nl_cont   = ignore
 sp_cmt_cpp_start    = add
-cmt_sp_after_star_cont          = 1
+sp_brace_typedef    = add       # }typedefd_name -> } typedefd_name
 
+cmt_sp_after_star_cont          = 1
 #
 # Aligning stuff
 #


### PR DESCRIPTION
    typedef enum {
         vvv
    }name;

becomes

    typedef enum {
         vvv
    } name;

Signed-off-by: Patrick Boettcher <patrick.boettcher@posteo.de>