### PR TITLE
samples: net: coap_client: Fix compile error

### DIFF
--- a/samples/net/coap_client/src/coap-client.c
+++ b/samples/net/coap_client/src/coap-client.c
@@ -176,11 +176,6 @@ static void event_iface_init(void)
 	static struct sockaddr_in6 any_addr = { .sin6_addr = IN6ADDR_ANY_INIT,
 						.sin6_family = AF_INET6 };
 
-	if (mgmt_event != NET_EVENT_IF_UP) {
-		/* Spurious callback. */
-		return;
-	}
-
 	r = net_context_get(PF_INET6, SOCK_DGRAM, IPPROTO_UDP, &context);
 	if (r) {
 		printk("Could not get an UDP context\n");


### PR DESCRIPTION
The mgmt_event is undeclared so we need to remove this piece of
code.

Signed-off-by: Jukka Rissanen <jukka.rissanen@linux.intel.com>