### PR TITLE
userspace: fix kobj detection declared extern

### DIFF
--- a/tests/kernel/mem_protect/obj_validation/src/main.c
+++ b/tests/kernel/mem_protect/obj_validation/src/main.c
@@ -10,6 +10,11 @@
 
 #define SEM_ARRAY_SIZE	16
 
+/* Show that extern declarations don't interfere with detecting kernel
+ * objects, this was at one point a problem.
+ */
+extern struct k_sem sem1;
+
 static __kernel struct k_sem semarray[SEM_ARRAY_SIZE];
 static struct k_sem *dyn_sem[SEM_ARRAY_SIZE];
 


### PR DESCRIPTION
If a variable is declared extern first, the name and type
information is stored in a special DW_DIE_variable which
is then referenced by the actual instances via the
tag DW_AT_specification.

We now place extern variable instances in an extern environment
and use this data to fetch the name/type of the instances,
which do not have it (which is why they were being skipped).

As it turns out, the gross hack for the system workqueue was
due to this problem because of the extern declaration in
kernel.h.

Fixes: #6992

Signed-off-by: Andrew Boie <andrew.p.boie@intel.com>