### PR TITLE
LwM2M: optimizations for 1.12

### DIFF
--- a/subsys/net/lib/lwm2m/Kconfig
+++ b/subsys/net/lib/lwm2m/Kconfig
@@ -51,7 +51,7 @@ config LWM2M_ENGINE_MAX_REPLIES
 
 config LWM2M_ENGINE_MAX_OBSERVER
 	int "Maximum # of observable LWM2M resources"
-	default 20
+	default 10
 	range 5 200
 	help
 	  This value sets the maximum number of resources which can be

--- a/subsys/net/lib/lwm2m/lwm2m_engine.c
+++ b/subsys/net/lib/lwm2m/lwm2m_engine.c
@@ -656,7 +656,6 @@ next_engine_obj_inst(struct lwm2m_engine_obj_inst *last,
 int lwm2m_create_obj_inst(u16_t obj_id, u16_t obj_inst_id,
 			  struct lwm2m_engine_obj_inst **obj_inst)
 {
-	int i;
 	struct lwm2m_engine_obj *obj;
 
 	*obj_inst = NULL;
@@ -690,14 +689,6 @@ int lwm2m_create_obj_inst(u16_t obj_id, u16_t obj_inst_id,
 	obj->instance_count++;
 	(*obj_inst)->obj = obj;
 	(*obj_inst)->obj_inst_id = obj_inst_id;
-	snprintk((*obj_inst)->path, MAX_RESOURCE_LEN, "%u/%u",
-		 obj_id, obj_inst_id);
-	for (i = 0; i < (*obj_inst)->resource_count; i++) {
-		snprintk((*obj_inst)->resources[i].path, MAX_RESOURCE_LEN,
-			 "%u/%u/%u", obj_id, obj_inst_id,
-			 (*obj_inst)->resources[i].res_id);
-	}
-
 	engine_register_obj_inst(*obj_inst);
 #ifdef CONFIG_LWM2M_RD_CLIENT_SUPPORT
 	engine_trigger_update();
@@ -1109,9 +1100,10 @@ u16_t lwm2m_get_rd_data(u8_t *client_data, u16_t size)
 					     obj_inst, node) {
 			if (obj_inst->obj->obj_id == obj->obj_id) {
 				len = snprintk(temp, sizeof(temp),
-					       "%s</%s>",
+					       "%s</%u/%u>",
 					       (pos > 0) ? "," : "",
-					       obj_inst->path);
+					       obj_inst->obj->obj_id,
+					       obj_inst->obj_inst_id);
 				/*
 				 * TODO: iterate through resources once block
 				 * transfer is handled correctly

--- a/subsys/net/lib/lwm2m/lwm2m_engine.c
+++ b/subsys/net/lib/lwm2m/lwm2m_engine.c
@@ -108,6 +108,16 @@ struct observe_node {
 	u8_t  tkl;
 };
 
+struct notification_attrs {
+	/* use to determine which value is set */
+	float32_value_t gt;
+	float32_value_t lt;
+	float32_value_t st;
+	s32_t pmin;
+	s32_t pmax;
+	u8_t flags;
+};
+
 static struct observe_node observe_node_data[CONFIG_LWM2M_ENGINE_MAX_OBSERVER];
 
 #define MAX_PERIODIC_SERVICE	10
@@ -305,16 +315,6 @@ static void free_block_ctx(struct block_context *ctx)
 }
 
 /* observer functions */
-
-struct notification_attrs {
-	/* use to determine which value is set */
-	u8_t flags;
-	float32_value_t gt;
-	float32_value_t lt;
-	float32_value_t st;
-	s32_t pmin;
-	s32_t pmax;
-};
 
 static int update_attrs(sys_slist_t *list, struct notification_attrs *out)
 {

--- a/subsys/net/lib/lwm2m/lwm2m_engine.c
+++ b/subsys/net/lib/lwm2m/lwm2m_engine.c
@@ -394,7 +394,7 @@ static int engine_add_observer(struct lwm2m_message *msg,
 		.pmin  = DEFAULT_SERVER_PMIN,
 		.pmax  = DEFAULT_SERVER_PMAX,
 	};
-	int i;
+	int i, ret;
 
 	if (!msg || !msg->ctx) {
 		SYS_LOG_ERR("valid lwm2m message is required");
@@ -439,8 +439,9 @@ static int engine_add_observer(struct lwm2m_message *msg,
 		return -ENOENT;
 	}
 
-	if (update_attrs(&obj->attr_list, &attrs) < 0) {
-		return -EINVAL;
+	ret = update_attrs(&obj->attr_list, &attrs);
+	if (ret < 0) {
+		return ret;
 	}
 
 	/* check if object instance exists */
@@ -453,8 +454,9 @@ static int engine_add_observer(struct lwm2m_message *msg,
 			return -ENOENT;
 		}
 
-		if (update_attrs(&obj_inst->attr_list, &attrs) < 0) {
-			return -EINVAL;
+		ret = update_attrs(&obj_inst->attr_list, &attrs);
+		if (ret < 0) {
+			return ret;
 		}
 	}
 
@@ -473,9 +475,9 @@ static int engine_add_observer(struct lwm2m_message *msg,
 			return -ENOENT;
 		}
 
-		if (update_attrs(&obj_inst->resources[i].attr_list,
-				 &attrs) < 0) {
-			return -EINVAL;
+		ret = update_attrs(&obj_inst->resources[i].attr_list, &attrs);
+		if (ret < 0) {
+			return ret;
 		}
 	}
 
@@ -2251,7 +2253,10 @@ static int lwm2m_write_attr_handler(struct lwm2m_engine_obj *obj,
 	}
 
 	/* retrieve existing attributes */
-	update_attrs(attr_list, &nattrs);
+	ret = update_attrs(attr_list, &nattrs);
+	if (ret < 0) {
+		return ret;
+	}
 
 	/* loop through options to parse attribute */
 	for (int i = 0; i < nr_opt; i++) {
@@ -2459,7 +2464,10 @@ static int lwm2m_write_attr_handler(struct lwm2m_engine_obj *obj,
 		nattrs.pmin = DEFAULT_SERVER_PMIN;
 		nattrs.pmax = DEFAULT_SERVER_PMAX;
 
-		update_attrs(&obj->attr_list, &nattrs);
+		ret = update_attrs(&obj->attr_list, &nattrs);
+		if (ret < 0) {
+			return ret;
+		}
 
 		if (obs->path.level > 1) {
 			if (path->level > 1 &&
@@ -2478,7 +2486,10 @@ static int lwm2m_write_attr_handler(struct lwm2m_engine_obj *obj,
 				}
 			}
 
-			update_attrs(&obj_inst->attr_list, &nattrs);
+			ret = update_attrs(&obj_inst->attr_list, &nattrs);
+			if (ret < 0) {
+				return ret;
+			}
 		}
 
 		if (obs->path.level > 2) {
@@ -2495,7 +2506,10 @@ static int lwm2m_write_attr_handler(struct lwm2m_engine_obj *obj,
 				}
 			}
 
-			update_attrs(&res->attr_list, &nattrs);
+			ret = update_attrs(&res->attr_list, &nattrs);
+			if (ret < 0) {
+				return ret;
+			}
 		}
 
 		SYS_LOG_DBG("%d/%d/%d(%d) updated from %d/%d to %u/%u",

--- a/subsys/net/lib/lwm2m/lwm2m_engine.c
+++ b/subsys/net/lib/lwm2m/lwm2m_engine.c
@@ -104,7 +104,6 @@ struct observe_node {
 	u32_t max_period_sec;
 	u32_t counter;
 	u16_t format;
-	bool used;
 	u8_t  tkl;
 };
 
@@ -499,7 +498,7 @@ static int engine_add_observer(struct lwm2m_message *msg,
 
 	/* find an unused observer index node */
 	for (i = 0; i < CONFIG_LWM2M_ENGINE_MAX_OBSERVER; i++) {
-		if (!observe_node_data[i].used) {
+		if (!observe_node_data[i].ctx) {
 			break;
 		}
 	}
@@ -510,7 +509,6 @@ static int engine_add_observer(struct lwm2m_message *msg,
 	}
 
 	/* copy the values and add it to the list */
-	observe_node_data[i].used = true;
 	observe_node_data[i].ctx = msg->ctx;
 	memcpy(&observe_node_data[i].path, path, sizeof(*path));
 	memcpy(observe_node_data[i].token, token, tkl);

--- a/subsys/net/lib/lwm2m/lwm2m_engine.c
+++ b/subsys/net/lib/lwm2m/lwm2m_engine.c
@@ -316,38 +316,54 @@ static void free_block_ctx(struct block_context *ctx)
 
 /* observer functions */
 
-static int update_attrs(sys_slist_t *list, struct notification_attrs *out)
+static int update_attrs(void *ref, struct notification_attrs *out)
 {
-	struct lwm2m_attr *attr;
+	int i;
 
-	SYS_SLIST_FOR_EACH_CONTAINER(list, attr, node) {
-		switch (attr->type) {
+	for (i = 0; i < CONFIG_LWM2M_NUM_ATTR; i++) {
+		if (ref == write_attr_pool[i].ref) {
+			continue;
+		}
+
+		switch (write_attr_pool[i].type) {
 		case LWM2M_ATTR_PMIN:
-			out->pmin = attr->int_val;
+			out->pmin = write_attr_pool[i].int_val;
 			break;
 		case LWM2M_ATTR_PMAX:
-			out->pmax = attr->int_val;
+			out->pmax = write_attr_pool[i].int_val;
 			break;
 		case LWM2M_ATTR_LT:
-			out->lt = attr->float_val;
+			out->lt = write_attr_pool[i].float_val;
 			break;
 		case LWM2M_ATTR_GT:
-			out->gt = attr->float_val;
+			out->gt = write_attr_pool[i].float_val;
 			break;
 		case LWM2M_ATTR_STEP:
-			out->st = attr->float_val;
+			out->st = write_attr_pool[i].float_val;
 			break;
 		default:
 			SYS_LOG_ERR("Unrecognize attr: %d",
-				    attr->type);
+				    write_attr_pool[i].type);
 			return -EINVAL;
 		}
 
 		/* mark as set */
-		out->flags |= BIT(attr->type);
+		out->flags |= BIT(write_attr_pool[i].type);
 	}
 
 	return 0;
+}
+
+static void clear_attrs(void *ref)
+{
+	int i;
+
+	for (i = 0; i < CONFIG_LWM2M_NUM_ATTR; i++) {
+		if (ref == write_attr_pool[i].ref) {
+			memset(&write_attr_pool[i], 0,
+			       sizeof(write_attr_pool[i]));
+		}
+	}
 }
 
 int lwm2m_notify_observer(u16_t obj_id, u16_t obj_inst_id, u16_t res_id)
@@ -439,7 +455,7 @@ static int engine_add_observer(struct lwm2m_message *msg,
 		return -ENOENT;
 	}
 
-	ret = update_attrs(&obj->attr_list, &attrs);
+	ret = update_attrs(obj, &attrs);
 	if (ret < 0) {
 		return ret;
 	}
@@ -454,7 +470,7 @@ static int engine_add_observer(struct lwm2m_message *msg,
 			return -ENOENT;
 		}
 
-		ret = update_attrs(&obj_inst->attr_list, &attrs);
+		ret = update_attrs(obj_inst, &attrs);
 		if (ret < 0) {
 			return ret;
 		}
@@ -475,7 +491,7 @@ static int engine_add_observer(struct lwm2m_message *msg,
 			return -ENOENT;
 		}
 
-		ret = update_attrs(&obj_inst->resources[i].attr_list, &attrs);
+		ret = update_attrs(&obj_inst->resources[i], &attrs);
 		if (ret < 0) {
 			return ret;
 		}
@@ -703,8 +719,6 @@ int lwm2m_delete_obj_inst(u16_t obj_id, u16_t obj_inst_id)
 	int i, ret = 0;
 	struct lwm2m_engine_obj *obj;
 	struct lwm2m_engine_obj_inst *obj_inst;
-	struct lwm2m_attr *attr, *tmp;
-	sys_snode_t *prev_node = NULL;
 
 	obj = get_engine_obj(obj_id);
 	if (!obj) {
@@ -725,25 +739,12 @@ int lwm2m_delete_obj_inst(u16_t obj_id, u16_t obj_inst_id)
 
 	/* reset obj_inst and res_inst data structure */
 	for (i = 0; i < obj_inst->resource_count; i++) {
-		SYS_SLIST_FOR_EACH_CONTAINER_SAFE(
-				&obj_inst->resources[i].attr_list, attr,
-				tmp, node) {
-			sys_slist_remove(&obj_inst->resources[i].attr_list,
-					 prev_node, &attr->node);
-			memset(attr, 0, sizeof(*attr));
-		}
-
+		clear_attrs(&obj_inst->resources[i]);
 		memset(obj_inst->resources + i, 0,
 		       sizeof(struct lwm2m_engine_res_inst));
 	}
 
-	SYS_SLIST_FOR_EACH_CONTAINER_SAFE(
-			&obj_inst->attr_list, attr, tmp, node) {
-		sys_slist_remove(&obj_inst->attr_list, prev_node,
-				 &attr->node);
-		memset(attr, 0, sizeof(*attr));
-	}
-
+	clear_attrs(obj_inst);
 	memset(obj_inst, 0, sizeof(struct lwm2m_engine_obj_inst));
 #ifdef CONFIG_LWM2M_RD_CLIENT_SUPPORT
 	engine_trigger_update();
@@ -2194,21 +2195,20 @@ static int lwm2m_write_attr_handler(struct lwm2m_engine_obj *obj,
 {
 	bool update_observe_node = false;
 	char opt_buf[COAP_OPTION_BUF_LEN];
-	int nr_opt, ret = 0;
+	int nr_opt, i, ret = 0;
 	struct coap_option options[NR_LWM2M_ATTR];
 	struct lwm2m_engine_obj_inst *obj_inst = NULL;
 	struct lwm2m_engine_res_inst *res = NULL;
 	struct lwm2m_input_context *in;
 	struct lwm2m_obj_path *path;
-	struct lwm2m_attr *attr, *tmp;
+	struct lwm2m_attr *attr;
 	struct notification_attrs nattrs = { 0 };
 	struct observe_node *obs;
-	sys_slist_t *attr_list;
-	sys_snode_t *prev_node = NULL;
 	u8_t type = 0;
 	void *nattr_ptrs[NR_LWM2M_ATTR] = {
 		&nattrs.pmin, &nattrs.pmax, &nattrs.gt, &nattrs.lt, &nattrs.st
 	};
+	void *ref;
 
 	if (!obj || !context) {
 		return -EINVAL;
@@ -2237,29 +2237,29 @@ static int lwm2m_write_attr_handler(struct lwm2m_engine_obj *obj,
 			return ret;
 		}
 
-		attr_list = &res->attr_list;
+		ref = res;
 	} else if (path->level == 1) {
-		attr_list = &obj->attr_list;
+		ref = obj;
 	} else if (path->level == 2) {
 		obj_inst = get_engine_obj_inst(path->obj_id, path->obj_inst_id);
 		if (!obj_inst) {
 			return -ENOENT;
 		}
 
-		attr_list = &obj_inst->attr_list;
+		ref = obj_inst;
 	} else {
 		/* bad request */
 		return -EEXIST;
 	}
 
 	/* retrieve existing attributes */
-	ret = update_attrs(attr_list, &nattrs);
+	ret = update_attrs(ref, &nattrs);
 	if (ret < 0) {
 		return ret;
 	}
 
 	/* loop through options to parse attribute */
-	for (int i = 0; i < nr_opt; i++) {
+	for (i = 0; i < nr_opt; i++) {
 		int limit = min(options[i].len, 5), plen = 0, vlen;
 		float32_value_t val = { 0 };
 		type = 0;
@@ -2368,12 +2368,17 @@ static int lwm2m_write_attr_handler(struct lwm2m_engine_obj *obj,
 		}
 	}
 
-	SYS_SLIST_FOR_EACH_CONTAINER_SAFE(attr_list, attr, tmp, node) {
+	/* find matching attributes */
+	for (i = 0; i < CONFIG_LWM2M_NUM_ATTR; i++) {
+		if (ref != write_attr_pool[i].ref) {
+			continue;
+		}
+
+		attr = write_attr_pool + i;
 		type = attr->type;
 
 		if (!(BIT(type) & nattrs.flags)) {
 			SYS_LOG_DBG("Unset attr %s", LWM2M_ATTR_STR[type]);
-			sys_slist_remove(attr_list, prev_node, &attr->node);
 			memset(attr, 0, sizeof(*attr));
 
 			if (type <= LWM2M_ATTR_PMAX) {
@@ -2383,7 +2388,6 @@ static int lwm2m_write_attr_handler(struct lwm2m_engine_obj *obj,
 			continue;
 		}
 
-		prev_node = &attr->node;
 		nattrs.flags &= ~BIT(type);
 
 		if (type <= LWM2M_ATTR_PMAX) {
@@ -2409,15 +2413,13 @@ static int lwm2m_write_attr_handler(struct lwm2m_engine_obj *obj,
 
 	/* add attribute to obj/obj_inst/res */
 	for (type = 0; nattrs.flags && type < NR_LWM2M_ATTR; type++) {
-		int i;
-
 		if (!(BIT(type) & nattrs.flags)) {
 			continue;
 		}
 
 		/* grab an entry for newly added attribute */
 		for (i = 0; i < CONFIG_LWM2M_NUM_ATTR; i++) {
-			if (!write_attr_pool[i].used) {
+			if (!write_attr_pool[i].ref) {
 				break;
 			}
 		}
@@ -2428,7 +2430,8 @@ static int lwm2m_write_attr_handler(struct lwm2m_engine_obj *obj,
 
 		attr = write_attr_pool + i;
 		attr->type = type;
-		attr->used = true;
+		attr->ref = ref;
+
 		if (type <= LWM2M_ATTR_PMAX) {
 			attr->int_val = *(s32_t *)nattr_ptrs[type];
 			update_observe_node = true;
@@ -2437,7 +2440,6 @@ static int lwm2m_write_attr_handler(struct lwm2m_engine_obj *obj,
 			       sizeof(float32_value_t));
 		}
 
-		sys_slist_append(attr_list, &attr->node);
 		nattrs.flags &= ~BIT(type);
 		SYS_LOG_DBG("Add %s to %d.%06d", LWM2M_ATTR_STR[type],
 			    attr->float_val.val1, attr->float_val.val2);
@@ -2464,7 +2466,7 @@ static int lwm2m_write_attr_handler(struct lwm2m_engine_obj *obj,
 		nattrs.pmin = DEFAULT_SERVER_PMIN;
 		nattrs.pmax = DEFAULT_SERVER_PMAX;
 
-		ret = update_attrs(&obj->attr_list, &nattrs);
+		ret = update_attrs(obj, &nattrs);
 		if (ret < 0) {
 			return ret;
 		}
@@ -2486,7 +2488,7 @@ static int lwm2m_write_attr_handler(struct lwm2m_engine_obj *obj,
 				}
 			}
 
-			ret = update_attrs(&obj_inst->attr_list, &nattrs);
+			ret = update_attrs(obj_inst, &nattrs);
 			if (ret < 0) {
 				return ret;
 			}
@@ -2506,7 +2508,7 @@ static int lwm2m_write_attr_handler(struct lwm2m_engine_obj *obj,
 				}
 			}
 
-			ret = update_attrs(&res->attr_list, &nattrs);
+			ret = update_attrs(res, &nattrs);
 			if (ret < 0) {
 				return ret;
 			}
@@ -2696,15 +2698,20 @@ static int do_read_op(struct lwm2m_engine_obj *obj,
 	return ret;
 }
 
-static int print_attr(struct net_pkt *pkt, char *buf, u16_t buflen,
-		      sys_slist_t *attr_list)
+static int print_attr(struct net_pkt *pkt, char *buf, u16_t buflen, void *ref)
 {
 	struct lwm2m_attr *attr;
-	int used, base;
+	int i, used, base;
 	u8_t digit;
 	s32_t fraction;
 
-	SYS_SLIST_FOR_EACH_CONTAINER(attr_list, attr, node) {
+	for (i = 0; i < CONFIG_LWM2M_NUM_ATTR; i++) {
+		if (ref != write_attr_pool[i].ref) {
+			continue;
+		}
+
+		attr = write_attr_pool + i;
+
 		/* assuming integer will have float_val.val2 set as 0 */
 
 		used = snprintk(buf, buflen, ";%s=%s%d%s",
@@ -2823,7 +2830,7 @@ static int do_discover_op(struct lwm2m_engine_context *context, bool well_known)
 			/* report object attrs (5.4.2) */
 			ret = print_attr(out->out_cpkt->pkt,
 					 disc_buf, sizeof(disc_buf),
-					 &obj_inst->obj->attr_list);
+					 obj_inst->obj);
 			if (ret < 0) {
 				return ret;
 			}
@@ -2850,7 +2857,7 @@ static int do_discover_op(struct lwm2m_engine_context *context, bool well_known)
 			/* report object instance attrs (5.4.2) */
 			ret = print_attr(out->out_cpkt->pkt,
 					 disc_buf, sizeof(disc_buf),
-					 &obj_inst->attr_list);
+					 obj_inst);
 			if (ret < 0) {
 				return ret;
 			}
@@ -2880,8 +2887,8 @@ static int do_discover_op(struct lwm2m_engine_context *context, bool well_known)
 			/* report resource attrs when path > 1 (5.4.2) */
 			if (path->level > 1) {
 				ret = print_attr(out->out_cpkt->pkt,
-					disc_buf, sizeof(disc_buf),
-					&obj_inst->resources[i].attr_list);
+						 disc_buf, sizeof(disc_buf),
+						 &obj_inst->resources[i]);
 				if (ret < 0) {
 					return ret;
 				}

--- a/subsys/net/lib/lwm2m/lwm2m_object.h
+++ b/subsys/net/lib/lwm2m/lwm2m_object.h
@@ -211,8 +211,6 @@ struct lwm2m_attr {
 };
 
 struct lwm2m_engine_res_inst {
-	char path[MAX_RESOURCE_LEN]; /* 3/0/0 */
-
 	/* runtime field attributes (lwm2m_attr) */
 	sys_slist_t attr_list;
 
@@ -232,7 +230,6 @@ struct lwm2m_engine_obj_inst {
 	/* instance list */
 	sys_snode_t node;
 
-	char path[MAX_RESOURCE_LEN]; /* 3/0 */
 	struct lwm2m_engine_obj *obj;
 	struct lwm2m_engine_res_inst *resources;
 

--- a/subsys/net/lib/lwm2m/lwm2m_object.h
+++ b/subsys/net/lib/lwm2m/lwm2m_object.h
@@ -143,17 +143,24 @@ typedef struct lwm2m_engine_obj_inst *
 typedef int (*lwm2m_engine_obj_delete_cb_t)(u16_t obj_inst_id);
 
 struct lwm2m_engine_obj {
+	/* object list */
 	sys_snode_t node;
-	u16_t obj_id;
+
+	/* object field definitions */
 	struct lwm2m_engine_obj_field *fields;
-	u16_t field_count;
-	u16_t instance_count;
-	u16_t max_instance_count;
+
+	/* object event callbacks */
 	lwm2m_engine_obj_create_cb_t create_cb;
 	lwm2m_engine_obj_delete_cb_t delete_cb;
 
 	/* runtime field attributes (lwm2m_attr) */
 	sys_slist_t attr_list;
+
+	/* object member data */
+	u16_t obj_id;
+	u16_t field_count;
+	u16_t instance_count;
+	u16_t max_instance_count;
 };
 
 #define INIT_OBJ_RES(res_var, index_var, id_val, multi_var, \
@@ -205,10 +212,6 @@ struct lwm2m_attr {
 
 struct lwm2m_engine_res_inst {
 	char path[MAX_RESOURCE_LEN]; /* 3/0/0 */
-	u16_t  res_id;
-	u8_t   *multi_count_var;
-	void  *data_ptr;
-	size_t data_len;
 
 	/* runtime field attributes (lwm2m_attr) */
 	sys_slist_t attr_list;
@@ -218,30 +221,43 @@ struct lwm2m_engine_res_inst {
 	lwm2m_engine_get_data_cb_t	pre_write_cb;
 	lwm2m_engine_set_data_cb_t	post_write_cb;
 	lwm2m_engine_exec_cb_t		execute_cb;
+
+	u8_t  *multi_count_var;
+	void  *data_ptr;
+	u16_t data_len;
+	u16_t res_id;
 };
 
 struct lwm2m_engine_obj_inst {
+	/* instance list */
 	sys_snode_t node;
+
 	char path[MAX_RESOURCE_LEN]; /* 3/0 */
 	struct lwm2m_engine_obj *obj;
-	u16_t obj_inst_id;
 	struct lwm2m_engine_res_inst *resources;
-	u16_t resource_count;
 
 	/* runtime field attributes (lwm2m_attr) */
 	sys_slist_t attr_list;
+
+	/* object instance member data */
+	u16_t obj_inst_id;
+	u16_t resource_count;
 };
 
 struct lwm2m_output_context {
 	const struct lwm2m_writer *writer;
 	struct coap_packet *out_cpkt;
 
-	/* current write position in net_buf chain */
+	/* current write fragment in net_buf chain */
 	struct net_buf *frag;
-	u16_t offset;
 
 	/* markers for last resource inst */
 	struct net_buf *mark_frag_ri;
+
+	/* current write position in net_buf chain */
+	u16_t offset;
+
+	/* markers for last resource inst ID */
 	u16_t mark_pos_ri;
 
 	/* flags for reader/writer */

--- a/subsys/net/lib/lwm2m/lwm2m_object.h
+++ b/subsys/net/lib/lwm2m/lwm2m_object.h
@@ -153,9 +153,6 @@ struct lwm2m_engine_obj {
 	lwm2m_engine_obj_create_cb_t create_cb;
 	lwm2m_engine_obj_delete_cb_t delete_cb;
 
-	/* runtime field attributes (lwm2m_attr) */
-	sys_slist_t attr_list;
-
 	/* object member data */
 	u16_t obj_id;
 	u16_t field_count;
@@ -200,20 +197,18 @@ struct lwm2m_engine_obj {
 
 /* TODO: support multiple server (sec 5.4.2) */
 struct lwm2m_attr {
+	void *ref;
+
+	/* values */
 	union {
 		float32_value_t float_val;
 		s32_t int_val;
 	};
 
-	sys_snode_t node;
 	u8_t type;
-	bool used;
 };
 
 struct lwm2m_engine_res_inst {
-	/* runtime field attributes (lwm2m_attr) */
-	sys_slist_t attr_list;
-
 	/* callbacks set by user code on obj instance */
 	lwm2m_engine_get_data_cb_t	read_cb;
 	lwm2m_engine_get_data_cb_t	pre_write_cb;
@@ -232,9 +227,6 @@ struct lwm2m_engine_obj_inst {
 
 	struct lwm2m_engine_obj *obj;
 	struct lwm2m_engine_res_inst *resources;
-
-	/* runtime field attributes (lwm2m_attr) */
-	sys_slist_t attr_list;
 
 	/* object instance member data */
 	u16_t obj_inst_id;


### PR DESCRIPTION
The following are a set of LwM2M client optimization patches.
- They drop ~400 bytes in flash and ~2880 bytes of SRAM(!) when test compiling against real HW (nrf52_blenano2)
- Add better handling for update_attrs() function