### PR TITLE
 mimxrt1050_evk: Add config to select code linking location

### DIFF
--- a/arch/arm/soc/nxp_imx/rt/arm_mpu_mem_cfg.h
+++ b/arch/arm/soc/nxp_imx/rt/arm_mpu_mem_cfg.h
@@ -22,6 +22,10 @@
 #define REGION_FLASH_SIZE REGION_1M
 #elif CONFIG_FLASH_SIZE == 2048
 #define REGION_FLASH_SIZE REGION_2M
+#elif CONFIG_FLASH_SIZE == 8192
+#define REGION_FLASH_SIZE REGION_8M
+#elif CONFIG_FLASH_SIZE == 65536
+#define REGION_FLASH_SIZE REGION_64M
 #else
 #error "Unsupported configuration"
 #endif
@@ -35,6 +39,8 @@
 #define REGION_SRAM_0_SIZE REGION_128K
 #elif CONFIG_SRAM_SIZE == 256
 #define REGION_SRAM_0_SIZE REGION_256K
+#elif CONFIG_SRAM_SIZE == 32768
+#define REGION_SRAM_0_SIZE REGION_32M
 #else
 #error "Unsupported configuration"
 #endif

--- a/boards/arm/mimxrt1050_evk/Kconfig
+++ b/boards/arm/mimxrt1050_evk/Kconfig
@@ -1,0 +1,24 @@
+#
+# Copyright (c) 2018, NXP
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+
+if BOARD_MIMXRT1050_EVK
+
+choice
+	prompt "Code location selection"
+	default CODE_ITCM
+
+config CODE_ITCM
+	bool "Link code into internal instruction tightly coupled memory (ITCM)"
+
+config CODE_HYPERFLASH
+	bool "Link code into external HyperFlash memory"
+
+config CODE_QSPI
+	bool "Link code into external QSPI memory"
+
+endchoice
+
+endif # BOARD_MIMXRT1050_EVK

--- a/boards/arm/mimxrt1050_evk/Kconfig.defconfig
+++ b/boards/arm/mimxrt1050_evk/Kconfig.defconfig
@@ -36,4 +36,12 @@ config UART_MCUX_LPUART_1
 
 endif # UART_MCUX_LPUART
 
+if CODE_HYPERFLASH || CODE_QSPI
+
+# Reserve space for the IVT
+config TEXT_SECTION_OFFSET
+	default 0x2000
+
+endif
+
 endif # BOARD_MIMXRT1050_EVK

--- a/boards/arm/mimxrt1050_evk/mimxrt1050_evk.dts
+++ b/boards/arm/mimxrt1050_evk/mimxrt1050_evk.dts
@@ -26,6 +26,26 @@
 		zephyr,sram = &dtcm0;
 		zephyr,console = &uart1;
 	};
+
+	sdram0: memory@80000000 {
+		/* Micron MT48LC16M16A2B4-6AIT:G */
+		device_type = "memory";
+		reg = <0x80000000 0x2000000>;
+	};
+};
+
+&flexspi0 {
+	hyperflash0: hyperflash@0 {
+		/* Cypress S26KS512SDPBHI02 */
+		reg = <0x60000000 0x4000000>;
+		status = "disabled";
+	};
+
+	qspi0: qspi@0 {
+		/* ISSI IS25WP064AJBLE */
+		reg = <0x60000000 0x800000>;
+		status = "disabled";
+	};
 };
 
 &uart1 {

--- a/boards/arm/mimxrt1050_evk/mimxrt1050_evk.dts
+++ b/boards/arm/mimxrt1050_evk/mimxrt1050_evk.dts
@@ -22,7 +22,13 @@
 	};
 
 	chosen {
+#if defined(CONFIG_CODE_ITCM)
 		zephyr,flash = &itcm0;
+#elif defined(CONFIG_CODE_HYPERFLASH)
+		zephyr,flash = &hyperflash0;
+#elif defined(CONFIG_CODE_QSPI)
+		zephyr,flash = &qspi0;
+#endif
 		zephyr,sram = &dtcm0;
 		zephyr,console = &uart1;
 	};
