### PR TITLE
scripts: kconfig: Give symbol locations in warnings

### DIFF
--- a/scripts/kconfig/kconfig.py
+++ b/scripts/kconfig/kconfig.py
@@ -33,6 +33,18 @@ kconf.write_autoconf(sys.argv[3])
 
 # Print warnings for symbols whose actual value doesn't match the assigned
 # value
+
+def name_and_loc(sym):
+    # Helper for printing symbol names and Kconfig file location(s) in warnings
+
+    if not sym.nodes:
+        return sym.name + " (undefined)"
+
+    return "{} (defined at {})".format(
+        sym.name,
+        ", ".join("{}:{}".format(node.filename, node.linenr)
+                  for node in sym.nodes))
+
 for sym in kconf.defined_syms:
     # Was the symbol assigned to?
     #print('name: {} value: {}'.format(sym.name, sym.str_value))
@@ -46,5 +58,5 @@ for sym in kconf.defined_syms:
         if user_value != sym.str_value:
             print('warning: {} was assigned the value "{}" but got the '
                   'value "{}" -- check dependencies'
-                  .format(sym.name, user_value, sym.str_value))
+                  .format(name_and_loc(sym), user_value, sym.str_value))
 


### PR DESCRIPTION
Warnings from Kconfiglib itself always give symbol locations, but the
custom value mismatch warning in kconfig.py doesn't. Make it print the
symbol locations too. This is helpful when debugging.

Before:

    warning: UART_QMSI_0_HW_FC was assigned the value "y" but got the value "n" -- check dependencies

After:

    warning: UART_QMSI_0_HW_FC (defined at /home/ulf/zephyr/drivers/serial/Kconfig.qmsi:35, /home/ulf/zephyr/arch/x86/soc/intel_quark/quark_se/Kconfig.defconfig.series:194) was assigned the value "y" but got the value "n" -- check dependencies

Signed-off-by: Ulf Magnusson <ulfalizer@gmail.com>