### PR TITLE
net: ipv6: Drop packet with my source address and port

### DIFF
--- a/subsys/net/ip/connection.c
+++ b/subsys/net/ip/connection.c
@@ -777,6 +777,30 @@ static inline void send_icmp_error(struct net_pkt *pkt)
 	}
 }
 
+static bool is_invalid_packet(struct net_pkt *pkt,
+			       u16_t src_port,
+			       u16_t dst_port)
+{
+	bool my_src_addr = false;
+
+	switch (NET_IPV6_HDR(pkt)->vtc & 0xf0) {
+#if defined(CONFIG_NET_IPV6)
+	case 0x60:
+		if (!net_is_my_ipv6_addr(&NET_IPV6_HDR(pkt)->src)) {
+			my_src_addr = true;
+		}
+#endif
+#if defined(CONFIG_NET_IPV4)
+	case 0x40:
+		if (!net_is_my_ipv4_addr(&NET_IPV4_HDR(pkt)->src)) {
+			my_src_addr = true;
+		}
+#endif
+	}
+
+	return my_src_addr && (src_port == dst_port);
+}
+
 enum net_verdict net_conn_input(enum net_ip_protocol proto, struct net_pkt *pkt)
 {
 	int i, best_match = -1;
@@ -827,6 +851,11 @@ enum net_verdict net_conn_input(enum net_ip_protocol proto, struct net_pkt *pkt)
 		chksum = tcp_hdr->chksum;
 	} else {
 		NET_DBG("No UDP or TCP configured, dropping packet.");
+		return NET_DROP;
+	}
+
+	if (is_invalid_packet(pkt, src_port, dst_port)) {
+		NET_DBG("Dropping invalid packet");
 		return NET_DROP;
 	}
 


### PR DESCRIPTION
If a UDP packet with source IPv6 address same as the address of echo
server is received, it causes echo server to recursively send the packet
to itself, resulting in a crash and memory depletion. This commit fixes
the crash by dropping the packet.

Signed-off-by: Ruslan Mstoi <ruslan.mstoi@intel.com>