### PR TITLE
mimxrt1050_evk: Move led and button definitions to dts

### DIFF
--- a/boards/arm/mimxrt1050_evk/board.h
+++ b/boards/arm/mimxrt1050_evk/board.h
@@ -9,10 +9,4 @@
 
 #include <soc.h>
 
-#define LED0_GPIO_PORT	CONFIG_MCUX_IGPIO_1_NAME
-#define LED0_GPIO_PIN	9
-
-#define SW0_GPIO_NAME	CONFIG_MCUX_IGPIO_5_NAME
-#define SW0_GPIO_PIN	0
-
 #endif /* __INC_BOARD_H */

--- a/boards/arm/mimxrt1050_evk/mimxrt1050_evk.dts
+++ b/boards/arm/mimxrt1050_evk/mimxrt1050_evk.dts
@@ -19,6 +19,8 @@
 		gpio-4= &gpio4;
 		gpio-5= &gpio5;
 		uart-1 = &uart1;
+		led0 = &green_led;
+		sw0 = &user_button;
 	};
 
 	chosen {
@@ -37,6 +39,22 @@
 		/* Micron MT48LC16M16A2B4-6AIT:G */
 		device_type = "memory";
 		reg = <0x80000000 0x2000000>;
+	};
+
+	leds {
+		compatible = "gpio-leds";
+		green_led: led@0 {
+			gpios = <&gpio1 9 GPIO_INT_ACTIVE_LOW>;
+			label = "User LD1";
+		};
+	};
+
+	gpio_keys {
+		compatible = "gpio-keys";
+		user_button: button@0 {
+			label = "User SW8";
+			gpios = <&gpio5 0 GPIO_INT_ACTIVE_LOW>;
+		};
 	};
 };
 

--- a/dts/arm/nxp/nxp_rt.dtsi
+++ b/dts/arm/nxp/nxp_rt.dtsi
@@ -6,6 +6,7 @@
 
 #include <arm/armv7-m.dtsi>
 #include <dt-bindings/clock/imx_ccm.h>
+#include <dt-bindings/gpio/gpio.h>
 
 / {
 	cpus {
@@ -73,6 +74,8 @@
 			reg = <0x401b8000 0x4000>;
 			interrupts = <80 0>, <81 0>;
 			label = "GPIO_1";
+			gpio-controller;
+			#gpio-cells = <2>;
 		};
 
 		gpio2: gpio@401bc000 {
@@ -80,6 +83,8 @@
 			reg = <0x401bc000 0x4000>;
 			interrupts = <82 0>, <83 0>;
 			label = "GPIO_2";
+			gpio-controller;
+			#gpio-cells = <2>;
 		};
 
 		gpio3: gpio@401c0000 {
@@ -87,6 +92,8 @@
 			reg = <0x401c0000 0x4000>;
 			interrupts = <84 0>, <85 0>;
 			label = "GPIO_3";
+			gpio-controller;
+			#gpio-cells = <2>;
 		};
 
 		gpio4: gpio@401c4000 {
@@ -94,6 +101,8 @@
 			reg = <0x401c4000 0x4000>;
 			interrupts = <86 0>, <87 0>;
 			label = "GPIO_4";
+			gpio-controller;
+			#gpio-cells = <2>;
 		};
 
 		gpio5: gpio@400c0000 {
@@ -101,6 +110,8 @@
 			reg = <0x400c0000 0x4000>;
 			interrupts = <88 0>, <89 0>;
 			label = "GPIO_5";
+			gpio-controller;
+			#gpio-cells = <2>;
 		};
 
 		iomuxc: iomuxc@401f8000 {


### PR DESCRIPTION
Moves the led and button definitions for the mimxrt1050_evk board from
board.h to dts.

Signed-off-by: Maureen Helm <maureen.helm@nxp.com>