### PR TITLE
kconfig: Move CPLUSPLUS from root to "Compiler Options"

### DIFF
--- a/misc/Kconfig
+++ b/misc/Kconfig
@@ -184,6 +184,12 @@ config TOOLCHAIN_VARIANT
 	  For optimized compilers with reduced features, specify the name
 	  of the variant.
 
+config CPLUSPLUS
+	bool "Enable C++ support for the application"
+	default n
+	help
+	  This option enables the use of applications built with C++.
+
 endmenu
 
 menu "Build Options"

--- a/subsys/Kconfig
+++ b/subsys/Kconfig
@@ -9,8 +9,6 @@ source "subsys/bluetooth/Kconfig"
 
 source "subsys/console/Kconfig"
 
-source "subsys/cpp/Kconfig"
-
 source "subsys/debug/Kconfig"
 
 source "subsys/disk/Kconfig"

--- a/subsys/cpp/Kconfig
+++ b/subsys/cpp/Kconfig
@@ -1,7 +1,0 @@
-
-config CPLUSPLUS
-	bool "Enable C++ support for the application"
-	default n
-	help
-	  This option enables the use of applications built with C++.
-


### PR DESCRIPTION
Enabling C++ support for the application has been inappropriately
located at the root of the Kconfig menu. The root should be kept as
clean possible to allow easy navigation.

This commit moves CONFIG_CPLUSPLUS into

~/"Build and Linker Features"/"Compiler Options".

This is a purely cosmetic change and does not change the
'visibility' (depends) of the Kconfig option.

Arguably, it would fit better into

~/"Build and Linker Features"/"Language Options"

but this entry does not exist.

Signed-off-by: Sebastian Bøe <sebastian.boe@nordicsemi.no>