### PR TITLE
arch/soc/st_stm32: Move STM32Cube HAL core funtions

### DIFF
--- a/arch/arm/soc/st_stm32/common/CMakeLists.txt
+++ b/arch/arm/soc/st_stm32/common/CMakeLists.txt
@@ -1,1 +1,2 @@
 zephyr_sources_ifdef(CONFIG_STM32_ARM_MPU_ENABLE arm_mpu_regions.c)
+zephyr_sources(stm32cube_hal.c)

--- a/arch/arm/soc/st_stm32/common/stm32cube_hal.c
+++ b/arch/arm/soc/st_stm32/common/stm32cube_hal.c
@@ -1,0 +1,37 @@
+/*
+ * Copyright (c) 2018, I-SENSE group of ICCS
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * @file
+ * @brief Zephyr's implementation for STM32Cube HAL core initialization
+ *        functions. These functions are declared as __weak in
+ *        STM32Cube HAL in order to be overwritten in case of other
+ *        implementations.
+ */
+
+#include <kernel.h>
+#include <soc.h>
+/**
+ * @brief This function configures the source of stm32cube time base.
+ *        Cube HAL expects a 1ms tick which matches with k_uptime_get_32.
+ *        Tick interrupt priority is not used
+ * @return HAL status
+ */
+uint32_t HAL_GetTick(void)
+{
+	return k_uptime_get_32();
+}
+
+/**
+ * @brief This function provides minimum delay (in milliseconds) based
+ *	  on variable incremented.
+ * @param Delay: specifies the delay time length, in milliseconds.
+ * @return None
+ */
+void HAL_Delay(__IO uint32_t Delay)
+{
+	k_sleep(Delay);
+}

--- a/arch/arm/soc/st_stm32/stm32f0/soc.c
+++ b/arch/arm/soc/st_stm32/stm32f0/soc.c
@@ -9,10 +9,8 @@
  * @brief System/hardware module for STM32F0 processor
  */
 
-#include <kernel.h>
 #include <device.h>
 #include <init.h>
-#include <soc.h>
 #include <arch/cpu.h>
 #include <cortex_m/exc.h>
 #include <linker/linker-defs.h>
@@ -46,29 +44,6 @@ void relocate_vector_table(void)
 	memcpy(_ram_vector_start, _vector_start, vector_size);
 	LL_SYSCFG_SetRemapMemory(LL_SYSCFG_REMAP_SRAM);
 #endif
-}
-
-
-/**
- * @brief This function configures the source of stm32cube time base.
- *        Cube HAL expects a 1ms tick which matches with k_uptime_get_32.
- *        Tick interrupt priority is not used
- * @return HAL status
- */
-uint32_t HAL_GetTick(void)
-{
-	return k_uptime_get_32();
-}
-
-/**
- * @brief This function provides minimum delay (in milliseconds) based
- *	  on variable incremented.
- * @param Delay: specifies the delay time length, in milliseconds.
- * @return None
- */
-void HAL_Delay(__IO uint32_t Delay)
-{
-	k_sleep(Delay);
 }
 
 /**

--- a/arch/arm/soc/st_stm32/stm32f1/soc.c
+++ b/arch/arm/soc/st_stm32/stm32f1/soc.c
@@ -9,34 +9,10 @@
  * @brief System/hardware module for STM32F1 processor
  */
 
-#include <kernel.h>
 #include <device.h>
 #include <init.h>
-#include <soc.h>
 #include <arch/cpu.h>
 #include <cortex_m/exc.h>
-
-/**
- * @brief This function configures the source of stm32cube time base.
- *        Cube HAL expects a 1ms tick which matches with k_uptime_get_32.
- *        Tick interrupt priority is not used
- * @return HAL status
- */
-uint32_t HAL_GetTick(void)
-{
-	return k_uptime_get_32();
-}
-
-/**
- * @brief This function provides minimum delay (in milliseconds) based
- *	  on variable incremented.
- * @param Delay: specifies the delay time length, in milliseconds.
- * @return None
- */
-void HAL_Delay(__IO uint32_t Delay)
-{
-	k_sleep(Delay);
-}
 
 /**
  * @brief Perform basic hardware initialization at boot.

--- a/arch/arm/soc/st_stm32/stm32f3/soc.c
+++ b/arch/arm/soc/st_stm32/stm32f3/soc.c
@@ -9,34 +9,10 @@
  * @brief System/hardware module for STM32F3 processor
  */
 
