### PR TITLE
arch: arm: Define & implement API for test target (Non-Secure)

### DIFF
--- a/arch/arm/core/CMakeLists.txt
+++ b/arch/arm/core/CMakeLists.txt
@@ -23,3 +23,4 @@ zephyr_library_sources_ifdef(CONFIG_USERSPACE userspace.S)
 
 add_subdirectory_ifdef(CONFIG_CPU_CORTEX_M cortex_m)
 add_subdirectory_ifdef(CONFIG_CPU_HAS_MPU  cortex_m/mpu)
+add_subdirectory_ifdef(CONFIG_CPU_CORTEX_M_HAS_CMSE cortex_m/cmse)

--- a/arch/arm/core/cortex_m/Kconfig
+++ b/arch/arm/core/cortex_m/Kconfig
@@ -49,7 +49,7 @@ config CPU_CORTEX_M23
 	bool
 	select CPU_CORTEX_M
 	# Omit prompt to signify "hidden" option
-	select ARMV6_M_ARMV8_M_BASELINE
+	select ARMV8_M_BASELINE
 	help
 	  This option signifies the use of a Cortex-M23 CPU
 
@@ -168,6 +168,7 @@ config CPU_CORTEX_M0_HAS_VECTOR_TABLE_REMAP
 
 config CPU_CORTEX_M_HAS_CMSE
 	bool
+	depends on ARMV8_M_BASELINE || ARMV8_M_MAINLINE
 	default n
 	help
 	  This option signifies the Cortex-M CPU has the CMSE intrinsics.
@@ -190,6 +191,19 @@ config ARMV6_M_ARMV8_M_BASELINE
 	  registers, and features, of a Mainline implementation.
 	  - ARMv6-M compatibility is provided by all ARMv8-M
 	  implementations.
+
+config ARMV8_M_BASELINE
+	bool
+	# Omit prompt to signify "hidden" option
+	default n
+	select ARMV6_M_ARMV8_M_BASELINE
+	select CPU_CORTEX_M_HAS_CMSE
+	help
+	  This option signifies the use of an ARMv8-M processor
+	  implementation.
+
+	  ARMv8-M Baseline includes additional features
+	  not present in the ARMv6-M architecture.
 
 config ARMV7_M_ARMV8_M_MAINLINE
 	bool
@@ -220,6 +234,7 @@ config ARMV8_M_MAINLINE
 	# Omit prompt to signify "hidden" option
 	select ARMV7_M_ARMV8_M_MAINLINE
 	select CPU_CORTEX_M_HAS_SPLIM
+	select CPU_CORTEX_M_HAS_CMSE
 	help
 	  This option signifies the use of an ARMv8-M processor
 	  implementation, supporting the Main Extension.

--- a/arch/arm/core/cortex_m/Kconfig
+++ b/arch/arm/core/cortex_m/Kconfig
@@ -166,6 +166,12 @@ config CPU_CORTEX_M0_HAS_VECTOR_TABLE_REMAP
 	  This option signifies the Cortex-M0 has some mechanisms that can map
 	  the vector table to SRAM
 
+config CPU_CORTEX_M_HAS_CMSE
+	bool
+	default n
+	help
+	  This option signifies the Cortex-M CPU has the CMSE intrinsics.
+
 config ARMV6_M_ARMV8_M_BASELINE
 	bool
 	# Omit prompt to signify "hidden" option

--- a/arch/arm/core/cortex_m/cmse/CMakeLists.txt
+++ b/arch/arm/core/cortex_m/cmse/CMakeLists.txt
@@ -1,0 +1,1 @@
+zephyr_sources(arm_core_cmse.c)

