### PR TITLE
net: pkt: net_pkt_get_reserve_data() was aliased incorrectly

### DIFF
--- a/include/net/net_pkt.h
+++ b/include/net/net_pkt.h
@@ -541,8 +541,8 @@ struct net_buf *net_pkt_get_reserve_data_debug(struct net_buf_pool *pool,
 					       int line);
 
 #define net_pkt_get_reserve_data(pool, reserve_head, timeout)		\
-	net_pkt_get_reserve_debug(pool, reserve_head, timeout,		\
-				  __func__, __LINE__)
+	net_pkt_get_reserve_data_debug(pool, reserve_head, timeout,	\
+				       __func__, __LINE__)
 
 struct net_pkt *net_pkt_get_rx_debug(struct net_context *context,
 				     s32_t timeout,


### PR DESCRIPTION
If CONFIG_NET_DEBUG_NET_PKT was enabled, then a call to
net_pkt_get_reserve_data() was calling wrong debug function
which caused compile error.

Signed-off-by: Jukka Rissanen <jukka.rissanen@linux.intel.com>