### PR TITLE
Scheduler refactoring

### DIFF
--- a/arch/arm/core/thread_abort.c
+++ b/arch/arm/core/thread_abort.c
@@ -49,5 +49,5 @@ void _impl_k_thread_abort(k_tid_t thread)
 	}
 
 	/* The abort handler might have altered the ready queue. */
-	_reschedule_noyield(key);
+	_reschedule(key);
 }

--- a/arch/arm/core/thread_abort.c
+++ b/arch/arm/core/thread_abort.c
@@ -49,5 +49,5 @@ void _impl_k_thread_abort(k_tid_t thread)
 	}
 
 	/* The abort handler might have altered the ready queue. */
-	_reschedule_threads(key);
+	_reschedule_noyield(key);
 }

--- a/arch/posix/core/posix_core.c
+++ b/arch/posix/core/posix_core.c
@@ -532,7 +532,7 @@ void _impl_k_thread_abort(k_tid_t thread)
 	}
 
 	/* The abort handler might have altered the ready queue. */
-	_reschedule_threads(key);
+	_reschedule_noyield(key);
 }
 #endif
 

--- a/arch/posix/core/posix_core.c
+++ b/arch/posix/core/posix_core.c
@@ -532,7 +532,7 @@ void _impl_k_thread_abort(k_tid_t thread)
 	}
 
 	/* The abort handler might have altered the ready queue. */
-	_reschedule_noyield(key);
+	_reschedule(key);
 }
 #endif
 

--- a/doc/kernel/threads/lifecycle.rst
+++ b/doc/kernel/threads/lifecycle.rst
@@ -289,7 +289,6 @@ The following thread APIs are provided by :file:`kernel.h`:
 
 * :c:macro:`K_THREAD_DEFINE`
 * :cpp:func:`k_thread_create()`
-* :cpp:func:`k_thread_cancel()`
 * :cpp:func:`k_thread_abort()`
 * :cpp:func:`k_thread_suspend()`
 * :cpp:func:`k_thread_resume()`

--- a/include/kernel.h
+++ b/include/kernel.h
@@ -717,8 +717,10 @@ __syscall k_tid_t k_current_get(void);
  *
  * @retval 0 Thread spawning canceled.
  * @retval -EINVAL Thread has already started executing.
+ *
+ * @deprecated This API is deprecated.  Use k_thread_abort().
  */
-__syscall int k_thread_cancel(k_tid_t thread);
+__deprecated __syscall int k_thread_cancel(k_tid_t thread);
 
 /**
  * @brief Abort a thread.

--- a/include/kernel.h
+++ b/include/kernel.h
@@ -3948,7 +3948,7 @@ extern int k_poll_signal(struct k_poll_signal *signal, int result);
 /**
  * @internal
  */
-extern int _handle_obj_poll_events(sys_dlist_t *events, u32_t state);
+extern void _handle_obj_poll_events(sys_dlist_t *events, u32_t state);
 
 /** @} */
 

--- a/kernel/include/ksched.h
+++ b/kernel/include/ksched.h
@@ -26,7 +26,7 @@ extern int _reschedule_yield(int key);
 extern void k_sched_unlock(void);
 extern void _pend_thread(struct k_thread *thread,
 			 _wait_q_t *wait_q, s32_t timeout);
-extern void _pend_current_thread(_wait_q_t *wait_q, s32_t timeout);
+extern int _pend_current_thread(int key, _wait_q_t *wait_q, s32_t timeout);
 extern void _move_thread_to_end_of_prio_q(struct k_thread *thread);
 extern int _is_thread_time_slicing(struct k_thread *thread);
 extern void _update_time_slice_before_swap(void);

--- a/kernel/include/ksched.h
+++ b/kernel/include/ksched.h
@@ -489,26 +489,26 @@ _find_first_thread_to_unpend(_wait_q_t *wait_q, struct k_thread *from)
 
 /* Unpend a thread from the wait queue it is on. Thread must be pending. */
 /* must be called with interrupts locked */
-static inline void _unpend_thread(struct k_thread *thread)
-{
-	__ASSERT(thread->base.thread_state & _THREAD_PENDING, "");
+void _unpend_thread(struct k_thread *thread);
 
-	sys_dlist_remove(&thread->base.k_q_node);
-	_mark_thread_as_not_pending(thread);
-}
+/* Same, but does not abort current timeout */
+void _unpend_thread_no_timeout(struct k_thread *thread);
 
 /* unpend the first thread from a wait queue */
 /* must be called with interrupts locked */
-static inline struct k_thread *_unpend_first_thread(_wait_q_t *wait_q)
+struct k_thread *_unpend_first_thread(_wait_q_t *wait_q);
+
+static inline struct k_thread *_unpend1_no_timeout(_wait_q_t *wait_q)
 {
 	struct k_thread *thread = _find_first_thread_to_unpend(wait_q, NULL);
 
 	if (thread) {
-		_unpend_thread(thread);
+		_unpend_thread_no_timeout(thread);
 	}
 
 	return thread;
 }
