### PR TITLE
kconfig: Make 'source' non-globbing and use 'gsource'

### DIFF
--- a/Kconfig.zephyr
+++ b/Kconfig.zephyr
@@ -43,5 +43,8 @@ source "tests/Kconfig"
 # Board defaults should be parsed after SoC defaults
 # because board usually overrides SoC values.
 #
-source "arch/$ENV_VAR_SYM_ARCH/soc/*/Kconfig.defconfig"
-source "$ENV_VAR_SYM_BOARD_DIR/Kconfig.defconfig"
+
+# $ENV_VAR_SYM_ARCH and $ENV_VAR_SYM_BOARD_DIR might be glob patterns
+
+gsource "arch/$ENV_VAR_SYM_ARCH/soc/*/Kconfig.defconfig"
+gsource "$ENV_VAR_SYM_BOARD_DIR/Kconfig.defconfig"

--- a/arch/Kconfig
+++ b/arch/Kconfig
@@ -326,6 +326,7 @@ config BOARD
 	  arch/<arch>/soc/<family>/<series>
 
 
-source "arch/$ENV_VAR_SYM_ARCH/Kconfig"
+# $ENV_VAR_SYM_ARCH might be a glob pattern
+gsource "arch/$ENV_VAR_SYM_ARCH/Kconfig"
 
 source "boards/Kconfig"

--- a/arch/arc/Kconfig
+++ b/arch/arc/Kconfig
@@ -10,7 +10,7 @@ choice
 	prompt "ARC SoC Selection"
 	depends on ARC
 
-	source "arch/arc/soc/*/Kconfig.soc"
+	gsource "arch/arc/soc/*/Kconfig.soc"
 endchoice
 
 
@@ -209,6 +209,6 @@ config CACHE_FLUSHING
 
 endmenu
 
-source "arch/arc/soc/*/Kconfig"
+gsource "arch/arc/soc/*/Kconfig"
 
 endmenu

--- a/arch/arm/Kconfig
+++ b/arch/arm/Kconfig
@@ -11,7 +11,7 @@ choice
 	default SOC_SERIES_KINETIS_K6X
 	depends on ARM
 
-	source "arch/arm/soc/*/Kconfig.soc"
+	gsource "arch/arm/soc/*/Kconfig.soc"
 endchoice
 
 menu "ARM Options"
@@ -29,7 +29,7 @@ source "arch/arm/core/Kconfig"
 
 menu "SoC Configuration"
 
-source "arch/arm/soc/*/Kconfig"
+gsource "arch/arm/soc/*/Kconfig"
 
 endmenu
 endmenu

--- a/arch/arm/soc/arm/Kconfig
+++ b/arch/arm/soc/arm/Kconfig
@@ -16,4 +16,4 @@ config SOC_FAMILY
 	default arm
 endif
 
-source "arch/arm/soc/arm/*/Kconfig.soc"
+gsource "arch/arm/soc/arm/*/Kconfig.soc"

--- a/arch/arm/soc/arm/Kconfig.defconfig
+++ b/arch/arm/soc/arm/Kconfig.defconfig
@@ -5,4 +5,4 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 
-source "arch/arm/soc/arm/*/Kconfig.defconfig.series"
+gsource "arch/arm/soc/arm/*/Kconfig.defconfig.series"

--- a/arch/arm/soc/arm/Kconfig.soc
+++ b/arch/arm/soc/arm/Kconfig.soc
@@ -5,4 +5,4 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 
-source "arch/arm/soc/arm/*/Kconfig.series"
+gsource "arch/arm/soc/arm/*/Kconfig.series"

--- a/arch/arm/soc/arm/beetle/Kconfig.defconfig.series
+++ b/arch/arm/soc/arm/beetle/Kconfig.defconfig.series
@@ -8,7 +8,7 @@
 
 if SOC_SERIES_BEETLE
 
-source "arch/arm/soc/arm/beetle/Kconfig.defconfig.beetle*"
+gsource "arch/arm/soc/arm/beetle/Kconfig.defconfig.beetle*"
 
 config SOC_SERIES
 	default beetle

--- a/arch/arm/soc/arm/mps2/Kconfig.defconfig.series
+++ b/arch/arm/soc/arm/mps2/Kconfig.defconfig.series
@@ -13,6 +13,6 @@ config SYS_CLOCK_HW_CYCLES_PER_SEC
 	int
 	default 25000000
 
