### PR TITLE
doc: tests: remove obsolete and bogus test groups

### DIFF
--- a/drivers/spi/spi_handlers.c
+++ b/drivers/spi/spi_handlers.c
@@ -6,6 +6,7 @@
 
 #include <spi.h>
 #include <syscall_handler.h>
+#include <string.h>
 
 /* This assumes that bufs and buf_copy are copies from the values passed
  * as syscall arguments.

--- a/tests/drivers/uart/uart_basic_api/src/test_uart_poll.c
+++ b/tests/drivers/uart/uart_basic_api/src/test_uart_poll.c
@@ -4,28 +4,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-/*
- * @addtogroup t_uart_basic
- * @{
- * @defgroup t_uart_poll test_uart_poll
- * @brief TestPurpose: verify UART works well in poll mode
- * @details
- * - Test Steps
- *    - Poll Output:
- *      -# Output the prepared data using uart_poll_out(), and compare
- *         the output characters with the original characters.
- *    - Poll Input:
- *      -# Wait for data from UART console using uart_poll_in(). User sends
- *         data to UART console using echo "qwer" > /dev/ttyUSB* and waits
- *         for uart_poll_in() exit.
- * - Expected Results
- *   -# When test UART poll out, the return value from uart_poll_out()
- *      will be equal to the character sent out.
- *   -# When test UART poll in, the app will wait for input from UART
- *      console and exit after receiving '\n'.
- * @}
- */
-
 #include "test_uart.h"
 
 static const char *poll_data = "This is a POLL test.\r\n";

--- a/tests/kernel/lifo/lifo_api/src/main.c
+++ b/tests/kernel/lifo/lifo_api/src/main.c
@@ -4,13 +4,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-/**
- * @addtogroup t_lifo
- * @{
- * @defgroup t_lifo_api test_lifo_api
- * @}
- */
-
 #include <ztest.h>
 extern void test_lifo_thread2thread(void);
 extern void test_lifo_thread2isr(void);

--- a/tests/kernel/lifo/lifo_api/src/test_lifo_contexts.c
+++ b/tests/kernel/lifo/lifo_api/src/test_lifo_contexts.c
@@ -4,19 +4,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-/**
- * @addtogroup t_lifo_api
- * @{
- * @defgroup t_lifo_api_basic test_lifo_api_basic
- * @brief TestPurpose: verify zephyr lifo apis under different context
- * - API coverage
- *   -# k_lifo_init K_LIFO_DEFINE
- *   -# k_lifo_put
- *   -# k_lifo_get
- * @}
- */
-
-
 #include "test_lifo.h"
 
 #define STACK_SIZE (512 + CONFIG_TEST_EXTRA_STACKSIZE)

--- a/tests/kernel/lifo/lifo_api/src/test_lifo_fail.c
+++ b/tests/kernel/lifo/lifo_api/src/test_lifo_fail.c
@@ -4,17 +4,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-/**
- * @addtogroup t_lifo_api
- * @{
- * @defgroup t_lifo_get_fail test_lifo_get_fail
- * @brief TestPurpose: verify zephyr lifo_get when no data
- * - API coverage
- *   -# k_lifo_init
- *   -# k_lifo_get [TIMEOUT|K_NO_WAIT]
- * @}
- */
-
 #include "test_lifo.h"
 
 #define TIMEOUT 100

--- a/tests/kernel/lifo/lifo_api/src/test_lifo_loop.c
+++ b/tests/kernel/lifo/lifo_api/src/test_lifo_loop.c
@@ -4,28 +4,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-/**
- * @addtogroup t_lifo_api
- * @{
- * @defgroup t_lifo_loop test_lifo_loop
- * @brief TestPurpose: verify zephyr lifo continuous read write
- *                     in loop
- * @details
- * - Test Steps
- *   -# lifo put from main thread
- *   -# lifo read from isr
- *   -# lifo put from isr
- *   -# lifo get from spawn thread
- *   -# loop above steps for LOOPs times
- * - Expected Results
- *   -# lifo data pass correctly and stably across contexts
- * - API coverage
- *   -# k_lifo_init
- *   -# k_lifo_put
- *   -# k_lifo_get
- * @}
- */
-
 #include "test_lifo.h"
 
 #define STACK_SIZE (512 + CONFIG_TEST_EXTRA_STACKSIZE)

