### PR TITLE
arch: arm: clear BFSR sticky bits in ARMv8-M Mainline MCUs

### DIFF
--- a/arch/arm/core/fault.c
+++ b/arch/arm/core/fault.c
@@ -121,6 +121,10 @@ void _FaultDump(const NANO_ESF *esf, int fault)
 
 	/* clear USFR sticky bits */
 	SCB->CFSR |= SCB_CFSR_USGFAULTSR_Msk;
+#if defined(CONFIG_ARMV8_M_MAINLINE)
+	/* clear BSFR sticky bits */
+	SCB->CFSR |= SCB_CFSR_BUSFAULTSR_Msk;
+#endif /* CONFIG_ARMV8_M_MAINLINE */
 #else
 #error Unknown ARM architecture
 #endif /* CONFIG_ARMV6_M_ARMV8_M_BASELINE */
@@ -247,6 +251,11 @@ static void _BusFault(const NANO_ESF *esf, int fromHardFault)
 		PR_EXC("  Floating-point lazy state preservation error\n");
 	}
 #endif /* !defined(CONFIG_ARMV7_M_ARMV8_M_FP) */
+
+#if defined(CONFIG_ARMV8_M_MAINLINE)
+	/* clear BSFR sticky bits */
+	SCB->CFSR |= SCB_CFSR_BUSFAULTSR_Msk;
+#endif /* CONFIG_ARMV8_M_MAINLINE */
 }
 
 /**


### PR DESCRIPTION
Contrary to ARMv7-M, in ARMv8-M MCUs with the Main Extension,
BusFault Status Register bits are sticky and must be cleared.

Signed-off-by: Ioannis Glaropoulos <Ioannis.Glaropoulos@nordicsemi.no>