### PR TITLE
arch: arm: include GCC -mcmse compile option for secure firmware

### DIFF
--- a/arch/arm/CMakeLists.txt
+++ b/arch/arm/CMakeLists.txt
@@ -19,5 +19,7 @@ zephyr_compile_options(
   ${ARCH_FLAG}
   )
 
+zephyr_compile_options_ifdef(CONFIG_ARM_SECURE_FIRMWARE -mcmse)
+
 add_subdirectory(soc)
 add_subdirectory(core)


### PR DESCRIPTION
Make GCC compile with the -mcmse compile option, if we are
building a Secure firmware. The option will make Security
Extensions for secure executables available, and will set
the corresponding compile-time indicator flag, accordingly:
(i.e. __ARM_FEATURE_CMSE=3).

Signed-off-by: Ioannis Glaropoulos <Ioannis.Glaropoulos@nordicsemi.no>