### PR TITLE
Smp global lock

### DIFF
--- a/include/kernel.h
+++ b/include/kernel.h
@@ -440,6 +440,9 @@ struct _thread_base {
 
 	/* CPU index on which thread was last run */
 	u8_t cpu;
+
+	/* Recursive count of irq_lock() calls */
+	u8_t global_lock_count;
 #endif
 
 	/* data returned by APIs */

--- a/kernel/init.c
+++ b/kernel/init.c
@@ -425,6 +425,8 @@ FUNC_NORETURN void _Cstart(void)
 	 */
 	char dummy_thread_memory[sizeof(struct k_thread)];
 	struct k_thread *dummy_thread = (struct k_thread *)&dummy_thread_memory;
+
+	memset(dummy_thread_memory, 0, sizeof(dummy_thread_memory));
 #endif
 
 	/*

--- a/kernel/init.c
+++ b/kernel/init.c
@@ -238,6 +238,9 @@ static void bg_thread_main(void *unused1, void *unused2, void *unused3)
 
 	_init_static_threads();
 
+#ifdef CONFIG_SMP
+	smp_init();
+#endif
 
 #ifdef CONFIG_BOOT_TIME_MEASUREMENT
 	/* record timestamp for kernel's _main() function */
@@ -439,10 +442,6 @@ FUNC_NORETURN void _Cstart(void)
 	/* initialize stack canaries */
 #ifdef CONFIG_STACK_CANARIES
 	__stack_chk_guard = (void *)sys_rand32_get();
-#endif
-
-#ifdef CONFIG_SMP
-	smp_init();
 #endif
 
 	/* display boot banner */

--- a/kernel/sched.c
+++ b/kernel/sched.c
@@ -562,13 +562,23 @@ void *_get_next_switch_handle(void *interrupted)
 	}
 
 	int key = irq_lock();
+	struct k_thread *new_thread = _get_next_ready_thread();
 
-	_current->switch_handle = interrupted;
-	_current = _get_next_ready_thread();
-
-	void *ret = _current->switch_handle;
+#ifdef CONFIG_SMP
+	_current->base.active = 0;
+	new_thread->base.active = 1;
+#endif
 
 	irq_unlock(key);
+
+	_current->switch_handle = interrupted;
+	_current = new_thread;
+
+	void *ret = new_thread->switch_handle;
+
+#ifdef CONFIG_SMP
+	_smp_reacquire_global_lock(_current);
+#endif
 
 	_check_stack_sentinel();
 


### PR DESCRIPTION
Fix for https://github.com/zephyrproject-rtos/zephyr/issues/7020, plus two extra bits.

I should really write a test case for the irq_lock() virtualization too, though I guess the existing codebase makes a good exerciser.