### PR TITLE
CODEOWNERS: Add myself as the Codeowner for LED API and drivers

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -82,6 +82,7 @@ drivers/gpio/*stm32*                     @rsalveti @idlethread
 drivers/gpio/gpio_pulpino.c              @fractalclone @kgugala @pgielda
 drivers/ieee802154/*                     @jukkar @tbursztyka
 drivers/interrupt_controller/*           @andrewboie
+drivers/led/*                            @Mani-Sadhasivam
 drivers/led_strip/*                      @mbolivar
 drivers/pinmux/stm32/*                   @rsalveti @idlethread
 drivers/sensor/*                         @bogdan-davidoaia
@@ -133,6 +134,7 @@ include/irq.h                            @andrewboie @andyross
 include/irq_offload.h                    @andrewboie @andyross
 include/kernel.h                         @andrewboie @andyross
 include/kernel_version.h                 @andrewboie @andyross
+include/led.h                            @Mani-Sadhasivam
 include/led_strip.h                      @mbolivar
 include/linker/linker-defs.h             @andrewboie @andyross
 include/linker/linker-tool-gcc.h         @andrewboie @andyross


### PR DESCRIPTION
 Add myself as the Codeowner for LED API and its drivers.

Signed-off-by: Manivannan Sadhasivam <manivannan.sadhasivam@linaro.org>