### PR TITLE
arc: add STACK_SENTINEL and improve exception handling

### DIFF
--- a/arch/arc/core/fast_irq.S
+++ b/arch/arc/core/fast_irq.S
@@ -123,8 +123,6 @@ firq_nest:
 
 SECTION_FUNC(TEXT, _firq_exit)
 
-	pop sp
-
 #if CONFIG_RGF_NUM_BANKS != 1
 #ifndef CONFIG_FIRQ_NO_LPCC
 	/* restore lp_count, lp_start, lp_end from r23-r25 */
@@ -141,6 +139,10 @@ SECTION_FUNC(TEXT, _firq_exit)
 	cmp	r0, 0
 	bne.d	_firq_no_reschedule
 	st	r0, [r1]
+
+#ifdef CONFIG_STACK_SENTINEL
+	bl _check_stack_sentinel
+#endif
 
 #ifdef CONFIG_PREEMPT_ENABLED
 
@@ -164,6 +166,8 @@ SECTION_FUNC(TEXT, _firq_exit)
 
 .balign 4
 _firq_no_reschedule:
+	pop sp
+
 	/*
 	 * Keeping this code block close to those that use it allows using brxx
 	 * instruction instead of a pair of cmp and bxx
@@ -207,6 +211,7 @@ _firq_no_reschedule:
 
 .balign 4
 _firq_reschedule:
+	pop sp
 
 #if CONFIG_RGF_NUM_BANKS != 1
 	/*

--- a/arch/arc/core/fault.c
+++ b/arch/arc/core/fault.c
@@ -29,7 +29,7 @@
  *
  * @return This function does not return.
  */
-void _Fault(void)
+void _Fault(const NANO_ESF *esf)
 {
 	u32_t vector, code, parameter;
 	u32_t exc_addr = _arc_v2_aux_reg_read(_ARC_V2_EFA);
@@ -47,8 +47,9 @@ void _Fault(void)
 	 * check violation
 	 */
 	if (vector == 6 && parameter == 2) {
-		_NanoFatalErrorHandler(_NANO_ERR_STACK_CHK_FAIL, &_default_esf);
+		_NanoFatalErrorHandler(_NANO_ERR_STACK_CHK_FAIL, esf);
+		return;
 	}
 #endif
-	_NanoFatalErrorHandler(_NANO_ERR_HW_EXCEPTION, &_default_esf);
+	_NanoFatalErrorHandler(_NANO_ERR_HW_EXCEPTION, esf);
 }

--- a/arch/arc/core/fault_s.S
+++ b/arch/arc/core/fault_s.S
@@ -17,7 +17,7 @@
 #include <swap_macros.h>
 
 GTEXT(_Fault)
-
+GTEXT(_do_kernel_oops)
 GTEXT(__reset)
 GTEXT(__memory_error)
 GTEXT(__instruction_error)
@@ -47,9 +47,6 @@ SECTION_SUBSEC_FUNC(TEXT,__fault,__ev_tlb_miss_d)
 SECTION_SUBSEC_FUNC(TEXT,__fault,__ev_prot_v)
 SECTION_SUBSEC_FUNC(TEXT,__fault,__ev_privilege_v)
 SECTION_SUBSEC_FUNC(TEXT,__fault,__ev_swi)
-#if !defined(CONFIG_IRQ_OFFLOAD) && !defined(CONFIG_USERSPACE)
-SECTION_SUBSEC_FUNC(TEXT,__fault,__ev_trap)
-#endif
 SECTION_SUBSEC_FUNC(TEXT,__fault,__ev_extension)
 SECTION_SUBSEC_FUNC(TEXT,__fault,__ev_div_zero)
 SECTION_SUBSEC_FUNC(TEXT,__fault,__ev_dc_error)
@@ -79,7 +76,6 @@ SECTION_SUBSEC_FUNC(TEXT,__fault,__ev_maligned)
 	lr r0,[_ARC_V2_ERET]
 	st_s r0, [sp, ___isf_t_pc_OFFSET] /* eret into pc */
 
