### PR TITLE
net: sockets: Add freeaddrinfo()

### DIFF
--- a/include/net/socket.h
+++ b/include/net/socket.h
@@ -164,6 +164,11 @@ static inline int getaddrinfo(const char *host, const char *service,
 	return zsock_getaddrinfo(host, service, hints, res);
 }
 
+static inline void freeaddrinfo(struct zsock_addrinfo *ai)
+{
+	ARG_UNUSED(ai);
+}
+
 #define addrinfo zsock_addrinfo
 #define EAI_BADFLAGS DNS_EAI_BADFLAGS
 #define EAI_NONAME DNS_EAI_NONAME


### PR DESCRIPTION
Add freeaddrinfo() to complement getaddrinfo().

Existing applications using getaddrinfo() will usually free
allocated memory using freeaddrinfo(). Even if nothing is allocated
the function should exist to avoid having to change the application
when porting.

Signed-off-by: Stig Bjørlykke <stig.bjorlykke@nordicsemi.no>