### PR TITLE
doc: add native posix command line help

### DIFF
--- a/boards/posix/native_posix/doc/board.rst
+++ b/boards/posix/native_posix/doc/board.rst
@@ -159,7 +159,16 @@ Run the zephyr.exe executable as you would any other Linux console application.
 This executable accepts several command line options depending on the
 compilation configuration.
 You can run it with the ``--help`` command line switch to get a list of
-available options.
+available options::
+
+   $ zephyr/zephyr.exe --help
+
+     [-h] [--h] [--help] [-?]  :Display this help
+     [-stop_at=<time>]         :In simulated seconds, when to stop automatically
+     [-seed=<r_seed>]          :Seed for the entropy device
+     [-testargs <arg>...]      :Any argument that follows will be ignored
+                                by the top level, and made
+                                available for possible tests
 
 Note that the Zephyr kernel does not actually exit once the application is
 finished. It simply goes into the idle loop forever.

--- a/doc/getting_started/getting_started.rst
+++ b/doc/getting_started/getting_started.rst
@@ -260,7 +260,8 @@ Running a Sample Application natively (POSIX OS)
 It is also possible to compile some of the sample and test applications to run
 as native process on a POSIX OS (e.g. Linux).
 To be able to do this, remember to have installed the 32 bit libC if your OS is
-natively 64bit.
+natively 64bit. See the :ref:`native_posix` section on host depencencies
+for more information.
 
 To compile and run an application in this way, type:
 
@@ -275,9 +276,13 @@ and then:
 .. code-block:: console
 
    ninja run
+
    # or just:
    zephyr/zephyr.exe
    # Press Ctrl+C to exit
+
+You can run ``zephyr/zephyr.exe --help`` to get a list of available
+options.  See the :ref:`native_posix` document for more information.
 
 This executable can be instrumented like any other Linux process. For ex. with gdb
 or valgrind.


### PR DESCRIPTION
The zephyr.exe created when building a native POSIX application can take
some parameters that are documented in the "board" document, so add a
reference to that documentation here.

fixes: #6384

Signed-off-by: David B. Kinder <david.b.kinder@intel.com>