### PR TITLE
net: ethernet: Return correct non VLAN interface

### DIFF
--- a/subsys/net/ip/l2/ethernet.c
+++ b/subsys/net/ip/l2/ethernet.c
@@ -545,11 +545,19 @@ static inline int ethernet_enable(struct net_if *iface, bool state)
 struct net_if *net_eth_get_vlan_iface(struct net_if *iface, u16_t tag)
 {
 	struct ethernet_context *ctx = net_if_l2_data(iface);
+	struct net_if *first_non_vlan_iface = NULL;
 	int i;
 
 	for (i = 0; i < CONFIG_NET_VLAN_COUNT; i++) {
-		if (ctx->vlan[i].tag == NET_VLAN_TAG_UNSPEC ||
-		    ctx->vlan[i].tag != tag) {
+		if (ctx->vlan[i].tag == NET_VLAN_TAG_UNSPEC) {
+			if (!first_non_vlan_iface) {
+				first_non_vlan_iface = ctx->vlan[i].iface;
+			}
+
+			continue;
+		}
+
+		if (ctx->vlan[i].tag != tag) {
 			continue;
 		}
 
@@ -559,7 +567,7 @@ struct net_if *net_eth_get_vlan_iface(struct net_if *iface, u16_t tag)
 		return ctx->vlan[i].iface;
 	}
 
-	return NULL;
+	return first_non_vlan_iface;
 }
 
 static bool enable_vlan_iface(struct ethernet_context *ctx,

--- a/tests/net/vlan/src/main.c
+++ b/tests/net/vlan/src/main.c
@@ -566,14 +566,14 @@ static void vlan_disable_test(void)
 	eth_ctx = net_if_l2_data(eth_interfaces[0]);
 
 	iface = net_eth_get_vlan_iface(eth_interfaces[0], VLAN_TAG_1);
-	zassert_equal_ptr(iface, NULL,
+	zassert_equal_ptr(iface, eth_interfaces[0],
 			  "Invalid interface for tag %d (%p vs %p)\n",
-			  VLAN_TAG_1, iface, NULL);
+			  VLAN_TAG_1, iface, eth_interfaces[0]);
 
 	iface = net_eth_get_vlan_iface(eth_interfaces[0], VLAN_TAG_2);
-	zassert_equal_ptr(iface, NULL,
+	zassert_equal_ptr(iface, eth_interfaces[0],
 			  "Invalid interface for tag %d (%p vs %p)\n",
-			  VLAN_TAG_2, iface, NULL);
+			  VLAN_TAG_2, iface, eth_interfaces[0]);
 
 	ret = net_eth_is_vlan_enabled(eth_ctx, eth_interfaces[0]);
 	zassert_equal(ret, false, "VLAN enabled for interface 0\n");


### PR DESCRIPTION
If we have several network interfaces and not all of them are
VLAN enabled, then we might return wrong network interface to
the ethernet device driver when it asks one. To fix this, return
the first interface that has not enabled VLAN if the tag of the
network packet is unspecified.

Signed-off-by: Jukka Rissanen <jukka.rissanen@linux.intel.com>