### PR TITLE
Bluetooth: Mesh: cfg_cli: Fix possible race condition

### DIFF
--- a/subsys/bluetooth/host/mesh/cfg_cli.c
+++ b/subsys/bluetooth/host/mesh/cfg_cli.c
@@ -318,7 +318,9 @@ static void mod_pub_status(struct bt_mesh_model *model,
 		return;
 	}
 
-	*param->status = status;
+	if (param->status) {
+		*param->status = status;
+	}
 
 	if (param->pub) {
 		param->pub->addr = net_buf_simple_pull_le16(buf);
@@ -383,7 +385,9 @@ static void mod_sub_status(struct bt_mesh_model *model,
 		*param->sub_addr = sub_addr;
 	}
 
-	*param->status = status;
+	if (param->status) {
+		*param->status = status;
+	}
 
 	k_sem_give(&cli->op_sync);
 }


### PR DESCRIPTION
If the thread that sends the configuration messages has low priority
and is sending to the local node (a common use case currently) it's
possible that the response arrives before the cli->op_* state
variables are set, resulting in the message never getting properly
processed and the client API call timing out.

Split the initialization into a separete cli_prepare() call and add a
cli_reset() to clean up the variables in case of premature completion
of the client operation (e.g. due to message sending failure).

Signed-off-by: Johan Hedberg <johan.hedberg@intel.com>