### PR TITLE
Bluetooth: Mesh: Fix possible NULL dereferences in client models

### DIFF
--- a/subsys/bluetooth/host/mesh/cfg_cli.c
+++ b/subsys/bluetooth/host/mesh/cfg_cli.c
@@ -168,7 +168,9 @@ static void net_key_status(struct bt_mesh_model *model,
 		return;
 	}
 
-	*param->status = status;
+	if (param->status) {
+		*param->status = status;
+	}
 
 	k_sem_give(&cli->op_sync);
 }
@@ -205,7 +207,9 @@ static void app_key_status(struct bt_mesh_model *model,
 		return;
 	}
 
-	*param->status = status;
+	if (param->status) {
+		*param->status = status;
+	}
 
 	k_sem_give(&cli->op_sync);
 }
@@ -255,7 +259,9 @@ static void mod_app_status(struct bt_mesh_model *model,
 		return;
 	}
 
-	*param->status = status;
+	if (param->status) {
+		*param->status = status;
+	}
 
 	k_sem_give(&cli->op_sync);
 }

--- a/subsys/bluetooth/host/mesh/health_cli.c
+++ b/subsys/bluetooth/host/mesh/health_cli.c
@@ -154,7 +154,9 @@ static void health_attention_status(struct bt_mesh_model *model,
 
 	param = health_cli->op_param;
 
-	*param->attention = net_buf_simple_pull_u8(buf);
+	if (param->attention) {
+		*param->attention = net_buf_simple_pull_u8(buf);
+	}
 
 	k_sem_give(&health_cli->op_sync);
 }


### PR DESCRIPTION
There's a small but real chance of a race-condition when sending
messages to the local node (through the local network interface) that
expected parameters will be NULL in the message handles. Add
appropriate NULL checks for them.

Signed-off-by: Johan Hedberg <johan.hedberg@intel.com>