### PR TITLE
net: tcp: Cancel fin_timer in FIN_WAIT2 instead FIN_WAIT1

### DIFF
--- a/subsys/net/ip/tcp.c
+++ b/subsys/net/ip/tcp.c
@@ -2013,8 +2013,6 @@ NET_CONN_CB(tcp_established)
 
 		if (net_tcp_get_state(context->tcp)
 			   == NET_TCP_FIN_WAIT_1) {
-			/* Received FIN on FIN_WAIT1, so cancel the timer */
-			k_delayed_work_cancel(&context->tcp->fin_timer);
 			/* Active close: step to FIN_WAIT_2 */
 			net_tcp_change_state(context->tcp, NET_TCP_FIN_WAIT_2);
 		} else if (net_tcp_get_state(context->tcp)
@@ -2041,6 +2039,8 @@ NET_CONN_CB(tcp_established)
 					      ACK_TIMEOUT);
 		} else if (net_tcp_get_state(context->tcp)
 			   == NET_TCP_FIN_WAIT_2) {
+			/* Received FIN on FIN_WAIT_2, so cancel the timer */
+			k_delayed_work_cancel(&context->tcp->fin_timer);
 			/* Active close: step to TIME_WAIT */
 			net_tcp_change_state(context->tcp, NET_TCP_TIME_WAIT);
 		}


### PR DESCRIPTION
According to RFC 793 we should wait for FIN in FIN-WAIT-1 and
FIN-WAIT-2 states. Receiving ACK in FIN-WAIT-1 just moves us to
FIN-WAIT-2 state.

Right now TCP connection is never closed if FIN is not received
in FIN-WAIT-2 state. Fix that by keeping fin_timer active in
FIN-WAIT-2 state, but canceling it just after FIN is received.

Fixes: 124c06702726 ("net: tcp: Cancel the fin_timer on FIN message
  in FIN_WAIT1 state")
Signed-off-by: Marcin Niestroj <m.niestroj@grinn-global.com>