### PR TITLE
cmake: qemu_x86: remove useless options

### DIFF
--- a/boards/x86/qemu_x86/board.cmake
+++ b/boards/x86/qemu_x86/board.cmake
@@ -17,8 +17,6 @@ set(QEMU_FLAGS_${ARCH}
   -clock dynticks
   -no-acpi
   -balloon none
-  -L ${QEMU_BIOS}
-  -bios bios.bin
   -machine type=pc-0.14
   )
 


### PR DESCRIPTION
BIOS options are unnecessary and were breaking 'make run' on
OS X.

Change-Id: I8b3bd3cd08cc43b46099910b625d629629c9579a
Signed-off-by: Andrew Boie <andrew.p.boie@intel.com>