### PR TITLE
ci: Bump toolchain version to SDK 0.9.3

### DIFF
--- a/.shippable.yml
+++ b/.shippable.yml
@@ -4,7 +4,7 @@ compiler: gcc
 
 env:
     global:
-        - SDK=0.9.2
+        - SDK=0.9.3
         - SANITYCHECK_OPTIONS=" --inline-logs"
         - SANITYCHECK_OPTIONS_RETRY="${SANITYCHECK_OPTIONS} --only-failed --outdir=out-2nd-pass"
         - ZEPHYR_SDK_INSTALL_DIR=/opt/sdk/zephyr-sdk-0.9.2


### PR DESCRIPTION
Bump the sdk version to 0.9.3 to get fixes related to new DTC and gcc
built such that it passes args down the assembler (like include paths).

Signed-off-by: Kumar Gala <kumar.gala@linaro.org>