### PR TITLE
tests: mem_prot: skip unsupported tests

### DIFF
--- a/tests/kernel/mem_protect/mem_protect/src/kobject.c
+++ b/tests/kernel/mem_protect/mem_protect/src/kobject.c
@@ -581,6 +581,7 @@ void kobject_test_user_1_17(void *p1, void *p2, void *p3)
 /* Create a new thread from user and use a huge stack size which overflows
  * _handler_k_thread_create validation.
  */
+#ifndef CONFIG_MPU_REQUIRES_POWER_OF_TWO_ALIGNMENT
 void test_create_new_thread_from_user_invalid_stacksize(void *p1,
 							void *p2, void *p3)
 {
@@ -599,6 +600,13 @@ void test_create_new_thread_from_user_invalid_stacksize(void *p1,
 	k_sem_take(&sync_sem, SYNC_SEM_TIMEOUT);
 
 }
+#else
+void test_create_new_thread_from_user_invalid_stacksize(void *p1,
+							void *p2, void *p3)
+{
+	ztest_test_skip();
+}
+#endif
 
 /****************************************************************************/
 /* object validation checks */
@@ -626,6 +634,8 @@ void kobject_test_user_1_18(void *p1, void *p2, void *p3)
 /* Create a new thread from user and use a stack bigger than allowed size.
  * _handler_k_thread_create validation.
  */
+
+#ifndef CONFIG_MPU_REQUIRES_POWER_OF_TWO_ALIGNMENT
 void test_create_new_thread_from_user_huge_stacksize(void *p1,
 						     void *p2, void *p3)
 {
@@ -644,6 +654,13 @@ void test_create_new_thread_from_user_huge_stacksize(void *p1,
 	k_sem_take(&sync_sem, SYNC_SEM_TIMEOUT);
 
 }
+#else
+void test_create_new_thread_from_user_huge_stacksize(void *p1,
+						     void *p2, void *p3)
+{
+	ztest_test_skip();
+}
+#endif
 
 /****************************************************************************/
 /* object validation checks */

--- a/tests/kernel/mem_protect/mem_protect/src/main.c
+++ b/tests/kernel/mem_protect/mem_protect/src/main.c
@@ -75,10 +75,8 @@ void test_main(void)
 	 ztest_unit_test(test_kobject_reinitialize_thread_kobj),
 	 ztest_unit_test(test_create_new_thread_from_user),
 	 ztest_unit_test(test_create_new_thread_from_user_no_access_stack),
-#ifndef CONFIG_MPU_REQUIRES_POWER_OF_TWO_ALIGNMENT
 	 ztest_unit_test(test_create_new_thread_from_user_invalid_stacksize),
 	 ztest_unit_test(test_create_new_thread_from_user_huge_stacksize),
-#endif
 	 ztest_unit_test(test_create_new_supervisor_thread_from_user),
 	 ztest_unit_test(test_create_new_essential_thread_from_user),
 	 ztest_unit_test(test_create_new_higher_prio_thread_from_user),


### PR DESCRIPTION
If a test is not supported on some platform, skip it and report SKIP.

Signed-off-by: Anas Nashif <anas.nashif@intel.com>