### PR TITLE
Bluetooth: Advertising API enhancements

### DIFF
--- a/include/bluetooth/bluetooth.h
+++ b/include/bluetooth/bluetooth.h
@@ -115,6 +115,12 @@ enum {
 	 *  occur.
 	 */
 	BT_LE_ADV_OPT_ONE_TIME = BIT(1),
+
+	/** Advertise using the identity address as the own address.
+	 *  @warning This will compromise the privacy of the device, so care
+	 *           must be taken when using this option.
+	 */
+	BT_LE_ADV_OPT_USE_IDENTITY = BIT(2),
 };
 
 /** LE Advertising Parameters. */

--- a/include/bluetooth/bluetooth.h
+++ b/include/bluetooth/bluetooth.h
@@ -133,12 +133,6 @@ struct bt_le_adv_param {
 
 	/** Maximum Advertising Interval (N * 0.625) */
 	u16_t interval_max;
-
-	/** Optional predefined (random) own address. Currently
-	 *  the only permitted use of this is for NRPA with
-	 *  non-connectable advertising.
-	 */
-	const bt_addr_t *own_addr;
 };
 
 /** Helper to declare advertising parameters inline

--- a/subsys/bluetooth/host/hci_core.c
+++ b/subsys/bluetooth/host/hci_core.c
@@ -4727,15 +4727,7 @@ int bt_le_adv_start(const struct bt_le_adv_param *param,
 
 		set_param.type = BT_LE_ADV_IND;
 	} else {
-		if (param->own_addr) {
-			/* Only NRPA is allowed */
-			if (!BT_ADDR_IS_NRPA(param->own_addr)) {
-				return -EINVAL;
-			}
-
-			err = set_random_address(param->own_addr);
-			set_param.own_addr_type = BT_ADDR_LE_RANDOM;
-		} else if (param->options & BT_LE_ADV_OPT_USE_IDENTITY) {
+		if (param->options & BT_LE_ADV_OPT_USE_IDENTITY) {
 			if (atomic_test_bit(bt_dev.flags,
 					    BT_DEV_ID_STATIC_RANDOM)) {
 				err = set_random_address(&bt_dev.id_addr.a);

--- a/subsys/bluetooth/host/mesh/Kconfig
+++ b/subsys/bluetooth/host/mesh/Kconfig
@@ -388,6 +388,14 @@ config BT_MESH_DEBUG
 
 if BT_MESH_DEBUG
 
+config BT_MESH_DEBUG_USE_ID_ADDR
+	bool "Use identity address for all advertising"
+	help
+	  This option forces the usage of the local identity address for
+	  all advertising. This can be a help for debugging (analyzing
+	  traces), however it should never be enabled for a production
+	  build as it compromises the privacy of the device.
+
 config BT_MESH_DEBUG_NET
 	bool "Network layer debug"
 	help

--- a/subsys/bluetooth/host/mesh/adv.c
+++ b/subsys/bluetooth/host/mesh/adv.c
@@ -115,7 +115,12 @@ static inline void adv_send(struct net_buf *buf)
 	ad.data_len = buf->len;
 	ad.data = buf->data;
 
-	param.options = 0;
+	if (IS_ENABLED(CONFIG_BT_MESH_DEBUG_USE_ID_ADDR)) {
+		param.options = BT_LE_ADV_OPT_USE_IDENTITY;
+	} else {
+		param.options = 0;
+	}
+
 	param.interval_min = ADV_SCAN_UNIT(adv_int);
 	param.interval_max = param.interval_min;
 

--- a/subsys/bluetooth/host/mesh/adv.c
+++ b/subsys/bluetooth/host/mesh/adv.c
@@ -118,7 +118,6 @@ static inline void adv_send(struct net_buf *buf)
 	param.options = 0;
 	param.interval_min = ADV_SCAN_UNIT(adv_int);
 	param.interval_max = param.interval_min;
-	param.own_addr = NULL;
 
 	err = bt_le_adv_start(&param, &ad, 1, NULL, 0);
 	net_buf_unref(buf);

--- a/subsys/bluetooth/host/mesh/proxy.c
+++ b/subsys/bluetooth/host/mesh/proxy.c
@@ -44,14 +44,21 @@
 
 #define CLIENT_BUF_SIZE 68
 
+#if defined(CONFIG_BT_MESH_DEBUG_USE_ID_ADDR)
+#define ADV_OPT (BT_LE_ADV_OPT_CONNECTABLE | BT_LE_ADV_OPT_ONE_TIME | \
+		 BT_LE_ADV_OPT_USE_IDENTITY)
+#else
+#define ADV_OPT (BT_LE_ADV_OPT_CONNECTABLE | BT_LE_ADV_OPT_ONE_TIME)
+#endif
+
 static const struct bt_le_adv_param slow_adv_param = {
-	.options = (BT_LE_ADV_OPT_CONNECTABLE | BT_LE_ADV_OPT_ONE_TIME),
+	.options = ADV_OPT,
 	.interval_min = BT_GAP_ADV_SLOW_INT_MIN,
 	.interval_max = BT_GAP_ADV_SLOW_INT_MAX,
 };
 
 static const struct bt_le_adv_param fast_adv_param = {
-	.options = (BT_LE_ADV_OPT_CONNECTABLE | BT_LE_ADV_OPT_ONE_TIME),
+	.options = ADV_OPT,
 	.interval_min = BT_GAP_ADV_FAST_INT_MIN_2,
 	.interval_max = BT_GAP_ADV_FAST_INT_MAX_2,
 };

--- a/subsys/bluetooth/shell/bt.c
+++ b/subsys/bluetooth/shell/bt.c
@@ -710,7 +710,6 @@ static int cmd_advertise(int argc, char *argv[])
 		return 0;
 	}
 
-	param.own_addr = NULL;
 	param.interval_min = BT_GAP_ADV_FAST_INT_MIN_2;
 	param.interval_max = BT_GAP_ADV_FAST_INT_MAX_2;
 


### PR DESCRIPTION
Three enhancements related to the advertising API. The first one adds an option to force advertising using the identity address. The second one removes the own_addr parameter which was largely a work-around/hack that has no in-tree users anymore. The third patch adds a new Kconfig debug option for mesh to take advantage of the new advertising option.