### PR TITLE
build: doc: Add support for a Windows equivalent to .zephyrrc

### DIFF
--- a/doc/getting_started/installation_win.rst
+++ b/doc/getting_started/installation_win.rst
@@ -135,8 +135,7 @@ packages from their respective websites.
       set GCCARMEMB_TOOLCHAIN_PATH=c:\gccarmemb
 
    To use the same toolchain in new sessions in the future you can set the
-   variables in a ``.cmd`` file and run that every time you open a new
-   Command Prompt.
+   variables in the file :file:`%userprofile%\\zephyrrc.cmd`.
 
    And for either, run the :file:`zephyr-env.cmd` file in order to set the
    :makevar:`ZEPHYR_BASE` environment variable:

--- a/zephyr-env.cmd
+++ b/zephyr-env.cmd
@@ -1,2 +1,6 @@
 @echo off
 set ZEPHYR_BASE=%~dp0
+
+if exist "%userprofile%\zephyrrc.cmd" (
+	call "%userprofile%\zephyrrc.cmd"
+)


### PR DESCRIPTION
Adds support for setting user environment variables in the file
%userprofile%\zephyrrc.cmd

Signed-off-by: Maureen Helm <maureen.helm@nxp.com>