### PR TITLE
Modify BUILD_ASSERT to ensure it is supported on toolchains like xcc

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -99,7 +99,6 @@ zephyr_compile_options(
   -Wformat
   -Wformat-security
   -Wno-format-zero-length
-  -Wno-unused-local-typedefs
   -imacros ${AUTOCONF_H}
   -ffreestanding
   -Wno-main

--- a/include/kernel.h
+++ b/include/kernel.h
@@ -2705,8 +2705,8 @@ static inline unsigned int _impl_k_sem_count_get(struct k_sem *sem)
 	struct k_sem name \
 		__in_section(_k_sem, static, name) = \
 		_K_SEM_INITIALIZER(name, initial_count, count_limit); \
-	BUILD_ASSERT((count_limit) != 0); \
-	BUILD_ASSERT((initial_count) <= (count_limit));
+	BUILD_ASSERT(((count_limit) != 0) && \
+		     ((initial_count) <= (count_limit)));
 
 /** @} */
 


### PR DESCRIPTION
BUILD_ASSERT() macro makes use of __COUNTER__ which may not be supported in some compilers (like xcc). So, multiple uses of BUILD_ASSERT() in same scope is not possible for such compilers. Instead, the expression to BUILD_ASSERT can be "&&"ed to achieve the same purpose.
