### PR TITLE
boards/arm/olimexino_stm32: Don't enable I2C and SPI

### DIFF
--- a/boards/arm/olimexino_stm32/olimexino_stm32_defconfig
+++ b/boards/arm/olimexino_stm32/olimexino_stm32_defconfig
@@ -13,12 +13,6 @@ CONFIG_SERIAL=y
 CONFIG_CONSOLE=y
 CONFIG_UART_CONSOLE=y
 
-# enable I2C driver
-CONFIG_I2C=y
-
-# enable SPI
-CONFIG_SPI=y
-
 # enable pinmux
 CONFIG_PINMUX=y
 


### PR DESCRIPTION
The test "net/utils" fails to build on olimexino_stm32
due to "region `SRAM' overflowed by 192 bytes".

Disabling I2C and SPI on board level the test build fine.

Moreover, according to issue #6858, we will only configure
board valuable HW and connectors on board level and the
user should enable what is needed on application level.

Signed-off-by: Yannis Damigos <giannis.damigos@gmail.com>