### PR TITLE
ti_adc108s102: fix some validation issues

### DIFF
--- a/drivers/adc/adc_ti_adc108s102.c
+++ b/drivers/adc/adc_ti_adc108s102.c
@@ -134,6 +134,10 @@ static inline int _verify_entries(struct adc_seq_table *seq_table)
 	u32_t chans_set = 0;
 	int i;
 
+	if (seq_table->num_entries >= ADC108S102_CMD_BUFFER_SIZE) {
+		return 0;
+	}
+
 	for (i = 0; i < seq_table->num_entries; i++) {
 		entry = &seq_table->entries[i];
 

--- a/drivers/adc/adc_ti_adc108s102.c
+++ b/drivers/adc/adc_ti_adc108s102.c
@@ -138,7 +138,7 @@ static inline int _verify_entries(struct adc_seq_table *seq_table)
 		entry = &seq_table->entries[i];
 
 		if (entry->sampling_delay <= 0 ||
-		    entry->channel_id > ADC108S102_CHANNELS) {
+		    entry->channel_id >= ADC108S102_CHANNELS) {
 			return 0;
 		}
 


### PR DESCRIPTION
Channel IDs start at 0, need to fail if the provided ID
equals ADC102S102_CHANNELS, not just larger than it.

Validate that num_entries doesn't exceed the bounds of the command/sample buffer arrays.