### PR TITLE
drivers: spi: Correct a typo in spi_nrfx_spi.c

### DIFF
--- a/drivers/spi/spi_nrfx_spi.c
+++ b/drivers/spi/spi_nrfx_spi.c
@@ -139,7 +139,7 @@ static void transfer_next_chunk(struct device *dev)
 	size_t chunk_len = spi_context_longest_current_buf(ctx);
 
 	if (chunk_len > 0) {
-		nrfx_spim_xfer_desc_t xfer;
+		nrfx_spi_xfer_desc_t xfer;
 		nrfx_err_t result;
 
 		dev_data->chunk_len = chunk_len;


### PR DESCRIPTION
Introduced with the commit 7a9c4cbd9d56144235dde08b9ca1e84dde963e62,
by copy-pasting from "spi_nrfx_spim.c". Shame on me...

Signed-off-by: Andrzej Głąbek <andrzej.glabek@nordicsemi.no>