### PR TITLE
usb: add USB2.0 device and High Speed support

### DIFF
--- a/boards/xtensa/intel_s1000_crb/Kconfig.defconfig
+++ b/boards/xtensa/intel_s1000_crb/Kconfig.defconfig
@@ -68,8 +68,12 @@ config USB_DW
 	def_bool y
 config USB_DW_IRQ_PRI
 	default 3
-config USB_PHY_2
+config USB_DW_USB_2_0
 	def_bool y
+config USB_HID_MAX_PAYLOAD_SIZE
+	default 128
+config USB_COMPOSITE_BUFFER_SIZE
+	default 128
 endif # USB
 
 if UART_NS16550

--- a/drivers/usb/device/Kconfig
+++ b/drivers/usb/device/Kconfig
@@ -26,6 +26,14 @@ config USB_DW_IRQ_PRI
 	help
 	  USB interrupt priority.
 
+config USB_DW_USB_2_0
+	bool
+	prompt "DesignWare Controller and PHY support for USB specification 2.0"
+	depends on USB_DW
+	default n
+	help
+	  Indicates whether or not USB specification version 2.0 is supported
+
 config USB_DC_STM32
 	bool
 	prompt "USB device controller driver for STM32 devices"

--- a/drivers/usb/device/usb_dc_dw.c
+++ b/drivers/usb/device/usb_dc_dw.c
@@ -526,11 +526,15 @@ static int usb_dw_init(void)
 		return ret;
 	}
 
-	/* Set device speed to FS */
-#ifdef USB_PHY_2
-	USB_DW->dcfg &= ~USB_DW_DCFG_DEV_SPD_FS;
-	USB_DW->dcfg |= 0x01;
+#ifdef CONFIG_USB_DW_USB_2_0
+	/* set the PHY interface to be 16-bit UTMI */
+	USB_DW->gusbcfg = (USB_DW->gusbcfg & ~USB_DW_GUSBCFG_PHY_IF_MASK) |
+		USB_DW_GUSBCFG_PHY_IF_16_BIT;
+
+	/* Set USB2.0 High Speed */
+	USB_DW->dcfg |= USB_DW_DCFG_DEV_SPD_USB2_HS;
 #else
+	/* Set device speed to Full Speed */
 	USB_DW->dcfg |= USB_DW_DCFG_DEV_SPD_FS;
 #endif
 

--- a/drivers/usb/device/usb_dw_registers.h
+++ b/drivers/usb/device/usb_dw_registers.h
@@ -121,6 +121,9 @@ struct usb_dw_reg {
 
 /* USB register offsets and masks */
 #define USB_DW_HWCFG4_DEDFIFOMODE BIT(25)
+#define USB_DW_GUSBCFG_PHY_IF_MASK BIT(3)
+#define USB_DW_GUSBCFG_PHY_IF_8_BIT (0)
+#define USB_DW_GUSBCFG_PHY_IF_16_BIT (1<<3)
 #define USB_DW_GRSTCTL_AHB_IDLE BIT(31)
 #define USB_DW_GRSTCTL_TX_FNUM_OFFSET (6)
 #define USB_DW_GRSTCTL_TX_FFLSH BIT(5)
@@ -136,6 +139,8 @@ struct usb_dw_reg {
 #define USB_DW_GINTSTS_USB_SUSP BIT(11)
 #define USB_DW_GINTSTS_RX_FLVL BIT(4)
 #define USB_DW_GINTSTS_OTG_INT BIT(2)
+#define USB_DW_DCFG_DEV_SPD_USB2_HS (0)
+#define USB_DW_DCFG_DEV_SPD_USB2_FS (0x1)
 #define USB_DW_DCFG_DEV_SPD_LS (0x2)
 #define USB_DW_DCFG_DEV_SPD_FS (0x3)
 #define USB_DW_DCFG_DEV_ADDR_MASK (0x7F << 4)

--- a/subsys/usb/class/hid/Kconfig
+++ b/subsys/usb/class/hid/Kconfig
@@ -30,4 +30,10 @@ config HID_INTERRUPT_EP_MPS
 	help
 	  USB HID Device interrupt endpoint size
 
+config USB_HID_MAX_PAYLOAD_SIZE
+	int
+	default 64
+	help
+	  Max allowed payload size over USB HID Class
+
 endif # USB_DEVICE_HID

--- a/subsys/usb/class/hid/core.c
+++ b/subsys/usb/class/hid/core.c
@@ -229,7 +229,7 @@ USBD_CFG_DATA_DEFINE(hid) struct usb_cfg_data hid_config = {
 };
 
 #if !defined(CONFIG_USB_COMPOSITE_DEVICE)
-static u8_t interface_data[64];
+static u8_t interface_data[CONFIG_USB_HID_MAX_PAYLOAD_SIZE];
 #endif
 
 int usb_hid_init(void)


### PR DESCRIPTION
This PR adds support for 
- USB2.0 device and high speed in DesignWare driver
- USB2.0 spec support in USB device driver
This PR also increases the max packet size for USB HID interrupt endpoint from 16 to 64