### PR TITLE
arch: arm: soc: stm32l0: fix port H EXTI

### DIFF
--- a/arch/arm/soc/st_stm32/stm32l0/soc.h
+++ b/arch/arm/soc/st_stm32/stm32l0/soc.h
@@ -31,6 +31,8 @@
 
 #include "soc_irq.h"
 
+#include <stm32l0xx_ll_system.h>
+
 #ifdef CONFIG_SERIAL_HAS_DRIVER
 #include <stm32l0xx_ll_usart.h>
 #endif
@@ -39,7 +41,6 @@
 #include <stm32l0xx_ll_utils.h>
 #include <stm32l0xx_ll_bus.h>
 #include <stm32l0xx_ll_rcc.h>
-#include <stm32l0xx_ll_system.h>
 #endif /* CONFIG_CLOCK_CONTROL_STM32_CUBE */
 
 #ifdef CONFIG_I2C_STM32_V2

--- a/arch/arm/soc/st_stm32/stm32l0/soc_gpio.c
+++ b/arch/arm/soc/st_stm32/stm32l0/soc_gpio.c
@@ -135,6 +135,15 @@ int stm32_gpio_enable_int(int port, int pin)
 		return -EINVAL;
 	}
 
+	/*
+	 * Ports F and G are not present on some STM32L0 parts, so
+	 * for these parts port H external interrupt should be enabled
+	 * by writing value 0x5 instead of 0x7.
+	 */
+	if (port == STM32_PORTH) {
+		port = LL_SYSCFG_EXTI_PORTH;
+	}
+
 	shift = 4 * (pin % 4);
 
 	exticr->val &= ~(0xf << shift);


### PR DESCRIPTION
In STM32L0 series port H external interrupt should be enabled by writing value 0x5 instead of 0x7 to SYSCFG_EXTICRn registers (see e.g. RM0367, 10.2.4).

Signed-off-by: Ilya Tagunov <tagunil@gmail.com>