### PR TITLE
lib: posix: Do not redefine PATH_MAX in unistd.h

### DIFF
--- a/include/posix/unistd.h
+++ b/include/posix/unistd.h
@@ -16,9 +16,6 @@ extern "C" {
 #ifdef CONFIG_POSIX_FS
 #include <fs.h>
 
-#undef PATH_MAX
-#define PATH_MAX        256
-
 typedef struct fs_dir_t DIR;
 typedef unsigned int mode_t;
 

--- a/lib/libc/minimal/include/limits.h
+++ b/lib/libc/minimal/include/limits.h
@@ -48,6 +48,8 @@ extern "C" {
 #define ULONG_MAX   0xFFFFFFFFul
 #define ULLONG_MAX  0xFFFFFFFFFFFFFFFFull
 
+#define PATH_MAX    256
+
 #ifdef __cplusplus
 }
 #endif

--- a/lib/posix/fs.c
+++ b/lib/posix/fs.c
@@ -4,12 +4,12 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <kernel.h>
-#include <string.h>
 #include <errno.h>
+#include <kernel.h>
+#include <limits.h>
 #include <posix/pthread.h>
 #include <posix/unistd.h>
-
+#include <string.h>
 
 union file_desc {
 	struct fs_file_t file;


### PR DESCRIPTION
This constant should be defined in limits.h.  Define it in limits.h in
the minimal libc, and use the definition found in newlib's includes.
Values in newlib includes range from 1024 to 4096.

The rationale is that all code should use the same value; having
buffers specified with different sizes will lead to interoperability
and out of bounds array writes.

Signed-off-by: Leandro Pereira <leandro.pereira@intel.com>