### PR TITLE
Fix OpenThread commissioning

### DIFF
--- a/subsys/net/ip/l2/openthread/CMakeLists.txt
+++ b/subsys/net/ip/l2/openthread/CMakeLists.txt
@@ -1,5 +1,5 @@
 zephyr_library_named(subsys__net__ip__l2__openthread)
-zephyr_library_include_directories(. ../..)
+zephyr_library_include_directories(. ../.. ../../../lib/openthread/platform)
 zephyr_library_compile_definitions_ifdef(
   CONFIG_NEWLIB_LIBC __LINUX_ERRNO_EXTENSIONS__
   )

--- a/subsys/net/ip/l2/openthread/openthread.c
+++ b/subsys/net/ip/l2/openthread/openthread.c
@@ -23,7 +23,7 @@
 #include <misc/__assert.h>
 #include <openthread/openthread.h>
 #include <openthread/cli.h>
-#include <openthread/platform/platform.h>
+#include <platform.h>
 
 #include "openthread_utils.h"
 
@@ -202,7 +202,7 @@ static enum net_verdict openthread_recv(struct net_if *iface,
 	/* TODO: get channel from packet */
 	recv_frame.mChannel = CONFIG_OPENTHREAD_CHANNEL;
 	recv_frame.mLqi = net_pkt_ieee802154_lqi(pkt);
-	recv_frame.mPower = net_pkt_ieee802154_rssi(pkt);
+	recv_frame.mRssi = net_pkt_ieee802154_rssi(pkt);
 
 #if defined(CONFIG_OPENTHREAD_L2_DEBUG_DUMP_15_4)
 	net_hexdump_frags("Received 802.15.4 frame", pkt, true);

--- a/subsys/net/ip/l2/openthread/openthread.c
+++ b/subsys/net/ip/l2/openthread/openthread.c
@@ -24,6 +24,7 @@
 #include <openthread/openthread.h>
 #include <openthread/cli.h>
 #include <platform.h>
+#include <platform-zephyr.h>
 
 #include "openthread_utils.h"
 
@@ -199,8 +200,7 @@ static enum net_verdict openthread_recv(struct net_if *iface,
 	recv_frame.mPsdu = net_buf_frag_last(pkt->frags)->data;
 	/* Length inc. CRC. */
 	recv_frame.mLength = net_buf_frags_len(pkt->frags);
-	/* TODO: get channel from packet */
-	recv_frame.mChannel = CONFIG_OPENTHREAD_CHANNEL;
+	recv_frame.mChannel = platformRadioChannelGet(ot_context->instance);
 	recv_frame.mLqi = net_pkt_ieee802154_lqi(pkt);
 	recv_frame.mRssi = net_pkt_ieee802154_rssi(pkt);
 

--- a/subsys/net/lib/openthread/CMakeLists.txt
+++ b/subsys/net/lib/openthread/CMakeLists.txt
@@ -23,7 +23,7 @@ if(NOT EXTERNAL_PROJECT_PATH_OPENTHREAD)
   # TODO: Point to a Zephyr fork
   # Nov. 7
   set_ifndef(ot_GIT_REPOSITORY "https://github.com/openthread/openthread.git")
-  set_ifndef(ot_GIT_TAG a89eb887488dcbab7f5e9237e2bbcaad38140690)
+  set_ifndef(ot_GIT_TAG db4759cc41257d0572ddedbeead1e02c52033620)
   set_ifndef(ot_GIT_PROGRESS 1)
 
   list(APPEND cmd
@@ -192,15 +192,20 @@ list(APPEND cmd
 
 # TODO: Find out how to make this work.
 set(ot_include_dir ${ot_SOURCE_DIR}/include)
+# For platform.h
+set(ot_platforms_dir ${ot_SOURCE_DIR}/examples/platforms)
 
 # TODO: Is this only needed by alarm.c?
 zephyr_system_include_directories(${ot_include_dir})
+zephyr_system_include_directories(${ot_platforms_dir})
 
 # TODO: Why doesn't app get this path from the above function call?
 target_include_directories(app SYSTEM PRIVATE ${ot_include_dir})
+target_include_directories(app SYSTEM PRIVATE ${ot_platforms_dir})
 
 #set_target_properties(ot_lib PROPERTIES INTERFACE_INCLUDE_DIRECTORIES ${ot_include_dir})
 zephyr_include_directories(${ot_include_dir})
+zephyr_include_directories(${ot_platforms_dir})
 
 # Determine which libs should be linked in
 set(ot_libs

--- a/subsys/net/lib/openthread/platform/alarm.c
+++ b/subsys/net/lib/openthread/platform/alarm.c
@@ -9,7 +9,7 @@
 #include <inttypes.h>
 
 #include <openthread/platform/alarm-milli.h>
-#include <openthread/platform/platform.h>
+#include <platform.h>
 
 #define SYS_LOG_DOMAIN "openthread-plat"
 #define SYS_LOG_LEVEL SYS_LOG_LEVEL_DEBUG

--- a/subsys/net/lib/openthread/platform/platform-zephyr.h
+++ b/subsys/net/lib/openthread/platform/platform-zephyr.h
@@ -13,6 +13,8 @@
 #ifndef PLATFORM_ZEPHYR_H_
 #define PLATFORM_ZEPHYR_H_
 
+#include <stdint.h>
+
 #include <openthread/openthread.h>
 
 /**
@@ -42,6 +44,16 @@ void platformRadioInit(void);
  *
  */
 void platformRadioProcess(otInstance *aInstance);
+
+/**
+ * Get current channel from radio driver.
+ *
+ * @param[in]  aInstance  The OpenThread instance structure.
+ *
+ * @return Current channel radio driver operates on.
+ *
+ */
+uint16_t platformRadioChannelGet(otInstance *aInstance);
 
 /**
  * This function initializes the random number service used by OpenThread.

--- a/subsys/net/lib/openthread/platform/radio.c
+++ b/subsys/net/lib/openthread/platform/radio.c
@@ -32,6 +32,8 @@
 
 #include <openthread/types.h>
 
+#include "platform-zephyr.h"
+
 #define FCS_SIZE 2
 
 static otRadioState sState = OT_RADIO_STATE_DISABLED;
@@ -45,6 +47,7 @@ static struct device *radio_dev;
 static struct ieee802154_radio_api *radio_api;
 
 static s8_t tx_power;
+static u16_t channel;
 
 static void dataInit(void)
 {
@@ -87,6 +90,8 @@ void platformRadioProcess(otInstance *aInstance)
 		 * adds CRC and increases frame length on its own.
 		 */
 		tx_payload->len = sTransmitFrame.mLength - FCS_SIZE;
+
+		channel = sTransmitFrame.mChannel;
 
 		radio_api->set_channel(radio_dev, sTransmitFrame.mChannel);
 		radio_api->set_txpower(radio_dev, tx_power);
@@ -134,6 +139,13 @@ void platformRadioProcess(otInstance *aInstance)
 			}
 		}
 	}
+}
+
+uint16_t platformRadioChannelGet(otInstance *aInstance)
+{
+	ARG_UNUSED(aInstance);
+
+	return channel;
 }
 
 void otPlatRadioSetPanId(otInstance *aInstance, u16_t aPanId)
@@ -206,6 +218,8 @@ otError otPlatRadioSleep(otInstance *aInstance)
 otError otPlatRadioReceive(otInstance *aInstance, u8_t aChannel)
 {
 	ARG_UNUSED(aInstance);
+
+	channel = aChannel;
 
 	radio_api->set_channel(radio_dev, aChannel);
 	radio_api->set_txpower(radio_dev, tx_power);

--- a/subsys/net/lib/openthread/platform/radio.c
+++ b/subsys/net/lib/openthread/platform/radio.c
@@ -28,7 +28,7 @@
 
 #include <openthread/platform/radio.h>
 #include <openthread/platform/diag.h>
-#include <openthread/platform/platform.h>
+#include <platform.h>
 
 #include <openthread/types.h>
 
@@ -89,7 +89,7 @@ void platformRadioProcess(otInstance *aInstance)
 		tx_payload->len = sTransmitFrame.mLength - FCS_SIZE;
 
 		radio_api->set_channel(radio_dev, sTransmitFrame.mChannel);
-		radio_api->set_txpower(radio_dev, sTransmitFrame.mPower);
+		radio_api->set_txpower(radio_dev, tx_power);
 
 		if (sTransmitFrame.mIsCcaEnabled) {
 			if (radio_api->cca(radio_dev) ||
@@ -123,7 +123,7 @@ void platformRadioProcess(otInstance *aInstance)
 				ackPsdu[2] = sTransmitFrame.mPsdu[2];
 				ackFrame.mPsdu = ackPsdu;
 				ackFrame.mLqi = 80;
-				ackFrame.mPower = -40;
+				ackFrame.mRssi = -40;
 				ackFrame.mLength = 5;
 
 				otPlatRadioTxDone(aInstance, &sTransmitFrame,
@@ -344,9 +344,25 @@ int8_t otPlatRadioGetReceiveSensitivity(otInstance *aInstance)
 	return -100;
 }
 
-void otPlatRadioSetDefaultTxPower(otInstance *aInstance, int8_t aPower)
+otError otPlatRadioGetTransmitPower(otInstance *aInstance, int8_t *aPower)
+{
+	ARG_UNUSED(aInstance);
+
+	if (aPower == NULL) {
+		return OT_ERROR_INVALID_ARGS;
+	}
+
+	*aPower = tx_power;
+
+	return OT_ERROR_NONE;
+}
+
+otError otPlatRadioSetTransmitPower(otInstance *aInstance, int8_t aPower)
 {
 	ARG_UNUSED(aInstance);
 
 	tx_power = aPower;
+
+	return OT_ERROR_NONE;
 }
+

--- a/subsys/net/lib/openthread/platform/shell.c
+++ b/subsys/net/lib/openthread/platform/shell.c
@@ -9,7 +9,7 @@
 #include <misc/printk.h>
 #include <shell/shell.h>
 #include <openthread/cli.h>
-#include <openthread/platform/platform.h>
+#include <platform.h>
 
 #include "platform-zephyr.h"
 


### PR DESCRIPTION
Fixes #6874.

First commit bumps OT version to get fixes that enable valid Joiner ID handling and correct radio operation after `thread stop` command was called. It also contains changes in Zephyr port required to work with updated version.
Second commit provides a function to obtain channel that radio currently operates on. In result, device can join network discovered at any channel, not only the hardcoded one.