### PR TITLE
tests: fp_sharing: Increase timeout period

### DIFF
--- a/tests/kernel/fp_sharing/testcase.yaml
+++ b/tests/kernel/fp_sharing/testcase.yaml
@@ -4,7 +4,7 @@ tests:
     platform_whitelist: frdm_k64f
     slow: true
     tags: core
-    timeout: 600
+    timeout: 3600
   kernel.fp_sharing.x86:
     platform_whitelist: qemu_x86
     slow: true


### PR DESCRIPTION
Increase timeout value for test case when running on frdm_k64f for
allowing automation script to look for execution report after right
interval as this test case involves floating point calculations.

Signed-off-by: Spoorthi K <spoorthi.k@intel.com>