### PR TITLE
[WIP] scripts: extract_dts_includes.py: enhance

### DIFF
--- a/cmake/dts.cmake
+++ b/cmake/dts.cmake
@@ -86,6 +86,7 @@ if(CONFIG_HAS_DTS)
 
   # Run extract_dts_includes.py for the header file
   # generated_dts_board.h
+  set_ifndef(DTS_BINDINGS_DIR ${ZEPHYR_BASE}/dts/bindings)
   set_ifndef(DTS_BOARD_FIXUP_FILE ${BOARD_ROOT}/boards/${ARCH}/${BOARD_FAMILY}/dts.fixup)
   if(EXISTS ${DTS_BOARD_FIXUP_FILE})
     set(DTS_BOARD_FIXUP ${DTS_BOARD_FIXUP_FILE})
@@ -105,7 +106,7 @@ if(CONFIG_HAS_DTS)
 
   set(CMD_EXTRACT_DTS_INCLUDES ${PYTHON_EXECUTABLE} ${ZEPHYR_BASE}/scripts/dts/extract_dts_includes.py
     --dts ${BOARD}.dts_compiled
-    --yaml ${ZEPHYR_BASE}/dts/bindings
+    --yaml ${DTS_BINDINGS_DIR}
     ${DTS_FIXUPS}
     --keyvalue ${GENERATED_DTS_BOARD_CONF}
     --include ${GENERATED_DTS_BOARD_H}

--- a/cmake/dts.cmake
+++ b/cmake/dts.cmake
@@ -10,6 +10,7 @@
 # See ~/zephyr/doc/dts
 set(GENERATED_DTS_BOARD_H    ${PROJECT_BINARY_DIR}/include/generated/generated_dts_board.h)
 set(GENERATED_DTS_BOARD_CONF ${PROJECT_BINARY_DIR}/include/generated/generated_dts_board.conf)
+set(GENERATED_DTS_BOARD_EDTS ${PROJECT_BINARY_DIR}/include/generated/generated_dts_board.json)
 set_ifndef(DTS_SOURCE ${BOARD_ROOT}/boards/${ARCH}/${BOARD_FAMILY}/${BOARD}.dts)
 set_ifndef(DTS_COMMON_OVERLAYS ${ZEPHYR_BASE}/dts/common/common.dts)
 
@@ -108,6 +109,7 @@ if(CONFIG_HAS_DTS)
     ${DTS_FIXUPS}
     --keyvalue ${GENERATED_DTS_BOARD_CONF}
     --include ${GENERATED_DTS_BOARD_H}
+    --edts ${GENERATED_DTS_BOARD_EDTS}
     )
 
   # Run extract_dts_includes.py to create a .conf and a header file that can be

--- a/dts/bindings/can/can.yaml
+++ b/dts/bindings/can/can.yaml
@@ -10,6 +10,11 @@ child:
     bus: can
 
 properties:
+    compatible:
+      type: string
+      category: required
+      description: compatible strings
+      generation: define
     "#address-cells":
       type: int
       category: required
@@ -47,5 +52,5 @@ properties:
       type: array
       category: optional
       description: pinmux information for RX, TX
-      generation: structure
+      generation: define
 ...

--- a/dts/bindings/clock/clock-consumer.yaml
+++ b/dts/bindings/clock/clock-consumer.yaml
@@ -1,0 +1,72 @@
+#
+# Copyright (c) 2018 Bobby Noelte
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+
+# -- Assigned clock parents and rates --
+# Some platforms may require initial configuration of default parent clocks
+# and clock frequencies. Such a configuration can be specified in a device tree
+# node through assigned-clocks, assigned-clock-parents and assigned-clock-rates
+# properties.
+---
+title: Clock Consumer Base Structure
+id: clock-consumer
+version: 0.1
+
+description: >
+    This binding gives the base structures for all clock consumers.
+
+properties:
+
+    clocks:
+      type: array
+      category: required
+      description: >
+        List of phandle and clock specifier pairs, one pair for each clock
+        input to the device. Note - if the clock provider specifies '0' for
+        clock-cells, then only the phandle portion of the pair will appear.
+      generation: define
+
+    clock-names:
+      type: array
+      category: optional
+      description: >
+        List of clock input name strings sorted in the same order as the clocks
+        property.
+      generation: define
+
+    clock-ranges:
+      type: empty
+      category: optional
+      description: >
+        Empty property indicating that child nodes can inherit named clocks from
+        this node. Useful for bus nodes to provide a clock to their children.
+      generation: define
+
+    assigned-clocks:
+      type: array
+      category: optional
+      description: >
+        List of phandle and clock specifier pairs, one pair for each assigned
+        clock input. Note - if the clock provider specifies '0' for
+        clock-cells, then only the phandle portion of the pair will appear.
+      generation: define
+
+    assigned-clock-parents:
+      type: array
+      category: optional
+      description: >
+        List of parent clocks in the form of a phandle and clock
+        specifier pair. The list shall correspond to the clocks listed in the
+        assigned-clocks directive.
+      generation: define
+
+    assigned-clock-rates:
+      type: array
+      category: optional
+      description: >
+        List of frequencies in Hz. The list shall correspond to the clocks
+        listed in the assigned-clocks directive.
+      generation: define
+...

--- a/dts/bindings/clock/clock-provider.yaml
+++ b/dts/bindings/clock/clock-provider.yaml
@@ -1,0 +1,51 @@
+#
+# Copyright (c) 2018 Bobby Noelte
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+---
+title: Clock Provider Base Structure
+id: clock-provider
+version: 0.1
+
+description: >
+    This binding gives the base structures for all clock providers.
+
+properties:
+    compatible:
+      type: string
+      category: required
+      description: compatible strings
+      generation: define
+
+    label:
+      type: string
+      category: required
+      description: Human readable string describing the clock (used by Zephyr for API name)
+      generation: define
+
+    "#clock-cells":
+      type: int
+      category: required
+      description: >
+        This device is providing controllable clocks, the
+        clock_cells property needs to be specified.
+      generation: define
+
+    clock-output-names:
+      type: array
+      category: optional
+      description: >
+        A list of strings of clock output signal names indexed by the first
+        cell in the clock specifier.
+      generation: define
+
+    clock-indices:
+      type: array
+      category: optional
+      description: >
+        The identifying number for the clocks in the node. If it is not linear
+        from zero, then this allows the mapping of identifiers into the
+        clock-output-names array.
+      generation: define
+...

--- a/dts/bindings/clock/fixed-clock.yaml
+++ b/dts/bindings/clock/fixed-clock.yaml
@@ -1,0 +1,52 @@
+#
+# Copyright (c) 2017, b0661n0e17e@gmail.com
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+---
+title: Simple fixed-rate clock sources.
+id: fixed-clock
+version: 0.1
+
+description: >
+    Binding for simple fixed-rate clock sources.
+
+inherits:
+    !include clock-provider.yaml
+
+properties:
+    compatible:
+      constraint: "fixed-clock"
+
+    "#clock-cells":
+      constraint: 0
+
+    clock-frequency:
+      type: int
+      category: required
+      description: Frequency of clock in Hz. Should be a single cell.
+      generation: define
+
+    clock-accuracy:
+      type: int
+      category: optional
+      description: Accuracy of clock in ppb (parts per billion). Should be a single cell.
+      generation: define
+
+    oscillator:
+      type: int
+      category: optional
+      description: clock is an oszillator (a quartz)
+      generation: define
+
+    pinctrl-\d+:
+      type: array
+      category: optional
+      description: pinmux information for clock IN, OUT
+      generation: define
+
+    pinctrl-names:
+      type: array
+      description: names to assign to states
+      category: required
+...

--- a/dts/bindings/gpio/gpio-pinctrl.yaml
+++ b/dts/bindings/gpio/gpio-pinctrl.yaml
@@ -1,0 +1,47 @@
+---
+title: GPIO with PINCTRL base structure
+id: gpio-pinctrl
+version: 0.1
+
+description: >
+    This binding gives the base structures for all GPIO devices node using a PINCTRL backend
+
+properties:
+    compatible:
+      type: string
+      category: required
+      description: compatible strings
+      generation: define
+
+    gpio-controller:
+      type: string
+      category: required
+      description: device controller identification
+      generation: define
+
+    compatible:
+      type: string
+      category: required
+      description: compatible strings
+
+    "#gpio-cells":
+      type: int
+      category: required
+      description: should be 2.
+
+    label:
+      type: string
+      category: required
+      description: Human readable string describing the device (used by Zephyr for device name)
+      generation: define
+
+    gpio-ranges:
+      type: array
+      category: optional
+      description: gpio range in pin controller
+      generation: define
+
+"#cells":
+  - pin
+  - flags
+...

--- a/dts/bindings/i2c/i2c.yaml
+++ b/dts/bindings/i2c/i2c.yaml
@@ -15,27 +15,43 @@ child:
     bus: i2c
 
 properties:
+    compatible:
+      type: string
+      category: required
+      description: compatible strings
+      generation: define
+
     "#address-cells":
       type: int
       category: required
       description: should be 1.
+
     "#size-cells":
       type: int
       category: required
       description: should be 0.
+
     clock-frequency :
       type: int
       category: optional
       description: Initial clock frequency in Hz
       generation: define
+
     clocks:
       type: array
       category: required
       description: Clock gate information
       generation: define
+
     label:
       type: string
       category: required
       description: Human readable string describing the device (used by Zephyr for API name)
+      generation: define
+
+    pinctrl-\d+:
+      type: array
+      category: optional
+      description: pinmux information for SCL, SDA
       generation: define
 ...

--- a/dts/bindings/pinctrl/pinctrl.yaml
+++ b/dts/bindings/pinctrl/pinctrl.yaml
@@ -1,0 +1,42 @@
+#
+# Copyright (c) 2018 Bobby Noelte
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+---
+title: Pinctrl Base Structure
+id: pinctrl
+version: 0.1
+
+description: >
+    This binding gives the base structures for all pin controller devices
+
+properties:
+    pin-controller:
+      type: string
+      category: required
+      description: device controller identification
+      generation: define
+
+    compatible:
+      type: string
+      category: required
+      description: compatible strings
+      generation: define
+
+    "#address-cells":
+      type: int
+      category: required
+      description: should be 1.
+
+    "#size-cells":
+      type: int
+      category: required
+      description: should be 0.
+
+    label:
+      type: string
+      category: required
+      description: Human readable string describing the device (used by Zephyr for device name)
+      generation: define
+...

--- a/dts/bindings/serial/uart.yaml
+++ b/dts/bindings/serial/uart.yaml
@@ -7,6 +7,11 @@ description: >
     This binding gives the base structures for all UART devices
 
 properties:
+    compatible:
+      type: string
+      category: required
+      description: compatible strings
+      generation: define
     clock-frequency:
       type: int
       category: optional

--- a/dts/bindings/spi/spi.yaml
+++ b/dts/bindings/spi/spi.yaml
@@ -15,14 +15,22 @@ child:
     bus: spi
 
 properties:
+    compatible:
+      type: string
+      category: required
+      description: compatible strings
+      generation: define
+
     "#address-cells":
       type: int
       category: required
       description: should be 1.
+
     "#size-cells":
       type: int
       category: required
       description: should be 0.
+
     label:
       type: string
       category: required
@@ -34,5 +42,9 @@ properties:
       category: optional
       generation: define, use-prop-name
 
-
+    pinctrl-\d+:
+      type: array
+      category: optional
+      description: pinmux information for SCK, MOSI, MISO
+      generation: define
 ...

--- a/scripts/dts/edtsdatabase.py
+++ b/scripts/dts/edtsdatabase.py
@@ -1,0 +1,193 @@
+#
+# Copyright (c) 2018 Bobby Noelte
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+
+from collections.abc import Mapping
+import json
+
+##
+# @brief Extended DTS database
+#
+# Database schema:
+#
+# _edts dict(
+#   'devices':  dict(device-id :  device-struct),
+#   'compatibles':  dict(compatible : sorted list(device-id)),
+#   'device-types': dict(device-type : sorted list(device-id)),
+#   ...
+# )
+#
+# device-struct: dict(
+#   'device-id' : device-id,
+#   'device-type' : list(device-type) or device-type,
+#   'compatible' : list(compatible) or compatible,
+#   'label' : label,
+#   property-name : property-value ...
+# )
+#
+# Database types:
+#
+# device-id: <compatible>_<base address in hex>_<offset in hex>,
+# compatible: any of ['st,stm32-spi-fifo', ...] - 'compatibe' from <binding>.yaml
+# device-type: any of ['GPIO', 'SPI', 'CAN', ...] - 'id' from <binding>.yaml
+# label: any of ['UART_0', 'SPI_11', ...] - label directive from DTS
+#
+class EDTSDatabase(Mapping):
+
+    def __init__(self, *args, **kw):
+        self._edts = dict(*args, **kw)
+        # setup basic database schema
+        for edts_key in ('devices', 'compatibles', 'device-types'):
+            if not edts_key in self._edts:
+                self._edts[edts_key] = dict()
+
+    def __getitem__(self, key):
+        return self._edts[key]
+
+    def __iter__(self):
+        return iter(self._edts)
+
+    def __len__(self):
+        return len(self._edts)
+
+    def convert_string_to_label(self, s):
+        # Transmute ,-@/ to _
+        s = s.replace("-", "_")
+        s = s.replace(",", "_")
+        s = s.replace("@", "_")
+        s = s.replace("/", "_")
+        # Uppercase the string
+        s = s.upper()
+        return s
+
+    def device_id(self, compatible, base_address, offset):
+        # sanitize
+        base_address = int(base_address)
+        offset = int(offset)
+        compatibe = self.convert_string_to_label(compatible.strip())
+        return "{}_{:08X}_{:02X}".format(compatible, base_address, offset)
+
+    def device_id_by_label(self, label):
+        for device in self._edts['devices']:
+            if label == device['label']:
+                return device['device-id']
+
+    def _update_device_compatible(self, device_id, compatible):
+        if compatible not in self._edts['compatibles']:
+            self._edts['compatibles'][compatible] = list()
+        if device_id not in self._edts['compatibles'][compatible]:
+            self._edts['compatibles'][compatible].append(device_id)
+            self._edts['compatibles'][compatible].sort()
+
+    def _update_device_type(self, device_id, device_type):
+        if device_type not in self._edts['device-types']:
+            self._edts['device-types'][device_type] = list()
+        if device_id not in self._edts['device-types'][device_type]:
+            self._edts['device-types'][device_type].append(device_id)
+            self._edts['device-types'][device_type].sort()
+
+    ##
+    # @brief Insert property value for the device of the given device id.
+    #
+    # @param device_id
+    # @param property_path Path of the property to access
+    #                      (e.g. 'reg/0', 'interrupts/prio', 'label', ...)
+    # @param property_value value
+    #
+    def insert_device_property(self, device_id, property_path, property_value):
+        # special properties
+        if property_path == 'compatible':
+            self._update_device_compatible(device_id, property_value)
+        elif property_path == 'device-type':
+            self._update_device_type(device_id, property_value)
+
+        # normal property management
+        if device_id not in self._edts['devices']:
+            self._edts['devices'][device_id] = dict()
+            self._edts['devices'][device_id]['device-id'] = device_id
+        if property_path == 'device-id':
+            # already set
+            return
+        keys = property_path.strip("'").split('/')
+        property_access_point = self._edts['devices'][device_id]
+        for i in range(0, len(keys)):
+            if i < len(keys) - 1:
+                # there are remaining keys
+                if keys[i] not in property_access_point:
+                    property_access_point[keys[i]] = dict()
+                property_access_point = property_access_point[key[i]]
+            else:
+                # we have to set the property value
+                if keys[i] in property_access_point:
+                    # There is already a value set
+                    current_value = property_access_point[keys[i]]
+                    if not isinstance(current_value, list):
+                        current_value = [current_value, ]
+                    if isinstance(property_value, list):
+                        property_value = current_value.extend(property_value)
+                    else:
+                        property_value = current_value.append(property_value)
+                property_access_point[keys[i]] = property_value
+
+    ##
+    #
+    # @return list of devices that are compatible
+    def compatible_devices(self, compatible):
+        devices = list()
+        for device_id in self._edts['compatibles'][compatible]:
+            devices.append(self._edts['devices'][device_id])
+        return devices
+
+    ##
+    #
+    # @return list of device ids of activated devices that are compatible
+    def compatible_devices_id(self, compatible):
+        return self._edts['compatibles'].get(compatible, [])
+
+    ##
+    # @brief Get device tree property value for the device of the given device id.
+    #
+    #
+    # @param device_id
+    # @param property_path Path of the property to access
+    #                      (e.g. 'reg/0', 'interrupts/prio', 'device_id', ...)
+    # @return property value
+    #
+    def device_property(self, device_id, property_path, default="<unset>"):
+        property_value = self._edts['devices'][device_id]
+        for key in property_path.strip("'").split('/'):
+            if isinstance(property_value, list):
+                # TODO take into account prop with more than 1 elements of cell_size > 1
+                if isinstance(property_value[0], dict):
+                    property_value = property_value[0]
+            try:
+                property_value = property_value[str(key)]
+            except TypeError:
+                property_value = property_value[int(key)]
+            except KeyError:
+                    # we should have a dict
+                    if isinstance(property_value, dict):
+                        # look for key in labels
+                        for x in range(0, len(property_value['labels'])):
+                            if property_value['labels'][x] == key:
+                                property_value = property_value['data'][x]
+                                break
+                    else:
+                        return "Dict was expected here"
+        if property_value is None:
+            if default == "<unset>":
+                default = \
+                "Device tree property {} not available in {}[{}]".format(property_path, compatible, device_index)
+            return default
+        return property_value
+
+    def load(self, file_path):
+        with open(file_path, "r") as load_file:
+            self._edts = json.load(load_file)
+
+    def save(self, file_path):
+        with open(file_path, "w") as save_file:
+            json.dump(self._edts, save_file, indent = 4)
+

--- a/scripts/dts/extract/clocks.py
+++ b/scripts/dts/extract/clocks.py
@@ -7,17 +7,99 @@
 from extract.globals import *
 from extract.directive import DTDirective
 
+from extract.default import default
+
 ##
 # @brief Manage clocks related directives.
 #
 # Handles:
 # - clocks
+# - clock-names
+# - clock-output-names
+# - clock-indices
+# - clock-ranges
+# - clock-frequency
+# - clock-accuracy
+# - oscillator
+# - assigned-clocks
+# - assigned-clock-parents
+# - assigned-clock-rates
 # directives.
 #
 class DTClocks(DTDirective):
 
     def __init__(self):
