### PR TITLE
net: ipv6: Fix crash from double free of fragment

### DIFF
--- a/subsys/net/ip/ipv6.c
+++ b/subsys/net/ip/ipv6.c
@@ -3485,6 +3485,7 @@ static enum net_verdict handle_fragment_hdr(struct net_pkt *pkt,
 		 * list. We must discard the whole packet at this point.
 		 */
 		NET_DBG("No slots available for 0x%x", reass->id);
+		net_pkt_unref(pkt);
 		goto drop;
 	}
 
@@ -3515,6 +3516,7 @@ static enum net_verdict handle_fragment_hdr(struct net_pkt *pkt,
 			reass->pkt[i] = NULL;
 		}
 
+		net_pkt_unref(pkt);
 		goto drop;
 	}
 
@@ -3526,7 +3528,9 @@ accept:
 
 drop:
 	if (reass) {
-		reassembly_cancel(reass->id, &reass->src, &reass->dst);
+		if (reassembly_cancel(reass->id, &reass->src, &reass->dst)) {
+			return NET_OK;
+		}
 	}
 
 	return NET_DROP;


### PR DESCRIPTION
This commit fixes crash caused by double free from message sequence
fragmentation. When double free happens the call stack is:

0  reassembly_cancel
1  handle_fragment_hdr
2  net_ipv6_process_pkt
3  process_data
4  processing_data
5  net_rx
6  process_rx_packet
7  work_q_main
8  _thread_entry

So at first packet is unrefed in reassembly_cancel and then also in
processing_data.

Signed-off-by: Ruslan Mstoi <ruslan.mstoi@intel.com>