### PR TITLE
checkpatch: downgrade COMPLEX_MACRO to a warning

### DIFF
--- a/scripts/checkpatch.pl
+++ b/scripts/checkpatch.pl
@@ -4959,7 +4959,7 @@ sub process {
 					ERROR("MULTISTATEMENT_MACRO_USE_DO_WHILE",
 					      "Macros with multiple statements should be enclosed in a do - while loop\n" . "$herectx");
 				} else {
-					ERROR("COMPLEX_MACRO",
+					WARN("COMPLEX_MACRO",
 					      "Macros with complex values should be enclosed in parentheses\n" . "$herectx");
 				}
 


### PR DESCRIPTION
This is generating lots of false positives and we keep overriding them
manually, so downgrade and mark it as a warning.

Signed-off-by: Anas Nashif <anas.nashif@intel.com>