### PR TITLE
samples: flash_shell: Use correct flash write block size

### DIFF
--- a/samples/drivers/flash_shell/src/main.c
+++ b/samples/drivers/flash_shell/src/main.c
@@ -236,11 +236,7 @@ static int flash_shell_write_block_size(int argc, char *argv[])
 		return 0;
 	}
 
-#if defined FLASH_WRITE_BLOCK_SIZE
-	printk("%d\n", FLASH_WRITE_BLOCK_SIZE);
-#else
-	printk("Flash write block size is unknown.\n");
-#endif
+	printk("%d\n", flash_get_write_block_size(flash_device));
 	return 0;
 }
 


### PR DESCRIPTION
Change the flash_shell sample from using FLASH_WRITE_BLOCK_SIZE
definition to using the flash_get_write_block_size() api for the
selected flash_device.

This fixes the flash_shell sample when using multiple flash devices
with different write block sizes.

Signed-off-by: Henrik Brix Andersen <henrik@brixandersen.dk>