### PR TITLE
drivers: eth: native_posix: No need to sleep in select

### DIFF
--- a/drivers/ethernet/eth_native_posix_adapt.c
+++ b/drivers/ethernet/eth_native_posix_adapt.c
@@ -115,7 +115,7 @@ int eth_wait_data(int fd)
 	FD_SET(fd, &rset);
 
 	timeout.tv_sec = 0;
-	timeout.tv_usec = USEC(50);
+	timeout.tv_usec = 0;
 
 	ret = select(fd + 1, &rset, NULL, NULL, &timeout);
 	if (ret < 0 && errno != EINTR) {


### PR DESCRIPTION
We can just use polling mode with 0 timeout when waiting data
to arrive from host OS. The 50ms timeout is not needed.

Signed-off-by: Jukka Rissanen <jukka.rissanen@linux.intel.com>