### PR TITLE
doc: update doc generation instructions

### DIFF
--- a/doc/README.rst
+++ b/doc/README.rst
@@ -48,7 +48,7 @@ Installing the documentation processors
 Our documentation processing has been tested to run with:
 
 * Doxygen version 1.8.13
-* Sphinx version 1.7.0
+* Sphinx version 1.6.7
 * Breathe version 4.7.3
 * docutils version 0.14
 * sphinx_rtd_theme version 0.2.4


### PR DESCRIPTION
Incorrectly stated Sphinx 1.7.0 was supported (it's not); newest working
version is 1.6.7.

Signed-off-by: David B. Kinder <david.b.kinder@intel.com>