-source "arch/arm/soc/arm/mps2/Kconfig.defconfig.mps2*"
+gsource "arch/arm/soc/arm/mps2/Kconfig.defconfig.mps2*"
 
 endif # SOC_SERIES_MPS2

--- a/arch/arm/soc/atmel_sam/Kconfig
+++ b/arch/arm/soc/atmel_sam/Kconfig
@@ -17,4 +17,4 @@ config SOC_FAMILY
 endif #SOC_FAMILY_SAM
 
 # Select SoC Part No. and configuration options
-source "arch/arm/soc/atmel_sam/*/Kconfig.soc"
+gsource "arch/arm/soc/atmel_sam/*/Kconfig.soc"

--- a/arch/arm/soc/atmel_sam/Kconfig.defconfig
+++ b/arch/arm/soc/atmel_sam/Kconfig.defconfig
@@ -10,4 +10,4 @@ config WATCHDOG
 	def_bool y
 
 endif
-source "arch/arm/soc/atmel_sam/*/Kconfig.defconfig.series"
+gsource "arch/arm/soc/atmel_sam/*/Kconfig.defconfig.series"

--- a/arch/arm/soc/atmel_sam/Kconfig.soc
+++ b/arch/arm/soc/atmel_sam/Kconfig.soc
@@ -4,4 +4,4 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 
-source "arch/arm/soc/atmel_sam/*/Kconfig.series"
+gsource "arch/arm/soc/atmel_sam/*/Kconfig.series"

--- a/arch/arm/soc/atmel_sam0/Kconfig
+++ b/arch/arm/soc/atmel_sam0/Kconfig
@@ -15,4 +15,4 @@ config SOC_FAMILY
 
 endif
 
-source "arch/arm/soc/atmel_sam0/*/Kconfig.soc"
+gsource "arch/arm/soc/atmel_sam0/*/Kconfig.soc"

--- a/arch/arm/soc/atmel_sam0/Kconfig.defconfig
+++ b/arch/arm/soc/atmel_sam0/Kconfig.defconfig
@@ -3,4 +3,4 @@
 # Copyright (c) 2017 Google LLC.
 # SPDX-License-Identifier: Apache-2.0
 
-source "arch/arm/soc/atmel_sam0/*/Kconfig.defconfig.series"
+gsource "arch/arm/soc/atmel_sam0/*/Kconfig.defconfig.series"

--- a/arch/arm/soc/atmel_sam0/Kconfig.soc
+++ b/arch/arm/soc/atmel_sam0/Kconfig.soc
@@ -3,4 +3,4 @@
 # Copyright (c) 2017 Google LLC.
 # SPDX-License-Identifier: Apache-2.0
 
-source "arch/arm/soc/atmel_sam0/*/Kconfig.series"
+gsource "arch/arm/soc/atmel_sam0/*/Kconfig.series"

--- a/arch/arm/soc/nordic_nrf/Kconfig
+++ b/arch/arm/soc/nordic_nrf/Kconfig
@@ -16,4 +16,4 @@ config SOC_FAMILY
 	default nordic_nrf
 endif
 
-source "arch/arm/soc/nordic_nrf/*/Kconfig.soc"
+gsource "arch/arm/soc/nordic_nrf/*/Kconfig.soc"

--- a/arch/arm/soc/nordic_nrf/Kconfig.defconfig
+++ b/arch/arm/soc/nordic_nrf/Kconfig.defconfig
@@ -31,6 +31,6 @@ config SOC_FLASH_NRF
 
 endif # FLASH
 
-source "arch/arm/soc/nordic_nrf/*/Kconfig.defconfig.series"
+gsource "arch/arm/soc/nordic_nrf/*/Kconfig.defconfig.series"
 
 endif # SOC_FAMILY_NRF

--- a/arch/arm/soc/nordic_nrf/Kconfig.soc
+++ b/arch/arm/soc/nordic_nrf/Kconfig.soc
@@ -5,5 +5,5 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 
-source "arch/arm/soc/nordic_nrf/*/Kconfig.series"
+gsource "arch/arm/soc/nordic_nrf/*/Kconfig.series"
 

--- a/arch/arm/soc/nordic_nrf/nrf51/Kconfig.defconfig.series
+++ b/arch/arm/soc/nordic_nrf/nrf51/Kconfig.defconfig.series
@@ -8,7 +8,7 @@
 
 if SOC_SERIES_NRF51X
 
