### PR TITLE
x86: fix newlib with MMU enabled

### DIFF
--- a/include/arch/x86/linker.ld
+++ b/include/arch/x86/linker.ld
@@ -306,6 +306,7 @@ SECTIONS
 
 #include <linker/kobject.ld>
 
+	MMU_PAGE_ALIGN
 	__data_ram_end = .;
 
 	/* All unused memory also owned by the kernel for heaps */


### PR DESCRIPTION
newlib uses any RAM between _end and the bounds of physical
RAM for the _sbrk() heap. Set up a user-writable boot region
so that this works properly.

Signed-off-by: Andrew Boie <andrew.p.boie@intel.com>