### PR TITLE
ci: Increase number of build slaves to 5

### DIFF
--- a/.shippable.yml
+++ b/.shippable.yml
@@ -9,13 +9,14 @@ env:
         - SANITYCHECK_OPTIONS_RETRY="${SANITYCHECK_OPTIONS} --only-failed --outdir=out-2nd-pass"
         - ZEPHYR_SDK_INSTALL_DIR=/opt/sdk/zephyr-sdk-0.9.2
         - ZEPHYR_TOOLCHAIN_VARIANT=zephyr
-        - MATRIX_BUILDS="4"
-        - MATRIX_BUILDS_EXTRA="4"
+        - MATRIX_BUILDS="5"
+        - MATRIX_BUILDS_EXTRA="5"
     matrix:
         - MATRIX_BUILD="1"
         - MATRIX_BUILD="2"
         - MATRIX_BUILD="3"
         - MATRIX_BUILD="4"
+        - MATRIX_BUILD="5"
 
 build:
     cache: true
@@ -36,7 +37,7 @@ build:
       - source zephyr-env.sh
       - ccache -c -s --max-size=2000M
       - >
-          if [ "$MATRIX_BUILD" = "4" -a "$IS_PULL_REQUEST" = "true" ]; then
+          if [ "$MATRIX_BUILD" = "5" -a "$IS_PULL_REQUEST" = "true" ]; then
             export COMMIT_RANGE=origin/${PULL_REQUEST_BASE_BRANCH}..HEAD
             echo "Building a Pull Request";
             echo "- Building Documentation";


### PR DESCRIPTION
To try and improve CI builds related to pull requests lets bump up the
number of build slaves to 5 to increase throughput.

Signed-off-by: Kumar Gala <kumar.gala@linaro.org>