### PR TITLE
doc: Show a command to enable IPv4 forwarding

### DIFF
--- a/doc/subsystems/networking/qemu_setup.rst
+++ b/doc/subsystems/networking/qemu_setup.rst
@@ -153,6 +153,11 @@ used, the following command should be run as root:
 
 Additionally, IPv4 forwarding should be enabled on host, and you may need to
 check that other firewall (iptables) rules don't interfere with masquerading.
+To enable IPv4 forwarding the following command should be run as root:
+
+.. code-block:: console
+
+   sysctl -w net.ipv4.ip_forward=1
 
 Network connection between two QEMU VMs
 ***************************************


### PR DESCRIPTION
Using QEMU host on a Zephyr application using IPv4 to access Internet
requires IPv4 forwarding, so show a command to enable IPv4 forwarding.

Signed-off-by: Stig Bjørlykke <stig.bjorlykke@nordicsemi.no>