### PR TITLE
TCP refactoring

### DIFF
--- a/subsys/net/ip/net_context.c
+++ b/subsys/net/ip/net_context.c
@@ -1111,18 +1111,6 @@ static int send_reset(struct net_context *context,
 	return ret;
 }
 
-static int tcp_hdr_len(struct net_pkt *pkt)
-{
-	struct net_tcp_hdr hdr, *tcp_hdr;
-
-	tcp_hdr = net_tcp_get_hdr(pkt, &hdr);
-	if (tcp_hdr) {
-		return NET_TCP_HDR_LEN(tcp_hdr);
-	}
-
-	return 0;
-}
-
 /* This is called when we receive data after the connection has been
  * established. The core TCP logic is located here.
  */

--- a/subsys/net/ip/net_context.c
+++ b/subsys/net/ip/net_context.c
@@ -2214,7 +2214,6 @@ int net_context_sendto(struct net_pkt *pkt,
 		       void *token,
 		       void *user_data)
 {
-#if defined(CONFIG_NET_TCP)
 	struct net_context *context = net_pkt_context(pkt);
 
 	NET_ASSERT(PART_OF_ARRAY(contexts, context));
@@ -2223,7 +2222,6 @@ int net_context_sendto(struct net_pkt *pkt,
 		/* Match POSIX behavior and ignore dst_address and addrlen */
 		return net_context_send(pkt, cb, timeout, token, user_data);
 	}
-#endif /* CONFIG_NET_TCP */
 
 	return sendto(pkt, dst_addr, addrlen, cb, timeout, token, user_data);
 }

