### PR TITLE
kconfig: Remove no-op selects of choice symbols

### DIFF
--- a/arch/x86/soc/intel_quark/quark_x1000/Kconfig.defconfig.series
+++ b/arch/x86/soc/intel_quark/quark_x1000/Kconfig.defconfig.series
@@ -119,7 +119,6 @@ if GPIO_DW
 
 config GPIO_DW_0
 	def_bool y
-	select GPIO_DW_0_IRQ_SHARED if SHARED_IRQ
 
 if GPIO_DW_0
 

--- a/drivers/crypto/Kconfig
+++ b/drivers/crypto/Kconfig
@@ -72,7 +72,6 @@ config CRYPTO_MBEDTLS_SHIM
 	bool "Enable mbedTLS shim driver [EXPERIMENTAL] "
 	default n
 	select MBEDTLS
-	select MBEDTLS_BUILTIN
 	select MBEDTLS_ENABLE_HEAP
 	help
 	  Enable mbedTLS shim layer compliant with crypto APIs. You will need

--- a/drivers/entropy/Kconfig.mcux
+++ b/drivers/entropy/Kconfig.mcux
@@ -9,7 +9,6 @@ menuconfig ENTROPY_MCUX_RNGA
 	depends on ENTROPY_GENERATOR && HAS_MCUX_RNGA
 	default n
 	select ENTROPY_HAS_DRIVER
-	select ENTROPY_DEVICE_RANDOM_GENERATOR
 	help
 	  This option enables the random number generator accelerator (RNGA)
 	  driver based on the MCUX RNGA driver.
@@ -19,7 +18,6 @@ menuconfig ENTROPY_MCUX_TRNG
 	depends on ENTROPY_GENERATOR && HAS_MCUX_TRNG
 	default n
 	select ENTROPY_HAS_DRIVER
-	select ENTROPY_DEVICE_RANDOM_GENERATOR
 	help
 	  This option enables the true random number generator (TRNG)
 	  driver based on the MCUX TRNG driver.

--- a/drivers/entropy/Kconfig.native_posix
+++ b/drivers/entropy/Kconfig.native_posix
@@ -4,7 +4,6 @@ menuconfig ENTROPY_NATIVE_POSIX
 	depends on ENTROPY_GENERATOR && ARCH_POSIX
 	default n
 	select ENTROPY_HAS_DRIVER
-	select ENTROPY_DEVICE_RANDOM_GENERATOR
 	help
 	  This option enables the random number generator for the
 	  native_posix board (ARCH_POSIX). This is based on the host random() API.

--- a/ext/lib/mgmt/mcumgr/cmd/img_mgmt/Kconfig
+++ b/ext/lib/mgmt/mcumgr/cmd/img_mgmt/Kconfig
@@ -21,7 +21,6 @@ menuconfig MCUMGR_CMD_IMG_MGMT
     select FLASH
     select MPU_ALLOW_FLASH_WRITE if CPU_HAS_MPU
     select IMG_MANAGER
-    select MCUBOOT_IMG_MANAGER
 
     default n
     help

--- a/subsys/bluetooth/controller/Kconfig
+++ b/subsys/bluetooth/controller/Kconfig
@@ -26,7 +26,6 @@ config BT_LL_SW
 	select ENTROPY_GENERATOR
 	select ENTROPY_NRF5_RNG if SOC_FAMILY_NRF
 	select ENTROPY_NRF5_BIAS_CORRECTION if SOC_FAMILY_NRF
-	select ENTROPY_DEVICE_RANDOM_GENERATOR
 	help
 	  Use Zephyr software BLE Link Layer implementation.
 


### PR DESCRIPTION
Selecting a choice symbol is always a no-op, and the latest version of
Kconfiglib prints a warning. This commit removes all selects of choice
symbols, which might make the Kconfig files a bit clearer and gets rid
of the warnings.

This is just a dumb removal. I did not try to guess the intent of each
select.

Fixes #6849

Signed-off-by: Ulf Magnusson <ulfalizer@gmail.com>