### PR TITLE
drivers: i2c: SC18IS600 SPI to I2C bridge

### DIFF
--- a/drivers/i2c/CMakeLists.txt
+++ b/drivers/i2c/CMakeLists.txt
@@ -12,6 +12,7 @@ zephyr_sources_ifdef(CONFIG_I2C_SAM_TWI		i2c_sam_twi.c)
 zephyr_sources_ifdef(CONFIG_I2C_SAM_TWIHS	i2c_sam_twihs.c)
 zephyr_sources_ifdef(CONFIG_I2C_SBCON		i2c_sbcon.c)
 zephyr_sources_ifdef(CONFIG_I2C_NIOS2		i2c_nios2.c)
+zephyr_sources_ifdef(CONFIG_I2C_SC18IS600	i2c_sc18is600.c)
 
 zephyr_sources_ifdef(CONFIG_I2C_STM32_V1
 	i2c_ll_stm32_v1.c

--- a/drivers/i2c/Kconfig
+++ b/drivers/i2c/Kconfig
@@ -184,6 +184,13 @@ config I2C_CC32XX
 	help
 	  Enable the CC32XX I2C driver.
 
+config I2C_SC18IS600
+	bool "SC18IS600 I2C bridge driver"
+	depends on SPI
+	default n
+	help
+	  Enable support for SC18IS600 I2C bridge
+
 config I2C_BITBANG
 	bool
 	default n

--- a/drivers/i2c/i2c_sc18is600.c
+++ b/drivers/i2c/i2c_sc18is600.c
@@ -1,0 +1,315 @@
+/*
+ * Copyright (c) 2017-2018 Antmicro Ltd <www.antmicro.com>
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <device.h>
+#include <misc/printk.h>
+#include <i2c.h>
+#include <spi.h>
+
+#include "i2c_sc18is600.h"
+
+#define I2C_CS	0
+
+#define I2C_CLOCK_REG	2
+#define I2C_TO_REG	3
+#define I2C_STATUS_REG	4
+#define I2C_ADDR_REG 5
+
+#define I2C_STATUS_SUCCESS		0xF0
+#define I2C_STATUS_NO_ACK		0xF1
+#define I2C_STATUS_NACK			0xF2
+#define I2C_STATUS_BUSY			0xF3
+#define I2C_STATUS_TIMEOUT		0xF8
+#define I2C_STATUS_INVALID_COUNT	0xF9
+
+#define WRITE_N_BYTES_TO_DEVICE		0x00
+#define READ_N_BYTES_FROM_DEVICE	0x01
+#define READ_AFTER_WRITE_DEVICE		0x02
+
+#define READ_BRIDGE_RX_BUFFER		0x06
+#define WRITE_TO_BRIDGE_REGISTER	0x20
+#define READ_FROM_BRIDGE_REGISTER	0x21
+
+struct i2c_sc18is600_runtime {
+	struct device *spi_d;
+	struct spi_config spi_c;
+	u32_t i2c_config;
+};
+
+struct i2c_sc18is600_config {};
+
+static struct i2c_sc18is600_runtime i2c_sc18is600_0_runtime;
+static struct i2c_sc18is600_config i2c_sc18is600_0_config;
+
+
+int i2c_sc18is600_spi_send_buffer(struct device *dev, u8_t *data, size_t len)
+{
+	struct i2c_sc18is600_runtime *run_data =
+		(struct i2c_sc18is600_runtime *) dev->driver_data;
+
+	struct spi_buf tx_buf = {
+		.buf = data,
+		.len = len,
+	};
+
+	int err;
+
+	err = spi_write(&(run_data->spi_c), &tx_buf, 1);
+	if (err) {
+		printk("spi_write failed\n");
+	}
+	return err;
+}
+
+int i2c_sc18is600_spi_transceive_buffer(struct device *dev, u8_t *tx_data,
+		size_t tx_len, u8_t *rx_data, size_t rx_len)
+{
+	struct i2c_sc18is600_runtime *run_data =
+		(struct i2c_sc18is600_runtime *) dev->driver_data;
+
+	struct spi_buf tx_buf = {
+		.buf = tx_data,
+		.len = tx_len,
+	};
+
+	struct spi_buf rx_buf = {
+		.buf = rx_data,
+		.len = rx_len,
+	};
+
+	int err;
+
+	err = spi_transceive(&(run_data->spi_c), &tx_buf, 1, &rx_buf, 1);
+	if (err) {
+		printk("spi_transceive failed\n");
+	}
+
+	return err;
+}
+
+void i2c_sc18is600_spi_setup(struct device *i2c_dev)
+{
+	struct i2c_sc18is600_runtime *data =
+		(struct i2c_sc18is600_runtime *) i2c_dev->driver_data;
+	data->spi_c.dev = data->spi_d;
+	data->spi_c.frequency = 1000000UL;
+	/* 8-bit data, polarity (inactive state of SCK is logical 1),
+	 * and phase (shift on leading edge, sample on trailing edge)
+	 */
+	data->spi_c.operation = (8 << 5) | (3 << 1);
+	data->spi_c.slave = I2C_CS;
+	data->spi_c.cs = NULL;
+}
+
+u8_t i2c_sc18is600_read_from_bridge_register(struct device *dev, u8_t reg)
+{
+	size_t n = 8;
+	u8_t rx_buf[n];
+	u8_t tx_buf[n];
+
+	tx_buf[0] = READ_FROM_BRIDGE_REGISTER;
+	tx_buf[1] = reg;
+	for (int i = 2; i < n; i++)
+		tx_buf[i] = 0xFF;
+	i2c_sc18is600_spi_transceive_buffer(dev, tx_buf, n, rx_buf, n);
+	return rx_buf[2];
+}
+
+void i2c_sc18is600_write_to_bridge_register(struct device *dev, u8_t reg,
+		u8_t val)
+{
+	u8_t buf[3] = {WRITE_TO_BRIDGE_REGISTER, reg, val};
+
+	i2c_sc18is600_spi_send_buffer(dev, buf, 3);
+}
+
+static inline void i2c_sc18is600_wait_for_end(struct device *dev)
+{
+	while (i2c_sc18is600_read_from_bridge_register(dev, I2C_STATUS_REG)
+			!= I2C_STATUS_SUCCESS) {
+		printk(".");
+	}
+}
+
+void i2c_sc18is600_dump_bridge_registers(struct device *dev)
+{
+	int ret;
+
+	ret = i2c_sc18is600_read_from_bridge_register(dev, 0x00);
+	printk("reg 0x00 (IOCONFIG): 0x%02X\n", ret);
+
+	ret = i2c_sc18is600_read_from_bridge_register(dev, 0x01);
+	printk("reg 0x01 (IOSTATE):  0x%02X\n", ret);
+
+	ret = i2c_sc18is600_read_from_bridge_register(dev, 0x02);
+	printk("reg 0x02 (I2C CLK):  0x%02X\n", ret);
+
+	ret = i2c_sc18is600_read_from_bridge_register(dev, 0x03);
+	printk("reg 0x03 (I2C TO):   0x%02X\n", ret);
+
+	ret = i2c_sc18is600_read_from_bridge_register(dev, 0x04);
+	printk("reg 0x04 (I2C STAT): 0x%02X\n", ret);
+
+	ret = i2c_sc18is600_read_from_bridge_register(dev, 0x05);
+	printk("reg 0x05 (I2C ADDR): 0x%02X\n", ret);
+}
+void i2c_sc18is600_eeprom_wait(struct device *dev)
+{
+	while (i2c_sc18is600_read_from_bridge_register(dev, I2C_STATUS_REG)
+			!= I2C_STATUS_NO_ACK) {
+		printk(".");
+	}
+}
+
+void i2c_sc18is600_read_after_write_to_device(struct device *dev, u8_t count_w,
+		u8_t count_r, u8_t addr_w,
+		u8_t addr_r, u8_t *data_w)
+{
+	size_t bufsize = 5 + count_w;
+	u8_t buf[bufsize];
+	size_t index = 0;
+
+	buf[index++] = READ_AFTER_WRITE_DEVICE;
+	buf[index++] = count_w;
+	buf[index++] = count_r;
+	buf[index++] = addr_w;
+	for (int i = 0; i < count_w; i++)
+		buf[index++] = data_w[i];
+	buf[index++] = addr_r;
+	i2c_sc18is600_spi_send_buffer(dev, buf, bufsize);
+}
+
+void i2c_sc18is600_read_from_device(struct device *dev, u8_t addr,
+		u8_t count, u8_t *data)
+{
+	u8_t buf[3] = {READ_N_BYTES_FROM_DEVICE, count, addr};
+
+	i2c_sc18is600_spi_send_buffer(dev, buf, 3);
+}
+
+void i2c_sc18is600_read_from_bridge_rx_buffer(struct device *dev,
+		u8_t count, u8_t *data)
+{
+	size_t bufsize = 1 + count;
+	u8_t tx_buffer[bufsize];
+	u8_t rx_buffer[bufsize];
+	size_t index = 0;
+
+	tx_buffer[index++] = READ_BRIDGE_RX_BUFFER;
+
+	for (int i = 0; i < count; i++) {
+		tx_buffer[index++] = 0xFF; /* Send dummy bytes */
+	}
+	/* Set delay between two consecutive spi frames
+	 * to 7 clock cycles, SC18IS600 specific
+	 */
+	SPI1_REG(SPI_REG_DINTERXFR) = 0x07;
+	i2c_sc18is600_spi_transceive_buffer(dev, tx_buffer, bufsize,
+			rx_buffer, bufsize);
+	SPI1_REG(SPI_REG_DINTERXFR) = 0x00; /* Remove delay */
+
+	for (u8_t i = 0; i < count; i++) {
+		data[i] = rx_buffer[i + 1];
+	}
+}
+
+void i2c_sc18is600_write_to_device(struct device *dev, u8_t addr,
+		u8_t count, u8_t *data)
+{
+	size_t bufsize = 3 + count;
+	size_t index = 0;
+	u8_t tx_buffer[bufsize];
+
+	tx_buffer[index++] = WRITE_N_BYTES_TO_DEVICE;
+	tx_buffer[index++] = count;
+	tx_buffer[index++] = addr;
+	for (int i = 0; i < count; i++)
+		tx_buffer[index++] = data[i];
+	i2c_sc18is600_spi_send_buffer(dev, tx_buffer, bufsize);
+}
+
+/* INITIALIZATION */
+static int i2c_sc18is600_init(struct device *dev)
+{
+	struct i2c_sc18is600_runtime *data =
+		(struct i2c_sc18is600_runtime *) dev->driver_data;
+
+	data->spi_d = device_get_binding(CONFIG_SPI_0_NAME);
+	if (!data->spi_d)
+		printk("spi device binding inside i2c driver failed\n");
+	return 0;
+}
+
+/* POWER MANAGEMENT */
+
+void i2c_sc18is600_remove_pinmux(void)
+{
+	GPIO_REG(GPIO_IOF_EN) &= ~((1 << 2) | (1 << 3)
+			| (1 << 4) | (1 << 5)
+			| (1 << 9) | (1 << 10));
+	GPIO_REG(GPIO_INPUT_EN) &= ~((1 << 2) | (1 << 3)
+			| (1 << 4) | (1 << 5)
+			| (1 << 9) | (1 << 10));
+	GPIO_REG(GPIO_OUTPUT_EN) &= ~((1 << 2) | (1 << 3)
+			| (1 << 4) | (1 << 5)
+			| (1 << 9) | (1 << 10));
+}
+
+/* API */
+static int i2c_sc18is600_configure(struct device *dev, u32_t dev_config)
+{
+	struct i2c_sc18is600_runtime *data =
+		(struct i2c_sc18is600_runtime *) dev->driver_data;
+	i2c_sc18is600_spi_setup(dev);
+	data->i2c_config = dev_config;
+	i2c_sc18is600_write_to_bridge_register(dev, 0x02, 0x05);
+	return 0;
+};
+
+static int i2c_sc18is600_transfer(struct device *dev, struct i2c_msg *msgs,
+		u8_t num_msgs, u16_t addr)
+{
+	struct i2c_sc18is600_runtime *data =
+		(struct i2c_sc18is600_runtime *) dev->driver_data;
+	i2c_sc18is600_configure(dev, data->i2c_config);
+
+	if (num_msgs > 0) {
+		if (num_msgs == 2) {
+			/* i2c_burst_read */
+			if (msgs[0].flags == I2C_MSG_WRITE
+					&& msgs[1].flags == (I2C_MSG_RESTART
+						| I2C_MSG_READ
+						| I2C_MSG_STOP)) {
+				u8_t *transmit_data = msgs[0].buf;
+				u32_t count_transmit = msgs[0].len;
+				u32_t count_read = msgs[1].len;
+				u8_t *receive_data = msgs[1].buf;
+
+				i2c_sc18is600_read_after_write_to_device(dev,
+						count_transmit,
+						count_read, addr & 0xFF,
+						(addr & 0xFF) | 0x01,
+						transmit_data);
+				k_sleep(1);
+				i2c_sc18is600_read_from_bridge_rx_buffer(dev,
+						count_read, receive_data);
+			}
+		}
+	}
+
+	return 0;
+};
+
+static const struct i2c_driver_api sc18is600_i2c_api = {
+	.configure = i2c_sc18is600_configure,
+	.transfer = i2c_sc18is600_transfer,
+};
+
+DEVICE_DEFINE(i2c_0, CONFIG_I2C_0_NAME, i2c_sc18is600_init,
+		device_pm_control_nop, &i2c_sc18is600_0_runtime,
+		&i2c_sc18is600_0_config, APPLICATION,
+		CONFIG_I2C_INIT_PRIORITY, &sc18is600_i2c_api);
+