--- a/subsys/net/ip/net_context.c
+++ b/subsys/net/ip/net_context.c
@@ -1743,7 +1743,6 @@ NET_CONN_CB(tcp_syn_rcvd)
 	 */
 	if (NET_TCP_FLAGS(tcp_hdr) == NET_TCP_ACK) {
 		struct net_context *new_context;
-		struct net_tcp *new_tcp;
 		socklen_t addrlen;
 		int ret;
 
@@ -1806,8 +1805,6 @@ NET_CONN_CB(tcp_syn_rcvd)
 		 * was used to establish this connection. The old TCP
 		 * must be listening to accept other connections.
 		 */
-		new_tcp = new_context->tcp;
-		new_tcp->accept_cb = NULL;
 		copy_pool_vars(new_context, context);
 
 		net_tcp_change_state(tcp, NET_TCP_LISTEN);

--- a/subsys/net/ip/net_context.c
+++ b/subsys/net/ip/net_context.c
@@ -2357,27 +2357,8 @@ int net_context_recv(struct net_context *context,
 }
 
 int net_context_update_recv_wnd(struct net_context *context,
-				s32_t delta)
-{
-#if defined(CONFIG_NET_TCP)
-	s32_t new_win;
-
-	if (!context->tcp) {
-		NET_ERR("context->tcp == NULL");
-		return -EPROTOTYPE;
-	}
-
-	new_win = context->tcp->recv_wnd + delta;
-	if (new_win < 0 || new_win > UINT16_MAX) {
-		return -EINVAL;
-	}
-
-	context->tcp->recv_wnd = new_win;
-
-	return 0;
-#else
-	return -EPROTOTYPE;
-#endif
+				s32_t delta) {
+	return net_tcp_update_recv_wnd(context, delta);
 }
 
 static int set_context_priority(struct net_context *context,

--- a/subsys/net/ip/net_context.c
+++ b/subsys/net/ip/net_context.c
@@ -2208,17 +2208,20 @@ static void set_appdata_values(struct net_pkt *pkt, enum net_ip_protocol proto)
 	struct net_buf *frag;
 	u16_t offset;
 
+	switch (proto) {
+	case IPPROTO_UDP:
 #if defined(CONFIG_NET_UDP)
-	if (proto == IPPROTO_UDP) {
 		proto_len = sizeof(struct net_udp_hdr);
-	}
 #endif /* CONFIG_NET_UDP */
+		break;
 
-#if defined(CONFIG_NET_TCP)
-	if (proto == IPPROTO_TCP) {
+	case IPPROTO_TCP:
 		proto_len = tcp_hdr_len(pkt);
+		break;
+
+	default:
+		return;
 	}
-#endif /* CONFIG_NET_TCP */
 
 	frag = net_frag_get_pos(pkt, net_pkt_ip_hdr_len(pkt) +
 				net_pkt_ipv6_ext_len(pkt) +

--- a/subsys/net/ip/net_context.c
+++ b/subsys/net/ip/net_context.c
@@ -1352,11 +1352,9 @@ int net_context_connect(struct net_context *context,
 			s32_t timeout,
 			void *user_data)
 {
-#if defined(CONFIG_NET_TCP)
 	struct sockaddr *laddr = NULL;
 	struct sockaddr local_addr;
 	u16_t lport, rport;
-#endif
 	int ret;
 
 	NET_ASSERT(addr);
@@ -1409,11 +1407,10 @@ int net_context_connect(struct net_context *context,
 			return -EINVAL;
 		}
 
-#if defined(CONFIG_NET_TCP)
-		if (net_is_ipv6_addr_mcast(&addr6->sin6_addr)) {
+		if (net_context_get_ip_proto(context) == IPPROTO_TCP &&
+		    net_is_ipv6_addr_mcast(&addr6->sin6_addr)) {
 			return -EADDRNOTAVAIL;
 		}
-#endif /* CONFIG_NET_TCP */
 
 		memcpy(&addr6->sin6_addr, &net_sin6(addr)->sin6_addr,
 		       sizeof(struct in6_addr));
@@ -1427,7 +1424,6 @@ int net_context_connect(struct net_context *context,
 			context->flags &= ~NET_CONTEXT_REMOTE_ADDR_SET;
 		}
 
-#if defined(CONFIG_NET_TCP)
 		rport = addr6->sin6_port;
 
 		net_sin6_ptr(&context->local)->sin6_family = AF_INET6;
@@ -1441,7 +1437,6 @@ int net_context_connect(struct net_context *context,
 
 			laddr = &local_addr;
 		}
-#endif
 	} else
 #endif /* CONFIG_NET_IPV6 */
 
@@ -1454,9 +1449,7 @@ int net_context_connect(struct net_context *context,
 			return -EINVAL;
 		}
 
-#if defined(CONFIG_NET_TCP)
 		/* FIXME - Add multicast and broadcast address check */
-#endif /* CONFIG_NET_TCP */
 
 		memcpy(&addr4->sin_addr, &net_sin(addr)->sin_addr,
 		       sizeof(struct in_addr));
@@ -1470,7 +1463,6 @@ int net_context_connect(struct net_context *context,
 			context->flags &= ~NET_CONTEXT_REMOTE_ADDR_SET;
 		}
 
-#if defined(CONFIG_NET_TCP)
 		rport = addr4->sin_port;
 
 		net_sin_ptr(&context->local)->sin_family = AF_INET;
@@ -1484,7 +1476,6 @@ int net_context_connect(struct net_context *context,
 
 			laddr = &local_addr;
 		}
-#endif
 	} else
 #endif /* CONFIG_NET_IPV4 */
 

--- a/subsys/net/ip/net_context.c
+++ b/subsys/net/ip/net_context.c
@@ -43,294 +43,12 @@
 
 #define NET_MAX_CONTEXT CONFIG_NET_MAX_CONTEXTS
 
-#if defined(CONFIG_NET_TCP_ACK_TIMEOUT)
-#define ACK_TIMEOUT CONFIG_NET_TCP_ACK_TIMEOUT
-#else
-#define ACK_TIMEOUT K_SECONDS(1)
-#endif
-
-/* TODO: It should be 2 * MSL (Maximum segment lifetime) */
-#define TIMEWAIT_TIMEOUT MSEC(250)
-
-#define FIN_TIMEOUT K_SECONDS(1)
-
-/* Declares a wrapper function for a net_conn callback that refs the
- * context around the invocation (to protect it from premature
- * deletion).  Long term would be nice to see this feature be part of
- * the connection type itself, but right now it has opaque "user_data"
- * pointers and doesn't understand what a net_context is.
- */
-#define NET_CONN_CB(name) \
-	static enum net_verdict _##name(struct net_conn *conn,	  \
-					struct net_pkt *pkt,	  \
-					void *user_data);	  \
-	static enum net_verdict name(struct net_conn *conn,	  \
-				     struct net_pkt *pkt,	  \
-				     void *user_data)		  \
-	{							  \
-		enum net_verdict result;			  \
-								  \
-		net_context_ref(user_data);			  \
-		result = _##name(conn, pkt, user_data);		  \
-		net_context_unref(user_data);			  \
-		return result;					  \
-	}							  \
-	static enum net_verdict _##name(struct net_conn *conn,    \
-					struct net_pkt *pkt,      \
-					void *user_data)	  \
-
-
 static struct net_context contexts[NET_MAX_CONTEXT];
 
 /* We need to lock the contexts array as these APIs are typically called
  * from applications which are usually run in task context.
  */
 static struct k_sem contexts_lock;
-
-static enum net_verdict packet_received(struct net_conn *conn,
-					struct net_pkt *pkt,
-					void *user_data);
-
-static void set_appdata_values(struct net_pkt *pkt, enum net_ip_protocol proto);
-
-#if defined(CONFIG_NET_TCP)
-static int send_reset(struct net_context *context, struct sockaddr *local,
-		      struct sockaddr *remote);
-
-static struct tcp_backlog_entry {
-	struct net_tcp *tcp;
-	struct sockaddr remote;
-	u32_t send_seq;
-	u32_t send_ack;
-	u16_t send_mss;
-	struct k_delayed_work ack_timer;
-} tcp_backlog[CONFIG_NET_TCP_BACKLOG_SIZE];
-
-static void backlog_ack_timeout(struct k_work *work)
-{
-	struct tcp_backlog_entry *backlog =
-		CONTAINER_OF(work, struct tcp_backlog_entry, ack_timer);
-
-	NET_DBG("Did not receive ACK in %dms", ACK_TIMEOUT);
-
-	/* TODO: If net_context is bound to unspecified IPv6 address
-	 * and some port number, local address is not available.
-	 * RST packet might be invalid. Cache local address
-	 * and use it in RST message preparation.
-	 */
-	send_reset(backlog->tcp->context, NULL, &backlog->remote);
-
-	memset(backlog, 0, sizeof(struct tcp_backlog_entry));
-}
-
-static int tcp_backlog_find(struct net_pkt *pkt, int *empty_slot)
-{
-	struct net_tcp_hdr hdr, *tcp_hdr;
-	int i, empty = -1;
-
-	for (i = 0; i < CONFIG_NET_TCP_BACKLOG_SIZE; i++) {
-		if (tcp_backlog[i].tcp == NULL && empty < 0) {
-			empty = i;
-			continue;
-		}
-
-		if (net_pkt_family(pkt) != tcp_backlog[i].remote.sa_family) {
-			continue;
-		}
-
-		tcp_hdr = net_tcp_get_hdr(pkt, &hdr);
-		if (!tcp_hdr) {
-			return -EINVAL;
-		}
-
-		switch (net_pkt_family(pkt)) {
-#if defined(CONFIG_NET_IPV6)
-		case AF_INET6:
-			if (net_sin6(&tcp_backlog[i].remote)->sin6_port !=
-			    tcp_hdr->src_port) {
-				continue;
-			}
-
-			if (memcmp(&net_sin6(&tcp_backlog[i].remote)->sin6_addr,
-				   &NET_IPV6_HDR(pkt)->src,
-				   sizeof(struct in6_addr))) {
-				continue;
-			}
-
-			break;
-#endif
-#if defined(CONFIG_NET_IPV4)
-		case AF_INET:
-			if (net_sin(&tcp_backlog[i].remote)->sin_port !=
-			    tcp_hdr->src_port) {
-				continue;
-			}
-
-			if (memcmp(&net_sin(&tcp_backlog[i].remote)->sin_addr,
-				   &NET_IPV4_HDR(pkt)->src,
-				   sizeof(struct in_addr))) {
-				continue;
-			}
-
-			break;
-#endif
-		}
-
-		return i;
-	}
-
-	if (empty_slot) {
-		*empty_slot = empty;
-	}
-
-	return -EADDRNOTAVAIL;
-}
-
-static int tcp_backlog_syn(struct net_pkt *pkt, struct net_context *context,
-			   u16_t send_mss)
-{
-	int empty_slot = -1;
-	int ret;
-
-	if (tcp_backlog_find(pkt, &empty_slot) >= 0) {
-		return -EADDRINUSE;
-	}
-
-	if (empty_slot < 0) {
-		return -ENOSPC;
-	}
-
-	tcp_backlog[empty_slot].tcp = context->tcp;
-
-	ret = net_pkt_get_src_addr(pkt, &tcp_backlog[empty_slot].remote,
-				   sizeof(tcp_backlog[empty_slot].remote));
-	if (ret < 0) {
-		/* Release the assigned empty slot */
-		tcp_backlog[empty_slot].tcp = NULL;
-
-		return ret;
-	}
-
-	tcp_backlog[empty_slot].send_seq = context->tcp->send_seq;
-	tcp_backlog[empty_slot].send_ack = context->tcp->send_ack;
-	tcp_backlog[empty_slot].send_mss = send_mss;
-
-	k_delayed_work_init(&tcp_backlog[empty_slot].ack_timer,
-			    backlog_ack_timeout);
-	k_delayed_work_submit(&tcp_backlog[empty_slot].ack_timer, ACK_TIMEOUT);
-
-	return 0;
-}
-
-static int tcp_backlog_ack(struct net_pkt *pkt, struct net_context *context)
-{
-	struct net_tcp_hdr hdr, *tcp_hdr;
-	int r;
-
-	r = tcp_backlog_find(pkt, NULL);
-
-	if (r < 0) {
-		return r;
-	}
-
-	tcp_hdr = net_tcp_get_hdr(pkt, &hdr);
-	if (!tcp_hdr) {
-		return -EINVAL;
-	}
-
-	/* Sent SEQ + 1 needs to be the same as the received ACK */
-	if (tcp_backlog[r].send_seq + 1 != sys_get_be32(tcp_hdr->ack)) {
-		return -EINVAL;
-	}
-
-	memcpy(&context->remote, &tcp_backlog[r].remote,
-		sizeof(struct sockaddr));
-	context->tcp->send_seq = tcp_backlog[r].send_seq + 1;
-	context->tcp->send_ack = tcp_backlog[r].send_ack;
-	context->tcp->send_mss = tcp_backlog[r].send_mss;
-
-	k_delayed_work_cancel(&tcp_backlog[r].ack_timer);
-	memset(&tcp_backlog[r], 0, sizeof(struct tcp_backlog_entry));
-
-	return 0;
-}
-
-static int tcp_backlog_rst(struct net_pkt *pkt)
-{
-	struct net_tcp_hdr hdr, *tcp_hdr;
-	int r;
-
-	r = tcp_backlog_find(pkt, NULL);
-	if (r < 0) {
-		return r;
-	}
-
-	tcp_hdr = net_tcp_get_hdr(pkt, &hdr);
-	if (!tcp_hdr) {
-		return -EINVAL;
-	}
-
-	/* The ACK sent needs to be the same as the received SEQ */
-	if (tcp_backlog[r].send_ack != sys_get_be32(tcp_hdr->seq)) {
-		return -EINVAL;
-	}
-
-	k_delayed_work_cancel(&tcp_backlog[r].ack_timer);
-	memset(&tcp_backlog[r], 0, sizeof(struct tcp_backlog_entry));
-
-	return 0;
-}
-
-static void handle_fin_timeout(struct k_work *work)
-{
-	struct net_tcp *tcp =
-		CONTAINER_OF(work, struct net_tcp, fin_timer);
-
-	NET_DBG("Did not receive FIN in %dms", FIN_TIMEOUT);
-
-	net_context_unref(tcp->context);
-}
-
-static void handle_ack_timeout(struct k_work *work)
-{
-	/* This means that we did not receive ACK response in time. */
-	struct net_tcp *tcp = CONTAINER_OF(work, struct net_tcp, ack_timer);
-
-	NET_DBG("Did not receive ACK in %dms while in %s", ACK_TIMEOUT,
-		net_tcp_state_str(net_tcp_get_state(tcp)));
-
-	if (net_tcp_get_state(tcp) == NET_TCP_LAST_ACK) {
-		/* We did not receive the last ACK on time. We can only
-		 * close the connection at this point. We will not send
-		 * anything to peer in this last state, but will go directly
-		 * to to CLOSED state.
-		 */
-		net_tcp_change_state(tcp, NET_TCP_CLOSED);
-
-		net_context_unref(tcp->context);
-	}
-}
-
-static void handle_timewait_timeout(struct k_work *work)
-{
-	struct net_tcp *tcp = CONTAINER_OF(work, struct net_tcp,
-					   timewait_timer);
-
-	NET_DBG("Timewait expired in %dms", TIMEWAIT_TIMEOUT);
-
-	if (net_tcp_get_state(tcp) == NET_TCP_TIME_WAIT) {
-		net_tcp_change_state(tcp, NET_TCP_CLOSED);
-
-		if (tcp->context->recv_cb) {
-			tcp->context->recv_cb(tcp->context, NULL, 0,
-					      tcp->recv_user_data);
-		}
-
-		net_context_unref(tcp->context);
-	}
-}
-
-#endif /* CONFIG_NET_TCP */
 
 static int check_used_port(enum net_ip_protocol ip_proto,
 			   u16_t local_port,
@@ -481,24 +199,11 @@ int net_context_get(sa_family_t family,
 			continue;
 		}
 
-#if defined(CONFIG_NET_TCP)
 		if (ip_proto == IPPROTO_TCP) {
-			contexts[i].tcp = net_tcp_alloc(&contexts[i]);
-			if (!contexts[i].tcp) {
-				NET_ASSERT_INFO(contexts[i].tcp,
-						"Cannot allocate TCP context");
-				ret = -ENOBUFS;
+			if (net_tcp_get(&contexts[i]) < 0) {
 				break;
 			}
-
-			k_delayed_work_init(&contexts[i].tcp->ack_timer,
-					    handle_ack_timeout);
-			k_delayed_work_init(&contexts[i].tcp->fin_timer,
-					    handle_fin_timeout);
-			k_delayed_work_init(&contexts[i].tcp->timewait_timer,
-					    handle_timewait_timeout);
 		}
-#endif /* CONFIG_NET_TCP */
 
 		contexts[i].iface = 0;
 		contexts[i].flags = 0;
@@ -591,24 +296,7 @@ int net_context_unref(struct net_context *context)
 
 	k_sem_take(&contexts_lock, K_FOREVER);
 
-#if defined(CONFIG_NET_TCP)
-	if (context->tcp) {
-		int i;
-
-		/* Clear the backlog for this TCP context. */
-		for (i = 0; i < CONFIG_NET_TCP_BACKLOG_SIZE; i++) {
-			if (tcp_backlog[i].tcp != context->tcp) {
-				continue;
-			}
-
-			k_delayed_work_cancel(&tcp_backlog[i].ack_timer);
-			memset(&tcp_backlog[i], 0, sizeof(tcp_backlog[i]));
-		}
-
-		net_tcp_release(context->tcp);
-		context->tcp = NULL;
-	}
-#endif /* CONFIG_NET_TCP */
+	net_tcp_unref(context);
 
 	if (context->conn_handler) {
 		net_conn_unregister(context->conn_handler);
@@ -934,417 +622,6 @@ int net_context_listen(struct net_context *context, int backlog)
 	return -EOPNOTSUPP;
 }
 
-#if defined(CONFIG_NET_TCP)
-#if defined(CONFIG_NET_DEBUG_CONTEXT)
-#define net_tcp_print_recv_info(str, pkt, port)				\
-	do {								\
-		if (net_context_get_family(context) == AF_INET6) {	\
-			NET_DBG("%s received from %s port %d", str,	\
-				net_sprint_ipv6_addr(&NET_IPV6_HDR(pkt)->src),\
-				ntohs(port));				\
-		} else if (net_context_get_family(context) == AF_INET) {\
-			NET_DBG("%s received from %s port %d", str,	\
-				net_sprint_ipv4_addr(&NET_IPV4_HDR(pkt)->src),\
-				ntohs(port));				\
-		}							\
-	} while (0)
-
-#define net_tcp_print_send_info(str, pkt, port)				\
-	do {								\
-		struct net_context *ctx = net_pkt_context(pkt);		\
-		if (net_context_get_family(ctx) == AF_INET6) {		\
-			NET_DBG("%s sent to %s port %d", str,		\
-				net_sprint_ipv6_addr(&NET_IPV6_HDR(pkt)->dst),\
-				ntohs(port));				\
-		} else if (net_context_get_family(ctx) == AF_INET) {	\
-			NET_DBG("%s sent to %s port %d", str,		\
-				net_sprint_ipv4_addr(&NET_IPV4_HDR(pkt)->dst),\
-				ntohs(port));				\
-		}							\
-	} while (0)
-
-#else
-#define net_tcp_print_recv_info(...)
-#define net_tcp_print_send_info(...)
-#endif /* CONFIG_NET_DEBUG_CONTEXT */
-
-static void print_send_info(struct net_pkt *pkt, const char *msg)
-{
-	if (IS_ENABLED(CONFIG_NET_DEBUG_CONTEXT)) {
-		struct net_tcp_hdr hdr, *tcp_hdr;
-
-		tcp_hdr = net_tcp_get_hdr(pkt, &hdr);
-		if (tcp_hdr) {
-			net_tcp_print_send_info(msg, pkt, tcp_hdr->dst_port);
-		}
-	}
-}
-
-/* Send SYN or SYN/ACK. */
-static inline int send_syn_segment(struct net_context *context,
-				       const struct sockaddr_ptr *local,
-				       const struct sockaddr *remote,
-				       int flags, const char *msg)
-{
-	struct net_pkt *pkt = NULL;
-	int ret;
-
-	ret = net_tcp_prepare_segment(context->tcp, flags, NULL, 0,
-				      local, remote, &pkt);
-	if (ret) {
-		return ret;
-	}
-
-	ret = net_send_data(pkt);
-	if (ret < 0) {
-		net_pkt_unref(pkt);
-		return ret;
-	}
-
-	context->tcp->send_seq++;
-
-	print_send_info(pkt, msg);
-
-	return ret;
-}
-
-static inline int send_syn(struct net_context *context,
-			   const struct sockaddr *remote)
-{
-	net_tcp_change_state(context->tcp, NET_TCP_SYN_SENT);
-
-	return send_syn_segment(context, NULL, remote, NET_TCP_SYN, "SYN");
-}
-
-static inline int send_syn_ack(struct net_context *context,
-			       struct sockaddr_ptr *local,
-			       struct sockaddr *remote)
-{
-	return send_syn_segment(context, local, remote,
-				    NET_TCP_SYN | NET_TCP_ACK,
-				    "SYN_ACK");
-}
-
-static int send_ack(struct net_context *context,
-		    struct sockaddr *remote, bool force)
-{
-	struct net_pkt *pkt = NULL;
-	int ret;
-
-	/* Something (e.g. a data transmission under the user
-	 * callback) already sent the ACK, no need
-	 */
-	if (!force && context->tcp->send_ack == context->tcp->sent_ack) {
-		return 0;
-	}
-
-	ret = net_tcp_prepare_ack(context->tcp, remote, &pkt);
-	if (ret) {
-		return ret;
-	}
-
-	print_send_info(pkt, "ACK");
-
-	ret = net_tcp_send_pkt(pkt);
-	if (ret < 0) {
-		net_pkt_unref(pkt);
-	}
-
-	return ret;
-}
-
-static int send_reset(struct net_context *context,
-		      struct sockaddr *local,
-		      struct sockaddr *remote)
-{
-	struct net_pkt *pkt = NULL;
-	int ret;
-
-	ret = net_tcp_prepare_reset(context->tcp, local, remote, &pkt);
-	if (ret || !pkt) {
-		return ret;
-	}
-
-	print_send_info(pkt, "RST");
-
-	ret = net_send_data(pkt);
-	if (ret < 0) {
-		net_pkt_unref(pkt);
-	}
-
-	return ret;
-}
-
-/* This is called when we receive data after the connection has been
- * established. The core TCP logic is located here.
- */
-NET_CONN_CB(tcp_established)
-{
-	struct net_context *context = (struct net_context *)user_data;
-	struct net_tcp_hdr hdr, *tcp_hdr;
-	enum net_verdict ret = NET_OK;
-	u8_t tcp_flags;
-	u16_t data_len;
-
-	NET_ASSERT(context && context->tcp);
-
-	tcp_hdr = net_tcp_get_hdr(pkt, &hdr);
-	if (!tcp_hdr) {
-		return NET_DROP;
-	}
-
-	if (net_tcp_get_state(context->tcp) < NET_TCP_ESTABLISHED) {
-		NET_ERR("Context %p in wrong state %d",
-			context, net_tcp_get_state(context->tcp));
-		return NET_DROP;
-	}
-
-	net_tcp_print_recv_info("DATA", pkt, tcp_hdr->src_port);
-
-	tcp_flags = NET_TCP_FLAGS(tcp_hdr);
-
-	if (net_tcp_seq_cmp(sys_get_be32(tcp_hdr->seq),
-			    context->tcp->send_ack) < 0) {
-		/* Peer sent us packet we've already seen. Apparently,
-		 * our ack was lost.
-		 */
-
-		/* RFC793 specifies that "highest" (i.e. current from our PoV)
-		 * ack # value can/should be sent, so we just force resend.
-		 */
-		send_ack(context, &conn->remote_addr, true);
-		return NET_DROP;
-	}
-
-	if (net_tcp_seq_cmp(sys_get_be32(tcp_hdr->seq),
-			    context->tcp->send_ack) > 0) {
-		/* Don't try to reorder packets.  If it doesn't
-		 * match the next segment exactly, drop and wait for
-		 * retransmit
-		 */
-		return NET_DROP;
-	}
-
-	/*
-	 * If we receive RST here, we close the socket. See RFC 793 chapter
-	 * called "Reset Processing" for details.
-	 */
-	if (tcp_flags & NET_TCP_RST) {
-		/* We only accept RST packet that has valid seq field. */
-		if (!net_tcp_validate_seq(context->tcp, pkt)) {
-			net_stats_update_tcp_seg_rsterr();
-			return NET_DROP;
-		}
-
-		net_stats_update_tcp_seg_rst();
-
-		net_tcp_print_recv_info("RST", pkt, tcp_hdr->src_port);
-
-		if (context->recv_cb) {
-			context->recv_cb(context, NULL, -ECONNRESET,
-					 context->tcp->recv_user_data);
-		}
-
-		net_context_unref(context);
-
-		return NET_DROP;
-	}
-
-	/* Handle TCP state transition */
-	if (tcp_flags & NET_TCP_ACK) {
-		if (!net_tcp_ack_received(context,
-				     sys_get_be32(tcp_hdr->ack))) {
-			return NET_DROP;
-		}
-
-		/* TCP state might be changed after maintaining the sent pkt
-		 * list, e.g., an ack of FIN is received.
-		 */
-
-		if (net_tcp_get_state(context->tcp)
-			   == NET_TCP_FIN_WAIT_1) {
-			/* Received FIN on FIN_WAIT1, so cancel the timer */
-			k_delayed_work_cancel(&context->tcp->fin_timer);
-			/* Active close: step to FIN_WAIT_2 */
-			net_tcp_change_state(context->tcp, NET_TCP_FIN_WAIT_2);
-		} else if (net_tcp_get_state(context->tcp)
-			   == NET_TCP_LAST_ACK) {
-			/* Passive close: step to CLOSED */
-			net_tcp_change_state(context->tcp, NET_TCP_CLOSED);
-			/* Release the pkt before clean up */
-			net_pkt_unref(pkt);
-			goto clean_up;
-		}
-	}
-
-	if (tcp_flags & NET_TCP_FIN) {
-		if (net_tcp_get_state(context->tcp) == NET_TCP_ESTABLISHED) {
-			/* Passive close: step to CLOSE_WAIT */
-			net_tcp_change_state(context->tcp, NET_TCP_CLOSE_WAIT);
-
-			/* We should receive ACK next in order to get rid of
-			 * LAST_ACK state that we are entering in a short while.
-			 * But we need to be prepared to NOT to receive it as
-			 * otherwise the connection would be stuck forever.
-			 */
-			k_delayed_work_submit(&context->tcp->ack_timer, ACK_TIMEOUT);
-		} else if (net_tcp_get_state(context->tcp)
-			   == NET_TCP_FIN_WAIT_2) {
-			/* Active close: step to TIME_WAIT */
-			net_tcp_change_state(context->tcp, NET_TCP_TIME_WAIT);
-		}
-
-		context->tcp->fin_rcvd = 1;
-	}
-
-	set_appdata_values(pkt, IPPROTO_TCP);
-
-	data_len = net_pkt_appdatalen(pkt);
-	if (data_len > net_tcp_get_recv_wnd(context->tcp)) {
-		NET_ERR("Context %p: overflow of recv window (%d vs %d), pkt dropped",
-			context, net_tcp_get_recv_wnd(context->tcp), data_len);
-		return NET_DROP;
-	}
-
-	/* If the pkt has appdata, notify the recv callback which should
-	 * release the pkt. Otherwise, release the pkt immediately.
-	 */
-	if (data_len > 0) {
-		ret = packet_received(conn, pkt, context->tcp->recv_user_data);
-	} else if (data_len == 0) {
-		net_pkt_unref(pkt);
-	}
-
-	/* Increment the ack */
-	context->tcp->send_ack += data_len;
-	if (tcp_flags & NET_TCP_FIN) {
-		context->tcp->send_ack += 1;
-	}
-
-	send_ack(context, &conn->remote_addr, false);
-
-clean_up:
-	if (net_tcp_get_state(context->tcp) == NET_TCP_TIME_WAIT) {
-		k_delayed_work_submit(&context->tcp->timewait_timer,
-				      TIMEWAIT_TIMEOUT);
-	}
-
-	if (net_tcp_get_state(context->tcp) == NET_TCP_CLOSED) {
-		if (context->recv_cb) {
-			context->recv_cb(context, NULL, 0,
-					 context->tcp->recv_user_data);
-		}
-
-		net_context_unref(context);
-	}
-
-	return ret;
-}
-
-
-NET_CONN_CB(tcp_synack_received)
-{
-	struct net_context *context = (struct net_context *)user_data;
-	struct net_tcp_hdr hdr, *tcp_hdr;
-	int ret;
-
-	NET_ASSERT(context && context->tcp);
-
-	switch (net_tcp_get_state(context->tcp)) {
-	case NET_TCP_SYN_SENT:
-		net_context_set_iface(context, net_pkt_iface(pkt));
-		break;
-	default:
-		NET_DBG("Context %p in wrong state %d",
-			context, net_tcp_get_state(context->tcp));
-		return NET_DROP;
-	}
-
-	net_pkt_set_context(pkt, context);
-
-	NET_ASSERT(net_pkt_iface(pkt));
-
-	tcp_hdr = net_tcp_get_hdr(pkt, &hdr);
-	if (!tcp_hdr) {
-		return NET_DROP;
-	}
-
-	if (NET_TCP_FLAGS(tcp_hdr) & NET_TCP_RST) {
-		/* We only accept RST packet that has valid seq field. */
-		if (!net_tcp_validate_seq(context->tcp, pkt)) {
-			net_stats_update_tcp_seg_rsterr();
-			return NET_DROP;
-		}
-
-		net_stats_update_tcp_seg_rst();
-
-		if (context->connect_cb) {
-			context->connect_cb(context, -ECONNREFUSED,
-					    context->user_data);
-		}
-
-		return NET_DROP;
-	}
-
-	if (NET_TCP_FLAGS(tcp_hdr) & NET_TCP_SYN) {
-		context->tcp->send_ack =
-			sys_get_be32(tcp_hdr->seq) + 1;
-	}
-	/*
-	 * If we receive SYN, we send SYN-ACK and go to SYN_RCVD state.
-	 */
-	if (NET_TCP_FLAGS(tcp_hdr) == (NET_TCP_SYN | NET_TCP_ACK)) {
-		/* Remove the temporary connection handler and register
-		 * a proper now as we have an established connection.
-		 */
-		struct sockaddr local_addr;
-		struct sockaddr remote_addr;
-
-		if (net_pkt_get_src_addr(
-			pkt, &remote_addr, sizeof(remote_addr)) < 0) {
-			NET_DBG("Cannot parse remote address"
-				" from received pkt");
-			return NET_DROP;
-		}
-
-		if (net_pkt_get_dst_addr(
-			pkt, &local_addr, sizeof(local_addr)) < 0) {
-			NET_DBG("Cannot parse local address from received pkt");
-			return NET_DROP;
-		}
-
-		net_tcp_unregister(context->conn_handler);
-
-		ret = net_tcp_register(&remote_addr,
-				       &local_addr,
-				       ntohs(tcp_hdr->src_port),
-				       ntohs(tcp_hdr->dst_port),
-				       tcp_established,
-				       context,
-				       &context->conn_handler);
-		if (ret < 0) {
-			NET_DBG("Cannot register TCP handler (%d)", ret);
-			send_reset(context, &local_addr, &remote_addr);
-			return NET_DROP;
-		}
-
-		net_tcp_change_state(context->tcp, NET_TCP_ESTABLISHED);
-		net_context_set_state(context, NET_CONTEXT_CONNECTED);
-
-		send_ack(context, &remote_addr, false);
-
-		k_sem_give(&context->tcp->connect_wait);
-
-		if (context->connect_cb) {
-			context->connect_cb(context, 0, context->user_data);
-		}
-	}
-
-	return NET_DROP;
-}
-
-#endif /* CONFIG_NET_TCP */
-
 int net_context_connect(struct net_context *context,
 			const struct sockaddr *addr,
 			socklen_t addrlen,
@@ -1359,9 +636,6 @@ int net_context_connect(struct net_context *context,
 
 	NET_ASSERT(addr);
 	NET_ASSERT(PART_OF_ARRAY(contexts, context));
-#if defined(CONFIG_NET_TCP)
-	NET_ASSERT(context->tcp);
-#endif
 
 	if (!net_context_is_used(context)) {
 		return -EBADF;
@@ -1451,6 +725,8 @@ int net_context_connect(struct net_context *context,
 
 		/* FIXME - Add multicast and broadcast address check */
 
+		addr4 = (struct sockaddr_in *)&context->remote;
+
 		memcpy(&addr4->sin_addr, &net_sin(addr)->sin_addr,
 		       sizeof(struct in_addr));
 
@@ -1483,337 +759,34 @@ int net_context_connect(struct net_context *context,
 		return -EINVAL; /* Not IPv4 or IPv6 */
 	}
 
+	switch (net_context_get_type(context)) {
 #if defined(CONFIG_NET_UDP)
-	if (net_context_get_type(context) == SOCK_DGRAM) {
+	case SOCK_DGRAM:
 		if (cb) {
 			cb(context, 0, user_data);
 		}
 
 		return 0;
-	}
+
 #endif /* CONFIG_NET_UDP */
 
-#if defined(CONFIG_NET_TCP)
-	if (net_context_get_type(context) != SOCK_STREAM) {
+	case SOCK_STREAM:
+		return net_tcp_connect(context, addr, laddr, rport, lport,
+				       timeout, cb, user_data);
+
+	default:
 		return -ENOTSUP;
+
 	}
-
-	/* We need to register a handler, otherwise the SYN-ACK
-	 * packet would not be received.
-	 */
-	ret = net_tcp_register(addr,
-			       laddr,
-			       ntohs(rport),
-			       ntohs(lport),
-			       tcp_synack_received,
-			       context,
-			       &context->conn_handler);
-	if (ret < 0) {
-		return ret;
-	}
-
-	context->connect_cb = cb;
-	context->user_data = user_data;
-
-	net_context_set_state(context, NET_CONTEXT_CONNECTING);
-
-	send_syn(context, addr);
-
-
-	/* in tcp_synack_received() we give back this semaphore */
-	if (timeout != 0 && k_sem_take(&context->tcp->connect_wait, timeout)) {
-		return -ETIMEDOUT;
-	}
-#endif
 
 	return 0;
 }
-
-#if defined(CONFIG_NET_TCP)
-
-static void pkt_get_sockaddr(sa_family_t family, struct net_pkt *pkt,
-			     struct sockaddr_ptr *addr)
-{
-	struct net_tcp_hdr hdr, *tcp_hdr;
-
-	tcp_hdr = net_tcp_get_hdr(pkt, &hdr);
-	if (!tcp_hdr) {
-		return;
-	}
-
-	memset(addr, 0, sizeof(*addr));
-
-#if defined(CONFIG_NET_IPV4)
-	if (family == AF_INET) {
-		struct sockaddr_in_ptr *addr4 = net_sin_ptr(addr);
-
-		addr4->sin_family = AF_INET;
-		addr4->sin_port = tcp_hdr->dst_port;
-		addr4->sin_addr = &NET_IPV4_HDR(pkt)->dst;
-	}
-#endif
-
-#if defined(CONFIG_NET_IPV6)
-	if (family == AF_INET6) {
-		struct sockaddr_in6_ptr *addr6 = net_sin6_ptr(addr);
-
-		addr6->sin6_family = AF_INET6;
-		addr6->sin6_port = tcp_hdr->dst_port;
-		addr6->sin6_addr = &NET_IPV6_HDR(pkt)->dst;
-	}
-#endif
-}
-
-#if defined(CONFIG_NET_CONTEXT_NET_PKT_POOL)
-static inline void copy_pool_vars(struct net_context *new_context,
-				  struct net_context *listen_context)
-{
-	new_context->tx_slab = listen_context->tx_slab;
-	new_context->data_pool = listen_context->data_pool;
-}
-#else
-#define copy_pool_vars(...)
-#endif /* CONFIG_NET_CONTEXT_NET_PKT_POOL */
-
-/* This callback is called when we are waiting connections and we receive
- * a packet. We need to check if we are receiving proper msg (SYN) here.
- * The ACK could also be received, in which case we have an established
- * connection.
- */
-NET_CONN_CB(tcp_syn_rcvd)
-{
-	struct net_context *context = (struct net_context *)user_data;
-	struct net_tcp_hdr hdr, *tcp_hdr;
-	struct net_tcp *tcp;
-	struct sockaddr_ptr pkt_src_addr;
-	struct sockaddr local_addr;
-	struct sockaddr remote_addr;
-
-	NET_ASSERT(context && context->tcp);
-
-	tcp = context->tcp;
-
-	switch (net_tcp_get_state(tcp)) {
-	case NET_TCP_LISTEN:
-		net_context_set_iface(context, net_pkt_iface(pkt));
-		break;
-	case NET_TCP_SYN_RCVD:
-		if (net_pkt_iface(pkt) != net_context_get_iface(context)) {
-			return NET_DROP;
-		}
-		break;
-	default:
-		NET_DBG("Context %p in wrong state %d",
-			context, tcp->state);
-		return NET_DROP;
-	}
-
-	net_pkt_set_context(pkt, context);
-
-	NET_ASSERT(net_pkt_iface(pkt));
-
-	tcp_hdr = net_tcp_get_hdr(pkt, &hdr);
-	if (!tcp_hdr) {
-		return NET_DROP;
-	}
-
-	if (net_pkt_get_src_addr(pkt, &remote_addr, sizeof(remote_addr)) < 0) {
-		NET_DBG("Cannot parse remote address from received pkt");
-		return NET_DROP;
-	}
-
-	if (net_pkt_get_dst_addr(pkt, &local_addr, sizeof(local_addr)) < 0) {
-		NET_DBG("Cannot parse local address from received pkt");
-		return NET_DROP;
-	}
-
-	/*
-	 * If we receive SYN, we send SYN-ACK and go to SYN_RCVD state.
-	 */
-	if (NET_TCP_FLAGS(tcp_hdr) == NET_TCP_SYN) {
-		int r;
-		int opt_totlen;
-		struct net_tcp_options tcp_opts = {
-			.mss = NET_TCP_DEFAULT_MSS,
-		};
-
-		net_tcp_print_recv_info("SYN", pkt, tcp_hdr->src_port);
-
-		opt_totlen = NET_TCP_HDR_LEN(tcp_hdr)
-			     - sizeof(struct net_tcp_hdr);
-		/* We expect MSS option to be present (opt_totlen > 0),
-		 * so call unconditionally.
-		 */
-		if (net_tcp_parse_opts(pkt, opt_totlen, &tcp_opts) < 0) {
-			return NET_DROP;
-		}
-
-		net_tcp_change_state(tcp, NET_TCP_SYN_RCVD);
-
-		/* Set TCP seq and ack which are then stored in the backlog */
-		context->tcp->send_seq = tcp_init_isn();
-		context->tcp->send_ack =
-			sys_get_be32(tcp_hdr->seq) + 1;
-
-		/* Get MSS from TCP options here*/
-
-		r = tcp_backlog_syn(pkt, context, tcp_opts.mss);
-		if (r < 0) {
-			if (r == -EADDRINUSE) {
-				NET_DBG("TCP connection already exists");
-			} else {
-				NET_DBG("No free TCP backlog entries");
-			}
-
-			return NET_DROP;
-		}
-
-		pkt_get_sockaddr(net_context_get_family(context),
-				 pkt, &pkt_src_addr);
-		send_syn_ack(context, &pkt_src_addr, &remote_addr);
-
-		return NET_DROP;
-	}
-
-	/*
-	 * See RFC 793 chapter 3.4 "Reset Processing" and RFC 793, page 65
-	 * for more details.
-	 */
-	if (NET_TCP_FLAGS(tcp_hdr) == NET_TCP_RST) {
-
-		if (tcp_backlog_rst(pkt) < 0) {
-			net_stats_update_tcp_seg_rsterr();
-			return NET_DROP;
-		}
-
-		net_stats_update_tcp_seg_rst();
-
-		net_tcp_print_recv_info("RST", pkt, tcp_hdr->src_port);
-
-		return NET_DROP;
-	}
-
-	/*
-	 * If we receive ACK, we go to ESTABLISHED state.
-	 */
-	if (NET_TCP_FLAGS(tcp_hdr) == NET_TCP_ACK) {
-		struct net_context *new_context;
-		socklen_t addrlen;
-		int ret;
-
-		net_tcp_print_recv_info("ACK", pkt, tcp_hdr->src_port);
-
-		if (!context->tcp->accept_cb) {
-			NET_DBG("No accept callback, connection reset.");
-			goto reset;
-		}
-
-		/* We create a new context that starts to wait data.
-		 */
-		ret = net_context_get(net_pkt_family(pkt),
-				      SOCK_STREAM, IPPROTO_TCP,
-				      &new_context);
-		if (ret < 0) {
-			NET_DBG("Cannot get accepted context, "
-				"connection reset");
-			goto conndrop;
-		}
-
-		ret = tcp_backlog_ack(pkt, new_context);
-		if (ret < 0) {
-			NET_DBG("Cannot find context from TCP backlog");
-
-			net_context_unref(new_context);
-
-			goto conndrop;
-		}
-
-		ret = net_context_bind(new_context, &local_addr,
-				       sizeof(local_addr));
-		if (ret < 0) {
-			NET_DBG("Cannot bind accepted context, "
-				"connection reset");
-			net_context_unref(new_context);
-			goto conndrop;
-		}
-
-		new_context->flags |= NET_CONTEXT_REMOTE_ADDR_SET;
-
-		memcpy(&new_context->remote, &remote_addr,
-		       sizeof(remote_addr));
-
-		ret = net_tcp_register(&new_context->remote,
-			       &local_addr,
-			       ntohs(net_sin(&new_context->remote)->sin_port),
-			       ntohs(net_sin(&local_addr)->sin_port),
-			       tcp_established,
-			       new_context,
-			       &new_context->conn_handler);
-		if (ret < 0) {
-			NET_DBG("Cannot register accepted TCP handler (%d)",
-				ret);
-			net_context_unref(new_context);
-			goto conndrop;
-		}
-
-		/* Swap the newly-created TCP states with the one that
-		 * was used to establish this connection. The old TCP
-		 * must be listening to accept other connections.
-		 */
-		copy_pool_vars(new_context, context);
-
-		net_tcp_change_state(tcp, NET_TCP_LISTEN);
-
-		/* We cannot use net_tcp_change_state() here as that will
-		 * check the state transitions. So set the state directly.
-		 */
-		new_context->tcp->state = NET_TCP_ESTABLISHED;
-
-		net_context_set_state(new_context, NET_CONTEXT_CONNECTED);
-
-		if (new_context->remote.sa_family == AF_INET) {
-			addrlen = sizeof(struct sockaddr_in);
-		} else if (new_context->remote.sa_family == AF_INET6) {
-			addrlen = sizeof(struct sockaddr_in6);
-		} else {
-			NET_ASSERT_INFO(false, "Invalid protocol family %d",
-					new_context->remote.sa_family);
-			net_context_unref(new_context);
-			return NET_DROP;
-		}
-
-		context->tcp->accept_cb(new_context,
-					&new_context->remote,
-					addrlen,
-					0,
-					context->user_data);
-	}
-
-	return NET_DROP;
-
-conndrop:
-	net_stats_update_tcp_seg_conndrop();
-
-reset:
-	send_reset(tcp->context, &local_addr, &remote_addr);
-
-	return NET_DROP;
-}
-
-#endif /* CONFIG_NET_TCP */
 
 int net_context_accept(struct net_context *context,
 		       net_tcp_accept_cb_t cb,
 		       s32_t timeout,
 		       void *user_data)
 {
-#if defined(CONFIG_NET_TCP)
-	struct sockaddr local_addr;
-	struct sockaddr *laddr = NULL;
-	u16_t lport = 0;
-	int ret;
-#endif /* CONFIG_NET_TCP */
-
 	NET_ASSERT(PART_OF_ARRAY(contexts, context));
 
 	if (!net_context_is_used(context)) {
@@ -1839,66 +812,9 @@ int net_context_accept(struct net_context *context,
 		return -EINVAL;
 	}
 
-#if defined(CONFIG_NET_TCP)
 	if (net_context_get_ip_proto(context) == IPPROTO_TCP) {
-		NET_ASSERT(context->tcp);
-
-		if (net_tcp_get_state(context->tcp) != NET_TCP_LISTEN) {
-			NET_DBG("Context %p in wrong state %d, should be %d",
-				context, context->tcp->state, NET_TCP_LISTEN);
-			return -EINVAL;
-		}
+		return net_tcp_accept(context, cb, user_data);
 	}
-
-	local_addr.sa_family = net_context_get_family(context);
-
-#if defined(CONFIG_NET_IPV6)
-	if (net_context_get_family(context) == AF_INET6) {
-		if (net_sin6_ptr(&context->local)->sin6_addr) {
-			net_ipaddr_copy(&net_sin6(&local_addr)->sin6_addr,
-				     net_sin6_ptr(&context->local)->sin6_addr);
-
-			laddr = &local_addr;
-		}
-
-		net_sin6(&local_addr)->sin6_port = lport =
-			net_sin6((struct sockaddr *)&context->local)->sin6_port;
-	}
-#endif /* CONFIG_NET_IPV6 */
-
-#if defined(CONFIG_NET_IPV4)
-	if (net_context_get_family(context) == AF_INET) {
-		if (net_sin_ptr(&context->local)->sin_addr) {
-			net_ipaddr_copy(&net_sin(&local_addr)->sin_addr,
-				      net_sin_ptr(&context->local)->sin_addr);
-
-			laddr = &local_addr;
-		}
-
-		net_sin(&local_addr)->sin_port = lport =
-			net_sin((struct sockaddr *)&context->local)->sin_port;
-	}
-#endif /* CONFIG_NET_IPV4 */
-
-	ret = net_tcp_register(context->flags & NET_CONTEXT_REMOTE_ADDR_SET ?
-			       &context->remote : NULL,
-			       laddr,
-			       ntohs(net_sin(&context->remote)->sin_port),
-			       ntohs(lport),
-			       tcp_syn_rcvd,
-			       context,
-			       &context->conn_handler);
-	if (ret < 0) {
-		return ret;
-	}
-
-	context->user_data = user_data;
-
-	/* accept callback is only valid for TCP contexts */
-	if (net_context_get_ip_proto(context) == IPPROTO_TCP) {
-		context->tcp->accept_cb = cb;
-	}
-#endif /* CONFIG_NET_TCP */
 
 	return 0;
 }
@@ -1989,7 +905,7 @@ static int sendto(struct net_pkt *pkt,
 		  void *user_data)
 {
 	struct net_context *context = net_pkt_context(pkt);
-	int ret;
+	int ret = 0;
 
 	if (!net_context_is_used(context)) {
 		return -EBADF;
@@ -2140,7 +1056,8 @@ int net_context_sendto(struct net_pkt *pkt,
 	return sendto(pkt, dst_addr, addrlen, cb, timeout, token, user_data);
 }
 
-static void set_appdata_values(struct net_pkt *pkt, enum net_ip_protocol proto)
+void net_context_set_appdata_values(struct net_pkt *pkt,
+				    enum net_ip_protocol proto)
 {
 	size_t total_len = net_pkt_get_len(pkt);
 	u16_t proto_len = 0;
@@ -2178,9 +1095,9 @@ static void set_appdata_values(struct net_pkt *pkt, enum net_ip_protocol proto)
 			net_pkt_appdatalen(pkt), total_len);
 }
 
-static enum net_verdict packet_received(struct net_conn *conn,
-					struct net_pkt *pkt,
-					void *user_data)
+enum net_verdict net_context_packet_received(struct net_conn *conn,
+					     struct net_pkt *pkt,
+					     void *user_data)
 {
 	struct net_context *context = find_context(conn);
 
@@ -2200,14 +1117,14 @@ static enum net_verdict packet_received(struct net_conn *conn,
 
 	if (net_context_get_ip_proto(context) != IPPROTO_TCP) {
 		/* TCP packets get appdata earlier in tcp_established(). */
-		set_appdata_values(pkt, IPPROTO_UDP);
+		net_context_set_appdata_values(pkt, IPPROTO_UDP);
+	} else {
+		net_stats_update_tcp_recv(net_pkt_appdatalen(pkt));
 	}
 
 	NET_DBG("Set appdata %p to len %u (total %zu)",
 		net_pkt_appdata(pkt), net_pkt_appdatalen(pkt),
 		net_pkt_get_len(pkt));
-
-	net_stats_update_tcp_recv(net_pkt_appdatalen(pkt));
 
 	context->recv_cb(context, pkt, 0, user_data);
 
@@ -2279,7 +1196,7 @@ static int recv_udp(struct net_context *context,
 				laddr,
 				ntohs(net_sin(&context->remote)->sin_port),
 				ntohs(lport),
-				packet_received,
+				net_context_packet_received,
 				user_data,
 				&context->conn_handler);
 
@@ -2331,9 +1248,9 @@ int net_context_recv(struct net_context *context,
 	if (timeout) {
 		int ret;
 
-		/* Make sure we have the lock, then the packet_received()
-		 * callback will release the semaphore when data has been
-		 * received.
+		/* Make sure we have the lock, then the
+		 * net_context_packet_received() callback will release the
+		 * semaphore when data has been received.
 		 */
 		k_sem_reset(&context->recv_data_wait);
 

--- a/subsys/net/ip/net_context.c
+++ b/subsys/net/ip/net_context.c
@@ -927,14 +927,9 @@ int net_context_listen(struct net_context *context, int backlog)
 	}
 #endif /* CONFIG_NET_OFFLOAD */
 
-#if defined(CONFIG_NET_TCP)
-	if (net_context_get_ip_proto(context) == IPPROTO_TCP) {
-		net_tcp_change_state(context->tcp, NET_TCP_LISTEN);
-		net_context_set_state(context, NET_CONTEXT_LISTENING);
-
+	if (net_tcp_listen(context) >= 0) {
 		return 0;
 	}
-#endif
 
 	return -EOPNOTSUPP;
 }

--- a/subsys/net/ip/net_private.h
+++ b/subsys/net/ip/net_private.h
@@ -15,6 +15,8 @@
 #include <net/net_context.h>
 #include <net/net_pkt.h>
 
+#include "connection.h"
+
 extern void net_pkt_init(void);
 extern void net_if_init(void);
 extern void net_if_post_init(void);
@@ -93,6 +95,13 @@ struct net_tcp_hdr *net_tcp_header_fits(struct net_pkt *pkt,
 
 	return NULL;
 }
+
+void net_context_set_appdata_values(struct net_pkt *pkt,
+				    enum net_ip_protocol proto);
+
+enum net_verdict net_context_packet_received(struct net_conn *conn,
+					     struct net_pkt *pkt,
+					     void *user_data);
 
 #if defined(CONFIG_NET_IPV4)
 extern u16_t net_calc_chksum_ipv4(struct net_pkt *pkt);

--- a/subsys/net/ip/tcp.c
+++ b/subsys/net/ip/tcp.c
@@ -1355,3 +1355,15 @@ error:
 	NET_ERR("Invalid TCP opt: %d len: %d", opt, optlen);
 	return -EINVAL;
 }
+
+int tcp_hdr_len(struct net_pkt *pkt)
+{
+	struct net_tcp_hdr hdr, *tcp_hdr;
+
+	tcp_hdr = net_tcp_get_hdr(pkt, &hdr);
+	if (tcp_hdr) {
+		return NET_TCP_HDR_LEN(tcp_hdr);
+	}
+
+	return 0;
+}

--- a/subsys/net/ip/tcp.c
+++ b/subsys/net/ip/tcp.c
@@ -762,6 +762,17 @@ int net_tcp_queue_data(struct net_context *context, struct net_pkt *pkt)
 
 	NET_DBG("[%p] Queue %p len %zd", context->tcp, pkt, data_len);
 
+	if (net_context_get_state(context) != NET_CONTEXT_CONNECTED) {
+		return -ENOTCONN;
+	}
+
+	NET_ASSERT(context->tcp);
+	if (context->tcp->flags & NET_TCP_IS_SHUTDOWN) {
+		return -ESHUTDOWN;
+	}
+
+	net_pkt_set_appdatalen(pkt, net_pkt_get_len(pkt));
+
 	/* Set PSH on all packets, our window is so small that there's
 	 * no point in the remote side trying to finesse things and
 	 * coalesce packets.

--- a/subsys/net/ip/tcp.c
+++ b/subsys/net/ip/tcp.c
@@ -1367,3 +1367,20 @@ int tcp_hdr_len(struct net_pkt *pkt)
 
 	return 0;
 }
+
+int net_tcp_recv(struct net_context *context, net_context_recv_cb_t cb,
+		 void *user_data)
+{
+	NET_ASSERT(context->tcp);
+
+	if (context->tcp->flags & NET_TCP_IS_SHUTDOWN) {
+		return -ESHUTDOWN;
+	} else if (net_context_get_state(context) != NET_CONTEXT_CONNECTED) {
+		return -ENOTCONN;
+	}
+
+	context->recv_cb = cb;
+	context->tcp->recv_user_data = user_data;
+
+	return 0;
+}

--- a/subsys/net/ip/tcp.c
+++ b/subsys/net/ip/tcp.c
@@ -913,7 +913,8 @@ static void restart_timer(struct net_tcp *tcp)
 	}
 }
 
-int net_tcp_send_data(struct net_context *context)
+int net_tcp_send_data(struct net_context *context, net_context_send_cb_t cb,
+		      void *token, void *user_data)
 {
 	struct net_pkt *pkt;
 
@@ -943,6 +944,16 @@ int net_tcp_send_data(struct net_context *context)
 
 			net_pkt_set_queued(pkt, true);
 		}
+	}
+
+	/* Just make the callback synchronously even if it didn't
+	 * go over the wire.  In theory it would be nice to track
+	 * specific ACK locations in the stream and make the
+	 * callback at that time, but there's nowhere to store the
+	 * potentially-separate token/user_data values right now.
+	 */
+	if (cb) {
+		cb(context, 0, token, user_data);
 	}
 
 	return 0;

--- a/subsys/net/ip/tcp.c
+++ b/subsys/net/ip/tcp.c
@@ -1434,3 +1434,15 @@ int net_tcp_put(struct net_context *context)
 
 	return -EOPNOTSUPP;
 }
+
+int net_tcp_listen(struct net_context *context)
+{
+	if (net_context_get_ip_proto(context) == IPPROTO_TCP) {
+		net_tcp_change_state(context->tcp, NET_TCP_LISTEN);
+		net_context_set_state(context, NET_CONTEXT_LISTENING);
+
+		return 0;
+	}
+
+	return -EOPNOTSUPP;
+}

--- a/subsys/net/ip/tcp.c
+++ b/subsys/net/ip/tcp.c
@@ -45,6 +45,15 @@
 #define NET_MAX_TCP_CONTEXT CONFIG_NET_MAX_CONTEXTS
 static struct net_tcp tcp_context[NET_MAX_TCP_CONTEXT];
 
+static struct tcp_backlog_entry {
+	struct net_tcp *tcp;
+	struct sockaddr remote;
+	u32_t send_seq;
+	u32_t send_ack;
+	u16_t send_mss;
+	struct k_delayed_work ack_timer;
+} tcp_backlog[CONFIG_NET_TCP_BACKLOG_SIZE];
+
 /* 2MSL timeout, where "MSL" is arbitrarily 2 minutes in the RFC */
 #if defined(CONFIG_NET_TCP_2MSL_TIME)
 #define TIME_WAIT_MS K_SECONDS(CONFIG_NET_TCP_2MSL_TIME)
@@ -52,7 +61,42 @@ static struct net_tcp tcp_context[NET_MAX_TCP_CONTEXT];
 #define TIME_WAIT_MS K_SECONDS(2 * 2 * 60)
 #endif
 
+#if defined(CONFIG_NET_TCP_ACK_TIMEOUT)
+#define ACK_TIMEOUT CONFIG_NET_TCP_ACK_TIMEOUT
+#else
+#define ACK_TIMEOUT K_SECONDS(1)
+#endif
+
+/* TODO: It should be 2 * MSL (Maximum segment lifetime) */
+#define TIMEWAIT_TIMEOUT MSEC(250)
+
 #define FIN_TIMEOUT K_SECONDS(1)
+
+/* Declares a wrapper function for a net_conn callback that refs the
+ * context around the invocation (to protect it from premature
+ * deletion).  Long term would be nice to see this feature be part of
+ * the connection type itself, but right now it has opaque "user_data"
+ * pointers and doesn't understand what a net_context is.
+ */
+#define NET_CONN_CB(name) \
+	static enum net_verdict _##name(struct net_conn *conn,	  \
+					struct net_pkt *pkt,	  \
+					void *user_data);	  \
+	static enum net_verdict name(struct net_conn *conn,	  \
+				     struct net_pkt *pkt,	  \
+				     void *user_data)		  \
+	{							  \
+		enum net_verdict result;			  \
+								  \
+		net_context_ref(user_data);			  \
+		result = _##name(conn, pkt, user_data);		  \
+		net_context_unref(user_data);			  \
+		return result;					  \
+	}							  \
+	static enum net_verdict _##name(struct net_conn *conn,    \
+					struct net_pkt *pkt,      \
+					void *user_data)	  \
+
 
 struct tcp_segment {
 	u32_t seq;
@@ -1462,6 +1506,1068 @@ int net_tcp_update_recv_wnd(struct net_context *context, s32_t delta)
 	}
 
 	context->tcp->recv_wnd = new_win;
+
+	return 0;
+}
+
+static int send_reset(struct net_context *context, struct sockaddr *local,
+		      struct sockaddr *remote);
+
+static void backlog_ack_timeout(struct k_work *work)
+{
+	struct tcp_backlog_entry *backlog =
+		CONTAINER_OF(work, struct tcp_backlog_entry, ack_timer);
+
+	NET_DBG("Did not receive ACK in %dms", ACK_TIMEOUT);
+
+	/* TODO: If net_context is bound to unspecified IPv6 address
+	 * and some port number, local address is not available.
+	 * RST packet might be invalid. Cache local address
+	 * and use it in RST message preparation.
+	 */
+	send_reset(backlog->tcp->context, NULL, &backlog->remote);
+
+	memset(backlog, 0, sizeof(struct tcp_backlog_entry));
+}
+
+static int tcp_backlog_find(struct net_pkt *pkt, int *empty_slot)
+{
+	struct net_tcp_hdr hdr, *tcp_hdr;
+	int i, empty = -1;
+
+	for (i = 0; i < CONFIG_NET_TCP_BACKLOG_SIZE; i++) {
+		if (tcp_backlog[i].tcp == NULL && empty < 0) {
+			empty = i;
+			continue;
+		}
+
+		if (net_pkt_family(pkt) != tcp_backlog[i].remote.sa_family) {
+			continue;
+		}
+
+		tcp_hdr = net_tcp_get_hdr(pkt, &hdr);
+		if (!tcp_hdr) {
+			return -EINVAL;
+		}
+
+		switch (net_pkt_family(pkt)) {
+#if defined(CONFIG_NET_IPV6)
+		case AF_INET6:
+			if (net_sin6(&tcp_backlog[i].remote)->sin6_port !=
+			    tcp_hdr->src_port) {
+				continue;
+			}
+
+			if (memcmp(&net_sin6(&tcp_backlog[i].remote)->sin6_addr,
+				   &NET_IPV6_HDR(pkt)->src,
+				   sizeof(struct in6_addr))) {
+				continue;
+			}
+
+			break;
+#endif
+#if defined(CONFIG_NET_IPV4)
+		case AF_INET:
+			if (net_sin(&tcp_backlog[i].remote)->sin_port !=
+			    tcp_hdr->src_port) {
+				continue;
+			}
+
+			if (memcmp(&net_sin(&tcp_backlog[i].remote)->sin_addr,
+				   &NET_IPV4_HDR(pkt)->src,
+				   sizeof(struct in_addr))) {
+				continue;
+			}
+
+			break;
+#endif
+		}
+
+		return i;
+	}
+
+	if (empty_slot) {
+		*empty_slot = empty;
+	}
+
+	return -EADDRNOTAVAIL;
+}
+
+static int tcp_backlog_syn(struct net_pkt *pkt, struct net_context *context,
+			   u16_t send_mss)
+{
+	int empty_slot = -1;
+	int ret;
+
+	if (tcp_backlog_find(pkt, &empty_slot) >= 0) {
+		return -EADDRINUSE;
+	}
+
+	if (empty_slot < 0) {
+		return -ENOSPC;
+	}
+
+	tcp_backlog[empty_slot].tcp = context->tcp;
+
+	ret = net_pkt_get_src_addr(pkt, &tcp_backlog[empty_slot].remote,
+				   sizeof(tcp_backlog[empty_slot].remote));
+	if (ret < 0) {
+		/* Release the assigned empty slot */
+		tcp_backlog[empty_slot].tcp = NULL;
+
+		return ret;
+	}
+
+	tcp_backlog[empty_slot].send_seq = context->tcp->send_seq;
+	tcp_backlog[empty_slot].send_ack = context->tcp->send_ack;
+	tcp_backlog[empty_slot].send_mss = send_mss;
+
+	k_delayed_work_init(&tcp_backlog[empty_slot].ack_timer,
+			    backlog_ack_timeout);
+	k_delayed_work_submit(&tcp_backlog[empty_slot].ack_timer, ACK_TIMEOUT);
+
+	return 0;
+}
+
+static int tcp_backlog_ack(struct net_pkt *pkt, struct net_context *context)
+{
+	struct net_tcp_hdr hdr, *tcp_hdr;
+	int r;
+
+	r = tcp_backlog_find(pkt, NULL);
+
+	if (r < 0) {
+		return r;
+	}
+
+	tcp_hdr = net_tcp_get_hdr(pkt, &hdr);
+	if (!tcp_hdr) {
+		return -EINVAL;
+	}
+
+	/* Sent SEQ + 1 needs to be the same as the received ACK */
+	if (tcp_backlog[r].send_seq + 1 != sys_get_be32(tcp_hdr->ack)) {
+		return -EINVAL;
+	}
+
+	memcpy(&context->remote, &tcp_backlog[r].remote,
+		sizeof(struct sockaddr));
+	context->tcp->send_seq = tcp_backlog[r].send_seq + 1;
+	context->tcp->send_ack = tcp_backlog[r].send_ack;
+	context->tcp->send_mss = tcp_backlog[r].send_mss;
+
+	k_delayed_work_cancel(&tcp_backlog[r].ack_timer);
+	memset(&tcp_backlog[r], 0, sizeof(struct tcp_backlog_entry));
+
+	return 0;
+}
+
+static int tcp_backlog_rst(struct net_pkt *pkt)
+{
+	struct net_tcp_hdr hdr, *tcp_hdr;
+	int r;
+
+	r = tcp_backlog_find(pkt, NULL);
+	if (r < 0) {
+		return r;
+	}
+
+	tcp_hdr = net_tcp_get_hdr(pkt, &hdr);
+	if (!tcp_hdr) {
+		return -EINVAL;
+	}
+
+	/* The ACK sent needs to be the same as the received SEQ */
+	if (tcp_backlog[r].send_ack != sys_get_be32(tcp_hdr->seq)) {
+		return -EINVAL;
+	}
+
+	k_delayed_work_cancel(&tcp_backlog[r].ack_timer);
+	memset(&tcp_backlog[r], 0, sizeof(struct tcp_backlog_entry));
+
+	return 0;
+}
+
+static void handle_fin_timeout(struct k_work *work)
+{
+	struct net_tcp *tcp =
+		CONTAINER_OF(work, struct net_tcp, fin_timer);
+
+	NET_DBG("Did not receive FIN in %dms", FIN_TIMEOUT);
+
+	net_context_unref(tcp->context);
+}
+
+static void handle_ack_timeout(struct k_work *work)
+{
+	/* This means that we did not receive ACK response in time. */
+	struct net_tcp *tcp = CONTAINER_OF(work, struct net_tcp, ack_timer);
+
+	NET_DBG("Did not receive ACK in %dms while in %s", ACK_TIMEOUT,
+		net_tcp_state_str(net_tcp_get_state(tcp)));
+
+	if (net_tcp_get_state(tcp) == NET_TCP_LAST_ACK) {
+		/* We did not receive the last ACK on time. We can only
+		 * close the connection at this point. We will not send
+		 * anything to peer in this last state, but will go directly
+		 * to to CLOSED state.
+		 */
+		net_tcp_change_state(tcp, NET_TCP_CLOSED);
+
+		net_context_unref(tcp->context);
+	}
+}
+
+static void handle_timewait_timeout(struct k_work *work)
+{
+	struct net_tcp *tcp = CONTAINER_OF(work, struct net_tcp,
+					   timewait_timer);
+
+	NET_DBG("Timewait expired in %dms", TIMEWAIT_TIMEOUT);
+
+	if (net_tcp_get_state(tcp) == NET_TCP_TIME_WAIT) {
+		net_tcp_change_state(tcp, NET_TCP_CLOSED);
+
+		if (tcp->context->recv_cb) {
+			tcp->context->recv_cb(tcp->context, NULL, 0,
+					      tcp->recv_user_data);
+		}
+
+		net_context_unref(tcp->context);
+	}
+}
+
+int net_tcp_get(struct net_context *context)
+{
+	context->tcp = net_tcp_alloc(context);
+	if (!context->tcp) {
+		NET_ASSERT_INFO(context->tcp, "Cannot allocate TCP context");
+		return -ENOBUFS;
+	}
+
+	k_delayed_work_init(&context->tcp->ack_timer, handle_ack_timeout);
+	k_delayed_work_init(&context->tcp->fin_timer, handle_fin_timeout);
+	k_delayed_work_init(&context->tcp->timewait_timer,
+			    handle_timewait_timeout);
+
+	return 0;
+}
+
+int net_tcp_unref(struct net_context *context)
+{
+	int i;
+
+	if (!context->tcp)
+		return 0;
+
+	/* Clear the backlog for this TCP context. */
+	for (i = 0; i < CONFIG_NET_TCP_BACKLOG_SIZE; i++) {
+		if (tcp_backlog[i].tcp != context->tcp) {
+			continue;
+		}
+
+		k_delayed_work_cancel(&tcp_backlog[i].ack_timer);
+		memset(&tcp_backlog[i], 0, sizeof(tcp_backlog[i]));
+	}
+
+	net_tcp_release(context->tcp);
+	context->tcp = NULL;
+
+	return 0;
+}
+
+/** **/
+
+#if defined(CONFIG_NET_DEBUG_CONTEXT)
+#define net_tcp_print_recv_info(str, pkt, port)				\
+	do {								\
+		if (net_context_get_family(context) == AF_INET6) {	\
+			NET_DBG("%s received from %s port %d", str,	\
+				net_sprint_ipv6_addr(&NET_IPV6_HDR(pkt)->src),\
+				ntohs(port));				\
+		} else if (net_context_get_family(context) == AF_INET) {\
+			NET_DBG("%s received from %s port %d", str,	\
+				net_sprint_ipv4_addr(&NET_IPV4_HDR(pkt)->src),\
+				ntohs(port));				\
+		}							\
+	} while (0)
+
+#define net_tcp_print_send_info(str, pkt, port)				\
+	do {								\
+		struct net_context *ctx = net_pkt_context(pkt);		\
+		if (net_context_get_family(ctx) == AF_INET6) {		\
+			NET_DBG("%s sent to %s port %d", str,		\
+				net_sprint_ipv6_addr(&NET_IPV6_HDR(pkt)->dst),\
+				ntohs(port));				\
+		} else if (net_context_get_family(ctx) == AF_INET) {	\
+			NET_DBG("%s sent to %s port %d", str,		\
+				net_sprint_ipv4_addr(&NET_IPV4_HDR(pkt)->dst),\
+				ntohs(port));				\
+		}							\
+	} while (0)
+
+#else
+#define net_tcp_print_recv_info(...)
+#define net_tcp_print_send_info(...)
+#endif /* CONFIG_NET_DEBUG_CONTEXT */
+
+static void print_send_info(struct net_pkt *pkt, const char *msg)
+{
+	if (IS_ENABLED(CONFIG_NET_DEBUG_CONTEXT)) {
+		struct net_tcp_hdr hdr, *tcp_hdr;
+
+		tcp_hdr = net_tcp_get_hdr(pkt, &hdr);
+		if (tcp_hdr) {
+			net_tcp_print_send_info(msg, pkt, tcp_hdr->dst_port);
+		}
+	}
+}
+
+/* Send SYN or SYN/ACK. */
+static inline int send_syn_segment(struct net_context *context,
+				       const struct sockaddr_ptr *local,
+				       const struct sockaddr *remote,
+				       int flags, const char *msg)
+{
+	struct net_pkt *pkt = NULL;
+	int ret;
+
+	ret = net_tcp_prepare_segment(context->tcp, flags, NULL, 0,
+				      local, remote, &pkt);
+	if (ret) {
+		return ret;
+	}
+
+	ret = net_send_data(pkt);
+	if (ret < 0) {
+		net_pkt_unref(pkt);
+		return ret;
+	}
+
+	context->tcp->send_seq++;
+
+	print_send_info(pkt, msg);
+
+	return ret;
+}
+
+static inline int send_syn(struct net_context *context,
+			   const struct sockaddr *remote)
+{
+	net_tcp_change_state(context->tcp, NET_TCP_SYN_SENT);
+
+	return send_syn_segment(context, NULL, remote, NET_TCP_SYN, "SYN");
+}
+
+static inline int send_syn_ack(struct net_context *context,
+			       struct sockaddr_ptr *local,
+			       struct sockaddr *remote)
+{
+	return send_syn_segment(context, local, remote,
+				    NET_TCP_SYN | NET_TCP_ACK,
+				    "SYN_ACK");
+}
+
+static int send_ack(struct net_context *context,
+		    struct sockaddr *remote, bool force)
+{
+	struct net_pkt *pkt = NULL;
+	int ret;
+
+	/* Something (e.g. a data transmission under the user
+	 * callback) already sent the ACK, no need
+	 */
+	if (!force && context->tcp->send_ack == context->tcp->sent_ack) {
+		return 0;
+	}
+
+	ret = net_tcp_prepare_ack(context->tcp, remote, &pkt);
+	if (ret) {
+		return ret;
+	}
+
+	print_send_info(pkt, "ACK");
+
+	ret = net_tcp_send_pkt(pkt);
+	if (ret < 0) {
+		net_pkt_unref(pkt);
+	}
+
+	return ret;
+}
+
+static int send_reset(struct net_context *context,
+		      struct sockaddr *local,
+		      struct sockaddr *remote)
+{
+	struct net_pkt *pkt = NULL;
+	int ret;
+
+	ret = net_tcp_prepare_reset(context->tcp, local, remote, &pkt);
+	if (ret || !pkt) {
+		return ret;
+	}
+
+	print_send_info(pkt, "RST");
+
+	ret = net_send_data(pkt);
+	if (ret < 0) {
+		net_pkt_unref(pkt);
+	}
+
+	return ret;
+}
+
+/* This is called when we receive data after the connection has been
+ * established. The core TCP logic is located here.
+ */
+NET_CONN_CB(tcp_established)
+{
+	struct net_context *context = (struct net_context *)user_data;
+	struct net_tcp_hdr hdr, *tcp_hdr;
+	enum net_verdict ret = NET_OK;
+	u8_t tcp_flags;
+	u16_t data_len;
+
+	NET_ASSERT(context && context->tcp);
+
+	tcp_hdr = net_tcp_get_hdr(pkt, &hdr);
+	if (!tcp_hdr) {
+		return NET_DROP;
+	}
+
+	if (net_tcp_get_state(context->tcp) < NET_TCP_ESTABLISHED) {
+		NET_ERR("Context %p in wrong state %d",
+			context, net_tcp_get_state(context->tcp));
+		return NET_DROP;
+	}
+
+	net_tcp_print_recv_info("DATA", pkt, tcp_hdr->src_port);
+
+	tcp_flags = NET_TCP_FLAGS(tcp_hdr);
+
+	if (net_tcp_seq_cmp(sys_get_be32(tcp_hdr->seq),
+			    context->tcp->send_ack) < 0) {
+		/* Peer sent us packet we've already seen. Apparently,
+		 * our ack was lost.
+		 */
+
+		/* RFC793 specifies that "highest" (i.e. current from our PoV)
+		 * ack # value can/should be sent, so we just force resend.
+		 */
+		send_ack(context, &conn->remote_addr, true);
+		return NET_DROP;
+	}
+
+	if (net_tcp_seq_cmp(sys_get_be32(tcp_hdr->seq),
+			    context->tcp->send_ack) > 0) {
+		/* Don't try to reorder packets.  If it doesn't
+		 * match the next segment exactly, drop and wait for
+		 * retransmit
+		 */
+		return NET_DROP;
+	}
+
+	/*
+	 * If we receive RST here, we close the socket. See RFC 793 chapter
+	 * called "Reset Processing" for details.
+	 */
+	if (tcp_flags & NET_TCP_RST) {
+		/* We only accept RST packet that has valid seq field. */
+		if (!net_tcp_validate_seq(context->tcp, pkt)) {
+			net_stats_update_tcp_seg_rsterr();
+			return NET_DROP;
+		}
+
+		net_stats_update_tcp_seg_rst();
+
+		net_tcp_print_recv_info("RST", pkt, tcp_hdr->src_port);
+
+		if (context->recv_cb) {
+			context->recv_cb(context, NULL, -ECONNRESET,
+					 context->tcp->recv_user_data);
+		}
+
+		net_context_unref(context);
+
+		return NET_DROP;
+	}
+
+	/* Handle TCP state transition */
+	if (tcp_flags & NET_TCP_ACK) {
+		if (!net_tcp_ack_received(context,
+				     sys_get_be32(tcp_hdr->ack))) {
+			return NET_DROP;
+		}
+
+		/* TCP state might be changed after maintaining the sent pkt
+		 * list, e.g., an ack of FIN is received.
+		 */
+
+		if (net_tcp_get_state(context->tcp)
+			   == NET_TCP_FIN_WAIT_1) {
+			/* Received FIN on FIN_WAIT1, so cancel the timer */
+			k_delayed_work_cancel(&context->tcp->fin_timer);
+			/* Active close: step to FIN_WAIT_2 */
+			net_tcp_change_state(context->tcp, NET_TCP_FIN_WAIT_2);
+		} else if (net_tcp_get_state(context->tcp)
+			   == NET_TCP_LAST_ACK) {
+			/* Passive close: step to CLOSED */
+			net_tcp_change_state(context->tcp, NET_TCP_CLOSED);
+			/* Release the pkt before clean up */
+			net_pkt_unref(pkt);
+			goto clean_up;
+		}
+	}
+
+	if (tcp_flags & NET_TCP_FIN) {
+		if (net_tcp_get_state(context->tcp) == NET_TCP_ESTABLISHED) {
+			/* Passive close: step to CLOSE_WAIT */
+			net_tcp_change_state(context->tcp, NET_TCP_CLOSE_WAIT);
+
+			/* We should receive ACK next in order to get rid of
+			 * LAST_ACK state that we are entering in a short while.
+			 * But we need to be prepared to NOT to receive it as
+			 * otherwise the connection would be stuck forever.
+			 */
+			k_delayed_work_submit(&context->tcp->ack_timer,
+					      ACK_TIMEOUT);
+		} else if (net_tcp_get_state(context->tcp)
+			   == NET_TCP_FIN_WAIT_2) {
+			/* Active close: step to TIME_WAIT */
+			net_tcp_change_state(context->tcp, NET_TCP_TIME_WAIT);
+		}
+
+		context->tcp->fin_rcvd = 1;
+	}
+
+	net_context_set_appdata_values(pkt, IPPROTO_TCP);
+
+	data_len = net_pkt_appdatalen(pkt);
+	if (data_len > net_tcp_get_recv_wnd(context->tcp)) {
+		NET_ERR("Context %p: overflow of recv window (%d vs %d), "
+			"pkt dropped",
+			context, net_tcp_get_recv_wnd(context->tcp), data_len);
+		return NET_DROP;
+	}
+
+	/* If the pkt has appdata, notify the recv callback which should
+	 * release the pkt. Otherwise, release the pkt immediately.
+	 */
+	if (data_len > 0) {
+		ret = net_context_packet_received(conn, pkt,
+						  context->tcp->recv_user_data);
+	} else if (data_len == 0) {
+		net_pkt_unref(pkt);
+	}
+
+	/* Increment the ack */
+	context->tcp->send_ack += data_len;
+	if (tcp_flags & NET_TCP_FIN) {
+		context->tcp->send_ack += 1;
+	}
+
+	send_ack(context, &conn->remote_addr, false);
+
+clean_up:
+	if (net_tcp_get_state(context->tcp) == NET_TCP_TIME_WAIT) {
+		k_delayed_work_submit(&context->tcp->timewait_timer,
+				      TIMEWAIT_TIMEOUT);
+	}
+
+	if (net_tcp_get_state(context->tcp) == NET_TCP_CLOSED) {
+		if (context->recv_cb) {
+			context->recv_cb(context, NULL, 0,
+					 context->tcp->recv_user_data);
+		}
+
+		net_context_unref(context);
+	}
+
+	return ret;
+}
+
+
+NET_CONN_CB(tcp_synack_received)
+{
+	struct net_context *context = (struct net_context *)user_data;
+	struct net_tcp_hdr hdr, *tcp_hdr;
+	int ret;
+
+	NET_ASSERT(context && context->tcp);
+
+	switch (net_tcp_get_state(context->tcp)) {
+	case NET_TCP_SYN_SENT:
+		net_context_set_iface(context, net_pkt_iface(pkt));
+		break;
+	default:
+		NET_DBG("Context %p in wrong state %d",
+			context, net_tcp_get_state(context->tcp));
+		return NET_DROP;
+	}
+
+	net_pkt_set_context(pkt, context);
+
+	NET_ASSERT(net_pkt_iface(pkt));
+
+	tcp_hdr = net_tcp_get_hdr(pkt, &hdr);
+	if (!tcp_hdr) {
+		return NET_DROP;
+	}
+
+	if (NET_TCP_FLAGS(tcp_hdr) & NET_TCP_RST) {
+		/* We only accept RST packet that has valid seq field. */
+		if (!net_tcp_validate_seq(context->tcp, pkt)) {
+			net_stats_update_tcp_seg_rsterr();
+			return NET_DROP;
+		}
+
+		net_stats_update_tcp_seg_rst();
+
+		if (context->connect_cb) {
+			context->connect_cb(context, -ECONNREFUSED,
+					    context->user_data);
+		}
+
+		return NET_DROP;
+	}
+
+	if (NET_TCP_FLAGS(tcp_hdr) & NET_TCP_SYN) {
+		context->tcp->send_ack =
+			sys_get_be32(tcp_hdr->seq) + 1;
+	}
+	/*
+	 * If we receive SYN, we send SYN-ACK and go to SYN_RCVD state.
+	 */
+	if (NET_TCP_FLAGS(tcp_hdr) == (NET_TCP_SYN | NET_TCP_ACK)) {
+		/* Remove the temporary connection handler and register
+		 * a proper now as we have an established connection.
+		 */
+		struct sockaddr local_addr;
+		struct sockaddr remote_addr;
+
+		if (net_pkt_get_src_addr(
+			pkt, &remote_addr, sizeof(remote_addr)) < 0) {
+			NET_DBG("Cannot parse remote address"
+				" from received pkt");
+			return NET_DROP;
+		}
+
+		if (net_pkt_get_dst_addr(
+			pkt, &local_addr, sizeof(local_addr)) < 0) {
+			NET_DBG("Cannot parse local address from received pkt");
+			return NET_DROP;
+		}
+
+		net_tcp_unregister(context->conn_handler);
+
+		ret = net_tcp_register(&remote_addr,
+				       &local_addr,
+				       ntohs(tcp_hdr->src_port),
+				       ntohs(tcp_hdr->dst_port),
+				       tcp_established,
+				       context,
+				       &context->conn_handler);
+		if (ret < 0) {
+			NET_DBG("Cannot register TCP handler (%d)", ret);
+			send_reset(context, &local_addr, &remote_addr);
+			return NET_DROP;
+		}
+
+		net_tcp_change_state(context->tcp, NET_TCP_ESTABLISHED);
+		net_context_set_state(context, NET_CONTEXT_CONNECTED);
+
+		send_ack(context, &remote_addr, false);
+
+		k_sem_give(&context->tcp->connect_wait);
+
+		if (context->connect_cb) {
+			context->connect_cb(context, 0, context->user_data);
+		}
+	}
+
+	return NET_DROP;
+}
+
+static void pkt_get_sockaddr(sa_family_t family, struct net_pkt *pkt,
+			     struct sockaddr_ptr *addr)
+{
+	struct net_tcp_hdr hdr, *tcp_hdr;
+
+	tcp_hdr = net_tcp_get_hdr(pkt, &hdr);
+	if (!tcp_hdr) {
+		return;
+	}
+
+	memset(addr, 0, sizeof(*addr));
+
+#if defined(CONFIG_NET_IPV4)
+	if (family == AF_INET) {
+		struct sockaddr_in_ptr *addr4 = net_sin_ptr(addr);
+
+		addr4->sin_family = AF_INET;
+		addr4->sin_port = tcp_hdr->dst_port;
+		addr4->sin_addr = &NET_IPV4_HDR(pkt)->dst;
+	}
+#endif
+
+#if defined(CONFIG_NET_IPV6)
+	if (family == AF_INET6) {
+		struct sockaddr_in6_ptr *addr6 = net_sin6_ptr(addr);
+
+		addr6->sin6_family = AF_INET6;
+		addr6->sin6_port = tcp_hdr->dst_port;
+		addr6->sin6_addr = &NET_IPV6_HDR(pkt)->dst;
+	}
+#endif
+}
+
+#if defined(CONFIG_NET_CONTEXT_NET_PKT_POOL)
+static inline void copy_pool_vars(struct net_context *new_context,
+				  struct net_context *listen_context)
+{
+	new_context->tx_slab = listen_context->tx_slab;
+	new_context->data_pool = listen_context->data_pool;
+}
+#else
+#define copy_pool_vars(...)
+#endif /* CONFIG_NET_CONTEXT_NET_PKT_POOL */
+
+/* This callback is called when we are waiting connections and we receive
+ * a packet. We need to check if we are receiving proper msg (SYN) here.
+ * The ACK could also be received, in which case we have an established
+ * connection.
+ */
+NET_CONN_CB(tcp_syn_rcvd)
+{
+	struct net_context *context = (struct net_context *)user_data;
+	struct net_tcp_hdr hdr, *tcp_hdr;
+	struct net_tcp *tcp;
+	struct sockaddr_ptr pkt_src_addr;
+	struct sockaddr local_addr;
+	struct sockaddr remote_addr;
+
+	NET_ASSERT(context && context->tcp);
+
+	tcp = context->tcp;
+
+	switch (net_tcp_get_state(tcp)) {
+	case NET_TCP_LISTEN:
+		net_context_set_iface(context, net_pkt_iface(pkt));
+		break;
+	case NET_TCP_SYN_RCVD:
+		if (net_pkt_iface(pkt) != net_context_get_iface(context)) {
+			return NET_DROP;
+		}
+		break;
+	default:
+		NET_DBG("Context %p in wrong state %d",
+			context, tcp->state);
+		return NET_DROP;
+	}
+
+	net_pkt_set_context(pkt, context);
+
+	NET_ASSERT(net_pkt_iface(pkt));
+
+	tcp_hdr = net_tcp_get_hdr(pkt, &hdr);
+	if (!tcp_hdr) {
+		return NET_DROP;
+	}
+
+	if (net_pkt_get_src_addr(pkt, &remote_addr, sizeof(remote_addr)) < 0) {
+		NET_DBG("Cannot parse remote address from received pkt");
+		return NET_DROP;
+	}
+
+	if (net_pkt_get_dst_addr(pkt, &local_addr, sizeof(local_addr)) < 0) {
+		NET_DBG("Cannot parse local address from received pkt");
+		return NET_DROP;
+	}
+
+	/*
+	 * If we receive SYN, we send SYN-ACK and go to SYN_RCVD state.
+	 */
+	if (NET_TCP_FLAGS(tcp_hdr) == NET_TCP_SYN) {
+		int r;
+		int opt_totlen;
+		struct net_tcp_options tcp_opts = {
+			.mss = NET_TCP_DEFAULT_MSS,
+		};
+
+		net_tcp_print_recv_info("SYN", pkt, tcp_hdr->src_port);
+
+		opt_totlen = NET_TCP_HDR_LEN(tcp_hdr)
+			     - sizeof(struct net_tcp_hdr);
+		/* We expect MSS option to be present (opt_totlen > 0),
+		 * so call unconditionally.
+		 */
+		if (net_tcp_parse_opts(pkt, opt_totlen, &tcp_opts) < 0) {
+			return NET_DROP;
+		}
+
+		net_tcp_change_state(tcp, NET_TCP_SYN_RCVD);
+
+		/* Set TCP seq and ack which are then stored in the backlog */
+		context->tcp->send_seq = tcp_init_isn();
+		context->tcp->send_ack =
+			sys_get_be32(tcp_hdr->seq) + 1;
+
+		/* Get MSS from TCP options here*/
+
+		r = tcp_backlog_syn(pkt, context, tcp_opts.mss);
+		if (r < 0) {
+			if (r == -EADDRINUSE) {
+				NET_DBG("TCP connection already exists");
+			} else {
+				NET_DBG("No free TCP backlog entries");
+			}
+
+			return NET_DROP;
+		}
+
+		pkt_get_sockaddr(net_context_get_family(context),
+				 pkt, &pkt_src_addr);
+		send_syn_ack(context, &pkt_src_addr, &remote_addr);
+
+		return NET_DROP;
+	}
+
+	/*
+	 * See RFC 793 chapter 3.4 "Reset Processing" and RFC 793, page 65
+	 * for more details.
+	 */
+	if (NET_TCP_FLAGS(tcp_hdr) == NET_TCP_RST) {
+
+		if (tcp_backlog_rst(pkt) < 0) {
+			net_stats_update_tcp_seg_rsterr();
+			return NET_DROP;
+		}
+
+		net_stats_update_tcp_seg_rst();
+
+		net_tcp_print_recv_info("RST", pkt, tcp_hdr->src_port);
+
+		return NET_DROP;
+	}
+
+	/*
+	 * If we receive ACK, we go to ESTABLISHED state.
+	 */
+	if (NET_TCP_FLAGS(tcp_hdr) == NET_TCP_ACK) {
+		struct net_context *new_context;
+		socklen_t addrlen;
+		int ret;
+
+		net_tcp_print_recv_info("ACK", pkt, tcp_hdr->src_port);
+
+		if (!context->tcp->accept_cb) {
+			NET_DBG("No accept callback, connection reset.");
+			goto reset;
+		}
+
+		/* We create a new context that starts to wait data.
+		 */
+		ret = net_context_get(net_pkt_family(pkt),
+				      SOCK_STREAM, IPPROTO_TCP,
+				      &new_context);
+		if (ret < 0) {
+			NET_DBG("Cannot get accepted context, "
+				"connection reset");
+			goto conndrop;
+		}
+
+		ret = tcp_backlog_ack(pkt, new_context);
+		if (ret < 0) {
+			NET_DBG("Cannot find context from TCP backlog");
+
+			net_context_unref(new_context);
+
+			goto conndrop;
+		}
+
+		ret = net_context_bind(new_context, &local_addr,
+				       sizeof(local_addr));
+		if (ret < 0) {
+			NET_DBG("Cannot bind accepted context, "
+				"connection reset");
+			net_context_unref(new_context);
+			goto conndrop;
+		}
+
+		new_context->flags |= NET_CONTEXT_REMOTE_ADDR_SET;
+
+		memcpy(&new_context->remote, &remote_addr,
+		       sizeof(remote_addr));
+
+		ret = net_tcp_register(&new_context->remote,
+			       &local_addr,
+			       ntohs(net_sin(&new_context->remote)->sin_port),
+			       ntohs(net_sin(&local_addr)->sin_port),
+			       tcp_established,
+			       new_context,
+			       &new_context->conn_handler);
+		if (ret < 0) {
+			NET_DBG("Cannot register accepted TCP handler (%d)",
+				ret);
+			net_context_unref(new_context);
+			goto conndrop;
+		}
+
+		/* Swap the newly-created TCP states with the one that
+		 * was used to establish this connection. The old TCP
+		 * must be listening to accept other connections.
+		 */
+		copy_pool_vars(new_context, context);
+
+		net_tcp_change_state(tcp, NET_TCP_LISTEN);
+
+		/* We cannot use net_tcp_change_state() here as that will
+		 * check the state transitions. So set the state directly.
+		 */
+		new_context->tcp->state = NET_TCP_ESTABLISHED;
+
+		net_context_set_state(new_context, NET_CONTEXT_CONNECTED);
+
+		if (new_context->remote.sa_family == AF_INET) {
+			addrlen = sizeof(struct sockaddr_in);
+		} else if (new_context->remote.sa_family == AF_INET6) {
+			addrlen = sizeof(struct sockaddr_in6);
+		} else {
+			NET_ASSERT_INFO(false, "Invalid protocol family %d",
+					new_context->remote.sa_family);
+			net_context_unref(new_context);
+			return NET_DROP;
+		}
+
+		context->tcp->accept_cb(new_context,
+					&new_context->remote,
+					addrlen,
+					0,
+					context->user_data);
+	}
+
+	return NET_DROP;
+
+conndrop:
+	net_stats_update_tcp_seg_conndrop();
+
+reset:
+	send_reset(tcp->context, &local_addr, &remote_addr);
+
+	return NET_DROP;
+}
+
+int net_tcp_accept(struct net_context *context, net_tcp_accept_cb_t cb,
+		   void *user_data)
+{
+	struct sockaddr local_addr;
+	struct sockaddr *laddr = NULL;
+	u16_t lport = 0;
+	int ret;
+
+	NET_ASSERT(context->tcp);
+
+	if (net_tcp_get_state(context->tcp) != NET_TCP_LISTEN) {
+		NET_DBG("Context %p in wrong state %d, should be %d",
+			context, context->tcp->state, NET_TCP_LISTEN);
+		return -EINVAL;
+	}
+
+	local_addr.sa_family = net_context_get_family(context);
+
+#if defined(CONFIG_NET_IPV6)
+	if (net_context_get_family(context) == AF_INET6) {
+		if (net_sin6_ptr(&context->local)->sin6_addr) {
+			net_ipaddr_copy(&net_sin6(&local_addr)->sin6_addr,
+				     net_sin6_ptr(&context->local)->sin6_addr);
+
+			laddr = &local_addr;
+		}
+
+		net_sin6(&local_addr)->sin6_port = lport =
+			net_sin6((struct sockaddr *)&context->local)->sin6_port;
+	}
+#endif /* CONFIG_NET_IPV6 */
+
+#if defined(CONFIG_NET_IPV4)
+	if (net_context_get_family(context) == AF_INET) {
+		if (net_sin_ptr(&context->local)->sin_addr) {
+			net_ipaddr_copy(&net_sin(&local_addr)->sin_addr,
+				      net_sin_ptr(&context->local)->sin_addr);
+
+			laddr = &local_addr;
+		}
+
+		net_sin(&local_addr)->sin_port = lport =
+			net_sin((struct sockaddr *)&context->local)->sin_port;
+	}
+#endif /* CONFIG_NET_IPV4 */
+
+	ret = net_tcp_register(context->flags & NET_CONTEXT_REMOTE_ADDR_SET ?
+			       &context->remote : NULL,
+			       laddr,
+			       ntohs(net_sin(&context->remote)->sin_port),
+			       ntohs(lport),
+			       tcp_syn_rcvd,
+			       context,
+			       &context->conn_handler);
+	if (ret < 0) {
+		return ret;
+	}
+
+	context->user_data = user_data;
+
+	/* accept callback is only valid for TCP contexts */
+	if (net_context_get_ip_proto(context) == IPPROTO_TCP) {
+		context->tcp->accept_cb = cb;
+	}
+
+	return 0;
+}
+
+int net_tcp_connect(struct net_context *context,
+		    const struct sockaddr *addr,
+		    struct sockaddr *laddr,
+		    u16_t rport,
+		    u16_t lport,
+		    s32_t timeout,
+		    net_context_connect_cb_t cb,
+		    void *user_data)
+{
+	int ret;
+
+	NET_ASSERT(context->tcp);
+
+	if (net_context_get_type(context) != SOCK_STREAM) {
+		return -ENOTSUP;
+	}
+
+	/* We need to register a handler, otherwise the SYN-ACK
+	 * packet would not be received.
+	 */
+	ret = net_tcp_register(addr,
+			       laddr,
+			       ntohs(rport),
+			       ntohs(lport),
+			       tcp_synack_received,
+			       context,
+			       &context->conn_handler);
+	if (ret < 0) {
+		return ret;
+	}
+
+	context->connect_cb = cb;
+	context->user_data = user_data;
+
+	net_context_set_state(context, NET_CONTEXT_CONNECTING);
+
+	send_syn(context, addr);
+
+	/* in tcp_synack_received() we give back this semaphore */
+	if (timeout != 0 && k_sem_take(&context->tcp->connect_wait, timeout)) {
+		return -ETIMEDOUT;
+	}
 
 	return 0;
 }

--- a/subsys/net/ip/tcp.c
+++ b/subsys/net/ip/tcp.c
@@ -1446,3 +1446,22 @@ int net_tcp_listen(struct net_context *context)
 
 	return -EOPNOTSUPP;
 }
+
+int net_tcp_update_recv_wnd(struct net_context *context, s32_t delta)
+{
+	s32_t new_win;
+
+	if (!context->tcp) {
+		NET_ERR("context->tcp == NULL");
+		return -EPROTOTYPE;
+	}
+
+	new_win = context->tcp->recv_wnd + delta;
+	if (new_win < 0 || new_win > UINT16_MAX) {
+		return -EINVAL;
+	}
+
+	context->tcp->recv_wnd = new_win;
+
+	return 0;
+}

--- a/subsys/net/ip/tcp.h
+++ b/subsys/net/ip/tcp.h
@@ -329,10 +329,14 @@ void net_tcp_foreach(net_tcp_cb_t cb, void *user_data);
  * @brief Send available queued data over TCP connection
  *
  * @param context TCP context
+ * @param cb TCP callback function
+ * @param token TCP token
+ * @param user_data User specified data
  *
  * @return 0 if ok, < 0 if error
  */
-int net_tcp_send_data(struct net_context *context);
+int net_tcp_send_data(struct net_context *context, net_context_send_cb_t cb,
+		      void *token, void *user_data);
 
 /**
  * @brief Enqueue a single packet for transmission
@@ -551,9 +555,15 @@ static inline void net_tcp_foreach(net_tcp_cb_t cb, void *user_data)
 	ARG_UNUSED(user_data);
 }
 
-static inline int net_tcp_send_data(struct net_context *context)
+static inline int net_tcp_send_data(struct net_context *context,
+				    net_context_send_cb_t cb, void *token,
+				    void *user_data)
 {
 	ARG_UNUSED(context);
+	ARG_UNUSED(cb);
+	ARG_UNUSED(token);
+	ARG_UNUSED(user_data);
+
 	return 0;
 }
 

--- a/subsys/net/ip/tcp.h
+++ b/subsys/net/ip/tcp.h
@@ -179,6 +179,8 @@ struct net_tcp {
 	u16_t send_mss;
 };
 
+typedef void (*net_tcp_cb_t)(struct net_tcp *tcp, void *user_data);
+
 static inline bool net_tcp_is_used(struct net_tcp *tcp)
 {
 	NET_ASSERT(tcp);
@@ -244,6 +246,7 @@ void net_tcp_change_state(struct net_tcp *tcp, enum net_tcp_state new_state);
 #define net_tcp_change_state(...)
 #endif
 
+#if defined(CONFIG_NET_TCP)
 /**
  * @brief Allocate TCP connection context.
  *
@@ -312,8 +315,6 @@ int net_tcp_prepare_reset(struct net_tcp *tcp,
 			  const struct sockaddr *local,
 			  const struct sockaddr *remote,
 			  struct net_pkt **pkt);
-
-typedef void (*net_tcp_cb_t)(struct net_tcp *tcp, void *user_data);
 
 /**
  * @brief Go through all the TCP connections and call callback
@@ -398,7 +399,6 @@ static inline enum net_tcp_state net_tcp_get_state(const struct net_tcp *tcp)
  */
 bool net_tcp_validate_seq(struct net_tcp *tcp, struct net_pkt *pkt);
 
-#if defined(CONFIG_NET_TCP)
 /**
  * @brief Get TCP packet header data from net_pkt. The array values are in
  * network byte order and other values are in host byte order.
@@ -476,6 +476,112 @@ int net_tcp_parse_opts(struct net_pkt *pkt, int opt_totlen,
 		       struct net_tcp_options *opts);
 
 #else
+static inline struct net_tcp *net_tcp_alloc(struct net_context *context)
+{
+	ARG_UNUSED(context);
+	return NULL;
+}
+
+static inline int net_tcp_release(struct net_tcp *tcp)
+{
+	ARG_UNUSED(tcp);
+	return 0;
+}
+
+static inline int net_tcp_prepare_segment(struct net_tcp *tcp, u8_t flags,
+					  void *options, size_t optlen,
+					  const struct sockaddr_ptr *local,
+					  const struct sockaddr *remote,
+					  struct net_pkt **send_pkt)
+{
+	ARG_UNUSED(tcp);
+	ARG_UNUSED(flags);
+	ARG_UNUSED(options);
+	ARG_UNUSED(optlen);
+	ARG_UNUSED(local);
+	ARG_UNUSED(remote);
+	ARG_UNUSED(send_pkt);
+	return 0;
+}
+
+static inline int net_tcp_prepare_ack(struct net_tcp *tcp,
+				      const struct sockaddr *remote,
+				      struct net_pkt **pkt)
+{
+	ARG_UNUSED(tcp);
+	ARG_UNUSED(remote);
+	ARG_UNUSED(pkt);
+	return 0;
+}
+
+static inline int net_tcp_prepare_reset(struct net_tcp *tcp,
+					const struct sockaddr *remote,
+					struct net_pkt **pkt)
+{
+	ARG_UNUSED(tcp);
+	ARG_UNUSED(remote);
+	ARG_UNUSED(pkt);
+	return 0;
+}
+
+static inline void net_tcp_foreach(net_tcp_cb_t cb, void *user_data)
+{
+	ARG_UNUSED(cb);
+	ARG_UNUSED(user_data);
+}
+
+static inline int net_tcp_send_data(struct net_context *context)
+{
+	ARG_UNUSED(context);
+	return 0;
+}
+
+static inline int net_tcp_queue_data(struct net_context *context,
+				     struct net_pkt *pkt)
+{
+	ARG_UNUSED(context);
+	ARG_UNUSED(pkt);
+	return -EPROTONOSUPPORT;
+}
+
+static inline int net_tcp_send_pkt(struct net_pkt *pkt)
+{
+	ARG_UNUSED(pkt);
+	return 0;
+}
+
+static inline bool net_tcp_ack_received(struct net_context *ctx, u32_t ack)
+{
+	ARG_UNUSED(ctx);
+	ARG_UNUSED(ack);
+	return false;
+}
+
+static inline u16_t net_tcp_get_recv_mss(const struct net_tcp *tcp)
+{
+	ARG_UNUSED(tcp);
+	return 0;
+}
+
+static inline u32_t net_tcp_get_recv_wnd(const struct net_tcp *tcp)
+{
+	ARG_UNUSED(tcp);
+	return 0;
+}
+
+static inline enum net_tcp_state net_tcp_get_state(const struct net_tcp *tcp)
+{
+	ARG_UNUSED(tcp);
+	return NET_TCP_CLOSED;
+}
+
+static inline bool net_tcp_validate_seq(struct net_tcp *tcp,
+					struct net_pkt *pkt)
+{
+	ARG_UNUSED(tcp);
+	ARG_UNUSED(pkt);
+	return false;
+}
 
 static inline u16_t net_tcp_get_chksum(struct net_pkt *pkt,
 				       struct net_buf *frag)

--- a/subsys/net/ip/tcp.h
+++ b/subsys/net/ip/tcp.h
@@ -523,6 +523,18 @@ int net_tcp_put(struct net_context *context);
  */
 int net_tcp_listen(struct net_context *context);
 
+/**
+ * @brief Update TCP receive window
+ *
+ * @param context Network context
+ * @param delta Receive window delta
+ *
+ * @return 0 on success, -EPROTOTYPE if there is no TCP context, -EINVAL
+ *         if the receive window delta is out of bounds, -EPROTONOSUPPORT
+ *         if TCP is not supported
+ */
+int net_tcp_update_recv_wnd(struct net_context *context, s32_t delta);
+
 #else
 static inline struct net_tcp *net_tcp_alloc(struct net_context *context)
 {
@@ -699,6 +711,16 @@ static inline int net_tcp_listen(struct net_context *context)
 
 	return -EPROTONOSUPPORT;
 }
+
+static inline int net_tcp_update_recv_wnd(struct net_context *context,
+					  s32_t delta)
+{
+	ARG_UNUSED(context);
+	ARG_UNUSED(delta);
+
+	return -EPROTONOSUPPORT;
+}
+
 #endif
 
 #if defined(CONFIG_NET_TCP)

--- a/subsys/net/ip/tcp.h
+++ b/subsys/net/ip/tcp.h
@@ -513,6 +513,16 @@ int net_tcp_recv(struct net_context *context, net_context_recv_cb_t cb,
  */
 int net_tcp_put(struct net_context *context);
 
+/**
+ * @brief Set TCP socket into listening state
+ *
+ * @param context Network context
+ *
+ * @return 0 if successful, -EOPNOTSUPP if the context was not for TCP,
+ *         -EPROTONOSUPPORT if TCP is not supported
+ */
+int net_tcp_listen(struct net_context *context);
+
 #else
 static inline struct net_tcp *net_tcp_alloc(struct net_context *context)
 {
@@ -677,6 +687,13 @@ static inline int net_tcp_recv(struct net_context *context,
 }
 
 static inline int net_tcp_put(struct net_context *context)
+{
+	ARG_UNUSED(context);
+
+	return -EPROTONOSUPPORT;
+}
+
+static inline int net_tcp_listen(struct net_context *context)
 {
 	ARG_UNUSED(context);
 

--- a/subsys/net/ip/tcp.h
+++ b/subsys/net/ip/tcp.h
@@ -475,6 +475,15 @@ u16_t net_tcp_get_chksum(struct net_pkt *pkt, struct net_buf *frag);
 int net_tcp_parse_opts(struct net_pkt *pkt, int opt_totlen,
 		       struct net_tcp_options *opts);
 
+/**
+ * @brief Get TCP header length
+ *
+ * @param pkt Network packet
+ *
+ * @return TCP header length
+ */
+int tcp_hdr_len(struct net_pkt *pkt);
+
 #else
 static inline struct net_tcp *net_tcp_alloc(struct net_context *context)
 {
@@ -614,6 +623,14 @@ static inline struct net_tcp_hdr *net_tcp_set_hdr(struct net_pkt *pkt,
 	ARG_UNUSED(hdr);
 	return NULL;
 }
+
+static inline int tcp_hdr_len(struct net_pkt *pkt)
+{
+	ARG_UNUSED(pkt);
+
+	return 0;
+}
+
 #endif
 
 #if defined(CONFIG_NET_TCP)

--- a/subsys/net/ip/tcp.h
+++ b/subsys/net/ip/tcp.h
@@ -484,6 +484,18 @@ int net_tcp_parse_opts(struct net_pkt *pkt, int opt_totlen,
  */
 int tcp_hdr_len(struct net_pkt *pkt);
 
+/**
+ * @brief TCP receive function
+ *
+ * @param context Network context
+ * @param cb TCP receive callback function
+ * @param user_data TCP receive callback user data
+ *
+ * @return 0 if no erro, < 0 in case of error
+ */
+int net_tcp_recv(struct net_context *context, net_context_recv_cb_t cb,
+		 void *user_data);
+
 #else
 static inline struct net_tcp *net_tcp_alloc(struct net_context *context)
 {
@@ -629,6 +641,16 @@ static inline int tcp_hdr_len(struct net_pkt *pkt)
 	ARG_UNUSED(pkt);
 
 	return 0;
+}
+
+static inline int net_tcp_recv(struct net_context *context,
+			       net_context_recv_cb_t cb, void *user_data)
+{
+	ARG_UNUSED(context);
+	ARG_UNUSED(cb);
+	ARG_UNUSED(user_data);
+
+	return -EPROTOTYPE;
 }
 
 #endif

--- a/subsys/net/ip/tcp.h
+++ b/subsys/net/ip/tcp.h
@@ -500,6 +500,19 @@ int tcp_hdr_len(struct net_pkt *pkt);
 int net_tcp_recv(struct net_context *context, net_context_recv_cb_t cb,
 		 void *user_data);
 
+
+/**
+ * @brief Queue a TCP FIN packet if needed to close the socket
+ *
+ * @param context Network context
+ *
+ * @return 0 on success where a TCP FIN packet has been queueed, -ENOTCONN
+ *         in case the socket was not connected or listening, -EOPNOTSUPP
+ *         in case it was not a TCP socket or -EPROTONOSUPPORT if TCP is not
+ *         supported
+ */
+int net_tcp_put(struct net_context *context);
+
 #else
 static inline struct net_tcp *net_tcp_alloc(struct net_context *context)
 {
@@ -663,6 +676,12 @@ static inline int net_tcp_recv(struct net_context *context,
 	return -EPROTOTYPE;
 }
 
+static inline int net_tcp_put(struct net_context *context)
+{
+	ARG_UNUSED(context);
+
+	return -EPROTONOSUPPORT;
+}
 #endif
 
 #if defined(CONFIG_NET_TCP)

--- a/subsys/net/ip/tcp.h
+++ b/subsys/net/ip/tcp.h
@@ -535,6 +535,59 @@ int net_tcp_listen(struct net_context *context);
  */
 int net_tcp_update_recv_wnd(struct net_context *context, s32_t delta);
 
+/**
+ * @brief Initialize TCP parts of a context
+ *
+ * @param context Network context
+ *
+ * @return 0 if successful, < 0 on error
+ */
+int net_tcp_get(struct net_context *context);
+
+/**
+ * @brief Unref TCP parts of a context
+ *
+ * @param context Network context
+ *
+ * @return 0 if successful, < 0 on error
+ */
+int net_tcp_unref(struct net_context *context);
+
+/**
+ * @brief Accept TCP connection
+ *
+ * @param context Network context
+ * @param cb Accept callback
+ * @param user_data Accept callback user data
+ *
+ * @return 0 on success, < 0 on error
+ */
+int net_tcp_accept(struct net_context *context, net_tcp_accept_cb_t cb,
+		   void *user_data);
+
+/**
+ * @brief Connect TCP connection
+ *
+ * @param context Network context
+ * @param addr Remote address
+ * @param laddr Local address
+ * @param rport Remote port
+ * @param lport Local port
+ * @param timeout Connect timeout
+ * @param cb Connect callback
+ * @param user_data Connect callback user data
+ *
+ * @return 0 on success, < 0 on error
+ */
+int net_tcp_connect(struct net_context *context,
+		    const struct sockaddr *addr,
+		    struct sockaddr *laddr,
+		    u16_t rport,
+		    u16_t lport,
+		    s32_t timeout,
+		    net_context_connect_cb_t cb,
+		    void *user_data);
+
 #else
 static inline struct net_tcp *net_tcp_alloc(struct net_context *context)
 {
@@ -717,6 +770,47 @@ static inline int net_tcp_update_recv_wnd(struct net_context *context,
 {
 	ARG_UNUSED(context);
 	ARG_UNUSED(delta);
+
+	return -EPROTONOSUPPORT;
+}
+
+static inline int net_tcp_get(struct net_context *context)
+{
+	ARG_UNUSED(context);
+
+	return -EPROTONOSUPPORT;
+}
+
+static inline int net_tcp_unref(struct net_context *context)
+{
+	ARG_UNUSED(context);
+
+	return -EPROTONOSUPPORT;
+}
+
+static inline int net_tcp_accept(struct net_context *context,
+				 net_tcp_accept_cb_t cb, void *user_data)
+{
+	ARG_UNUSED(context);
+	ARG_UNUSED(cb);
+	ARG_UNUSED(user_data);
+
+	return -EPROTONOSUPPORT;
+}
+
+static inline int net_tcp_connect(struct net_context *context,
+				  const struct sockaddr *addr,
+				  struct sockaddr *laddr,
+				  u16_t rport, u16_t lport, s32_t timeout,
+				  net_context_connect_cb_t cb, void *user_data)
+{
+	ARG_UNUSED(context);
+	ARG_UNUSED(addr);
+	ARG_UNUSED(laddr);
+	ARG_UNUSED(rport);
+	ARG_UNUSED(lport);
+	ARG_UNUSED(cb);
+	ARG_UNUSED(user_data);
 
 	return -EPROTONOSUPPORT;
 }

--- a/tests/net/socket/tcp/prj.conf
+++ b/tests/net/socket/tcp/prj.conf
@@ -1,3 +1,6 @@
+# Setup for self-contained net testing without requiring a SLIP driver
+CONFIG_NET_TEST=y
+
 # General config
 CONFIG_NEWLIB_LIBC=y
 
@@ -10,6 +13,7 @@ CONFIG_NET_SOCKETS=y
 CONFIG_NET_SOCKETS_POSIX_NAMES=y
 
 # Network driver config
+CONFIG_NET_LOOPBACK=y
 CONFIG_TEST_RANDOM_GENERATOR=y
 
 # Network address config

--- a/tests/net/socket/tcp/testcase.yaml
+++ b/tests/net/socket/tcp/testcase.yaml
@@ -1,7 +1,4 @@
 tests:
   test:
-    extra_configs:
-      - CONFIG_NET_TEST=y
-      - CONFIG_NET_LOOPBACK=y
     min_ram: 32
     tags: net


### PR DESCRIPTION
This PR will move TCP functionality from net_context.c to tcp.c, while leaving TCP function calls in net_context.c that resolve to empty inline functions when TCP is not enabled. As small pieces as possible are worked on one by one, except for the last patch that moves a majority of the TCP functionality to the new file. No functionality has been changed, except for patches 4/14 and 13/14. The issue described this desired change is #5482.

Patch 4/14 reorders the function calls, so that address checks happen before offloading, and any bind calls to the stack happen after offloading.
Patch 13/14 contains a fix where calling connect will set both local and remote addresses also for a UDP.