### PR TITLE
cmake: Fix CONFIG_CUSTOM_LINKER_SCRIPT

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -265,11 +265,9 @@ zephyr_ld_options(
 
 if(CONFIG_HAVE_CUSTOM_LINKER_SCRIPT)
   set(LINKER_SCRIPT ${APPLICATION_SOURCE_DIR}/${CONFIG_CUSTOM_LINKER_SCRIPT})
-  if(NOT EXISTS LINKER_SCRIPT)
+  if(NOT EXISTS ${LINKER_SCRIPT})
     set(LINKER_SCRIPT ${CONFIG_CUSTOM_LINKER_SCRIPT})
-    if(NOT EXISTS LINKER_SCRIPT)
-      message(FATAL_ERROR "CONFIG_HAVE_CUSTOM_LINKER_SCRIPT was set, but no linker script was found at '${CONFIG_CUSTOM_LINKER_SCRIPT}'")
-    endif()
+    assert_exists(CONFIG_CUSTOM_LINKER_SCRIPT)
   endif()
 else()
   # Try a board specific linker file


### PR DESCRIPTION
Specifying a custom linker script is supposed to be supported through
Kconfig, but evidently this has been unused and 100% broken at least
since the CMake migration.

This commit fixes #6983

Signed-off-by: Sebastian Bøe <sebastian.boe@nordicsemi.no>