### PR TITLE
net: app: Select proper source IPv4 address in client

### DIFF
--- a/subsys/net/lib/app/net_app.c
+++ b/subsys/net/lib/app/net_app.c
@@ -305,15 +305,9 @@ int _net_app_set_local_addr(struct net_app_ctx *ctx, struct sockaddr *addr,
 #endif
 	} else if (addr->sa_family == AF_INET) {
 #if defined(CONFIG_NET_IPV4)
-		struct net_if *iface =
-			net_if_ipv4_select_src_iface(
-				&net_sin(&ctx->ipv4.remote)->sin_addr);
-
-		NET_ASSERT(iface->config.ip.ipv4);
-
-		/* For IPv4 we take the first address in the interface */
 		net_ipaddr_copy(&net_sin(addr)->sin_addr,
-			   &iface->config.ip.ipv4->unicast[0].address.in_addr);
+				net_if_ipv4_select_src_addr(NULL,
+				     &net_sin(&ctx->ipv4.remote)->sin_addr));
 #else
 		return -EPFNOSUPPORT;
 #endif


### PR DESCRIPTION
Instead of selecting the first IPv4 address from the network
interface, use destination address to select the proper local IPv4
address.

Fixes #7500

Signed-off-by: Jukka Rissanen <jukka.rissanen@linux.intel.com>