### PR TITLE
boards: dts: Add i2c to nrf5X_pcaX board dts.

### DIFF
--- a/boards/arm/nrf51_pca10028/nrf51_pca10028.dts
+++ b/boards/arm/nrf51_pca10028/nrf51_pca10028.dts
@@ -24,6 +24,14 @@
 	status = "ok";
 };
 
+&i2c0 {
+	status = "ok";
+};
+
+&i2c1 {
+	status = "ok";
+};
+
 &flash0 {
 	/*
 	 * For more information, see:

--- a/boards/arm/nrf52840_pca10056/nrf52840_pca10056.dts
+++ b/boards/arm/nrf52840_pca10056/nrf52840_pca10056.dts
@@ -25,6 +25,14 @@
 	status = "ok";
 };
 
+&i2c0 {
+	status = "ok";
+};
+
+&i2c1 {
+	status = "ok";
+};
+
 &flash0 {
 	/*
 	 * For more information, see:

--- a/boards/arm/nrf52_pca10040/nrf52_pca10040.dts
+++ b/boards/arm/nrf52_pca10040/nrf52_pca10040.dts
@@ -25,6 +25,13 @@
 	compatible = "nordic,nrf-uart";
 	current-speed = <115200>;
 };
+&i2c0 {
+	status = "ok";
+};
+
+&i2c1 {
+	status = "ok";
+};
 
 &flash0 {
 	/*


### PR DESCRIPTION
Fixes #7137

Enables the i2c drivers for these boards, allowing I2C to be used.
Required to enable i2c with these boards.
Tested building samples/bluetooth/beacon for nrf52_pca10040 with i2c enabled.

Parameters used for enabling i2c:
CONFIG_I2C=y
CONFIG_I2C_0=y
CONFIG_I2C_NRF5=y
CONFIG_I2C_NRF5_0_GPIO_SCL_PIN=6
CONFIG_I2C_NRF5_0_GPIO_SDA_PIN=7

Signed-off-by: Håkon Øye Amundsen <haakon.amundsen@nordicsemi.com>