### PR TITLE
usb: dw: Fix Coverity issue with get_mps()

### DIFF
--- a/drivers/usb/device/usb_dc_dw.c
+++ b/drivers/usb/device/usb_dc_dw.c
@@ -1194,13 +1194,9 @@ int usb_dc_ep_mps(const u8_t ep)
 {
 	enum usb_dw_out_ep_idx ep_idx = USB_DW_EP_ADDR2IDX(ep);
 
-	switch (USB_DW_EP_ADDR2DIR(ep)) {
-	case USB_EP_DIR_OUT:
+	if (USB_DW_EP_ADDR2DIR(ep) == USB_EP_DIR_OUT) {
 		return usb_dw_ctrl.out_ep_ctrl[ep_idx].mps;
-	case USB_EP_DIR_IN:
+	} else {
 		return usb_dw_ctrl.in_ep_ctrl[ep_idx].mps;
 	}
-
-	/* Should not happen */
-	return 0;
 }


### PR DESCRIPTION
Fix issue with Coverity using if / else instead of switch, though it
does not affect code.

Fixes: #7257
CID: 185399

Signed-off-by: Andrei Emeltchenko <andrei.emeltchenko@intel.com>