### PR TITLE
net: icmpv6: Fix payload length and checksum

### DIFF
--- a/subsys/net/ip/icmpv6.c
+++ b/subsys/net/ip/icmpv6.c
@@ -537,6 +537,8 @@ int net_icmpv6_send_error(struct net_pkt *orig, u8_t type, u8_t code,
 	} else if (NET_IPV6_HDR(orig)->nexthdr == IPPROTO_TCP) {
 		extra_len = sizeof(struct net_ipv6_hdr) +
 			sizeof(struct net_tcp_hdr);
+	} else if (NET_IPV6_HDR(orig)->nexthdr == NET_IPV6_NEXTHDR_FRAG) {
+		extra_len = net_pkt_get_len(orig);
 	} else {
 		size_t space = CONFIG_NET_BUF_DATA_SIZE -
 			net_if_get_ll_reserve(iface,


### PR DESCRIPTION
With fragmentation disabled echo server responds to packet fragment with
ICMPv6 message Type: "Parameter Problem (4)", Code: "unrecognized Next
Header type encountered (1)". If a fragment with payload length 15 is
received in response sent by echo server IPv6 payload length and ICMPv6
checksum are wrong. This patch solves the issue by correcting payload
length.

Signed-off-by: Ruslan Mstoi <ruslan.mstoi@intel.com>