### PR TITLE
arch: arm: ARMv8-M address/address-range permissions checks (for secure firmware)

### DIFF
--- a/arch/arm/core/cortex_m/cmse/arm_core_cmse.c
+++ b/arch/arm/core/cortex_m/cmse/arm_core_cmse.c
@@ -70,3 +70,70 @@ int arm_cmse_addr_range_readwrite_ok(u32_t addr, u32_t size, int force_npriv)
 	return arm_cmse_addr_range_read_write_ok(addr, size, force_npriv, 1);
 }
 
+#if defined(CONFIG_ARM_SECURE_FIRMWARE)
+
+int arm_cmse_mpu_nonsecure_region_get(u32_t addr)
+{
+	cmse_address_info_t addr_info =	cmse_TTA((void *)addr);
+
+	if (addr_info.flags.mpu_region_valid) {
+		return  addr_info.flags.mpu_region;
+	}
+
+	return -EINVAL;
+}
+
+int arm_cmse_sau_region_get(u32_t addr)
+{
+	cmse_address_info_t addr_info =	cmse_TT((void *)addr);
+
+	if (addr_info.flags.sau_region_valid) {
+		return addr_info.flags.sau_region;
+	}
+
+	return -EINVAL;
+}
+
+int arm_cmse_idau_region_get(u32_t addr)
+{
+	cmse_address_info_t addr_info =	cmse_TT((void *)addr);
+
+	if (addr_info.flags.idau_region_valid) {
+		return addr_info.flags.idau_region;
+	}
+
+	return -EINVAL;
+}
+
+int arm_cmse_addr_is_secure(u32_t addr)
+{
+	cmse_address_info_t addr_info =	cmse_TT((void *)addr);
+
+	return addr_info.flags.secure;
+}
+
+static int arm_cmse_addr_nonsecure_read_write_ok(u32_t addr,
+	int force_npriv, int rw)
+{
+	cmse_address_info_t addr_info;
+	if (force_npriv) {
+		addr_info = cmse_TTAT((void *)addr);
+	} else {
+		addr_info = cmse_TTA((void *)addr);
+	}
+
+	return rw ? addr_info.flags.nonsecure_readwrite_ok :
+		addr_info.flags.nonsecure_read_ok;
+}
+
+int arm_cmse_addr_nonsecure_read_ok(u32_t addr, int force_npriv)
+{
+	return arm_cmse_addr_nonsecure_read_write_ok(addr, force_npriv, 0);
+}
+
+int arm_cmse_addr_nonsecure_read_write_ok(u32_t addr, int force_npriv)
+{
+	return arm_cmse_addr_nonsecure_read_write_ok(addr, force_npriv, 1);
+}
+
+#endif /* CONFIG_ARM_SECURE_FIRMWARE */

--- a/arch/arm/core/cortex_m/cmse/arm_core_cmse.c
+++ b/arch/arm/core/cortex_m/cmse/arm_core_cmse.c
@@ -7,15 +7,15 @@
 #include <zephyr.h>
 #include <cortex_m/cmse.h>
 
-int arm_cmse_mpu_region_get(u32_t addr, u8_t *p_region)
+int arm_cmse_mpu_region_get(u32_t addr)
 {
 	cmse_address_info_t addr_info =	cmse_TT((void *)addr);
 
 	if (addr_info.flags.mpu_region_valid) {
-		*p_region = addr_info.flags.mpu_region;
+		return addr_info.flags.mpu_region;
 	}
 
-	return addr_info.flags.mpu_region_valid;
+	return -EINVAL;
 }
 
 static int arm_cmse_addr_read_write_ok(u32_t addr, int force_npriv, int rw)

--- a/arch/arm/core/cortex_m/cmse/arm_core_cmse.c
+++ b/arch/arm/core/cortex_m/cmse/arm_core_cmse.c
@@ -131,9 +131,43 @@ int arm_cmse_addr_nonsecure_read_ok(u32_t addr, int force_npriv)
 	return arm_cmse_addr_nonsecure_read_write_ok(addr, force_npriv, 0);
 }
 
