### PR TITLE
drivers: pwm: Add shim for nrfx PWM HW driver

### DIFF
--- a/drivers/pwm/CMakeLists.txt
+++ b/drivers/pwm/CMakeLists.txt
@@ -5,6 +5,7 @@ zephyr_library_sources_ifdef(CONFIG_PWM_DW		pwm_dw.c)
 zephyr_library_sources_ifdef(CONFIG_PWM_QMSI		pwm_qmsi.c)
 zephyr_library_sources_ifdef(CONFIG_PWM_STM32		pwm_stm32.c)
 zephyr_library_sources_ifdef(CONFIG_PWM_NRF5_SW		pwm_nrf5_sw.c)
+zephyr_library_sources_ifdef(CONFIG_PWM_NRFX		pwm_nrfx.c)
 zephyr_library_sources_ifdef(CONFIG_PWM_MCUX_FTM 	pwm_mcux_ftm.c)
 zephyr_library_sources_ifdef(CONFIG_PWM_LED_ESP32	pwm_led_esp32.c)
 

--- a/drivers/pwm/Kconfig
+++ b/drivers/pwm/Kconfig
@@ -55,6 +55,8 @@ source "drivers/pwm/Kconfig.stm32"
 
 source "drivers/pwm/Kconfig.nrf5_sw"
 
+source "drivers/pwm/Kconfig.nrfx"
+
 source "drivers/pwm/Kconfig.mcux_ftm"
 
 source "drivers/pwm/Kconfig.esp32"

