### PR TITLE
kconfig: Do not source "arch/posix/core/Kconfig"

### DIFF
--- a/arch/posix/Kconfig
+++ b/arch/posix/Kconfig
@@ -23,8 +23,6 @@ config ARCH_DEFCONFIG
 	string
 	default "arch/posix/defconfig"
 
-source "arch/posix/core/Kconfig"
-
 config ARCH_POSIX_RECOMMENDED_STACK_SIZE
 	int
 	depends on ARCH_POSIX


### PR DESCRIPTION
This file never existed.

'source' currently ignores missing files instead of throwing an error,
due to Zephyr's custom globbing logic.

Signed-off-by: Ulf Magnusson <ulfalizer@gmail.com>