### PR TITLE
spi: Fix mcux dspi driver to parse lsb transfer mode correctly

### DIFF
--- a/drivers/spi/spi_mcux_dspi.c
+++ b/drivers/spi/spi_mcux_dspi.c
@@ -154,7 +154,7 @@ static int spi_mcux_configure(struct device *dev,
 		: kDSPI_ClockPhaseFirstEdge;
 
 	master_config.ctarConfig.direction =
-		(SPI_MODE_GET(spi_cfg->operation) & SPI_TRANSFER_LSB)
+		(spi_cfg->operation & SPI_TRANSFER_LSB)
 		? kDSPI_LsbFirst
 		: kDSPI_MsbFirst;
 


### PR DESCRIPTION
The mcux dspi driver was incorrectly using the macro SPI_MODE_GET() to
parse the operation for SPI_TRANSFER_LSB. The effect of this bug was
that the driver would quietly always operate in SPI_TRANSFER_MSB mode.

Coverity-CID: 185401

Signed-off-by: Maureen Helm <maureen.helm@nxp.com>

Fixes #7255 