### PR TITLE
Fix check compiler flag

### DIFF
--- a/cmake/extensions.cmake
+++ b/cmake/extensions.cmake
@@ -943,7 +943,11 @@ endfunction()
 # check_compiler_flag(C "-Wall" my_check)
 # print(my_check) # my_check is now 1
 function(check_compiler_flag lang option ok)
-  string(MAKE_C_IDENTIFIER check${option}_${lang} ${ok})
+
+  string(MAKE_C_IDENTIFIER
+    check${option}_${lang}_${CMAKE_REQUIRED_FLAGS}
+    ${ok}
+    )
 
   if(${lang} STREQUAL C)
     check_c_compiler_flag("${option}" ${${ok}})

--- a/cmake/extensions.cmake
+++ b/cmake/extensions.cmake
@@ -943,6 +943,9 @@ endfunction()
 # check_compiler_flag(C "-Wall" my_check)
 # print(my_check) # my_check is now 1
 function(check_compiler_flag lang option ok)
+  if(NOT DEFINED CMAKE_REQUIRED_QUIET)
+    set(CMAKE_REQUIRED_QUIET 1)
+  endif()
 
   string(MAKE_C_IDENTIFIER
     check${option}_${lang}_${CMAKE_REQUIRED_FLAGS}

--- a/cmake/extensions.cmake
+++ b/cmake/extensions.cmake
@@ -622,8 +622,15 @@ function(zephyr_check_compiler_flag lang option check)
   # We need to create a unique key wrt. testing the toolchain
   # capability. This key must be a valid C identifier that includes
   # everything that can affect the toolchain test.
+
+  # The 'cacheformat' must be bumped if a bug in the caching mechanism
+  # is detected and all old keys must be invalidated.
+  set(cacheformat 2)
+
   set(key_string "")
   set(key_string "${key_string}ZEPHYR_TOOLCHAIN_CAPABILITY_CACHE_")
+  set(key_string "${key_string}cacheformat_")
+  set(key_string "${key_string}${cacheformat}_")
   set(key_string "${key_string}${TOOLCHAIN_SIGNATURE}_")
   set(key_string "${key_string}${lang}_")
   set(key_string "${key_string}${option}_")


### PR DESCRIPTION
Fix a bug where different compiler checks were aliased and therefore
the test results were incorrectly re-used.

The 'check' string is used by CMake internally to cache test results,
but when testing linker flags the check string has been aliased
between the different linker checks. To fix the aliasing issue we add
the CMAKE_REQUIRED_FLAGS variable to the 'check' string. The aliasing
issue disappears because the linker flag-under-test is in
'CMAKE_REQUIRED_FLAGS'.

Also, suppress the compiler check messages because they have become unacceptably verbose.

This fixes #7246 