### PR TITLE
tests: socket: udp: Make sure client sockaddr fully initialized

### DIFF
--- a/tests/net/socket/udp/src/main.c
+++ b/tests/net/socket/udp/src/main.c
@@ -52,6 +52,7 @@ static void prepare_sock_v6(const char *addr,
 	*sock = socket(AF_INET6, SOCK_DGRAM, IPPROTO_UDP);
 	zassert_true(*sock >= 0, "socket open failed");
 
+	memset(sockaddr, 0, sizeof(*sockaddr));
 	sockaddr->sin6_family = AF_INET6;
 	sockaddr->sin6_port = htons(port);
 	rv = inet_pton(AF_INET6, addr, &sockaddr->sin6_addr);


### PR DESCRIPTION
Previously, some fields like sin6_scope_id weren't explicitly
initialized. Such aren't really used, but to keep Coverity
happy, let's zero out the entire address structure.

Coverity-Id: 182763
Fixes: #6108

Signed-off-by: Paul Sokolovsky <paul.sokolovsky@linaro.org>