### PR TITLE
dts: Add led nodes to nxp boards, refactor mcux gpio driver to use dts

### DIFF
--- a/arch/arm/soc/nxp_kinetis/k6x/soc.h
+++ b/arch/arm/soc/nxp_kinetis/k6x/soc.h
@@ -35,11 +35,6 @@ extern "C" {
 
 #define IRQ_SPI0 26
 #define IRQ_SPI1 27
-#define IRQ_GPIO_PORTA 59
-#define IRQ_GPIO_PORTB 60
-#define IRQ_GPIO_PORTC 61
-#define IRQ_GPIO_PORTD 62
-#define IRQ_GPIO_PORTE 63
 #define IRQ_ETH_IEEE1588_TMR 82
 #define IRQ_ETH_TX 83
 #define IRQ_ETH_RX 84

--- a/arch/arm/soc/nxp_kinetis/kl2x/soc.h
+++ b/arch/arm/soc/nxp_kinetis/kl2x/soc.h
@@ -18,8 +18,6 @@ extern "C" {
 /* IRQs */
 #define IRQ_SPI0		10
 #define IRQ_SPI1                11
-#define IRQ_GPIO_PORTA          30
-#define IRQ_GPIO_PORTD          31
 
 #ifndef _ASMLANGUAGE
 

--- a/arch/arm/soc/nxp_kinetis/kwx/soc.h
+++ b/arch/arm/soc/nxp_kinetis/kwx/soc.h
@@ -22,9 +22,6 @@ extern "C" {
 
 #define IRQ_SPI0 10
 #define IRQ_SPI1 29
-#define IRQ_GPIO_PORTA 30
-#define IRQ_GPIO_PORTB 31
-#define IRQ_GPIO_PORTC 31
 
 #endif
 
@@ -35,11 +32,6 @@ extern "C" {
 /* IRQs */
 #define IRQ_SPI0 26
 #define IRQ_SPI1 27
-#define IRQ_GPIO_PORTA 59
-#define IRQ_GPIO_PORTB 60
-#define IRQ_GPIO_PORTC 61
-#define IRQ_GPIO_PORTD 62
-#define IRQ_GPIO_PORTE 63
 
 #endif
 

--- a/boards/arm/frdm_k64f/board.h
+++ b/boards/arm/frdm_k64f/board.h
@@ -9,42 +9,4 @@
 
 #include <soc.h>
 
-/* Push button switch 2 */
-#define SW2_GPIO_NAME	CONFIG_GPIO_MCUX_PORTC_NAME
-#define SW2_GPIO_PIN	6
-
-/* Push button switch 3 */
-#define SW3_GPIO_NAME	CONFIG_GPIO_MCUX_PORTA_NAME
-#define SW3_GPIO_PIN	4
-
-/* Red LED */
-#define RED_GPIO_NAME	CONFIG_GPIO_MCUX_PORTB_NAME
-#define RED_GPIO_PIN	22
-
-/* Green LED */
-#define GREEN_GPIO_NAME	CONFIG_GPIO_MCUX_PORTE_NAME
-#define GREEN_GPIO_PIN	26
-
-/* Blue LED */
-#define BLUE_GPIO_NAME	CONFIG_GPIO_MCUX_PORTB_NAME
-#define BLUE_GPIO_PIN	21
-
-/* LED0. There is no physical LED on the board with this name, so create an
- * alias to the green LED to make various samples work.
- */
-#define LED0_GPIO_PORT	GREEN_GPIO_NAME
-#define LED0_GPIO_PIN	GREEN_GPIO_PIN
-
-/* LED1. There is no physical LED on the board with this name, so create an
- * alias to the blue LED to make various samples work.
- */
-#define LED1_GPIO_PORT	BLUE_GPIO_NAME
-#define LED1_GPIO_PIN 	BLUE_GPIO_PIN
-
-/* Push button switch 0. There is no physical switch on the board with this
- * name, so create an alias to SW3 to make the basic button sample work.
- */
-#define SW0_GPIO_NAME	SW3_GPIO_NAME
-#define SW0_GPIO_PIN	SW3_GPIO_PIN
-
 #endif /* __INC_BOARD_H */

--- a/boards/arm/frdm_k64f/frdm_k64f.dts
+++ b/boards/arm/frdm_k64f/frdm_k64f.dts
@@ -28,6 +28,11 @@
 		i2c-0 = &i2c0;
 		i2c-1 = &i2c1;
 		i2c-2 = &i2c2;
+		led0 = &green_led;
+		led1 = &blue_led;
+		led2 = &red_led;
+		sw0 = &user_button_3;
+		sw1 = &user_button_2;
 	};
 
 	chosen {
@@ -38,6 +43,36 @@
 		zephyr,bt-uart = &uart3;
 #endif
 		zephyr,uart-pipe = &uart0;
+	};
+
+	leds {
+		compatible = "gpio-leds";
+		red_led: led@0 {
+			gpios = <&gpiob 22 GPIO_INT_ACTIVE_LOW>;
+			label = "User LD1";
+		};
+		green_led: led@1 {
+			gpios = <&gpioe 26 GPIO_INT_ACTIVE_LOW>;
+			label = "User LD2";
+		};
+		blue_led: led@2 {
+			gpios = <&gpiob 21 GPIO_INT_ACTIVE_LOW>;
+			label = "User LD3";
+		};
+	};
+
+	gpio_keys {
+		compatible = "gpio-keys";
+		#address-cells = <1>;
+		#size-cells = <0>;
+		user_button_2: button@0 {
+			label = "User SW2";
+			gpios = <&gpioc 6 GPIO_INT_ACTIVE_LOW>;
+		};
+		user_button_3: button@1 {
+			label = "User SW3";
+			gpios = <&gpioa 4 GPIO_INT_ACTIVE_LOW>;
+		};
 	};
 };
 

--- a/boards/arm/frdm_kl25z/board.h
+++ b/boards/arm/frdm_kl25z/board.h
@@ -9,42 +9,4 @@
 
 #include <soc.h>
 
-/* Push button switch for test purposes */
-#define SW0_TEST_GPIO_NAME	CONFIG_GPIO_MCUX_PORTA_NAME
-#define SW0_TEST_GPIO_PIN	16
-
-/* Push button switch for test purposes */
-#define SW1_TEST_GPIO_NAME	CONFIG_GPIO_MCUX_PORTA_NAME
-#define SW1_TEST_GPIO_PIN	17
-
-/* Red LED */
-#define RED_GPIO_NAME	CONFIG_GPIO_MCUX_PORTB_NAME
-#define RED_GPIO_PIN	18
-
-/* Green LED */
-#define GREEN_GPIO_NAME	CONFIG_GPIO_MCUX_PORTB_NAME
-#define GREEN_GPIO_PIN	19
-
-/* Blue LED */
-#define BLUE_GPIO_NAME	CONFIG_GPIO_MCUX_PORTD_NAME
-#define BLUE_GPIO_PIN	1
-
-/* LED0. There is no physical LED on the board with this name, so create an
- * alias to the green LED to make various samples work.
- */
-#define LED0_GPIO_PORT	GREEN_GPIO_NAME
-#define LED0_GPIO_PIN	GREEN_GPIO_PIN
-
-/* LED1. There is no physical LED on the board with this name, so create an
- * alias to the blue LED to make various samples work.
- */
-#define LED1_GPIO_PORT	BLUE_GPIO_NAME
-#define LED1_GPIO_PIN	BLUE_GPIO_PIN
-
-/* Push button switch 0. There is no physical switch on the board,
- * so an push button must be added to such pins for basic button sample work.
- */
-#define SW0_GPIO_NAME	SW0_TEST_GPIO_NAME
-#define SW0_GPIO_PIN	SW0_TEST_GPIO_PIN
-
 #endif /* __INC_BOARD_H */

--- a/boards/arm/frdm_kl25z/frdm_kl25z.dts
+++ b/boards/arm/frdm_kl25z/frdm_kl25z.dts
@@ -11,12 +11,52 @@
 		uart-0 = &uart0;
 		i2c-0 = &i2c0;
 		i2c-1 = &i2c1;
+		gpio-a = &gpioa;
+		gpio-b = &gpiob;
+		gpio-c = &gpioc;
+		gpio-d = &gpiod;
+		gpio-e = &gpioe;
+		led0 = &green_led;
+		led1 = &blue_led;
+		led2 = &red_led;
+		sw0 = &user_button_0;
+		sw1 = &user_button_1;
 	};
 
 	chosen {
 		zephyr,sram = &sram0;
 		zephyr,flash = &flash0;
 		zephyr,console = &uart0;
+	};
+
+	leds {
+		compatible = "gpio-leds";
+		red_led: led@0 {
+			gpios = <&gpiob 18 GPIO_INT_ACTIVE_LOW>;
+			label = "User LD1";
+		};
+		green_led: led@1 {
+			gpios = <&gpiob 19 GPIO_INT_ACTIVE_LOW>;
+			label = "User LD2";
+		};
+		blue_led: led@2 {
+			gpios = <&gpiod 1 GPIO_INT_ACTIVE_LOW>;
+			label = "User LD3";
+		};
+	};
+
+	gpio_keys {
+		compatible = "gpio-keys";
+		#address-cells = <1>;
+		#size-cells = <0>;
+		user_button_0: button@0 {
+			label = "User SW0";
+			gpios = <&gpioa 16 GPIO_INT_ACTIVE_LOW>;
+		};
+		user_button_1: button@1 {
+			label = "User SW1";
+			gpios = <&gpioa 17 GPIO_INT_ACTIVE_LOW>;
+		};
 	};
 };
 

