### PR TITLE
kconfig: fix menuconfig

### DIFF
--- a/arch/Kconfig
+++ b/arch/Kconfig
@@ -110,7 +110,6 @@ config DYNAMIC_OBJECTS
 	bool "Allow kernel objects to be requested on system heap"
 	default n
 	depends on USERSPACE
-	depends on HEAP_MEM_POOL_SIZE > 0
 	help
 	Enabling this option allows for kernel objects to be requested from
 	the system heap, at a cost in performance and additional memory.


### PR DESCRIPTION
"depends on" cannot use expressions as arguments, this statement
didn't actually do anything for kconfiglib.py and caused an
error with menuconfig.

There's currently no way to depend on a system heap being
present, however forthcoming patches move this feature away
from using the system heap anyway.

For now, if the user enables dynamic objects without defining
a system heap, they will get a build error.

Fixes #7266.

Signed-off-by: Andrew Boie <andrew.p.boie@intel.com>