### PR TITLE
doc: boards: Remove hint to ini file

### DIFF
--- a/doc/porting/board_porting.rst
+++ b/doc/porting/board_porting.rst
@@ -120,7 +120,3 @@ Board
 A board implements an SoC with all its features, together with peripherals
 available on the board that differentiates the board with additional interfaces
 and features not available in the SoC.
-
-While adding your board support, make sure to add it to the list of
-``platforms`` in the appropriate architecture ``.ini`` file in
-``scripts/sanity_chk/arches/``.


### PR DESCRIPTION
Since commit a792a3d410ce2a71c7f4882a89a72e79ecb79cb6, adding an ini
file in scripts/sanity_chk/arches/ to support a new board is no longer
needed.

Signed-off-by: Reto Schneider <code@reto-schneider.ch>