### PR TITLE
doc: fix misspellings in doc and Kconfig files

### DIFF
--- a/boards/arm/colibri_imx7d_m4/doc/colibri_imx7d_m4.rst
+++ b/boards/arm/colibri_imx7d_m4/doc/colibri_imx7d_m4.rst
@@ -118,7 +118,7 @@ The M4 Core is configured to run at a 200 MHz clock speed.
 Serial Port
 ===========
 
-The iMX7D SoC has seven UARTs. The numeber 2 is configured for the console and
+The iMX7D SoC has seven UARTs. The number 2 is configured for the console and
 the remaining are not used/tested.
 
 Programming and Debugging

--- a/doc/kernel/usermode/syscalls.rst
+++ b/doc/kernel/usermode/syscalls.rst
@@ -295,7 +295,7 @@ Several macros exist to validate arguments:
 * :c:macro:`_SYSCALL_DRIVER_OP()` checks at runtime if a driver
   instance is capable of performing a particular operation.  While this
   macro can be used by itself, it's mostly a building block for macros
-  that are automatically generated for every driver subsytem.  For
+  that are automatically generated for every driver subsystem.  For
   instance, to validate the GPIO driver, one could use the
   :c:macro:`_SYSCALL_DRIVER_GPIO()` macro.
 

--- a/drivers/led/Kconfig.lp3943
+++ b/drivers/led/Kconfig.lp3943
@@ -12,7 +12,7 @@ menuconfig LP3943
 	  Enable LED driver for LP3943.
 
 	  LP3943 LED driver has 16 channels each with multi-programmable
-	  states at a specified rate. Each channel can drive upto 25 mA
+	  states at a specified rate. Each channel can drive up to 25 mA
 	  per LED.
 
 if !HAS_DTS_I2C_DEVICE

--- a/kernel/Kconfig
+++ b/kernel/Kconfig
@@ -496,7 +496,7 @@ config RETPOLINE
 	prompt "Build with retpolines enabled"
 	default y if !X86_NO_SPECTRE
 	help
-	  This is recommended on platforms with speculative exeuctions, to protect
+	  This is recommended on platforms with speculative executions, to protect
 	  against branch target injection (AKA Spectre-V2).  Full description of
 	  how retpolines work can be found here[1].
 


### PR DESCRIPTION
Fix misspellings missed during regular PR reviews.

Signed-off-by: David B. Kinder <david.b.kinder@intel.com>