--- a/arch/arm/core/cortex_m/cmse/arm_core_cmse.c
+++ b/arch/arm/core/cortex_m/cmse/arm_core_cmse.c
@@ -1,0 +1,41 @@
+/*
+ * Copyright (c) 2018 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <zephyr.h>
+#include <cortex_m/cmse.h>
+
+int arm_cmse_mpu_region_get(u32_t addr, u8_t *p_region)
+{
+	cmse_address_info_t addr_info =	cmse_TT((void *)addr);
+
+	if (addr_info.flags.mpu_region_valid) {
+		*p_region = addr_info.flags.mpu_region;
+	}
+
+	return addr_info.flags.mpu_region_valid;
+}
+
+static int arm_cmse_addr_read_write_ok(u32_t addr, int force_npriv, int rw)
+{
+	cmse_address_info_t addr_info;
+	if (force_npriv) {
+		addr_info = cmse_TTT((void *)addr);
+	} else {
+		addr_info = cmse_TT((void *)addr);
+	}
+
+	return rw ? addr_info.flags.readwrite_ok : addr_info.flags.read_ok;
+}
+
+int arm_cmse_addr_read_ok(u32_t addr, int force_npriv)
+{
+	return arm_cmse_addr_read_write_ok(addr, force_npriv, 0);
+}
+
+int arm_cmse_addr_readwrite_ok(u32_t addr, int force_npriv)
+{
+	return arm_cmse_addr_read_write_ok(addr, force_npriv, 1);
+}

--- a/arch/arm/core/cortex_m/cmse/arm_core_cmse.c
+++ b/arch/arm/core/cortex_m/cmse/arm_core_cmse.c
@@ -39,3 +39,34 @@ int arm_cmse_addr_readwrite_ok(u32_t addr, int force_npriv)
 {
 	return arm_cmse_addr_read_write_ok(addr, force_npriv, 1);
 }
+
+static int arm_cmse_addr_range_read_write_ok(u32_t addr, u32_t size,
+	int force_npriv, int rw)
+{
+	int flags = 0;
+
+	if (force_npriv) {
+		flags |= CMSE_MPU_UNPRIV;
+	}
+	if (rw) {
+		flags |= CMSE_MPU_READWRITE;
+	} else {
+		flags |= CMSE_MPU_READ;
+	}
+	if (cmse_check_address_range((void *)addr, size, flags) != NULL) {
+		return 1;
+	} else {
+		return 0;
+	}
+}
+
+int arm_cmse_addr_range_read_ok(u32_t addr, u32_t size, int force_npriv)
+{
+	return arm_cmse_addr_range_read_write_ok(addr, size, force_npriv, 0);
+}
+
+int arm_cmse_addr_range_readwrite_ok(u32_t addr, u32_t size, int force_npriv)
+{
+	return arm_cmse_addr_range_read_write_ok(addr, size, force_npriv, 1);
+}
+

--- a/arch/arm/include/cortex_m/cmse.h
+++ b/arch/arm/include/cortex_m/cmse.h
@@ -1,0 +1,102 @@
+/*
+ * Copyright (c) 2018 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * @file
+ * @brief ARM Core CMSE API
+ *
+ * CMSE API for Cortex-M23/M33 CPUs.
+ */
+
+#ifndef _ARM_CORTEXM_CMSE__H_
+#define _ARM_CORTEXM_CMSE__H_
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#ifdef _ASMLANGUAGE
+
+/* nothing */
+
+#else
+
+#include <arm_cmse.h>
+#include <stdint.h>
+
+/*
+ * Address information retrieval based on the TT instructions.
+ *
+ * The TT instructions are used to check the access permissions that different
+ * security states and privilege levels have on memory at a specified address
+ */
+
+/**
+ * @brief Get the MPU region number of an address
+ *
+ * Get the MPU region that the address maps to. Return non-zero
+ * to indicate that a valid MPU region was retrieved, and store the
+ * MPU region information in the supplied location.
+ *
+ * Note:
+ * Obtained region is valid only if:
+ * - the function is called from privileged mode
+ * - the MPU is implemented and enabled
+ * - the given address matches a single, enabled MPU region
+ *
+ * @param addr The address for which the MPU region is requested
+ * @param p_region Output pointer to the location to store the MPU region
+ *
+ * @return non-zero if @ref region contains a valid MPU region, otherwise 0.
+  */
+int arm_cmse_mpu_region_get(u32_t addr, u8_t *p_region);
+
+/**
+ * @brief Read accessibility of an address
+ *
+ * Evaluates whether a specified memory location can be read according to the
+ * permissions of the current state MPU and the specified operation mode.
+ *
+ * This function shall always return zero:
+ * - if executed from an unprivileged mode,
+ * - if the address matches multiple MPU regions.
+ *
+ * @param addr The address for which the readability is requested
+ * @param force_npriv Instruct to return the readability of the address
+ *                    for unprivileged access, regardless of whether the current
+ *                    mode is privileged or unprivileged.
+ *
+ * @return 1 if address is readable, 0 otherwise.
+ */
+int arm_cmse_addr_read_ok(u32_t addr, int force_npriv);
+
+/**
+ * @brief Read and Write accessibility of an address
+ *
+ * Evaluates whether a specified memory location can be read/written according
+ * to the permissions of the current state MPU and the specified operation
+ * mode.
+ *
+ * This function shall always return zero:
+ * - if executed from an unprivileged mode,
+ * - if the address matches multiple MPU regions.
+ *
+ * @param addr The address for which the RW ability is requested
+ * @param force_npriv Instruct to return the RW ability of the address
+ *                    for unprivileged access, regardless of whether the current
+ *                    mode is privileged or unprivileged.
+ *
+ * @return 1 if address is Read and Writable, 0 otherwise.
+ */
+int arm_cmse_addr_readwrite_ok(u32_t addr, int force_npriv);
+
+#endif /* _ASMLANGUAGE */
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* _ARM_CORTEXM_CMSE__H_ */

