### PR TITLE
Remove nrfxxx nwtsim

### DIFF
--- a/drivers/entropy/entropy_nrf5.c
+++ b/drivers/entropy/entropy_nrf5.c
@@ -162,9 +162,6 @@ static inline u8_t get(struct rand *rng, u8_t octets, u8_t *rand)
 
 	if (remaining < rng->threshold) {
 		NRF_RNG->TASKS_START = 1;
-#if defined(CONFIG_BOARD_NRFXX_NWTSIM)
-		NRF_RNG_regw_sideeffects();
-#endif
 	}
 
 	return octets;
@@ -229,9 +226,6 @@ static void isr_rand(void *arg)
 
 		if (ret != -EBUSY) {
 			NRF_RNG->TASKS_STOP = 1;
-#if defined(CONFIG_BOARD_NRFXX_NWTSIM)
-			NRF_RNG_regw_sideeffects();
-#endif
 		}
 	}
 }
@@ -308,9 +302,6 @@ static int entropy_nrf5_init(struct device *device)
 	NRF_RNG->INTENSET = RNG_INTENSET_VALRDY_Msk;
 
 	NRF_RNG->TASKS_START = 1;
-#if defined(CONFIG_BOARD_NRFXX_NWTSIM)
-	NRF_RNG_regw_sideeffects();
-#endif
 
 	IRQ_CONNECT(NRF5_IRQ_RNG_IRQn, CONFIG_ENTROPY_NRF5_PRI, isr_rand,
 		    DEVICE_GET(entropy_nrf5), 0);

--- a/subsys/bluetooth/controller/hal/nrf5/cntr.c
+++ b/subsys/bluetooth/controller/hal/nrf5/cntr.c
@@ -24,9 +24,6 @@ void cntr_init(void)
 			     RTC_EVTENSET_COMPARE1_Msk);
 	NRF_RTC->INTENSET = (RTC_INTENSET_COMPARE0_Msk |
 			     RTC_INTENSET_COMPARE1_Msk);
-#if defined(CONFIG_BOARD_NRFXX_NWTSIM)
-	NRF_RTC0_regw_sideeffects();
-#endif
 }
 
 u32_t cntr_start(void)
@@ -36,9 +33,6 @@ u32_t cntr_start(void)
 	}
 
 	NRF_RTC->TASKS_START = 1;
-#if defined(CONFIG_BOARD_NRFXX_NWTSIM)
-	NRF_RTC0_regw_sideeffects();
-#endif
 
 	return 0;
 }
@@ -52,9 +46,6 @@ u32_t cntr_stop(void)
 	}
 
 	NRF_RTC->TASKS_STOP = 1;
-#if defined(CONFIG_BOARD_NRFXX_NWTSIM)
-	NRF_RTC0_regw_sideeffects();
-#endif
 
 	return 0;
 }

--- a/subsys/bluetooth/controller/hal/nrf5/ecb.c
+++ b/subsys/bluetooth/controller/hal/nrf5/ecb.c
@@ -31,23 +31,12 @@ static void do_ecb(struct ecb_param *ecb)
 		NRF_ECB->EVENTS_ENDECB = 0;
 		NRF_ECB->EVENTS_ERRORECB = 0;
 		NRF_ECB->TASKS_STARTECB = 1;
-#if defined(CONFIG_BOARD_NRFXX_NWTSIM)
-		NRF_ECB_regw_sideeffects_TASKS_STOPECB();
-		NRF_ECB_regw_sideeffects_TASKS_STARTECB();
-#endif
 		while ((NRF_ECB->EVENTS_ENDECB == 0) &&
 		       (NRF_ECB->EVENTS_ERRORECB == 0) &&
 		       (NRF_ECB->ECBDATAPTR != 0)) {
-#if defined(CONFIG_BOARD_NRFXX_NWTSIM)
-			__WFE();
-#else
 			/*__WFE();*/
-#endif
 		}
 		NRF_ECB->TASKS_STOPECB = 1;