-source "arch/arm/soc/nordic_nrf/nrf51/Kconfig.defconfig.nrf51*"
+gsource "arch/arm/soc/nordic_nrf/nrf51/Kconfig.defconfig.nrf51*"
 
 config SOC_SERIES
 	default nrf51

--- a/arch/arm/soc/nordic_nrf/nrf52/Kconfig.defconfig.series
+++ b/arch/arm/soc/nordic_nrf/nrf52/Kconfig.defconfig.series
@@ -7,7 +7,7 @@
 
 if SOC_SERIES_NRF52X
 
-source "arch/arm/soc/nordic_nrf/nrf52/Kconfig.defconfig.nrf52*"
+gsource "arch/arm/soc/nordic_nrf/nrf52/Kconfig.defconfig.nrf52*"
 
 config SOC_SERIES
 	default nrf52

--- a/arch/arm/soc/nxp_imx/Kconfig
+++ b/arch/arm/soc/nxp_imx/Kconfig
@@ -16,7 +16,7 @@ config SOC_FAMILY
 	default "nxp_imx"
 endif
 
-source "arch/arm/soc/nxp_imx/*/Kconfig.soc"
+gsource "arch/arm/soc/nxp_imx/*/Kconfig.soc"
 
 config SOC_PART_NUMBER
 	string

--- a/arch/arm/soc/nxp_imx/Kconfig.defconfig
+++ b/arch/arm/soc/nxp_imx/Kconfig.defconfig
@@ -4,4 +4,4 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 
-source "arch/arm/soc/nxp_imx/*/Kconfig.defconfig.series"
+gsource "arch/arm/soc/nxp_imx/*/Kconfig.defconfig.series"

--- a/arch/arm/soc/nxp_imx/Kconfig.soc
+++ b/arch/arm/soc/nxp_imx/Kconfig.soc
@@ -4,4 +4,4 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 
-source "arch/arm/soc/nxp_imx/*/Kconfig.series"
+gsource "arch/arm/soc/nxp_imx/*/Kconfig.series"

--- a/arch/arm/soc/nxp_imx/rt/Kconfig.defconfig.series
+++ b/arch/arm/soc/nxp_imx/rt/Kconfig.defconfig.series
@@ -15,6 +15,6 @@ config NUM_IRQS
 	# must be >= the highest interrupt number used
 	default 160
 
-source "arch/arm/soc/nxp_imx/rt/Kconfig.defconfig.mimxrt*"
+gsource "arch/arm/soc/nxp_imx/rt/Kconfig.defconfig.mimxrt*"
 
 endif # SOC_SERIES_IMX_RT

--- a/arch/arm/soc/nxp_kinetis/Kconfig
+++ b/arch/arm/soc/nxp_kinetis/Kconfig
@@ -17,7 +17,7 @@ config SOC_FAMILY
 	default "nxp_kinetis"
 endif
 
-source "arch/arm/soc/nxp_kinetis/*/Kconfig.soc"
+gsource "arch/arm/soc/nxp_kinetis/*/Kconfig.soc"
 
 config SOC_PART_NUMBER
 	string

--- a/arch/arm/soc/nxp_kinetis/Kconfig.defconfig
+++ b/arch/arm/soc/nxp_kinetis/Kconfig.defconfig
@@ -1,1 +1,1 @@
-source "arch/arm/soc/nxp_kinetis/*/Kconfig.defconfig.series"
+gsource "arch/arm/soc/nxp_kinetis/*/Kconfig.defconfig.series"

--- a/arch/arm/soc/nxp_kinetis/Kconfig.soc
+++ b/arch/arm/soc/nxp_kinetis/Kconfig.soc
@@ -4,4 +4,4 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 
-source "arch/arm/soc/nxp_kinetis/*/Kconfig.series"
+gsource "arch/arm/soc/nxp_kinetis/*/Kconfig.series"

--- a/arch/arm/soc/nxp_kinetis/k6x/Kconfig.defconfig.series
+++ b/arch/arm/soc/nxp_kinetis/k6x/Kconfig.defconfig.series
@@ -16,6 +16,6 @@ config NUM_IRQS
 	# must be >= the highest interrupt number used
 	default 86
 
