### PR TITLE
samples: net: lwm2m: adjust BT RX buffer count /sizes for BT

### DIFF
--- a/samples/net/lwm2m_client/overlay-bt.conf
+++ b/samples/net/lwm2m_client/overlay-bt.conf
@@ -1,3 +1,7 @@
 CONFIG_NET_L2_BT=y
 CONFIG_BT_DEVICE_NAME="LwM2M IPSP node"
 CONFIG_NET_APP_BT_NODE=y
+
+# raise bluetooth RX buffer settings for 6lowpan traffic
+CONFIG_BT_RX_BUF_COUNT=20
+CONFIG_BT_RX_BUF_LEN=128


### PR DESCRIPTION
Due to higher traffic demands when using 6lowpan, we should raise
the default BT RX buffer counts and sizes.

This avoids the following error on some HW:
[net/buf] [WRN] net_buf_alloc_len_debug: bt_buf_get_rx():4985: Pool 0x20009424 low on buffers.
[net/buf] [WRN] net_buf_alloc_len_debug: bt_buf_get_rx():4985: Pool 0x20009424 blocked for 0 secs

Signed-off-by: Michael Scott <michael@opensourcefoundries.com>