### PR TITLE
net: tcp: expose some TCP helper functions

### DIFF
--- a/include/net/tcp.h
+++ b/include/net/tcp.h
@@ -1,0 +1,69 @@
+/** @file
+ * @brief TCP utility functions
+ */
+
+/*
+ * Copyright (c) 2018 Intel Corporation
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef __TCP_H
+#define __TCP_H
+
+#include <zephyr/types.h>
+
+#include <net/net_core.h>
+#include <net/net_ip.h>
+#include <net/net_pkt.h>
+#include <net/net_context.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#if defined(CONFIG_NET_TCP)
+/**
+ * @brief Get TCP packet header data from net_pkt. The array values are in
+ * network byte order and other values are in host byte order.
+ * Note that you must access the TCP header values by the returned pointer,
+ * the hdr parameter is just a placeholder for the header data and it might
+ * not contain anything if the header fits properly in the first fragment of
+ * the network packet.
+ *
+ * @param pkt Network packet
+ * @param hdr Where to place the header if it does not fit in first fragment
+ * of the network packet. This might not be pupulated if TCP header fits in
+ * net_buf fragment.
+ *
+ * @return Return pointer to header or NULL if something went wrong.
+ *         Always use the returned pointer to access the TCP header.
+ */
+struct net_tcp_hdr *net_tcp_get_hdr(struct net_pkt *pkt,
+				    struct net_tcp_hdr *hdr);
+
+/**
+ * @brief Set TCP packet header data in net_pkt.
+ *
+ * @details  The values in the header must be in network byte order.
+ * This function is normally called after a call to net_tcp_get_hdr().
+ * The hdr parameter value should be the same that is returned by function
+ * net_tcp_get_hdr() call. Note that if the TCP header fits in first net_pkt
+ * fragment, then this function will not do anything as the returned value
+ * was pointing directly to net_pkt.
+ *
+ * @param pkt Network packet
+ * @param hdr Header data pointer that was returned by net_tcp_get_hdr().
+ *
+ * @return Return hdr or NULL if error
+ */
+struct net_tcp_hdr *net_tcp_set_hdr(struct net_pkt *pkt,
+				    struct net_tcp_hdr *hdr);
+
+#endif /* CONFIG_NET_TCP */
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* __TCP_H */

--- a/subsys/net/ip/connection.c
+++ b/subsys/net/ip/connection.c
@@ -19,12 +19,13 @@
 #include <net/net_core.h>
 #include <net/net_pkt.h>
 #include <net/udp.h>
+#include <net/tcp.h>
 
 #include "net_private.h"
 #include "icmpv6.h"
 #include "icmpv4.h"
 #include "udp_internal.h"
-#include "tcp.h"
+#include "tcp_internal.h"
 #include "connection.h"
 #include "net_stats.h"
 

--- a/subsys/net/ip/ipv4.c
+++ b/subsys/net/ip/ipv4.c
@@ -18,12 +18,13 @@
 #include <net/net_pkt.h>
 #include <net/net_stats.h>
 #include <net/net_context.h>
+#include <net/tcp.h>
 #include "net_private.h"
 #include "connection.h"
 #include "net_stats.h"
 #include "icmpv4.h"
 #include "udp_internal.h"
