### PR TITLE
Caching toolchain capabilities

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,11 @@ build
 build-*
 cscope.*
 .dir
+
+# The .cache directory will be used to cache toolchain capabilities if
+# no suitable out-of-tree directory is found.
+.cache
+
 outdir
 outdir-*
 scripts/basic/fixdep

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1071,7 +1071,7 @@ if(CONFIG_OUTPUT_PRINT_MEMORY_USAGE)
 
   set(SAVED_CMAKE_REQUIRED_FLAGS ${CMAKE_REQUIRED_FLAGS})
   set(CMAKE_REQUIRED_FLAGS "${CMAKE_REQUIRED_FLAGS} ${option}")
-  check_c_compiler_flag("" ${check})
+  zephyr_check_compiler_flag(C "" ${check})
   set(CMAKE_REQUIRED_FLAGS ${SAVED_CMAKE_REQUIRED_FLAGS})
 
   target_link_libraries_ifdef(${check} zephyr_prebuilt ${option})

--- a/cmake/app/boilerplate.cmake
+++ b/cmake/app/boilerplate.cmake
@@ -274,6 +274,13 @@ set(KERNEL_EXE_NAME   ${KERNEL_NAME}.exe)
 set(KERNEL_STAT_NAME  ${KERNEL_NAME}.stat)
 set(KERNEL_STRIP_NAME ${KERNEL_NAME}.strip)
 
+# Populate USER_CACHE_DIR with a directory that user applications may
+# write cache files to.
+if(NOT DEFINED USER_CACHE_DIR)
+  find_appropriate_cache_directory(USER_CACHE_DIR)
+endif()
+message(STATUS "Cache files will be written to: ${USER_CACHE_DIR}")
+
 include(${BOARD_DIR}/board.cmake OPTIONAL)
 
 zephyr_library_named(app)

--- a/cmake/compiler/host-gcc.cmake
+++ b/cmake/compiler/host-gcc.cmake
@@ -1,16 +1,17 @@
 # Configures CMake for using GCC
 
-set(CMAKE_C_COMPILER   gcc     CACHE INTERNAL " " FORCE)
-set(CMAKE_OBJCOPY      objcopy CACHE INTERNAL " " FORCE)
-set(CMAKE_OBJDUMP      objdump CACHE INTERNAL " " FORCE)
-#set(CMAKE_LINKER      ld      CACHE INTERNAL " " FORCE) # Not in use yet
-set(CMAKE_AR           ar      CACHE INTERNAL " " FORCE)
-set(CMAKE_RANLILB      ranlib  CACHE INTERNAL " " FORCE)
-set(CMAKE_READELF      readelf CACHE INTERNAL " " FORCE)
-set(CMAKE_GDB          gdb     CACHE INTERNAL " " FORCE)
-set(CMAKE_C_FLAGS 	-m32   CACHE INTERNAL " " FORCE)
-set(CMAKE_CXX_FLAGS 	-m32   CACHE INTERNAL " " FORCE)
-set(CMAKE_SHARED_LINKER_FLAGS -m32 CACHE INTERNAL " " FORCE)
+find_program(CMAKE_C_COMPILER   gcc    )
+find_program(CMAKE_OBJCOPY      objcopy)
+find_program(CMAKE_OBJDUMP      objdump)
+#find_program(CMAKE_LINKER      ld     ) # Not in use yet
+find_program(CMAKE_AR           ar     )
+find_program(CMAKE_RANLILB      ranlib )
+find_program(CMAKE_READELF      readelf)
+find_program(CMAKE_GDB          gdb    )
+
+set(CMAKE_C_FLAGS 	          -m32 )
+set(CMAKE_CXX_FLAGS 	      -m32 )
+set(CMAKE_SHARED_LINKER_FLAGS -m32 )
 
 if(CONFIG_CPLUSPLUS)
   set(cplusplus_compiler g++)
@@ -24,5 +25,4 @@ else()
     set(cplusplus_compiler ${CMAKE_C_COMPILER})
   endif()
 endif()
-set(CMAKE_CXX_COMPILER ${cplusplus_compiler}     CACHE INTERNAL " " FORCE)
-
+find_program(CMAKE_CXX_COMPILER ${cplusplus_compiler}     CACHE INTERNAL " " FORCE)

