### PR TITLE
subsys: fs: fcb: fix - crc write size not aligned

### DIFF
--- a/subsys/fs/fcb/fcb_append.c
+++ b/subsys/fs/fcb/fcb_append.c
@@ -6,6 +6,7 @@
  */
 
 #include <stddef.h>
+#include <string.h>
 
 #include "fcb.h"
 #include "fcb_priv.h"
@@ -115,16 +116,18 @@ int
 fcb_append_finish(struct fcb *fcb, struct fcb_entry *loc)
 {
 	int rc;
-	u8_t crc8;
+	u8_t crc8[fcb->f_align];
 	off_t off;
 
-	rc = fcb_elem_crc8(fcb, loc, &crc8);
+	memset(crc8, 0xFF, sizeof(crc8));
+
+	rc = fcb_elem_crc8(fcb, loc, &crc8[0]);
 	if (rc) {
 		return rc;
 	}
 	off = loc->fe_data_off + fcb_len_in_flash(fcb, loc->fe_data_len);
 
-	rc = fcb_flash_write(fcb, loc->fe_sector, off, &crc8, sizeof(crc8));
+	rc = fcb_flash_write(fcb, loc->fe_sector, off, crc8, fcb->f_align);
 	if (rc) {
 		return FCB_ERR_FLASH;
 	}


### PR DESCRIPTION
This is bug-fix for issue #7311
FCB: CRC write size in append_finish doesn't honor
flash min write size

This patch changes write size to the minimum supported
write size.


Signed-off-by: Andrzej Puzdrowski <andrzej.puzdrowski@nordicsemi.no>