### PR TITLE
arm_mpu: fix _get_region_attr()

### DIFF
--- a/arch/arm/core/cortex_m/mpu/arm_mpu.c
+++ b/arch/arm/core/cortex_m/mpu/arm_mpu.c
@@ -29,7 +29,7 @@ static inline u32_t _get_region_attr(u32_t xn, u32_t ap, u32_t tex,
 				     u32_t srd, u32_t size)
 {
 	return ((xn << 28) | (ap) | (tex << 19) | (s << 18)
-		| (c << 17) | (b << 16) | (srd << 5) | (size));
+		| (c << 17) | (b << 16) | (srd << 8) | (size));
 }
 
 /**


### PR DESCRIPTION
srd bits start at bit 8, not bit 5.
To date we are not using sub-regions so this problem was
undetected.

Signed-off-by: Andrew Boie <andrew.p.boie@intel.com>