### PR TITLE
include: toolchain: common: Remove deprecated __stack macro

### DIFF
--- a/include/toolchain/common.h
+++ b/include/toolchain/common.h
@@ -99,13 +99,6 @@
 #define _STRINGIFY(x) #x
 #define STRINGIFY(s) _STRINGIFY(s)
 
-/* Indicate that an array will be used for stack space. */
-
-#if !defined(_ASMLANGUAGE)
-  /* don't use this anymore, use K_DECLARE_STACK instead. Remove for 1.11 */
-  #define __stack __aligned(STACK_ALIGN) __DEPRECATED_MACRO
-#endif
-
 /* concatenate the values of the arguments into one */
 #define _DO_CONCAT(x, y) x ## y
 #define _CONCAT(x, y) _DO_CONCAT(x, y)


### PR DESCRIPTION
This macro has been deprecated in favor of K_DECLARE_STACK; should have
been removed by 1.11.

Signed-off-by: Leandro Pereira <leandro.pereira@intel.com>