### PR TITLE
doc: change https://zephyrproject.org/doc refs

### DIFF
--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -49,7 +49,7 @@ There are some imported or reused components of the Zephyr project that
 use other licensing, as described in `Zephyr Licensing`_.
 
 .. _Zephyr Licensing:
-   https://www.zephyrproject.org/doc/LICENSING.html
+   http://docs.zephyrproject.org/LICENSING.html
 
 Importing code into the Zephyr OS from other projects that use a license
 other than the Apache 2.0 license needs to be fully understood in
@@ -64,7 +64,7 @@ See `Contributing non-Apache 2.0 components`_ for more information about
 this contributing and review process for imported components.
 
 .. _Contributing non-Apache 2.0 components:
-   https://www.zephyrproject.org/doc/contribute/contribute_non-apache.html
+   http://docs.zephyrproject.org/contribute/contribute_non-apache.html
 
 .. _DCO:
 
@@ -138,7 +138,7 @@ and how to set up your development environment as introduced in the Zephyr
 `Getting Started Guide`_.
 
 .. _Getting Started Guide:
-   https://www.zephyrproject.org/doc/getting_started/getting_started.html
+   http://docs.zephyrproject.org/getting_started/getting_started.html
 
 You should be familiar with common developer tools such as Git and CMake, and
 platforms such as GitHub.
@@ -170,7 +170,7 @@ configurations, and a collection of subsystem tests.  All of these are
 available for developers to contribute to and enhance.
 
 .. _Source Tree Structure:
-   https://www.zephyrproject.org/doc/kernel/overview/source_tree.html
+   http://docs.zephyrproject.org/kernel/overview/source_tree.html
 
 Pull Requests and Issues
 ************************

--- a/README.rst
+++ b/README.rst
@@ -68,7 +68,7 @@ support systems:
 
 * **Documentation**: Extensive Project technical documentation is developed
   along with the Zephyr kernel itself, and can be found at
-  http://docs.zephyrproject.  Additional documentation is maintained in
+  http://docs.zephyrproject.org.  Additional documentation is maintained in
   the `Zephyr GitHub wiki`_.
 
 * **Cross-reference**: Source code cross-reference for the Zephyr
@@ -102,12 +102,12 @@ support systems:
   client or use a client-side application such as pidgin.
 
 
-.. _supported boards: https://www.zephyrproject.org/doc/boards/boards.html
-.. _Zephyr Introduction: https://www.zephyrproject.org/doc/introduction/introducing_zephyr.html
-.. _Getting Started Guide: https://www.zephyrproject.org/doc/getting_started/getting_started.html
-.. _Contribution Guide: https://www.zephyrproject.org/doc/contribute/contribute_guidelines.html
+.. _supported boards: http://docs.zephyrproject.org/boards/boards.html
+.. _Zephyr Introduction: http://docs.zephyrproject.org/introduction/introducing_zephyr.html
+.. _Getting Started Guide: http://docs.zephyrproject.org/getting_started/getting_started.html
+.. _Contribution Guide: http://docs.zephyrproject.org/contribute/contribute_guidelines.html
 .. _Zephyr GitHub wiki: https://github.com/zephyrproject-rtos/zephyr/wiki
 .. _Zephyr mailing lists: https://lists.zephyrproject.org/
 .. _Zephyr mailing list subgroups: https://lists.zephyrproject.org/g/main/subgroups
-.. _Sample and Demo Code Examples: https://www.zephyrproject.org/doc/samples/samples.html
-.. _Security Overview: https://www.zephyrproject.org/doc/security/security-overview.html
+.. _Sample and Demo Code Examples: http://docs.zephyrproject.org/samples/samples.html
+.. _Security Overview: http://docs.zephyrproject.org/security/security-overview.html

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -9,15 +9,15 @@ Zephyr Project Documentation
    Welcome to the Zephyr Project's documentation version |version|!
 
    Documentation for the development branch of Zephyr can be found at
