### PR TITLE
tests: lib: rbtree: Clarify increment of variable

### DIFF
--- a/tests/lib/rbtree/src/main.c
+++ b/tests/lib/rbtree/src/main.c
@@ -152,7 +152,8 @@ void check_tree(int size)
 		CHECK(get_node_mask(i) == rb_contains(&tree, &nodes[i]));
 
 		if (get_node_mask(i)) {
-			CHECK(node_index(walked_nodes[ni++]) == i);
+			CHECK(node_index(walked_nodes[ni]) == i);
+			ni++;
 		}
 	}
 


### PR DESCRIPTION
This patch fixes a coverity issue with the post increment of ni inside
an zassert call.  There might be side effects of non-debug builds that
would cause the code to not do the right thing.

Coverity-ID: 185391
Fixes #7264

Signed-off-by: Andy Gross <andy.gross@linaro.org>