### PR TITLE
tests posix: fix non-initialized variables issue (lib/posix/pthread.c coverage issue fix)

### DIFF
--- a/tests/posix/mqueue/src/mqueue_test.c
+++ b/tests/posix/mqueue/src/mqueue_test.c
@@ -65,7 +65,7 @@ void test_mqueue(void)
 	struct mq_attr attrs;
 	s32_t mode = 0777, flags = O_RDWR | O_CREAT, ret, i;
 	void *retval;
-	pthread_attr_t attr[N_THR];
+	pthread_attr_t attr[N_THR] = {0};
 	pthread_t newthread[N_THR];
 
 	attrs.mq_msgsize = MESSAGE_SIZE;

--- a/tests/posix/pthread/src/pthread.c
+++ b/tests/posix/pthread/src/pthread.c
@@ -175,7 +175,7 @@ int barrier_test_done(void)
 void test_pthread(void)
 {
 	int i, ret, min_prio, max_prio;
-	pthread_attr_t attr[N_THR];
+	pthread_attr_t attr[N_THR] = {0};
 	struct sched_param schedparam;
 	pthread_t newthread[N_THR];
 	int schedpolicy = SCHED_FIFO;

--- a/tests/posix/pthread_cancel/src/pthread_cancel.c
+++ b/tests/posix/pthread_cancel/src/pthread_cancel.c
@@ -51,7 +51,7 @@ void *thread_top(void *p1)
 void test_pthread_cancel(void)
 {
 	s32_t i, ret;
-	pthread_attr_t attr[N_THR];
+	pthread_attr_t attr[N_THR] = {0};
 	struct sched_param schedparam;
 	pthread_t newthread[N_THR];
 	void *retval;

--- a/tests/posix/pthread_equal/src/pthread_equal.c
+++ b/tests/posix/pthread_equal/src/pthread_equal.c
@@ -23,7 +23,7 @@ void *thread_top(void *p1)
 void test_pthread_equal(void)
 {
 	int ret = -1;
-	pthread_attr_t attr;
+	pthread_attr_t attr = {0};
 	struct sched_param schedparam;
 	pthread_t newthread;
 

--- a/tests/posix/pthread_join/src/pthread.c
+++ b/tests/posix/pthread_join/src/pthread.c
@@ -46,7 +46,7 @@ static bool is_sched_prio_valid(int prio, int policy)
 void test_pthread_join(void)
 {
 	s32_t i, ret;
-	pthread_attr_t attr[N_THR];
+	pthread_attr_t attr[N_THR] = {0};
 	struct sched_param schedparam;
 	pthread_t newthread[N_THR];
 	u32_t detachstate, schedpolicy = SCHED_RR;

--- a/tests/posix/pthread_rwlock/src/posix_rwlock.c
+++ b/tests/posix/pthread_rwlock/src/posix_rwlock.c
@@ -54,7 +54,7 @@ static void *thread_top(void *p1)
 static void test_rw_lock(void)
 {
 	s32_t i, ret;
-	pthread_attr_t attr[N_THR];
+	pthread_attr_t attr[N_THR] = {0};
 	struct sched_param schedparam;
 	pthread_t newthread[N_THR];
 	struct timespec time;

--- a/tests/posix/semaphore/src/sem.c
+++ b/tests/posix/semaphore/src/sem.c
@@ -26,7 +26,7 @@ static void *foo_func(void *p1)
 static void test_sema(void)
 {
 	pthread_t newthread;
-	pthread_attr_t attr;
+	pthread_attr_t attr = {0};
 	struct sched_param schedparam;
 	int schedpolicy = SCHED_FIFO;
 	int val, ret;


### PR DESCRIPTION
Fix several non-initialized stack allocated variables which caused
unpredictable test behaviour.

Note: It was detected through variations in the coverage reports.

Signed-off-by: Alberto Escolar Piedras <alpi@oticon.com>