### PR TITLE
ci: Clean the capability cache when the ccache is cleaned

### DIFF
--- a/.shippable.yml
+++ b/.shippable.yml
@@ -72,7 +72,7 @@ build:
       - rm test_file.txt
       - ccache -s
     on_failure:
-      - rm -rf ccache
+      - rm -rf ccache $HOME/.cache/zephyr
       - mkdir -p shippable/testresults
       - mkdir -p shippable/codecoverage
       - source zephyr-env.sh
@@ -97,7 +97,7 @@ build:
             cp ./scripts/sanity_chk/last_sanity.xml shippable/testresults/;
           fi;
     on_success:
-      - rm -rf ccache
+      - rm -rf ccache $HOME/.cache/zephyr
       - mkdir -p shippable/testresults
       - mkdir -p shippable/codecoverage
       - source zephyr-env.sh


### PR DESCRIPTION
Clear the toolchain capability cache when ccache is cleared so that
the different host-side caching mechanisms have a similair lifetime.

This fixes #7495 

Signed-off-by: Sebastian Bøe <sebastian.boe@nordicsemi.no>