### PR TITLE
drivers: spi: fix the bug of slave selection in spi_dw

### DIFF
--- a/drivers/spi/spi_dw.c
+++ b/drivers/spi/spi_dw.c
@@ -250,7 +250,7 @@ static int spi_dw_configure(const struct spi_dw_config *info,
 	if (!spi_dw_is_slave(spi)) {
 		/* Baud rate and Slave select, for master only */
 		write_baudr(SPI_DW_CLK_DIVIDER(config->frequency), info->regs);
-		write_ser(config->slave, info->regs);
+		write_ser(1 << config->slave, info->regs);
 	}
 
 	spi_context_cs_configure(&spi->ctx);


### PR DESCRIPTION
According to data sheet of dw_spi, ser reg is used to
select spi device/slave.

one bit in ser maps to one spi device/slave, i.e..
cs 0 ---> bit 0
cs 1 ---> bit 1
cs 2 ---> bit 2

the original code has a bug. the config->slave cannot
directly be written into ser. It should be mapped to
the correct bits through 1 << config->slave.

Signed-off-by: Wayne Ren <wei.ren@synopsys.com>