### PR TITLE
kconfig: Get rid of leading/trailing whitespace in prompts

### DIFF
--- a/doc/scripts/genrest/genrest.py
+++ b/doc/scripts/genrest/genrest.py
@@ -88,12 +88,9 @@ def write_kconfig_rst():
         # Add an index entry for the symbol that links to its RST file. Also
         # list its prompt(s), if any. (A symbol can have multiple prompts if it
         # has multiple definitions.)
-        #
-        # The strip() avoids RST choking on stuff like *foo *, when people
-        # accidentally include leading/trailing whitespace in prompts.
         index_rst += "   * - :option:`CONFIG_{}`\n     - {}\n".format(
             sym.name,
-            " / ".join(node.prompt[0].strip()
+            " / ".join(node.prompt[0]
                        for node in sym.nodes if node.prompt))
 
     write_if_updated(os.path.join(out_dir, "index.rst"), index_rst)
@@ -104,7 +101,7 @@ def write_sym_rst(sym, out_dir):
     kconf = sym.kconfig
 
     # List all prompts on separate lines
-    prompt_str = "\n\n".join("*{}*".format(node.prompt[0].strip())
+    prompt_str = "\n\n".join("*{}*".format(node.prompt[0])
                              for node in sym.nodes if node.prompt) \
                  or "*(No prompt -- not directly user assignable.)*"
 
@@ -187,9 +184,7 @@ def write_sym_rst(sym, out_dir):
             path = " → " + menu.prompt[0] + path
             menu = menu.parent
 
-        # The strip() avoids RST choking on leading/trailing whitespace in
-        # prompts
-        return ("(top menu)" + path).strip()
+        return "(top menu)" + path
 
     heading = "Kconfig definition"
     if len(sym.nodes) > 1:

--- a/drivers/crypto/Kconfig
+++ b/drivers/crypto/Kconfig
@@ -42,7 +42,7 @@ config SYS_LOG_CRYPTO_LEVEL
 	  - 4 DEBUG, write SYS_LOG_DBG in addition to previous levels
 
 config CRYPTO_TINYCRYPT_SHIM
-	bool "Enable TinyCrypt shim driver [EXPERIMENTAL] "
+	bool "Enable TinyCrypt shim driver [EXPERIMENTAL]"
 	default n
 	select TINYCRYPT
 	select TINYCRYPT_AES
@@ -69,7 +69,7 @@ config CRYPTO_TINYCRYPT_SHIM_DRV_NAME
 	  Device name for TinyCrypt Pseudo device.
 
 config CRYPTO_MBEDTLS_SHIM
-	bool "Enable mbedTLS shim driver [EXPERIMENTAL] "
+	bool "Enable mbedTLS shim driver [EXPERIMENTAL]"
 	default n
 	select MBEDTLS
 	select MBEDTLS_ENABLE_HEAP

--- a/kernel/Kconfig
+++ b/kernel/Kconfig
@@ -240,7 +240,7 @@ config INT_LATENCY_BENCHMARK
 
 config EXECUTION_BENCHMARKING
 	bool
-	prompt "Timing metrics "
+	prompt "Timing metrics"
 	default n
 	help
 	  This option enables the tracking of various times inside the kernel

--- a/subsys/settings/Kconfig
+++ b/subsys/settings/Kconfig
@@ -42,7 +42,7 @@ config SETTINGS_FCB_NUM_AREAS
 	int
 	default 8
 	depends on SETTINGS && SETTINGS_FCB
-	prompt "Number of flash areas used by the settings subsystem "
+	prompt "Number of flash areas used by the settings subsystem"
 	help
 	  Number of areas to allocate in the settings FCB. A smaller number is
 	  used if the flash hardware cannot support this value.


### PR DESCRIPTION
Leading/trailing whitespace in prompts requires ugly workarounds in
`genrest.py`, as e.g. `*prompt *` is invalid RST. `strip()` all prompts in
Kconfiglib and get rid of the `genrest.py` workarounds. Add a warning too.

The Kconfiglib update has some unrelated cleanups and fixes (that won't
affect Zephyr).

Signed-off-by: Ulf Magnusson <Ulf.Magnusson@nordicsemi.no>