### PR TITLE
tests: Kconfig: Added a new kconfig.

### DIFF
--- a/tests/Kconfig
+++ b/tests/Kconfig
@@ -32,4 +32,14 @@ config COVERAGE
 	  This option will build your application with the -coverage option
 	  which will generate data that can be used to create coverage reports.
 	  Currently this is fully supported only on the native POSIX port.
+
+config TEST_USERSPACE
+	bool "Enable userspace if available"
+	depends on ARCH_HAS_USERSPACE
+	select USERSPACE
+	select APPLICATION_MEMORY
+	default n
+	help
+	  This option will help test the userspace mode. This can be enabled
+	  only when CONFIG_HAS_USERSPACE is set.
 endmenu


### PR DESCRIPTION
A new Kconfig to help test the userspace mode. Needed for devices
which have userspace capabilities but are not enabled by default.
This kconfig enables the userspace for the devices which have
CONFIG_ARCH_HAS_USERSPACE enabled.

Needed for #6516 and #6571  

Signed-off-by: Adithya Baglody <adithya.nagaraj.baglody@intel.com