### PR TITLE
net: l2: Remove l2_data section start and end pointers

### DIFF
--- a/include/net/net_l2.h
+++ b/include/net/net_l2.h
@@ -60,8 +60,6 @@ struct net_l2 {
 	extern const struct net_l2 NET_L2_GET_NAME(_name)
 #define NET_L2_GET_CTX_TYPE(_name) _name##_CTX_TYPE
 
-extern struct net_l2 __net_l2_start[];
-
 #ifdef CONFIG_NET_L2_DUMMY
 #define DUMMY_L2		DUMMY
 #define DUMMY_L2_CTX_TYPE	void*
@@ -94,8 +92,6 @@ NET_L2_DECLARE_PUBLIC(OFFLOAD_IP);
 #define OPENTHREAD_L2		OPENTHREAD
 NET_L2_DECLARE_PUBLIC(OPENTHREAD_L2);
 #endif /* CONFIG_NET_L2_OPENTHREAD */
-
-extern struct net_l2 __net_l2_end[];
 
 #define NET_L2_INIT(_name, _recv_fn, _send_fn, _reserve_fn, _enable_fn)	\
 	const struct net_l2 (NET_L2_GET_NAME(_name)) __used		\


### PR DESCRIPTION
As the l2_data section might contain different size context elements
like "struct ethernet_context" for Ethernet and "void *" for
Dummy L2, remove the __net_l2_start and __net_l2_end variables so
that user does not accidentally try to use them as that would not work.

Signed-off-by: Jukka Rissanen <jukka.rissanen@linux.intel.com>