### PR TITLE
kernel: sem: Ensure that initial count is lesser or equal than limit

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -99,6 +99,7 @@ zephyr_compile_options(
   -Wformat
   -Wformat-security
   -Wno-format-zero-length
+  -Wno-unused-local-typedefs
   -imacros ${AUTOCONF_H}
   -ffreestanding
   -Wno-main

--- a/include/kernel.h
+++ b/include/kernel.h
@@ -2693,7 +2693,9 @@ static inline unsigned int _impl_k_sem_count_get(struct k_sem *sem)
 #define K_SEM_DEFINE(name, initial_count, count_limit) \
 	struct k_sem name \
 		__in_section(_k_sem, static, name) = \
-		_K_SEM_INITIALIZER(name, initial_count, count_limit)
+		_K_SEM_INITIALIZER(name, initial_count, count_limit); \
+	BUILD_ASSERT((count_limit) != 0); \
+	BUILD_ASSERT((initial_count) <= (count_limit));
 
 /** @} */
 

--- a/include/toolchain/common.h
+++ b/include/toolchain/common.h
@@ -127,7 +127,10 @@
 
 #ifndef BUILD_ASSERT
 /* compile-time assertion that makes the build fail */
-#define BUILD_ASSERT(EXPR) typedef char __build_assert_failure[(EXPR) ? 1 : -1]
+#define BUILD_ASSERT(EXPR) \
+	enum _CONCAT(__build_assert_enum, __COUNTER__) { \
+		_CONCAT(__build_assert, __COUNTER__) = 1 / !!(EXPR) \
+	}
 #endif
 #ifndef BUILD_ASSERT_MSG
 /* build assertion with message -- common implementation swallows message. */

--- a/include/toolchain/gcc.h
+++ b/include/toolchain/gcc.h
@@ -21,7 +21,8 @@
  * GCC 4.6 and higher have _Static_assert built in, and its output is
  * easier to understand than the common BUILD_ASSERT macros.
  */
-#elif (__GNUC__ > 4 || (__GNUC__ == 4 && __GNUC_MINOR__ >= 6))
+#elif (__GNUC__ > 4 || (__GNUC__ == 4 && __GNUC_MINOR__ >= 6)) && \
+	(__STDC_VERSION__) > 199901L
 #define BUILD_ASSERT(EXPR) _Static_assert(EXPR, "")
 #define BUILD_ASSERT_MSG(EXPR, MSG) _Static_assert(EXPR, MSG)
 #endif

--- a/kernel/sem.c
+++ b/kernel/sem.c
@@ -59,6 +59,7 @@ void _impl_k_sem_init(struct k_sem *sem, unsigned int initial_count,
 		      unsigned int limit)
 {
 	__ASSERT(limit != 0, "limit cannot be zero");
+	__ASSERT(initial_count <= limit, "count cannot be greater than limit");
 
 	sem->count = initial_count;
 	sem->limit = limit;
@@ -76,7 +77,7 @@ void _impl_k_sem_init(struct k_sem *sem, unsigned int initial_count,
 _SYSCALL_HANDLER(k_sem_init, sem, initial_count, limit)
 {
 	_SYSCALL_OBJ_INIT(sem, K_OBJ_SEM);
-	_SYSCALL_VERIFY(limit != 0);
+	_SYSCALL_VERIFY(limit != 0 && initial_count <= limit);
 	_impl_k_sem_init((struct k_sem *)sem, initial_count, limit);
 	return 0;
 }


### PR DESCRIPTION
Ensure this value during static initialization (with build assertions),
and dynamic initializations through system calls.

If initial count is larger than the limit, it's possible for the count
to wraparound, causing locking issues.

Signed-off-by: Leandro Pereira <leandro.pereira@intel.com>