-source "arch/arm/soc/nxp_kinetis/k6x/Kconfig.defconfig.mk*"
+gsource "arch/arm/soc/nxp_kinetis/k6x/Kconfig.defconfig.mk*"
 
 endif # SOC_SERIES_KINETIS_K6X

--- a/arch/arm/soc/nxp_kinetis/kl2x/Kconfig.defconfig.series
+++ b/arch/arm/soc/nxp_kinetis/kl2x/Kconfig.defconfig.series
@@ -10,6 +10,6 @@ if SOC_SERIES_KINETIS_KL2X
 config SOC_SERIES
 	default kl2x
 
-source "arch/arm/soc/nxp_kinetis/kl2x/Kconfig.defconfig.mk*"
+gsource "arch/arm/soc/nxp_kinetis/kl2x/Kconfig.defconfig.mk*"
 
 endif # SOC_SERIES_KINETIS_KL2X

--- a/arch/arm/soc/nxp_kinetis/kwx/Kconfig.defconfig.series
+++ b/arch/arm/soc/nxp_kinetis/kwx/Kconfig.defconfig.series
@@ -10,6 +10,6 @@ if SOC_SERIES_KINETIS_KWX
 config SOC_SERIES
 	default kwx
 
-source "arch/arm/soc/nxp_kinetis/kwx/Kconfig.defconfig.mk*"
+gsource "arch/arm/soc/nxp_kinetis/kwx/Kconfig.defconfig.mk*"
 
 endif # SOC_SERIES_KINETIS_KWX

--- a/arch/arm/soc/nxp_lpc/Kconfig
+++ b/arch/arm/soc/nxp_lpc/Kconfig
@@ -16,7 +16,7 @@ config SOC_FAMILY
 	default "nxp_lpc"
 endif
 
-source "arch/arm/soc/nxp_lpc/*/Kconfig.soc"
+gsource "arch/arm/soc/nxp_lpc/*/Kconfig.soc"
 
 config SOC_PART_NUMBER
 	string

--- a/arch/arm/soc/nxp_lpc/Kconfig.defconfig
+++ b/arch/arm/soc/nxp_lpc/Kconfig.defconfig
@@ -4,4 +4,4 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 
-source "arch/arm/soc/nxp_lpc/*/Kconfig.defconfig.series"
+gsource "arch/arm/soc/nxp_lpc/*/Kconfig.defconfig.series"

--- a/arch/arm/soc/nxp_lpc/Kconfig.soc
+++ b/arch/arm/soc/nxp_lpc/Kconfig.soc
@@ -4,4 +4,4 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 
-source "arch/arm/soc/nxp_lpc/*/Kconfig.series"
+gsource "arch/arm/soc/nxp_lpc/*/Kconfig.series"

--- a/arch/arm/soc/nxp_lpc/lpc54xxx/Kconfig.defconfig.series
+++ b/arch/arm/soc/nxp_lpc/lpc54xxx/Kconfig.defconfig.series
@@ -15,6 +15,6 @@ config NUM_IRQS
 	# must be >= the highest interrupt number used
 	default 40
 
-source "arch/arm/soc/nxp_lpc/lpc54xxx/Kconfig.defconfig.lp*"
+gsource "arch/arm/soc/nxp_lpc/lpc54xxx/Kconfig.defconfig.lp*"
 
 endif # SOC_SERIES_LPC54XXX

--- a/arch/arm/soc/silabs_exx32/Kconfig
+++ b/arch/arm/soc/silabs_exx32/Kconfig
@@ -15,7 +15,7 @@ config SOC_FAMILY
 	default "silabs_exx32"
 endif
 
-source "arch/arm/soc/silabs_exx32/*/Kconfig.soc"
+gsource "arch/arm/soc/silabs_exx32/*/Kconfig.soc"
 
 config SOC_PART_NUMBER
 	string

--- a/arch/arm/soc/silabs_exx32/Kconfig.defconfig
+++ b/arch/arm/soc/silabs_exx32/Kconfig.defconfig
@@ -1,1 +1,1 @@
-source "arch/arm/soc/silabs_exx32/*/Kconfig.defconfig.series"
+gsource "arch/arm/soc/silabs_exx32/*/Kconfig.defconfig.series"