-        pass
+        ##
+        # Dictionary of all clocks
+        # primary key is the top node
+        # secondary key is is the clock name,
+        # value is the clock id
+        self._clocks = {}
+
+    ##
+    # @brief Get output clock names of clock provider
+    #
+    def _clock_output_names(self, clock_provider):
+        names = clock_provider['props'].get('clock-output-names', [])
+        if len(names) == 0:
+            names = [clock_provider['props'].get('label', '<clock name unknown>')]
+        elif not isinstance(names, list):
+            names = [names]
+        return names
+
+    ##
+    # @brief Get clock id of output clock of clock provider
+    #
+    # @param clock_provider
+    # @param clock_output_name
+    # @return clock id
+    #
+    def _clock_output_id(self, clock_provider, clock_output_name):
+        clock_output_names = self._clock_output_names(clock_provider)
+        clock_indices = clock_provider['props'].get('clock-indices', None)
+        if clock_indices:
+            if len(clock_output_names) != len(clock_indices):
+                raise Exception(
+                    ("clock-output-names count ({}) does not match"
+                    " clock-indices count ({}) in clock provider {}.")
+                        .format(len(clock_output_names), len(clock_indices),
+                                str(clock_provider['name'])))
+        for i, name in enumerate(clock_output_names):
+            if name == clock_output_name:
+                if clock_indices:
+                    return clock_indices[i]
+                return i
+        return None
+
+    ##
+    # @brief Get clock name of output clock of clock provider
+    #
+    # @param clock_provider
+    # @param clock_output_name
+    # @return clock id
+    #
+    def _clock_output_name(self, clock_provider, clock_output_id):
+        clock_output_names = self._clock_output_names(clock_provider)
+        clock_indices = clock_provider['props'].get('clock-indices', None)
+        if clock_indices:
+            for i, clock_id in enumerate(clock_indices):
+                if clock_id == clock_output_id:
+                    clock_output_id = i
+                    break
+        return clock_output_names[clock_output_id]
+
+    ##
+    # @brief Get clock name of input clock of clock consumer
+    #
+    def _clock_input_name(self, clock_consumer, clock_input_index):
+        clock_names = clock_consumer['props'].get('clock-names', None)
+        if clock_names is None:
+            return "clk{}".format(clock_input_index)
+        if not isinstance(clock_names, list):
+            clock_names = [clock_names]
+        if len(clock_names) <= clock_input_index:
+            return "clk{}".format(clock_input_index)
+        return clock_names[clock_input_index]
 
     def _extract_consumer(self, node_address, yaml, clocks, names, defs, def_label):
 
@@ -25,6 +107,7 @@ class DTClocks(DTDirective):
         clock_consumer_compat = get_compat(node_address)
         clock_consumer_bindings = yaml[clock_consumer_compat]
         clock_consumer_label = self.get_node_label_string(node_address)
+        clock_consumer_clock_names = clock_consumer['props'].get('clock-names', None)
 
         clock_index = 0
         clock_cell_index = 0
@@ -61,6 +144,32 @@ class DTClocks(DTDirective):
                 #####################################
                 prop_def = {}
                 prop_alias = {}
+
+                clock_label_prefix = [clock_consumer_label, 'CLOCK', str(clock_index)]
+
+                # - map clock consumer clock name to clock index
+                clock_label = self.get_label_string([clock_consumer_label,
+                    "CLOCK", "ID", self._clock_input_name(clock_consumer, clock_index)])
+                prop_def[clock_label] = clock_index
+
+                # - define clock provider device
+                clock_label = self.get_label_string(clock_label_prefix + \
+                                                    ["PROVIDER"])
+                prop_def[clock_label] = clock_provider_label
+
+                # - define clock provider output definition
+                for i, cell in enumerate(clock_cells):
+                    if i >= len(clock_cells_names):
+                        clock_cell_name = 'CELL{}'.format(i)
+                    else:
+                        clock_cell_name = clock_cells_names[i]
+                    clock_label = self.get_label_string(clock_label_prefix + \
+                        [clock_cell_name,])
+                    prop_def[clock_label] = str(cell)
+
+                # ------ legacy start
+                # legacy definitions for backwards compatibility
+                # @todo remove legacy definitions
 
                 # Legacy clocks definitions by extract_cells
                 for i, cell in enumerate(clock_cells):
@@ -111,14 +220,174 @@ class DTClocks(DTDirective):
                             clock_alias_label = self.get_label_string([
                                 alias, clock_cell_name, index])
                             prop_alias[clock_alias_label] = clock_label
+                # ------ legacy end
 
                 insert_defs(node_address, defs, prop_def, prop_alias)
 
                 clock_cell_index = 0
                 clock_index += 1
+            # - count of clocks
+            prop_def = {}
+            clock_label = self.get_label_string([clock_consumer_label, \
+                                                 'CLOCK', "COUNT"])
+            prop_def[clock_label] = str(clock_index)
+            insert_defs(node_address, defs, prop_def, {})
+
+    def _extract_assigned(self, node_address, yaml, clocks, names, defs, def_label):
+
+        clock_consumer = reduced[node_address]
+        clock_consumer_label = self.get_node_label_string(node_address)
+        clocks = clock_consumer['props'].get('assigned-clocks', None)
+        clock_parents = clock_consumer['props'].get('assigned-clock-parents', None)
+        clock_rates = clock_consumer['props'].get('assigned-clock-rates', None)
+
+        clock_index = 0
+        clock_cell_index = 0
+        nr_clock_cells = 1 # [phandle, clock specifier] -> 1 specifier
+        clock_provider_node_address = ''
+        clock_provider = {}
+        for cell in clocks:
+            if clock_cell_index == 0:
+                if cell not in phandles:
+                    raise Exception(
+                        ("Could not find the clock provider node {} for assigned-clocks"
+                         " = {} in clock consumer node {}. Did you activate"
+                         " the clock node?. Last clock provider: {}.")
+                            .format(str(cell), str(clocks), node_address,
+                                    str(clock_provider)))
+                clock_provider_node_address = phandles[cell]
+                clock_provider = reduced[clock_provider_node_address]
+                clock_provider_label = self.get_node_label_string( \
+                                                clock_provider_node_address)
+                clock_cells = []
+            else:
+                clock_cells.append(cell)
+            clock_cell_index += 1
+            if clock_cell_index > nr_clock_cells:
+                # clock provider device - assigned clocks info
+                ##############################################
+                prop_def = {}
+                prop_alias = {}
+
+                clock_label_prefix = [clock_provider_label, 'CLOCK', 'OUTPUT',
+                                      str(int(clock_cells[0])), 'ASSIGNED']
+
+                # - define assigned clock rate
+                if len(clock_rates) > clock_index:
+                    clock_label = self.get_label_string(
+                        clock_label_prefix + ["RATE"])
+                    prop_def[clock_label] = clock_rates[clock_index]
+                # - define assigned clock parent
+                if len(clock_parents) > clock_index * 2 + 1:
+                    clock_parent_node_address = phandles[clock_parents[clock_index * 2]]
+                    clock_parent_label = self.get_node_label_string(clock_parent_node_address)
+                    clock_parent_output_id = str(int(clock_parents[clock_index * 2 + 1]))
+                    clock_label = self.get_label_string(
+                        clock_label_prefix + ["PARENT", "CLOCK", "PROVIDER"])
+                    prop_def[clock_label] = clock_parent_label
+                    clock_label = self.get_label_string(
+                        clock_label_prefix + ["PARENT", "CLOCK", "ID"])
+                    prop_def[clock_label] = clock_parent_output_id
+                # - define assigned consumer
+                clock_label = self.get_label_string(
+                    clock_label_prefix + ["CONSUMER"])
+                prop_def[clock_label] = clock_consumer_label
+
+                insert_defs(clock_provider_node_address, defs,
+                            prop_def, prop_alias)
+
+                clock_cell_index = 0
+                clock_index += 1
+
+    def _extract_provider(self, node_address, yaml, prop_list, names, defs, def_label):
+
+        clock_provider_def = {}
+        clock_provider = reduced[node_address]
+        clock_provider_label = self.get_node_label_string(node_address)
+
+        # top node
+        top_node_def = {}
+        top_node_address = node_top_address(node_address)
+        top_node_label = convert_string_to_label(top_node_address)
+        # assure top node in clocks
+        if not top_node_address in self._clocks:
+            self._clocks[top_node_address] = {}
+
+        output_count = 0
+        for output_name in self._clock_output_names(clock_provider):
+            output_id = self._clock_output_id(clock_provider, output_name)
+
+            # - Clock output information is added to the clock provider node
+            clock_label = self.get_label_string([clock_provider_label,
+                "CLOCK", "OUTPUT", str(output_id), "NAME"])
+            clock_provider_def[clock_label] = '"{}"'.format(output_name)
+            clock_label = self.get_label_string([clock_provider_label,
+                "CLOCK", "OUTPUT", "ID", output_name])
+            clock_provider_def[clock_label] = str(output_id)
+            if output_id >= output_count:
+                output_count = output_id + 1
+
+            # - Clock information is added to the top node
+            if output_name in self._clocks[top_node_address]:
+                raise Exception(
+                    ("Clock output name {} used by multiple clock providers."
+                     " Could not allocate to {}.")
+                        .format(output_name, node_address))
+            clock_index = len(self._clocks[top_node_address]) + 1
+            self._clocks[top_node_address][output_name] = clock_index
+            clock_label = self.get_label_string([top_node_label, "CLOCK",
+                                        str(clock_index), "PROVIDER"])
+            top_node_def[clock_label] = clock_provider_label
+            clock_label = self.get_label_string([top_node_label, "CLOCK",
+                                        str(clock_index), "OUTPUT", "ID"])
+            top_node_def[clock_label] = str(output_id)
+            clock_label = self.get_label_string([top_node_label, "CLOCK", "ID",
+                                                output_name])
+            top_node_def[clock_label] = str(clock_index)
+
+        # clock provider clock count
+        clock_label = self.get_label_string([clock_provider_label,
+            "CLOCK", "OUTPUT", "COUNT"])
+        clock_provider_def[clock_label] = str(output_count)
+        insert_defs(node_address, defs, clock_provider_def, {})
+        # top node clock count
+        clock_label = self.get_label_string([top_node_label, "CLOCK", "COUNT"])
+        top_node_def[clock_label] = str(len(self._clocks))
+        insert_defs(top_node_address, defs, top_node_def, {})
 
     ##
     # @brief Extract clocks related directives
+    #
+    # Clock information is added to the top node
+    #   index is free running
+    # - <top node>_CLOCK_<index>_PROVIDER: <clock_provider_label>
+    # - <top node>_CLOCK_<index>_OUTPUT_ID: <clock_provider_output_id>
+    # - <top node>_CLOCK_ID_<clock-name> : <index>
+    #   clock_name taken from provider clock-output-names directive
+    # - <top node>_CLOCK_COUNT: <index> + 1
+    #
+    # Clock output information is added to the clock provider node
+    #   index follows provider clock-output-names amended by clock-indices
+    # - <clock_provider_label>_CLOCK_OUTPUT_<index>_NAME: <clock_name>
+    #   clock_name taken from provider clock-output-names directive
+    # - <clock_provider_label>_CLOCK_OUTPUT_ID_<clock_name> : <index>
+    #   clock_name taken from provider clock-output-names directive
+    # - <clock_provider_label>_CLOCK_OUTPUT_COUNT: <index> + 1
+    #
+    # Assigned clock information is added to the clock provider node.
+    # - <clock_provider_label>_CLOCK_OUTPUT_<index>_ASSIGNED_PARENT_CLOCK_PROVIDER: <clock parent label>
+    # - <clock_provider_label>_CLOCK_OUTPUT_<index>_ASSIGNED_PARENT_CLOCK_ID: <index>
+    # - <clock_provider_label>_CLOCK_OUTPUT_<index>_ASSIGNED_RATE: <clock rate>
+    # - <clock_provider_label>_CLOCK_OUTPUT_<index>_ASSIGNED_CONSUMER: <clock_consumer_label>
+    #
+    # Clock information is added to the clock consumer node
+    #   index follows consumer clocks directive
+    # - <clock_consumer_label>_CLOCK_<index>_<clock-cell-name>: <clock-cell-value>
+    #   clock_cell_name taken from provider #cells binding
+    # - <clock_consumer_label>_CLOCK_<index>_PROVIDER: <clock_provider_label>
+    # - <clock_consumer_label>_CLOCK_ID_<clock_name>: <index>
+    #   clock_name taken from consumer clock-names directive
+    # - <clock_consumer_label>_CLOCK_COUNT: <index> + 1
     #
     # @param node_address Address of node owning the clockxxx definition.
     # @param yaml YAML definition for the owning node.
@@ -140,6 +409,24 @@ class DTClocks(DTDirective):
         if prop == 'clocks':
             # indicator for clock consumers
             self._extract_consumer(node_address, yaml, prop_list, names, defs, def_label)
+        elif prop in ('clock-names', 'clock-ranges'):
+            # covered by _extract_consumer
+            pass
+        elif prop == '#clock-cells':
+            # indicator for clock providers
+            self._extract_provider(node_address, yaml, prop_list, names, defs, def_label)
+        elif prop in ('clock-output-names', 'clock-indices'):
+            # covered by _extract_provider
+            pass
+        elif prop in ('clock-frequency', 'clock-accuracy', 'oscillator'):
+            # use default extraction
+            default.extract(node_address, yaml, prop, names, defs, def_label)
+        elif prop in 'assigned-clocks':
+            # indicator for assigned clocks
+            self._extract_assigned(node_address, yaml, prop_list, names, defs, def_label)
+        elif prop in ('assigned-clock-parents', 'assigned-clock-rates'):
+            # covered by _extract_assigned
+            pass
         else:
             raise Exception(
                 "DTClocks.extract called with unexpected directive ({})."

--- a/scripts/dts/extract/clocks.py
+++ b/scripts/dts/extract/clocks.py
@@ -101,7 +101,7 @@ class DTClocks(DTDirective):
             return "clk{}".format(clock_input_index)
         return clock_names[clock_input_index]
 
-    def _extract_consumer(self, node_address, yaml, clocks, names, defs, def_label):
+    def _extract_consumer(self, node_address, yaml, clocks, names, def_label):
 
         clock_consumer = reduced[node_address]
         clock_consumer_compat = get_compat(node_address)
@@ -222,7 +222,7 @@ class DTClocks(DTDirective):
                             prop_alias[clock_alias_label] = clock_label
                 # ------ legacy end
 
-                insert_defs(node_address, defs, prop_def, prop_alias)
+                insert_defs(node_address, prop_def, prop_alias)
 
                 clock_cell_index = 0
                 clock_index += 1
@@ -231,9 +231,9 @@ class DTClocks(DTDirective):
             clock_label = self.get_label_string([clock_consumer_label, \
                                                  'CLOCK', "COUNT"])
             prop_def[clock_label] = str(clock_index)
-            insert_defs(node_address, defs, prop_def, {})
+            insert_defs(node_address, prop_def, {})
 
-    def _extract_assigned(self, node_address, yaml, clocks, names, defs, def_label):
+    def _extract_assigned(self, node_address, yaml, clocks, names, def_label):
 
         clock_consumer = reduced[node_address]
         clock_consumer_label = self.get_node_label_string(node_address)
@@ -293,13 +293,12 @@ class DTClocks(DTDirective):
                     clock_label_prefix + ["CONSUMER"])
                 prop_def[clock_label] = clock_consumer_label
 
-                insert_defs(clock_provider_node_address, defs,
-                            prop_def, prop_alias)
+                insert_defs(clock_provider_node_address, prop_def, prop_alias)
 
                 clock_cell_index = 0
                 clock_index += 1
 
-    def _extract_provider(self, node_address, yaml, prop_list, names, defs, def_label):
+    def _extract_provider(self, node_address, yaml, prop_list, names, def_label):
 
         clock_provider_def = {}
         clock_provider = reduced[node_address]
@@ -349,11 +348,11 @@ class DTClocks(DTDirective):
         clock_label = self.get_label_string([clock_provider_label,
             "CLOCK", "OUTPUT", "COUNT"])
         clock_provider_def[clock_label] = str(output_count)
-        insert_defs(node_address, defs, clock_provider_def, {})
+        insert_defs(node_address, clock_provider_def, {})
         # top node clock count
         clock_label = self.get_label_string([top_node_label, "CLOCK", "COUNT"])
         top_node_def[clock_label] = str(len(self._clocks))
-        insert_defs(top_node_address, defs, top_node_def, {})
+        insert_defs(top_node_address, top_node_def, {})
 
     ##
     # @brief Extract clocks related directives
@@ -393,10 +392,9 @@ class DTClocks(DTDirective):
     # @param yaml YAML definition for the owning node.
     # @param prop clockxxx property name
     # @param names (unused)
-    # @param[out] defs Property definitions for each node address
     # @param def_label Define label string of node owning the directive.
     #
-    def extract(self, node_address, yaml, prop, names, defs, def_label):
+    def extract(self, node_address, yaml, prop, names, def_label):
 
         properties = reduced[node_address]['props'][prop]
 
@@ -408,22 +406,22 @@ class DTClocks(DTDirective):
 
         if prop == 'clocks':
             # indicator for clock consumers
-            self._extract_consumer(node_address, yaml, prop_list, names, defs, def_label)
+            self._extract_consumer(node_address, yaml, prop_list, names, def_label)
         elif prop in ('clock-names', 'clock-ranges'):
             # covered by _extract_consumer
             pass
         elif prop == '#clock-cells':
             # indicator for clock providers
-            self._extract_provider(node_address, yaml, prop_list, names, defs, def_label)
+            self._extract_provider(node_address, yaml, prop_list, names, def_label)
         elif prop in ('clock-output-names', 'clock-indices'):
             # covered by _extract_provider
             pass
         elif prop in ('clock-frequency', 'clock-accuracy', 'oscillator'):
             # use default extraction
-            default.extract(node_address, yaml, prop, names, defs, def_label)
+            default.extract(node_address, yaml, prop, names, def_label)
         elif prop in 'assigned-clocks':
             # indicator for assigned clocks
-            self._extract_assigned(node_address, yaml, prop_list, names, defs, def_label)
+            self._extract_assigned(node_address, yaml, prop_list, names, def_label)
         elif prop in ('assigned-clock-parents', 'assigned-clock-rates'):
             # covered by _extract_assigned
             pass

