### PR TITLE
net: drivers: wifi: SimpleLink WiFi Offload Driver (wifi_mgmt only) 

### DIFF
--- a/drivers/wifi/CMakeLists.txt
+++ b/drivers/wifi/CMakeLists.txt
@@ -1,1 +1,14 @@
 add_subdirectory_ifdef(CONFIG_WIFI_WINC1500	winc1500)
+if(CONFIG_WIFI_SIMPLELINK)
+  zephyr_include_directories(
+    .
+    $ENV{ZEPHYR_BASE}/ext/hal/ti/simplelink/kernel/zephyr/dpl
+    $ENV{ZEPHYR_BASE}/ext/hal/ti/simplelink/source
+    $ENV{ZEPHYR_BASE}/ext/hal/ti/simplelink/source/ti/drivers/net/wifi/porting
+    $ENV{ZEPHYR_BASE}/ext/hal/ti/simplelink/source/ti/drivers/net/wifi/bsd
+    )
+  zephyr_sources(
+    simplelink_support.c
+    simplelink.c
+    )
+endif()

--- a/drivers/wifi/Kconfig
+++ b/drivers/wifi/Kconfig
@@ -44,5 +44,6 @@ config WIFI_OFFLOAD
 	  Enable support for Full-MAC WiFi devices.
 
 source "drivers/wifi/winc1500/Kconfig.winc1500"
+source "drivers/wifi/Kconfig.simplelink"
 
 endif # WIFI

--- a/drivers/wifi/Kconfig.simplelink
+++ b/drivers/wifi/Kconfig.simplelink
@@ -1,0 +1,46 @@
+# Kconfig - SimpleLink WiFi driver options
+
+#
+# Copyright (c) 2018 Texas Instruments, Incorporated
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+
+menuconfig WIFI_SIMPLELINK
+	bool "SimpleLink WiFi driver support"
+	default n
+	depends on WIFI
+	select SIMPLELINK_HOST_DRIVER
+	select WIFI_OFFLOAD
+	select NET_L2_WIFI_MGMT
+
+if WIFI_SIMPLELINK
+
+config WIFI_SIMPLELINK_NAME
+	string "Driver name"
+	default "SimpleLink"
+
+config WIFI_SIMPLELINK_MAX_PACKET_SIZE
+	int "Maximum size of a packet, in bytes"
+	# MTU (ipv4) per: http://www.ti.com/lit/ug/swru455d/swru455d.pdf:
+	default 1472
+	help
+	 Set the maximum size of a network packet going through the chip.
+	 This sets the size of each buffer, in each buffer pool.
+	 Do not modify it unless you know what you are doing.
+
+config WIFI_SIMPLELINK_SCAN_COUNT
+	int "Number of entries in network scan table: Max: 30"
+	default 20
+	help
+	 The number of results to request on a wifi scan operation.
+	 Actual number returned may be less.  Maximum is 30.
+
+config WIFI_SIMPLELINK_MAX_SCAN_RETRIES
+	int "Number of retries to get network scan table"
+	default 10
+	help
+	 The number of times, separated by a one second interval, to retry
+	 a request for the network list.
+
+endif # WIFI_SIMPLELINK

