### PR TITLE
Bluetooth: GATT: Fix CCC handling

### DIFF
--- a/include/bluetooth/gatt.h
+++ b/include/bluetooth/gatt.h
@@ -488,13 +488,11 @@ ssize_t bt_gatt_attr_read_chrc(struct bt_conn *conn,
 #define BT_GATT_CCC_MAX (CONFIG_BT_MAX_PAIRED + CONFIG_BT_MAX_CONN)
 
 /** @brief GATT CCC configuration entry.
- *  @param valid Valid flag
  *  @param peer Remote peer address
  *  @param value Configuration value.
  *  @param data Configuration pointer data.
  */
 struct bt_gatt_ccc_cfg {
-	u8_t			valid;
 	bt_addr_le_t		peer;
 	u16_t			value;
 	u8_t			data[4] __aligned(4);


### PR DESCRIPTION
The 'valid' of struct bt_gatt_ccc_cfg was redundant, since setting
'peer' to BT_ADDR_LE_ANY does the same job. What's worse, the handling
of 'valid' was also buggy in that some places looking for valid CCC
structs only matched the address, meaning it might yield a positive
match for invalid entries.

Fix these issues by removing the 'valid' struct member, and solely
using the 'peer' member to identify valid entries. Also simplify the
code by acknowledging that no CCC entry is essentially the same as the
value '0' written to CCC.

Signed-off-by: Johan Hedberg <johan.hedberg@intel.com>