### PR TITLE
arch/arm/soc/nordic_nrf/nrf52: make MPU config depend on series

### DIFF
--- a/arch/arm/soc/nordic_nrf/nrf52/Kconfig.soc
+++ b/arch/arm/soc/nordic_nrf/nrf52/Kconfig.soc
@@ -31,7 +31,7 @@ endchoice
 
 config ARM_MPU_NRF52X
 	bool "Enable MPU on nRF52"
-	depends on CPU_HAS_MPU
+	depends on CPU_HAS_MPU && SOC_SERIES_NRF52X
 	select ARM_MPU
 	default n
 	help


### PR DESCRIPTION
ARM_MPU_NRF52X was independent from SoC series which cause that it
appears for any MPU-equipped device in menuconfig.
This patch mitigates this behavior.

fix for nRF52xx part of #7452

Signed-off-by: Andrzej Puzdrowski <andrzej.puzdrowski@nordicsemi.no>