### PR TITLE
net: ethernet: Avoid overlapping memcpy for tx packets

### DIFF
--- a/subsys/net/ip/l2/ethernet.c
+++ b/subsys/net/ip/l2/ethernet.c
@@ -316,10 +316,16 @@ setup_hdr:
 
 		hdr = (struct net_eth_hdr *)(frag->data -
 					     net_pkt_ll_reserve(pkt));
-		memcpy(&hdr->dst, net_pkt_ll_dst(pkt)->addr,
-		       sizeof(struct net_eth_addr));
-		memcpy(&hdr->src, net_pkt_ll_src(pkt)->addr,
-		       sizeof(struct net_eth_addr));
+		if ((u8_t *)&hdr->dst != net_pkt_ll_dst(pkt)->addr) {
+			memcpy(&hdr->dst, net_pkt_ll_dst(pkt)->addr,
+			       sizeof(struct net_eth_addr));
+		}
+
+		if ((u8_t *)&hdr->src != net_pkt_ll_src(pkt)->addr) {
+			memcpy(&hdr->src, net_pkt_ll_src(pkt)->addr,
+			       sizeof(struct net_eth_addr));
+		}
+
 		hdr->type = ptype;
 		print_ll_addrs(pkt, ntohs(hdr->type), frag->len);
 


### PR DESCRIPTION
This was reported by valgrind

Source and destination overlap in memcpy(0x80c18c0, 0x80c18c0, 6)
   at 0x4035C3E: memcpy (vg_replace_strmem.c:1023)
   by 0x80978CA: ethernet_send (ethernet.c:319)
   by 0x8061B9B: net_if_send_data (net_if.c:281)
   by 0x805F215: net_send_data (net_core.c:399)
   by 0x8080998: send_mldv2_raw (ipv6.c:2858)
   by 0x8080BA6: send_mldv2 (ipv6.c:2889)
   by 0x8080D6C: net_ipv6_mld_join (ipv6.c:2915)
   by 0x8061EF0: join_mcast_allnodes (net_if.c:438)
   by 0x8062CA4: net_if_ipv6_addr_add (net_if.c:826)
   by 0x8062296: net_if_start_dad (net_if.c:557)
   by 0x8066667: net_if_up (net_if.c:2107)
   by 0x8066AF0: net_if_post_init (net_if.c:2341)

Signed-off-by: Jukka Rissanen <jukka.rissanen@linux.intel.com>