### PR TITLE
board/arm/nrf52xx_boards: NFCT pins configuration

### DIFF
--- a/arch/arm/soc/nordic_nrf/nrf52/Kconfig.soc
+++ b/arch/arm/soc/nordic_nrf/nrf52/Kconfig.soc
@@ -36,3 +36,14 @@ config ARM_MPU_NRF52X
 	default n
 	help
 	  Enable MPU support on Nordic Semiconductor nRF52x series ICs.
+
+config NFCT_PINS_AS_GPIOS
+	bool "NFCT pins as GPIOs"
+	depends on SOC_SERIES_NRF52X
+	help
+	  P0.9 and P0.10 are usually reserved for NFC. This option switch
+	  them to normal GPIO mode. HW enabling happens once in the device
+	  lifetime, during the first system startup. Disabling this option will
+	  not switch back these pins to NFCT mode. Doing this requires UICR
+	  erase prior to flashing device using the image which has
+	  this option disabled.

--- a/arch/arm/soc/nordic_nrf/nrf52/Kconfig.soc
+++ b/arch/arm/soc/nordic_nrf/nrf52/Kconfig.soc
@@ -47,3 +47,8 @@ config NFCT_PINS_AS_GPIOS
 	  not switch back these pins to NFCT mode. Doing this requires UICR
 	  erase prior to flashing device using the image which has
 	  this option disabled.
+
+config GPIO_AS_PINRESET
+	bool "GPIO as pin reset (reset button)"
+	depends on SOC_SERIES_NRF52X
+	default y

--- a/boards/arm/96b_nitrogen/Kconfig
+++ b/boards/arm/96b_nitrogen/Kconfig
@@ -6,8 +6,4 @@
 
 if BOARD_96B_NITROGEN
 
-config GPIO_AS_PINRESET
-	bool "GPIO as pin reset (reset button)"
-	default y
-
 endif # BOARD_96B_NITROGEN

--- a/boards/arm/nrf52840_pca10056/Kconfig
+++ b/boards/arm/nrf52840_pca10056/Kconfig
@@ -6,8 +6,4 @@
 
 if BOARD_NRF52840_PCA10056
 
-config GPIO_AS_PINRESET
-	bool "GPIO as pin reset (reset button)"
-	default y
-
 endif # BOARD_NRF52840_PCA10056

--- a/boards/arm/nrf52_pca10040/Kconfig
+++ b/boards/arm/nrf52_pca10040/Kconfig
@@ -6,8 +6,4 @@
 
 if BOARD_NRF52_PCA10040
 
-config  GPIO_AS_PINRESET
-	bool "GPIO as pin reset (reset button)"
-	default y
-
 endif # BOARD_NRF52_PCA10040

--- a/boards/arm/nrf52_vbluno52/Kconfig
+++ b/boards/arm/nrf52_vbluno52/Kconfig
@@ -6,8 +6,4 @@
 
 if BOARD_NRF52_VBLUNO52
 
-config  GPIO_AS_PINRESET
-	bool "GPIO as pin reset (reset button)"
-	default y
-
 endif # BOARD_NRF52_VBLUNO52


### PR DESCRIPTION
It is possible to use NFCT pins as regular GPIOs.
This patch introduce option for enabling this feature.

Fix for #6937 

Additionally this fix nrf52 part of #7452

Signed-off-by: Andrzej Puzdrowski <andrzej.puzdrowski@nordicsemi.no>