### PR TITLE
doc: misspellings in public API doxygen comments

### DIFF
--- a/include/crc16.h
+++ b/include/crc16.h
@@ -48,7 +48,7 @@ u16_t crc16(const u8_t *src, size_t len, u16_t polynomial,
  * See ITU-T Recommendation V.41 (November 1988).  Uses 0x1021 as the
  * polynomial, reflects the input, and reflects the output.
  *
- * To calculate the CRC across non-contigious blocks use the return
+ * To calculate the CRC across non-contiguous blocks use the return
  * value from block N-1 as the seed for block N.
  *
  * For CRC-16/CCITT, use 0 as the initial seed.  Other checksums in
@@ -73,7 +73,7 @@ u16_t crc16_ccitt(u16_t seed, const u8_t *src, size_t len);
  * The MSB first version of ITU-T Recommendation V.41 (November 1988).
  * Uses 0x1021 as the polynomial with no reflection.
  *
- * To calculate the CRC across non-contigious blocks use the return
+ * To calculate the CRC across non-contiguous blocks use the return
  * value from block N-1 as the seed for block N.
  *
  * For CRC-16/XMODEM, use 0 as the initial seed.  Other checksums in

--- a/include/fs.h
+++ b/include/fs.h
@@ -220,7 +220,7 @@ int fs_unlink(const char *path);
  * must contain a full filename path, rather than just the new parent
  * directory.  If an object already exists at the specified destination path,
  * this function causes it to be unlinked prior to the rename (i.e., the
- * estination gets clobbered).
+ * destination gets clobbered).
  *
  * @param from The source path.
  * @param to The destination path.

--- a/include/kernel.h
+++ b/include/kernel.h
@@ -4315,7 +4315,7 @@ __syscall void k_str_out(char *c, size_t n);
  * startup is running on CPU zero, other processors are numbered
  * sequentially.  On return from this function, the CPU is known to
  * have begun operating and will enter the provided function.  Its
- * interrupts will be initialied but disabled such that irq_unlock()
+ * interrupts will be initialized but disabled such that irq_unlock()
  * with the provided key will work to enable them.
  *
  * Normally, in SMP mode this function will be called by the kernel

--- a/include/net/buf.h
+++ b/include/net/buf.h
@@ -448,8 +448,8 @@ static inline void net_buf_simple_restore(struct net_buf_simple *buf,
 /** Flag indicating that the buffer's associated data pointer, points to
  * externally allocated memory. Therefore once ref goes down to zero, the
  * pointed data will not need to be deallocated. This never needs to be
- * explicitely set or unet by the net_buf API user. Such net_buf is
- * exclusively instanciated via net_buf_alloc_with_data() function.
+ * explicitly set or unet by the net_buf API user. Such net_buf is
+ * exclusively instantiated via net_buf_alloc_with_data() function.
  * Reference count mechanism however will behave the same way, and ref
  * count going to 0 will free the net_buf but no the data pointer in it.
  */

--- a/include/stats.h
+++ b/include/stats.h
@@ -318,7 +318,7 @@ int stats_group_walk(stats_group_walk_fn *walk_cb, void *arg);
 /**
  * @brief Retrieves the next registered statistics group.
  *
- * @param cur                   The group whose sucessor is being retrieved, or
+ * @param cur                   The group whose successor is being retrieved, or
  *                                  NULL to retrieve the first group.
  *
  * @return                      Pointer to the retrieved group on success;


### PR DESCRIPTION
occasional spelling-check pass found some misspellings

Signed-off-by: David B. Kinder <david.b.kinder@intel.com>