--- a/arch/arm/soc/silabs_exx32/Kconfig.soc
+++ b/arch/arm/soc/silabs_exx32/Kconfig.soc
@@ -4,4 +4,4 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 
-source "arch/arm/soc/silabs_exx32/*/Kconfig.series"
+gsource "arch/arm/soc/silabs_exx32/*/Kconfig.series"

--- a/arch/arm/soc/silabs_exx32/efm32wg/Kconfig.defconfig.series
+++ b/arch/arm/soc/silabs_exx32/efm32wg/Kconfig.defconfig.series
@@ -16,6 +16,6 @@ config NUM_IRQS
 	# must be >= the highest interrupt number used
 	default 39
 
-source "arch/arm/soc/silabs_exx32/efm32wg/Kconfig.defconfig.e*"
+gsource "arch/arm/soc/silabs_exx32/efm32wg/Kconfig.defconfig.e*"
 
 endif # SOC_SERIES_EFM32WG

--- a/arch/arm/soc/st_stm32/Kconfig
+++ b/arch/arm/soc/st_stm32/Kconfig
@@ -30,4 +30,4 @@ config STM32_ARM_MPU_ENABLE
 	help
 	  Enable MPU support on STM32 SoCs
 
-source "arch/arm/soc/st_stm32/*/Kconfig.soc"
+gsource "arch/arm/soc/st_stm32/*/Kconfig.soc"

--- a/arch/arm/soc/st_stm32/Kconfig.defconfig
+++ b/arch/arm/soc/st_stm32/Kconfig.defconfig
@@ -1,1 +1,1 @@
-source "arch/arm/soc/st_stm32/*/Kconfig.defconfig.series"
+gsource "arch/arm/soc/st_stm32/*/Kconfig.defconfig.series"

--- a/arch/arm/soc/st_stm32/Kconfig.soc
+++ b/arch/arm/soc/st_stm32/Kconfig.soc
@@ -5,4 +5,4 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 
-source "arch/arm/soc/st_stm32/*/Kconfig.series"
+gsource "arch/arm/soc/st_stm32/*/Kconfig.series"

--- a/arch/arm/soc/st_stm32/stm32f0/Kconfig.defconfig.series
+++ b/arch/arm/soc/st_stm32/stm32f0/Kconfig.defconfig.series
@@ -7,7 +7,7 @@
 
 if SOC_SERIES_STM32F0X
 
-source "arch/arm/soc/st_stm32/stm32f0/Kconfig.defconfig.stm32f0*"
+gsource "arch/arm/soc/st_stm32/stm32f0/Kconfig.defconfig.stm32f0*"
 
 config SOC_SERIES
 	default stm32f0

--- a/arch/arm/soc/st_stm32/stm32f1/Kconfig.defconfig.series
+++ b/arch/arm/soc/st_stm32/stm32f1/Kconfig.defconfig.series
@@ -7,7 +7,7 @@
 
 if SOC_SERIES_STM32F1X
 
-source "arch/arm/soc/st_stm32/stm32f1/Kconfig.defconfig.stm32f1*"
+gsource "arch/arm/soc/st_stm32/stm32f1/Kconfig.defconfig.stm32f1*"
 
 config SOC_SERIES
 	default stm32f1

--- a/arch/arm/soc/st_stm32/stm32f3/Kconfig.defconfig.series
+++ b/arch/arm/soc/st_stm32/stm32f3/Kconfig.defconfig.series
@@ -7,7 +7,7 @@
 
 if SOC_SERIES_STM32F3X
 
-source "arch/arm/soc/st_stm32/stm32f3/Kconfig.defconfig.stm32f3*"
+gsource "arch/arm/soc/st_stm32/stm32f3/Kconfig.defconfig.stm32f3*"
 
 config SOC_SERIES
 	default stm32f3

--- a/arch/arm/soc/st_stm32/stm32f4/Kconfig.defconfig.series
+++ b/arch/arm/soc/st_stm32/stm32f4/Kconfig.defconfig.series
@@ -7,7 +7,7 @@
 
 if SOC_SERIES_STM32F4X
 
-source "arch/arm/soc/st_stm32/stm32f4/Kconfig.defconfig.stm32f4*"
+gsource "arch/arm/soc/st_stm32/stm32f4/Kconfig.defconfig.stm32f4*"
 
 config SOC_SERIES
 	default stm32f4

--- a/arch/arm/soc/st_stm32/stm32l0/Kconfig.defconfig.series
+++ b/arch/arm/soc/st_stm32/stm32l0/Kconfig.defconfig.series
@@ -7,7 +7,7 @@
 
 if SOC_SERIES_STM32L0X
 
