### PR TITLE
Remove a silent error check to let it fall through into the next

### DIFF
--- a/subsys/net/lib/lwm2m/lwm2m_rd_client.c
+++ b/subsys/net/lib/lwm2m/lwm2m_rd_client.c
@@ -240,10 +240,6 @@ static int do_registration_reply_cb(const struct coap_packet *response,
 	if (code == COAP_RESPONSE_CODE_CREATED) {
 		ret = coap_find_options(response, COAP_OPTION_LOCATION_PATH,
 					options, 2);
-		if (ret < 0) {
-			return ret;
-		}
-
 		if (ret < 2) {
 			SYS_LOG_ERR("Unexpected endpoint data returned.");
 			return -EINVAL;


### PR DESCRIPTION
The next error check is much more suitable to hangle the error due to
the error message to let the user know that something went wrong.

Fixes #7661.

Signed-off-by: Daniel Egger <daniel@eggers-club.de>