### PR TITLE
ARM: -march compile option is not set

### DIFF
--- a/arch/arm/CMakeLists.txt
+++ b/arch/arm/CMakeLists.txt
@@ -9,7 +9,7 @@ set(ARCH_FOR_cortex-m33    armv8-m.main)
 
 set_property(GLOBAL PROPERTY E_KERNEL_ENTRY  -e${CONFIG_KERNEL_ENTRY})
 
-if(${ARCH_FOR_${GCC_M_CPU}})
+if(ARCH_FOR_${GCC_M_CPU})
     set(ARCH_FLAG -march=${ARCH_FOR_${GCC_M_CPU}})
 endif()
 


### PR DESCRIPTION
Removing ${} variable evaluation fixes the issue.

For sam4s_xplained:

Before:
```
/repos/zephyr/samples/hello_world/build$ make VERBOSE=1 | grep march
/repos/zephyr/samples/hello_world/build$
```

After:
```
/repos/zephyr/samples/hello_world/build$ make VERBOSE=1 | grep march
...
-mthumb -mcpu=cortex-m4 -march=armv7e-m
...
```

Signed-off-by: Paolo Teti <paolo.teti@gmail.com>