### PR TITLE
tests: net: websocket: Fix null at the end of string

### DIFF
--- a/tests/net/websocket/src/server.c
+++ b/tests/net/websocket/src/server.c
@@ -143,7 +143,7 @@ static void ws_connected(struct http_ctx *ctx,
 			 void *user_data)
 {
 	char url[32];
-	int len = min(sizeof(url), ctx->http.url_len);
+	int len = min(sizeof(url) - 1, ctx->http.url_len);
 
 	memcpy(url, ctx->http.url, len);
 	url[len] = '\0';


### PR DESCRIPTION
We might access too long string when copying URL.

Coverity-CID: 183041
Fixes #6691

Signed-off-by: Jukka Rissanen <jukka.rissanen@linux.intel.com>