### PR TITLE
arch: arc: fix the typo of label which caused issue #7249

### DIFF
--- a/arch/arc/core/fault_s.S
+++ b/arch/arc/core/fault_s.S
@@ -107,7 +107,7 @@ _exc_return:
 
 	/* check if the current thread needs to be rescheduled */
 	ld_s r0, [r1, _kernel_offset_to_ready_q_cache]
-	breq r0, r2, _exc_return
+	breq r0, r2, _exc_return_from_exc
 
 	_save_callee_saved_regs
 


### PR DESCRIPTION
* fix the issue #7249 which is caused by a typo of label

the failed test cases mem_pool_api and fifo_api are re-tested on emsk_7d_v22
emsk_9d, emsk_7d, emsk_11d.   All passed

Signed-off-by: Wayne Ren <wei.ren@synopsys.com>