### PR TITLE
dts: arc: quark_se_c1000_ss: Fix worng interrupt number in i2c 0/1

### DIFF
--- a/dts/arc/quark_se_c1000_ss.dtsi
+++ b/dts/arc/quark_se_c1000_ss.dtsi
@@ -70,7 +70,7 @@
 			#address-cells = <1>;
 			#size-cells = <0>;
 			reg = <0x80012000 0x100>;
-			interrupts = <21 1>, <20 1>, <19 1>, <18 1>;
+			interrupts = <22 1>, <25 1>, <24 1>, <23 1>;
 			interrupt-names = "error", "stop", "tx", "rx";
 			interrupt-parent = <&core_intc>;
 			label = "I2C_0";
@@ -84,7 +84,7 @@
 			#address-cells = <1>;
 			#size-cells = <0>;
 			reg = <0x80012100 0x100>;
-			interrupts = <25 1>, <24 1>, <23 1>, <22 1>;
+			interrupts = <26 1>, <29 1>, <28 1>, <27 1>;
 			interrupt-names = "error", "stop", "tx", "rx";
 			interrupt-parent = <&core_intc>;
 			label = "I2C_1";


### PR DESCRIPTION
This fixes https://github.com/zephyrproject-rtos/zephyr/issues/7026

The issue is due worng interrupt number populated in dts for
i2c0 and i2c1 instance.

Signed-off-by: Savinay Dharmappa <savinay.dharmappa@intel.com>