### PR TITLE
net: app: fix build warning in _net_app_ssl_mainloop()

### DIFF
--- a/subsys/net/lib/app/net_app.c
+++ b/subsys/net/lib/app/net_app.c
@@ -2129,7 +2129,7 @@ reset:
 					 * Is closing the connection here the
 					 * right thing?
 					 */
-					NET_ERR("could not skip %zu bytes",
+					NET_ERR("could not skip %d bytes",
 						hdr_len);
 					net_pkt_unref(pkt);
 					ret = -EINVAL;


### PR DESCRIPTION
Fix a build warning when compiling a net_app sample with
CONFIG_NET_APP_DTLS enabled by changing the print formatter from %zu
to %d.  It references the var hdr_len which is defined as an int:

In file included from include/net/net_core.h:78:0,
                 from subsys/net/lib/app/net_app.c:27:
subsys/net/lib/app/net_app.c: In function ‘_net_app_ssl_mainloop’:
include/logging/sys_log.h:96:20: warning: format ‘%zu’ expects
...
subsys/net/lib/app/net_app.c:2132:6: note: in expansion of macro
‘NET_ERR’
      NET_ERR("could not skip %zu bytes",
      ^~~~~~~

Signed-off-by: Michael Scott <michael@opensourcefoundries.com>