+
 
 #ifdef CONFIG_USERSPACE
 /**

--- a/kernel/include/ksched.h
+++ b/kernel/include/ksched.h
@@ -509,6 +509,14 @@ static inline struct k_thread *_unpend1_no_timeout(_wait_q_t *wait_q)
 	return thread;
 }
 
+static inline void _ready_one_thread(_wait_q_t *wq)
+{
+	struct k_thread *th = _unpend_first_thread(wq);
+
+	if (th) {
+		_ready_thread(th);
+	}
+}
 
 #ifdef CONFIG_USERSPACE
 /**

--- a/kernel/include/ksched.h
+++ b/kernel/include/ksched.h
@@ -21,13 +21,13 @@ extern k_tid_t const _idle_thread;
 
 extern void _add_thread_to_ready_q(struct k_thread *thread);
 extern void _remove_thread_from_ready_q(struct k_thread *thread);
-extern void _reschedule_threads(int key);
+extern int _reschedule_noyield(int key);
+extern int _reschedule_yield(int key);
 extern void k_sched_unlock(void);
 extern void _pend_thread(struct k_thread *thread,
 			 _wait_q_t *wait_q, s32_t timeout);
 extern void _pend_current_thread(_wait_q_t *wait_q, s32_t timeout);
 extern void _move_thread_to_end_of_prio_q(struct k_thread *thread);
-extern int __must_switch_threads(void);
 extern int _is_thread_time_slicing(struct k_thread *thread);
 extern void _update_time_slice_before_swap(void);
 #ifdef _NON_OPTIMIZED_TICKS_PER_SEC
@@ -261,15 +261,6 @@ static inline int _get_highest_ready_prio(void)
 	return abs_prio - _NUM_COOP_PRIO;
 }
 #endif
-
-/*
- * Checks if current thread must be context-switched out. The caller must
- * already know that the execution context is a thread.
- */
-static inline int _must_switch_threads(void)
-{
-	return _is_preempt(_current) && __must_switch_threads();
-}
 
 /*
  * Called directly by other internal kernel code.

--- a/kernel/include/ksched.h
+++ b/kernel/include/ksched.h
@@ -21,8 +21,7 @@ extern k_tid_t const _idle_thread;
 
 extern void _add_thread_to_ready_q(struct k_thread *thread);
 extern void _remove_thread_from_ready_q(struct k_thread *thread);
-extern int _reschedule_noyield(int key);
-extern int _reschedule_yield(int key);
+extern int _reschedule(int key);
 extern void k_sched_unlock(void);
 extern void _pend_thread(struct k_thread *thread,
 			 _wait_q_t *wait_q, s32_t timeout);

--- a/kernel/include/timeout_q.h
+++ b/kernel/include/timeout_q.h
@@ -69,7 +69,7 @@ static inline void _unpend_thread_timing_out(struct k_thread *thread,
 					     struct _timeout *timeout_obj)
 {
 	if (timeout_obj->wait_q) {
-		_unpend_thread(thread);
+		_unpend_thread_no_timeout(thread);
 		thread->base.timeout.wait_q = NULL;
 	}
 }

--- a/kernel/mailbox.c
+++ b/kernel/mailbox.c
@@ -218,7 +218,7 @@ static void mbox_message_dispose(struct k_mbox_msg *rx_msg)
 	_set_thread_return_value(sending_thread, 0);
 	_mark_thread_as_not_pending(sending_thread);
 	_ready_thread(sending_thread);
-	_reschedule_noyield(key);
+	_reschedule(key);
 }
 
 /**
@@ -275,7 +275,7 @@ static int mbox_message_put(struct k_mbox *mbox, struct k_mbox_msg *tx_msg,
 			 * until the receiver consumes the message
 			 */
 			if (sending_thread->base.thread_state & _THREAD_DUMMY) {
-				_reschedule_noyield(key);
+				_reschedule(key);
 				return 0;
 			}
 #endif

--- a/kernel/mailbox.c
+++ b/kernel/mailbox.c
@@ -260,7 +260,6 @@ static int mbox_message_put(struct k_mbox *mbox, struct k_mbox_msg *tx_msg,
 		if (mbox_message_match(tx_msg, rx_msg) == 0) {
 			/* take receiver out of rx queue */
 			_unpend_thread(receiving_thread);
-			_abort_thread_timeout(receiving_thread);
 
 			/* ready receiver for execution */
 			_set_thread_return_value(receiving_thread, 0);
@@ -441,7 +440,6 @@ int k_mbox_get(struct k_mbox *mbox, struct k_mbox_msg *rx_msg, void *buffer,
 		if (mbox_message_match(tx_msg, rx_msg) == 0) {
 			/* take sender out of mailbox's tx queue */
 			_unpend_thread(sending_thread);
-			_abort_thread_timeout(sending_thread);
 
 			irq_unlock(key);
 

--- a/kernel/mailbox.c
+++ b/kernel/mailbox.c
@@ -285,8 +285,8 @@ static int mbox_message_put(struct k_mbox *mbox, struct k_mbox_msg *tx_msg,
 			 * synchronous send: pend current thread (unqueued)
 			 * until the receiver consumes the message
 			 */
-			_pend_current_thread(NULL, K_FOREVER);
-			return _Swap(key);
+			return _pend_current_thread(key, NULL, K_FOREVER);
+
 		}
 	}
 
@@ -306,8 +306,7 @@ static int mbox_message_put(struct k_mbox *mbox, struct k_mbox_msg *tx_msg,
 #endif
 
 	/* synchronous send: sender waits on tx queue for receiver or timeout */
-	_pend_current_thread(&mbox->tx_msg_queue, timeout);
-	return _Swap(key);
+	return _pend_current_thread(key, &mbox->tx_msg_queue, timeout);
 }
 
 int k_mbox_put(struct k_mbox *mbox, struct k_mbox_msg *tx_msg, s32_t timeout)
@@ -461,9 +460,8 @@ int k_mbox_get(struct k_mbox *mbox, struct k_mbox_msg *rx_msg, void *buffer,
 	}
 
 	/* wait until a matching sender appears or a timeout occurs */
-	_pend_current_thread(&mbox->rx_msg_queue, timeout);
 	_current->base.swap_data = rx_msg;
-	result = _Swap(key);
+	result = _pend_current_thread(key, &mbox->rx_msg_queue, timeout);
 
 	/* consume message data immediately, if needed */
 	if (result == 0) {

--- a/kernel/mailbox.c
+++ b/kernel/mailbox.c
@@ -219,7 +219,7 @@ static void mbox_message_dispose(struct k_mbox_msg *rx_msg)
 	_set_thread_return_value(sending_thread, 0);
 	_mark_thread_as_not_pending(sending_thread);
 	_ready_thread(sending_thread);
-	_reschedule_threads(key);
+	_reschedule_noyield(key);
 }
 
 /**
@@ -276,7 +276,7 @@ static int mbox_message_put(struct k_mbox *mbox, struct k_mbox_msg *tx_msg,
 			 * until the receiver consumes the message
 			 */
 			if (sending_thread->base.thread_state & _THREAD_DUMMY) {
-				_reschedule_threads(key);
+				_reschedule_noyield(key);
 				return 0;
 			}
 #endif

--- a/kernel/mailbox.c
+++ b/kernel/mailbox.c
@@ -285,8 +285,7 @@ static int mbox_message_put(struct k_mbox *mbox, struct k_mbox_msg *tx_msg,
 			 * synchronous send: pend current thread (unqueued)
 			 * until the receiver consumes the message
 			 */
-			_remove_thread_from_ready_q(_current);
-			_mark_thread_as_pending(_current);
+			_pend_current_thread(NULL, K_FOREVER);
 			return _Swap(key);
 		}
 	}

--- a/kernel/mailbox.c
+++ b/kernel/mailbox.c
@@ -17,7 +17,6 @@
 #include <wait_q.h>
 #include <misc/dlist.h>
 #include <init.h>
-#include <kswap.h>
 
 #if (CONFIG_NUM_MBOX_ASYNC_MSGS > 0)
 

--- a/kernel/mem_slab.c
+++ b/kernel/mem_slab.c
@@ -127,5 +127,5 @@ void k_mem_slab_free(struct k_mem_slab *slab, void **mem)
 		slab->num_used--;
 	}
 
-	_reschedule_noyield(key);
+	_reschedule(key);
 }