-#if defined(CONFIG_BOARD_NRFXX_NWTSIM)
-		NRF_ECB_regw_sideeffects_TASKS_STOPECB();
-#endif
 	} while ((NRF_ECB->EVENTS_ERRORECB != 0) || (NRF_ECB->ECBDATAPTR == 0));
 
 	NRF_ECB->ECBDATAPTR = 0;
@@ -112,10 +101,6 @@ u32_t ecb_encrypt_nonblocking(struct ecb *ecb)
 
 	/* start the encryption h/w */
 	NRF_ECB->TASKS_STARTECB = 1;
-#if defined(CONFIG_BOARD_NRFXX_NWTSIM)
-	NRF_ECB_regw_sideeffects_INTENSET();
-	NRF_ECB_regw_sideeffects_TASKS_STARTECB();
-#endif
 
 	return 0;
 }
@@ -124,9 +109,6 @@ static void ecb_cleanup(void)
 {
 	/* stop h/w */
 	NRF_ECB->TASKS_STOPECB = 1;
-#if defined(CONFIG_BOARD_NRFXX_NWTSIM)
-	NRF_ECB_regw_sideeffects_TASKS_STOPECB();
-#endif
 
 	/* cleanup interrupt */
 	irq_disable(ECB_IRQn);

--- a/subsys/bluetooth/controller/hal/nrf5/radio/radio.c
+++ b/subsys/bluetooth/controller/hal/nrf5/radio/radio.c
@@ -47,9 +47,6 @@ void radio_isr_set(radio_isr_fp fp_radio_isr)
 				 */
 	    );
 
-#if defined(CONFIG_BOARD_NRFXX_NWTSIM)
-	NRF_RADIO_regw_sideeffects_INTENSET();
-#endif
 	NVIC_ClearPendingIRQ(RADIO_IRQn);
 	irq_enable(RADIO_IRQn);
 }
@@ -81,15 +78,9 @@ void radio_reset(void)
 	NRF_RADIO->POWER =
 	    ((RADIO_POWER_POWER_Disabled << RADIO_POWER_POWER_Pos) &
 	     RADIO_POWER_POWER_Msk);
-#if defined(CONFIG_BOARD_NRFXX_NWTSIM)
-	NRF_RADIO_regw_sideeffects_POWER();
-#endif
 	NRF_RADIO->POWER =
 	    ((RADIO_POWER_POWER_Enabled << RADIO_POWER_POWER_Pos) &
 	     RADIO_POWER_POWER_Msk);
-#if defined(CONFIG_BOARD_NRFXX_NWTSIM)
-	NRF_RADIO_regw_sideeffects_POWER();
-#endif
 
 	hal_radio_reset();
 }
@@ -247,17 +238,11 @@ u32_t radio_rx_chain_delay_get(u8_t phy, u8_t flags)
 void radio_rx_enable(void)
 {
 	NRF_RADIO->TASKS_RXEN = 1;
-#if defined(CONFIG_BOARD_NRFXX_NWTSIM)
-	NRF_RADIO_regw_sideeffects_TASKS_RXEN();
-#endif
 }
 
 void radio_tx_enable(void)
 {
 	NRF_RADIO->TASKS_TXEN = 1;
-#if defined(CONFIG_BOARD_NRFXX_NWTSIM)
-	NRF_RADIO_regw_sideeffects_TASKS_TXEN();
-#endif
 }
 
 void radio_disable(void)
@@ -267,17 +252,10 @@ void radio_disable(void)
 			   HAL_SW_SWITCH_GROUP_TASK_ENABLE_PPI_DISABLE;
 	NRF_PPI->TASKS_CHG[SW_SWITCH_TIMER_TASK_GROUP(0)].DIS = 1;
 	NRF_PPI->TASKS_CHG[SW_SWITCH_TIMER_TASK_GROUP(1)].DIS = 1;
