### PR TITLE
tests/samples: add hw dependencies

### DIFF
--- a/samples/bluetooth/hci_spi/sample.yaml
+++ b/samples/bluetooth/hci_spi/sample.yaml
@@ -7,3 +7,4 @@ tests:
     harness: bluetooth
     platform_whitelist: 96b_carbon_nrf51 nrf51_pca10028
     tags: samples bluetooth spi
+    depends_on: spi

--- a/samples/boards/quark_se_c1000/power_mgr/sample.yaml
+++ b/samples/boards/quark_se_c1000/power_mgr/sample.yaml
@@ -4,3 +4,4 @@ tests:
   test:
     filter: (CONFIG_SOC_QUARK_SE_C1000 or CONFIG_SOC_QUARK_SE_C1000_SS)
     tags: samples power
+    depends_on: rtc

--- a/samples/drivers/lcd_hd44780/sample.yaml
+++ b/samples/drivers/lcd_hd44780/sample.yaml
@@ -5,3 +5,4 @@ tests:
     platform_whitelist: arduino_due
     tags: samples
     harness: display
+    depends_on: gpio

--- a/samples/grove/lcd/sample.yaml
+++ b/samples/grove/lcd/sample.yaml
@@ -2,7 +2,6 @@ sample:
   name: Grove LCD Sample
 tests:
   test:
-    platform_whitelist: arduino_101_sss quark_d2000_crb
-      arduino_due
     tags: drivers
     harness: grove
+    depends_on: i2c

--- a/samples/grove/light/sample.yaml
+++ b/samples/grove/light/sample.yaml
@@ -6,3 +6,4 @@ tests:
       arduino_due
     tags: drivers sensor grove light
     harness: grove
+    depends_on: adc

--- a/samples/grove/temperature/sample.yaml
+++ b/samples/grove/temperature/sample.yaml
@@ -7,3 +7,4 @@ tests:
       arduino_due
     tags: drivers sensor grove temperature
     harness: grove
+    depends_on: adc

--- a/samples/hello_world/prj.conf
+++ b/samples/hello_world/prj.conf
@@ -1,1 +1,2 @@
 # nothing here
+CONFIG_BUILD_OUTPUT_STRIPPED=y

--- a/samples/net/irc_bot/sample.yaml
+++ b/samples/net/irc_bot/sample.yaml
@@ -3,5 +3,5 @@ sample:
 tests:
   test:
     harness: net
-    depends_on: netif
+    depends_on: netif gpio
     tags: net irc

--- a/tests/drivers/build_all/testcase.yaml
+++ b/tests/drivers/build_all/testcase.yaml
@@ -1,3 +1,5 @@
+common:
+  depends_on: gpio spi i2c
 tests:
   test_build_drivers:
     build_only: true

--- a/tests/power/power_states/testcase.yaml
+++ b/tests/power/power_states/testcase.yaml
@@ -3,8 +3,10 @@ tests:
     filter: (CONFIG_SOC_QUARK_SE_C1000 or CONFIG_SOC_QUARK_SE_C1000_SS)
     platform_exclude: tinytile
     tags: samples power
+    depends_on: rtc
   test_socwatch:
     extra_args: CONF_FILE="prj_socwatch.conf"
     filter: CONFIG_SOC_QUARK_SE_C1000
     platform_exclude: tinytile
     tags: samples power
+    depends_on: rtc


### PR DESCRIPTION
Add hardware dependencies and filters to make sure we do not explode if
for example we try to build a sample/test using rtc when the platform
does not support that.

Signed-off-by: Anas Nashif <anas.nashif@intel.com>