--- a/drivers/pwm/Kconfig.nrfx
+++ b/drivers/pwm/Kconfig.nrfx
@@ -1,0 +1,299 @@
+# Copyright (c) 2018, Cue Health Inc
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+
+menuconfig PWM_NRFX
+	bool "nRF PWM nrfx driver"
+	depends on SOC_SERIES_NRF52X
+	help
+	  Enable support for nrfx Hardware PWM driver for nRF52 MCU series.
+
+if PWM_NRFX
+
+if PWM_0
+
+config PWM_0_NAME
+	string "PWM module 0 device name"
+	default "PWM_0"
+	help
+	  Specify the device name for the Nordic Semiconductor nRF52 series HW
+	  PWM module 0.
+
+config PWM_0_NRF_CLOCK_PRESCALER
+	int "Clock prescaler"
+	range 0 7
+	default 0
+	help
+	  Clock = 16MHz / (2^prescaler).
+
+config PWM_0_NRF_CH0_PIN
+	int "CH0 pin number"
+	range -1 47 if SOC_NRF52840_QIAA
+	range -1 31
+	default -1
+	help
+	  GPIO pin number to use for CH0 (set to -1 if not used).
+
+config PWM_0_NRF_CH0_INVERTED
+	bool "CH0 inverted"
+	help
+	  Inverses the polarity.
+
+config PWM_0_NRF_CH1_PIN
+	int "CH1 pin number"
+	range -1 47 if SOC_NRF52840_QIAA
+	range -1 31
+	default -1
+	help
+	  GPIO pin number to use for CH1 (set to -1 if not used).
+
+config PWM_0_NRF_CH1_INVERTED
+	bool "CH1 inverted"
+	default n
+	help
+	  Inverses the polarity.
+
+config PWM_0_NRF_CH2_PIN
+	int "CH2 pin number"
+	range -1 47 if SOC_NRF52840_QIAA
+	range -1 31
+	default -1
+	help
+	  GPIO pin number to use for CH2 (set to -1 if not used).
+
+config PWM_0_NRF_CH2_INVERTED
+	bool "CH2 inverted"
+	help
+	  Inverses the polarity.
+
+config PWM_0_NRF_CH3_PIN
+	int "CH3 pin number"
+	range -1 47 if SOC_NRF52840_QIAA
+	range -1 31
+	default -1
+	help
+	  GPIO pin number to use for CH3 (set to -1 if not used).
+
+config PWM_0_NRF_CH3_INVERTED
+	bool "CH3 Inverted"
+	help
+	  Inverses the polarity.
+
+endif # PWM_0
+
+if PWM_1
+
+config PWM_1_NAME
+	string "PWM module 1 device name"
+	default "PWM_1"
+	help
+	  Specify the device name for the Nordic Semiconductor nRF52 series HW
+	  PWM module 1.
+
+config PWM_1_NRF_CLOCK_PRESCALER
+	int "Clock prescaler"
+	range 0 7
+	default 0
+	help
+	  Clock = 16MHz / (2^prescaler).
+
+config PWM_1_NRF_CH0_PIN
+	int "CH0 pin number"
+	range -1 47 if SOC_NRF52840_QIAA
+	range -1 31
+	default -1
+	help
+	  GPIO pin number to use for CH0
+
+config PWM_1_NRF_CH0_INVERTED
+	bool "CH0 inverted"
+	help
+	  Inverses the polarity.
+
+config PWM_1_NRF_CH1_PIN
+	int "CH1 pin number"
+	range -1 47 if SOC_NRF52840_QIAA
+	range -1 31
+	default -1
+	help
+	  GPIO pin number to use for CH1 (set to -1 if not used).
+
+config PWM_1_NRF_CH1_INVERTED
+	bool "CH1 inverted"
+	default n
+	help
+	  Inverses the polarity.
+
+config PWM_1_NRF_CH2_PIN
+	int "CH2 pin number"
+	range -1 47 if SOC_NRF52840_QIAA
+	range -1 31
+	default -1
+	help
+	  GPIO pin number to use for CH2 (set to -1 if not used).
+
+config PWM_1_NRF_CH2_INVERTED
+	bool "CH2 inverted"
+	help
+	  Inverses the polarity.
+
+config PWM_1_NRF_CH3_PIN
+	int "CH3 pin number"
+	range -1 47 if SOC_NRF52840_QIAA
+	range -1 31
+	default -1
+	help
+	  GPIO pin number to use for CH3 (set to -1 if not used).
+
+config PWM_1_NRF_CH3_INVERTED
+	bool "CH3 Inverted"
+	help
+	  Inverses the polarity.
+
+endif # PWM_1
+
+
+if PWM_2
+
+config PWM_2_NAME
+	string "PWM module 2 device name"
+	default "PWM_2"
+	help
+	  Specify the device name for the Nordic Semiconductor nRF52 series HW
+	  PWM module 2.
+
+config PWM_2_NRF_CLOCK_PRESCALER
+	int "Clock prescaler"
+	range 0 7
+	default 0
+	help
+	  Clock = 16MHz / (2^prescaler).
+
+config PWM_2_NRF_CH0_PIN
+	int "CH0 pin number"
+	range -1 47 if SOC_NRF52840_QIAA
+	range -1 31
+	default -1
+	help
+	  GPIO pin number to use for CH0 (set to -1 if not used).
+
+config PWM_2_NRF_CH0_INVERTED
+	bool "CH0 inverted"
+	help
+	  Inverses the polarity.
+
+config PWM_2_NRF_CH1_PIN
+	int "CH1 pin number"
+	range -1 47 if SOC_NRF52840_QIAA
+	range -1 31
+	default -1
+	help
+	  GPIO pin number to use for CH1 (set to -1 if not used).
+
+config PWM_2_NRF_CH1_INVERTED
+	bool "CH1 inverted"
+	default n
+	help
+	  Inverses the polarity.
+
+config PWM_2_NRF_CH2_PIN
+	int "CH2 pin number"
+	range -1 47 if SOC_NRF52840_QIAA
+	range -1 31
+	default -1
+	help
+	  GPIO pin number to use for CH2 (set to -1 if not used).
+
+config PWM_2_NRF_CH2_INVERTED
+	bool "CH2 inverted"
+	help
+	  Inverses the polarity.
+
+config PWM_2_NRF_CH3_PIN
+	int "CH3 pin number"
+	range -1 47 if SOC_NRF52840_QIAA
+	range -1 31
+	default -1
+	help
+	  GPIO pin number to use for CH3 (set to -1 if not used).
+
+config PWM_2_NRF_CH3_INVERTED
+	bool "CH3 Inverted"
+	help
+	  Inverses the polarity.
+
+endif # PWM_2
+
+if PWM_3
+
+config PWM_3_NAME
+	string "PWM module 3 device name"
+	default "PWM_3"
+	help
+	  Specify the device name for the Nordic Semiconductor nRF52 series HW
+	  PWM module 3.
+
+config PWM_3_NRF_CLOCK_PRESCALER
+	int "Clock prescaler"
+	range 0 7
+	default 0
+	help
+	  Clock = 16MHz / (2^prescaler).
+
+config PWM_3_NRF_CH0_PIN
+	int "CH0 pin number"
+	range -1 47 if SOC_NRF52840_QIAA
+	range -1 31
+	default -1
+	help
+	  GPIO pin number to use for CH0 (set to -1 if not used).
+
+config PWM_3_NRF_CH0_INVERTED
+	bool "CH0 inverted"
+	help
+	  Inverses the polarity.
+
+config PWM_3_NRF_CH1_PIN
+	int "CH1 pin number"
+	range -1 47 if SOC_NRF52840_QIAA
+	range -1 31
+	default -1
+	help
+	  GPIO pin number to use for CH1.
+
+config PWM_3_NRF_CH1_INVERTED
+	bool "CH1 inverted"
+	default n
+	help
+	  Inverses the polarity.
+
+config PWM_3_NRF_CH2_PIN
+	int "CH2 pin number"
+	range -1 47 if SOC_NRF52840_QIAA
+	range -1 31
+	default -1
+	help
+	  GPIO pin number to use for CH2 (set to -1 if not used).
+
+config PWM_3_NRF_CH2_INVERTED
+	bool "CH2 inverted"
+	help
+	  Inverses the polarity.
+
+config PWM_3_NRF_CH3_PIN
+	int "CH3 pin number"
+	range -1 47 if SOC_NRF52840_QIAA
+	range -1 31
+	default -1
+	help
+	  GPIO pin number to use for CH3 (set to -1 if not used).
+
+config PWM_3_NRF_CH3_INVERTED
+	bool "CH3 Inverted"
+	help
+	  Inverses the polarity.
+
+endif # PWM_3
+
+endif # PWM_NRFX