--- a/kernel/mem_slab.c
+++ b/kernel/mem_slab.c
@@ -119,7 +119,6 @@ void k_mem_slab_free(struct k_mem_slab *slab, void **mem)
 
 	if (pending_thread) {
 		_set_thread_return_value_with_data(pending_thread, 0, *mem);
-		_abort_thread_timeout(pending_thread);
 		_ready_thread(pending_thread);
 	} else {
 		**(char ***)mem = slab->free_list;

--- a/kernel/mem_slab.c
+++ b/kernel/mem_slab.c
@@ -101,8 +101,7 @@ int k_mem_slab_alloc(struct k_mem_slab *slab, void **mem, s32_t timeout)
 		result = -ENOMEM;
 	} else {
 		/* wait for a free block or timeout */
-		_pend_current_thread(&slab->wait_q, timeout);
-		result = _Swap(key);
+		result = _pend_current_thread(key, &slab->wait_q, timeout);
 		if (result == 0) {
 			*mem = _current->base.swap_data;
 		}

--- a/kernel/mem_slab.c
+++ b/kernel/mem_slab.c
@@ -13,7 +13,6 @@
 #include <misc/dlist.h>
 #include <ksched.h>
 #include <init.h>
-#include <kswap.h>
 
 extern struct k_mem_slab _k_mem_slab_list_start[];
 extern struct k_mem_slab _k_mem_slab_list_end[];

--- a/kernel/mem_slab.c
+++ b/kernel/mem_slab.c
@@ -123,15 +123,11 @@ void k_mem_slab_free(struct k_mem_slab *slab, void **mem)
 		_set_thread_return_value_with_data(pending_thread, 0, *mem);
 		_abort_thread_timeout(pending_thread);
 		_ready_thread(pending_thread);
-		if (_must_switch_threads()) {
-			_Swap(key);
-			return;
-		}
 	} else {
 		**(char ***)mem = slab->free_list;
 		slab->free_list = *(char **)mem;
 		slab->num_used--;
 	}
 
-	irq_unlock(key);
+	_reschedule_noyield(key);
 }

--- a/kernel/mempool.c
+++ b/kernel/mempool.c
@@ -51,7 +51,7 @@ SYS_INIT(init_static_pools, PRE_KERNEL_1, CONFIG_KERNEL_INIT_PRIORITY_OBJECTS);
 int k_mem_pool_alloc(struct k_mem_pool *p, struct k_mem_block *block,
 		     size_t size, s32_t timeout)
 {
-	int ret, key;
+	int ret;
 	s64_t end = 0;
 
 	__ASSERT(!(_is_in_isr() && timeout != K_NO_WAIT), "");
@@ -74,9 +74,7 @@ int k_mem_pool_alloc(struct k_mem_pool *p, struct k_mem_block *block,
 			return ret;
 		}
 
-		key = irq_lock();
-		_pend_current_thread(&p->wait_q, timeout);
-		_Swap(key);
+		_pend_current_thread(irq_lock(), &p->wait_q, timeout);
 
 		if (timeout != K_FOREVER) {
 			timeout = end - _tick_get();

--- a/kernel/mempool.c
+++ b/kernel/mempool.c
@@ -10,7 +10,6 @@
 #include <init.h>
 #include <string.h>
 #include <misc/__assert.h>
-#include <kswap.h>
 
 /* Linker-defined symbols bound the static pool structs */
 extern struct k_mem_pool _k_mem_pool_list_start[];

--- a/kernel/mempool.c
+++ b/kernel/mempool.c
@@ -109,7 +109,7 @@ void k_mem_pool_free_id(struct k_mem_block_id *id)
 	}
 
 	if (need_sched && !_is_in_isr()) {
-		_reschedule_noyield(key);
+		_reschedule(key);
 	} else {
 		irq_unlock(key);
 	}

--- a/kernel/mempool.c
+++ b/kernel/mempool.c
@@ -103,7 +103,6 @@ void k_mem_pool_free_id(struct k_mem_block_id *id)
 		struct k_thread *th = (void *)sys_dlist_peek_head(&p->wait_q);
 
 		_unpend_thread(th);
-		_abort_thread_timeout(th);
 		_ready_thread(th);
 		need_sched = 1;
 	}

--- a/kernel/mempool.c
+++ b/kernel/mempool.c
@@ -112,7 +112,7 @@ void k_mem_pool_free_id(struct k_mem_block_id *id)
 	}
 
 	if (need_sched && !_is_in_isr()) {
-		_reschedule_threads(key);
+		_reschedule_noyield(key);
 	} else {
 		irq_unlock(key);
 	}

--- a/kernel/msg_q.c
+++ b/kernel/msg_q.c
@@ -112,9 +112,8 @@ int _impl_k_msgq_put(struct k_msgq *q, void *data, s32_t timeout)
 		result = -ENOMSG;
 	} else {
 		/* wait for put message success, failure, or timeout */
-		_pend_current_thread(&q->wait_q, timeout);
 		_current->base.swap_data = data;
-		return _reschedule_yield(key);
+		return _pend_current_thread(key, &q->wait_q, timeout);
 	}
 
 	irq_unlock(key);
@@ -195,9 +194,8 @@ int _impl_k_msgq_get(struct k_msgq *q, void *data, s32_t timeout)
 		result = -ENOMSG;
 	} else {
 		/* wait for get message success or timeout */
-		_pend_current_thread(&q->wait_q, timeout);
 		_current->base.swap_data = data;
-		return _Swap(key);
+		return _pend_current_thread(key, &q->wait_q, timeout);
 	}
 
 	irq_unlock(key);

--- a/kernel/msg_q.c
+++ b/kernel/msg_q.c
@@ -94,7 +94,7 @@ int _impl_k_msgq_put(struct k_msgq *q, void *data, s32_t timeout)
 			_set_thread_return_value(pending_thread, 0);
 			_abort_thread_timeout(pending_thread);
 			_ready_thread(pending_thread);
-			_reschedule_noyield(key);
+			_reschedule(key);
 			return 0;
 		} else {
 			/* put message in queue */
@@ -184,7 +184,7 @@ int _impl_k_msgq_get(struct k_msgq *q, void *data, s32_t timeout)
 			_set_thread_return_value(pending_thread, 0);
 			_abort_thread_timeout(pending_thread);
 			_ready_thread(pending_thread);
-			_reschedule_noyield(key);
+			_reschedule(key);
 			return 0;
 		}
 		result = 0;
@@ -229,7 +229,7 @@ void _impl_k_msgq_purge(struct k_msgq *q)
 	q->used_msgs = 0;
 	q->read_ptr = q->write_ptr;
 
-	_reschedule_noyield(key);
+	_reschedule(key);
 }
 
 #ifdef CONFIG_USERSPACE

--- a/kernel/msg_q.c
+++ b/kernel/msg_q.c
@@ -92,7 +92,6 @@ int _impl_k_msgq_put(struct k_msgq *q, void *data, s32_t timeout)
 			       q->msg_size);
 			/* wake up waiting thread */
 			_set_thread_return_value(pending_thread, 0);
-			_abort_thread_timeout(pending_thread);
 			_ready_thread(pending_thread);
 			_reschedule(key);
 			return 0;
