### PR TITLE
runner: Black Magick probe runner

### DIFF
--- a/boards/common/blackmagick.board.cmake
+++ b/boards/common/blackmagick.board.cmake
@@ -1,0 +1,2 @@
+set_ifndef(BOARD_FLASH_RUNNER blackmagick)
+board_finalize_runner_args(blackmagick) # No default arguments to provide.

--- a/scripts/support/runner/__init__.py
+++ b/scripts/support/runner/__init__.py
@@ -21,5 +21,6 @@ from . import openocd
 from . import pyocd
 from . import qemu
 from . import xtensa
+from . import blackmagick
 
 __all__ = ['ZephyrBinaryRunner']

--- a/scripts/support/runner/blackmagick.py
+++ b/scripts/support/runner/blackmagick.py
@@ -1,0 +1,53 @@
+# Copyright (c) 2018 Roman Tataurov <diytronic@yandex.ru>
+#
+# SPDX-License-Identifier: Apache-2.0
+
+'''Runner for flashing with Black Magick Probe.'''
+
+# https://github.com/blacksphere/blackmagic/wiki
+
+import sys
+
+from .core import ZephyrBinaryRunner, RunnerCaps
+
+class BlackMagickRunner(ZephyrBinaryRunner):
+    '''Runner front-end for Black Magick probe.'''
+
+    def __init__(self, gdb, kernel_elf, gdb_serial, debug=False):
+        super(BlackMagickRunner, self).__init__(debug=debug)
+        self.gdb = gdb
+        self.kernel_elf = kernel_elf
+        self.gdb_serial = gdb_serial
+
+    @classmethod
+    def name(cls):
+        return 'blackmagick'
+
+    @classmethod
+    def capabilities(cls):
+        return RunnerCaps(commands={'flash'})
+
+    @classmethod
+    def do_add_parser(cls, parser):
+        parser.add_argument('--gdb-serial', default='/dev/ttyACM0',
+                            help='GDB port')
+
+    @classmethod
+    def create_from_args(cls, args):
+        return BlackMagickRunner(args.gdb,
+            args.kernel_elf, args.gdb_serial, debug=args.verbose)
+
+    def do_run(self, command, **kwargs):
+        command = [
+            self.gdb,
+            '-ex', "set confirm off",
+            '-ex', "target extended-remote {}".format(self.gdb_serial),
+            '-ex', "monitor swdp_scan",
+            '-ex', "attach 1",
+            '-ex', "load {}".format(self.kernel_elf),
+            '-ex', "kill",
+            '-ex', "quit",
+            '-silent'
+        ]
+
+        self.check_call(command)


### PR DESCRIPTION
Hello!

Let me introduce code to support Black Magick Probe - in-application debugging tool for embedded microprocessors. More details is here https://github.com/blacksphere/blackmagic/wiki 

I am using it with some of my projects so decided to add runner for it. Now realized only [flashing]( https://github.com/blacksphere/blackmagic/wiki/GDB-Automation), but its possible and planned to add [debugging](https://github.com/blacksphere/blackmagic/wiki/Useful-GDB-commands) feature as well.  

In case of nothing plugged in it looks like this

```
$  ninja flash
[1/70] Generating always_rebuild
Building for board stm32_blue_pill
[1/2] Flashing stm32_blue_pill
/dev/ttyACM0: Device or resource busy.
"monitor" command not supported by this target.
Don't know how to attach.  Try "help target".
You can't do that when your target is `None'
The program is not being run.
``` 

In case of success flashing 

```
$ ninja flash
[1/70] Generating always_rebuild
Building for board stm32_blue_pill
[1/2] Flashing stm32_blue_pill
Remote debugging using /dev/ttyACM0
Target voltage: unknown
Available Targets:
No. Att Driver
 1      STM32F1 medium density
Attaching to Remote target
0x4f480588 in ?? ()
Loading section text, size 0x30e6 lma 0x8000000
Loading section devconfig, size 0x90 lma 0x80030e8
Loading section rodata, size 0x5fc lma 0x8003178
Loading section datas, size 0x20 lma 0x8003774
Loading section initlevel, size 0x90 lma 0x8003794
Start address 0x8001c1c, load size 14370
Transfer rate: 11 KB/sec, 798 bytes/write.
```

Just kind of proofs it really work :) 