### PR TITLE
Misc docs drivers fixes

### DIFF
--- a/doc/devices/drivers/drivers.rst
+++ b/doc/devices/drivers/drivers.rst
@@ -300,19 +300,19 @@ leading zeroes or sign (e.g. 32), or an equivalent symbolic name (e.g.
 System Drivers
 **************
 
-In some cases you may just need to run a function at boot. Special ``SYS_INIT``
-macros exist that map to ``DEVICE_INIT()`` or ``DEVICE_INIT_PM()`` calls.
+In some cases you may just need to run a function at boot. Special ``SYS_*``
+macros exist that map to ``DEVICE_*INIT()`` calls.
 For ``SYS_INIT()`` there are no config or runtime data structures and there
 isn't a way
 to later get a device pointer by name. The same policies for initialization
 level and priority apply.
 
-For ``SYS_INIT_PM()`` you can obtain pointers by name, see
+For ``SYS_DEVICE_DEFINE()`` you can obtain pointers by name, see
 :ref:`power management <power_management>` section.
 
 :c:func:`SYS_INIT()`
 
-:c:func:`SYS_INIT_PM()`
+:c:func:`SYS_DEVICE_DEFINE()`
 
 Error handling
 **************

--- a/doc/devices/drivers/drivers.rst
+++ b/doc/devices/drivers/drivers.rst
@@ -91,6 +91,13 @@ split into read-only and runtime-mutable parts. At a high level we have:
         void *driver_data;
   };
 
+  struct device_config {
+	char    *name;
+	int (*init)(struct device *device);
+	const void *config_info;
+    [...]
+  };
+
 The ``config`` member is for read-only configuration data set at build time. For
 example, base memory mapped IO addresses, IRQ line numbers, or other fixed
 physical characteristics of the device. This is the ``config_info`` structure

--- a/doc/devices/drivers/drivers.rst
+++ b/doc/devices/drivers/drivers.rst
@@ -5,9 +5,8 @@ Device Drivers and Device Model
 
 Introduction
 ************
-The Zephyr kernel supports a variety of device drivers. The specific set of
-device drivers available for an application's board configuration varies
-according to the associated hardware components and device driver software.
+The Zephyr kernel supports a variety of device drivers. Whether a
+driver is available depends on the board and the driver.
 
 The Zephyr device model provides a consistent device model for configuring the
 drivers that are part of a system. The device model is responsible
@@ -109,7 +108,7 @@ build time. The next section describes this in more detail.
 Subsystems and API Structures
 *****************************
 
-Most drivers will be targeting a device-independent subsystem API.
+Most drivers will be implementing a device-independent subsystem API.
 Applications can simply program to that generic API, and application
 code is not specific to any particular driver implementation.
 

--- a/doc/devices/drivers/drivers.rst
+++ b/doc/devices/drivers/drivers.rst
@@ -140,17 +140,6 @@ A subsystem API definition typically looks like this:
         api->do_that(device, foo, bar);
   }
 
-In general, it's best to use ``__ASSERT()`` macros instead of
-propagating return values unless the failure is expected to occur during
-the normal course of operation (such as a storage device full). Bad
-parameters, programming errors, consistency checks, pathological/unrecoverable
-failures, etc., should be handled by assertions.
-
-When it is appropriate to return error conditions for the caller to check, 0
-should be returned on success and a POSIX errno.h code returned on failure.
-See https://github.com/zephyrproject-rtos/zephyr/wiki/Naming-Conventions#return-codes for
-details about this.
-
 A driver implementing a particular subsystem will define the real implementation
 of these APIs, and populate an instance of subsystem_api structure:
 
@@ -317,3 +306,20 @@ For ``SYS_INIT_PM()`` you can obtain pointers by name, see
 :c:func:`SYS_INIT()`
 
 :c:func:`SYS_INIT_PM()`
+
+Error handling
+**************
+
+In general, it's best to use ``__ASSERT()`` macros instead of
+propagating return values unless the failure is expected to occur
+during the normal course of operation (such as a storage device
+full). Bad parameters, programming errors, consistency checks,
+pathological/unrecoverable failures, etc., should be handled by
+assertions.
+
+When it is appropriate to return error conditions for the caller to
+check, 0 should be returned on success and a POSIX errno.h code
+returned on failure.  See
+https://github.com/zephyrproject-rtos/zephyr/wiki/Naming-Conventions#return-codes
+for details about this.
+

--- a/include/init.h
+++ b/include/init.h
@@ -27,8 +27,8 @@ extern "C" {
 #define _SYS_INIT_LEVEL_APPLICATION	3
 
 
-/* Counter use to avoid issues if two or more system devices are declared
- * in the same C file with the same init function
+/* A counter is used to avoid issues when two or more system devices
+ * are declared in the same C file with the same init function.
  */
 #define _SYS_NAME(init_fn) _CONCAT(_CONCAT(sys_init_, init_fn), __COUNTER__)
 


### PR DESCRIPTION
Misc. fixes to the 'drivers' documentation.

Some of the documentation was outright wrong (outdated references to renamed macros) and some of the documentation was confusing.