### PR TITLE
net: if: Bring back __net_if_align

### DIFF
--- a/include/net/net_if.h
+++ b/include/net/net_if.h
@@ -374,7 +374,7 @@ struct net_if {
 
 	/** Network interface instance configuration */
 	struct net_if_config config;
-};
+} __net_if_align;
 
 /**
  * @brief Send a packet through a net iface


### PR DESCRIPTION
The __net_if_align was removed in earlier commits but it needs
to come back as in some arch the alignment of net_if section
will be wrong.

Signed-off-by: Jukka Rissanen <jukka.rissanen@linux.intel.com>