### PR TITLE
yaml: rename cell_string clocks

### DIFF
--- a/dts/bindings/clock/st,stm32-rcc.yaml
+++ b/dts/bindings/clock/st,stm32-rcc.yaml
@@ -19,7 +19,7 @@ properties:
       generation: define
       category: required
 
-cell_string: clocks
+cell_string: CLOCKS
 
 "#cells":
   - bus


### PR DESCRIPTION
Use capital letters, as this seems to be the norm for this field

Signed-off-by: Erwan Gouriou <erwan.gouriou@linaro.org>