### PR TITLE
scripts: extract_dts_includes.py: fix multiple include in bindings

### DIFF
--- a/dts/bindings/device_node.yaml.template
+++ b/dts/bindings/device_node.yaml.template
@@ -6,6 +6,11 @@ description: >
     Describe in free form text w/ spanning lines what you
     are describing
 
+inherits:
+  - !include other.yaml # or [other1.yaml, other2.yaml]
+# other.yaml contains bindings that also apply to this node.
+# In case there are duplicate definitions in the different
+# bindings the one that is defined first prevails.
 
 < parent | child >:
 # parent/child is used to document implicit relation between nodes.


### PR DESCRIPTION
Correctly process multiple include files given to the
!include command of the YAML loader.

The fix only targets the sequential definition of include files.

The PR changes the 'node_type' node property to list type to account for multiple base types.

Fixes #7067

Signed-off-by: Bobby Noelte <b0661n0e17e@gmail.com>