### PR TITLE
multigit: support external modules outside of zephyr [RFC]

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -317,6 +317,16 @@ add_subdirectory(misc)
 # property which is set implicitly for custom command outputs
 include(misc/generated/CMakeLists.txt)
 add_subdirectory(boards)
+
+FILE(GLOB_RECURSE EXT_MODULES ${CONTAINER_DIR}/modules/*/module.yml)
+FILE(GLOB_RECURSE EXT_HALS ${CONTAINER_DIR}/hals/*/module.yml)
+set(modules ${EXT_MODULES} ${EXT_HALS})
+foreach(module_file ${modules})
+  get_filename_component(module_dir ${module_file} DIRECTORY)
+  string(REPLACE ${CONTAINER_DIR}/ "" MODULE_BINARY_DIR ${module_dir})
+  add_subdirectory(${module_dir} ${MODULE_BINARY_DIR})
+endforeach(module_file)
+
 add_subdirectory(ext)
 add_subdirectory(subsys)
 add_subdirectory(drivers)

--- a/Kconfig.zephyr
+++ b/Kconfig.zephyr
@@ -18,6 +18,10 @@ config ENV_VAR_SYM_ARCH
 	string
 	option env="ENV_VAR_ARCH"
 
+config ENV_VAR_SYM_CONTAINER_DIR
+        string
+        option env="ENV_VAR_CONTAINER_DIR"
+
 source "arch/Kconfig"
 
 source "kernel/Kconfig"
@@ -33,6 +37,9 @@ source "lib/Kconfig"
 source "subsys/Kconfig"
 
 source "ext/Kconfig"
+
+source "$ENV_VAR_SYM_CONTAINER_DIR/hal/*/Kconfig.module"
+source "$ENV_VAR_SYM_CONTAINER_DIR/modules/*/Kconfig.module"
 
 source "tests/Kconfig"
 

--- a/cmake/app/boilerplate.cmake
+++ b/cmake/app/boilerplate.cmake
@@ -73,6 +73,7 @@ set(__build_dir ${CMAKE_CURRENT_BINARY_DIR}/zephyr)
 
 set(PROJECT_BINARY_DIR ${__build_dir})
 set(PROJECT_SOURCE_DIR $ENV{ZEPHYR_BASE})
+get_filename_component(CONTAINER_DIR ${PROJECT_SOURCE_DIR} DIRECTORY)
 
 # Convert path to use the '/' separator
 string(REPLACE "\\" "/" PROJECT_SOURCE_DIR ${PROJECT_SOURCE_DIR})

--- a/cmake/kconfig.cmake
+++ b/cmake/kconfig.cmake
@@ -41,6 +41,8 @@ set(COMMAND_RUNS_ON_WIN_pymenuconfig 1)
 set(ENV{ENV_VAR_ARCH}         ${ARCH})
 set(ENV{ENV_VAR_BOARD_DIR}    ${BOARD_DIR})
 
+set(ENV{ENV_VAR_CONTAINER_DIR} ${CONTAINER_DIR})
+
 foreach(kconfig_target ${kconfig_target_list})
   if ((NOT WIN32) OR (DEFINED COMMAND_RUNS_ON_WIN_${kconfig_target}))
     add_custom_target(


### PR DESCRIPTION
Support modules outside of the Zephyr tree. This is the first step for
supporting multigit feature.

Modules and HALs in this setup are hosted at the same level as the
zephyr tree:

   zephyr/
   modules/
   hals/

Each module should have at least the following files:

   module.yml
   CMakeLists.txt
   Kconfig.module

module.yml is for module meta-data such as license, url, details, etc.

Signed-off-by: Anas Nashif <anas.nashif@intel.com>