-#ifndef CONFIG_USERSPACE
 	ld r1, [exc_nest_count]
 	add r0, r1, 1
 	st r0, [exc_nest_count]
@@ -92,34 +88,64 @@ SECTION_SUBSEC_FUNC(TEXT,__fault,__ev_maligned)
 	ld sp, [r1, _kernel_offset_to_irq_stack]
 exc_nest_handle:
 	push_s r0
-#endif
 
 	jl _Fault
 
-#ifndef CONFIG_USERSPACE
+_exc_return:
 	pop sp
 
 	mov	r1, exc_nest_count
 	ld	r0, [r1]
 	sub	r0, r0, 1
+	cmp	r0, 0
+	bne.d	_exc_return_from_exc
 	st 	r0, [r1]
-#endif
-	/* if _Fault returns, restore the registers */
-	_pop_irq_stack_frame
 
+#ifdef CONFIG_PREEMPT_ENABLED
+	mov_s r1, _kernel
+	ld_s r2, [r1, _kernel_offset_to_current]
+
+	/* check if the current thread needs to be rescheduled */
+	ld_s r0, [r1, _kernel_offset_to_ready_q_cache]
+	breq r0, r2, _exc_return
+
+	_save_callee_saved_regs
+
+	st _CAUSE_RIRQ, [r2, _thread_offset_to_relinquish_cause]
+	/* note: Ok to use _CAUSE_RIRQ since everything is saved */
+
+	ld_s r2, [r1, _kernel_offset_to_ready_q_cache]
+	st_s r2, [r1, _kernel_offset_to_current]
+
+	/* clear AE bit to forget this was an exception */
+	lr r3, [_ARC_V2_STATUS32]
+	and r3,r3,(~_ARC_V2_STATUS32_AE)
+	kflag r3
+	/* pretend lowest priority interrupt happened to use common handler */
+	lr r3, [_ARC_V2_AUX_IRQ_ACT]
+	or r3,r3,(1<<(CONFIG_NUM_IRQ_PRIO_LEVELS-1)) /* use lowest */
+	sr r3, [_ARC_V2_AUX_IRQ_ACT]
+
+	/* Assumption: r2 has current thread */
+	b _rirq_common_interrupt_swap
+#endif
+
+_exc_return_from_exc:
+	_pop_irq_stack_frame
 	rtie
+
 
 #ifdef CONFIG_IRQ_OFFLOAD
 GTEXT(_irq_do_offload);
 #endif
 
-#if defined(CONFIG_IRQ_OFFLOAD) || defined(CONFIG_USERSPACE)
+
 SECTION_SUBSEC_FUNC(TEXT,__fault,__ev_trap)
-#ifdef CONFIG_USERSPACE
 	/* get the id of trap_s */
 	lr ilink, [_ARC_V2_ECR]
 	and ilink, ilink, 0x3f
-	cmp ilink, 0x3
+#ifdef CONFIG_USERSPACE
+	cmp ilink, _TRAP_S_CALL_SYSTEM_CALL
 	bne _do_other_trap
 /* do sys_call */
 	mov ilink, _SYSCALL_LIMIT
@@ -182,58 +208,19 @@ _do_other_trap:
 trap_nest_handle:
 	push_s r0
 
+	mov blink,  _exc_return
+
+	cmp ilink, _TRAP_S_CALL_RUNTIME_EXCEPT
+	beq _oops
+
 #ifdef CONFIG_IRQ_OFFLOAD
-	jl _irq_do_offload
+	cmp ilink, _TRAP_S_SCALL_IRQ_OFFLOAD
+	bne _trap_fault
+	j _irq_do_offload
 #endif
 
-	pop sp
+_trap_fault:
+	j _Fault
 
