### PR TITLE
samples: net: websocket_console: Do not copy pass end of string

### DIFF
--- a/samples/net/ws_console/src/ws_console.c
+++ b/samples/net/ws_console/src/ws_console.c
@@ -247,7 +247,7 @@ static void ws_connected(struct http_ctx *ctx,
 			 void *user_data)
 {
 	char url[32];
-	int len = min(sizeof(url), ctx->http.url_len);
+	int len = min(sizeof(url) - 1, ctx->http.url_len);
 
 	memcpy(url, ctx->http.url, len);
 	url[len] = '\0';


### PR DESCRIPTION
We might access too long string when copying URL.

Signed-off-by: Jukka Rissanen <jukka.rissanen@linux.intel.com>