### PR TITLE
net/ethernet: Add newline to Kconfig

### DIFF
--- a/subsys/net/ip/l2/ethernet/Kconfig
+++ b/subsys/net/ip/l2/ethernet/Kconfig
@@ -67,4 +67,4 @@ config NET_DEBUG_ARP
 	help
 	  Enables core ARP code part to output debug messages
 
-endif # NET_L2_ETHERNET
+endif # NET_L2_ETHERNET\n


### PR DESCRIPTION
Fix 'make menuconfig' errors:

Scanning dependencies of target menuconfig
/home/visconti/Projects/GIT/FW/zephyr/subsys/net/ip/l2/ethernet/Kconfig:70: 'endif' in different file than 'if'
/home/visconti/Projects/GIT/FW/zephyr/subsys/net/ip/l2/ethernet/Kconfig:17: location of the 'if'
/home/visconti/Projects/GIT/FW/zephyr/subsys/net/ip/l2/Kconfig:100: 'endmenu' in different file than 'menu'
/home/visconti/Projects/GIT/FW/zephyr/subsys/net/ip/l2/ethernet/Kconfig:17: location of the 'menu'
/home/visconti/Projects/GIT/FW/zephyr/subsys/net/ip/Kconfig:434: 'endmenu' in different file than 'menu'
/home/visconti/Projects/GIT/FW/zephyr/subsys/net/ip/l2/ethernet/Kconfig:17: location of the 'menu'
/home/visconti/Projects/GIT/FW/zephyr/subsys/net/Kconfig:99: 'endif' in different file than 'if'
/home/visconti/Projects/GIT/FW/zephyr/subsys/net/ip/l2/ethernet/Kconfig:17: location of the 'if'
/home/visconti/Projects/GIT/FW/zephyr/subsys/net/Kconfig:101: 'endmenu' in different file than 'menu'
/home/visconti/Projects/GIT/FW/zephyr/subsys/net/ip/l2/ethernet/Kconfig:17: location of the 'menu'
make[3]: *** [CMakeFiles/menuconfig] Error 1
make[2]: *** [CMakeFiles/menuconfig.dir/all] Error 2
make[1]: *** [CMakeFiles/menuconfig.dir/rule] Error 2
make: *** [menuconfig] Error 2

It turned out that a '\n' was missing at the end of the Kconfig file.

Signed-off-by: Armando Visconti <armando.visconti@st.com>