### PR TITLE
doc: fix links to mailing lists

### DIFF
--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -179,16 +179,15 @@ Pull Requests and Issues
 
 .. _open pull requests: https://github.com/zephyrproject-rtos/zephyr/pulls
 
-.. _Zephyr-devel mailing list:
-   https://lists.zephyrproject.org/mailman/listinfo/zephyr-devel
+.. _Zephyr devel mailing list: https://lists.zephyrproject.org/g/devel
 
 Before starting on a patch, first check in our issues `Zephyr Project Issues`_
 system to see what's been reported on the issue you'd like to address.  Have a
-conversation on the `Zephyr-devel mailing list`_ (or the #zephyrproject IRC
+conversation on the `Zephyr devel mailing list`_ (or the #zephyrproject IRC
 channel on freenode.net) to see what others think of your issue (and proposed
 solution).  You may find others that have encountered the issue you're
 finding, or that have similar ideas for changes or additions.  Send a message
-to the `Zephyr-devel mailing list`_ to introduce and discuss your idea with
+to the `Zephyr devel mailing list`_ to introduce and discuss your idea with
 the development community.
 
 Please note that it's common practice on IRC to be away from the

--- a/README.rst
+++ b/README.rst
@@ -68,7 +68,7 @@ support systems:
 
 * **Documentation**: Extensive Project technical documentation is developed
   along with the Zephyr kernel itself, and can be found at
-  https://zephyrproject.org/doc.  Additional documentation is maintained in
+  http://docs.zephyrproject.  Additional documentation is maintained in
   the `Zephyr GitHub wiki`_.
 
 * **Cross-reference**: Source code cross-reference for the Zephyr
@@ -88,10 +88,11 @@ support systems:
   Security related issue tracking is done in JIRA.  The location of this JIRA
   is https://zephyrprojectsec.atlassian.net.
 
-* **Mailing List**: The `Zephyr Mailing Lists`_ are perhaps the most convenient
+* **Mailing List**: The `Zephyr mailing lists`_ are perhaps the most convenient
   way to track developer discussions and to ask your own support questions to
-  the Zephyr project community.
-  You can also read through message archives to follow
+  the Zephyr project community.  Notice there are specific `Zephyr mailing list
+  subgroups`_ for announcements and developers.
+  You can read through message archives to follow
   past posts and discussions, a good thing to do to discover more about the
   Zephyr project.
 
@@ -106,6 +107,7 @@ support systems:
 .. _Getting Started Guide: https://www.zephyrproject.org/doc/getting_started/getting_started.html
 .. _Contribution Guide: https://www.zephyrproject.org/doc/contribute/contribute_guidelines.html
 .. _Zephyr GitHub wiki: https://github.com/zephyrproject-rtos/zephyr/wiki
-.. _Zephyr Mailing Lists: https://lists.zephyrproject.org/
+.. _Zephyr mailing lists: https://lists.zephyrproject.org/
+.. _Zephyr mailing list subgroups: https://lists.zephyrproject.org/g/main/subgroups
 .. _Sample and Demo Code Examples: https://www.zephyrproject.org/doc/samples/samples.html
 .. _Security Overview: https://www.zephyrproject.org/doc/security/security-overview.html

--- a/doc/contribute/contribute_non-apache.rst
+++ b/doc/contribute/contribute_non-apache.rst
@@ -23,7 +23,7 @@ pull requests (PR) following the Zephyr Project's :ref:`Contribution workflow`.
 
 Before you begin working on including a new component to the Zephyr
 Project (Apache-2.0 licensed or not), you should start up a conversation
-on the `developer mailing list <https://lists.zephyrproject.org>`_
+on the `developer mailing list <https://lists.zephyrproject.org/g/devel>`_
 to see what the Zephyr community thinks about the idea.  Maybe there's
 someone else working on something similar you can collaborate with, or a
 different approach may make the new component unnecessary.


### PR DESCRIPTION
A recent LF change to the Zephyr mailing list hosting software changed
the mailing list names and links to the message archives.

Signed-off-by: David B. Kinder <david.b.kinder@intel.com>