### PR TITLE
net: core: Check interface when receiving a packet

### DIFF
--- a/subsys/net/ip/net_core.c
+++ b/subsys/net/ip/net_core.c
@@ -336,8 +336,9 @@ static void net_queue_rx(struct net_if *iface, struct net_pkt *pkt)
 /* Called by driver when an IP packet has been received */
 int net_recv_data(struct net_if *iface, struct net_pkt *pkt)
 {
-	NET_ASSERT(pkt && pkt->frags);
-	NET_ASSERT(iface);
+	if (!pkt || !iface) {
+		return -EINVAL;
+	}
 
 	if (!pkt->frags) {
 		return -ENODATA;


### PR DESCRIPTION
Although very unlikely, make sure that if the net_recv_data() is
called with NULL network interface or packet, we recover that and
return error to the caller.

Signed-off-by: Jukka Rissanen <jukka.rissanen@linux.intel.com>