### PR TITLE
license: fix spdx identifier in a few files

### DIFF
--- a/include/syscall.h
+++ b/include/syscall.h
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) 2017, Intel Corporation
  *
- * SPDX-License-Identifier: Apache 2.0
+ * SPDX-License-Identifier: Apache-2.0
  */
 
 

--- a/kernel/include/syscall_handler.h
+++ b/kernel/include/syscall_handler.h
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) 2017, Intel Corporation
  *
- * SPDX-License-Identifier: Apache 2.0
+ * SPDX-License-Identifier: Apache-2.0
  */
 
 


### PR DESCRIPTION
Use correct SPDX identifier for Apache 2.0.

Signed-off-by: Anas Nashif <anas.nashif@intel.com>