--- a/tests/kernel/mbox/mbox_api/src/test_mbox_api.c
+++ b/tests/kernel/mbox/mbox_api/src/test_mbox_api.c
@@ -4,22 +4,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-/**
- * @addtogroup t_mbox
- * @{
- * @defgroup t_mbox_api test_mbox_api
- * @brief TestPurpose: verify data passing via mailbox APIs
- * - API coverage
- *   -# K_MBOX_DEFINE
- *   -# k_mbox_init
- *   -# k_mbox_put
- *   -# k_mbox_async_put
- *   -# k_mbox_get
- *   -# k_mbox_data_get
- *   -# k_mbox_data_block_get
- * @}
- */
-
 #include <ztest.h>
 
 #define TIMEOUT 100

--- a/tests/kernel/mem_heap/mheap_api_concept/src/test_mheap_api.c
+++ b/tests/kernel/mem_heap/mheap_api_concept/src/test_mheap_api.c
@@ -4,19 +4,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-/**
- * @addtogroup t_mheap
- * @{
- * @defgroup t_mheap_api test_mheap_api
- * @brief TestPurpose: verify heap memory pool APIs.
- * @details All TESTPOINTs extracted from API doc
- * https://www.zephyrproject.org/doc/api/kernel_api.html#heap-memory-pool
- * - API coverage
- *   -# k_malloc
- *   -# k_free
- * @}
- */
-
 #include <ztest.h>
 #include "test_mheap.h"
 

--- a/tests/kernel/mem_heap/mheap_api_concept/src/test_mheap_concept.c
+++ b/tests/kernel/mem_heap/mheap_api_concept/src/test_mheap_concept.c
@@ -4,20 +4,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-/**
- * @addtogroup t_mheap
- * @{
- * @defgroup t_mheap_concept test_mheap_concept
- * @brief TestPurpose: verify memory pool concepts.
- * @details All TESTPOINTs extracted from kernel documentation.
- * https://www.zephyrproject.org/doc/kernel/memory/heap.html#concepts
- *
- * TESTPOINTs cover testable kernel behaviors that preserve across internal
- * implementation change or kernel version change.
- * As a black-box test, TESTPOINTs do not cover internal operations.
- * @}
- */
-
 #include <ztest.h>
 #include "test_mheap.h"
 

--- a/tests/kernel/mem_pool/mem_pool_api/src/test_mpool_api.c
+++ b/tests/kernel/mem_pool/mem_pool_api/src/test_mpool_api.c
@@ -4,19 +4,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-/**
- * @addtogroup t_mpool
- * @{
- * @defgroup t_mpool_api test_mpool_api
- * @brief TestPurpose: verify memory pool APIs.
- * @details All TESTPOINTs extracted from kernel-doc comments in <kernel.h>
- * - API coverage
- *   -# K_MEM_POOL_DEFINE
- *   -# k_mem_pool_alloc
- *   -# k_mem_pool_free
- * @}
- */
-
 #include <ztest.h>
 #include <irq_offload.h>
 #include "test_mpool.h"

