### PR TITLE
doc: win: Invoke pip3 instead of pip to be safe

### DIFF
--- a/doc/getting_started/installation_win.rst
+++ b/doc/getting_started/installation_win.rst
@@ -85,7 +85,7 @@ packages from their respective websites.
 #. Install the required Python modules::
 
       cd %userprofile%\zephyr
-      pip install --user -r scripts/requirements.txt
+      pip3 install --user -r scripts/requirements.txt
 
 #. If you require pyocd, an open source python2 library for programming and
    debugging ARM Cortex-M microcontrollers, use this command::


### PR DESCRIPTION
It has been observed that users might "default" to Python2 and pip
will therefore install packages for the wrong Python. pip3 appears to
always be installed when Python3 is installed, so we invoke pip3
instead of pip to be safe.

Signed-off-by: Sebastian Bøe <sebastian.boe@nordicsemi.no>