### PR TITLE
net: tc: Proper packet priority to traffic class mapping

### DIFF
--- a/subsys/net/ip/net_tc.c
+++ b/subsys/net/ip/net_tc.c
@@ -46,21 +46,20 @@ void net_tc_submit_to_rx_queue(u8_t tc, struct net_pkt *pkt)
 
 int net_tx_priority2tc(enum net_priority prio)
 {
-	/* FIXME: Initial implementation just maps the priority to certain
-	 * traffic class to certain queue. This needs to be made more generic.
-	 *
+	/*
 	 * Use the example priority -> traffic class mapper found in
-	 * IEEE 802.1Q chapter 8.6.6 table 8.4 and chapter 34.5 table 34-1
+	 * IEEE 802.1Q chapter I.3, chapter 8.6.6 table 8.4 and
+	 * chapter 34.5 table 34-1
 	 *
 	 *  Priority         Acronym   Traffic types
 	 *  0 (lowest)       BK        Background
 	 *  1 (default)      BE        Best effort
 	 *  2                EE        Excellent effort
-	 *  3 (highest)      CA        Critical applications
+	 *  3                CA        Critical applications
 	 *  4                VI        Video, < 100 ms latency and jitter
 	 *  5                VO        Voice, < 10 ms latency and jitter
 	 *  6                IC        Internetwork control
-	 *  7                NC        Network control
+	 *  7 (highest)      NC        Network control
 	 */
 	/* Priority is the index to this array */
 	static const u8_t tc[] = {
@@ -68,25 +67,25 @@ int net_tx_priority2tc(enum net_priority prio)
 		0, 0, 0, 0, 0, 0, 0, 0
 #endif
 #if NET_TC_TX_COUNT == 2
-		0, 0, 1, 1, 0, 0, 0, 0
+		0, 0, 0, 0, 1, 1, 1, 1
 #endif
 #if NET_TC_TX_COUNT == 3
-		0, 0, 1, 2, 0, 0, 0, 0
+		0, 0, 0, 0, 1, 1, 2, 2
 #endif
 #if NET_TC_TX_COUNT == 4
-		0, 0, 2, 3, 1, 1, 1, 1
+		0, 0, 1, 1, 2, 2, 3, 3
 #endif
 #if NET_TC_TX_COUNT == 5
-		0, 0, 3, 4, 1, 1, 2, 2
+		0, 0, 1, 1, 2, 2, 3, 4
 #endif
 #if NET_TC_TX_COUNT == 6
-		0, 0, 4, 5, 1, 1, 2, 3
+		0, 1, 2, 2, 3, 3, 4, 5
 #endif
 #if NET_TC_TX_COUNT == 7
-		0, 0, 5, 6, 1, 2, 3, 4
+		0, 1, 2, 3, 4, 4, 5, 6
 #endif
 #if NET_TC_TX_COUNT == 8
-		0, 1, 6, 7, 2, 3, 4, 5
+		0, 1, 2, 3, 4, 5, 6, 7
 #endif
 	};
 
@@ -100,21 +99,20 @@ int net_tx_priority2tc(enum net_priority prio)
 
 int net_rx_priority2tc(enum net_priority prio)
 {
-	/* FIXME: Initial implementation just maps the priority to certain
-	 * traffic class to certain queue. This needs to be made more generic.
-	 *
+	/*
 	 * Use the example priority -> traffic class mapper found in
-	 * IEEE 802.1Q chapter 8.6.6 table 8.4 and chapter 34.5 table 34-1
+	 * IEEE 802.1Q chapter I.3, chapter 8.6.6 table 8.4 and
+	 * chapter 34.5 table 34-1
 	 *
 	 *  Priority         Acronym   Traffic types
 	 *  0 (lowest)       BK        Background
 	 *  1 (default)      BE        Best effort
 	 *  2                EE        Excellent effort
-	 *  3 (highest)      CA        Critical applications
+	 *  3                CA        Critical applications
 	 *  4                VI        Video, < 100 ms latency and jitter
 	 *  5                VO        Voice, < 10 ms latency and jitter
 	 *  6                IC        Internetwork control
-	 *  7                NC        Network control
+	 *  7 (highest)      NC        Network control
 	 */
 	/* Priority is the index to this array */
 	static const u8_t tc[] = {
@@ -122,25 +120,25 @@ int net_rx_priority2tc(enum net_priority prio)
 		0, 0, 0, 0, 0, 0, 0, 0
 #endif
 #if NET_TC_RX_COUNT == 2
-		0, 0, 1, 1, 0, 0, 0, 0
+		0, 0, 0, 0, 1, 1, 1, 1
 #endif
 #if NET_TC_RX_COUNT == 3
-		0, 0, 1, 2, 0, 0, 0, 0
+		0, 0, 0, 0, 1, 1, 2, 2
 #endif
 #if NET_TC_RX_COUNT == 4
-		0, 0, 2, 3, 1, 1, 1, 1
+		0, 0, 1, 1, 2, 2, 3, 3
 #endif
 #if NET_TC_RX_COUNT == 5
-		0, 0, 3, 4, 1, 1, 2, 2
+		0, 0, 1, 1, 2, 2, 3, 4
 #endif
 #if NET_TC_RX_COUNT == 6
-		0, 0, 4, 5, 1, 1, 2, 3
+		0, 1, 2, 2, 3, 3, 4, 5
 #endif
 #if NET_TC_RX_COUNT == 7
-		0, 0, 5, 6, 1, 2, 3, 4
+		0, 1, 2, 3, 4, 4, 5, 6
 #endif
 #if NET_TC_RX_COUNT == 8
-		0, 1, 6, 7, 2, 3, 4, 5
+		0, 1, 2, 3, 4, 5, 6, 7
 #endif
 	};
 


### PR DESCRIPTION
The IEEE 802.1Q chapter I.3 contains a proper network packet
priority to traffic class mapping. The original mapping was
clearly incorrect.

Signed-off-by: Jukka Rissanen <jukka.rissanen@linux.intel.com>