-	/* check if we're a nested interrupt: if so, let the
-	 * interrupted interrupt handle the reschedule
-	 */
-	mov	r1, exc_nest_count
-	ld	r0, [r1]
-	sub	r0, r0, 1
-	cmp	r0, 0
-	beq.d	_trap_check_for_swap
-	st 	r0, [r1]
-
-_trap_return:
-	_pop_irq_stack_frame
-	rtie
-
-.balign 4
-_trap_check_for_swap:
-	mov_s r1, _kernel
-	ld_s r2, [r1, _kernel_offset_to_current]
-	/*
-	 * Non-preemptible thread ? Do not schedule (see explanation of
-	 * preempt field in kernel_struct.h).
-	 */
-	ldh_s r0, [r2, _thread_offset_to_preempt]
-	brhs r0, _NON_PREEMPT_THRESHOLD, _trap_return
-
-	/* check if the current thread needs to be rescheduled */
-	ld_s r0, [r1, _kernel_offset_to_ready_q_cache]
-	breq r0, r2, _trap_return
-
-	_save_callee_saved_regs
-
-	st _CAUSE_RIRQ, [r2, _thread_offset_to_relinquish_cause]
-	/* note: Ok to use _CAUSE_RIRQ since everything is saved */
-
-	ld_s r2, [r1, _kernel_offset_to_ready_q_cache]
-	st_s r2, [r1, _kernel_offset_to_current]
-
-	/* clear AE bit to forget this was an exception */
-	lr r3, [_ARC_V2_STATUS32]
-	and r3,r3,(~_ARC_V2_STATUS32_AE)
-	kflag r3
-	/* pretend lowest priority interrupt happened to use common handler */
-	lr r3, [_ARC_V2_AUX_IRQ_ACT]
-	or r3,r3,(1<<(CONFIG_NUM_IRQ_PRIO_LEVELS-1)) /* use lowest */
-	sr r3, [_ARC_V2_AUX_IRQ_ACT]
-
-	/* Assumption: r2 has current thread */
-	b _rirq_common_interrupt_swap
-#endif /* CONFIG_IRQ_OFFLOAD || CONFIG_USERSPACE */
+_oops:
+	j _do_kernel_oops

--- a/arch/arc/core/irq_offload.c
+++ b/arch/arc/core/irq_offload.c
@@ -28,7 +28,9 @@ void irq_offload(irq_offload_routine_t routine, void *parameter)
 	offload_routine = routine;
 	offload_param = parameter;
 
-	__asm__ volatile ("trap_s 0");
+	__asm__ volatile ("trap_s %[id]"
+		:
+		: [id] "i"(_TRAP_S_SCALL_IRQ_OFFLOAD) : );
 
 	irq_unlock(key);
 }

--- a/arch/arc/core/regular_irq.S
+++ b/arch/arc/core/regular_irq.S
@@ -95,6 +95,10 @@ SECTION_FUNC(TEXT, _rirq_exit)
 	bne.d	_rirq_return_from_rirq
 	st	r0, [r1]
 
+#ifdef CONFIG_STACK_SENTINEL
+	bl _check_stack_sentinel
+#endif
+
 #ifdef CONFIG_PREEMPT_ENABLED
 
 	mov r1, _kernel

--- a/arch/arc/core/sys_fatal_error_handler.c
+++ b/arch/arc/core/sys_fatal_error_handler.c
@@ -37,15 +37,22 @@
  *
  * @return N/A
  */
