### PR TITLE
Get rid of 'option env' symbols + display properties on multi.def. symbols in the right place

### DIFF
--- a/Kconfig.zephyr
+++ b/Kconfig.zephyr
@@ -6,17 +6,6 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 #
-config KERNELVERSION
-	string
-	option env="KERNELVERSION"
-
-config ENV_VAR_SYM_BOARD_DIR
-	string
-	option env="ENV_VAR_BOARD_DIR"
-
-config ENV_VAR_SYM_ARCH
-	string
-	option env="ENV_VAR_ARCH"
 
 source "arch/Kconfig"
 
@@ -44,7 +33,7 @@ source "tests/Kconfig"
 # because board usually overrides SoC values.
 #
 
-# $ENV_VAR_SYM_ARCH and $ENV_VAR_SYM_BOARD_DIR might be glob patterns
+# $ENV_VAR_ARCH and $ENV_VAR_BOARD_DIR might be glob patterns
 
-gsource "arch/$ENV_VAR_SYM_ARCH/soc/*/Kconfig.defconfig"
-gsource "$ENV_VAR_SYM_BOARD_DIR/Kconfig.defconfig"
+gsource "arch/$ENV_VAR_ARCH/soc/*/Kconfig.defconfig"
+gsource "$ENV_VAR_BOARD_DIR/Kconfig.defconfig"

--- a/arch/Kconfig
+++ b/arch/Kconfig
@@ -326,7 +326,7 @@ config BOARD
 	  arch/<arch>/soc/<family>/<series>
 
 
-# $ENV_VAR_SYM_ARCH might be a glob pattern
-gsource "arch/$ENV_VAR_SYM_ARCH/Kconfig"
+# $ENV_VAR_ARCH might be a glob pattern
+gsource "arch/$ENV_VAR_ARCH/Kconfig"
 
 source "boards/Kconfig"

--- a/boards/Kconfig
+++ b/boards/Kconfig
@@ -14,14 +14,14 @@ config QEMU_TARGET
 	  Mark all QEMU targets with this variable for checking whether we are
 	  running in an emulated environment.
 
-# $ENV_VAR_SYM_BOARD_DIR might be a glob pattern
+# $ENV_VAR_BOARD_DIR might be a glob pattern
 
 choice
 prompt "Board Selection"
-gsource "$ENV_VAR_SYM_BOARD_DIR/Kconfig.board"
+gsource "$ENV_VAR_BOARD_DIR/Kconfig.board"
 endchoice
 
 
 menu "Board Options"
-gsource "$ENV_VAR_SYM_BOARD_DIR/Kconfig"
+gsource "$ENV_VAR_BOARD_DIR/Kconfig"
 endmenu

--- a/doc/application/application-kconfig.include
+++ b/doc/application/application-kconfig.include
@@ -1,9 +1,5 @@
 mainmenu "Your Application Name"
 
-config ZEPHYR_BASE
-	string
-	option env="ZEPHYR_BASE"
-
 source "$ZEPHYR_BASE/Kconfig.zephyr"
 
 # Your application configuration options go here.

--- a/doc/application/application.rst
+++ b/doc/application/application.rst
@@ -795,9 +795,15 @@ Make sure to follow these steps in order.
 
    .. literalinclude:: application-kconfig.include
 
-   .. important::
+   .. note::
 
-      The indented lines above must use tabs, not spaces.
+       Environment variables in ``source`` statements are expanded directly,
+       so you do not need to define a ``option env="ZEPHYR_BASE"`` Kconfig
+       "bounce" symbol. If you use such a symbol, it must have the same name as
+       the environment variable.
+
+       See the :ref:`kconfig_extensions_and_changes` section in the
+       :ref:`board_porting_guide` for more information.
 
 #. Now include the mandatory boilerplate that integrates the
    application with the Zephyr build system on a new line, **after any

--- a/doc/porting/board_porting.rst
+++ b/doc/porting/board_porting.rst
@@ -260,12 +260,28 @@ symbols.
 Having fixed settings be user-configurable might be confusing, and would allow
 the user to create broken configurations.
 
-Kconfig extensions
-==================
+.. _kconfig_extensions_and_changes:
 
-Zephyr uses the `Kconfiglib <https://github.com/ulfalizer/Kconfiglib>`_ Kconfig
-implementation, which adds the following extensions to the `Kconfig language
-<https://www.kernel.org/doc/Documentation/kbuild/kconfig-language.txt>`_:
+Kconfig extensions and changes
+==============================
+
+Zephyr uses the `Kconfiglib <https://github.com/ulfalizer/Kconfiglib>`_
+implementation of `Kconfig
+<https://www.kernel.org/doc/Documentation/kbuild/kconfig-language.txt>`_. It
+simplifies how environment variables are handled, and adds some extensions.
+
+Environment variables in ``source`` statements are expanded directly in
+Kconfiglib, meaning no ``option env="ENV_VAR"`` "bounce" symbols need to be
+defined. If you need compatibility with the C Kconfig tools for an out-of-tree
+Kconfig tree, you can still add such symbols, but they must have the same name
+as the corresponding environment variables.
+
+.. note::
+
+    As of writing, there are plans to remove ``option env`` from the C tools as
+    well.
+
+The following Kconfig extensions are available:
 
 - The ``gsource`` statement, which includes each file matching a given wildcard
   pattern.


### PR DESCRIPTION
This series adds two changes that are only related in that the first one makes the second one much cleaner to implement.

First change:
Get rid of `option env` symbols and have `$FOO` directly reference the environment variable `FOO`.

Second change:
For symbols defined in multiple locations (e.g., `Kconfig.defconfig` symbols), display all properties (`selects`, `defaults`, etc.) on the definition that actually has the property. This applies to the RST documentation and the menuconfig information display.

See the commit messages for longer descriptions and motivations. Some major Kconfiglib surgery was required here. The end result is cleaner codewise as well though.

Symbol reference before:

![beforechange](https://user-images.githubusercontent.com/154768/40141106-1223bc3e-5955-11e8-9e90-d896e943f874.png)

Symbol reference after:

![afterchange](https://user-images.githubusercontent.com/154768/40141119-1d1eee56-5955-11e8-9c48-970b1df24c2a.png)