### PR TITLE
Memory Pool should always check for overflows in k_malloc() and k_calloc()

### DIFF
--- a/kernel/mempool.c
+++ b/kernel/mempool.c
@@ -143,7 +143,10 @@ void *k_malloc(size_t size)
 	 * get a block large enough to hold an initial (hidden) block
 	 * descriptor, as well as the space the caller requested
 	 */
-	size += sizeof(struct k_mem_block_id);
+	if (__builtin_add_overflow(size, sizeof(struct k_mem_block_id),
+				   &size)) {
+		return NULL;
+	}
 	if (k_mem_pool_alloc(_HEAP_MEM_POOL, &block, size, K_NO_WAIT) != 0) {
 		return NULL;
 	}

--- a/kernel/mempool.c
+++ b/kernel/mempool.c
@@ -175,12 +175,10 @@ void *k_calloc(size_t nmemb, size_t size)
 	void *ret;
 	size_t bounds;
 
-#ifdef CONFIG_ASSERT
-	__ASSERT(!__builtin_mul_overflow(nmemb, size, &bounds),
-		 "requested size overflow");
-#else
-	bounds = nmemb * size;
-#endif
+	if (__builtin_mul_overflow(nmemb, size, &bounds)) {
+		return NULL;
+	}
+
 	ret = k_malloc(bounds);
 	if (ret) {
 		memset(ret, 0, bounds);

--- a/tests/kernel/mem_pool/mem_pool/src/main.c
+++ b/tests/kernel/mem_pool/mem_pool/src/main.c
@@ -340,6 +340,9 @@ static void test_pool_malloc(void)
 	/* ensure a small block can no longer be allocated */
 	zassert_is_null(k_malloc(32), "32 byte allocation did not fail\n");
 
+	/* ensure overflow detection is working */
+	zassert_is_null(k_malloc(0xffffffff), "overflow check failed");
+	zassert_is_null(k_calloc(0xffffffff, 2), "overflow check failed");
 }
 
 K_THREAD_DEFINE(t_alternate, STACKSIZE, alternate_task, NULL, NULL, NULL,


### PR DESCRIPTION
Assertions should only be used to test for invariants, never for error conditions that might occur in runtime.  Checking for overflow is really cheap, code-wise (just a "jo" on x86), so there's no excuse not to do this always.