### PR TITLE
kernel: Add option to randomize link order

### DIFF
--- a/cmake/extensions.cmake
+++ b/cmake/extensions.cmake
@@ -44,6 +44,20 @@ include(CheckCXXCompilerFlag)
 
 # https://cmake.org/cmake/help/latest/command/target_sources.html
 function(zephyr_sources)
+  if (CONFIG_RANDOMIZE_LINK_ORDER)
+    list(LENGTH ARGV SOURCES_LENGTH)
+    foreach(i RANGE ${SOURCES_LENGTH} 1)
+      # Random seed here seems fixed
+      string(RANDOM LENGTH 8 ALPHABET 0123456789 j)
+
+      math(EXPR j "(${j} + 0) % ${SOURCES_LENGTH}")
+
+      set(TEMP, ${ARGV${j}})
+      set(ARGV${i}, ${ARGV${j}})
+      set(ARGV${j}, ${TEMP})
+    endforeach()
+  endif ()
+
   foreach(arg ${ARGV})
     if(IS_ABSOLUTE ${arg})
       set(path ${arg})

--- a/kernel/Kconfig
+++ b/kernel/Kconfig
@@ -491,6 +491,16 @@ endmenu
 
 menu "Security Options"
 
+config RANDOMIZE_LINK_ORDER
+	bool
+	prompt "Randomize link order of libzephyr.a"
+	default n
+	help
+	  Enabling this option will randomize the libzephyr.a link order.
+
+	  This provides a little bit more unpredictability, making reusing
+	  exploits slightly harder.
+
 config STACK_CANARIES
 	bool
 	prompt "Compiler stack canaries"


### PR DESCRIPTION
On systems where virtual memory addressing isn't possible (e.g. all MPU microcontrollers), it's not possible to have something akin to ASLR. This option will randomize the link order of libzephyr.a during build time, making it slightly harder to create reusable exploits for certain kinds of attacks.

That's the idea, at least.  Genrating random numbers in CMake is kind of weird.  One has to generate a random string up to a certain length, and if no random seed is provided, the same sequence is generated over and over again.

I'm looking for feedback, then:

- Is there a better way to randomize the link order? A better place to hook this into?
- Can this be done in a way that, if the feature is enabled, a no-op "make" actually rebuilds libzephyr.a with a different order?
