### PR TITLE
drivers/adc: Uneven buffers will lead to buffer overflow

### DIFF
--- a/drivers/adc/adc_ti_adc108s102.c
+++ b/drivers/adc/adc_ti_adc108s102.c
@@ -150,6 +150,10 @@ static inline int _verify_entries(struct adc_seq_table *seq_table)
 			continue;
 		}
 
+		if (entry->buffer_length & 0x1) {
+			return 0;
+		}
+
 		chans_set++;
 	}
 


### PR DESCRIPTION
TI's ADC108S102 is a sampling on 16 bits, and thus requires the
destination buffer to be made of an even number of bytes.

Fixes #7389

Signed-off-by: Tomasz Bursztyka <tomasz.bursztyka@linux.intel.com>