-#if defined(CONFIG_BOARD_NRFXX_NWTSIM)
-	NRF_PPI_regw_sideeffects_CHEN();
-	NRF_PPI_tasw_sideeffects();
-#endif
 #endif /* !CONFIG_BT_CTLR_TIFS_HW */
 
 	NRF_RADIO->SHORTS = 0;
 	NRF_RADIO->TASKS_DISABLE = 1;
-#if defined(CONFIG_BOARD_NRFXX_NWTSIM)
-	NRF_RADIO_regw_sideeffects_TASKS_DISABLE();
-#endif
 }
 
 void radio_status_reset(void)
@@ -521,10 +499,6 @@ static void sw_switch(u8_t dir, u8_t phy_curr, u8_t flags_curr, u8_t phy_next,
 	NRF_PPI->CHENSET =
 		HAL_SW_SWITCH_TIMER_CLEAR_PPI_ENABLE |
 		HAL_SW_SWITCH_GROUP_TASK_ENABLE_PPI_ENABLE;
-#if defined(CONFIG_BOARD_NRFXX_NWTSIM)
-	NRF_TIMER_regw_sideeffects_CC(SW_SWITCH_TIMER_NBR, sw_tifs_toggle);
-	NRF_PPI_regw_sideeffects();
-#endif
 
 #if defined(CONFIG_BT_CTLR_SW_SWITCH_SINGLE_TIMER)
 	/* Since the event timer is cleared on END, we
@@ -573,9 +547,6 @@ void radio_switch_complete_and_disable(void)
 #if !defined(CONFIG_BT_CTLR_TIFS_HW)
 	NRF_PPI->CHENCLR = HAL_SW_SWITCH_TIMER_CLEAR_PPI_DISABLE |
 			   HAL_SW_SWITCH_GROUP_TASK_ENABLE_PPI_DISABLE;
-#if defined(CONFIG_BOARD_NRFXX_NWTSIM)
-	NRF_PPI_regw_sideeffects_CHEN();
-#endif
 #endif /* !CONFIG_BT_CTLR_TIFS_HW */
 }
 
@@ -642,9 +613,6 @@ void radio_bc_configure(u32_t n)
 {
 	NRF_RADIO->BCC = n;
 	NRF_RADIO->SHORTS |= RADIO_SHORTS_ADDRESS_BCSTART_Msk;
-#if defined(CONFIG_BOARD_NRFXX_NWTSIM)
-	NRF_RADIO_regw_sideeffects_BCC();
-#endif
 }
 
 void radio_bc_status_reset(void)
@@ -660,9 +628,6 @@ u32_t radio_bc_has_match(void)
 void radio_tmr_status_reset(void)
 {
 	NRF_RTC0->EVTENCLR = RTC_EVTENCLR_COMPARE2_Msk;
-#if defined(CONFIG_BOARD_NRFXX_NWTSIM)
-	NRF_RTC0_regw_sideeffects();
-#endif
 
 	NRF_PPI->CHENCLR =
 			HAL_RADIO_ENABLE_ON_TICK_PPI_DISABLE |
@@ -681,9 +646,6 @@ void radio_tmr_status_reset(void)
 #endif /* CONFIG_BT_CTLR_PHY_CODED */
 			HAL_TRIGGER_CRYPT_PPI_DISABLE;
 
-#if defined(CONFIG_BOARD_NRFXX_NWTSIM)
-	NRF_PPI_regw_sideeffects_CHEN();
-#endif
 }
 
 void radio_tmr_tifs_set(u32_t tifs)
@@ -692,9 +654,6 @@ void radio_tmr_tifs_set(u32_t tifs)
 	NRF_RADIO->TIFS = tifs;
 #else /* !CONFIG_BT_CTLR_TIFS_HW */
 	SW_SWITCH_TIMER->CC[SW_SWITCH_TIMER_EVTS_COMP(sw_tifs_toggle)] = tifs;