@@ -182,7 +181,6 @@ int _impl_k_msgq_get(struct k_msgq *q, void *data, s32_t timeout)
 
 			/* wake up waiting thread */
 			_set_thread_return_value(pending_thread, 0);
-			_abort_thread_timeout(pending_thread);
 			_ready_thread(pending_thread);
 			_reschedule(key);
 			return 0;
@@ -222,7 +220,6 @@ void _impl_k_msgq_purge(struct k_msgq *q)
 	/* wake up any threads that are waiting to write */
 	while ((pending_thread = _unpend_first_thread(&q->wait_q)) != NULL) {
 		_set_thread_return_value(pending_thread, -ENOMSG);
-		_abort_thread_timeout(pending_thread);
 		_ready_thread(pending_thread);
 	}
 

--- a/kernel/msg_q.c
+++ b/kernel/msg_q.c
@@ -20,7 +20,6 @@
 #include <misc/dlist.h>
 #include <init.h>
 #include <syscall_handler.h>
-#include <kswap.h>
 
 extern struct k_msgq _k_msgq_list_start[];
 extern struct k_msgq _k_msgq_list_end[];

--- a/kernel/mutex.c
+++ b/kernel/mutex.c
@@ -231,7 +231,6 @@ void _impl_k_mutex_unlock(struct k_mutex *mutex)
 		mutex, new_owner, new_owner ? new_owner->base.prio : -1000);
 
 	if (new_owner) {
-		_abort_thread_timeout(new_owner);
 		_ready_thread(new_owner);
 
 		irq_unlock(key);

--- a/kernel/mutex.c
+++ b/kernel/mutex.c
@@ -225,6 +225,8 @@ void _impl_k_mutex_unlock(struct k_mutex *mutex)
 
 	struct k_thread *new_owner = _unpend_first_thread(&mutex->wait_q);
 
+	mutex->owner = new_owner;
+
 	K_DEBUG("new owner of mutex %p: %p (prio: %d)\n",
 		mutex, new_owner, new_owner ? new_owner->base.prio : -1000);
 
@@ -241,13 +243,11 @@ void _impl_k_mutex_unlock(struct k_mutex *mutex)
 		 * waiter since the wait queue is priority-based: no need to
 		 * ajust its priority
 		 */
-		mutex->owner = new_owner;
 		mutex->lock_count++;
 		mutex->owner_orig_prio = new_owner->base.prio;
-	} else {
-		irq_unlock(key);
-		mutex->owner = NULL;
 	}
+
+	irq_unlock(key);
 
 	k_sched_unlock();
 }

--- a/kernel/mutex.c
+++ b/kernel/mutex.c
@@ -158,9 +158,7 @@ int _impl_k_mutex_lock(struct k_mutex *mutex, s32_t timeout)
 		adjust_owner_prio(mutex, new_prio);
 	}
 
-	_pend_current_thread(&mutex->wait_q, timeout);
-
-	int got_mutex = _Swap(key);
+	int got_mutex = _pend_current_thread(key, &mutex->wait_q, timeout);
 
 	K_DEBUG("on mutex %p got_mutex value: %d\n", mutex, got_mutex);
 

--- a/kernel/mutex.c
+++ b/kernel/mutex.c
@@ -36,7 +36,6 @@
 #include <errno.h>
 #include <init.h>
 #include <syscall_handler.h>
-#include <kswap.h>
 
 #define RECORD_STATE_CHANGE(mutex) do { } while ((0))
 #define RECORD_CONFLICT(mutex) do { } while ((0))

--- a/kernel/pipes.c
+++ b/kernel/pipes.c
@@ -529,8 +529,7 @@ int _k_pipe_put_internal(struct k_pipe *pipe, struct k_pipe_async *async_desc,
 		 */
 		key = irq_lock();
 		_sched_unlock_no_reschedule();
-		_pend_current_thread(&pipe->wait_q.writers, timeout);
-		_Swap(key);
+		_pend_current_thread(key, &pipe->wait_q.writers, timeout);
 	} else {
 		k_sched_unlock();
 	}
@@ -672,8 +671,7 @@ int _impl_k_pipe_get(struct k_pipe *pipe, void *data, size_t bytes_to_read,
 		_current->base.swap_data = &pipe_desc;
 		key = irq_lock();
 		_sched_unlock_no_reschedule();
-		_pend_current_thread(&pipe->wait_q.readers, timeout);
-		_Swap(key);
+		_pend_current_thread(key, &pipe->wait_q.readers, timeout);
 	} else {
 		k_sched_unlock();
 	}

--- a/kernel/pipes.c
+++ b/kernel/pipes.c
@@ -511,7 +511,7 @@ int _k_pipe_put_internal(struct k_pipe *pipe, struct k_pipe_async *async_desc,
 		_sched_unlock_no_reschedule();
 		_pend_thread((struct k_thread *) &async_desc->thread,
 			     &pipe->wait_q.writers, K_FOREVER);
-		_reschedule_threads(key);
+		_reschedule_noyield(key);
 		return 0;
 	}
 #endif

--- a/kernel/pipes.c
+++ b/kernel/pipes.c
@@ -335,7 +335,6 @@ static bool pipe_xfer_prepare(sys_dlist_t      *xfer_list,
 		 * Add it to the transfer list.
 		 */
 		_unpend_thread(thread);
-		_abort_thread_timeout(thread);
 		sys_dlist_append(xfer_list, &thread->base.k_q_node);
 	}
 

--- a/kernel/pipes.c
+++ b/kernel/pipes.c
@@ -19,7 +19,6 @@
 #include <misc/dlist.h>
 #include <init.h>
 #include <syscall_handler.h>
