### PR TITLE
xtensa: fix CONFIG_INIT_STACKS for IRQ stack

### DIFF
--- a/arch/xtensa/include/kernel_arch_func.h
+++ b/arch/xtensa/include/kernel_arch_func.h
@@ -10,6 +10,7 @@
 #define _kernel_arch_func__h_
 
 #ifndef _ASMLANGUAGE
+#include <string.h>
 
 #ifdef __cplusplus
 extern "C" {
@@ -76,6 +77,11 @@ static ALWAYS_INLINE void kernel_arch_init(void)
 	 * Leave CPENABLE alone.
 	 */
 	_xt_coproc_init();
+#endif
+
+#ifdef CONFIG_INIT_STACKS
+	memset(K_THREAD_STACK_BUFFER(_interrupt_stack), 0xAA,
+	       CONFIG_ISR_STACK_SIZE);
 #endif
 }
 


### PR DESCRIPTION
The interrupt stack area wasn't being set to a repeating
0xAA pattern at boot as it should be. This is now done in
kernel_arch_init(), which runs before interrupts are
enabled for the first time.

Fixes #7327

Signed-off-by: Andrew Boie <andrew.p.boie@intel.com>