--- a/scripts/dts/extract/compatible.py
+++ b/scripts/dts/extract/compatible.py
@@ -1,0 +1,100 @@
+#
+# Copyright (c) 2018 Bobby Noelte
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+
+from extract.globals import *
+from extract.directive import DTDirective
+
+##
+# @brief Manage compatible directives.
+#
+class DTCompatible(DTDirective):
+
+    def __init__(self):
+        self._data = {}
+        ##
+        # Dictionary of all compatible strings
+        # key is the compatible label, value is the compatible id
+        self._compatible = { "UNKNOWN" : 0, }
+        ##
+        # Number of compatible strings
+        self._compatible_count = 1
+
+    ##
+    # @brief Extract compatible
+    #
+    # compatible information is added to the root node
+    # - COMPATIBLE_ID_<compatible_label>: <index>
+    # - COMPATIBLE_COUNT: <index> + 1
+    #
+    # and compatible information is added to the device node
+    # - [device_label]_COMPATIBLE_<index>_ID: <compatible_index>
+    # - [device_label]_COMPATIBLE_COUNT: <index> + 1
+    #
+    # @param node_address Address of node owning the
+    #                     compatible definition.
+    # @param yaml YAML definition for the owning node.
+    # @param prop compatible property name
+    # @param names (unused)
+    # @param[out] defs Property definitions for each node address
+    # @param def_label Define label string of node owning the
+    #                  compatible definition.
+    #
+    def extract(self, node_address, yaml, prop, names, defs, def_label):
+
+        # compatible definition
+        compatible = reduced[node_address]['props'][prop]
+        if not isinstance(compatible, list):
+            compatible = [compatible]
+        device_label = self.get_node_label_string(node_address)
+
+        # address for compatible pseudo node
+        compatible_node_address = "compatible"
+        # label for compatible pseudo node
+        compatible_node_label = "COMPATIBLE"
+
+        # Get the index for the compatible info for this node
+        # (precaution if there are several compatible directives in a node)
+        index_label = self.get_label_string( \
+                    [device_label, "COMPATIBLE", "COUNT"])
+        index = self._data.get(index_label, 0)
+        self._data[index_label] = index + 1
+
+        prop_def = {}
+        for comp in compatible:
+            # sanitize string
+            comp = self.get_label_string([comp])
+            if comp in self._compatible:
+                soc_compatible_index = self._compatible[comp]
+            else:
+                # add new compatible string
+                soc_compatible_index = len(self._compatible)
+                self._compatible[comp] = soc_compatible_index
+
+            compatible_id_label = self.get_label_string([device_label, "COMPATIBLE",
+                                                    str(index), "ID"])
+            prop_def[compatible_id_label] = soc_compatible_index
+            index = index + 1
+
+        self._data[index_label] = index
+        prop_def[index_label] = self._data[index_label]
+
+        # update node of compatible directive with compatible info
+        insert_defs(node_address, defs, prop_def, {})
+
+        # update soc node with compatible info
+        prop_def = {}
+        for comp in self._compatible:
+            compatible_label = self.get_label_string( \
+                                [compatible_node_label, "ID", comp])
+            prop_def[compatible_label] = str(self._compatible[comp])
+        index_label = self.get_label_string( \
+                                [compatible_node_label, "COUNT"])
+        prop_def[index_label] = len(self._compatible)
+        insert_defs(compatible_node_address, defs, prop_def, {})
+
+##
+# @brief Management information for compatible.
+compatible = DTCompatible()

--- a/scripts/dts/extract/compatible.py
+++ b/scripts/dts/extract/compatible.py
@@ -38,11 +38,10 @@ class DTCompatible(DTDirective):
     # @param yaml YAML definition for the owning node.
     # @param prop compatible property name
     # @param names (unused)
-    # @param[out] defs Property definitions for each node address
     # @param def_label Define label string of node owning the
     #                  compatible definition.
     #
-    def extract(self, node_address, yaml, prop, names, defs, def_label):
+    def extract(self, node_address, yaml, prop, names, def_label):
 
         # compatible definition
         compatible = reduced[node_address]['props'][prop]
@@ -82,7 +81,7 @@ class DTCompatible(DTDirective):
         prop_def[index_label] = self._data[index_label]
 
         # update node of compatible directive with compatible info
-        insert_defs(node_address, defs, prop_def, {})
+        insert_defs(node_address, prop_def, {})
 
         # update soc node with compatible info
         prop_def = {}
@@ -93,7 +92,7 @@ class DTCompatible(DTDirective):
         index_label = self.get_label_string( \
                                 [compatible_node_label, "COUNT"])
         prop_def[index_label] = len(self._compatible)
-        insert_defs(compatible_node_address, defs, prop_def, {})
+        insert_defs(compatible_node_address, prop_def, {})
 
 ##
 # @brief Management information for compatible.

--- a/scripts/dts/extract/controller.py
+++ b/scripts/dts/extract/controller.py
@@ -1,0 +1,73 @@
+#
+# Copyright (c) 2018 Bobby Noelte
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+
+from extract.globals import *
+from extract.directive import DTDirective
+
+##
+# @brief Manage <device>-controller directives.
+#
+class DTController(DTDirective):
+
+    def __init__(self):
+        self._controllers = {}
+        self._data = {}
+
+    ##
+    # @brief Extract <device>-controller
+    #
+    # <device>-controller information is added to the top node
+    # - <top node>_<device>_CONTROLLER_<index>: <device_label>
+    # - <top node>_<device>_CONTROLLER_COUNT: <index> + 1
+    #
+    # @param node_address Address of node owning the
+    #                     <device>-controller definition.
+    # @param yaml YAML definition for the owning node.
+    # @param prop <device>-controller property name
+    # @param names (unused)
+    # @param[out] defs Property definitions for each node address
+    # @param def_label Define label string of node owning the
+    #                  <device>-controller definition.
+    #
+    def extract(self, node_address, yaml, prop, names, defs, def_label):
+
+        # <device>-controller definition
+        device = prop.replace('-controller', '')
+        device_label = self.get_node_label_string(node_address)
+
+        # top node
+        top_node_def = {}
+        top_node_address = node_top_address(node_address)
+        top_node_label = convert_string_to_label(top_node_address)
+        # assure top node in controllers
+        if not top_node_address in self._controllers:
+            self._controllers[top_node_address] = {}
+        # assure device in top node
+        if not device in self._controllers[top_node_address]:
+            self._controllers[top_node_address][device] = {}
+
+        # - Controller information is added to the top node
+        if device_label in self._controllers[top_node_address][device]:
+            # raise Exception(
+            print("----------", node_address,
+                "Device address {} used by multiple {} controllers."
+                    .format(device_label, device))
+            return
+        controller_index = len(self._controllers[top_node_address][device])
+        self._controllers[top_node_address][device][device_label] = controller_index
+        controller_label = self.get_label_string([top_node_label, device,
+                                    "CONTROLLER", str(controller_index)])
+        top_node_def[controller_label] = device_label
+
+        # top node controller count
+        controller_label = self.get_label_string([top_node_label, device,
+                                    "CONTROLLER", "COUNT"])
+        top_node_def[controller_label] = str(len(self._controllers[top_node_address][device]))
+        insert_defs(top_node_address, defs, top_node_def, {})
+
+##
+# @brief Management information for [device]-controller.
+controller = DTController()

--- a/scripts/dts/extract/controller.py
+++ b/scripts/dts/extract/controller.py
@@ -28,11 +28,10 @@ class DTController(DTDirective):
     # @param yaml YAML definition for the owning node.
     # @param prop <device>-controller property name
     # @param names (unused)
-    # @param[out] defs Property definitions for each node address
     # @param def_label Define label string of node owning the
     #                  <device>-controller definition.
     #
-    def extract(self, node_address, yaml, prop, names, defs, def_label):
+    def extract(self, node_address, yaml, prop, names, def_label):
 
         # <device>-controller definition
         device = prop.replace('-controller', '')
@@ -66,7 +65,7 @@ class DTController(DTDirective):
         controller_label = self.get_label_string([top_node_label, device,
                                     "CONTROLLER", "COUNT"])
         top_node_def[controller_label] = str(len(self._controllers[top_node_address][device]))
-        insert_defs(top_node_address, defs, top_node_def, {})
+        insert_defs(top_node_address, top_node_def, {})
 
 ##
 # @brief Management information for [device]-controller.

--- a/scripts/dts/extract/default.py
+++ b/scripts/dts/extract/default.py
@@ -22,10 +22,9 @@ class DTDefault(DTDirective):
     # @param yaml YAML definition for the owning node.
     # @param prop property name
     # @param names (unused)
-    # @param[out] defs Property definitions for each node address
     # @param def_label Define label string of node owning the directive.
     #
-    def extract(self, node_address, yaml, prop, names, defs, def_label):
+    def extract(self, node_address, yaml, prop, names, def_label):
         prop_def = {}
         prop_alias = {}
         prop_values = reduced[node_address]['props'][prop]
@@ -55,7 +54,7 @@ class DTDefault(DTDirective):
                     alias = alias_label + '_' + prop_name
                     prop_alias[alias] = label
 
-        insert_defs(node_address, defs, prop_def, prop_alias)
+        insert_defs(node_address, prop_def, prop_alias)
 
 ##
 # @brief Management information for directives handled by default.

--- a/scripts/dts/extract/directive.py
+++ b/scripts/dts/extract/directive.py
@@ -58,8 +58,7 @@ class DTDirective(object):
     # @param yaml YAML definition for the node.
     # @param prop Directive property name
     # @param names Names assigned to directive.
-    # @param[out] defs Property definitions for each node address
     # @param def_label Define label string of node owning the directive.
     #
-    def extract(self, node_address, yaml, prop, names, defs, def_label):
+    def extract(self, node_address, yaml, prop, names, def_label):
         pass

--- a/scripts/dts/extract/flash.py
+++ b/scripts/dts/extract/flash.py
@@ -19,7 +19,7 @@ class DTFlash(DTDirective):
         # Node of the flash
         self._flash_node = None
 
-    def _extract_partition(self, node_address, yaml, prop, names, defs, def_label):
+    def _extract_partition(self, node_address, yaml, prop, names, def_label):
         prop_def = {}
         prop_alias = {}
         node = reduced[node_address]
@@ -51,9 +51,9 @@ class DTFlash(DTDirective):
         prop_alias[label] = self.get_label_string(
             label_prefix + ["SIZE", '0'])
 
-        insert_defs(node_address, defs, prop_def, prop_alias)
+        insert_defs(node_address, prop_def, prop_alias)
 
-    def _extract_flash(self, node_address, yaml, prop, names, defs, def_label):
+    def _extract_flash(self, node_address, yaml, prop, names, def_label):
         load_defs = {}
 
         if node_address == 'dummy-flash':
@@ -63,7 +63,7 @@ class DTFlash(DTDirective):
                 'CONFIG_FLASH_BASE_ADDRESS': 0,
                 'CONFIG_FLASH_SIZE': 0
             }
-            insert_defs(node_address, defs, load_defs, {})
+            insert_defs(node_address, load_defs, {})
             self._flash_base_address = 0
             return
 
@@ -72,14 +72,14 @@ class DTFlash(DTDirective):
         flash_props = ["label", "write-block-size", "erase-block-size"]
         for prop in flash_props:
             if prop in self._flash_node['props']:
-                default.extract(node_address, None, prop, None, defs, def_label)
-        insert_defs(node_address, defs, load_defs, {})
+                default.extract(node_address, None, prop, None, def_label)
+        insert_defs(node_address, load_defs, {})
 
         #for address in reduced:
         #    if address.startswith(node_address) and 'partition@' in address:
-        #        self._extract_partition(address, yaml, 'partition', None, defs, def_label)
+        #        self._extract_partition(address, yaml, 'partition', None, def_label)
 
-    def _extract_code_partition(self, node_address, yaml, prop, names, defs, def_label):
+    def _extract_code_partition(self, node_address, yaml, prop, names, def_label):
         load_defs = {}
 
         if node_address == 'dummy-flash':
@@ -104,7 +104,7 @@ class DTFlash(DTDirective):
             load_defs['CONFIG_FLASH_LOAD_OFFSET'] = 0
             load_defs['CONFIG_FLASH_LOAD_SIZE'] = 0
 
-        insert_defs(node_address, defs, load_defs, {})
+        insert_defs(node_address, load_defs, {})
 
     ##
     # @brief Extract flash
@@ -114,21 +114,20 @@ class DTFlash(DTDirective):
     # @param yaml YAML definition for the owning node.
     # @param prop compatible property name
     # @param names (unused)
-    # @param[out] defs Property definitions for each node address
     # @param def_label Define label string of node owning the
     #                  compatible definition.
     #
-    def extract(self, node_address, yaml, prop, names, defs, def_label):
+    def extract(self, node_address, yaml, prop, names, def_label):
 
         if prop == 'zephyr,flash':
             # indicator for flash
-            self._extract_flash(node_address, yaml, prop, names, defs, def_label)
+            self._extract_flash(node_address, yaml, prop, names, def_label)
         elif prop == 'zephyr,code-partition':
             # indicator for code_partition
-            self._extract_code_partition(node_address, yaml, prop, names, defs, def_label)
+            self._extract_code_partition(node_address, yaml, prop, names, def_label)
         elif prop == 'reg':
             # indicator for partition
-            self._extract_partition(node_address, yaml, prop, names, defs, def_label)
+            self._extract_partition(node_address, yaml, prop, names, def_label)
         else:
             raise Exception(
                 "DTFlash.extract called with unexpected directive ({})."

--- a/scripts/dts/extract/globals.py
+++ b/scripts/dts/extract/globals.py
@@ -1,6 +1,6 @@
 #
 # Copyright (c) 2017 Linaro
-# Copyright (c) 2017 Bobby Noelte
+# Copyright (c) 2018 Bobby Noelte
 #
 # SPDX-License-Identifier: Apache-2.0
 #
@@ -179,3 +179,7 @@ def find_parent_prop(node_address, prop):
                         " has no " + prop + " property")
 
     return parent_prop
+
+def node_top_address(node_address):
+    address = node_address.split('/')[1]
+    return address

--- a/scripts/dts/extract/globals.py
+++ b/scripts/dts/extract/globals.py
@@ -5,13 +5,16 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 
+import sys
 from collections import defaultdict
+import edtsdatabase
 
 # globals
 phandles = {}
 aliases = defaultdict(list)
 chosen = {}
 reduced = {}
