### PR TITLE
doc: Fix path in documentation about uncrustify.cfg

### DIFF
--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -317,9 +317,9 @@ standards together with a configuration file we've provided:
 .. code-block:: bash
 
    # On Linux/macOS
-   uncrustify --replace --no-backup -l C -c $ZEPHYR_BASE/scripts/uncrustify.cfg my_source_file.c
+   uncrustify --replace --no-backup -l C -c $ZEPHYR_BASE/.uncrustify.cfg my_source_file.c
    # On Windows
-   uncrustify --replace --no-backup -l C -c %ZEPHYR_BASE%\scripts\uncrustify.cfg my_source_file.c
+   uncrustify --replace --no-backup -l C -c %ZEPHYR_BASE%\.uncrustify.cfg my_source_file.c
 
 On Linux systems, you can install uncrustify with
 


### PR DESCRIPTION
The location of the uncrustify.cfg file was changed in commit
fdadb501f75d8fee1073b9918037dcafaefb9f78 , but the documentation
referring to that file was left pointing at the old path.

Signed-off-by: Iván Sánchez Ortega <ivan@sanchezortega.es>