### PR TITLE
samples: remove stray config

### DIFF
--- a/samples/hello_world/prj.conf
+++ b/samples/hello_world/prj.conf
@@ -1,2 +1,1 @@
 # nothing here
-CONFIG_BUILD_OUTPUT_STRIPPED=y


### PR DESCRIPTION
CONFIG_BUILD_OUTPUT_STRIPPED was added by mistake into this sample.

Signed-off-by: Anas Nashif <anas.nashif@intel.com>