### PR TITLE
net: tcp: Fix crash from SYN flood

### DIFF
--- a/subsys/net/ip/net_pkt.c
+++ b/subsys/net/ip/net_pkt.c
@@ -1957,6 +1957,11 @@ struct net_tcp_hdr *net_pkt_tcp_data(struct net_pkt *pkt)
 		return NULL;
 	}
 
+	if (!frag->data) {
+		NET_ERR("NULL fragment data!");
+		return NULL;
+	}
+
 	return (struct net_tcp_hdr *)(frag->data + offset);
 }
 

--- a/subsys/net/ip/tcp.c
+++ b/subsys/net/ip/tcp.c
@@ -1211,6 +1211,11 @@ struct net_tcp_hdr *net_tcp_get_hdr(struct net_pkt *pkt,
 	u16_t pos;
 
 	tcp_hdr = net_pkt_tcp_data(pkt);
+	if (!tcp_hdr) {
+		NET_ERR("NULL TCP header!");
+		return NULL;
+	}
+
 	if (net_tcp_header_fits(pkt, tcp_hdr)) {
 		return tcp_hdr;
 	}


### PR DESCRIPTION
SYN flood causes crash in RX thread due to NULL pointer access. After
the crash available RX memory is zero, hence echo server does not
respond to echo request.

Signed-off-by: Ruslan Mstoi <ruslan.mstoi@intel.com>