### PR TITLE
tests/net: utils: increase min RAM requirement to 24K

### DIFF
--- a/tests/net/utils/testcase.yaml
+++ b/tests/net/utils/testcase.yaml
@@ -1,4 +1,4 @@
 tests:
   test:
-    min_ram: 16
+    min_ram: 24
     tags: net


### PR DESCRIPTION
Min RAM requirement for tests/net/utils was 16K,
hence run on nucleo_l073rz.
Though, build size is a little more than 20K which
overflows board RAM.

Increase min RAM requirement for this test to 24K

Signed-off-by: Erwan Gouriou <erwan.gouriou@linaro.org>