-#include <kswap.h>
 
 struct k_pipe_desc {
 	unsigned char *buffer;           /* Position in src/dest buffer */

--- a/kernel/pipes.c
+++ b/kernel/pipes.c
@@ -510,7 +510,7 @@ int _k_pipe_put_internal(struct k_pipe *pipe, struct k_pipe_async *async_desc,
 		_sched_unlock_no_reschedule();
 		_pend_thread((struct k_thread *) &async_desc->thread,
 			     &pipe->wait_q.writers, K_FOREVER);
-		_reschedule_noyield(key);
+		_reschedule(key);
 		return 0;
 	}
 #endif

--- a/kernel/poll.c
+++ b/kernel/poll.c
@@ -246,9 +246,7 @@ int k_poll(struct k_poll_event *events, int num_events, s32_t timeout)
 
 	_wait_q_t wait_q = _WAIT_Q_INIT(&wait_q);
 
-	_pend_current_thread(&wait_q, timeout);
-
-	int swap_rc = _Swap(key);
+	int swap_rc = _pend_current_thread(key, &wait_q, timeout);
 
 	/*
 	 * Clear all event registrations. If events happen while we're in this

--- a/kernel/poll.c
+++ b/kernel/poll.c
@@ -19,7 +19,6 @@
 #include <kernel_internal.h>
 #include <wait_q.h>
 #include <ksched.h>
-#include <kswap.h>
 #include <misc/slist.h>
 #include <misc/dlist.h>
 #include <misc/__assert.h>

--- a/kernel/poll.c
+++ b/kernel/poll.c
@@ -333,6 +333,6 @@ int k_poll_signal(struct k_poll_signal *signal, int result)
 
 	int rc = signal_poll_event(poll_event, K_POLL_STATE_SIGNALED);
 
-	_reschedule_noyield(key);
+	_reschedule(key);
 	return rc;
 }

--- a/kernel/poll.c
+++ b/kernel/poll.c
@@ -285,7 +285,6 @@ static int signal_poll_event(struct k_poll_event *event, u32_t state)
 	}
 
 	_unpend_thread(thread);
-	_abort_thread_timeout(thread);
 	_set_thread_return_value(thread,
 				 state == K_POLL_STATE_NOT_READY ? -EINTR : 0);
 

--- a/kernel/queue.c
+++ b/kernel/queue.c
@@ -20,7 +20,6 @@
 #include <ksched.h>
 #include <misc/slist.h>
 #include <init.h>
-#include <kswap.h>
 
 extern struct k_queue _k_queue_list_start[];
 extern struct k_queue _k_queue_list_end[];

--- a/kernel/queue.c
+++ b/kernel/queue.c
@@ -61,7 +61,6 @@ void k_queue_init(struct k_queue *queue)
 #if !defined(CONFIG_POLL)
 static void prepare_thread_to_run(struct k_thread *thread, void *data)
 {
-	_abort_thread_timeout(thread);
 	_ready_thread(thread);
 	_set_thread_return_value_with_data(thread, 0, data);
 }

--- a/kernel/queue.c
+++ b/kernel/queue.c
@@ -224,8 +224,8 @@ void *k_queue_get(struct k_queue *queue, s32_t timeout)
 	return k_queue_poll(queue, timeout);
 
 #else
-	_pend_current_thread(&queue->wait_q, timeout);
+	int ret = _pend_current_thread(key, &queue->wait_q, timeout);
 
-	return _Swap(key) ? NULL : _current->base.swap_data;
+	return ret ? NULL : _current->base.swap_data;
 #endif /* CONFIG_POLL */
 }

--- a/kernel/queue.c
+++ b/kernel/queue.c
@@ -89,7 +89,7 @@ void k_queue_cancel_wait(struct k_queue *queue)
 	handle_poll_events(queue, K_POLL_STATE_NOT_READY);
 #endif /* !CONFIG_POLL */
 
-	_reschedule_noyield(key);
+	_reschedule(key);
 }
 
 void k_queue_insert(struct k_queue *queue, void *prev, void *data)
@@ -102,7 +102,7 @@ void k_queue_insert(struct k_queue *queue, void *prev, void *data)
 
 	if (first_pending_thread) {
 		prepare_thread_to_run(first_pending_thread, data);
-		_reschedule_noyield(key);
+		_reschedule(key);
 		return;
 	}
 #endif /* !CONFIG_POLL */
@@ -113,7 +113,7 @@ void k_queue_insert(struct k_queue *queue, void *prev, void *data)
 	handle_poll_events(queue, K_POLL_STATE_DATA_AVAILABLE);
 #endif /* CONFIG_POLL */
 
-	_reschedule_noyield(key);
+	_reschedule(key);
 }
 
 void k_queue_append(struct k_queue *queue, void *data)
@@ -148,7 +148,7 @@ void k_queue_append_list(struct k_queue *queue, void *head, void *tail)
 	handle_poll_events(queue, K_POLL_STATE_DATA_AVAILABLE);
 #endif /* !CONFIG_POLL */
 
-	_reschedule_noyield(key);
+	_reschedule(key);
 }
 
 void k_queue_merge_slist(struct k_queue *queue, sys_slist_t *list)

--- a/kernel/sched.c
+++ b/kernel/sched.c
@@ -203,6 +203,10 @@ void _pend_thread(struct k_thread *thread, _wait_q_t *wait_q, s32_t timeout)
 	sys_dlist_t *wait_q_list = (sys_dlist_t *)wait_q;
 	struct k_thread *pending;
 