-#if defined(CONFIG_BOARD_NRFXX_NWTSIM)
-	NRF_TIMER_regw_sideeffects_CC(SW_SWITCH_TIMER_NBR, sw_tifs_toggle);
-#endif
 #endif /* !CONFIG_BT_CTLR_TIFS_HW */
 }
 
@@ -713,9 +672,6 @@ u32_t radio_tmr_start(u8_t trx, u32_t ticks_start, u32_t remainder)
 
 	EVENT_TIMER->CC[0] = remainder;
 
-#if defined(CONFIG_BOARD_NRFXX_NWTSIM)
-	NRF_TIMER_regw_sideeffects_TASKS_CLEAR(EVENT_TIMER_NBR);
-#endif
 
 	NRF_RTC0->CC[2] = ticks_start;
 	NRF_RTC0->EVTENSET = RTC_EVTENSET_COMPARE2_Msk;
@@ -723,14 +679,8 @@ u32_t radio_tmr_start(u8_t trx, u32_t ticks_start, u32_t remainder)
 	HAL_EVENT_TIMER_START_PPI_REGISTER_EVT = HAL_EVENT_TIMER_START_EVT;
 	HAL_EVENT_TIMER_START_PPI_REGISTER_TASK = HAL_EVENT_TIMER_START_TASK;
 	NRF_PPI->CHENSET = HAL_EVENT_TIMER_START_PPI_ENABLE;
-#if defined(CONFIG_BOARD_NRFXX_NWTSIM)
-	NRF_PPI_regw_sideeffects_CHEN();
-#endif
 
 	hal_radio_enable_on_tick_ppi_config_and_enable(trx);
-#if defined(CONFIG_BOARD_NRFXX_NWTSIM)
-	NRF_PPI_regw_sideeffects_CHEN();
-#endif
 
 #if !defined(CONFIG_BT_CTLR_TIFS_HW)
 #if defined(CONFIG_BT_CTLR_SW_SWITCH_SINGLE_TIMER)
@@ -742,10 +692,6 @@ u32_t radio_tmr_start(u8_t trx, u32_t ticks_start, u32_t remainder)
 	SW_SWITCH_TIMER->PRESCALER = 4;
 	SW_SWITCH_TIMER->BITMODE = 0; /* 16 bit */
 	SW_SWITCH_TIMER->TASKS_START = 1;
-#if defined(CONFIG_BOARD_NRFXX_NWTSIM)
-	NRF_TIMER_regw_sideeffects_TASKS_CLEAR(SW_SWITCH_TIMER_NBR);
-	NRF_TIMER_regw_sideeffects_TASKS_START(SW_SWITCH_TIMER_NBR);
-#endif
 #endif /* !CONFIG_BT_CTLR_SW_SWITCH_SINGLE_TIMER */
 
 	HAL_SW_SWITCH_TIMER_CLEAR_PPI_REGISTER_EVT =
@@ -782,10 +728,6 @@ u32_t radio_tmr_start(u8_t trx, u32_t ticks_start, u32_t remainder)
 			HAL_SW_SWITCH_RADIO_ENABLE_PPI_1_INCLUDE;
 #endif /* !CONFIG_BT_CTLR_TIFS_HW */
 
-#if defined(CONFIG_BOARD_NRFXX_NWTSIM)
-	NRF_RTC0_regw_sideeffects();
-	NRF_PPI_regw_sideeffects();
-#endif
 	return remainder;
 }
 
@@ -794,9 +736,6 @@ void radio_tmr_start_us(u8_t trx, u32_t us)
 	EVENT_TIMER->CC[0] = us;
 
 	hal_radio_enable_on_tick_ppi_config_and_enable(trx);
-#if defined(CONFIG_BOARD_NRFXX_NWTSIM)
-	NRF_PPI_regw_sideeffects_CHEN();
-#endif
 }
 
 u32_t radio_tmr_start_now(u8_t trx)