+edts = edtsdatabase.EDTSDatabase()
 
 regs_config = {
     'zephyr,flash' : 'CONFIG_FLASH',

--- a/scripts/dts/extract/globals.py
+++ b/scripts/dts/extract/globals.py
@@ -14,6 +14,7 @@ phandles = {}
 aliases = defaultdict(list)
 chosen = {}
 reduced = {}
+defs = {}
 edts = edtsdatabase.EDTSDatabase()
 
 regs_config = {
@@ -117,7 +118,7 @@ def get_phandles(root, name, handles):
                 get_phandles(v, name + k, handles)
 
 
-def insert_defs(node_address, defs, new_defs, new_aliases):
+def insert_defs(node_address, new_defs, new_aliases):
     if node_address in defs:
         if 'aliases' in defs[node_address]:
             defs[node_address]['aliases'].update(new_aliases)

--- a/scripts/dts/extract/gpioranges.py
+++ b/scripts/dts/extract/gpioranges.py
@@ -1,0 +1,133 @@
+#
+# Copyright (c) 2017 Bobby Noelte
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+
+from extract.globals import *
+from extract.directive import DTDirective
+
+##
+# @brief Manage gpio-ranges directive.
+#
+class DTGpioRanges(DTDirective):
+
+    def __init__(self):
+        self._data = {}
+
+    ##
+    # @brief Extract GPIO ranges
+    #
+    # GPIO range information is added to the GPIO port node
+    # - <gpio_label>_GPIO_RANGE_<index>_<property>: <property value>
+    #
+    # and to the pin controller node that controls the GPIO port pins
+    # - <pin_controller_label>_GPIO_RANGE_<index>_<property>: <property value>
+    #
+    # @param node_address Address of node owning the gpio-ranges definition.
+    # @param yaml YAML definition for the owning node.
+    # @param prop gpio-ranges property name
+    # @param names (unused)
+    # @param[out] defs Property definitions for each node address
+    # @param def_label Define label string of node owning the gio-ranges definition.
+    #
+    def extract(self, node_address, yaml, prop, names, defs, def_label):
+
+        # gpio-ranges definition
+        gpio_ranges = reduced[node_address]['props'][prop]
+
+        gpio_range_cells = 3
+        prop_list = []
+        if not isinstance(gpio_ranges, list):
+            prop_list.append(gpio_ranges)
+        else:
+            prop_list = list(gpio_ranges)
+
+        gpio_label = self.get_node_label_string(node_address)
+
+        gpio_range_cell = 0
+        gpio_pin_start = 0
+        gpio_pin_count = 0
+        pin_controller_node_address = ''
+        pin_controller_pin_start = 0
+        for p in prop_list:
+            if gpio_range_cell == 0:
+                pin_controller_node_address = phandles[p]
+            elif gpio_range_cell == 1:
+                gpio_pin_start = p
+            elif gpio_range_cell == 2:
+                pin_controller_pin_start = p
+            elif gpio_range_cell == 3:
+                gpio_pin_count = p
+            if gpio_range_cell < gpio_range_cells:
+                gpio_range_cell += 1
+            else:
+                # pin controller device - gpio range info
+                #########################################
+                pin_controller_label = self.get_node_label_string( \
+                                                pin_controller_node_address)
+                # Get the index for the gpio range info
+                # of the specific pin controller
+                index_label = self.get_label_string( \
+                            [pin_controller_label, "GPIO", "RANGE", "COUNT"])
+                index = self._data.get(index_label, 0)
+                self._data[index_label] = index + 1
+
+                prop_def = {}
+                range_label_prefix = [pin_controller_label, \
+                                       "GPIO", "RANGE", str(index)]
+                # - define label of GPIO device
+                range_label = self.get_label_string(range_label_prefix + ["CLIENT"])
+                prop_def[range_label] = gpio_label
+                # - gpio pin number of base pin of GPIO port
+                range_label = self.get_label_string(range_label_prefix + \
+                                               ["CLIENT", "BASE"])
+                prop_def[range_label] = str(gpio_pin_start)
+                # - pin controller pin number of base pin of GPIO port
+                range_label = self.get_label_string(range_label_prefix + \
+                                               ["BASE"])
+                prop_def[range_label] = str(pin_controller_pin_start)
+                # - number of pins of GPIO port in range
+                #   (consecutive numbers assumed)
+                range_label = self.get_label_string(range_label_prefix + ["NPINS"])
+                prop_def[range_label] = str(gpio_pin_count)
+                # -count of ranges
+                prop_def[index_label] = str(self._data[index_label])
+
+                insert_defs(pin_controller_node_address, defs, prop_def, {})
+
+                # gpio device - gpio range info
+                ###############################
+                index_label = self.get_label_string([gpio_label, \
+                                                "GPIO", "RANGE", "COUNT"])
+                index = self._data.get(index_label, 0)
+                self._data[index_label] = index + 1
+
+                prop_def = {}
+                range_label_prefix = [gpio_label, "GPIO", "RANGE", str(index)]
+                # - define label of pin controller device
+                range_label = self.get_label_string(range_label_prefix + \
+                                               ["CONTROLLER"])
+                prop_def[range_label] = pin_controller_label
+                # - gpio pin number of base pin of GPIO port
+                range_label = self.get_label_string(range_label_prefix + ["BASE"])
+                prop_def[range_label] = str(gpio_pin_start)
+                # - pin controller pin number of base pin of GPIO port
+                range_label = self.get_label_string(range_label_prefix + \
+                                               ["CONTROLLER", "BASE"])
+                prop_def[range_label] = str(pin_controller_pin_start)
+                # - number of pins of GPIO port in range
+                #   (consecutive numbers assumed)
+                range_label = self.get_label_string(range_label_prefix + ["NPINS"])
+                prop_def[range_label] = str(gpio_pin_count)
+                # -count of ranges
+                prop_def[index_label] = str(self._data[index_label])
+
+                insert_defs(node_address, defs, prop_def, {})
+
+                gio_range_cell = 0
+
+##
+# @brief Management information for gpio-ranges.
+gpioranges = DTGpioRanges()
+

--- a/scripts/dts/extract/gpioranges.py
+++ b/scripts/dts/extract/gpioranges.py
@@ -28,10 +28,9 @@ class DTGpioRanges(DTDirective):
     # @param yaml YAML definition for the owning node.
     # @param prop gpio-ranges property name
     # @param names (unused)
-    # @param[out] defs Property definitions for each node address
     # @param def_label Define label string of node owning the gio-ranges definition.
     #
-    def extract(self, node_address, yaml, prop, names, defs, def_label):
+    def extract(self, node_address, yaml, prop, names, def_label):
 
         # gpio-ranges definition
         gpio_ranges = reduced[node_address]['props'][prop]
@@ -94,7 +93,7 @@ class DTGpioRanges(DTDirective):
                 # -count of ranges
                 prop_def[index_label] = str(self._data[index_label])
 
-                insert_defs(pin_controller_node_address, defs, prop_def, {})
+                insert_defs(pin_controller_node_address, prop_def, {})
 
                 # gpio device - gpio range info
                 ###############################
@@ -123,7 +122,7 @@ class DTGpioRanges(DTDirective):
                 # -count of ranges
                 prop_def[index_label] = str(self._data[index_label])
 
-                insert_defs(node_address, defs, prop_def, {})
+                insert_defs(node_address, prop_def, {})
 
                 gio_range_cell = 0
 

--- a/scripts/dts/extract/heuristics.py
+++ b/scripts/dts/extract/heuristics.py
@@ -1,0 +1,66 @@
+#
+# Copyright (c) 2018 Bobby Noelte
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+
+from extract.globals import *
+from extract.directive import DTDirective
+
+from extract.controller import controller
+from extract.default import default
+
+##
+# @brief Generate device tree information based on heuristics.
+#
+class DTHeuristics(DTDirective):
+
+    def __init__(self):
+        pass
+
+    ##
+    # @brief Generate device tree information based on heuristics.
+    #
+    # Device tree properties may have to be deduced by heuristics
+    # as the property definitions are not always consistent across
+    # different node types.
+    #
+    # @param node_address Address of node owning the
+    #                     compatible definition.
+    # @param yaml YAML definition for the owning node.
+    # @param prop compatible property name
+    # @param names (unused)
+    # @param[out] defs Property definitions for each node address
+    # @param def_label Define label string of node owning the
+    #                  compatible definition.
+    #
+    def extract(self, node_address, yaml, prop, names, defs, def_label):
+        # Check for <device>-controllers
+        compatible = reduced[node_address]['props']['compatible']
+        if not isinstance(compatible, list):
+            compatible = [compatible]
+        for compat in compatible:
+            if 'uart' in yaml[compat]['node_type']:
+                controller.extract(node_address, yaml, 'serial-controller', {},
+                                   defs, def_label)
+                break
+            if 'spi' in yaml[compat]['node_type']:
+                controller.extract(node_address, yaml, 'spi-controller', {},
+                                   defs, def_label)
+                break
+            if 'i2c' in yaml[compat]['node_type']:
+                controller.extract(node_address, yaml, 'i2c-controller', {},
+                                   defs, def_label)
+                break
+            if 'clock-provider' in yaml[compat]['node_type']:
+                controller.extract(node_address, yaml, 'clock-controller', {},
+                                   defs, def_label)
+                break
+            if 'can' in yaml[compat]['node_type']:
+                controller.extract(node_address, yaml, 'can-controller', {},
+                                   defs, def_label)
+                break
+
+##
+# @brief Management information for heuristics.
+heuristics = DTHeuristics()

--- a/scripts/dts/extract/heuristics.py
+++ b/scripts/dts/extract/heuristics.py
@@ -30,11 +30,10 @@ class DTHeuristics(DTDirective):
     # @param yaml YAML definition for the owning node.
     # @param prop compatible property name
     # @param names (unused)
-    # @param[out] defs Property definitions for each node address
     # @param def_label Define label string of node owning the
     #                  compatible definition.
     #
-    def extract(self, node_address, yaml, prop, names, defs, def_label):
+    def extract(self, node_address, yaml, prop, names, def_label):
         # Check for <device>-controllers
         compatible = reduced[node_address]['props']['compatible']
         if not isinstance(compatible, list):
@@ -42,23 +41,23 @@ class DTHeuristics(DTDirective):
         for compat in compatible:
             if 'uart' in yaml[compat]['node_type']:
                 controller.extract(node_address, yaml, 'serial-controller', {},
-                                   defs, def_label)
+                                   def_label)
                 break
             if 'spi' in yaml[compat]['node_type']:
                 controller.extract(node_address, yaml, 'spi-controller', {},
-                                   defs, def_label)
+                                   def_label)
                 break
             if 'i2c' in yaml[compat]['node_type']:
                 controller.extract(node_address, yaml, 'i2c-controller', {},
-                                   defs, def_label)
+                                   def_label)
                 break
             if 'clock-provider' in yaml[compat]['node_type']:
                 controller.extract(node_address, yaml, 'clock-controller', {},
-                                   defs, def_label)
+                                   def_label)
                 break
             if 'can' in yaml[compat]['node_type']:
                 controller.extract(node_address, yaml, 'can-controller', {},
-                                   defs, def_label)
+                                   def_label)
                 break
 
 ##

--- a/scripts/dts/extract/interrupts.py
+++ b/scripts/dts/extract/interrupts.py
@@ -34,11 +34,10 @@ class DTInterrupts(DTDirective):
     # @param yaml YAML definition for the owning node.
     # @param prop compatible property name
     # @param names (unused)
-    # @param[out] defs Property definitions for each node address
     # @param def_label Define label string of node owning the
     #                  compatible definition.
     #
-    def extract(self, node_address, yaml, prop, names, defs, def_label):
+    def extract(self, node_address, yaml, prop, names, def_label):
 
         node = reduced[node_address]
 
@@ -83,7 +82,7 @@ class DTInterrupts(DTDirective):
                         prop_alias['_'.join(alias_list)] = l_fqn
 
             index += 1
-            insert_defs(node_address, defs, prop_def, prop_alias)
+            insert_defs(node_address, prop_def, prop_alias)
 
 ##
 # @brief Management information for interrupts.

--- a/scripts/dts/extract/pinctrl.py
+++ b/scripts/dts/extract/pinctrl.py
@@ -595,11 +595,10 @@ class DTPinCtrl(DTDirective):
     # @param yaml YAML definition for the owning node.
     # @param prop pinctrl-x key
     # @param names Names assigned to pinctrl state pinctrl-<index>.
-    # @param[out] defs Property definitions for each node address
     # @param def_label Define label string of client node owning the pinctrl
     #                  definition.
     #
-    def extract(self, node_address, yaml, prop, names, defs, def_label):
+    def extract(self, node_address, yaml, prop, names, def_label):
 
         # Get pinctrl index from pinctrl-<index> directive
         pinctrl_index = int(prop.split('-')[1])
@@ -698,9 +697,9 @@ class DTPinCtrl(DTDirective):
                         label = self.get_label_string([label_prefix, pinconf_prop])
                         pin_controller_prop_def[label] = pinconf
             # update property definitions of related pin controller node
-            insert_defs(pin_controller_node_address, defs, pin_controller_prop_def, {})
+            insert_defs(pin_controller_node_address, pin_controller_prop_def, {})
         # update property definitions of owning node
-        insert_defs(node_address, defs, client_prop_def, {})
+        insert_defs(node_address, client_prop_def, {})
 
 ##
 # @brief Management information for pinctrl-[x].

--- a/scripts/dts/extract/pinctrl.py
+++ b/scripts/dts/extract/pinctrl.py
@@ -12,11 +12,584 @@ from extract.directive import DTDirective
 #
 class DTPinCtrl(DTDirective):
 
+    ##
+    # @brief Boolean type properties for pin configuration by pinctrl.
+    pinconf_bool_props = [
+        "bias-disable", "bias-high-impedance", "bias-bus-hold",
+        "drive-push-pull", "drive-open-drain", "drive-open-source",
+        "input-enable", "input-disable", "input-schmitt-enable",
+        "input-schmitt-disable", "low-power-enable", "low-power-disable",
+        "output-disable", "output-enable", "output-low","output-high"]
+    ##
+    # @brief Boolean or value type properties for pin configuration by pinctrl.
+    pinconf_bool_or_value_props = [
+        "bias-pull-up", "bias-pull-down", "bias-pull-pin-default"]
+    ##
+    # @brief List type properties for pin configuration by pinctrl.
+    pinconf_list_props = [
+        "pinmux", "pins", "group", "drive-strength", "input-debounce",
+        "power-source", "slew-rate", "speed"]
+
     def __init__(self):
