### PR TITLE
tests: posix: Initializing a scalar variable

### DIFF
--- a/tests/posix/posix_checks/src/posix_checks.c
+++ b/tests/posix/posix_checks/src/posix_checks.c
@@ -106,7 +106,7 @@ void handler(union sigval val)
 void check_timer_support(int clock_id)
 {
 	int ret;
-	struct sigevent sig;
+	struct sigevent sig = {0};
 	timer_t timerid;
 	struct itimerspec value, ovalue;
 

--- a/tests/posix/posix_checks/src/posix_checks.c
+++ b/tests/posix/posix_checks/src/posix_checks.c
@@ -106,10 +106,11 @@ void handler(union sigval val)
 void check_timer_support(int clock_id)
 {
 	int ret;
-	struct sigevent sig = {0};
+	struct sigevent sig;
 	timer_t timerid;
 	struct itimerspec value, ovalue;
 
+	sig.sigev_signo = 0;
 	sig.sigev_notify = SIGEV_SIGNAL;
 	sig.sigev_notify_function = handler;
 	sig.sigev_value.sival_int = 20;


### PR DESCRIPTION
Avoiding arbitrary value left from earlier computations.
Fixes #7088

Signed-off-by: Nagaraj Hegde <hegdenagaraj4@gmail.com>