### PR TITLE
include: posix: correcting the return type of sleep.

### DIFF
--- a/include/posix/unistd.h
+++ b/include/posix/unistd.h
@@ -20,7 +20,7 @@ extern "C" {
  *
  * See IEEE 1003.1
  */
-static inline int sleep(unsigned int seconds)
+static inline unsigned sleep(unsigned int seconds)
 {
 	k_sleep(K_SECONDS(seconds));
 	return 0;


### PR DESCRIPTION
Currently return type of sleep is int, but as per POSIX 1003.1 it
should be unsigned.

Signed-off-by: Youvedeep Singh <youvedeep.singh@intel.com>