### PR TITLE
tests: net: checksum_offload: Adjust number of interfaces

### DIFF
--- a/tests/net/checksum_offload/src/main.c
+++ b/tests/net/checksum_offload/src/main.c
@@ -59,8 +59,11 @@ static struct in_addr in4addr_my = { { { 192, 0, 2, 1 } } };
 static struct in_addr in4addr_dst = { { { 192, 168, 1, 1 } } };
 static struct in_addr in4addr_my2 = { { { 192, 0, 42, 1 } } };
 
-/* Keep track of all ethernet interfaces */
-static struct net_if *eth_interfaces[2];
+/* Keep track of all ethernet interfaces. For native_posix board, we need
+ * to increase the count as it has one extra network interface defined in
+ * eth_native_posix driver.
+ */
+static struct net_if *eth_interfaces[2 + IS_ENABLED(CONFIG_ETH_NATIVE_POSIX)];
 
 static struct net_context *udp_v6_ctx_1;
 static struct net_context *udp_v6_ctx_2;

--- a/tests/net/checksum_offload/testcase.yaml
+++ b/tests/net/checksum_offload/testcase.yaml
@@ -3,5 +3,3 @@ tests:
     min_ram: 16
     tags: net checksum_offload
     depends_on: netif
-    # FIXME
-    platform_exclude: native_posix


### PR DESCRIPTION
The test actually has three network interfaces and not two so
check that correctly.

Fixes #6988

Signed-off-by: Jukka Rissanen <jukka.rissanen@linux.intel.com>