-        pass
+        ##
+        # @brief Pinctrl ids in use.
+        #
+        self._pinctrl_ids = {}
+        ##
+        # @brief Number of pinctrls in pinctrl dataset of pin controllers.
+        #
+        self._pinctrl_count = {}
+        ##
+        # @brief Pinctrl label prefix indexed by pinctrl id.
+        #
+        self._pinctrl_label_prefix = {}
+        ##
+        # @brief Function index indexed by pin_controller and function.
+        #
+        self._function_index = {}
+        ##
+        # @brief State name index indexed by pin_controller and state name.
+        #
+        self._state_name_index = {}
+        ##
+        # @brief State index indexed by pin_controller and owner
+        #        and state name index.
+        #
+        self._state_index = {}
+        ##
+        # @brief Pin controller index indexed by owner and pin_controller.
+        #
+        self._pin_controller_index = {}
+
+    ##
+    # @brief Create an unique identifier for a specific pinctrl portion.
+    #
+    # @param client_label Define label string of client node owning the pinctrl
+    #                     definition.
+    # @param pin_controller_label Define Label of pin controller controlling
+    #                             the pin(s) of  the pin configuration
+    # @param pinctrl_name Pinctrl definition name as given by pinctrl-names.
+    # @param pin_config_node_address
+    # @param pin_config_subnode_address
+    # @return pinctrl_id
+    #
+    def _get_pinctrl_id(self, client_label, pin_controller_label, pinctrl_name,
+                        pin_config_node_address, pin_config_subnode_address):
+        pin_config_name = self.get_label_string(\
+                                pin_config_node_address.split('/')[-1:])
+        pin_config_subnode_name = self.get_label_string(\
+                                pin_config_subnode_address.split('/')[-1:])
+        pinctrl_id = client_label + pinctrl_name \
+                        + pin_controller_label + pin_config_name \
+                        + pin_config_subnode_name
+        if pinctrl_id in self._pinctrl_ids:
+            # This pinctrl id is not unique
+            raise Exception("Duplicate pinctrl id '{}' for '{}'."
+                            .format(pinctrl_id, pin_config_subnode_address))
+        else:
+            self._pinctrl_ids[pinctrl_id] = pin_config_subnode_address
+        return pinctrl_id
+
+    ##
+    # @brief Get pin controller's pinctrl label prefix for pinctrl
+    #
+    # @param pinctrl_id Unique identifier of a specific pinctrl portion
+    #
+    def _get_pinctrl_label_prefix(self, pinctrl_id):
+        return self._pinctrl_label_prefix.get(pinctrl_id, None)
+
+    ##
+    # @brief Map pin controller's pinctrl label prefix to pinctrl
+    #
+    # @param pinctrl_id Unique identifier of a specific pinctrl portion
+    #
+    def _map_pinctrl_label_prefix(self, pinctrl_id, pinctrl_label_prefix):
+        self._pinctrl_label_prefix[pinctrl_id]  = pinctrl_label_prefix
+
+    ##
+    # @brief Get the function index within dataset of pin controller.
+    #
+    # @param pin_controller Label string of pin controller.
+    # @param function Label string denoting the node (aka. function).
+    # @retval -1 if there is no function info available.
+    # @returns the function index
+    #
+    def _get_function_index(self, pin_controller, function):
+        if pin_controller in self._function_index and \
+            function in self._function_index[pin_controller]:
+                return self._function_index[pin_controller][function]
+        return -1
+
+    ##
+    # @brief Map the index of function within dataset of pin controller.
+    #
+    # The function is mapped to the node.
+    #
+    # @param pin_controller Label string of pin controller.
+    # @param function Label string denoting the node (aka. function).
+    # @param function_index the function index
+    #
+    def _map_function_index(self, pin_controller, function, function_index):
+        if pin_controller not in self._function_index:
+            self._function_index[pin_controller] = {}
+        self._function_index[pin_controller][function] = function_index
+
+    ##
+    # @brief Get the number of functions in the function dataset of a pin controller.
+    #
+    # @param pin_controller Label string of pin controller.
+    # @return function count
+    #
+    def _get_function_count(self, pin_controller):
+        if pin_controller not in self._function_index:
+            return 0
+        return len(self._function_index[pin_controller])
+
+    ##
+    # @brief Get the state name index within dataset of pin controller.
+    #
+    # @param pin_controller Label string of pin controller.
+    # @param state_name State name.
+    # @retval -1 if there is no state name info available.
+    # @returns the state name index
+    #
+    def _get_state_name_index(self, pin_controller, state_name):
+        if pin_controller in self._state_name_index and \
+            state_name in self._state_name_index[pin_controller]:
+                return self._state_name_index[pin_controller][state_name]
+        return -1
+
+    ##
+    # @brief Map the index of state name within dataset of pin controller.
+    #
+    # @param pin_controller Label string of pin controller.
+    # @param state_name State name.
+    # @param state_name_index the state name index
+    #
+    def _map_state_name_index(self, pin_controller, state_name, state_name_index):
+        if pin_controller not in self._state_name_index:
+            self._state_name_index[pin_controller] = {}
+        self._state_name_index[pin_controller][state_name] = state_name_index
+
+    ##
+    # @brief Get the number of pinctrl state names in the state name dataset of
+    #        a pin controllers.
+    #
+    # @param pin_controller Label string of pin controller.
+    # @return state name count
+    #
+    def _get_state_name_count(self, pin_controller):
+        if pin_controller not in self._state_name_index:
+            return 0
+        return len(self._state_name_index[pin_controller])
+
+    ##
+    # @brief Get the index of pinctrl state within dataset of pin controller.
+    #
+    # @param pin_controller Label string of pin controller.
+    # @param owner Label string denoting the state owner.
+    # @param state_name_index Index of state name of the pinctrl state.
+    # @retval -1 if there is no state available.
+    # @returns the state index
+    #
+    def _get_state_index(self, pin_controller, owner, state_name_index):
+        state_name_index = str(state_name_index)
+        if pin_controller in self._state_index and \
+            owner in self._state_index[pin_controller] and \
+            state_name_index in self._state_index[pin_controller][owner]:
+                return self._state_index[pin_controller][owner][state_name_index]
+        return -1
+
+    ##
+    # @brief Map the index of pinctrl state within dataset of pin controller.
+    #
+    # The state is mapped to the node that owns the pinctrl state with the
+    # given pinctrl name.
+    #
+    # @param pin_controller Label string of pin controller.
+    # @param owner Label string denoting the state owner
+    # @param state_name_index Index of state name of the pinctrl state.
+    # @param state_index the state index
+    #
+    def _map_state_index(self, pin_controller, owner, state_name_index, state_index):
+        state_name_index = str(state_name_index)
+        if pin_controller not in self._state_index:
+            self._state_index[pin_controller] = {}
+        if owner not in self._state_index[pin_controller]:
+            self._state_index[pin_controller][owner] = {}
+        self._state_index[pin_controller][owner][state_name_index] = state_index
+
+    ##
+    # @brief Get the number of pinctrl states in the state dataset of
+    #        a pin controller.
+    #
+    # @param pin_controller Label string of pin controller.
+    # @return state count
+    #
+    def _get_state_count(self, pin_controller):
+        if pin_controller not in self._state_index:
+            return 0
+        state_count = 0
+        for client in self._state_index[pin_controller]:
+            state_count += len(self._state_index[pin_controller][client])
+        return state_count
+
+    ##
+    # @brief Get the index of pin controller info within dataset of client.
+    #
+    # @param owner Label string denoting the pin controller client.
+    # @param pin_controller Label string of pin controller.
+    # @retval -1 if there is no state available.
+    # @returns the pin controller index
+    #
+    def _get_pin_controller_index(self, owner, pin_controller):
+        if owner in self._pin_controller_index and \
+            pin_controller in self._pin_controller_index[owner]:
+                return self._pin_controller_index[owner][pin_controller]
+        return -1
+
+    ##
+    # @brief Map the index of pin controller info within dataset of client.
+    #
+    # The pin controller is mapped to the node (client) that references
+    # the pin controller.
+    #
+    # @param owner Label string denoting the pin controller client.
+    # @param pin_controller Label string of pin controller.
+    # @param pin_controller_index pin controller index
+    #
+    def _map_pin_controller_index(self, owner, pin_controller, pin_controller_index):
+        if owner not in self._pin_controller_index:
+            self._pin_controller_index[owner] = {}
+        self._pin_controller_index[owner][pin_controller] = pin_controller_index
+
+    ##
+    # @brief Get the number of pin controller info in pin controller dataset
+    #        of clients (nodes that issued a pinctrl-x directive).
+    #
+    # @param owner Label string denoting the pin controller client.
+    # @return pin controller count
+    #
+    def _get_pin_controller_count(self, owner):
+        if owner not in self._pin_controller_index:
+            return 0
+        return len(self._pin_controller_index[owner])
+
+    ##
+    # @brief Initialise function info for the pin's pinctrl info
+    #
+    # @param client_label Label of node owning the pin.
+    # @param pin_controller_label Label of pin controller that controls the pin.
+    # @param[out] prop_def Pin controller properties that will be converted
+    #                      to defines.
+    # @return index of function info within pin controllers functions dataset
+    #
+    def _init_function_info(self, client_label, pin_controller_label,
+                            prop_def):
+        index = self._get_function_index(pin_controller_label,
+                                                  client_label)
+        if index < 0:
+            # Function is not mapped
+            # Map function to new pin controller function info
+            index = self._get_function_count(pin_controller_label)
+            self._map_function_index(pin_controller_label,
+                                     client_label, index)
+
+            # Init/update the property describing the total count of functions
+            # of this specific pin controller
+            index_label = self.get_label_string([pin_controller_label,
+                                            "FUNCTION", "COUNT"])
+            prop_def[index_label] = self._get_function_count(pin_controller_label)
+
+            # Set properties describing the function
+            function_label = self.get_label_string([pin_controller_label,
+                                "FUNCTION", str(index), "CLIENT"])
+            prop_def[function_label] = client_label
+        return index
+
+    ##
+    # @brief Initialise state name info for the pin's pinctrl info
+    #
+    # @param pin_controller_label Label of pin controller.
+    # @param pinctrl_name Name assigned to pinctrl state
+    # @param[out] prop_def Pin controller properties that will be converted
+    #                      to defines.
+    # @return index of state name info within pin controllers state name dataset
+    #
+    def _init_state_name_info(self, pin_controller_label, pinctrl_name,
+                                    prop_def):
+        index = self._get_state_name_index(pin_controller_label, pinctrl_name)
+        if index < 0:
+            # State name is not mapped
+            # Map state name to new pin controller state name info
+            index = self._get_state_name_count(pin_controller_label)
+            self._map_state_name_index(pin_controller_label, pinctrl_name,
+                                       index)
+
+            # Init/update the property describing the total count of functions
+            # of this specific pin controller
+            index_label = self.get_label_string([pin_controller_label,
+                                            "STATE", "NAME", "COUNT"])
+            prop_def[index_label] = self._get_state_name_count(
+                                                        pin_controller_label)
+
+            # Set properties describing the state name
+            label = self.get_label_string([pin_controller_label,
+                                                "STATE", "NAME", str(index)])
+            prop_def[label] = pinctrl_name
+        return index
+
+    ##
+    # @brief Initialise pinctrl state info for the pin's pinctrl info
+    #
+    # Pinctrl state info references the function index of the function the
+    # state applies to.
+    #
+    # @param client_label Label of node owning the pin.
+    # @param pin_controller_label Label of pin controller that controls the
+    #                             pin.
+    # @param state_name_index Index of pinctrl state name info within pin
+    #                         controllers state name dataset.
+    # @param function_index Index of function info within pin controllers
+    #                       functions dataset.
+    # @param[out] prop_def Pin controller properties that will be converted
+    #                      to defines.
+    # @return index of state info within pin controllers states dataset
+    #
+    def _init_state_info(self, client_label, pin_controller_label,
+                         state_name_index, function_index, prop_def):
+        index = self._get_state_index(pin_controller_label,
+                                            client_label, state_name_index)
+        if index < 0:
+            # State is not mapped
+            # Map owner state to new pin controller state
+            index = self._get_state_count(pin_controller_label)
+            self._map_state_index(pin_controller_label,
+                                  client_label, state_name_index, index)
+
+            # Init/update the property describing the total count of pinctrl states
+            # of this specific pin controller
+            index_label = self.get_label_string([pin_controller_label,
+                                "PINCTRL", "STATE", "COUNT"])
+            prop_def[index_label] = self._get_state_count(pin_controller_label)
+
+            # Set properties describing the pinctrl state
+            state_label = self.get_label_string([pin_controller_label,
+                            "PINCTRL", "STATE", str(index), "NAME_ID"])
+            prop_def[state_label] = state_name_index
+            state_label = self.get_label_string([pin_controller_label,
+                            "PINCTRL", "STATE", str(index), "FUNCTION_ID"])
+            prop_def[state_label] = function_index
+        return index
+
+    ##
+    # @brief Initialise pinctrl info of pin controller
+    #
+    # Pinctrl info references the pinctrl state index of the state the
+    # pinctrl info belongs to.
+    #
+    # @param pin_controller_label Label of pin controller that controls the
+    #                             pin.
+    # @param state_index Index of state info within pin controllers
+    #                       pinctrl states dataset.
+    # @param[out] prop_def Pin controller properties that will be converted
+    #                      to defines.
+    # @return pinctrl label prefix
+    #
+    def _init_pinctrl_info(self, pin_controller_label, state_index, prop_def):
+        index = self._pinctrl_count.get(pin_controller_label, 0)
+        self._pinctrl_count[pin_controller_label] = index + 1
+
+        # Init/update the property describing the total count of pinctrl info
+        # of this specific pin controller
+        index_label = self.get_label_string([pin_controller_label, \
+                                                        "PINCTRL", "COUNT"])
+        prop_def[index_label] = self._pinctrl_count[pin_controller_label]
+
+        # create initial pin properties (all 0)
+        # will be overridden by "real" configuration
+        pinctrl_label_prefix = [pin_controller_label, "PINCTRL", str(index)]
+        for pinconf_prop in (self.pinconf_bool_props +
+                      self.pinconf_bool_or_value_props +
+                      self.pinconf_list_props):
+            pinctrl_label = self.get_label_string(pinctrl_label_prefix + [pinconf_prop])
+            prop_def[pinctrl_label] = 0
+
+        # Set properties describing the pinctrl info
+        pinctrl_label = self.get_label_string(pinctrl_label_prefix + ['STATE_ID'])
+        prop_def[pinctrl_label] = state_index
+
+        return self.get_label_string(pinctrl_label_prefix)
+
+
+    ##
+    # @brief Initialise pin controller info of the client.
+    #
+    # @param client_label Label of node owning the pin.
+    # @param pin_controller_label Label of pin controller that controls the
+    #                             pin.
+    # @param function_index Index of function info within pin controllers
+    #                       functions dataset.
+    # @param[out] prop_def Client properties that will be converted
+    #                      to defines.
+    # @return Index of pin controller info within client's pin controller
+    #         dataset.
+    #
+    def _init_pin_controller_info(self, client_label, pin_controller_label,
+                                        function_index, prop_def):
+        index = self._get_pin_controller_index(client_label,
+                                               pin_controller_label)
+
+        if index < 0:
+            # Pin controller is not mapped
+            # Map pin controller to new pin controller info of pin owner
+            index = self._get_pin_controller_count(client_label)
+            self._map_pin_controller_index(client_label,
+                                           pin_controller_label, index)
+
+            # Init/update the property describing the total count of
+            # pin controller info of this specific pin owner node
+            index_label = self.get_label_string([client_label,
+                                "PINCTRL", "CONTROLLER", "COUNT"])
+            prop_def[index_label] = \
+                                self._get_pin_controller_count(client_label)
+
+            # Set properties describing the pin controller
+            label = self.get_label_string([client_label,
+                            "PINCTRL", "CONTROLLER", str(index), "CONTROLLER"])
+            prop_def[label] = pin_controller_label
+            label = self.get_label_string([client_label,
+                            "PINCTRL", "CONTROLLER", str(index), "FUNCTION_ID"])
+            prop_def[label] = function_index
+        return index
+
+
+    ##
+    # @brief Initialise pinctrl information of pin.
+    #
+    # Initialise/ update the pinctrl management information.
+    # - Index of initialisation info for the pin of the specific pin controller.
+    #   <pin_controller_label>_PINCTRL_COUNT: <index>
+    # - Mapping from pin pinctrl identifier to pin default label string.
+    #   <pin_pinctrl_id>: <pin_controller_base_label>_PINCTRL_<index>
+    # - Mapping of pinctrl name of owner node to pinctrl state index
+    #   <client_label>_<pinctrl_name>: <state_index>
+    # - Mapping of owner node to pinctrl function index
+    #   <client_label>: <function_index>
+    #
+    # Initialise the pin's pinctrl properties in the pin controller's
+    # properties definition. Four datasets are initialised:
+    # - FUNCTION
+    #   - <pin_controller_label>_FUNCTION_<index>_FUNCTION:
+    #       <client_label>
+    #   - <pin_controller_label>_FUNCTION_<index>_LABEL:
+    #       <client_label>_LABEL
+    #   - <pin_controller_label>_FUNCTION_<index>_BASE_ADDRESS:
+    #       <client_label>_BASE_ADDRESS
+    #   - <pin_controller_label>_FUNCTION_COUNT: <index> + 1
+    # - STATE_NAME
+    #   - <pin_controller_label>_STATE_NAME_<index>: <pinctrl_name>
+    #   - <pin_controller_label>_STATE_NAME_COUNT: <index> + 1
+    # - PINCTRL_STATE
+    #   - <pin_controller_label>_PINCTRL_STATE_<index>_NAME_ID:
+    #       <STATE_NAME index>
+    #   - <pin_controller_label>_PINCTRL_STATE_<index>_FUNCTION_ID:
+    #       <FUNCTION index>
+    #   - <pin_controller_label>_PINCTRL_STATE_COUNT: <index> + 1
+    # - PINCTRL
+    #   - <pin_controller_label>_PINCTRL_<index>_<property>: 0
+    #   - <pin_controller_label>_PINCTRL_<index>_STATE: <PINCTRL_STATE index>
+    #   - <pin_controller_label>_PINCTRL_COUNT: <index> + 1
+    #
+    # Initialise the pin's pinctrl properties in the owner (client) node's
+    # properties definition:
+    # - PINCTRL_CONTROLLER
+    #   - <client_label>_PINCTRL_CONTROLLER_<index>_FUNCTION:
+    #       <FUNCTION index>
+    #   - <client_label>_PINCTRL_CONTROLLER_<index>_LABEL:
+    #       <pin_controller_label>_LABEL
+    #   - <client_label>_PINCTRL_CONTROLLER_<index>_BASE_ADDRESS:
+    #       <pin_controller_label>_BASE_ADDRESS
+    #   - <client_label>_PINCTRL_CONTROLLER_COUNT: <index> + 1
+    # - PINCTRL_<pinctrl_name>
+    #   - <client_label>_PINCTRL_<pinctrl_name>_CONTROLLER:
+    #       <PINCTRL_CONTROLLER index>
+    #   - <client_label>_PINCTRL_<pinctrl_name>_STATE:
+    #       <PINCTRL_STATE index>
+    #
+    # The function assures that the initialisation is only done once.
+    #
+    # @param pinctrl_id Unique identifier for a specific pinctrl portion
+    # @param client_label Label of node issueing the pinctrl directive.
+    # @param pin_controller_label Label string of pin controller controlling the
+    #                             pin.
+    # @param pinctrl_name Name assigned to pinctrl pinctrl-<index>.
+    # @param[out] client_prop_def Pin controller client node properties that will
+    #                            be converted to defines.
+    # @param[out] pin_controller_prop_def Pin controller properties that will
+    #                                     be converted to defines.
+    #
+    def _init_pinctrl(self, pinctrl_id, client_label, pin_controller_label,
+                            pinctrl_name,
+                            client_prop_def, pin_controller_prop_def):
+
+        if self._get_pinctrl_label_prefix(pinctrl_id) is not None:
+            # Already initialized
+            return
+
+        # Set/ get the pin controller's function info
+        pin_controller_function_index = self._init_function_info(
+                                                client_label,
+                                                pin_controller_label,
+                                                pin_controller_prop_def)
+
+        # Set/ get the pin controller's pinctrl state name info
+        pin_controller_state_name_index = self._init_state_name_info(
+                                                pin_controller_label,
+                                                pinctrl_name,
+                                                pin_controller_prop_def)
+
+        # Set/ get the pin controller's pinctrl state info
+        pin_controller_state_index = self._init_state_info(client_label,
+                                                pin_controller_label,
+                                                pin_controller_state_name_index,
+                                                pin_controller_function_index,
+                                                pin_controller_prop_def)
+
+        # Set the pin controller's pinctrl info to initial values
+        pinctrl_label_prefix = self._init_pinctrl_info(
+                                                pin_controller_label,
+                                                pin_controller_state_index,
+                                                pin_controller_prop_def)
+
+        # Set the owner's (client) pin controller info
+        client_pin_controller_index = self._init_pin_controller_info(
+                                                client_label,
+                                                pin_controller_label,
+                                                pin_controller_function_index,
+                                                client_prop_def)
+
+        # Set the owner's (client) pinctrl info
+        pinconf_label = self.get_label_string( \
+                    [client_label, "PINCTRL", pinctrl_name, "CONTROLLER_ID"])
+        client_prop_def[pinconf_label] = client_pin_controller_index
+        pinconf_label = self.get_label_string( \
+                    [client_label, "PINCTRL", pinctrl_name, "STATE_ID"])
+        client_prop_def[pinconf_label] = pin_controller_state_index
+
+        # remember pin controller's pinctrl label prefix associated
+        # to this pinctrl portion
+        self._map_pinctrl_label_prefix(pinctrl_id, pinctrl_label_prefix)
 
     ##
     # @brief Extract pinctrl information.
+    #
+    # Pinctrl information is added to the client node that owns the pinctrl
+    # directive
+    # - <client_label>_PINCTRL_<index>_<property>: <property value>
+    #
+    # and to the pin controller node that controls the pin:
+    # - <pin_controller_label>_PINCTRL_<index>_<property>: <property value>
     #
     # @param node_address Address of node owning the pinctrl definition.
     # @param yaml YAML definition for the owning node.
@@ -28,45 +601,106 @@ class DTPinCtrl(DTDirective):
     #
     def extract(self, node_address, yaml, prop, names, defs, def_label):
 
-        pinconf = reduced[node_address]['props'][prop]
-
-        prop_list = []
-        if not isinstance(pinconf, list):
-            prop_list.append(pinconf)
+        # Get pinctrl index from pinctrl-<index> directive
+        pinctrl_index = int(prop.split('-')[1])
+        # Pinctrl definition
+        pinctrl = reduced[node_address]['props'][prop]
+        # Name of this pinctrl state. Use directive if there is no name.
+        if pinctrl_index >= len(names):
+            pinctrl_name = prop
         else:
-            prop_list = list(pinconf)
+            pinctrl_name = names[pinctrl_index]
 
-        def_prefix = def_label.split('_')
+        pin_config_handles = []
+        if not isinstance(pinctrl, list):
+            pin_config_handles.append(pinctrl)
+        else:
+            pin_config_handles = list(pinctrl)
 
-        prop_def = {}
-        for p in prop_list:
-            pin_node_address = phandles[p]
-            pin_subnode = '/'.join(pin_node_address.split('/')[-1:])
-            cell_yaml = yaml[get_compat(pin_node_address)]
-            cell_prefix = 'PINMUX'
-            post_fix = []
-
-            if cell_prefix is not None:
-                post_fix.append(cell_prefix)
-
-            for subnode in reduced.keys():
-                if pin_subnode in subnode and pin_node_address != subnode:
-                    # found a subnode underneath the pinmux handle
-                    pin_label = def_prefix + post_fix + subnode.split('/')[-2:]
-
-                    for i, cells in enumerate(reduced[subnode]['props']):
-                        key_label = list(pin_label) + \
-                            [cell_yaml['#cells'][0]] + [str(i)]
-                        func_label = key_label[:-2] + \
-                            [cell_yaml['#cells'][1]] + [str(i)]
-                        key_label = convert_string_to_label('_'.join(key_label))
-                        func_label = convert_string_to_label('_'.join(func_label))
-
-                        prop_def[key_label] = cells
-                        prop_def[func_label] = \
-                            reduced[subnode]['props'][cells]
-
-        insert_defs(node_address, defs, prop_def, {})
+        client_prop_def = {}
+        for pin_config_handle in pin_config_handles:
+            pin_config_node_address = phandles[pin_config_handle]
+            pin_config_subnode_prefix = \
+                            '/'.join(pin_config_node_address.split('/')[-1:])
+            pin_controller_node_address = \
+                            '/'.join(pin_config_node_address.split('/')[:-1])
+            pin_controller_label = self.get_node_label_string( \
+                                                pin_controller_node_address)
+            pin_controller_prop_def = {}
+            for subnode_address in reduced:
+                if pin_config_subnode_prefix in subnode_address \
+                    and pin_config_node_address != subnode_address:
+                    # Found a subnode underneath the pin configuration node
+                    # Create an identifier for this specific pinctrl portion.
+                    pinctrl_id = self._get_pinctrl_id(
+                        def_label, pin_controller_label, pinctrl_name,
+                        pin_config_node_address, subnode_address)
+                    # Create pin control directives
+                    pinconf_props = reduced[subnode_address]['props'].keys()
+                    for i, pinconf_prop in enumerate(pinconf_props):
+                        pinconf = reduced[subnode_address]['props'][pinconf_prop]
+                        if pinconf_prop in self.pinconf_bool_props:
+                            self._init_pinctrl(pinctrl_id, def_label, \
+                                pin_controller_label, pinctrl_name, \
+                                client_prop_def, pin_controller_prop_def)
+                            pinconf = 1 if pinconf else 0
+                        elif pinconf_prop in self.pinconf_bool_or_value_props:
+                            self._init_pinctrl(pinctrl_id, def_label, \
+                                pin_controller_label, pinctrl_name, \
+                                client_prop_def, pin_controller_prop_def)
+                            if isinstance(pinconf, bool):
+                                pinconf = 1 if pinconf else 0
+                        elif pinconf_prop in self.pinconf_list_props:
+                            self._init_pinctrl(pinctrl_id, def_label, \
+                                pin_controller_label, pinctrl_name, \
+                                client_prop_def, pin_controller_prop_def)
+                            if isinstance(pinconf, list):
+                                pinconf = ','.join(map(str, pinconf))
+                        else:
+                            # unknown pin configuration property name
+                            # use cell names if available
+                            # (for a pinmux node these are: pin, function)
+                            controller_compat = get_compat(pin_controller_node_address)
+                            if controller_compat is None:
+                                raise Exception("No binding or compatible missing for {}."
+                                                .format(pin_controller_node_address))
+                            controller_yaml = yaml.get(controller_compat, None)
+                            if controller_yaml is None:
+                                raise Exception("No binding for {}."
+                                                .format(controller_compat))
+                            if 'pinmux' in controller_compat:
+                                cell_prefix = 'PINMUX'
+                            else:
+                                cell_prefix = 'PINCTRL'
+                            cell_names = controller_yaml.get('#cells', None)
+                            if cell_names is None:
+                                # No cell names - use default names for pinctrl
+                                cell_names = ['pin', 'function']
+                            pin_label = self.get_label_string([def_label, \
+                                        cell_prefix] + subnode_address.split('/')[-2:] \
+                                        + [cell_names[0], str(i)])
+                            func_label = self.get_label_string([def_label, \
+                                        cell_prefix] + subnode_address.split('/')[-2:] \
+                                        + [cell_names[1], str(i)])
+                            client_prop_def[pin_label] = pinconf_prop
+                            client_prop_def[func_label] = pinconf
+                            # unknown -> skip pin controller property update
+                            continue
+                        # update client pinctrl property definition
+                        pin_config_subnode_name = self.get_label_string(\
+                                subnode_address.split('/')[-1:])
+                        label = self.get_label_string([def_label, "PINCTRL", \
+                                pinctrl_name, pin_config_subnode_name, pinconf_prop])
+                        client_prop_def[label] = pinconf
+                        # update pin controller pinctrl property definition
+                        label_prefix = self._get_pinctrl_label_prefix( \
+                                                                    pinctrl_id)
+                        label = self.get_label_string([label_prefix, pinconf_prop])
+                        pin_controller_prop_def[label] = pinconf
+            # update property definitions of related pin controller node
+            insert_defs(pin_controller_node_address, defs, pin_controller_prop_def, {})
+        # update property definitions of owning node
+        insert_defs(node_address, defs, client_prop_def, {})
 
 ##
 # @brief Management information for pinctrl-[x].