--- a/drivers/wifi/simplelink.c
+++ b/drivers/wifi/simplelink.c
@@ -1,0 +1,239 @@
+/**
+ * Copyright (c) 2018 Texas Instruments, Incorporated
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#define SYS_LOG_LEVEL CONFIG_SYS_LOG_WIFI_LEVEL
+#define SYS_LOG_DOMAIN "dev/simplelink"
+#include <logging/sys_log.h>
+
+#include <zephyr.h>
+#include <kernel.h>
+#include <device.h>
+#include <net/net_if.h>
+#include <net/wifi_mgmt.h>
+#include <net/net_offload.h>
+
+#include <ti/drivers/net/wifi/wlan.h>
+#include "simplelink_support.h"
+
+#define SCAN_RETRY_DELAY 2000  /* ms */
+
+struct simplelink_data {
+	struct net_if *iface;
+	unsigned char mac[6];
+
+	/* Fields for scan API to emulate an asynchronous scan: */
+	struct k_delayed_work work;
+	scan_result_cb_t cb;
+	int num_results_or_err;
+	int scan_retries;
+};
+
+static struct simplelink_data simplelink_data;
+
+/* Handle connection events from the SimpleLink Event Handlers: */
+static void simplelink_wifi_cb(u32_t event, struct sl_connect_state *conn)
+{
+	struct in_addr addr;
+	struct in_addr gwaddr;
+	int status;
+
+	/*
+	 * Once Zephyr wifi_mgmt wifi_status codes are defined, will need
+	 * to map from SimpleLink error codes.  For now, just return -EIO.
+	 */
+	status = (conn->error ? -EIO : 0);
+
+	switch (event) {
+	case SL_WLAN_EVENT_CONNECT:
+		/* Only get this event if connect succeeds: */
+		wifi_mgmt_raise_connect_result_event(simplelink_data.iface,
+						     status);
+		break;
+
+	case SL_WLAN_EVENT_DISCONNECT:
+		/* Could be during a connect, disconnect, or async error: */
+		wifi_mgmt_raise_disconnect_result_event(simplelink_data.iface,
+							status);
+		break;
+
+	case SIMPLELINK_WIFI_CB_IPACQUIRED:
+		addr.s_addr = htonl(conn->ip_addr);
+		gwaddr.s_addr = htonl(conn->gateway_ip);
+		net_if_ipv4_set_gw(simplelink_data.iface, &gwaddr);
+		net_if_ipv4_addr_add(simplelink_data.iface, &addr,
+				     NET_ADDR_DHCP, 0);
+		break;
+
+	default:
+		SYS_LOG_DBG("Unrecognized mgmt event: 0x%x", event);
+		break;
+	}
+}
+
+/* TBD: Only here to link/test WiFi mgmnt part */
+static struct net_offload simplelink_offload = {
+	.get            = NULL,
+	.bind		= NULL,
+	.listen		= NULL,
+	.connect	= NULL,
+	.accept		= NULL,
+	.send		= NULL,
+	.sendto		= NULL,
+	.recv		= NULL,
+	.put		= NULL,
+};
+
+static void simplelink_scan_work_handler(struct k_work *work)
+{
+	if (simplelink_data.num_results_or_err > 0) {
+		int index = 0;
+		struct wifi_scan_result scan_result;
+
+		/* Iterate over the table, and call the scan_result callback. */
+		while (index < simplelink_data.num_results_or_err) {
+			_simplelink_get_scan_result(index, &scan_result);
+			simplelink_data.cb(simplelink_data.iface, 0,
+					   &scan_result);
+			/* Yield, to ensure notifications get delivered:  */
+			k_yield();
+			index++;
+		}
+
+		/* Sending a NULL entry indicates e/o results, and
+		 * triggers the NET_EVENT_WIFI_SCAN_DONE event:
+		 */
+		simplelink_data.cb(simplelink_data.iface, 0, NULL);
+
+	} else if ((simplelink_data.num_results_or_err ==
+		    SL_ERROR_WLAN_GET_NETWORK_LIST_EAGAIN) &&
+		   (simplelink_data.scan_retries++ <
+		    CONFIG_WIFI_SIMPLELINK_MAX_SCAN_RETRIES)) {
+		s32_t delay;
+
+		/* Try again: */
+		simplelink_data.num_results_or_err = _simplelink_start_scan();
+		simplelink_data.scan_retries++;
+		delay = (simplelink_data.num_results_or_err > 0 ? 0 :
+			 SCAN_RETRY_DELAY);
+		if (delay > 0) {
+			SYS_LOG_DBG("Retrying scan...");
+		}
+		k_delayed_work_submit(&simplelink_data.work, delay);
+
+	} else {
+		/* Encountered an error, or max retries exceeded: */
+		SYS_LOG_ERR("Scan failed: retries: %d; err: %d",
+			    simplelink_data.scan_retries,
+			    simplelink_data.num_results_or_err);
+		simplelink_data.cb(simplelink_data.iface, -EIO, NULL);
+	}
+}
+
+static int simplelink_mgmt_scan(struct device *dev, scan_result_cb_t cb)
+{
+	int err;
+	int status;
+
+	/* Cancel any previous scan processing in progress: */
+	k_delayed_work_cancel(&simplelink_data.work);
+
+	/* "Request" the scan: */
+	err = _simplelink_start_scan();
+
+	/* Now, launch a delayed work handler to do retries and reporting.
+	 * Indicate (to the work handler) either a positive number of results
+	 * already returned, or indicate a retry is required:
+	 */
+	if ((err > 0) || (err == SL_ERROR_WLAN_GET_NETWORK_LIST_EAGAIN)) {
+		s32_t delay = (err > 0 ? 0 : SCAN_RETRY_DELAY);
+
+		/* Store for later reference by delayed work handler: */
+		simplelink_data.cb = cb;
+		simplelink_data.num_results_or_err = err;
+		simplelink_data.scan_retries = 0;
+
+		k_delayed_work_submit(&simplelink_data.work, delay);
+		status = 0;
+	} else {
+		status = -EIO;
+	}
+
+	return status;
+}
+
+static int simplelink_mgmt_connect(struct device *dev,
+				   struct wifi_connect_req_params *params)
+{
+	int ret;
+
+	ret = _simplelink_connect(params);
+
+	return ret ? -EIO : ret;
+}
+
+static int simplelink_mgmt_disconnect(struct device *dev)
+{
+	int ret;
+
+	ret = _simplelink_disconnect();
+
+	return ret ? -EIO : ret;
+}
+
+static void simplelink_iface_init(struct net_if *iface)
+{
+	SYS_LOG_DBG("MAC Address %02X:%02X:%02X:%02X:%02X:%02X",
+		    simplelink_data.mac[0], simplelink_data.mac[1],
+		    simplelink_data.mac[2],
+		    simplelink_data.mac[3], simplelink_data.mac[4],
+		    simplelink_data.mac[5]);
+
+	net_if_set_link_addr(iface, simplelink_data.mac,
+			     sizeof(simplelink_data.mac),
+			     NET_LINK_ETHERNET);
+
+	/* TBD: Pending support for socket offload: */
+	iface->if_dev->offload = &simplelink_offload;
+
+	simplelink_data.iface = iface;
+}
+
+static const struct net_wifi_mgmt_offload simplelink_api = {
+	.iface_api.init = simplelink_iface_init,
+	.scan		= simplelink_mgmt_scan,
+	.connect	= simplelink_mgmt_connect,
+	.disconnect	= simplelink_mgmt_disconnect,
+};
+
+static int simplelink_init(struct device *dev)
+{
+	int ret;
+
+	ARG_UNUSED(dev);
+
+	/* Initialize and configure NWP to defaults: */
+	ret = _simplelink_init(simplelink_wifi_cb);
+	if (ret) {
+		SYS_LOG_ERR("_simplelink_init failed!");
+		return(-EIO);
+	}
+
+	/* Grab our MAC address: */
+	_simplelink_get_mac(simplelink_data.mac);
+
+	/* We use system workqueue to deal with scan retries: */
+	k_delayed_work_init(&simplelink_data.work,
+			    simplelink_scan_work_handler);
+
+	SYS_LOG_DBG("SimpleLink driver Initialized");
+
+	return 0;
+}
+
+NET_DEVICE_OFFLOAD_INIT(simplelink, CONFIG_WIFI_SIMPLELINK_NAME,
+			simplelink_init, &simplelink_data, NULL,
+			CONFIG_WIFI_INIT_PRIORITY, &simplelink_api,
+			CONFIG_WIFI_SIMPLELINK_MAX_PACKET_SIZE);