@@ -804,15 +743,9 @@ u32_t radio_tmr_start_now(u8_t trx)
 	u32_t now, start;
 
 	hal_radio_enable_on_tick_ppi_config_and_enable(trx);
-#if defined(CONFIG_BOARD_NRFXX_NWTSIM)
-	NRF_PPI_regw_sideeffects_CHEN();
-#endif
 
 	/* Capture the current time */
 	EVENT_TIMER->TASKS_CAPTURE[1] = 1;
-#if defined(CONFIG_BOARD_NRFXX_NWTSIM)
-	NRF_TIMER_regw_sideeffects_TASKS_CAPTURE(EVENT_TIMER_NBR, 1);
-#endif
 	now = EVENT_TIMER->CC[1];
 	start = now;
 
@@ -826,10 +759,6 @@ u32_t radio_tmr_start_now(u8_t trx)
 
 		/* Capture the current time */
 		EVENT_TIMER->TASKS_CAPTURE[1] = 1;
-#if defined(CONFIG_BOARD_NRFXX_NWTSIM)
-	NRF_TIMER_regw_sideeffects_CC(EVENT_TIMER_NBR, 0);
-	NRF_TIMER_regw_sideeffects_TASKS_CAPTURE(EVENT_TIMER_NBR, 1);
-#endif
 		now = EVENT_TIMER->CC[1];
 	} while (now > start);
 
@@ -840,27 +769,16 @@ void radio_tmr_stop(void)
 {
 	EVENT_TIMER->TASKS_STOP = 1;
 	EVENT_TIMER->TASKS_SHUTDOWN = 1;
-#if defined(CONFIG_BOARD_NRFXX_NWTSIM)
-	NRF_TIMER_regw_sideeffects_TASKS_STOP(EVENT_TIMER_NBR);
-	/* Shutdown not modelled (deprecated) */
-#endif
 
 #if !defined(CONFIG_BT_CTLR_TIFS_HW)
 	SW_SWITCH_TIMER->TASKS_STOP = 1;
 	SW_SWITCH_TIMER->TASKS_SHUTDOWN = 1;
-#if defined(CONFIG_BOARD_NRFXX_NWTSIM)
-	NRF_TIMER_regw_sideeffects_TASKS_STOP(SW_SWITCH_TIMER_NBR);
-	/* Shutdown not modelled (deprecated) */
-#endif
 #endif /* !CONFIG_BT_CTLR_TIFS_HW */
 }
 
 void radio_tmr_hcto_configure(u32_t hcto)
 {
 	EVENT_TIMER->CC[1] = hcto;
-#if defined(CONFIG_BOARD_NRFXX_NWTSIM)
-	NRF_TIMER_regw_sideeffects_CC(EVENT_TIMER_NBR, 1);
-#endif
 
 	HAL_RADIO_RECV_TIMEOUT_CANCEL_PPI_REGISTER_EVT =
 		HAL_RADIO_RECV_TIMEOUT_CANCEL_PPI_EVT;
@@ -873,9 +791,6 @@ void radio_tmr_hcto_configure(u32_t hcto)
 	NRF_PPI->CHENSET =
 		HAL_RADIO_RECV_TIMEOUT_CANCEL_PPI_ENABLE |
 		HAL_RADIO_DISABLE_ON_HCTO_PPI_ENABLE;
-#if defined(CONFIG_BOARD_NRFXX_NWTSIM)
-	NRF_PPI_regw_sideeffects();
-#endif
 }
 
 void radio_tmr_aa_capture(void)
@@ -891,9 +806,6 @@ void radio_tmr_aa_capture(void)
 	NRF_PPI->CHENSET =
 		HAL_RADIO_READY_TIME_CAPTURE_PPI_ENABLE |
 		HAL_RADIO_RECV_TIMEOUT_CANCEL_PPI_ENABLE;
