### PR TITLE
gpio_nrf5: bugfix: Don't require INT_EDGE to enable INT_DOUBLE_EDGE

### DIFF
--- a/include/dt-bindings/gpio/gpio.h
+++ b/include/dt-bindings/gpio/gpio.h
@@ -52,7 +52,9 @@
 /** Do Edge trigger. */
 #define GPIO_INT_EDGE		(1 << 5)
 
-/** Interrupt triggers on both rising and falling edge. */
+/** Interrupt triggers on both rising and falling edge.
+ *  Must be combined with GPIO_INT_EDGE.
+ */
 #define GPIO_INT_DOUBLE_EDGE	(1 << 6)
 /** @} */
 


### PR DESCRIPTION
The driver has been ignoring INT_DOUBLE_EDGE when INT_EDGE is set,
AFAICT from the documentation and other drivers, e..g CC2650, this is
incorrect behaviour.

~~This patch ensures that INT_DOUBLE_EDGE takes effect even though
INT_EDGE has not been set.~~

Signed-off-by: Sebastian Bøe <sebastian.boe@nordicsemi.no>