-#include <kernel.h>
 #include <device.h>
 #include <init.h>
-#include <soc.h>
 #include <arch/cpu.h>
 #include <cortex_m/exc.h>
-
-/**
- * @brief This function configures the source of stm32cube time base.
- *        Cube HAL expects a 1ms tick which matches with k_uptime_get_32.
- *        Tick interrupt priority is not used
- * @return HAL status
- */
-uint32_t HAL_GetTick(void)
-{
-	return k_uptime_get_32();
-}
-
-/**
- * @brief This function provides minimum delay (in milliseconds) based
- *	  on variable incremented.
- * @param Delay: specifies the delay time length, in milliseconds.
- * @return None
- */
-void HAL_Delay(__IO uint32_t Delay)
-{
-	k_sleep(Delay);
-}
 
 /**
  * @brief Perform basic hardware initialization at boot.

--- a/arch/arm/soc/st_stm32/stm32f4/soc.c
+++ b/arch/arm/soc/st_stm32/stm32f4/soc.c
@@ -10,23 +10,10 @@
  * @brief System/hardware module for STM32F4 processor
  */
 
-#include <kernel.h>
 #include <device.h>
 #include <init.h>
-#include <soc.h>
 #include <arch/cpu.h>
 #include <cortex_m/exc.h>
-
-/**
- * @brief This function configures the source of stm32cube time base.
- *        Cube HAL expects a 1ms tick which matches with k_uptime_get_32.
- *        Tick interrupt priority is not used
- * @return HAL status
- */
-uint32_t HAL_GetTick(void)
-{
-	return k_uptime_get_32();
-}
 
 /**
  * @brief Perform basic hardware initialization at boot.

--- a/arch/arm/soc/st_stm32/stm32l0/soc.c
+++ b/arch/arm/soc/st_stm32/stm32l0/soc.c
@@ -9,26 +9,12 @@
  * @brief System/hardware module for STM32L0 processor
  */
 
-#include <kernel.h>
 #include <device.h>
 #include <init.h>
-#include <soc.h>
 #include <arch/cpu.h>
 #include <cortex_m/exc.h>
 #include <linker/linker-defs.h>
 #include <string.h>
-
-
-/**
- * @brief This function configures the source of stm32cube time base.
- *        Cube HAL expects a 1ms tick which matches with k_uptime_get_32.
- *        Tick interrupt priority is not used
- * @return HAL status
- */
-uint32_t HAL_GetTick(void)
-{
-	return k_uptime_get_32();
-}
 
 /**
  * @brief Perform basic hardware initialization at boot.

--- a/arch/arm/soc/st_stm32/stm32l4/soc.c
+++ b/arch/arm/soc/st_stm32/stm32l4/soc.c
@@ -10,35 +10,10 @@
  * @brief System/hardware module for STM32L4 processor
  */
 
-#include <kernel.h>
 #include <device.h>
 #include <init.h>
-#include <soc.h>
 #include <arch/cpu.h>
 #include <cortex_m/exc.h>
-
-
-/**
- * @brief This function provides minimum delay (in milliseconds) based
- *	  on variable incremented.
- * @param Delay: specifies the delay time length, in milliseconds.
- * @return None
- */
-void HAL_Delay(__IO uint32_t Delay)
-{
-	k_sleep(Delay);
-}
-
-/**
- * @brief This function configures the source of stm32cube time base.
- *        Cube HAL expects a 1ms tick which matches with k_uptime_get_32.
- *        Tick interrupt priority is not used
- * @return HAL status
- */
-uint32_t HAL_GetTick(void)
-{
-	return k_uptime_get_32();
-}
 
 /**
  * @brief Perform basic hardware initialization at boot.


### PR DESCRIPTION
STM32Cube HAL core initialization functions HAL_GetTick()
and HAL_Delay() are implemented in all STM32 series. This
patch moves these functions in file stm32cube_hal.c under
"common" folder to reduce code duplication.

Signed-off-by: Yannis Damigos <giannis.damigos@gmail.com>