### PR TITLE
doc: fix missing NVS API documentation

### DIFF
--- a/doc/subsystems/nvs/nvs.rst
+++ b/doc/subsystems/nvs/nvs.rst
@@ -32,8 +32,8 @@ already performing such a check you can disable the extra flash protection
 (``CONFIG_NVS_FLASH_PROTECTION=n``).
 
 To protect the storage system against frequent sector erases the size of
-id-data pairs is limited to ``CONFIG_NVS_MAX_ELEM_SIZE``. This limit is by default set to 1/4 of the sector
-size.
+id-data pairs is limited to ``CONFIG_NVS_MAX_ELEM_SIZE``. This limit is
+by default set to 1/4 of the sector size.
 
 
 For NVS the file system is declared as:
@@ -107,5 +107,8 @@ API
 
 The NVS subsystem APIs are provided by ``nvs.h``:
 
-.. doxygengroup:: nvs
+.. doxygengroup:: nvs_data_structures
+   :project: Zephyr
+
+.. doxygengroup:: nvs_high_level_api
    :project: Zephyr


### PR DESCRIPTION
Sphinx only displays API documentation for items within the specified
doxygen defgroup, and importantly, not the subgroups of this defgroup.

If you define a defgroup with defgroup children, you need to tell Sphinx
to display API information about the child defgroups too.  (If the
parent defgroup has no entities of it's own, you can leave that out.)

This patch replaces the (empty) display of the parent defgroup with that
of its two child defgroups.

It also fixes an unnecessarily long text line while I was in there.

Fixes: #7666

Signed-off-by: David B. Kinder <david.b.kinder@intel.com>