### PR TITLE
net: tc: Fix array checks

### DIFF
--- a/subsys/net/ip/net_tc.c
+++ b/subsys/net/ip/net_tc.c
@@ -90,7 +90,7 @@ int net_tx_priority2tc(enum net_priority prio)
 #endif
 	};
 
-	if (prio >= sizeof(tc)) {
+	if (prio >= ARRAY_SIZE(tc)) {
 		/* Use default value suggested in 802.1Q */
 		prio = NET_PRIORITY_BE;
 	}
@@ -144,7 +144,7 @@ int net_rx_priority2tc(enum net_priority prio)
 #endif
 	};
 
-	if (prio >= sizeof(tc)) {
+	if (prio >= ARRAY_SIZE(tc)) {
 		/* Use default value suggested in 802.1Q */
 		prio = NET_PRIORITY_BE;
 	}
@@ -200,7 +200,7 @@ static int tx_tc2thread(int tc)
 	BUILD_ASSERT_MSG(NET_TC_TX_COUNT <= CONFIG_NUM_COOP_PRIORITIES,
 			 "Too many traffic classes");
 
-	NET_ASSERT(tc < sizeof(thread_priorities));
+	NET_ASSERT(tc < ARRAY_SIZE(thread_priorities));
 
 	return thread_priorities[tc];
 }
@@ -253,7 +253,7 @@ static int rx_tc2thread(int tc)
 	BUILD_ASSERT_MSG(NET_TC_RX_COUNT <= CONFIG_NUM_COOP_PRIORITIES,
 			 "Too many traffic classes");
 
-	NET_ASSERT(tc < sizeof(thread_priorities));
+	NET_ASSERT(tc < ARRAY_SIZE(thread_priorities));
 
 	return thread_priorities[tc];
 }

--- a/subsys/net/ip/net_tc.c
+++ b/subsys/net/ip/net_tc.c
@@ -63,7 +63,7 @@ int net_tx_priority2tc(enum net_priority prio)
 	 *  7                NC        Network control
 	 */
 	/* Priority is the index to this array */
-	static const int tc[] = {
+	static const u8_t tc[] = {
 #if NET_TC_TX_COUNT == 1
 		0, 0, 0, 0, 0, 0, 0, 0
 #endif
@@ -117,7 +117,7 @@ int net_rx_priority2tc(enum net_priority prio)
 	 *  7                NC        Network control
 	 */
 	/* Priority is the index to this array */
-	static const int tc[] = {
+	static const u8_t tc[] = {
 #if NET_TC_RX_COUNT == 1
 		0, 0, 0, 0, 0, 0, 0, 0
 #endif
@@ -153,7 +153,7 @@ int net_rx_priority2tc(enum net_priority prio)
 }
 
 /* Convert traffic class to thread priority */
-static int tx_tc2thread(int tc)
+static u8_t tx_tc2thread(u8_t tc)
 {
 	/* Initial implementation just maps the traffic class to certain queue.
 	 * If there are less queues than classes, then map them into
@@ -170,7 +170,7 @@ static int tx_tc2thread(int tc)
 	 * that thread_priorities[7] value should contain the highest priority
 	 * for the TX queue handling thread.
 	 */
-	static const int thread_priorities[] = {
+	static const u8_t thread_priorities[] = {
 #if NET_TC_TX_COUNT == 1
 		7
 #endif
@@ -206,7 +206,7 @@ static int tx_tc2thread(int tc)
 }
 
 /* Convert traffic class to thread priority */
-static int rx_tc2thread(int tc)
+static u8_t rx_tc2thread(u8_t tc)
 {
 	/* Initial implementation just maps the traffic class to certain queue.
 	 * If there are less queues than classes, then map them into
@@ -223,7 +223,7 @@ static int rx_tc2thread(int tc)
 	 * that thread_priorities[7] value should contain the highest priority
 	 * for the RX queue handling thread.
 	 */
-	static const int thread_priorities[] = {
+	static const u8_t thread_priorities[] = {
 #if NET_TC_RX_COUNT == 1
 		7
 #endif


### PR DESCRIPTION
The array size checks were incorrect.

Coverity-CID: 183482
Coverity-CID: 183485

Fixes #6883
Fixes #6885

Signed-off-by: Jukka Rissanen <jukka.rissanen@linux.intel.com>