+	if (!wait_q_list) {
+		goto inserted;
+	}
+
 	SYS_DLIST_FOR_EACH_CONTAINER(wait_q_list, pending, base.k_q_node) {
 		if (_is_t1_higher_prio_than_t2(thread, pending)) {
 			sys_dlist_insert_before(wait_q_list,

--- a/kernel/sched.c
+++ b/kernel/sched.c
@@ -240,12 +240,15 @@ inserted:
 #endif
 }
 
-/* pend the current thread */
-/* must be called with interrupts locked */
-void _pend_current_thread(_wait_q_t *wait_q, s32_t timeout)
+/* Block the current thread and swap to the next.  Releases the
+ * irq_lock, does a _Swap and returns the return value set at wakeup
+ * time
+ */
+int _pend_current_thread(int key, _wait_q_t *wait_q, s32_t timeout)
 {
 	_remove_thread_from_ready_q(_current);
 	_pend_thread(_current, wait_q, timeout);
+	return _Swap(key);
 }
 
 int _impl_k_thread_priority_get(k_tid_t thread)

--- a/kernel/sched.c
+++ b/kernel/sched.c
@@ -230,6 +230,31 @@ inserted:
 #endif
 }
 
+void _unpend_thread_no_timeout(struct k_thread *thread)
+{
+	__ASSERT(thread->base.thread_state & _THREAD_PENDING, "");
+
+	sys_dlist_remove(&thread->base.k_q_node);
+	_mark_thread_as_not_pending(thread);
+}
+
+void _unpend_thread(struct k_thread *thread)
+{
+	_unpend_thread_no_timeout(thread);
+	_abort_thread_timeout(thread);
+}
+
+struct k_thread *_unpend_first_thread(_wait_q_t *wait_q)
+{
+	struct k_thread *t = _unpend1_no_timeout(wait_q);
+
+	if (t) {
+		_abort_thread_timeout(t);
+	}
+
+	return t;
+}
+
 /* Block the current thread and swap to the next.  Releases the
  * irq_lock, does a _Swap and returns the return value set at wakeup
  * time

--- a/kernel/sem.c
+++ b/kernel/sem.c
@@ -27,7 +27,6 @@
 #include <ksched.h>
 #include <init.h>
 #include <syscall_handler.h>
-#include <kswap.h>
 
 extern struct k_sem _k_sem_list_start[];
 extern struct k_sem _k_sem_list_end[];

--- a/kernel/sem.c
+++ b/kernel/sem.c
@@ -98,7 +98,6 @@ static void do_sem_give(struct k_sem *sem)
 	struct k_thread *thread = _unpend_first_thread(&sem->wait_q);
 
 	if (thread) {
-		(void)_abort_thread_timeout(thread);
 		_ready_thread(thread);
 		_set_thread_return_value(thread, 0);
 	} else {
@@ -121,7 +120,7 @@ void _sem_give_non_preemptible(struct k_sem *sem)
 {
 	struct k_thread *thread;
 
-	thread = _unpend_first_thread(&sem->wait_q);
+	thread = _unpend1_no_timeout(&sem->wait_q);
 	if (!thread) {
 		increment_count_up_to_limit(sem);
 		return;

--- a/kernel/sem.c
+++ b/kernel/sem.c
@@ -135,7 +135,7 @@ void _impl_k_sem_give(struct k_sem *sem)
 	unsigned int key = irq_lock();
 
 	do_sem_give(sem);
-	_reschedule_noyield(key);
+	_reschedule(key);
 }
 
 #ifdef CONFIG_USERSPACE

--- a/kernel/sem.c
+++ b/kernel/sem.c
@@ -160,9 +160,7 @@ int _impl_k_sem_take(struct k_sem *sem, s32_t timeout)
 		return -EBUSY;
 	}
 
-	_pend_current_thread(&sem->wait_q, timeout);
-
-	return _Swap(key);
+	return _pend_current_thread(key, &sem->wait_q, timeout);
 }
 
 #ifdef CONFIG_USERSPACE

--- a/kernel/stack.c
+++ b/kernel/stack.c
@@ -86,17 +86,14 @@ void _impl_k_stack_push(struct k_stack *stack, u32_t data)
 
 		_set_thread_return_value_with_data(first_pending_thread,
 						   0, (void *)data);
-
-		if (!_is_in_isr() && _must_switch_threads()) {
-			(void)_Swap(key);
-			return;
-		}
+		_reschedule_noyield(key);
+		return;
 	} else {
 		*(stack->next) = data;
 		stack->next++;
+		irq_unlock(key);
 	}
 
-	irq_unlock(key);
 }
 
 #ifdef CONFIG_USERSPACE

--- a/kernel/stack.c
+++ b/kernel/stack.c
@@ -128,9 +128,8 @@ int _impl_k_stack_pop(struct k_stack *stack, u32_t *data, s32_t timeout)
 		return -EBUSY;
 	}
 
-	_pend_current_thread(&stack->wait_q, timeout);
+	result = _pend_current_thread(key, &stack->wait_q, timeout);
 
-	result = _Swap(key);
 	if (result == 0) {
 		*data = (u32_t)_current->base.swap_data;
 	}

--- a/kernel/stack.c
+++ b/kernel/stack.c
@@ -18,7 +18,6 @@
 #include <misc/__assert.h>
 #include <init.h>
 #include <syscall_handler.h>
-#include <kswap.h>
 
 extern struct k_stack _k_stack_list_start[];
 extern struct k_stack _k_stack_list_end[];

--- a/kernel/stack.c
+++ b/kernel/stack.c
@@ -80,12 +80,11 @@ void _impl_k_stack_push(struct k_stack *stack, u32_t data)
 	first_pending_thread = _unpend_first_thread(&stack->wait_q);
 
 	if (first_pending_thread) {
-		_abort_thread_timeout(first_pending_thread);
 		_ready_thread(first_pending_thread);
 
 		_set_thread_return_value_with_data(first_pending_thread,
 						   0, (void *)data);
-		_reschedule_noyield(key);
+		_reschedule(key);
 		return;
 	} else {
 		*(stack->next) = data;

--- a/kernel/thread.c
+++ b/kernel/thread.c
@@ -228,7 +228,7 @@ void _impl_k_thread_start(struct k_thread *thread)
 
 	_mark_thread_as_started(thread);
 	_ready_thread(thread);
-	_reschedule_noyield(key);
+	_reschedule(key);
 }
 
 #ifdef CONFIG_USERSPACE
@@ -484,7 +484,7 @@ void _impl_k_thread_resume(struct k_thread *thread)
 
 	_k_thread_single_resume(thread);
 
-	_reschedule_noyield(key);
+	_reschedule(key);
 }
 
 #ifdef CONFIG_USERSPACE

--- a/kernel/thread.c
+++ b/kernel/thread.c
@@ -228,7 +228,7 @@ void _impl_k_thread_start(struct k_thread *thread)
 
 	_mark_thread_as_started(thread);
 	_ready_thread(thread);
-	_reschedule_threads(key);
+	_reschedule_noyield(key);
 }
 
 #ifdef CONFIG_USERSPACE
@@ -484,7 +484,7 @@ void _impl_k_thread_resume(struct k_thread *thread)
 
 	_k_thread_single_resume(thread);
 
-	_reschedule_threads(key);
+	_reschedule_noyield(key);
 }
 
 #ifdef CONFIG_USERSPACE

--- a/kernel/thread.c
+++ b/kernel/thread.c
@@ -501,7 +501,7 @@ void _k_thread_single_abort(struct k_thread *thread)
 		_remove_thread_from_ready_q(thread);
 	} else {
 		if (_is_thread_pending(thread)) {
-			_unpend_thread(thread);
+			_unpend_thread_no_timeout(thread);
 		}
 		if (_is_thread_timeout_active(thread)) {
 			_abort_thread_timeout(thread);

--- a/kernel/thread_abort.c
+++ b/kernel/thread_abort.c
@@ -46,7 +46,7 @@ void _impl_k_thread_abort(k_tid_t thread)
 		}
 
 		/* The abort handler might have altered the ready queue. */
-		_reschedule_noyield(key);
+		_reschedule(key);
 	}
 }
 #endif

--- a/kernel/thread_abort.c
+++ b/kernel/thread_abort.c
@@ -46,7 +46,7 @@ void _impl_k_thread_abort(k_tid_t thread)
 		}
 
 		/* The abort handler might have altered the ready queue. */
-		_reschedule_threads(key);
+		_reschedule_noyield(key);
 	}
 }
 #endif

--- a/kernel/timer.c
+++ b/kernel/timer.c
@@ -173,7 +173,7 @@ void _impl_k_timer_stop(struct k_timer *timer)
 	if (_is_in_isr()) {
 		irq_unlock(key);
 	} else {
-		_reschedule_threads(key);
+		_reschedule_noyield(key);
 	}
 }
 

--- a/kernel/timer.c
+++ b/kernel/timer.c
@@ -172,7 +172,7 @@ void _impl_k_timer_stop(struct k_timer *timer)
 	if (_is_in_isr()) {
 		irq_unlock(key);
 	} else {
-		_reschedule_noyield(key);
+		_reschedule(key);
 	}
 }
 

