### PR TITLE
cmake: Fix printed list of supported boards.

### DIFF
--- a/cmake/extensions.cmake
+++ b/cmake/extensions.cmake
@@ -996,7 +996,9 @@ macro(assert_with_usage test comment)
     message("see usage:")
     execute_process(
       COMMAND
-      ${CMAKE_COMMAND} -P ${ZEPHYR_BASE}/cmake/usage/usage.cmake
+      ${CMAKE_COMMAND}
+      -DBOARD_ROOT=${BOARD_ROOT}
+      -P ${ZEPHYR_BASE}/cmake/usage/usage.cmake
       )
     message(FATAL_ERROR "Invalid usage")
   endif()

--- a/cmake/usage/CMakeLists.txt
+++ b/cmake/usage/CMakeLists.txt
@@ -1,6 +1,8 @@
 add_custom_target(
   usage
-  ${CMAKE_COMMAND} -P ${CMAKE_CURRENT_SOURCE_DIR}/usage.cmake
+  ${CMAKE_COMMAND}
+  -DBOARD_ROOT=${BOARD_ROOT}
+  -P ${CMAKE_CURRENT_SOURCE_DIR}/usage.cmake
   )
 
 add_custom_target(

--- a/cmake/usage/usage.cmake
+++ b/cmake/usage/usage.cmake
@@ -12,7 +12,7 @@ set(arch_list
   xtensa
   )
 
-set(board_dir $ENV{ZEPHYR_BASE}/boards)
+set(board_dir ${BOARD_ROOT}/boards)
 
 foreach(arch ${arch_list})
   set(board_arch_dir ${board_dir}/${arch})


### PR DESCRIPTION
This fixes #7184.

Use $BOARD_ROOT to find correct list of supported boards.
This is needed since the user can set this variable to any directory.
Pass $BOARD_ROOT to usage.cmake where it is called.

Signed-off-by: Håkon Øye Amundsen <haakon.amundsen@nordicsemi.no>