### PR TITLE
susbsys: settings: fcb back-end initialization and fix coverity issues

### DIFF
--- a/include/settings/settings.h
+++ b/include/settings/settings.h
@@ -101,7 +101,7 @@ struct settings_handler {
 	char *(*h_get)(int argc, char **argv, char *val, int val_len_max);
 	int (*h_set)(int argc, char **argv, char *val);
 	int (*h_commit)(void);
-	int (*h_export)(void (*export_func)(char *name, char *val),
+	int (*h_export)(int (*export_func)(const char *name, char *val),
 			enum settings_export_tgt tgt);
 };
 
@@ -111,8 +111,10 @@ struct settings_handler {
  * Can be called at application startup.
  * In case the backend is NFFS Remember to call it after FS was mounted.
  * For FCB backend it can be called without such a restriction.
+ *
+ * @return 0 on success, non-zero on failure.
  */
-void settings_subsys_init(void);
+int settings_subsys_init(void);
 
 /**
  * Register a handler for settings items.

--- a/subsys/settings/src/settings_fcb.c
+++ b/subsys/settings/src/settings_fcb.c
@@ -204,7 +204,8 @@ static void settings_fcb_compress(struct settings_fcb *cf)
 		if (rc) {
 			continue;
 		}
-		fcb_append_finish(&cf->cf_fcb, &loc2.loc);
+		rc = fcb_append_finish(&cf->cf_fcb, &loc2.loc);
+		__ASSERT(rc == 0, "Failed to finish fcb_append.\n");
 	}
 	rc = fcb_rotate(&cf->cf_fcb);
 
@@ -233,8 +234,7 @@ static int settings_fcb_append(struct settings_fcb *cf, char *buf, int len)
 	if (rc) {
 		return -EINVAL;
 	}
-	fcb_append_finish(&cf->cf_fcb, &loc);
-	return 0;
+	return fcb_append_finish(&cf->cf_fcb, &loc);
 }
 
 static int settings_fcb_save(struct settings_store *cs, const char *name,

--- a/subsys/settings/src/settings_init.c
+++ b/subsys/settings/src/settings_init.c
@@ -95,18 +95,19 @@ static void settings_init_fcb(void)
 
 #endif
 
-void settings_subsys_init(void)
+int settings_subsys_init(void)
 {
 	settings_init();
 
 #ifdef CONFIG_SETTINGS_FS
-	settings_init_fs();
+	settings_init_fs(); /* func rises kernel panic once error */
 
 	/*
 	 * Must be called after root FS has been initialized.
 	 */
-	fs_mkdir(CONFIG_SETTINGS_FS_DIR);
+	return fs_mkdir(CONFIG_SETTINGS_FS_DIR);
 #elif defined(CONFIG_SETTINGS_FCB)
-	settings_init_fcb();
+	settings_init_fcb(); /* func rises kernel panic once error */
+	return 0;
 #endif
 }

--- a/subsys/settings/src/settings_init.c
+++ b/subsys/settings/src/settings_init.c
@@ -70,20 +70,22 @@ static void settings_init_fcb(void)
 	rc = settings_fcb_src(&config_init_settings_fcb);
 
 	if (rc != 0) {
-		k_panic();
-	}
+		rc = flash_area_open(CONFIG_SETTINGS_FCB_FLASH_AREA, &fap);
 
-	rc = flash_area_open(CONFIG_SETTINGS_FCB_FLASH_AREA, &fap);
+		if (rc == 0) {
+			rc = flash_area_erase(fap, 0, fap->fa_size);
+			flash_area_close(fap);
+		}
 
-	if (rc == 0) {
-		rc = flash_area_erase(fap, 0, fap->fa_size);
-		flash_area_close(fap);
+		if (rc != 0) {
+			k_panic();
+		} else {
+			rc = settings_fcb_src(&config_init_settings_fcb);
+		}
 	}
 
 	if (rc != 0) {
 		k_panic();
-	} else {
-		rc = settings_fcb_src(&config_init_settings_fcb);
 	}
 
 	rc = settings_fcb_dst(&config_init_settings_fcb);

--- a/tests/subsys/settings/fcb/src/settings_test_fcb.c
+++ b/tests/subsys/settings/fcb/src/settings_test_fcb.c
@@ -25,17 +25,17 @@ int c2_var_count = 1;
 char *c1_handle_get(int argc, char **argv, char *val, int val_len_max);
 int c1_handle_set(int argc, char **argv, char *val);
 int c1_handle_commit(void);
-int c1_handle_export(void (*cb)(char *name, char *value),
+int c1_handle_export(int (*cb)(const char *name, char *value),
 			enum settings_export_tgt tgt);
 
 char *c2_handle_get(int argc, char **argv, char *val, int val_len_max);
 int c2_handle_set(int argc, char **argv, char *val);
-int c2_handle_export(void (*cb)(char *name, char *value),
+int c2_handle_export(int (*cb)(const char *name, char *value),
 		     enum settings_export_tgt tgt);
 
 char *c3_handle_get(int argc, char **argv, char *val, int val_len_max);
 int c3_handle_set(int argc, char **argv, char *val);
-int c3_handle_export(void (*cb)(char *name, char *value),
+int c3_handle_export(int (*cb)(const char *name, char *value),
 		     enum settings_export_tgt tgt);
 
 struct settings_handler c_test_handlers[] = {
@@ -112,7 +112,7 @@ int c1_handle_commit(void)
 	return 0;
 }
 
-int c1_handle_export(void (*cb)(char *name, char *value),
+int c1_handle_export(int (*cb)(const char *name, char *value),
 			enum settings_export_tgt tgt)
 {
 	char value[32];
@@ -122,10 +122,10 @@ int c1_handle_export(void (*cb)(char *name, char *value),
 	}
 
 	settings_str_from_value(SETTINGS_INT8, &val8, value, sizeof(value));
-	cb("myfoo/mybar", value);
+	(void)cb("myfoo/mybar", value);
 
 	settings_str_from_value(SETTINGS_INT64, &val64, value, sizeof(value));
-	cb("myfoo/mybar64", value);
+	(void)cb("myfoo/mybar64", value);
 
 	return 0;
 }
@@ -258,7 +258,7 @@ int c2_handle_set(int argc, char **argv, char *val)
 	return -ENOENT;
 }
 
-int c2_handle_export(void (*cb)(char *name, char *value),
+int c2_handle_export(int (*cb)(const char *name, char *value),
 		     enum settings_export_tgt tgt)
 {
 	int i;
@@ -266,7 +266,7 @@ int c2_handle_export(void (*cb)(char *name, char *value),
 
 	for (i = 0; i < c2_var_count; i++) {
 		snprintf(name, sizeof(name), "2nd/string%d", i);
-		cb(name, val_string[i]);
+		(void)cb(name, val_string[i]);
 	}
 
 	return 0;
@@ -297,13 +297,13 @@ int c3_handle_set(int argc, char **argv, char *val)
 	return -ENOENT;
 }
 
-int c3_handle_export(void (*cb)(char *name, char *value),
+int c3_handle_export(int (*cb)(const char *name, char *value),
 		     enum settings_export_tgt tgt)
 {
 	char value[32];
 
 	settings_str_from_value(SETTINGS_INT32, &val32, value, sizeof(value));
-	cb("3/v", value);
+	(void)cb("3/v", value);
 
 	return 0;
 }

--- a/tests/subsys/settings/nffs/src/settings_test_nffs.c
+++ b/tests/subsys/settings/nffs/src/settings_test_nffs.c
@@ -24,7 +24,7 @@ int c2_var_count = 1;
 char *c1_handle_get(int argc, char **argv, char *val, int val_len_max);
 int c1_handle_set(int argc, char **argv, char *val);
 int c1_handle_commit(void);
-int c1_handle_export(void (*cb)(char *name, char *value),
+int c1_handle_export(int (*cb)(const char *name, char *value),
 			enum settings_export_tgt tgt);
 
 struct settings_handler c_test_handlers[] = {
@@ -86,7 +86,7 @@ int c1_handle_commit(void)
 	return 0;
 }
 
-int c1_handle_export(void (*cb)(char *name, char *value),
+int c1_handle_export(int (*cb)(const char *name, char *value),
 			enum settings_export_tgt tgt)
 {
 	char value[32];
@@ -96,10 +96,10 @@ int c1_handle_export(void (*cb)(char *name, char *value),
 	}
 
 	settings_str_from_value(SETTINGS_INT8, &val8, value, sizeof(value));
-	cb("myfoo/mybar", value);
+	(void)cb("myfoo/mybar", value);
 
 	settings_str_from_value(SETTINGS_INT64, &val64, value, sizeof(value));
-	cb("myfoo/mybar64", value);
+	(void)cb("myfoo/mybar64", value);
 
 	return 0;
 }


### PR DESCRIPTION
API settings_subsys_init call was changed so that it returns
error (so returns int instead of void).
Prototype of storage helper function export_func for
settings_handler::h_export was changed so that it returns error
(so returns int instead of void).
Fixed few other error handling issues by ignoring return
values.

Tests were aligned to above patches.

In f. settings_init_fcb the storage area was implemented badly:
- storage was always erased
- the only source of settings fcb instance was pointed twice.
This patch fix both issues.

Signed-off-by: Andrzej Puzdrowski <andrzej.puzdrowski@nordicsemi.no>