### PR TITLE
boards: nucleo_l432kc: fix GPIO definitions

### DIFF
--- a/boards/arm/nucleo_l432kc/doc/nucleol432kc.rst
+++ b/boards/arm/nucleo_l432kc/doc/nucleol432kc.rst
@@ -18,7 +18,7 @@ some highlights of the Nucleo L432KC board:
   - USB VBUS or external source(3.3V, 5V, 7 - 12V)
   - Power management access point
 
-- Three LEDs: USB communication (LD1), user LED (LD2), power LED (LD3)
+- Three LEDs: USB communication (LD1), power LED (LD2), user LED (LD3)
 - One push-button: RESET
 
 .. image:: img/nucleo32_ulp_logo.jpg

--- a/boards/arm/nucleo_l432kc/nucleo_l432kc.dts
+++ b/boards/arm/nucleo_l432kc/nucleo_l432kc.dts
@@ -19,23 +19,14 @@
 
 	leds {
 		compatible = "gpio-leds";
-		green_led_2: led@0 {
-			gpios = <&gpioa 5 GPIO_INT_ACTIVE_HIGH>;
-			label = "User LD2";
-		};
-	};
-
-	gpio_keys {
-		compatible = "gpio-keys";
-		user_button: button@0 {
-			label = "User";
-			gpios = <&gpioc 13 GPIO_INT_ACTIVE_LOW>;
+		green_led: led@0 {
+			gpios = <&gpiob 3 GPIO_INT_ACTIVE_HIGH>;
+			label = "User LD3";
 		};
 	};
 
 	aliases {
-		led0 = &green_led_2;
-		sw0 = &user_button;
+		led0 = &green_led;
 	};
 };
 


### PR DESCRIPTION
The ST Nucleo L432KC board only has a reset switch and not user switch.
It has a single user LED connected to PB3, and called LD3 in the ST
documentation.

This patch fixes the corresponding device tree definition. At the same
time also it also fixes the documentation, where the name of the power
and user LEDs are swapped.

Signed-off-by: Aurelien Jarno <aurelien@aurel32.net>


_This patch allows me to run basic/blinky example and get LD3 blinking. Note however that configuring PB3 in push-pull output or in open-drain with the output low causes the USART2 RX to stop working. I have spend some time investigating and I wonder if my board is somehow broken._