### PR TITLE
tests: net: tc: Run the tests only for qemu_x86

### DIFF
--- a/tests/net/traffic_class/testcase.yaml
+++ b/tests/net/traffic_class/testcase.yaml
@@ -1,178 +1,123 @@
+common:
+    platform_whitelist: native_posix
+    tags: net traffic_class
 tests:
   test_tc_1:
-    min_ram: 80
-    tags: net traffic_class
     extra_configs:
       - CONFIG_NET_TC_TX_COUNT=1
       - CONFIG_NET_TC_RX_COUNT=1
   test_tc_2:
-    min_ram: 80
-    tags: net traffic_class
     extra_configs:
       - CONFIG_NET_TC_TX_COUNT=2
       - CONFIG_NET_TC_RX_COUNT=2
   test_tc_3:
-    min_ram: 80
-    tags: net traffic_class
     extra_configs:
       - CONFIG_NET_TC_TX_COUNT=3
       - CONFIG_NET_TC_RX_COUNT=3
   test_tc_4:
-    min_ram: 80
-    tags: net traffic_class
     extra_configs:
       - CONFIG_NET_TC_TX_COUNT=4
       - CONFIG_NET_TC_RX_COUNT=4
   test_tc_5:
-    min_ram: 80
-    tags: net traffic_class
     extra_configs:
       - CONFIG_NET_TC_TX_COUNT=5
       - CONFIG_NET_TC_RX_COUNT=5
   test_tc_6:
-    min_ram: 80
-    tags: net traffic_class
     extra_configs:
       - CONFIG_NET_TC_TX_COUNT=6
       - CONFIG_NET_TC_RX_COUNT=6
   test_tc_7:
-    min_ram: 80
-    tags: net traffic_class
     extra_configs:
       - CONFIG_NET_TC_TX_COUNT=7
       - CONFIG_NET_TC_RX_COUNT=7
   test_tc_8:
-    min_ram: 80
-    tags: net traffic_class
     extra_configs:
       - CONFIG_NET_TC_TX_COUNT=8
       - CONFIG_NET_TC_RX_COUNT=8
 # TX multi queue, RX one queue
   test_tc_2_no_rx:
-    min_ram: 80
-    tags: net traffic_class
     extra_configs:
       - CONFIG_NET_TC_TX_COUNT=2
       - CONFIG_NET_TC_RX_COUNT=1
   test_tc_3_no_rx:
-    min_ram: 80
-    tags: net traffic_class
     extra_configs:
       - CONFIG_NET_TC_TX_COUNT=3
       - CONFIG_NET_TC_RX_COUNT=1
   test_tc_4_no_rx:
-    min_ram: 80
-    tags: net traffic_class
     extra_configs:
       - CONFIG_NET_TC_TX_COUNT=4
       - CONFIG_NET_TC_RX_COUNT=1
   test_tc_5_no_rx:
-    min_ram: 80
-    tags: net traffic_class
     extra_configs:
       - CONFIG_NET_TC_TX_COUNT=5
       - CONFIG_NET_TC_RX_COUNT=1
   test_tc_6_no_rx:
-    min_ram: 80
-    tags: net traffic_class
     extra_configs:
       - CONFIG_NET_TC_TX_COUNT=6
       - CONFIG_NET_TC_RX_COUNT=1
   test_tc_7_no_rx:
-    min_ram: 80
-    tags: net traffic_class
     extra_configs:
       - CONFIG_NET_TC_TX_COUNT=7
       - CONFIG_NET_TC_RX_COUNT=1
   test_tc_8_no_rx:
-    min_ram: 80
-    tags: net traffic_class
     extra_configs:
       - CONFIG_NET_TC_TX_COUNT=8
       - CONFIG_NET_TC_RX_COUNT=1
 # TX one queue, RX multi queue
   test_tc_2_no_tx:
-    min_ram: 80
-    tags: net traffic_class
     extra_configs:
       - CONFIG_NET_TC_RX_COUNT=2
       - CONFIG_NET_TC_TX_COUNT=1
   test_tc_3_no_tx:
-    min_ram: 80
-    tags: net traffic_class
     extra_configs:
       - CONFIG_NET_TC_RX_COUNT=3
       - CONFIG_NET_TC_TX_COUNT=1
   test_tc_4_no_tx:
-    min_ram: 80
-    tags: net traffic_class
     extra_configs:
       - CONFIG_NET_TC_RX_COUNT=4
       - CONFIG_NET_TC_TX_COUNT=1
   test_tc_5_no_tx:
-    min_ram: 80
-    tags: net traffic_class
     extra_configs:
       - CONFIG_NET_TC_RX_COUNT=5
       - CONFIG_NET_TC_TX_COUNT=1
   test_tc_6_no_tx:
-    min_ram: 80
-    tags: net traffic_class
     extra_configs:
       - CONFIG_NET_TC_RX_COUNT=6
       - CONFIG_NET_TC_TX_COUNT=1
   test_tc_7_no_tx:
-    min_ram: 80
-    tags: net traffic_class
     extra_configs:
       - CONFIG_NET_TC_RX_COUNT=7
       - CONFIG_NET_TC_TX_COUNT=1
   test_tc_8_no_tx:
-    min_ram: 80
-    tags: net traffic_class
     extra_configs:
       - CONFIG_NET_TC_RX_COUNT=8
       - CONFIG_NET_TC_TX_COUNT=1
 # Then test some hybrid combinations.
   test_tc_tx_2_rx_3:
-    min_ram: 80
-    tags: net traffic_class
     extra_configs:
       - CONFIG_NET_TC_RX_COUNT=3
       - CONFIG_NET_TC_TX_COUNT=2
   test_tc_tx_3_rx_8:
-    min_ram: 80
-    tags: net traffic_class
     extra_configs:
       - CONFIG_NET_TC_RX_COUNT=8
       - CONFIG_NET_TC_TX_COUNT=3
   test_tc_rx_4_tx_8:
-    min_ram: 80
-    tags: net traffic_class
     extra_configs:
       - CONFIG_NET_TC_RX_COUNT=4
       - CONFIG_NET_TC_TX_COUNT=8
   test_tc_rx_5_tx_7:
-    min_ram: 80
-    tags: net traffic_class
     extra_configs:
       - CONFIG_NET_TC_RX_COUNT=5
       - CONFIG_NET_TC_TX_COUNT=7
   test_tc_tx_6_rx_2:
-    min_ram: 80
-    tags: net traffic_class
     extra_configs:
       - CONFIG_NET_TC_RX_COUNT=2
       - CONFIG_NET_TC_TX_COUNT=6
   test_tc_tx_7_rx_5:
-    min_ram: 80
-    tags: net traffic_class
     extra_configs:
       - CONFIG_NET_TC_RX_COUNT=5
       - CONFIG_NET_TC_TX_COUNT=7
   test_tc_tx_8_rx_7:
-    min_ram: 80
-    tags: net traffic_class
     extra_configs:
       - CONFIG_NET_TC_RX_COUNT=7
       - CONFIG_NET_TC_TX_COUNT=8


### PR DESCRIPTION
Speedup the CI by only running the tests in qemu_x86 instead of
almost all boards.

Signed-off-by: Jukka Rissanen <jukka.rissanen@linux.intel.com>