-   https://www.zephyrproject.org/doc/
+   http://docs.zephyrproject.org/
 
 .. only:: (development or daily)
 
    Welcome to the Zephyr Project's documentation. This is the documentation of the
    master tree under development (version |version|).
 
-   Documentation for released versions of Zephyr can be found at
-   ``https://www.zephyrproject.org/doc/<version>``. The following documentation
+   Documentation for tagged released versions of Zephyr can be found at
+   ``http://docs.zephyrproject.org/<version>``. The following documentation
    versions are available:
 
    `Zephyr 1.5.0`_ | `Zephyr 1.6.1`_ | `Zephyr 1.7.1`_ | `Zephyr 1.8.0`_ |
@@ -63,10 +63,10 @@ Indices and Tables
 
 * :ref:`genindex`
 
-.. _Zephyr 1.11.0: https://www.zephyrproject.org/doc/1.11.0/
-.. _Zephyr 1.10.0: https://www.zephyrproject.org/doc/1.10.0/
-.. _Zephyr 1.9.2: https://www.zephyrproject.org/doc/1.9.0/
-.. _Zephyr 1.8.0: https://www.zephyrproject.org/doc/1.8.0/
-.. _Zephyr 1.7.1: https://www.zephyrproject.org/doc/1.7.0/
-.. _Zephyr 1.6.1: https://www.zephyrproject.org/doc/1.6.0/
-.. _Zephyr 1.5.0: https://www.zephyrproject.org/doc/1.5.0/
+.. _Zephyr 1.11.0: http://docs.zephyrproject.org/1.11.0/
+.. _Zephyr 1.10.0: http://docs.zephyrproject.org/1.10.0/
+.. _Zephyr 1.9.2: http://docs.zephyrproject.org/1.9.0/
+.. _Zephyr 1.8.0: http://docs.zephyrproject.org/1.8.0/
+.. _Zephyr 1.7.1: http://docs.zephyrproject.org/1.7.0/
+.. _Zephyr 1.6.1: http://docs.zephyrproject.org/1.6.0/
+.. _Zephyr 1.5.0: http://docs.zephyrproject.org/1.5.0/

--- a/doc/kernel/overview/source_tree.rst
+++ b/doc/kernel/overview/source_tree.rst
@@ -25,7 +25,7 @@ which are not described here.
 
 :file:`doc`
     Zephyr technical documentation source files and tools used to
-    generate the http://zephyrproject.org/doc web content.
+    generate the http://docs.zephyrproject.org web content.
 
 :file:`drivers`
     Device driver code.

--- a/doc/security/security-overview.rst
+++ b/doc/security/security-overview.rst
@@ -457,7 +457,7 @@ modules in all of its stages and the management of reported security
 issues. Furthermore, threat models need to be created for currently
 known and future attack vectors, and their impact on the system needs to
 be investigated and mitigated. Please refer to the
-`secure coding guidelines`_ outlined in the Zephyr project documentation
+:ref:`secure code` outlined in the Zephyr project documentation
 for detailed information.
 
 The software security process includes:
@@ -787,7 +787,5 @@ See :ref:`security-citations`
 .. _`RFC2119`: https://www.ietf.org/rfc/rfc2119.txt
 .. _`Application Thread Modeling`: https://www.owasp.org/index.php/Application_Threat_Modeling
 .. _`STRIDE`: https://msdn.microsoft.com/en-us/library/ee823878%28v=cs.20%29.aspx
-.. _`Zephyr Kernel subsystem documentation`: https://www.zephyrproject.org/doc/subsystems/subsystems.html
-.. _`secure coding guidelines`: https://www.zephyrproject.org/doc/contribute/security.html
 .. _`development model documentation`: https://github.com/zephyrproject-rtos/zephyr/wiki/Development-Model
 .. _`CVSS`: https://www.first.org/cvss/specification-document


### PR DESCRIPTION
Remove extra indirection to documentation (and required
server link redirection) from https://zephyrproject.org/doc/...
to http://docs.zephyrproject.org/...

Signed-off-by: David B. Kinder <david.b.kinder@intel.com>