### PR TITLE
lib: rbtree: Add RB_FOR_EACH macro for iterative enumeration

### DIFF
--- a/include/misc/rb.h
+++ b/include/misc/rb.h
@@ -4,6 +4,18 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+/* Our SDK/toolchains integration seems to be inconsistent about
+ * whether they expose alloca.h or not.  On gcc it's a moot point as
+ * it's always builtin.
+ */
+#ifdef __GNUC__
+#ifndef alloca
+#define alloca __builtin_alloca
+#endif
+#else
+#include <alloca.h>
+#endif
+
 /**
  * @file
  * @brief Red/Black balanced tree data structure
@@ -97,15 +109,55 @@ int rb_contains(struct rbtree *tree, struct rbnode *node);
 /**
  * @brief Walk/enumerate a rbtree
  *
- * Very simple recursive enumeration implementation.  A rather more
- * subtle (have to alloca() a stack to manage manually) iterative one
- * is possible that uses a FOREACH-style macro API, but this is good
- * enough for many purposes and much smaller.
+ * Very simple recursive enumeration.  Low code size, but requiring a
+ * separate function can be clumsy for the user and there is no way to
+ * break out of the loop early.  See RB_FOR_EACH for an iterative
+ * implementation.
  */
 static inline void rb_walk(struct rbtree *tree, rb_visit_t visit_fn,
 			   void *cookie)
 {
 	_rb_walk(tree->root, visit_fn, cookie);
 }
+
+struct _rb_foreach {
+	struct rbnode **stack;
+	char *is_left;
+	int top;
+};
+
+#define _RB_FOREACH_INIT(tree, node) {					\
+	.stack   = alloca((tree)->max_depth * sizeof(struct rbnode *)), \
+	.is_left = alloca((tree)->max_depth * sizeof(char)),		\
+	.top     = -1							\
+}
+
+struct rbnode *_rb_foreach_next(struct rbtree *tree, struct _rb_foreach *f);
+
+/**
+ * @brief Walk a tree in-order without recursing
+ *
+ * While @ref rb_walk() is very simple, recursing on the C stack can
+ * be clumsy for some purposes and on some architectures wastes
+ * significant memory in stack frames.  This macro implements a
+ * non-recursive "foreach" loop that can iterate directly on the tree,
+ * at a moderate cost in code size.
+ *
+ * Note that the resulting loop is not safe against modifications to
+ * the tree.  Changes to the tree structure during the loop will
+ * produce incorrect results, as nodes may be skipped or duplicated.
+ * Unlike linked lists, no _SAFE variant exists.
+ *
+ * Note also that the macro expands its arguments multiple times, so
+ * they should not be expressions with side effects.
+ *
+ * @param tree A pointer to a struct rbtree to walk
+ * @param node The symbol name of a local struct rbnode* variable to
+ *             use as the iterator
+ */
+#define RB_FOR_EACH(tree, node) \
+	for (struct _rb_foreach __f = _RB_FOREACH_INIT(tree, node);	\
+	     (node = _rb_foreach_next(tree, &__f));			\
+	     /**/)
 
 #endif /* _RB_H */

--- a/tests/lib/rbtree/src/main.c
+++ b/tests/lib/rbtree/src/main.c
@@ -124,13 +124,20 @@ void check_rb(void)
 /* First validates the external API behavior via a walk, then checks
  * interior tree and red/black state via internal APIs.
  */
-void check_tree(int size)
+void _check_tree(int size, int use_foreach)
 {
 	int nwalked = 0, i, ni;
 	struct rbnode *n, *last = NULL;
 
 	memset(walked_nodes, 0, sizeof(walked_nodes));
-	rb_walk(&tree, visit_node, &nwalked);
+
+	if (use_foreach) {
+		RB_FOR_EACH(&tree, n) {
+			visit_node(n, &nwalked);
+		}
+	} else {
+		rb_walk(&tree, visit_node, &nwalked);
+	}
 
 	/* Make sure all found nodes are in-order and marked in the tree */
 	for (i = 0; i < nwalked; i++) {
@@ -161,6 +168,13 @@ void check_tree(int size)
 	if (tree.root) {
 		check_rb();
 	}
+}
+
+void check_tree(int size)
+{
+	/* Do it with both enumeration mechanisms */
+	_check_tree(size, 0);
+	_check_tree(size, 1);
 }
 
 void test_tree(int size)
@@ -209,7 +223,7 @@ void test_rbtree_spam(void)
 			size = MAX_NODES;
 		}
 
-		TC_PRINT("Checking trees build from %d nodes...\n", size);
+		TC_PRINT("Checking trees built from %d nodes...\n", size);
 
 		test_tree(size);
 	} while (size < MAX_NODES);


### PR DESCRIPTION
Works mostly like the list enumeration macros.  Implemented by fairly
clever alloca trickery and some subtle "next node" logic.  More
convenient for many uses, can be early-exited, but has somewhat larger
code size than rb_walk().

Signed-off-by: Andy Ross <andrew.j.ross@intel.com>