### PR TITLE
drivers: flash: stm32f0: remove CONFIG_FLASH_PAGE_SIZE

### DIFF
--- a/arch/arm/soc/st_stm32/stm32f0/Kconfig.defconfig.stm32f030x8
+++ b/arch/arm/soc/st_stm32/stm32f0/Kconfig.defconfig.stm32f030x8
@@ -11,10 +11,6 @@ config SOC
 	string
 	default stm32f030x8
 
-config FLASH_PAGE_SIZE
-	hex
-	default 0x400
-
 config NUM_IRQS
 	int
 	default 29

--- a/arch/arm/soc/st_stm32/stm32f0/Kconfig.defconfig.stm32f051x8
+++ b/arch/arm/soc/st_stm32/stm32f0/Kconfig.defconfig.stm32f051x8
@@ -11,10 +11,6 @@ config SOC
 	string
 	default stm32f051x8
 
-config FLASH_PAGE_SIZE
-	hex
-	default 0x400
-
 config NUM_IRQS
 	int
 	default 29

--- a/arch/arm/soc/st_stm32/stm32f0/Kconfig.defconfig.stm32f070xb
+++ b/arch/arm/soc/st_stm32/stm32f0/Kconfig.defconfig.stm32f070xb
@@ -11,10 +11,6 @@ config SOC
 	string
 	default stm32f070xb
 
-config FLASH_PAGE_SIZE
-	hex
-	default 0x800
-
 config NUM_IRQS
 	int
 	default 32

--- a/arch/arm/soc/st_stm32/stm32f0/Kconfig.defconfig.stm32f072xb
+++ b/arch/arm/soc/st_stm32/stm32f0/Kconfig.defconfig.stm32f072xb
@@ -11,10 +11,6 @@ config SOC
 	string
 	default stm32f072xb
 
-config FLASH_PAGE_SIZE
-	hex
-	default 0x800
-
 config NUM_IRQS
 	int
 	default 32

--- a/arch/arm/soc/st_stm32/stm32f0/Kconfig.defconfig.stm32f091xc
+++ b/arch/arm/soc/st_stm32/stm32f0/Kconfig.defconfig.stm32f091xc
@@ -11,10 +11,6 @@ config SOC
 	string
 	default stm32f091xc
 
-config FLASH_PAGE_SIZE
-	hex
-	default 0x800
-
 config NUM_IRQS
 	int
 	default 32

--- a/drivers/flash/flash_stm32f0x.c
+++ b/drivers/flash/flash_stm32f0x.c
@@ -29,7 +29,7 @@ bool flash_stm32_valid_range(struct device *dev, off_t offset, u32_t len,
 
 static unsigned int get_page(off_t offset)
 {
-	return offset / CONFIG_FLASH_PAGE_SIZE;
+	return offset / FLASH_PAGE_SIZE;
 }
 
 static int write_hword(struct device *dev, off_t offset, u16_t val)
@@ -92,7 +92,7 @@ static int erase_page(struct device *dev, unsigned int page)
 	}
 
 	/* Calculate the flash page address */
-	page_address += page * CONFIG_FLASH_PAGE_SIZE;
+	page_address += page * FLASH_PAGE_SIZE;
 
 	/* Set the PER bit and select the page you wish to erase */
 	regs->cr |= FLASH_CR_PER;


### PR DESCRIPTION
STM32F0 flash driver already uses FLASH_PAGE_SIZE from HAL in flash layout part, so CONFIG_FLASH_PAGE_SIZE is redundant and confusing.

Maybe HAL flash headers should be explicitly included here, but that is a different issue. STM32 flash drivers definitely need some love.

Signed-off-by: Ilya Tagunov <tagunil@gmail.com>