### PR TITLE
Extend LED API and add implementation for NCP5623 

### DIFF
--- a/drivers/led/CMakeLists.txt
+++ b/drivers/led/CMakeLists.txt
@@ -1,4 +1,5 @@
 zephyr_sources_ifdef(CONFIG_LP3943 lp3943.c)
 zephyr_sources_ifdef(CONFIG_PCA9633 pca9633.c)
+zephyr_sources_ifdef(CONFIG_NCP5623 ncp5623.c)
 
 zephyr_sources_ifdef(CONFIG_USERSPACE   led_handlers.c)

--- a/drivers/led/Kconfig
+++ b/drivers/led/Kconfig
@@ -42,5 +42,6 @@ config LED_INIT_PRIORITY
 
 source "drivers/led/Kconfig.lp3943"
 source "drivers/led/Kconfig.pca9633"
+source "drivers/led/Kconfig.ncp5623"
 
 endif # LED

--- a/drivers/led/Kconfig.ncp5623
+++ b/drivers/led/Kconfig.ncp5623
@@ -1,0 +1,63 @@
+#
+# Copyright (c) 2018 Workaround GmbH
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+
+menuconfig NCP5623
+	bool
+	prompt "NCP5623 LED driver"
+	depends on I2C
+	default n
+	help
+	  Enable LED driver for NCP5623.
+
+config NCP5623C
+	bool
+	prompt "NCP5623C LED driver"
+	depends on NCP5623
+	default n
+	help
+	  Enable the C variant of the NCP5623 LED driver line.
+
+config NCP5623C_DEV_NAME
+	string
+	prompt "NCP5623C device name"
+	depends on NCP5623C
+	default "NCP5623C"
+	help
+	  Device name for NCP5623C LED driver.
+
+config NCP5623C_I2C_MASTER_DEV_NAME
+	string
+	prompt "I2C master where NCP5623C is connected"
+	depends on NCP5623C
+	default "I2C_0"
+	help
+	  Specify the device name of the I2C master device to which
+	  NCP5623C is connected.
+
+config NCP5623D
+	bool
+	prompt "NCP5623D LED driver"
+	depends on NCP5623
+	default n
+	help
+	  Enable the D variant of the NCP5623 LED driver line.
+
+config NCP5623D_DEV_NAME
+	string
+	prompt "NCP5623D device name"
+	depends on NCP5623D
+	default "NCP5623D"
+	help
+	  Device name for NCP5623D LED driver.
+
+config NCP5623D_I2C_MASTER_DEV_NAME
+	string
+	prompt "I2C master where NCP5623D is connected"
+	depends on NCP5623D
+	default "I2C_0"
+	help
+	  Specify the device name of the I2C master device to which
+	  NCP5623D is connected.

--- a/drivers/led/led_handlers.c
+++ b/drivers/led/led_handlers.c
@@ -20,6 +20,19 @@ Z_SYSCALL_HANDLER(led_set_brightness, dev, led, value)
 	return _impl_led_set_brightness((struct device *)dev, led, value);
 }
 