--- a/scripts/dts/extract/reg.py
+++ b/scripts/dts/extract/reg.py
@@ -23,11 +23,10 @@ class DTReg(DTDirective):
     # @param yaml YAML definition for the owning node.
     # @param prop reg property name
     # @param names (unused)
-    # @param[out] defs Property definitions for each node address
     # @param def_label Define label string of node owning the
     #                  compatible definition.
     #
-    def extract(self, node_address, yaml, prop, names, defs, def_label):
+    def extract(self, node_address, yaml, prop, names, def_label):
 
         node = reduced[node_address]
         node_compat = get_compat(node_address)
@@ -99,7 +98,7 @@ class DTReg(DTDirective):
                     prop_alias['_'.join(alias_addr)] = '_'.join(l_base + l_addr)
                     prop_alias['_'.join(alias_size)] = '_'.join(l_base + l_size)
 
-            insert_defs(node_address, defs, prop_def, prop_alias)
+            insert_defs(node_address, prop_def, prop_alias)
 
             # increment index for definition creation
             index += 1

--- a/scripts/dts/extract_dts_includes.py
+++ b/scripts/dts/extract_dts_includes.py
@@ -21,6 +21,7 @@ from devicetree import parse_file
 from extract.globals import *
 
 from extract.clocks import clocks
+from extract.compatible import compatible
 from extract.interrupts import interrupts
 from extract.reg import reg
 from extract.flash import flash