--- a/kernel/timer.c
+++ b/kernel/timer.c
@@ -206,8 +206,7 @@ u32_t _impl_k_timer_status_sync(struct k_timer *timer)
 	if (result == 0) {
 		if (timer->timeout.delta_ticks_from_prev != _INACTIVE) {
 			/* wait for timer to expire or stop */
-			_pend_current_thread(&timer->wait_q, K_FOREVER);
-			_Swap(key);
+			_pend_current_thread(key, &timer->wait_q, K_FOREVER);
 
 			/* get updated timer status */
 			key = irq_lock();

--- a/kernel/timer.c
+++ b/kernel/timer.c
@@ -75,13 +75,14 @@ void _timer_expiration_handler(struct _timeout *t)
 	}
 
 	/*
-	 * Interrupts _DO NOT_ have to be locked in this specific instance of
-	 * calling _unpend_thread() because a) this is the only place a thread
-	 * can be taken off this pend queue, and b) the only place a thread
-	 * can be put on the pend queue is at thread level, which of course
-	 * cannot interrupt the current context.
+	 * Interrupts _DO NOT_ have to be locked in this specific
+	 * instance of thread unpending because a) this is the only
+	 * place a thread can be taken off this pend queue, and b) the
+	 * only place a thread can be put on the pend queue is at
+	 * thread level, which of course cannot interrupt the current
+	 * context.
 	 */
-	_unpend_thread(thread);
+	_unpend_thread_no_timeout(thread);
 
 	key = irq_lock();
 	_ready_thread(thread);
@@ -163,7 +164,7 @@ void _impl_k_timer_stop(struct k_timer *timer)
 	}
 
 	key = irq_lock();
-	struct k_thread *pending_thread = _unpend_first_thread(&timer->wait_q);
+	struct k_thread *pending_thread = _unpend1_no_timeout(&timer->wait_q);
 
 	if (pending_thread) {
 		_ready_thread(pending_thread);

--- a/kernel/timer.c
+++ b/kernel/timer.c
@@ -9,7 +9,6 @@
 #include <init.h>
 #include <wait_q.h>
 #include <syscall_handler.h>
-#include <kswap.h>
 
 extern struct k_timer _k_timer_list_start[];
 extern struct k_timer _k_timer_list_end[];

--- a/lib/posix/pthread_barrier.c
+++ b/lib/posix/pthread_barrier.c
@@ -23,7 +23,7 @@ int pthread_barrier_wait(pthread_barrier_t *b)
 		while (!sys_dlist_is_empty(&b->wait_q)) {
 			ready_one_thread(&b->wait_q);
 		}
-		return _reschedule_noyield(key);
+		return _reschedule(key);
 	} else {
 		return _pend_current_thread(key, &b->wait_q, K_FOREVER);
 	}

--- a/lib/posix/pthread_barrier.c
+++ b/lib/posix/pthread_barrier.c
@@ -9,8 +9,6 @@
 #include <ksched.h>
 #include <wait_q.h>
 
-void ready_one_thread(_wait_q_t *wq);
-
 int pthread_barrier_wait(pthread_barrier_t *b)
 {
 	int key = irq_lock();
@@ -21,7 +19,7 @@ int pthread_barrier_wait(pthread_barrier_t *b)
 		b->count = 0;
 
 		while (!sys_dlist_is_empty(&b->wait_q)) {
-			ready_one_thread(&b->wait_q);
+			_ready_one_thread(&b->wait_q);
 		}
 		return _reschedule(key);
 	} else {

--- a/lib/posix/pthread_barrier.c
+++ b/lib/posix/pthread_barrier.c
@@ -24,14 +24,9 @@ int pthread_barrier_wait(pthread_barrier_t *b)
 		while (!sys_dlist_is_empty(&b->wait_q)) {
 			ready_one_thread(&b->wait_q);
 		}
-
-		if (!__must_switch_threads()) {
-			irq_unlock(key);
-			return 0;
-		}
 	} else {
 		_pend_current_thread(&b->wait_q, K_FOREVER);
 	}
 
-	return _Swap(key);
+	return _reschedule_noyield(key);
 }

--- a/lib/posix/pthread_barrier.c
+++ b/lib/posix/pthread_barrier.c
@@ -8,7 +8,6 @@
 #include <posix/pthread.h>
 #include <ksched.h>
 #include <wait_q.h>
-#include <kswap.h>
 
 void ready_one_thread(_wait_q_t *wq);
 

--- a/lib/posix/pthread_barrier.c
+++ b/lib/posix/pthread_barrier.c
@@ -24,9 +24,8 @@ int pthread_barrier_wait(pthread_barrier_t *b)
 		while (!sys_dlist_is_empty(&b->wait_q)) {
 			ready_one_thread(&b->wait_q);
 		}
+		return _reschedule_noyield(key);
 	} else {
-		_pend_current_thread(&b->wait_q, K_FOREVER);
+		return _pend_current_thread(key, &b->wait_q, K_FOREVER);
 	}
-
-	return _reschedule_noyield(key);
 }

--- a/lib/posix/pthread_common.c
+++ b/lib/posix/pthread_common.c
@@ -10,15 +10,6 @@
 #include <posix/pthread.h>
 #include <posix/time.h>
 
-void ready_one_thread(_wait_q_t *wq)
-{
-	struct k_thread *th = _unpend_first_thread(wq);
-
-	if (th) {
-		_ready_thread(th);
-	}
-}
-
 s64_t timespec_to_timeoutms(const struct timespec *abstime)
 {
 	s64_t milli_secs;

--- a/lib/posix/pthread_common.c
+++ b/lib/posix/pthread_common.c
@@ -15,7 +15,6 @@ void ready_one_thread(_wait_q_t *wq)
 	struct k_thread *th = _unpend_first_thread(wq);
 
 	if (th) {
-		_abort_thread_timeout(th);
 		_ready_thread(th);
 	}
 }

--- a/lib/posix/pthread_cond.c
+++ b/lib/posix/pthread_cond.c
@@ -22,7 +22,7 @@ static int cond_wait(pthread_cond_t *cv, pthread_mutex_t *mut, int timeout)
 	ready_one_thread(&mut->sem->wait_q);
 	_pend_current_thread(&cv->wait_q, timeout);
 
-	ret = _Swap(key);
+	ret = _reschedule_yield(key);
 
 	/* FIXME: this extra lock (and the potential context switch it
 	 * can cause) could be optimized out.  At the point of the
@@ -47,25 +47,13 @@ static int cond_wait(pthread_cond_t *cv, pthread_mutex_t *mut, int timeout)
  *
  * https://blog.mozilla.org/nfroyd/2017/03/29/on-mutex-performance-part-1/
  */
-static void swap_or_unlock(int key)
-{
-	/* API madness: use __ not _ here.  The latter checks for our
-	 * preemption state, but we want to do a switch here even if
-	 * we can be preempted.
-	 */
-	if (!_is_in_isr() && __must_switch_threads()) {
-		_Swap(key);
-	} else {
-		irq_unlock(key);
-	}
-}
 
 int pthread_cond_signal(pthread_cond_t *cv)
 {
 	int key = irq_lock();
 
 	ready_one_thread(&cv->wait_q);
-	swap_or_unlock(key);
+	reschedule_yield(key);
 
 	return 0;
 }
