### PR TITLE
boards: hifive1: Add missing board yaml file

### DIFF
--- a/boards/riscv32/hifive1/hifive1.yaml
+++ b/boards/riscv32/hifive1/hifive1.yaml
@@ -1,0 +1,11 @@
+identifier: hifive1
+name: SiFive HiFive1
+type: mcu
+arch: riscv32
+toolchain:
+  - zephyr
+ram: 16
+testing:
+  ignore_tags:
+    - net
+    - bluetooth


### PR DESCRIPTION
When we added support for the HiFive1 board we forget to make sure it
had a board yaml file.  Add the file so we get sanitycheck running on
the board.

Signed-off-by: Kumar Gala <kumar.gala@linaro.org>