### PR TITLE
doc: Fix SAM0 SPI controller device names

### DIFF
--- a/boards/arm/adafruit_feather_m0_basic_proto/doc/adafruit_feather_m0_basic_proto.rst
+++ b/boards/arm/adafruit_feather_m0_basic_proto/doc/adafruit_feather_m0_basic_proto.rst
@@ -82,7 +82,7 @@ SPI Port
 ========
 
 The SAMD21 MCU has 6 SERCOM based SPIs.  On the Adafruit Feather M0
-Basic Proto, SPI4 is available on pin 22 (MISO), pin 23 (MOSI), and
+Basic Proto, SERCOM4 is available on pin 22 (MISO), pin 23 (MOSI), and
 pin 24 (SCK).
 
 USB Device Port

--- a/boards/arm/adafruit_trinket_m0/doc/adafruit_trinket_m0.rst
+++ b/boards/arm/adafruit_trinket_m0/doc/adafruit_trinket_m0.rst
@@ -81,10 +81,10 @@ SERCOM2 is available on pins 2 (RX) and 0 (TX).
 SPI Port
 ========
 
-The SAMD21 MCU has 6 SERCOM based SPIs.  On the Trinket, SPI1 is used
-to drive the DotStar RGB LED.  SERCOM0 can be put into SPI mode and
-used to connect to devices over pin 2 (MISO), pin 4 (MOSI), and pin 3
-(SCK).
+The SAMD21 MCU has 6 SERCOM based SPIs.  On the Trinket, SERCOM1 is
+used to drive the DotStar RGB LED.  SERCOM0 can be put into SPI mode
+and used to connect to devices over pin 2 (MISO), pin 4 (MOSI), and
+pin 3 (SCK).
 
 USB Device Port
 ===============

--- a/boards/arm/arduino_zero/doc/arduino_zero.rst
+++ b/boards/arm/arduino_zero/doc/arduino_zero.rst
@@ -81,8 +81,8 @@ SERCOM0 is available on the D0/D1 pins.
 SPI Port
 ========
 
-The SAMD21 MCU has 6 SERCOM based SPIs.  On the Arduino Zero, SPI4 is
-available on the 6 pin connector at the edge of the board.
+The SAMD21 MCU has 6 SERCOM based SPIs.  On the Arduino Zero, SERCOM4
+is available on the 6 pin connector at the edge of the board.
 
 USB Device Port
 ===============


### PR DESCRIPTION
The SAM0 SoC was switched to use DTS for SPI configuration. Update
documentation for the SAM0 based boards to use the correct SPI
controller device names.

Signed-off-by: Henrik Brix Andersen <henrik@brixandersen.dk>