### PR TITLE
kernel: restore stack size check

### DIFF
--- a/kernel/thread.c
+++ b/kernel/thread.c
@@ -376,12 +376,13 @@ _SYSCALL_HANDLER(k_thread_create,
 						     &total_size),
 			    "stack size overflow (%u+%u)", stack_size,
 			    guard_size);
-
+#else
+	total_size = stack_size;
+#endif
 	/* They really ought to be equal, make this more strict? */
 	_SYSCALL_VERIFY_MSG(total_size <= stack_object->data,
 			    "stack size %u is too big, max is %u",
 			    total_size, stack_object->data);
-#endif
 
 	/* Verify the struct containing args 6-10 */
 	_SYSCALL_MEMORY_READ(margs, sizeof(*margs));


### PR DESCRIPTION
The handler for k_thread_create() wasn't verifying that the
provided stack size actually fits in the requested stack object
on systems that enforce power-of-two size/alignment for stacks.

Signed-off-by: Andrew Boie <andrew.p.boie@intel.com>