### PR TITLE
doc: fix misspellings in Kconfig files

### DIFF
--- a/drivers/ethernet/Kconfig.enc28j60
+++ b/drivers/ethernet/Kconfig.enc28j60
@@ -84,7 +84,7 @@ config ETH_ENC28J60_0_SLAVE
 	  ENC28J60C chip select pin.
 
 config ETH_ENC28J60_0_GPIO_SPI_CS
-	bool "Manage SPI CS throug a GPIO pin"
+	bool "Manage SPI CS through a GPIO pin"
 	default n
 	help
 	This option is useful if one needs to manage SPI CS through a GPIO

--- a/subsys/net/ip/Kconfig
+++ b/subsys/net/ip/Kconfig
@@ -50,8 +50,8 @@ config NET_TC_TX_COUNT
 	help
 	  Define how many Tx traffic classes (queues) the system should have
 	  when sending a network packet. The network packet priority can then
-	  be mapped to this traffic class so that higher prioritised packets
-	  can be processed before lower prioritised ones. Each queue is handled
+	  be mapped to this traffic class so that higher prioritized packets
+	  can be processed before lower prioritized ones. Each queue is handled
 	  by a separate thread which will need RAM for stack space.
 	  Only increase the value from 1 if you really need this feature.
 	  The default value is 1 which means that all the network traffic is
@@ -65,8 +65,8 @@ config NET_TC_RX_COUNT
 	help
 	  Define how many Rx traffic classes (queues) the system should have
 	  when receiving a network packet. The network packet priority can then
-	  be mapped to this traffic class so that higher prioritised packets
-	  can be processed before lower prioritised ones. Each queue is handled
+	  be mapped to this traffic class so that higher prioritized packets
+	  can be processed before lower prioritized ones. Each queue is handled
 	  by a separate thread which will need RAM for stack space.
 	  Only increase the value from 1 if you really need this feature.
 	  The default value is 1 which means that all the network traffic is


### PR DESCRIPTION
occasional spelling-check scan found some misspellings

Signed-off-by: David B. Kinder <david.b.kinder@intel.com>