### PR TITLE
Bluetooth: Remove unused rx_prio_queue

### DIFF
--- a/subsys/bluetooth/host/hci_core.h
+++ b/subsys/bluetooth/host/hci_core.h
@@ -150,12 +150,6 @@ struct bt_dev {
 	struct k_fifo		rx_queue;
 #endif
 
-	/* Queue for high priority HCI events which may unlock waiters
-	 * in other threads. Such events include Number of Completed
-	 * Packets, as well as the Command Complete/Status events.
-	 */
-	struct k_fifo		rx_prio_queue;
-
 	/* Queue for outgoing HCI commands */
 	struct k_fifo		cmd_tx_queue;
 


### PR DESCRIPTION
The rx_prio_queue k_fifo object has not been used for anything for a
really long time. The use for it was originally removed by the following
commit:

commit ad475d863ab84dfd4c0b2896d903f0140a0f713a
Author: Szymon Janc <ext.szymon.janc@tieto.com>
Date:   Fri Apr 22 11:36:04 2016 +0200

    Bluetooth: Remove RX priority fiber

Signed-off-by: Johan Hedberg <johan.hedberg@intel.com>