### PR TITLE
sensors: introduce kconfig named choices

### DIFF
--- a/boards/arm/disco_l475_iot1/Kconfig.defconfig
+++ b/boards/arm/disco_l475_iot1/Kconfig.defconfig
@@ -94,6 +94,15 @@ config PWM_STM32_2
 
 endif # PWM
 
+choice LIS3MDL_TRIGGER_MODE
+	default LIS3MDL_TRIGGER_NONE
+endchoice
+
+choice HTS221_TRIGGER_MODE
+	default HTS221_TRIGGER_NONE
+endchoice
+
+
 if VL53L0X
 
 config VL53L0X_XSHUT_CONTROL_ENABLE

--- a/boards/arm/disco_l475_iot1/disco_l475_iot1_defconfig
+++ b/boards/arm/disco_l475_iot1/disco_l475_iot1_defconfig
@@ -38,7 +38,3 @@ CONFIG_I2C=y
 
 # enable SPI
 CONFIG_SPI=y
-
-# sensors configuration
-CONFIG_LIS3MDL_TRIGGER_NONE=y
-CONFIG_HTS221_TRIGGER_NONE=y

--- a/drivers/sensor/hts221/Kconfig
+++ b/drivers/sensor/hts221/Kconfig
@@ -29,7 +29,7 @@ config HTS221_I2C_MASTER_DEV_NAME
 
 endif
 
-choice
+choice HTS221_TRIGGER_MODE
 	prompt "Trigger mode"
 	depends on HTS221
 	default HTS221_TRIGGER_GLOBAL_THREAD
@@ -49,7 +49,7 @@ config HTS221_TRIGGER_OWN_THREAD
 	depends on GPIO
 	select HTS221_TRIGGER
 
-endchoice
+endchoice # HTS221_TRIGGER_MODE
 
 config HTS221_TRIGGER
 	bool

--- a/drivers/sensor/lis3mdl/Kconfig
+++ b/drivers/sensor/lis3mdl/Kconfig
@@ -38,7 +38,7 @@ config LIS3MDL_I2C_MASTER_DEV_NAME
 
 endif
 
-choice
+choice LIS3MDL_TRIGGER_MODE
 	prompt "Trigger mode"
 	depends on LIS3MDL
 	default LIS3MDL_TRIGGER_GLOBAL_THREAD
@@ -58,7 +58,7 @@ config LIS3MDL_TRIGGER_OWN_THREAD
 	depends on GPIO
 	select LIS3MDL_TRIGGER
 
-endchoice
+endchoice # LIS3MDL_TRIGGER_MODE
 
 config LIS3MDL_TRIGGER
 	bool


### PR DESCRIPTION
Use Kconfig specific object "named choices".
Aim is to allow to define config choices selection in Kconfig.*
files instead of _defconfig and hence allow to keep flags
activation conditional.

When not specified, default choice value is the first option defined.
Hence, options order have been changed to keep default choices
default value unchanged.

Signed-off-by: Erwan Gouriou <erwan.gouriou@linaro.org>