### PR TITLE
arch: arm: SecureFault_IRQn for non-CMSIS-compliant MCUs

### DIFF
--- a/include/arch/arm/cortex_m/cmsis.h
+++ b/include/arch/arm/cortex_m/cmsis.h
@@ -53,6 +53,9 @@ typedef enum {
 	MemoryManagement_IRQn         = -12,
 	BusFault_IRQn                 = -11,
 	UsageFault_IRQn               = -10,
+#if defined(CONFIG_ARM_SECURE_FIRMWARE)
+	SecureFault_IRQn              = -7,
+#endif /* CONFIG_ARM_SECURE_FIRMWARE */
 #endif /* CONFIG_ARMV7_M_ARMV8_M_MAINLINE */
 	SVCall_IRQn                   =  -5,
 	DebugMonitor_IRQn             =  -4,


### PR DESCRIPTION
Define IRQ number for SecureFault Handler when building Secure
Firmware for non-CMSIS-compliant ARM Cortex-M MCUs.

Signed-off-by: Ioannis Glaropoulos <Ioannis.Glaropoulos@nordicsemi.no>