### PR TITLE
Add support for POSIX named semaphores.

### DIFF
--- a/arch/posix/include/posix_cheats.h
+++ b/arch/posix/include/posix_cheats.h
@@ -41,8 +41,10 @@
 #define sigevent	       zap_sigevent
 #define pthread_rwlock_obj     zap_pthread_rwlock_obj
 #define pthread_rwlockattr_t   zap_pthread_rwlockattr_t
-/* Condition variables */
+#define sem_t                  zap_sem_t
+#define mode_t                 zap_mode_t
 
+/* Condition variables */
 #define pthread_cond_init(...)        zap_pthread_cond_init(__VA_ARGS__)
 #define pthread_cond_destroy(...)     zap_pthread_cond_destroy(__VA_ARGS__)
 #define pthread_cond_signal(...)      zap_pthread_cond_signal(__VA_ARGS__)
@@ -60,6 +62,10 @@
 #define sem_timedwait(...)	      zap_sem_timedwait(__VA_ARGS__)
 #define sem_trywait(...)	      zap_sem_trywait(__VA_ARGS__)
 #define sem_wait(...)		      zap_sem_wait(__VA_ARGS__)
+#define sem_open(...)		      zap_sem_open(__VA_ARGS__)
+#define sem_close(...)		      zap_sem_close(__VA_ARGS__)
+#define sem_unlink(...)		      zap_sem_unlink(__VA_ARGS__)
+
 
 /* Mutex */
 #define pthread_mutex_init(...)       zap_pthread_mutex_init(__VA_ARGS__)

--- a/include/posix/fcntl.h
+++ b/include/posix/fcntl.h
@@ -1,0 +1,21 @@
+/*
+ * Copyright (c) 2018 Juan Manuel Torres Palma <j.m.torrespalma@gmail.com>
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef FCNTL_H_
+#define FCNTL_H_
+
+/*
+ * File or object creation flags, bitwise distinct.
+ * According to open(), should be signed integers.
+ */
+#define O_CREAT   (0x01)
+#define O_EXCL    (0x02)
+#define O_NOCTTY  (0x04)
+#define O_TRUNC   (0x08)
+
+#include <sys/types.h>
+
+#endif /* FCNTL_H_ */

--- a/include/posix/limits.h
+++ b/include/posix/limits.h
@@ -1,0 +1,17 @@
+/*
+ * Copyright (c) 2018 Juan Manuel Torres Palma <j.m.torrespalma@gmail.com>
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef LIMITS_H_
+#define LIMITS_H_
+
+/*
+ * Here come all implementation defined limits and constants. Ideally, all of
+ * them should come from CONFIG_* values.
+ */
+
+#define PATH_MAX (64)
+
+#endif /* LIMITS_H_ */

--- a/include/posix/semaphore.h
+++ b/include/posix/semaphore.h
@@ -11,7 +11,11 @@ extern "C" {
 #endif
 
 #include "sys/types.h"
+#include <fcntl.h>
+#include <limits.h>
 #include <time.h>
+
+#define SEM_FAILED (NULL)
 
 int sem_destroy(sem_t *semaphore);
 int sem_getvalue(sem_t *restrict semaphore, int *restrict value);
@@ -20,6 +24,9 @@ int sem_post(sem_t *semaphore);
 int sem_timedwait(sem_t *restrict semaphore, struct timespec *restrict abstime);
 int sem_trywait(sem_t *semaphore);
 int sem_wait(sem_t *semaphore);
+sem_t *sem_open(const char *name, int oflag, ...);
+int sem_close(sem_t *sem);
+int sem_unlink(const char *name);
 
 #ifdef __cplusplus
 }

