### PR TITLE
 drivers/stm32f0x_ll_clock: Enable SYSCFG in clock_control

### DIFF
--- a/arch/arm/soc/st_stm32/stm32f0/soc_gpio.c
+++ b/arch/arm/soc/st_stm32/stm32f0/soc_gpio.c
@@ -110,17 +110,6 @@ int stm32_gpio_enable_int(int port, int pin)
 		(struct stm32f0x_syscfg *)SYSCFG_BASE;
 	volatile union syscfg__exticr *exticr;
 
-	/* Enable System Configuration Controller clock. */
-	struct device *clk =
-		device_get_binding(STM32_CLOCK_CONTROL_NAME);
-
-	struct stm32_pclken pclken = {
-		.bus = STM32_CLOCK_BUS_APB1_2,
-		.enr = LL_APB1_GRP2_PERIPH_SYSCFG
-	};
-
-	clock_control_on(clk, (clock_control_subsys_t *) &pclken);
-
 	int shift = 0;
 
 	if (pin <= 3) {

--- a/drivers/clock_control/stm32f0x_ll_clock.c
+++ b/drivers/clock_control/stm32f0x_ll_clock.c
@@ -69,7 +69,10 @@ void config_pll_init(LL_UTILS_PLLInitTypeDef *pllinit)
  */
 void config_enable_default_clocks(void)
 {
-	/* Nothing for now */
+#if defined(CONFIG_EXTI_STM32) || defined(CONFIG_USB_DC_STM32)
+	/* Enable System Configuration Controller clock. */
+	LL_APB1_GRP2_EnableClock(LL_APB1_GRP2_PERIPH_SYSCFG);
+#endif
 }
 
 /**

--- a/drivers/usb/device/usb_dc_stm32.c
+++ b/drivers/usb/device/usb_dc_stm32.c
@@ -317,7 +317,12 @@ int usb_dc_attach(void)
 	 * pair PA11/12 mapped instead of PA9/10 (e.g. stm32f070x6)
 	 */
 #if defined(CONFIG_SOC_SERIES_STM32F0X) && defined(SYSCFG_CFGR1_PA11_PA12_RMP)
-	LL_SYSCFG_EnablePinRemap();
+	if (LL_APB1_GRP2_IsEnabledClock(LL_APB1_GRP2_PERIPH_SYSCFG)) {
+		LL_SYSCFG_EnablePinRemap();
+	} else {
+		SYS_LOG_ERR("System Configuration Controller clock is "
+			    "disable. Unable to enable pin remapping."
+	}
 #endif
 
 	ret = usb_dc_stm32_clock_enable();


### PR DESCRIPTION
Enable System Configuration Controller clock in clock_control
instead of gpio controller when we set a gpio as interrupt.
We use System Configuration Controller to manage external
interrupts and enable PIN pair PA11/12, used in USB device,
mapped instead of PA9/10.

Also, add a check to raise an error if SYSCFG is disabled,
before doing the pin remaping for F0 SoCs on QFN28
and TSSOP20 packages in USB device driver.