### PR TITLE
doc: subsys: Remove unnecessary subsystem from titles

### DIFF
--- a/doc/subsystems/dfu.rst
+++ b/doc/subsystems/dfu.rst
@@ -1,7 +1,7 @@
 .. _dfu:
 
-Device Firmware Upgrade Subsystem
-#################################
+Device Firmware Upgrade
+#######################
 
 Overview
 ********

--- a/doc/subsystems/mgmt.rst
+++ b/doc/subsystems/mgmt.rst
@@ -1,7 +1,7 @@
 .. _mgmt:
 
-Management Subsystem
-####################
+Management
+##########
 
 Overview
 ********


### PR DESCRIPTION
In order to be consistent with the rest of the subsystems, remove
"subsystem" from the title.

Signed-off-by: Carles Cufi <carles.cufi@nordicsemi.no>