### PR TITLE
filter-doc-log.sh: Fix error for empty log file

### DIFF
--- a/doc/scripts/filter-doc-log.sh
+++ b/doc/scripts/filter-doc-log.sh
@@ -28,7 +28,7 @@ else
     green='\e[32m'
 fi
 
-if [ -s "${LOG_FILE}" ]; then
+if [ -e "${LOG_FILE}" ]; then
    $KI_SCRIPT --config-dir ${CONFIG_DIR} ${LOG_FILE} > doc.warnings 2>&1
    if [ -s doc.warnings ]; then
 	   echo


### PR DESCRIPTION
Running 'make html' in doc/ when doc.log is missing or empty gives the
following error if sphinx-build doesn't write anything on stdout/stderr:

    Error in ./scripts/filter-doc-log.sh: logfile "doc.log" not found.
    Makefile:84: recipe for target ”html” failed
    make: *** [html] Error 1

The problem is that scripts/filter-doc-log.sh tests for the existence of
the log file with [ -s ${LOG_FILE} ], which requires it to be nonempty.

Fix it by using -e instead, which only checks if the log file exists.
scripts/filter-known-issues.py ($KI_SCRIPT) seems to be able to deal
with empty files (and runs quickly).

Fixes #6854

Signed-off-by: Ulf Magnusson <ulfalizer@gmail.com>