--- a/drivers/wifi/simplelink_support.c
+++ b/drivers/wifi/simplelink_support.c
@@ -1,0 +1,598 @@
+/*
+ * Copyright (c) 2018, Texas Instruments Incorporated
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ */
+
+#define SYS_LOG_LEVEL CONFIG_SYS_LOG_WIFI_LEVEL
+#define SYS_LOG_DOMAIN "dev/simplelink"
+#include <logging/sys_log.h>
+
+#include <stdlib.h>
+#include <string.h>
+#include <zephyr.h>
+#include <stdint.h>
+
+#include <ti/drivers/net/wifi/simplelink.h>
+#include <CC3220SF_LAUNCHXL.h>
+
+#include "simplelink_support.h"
+
+#define SET_STATUS_BIT(status, bit) {status |= (1 << (bit)); }
+#define CLR_STATUS_BIT(status, bit) {status &= ~(1 << (bit)); }
+#define GET_STATUS_BIT(status, bit) (0 != (status & (1 << (bit))))
+
+#define SL_STOP_TIMEOUT	 (200)
+
+#undef ASSERT_ON_ERROR
+#define ASSERT_ON_ERROR(ret, e) __ASSERT(ret >= 0, e)
+#define DEVICE_ERROR	 ("See \"DEVICE ERRORS CODES\" in SimpleLink errors.h")
+#define WLAN_ERROR	 ("See \"WLAN ERRORS CODES\" in SimpleLink errors.h")
+#define NETAPP_ERROR	 ("See \"NETAPP ERRORS CODES\" in SimpleLink errors.h")
+
+#define CHANNEL_MASK_ALL	    (0x1FFF)
+#define RSSI_TH_MAX		    (-95)
+
+enum status_bits {
+	/* Network Processor is powered up */
+	STATUS_BIT_NWP_INIT = 0,
+	/* The device is connected to the AP */
+	STATUS_BIT_CONNECTION,
+	/* The device has leased IP to any connected client */
+	STATUS_BIT_IP_LEASED,
+	/* The device has acquired an IP */
+	STATUS_BIT_IP_ACQUIRED,
+	/* The device has acquired an IPv6 address */
+	STATUS_BIT_IPV6_ACQUIRED,
+};
+
+struct nwp_status {
+	/* Callback to notify net & wifi mgmt events from SL Event Handlers */
+	simplelink_wifi_cb_t cb;
+
+	/* Status Variables */
+	u32_t status;	/* The state of the NWP */
+	u32_t role;	/* The device's role (STA, P2P or AP) */
+
+	/* Scan results table: */
+	SlWlanNetworkEntry_t net_entries[CONFIG_WIFI_SIMPLELINK_SCAN_COUNT];
+};
+
+/* STA/AP mode state: shared with simplelink.c */
+struct sl_connect_state sl_conn;
+
+/* Network Coprocessor state, including role and connection state: */
+static struct nwp_status nwp;
+
+/* Configure the device to a default state, resetting previous parameters .*/
+static s32_t configure_simplelink(void)
+{
+	s32_t retval = -1;
+	s32_t mode = -1;
+	u32_t if_bitmap = 0;
+	SlWlanScanParamCommand_t scan_default = { 0 };
+	SlWlanRxFilterOperationCommandBuff_t rx_filterid_mask = { { 0 } };
+	u8_t config_opt;
+	u8_t power;
+
+	/* Turn on NWP */
+	mode = sl_Start(0, 0, 0);
+	ASSERT_ON_ERROR(mode, DEVICE_ERROR);
+
+	if (mode != ROLE_STA) {
+		/* Set NWP role as STA */
+		mode = sl_WlanSetMode(ROLE_STA);
+		ASSERT_ON_ERROR(mode, WLAN_ERROR);
+
+		/* For changes to take affect, we restart the NWP */
+		retval = sl_Stop(SL_STOP_TIMEOUT);
+		ASSERT_ON_ERROR(retval, DEVICE_ERROR);
+
+		mode = sl_Start(0, 0, 0);
+		ASSERT_ON_ERROR(mode, DEVICE_ERROR);
+	}
+
+	if (mode != ROLE_STA) {
+		SYS_LOG_ERR("Failed to configure NWP to default state");
+		return -1;
+	}
+
+	/* Remove Auto Connection Policy, to avoid multiple re-connect tries:
+	 * Note: this doesn't actually work.
+	 * NWP still issues multiple reconnects on a connection failure.
+	 */
+	retval = sl_WlanPolicySet(SL_WLAN_POLICY_CONNECTION,
+				  SL_WLAN_CONNECTION_POLICY(0, 0, 0, 0),
+				  NULL, 0);
+	ASSERT_ON_ERROR(retval, WLAN_ERROR);
+
+	/* Disable Auto Provisioning*/
+	retval = sl_WlanProvisioning(SL_WLAN_PROVISIONING_CMD_STOP, 0xFF, 0,
+				     NULL, 0x0);
+	ASSERT_ON_ERROR(retval, WLAN_ERROR);
+
+	/* Delete existing profiles */
+	retval = sl_WlanProfileDel(0xFF);
+	ASSERT_ON_ERROR(retval, WLAN_ERROR);
+
+	/* enable DHCP client */
+	retval = sl_NetCfgSet(SL_NETCFG_IPV4_STA_ADDR_MODE,
+			      SL_NETCFG_ADDR_DHCP, 0, 0);
+	ASSERT_ON_ERROR(retval, NETAPP_ERROR);
+
+#if !defined(CONFIG_NET_IPV6)
+	/* Disable ipv6 */
+	if_bitmap = !(SL_NETCFG_IF_IPV6_STA_LOCAL |
+		      SL_NETCFG_IF_IPV6_STA_GLOBAL);
+	retval = sl_NetCfgSet(SL_NETCFG_IF, SL_NETCFG_IF_STATE,
+			      sizeof(if_bitmap),
+			      (const unsigned char *)&if_bitmap);
+	ASSERT_ON_ERROR(retval, NETAPP_ERROR);
+#endif
+
+	/* Configure scan parameters to default */
+	scan_default.ChannelsMask = CHANNEL_MASK_ALL;
+	scan_default.RssiThershold = RSSI_TH_MAX;
+
+	retval = sl_WlanSet(SL_WLAN_CFG_GENERAL_PARAM_ID,
+			    SL_WLAN_GENERAL_PARAM_OPT_SCAN_PARAMS,
+			    sizeof(scan_default), (u8_t *)&scan_default);
+	ASSERT_ON_ERROR(retval, WLAN_ERROR);
+
+	/* Disable scans: In other words, use "one-shot" scanning */
+	config_opt = SL_WLAN_SCAN_POLICY(0, 0);
+	retval = sl_WlanPolicySet(SL_WLAN_POLICY_SCAN, config_opt, NULL, 0);
+	ASSERT_ON_ERROR(retval, WLAN_ERROR);
+
+	/* Set TX power lvl to max */
+	power = 0;
+	retval = sl_WlanSet(SL_WLAN_CFG_GENERAL_PARAM_ID,
+			    SL_WLAN_GENERAL_PARAM_OPT_STA_TX_POWER, 1,
+			    (u8_t *)&power);
+	ASSERT_ON_ERROR(retval, WLAN_ERROR);
+
+	/* Set NWP Power policy to 'normal' */
+	retval = sl_WlanPolicySet(SL_WLAN_POLICY_PM, SL_WLAN_NORMAL_POLICY,
+				  NULL, 0);
+	ASSERT_ON_ERROR(retval, WLAN_ERROR);
+
+	/* Unregister mDNS services */
+	retval = sl_NetAppMDNSUnRegisterService(0, 0, 0);
+	ASSERT_ON_ERROR(retval, NETAPP_ERROR);
+
+	/* Remove all 64 RX filters (8*8) */
+	memset(rx_filterid_mask.FilterBitmap, 0xFF, 8);
+
+	retval = sl_WlanSet(SL_WLAN_RX_FILTERS_ID, SL_WLAN_RX_FILTER_REMOVE,
+			    sizeof(SlWlanRxFilterOperationCommandBuff_t),
+			    (u8_t *)&rx_filterid_mask);
+	ASSERT_ON_ERROR(retval, WLAN_ERROR);
+
+	/* Set NWP role as STA */
+	retval = sl_WlanSetMode(ROLE_STA);
+	ASSERT_ON_ERROR(retval, WLAN_ERROR);
+
+	/* For changes to take affect, we restart the NWP */
+	retval = sl_Stop(0xFF);
+	ASSERT_ON_ERROR(retval, DEVICE_ERROR);
+
+	mode = sl_Start(0, 0, 0);
+	ASSERT_ON_ERROR(mode, DEVICE_ERROR);
+
+	if (mode != ROLE_STA) {
+		SYS_LOG_ERR("Failed to configure device to it's default state");
+		retval = -1;
+	} else {
+		nwp.role = ROLE_STA;
+		SET_STATUS_BIT(nwp.status, STATUS_BIT_NWP_INIT);
+		retval = 0;
+	}
+
+	return retval;
+}
+
+/**
+ *  @brief SimpleLinkWlanEventHandler
+ *
+ *  This handler gets called whenever a WLAN event is reported
+ *  by the host driver / NWP.
+ *
+ *  @note See the CC3120/CC3220 NWP programmer's guide (SWRU455)
+ *	  sections 4.3.4, 4.4.5 and 4.5.5.
+ */
+void SimpleLinkWlanEventHandler(SlWlanEvent_t *wlan_event)
+{
+	SlWlanEventDisconnect_t	 *event_data = NULL;
+
+	if (!wlan_event) {
+		return;
+	}
+
+	switch (wlan_event->Id) {
+	case SL_WLAN_EVENT_CONNECT:
+		SET_STATUS_BIT(nwp.status, STATUS_BIT_CONNECTION);
+
+		/* Store new connection SSID and BSSID: */
+		memcpy(sl_conn.ssid, wlan_event->Data.Connect.SsidName,
+		       wlan_event->Data.Connect.SsidLen);
+		memcpy(sl_conn.bssid, wlan_event->Data.Connect.Bssid,
+		       BSSID_LEN_MAX);
+
+		SYS_LOG_INF("\n[WLAN EVENT] STA Connected to the AP: %s, "
+			    "BSSID: %x:%x:%x:%x:%x:%x",
+			    sl_conn.ssid, sl_conn.bssid[0],
+			    sl_conn.bssid[1], sl_conn.bssid[2],
+			    sl_conn.bssid[3], sl_conn.bssid[4],
+			    sl_conn.bssid[5]);
+
+		/* Continue the notification callback chain... */
+		sl_conn.error = 0;
+		nwp.cb(SL_WLAN_EVENT_CONNECT, &sl_conn);
+		break;
+
+	case SL_WLAN_EVENT_DISCONNECT:
+		CLR_STATUS_BIT(nwp.status, STATUS_BIT_CONNECTION);
+		CLR_STATUS_BIT(nwp.status, STATUS_BIT_IP_ACQUIRED);
+		CLR_STATUS_BIT(nwp.status, STATUS_BIT_IPV6_ACQUIRED);
+
+		event_data = &wlan_event->Data.Disconnect;
+
+		/* If the user has initiated 'Disconnect' request,
+		 * 'reason_code' is SL_WLAN_DISCONNECT_USER_INITIATED
+		 */
+		if (SL_WLAN_DISCONNECT_USER_INITIATED ==
+		    event_data->ReasonCode) {
+			SYS_LOG_INF("\n[WLAN EVENT] "
+				    "Device disconnected from the AP: %s,\n\r"
+				    "BSSID: %x:%x:%x:%x:%x:%x on application's"
+				    " request",
+				    event_data->SsidName, event_data->Bssid[0],
+				    event_data->Bssid[1], event_data->Bssid[2],
+				    event_data->Bssid[3], event_data->Bssid[4],
+				    event_data->Bssid[5]);
+			sl_conn.error = 0;
+		} else {
+			SYS_LOG_ERR("\n[WLAN ERROR] "
+				    "Device disconnected from the AP: %s,\n\r"
+				    "BSSID: %x:%x:%x:%x:%x:%x on error: %d",
+				    event_data->SsidName, event_data->Bssid[0],
+				    event_data->Bssid[1], event_data->Bssid[2],
+				    event_data->Bssid[3], event_data->Bssid[4],
+				    event_data->Bssid[5],
+				    event_data->ReasonCode);
+			sl_conn.error = event_data->ReasonCode;
+		}
+
+		memset(&(sl_conn.ssid), 0x0, sizeof(sl_conn.ssid));
+		memset(&(sl_conn.bssid), 0x0, sizeof(sl_conn.bssid));
+
+		/* Continue the notification callback chain... */
+		nwp.cb(SL_WLAN_EVENT_DISCONNECT, &sl_conn);
+		break;
+
+	case SL_WLAN_EVENT_STA_ADDED:
+		memcpy(&(sl_conn.bssid), wlan_event->Data.STAAdded.Mac,
+		       SL_WLAN_BSSID_LENGTH);
+		SYS_LOG_INF("\n[WLAN EVENT] STA was added to AP: "
+			    "BSSID: %x:%x:%x:%x:%x:%x",
+			    sl_conn.bssid[0], sl_conn.bssid[1],
+			    sl_conn.bssid[2], sl_conn.bssid[3],
+			    sl_conn.bssid[4], sl_conn.bssid[5]);
+		break;
+	case SL_WLAN_EVENT_STA_REMOVED:
+		memcpy(&(sl_conn.bssid), wlan_event->Data.STAAdded.Mac,
+		       SL_WLAN_BSSID_LENGTH);
+		SYS_LOG_INF("\n[WLAN EVENT] STA was removed from AP: "
+			    "BSSID: %x:%x:%x:%x:%x:%x",
+			    sl_conn.bssid[0], sl_conn.bssid[1],
+			    sl_conn.bssid[2], sl_conn.bssid[3],
+			    sl_conn.bssid[4], sl_conn.bssid[5]);
+
+		memset(&(sl_conn.bssid), 0x0, sizeof(sl_conn.bssid));
+		break;
+	default:
+		SYS_LOG_ERR("\n[WLAN EVENT] Unexpected event [0x%lx]",
+			    wlan_event->Id);
+		break;
+	}
+}
+
+/**
+ *  @brief SimpleLinkNetAppEventHandler
+ *
+ *  This handler gets called whenever a Netapp event is reported
+ *  by the host driver / NWP.
+ *
+ *  @note See the CC3120/CC3220 NWP programmer's guide (SWRU455)
+ *	  section 5.7.
+ */
+void SimpleLinkNetAppEventHandler(SlNetAppEvent_t *netapp_event)
+{
+	SlIpV4AcquiredAsync_t *event_data = NULL;
+	u32_t i;
+
+	if (!netapp_event) {
+		return;
+	}
+
+	switch (netapp_event->Id) {
+	case SL_DEVICE_EVENT_DROPPED_NETAPP_IPACQUIRED:
+		SET_STATUS_BIT(nwp.status, STATUS_BIT_IP_ACQUIRED);
+
+		/* Ip Acquired Event Data */
+		event_data = &netapp_event->Data.IpAcquiredV4;
+		sl_conn.ip_addr = event_data->Ip;
+
+		/* Gateway IP address */
+		sl_conn.gateway_ip = event_data->Gateway;
+
+		SYS_LOG_INF("\n[NETAPP EVENT] IP set to: IPv4=%d.%d.%d.%d, "
+			    "Gateway=%d.%d.%d.%d",
+			    SL_IPV4_BYTE(sl_conn.ip_addr, 3),
+			    SL_IPV4_BYTE(sl_conn.ip_addr, 2),
+			    SL_IPV4_BYTE(sl_conn.ip_addr, 1),
+			    SL_IPV4_BYTE(sl_conn.ip_addr, 0),
+
+			    SL_IPV4_BYTE(sl_conn.gateway_ip, 3),
+			    SL_IPV4_BYTE(sl_conn.gateway_ip, 2),
+			    SL_IPV4_BYTE(sl_conn.gateway_ip, 1),
+			    SL_IPV4_BYTE(sl_conn.gateway_ip, 0));
+
+		nwp.cb(SIMPLELINK_WIFI_CB_IPACQUIRED, &sl_conn);
+		break;
+
+	case SL_DEVICE_EVENT_DROPPED_NETAPP_IPACQUIRED_V6:
+		SET_STATUS_BIT(nwp.status, STATUS_BIT_IPV6_ACQUIRED);
+
+		for (i = 0; i < 4; i++) {
+			sl_conn.ipv6_addr[i] =
+			  netapp_event->Data.IpAcquiredV6.Ip[i];
+		}
+
+		if (SYS_LOG_LEVEL >= SYS_LOG_LEVEL_INFO) {
+			char ipv6_addr[NET_IPV6_ADDR_LEN];
+
+			net_addr_ntop(AF_INET6, sl_conn.ipv6_addr,
+				      ipv6_addr,
+				      sizeof(ipv6_addr));
+			SYS_LOG_INF("\n[NETAPP EVENT] IP Acquired: IPv6= %s",
+				    ipv6_addr);
+		}
+
+		break;
+
+	case SL_DEVICE_EVENT_DROPPED_NETAPP_IP_LEASED:
+		SET_STATUS_BIT(nwp.status, STATUS_BIT_IP_LEASED);
+		SET_STATUS_BIT(nwp.status, STATUS_BIT_IP_ACQUIRED);
+
+		sl_conn.sta_ip = netapp_event->Data.IpLeased.IpAddress;
+		SYS_LOG_INF("\n[NETAPP EVENT] IP Leased to Client: "
+			    "IP=%d.%d.%d.%d",
+			    SL_IPV4_BYTE(sl_conn.sta_ip, 3),
+			    SL_IPV4_BYTE(sl_conn.sta_ip, 2),
+			    SL_IPV4_BYTE(sl_conn.sta_ip, 1),
+			    SL_IPV4_BYTE(sl_conn.sta_ip, 0));
+
+		break;
+
+	case SL_DEVICE_EVENT_DROPPED_NETAPP_IP_RELEASED:
+		SYS_LOG_INF("\n[NETAPP EVENT] IP is released.");
+		break;
+
+	default:
+		SYS_LOG_ERR("\n[NETAPP EVENT] Unexpected event [0x%lx]",
+			    netapp_event->Id);
+		break;
+	}
+}
+
+/**
+ *  @brief SimpleLinkGeneralEventHandler
+ *
+ *  This handler gets called whenever a general error is reported
+ *  by the NWP / Host driver. Since these errors are not fatal,
+ *  the application can handle them.
+ *
+ *  @note See the CC3120/CC3220 NWP programmer's guide (SWRU455)
+ *	  section 17.9.
+ */
+void SimpleLinkGeneralEventHandler(SlDeviceEvent_t *dev_event)
+{
+	if (!dev_event) {
+		return;
+	}
+
+	SYS_LOG_INF("\n[GENERAL EVENT] - ID=[%d] Sender=[%d]",
+		    dev_event->Data.Error.Code,
+		    dev_event->Data.Error.Source);
+}
+
+/**
+ *  @brief SimpleLinkFatalErrorEventHandler
+ *
+ *  This handler gets called whenever a driver error occurs requiring
+ *  restart of the device in order to recover.
+ */
+void SimpleLinkFatalErrorEventHandler(SlDeviceFatal_t *fatal_err_event)
+{
+
+	switch (fatal_err_event->Id) {
+	case SL_DEVICE_EVENT_FATAL_DEVICE_ABORT:
+		SYS_LOG_ERR("\n[ERROR] - FATAL ERROR: "
+			    "Abort NWP event detected: "
+			    "AbortType=%ld, AbortData=0x%lx",
+			    fatal_err_event->Data.DeviceAssert.Code,
+			    fatal_err_event->Data.DeviceAssert.Value);
+		break;
+
+	case SL_DEVICE_EVENT_FATAL_DRIVER_ABORT:
+		SYS_LOG_ERR("\n[ERROR] - FATAL ERROR: Driver Abort detected.");
+		break;
+
+	case SL_DEVICE_EVENT_FATAL_NO_CMD_ACK:
+		SYS_LOG_ERR("\n[ERROR] - FATAL ERROR: No Cmd Ack detected "
+			    "[cmd opcode = 0x%lx]",
+			    fatal_err_event->Data.NoCmdAck.Code);
+		break;
+
+	case SL_DEVICE_EVENT_FATAL_SYNC_LOSS:
+		SYS_LOG_ERR("\n[ERROR] - FATAL ERROR: Sync loss detected");
+		break;
+
+	case SL_DEVICE_EVENT_FATAL_CMD_TIMEOUT:
+		SYS_LOG_ERR("\n[ERROR] - FATAL ERROR: "
+			    "Async event timeout detected "
+			    "[event opcode =0x%lx]",
+			    fatal_err_event->Data.CmdTimeout.Code);
+		break;
+
+	default:
+		SYS_LOG_ERR("\n[ERROR] - FATAL ERROR: "
+			    "Unspecified error detected");
+		break;
+	}
+}
+
+/* Unused, but must be defined to link.	 */
+void SimpleLinkSockEventHandler(SlSockEvent_t *psock)
+{
+	ARG_UNUSED(psock);
+}
+
+/* Unused, but must be defined to link.	 */
+void SimpleLinkHttpServerEventHandler(SlNetAppHttpServerEvent_t *http_event,
+				      SlNetAppHttpServerResponse_t *http_resp)
+{
+	ARG_UNUSED(http_event);
+	ARG_UNUSED(http_resp);
+}
+
+
+/* Unused, but must be defined to link.	 */
+void SimpleLinkNetAppRequestEventHandler(SlNetAppRequest_t *netapp_request,
+					 SlNetAppResponse_t *netapp_response)
+{
+	ARG_UNUSED(netapp_request);
+	ARG_UNUSED(netapp_response);
+}
+
+/* Unused, but must be defined to link.	 */
+void SimpleLinkNetAppRequestMemFreeEventHandler(u8_t *buffer)
+{
+	ARG_UNUSED(buffer);
+}
+
+/* Note: SimpleLink WiFi scan also can return the following:
+ * - BSSID
+ * - Whether network hidden or visible
+ * - Other types of security
+ */
+void _simplelink_get_scan_result(int index,
+				 struct wifi_scan_result *scan_result)
+{
+	SlWlanNetworkEntry_t *net_entry;
+	int sec_bmp;
+
+	__ASSERT_NO_MSG(index <= CONFIG_WIFI_SIMPLELINK_SCAN_COUNT);
+	net_entry = &nwp.net_entries[index];
+
+	memset(scan_result, 0x0, sizeof(struct wifi_scan_result));
+
+	__ASSERT_NO_MSG(net_entry->SsidLen <= WIFI_SSID_MAX_LEN);
+	memcpy(scan_result->ssid, net_entry->Ssid, net_entry->SsidLen);
+	scan_result->ssid_length = net_entry->SsidLen;
+	scan_result->channel = net_entry->Channel;
+
+	/* Parse security bitmap: */
+	sec_bmp = net_entry->SecurityInfo;
+	if (SL_WLAN_SCAN_RESULT_SEC_TYPE_BITMAP(sec_bmp) & 0x6) {
+		scan_result->security = WIFI_SECURITY_TYPE_PSK;
+	} else {
+		scan_result->security = WIFI_SECURITY_TYPE_NONE;
+	}
+
+	scan_result->rssi = net_entry->Rssi;
+}
+
+int _simplelink_start_scan(void)
+{
+	s32_t ret;
+
+	/* Clear the results buffer */
+	memset(&nwp.net_entries, 0x0, sizeof(nwp.net_entries));
+
+	/* Attempt to get scan results from NWP
+	 * Note: If scan policy isn't set, invoking 'sl_WlanGetNetworkList()'
+	 * for the first time triggers 'one shot' scan.
+	 */
+	ret = sl_WlanGetNetworkList(0, CONFIG_WIFI_SIMPLELINK_SCAN_COUNT,
+				    &nwp.net_entries[0]);
+	SYS_LOG_DBG("sl_WlanGetNetworkList: %d", ret);
+
+	return ret;
+}
+
+void _simplelink_get_mac(unsigned char *mac)
+{
+	u16_t mac_len = SL_MAC_ADDR_LEN;
+	u16_t config_opt = 0;
+
+	sl_NetCfgGet(SL_NETCFG_MAC_ADDRESS_GET, &config_opt,
+		     &mac_len, (u8_t *)mac);
+}
+
+int _simplelink_connect(struct wifi_connect_req_params *params)
+{
+	SlWlanSecParams_t secParams = { 0 };
+	long lretval;
+
+	if (params->security == WIFI_SECURITY_TYPE_PSK) {
+		secParams.Key = (signed char *)params->psk;
+		secParams.KeyLen = params->psk_length;
+		/* This is only mapping handled for now: */
+		secParams.Type = SL_WLAN_SEC_TYPE_WPA_WPA2;
+	} else {
+		secParams.Key = (signed char *)NULL;
+		secParams.KeyLen = 0;
+		secParams.Type = SL_WLAN_SEC_TYPE_OPEN;
+	}
+
+	lretval = sl_WlanConnect((signed char *)params->ssid,
+				 params->ssid_length, 0, &secParams, 0);
+	SYS_LOG_DBG("sl_WlanConnect: %ld", lretval);
+
+	return lretval;
+}
+
+int _simplelink_disconnect(void)
+{
+	long lretval;
+
+	lretval = sl_WlanDisconnect();
+	SYS_LOG_DBG("sl_WlanDisconnect: %ld", lretval);
+
+	return lretval;
+}
+
+int _simplelink_init(simplelink_wifi_cb_t wifi_cb)
+{
+	int retval;
+
+	__ASSERT(wifi_cb, "callback must be supplied");
+
+	/* Init the board: */
+	CC3220SF_LAUNCHXL_init();
+
+	/* Configure SimpleLink NWP: */
+	nwp.status = 0;
+	nwp.role = ROLE_RESERVED;
+	nwp.cb = wifi_cb;
+
+	memset(&sl_conn, 0x0, sizeof(sl_conn));
+
+	retval = configure_simplelink();
+	__ASSERT(retval >= 0, "Unable to configure SimpleLink");
+
+	return retval;
+}

