### PR TITLE
arch: arm: soc: Cleanup Kconfig inclusion per SoC

### DIFF
--- a/arch/arm/soc/arm/Kconfig
+++ b/arch/arm/soc/arm/Kconfig
@@ -14,6 +14,6 @@ if SOC_FAMILY_ARM
 config SOC_FAMILY
 	string
 	default arm
-endif
 
 gsource "arch/arm/soc/arm/*/Kconfig.soc"
+endif # SOC_FAMILY_ARM

--- a/arch/arm/soc/atmel_sam/Kconfig
+++ b/arch/arm/soc/atmel_sam/Kconfig
@@ -14,7 +14,7 @@ config SOC_FAMILY
 	string
 	default atmel_sam
 
-endif #SOC_FAMILY_SAM
-
 # Select SoC Part No. and configuration options
 gsource "arch/arm/soc/atmel_sam/*/Kconfig.soc"
+
+endif # SOC_FAMILY_SAM

--- a/arch/arm/soc/atmel_sam0/Kconfig
+++ b/arch/arm/soc/atmel_sam0/Kconfig
@@ -13,6 +13,6 @@ config SOC_FAMILY
 	string
 	default atmel_sam0
 
-endif
 
 gsource "arch/arm/soc/atmel_sam0/*/Kconfig.soc"
+endif # SOC_FAMILY_SAM0

--- a/arch/arm/soc/nordic_nrf/Kconfig
+++ b/arch/arm/soc/nordic_nrf/Kconfig
@@ -14,6 +14,6 @@ if SOC_FAMILY_NRF
 config SOC_FAMILY
 	string
 	default nordic_nrf
-endif
 
 gsource "arch/arm/soc/nordic_nrf/*/Kconfig.soc"
+endif # SOC_FAMILY_NRF

--- a/arch/arm/soc/nxp_imx/Kconfig
+++ b/arch/arm/soc/nxp_imx/Kconfig
@@ -14,7 +14,6 @@ if SOC_FAMILY_IMX
 config SOC_FAMILY
 	string
 	default "nxp_imx"
-endif
 
 gsource "arch/arm/soc/nxp_imx/*/Kconfig.soc"
 
@@ -25,3 +24,5 @@ config SOC_PART_NUMBER
 	  This string holds the full part number of the SoC. It is a hidden option
 	  that you should not set directly. The part number selection choice defines
 	  the default value for this string.
+
+endif # SOC_FAMILY_IMX

--- a/arch/arm/soc/nxp_kinetis/Kconfig
+++ b/arch/arm/soc/nxp_kinetis/Kconfig
@@ -15,7 +15,6 @@ if SOC_FAMILY_KINETIS
 config SOC_FAMILY
 	string
 	default "nxp_kinetis"
-endif
 
 gsource "arch/arm/soc/nxp_kinetis/*/Kconfig.soc"
 
@@ -117,3 +116,4 @@ config MCG_FRDIV
 	  kHz.
 
 endif # HAS_MCG
+endif # SOC_FAMILY_KINETIS

--- a/arch/arm/soc/nxp_lpc/Kconfig
+++ b/arch/arm/soc/nxp_lpc/Kconfig
@@ -14,7 +14,6 @@ if SOC_FAMILY_LPC
 config SOC_FAMILY
 	string
 	default "nxp_lpc"
-endif
 
 gsource "arch/arm/soc/nxp_lpc/*/Kconfig.soc"
 
@@ -26,3 +25,4 @@ config SOC_PART_NUMBER
 	  This string holds the full part number of the SoC. It is a hidden option
 	  that you should not set directly. The part number selection choice defines
 	  the default value for this string.
+endif # SOC_FAMILY_LPC

--- a/arch/arm/soc/silabs_exx32/Kconfig
+++ b/arch/arm/soc/silabs_exx32/Kconfig
@@ -13,7 +13,6 @@ if SOC_FAMILY_EXX32
 config SOC_FAMILY
 	string
 	default "silabs_exx32"
-endif
 
 gsource "arch/arm/soc/silabs_exx32/*/Kconfig.soc"
 
@@ -69,3 +68,4 @@ config CMU_LFXO_FREQ
 	  board's defconfig.
 
 endif # HAS_CMU
+endif # SOC_FAMILY_EXX32

--- a/arch/arm/soc/st_stm32/Kconfig
+++ b/arch/arm/soc/st_stm32/Kconfig
@@ -20,7 +20,6 @@ config BUILD_OUTPUT_HEX
 config SOC_FAMILY
 	string
 	default st_stm32
-endif
 
 config STM32_ARM_MPU_ENABLE
 	bool "Enable MPU on STM32"
@@ -31,3 +30,5 @@ config STM32_ARM_MPU_ENABLE
 	  Enable MPU support on STM32 SoCs
 
 gsource "arch/arm/soc/st_stm32/*/Kconfig.soc"
+
+endif # SOC_FAMILY_STM32

--- a/arch/arm/soc/ti_simplelink/Kconfig
+++ b/arch/arm/soc/ti_simplelink/Kconfig
@@ -10,6 +10,6 @@ if SOC_FAMILY_TISIMPLELINK
 config SOC_FAMILY
 	string
 	default ti_simplelink
-endif
 
 gsource "arch/arm/soc/ti_simplelink/*/Kconfig.soc"
+endif # SOC_FAMILY_TISIMPLELINK


### PR DESCRIPTION
When we included SoC specific Kconfig files we do something like:

gsource "arch/arm/soc/arm/*/Kconfig.soc"

However, we should do that inside an if block for that SoC family so as
to limit SoC family specific options to only being visible when that SoC
family is selected.  So we simply move the gsource and related items
inside the if SOC_FAMILY_<SOC> block.

Fixes: #7452

Signed-off-by: Kumar Gala <kumar.gala@linaro.org>