### PR TITLE
tests: fp_sharing: Fix definition of PI_NUM_ITERATIONS

### DIFF
--- a/tests/kernel/fp_sharing/CMakeLists.txt
+++ b/tests/kernel/fp_sharing/CMakeLists.txt
@@ -6,7 +6,9 @@ project(NONE)
 # compensate for this, one can control the number of iterations in the PI
 # calculation through PI_NUM_ITERATIONS. Lowering this value will increase
 # the speed of the test but it will come at the expense of precision.
-zephyr_compile_definitions(PI_NUM_ITERATIONS=700000)
+
+set_ifndef(PI_NUM_ITERATIONS 700000)
+zephyr_compile_definitions(PI_NUM_ITERATIONS=${PI_NUM_ITERATIONS})
 
 FILE(GLOB app_sources src/*.c)
 target_sources(app PRIVATE ${app_sources})


### PR DESCRIPTION
The fp_sharing test has an option to control the number of iterations in
the pi calculation, which is used to adjust the duration of the test on
different platforms that may have significantly different execution
frequencies (e.g., qemu_x86 vs. frdm_k64f). The conversion to CMake did
not handle this option correctly and forced the same value for all
platforms.

The test now completes in about 5 minutes on frdm_k64f.

Signed-off-by: Maureen Helm <maureen.helm@nxp.com>

Fixes #7033 