### PR TITLE
boards: arduino_due, nrf52_pca20020: Add "ram" and "flash" properties

### DIFF
--- a/boards/arm/arduino_due/arduino_due.yaml
+++ b/boards/arm/arduino_due/arduino_due.yaml
@@ -2,6 +2,8 @@ identifier: arduino_due
 name: Arduino Due
 type: mcu
 arch: arm
+ram: 96
+flash: 512
 toolchain:
   - zephyr
   - gccarmemb

--- a/boards/arm/nrf52_pca20020/nrf52_pca20020.yaml
+++ b/boards/arm/nrf52_pca20020/nrf52_pca20020.yaml
@@ -2,6 +2,8 @@ identifier: nrf52_pca20020
 name: nRF52-PCA20020
 type: mcu
 arch: arm
+ram: 64
+flash: 512
 toolchain:
   - zephyr
   - gccarmemb


### PR DESCRIPTION
Based on large mbedTLS tests failing due to running out of RAM.

Signed-off-by: Paul Sokolovsky <paul.sokolovsky@linaro.org>