### PR TITLE
arm: soc: NXP: Enable SEGGER RTT on all NXP SoCs

### DIFF
--- a/arch/arm/soc/nxp_imx/Kconfig
+++ b/arch/arm/soc/nxp_imx/Kconfig
@@ -6,6 +6,7 @@
 
 config SOC_FAMILY_IMX
 	bool
+	select HAS_SEGGER_RTT
 	# omit prompt to signify a "hidden" option
 	default n
 

--- a/arch/arm/soc/nxp_kinetis/Kconfig
+++ b/arch/arm/soc/nxp_kinetis/Kconfig
@@ -7,6 +7,7 @@
 
 config SOC_FAMILY_KINETIS
 	bool
+	select HAS_SEGGER_RTT
 	# omit prompt to signify a "hidden" option
 	default n
 

--- a/arch/arm/soc/nxp_kinetis/kwx/Kconfig.soc
+++ b/arch/arm/soc/nxp_kinetis/kwx/Kconfig.soc
@@ -30,7 +30,6 @@ config SOC_MKW24D5
 	select HAS_MCUX_SIM
 	select HAS_OSC
 	select HAS_MCG
-	select HAS_SEGGER_RTT
 
 config SOC_MKW40Z4
 	bool "SOC_MKW40Z4"
@@ -42,7 +41,6 @@ config SOC_MKW40Z4
 	select HAS_MCUX_TRNG
 	select HAS_OSC
 	select HAS_MCG
-	select HAS_SEGGER_RTT
 
 config SOC_MKW41Z4
 	bool "SOC_MKW41Z4"

--- a/arch/arm/soc/nxp_lpc/Kconfig
+++ b/arch/arm/soc/nxp_lpc/Kconfig
@@ -6,6 +6,7 @@
 
 config SOC_FAMILY_LPC
 	bool
+	select HAS_SEGGER_RTT
 	# omit prompt to signify a "hidden" option
 	default n
 


### PR DESCRIPTION
It seems like SEGGER is supported across all the NXP SoC families so
lets enable it across all of them.

Signed-off-by: Kumar Gala <kumar.gala@linaro.org>