-source "arch/arm/soc/st_stm32/stm32l0/Kconfig.defconfig.stm32l0*"
+gsource "arch/arm/soc/st_stm32/stm32l0/Kconfig.defconfig.stm32l0*"
 
 config SOC_SERIES
 	default stm32l0

--- a/arch/arm/soc/st_stm32/stm32l4/Kconfig.defconfig.series
+++ b/arch/arm/soc/st_stm32/stm32l4/Kconfig.defconfig.series
@@ -8,7 +8,7 @@
 
 if SOC_SERIES_STM32L4X
 
-source "arch/arm/soc/st_stm32/stm32l4/Kconfig.defconfig.stm32l4*"
+gsource "arch/arm/soc/st_stm32/stm32l4/Kconfig.defconfig.stm32l4*"
 
 config SOC_SERIES
 	default stm32l4

--- a/arch/arm/soc/ti_simplelink/Kconfig
+++ b/arch/arm/soc/ti_simplelink/Kconfig
@@ -12,4 +12,4 @@ config SOC_FAMILY
 	default ti_simplelink
 endif
 
-source "arch/arm/soc/ti_simplelink/*/Kconfig.soc"
+gsource "arch/arm/soc/ti_simplelink/*/Kconfig.soc"

--- a/arch/arm/soc/ti_simplelink/Kconfig.defconfig
+++ b/arch/arm/soc/ti_simplelink/Kconfig.defconfig
@@ -1,1 +1,1 @@
-source "arch/arm/soc/ti_simplelink/*/Kconfig.defconfig.series"
+gsource "arch/arm/soc/ti_simplelink/*/Kconfig.defconfig.series"

--- a/arch/arm/soc/ti_simplelink/Kconfig.soc
+++ b/arch/arm/soc/ti_simplelink/Kconfig.soc
@@ -1,4 +1,4 @@
 # Kconfig - Texas Instruments SimpleLink Family
 #
 
-source "arch/arm/soc/ti_simplelink/*/Kconfig.series"
+gsource "arch/arm/soc/ti_simplelink/*/Kconfig.series"

--- a/arch/arm/soc/ti_simplelink/cc32xx/Kconfig.defconfig.series
+++ b/arch/arm/soc/ti_simplelink/cc32xx/Kconfig.defconfig.series
@@ -3,7 +3,7 @@
 
 if SOC_SERIES_CC32XX
 
-source "arch/arm/soc/ti_simplelink/cc32xx/Kconfig.defconfig.cc32*"
+gsource "arch/arm/soc/ti_simplelink/cc32xx/Kconfig.defconfig.cc32*"
 
 config SOC_SERIES
 	default cc32xx

--- a/arch/arm/soc/ti_simplelink/msp432p4xx/Kconfig.defconfig.series
+++ b/arch/arm/soc/ti_simplelink/msp432p4xx/Kconfig.defconfig.series
@@ -7,7 +7,7 @@
 
 if SOC_SERIES_MSP432P4XX
 
-source "arch/arm/soc/ti_simplelink/msp432p4xx/Kconfig.defconfig.msp432p4*"
+gsource "arch/arm/soc/ti_simplelink/msp432p4xx/Kconfig.defconfig.msp432p4*"
 
 config SOC_SERIES
 	default msp432p4xx

--- a/arch/nios2/Kconfig
+++ b/arch/nios2/Kconfig
@@ -7,7 +7,7 @@
 choice
 	prompt "Nios II configuration selection"
 	depends on NIOS2
-	source "arch/nios2/soc/*/Kconfig.soc"
+	gsource "arch/nios2/soc/*/Kconfig.soc"
 endchoice
 
 menu "Nios II Options"
@@ -113,6 +113,6 @@ endchoice
 
 endmenu
 
-source "arch/nios2/soc/*/Kconfig"
+gsource "arch/nios2/soc/*/Kconfig"
 
 endmenu

--- a/arch/posix/Kconfig
+++ b/arch/posix/Kconfig
@@ -10,7 +10,7 @@ choice
 	prompt "POSIX Configuration Selection"
 	depends on ARCH_POSIX
 
-	source "arch/posix/soc/*/Kconfig.soc"
+	gsource "arch/posix/soc/*/Kconfig.soc"
 endchoice
 
 menu "POSIX (native) Options"
