### PR TITLE
Bluetooth: Mesh: Fix Node Identity advertising with PB-ADV

### DIFF
--- a/subsys/bluetooth/host/mesh/net.c
+++ b/subsys/bluetooth/host/mesh/net.c
@@ -481,8 +481,7 @@ int bt_mesh_net_create(u16_t idx, u8_t flags, const u8_t key[16],
 	sub->net_idx = idx;
 
 	if (IS_ENABLED(CONFIG_BT_MESH_GATT_PROXY)) {
-		sub->node_id = BT_MESH_NODE_IDENTITY_RUNNING;
-		sub->node_id_start = k_uptime_get_32();
+		sub->node_id = BT_MESH_NODE_IDENTITY_STOPPED;
 	} else {
 		sub->node_id = BT_MESH_NODE_IDENTITY_NOT_SUPPORTED;
 	}

--- a/subsys/bluetooth/host/mesh/prov.c
+++ b/subsys/bluetooth/host/mesh/prov.c
@@ -1057,6 +1057,15 @@ static void prov_data(const u8_t *data)
 	link.expect = 0;
 
 	bt_mesh_provision(pdu, net_idx, flags, iv_index, 0, addr, dev_key);
+
+#if defined(CONFIG_BT_MESH_PB_GATT) && defined(CONFIG_BT_MESH_GATT_PROXY)
+	/* After PB-GATT provisioning we should start advertising
+	 * using Node Identity.
+	 */
+	if (link.conn) {
+		bt_mesh_proxy_identity_enable();
+	}
+#endif
 }
 
 static void prov_complete(const u8_t *data)


### PR DESCRIPTION
The Node Identity advertising should only be automatically enabled
when provisioning happened over PB-GATT, but not when it happened over
PB-ADV. Move the enabling of Node Identity to the provisioning code,
where we know the bearer that was used (this information does not get
passed to the bt_mesh_provision function).

Fixes #6338

Signed-off-by: Johan Hedberg <johan.hedberg@intel.com>