--- a/drivers/wifi/simplelink_support.h
+++ b/drivers/wifi/simplelink_support.h
@@ -1,0 +1,54 @@
+/*
+ * Copyright (c) 2018, Texas Instruments Incorporated
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ */
+
+#ifndef __SIMPLELINK_SUPPORT_H__
+#define __SIMPLELINK_SUPPORT_H__
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#include <net/wifi_mgmt.h>
+
+#define SSID_LEN_MAX	 (32)
+#define BSSID_LEN_MAX	 (6)
+
+/* Define ID for simplelink_wifi_cb to not conflict with WLAN event IDs: */
+#define SIMPLELINK_WIFI_CB_IPACQUIRED \
+		(SL_WLAN_EVENT_MAX + SL_DEVICE_EVENT_DROPPED_NETAPP_IPACQUIRED)
+
+struct sl_connect_state {
+	u32_t gateway_ip;
+	u8_t ssid[SSID_LEN_MAX + 1];
+	u8_t bssid[BSSID_LEN_MAX];
+	u32_t ip_addr;
+	u32_t sta_ip;
+	u32_t ipv6_addr[4];
+	s16_t error;
+};
+
+/* Callback from SimpleLink Event Handlers: */
+typedef void (*simplelink_wifi_cb_t)(u32_t mgmt_event,
+				     struct sl_connect_state *conn);
+
+extern int _simplelink_start_scan(void);
+extern void _simplelink_get_scan_result(int index,
+					struct wifi_scan_result *scan_result);
+extern void _simplelink_get_mac(unsigned char *mac);
+extern int _simplelink_init(simplelink_wifi_cb_t wifi_cb);
+extern int _simplelink_connect(struct wifi_connect_req_params *params);
+extern int _simplelink_disconnect(void);
+
+#ifdef __cplusplus
+}
+#endif
+
+/**
+ * @}
+ */
+
+#endif /* __SIMPLELINK_SUPPORT_H__ */

