### PR TITLE
doc: net: Add websocket and websocket_console to net API docs

### DIFF
--- a/doc/api/networking.rst
+++ b/doc/api/networking.rst
@@ -161,3 +161,15 @@ HTTP
 
 .. doxygengroup:: http
    :project: Zephyr
+
+Websocket
+=========
+
+.. doxygengroup:: websocket
+   :project: Zephyr
+
+Websocket console
+=================
+
+.. doxygengroup:: websocket_console
+   :project: Zephyr


### PR DESCRIPTION
Websocket related groups were missing from network API documentation.

Fixes #6779

Signed-off-by: Jukka Rissanen <jukka.rissanen@linux.intel.com>