### PR TITLE
arch/arm/soc/st_stm32: Fix typos in soc.h

### DIFF
--- a/arch/arm/soc/st_stm32/stm32f1/soc.h
+++ b/arch/arm/soc/st_stm32/stm32f1/soc.h
@@ -5,7 +5,7 @@
  */
 
 /**
- * @file SoC configuration macros for the STM32F103 family processors.
+ * @file SoC configuration macros for the STM32F1 family processors.
  *
  * Based on reference manual:
  *   STM32F101xx, STM32F102xx, STM32F103xx, STM32F105xx and STM32F107xx

--- a/arch/arm/soc/st_stm32/stm32l4/soc.h
+++ b/arch/arm/soc/st_stm32/stm32l4/soc.h
@@ -6,7 +6,7 @@
  */
 
 /**
- * @file SoC configuration macros for the STM32F103 family processors.
+ * @file SoC configuration macros for the STM32L4 family processors.
  *
  * Based on reference manual:
  *   STM32L4x1, STM32L4x2, STM32L431xx STM32L443xx STM32L433xx, STM32L4x5,


### PR DESCRIPTION
Fix typos in soc.h for stm32f1 and stm32l4 families.

Signed-off-by: Yannis Damigos <giannis.damigos@gmail.com>