--- a/drivers/pwm/pwm_nrfx.c
+++ b/drivers/pwm/pwm_nrfx.c
@@ -1,0 +1,232 @@
+/*
+ * Copyright (c) 2018, Cue Health Inc
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+#include <nrfx_pwm.h>
+#include <pwm.h>
+
+#define SYS_LOG_DOMAIN "pwm_nrfx"
+#define SYS_LOG_LEVEL CONFIG_SYS_LOG_PWM_LEVEL
+#include <logging/sys_log.h>
+
+#define PWM_NRFX_CH_VALUE_NORMAL        (1UL << 15)
+#define PWM_NRFX_CH_VALUE_INVERTED      (0)
+
+struct pwm_nrfx_config {
+	nrfx_pwm_t pwm;
+	nrfx_pwm_config_t config;
+	nrf_pwm_sequence_t seq;
+};
+
+struct pwm_nrfx_data {
+	u16_t current[NRF_PWM_CHANNEL_COUNT];
+	u16_t top_value;
+};
+
+static int pwm_nrfx_pin_set(struct device *dev, u32_t pwm,
+			    u32_t period_cycles, u32_t pulse_cycles)
+{
+	const struct pwm_nrfx_config *pconfig = dev->config->config_info;
+	struct pwm_nrfx_data *pdata = dev->driver_data;
+
+	if (pwm >= NRF_PWM_CHANNEL_COUNT) {
+		return -EINVAL;
+	}
+
+	if (period_cycles != pdata->top_value) {
+		if (period_cycles > PWM_COUNTERTOP_COUNTERTOP_Msk) {
+			return -EINVAL;
+		}
+
+		pdata->top_value = period_cycles;
+		nrf_pwm_configure(pconfig->pwm.p_registers,
+				  pconfig->config.base_clock,
+				  pconfig->config.count_mode,
+				  pdata->top_value);
+	}
+
+	if (pulse_cycles > pdata->top_value) {
+		return -EINVAL;
+	}
+
+	/* Modify only the COMPARE bits while preserving the POLARITY
+	 * bit that controls the inversion of the channel.
+	 * For more details see product specification.
+	 */
+	pdata->current[pwm] = ((pdata->current[pwm]
+				& ~PWM_COUNTERTOP_COUNTERTOP_Msk)
+				| pulse_cycles);
+
+	return 0;
+}
+
+static int pwm_nrfx_get_cycles_per_sec(struct device *dev, u32_t pwm,
+				       u64_t *cycles)
+{
+	const struct pwm_nrfx_config *pconfig = dev->config->config_info;
+
+	switch (pconfig->config.base_clock) {
+	case NRF_PWM_CLK_16MHz:
+		*cycles = 16ul * 1000ul * 1000ul;
+		break;
+	case NRF_PWM_CLK_8MHz:
+		*cycles = 8ul * 1000ul * 1000ul;
+		break;
+	case NRF_PWM_CLK_4MHz:
+		*cycles = 4ul * 1000ul * 1000ul;
+		break;
+	case NRF_PWM_CLK_2MHz:
+		*cycles = 2ul * 1000ul * 1000ul;
+		break;
+	case NRF_PWM_CLK_1MHz:
+		*cycles = 1ul * 1000ul * 1000ul;
+		break;
+	case NRF_PWM_CLK_500kHz:
+		*cycles = 500ul * 1000ul;
+		break;
+	case NRF_PWM_CLK_250kHz:
+		*cycles = 250ul * 1000ul;
+		break;
+	case NRF_PWM_CLK_125kHz:
+		*cycles = 125ul * 1000ul;
+		break;
+	}
+	return 0;
+}
+
+static const struct pwm_driver_api pwm_nrfx_drv_api_funcs = {
+	.pin_set = pwm_nrfx_pin_set,
+	.get_cycles_per_sec = pwm_nrfx_get_cycles_per_sec,
+};
+
+static int pwm_nrfx_init(struct device *dev)
+{
+	const struct pwm_nrfx_config *pconfig = dev->config->config_info;
+
+	nrfx_err_t result = nrfx_pwm_init(&pconfig->pwm, &pconfig->config,
+					  NULL);
+
+	if (result != NRFX_SUCCESS) {
+		SYS_LOG_ERR("Failed to initialize device: %s",
+			    dev->config->name);
+		return -EBUSY;
+	}
+
+	nrfx_pwm_simple_playback(&pconfig->pwm,
+				 &pconfig->seq,
+				 1,
+				 NRFX_PWM_FLAG_LOOP);
+
+	return 0;
+}
+
+
+#define PWM_NRFX_OUTPUT_PIN(dev_idx, ch_idx)		     \
+	(CONFIG_PWM_##dev_idx##_NRF_CH##ch_idx##_PIN |	     \
+	 (CONFIG_PWM_##dev_idx##_NRF_CH##ch_idx##_INVERTED ? \
+	  NRFX_PWM_PIN_INVERTED : 0))
+
+#define PWM_NRFX_DEFAULT_VALUE(dev_idx, ch_idx)		    \
+	(CONFIG_PWM_##dev_idx##_NRF_CH##ch_idx##_INVERTED ? \
+	 PWM_NRFX_CH_VALUE_INVERTED : PWM_NRFX_CH_VALUE_NORMAL)
+
+#define PWM_NRFX_DEVICE(idx)						      \
+	static struct pwm_nrfx_data pwm_nrfx_##idx##_data = {		      \
+		.current = {						      \
+			PWM_NRFX_DEFAULT_VALUE(idx, 0),			      \
+			PWM_NRFX_DEFAULT_VALUE(idx, 1),			      \
+			PWM_NRFX_DEFAULT_VALUE(idx, 2),			      \
+			PWM_NRFX_DEFAULT_VALUE(idx, 3),			      \
+		},							      \
+		.top_value = NRFX_PWM_DEFAULT_CONFIG_TOP_VALUE		      \
+	};								      \
+	static const struct pwm_nrfx_config pwm_nrfx_##idx##_config = {	      \
+		.pwm = NRFX_PWM_INSTANCE(idx),				      \
+		.config = {						      \
+			.output_pins = {				      \
+				PWM_NRFX_OUTPUT_PIN(idx, 0),		      \
+				PWM_NRFX_OUTPUT_PIN(idx, 1),		      \
+				PWM_NRFX_OUTPUT_PIN(idx, 2),		      \
+				PWM_NRFX_OUTPUT_PIN(idx, 3),		      \
+			},						      \
+			.base_clock = (nrf_pwm_clk_t)			      \
+				      CONFIG_PWM_##idx##_NRF_CLOCK_PRESCALER, \
+			.count_mode = NRF_PWM_MODE_UP,			      \
+			.top_value = NRFX_PWM_DEFAULT_CONFIG_TOP_VALUE,	      \
+			.load_mode = NRF_PWM_LOAD_INDIVIDUAL,		      \
+			.step_mode = NRF_PWM_STEP_TRIGGERED,		      \
+		},							      \
+		.seq.values.p_raw = pwm_nrfx_##idx##_data.current,	      \
+		.seq.length = NRF_PWM_CHANNEL_COUNT			      \
+	};								      \
+									      \
+	DEVICE_AND_API_INIT(pwm_nrfx_##idx, CONFIG_PWM_##idx##_NAME,	      \
+			    pwm_nrfx_init, &pwm_nrfx_##idx##_data,	      \
+			    &pwm_nrfx_##idx##_config,			      \
+			    POST_KERNEL, CONFIG_KERNEL_INIT_PRIORITY_DEVICE,  \
+			    &pwm_nrfx_drv_api_funcs)
+
+#ifdef CONFIG_PWM_0
+#ifndef CONFIG_PWM_0_NRF_CH0_INVERTED
+#define CONFIG_PWM_0_NRF_CH0_INVERTED 0
+#endif
+#ifndef CONFIG_PWM_0_NRF_CH1_INVERTED
+#define CONFIG_PWM_0_NRF_CH1_INVERTED 0
+#endif
+#ifndef CONFIG_PWM_0_NRF_CH2_INVERTED
+#define CONFIG_PWM_0_NRF_CH2_INVERTED 0
+#endif
+#ifndef CONFIG_PWM_0_NRF_CH3_INVERTED
+#define CONFIG_PWM_0_NRF_CH3_INVERTED 0
+#endif
+PWM_NRFX_DEVICE(0);
+#endif
+
+#ifdef CONFIG_PWM_1
+#ifndef CONFIG_PWM_1_NRF_CH0_INVERTED
+#define CONFIG_PWM_1_NRF_CH0_INVERTED 0
+#endif
+#ifndef CONFIG_PWM_1_NRF_CH1_INVERTED
+#define CONFIG_PWM_1_NRF_CH1_INVERTED 0
+#endif
+#ifndef CONFIG_PWM_1_NRF_CH2_INVERTED
+#define CONFIG_PWM_1_NRF_CH2_INVERTED 0
+#endif
+#ifndef CONFIG_PWM_1_NRF_CH3_INVERTED
+#define CONFIG_PWM_1_NRF_CH3_INVERTED 0
+#endif
+PWM_NRFX_DEVICE(1);
+#endif
+
+#ifdef CONFIG_PWM_2
+#ifndef CONFIG_PWM_2_NRF_CH0_INVERTED
+#define CONFIG_PWM_2_NRF_CH0_INVERTED 0
+#endif
+#ifndef CONFIG_PWM_2_NRF_CH1_INVERTED
+#define CONFIG_PWM_2_NRF_CH1_INVERTED 0
+#endif
+#ifndef CONFIG_PWM_2_NRF_CH2_INVERTED
+#define CONFIG_PWM_2_NRF_CH2_INVERTED 0
+#endif
+#ifndef CONFIG_PWM_2_NRF_CH3_INVERTED
+#define CONFIG_PWM_2_NRF_CH3_INVERTED 0
+#endif
+PWM_NRFX_DEVICE(2);
+#endif
+
+#ifdef CONFIG_PWM_3
+#ifndef CONFIG_PWM_3_NRF_CH0_INVERTED
+#define CONFIG_PWM_3_NRF_CH0_INVERTED 0
+#endif
+#ifndef CONFIG_PWM_3_NRF_CH1_INVERTED
+#define CONFIG_PWM_3_NRF_CH1_INVERTED 0
+#endif
+#ifndef CONFIG_PWM_3_NRF_CH2_INVERTED
+#define CONFIG_PWM_3_NRF_CH2_INVERTED 0
+#endif
+#ifndef CONFIG_PWM_3_NRF_CH3_INVERTED
+#define CONFIG_PWM_3_NRF_CH3_INVERTED 0
+#endif
+PWM_NRFX_DEVICE(3);
+#endif

