### PR TITLE
Trivial zephyr-app-commands related fixes

### DIFF
--- a/samples/boards/olimex_stm32_e407/ccm/README.rst
+++ b/samples/boards/olimex_stm32_e407/ccm/README.rst
@@ -39,18 +39,12 @@ For example the olimex STM32 E407 DTS file looks like this:
 .. literalinclude:: ../../../../boards/arm/olimex_stm32_e407/olimex_stm32_e407.dts
    :linenos:
 
-Building
-********
+Building and Running
+********************
 
-.. code-block:: console
-
-   $ cd samples/boards/olimex_stm32_e407/ccm
-   $ mkdir build
-   $ cmake ../ -DBOARD=olimex_stm32_e407
-   $ make
-
-Running
-*******
+.. zephyr-app-commands::
+   :app: samples/boards/olimex_stm32_e407/ccm
+   :goals: build flash
 
 The first time the example is run after power on, the output will
 look like this:

--- a/samples/sensor/vl53l0x/README.rst
+++ b/samples/sensor/vl53l0x/README.rst
@@ -26,12 +26,10 @@ Building and Running
  This project outputs sensor data to the console. It requires a VL53L0X
  sensor, which is present on the disco_l475_iot1 board.
 
- .. code-block:: console
+ .. zephyr-app-commands::
+    :app: samples/sensor/vl53l0x/
+    :goals: build flash
 
-    $ cd samples/sensors/vl53l0x
-    $ mkdir disco_l475_iot1 && cd disco_l475_iot1
-    $ cmake -DBOARD=disco_l475_iot1 ..
-    $ make
 
 Sample Output
 =============


### PR DESCRIPTION
A couple of trivial patches switching to zephyr-app-commands instead of assuming Makefiles. This also makes it clear how to flash the samples.