### PR TITLE
tests: rbtree: Fix test so its actually runs

### DIFF
--- a/tests/lib/rbtree/src/main.c
+++ b/tests/lib/rbtree/src/main.c
@@ -11,7 +11,7 @@
 #define CHECK(n) \
 	zassert_true(!!(n), "Tree check failed: [ " #n " ] @%d", __LINE__)
 
-#define MAX_NODES 2048
+#define MAX_NODES 256
 
 static struct rbtree tree;
 

--- a/tests/lib/rbtree/testcase.yaml
+++ b/tests/lib/rbtree/testcase.yaml
@@ -1,2 +1,3 @@
 tests:
     misc.rbtree:
+       tags: rbtree


### PR DESCRIPTION
1. Add a tag in the testcase.yaml to deal with the following error from
sanitycheck:

E: tests/lib/rbtree/testcase.yaml: can't load (skipping):
   <NotMappingError: error code 6: Value: None is not of a
    mapping type: Path: '/'>

2. Reduced the MAX_NODES so the test will build on small memory systems

Signed-off-by: Kumar Gala <kumar.gala@linaro.org>