### PR TITLE
ci: use new docker file with new SDK

### DIFF
--- a/.shippable.yml
+++ b/.shippable.yml
@@ -4,10 +4,10 @@ compiler: gcc
 
 env:
     global:
-        - SDK=0.9.2
+        - SDK=0.9.3
         - SANITYCHECK_OPTIONS=" --inline-logs"
         - SANITYCHECK_OPTIONS_RETRY="${SANITYCHECK_OPTIONS} --only-failed --outdir=out-2nd-pass"
-        - ZEPHYR_SDK_INSTALL_DIR=/opt/sdk/zephyr-sdk-0.9.2
+        - ZEPHYR_SDK_INSTALL_DIR=/opt/sdk/zephyr-sdk-0.9.3
         - ZEPHYR_TOOLCHAIN_VARIANT=zephyr
         - MATRIX_BUILDS="5"
         - MATRIX_BUILDS_EXTRA="5"
@@ -24,7 +24,7 @@ build:
         - ${SHIPPABLE_BUILD_DIR}/ccache
     pre_ci_boot:
         image_name: zephyrprojectrtos/ci
-        image_tag: v0.4-rc1
+        image_tag: v0.4-rc2
         pull: true
         options: "-e HOME=/home/buildslave --privileged=true --tty --net=bridge --user buildslave"
 


### PR DESCRIPTION
Use docker image 0.4-rc2 with Zephyr SDK 0.9.3.

2 Fixes in new SDK:
- updated dtc
- Fix for xtensa gdb with qemu

Signed-off-by: Anas Nashif <anas.nashif@intel.com>