@@ -34,6 +34,6 @@ config ARCH_POSIX_RECOMMENDED_STACK_SIZE
 	  thread stack, the real stack is the native underlying pthread stack.
 	  Therefore the allocated stack can be limited to this size)
 
-source "arch/posix/soc/*/Kconfig"
+gsource "arch/posix/soc/*/Kconfig"
 
 endmenu

--- a/arch/riscv32/Kconfig
+++ b/arch/riscv32/Kconfig
@@ -7,7 +7,7 @@
 choice
 	prompt "RISCV32 configuration selection"
 	depends on RISCV32
-	source "arch/riscv32/soc/*/Kconfig.soc"
+	gsource "arch/riscv32/soc/*/Kconfig.soc"
 endchoice
 
 menu "RISCV32 Options"
@@ -65,6 +65,6 @@ config GEN_IRQ_VECTOR_TABLE
 
 endmenu
 
-source "arch/riscv32/soc/*/Kconfig"
+gsource "arch/riscv32/soc/*/Kconfig"
 
 endmenu

--- a/arch/riscv32/soc/riscv-privilege/Kconfig
+++ b/arch/riscv32/soc/riscv-privilege/Kconfig
@@ -24,4 +24,4 @@ config RISCV_HAS_PLIC
 	  Does the SOC provide support for a Platform Level Interrupt Controller
 
 
-source "arch/riscv32/soc/riscv-privilege/*/Kconfig.soc"
+gsource "arch/riscv32/soc/riscv-privilege/*/Kconfig.soc"

--- a/arch/riscv32/soc/riscv-privilege/Kconfig.defconfig
+++ b/arch/riscv32/soc/riscv-privilege/Kconfig.defconfig
@@ -4,4 +4,4 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 #
-source "arch/riscv32/soc/riscv-privilege/*/Kconfig.defconfig.series"
+gsource "arch/riscv32/soc/riscv-privilege/*/Kconfig.defconfig.series"

--- a/arch/riscv32/soc/riscv-privilege/Kconfig.soc
+++ b/arch/riscv32/soc/riscv-privilege/Kconfig.soc
@@ -5,4 +5,4 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 
-source "arch/riscv32/soc/riscv-privilege/*/Kconfig.series"
+gsource "arch/riscv32/soc/riscv-privilege/*/Kconfig.series"

--- a/arch/x86/Kconfig
+++ b/arch/x86/Kconfig
@@ -10,7 +10,7 @@ choice
 	prompt "x86 SoC Selection"
 	depends on X86
 
-	source "arch/x86/soc/*/Kconfig.soc"
+	gsource "arch/x86/soc/*/Kconfig.soc"
 endchoice
 
 menu "X86 Architecture Options"
@@ -312,6 +312,6 @@ config X86_FIXED_IRQ_MAPPING
 
 endmenu
 
-source "arch/x86/soc/*/Kconfig"
+gsource "arch/x86/soc/*/Kconfig"
 
 endmenu

--- a/arch/x86/soc/intel_quark/Kconfig
+++ b/arch/x86/soc/intel_quark/Kconfig
@@ -14,6 +14,6 @@ config SOC_FAMILY
 	default "intel_quark"
 endif
 
-source "arch/x86/soc/intel_quark/*/Kconfig.soc"
+gsource "arch/x86/soc/intel_quark/*/Kconfig.soc"
 
-source "arch/x86/soc/intel_quark/*/Kconfig"
+gsource "arch/x86/soc/intel_quark/*/Kconfig"

--- a/arch/x86/soc/intel_quark/Kconfig.defconfig
+++ b/arch/x86/soc/intel_quark/Kconfig.defconfig
@@ -1,1 +1,1 @@
-source "arch/x86/soc/intel_quark/*/Kconfig.defconfig.series"
+gsource "arch/x86/soc/intel_quark/*/Kconfig.defconfig.series"

--- a/arch/x86/soc/intel_quark/Kconfig.soc
+++ b/arch/x86/soc/intel_quark/Kconfig.soc
@@ -4,4 +4,4 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 
-source "arch/x86/soc/intel_quark/*/Kconfig.series"
+gsource "arch/x86/soc/intel_quark/*/Kconfig.series"

