### PR TITLE
net: websocket: Use system provided base64 function

### DIFF
--- a/samples/net/ws_console/prj.conf
+++ b/samples/net/ws_console/prj.conf
@@ -39,10 +39,9 @@ CONFIG_HTTP_SERVER=y
 # How many URLs we are serving
 CONFIG_HTTP_SERVER_NUM_URLS=5
 
-# base64 support needed by websocket
+# sha1 support needed by websocket
 CONFIG_MBEDTLS=y
 CONFIG_MBEDTLS_BUILTIN=y
-CONFIG_MBEDTLS_CFG_FILE="config-mini-tls1_2.h"
 
 # Logging
 CONFIG_NET_LOG=y

--- a/samples/net/ws_console/sample.yaml
+++ b/samples/net/ws_console/sample.yaml
@@ -3,5 +3,5 @@ sample:
 tests:
    test:
         build_only: true
-        platform_whitelist: qemu_x86
+        platform_whitelist: qemu_x86 native_posix
         tags: net websocket

--- a/samples/net/ws_echo_server/prj.conf
+++ b/samples/net/ws_echo_server/prj.conf
@@ -38,10 +38,9 @@ CONFIG_HTTP_SERVER=y
 # How many URLs we are serving
 CONFIG_HTTP_SERVER_NUM_URLS=5
 
-# base64 support needed by websocket
+# sha1 support needed by websocket
 CONFIG_MBEDTLS=y
 CONFIG_MBEDTLS_BUILTIN=y
-CONFIG_MBEDTLS_CFG_FILE="config-mini-tls1_2.h"
 
 # Logging
 CONFIG_NET_LOG=y

--- a/samples/net/ws_echo_server/sample.yaml
+++ b/samples/net/ws_echo_server/sample.yaml
@@ -3,5 +3,5 @@ sample:
 tests:
    test:
         build_only: true
-        platform_whitelist: qemu_x86 qemu_cortex_m3
+        platform_whitelist: qemu_x86 qemu_cortex_m3 native_posix
         tags: net websocket

--- a/subsys/net/lib/websocket/Kconfig
+++ b/subsys/net/lib/websocket/Kconfig
@@ -8,6 +8,7 @@ menuconfig WEBSOCKET
 	default n
 	depends on HTTP
 	select NET_TCP
+	select BASE64
 	help
 	This option enables the websocket library.
 

--- a/subsys/net/lib/websocket/websocket.c
+++ b/subsys/net/lib/websocket/websocket.c
@@ -20,7 +20,7 @@
 #include <net/net_ip.h>
 #include <net/websocket.h>
 
-#include <mbedtls/base64.h>
+#include <base64.h>
 #include <mbedtls/sha1.h>
 
 #define BUF_ALLOC_TIMEOUT 100
@@ -395,12 +395,12 @@ static struct net_pkt *prepare_reply(struct http_ctx *ctx,
 
 	snprintk(tmp, sizeof(tmp), "Sec-WebSocket-Accept: ");
 
-	ret = mbedtls_base64_encode(tmp + sizeof("Sec-WebSocket-Accept: ") - 1,
-				    sizeof(tmp) -
-				    (sizeof("Sec-WebSocket-Accept: ") - 1),
-				    &olen, accept, sizeof(accept));
+	ret = base64_encode(tmp + sizeof("Sec-WebSocket-Accept: ") - 1,
+			    sizeof(tmp) -
+			    (sizeof("Sec-WebSocket-Accept: ") - 1),
+			    &olen, accept, sizeof(accept));
 	if (ret) {
-		if (ret == MBEDTLS_ERR_BASE64_BUFFER_TOO_SMALL) {
+		if (ret == -ENOMEM) {
 			NET_DBG("[%p] Too short buffer olen %zd", ctx, olen);
 		}
 

--- a/tests/net/websocket/prj.conf
+++ b/tests/net/websocket/prj.conf
@@ -50,10 +50,9 @@ CONFIG_HTTP_SERVER=y
 # How many URLs we are serving
 CONFIG_HTTP_SERVER_NUM_URLS=5
 
-# base64 support needed by websocket
+# sha1 support needed by websocket
 CONFIG_MBEDTLS=y
 CONFIG_MBEDTLS_BUILTIN=y
-CONFIG_MBEDTLS_CFG_FILE="config-mini-tls1_2.h"
 
 # Logging
 CONFIG_NET_LOG=y


### PR DESCRIPTION
Instead of using mbedtls_base64, use system provided base64 encoding
function.

Signed-off-by: Jukka Rissanen <jukka.rissanen@linux.intel.com>