### PR TITLE
cmake: toolchain: Improve error feedback when toolchain is not found

### DIFF
--- a/cmake/compiler/gcc.cmake
+++ b/cmake/compiler/gcc.cmake
@@ -11,7 +11,15 @@ find_program(CMAKE_READELF    ${CROSS_COMPILE}readelf PATH ${TOOLCHAIN_HOME} NO_
 find_program(CMAKE_GDB        ${CROSS_COMPILE}gdb     PATH ${TOOLCHAIN_HOME} NO_DEFAULT_PATH)
 find_program(CMAKE_NM         ${CROSS_COMPILE}nm      PATH ${TOOLCHAIN_HOME} NO_DEFAULT_PATH)
 
-assert_exists(CMAKE_READELF)
+if(CMAKE_C_COMPILER STREQUAL CMAKE_C_COMPILER-NOTFOUND)
+  message(FATAL_ERROR "Zephyr was unable to find the toolchain. Is the environment misconfigured?
+User-configuration:
+ZEPHYR_TOOLCHAIN_VARIANT: ${ZEPHYR_TOOLCHAIN_VARIANT}
+Internal variables:
+CROSS_COMPILE: ${CROSS_COMPILE}
+TOOLCHAIN_HOME: ${TOOLCHAIN_HOME}
+")
+endif()
 
 if(CONFIG_CPLUSPLUS)
   set(cplusplus_compiler ${CROSS_COMPILE}g++)


### PR DESCRIPTION
Improve the error feedback when the toolchain is not found.

Currently, for some setups, presumably primarily SDK-less setups,
users can get an error message like this for certain types of
misconfigurations:

CMake Error at /home/ubuntu/Desktop/zephyr/cmake/extensions.cmake:984 (message):
  No such file or directory: CMAKE_READELF: 'CMAKE_READELF-NOTFOUND'
Call Stack (most recent call first):
  /home/ubuntu/Desktop/zephyr/cmake/compiler/gcc.cmake:14 (assert_exists)
  /home/ubuntu/Desktop/zephyr/cmake/toolchain.cmake:38 (include)
  /home/ubuntu/Desktop/zephyr/cmake/app/boilerplate.cmake:243 (include)
  CMakeLists.txt:1 (include)

This commit will improve the error feedback to give a explanation for
what kind of failure has occured and will also dump relevant variables
to ease debugging.

This fixes #7075

Signed-off-by: Sebastian Bøe <sebastian.boe@nordicsemi.no>