--- a/boards/arm/frdm_kw41z/board.h
+++ b/boards/arm/frdm_kw41z/board.h
@@ -9,42 +9,4 @@
 
 #include <soc.h>
 
-/* Push button switch 3 */
-#define SW3_GPIO_NAME	CONFIG_GPIO_MCUX_PORTC_NAME
-#define SW3_GPIO_PIN	4
-
-/* Push button switch 4 */
-#define SW4_GPIO_NAME	CONFIG_GPIO_MCUX_PORTC_NAME
-#define SW4_GPIO_PIN	5
-
-/* Red LED */
-#define RED_GPIO_NAME	CONFIG_GPIO_MCUX_PORTC_NAME
-#define RED_GPIO_PIN	1
-
-/* Green LED */
-#define GREEN_GPIO_NAME	CONFIG_GPIO_MCUX_PORTA_NAME
-#define GREEN_GPIO_PIN	19
-
-/* Blue LED */
-#define BLUE_GPIO_NAME	CONFIG_GPIO_MCUX_PORTA_NAME
-#define BLUE_GPIO_PIN	18
-
-/* LED0. There is no physical LED on the board with this name, so create an
- * alias to the green LED to make various samples work.
- */
-#define LED0_GPIO_PORT	GREEN_GPIO_NAME
-#define LED0_GPIO_PIN	GREEN_GPIO_PIN
-
-/* LED1. There is no physical LED on the board with this name, so create an
- * alias to the blue LED to make various samples work.
- */
-#define LED1_GPIO_PORT	BLUE_GPIO_NAME
-#define LED1_GPIO_PIN	BLUE_GPIO_PIN
-
-/* Push button switch 0. There is no physical switch on the board with this
- * name, so create an alias to SW3 to make the basic button sample work.
- */
-#define SW0_GPIO_NAME	SW3_GPIO_NAME
-#define SW0_GPIO_PIN	SW3_GPIO_PIN
-
 #endif /* __INC_BOARD_H */

