### PR TITLE
dts: dtc v1.4.6 warnings: Fix warnings for leading 0s

### DIFF
--- a/dts/arm/nxp/nxp_imx7d_m4.dtsi
+++ b/dts/arm/nxp/nxp_imx7d_m4.dtsi
@@ -46,7 +46,7 @@
 			label = "TCMU SYSTEM";
 		};
 
-		ocram_code: code@00900000 {
+		ocram_code: code@900000 {
 			compatible = "nxp,imx-code-bus";
 			reg = <0x00900000 0x20000>;
 			label = "OCRAM CODE";
@@ -65,7 +65,7 @@
 			label = "OCRAM_S CODE";
 		};
 
-		ocram_s_sys: memory@00180000 {
+		ocram_s_sys: memory@180000 {
 			device_type = "memory";
 			compatible = "nxp,imx-sys-bus";
 			reg = <0x00180000 0x8000>;

--- a/dts/x86/atom.dtsi
+++ b/dts/x86/atom.dtsi
@@ -22,11 +22,11 @@
 		};
 	};
 
-	flash0: flash@00100000{
+	flash0: flash@100000{
 		reg = <0x00100000 DT_FLASH_SIZE>;
 	};
 
-	sram0: memory@00400000 {
+	sram0: memory@400000 {
 		device_type = "memory";
 		compatible = "mmio-sram";
 		reg = <0x00400000 DT_SRAM_SIZE>;

--- a/dts/x86/ia32.dtsi
+++ b/dts/x86/ia32.dtsi
@@ -24,11 +24,11 @@
 	};
 
 
-	flash0: flash@00001000 {
+	flash0: flash@1000 {
 		reg = <0x00001000 DT_FLASH_SIZE>;
 	};
 
-	sram0: memory@00400000 {
+	sram0: memory@400000 {
 		device_type = "memory";
 		compatible = "mmio-sram";
 		reg = <0x00400000 DT_SRAM_SIZE>;

--- a/dts/x86/intel_quark_d2000.dtsi
+++ b/dts/x86/intel_quark_d2000.dtsi
@@ -22,11 +22,11 @@
 		};
 	};
 
-	flash0: flash@00180000 {
+	flash0: flash@180000 {
 		reg = <0x00180000 DT_FLASH_SIZE>;
 	};
 
-	sram0: memory@00280000 {
+	sram0: memory@280000 {
 		device_type = "memory";
 		compatible = "mmio-sram";
 		reg = <0x00280000 DT_SRAM_SIZE>;

--- a/dts/x86/quark_x1000.dtsi
+++ b/dts/x86/quark_x1000.dtsi
@@ -23,11 +23,11 @@
 		};
 	};
 
-	flash0: flash@00100000{
+	flash0: flash@100000{
 		reg = <0x00100000 DT_FLASH_SIZE>;
 	};
 
-	sram0: memory@00400000 {
+	sram0: memory@400000 {
 		device_type = "memory";
 		compatible = "mmio-sram";
 		reg = <0x00400000 DT_SRAM_SIZE>;


### PR DESCRIPTION
Fixes the following warnings:
Node unit name should not have leading 0s

Fixes #7155

Signed-off-by: Yannis Damigos <giannis.damigos@gmail.com>