### PR TITLE
Bluetooth: controller: Refactor to use max macro

### DIFF
--- a/subsys/bluetooth/controller/ll_sw/ctrl_internal.h
+++ b/subsys/bluetooth/controller/ll_sw/ctrl_internal.h
@@ -327,16 +327,12 @@ struct pdu_data_q_tx {
 #define LL_MEM_TXQ (sizeof(struct pdu_data_q_tx) * \
 		    (RADIO_PACKET_COUNT_TX_MAX + 2))
 
-#define LL_MEM_RX_POOL_SZ (MROUND(offsetof(struct radio_pdu_node_rx,\
-				pdu_data) + ((\
-			(PDU_AC_SIZE_MAX + PDU_AC_SIZE_EXTRA) < \
-			 (offsetof(struct pdu_data, lldata) + \
-			  RADIO_LL_LENGTH_OCTETS_RX_MAX)) ? \
-		      (offsetof(struct pdu_data, lldata) + \
-		      RADIO_LL_LENGTH_OCTETS_RX_MAX) \
-			: \
-		      (PDU_AC_SIZE_MAX + PDU_AC_SIZE_EXTRA))) * \
-			(RADIO_PACKET_COUNT_RX_MAX + 3))
+#define LL_MEM_RX_POOL_SZ (MROUND(offsetof(struct radio_pdu_node_rx, \
+					   pdu_data) + \
+				  max((PDU_AC_SIZE_MAX + PDU_AC_SIZE_EXTRA), \
+				      (offsetof(struct pdu_data, lldata) + \
+				       RADIO_LL_LENGTH_OCTETS_RX_MAX))) * \
+			   (RADIO_PACKET_COUNT_RX_MAX + 3))
 
 #define LL_MEM_RX_LINK_POOL (sizeof(void *) * 2 * ((RADIO_PACKET_COUNT_RX_MAX +\
 				4) + RADIO_CONNECTION_CONTEXT_MAX))

--- a/subsys/bluetooth/controller/ticker/ticker.c
+++ b/subsys/bluetooth/controller/ticker/ticker.c
@@ -1033,8 +1033,7 @@ static inline void ticker_job_compare_update(struct ticker_instance *instance,
 		cc = instance->ticks_current;
 		ticks_elapsed = ticker_ticks_diff_get(ctr, cc) +
 				COUNTER_CMP_OFFSET_MIN;
-		cc += ((ticks_elapsed < ticks_to_expire) ?
-		       ticks_to_expire : ticks_elapsed);
+		cc += max(ticks_elapsed, ticks_to_expire);
 		cc &= 0x00FFFFFF;
 
 		instance->trigger_set_cb(cc);


### PR DESCRIPTION
Cleaned up the use of conditional statements to use the max macro.

Fixes #6230.

Signed-off-by: David Maitland <hello@davidmaitland.me>