### PR TITLE
boards: frdm_kw41z: enable xoroshiro on board level only

### DIFF
--- a/arch/arm/soc/nxp_kinetis/kwx/Kconfig.defconfig.mkw41z4
+++ b/arch/arm/soc/nxp_kinetis/kwx/Kconfig.defconfig.mkw41z4
@@ -69,9 +69,6 @@ if ENTROPY_GENERATOR
 config ENTROPY_MCUX_TRNG
 	def_bool y
 
-config XOROSHIRO_RANDOM_GENERATOR
-	def_bool y
-
 endif # ENTROPY_GENERATOR
 
 if FLASH


### PR DESCRIPTION
Enabling the driver on board level is sufficient. We need to find a
better way for selecting random drivers on SoC level, this is currently
not possible due to how Kconfig works.

Fixes #7097

Signed-off-by: Anas Nashif <anas.nashif@intel.com>