### PR TITLE
cmake: Add support for loading a defaults file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,7 @@ cscope.*
 .dir
 outdir
 outdir-*
+defaults.cmake
 scripts/basic/fixdep
 scripts/gen_idt/gen_idt
 scripts/kconfig/conf

--- a/cmake/app/boilerplate.cmake
+++ b/cmake/app/boilerplate.cmake
@@ -84,6 +84,12 @@ set(AUTOCONF_H ${__build_dir}/include/generated/autoconf.h)
 # Re-configure (Re-execute all CMakeLists.txt code) when autoconf.h changes
 set_property(DIRECTORY APPEND PROPERTY CMAKE_CONFIGURE_DEPENDS ${AUTOCONF_H})
 
+# Load additional default values from the user
+if (EXISTS ${ZEPHYR_BASE}/defaults.cmake)
+  message(STATUS "Loading additional defaults")
+  include(${ZEPHYR_BASE}/defaults.cmake)
+endif()
+
 include(${ZEPHYR_BASE}/cmake/extensions.cmake)
 
 find_package(PythonInterp 3.4)

--- a/doc/application/application.rst
+++ b/doc/application/application.rst
@@ -154,6 +154,13 @@ configure the Zephyr build system:
   can also be defined in the environment, in your application's
   :file:`CMakeLists.txt` file, or in the ``cmake`` command line.
 
+Additionally, if you have a single Zephyr copy that you use to build multiple
+applications against, you can also set CMake defaults using the
+:file:`{ZEPHYR_BASE}/defaults.cmake`. This file does not exist by default, but
+you can create it to share CMake variables across multiple applications. For
+example, you could use it to define a string or a path that is unique to your
+applications. If the file exists, the Zephyr build system will load it.
+
 .. _build_an_application:
 
 Build an Application


### PR DESCRIPTION
In order to avoid (ab)using environment variables, add the possibility
of using a CMake defaults file that is loaded in the boilerplate.

Signed-off-by: Carles Cufi <carles.cufi@nordicsemi.no>