### PR TITLE
Bluetooth: Mesh: Fix Node Identity advertising

### DIFF
--- a/include/bluetooth/mesh.h
+++ b/include/bluetooth/mesh.h
@@ -18,17 +18,8 @@
 #include <bluetooth/mesh/main.h>
 #include <bluetooth/mesh/cfg_srv.h>
 #include <bluetooth/mesh/health_srv.h>
-
-#if defined(CONFIG_BT_MESH_CFG_CLI)
 #include <bluetooth/mesh/cfg_cli.h>
-#endif
-
-#if defined(CONFIG_BT_MESH_HEALTH_CLI)
 #include <bluetooth/mesh/health_cli.h>
-#endif
-
-#if defined(CONFIG_BT_MESH_GATT_PROXY)
 #include <bluetooth/mesh/proxy.h>
-#endif
 
 #endif /* __BT_MESH_H */


### PR DESCRIPTION
Fix a race condition resulting from bt_mesh_provision() clearing information about the used provisioning bearer.