--- a/tests/kernel/mem_pool/mem_pool_concept/src/test_mpool_alloc_wait.c
+++ b/tests/kernel/mem_pool/mem_pool_concept/src/test_mpool_alloc_wait.c
@@ -4,38 +4,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-/**
- * @addtogroup t_mpool
- * @{
- * @defgroup t_mpool_concept test_mpool_concept
- * @brief TestPurpose: verify memory pool concepts.
- * @details All TESTPOINTs extracted from kernel documentation.
- * TESTPOINTs cover testable kernel behaviors that preserve across internal
- * implementation change or kernel version change.
- * As a black-box test, TESTPOINTs do not cover internal operations.
- *
- * TESTPOINTs duplicated to <kernel.h> are covered in API test:
- * - TESTPOINT: ensure that all memory blocks in the buffer are similarly
- * aligned to this boundary
- * - TESTPOINT: Following a successful allocation, the data field of the block
- * descriptor supplied by the thread indicates the starting address of the
- * memory block
- * - TESTPOINT: memory pool blocks can be recursively partitioned into quarters
- * until blocks of the minimum size are obtained
- * - TESTPOINT: if a suitable block can't be created, the allocation request
- * fails
- *
- * TESTPOINTs related to kconfig are covered in kconfig test:
- * - TESTPOINT: If the block set does not contain a free block, the memory pool
- * attempts to create one automatically by splitting a free block of a larger
- * size or by merging free blocks of smaller sizes
- *
- * TESTPOINTS related to multiple instances are covered in re-entrance test:
- * - TESTPOINT: More than one memory pool can be defined, if needed. For
- * example, different applications can utilize different memory pools
- * @}
- */
-
 #include <ztest.h>
 #include "test_mpool.h"
 

--- a/tests/kernel/mem_pool/mem_pool_threadsafe/src/main.c
+++ b/tests/kernel/mem_pool/mem_pool_threadsafe/src/main.c
@@ -4,35 +4,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-
-/**
- * @addtogroup t_mpool
- * @{
- * @defgroup t_mpool_threadsafe test_mpool_threadsafe
- * @brief TestPurpose: verify API thread safe in multi-threads environment.
- * @details This is an extensive test. Multiple threads in same priority are
- * created, with time slice scheduling enabled in a very small slicing size:
- * 1 millisecond (refer to prj.conf).
- * All threads share a same entry function to invoke same kernel APIs.
- * Unless explicitly stated, kernel APIs are supposed to be thread safe.
- * Expect all threads should complete and exit the entry function normally.
- *
- * NOTE:
- * # API functionality is not TESTPOINT here. When invoked by multiple
- * threads, each API following its own behavior specification returns either
- * success or failure. Like, memory allocation successful or fail is pending on
- * whether any free memory blocks are available at the moment when the API is
- * invoked by a thread just got scheduled in.
- * # For kernel object APIs, more than one instance of the same object type are
- * created. Like, 4 threads operating on 2 instances, the test would cover the
- * kernel's code branches that handling "multiple threads accessing to a same
- * instance" and that handling "multiple instances serving simultaneously".
- * # The test adopts a slicing size in 1 millisecond. Thread safe theoretically
- * should work in a smaller slicing size. But this does not intent to stress
- * test that.
- * @}
- */
-
 #include <ztest.h>
 #include <atomic.h>
 #define THREAD_NUM 4

--- a/tests/kernel/mem_slab/mslab_api/src/test_mslab_api.c
+++ b/tests/kernel/mem_slab/mslab_api/src/test_mslab_api.c
@@ -4,22 +4,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-/**
- * @addtogroup t_mslab
- * @{
- * @defgroup t_mslab_api test_mslab_api
- * @brief TestPurpose: verify memory slab APIs.
- * @details All TESTPOINTs extracted from kernel-doc comments in <kernel.h>
- * - API coverage
- *   - K_MEM_SLAB_DEFINE
- *   - k_mem_slab_init
- *   - k_mem_slab_alloc
- *   - k_mem_slab_free
- *   - k_mem_slab_num_used_get
- *   - k_mem_slab_num_free_get
- * @}
- */
-
 #include <ztest.h>
 #include "test_mslab.h"
 

