### PR TITLE
netusb: implement the ethernet interface.

### DIFF
--- a/subsys/usb/class/netusb/netusb.c
+++ b/subsys/usb/class/netusb/netusb.c
@@ -22,6 +22,7 @@
 #include <usb_device.h>
 #include <usb_common.h>
 #include <class/usb_cdc.h>
+#include <net/ethernet.h>
 
 #include "../../usb_descriptor.h"
 #include "../../composite.h"
@@ -272,9 +273,12 @@ static void netusb_init(struct net_if *iface)
 	SYS_LOG_INF("netusb initialized");
 }
 
-static struct net_if_api api_funcs = {
-	.init = netusb_init,
-	.send = netusb_send,
+static const struct ethernet_api netusb_api_funcs = {
+	.iface_api = {
+		.init = netusb_init,
+		.send = netusb_send,
+	},
+	.get_capabilities = NULL,
 };
 
 static int netusb_init_dev(struct device *dev)
@@ -284,5 +288,5 @@ static int netusb_init_dev(struct device *dev)
 }
 
 NET_DEVICE_INIT(eth_netusb, "eth_netusb", netusb_init_dev, NULL, NULL,
-		CONFIG_ETH_INIT_PRIORITY, &api_funcs, ETHERNET_L2,
+		CONFIG_ETH_INIT_PRIORITY, &netusb_api_funcs, ETHERNET_L2,
 		NET_L2_GET_CTX_TYPE(ETHERNET_L2), NETUSB_MTU);


### PR DESCRIPTION
net_eth_get_hw_capabilities() calls .get_capabilities() which is part
of the ethernet API but not the net_if_api that netusb implements.
This caused a fault as .get_capabilities() was past the end of the
struct and resolved to a random address.

Also remove the __packed from the API definition.  __packed allows the
struct to be linked at a non-word size boundrary which causes an
unaligned access fault on the Cortex-M0.

Finally, make the API const and give it a unique name.

Signed-off-by: Michael Hope <mlhx@google.com>