-#if defined(CONFIG_BOARD_NRFXX_NWTSIM)
-	NRF_PPI_regw_sideeffects();
-#endif
 }
 
 u32_t radio_tmr_aa_get(void)
@@ -927,9 +839,6 @@ void radio_tmr_end_capture(void)
 		HAL_RADIO_END_TIME_CAPTURE_PPI_TASK;
 	NRF_PPI->CHENSET = HAL_RADIO_END_TIME_CAPTURE_PPI_ENABLE;
 
-#if defined(CONFIG_BOARD_NRFXX_NWTSIM)
-	NRF_PPI_regw_sideeffects();
-#endif
 }
 
 u32_t radio_tmr_end_get(void)
@@ -958,10 +867,6 @@ void radio_tmr_sample(void)
 	cc = EVENT_TIMER->CC[HAL_EVENT_TIMER_SAMPLE_CC_OFFSET];
 	EVENT_TIMER->TASKS_CAPTURE[HAL_EVENT_TIMER_SAMPLE_CC_OFFSET] = 1;
 
-#if defined(CONFIG_BOARD_NRFXX_NWTSIM)
-	NRF_TIMER_regw_sideeffects_TASKS_CAPTURE(EVENT_TIMER_NBR,
-		HAL_EVENT_TIMER_SAMPLE_CC_OFFSET);
-#endif /* CONFIG_BOARD_NRFXX_NWTSIM */
 
 	tmr_sample_val = EVENT_TIMER->CC[HAL_EVENT_TIMER_SAMPLE_CC_OFFSET];
 	EVENT_TIMER->CC[HAL_EVENT_TIMER_SAMPLE_CC_OFFSET] = cc;
@@ -969,10 +874,6 @@ void radio_tmr_sample(void)
 #else /* !CONFIG_BT_CTLR_SW_SWITCH_SINGLE_TIMER */
 	EVENT_TIMER->TASKS_CAPTURE[HAL_EVENT_TIMER_SAMPLE_CC_OFFSET] = 1;
 
-#if defined(CONFIG_BOARD_NRFXX_NWTSIM)
-	NRF_TIMER_regw_sideeffects_TASKS_CAPTURE(EVENT_TIMER_NBR,
-		HAL_EVENT_TIMER_SAMPLE_CC_OFFSET);
-#endif /* CONFIG_BOARD_NRFXX_NWTSIM */
 #endif /* !CONFIG_BT_CTLR_SW_SWITCH_SINGLE_TIMER */
 }
 
@@ -1048,9 +949,6 @@ void radio_gpio_lna_off(void)
 void radio_gpio_pa_lna_enable(u32_t trx_us)
 {
 	EVENT_TIMER->CC[2] = trx_us;
-#if defined(CONFIG_BOARD_NRFXX_NWTSIM)
-	NRF_TIMER_regw_sideeffects_CC(EVENT_TIMER_NBR, 2);
-#endif
 
 	HAL_ENABLE_PALNA_PPI_REGISTER_EVT = HAL_ENABLE_PALNA_PPI_EVT;
 	HAL_ENABLE_PALNA_PPI_REGISTER_TASK = HAL_ENABLE_PALNA_PPI_TASK;
@@ -1060,9 +958,6 @@ void radio_gpio_pa_lna_enable(u32_t trx_us)
 
 	NRF_PPI->CHENSET =
 		HAL_ENABLE_PALNA_PPI_ENABLE | HAL_DISABLE_PALNA_PPI_ENABLE;
-#if defined(CONFIG_BOARD_NRFXX_NWTSIM)
-	NRF_PPI_regw_sideeffects();
-#endif
 }
 
 void radio_gpio_pa_lna_disable(void)
@@ -1070,9 +965,6 @@ void radio_gpio_pa_lna_disable(void)
 	NRF_PPI->CHENCLR =
 		HAL_ENABLE_PALNA_PPI_DISABLE |
 		HAL_DISABLE_PALNA_PPI_DISABLE;
