### PR TITLE
arch/arm: stm32: All SoCs have dts for I2C and SPI

### DIFF
--- a/arch/arm/soc/st_stm32/Kconfig
+++ b/arch/arm/soc/st_stm32/Kconfig
@@ -9,6 +9,8 @@ config SOC_FAMILY_STM32
 	bool
 	# omit prompt to signify a "hidden" option
 	default n
+	select HAS_DTS_I2C_DEVICE if I2C
+	select HAS_DTS_SPI_DEVICE if SPI
 
 if SOC_FAMILY_STM32
 

--- a/boards/arm/96b_carbon/Kconfig.board
+++ b/boards/arm/96b_carbon/Kconfig.board
@@ -7,5 +7,4 @@
 
 config BOARD_96B_CARBON
 	bool "96Boards Carbon (STM32F401)"
-	select HAS_DTS_SPI_DEVICE
 	depends on SOC_STM32F401XE

--- a/boards/arm/disco_l475_iot1/Kconfig.board
+++ b/boards/arm/disco_l475_iot1/Kconfig.board
@@ -7,6 +7,4 @@
 
 config BOARD_DISCO_L475_IOT1
 	bool "Discovery IoT L475 Development Board"
-	select HAS_DTS_I2C_DEVICE
-	select HAS_DTS_SPI_DEVICE
 	depends on SOC_STM32L475XG

--- a/boards/arm/nucleo_f412zg/Kconfig.board
+++ b/boards/arm/nucleo_f412zg/Kconfig.board
@@ -7,5 +7,4 @@
 
 config BOARD_NUCLEO_F412ZG
 	bool "NUCLEO-144 F412ZG Development Board"
-	select HAS_DTS_I2C_DEVICE
 	depends on SOC_STM32F412ZG

--- a/boards/arm/nucleo_f429zi/Kconfig.board
+++ b/boards/arm/nucleo_f429zi/Kconfig.board
@@ -7,5 +7,4 @@
 
 config BOARD_NUCLEO_F429ZI
 	bool "NUCLEO-144 F429ZI Development Board"
-	select HAS_DTS_I2C_DEVICE
 	depends on SOC_STM32F429XI


### PR DESCRIPTION
All boards based on STM32 should use dts for I2C and SPI.
Move CONFIG flags selection from boards to arch and select them
for all STM32 SoCs.

Signed-off-by: Erwan Gouriou <erwan.gouriou@linaro.org>