-int arm_cmse_addr_nonsecure_read_write_ok(u32_t addr, int force_npriv)
+int arm_cmse_addr_nonsecure_readwrite_ok(u32_t addr, int force_npriv)
 {
 	return arm_cmse_addr_nonsecure_read_write_ok(addr, force_npriv, 1);
+}
+
+static int arm_cmse_addr_range_nonsecure_read_write_ok(u32_t addr, u32_t size,
+	int force_npriv, int rw)
+{
+	int flags = CMSE_NONSECURE;
+
+	if (force_npriv) {
+		flags |= CMSE_MPU_UNPRIV;
+	}
+	if (rw) {
+		flags |= CMSE_MPU_READWRITE;
+	} else {
+		flags |= CMSE_MPU_READ;
+	}
+	if (cmse_check_address_range((void *)addr, size, flags) != NULL) {
+		return 1;
+	} else {
+		return 0;
+	}
+}
+
+int arm_cmse_addr_range_nonsecure_read_ok(u32_t addr, u32_t size,
+	int force_npriv)
+{
+	return arm_cmse_addr_range_nonsecure_read_write_ok(addr, size,
+		force_npriv, 0);
+}
+
+int arm_cmse_addr_range_nonsecure_readwrite_ok(u32_t addr, u32_t size,
+	int force_npriv)
+{
+	return arm_cmse_addr_range_nonsecure_read_write_ok(addr, size,
+		force_npriv, 1);
 }
 
 #endif /* CONFIG_ARM_SECURE_FIRMWARE */

