### PR TITLE
net: app: server: Fix compile error if TCP is disabled

### DIFF
--- a/subsys/net/lib/app/client.c
+++ b/subsys/net/lib/app/client.c
@@ -271,7 +271,7 @@ static void close_net_ctx(struct net_app_ctx *ctx)
 		ctx->ipv4.ctx = NULL;
 	}
 #endif
-#if defined(CONFIG_NET_APP_SERVER)
+#if defined(CONFIG_NET_APP_SERVER) && defined(CONFIG_NET_TCP)
 	{
 		int i;
 


### PR DESCRIPTION
There was a compile error if TCP was disabled in net-app server.

Signed-off-by: Jukka Rissanen <jukka.rissanen@linux.intel.com>