### PR TITLE
tests: ztest: test_main takes no arguments

### DIFF
--- a/tests/subsys/dfu/img_util/src/main.c
+++ b/tests/subsys/dfu/img_util/src/main.c
@@ -46,8 +46,9 @@ void test_collecting(void)
 	}
 }
 
-void test_main(void *p1, void *p2, void *p3)
+void test_main(void)
 {
-	ztest_test_suite(test_util, ztest_unit_test(test_collecting));
+	ztest_test_suite(test_util,
+			ztest_unit_test(test_collecting));
 	ztest_run_test_suite(test_util);
 }

--- a/tests/subsys/dfu/mcuboot/src/main.c
+++ b/tests/subsys/dfu/mcuboot/src/main.c
@@ -138,7 +138,7 @@ void test_write_confirm(void)
 	zassert_equal(1, readout[0] & 0xff, "confirmation error");
 }
 
-void test_main(void *p1, void *p2, void *p3)
+void test_main(void)
 {
 	ztest_test_suite(test_mcuboot_interface,
 			 ztest_unit_test(test_bank_erase),

--- a/tests/subsys/fs/fcb/src/main.c
+++ b/tests/subsys/fs/fcb/src/main.c
@@ -143,7 +143,7 @@ void fcb_test_rotate(void);
 void fcb_test_multi_scratch(void);
 void fcb_test_last_of_n(void);
 
-void test_main(void *p1, void *p2, void *p3)
+void test_main(void)
 {
 	ztest_test_suite(test_fcb,
 			 ztest_unit_test_setup_teardown(fcb_test_len,

--- a/tests/subsys/settings/fcb/src/settings_test_fcb.c
+++ b/tests/subsys/settings/fcb/src/settings_test_fcb.c
@@ -325,7 +325,7 @@ void test_config_save_3_fcb(void);
 void test_config_compress_reset(void);
 void test_config_save_one_fcb(void);
 
-void test_main(void *p1, void *p2, void *p3)
+void test_main(void)
 {
 	ztest_test_suite(test_config_fcb,
 			 /* Config tests */

--- a/tests/subsys/settings/nffs/src/settings_test_nffs.c
+++ b/tests/subsys/settings/nffs/src/settings_test_nffs.c
@@ -208,7 +208,7 @@ void test_config_save_in_file(void);
 void test_config_save_one_file(void);
 void test_config_compress_file(void);
 
-void test_main(void *p1, void *p2, void *p3)
+void test_main(void)
 {
 	ztest_test_suite(test_config_fcb,
 			 /* Config tests */

--- a/tests/subsys/storage/flash_map/src/main.c
+++ b/tests/subsys/storage/flash_map/src/main.c
@@ -96,7 +96,7 @@ void flash_map_test_case_2(void)
 
 }
 
-void test_main(void *p1, void *p2, void *p3)
+void test_main(void)
 {
 	ztest_test_suite(test_flash_map,
 			 ztest_unit_test(flash_map_test_case_2));


### PR DESCRIPTION
Some tests were using test_main with arguments causing conflicts during build.

Signed-off-by: Anas Nashif <anas.nashif@intel.com>