--- a/tests/kernel/mem_slab/mslab_concept/src/test_mslab_alloc_wait.c
+++ b/tests/kernel/mem_slab/mslab_concept/src/test_mslab_alloc_wait.c
@@ -4,28 +4,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-/**
- * @addtogroup t_mslab
- * @{
- * @defgroup t_mslab_concept test_mslab_concept
- * @brief TestPurpose: verify memory slab concepts.
- * @details All TESTPOINTs extracted from kernel documentation.
- * TESTPOINTs cover testable kernel behaviors that preserve across internal
- * implementation change or kernel version change.
- * As a black-box test, TESTPOINTs do not cover internal operations.
- *
- * TESTPOINTs duplicated to <kernel.h> are covered in API test:
- * - TESTPOINT: ensure that all memory blocks in the buffer are similarly
- * aligned to this boundary
- * - TESTPOINT: A memory slab must be initialized before it can be used. This
- * marks all of its blocks as unused.
- *
- * TESTPOINTS related to multiple instances are covered in re-entrance test:
- * - TESTPOINT: Unlike a heap, more than one memory slab can be defined, if
- * needed.
- * @}
- */
-
 #include <ztest.h>
 #include "test_mslab.h"
 

--- a/tests/kernel/mem_slab/mslab_threadsafe/src/test_mslab_threadsafe.c
+++ b/tests/kernel/mem_slab/mslab_threadsafe/src/test_mslab_threadsafe.c
@@ -4,14 +4,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-/**
- * @addtogroup t_mslab
- * @{
- * @defgroup t_mslab_threadsafe test_mslab_threadsafe
- * @brief TestPurpose: verify API thread safe in multi-threads environment
- * @}
- */
-
 #include <ztest.h>
 #include <atomic.h>
 #define LOOP 10

--- a/tests/kernel/mutex/mutex_api/src/main.c
+++ b/tests/kernel/mutex/mutex_api/src/main.c
@@ -4,14 +4,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-/**
- * @addtogroup t_sema
- * @{
- * @defgroup t_sema_api test_sema_api
- * @}
- */
-
-
 #include <ztest.h>
 extern void test_mutex_lock_unlock(void);
 extern void test_mutex_reent_lock_forever(void);

--- a/tests/kernel/mutex/mutex_api/src/test_mutex_apis.c
+++ b/tests/kernel/mutex/mutex_api/src/test_mutex_apis.c
@@ -3,20 +3,6 @@
  *
  * SPDX-License-Identifier: Apache-2.0
  */
-
-/**
- * @addtogroup t_mutex_api
- * @{
- * @defgroup t_mutex_lock test_mutex_lock
- * @brief TestPurpose: verify zephyr mutex lock/unlock apis under different
- *                     condition
- * - API coverage
- *   -# k_mutex_init K_MUTEX_DEFINE
- *   -# k_mutex_lock [FOREVER NO_WAIT TIMEOUT]
- *   -# k_mutex_unlock
- * @}
- */
-
 #include <ztest.h>
 
 #define TIMEOUT 500

--- a/tests/kernel/pipe/pipe/src/test_pipe.c
+++ b/tests/kernel/pipe/pipe/src/test_pipe.c
@@ -4,17 +4,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-/**
- * @addtogroup t_pipe
- * @{
- * @defgroup t_pipe_basic test_pipe_basic
- * @brief TestPurpose: verify zephyr pipe apis under different context
- * - API coverage
- *   -# k_pipe_init K_PIPE_DEFINE
- *   -# k_pipe_put
- *   -# k_pipe_get
- * @}
- */
 
 #include <ztest.h>
 

--- a/tests/kernel/pipe/pipe_api/src/main.c
+++ b/tests/kernel/pipe/pipe_api/src/main.c
@@ -4,13 +4,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-/**
- * @addtogroup t_pipe
- * @{
- * @defgroup t_pipe_api test_pipe_api
- * @}
- */
-
 #include <ztest.h>
 extern void test_pipe_thread2thread(void);
 

