### PR TITLE
Bluetooth: L2CAP: Add support for dynamically allocated PSM values

### DIFF
--- a/include/bluetooth/l2cap.h
+++ b/include/bluetooth/l2cap.h
@@ -214,7 +214,18 @@ struct bt_l2cap_chan_ops {
 
 /** @brief L2CAP Server structure. */
 struct bt_l2cap_server {
-	/** Server PSM */
+	/** Server PSM. Possible values:
+	 *
+	 *  0               A dynamic value will be auto-allocated when
+	 *                  bt_l2cap_server_register() is called.
+	 *
+	 *  0x0001-0x007f   Standard, Bluetooth SIG-assigned fixed values.
+	 *
+	 *  0x0080-0x00ff   Dynamically allocated. May be pre-set by the
+	 *                  application before server registration (not
+	 *                  recommended however), or auto-allocated by the
+	 *                  stack if the app gave 0 as the value.
+	 */
 	u16_t			psm;
 
 	/** Required minimim security level */
@@ -240,6 +251,15 @@ struct bt_l2cap_server {
  *  Register L2CAP server for a PSM, each new connection is authorized using
  *  the accept() callback which in case of success shall allocate the channel
  *  structure to be used by the new connection.
+ *
+ *  For fixed, SIG-assigned PSMs (in the range 0x0001-0x007f) the PSM should
+ *  be assigned to server->psm before calling this API. For dynamic PSMs
+ *  (in the range 0x0080-0x00ff) server->psm may be pre-set to a given value
+ *  (this is however not recommended) or be left as 0, in which case upon
+ *  return a newly allocated value will have been assigned to it. For
+ *  dynamically allocated values the expectation is that it's exposed through
+ *  a GATT service, and that's how L2CAP clients discover how to connect to
+ *  the server.
  *
  *  @param server Server structure.
  *

--- a/subsys/bluetooth/host/l2cap.c
+++ b/subsys/bluetooth/host/l2cap.c
@@ -42,8 +42,10 @@
 #define L2CAP_LE_CID_IS_DYN(_cid) \
 	(_cid >= L2CAP_LE_CID_DYN_START && _cid <= L2CAP_LE_CID_DYN_END)
 
-#define L2CAP_LE_PSM_START	0x0001
-#define L2CAP_LE_PSM_END	0x00ff
+#define L2CAP_LE_PSM_FIXED_START 0x0001
+#define L2CAP_LE_PSM_FIXED_END   0x007f
+#define L2CAP_LE_PSM_DYN_START   0x0080
+#define L2CAP_LE_PSM_DYN_END     0x00ff
 
 #define L2CAP_CONN_TIMEOUT	K_SECONDS(40)
 #define L2CAP_DISC_TIMEOUT	K_SECONDS(2)
@@ -589,9 +591,38 @@ static struct bt_l2cap_server *l2cap_server_lookup_psm(u16_t psm)
 
 int bt_l2cap_server_register(struct bt_l2cap_server *server)
 {
-	if (server->psm < L2CAP_LE_PSM_START ||
-	    server->psm > L2CAP_LE_PSM_END || !server->accept) {
+	if (!server->accept) {
 		return -EINVAL;
+	}
+
+	if (server->psm) {
+		if (server->psm < L2CAP_LE_PSM_FIXED_START ||
+		    server->psm > L2CAP_LE_PSM_DYN_END) {
+			return -EINVAL;
+		}
+
+		/* Check if given PSM is already in use */
+		if (l2cap_server_lookup_psm(server->psm)) {
+			BT_DBG("PSM already registered");
+			return -EADDRINUSE;
+		}
+	} else {
+		u16_t psm;
+
+		for (psm = L2CAP_LE_PSM_DYN_START;
+		     psm <= L2CAP_LE_PSM_DYN_END; psm++) {
+			if (!l2cap_server_lookup_psm(psm)) {
+				break;
+			}
+		}
+
+		if (psm > L2CAP_LE_PSM_DYN_END) {
+			BT_WARN("No free dynamic PSMs available");
+			return -EADDRNOTAVAIL;
+		}
+
+		BT_DBG("Allocated PSM 0x%04x for new server", psm);
+		server->psm = psm;
 	}
 
 	if (server->sec_level > BT_SECURITY_FIPS) {
@@ -599,12 +630,6 @@ int bt_l2cap_server_register(struct bt_l2cap_server *server)
 	} else if (server->sec_level < BT_SECURITY_LOW) {
 		/* Level 0 is only applicable for BR/EDR */
 		server->sec_level = BT_SECURITY_LOW;
-	}
-
-	/* Check if given PSM is already in use */
-	if (l2cap_server_lookup_psm(server->psm)) {
-		BT_DBG("PSM already registered");
-		return -EADDRINUSE;
 	}
 
 	BT_DBG("PSM 0x%04x", server->psm);
@@ -1568,7 +1593,7 @@ void bt_l2cap_init(void)
 static int l2cap_le_connect(struct bt_conn *conn, struct bt_l2cap_le_chan *ch,
 			    u16_t psm)
 {
-	if (psm < L2CAP_LE_PSM_START || psm > L2CAP_LE_PSM_END) {
+	if (psm < L2CAP_LE_PSM_FIXED_START || psm > L2CAP_LE_PSM_DYN_END) {
 		return -EINVAL;
 	}
 


### PR DESCRIPTION
The Bluetooth core specification splits the valid LE L2CAP PSM range
into two subranges:

 - Standard, SIG-assigned fixed PSM values in the range 0x0001-0x007f
 - Dynamic, allocated at runtime in the range 0x0080-0x00ff

Previously the bt_l2cap_server_register() API was assuming that the
app would always decide the PSM, which effectively made it impossible
to have collision-free dynamic PSMs. This patch extends the
implementation so that if server->psm is 0, then the stack will look
for a free PSM from the dynamic range and take it into use.

Signed-off-by: Johan Hedberg <johan.hedberg@intel.com>