@@ -385,6 +386,8 @@ def extract_property(node_compat, yaml, node_address, prop, prop_val, names,
             reg.extract(node_address, yaml, prop, names, defs, def_label)
     elif prop == 'interrupts' or prop == 'interrupts-extended':
         interrupts.extract(node_address, yaml, prop, names, defs, def_label)
+    elif prop == 'compatible':
+        compatible.extract(node_address, yaml, prop, names, defs, def_label)
     elif 'pinctrl-' in prop:
         pinctrl.extract(node_address, yaml, prop, names, defs, def_label)
     elif 'clocks' in prop:

--- a/scripts/dts/extract_dts_includes.py
+++ b/scripts/dts/extract_dts_includes.py
@@ -22,11 +22,13 @@ from extract.globals import *
 
 from extract.clocks import clocks
 from extract.compatible import compatible
+from extract.controller import controller
 from extract.interrupts import interrupts
 from extract.reg import reg
 from extract.flash import flash
 from extract.pinctrl import pinctrl
 from extract.gpioranges import gpioranges
+from extract.heuristics import heuristics
 from extract.default import default
 
 class Loader(yaml.Loader):
@@ -389,6 +391,11 @@ def extract_property(node_compat, yaml, node_address, prop, prop_val, names,
         interrupts.extract(node_address, yaml, prop, names, defs, def_label)
     elif prop == 'compatible':
         compatible.extract(node_address, yaml, prop, names, defs, def_label)
+        # do extra property definition based on heuristics
+        # do it here as the compatible property is mandatory
+        heuristics.extract(node_address, yaml, prop, names, defs, def_label)
+    elif '-controller' in prop:
+        controller.extract(node_address, yaml, prop, names, defs, def_label)
     elif 'pinctrl-' in prop:
         pinctrl.extract(node_address, yaml, prop, names, defs, def_label)
     elif 'gpio-ranges' in prop:

--- a/scripts/dts/extract_dts_includes.py
+++ b/scripts/dts/extract_dts_includes.py
@@ -15,6 +15,7 @@ import re
 import yaml
 import argparse
 import collections
+from copy import deepcopy
 
 from devicetree import parse_file
 from extract.globals import *
@@ -440,12 +441,17 @@ def extract_node_include_info(reduced, root_node_address, sub_node_address,
                     if re.match(k + '$', c):
 
                         if 'pinctrl-' in c:
-                            names = node['props'].get('pinctrl-names', [])
+                            names = deepcopy(node['props'].get(
+                                                        'pinctrl-names', []))
                         else:
-                            names = node['props'].get(c[:-1] + '-names', [])
-                            if not names:
-                                names = node['props'].get(c + '-names', [])
-
+                            if not c.endswith("-names"):
+                                names = deepcopy(node['props'].get(
+                                                        c[:-1] + '-names', []))
+                                if not names:
+                                    names = deepcopy(node['props'].get(
+                                                            c + '-names', []))
+                            else:
+                                names = []
                         if not isinstance(names, list):
                             names = [names]
 

--- a/scripts/dts/extract_dts_includes.py
+++ b/scripts/dts/extract_dts_includes.py
@@ -390,7 +390,7 @@ def extract_property(node_compat, yaml, node_address, prop, prop_val, names,
         compatible.extract(node_address, yaml, prop, names, defs, def_label)
     elif 'pinctrl-' in prop:
         pinctrl.extract(node_address, yaml, prop, names, defs, def_label)
-    elif 'clocks' in prop:
+    elif prop.startswith(('clock', '#clock', 'assigned-clock', 'oscillator')):
         clocks.extract(node_address, yaml, prop, names, defs, def_label)
     elif 'gpios' in prop:
         try:

--- a/scripts/dts/extract_dts_includes.py
+++ b/scripts/dts/extract_dts_includes.py
@@ -26,6 +26,7 @@ from extract.interrupts import interrupts
 from extract.reg import reg
 from extract.flash import flash
 from extract.pinctrl import pinctrl
+from extract.gpioranges import gpioranges
 from extract.default import default
 
 class Loader(yaml.Loader):
@@ -390,6 +391,8 @@ def extract_property(node_compat, yaml, node_address, prop, prop_val, names,
         compatible.extract(node_address, yaml, prop, names, defs, def_label)
     elif 'pinctrl-' in prop:
         pinctrl.extract(node_address, yaml, prop, names, defs, def_label)
+    elif 'gpio-ranges' in prop:
+        gpioranges.extract(node_address, yaml, prop, names, defs, def_label)
     elif prop.startswith(('clock', '#clock', 'assigned-clock', 'oscillator')):
         clocks.extract(node_address, yaml, prop, names, defs, def_label)
     elif 'gpios' in prop:

--- a/scripts/dts/extract_dts_includes.py
+++ b/scripts/dts/extract_dts_includes.py
@@ -71,7 +71,7 @@ class Loader(yaml.Loader):
             return yaml.load(f, Loader)
 
 
-def extract_reg_prop(node_address, names, defs, def_label, div, post_label):
+def extract_reg_prop(node_address, names, def_label, div, post_label):
 
     reg = reduced[node_address]['props']['reg']
     if type(reg) is not list: reg = [ reg ]
@@ -137,13 +137,13 @@ def extract_reg_prop(node_address, names, defs, def_label, div, post_label):
                 prop_alias['_'.join(alias_addr)] = '_'.join(l_base + l_addr)
                 prop_alias['_'.join(alias_size)] = '_'.join(l_base + l_size)
 
-        insert_defs(node_address, defs, prop_def, prop_alias)
+        insert_defs(node_address, prop_def, prop_alias)
 
         # increment index for definition creation
         index += 1
 
 
-def extract_controller(node_address, yaml, prop, prop_values, index, defs, def_label, generic):
+def extract_controller(node_address, yaml, prop, prop_values, index, def_label, generic):
 
     prop_def = {}
     prop_alias = {}
@@ -199,7 +199,7 @@ def extract_controller(node_address, yaml, prop, prop_values, index, defs, def_l
                 alias = [alias_label] + label[1:]
                 prop_alias['_'.join(alias)] = '_'.join(label)
 
-        insert_defs(node_address, defs, prop_def, prop_alias)
+        insert_defs(node_address, prop_def, prop_alias)
 
     # prop off phandle + num_cells to get to next list item
     prop_values = prop_values[num_cells+1:]
@@ -207,10 +207,10 @@ def extract_controller(node_address, yaml, prop, prop_values, index, defs, def_l
     # recurse if we have anything left
     if len(prop_values):
         extract_controller(node_address, yaml, prop, prop_values, index + 1,
-                           defs, def_label, generic)
+                           def_label, generic)
 
 
-def extract_cells(node_address, yaml, prop, prop_values, names, index, defs,
+def extract_cells(node_address, yaml, prop, prop_values, names, index,
                   def_label, generic):
 
     cell_parent = phandles[prop_values.pop(0)]
@@ -273,15 +273,15 @@ def extract_cells(node_address, yaml, prop, prop_values, names, index, defs,
                 alias = [alias_label] + label[1:]
                 prop_alias['_'.join(alias)] = '_'.join(label)
 
-        insert_defs(node_address, defs, prop_def, prop_alias)
+        insert_defs(node_address, prop_def, prop_alias)
 
     # recurse if we have anything left
     if len(prop_values):
         extract_cells(node_address, yaml, prop, prop_values, names,
-                      index + 1, defs, def_label, generic)
+                      index + 1, def_label, generic)
 
 
-def extract_single(node_address, yaml, prop, key, defs, def_label):
+def extract_single(node_address, yaml, prop, key, def_label):
 
     prop_def = {}
     prop_alias = {}
@@ -311,9 +311,9 @@ def extract_single(node_address, yaml, prop, key, defs, def_label):
                 alias = alias_label + '_' + k
                 prop_alias[alias] = label
 
-    insert_defs(node_address, defs, prop_def, prop_alias)
+    insert_defs(node_address, prop_def, prop_alias)
 
-def extract_string_prop(node_address, yaml, key, label, defs):
+def extract_string_prop(node_address, yaml, key, label):
 
     prop_def = {}
 
@@ -330,7 +330,7 @@ def extract_string_prop(node_address, yaml, key, label, defs):
 
 
 def extract_property(node_compat, yaml, node_address, prop, prop_val, names,
-                     defs, label_override):
+                     label_override):
 
     if 'base_label' in yaml[node_compat]:
         def_label = yaml[node_compat].get('base_label')
@@ -376,7 +376,7 @@ def extract_property(node_compat, yaml, node_address, prop, prop_val, names,
 
             # Generate bus-name define
             extract_single(node_address, yaml, 'parent-label',
-                           'bus-name', defs, def_label)
+                           'bus-name', def_label)
 
     if label_override is not None:
         def_label += '_' + label_override
@@ -384,40 +384,40 @@ def extract_property(node_compat, yaml, node_address, prop, prop_val, names,
     if prop == 'reg':
         if 'partition@' in node_address:
             # reg in partition is covered by flash handling
-            flash.extract(node_address, yaml, prop, names, defs, def_label)
+            flash.extract(node_address, yaml, prop, names, def_label)
         else:
-            reg.extract(node_address, yaml, prop, names, defs, def_label)
+            reg.extract(node_address, yaml, prop, names, def_label)
     elif prop == 'interrupts' or prop == 'interrupts-extended':
-        interrupts.extract(node_address, yaml, prop, names, defs, def_label)
+        interrupts.extract(node_address, yaml, prop, names, def_label)
     elif prop == 'compatible':
-        compatible.extract(node_address, yaml, prop, names, defs, def_label)
+        compatible.extract(node_address, yaml, prop, names, def_label)
         # do extra property definition based on heuristics
         # do it here as the compatible property is mandatory
-        heuristics.extract(node_address, yaml, prop, names, defs, def_label)
+        heuristics.extract(node_address, yaml, prop, names, def_label)
     elif '-controller' in prop:
-        controller.extract(node_address, yaml, prop, names, defs, def_label)
+        controller.extract(node_address, yaml, prop, names, def_label)
     elif 'pinctrl-' in prop:
-        pinctrl.extract(node_address, yaml, prop, names, defs, def_label)
+        pinctrl.extract(node_address, yaml, prop, names, def_label)
     elif 'gpio-ranges' in prop:
-        gpioranges.extract(node_address, yaml, prop, names, defs, def_label)
+        gpioranges.extract(node_address, yaml, prop, names, def_label)
     elif prop.startswith(('clock', '#clock', 'assigned-clock', 'oscillator')):
-        clocks.extract(node_address, yaml, prop, names, defs, def_label)
+        clocks.extract(node_address, yaml, prop, names, def_label)
     elif 'gpios' in prop:
         try:
             prop_values = list(reduced[node_address]['props'].get(prop))
         except:
             prop_values = reduced[node_address]['props'].get(prop)
 
-        extract_controller(node_address, yaml, prop, prop_values, 0, defs,
+        extract_controller(node_address, yaml, prop, prop_values, 0,
                            def_label, 'gpio')
         extract_cells(node_address, yaml, prop, prop_values,
-                      names, 0, defs, def_label, 'gpio')
+                      names, 0, def_label, 'gpio')
     else:
-        default.extract(node_address, yaml, prop, names, defs, def_label)
+        default.extract(node_address, yaml, prop, names, def_label)
 
 
 def extract_node_include_info(reduced, root_node_address, sub_node_address,
-                              yaml, defs, structs, y_sub):
+                              yaml, y_sub):
     node = reduced[sub_node_address]
     node_compat = get_compat(root_node_address)
     label_override = None
@@ -443,8 +443,7 @@ def extract_node_include_info(reduced, root_node_address, sub_node_address,
                 for c in reduced:
                     if root_node_address + '/' in c:
                         extract_node_include_info(
-                            reduced, root_node_address, c, yaml, defs, structs,
-                            v)
+                            reduced, root_node_address, c, yaml, v)
             if 'generation' in v:
 
                 for c in node['props'].keys():
@@ -470,7 +469,7 @@ def extract_node_include_info(reduced, root_node_address, sub_node_address,
 
                         extract_property(
                             node_compat, yaml, sub_node_address, c, v, names,
-                            defs, label_override)
+                            label_override)
 
 
 def dict_merge(dct, merge_dct):
@@ -581,7 +580,7 @@ def get_key_value(k, v, tabstop):
     return line
 
 
-def output_keyvalue_lines(fd, defs):
+def output_keyvalue_lines(fd):
     node_keys = sorted(defs.keys())
     for node in node_keys:
         fd.write('# ' + node.split('/')[-1])
@@ -598,12 +597,12 @@ def output_keyvalue_lines(fd, defs):
 
         fd.write("\n")
 
-def generate_keyvalue_file(defs, kv_file):
+def generate_keyvalue_file(kv_file):
     with open(kv_file, "w") as fd:
-        output_keyvalue_lines(fd, defs)
+        output_keyvalue_lines(fd)
 
 
-def output_include_lines(fd, defs, fixups):
+def output_include_lines(fd, fixups):
     compatible = reduced['/']['props']['compatible'][0]
 
     fd.write("/**************************************************\n")
@@ -665,9 +664,9 @@ def output_include_lines(fd, defs, fixups):
     fd.write("#endif\n")
 
 
-def generate_include_file(defs, inc_file, fixups):
+def generate_include_file(inc_file, fixups):
     with open(inc_file, "w") as fd:
-        output_include_lines(fd, defs, fixups)
+        output_include_lines(fd, fixups)
 
 
 def load_and_parse_dts(dts_file):
@@ -717,31 +716,29 @@ def load_yaml_descriptions(dts, yaml_dir):
 
 
 def generate_node_definitions(yaml_list):
-    defs = {}
-    structs = {}
 
     for k, v in reduced.items():
         node_compat = get_compat(k)
         if node_compat is not None and node_compat in yaml_list:
             extract_node_include_info(
-                reduced, k, k, yaml_list, defs, structs, None)
+                reduced, k, k, yaml_list, None)
 
     if defs == {}:
         raise Exception("No information parsed from dts file.")
 
     for k, v in regs_config.items():
         if k in chosen:
-            extract_reg_prop(chosen[k], None, defs, v, 1024, None)
+            extract_reg_prop(chosen[k], None, v, 1024, None)
 
     for k, v in name_config.items():
         if k in chosen:
-            extract_string_prop(chosen[k], None, "label", v, defs)
+            extract_string_prop(chosen[k], None, "label", v)
 
     node_address = chosen.get('zephyr,flash', 'dummy-flash')
-    flash.extract(node_address, yaml_list, 'zephyr,flash', None, defs, 'FLASH')
+    flash.extract(node_address, yaml_list, 'zephyr,flash', None, 'FLASH')
     node_address = chosen.get('zephyr,code-partition', node_address)
     flash.extract(node_address, yaml_list, 'zephyr,code-partition', None,
-                  defs, 'FLASH')
+                  'FLASH')
 
     return defs
 
@@ -780,9 +777,9 @@ def main():
     defs = generate_node_definitions(yaml_list)
 
      # generate config and include file
-    generate_keyvalue_file(defs, args.keyvalue[0])
+    generate_keyvalue_file(args.keyvalue[0])
 
-    generate_include_file(defs, args.include[0], args.fixup)
+    generate_include_file(args.include[0], args.fixup)
     edts.save(args.edts[0])
 
 

--- a/scripts/dts/extract_dts_includes.py
+++ b/scripts/dts/extract_dts_includes.py
@@ -740,6 +740,8 @@ def parse_arguments():
     parser.add_argument("-d", "--dts", nargs=1, required=True, help="DTS file")
     parser.add_argument("-y", "--yaml", nargs=1, required=True,
                         help="YAML file")
+    parser.add_argument("-e", "--edts", nargs=1, required=True,
+                        help="Generate EDTS database file for the build system")
     parser.add_argument("-f", "--fixup", nargs='+',
                         help="Fixup file(s), we allow multiple")
     parser.add_argument("-i", "--include", nargs=1, required=True,
@@ -768,6 +770,7 @@ def main():
     generate_keyvalue_file(defs, args.keyvalue[0])
 
     generate_include_file(defs, args.include[0], args.fixup)
+    edts.save(args.edts[0])
 
 
 if __name__ == '__main__':

--- a/tests/unit/scripts/extract_dts_includes/CMakeLists.txt
+++ b/tests/unit/scripts/extract_dts_includes/CMakeLists.txt
@@ -1,0 +1,52 @@
+# Copyright (c) 2018 Bobby Noelte <b0661n0e17e@gmail.com>
+#
+# SPDX-License-Identifier: Apache-2.0
+
+# Prepare generic unit test environment
+#
+# parameters:
+# - INCLUDE is relative to zephyr base
+# - SOURCES defaults to main.c
+#
+# target:
+# - testbinary (default)
+list(APPEND INCLUDE subsys) # for ztest
+include($ENV{ZEPHYR_BASE}/tests/unit/unittest.cmake)
+
+# Fake zephyr environment to prepare the
+# generation of include/generated/generated_dts_board.h from DTS
+set(ZEPHYR_BASE $ENV{ZEPHYR_BASE})
+set(PROJECT_BINARY_DIR ${CMAKE_CURRENT_BINARY_DIR})
+set(PROJECT_SOURCE_DIR ${ZEPHYR_BASE})
+set(ARCH host)
+set(BOARD_FAMILY host)
+set(BOARD host)
+set(CONFIG_HAS_DTS True)
+set(APPLICATION_SOURCE_DIR ${CMAKE_CURRENT_SOURCE_DIR})
+
+include(${ZEPHYR_BASE}/cmake/extensions.cmake)
+
+# Get the tools for DTS - python and DTC
+find_package(PythonInterp 3.4)
+include(${ZEPHYR_BASE}/cmake/host-tools.cmake)
+
+# Generate include/generated/generated_dts_board.h from DTS
+file(REMOVE_RECURSE ${PROJECT_BINARY_DIR}/include/generated)
+file(MAKE_DIRECTORY ${PROJECT_BINARY_DIR}/include/generated)
+set(AUTOCONF_H ${APPLICATION_SOURCE_DIR}/autoconf.h)
+set(DTS_SOURCE ${APPLICATION_SOURCE_DIR}/dts/test.dts)
+
+set(DTS_BINDINGS_DIR ${APPLICATION_SOURCE_DIR}/bindings)
+include(${ZEPHYR_BASE}/cmake/dts.cmake)
+
+
+# Make test aware of
+# - dts bindings header files
+# - generated include file
+target_include_directories(testbinary PRIVATE
+                           ${DTS_BINDINGS_DIR}
+                           ${PROJECT_BINARY_DIR}/include
+                           ${PROJECT_BINARY_DIR}/include/generated
+                           )
+
+project(none) # switches PROJECT_SOURCE_DIR and PROJECT_BINARY_DIR

--- a/tests/unit/scripts/extract_dts_includes/bindings/arm,v7m-nvic.yaml
+++ b/tests/unit/scripts/extract_dts_includes/bindings/arm,v7m-nvic.yaml
@@ -1,0 +1,32 @@
+---
+title: ARM Cortex M4 NVIC Interrupt Controller
+version: 0.1
+
+description: >
+    This binding describes the ARM Cortex M4 NVIC IRQ controller
+
+properties:
+    compatible:
+      category: required
+      type: string
+      description: compatible strings
+      constraint: "arm,v7m-nvic"
+
+    reg:
+      category: required
+      type: int
+      description: mmio register space
+      generation: define
+
+    arm,num-irq-priority-bits:
+      category: required
+      type: int
+      description: number of bits of IRQ priorities
+      generation: define
+
+cell_string: IRQ
+
+"#cells":
+  - irq
+  - priority
+...

--- a/tests/unit/scripts/extract_dts_includes/bindings/test,device.yaml
+++ b/tests/unit/scripts/extract_dts_includes/bindings/test,device.yaml
@@ -1,0 +1,64 @@
+---
+title: Test Device
+id: test,device
+version: 0.1
+
+description: >
+    This binding gives a base representation of the test device
+
+properties:
+    compatible:
+      type: string
+      category: required
+      description: compatible strings
+      constraint: "test,device"
+      generation: define
+
+    label:
+      type: string
+      category: required
+      description: Human readable string describing the device
+      generation: define
+
+    reg:
+      type: array
+      description: mmio register space
+      generation: define
+      category: required
+
+    interrupts:
+      type: array
+      category: required
+      description: required interrupts
+      generation: define
+
+    clocks:
+      type: array
+      category: required
+      description: Clock gate control information
+      generation: define
+
+    clock-frequency:
+      type: int
+      category: optional
+      description: Clock frequency information for UART operation
+      generation: define
+
+    current-speed:
+      type: int
+      category: required
+      description: Initial baud rate setting for UART
+      generation: define
+
+    interrupt-names:
+      type: stringlist
+      category: optional
+      description: names of required interrupts
+      generation: define
+
+    pinctrl-\d+:
+      type: array
+      category: optional
+      description: pinctrl information
+      generation: define
+...

--- a/tests/unit/scripts/extract_dts_includes/bindings/test,gpio.yaml
+++ b/tests/unit/scripts/extract_dts_includes/bindings/test,gpio.yaml
@@ -1,0 +1,46 @@
+---
+title: TEST GPIO
+id: test,gpio
+version: 0.1
+
+description: >
+    This binding gives a base representation of the TEST GPIO
+
+properties:
+    compatible:
+      type: string
+      category: required
+      description: compatible strings
+      constraint: "test,gpio"
+      generation: define
+
+    gpio-controller:
+      type: string
+      category: required
+      description: device controller identification
+      generation: define
+
+    label:
+      type: string
+      category: required
+      description: Human readable string describing the device
+      generation: define
+
+    reg:
+      type: array
+      description: mmio register space
+      generation: define
+      category: required
+
+    interrupts:
+      type: array
+      category: required
+      description: required interrupts
+      generation: define
+
+    gpio-ranges:
+      type: array
+      category: required
+      description: gpio range in pin controller
+      generation: define
+...

--- a/tests/unit/scripts/extract_dts_includes/bindings/test,pinctrl.yaml
+++ b/tests/unit/scripts/extract_dts_includes/bindings/test,pinctrl.yaml
@@ -1,0 +1,35 @@
+---
+title: TEST PINCTRL
+id: test,pinctrl
+version: 0.1
+
+description: >
+    This binding gives a base representation of the TEST PINCTRL device
+
+properties:
+    compatible:
+      type: string
+      category: required
+      description: compatible strings
+      constraint: "test,pinctrl"
+      generation: define
+
+    pin-controller:
+      type: string
+      category: required
+      description: device controller identification
+      generation: define
+
+    label:
+      type: string
+      category: required
+      description: Human readable string describing the device
+      generation: define
+
+    reg:
+      type: int
+      description: mmio register space
+      generation: define
+      category: required
+
+...

--- a/tests/unit/scripts/extract_dts_includes/bindings/test,pinmux.yaml
+++ b/tests/unit/scripts/extract_dts_includes/bindings/test,pinmux.yaml
@@ -1,0 +1,32 @@
+---
+title: TEST PINMUX
+id: test,pinmux
+version: 0.1
+
+description: >
+    This binding gives a base representation of the TEST PINMUX
+
+properties:
+    compatible:
+      type: string
+      category: required
+      description: compatible strings
+      constraint: "test,pinmux"
+      generation: define
+
+    label:
+      type: string
+      category: required
+      description: Human readable string describing the device
+      generation: define
+
+    reg:
+      type: int
+      description: mmio register space
+      generation: define
+      category: required
+
+"#cells":
+  - pin
+  - function
+...

--- a/tests/unit/scripts/extract_dts_includes/dts/armv7-m.dtsi
+++ b/tests/unit/scripts/extract_dts_includes/dts/armv7-m.dtsi
@@ -1,0 +1,25 @@
+#include "skeleton.dtsi"
+
+/ {
+	soc {
+		#address-cells = <1>;
+		#size-cells = <1>;
+		compatible = "simple-bus";
+		interrupt-parent = <&nvic>;
+		ranges;
+
+		nvic: interrupt-controller@e000e100  {
+			compatible = "arm,v7m-nvic";
+			reg = <0xe000e100 0xc00>;
+			interrupt-controller;
+			#interrupt-cells = <2>;
+		};
+
+		systick: timer@e000e010 {
+			compatible = "arm,armv7m-systick";
+			reg = <0xe000e010 0x10>;
+			status = "disabled";
+		};
+	};
+};
+

--- a/tests/unit/scripts/extract_dts_includes/dts/skeleton.dtsi
+++ b/tests/unit/scripts/extract_dts_includes/dts/skeleton.dtsi
@@ -1,0 +1,12 @@
+/*
+ * Skeleton device tree; the bare minimum needed to boot; just include and
+ * add a compatible value.  The bootloader will typically populate the memory
+ * node.
+ */
+
+/ {
+	#address-cells = <1>;
+	#size-cells = <1>;
+	chosen { };
+	aliases { };
+};

--- a/tests/unit/scripts/extract_dts_includes/dts/test-pinctrl.dtsi
+++ b/tests/unit/scripts/extract_dts_includes/dts/test-pinctrl.dtsi
@@ -1,0 +1,59 @@
+/*
+ * Copyright (c) 2018 Bobby Noelte
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include "../pinctrl_test.h"
+
+/{
+	soc {
+		pinctrl0:pin-controller@40000000 {
+			device0_rx_pins_a:device0@000 {
+				rx {
+					pinmux = <1000 2000>;
+					bias-pull-up = <1000>;
+					input-enable;
+				};
+			};
+			device0_tx_pins_a:device0@001 {
+				tx {
+					pinmux = <1001 2001>;
+					bias-pull-down = <1001>;
+					output-enable;
+				};
+			};
+			device0_rx_pins_b:device0@002 {
+				rx {
+					pinmux = <1002 2002>;
+					bias-pull-up = <1002>;
+					input-enable;
+				};
+			};
+			device0_tx_pins_b:device0@003 {
+				tx {
+					pinmux = <1003 2003>;
+					bias-pull-down = <1003>;
+					output-enable;
+				};
+			};
+		};
+		pinctrl1:pin-controller@50000000 {
+			device1_rx_tx_pins_a:device1@000
+			{
+				rx_tx {
+					pins = "PIN_A", "PIN_B";
+					output-high;
+				};
+			};
+		};
+		pinmux0:pinmux@60000000 {
+			device2_rx_tx_pins_a:device2@0 {
+				rx_tx {
+					rx = <1234 5678>;
+					tx = <2345 6789>;
+				};
+			};
+		};
+	};
+};

--- a/tests/unit/scripts/extract_dts_includes/dts/test.dts
+++ b/tests/unit/scripts/extract_dts_includes/dts/test.dts
@@ -1,0 +1,176 @@
+/dts-v1/;
+
+#include "armv7-m.dtsi"
+#include "test-pinctrl.dtsi"
+
+/{
+	cpus {
+		#address-cells = <1>;
+		#size-cells = <0>;
+
+		cpu@0 {
+			device_type = "cpu";
+			compatible = "arm,cortex-m3";
+			reg = <0>;
+		};
+	};
+
+	sram0:memory@20000000 {
+		device_type = "memory";
+		compatible = "mmio-sram";
+		reg = <0x20000000 (64 * 1024)>;
+	};
+
+	flash0:flash@0 {
+		reg = <0x00000000 (256 * 1024)>;
+	};
+
+	soc {
+		pinctrl0:pin-controller@40000000 {
+			pin-controller;
+			compatible = "test,pinctrl";
+			#address-cells = <1>;
+			#size-cells = <1>;
+			reg = <0x40000000 0x1C00>;
+			status = "disabled";
+			label = PINCTRL_TEST_DEVICE0_NAME;
+		};
+
+		pinctrl1:pin-controller@50000000 {
+			pin-controller;
+			compatible = "test,pinctrl";
+			#address-cells = <1>;
+			#size-cells = <1>;
+			reg = <0x50000000 0x1C00>;
+			status = "disabled";
+			label = PINCTRL_TEST_DEVICE1_NAME;
+		};
+
+		pinmux0:pinmux@60000000 {
+			pin-controller;
+			compatible = "test,pinmux";
+			#address-cells = <1>;
+			#size-cells = <1>;
+			reg = <0x60000000 0x1800>;
+			status = "disabled";
+			label = "LEGACY_PINMUX";
+		};
+
+		gpio0:gpio@10000000 {
+			gpio-controller;
+			compatible = "test,gpio";
+			#address-cells = <1>;
+			#size-cells = <1>;
+			reg = <0x10000000 0x1800>;
+			gpio-ranges = <&pinctrl0 GPIO_PORT_PIN0 16 16>;
+			status = "disabled";
+			label = "GPIO_0";
+		};
+
+		gpio1:gpio@20000000 {
+			gpio-controller;
+			compatible = "test,gpio";
+			#address-cells = <1>;
+			#size-cells = <1>;
+			reg = <0x20000000 0x1800>;
+			gpio-ranges = <&pinctrl1 GPIO_PORT_PIN0 0 16>;
+			status = "disabled";
+			label = "GPIO_1";
+		};
+
+		gpio2:gpio@30000000 {
+			gpio-controller;
+			compatible = "test,gpio";
+			#address-cells = <1>;
+			#size-cells = <1>;
+			reg = <0x30000000 0x1800>;
+			gpio-ranges = <&pinctrl1 GPIO_PORT_PIN0 16 16>;
+			status = "disabled";
+			label = "GPIO_2";
+		};
+
+		device0:device@4000C000 {
+			compatible = "test,device";
+			reg = <0x4000C000 0x4c>;
+			interrupts = <5 3>;
+			status = "disabled";
+			label = "DEVICE_0";
+		};
+
+		device1:device@5000C000 {
+			compatible = "test,device";
+			reg = <0x5000C000 0x4c>;
+			interrupts = <5 3>;
+			status = "disabled";
+			label = "DEVICE_1";
+		};
+
+		device2:device@6000C000 {
+			compatible = "test,device";
+			reg = <0x6000C000 0x4c>;
+			interrupts = <5 3>;
+			status = "disabled";
+			label = "DEVICE_2";
+		};
+	};
+};
+
+&nvic {
+	arm,num-irq-priority-bits = <3>;
+};
+
+/{
+	model = "QEMU Cortex-M3";
+	compatible = "ti,lm3s6965evb-qemu", "ti,lm3s6965";
+
+	chosen {
+		zephyr,sram = &sram0;
+		zephyr,flash = &flash0;
+	};
+};
+
+&pinctrl0 {
+	status = "ok";
+};
+
+&pinctrl1 {
+	status = "ok";
+};
+
+&pinmux0 {
+	status = "ok";
+};
+
+&gpio0 {
+	status = "ok";
+};
+
+&gpio1 {
+	status = "ok";
+};
+
+&gpio2 {
+	status = "ok";
+};
+
+&device0 {
+	pinctrl-0 = <&device0_rx_pins_a &device0_tx_pins_a>;
+	pinctrl-1 = <&device0_rx_pins_b &device0_tx_pins_b>;
+	pinctrl-names = "default", "shutdown";
+	status = "ok";
+	current-speed = <115200>;
+};
+
+&device1 {
+	pinctrl-0 = <&device1_rx_tx_pins_a>;
+	pinctrl-names = "default";
+	status = "ok";
+	current-speed = <115200>;
+};
+
+&device2 {
+	pinctrl-0 = <&device2_rx_tx_pins_a>;
+	pinctrl-names = "default";
+	status = "ok";
+	current-speed = <115200>;
+};

--- a/tests/unit/scripts/extract_dts_includes/main.c
+++ b/tests/unit/scripts/extract_dts_includes/main.c
@@ -1,0 +1,385 @@
+/*
+ * Copyright (c) 2018 Bobby Noelte
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <ztest.h>
+#include <zephyr/types.h>
+#include <misc/util.h>
+#include <generated/generated_dts_board.h>
+
+#include "pinctrl_test.h"
+
+static _Bool assert_pinmux(u32_t a_port, u32_t a_mux,
+			   u32_t b_port, u32_t b_mux)
+{
+	if (a_port != b_port) {
+		TC_PRINT("%s: %u, %u, %u, %u failed - port %u != %u\n",
+			 __func__, a_port, a_mux, b_port, b_mux,
+			 a_port, b_port);
+		return 0;
+	}
+	if (a_mux != b_mux) {
+		TC_PRINT("%s: %u, %u, %u, %u failed - mux %u != %u\n",
+			 __func__, a_port, a_mux, b_port, b_mux,
+			 a_mux, b_mux);
+		return 0;
+	}
+	return 1;
+}
+
+static _Bool assert_strcmp(const char *s1, const char *s2)
+{
+	const char *_s1 = s1;
+	const char *_s2 = s2;
+
+	for (int i = 0; i <= 1000; i++) {
+		if ((*s1 == 0) && (*s2 == 0)) {
+			return 1;
+		}
+		if (*s1 != *s2) {
+			TC_PRINT("%s: %s, %s failed - char %c != %c (%d)\n",
+				 __func__, _s1, _s2, *s1, *s2, i);
+			return 0;
+		}
+		if (((*s1 == 0) && (*s2 != 0)) || ((*s1 != 0) && (*s2 == 0))) {
+			TC_PRINT("%s: %s, %s failed - end of string (%d)\n",
+				 __func__, _s1, _s2, i);
+			return 0;
+		}
+		if (i >= 1000) {
+			TC_PRINT("%s: %s, %s failed - no end of string (%d)\n",
+				 __func__, _s1, _s2, i);
+			return 0;
+		}
+		s1++;
+		s2++;
+	};
+	return 1;
+}
+
+static struct {
+	u32_t uut_port;
+	u32_t uut_mux;
+	u32_t expected_port;
+	u32_t expected_mux;
+} test_pinctrl_define_pinmux[] = {
+	/* assure pinmux defines are correctly generated for device 0*/
+	{ TEST_DEVICE_4000C000_PINCTRL_DEFAULT_RX_PINMUX, 1000, 2000 },
+	{ TEST_DEVICE_4000C000_PINCTRL_DEFAULT_TX_PINMUX, 1001, 2001 },
+	/* assure PINCTRL_TEST_DEVICE0 pinmux for Device 0 is correct */
+#if TEST_DEVICE_4000C000_PINCTRL_DEFAULT_STATE_ID == 0
+	{ TEST_PINCTRL_40000000_PINCTRL_0_PINMUX, 1000, 2000 },
+#elif TEST_DEVICE_4000C000_PINCTRL_DEFAULT_STATE_ID == 1
+	{ TEST_PINCTRL_40000000_PINCTRL_1_PINMUX, 1000, 2000 },
+#elif TEST_DEVICE_4000C000_PINCTRL_DEFAULT_STATE_ID == 2
+	{ TEST_PINCTRL_40000000_PINCTRL_2_PINMUX, 1000, 2000 },
+#else
+#error "unexpected default state id of pinctrl for device 0"
+#endif
+#if TEST_DEVICE_4000C000_PINCTRL_SHUTDOWN_STATE_ID == 0
+	{ TEST_PINCTRL_40000000_PINCTRL_0_PINMUX, 1001, 2001 },
+#elif TEST_DEVICE_4000C000_PINCTRL_SHUTDOWN_STATE_ID == 1
+	{ TEST_PINCTRL_40000000_PINCTRL_1_PINMUX, 1001, 2001 },
+#elif TEST_DEVICE_4000C000_PINCTRL_SHUTDOWN_STATE_ID == 2
+	{ TEST_PINCTRL_40000000_PINCTRL_2_PINMUX, 1001, 2001 },
+#else
+#error "unexpected shutdown state id of pinctrl for device 0"
+#endif
+};
+
+static struct {
+	u32_t uut_val;
+	u32_t expected_val;
+} test_pinctrl_define_int[] = {
+	/* assure define directives are correctly generated for device 0*/
+	{ TEST_DEVICE_4000C000_PINCTRL_DEFAULT_RX_BIAS_PULL_UP, 1000},
+	{ TEST_DEVICE_4000C000_PINCTRL_DEFAULT_RX_INPUT_ENABLE, 1},
+	{ TEST_DEVICE_4000C000_PINCTRL_DEFAULT_TX_BIAS_PULL_DOWN, 1001},
+	{ TEST_DEVICE_4000C000_PINCTRL_DEFAULT_TX_OUTPUT_ENABLE, 1},
+	/* assure PINCTRL_TEST_DEVICE0 pin control directives for Device 0
+	 * are correct
+	 */
+#if TEST_DEVICE_4000C000_PINCTRL_DEFAULT_STATE_ID == 0
+	{ TEST_PINCTRL_40000000_PINCTRL_0_BIAS_PULL_UP, 1000},
+	{ TEST_PINCTRL_40000000_PINCTRL_0_INPUT_ENABLE, 1},
+#elif TEST_DEVICE_4000C000_PINCTRL_DEFAULT_STATE_ID == 1
+	{ TEST_PINCTRL_40000000_PINCTRL_0_BIAS_PULL_UP, 1000},
+	{ TEST_PINCTRL_40000000_PINCTRL_0_INPUT_ENABLE, 1},
+#elif TEST_DEVICE_4000C000_PINCTRL_DEFAULT_STATE_ID == 2
+	{ TEST_PINCTRL_40000000_PINCTRL_0_BIAS_PULL_UP, 1000},
+	{ TEST_PINCTRL_40000000_PINCTRL_0_INPUT_ENABLE, 1},
+#else
+#error "unexpected default state id of pinctrl for device 0"
+#endif
+#if TEST_DEVICE_4000C000_PINCTRL_SHUTDOWN_STATE_ID == 0
+	{ TEST_PINCTRL_40000000_PINCTRL_0_BIAS_PULL_DOWN, 1001},
+	{ TEST_PINCTRL_40000000_PINCTRL_0_OUTPUT_ENABLE, 1},
+#elif TEST_DEVICE_4000C000_PINCTRL_SHUTDOWN_STATE_ID == 1
+	{ TEST_PINCTRL_40000000_PINCTRL_1_BIAS_PULL_DOWN, 1001},
+	{ TEST_PINCTRL_40000000_PINCTRL_1_OUTPUT_ENABLE, 1},
+#elif TEST_DEVICE_4000C000_PINCTRL_SHUTDOWN_STATE_ID == 2
+	{ TEST_PINCTRL_40000000_PINCTRL_2_BIAS_PULL_DOWN, 1001},
+	{ TEST_PINCTRL_40000000_PINCTRL_2_OUTPUT_ENABLE, 1},
+#else
+#error "unexpected shutdown state id of pinctrl for device 0"
+#endif
+};
+
+static struct {
+	const char *uut_str;
+	const char *expected_str;
+} test_pinctrl_define_str[] = {
+	/* Assure we are on the correct generated_dts_board.h */
+	{ TEST_DEVICE_4000C000_LABEL, "DEVICE_0" },
+	{ TEST_DEVICE_5000C000_LABEL, "DEVICE_1" },
+	{ TEST_DEVICE_6000C000_LABEL, "DEVICE_2" },
+	{ TEST_GPIO_10000000_LABEL, "GPIO_0" },
+	{ TEST_GPIO_20000000_LABEL, "GPIO_1" },
+	{ TEST_GPIO_30000000_LABEL, "GPIO_2" },
+	{ TEST_PINCTRL_40000000_LABEL, "PINCTRL_TEST_DEVICE0" },
+	{ TEST_PINCTRL_50000000_LABEL, "PINCTRL_TEST_DEVICE1" },
+
+	/* assure non-linux pinctrl-binding directives are created */
+#define xstr2(s) str2(s)
+#define xstr(s) str(s)
+#define str2(s1, s2) (#s1 "," #s2)
+#define str(s) #s
+	/* find out the index of the pin configuration */
+#define rx 9999
+#if rx == TEST_DEVICE_6000C000_PINMUX_DEVICE2_0_RX_TX_PIN_0
+#define EXPECTED_RX_TX_PIN_0 "rx"
+#define EXPECTED_FUNCTION_0 "[1234,5678]"
+#define EXPECTED_RX_TX_PIN_1 "tx"
+#define EXPECTED_FUNCTION_1 "[2345,6789]"
+#else
+#define EXPECTED_RX_TX_PIN_1 "rx"
+#define EXPECTED_FUNCTION_1 "[1234,5678]"
+#define EXPECTED_RX_TX_PIN_0 "tx"
+#define EXPECTED_FUNCTION_0 "[2345,6789]"
+#endif
+#undef rx
+	/* strings to compare */
+#define TEST_PINMUX_LEGACY0 \
+	xstr(TEST_DEVICE_6000C000_PINMUX_DEVICE2_0_RX_TX_PIN_0)
+	{ TEST_PINMUX_LEGACY0, EXPECTED_RX_TX_PIN_0},
+#define TEST_PINMUX_LEGACY1 \
+	xstr2(TEST_DEVICE_6000C000_PINMUX_DEVICE2_0_RX_TX_FUNCTION_0)
+	{ TEST_PINMUX_LEGACY1, EXPECTED_FUNCTION_0},
+#define TEST_PINMUX_LEGACY2 \
+	xstr(TEST_DEVICE_6000C000_PINMUX_DEVICE2_0_RX_TX_PIN_1)
+	{ TEST_PINMUX_LEGACY2, EXPECTED_RX_TX_PIN_1},
+#define TEST_PINMUX_LEGACY3 \
+	xstr2(TEST_DEVICE_6000C000_PINMUX_DEVICE2_0_RX_TX_FUNCTION_1)
+	{ TEST_PINMUX_LEGACY3, EXPECTED_FUNCTION_1},
+};
+
+/**
+ * @brief Test PINCTRL define directives
+ *
+ * Test that PINCTRL defines in generated_dts_board.h are correctly generated.
+ */
+void test_pinctrl_define_directives(void)
+{
+	for (int i = 0; i < ARRAY_SIZE(test_pinctrl_define_str); i++) {
+		if (!assert_strcmp(test_pinctrl_define_str[i].uut_str,
+				   test_pinctrl_define_str[i].expected_str)) {
+			TC_PRINT("%s: test string %d\n",
+				 __func__, i);
+			ztest_test_fail();
+		}
+	}
+
+	for (int i = 0; i < ARRAY_SIZE(test_pinctrl_define_int); i++) {
+		zassert_equal(test_pinctrl_define_int[i].uut_val,
+			      test_pinctrl_define_int[i].expected_val,
+			      "test value %d", i);
+	}
+
+	for (int i = 0; i < ARRAY_SIZE(test_pinctrl_define_pinmux); i++) {
+		if (!assert_pinmux(
+			test_pinctrl_define_pinmux[i].uut_port,
+			test_pinctrl_define_pinmux[i].uut_mux,
+			test_pinctrl_define_pinmux[i].expected_port,
+			test_pinctrl_define_pinmux[i].expected_mux)) {
+			TC_PRINT("%s: test pinmux %d\n",
+				 __func__, i);
+			ztest_test_fail();
+		}
+	}
+}
+
+void test_pinctrl_default_init(void)
+{
+#define TEST_PINCTRL_DEFAULT_INIT(label, idx)                               \
+	_TEST_PINCTRL_DEFAULT_INIT1(label##_PINCTRL_##idx##_PINMUX,         \
+				    label##_PINCTRL_##idx##_BIAS_PULL_UP,   \
+				    label##_PINCTRL_##idx##_BIAS_PULL_DOWN, \
+				    label##_PINCTRL_##idx##_INPUT_ENABLE,   \
+				    label##_PINCTRL_##idx##_OUTPUT_ENABLE)
+#define _TEST_PINCTRL_DEFAULT_INIT1(_mux, _up, _down, _in, _out) \
+	_TEST_PINCTRL_DEFAULT_INIT2(_mux, _up, _down, _in, _out)
+#define _TEST_PINCTRL_DEFAULT_INIT2(_mux0, _mux1, _up, _down, _in, _out) \
+	{.pinmux = {_mux0, _mux1},                                       \
+	 .bias_pull_up = _up,                                            \
+	 .bias_pull_down = _down,                                        \
+	 .input_enable = _in,                                            \
+	 .output_enable = _out},
+
+	struct s_pinctrl_init {
+		u32_t pinmux[2];
+		u32_t bias_pull_up;
+		u32_t bias_pull_down;
+		_Bool input_enable;
+		_Bool output_enable;
+	};
+
+	const struct s_pinctrl_init pinctrl_init[] = {
+#if TEST_PINCTRL_40000000_PINCTRL_COUNT > 0
+		TEST_PINCTRL_DEFAULT_INIT(TEST_PINCTRL_40000000, 0)
+#endif
+#if TEST_PINCTRL_40000000_PINCTRL_COUNT > 1
+		TEST_PINCTRL_DEFAULT_INIT(TEST_PINCTRL_40000000, 1)
+#endif
+#if TEST_PINCTRL_40000000_PINCTRL_COUNT > 2
+		TEST_PINCTRL_DEFAULT_INIT(TEST_PINCTRL_40000000, 2)
+#endif
+#if TEST_PINCTRL_40000000_PINCTRL_COUNT > 3
+		TEST_PINCTRL_DEFAULT_INIT(TEST_PINCTRL_40000000, 3)
+#endif
+
+/* unused default configuration index 4 */
+#if TEST_PINCTRL_40000000_PINCTRL_COUNT > 4
+		TEST_PINCTRL_DEFAULT_INIT(TEST_PINCTRL_40000000, 4)
+#endif
+	};
+
+	/* http://www.geeksforgeeks.org/how-to-find-size-of-array-in-cc/
+	 * -without-using-sizeof-operator/
+	 */
+	const int pinctrl_init_size = *(&pinctrl_init + 1) - pinctrl_init;
+
+	zassert_equal(TEST_PINCTRL_40000000_PINCTRL_COUNT,
+		      4,
+		      "pin control init size");
+	zassert_equal(pinctrl_init_size,
+		      TEST_PINCTRL_40000000_PINCTRL_COUNT,
+		      "pin control init size");
+	zassert_equal(pinctrl_init[0].bias_pull_up,
+		      TEST_PINCTRL_40000000_PINCTRL_0_BIAS_PULL_UP,
+		      "");
+	zassert_equal(pinctrl_init[0].bias_pull_down,
+		      TEST_PINCTRL_40000000_PINCTRL_0_BIAS_PULL_DOWN,
+		      "");
+	zassert_equal(pinctrl_init[0].input_enable,
+		      TEST_PINCTRL_40000000_PINCTRL_0_INPUT_ENABLE,
+		      "");
+	zassert_equal(pinctrl_init[0].output_enable,
+		      TEST_PINCTRL_40000000_PINCTRL_0_OUTPUT_ENABLE,
+		      "");
+	zassert_equal(pinctrl_init[1].bias_pull_up,
+		      TEST_PINCTRL_40000000_PINCTRL_1_BIAS_PULL_UP,
+		      "");
+	zassert_equal(pinctrl_init[1].bias_pull_down,
+		      TEST_PINCTRL_40000000_PINCTRL_1_BIAS_PULL_DOWN,
+		      "");
+	zassert_equal(pinctrl_init[1].input_enable,
+		      TEST_PINCTRL_40000000_PINCTRL_1_INPUT_ENABLE,
+		      "");
+	zassert_equal(pinctrl_init[1].output_enable,
+		      TEST_PINCTRL_40000000_PINCTRL_1_OUTPUT_ENABLE,
+		      "");
+}
+
+void test_pinctrl_pins_default_init(void)
+{
+#define PIN_A 23
+#define PIN_B 34
+
+#define TEST_PINCTRL_PINS_INIT(label, idx)                            \
+	_TEST_PINCTRL_PINS_INIT1(label##_PINCTRL_##idx##_OUTPUT_HIGH, \
+				 label##_PINCTRL_##idx##_PINS)
+#define _TEST_PINCTRL_PINS_INIT1(_high, _pins) \
+	_TEST_PINCTRL_PINS_INIT2(_high, _pins, 0, 0, 0, 0, 0, 0)
+#define _TEST_PINCTRL_PINS_INIT2(                             \
+	_high, _pin0, _pin1, _pin2, _pin3, _pin4, _pin5, ...) \
+	{.pins = {_pin0, _pin1, _pin2, _pin3, _pin4, _pin5},  \
+	 .output_high = _high},
+
+	struct s_pinctrl_init {
+		u32_t pins[6];
+		_Bool output_high;
+	};
+
+	const struct s_pinctrl_init pinctrl_init[] = {
+#if TEST_PINCTRL_50000000_PINCTRL_COUNT > 0
+		TEST_PINCTRL_PINS_INIT(TEST_PINCTRL_50000000, 0)
+#endif
+
+/* unused default configuration index 001 */
+#if TEST_PINCTRL_50000000_PINCTRL_COUNT > 1
+		TEST_PINCTRL_PINS_INIT(TEST_PINCTRL_50000000, 1)
+#endif
+#if TEST_PINCTRL_50000000_PINCTRL_COUNT > 2
+		TEST_PINCTRL_PINS_INIT(TEST_PINCTRL_50000000, 2)
+#endif
+	};
+
+	const int pinctrl_init_size = *(&pinctrl_init + 1) - pinctrl_init;
+
+	zassert_equal(TEST_PINCTRL_50000000_PINCTRL_COUNT,
+		      1,
+		      "pin control init size");
+	zassert_equal(pinctrl_init_size,
+		      TEST_PINCTRL_50000000_PINCTRL_COUNT,
+		      "pin control init size");
+	zassert_equal(pinctrl_init[0].pins[0], PIN_A, "");
+	zassert_equal(pinctrl_init[0].pins[1], PIN_B, "");
+	zassert_equal(pinctrl_init[0].pins[2], 0, "");
+	zassert_equal(pinctrl_init[0].output_high,
+		      TEST_PINCTRL_50000000_PINCTRL_0_OUTPUT_HIGH,
+		      "");
+}
+
+void test_gpio_ranges(void)
+{
+	/* defines are generated */
+	zassert_equal(TEST_GPIO_10000000_GPIO_RANGE_0_BASE,
+		      GPIO_PORT_PIN0,
+		      "gpio-ranges gpio port pin base");
+	zassert_equal(TEST_GPIO_10000000_GPIO_RANGE_0_NPINS,
+		      16,
+		      "gpio-ranges gpio port pins number");
+	zassert_equal(TEST_GPIO_10000000_GPIO_RANGE_0_CONTROLLER_BASE,
+		      16,
+		      "gpio-ranges controller port pin base");
+	zassert(assert_strcmp(xstr(TEST_GPIO_10000000_GPIO_RANGE_0_CONTROLLER),
+			      "TEST_PINCTRL_40000000"),
+		"pass",
+		"fail");
+}
+
+void test_device_controller(void)
+{
+	/* defines are generated */
+	zassert_equal(SOC_PIN_CONTROLLER_COUNT,
+		      2,
+		      "soc pin controller count: %d",
+		      (int)SOC_PIN_CONTROLLER_COUNT);
+	zassert_equal(SOC_GPIO_CONTROLLER_COUNT,
+		      3,
+		      "soc gpio controller count: %d",
+		      (int)SOC_GPIO_CONTROLLER_COUNT);
+}
+
+void test_main(void)
+{
+	ztest_test_suite(test_extract_dts_includes,
+			 ztest_unit_test(test_pinctrl_define_directives),
+			 ztest_unit_test(test_pinctrl_default_init),
+			 ztest_unit_test(test_pinctrl_pins_default_init),
+			 ztest_unit_test(test_gpio_ranges),
+			 ztest_unit_test(test_device_controller));
+	ztest_run_test_suite(test_extract_dts_includes);
+}

--- a/tests/unit/scripts/extract_dts_includes/pinctrl_test.h
+++ b/tests/unit/scripts/extract_dts_includes/pinctrl_test.h
@@ -1,0 +1,18 @@
+/*
+ * Copyright (c) 2017 Bobby Noelte
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/* Device tree defines for the TEST PINCTRL device driver.
+ */
+
+#ifndef _PINCTRL_TEST_H
+#define _PINCTRL_TEST_H
+
+#define PINCTRL_TEST_DEVICE0_NAME "PINCTRL_TEST_DEVICE0"
+#define PINCTRL_TEST_DEVICE1_NAME "PINCTRL_TEST_DEVICE1"
+
+#define GPIO_PORT_PIN0 0x00000001U
+
+#endif /* _PINCTRL_TEST_H */

--- a/tests/unit/scripts/extract_dts_includes/testcase.yaml
+++ b/tests/unit/scripts/extract_dts_includes/testcase.yaml
@@ -1,0 +1,5 @@
+tests:
+    test:
+      tags: extract_dts_includes
+      timeout: 5
+      type: unit


### PR DESCRIPTION
# Overview

To ease the maintenance and ongoing development extract_dts_includes.py is refactored.

To manage devices efficiently extract_dts_includes.py is extended/ amended:
  - to extract the compatibe directive
  - to extract [device-type]-controller directives (e.g. gpio-controller, pin-controller, ...)
  - to apply some heuristics to detect device controller nodes by the node type of the binding (yaml file). Such nodes are added to the list of device controllers for a SoC the same way as a [device-type]-controller directive.
  - to extract all clock related directives

To support pinctrl devices extract_dts_includes.py is extended:
  - to extract new pinctrl and gpio-ranges directives as described in the Linux pinctrl-bindings.txt.

The PR is a cut-out from PR #5799 for review but can be independently applied.

# Motivation for or Use Case

The prime motivation is to be able to create pin controller drivers that can configure the pins on startup by the information from the device tree in a standardized way. Therefor all relevant device tree information must be available in generated_dts_boards.[h,conf] in a way that can easily be used to generate structured data at build time.

Generation of structured data is done by CodeGen that reads generated_dts_boards.conf

# Design Details

To allow modularization of the monolitic script all global data and functions are factorized to a python module that can be imported by other modules.
  - extract/globals.py

The extraction of device tree directives is added as separate python modules that are derived from the common base class DTDirective:
  - extract/pinctrl.py: pinctrl-[x] and pinctrl-names directives
  - extract/gpioranges.py: gpio-ranges directive
  - extract/interrupts.py: interrupts directive
  - extract/reg.py: reg directive
  - extract/flash.py: reg directive in partitions and partitions chosen
  - extract/controller.py: [device-type]-controller directive
  - extract/compatible.py: compatible directive
  - extract/clocks.py: clock related directives
  - extract/heuristics.py: handling of heuristics; expecially for device controller detection
  - extract/default.py: default used for all directives not covered by any other module

# Test Strategy

This PR includes a unit test that tests the correct generation of defines for the pinctrl directive in device trees. It also tests that the default behaviour for the pinctrl directive stays the same.

A working proof of concept for STM32F0x drivers using the extracted device tree information is available in PR #5799.

Signed-off-by: Bobby Noelte <b0661n0e17e@gmail.com>