@@ -38,13 +44,21 @@
 	hyperflash0: hyperflash@0 {
 		/* Cypress S26KS512SDPBHI02 */
 		reg = <0x60000000 0x4000000>;
+#if defined(CONFIG_CODE_HYPERFLASH)
+		status = "ok";
+#else
 		status = "disabled";
+#endif
 	};
 
 	qspi0: qspi@0 {
 		/* ISSI IS25WP064AJBLE */
 		reg = <0x60000000 0x800000>;
+#if defined(CONFIG_CODE_QSPI)
+		status = "ok";
+#else
 		status = "disabled";
+#endif
 	};
 };
 

--- a/dts/arm/nxp/nxp_rt.dtsi
+++ b/dts/arm/nxp/nxp_rt.dtsi
@@ -41,6 +41,24 @@
 			};
 		};
 
+		flexspi0: flexspi0@402a8000 {
+			compatible = "nxp,imx-flexspi";
+			reg = <0x402a8000 0x4000>;
+			interrupts = <108 0>;
+			label = "FLEXSPI0";
+			#address-cells = <1>;
+			#size-cells = <1>;
+		};
+
+		semc0: semc0@402f0000 {
+			compatible = "nxp,imx-semc";
+			reg = <0x402f0000 0x4000>;
+			interrupts = <109 0>;
+			label = "SEMC0";
+			#address-cells = <1>;
+			#size-cells = <1>;
+		};
+
 		ccm: ccm@400fc000 {
 			compatible = "nxp,imx-ccm";
 			reg = <0x400fc000 0x4000>;

--- a/dts/bindings/memory-controllers/nxp,imx-semc.yaml
+++ b/dts/bindings/memory-controllers/nxp,imx-semc.yaml
@@ -1,0 +1,39 @@
+#
+# Copyright (c) 2018, NXP
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+---
+title: NXP SEMC
+id: nxp,imx-semc
+version: 0.1
+
+description: >
+    This binding gives a base representation of the NXP smart external memory
+    controller (SEMC)
+
+properties:
+    compatible:
+      type: string
+      category: required
+      description: compatible strings
+      constraint: "nxp,imx-semc"
+
+    reg:
+      type: array
+      description: mmio register space
+      generation: define
+      category: required
+
+    interrupts:
+      type: array
+      category: required
+      description: required interrupts
+      generation: define
+
+    label:
+      type: string
+      category: required
+      description: Human readable string describing the device (used by Zephyr for API name)
+      generation: define
+...

--- a/dts/bindings/spi/nxp,imx-flexspi.yaml
+++ b/dts/bindings/spi/nxp,imx-flexspi.yaml
@@ -1,0 +1,35 @@
+#
+# Copyright (c) 2018, NXP
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+---
+title: NXP FlexSPI
+id: nxp,imx-flexspi
+version: 0.1
+
+description: >
+    This binding gives a base representation of the NXP FlexSPI controller
+
+inherits:
+    !include spi.yaml
+
+properties:
+    compatible:
+      type: string
+      category: required
+      description: compatible strings
+      constraint: "nxp,imx-flexspi"
+
+    reg:
+      type: array
+      description: mmio register space
+      generation: define
+      category: required
+
+    interrupts:
+      type: array
+      category: required
+      description: required interrupts
+      generation: define
+...


### PR DESCRIPTION
Adds a board-level config option to select whether the code gets linked
into internal instruction tightly coupled memory (ITCM), external
hyperflash, or external qspi flash. The default is ITCM.

Note that we are not yet building an image vector table (IVT) into the
image, therefore the zephyr binary is not bootable by the SoC ROM as-is.
However, the DAPLink firmware prepends an IVT to the image when you use
its drag-and-drop feature to program flash, and this results in a
bootable zephyr application.

Signed-off-by: Maureen Helm <maureen.helm@nxp.com>