### PR TITLE
sensor: vl53l0x: make xshut pin control optional

### DIFF
--- a/boards/arm/disco_l475_iot1/Kconfig.defconfig
+++ b/boards/arm/disco_l475_iot1/Kconfig.defconfig
@@ -78,6 +78,9 @@ endif # PWM
 
 if VL53L0X
 
+config VL53L0X_XSHUT_CONTROL_ENABLE
+	default y
+
 config VL53L0X_XSHUT_GPIO_DEV_NAME
 	default "GPIOC"
 

--- a/drivers/sensor/vl53l0x/Kconfig
+++ b/drivers/sensor/vl53l0x/Kconfig
@@ -44,11 +44,18 @@ config VL53L0X_I2C_MASTER_DEV_NAME
 
 endif
 
+config VL53L0X_XSHUT_CONTROL_ENABLE
+	bool "Enable XSHUT pin control"
+	depends on VL53L0X
+	default n
+	help
+	    Enable it if XSHUT pin is controlled by host.
+
 config VL53L0X_XSHUT_GPIO_DEV_NAME
 	string
 	prompt "GPIO device"
 	default "GPIO_6"
-	depends on VL53L0X
+	depends on VL53L0X_XSHUT_CONTROL_ENABLE
 	help
 	  The device name of the GPIO device to which the VL53L0X xshut pin
 	  is connected.
@@ -57,7 +64,7 @@ config VL53L0X_XSHUT_GPIO_PIN_NUM
 	int
 	prompt "Interrupt GPIO pin number"
 	default 6
-	depends on VL53L0X
+	depends on VL53L0X_XSHUT_CONTROL_ENABLE
 	help
 	  The number of the GPIO on which the xshut signal from the VL53L0X
 	  is connected.

--- a/drivers/sensor/vl53l0x/vl53l0x.c
+++ b/drivers/sensor/vl53l0x/vl53l0x.c
@@ -199,9 +199,11 @@ static int vl53l0x_init(struct device *dev)
 	VL53L0X_Error ret;
 	u16_t vl53l0x_id = 0;
 	VL53L0X_DeviceInfo_t vl53l0x_dev_info;
-	struct device *gpio;
 
 	SYS_LOG_DBG("enter in %s", __func__);
+
+#ifdef CONFIG_VL53L0X_XSHUT_CONTROL_ENABLE
+	struct device *gpio;
 
 	/* configure and set VL53L0X_XSHUT_Pin */
 	gpio = device_get_binding(CONFIG_VL53L0X_XSHUT_GPIO_DEV_NAME);
@@ -222,6 +224,7 @@ static int vl53l0x_init(struct device *dev)
 
 	gpio_pin_write(gpio, CONFIG_VL53L0X_XSHUT_GPIO_PIN_NUM, 1);
 	k_sleep(100);
+#endif
 
 	drv_data->i2c = device_get_binding(CONFIG_VL53L0X_I2C_MASTER_DEV_NAME);
 	if (drv_data->i2c == NULL) {


### PR DESCRIPTION
The XSHUT pin, used to shutdown the device when it is not
in current use, is optional and some boards (like ArgonKey)
leave it tied to vdd. So, the driver must provide a way to
make this part configurable.

Signed-off-by: Armando Visconti <armando.visconti@st.com>