### PR TITLE
tests: remove comma from whitelist

### DIFF
--- a/tests/subsys/settings/fcb/testcase.yaml
+++ b/tests/subsys/settings/fcb/testcase.yaml
@@ -1,4 +1,4 @@
 tests:
   system.settings.fcb:
-    platform_whitelist: nrf52840_pca10056, nrf52_pca10040
+    platform_whitelist: nrf52840_pca10056 nrf52_pca10040
     tags: settings_fcb

--- a/tests/subsys/settings/fcb_init/testcase.yaml
+++ b/tests/subsys/settings/fcb_init/testcase.yaml
@@ -1,4 +1,4 @@
 tests:
   system.settings.fcb:
-    platform_whitelist: nrf52840_pca10056, nrf52_pca10040
+    platform_whitelist: nrf52840_pca10056 nrf52_pca10040
     tags: settings_intialization_fcb

--- a/tests/subsys/settings/nffs/testcase.yaml
+++ b/tests/subsys/settings/nffs/testcase.yaml
@@ -1,4 +1,4 @@
 tests:
   system.settings.nffs:
-    platform_whitelist: nrf52840_pca10056, nrf52_pca10040
+    platform_whitelist: nrf52840_pca10056 nrf52_pca10040
     tags: settings_fs


### PR DESCRIPTION
items in platform_whitelist are not comma separated.

Signed-off-by: Anas Nashif <anas.nashif@intel.com>