--- a/ext/hal/ti/simplelink/Kconfig
+++ b/ext/hal/ti/simplelink/Kconfig
@@ -11,7 +11,7 @@ config SIMPLELINK_HOST_DRIVER
 	default n
 	depends on HAS_CC3220SDK
 	depends on MULTITHREADING
-	depends on NEWLIB_LIBC
+	select NEWLIB_LIBC
 	select ERRNO
 	help
 	  Build the SimpleLink host driver

--- a/samples/net/wifi/boards/cc3220sf_launchxl.conf
+++ b/samples/net/wifi/boards/cc3220sf_launchxl.conf
@@ -1,0 +1,6 @@
+# Conf file to test the net_wifi shell module with the cc3220sf WiFi driver
+# cmake .. -DBOARD=cc3220sf_launchxl
+CONFIG_WIFI_SIMPLELINK=y
+# Debugging
+CONFIG_SYS_LOG_WIFI_LEVEL=4
+CONFIG_DEBUG=y


### PR DESCRIPTION
Initiate a SimpleLink WiFi Driver, implemented to the WiFi management
offload APIs for scan, connect, disconnect.

Also registers the DHCP-obtained IPv4 address upon connect.

This was validated on a cc3220sf_launchxl using the wifi
shell module from the Zephyr shell_module sample.   
A commit for that sample test is also included.

This is a replacement for the closed PR #6466.
