### PR TITLE
Bluetooth: GATT: Fix documentation of bt_gatt_notify

### DIFF
--- a/include/bluetooth/gatt.h
+++ b/include/bluetooth/gatt.h
@@ -701,6 +701,8 @@ int bt_gatt_notify(struct bt_conn *conn, const struct bt_gatt_attr *attr,
  *  @param conn Connection object.
  *  @param attr Attribute object.
  *  @param err ATT error code
+ *
+ *  @return 0 in case of success or negative value in case of error.
  */
 typedef void (*bt_gatt_indicate_func_t)(struct bt_conn *conn,
 					const struct bt_gatt_attr *attr,


### PR DESCRIPTION
Document the return value of bt_gatt_notify.

Signed-off-by: Luiz Augusto von Dentz <luiz.von.dentz@intel.com>