### PR TITLE
pwm: stm32: Fix type for PMW3 support

### DIFF
--- a/drivers/pwm/pwm_stm32.c
+++ b/drivers/pwm/pwm_stm32.c
@@ -248,7 +248,7 @@ static const struct pwm_stm32_config pwm_stm32_dev_cfg_3 = {
 		    .enr = LL_APB1_GRP1_PERIPH_TIM3 },
 };
 
-DEVICE_AND_API_INIT(pwm_stm32_2, CONFIG_PWM_STM32_3_DEV_NAME,
+DEVICE_AND_API_INIT(pwm_stm32_3, CONFIG_PWM_STM32_3_DEV_NAME,
 		    pwm_stm32_init,
 		    &pwm_stm32_dev_data_3, &pwm_stm32_dev_cfg_3,
 		    POST_KERNEL, CONFIG_KERNEL_INIT_PRIORITY_DEVICE,


### PR DESCRIPTION
When we called DEVICE_AND_API_INIT for PMW3, we accidently had
pwm_stm32_2 instead of pwm_stm32_3.

Fixes: #6625

Signed-off-by: Kumar Gala <kumar.gala@linaro.org>