### PR TITLE
scripts: Fix misspelled CMake project name

### DIFF
--- a/scripts/CMakeLists.txt
+++ b/scripts/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 3.6)
-Project(Zehpyr-Host-Tools)
+Project(Zephyr-Host-Tools)
 
 # fixdep is added because all files depend on autoconf.h,
 # which would imply that changing the configuration triggers a complete rebuild.


### PR DESCRIPTION
s/Zehpyr/Zephyr/

Signed-off-by: Ulf Magnusson <ulfalizer@gmail.com>