### PR TITLE
fs: Convert NFFS partition to a generic one

### DIFF
--- a/boards/arm/adafruit_feather_m0_basic_proto/adafruit_feather_m0_basic_proto.dts
+++ b/boards/arm/adafruit_feather_m0_basic_proto/adafruit_feather_m0_basic_proto.dts
@@ -56,9 +56,9 @@
 		 * and is used by NFFS if enabled.
 		 */
 
-#if defined(CONFIG_FILE_SYSTEM_NFFS)
-		nffs_partition: partition@3c000 {
-			label = "nffs";
+#if defined(CONFIG_FS_FLASH_MAP_STORAGE)
+		storage_partition: partition@3c000 {
+			label = "storage";
 			reg = <0x0003c000 0x00004000>;
 		};
 #endif

--- a/boards/arm/adafruit_trinket_m0/adafruit_trinket_m0.dts
+++ b/boards/arm/adafruit_trinket_m0/adafruit_trinket_m0.dts
@@ -69,9 +69,9 @@
 		 * and is used by NFFS if enabled.
 		 */
 
-#if defined(CONFIG_FILE_SYSTEM_NFFS)
-		nffs_partition: partition@3c000 {
-			label = "nffs";
+#if defined(CONFIG_FS_FLASH_MAP_STORAGE)
+		storage_partition: partition@3c000 {
+			label = "storage";
 			reg = <0x0003c000 0x00004000>;
 		};
 #endif

--- a/boards/arm/arduino_zero/arduino_zero.dts
+++ b/boards/arm/arduino_zero/arduino_zero.dts
@@ -46,9 +46,9 @@
 		 * and is used by NFFS if enabled.
 		 */
 
-#if defined(CONFIG_FILE_SYSTEM_NFFS)
-		nffs_partition: partition@3c000 {
-			label = "nffs";
+#if defined(CONFIG_FS_FLASH_MAP_STORAGE)
+		storage_partition: partition@3c000 {
+			label = "storage";
 			reg = <0x0003c000 0x00004000>;
 		};
 #endif

--- a/boards/arm/nrf51_pca10028/nrf51_pca10028.dts
+++ b/boards/arm/nrf51_pca10028/nrf51_pca10028.dts
@@ -59,9 +59,9 @@
 			reg = <0x0003c000 0x2000>;
 		};
 
-#if defined(CONFIG_FILE_SYSTEM_NFFS)
-		nffs_partition: partition@3e000 {
-			label = "nffs";
+#if defined(CONFIG_FS_FLASH_MAP_STORAGE)
+		storage_partition: partition@3e000 {
+			label = "storage";
 			reg = <0x0003e000 0x00002000>;
 		};
 #endif

--- a/boards/arm/nrf52840_pca10056/nrf52840_pca10056.dts
+++ b/boards/arm/nrf52840_pca10056/nrf52840_pca10056.dts
@@ -60,9 +60,9 @@
 			reg = <0x000de000 0x0001e000>;
 		};
 
-#if defined(CONFIG_FILE_SYSTEM_NFFS)
-		nffs_partition: partition@fc000 {
-			label = "nffs";
+#if defined(CONFIG_FS_FLASH_MAP_STORAGE)
+		storage_partition: partition@fc000 {
+			label = "storage";
 			reg = <0x000fc000 0x00004000>;
 		};
 #endif

--- a/boards/arm/nrf52_pca10040/nrf52_pca10040.dts
+++ b/boards/arm/nrf52_pca10040/nrf52_pca10040.dts
@@ -60,9 +60,9 @@
 			reg = <0x00070000 0xa000>;
 		};
 
-#if defined(CONFIG_FILE_SYSTEM_NFFS)
-		nffs_partition: partition@7a000 {
-			label = "nffs";
+#if defined(CONFIG_FS_FLASH_MAP_STORAGE)
+		storage_partition: partition@7a000 {
+			label = "storage";
 			reg = <0x0007a000 0x00006000>;
 		};
 #endif

--- a/boards/arm/nrf52_pca20020/nrf52_pca20020.dts
+++ b/boards/arm/nrf52_pca20020/nrf52_pca20020.dts
@@ -100,9 +100,9 @@
 		 * will be created in this area.
 		 */
 
-#if defined(CONFIG_FILE_SYSTEM_NFFS)
-		nffs_partition: partition@7a000 {
-			label = "nffs";
+#if defined(CONFIG_FS_FLASH_MAP_STORAGE)
+		storage_partition: partition@7a000 {
+			label = "storage";
 			reg = <0x0007a000 0x00006000>;
 		};
 #endif

--- a/boards/arm/nrf52_sparkfun/nrf52_sparkfun.dts
+++ b/boards/arm/nrf52_sparkfun/nrf52_sparkfun.dts
@@ -53,9 +53,9 @@
 			reg = <0x00070000 0xa000>;
 		};
 
-#if defined(CONFIG_FILE_SYSTEM_NFFS)
-		nffs_partition: partition@7a000 {
-			label = "nffs";
+#if defined(CONFIG_FS_FLASH_MAP_STORAGE)
+		storage_partition: partition@7a000 {
+			label = "storage";
 			reg = <0x0007a000 0x00006000>;
 		};
 #endif

--- a/doc/devices/dts/flash_partitions.rst
+++ b/doc/devices/dts/flash_partitions.rst
@@ -224,8 +224,8 @@ See the  `MCUboot documentation`_ for more details on these partitions.
 .. _MCUboot documentation:
    https://github.com/runtimeco/mcuboot/blob/master/docs/design.md#image-slots
 
-NFFS Partitions
-***************
+File System Partitions
+**********************
 
-**nffs_partition**
-  This is the area where NFFS expects its partition.
+**storage_partition**
+  This is the area where e.g. NFFS expects its partition.

--- a/samples/application_development/out_of_tree_board/boards/arm/nrf52840_pca10056/nrf52840_pca10056.dts
+++ b/samples/application_development/out_of_tree_board/boards/arm/nrf52840_pca10056/nrf52840_pca10056.dts
@@ -52,9 +52,9 @@
 			reg = <0x000de000 0x0001e000>;
 		};
 
-#if defined(CONFIG_FILE_SYSTEM_NFFS)
-		nffs_partition: partition@fc000 {
-			label = "nffs";
+#if defined(CONFIG_FS_FLASH_MAP_STORAGE)
+		storage_partition: partition@fc000 {
+			label = "storage";
 			reg = <0x000fc000 0x00004000>;
 		};
 #endif

--- a/subsys/fs/Kconfig
+++ b/subsys/fs/Kconfig
@@ -4,6 +4,12 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 
+# Hidden. Automatically selected by file systems or FCB that need it
+config FS_FLASH_MAP_STORAGE
+	bool
+	depends on FLASH_MAP
+	default n
+
 menu "File Systems"
 
 config FILE_SYSTEM
@@ -37,6 +43,7 @@ config FAT_FILESYSTEM_ELM
 config FILE_SYSTEM_NFFS
 	bool "NFFS file system support"
 	select FLASH_PAGE_LAYOUT
+	select FS_FLASH_MAP_STORAGE
 	help
 	  Enables NFFS file system support.
 	  Note: NFFS requires 1-byte unaligned access to flash thus it

--- a/subsys/fs/fcb/Kconfig
+++ b/subsys/fs/fcb/Kconfig
@@ -14,5 +14,6 @@ config FCB
 	prompt "Flash Circular Buffer support"
 	default n
 	depends on FLASH_MAP
+	select FS_FLASH_MAP_STORAGE
 	help
 	  Enable support of Flash Circular Buffer.

--- a/subsys/fs/nffs_fs.c
+++ b/subsys/fs/nffs_fs.c
@@ -528,8 +528,8 @@ static int nffs_mount(struct fs_mount_t *mountp)
 	/* Set flash descriptor fields */
 	flash_desc->id = 0;
 	flash_desc->sector_count = flash_get_page_count(flash_dev);
-	flash_desc->area_offset = FLASH_AREA_NFFS_OFFSET;
-	flash_desc->area_size = FLASH_AREA_NFFS_SIZE;
+	flash_desc->area_offset = FLASH_AREA_STORAGE_OFFSET;
+	flash_desc->area_size = FLASH_AREA_STORAGE_SIZE;
 
 	rc = nffs_misc_reset();
 	if (rc) {

--- a/subsys/storage/flash_map/flash_map_default.c
+++ b/subsys/storage/flash_map/flash_map_default.c
@@ -41,13 +41,13 @@ const struct flash_area default_flash_map[] = {
 		.fa_size = FLASH_AREA_IMAGE_SCRATCH_SIZE,
 	},
 
-#ifdef CONFIG_FILE_SYSTEM_NFFS
-	/* FLASH_AREA_NFFS_ */
+#ifdef CONFIG_FS_FLASH_MAP_STORAGE
+	/* FLASH_AREA_STORAGE */
 	{
 		.fa_id = 4,
 		.fa_device_id = SOC_FLASH_0_ID,
-		.fa_off = FLASH_AREA_NFFS_OFFSET,
-		.fa_size = FLASH_AREA_NFFS_SIZE,
+		.fa_off = FLASH_AREA_STORAGE_OFFSET,
+		.fa_size = FLASH_AREA_STORAGE_SIZE,
 	},
 #endif
 };

--- a/tests/subsys/fs/multi-fs/CMakeLists.txt
+++ b/tests/subsys/fs/multi-fs/CMakeLists.txt
@@ -3,8 +3,8 @@ project(NONE)
 
 zephyr_compile_definitions(
   -DTEST_FLASH_OFFSET=0
-  -DFLASH_AREA_NFFS_OFFSET=0
-  -DFLASH_AREA_NFFS_SIZE=1048576
+  -DFLASH_AREA_STORAGE_OFFSET=0
+  -DFLASH_AREA_STORAGE_SIZE=1048576
 )
 
 target_link_libraries(app ELMFAT)

--- a/tests/subsys/fs/multi-fs/src/test_ram_backend.c
+++ b/tests/subsys/fs/multi-fs/src/test_ram_backend.c
@@ -11,7 +11,7 @@
 #include <zephyr/types.h>
 #include <ztest_assert.h>
 
-static u8_t rambuf[FLASH_AREA_NFFS_SIZE];
+static u8_t rambuf[FLASH_AREA_STORAGE_SIZE];
 
 static int test_ram_flash_init(struct device *dev)
 {
@@ -29,7 +29,7 @@ static int test_flash_ram_erase(struct device *dev, off_t offset, size_t len)
 	off_t end_offset = offset + len;
 
 	zassert_true(offset >= 0, "invalid offset");
-	zassert_true(offset + len <= FLASH_AREA_NFFS_SIZE,
+	zassert_true(offset + len <= FLASH_AREA_STORAGE_SIZE,
 		     "flash address out of bounds");
 
 	while (offset < end_offset) {
@@ -45,7 +45,7 @@ static int test_flash_ram_write(struct device *dev, off_t offset,
 						const void *data, size_t len)
 {
 	zassert_true(offset >= 0, "invalid offset");
-	zassert_true(offset + len <= FLASH_AREA_NFFS_SIZE,
+	zassert_true(offset + len <= FLASH_AREA_STORAGE_SIZE,
 		     "flash address out of bounds");
 
 	memcpy(rambuf + offset, data, len);
@@ -57,7 +57,7 @@ static int test_flash_ram_read(struct device *dev, off_t offset, void *data,
 								size_t len)
 {
 	zassert_true(offset >= 0, "invalid offset");
-	zassert_true(offset + len <= FLASH_AREA_NFFS_SIZE,
+	zassert_true(offset + len <= FLASH_AREA_STORAGE_SIZE,
 		     "flash address out of bounds");
 
 	memcpy(data, rambuf + offset, len);

--- a/tests/subsys/fs/nffs_fs_api/CMakeLists.txt
+++ b/tests/subsys/fs/nffs_fs_api/CMakeLists.txt
@@ -12,8 +12,8 @@ project(NONE)
 if(BOARD STREQUAL qemu_x86)
     zephyr_compile_definitions(
         -DTEST_FLASH_OFFSET=0
-        -DFLASH_AREA_NFFS_OFFSET=0
-        -DFLASH_AREA_NFFS_SIZE=1048576
+	-DFLASH_AREA_STORAGE_OFFSET=0
+	-DFLASH_AREA_STORAGE_SIZE=1048576
     )
 elseif(BOARD STREQUAL nrf51_pca10028)
     zephyr_compile_definitions(

--- a/tests/subsys/fs/nffs_fs_api/src/test_ram_backend.c
+++ b/tests/subsys/fs/nffs_fs_api/src/test_ram_backend.c
@@ -11,7 +11,7 @@
 #include <zephyr/types.h>
 #include <ztest_assert.h>
 
-static u8_t rambuf[FLASH_AREA_NFFS_SIZE];
+static u8_t rambuf[FLASH_AREA_STORAGE_SIZE];
 
 static int test_ram_flash_init(struct device *dev)
 {
@@ -29,7 +29,7 @@ static int test_flash_ram_erase(struct device *dev, off_t offset, size_t len)
 	off_t end_offset = offset + len;
 
 	zassert_true(offset >= 0, "invalid offset");
-	zassert_true(offset + len <= FLASH_AREA_NFFS_SIZE,
+	zassert_true(offset + len <= FLASH_AREA_STORAGE_SIZE,
 		     "flash address out of bounds");
 
 	while (offset < end_offset) {
@@ -45,7 +45,7 @@ static int test_flash_ram_write(struct device *dev, off_t offset,
 						const void *data, size_t len)
 {
 	zassert_true(offset >= 0, "invalid offset");
-	zassert_true(offset + len <= FLASH_AREA_NFFS_SIZE,
+	zassert_true(offset + len <= FLASH_AREA_STORAGE_SIZE,
 		     "flash address out of bounds");
 
 	memcpy(rambuf + offset, data, len);
@@ -57,7 +57,7 @@ static int test_flash_ram_read(struct device *dev, off_t offset, void *data,
 								size_t len)
 {
 	zassert_true(offset >= 0, "invalid offset");
-	zassert_true(offset + len <= FLASH_AREA_NFFS_SIZE,
+	zassert_true(offset + len <= FLASH_AREA_STORAGE_SIZE,
 		     "flash address out of bounds");
 
 	memcpy(data, rambuf + offset, len);


### PR DESCRIPTION
The NFFS partition at the end of flash is also useful for any other
file system or even the Flash Circular Buffer (FCB). Rename the
partition from 'nffs_partition' to 'storage_partition' and make it
depend on a new hidden Kconfig entry which the relevant users will
select (such as NFFS and FCB).

Signed-off-by: Johan Hedberg <johan.hedberg@intel.com>