### PR TITLE
DRAFT/scripts: list testcases built into an ELF Zephyr ztest

### DIFF
--- a/scripts/elf_helper.py
+++ b/scripts/elf_helper.py
@@ -325,11 +325,17 @@ def get_filename_lineno(die):
 
 class ElfHelper:
 
-    def __init__(self, filename, verbose, kobjs, subs):
+    def __init__(self, filename, verbose, kobjs, subs,
+                 check_bounds = True):
+        """
+        :param bool check_bounds: (optional) check the objects are
+            inside the kernel RAM and ROM bounds (default: yes)
+        """
         self.verbose = verbose
         self.fp = open(filename, "rb")
         self.elf = ELFFile(self.fp)
         self.little_endian = self.elf.little_endian
+        self.check_bounds = check_bounds
         global kobjects
         global subsystems
         kobjects = kobjs
@@ -445,8 +451,9 @@ class ElfHelper:
                 # Never linked; gc-sections deleted it
                 continue
 
-            if ((addr < kram_start or addr >= kram_end) and
-               (addr < krom_start or addr >= krom_end)):
+            if self.check_bounds \
+               and (((addr < kram_start or addr >= kram_end) and
+                     (addr < krom_start or addr >= krom_end))):
 
                 self.debug_die(die,
                                "object '%s' found in invalid location %s"

--- a/scripts/get-unit-tests.py
+++ b/scripts/get-unit-tests.py
@@ -1,0 +1,26 @@
+#! /usr/bin/python3
+#
+# Get all the test functions in a given binary given in argv #1
+#
+# ztest Zephyr images contain a test suite, declared with
+# ztest_test_suite() and it's fed a name and list of test functions.
+#
+# To find them, look for any symbols of type 'struct unit_test'; per
+# tests/ztest/include/ztest_test.h, those include in the second member
+# (+4) a pointer to a test function.
+#
+import elf_helper
+import sys
+eh = elf_helper.ElfHelper(sys.argv[1], False, "unit_test", [],
+                          check_bounds = False)
+syms = eh.get_symbols()			# map of symbols and their addresses
+syms_addrs = {}				# map of address to symbol
+for name, addr in syms.items():
+    syms_addrs[addr] = name
+# Iterate over all objects of type 'unit_test'; for each, dereference
+# the value in addr + 4 (->test) and lookup its name; print it.
+for addr, obj in eh.find_kobjects(syms).items():
+    fn_addr = elf_helper.addr_deref(eh.elf, addr + 4)
+    # fn_addr zero is end of table, so we ignore it
+    if fn_addr > 0 and fn_addr in syms_addrs:
+        print(syms_addrs[fn_addr])

--- a/tests/ztest/include/ztest_test.h
+++ b/tests/ztest/include/ztest_test.h
@@ -14,6 +14,10 @@
 #define __ZTEST_TEST_H__
 
 struct unit_test {
+	/*
+	 * If the offset of ->test changes, you need to update
+	 * ../../../scripts/get-unit-tests.py and probably others
+	 */
 	const char *name;
 	void (*test)(void);
 	void (*setup)(void);


### PR DESCRIPTION
When a ztest app is built, extract the list of unit ztests contained
in it.

This is done by parsing out the list of statics of type 'struct
unit_test' declared by ztest_(user_)unit_test() and friends.

Signed-off-by: Inaky Perez-Gonzalez <inaky.perez-gonzalez@intel.com>