### PR TITLE
boards: nucleo_f413zh: enable usb

### DIFF
--- a/boards/arm/nucleo_f413zh/doc/nucleof413zh.rst
+++ b/boards/arm/nucleo_f413zh/doc/nucleof413zh.rst
@@ -85,6 +85,8 @@ The Zephyr nucleo_413zh board configuration supports the following hardware feat
 +-----------+------------+-------------------------------------+
 | PWM       | on-chip    | pwm                                 |
 +-----------+------------+-------------------------------------+
+| USB       | on-chip    | USB device                          |
++-----------+------------+-------------------------------------+
 
 Other hardware features are not yet supported on this Zephyr port.
 
@@ -129,6 +131,8 @@ Default Zephyr Peripheral Mapping:
 - UART_3_TX : PD8
 - UART_3_RX : PD9
 - PWM_2_CH1 : PA0
+- USB_DM : PA11
+- USB_DP : PA12
 - USER_PB : PC13
 - LD1 : PB0
 - LD2 : PB7
@@ -146,6 +150,12 @@ Serial Port
 
 Nucleo F413ZH board has 10 UARTs. The Zephyr console output is assigned to UART3.
 Default settings are 115200 8N1.
+
+USB
+===
+Nucleo F413ZH board has a USB OTG dual-role device (DRD) controller that
+supports both device and host functions through its micro USB connector
+(USB USER). Only USB device function is supported in Zephyr at the moment.
 
 
 Programming and Debugging

--- a/boards/arm/nucleo_f413zh/nucleo_f413zh.dts
+++ b/boards/arm/nucleo_f413zh/nucleo_f413zh.dts
@@ -55,3 +55,7 @@
 	pinctrl-names = "default";
 	status = "ok";
 };
+
+&usbotg_fs {
+	status = "ok";
+};

--- a/boards/arm/nucleo_f413zh/nucleo_f413zh.yaml
+++ b/boards/arm/nucleo_f413zh/nucleo_f413zh.yaml
@@ -5,3 +5,4 @@ arch: arm
 toolchain:
   - zephyr
   - gccarmemb
+  - usb_device

--- a/boards/arm/nucleo_f413zh/pinmux.c
+++ b/boards/arm/nucleo_f413zh/pinmux.c
@@ -21,6 +21,10 @@ static const struct pin_config pinconf[] = {
 #ifdef CONFIG_PWM_STM32_2
 	{STM32_PIN_PA0, STM32F4_PINMUX_FUNC_PA0_PWM2_CH1},
 #endif /* CONFIG_PWM_STM32_2 */
+#ifdef CONFIG_USB_DC_STM32
+	{STM32_PIN_PA11, STM32F4_PINMUX_FUNC_PA11_OTG_FS_DM},
+	{STM32_PIN_PA12, STM32F4_PINMUX_FUNC_PA12_OTG_FS_DP},
+#endif	/* CONFIG_USB_DC_STM */
 };
 
 static int pinmux_stm32_init(struct device *port)


### PR DESCRIPTION
Enable usb on Nucleo-F413ZH board.

FYI: @ydamigos 