### PR TITLE
Bluetooth: GATT: Add support to persistent CCC config

### DIFF
--- a/subsys/bluetooth/host/gatt_internal.h
+++ b/subsys/bluetooth/host/gatt_internal.h
@@ -12,6 +12,9 @@ void bt_gatt_init(void);
 void bt_gatt_connected(struct bt_conn *conn);
 void bt_gatt_disconnected(struct bt_conn *conn);
 
+int bt_gatt_store_ccc(const bt_addr_le_t *addr);
+int bt_gatt_clear_ccc(const bt_addr_le_t *addr);
+
 #if defined(CONFIG_BT_GATT_CLIENT)
 void bt_gatt_notification(struct bt_conn *conn, u16_t handle,
 			  const void *data, u16_t length);

--- a/subsys/bluetooth/host/hci_core.c
+++ b/subsys/bluetooth/host/hci_core.c
@@ -38,6 +38,7 @@
 
 #include "conn_internal.h"
 #include "l2cap_internal.h"
+#include "gatt_internal.h"
 #include "smp.h"
 #include "crypto.h"
 #include "settings.h"
@@ -1313,6 +1314,10 @@ int bt_unpair(const bt_addr_le_t *addr)
 		if (keys) {
 			bt_keys_clear(keys);
 		}
+	}
+
+	if (IS_ENABLED(CONFIG_BT_SETTINGS)) {
+		bt_gatt_clear_ccc(addr);
 	}
 
 	return 0;


### PR DESCRIPTION
This makes use of bt_settings to store CCC configs for bonded devices.

Signed-off-by: Luiz Augusto von Dentz <luiz.von.dentz@intel.com>