### PR TITLE
net: ipv6: Remove irrelevant error log

### DIFF
--- a/subsys/net/ip/ipv6.c
+++ b/subsys/net/ip/ipv6.c
@@ -3188,7 +3188,6 @@ static void reassembly_info(char *str, struct net_ipv6_reassembly *reass)
 
 	for (i = 0, len = 0; i < NET_IPV6_FRAGMENTS_MAX_PKT; i++) {
 		if (!reass->pkt[i]) {
-			NET_ERR("NULL pending fragment");
 			continue;
 		}
 


### PR DESCRIPTION
"NULL pending fragment" error log is not really an error, hence it is removed.

Signed-off-by: Ruslan Mstoi <ruslan.mstoi@intel.com>