### PR TITLE
build: fix git describe call on older Git versions

### DIFF
--- a/cmake/app/boilerplate.cmake
+++ b/cmake/app/boilerplate.cmake
@@ -243,7 +243,7 @@ include(${ZEPHYR_BASE}/cmake/toolchain.cmake)
 
 find_package(Git QUIET)
 if(GIT_FOUND)
-  execute_process(COMMAND ${GIT_EXECUTABLE} -C ${ZEPHYR_BASE} describe
+  execute_process(COMMAND ${GIT_EXECUTABLE} --work-tree=${ZEPHYR_BASE} describe
     WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
     OUTPUT_VARIABLE BUILD_VERSION
     OUTPUT_STRIP_TRAILING_WHITESPACE)


### PR DESCRIPTION
Older Git versions do not support the -C argument for specifying the
working directory. Switch to using --work-tree instead.

This fixes #7287.

Signed-off-by: Henrik Brix Andersen <henrik@brixandersen.dk>