### PR TITLE
ethernet: fix an unaligned access fault by removing __packed.

### DIFF
--- a/include/net/ethernet.h
+++ b/include/net/ethernet.h
@@ -56,7 +56,7 @@ struct ethernet_api {
 
 	/** Get the device capabilities */
 	enum eth_hw_caps (*get_capabilities)(struct device *dev);
-} __packed;
+};
 
 struct net_eth_addr {
 	u8_t addr[6];


### PR DESCRIPTION
__packed allows the struct to be linked at a non-word size boundrary
which causes an unaligned access fault on the Cortex-M0+.

Signed-off-by: Michael Hope <mlhx@google.com>