### PR TITLE
 POSIX arch: Fix linker -T warning

### DIFF
--- a/arch/posix/CMakeLists.txt
+++ b/arch/posix/CMakeLists.txt
@@ -39,7 +39,3 @@ zephyr_ld_options(
 
 add_subdirectory(soc)
 add_subdirectory(core)
-
-# Override the flag used with linker.cmd
-# "-Wl,--just-symbols linker.cmd" instead of "-T linker.cmd"
-set_property(GLOBAL PROPERTY TOPT -Wl,--just-symbols)

--- a/include/arch/posix/linker.ld
+++ b/include/arch/posix/linker.ld
@@ -9,7 +9,7 @@
  * @file
  * @brief Linker command/script file
  *
- * Linker script for the Nios II platform
+ * Linker script for the POSIX (native) platform
  */
 
 #define _LINKER
@@ -25,13 +25,15 @@
 SECTIONS
  {
 
-/* Ideally we would have here the platform default linker script SECTIONS */
-/* content */
-
-
 #include <linker/common-rom.ld>
 
 #include <linker/common-ram.ld>
 
  __data_ram_end = .;
- }
+ } INSERT AFTER .data;
+
+/*
+ * Note that the INSERT command actually changes the meaning of the -T command
+ * line switch: The script will now augment the default SECTIONS instead of
+ * replacing it.
+ */

--- a/scripts/sanitycheck
+++ b/scripts/sanitycheck
@@ -834,8 +834,7 @@ class MakeGenerator:
         if self.deprecations:
             cflags = cflags + "  -Wno-deprecated-declarations"
 
-        if not "native_posix" in args:
-            ldflags="-Wl,--fatal-warnings"
+        ldflags="-Wl,--fatal-warnings"
 
         if options.ninja:
             generator = "Ninja"


### PR DESCRIPTION
Fix for the link waning "warning: zephyr/linker.cmd contains output sections; did you forget -T?" 
while building POSIX arch based boards.

Fixes: #5757 