--- a/tests/kernel/pipe/pipe_api/src/test_pipe_contexts.c
+++ b/tests/kernel/pipe/pipe_api/src/test_pipe_contexts.c
@@ -4,18 +4,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-/**
- * @addtogroup t_pipe_api
- * @{
- * @defgroup t_pipe_api_basic test_pipe_api_basic
- * @brief TestPurpose: verify zephyr pipe apis under different context
- * - API coverage
- *   -# k_pipe_init K_PIPE_DEFINE
- *   -# k_pipe_put
- *   -# k_pipe_get
- * @}
- */
-
 #include <ztest.h>
 
 #define STACK_SIZE 1024

--- a/tests/kernel/pipe/pipe_api/src/test_pipe_fail.c
+++ b/tests/kernel/pipe/pipe_api/src/test_pipe_fail.c
@@ -4,16 +4,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-/**
- * @addtogroup t_pipe_api
- * @{
- * @defgroup t_pipe_fail_get_put test_pipe_fail_get_put
- * @brief TestPurpose: verify zephyr pipe get/put under different condition
- * - API coverage
- *   -# k_pipe_get [TIMEOUT K_NO_WAIT]
- *   -# k_pipe_put [K_FOREVER TIMEOUT K_NO_WAIT]
- * @}
- */
 
 #include <ztest.h>
 

--- a/tests/kernel/poll/src/main.c
+++ b/tests/kernel/poll/src/main.c
@@ -4,13 +4,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-/**
- * @addtogroup t_poll
- * @{
- * @defgroup t_poll_api test_poll_api
- * @}
- */
-
 #include <ztest.h>
 extern void test_poll_no_wait(void);
 extern void test_poll_wait(void);

--- a/tests/kernel/poll/src/test_poll.c
+++ b/tests/kernel/poll/src/test_poll.c
@@ -4,18 +4,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-/**
- * @addtogroup t_poll_api
- * @{
- * @defgroup t_poll_api_basic test_poll_api_basic
- * @brief TestPurpose: verify zephyr poll apis across different context
- * - API coverage
- *   -# k_sem_init K_SEMA_DEFINE
- *   -# k_sem_take k_sema_give k_sema_reset
- *   -# k_sem_count_get
- * @}
- */
-
 #include <ztest.h>
 #include <kernel.h>
 

--- a/tests/kernel/profiling/profiling_api/src/main.c
+++ b/tests/kernel/profiling/profiling_api/src/main.c
@@ -4,17 +4,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-/**
- * @addtogroup t_profiling
- * @{
- * @defgroup t_profiling_api test_profiling_api
- * @brief TestPurpose: verify profiling APIs.
- * @details All TESTPOINTs extracted from kernel-doc comments in <kernel.h>
- * - API coverage
- *   - k_thread_foreach
- * @}
- */
-
 #include <ztest.h>
 #include <irq_offload.h>
 #include <misc/stack.h>

--- a/tests/kernel/queue/src/main.c
+++ b/tests/kernel/queue/src/main.c
@@ -4,13 +4,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-/**
- * @addtogroup t_queue
- * @{
- * @defgroup t_queue_api test_queue_api
- * @}
- */
-
 #include <ztest.h>
 extern void test_queue_thread2thread(void);
 extern void test_queue_thread2isr(void);

--- a/tests/kernel/queue/src/test_queue_contexts.c
+++ b/tests/kernel/queue/src/test_queue_contexts.c
@@ -4,18 +4,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-/**
- * @addtogroup t_queue_api
- * @{
- * @defgroup t_queue_api_basic test_queue_api_basic
- * @brief TestPurpose: verify zephyr queue apis under different context
- * - API coverage
- *   -# k_queue_init K_QUEUE_DEFINE
- *   -# k_queue_append k_queue_prepend k_queue_append_list k_queue_merge_slist
- *   -# k_queue_get
- * @}
- */
-
 #include "test_queue.h"
 
 #define STACK_SIZE (512 + CONFIG_TEST_EXTRA_STACKSIZE)

