### PR TITLE
subsys: settings: Fix Kconfig dependencies

### DIFF
--- a/subsys/settings/Kconfig
+++ b/subsys/settings/Kconfig
@@ -8,7 +8,9 @@ menuconfig SETTINGS
 	bool
 	default n
 	prompt "Enable settings subsystem with non-volatile storage"
-	depends on FILE_SYSTEM || FCB
+	# Only NFFS is currently supported as FS.
+	# The reason in that FatFs doesn't implement the fs_rename() API
+	depends on (FILE_SYSTEM && FILE_SYSTEM_NFFS) || (FCB && FLASH_PAGE_LAYOUT)
 	select BASE64
 	help
 	  The settings subsystem allows its users to serialize and


### PR DESCRIPTION
If CONFIG_FLASH_PAGE_LAYOUT is not enabled, building the settings code
fails at the linking stage with the following error when FCB is the
backend.

```
libzephyr.a(settings_init.c.obj): In function `settings_init_fcb':
subsys/settings/src/settings_init.c:62: undefined reference to `flash_area_get_sectors'
collect2: error: ld returned 1 exit status
```

Also, the File System backend will currently only work with NFFS due
to fs_rename() missing from other File Systems (FAT in particular).

Signed-off-by: Johan Hedberg <johan.hedberg@intel.com>