### PR TITLE
gpio: dts: Introduce Kconfig symbols to convey GPIO dts support

### DIFF
--- a/drivers/gpio/Kconfig.mcux
+++ b/drivers/gpio/Kconfig.mcux
@@ -9,6 +9,7 @@
 menuconfig GPIO_MCUX
 	bool "MCUX GPIO driver"
 	depends on GPIO && HAS_MCUX
+	select HAS_DTS_GPIO
 	default n
 	help
 	  Enable the MCUX pinmux driver.

--- a/drivers/gpio/Kconfig.stm32
+++ b/drivers/gpio/Kconfig.stm32
@@ -8,6 +8,7 @@
 menuconfig GPIO_STM32
 	bool "GPIO Driver for STM32 family of MCUs"
 	depends on GPIO && SOC_FAMILY_STM32
+	select HAS_DTS_GPIO
 	default n
 	help
 	  Enable GPIO driver for STM32 line of MCUs

--- a/dts/Kconfig
+++ b/dts/Kconfig
@@ -11,6 +11,22 @@ config HAS_DTS_ADC
 	  This option specifies that the target platform supports device tree
 	  configuration for ADC.
 
+config HAS_DTS_GPIO
+	bool
+	default n
+	depends on HAS_DTS
+	help
+	  This option specifies that the target platform supports device tree
+	  configuration for GPIO.
+
+config HAS_DTS_GPIO_DEVICE
+	bool
+	default n
+	depends on HAS_DTS_GPIO
+	help
+	  This option specifies that the target platform supports device tree
+	  configuration for GPIO on the driver/consumer side.
+
 config HAS_DTS_I2C
 	bool
 	default n


### PR DESCRIPTION
Add a set of Kconfig symbols that allow us to set that the GPIO
driver/SoC support DTS (HAS_DTS_GPIO) and that drivers that need/use GPIO
support DTS as well (HAS_DTS_GPIO_DEVICE).

Signed-off-by: Kumar Gala <kumar.gala@linaro.org>