### PR TITLE
kernel: Fix building of k_thread_create

### DIFF
--- a/kernel/thread.c
+++ b/kernel/thread.c
@@ -346,8 +346,9 @@ _SYSCALL_HANDLER(k_thread_create,
 {
 	int prio;
 	u32_t options, delay;
+	u32_t total_size;
 #ifndef CONFIG_MPU_REQUIRES_POWER_OF_TWO_ALIGNMENT
-	u32_t guard_size, total_size;
+	u32_t guard_size;
 #endif
 	struct _k_object *stack_object;
 	struct k_thread *new_thread = (struct k_thread *)new_thread_p;


### PR DESCRIPTION
commit ec7ecf7900289fda94d29b469cd6452755017a60 moved some code around
such that the total_size variable is used regardless of how
CONFIG_MPU_REQUIRES_POWER_OF_TWO_ALIGNMENT is set.  So move the
decleration of total_size outside of the ifndef block so things build
properly.

Signed-off-by: Kumar Gala <kumar.gala@linaro.org>