### PR TITLE
drivers: timer: nRFx: Remove redundant code

### DIFF
--- a/drivers/timer/nrf_rtc_timer.c
+++ b/drivers/timer/nrf_rtc_timer.c
@@ -11,7 +11,6 @@
 #include <arch/arm/cortex_m/cmsis.h>
 #include <sys_clock.h>
 
-extern void youve_print(void);
 /*
  * Convenience defines.
  */


### PR DESCRIPTION
Remove redundant declaration of youve_print. This probably
had been a review oversight and upstreamed.

Signed-off-by: Vinayak Kariappa Chettimada <vich@nordicsemi.no>