### PR TITLE
smaples/mgmt/mcumgr/smp_svr: fix missing nffs.h header

### DIFF
--- a/samples/subsys/mgmt/mcumgr/smp_svr/src/main.c
+++ b/samples/subsys/mgmt/mcumgr/smp_svr/src/main.c
@@ -19,6 +19,7 @@
 #include <device.h>
 #include <fs.h>
 #include "fs_mgmt/fs_mgmt.h"
+#include <nffs/nffs.h>
 #endif
 #ifdef CONFIG_MCUMGR_CMD_OS_MGMT
 #include "os_mgmt/os_mgmt.h"


### PR DESCRIPTION
Header was missing after merging PR #6970
`Add support for File System multiple instances`

Signed-off-by: Andrzej Puzdrowski <andrzej.puzdrowski@nordicsemi.no>