### PR TITLE
Bluetooth: controller: Use hal/ticker.h to abstract SoC specifics

### DIFF
--- a/subsys/bluetooth/controller/hal/nrf5/ticker.h
+++ b/subsys/bluetooth/controller/hal/nrf5/ticker.h
@@ -30,9 +30,3 @@
 
 /* Macro defines the h/w supported most significant bit */
 #define HAL_TICKER_MSBIT 23
-
-/* Exported integration interfaces */
-u8_t hal_ticker_instance0_caller_id_get(u8_t user_id);
-void hal_ticker_instance0_sched(u8_t caller_id, u8_t callee_id, u8_t chain,
-				void *instance);
-void hal_ticker_instance0_trigger_set(u32_t value);

--- a/subsys/bluetooth/controller/hal/ticker.h
+++ b/subsys/bluetooth/controller/hal/ticker.h
@@ -1,0 +1,15 @@
+/*
+ * Copyright (c) 2016-2018 Nordic Semiconductor ASA
+ * Copyright (c) 2016 Vinayak Kariappa Chettimada
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#if defined(CONFIG_SOC_FAMILY_NRF)
+#include "hal/nrf5/ticker.h"
+#endif /* CONFIG_SOC_FAMILY_NRF */
+
+u8_t hal_ticker_instance0_caller_id_get(u8_t user_id);
+void hal_ticker_instance0_sched(u8_t caller_id, u8_t callee_id, u8_t chain,
+				void *instance);
+void hal_ticker_instance0_trigger_set(u32_t value);

--- a/subsys/bluetooth/controller/ll_sw/ctrl.c
+++ b/subsys/bluetooth/controller/ll_sw/ctrl.c
@@ -18,7 +18,6 @@
 #include "ll.h"
 
 #if defined(CONFIG_SOC_FAMILY_NRF)
-#include "hal/nrf5/ticker.h"
 #include <drivers/entropy/nrf5_entropy.h>
 #endif /* CONFIG_SOC_FAMILY_NRF */
 
@@ -26,6 +25,7 @@
 #include "hal/ecb.h"
 #include "hal/ccm.h"
 #include "hal/radio.h"
+#include "hal/ticker.h"
 #include "hal/debug.h"
 
 #include "util/util.h"

--- a/subsys/bluetooth/controller/ll_sw/ll.c
+++ b/subsys/bluetooth/controller/ll_sw/ll.c
@@ -23,11 +23,8 @@
 #include "hal/cntr.h"
 #include "hal/ccm.h"
 #include "hal/radio.h"
+#include "hal/ticker.h"
 #include "hal/debug.h"
-
-#if defined(CONFIG_SOC_FAMILY_NRF)
-#include "hal/nrf5/ticker.h"
-#endif /* CONFIG_SOC_FAMILY_NRF */
 
 #include "util/util.h"
 #include "util/mem.h"

--- a/subsys/bluetooth/controller/ticker/ticker.c
+++ b/subsys/bluetooth/controller/ticker/ticker.c
@@ -9,10 +9,7 @@
 #include <soc.h>
 
 #include "hal/cntr.h"
-
-#if defined(CONFIG_SOC_FAMILY_NRF)
-#include "hal/nrf5/ticker.h"
-#endif /* CONFIG_SOC_FAMILY_NRF */
+#include "hal/ticker.h"
 
 #include "ticker.h"
 


### PR DESCRIPTION
Introduce hal/ticker.h to abstract out SoC specific
implementations and move any conditional compilations to
include header files here.

Signed-off-by: Vinayak Kariappa Chettimada <vich@nordicsemi.no>