### PR TITLE
kernel: Fix compile warning with _impl_k_object_alloc

### DIFF
--- a/include/kernel.h
+++ b/include/kernel.h
@@ -321,6 +321,8 @@ void k_object_free(void *obj);
 #else
 static inline void *_impl_k_object_alloc(enum k_objects otype)
 {
+	ARG_UNUSED(otype);
+
 	return NULL;
 }
 


### PR DESCRIPTION
We get the following warning with CONFIG_DYNAMIC_OBJECTS=n in
_impl_k_object_alloc:

include/kernel.h:322:57: warning: unused parameter ‘otype’ [-Wunused-parameter]
 static inline void *_impl_k_object_alloc(enum k_objects otype)
                                                         ^~~~~
Simple fix is to ARG_UNUSED otype.

Signed-off-by: Kumar Gala <kumar.gala@linaro.org>