### PR TITLE
drivers/dma: dma_stm32f4x: check stream id boundaries

### DIFF
--- a/drivers/dma/dma_stm32f4x.c
+++ b/drivers/dma/dma_stm32f4x.c
@@ -368,6 +368,11 @@ static int dma_stm32_config(struct device *dev, u32_t id,
 	struct dma_stm32_stream_reg *regs = &ddata->stream[id].regs;
 	int ret;
 
+
+	if (id >= DMA_STM32_MAX_STREAMS) {
+		return -EINVAL;
+	}
+
 	if (stream->busy) {
 		return -EBUSY;
 	}
@@ -408,6 +413,10 @@ static int dma_stm32_start(struct device *dev, u32_t id)
 	u32_t irqstatus;
 	int ret;
 
+	if (id >= DMA_STM32_MAX_STREAMS) {
+		return -EINVAL;
+	}
+
 	ret = dma_stm32_disable_stream(ddata, id);
 	if (ret) {
 		return ret;
@@ -441,6 +450,10 @@ static int dma_stm32_stop(struct device *dev, u32_t id)
 	struct dma_stm32_stream *stream = &ddata->stream[id];
 	u32_t scr, sfcr, irqstatus;
 	int ret;
+
+	if (id >= DMA_STM32_MAX_STREAMS) {
+		return -EINVAL;
+	}
 
 	/* Disable all IRQs */
 	scr = dma_stm32_read(ddata, DMA_STM32_SCR(id));


### PR DESCRIPTION
Check that stream Id passed to stm32 DMA API is within
possible stream values and return -EINVAL is invalid stream
id is passed.

fixes: #7380


Signed-off-by: Erwan Gouriou <erwan.gouriou@linaro.org>