### PR TITLE
net: icmpv6: Fix error condition

### DIFF
--- a/subsys/net/ip/icmpv6.c
+++ b/subsys/net/ip/icmpv6.c
@@ -182,7 +182,7 @@ struct net_icmp_hdr *net_icmpv6_get_hdr(struct net_pkt *pkt,
 	frag = net_frag_read_u8(frag, pos, &pos, &hdr->code);
 	frag = net_frag_read(frag, pos, &pos, sizeof(hdr->chksum),
 			     (u8_t *)&hdr->chksum);
-	if (!frag) {
+	if (pos > 0 && !frag) {
 		NET_ERR("Malformed ICMPv6 packet");
 		return NULL;
 	}
@@ -238,7 +238,7 @@ struct net_icmpv6_ns_hdr *net_icmpv6_get_ns_hdr(struct net_pkt *pkt,
 			     net_pkt_ipv6_ext_len(pkt) +
 			     sizeof(struct net_icmp_hdr) + 4 /* reserved */,
 			     &pos, sizeof(struct in6_addr), (u8_t *)&hdr->tgt);
-	if (!frag) {
+	if (pos > 0 && !frag) {
 		NET_ASSERT(frag);
 		return NULL;
 	}
@@ -294,7 +294,7 @@ struct net_icmpv6_nd_opt_hdr *net_icmpv6_get_nd_opt_hdr(struct net_pkt *pkt,
 				net_pkt_ipv6_ext_opt_len(pkt),
 				&pos, &hdr->type);
 	frag = net_frag_read_u8(frag, pos, &pos, &hdr->len);
-	if (!frag) {
+	if (pos > 0 && !frag) {
 		return NULL;
 	}
 
@@ -320,7 +320,7 @@ struct net_icmpv6_na_hdr *net_icmpv6_get_na_hdr(struct net_pkt *pkt,
 	frag = net_frag_skip(frag, pos, &pos, 3); /* reserved */
 	frag = net_frag_read(frag, pos, &pos, sizeof(struct in6_addr),
 			     (u8_t *)&hdr->tgt);
-	if (!frag) {
+	if (pos > 0 && !frag) {
 		NET_ASSERT(frag);
 		return NULL;
 	}
@@ -382,7 +382,7 @@ struct net_icmpv6_ra_hdr *net_icmpv6_get_ra_hdr(struct net_pkt *pkt,
 			     (u8_t *)&hdr->reachable_time);
 	frag = net_frag_read(frag, pos, &pos, sizeof(hdr->retrans_timer),
 			     (u8_t *)&hdr->retrans_timer);
-	if (!frag) {
+	if (pos > 0 && !frag) {
 		NET_ASSERT(frag);
 		return NULL;
 	}

--- a/subsys/net/ip/icmpv6.c
+++ b/subsys/net/ip/icmpv6.c
@@ -208,7 +208,7 @@ struct net_icmp_hdr *net_icmpv6_set_hdr(struct net_pkt *pkt,
 	frag = net_pkt_write(pkt, frag, pos, &pos, sizeof(hdr->chksum),
 			     (u8_t *)&hdr->chksum, PKT_WAIT_TIME);
 	if (!frag) {
-		NET_ASSERT(frag);
+		NET_ERR("Cannot set the ICMPv6 header");
 		return NULL;
 	}
 
@@ -239,7 +239,7 @@ struct net_icmpv6_ns_hdr *net_icmpv6_get_ns_hdr(struct net_pkt *pkt,
 			     sizeof(struct net_icmp_hdr) + 4 /* reserved */,
 			     &pos, sizeof(struct in6_addr), (u8_t *)&hdr->tgt);
 	if (pos > 0 && !frag) {
-		NET_ASSERT(frag);
+		NET_ERR("Cannot get the ICMPv6 NS header");;
 		return NULL;
 	}
 
@@ -267,7 +267,7 @@ struct net_icmpv6_ns_hdr *net_icmpv6_set_ns_hdr(struct net_pkt *pkt,
 	frag = net_pkt_write(pkt, frag, pos, &pos, sizeof(struct in6_addr),
 			     (u8_t *)&hdr->tgt, PKT_WAIT_TIME);
 	if (!frag) {
-		NET_ASSERT(frag);
+		NET_ERR("Cannot set the ICMPv6 NS header");
 		return NULL;
 	}
 
@@ -321,7 +321,7 @@ struct net_icmpv6_na_hdr *net_icmpv6_get_na_hdr(struct net_pkt *pkt,
 	frag = net_frag_read(frag, pos, &pos, sizeof(struct in6_addr),
 			     (u8_t *)&hdr->tgt);
 	if (pos > 0 && !frag) {
-		NET_ASSERT(frag);
+		NET_ERR("Cannot get the ICMPv6 NA header");
 		return NULL;
 	}
 
@@ -352,7 +352,7 @@ struct net_icmpv6_na_hdr *net_icmpv6_set_na_hdr(struct net_pkt *pkt,
 	frag = net_pkt_write(pkt, frag, pos, &pos, sizeof(struct in6_addr),
 			     (u8_t *)&hdr->tgt, PKT_WAIT_TIME);
 	if (!frag) {
-		NET_ASSERT(frag);
+		NET_ERR("Cannot set the ICMPv6 NA header");
 		return NULL;
 	}
 
@@ -383,7 +383,7 @@ struct net_icmpv6_ra_hdr *net_icmpv6_get_ra_hdr(struct net_pkt *pkt,
 	frag = net_frag_read(frag, pos, &pos, sizeof(hdr->retrans_timer),
 			     (u8_t *)&hdr->retrans_timer);
 	if (pos > 0 && !frag) {
-		NET_ASSERT(frag);
+		NET_ERR("Cannot get the ICMPv6 RA header");
 		return NULL;
 	}
 


### PR DESCRIPTION
When calling net_frag_read(), frag == NULL is an error only if pos is
not zero. It is thus incorrect to throw an error only if !frag, as
pos must also be checked to be not zero.