### PR TITLE
lib: json: Efficiently pack field name, offset, alignment, type

### DIFF
--- a/lib/json/json.c
+++ b/lib/json/json.c
@@ -476,8 +476,6 @@ static int decode_value(struct json_obj *obj,
 
 static ptrdiff_t get_elem_size(const struct json_obj_descr *descr)
 {
-	assert(descr->alignment);
-
 	switch (descr->type) {
 	case JSON_TOK_NUMBER:
 		return sizeof(s32_t);
@@ -495,7 +493,7 @@ static ptrdiff_t get_elem_size(const struct json_obj_descr *descr)
 		for (i = 0; i < descr->object.sub_descr_len; i++) {
 			ptrdiff_t s = get_elem_size(&descr->object.sub_descr[i]);
 
-			total += ROUND_UP(s, descr->alignment);
+			total += ROUND_UP(s, descr->alignment + 1);
 		}
 
 		return total;


### PR DESCRIPTION
This trades a little bit over 40 bytes (on x86) of text for a lot of savings in rodata.  This is accomplished by using bitfields to pack the field name length, offset, alignment, and the type tag into a single 32-bit unsigned integer instead of scattering this information into four different integers.

Signed-off-by: Leandro Pereira <leandro.pereira@intel.com>