### PR TITLE
net: app: server: Create IPv4 listener also if IPv6 is enabled

### DIFF
--- a/subsys/net/lib/app/net_app.c
+++ b/subsys/net/lib/app/net_app.c
@@ -398,7 +398,6 @@ int _net_app_config_local_ctx(struct net_app_ctx *ctx,
 
 		if (!ret) {
 			select_default_ctx(ctx);
-			return ret;
 		}
 #endif
 


### PR DESCRIPTION
We returned too early when creating listeners which meant that
IPv4 listener was not created if IPv6 one was created successfully.

Signed-off-by: Jukka Rissanen <jukka.rissanen@linux.intel.com>