### PR TITLE
Support utf8 in kconfig values

### DIFF
--- a/cmake/extensions.cmake
+++ b/cmake/extensions.cmake
@@ -638,6 +638,7 @@ function(import_kconfig config_file)
     ${config_file}
     DOT_CONFIG_LIST
     REGEX "^CONFIG_"
+    ENCODING "UTF-8"
   )
 
   foreach (CONFIG ${DOT_CONFIG_LIST})

--- a/misc/generated/CMakeLists.txt
+++ b/misc/generated/CMakeLists.txt
@@ -4,6 +4,7 @@ file(STRINGS
   ${AUTOCONF_H}
   CONFIG_LIST
   REGEX "^#define CONFIG_"
+  ENCODING "UTF-8"
   )
 foreach (CONFIG ${CONFIG_LIST})
   string(REGEX REPLACE "#define (CONFIG_[A-Z|_|0-9]*) (.*)" "GEN_ABSOLUTE_SYM(\\1, \\2)" CONFIG ${CONFIG})

--- a/misc/generated/CMakeLists.txt
+++ b/misc/generated/CMakeLists.txt
@@ -1,6 +1,10 @@
 set(CONFIGS_C ${CMAKE_CURRENT_BINARY_DIR}/misc/generated/configs.c)
 
-file(STRINGS ${AUTOCONF_H} CONFIG_LIST REGEX "^#define CONFIG_")
+file(STRINGS
+  ${AUTOCONF_H}
+  CONFIG_LIST
+  REGEX "^#define CONFIG_"
+  )
 foreach (CONFIG ${CONFIG_LIST})
   string(REGEX REPLACE "#define (CONFIG_[A-Z|_|0-9]*) (.*)" "GEN_ABSOLUTE_SYM(\\1, \\2)" CONFIG ${CONFIG})
   string(REGEX REPLACE "\"(.*)\"" "1" CONFIG ${CONFIG})

--- a/tests/misc/test_build/testcase.yaml
+++ b/tests/misc/test_build/testcase.yaml
@@ -21,3 +21,8 @@ tests:
     platform_whitelist: nrf51_pca10028 nrf52_pca10040
     extra_configs:
       - CONFIG_BOOTLOADER_MCUBOOT=y
+  test_utf8_in_kconfig_values:
+    build_only: true
+    tags: apps
+    extra_configs:
+      - CONFIG_KERNEL_BIN_NAME="A_kconfig_value_with_a_utf8_char_in_it_Bøe_"


### PR DESCRIPTION
Support utf8 in kconfig values.

We are using the CMake command 'file(STRINGS' (which defaults to only
decoding ASCII) to read Kconfig configurations. When UTF-8 characters
are detected they are treated as newlines.

This behaviour has caused issues when users have input UTF-8
characters into Kconfig values. E.g. USB device descriptor strings.

This commit adds the flag 'ENCODING "UTF-8"' to the 'file(STRINGS'
command so that UTF-8 characters are correctly passed through the
build system.

Note that this is not related to https://github.com/zephyrproject-rtos/zephyr/issues/6726

This resolves an issue that was discovered in https://github.com/zephyrproject-rtos/zephyr/issues/6649

#6649 consists of both a feature request and a bug report. So this does not resolve 6649.

This PR also adds a test that proves that the fix/feature works.

