### PR TITLE
doc: DRAFT start for 1.12 release notes

### DIFF
--- a/doc/release-notes-1.12.rst
+++ b/doc/release-notes-1.12.rst
@@ -1,0 +1,73 @@
+:orphan:
+
+.. _zephyr_1.12:
+
+Zephyr Kernel 1.12.0 (DRAFT)
+############################
+
+We are pleased to announce the release of Zephyr kernel version 1.12.0.
+
+Major enhancements with this release include:
+
+- 802.1Q - Virtual Local Area Network (VLAN) traffic on an Ethernet network
+- Support multiple concurrent filesystem devices, partitions, and FS types
+- Support for TAP net device on the the native POSIX port
+- SPI slave support
+- Runtime non-volatile configuration data storage system
+
+
+The following sections provide detailed lists of changes by component.
+
+Kernel
+******
+
+* Detail
+
+Architectures
+*************
+
+
+Boards
+******
+
+
+Drivers and Sensors
+*******************
+
+
+Networking
+**********
+
+
+Bluetooth
+*********
+
+
+Build and Infrastructure
+************************
+
+
+Libraries / Subsystems
+***********************
+
+
+HALs
+****
+
+
+Documentation
+*************
+
+
+Tests and Samples
+*****************
+
+
+Issue Related Items
+*******************
+
+These GitHub issues were addressed since the previous 1.11.0 tagged
+release:
+
+.. comment  List derived from GitHub Issue query: ...
+   * :github:`issuenumber` - issue title


### PR DESCRIPTION
Get the 1.12 release notes started with material derived from the 1.12
roadmap (closed issues) and headings from the 1.11 release notes.

Signed-off-by: David B. Kinder <david.b.kinder@intel.com>