### PR TITLE
newlib: libc-hooks: Print "exit" message with newline

### DIFF
--- a/lib/libc/newlib/libc-hooks.c
+++ b/lib/libc/newlib/libc-hooks.c
@@ -121,7 +121,7 @@ FUNC_ALIAS(_fstat, fstat, int);
 
 void _exit(int status)
 {
-	_write(1, "exit", 4);
+	_write(1, "exit\n", 5);
 	while (1) {
 		;
 	}


### PR DESCRIPTION
Calling POSIX exit() function in Zephyr w/newlib leads to printing
"exit" to stdout followed by infinite loop. That message was
printed without a newline though, leading to confusing artifacts
in the console output.

Signed-off-by: Paul Sokolovsky <paul.sokolovsky@linaro.org>