### PR TITLE
tests: add min_flash option for some tests

### DIFF
--- a/tests/benchmarks/app_kernel/testcase.yaml
+++ b/tests/benchmarks/app_kernel/testcase.yaml
@@ -1,6 +1,7 @@
 tests:
   benchmark.application:
     arch_whitelist: x86 arm
+    min_flash: 34
     min_ram: 32
     tags: benchmark
     slow: true

--- a/tests/crypto/ecc_dh/testcase.yaml
+++ b/tests/crypto/ecc_dh/testcase.yaml
@@ -1,5 +1,6 @@
 tests:
   crypto.ecc_dh:
+    min_flash: 35
     min_ram: 16
     slow: true
     tags: crypto ecc dh

--- a/tests/crypto/ecc_dsa/testcase.yaml
+++ b/tests/crypto/ecc_dsa/testcase.yaml
@@ -1,5 +1,6 @@
 tests:
   crypto.ecc_dsa:
+    min_flash: 45
     min_ram: 16
     tags: crypto ecc dsa
     timeout: 180

--- a/tests/drivers/build_all/testcase.yaml
+++ b/tests/drivers/build_all/testcase.yaml
@@ -6,6 +6,7 @@ tests:
   test_build_ethernet:
     build_only: true
     extra_args: CONF_FILE=ethernet.conf
+    min_flash: 42
     min_ram: 32
     platform_exclude: zedboard_pulpino
     tags: drivers footprint
@@ -18,6 +19,7 @@ tests:
   test_build_sensors_a_m:
     build_only: true
     extra_args: CONF_FILE=sensors_a_m.conf
+    min_flash: 44
     min_ram: 32
     platform_exclude: zedboard_pulpino
     tags: drivers footprint


### PR DESCRIPTION
Following tests were failing on a microcontroller with 32KB flash:
    benchmark.application
    crypto.ecc_dh
    crypto.ecc_dsa
    test_build_ethernet
    test_build_sensors_a_m

The min_flash option has been added in the test case yaml files.

Signed-off-by: Diego Sueiro <diego.sueiro@gmail.com>