--- a/arch/x86/soc/intel_quark/quark_se/Kconfig.defconfig.series
+++ b/arch/x86/soc/intel_quark/quark_se/Kconfig.defconfig.series
@@ -246,7 +246,7 @@ config USB_DW_IRQ_PRI
 	default 3
 endif # USB
 
-source "arch/x86/soc/intel_quark/quark_se/Kconfig.defconfig.quark_se*"
-source "arch/x86/soc/intel_quark/quark_se/Kconfig.defconfig.curie*"
+gsource "arch/x86/soc/intel_quark/quark_se/Kconfig.defconfig.quark_se*"
+gsource "arch/x86/soc/intel_quark/quark_se/Kconfig.defconfig.curie*"
 
 endif # SOC_SERIES_QUARK_SE

--- a/arch/xtensa/Kconfig
+++ b/arch/xtensa/Kconfig
@@ -6,7 +6,7 @@
 choice
 	prompt "XTENSA core Selection"
 	depends on XTENSA
-	source "arch/xtensa/soc/*/Kconfig.soc"
+	gsource "arch/xtensa/soc/*/Kconfig.soc"
 endchoice
 
 menu "XTENSA Options"
@@ -109,7 +109,7 @@ config TOOLCHAIN_VARIANT
 	string
 	default RG-2016.4-linux
 
-source "arch/xtensa/soc/*/Kconfig"
+gsource "arch/xtensa/soc/*/Kconfig"
 
 endmenu
 

--- a/boards/Kconfig
+++ b/boards/Kconfig
@@ -14,12 +14,14 @@ config QEMU_TARGET
 	  Mark all QEMU targets with this variable for checking whether we are
 	  running in an emulated environment.
 
+# $ENV_VAR_SYM_BOARD_DIR might be a glob pattern
+
 choice
 prompt "Board Selection"
-source "$ENV_VAR_SYM_BOARD_DIR/Kconfig.board"
+gsource "$ENV_VAR_SYM_BOARD_DIR/Kconfig.board"
 endchoice
 
 
 menu "Board Options"
-source "$ENV_VAR_SYM_BOARD_DIR/Kconfig"
+gsource "$ENV_VAR_SYM_BOARD_DIR/Kconfig"
 endmenu

--- a/drivers/i2s/Kconfig
+++ b/drivers/i2s/Kconfig
@@ -38,6 +38,6 @@ config SYS_LOG_I2S_LEVEL
 
 comment "Device Drivers"
 
-source "drivers/i2s/Kconfig.*"
+gsource "drivers/i2s/Kconfig.*"
 
 endif # I2S

--- a/scripts/kconfig/kconfiglib.py
+++ b/scripts/kconfig/kconfiglib.py
@@ -1941,7 +1941,6 @@ class Kconfig(object):
                 prev.next = prev = node
 
             elif t0 == _T_SOURCE:
-                assert False # T_SOURCE is not in use in Zephyr for now.
                 self._enter_file(self._expand_syms(self._expect_str_and_eol()))
                 prev = self._parse_block(None, parent, prev, visible_if_deps)
                 self._leave_file()
@@ -4998,7 +4997,7 @@ _get_keyword = {
     "range":          _T_RANGE,
     "rsource":        _T_RSOURCE,
     "select":         _T_SELECT,
-    "source":         _T_GSOURCE, # Have 'source' behave like 'gsource' for now
+    "source":         _T_SOURCE,
     "string":         _T_STRING,
     "tristate":       _T_TRISTATE,
     "visible":        _T_VISIBLE,


### PR DESCRIPTION
Until now, Zephyr has used a patched Kconfiglib that turns 'source' into
a globbing source (by replacing 'source' with 'gsource' at the token
level). There's two problems with this:

  - The patch needs to be maintained separately

  - Misspelled filenames are silently ignored, as they look like glob
    patterns that don't match anything

Fix it as follows:

  1. Replace all 'source' statements that use wildcards with 'gsource'

  2. Remove the custom Kconfiglib patch so that 'source' no longer globs

The sed pattern `/source.*[*?]/s/source/gsource/` was run over all
Kconfig* files to do the replacement.

source's that use environment variables that might contain glob patterns
were manually changed to gsource.

Building the docs in doc/ is a good test, as doc/Makefile deliberately
sets the environment variables to glob up as many Kconfig files as
possible.

Signed-off-by: Ulf Magnusson <ulfalizer@gmail.com>