### PR TITLE
drivers: usb: nrf5: various fixes

### DIFF
--- a/drivers/usb/device/usb_dc_nrf5.c
+++ b/drivers/usb/device/usb_dc_nrf5.c
@@ -2208,3 +2208,19 @@ int usb_dc_set_status_callback(const usb_dc_status_callback cb)
 
 	return 0;
 }
+
+int usb_dc_ep_mps(const u8_t ep)
+{
+	struct nrf5_usbd_ep_ctx *ep_ctx;
+
+	if (!dev_attached()) {
+		return -ENODEV;
+	}
+
+	ep_ctx = endpoint_ctx(ep);
+	if (!ep_ctx) {
+		return -EINVAL;
+	}
+
+	return ep_ctx->cfg.max_sz;
+}

--- a/drivers/usb/device/usb_dc_nrf5.c
+++ b/drivers/usb/device/usb_dc_nrf5.c
@@ -1422,11 +1422,8 @@ static inline void handle_iso_ep_idle_state_events(struct ep_usb_event *ev)
 			 * will transfer the OUT data anyway if DMA is set up.
 			 */
 
-			/**
-			 * Have anything in the ISO OUT buffer to write to
-			 * USB bus?
-			 */
-			if (ep_ctx->buf.len) {
+			/** Is buffer available? */
+			if (!ep_ctx->buf.len) {
 				u32_t maxcnt;
 
 				maxcnt = nrf_usbd_episoout_size_get(addr);
@@ -1439,8 +1436,11 @@ static inline void handle_iso_ep_idle_state_events(struct ep_usb_event *ev)
 				start_epout_task(addr);
 			}
 		} else {
-			/** Is buffer available? */
-			if (!ep_ctx->buf.len) {
+			/**
+			 * Have anything in the ISO IN buffer to write to
+			 * USB bus?
+			 */
+			if (ep_ctx->buf.len) {
 				nrf_usbd_ep_easydma_set(addr,
 							(u32_t)ep_ctx->buf.data,
 							ep_ctx->cfg.max_sz);


### PR DESCRIPTION
Fix the following issues:

1. Recently the usb_dc_ep_mps() API was added which is required for usb_transfer APIs. This function needs to be implemented by all the usb device drivers. Since the nRF52840 driver was merged just before the merge of usb_transfer API PR #5983 the new API definition is missing. Without this change, there's a linking issue as the usb_dc_ep_mps() function is missing.

2. Fix OUT endpoint read size that is seen with cdc_acm sample.

3. Fix issue with ISO IN/OUT SOF handling.