--- a/tests/kernel/queue/src/test_queue_fail.c
+++ b/tests/kernel/queue/src/test_queue_fail.c
@@ -4,17 +4,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-/**
- * @addtogroup t_queue_api
- * @{
- * @defgroup t_queue_get_fail test_queue_get_fail
- * @brief TestPurpose: verify zephyr queue_get when no data
- * - API coverage
- *   -# k_queue_init
- *   -# k_queue_get
- * @}
- */
-
 #include "test_queue.h"
 
 #define TIMEOUT 100

--- a/tests/kernel/queue/src/test_queue_loop.c
+++ b/tests/kernel/queue/src/test_queue_loop.c
@@ -4,30 +4,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-/**
- * @addtogroup t_queue_api
- * @{
- * @defgroup t_queue_loop test_queue_loop
- * @brief TestPurpose: verify zephyr queue continuous read write
- *                     in loop
- * @details
- * - Test Steps
- *   -# queue append/prepend/find_and_remove from main thread
- *   -# queue read from isr
- *   -# queue append/prepend/find_and_remove from isr
- *   -# queue get from spawn thread
- *   -# loop above steps for LOOPs times
- * - Expected Results
- *   -# queue data pass correctly and stably across contexts
- * - API coverage
- *   -# k_queue_init
- *   -# k_queue_append
- *   -# k_queue_prepend
- *   -# k_queue_remove
- *   -# k_queue_get
- * @}
- */
-
 #include "test_queue.h"
 
 #define STACK_SIZE (512 + CONFIG_TEST_EXTRA_STACKSIZE)

--- a/tests/kernel/semaphore/sema_api/src/main.c
+++ b/tests/kernel/semaphore/sema_api/src/main.c
@@ -4,18 +4,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-/**
- * @addtogroup t_sema_api
- * @{
- * @defgroup t_sema_api_basic test_sema_api_basic
- * @brief TestPurpose: verify zephyr sema apis across different context
- * - API coverage
- *   -# k_sem_init K_SEMA_DEFINE
- *   -# k_sem_take k_sema_give k_sema_reset
- *   -# k_sem_count_get
- * @}
- */
-
 #include <ztest.h>
 #include <irq_offload.h>
 

--- a/tests/kernel/stack/stack_api/src/main.c
+++ b/tests/kernel/stack/stack_api/src/main.c
@@ -4,13 +4,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-/**
- * @addtogroup t_stack
- * @{
- * @defgroup t_stack_api test_stack_api
- * @}
- */
-
 #include <ztest.h>
 extern void test_stack_thread2thread(void);
 extern void test_stack_thread2isr(void);

--- a/tests/kernel/stack/stack_api/src/test_stack_contexts.c
+++ b/tests/kernel/stack/stack_api/src/test_stack_contexts.c
@@ -4,18 +4,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-/**
- * @addtogroup t_stack_api
- * @{
- * @defgroup t_stack_api_basic test_stack_api_basic
- * @brief TestPurpose: verify zephyr stack apis under different context
- * - API coverage
- *   -# k_stack_init K_STACK_DEFINE
- *   -# k_stack_push
- *   -# k_stack_pop
- * @}
- */
-
 #include <ztest.h>
 #include <irq_offload.h>
 

--- a/tests/kernel/stack/stack_api/src/test_stack_fail.c
+++ b/tests/kernel/stack/stack_api/src/test_stack_fail.c
@@ -4,16 +4,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-/**
- * @addtogroup t_stack_api
- * @{
- * @defgroup t_stack_fail_pop test_stack_fail_pop
- * @brief TestPurpose: verify zephyr stack pop when empty
- * - API coverage
- *   -# k_stack_pop
- * @}
- */
-
 #include <ztest.h>
 #include <irq_offload.h>
 

--- a/tests/kernel/systhreads/src/main.c
+++ b/tests/kernel/systhreads/src/main.c
@@ -4,13 +4,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-/**
- * @addtogroup t_kernel_threads
- * @{
- * @defgroup t_systhreads test_systhreads
- * @brief TestPurpose: verify 2 system threads - main thread and idle thread
- * @}
- */
 
 #include <ztest.h>
 static int main_prio;

