### PR TITLE
Fixed the coverity issue 185397

### DIFF
--- a/tests/net/ipv6_fragment/src/main.c
+++ b/tests/net/ipv6_fragment/src/main.c
@@ -473,18 +473,16 @@ static void test_setup(void)
 		zassert_not_null(ifaddr, "addr1");
 	}
 
-	/* For testing purposes we need to set the adddresses preferred */
-	ifaddr->addr_state = NET_ADDR_PREFERRED;
-
 	ifaddr = net_if_ipv6_addr_add(iface1, &ll_addr,
 				      NET_ADDR_MANUAL, 0);
 	if (!ifaddr) {
 		DBG("Cannot add IPv6 address %s\n",
 		       net_sprint_ipv6_addr(&ll_addr));
 		zassert_not_null(ifaddr, "ll_addr");
-	}
-
-	ifaddr->addr_state = NET_ADDR_PREFERRED;
+	} else {
+		/* For testing purposes we need to set the adddresses preferred */
+		ifaddr->addr_state = NET_ADDR_PREFERRED;
+        }
 
 	net_if_up(iface1);
 	net_if_up(iface2);


### PR DESCRIPTION
Fixed the coverity issue 185397 by assigning the ifaddr only when it is not NULL. It could have been also marked false positive as the "zassert.." would cause an assert if the pointer is NULL. However in future, if the code was made assert free just by changing definition of the "zassert.." macro, it could lead to crash. Hence fixed it to be assigned in else condition.

Signed-off-by: Paras Jain <parasjain2000@gmail.com>