### PR TITLE
sanitycheck: add min_flash option for 32K devices

### DIFF
--- a/samples/drivers/crypto/sample.yaml
+++ b/samples/drivers/crypto/sample.yaml
@@ -8,6 +8,7 @@ common:
   min_ram: 16
 tests:
   test-mbedtls:
+    min_flash: 34
     extra_args: CONF_FILE=prj_mtls_shim.conf
     harness_config:
       type: multi_line

--- a/tests/kernel/common/testcase.yaml
+++ b/tests/kernel/common/testcase.yaml
@@ -1,4 +1,5 @@
 tests:
   kernel.common:
     tags: kernel
+    min_flash: 33
     min_ram: 16


### PR DESCRIPTION
Following tests were failing on a microcontroller with 32KB flash:
    test-mbedtls
    kernel.common

The min_flash option has been added in the test case yaml files.

Signed-off-by: Diego Sueiro <diego.sueiro@gmail.com>