### PR TITLE
samples: usb: add nucleo_f070rb.overlay

### DIFF
--- a/samples/subsys/usb/cdc_acm/nucleo_f070rb.overlay
+++ b/samples/subsys/usb/cdc_acm/nucleo_f070rb.overlay
@@ -1,0 +1,3 @@
+&usb {
+	status = "ok";
+};

--- a/samples/subsys/usb/hid-mouse/nucleo_f070rb.overlay
+++ b/samples/subsys/usb/hid-mouse/nucleo_f070rb.overlay
@@ -1,0 +1,3 @@
+&usb {
+	status = "ok";
+};

--- a/samples/subsys/usb/hid/nucleo_f070rb.overlay
+++ b/samples/subsys/usb/hid/nucleo_f070rb.overlay
@@ -1,0 +1,3 @@
+&usb {
+	status = "ok";
+};


### PR DESCRIPTION
nucleo_f070rb doesn't has an actual USB connector, so it's better
enable it's USB in overlay rather than in dts.

Signed-off-by: qianfan Zhao <qianfanguijin@163.com>