-FUNC_NORETURN __weak void _SysFatalErrorHandler(unsigned int reason,
+__weak void _SysFatalErrorHandler(unsigned int reason,
 						const NANO_ESF *pEsf)
 {
 	ARG_UNUSED(pEsf);
 
 #if !defined(CONFIG_SIMPLE_FATAL_ERROR_HANDLER)
+#if defined(CONFIG_STACK_CANARIES) || defined(CONFIG_ARC_STACK_CHECKING) \
+	|| defined(CONFIG_STACK_SENTINEL)
+	if (reason == _NANO_ERR_STACK_CHK_FAIL) {
+		goto hang_system;
+	}
+#endif
 	if (reason == _NANO_ERR_KERNEL_PANIC) {
 		goto hang_system;
 	}
+
 	if (k_is_in_isr() || _is_thread_essential()) {
 		printk("Fatal fault in %s! Spinning...\n",
 		       k_is_in_isr() ? "ISR" : "essential thread");

--- a/arch/arc/core/sys_fatal_error_handler.c
+++ b/arch/arc/core/sys_fatal_error_handler.c
@@ -43,8 +43,7 @@ __weak void _SysFatalErrorHandler(unsigned int reason,
 	ARG_UNUSED(pEsf);
 
 #if !defined(CONFIG_SIMPLE_FATAL_ERROR_HANDLER)
-#if defined(CONFIG_STACK_CANARIES) || defined(CONFIG_ARC_STACK_CHECKING) \
-	|| defined(CONFIG_STACK_SENTINEL)
+#if defined(CONFIG_ARC_STACK_CHECKING) || defined(CONFIG_STACK_SENTINEL)
 	if (reason == _NANO_ERR_STACK_CHK_FAIL) {
 		goto hang_system;
 	}
@@ -53,13 +52,16 @@ __weak void _SysFatalErrorHandler(unsigned int reason,
 		goto hang_system;
 	}
 
-	if (k_is_in_isr() || _is_thread_essential()) {
-		printk("Fatal fault in %s! Spinning...\n",
-		       k_is_in_isr() ? "ISR" : "essential thread");
+	if (_is_thread_essential()) {
+		printk("Fatal fault in essential thread! Spinning...\n");
 		goto hang_system;
 	}
+
 	printk("Fatal fault in thread %p! Aborting.\n", _current);
+
 	k_thread_abort(_current);
+
+	return;
 
 hang_system:
 #else
@@ -69,5 +71,4 @@ hang_system:
 	for (;;) {
 		k_cpu_idle();
 	}
-	CODE_UNREACHABLE;
 }

--- a/arch/arc/include/kernel_arch_func.h
+++ b/arch/arc/include/kernel_arch_func.h
@@ -42,20 +42,6 @@ _set_thread_return_value(struct k_thread *thread, unsigned int value)
 	thread->arch.return_value = value;
 }
 
-static ALWAYS_INLINE int _is_in_isr(void)
-{
-	u32_t act = _arc_v2_aux_reg_read(_ARC_V2_AUX_IRQ_ACT);
-#if CONFIG_IRQ_OFFLOAD
-	/* Check if we're in a TRAP_S exception as well */
-	if (_arc_v2_aux_reg_read(_ARC_V2_STATUS32) & _ARC_V2_STATUS32_AE &&
-	    _ARC_V2_ECR_VECTOR(_arc_v2_aux_reg_read(_ARC_V2_ECR)) == EXC_EV_TRAP
-	   ) {
-		return 1;
-	}
-#endif
-	return ((act & 0xffff) != 0);
-}
-
 /**
  *
  * @brief Indicates the interrupt number of the highest priority
@@ -70,6 +56,7 @@ static ALWAYS_INLINE int _INTERRUPT_CAUSE(void)
 	return irq_num;
 }
 
+#define _is_in_isr	_arc_v2_irq_unit_is_in_isr
 
 extern void _thread_entry_wrapper(void);
 extern void _user_thread_entry_wrapper(void);

--- a/include/arch/arc/v2/arcv2_irq_unit.h
+++ b/include/arch/arc/v2/arcv2_irq_unit.h
@@ -48,7 +48,8 @@ extern "C" {
  * @return N/A
  */
 
-static inline void _arc_v2_irq_unit_irq_enable_set(
+static ALWAYS_INLINE
+void _arc_v2_irq_unit_irq_enable_set(
 	int irq,
 	unsigned char enable
 	)
@@ -65,7 +66,8 @@ static inline void _arc_v2_irq_unit_irq_enable_set(
  * @return N/A
  */
 
-static inline void _arc_v2_irq_unit_int_enable(int irq)
+static ALWAYS_INLINE
+void _arc_v2_irq_unit_int_enable(int irq)
 {
 	_arc_v2_irq_unit_irq_enable_set(irq, _ARC_V2_INT_ENABLE);
 }
@@ -78,7 +80,8 @@ static inline void _arc_v2_irq_unit_int_enable(int irq)
  * @return N/A
  */
 
-static inline void _arc_v2_irq_unit_int_disable(int irq)
+static ALWAYS_INLINE
+void _arc_v2_irq_unit_int_disable(int irq)
 {
 	_arc_v2_irq_unit_irq_enable_set(irq, _ARC_V2_INT_DISABLE);
 }
@@ -91,7 +94,8 @@ static inline void _arc_v2_irq_unit_int_disable(int irq)
  * @return N/A
  */
 
-static inline void _arc_v2_irq_unit_prio_set(int irq, unsigned char prio)
+static ALWAYS_INLINE
+void _arc_v2_irq_unit_prio_set(int irq, unsigned char prio)
 {
 	_arc_v2_aux_reg_write(_ARC_V2_IRQ_SELECT, irq);
 #ifdef CONFIG_ARC_HAS_SECURE
@@ -114,10 +118,31 @@ static inline void _arc_v2_irq_unit_prio_set(int irq, unsigned char prio)
  * @return N/A
  */
 
-static inline void _arc_v2_irq_unit_sensitivity_set(int irq, int s)
+static ALWAYS_INLINE
+void _arc_v2_irq_unit_sensitivity_set(int irq, int s)
 {
 	_arc_v2_aux_reg_write(_ARC_V2_IRQ_SELECT, irq);
 	_arc_v2_aux_reg_write(_ARC_V2_IRQ_TRIGGER, s);
+}
+
+/*
+ * @brief Check whether processor in interrupt/exception state
+ *
+ * Check whether processor in interrupt/exception state
+ *
+ * @return N/A
+ */
+static ALWAYS_INLINE
+int _arc_v2_irq_unit_is_in_isr(void)
+{
+	unsigned int act = _arc_v2_aux_reg_read(_ARC_V2_AUX_IRQ_ACT);
+
+	/* in exception ?*/
+	if (_arc_v2_aux_reg_read(_ARC_V2_STATUS32) & _ARC_V2_STATUS32_AE) {
+		return 1;
+	}
+
+	return ((act & 0xffff) != 0);
 }
 
 /*

--- a/include/arch/arc/v2/exc.h
+++ b/include/arch/arc/v2/exc.h
@@ -20,13 +20,7 @@ extern "C" {
 
 #ifdef _ASMLANGUAGE
 #else
-struct __esf {
-	/* XXX - not defined yet */
-	int placeholder;
-};
-
-typedef struct __esf NANO_ESF;
-extern const NANO_ESF _default_esf;
+typedef struct  _irq_stack_frame NANO_ESF;
 #endif
 
 #ifdef __cplusplus

--- a/kernel/compiler_stack_protect.c
+++ b/kernel/compiler_stack_protect.c
@@ -36,6 +36,7 @@ void FUNC_NORETURN _StackCheckHandler(void)
 	/* Stack canary error is a software fatal condition; treat it as such.
 	 */
 	_k_except_reason(_NANO_ERR_STACK_CHK_FAIL);
+	CODE_UNREACHABLE;
 }
 
 /* Global variable */

--- a/tests/kernel/fatal/src/main.c
+++ b/tests/kernel/fatal/src/main.c
@@ -48,7 +48,7 @@ static volatile int crash_reason;
  * In both cases the thread is guaranteed never to run again once we
  * return from the _SysFatalErrorHandler().
  */
-#if !(defined(CONFIG_ARM) || defined(CONFIG_XTENSA_ASM2))
+#if !(defined(CONFIG_ARM) || defined(CONFIG_XTENSA_ASM2) || defined(CONFIG_ARC))
 #define ERR_IS_NORETURN 1
 #endif
 

--- a/tests/kernel/fatal/testcase.yaml
+++ b/tests/kernel/fatal/testcase.yaml
@@ -4,6 +4,5 @@ tests:
     filter: CONFIG_ARCH_HAS_STACK_PROTECTION
     tags: core ignore_faults
   kernel.fatal.stack_sentinel:
-    arch_exclude: arc
     extra_args: CONF_FILE=sentinel.conf
     tags: core ignore_faults

--- a/tests/kernel/mem_protect/protection/src/main.c
+++ b/tests/kernel/mem_protect/protection/src/main.c
@@ -22,14 +22,14 @@
  * and immediately fires upon completing the exception path; the faulting
  * thread is never run again.
  */
-#ifndef CONFIG_ARM
+#if !(defined(CONFIG_ARM) || defined(CONFIG_ARC))
 FUNC_NORETURN
 #endif
 void _SysFatalErrorHandler(unsigned int reason, const NANO_ESF *pEsf)
 {
 	INFO("Caught system error -- reason %d\n", reason);
 	ztest_test_pass();
-#ifndef CONFIG_ARM
+#if !(defined(CONFIG_ARM) || defined(CONFIG_ARC))
 	CODE_UNREACHABLE;
 #endif
 }

--- a/tests/kernel/mem_protect/userspace/src/main.c
+++ b/tests/kernel/mem_protect/userspace/src/main.c
@@ -56,7 +56,7 @@ static volatile unsigned int expected_reason;
  * and immediately fires upon completing the exception path; the faulting
  * thread is never run again.
  */
-#ifndef CONFIG_ARM
+#if !(defined(CONFIG_ARM) || defined(CONFIG_ARC))
 FUNC_NORETURN
 #endif
 void _SysFatalErrorHandler(unsigned int reason, const NANO_ESF *pEsf)
@@ -79,7 +79,7 @@ void _SysFatalErrorHandler(unsigned int reason, const NANO_ESF *pEsf)
 	} else {
 		zassert_unreachable("Unexpected fault during test\n");
 	}
-#ifndef CONFIG_ARM
+#if !(defined(CONFIG_ARM) || defined(CONFIG_ARC))
 	CODE_UNREACHABLE;
 #endif
 }

--- a/tests/kernel/pipe/pipe/src/test_pipe.c
+++ b/tests/kernel/pipe/pipe/src/test_pipe.c
@@ -695,7 +695,7 @@ void _SysFatalErrorHandler(unsigned int reason, const NANO_ESF *pEsf)
 	} else {
 		ztest_test_fail();
 	}
-#ifndef CONFIG_ARM
+#if !(defined(CONFIG_ARM) || defined(CONFIG_ARC))
 	CODE_UNREACHABLE;
 #endif
 


### PR DESCRIPTION
This PR is consisted of three parts.

# PART I:  optimize the exception handling
   The original exception handling has space to optimize and
and some bugs need to be fixed.

* define NANO_ESF
   * add the definition of NANO_ESF which is an irq_stack_frame
   * add the corresponding codes in exception entry and handler
   * remove _default_esf
* implement the _ARCH_EXCEPT
   * use trap exception to raise exception by kernel
   * add corresponding trap exception entry
   * add _do_kernel_oops to handle the exception raised by
     _ARCH_EXCEPT.
* add the thread context switch in exception return
   * case: kernel oops may raise thread context switch
   * case: some tests will re-implement SysFatalHandler to raise
     thread context switch.
   * as the exception and isr are handled in kernel isr stack, so
     the thread context switch must be in the return of exception/isr
     , and the exception handler must return, should not be decorated
     with FUNC_NORETURN
* for arc, _is_in_isr should consider the case of exception
* bug fixes

# PART II: add the support of STACK_SENTINEL
  * call the _check_stack_sentinel in unnested isr
return.

# PART III: necessary changes in tests and kernel codes
   * code fixes for arc related tests
   * add CODE_UNREACHABLE in _StackCheckHandler

The three parts are a whole to pass the tests/kernel/fatal

The issue #6513 and #7055 can be fixed with this PR.