+Z_SYSCALL_HANDLER(led_set_color, dev, r, g, b)
+{
+	_SYSCALL_DRIVER_LED(dev, set_color);
+	return _impl_led_set_color((struct device *)dev, r, g, b);
+}
+
+Z_SYSCALL_HANDLER(led_fade_brightness, dev, led, start, stop, fade_time)
+{
+	_SYSCALL_DRIVER_LED(dev, fade_brightness);
+	return _impl_led_fade_brightness((struct device *)dev, led,
+					start, stop, fade_time);
+}
+
 Z_SYSCALL_HANDLER(led_on, dev, led)
 {
 	Z_OOPS(Z_SYSCALL_DRIVER_LED(dev, on));

--- a/drivers/led/lp3943.c
+++ b/drivers/led/lp3943.c
@@ -15,6 +15,8 @@
  *   to LEDs from 8 to 15. So, it is not possible to set unique blink period
  *   and brightness value for LEDs in a group, changing either of these
  *   values for a LED will affect other LEDs also.
+ * - RGB colors are currently not supported.
+ * - Fading the brightness is currently not supported.
  */
 
 #include <i2c.h>
@@ -184,6 +186,17 @@ static int lp3943_led_set_brightness(struct device *dev, u32_t led,
 	return 0;
 }
 
+static int lp3943_led_set_color(struct device *dev, u8_t r, u8_t g, u8_t b)
+{
+	return -ENOTSUP;
+}
+
+static int lp3943_led_fade_brightness(struct device *dev, u32_t led,
+			    u8_t start, u8_t stop, u32_t fade_time)
+{
+	return -ENOTSUP;
+}
+
 static inline int lp3943_led_on(struct device *dev, u32_t led)
 {
 	struct lp3943_data *data = dev->driver_data;
@@ -253,6 +266,8 @@ static struct lp3943_data lp3943_led_data;
 static const struct led_driver_api lp3943_led_api = {
 	.blink = lp3943_led_blink,
 	.set_brightness = lp3943_led_set_brightness,
+	.set_color = lp3943_led_set_color,
+	.fade_brightness = lp3943_led_fade_brightness,
 	.on = lp3943_led_on,
 	.off = lp3943_led_off,
 };

--- a/drivers/led/ncp5623.c
+++ b/drivers/led/ncp5623.c
@@ -1,0 +1,319 @@
+/*
+ * Copyright (c) 2018 Workaround GmbH
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * @file
+ * @brief NCP5623 LED driver
+ *
+ * Limitations:
+ * - Blinking is not supported.
+ * - The driver currently assumes following mapping
+ *	LED 1: Green LED
+ *	LED 2: Blue LED
+ *	LED 3: Red LED
+ *   This has to be made configurable in a second step.
+ * - The driver ignores the led channel argument currently. It behaves as a
+ *   single instance controlling the three LEDs based on the RGB and brightness
+ *   values.
+ */
+
+#include <zephyr.h>
+#include <init.h>
+#include <device.h>
+#include <i2c.h>
+#include <led.h>
+
+#define SYS_LOG_DOMAIN "ncp5623_led"
+#define SYS_LOG_LEVEL CONFIG_SYS_LOG_LED_LEVEL
+#include <logging/sys_log.h>
+
+#include "led_context.h"
+
+#define NCP5623C_I2C_ADDR 0x39
+#define NCP5623D_I2C_ADDR 0x38
+
+/*
+ * The NCP5623 driver only supports the range 0x00..0x1F for values
+ */
+#define NCP5623_MAX_ARG_SIZE 0x1F
+
+/* NCP5623 Functions */
+#define NCP5623_SHUTDOWN      (0 << 5)
+#define NCP5623_CURRENT_CTL   (1 << 5)
+#define NCP5623_GREEN_CTL     (2 << 5)
+#define NCP5623_BLUE_CTL      (3 << 5)
+#define NCP5623_RED_CTL       (4 << 5)
+#define NCP5623_STEPS_UP      (5 << 5)
+#define NCP5623_STEPS_DOWN    (6 << 5)
+#define NCP5623_STEP_TIME_RUN (7 << 5)
+
+/* Fading is done in steps with a duration of a multiple of 8ms */
+#define NCP5623_TIME_STEPS_MS 8
+
+/* The chip needs 150 microseconds between two commands for proper operation */
+#define NCP5623_COMMAND_PROCESSING_TIME_US 150
+
+struct ncp5623_config {
+	u8_t addr;
+	char *i2c_dev_name;
+};
+
+struct ncp5623_data {
+	struct device *i2c;
+	struct led_data dev_data;
+};
+
+/*
+ * @brief correct the 8 bit api values to the 5 bit values this device
+ * supports.
+ *
+ * @param byte The 8 bit value to correct.
+ *
+ * @return a uint8_t holding a 5 bit value [0x00 .. NCP_MAX_ARG_SIZE].
+ *
+ * @note Bitshifting the value three positions to the right is corresponds to
+ * floor((byte/0xFF)*0x1F) and rescales therefore the API range (0x00 to 0xFF)
+ * to the range supported by the driver (0x00 to 0x1F) with minimal rounding
+ * errors.
+ */
+static inline u8_t ncp5623_convert(u8_t byte)
+{
+	return (u8_t)(byte >> 3);
+}
+
+/*
+ * @brief Write a key value pair to the NCP5623 chip.
+ *
+ * @param dev LED device.
+ * @param key Register key.
+ * @param val Value to write.
+ *
+ * @return Error code.
+ *
+ * @retval 0 If successful.
+ * @retval -ERRNO on failure.
+ */
+static int ncp5623_write(struct device *dev, u8_t key, u8_t val)
+{
+	int ret;
+	struct ncp5623_data *data = dev->driver_data;
+	const struct ncp5623_config *cfg = dev->config->config_info;
+
+	u8_t buf = key | val;
+
+	ret = i2c_write(data->i2c, &buf, (u32_t)sizeof(buf), cfg->addr);
+	k_busy_wait(NCP5623_COMMAND_PROCESSING_TIME_US);
+	return ret;
+}
+
+static int ncp5623_led_blink(struct device *dev, u32_t led,
+			     u32_t delay_on, u32_t delay_off)
+{
+	return -ENOTSUP;
+}
+
+static int ncp5623_led_set_brightness(struct device *dev, u32_t led,
+				      u8_t value)
+{
+	struct ncp5623_data *data = dev->driver_data;
+	struct led_data *dev_data = &data->dev_data;
+	int ret;
+
+	ARG_UNUSED(led);
+
+	if (value < dev_data->min_brightness ||
+			value > dev_data->max_brightness) {
+		SYS_LOG_WRN("Brightness 0x%02X is not in the allowed range.",
+				value);
+		return -EINVAL;
+	}
+
+	value = (value * NCP5623_MAX_ARG_SIZE) / dev_data->max_brightness;
+
+	ret = ncp5623_write(dev, NCP5623_CURRENT_CTL, value);
+	if (ret) {
+		SYS_LOG_ERR("Failed to set brightness 0x%02X with error %d",
+				value, ret);
+	}
+
+	return ret;
+}
+
+static int ncp5623_led_set_color(struct device *dev, u8_t r, u8_t g, u8_t b)
+{
+	int ret;
+
+	r = ncp5623_convert(r);
+	g = ncp5623_convert(g);
+	b = ncp5623_convert(b);
+
+	ret = ncp5623_write(dev, NCP5623_RED_CTL, r);
+	if (ret) {
+		SYS_LOG_ERR("Failed to set red value 0x%02X with error %d",
+				r, ret);
+		return ret;
+	}
+
+	ret = ncp5623_write(dev, NCP5623_GREEN_CTL, g);
+	if (ret) {
+		SYS_LOG_ERR("Failed to set green value 0x%02X with error %d",
+				g, ret);
+		return ret;
+	}
+
+	ret = ncp5623_write(dev, NCP5623_BLUE_CTL, b);
+	if (ret) {
+		SYS_LOG_ERR("Failed to set blue value 0x%02X with error %d",
+				b, ret);
+	}
+
+	return ret;
+}
+
+static int ncp5623_led_fade_brightness(struct device *dev, u32_t led,
+				       u8_t start, u8_t stop, u32_t fade_time)
+{
+	struct ncp5623_data *data = dev->driver_data;
+	struct led_data *dev_data = &data->dev_data;
+	int ret;
+	u8_t fade_dir_reg, fade_steps, time_per_step;
+
+	ARG_UNUSED(led);
+
+	ret = ncp5623_led_set_brightness(dev, led, start);
+	if (ret) {
+		SYS_LOG_ERR("Setting start brightness failed with %d", ret);
+		return ret;
+	}
+
+	start = (start * NCP5623_MAX_ARG_SIZE) / dev_data->max_brightness;
+	stop = (stop * NCP5623_MAX_ARG_SIZE) / dev_data->max_brightness;
+
+	if (stop > start) {
+		fade_dir_reg = NCP5623_STEPS_UP;
+		fade_steps = stop - start;
+	} else if (stop < start) {
+		fade_dir_reg = NCP5623_STEPS_DOWN;
+		fade_steps = start - stop;
+	} else {
+		SYS_LOG_INF("Start and Stop brightness are equal.");
+		return -EINVAL;
+	}
+
+	time_per_step =
+		(uint8_t)(fade_time / (fade_steps * NCP5623_TIME_STEPS_MS));
+
+	/*
+	 * 0x00 and >0x1E doesn't have effect on the device.
+	 * As per specification (NCP5623 page 7), 0x1F is a valid value but
+	 * observation did not show expected result.
+	 */
+	if (time_per_step == 0x00) {
+		time_per_step = 0x01;
+	} else if (time_per_step >= 0x1F) {
+		time_per_step = 0x1E;
+	}
+
+	ret = ncp5623_write(dev, fade_dir_reg, stop);
+	if (ret) {
+		SYS_LOG_ERR("Failed to set target brightness 0x%02X with %d",
+				stop, ret);
+		return ret;
+	}
+
+	ret = ncp5623_write(dev, NCP5623_STEP_TIME_RUN, time_per_step);
+	if (ret) {
+		SYS_LOG_ERR("Failed to set time per step 0x%02X with %d",
+				time_per_step, ret);
+		return ret;
+	}
+
+	return ret;
+}
+
+static int ncp5623_led_on(struct device *dev, u32_t led)
+{
+	/*
+	 * NCP5623 doesn't provide a specific functionality to turn the device
+	 * on. This is simply done by increasing the brightness.
+	 */
+	ARG_UNUSED(dev);
+	ARG_UNUSED(led);
+
+	return -ENOTSUP;
+}
+
+static int ncp5623_led_off(struct device *dev, u32_t led)
+{
+	ARG_UNUSED(led);
+
+	if (ncp5623_write(dev, NCP5623_SHUTDOWN, 0)) {
+		SYS_LOG_ERR("Failed to turn off LED");
+		return -EIO;
+	}
+
+	return 0;
+}
+
+static int ncp5623_led_init(struct device *dev)
+{
+	struct ncp5623_data *data = dev->driver_data;
+	struct led_data *dev_data = &data->dev_data;
+	const struct ncp5623_config *cfg = dev->config->config_info;
+
+	data->i2c = device_get_binding(cfg->i2c_dev_name);
+	if (data->i2c == NULL) {
+		SYS_LOG_ERR("Failed to get I2C device");
+		return -EINVAL;
+	}
+
+	dev_data->min_period = 0;
+	dev_data->max_period = 0;
+	dev_data->min_brightness = 0;
+	dev_data->max_brightness = 100;
+
+	SYS_LOG_DBG("NCP5623 LED driver init complete");
+
+	return 0;
+}
+
+static const struct led_driver_api ncp5623_led_api = {
+	.blink = ncp5623_led_blink,
+	.set_brightness = ncp5623_led_set_brightness,
+	.set_color = ncp5623_led_set_color,
+	.fade_brightness = ncp5623_led_fade_brightness,
+	.on = ncp5623_led_on,
+	.off = ncp5623_led_off,
+};
+
+#if CONFIG_NCP5623C
+static struct ncp5623_config ncp5623c_led_config = {
+	.addr = NCP5623C_I2C_ADDR,
+	.i2c_dev_name = CONFIG_NCP5623C_I2C_MASTER_DEV_NAME,
+};
+
+static struct ncp5623_data ncp5623c_led_data;
+
+DEVICE_AND_API_INIT(ncp5623c_led, CONFIG_NCP5623C_DEV_NAME,
+		    &ncp5623_led_init, &ncp5623c_led_data,
+		    &ncp5623c_led_config, POST_KERNEL, CONFIG_LED_INIT_PRIORITY,
+		    &ncp5623_led_api);
+
+#endif /* CONFIG_NCP5623C */
+
+#if CONFIG_NCP5623D
+static struct ncp5623_config ncp5623d_led_config = {
+	.addr = NCP5623D_I2C_ADDR,
+	.i2c_dev_name = CONFIG_NCP5623D_I2C_MASTER_DEV_NAME,
+};
+
+static struct ncp5623_data ncp5623d_led_data;
+
+DEVICE_AND_API_INIT(ncp5623d_led, CONFIG_NCP5623D_DEV_NAME,
+		    &ncp5623_led_init, &ncp5623d_led_data,
+		    &ncp5623d_led_config, POST_KERNEL, CONFIG_LED_INIT_PRIORITY,
+		    &ncp5623_led_api);
+#endif /* CONFIG_NCP5623D */

--- a/include/led.h
+++ b/include/led.h
@@ -32,6 +32,24 @@ typedef int (*led_api_blink)(struct device *dev, u32_t led,
  */
 typedef int (*led_api_set_brightness)(struct device *dev, u32_t led,
 				      u8_t value);
+
+/**
+ * @typedef led_api_set_color()
+ * @brief Callback API for setting color of an LED
+ *
+ * @see led_set_color() for argument descriptions.
+ */
+typedef int (*led_api_set_color)(struct device *dev, u8_t r, u8_t g, u8_t b);
+
+/**
+ * @typedef led_api_fade_brightness()
+ * @brief Callback API for fading brightness of an LED
+ *
+ * @see led_fade_brightness() for argument descriptions.
+ */
+typedef int (*led_api_fade_brightness)(struct device *dev, u32_t led,
+				       u8_t start, u8_t stop, u32_t fade_time);
+
 /**
  * @typedef led_api_on()
  * @brief Callback API for turning on an LED
@@ -56,6 +74,8 @@ typedef int (*led_api_off)(struct device *dev, u32_t led);
 struct led_driver_api {
 	led_api_blink blink;
 	led_api_set_brightness set_brightness;
+	led_api_set_color set_color;
+	led_api_fade_brightness fade_brightness;
 	led_api_on on;
 	led_api_off off;
 };
@@ -102,6 +122,51 @@ static inline int _impl_led_set_brightness(struct device *dev, u32_t led,
 	const struct led_driver_api *api = dev->driver_api;
 
 	return api->set_brightness(dev, led, value);
+}
+
+/**
+ * @brief Set LED color
+ *
+ * This routine sets the color of a RGB LED to the given values.
+ *
+ * @param dev LED device
+ * @param r Red value to be set between 0 and 255
+ * @param g Green value to be set between 0 and 255
+ * @param b Blue value to be set between 0 and 255
+ * @return 0 on success, negative on error
+ */
+__syscall int led_set_color(struct device *dev, u8_t r, u8_t g, u8_t b);
+
+static inline int _impl_led_set_color(struct device *dev,
+				     u8_t r, u8_t g, u8_t b)
+{
+	const struct led_driver_api *api = dev->driver_api;
+
+	return api->set_color(dev, r, g, b);
+}
+
+/**
+ * @brief Fade brightness of a LED over given time frame
+ *
+ * This routine fades the brightness of a LED from the start to stop brightness
+ * over the given time.
+ *
+ * @param dev LED device
+ * @param led LED channel/pin
+ * @param start Start brightness in percent
+ * @param stop Target brightness in percent
+ * @param fade_time Time in milliseconds until fading is completed.
+ * @return 0 on success, negative on error
+ */
+__syscall int led_fade_brightness(struct device *dev, u32_t led,
+				     u8_t start, u8_t stop, u32_t fade_time);
+
+static inline int _impl_led_fade_brightness(struct device *dev, u32_t led,
+				     u8_t start, u8_t stop, u32_t fade_time)
+{
+	const struct led_driver_api *api = dev->driver_api;
+
+	return api->fade_brightness(dev, led, start, stop, fade_time);
 }
 
 /**


### PR DESCRIPTION
This PR adds the following changes:

* LED driver API extension for setting RGB color and fading brightness.
* Support for relevant ON Semiconductor NCP5623 LED driver.
