### PR TITLE
net: tcp: send_syn_segment: Log packet before it's sent

### DIFF
--- a/subsys/net/ip/tcp.c
+++ b/subsys/net/ip/tcp.c
@@ -1845,6 +1845,8 @@ static inline int send_syn_segment(struct net_context *context,
 		return ret;
 	}
 
+	print_send_info(pkt, msg);
+
 	ret = net_send_data(pkt);
 	if (ret < 0) {
 		net_pkt_unref(pkt);
@@ -1852,8 +1854,6 @@ static inline int send_syn_segment(struct net_context *context,
 	}
 
 	context->tcp->send_seq++;
-
-	print_send_info(pkt, msg);
 
 	return ret;
 }


### PR DESCRIPTION
After successful send, the packet is automatically cleared, so
trying to call print_send_info() on it leads to errors:

[net/pkt] [ERR] net_pkt_tcp_data: NULL fragment data!
[net/tcp] [ERR] net_tcp_get_hdr: NULL TCP header!

(if error logging enabled).

This change is similar to how print_send_info() is called in
existing send_reset() function of this source file.

Signed-off-by: Paul Sokolovsky <paul.sokolovsky@linaro.org>