### PR TITLE
sensors: Add definition for ambient temperature

### DIFF
--- a/drivers/sensor/adxl362/adxl362.c
+++ b/drivers/sensor/adxl362/adxl362.c
@@ -468,7 +468,7 @@ static int adxl362_channel_get(struct device *dev,
 		val->val1 = data->acc_z / 1000;
 		val->val2 = (data->acc_z % 1000) * 1000;
 		break;
-	case SENSOR_CHAN_TEMP: /* Temperature in degrees Celsius. */
+	case SENSOR_CHAN_DIE_TEMP: /* Temperature in degrees Celsius. */
 		val->val1 = data->temp / 1000;
 		val->val2 = (data->temp % 1000) * 1000;
 		break;

--- a/drivers/sensor/amg88xx/amg88xx.c
+++ b/drivers/sensor/amg88xx/amg88xx.c
@@ -20,7 +20,7 @@ static int amg88xx_sample_fetch(struct device *dev, enum sensor_channel chan)
 {
 	struct amg88xx_data *drv_data = dev->driver_data;
 
-	__ASSERT_NO_MSG(chan == SENSOR_CHAN_ALL || chan == SENSOR_CHAN_TEMP);
+	__ASSERT_NO_MSG(chan == SENSOR_CHAN_ALL || chan == SENSOR_CHAN_AMBIENT_TEMP);
 
 	if (i2c_burst_read(drv_data->i2c, CONFIG_AMG88XX_I2C_ADDR,
 			   AMG88XX_OUTPUT_BASE,
@@ -39,7 +39,7 @@ static int amg88xx_channel_get(struct device *dev,
 	struct amg88xx_data *drv_data = dev->driver_data;
 	size_t len = ARRAY_SIZE(drv_data->sample);
 
-	if (chan != SENSOR_CHAN_TEMP) {
+	if (chan != SENSOR_CHAN_AMBIENT_TEMP) {
 		return -ENOTSUP;
 	}
 

--- a/drivers/sensor/amg88xx/amg88xx_trigger.c
+++ b/drivers/sensor/amg88xx/amg88xx_trigger.c
@@ -26,7 +26,7 @@ int amg88xx_attr_set(struct device *dev,
 	u8_t intl_reg;
 	u8_t inth_reg;
 
-	if (chan != SENSOR_CHAN_TEMP) {
+	if (chan != SENSOR_CHAN_AMBIENT_TEMP) {
 		return -ENOTSUP;
 	}
 

--- a/drivers/sensor/bma280/bma280.c
+++ b/drivers/sensor/bma280/bma280.c
@@ -87,7 +87,7 @@ static int bma280_channel_get(struct device *dev,
 		bma280_channel_accel_convert(val, drv_data->x_sample);
 		bma280_channel_accel_convert(val + 1, drv_data->y_sample);
 		bma280_channel_accel_convert(val + 2, drv_data->z_sample);
-	} else if (chan == SENSOR_CHAN_TEMP) {
+	} else if (chan == SENSOR_CHAN_DIE_TEMP) {
 		/* temperature_val = 23 + sample / 2 */
 		val->val1 = (drv_data->temp_sample >> 1) + 23;
 		val->val2 = 500000 * (drv_data->temp_sample & 1);

--- a/drivers/sensor/bme280/bme280.c
+++ b/drivers/sensor/bme280/bme280.c
@@ -186,7 +186,7 @@ static int bme280_channel_get(struct device *dev,
 	struct bme280_data *data = dev->driver_data;
 
 	switch (chan) {
-	case SENSOR_CHAN_TEMP:
+	case SENSOR_CHAN_AMBIENT_TEMP:
 		/*
 		 * data->comp_temp has a resolution of 0.01 degC.  So
 		 * 5123 equals 51.23 degC.

--- a/drivers/sensor/bmg160/bmg160.c
+++ b/drivers/sensor/bmg160/bmg160.c
@@ -213,7 +213,7 @@ static void bmg160_to_fixed_point(struct bmg160_device_data *bmg160,
 				  enum sensor_channel chan, s16_t raw,
 				  struct sensor_value *val)
 {
-	if (chan == SENSOR_CHAN_TEMP) {
+	if (chan == SENSOR_CHAN_DIE_TEMP) {
 		val->val1 = 23 + (raw / 2);
 		val->val2 = (raw % 2) * 500000;
 	} else {
@@ -248,7 +248,7 @@ static int bmg160_channel_get(struct device *dev, enum sensor_channel chan,
 
 		return 0;
 
-	case SENSOR_CHAN_TEMP:
+	case SENSOR_CHAN_DIE_TEMP:
 		bmg160_to_fixed_point(bmg160, chan, bmg160->raw_temp, val);
 		return 0;
 

--- a/drivers/sensor/bmi160/bmi160.c
+++ b/drivers/sensor/bmi160/bmi160.c
@@ -793,7 +793,7 @@ static int bmi160_channel_get(struct device *dev,
 		bmi160_acc_channel_get(dev, chan, val);
 		return 0;
 #endif
-	case SENSOR_CHAN_TEMP:
+	case SENSOR_CHAN_DIE_TEMP:
 		return bmi160_temp_channel_get(dev, val);
 	default:
 		SYS_LOG_DBG("Channel not supported.");

--- a/drivers/sensor/dht/dht.c
+++ b/drivers/sensor/dht/dht.c
@@ -162,7 +162,7 @@ static int dht_channel_get(struct device *dev,
 {
 	struct dht_data *drv_data = dev->driver_data;
 
-	__ASSERT_NO_MSG(chan == SENSOR_CHAN_TEMP || chan == SENSOR_CHAN_HUMIDITY);
+	__ASSERT_NO_MSG(chan == SENSOR_CHAN_AMBIENT_TEMP || chan == SENSOR_CHAN_HUMIDITY);
 
 	/* see data calculation example from datasheet */
 #if defined(CONFIG_DHT_CHIP_DHT11)
@@ -170,7 +170,7 @@ static int dht_channel_get(struct device *dev,
 	if (chan == SENSOR_CHAN_HUMIDITY) {
 		val->val1 = drv_data->sample[0];
 		val->val2 = 0;
-	} else { /* chan == SENSOR_CHAN_TEMP */
+	} else { /* chan == SENSOR_CHAN_AMBIENT_TEMP */
 		val->val1 = drv_data->sample[2];
 		val->val2 = 0;
 	}
@@ -185,7 +185,7 @@ static int dht_channel_get(struct device *dev,
 		raw_val = (drv_data->sample[0] << 8) | drv_data->sample[1];
 		val->val1 = raw_val / 10;
 		val->val2 = (raw_val % 10) * 100000;
-	} else { /* chan == SENSOR_CHAN_TEMP */
+	} else { /* chan == SENSOR_CHAN_AMBIENT_TEMP */
 		raw_val = (drv_data->sample[2] << 8) | drv_data->sample[3];
 
 		sign = raw_val & 0x8000;

--- a/drivers/sensor/fxos8700/fxos8700.c
+++ b/drivers/sensor/fxos8700/fxos8700.c
@@ -216,7 +216,7 @@ static int fxos8700_channel_get(struct device *dev, enum sensor_channel chan,
 			ret = 0;
 		}
 #ifdef CONFIG_FXOS8700_TEMP
-		if (chan == SENSOR_CHAN_TEMP) {
+		if (chan == SENSOR_CHAN_DIE_TEMP) {
 			fxos8700_temp_convert(val, data->temp);
 			ret = 0;
 		}

--- a/drivers/sensor/hdc1008/hdc1008.c
+++ b/drivers/sensor/hdc1008/hdc1008.c
@@ -67,7 +67,7 @@ static int hdc1008_channel_get(struct device *dev,
 	 * Register" sections for more details on processing
 	 * sample data.
 	 */
-	if (chan == SENSOR_CHAN_TEMP) {
+	if (chan == SENSOR_CHAN_AMBIENT_TEMP) {
 		/* val = -40 + 165 * sample / 2^16 */
 		tmp = 165 * (u64_t)drv_data->t_sample;
 		val->val1 = (s32_t)(tmp >> 16) - 40;

--- a/drivers/sensor/hp206c/hp206c.c
+++ b/drivers/sensor/hp206c/hp206c.c
@@ -256,7 +256,7 @@ static int hp206c_channel_get(struct device *dev,
 			      struct sensor_value *val)
 {
 	switch (chan) {
-	case SENSOR_CHAN_TEMP:
+	case SENSOR_CHAN_AMBIENT_TEMP:
 		return hp206c_temperature_get(dev, val);
 
 	case SENSOR_CHAN_PRESS:

--- a/drivers/sensor/hts221/hts221.c
+++ b/drivers/sensor/hts221/hts221.c
@@ -20,14 +20,14 @@ static int hts221_channel_get(struct device *dev,
 	struct hts221_data *drv_data = dev->driver_data;
 	s32_t conv_val;
 
-	__ASSERT_NO_MSG(chan == SENSOR_CHAN_TEMP ||
+	__ASSERT_NO_MSG(chan == SENSOR_CHAN_AMBIENT_TEMP ||
 			chan == SENSOR_CHAN_HUMIDITY);
 
 	/*
 	 * see "Interpreting humidity and temperature readings" document
 	 * for more details
 	 */
-	if (chan == SENSOR_CHAN_TEMP) {
+	if (chan == SENSOR_CHAN_AMBIENT_TEMP) {
 		conv_val = (s32_t)(drv_data->t1_degc_x8 -
 				     drv_data->t0_degc_x8) *
 			   (drv_data->t_sample - drv_data->t0_out) /

--- a/drivers/sensor/lis3mdl/lis3mdl.c
+++ b/drivers/sensor/lis3mdl/lis3mdl.c
@@ -44,7 +44,7 @@ static int lis3mdl_channel_get(struct device *dev,
 	} else if (chan == SENSOR_CHAN_MAGN_Z) {
 		lis3mdl_convert(val, drv_data->z_sample,
 				lis3mdl_magn_gain[LIS3MDL_FS_IDX]);
-	} else { /* chan == SENSOR_CHAN_TEMP */
+	} else { /* chan == SENSOR_CHAN_DIE_TEMP */
 		/* temp_val = 25 + sample / 8 */
 		lis3mdl_convert(val, drv_data->temp_sample, 8);
 		val->val1 += 25;

--- a/drivers/sensor/lps22hb/lps22hb.c
+++ b/drivers/sensor/lps22hb/lps22hb.c
@@ -76,7 +76,7 @@ static int lps22hb_channel_get(struct device *dev,
 
 	if (chan == SENSOR_CHAN_PRESS) {
 		lps22hb_press_convert(val, data->sample_press);
-	} else if (chan == SENSOR_CHAN_TEMP) {
+	} else if (chan == SENSOR_CHAN_AMBIENT_TEMP) {
 		lps22hb_temp_convert(val, data->sample_temp);
 	} else {
 		return -ENOTSUP;

--- a/drivers/sensor/lps25hb/lps25hb.c
+++ b/drivers/sensor/lps25hb/lps25hb.c
@@ -92,7 +92,7 @@ static int lps25hb_channel_get(struct device *dev,
 
 	if (chan == SENSOR_CHAN_PRESS) {
 		lps25hb_press_convert(val, data->sample_press);
-	} else if (chan == SENSOR_CHAN_TEMP) {
+	} else if (chan == SENSOR_CHAN_AMBIENT_TEMP) {
 		lps25hb_temp_convert(val, data->sample_temp);
 	} else {
 		return -ENOTSUP;

--- a/drivers/sensor/lsm6ds0/lsm6ds0.c
+++ b/drivers/sensor/lsm6ds0/lsm6ds0.c
@@ -209,7 +209,7 @@ static int lsm6ds0_sample_fetch(struct device *dev, enum sensor_channel chan)
 	__ASSERT_NO_MSG(chan == SENSOR_CHAN_ALL ||
 			chan == SENSOR_CHAN_ACCEL_XYZ ||
 #if defined(CONFIG_LSM6DS0_ENABLE_TEMP)
-			chan == SENSOR_CHAN_TEMP ||
+			chan == SENSOR_CHAN_DIE_TEMP ||
 #endif
 			chan == SENSOR_CHAN_GYRO_XYZ);
 
@@ -221,7 +221,7 @@ static int lsm6ds0_sample_fetch(struct device *dev, enum sensor_channel chan)
 		lsm6ds0_sample_fetch_gyro(dev);
 		break;
 #if defined(CONFIG_LSM6DS0_ENABLE_TEMP)
-	case SENSOR_CHAN_TEMP:
+	case SENSOR_CHAN_DIE_TEMP:
 		lsm6ds0_sample_fetch_temp(dev);
 		break;
 #endif
@@ -383,7 +383,7 @@ static int lsm6ds0_channel_get(struct device *dev,
 		lsm6ds0_gyro_channel_get(chan, val, data);
 		break;
 #if defined(CONFIG_LSM6DS0_ENABLE_TEMP)
-	case SENSOR_CHAN_TEMP:
+	case SENSOR_CHAN_DIE_TEMP:
 		lsm6ds0_gyro_channel_get_temp(val, data);
 		break;
 #endif

--- a/drivers/sensor/lsm6dsl/lsm6dsl.c
+++ b/drivers/sensor/lsm6dsl/lsm6dsl.c
@@ -180,7 +180,7 @@ static int lsm6dsl_sample_fetch(struct device *dev, enum sensor_channel chan)
 		lsm6dsl_sample_fetch_gyro(dev);
 		break;
 #if defined(CONFIG_LSM6DSL_ENABLE_TEMP)
-	case SENSOR_CHAN_TEMP:
+	case SENSOR_CHAN_DIE_TEMP:
 		lsm6dsl_sample_fetch_temp(dev);
 		break;
 #endif
@@ -325,7 +325,7 @@ static int lsm6dsl_channel_get(struct device *dev,
 		lsm6dsl_gyro_channel_get(chan, val, data);
 		break;
 #if defined(CONFIG_LSM6DSL_ENABLE_TEMP)
-	case SENSOR_CHAN_TEMP:
+	case SENSOR_CHAN_DIE_TEMP:
 		lsm6dsl_gyro_channel_get_temp(val, data);
 		break;
 #endif

--- a/drivers/sensor/lsm9ds0_mfd/lsm9ds0_mfd.c
+++ b/drivers/sensor/lsm9ds0_mfd/lsm9ds0_mfd.c
@@ -371,7 +371,7 @@ static int lsm9ds0_mfd_sample_fetch(struct device *dev,
 		return lsm9ds0_mfd_sample_fetch_magn(dev);
 #endif
 #if !defined(LSM9DS0_MFD_TEMP_DISABLED)
-	case SENSOR_CHAN_TEMP:
+	case SENSOR_CHAN_DIE_TEMP:
 		return lsm9ds0_mfd_sample_fetch_temp(dev);
 #endif
 	case SENSOR_CHAN_ALL:
@@ -569,7 +569,7 @@ static int lsm9ds0_mfd_channel_get(struct device *dev,
 		return lsm9ds0_mfd_get_magn(dev, chan, val);
 #endif
 #if !defined(LSM9DS0_MFD_TEMP_DISABLED)
-	case SENSOR_CHAN_TEMP:
+	case SENSOR_CHAN_DIE_TEMP:
 		val->val1 = data->sample_temp;
 		val->val2 = 0;
 		return 0;

--- a/drivers/sensor/mcp9808/mcp9808.c
+++ b/drivers/sensor/mcp9808/mcp9808.c
@@ -46,7 +46,7 @@ static int mcp9808_sample_fetch(struct device *dev, enum sensor_channel chan)
 {
 	struct mcp9808_data *data = dev->driver_data;
 
-	__ASSERT_NO_MSG(chan == SENSOR_CHAN_ALL || chan == SENSOR_CHAN_TEMP);
+	__ASSERT_NO_MSG(chan == SENSOR_CHAN_ALL || chan == SENSOR_CHAN_AMBIENT_TEMP);
 
 	return mcp9808_reg_read(data, MCP9808_REG_TEMP_AMB, &data->reg_val);
 }
@@ -57,7 +57,7 @@ static int mcp9808_channel_get(struct device *dev,
 {
 	struct mcp9808_data *data = dev->driver_data;
 
-	__ASSERT_NO_MSG(chan == SENSOR_CHAN_TEMP);
+	__ASSERT_NO_MSG(chan == SENSOR_CHAN_AMBIENT_TEMP);
 
 	val->val1 = (data->reg_val & MCP9808_TEMP_INT_MASK) >>
 		     MCP9808_TEMP_INT_SHIFT;

--- a/drivers/sensor/mcp9808/mcp9808_trigger.c
+++ b/drivers/sensor/mcp9808/mcp9808_trigger.c
@@ -62,7 +62,7 @@ int mcp9808_attr_set(struct device *dev, enum sensor_channel chan,
 	u8_t reg_addr;
 	s32_t val2;
 
-	__ASSERT_NO_MSG(chan == SENSOR_CHAN_TEMP);
+	__ASSERT_NO_MSG(chan == SENSOR_CHAN_AMBIENT_TEMP);
 
 	val2 = val->val2;
 	while (val2 > 0) {

--- a/drivers/sensor/mpu6050/mpu6050.c
+++ b/drivers/sensor/mpu6050/mpu6050.c
@@ -97,7 +97,7 @@ static int mpu6050_channel_get(struct device *dev,
 		mpu6050_convert_gyro(val, drv_data->gyro_z,
 				     drv_data->gyro_sensitivity_x10);
 		break;
-	default: /* chan == SENSOR_CHAN_TEMP */
+	default: /* chan == SENSOR_CHAN_DIE_TEMP */
 		mpu6050_convert_temp(val, drv_data->temp);
 	}
 

--- a/drivers/sensor/nrf5/temp_nrf5.c
+++ b/drivers/sensor/nrf5/temp_nrf5.c
@@ -36,7 +36,7 @@ static int temp_nrf5_sample_fetch(struct device *dev, enum sensor_channel chan)
 
 	SYS_LOG_DBG("");
 
-	if (chan != SENSOR_CHAN_ALL && chan != SENSOR_CHAN_TEMP) {
+	if (chan != SENSOR_CHAN_ALL && chan != SENSOR_CHAN_AMBIENT_TEMP) {
 		return -ENOTSUP;
 	}
 
@@ -69,7 +69,7 @@ static int temp_nrf5_channel_get(struct device *dev,
 
 	SYS_LOG_DBG("");
 
-	if (chan != SENSOR_CHAN_TEMP) {
+	if (chan != SENSOR_CHAN_AMBIENT_TEMP) {
 		return -ENOTSUP;
 	}
 

--- a/drivers/sensor/sht3xd/sht3xd.c
+++ b/drivers/sensor/sht3xd/sht3xd.c
@@ -120,7 +120,7 @@ static int sht3xd_channel_get(struct device *dev,
 	 * See datasheet "Conversion of Signal Output" section
 	 * for more details on processing sample data.
 	 */
-	if (chan == SENSOR_CHAN_TEMP) {
+	if (chan == SENSOR_CHAN_AMBIENT_TEMP) {
 		/* val = -45 + 175 * sample / (2^16 -1) */
 		tmp = 175 * (u64_t)drv_data->t_sample;
 		val->val1 = (s32_t)(tmp / 0xFFFF) - 45;

--- a/drivers/sensor/sht3xd/sht3xd_trigger.c
+++ b/drivers/sensor/sht3xd/sht3xd_trigger.c
@@ -38,7 +38,7 @@ int sht3xd_attr_set(struct device *dev,
 	u16_t set_cmd, clear_cmd, reg_val, temp, rh;
 
 	if (attr == SENSOR_ATTR_LOWER_THRESH) {
-		if (chan == SENSOR_CHAN_TEMP) {
+		if (chan == SENSOR_CHAN_AMBIENT_TEMP) {
 			drv_data->t_low = sht3xd_temp_processed_to_raw(val);
 		} else if (chan == SENSOR_CHAN_HUMIDITY) {
 			drv_data->rh_low = sht3xd_rh_processed_to_raw(val);
@@ -51,7 +51,7 @@ int sht3xd_attr_set(struct device *dev,
 		temp = drv_data->t_low;
 		rh = drv_data->rh_low;
 	} else if (attr == SENSOR_ATTR_UPPER_THRESH) {
-		if (chan == SENSOR_CHAN_TEMP) {
+		if (chan == SENSOR_CHAN_AMBIENT_TEMP) {
 			drv_data->t_high = sht3xd_temp_processed_to_raw(val);
 		} else if (chan == SENSOR_CHAN_HUMIDITY) {
 			drv_data->rh_high = sht3xd_rh_processed_to_raw(val);

--- a/drivers/sensor/th02/th02.c
+++ b/drivers/sensor/th02/th02.c
@@ -85,7 +85,7 @@ static int th02_sample_fetch(struct device *dev, enum sensor_channel chan)
 {
 	struct th02_data *drv_data = dev->driver_data;
 
-	__ASSERT_NO_MSG(chan == SENSOR_CHAN_ALL || chan == SENSOR_CHAN_TEMP);
+	__ASSERT_NO_MSG(chan == SENSOR_CHAN_ALL || chan == SENSOR_CHAN_AMBIENT_TEMP);
 
 	drv_data->t_sample = get_temp(drv_data->i2c);
 	SYS_LOG_INF("temp: %u", drv_data->t_sample);
@@ -100,10 +100,10 @@ static int th02_channel_get(struct device *dev, enum sensor_channel chan,
 {
 	struct th02_data *drv_data = dev->driver_data;
 
-	__ASSERT_NO_MSG(chan == SENSOR_CHAN_TEMP ||
+	__ASSERT_NO_MSG(chan == SENSOR_CHAN_AMBIENT_TEMP ||
 			chan == SENSOR_CHAN_HUMIDITY);
 
-	if (chan == SENSOR_CHAN_TEMP) {
+	if (chan == SENSOR_CHAN_AMBIENT_TEMP) {
 		/* val = sample / 32 - 50 */
 		val->val1 = drv_data->t_sample / 32 - 50;
 		val->val2 = (drv_data->t_sample % 32) * (1000000 / 32);

--- a/drivers/sensor/tmp007/tmp007.c
+++ b/drivers/sensor/tmp007/tmp007.c
@@ -68,7 +68,7 @@ static int tmp007_sample_fetch(struct device *dev, enum sensor_channel chan)
 	struct tmp007_data *drv_data = dev->driver_data;
 	u16_t val;
 
-	__ASSERT_NO_MSG(chan == SENSOR_CHAN_ALL || chan == SENSOR_CHAN_TEMP);
+	__ASSERT_NO_MSG(chan == SENSOR_CHAN_ALL || chan == SENSOR_CHAN_AMBIENT_TEMP);
 
 	if (tmp007_reg_read(drv_data, TMP007_REG_TOBJ, &val) < 0) {
 		return -EIO;
@@ -90,7 +90,7 @@ static int tmp007_channel_get(struct device *dev,
 	struct tmp007_data *drv_data = dev->driver_data;
 	s32_t uval;
 
-	if (chan != SENSOR_CHAN_TEMP) {
+	if (chan != SENSOR_CHAN_AMBIENT_TEMP) {
 		return -ENOTSUP;
 	}
 

--- a/drivers/sensor/tmp007/tmp007_trigger.c
+++ b/drivers/sensor/tmp007/tmp007_trigger.c
@@ -23,7 +23,7 @@ int tmp007_attr_set(struct device *dev,
 	s64_t value;
 	u8_t reg;
 
-	if (chan != SENSOR_CHAN_TEMP) {
+	if (chan != SENSOR_CHAN_AMBIENT_TEMP) {
 		return -ENOTSUP;
 	}
 

--- a/drivers/sensor/tmp112/tmp112.c
+++ b/drivers/sensor/tmp112/tmp112.c
@@ -81,7 +81,7 @@ static int tmp112_attr_set(struct device *dev,
 	s64_t value;
 	u16_t cr;
 
-	if (chan != SENSOR_CHAN_TEMP) {
+	if (chan != SENSOR_CHAN_AMBIENT_TEMP) {
 		return -ENOTSUP;
 	}
 
@@ -153,7 +153,7 @@ static int tmp112_sample_fetch(struct device *dev, enum sensor_channel chan)
 	struct tmp112_data *drv_data = dev->driver_data;
 	u16_t val;
 
-	__ASSERT_NO_MSG(chan == SENSOR_CHAN_ALL || chan == SENSOR_CHAN_TEMP);
+	__ASSERT_NO_MSG(chan == SENSOR_CHAN_ALL || chan == SENSOR_CHAN_AMBIENT_TEMP);
 
 	if (tmp112_reg_read(drv_data, TMP112_REG_TEMPERATURE, &val) < 0) {
 		return -EIO;
@@ -175,7 +175,7 @@ static int tmp112_channel_get(struct device *dev,
 	struct tmp112_data *drv_data = dev->driver_data;
 	s32_t uval;
 
-	if (chan != SENSOR_CHAN_TEMP) {
+	if (chan != SENSOR_CHAN_AMBIENT_TEMP) {
 		return -ENOTSUP;
 	}
 

--- a/include/sensor.h
+++ b/include/sensor.h
@@ -96,8 +96,12 @@ enum sensor_channel {
 	 * Magnetic field on any axis.
 	 */
 	SENSOR_CHAN_MAGN_ANY = SENSOR_CHAN_MAGN_XYZ,
-	/** Temperature in degrees Celsius. */
+	/** Temperature in degrees Celsius. (deprecated) */
 	SENSOR_CHAN_TEMP,
+	/** Device die temperature in degrees Celsius. */
+	SENSOR_CHAN_DIE_TEMP,
+	/** Ambient temperature in degrees Celsius. */
+	SENSOR_CHAN_AMBIENT_TEMP,
 	/** Pressure in kilopascal. */
 	SENSOR_CHAN_PRESS,
 	/**

--- a/samples/boards/arduino_101/environmental_sensing/ap/src/main.c
+++ b/samples/boards/arduino_101/environmental_sensing/ap/src/main.c
@@ -99,7 +99,7 @@ static void sensor_ipm_callback(void *context, u32_t id, volatile void *data)
 	volatile struct sensor_value *val = data;
 
 	switch (id) {
-	case SENSOR_CHAN_TEMP:
+	case SENSOR_CHAN_AMBIENT_TEMP:
 		/* resolution of 0.01 degrees Celsius */
 		temp_value = val->val1 * 100 + val->val2 / 10000;
 		break;

--- a/samples/boards/arduino_101/environmental_sensing/sensor/src/main.c
+++ b/samples/boards/arduino_101/environmental_sensing/sensor/src/main.c
@@ -27,7 +27,7 @@ struct channel_info {
 
 /* change device names if you want to use different sensors */
 static struct channel_info info[] = {
-	{SENSOR_CHAN_TEMP, "HDC1008"},
+	{SENSOR_CHAN_AMBIENT_TEMP, "HDC1008"},
 	{SENSOR_CHAN_HUMIDITY, "HDC1008"},
 	{SENSOR_CHAN_PRESS, "BMP280"},
 };

--- a/samples/grove/temperature/src/main.c
+++ b/samples/grove/temperature/src/main.c
@@ -44,7 +44,7 @@ void main(void)
 		struct sensor_value temp;
 
 		sensor_sample_fetch(dev);
-		sensor_channel_get(dev, SENSOR_CHAN_TEMP, &temp);
+		sensor_channel_get(dev, SENSOR_CHAN_AMBIENT_TEMP, &temp);
 #ifdef CONFIG_GROVE_LCD_RGB
 		char row[16];
 

--- a/samples/sensor/amg88xx/src/main.c
+++ b/samples/sensor/amg88xx/src/main.c
@@ -65,7 +65,7 @@ void main(void)
 		.val2 = 0,
 	};
 
-	if (sensor_attr_set(dev, SENSOR_CHAN_TEMP,
+	if (sensor_attr_set(dev, SENSOR_CHAN_AMBIENT_TEMP,
 			    SENSOR_ATTR_UPPER_THRESH, &attr)) {
 		printk("Could not set threshold\n");
 		return;
@@ -73,7 +73,7 @@ void main(void)
 
 	struct sensor_trigger trig = {
 		.type = SENSOR_TRIG_THRESHOLD,
-		.chan = SENSOR_CHAN_TEMP,
+		.chan = SENSOR_CHAN_AMBIENT_TEMP,
 	};
 
 	if (sensor_trigger_set(dev, &trig, trigger_handler)) {
@@ -94,7 +94,7 @@ void main(void)
 			return;
 		}
 
-		ret = sensor_channel_get(dev, SENSOR_CHAN_TEMP,
+		ret = sensor_channel_get(dev, SENSOR_CHAN_AMBIENT_TEMP,
 					 (struct sensor_value *)temp_value);
 		if (ret) {
 			printk("Failed to get sensor values, %d\n", ret);

--- a/samples/sensor/bme280/src/main.c
+++ b/samples/sensor/bme280/src/main.c
@@ -19,7 +19,7 @@ void main(void)
 		struct sensor_value temp, press, humidity;
 
 		sensor_sample_fetch(dev);
-		sensor_channel_get(dev, SENSOR_CHAN_TEMP, &temp);
+		sensor_channel_get(dev, SENSOR_CHAN_AMBIENT_TEMP, &temp);
 		sensor_channel_get(dev, SENSOR_CHAN_PRESS, &press);
 		sensor_channel_get(dev, SENSOR_CHAN_HUMIDITY, &humidity);
 

--- a/samples/sensor/bmg160/src/main.c
+++ b/samples/sensor/bmg160/src/main.c
@@ -36,7 +36,7 @@ static void print_temp_data(struct device *bmg160)
 {
 	struct sensor_value val;
 
-	if (sensor_channel_get(bmg160, SENSOR_CHAN_TEMP, &val) < 0) {
+	if (sensor_channel_get(bmg160, SENSOR_CHAN_DIE_TEMP, &val) < 0) {
 		printf("Temperature channel read error.\n");
 		return;
 	}

--- a/samples/sensor/bmi160/src/bmi160.c
+++ b/samples/sensor/bmi160/src/bmi160.c
@@ -191,7 +191,7 @@ static void print_temp_data(struct device *bmi160)
 	struct sensor_value val;
 	char buf[18];
 
-	if (sensor_channel_get(bmi160, SENSOR_CHAN_TEMP, &val) < 0) {
+	if (sensor_channel_get(bmi160, SENSOR_CHAN_DIE_TEMP, &val) < 0) {
 		printk("Temperature channel read error.\n");
 		return;
 	}

--- a/samples/sensor/fxos8700/src/main.c
+++ b/samples/sensor/fxos8700/src/main.c
@@ -65,7 +65,7 @@ void main(void)
 
 		sensor_channel_get(dev, SENSOR_CHAN_ACCEL_XYZ, accel);
 		sensor_channel_get(dev, SENSOR_CHAN_MAGN_XYZ, magn);
-		sensor_channel_get(dev, SENSOR_CHAN_TEMP, &temp);
+		sensor_channel_get(dev, SENSOR_CHAN_DIE_TEMP, &temp);
 
 		/* Print accel x,y,z and mag x,y,z data */
 		printf("AX=%10.6f AY=%10.6f AZ=%10.6f "

--- a/samples/sensor/hts221/src/main.c
+++ b/samples/sensor/hts221/src/main.c
@@ -26,7 +26,7 @@ void main(void)
 			return;
 		}
 
-		if (sensor_channel_get(dev, SENSOR_CHAN_TEMP, &temp) < 0) {
+		if (sensor_channel_get(dev, SENSOR_CHAN_AMBIENT_TEMP, &temp) < 0) {
 			printf("Cannot read HTS221 temperature channel\n");
 			return;
 		}

--- a/samples/sensor/mcp9808/src/main.c
+++ b/samples/sensor/mcp9808/src/main.c
@@ -15,7 +15,7 @@ static void trigger_handler(struct device *dev, struct sensor_trigger *trig)
 	struct sensor_value temp;
 
 	sensor_sample_fetch(dev);
-	sensor_channel_get(dev, SENSOR_CHAN_TEMP, &temp);
+	sensor_channel_get(dev, SENSOR_CHAN_AMBIENT_TEMP, &temp);
 
 	printf("trigger fired, temp %d.%06d\n", temp.val1, temp.val2);
 }
@@ -42,11 +42,11 @@ void main(void)
 	val.val1 = 26;
 	val.val2 = 0;
 
-	sensor_attr_set(dev, SENSOR_CHAN_TEMP,
+	sensor_attr_set(dev, SENSOR_CHAN_AMBIENT_TEMP,
 			SENSOR_ATTR_UPPER_THRESH, &val);
 
 	trig.type = SENSOR_TRIG_THRESHOLD;
-	trig.chan = SENSOR_CHAN_TEMP;
+	trig.chan = SENSOR_CHAN_AMBIENT_TEMP;
 
 	sensor_trigger_set(dev, &trig, trigger_handler);
 #endif
@@ -61,7 +61,7 @@ void main(void)
 			break;
 		}
 
-		rc = sensor_channel_get(dev, SENSOR_CHAN_TEMP, &temp);
+		rc = sensor_channel_get(dev, SENSOR_CHAN_AMBIENT_TEMP, &temp);
 		if (rc != 0) {
 			printf("sensor_channel_get error: %d\n", rc);
 			break;

--- a/samples/sensor/th02/src/main.c
+++ b/samples/sensor/th02/src/main.c
@@ -23,7 +23,7 @@ struct channel_info {
 
 /* change device names if you want to use different sensors */
 static struct channel_info info[] = {
-	{ SENSOR_CHAN_TEMP, "TH02" },
+	{ SENSOR_CHAN_AMBIENT_TEMP, "TH02" },
 	{ SENSOR_CHAN_HUMIDITY, "TH02" },
 };
 

--- a/samples/sensor/thermometer/src/main.c
+++ b/samples/sensor/thermometer/src/main.c
@@ -33,7 +33,7 @@ void main(void)
 			break;
 		}
 
-		r = sensor_channel_get(temp_dev, SENSOR_CHAN_TEMP,
+		r = sensor_channel_get(temp_dev, SENSOR_CHAN_AMBIENT_TEMP,
 				       &temp_value);
 		if (r) {
 			printf("sensor_channel_get failed return: %d\n", r);

--- a/samples/sensor/tmp112/src/main.c
+++ b/samples/sensor/tmp112/src/main.c
@@ -18,7 +18,7 @@ static void do_main(struct device *dev)
 
 	attr.val1 = 150;
 	attr.val2 = 0;
-	ret = sensor_attr_set(dev, SENSOR_CHAN_TEMP,
+	ret = sensor_attr_set(dev, SENSOR_CHAN_AMBIENT_TEMP,
 			      SENSOR_ATTR_FULL_SCALE, &attr);
 	if (ret) {
 		printk("sensor_attr_set failed ret %d\n", ret);
@@ -27,7 +27,7 @@ static void do_main(struct device *dev)
 
 	attr.val1 = 8;
 	attr.val2 = 0;
-	ret = sensor_attr_set(dev, SENSOR_CHAN_TEMP,
+	ret = sensor_attr_set(dev, SENSOR_CHAN_AMBIENT_TEMP,
 			      SENSOR_ATTR_SAMPLING_FREQUENCY, &attr);
 	if (ret) {
 		printk("sensor_attr_set failed ret %d\n", ret);
@@ -41,7 +41,7 @@ static void do_main(struct device *dev)
 			return;
 		}
 
-		ret = sensor_channel_get(dev, SENSOR_CHAN_TEMP, &temp_value);
+		ret = sensor_channel_get(dev, SENSOR_CHAN_AMBIENT_TEMP, &temp_value);
 		if (ret) {
 			printk("sensor_channel_get failed ret %d\n", ret);
 			return;


### PR DESCRIPTION
Some device include a temperature sensor that measure the die temperature
and can be used to compensate other sensor's drift. This temperature IS NOT
related to the the ambient temperature for which a new separated definition
is required.

Signed-off-by: Armando Visconti <armando.visconti@st.com>