### PR TITLE
Revert dts: Add led nodes to nxp boards, refactor mcux gpio driver to use dts

### DIFF
--- a/arch/arm/soc/nxp_kinetis/k6x/soc.h
+++ b/arch/arm/soc/nxp_kinetis/k6x/soc.h
@@ -35,6 +35,11 @@ extern "C" {
 
 #define IRQ_SPI0 26
 #define IRQ_SPI1 27
+#define IRQ_GPIO_PORTA 59
+#define IRQ_GPIO_PORTB 60
+#define IRQ_GPIO_PORTC 61
+#define IRQ_GPIO_PORTD 62
+#define IRQ_GPIO_PORTE 63
 #define IRQ_ETH_IEEE1588_TMR 82
 #define IRQ_ETH_TX 83
 #define IRQ_ETH_RX 84

--- a/arch/arm/soc/nxp_kinetis/kl2x/soc.h
+++ b/arch/arm/soc/nxp_kinetis/kl2x/soc.h
@@ -18,6 +18,8 @@ extern "C" {
 /* IRQs */
 #define IRQ_SPI0		10
 #define IRQ_SPI1                11
+#define IRQ_GPIO_PORTA          30
+#define IRQ_GPIO_PORTD          31
 
 #ifndef _ASMLANGUAGE
 

--- a/arch/arm/soc/nxp_kinetis/kwx/soc.h
+++ b/arch/arm/soc/nxp_kinetis/kwx/soc.h
@@ -22,6 +22,9 @@ extern "C" {
 
 #define IRQ_SPI0 10
 #define IRQ_SPI1 29
+#define IRQ_GPIO_PORTA 30
+#define IRQ_GPIO_PORTB 31
+#define IRQ_GPIO_PORTC 31
 
 #endif
 
@@ -32,6 +35,11 @@ extern "C" {
 /* IRQs */
 #define IRQ_SPI0 26
 #define IRQ_SPI1 27
+#define IRQ_GPIO_PORTA 59
+#define IRQ_GPIO_PORTB 60
+#define IRQ_GPIO_PORTC 61
+#define IRQ_GPIO_PORTD 62
+#define IRQ_GPIO_PORTE 63
 
 #endif
 

--- a/boards/arm/hexiwear_k64/pinmux.c
+++ b/boards/arm/hexiwear_k64/pinmux.c
@@ -56,7 +56,7 @@ static int hexiwear_k64_pinmux_init(struct device *dev)
 	/* 3V3B_EN */
 	pinmux_pin_set(portb, 12, PORT_PCR_MUX(kPORT_MuxAsGpio));
 
-	struct device *gpiob = device_get_binding(GPIO_B_LABEL);
+	struct device *gpiob = device_get_binding(CONFIG_GPIO_MCUX_PORTB_NAME);
 
 	gpio_pin_configure(gpiob, 12, GPIO_DIR_OUT);
 	gpio_pin_write(gpiob, 12, 0);
@@ -91,7 +91,7 @@ static int hexiwear_k64_pinmux_init(struct device *dev)
 	/* LDO - MAX30101 power supply */
 	pinmux_pin_set(porta, 29, PORT_PCR_MUX(kPORT_MuxAsGpio));
 
-	struct device *gpioa = device_get_binding(GPIO_A_LABEL);
+	struct device *gpioa = device_get_binding(CONFIG_GPIO_MCUX_PORTA_NAME);
 
 	gpio_pin_configure(gpioa, 29, GPIO_DIR_OUT);
 	gpio_pin_write(gpioa, 29, 1);
@@ -100,7 +100,7 @@ static int hexiwear_k64_pinmux_init(struct device *dev)
 #ifdef CONFIG_BATTERY_SENSE
 	pinmux_pin_set(portc, 14, PORT_PCR_MUX(kPORT_MuxAsGpio));
 
-	struct device *gpioc = device_get_binding(GPIO_C_LABEL);
+	struct device *gpioc = device_get_binding(CONFIG_GPIO_MCUX_PORTC_NAME);
 
 	gpio_pin_configure(gpioc, 14, GPIO_DIR_OUT);
 	gpio_pin_write(gpioc, 14, 0);

--- a/drivers/gpio/Kconfig.mcux
+++ b/drivers/gpio/Kconfig.mcux
@@ -22,12 +22,32 @@ config GPIO_MCUX_PORTA
 	help
 	  Enable Port A.
 
+config GPIO_MCUX_PORTA_NAME
+	string "Port A driver name"
+	depends on GPIO_MCUX_PORTA
+	default "GPIO_0"
+
+config GPIO_MCUX_PORTA_PRI
+	int "Port A interrupt priority"
+	depends on GPIO_MCUX_PORTA
+	default 2
+
 config GPIO_MCUX_PORTB
 	bool "Port B"
 	depends on PINMUX_MCUX_PORTB
 	default n
 	help
 	  Enable Port B.
+
+config GPIO_MCUX_PORTB_NAME
+	string "Port B driver name"
+	depends on GPIO_MCUX_PORTB
+	default "GPIO_1"
+
+config GPIO_MCUX_PORTB_PRI
+	int "Port B interrupt priority"
+	depends on GPIO_MCUX_PORTB
+	default 2
 
 config GPIO_MCUX_PORTC
 	bool "Port C"
@@ -36,6 +56,16 @@ config GPIO_MCUX_PORTC
 	help
 	  Enable Port C.
 
+config GPIO_MCUX_PORTC_NAME
+	string "Port C driver name"
+	depends on GPIO_MCUX_PORTC
+	default "GPIO_2"
+
+config GPIO_MCUX_PORTC_PRI
+	int "Port C interrupt priority"
+	depends on GPIO_MCUX_PORTC
+	default 2
+
 config GPIO_MCUX_PORTD
 	bool "Port D"
 	depends on PINMUX_MCUX_PORTD
@@ -43,11 +73,31 @@ config GPIO_MCUX_PORTD
 	help
 	  Enable Port D.
 
+config GPIO_MCUX_PORTD_NAME
+	string "Port D driver name"
+	depends on GPIO_MCUX_PORTD
+	default "GPIO_3"
+
+config GPIO_MCUX_PORTD_PRI
+	int "Port D interrupt priority"
+	depends on GPIO_MCUX_PORTD
+	default 2
+
 config GPIO_MCUX_PORTE
 	bool "Port E"
 	depends on PINMUX_MCUX_PORTE
 	default n
 	help
 	  Enable Port E.
+
+config GPIO_MCUX_PORTE_NAME
+	string "Port E driver name"
+	depends on GPIO_MCUX_PORTE
+	default "GPIO_4"
+
+config GPIO_MCUX_PORTE_PRI
+	int "Port E interrupt priority"
+	depends on GPIO_MCUX_PORTE
+	default 2
 
 endif # GPIO_MCUX

--- a/drivers/gpio/gpio_mcux.c
+++ b/drivers/gpio/gpio_mcux.c
@@ -237,9 +237,9 @@ static const struct gpio_driver_api gpio_mcux_driver_api = {
 static int gpio_mcux_porta_init(struct device *dev);
 
 static const struct gpio_mcux_config gpio_mcux_porta_config = {
-	.gpio_base = (GPIO_Type *) GPIO_A_BASE_ADDRESS,
+	.gpio_base = GPIOA,
 	.port_base = PORTA,
-#ifdef GPIO_A_IRQ
+#ifdef IRQ_GPIO_PORTA
 	.flags = GPIO_INT,
 #else
 	.flags = 0,
@@ -248,7 +248,7 @@ static const struct gpio_mcux_config gpio_mcux_porta_config = {
 
 static struct gpio_mcux_data gpio_mcux_porta_data;
 
-DEVICE_AND_API_INIT(gpio_mcux_porta, GPIO_A_LABEL,
+DEVICE_AND_API_INIT(gpio_mcux_porta, CONFIG_GPIO_MCUX_PORTA_NAME,
 		    gpio_mcux_porta_init,
 		    &gpio_mcux_porta_data, &gpio_mcux_porta_config,
 		    POST_KERNEL, CONFIG_KERNEL_INIT_PRIORITY_DEFAULT,
@@ -256,11 +256,11 @@ DEVICE_AND_API_INIT(gpio_mcux_porta, GPIO_A_LABEL,
 
 static int gpio_mcux_porta_init(struct device *dev)
 {
-#ifdef GPIO_A_IRQ
-	IRQ_CONNECT(GPIO_A_IRQ, GPIO_A_IRQ_PRIORITY,
+#ifdef IRQ_GPIO_PORTA
+	IRQ_CONNECT(IRQ_GPIO_PORTA, CONFIG_GPIO_MCUX_PORTA_PRI,
 		    gpio_mcux_port_isr, DEVICE_GET(gpio_mcux_porta), 0);
 
-	irq_enable(GPIO_A_IRQ);
+	irq_enable(IRQ_GPIO_PORTA);
 
 	return 0;
 #else
@@ -273,9 +273,9 @@ static int gpio_mcux_porta_init(struct device *dev)
 static int gpio_mcux_portb_init(struct device *dev);
 
 static const struct gpio_mcux_config gpio_mcux_portb_config = {
-	.gpio_base = (GPIO_Type *) GPIO_B_BASE_ADDRESS,
+	.gpio_base = GPIOB,
 	.port_base = PORTB,
-#ifdef GPIO_B_IRQ
+#ifdef IRQ_GPIO_PORTB
 	.flags = GPIO_INT,
 #else
 	.flags = 0,
@@ -284,7 +284,7 @@ static const struct gpio_mcux_config gpio_mcux_portb_config = {
 
 static struct gpio_mcux_data gpio_mcux_portb_data;
 
-DEVICE_AND_API_INIT(gpio_mcux_portb, GPIO_B_LABEL,
+DEVICE_AND_API_INIT(gpio_mcux_portb, CONFIG_GPIO_MCUX_PORTB_NAME,
 		    gpio_mcux_portb_init,
 		    &gpio_mcux_portb_data, &gpio_mcux_portb_config,
 		    POST_KERNEL, CONFIG_KERNEL_INIT_PRIORITY_DEFAULT,
@@ -292,11 +292,11 @@ DEVICE_AND_API_INIT(gpio_mcux_portb, GPIO_B_LABEL,
 
 static int gpio_mcux_portb_init(struct device *dev)
 {
-#ifdef GPIO_B_IRQ
-	IRQ_CONNECT(GPIO_B_IRQ, GPIO_B_IRQ_PRIORITY,
+#ifdef IRQ_GPIO_PORTB
+	IRQ_CONNECT(IRQ_GPIO_PORTB, CONFIG_GPIO_MCUX_PORTB_PRI,
 		    gpio_mcux_port_isr, DEVICE_GET(gpio_mcux_portb), 0);
 
-	irq_enable(GPIO_B_IRQ);
+	irq_enable(IRQ_GPIO_PORTB);
 
 	return 0;
 #else
@@ -309,9 +309,9 @@ static int gpio_mcux_portb_init(struct device *dev)
 static int gpio_mcux_portc_init(struct device *dev);
 
 static const struct gpio_mcux_config gpio_mcux_portc_config = {
-	.gpio_base = (GPIO_Type *) GPIO_C_BASE_ADDRESS,
+	.gpio_base = GPIOC,
 	.port_base = PORTC,
-#ifdef GPIO_C_IRQ
+#ifdef IRQ_GPIO_PORTC
 	.flags = GPIO_INT,
 #else
 	.flags = 0,
@@ -320,7 +320,7 @@ static const struct gpio_mcux_config gpio_mcux_portc_config = {
 
 static struct gpio_mcux_data gpio_mcux_portc_data;
 
-DEVICE_AND_API_INIT(gpio_mcux_portc, GPIO_C_LABEL,
+DEVICE_AND_API_INIT(gpio_mcux_portc, CONFIG_GPIO_MCUX_PORTC_NAME,
 		    gpio_mcux_portc_init,
 		    &gpio_mcux_portc_data, &gpio_mcux_portc_config,
 		    POST_KERNEL, CONFIG_KERNEL_INIT_PRIORITY_DEFAULT,
@@ -328,11 +328,11 @@ DEVICE_AND_API_INIT(gpio_mcux_portc, GPIO_C_LABEL,
 
 static int gpio_mcux_portc_init(struct device *dev)
 {
-#ifdef GPIO_C_IRQ
-	IRQ_CONNECT(GPIO_C_IRQ, GPIO_C_IRQ_PRIORITY,
+#ifdef IRQ_GPIO_PORTC
+	IRQ_CONNECT(IRQ_GPIO_PORTC, CONFIG_GPIO_MCUX_PORTC_PRI,
 		    gpio_mcux_port_isr, DEVICE_GET(gpio_mcux_portc), 0);
 
-	irq_enable(GPIO_C_IRQ);
+	irq_enable(IRQ_GPIO_PORTC);
 
 	return 0;
 #else
@@ -345,9 +345,9 @@ static int gpio_mcux_portc_init(struct device *dev)
 static int gpio_mcux_portd_init(struct device *dev);
 
 static const struct gpio_mcux_config gpio_mcux_portd_config = {
-	.gpio_base = (GPIO_Type *) GPIO_D_BASE_ADDRESS,
+	.gpio_base = GPIOD,
 	.port_base = PORTD,
-#ifdef GPIO_D_IRQ
+#ifdef IRQ_GPIO_PORTD
 	.flags = GPIO_INT,
 #else
 	.flags = 0,
@@ -356,7 +356,7 @@ static const struct gpio_mcux_config gpio_mcux_portd_config = {
 
 static struct gpio_mcux_data gpio_mcux_portd_data;
 
-DEVICE_AND_API_INIT(gpio_mcux_portd, GPIO_D_LABEL,
+DEVICE_AND_API_INIT(gpio_mcux_portd, CONFIG_GPIO_MCUX_PORTD_NAME,
 		    gpio_mcux_portd_init,
 		    &gpio_mcux_portd_data, &gpio_mcux_portd_config,
 		    POST_KERNEL, CONFIG_KERNEL_INIT_PRIORITY_DEFAULT,
@@ -364,11 +364,11 @@ DEVICE_AND_API_INIT(gpio_mcux_portd, GPIO_D_LABEL,
 
 static int gpio_mcux_portd_init(struct device *dev)
 {
-#ifdef GPIO_D_IRQ
-	IRQ_CONNECT(GPIO_D_IRQ, GPIO_D_IRQ_PRIORITY,
+#ifdef IRQ_GPIO_PORTD
+	IRQ_CONNECT(IRQ_GPIO_PORTD, CONFIG_GPIO_MCUX_PORTD_PRI,
 		    gpio_mcux_port_isr, DEVICE_GET(gpio_mcux_portd), 0);
 
-	irq_enable(GPIO_D_IRQ);
+	irq_enable(IRQ_GPIO_PORTD);
 
 	return 0;
 #else
@@ -381,9 +381,9 @@ static int gpio_mcux_portd_init(struct device *dev)
 static int gpio_mcux_porte_init(struct device *dev);
 
 static const struct gpio_mcux_config gpio_mcux_porte_config = {
-	.gpio_base = (GPIO_Type *) GPIO_E_BASE_ADDRESS,
+	.gpio_base = GPIOE,
 	.port_base = PORTE,
-#ifdef GPIO_E_IRQ
+#ifdef IRQ_GPIO_PORTE
 	.flags = GPIO_INT,
 #else
 	.flags = 0,
@@ -392,7 +392,7 @@ static const struct gpio_mcux_config gpio_mcux_porte_config = {
 
 static struct gpio_mcux_data gpio_mcux_porte_data;
 
-DEVICE_AND_API_INIT(gpio_mcux_porte, GPIO_E_LABEL,
+DEVICE_AND_API_INIT(gpio_mcux_porte, CONFIG_GPIO_MCUX_PORTE_NAME,
 		    gpio_mcux_porte_init,
 		    &gpio_mcux_porte_data, &gpio_mcux_porte_config,
 		    POST_KERNEL, CONFIG_KERNEL_INIT_PRIORITY_DEFAULT,
@@ -400,11 +400,11 @@ DEVICE_AND_API_INIT(gpio_mcux_porte, GPIO_E_LABEL,
 
 static int gpio_mcux_porte_init(struct device *dev)
 {
-#ifdef GPIO_E_IRQ
-	IRQ_CONNECT(GPIO_E_IRQ, GPIO_E_IRQ_PRIORITY,
+#ifdef IRQ_GPIO_PORTE
+	IRQ_CONNECT(IRQ_GPIO_PORTE, CONFIG_GPIO_MCUX_PORTE_PRI,
 		    gpio_mcux_port_isr, DEVICE_GET(gpio_mcux_porte), 0);
 
-	irq_enable(GPIO_E_IRQ);
+	irq_enable(IRQ_GPIO_PORTE);
 
 	return 0;
 #else

--- a/samples/net/common/cc2520_frdm_k64f.c
+++ b/samples/net/common/cc2520_frdm_k64f.c
@@ -16,7 +16,7 @@
 #include <ieee802154/cc2520.h>
 #include <gpio.h>
 
-#define CC2520_GPIO_DEV_NAME GPIO_C_LABEL
+#define CC2520_GPIO_DEV_NAME CONFIG_GPIO_MCUX_PORTC_NAME
 
 #define CC2520_GPIO_VREG_EN	12  /* PTC12 */
 #define CC2520_GPIO_RESET	3   /* PTC3 */


### PR DESCRIPTION
Reverts #7129. Fixes #7172 