@@ -78,7 +66,7 @@ int pthread_cond_broadcast(pthread_cond_t *cv)
 		ready_one_thread(&cv->wait_q);
 	}
 
-	swap_or_unlock(key);
+	reschedule_yield(key);
 
 	return 0;
 }

--- a/lib/posix/pthread_cond.c
+++ b/lib/posix/pthread_cond.c
@@ -20,9 +20,7 @@ static int cond_wait(pthread_cond_t *cv, pthread_mutex_t *mut, int timeout)
 
 	mut->sem->count = 1;
 	ready_one_thread(&mut->sem->wait_q);
-	_pend_current_thread(&cv->wait_q, timeout);
-
-	ret = _reschedule_yield(key);
+	ret = _pend_current_thread(&cv->wait_q, timeout);
 
 	/* FIXME: this extra lock (and the potential context switch it
 	 * can cause) could be optimized out.  At the point of the

--- a/lib/posix/pthread_cond.c
+++ b/lib/posix/pthread_cond.c
@@ -19,7 +19,7 @@ static int cond_wait(pthread_cond_t *cv, pthread_mutex_t *mut, int timeout)
 
 	mut->sem->count = 1;
 	ready_one_thread(&mut->sem->wait_q);
-	ret = _pend_current_thread(&cv->wait_q, timeout);
+	ret = _pend_current_thread(key, &cv->wait_q, timeout);
 
 	/* FIXME: this extra lock (and the potential context switch it
 	 * can cause) could be optimized out.  At the point of the
@@ -50,7 +50,7 @@ int pthread_cond_signal(pthread_cond_t *cv)
 	int key = irq_lock();
 
 	ready_one_thread(&cv->wait_q);
-	reschedule_yield(key);
+	_reschedule(key);
 
 	return 0;
 }
@@ -63,7 +63,7 @@ int pthread_cond_broadcast(pthread_cond_t *cv)
 		ready_one_thread(&cv->wait_q);
 	}
 
-	reschedule_yield(key);
+	_reschedule(key);
 
 	return 0;
 }

--- a/lib/posix/pthread_cond.c
+++ b/lib/posix/pthread_cond.c
@@ -7,7 +7,6 @@
 #include <kernel.h>
 #include <ksched.h>
 #include <wait_q.h>
-#include <kswap.h>
 #include <posix/pthread.h>
 
 void ready_one_thread(_wait_q_t *wq);

--- a/tests/kernel/threads/lifecycle/lifecycle_api/src/main.c
+++ b/tests/kernel/threads/lifecycle/lifecycle_api/src/main.c
@@ -20,9 +20,6 @@ extern void test_threads_spawn_forever(void);
 extern void test_thread_start(void);
 extern void test_threads_suspend_resume_cooperative(void);
 extern void test_threads_suspend_resume_preemptible(void);
-extern void test_threads_cancel_undelayed(void);
-extern void test_threads_cancel_delayed(void);
-extern void test_threads_cancel_started(void);
 extern void test_threads_abort_self(void);
 extern void test_threads_abort_others(void);
 extern void test_threads_abort_repeat(void);
@@ -52,9 +49,6 @@ void test_main(void)
 			 ztest_unit_test(test_threads_suspend_resume_cooperative),
 			 ztest_unit_test(test_threads_suspend_resume_preemptible),
 			 ztest_unit_test(test_threads_priority_set),
-			 ztest_user_unit_test(test_threads_cancel_undelayed),
-			 ztest_user_unit_test(test_threads_cancel_delayed),
-			 ztest_user_unit_test(test_threads_cancel_started),
 			 ztest_user_unit_test(test_threads_abort_self),
 			 ztest_user_unit_test(test_threads_abort_others),
 			 ztest_unit_test(test_threads_abort_repeat),

--- a/tests/kernel/threads/lifecycle/lifecycle_api/src/test_threads_cancel_abort.c
+++ b/tests/kernel/threads/lifecycle/lifecycle_api/src/test_threads_cancel_abort.c
@@ -37,63 +37,6 @@ static void thread_entry_abort(void *p1, void *p2, void *p3)
 	zassert_true(1 == 0, NULL);
 }
 
-/*test cases*/
-void test_threads_cancel_undelayed(void)
-{
-	int cur_prio = k_thread_priority_get(k_current_get());
-
-	/* spawn thread with lower priority */
-	int spawn_prio = cur_prio + 1;
-
-	k_tid_t tid = k_thread_create(&tdata, tstack, STACK_SIZE,
-				      thread_entry, NULL, NULL, NULL,
-				      spawn_prio, K_USER, 0);
-
-	/**TESTPOINT: check cancel retcode when thread is not delayed*/
-	int cancel_ret = k_thread_cancel(tid);
-
-	zassert_equal(cancel_ret, -EINVAL, NULL);
-	k_thread_abort(tid);
-}
-
-void test_threads_cancel_started(void)
-{
-	int cur_prio = k_thread_priority_get(k_current_get());
-
-	/* spawn thread with lower priority */
-	int spawn_prio = cur_prio + 1;
-
-	k_tid_t tid = k_thread_create(&tdata, tstack, STACK_SIZE,
-				      thread_entry, NULL, NULL, NULL,
-				      spawn_prio, K_USER, 0);
-
-	k_sleep(50);
-	/**TESTPOINT: check cancel retcode when thread is started*/
-	int cancel_ret = k_thread_cancel(tid);
-
-	zassert_equal(cancel_ret, -EINVAL, NULL);
-	k_thread_abort(tid);
-}
-
-void test_threads_cancel_delayed(void)
-{
-	int cur_prio = k_thread_priority_get(k_current_get());
-
-	/* spawn thread with lower priority */
-	int spawn_prio = cur_prio + 1;
-
-	k_tid_t tid = k_thread_create(&tdata, tstack, STACK_SIZE,
-				      thread_entry, NULL, NULL, NULL,
-				      spawn_prio, K_USER, 100);
-
-	k_sleep(50);
-	/**TESTPOINT: check cancel retcode when thread is started*/
-	int cancel_ret = k_thread_cancel(tid);
-
-	zassert_equal(cancel_ret, 0, NULL);
-	k_thread_abort(tid);
-}
-
 void test_threads_abort_self(void)
 {
 	execute_flag = 0;


### PR DESCRIPTION
Big pull request which in theory shouldn't change any behavior (only done sanitycheck over tests/kernel, and only on x86 so far though!).

The net effect is to eliminate most of the use of our fine-grained scheduler tooling in favor of coarser functions with clear semantics, easier replaceability, and (most importantly) clean synchronization expectations instead of "must be called with irq_lock held" all over the place.  Almost everything comes down to:

1. Pend the current thread and context switch to whatever is next
2. Unpend one thread from a wait_q and make it runnable
3. Unpend a specific thread from wherever it is sleeping
4. Check the scheduling context and context switch ("_reschedule") if needed

