### PR TITLE
Bluetooth: Mesh: Remove redundant ivu_unknown variable

### DIFF
--- a/subsys/bluetooth/host/mesh/net.h
+++ b/subsys/bluetooth/host/mesh/net.h
@@ -211,7 +211,6 @@ struct bt_mesh_net {
 	      iv_update:1,       /* 1 if IV Update in Progress */
 	      ivu_initiator:1,   /* IV Update initiated by us */
 	      ivu_test:1,        /* IV Update test mode */
-	      ivu_unknown:1,     /* Set to 1 right after provisioning */
 	      pending_update:1,  /* Update blocked by SDU in progress */
 	      valid:1;           /* 0 if unused */
 

--- a/subsys/bluetooth/host/mesh/settings.c
+++ b/subsys/bluetooth/host/mesh/settings.c
@@ -186,7 +186,6 @@ static int iv_set(int argc, char **argv, char *val)
 	bt_mesh.iv_index = iv.iv_index;
 	bt_mesh.iv_update = iv.iv_update;
 	bt_mesh.ivu_duration = iv.iv_duration;
-	bt_mesh.ivu_unknown = 0;
 
 	BT_DBG("IV Index 0x%04x (IV Update Flag %u) duration %u hours",
 	       bt_mesh.iv_index, bt_mesh.iv_update, bt_mesh.ivu_duration);


### PR DESCRIPTION
Instead of having an ivu_unknown variable to track when we can ignore
the 96-hour minimum duration requirement, simply set the duration to
the minimum (96 hours) in the places where ivu_unknown would have been
1.

Signed-off-by: Johan Hedberg <johan.hedberg@intel.com>