### PR TITLE
sensors: ccs811: Implement sampling mode switching

### DIFF
--- a/drivers/sensor/ccs811/ccs811.h
+++ b/drivers/sensor/ccs811/ccs811.h
@@ -52,6 +52,7 @@ struct ccs811_data {
 	u8_t status;
 	u8_t error;
 	u16_t resistance;
+	u8_t mode;
 };
 
 #define SYS_LOG_DOMAIN "CCS811"

--- a/include/sensor.h
+++ b/include/sensor.h
@@ -228,6 +228,10 @@ enum sensor_attribute {
 	 * algorithms to calibrate itself on a certain axis, or all of them.
 	 */
 	SENSOR_ATTR_CALIB_TARGET,
+	/**
+	 * Sensor sampling interval in seconds.
+	 */
+	SENSOR_ATTR_SAMPLING_INTERVAL,
 };
 
 /**


### PR DESCRIPTION
CCS811 measurement mode selection is implemented with sensor attributes.
A new measurement interval sensor attribute is introduced.