--- a/ext/hal/nordic/Kconfig
+++ b/ext/hal/nordic/Kconfig
@@ -9,6 +9,9 @@ config HAS_NORDIC_DRIVERS
 
 config HAS_NRFX
 	bool
+	
+config NRFX_PWM
+	bool
 
 config NRFX_SPI
 	bool

--- a/ext/hal/nordic/nrfx_config_nrf52832.h
+++ b/ext/hal/nordic/nrfx_config_nrf52832.h
@@ -956,28 +956,28 @@
 
 // <e> NRFX_PWM_ENABLED - nrfx_pwm - PWM peripheral driver
 //==========================================================
-#ifndef NRFX_PWM_ENABLED
-#define NRFX_PWM_ENABLED 0
+#ifdef CONFIG_NRFX_PWM
+#define NRFX_PWM_ENABLED 1
 #endif
 // <q> NRFX_PWM0_ENABLED  - Enable PWM0 instance
 
 
-#ifndef NRFX_PWM0_ENABLED
-#define NRFX_PWM0_ENABLED 0
+#ifdef CONFIG_PWM_0
+#define NRFX_PWM0_ENABLED 1
 #endif
 
 // <q> NRFX_PWM1_ENABLED  - Enable PWM1 instance
 
 
-#ifndef NRFX_PWM1_ENABLED
-#define NRFX_PWM1_ENABLED 0
+#ifdef CONFIG_PWM_1
+#define NRFX_PWM1_ENABLED 1
 #endif
 
 // <q> NRFX_PWM2_ENABLED  - Enable PWM2 instance
 
 