--- a/include/posix/sys/types.h
+++ b/include/posix/sys/types.h
@@ -16,6 +16,9 @@ extern "C" {
 #ifdef CONFIG_PTHREAD_IPC
 #include <kernel.h>
 
+/* Permissions */
+typedef int mode_t;
+
 /* Thread attributes */
 typedef struct pthread_attr_t {
 	int priority;

--- a/kernel/posix/semaphore.c
+++ b/kernel/posix/semaphore.c
@@ -4,8 +4,11 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <pthread.h>
+#include <fcntl.h>
+#include <limits.h>
+#include <semaphore.h>
 #include <errno.h>
+#include <string.h>
 
 /**
  * @brief Destroy semaphore.
@@ -135,4 +138,343 @@ int sem_wait(sem_t *semaphore)
 {
 	k_sem_take(semaphore, K_FOREVER);
 	return 0;
+}
+
+
+/*
+ * Named semaphore design:
+ * - Opened table -> which semaphore is open by which thread.
+ * - Named semaphore pool -> global struct to allocate named sem.
+ */
+
+/*
+ * Used for error setting and exit
+ */
+#define SEM_ERRNO_SET(_code)      \
+	do {                      \
+		errno = (_code);  \
+		goto error;       \
+	} while (0)
+
+#define NSEM_SYS_N_MAX     (32) /* Limit of allocated nsem in system */
+#define NSEM_SYS_OPEN_MAX  (32) /* System limit of simultaneously open nsem */
+#define NSEM_PROC_OPEN_MAX  (4) /* Process limit of simultaneously open nsem */
+
+/*
+ * Private named semaphore
+ */
+struct _nsem {
+	sem_t sem;
+	const char *name;
+	bool to_free; /* Flag set by unlink */
+	bool in_use;  /* Used to check if this spot is available */
+};
+static unsigned int sem_named_n;
+static struct _nsem sem_named[NSEM_SYS_N_MAX];
+
+/*
+ * Given a sem_t value, return the _nsem object containing it.
+ * This needs to be updated if we change the order of the elements in
+ * struct _nsem.
+ */
+#define nsem_container_of(sem_t_ptr) ((struct _nsem *)sem_t_ptr)
+
+/*
+ * Opened table entries
+ */
+struct _nsem_otable {
+	struct _nsem *nsem_ptr;
+	k_tid_t proc;
+};
+static struct _nsem_otable nsem_otable[NSEM_SYS_OPEN_MAX];
+
+/*
+ * Private functions.
+ */
+
+/*
+ * Only called if we are sure it does not exist
+ */
+static inline struct _nsem *nsem_alloc(const char *name)
+{
+	struct _nsem *it, *lmt;
+
+	it = sem_named;
+	lmt = sem_named + NSEM_SYS_N_MAX;
+
+	while (it != lmt) {
+		if (!it->in_use) {
+			it->in_use = true;
+			it->to_free = false;
+			it->name = name;
+
+			return it;
+		}
+		++it;
+	}
+
+	return NULL;
+}
+
+static inline void nsem_free(struct _nsem *nsem)
+{
+	nsem->name = NULL;
+	nsem->in_use = false;
+	nsem->to_free = false;
+	sem_destroy(&nsem->sem); /* This should never fail */
+}
+
+/*
+ * NULL if not found, pointer to the object if found.
+ * In sem_named there can be several elements with the same name, but all
+ * except one must have the field "to_free" == 0, thus, the rest are waiting to
+ * be closed.
+ */
+static inline struct _nsem *nsem_find_by_name(const char *name)
+{
+	struct _nsem *it, *lmt;
+
+	it = sem_named;
+	lmt = sem_named + NSEM_SYS_N_MAX;
+
+	while (it != lmt) {
+		if (!strncmp(name, it->name, PATH_MAX) &&
+		    it->in_use && !it->to_free)
+			return it;
+		++it;
+	}
+
+	return NULL;
+}
+
+static inline struct _nsem_otable *nsem_otable_alloc(k_tid_t proc,
+						     struct _nsem *nsem)
+{
+	struct _nsem_otable *it, *lmt;
+
+	it = nsem_otable;
+	lmt = nsem_otable + NSEM_SYS_N_MAX;
+
+	while (it != lmt) {
+		if (!it->nsem_ptr) {
+			it->nsem_ptr = nsem;
+			it->proc = proc;
+
+			return it;
+		}
+		++it;
+	}
+
+	return NULL;
+}
+
+static inline void nsem_otable_free(struct _nsem_otable *ote)
+{
+	ote->nsem_ptr = NULL; /* Flag to mark as non used */
+}
+
+/*
+ * Find in opened table an entry matching with arguments.
+ * Returns NULL if not found, or invalid arguments.
+ */
+static inline struct _nsem_otable *nsem_otable_find(k_tid_t proc,
+						    struct _nsem *nsem)
+{
+	struct _nsem_otable *it, *lmt;
+
+	if (!nsem)
+		return NULL;
+
+	it = nsem_otable;
+	lmt = nsem_otable + NSEM_SYS_OPEN_MAX;
+
+	while (it != lmt) {
+		if (it->nsem_ptr == nsem && it->proc == proc) {
+			return it;
+		}
+		++it;
+	}
+
+	return 0;
+}
+
+static inline unsigned int nsem_otable_count_refs(struct _nsem *nsem)
+{
+	struct _nsem_otable *it, *lmt;
+	unsigned int count = 0;
+
+	if (nsem == NULL) {
+		return 0;
+	}
+
+	it = nsem_otable;
+	lmt = nsem_otable + NSEM_SYS_OPEN_MAX;
+
+	while (it != lmt) {
+		if (it->nsem_ptr == nsem) {
+			++count;
+		}
+		++it;
+	}
+
+	return count;
+}
+
+static inline unsigned nsem_otable_count_opened(k_tid_t proc)
+{
+	struct _nsem_otable *it, *lmt;
+	unsigned int count = 0;
+
+	it = nsem_otable;
+	lmt = nsem_otable + NSEM_SYS_OPEN_MAX;
+
+	while (it != lmt) {
+		if (it->proc == proc) {
+			++count;
+		}
+		++it;
+	}
+
+	return count;
+}
+
+/*
+ * Flags control if the semaphore is created or simply retrieved
+ * O_CREAT: Creates a new semaphore with mode_t permissions and count.
+ * O_EXCL:  Passed along with O_CREAT, fails if a semaphore with name already
+ *          exists.
+ *
+ * This function is atomic since a few variables are shared.
+ */
+sem_t *sem_open(const char *name, int oflag, ...)
+{
+	struct _nsem *nsem;
+	unsigned int value;
+	unsigned int key;
+	va_list al;
+	k_tid_t curr;
+
+	key = irq_lock();
+
+	nsem = nsem_find_by_name(name);
+	curr = k_current_get();
+
+	/*
+	 * Multiple calls to sem_open() by the same process
+	 * should be successful.
+	 */
+	if (nsem_otable_find(curr, nsem)) { /* Deals with NULL */
+		goto success;
+	}
+
+	if (sem_named_n == NSEM_SYS_N_MAX) {
+		SEM_ERRNO_SET(ENFILE);
+	}
+
+	if (nsem_otable_count_opened(curr) == NSEM_PROC_OPEN_MAX) {
+		SEM_ERRNO_SET(EMFILE);
+	}
+
+	/* Check if this named semaphore already exists */
+	if (nsem) {
+		if (oflag & O_EXCL) {
+			SEM_ERRNO_SET(EEXIST);
+		}
+	} else {
+		if (!(oflag & O_CREAT)) {
+			SEM_ERRNO_SET(ENOENT);
+		}
+
+		va_start(al, oflag);
+		va_arg(al, mode_t); /* permissions not used */
+		value = va_arg(al, unsigned int);
+		va_end(al);
+
+		nsem = nsem_alloc(name);
+		sem_init(&nsem->sem, 0, value);
+		sem_named_n++;
+	}
+
+	/* Should always be successful, we checked the size before */
+	nsem_otable_alloc(curr, nsem);
+
+success:
+	irq_unlock(key);
+	return &nsem->sem;
+
+error:
+	irq_unlock(key);
+	return SEM_FAILED;
+}
+
+/*
+ * Close can destroy a semaphore too if sem_unlink has been called on that sem
+ * before and it's the last reference to it.
+ */
+int sem_close(sem_t *sem)
+{
+	struct _nsem_otable *ote;
+	struct _nsem *nsem;
+	unsigned int key;
+	k_tid_t curr;
+
+	key = irq_lock();
+
+
+	/* This is safe since we don't read or write nsem */
+	nsem = nsem_container_of(sem);
+	curr = k_current_get();
+	ote = nsem_otable_find(curr, nsem);
+
+	/* If ote is set, nsem is legit so we can use it */
+	if (!ote) {
+		SEM_ERRNO_SET(EINVAL);
+	}
+
+	/* Dereference semaphore */
+	nsem_otable_free(ote);
+	if (nsem->to_free && !nsem_otable_count_refs(nsem)) {
+		nsem_free(nsem);
+		sem_named_n--;
+	}
+
+	irq_unlock(key);
+	return 0;
+
+error:
+	irq_unlock(key);
+	return -1;
+}
+
+/*
+ * Free a semaphore if no references left.
+ * Otherwise, mark it as pending to free.
+ */
+int sem_unlink(const char *name)
+{
+	struct _nsem *nsem;
+	unsigned int key, refs;
+
+	key = irq_lock();
+	nsem = nsem_find_by_name(name);
+
+	if (!nsem) {
+		SEM_ERRNO_SET(ENOENT);
+	}
+
+	refs = nsem_otable_count_refs(nsem);
+
+	if (!refs) {
+		nsem_free(nsem);
+		sem_named_n--;
+	} else {
+		nsem->to_free = true;
+	}
+
+	irq_unlock(key);
+	return 0;
+
+error:
+	irq_unlock(key);
+	return -1;
 }

--- a/tests/posix/semaphore/src/sem.c
+++ b/tests/posix/semaphore/src/sem.c
@@ -54,8 +54,132 @@ static void test_sema(void)
 	zassert_false(sem_destroy(&sema), "sema is not destroyed\n");
 }
 
+/*
+ * Test for named semaphores
+ */
+
+#define N_THRD (3)
+#define SSZ (64)
+
+const char sem_name[] = "/shared_sem";
+int shared_counter = 0;
+
+/*
+ * Flags to track the status of child threads
+ */
+sem_t *ssem_value[N_THRD];
+unsigned int status_flag_open[N_THRD];
+unsigned int status_flag_count[N_THRD];
+unsigned int status_flag_close[N_THRD];
+unsigned int unlinked = 0;
+
+/*
+ * Simple test:
+ * - all child threads receive the same semaphore
+ * - can be used for shared variable access
+ * - can be destroyed properly
+ */
+void *child_code(void *vid)
+{
+	unsigned id = (unsigned) vid;
+	sem_t *ssem;
+	int rv;
+
+	/* Check open */
+	ssem = sem_open(sem_name, O_CREAT, 0666, 1);
+	ssem_value[id] = ssem;
+	status_flag_open[id] = 1;
+
+	/* Check correct locking and counter */
+	rv = sem_wait(ssem);
+	shared_counter++;
+	rv = sem_post(ssem);
+	status_flag_count[id] = 1;
+
+	/* Check close */
+	rv = sem_close(ssem);
+	status_flag_close[id] = 1;
+
+	/* Thread 0 takes care of unlinking */
+	if (id == 0) {
+		rv = sem_unlink(sem_name);
+		unlinked = 1;
+	}
+
+	return NULL;
+}
+
+K_THREAD_DEFINE(t0, SSZ, child_code, (void *)0, NULL, NULL, K_USER,
+		0, K_FOREVER);
+K_THREAD_DEFINE(t1, SSZ, child_code, (void *)1, NULL, NULL, K_USER,
+		0, K_FOREVER);
+K_THREAD_DEFINE(t2, SSZ, child_code, (void *)2, NULL, NULL, K_USER,
+		0, K_FOREVER);
+
+/*
+ * Checks if a status array is all set to 1.
+ */
+static inline bool check_barrier(unsigned int status[N_THRD])
+{
+	for (int i = 0; i < N_THRD; ++i) {
+		if (status[i] == 0)
+			return false;
+	}
+
+	return true;
+}
+
+/*
+ * Checks if the semaphore contains the same value for all threads.
+ */
+static inline bool check_sem(sem_t *sarr[N_THRD])
+{
+	for (int i = 1; i < N_THRD; ++i) {
+		if (sarr[0] != sarr[i])
+			return false;
+	}
+
+	return true;
+}
+
+
+/*
+ * This function behaves as a checker, and taking care all threads pass all
+ * checks.
+ * TODO: add timeout.
+ */
+static void test_named_semaphores(void)
+{
+	/* Launch threads */
+	k_thread_start(t0);
+	k_thread_start(t1);
+	k_thread_start(t2);
+
+	/* Wait for all to open and check they received the same object */
+	while (!check_barrier(status_flag_open)) {
+		k_sleep(100);
+	}
+	zassert_false(!check_sem(ssem_value),
+		      "Wrong in shared semaphore open");
+
+	/* Check that there is no race condition in variable rw op */
+	while (!check_barrier(status_flag_count)) {
+		k_sleep(100);
+	}
+	zassert_equal(shared_counter, N_THRD, "Shared variable access failed");
+
+	while (!check_barrier(status_flag_close)) {
+		k_sleep(100);
+	}
+
+	while (!unlinked) {
+		k_sleep(100);
+	}
+}
+
 void test_main(void)
 {
-	ztest_test_suite(test_sem, ztest_unit_test(test_sema));
+	ztest_test_suite(test_sem, ztest_unit_test(test_sema),
+			 ztest_unit_test(test_named_semaphores));
 	ztest_run_test_suite(test_sem);
 }


### PR DESCRIPTION
Implements `sem_open()`, `sem_close()` and `sem_unlink()` to support named semaphores. With the addition of this functions, POSIX semaphores support is complete.

In addition, a test case is included to check correct POSIX behaviour.