### PR TITLE
net: hostname: Fix hostname buffer length

### DIFF
--- a/subsys/net/hostname.c
+++ b/subsys/net/hostname.c
@@ -24,7 +24,7 @@
 #define EXTRA_SPACE 0
 #endif /* CONFIG_NET_HOSTNAME_UNIQUE */
 
-static char hostname[sizeof(CONFIG_NET_HOSTNAME) - 1 + EXTRA_SPACE];
+static char hostname[sizeof(CONFIG_NET_HOSTNAME) + EXTRA_SPACE];
 
 const char *net_hostname_get(void)
 {


### PR DESCRIPTION
The buffer allocated for hostname was one byte too short.

Signed-off-by: Jukka Rissanen <jukka.rissanen@linux.intel.com>