### PR TITLE
sensors: hts221: Fix a crash due to bad device init

### DIFF
--- a/drivers/sensor/hts221/hts221.c
+++ b/drivers/sensor/hts221/hts221.c
@@ -145,6 +145,12 @@ int hts221_init(struct device *dev)
 		return -EIO;
 	}
 
+	/*
+	 * the device requires about 2.2 ms to download the flash content
+	 * into the volatile mem
+	 */
+	k_sleep(3);
+
 	if (hts221_read_conversion_data(drv_data) < 0) {
 		SYS_LOG_ERR("Failed to read conversion data.");
 		return -EINVAL;


### PR DESCRIPTION
The hts221 requires 2.2 ms at boot time to download
the flash content into the volatile mem and the
calibration values cannot be read before that.

This issue is causing following crash:

  ***** USAGE FAULT *****
    Executing thread ID (thread): 0x20000234
    Faulting instruction address:  0x80037de
    Division by zero
  Fatal fault in essential thread! Spinning...

Signed-off-by: Armando Visconti <armando.visconti@st.com>