### PR TITLE
tests: threads: Add test case to verify k_wakeup()

### DIFF
--- a/tests/kernel/threads/scheduling/schedule_api/src/main.c
+++ b/tests/kernel/threads/scheduling/schedule_api/src/main.c
@@ -15,6 +15,7 @@ void test_main(void)
 			 ztest_unit_test(test_yield_cooperative),
 			 ztest_unit_test(test_sleep_cooperative),
 			 ztest_unit_test(test_sleep_wakeup_preemptible),
+			 ztest_unit_test(test_pending_thread_wakeup),
 			 ztest_unit_test(test_time_slicing_preemptible),
 			 ztest_unit_test(test_time_slicing_disable_preemptible),
 			 ztest_unit_test(test_lock_preemptible),

--- a/tests/kernel/threads/scheduling/schedule_api/src/test_sched.h
+++ b/tests/kernel/threads/scheduling/schedule_api/src/test_sched.h
@@ -27,6 +27,7 @@ void test_priority_preemptible(void);
 void test_yield_cooperative(void);
 void test_sleep_cooperative(void);
 void test_sleep_wakeup_preemptible(void);
+void test_pending_thread_wakeup(void);
 void test_time_slicing_preemptible(void);
 void test_time_slicing_disable_preemptible(void);
 void test_lock_preemptible(void);


### PR DESCRIPTION
Test case to verify wake up of a pending thread

Signed-off-by: Spoorthi K <spoorthi.k@intel.com>