### PR TITLE
arch: arm: improve help text for PROGRAMMABLE_FAULT_PRIOS option

### DIFF
--- a/arch/arm/core/cortex_m/Kconfig
+++ b/arch/arm/core/cortex_m/Kconfig
@@ -123,8 +123,9 @@ config CPU_CORTEX_M_HAS_PROGRAMMABLE_FAULT_PRIOS
 	depends on ARMV7_M_ARMV8_M_MAINLINE
 	default n
 	help
-	  This option signifies the CPU faults other than the hard fault, and
-	  needs to reserve a priority for them.
+	  This option signifies the CPU may trigger system faults
+	  (other than HardFault) with configurable priority, and,
+	  therefore, it needs to reserve a priority level for them.
 
 config CPU_CORTEX_M0_HAS_VECTOR_TABLE_REMAP
 	bool


### PR DESCRIPTION
Improve the help text of ARM k-config option
CPU_CORTEX_M_HAS_PROGRAMMABLE_FAULT_PRIOS.

Signed-off-by: Ioannis Glaropoulos <Ioannis.Glaropoulos@nordicsemi.no>