--- a/arch/arm/include/cortex_m/cmse.h
+++ b/arch/arm/include/cortex_m/cmse.h
@@ -93,6 +93,50 @@ int arm_cmse_addr_read_ok(u32_t addr, int force_npriv);
  */
 int arm_cmse_addr_readwrite_ok(u32_t addr, int force_npriv);
 
+/**
+ * @brief Read accessibility of an address range
+ *
+ * Evaluates whether a memory address range, specified by its base address
+ * and size, can be read according to the permissions of the current state MPU
+ * and the specified operation mode.
+ *
+ * This function shall always return zero:
+ * - if executed from an unprivileged mode,
+ * - if the address range overlaps with multiple MPU (and/or SAU/IDAU) regions.
+ *
+ * @param addr The base address of an address range,
+ *             for which the readability is requested
+ * @param size The size of the address range
+ * @param force_npriv Instruct to return the readability of the address range
+ *                    for unprivileged access, regardless of whether the current
+ *                    mode is privileged or unprivileged.
+ *
+ * @return 1 if address range is readable, 0 otherwise.
+ */
+int arm_cmse_addr_range_read_ok(u32_t addr, u32_t size, int force_npriv);
+
+/**
+ * @brief Read and Write accessibility of an address range
+ *
+ * Evaluates whether a memory address range, specified by its base address
+ * and size, can be read/written according to the permissions of the current
+ * state MPU and the specified operation mode.
+ *
+ * This function shall always return zero:
+ * - if executed from an unprivileged mode,
+ * - if the address range overlaps with multiple MPU (and/or SAU/IDAU) regions.
+ *
+ * @param addr The base address of an address range,
+ *             for which the RW ability is requested
+ * @param size The size of the address range
+ * @param force_npriv Instruct to return the RW ability of the address range
+ *                    for unprivileged access, regardless of whether the current
+ *                    mode is privileged or unprivileged.
+ *
+ * @return 1 if address range is Read and Writable, 0 otherwise.
+ */
+int arm_cmse_addr_range_readwrite_ok(u32_t addr, u32_t size, int force_npriv);
+
 #endif /* _ASMLANGUAGE */
 
 #ifdef __cplusplus

