### PR TITLE
tests: kernel: mem_protect: Update platform whitelist

### DIFF
--- a/tests/kernel/mem_protect/x86_mmu_api/testcase.yaml
+++ b/tests/kernel/mem_protect/x86_mmu_api/testcase.yaml
@@ -1,4 +1,4 @@
 tests:
   kernel.memory_protection.mmu:
-    platform_whitelist: qemu_x86 arduino_101
+    platform_whitelist: qemu_x86
     tags: kernel


### PR DESCRIPTION
Remove arduino_101 from platform whitelist in testcase.yaml as all the
test cases are not meant to run on Arduino_101.

Fixes: #6424 
Signed-off-by: Spoorthi K <spoorthi.k@intel.com>