### PR TITLE
ztest_assert() prints newline after failure message

### DIFF
--- a/tests/ztest/include/ztest_assert.h
+++ b/tests/ztest/include/ztest_assert.h
@@ -49,8 +49,10 @@ static inline void _zassert(int cond,
 		      file, line, func, default_msg);
 #if defined(CONFIG_STDOUT_CONSOLE)
 		vprintf(msg, vargs);
+		printf("\n");
 #else
 		vprintk(msg, vargs);
+		printk("\n");
 #endif
 		va_end(vargs);
 		ztest_test_fail();


### PR DESCRIPTION
Most calls to ztest_assert() contain a message with no trailing
newline. So when it fails, we get (eg:):

```
  starting test - test_multilib

      Assertion failed at common/src/multilib.c:19: test_multilib: (c not equal to 323)
  smoke-test failed: wrong multilib selectedFAIL - test_multilib.
```

when we'd like to get:
```
  smoke-test failed: wrong multilib selected
  FAIL - test_multilib.
```
among other things, because it is easier to parse for correctness.

So this patch adds a trailing newline to the message instead of going
around trying to police every call site to do it.

Signed-off-by: Inaky Perez-Gonzalez <inaky.perez-gonzalez@intel.com>