### PR TITLE
lib: posix: Fix pthread_attr_init() return code

### DIFF
--- a/lib/posix/pthread.c
+++ b/lib/posix/pthread.c
@@ -278,11 +278,11 @@ int pthread_setschedparam(pthread_t pthread, int policy,
 int pthread_attr_init(pthread_attr_t *attr)
 {
 
-	if (attr->initialized == true) {
-		return EBUSY;
+	if (attr == NULL) {
+		return ENOMEM;
 	}
 
-	*attr = init_pthread_attrs;
+	memcpy(attr, &init_pthread_attrs, sizeof(pthread_attr_t));
 
 	return 0;
 }


### PR DESCRIPTION
pthread_attr_init() should not return EBUSY as per POSIX spec
so fixed this by return ENOMEM if the attr pointer is NULL.

Also fixed the attribute initialization logic by copying the
init_pthread_attrs to the attr.

Fixes #7480

Signed-off-by: Ramakrishna Pallala <ramakrishna.pallala@intel.com>