### PR TITLE
tests: socket: Free resources with freeaddrinfo

### DIFF
--- a/tests/net/socket/getaddrinfo/src/main.c
+++ b/tests/net/socket/getaddrinfo/src/main.c
@@ -21,6 +21,8 @@ void test_getaddrinfo_ok(void)
 
 	/* With a local dnsmasq server this request shall return 0. */
 	/* zassert_equal(ret, 0, "Invalid result"); */
+
+	freeaddrinfo(res);
 }
 
 void test_getaddrinfo_no_host(void)
@@ -33,6 +35,8 @@ void test_getaddrinfo_no_host(void)
 	zassert_equal(ret, DNS_EAI_SYSTEM, "Invalid result");
 	zassert_equal(errno, EINVAL, "Invalid errno");
 	zassert_is_null(res, "ai_addr is not NULL");
+
+	freeaddrinfo(res);
 }
 
 void test_main(void)


### PR DESCRIPTION
In Zephyr this has no effect because getaddrinfo() returns a pointer
to a static array, but Coverity scan checks for this pattern.

Coverity-CID: 185273
Coverity-CID: 185279

Fixes #7085
Fixes #7091

Signed-off-by: Stig Bjørlykke <stig.bjorlykke@nordicsemi.no>