### PR TITLE
tests/kernel/gen_isr_table: fix mispelled 'kerne'

### DIFF
--- a/tests/kernel/gen_isr_table/testcase.yaml
+++ b/tests/kernel/gen_isr_table/testcase.yaml
@@ -1,4 +1,4 @@
 tests:
-  kerne.interrupt:
+  kernel.interrupt:
     filter: CONFIG_GEN_ISR_TABLES and CONFIG_ARMV7_M_ARMV8_M_MAINLINE
     tags: core


### PR DESCRIPTION
Signed-off-by: Inaky Perez-Gonzalez <inaky.perez-gonzalez@intel.com>