### PR TITLE
netapp / LwM2M: local port support and LwM2M registration client changes

### DIFF
--- a/subsys/net/lib/app/client.c
+++ b/subsys/net/lib/app/client.c
@@ -293,7 +293,7 @@ static int bind_local(struct net_app_ctx *ctx)
 	if (ctx->ipv4.remote.sa_family == AF_INET && ctx->ipv4.ctx) {
 		ctx->ipv4.local.sa_family = AF_INET;
 		_net_app_set_local_addr(ctx, &ctx->ipv4.local, NULL,
-					net_sin(&ctx->ipv4.local)->sin_port);
+				ntohs(net_sin(&ctx->ipv4.local)->sin_port));
 
 		ret = _net_app_set_net_ctx(ctx, ctx->ipv4.ctx,
 					   &ctx->ipv4.local,
@@ -310,7 +310,7 @@ static int bind_local(struct net_app_ctx *ctx)
 	if (ctx->ipv6.remote.sa_family == AF_INET6 && ctx->ipv6.ctx) {
 		ctx->ipv6.local.sa_family = AF_INET6;
 		_net_app_set_local_addr(ctx, &ctx->ipv6.local, NULL,
-				       net_sin6(&ctx->ipv6.local)->sin6_port);
+				ntohs(net_sin6(&ctx->ipv6.local)->sin6_port));
 
 		ret = _net_app_set_net_ctx(ctx, ctx->ipv6.ctx,
 					   &ctx->ipv6.local,

--- a/subsys/net/lib/app/net_app.c
+++ b/subsys/net/lib/app/net_app.c
@@ -415,6 +415,8 @@ int _net_app_config_local_ctx(struct net_app_ctx *ctx,
 #if defined(CONFIG_NET_IPV6)
 			ret = setup_ipv6_ctx(ctx, sock_type, proto);
 			ctx->default_ctx = &ctx->ipv6;
+			net_sin6(&ctx->ipv6.local)->sin6_port =
+				net_sin6(addr)->sin6_port;
 #else
 			ret = -EPFNOSUPPORT;
 			goto fail;
@@ -423,6 +425,8 @@ int _net_app_config_local_ctx(struct net_app_ctx *ctx,
 #if defined(CONFIG_NET_IPV4)
 			ret = setup_ipv4_ctx(ctx, sock_type, proto);
 			ctx->default_ctx = &ctx->ipv4;
+			net_sin(&ctx->ipv4.local)->sin_port =
+				net_sin(addr)->sin_port;
 #else
 			ret = -EPFNOSUPPORT;
 			goto fail;
@@ -431,11 +435,15 @@ int _net_app_config_local_ctx(struct net_app_ctx *ctx,
 #if defined(CONFIG_NET_IPV4)
 			ret = setup_ipv4_ctx(ctx, sock_type, proto);
 			ctx->default_ctx = &ctx->ipv4;
+			net_sin(&ctx->ipv4.local)->sin_port =
+				net_sin(addr)->sin_port;
 #endif
 			/* We ignore the IPv4 error if IPv6 is enabled */
 #if defined(CONFIG_NET_IPV6)
 			ret = setup_ipv6_ctx(ctx, sock_type, proto);
 			ctx->default_ctx = &ctx->ipv6;
+			net_sin6(&ctx->ipv6.local)->sin6_port =
+				net_sin6(addr)->sin6_port;
 #endif
 		} else {
 			ret = -EINVAL;

--- a/subsys/net/lib/lwm2m/Kconfig
+++ b/subsys/net/lib/lwm2m/Kconfig
@@ -125,6 +125,15 @@ config LWM2M_FIRMWARE_UPDATE_PULL_SUPPORT
 	  block transfer and "FIRMWARE PACKAGE URI" resource.  This option
 	  adds another UDP context and packet handling.
 
+config LWM2M_FIRMWARE_UPDATE_PULL_LOCAL_PORT
+	int "LWM2M client firmware pull local port"
+	default 0
+	depends on LWM2M_FIRMWARE_UPDATE_PULL_SUPPORT
+	help
+	  This is the client port for LWM2M firmware download.  The default
+	  setting of 0 sets a random port for the client to be used for
+	  outgoing communication.
+
 config LWM2M_COAP_BLOCK_SIZE
 	int "LWM2M CoAP block-wise transfer size"
 	default 256

--- a/subsys/net/lib/lwm2m/Kconfig
+++ b/subsys/net/lib/lwm2m/Kconfig
@@ -95,13 +95,6 @@ config LWM2M_RD_CLIENT_SUPPORT
 	  Client will use registration state machine to locate and connect to
 	  LWM2M servers (including bootstrap server support)
 
-config LWM2M_RD_CLIENT_INSTANCE_COUNT
-	int "Maximum # of LWM2M RD client instances"
-	default 1
-	help
-	  This setting establishes the total count of LWM2M RD client instances
-	  available.
-
 config LWM2M_PEER_PORT
 	int "LWM2M server port"
 	depends on LWM2M_RD_CLIENT_SUPPORT

--- a/subsys/net/lib/lwm2m/Kconfig
+++ b/subsys/net/lib/lwm2m/Kconfig
@@ -66,10 +66,11 @@ config LWM2M_ENGINE_DEFAULT_LIFETIME
 
 config LWM2M_LOCAL_PORT
 	int "LWM2M client port"
-	default 5683
+	default 0
 	help
-	  This is the client port for LWM2M communication (0 = random, defaults
-	  to 5683)
+	  This is the client port for LWM2M communication.  The default
+	  setting of 0 sets a random port for the client to be used for
+	  outgoing communication.
 
 config LWM2M_SECURITY_INSTANCE_COUNT
 	int "Maximum # of LWM2M Security object instances"

--- a/subsys/net/lib/lwm2m/lwm2m_engine.c
+++ b/subsys/net/lib/lwm2m/lwm2m_engine.c
@@ -3851,11 +3851,23 @@ static int setup_cert(struct net_app_ctx *app_ctx, void *cert)
 int lwm2m_engine_start(struct lwm2m_ctx *client_ctx,
 		       char *peer_str, u16_t peer_port)
 {
+	struct sockaddr client_addr;
 	int ret = 0;
 
 	/* TODO: use security object for initial setup */
+
+	/* setup the local client port */
+	memset(&client_addr, 0, sizeof(client_addr));
+#if defined(CONFIG_NET_IPV6)
+	client_addr.sa_family = AF_INET6;
+	net_sin6(&client_addr)->sin6_port = htons(CONFIG_LWM2M_LOCAL_PORT);
+#elif defined(CONFIG_NET_IPV4)
+	client_addr.sa_family = AF_INET;
+	net_sin(&client_addr)->sin_port = htons(CONFIG_LWM2M_LOCAL_PORT);
+#endif
+
 	ret = net_app_init_udp_client(&client_ctx->net_app_ctx,
-				      NULL, NULL,
+				      &client_addr, NULL,
 				      peer_str,
 				      peer_port,
 				      client_ctx->net_init_timeout,

--- a/subsys/net/lib/lwm2m/lwm2m_rd_client.c
+++ b/subsys/net/lib/lwm2m/lwm2m_rd_client.c
@@ -106,167 +106,80 @@ struct lwm2m_rd_client_info {
 	char server_ep[CLIENT_EP_LEN];
 
 	lwm2m_ctx_event_cb_t event_cb;
-};
+} client;
 
 /* buffers */
 static char query_buffer[64]; /* allocate some data for queries and updates */
 static u8_t client_data[256]; /* allocate some data for the RD */
 
-#define CLIENT_INSTANCE_COUNT	CONFIG_LWM2M_RD_CLIENT_INSTANCE_COUNT
-static struct lwm2m_rd_client_info clients[CLIENT_INSTANCE_COUNT];
-static int client_count;
-
-static void set_sm_state(int index, u8_t sm_state)
+static void set_sm_state(u8_t sm_state)
 {
 	enum lwm2m_rd_client_event event = LWM2M_RD_CLIENT_EVENT_NONE;
 
 	/* Determine if a callback to the app is needed */
 	if (sm_state == ENGINE_BOOTSTRAP_DONE) {
 		event = LWM2M_RD_CLIENT_EVENT_BOOTSTRAP_COMPLETE;
-	} else if (clients[index].engine_state == ENGINE_UPDATE_SENT &&
+	} else if (client.engine_state == ENGINE_UPDATE_SENT &&
 		   sm_state == ENGINE_REGISTRATION_DONE) {
 		event = LWM2M_RD_CLIENT_EVENT_REG_UPDATE_COMPLETE;
 	} else if (sm_state == ENGINE_REGISTRATION_DONE) {
 		event = LWM2M_RD_CLIENT_EVENT_REGISTRATION_COMPLETE;
 	} else if ((sm_state == ENGINE_INIT ||
 		    sm_state == ENGINE_DEREGISTERED) &&
-		   (clients[index].engine_state > ENGINE_BOOTSTRAP_DONE &&
-		    clients[index].engine_state < ENGINE_DEREGISTER)) {
+		   (client.engine_state > ENGINE_BOOTSTRAP_DONE &&
+		    client.engine_state < ENGINE_DEREGISTER)) {
 		event = LWM2M_RD_CLIENT_EVENT_DISCONNECT;
 	}
 
 	/* TODO: add locking? */
-	clients[index].engine_state = sm_state;
+	client.engine_state = sm_state;
 
-	if (event > LWM2M_RD_CLIENT_EVENT_NONE && clients[index].event_cb) {
-		clients[index].event_cb(clients[index].ctx, event);
+	if (event > LWM2M_RD_CLIENT_EVENT_NONE && client.event_cb) {
+		client.event_cb(client.ctx, event);
 	}
 }
 
-static bool sm_is_registered(int index)
+static bool sm_is_registered(void)
 {
-	return (clients[index].engine_state >= ENGINE_REGISTRATION_DONE &&
-		clients[index].engine_state <= ENGINE_DEREGISTER_FAILED);
+	return (client.engine_state >= ENGINE_REGISTRATION_DONE &&
+		client.engine_state <= ENGINE_DEREGISTER_FAILED);
 }
 
-static u8_t get_sm_state(int index)
+static u8_t get_sm_state(void)
 {
 	/* TODO: add locking? */
-	return clients[index].engine_state;
-}
-
-static int find_clients_index(const struct sockaddr *addr)
-{
-	int index = -1, i;
-	struct sockaddr *remote = NULL;
-	struct net_app_ctx *net_app_ctx;
-
-	for (i = 0; i < client_count; i++) {
-		if (!clients[i].ctx) {
-			continue;
-		}
-
-		net_app_ctx = &clients[i].ctx->net_app_ctx;
-
-#if defined(CONFIG_NET_APP_DTLS)
-		if (net_app_ctx->dtls.ctx) {
-			remote = &net_app_ctx->dtls.ctx->remote;
-		}
-#endif
-
-		if (!remote) {
-			remote = &net_app_ctx->default_ctx->remote;
-		}
-
-		if (remote->sa_family != addr->sa_family) {
-			continue;
-		}
-
-#if defined(CONFIG_NET_IPV6)
-		if (remote->sa_family == AF_INET6 &&
-		    net_ipv6_addr_cmp(&net_sin6(remote)->sin6_addr,
-				      &net_sin6(addr)->sin6_addr) &&
-		    net_sin6(remote)->sin6_port ==
-				net_sin6(addr)->sin6_port) {
-			index = i;
-			break;
-		}
-#endif
-
-#if defined(CONFIG_NET_IPV4)
-		if (remote->sa_family == AF_INET &&
-		    net_ipv4_addr_cmp(&net_sin(remote)->sin_addr,
-				      &net_sin(addr)->sin_addr) &&
-		    net_sin(remote)->sin_port ==
-				net_sin(addr)->sin_port) {
-			index = i;
-			break;
-		}
-#endif
-	}
-
-	return index;
-}
-
-static int find_rd_client_from_msg(struct lwm2m_message *msg,
-				   struct lwm2m_rd_client_info *rd_clients,
-				   size_t len)
-{
-	size_t i;
-
-	if (!msg || !rd_clients) {
-		return -1;
-	}
-
-	for (i = 0; i < len; i++) {
-		if (rd_clients[i].ctx && rd_clients[i].ctx == msg->ctx) {
-			return i;
-		}
-	}
-
-	return -1;
+	return client.engine_state;
 }
 
 static void sm_handle_timeout_state(struct lwm2m_message *msg,
 				    enum sm_engine_state sm_state)
 {
-	int index;
 	enum lwm2m_rd_client_event event = LWM2M_RD_CLIENT_EVENT_NONE;
 
-	index = find_rd_client_from_msg(msg, clients, CLIENT_INSTANCE_COUNT);
-	if (index < 0) {
-		SYS_LOG_ERR("Can't find RD client from msg: %p!", msg);
-		return;
-	}
-
-	if (clients[index].engine_state == ENGINE_BOOTSTRAP_SENT) {
+	if (client.engine_state == ENGINE_BOOTSTRAP_SENT) {
 		event = LWM2M_RD_CLIENT_EVENT_BOOTSTRAP_FAILURE;
-	} else if (clients[index].engine_state == ENGINE_REGISTRATION_SENT) {
+	} else if (client.engine_state == ENGINE_REGISTRATION_SENT) {
 		event = LWM2M_RD_CLIENT_EVENT_REGISTRATION_FAILURE;
-	} else if (clients[index].engine_state == ENGINE_UPDATE_SENT) {
+	} else if (client.engine_state == ENGINE_UPDATE_SENT) {
 		event = LWM2M_RD_CLIENT_EVENT_REG_UPDATE_FAILURE;
-	} else if (clients[index].engine_state == ENGINE_DEREGISTER_SENT) {
+	} else if (client.engine_state == ENGINE_DEREGISTER_SENT) {
 		event = LWM2M_RD_CLIENT_EVENT_DEREGISTER_FAILURE;
 	} else {
 		/* TODO: unknown timeout state */
 	}
 
-	set_sm_state(index, sm_state);
+	set_sm_state(sm_state);
 
-	if (event > LWM2M_RD_CLIENT_EVENT_NONE && clients[index].event_cb) {
-		clients[index].event_cb(clients[index].ctx, event);
+	if (event > LWM2M_RD_CLIENT_EVENT_NONE && client.event_cb) {
+		client.event_cb(client.ctx, event);
 	}
 }
 
-/* force re-update with remote peer(s) */
+/* force re-update with remote peer */
 void engine_trigger_update(void)
 {
-	int index;
-
-	for (index = 0; index < client_count; index++) {
-		/* TODO: add locking? */
-		clients[index].trigger_update = 1;
-	}
+	/* TODO: add locking? */
+	client.trigger_update = 1;
 }
 
 /* state machine reply callbacks */
@@ -276,34 +189,27 @@ static int do_bootstrap_reply_cb(const struct coap_packet *response,
 				 const struct sockaddr *from)
 {
 	u8_t code;
-	int index;
 
 	code = coap_header_get_code(response);
 	SYS_LOG_DBG("Bootstrap callback (code:%u.%u)",
 		    COAP_RESPONSE_CODE_CLASS(code),
 		    COAP_RESPONSE_CODE_DETAIL(code));
 
-	index = find_clients_index(from);
-	if (index < 0) {
-		SYS_LOG_ERR("Bootstrap client index not found.");
-		return 0;
-	}
-
 	if (code == COAP_RESPONSE_CODE_CHANGED) {
 		SYS_LOG_DBG("Considered done!");
-		set_sm_state(index, ENGINE_BOOTSTRAP_DONE);
+		set_sm_state(ENGINE_BOOTSTRAP_DONE);
 	} else if (code == COAP_RESPONSE_CODE_NOT_FOUND) {
 		SYS_LOG_ERR("Failed: NOT_FOUND.  Not Retrying.");
-		set_sm_state(index, ENGINE_DO_REGISTRATION);
+		set_sm_state(ENGINE_DO_REGISTRATION);
 	} else if (code == COAP_RESPONSE_CODE_FORBIDDEN) {
 		SYS_LOG_ERR("Failed: 4.03 - Forbidden.  Not Retrying.");
-		set_sm_state(index, ENGINE_DO_REGISTRATION);
+		set_sm_state(ENGINE_DO_REGISTRATION);
 	} else {
 		/* TODO: Read payload for error message? */
 		SYS_LOG_ERR("Failed with code %u.%u. Retrying ...",
 			    COAP_RESPONSE_CODE_CLASS(code),
 			    COAP_RESPONSE_CODE_DETAIL(code));
-		set_sm_state(index, ENGINE_INIT);
+		set_sm_state(ENGINE_INIT);
 	}
 
 	return 0;
@@ -323,18 +229,12 @@ static int do_registration_reply_cb(const struct coap_packet *response,
 {
 	struct coap_option options[2];
 	u8_t code;
-	int ret, index;
+	int ret;
 
 	code = coap_header_get_code(response);
 	SYS_LOG_DBG("Registration callback (code:%u.%u)",
 		    COAP_RESPONSE_CODE_CLASS(code),
 		    COAP_RESPONSE_CODE_DETAIL(code));
-
-	index = find_clients_index(from);
-	if (index < 0) {
-		SYS_LOG_ERR("Registration client index not found.");
-		return 0;
-	}
 
 	/* check state and possibly set registration to done */
 	if (code == COAP_RESPONSE_CODE_CREATED) {
@@ -351,29 +251,29 @@ static int do_registration_reply_cb(const struct coap_packet *response,
 
 		/* option[0] should be "rd" */
 
-		if (options[1].len + 1 > sizeof(clients[index].server_ep)) {
+		if (options[1].len + 1 > sizeof(client.server_ep)) {
 			SYS_LOG_ERR("Unexpected length of query: "
 				    "%u (expected %zu)\n",
 				    options[1].len,
-				    sizeof(clients[index].server_ep));
+				    sizeof(client.server_ep));
 			return -EINVAL;
 		}
 
-		memcpy(clients[index].server_ep, options[1].value,
+		memcpy(client.server_ep, options[1].value,
 		       options[1].len);
-		clients[index].server_ep[options[1].len] = '\0';
-		set_sm_state(index, ENGINE_REGISTRATION_DONE);
+		client.server_ep[options[1].len] = '\0';
+		set_sm_state(ENGINE_REGISTRATION_DONE);
 		SYS_LOG_INF("Registration Done (EP='%s')",
-			    clients[index].server_ep);
+			    client.server_ep);
 
 		return 0;
 	} else if (code == COAP_RESPONSE_CODE_NOT_FOUND) {
 		SYS_LOG_ERR("Failed: NOT_FOUND.  Not Retrying.");
-		set_sm_state(index, ENGINE_REGISTRATION_DONE);
+		set_sm_state(ENGINE_REGISTRATION_DONE);
 		return 0;
 	} else if (code == COAP_RESPONSE_CODE_FORBIDDEN) {
 		SYS_LOG_ERR("Failed: 4.03 - Forbidden.  Not Retrying.");
-		set_sm_state(index, ENGINE_REGISTRATION_DONE);
+		set_sm_state(ENGINE_REGISTRATION_DONE);
 		return 0;
 	}
 
@@ -382,7 +282,7 @@ static int do_registration_reply_cb(const struct coap_packet *response,
 	SYS_LOG_ERR("failed with code %u.%u. Re-init network",
 		    COAP_RESPONSE_CODE_CLASS(code),
 		    COAP_RESPONSE_CODE_DETAIL(code));
-	set_sm_state(index, ENGINE_INIT);
+	set_sm_state(ENGINE_INIT);
 	return 0;
 }
 
@@ -399,23 +299,16 @@ static int do_update_reply_cb(const struct coap_packet *response,
 			      const struct sockaddr *from)
 {
 	u8_t code;
-	int index;
 
 	code = coap_header_get_code(response);
 	SYS_LOG_INF("Update callback (code:%u.%u)",
 		    COAP_RESPONSE_CODE_CLASS(code),
 		    COAP_RESPONSE_CODE_DETAIL(code));
 
-	index = find_clients_index(from);
-	if (index < 0) {
-		SYS_LOG_ERR("Registration client index not found.");
-		return 0;
-	}
-
 	/* If NOT_FOUND just continue on */
 	if ((code == COAP_RESPONSE_CODE_CHANGED) ||
 	    (code == COAP_RESPONSE_CODE_CREATED)) {
-		set_sm_state(index, ENGINE_REGISTRATION_DONE);
+		set_sm_state(ENGINE_REGISTRATION_DONE);
 		SYS_LOG_INF("Update Done");
 		return 0;
 	}
@@ -425,7 +318,7 @@ static int do_update_reply_cb(const struct coap_packet *response,
 	SYS_LOG_ERR("Failed with code %u.%u. Retrying registration",
 		    COAP_RESPONSE_CODE_CLASS(code),
 		    COAP_RESPONSE_CODE_DETAIL(code));
-	set_sm_state(index, ENGINE_DO_REGISTRATION);
+	set_sm_state(ENGINE_DO_REGISTRATION);
 
 	return 0;
 }
@@ -443,28 +336,21 @@ static int do_deregister_reply_cb(const struct coap_packet *response,
 				  const struct sockaddr *from)
 {
 	u8_t code;
-	int index;
 
 	code = coap_header_get_code(response);
 	SYS_LOG_DBG("Deregister callback (code:%u.%u)",
 		    COAP_RESPONSE_CODE_CLASS(code),
 		    COAP_RESPONSE_CODE_DETAIL(code));
 
-	index = find_clients_index(from);
-	if (index < 0) {
-		SYS_LOG_ERR("Registration clients index not found.");
-		return 0;
-	}
-
 	if (code == COAP_RESPONSE_CODE_DELETED) {
 		SYS_LOG_DBG("Deregistration success");
-		set_sm_state(index, ENGINE_DEREGISTERED);
+		set_sm_state(ENGINE_DEREGISTERED);
 	} else {
 		SYS_LOG_ERR("failed with code %u.%u",
 			    COAP_RESPONSE_CODE_CLASS(code),
 			    COAP_RESPONSE_CODE_DETAIL(code));
-		if (get_sm_state(index) == ENGINE_DEREGISTER_SENT) {
-			set_sm_state(index, ENGINE_DEREGISTER_FAILED);
+		if (get_sm_state() == ENGINE_DEREGISTER_SENT) {
+			set_sm_state(ENGINE_DEREGISTER_FAILED);
 		}
 	}
 
@@ -481,46 +367,46 @@ static void do_deregister_timeout_cb(struct lwm2m_message *msg)
 
 /* state machine step functions */
 
-static int sm_do_init(int index)
+static int sm_do_init(void)
 {
 	SYS_LOG_INF("RD Client started with endpoint "
 		    "'%s' and client lifetime %d",
-		    clients[index].ep_name,
-		    clients[index].lifetime);
+		    client.ep_name,
+		    client.lifetime);
 	/* Zephyr has joined network already */
-	clients[index].has_registration_info = 1;
-	clients[index].bootstrapped = 0;
-	clients[index].trigger_update = 0;
+	client.has_registration_info = 1;
+	client.bootstrapped = 0;
+	client.trigger_update = 0;
 #if defined(CONFIG_LWM2M_BOOTSTRAP_SERVER)
-	clients[index].use_bootstrap = 1;
+	client.use_bootstrap = 1;
 #else
-	clients[index].use_registration = 1;
+	client.use_registration = 1;
 #endif
-	if (clients[index].lifetime == 0) {
-		clients[index].lifetime = CONFIG_LWM2M_ENGINE_DEFAULT_LIFETIME;
+	if (client.lifetime == 0) {
+		client.lifetime = CONFIG_LWM2M_ENGINE_DEFAULT_LIFETIME;
 	}
 	/* Do bootstrap or registration */
-	if (clients[index].use_bootstrap) {
-		set_sm_state(index, ENGINE_DO_BOOTSTRAP);
+	if (client.use_bootstrap) {
+		set_sm_state(ENGINE_DO_BOOTSTRAP);
 	} else {
-		set_sm_state(index, ENGINE_DO_REGISTRATION);
+		set_sm_state(ENGINE_DO_REGISTRATION);
 	}
 
 	return 0;
 }
 
-static int sm_do_bootstrap(int index)
+static int sm_do_bootstrap(void)
 {
 	struct lwm2m_message *msg;
 	struct net_app_ctx *app_ctx = NULL;
 	int ret;
 	struct sockaddr *remote = NULL;
 
-	if (clients[index].use_bootstrap &&
-	    clients[index].bootstrapped == 0 &&
-	    clients[index].has_bs_server_info) {
-		app_ctx = &clients[index].ctx->net_app_ctx;
-		msg = lwm2m_get_message(clients[index].ctx);
+	if (client.use_bootstrap &&
+	    client.bootstrapped == 0 &&
+	    client.has_bs_server_info) {
+		app_ctx = &client.ctx->net_app_ctx;
+		msg = lwm2m_get_message(client.ctx);
 		if (!msg) {
 			SYS_LOG_ERR("Unable to get a lwm2m message!");
 			return -ENOMEM;
@@ -542,7 +428,7 @@ static int sm_do_bootstrap(int index)
 					  "bs", strlen("bs"));
 
 		snprintk(query_buffer, sizeof(query_buffer) - 1,
-			 "ep=%s", clients[index].ep_name);
+			 "ep=%s", client.ep_name);
 		/* TODO: handle return error */
 		coap_packet_append_option(&msg->cpkt, COAP_OPTION_URI_QUERY,
 					  query_buffer, strlen(query_buffer));
@@ -569,7 +455,7 @@ static int sm_do_bootstrap(int index)
 			goto cleanup;
 		}
 
-		set_sm_state(index, ENGINE_BOOTSTRAP_SENT);
+		set_sm_state(ENGINE_BOOTSTRAP_SENT);
 	}
 	return 0;
 
@@ -578,11 +464,11 @@ cleanup:
 	return ret;
 }
 
-static int sm_bootstrap_done(int index)
+static int sm_bootstrap_done(void)
 {
 	/* TODO: Fix this */
 	/* check that we should still use bootstrap */
-	if (clients[index].use_bootstrap) {
+	if (client.use_bootstrap) {
 #ifdef CONFIG_LWM2M_SECURITY_OBJ_SUPPORT
 		int i;
 
@@ -594,35 +480,35 @@ static int sm_bootstrap_done(int index)
 #if 0
 			if (!parse_endpoint(sec_data->server_uri,
 					    sec_data->server_uri_len,
-					    &clients[index].reg_server)) {
+					    &client.reg_server)) {
 #else
 			if (true) {
 #endif
 				SYS_LOG_ERR("Failed to parse URI!");
 			} else {
-				clients[index].has_registration_info = 1;
-				clients[index].bootstrapped++;
+				client.has_registration_info = 1;
+				client.bootstrapped++;
 			}
 		} else {
 			SYS_LOG_ERR("** failed to parse URI");
 		}
 
 		/* if we did not register above - then fail this and restart */
-		if (clients[index].bootstrapped == 0) {
+		if (client.bootstrapped == 0) {
 			/* Not ready - Retry with the bootstrap server again */
-			set_sm_state(index, ENGINE_DO_BOOTSTRAP);
+			set_sm_state(ENGINE_DO_BOOTSTRAP);
 		} else {
-			set_sm_state(index, ENGINE_DO_REGISTRATION);
+			set_sm_state(ENGINE_DO_REGISTRATION);
 		}
 	} else {
 #endif
-		set_sm_state(index, ENGINE_DO_REGISTRATION);
+		set_sm_state(ENGINE_DO_REGISTRATION);
 	}
 
 	return 0;
 }
 
-static int sm_send_registration(int index, bool send_obj_support_data,
+static int sm_send_registration(bool send_obj_support_data,
 				coap_reply_t reply_cb,
 				lwm2m_message_timeout_cb_t timeout_cb)
 {
@@ -632,15 +518,15 @@ static int sm_send_registration(int index, bool send_obj_support_data,
 	int ret;
 	struct sockaddr *remote = NULL;
 
-	app_ctx = &clients[index].ctx->net_app_ctx;
-	msg = lwm2m_get_message(clients[index].ctx);
+	app_ctx = &client.ctx->net_app_ctx;
+	msg = lwm2m_get_message(client.ctx);
 	if (!msg) {
 		SYS_LOG_ERR("Unable to get a lwm2m message!");
 		return -ENOMEM;
 	}
 
 	/* remember the last reg time */
-	clients[index].last_update = k_uptime_get();
+	client.last_update = k_uptime_get();
 
 	msg->type = COAP_TYPE_CON;
 	msg->code = COAP_METHOD_POST;
@@ -658,7 +544,7 @@ static int sm_send_registration(int index, bool send_obj_support_data,
 				  LWM2M_RD_CLIENT_URI,
 				  strlen(LWM2M_RD_CLIENT_URI));
 
-	if (!sm_is_registered(index)) {
+	if (!sm_is_registered()) {
 		/* include client endpoint in URI QUERY on 1st registration */
 		coap_append_option_int(&msg->cpkt, COAP_OPTION_CONTENT_FORMAT,
 				       LWM2M_FORMAT_APP_LINK_FORMAT);
@@ -668,7 +554,7 @@ static int sm_send_registration(int index, bool send_obj_support_data,
 		coap_packet_append_option(&msg->cpkt, COAP_OPTION_URI_QUERY,
 					  query_buffer, strlen(query_buffer));
 		snprintk(query_buffer, sizeof(query_buffer) - 1,
-			 "ep=%s", clients[index].ep_name);
+			 "ep=%s", client.ep_name);
 		/* TODO: handle return error */
 		coap_packet_append_option(&msg->cpkt, COAP_OPTION_URI_QUERY,
 					  query_buffer, strlen(query_buffer));
@@ -676,12 +562,12 @@ static int sm_send_registration(int index, bool send_obj_support_data,
 		/* include server endpoint in URI PATH otherwise */
 		/* TODO: handle return error */
 		coap_packet_append_option(&msg->cpkt, COAP_OPTION_URI_PATH,
-					  clients[index].server_ep,
-					  strlen(clients[index].server_ep));
+					  client.server_ep,
+					  strlen(client.server_ep));
 	}
 
 	snprintk(query_buffer, sizeof(query_buffer) - 1,
-		 "lt=%d", clients[index].lifetime);
+		 "lt=%d", client.lifetime);
 	/* TODO: handle return error */
 	coap_packet_append_option(&msg->cpkt, COAP_OPTION_URI_QUERY,
 				  query_buffer, strlen(query_buffer));
@@ -733,18 +619,18 @@ cleanup:
 	return ret;
 }
 
-static int sm_do_registration(int index)
+static int sm_do_registration(void)
 {
 	int ret = 0;
 
-	if (clients[index].use_registration &&
-	    !sm_is_registered(index) &&
-	    clients[index].has_registration_info) {
-		ret = sm_send_registration(index, true,
+	if (client.use_registration &&
+	    !sm_is_registered() &&
+	    client.has_registration_info) {
+		ret = sm_send_registration(true,
 					   do_registration_reply_cb,
 					   do_registration_timeout_cb);
 		if (!ret) {
-			set_sm_state(index, ENGINE_REGISTRATION_SENT);
+			set_sm_state(ENGINE_REGISTRATION_SENT);
 		} else {
 			SYS_LOG_ERR("Registration err: %d", ret);
 		}
@@ -753,23 +639,23 @@ static int sm_do_registration(int index)
 	return ret;
 }
 
-static int sm_registration_done(int index)
+static int sm_registration_done(void)
 {
 	int ret = 0;
 	bool forced_update;
 
 	/* check for lifetime seconds - 1 so that we can update early */
-	if (sm_is_registered(index) &&
-	    (clients[index].trigger_update ||
-	     ((clients[index].lifetime - SECONDS_TO_UPDATE_EARLY) <=
-	      (k_uptime_get() - clients[index].last_update) / 1000))) {
-		forced_update = clients[index].trigger_update;
-		clients[index].trigger_update = 0;
-		ret = sm_send_registration(index, forced_update,
+	if (sm_is_registered() &&
+	    (client.trigger_update ||
+	     ((client.lifetime - SECONDS_TO_UPDATE_EARLY) <=
+	      (k_uptime_get() - client.last_update) / 1000))) {
+		forced_update = client.trigger_update;
+		client.trigger_update = 0;
+		ret = sm_send_registration(forced_update,
 					   do_update_reply_cb,
 					   do_update_timeout_cb);
 		if (!ret) {
-			set_sm_state(index, ENGINE_UPDATE_SENT);
+			set_sm_state(ENGINE_UPDATE_SENT);
 		} else {
 			SYS_LOG_ERR("Registration update err: %d", ret);
 		}
@@ -778,14 +664,14 @@ static int sm_registration_done(int index)
 	return ret;
 }
 
-static int sm_do_deregister(int index)
+static int sm_do_deregister(void)
 {
 	struct net_app_ctx *app_ctx = NULL;
 	struct lwm2m_message *msg;
 	int ret;
 
-	app_ctx = &clients[index].ctx->net_app_ctx;
-	msg = lwm2m_get_message(clients[index].ctx);
+	app_ctx = &client.ctx->net_app_ctx;
+	msg = lwm2m_get_message(client.ctx);
 	if (!msg) {
 		SYS_LOG_ERR("Unable to get a lwm2m message!");
 		return -ENOMEM;
@@ -804,10 +690,10 @@ static int sm_do_deregister(int index)
 
 	/* TODO: handle return error */
 	coap_packet_append_option(&msg->cpkt, COAP_OPTION_URI_PATH,
-				  clients[index].server_ep,
-				  strlen(clients[index].server_ep));
+				  client.server_ep,
+				  strlen(client.server_ep));
 
-	SYS_LOG_INF("Deregister from '%s'", clients[index].server_ep);
+	SYS_LOG_INF("Deregister from '%s'", client.server_ep);
 
 	ret = lwm2m_send_message(msg);
 	if (ret < 0) {
@@ -816,7 +702,7 @@ static int sm_do_deregister(int index)
 		goto cleanup;
 	}
 
-	set_sm_state(index, ENGINE_DEREGISTER_SENT);
+	set_sm_state(ENGINE_DEREGISTER_SENT);
 	return 0;
 
 cleanup:
@@ -826,17 +712,15 @@ cleanup:
 
 static void lwm2m_rd_client_service(void)
 {
-	int index;
-
-	for (index = 0; index < client_count; index++) {
-		switch (get_sm_state(index)) {
+	if (client.ctx) {
+		switch (get_sm_state()) {
 
 		case ENGINE_INIT:
-			sm_do_init(index);
+			sm_do_init();
 			break;
 
 		case ENGINE_DO_BOOTSTRAP:
-			sm_do_bootstrap(index);
+			sm_do_bootstrap();
 			break;
 
 		case ENGINE_BOOTSTRAP_SENT:
@@ -844,11 +728,11 @@ static void lwm2m_rd_client_service(void)
 			break;
 
 		case ENGINE_BOOTSTRAP_DONE:
-			sm_bootstrap_done(index);
+			sm_bootstrap_done();
 			break;
 
 		case ENGINE_DO_REGISTRATION:
-			sm_do_registration(index);
+			sm_do_registration();
 			break;
 
 		case ENGINE_REGISTRATION_SENT:
@@ -856,7 +740,7 @@ static void lwm2m_rd_client_service(void)
 			break;
 
 		case ENGINE_REGISTRATION_DONE:
-			sm_registration_done(index);
+			sm_registration_done();
 			break;
 
 		case ENGINE_UPDATE_SENT:
@@ -864,7 +748,7 @@ static void lwm2m_rd_client_service(void)
 			break;
 
 		case ENGINE_DEREGISTER:
-			sm_do_deregister(index);
+			sm_do_deregister();
 			break;
 
 		case ENGINE_DEREGISTER_SENT:
@@ -878,8 +762,7 @@ static void lwm2m_rd_client_service(void)
 			break;
 
 		default:
-			SYS_LOG_ERR("Unhandled state: %d",
-				    get_sm_state(index));
+			SYS_LOG_ERR("Unhandled state: %d", get_sm_state());
 
 		}
 	}
@@ -890,11 +773,7 @@ int lwm2m_rd_client_start(struct lwm2m_ctx *client_ctx,
 			  const char *ep_name,
 			  lwm2m_ctx_event_cb_t event_cb)
 {
-	int index, ret = 0;
-
-	if (client_count + 1 > CLIENT_INSTANCE_COUNT) {
-		return -ENOMEM;
-	}
+	int ret = 0;
 
 	ret = lwm2m_engine_start(client_ctx, peer_str, peer_port);
 	if (ret < 0) {
@@ -908,13 +787,11 @@ int lwm2m_rd_client_start(struct lwm2m_ctx *client_ctx,
 	}
 
 	/* TODO: use server URI data from security */
-	index = client_count;
-	client_count++;
-	clients[index].ctx = client_ctx;
-	clients[index].event_cb = event_cb;
-	set_sm_state(index, ENGINE_INIT);
-	strncpy(clients[index].ep_name, ep_name, CLIENT_EP_LEN - 1);
-	SYS_LOG_INF("LWM2M Client: %s", clients[index].ep_name);
+	client.ctx = client_ctx;
+	client.event_cb = event_cb;
+	set_sm_state(ENGINE_INIT);
+	strncpy(client.ep_name, ep_name, CLIENT_EP_LEN - 1);
+	SYS_LOG_INF("LWM2M Client: %s", client.ep_name);
 
 	return 0;
 


### PR DESCRIPTION
The netapp layer didn't support setting the local_port of a new client.  This was required to fix https://github.com/zephyrproject-rtos/zephyr/issues/7475.

This patchset does the following:
- Fix a byte-order bug in the netapp layer
- Add local port handling to the netapp layer based on the client_addr parameter pass into the init function
- Set the local port for the LwM2M client based on CONFIG_LWM2M_LOCAL_PORT setting.
- Set the local port for the LwM2M client firmware update connection based on a new config: CONFIG_LWM2M_FIRMWARE_UPDATE_PULL_LOCAL_PORT.
- Use random ports as default instead of the previous setting so we don't change functionality for current users due to the bugfix
- Remove the multi-server logic of the LwM2M registration client as it doesn't work if the local port of the client is customized, and it's kind of a hot mess at the moment and needs to be re-thought out.  This cleanup makes implementing bootstrap support much easier.

This fixes: https://github.com/zephyrproject-rtos/zephyr/issues/7475