### PR TITLE
samples: net: http_server: Send final chunk

### DIFF
--- a/samples/net/http_server/src/main.c
+++ b/samples/net/http_server/src/main.c
@@ -129,6 +129,12 @@ static int http_response(struct http_ctx *ctx, const char *header,
 		return ret;
 	}
 
+	ret = http_send_chunk(ctx, NULL, 0, dst, NULL);
+	if (ret < 0) {
+		NET_ERR("Cannot send data to peer (%d)", ret);
+		return ret;
+	}
+
 	return http_send_flush(ctx, str);
 }
 


### PR DESCRIPTION
The final ending chunk was not sent after the request was served.
This caused the remote client to constantly send the same request
to the server.

Fixes #6356

Signed-off-by: Jukka Rissanen <jukka.rissanen@linux.intel.com>