### PR TITLE
add system calls for certain C library console functions

### DIFF
--- a/include/misc/libc-hooks.h
+++ b/include/misc/libc-hooks.h
@@ -1,0 +1,28 @@
+/*
+ * Copyright (c) 2018, Intel Corporation.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef ZEPHYR_LIBC_HOOKS_H
+#define ZEPHYR_LIBC_HOOKS_H
+
+#include <toolchain.h>
+#include <stdio.h>
+#include <stddef.h>
+
+/*
+ * Private header for specifying accessory functions to the C library internals
+ * that need to call into the kernel as system calls
+ */
+
+/* Minimal libc */
+
+__syscall int _zephyr_fputc(int c, FILE *stream);
+
+__syscall size_t _zephyr_fwrite(const void *_MLIBC_RESTRICT ptr, size_t size,
+				size_t nitems, FILE *_MLIBC_RESTRICT stream);
+
+#include <syscalls/libc-hooks.h>
+
+#endif /* ZEPHYR_LIBC_HOOKS_H */

--- a/include/misc/libc-hooks.h
+++ b/include/misc/libc-hooks.h
@@ -16,12 +16,26 @@
  * that need to call into the kernel as system calls
  */
 
+#ifdef CONFIG_NEWLIB_LIBC
+
+/* syscall generation ignores preprocessor, ensure this is defined to ensure
+ * we don't have compile errors
+ */
+#define _MLIBC_RESTRICT
+
+__syscall int _zephyr_read(char *buf, int nbytes);
+
+__syscall int _zephyr_write(char *buf, int nbytes);
+
+#else
 /* Minimal libc */
 
 __syscall int _zephyr_fputc(int c, FILE *stream);
 
 __syscall size_t _zephyr_fwrite(const void *_MLIBC_RESTRICT ptr, size_t size,
 				size_t nitems, FILE *_MLIBC_RESTRICT stream);
+
+#endif /* CONFIG_NEWLIB_LIBC */
 
 #include <syscalls/libc-hooks.h>
 

--- a/lib/libc/newlib/libc-hooks.c
+++ b/lib/libc/newlib/libc-hooks.c
@@ -12,6 +12,8 @@
 #include <misc/util.h>
 #include <kernel_internal.h>
 #include <misc/errno_private.h>
+#include <misc/libc-hooks.h>
+#include <syscall_handler.h>
 
 #define USED_RAM_END_ADDR   POINTER_TO_UINT(&_end)
 
@@ -76,8 +78,7 @@ void __stdin_hook_install(unsigned char (*hook)(void))
 	_stdin_hook = hook;
 }
 
-#ifndef CONFIG_POSIX_FS
-int _read(int fd, char *buf, int nbytes)
+int _impl__zephyr_read(char *buf, int nbytes)
 {
 	int i = 0;
 
@@ -90,9 +91,16 @@ int _read(int fd, char *buf, int nbytes)
 	}
 	return i;
 }
-FUNC_ALIAS(_read, read, int);
 
-int _write(int fd, char *buf, int nbytes)
+#ifdef CONFIG_USERSPACE
+Z_SYSCALL_HANDLER(_zephyr_read, buf, nbytes)
+{
+	Z_OOPS(Z_SYSCALL_MEMORY_WRITE(buf, nbytes));
+	return _impl__zephyr_read((char *)buf, nbytes);
+}
+#endif
+
+int _impl__zephyr_write(char *buf, int nbytes)
 {
 	int i;
 
@@ -103,6 +111,30 @@ int _write(int fd, char *buf, int nbytes)
 		_stdout_hook(*(buf + i));
 	}
 	return nbytes;
+}
+
+#ifdef CONFIG_USERSPACE
+Z_SYSCALL_HANDLER(_zephyr_write, buf, nbytes)
+{
+	Z_OOPS(Z_SYSCALL_MEMORY_READ(buf, nbytes));
+	return _impl__zephyr_write((char *)buf, nbytes);
+}
+#endif
+
+#ifndef CONFIG_POSIX_FS
+int _read(int fd, char *buf, int nbytes)
+{
+	ARG_UNUSED(fd);
+
+	return _zephyr_read(buf, nbytes);
+}
+FUNC_ALIAS(_read, read, int);
+
+int _write(int fd, char *buf, int nbytes)
+{
+	ARG_UNUSED(fd);
+
+	return _zephyr_write(buf, nbytes);
 }
 FUNC_ALIAS(_write, write, int);
 


### PR DESCRIPTION
In both minimal libc and newlib, certain C library I/O functions have been hooked up to the console drivers through a thin shim layer, involving registration of function pointers for reading/writing character data a byte at a time.

Unfortunately, calling into the console I/O drivers like this causes faults when running from user mode due to various private data to the kernel being accessed. With this change, these I/O calls now do a privilege elevation first.

This had already been done for printk(), but needed to be done here too.

Note that the newlib implementation is not fully tested due to discovering #6814 .

To date we do not have test cases to prove the correctness of the particular C library functions being elevated here, so they could not be lowered to user mode for purposes of this patch.

Fixes #6802.