### PR TITLE
drivers: spi: Fix compile issues related to TOCTOU changes

### DIFF
--- a/drivers/spi/spi_handlers.c
+++ b/drivers/spi/spi_handlers.c
@@ -5,6 +5,7 @@
  */
 
 #include <spi.h>
+#include <string.h>
 #include <syscall_handler.h>
 
 /* This assumes that bufs and buf_copy are copies from the values passed
@@ -37,7 +38,7 @@ static void copy_and_check(struct spi_buf_set *bufs,
 		/* Now for each array element, validate the memory buffers
 		 * that they point to
 		 */
-		struct spi_buf *buf = &bufs->buffers[i];
+		const struct spi_buf *buf = &bufs->buffers[i];
 
 		_SYSCALL_MEMORY(buf->buf, buf->len, writable);
 	}


### PR DESCRIPTION
Commit 845ac3ef4666d23332158321570930433d450824 added the use of
memset/memcpy but the include path are such that we didn't include
<string.h> anywhere so we ran into issues.

Additionally we were getting an error related to dropping a 'const'
qualifier.

Signed-off-by: Kumar Gala <kumar.gala@linaro.org>