### PR TITLE
drivers: add pinctrl device interface

### DIFF
--- a/doc/api/io_interfaces.rst
+++ b/doc/api/io_interfaces.rst
@@ -27,6 +27,9 @@ DMA Interface
 GPIO Interface
 **************
 
+.. doxygengroup:: gpio_interface_pin_defs
+   :project: Zephyr
+
 .. doxygengroup:: gpio_interface
    :project: Zephyr
 
@@ -56,6 +59,18 @@ PWM Interface
 *************
 
 .. doxygengroup:: pwm_interface
+   :project: Zephyr
+
+Pinctrl Interface
+*****************
+
+.. doxygengroup:: pinctrl_interface_pin_configurations
+   :project: Zephyr
+
+.. doxygengroup:: pinctrl_interface_functions
+   :project: Zephyr
+
+.. doxygengroup:: pinctrl_interface
    :project: Zephyr
 
 Pinmux Interface

--- a/doc/devices/drivers/drivers.rst
+++ b/doc/devices/drivers/drivers.rst
@@ -41,6 +41,23 @@ are listed below.
     Certain implementations of this device driver do not generate sequences of
     values that are truly random.
 
+Non Standard Drivers
+********************
+
+These device drivers are not present on all supported board configurations.
+
+* **General purpose input output**: The :ref:`device_drivers_gpio` deals with:
+
+  - input and output on ports and pins,
+  - interrupt generation on pins,
+  - configuration of ports and pins.
+
+* **Pin controller**: The :ref:`device_drivers_pinctrl` deals with:
+
+  - enumerating and naming controllable pins,
+  - multiplexing of pins,
+  - configuration of pins,
+
 Synchronous Calls
 *****************
 
@@ -330,3 +347,13 @@ returned on failure.  See
 https://github.com/zephyrproject-rtos/zephyr/wiki/Naming-Conventions#return-codes
 for details about this.
 
+Further reading
+***************
+
+More information on specific device drivers can be found in the following subsections:
+
+.. toctree::
+   :maxdepth: 1
+
+   gpio/gpio.rst
+   pinctrl/pinctrl.rst

