### PR TITLE
Cast value assigned to attribute count to correct type

### DIFF
--- a/include/bluetooth/gatt.h
+++ b/include/bluetooth/gatt.h
@@ -144,7 +144,7 @@ struct bt_gatt_service {
 	/** Service Attributes */
 	struct bt_gatt_attr	*attrs;
 	/** Service Attribute count */
-	u16_t			attr_count;
+	size_t			attr_count;
 	sys_snode_t		node;
 };
 


### PR DESCRIPTION
The result of the expansions of ARRAY_SIZE is an expression that is
casted to "unsigned long" and which leads Lint into believing that
there is a loss of information (27 bits to 16 bits in my case).

There seems to be more than this than just the cast to unsigned long.
I think that the magic of ZERO_OR_COMPILE_ERROR may also 
confuse Lint.
Also: How/where is it checked that the number of attributes is not 
actually larger than what fits into an u16_t?

Signed-off-by: Asbjørn Sæbø <asbjorn.sabo@nordicsemi.no>