--- a/drivers/i2c/i2c_sc18is600.h
+++ b/drivers/i2c/i2c_sc18is600.h
@@ -1,0 +1,130 @@
+/*
+ * Copyright (c) 2017-2018 Antmicro Ltd <www.antmicro.com>
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef _SIFIVE_I2C_H
+#define _SIFIVE_I2C_H
+
+/* Register offsets */
+
+#define SPI_REG_SCKDIV          0x00
+#define SPI_REG_SCKMODE         0x04
+#define SPI_REG_CSID            0x10
+#define SPI_REG_CSDEF           0x14
+#define SPI_REG_CSMODE          0x18
+
+#define SPI_REG_DCSSCK          0x28
+#define SPI_REG_DSCKCS          0x2a
+#define SPI_REG_DINTERCS        0x2c
+#define SPI_REG_DINTERXFR       0x2e
+
+#define SPI_REG_FMT             0x40
+#define SPI_REG_TXFIFO          0x48
+#define SPI_REG_RXFIFO          0x4c
+#define SPI_REG_TXCTRL          0x50
+#define SPI_REG_RXCTRL          0x54
+
+#define SPI_REG_FCTRL           0x60
+#define SPI_REG_FFMT            0x64
+
+#define SPI_REG_IE              0x70
+#define SPI_REG_IP              0x74
+
+/* Fields */
+
+#define SPI_SCK_POL             0x1
+#define SPI_SCK_PHA             0x2
+
+#define SPI_FMT_PROTO(x)        ((x) & 0x3)
+#define SPI_FMT_ENDIAN(x)       (((x) & 0x1) << 2)
+#define SPI_FMT_DIR(x)          (((x) & 0x1) << 3)
+#define SPI_FMT_LEN(x)          (((x) & 0xf) << 16)
+
+/* TXCTRL register */
+#define SPI_TXWM(x)             ((x) & 0xffff)
+/* RXCTRL register */
+#define SPI_RXWM(x)             ((x) & 0xffff)
+
+#define SPI_IP_TXWM             0x1
+#define SPI_IP_RXWM             0x2
+
+#define SPI_FCTRL_EN            0x1
+
+#define SPI_INSN_CMD_EN         0x1
+#define SPI_INSN_ADDR_LEN(x)    (((x) & 0x7) << 1)
+#define SPI_INSN_PAD_CNT(x)     (((x) & 0xf) << 4)
+#define SPI_INSN_CMD_PROTO(x)   (((x) & 0x3) << 8)
+#define SPI_INSN_ADDR_PROTO(x)  (((x) & 0x3) << 10)
+#define SPI_INSN_DATA_PROTO(x)  (((x) & 0x3) << 12)
+#define SPI_INSN_CMD_CODE(x)    (((x) & 0xff) << 16)
+#define SPI_INSN_PAD_CODE(x)    (((x) & 0xff) << 24)
+
+#define SPI_TXFIFO_FULL  (1 << 31)
+#define SPI_RXFIFO_EMPTY (1 << 31)
+
+/* Values */
+
+#define SPI_CSMODE_AUTO         0
+#define SPI_CSMODE_HOLD         2
+#define SPI_CSMODE_OFF          3
+
+#define SPI_DIR_RX              0
+#define SPI_DIR_TX              1
+
+#define SPI_PROTO_S             0
+#define SPI_PROTO_D             1
+#define SPI_PROTO_Q             2
+
+#define SPI_ENDIAN_MSB          0
+#define SPI_ENDIAN_LSB          1
+
+#define SPI1_CSID_SS0		0
+#define SPI1_CSID_SS2		2
+#define SPI1_CSID_SS3		3
+
+/* IOF masks */
+#define SPI1_CTRL_ADDR		0x10024000
+#define IOF0_SPI1_MASK		0x000007FC
+#define GPIO_CTRL_ADDR		0x10012000
+#define SPI11_NUM_SS		(4)
+#define IOF_SPI1_SS0		(2u)
+#define IOF_SPI1_SS1		(8u)
+#define IOF_SPI1_SS2		(9u)
+#define IOF_SPI1_SS3		(10u)
+#define IOF_SPI1_MOSI		(3u)
+#define IOF_SPI1_MISO		(4u)
+#define IOF_SPI1_SCK		(5u)
+#define IOF_SPI1_DQ0		(3u)
+#define IOF_SPI1_DQ1		(4u)
+#define IOF_SPI1_DQ2		(6u)
+#define IOF_SPI1_DQ3		(7u)
+
+/* gpio defines */
+#define GPIO_INPUT_VAL		(0x00)
+#define GPIO_INPUT_EN		(0x04)
+#define GPIO_OUTPUT_EN		(0x08)
+#define GPIO_OUTPUT_VAL		(0x0C)
+#define GPIO_PULLUP_EN		(0x10)
+#define GPIO_DRIVE		(0x14)
+#define GPIO_RISE_IE		(0x18)
+#define GPIO_RISE_IP		(0x1C)
+#define GPIO_FALL_IE		(0x20)
+#define GPIO_FALL_IP		(0x24)
+#define GPIO_HIGH_IE		(0x28)
+#define GPIO_HIGH_IP		(0x2C)
+#define GPIO_LOW_IE		(0x30)
+#define GPIO_LOW_IP		(0x34)
+#define GPIO_IOF_EN		(0x38)
+#define GPIO_IOF_SEL		(0x3C)
+#define GPIO_OUTPUT_XOR		(0x40)
+
+
+#define INT_SPI1_BASE 6
+#define _REG32(p, i) (*(volatile uint32_t *) ((p) + (i)))
+#define _REG32P(p, i) ((volatile uint32_t *) ((p) + (i)))
+
+#define SPI1_REG(offset) _REG32(SPI1_CTRL_ADDR, offset)
+#define GPIO_REG(offset) _REG32(GPIO_CTRL_ADDR, offset)
+#endif /* _SIFIVE_SPI_H */


### PR DESCRIPTION
Adds driver for the SC18IS600 SPI to I2C bridge. The bridge is registered as an ordinary I2C bus.