### PR TITLE
net: ipv6: fix memory leak caused by echo request

### DIFF
--- a/subsys/net/ip/ipv6.c
+++ b/subsys/net/ip/ipv6.c
@@ -2149,6 +2149,10 @@ int net_ipv6_send_ns(struct net_if *iface,
 		if (!nbr) {
 			NET_DBG("Could not create new neighbor %s",
 				net_sprint_ipv6_addr(&ns_hdr->tgt));
+			if (pending) {
+				net_pkt_unref(pending);
+			}
+
 			goto drop;
 		}
 	}


### PR DESCRIPTION
Memory leak occurs if neighbor table is full and echo request from an
unknown neighbor is received. Hence, on an attempt to send NS unref of
pending is not done, causing the memory leak.

Signed-off-by: Ruslan Mstoi <ruslan.mstoi@intel.com>