-#include "tcp.h"
+#include "tcp_internal.h"
 #include "ipv4.h"
 
 struct net_pkt *net_ipv4_create_raw(struct net_pkt *pkt,

--- a/subsys/net/ip/ipv6.c
+++ b/subsys/net/ip/ipv6.c
@@ -24,11 +24,12 @@
 #include <net/net_stats.h>
 #include <net/net_context.h>
 #include <net/net_mgmt.h>
+#include <net/tcp.h>
 #include "net_private.h"
 #include "connection.h"
 #include "icmpv6.h"
 #include "udp_internal.h"
-#include "tcp.h"
+#include "tcp_internal.h"
 #include "ipv6.h"
 #include "nbr.h"
 #include "6lo.h"

--- a/subsys/net/ip/net_context.c
+++ b/subsys/net/ip/net_context.c
@@ -24,6 +24,7 @@
 #include <net/net_ip.h>
 #include <net/net_context.h>
 #include <net/net_offload.h>
+#include <net/tcp.h>
 
 #include "connection.h"
 #include "net_private.h"
@@ -31,7 +32,7 @@
 #include "ipv6.h"
 #include "ipv4.h"
 #include "udp_internal.h"
-#include "tcp.h"
+#include "tcp_internal.h"
 #include "net_stats.h"
 
 #ifndef EPFNOSUPPORT

--- a/subsys/net/ip/net_core.c
+++ b/subsys/net/ip/net_core.c
@@ -29,6 +29,7 @@
 #include <net/net_pkt.h>
 #include <net/net_core.h>
 #include <net/dns_resolve.h>
+#include <net/tcp.h>
 
 #include "net_private.h"
 #include "net_shell.h"
@@ -47,7 +48,7 @@
 
 #include "connection.h"
 #include "udp_internal.h"
-#include "tcp.h"
+#include "tcp_internal.h"
 
 #include "net_stats.h"
 

--- a/subsys/net/ip/net_pkt.c
+++ b/subsys/net/ip/net_pkt.c
@@ -35,9 +35,10 @@
 #include <net/buf.h>
 #include <net/net_pkt.h>
 #include <net/udp.h>
+#include <net/tcp.h>
 
 #include "net_private.h"
-#include "tcp.h"
+#include "tcp_internal.h"
 #include "rpl.h"
 
 #if defined(CONFIG_NET_TCP)

--- a/subsys/net/ip/net_shell.c
+++ b/subsys/net/ip/net_shell.c
@@ -24,7 +24,8 @@
 #include "connection.h"
 
 #if defined(CONFIG_NET_TCP)
-#include "tcp.h"
+#include <net/tcp.h>
+#include "tcp_internal.h"
 #endif
 
 #if defined(CONFIG_NET_IPV6)

--- a/subsys/net/ip/tcp.c
+++ b/subsys/net/ip/tcp.c
@@ -26,6 +26,7 @@
 #include <net/net_pkt.h>
 #include <net/net_ip.h>
 #include <net/net_context.h>
+#include <net/tcp.h>
 #include <misc/byteorder.h>
 
 #include "connection.h"
@@ -33,7 +34,7 @@
 
 #include "ipv6.h"
 #include "ipv4.h"
-#include "tcp.h"
+#include "tcp_internal.h"
 #include "net_stats.h"
 
 #define ALLOC_TIMEOUT 500

--- a/subsys/net/ip/tcp_internal.h
+++ b/subsys/net/ip/tcp_internal.h
@@ -10,8 +10,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#ifndef __TCP_H
-#define __TCP_H
+#ifndef __TCP_INTERNAL_H
+#define __TCP_INTERNAL_H
 
 #include <zephyr/types.h>
 
@@ -404,43 +404,6 @@ static inline enum net_tcp_state net_tcp_get_state(const struct net_tcp *tcp)
 bool net_tcp_validate_seq(struct net_tcp *tcp, struct net_pkt *pkt);
 
 /**
- * @brief Get TCP packet header data from net_pkt. The array values are in
- * network byte order and other values are in host byte order.
- * Note that you must access the TCP header values by the returned pointer,
- * the hdr parameter is just a placeholder for the header data and it might
- * not contain anything if the header fits properly in the first fragment of
- * the network packet.
- *
- * @param pkt Network packet
- * @param hdr Where to place the header if it does not fit in first fragment
- * of the network packet. This might not be pupulated if TCP header fits in
- * net_buf fragment.
- *
- * @return Return pointer to header or NULL if something went wrong.
- *         Always use the returned pointer to access the TCP header.
- */
-struct net_tcp_hdr *net_tcp_get_hdr(struct net_pkt *pkt,
-				    struct net_tcp_hdr *hdr);
-
-/**
- * @brief Set TCP packet header data in net_pkt.
- *
- * @details  The values in the header must be in network byte order.
- * This function is normally called after a call to net_tcp_get_hdr().
- * The hdr parameter value should be the same that is returned by function
- * net_tcp_get_hdr() call. Note that if the TCP header fits in first net_pkt
- * fragment, then this function will not do anything as the returned value
- * was pointing directly to net_pkt.
- *
- * @param pkt Network packet
- * @param hdr Header data pointer that was returned by net_tcp_get_hdr().
- *
- * @return Return hdr or NULL if error
- */
-struct net_tcp_hdr *net_tcp_set_hdr(struct net_pkt *pkt,
-				    struct net_tcp_hdr *hdr);
-
-/**
  * @brief Set TCP checksum in network packet.
  *
  * @param pkt Network packet
@@ -827,4 +790,4 @@ void net_tcp_init(void);
 }
 #endif
 
-#endif /* __TCP_H */
+#endif /* __TCP_INTERNAL_H */

--- a/tests/net/tcp/src/main.c
+++ b/tests/net/tcp/src/main.c
@@ -20,6 +20,7 @@
 #include <net/net_core.h>
 #include <net/net_pkt.h>
 #include <net/net_ip.h>
+#include <net/tcp.h>
 
 #include <tc_util.h>
 
@@ -30,7 +31,7 @@
 #define DBG(fmt, ...)
 #endif
 
-#include "tcp.h"
+#include "tcp_internal.h"
 #include "net_private.h"
 
 static bool test_failed;


### PR DESCRIPTION
Similar to UDP, some drivers can make use of the following functions:
net_tcp_get_hdr()
net_tcp_set_hdr()

Let's expose them as <net/tcp.h> and change all internal references
to "tcp_internal.h".

NOTE: These changes are needed by an upcoming offloaded networking LTE-M modem driver.

Signed-off-by: Michael Scott <michael@opensourcefoundries.com>