-#if defined(CONFIG_BOARD_NRFXX_NWTSIM)
-	NRF_PPI_regw_sideeffects_CHEN();
-#endif
 }
 #endif /* CONFIG_BT_CTLR_GPIO_PA_PIN || CONFIG_BT_CTLR_GPIO_LNA_PIN */
 
@@ -1125,9 +1017,6 @@ void *radio_ccm_rx_pkt_set(struct ccm *ccm, u8_t phy, void *pkt)
 		HAL_TRIGGER_RATEOVERRIDE_PPI_REGISTER_TASK =
 			HAL_TRIGGER_RATEOVERRIDE_PPI_TASK;
 		NRF_PPI->CHENSET = HAL_TRIGGER_RATEOVERRIDE_PPI_ENABLE;
-#if defined(CONFIG_BOARD_NRFXX_NWTSIM)
-		NRF_PPI_regw_sideeffects();
-#endif /* CONFIG_BOARD_NRFXX_NWTSIM */
 		break;
 #endif /* CONFIG_SOC_NRF52840 */
 #endif /* CONFIG_BT_CTLR_PHY_CODED */
@@ -1146,14 +1035,8 @@ void *radio_ccm_rx_pkt_set(struct ccm *ccm, u8_t phy, void *pkt)
 	HAL_TRIGGER_CRYPT_PPI_REGISTER_EVT = HAL_TRIGGER_CRYPT_PPI_EVT;
 	HAL_TRIGGER_CRYPT_PPI_REGISTER_TASK = HAL_TRIGGER_CRYPT_PPI_TASK;
 	NRF_PPI->CHENSET = HAL_TRIGGER_CRYPT_PPI_ENABLE;
-#if defined(CONFIG_BOARD_NRFXX_NWTSIM)
-	NRF_PPI_regw_sideeffects();
-#endif
 
 	NRF_CCM->TASKS_KSGEN = 1;
-#if defined(CONFIG_BOARD_NRFXX_NWTSIM)
-	NRF_CCM_regw_sideeffects_TASKS_KSGEN();
-#endif
 
 	return _pkt_scratch;
 }
@@ -1187,9 +1070,6 @@ void *radio_ccm_tx_pkt_set(struct ccm *ccm, void *pkt)
 	NRF_CCM->EVENTS_ERROR = 0;
 
 	NRF_CCM->TASKS_KSGEN = 1;
-#if defined(CONFIG_BOARD_NRFXX_NWTSIM)
-	NRF_CCM_regw_sideeffects_TASKS_KSGEN();
-#endif
 
 	return _pkt_scratch;
 }
@@ -1197,18 +1077,12 @@ void *radio_ccm_tx_pkt_set(struct ccm *ccm, void *pkt)
 u32_t radio_ccm_is_done(void)
 {
 	NRF_CCM->INTENSET = CCM_INTENSET_ENDCRYPT_Msk;
-#if defined(CONFIG_BOARD_NRFXX_NWTSIM)
-	NRF_CCM_regw_sideeffects_INTENSET();
-#endif
 	while (NRF_CCM->EVENTS_ENDCRYPT == 0) {
 		__WFE();
 		__SEV();
 		__WFE();
 	}
 	NRF_CCM->INTENCLR = CCM_INTENCLR_ENDCRYPT_Msk;
-#if defined(CONFIG_BOARD_NRFXX_NWTSIM)
-	NRF_CCM_regw_sideeffects_INTENCLR();
-#endif
 	NVIC_ClearPendingIRQ(CCM_AAR_IRQn);
 
 	return (NRF_CCM->EVENTS_ERROR == 0);
@@ -1240,9 +1114,6 @@ void radio_ar_configure(u32_t nirk, void *irk)
 	HAL_TRIGGER_AAR_PPI_REGISTER_EVT = HAL_TRIGGER_AAR_PPI_EVT;
 	HAL_TRIGGER_AAR_PPI_REGISTER_TASK = HAL_TRIGGER_AAR_PPI_TASK;
 	NRF_PPI->CHENSET = HAL_TRIGGER_AAR_PPI_ENABLE;
-#if defined(CONFIG_BOARD_NRFXX_NWTSIM)
-	NRF_PPI_regw_sideeffects();
-#endif
 }
 
 u32_t radio_ar_match_get(void)

