### PR TITLE
OpenThread: Change SETTINGS_CONFIG_PAGE_SIZE to target specific value

### DIFF
--- a/dts/arm/nordic/nrf52840.dtsi
+++ b/dts/arm/nordic/nrf52840.dtsi
@@ -27,6 +27,7 @@
 				compatible = "soc-nv-flash";
 				label = "NRF_FLASH";
 				reg = <0x00000000 DT_FLASH_SIZE>;
+				erase-block-size = <4096>;
 				write-block-size = <4>;
 			};
 	};

--- a/subsys/net/lib/openthread/platform/openthread-core-zephyr-config.h
+++ b/subsys/net/lib/openthread/platform/openthread-core-zephyr-config.h
@@ -13,6 +13,8 @@
 #ifndef OPENTHREAD_CORE_ZEPHYR_CONFIG_H_
 #define OPENTHREAD_CORE_ZEPHYR_CONFIG_H_
 
+#include <generated_dts_board.h>
+
 /**
  * @def OPENTHREAD_CONFIG_NUM_MESSAGE_BUFFERS
  *
@@ -73,10 +75,11 @@
 /**
  * @def SETTINGS_CONFIG_PAGE_SIZE
  *
- * The page size of settings.
+ * The page size of settings. Ensure that 'erase-block-size'
+ * is set in your SOC dts file.
  *
  */
-#define SETTINGS_CONFIG_PAGE_SIZE                               4096
+#define SETTINGS_CONFIG_PAGE_SIZE          FLASH_ERASE_BLOCK_SIZE
 
 /**
  * @def SETTINGS_CONFIG_PAGE_NUM


### PR DESCRIPTION
…build value

- Changed define for SETTINGS_CONFIG_PAGE_SIZE from a hard coded value
  to reference build system generated FLASH_ERASE_BLOCK_SIZE. This value
  comes from 'erase-block-size' found in the dtsi file of devices.
- Modified nrf52840.dtsi to include definition for 'erase-block-size'

Fixes #7107

Signed-off-by: David Leach <david.leach@nxp.com>