### PR TITLE
libc: minimal: fix fwrite()

### DIFF
--- a/lib/libc/minimal/source/stdout/stdout_console.c
+++ b/lib/libc/minimal/source/stdout/stdout_console.c
@@ -59,7 +59,7 @@ size_t fwrite(const void *_MLIBC_RESTRICT ptr, size_t size, size_t nitems,
 	do {
 		j = size;
 		do {
-			if (_stdout_hook((int) *p) == EOF)
+			if (_stdout_hook((int) *p++) == EOF)
 				goto done;
 			j--;
 		} while (j > 0);


### PR DESCRIPTION
The implementation of fwrite() in the minimal libc does not increment
the source pointer, and thus always print the same character.