--- a/subsys/bluetooth/controller/hal/nrf5/radio/radio_nrf5.h
+++ b/subsys/bluetooth/controller/hal/nrf5/radio/radio_nrf5.h
@@ -10,9 +10,6 @@
 
 #define EVENT_TIMER NRF_TIMER0
 
-#if defined(CONFIG_BOARD_NRFXX_NWTSIM)
-#define EVENT_TIMER_NBR 0
-#endif /* CONFIG_BOARD_NRFXX_NWTSIM */
 
 /* EVENTS_TIMER capture register used for sampling TIMER time-stamps. */
 #define HAL_EVENT_TIMER_SAMPLE_CC_OFFSET 3

--- a/subsys/bluetooth/controller/hal/nrf5/radio/radio_nrf52832.h
+++ b/subsys/bluetooth/controller/hal/nrf5/radio/radio_nrf52832.h
@@ -187,17 +187,11 @@
 #define SW_SWITCH_TIMER EVENT_TIMER
 #define SW_SWITCH_TIMER_EVTS_COMP_BASE 4
 
-#if defined(CONFIG_BOARD_NRFXX_NWTSIM)
-#define SW_SWITCH_TIMER_NBR 4
-#endif /* CONFIG_BOARD_NRFXX_NWTSIM */
 
 #else /* !CONFIG_BT_CTLR_SW_SWITCH_SINGLE_TIMER */
 #define SW_SWITCH_TIMER NRF_TIMER1
 #define SW_SWITCH_TIMER_EVTS_COMP_BASE 0
 
-#if defined(CONFIG_BOARD_NRFXX_NWTSIM)
-#define SW_SWITCH_TIMER_NBR 1
-#endif /* CONFIG_BOARD_NRFXX_NWTSIM */
 #endif /* !CONFIG_BT_CTLR_SW_SWITCH_SINGLE_TIMER */
 
 #define SW_SWITCH_TIMER_TASK_GROUP_BASE 0
@@ -205,16 +199,13 @@
 
 static inline void hal_radio_reset(void)
 {
-#if !defined(CONFIG_BOARD_NRFXX_NWTSIM)
 	/* Anomalies 102, 106 and 107 */
 	*(volatile u32_t *)0x40001774 = ((*(volatile u32_t *)0x40001774) &
 					 0xfffffffe) | 0x01000000;
-#endif /* !CONFIG_BOARD_NRFXX_NWTSIM */
 }
 
 static inline void hal_radio_ram_prio_setup(void)
 {
-#if !defined(CONFIG_BOARD_NRFXX_NWTSIM)
 	struct {
 		u32_t volatile reserved_0[0x5a0 >> 2];
 		u32_t volatile bridge_type;
@@ -251,7 +242,6 @@ static inline void hal_radio_ram_prio_setup(void)
 	NRF_AMLI->RAMPRI.I2S     = 0xFFFFFFFFUL;
 	NRF_AMLI->RAMPRI.PDM     = 0xFFFFFFFFUL;
 	NRF_AMLI->RAMPRI.PWM     = 0xFFFFFFFFUL;
-#endif /* !CONFIG_BOARD_NRFXX_NWTSIM */
 }
 
 static inline u32_t hal_radio_phy_mode_get(u8_t phy, u8_t flags)


### PR DESCRIPTION
CONFIG_BOARD_NRFXX_NWTSIM doesn't exist and thus any code ifdef
protected cant be compiled or tested.  Remove this dead code.

Additionally, this code scatters a ton of CONFIG_BOARD_* defines in drivers and core code and we shouldn't be doing that.