### PR TITLE
net/ethernet: Fix uninitialized attributes in ethernet mgmt parameters

### DIFF
--- a/subsys/net/ip/l2/ethernet/ethernet_mgmt.c
+++ b/subsys/net/ip/l2/ethernet/ethernet_mgmt.c
@@ -30,8 +30,8 @@ static int ethernet_set_config(u32_t mgmt_request,
 	struct ethernet_req_params *params = (struct ethernet_req_params *)data;
 	struct device *dev = net_if_get_device(iface);
 	const struct ethernet_api *api = dev->driver_api;
+	struct ethernet_config config = { 0 };
 	enum ethernet_config_type type;
-	struct ethernet_config config;
 
 	if (!api->set_config) {
 		return -ENOTSUP;

--- a/tests/net/ethernet_mgmt/src/main.c
+++ b/tests/net/ethernet_mgmt/src/main.c
@@ -200,7 +200,7 @@ static void test_change_to_same_auto_neg(void)
 static void test_change_link(void)
 {
 	struct net_if *iface = net_if_get_default();
-	struct ethernet_req_params params;
+	struct ethernet_req_params params = { 0 };
 	int ret;
 
 	params.l.link_100bt = true;
@@ -214,7 +214,7 @@ static void test_change_link(void)
 static void test_change_same_link(void)
 {
 	struct net_if *iface = net_if_get_default();
-	struct ethernet_req_params params;
+	struct ethernet_req_params params = { 0 };
 	int ret;
 
 	params.l.link_100bt = true;
@@ -228,7 +228,7 @@ static void test_change_same_link(void)
 static void test_change_unsupported_link(void)
 {
 	struct net_if *iface = net_if_get_default();
-	struct ethernet_req_params params;
+	struct ethernet_req_params params = { 0 };
 	int ret;
 
 	params.l.link_1000bt = true;


### PR DESCRIPTION
Without that, behavior is unknown and bogus.

Signed-off-by: Tomasz Bursztyka <tomasz.bursztyka@linux.intel.com>