--- a/boards/arm/frdm_kw41z/frdm_kw41z.dts
+++ b/boards/arm/frdm_kw41z/frdm_kw41z.dts
@@ -17,12 +17,47 @@
 		gpio-c = &gpioc;
 		i2c-0 = &i2c0;
 		i2c-1 = &i2c1;
+		led0 = &green_led;
+		led1 = &blue_led;
+		led2 = &red_led;
+		sw0 = &user_button_3;
+		sw1 = &user_button_4;
 	};
 
 	chosen {
 		zephyr,sram = &sram0;
 		zephyr,flash = &flash0;
 		zephyr,console = &lpuart0;
+	};
+
+	leds {
+		compatible = "gpio-leds";
+		red_led: led@0 {
+			gpios = <&gpioc 1 GPIO_INT_ACTIVE_LOW>;
+			label = "User LD1";
+		};
+		green_led: led@1 {
+			gpios = <&gpioa 19 GPIO_INT_ACTIVE_LOW>;
+			label = "User LD2";
+		};
+		blue_led: led@2 {
+			gpios = <&gpioa 18 GPIO_INT_ACTIVE_LOW>;
+			label = "User LD3";
+		};
+	};
+
+	gpio_keys {
+		compatible = "gpio-keys";
+		#address-cells = <1>;
+		#size-cells = <0>;
+		user_button_3: button@0 {
+			label = "User SW3";
+			gpios = <&gpioc 4 GPIO_INT_ACTIVE_LOW>;
+		};
+		user_button_4: button@1 {
+			label = "User SW4";
+			gpios = <&gpioc 5 GPIO_INT_ACTIVE_LOW>;
+		};
 	};
 };
 

--- a/boards/arm/hexiwear_k64/board.h
+++ b/boards/arm/hexiwear_k64/board.h
@@ -20,26 +20,6 @@
 #define BLUE_PWM_NAME		CONFIG_FTM_3_NAME
 #define BLUE_PWM_CHANNEL	5
 
-#else
-
-/* Red LED */
-#define RED_GPIO_NAME		CONFIG_GPIO_MCUX_PORTC_NAME
-#define RED_GPIO_PIN		8
-
-/* Green LED */
-#define GREEN_GPIO_NAME		CONFIG_GPIO_MCUX_PORTD_NAME
-#define GREEN_GPIO_PIN		0
-
-/* Blue LED */
-#define BLUE_GPIO_NAME		CONFIG_GPIO_MCUX_PORTC_NAME
-#define BLUE_GPIO_PIN		9
-
-/* LED0. There is no physical LED on the board with this name, so create an
- * alias to the green LED to make the basic blinky sample work.
- */
-#define LED0_GPIO_PORT	GREEN_GPIO_NAME
-#define LED0_GPIO_PIN	GREEN_GPIO_PIN
-
 #endif /* CONFIG_PWM_3 */
 
 #endif /* __INC_BOARD_H */

--- a/boards/arm/hexiwear_k64/hexiwear_k64.dts
+++ b/boards/arm/hexiwear_k64/hexiwear_k64.dts
@@ -28,6 +28,9 @@
 		i2c-0 = &i2c0;
 		i2c-1 = &i2c1;
 		i2c-2 = &i2c2;
+		led0 = &green_led;
+		led1 = &blue_led;
+		led2 = &red_led;
 	};
 
 	chosen {
@@ -39,6 +42,21 @@
 #endif
 	};
 
