### PR TITLE
tests: mem_protect: Add memory domain test cases

### DIFF
--- a/tests/kernel/mem_protect/mem_protect/src/main.c
+++ b/tests/kernel/mem_protect/mem_protect/src/main.c
@@ -17,11 +17,15 @@
 extern void test_permission_inheritance(void);
 extern void test_mem_domain_valid_access(void);
 extern void test_mem_domain_invalid_access(void);
+extern void test_mem_domain_partitions_user_rw(void);
+extern void test_mem_domain_partitions_user_ro(void);
+extern void test_mem_domain_partitions_supervisor_rw(void);
 extern void test_mem_domain_add_partitions_invalid(void);
 extern void test_mem_domain_add_partitions_simple(void);
 extern void test_mem_domain_remove_partitions_simple(void);
 extern void test_mem_domain_remove_partitions(void);
 extern void test_mem_domain_remove_thread(void);
+extern void test_mem_domain_destroy(void);
 extern void test_kobject_access_grant(void);
 extern void test_syscall_invalid_kobject(void);
 extern void test_thread_without_kobject_permission(void);
@@ -54,11 +58,15 @@ void test_main(void)
 	 ztest_unit_test(test_permission_inheritance),
 	 ztest_unit_test(test_mem_domain_valid_access),
 	 ztest_unit_test(test_mem_domain_invalid_access),
+	 ztest_unit_test(test_mem_domain_partitions_user_rw),
+	 ztest_unit_test(test_mem_domain_partitions_supervisor_rw),
+	 ztest_unit_test(test_mem_domain_partitions_user_ro),
 	 ztest_unit_test(test_mem_domain_add_partitions_invalid),
 	 ztest_unit_test(test_mem_domain_add_partitions_simple),
 	 ztest_unit_test(test_mem_domain_remove_partitions_simple),
 	 ztest_unit_test(test_mem_domain_remove_partitions),
 	 ztest_unit_test(test_mem_domain_remove_thread),
+	 ztest_unit_test(test_mem_domain_destroy),
 	 ztest_unit_test(test_kobject_access_grant),
 	 ztest_unit_test(test_syscall_invalid_kobject),
 	 ztest_unit_test(test_thread_without_kobject_permission),


### PR DESCRIPTION
Add few tests to check access permissions of memory partitions of a memory domain and validate memory domain destroy.

Signed-off-by: Spoorthi K <spoorthi.k@intel.com>