### PR TITLE
subsys: fs: fix generic storage partition selection undesirably depends on flash_map module

### DIFF
--- a/boards/arm/adafruit_feather_m0_basic_proto/adafruit_feather_m0_basic_proto.dts
+++ b/boards/arm/adafruit_feather_m0_basic_proto/adafruit_feather_m0_basic_proto.dts
@@ -56,7 +56,7 @@
 		 * and is used by NFFS if enabled.
 		 */
 
-#if defined(CONFIG_FS_FLASH_MAP_STORAGE)
+#if defined(CONFIG_FS_FLASH_STORAGE_PARTITION)
 		storage_partition: partition@3c000 {
 			label = "storage";
 			reg = <0x0003c000 0x00004000>;

--- a/boards/arm/adafruit_trinket_m0/adafruit_trinket_m0.dts
+++ b/boards/arm/adafruit_trinket_m0/adafruit_trinket_m0.dts
@@ -69,7 +69,7 @@
 		 * and is used by NFFS if enabled.
 		 */
 
-#if defined(CONFIG_FS_FLASH_MAP_STORAGE)
+#if defined(CONFIG_FS_FLASH_STORAGE_PARTITION)
 		storage_partition: partition@3c000 {
 			label = "storage";
 			reg = <0x0003c000 0x00004000>;

--- a/boards/arm/arduino_zero/arduino_zero.dts
+++ b/boards/arm/arduino_zero/arduino_zero.dts
@@ -46,7 +46,7 @@
 		 * and is used by NFFS if enabled.
 		 */
 
-#if defined(CONFIG_FS_FLASH_MAP_STORAGE)
+#if defined(CONFIG_FS_FLASH_STORAGE_PARTITION)
 		storage_partition: partition@3c000 {
 			label = "storage";
 			reg = <0x0003c000 0x00004000>;

--- a/boards/arm/bbc_microbit/bbc_microbit.dts
+++ b/boards/arm/bbc_microbit/bbc_microbit.dts
@@ -55,7 +55,7 @@
 			reg = <0x0003c000 0x2000>;
 		};
 
-#if defined(CONFIG_FS_FLASH_MAP_STORAGE)
+#if defined(CONFIG_FS_FLASH_STORAGE_PARTITION)
 		storage_partition: partition@3e000 {
 			label = "storage";
 			reg = <0x0003e000 0x00002000>;

--- a/boards/arm/nrf51_pca10028/nrf51_pca10028.dts
+++ b/boards/arm/nrf51_pca10028/nrf51_pca10028.dts
@@ -59,7 +59,7 @@
 			reg = <0x0003c000 0x2000>;
 		};
 
-#if defined(CONFIG_FS_FLASH_MAP_STORAGE)
+#if defined(CONFIG_FS_FLASH_STORAGE_PARTITION)
 		storage_partition: partition@3e000 {
 			label = "storage";
 			reg = <0x0003e000 0x00002000>;

--- a/boards/arm/nrf52840_pca10056/nrf52840_pca10056.dts
+++ b/boards/arm/nrf52840_pca10056/nrf52840_pca10056.dts
@@ -60,7 +60,7 @@
 			reg = <0x000de000 0x0001e000>;
 		};
 
-#if defined(CONFIG_FS_FLASH_MAP_STORAGE)
+#if defined(CONFIG_FS_FLASH_STORAGE_PARTITION)
 		storage_partition: partition@fc000 {
 			label = "storage";
 			reg = <0x000fc000 0x00004000>;

--- a/boards/arm/nrf52_pca10040/nrf52_pca10040.dts
+++ b/boards/arm/nrf52_pca10040/nrf52_pca10040.dts
@@ -60,7 +60,7 @@
 			reg = <0x00070000 0xa000>;
 		};
 
-#if defined(CONFIG_FS_FLASH_MAP_STORAGE)
+#if defined(CONFIG_FS_FLASH_STORAGE_PARTITION)
 		storage_partition: partition@7a000 {
 			label = "storage";
 			reg = <0x0007a000 0x00006000>;

--- a/boards/arm/nrf52_pca20020/nrf52_pca20020.dts
+++ b/boards/arm/nrf52_pca20020/nrf52_pca20020.dts
@@ -100,7 +100,7 @@
 		 * will be created in this area.
 		 */
 
-#if defined(CONFIG_FS_FLASH_MAP_STORAGE)
+#if defined(CONFIG_FS_FLASH_STORAGE_PARTITION)
 		storage_partition: partition@7a000 {
 			label = "storage";
 			reg = <0x0007a000 0x00006000>;

--- a/boards/arm/nrf52_sparkfun/nrf52_sparkfun.dts
+++ b/boards/arm/nrf52_sparkfun/nrf52_sparkfun.dts
@@ -53,7 +53,7 @@
 			reg = <0x00070000 0xa000>;
 		};
 
-#if defined(CONFIG_FS_FLASH_MAP_STORAGE)
+#if defined(CONFIG_FS_FLASH_STORAGE_PARTITION)
 		storage_partition: partition@7a000 {
 			label = "storage";
 			reg = <0x0007a000 0x00006000>;

--- a/samples/application_development/out_of_tree_board/boards/arm/nrf52840_pca10056/nrf52840_pca10056.dts
+++ b/samples/application_development/out_of_tree_board/boards/arm/nrf52840_pca10056/nrf52840_pca10056.dts
@@ -52,7 +52,7 @@
 			reg = <0x000de000 0x0001e000>;
 		};
 
-#if defined(CONFIG_FS_FLASH_MAP_STORAGE)
+#if defined(CONFIG_FS_FLASH_STORAGE_PARTITION)
 		storage_partition: partition@fc000 {
 			label = "storage";
 			reg = <0x000fc000 0x00004000>;

--- a/subsys/fs/Kconfig
+++ b/subsys/fs/Kconfig
@@ -5,9 +5,8 @@
 #
 
 # Hidden. Automatically selected by file systems or FCB that need it
-config FS_FLASH_MAP_STORAGE
+config FS_FLASH_STORAGE_PARTITION
 	bool
-	depends on FLASH_MAP
 	default n
 
 menu "File Systems"
@@ -43,7 +42,7 @@ config FAT_FILESYSTEM_ELM
 config FILE_SYSTEM_NFFS
 	bool "NFFS file system support"
 	select FLASH_PAGE_LAYOUT
-	select FS_FLASH_MAP_STORAGE
+	select FS_FLASH_STORAGE_PARTITION
 	help
 	  Enables NFFS file system support.
 	  Note: NFFS requires 1-byte unaligned access to flash thus it

--- a/subsys/fs/fcb/Kconfig
+++ b/subsys/fs/fcb/Kconfig
@@ -14,6 +14,6 @@ config FCB
 	prompt "Flash Circular Buffer support"
 	default n
 	depends on FLASH_MAP
-	select FS_FLASH_MAP_STORAGE
+	select FS_FLASH_STORAGE_PARTITION
 	help
 	  Enable support of Flash Circular Buffer.

--- a/subsys/storage/flash_map/flash_map_default.c
+++ b/subsys/storage/flash_map/flash_map_default.c
@@ -41,7 +41,7 @@ const struct flash_area default_flash_map[] = {
 		.fa_size = FLASH_AREA_IMAGE_SCRATCH_SIZE,
 	},
 
-#ifdef CONFIG_FS_FLASH_MAP_STORAGE
+#ifdef CONFIG_FS_FLASH_STORAGE_PARTITION
 	/* FLASH_AREA_STORAGE */
 	{
 		.fa_id = 4,


### PR DESCRIPTION
FS_FLASH_MAP_STORAGE keyword enables the storage partition,
but it was depend on flash_map module which is unused by
NFFS. This patch makes it independent thanks
to it is possible to enable the storage partition
without flash_map module.

this bug was omitted in review of https://github.com/zephyrproject-rtos/zephyr/pull/7195

Signed-off-by: Andrzej Puzdrowski <andrzej.puzdrowski@nordicsemi.no>