### PR TITLE
entropy: nrf5x remove unnecessary header

### DIFF
--- a/drivers/entropy/entropy_nrf5.c
+++ b/drivers/entropy/entropy_nrf5.c
@@ -7,7 +7,6 @@
 
 #include <entropy.h>
 #include <atomic.h>
-#include <nrf_rng.h>
 #include <soc.h>
 
 struct rand {


### PR DESCRIPTION
Remove unnecessary header inclusion in nordic's nrf5 random
driver which otherwise adds a dependency to ext/hal/nordic.

Signed-off-by: Alberto Escolar Piedras <alpi@oticon.com>