### PR TITLE
Bluetooth: Introduce new bt_set_id_addr() API

### DIFF
--- a/include/bluetooth/bluetooth.h
+++ b/include/bluetooth/bluetooth.h
@@ -56,6 +56,21 @@ typedef void (*bt_ready_cb_t)(int err);
  */
 int bt_enable(bt_ready_cb_t cb);
 
+/** @brief Set the local Identity Address
+ *
+ *  Allows setting the local Identity Address from the application.
+ *  This API must be called before calling bt_enable(). Calling it at any
+ *  other time will cause it to fail. In most cases the application doesn't
+ *  need to use this API, however there are a few valid cases where
+ *  it can be useful (such as for testing).
+ *
+ *  At the moment, the given address must be a static random address. In the
+ *  future support for public addresses may be added.
+ *
+ *  @return Zero on success or (negative) error code otherwise.
+ */
+int bt_set_id_addr(const bt_addr_le_t *addr);
+
 /* Advertising API */
 
 /** Description of different data types that can be encoded into

--- a/subsys/bluetooth/host/hci_core.h
+++ b/subsys/bluetooth/host/hci_core.h
@@ -31,6 +31,7 @@ enum {
 	BT_DEV_ENABLE,
 	BT_DEV_READY,
 	BT_DEV_ID_STATIC_RANDOM,
+	BT_DEV_USER_ID_ADDR,
 	BT_DEV_HAS_PUB_KEY,
 	BT_DEV_PUB_KEY_BUSY,
 
@@ -54,6 +55,11 @@ enum {
 	/* Total number of flags - must be at the end of the enum */
 	BT_DEV_NUM_FLAGS,
 };
+
+/* Flags which should not be cleared upon HCI_Reset */
+#define BT_DEV_PERSISTENT_FLAGS (BIT(BT_DEV_ENABLE) | \
+				 BIT(BT_DEV_USER_ID_ADDR) | \
+				 BIT(BT_DEV_ID_STATIC_RANDOM))
 
 struct bt_dev_le {
 	/* LE features */


### PR DESCRIPTION
There are certain use cases where the application needs to be able to
explicitly set a specific identity address. This was previously
possible using the bt_storage API, however now that it's gone another
solution is needed.

This patch adds a ne bt_set_id_addr() API which the application can
use to set a specific identity address before calling bt_enable().

Fixes #7434

Signed-off-by: Johan Hedberg <johan.hedberg@intel.com>