### PR TITLE
arm: Kconfig Fix

### DIFF
--- a/arch/arm/Kconfig
+++ b/arch/arm/Kconfig
@@ -27,7 +27,7 @@ config ARCH_DEFCONFIG
 
 source "arch/arm/core/Kconfig"
 
-menu "Board Configuration"
+menu "SoC Configuration"
 
 source "arch/arm/soc/*/Kconfig"
 

--- a/arch/arm/soc/arm/beetle/Kconfig.soc
+++ b/arch/arm/soc/arm/beetle/Kconfig.soc
@@ -16,9 +16,9 @@ config SOC_BEETLE_R0
 endchoice
 
 config ARM_MPU_ENABLE
-	bool "Enable MPU"
+	bool "Enable MPU on ARM Beetle"
 	depends on CPU_HAS_MPU
 	select ARM_MPU
 	default n
 	help
-	  Enable MPU
+	  Enable MPU support on ARM Beetle SoCs

--- a/arch/arm/soc/nxp_kinetis/Kconfig
+++ b/arch/arm/soc/nxp_kinetis/Kconfig
@@ -42,12 +42,12 @@ config HAS_MCG
 	  Set if the multipurpose clock generator (MCG) module is present in the SoC.
 
 config HAS_SYSMPU
-	bool "Enable MPU"
+	bool "Enable MPU on NXP Kinetis"
 	depends on CPU_HAS_MPU
 	select NXP_MPU
 	default n
 	help
-	  Enable MPU
+	  Enable MPU support on NXP Kinetis SoCs
 
 if HAS_OSC
 

--- a/arch/arm/soc/st_stm32/Kconfig
+++ b/arch/arm/soc/st_stm32/Kconfig
@@ -23,11 +23,11 @@ config SOC_FAMILY
 endif
 
 config STM32_ARM_MPU_ENABLE
-	bool "Enable MPU"
+	bool "Enable MPU on STM32"
 	depends on CPU_HAS_MPU
 	select ARM_MPU
 	default n
 	help
-	  Enable MPU
+	  Enable MPU support on STM32 SoCs
 
 source "arch/arm/soc/st_stm32/*/Kconfig.soc"


### PR DESCRIPTION
Here is the couple of fixes for ARM Kconfigs.

1. Change the menu selection text for ARM SoCs to "SoC Configuration"
2. Elaborate MPU selection text to avoid ambiguity