### PR TITLE
drivers: sensors: lsm6dsl: Fix array overrun

### DIFF
--- a/drivers/sensor/lsm6dsl/lsm6dsl.c
+++ b/drivers/sensor/lsm6dsl/lsm6dsl.c
@@ -38,11 +38,13 @@ static int lsm6dsl_freq_to_odr_val(u16_t freq)
 
 static int lsm6dsl_odr_to_freq_val(u16_t odr)
 {
-	if (odr > ARRAY_SIZE(lsm6dsl_odr_map)) {
-		odr = ARRAY_SIZE(lsm6dsl_odr_map);
+	/* for valid index, return value from map */
+	if (odr < ARRAY_SIZE(lsm6dsl_odr_map)) {
+		return lsm6dsl_odr_map[odr];
 	}
 
-	return lsm6dsl_odr_map[odr];
+	/* invalid index, return last entry */
+	return lsm6dsl_odr_map[ARRAY_SIZE(lsm6dsl_odr_map) - 1];
 }
 
 #ifdef LSM6DSL_ACCEL_FS_RUNTIME


### PR DESCRIPTION
This patch fixes an overrun detected via Coverity.  The
lsm6dsl_odr_to_freq_val function takes an index as argument.  If the
index is out of bounds, the expected behavior was to return the last
element of an array.  The actual behavior was to overrun the array.

Fixes: #7482

Signed-off-by: Andy Gross <andy.gross@linaro.org>