--- a/doc/devices/drivers/gpio/gpio.rst
+++ b/doc/devices/drivers/gpio/gpio.rst
@@ -1,0 +1,334 @@
+.. _device_drivers_gpio:
+
+GPIO (general purpose input output) device driver
+#################################################
+
+The **general pupose input output** device driver deals with:
+
+- input and output on **ports** and **pins**,
+- interrupt generation on **pins**,
+- configuration of **ports** and **pins**
+
+.. contents::
+   :depth: 2
+   :local:
+   :backlinks: top
+
+General purpose input output concepts
+*************************************
+
+A **GPIO device driver**
+    provides access to a GPIO *port*.
+
+A GPIO **port**
+    is a group of *pins* arranged in a group and controllable as a group.
+
+A **pin**
+    is the physical input/ output line of a chip. The pin
+    numberspace is local [#pin_number_space]_ to a *port*. This
+    pin space may be sparse - i.e. there may be gaps in the space with numbers
+    where no pin exists.
+
+GPIO device driver
+******************
+
+The GPIO device driver provides applications and other drivers to:
+
+- read from a GPIO port or port pin,
+- write to GPIO port or port pin,
+- get signalled on GPIO port or port pin changes or interrupts.
+
+Application programming interface
+=================================
+
+The GPIO device driver API is provided by :file:`include/gpio.h`.
+
+The definition of GPIO pins differs slightly in case a PINCTRL device is
+activated by ``CONFIG_PINCTRL``. Here generic pin defines are provided
+for GPIO port pins. The pin defines allow to combine them to define
+a set of pins.
+
+If no PINCTRL device is activated the GPIO interface uses sequential
+pin numbers that can not be combined to define a set of pins. This
+legacy API is to be completely replaced by the PINCTRL variant when
+all GPIO drivers have been migrated to use the pin controller device
+for pin configuration.
+
+Control properties
+==================
+
+Pins
+----
+
+The pins are defined in the generic GPIO include file
+:file:`include/gpio_common.h` (eg. :c:macro:`GPIO_PORT_PIN0`).
+
+The maximum number of pins managed by a GPIO port device driver is 32.
+
+Pin Configuration
+=================
+
+Pin configuration by the GPIO pin configuration interface is deprecated.
+Please use the PINCTRL pin configuration interface instead.
+
+A generic set of GPIO port pin configuration properties is defined in
+:file:`include/gpio.h`.
+The GPIO pin configuration properties can be mapped to the generic pin
+configuration properties of the PINCTRL device that controls the GPIO
+port pins. A GPIO driver that is using the PINCTRL device to configure
+the pins is just doing this.
+
+**GPIO_DIR_IN**
+    GPIO pin to be input.
+
+    PINCTRL pin configuration property:
+
+    - :c:macro:`PINCTRL_CONFIG_INPUT_ENABLE`,
+    - :c:macro:`PINCTRL_CONFIG_OUTPUT_DISABLE`
+
+**GPIO_DIR_OUT**
+    GPIO pin to be output.
+
+    PINCTRL pin configuration property:
+
+    - :c:macro:`PINCTRL_CONFIG_INPUT_ENABLE`,
+    - :c:macro:`PINCTRL_CONFIG_OUTPUT_ENABLE`
+
+**GPIO_POL_NORMAL**
+    GPIO pin polarity is normal.
+
+    PINCTRL pin configuration property:
+
+    - :c:macro:`PINCTRL_CONFIG_OUTPUT_HIGH`
+
+**GPIO_POL_INV**
+    GPIO pin polarity is inverted.
+
+    PINCTRL pin configuration property:
+
+    - :c:macro:`PINCTRL_CONFIG_OUTPUT_LOW`
+
+**GPIO_PUD_NORMAL**
+    GPIO pin to have no pull-up or pull-down.
+
+    PINCTRL pin configuration property:
+
+    - :c:macro:`PINCTRL_CONFIG_BIAS_DISABLE`
+
+**GPIO_PUD_PULL_UP**
+    Pull-up GPIO pin.
+
+    PINCTRL pin configuration property:
+
+    - :c:macro:`PINCTRL_CONFIG_BIAS_PULL_UP`
+
+**GPIO_PUD_PULL_DOWN**
+    Pull-down GPIO pin.
+
+    PINCTRL pin configuration property:
+
+    - :c:macro:`PINCTRL_CONFIG_BIAS_PULL_DOWN`
+
+**GPIO_DS_DFLT_LOW**
+    Default drive strength when GPIO pin output is low.
+
+    PINCTRL pin configuration property:
+
+    - :c:macro:`PINCTRL_CONFIG_DRIVE_STRENGTH_DEFAULT`
+
+**GPIO_DS_DFLT_HIGH**
+    Default drive strength when GPIO pin output is high.
+
+    PINCTRL pin configuration property:
+
+    - :c:macro:`PINCTRL_CONFIG_DRIVE_STRENGTH_DEFAULT`
+
+**GPIO_DS_ALT_LOW**
+    Alternative drive strength when GPIO pin output is low.
+
+    PINCTRL pin configuration property:
+
+    - :c:macro:`PINCTRL_CONFIG_DRIVE_STRENGTH_7`
+
+**GPIO_DS_ALT_HIGH**
+    Alternative drive strength when GPIO pin output is high.
+
+    PINCTRL pin configuration property:
+
+    - :c:macro:`PINCTRL_CONFIG_DRIVE_STRENGTH_7`
+
+**GPIO_DS_DISCONNECT_LOW**
+    Disconnect pin when GPIO pin output is low.
+
+    PINCTRL pin configuration property:
+
+    - :c:macro:`PINCTRL_CONFIG_DRIVE_OPEN_SOURCE`
+
+**GPIO_DS_DISCONNECT_HIGH**
+    Disconnect pin when GPIO pin output is high.
+
+    PINCTRL pin configuration property:
+
+    - :c:macro:`PINCTRL_CONFIG_DRIVE_OPEN_DRAIN`
+
+Signalling Configuration
+========================
+
+Pin signalling can be configured by the general GPIO configuration interface.
+
+:c:func:`gpio_pin_configure`
+    Set the configuration of a pin.
+
+A generic set of GPIO port pin signalling properties is defined in
+:file:`include/gpio.h`. A GPIO driver may only support a subset of the
+signalling properties.
+
+**GPIO_INT**
+    GPIO pin to trigger interrupt.
+
+**GPIO_INT_ACTIVE_LOW**
+    GPIO pin trigger on level low or falling edge.
+
+**GPIO_INT_ACTIVE_HIGH**
+    GPIO pin trigger on level high or rising edge.
+
+**GPIO_INT_CLOCK_SYNC**
+    GPIO pin trigger to be synchronized to clock pulses.
+
+**GPIO_INT_DEBOUNCE**
+    Enable GPIO pin trigger debounce.
+
+**GPIO_INT_LEVEL**
+    Do Level trigger.
+
+**GPIO_INT_EDGE**
+    Do Edge trigger.
+
+**GPIO_INT_DOUBLE_EDGE**
+    Interrupt triggers on both rising and falling edge.
+
+
+GPIO device tree support
+************************
+
+Nodes
+=====
+
+GPIO Controller Node
+--------------------
+
+The GPIO device is defined by a GPIO controller node.
+
+Required properties are:
+
+- gpio-controller: Indicates this device is a GPIO controller
+- compatible:
+- label: Should be a name string
+
+
+Interaction with the PINCTRL device driver
+==========================================
+
+To enable a pin controller to report the pins that are associated to a GPIO
+device the gpio-ranges property shall be set in the device tree. Also the label
+property shall be set and used as device name.
+
+The gpio-ranges property is of the form:
+
+.. code-block:: text
+
+    gpio-ranges = <&[pin controller] [pin number in GPIO pin number space]
+                                     [pin number in pin controller number space]
+                                     [number of pins]>,
+                                     /* ... */
+                                     ;
+
+A GPIO port definition in the device tree may look like:
+
+.. code-block:: DTS
+
+    pinctrl: pin-controller@48000000 {
+        pin-controller;
+        /* ... */
+    };
+
+    gpioa: gpio@40020000 {
+        gpio-controller;
+        compatible = "st,stm32-gpio-pinctrl";
+        #gpio-cells = <2>;
+        reg = <0x40020000 0x400>;
+        label = "STM32_GPIOA";
+        gpio-ranges = <&pinctrl GPIO_PORT_PIN0 PINCTRL_STM32_PINA0 16>;
+    };
+
+
+GPIO device driver implementation
+*********************************
+
+Driver configuration information comes from three sources:
+
+- autoconf.h (Kconfig)
+- generated_dts_board.h (device tree)
+- soc.h
+
+Driver configuration by autoconf
+================================
+
+See :ref:`configuration` for the the full set of Kconfig symbols that are available.
+Specific to the GPIO driver are:
+
+:c:macro:`CONFIG_GPIO`
+    Enable GPIO driver.
+
+Driver configuration by device tree
+===================================
+
+For a GPIO controller node the following information is extracted from the device tree
+and provided in :file:`generated_dts_board.h`.
+
+The general device information for GPIO controllers:
+
+:c:macro:`SOC_GPIO_CONTROLLER_COUNT`
+    Number of GPIO controllers that are activated. All nodes that contain a
+    gpio-controller directive are counted.
+
+:c:macro:`SOC_GPIO_CONTROLLER_0` ...
+    The label prefix of GPIO controller 0 ... (e.g. 'ST_STM32_GPIO_PINCTRL_48000000').
+    The define is generated if a gpio-controller directive is given in the node.
+
+General information that is extracted for every device type:
+
+**LABEL**
+
+**BASE_ADDRESS**
+
+**SIZE**
+
+**COMPATIBLE_COUNT**
+
+**COMPATIBLE_0_ID**
+
+The specific device information for GPIO controllers:
+
+**PINCTRL_CONTROLLER**
+    For all pin controllers that are referenced in a pinctrl-x directive
+    PINCTRL_CONTROLLER defines are generated.
+
+**PINCTRL**
+    For all subnodes of pin configurations referenced by active GPIO nodes
+    - pinctrl-x(&xxx, pinconf_a, ...) - PINCTRL defines are generated.
+    The pinctrl references the *PINCTRL_CONTROLLER* given in the pinctrl-x
+    directive. The pinctrl also references the *PINCTRL_STATE* the pin
+    controller associates to this pinctrl.
+
+Driver configuration by soc.h
+=============================
+
+:file:`soc.h` may contain driver relevant information such as HAL header files.
+
+Design Rationales
+*****************
+
+.. [#pin_number_space] GPIO uses a **local pin number space** instead of
+   a global space to allow for object encapsulation.
+

--- a/doc/devices/drivers/pinctrl/pinctrl.rst
+++ b/doc/devices/drivers/pinctrl/pinctrl.rst
@@ -1,0 +1,1257 @@
+..
+    Copyright (c) 2018 Bobby Noelte
+    SPDX-License-Identifier: Apache-2.0
+
+.. _device_drivers_pinctrl:
+
+PINCTRL (pin controller) device driver
+######################################
+
+The **pin controller** device driver:
+
+- enumerates controllable **pins**,
+- multiplexes **pins**, and
+- configures **pins**.
+
+The Zephyr *pin controller* follows the concepts of the Linux PINCTRL
+(PIN CONTROL) subsystem linux_pinctrl_. The following documentation
+provides a summary of the concepts and definitions available in detail
+in the Linux documentation ( linux_pinctrl_, linux_pinctrl_bindings_ ).
+The Zephyr *pin controller* does not provide the full scope of the Linux
+PINCTRL subsystem. Also the PINCTRL interface is specific to Zephyr and
+not compatible to the Linux PINCTRL interface. However the device tree
+bindings are kept compatible to the linux_pinctrl_bindings_ as much as
+possible.
+
+.. contents::
+   :depth: 2
+   :local:
+   :backlinks: top
+
+Pin controller concepts
+***********************
+
+A **PINCTRL device driver**
+    provides access to the *pin controller*.
+
+A **pin controller**
+    is a set of hardware resources, usually accessed via registers, that
+    can control *pins*. It may be able to multiplex, bias, set load capacitance,
+    set drive strength, etc. for individual *pins* or *groups* of pins.
+    There may be several pin controllers in a system which control only a set of
+    the available *pins*.
+
+A **pin**
+    is the physical input/output line of a chip. Pins are denoted by u16_t
+    integer numbers. The pin numberspace is local [#pin_number_space]_ to
+    a *pin controller*. This pin space may be sparse - i.e. there may be gaps
+    in the space with numbers where no pin exists.
+
+A pins **group**
+    is a set of *pins* that can be multiplexed to a
+    common *function*. Groups are denoted by u16_t integer numbers. The group
+    numberspace is local to each *pin controller*. The group number space may
+    be sparse or even non-existing.
+
+A pinctrl **state**
+    defines the *pin configuration* and the *pin multiplexing* to a *function*
+    of a *group* of *pins*. Pinctrl states are denoted by u16_t integer numbers.
+    The pinctrl state number space is local to a *pin controller*.
+
+A **function**
+    is a logical or physical function block of a chip. Common functions are
+    for example GPIO, USART, SPI, I2C, USB, ADC. Functions are
+    denoted by u16_t integer numbers. The function number space is local to a
+    *pin controller*. It may be sparse - a *pin controller* may not be able to
+    multiplex (aka. connect) a *pin* or a *group* of pins to a function block.
+
+**Pin configuration**
+    allows to control the pins properties, mostly the electrical ones, by software.
+    For example you may be able to make an output pin high impedance,
+    or "tristate" meaning it is effectively disconnected. You may be able to connect an
+    input pin to VDD or GND using a certain resistor value - pull up and pull down - so
+    that the pin has a stable value when nothing is driving the rail it is connected to,
+    or when it's unconnected.
+
+**Pin multiplexing**
+    allows to control the connection between *pins* and *functions* by software.
+
+**Pin state setting**
+    is the combination of *pin configuration* and *pin multiplexing* for a
+    *group* of *pins*.
+
+PINCTRL device driver
+*********************
+
+The PINCTRL device driver provides applications and other drivers access:
+
+- to the drivers control properties sich as pins, groups, pinctrl states,
+  and functions,
+- to pin configuration,
+- to pin multiplexing, and
+- to pin state setting.
+
+The driver also provides initial setup of pin configuration and pin multiplexing
+controlled by the device tree pinctrl state information.
+
+Application programming interface
+=================================
+
+The PINCTRL device driver API is provided by :file:`pinctrl.h`.
+
+The application programming interface is available in two extension stages:
+
+**Basic interface**
+
+Pin control, and initial pin setup at startup using device tree information.
+
+.. [PINCTRL_BASIC] Basic interface
+
+**Extended interface with run time access to device tree information**
+
+Extended pin control and pin setup at run time using device tree information.
+The extended functionality is enabled by ``CONFIG_PINCTRL_RUNTIME_DTS``.
+
+Implementations of the extended interface usually need more FLASH and SRAM
+memory than needed by the basic interface.
+
+.. [PINCTRL_RUNTIME_DTS] Extended interface
+
+Control properties
+==================
+
+Pins
+----
+
+The pins are defined by the specific device driver in the associated pinctrl
+device tree bindings file (e.g. :file:`include/dt-bindings/pinctrl/pinctrl_stm32.h`
+for the STM32 PINCTRL device driver).
+
+The number of pins managed by a PINCTRL device driver may be retrieved by:
+
+:c:func:`pinctrl_get_pins_count()`
+    Get the number of pins selectable by this pin controller.
+    [PINCTRL_BASIC]_ [PINCTRL_RUNTIME_DTS]_
+
+Groups
+------
+
+The groups are defined by the device tree. Every pinctrl state of an active
+node sets up a group with all the pins this pinctrl state controls. There may
+be additional groups not covered by an active node's pinctrl state.
+
+The PINCTRL device driver has a mechanism for enumerating groups of pins and
+retrieving the actual enumerated pins that are part of a certain group.
+
+:c:func:`pinctrl_get_groups_count()`
+    Get the number of groups selectable by this pin controller.
+    [PINCTRL_RUNTIME_DTS]_
+
+:c:func:`pinctrl_get_group_pins()`
+    Get the pins that are in a pin group.
+    [PINCTRL_RUNTIME_DTS]_
+
+The pin group associated with a certain device can be retrieved also. Example
+for a group named "reset" of the device device_dev:
+
+.. code-block:: C
+
+    u16_t function;
+    u16_t group;
+
+    pinctrl_get_device_function(pinctrl_dev, device_dev, &function);
+    pinctrl_get_function_group(pinctrl_dev, function, "reset", &group);
+
+States
+------
+
+The states are defined by the device tree. Every pinctrl-x directive of an
+active node defines a pinctrl state.
+
+The PINCTRL device driver has a mechanism for enumerating pinctrl states and
+retrieving the pin group that is associated to a certain pinctrl state.
+
+:c:func:`pinctrl_get_states_count()`
+    Get the number of states selectable by this pin controller.
+    [PINCTRL_RUNTIME_DTS]_
+
+:c:func:`pinctrl_get_state_group()`
+    Get the group of pins controlled by the pinctrl state.
+    [PINCTRL_RUNTIME_DTS]_
+
+A pinctrl state associated with a certain device can be retrieved also.
+Example for a state named "reset" of the device device_dev:
+
+.. code-block:: C
+
+    u32_t function;
+    u16_t state;
+
+    pinctrl_get_device_function(pinctrl_dev, device_dev, &function);
+    pinctrl_get_function_state(pinctrl_dev, function, "reset", &state);
+
+Functions
+---------
+
+Functions may either denote a device or a low level hardware pinmux control.
+The device functions have function numbers in the range
+[0 ... (:c:macro:`PINCTRL_FUNCTION_PINMUX_BASE` - 1)]. Hardware pinmux function
+numbers start at :c:macro:`PINCTRL_FUNCTION_PINMUX_BASE`.
+
+There are two convenience functions to evaluate the type of a function:
+
+:c:func:`pinctrl_is_device_function()`
+    Is the function a client device multiplex control.
+    [PINCTRL_BASIC]_ [PINCTRL_RUNTIME_DTS]_
+
+:c:func:`pinctrl_is_pinmux_function()`
+    Is the function a hardware pinmux control.
+    [PINCTRL_BASIC]_ [PINCTRL_RUNTIME_DTS]_
+
+The function number that denotes a device can be retrieved by
+:c:func:`pinctrl_get_device_function()`.
+
+The function numbers to be used for hardware pinmux control are usually defined
+by the specific device driver in the associated pinctrl device tree bindings
+(e.g. :file:`include/dt-bindings/pinctrl/pinctrl_{driver}.h`).
+
+The PINCTRL device driver allows to retrieve the number of functions supported
+and the states that are associated to a function. Also the groups of pins that
+can be muxed to a function can be fetched.
+
+:c:func:`pinctrl_get_functions_count()`
+    Get the number of selectable functions of this pin controller.
+    [PINCTRL_RUNTIME_DTS]_
+
+:c:func:`pinctrl_get_function_group()`
+    Get the pin group with given name that can be muxed to the function.
+    [PINCTRL_RUNTIME_DTS]_
+
+:c:func:`pinctrl_get_function_groups()`
+    Get the pin groups that can be muxed to the function.
+    [PINCTRL_RUNTIME_DTS]_
+
+:c:func:`pinctrl_get_function_state()`
+    Get the pinctrl state with given name for the function.
+    [PINCTRL_RUNTIME_DTS]_
+
+:c:func:`pinctrl_get_function_states()`
+    Get the pinctrl states that can be set for the function.
+    [PINCTRL_RUNTIME_DTS]_
+
+:c:func:`pinctrl_get_device_function()`
+    Get the function that is associated to a device.
+    [PINCTRL_RUNTIME_DTS]_
+
+GPIO ranges
+-----------
+
+The PINCTRL device driver allows to map between the pin controller's
+pin number space and the GPIO device pin number space.
+
+:c:func:`pinctrl_get_gpio_range()`
+    Get the pin controller pin number and pin mapping for a GPIO pin.
+    [PINCTRL_BASIC]_ [PINCTRL_RUNTIME_DTS]_
+
+Pin Configuration
+=================
+
+:c:func:`pinctrl_config_get()`
+    Get the configuration of a pin.
+    [PINCTRL_BASIC]_ [PINCTRL_RUNTIME_DTS]_
+
+:c:func:`pinctrl_config_set()`
+    Configure a pin.
+    [PINCTRL_BASIC]_ [PINCTRL_RUNTIME_DTS]_
+
+:c:func:`pinctrl_config_group_get()`
+    Get the configuration of a group of pins.
+    [PINCTRL_RUNTIME_DTS]_
+
+:c:func:`pinctrl_config_group_set()`
+    Configure a group of pins.
+    [PINCTRL_RUNTIME_DTS]_
+
+A generic set of pin configuration properties is defined in
+:file:`include/pinctrl.h`.
+A pinctrl device driver may only support a subset of these
+pin configuration properties.
+
+:c:macro:`PINCTRL_CONFIG_BIAS_DISABLE`
+    Disable any pin bias.
+
+:c:macro:`PINCTRL_CONFIG_BIAS_HIGH_IMPEDANCE`
+    High impedance mode ("third-state", "floating").
+
+:c:macro:`PINCTRL_CONFIG_BIAS_BUS_HOLD`
+    Latch weakly.
+
+:c:macro:`PINCTRL_CONFIG_BIAS_PULL_UP`
+    Pull up the pin.
+
+:c:macro:`PINCTRL_CONFIG_BIAS_PULL_DOWN`
+    Pull down the pin.
+
+:c:macro:`PINCTRL_CONFIG_BIAS_PULL_PIN_DEFAULT`
+    Use pin default pull state.
+
+:c:macro:`PINCTRL_CONFIG_DRIVE_PUSH_PULL`
+    Drive actively high and low.
+
+:c:macro:`PINCTRL_CONFIG_DRIVE_OPEN_DRAIN`
+    Drive with open drain (open collector).
+    Output can only sink current.
+
+:c:macro:`PINCTRL_CONFIG_DRIVE_OPEN_SOURCE`
+    Drive with open source (open emitter).
+    Output can only source current.
+
+:c:macro:`PINCTRL_CONFIG_DRIVE_STRENGTH_DEFAULT`
+    Drive with default drive strength.
+
+:c:macro:`PINCTRL_CONFIG_DRIVE_STRENGTH_1`
+    Drive with minimum drive strength.
+
+:c:macro:`PINCTRL_CONFIG_DRIVE_STRENGTH_2`
+    Drive with minimum to medium drive strength.
+
+:c:macro:`PINCTRL_CONFIG_DRIVE_STRENGTH_3`
+    Drive with minimum to medium drive strength.
+
+:c:macro:`PINCTRL_CONFIG_DRIVE_STRENGTH_4`
+    Drive with medium drive strength.
+
+:c:macro:`PINCTRL_CONFIG_DRIVE_STRENGTH_5`
+    Drive with medium to maximum drive strength.
+
+:c:macro:`PINCTRL_CONFIG_DRIVE_STRENGTH_6`
+    Drive with medium to maximum drive strength.
+
+:c:macro:`PINCTRL_CONFIG_DRIVE_STRENGTH_7`
+    Drive with maximum drive strength.
+
+:c:macro:`PINCTRL_CONFIG_INPUT_ENABLE`
+    Enable the pins input.
+    Does not affect the pin's ability to drive output.
+
+:c:macro:`PINCTRL_CONFIG_INPUT_DISABLE`
+    Disable the pins input.
+    Does not affect the pin's ability to drive output.
+
+:c:macro:`PINCTRL_CONFIG_INPUT_SCHMITT_ENABLE`
+    Enable schmitt trigger mode for input.
+
+:c:macro:`PINCTRL_CONFIG_INPUT_SCHMITT_DISABLE`
+    Disable schmitt trigger mode for input.
+
+:c:macro:`PINCTRL_CONFIG_INPUT_DEBOUNCE_NONE`
+    Do not debounce input.
+
+:c:macro:`PINCTRL_CONFIG_INPUT_DEBOUNCE_SHORT`
+    Debounce input with short debounce time.
+
+:c:macro:`PINCTRL_CONFIG_INPUT_DEBOUNCE_MEDIUM`
+    Debounce input with medium debounce time.
+
+:c:macro:`PINCTRL_CONFIG_INPUT_DEBOUNCE_LONG`
+    Debounce input with long debounce time.
+
+:c:macro:`PINCTRL_CONFIG_POWER_SOURCE_DEFAULT`
+    Select default power source for pin.
+
+:c:macro:`PINCTRL_CONFIG_POWER_SOURCE_1`
+    Select power source #1 for pin.
+
+:c:macro:`PINCTRL_CONFIG_POWER_SOURCE_2`
+    Select power source #2 for pin.
+
+:c:macro:`PINCTRL_CONFIG_POWER_SOURCE_3`
+    Select power source #3 for pin.
+
+:c:macro:`PINCTRL_CONFIG_LOW_POWER_ENABLE`
+    Enable low power mode.
+
+:c:macro:`PINCTRL_CONFIG_LOW_POWER_DISABLE`
+    Disable low power mode.
+
+:c:macro:`PINCTRL_CONFIG_OUTPUT_ENABLE`
+    Enable output on pin.
+    Such as connecting the output buffer to the drive stage.
+    Does not set the output drive.
+
+:c:macro:`PINCTRL_CONFIG_OUTPUT_DISABLE`
+    Disable output on pin.
+    Such as disconnecting the output buffer from the drive stage.
+    Does not reset the output drive.
+
+:c:macro:`PINCTRL_CONFIG_OUTPUT_LOW`
+    Set output to active low.
+    A "1" in the output buffer drives the output to low level.
+
+:c:macro:`PINCTRL_CONFIG_OUTPUT_HIGH`
+    Set output to active high.
+    A "1" in the output buffer drives the output to high level.
+
+:c:macro:`PINCTRL_CONFIG_SLEW_RATE_SLOW`
+    Select slow slew rate.
+
+:c:macro:`PINCTRL_CONFIG_SLEW_RATE_MEDIUM`
+    Select medium slew rate.
+
+:c:macro:`PINCTRL_CONFIG_SLEW_RATE_FAST`
+    Select fast slew rate.
+
+:c:macro:`PINCTRL_CONFIG_SLEW_RATE_HIGH`
+    Select high slew rate.
+
+:c:macro:`PINCTRL_CONFIG_SPEED_SLOW`
+    Select low toggle speed.
+
+:c:macro:`PINCTRL_CONFIG_SPEED_MEDIUM`
+    Select medium toggle speed.
+
+:c:macro:`PINCTRL_CONFIG_SPEED_FAST`
+    Select fast toggle speed.
+
+:c:macro:`PINCTRL_CONFIG_SPEED_HIGH`
+    Select high toggle speed.
+
+Pin Multiplexing
+================
+
+Access to the pin multiplexer may be managed by
+:c:func:`pinctrl_mux_request()` and :c:func:`pinctrl_mux_free()`.
+
+:c:func:`pinctrl_mux_request()`
+    Request a pin for muxing.
+    [PINCTRL_RUNTIME_DTS]_
+
+:c:func:`pinctrl_mux_free()`
+    Release a pin for muxing.
+    [PINCTRL_RUNTIME_DTS]_
+
+The following multiplexing control functions do not adhere to any access
+control. Use the above access management functions if access management is
+necessary.
+
+:c:func:`pinctrl_mux_get()`
+    Get muxing function at pin.
+    [PINCTRL_BASIC]_ [PINCTRL_RUNTIME_DTS]_
+
+:c:func:`pinctrl_mux_set()`
+    Set muxing function at pin.
+    If the [PINCTRL_BASIC]_ interface is selected the muxing function is
+    restricted to hardware multiplex control. In the [PINCTRL_RUNTIME_DTS]_
+    interface also client device multiplex control is available.
+
+:c:func:`pinctrl_mux_group_set()`
+    Set muxing function for a group of pins.
+    [PINCTRL_RUNTIME_DTS]_
+
+
+Pin State Setting and Initialization
+====================================
+
+:c:func:`pinctrl_state_set()`
+    Set pinctrl state.
+    In the [PINCTRL_BASIC]_ interface the state is
+    restricted to the "default" state used for pin setup at startup.
+    If the [PINCTRL_RUNTIME_DTS]_ interface is selected all states
+    known in the device tree information can be set.
+
+The pinctrl device driver initializes pins based on device tree information.
+Pins that are controlled by client devices that are
+
+    - activated nodes in the device tree (status != "disabled")
+    - and where a "default" pin control is given
+
+are initialized during driver initialization.
+
+.. code-block:: DTS
+
+    pinctrl-0 = <&xxx_pins_a &xxxx_pins_b>;
+    pinctrl-names = "default";
+    status = "ok";
+
+
+Pin Concurrent Use by a Function and GPIO device driver
+=======================================================
+
+The GPIO device driver is just another client to the PINCTRL device driver.
+
+
+Interaction with GPIO device driver
+===================================
+
+The GPIO device driver uses the PINCTRL device driver as a backend.
+
+
+Interaction with PINMUX device driver
+=====================================
+
+The PINCTRL device driver also provides the PINMUX interface. No
+extra pinmux device is needed.
+
+The PINMUX interface of the PINCTRL driver is for transition. The
+PINCTRL multiplexing and configuration interfaces shall be used
+instead.
+
+
+PINCTRL device tree support
+***************************
+
+Nodes
+=====
+
+Pin Controller Node
+-------------------
+
+The pin controller device is defined by a pin controller node.
+
+Required properties are:
+
+    - pin-controller:
+    - compatible:
+    - label:
+
+
+Example:
+
+.. code-block:: DTS
+
+    pinctrl: pin-controller@48000000 {
+        pin-controller;
+        compatible = "st,stm32-pinctrl";
+        label = "PINCTRL";
+
+        /* pinctrl state nodes... */
+    };
+
+Pinctrl State Node
+------------------
+
+Pinctrl states are defined by pinctrl state nodes. The pinctrl state nodes are
+sub-nodes of the pin controller node. A pinctrl state node represents a group
+of pins and how they should be configured.
+
+A pinctrl state node is of the following format:
+
+.. code-block:: text
+
+    [pinctrl-state-label]: [device-name]@[device-configuration-index] {
+        [pin-configuration-label] {
+                [property] = [value];
+                ...
+        };
+        ...
+    };
+
+The device tree information is used to generate C defines:
+
+.. code-block:: C
+
+    #define [NODE-LABEL]_PINCTRL_[PINCTRL-NAME]_[PIN-CONFIGURATION-LABEL]_[PROPERTY] [value]
+
+The following pin configuration properties are supported by the device tree.
+*Pin controller* device drivers usually only support a subset of these
+pin configuration properties.
+
+**pins**:
+    The **pins** property denotes to which pins the configuration applies to.
+    The *pins* are specified as a list of pin numbers from the *pin controller*
+    [#pin_number_space]_.
+    Either the *pins* or the *group* or the *pinmux* property shall be given
+    for a pin configuration.
+
+**group**:
+    The **group** property denotes to which *group* of *pins* the configuration
+    applies to. The *group* is specified as a group number from the
+    *pin controller* group number space.
+    Either the *pins* or the *group* or the *pinmux* property shall be given
+    for a pin configuration.
+
+**pinmux**:
+    The **pinmux** property denotes to which *pins* the configuration applies to
+    and defines the *pin multiplexing* of these *pins* at the same time. The
+    *pinmux* is specified as a list of integer values. The interpretation of the
+    integer value(s) is specific to the *pin controller* device driver.
+    Either the *pins* or the *group* or the *pinmux* property shall be given
+    for a pin configuration.
+
+**bias-disable**
+    Disable any pin bias.
+
+**bias-high-impedance**
+    High impedance mode ("third-state", "floating").
+
+**bias-bus-hold**
+    Latch weakly.
+
+**bias-pull-up**
+    Pull up the pin.
+
+**bias-pull-down**
+    Pull down the pin.
+
+**bias-pull-pin-default**
+    Use pin default pull state.
+
+**drive-push-pull**
+    Drive actively high and low.
+
+**drive-open-drain**
+    Drive with open drain (open collector).
+
+**drive-open-source**
+    Drive with open source (open emitter).
+
+**drive-strength**
+    Drive strength. Generic drive strength values are:
+
+    - :c:macro:`PINCTRL_CONFIG_DRIVE_STRENGTH_DEFAULT`,
+    - :c:macro:`PINCTRL_CONFIG_DRIVE_STRENGTH_1`,
+    - :c:macro:`PINCTRL_CONFIG_DRIVE_STRENGTH_2`,
+    - :c:macro:`PINCTRL_CONFIG_DRIVE_STRENGTH_3`,
+    - :c:macro:`PINCTRL_CONFIG_DRIVE_STRENGTH_4`,
+    - :c:macro:`PINCTRL_CONFIG_DRIVE_STRENGTH_5`,
+    - :c:macro:`PINCTRL_CONFIG_DRIVE_STRENGTH_6`,
+    - :c:macro:`PINCTRL_CONFIG_DRIVE_STRENGTH_7`.
+
+**input-enable**
+    Enable the pins input. Does not affect the pin's ability to drive output.
+
+**input-disable**
+    Disable the pins input. Does not affect the pin's ability to drive output.
+
+**input-schmitt-enable**
+    Enable schmitt trigger mode for input.
+
+**input-schmitt-disable**
+    Disable schmitt trigger mode for input.
+
+**input-debounce**
+    Debounce input. Generic debounce values are:
+
+    - :c:macro:`PINCTRL_CONFIG_INPUT_DEBOUNCE_NONE`
+    - :c:macro:`PINCTRL_CONFIG_INPUT_DEBOUNCE_SHORT`
+    - :c:macro:`PINCTRL_CONFIG_INPUT_DEBOUNCE_MEDIUM`
+    - :c:macro:`PINCTRL_CONFIG_INPUT_DEBOUNCE_LONG`
+
+**low-power-enable**
+    Enable low power mode.
+
+**low-power-disable**
+    Disable low power mode.
+
+**output-disable**
+    Disable output on pin. Such as disconnecting the output buffer from the drive stage.
+    Does not reset the output drive.
+
+**output-enable**
+    Enable output on pin. Such as connecting the output buffer to the drive stage.
+    Does not set the output drive.
+
+**output-low**
+    Set output to active low. A "1" in the output buffer drives the output to low level.
+
+**output-high**
+    Set output to active high. A "1" in the output buffer drives the output to high level.
+
+**power-source**
+    Power source. Generic power source values are:
+
+    - :c:macro:`PINCTRL_CONFIG_POWER_SOURCE_DEFAULT`
+    - :c:macro:`PINCTRL_CONFIG_POWER_SOURCE_1`
+    - :c:macro:`PINCTRL_CONFIG_POWER_SOURCE_2`
+    - :c:macro:`PINCTRL_CONFIG_POWER_SOURCE_3`
+
+**slew-rate**
+    Slew rate. Generic slew rate values are:
+
+    - :c:macro:`PINCTRL_CONFIG_SLEW_RATE_SLOW`
+    - :c:macro:`PINCTRL_CONFIG_SLEW_RATE_MEDIUM`
+    - :c:macro:`PINCTRL_CONFIG_SLEW_RATE_FAST`
+    - :c:macro:`PINCTRL_CONFIG_SLEW_RATE_HIGH`
+
+**speed**
+    Toggle speed. Slew rate may be unaffected.
+    Generic toggle speed values are:
+
+    - :c:macro:`PINCTRL_CONFIG_SPEED_SLOW`
+    - :c:macro:`PINCTRL_CONFIG_SPEED_MEDIUM`
+    - :c:macro:`PINCTRL_CONFIG_SPEED_FAST`
+    - :c:macro:`PINCTRL_CONFIG_SPEED_HIGH`
+
+The following example device tree describes a pin controller with a pin
+configuration node and a SPI.
+
+.. code-block:: DTS
+
+    / {
+        /* ... */
+        soc {
+            /* ... */
+            pinctrl: pin-controller@48000000 {
+                compatible = "st,stm32-pinctrl";
+                pin-controller;
+                #address-cells = <1>;
+                #size-cells = <1>;
+                reg = <0x48000000 0x1800>;
+                label = "PINCTRL";
+                /* ... */
+                spi1_master_a: spi1@0 {
+                    sck {
+                        pinmux = <PINCTRL_STM32_PINB3 PINCTRL_STM32_FUNCTION_ALT_0>;
+                        drive-push-pull;
+                        bias-disable;
+                    };
+                    miso {
+                        pinmux = <PINCTRL_STM32_PINB4 PINCTRL_STM32_FUNCTION_ALT_0>;
+                        bias-disable;
+                    };
+                    mosi {
+                        pinmux = <PINCTRL_STM32_PINB5 PINCTRL_STM32_FUNCTION_ALT_0>;
+                        drive-push-pull;
+                        bias-disable;
+                    };
+                };
+            /* ... */
+            };
+            /* ... */
+            spi1: spi@40013000 {
+                spi-controller;
+                compatible = "st,stm32-spi-fifo";
+                #address-cells = <1>;
+                #size-cells = <0>;
+                reg = <0x40013000 0x400>;
+                interrupts = <25 5>;
+                status = "disabled";
+                label = "SPI_1";
+            };
+        };
+    };
+    /* ... */
+    &pinctrl {
+        status = "ok";
+    };
+
+    &spi1 {
+        pinctrl-0 = <&spi1_master_a>;
+        pinctrl-names = "default";
+        status = "ok";
+    };
+
+The device tree information is extracted to :file:`generated_dts_board.h`.
+
+The SPI_1 is registered as FUNCTION_2 at the pin controller.
+The "default" state of the SPI is registered as STATE_2. Three pin controls
+are associated to this state: PINCTRL_4, PINCTRL_5 and PINCTRL_6.
+PINCTRL_4 e.g. configures the pin sck.
+
+.. code-block:: C
+    :caption: Example generated_dts_board.h - pin controller node
+
+    /* pin-controller@48000000 */
+    #define ST_STM32_PINCTRL_48000000_BASE_ADDRESS_0                    0x48000000
+    ...
+    #define ST_STM32_PINCTRL_48000000_FUNCTION_2_CLIENT                 ST_STM32_SPI_FIFO_40013000
+    ...
+    #define ST_STM32_PINCTRL_48000000_FUNCTION_COUNT                    4
+    ...
+    #define ST_STM32_PINCTRL_48000000_PINCTRL_4_BIAS_BUS_HOLD           0
+    #define ST_STM32_PINCTRL_48000000_PINCTRL_4_BIAS_DISABLE            1
+    #define ST_STM32_PINCTRL_48000000_PINCTRL_4_BIAS_HIGH_IMPEDANCE     0
+    #define ST_STM32_PINCTRL_48000000_PINCTRL_4_BIAS_PULL_DOWN          0
+    #define ST_STM32_PINCTRL_48000000_PINCTRL_4_BIAS_PULL_PIN_DEFAULT   0
+    #define ST_STM32_PINCTRL_48000000_PINCTRL_4_BIAS_PULL_UP            0
+    #define ST_STM32_PINCTRL_48000000_PINCTRL_4_DRIVE_OPEN_DRAIN        0
+    #define ST_STM32_PINCTRL_48000000_PINCTRL_4_DRIVE_OPEN_SOURCE       0
+    #define ST_STM32_PINCTRL_48000000_PINCTRL_4_DRIVE_PUSH_PULL         1
+    #define ST_STM32_PINCTRL_48000000_PINCTRL_4_DRIVE_STRENGTH          0
+    #define ST_STM32_PINCTRL_48000000_PINCTRL_4_GROUP                   0
+    #define ST_STM32_PINCTRL_48000000_PINCTRL_4_INPUT_DEBOUNCE          0
+    #define ST_STM32_PINCTRL_48000000_PINCTRL_4_INPUT_DISABLE           0
+    #define ST_STM32_PINCTRL_48000000_PINCTRL_4_INPUT_ENABLE            0
+    #define ST_STM32_PINCTRL_48000000_PINCTRL_4_INPUT_SCHMITT_DISABLE   0
+    #define ST_STM32_PINCTRL_48000000_PINCTRL_4_INPUT_SCHMITT_ENABLE    0
+    #define ST_STM32_PINCTRL_48000000_PINCTRL_4_LOW_POWER_DISABLE       0
+    #define ST_STM32_PINCTRL_48000000_PINCTRL_4_LOW_POWER_ENABLE        0
+    #define ST_STM32_PINCTRL_48000000_PINCTRL_4_OUTPUT_DISABLE          0
+    #define ST_STM32_PINCTRL_48000000_PINCTRL_4_OUTPUT_ENABLE           0
+    #define ST_STM32_PINCTRL_48000000_PINCTRL_4_OUTPUT_HIGH             0
+    #define ST_STM32_PINCTRL_48000000_PINCTRL_4_OUTPUT_LOW              0
+    #define ST_STM32_PINCTRL_48000000_PINCTRL_4_PINMUX                  19,32768
+    #define ST_STM32_PINCTRL_48000000_PINCTRL_4_PINS                    0
+    #define ST_STM32_PINCTRL_48000000_PINCTRL_4_POWER_SOURCE            0
+    #define ST_STM32_PINCTRL_48000000_PINCTRL_4_SLEW_RATE               0
+    #define ST_STM32_PINCTRL_48000000_PINCTRL_4_SPEED                   0
+    #define ST_STM32_PINCTRL_48000000_PINCTRL_4_STATE_ID                2
+    ...
+    #define ST_STM32_PINCTRL_48000000_PINCTRL_5_STATE_ID                2
+    ...
+    #define ST_STM32_PINCTRL_48000000_PINCTRL_6_STATE_ID                2
+    ...
+    #define ST_STM32_PINCTRL_48000000_PINCTRL_COUNT                     10
+    ...
+    #define ST_STM32_PINCTRL_48000000_PINCTRL_STATE_2_FUNCTION_ID       2
+    #define ST_STM32_PINCTRL_48000000_PINCTRL_STATE_2_NAME_ID           0
+    ...
+    #define ST_STM32_PINCTRL_48000000_PINCTRL_STATE_COUNT               4
+    #define ST_STM32_PINCTRL_48000000_SIZE_0                            6144
+    #define ST_STM32_PINCTRL_48000000_STATE_NAME_0                      default
+    #define ST_STM32_PINCTRL_48000000_STATE_NAME_COUNT                  1
+    #define ST_STM32_PINCTRL_48000000_BASE_ADDRESS                      ST_STM32_PINCTRL_48000000_BASE_ADDRESS_0
+    #define ST_STM32_PINCTRL_48000000_SIZE                              ST_STM32_PINCTRL_48000000_SIZE_0
+
+The relevant pin control information is also given for the SPI node.
+
+.. code-block:: C
+    :caption: Example generated_dts_board.h - SPI node
+
+    /* spi@40013000 */
+    #define ST_STM32_SPI_FIFO_40013000_BASE_ADDRESS_0                       0x40013000
+    #define ST_STM32_SPI_FIFO_40013000_BASE_ADDRESS_1                       0x400
+    #define ST_STM32_SPI_FIFO_40013000_IRQ_0                                25
+    #define ST_STM32_SPI_FIFO_40013000_IRQ_0_PRIORITY                       5
+    #define ST_STM32_SPI_FIFO_40013000_LABEL                                "SPI_1"
+    #define ST_STM32_SPI_FIFO_40013000_PINCTRL_CONTROLLER_0_CONTROLLER      ST_STM32_PINCTRL_48000000
+    #define ST_STM32_SPI_FIFO_40013000_PINCTRL_CONTROLLER_0_FUNCTION_ID     2
+    #define ST_STM32_SPI_FIFO_40013000_PINCTRL_CONTROLLER_COUNT             1
+    #define ST_STM32_SPI_FIFO_40013000_PINCTRL_DEFAULT_CONTROLLER_ID        0
+    #define ST_STM32_SPI_FIFO_40013000_PINCTRL_DEFAULT_MISO_BIAS_DISABLE    1
+    #define ST_STM32_SPI_FIFO_40013000_PINCTRL_DEFAULT_MISO_PINMUX          20,32768
+    #define ST_STM32_SPI_FIFO_40013000_PINCTRL_DEFAULT_MOSI_BIAS_DISABLE    1
+    #define ST_STM32_SPI_FIFO_40013000_PINCTRL_DEFAULT_MOSI_DRIVE_PUSH_PULL 1
+    #define ST_STM32_SPI_FIFO_40013000_PINCTRL_DEFAULT_MOSI_PINMUX          21,32768
+    #define ST_STM32_SPI_FIFO_40013000_PINCTRL_DEFAULT_SCK_BIAS_DISABLE     1
+    #define ST_STM32_SPI_FIFO_40013000_PINCTRL_DEFAULT_SCK_DRIVE_PUSH_PULL  1
+    #define ST_STM32_SPI_FIFO_40013000_PINCTRL_DEFAULT_SCK_PINMUX           19,32768
+    #define ST_STM32_SPI_FIFO_40013000_PINCTRL_DEFAULT_STATE_ID             2
+    #define ST_STM32_SPI_FIFO_40013000_BASE_ADDRESS                         ST_STM32_SPI_FIFO_40013000_BASE_ADDRESS_0
+
+Also generic device information is available for the soc node.
+
+.. code-block:: C
+    :caption: Example generated_dts_board.h - soc node
+
+    /* soc */
+    #define SOC_PIN_CONTROLLER_COUNT    1
+    #define SOC_PIN_CONTROLLER_0        ST_STM32_PINCTRL_48000000
+    #define SOC_SPI_CONTROLLER_COUNT    1
+    #define SOC_SPI_CONTROLLER_0        ST_STM32_SPI_FIFO_40013000
+
+Pin Initialization
+==================
+
+Pin initialization is defined by the pinctrl named "default".
+
+In the following example pinctrl-0 is named "default". All pin states
+requested by pinctrl-0 (pina_state0_node_other and pinb_state0_node_other)
+will be set at initialization time.
+
+.. code-block:: DTS
+
+    pinctrl: pinctrl@48000000 {
+        pin-controller;
+        /* ... */
+
+        pina_state0_node_other {
+            /* ... */
+        };
+        pina_state1_node_other {
+            /* ... */
+        };
+        pinb_state0_node_other {
+            /* ... */
+        };
+        pinb_state1_node_other {
+            /* ... */
+        };
+    };
+
+    other: other@50000000 {
+        /* ... */
+        pinctrl-0 = <&pina_state0_node_other, &pinb_state0_node_other>;
+        pinctrl-1 = <&pina_state1_node_other, &pinb_state1_node_other>;
+        pinctrl-names = "default", "xxxx";
+        status = "ok";
+    };
+
+Interaction with the GPIO device driver
+=======================================
+
+GPIO to PINCTRL pin mapping by pinctrl-x
+----------------------------------------
+
+The GPIO device as a client device to the pin-controller may have at least
+one pinctrl-x directive that references the pin-controller and sets all port
+pins to GPIO input. By this all pin-controller pins that are associated to
+the GPIO port can be retrieved by :c:func:`pinctrl_get_group_pins`. The name
+of the group to retrieve corresponds to the pinctrl name of the pinctrl-x
+directive.
+
+.. code-block:: DTS
+
+    pinctrl: pin-controller@48000000 {
+        pin-controller;
+        /* ... */
+
+        gpioa_in: gpioa@0 {
+            pin0: {
+                pinmux = <...>;
+                /* ... */
+            }
+            /* ... */
+        }
+    };
+
+    gpioa: gpio@40020000 {
+        gpio-controller;
+        /* ... */
+        pinctrl-0 = <&gpioa_in>;
+        pinctrl-names = <"reset", ...>;
+    };
+
+A gpio driver may retrieve the pin-controller pins associate to it´s port:
+
+.. code-block:: C
+
+    u32_t function;
+    u32_t group;
+    u16_t pins[16];
+    u16_t num_pins = 16;
+
+    pinctrl_get_device_function(pinctrl_dev, gpio_dev, &function);
+    pinctrl_get_function_group(pinctrl_dev, function, "reset", &group);
+    pinctrl_get_group_pins(pinctrl_dev, group, &pins[0], &num_pins);
+
+GPIO to PINCTRL pin mapping by gpio-ranges
+------------------------------------------
+
+To enable a pin controller and/ or a GPIO port to retrieve the pin mapping
+between them the gpio-ranges property may be set in the device tree. Also
+the label property shall be set and used as device name in this case.
+
+The gpio-ranges property is of the form:
+
+.. code-block:: text
+
+    gpio-ranges = <&[pin controller] [pin number in GPIO pin number space]
+                                     [pin number in pin controller number space]
+                                     [number of pins]>,
+                                     /* ... */
+                                     ;
+
+A GPIO port definition in the device tree may look like:
+
+.. code-block:: DTS
+
+    pinctrl: pin-controller@48000000 {
+        pin-controller;
+        /* ... */
+    };
+
+    gpioa: gpio@48001000 {
+        gpio-controller;
+        compatible = "st,stm32-gpio-pinctrl";
+        #gpio-cells = <2>;
+        reg = <0x480010000 0x400>;
+        label = "GPIOE";
+        gpio-ranges = <&pinctrl GPIO_PORT_PIN0 PINCTRL_STM32_PINE0 16>;
+    };
+
+The GPIO port pin 0 is mapped to the pinctrl pin E0. In total 16 pins are
+mapped starting at pinctrl pin EO and continuing with the consecutively
+following pin numbers.
+
+GPIO_RANGE defines are generated for the GPIO node and for the PINCTRL
+node.
+
+.. code-block:: C
+
+    /* gpio@48001000 */
+    #define ST_STM32_GPIO_PINCTRL_48001000_BASE_ADDRESS_0               0x48001000
+    #define ST_STM32_GPIO_PINCTRL_48001000_GPIO_RANGE_0_BASE            1
+    #define ST_STM32_GPIO_PINCTRL_48001000_GPIO_RANGE_0_CONTROLLER      ST_STM32_PINCTRL_48000000
+    #define ST_STM32_GPIO_PINCTRL_48001000_GPIO_RANGE_0_CONTROLLER_BASE 64
+    #define ST_STM32_GPIO_PINCTRL_48001000_GPIO_RANGE_0_NPINS           16
+    #define ST_STM32_GPIO_PINCTRL_48001000_GPIO_RANGE_COUNT             1
+    #define ST_STM32_GPIO_PINCTRL_48001000_LABEL                        "GPIOE"
+    #define ST_STM32_GPIO_PINCTRL_48001000_SIZE_0                       1024
+    #define ST_STM32_GPIO_PINCTRL_48001000_BASE_ADDRESS                 ST_STM32_GPIO_PINCTRL_48001000_BASE_ADDRESS_0
+    #define ST_STM32_GPIO_PINCTRL_48001000_SIZE                         ST_STM32_GPIO_PINCTRL_48001000_SIZE_0
+
+.. code-block:: C
+
+    /* pin-controller@48000000 */
+    #define ST_STM32_PINCTRL_48000000_BASE_ADDRESS_0            0x48000000
+    ...
+    #define ST_STM32_PINCTRL_48000000_GPIO_RANGE_4_BASE         64
+    #define ST_STM32_PINCTRL_48000000_GPIO_RANGE_4_CLIENT       ST_STM32_GPIO_PINCTRL_48001000
+    #define ST_STM32_PINCTRL_48000000_GPIO_RANGE_4_CLIENT_BASE  1
+    #define ST_STM32_PINCTRL_48000000_GPIO_RANGE_4_NPINS        16
+    ...
+    #define ST_STM32_PINCTRL_48000000_GPIO_RANGE_COUNT          6
+    ...
+
+Interaction with the PINMUX device driver
+=========================================
+
+The pinmux device shall be disabled if a pin controller is used.
+
+.. code-block:: DTS
+
+    pinctrl: pin-controller@48000000 {
+        pin-controller;
+        /* ... */
+        status = "ok";
+    };
+
+    pinmux: pinmux@48000400 {
+        /* ... */
+        status = "disabled";
+    };
+
+
+PINCTRL device driver implementation
+************************************
+
+Driver Configuration
+====================
+
+Driver configuration information comes from three sources:
+    - autoconf.h (Kconfig)
+    - generated_dts_board.h (device tree)
+    - soc.h
+
+Driver configuration by autoconf.h
+----------------------------------
+
+See :ref:`configuration` for the the full set of Kconfig symbols that are available.
+Specific to the pin controller driver are:
+
+:c:macro:`CONFIG_PINCTRL`
+    Enable pinctrl driver.
+
+:c:macro:`CONFIG_PINCTRL_RUNTIME_DTS`
+    Enable run time pin configuration control based on device tree
+    information. When enabled the [PINCTRL_RUNTIME_DTS]_ API is available.
+
+:c:macro:`CONFIG_PINCTRL_PINMUX`
+    Enable the generic shim that maps from the pinmux interface to the pinctrl
+    interface.
+
+:c:macro:`CONFIG_PINCTRL_INIT_PRIORITY`
+    Initialization priority for the pinctrl driver.
+
+:c:macro:`CONFIG_PINCTRL_NAME`
+    Pinctrl driver name. May be used if no label information is given in the device
+    tree.
+
+Driver configuration by device tree
+-----------------------------------
+
+For a pin controller node the following information is extracted from the device tree
+and provided in :file:`generated_dts_board.h`.
+
+The general device information for pin controllers:
+
+:c:macro:`SOC_PIN_CONTROLLER_COUNT`
+    Number of pin controllers that are activated. All nodes that contain a
+    pin-controller directive are counted.
+
+:c:macro:`SOC_PIN_CONTROLLER_0` ...
+    The label prefix of pin controller 0 ... (e.g. 'ST_STM32_PINCTRL_48000000').
+    The define is generated if a pin-controller directive is given in the node.
+
+General information that is extracted for every device type:
+
+**LABEL**
+
+**BASE_ADDRESS**
+
+**SIZE**
+
+**COMPATIBLE_COUNT**
+
+**COMPATIBLE_0_ID**
+
+The specific device information for pin controllers:
+
+**FUNCTION**
+    For all active client nodes that reference a pin-controller by
+    pinctrl-x(&pinctrl, ...) FUNCTION defines are generated.
+    The function equals the client node.
+
+**STATE_NAME**
+    For all pinctrl names of pinctrl-x directives of active client nodes
+    STATE_NAME defines are generated. This is mostly to allow deduplication of
+    commonly used state names such as e.g. "default".
+
+**PINCTRL_STATE**
+    For all pinctrl-x directives of active client nodes PINCTRL_STATE defines
+    are generated.
+    The pinctrl state references the *FUNCTION* (aka. node) it is given in.
+    The pinctrl state also references the *STATE_NAME* given in the
+    pinctrl-names directive associated to the pinctrl-x directive.
+
+    All the pins that a pinctrl state controls are regarded to be a pin group.
+    The name of the pin group is the same as the name of the pinctrl state.
+
+**PINCTRL**
+    For all subnodes of pin configurations referenced by active client nodes -
+    pinctrl-x(&xxx, pinconf_a, ...) - PINCTRL defines are generated.
+    The pinctrl references the *FUNCTION* (aka. node) it is referenced from.
+    The pinctrl also references the *PINCTRL_STATE* it is referenced from.
+
+**GPIO_RANGE**
+    For all gpio-ranges directives of active GPIO nodes GPIO_RANGE defines are
+    generated.
+
+The datasets for the clients of pin controllers are:
+
+**PINCTRL_CONTROLLER**
+    For all pin controllers that are referenced in a pinctrl-x directive
+    PINCTRL_CONTROLLER defines are generated.
+
+**PINCTRL**
+    For all subnodes of pin configurations referenced by active client nodes
+    - pinctrl-x(&xxx, pinconf_a, ...) - PINCTRL defines are generated.
+    The pinctrl references the *PINCTRL_CONTROLLER* given in the pinctrl-x
+    directive. The pinctrl also references the *PINCTRL_STATE* the pin
+    controller associates to this pinctrl.
+
+Driver configuration by soc.h
+-----------------------------
+
+:file:`soc.h` may contain driver relevant information such as HAL header files.
+
+Driver structures and content generation
+========================================
+
+A driver implementation may either use a specific (DTS) script or the
+inline code generation to generate driver structures and content.
+
+Using the pin controller driver template
+----------------------------------------
+
+The pin controller template :file:`pinctrl_tmpl.c` is a template for pin
+controller driver implementation. The template parameters are given by
+global variables in the inline code generation snippet.
+The template is expanded by inline code generation with Python.
+The template generates the appropriate data structures
+and fills them using the information provided in :file:`generated_dts_board.conf`.
+
+A pin controller driver implementer has to write five hardware/ device specific
+functions to implement:
+
+    - :c:func:`pinctrl_config_get()`,
+    - :c:func:`pinctrl_config_set()`,
+    - :c:func:`pinctrl_mux_get()`,
+    - :c:func:`pinctrl_mux_set()`,
+    - and device initialization.
+
+Additionally two Python functions have to be provided that extract the pin number
+and the multiplexer value from the pinmux value(s) given in the device tree:
+
+    - :py:func:`pinmux_pin(pinmux)`
+    - :py:func:`pinmux_mux(pinmux)`
+
+The template expects the following globals to be set:
+
+    - compatible
+      The compatible string of the driver (e.g. 'st,stm32-pinctrl')
+    - data_info
+      device data type definition (e.g. 'struct pinctrl_stm32_data')
+    - config_get
+      C function name of device config_get function.
+    - mux_free
+      C function name of device mux_free function.
+    - mux_get
+      C function name of device mux_get function.
+    - mux_set
+      C function name of device mux_set function.
+    - device_init
+      C function name of device init function
+    - :py:func:`pinmux_pin(pinmux)`
+      Python function that extracts the pin number from the pinmux property.
+    - :py:func:`pinmux_mux(pinmux)`
+      Python function that extracts the mux value from the pinmux property.
+
+The structure of a pin controller driver may look like this example
+of the STM32 driver (:file:`drivers/pinctrl/pinctrl_stm32.c`):
+
+.. code-block:: C
+    :caption: Example pinctrl_stm32.c
+
+    /**
+     * @code{.codegen}
+     * compatible = 'st,stm32-pinctrl'
+     * codegen.if_device_tree_controller_compatible('PIN', compatible)
+     * @endcode{.codegen}
+     */
+    /** @code{.codeins}@endcode */
+    ...
+    struct pinctrl_stm32_data {
+       ...
+    }
+    ...
+    /* --- API (using the PINCTRL template code) --- */
+
+    /* forward declarations */
+    static int pinctrl_stm32_config_get(struct device *dev, u16_t pin,
+                                        u32_t *config);
+    static int pinctrl_stm32_config_set(struct device *dev, u16_t pin,
+                                        u32_t config);
+    static int pinctrl_stm32_mux_get(struct device *dev, u16_t pin, u16_t *func);
+    static int pinctrl_stm32_mux_set(struct device *dev, u16_t pin, u16_t func);
+    static int pinctrl_stm32_device_init(struct device *dev);
+
+    /**
+     * @code{.codegen}
+     * # compatible already set
+     * data_info = 'struct pinctrl_stm32_data'
+     * config_get = 'pinctrl_stm32_config_get'
+     * config_set = 'pinctrl_stm32_config_set'
+     * mux_get = 'pinctrl_stm32_mux_get'
+     * mux_set = 'pinctrl_stm32_mux_set'
+     * device_init = 'pinctrl_stm32_device_init'
+     * def pinmux_pin(pinmux):
+     *     return pinmux.split(',')[0]
+     * def pinmux_mux(pinmux):
+     *     return pinmux.split(',')[1]
+     * codegen.out_include('pinctrl_tmpl.c')
+     * @endcode{.codegen}
+     */
+    /** @code{.codeins}@endcode */
+
+    static int pinctrl_stm32_config_get(struct device *dev, u16_t pin,
+                                        u32_t *config)
+    { ... }
+
+    static int pinctrl_stm32_config_set(struct device *dev, u16_t pin,
+                                        u32_t config)
+    { ... }
+
+    static int pinctrl_stm32_mux_get(struct device *dev, u16_t pin, u16_t *func)
+    { ... }
+
+    static int pinctrl_stm32_mux_set(struct device *dev, u16_t pin, u16_t func)
+    { ... }
+
+    static int pinctrl_stm32_device_init(struct device *dev)
+    { ... }
+
+Design Rationales
+*****************
+
+.. [#pin_number_space] PINCTRL uses a **local pin number space** instead of
+   a global space to allow for object encapsulation.
+
+References
+**********
+
+.. target-notes::
+
+.. _linux_pinctrl: https://www.kernel.org/doc/Documentation/pinctrl.txt
+.. _linux_pinctrl_bindings: https://www.kernel.org/doc/Documentation/devicetree/bindings/pinctrl/pinctrl-bindings.txt

--- a/drivers/pinctrl/pinctrl_handlers.c
+++ b/drivers/pinctrl/pinctrl_handlers.c
@@ -1,0 +1,181 @@
+/*
+ * Copyright (c) 2018 Bobby Noelte
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <pinctrl.h>
+#include <syscall_handlers.h>
+#include <toolchain.h>
+
+Z_SYSCALL_HANDLER(pinctrl_get_pins_count, dev)
+{
+	Z_SYSCALL_OBJ(dev, K_OBJ_DRIVER_PINCTRL);
+	return _impl_pinctrl_get_pins_count((struct device *)dev);
+}
+
+Z_SYSCALL_HANDLER(pinctrl_get_groups_count, dev)
+{
+	Z_SYSCALL_OBJ(dev, K_OBJ_DRIVER_PINCTRL);
+	return _impl_pinctrl_get_groups_count((struct device *)dev);
+}
+
+Z_SYSCALL_HANDLER(pinctrl_get_group_pins, dev, group, pins, num_pins)
+{
+	Z_SYSCALL_OBJ(dev, K_OBJ_DRIVER_PINCTRL);
+	Z_SYSCALL_MEMORY_WRITE(pins, sizeof(u16_t) * *num_pins);
+	Z_SYSCALL_MEMORY_WRITE(num_pins, sizeof(u16_t));
+	return _impl_pinctrl_get_group_pins(
+		(struct device *)dev, group, (u16_t *)pins, (u16_t *)num_pins);
+}
+
+Z_SYSCALL_HANDLER(pinctrl_get_states_count, dev)
+{
+	Z_SYSCALL_OBJ(dev, K_OBJ_DRIVER_PINCTRL);
+	return _impl_pinctrl_get_states_count((struct device *)dev);
+}
+
+Z_SYSCALL_HANDLER(pinctrl_get_state_group, dev, state, group)
+{
+	Z_SYSCALL_OBJ(dev, K_OBJ_DRIVER_PINCTRL);
+	Z_SYSCALL_MEMORY_WRITE(group, sizeof(u16_t));
+	return pinctrl_get_state_group(
+		(struct device *)dev, func, name, (u16_t *)group);
+}
+
+Z_SYSCALL_HANDLER(pinctrl_get_functions_count, dev)
+{
+	Z_SYSCALL_OBJ(dev, K_OBJ_DRIVER_PINCTRL);
+	return _impl_pinctrl_get_functions_count((struct device *)dev);
+}
+
+Z_SYSCALL_HANDLER(pinctrl_get_function_group, dev, func, name, group)
+{
+	Z_SYSCALL_OBJ(dev, K_OBJ_DRIVER_PINCTRL);
+	Z_SYSCALL_MEMORY_WRITE(group, sizeof(u16_t));
+	return _impl_pinctrl_get_function_group(
+		(struct device *)dev, func, name, (u16_t *)group);
+}
+
+Z_SYSCALL_HANDLER(pinctrl_get_function_groups, dev, func, groups, num_groups)
+{
+	Z_SYSCALL_OBJ(dev, K_OBJ_DRIVER_PINCTRL);
+	Z_SYSCALL_MEMORY_WRITE(groups, sizeof(u16_t) * *num_groups);
+	Z_SYSCALL_MEMORY_WRITE(num_groups, sizeof(u16_t));
+	return _impl_pinctrl_get_function_groups((struct device *)dev,
+						 func,
+						 (u16_t *)groups,
+						 (u16_t *)num_groups);
+}
+
+Z_SYSCALL_HANDLER(pinctrl_get_function_state, dev, func, name, state)
+{
+	Z_SYSCALL_OBJ(dev, K_OBJ_DRIVER_PINCTRL);
+	Z_SYSCALL_MEMORY_WRITE(state, sizeof(u16_t));
+	return _impl_pinctrl_get_function_state(
+		(struct device *)dev, func, name, (u16_t *)state);
+}
+
+Z_SYSCALL_HANDLER(pinctrl_get_function_states, dev, func, states, num_states)
+{
+	Z_SYSCALL_OBJ(dev, K_OBJ_DRIVER_PINCTRL);
+	Z_SYSCALL_MEMORY_WRITE(states, sizeof(u16_t) * *num_states);
+	Z_SYSCALL_MEMORY_WRITE(num_states, sizeof(u16_t));
+	return _impl_pinctrl_get_function_states((struct device *)dev,
+						 func,
+						 (u16_t *)states,
+						 (u16_t *)num_states);
+}
+
+Z_SYSCALL_HANDLER(pinctrl_get_device_function, dev, other, func)
+{
+	Z_SYSCALL_OBJ(dev, K_OBJ_DRIVER_PINCTRL);
+	Z_SYSCALL_MEMORY_WRITE(func, sizeof(u16_t));
+	return _impl_pinctrl_get_device_function(
+		(struct device *)dev, (struct device *)other, (u16_t *)func);
+}
+
+Z_SYSCALL_HANDLER(pinctrl_get_gpio_range, dev, gpio, gpio_pin, pin, base_pin,
+		  num_pins)
+{
+	Z_SYSCALL_OBJ(dev, K_OBJ_DRIVER_PINCTRL);
+	Z_SYSCALL_OBJ(gpio, K_OBJ_DRIVER_GPIO);
+	Z_SYSCALL_MEMORY_WRITE(pin, sizeof(u16_t));
+	Z_SYSCALL_MEMORY_WRITE(base_pin, sizeof(u16_t));
+	Z_SYSCALL_MEMORY_WRITE(num_pins, sizeof(u8_t));
+	return _impl_pinctrl_get_gpio_range((struct device *)dev,
+					    (struct device *)gpio,
+					    gpio_pin,
+					    (u16_t *)pin,
+					    (u16_t *)base_pin,
+					    (u8_t *)num_pins);
+}
+
+Z_SYSCALL_HANDLER(pinctrl_config_get, dev, pin, config)
+{
+	Z_SYSCALL_OBJ(dev, K_OBJ_DRIVER_PINCTRL);
+	Z_SYSCALL_MEMORY_WRITE(config, sizeof(u32_t));
+	return _impl_pinctrl_config_get(
+		(struct device *)dev, pin, (u32_t *)config);
+}
+
+Z_SYSCALL_HANDLER(pinctrl_config_set, dev, pin, config)
+{
+	Z_SYSCALL_OBJ(dev, K_OBJ_DRIVER_PINCTRL);
+	return _impl_pinctrl_config_set((struct device *)dev, pin, config);
+}
+
+Z_SYSCALL_HANDLER(pinctrl_config_group_get, dev, group, configs, num_configs)
+{
+	Z_SYSCALL_OBJ(dev, K_OBJ_DRIVER_PINCTRL);
+	Z_SYSCALL_MEMORY_WRITE(configs, sizeof(u32_t) * *num_configs);
+	Z_SYSCALL_MEMORY_WRITE(num_configs, sizeof(u16_t));
+	return _impl_pinctrl_config_group_get((struct device *)dev,
+					      group,
+					      (u32_t *)configs,
+					      (u16_t *)num_configs);
+}
+
+Z_SYSCALL_HANDLER(pinctrl_config_group_set, dev, group, configs, num_configs)
+{
+	Z_SYSCALL_OBJ(dev, K_OBJ_DRIVER_PINCTRL);
+	return _impl_pinctrl_config_group_get(
+		(struct device *)dev, group, configs, num_configs);
+}
+
+Z_SYSCALL_HANDLER(pinctrl_mux_request, dev, pin, owner)
+{
+	Z_SYSCALL_OBJ(dev, K_OBJ_DRIVER_PINCTRL);
+	return _impl_pinctrl_mux_request((struct device *)dev, pin, owner);
+}
+
+Z_SYSCALL_HANDLER(pinctrl_mux_free, dev, pin, owner)
+{
+	Z_SYSCALL_OBJ(dev, K_OBJ_DRIVER_PINCTRL);
+	return _impl_pinctrl_mux_free((struct device *)dev, pin, owner);
+}
+
+Z_SYSCALL_HANDLER(pinctrl_mux_get, dev, pin, func)
+{
+	Z_SYSCALL_OBJ(dev, K_OBJ_DRIVER_PINCTRL);
+	Z_SYSCALL_MEMORY_WRITE(func, sizeof(u32_t));
+	return _impl_pinctrl_mux_get((struct device *)dev, pin, (u32_t *)func);
+}
+
+Z_SYSCALL_HANDLER(pinctrl_mux_set, dev, pin, func)
+{
+	Z_SYSCALL_OBJ(dev, K_OBJ_DRIVER_PINCTRL);
+	return _impl_pinctrl_mux_set((struct device *)dev, pin, func);
+}
+
+Z_SYSCALL_HANDLER(pinctrl_mux_group_set, dev, group, func)
+{
+	Z_SYSCALL_OBJ(dev, K_OBJ_DRIVER_PINCTRL);
+	return _impl_pinctrl_mux_group_set((struct device *)dev, group, func);
+}
+
+Z_SYSCALL_HANDLER(pinctrl_state_set, dev, state)
+{
+	Z_SYSCALL_OBJ(dev, K_OBJ_DRIVER_PINCTRL);
+	return _impl_pinctrl_mux_get((struct device *)dev, state);
+}

--- a/include/dt-bindings/gpio/gpio.h
+++ b/include/dt-bindings/gpio/gpio.h
@@ -1,183 +1,28 @@
 /*
  * Copyright (c) 2018 Linaro Limited
+ * Copyright (c) 2018 Bobby Noelte
  *
  * SPDX-License-Identifier: Apache-2.0
  */
-#ifndef __DT_BINDINGS_GPIO_GPIO_H
-#define __DT_BINDINGS_GPIO_GPIO_H
-
 
 /**
- * @name GPIO direction flags
- * The `GPIO_DIR_*` flags are used with `gpio_pin_configure` or `gpio_port_configure`,
- * to specify whether a GPIO pin will be used for input or output.
+ * @file
+ * @brief GPIO device tree defines
+ * @defgroup device_driver_gpio_dts GPIO device tree defines
+ * @ingroup device_driver_gpio
+ *
+ * Device tree defines for the GPIO device driver.
+ *
+ * @note Not to be used with the legacy GPIO device driver.
  * @{
  */
-/** GPIO pin to be input. */
-#define GPIO_DIR_IN		(0 << 0)
 
-/** GPIO pin to be output. */
-#define GPIO_DIR_OUT		(1 << 0)
+#ifndef _GPIO_DTS_H
+#define _GPIO_DTS_H
 
-/** @cond INTERNAL_HIDDEN */
-#define GPIO_DIR_MASK		0x1
-/** @endcond */
-/** @} */
+#include <gpio_common.h>
 
+#endif /* _GPIO_DTS_H */
 
-/**
- * @name GPIO interrupt flags
- * The `GPIO_INT_*` flags are used with `gpio_pin_configure` or `gpio_port_configure`,
- * to specify how input GPIO pins will trigger interrupts.
- * @{
- */
-/** GPIO pin to trigger interrupt. */
-#define GPIO_INT		(1 << 1)
+/** @} device_driver_gpio_dts */
 
-/** GPIO pin trigger on level low or falling edge. */
-#define GPIO_INT_ACTIVE_LOW	(0 << 2)
-
-/** GPIO pin trigger on level high or rising edge. */
-#define GPIO_INT_ACTIVE_HIGH	(1 << 2)
-
-/** GPIO pin trigger to be synchronized to clock pulses. */
-#define GPIO_INT_CLOCK_SYNC     (1 << 3)
-
-/** Enable GPIO pin debounce. */
-#define GPIO_INT_DEBOUNCE       (1 << 4)
-
-/** Do Level trigger. */
-#define GPIO_INT_LEVEL		(0 << 5)
-
-/** Do Edge trigger. */
-#define GPIO_INT_EDGE		(1 << 5)
-
-/** Interrupt triggers on both rising and falling edge.
- *  Must be combined with GPIO_INT_EDGE.
- */
-#define GPIO_INT_DOUBLE_EDGE	(1 << 6)
-/** @} */
-
-
-/**
- * @name GPIO polarity flags
- * The `GPIO_POL_*` flags are used with `gpio_pin_configure` or `gpio_port_configure`,
- * to specify the polarity of a GPIO pin.
- * @{
- */
-/** @cond INTERNAL_HIDDEN */
-#define GPIO_POL_POS		7
-/** @endcond */
-
-/** GPIO pin polarity is normal. */
-#define GPIO_POL_NORMAL		(0 << GPIO_POL_POS)
-
-/** GPIO pin polarity is inverted. */
-#define GPIO_POL_INV		(1 << GPIO_POL_POS)
-
-/** @cond INTERNAL_HIDDEN */
-#define GPIO_POL_MASK		(1 << GPIO_POL_POS)
-/** @endcond */
-/** @} */
-
-
-/**
- * @name GPIO pull flags
- * The `GPIO_PUD_*` flags are used with `gpio_pin_configure` or `gpio_port_configure`,
- * to specify the pull-up or pull-down electrical configuration of a GPIO pin.
- * @{
- */
-/** @cond INTERNAL_HIDDEN */
-#define GPIO_PUD_POS		8
-/** @endcond */
-
-/** Pin is neither pull-up nor pull-down. */
-#define GPIO_PUD_NORMAL		(0 << GPIO_PUD_POS)
-
-/** Enable GPIO pin pull-up. */
-#define GPIO_PUD_PULL_UP	(1 << GPIO_PUD_POS)
-
-/** Enable GPIO pin pull-down. */
-#define GPIO_PUD_PULL_DOWN	(2 << GPIO_PUD_POS)
-
-/** @cond INTERNAL_HIDDEN */
-#define GPIO_PUD_MASK		(3 << GPIO_PUD_POS)
-/** @endcond */
-/** @} */
-
-
-/**
- * @name GPIO drive strength flags
- * The `GPIO_DS_*` flags are used with `gpio_pin_configure` or `gpio_port_configure`,
- * to specify the drive strength configuration of a GPIO pin.
- *
- * The drive strength of individual pins can be configured
- * independently for when the pin output is low and high.
- *
- * The `GPIO_DS_*_LOW` enumerations define the drive strength of a pin
- * when output is low.
-
- * The `GPIO_DS_*_HIGH` enumerations define the drive strength of a pin
- * when output is high.
- *
- * The `DISCONNECT` drive strength indicates that the pin is placed in a
- * high impedance state and not driven, this option is used to
- * configure hardware that supports a open collector drive mode.
- *
- * The interface supports two different drive strengths:
- * `DFLT` - The lowest drive strength supported by the HW
- * `ALT` - The highest drive strength supported by the HW
- *
- * On hardware that supports only one standard drive strength, both
- * `DFLT` and `ALT` have the same behavior.
- *
- * On hardware that does not support a disconnect mode, `DISCONNECT`
- * will behave the same as `DFLT`.
- * @{
- */
-/** @cond INTERNAL_HIDDEN */
-#define GPIO_DS_LOW_POS 12
-#define GPIO_DS_LOW_MASK (0x3 << GPIO_DS_LOW_POS)
-/** @endcond */
-
-/** Default drive strength standard when GPIO pin output is low.
- */
-#define GPIO_DS_DFLT_LOW (0x0 << GPIO_DS_LOW_POS)
-
-/** Alternative drive strength when GPIO pin output is low.
- * For hardware that does not support configurable drive strength
- * use the default drive strength.
- */
-#define GPIO_DS_ALT_LOW (0x1 << GPIO_DS_LOW_POS)
-
-/** Disconnect pin when GPIO pin output is low.
- * For hardware that does not support disconnect use the default
- * drive strength.
- */
-#define GPIO_DS_DISCONNECT_LOW (0x3 << GPIO_DS_LOW_POS)
-
-/** @cond INTERNAL_HIDDEN */
-#define GPIO_DS_HIGH_POS 14
-#define GPIO_DS_HIGH_MASK (0x3 << GPIO_DS_HIGH_POS)
-/** @endcond */
-
-/** Default drive strength when GPIO pin output is high.
- */
-#define GPIO_DS_DFLT_HIGH (0x0 << GPIO_DS_HIGH_POS)
-
-/** Alternative drive strength when GPIO pin output is high.
- * For hardware that does not support configurable drive strengths
- * use the default drive strength.
- */
-#define GPIO_DS_ALT_HIGH (0x1 << GPIO_DS_HIGH_POS)
-
-/** Disconnect pin when GPIO pin output is high.
- * For hardware that does not support disconnect use the default
- * drive strength.
- */
-#define GPIO_DS_DISCONNECT_HIGH (0x3 << GPIO_DS_HIGH_POS)
-/** @} */
-
-
-
-#endif /* __DT_BINDINGS_GPIO_GPIO_H */

--- a/include/gpio_common.h
+++ b/include/gpio_common.h
@@ -1,0 +1,444 @@
+/*
+ * Copyright (c) 2018 Linaro Limited
+ * Copyright (c) 2018 Bobby Noelte
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef _GPIO_COMMON_H_
+#define _GPIO_COMMON_H_
+
+/**
+ * @name GPIO direction flags
+ * The `GPIO_DIR_*` flags are used with `gpio_pin_configure` or
+ * `gpio_port_configure`, to specify whether a GPIO pin will be used for input
+ * or output.
+ * @{
+ */
+/** GPIO pin to be input. */
+#define GPIO_DIR_IN		(0 << 0)
+
+/** GPIO pin to be output. */
+#define GPIO_DIR_OUT		(1 << 0)
+
+/** @cond INTERNAL_HIDDEN */
+#define GPIO_DIR_MASK		0x1
+/** @endcond */
+/** @} */
+
+
+/**
+ * @name GPIO interrupt flags
+ * The `GPIO_INT_*` flags are used with `gpio_pin_configure` or `
+ * gpio_port_configure`, to specify how input GPIO pins will trigger
+ * interrupts.
+ * @{
+ */
+/** GPIO pin to trigger interrupt. */
+#define GPIO_INT		(1 << 1)
+
+/** GPIO pin trigger on level low or falling edge. */
+#define GPIO_INT_ACTIVE_LOW	(0 << 2)
+
+/** GPIO pin trigger on level high or rising edge. */
+#define GPIO_INT_ACTIVE_HIGH	(1 << 2)
+
+/** GPIO pin trigger to be synchronized to clock pulses. */
+#define GPIO_INT_CLOCK_SYNC     (1 << 3)
+
+/** Enable GPIO pin debounce. */
+#define GPIO_INT_DEBOUNCE       (1 << 4)
+
+/** Do Level trigger. */
+#define GPIO_INT_LEVEL		(0 << 5)
+
+/** Do Edge trigger. */
+#define GPIO_INT_EDGE		(1 << 5)
+
+/** Interrupt triggers on both rising and falling edge.
+ *  Must be combined with GPIO_INT_EDGE.
+ */
+#define GPIO_INT_DOUBLE_EDGE	(1 << 6)
+/** @} */
+
+
+/**
+ * @name GPIO polarity flags
+ * The `GPIO_POL_*` flags are used with `gpio_pin_configure` or
+ * `gpio_port_configure`, to specify the polarity of a GPIO pin.
+ * @{
+ */
+/** @cond INTERNAL_HIDDEN */
+#define GPIO_POL_POS		7
+/** @endcond */
+
+/** GPIO pin polarity is normal. */
+#define GPIO_POL_NORMAL		(0 << GPIO_POL_POS)
+
+/** GPIO pin polarity is inverted. */
+#define GPIO_POL_INV		(1 << GPIO_POL_POS)
+
+/** @cond INTERNAL_HIDDEN */
+#define GPIO_POL_MASK		(1 << GPIO_POL_POS)
+/** @endcond */
+/** @} */
+
+
+/**
+ * @name GPIO pull flags
+ * The `GPIO_PUD_*` flags are used with `gpio_pin_configure` or
+ * `gpio_port_configure`, to specify the pull-up or pull-down electrical
+ * configuration of a GPIO pin.
+ * @{
+ */
+/** @cond INTERNAL_HIDDEN */
+#define GPIO_PUD_POS		8
+/** @endcond */
+
+/** Pin is neither pull-up nor pull-down. */
+#define GPIO_PUD_NORMAL		(0 << GPIO_PUD_POS)
+
+/** Enable GPIO pin pull-up. */
+#define GPIO_PUD_PULL_UP	(1 << GPIO_PUD_POS)
+
+/** Enable GPIO pin pull-down. */
+#define GPIO_PUD_PULL_DOWN	(2 << GPIO_PUD_POS)
+
+/** @cond INTERNAL_HIDDEN */
+#define GPIO_PUD_MASK		(3 << GPIO_PUD_POS)
+/** @endcond */
+/** @} */
+
+
+/**
+ * @name GPIO drive strength flags
+ * The `GPIO_DS_*` flags are used with `gpio_pin_configure` or
+ * `gpio_port_configure`, to specify the drive strength configuration of a
+ * GPIO pin.
+ *
+ * The drive strength of individual pins can be configured
+ * independently for when the pin output is low and high.
+ *
+ * The `GPIO_DS_*_LOW` enumerations define the drive strength of a pin
+ * when output is low.
+
+ * The `GPIO_DS_*_HIGH` enumerations define the drive strength of a pin
+ * when output is high.
+ *
+ * The `DISCONNECT` drive strength indicates that the pin is placed in a
+ * high impedance state and not driven, this option is used to
+ * configure hardware that supports a open collector drive mode.
+ *
+ * The interface supports two different drive strengths:
+ * `DFLT` - The lowest drive strength supported by the HW
+ * `ALT` - The highest drive strength supported by the HW
+ *
+ * On hardware that supports only one standard drive strength, both
+ * `DFLT` and `ALT` have the same behavior.
+ *
+ * On hardware that does not support a disconnect mode, `DISCONNECT`
+ * will behave the same as `DFLT`.
+ * @{
+ */
+/** @cond INTERNAL_HIDDEN */
+#define GPIO_DS_LOW_POS 12
+#define GPIO_DS_LOW_MASK (0x3 << GPIO_DS_LOW_POS)
+/** @endcond */
+
+/** Default drive strength standard when GPIO pin output is low.
+ */
+#define GPIO_DS_DFLT_LOW (0x0 << GPIO_DS_LOW_POS)
+
+/** Alternative drive strength when GPIO pin output is low.
+ * For hardware that does not support configurable drive strength
+ * use the default drive strength.
+ */
+#define GPIO_DS_ALT_LOW (0x1 << GPIO_DS_LOW_POS)
+
+/** Disconnect pin when GPIO pin output is low.
+ * For hardware that does not support disconnect use the default
+ * drive strength.
+ */
+#define GPIO_DS_DISCONNECT_LOW (0x3 << GPIO_DS_LOW_POS)
+
+/** @cond INTERNAL_HIDDEN */
+#define GPIO_DS_HIGH_POS 14
+#define GPIO_DS_HIGH_MASK (0x3 << GPIO_DS_HIGH_POS)
+/** @endcond */
+
+/** Default drive strength when GPIO pin output is high.
+ */
+#define GPIO_DS_DFLT_HIGH (0x0 << GPIO_DS_HIGH_POS)
+
+/** Alternative drive strength when GPIO pin output is high.
+ * For hardware that does not support configurable drive strengths
+ * use the default drive strength.
+ */
+#define GPIO_DS_ALT_HIGH (0x1 << GPIO_DS_HIGH_POS)
+
+/** Disconnect pin when GPIO pin output is high.
+ * For hardware that does not support disconnect use the default
+ * drive strength.
+ */
+#define GPIO_DS_DISCONNECT_HIGH (0x3 << GPIO_DS_HIGH_POS)
+/** @} */
+
+/**
+ * @brief GPIO Pin Defines
+ * @defgroup gpio_interface_pin_defs GPIO Pin Defines
+ * @ingroup gpio_interface
+ *
+ * @note Not to be used with the legacy GPIO device driver.
+ * @{
+ */
+
+/**
+ * @def GPIO_PORT_PIN
+ * @brief Helper to create pin number from pin index.
+ *
+ * @param idx Index of pin within port [0..31]
+ * @return Pin number
+ */
+#define GPIO_PORT_PIN(idx)  (1U << (idx))
+
+/**
+ * @def GPIO_PORT_PIN_IDX
+ * @brief Helper to create pin index from pin number.
+ *
+ * Pin number shall be one of GPIO_PORT_PINx (only one bit set).
+ *
+ * @note For runtime calculation use gpio_port_pin_idx() instead.
+ *
+ * @param pin Pin number
+ * @return Index of pin within port [0..31]
+ */
+#define GPIO_PORT_PIN_IDX(pin) ( \
+	(((pin & GPIO_PORT_PIN(0))  >>  0) *  0) + \
+	(((pin & GPIO_PORT_PIN(1))  >>  1) *  1) + \
+	(((pin & GPIO_PORT_PIN(2))  >>  2) *  2) + \
+	(((pin & GPIO_PORT_PIN(3))  >>  3) *  3) + \
+	(((pin & GPIO_PORT_PIN(4))  >>  4) *  4) + \
+	(((pin & GPIO_PORT_PIN(5))  >>  5) *  5) + \
+	(((pin & GPIO_PORT_PIN(6))  >>  6) *  6) + \
+	(((pin & GPIO_PORT_PIN(7))  >>  7) *  7) + \
+	(((pin & GPIO_PORT_PIN(8))  >>  8) *  8) + \
+	(((pin & GPIO_PORT_PIN(9))  >>  9) *  9) + \
+	(((pin & GPIO_PORT_PIN(10)) >> 10) * 10) + \
+	(((pin & GPIO_PORT_PIN(11)) >> 11) * 11) + \
+	(((pin & GPIO_PORT_PIN(12)) >> 12) * 12) + \
+	(((pin & GPIO_PORT_PIN(13)) >> 13) * 13) + \
+	(((pin & GPIO_PORT_PIN(14)) >> 14) * 14) + \
+	(((pin & GPIO_PORT_PIN(15)) >> 15) * 15) + \
+	(((pin & GPIO_PORT_PIN(16)) >> 16) * 16) + \
+	(((pin & GPIO_PORT_PIN(17)) >> 17) * 17) + \
+	(((pin & GPIO_PORT_PIN(18)) >> 18) * 18) + \
+	(((pin & GPIO_PORT_PIN(19)) >> 19) * 19) + \
+	(((pin & GPIO_PORT_PIN(20)) >> 20) * 20) + \
+	(((pin & GPIO_PORT_PIN(21)) >> 21) * 21) + \
+	(((pin & GPIO_PORT_PIN(22)) >> 22) * 22) + \
+	(((pin & GPIO_PORT_PIN(23)) >> 23) * 23) + \
+	(((pin & GPIO_PORT_PIN(24)) >> 24) * 24) + \
+	(((pin & GPIO_PORT_PIN(25)) >> 25) * 25) + \
+	(((pin & GPIO_PORT_PIN(26)) >> 26) * 26) + \
+	(((pin & GPIO_PORT_PIN(27)) >> 27) * 27) + \
+	(((pin & GPIO_PORT_PIN(28)) >> 28) * 28) + \
+	(((pin & GPIO_PORT_PIN(29)) >> 29) * 29) + \
+	(((pin & GPIO_PORT_PIN(30)) >> 30) * 30) + \
+	(((pin & GPIO_PORT_PIN(31)) >> 31) * 31))
+
+/**
+ * @def GPIO_PORT_PIN0
+ * @brief Pin 0 of the GPIO port.
+ */
+#define GPIO_PORT_PIN0		GPIO_PORT_PIN(0)
+
+/**
+ * @def GPIO_PORT_PIN1
+ * @brief Pin 1 of the GPIO port.
+ */
+#define GPIO_PORT_PIN1		GPIO_PORT_PIN(1)
+
+/**
+ * @def GPIO_PORT_PIN2
+ * @brief Pin 2 of the GPIO port.
+ */
+#define GPIO_PORT_PIN2		GPIO_PORT_PIN(2)
+
+/**
+ * @def GPIO_PORT_PIN3
+ * @brief Pin 3 of the GPIO port.
+ */
+#define GPIO_PORT_PIN3		GPIO_PORT_PIN(3)
+
+/**
+ * @def GPIO_PORT_PIN4
+ * @brief Pin 4 of the GPIO port.
+ */
+#define GPIO_PORT_PIN4		GPIO_PORT_PIN(4)
+
+/**
+ * @def GPIO_PORT_PIN5
+ * @brief Pin 5 of the GPIO port.
+ */
+#define GPIO_PORT_PIN5		GPIO_PORT_PIN(5)
+
+/**
+ * @def GPIO_PORT_PIN6
+ * @brief Pin 6 of the GPIO port.
+ */
+#define GPIO_PORT_PIN6		GPIO_PORT_PIN(6)
+
+/**
+ * @def GPIO_PORT_PIN7
+ * @brief Pin 7 of the GPIO port.
+ */
+#define GPIO_PORT_PIN7		GPIO_PORT_PIN(7)
+
+/**
+ * @def GPIO_PORT_PIN8
+ * @brief Pin 8 of the GPIO port.
+ */
+#define GPIO_PORT_PIN8		GPIO_PORT_PIN(8)
+
+/**
+ * @def GPIO_PORT_PIN9
+ * @brief Pin 9 of the GPIO port.
+ */
+#define GPIO_PORT_PIN9		GPIO_PORT_PIN(9)
+
+/**
+ * @def GPIO_PORT_PIN10
+ * @brief Pin 10 of the GPIO port.
+ */
+#define GPIO_PORT_PIN10		GPIO_PORT_PIN(10)
+
+/**
+ * @def GPIO_PORT_PIN11
+ * @brief Pin 11 of the GPIO port.
+ */
+#define GPIO_PORT_PIN11		GPIO_PORT_PIN(11)
+
+/**
+ * @def GPIO_PORT_PIN12
+ * @brief Pin 12 of the GPIO port.
+ */
+#define GPIO_PORT_PIN12		GPIO_PORT_PIN(12)
+
+/**
+ * @def GPIO_PORT_PIN13
+ * @brief Pin 13 of the GPIO port.
+ */
+#define GPIO_PORT_PIN13		GPIO_PORT_PIN(13)
+
+/**
+ * @def GPIO_PORT_PIN14
+ * @brief Pin 14 of the GPIO port.
+ */
+#define GPIO_PORT_PIN14		GPIO_PORT_PIN(14)
+
+/**
+ * @def GPIO_PORT_PIN15
+ * @brief Pin 15 of the GPIO port.
+ */
+#define GPIO_PORT_PIN15		GPIO_PORT_PIN(15)
+
+/**
+ * @def GPIO_PORT_PIN16
+ * @brief Pin 16 of the GPIO port.
+ */
+#define GPIO_PORT_PIN16		GPIO_PORT_PIN(16)
+
+/**
+ * @def GPIO_PORT_PIN17
+ * @brief Pin 17 of the GPIO port.
+ */
+#define GPIO_PORT_PIN17		GPIO_PORT_PIN(17)
+
+/**
+ * @def GPIO_PORT_PIN18
+ * @brief Pin 18 of the GPIO port.
+ */
+#define GPIO_PORT_PIN18		GPIO_PORT_PIN(18)
+
+/**
+ * @def GPIO_PORT_PIN19
+ * @brief Pin 19 of the GPIO port.
+ */
+#define GPIO_PORT_PIN19		GPIO_PORT_PIN(19)
+
+/**
+ * @def GPIO_PORT_PIN20
+ * @brief Pin 20 of the GPIO port.
+ */
+#define GPIO_PORT_PIN20		GPIO_PORT_PIN(20)
+
+/**
+ * @def GPIO_PORT_PIN21
+ * @brief Pin 21 of the GPIO port.
+ */
+#define GPIO_PORT_PIN21		GPIO_PORT_PIN(21)
+
+/**
+ * @def GPIO_PORT_PIN22
+ * @brief Pin 22 of the GPIO port.
+ */
+#define GPIO_PORT_PIN22		GPIO_PORT_PIN(22)
+
+/**
+ * @def GPIO_PORT_PIN23
+ * @brief Pin 23 of the GPIO port.
+ */
+#define GPIO_PORT_PIN23		GPIO_PORT_PIN(23)
+
+/**
+ * @def GPIO_PORT_PIN24
+ * @brief Pin 24 of the GPIO port.
+ */
+#define GPIO_PORT_PIN24		GPIO_PORT_PIN(24)
+
+/**
+ * @def GPIO_PORT_PIN25
+ * @brief Pin 25 of the GPIO port.
+ */
+#define GPIO_PORT_PIN25		GPIO_PORT_PIN(25)
+
+/**
+ * @def GPIO_PORT_PIN26
+ * @brief Pin 26 of the GPIO port.
+ */
+#define GPIO_PORT_PIN26		GPIO_PORT_PIN(26)
+
+/**
+ * @def GPIO_PORT_PIN27
+ * @brief Pin 27 of the GPIO port.
+ */
+#define GPIO_PORT_PIN27		GPIO_PORT_PIN(27)
+
+/**
+ * @def GPIO_PORT_PIN28
+ * @brief Pin 28 of the GPIO port.
+ */
+#define GPIO_PORT_PIN28		GPIO_PORT_PIN(28)
+
+/**
+ * @def GPIO_PORT_PIN29
+ * @brief Pin 29 of the GPIO port.
+ */
+#define GPIO_PORT_PIN29		GPIO_PORT_PIN(29)
+
+/**
+ * @def GPIO_PORT_PIN30
+ * @brief Pin 30 of the GPIO port.
+ */
+#define GPIO_PORT_PIN30		GPIO_PORT_PIN(30)
+
+/**
+ * @def GPIO_PORT_PIN31
+ * @brief Pin 31 of the GPIO port.
+ */
+#define GPIO_PORT_PIN31		GPIO_PORT_PIN(31)
+
+
+/** @} gpio_interface_pin_defs */
+
+#endif /* _GPIO_COMMON_H_ */

--- a/include/pinctrl.h
+++ b/include/pinctrl.h
@@ -1,0 +1,918 @@
+/*
+ * Copyright (c) 2018 Bobby Noelte
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * @file
+ * Public APIs for PINCTRL drivers
+ */
+
+#ifndef __INCLUDE_PINCTRL_H
+#define __INCLUDE_PINCTRL_H
+
+/**
+ * @brief PINCTRL Interface
+ * @defgroup pinctrl_interface PINCTRL Interface
+ * @ingroup io_interfaces
+ *
+ * Pin control interface for
+ * - pin control: get pin control properties
+ * - pin configuration: configure a pins electronic properties
+ * - pin multiplexing: reuse the same pin for different purposes
+ * @{
+ */
+
+#include <pinctrl_common.h>
+
+#include <zephyr/types.h>
+#include <misc/__assert.h>
+#include <device.h>
+
+
+/**
+ * @def PINCTRL_CONFIG
+ * @brief Create a pinctrl pin configuration value.
+ *
+ * The configuration defines shall be the
+ * @ref pinctrl_interface_pin_configurations "pinctrl pin configurations"
+ * given in the pinctrl_common.h file.
+ */
+#define PINCTRL_CONFIG(...) _PINCTRL_CONFIG0(__VA_ARGS__)
+/**
+ * @def _PINCTRL_CONFIG0
+ * @internal
+ */
+#define _PINCTRL_CONFIG0(...)                                   \
+	_PINCTRL_CONFIG32(__VA_ARGS__,                          \
+		0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, \
+		0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0)
+/**
+ * @def _PINCTRL_CONFIG32
+ * @internal
+ */
+#define _PINCTRL_CONFIG32(c0,  c1,  c2,  c3,  c4,  c5,  c6,  c7,  \
+			  c8,  c9,  c10, c11, c12, c13, c14, c15, \
+			  c16, c17, c18, c19, c20, c21, c22, c23, \
+			  c24, c25, c26, c27, c28, c29, c30, c31, \
+			  ...)                                    \
+	(c0  | c1  | c2  | c3  | c4  | c5  | c6  | c7  |          \
+	 c8  | c9  | c10 | c11 | c12 | c13 | c14 | c15 |          \
+	 c16 | c17 | c18 | c19 | c20 | c21 | c22 | c23 |          \
+	 c24 | c25 | c26 | c17 | c28 | c29 | c30 | c31)
+
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+struct pinctrl_control_api {
+	u16_t (*get_pins_count)(struct device *dev);
+#if CONFIG_PINCTRL_RUNTIME_DTS
+	int (*get_groups_count)(struct device *dev);
+	int (*get_group_pins)(struct device *dev, u16_t group,
+			      u16_t *pins, u16_t *num_pins);
+	u16_t (*get_states_count)(struct device *dev);
+	int (*get_state_group)(struct device *dev, u16_t state, u16_t *group);
+	u16_t (*get_functions_count)(struct device *dev);
+	int (*get_function_group)(struct device *dev, u16_t func,
+				  const char *name, u16_t *group);
+	int (*get_function_groups)(struct device *dev, u16_t func,
+				   u16_t *groups, u16_t *num_groups);
+	int (*get_function_state)(struct device *dev, u16_t func,
+				  const char *name, u16_t *state);
+	int (*get_function_states)(struct device *dev, u16_t func,
+				   u16_t *states, u16_t *num_states);
+	int (*get_device_function)(struct device *dev, struct device *client,
+				   u16_t *func);
+#endif /* CONFIG_PINCTRL_RUNTIME_DTS */
+	int (*get_gpio_range)(struct device *dev, struct device *gpio,
+			      u32_t gpio_pin, u16_t *pin, u16_t *base_pin,
+			      u8_t *num_pins);
+};
+
+struct pinctrl_config_api {
+	int (*get)(struct device *dev, u16_t pin, u32_t *config);
+	int (*set)(struct device *dev, u16_t pin, u32_t config);
+#if CONFIG_PINCTRL_RUNTIME_DTS
+	int (*group_get)(struct device *dev, u16_t group,
+			 u32_t *configs, u16_t *num_configs);
+	int (*group_set)(struct device *dev, u16_t group,
+			 const u32_t *configs, u16_t num_configs);
+#endif /* CONFIG_PINCTRL_RUNTIME_DTS */
+};
+
+struct pinctrl_mux_api {
+	int (*get)(struct device *dev, u16_t pin, u16_t *func);
+	int (*set)(struct device *dev, u16_t pin, u16_t func);
+#if CONFIG_PINCTRL_RUNTIME_DTS
+	int (*group_set)(struct device *dev, u16_t group, u16_t func);
+	int (*request)(struct device *dev, u16_t pin, const char *owner);
+	int (*free)(struct device *dev, u16_t pin, const char *owner);
+#endif /* CONFIG_PINCTRL_RUNTIME_DTS */
+};
+
+struct pinctrl_state_api {
+	int (*set)(struct device *dev, u16_t state);
+};
+
+struct pinctrl_driver_api {
+	struct pinctrl_control_api control;
+	struct pinctrl_config_api config;
+	struct pinctrl_mux_api mux;
+	struct pinctrl_state_api state;
+};
+
+/**
+ * Get the number of pins controlled by this pin controller.
+ *
+ * @param dev Pointer to the device structure for the driver instance.
+ * @return number of pins
+ */
+__syscall u16_t pinctrl_get_pins_count(struct device *dev);
+
+/** @internal
+ */
+static inline u16_t _impl_pinctrl_get_pins_count(struct device *dev)
+{
+	const struct pinctrl_driver_api *api =
+		(const struct pinctrl_driver_api *)dev->driver_api;
+
+	return api->control.get_pins_count(dev);
+}
+
+/**
+ * Get the number of groups selectable by this pin controller.
+ *
+ * @note To be enabled by CONFIG_PINCTRL_RUNTIME_DTS.
+ *
+ * @param dev Pointer to the device structure for the driver instance.
+ * @return number of groups
+ */
+__syscall u16_t pinctrl_get_groups_count(struct device *dev);
+
+/** @internal
+ */
+static inline u16_t _impl_pinctrl_get_groups_count(struct device *dev)
+{
+#if CONFIG_PINCTRL_RUNTIME_DTS
+	const struct pinctrl_driver_api *api =
+		(const struct pinctrl_driver_api *)dev->driver_api;
+
+	return api->control.get_groups_count(dev);
+#else
+	__ASSERT(0, "To be enabled by CONFIG_PINCTRL_RUNTIME_DTS.");
+	return 0;
+#endif /* CONFIG_PINCTRL_RUNTIME_DTS */
+}
+
+/**
+ * Get the pins that are in a pin group.
+ *
+ * Returns an array of pin numbers. The applicable pins
+ * are returned in @p pins and the number of pins in @p num_pins. The
+ * number of pins returned is bounded by the initial value of @p num_pins
+ * when called.
+ *
+ * @note To be enabled by CONFIG_PINCTRL_RUNTIME_DTS.
+ *
+ * @param dev Pointer to the device structure for the driver instance.
+ * @param group Group
+ * @param[in,out] pins Array of pins.
+ * @param[in,out] num_pins Size of the array of pins.
+ * @retval 0 on success
+ * @retval -EINVAL if number of pins exceeds array size.
+ * @retval -ENOTSUP if requested group is not available on this controller
+ */
+__syscall int pinctrl_get_group_pins(struct device *dev, u16_t group,
+				     u16_t *pins, u16_t *num_pins);
+
+/** @internal
+ */
+static inline int _impl_pinctrl_get_group_pins(struct device *dev, u16_t group,
+					       u16_t *pins, u16_t *num_pins)
+{
+#if CONFIG_PINCTRL_RUNTIME_DTS
+	const struct pinctrl_driver_api *api =
+		(const struct pinctrl_driver_api *)dev->driver_api;
+
+	return api->control.get_group_pins(dev, group, pins, num_pins);
+#else
+	__ASSERT(0, "To be enabled by CONFIG_PINCTRL_RUNTIME_DTS.");
+	return -ENOTSUP;
+#endif /* CONFIG_PINCTRL_RUNTIME_DTS */
+}
+
+/**
+ * Get the number of states selectable by this pin controller.
+ *
+ * @note To be enabled by CONFIG_PINCTRL_RUNTIME_DTS.
+ *
+ * @param dev Pointer to the device structure for the driver instance.
+ * @return number of states
+ */
+__syscall u16_t pinctrl_get_states_count(struct device *dev);
+
+/** @internal
+ */
+static inline u16_t _impl_pinctrl_get_states_count(struct device *dev)
+{
+#if CONFIG_PINCTRL_RUNTIME_DTS
+	const struct pinctrl_driver_api *api =
+		(const struct pinctrl_driver_api *)dev->driver_api;
+
+	return api->control.get_states_count(dev);
+#else
+	__ASSERT(0, "To be enabled by CONFIG_PINCTRL_RUNTIME_DTS.");
+	return 0;
+#endif /* CONFIG_PINCTRL_RUNTIME_DTS */
+}
+
+/**
+ * Get the group of pins controlled by the pinctrl state.
+ *
+ * @note To be enabled by CONFIG_PINCTRL_RUNTIME_DTS.
+ *
+ * @param dev Pointer to the device structure for the driver instance.
+ * @param state State
+ * @param[out] group Group
+ * @retval 0 on success
+ * @retval -ENOTSUP if requested state is not available on this controller
+ */
+__syscall int pinctrl_get_state_group(struct device *dev, u16_t state,
+				      u16_t *group);
+
+/** @internal
+ */
+static inline int _impl_pinctrl_get_state_group(struct device *dev,
+						u16_t state, u16_t *group)
+{
+#if CONFIG_PINCTRL_RUNTIME_DTS
+	const struct pinctrl_driver_api *api =
+		(const struct pinctrl_driver_api *)dev->driver_api;
+
+	return api->control.get_state_group(dev, state, group);
+#else
+	__ASSERT(0, "To be enabled by CONFIG_PINCTRL_RUNTIME_DTS.");
+	return -ENOTSUP;
+#endif /* CONFIG_PINCTRL_RUNTIME_DTS */
+}
+
+/**
+ * Get the number of selectable functions of this pin controller.
+ *
+ * @note To be enabled by CONFIG_PINCTRL_RUNTIME_DTS.
+ *
+ * @param dev Pointer to the device structure for the driver instance.
+ * @return number of functions
+ */
+__syscall u16_t pinctrl_get_functions_count(struct device *dev);
+
+/** @internal
+ */
+static inline u16_t _impl_pinctrl_get_functions_count(struct device *dev)
+{
+#if CONFIG_PINCTRL_RUNTIME_DTS
+	const struct pinctrl_driver_api *api =
+		(const struct pinctrl_driver_api *)dev->driver_api;
+
+	return api->control.get_functions_count(dev);
+#else
+	__ASSERT(0, "To be enabled by CONFIG_PINCTRL_RUNTIME_DTS.");
+	return 0;
+#endif /* CONFIG_PINCTRL_RUNTIME_DTS */
+}
+
+/**
+ * Get the pin group of given name that is related to given function.
+ *
+ * @note To be enabled by CONFIG_PINCTRL_RUNTIME_DTS.
+ *
+ * @param dev Pointer to the device structure for the driver instance.
+ * @param func Function
+ * @param name Group name
+ * @param[out] group Group
+ * @retval 0 on success
+ * @retval -ENODEV if requested function is not available on this controller
+ * @retval -ENOTSUP if there is no group with the requested name for
+ *                  the function
+ */
+__syscall int pinctrl_get_function_group(struct device *dev, u16_t func,
+					 const char *name, u16_t *group);
+
+/** @internal
+ */
+static inline int _impl_pinctrl_get_function_group(struct device *dev,
+						   u16_t func,
+						   const char *name,
+						   u16_t *group)
+{
+#if CONFIG_PINCTRL_RUNTIME_DTS
+	const struct pinctrl_driver_api *api =
+		(const struct pinctrl_driver_api *)dev->driver_api;
+
+	return api->control.get_function_group(dev, func, name, group);
+#else
+	__ASSERT(0, "To be enabled by CONFIG_PINCTRL_RUNTIME_DTS.");
+	return -ENOTSUP;
+#endif /* CONFIG_PINCTRL_RUNTIME_DTS */
+}
+
+/**
+ * Get the groups of pins that can be multiplexed to the function.
+ *
+ * Returns an array of group numbers. The group number can be used with
+ * pinctrl_get_group_pins() to retrieve the pins. The applicable groups
+ * are returned in @p groups and the number of groups in @p num_groups. The
+ * number of groups returned is bounded by the initial value of @p num_groups
+ * when called.
+ *
+ * @note To be enabled by CONFIG_PINCTRL_RUNTIME_DTS.
+ *
+ * @param dev Pointer to the device structure for the driver instance.
+ * @param func Function
+ * @param[out] groups Array of groups.
+ * @param[in,out] num_groups Size of the array of groups.
+ * @retval 0 on success
+ * @retval -ENODEV if requested function is not available on this controller
+ * @retval -ENOTSUP if there is no group
+ * @retval -EINVAL if the number of available groups exceeds array size
+ */
+__syscall int pinctrl_get_function_groups(struct device *dev, u16_t func,
+					  u16_t *groups, u16_t *num_groups);
+
+/** @internal
+ */
+static inline int _impl_pinctrl_get_function_groups(struct device *dev,
+						    u16_t func,
+						    u16_t *groups,
+						    u16_t *num_groups)
+{
+#if CONFIG_PINCTRL_RUNTIME_DTS
+	const struct pinctrl_driver_api *api =
+		(const struct pinctrl_driver_api *)dev->driver_api;
+
+	return api->control.get_function_groups(dev, func, groups, num_groups);
+#else
+	__ASSERT(0, "To be enabled by CONFIG_PINCTRL_RUNTIME_DTS.");
+	return -ENOTSUP;
+#endif /* CONFIG_PINCTRL_RUNTIME_DTS */
+}
+
+/**
+ * Get the state of given name that can be applied to given function.
+ *
+ * @note To be enabled by CONFIG_PINCTRL_RUNTIME_DTS.
+ *
+ * @param dev Pointer to the device structure for the driver instance.
+ * @param func Function
+ * @param name State name
+ * @param[out] state State
+ * @retval 0 on success
+ * @retval -ENODEV if function is unknown to pin controller
+ * @retval -ENOTSUP if there is no state with the requested name for
+ *                  the function
+ */
+__syscall int pinctrl_get_function_state(struct device *dev, u16_t func,
+					 const char *name, u16_t *state);
+
+/** @internal
+ */
+static inline int _impl_pinctrl_get_function_state(struct device *dev,
+						   u16_t func,
+						   const char *name,
+						   u16_t *state)
+{
+#if CONFIG_PINCTRL_RUNTIME_DTS
+	const struct pinctrl_driver_api *api =
+		(const struct pinctrl_driver_api *)dev->driver_api;
+
+	return api->control.get_function_state(dev, func, name, state);
+#else
+	__ASSERT(0, "To be enabled by CONFIG_PINCTRL_RUNTIME_DTS.");
+	return -ENOTSUP;
+#endif /* CONFIG_PINCTRL_RUNTIME_DTS */
+}
+
+/**
+ * Get the states that can be applied to the function.
+ *
+ * Returns an array of state numbers. The state number can be used with
+ * pinctrl_get_state_group() to retrieve the associated pin group.
+ * The applicable states are returned in @p states and the number of states
+ * in @p num_states. The number of states returned is bounded by the initial
+ * value of @p num_states when called.
+ *
+ * @note To be enabled by CONFIG_PINCTRL_RUNTIME_DTS.
+ *
+ * @param dev Pointer to the device structure for the driver instance.
+ * @param func Function
+ * @param[out] states Array of states.
+ * @param[in,out] num_states Size of the array of states.
+ * @retval 0 on success
+ * @retval -ENODEV if function is unknown to pin controller
+ * @retval -ENOTSUP if there is no state
+ * @retval -EINVAL if the number of available states exceeds array size
+ */
+__syscall int pinctrl_get_function_states(struct device *dev, u16_t func,
+					  u16_t *states, u16_t *num_states);
+
+/** @internal
+ */
+static inline int _impl_pinctrl_get_function_states(struct device *dev,
+						    u16_t func,
+						    u16_t *states,
+						    u16_t *num_states)
+{
+#if CONFIG_PINCTRL_RUNTIME_DTS
+	const struct pinctrl_driver_api *api =
+		(const struct pinctrl_driver_api *)dev->driver_api;
+
+	return api->control.get_function_states(dev, func, states, num_states);
+#else
+	__ASSERT(0, "To be enabled by CONFIG_PINCTRL_RUNTIME_DTS.");
+	return -ENOTSUP;
+#endif /* CONFIG_PINCTRL_RUNTIME_DTS */
+}
+
+/**
+ * Get the function that is associated to a client device.
+ *
+ * @note To be enabled by CONFIG_PINCTRL_RUNTIME_DTS.
+ *
+ * @param dev Pointer to the device structure for the driver instance.
+ * @param client Pointer to the device structure of the client driver instance.
+ * @param[out] func Function
+ * @retval 0 on success
+ * @retval -ENOTSUP if there is no function for the requested device
+ */
+__syscall int pinctrl_get_device_function(struct device *dev,
+					  struct device *client, u16_t *func);
+
+/** @internal
+ */
+static inline int _impl_pinctrl_get_device_function(struct device *dev,
+						    struct device *client,
+						    u16_t *func)
+{
+#if CONFIG_PINCTRL_RUNTIME_DTS
+	const struct pinctrl_driver_api *api =
+		(const struct pinctrl_driver_api *)dev->driver_api;
+
+	return api->control.get_device_function(dev, client, func);
+#else
+	__ASSERT(0, "To be enabled by CONFIG_PINCTRL_RUNTIME_DTS.");
+	return -ENOTSUP;
+#endif /* CONFIG_PINCTRL_RUNTIME_DTS */
+}
+
+/**
+ * Is the function a client device multiplex control.
+ *
+ * @param func Function
+ * @return >0 if the function denotes a client device, 0 otherwise.
+ */
+static inline int pinctrl_is_device_function(u16_t func)
+{
+	return (func >= PINCTRL_FUNCTION_DEVICE_BASE);
+}
+
+/**
+ * Is the function a hardware pinmux control.
+ *
+ * @param func Function
+ * @return >0 if the function is a hardware pinmux control, 0 otherwise.
+ */
+static inline int pinctrl_is_pinmux_function(u16_t func)
+{
+	return (func < PINCTRL_FUNCTION_DEVICE_BASE);
+}
+
+/**
+ * Get the pin controller pin number and pin mapping for a GPIO pin.
+ *
+ * @note Pin controller pins are numbered consecutively.
+ *
+ * @param dev Pointer to the device structure for the driver instance.
+ * @param gpio Pointer to the device structure of the GPIO driver instance.
+ * @param gpio_pin GPIO pin in GPIO number space.
+ * @param[out] pin GPIO pin in pin-controller number space.
+ * @param[out] base_pin Base pin of gpio range in pin-controller number space.
+ * @param[out] num_pins Number of pins in gpio range.
+ * @retval 0 on success
+ * @retval -ENOTSUP if there is no gpio range for the requested GPIO pin.
+ */
+__syscall int pinctrl_get_gpio_range(struct device *dev, struct device *gpio,
+				     u32_t gpio_pin, u16_t *pin,
+				     u16_t *base_pin, u8_t *num_pins);
+
+/** @internal
+ */
+static inline int _impl_pinctrl_get_gpio_range(struct device *dev,
+					       struct device *gpio,
+					       u32_t gpio_pin, u16_t *pin,
+					       u16_t *base_pin, u8_t *num_pins)
+{
+	const struct pinctrl_driver_api *api =
+		(const struct pinctrl_driver_api *)dev->driver_api;
+
+	return api->control.get_gpio_range(dev, gpio, gpio_pin, pin, base_pin,
+					   num_pins);
+}
+
+/**
+ * Get the configuration of a pin.
+ *
+ * The configuration returned may be different to the configuration set by
+ * pinctrl_config_set(). Some configuration options may be set or reset by
+ * the current function selection.
+ *
+ * @param dev Pointer to the device structure for the driver instance.
+ * @param pin Pin
+ * @param[out] config
+ * @retval 0 on success
+ * @retval -ENOTSUP if requested pin is not available on this controller
+ * @retval -EINVAL if requested pin is available but disabled
+ */
+__syscall int pinctrl_config_get(struct device *dev, u16_t pin, u32_t *config);
+
+/** @internal
+ */
+static inline int _impl_pinctrl_config_get(struct device *dev, u16_t pin,
+					   u32_t *config)
+{
+	const struct pinctrl_driver_api *api =
+		(const struct pinctrl_driver_api *)dev->driver_api;
+
+	return api->config.get(dev, pin, config);
+}
+
+/**
+ * @brief Configure a pin.
+ *
+ * @param dev Pointer to the device structure for the driver instance.
+ * @param pin Pin
+ * @param config
+ * @retval 0 on success
+ * @retval -ENOTSUP if requested pin is not available on this controller
+ */
+__syscall int pinctrl_config_set(struct device *dev, u16_t pin, u32_t config);
+
+/** @internal
+ */
+static inline int _impl_pinctrl_config_set(struct device *dev, u16_t pin,
+					   u32_t config)
+{
+	const struct pinctrl_driver_api *api =
+		(const struct pinctrl_driver_api *)dev->driver_api;
+
+	return api->config.set(dev, pin, config);
+}
+
+/**
+ * @brief Get the configuration of a pin group.
+ *
+ * @note To be enabled by CONFIG_PINCTRL_RUNTIME_DTS.
+ *
+ * @param dev Pointer to the device structure for the driver instance.
+ * @param group Pin group
+ * @param[out] configs set to the configuration of the pins in the group
+ * @param[in,out] num_configs number of pin configurations requested/ set.
+ * @retval 0 on success
+ * @retval -ENOTSUP if configuration read out is not available for this group
+ * @retval -EINVAL if the number of available configurations exceeds requested
+ */
+__syscall int pinctrl_config_group_get(struct device *dev,
+				       u16_t group, u32_t *configs,
+				       u16_t *num_configs);
+
+/** @internal
+ */
+static inline int _impl_pinctrl_config_group_get(struct device *dev,
+						 u16_t group, u32_t *configs,
+						 u16_t *num_configs)
+{
+#if CONFIG_PINCTRL_RUNTIME_DTS
+	const struct pinctrl_driver_api *api =
+		(const struct pinctrl_driver_api *)dev->driver_api;
+
+	return api->config.group_get(dev, group, configs, num_configs);
+#else
+	__ASSERT(0, "To be enabled by CONFIG_PINCTRL_RUNTIME_DTS.");
+	return -ENOTSUP;
+#endif /* CONFIG_PINCTRL_RUNTIME_DTS */
+}
+
+
+/**
+ * @brief Configure a group of pins.
+ *
+ * @note To be enabled by CONFIG_PINCTRL_RUNTIME_DTS.
+ *
+ * @param dev Pointer to the device structure for the driver instance.
+ * @param group Pin group
+ * @param configs The configurations of the pins in the group
+ * @param num_configs number of pin configurations to set.
+ * @retval 0 on success
+ * @retval -ENOTSUP if configuration is not available for this group
+ * @retval -EINVAL if number of configurations does not match pins in group
+ */
+__syscall int pinctrl_config_group_set(struct device *dev,
+				       u16_t group, const u32_t *configs,
+				       u16_t num_configs);
+
+/** @internal
+ */
+static inline int _impl_pinctrl_config_group_set(struct device *dev,
+						 u16_t group,
+						 const u32_t *configs,
+						 u16_t num_configs)
+{
+#if CONFIG_PINCTRL_RUNTIME_DTS
+	const struct pinctrl_driver_api *api =
+		(const struct pinctrl_driver_api *)dev->driver_api;
+
+	return api->config.group_set(dev, group, configs, num_configs);
+#else
+	__ASSERT(0, "To be enabled by CONFIG_PINCTRL_RUNTIME_DTS.");
+	return -ENOTSUP;
+#endif /* CONFIG_PINCTRL_RUNTIME_DTS */
+}
+
+/**
+ * @brief Request a pin for muxing.
+ *
+ * @note To be enabled by CONFIG_PINCTRL_RUNTIME_DTS.
+ *
+ * @param dev Pointer to the device structure for the driver instance.
+ * @param pin Pin
+ * @param owner A representation of the owner; typically the device
+ *		name that controls its mux function, or the requested GPIO name
+ * @retval 0 on success
+ * @retval -EBUSY pin already used
+ * @retval -ENOTSUP requested pin is not available on this controller
+ * @retval -ENOMEM can not handle request
+ */
+__syscall int pinctrl_mux_request(struct device *dev, u16_t pin,
+				  const char *owner);
+
+/** @internal
+ */
+static inline int _impl_pinctrl_mux_request(struct device *dev, u16_t pin,
+					    const char *owner)
+{
+#if CONFIG_PINCTRL_RUNTIME_DTS
+	const struct pinctrl_driver_api *api =
+		(const struct pinctrl_driver_api *)dev->driver_api;
+
+	return api->mux.request(dev, pin, owner);
+#else
+	__ASSERT(0, "To be enabled by CONFIG_PINCTRL_RUNTIME_DTS.");
+	return -ENOTSUP;
+#endif /* CONFIG_PINCTRL_RUNTIME_DTS */
+}
+
+/**
+ * @brief Release a pin for muxing.
+ *
+ * After release another may become owner of the pin.
+ *
+ * Only the owner may release a muxed pin.
+ *
+ * @note To be enabled by CONFIG_PINCTRL_RUNTIME_DTS.
+ *
+ * @param dev Pointer to the device structure for the driver instance.
+ * @param pin Pin
+ * @param owner A representation of the owner; typically the device
+ *		name that controls its mux function, or the requested GPIO name
+ * @retval 0 on success
+ * @retval -EACCES owner does not own the pin
+ * @retval -ENOTSUP requested pin is not available on this controller
+ */
+__syscall int pinctrl_mux_free(struct device *dev, u16_t pin,
+			       const char *owner);
+
+/** @internal
+ */
+static inline int _impl_pinctrl_mux_free(struct device *dev, u16_t pin,
+					 const char *owner)
+{
+#if CONFIG_PINCTRL_RUNTIME_DTS
+	const struct pinctrl_driver_api *api =
+		(const struct pinctrl_driver_api *)dev->driver_api;
+
+	return api->mux.free(dev, pin, owner);
+#else
+	__ASSERT(0, "To be enabled by CONFIG_PINCTRL_RUNTIME_DTS.");
+	return -ENOTSUP;
+#endif /* CONFIG_PINCTRL_RUNTIME_DTS */
+}
+
+/**
+ * @brief Get muxing function at pin
+ *
+ * @param dev Pointer to the device structure for the driver instance.
+ * @param pin Pin
+ * @param[out] func Muxing function
+ * @retval 0 on success
+ * @retval -ENOTSUP if requested pin is not available on this controller
+ */
+__syscall int pinctrl_mux_get(struct device *dev, u16_t pin, u16_t *func);
+
+/** @internal
+ */
+static inline int _impl_pinctrl_mux_get(struct device *dev, u16_t pin,
+					u16_t *func)
+{
+	const struct pinctrl_driver_api *api =
+		(const struct pinctrl_driver_api *)dev->driver_api;
+
+	return api->mux.get(dev, pin, func);
+}
+
+/**
+ * @brief Set muxing function at pin
+ *
+ * @param dev Pointer to the device structure for the driver instance.
+ * @param pin Pin
+ * @param func Muxing function
+ * @retval 0 on success
+ * @retval -ENOTSUP if requested pin is not available on this controller
+ */
+__syscall int pinctrl_mux_set(struct device *dev, u16_t pin, u16_t func);
+
+/** @internal
+ */
+static inline int _impl_pinctrl_mux_set(struct device *dev, u16_t pin,
+					u16_t func)
+{
+	const struct pinctrl_driver_api *api =
+		(const struct pinctrl_driver_api *)dev->driver_api;
+
+	return api->mux.set(dev, pin, func);
+}
+
+/**
+ * @brief Set muxing function for a group of pins
+ *
+ * @note To be enabled by CONFIG_PINCTRL_RUNTIME_DTS.
+ *
+ * @param dev Pointer to the device structure for the driver instance.
+ * @param group Group
+ * @param func Muxing function
+ * @retval 0 on success
+ * @retval -ENOTSUP if requested function or group is not available
+ *                  on this controller
+ * @retval -EINVAL if group does no belong to function
+ */
+__syscall int pinctrl_mux_group_set(struct device *dev, u16_t group,
+				    u16_t func);
+
+/** @internal
+ */
+static inline int _impl_pinctrl_mux_group_set(struct device *dev, u16_t group,
+					      u16_t func)
+{
+#if CONFIG_PINCTRL_RUNTIME_DTS
+	const struct pinctrl_driver_api *api =
+		(const struct pinctrl_driver_api *)dev->driver_api;
+
+	return api->mux.group_set(dev, group, func);
+#else
+	__ASSERT(0, "To be enabled by CONFIG_PINCTRL_RUNTIME_DTS.");
+	return -ENOTSUP;
+#endif /* CONFIG_PINCTRL_RUNTIME_DTS */
+}
+
+/**
+ * @brief Set pinctrl state.
+ *
+ * @param dev Pointer to the device structure for the driver instance.
+ * @param state State
+ * @retval 0 on success
+ * @retval -ENOTSUP if requested state is not available on this controller
+ */
+__syscall int pinctrl_state_set(struct device *dev, u16_t state);
+
+/** @internal
+ */
+static inline int _impl_pinctrl_state_set(struct device *dev, u16_t state)
+{
+	const struct pinctrl_driver_api *api =
+		(const struct pinctrl_driver_api *)dev->driver_api;
+
+	return api->state.set(dev, state);
+}
+
+
+#if defined(CONFIG_PINCTRL_PINMUX)
+
+/**
+ * @brief PINCTRL PINMUX interface
+ * @defgroup pinctrl_interface_pinmux PINCTRL PINMUX interface
+ * @ingroup pinctrl_interface
+ * @{
+ */
+
+#define CONFIG_PINMUX_NAME CONFIG_PINCTRL_NAME
+
+#define PINMUX_FUNC_A		PINCTRL_FUNCTION_HARDWARE_0
+#define PINMUX_FUNC_B		PINCTRL_FUNCTION_HARDWARE_1
+#define PINMUX_FUNC_C		PINCTRL_FUNCTION_HARDWARE_2
+#define PINMUX_FUNC_D		PINCTRL_FUNCTION_HARDWARE_3
+#define PINMUX_FUNC_E		PINCTRL_FUNCTION_HARDWARE_4
+#define PINMUX_FUNC_F		PINCTRL_FUNCTION_HARDWARE_5
+#define PINMUX_FUNC_G		PINCTRL_FUNCTION_HARDWARE_6
+#define PINMUX_FUNC_H		PINCTRL_FUNCTION_HARDWARE_7
+
+#define PINMUX_PULLUP_ENABLE	(0x1)
+#define PINMUX_PULLUP_DISABLE	(0x0)
+
+#define PINMUX_INPUT_ENABLED	(0x1)
+#define PINMUX_OUTPUT_ENABLED	(0x0)
+
+/**
+ * @brief Set pin function.
+ *
+ * @deprecated Use pinctrl_mux_set() instead.
+ */
+static inline int pinmux_pin_set(struct device *dev, u32_t pin, u16_t func)
+{
+	return pinctrl_mux_set(dev, (u16_t)pin, func);
+}
+
+/**
+ * @brief Get pin function.
+ *
+ * @deprecated Use pinctrl_mux_get() instead.
+ */
+static inline int pinmux_pin_get(struct device *dev, u32_t pin, u16_t *func)
+{
+	return pinctrl_mux_get(dev, (u16_t)pin, func);
+}
+
+/**
+ * @brief Set pin pullup.
+ *
+ * @deprecated Use pinctrl_config_set() instead.
+ */
+static inline int pinmux_pin_pullup(struct device *dev, u32_t pin, u8_t func)
+{
+	int ret;
+	u32_t config;
+
+	ret = pinctrl_config_get(dev, (u16_t)pin, &config);
+	if (ret != 0) {
+		return ret;
+	}
+	config &= ~PINCTRL_CONFIG_BIAS_MASK;
+	if (func == PINMUX_PULLUP_ENABLE) {
+		config |= PINCTRL_CONFIG_BIAS_PULL_UP;
+	} else {
+		config |= PINCTRL_CONFIG_BIAS_PULL_PIN_DEFAULT;
+	}
+	return pinctrl_config_set(dev, (u16_t)pin, config);
+}
+
+/**
+ * @brief Enable pin input.
+ *
+ * @deprecated Use pinctrl_config_set() instead.
+ */
+static inline int pinmux_pin_input_enable(struct device *dev, u32_t pin,
+					  u8_t func)
+{
+	int ret;
+	u32_t config;
+
+	ret = pinctrl_config_get(dev, (u16_t)pin, &config);
+	if (ret != 0) {
+		return ret;
+	}
+	config &= ~PINCTRL_CONFIG_INPUT_MASK;
+	if (func == PINMUX_INPUT_ENABLED) {
+		config |= PINCTRL_CONFIG_INPUT_ENABLE;
+	} else {
+		config |= PINCTRL_CONFIG_INPUT_DISABLE;
+	}
+	return pinctrl_config_set(dev, (u16_t)pin, config);
+}
+
+/**
+ * @} pinctrl_interface_pinmux
+ */
+
+#endif /* defined(CONFIG_PINCTRL_PINMUX) */
+
+#ifdef __cplusplus
+}
+#endif
+
+/**
+ * @} pinctrl_interface
+ */
+
+#include <syscalls/pinctrl.h>
+
+#endif /* __INCLUDE_PINCTRL_H */

--- a/include/pinctrl_common.h
+++ b/include/pinctrl_common.h
@@ -1,0 +1,342 @@
+/*
+ * Copyright (c) 2017 Bobby Noelte
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef _PINCTRL_COMMON_H_
+#define _PINCTRL_COMMON_H_
+
+/**
+ * @brief PINCTRL Pin Configurations
+ * @defgroup pinctrl_interface_pin_configurations PINCTRL Pin Configurations
+ * @ingroup pinctrl_interface
+ * @{
+ */
+
+/**
+ * @def PINCTRL_CONFIG_BIAS_DISABLE
+ * @brief Disable any pin bias.
+ */
+#define PINCTRL_CONFIG_BIAS_DISABLE             (1<<0)
+/**
+ * @def PINCTRL_CONFIG_BIAS_HIGH_IMPEDANCE
+ * @brief High impedance mode ("third-state", "floating").
+ */
+#define PINCTRL_CONFIG_BIAS_HIGH_IMPEDANCE	(1<<1)
+/**
+ * @def PINCTRL_CONFIG_BIAS_BUS_HOLD
+ * @brief Latch weakly.
+ */
+#define PINCTRL_CONFIG_BIAS_BUS_HOLD		(1<<2)
+/**
+ * @def PINCTRL_CONFIG_BIAS_PULL_UP
+ * @brief Pull up the pin.
+ */
+#define PINCTRL_CONFIG_BIAS_PULL_UP		(1<<3)
+/**
+ * @def PINCTRL_CONFIG_BIAS_PULL_DOWN
+ * @brief Pull down the pin.
+ */
+#define PINCTRL_CONFIG_BIAS_PULL_DOWN		(1<<4)
+/**
+ * @def PINCTRL_CONFIG_BIAS_PULL_PIN_DEFAULT
+ * @brief Use pin default pull state.
+ */
+#define PINCTRL_CONFIG_BIAS_PULL_PIN_DEFAULT	(1<<5)
+/**
+ * @def PINCTRL_CONFIG_DRIVE_PUSH_PULL
+ * @brief Drive actively high and low.
+ */
+#define PINCTRL_CONFIG_DRIVE_PUSH_PULL		(1<<6)
+/**
+ * @def PINCTRL_CONFIG_DRIVE_OPEN_DRAIN
+ * @brief Drive with open drain (open collector).
+ */
+#define PINCTRL_CONFIG_DRIVE_OPEN_DRAIN		(1<<7)
+/**
+ * @def PINCTRL_CONFIG_DRIVE_OPEN_SOURCE
+ * @brief Drive with open source (open emitter).
+ */
+#define PINCTRL_CONFIG_DRIVE_OPEN_SOURCE	(1<<8)
+/**
+ * @def PINCTRL_CONFIG_DRIVE_STRENGTH_DEFAULT
+ * @brief Drive with default drive strength.
+ */
+#define PINCTRL_CONFIG_DRIVE_STRENGTH_DEFAULT	(0<<9)
+/**
+ * @def PINCTRL_CONFIG_DRIVE_STRENGTH_1
+ * @brief Drive with minimum drive strength.
+ */
+#define PINCTRL_CONFIG_DRIVE_STRENGTH_1		(1<<9)
+/**
+ * @def PINCTRL_CONFIG_DRIVE_STRENGTH_2
+ * @brief Drive with minimum to medium drive strength.
+ */
+#define PINCTRL_CONFIG_DRIVE_STRENGTH_2		(2<<9)
+/**
+ * @def PINCTRL_CONFIG_DRIVE_STRENGTH_3
+ * @brief Drive with minimum to medium drive strength.
+ */
+#define PINCTRL_CONFIG_DRIVE_STRENGTH_3		(3<<9)
+/**
+ * @def PINCTRL_CONFIG_DRIVE_STRENGTH_4
+ * @brief Drive with medium drive strength.
+ */
+#define PINCTRL_CONFIG_DRIVE_STRENGTH_4		(4<<9)
+/**
+ * @def PINCTRL_CONFIG_DRIVE_STRENGTH_5
+ * @brief Drive with medium to maximum drive strength.
+ */
+#define PINCTRL_CONFIG_DRIVE_STRENGTH_5		(5<<9)
+/**
+ * @def PINCTRL_CONFIG_DRIVE_STRENGTH_6
+ * @brief Drive with medium to maximum drive strength.
+ */
+#define PINCTRL_CONFIG_DRIVE_STRENGTH_6		(6<<9)
+/**
+ * @def PINCTRL_CONFIG_DRIVE_STRENGTH_7
+ * @brief Drive with maximum drive strength.
+ */
+#define PINCTRL_CONFIG_DRIVE_STRENGTH_7		(7<<9)
+/**
+ * @def PINCTRL_CONFIG_INPUT_ENABLE
+ * @brief Enable the pins input.
+ * @note Does not affect the pin's ability to drive output.
+ */
+#define PINCTRL_CONFIG_INPUT_ENABLE		(1<<12)
+/**
+ * @def PINCTRL_CONFIG_INPUT_DISABLE
+ * @brief Disable the pins input.
+ * @note Does not affect the pin's ability to drive output.
+ */
+#define PINCTRL_CONFIG_INPUT_DISABLE		(1<<13)
+/**
+ * @def PINCTRL_CONFIG_INPUT_SCHMITT_ENABLE
+ * @brief Enable schmitt trigger mode for input.
+ */
+#define PINCTRL_CONFIG_INPUT_SCHMITT_ENABLE	(1<<14)
+/**
+ * @def PINCTRL_CONFIG_INPUT_SCHMITT_DISABLE
+ * @brief Disable schmitt trigger mode for input.
+ */
+#define PINCTRL_CONFIG_INPUT_SCHMITT_DISABLE	(1<<15)
+/**
+ * @def PINCTRL_CONFIG_INPUT_DEBOUNCE_NONE
+ * @brief Do not debounce input.
+ */
+#define PINCTRL_CONFIG_INPUT_DEBOUNCE_NONE	(0<<16)
+/**
+ * @def PINCTRL_CONFIG_INPUT_DEBOUNCE_SHORT
+ * @brief Debounce input with short debounce time.
+ */
+#define PINCTRL_CONFIG_INPUT_DEBOUNCE_SHORT	(1<<16)
+/**
+ * @def PINCTRL_CONFIG_INPUT_DEBOUNCE_MEDIUM
+ * @brief Debounce input with medium debounce time.
+ */
+#define PINCTRL_CONFIG_INPUT_DEBOUNCE_MEDIUM	(2<<16)
+/**
+ * @def PINCTRL_CONFIG_INPUT_DEBOUNCE_LONG
+ * @brief Debounce input with long debounce time.
+ */
+#define PINCTRL_CONFIG_INPUT_DEBOUNCE_LONG	(3<<16)
+/**
+ * @def PINCTRL_CONFIG_POWER_SOURCE_DEFAULT
+ * @brief Select default power source for pin.
+ */
+#define PINCTRL_CONFIG_POWER_SOURCE_DEFAULT	(0<<18)
+/**
+ * @def PINCTRL_CONFIG_POWER_SOURCE_1
+ * @brief Select power source #1 for pin.
+ */
+#define PINCTRL_CONFIG_POWER_SOURCE_1		(1<<18)
+/**
+ * @def PINCTRL_CONFIG_POWER_SOURCE_2
+ * @brief Select power source #2 for pin.
+ */
+#define PINCTRL_CONFIG_POWER_SOURCE_2		(2<<18)
+/**
+ * @def PINCTRL_CONFIG_POWER_SOURCE_3
+ * @brief Select power source #3 for pin.
+ */
+#define PINCTRL_CONFIG_POWER_SOURCE_3		(3<<18)
+/**
+ * @def PINCTRL_CONFIG_LOW_POWER_ENABLE
+ * @brief Enable low power mode.
+ */
+#define PINCTRL_CONFIG_LOW_POWER_ENABLE		(1<<20)
+/**
+ * @def PINCTRL_CONFIG_LOW_POWER_DISABLE
+ * @brief Disable low power mode.
+ */
+#define PINCTRL_CONFIG_LOW_POWER_DISABLE	(1<<21)
+/**
+ * @def PINCTRL_CONFIG_OUTPUT_ENABLE
+ * @brief Enable output on pin.
+ *
+ * Such as connecting the output buffer to the drive stage.
+ *
+ * @note Does not set the output drive.
+ */
+#define PINCTRL_CONFIG_OUTPUT_ENABLE            (1<<22)
+/**
+ * @def PINCTRL_CONFIG_OUTPUT_DISABLE
+ * @brief Disable output on pin.
+ *
+ * Such as disconnecting the output buffer from the drive stage.
+ *
+ * @note Does not reset the output drive.
+ */
+#define PINCTRL_CONFIG_OUTPUT_DISABLE           (1<<23)
+/**
+ * @def PINCTRL_CONFIG_OUTPUT_LOW
+ * @brief Set output to active low.
+ *
+ * A "1" in the output buffer drives the output to low level.
+ */
+#define PINCTRL_CONFIG_OUTPUT_LOW		(1<<24)
+/**
+ * @def PINCTRL_CONFIG_OUTPUT_HIGH
+ * @brief Set output to active high.
+ *
+ * A "1" in the output buffer drives the output to high level.
+ */
+#define PINCTRL_CONFIG_OUTPUT_HIGH		(1<<25)
+/**
+ * @def PINCTRL_CONFIG_SLEW_RATE_SLOW
+ * @brief Select slow slew rate.
+ */
+#define PINCTRL_CONFIG_SLEW_RATE_SLOW		(0<<26)
+/**
+ * @def PINCTRL_CONFIG_SLEW_RATE_MEDIUM
+ * @brief Select medium slew rate.
+ */
+#define PINCTRL_CONFIG_SLEW_RATE_MEDIUM		(1<<26)
+/**
+ * @def PINCTRL_CONFIG_SLEW_RATE_FAST
+ * @brief Select fast slew rate.
+ */
+#define PINCTRL_CONFIG_SLEW_RATE_FAST		(2<<26)
+/**
+ * @def PINCTRL_CONFIG_SLEW_RATE_HIGH
+ * @brief Select high slew rate.
+ */
+#define PINCTRL_CONFIG_SLEW_RATE_HIGH		(3<<26)
+/**
+ * @def PINCTRL_CONFIG_SPEED_SLOW
+ * @brief Select low toggle speed.
+ *
+ * @note Slew rate may be unaffected.
+ */
+#define PINCTRL_CONFIG_SPEED_SLOW		(0<<28)
+/**
+ * @def PINCTRL_CONFIG_SPEED_MEDIUM
+ * @brief Select medium toggle speed.
+ *
+ * @note Slew rate may be unaffected.
+ */
+#define PINCTRL_CONFIG_SPEED_MEDIUM		(1<<28)
+/**
+ * @def PINCTRL_CONFIG_SPEED_FAST
+ * @brief Select fast toggle speed.
+ *
+ * @note Slew rate may be unaffected.
+ */
+#define PINCTRL_CONFIG_SPEED_FAST		(2<<28)
+/**
+ * @def PINCTRL_CONFIG_SPEED_HIGH
+ * @brief Select high toggle speed.
+ *
+ * @note Slew rate may be unaffected.
+ */
+#define PINCTRL_CONFIG_SPEED_HIGH		(3<<28)
+
+/**
+ * @def PINCTRL_CONFIG_BIAS_MASK
+ * @brief Mask for all PINCTRL_CONFIG_BIAS_xxx values.
+ */
+#define PINCTRL_CONFIG_BIAS_MASK	(PINCTRL_CONFIG_BIAS_BUS_HOLD\
+					| PINCTRL_CONFIG_BIAS_DISABLE\
+					| PINCTRL_CONFIG_BIAS_HIGH_IMPEDANCE\
+					| PINCTRL_CONFIG_BIAS_PULL_DOWN\
+					| PINCTRL_CONFIG_BIAS_PULL_PIN_DEFAULT\
+					| PINCTRL_CONFIG_BIAS_PULL_UP)
+
+/**
+ * @def PINCTRL_CONFIG_INPUT_MASK
+ * @brief Mask for PINCTRL_CONFIG_INPUT_ENABLE/DISABLE values.
+ */
+#define PINCTRL_CONFIG_INPUT_MASK	(PINCTRL_CONFIG_INPUT_ENABLE\
+					| PINCTRL_CONFIG_INPUT_DISABLE)
+
+/**
+ * @def PINCTRL_CONFIG_OUTPUT_MASK
+ * @brief Mask for PINCTRL_CONFIG_OUTPUT_ENABLE/DISABLE values.
+ */
+#define PINCTRL_CONFIG_OUTPUT_MASK	(PINCTRL_CONFIG_OUTPUT_ENABLE\
+					| PINCTRL_CONFIG_OUTPUT_DISABLE)
+
+/**
+ * @def PINCTRL_CONFIG_DRIVE_MASK
+ * @brief Mask for PINCTRL_CONFIG_DRIVE_x values.
+ */
+#define PINCTRL_CONFIG_DRIVE_MASK	(PINCTRL_CONFIG_DRIVE_PUSH_PULL\
+					| PINCTRL_CONFIG_DRIVE_OPEN_DRAIN\
+					| PINCTRL_CONFIG_DRIVE_OPEN_SOURCE)
+
+
+/**
+ * @def PINCTRL_CONFIG_DRIVE_STRENGTH_MASK
+ * @brief Mask for PINCTRL_CONFIG_DRIVE_STRENGTH_x values.
+ */
+#define PINCTRL_CONFIG_DRIVE_STRENGTH_MASK	PINCTRL_CONFIG_DRIVE_STRENGTH_7
+
+/**@} pinctrl_interface_pin_configurations */
+
+/**
+ * @brief PINCTRL Functions
+ * @defgroup pinctrl_interface_functions PINCTRL Functions
+ * @ingroup pinctrl_interface
+ * @{
+ */
+
+#define PINCTRL_FUNCTION_HARDWARE_BASE	0
+#define PINCTRL_FUNCTION_HARDWARE_0	(PINCTRL_FUNCTION_HARDWARE_BASE + 0)
+#define PINCTRL_FUNCTION_HARDWARE_1	(PINCTRL_FUNCTION_HARDWARE_BASE + 1)
+#define PINCTRL_FUNCTION_HARDWARE_2	(PINCTRL_FUNCTION_HARDWARE_BASE + 2)
+#define PINCTRL_FUNCTION_HARDWARE_3	(PINCTRL_FUNCTION_HARDWARE_BASE + 3)
+#define PINCTRL_FUNCTION_HARDWARE_4	(PINCTRL_FUNCTION_HARDWARE_BASE + 4)
+#define PINCTRL_FUNCTION_HARDWARE_5	(PINCTRL_FUNCTION_HARDWARE_BASE + 5)
+#define PINCTRL_FUNCTION_HARDWARE_6	(PINCTRL_FUNCTION_HARDWARE_BASE + 6)
+#define PINCTRL_FUNCTION_HARDWARE_7	(PINCTRL_FUNCTION_HARDWARE_BASE + 7)
+#define PINCTRL_FUNCTION_HARDWARE_8	(PINCTRL_FUNCTION_HARDWARE_BASE + 8)
+#define PINCTRL_FUNCTION_HARDWARE_9	(PINCTRL_FUNCTION_HARDWARE_BASE + 9)
+#define PINCTRL_FUNCTION_HARDWARE_10	(PINCTRL_FUNCTION_HARDWARE_BASE + 10)
+#define PINCTRL_FUNCTION_HARDWARE_11	(PINCTRL_FUNCTION_HARDWARE_BASE + 11)
+#define PINCTRL_FUNCTION_HARDWARE_12	(PINCTRL_FUNCTION_HARDWARE_BASE + 12)
+#define PINCTRL_FUNCTION_HARDWARE_13	(PINCTRL_FUNCTION_HARDWARE_BASE + 13)
+#define PINCTRL_FUNCTION_HARDWARE_14	(PINCTRL_FUNCTION_HARDWARE_BASE + 14)
+#define PINCTRL_FUNCTION_HARDWARE_15	(PINCTRL_FUNCTION_HARDWARE_BASE + 15)
+#define PINCTRL_FUNCTION_HARDWARE_16	(PINCTRL_FUNCTION_HARDWARE_BASE + 16)
+#define PINCTRL_FUNCTION_HARDWARE_17	(PINCTRL_FUNCTION_HARDWARE_BASE + 17)
+#define PINCTRL_FUNCTION_HARDWARE_18	(PINCTRL_FUNCTION_HARDWARE_BASE + 18)
+#define PINCTRL_FUNCTION_HARDWARE_19	(PINCTRL_FUNCTION_HARDWARE_BASE + 19)
+#define PINCTRL_FUNCTION_HARDWARE_20	(PINCTRL_FUNCTION_HARDWARE_BASE + 20)
+#define PINCTRL_FUNCTION_HARDWARE_21	(PINCTRL_FUNCTION_HARDWARE_BASE + 21)
+#define PINCTRL_FUNCTION_HARDWARE_22	(PINCTRL_FUNCTION_HARDWARE_BASE + 22)
+#define PINCTRL_FUNCTION_HARDWARE_23	(PINCTRL_FUNCTION_HARDWARE_BASE + 23)
+#define PINCTRL_FUNCTION_HARDWARE_24	(PINCTRL_FUNCTION_HARDWARE_BASE + 24)
+#define PINCTRL_FUNCTION_HARDWARE_25	(PINCTRL_FUNCTION_HARDWARE_BASE + 25)
+#define PINCTRL_FUNCTION_HARDWARE_26	(PINCTRL_FUNCTION_HARDWARE_BASE + 26)
+#define PINCTRL_FUNCTION_HARDWARE_27	(PINCTRL_FUNCTION_HARDWARE_BASE + 27)
+#define PINCTRL_FUNCTION_HARDWARE_28	(PINCTRL_FUNCTION_HARDWARE_BASE + 28)
+#define PINCTRL_FUNCTION_HARDWARE_29	(PINCTRL_FUNCTION_HARDWARE_BASE + 29)
+#define PINCTRL_FUNCTION_HARDWARE_30	(PINCTRL_FUNCTION_HARDWARE_BASE + 30)
+#define PINCTRL_FUNCTION_HARDWARE_31	(PINCTRL_FUNCTION_HARDWARE_BASE + 31)
+#define PINCTRL_FUNCTION_DEVICE_BASE	32
+#define PINCTRL_FUNCTION_DEVICE_0	(PINCTRL_FUNCTION_DEVICE_BASE + 0)
+
+/**@} pinctrl_interface_functions */
+
+#endif /* _PINCTRL_COMMON_H_ */

