### PR TITLE
arch: ARM: Change the march used by cortex-m0 and cortex-m0plus

### DIFF
--- a/arch/arm/CMakeLists.txt
+++ b/arch/arm/CMakeLists.txt
@@ -1,7 +1,7 @@
 zephyr_cc_option_ifdef(CONFIG_LTO -flto)
 
-set(ARCH_FOR_cortex-m0        armv6-m         )
-set(ARCH_FOR_cortex-m0plus    armv6-m         )
+set(ARCH_FOR_cortex-m0        armv6s-m        )
+set(ARCH_FOR_cortex-m0plus    armv6s-m        )
 set(ARCH_FOR_cortex-m3        armv7-m         )
 set(ARCH_FOR_cortex-m4        armv7e-m        )
 set(ARCH_FOR_cortex-m23       armv8-m.base    )


### PR DESCRIPTION
Use -march=armv6s-m to ensure the svc directive exists