--- a/arch/arm/include/cortex_m/cmse.h
+++ b/arch/arm/include/cortex_m/cmse.h
@@ -137,6 +137,83 @@ int arm_cmse_addr_range_read_ok(u32_t addr, u32_t size, int force_npriv);
  */
 int arm_cmse_addr_range_readwrite_ok(u32_t addr, u32_t size, int force_npriv);
 
+/* Required for C99 compilation */
+#ifndef typeof
+#define typeof  __typeof__
+#endif
+
+/**
+ * @brief Read accessibility of an object
+ *
+ * Evaluates whether a given object can be read according to the
+ * permissions of the current state MPU.
+ *
+ * The macro shall always evaluate to zero if called from an unprivileged mode.
+ *
+ * @param p_obj Pointer to the given object
+ *              for which the readability is requested
+ *
+ * @pre Object is allocated in a single MPU (and/or SAU/IDAU) region.
+ *
+ * @return p_obj if object is readable, NULL otherwise.
+ */
+#define ARM_CMSE_OBJECT_READ_OK(p_obj) \
+	cmse_check_pointed_object(p_obj, CMSE_MPU_READ)
+
+/**
+ * @brief Read accessibility of an object (nPRIV mode)
+ *
+ * Evaluates whether a given object can be read according to the
+ * permissions of the current state MPU (unprivileged read).
+ *
+ * The macro shall always evaluate to zero if called from an unprivileged mode.
+ *
+ * @param p_obj Pointer to the given object
+ *              for which the readability is requested
+ *
+ * @pre Object is allocated in a single MPU (and/or SAU/IDAU) region.
+ *
+ * @return p_obj if object is readable, NULL otherwise.
+ */
+#define ARM_CMSE_OBJECT_UNPRIV_READ_OK(p_obj) \
+	cmse_check_pointed_object(p_obj, CMSE_MPU_UNPRIV | CMSE_MPU_READ)
+
+/**
+ * @brief Read and Write accessibility of an object
+ *
+ * Evaluates whether a given object can be read and written
+ * according to the permissions of the current state MPU.
+ *
+ * The macro shall always evaluate to zero if called from an unprivileged mode.
+ *
+ * @param p_obj Pointer to the given object
+ *              for which the read and write ability is requested
+ *
+ * @pre Object is allocated in a single MPU (and/or SAU/IDAU) region.
+ *
+ * @return p_obj if object is Read and Writable, NULL otherwise.
+ */
+#define ARM_CMSE_OBJECT_READWRITE_OK(p_obj) \
+	cmse_check_pointed_object(p_obj, CMSE_MPU_READWRITE)
+
+/**
+ * @brief Read and Write accessibility of an object (nPRIV mode)
+ *
+ * Evaluates whether a given object can be read and written according
+ * to the permissions of the current state MPU (unprivileged read/write).
+ *
+ * The macro shall always evaluate to zero if called from an unprivileged mode.
+ *
+ * @param p_obj Pointer to the given object
+ *              for which the read and write ability is requested
+ *
+ * @pre Object is allocated in a single MPU (and/or SAU/IDAU) region.
+ *
+ * @return p_obj if object is Read and Writable, NULL otherwise.
+ */
+#define ARM_CMSE_OBJECT_UNPRIV_READWRITE_OK(p_obj) \
+	cmse_check_pointed_object(p_obj, CMSE_MPU_UNPRIV | CMSE_MPU_READWRITE)
+
 #endif /* _ASMLANGUAGE */
 
 #ifdef __cplusplus


### PR DESCRIPTION
This commit defines and implements an internal ARMv8-M API
that allows the user to evaluate access permissions of memory
locations, based on the ARMv8-M Test Target (TT) instruction
support.

Signed-off-by: Ioannis Glaropoulos <Ioannis.Glaropoulos@nordicsemi.no>