### PR TITLE
tests: posix: Fix sigevent initialization

### DIFF
--- a/tests/posix/posix_checks/src/posix_checks.c
+++ b/tests/posix/posix_checks/src/posix_checks.c
@@ -106,14 +106,13 @@ void handler(union sigval val)
 void check_timer_support(int clock_id)
 {
 	int ret;
-	struct sigevent sig;
+	struct sigevent sig = {0};
 	timer_t timerid;
 	struct itimerspec value, ovalue;
 
 	sig.sigev_notify = SIGEV_SIGNAL;
 	sig.sigev_notify_function = handler;
 	sig.sigev_value.sival_int = 20;
-	sig.sigev_notify_attributes = NULL;
 
 	ret = timer_create(clock_id, &sig, &timerid);
 	if (ret != 0) {

--- a/tests/posix/timer/src/posix_timer.c
+++ b/tests/posix/timer/src/posix_timer.c
@@ -25,7 +25,7 @@ void handler(union sigval val)
 void test_timer(void)
 {
 	int ret;
-	struct sigevent sig;
+	struct sigevent sig = {0};
 	timer_t timerid;
 	struct itimerspec value, ovalue;
 	struct timespec ts, te;
@@ -34,7 +34,6 @@ void test_timer(void)
 	sig.sigev_notify = SIGEV_SIGNAL;
 	sig.sigev_notify_function = handler;
 	sig.sigev_value.sival_int = 20;
-	sig.sigev_notify_attributes = NULL;
 
 	printk("POSIX timer test\n");
 	ret = timer_create(CLOCK_MONOTONIC, &sig, &timerid);


### PR DESCRIPTION
This patch fixes a couple of coverity issues pertaining to
uninitialized members of a sigevent structure.

Coverity-ID: 183070
Coverity-ID: 185276
Fixes #6662
Fixes #7088

Signed-off-by: Andy Gross <andy.gross@linaro.org>