### PR TITLE
arch: arm: atmel_sam: Fixup build issue on sam_e70

### DIFF
--- a/arch/arm/soc/atmel_sam/common/arm_mpu_regions.c
+++ b/arch/arm/soc/atmel_sam/common/arm_mpu_regions.c
@@ -16,7 +16,7 @@ static struct arm_mpu_region mpu_regions[] = {
 			 REGION_FLASH_ATTR(REGION_FLASH_SIZE)),
 
 	MPU_REGION_ENTRY("SRAM_0",
-			 CONFIG_SRAM_BASE_ADDRESS_0,
+			 CONFIG_SRAM_BASE_ADDRESS,
 			 REGION_RAM_ATTR(REGION_SRAM_0_SIZE))
 
 };


### PR DESCRIPTION
With recent dts script change we dropped _0 from define names if there
is only a single one.  So for the MPU we need to use
CONFIG_SRAM_BASE_ADDRESS instead of CONFIG_SRAM_BASE_ADDRESS_0.

Signed-off-by: Kumar Gala <kumar.gala@linaro.org>