-#ifndef NRFX_PWM2_ENABLED
-#define NRFX_PWM2_ENABLED 0
+#ifdef CONFIG_PWM_2
+#define NRFX_PWM2_ENABLED 1
 #endif
 
 // <o> NRFX_PWM_DEFAULT_CONFIG_OUT0_PIN - Out0 pin  <0-31>

--- a/ext/hal/nordic/nrfx_config_nrf52840.h
+++ b/ext/hal/nordic/nrfx_config_nrf52840.h
@@ -956,35 +956,35 @@
 
 // <e> NRFX_PWM_ENABLED - nrfx_pwm - PWM peripheral driver
 //==========================================================
-#ifndef NRFX_PWM_ENABLED
-#define NRFX_PWM_ENABLED 0
+#ifndef CONFIG_NRFX_PWM
+#define NRFX_PWM_ENABLED 1
 #endif
 // <q> NRFX_PWM0_ENABLED  - Enable PWM0 instance
 
 
-#ifndef NRFX_PWM0_ENABLED
-#define NRFX_PWM0_ENABLED 0
+#ifndef CONFIG_PWM_0
+#define NRFX_PWM0_ENABLED 1
 #endif
 
 // <q> NRFX_PWM1_ENABLED  - Enable PWM1 instance
 
 
-#ifndef NRFX_PWM1_ENABLED
-#define NRFX_PWM1_ENABLED 0
+#ifndef CONFIG_PWM_1
+#define NRFX_PWM1_ENABLED 1
 #endif
 
 // <q> NRFX_PWM2_ENABLED  - Enable PWM2 instance
 
 
-#ifndef NRFX_PWM2_ENABLED
-#define NRFX_PWM2_ENABLED 0
+#ifndef CONFIG_PWM_2
+#define NRFX_PWM2_ENABLED 1
 #endif
 
 // <q> NRFX_PWM3_ENABLED  - Enable PWM3 instance
 
 
-#ifndef NRFX_PWM3_ENABLED
-#define NRFX_PWM3_ENABLED 0
+#ifndef CONFIG_PWM_3
+#define NRFX_PWM3_ENABLED 1
 #endif
 
 // <o> NRFX_PWM_DEFAULT_CONFIG_OUT0_PIN - Out0 pin  <0-31>


### PR DESCRIPTION
Adds a translation layer to make the nrfx driver for nrf52 PWM
peripheral accessible via the Zephyr's API.

Signed-off-by: Justin DeMartino <jdemarti@gmail.com>