### PR TITLE
driver: eth: native_posix: Enable ethernet by default

### DIFF
--- a/boards/posix/native_posix/Kconfig.defconfig
+++ b/boards/posix/native_posix/Kconfig.defconfig
@@ -13,4 +13,14 @@ config OUTPUT_PRINT_MEMORY_USAGE
 config BOARD
 	default "native_posix"
 
+if NETWORKING
+
+config NET_L2_ETHERNET
+	def_bool y if !NET_LOOPBACK && !NET_TEST
+
+config ETH_NATIVE_POSIX
+	def_bool y if NET_L2_ETHERNET
+
+endif # NETWORKING
+
 endif

--- a/drivers/ethernet/Kconfig.native_posix
+++ b/drivers/ethernet/Kconfig.native_posix
@@ -5,10 +5,8 @@
 # SPDX-License-Identifier: Apache-2.0
 
 menuconfig ETH_NATIVE_POSIX
-	bool
-	prompt "Native Posix Ethernet driver"
-	depends on ARCH_POSIX
-	select NET_L2_ETHERNET
+	bool "Native Posix Ethernet driver"
+	depends on ARCH_POSIX && NET_L2_ETHERNET
 	default n
 	help
 	  Enable native posix ethernet driver. Note, this driver is run inside


### PR DESCRIPTION
As the native_posix board has ethernet driver, then enable it by default
if networking is enabled in prj.conf file. This way we can use generic
networking config file when running the application for native_posix board.

Signed-off-by: Jukka Rissanen <jukka.rissanen@linux.intel.com>