### PR TITLE
ext: lib: encoding: tinycbor: fixup newlib_libc reqirement

### DIFF
--- a/ext/lib/encoding/tinycbor/Kconfig
+++ b/ext/lib/encoding/tinycbor/Kconfig
@@ -61,19 +61,19 @@ config CBOR_PARSER_NO_STRICT_CHECKS
 	help
 	  This option enables the strict parser checks.
 
-config CBOR_NO_FLOATING_POINT
+config CBOR_FLOATING_POINT
 	bool
 	select NEWLIB_LIBC
-	prompt "No Floating point support"
-	default y
+	prompt "Floating point support"
+	default n
 	help
 	  This option enables floating point support.
 
-config CBOR_NO_HALF_FLOAT_TYPE
+config CBOR_HALF_FLOAT_TYPE
 	bool
 	select NEWLIB_LIBC
-	prompt "No Half float type support"
-	default y
+	prompt "Half float type support"
+	default n
 	help
 	  This option enables half float type support.
 

--- a/ext/lib/encoding/tinycbor/src/compilersupport_p.h
+++ b/ext/lib/encoding/tinycbor/src/compilersupport_p.h
@@ -41,7 +41,7 @@ extern "C" {
 #  include <assert.h>
 #endif
 #include <float.h>
-#ifndef CBOR_NO_FLOATING_TYPE
+#ifndef CBOR_NO_HALF_FLOAT_TYPE
 #include <math.h>
 #endif
 #include <stddef.h>

--- a/ext/lib/encoding/tinycbor/src/config.h
+++ b/ext/lib/encoding/tinycbor/src/config.h
@@ -46,13 +46,13 @@
 #endif
 
 /** This option enables floating point support **/
-#ifdef CONFIG_CBOR_NO_FLOATING_POINT
-#define CBOR_NO_FLOATING_POINT CONFIG_CBOR_NO_FLOATING_POINT
+#ifndef CONFIG_CBOR_FLOATING_POINT
+#define CBOR_NO_FLOATING_POINT 1
 #endif
 
 /** This option enables half float type support **/
-#ifdef CONFIG_CBOR_NO_HALF_FLOAT_TYPE
-#define CBOR_NO_HALF_FLOAT_TYPE CONFIG_CBOR_NO_HALF_FLOAT_TYPE
+#ifndef CONFIG_CBOR_HALF_FLOAT_TYPE
+#define CBOR_NO_HALF_FLOAT_TYPE 1
 #endif
 
 /** This option enables open memstream support **/


### PR DESCRIPTION
half-FP feature requires <math.h> form newlib_libc. It was include wrongly by default. This path fix conduction for related include directive.

This path make logic for enabling float and half-float support positive driven and fix NEWLIB_LIBC selections for these features.

Signed-off-by: Andrzej Puzdrowski <andrzej.puzdrowski@nordicsemi.no>