### PR TITLE
Out of tree driver

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -340,14 +340,22 @@ add_custom_command(OUTPUT always_rebuild COMMAND cmake -E echo Building for boar
 set(syscall_list_h ${CMAKE_CURRENT_BINARY_DIR}/include/generated/syscall_list.h)
 set(syscalls_json  ${CMAKE_CURRENT_BINARY_DIR}/misc/generated/syscalls.json)
 
+list(APPEND SYSCALL_INCLUDE_DIRS ${PROJECT_SOURCE_DIR}/include)
+
+foreach(d ${SYSCALL_INCLUDE_DIRS})
+  list(APPEND parse_syscalls_include_args
+    --include ${d}
+    )
+endforeach()
+
 add_custom_command(
   OUTPUT
   ${syscalls_json}
   COMMAND
   ${PYTHON_EXECUTABLE}
   ${PROJECT_SOURCE_DIR}/scripts/parse_syscalls.py
-  --include          ${PROJECT_SOURCE_DIR}/include        # Read files from this dir
-  --json-file        ${syscalls_json}                     # Write this file
+  ${parse_syscalls_include_args}                  # Read files from these dirs
+  --json-file        ${syscalls_json}             # Write this file
   DEPENDS always_rebuild
   )
 

--- a/samples/application_development/out_of_tree_driver/CMakeLists.txt
+++ b/samples/application_development/out_of_tree_driver/CMakeLists.txt
@@ -1,0 +1,12 @@
+# Add an absolute directory path to the CMake variable
+# SYSCALL_INCLUDE_DIRS. This ensures that the syscall machinery will
+# be able to find application-defined syscalls.
+list(APPEND SYSCALL_INCLUDE_DIRS ${CMAKE_CURRENT_SOURCE_DIR}/src)
+
+include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
+project(NONE)
+
+target_sources(app PRIVATE
+  src/main.c
+  src/hello_world_driver.c
+  )

--- a/samples/application_development/out_of_tree_driver/prj.conf
+++ b/samples/application_development/out_of_tree_driver/prj.conf
@@ -1,0 +1,1 @@
+CONFIG_ASSERT=y

--- a/samples/application_development/out_of_tree_driver/sample.yaml
+++ b/samples/application_development/out_of_tree_driver/sample.yaml
@@ -1,0 +1,13 @@
+sample:
+  description: Sample that uses an out-of-tree driver
+  name: Out-of-tree driver
+tests:
+  drivers.out_of_tree:
+    tags: out_of_tree
+    harness: console
+    harness_config:
+      type: multi_line
+      regex:
+        - "Hello World from the app!"
+        - "device is (.*), name is CUSTOM_DRIVER"
+        - "Hello World from the kernel: 5"

--- a/samples/application_development/out_of_tree_driver/src/hello_world_driver.c
+++ b/samples/application_development/out_of_tree_driver/src/hello_world_driver.c
@@ -1,0 +1,34 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include "hello_world_driver.h"
+#include <zephyr/types.h>
+
+/**
+ * This is a minimal example of an out-of-tree driver
+ * implementation. See the header file of the same name for details.
+ */
+
+static struct hello_world_dev_data {
+	u32_t foo;
+} data;
+
+static int init(struct device *dev)
+{
+	data.foo = 5;
+
+	return 0;
+}
+
+static void print_impl(struct device *dev)
+{
+	printk("Hello World from the kernel: %d\n", data.foo);
+
+	__ASSERT(data.foo == 5, "Device was not initialized!");
+}
+
+DEVICE_AND_API_INIT(hello_world, "CUSTOM_DRIVER",
+		    init, &data, NULL,
+		    PRE_KERNEL_1, CONFIG_KERNEL_INIT_PRIORITY_DEVICE,
+		    &((struct hello_world_driver_api){ .print = print_impl }));

--- a/samples/application_development/out_of_tree_driver/src/hello_world_driver.h
+++ b/samples/application_development/out_of_tree_driver/src/hello_world_driver.h
@@ -1,0 +1,46 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ */
+#ifndef __HELLO_WORLD_DRIVER_H__
+#define __HELLO_WORLD_DRIVER_H__
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#include <device.h>
+
+/*
+ * This 'Hello World' driver has a 'print' syscall that prints the
+ * famous 'Hello World!' string.
+ *
+ * The string is formatted with some internal driver data to
+ * demonstrate that drivers are initialized during the boot process.
+ *
+ * The driver exists to demonstrate (and test) custom drivers that are
+ * maintained outside of Zephyr.
+ */
+
+struct hello_world_driver_api {
+	/* This struct has a member called 'print'. 'print' is function
+	 * pointer to a function that takes 'struct device *dev' as an
+	 * argument and returns 'void'.
+	 */
+	void (*print)(struct device *dev);
+};
+
+__syscall void hello_world_print(struct device *dev);
+static inline void _impl_hello_world_print(struct device *dev)
+{
+	const struct hello_world_driver_api *api = dev->driver_api;
+	__ASSERT(api->print, "Callback pointer should not be NULL");
+	api->print(dev);
+}
+
+#ifdef __cplusplus
+}
+#endif
+
+#include <syscalls/hello_world_driver.h>
+
+#endif /* __HELLO_WORLD_DRIVER_H__ */

--- a/samples/application_development/out_of_tree_driver/src/main.c
+++ b/samples/application_development/out_of_tree_driver/src/main.c
@@ -1,0 +1,20 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include "hello_world_driver.h"
+#include <stdio.h>
+#include <zephyr.h>
+
+void main(void)
+{
+	printk("Hello World from the app!\n");
+
+	struct device *dev = device_get_binding("CUSTOM_DRIVER");
+
+	__ASSERT(dev, "Failed to get device binding");
+
+	printk("device is %p, name is %s\n", dev, dev->config->name);
+
+	hello_world_print(dev);
+}

--- a/scripts/parse_syscalls.py
+++ b/scripts/parse_syscalls.py
@@ -9,6 +9,7 @@ import re
 import argparse
 import os
 import json
+from itertools import chain
 
 api_regex = re.compile(r'''
 __syscall\s+                    # __syscall attribute, must be first
@@ -94,10 +95,10 @@ def analyze_fn(match_group, fn):
     return (fn, handler, invocation, sys_id, table_entry)
 
 
-def analyze_headers(base_path):
+def analyze_headers(base_paths):
     ret = []
 
-    for root, dirs, files in os.walk(base_path):
+    for root, dirs, files in chain.from_iterable(os.walk(path) for path in base_paths):
         for fn in files:
 
             # toolchain/common.h has the definition of __syscall which we
@@ -125,7 +126,7 @@ def parse_args():
         description=__doc__,
         formatter_class=argparse.RawDescriptionHelpFormatter)
 
-    parser.add_argument("-i", "--include", required=True,
+    parser.add_argument("-i", "--include", required=True, action='append',
                         help="Base include directory")
     parser.add_argument(
         "-j", "--json-file", required=True,


### PR DESCRIPTION
This PR implements support for declaring syscall's out-of-tree and introduces a sample for demonstration and verification purposes.

To declare syscall's out of tree the user directs the Zephyr build system to directories where syscall's are declared through the use of a CMake variable.

To make this functionality self-documenting it was considered and then dismissed to use a Kconfig option. It was decided that CMake variables give greater flexibility in how paths can be constructed and that this functionality is inherently a build-system technical aspect.

This resolves #5554 