### PR TITLE
cmake: Add new generate_inc_file_for_target_with_target_name function

### DIFF
--- a/cmake/extensions.cmake
+++ b/cmake/extensions.cmake
@@ -329,14 +329,27 @@ function(generate_inc_file
     )
 endfunction()
 
+function(generate_inc_file_for_gen_target
+    target          # The cmake target that depends on the generated file
+    source_file     # The source file to be converted to hex
+    generated_file  # The generated file
+    gen_target      # The generated file target we depend on
+                    # Any additional arguments are passed on to file2hex.py
+    )
+  generate_inc_file(${source_file} ${generated_file} ${ARGN})
+
+  # Ensure 'generated_file' is generated before 'target' by creating a
+  # dependency between the two targets
+
+  add_dependencies(${target} ${gen_target})
+endfunction()
+
 function(generate_inc_file_for_target
     target          # The cmake target that depends on the generated file
     source_file     # The source file to be converted to hex
     generated_file  # The generated file
                     # Any additional arguments are passed on to file2hex.py
     )
-  generate_inc_file(${source_file} ${generated_file} ${ARGN})
-
   # Ensure 'generated_file' is generated before 'target' by creating a
   # 'custom_target' for it and setting up a dependency between the two
   # targets
@@ -355,7 +368,7 @@ function(generate_inc_file_for_target
   set(generated_target_name "gen_${basename}_${random_chars}")
 
   add_custom_target(${generated_target_name} DEPENDS ${generated_file})
-  add_dependencies(${target} ${generated_target_name})
+  generate_inc_file_for_gen_target(${target} ${source_file} ${generated_file} ${generated_target_name} ${ARGN})
 endfunction()
 
 # 1.2 zephyr_library_*


### PR DESCRIPTION
Add a variant on generate_inc_file_for_target in which the user can
specify the target that the generated file will depend on.  This allows
exposing that target to other possible places where a dependency on the
generated file existing might be needed.

Signed-off-by: Kumar Gala <kumar.gala@linaro.org>