### PR TITLE
drivers/spi: Remove DW spi slave test left over

### DIFF
--- a/drivers/spi/spi_dw.c
+++ b/drivers/spi/spi_dw.c
@@ -398,8 +398,6 @@ static int transceive(struct device *dev,
 		    spi->ctx.rx_len < DW_SPI_RXFTLR_DFLT) {
 			reg_data = spi->ctx.rx_len - 1;
 		}
-
-		reg_data = 0;
 	} else {
 		if (spi->ctx.rx_len && spi->ctx.rx_len < DW_SPI_FIFO_DEPTH) {
 			reg_data = spi->ctx.rx_len - 1;


### PR DESCRIPTION
This reset to 0 was used for testing threshold on slave mode.

Fixes #7254.
Coverity-CID: 185402

Signed-off-by: Tomasz Bursztyka <tomasz.bursztyka@linux.intel.com>