### PR TITLE
Generate aliases definition from device tree

### DIFF
--- a/scripts/dts/extract/globals.py
+++ b/scripts/dts/extract/globals.py
@@ -27,10 +27,12 @@ name_config = {
 
 
 def convert_string_to_label(s):
-    # Transmute ,- to _
+    # Transmute ,-@ to _
     s = s.replace("-", "_")
     s = s.replace(",", "_")
     s = s.replace("@", "_")
+    # Uppercase the string
+    s = s.upper()
     return s
 
 
@@ -142,10 +144,10 @@ def get_reduced(nodes, path):
 
 
 def get_node_label(node_compat, node_address):
-    def_label = convert_string_to_label(node_compat.upper())
+    def_label = convert_string_to_label(node_compat)
     if '@' in node_address:
         def_label += '_' + node_address.split('@')[-1].upper()
     else:
-        def_label += convert_string_to_label(node_address.upper())
+        def_label += convert_string_to_label(node_address)
 
     return def_label

--- a/scripts/dts/extract/globals.py
+++ b/scripts/dts/extract/globals.py
@@ -5,9 +5,11 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 
+from collections import defaultdict
+
 # globals
 phandles = {}
-aliases = {}
+aliases = defaultdict(list)
 chosen = {}
 reduced = {}
 
@@ -62,7 +64,7 @@ def get_aliases(root):
     if 'children' in root:
         if 'aliases' in root['children']:
             for k, v in root['children']['aliases']['props'].items():
-                aliases[v] = k
+                aliases[v].append(k)
 
 
 def get_compat(node):

--- a/scripts/dts/extract_dts_includes.py
+++ b/scripts/dts/extract_dts_includes.py
@@ -106,7 +106,7 @@ def extract_interrupts(node_address, yaml, y_key, names, defs, def_label):
             name = []
         else:
             try:
-                name = [convert_string_to_label(names.pop(0)).upper()]
+                name = [convert_string_to_label(names.pop(0))]
             except:
                 name = []
 
@@ -151,7 +151,7 @@ def extract_reg_prop(node_address, names, defs, def_label, div, post_label):
 
     index = 0
     l_base = def_label.split('/')
-    l_addr = [convert_string_to_label(post_label).upper()]
+    l_addr = [convert_string_to_label(post_label)]
     l_size = ["SIZE"]
 
     while props:
@@ -281,10 +281,8 @@ def extract_pinctrl(node_address, yaml, pinconf, names, index, defs,
                         [cell_yaml['#cells'][0]] + [str(i)]
                     func_label = key_label[:-2] + \
                         [cell_yaml['#cells'][1]] + [str(i)]
-                    key_label = convert_string_to_label(
-                        '_'.join(key_label)).upper()
-                    func_label = convert_string_to_label(
-                        '_'.join(func_label)).upper()
+                    key_label = convert_string_to_label('_'.join(key_label))
+                    func_label = convert_string_to_label('_'.join(func_label))
 
                     prop_def[key_label] = cells
                     prop_def[func_label] = \
@@ -299,13 +297,13 @@ def extract_single(node_address, yaml, prop, key, prefix, defs, def_label):
 
     if isinstance(prop, list):
         for i, p in enumerate(prop):
-            k = convert_string_to_label(key).upper()
+            k = convert_string_to_label(key)
             label = def_label + '_' + k
             if isinstance(p, str):
                 p = "\"" + p + "\""
             prop_def[label + '_' + str(i)] = p
     else:
-        k = convert_string_to_label(key).upper()
+        k = convert_string_to_label(key)
         label = def_label + '_' + k
 
         if prop == 'parent-label':
@@ -328,7 +326,7 @@ def extract_string_prop(node_address, yaml, key, label, defs):
     node = reduced[node_address]
     prop = node['props'][key]
 
-    k = convert_string_to_label(key).upper()
+    k = convert_string_to_label(key)
     prop_def[label] = "\"" + prop + "\""
 
     if node_address in defs:
@@ -419,8 +417,7 @@ def extract_node_include_info(reduced, root_node_address, sub_node_address,
     if yaml[node_compat].get('use-property-label', False):
         try:
             label = y_node['properties']['label']
-            label_override = convert_string_to_label(
-                                    node['props']['label']).upper()
+            label_override = convert_string_to_label(node['props']['label'])
         except KeyError:
             pass
 
@@ -436,7 +433,7 @@ def extract_node_include_info(reduced, root_node_address, sub_node_address,
 
                 prefix = []
                 if v.get('use-name-prefix') is not None:
-                    prefix = [convert_string_to_label(k.upper())]
+                    prefix = [convert_string_to_label(k)]
 
                 for c in node['props'].keys():
                     if c.endswith("-names"):


### PR DESCRIPTION
Aim of this pull request is to generate "#define" out of aliases{} node of dts files

Benefit is the ability to generate alternate definitions to a node with a name exempt from reference to a particular SoC. With this we can get "generic" #define that could be used in two different ways:
-directly in application code (cf #5381)
-in a fixup file dedicated to an application (cf #6837)

Code takes into account the case where a single node has several aliases.