### PR TITLE
soc: mps2_an385: Enable Memory Protection unit.

### DIFF
--- a/arch/arm/soc/arm/mps2/Kconfig.soc
+++ b/arch/arm/soc/arm/mps2/Kconfig.soc
@@ -11,5 +11,7 @@ depends on SOC_SERIES_MPS2
 config SOC_MPS2_AN385
 	bool "ARM Cortex-M3 SMM on V2M-MPS2 (Application Note AN385)"
 	select CPU_CORTEX_M3
+	select CPU_HAS_MPU
+	select MPU_REQUIRES_POWER_OF_TWO_ALIGNMENT
 
 endchoice


### PR DESCRIPTION
Pending on PR #7035 and QEMU version v2.12

Signed-off-by: Adithya Baglody <adithya.nagaraj.baglody@intel.com>