### PR TITLE
Bluetooth: Mesh: Fix IV Update duration tracking

### DIFF
--- a/subsys/bluetooth/host/mesh/Kconfig
+++ b/subsys/bluetooth/host/mesh/Kconfig
@@ -162,6 +162,32 @@ config BT_MESH_ADV_BUF_COUNT
 	  which leaves 56 bytes for application layer data using a
 	  4-byte MIC and 52 bytes using an 8-byte MIC.
 
+config BT_MESH_IVU_DIVIDER
+	int "Divider for IV Update state refresh timer"
+	default 4
+	range 2 96
+	help
+	  When the IV Update state enters Normal operation or IV Update
+	  in Progress, we need to keep track of how many hours has passed
+	  in the state, since the specification requires us to remain in
+	  the state at least for 96 hours (Update in Progress has an
+	  additional upper limit of 144 hours).
+
+	  In order to fulfil the above requirement, even if the node might
+	  be powered off once in a while, we need to store persistently
+	  how many hours the node has been in the state. This doesn't
+	  necessarily need to happen every hour (thanks to the flexible
+	  duration range). The exact cadence will depend a lot on the
+	  ways that the node will be used and what kind of power source it
+	  has.
+
+	  Since there is no single optimal answer, this configuration
+	  option allows specifying a divider, i.e. how many intervals
+	  the 96 hour minimum gets split into. After each interval the
+	  duration that the node has been in the current state gets
+	  stored to flash. E.g. the default value of 4 means that the
+	  state is saved every 24 hours (96 / 4).
+
 config BT_MESH_TX_SEG_MSG_COUNT
 	int "Maximum number of simultaneous outgoing segmented messages"
 	default 1

--- a/subsys/bluetooth/host/mesh/main.c
+++ b/subsys/bluetooth/host/mesh/main.c
@@ -65,7 +65,7 @@ int bt_mesh_provision(const u8_t net_key[16], u16_t net_idx,
 		BT_DBG("Storing network information persistently");
 		bt_mesh_store_net();
 		bt_mesh_store_subnet(&bt_mesh.sub[0]);
-		bt_mesh_store_iv();
+		bt_mesh_store_iv(false);
 	}
 
 	bt_mesh_net_start();
@@ -86,10 +86,10 @@ void bt_mesh_reset(void)
 	bt_mesh.iv_update = 0;
 	bt_mesh.pending_update = 0;
 	bt_mesh.valid = 0;
-	bt_mesh.last_update = 0;
+	bt_mesh.ivu_duration = 0;
 	bt_mesh.ivu_initiator = 0;
 
-	k_delayed_work_cancel(&bt_mesh.ivu_complete);
+	k_delayed_work_cancel(&bt_mesh.ivu_timer);
 
 	bt_mesh_cfg_reset();
 

--- a/subsys/bluetooth/host/mesh/settings.h
+++ b/subsys/bluetooth/host/mesh/settings.h
@@ -5,7 +5,7 @@
  */
 
 void bt_mesh_store_net(void);
-void bt_mesh_store_iv(void);
+void bt_mesh_store_iv(bool only_duration);
 void bt_mesh_store_seq(void);
 void bt_mesh_store_rpl(struct bt_mesh_rpl *rpl);
 void bt_mesh_store_subnet(struct bt_mesh_subnet *sub);


### PR DESCRIPTION
When the IV Update state enters Normal operation or IV Update in
Progress, we need to keep track of how many hours has passed in the
state, since the specification requires us to remain in the state at
least for 96 hours (Update in Progress has an additional upper limit
of 144 hours).

In order to fulfil the above requirement, even if the node might be
powered off once in a while, we need to store persistently how many
hours the node has been in the state. This doesn't necessarily need to
happen every hour (thanks to the flexible duration range). The exact
cadence will depend a lot on the ways that the node will be used and
what kind of power source it has.

Since there is no single optimal answer, this patch adds a new
configuration option, which allows specifying a divider, i.e. how many
intervals the 96 hour minimum gets split into. After each interval the
duration that the node has been in the current state gets stored to
flash. E.g. the default value of 4 means that the state is saved every
24 hours (96 / 4).

Signed-off-by: Johan Hedberg <johan.hedberg@intel.com>