### PR TITLE
usb: usb_dc_dw: Fix incorrect MPS return

### DIFF
--- a/drivers/usb/device/usb_dc_dw.c
+++ b/drivers/usb/device/usb_dc_dw.c
@@ -1187,5 +1187,15 @@ int usb_dc_set_status_callback(const usb_dc_status_callback cb)
 
 int usb_dc_ep_mps(const u8_t ep)
 {
-	return usb_dw_ctrl.out_ep_ctrl[USB_DW_EP_ADDR2IDX(ep)].mps;
+	enum usb_dw_out_ep_idx ep_idx = USB_DW_EP_ADDR2IDX(ep);
+
+	switch (USB_DW_EP_ADDR2DIR(ep)) {
+	case USB_EP_DIR_OUT:
+		return usb_dw_ctrl.out_ep_ctrl[ep_idx].mps;
+	case USB_EP_DIR_IN:
+		return usb_dw_ctrl.in_ep_ctrl[ep_idx].mps;
+	}
+
+	/* Should not happen */
+	return 0;
 }


### PR DESCRIPTION
Because of incorrectly set MPS we always got 0 returned for WRITE
transfers and ZLP were always generated for every packet.

Signed-off-by: Andrei Emeltchenko <andrei.emeltchenko@intel.com>