### PR TITLE
board: x86: tinytile: Enable I2C through DTS

### DIFF
--- a/boards/x86/tinytile/Kconfig.board
+++ b/boards/x86/tinytile/Kconfig.board
@@ -3,3 +3,4 @@ config BOARD_TINYTILE
 	bool "TinyTILE"
 	depends on SOC_SERIES_QUARK_SE
 	select HAS_DTS
+	select HAS_DTS_I2C

--- a/boards/x86/tinytile/tinytile.dts
+++ b/boards/x86/tinytile/tinytile.dts
@@ -37,3 +37,13 @@
 	status = "ok";
 	current-speed = <115200>;
 };
+
+&i2c0 {
+	status = "ok";
+	clock-frequency = <I2C_BITRATE_FAST>;
+};
+
+&i2c1 {
+	status = "ok";
+	clock-frequency = <I2C_BITRATE_FAST>;
+};


### PR DESCRIPTION
For some reason tinytile was missed in the conversion of quark_se boards
to use DTS for I2C.

Signed-off-by: Kumar Gala <kumar.gala@linaro.org>