### PR TITLE
kernel: remove k_pipe_init() as a system call

### DIFF
--- a/include/kernel.h
+++ b/include/kernel.h
@@ -3301,11 +3301,11 @@ struct k_pipe {
  *                         or zero if no ring buffer is used.
  * @param pipe_align Alignment of the pipe's ring buffer (power of 2).
  */
-#define K_PIPE_DEFINE(name, pipe_buffer_size, pipe_align)     \
-	static unsigned char __noinit __aligned(pipe_align)   \
-		_k_pipe_buf_##name[pipe_buffer_size];         \
-	struct k_pipe name                                    \
-		__in_section(_k_pipe, static, name) =    \
+#define K_PIPE_DEFINE(name, pipe_buffer_size, pipe_align)		\
+	static unsigned char __kernel_noinit __aligned(pipe_align)	\
+		_k_pipe_buf_##name[pipe_buffer_size];			\
+	struct k_pipe name						\
+		__in_section(_k_pipe, static, name) =			\
 		_K_PIPE_INITIALIZER(name, _k_pipe_buf_##name, pipe_buffer_size)
 
 /**
@@ -3321,8 +3321,7 @@ struct k_pipe {
  *
  * @return N/A
  */
-__syscall void k_pipe_init(struct k_pipe *pipe, unsigned char *buffer,
-			   size_t size);
+void k_pipe_init(struct k_pipe *pipe, unsigned char *buffer, size_t size);
 
 /**
  * @brief Write data to a pipe.

--- a/kernel/pipes.c
+++ b/kernel/pipes.c
@@ -128,7 +128,7 @@ SYS_INIT(init_pipes_module, PRE_KERNEL_1, CONFIG_KERNEL_INIT_PRIORITY_OBJECTS);
 
 #endif /* CONFIG_NUM_PIPE_ASYNC_MSGS or CONFIG_OBJECT_TRACING */
 
-void _impl_k_pipe_init(struct k_pipe *pipe, unsigned char *buffer, size_t size)
+void k_pipe_init(struct k_pipe *pipe, unsigned char *buffer, size_t size)
 {
 	pipe->buffer = buffer;
 	pipe->size = size;
@@ -140,18 +140,6 @@ void _impl_k_pipe_init(struct k_pipe *pipe, unsigned char *buffer, size_t size)
 	SYS_TRACING_OBJ_INIT(k_pipe, pipe);
 	_k_object_init(pipe);
 }
-
-#ifdef CONFIG_USERSPACE
-_SYSCALL_HANDLER(k_pipe_init, pipe, buffer, size)
-{
-	_SYSCALL_OBJ_INIT(pipe, K_OBJ_PIPE);
-	_SYSCALL_MEMORY_WRITE(buffer, size);
-
-	_impl_k_pipe_init((struct k_pipe *)pipe, (unsigned char *)buffer,
-			  size);
-	return 0;
-}
-#endif
 
 /**
  * @brief Copy bytes from @a src to @a dest

--- a/tests/kernel/pipe/pipe_api/src/main.c
+++ b/tests/kernel/pipe/pipe_api/src/main.c
@@ -12,29 +12,27 @@
  */
 
 #include <ztest.h>
-extern void test_pipe_thread2thread(void);
-extern void test_pipe_put_fail(void);
-extern void test_pipe_get_fail(void);
-extern void test_pipe_block_put(void);
-extern void test_pipe_block_put_sema(void);
-extern void test_pipe_get_put(void);
+#include "test_pipe.h"
 
-/* k objects */
-extern struct k_pipe pipe, kpipe, put_get_pipe;
+static unsigned char __kernel_noinit __aligned(4) pipe_buf[PIPE_LEN];
+
+extern struct k_pipe pipe, kpipe;
 extern struct k_sem end_sema;
-extern struct k_stack tstack;
+K_THREAD_STACK_EXTERN(tstack);
 extern struct k_thread tdata;
+
 /*test case main entry*/
 void test_main(void)
 {
+	k_pipe_init(&pipe, pipe_buf, PIPE_LEN);
 	k_thread_access_grant(k_current_get(),
 			      &kpipe, &pipe, &end_sema, &tdata, &tstack,
-			      &put_get_pipe, NULL);
+			      NULL);
 
 	ztest_test_suite(test_pipe_api,
 			 ztest_user_unit_test(test_pipe_thread2thread),
-			 ztest_user_unit_test(test_pipe_put_fail),
-			 ztest_user_unit_test(test_pipe_get_fail),
+			 ztest_unit_test(test_pipe_put_fail),
+			 ztest_unit_test(test_pipe_get_fail),
 			 ztest_unit_test(test_pipe_block_put),
 			 ztest_unit_test(test_pipe_block_put_sema),
 			 ztest_unit_test(test_pipe_get_put));

--- a/tests/kernel/pipe/pipe_api/src/test_pipe.h
+++ b/tests/kernel/pipe/pipe_api/src/test_pipe.h
@@ -1,0 +1,24 @@
+/*
+ * Copyright (c) 2018 Intel Corporation
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef TEST_PIPE_H
+#define TEST_PIPE_H
+
+#include <kernel.h>
+
+#define PIPE_LEN 16
+
+extern void test_pipe_thread2thread(void);
+extern void test_pipe_put_fail(void);
+extern void test_pipe_get_fail(void);
+extern void test_pipe_block_put(void);
+extern void test_pipe_block_put_sema(void);
+extern void test_pipe_get_put(void);
+
+/* k objects */
+
+
+#endif /* TEST_PIPE_H */

--- a/tests/kernel/pipe/pipe_api/src/test_pipe_contexts.c
+++ b/tests/kernel/pipe/pipe_api/src/test_pipe_contexts.c
@@ -17,9 +17,10 @@
  */
 
 #include <ztest.h>
+#include "test_pipe.h"
 
 #define STACK_SIZE 1024
-#define PIPE_LEN 16
+
 #define BYTES_TO_WRITE 4
 #define BYTES_TO_READ BYTES_TO_WRITE
 K_MEM_POOL_DEFINE(mpool, BYTES_TO_WRITE, PIPE_LEN, 1, BYTES_TO_WRITE);
@@ -120,7 +121,6 @@ void test_pipe_thread2thread(void)
 {
 	/**TESTPOINT: test k_pipe_init pipe*/
 
-	k_pipe_init(&pipe, data, PIPE_LEN);
 	tpipe_thread_thread(&pipe);
 
 	/**TESTPOINT: test K_PIPE_DEFINE pipe*/


### PR DESCRIPTION
User mode can't be trusted to provide the kernel with the buffer memory
for the pipe, it really need to be a buffer in kernel memory.

K_PIPE_DEFINE() adjusted to ensure that the implicit buffer array is
in kernel memory.

Some adjustments needed to be made to the pipe_api test case to reflect
this, and the failure case tests were moved back to supervisor mode.

Signed-off-by: Andrew Boie <andrew.p.boie@intel.com>