### PR TITLE
kconfiglib: Update to 981d24aff7654

### DIFF
--- a/scripts/kconfig/kconfiglib.py
+++ b/scripts/kconfig/kconfiglib.py
@@ -633,6 +633,7 @@ class Kconfig(object):
         self.top_node = MenuNode()
         self.top_node.kconfig = self
         self.top_node.item = MENU
+        self.top_node.is_menuconfig = True
         self.top_node.visibility = self.y
         self.top_node.prompt = ("Linux Kernel Configuration", self.y)
         self.top_node.parent = None
@@ -1967,8 +1968,8 @@ class Kconfig(object):
                 node = MenuNode()
                 node.kconfig = self
                 node.item = choice
-                node.prompt = node.help = None
                 node.is_menuconfig = True
+                node.prompt = node.help = None
                 node.parent = parent
                 node.filename = self._filename
                 node.linenr = self._linenr


### PR DESCRIPTION
Update Kconfiglib to upstream revision 981d24aff7654 (+ local Zephyr
modifications) to get commit 981d24aff7654 ("Set is_menuconfig True on
the top menu") in. It will be needed by the menuconfig implementation.

Origin: https://github.com/zephyrproject-rtos/Kconfiglib/tree/zephyr

Signed-off-by: Ulf Magnusson <ulfalizer@gmail.com>