--- a/tests/kernel/threads/lifecycle/lifecycle_api/src/main.c
+++ b/tests/kernel/threads/lifecycle/lifecycle_api/src/main.c
@@ -4,14 +4,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-/**
- * @addtogroup t_threads_lifecycle
- * @{
- * @defgroup t_threads_lifecycle_api test_threads_lifecycle_api
- * @brief TestPurpose: verify zephyr basic threads lifecycle apis
- * @}
- */
-
 #include <ztest.h>
 extern void test_threads_spawn_params(void);
 extern void test_threads_spawn_priority(void);

--- a/tests/kernel/threads/lifecycle/lifecycle_api/src/test_threads_cancel_abort.c
+++ b/tests/kernel/threads/lifecycle/lifecycle_api/src/test_threads_cancel_abort.c
@@ -4,12 +4,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-/**
- * @addtogroup t_threads_lifecycle
- * @{
- * @defgroup t_threads_cancel_abort test_threads_cancel_abort
- * @}
- */
 #include <ztest.h>
 
 #define STACK_SIZE (256 + CONFIG_TEST_EXTRA_STACKSIZE)

--- a/tests/kernel/threads/lifecycle/lifecycle_api/src/test_threads_set_priority.c
+++ b/tests/kernel/threads/lifecycle/lifecycle_api/src/test_threads_set_priority.c
@@ -4,12 +4,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-/**
- * @addtogroup t_threads_lifecycle
- * @{
- * @defgroup t_threads_priority_set test_threads_priority_set
- * @}
- */
 #include <ztest.h>
 
 #define STACK_SIZE (256 + CONFIG_TEST_EXTRA_STACKSIZE)

--- a/tests/kernel/threads/lifecycle/lifecycle_api/src/test_threads_spawn.c
+++ b/tests/kernel/threads/lifecycle/lifecycle_api/src/test_threads_spawn.c
@@ -4,13 +4,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-/**
- * @addtogroup t_threads_lifecycle
- * @{
- * @defgroup t_threads_spawn test_thread_spawn
- * @brief TestPurpose: verify basic thread spawn relevant apis
- * @}
- */
 
 #include <ztest.h>
 

--- a/tests/kernel/threads/lifecycle/lifecycle_api/src/test_threads_suspend_resume.c
+++ b/tests/kernel/threads/lifecycle/lifecycle_api/src/test_threads_suspend_resume.c
@@ -4,12 +4,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-/**
- * @addtogroup t_threads_lifecycle
- * @{
- * @defgroup t_threads_suspend_resume test_threads_suspend_resume
- * @}
- */
 #include <ztest.h>
 
 #define STACK_SIZE (256 + CONFIG_TEST_EXTRA_STACKSIZE)

--- a/tests/kernel/threads/lifecycle/thread_init/src/main.c
+++ b/tests/kernel/threads/lifecycle/thread_init/src/main.c
@@ -4,23 +4,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-/**
- * @addtogroup t_lifecycle
- * @{
- * @defgroup t_thread_init test_thread_init
- * @brief TestPurpose: verify thread initialization in all supported means
- * @details
- * - Test Steps
- *   -# initialize a thread in specific mean
- *   -# from thread entry function verify initialized fields
- * - Expected Results
- *   -# TESTPOINT: check initialized fields. Expect delay start, priority,
- * params of entry function are initialized as expected
- * - Verified Platforms
- *   -# qemu_x86, quark_se x86, quark_se arc, quark_d2000 x86, qemu_cortex_m3
- * @}
- */
-
 #include <ztest.h>
 
 /*macro definition*/

--- a/tests/kernel/threads/scheduling/schedule_api/src/main.c
+++ b/tests/kernel/threads/scheduling/schedule_api/src/main.c
@@ -4,15 +4,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-/**
- * @addtogroup t_kernel_threads
- * @{
- * @defgroup t_threads_scheduling test_threads_scheduling
- * @brief TestPurpose: verify threads scheduling based on priority, time
- * slice and lock/unlock
- * @}
- */
-
 #include "test_sched.h"
 
 /*test case main entry*/

