### PR TITLE
kernel: Fix left shift into sign bit

### DIFF
--- a/kernel/include/ksched.h
+++ b/kernel/include/ksched.h
@@ -203,7 +203,7 @@ static inline int _get_ready_q_prio_bmap_index(int prio)
 /* find out the prio bit for a given prio */
 static inline int _get_ready_q_prio_bit(int prio)
 {
-	return (1 << ((prio + _NUM_COOP_PRIO) & 0x1f));
+	return (1u << ((prio + _NUM_COOP_PRIO) & 0x1f));
 }
 
 /* find out the ready queue array index for a given prio */


### PR DESCRIPTION
Fixes a left shift that can cause a bit to be shifted into the sign bit, which is undefined behaviour according to the C specification.