### PR TITLE
drivers/ethernet: stm32: Don't exit driver init on HAL timeout

### DIFF
--- a/drivers/ethernet/eth_stm32_hal.c
+++ b/drivers/ethernet/eth_stm32_hal.c
@@ -333,7 +333,12 @@ static void eth_iface_init(struct net_if *iface)
 
 	hal_ret = HAL_ETH_Init(heth);
 
-	if (hal_ret != HAL_OK) {
+	if (hal_ret == HAL_TIMEOUT) {
+		/* HAL Init time out. This could be linked to */
+		/* a recoverable error. Log the issue and continue */
+		/* dirver initialisation */
+		SYS_LOG_ERR("HAL_ETH_Init Timed out\n");
+	} else if (hal_ret != HAL_OK) {
 		SYS_LOG_ERR("HAL_ETH_Init failed: %d\n", hal_ret);
 		return;
 	}


### PR DESCRIPTION
In case ethernet cable is unplugged, stm32 ethernet driver triggers
an error, driver initialization fails and fw crashes.
This could be enhanced as in case not cable is connected, HAL
returns a Time out, and will resume its initialization when
cable is plugged.
Treat HAL timeout in ethernet driver initialization as a
recoverable error and continues driver init when it happens.

Tested with sample/net/dhcpv4_client. Start board with cable
unplugged. Wait some time before plugging the cable. DHCP request
is correctly performed when cable is plugged.

Fixes: #7127

Signed-off-by: Erwan Gouriou <erwan.gouriou@linaro.org>