### PR TITLE
Fix MAC address changing through the eth mgmt api

### DIFF
--- a/subsys/net/ip/l2/ethernet/ethernet_mgmt.c
+++ b/subsys/net/ip/l2/ethernet/ethernet_mgmt.c
@@ -90,7 +90,7 @@ static int ethernet_set_config(u32_t mgmt_request,
 			return -EACCES;
 		}
 
-		memcpy(&params->mac_address, &config.mac_address,
+		memcpy(&config.mac_address, &params->mac_address,
 		       sizeof(struct net_eth_addr));
 		type = ETHERNET_CONFIG_TYPE_MAC_ADDRESS;
 	} else {

--- a/tests/net/ethernet_mgmt/src/main.c
+++ b/tests/net/ethernet_mgmt/src/main.c
@@ -163,6 +163,11 @@ static void test_change_mac_when_down(void)
 	ret = net_mgmt(NET_REQUEST_ETHERNET_SET_MAC_ADDRESS, iface,
 		       &params, sizeof(struct ethernet_req_params));
 
+	zassert_equal(ret, 0, "unable to change mac address\n");
+
+	ret = memcmp(net_if_get_link_addr(iface)->addr, mac_addr_change,
+		     sizeof(mac_addr_change));
+
 	zassert_equal(ret, 0, "invalid mac address change\n");
 
 	net_if_up(iface);


### PR DESCRIPTION
There was a minor bug in the current eth mgmt code and unfortunately the test did not check it properly either.

The arguments to memcpy were inverted.

This PR adds a missing check to the test and fixes the memcpy arguments.