### PR TITLE
tests kernel pending: unitialized variable

### DIFF
--- a/tests/kernel/pending/src/main.c
+++ b/tests/kernel/pending/src/main.c
@@ -279,8 +279,8 @@ void test_pending(void)
 	 */
 	k_thread_priority_set(k_current_get(), 9);
 
-	struct offload_work offload1;
-	struct offload_work offload2;
+	struct offload_work offload1 = {0};
+	struct offload_work offload2 = {0};
 
 	k_work_init(&offload1.work_item, sync_threads);
 	offload1.sem = &start_test_sem;


### PR DESCRIPTION
Fix in an unitialized variable in tests/kernel/pending.
To avoid a set of valgrind errors:
```
==24727== Conditional jump or move depends on uninitialised value(s)
==24727==    at 0x80491F9: atomic_and (atomic.h:250)
==24727==    by 0x80492F9: atomic_clear_bit (atomic.h:391)
==24727==    by 0x804936A: k_work_init (kernel.h:2253)
==24727==    by 0x804A7A7: test_pending (main.c:285)
==24727==    by 0x8052EBB: run_test_functions (ztest.c:56)
==24727==    by 0x8053076: test_cb (ztest.c:196)
==24727== 
==24727== Conditional jump or move depends on uninitialised value(s)
==24727==    at 0x80491B7: atomic_or (atomic.h:208)
==24727==    by 0x804926F: atomic_test_and_set_bit (atomic.h:371)
==24727==    by 0x80493EF: k_work_submit_to_queue (kernel.h:2282)
==24727==    by 0x804A7DE: test_pending (main.c:287)
==24727== 
==24727== Thread 7:
==24727== Conditional jump or move depends on uninitialised value(s)
==24727==    at 0x805B40A: atomic_and (atomic.h:250)
==24727==    by 0x805B485: atomic_test_and_clear_bit (atomic.h:350)
==24727==    by 0x805B627: work_q_main (work_q.c:37)
```

Signed-off-by: Alberto Escolar Piedras <alpi@oticon.com>