### PR TITLE
doc: getting_started: Remove redundant and erronous doc's

### DIFF
--- a/doc/getting_started/getting_started.rst
+++ b/doc/getting_started/getting_started.rst
@@ -84,23 +84,6 @@ Building a Sample Application
 
 To build an example application follow these steps:
 
-
-#. Make sure your environment is setup by exporting the following environment
-   variables. When using the Zephyr SDK on Linux for example, type:
-
-   .. code-block:: console
-
-
-      # On Linux/macOS
-      export ZEPHYR_TOOLCHAIN_VARIANT=zephyr
-      export ZEPHYR_SDK_INSTALL_DIR=<sdk installation directory>
-      # On Windows
-      set ZEPHYR_TOOLCHAIN_VARIANT=zephyr
-      set ZEPHYR_SDK_INSTALL_DIR=<sdk installation directory>
-
-   .. note:: In previous releases of Zephyr, the ``ZEPHYR_TOOLCHAIN_VARIANT``
-             variable was called ``ZEPHYR_GCC_VARIANT``.
-
 #. Navigate to the main project directory:
 
    .. code-block:: console

--- a/doc/getting_started/installation_linux.rst
+++ b/doc/getting_started/installation_linux.rst
@@ -166,5 +166,8 @@ Follow these steps to install the SDK on your Linux host system.
      export ZEPHYR_SDK_INSTALL_DIR=/opt/zephyr-sdk
      EOF
 
+.. note:: In previous releases of Zephyr, the ``ZEPHYR_TOOLCHAIN_VARIANT``
+          variable was called ``ZEPHYR_GCC_VARIANT``.
+
 .. _Zephyr SDK archive:
     https://www.zephyrproject.org/developers/#downloads

--- a/doc/getting_started/installation_mac.rst
+++ b/doc/getting_started/installation_mac.rst
@@ -238,6 +238,9 @@ variables in the file :file:`${HOME}/.zephyrrc`, for example:
    export ZEPHYR_TOOLCHAIN_VARIANT=xtools
    EOF
 
+.. note:: In previous releases of Zephyr, the ``ZEPHYR_TOOLCHAIN_VARIANT``
+          variable was called ``ZEPHYR_GCC_VARIANT``.
+
 .. _Homebrew site: http://brew.sh/
 
 .. _crosstool-ng site: http://crosstool-ng.org

--- a/doc/getting_started/installation_win.rst
+++ b/doc/getting_started/installation_win.rst
@@ -144,6 +144,9 @@ packages from their respective websites.
 
       zephyr-env.cmd
 
+.. note:: In previous releases of Zephyr, the ``ZEPHYR_TOOLCHAIN_VARIANT``
+          variable was called ``ZEPHYR_GCC_VARIANT``.
+
 #. Finally, you can try building the :ref:`hello_world` sample to check things
    out.
 


### PR DESCRIPTION
The 'getting started' documentation is stating that one should set
some environment variables, but this is not necessary because the user
has already been instructed to set the variables in the
platform-specific guides.

The duplicated documentation should be removed because it is inferiour
to the original documentation. E.g. this documentation does not
describe how to permanently set environment variables. Also, it is
confusingly demonstrating how to use the SDK on Windows, but this is
not supported.

I believe that the purpose of the section is to verify that the user
has not misconfigured or misinstalled the toolchain, but this
responsibility is handled better by CMake itself.

Signed-off-by: Sebastian Bøe <sebastian.boe@nordicsemi.no>