### PR TITLE
doc: Document Zephyr's Kconfig configuration scheme

### DIFF
--- a/doc/application/application.rst
+++ b/doc/application/application.rst
@@ -880,6 +880,9 @@ As long as :file:`zephyr/.config` exists and is up-to-date (is newer than the
 preference to producing a new merged configuration. This can be used during
 development, as described below in :ref:`override_kernel_conf`.
 
+For more information on Zephyr's Kconfig configuration scheme, see the
+:ref:`setting_configuration_values` section in the :ref:`board_porting_guide`.
+
 For information on available kernel configuration options, including
 inter-dependencies between options, see the :ref:`configuration`.
 

--- a/doc/porting/arch.rst
+++ b/doc/porting/arch.rst
@@ -14,6 +14,10 @@ The following are examples of ISAs and ABIs that Zephyr supports:
 * ARMv7-M ISA with Thumb2 instruction set and ARM Embedded ABI (aeabi)
 * ARCv2 ISA
 
+For information on Kconfig configuration, see the
+:ref:`setting_configuration_values` section in the :ref:`board_porting_guide`.
+Architectures use a similar Kconfig configuration scheme.
+
 An architecture port can be divided in several parts; most are required and
 some are optional:
 


### PR DESCRIPTION
In particular, try to demystify `Kconfig.defconfig` files, and provide
guidelines on whether configuration settings should go in
`BOARD_defconfig` or `Kconfig.defconfig`.

The board porting section seems to be the most relevant one here, so put
the documentation there, with some "see also" links from elsewhere.
Things could be reorganized later if needed.

Give a general overview of visible and invisible Kconfig symbols as
well, as that ties in with the configuration scheme.

This is reverse-engineering on my part. The configuration scheme doesn't
seem to be documented anywhere prior. Please tell me if my understanding
doesn't match yours anywhere.

Fixes: #7159

Signed-off-by: Ulf Magnusson <ulfalizer@gmail.com>