+	leds {
+		compatible = "gpio-leds";
+		red_led: led@0 {
+			gpios = <&gpioc 8 GPIO_INT_ACTIVE_LOW>;
+			label = "User LD1";
+		};
+		green_led: led@1 {
+			gpios = <&gpiod 0 GPIO_INT_ACTIVE_LOW>;
+			label = "User LD2";
+		};
+		blue_led: led@2 {
+			gpios = <&gpioc 9 GPIO_INT_ACTIVE_LOW>;
+			label = "User LD3";
+		};
+	};
 };
 
 &adc0 {

--- a/boards/arm/hexiwear_k64/pinmux.c
+++ b/boards/arm/hexiwear_k64/pinmux.c
@@ -56,7 +56,7 @@ static int hexiwear_k64_pinmux_init(struct device *dev)
 	/* 3V3B_EN */
 	pinmux_pin_set(portb, 12, PORT_PCR_MUX(kPORT_MuxAsGpio));
 
-	struct device *gpiob = device_get_binding(CONFIG_GPIO_MCUX_PORTB_NAME);
+	struct device *gpiob = device_get_binding(GPIO_B_LABEL);
 
 	gpio_pin_configure(gpiob, 12, GPIO_DIR_OUT);
 	gpio_pin_write(gpiob, 12, 0);
@@ -91,7 +91,7 @@ static int hexiwear_k64_pinmux_init(struct device *dev)
 	/* LDO - MAX30101 power supply */
 	pinmux_pin_set(porta, 29, PORT_PCR_MUX(kPORT_MuxAsGpio));
 
-	struct device *gpioa = device_get_binding(CONFIG_GPIO_MCUX_PORTA_NAME);
+	struct device *gpioa = device_get_binding(GPIO_A_LABEL);
 
 	gpio_pin_configure(gpioa, 29, GPIO_DIR_OUT);
 	gpio_pin_write(gpioa, 29, 1);
@@ -100,7 +100,7 @@ static int hexiwear_k64_pinmux_init(struct device *dev)
 #ifdef CONFIG_BATTERY_SENSE
 	pinmux_pin_set(portc, 14, PORT_PCR_MUX(kPORT_MuxAsGpio));
 
-	struct device *gpioc = device_get_binding(CONFIG_GPIO_MCUX_PORTC_NAME);
+	struct device *gpioc = device_get_binding(GPIO_C_LABEL);
 
 	gpio_pin_configure(gpioc, 14, GPIO_DIR_OUT);
 	gpio_pin_write(gpioc, 14, 0);

--- a/boards/arm/usb_kw24d512/board.h
+++ b/boards/arm/usb_kw24d512/board.h
@@ -9,16 +9,4 @@
 
 #include <soc.h>
 
-/* Push button switch (SW1) */
-#define SW0_GPIO_NAME	CONFIG_GPIO_MCUX_PORTC_NAME
-#define SW0_GPIO_PIN	4
-
-/* LED0 (D2) */
-#define LED0_GPIO_PORT	CONFIG_GPIO_MCUX_PORTD_NAME
-#define LED0_GPIO_PIN	4
-
-/* LED1 (D3) */
-#define LED1_GPIO_PORT	CONFIG_GPIO_MCUX_PORTD_NAME
-#define LED1_GPIO_PIN	5
-
 #endif /* __INC_BOARD_H */

--- a/boards/arm/usb_kw24d512/usb_kw24d512.dts
+++ b/boards/arm/usb_kw24d512/usb_kw24d512.dts
@@ -19,6 +19,9 @@
 		gpio-d = &gpiod;
 		gpio-e = &gpioe;
 		i2c-0 = &i2c0;
+		led0 = &led_0;
+		led1 = &led_1;
+		sw0 = &user_button_1;
 	};
 
 	chosen {
@@ -26,6 +29,28 @@
 		zephyr,flash = &flash0;
 		zephyr,console = &uart0;
 		zephyr,uart-pipe = &uart0;
+	};
+
+	leds {
+		compatible = "gpio-leds";
+		led_0: led@0 {
+			gpios = <&gpiod 4 GPIO_INT_ACTIVE_LOW>;
+			label = "User LD1";
+		};
+		led_1: led@1 {
+			gpios = <&gpiod 5 GPIO_INT_ACTIVE_LOW>;
+			label = "User LD2";
+		};
+	};
+
+	gpio_keys {
+		compatible = "gpio-keys";
+		#address-cells = <1>;
+		#size-cells = <0>;
+		user_button_1: button@0 {
+			label = "User SW1";
+			gpios = <&gpioc 4 GPIO_INT_ACTIVE_LOW>;
+		};
 	};
 };
 

--- a/drivers/gpio/Kconfig.mcux
+++ b/drivers/gpio/Kconfig.mcux
@@ -22,32 +22,12 @@ config GPIO_MCUX_PORTA
 	help
 	  Enable Port A.
 
-config GPIO_MCUX_PORTA_NAME
-	string "Port A driver name"
-	depends on GPIO_MCUX_PORTA
-	default "GPIO_0"
-
-config GPIO_MCUX_PORTA_PRI
-	int "Port A interrupt priority"
-	depends on GPIO_MCUX_PORTA
-	default 2
-
 config GPIO_MCUX_PORTB
 	bool "Port B"
 	depends on PINMUX_MCUX_PORTB
 	default n
 	help
 	  Enable Port B.
-
-config GPIO_MCUX_PORTB_NAME
-	string "Port B driver name"
-	depends on GPIO_MCUX_PORTB
-	default "GPIO_1"
-
-config GPIO_MCUX_PORTB_PRI
-	int "Port B interrupt priority"
-	depends on GPIO_MCUX_PORTB
-	default 2
 
 config GPIO_MCUX_PORTC
 	bool "Port C"
@@ -56,16 +36,6 @@ config GPIO_MCUX_PORTC
 	help
 	  Enable Port C.
 
-config GPIO_MCUX_PORTC_NAME
-	string "Port C driver name"
-	depends on GPIO_MCUX_PORTC
-	default "GPIO_2"
-
-config GPIO_MCUX_PORTC_PRI
-	int "Port C interrupt priority"
-	depends on GPIO_MCUX_PORTC
-	default 2
-
 config GPIO_MCUX_PORTD
 	bool "Port D"
 	depends on PINMUX_MCUX_PORTD