--- a/arch/arm/include/cortex_m/cmse.h
+++ b/arch/arm/include/cortex_m/cmse.h
@@ -38,9 +38,8 @@ extern "C" {
 /**
  * @brief Get the MPU region number of an address
  *
- * Get the MPU region that the address maps to. Return non-zero
- * to indicate that a valid MPU region was retrieved, and store the
- * MPU region information in the supplied location.
+ * Return the non-negative MPU region that the address maps to,
+ * or -EINVAL to indicate that an invalid MPU region was retrieved.
  *
  * Note:
  * Obtained region is valid only if:
@@ -49,11 +48,10 @@ extern "C" {
  * - the given address matches a single, enabled MPU region
  *
  * @param addr The address for which the MPU region is requested
- * @param p_region Output pointer to the location to store the MPU region
  *
- * @return non-zero if @ref region contains a valid MPU region, otherwise 0.
-  */
-int arm_cmse_mpu_region_get(u32_t addr, u8_t *p_region);
+ * @return a valid MPU region number or -EINVAL
+ */
+int arm_cmse_mpu_region_get(u32_t addr);
 
 /**
  * @brief Read accessibility of an address

--- a/arch/arm/include/cortex_m/cmse.h
+++ b/arch/arm/include/cortex_m/cmse.h
@@ -27,6 +27,7 @@ extern "C" {
 #include <arm_cmse.h>
 #include <stdint.h>
 
+
 /*
  * Address information retrieval based on the TT instructions.
  *
@@ -213,6 +214,116 @@ int arm_cmse_addr_range_readwrite_ok(u32_t addr, u32_t size, int force_npriv);
  */
 #define ARM_CMSE_OBJECT_UNPRIV_READWRITE_OK(p_obj) \
 	cmse_check_pointed_object(p_obj, CMSE_MPU_UNPRIV | CMSE_MPU_READWRITE)
+
+#if defined(CONFIG_ARM_SECURE_FIRMWARE)
+
+/**
+ * @brief Get the MPU (Non-Secure) region number of an address
+ *
+ * Return the non-negative MPU (Non-Secure) region that the address maps to,
+ * or -EINVAL to indicate that an invalid MPU region was retrieved.
+ *
+ * Note:
+ * Obtained region is valid only if:
+ * - the function is called from Secure state
+ * - the MPU is implemented and enabled
+ * - the given address matches a single, enabled MPU region
+ *
+ * @param addr The address for which the MPU region is requested
+ *
+ * @return a valid MPU region number or -EINVAL
+  */
+int arm_cmse_mpu_nonsecure_region_get(u32_t addr);
+
+/**
+ * @brief Get the SAU region number of an address
+ *
+ * Return the non-negative SAU (Non-Secure) region that the address maps to,
+ * or -EINVAL to indicate that an invalid SAU region was retrieved.
+ *
+ * Note:
+ * Obtained region is valid only if:
+ * - the function is called from Secure state
+ * - the SAU is implemented and enabled
+ * - the given address is not exempt from the secure memory attribution
+ *
+ * @param addr The address for which the SAU region is requested
+ *
+ * @return a valid SAU region number or -EINVAL
+  */
+int arm_cmse_sau_region_get(u32_t addr);
+
+/**
+ * @brief Get the IDAU region number of an address
+ *
+ * Return the non-negative IDAU (Non-Secure) region that the address maps to,
+ * or -EINVAL to indicate that an invalid IDAU region was retrieved.
+ *
+ * Note:
+ * Obtained region is valid only if:
+ * - the function is called from Secure state
+ * - the IDAU can provide a region number
+ * - the given address is not exempt from the secure memory attribution
+ *
+ * @param addr The address for which the IDAU region is requested
+ *
+ * @return a valid IDAU region number or -EINVAL
+  */
+int arm_cmse_idau_region_get(u32_t addr);
+
+/**
+ * @brief Security attribution of an address
+ *
+ * Evaluates whether a specified memory location belongs to a Secure region.
+ * This function shall always return zero if executed from Non-Secure state.
+ *
+ * @param addr The address for which the security attribution is requested
+ *
+ * @return 1 if address is Secure, 0 otherwise.
+ */
+int arm_cmse_addr_is_secure(u32_t addr);
+
+/**
+ * @brief Non-Secure Read accessibility of an address
+ *
+ * Evaluates whether a specified memory location can be read from Non-Secure
+ * state according to the permissions of the Non-Secure state MPU and the
+ * specified operation mode.
+ *
+ * This function shall always return zero:
+ * - if executed from Non-Secure state
+ * - if the address matches multiple MPU regions.
+ *
+ * @param addr The address for which the readability is requested
+ * @param force_npriv Instruct to return the readability of the address
+ *                    for unprivileged access, regardless of whether the current
+ *                    mode is privileged or unprivileged.
+ *
+ * @return 1 if address is readable from Non-Secure state, 0 otherwise.
+ */
+int arm_cmse_addr_nonsecure_read_ok(u32_t addr, int force_npriv);
+
+/**
+ * @brief Non-Secure Read and Write accessibility of an address
+ *
+ * Evaluates whether a specified memory location can be read/written from
+ * Non-Secure state according to the permissions of the Non-Secure state MPU
+ * and the specified operation mode.
+ *
+ * This function shall always return zero:
+ * - if executed from Non-Secure  mode,
+ * - if the address matches multiple MPU regions.
+ *
+ * @param addr The address for which the RW ability is requested
+ * @param force_npriv Instruct to return the RW ability of the address
+ *                    for unprivileged access, regardless of whether the current
+ *                    mode is privileged or unprivileged.
+ *
+ * @return 1 if address is Read and Writable from Non-Secure state, 0 otherwise
+ */
+int arm_cmse_addr_nonsecure_read_write_ok(u32_t addr, int force_npriv);
+
+#endif /* CONFIG_ARM_SECURE_FIRMWARE */
 
 #endif /* _ASMLANGUAGE */
 

--- a/arch/arm/include/cortex_m/cmse.h
+++ b/arch/arm/include/cortex_m/cmse.h
@@ -367,6 +367,80 @@ int arm_cmse_addr_range_nonsecure_read_ok(u32_t addr, u32_t size,
 int arm_cmse_addr_range_nonsecure_readwrite_ok(u32_t addr, u32_t size,
 	int force_npriv);
 
+/**
+ * @brief Non-Secure Read accessibility of an object
+ *
+ * Evaluates whether a given object can be read according to the
+ * permissions of the Non-Secure state MPU.
+ *
+ * The macro shall always evaluate to zero if called from Non-Secure state.
+ *
+ * @param p_obj Pointer to the given object
+ *              for which the readability is requested
+ *
+ * @pre Object is allocated in a single MPU region.
+ *
+ * @return p_obj if object is readable from Non-Secure state, NULL otherwise.
+ */
+#define ARM_CMSE_OBJECT_NONSECURE_READ_OK(p_obj) \
+	cmse_check_pointed_object(p_obj, CMSE_NONSECURE | CMSE_MPU_READ)
+
+/**
+ * @brief Non-Secure Read accessibility of an object (nPRIV mode)
+ *
+ * Evaluates whether a given object can be read according to the
+ * permissions of the Non-Secure state MPU (unprivileged read).
+ *
+ * The macro shall always evaluate to zero if called from Non-Secure state.
+ *
+ * @param p_obj Pointer to the given object
+ *              for which the readability is requested
+ *
+ * @pre Object is allocated in a single MPU region.
+ *
+ * @return p_obj if object is readable from Non-Secure state, NULL otherwise.
+ */
+#define ARM_CMSE_OBJECT_NONSECURE_UNPRIV_READ_OK(p_obj) \
+	cmse_check_pointed_object(p_obj, \
+		CMSE_NONSECURE | CMSE_MPU_UNPRIV | CMSE_MPU_READ)
+
+/**
+ * @brief Non-Secure Read and Write accessibility of an object
+ *
+ * Evaluates whether a given object can be read and written
+ * according to the permissions of the Non-Secure state MPU.
+ *
+ * The macro shall always evaluate to zero if called from Non-Secure state.
+ *
+ * @param p_obj Pointer to the given object
+ *              for which the read and write ability is requested
+ *
+ * @pre Object is allocated in a single MPU region.
+ *
+ * @return p_obj if object is Non-Secure Read and Writable, NULL otherwise.
+ */
+#define ARM_CMSE_OBJECT_NONSECURE_READWRITE_OK(p_obj) \
+	cmse_check_pointed_object(p_obj, CMSE_NONSECURE | CMSE_MPU_READWRITE)
+
+/**
+ * @brief Non-Secure Read and Write accessibility of an object (nPRIV mode)
+ *
+ * Evaluates whether a given object can be read and written according
+ * to the permissions of the Non-Secure state MPU (unprivileged read/write).
+ *
+ * The macro shall always evaluate to zero if called from Non-Secure state.
+ *
+ * @param p_obj Pointer to the given object
+ *              for which the read and write ability is requested
+ *
+ * @pre Object is allocated in a single MPU region.
+ *
+ * @return p_obj if object is Non-Secure Read and Writable, NULL otherwise.
+ */
+#define ARM_CMSE_OBJECT_NON_SECURE_UNPRIV_READWRITE_OK(p_obj) \
+	cmse_check_pointed_object(p_obj, \
+			CMSE_NONSECURE | CMSE_MPU_UNPRIV | CMSE_MPU_READWRITE)
+
 #endif /* CONFIG_ARM_SECURE_FIRMWARE */
 
 #endif /* _ASMLANGUAGE */

--- a/arch/arm/include/cortex_m/cmse.h
+++ b/arch/arm/include/cortex_m/cmse.h
@@ -319,7 +319,53 @@ int arm_cmse_addr_nonsecure_read_ok(u32_t addr, int force_npriv);
  *
  * @return 1 if address is Read and Writable from Non-Secure state, 0 otherwise
  */
-int arm_cmse_addr_nonsecure_read_write_ok(u32_t addr, int force_npriv);
+int arm_cmse_addr_nonsecure_readwrite_ok(u32_t addr, int force_npriv);
+
+/**
+ * @brief Non-Secure Read accessibility of an address range
+ *
+ * Evaluates whether a memory address range, specified by its base address
+ * and size, can be read according to the permissions of the Non-Secure state
+ * MPU and the specified operation mode.
+ *
+ * This function shall always return zero:
+ * - if executed from Non-Secure  mode,
+ * - if the address matches multiple MPU (and/or SAU/IDAU) regions.
+ *
+ * @param addr The base address of an address range,
+ *             for which the readability is requested
+ * @param size The size of the address range
+ * @param force_npriv Instruct to return the readability of the address range
+ *                    for unprivileged access, regardless of whether the current
+ *                    mode is privileged or unprivileged.
+ *
+ * @return 1 if address range is readable, 0 otherwise.
+ */
+int arm_cmse_addr_range_nonsecure_read_ok(u32_t addr, u32_t size,
+	int force_npriv);
+
+/**
+ * @brief Non-Secure Read and Write accessibility of an address range
+ *
+ * Evaluates whether a memory address range, specified by its base address
+ * and size, can be read and written according to the permissions of the
+ * Non-Secure state MPU and the specified operation mode.
+ *
+ * This function shall always return zero:
+ * - if executed from Non-Secure  mode,
+ * - if the address matches multiple MPU (and/or SAU/IDAU) regions.
+ *
+ * @param addr The base address of an address range,
+ *             for which Read and Write ability is requested
+ * @param size The size of the address range
+ * @param force_npriv Instruct to return the readability of the address range
+ *                    for unprivileged access, regardless of whether the current
+ *                    mode is privileged or unprivileged.
+ *
+ * @return 1 if address range is readable, 0 otherwise.
+ */
+int arm_cmse_addr_range_nonsecure_readwrite_ok(u32_t addr, u32_t size,
+	int force_npriv);
 
 #endif /* CONFIG_ARM_SECURE_FIRMWARE */
 


### PR DESCRIPTION
An extension of #6845 for ARMv8-M systems with Security Extension.
Overlaps and blocked by #6845 

Update: #6845 is merged, so this PR contains only the added parts for Secure permissions

