### PR TITLE
drivers/spi: Fix tmod update on DW driver

### DIFF
--- a/drivers/spi/spi_dw.c
+++ b/drivers/spi/spi_dw.c
@@ -256,9 +256,9 @@ static int spi_dw_configure(const struct spi_dw_config *info,
 	spi_context_cs_configure(&spi->ctx);
 
 	if (spi_dw_is_slave(spi)) {
-		SYS_LOG_DBG("Installed slave config %p: slave_cb %p,"
+		SYS_LOG_DBG("Installed slave config %p:"
 			    " ws/dfs %u/%u, mode %u/%u/%u",
-			    config, config->slave_cb,
+			    config,
 			    SPI_WORD_SIZE_GET(config->operation), spi->dfs,
 			    (SPI_MODE_GET(config->operation) &
 			     SPI_MODE_CPOL) ? 1 : 0,
@@ -366,7 +366,6 @@ static int transceive(struct device *dev,
 		write_ctrlr1(0, info->regs);
 	}
 
-
 	if (spi_dw_is_slave(spi)) {
 		/* Enabling MISO line relevantly */
 		if (tmod == DW_SPI_CTRLR0_TMOD_RX) {
@@ -377,7 +376,11 @@ static int transceive(struct device *dev,
 	}
 
 	/* Updating TMOD in CTRLR0 register */
-	write_ctrlr0(read_ctrlr0(info->regs) | tmod, info->regs);
+	reg_data = read_ctrlr0(info->regs);
+	reg_data &= ~DW_SPI_CTRLR0_TMOD_RESET;
+	reg_data |= tmod;
+
+	write_ctrlr0(reg_data, info->regs);
 
 	/* Set buffers info */
 	spi_context_buffers_setup(&spi->ctx, tx_bufs, rx_bufs, spi->dfs);

--- a/drivers/spi/spi_dw.h
+++ b/drivers/spi/spi_dw.h
@@ -114,6 +114,7 @@ struct spi_dw_data {
 #define DW_SPI_CTRLR0_TMOD_TX		(1 << DW_SPI_CTRLR0_TMOD_SHIFT)
 #define DW_SPI_CTRLR0_TMOD_RX		(2 << DW_SPI_CTRLR0_TMOD_SHIFT)
 #define DW_SPI_CTRLR0_TMOD_EEPROM	(3 << DW_SPI_CTRLR0_TMOD_SHIFT)
+#define DW_SPI_CTRLR0_TMOD_RESET	(3 << DW_SPI_CTRLR0_TMOD_SHIFT)
 
 #define DW_SPI_CTRLR0_DFS_16(__bpw)	((__bpw) - 1)
 #define DW_SPI_CTRLR0_DFS_32(__bpw)	(((__bpw) - 1) << 16)


### PR DESCRIPTION
Logical or is unsufficent for setting up new tmod: it's required to
remove previous one first. Indeed, 0 as tmod is valid (tx-rx mode), but
previous tmod could be 10 or 01, so a logical or will keep the previous
tmod leading to a bogus transaction.

Fixing also a rebase issue visible when debug mode is enabled. Slave
callback is a left over from a test on spi slave.

Signed-off-by: Tomasz Bursztyka <tomasz.bursztyka@linux.intel.com>