### PR TITLE
arch: arm: set VECTOR_ADDRESS to _vector_start

### DIFF
--- a/arch/arm/core/cortex_m/prep_c.c
+++ b/arch/arm/core/cortex_m/prep_c.c
@@ -27,8 +27,7 @@
 #ifdef CONFIG_CPU_CORTEX_M_HAS_VTOR
 
 #ifdef CONFIG_XIP
-#define VECTOR_ADDRESS ((uintptr_t)&_image_rom_start + \
-			CONFIG_TEXT_SECTION_OFFSET)
+#define VECTOR_ADDRESS ((uintptr_t)_vector_start)
 #else
 #define VECTOR_ADDRESS CONFIG_SRAM_BASE_ADDRESS
 #endif


### PR DESCRIPTION
This commit sets VECTOR_ADDRESS in prep_c.c directly to the
value of _vector_start for XIP images for MCUs which have the
VTOR register.

Signed-off-by: Ioannis Glaropoulos <Ioannis.Glaropoulos@nordicsemi.no>