### PR TITLE
dts: cleanup dts warnings on STM32

### DIFF
--- a/boards/arm/96b_argonkey/96b_argonkey.dts
+++ b/boards/arm/96b_argonkey/96b_argonkey.dts
@@ -31,8 +31,6 @@
 
 	gpio_keys {
 		compatible = "gpio-keys";
-		#address-cells = <1>;
-		#size-cells = <0>;
 		user_button: button@0 {
 			label = "User";
 			gpios = <&gpioa 2 GPIO_INT_ACTIVE_LOW>;

--- a/boards/arm/96b_carbon/96b_carbon.dts
+++ b/boards/arm/96b_carbon/96b_carbon.dts
@@ -35,8 +35,6 @@
 
 	gpio_keys {
 		compatible = "gpio-keys";
-		#address-cells = <1>;
-		#size-cells = <0>;
 		user_button: button@0 {
 			label = "User";
 			gpios = <&gpiob 2 GPIO_INT_ACTIVE_LOW>;

--- a/boards/arm/96b_neonkey/96b_neonkey.dts
+++ b/boards/arm/96b_neonkey/96b_neonkey.dts
@@ -39,8 +39,6 @@
 
 	gpio_keys {
 		compatible = "gpio-keys";
-		#address-cells = <1>;
-		#size-cells = <0>;
 		user_button: button@0 {
 			label = "User";
 			gpios = <&gpiob 2 GPIO_INT_ACTIVE_LOW>;

--- a/boards/arm/disco_l475_iot1/disco_l475_iot1.dts
+++ b/boards/arm/disco_l475_iot1/disco_l475_iot1.dts
@@ -31,8 +31,6 @@
 
 	gpio_keys {
 		compatible = "gpio-keys";
-		#address-cells = <1>;
-		#size-cells = <0>;
 		user_button: button@0 {
 			label = "User";
 			gpios = <&gpioc 13 GPIO_INT_ACTIVE_LOW>;

--- a/boards/arm/frdm_k64f/frdm_k64f.dts
+++ b/boards/arm/frdm_k64f/frdm_k64f.dts
@@ -63,8 +63,6 @@
 
 	gpio_keys {
 		compatible = "gpio-keys";
-		#address-cells = <1>;
-		#size-cells = <0>;
 		user_button_2: button@0 {
 			label = "User SW2";
 			gpios = <&gpioc 6 GPIO_INT_ACTIVE_LOW>;

--- a/boards/arm/frdm_kl25z/frdm_kl25z.dts
+++ b/boards/arm/frdm_kl25z/frdm_kl25z.dts
@@ -47,8 +47,6 @@
 
 	gpio_keys {
 		compatible = "gpio-keys";
-		#address-cells = <1>;
-		#size-cells = <0>;
 		user_button_0: button@0 {
 			label = "User SW0";
 			gpios = <&gpioa 16 GPIO_INT_ACTIVE_LOW>;

--- a/boards/arm/frdm_kw41z/frdm_kw41z.dts
+++ b/boards/arm/frdm_kw41z/frdm_kw41z.dts
@@ -48,8 +48,6 @@
 
 	gpio_keys {
 		compatible = "gpio-keys";
-		#address-cells = <1>;
-		#size-cells = <0>;
 		user_button_3: button@0 {
 			label = "User SW3";
 			gpios = <&gpioc 4 GPIO_INT_ACTIVE_LOW>;

--- a/boards/arm/nucleo_f030r8/nucleo_f030r8.dts
+++ b/boards/arm/nucleo_f030r8/nucleo_f030r8.dts
@@ -27,8 +27,6 @@
 
 	gpio_keys {
 		compatible = "gpio-keys";
-		#address-cells = <1>;
-		#size-cells = <0>;
 		user_button: button@0 {
 			label = "User";
 			gpios = <&gpioc 13 GPIO_INT_ACTIVE_LOW>;

--- a/boards/arm/nucleo_f070rb/nucleo_f070rb.dts
+++ b/boards/arm/nucleo_f070rb/nucleo_f070rb.dts
@@ -27,8 +27,6 @@
 
 	gpio_keys {
 		compatible = "gpio-keys";
-		#address-cells = <1>;
-		#size-cells = <0>;
 		user_button: button@0 {
 			label = "User";
 			gpios = <&gpioc 13 GPIO_INT_ACTIVE_LOW>;

--- a/boards/arm/nucleo_f091rc/nucleo_f091rc.dts
+++ b/boards/arm/nucleo_f091rc/nucleo_f091rc.dts
@@ -27,8 +27,6 @@
 
 	gpio_keys {
 		compatible = "gpio-keys";
-		#address-cells = <1>;
-		#size-cells = <0>;
 		user_button: button@0 {
 			label = "User";
 			gpios = <&gpioc 13 GPIO_INT_ACTIVE_LOW>;

--- a/boards/arm/nucleo_f103rb/nucleo_f103rb.dts
+++ b/boards/arm/nucleo_f103rb/nucleo_f103rb.dts
@@ -27,8 +27,6 @@
 
 	gpio_keys {
 		compatible = "gpio-keys";
-		#address-cells = <1>;
-		#size-cells = <0>;
 		user_button: button@0 {
 			label = "User";
 			gpios = <&gpioc 13 GPIO_INT_ACTIVE_LOW>;

--- a/boards/arm/nucleo_f334r8/nucleo_f334r8.dts
+++ b/boards/arm/nucleo_f334r8/nucleo_f334r8.dts
@@ -27,8 +27,6 @@
 
 	gpio_keys {
 		compatible = "gpio-keys";
-		#address-cells = <1>;
-		#size-cells = <0>;
 		user_button: button@0 {
 			label = "User";
 			gpios = <&gpioc 13 GPIO_INT_ACTIVE_LOW>;

--- a/boards/arm/nucleo_f401re/nucleo_f401re.dts
+++ b/boards/arm/nucleo_f401re/nucleo_f401re.dts
@@ -27,8 +27,6 @@
 
 	gpio_keys {
 		compatible = "gpio-keys";
-		#address-cells = <1>;
-		#size-cells = <0>;
 		user_button: button@0 {
 			label = "User";
 			gpios = <&gpioc 13 GPIO_INT_ACTIVE_LOW>;

--- a/boards/arm/nucleo_f411re/nucleo_f411re.dts
+++ b/boards/arm/nucleo_f411re/nucleo_f411re.dts
@@ -27,8 +27,6 @@
 
 	gpio_keys {
 		compatible = "gpio-keys";
-		#address-cells = <1>;
-		#size-cells = <0>;
 		user_button: button@0 {
 			label = "User";
 			gpios = <&gpioc 13 GPIO_INT_ACTIVE_LOW>;

--- a/boards/arm/nucleo_f412zg/nucleo_f412zg.dts
+++ b/boards/arm/nucleo_f412zg/nucleo_f412zg.dts
@@ -35,8 +35,6 @@
 
 	gpio_keys {
 		compatible = "gpio-keys";
-		#address-cells = <1>;
-		#size-cells = <0>;
 		user_button: button@0 {
 			label = "User";
 			gpios = <&gpioc 13 GPIO_INT_ACTIVE_LOW>;

--- a/boards/arm/nucleo_f413zh/nucleo_f413zh.dts
+++ b/boards/arm/nucleo_f413zh/nucleo_f413zh.dts
@@ -35,8 +35,6 @@
 
 	gpio_keys {
 		compatible = "gpio-keys";
-		#address-cells = <1>;
-		#size-cells = <0>;
 		user_button: button@0 {
 			label = "User";
 			gpios = <&gpioc 13 GPIO_INT_ACTIVE_LOW>;

--- a/boards/arm/nucleo_f429zi/nucleo_f429zi.dts
+++ b/boards/arm/nucleo_f429zi/nucleo_f429zi.dts
@@ -35,8 +35,6 @@
 
 	gpio_keys {
 		compatible = "gpio-keys";
-		#address-cells = <1>;
-		#size-cells = <0>;
 		user_button: button@0 {
 			label = "User";
 			gpios = <&gpioc 13 GPIO_INT_ACTIVE_LOW>;

--- a/boards/arm/nucleo_f446re/nucleo_f446re.dts
+++ b/boards/arm/nucleo_f446re/nucleo_f446re.dts
@@ -27,8 +27,6 @@
 
 	gpio_keys {
 		compatible = "gpio-keys";
-		#address-cells = <1>;
-		#size-cells = <0>;
 		user_button: button@0 {
 			label = "User";
 			gpios = <&gpioc 13 GPIO_INT_ACTIVE_LOW>;

--- a/boards/arm/nucleo_l073rz/nucleo_l073rz.dts
+++ b/boards/arm/nucleo_l073rz/nucleo_l073rz.dts
@@ -27,8 +27,6 @@
 
 	gpio_keys {
 		compatible = "gpio-keys";
-		#address-cells = <1>;
-		#size-cells = <0>;
 		user_button: button@0 {
 			label = "User";
 			gpios = <&gpioc 13 GPIO_INT_ACTIVE_LOW>;

--- a/boards/arm/nucleo_l432kc/nucleo_l432kc.dts
+++ b/boards/arm/nucleo_l432kc/nucleo_l432kc.dts
@@ -27,8 +27,6 @@
 
 	gpio_keys {
 		compatible = "gpio-keys";
-		#address-cells = <1>;
-		#size-cells = <0>;
 		user_button: button@0 {
 			label = "User";
 			gpios = <&gpioc 13 GPIO_INT_ACTIVE_LOW>;

--- a/boards/arm/nucleo_l476rg/nucleo_l476rg.dts
+++ b/boards/arm/nucleo_l476rg/nucleo_l476rg.dts
@@ -27,8 +27,6 @@
 
 	gpio_keys {
 		compatible = "gpio-keys";
-		#address-cells = <1>;
-		#size-cells = <0>;
 		user_button: button@0 {
 			label = "User";
 			gpios = <&gpioc 13 GPIO_INT_ACTIVE_LOW>;

--- a/boards/arm/olimex_stm32_e407/olimex_stm32_e407.dts
+++ b/boards/arm/olimex_stm32_e407/olimex_stm32_e407.dts
@@ -28,8 +28,6 @@
 
 	gpio_keys {
 		compatible = "gpio-keys";
-		#address-cells = <1>;
-		#size-cells = <0>;
 		user_button: button@0 {
 			label = "Key";
 			gpios = <&gpioa 0 GPIO_INT_ACTIVE_LOW>;

--- a/boards/arm/olimex_stm32_h407/olimex_stm32_h407.dts
+++ b/boards/arm/olimex_stm32_h407/olimex_stm32_h407.dts
@@ -28,8 +28,6 @@
 
 	gpio_keys {
 		compatible = "gpio-keys";
-		#address-cells = <1>;
-		#size-cells = <0>;
 		user_button: button@0 {
 			label = "User";
 			gpios = <&gpioc 13 GPIO_INT_ACTIVE_LOW>;

--- a/boards/arm/olimex_stm32_p405/olimex_stm32_p405.dts
+++ b/boards/arm/olimex_stm32_p405/olimex_stm32_p405.dts
@@ -28,8 +28,6 @@
 
 	gpio_keys {
 		compatible = "gpio-keys";
-		#address-cells = <1>;
-		#size-cells = <0>;
 		user_button: button@0 {
 			label = "Key";
 			gpios = <&gpioa 0 GPIO_INT_ACTIVE_LOW>;

--- a/boards/arm/olimexino_stm32/olimexino_stm32.dts
+++ b/boards/arm/olimexino_stm32/olimexino_stm32.dts
@@ -31,8 +31,6 @@
 
 	gpio_keys {
 		compatible = "gpio-keys";
-		#address-cells = <1>;
-		#size-cells = <0>;
 		user_button: button@0 {
 			label = "Key";
 			gpios = <&gpioc 9 GPIO_INT_ACTIVE_LOW>;

--- a/boards/arm/stm3210c_eval/stm3210c_eval.dts
+++ b/boards/arm/stm3210c_eval/stm3210c_eval.dts
@@ -27,8 +27,6 @@
 
 	gpio_keys {
 		compatible = "gpio-keys";
-		#address-cells = <1>;
-		#size-cells = <0>;
 		user_button: button@0 {
 			label = "User";
 			gpios = <&gpiob 9 GPIO_INT_ACTIVE_LOW>;

--- a/boards/arm/stm32373c_eval/stm32373c_eval.dts
+++ b/boards/arm/stm32373c_eval/stm32373c_eval.dts
@@ -27,8 +27,6 @@
 
 	gpio_keys {
 		compatible = "gpio-keys";
-		#address-cells = <1>;
-		#size-cells = <0>;
 		user_button: button@0 {
 			label = "Key";
 			gpios = <&gpioa 2 GPIO_INT_ACTIVE_LOW>;

--- a/boards/arm/stm32f072_eval/stm32f072_eval.dts
+++ b/boards/arm/stm32f072_eval/stm32f072_eval.dts
@@ -40,8 +40,6 @@
 
 	gpio_keys {
 		compatible = "gpio-keys";
-		#address-cells = <1>;
-		#size-cells = <0>;
 		tamper: tamper@0 {
 			label = "tamper button";
 			gpios = <&gpioc 13 GPIO_INT_ACTIVE_LOW>;

--- a/boards/arm/stm32f072b_disco/stm32f072b_disco.dts
+++ b/boards/arm/stm32f072b_disco/stm32f072b_disco.dts
@@ -39,8 +39,6 @@
 
 	gpio_keys {
 		compatible = "gpio-keys";
-		#address-cells = <1>;
-		#size-cells = <0>;
 		user_button: button@0 {
 			label = "User";
 			gpios = <&gpioa 0 GPIO_INT_ACTIVE_LOW>;

--- a/boards/arm/stm32f0_disco/stm32f0_disco.dts
+++ b/boards/arm/stm32f0_disco/stm32f0_disco.dts
@@ -31,8 +31,6 @@
 
 	gpio_keys {
 		compatible = "gpio-keys";
-		#address-cells = <1>;
-		#size-cells = <0>;
 		user_button: button@0 {
 			label = "Key";
 			gpios = <&gpioa 0 GPIO_INT_ACTIVE_LOW>;

--- a/boards/arm/stm32f3_disco/stm32f3_disco.dts
+++ b/boards/arm/stm32f3_disco/stm32f3_disco.dts
@@ -55,8 +55,6 @@
 
 	gpio_keys {
 		compatible = "gpio-keys";
-		#address-cells = <1>;
-		#size-cells = <0>;
 		user_button: button@0 {
 			label = "User";
 			gpios = <&gpioa 0 GPIO_INT_ACTIVE_LOW>;

--- a/boards/arm/stm32f411e_disco/stm32f411e_disco.dts
+++ b/boards/arm/stm32f411e_disco/stm32f411e_disco.dts
@@ -39,8 +39,6 @@
 
 	gpio_keys {
 		compatible = "gpio-keys";
-		#address-cells = <1>;
-		#size-cells = <0>;
 		user_button: button@0 {
 			label = "User";
 			gpios = <&gpioa 0 GPIO_INT_ACTIVE_LOW>;

--- a/boards/arm/stm32f412g_disco/stm32f412g_disco.dts
+++ b/boards/arm/stm32f412g_disco/stm32f412g_disco.dts
@@ -39,8 +39,6 @@
 
 	gpio_keys {
 		compatible = "gpio-keys";
-		#address-cells = <1>;
-		#size-cells = <0>;
 		joy_sel: joystick@0 {
 			label = "joystick selection";
 			gpios = <&gpioa 0 GPIO_INT_ACTIVE_LOW>;

--- a/boards/arm/stm32f429i_disc1/stm32f429i_disc1.dts
+++ b/boards/arm/stm32f429i_disc1/stm32f429i_disc1.dts
@@ -31,8 +31,6 @@
 
 	gpio_keys {
 		compatible = "gpio-keys";
-		#address-cells = <1>;
-		#size-cells = <0>;
 		user_button: button@0 {
 			label = "User";
 			gpios = <&gpioa 0 GPIO_INT_ACTIVE_LOW>;

--- a/boards/arm/stm32f469i_disco/stm32f469i_disco.dts
+++ b/boards/arm/stm32f469i_disco/stm32f469i_disco.dts
@@ -39,8 +39,6 @@
 
 	gpio_keys {
 		compatible = "gpio-keys";
-		#address-cells = <1>;
-		#size-cells = <0>;
 		user_button: button@0 {
 			label = "User";
 			gpios = <&gpioa 0 GPIO_INT_ACTIVE_LOW>;

--- a/boards/arm/stm32f4_disco/stm32f4_disco.dts
+++ b/boards/arm/stm32f4_disco/stm32f4_disco.dts
@@ -39,8 +39,6 @@
 
 	gpio_keys {
 		compatible = "gpio-keys";
-		#address-cells = <1>;
-		#size-cells = <0>;
 		user_button: button@0 {
 			label = "Key";
 			gpios = <&gpioa 0 GPIO_INT_ACTIVE_LOW>;

--- a/boards/arm/stm32l476g_disco/stm32l476g_disco.dts
+++ b/boards/arm/stm32l476g_disco/stm32l476g_disco.dts
@@ -35,8 +35,6 @@
 
 	gpio_keys {
 		compatible = "gpio-keys";
-		#address-cells = <1>;
-		#size-cells = <0>;
 		joy_center: joystick@0 {
 			label = "joystick center";
 			gpios = <&gpioa 0 GPIO_INT_ACTIVE_LOW>;

--- a/boards/arm/stm32l496g_disco/stm32l496g_disco.dts
+++ b/boards/arm/stm32l496g_disco/stm32l496g_disco.dts
@@ -27,8 +27,6 @@
 
 	gpio_keys {
 		compatible = "gpio-keys";
-		#address-cells = <1>;
-		#size-cells = <0>;
 		joy_sel: joystick@0 {
 			label = "joystick select";
 			gpios = <&gpioc 13 GPIO_INT_ACTIVE_LOW>;

--- a/boards/arm/usb_kw24d512/usb_kw24d512.dts
+++ b/boards/arm/usb_kw24d512/usb_kw24d512.dts
@@ -45,8 +45,6 @@
 
 	gpio_keys {
 		compatible = "gpio-keys";
-		#address-cells = <1>;
-		#size-cells = <0>;
 		user_button_1: button@0 {
 			label = "User SW1";
 			gpios = <&gpioc 4 GPIO_INT_ACTIVE_LOW>;

--- a/dts/arm/st/stm32f0-pinctrl.dtsi
+++ b/dts/arm/st/stm32f0-pinctrl.dtsi
@@ -8,7 +8,7 @@
 
 / {
 	soc {
-		pinctrl: pin-controller {
+		pinctrl: pin-controller@48000000 {
 			usart1_pins_a: usart1@0 {
 				rx_tx {
 					rx = <STM32_PIN_PB7 (STM32_PINMUX_ALT_FUNC_0 | STM32_PUPDR_NO_PULL)>;

--- a/dts/arm/st/stm32f0.dtsi
+++ b/dts/arm/st/stm32f0.dtsi
@@ -56,7 +56,7 @@
 			label = "STM32_CLK_RCC";
 		};
 
-		pinctrl: pin-controller {
+		pinctrl: pin-controller@48000000 {
 			compatible = "st,stm32-pinmux";
 			#address-cells = <1>;
 			#size-cells = <1>;

--- a/dts/arm/st/stm32f0.dtsi
+++ b/dts/arm/st/stm32f0.dtsi
@@ -51,7 +51,7 @@
 		rcc: rcc@40021000 {
 			compatible = "st,stm32-rcc";
 			clocks-controller;
-			#clocks-cells = <2>;
+			#clock-cells = <2>;
 			reg = <0x40021000 0x400>;
 			label = "STM32_CLK_RCC";
 		};

--- a/dts/arm/st/stm32f072.dtsi
+++ b/dts/arm/st/stm32f072.dtsi
@@ -8,7 +8,7 @@
 
 / {
 	soc {
-		pinctrl: pin-controller {
+		pinctrl: pin-controller@48000000 {
 
 			gpioe: gpio@48001000 {
 				compatible = "st,stm32-gpio";

--- a/dts/arm/st/stm32f091.dtsi
+++ b/dts/arm/st/stm32f091.dtsi
@@ -18,7 +18,7 @@
 			label = "SPI_2";
 		};
 
-		pinctrl: pin-controller {
+		pinctrl: pin-controller@48000000 {
 
 			gpioe: gpio@48001000 {
 				compatible = "st,stm32-gpio";

--- a/dts/arm/st/stm32f1-pinctrl.dtsi
+++ b/dts/arm/st/stm32f1-pinctrl.dtsi
@@ -8,7 +8,7 @@
 
 / {
 	soc {
-		pinctrl: pin-controller {
+		pinctrl: pin-controller@40010800 {
 			usart1_pins_a: usart1@0 {
 				rx_tx {
 					rx = <STM32_PIN_PA10 STM32_PIN_USART_RX>;

--- a/dts/arm/st/stm32f1.dtsi
+++ b/dts/arm/st/stm32f1.dtsi
@@ -44,7 +44,7 @@
 			label = "STM32_CLK_RCC";
 		};
 
-		pinctrl: pin-controller {
+		pinctrl: pin-controller@40010800 {
 			compatible = "st,stm32-pinmux";
 			#address-cells = <1>;
 			#size-cells = <1>;

--- a/dts/arm/st/stm32f1.dtsi
+++ b/dts/arm/st/stm32f1.dtsi
@@ -39,7 +39,7 @@
 		rcc: rcc@40021000 {
 			compatible = "st,stm32-rcc";
 			clocks-controller;
-			#clocks-cells = <2>;
+			#clock-cells = <2>;
 			reg = <0x40021000 0x400>;
 			label = "STM32_CLK_RCC";
 		};

--- a/dts/arm/st/stm32f103Xe.dtsi
+++ b/dts/arm/st/stm32f103Xe.dtsi
@@ -20,7 +20,7 @@
 			status = "disabled";
 		};
 
-		pinctrl: pin-controller {
+		pinctrl: pin-controller@40010800 {
 			reg = <0x40010800 0x2000>;
 
 			gpiof: gpio@40011c00 {

--- a/dts/arm/st/stm32f3-pinctrl.dtsi
+++ b/dts/arm/st/stm32f3-pinctrl.dtsi
@@ -8,7 +8,7 @@
 
 / {
 	soc {
-		pinctrl: pin-controller {
+		pinctrl: pin-controller@48000000 {
 			usart1_pins_a: usart1@0 {
 				rx_tx {
 					rx = <STM32_PIN_PB6 (STM32_PINMUX_ALT_FUNC_7 | STM32_PUPDR_NO_PULL)>;

--- a/dts/arm/st/stm32f3.dtsi
+++ b/dts/arm/st/stm32f3.dtsi
@@ -49,7 +49,7 @@
 		rcc: rcc@40021000 {
 			compatible = "st,stm32-rcc";
 			clocks-controller;
-			#clocks-cells = <2>;
+			#clock-cells = <2>;
 			reg = <0x40021000 0x400>;
 			label = "STM32_CLK_RCC";
 		};

--- a/dts/arm/st/stm32f3.dtsi
+++ b/dts/arm/st/stm32f3.dtsi
@@ -54,7 +54,7 @@
 			label = "STM32_CLK_RCC";
 		};
 
-		pinctrl: pin-controller {
+		pinctrl: pin-controller@48000000 {
 			compatible = "st,stm32-pinmux";
 			#address-cells = <1>;
 			#size-cells = <1>;

--- a/dts/arm/st/stm32f303.dtsi
+++ b/dts/arm/st/stm32f303.dtsi
@@ -35,7 +35,7 @@
 			label = "SPI_2";
 		};
 
-		pinctrl: pin-controller {
+		pinctrl: pin-controller@48000000 {
 
 			gpioe: gpio@48001000 {
 				compatible = "st,stm32-gpio";

--- a/dts/arm/st/stm32f4-pinctrl.dtsi
+++ b/dts/arm/st/stm32f4-pinctrl.dtsi
@@ -8,7 +8,7 @@
 
 / {
 	soc {
-		pinctrl: pin-controller {
+		pinctrl: pin-controller@40020000 {
 			usart1_pins_a: usart1@0 {
 				rx_tx {
 					rx = <STM32_PIN_PB7 (STM32_PINMUX_ALT_FUNC_7 | STM32_PUPDR_NO_PULL)>;

--- a/dts/arm/st/stm32f4.dtsi
+++ b/dts/arm/st/stm32f4.dtsi
@@ -51,7 +51,7 @@
 		rcc: rcc@40023800 {
 			compatible = "st,stm32-rcc";
 			clocks-controller;
-			#clocks-cells = <2>;
+			#clock-cells = <2>;
 			reg = <0x40023800 0x400>;
 			label = "STM32_CLK_RCC";
 		};

--- a/dts/arm/st/stm32f4.dtsi
+++ b/dts/arm/st/stm32f4.dtsi
@@ -56,7 +56,7 @@
 			label = "STM32_CLK_RCC";
 		};
 
-		pinctrl: pin-controller {
+		pinctrl: pin-controller@40020000 {
 			compatible = "st,stm32-pinmux";
 			#address-cells = <1>;
 			#size-cells = <1>;

--- a/dts/arm/st/stm32f405-pinctrl.dtsi
+++ b/dts/arm/st/stm32f405-pinctrl.dtsi
@@ -8,7 +8,7 @@
 
 / {
 	soc {
-		pinctrl: pin-controller {
+		pinctrl: pin-controller@40020000 {
 			usart3_pins_a: usart3@0 {
 				rx_tx {
 					rx = <STM32_PIN_PB11 (STM32_PINMUX_ALT_FUNC_7 | STM32_PUSHPULL_PULLUP)>;

--- a/dts/arm/st/stm32f405.dtsi
+++ b/dts/arm/st/stm32f405.dtsi
@@ -14,7 +14,7 @@
 	};
 
 	soc {
-		pinctrl: pin-controller {
+		pinctrl: pin-controller@40020000 {
 			reg = <0x40020000 0x2400>;
 
 			gpiof: gpio@40021400 {

--- a/dts/arm/st/stm32f412-pinctrl.dtsi
+++ b/dts/arm/st/stm32f412-pinctrl.dtsi
@@ -8,7 +8,7 @@
 
 / {
 	soc {
-		pinctrl: pin-controller {
+		pinctrl: pin-controller@40020000 {
 			usart3_pins_a: usart3@0 {
 				rx_tx {
 					rx = <STM32_PIN_PB11 (STM32_PINMUX_ALT_FUNC_7 | STM32_PUSHPULL_PULLUP)>;

--- a/dts/arm/st/stm32f412.dtsi
+++ b/dts/arm/st/stm32f412.dtsi
@@ -9,7 +9,7 @@
 
 / {
 	soc {
-		pinctrl: pin-controller {
+		pinctrl: pin-controller@40020000 {
 			reg = <0x40020000 0x1c00>;
 
 			gpiof: gpio@40021400 {

--- a/dts/arm/st/stm32f413-pinctrl.dtsi
+++ b/dts/arm/st/stm32f413-pinctrl.dtsi
@@ -8,7 +8,7 @@
 
 / {
 	soc {
-		pinctrl: pin-controller {
+		pinctrl: pin-controller@40020000 {
 			usart3_pins_a: usart3@0 {
 				rx_tx {
 					rx = <STM32_PIN_PB11 (STM32_PINMUX_ALT_FUNC_7 | STM32_PUSHPULL_PULLUP)>;

--- a/dts/arm/st/stm32f429.dtsi
+++ b/dts/arm/st/stm32f429.dtsi
@@ -8,7 +8,7 @@
 
 / {
 	soc {
-		pinctrl: pin-controller {
+		pinctrl: pin-controller@40020000 {
 			reg = <0x40020000 0x2C00>;
 
 			gpioj: gpio@40022400 {

--- a/dts/arm/st/stm32l0-pinctrl.dtsi
+++ b/dts/arm/st/stm32l0-pinctrl.dtsi
@@ -8,7 +8,7 @@
 
 / {
 	soc {
-		pinctrl: pin-controller {
+		pinctrl: pin-controller@50000000 {
 			usart1_pins_a: usart1@0 {
 				rx_tx {
 					rx = <STM32_PIN_PB7 (STM32_PINMUX_ALT_FUNC_0 | STM32_PUPDR_NO_PULL)>;

--- a/dts/arm/st/stm32l0.dtsi
+++ b/dts/arm/st/stm32l0.dtsi
@@ -51,7 +51,7 @@
 		rcc: rcc@40021000 {
 			compatible = "st,stm32-rcc";
 			clocks-controller;
-			#clocks-cells = <2>;
+			#clock-cells = <2>;
 			reg = <0x40021000 0x400>;
 			label = "STM32_CLK_RCC";
 		};

--- a/dts/arm/st/stm32l0.dtsi
+++ b/dts/arm/st/stm32l0.dtsi
@@ -56,7 +56,7 @@
 			label = "STM32_CLK_RCC";
 		};
 
-		pinctrl: pin-controller {
+		pinctrl: pin-controller@50000000 {
 			compatible = "st,stm32-pinmux";
 			#address-cells = <1>;
 			#size-cells = <1>;

--- a/dts/arm/st/stm32l072.dtsi
+++ b/dts/arm/st/stm32l072.dtsi
@@ -8,7 +8,7 @@
 
 / {
 	soc {
-		pinctrl: pin-controller {
+		pinctrl: pin-controller@50000000 {
 
 			gpioe: gpio@50001000 {
 				compatible = "st,stm32-gpio";

--- a/dts/arm/st/stm32l4-pinctrl.dtsi
+++ b/dts/arm/st/stm32l4-pinctrl.dtsi
@@ -8,7 +8,7 @@
 
 / {
 	soc {
-		pinctrl: pin-controller {
+		pinctrl: pin-controller@48000000 {
 			usart1_pins_a: usart1@0 {
 				rx_tx {
 					rx = <STM32_PIN_PB7 (STM32_PINMUX_ALT_FUNC_7 | STM32_PUPDR_NO_PULL)>;

--- a/dts/arm/st/stm32l4.dtsi
+++ b/dts/arm/st/stm32l4.dtsi
@@ -57,7 +57,7 @@
 			label = "STM32_CLK_RCC";
 		};
 
-		pinctrl: pin-controller {
+		pinctrl: pin-controller@48000000 {
 			compatible = "st,stm32-pinmux";
 			#address-cells = <1>;
 			#size-cells = <1>;

--- a/dts/arm/st/stm32l4.dtsi
+++ b/dts/arm/st/stm32l4.dtsi
@@ -52,7 +52,7 @@
 		rcc: rcc@40021000 {
 			compatible = "st,stm32-rcc";
 			clocks-controller;
-			#clocks-cells = <2>;
+			#clock-cells = <2>;
 			reg = <0x40021000 0x400>;
 			label = "STM32_CLK_RCC";
 		};

--- a/dts/arm/st/stm32l475.dtsi
+++ b/dts/arm/st/stm32l475.dtsi
@@ -8,7 +8,7 @@
 
 / {
 	soc {
-		pinctrl: pin-controller {
+		pinctrl: pin-controller@48000000 {
 
 			gpiod: gpio@48000c00 {
 				compatible = "st,stm32-gpio";

--- a/dts/arm/st/stm32l496.dtsi
+++ b/dts/arm/st/stm32l496.dtsi
@@ -8,7 +8,7 @@
 
 / {
 	soc {
-		pinctrl: pin-controller {
+		pinctrl: pin-controller@48000000 {
 			reg = <0x48000000 0x2400>;
 
 			gpioi: gpio@480002000 {


### PR DESCRIPTION
Upcoming version v1.4.6 of device tree compiler (dtc) has implemented syntax checks to verify dts file sanity, with warning generated on harmless syntax errors.

Edit: Propose to derogate on one warning, cf #7013 