--- a/include/pinmux.h
+++ b/include/pinmux.h
@@ -12,6 +12,12 @@
 #ifndef __INCLUDE_PINMUX_H
 #define __INCLUDE_PINMUX_H
 
+#if CONFIG_PINCTRL
+/* PINMUX is provided by PINCTRL */
+#include <pinctrl.h>
+#else
+/* Legacy Pinmux Interface */
+
 /**
  * @brief Pinmux Interface
  * @defgroup pinmux_interface Pinmux Interface
@@ -110,5 +116,7 @@ static inline int pinmux_pin_input_enable(struct device *dev, u32_t pin,
  *
  * @}
  */
+
+#endif /* !defined(CONFIG_PINCTRL) */
 
 #endif /* __INCLUDE_PINMUX_H */

--- a/scripts/gen_kobject_list.py
+++ b/scripts/gen_kobject_list.py
@@ -45,6 +45,7 @@ subsystems = [
     "i2s_driver_api",
     "ipm_driver_api",
     "led_driver_api",
+    "pinctrl_driver_api",
     "pinmux_driver_api",
     "pwm_driver_api",
     "entropy_driver_api",


### PR DESCRIPTION
# Overview

This PR provides a new device interface for pin controllers.

The PR is a cut-out from PR #5799 for review but can be independently applied.

The PINCTRL device driver provides applications and other drivers access:
  - to the drivers control properties such as pins, groups, pinctrl states, and functions,
  - to pin configuration,
  - to pin multiplexing, and
  - to pin state setting.

The Zephyr *pin controller* follows the concepts of the Linux [PINCTRL (PIN CONTROL) subsystem](https://www.kernel.org/doc/Documentation/pinctrl.txt).

The Zephyr *pin controller* does not provide the full scope of the Linux PINCTRL subsystem. Also the PINCTRL interface is specific to Zephyr and not compatible (but similar) to the Linux PINCTRL interface.

# Motivation for or Use Case

The prime motivation is to be able to create a pinctrl driver that can configure the pins on startup by the information from the device tree in a standardized way.

Another motivation is that some pin properties (e.g. speed) are not configurable in a standardized way and have to be individually set up by the application directly accessing the HW registers.

The available pinmux interface is very restricted in configuration and muxing capabilities. A major drawback is that the current pinmux interface does not fit to the pinctrl device tree directive - see [pinctrl bindings](https://www.kernel.org/doc/Documentation/devicetree/bindings/pinctrl/pinctrl-bindings.tx).

The new pin controller interface gives much more configuration and muxing capabilities in a standardized way. It allows to use the pinctrl bindings.

# Design Details

The pin controller interface provides the pin control functions similar to Linux and UBoot. It mostly targets compile time configuration (vs. boot time configuration as Linux and UBoot).

The pin controller interface provides the current pinmux interface as a generic shim.

Pin control and GPIO is highly coupled (the same pins). The PINCTRL device interface provides a superset to the GPIO configuraton properties. If the PINCTRL device is selected GPIO devices have to use the new pin controller device for pin configuration. By this change the GPIO interface is also extended by generic pin definitions that allow to define a set of pins for GPIO operations. The generic GPIO pin definitions are automatically selected if the PINCTRL device is selected.

## PINCTRL driver interface

The PINCTRL driver interface API is added in include/pinctrl.h. Defines that may be used in the device tree and in the interface are in include/pinctrl_common.h. That way they can be included from the interface and from the device tree bindings (e.g include/dt-bindings/pinctrl_stm32.h). Within include/pinctrl.h a generic shim that maps the PINMUX interface to the PINCTRL interface is added.

The application programming interface is available in two extension stages:

* Basic interface
  Pin control, and initial pin setup at startup using device tree information.
* Extended interface with run time access to device tree information
  Extended pin control and pin setup at run time using device tree information. The extended functionality is enabled by CONFIG_PINCTRL_RUNTIME_DTS.

Implementations of the extended interface usually need more FLASH and SRAM memory than needed by the basic interface.

## GPIO driver interface extensions

For the GPIO-PINCTRL drivers (GPIO drivers that use the PINCTRL driver for pin configuration) generic PIN defines are introduced. These PIN defines allow to describe a set of pins by just or-ing the defines. Such operations on a set of pins of a port can easily be described and implemented.

By this one also get rid of the BIT() macro for masks:

 gpio_init_callback(&gpio_cb, button_callback, **BIT**(SW0_GPIO_PIN));
 gpio_pin_enable_callback(button_gpio_dev, SW0_GPIO_PIN);
  
becomes

 gpio_init_callback(&gpio_cb, button_callback, SW0_GPIO_PIN);
 gpio_pin_enable_callback(button_gpio_dev, SW0_GPIO_PIN);

# Alternatives

Use current GPIO, pinmux with reduced capabilities and do the rest by the application.

# Test Strategy

A working proof of concept for STM32F0x is available in PR #5799.

Signed-off-by: Bobby Noelte <b0661n0e17e@gmail.com>