--- a/cmake/extensions.cmake
+++ b/cmake/extensions.cmake
@@ -882,9 +882,9 @@ function(check_compiler_flag lang option ok)
   string(MAKE_C_IDENTIFIER check${option}_${lang} ${ok})
 
   if(${lang} STREQUAL C)
-    check_c_compiler_flag(${option} ${${ok}})
+    check_c_compiler_flag("${option}" ${${ok}})
   else()
-    check_cxx_compiler_flag(${option} ${${ok}})
+    check_cxx_compiler_flag("${option}" ${${ok}})
   endif()
 
   if(${${${ok}}})

--- a/cmake/extensions.cmake
+++ b/cmake/extensions.cmake
@@ -466,7 +466,7 @@ endfunction()
 function(zephyr_library_cc_option)
   foreach(option ${ARGV})
     string(MAKE_C_IDENTIFIER check${option} check)
-    check_c_compiler_flag(${option} ${check})
+    zephyr_check_compiler_flag(C ${option} ${check})
 
     if(${check})
       zephyr_library_compile_options(${option})
@@ -971,7 +971,7 @@ function(target_cc_option_fallback target scope option1 option2)
     foreach(lang C CXX)
       # For now, we assume that all flags that apply to C/CXX also
       # apply to ASM.
-      check_compiler_flag(${lang} ${option1} check)
+      zephyr_check_compiler_flag(${lang} ${option1} check)
       if(${check})
         target_compile_options(${target} ${scope}
           $<$<COMPILE_LANGUAGE:${lang}>:${option1}>
@@ -985,7 +985,7 @@ function(target_cc_option_fallback target scope option1 option2)
       endif()
     endforeach()
   else()
-    check_compiler_flag(C ${option1} check)
+    zephyr_check_compiler_flag(C ${option1} check)
     if(${check})
       target_compile_options(${target} ${scope} ${option1})
     elseif(option2)
@@ -1000,7 +1000,7 @@ function(target_ld_options target scope)
 
     set(SAVED_CMAKE_REQUIRED_FLAGS ${CMAKE_REQUIRED_FLAGS})
     set(CMAKE_REQUIRED_FLAGS "${CMAKE_REQUIRED_FLAGS} ${option}")
-    check_c_compiler_flag("" ${check})
+    zephyr_check_compiler_flag(C "" ${check})
     set(CMAKE_REQUIRED_FLAGS ${SAVED_CMAKE_REQUIRED_FLAGS})
 
     target_link_libraries_ifdef(${check} ${target} ${scope} ${option})

--- a/cmake/extensions.cmake
+++ b/cmake/extensions.cmake
@@ -18,6 +18,7 @@ include(CheckCXXCompilerFlag)
 # 3.2. *_ifndef
 # 3.3. *_option compiler compatibility checks
 # 3.4. Debugging CMake
+# 3.5. File system management
 
 ########################################################
 # 1. Zephyr-aware extensions
@@ -1001,4 +1002,22 @@ macro(assert_with_usage test comment)
     message(FATAL_ERROR "Invalid usage")
   endif()
 endmacro()
+
+# 3.5. File system management
+function(check_if_directory_is_writeable dir ok)
+  execute_process(
+    COMMAND
+    ${PYTHON_EXECUTABLE}
+    ${ZEPHYR_BASE}/scripts/dir_is_writeable.py
+    ${dir}
+    RESULT_VARIABLE ret
+    )
+
+  if("${ret}" STREQUAL "0")
+    # The directory is write-able
+    set(${ok} 1 PARENT_SCOPE)
+  else()
+    set(${ok} 0 PARENT_SCOPE)
+  endif()
+endfunction()
 

--- a/cmake/extensions.cmake
+++ b/cmake/extensions.cmake
@@ -1021,3 +1021,58 @@ function(check_if_directory_is_writeable dir ok)
   endif()
 endfunction()
 
+function(find_appropriate_cache_directory dir)
+  set(env_suffix_LOCALAPPDATA   .cache)
+
+  if(CMAKE_HOST_APPLE)
+    # On macOS, ~/Library/Caches is the preferred cache directory.
+    set(env_suffix_HOME Library/Caches)
+  else()
+    set(env_suffix_HOME .cache)
+  endif()
+
+  # Determine which env vars should be checked
+  if(CMAKE_HOST_APPLE)
+    set(dirs HOME)
+  elseif(CMAKE_HOST_WIN32)
+    set(dirs LOCALAPPDATA)
+  else()
+    # Assume Linux when we did not detect 'mac' or 'win'
+    #
+    # On Linux, freedesktop.org recommends using $XDG_CACHE_HOME if
+    # that is defined and defaulting to $HOME/.cache otherwise.
+    set(dirs
+      XDG_CACHE_HOME
+      HOME
+      )
+  endif()
+
+  foreach(env_var ${dirs})
+    if(DEFINED ENV{${env_var}})
+      set(env_dir $ENV{${env_var}})
+
+      check_if_directory_is_writeable(${env_dir} ok)
+      if(${ok})
+        # The directory is write-able
+        set(user_dir ${env_dir}/${env_suffix_${env_var}})
+        break()
+      else()
+        # The directory was not writeable, keep looking for a suitable
+        # directory
+      endif()
+    endif()
+  endforeach()
+
+  # Populate local_dir with a suitable directory for caching
+  # files. Prefer a directory outside of the git repository because it
+  # is good practice to have clean git repositories.
+  if(DEFINED user_dir)
+    # Zephyr's cache files go in the "zephyr" subdirectory of the
+    # user's cache directory.
+    set(local_dir ${user_dir}/zephyr)
+  else()
+    set(local_dir ${ZEPHYR_BASE}/.cache)
+  endif()
+
+  set(${dir} ${local_dir} PARENT_SCOPE)
+endfunction()

--- a/cmake/toolchain.cmake
+++ b/cmake/toolchain.cmake
@@ -36,3 +36,17 @@ endif()
 # Configure the toolchain based on what toolchain technology is used
 # (gcc, host-gcc etc.)
 include(${ZEPHYR_BASE}/cmake/compiler/${COMPILER}.cmake OPTIONAL)
+
+# Uniquely identify the toolchain wrt. it's capabilities.
+#
+# What we are looking for, is a signature definition that is defined
+# like this:
+
+# Toolchains with the same signature will always support the same set
+# of flags.
+
+# It is not clear how this signature should be constructed. The
+# strategy chosen is to md5sum the CC binary.
+
+file(MD5 ${CMAKE_C_COMPILER} CMAKE_C_COMPILER_MD5_SUM)
+set(TOOLCHAIN_SIGNATURE ${CMAKE_C_COMPILER_MD5_SUM})

--- a/scripts/dir_is_writeable.py
+++ b/scripts/dir_is_writeable.py
@@ -1,0 +1,10 @@
+import os
+import sys
+
+def main():
+    is_writeable = os.access(sys.argv[1], os.W_OK)
+    return_code = int(not is_writeable)
+    sys.exit(return_code)
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
This PR fixes #5633 and optimizes the CMake configure-time by 50%.

It does this by introducing a caching version of check_compiler_flag called zephyr_check_compiler_flag.

zephyr_check_compiler_flag documents itself like this:

> zephyr_check_compiler_flag is a part of Zephyr's toolchain
> infrastructure. It should be used when testing toolchain
> capabilities and it should normally be used in place of the
> functions:
> 
> check_compiler_flag
> check_c_compiler_flag
> check_cxx_compiler_flag
> 
> See check_compiler_flag() for API documentation as it has the same
> API.
> 
> It is implemented as a wrapper on top of check_compiler_flag, which
> again wraps the CMake-builtin's check_c_compiler_flag and
> check_cxx_compiler_flag.
> 
> It takes time to check for compatibility of flags against toolchains
> so we cache the capability test results in USER_CACHE_DIR (This
> caching comes in addition to the caching that CMake does in the
> build folder's CMakeCache.txt)
> 

Several problems needed to be solved.

Such as; how do you identify a toolchain to know if you have already tested it's capabilities? https://github.com/zephyrproject-rtos/zephyr/commit/bd48249656ebac8ccb19d09fa6a290d196ba7038

Where do you store/cache the toolchain capability test results in a cross-platform manner? https://github.com/zephyrproject-rtos/zephyr/commit/b1a9f67a88eb257397a0bf1186f270c46e693dea