### PR TITLE
kconfig: Refactor kconfig.py to use __main__ and argparse

### DIFF
--- a/scripts/kconfig/kconfig.py
+++ b/scripts/kconfig/kconfig.py
@@ -2,71 +2,90 @@
 # Modified from: https://github.com/ulfalizer/Kconfiglib/blob/master/examples/merge_config.py
 from kconfiglib import Kconfig, Symbol, BOOL, STRING, TRISTATE, TRI_TO_STR
 import sys
+import argparse
 
-if len(sys.argv) < 5:
-    print('usage: {} Kconfig dotconfig autoconf conf1 [conf2 ...]'
-          .format(sys.argv[0]))
-    sys.exit(1)
+def main():
+    parse_args()
 
-print("Parsing Kconfig tree in {}".format(sys.argv[1]))
-kconf = Kconfig(sys.argv[1])
+    print("Parsing Kconfig tree in {}".format(args.kconfig_root))
+    kconf = Kconfig(args.kconfig_root)
 
-# Enable warnings for assignments to undefined symbols
-kconf.enable_undef_warnings()
+    # Enable warnings for assignments to undefined symbols
+    kconf.enable_undef_warnings()
 
-# This script uses alldefconfig as the base. Other starting states could be set
-# up here as well. The approach in examples/allnoconfig_simpler.py could
-# provide an allnoconfig starting state for example.
+    # This script uses alldefconfig as the base. Other starting states could be set
+    # up here as well. The approach in examples/allnoconfig_simpler.py could
+    # provide an allnoconfig starting state for example.
 
-print("Using {} as base".format(sys.argv[4]))
-for config in sys.argv[5:]:
-    print("Merging {}".format(config))
-# Create a merged configuration by loading the fragments with replace=False
-for config in sys.argv[4:]:
-    kconf.load_config(config, replace=False)
+    print("Using {} as base".format(args.conf_fragments[0]))
+    for config in args.conf_fragments[1:]:
+        print("Merging {}".format(config))
+    # Create a merged configuration by loading the fragments with replace=False
+    for config in args.conf_fragments:
+        kconf.load_config(config, replace=False)
 
 
-# Print warnings for symbols whose actual value doesn't match the assigned
-# value
+    # Print warnings for symbols whose actual value doesn't match the assigned
+    # value
 
-def name_and_loc(sym):
-    # Helper for printing symbol names and Kconfig file location(s) in warnings
+    def name_and_loc(sym):
+        # Helper for printing symbol names and Kconfig file location(s) in warnings
 
-    if not sym.nodes:
-        return sym.name + " (undefined)"
+        if not sym.nodes:
+            return sym.name + " (undefined)"
 
-    return "{} (defined at {})".format(
-        sym.name,
-        ", ".join("{}:{}".format(node.filename, node.linenr)
-                  for node in sym.nodes))
+        return "{} (defined at {})".format(
+            sym.name,
+            ", ".join("{}:{}".format(node.filename, node.linenr)
+                      for node in sym.nodes))
 
-for sym in kconf.defined_syms:
-    # Was the symbol assigned to?
-    if sym.user_value is not None:
-        # Tristate values are represented as 0, 1, 2. Having them as
-        # "n", "m", "y" is more convenient here, so convert.
-        if sym.type in (BOOL, TRISTATE):
-            user_value = TRI_TO_STR[sym.user_value]
-        else:
-            user_value = sym.user_value
-        if user_value != sym.str_value:
-            print('warning: {} was assigned the value "{}" but got the '
-                  'value "{}" -- check dependencies'.format(
-                      name_and_loc(sym), user_value, sym.str_value
-                  ),
+    for sym in kconf.defined_syms:
+        # Was the symbol assigned to?
+        if sym.user_value is not None:
+            # Tristate values are represented as 0, 1, 2. Having them as
+            # "n", "m", "y" is more convenient here, so convert.
+            if sym.type in (BOOL, TRISTATE):
+                user_value = TRI_TO_STR[sym.user_value]
+            else:
+                user_value = sym.user_value
+            if user_value != sym.str_value:
+                print('warning: {} was assigned the value "{}" but got the '
+                      'value "{}" -- check dependencies'.format(
+                          name_and_loc(sym), user_value, sym.str_value
+                      ),
+                      file=sys.stderr)
+
+
+    # Turn the warning for malformed .config lines into an error
+    for warning in kconf.warnings:
+        if "ignoring malformed line" in warning:
+            print("Aborting due to malformed configuration settings",
                   file=sys.stderr)
+            sys.exit(1)
 
 
-# Turn the warning for malformed .config lines into an error
-for warning in kconf.warnings:
-    if "ignoring malformed line" in warning:
-        print("Aborting due to malformed configuration settings",
-              file=sys.stderr)
-        sys.exit(1)
+    # Write the merged configuration
+    kconf.write_config(args.dotconfig)
+
+    # Write the C header
+    kconf.write_autoconf(args.autoconf)
 
 
-# Write the merged configuration
-kconf.write_config(sys.argv[2])
+def parse_args():
+    global args
 
-# Write the C header
-kconf.write_autoconf(sys.argv[3])
+    parser = argparse.ArgumentParser(
+        description=__doc__,
+        formatter_class=argparse.RawDescriptionHelpFormatter
+    )
+
+    parser.add_argument("kconfig_root")
+    parser.add_argument("dotconfig")
+    parser.add_argument("autoconf")
+    parser.add_argument("conf_fragments", metavar='conf', type=str, nargs='+')
+
+    args = parser.parse_args()
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Kconfig.py is not following the de-facto (real?) coding standards of
Zephyr. This commit refactors kconfig.py with two changes:

Use \__main__ and def main().

Use argparse instead of sys.argv.

Signed-off-by: Sebastian Bøe <sebastian.boe@nordicsemi.no>