### PR TITLE
arch: arm: nordic_nrf: Restore copyright years

### DIFF
--- a/arch/arm/soc/nordic_nrf/Kconfig
+++ b/arch/arm/soc/nordic_nrf/Kconfig
@@ -1,6 +1,6 @@
 # Kconfig - Nordic Semiconductor nRFx MCU line
 #
-# Copyright (c) 2018 Nordic Semiconductor ASA
+# Copyright (c) 2016-2018 Nordic Semiconductor ASA
 #
 # SPDX-License-Identifier: Apache-2.0
 #

--- a/arch/arm/soc/nordic_nrf/Kconfig.defconfig
+++ b/arch/arm/soc/nordic_nrf/Kconfig.defconfig
@@ -1,6 +1,6 @@
 # Kconfig.defconfig - Nordic Semiconductor nRFx MCU line
 #
-# Copyright (c) 2018 Nordic Semiconductor ASA
+# Copyright (c) 2016-2018 Nordic Semiconductor ASA
 #
 # SPDX-License-Identifier: Apache-2.0
 #

--- a/arch/arm/soc/nordic_nrf/Kconfig.soc
+++ b/arch/arm/soc/nordic_nrf/Kconfig.soc
@@ -1,6 +1,6 @@
 # Kconfig.soc - Nordic Semiconductor nRFx MCU line
 #
-# Copyright (c) 2018 Nordic Semiconductor ASA
+# Copyright (c) 2016-2018 Nordic Semiconductor ASA
 #
 # SPDX-License-Identifier: Apache-2.0
 #

--- a/arch/arm/soc/nordic_nrf/include/nrf_common.h
+++ b/arch/arm/soc/nordic_nrf/include/nrf_common.h
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2016 Linaro Ltd.
- * Copyright (c) 2018 Nordic Semiconductor ASA
+ * Copyright (c) 2016-2018 Nordic Semiconductor ASA
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/arch/arm/soc/nordic_nrf/nrf52/Kconfig.defconfig.series
+++ b/arch/arm/soc/nordic_nrf/nrf52/Kconfig.defconfig.series
@@ -1,6 +1,6 @@
 # Kconfig.defconfig.series - Nordic Semiconductor nRF52 MCU line
 #
-# Copyright (c) 2018 Nordic Semiconductor ASA
+# Copyright (c) 2016-2018 Nordic Semiconductor ASA
 #
 # SPDX-License-Identifier: Apache-2.0
 #

--- a/arch/arm/soc/nordic_nrf/nrf52/Kconfig.series
+++ b/arch/arm/soc/nordic_nrf/nrf52/Kconfig.series
@@ -1,6 +1,6 @@
 # Kconfig.series - Nordic Semiconductor nRF52 MCU line
 #
-# Copyright (c) 2018 Nordic Semiconductor ASA
+# Copyright (c) 2016-2018 Nordic Semiconductor ASA
 #
 # SPDX-License-Identifier: Apache-2.0
 #

--- a/drivers/serial/uart_nrf5.c
+++ b/drivers/serial/uart_nrf5.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016 Nordic Semiconductor ASA
+ * Copyright (c) 2016-2018 Nordic Semiconductor ASA
  *
  * SPDX-License-Identifier: Apache-2.0
  */


### PR DESCRIPTION
A previous commit had mistakenly overwritten the copyright years instead
of extending the range. Fix this mistake so that the proper range is
recorded.

Signed-off-by: Carles Cufi <carles.cufi@nordicsemi.no>