### PR TITLE
samples: sockets: Make more errors fatal

### DIFF
--- a/samples/net/sockets/big_http_download/src/big_http_download.c
+++ b/samples/net/sockets/big_http_download/src/big_http_download.c
@@ -37,7 +37,7 @@ static char download_url[] =
 static uint8_t download_hash[32] = "\x33\x7c\x37\xd7\xec\x00\x34\x84\x14\x22\x4b\xaa\x6b\xdb\x2d\x43\xf2\xa3\x4e\xf5\x67\x6b\xaf\xcd\xca\xd9\x16\xf1\x48\xb5\xb3\x17";
 
 #define SSTRLEN(s) (sizeof(s) - 1)
-#define CHECK(r) { if (r == -1) { printf("Error: " #r "\n"); } }
+#define CHECK(r) { if (r == -1) { printf("Error: " #r "\n"); exit(1); } }
 
 const char *host;
 const char *port = "80";

--- a/samples/net/sockets/http_get/src/http_get.c
+++ b/samples/net/sockets/http_get/src/http_get.c
@@ -5,6 +5,7 @@
  */
 
 #include <stdio.h>
+#include <stdlib.h>
 
 #ifndef __ZEPHYR__
 
@@ -31,7 +32,7 @@
 
 
 #define SSTRLEN(s) (sizeof(s) - 1)
-#define CHECK(r) { if (r == -1) { printf("Error: " #r "\n"); } }
+#define CHECK(r) { if (r == -1) { printf("Error: " #r "\n"); exit(1); } }
 
 #define REQUEST "GET " HTTP_PATH " HTTP/1.0\r\nHost: " HTTP_HOST "\r\n\r\n"
 
@@ -77,7 +78,7 @@ int main(void)
 	CHECK(sock);
 	printf("sock = %d\n", sock);
 	CHECK(connect(sock, res->ai_addr, res->ai_addrlen));
-	send(sock, REQUEST, SSTRLEN(REQUEST), 0);
+	CHECK(send(sock, REQUEST, SSTRLEN(REQUEST), 0));
 
 	printf("Response:\n\n");
 
@@ -97,7 +98,7 @@ int main(void)
 		printf("%s\n", response);
 	}
 
-	close(sock);
+	(void)close(sock);
 
 	return 0;
 }


### PR DESCRIPTION
In samples, using CHECK() helper macro, make it exist in case of
error. This makes sure that negative value (error indicator) can't
be passed as argument to other function and fixes Coverity reports.

Coverity-CID: 183062

Signed-off-by: Paul Sokolovsky <paul.sokolovsky@linaro.org>