--- a/tests/kernel/threads/scheduling/schedule_api/src/test_sched_is_preempt_thread.c
+++ b/tests/kernel/threads/scheduling/schedule_api/src/test_sched_is_preempt_thread.c
@@ -4,16 +4,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-/**
- * @addtogroup t_sched_api
- * @{
- * @defgroup t_sched_is_preempt_thread test_sched_is_preempt_thread
- * @brief TestPurpose: verify context type is preempt thread
- * - API coverage
- *   -# k_is_preempt_thread
- * @}
- */
-
 #include <ztest.h>
 #include <irq_offload.h>
 

--- a/tests/kernel/threads/scheduling/schedule_api/src/test_sched_priority.c
+++ b/tests/kernel/threads/scheduling/schedule_api/src/test_sched_priority.c
@@ -4,14 +4,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-/**
- * @addtogroup t_threads_scheduling
- * @{
- * @defgroup t_threads_priority test_threads_priority
- * @brief TestPurpose: verify threads scheduling priority
- * @}
- */
-
 #include "test_sched.h"
 
 static K_THREAD_STACK_DEFINE(tstack, STACK_SIZE);

--- a/tests/kernel/threads/scheduling/schedule_api/src/test_sched_timeslice_and_lock.c
+++ b/tests/kernel/threads/scheduling/schedule_api/src/test_sched_timeslice_and_lock.c
@@ -4,14 +4,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-/**
- * @addtogroup t_threads_scheduling
- * @{
- * @defgroup t_sched_timeslice_and_lock test_sched_timeslice_and_lock
- * @brief TestPurpose: verify sched time slice and lock/unlock
- * @}
- */
-
 #include "test_sched.h"
 #define THREADS_NUM     3
 static K_THREAD_STACK_ARRAY_DEFINE(tstack, THREADS_NUM, STACK_SIZE);

--- a/tests/kernel/tickless/tickless_concept/src/main.c
+++ b/tests/kernel/tickless/tickless_concept/src/main.c
@@ -4,16 +4,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-/**
- * @addtogroup t_tickless
- * @{
- * @defgroup t_tickless_concept test_tickless_concept
- * @brief TestPurpose: verify tickless idle concepts
- * @details
-https://www.zephyrproject.org/doc/subsystems/power_management.html#tickless-idle
- * @}
- */
-
 #include <ztest.h>
 #include <power.h>
 

--- a/tests/kernel/timer/timer_api/src/main.c
+++ b/tests/kernel/timer/timer_api/src/main.c
@@ -4,14 +4,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-/**
- * @addtogroup t_kernel_timer
- * @{
- * @defgroup t_timer_api test_timer_api
- * @brief TestPurpose: verify timer api functionality
- * @}
- */
-
 #include <ztest.h>
 #include <zephyr/types.h>
 

--- a/tests/kernel/workq/work_queue_api/src/main.c
+++ b/tests/kernel/workq/work_queue_api/src/main.c
@@ -5,26 +5,6 @@
  */
 
 
-/**
- * @addtogroup t_workq
- * @{
- * @defgroup t_workq_api test_workq_api
- * @brief TestPurpose: verify work queue API functionalities
- * - API coverage
- *   -# k_work_init
- *   -# k_delayed_work_init
- *   -# k_work_q_start
- *   -# k_work_submit_to_queue
- *   -# k_work_submit
- *   -# k_delayed_work_submit_to_queue
- *   -# k_delayed_work_submit
- *   -# k_delayed_work_cancel
- *   -# k_delayed_work_remaining_get
- *   -# k_work_pending
- *   -#
- * @}
- */
-
 #include <ztest.h>
 #include <irq_offload.h>
 


### PR DESCRIPTION
Remove unstructured and unused doxygen groups for tests. We will now add
doxygen comments per test function and follow a more structured
grouping.

Signed-off-by: Anas Nashif <anas.nashif@intel.com>