### PR TITLE
boards: arm: nrf52_blenano2: Add I2C default config

### DIFF
--- a/boards/arm/nrf52_blenano2/Kconfig.defconfig
+++ b/boards/arm/nrf52_blenano2/Kconfig.defconfig
@@ -32,4 +32,24 @@ config UART_NRF5_GPIO_CTS_PIN
 
 endif # UART_NRF5
 
+if I2C
+
+config I2C_NRF5
+        def_bool y
+
+config I2C_0
+        default y
+
+endif # I2C
+
+if I2C_NRF5
+
+config I2C_NRF5_0_GPIO_SCL_PIN
+        default 2
+
+config I2C_NRF5_0_GPIO_SDA_PIN
+        default 28
+
+endif # I2C_NRF5
+
 endif # BOARD_NRF52_BLENANO2


### PR DESCRIPTION
Add default pin configuration for I2C0.
Documentation indicates pin 2 for SCL0 and 28 for SDA0.

Signed-off-by: Loic Poulain <loic.poulain@linaro.org>