### PR TITLE
CoAP: clear more fields and allow timeout to be configurable

### DIFF
--- a/subsys/net/lib/coap/Kconfig
+++ b/subsys/net/lib/coap/Kconfig
@@ -62,6 +62,13 @@ config COAP_EXTENDED_OPTIONS_LEN_VALUE
 	  COAP_EXTENDED_OPTIONS_LEN is enabled. Define the value according to
 	  user requirement.
 
+config COAP_INIT_ACK_TIMEOUT_MS
+	int "base length of the random generated initial ACK timeout in ms"
+	default 2345
+	range 2345 100000
+	help
+	  This value is used as a base value to retry pending CoAP packets.
+
 config NET_DEBUG_COAP
 	bool "Debug COAP"
 	default n

--- a/subsys/net/lib/coap/coap.c
+++ b/subsys/net/lib/coap/coap.c
@@ -787,9 +787,7 @@ void coap_reply_init(struct coap_reply *reply,
 
 void coap_reply_clear(struct coap_reply *reply)
 {
-	reply->id = 0;
-	reply->tkl = 0;
-	reply->reply = NULL;
+	memset(reply, 0, sizeof(*reply));
 }
 
 int coap_resource_notify(struct coap_resource *resource)

--- a/subsys/net/lib/coap/coap.c
+++ b/subsys/net/lib/coap/coap.c
@@ -539,7 +539,7 @@ struct coap_pending *coap_pending_next_to_expire(
  * where ACK_TIMEOUT = 2 and ACK_RANDOM_FACTOR = 1.5 by default
  * Ref: https://tools.ietf.org/html/rfc7252#section-4.8
  */
-#define INIT_ACK_TIMEOUT	2345
+#define INIT_ACK_TIMEOUT	CONFIG_COAP_INIT_ACK_TIMEOUT_MS
 
 static s32_t next_timeout(s32_t previous)
 {


### PR DESCRIPTION
This patchset accomplishes 2 changes:
- Add a config COAP_INIT_ACK_TIMEOUT_MS setting to make the timeout configurable.  This allows high latency connections like LoRA and LTE-M to set a higher default timeout for CoAP transfers.
- Clear more values in the coap_reply when calling coap_reply_clear().  This avoids leaving data behind from previous uses of the coap_reply structure.

These changes are used in other patchsets that support LTE-M and an upcoming bugfix in the LwM2M subsystem when re-transmitting CoAP packets.