### PR TITLE
arch: arm: Flush pipeline after switching privilege levels

### DIFF
--- a/arch/arm/core/swap_helper.S
+++ b/arch/arm/core/swap_helper.S
@@ -183,6 +183,12 @@ _thread_irq_disabled:
     orr r3, r0
     msr CONTROL, r3
 
+    /* ISB is not strictly necessary here (stack pointer is not being
+     * touched), but it's recommended to avoid executing pre-fetched
+     * instructions with the previous privilege.
+     */
+    isb
+
     /* r2 contains k_thread */
     add r0, r2, #0
     push {r2, lr}
@@ -386,6 +392,12 @@ valid_syscall_id:
     /* set mode to privileged, r2 still contains value from CONTROL */
     bic r2, #1
     msr CONTROL, r2
+
+    /* ISB is not strictly necessary here (stack pointer is not being
+     * touched), but it's recommended to avoid executing pre-fetched
+     * instructions with the previous privilege.
+     */
+    isb
 
     /* return from SVC to the modified LR - _arm_do_syscall */
     bx lr

--- a/arch/arm/core/userspace.S
+++ b/arch/arm/core/userspace.S
@@ -94,6 +94,12 @@ SECTION_FUNC(TEXT,_arm_userspace_enter)
     orrs ip, ip, #1
     msr CONTROL, ip
 
+    /* ISB is not strictly necessary here (stack pointer is not being
+     * touched), but it's recommended to avoid executing pre-fetched
+     * instructions with the previous privilege.
+     */
+    isb
+
     /* jump to _thread_entry entry */
     ldr ip, =_thread_entry
     bx ip
@@ -172,6 +178,12 @@ dispatch_syscall:
     mrs ip, CONTROL
     orrs ip, ip, #1
     msr CONTROL, ip
+
+    /* ISB is not strictly necessary here (stack pointer is not being
+     * touched), but it's recommended to avoid executing pre-fetched
+     * instructions with the previous privilege.
+     */
+    isb
 
     /*
      * return back to original function that called SVC, add 1 to force thumb


### PR DESCRIPTION
During the transition of privilege levels while performing a syscall, the ARM documentation recommends flushing the pipeline to avoid pre-fetched instructions from being executed with the previous privilege level.

The manual says:
>        4.16 CONTROL register
>        (...) after programming the CONTROL register, an ISB instruction
>        should be used.
>        (...) This is not implemented in the Cortex M0 processor.