### PR TITLE
subsys: debug: Fix stack sentinel dependencies

### DIFF
--- a/subsys/debug/Kconfig
+++ b/subsys/debug/Kconfig
@@ -25,8 +25,9 @@ config STACK_USAGE
 
 config STACK_SENTINEL
 	bool "Enable stack sentinel"
-	select THREAD_STACK_INFO
 	default n
+	select THREAD_STACK_INFO
+	depends on !USERSPACE
 	help
 	  Store a magic value at the lowest addresses of a thread's stack.
 	  Periodically check that this value is still present and kill the


### PR DESCRIPTION
This patch restricts the stack sentinel to only be allowed if the
USERSPACE configuration option is not set.  The stack sentinel feature
is redundant if used in conjunction with the USERSPACE, due to the
protection mechanisms in place for stacks.

Fixes #6802 
Signed-off-by: Andy Gross <andy.gross@linaro.org>