### PR TITLE
tests: threads: Add test to verify delayed thread abort

### DIFF
--- a/tests/kernel/threads/lifecycle/lifecycle_api/src/main.c
+++ b/tests/kernel/threads/lifecycle/lifecycle_api/src/main.c
@@ -26,6 +26,7 @@ extern void test_threads_abort_repeat(void);
 extern void test_abort_handler(void);
 extern void test_essential_thread_operation(void);
 extern void test_threads_priority_set(void);
+extern void test_delayed_thread_abort(void);
 
 __kernel struct k_thread tdata;
 #define STACK_SIZE (256 + CONFIG_TEST_EXTRA_STACKSIZE)
@@ -53,6 +54,7 @@ void test_main(void)
 			 ztest_user_unit_test(test_threads_abort_others),
 			 ztest_unit_test(test_threads_abort_repeat),
 			 ztest_unit_test(test_abort_handler),
+			 ztest_unit_test(test_delayed_thread_abort),
 			 ztest_unit_test(test_essential_thread_operation)
 			 );
 	ztest_run_test_suite(threads_lifecycle);

--- a/tests/kernel/threads/lifecycle/lifecycle_api/src/test_threads_cancel_abort.c
+++ b/tests/kernel/threads/lifecycle/lifecycle_api/src/test_threads_cancel_abort.c
@@ -104,15 +104,15 @@ static void uthread_entry(void)
 {
 	block = k_malloc(BLOCK_SIZE);
 	zassert_true(block != NULL, NULL);
-		printk("Child thread is running\n");
+	printk("Child thread is running\n");
 	k_sleep(K_MSEC(2));
 }
 
 void test_abort_handler(void)
 {
 	k_tid_t tid = k_thread_create(&tdata, tstack, STACK_SIZE,
-			(k_thread_entry_t)uthread_entry, NULL, NULL, NULL,
-			0, 0, 0);
+				      (k_thread_entry_t)uthread_entry, NULL, NULL, NULL,
+				      0, 0, 0);
 
 	tdata.fn_abort = &abort_function;
 
@@ -124,5 +124,43 @@ void test_abort_handler(void)
 	k_thread_abort(tid);
 
 	zassert_true(abort_called == true, "Abort handler"
-			" is not called");
+		     " is not called");
+}
+
+static void delayed_thread_entry(void *p1, void *p2, void *p3)
+{
+	execute_flag = 1;
+
+	zassert_unreachable("Delayed thread shouldn't be executed\n");
+}
+
+void test_delayed_thread_abort(void)
+{
+	int current_prio = k_thread_priority_get(k_current_get());
+
+	/* Make current thread preemptive */
+	k_thread_priority_set(k_current_get(), K_PRIO_PREEMPT(2));
+
+	/* Create a preemptive thread of higher priority than
+	 * current thread
+	 */
+	k_tid_t tid = k_thread_create(&tdata, tstack, STACK_SIZE,
+				      (k_thread_entry_t)delayed_thread_entry, NULL, NULL, NULL,
+				      K_PRIO_PREEMPT(1), 0, 100);
+
+	/* Give up CPU */
+	k_sleep(50);
+
+	/* Test point: check if thread delayed for 100ms has not started*/
+	zassert_true(execute_flag == 0, "Delayed thread created is not"
+		     " put to wait queue\n");
+
+	k_thread_abort(tid);
+
+	/* Test point: Test abort of thread before its execution*/
+	zassert_false(execute_flag == 1, "Delayed thread is has executed"
+		      " before cancellation\n");
+
+	/* Restore the priority */
+	k_thread_priority_set(k_current_get(), current_prio);
 }


### PR DESCRIPTION
As k_thread_cancel() is deprecated, we need to test if delayed thread
which is in wait queue can be cancelled from k_thread_abort().

Signed-off-by: Spoorthi K <spoorthi.k@intel.com>