### PR TITLE
doc: Document format for CONF_FILE

### DIFF
--- a/doc/application/application.rst
+++ b/doc/application/application.rst
@@ -143,10 +143,11 @@ configure the Zephyr build system:
   application's :file:`CMakeLists.txt` file, or in the ``cmake`` command line.
 
 * :makevar:`CONF_FILE`: Indicates the name of one or more configuration
-  fragment files.  Each file includes kconfig configuration values that
-  override the default configuration values.  Like :makevar:`BOARD`, this can
-  also be defined in the environment, in your application's
-  :file:`CMakeLists.txt` file, or in the ``cmake`` command line.
+  fragment files.  Multiple filenames are separated by a single space.  Each
+  file includes Kconfig configuration values that override the default
+  configuration values.  Like :makevar:`BOARD`, this can also be defined in the
+  environment, in your application's :file:`CMakeLists.txt` file, or in the
+  ``cmake`` command line.
 
 * :makevar:`DTC_OVERLAY_FILE`: Indicates the name of one or more Device Tree
   overlay files.  Each file includes Device Tree values that
@@ -759,6 +760,7 @@ Make sure to follow these steps in order.
    the usual :file:`prj.conf` (or :file:`prj_YOUR_BOARD.conf`, where
    ``YOUR_BOARD`` is a board name), add lines setting the
    :makevar:`CONF_FILE` variable to these files appropriately.
+   If multiple filenames are given, separate them by a single space.
 
    More details are available below in :ref:`application_kconfig`.
 


### PR DESCRIPTION
The documentation doesn't give the format for listing multiple files in
CONF_FILE. It's a space-separated list.

Signed-off-by: Ulf Magnusson <ulfalizer@gmail.com>