### PR TITLE
tests : ipv6_fragment : Avoid NULL pointer access

### DIFF
--- a/tests/net/ipv6_fragment/src/main.c
+++ b/tests/net/ipv6_fragment/src/main.c
@@ -473,18 +473,16 @@ static void test_setup(void)
 		zassert_not_null(ifaddr, "addr1");
 	}
 
-	/* For testing purposes we need to set the adddresses preferred */
-	ifaddr->addr_state = NET_ADDR_PREFERRED;
-
 	ifaddr = net_if_ipv6_addr_add(iface1, &ll_addr,
 				      NET_ADDR_MANUAL, 0);
 	if (!ifaddr) {
 		DBG("Cannot add IPv6 address %s\n",
 		       net_sprint_ipv6_addr(&ll_addr));
 		zassert_not_null(ifaddr, "ll_addr");
+	} else {
+		/* we need to set the adddresses preferred */
+		ifaddr->addr_state = NET_ADDR_PREFERRED;
 	}
-
-	ifaddr->addr_state = NET_ADDR_PREFERRED;
 
 	net_if_up(iface1);
 	net_if_up(iface2);


### PR DESCRIPTION
Assign the pointer only when it is not NULL.

It could have been marked as false positive as the "zassert.." will assert in case of NULL pointer. However if in future, to make the code assert free, if the "zassert.." define is changed, it could cause crash. Hence assigning it on when pointer is not NULL.  Fixes SA 185397.

Fixes #7259 

Signed-off-by: Paras Jain <parasjain2000@gmail.com>