### PR TITLE
subsys: nffs: Unlock mutex before returning

### DIFF
--- a/subsys/fs/nffs_fs.c
+++ b/subsys/fs/nffs_fs.c
@@ -350,8 +350,8 @@ static off_t nffs_tell(struct fs_file_t *zfp)
 	k_mutex_lock(&nffs_lock, K_FOREVER);
 
 	if (!zfp->nffs_fp) {
-		return -EIO;
 		k_mutex_unlock(&nffs_lock);
+		return -EIO;
 	}
 
 	offset = zfp->nffs_fp->nf_offset;


### PR DESCRIPTION
The implementation for the tell() primitive was attempting to unlock
the NFFS mutex after returning an error code.

Coverity-Id: 185283

Signed-off-by: Leandro Pereira <leandro.pereira@intel.com>