### PR TITLE
doc: networking: qemu_setup: Update details and add DNS information

### DIFF
--- a/doc/subsystems/networking/qemu_setup.rst
+++ b/doc/subsystems/networking/qemu_setup.rst
@@ -62,6 +62,8 @@ In terminal #3, type:
 
    sudo ./loop-slip-tap.sh
 
+For applications requiring DNS, you may need to restart the host's DNS server
+at this point, as described in :ref:`networking_internet`.
 
 Step 3 - Start app in QEMU
 ==========================
@@ -133,13 +135,21 @@ To stop the daemons, press Ctrl+C in the corresponding terminal windows
 (you need to stop both ``loop-slip-tap.sh`` and ``loop-socat.sh``).
 
 
-Setting up Zephyr and NAT/masquerading on QEMU host to access Internet
-**********************************************************************
+.. _networking_internet:
+
+Setting up Zephyr and NAT/masquerading on host to access Internet
+*****************************************************************
+
+To access the internet from a Zephyr application, some additional
+setup on the host may be required. This setup is common for both
+application running in QEMU and on real hardware, assuming that
+a development board is connected to the development host. If a
+board is connected to a dedicated router, it should not be needed.
 
 To access the internet from a Zephyr application using IPv4,
 a gateway should be set via DHCP or configured manually.
-For applications using the :ref:`net_app_api` facility (with the config option
-:option:`CONFIG_NET_APP` enabled),
+For applications using the "Settings" part of :ref:`net_app_api`
+facility (with the config option :option:`CONFIG_NET_APP_SETTINGS` enabled),
 set the :option:`CONFIG_NET_APP_MY_IPV4_GW` option to the IP address
 of the gateway. For apps not using the :ref:`net_app_api` facility, set up the
 gateway by calling the :c:func:`net_if_ipv4_set_gw` at runtime.
@@ -159,6 +169,22 @@ To enable IPv4 forwarding the following command should be run as root:
 .. code-block:: console
 
    sysctl -w net.ipv4.ip_forward=1
+
+Some applications may also require a DNS server. A number of Zephyr-provided
+samples assume by default that the DNS server is available on the host
+(IP 192.0.2.2), which, in modern Linux distributions, usually runs at least
+a DNS proxy. When running with QEMU, it may be required to restart the host's
+DNS, so it can serve requests on the newly created TAP interface. For example,
+on Debian-based systems:
+
+.. code-block:: console
+
+   service dnsmasq restart
+
+An alternative to relying on the host's DNS server is to use one in the
+network. For example, 8.8.8.8 is a publicly available DNS server. You can
+configure it using :option:`CONFIG_DNS_SERVER1` option.
+
 
 Network connection between two QEMU VMs
 ***************************************


### PR DESCRIPTION
Majority of "accessing Internet" setup is the same for both QEMU and
real boards connected to host, mention that explicitly. Be more
precise that networking settings require net_app_settings API, not
entire net_app. Finally, add information about DNS setup for the
samples requiring it.

Signed-off-by: Paul Sokolovsky <paul.sokolovsky@linaro.org>