### PR TITLE
Fix Test kernel arm irq vector table

### DIFF
--- a/drivers/timer/nrf_rtc_timer.c
+++ b/drivers/timer/nrf_rtc_timer.c
@@ -452,7 +452,7 @@ void _timer_idle_exit(void)
  * this example. The ISR will then announce the number of sys ticks it was
  * delayed (2), and schedule the next sys tick (5) at 500.
  */
-static void rtc1_nrf5_isr(void *arg)
+void rtc1_nrf5_isr(void *arg)
 {
 
 	ARG_UNUSED(arg);

--- a/tests/kernel/arm_irq_vector_table/README.txt
+++ b/tests/kernel/arm_irq_vector_table/README.txt
@@ -3,7 +3,7 @@ Title: Installation of ISRs Directly in the Vector Table (ARM Only)
 Description:
 
 Verify a project can install ISRs directly in the vector table. Only for
-ARM Cortex-M3/4 targets.
+ARM Cortex-M3/4/7/33 targets.
 
 ---------------------------------------------------------------------------
 

--- a/tests/kernel/arm_irq_vector_table/prj.conf
+++ b/tests/kernel/arm_irq_vector_table/prj.conf
@@ -3,3 +3,5 @@ CONFIG_ZTEST_STACKSIZE=512
 CONFIG_MAIN_STACK_SIZE=512
 CONFIG_GEN_ISR_TABLES=n
 CONFIG_NUM_IRQS=3
+# Force Bluetooth disable (required by platforms that enable Bluetooth by default)
+CONFIG_BT=n


### PR DESCRIPTION
This PR fixes the UsageFault error in irq_vector_table test for nRF52x-based platforms, reported in #6890.

Fixes #6890