### PR TITLE
drivers: led: Add system call handler support

### DIFF
--- a/drivers/led/CMakeLists.txt
+++ b/drivers/led/CMakeLists.txt
@@ -1,1 +1,3 @@
 zephyr_sources_ifdef(CONFIG_LP3943 lp3943.c)
+
+zephyr_sources_ifdef(CONFIG_USERSPACE   led_handlers.c)

--- a/drivers/led/led_handlers.c
+++ b/drivers/led/led_handlers.c
@@ -1,0 +1,33 @@
+/*
+ * Copyright (c) 2018 Linaro Ltd.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <syscall_handler.h>
+#include <led.h>
+
+_SYSCALL_HANDLER(led_blink, dev, led, delay_on, delay_off)
+{
+	_SYSCALL_DRIVER_LED(dev, blink);
+	return _impl_led_blink((struct device *)dev, led, delay_on,
+					delay_off);
+}
+
+_SYSCALL_HANDLER(led_set_brightness, dev, led, value)
+{
+	_SYSCALL_DRIVER_LED(dev, set_brightness);
+	return _impl_led_set_brightness((struct device *)dev, led, value);
+}
+
+_SYSCALL_HANDLER(led_on, dev, led)
+{
+	_SYSCALL_DRIVER_LED(dev, on);
+	return _impl_led_on((struct device *)dev, led);
+}
+
+_SYSCALL_HANDLER(led_off, dev, led)
+{
+	_SYSCALL_DRIVER_LED(dev, off);
+	return _impl_led_off((struct device *)dev, led);
+}

--- a/include/led.h
+++ b/include/led.h
@@ -71,7 +71,10 @@ struct led_driver_api {
  * @param delay_off Time period (in milliseconds) an LED should be OFF
  * @return 0 on success, negative on error
  */
-static inline int led_blink(struct device *dev, u32_t led,
+__syscall int led_blink(struct device *dev, u32_t led,
+			    u32_t delay_on, u32_t delay_off);
+
+static inline int _impl_led_blink(struct device *dev, u32_t led,
 			    u32_t delay_on, u32_t delay_off)
 {
 	const struct led_driver_api *api = dev->driver_api;
@@ -90,7 +93,10 @@ static inline int led_blink(struct device *dev, u32_t led,
  * @param value Brightness value to set in percent
  * @return 0 on success, negative on error
  */
-static inline int led_set_brightness(struct device *dev, u32_t led,
+__syscall int led_set_brightness(struct device *dev, u32_t led,
+				     u8_t value);
+
+static inline int _impl_led_set_brightness(struct device *dev, u32_t led,
 				     u8_t value)
 {
 	const struct led_driver_api *api = dev->driver_api;
@@ -107,7 +113,9 @@ static inline int led_set_brightness(struct device *dev, u32_t led,
  * @param led LED channel/pin
  * @return 0 on success, negative on error
  */
-static inline int led_on(struct device *dev, u32_t led)
+__syscall int led_on(struct device *dev, u32_t led);
+
+static inline int _impl_led_on(struct device *dev, u32_t led)
 {
 	const struct led_driver_api *api = dev->driver_api;
 
@@ -123,11 +131,15 @@ static inline int led_on(struct device *dev, u32_t led)
  * @param led LED channel/pin
  * @return 0 on success, negative on error
  */
-static inline int led_off(struct device *dev, u32_t led)
+__syscall int led_off(struct device *dev, u32_t led);
+
+static inline int _impl_led_off(struct device *dev, u32_t led)
 {
 	const struct led_driver_api *api = dev->driver_api;
 
 	return api->off(dev, led);
 }
+
+#include <syscalls/led.h>
 
 #endif	/* _ZEPHYR_LED_H */

--- a/scripts/gen_kobject_list.py
+++ b/scripts/gen_kobject_list.py
@@ -35,6 +35,7 @@ subsystems = [
     "i2c_driver_api",
     "i2s_driver_api",
     "ipm_driver_api",
+    "led_driver_api",
     "pinmux_driver_api",
     "pwm_driver_api",
     "entropy_driver_api",


### PR DESCRIPTION
Add system call handler support to LED subsystem. No buffers are
involved in any of the API's and hence the syscall support is
straightforward.

This PR has been validated on 96Boards Neonkey with CONFIG_USERSPACE
enabled.

Signed-off-by: Manivannan Sadhasivam <manivannan.sadhasivam@linaro.org>