### PR TITLE
dts: bindings: Add binding for i2s modules

### DIFF
--- a/dts/bindings/i2s/i2s.yaml
+++ b/dts/bindings/i2s/i2s.yaml
@@ -1,0 +1,37 @@
+#
+# Copyright (c) 2018, S Balamurugan <bala071985@gmail.com>
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+---
+title: I2S Base Structure
+id: I2S
+version: 0.1
+
+description: >
+    This binding gives the base structure for all I2S devices
+
+properties:
+    compatible:
+      type: string
+      category: required
+      description: compatible strings
+
+    label:
+      type: string
+      category: required
+      description: Human readable string describing the device (used by Zephyr for API name)
+      generation: define
+
+    reg:
+      type: array
+      category: required
+      description: mmio register space
+      generation: define
+
+    interrupts:
+      type: array
+      category: required
+      description: required interrupts
+      generation: define
+...


### PR DESCRIPTION
provides generic yaml description for i2s devices.

Signed-off-by: S Balamurugan <bala071985@gmail.com>