### PR TITLE
lib: posix: pthread_common: Fix potential integer overflow issue

### DIFF
--- a/lib/posix/pthread_common.c
+++ b/lib/posix/pthread_common.c
@@ -12,8 +12,7 @@
 
 s64_t timespec_to_timeoutms(const struct timespec *abstime)
 {
-	s64_t milli_secs;
-	s32_t secs, nsecs;
+	s64_t milli_secs, secs, nsecs;
 	struct timespec curtime;
 
 	/* FIXME: Zephyr does have CLOCK_REALTIME to get time.


### PR DESCRIPTION
Fix potential overflow of interger expression for by fixing
variable type to s64_t.

CID: 185275

Signed-off-by: Ramakrishna Pallala <ramakrishna.pallala@intel.com>