### PR TITLE
subsys: usb: check for invalid descriptor type request

### DIFF
--- a/subsys/usb/usb_device.c
+++ b/subsys/usb/usb_device.c
@@ -389,6 +389,15 @@ static bool usb_get_descriptor(u16_t type_index, u16_t lang_id,
 	type = GET_DESC_TYPE(type_index);
 	index = GET_DESC_INDEX(type_index);
 
+	/*
+	 * Invalid types of descriptors,
+	 * see USB Spec. Revision 2.0, 9.4.3 Get Descriptor
+	 */
+	if ((type == DESC_INTERFACE) || (type == DESC_ENDPOINT) ||
+	    (type > DESC_OTHER_SPEED)) {
+		return false;
+	}
+
 	p = (u8_t *)usb_dev.descriptors;
 	cur_index = 0;
 


### PR DESCRIPTION
Implementation of Get Descriptor Request should not return interface
or endpoint descriptors in a single request without configuration
descriptor, see USB Spec. Revision 2.0, 9.4.3 Get Descriptor

This patch fixes linux kernel usbtest subtest 7 and subtest 11 errors.