### PR TITLE
boards: dts: Cleanup aliases

### DIFF
--- a/boards/arc/arduino_101_sss/arduino_101_sss.dts
+++ b/boards/arc/arduino_101_sss/arduino_101_sss.dts
@@ -13,8 +13,8 @@
 	compatible = "intel,arduino_101_sss", "intel,quark_se_c1000";
 
 	aliases {
-		uart_0 = &uart0;
-		uart_1 = &uart1;
+		uart-0 = &uart0;
+		uart-1 = &uart1;
 	};
 
 	chosen {

--- a/boards/arc/em_starterkit/em_starterkit.dts
+++ b/boards/arc/em_starterkit/em_starterkit.dts
@@ -7,9 +7,9 @@
 	compatible = "snps,em_starterkit-em9d", "snps,em_starterkit";
 
 	aliases {
-		uart_0 = &uart0;
-		uart_1 = &uart1;
-		uart_2 = &uart2;
+		uart-0 = &uart0;
+		uart-1 = &uart1;
+		uart-2 = &uart2;
 	};
 
 	chosen {

--- a/boards/arc/em_starterkit/em_starterkit_em11d.dts
+++ b/boards/arc/em_starterkit/em_starterkit_em11d.dts
@@ -7,9 +7,9 @@
 	compatible = "snps,em_starterkit-em11d", "snps,em_starterkit";
 
 	aliases {
-		uart_0 = &uart0;
-		uart_1 = &uart1;
-		uart_2 = &uart2;
+		uart-0 = &uart0;
+		uart-1 = &uart1;
+		uart-2 = &uart2;
 	};
 
 	chosen {

--- a/boards/arc/em_starterkit/em_starterkit_em7d.dts
+++ b/boards/arc/em_starterkit/em_starterkit_em7d.dts
@@ -7,9 +7,9 @@
 	compatible = "snps,em_starterkit-em7d", "snps,em_starterkit";
 
 	aliases {
-		uart_0 = &uart0;
-		uart_1 = &uart1;
-		uart_2 = &uart2;
+		uart-0 = &uart0;
+		uart-1 = &uart1;
+		uart-2 = &uart2;
 	};
 
 	chosen {

--- a/boards/arc/quark_se_c1000_ss_devboard/quark_se_c1000_ss_devboard.dts
+++ b/boards/arc/quark_se_c1000_ss_devboard/quark_se_c1000_ss_devboard.dts
@@ -13,8 +13,8 @@
 	compatible = "intel,quark_se_c1000_ss_devboard", "intel,quark_se_c1000";
 
 	aliases {
-		uart_0 = &uart0;
-		uart_1 = &uart1;
+		uart-0 = &uart0;
+		uart-1 = &uart1;
 	};
 
 	chosen {

--- a/boards/arm/arduino_due/arduino_due.dts
+++ b/boards/arm/arduino_due/arduino_due.dts
@@ -7,9 +7,9 @@
 	compatible = "arduino,due", "atmel,sam3x8e", "atmel,sam3x";
 
 	aliases {
-		uart_0 = &uart0;
-		i2c_0 = &i2c0;
-		i2c_1 = &i2c1;
+		uart-0 = &uart0;
+		i2c-0 = &i2c0;
+		i2c-1 = &i2c1;
 	};
 
 	chosen {

--- a/boards/arm/cc2650_sensortag/cc2650_sensortag.dts
+++ b/boards/arm/cc2650_sensortag/cc2650_sensortag.dts
@@ -9,11 +9,11 @@
 	compatible = "ti,cc2650";
 
 	aliases {
-		gpio_a = &gpioa;
-		pinmux_a = &pinmux_a;
+		gpio-a = &gpioa;
+		pinmux-a = &pinmux_a;
 		prcm0 = &prcm0;
 		trng0 = &trng0;
-		uart_0 = &uart0;
+		uart-0 = &uart0;
 	};
 
 	chosen {

--- a/boards/arm/cc3220sf_launchxl/cc3220sf_launchxl.dts
+++ b/boards/arm/cc3220sf_launchxl/cc3220sf_launchxl.dts
@@ -7,9 +7,9 @@
 	compatible = "ti,cc3220sf-launchxl", "ti,cc3220sf", "ti,cc32xx";
 
 	aliases {
-		uart_0 = &uart0;
-		uart_1 = &uart1;
-		i2c_0 = &i2c0;
+		uart-0 = &uart0;
+		uart-1 = &uart1;
+		i2c-0 = &i2c0;
 	};
 
 	chosen {

--- a/boards/arm/frdm_k64f/frdm_k64f.dts
+++ b/boards/arm/frdm_k64f/frdm_k64f.dts
@@ -7,27 +7,27 @@
 	compatible = "nxp,mk64f12", "nxp,k64f", "nxp,k6x";
 
 	aliases {
-		adc_0 = &adc0;
-		adc_1 = &adc1;
-		pwm_0 = &pwm0;
-		pwm_1 = &pwm1;
-		pwm_2 = &pwm2;
-		pwm_3 = &pwm3;
-		uart_0 = &uart0;
-		uart_3 = &uart3;
-		pinmux_a = &pinmux_a;
-		pinmux_b = &pinmux_b;
-		pinmux_c = &pinmux_c;
-		pinmux_d = &pinmux_d;
-		pinmux_e = &pinmux_e;
-		gpio_a = &gpioa;
-		gpio_b = &gpiob;
-		gpio_c = &gpioc;
-		gpio_d = &gpiod;
-		gpio_e = &gpioe;
-		i2c_0 = &i2c0;
-		i2c_1 = &i2c1;
-		i2c_2 = &i2c2;
+		adc-0 = &adc0;
+		adc-1 = &adc1;
+		pwm-0 = &pwm0;
+		pwm-1 = &pwm1;
+		pwm-2 = &pwm2;
+		pwm-3 = &pwm3;
+		uart-0 = &uart0;
+		uart-3 = &uart3;
+		pinmux-a = &pinmux_a;
+		pinmux-b = &pinmux_b;
+		pinmux-c = &pinmux_c;
+		pinmux-d = &pinmux_d;
+		pinmux-e = &pinmux_e;
+		gpio-a = &gpioa;
+		gpio-b = &gpiob;
+		gpio-c = &gpioc;
+		gpio-d = &gpiod;
+		gpio-e = &gpioe;
+		i2c-0 = &i2c0;
+		i2c-1 = &i2c1;
+		i2c-2 = &i2c2;
 	};
 
 	chosen {

--- a/boards/arm/frdm_kl25z/frdm_kl25z.dts
+++ b/boards/arm/frdm_kl25z/frdm_kl25z.dts
@@ -7,10 +7,10 @@
 	compatible = "nxp,frdm-kl25z", "nxp,kl25z", "nxp,mkl25z4";
 
 	aliases {
-		adc_0 = &adc0;
-		uart_0 = &uart0;
-		i2c_0 = &i2c0;
-		i2c_1 = &i2c1;
+		adc-0 = &adc0;
+		uart-0 = &uart0;
+		i2c-0 = &i2c0;
+		i2c-1 = &i2c1;
 	};
 
 	chosen {

--- a/boards/arm/frdm_kw41z/frdm_kw41z.dts
+++ b/boards/arm/frdm_kw41z/frdm_kw41z.dts
@@ -7,16 +7,16 @@
 	compatible = "nxp,kw41z", "nxp,mkw41z4";
 
 	aliases {
-		adc_0 = &adc0;
-		lpuart_0 = &lpuart0;
-		pinmux_a = &pinmux_a;
-		pinmux_b = &pinmux_b;
-		pinmux_c = &pinmux_c;
-		gpio_a = &gpioa;
-		gpio_b = &gpiob;
-		gpio_c = &gpioc;
-		i2c_0 = &i2c0;
-		i2c_1 = &i2c1;
+		adc-0 = &adc0;
+		lpuart-0 = &lpuart0;
+		pinmux-a = &pinmux_a;
+		pinmux-b = &pinmux_b;
+		pinmux-c = &pinmux_c;
+		gpio-a = &gpioa;
+		gpio-b = &gpiob;
+		gpio-c = &gpioc;
+		i2c-0 = &i2c0;
+		i2c-1 = &i2c1;
 	};
 
 	chosen {

--- a/boards/arm/hexiwear_k64/hexiwear_k64.dts
+++ b/boards/arm/hexiwear_k64/hexiwear_k64.dts
@@ -7,27 +7,27 @@
 	compatible = "nxp,hexiwear", "nxp,k64f", "nxp,k6x";
 
 	aliases {
-		adc_0 = &adc0;
-		adc_1 = &adc1;
-		pwm_0 = &pwm0;
-		pwm_1 = &pwm1;
-		pwm_2 = &pwm2;
-		pwm_3 = &pwm3;
-		uart_0 = &uart0;
-		uart_4 = &uart4;
-		pinmux_a = &pinmux_a;
-		pinmux_b = &pinmux_b;
-		pinmux_c = &pinmux_c;
-		pinmux_d = &pinmux_d;
-		pinmux_e = &pinmux_e;
-		gpio_a = &gpioa;
-		gpio_b = &gpiob;
-		gpio_c = &gpioc;
-		gpio_d = &gpiod;
-		gpio_e = &gpioe;
-		i2c_0 = &i2c0;
-		i2c_1 = &i2c1;
-		i2c_2 = &i2c2;
+		adc-0 = &adc0;
+		adc-1 = &adc1;
+		pwm-0 = &pwm0;
+		pwm-1 = &pwm1;
+		pwm-2 = &pwm2;
+		pwm-3 = &pwm3;
+		uart-0 = &uart0;
+		uart-4 = &uart4;
+		pinmux-a = &pinmux_a;
+		pinmux-b = &pinmux_b;
+		pinmux-c = &pinmux_c;
+		pinmux-d = &pinmux_d;
+		pinmux-e = &pinmux_e;
+		gpio-a = &gpioa;
+		gpio-b = &gpiob;
+		gpio-c = &gpioc;
+		gpio-d = &gpiod;
+		gpio-e = &gpioe;
+		i2c-0 = &i2c0;
+		i2c-1 = &i2c1;
+		i2c-2 = &i2c2;
 	};
 
 	chosen {

--- a/boards/arm/hexiwear_kw40z/hexiwear_kw40z.dts
+++ b/boards/arm/hexiwear_kw40z/hexiwear_kw40z.dts
@@ -7,16 +7,16 @@
 	compatible = "nxp,kw40z", "nxp,mkw40z4";
 
 	aliases {
-		adc_0 = &adc0;
-		lpuart_0 = &lpuart0;
-		pinmux_a = &pinmux_a;
-		pinmux_b = &pinmux_b;
-		pinmux_c = &pinmux_c;
-		gpio_a = &gpioa;
-		gpio_b = &gpiob;
-		gpio_c = &gpioc;
-		i2c_0 = &i2c0;
-		i2c_1 = &i2c1;
+		adc-0 = &adc0;
+		lpuart-0 = &lpuart0;
+		pinmux-a = &pinmux_a;
+		pinmux-b = &pinmux_b;
+		pinmux-c = &pinmux_c;
+		gpio-a = &gpioa;
+		gpio-b = &gpiob;
+		gpio-c = &gpioc;
+		i2c-0 = &i2c0;
+		i2c-1 = &i2c1;
 	};
 
 	chosen {

--- a/boards/arm/lpcxpresso54114/lpcxpresso54114.dts
+++ b/boards/arm/lpcxpresso54114/lpcxpresso54114.dts
@@ -13,7 +13,7 @@
 	compatible = "nxp,lpc54xxx", "nxp,lpc";
 
 	aliases{
-		usart_0 = &usart0;
+		usart-0 = &usart0;
 	};
 
 	chosen {

--- a/boards/arm/mimxrt1050_evk/mimxrt1050_evk.dts
+++ b/boards/arm/mimxrt1050_evk/mimxrt1050_evk.dts
@@ -13,12 +13,12 @@
 	compatible = "nxp,mimxrt1052";
 
 	aliases {
-		gpio_1= &gpio1;
-		gpio_2= &gpio2;
-		gpio_3= &gpio3;
-		gpio_4= &gpio4;
-		gpio_5= &gpio5;
-		uart_1 = &uart1;
+		gpio-1= &gpio1;
+		gpio-2= &gpio2;
+		gpio-3= &gpio3;
+		gpio-4= &gpio4;
+		gpio-5= &gpio5;
+		uart-1 = &uart1;
 	};
 
 	chosen {

--- a/boards/arm/msp_exp432p401r_launchxl/msp_exp432p401r_launchxl.dts
+++ b/boards/arm/msp_exp432p401r_launchxl/msp_exp432p401r_launchxl.dts
@@ -8,7 +8,7 @@
 						"ti,msp432p4xx";
 
 	aliases {
-		uart_0 = &uart0;
+		uart-0 = &uart0;
 	};
 
 	chosen {

--- a/boards/arm/qemu_cortex_m3/qemu_cortex_m3.dts
+++ b/boards/arm/qemu_cortex_m3/qemu_cortex_m3.dts
@@ -7,9 +7,9 @@
 	compatible = "ti,lm3s6965evb-qemu", "ti,lm3s6965";
 
 	aliases {
-		uart_0 = &uart0;
-		uart_1 = &uart1;
-		uart_2 = &uart2;
+		uart-0 = &uart0;
+		uart-1 = &uart1;
+		uart-2 = &uart2;
 	};
 
 	chosen {

--- a/boards/arm/sam4s_xplained/sam4s_xplained.dts
+++ b/boards/arm/sam4s_xplained/sam4s_xplained.dts
@@ -12,8 +12,8 @@
 	compatible = "atmel,sam4s_xplained", "atmel,sam4s16c", "atmel,sam4s";
 
 	aliases {
-		i2c_0 = &i2c0;
-		i2c_1 = &i2c1;
+		i2c-0 = &i2c0;
+		i2c-1 = &i2c1;
 	};
 
 	chosen {

--- a/boards/arm/sam_e70_xplained/sam_e70_xplained.dts
+++ b/boards/arm/sam_e70_xplained/sam_e70_xplained.dts
@@ -14,9 +14,9 @@
 	compatible = "atmel,sam_e70_xplained", "atmel,same70q21", "atmel,same70";
 
 	aliases {
-		i2c_0 = &i2c0;
-		i2c_1 = &i2c1;
-		i2c_2 = &i2c2;
+		i2c-0 = &i2c0;
+		i2c-1 = &i2c1;
+		i2c-2 = &i2c2;
 	};
 
 	chosen {

--- a/boards/arm/usb_kw24d512/usb_kw24d512.dts
+++ b/boards/arm/usb_kw24d512/usb_kw24d512.dts
@@ -7,18 +7,18 @@
 	compatible = "nxp,usb-kw24d512", "nxp,kw24d512", "nxp,kw2xd";
 
 	aliases {
-		uart_0 = &uart0;
-		pinmux_a = &pinmux_a;
-		pinmux_b = &pinmux_b;
-		pinmux_c = &pinmux_c;
-		pinmux_d = &pinmux_d;
-		pinmux_e = &pinmux_e;
-		gpio_a = &gpioa;
-		gpio_b = &gpiob;
-		gpio_c = &gpioc;
-		gpio_d = &gpiod;
-		gpio_e = &gpioe;
-		i2c_0 = &i2c0;
+		uart-0 = &uart0;
+		pinmux-a = &pinmux_a;
+		pinmux-b = &pinmux_b;
+		pinmux-c = &pinmux_c;
+		pinmux-d = &pinmux_d;
+		pinmux-e = &pinmux_e;
+		gpio-a = &gpioa;
+		gpio-b = &gpiob;
+		gpio-c = &gpioc;
+		gpio-d = &gpiod;
+		gpio-e = &gpioe;
+		i2c-0 = &i2c0;
 	};
 
 	chosen {

--- a/boards/x86/arduino_101/arduino_101.dts
+++ b/boards/x86/arduino_101/arduino_101.dts
@@ -10,8 +10,8 @@
 	compatible = "arduino,101","intel,quark";
 
 	aliases {
-		uart_0 = &uart0;
-		uart_1 = &uart1;
+		uart-0 = &uart0;
+		uart-1 = &uart1;
 	};
 
 	chosen {

--- a/boards/x86/galileo/galileo.dts
+++ b/boards/x86/galileo/galileo.dts
@@ -10,8 +10,8 @@
 	compatible = "intel,quark_x1000";
 
 	aliases {
-		uart_0 = &uart0;
-		uart_1 = &uart1;
+		uart-0 = &uart0;
+		uart-1 = &uart1;
 	};
 
 	chosen {

--- a/boards/x86/minnowboard/minnowboard.dts
+++ b/boards/x86/minnowboard/minnowboard.dts
@@ -15,8 +15,8 @@
 	compatible = "intel,atom";
 
 	aliases {
-		uart_0 = &uart0;
-		uart_1 = &uart1;
+		uart-0 = &uart0;
+		uart-1 = &uart1;
 	};
 
 	chosen {

--- a/boards/x86/qemu_x86/qemu_x86.dts
+++ b/boards/x86/qemu_x86/qemu_x86.dts
@@ -15,8 +15,8 @@
 	compatible = "intel,ia32";
 
 	aliases {
-		uart_0 = &uart0;
-		uart_1 = &uart1;
+		uart-0 = &uart0;
+		uart-1 = &uart1;
 	};
 
 	chosen {

--- a/boards/x86/quark_d2000_crb/quark_d2000_crb.dts
+++ b/boards/x86/quark_d2000_crb/quark_d2000_crb.dts
@@ -10,8 +10,8 @@
 	compatible = "intel,quark-d2000-crb", "intel,quark-d2000";
 
 	aliases {
-		uart_0 = &uart0;
-		uart_1 = &uart1;
+		uart-0 = &uart0;
+		uart-1 = &uart1;
 	};
 
 	chosen {

--- a/boards/x86/quark_se_c1000_devboard/quark_se_c1000_devboard.dts
+++ b/boards/x86/quark_se_c1000_devboard/quark_se_c1000_devboard.dts
@@ -10,8 +10,8 @@
 	compatible = "intel,quark_se_c1000_devboard", "intel,quark_se_c1000";
 
 	aliases {
-		uart_0 = &uart0;
-		uart_1 = &uart1;
+		uart-0 = &uart0;
+		uart-1 = &uart1;
 	};
 
 	chosen {

--- a/boards/x86/tinytile/tinytile.dts
+++ b/boards/x86/tinytile/tinytile.dts
@@ -10,8 +10,8 @@
 	compatible = "intel,tinytile", "intel,quark_se_c100";
 
 	aliases {
-		uart_0 = &uart0;
-		uart_1 = &uart1;
+		uart-0 = &uart0;
+		uart-1 = &uart1;
 	};
 
 	chosen {

--- a/boards/x86/x86_jailhouse/x86_jailhouse.dts
+++ b/boards/x86/x86_jailhouse/x86_jailhouse.dts
@@ -15,8 +15,8 @@
 	compatible = "intel,ia32";
 
 	aliases {
-		uart_0 = &uart0;
-		uart_1 = &uart1;
+		uart-0 = &uart0;
+		uart-1 = &uart1;
 	};
 
 	chosen {


### PR DESCRIPTION
Underscore ('_') isn't a valid char for alias names based on the device
tree spec.  Newer dtc compilers flag this as a warning so lets clean it
up.  Replaced '_' with '-' to keep things simple.

Signed-off-by: Kumar Gala <kumar.gala@linaro.org>