### PR TITLE
drivers: sensor: temp_nrf5: fix sensor type

### DIFF
--- a/drivers/sensor/nrf5/temp_nrf5.c
+++ b/drivers/sensor/nrf5/temp_nrf5.c
@@ -36,7 +36,7 @@ static int temp_nrf5_sample_fetch(struct device *dev, enum sensor_channel chan)
 
 	SYS_LOG_DBG("");
 
-	if (chan != SENSOR_CHAN_ALL && chan != SENSOR_CHAN_AMBIENT_TEMP) {
+	if (chan != SENSOR_CHAN_ALL && chan != SENSOR_CHAN_DIE_TEMP) {
 		return -ENOTSUP;
 	}
 
@@ -69,7 +69,7 @@ static int temp_nrf5_channel_get(struct device *dev,
 
 	SYS_LOG_DBG("");
 
-	if (chan != SENSOR_CHAN_AMBIENT_TEMP) {
+	if (chan != SENSOR_CHAN_DIE_TEMP) {
 		return -ENOTSUP;
 	}
 


### PR DESCRIPTION
The sensor channel type for the nRF TEMP peripheral is incorrectly set
to SENSOR_CHAN_AMBIENT_TEMP. This peripheral measures die temperature,
not ambient temperature.

Fix the sensor channel.