@@ -73,31 +43,11 @@ config GPIO_MCUX_PORTD
 	help
 	  Enable Port D.
 
-config GPIO_MCUX_PORTD_NAME
-	string "Port D driver name"
-	depends on GPIO_MCUX_PORTD
-	default "GPIO_3"
-
-config GPIO_MCUX_PORTD_PRI
-	int "Port D interrupt priority"
-	depends on GPIO_MCUX_PORTD
-	default 2
-
 config GPIO_MCUX_PORTE
 	bool "Port E"
 	depends on PINMUX_MCUX_PORTE
 	default n
 	help
 	  Enable Port E.
-
-config GPIO_MCUX_PORTE_NAME
-	string "Port E driver name"
-	depends on GPIO_MCUX_PORTE
-	default "GPIO_4"
-
-config GPIO_MCUX_PORTE_PRI
-	int "Port E interrupt priority"
-	depends on GPIO_MCUX_PORTE
-	default 2
 
 endif # GPIO_MCUX

--- a/drivers/gpio/gpio_mcux.c
+++ b/drivers/gpio/gpio_mcux.c
@@ -237,9 +237,9 @@ static const struct gpio_driver_api gpio_mcux_driver_api = {
 static int gpio_mcux_porta_init(struct device *dev);
 
 static const struct gpio_mcux_config gpio_mcux_porta_config = {
-	.gpio_base = GPIOA,
+	.gpio_base = (GPIO_Type *) GPIO_A_BASE_ADDRESS,
 	.port_base = PORTA,
-#ifdef IRQ_GPIO_PORTA
+#ifdef GPIO_A_IRQ
 	.flags = GPIO_INT,
 #else
 	.flags = 0,
@@ -248,7 +248,7 @@ static const struct gpio_mcux_config gpio_mcux_porta_config = {
 
 static struct gpio_mcux_data gpio_mcux_porta_data;
 
-DEVICE_AND_API_INIT(gpio_mcux_porta, CONFIG_GPIO_MCUX_PORTA_NAME,
+DEVICE_AND_API_INIT(gpio_mcux_porta, GPIO_A_LABEL,
 		    gpio_mcux_porta_init,
 		    &gpio_mcux_porta_data, &gpio_mcux_porta_config,
 		    POST_KERNEL, CONFIG_KERNEL_INIT_PRIORITY_DEFAULT,
@@ -256,11 +256,11 @@ DEVICE_AND_API_INIT(gpio_mcux_porta, CONFIG_GPIO_MCUX_PORTA_NAME,
 
 static int gpio_mcux_porta_init(struct device *dev)
 {
-#ifdef IRQ_GPIO_PORTA
-	IRQ_CONNECT(IRQ_GPIO_PORTA, CONFIG_GPIO_MCUX_PORTA_PRI,
+#ifdef GPIO_A_IRQ
+	IRQ_CONNECT(GPIO_A_IRQ, GPIO_A_IRQ_PRIORITY,
 		    gpio_mcux_port_isr, DEVICE_GET(gpio_mcux_porta), 0);
 
-	irq_enable(IRQ_GPIO_PORTA);
+	irq_enable(GPIO_A_IRQ);
 
 	return 0;
 #else
@@ -273,9 +273,9 @@ static int gpio_mcux_porta_init(struct device *dev)
 static int gpio_mcux_portb_init(struct device *dev);
 
 static const struct gpio_mcux_config gpio_mcux_portb_config = {
-	.gpio_base = GPIOB,
+	.gpio_base = (GPIO_Type *) GPIO_B_BASE_ADDRESS,
 	.port_base = PORTB,
-#ifdef IRQ_GPIO_PORTB
+#ifdef GPIO_B_IRQ
 	.flags = GPIO_INT,
 #else
 	.flags = 0,
@@ -284,7 +284,7 @@ static const struct gpio_mcux_config gpio_mcux_portb_config = {
 
 static struct gpio_mcux_data gpio_mcux_portb_data;
 
-DEVICE_AND_API_INIT(gpio_mcux_portb, CONFIG_GPIO_MCUX_PORTB_NAME,
+DEVICE_AND_API_INIT(gpio_mcux_portb, GPIO_B_LABEL,
 		    gpio_mcux_portb_init,
 		    &gpio_mcux_portb_data, &gpio_mcux_portb_config,
 		    POST_KERNEL, CONFIG_KERNEL_INIT_PRIORITY_DEFAULT,
@@ -292,11 +292,11 @@ DEVICE_AND_API_INIT(gpio_mcux_portb, CONFIG_GPIO_MCUX_PORTB_NAME,
 
 static int gpio_mcux_portb_init(struct device *dev)
 {
-#ifdef IRQ_GPIO_PORTB
-	IRQ_CONNECT(IRQ_GPIO_PORTB, CONFIG_GPIO_MCUX_PORTB_PRI,
+#ifdef GPIO_B_IRQ
+	IRQ_CONNECT(GPIO_B_IRQ, GPIO_B_IRQ_PRIORITY,
 		    gpio_mcux_port_isr, DEVICE_GET(gpio_mcux_portb), 0);
 
-	irq_enable(IRQ_GPIO_PORTB);
+	irq_enable(GPIO_B_IRQ);
 
 	return 0;
 #else
@@ -309,9 +309,9 @@ static int gpio_mcux_portb_init(struct device *dev)
 static int gpio_mcux_portc_init(struct device *dev);
 
 static const struct gpio_mcux_config gpio_mcux_portc_config = {
-	.gpio_base = GPIOC,
+	.gpio_base = (GPIO_Type *) GPIO_C_BASE_ADDRESS,
 	.port_base = PORTC,
-#ifdef IRQ_GPIO_PORTC
+#ifdef GPIO_C_IRQ
 	.flags = GPIO_INT,
 #else
 	.flags = 0,
@@ -320,7 +320,7 @@ static const struct gpio_mcux_config gpio_mcux_portc_config = {
 
 static struct gpio_mcux_data gpio_mcux_portc_data;
 
-DEVICE_AND_API_INIT(gpio_mcux_portc, CONFIG_GPIO_MCUX_PORTC_NAME,
+DEVICE_AND_API_INIT(gpio_mcux_portc, GPIO_C_LABEL,
 		    gpio_mcux_portc_init,
 		    &gpio_mcux_portc_data, &gpio_mcux_portc_config,
 		    POST_KERNEL, CONFIG_KERNEL_INIT_PRIORITY_DEFAULT,
@@ -328,11 +328,11 @@ DEVICE_AND_API_INIT(gpio_mcux_portc, CONFIG_GPIO_MCUX_PORTC_NAME,
 
 static int gpio_mcux_portc_init(struct device *dev)
 {
-#ifdef IRQ_GPIO_PORTC
-	IRQ_CONNECT(IRQ_GPIO_PORTC, CONFIG_GPIO_MCUX_PORTC_PRI,
+#ifdef GPIO_C_IRQ
+	IRQ_CONNECT(GPIO_C_IRQ, GPIO_C_IRQ_PRIORITY,
 		    gpio_mcux_port_isr, DEVICE_GET(gpio_mcux_portc), 0);
 
-	irq_enable(IRQ_GPIO_PORTC);
+	irq_enable(GPIO_C_IRQ);
 
 	return 0;
 #else
@@ -345,9 +345,9 @@ static int gpio_mcux_portc_init(struct device *dev)
 static int gpio_mcux_portd_init(struct device *dev);
 
 static const struct gpio_mcux_config gpio_mcux_portd_config = {
-	.gpio_base = GPIOD,
+	.gpio_base = (GPIO_Type *) GPIO_D_BASE_ADDRESS,
 	.port_base = PORTD,
-#ifdef IRQ_GPIO_PORTD
+#ifdef GPIO_D_IRQ
 	.flags = GPIO_INT,
 #else
 	.flags = 0,
@@ -356,7 +356,7 @@ static const struct gpio_mcux_config gpio_mcux_portd_config = {
 
 static struct gpio_mcux_data gpio_mcux_portd_data;
 
-DEVICE_AND_API_INIT(gpio_mcux_portd, CONFIG_GPIO_MCUX_PORTD_NAME,
+DEVICE_AND_API_INIT(gpio_mcux_portd, GPIO_D_LABEL,
 		    gpio_mcux_portd_init,
 		    &gpio_mcux_portd_data, &gpio_mcux_portd_config,
 		    POST_KERNEL, CONFIG_KERNEL_INIT_PRIORITY_DEFAULT,
@@ -364,11 +364,11 @@ DEVICE_AND_API_INIT(gpio_mcux_portd, CONFIG_GPIO_MCUX_PORTD_NAME,
 
 static int gpio_mcux_portd_init(struct device *dev)
 {
-#ifdef IRQ_GPIO_PORTD
-	IRQ_CONNECT(IRQ_GPIO_PORTD, CONFIG_GPIO_MCUX_PORTD_PRI,
+#ifdef GPIO_D_IRQ
+	IRQ_CONNECT(GPIO_D_IRQ, GPIO_D_IRQ_PRIORITY,
 		    gpio_mcux_port_isr, DEVICE_GET(gpio_mcux_portd), 0);
 
-	irq_enable(IRQ_GPIO_PORTD);
+	irq_enable(GPIO_D_IRQ);
 
 	return 0;
 #else
@@ -381,9 +381,9 @@ static int gpio_mcux_portd_init(struct device *dev)
 static int gpio_mcux_porte_init(struct device *dev);
 
 static const struct gpio_mcux_config gpio_mcux_porte_config = {
-	.gpio_base = GPIOE,
+	.gpio_base = (GPIO_Type *) GPIO_E_BASE_ADDRESS,
 	.port_base = PORTE,
-#ifdef IRQ_GPIO_PORTE
+#ifdef GPIO_E_IRQ
 	.flags = GPIO_INT,
 #else
 	.flags = 0,
@@ -392,7 +392,7 @@ static const struct gpio_mcux_config gpio_mcux_porte_config = {
 
 static struct gpio_mcux_data gpio_mcux_porte_data;
 
-DEVICE_AND_API_INIT(gpio_mcux_porte, CONFIG_GPIO_MCUX_PORTE_NAME,
+DEVICE_AND_API_INIT(gpio_mcux_porte, GPIO_E_LABEL,
 		    gpio_mcux_porte_init,
 		    &gpio_mcux_porte_data, &gpio_mcux_porte_config,
 		    POST_KERNEL, CONFIG_KERNEL_INIT_PRIORITY_DEFAULT,
@@ -400,11 +400,11 @@ DEVICE_AND_API_INIT(gpio_mcux_porte, CONFIG_GPIO_MCUX_PORTE_NAME,
 
 static int gpio_mcux_porte_init(struct device *dev)
 {
-#ifdef IRQ_GPIO_PORTE
-	IRQ_CONNECT(IRQ_GPIO_PORTE, CONFIG_GPIO_MCUX_PORTE_PRI,
+#ifdef GPIO_E_IRQ
+	IRQ_CONNECT(GPIO_E_IRQ, GPIO_E_IRQ_PRIORITY,
 		    gpio_mcux_port_isr, DEVICE_GET(gpio_mcux_porte), 0);
 
-	irq_enable(IRQ_GPIO_PORTE);
+	irq_enable(GPIO_E_IRQ);
 
 	return 0;
 #else

--- a/dts/arm/nxp/nxp_k6x.dtsi
+++ b/dts/arm/nxp/nxp_k6x.dtsi
@@ -1,5 +1,6 @@
 #include <arm/armv7-m.dtsi>
 #include <dt-bindings/clock/kinetis_sim.h>
+#include <dt-bindings/gpio/gpio.h>
 #include <dt-bindings/i2c/i2c.h>
 
 / {
@@ -242,7 +243,7 @@
 			compatible = "nxp,kinetis-gpio";
 			reg = <0x400ff000 0x40>;
 			interrupts = <59 2>;
-
+			label = "GPIO_0";
 			gpio-controller;
 			#gpio-cells = <2>;
 		};
@@ -251,7 +252,7 @@
 			compatible = "nxp,kinetis-gpio";
 			reg = <0x400ff040 0x40>;
 			interrupts = <60 2>;
-
+			label = "GPIO_1";
 			gpio-controller;
 			#gpio-cells = <2>;
 		};
@@ -260,7 +261,7 @@
 			compatible = "nxp,kinetis-gpio";
 			reg = <0x400ff080 0x40>;
 			interrupts = <61 2>;
-
+			label = "GPIO_2";
 			gpio-controller;
 			#gpio-cells = <2>;
 		};
@@ -269,7 +270,7 @@
 			compatible = "nxp,kinetis-gpio";
 			reg = <0x400ff0c0 0x40>;
 			interrupts = <62 2>;
-
+			label = "GPIO_3";
 			gpio-controller;
 			#gpio-cells = <2>;
 		};
@@ -278,7 +279,7 @@
 			compatible = "nxp,kinetis-gpio";
 			reg = <0x400ff100 0x40>;
 			interrupts = <63 2>;
-
+			label = "GPIO_4";
 			gpio-controller;
 			#gpio-cells = <2>;
 		};

--- a/dts/arm/nxp/nxp_kl25z.dtsi
+++ b/dts/arm/nxp/nxp_kl25z.dtsi
@@ -1,5 +1,6 @@
 #include "armv6-m.dtsi"
 #include <dt-bindings/clock/kinetis_sim.h>
+#include <dt-bindings/gpio/gpio.h>
 #include <dt-bindings/i2c/i2c.h>
 
 / {
@@ -93,6 +94,48 @@
 			interrupts = <15 0>;
 			label = "ADC_0";
 			status = "disabled";
+		};
+
+		gpioa: gpio@400ff000 {
+			compatible = "nxp,kinetis-gpio";
+			reg = <0x400ff000 0x40>;
+			interrupts = <30 2>;
+			label = "GPIO_0";
+			gpio-controller;
+			#gpio-cells = <2>;
+		};
+
+		gpiob: gpio@400ff040 {
+			compatible = "nxp,kinetis-gpio";
+			reg = <0x400ff040 0x40>;
+			label = "GPIO_1";
+			gpio-controller;
+			#gpio-cells = <2>;
+		};
+
+		gpioc: gpio@400ff080 {
+			compatible = "nxp,kinetis-gpio";
+			reg = <0x400ff080 0x40>;
+			label = "GPIO_2";
+			gpio-controller;
+			#gpio-cells = <2>;
+		};
+
+		gpiod: gpio@400ff0c0 {
+			compatible = "nxp,kinetis-gpio";
+			reg = <0x400ff0c0 0x40>;
+			interrupts = <31 2>;
+			label = "GPIO_3";
+			gpio-controller;
+			#gpio-cells = <2>;
+		};
+
+		gpioe: gpio@400ff100 {
+			compatible = "nxp,kinetis-gpio";
+			reg = <0x400ff100 0x40>;
+			label = "GPIO_4";
+			gpio-controller;
+			#gpio-cells = <2>;
 		};
 	};
 };

--- a/dts/arm/nxp/nxp_kw2xd.dtsi
+++ b/dts/arm/nxp/nxp_kw2xd.dtsi
@@ -1,5 +1,6 @@
 #include <arm/armv7-m.dtsi>
 #include <dt-bindings/clock/kinetis_sim.h>
+#include <dt-bindings/gpio/gpio.h>
 #include <dt-bindings/i2c/i2c.h>
 
 / {
@@ -193,7 +194,7 @@
 			compatible = "nxp,kinetis-gpio";
 			reg = <0x400ff000 0x40>;
 			interrupts = <59 2>;
-
+			label = "GPIO_0";
 			gpio-controller;
 			#gpio-cells = <2>;
 		};
@@ -202,7 +203,7 @@
 			compatible = "nxp,kinetis-gpio";
 			reg = <0x400ff040 0x40>;
 			interrupts = <60 2>;
-
+			label = "GPIO_1";
 			gpio-controller;
 			#gpio-cells = <2>;
 		};
@@ -211,7 +212,7 @@
 			compatible = "nxp,kinetis-gpio";
 			reg = <0x400ff080 0x40>;
 			interrupts = <61 2>;
-
+			label = "GPIO_2";
 			gpio-controller;
 			#gpio-cells = <2>;
 		};
@@ -220,7 +221,7 @@
 			compatible = "nxp,kinetis-gpio";
 			reg = <0x400ff0c0 0x40>;
 			interrupts = <62 2>;
-
+			label = "GPIO_3";
 			gpio-controller;
 			#gpio-cells = <2>;
 		};
@@ -229,7 +230,7 @@
 			compatible = "nxp,kinetis-gpio";
 			reg = <0x400ff100 0x40>;
 			interrupts = <63 2>;
-
+			label = "GPIO_4";
 			gpio-controller;
 			#gpio-cells = <2>;
 		};

--- a/dts/arm/nxp/nxp_kw40z.dtsi
+++ b/dts/arm/nxp/nxp_kw40z.dtsi
@@ -1,5 +1,6 @@
 #include "armv6-m.dtsi"
 #include <dt-bindings/clock/kinetis_sim.h>
+#include <dt-bindings/gpio/gpio.h>
 #include <dt-bindings/i2c/i2c.h>
 
 / {
@@ -161,6 +162,7 @@
 			compatible = "nxp,kinetis-gpio";
 			reg = <0x400ff000 0x40>;
 			interrupts = <30 2>;
+			label = "GPIO_0";
 			gpio-controller;
 			#gpio-cells = <2>;
 		};
@@ -169,6 +171,7 @@
 			compatible = "nxp,kinetis-gpio";
 			reg = <0x400ff040 0x40>;
 			interrupts = <31 2>;
+			label = "GPIO_2";
 			gpio-controller;
 			#gpio-cells = <2>;
 		};
@@ -177,6 +180,7 @@
 			compatible = "nxp,kinetis-gpio";
 			reg = <0x400ff080 0x40>;
 			interrupts = <31 2>;
+			label = "GPIO_3";
 			gpio-controller;
 			#gpio-cells = <2>;
 		};

--- a/dts/arm/nxp/nxp_kw41z.dtsi
+++ b/dts/arm/nxp/nxp_kw41z.dtsi
@@ -1,5 +1,6 @@
 #include <arm/armv6-m.dtsi>
 #include <dt-bindings/clock/kinetis_sim.h>
+#include <dt-bindings/gpio/gpio.h>
 #include <dt-bindings/i2c/i2c.h>
 
 / {
@@ -161,6 +162,7 @@
 			compatible = "nxp,kinetis-gpio";
 			reg = <0x400ff000 0x40>;
 			interrupts = <30 2>;
+			label = "GPIO_0";
 			gpio-controller;
 			#gpio-cells = <2>;
 		};
@@ -169,6 +171,7 @@
 			compatible = "nxp,kinetis-gpio";
 			reg = <0x400ff040 0x40>;
 			interrupts = <31 2>;
+			label = "GPIO_1";
 			gpio-controller;
 			#gpio-cells = <2>;
 		};
@@ -177,6 +180,7 @@
 			compatible = "nxp,kinetis-gpio";
 			reg = <0x400ff080 0x40>;
 			interrupts = <31 2>;
+			label = "GPIO_2";
 			gpio-controller;
 			#gpio-cells = <2>;
 		};

--- a/dts/bindings/gpio/nxp,kinetis-gpio.yaml
+++ b/dts/bindings/gpio/nxp,kinetis-gpio.yaml
@@ -24,6 +24,12 @@ properties:
       description: required interrupts
       generation: define
 
+    label:
+      type: string
+      category: required
+      description: Human readable string describing the device (used by Zephyr for API name)
+      generation: define
+
 cell_string: GPIO
 
 "#cells":

--- a/samples/net/common/cc2520_frdm_k64f.c
+++ b/samples/net/common/cc2520_frdm_k64f.c
@@ -16,7 +16,7 @@
 #include <ieee802154/cc2520.h>
 #include <gpio.h>
 
-#define CC2520_GPIO_DEV_NAME CONFIG_GPIO_MCUX_PORTC_NAME
+#define CC2520_GPIO_DEV_NAME GPIO_C_LABEL
 
 #define CC2520_GPIO_VREG_EN	12  /* PTC12 */
 #define CC2520_GPIO_RESET	3   /* PTC3 */


### PR DESCRIPTION
Based upon the work done in #5381, adds led and button gpio nodes to nxp boards. Refactors the mcux gpio driver to use device tree for base addresses, irqs, and device names.

Tested samples/basic/blinky on every board touched.

@pfalcon: Last time I mucked around with gpio device names I broke things for you (zephyr.js or micropython IIRC). I believe I preserved the names with this change, but please double check.