### PR TITLE
doc: fix missing networking API documentation

### DIFF
--- a/doc/api/networking.rst
+++ b/doc/api/networking.rst
@@ -4,7 +4,7 @@ Networking API
 ##############
 
 .. contents::
-   :depth: 1
+   :depth: 2
    :local:
    :backlinks: top
 
@@ -117,10 +117,28 @@ Ethernet
 .. doxygengroup:: ethernet
    :project: Zephyr
 
+Ethernet Management
+===================
+
+.. doxygengroup:: ethernet_mgmt
+   :project: Zephyr
+
+Virtual LAN definitions and helpers
+===================================
+
+.. doxygengroup:: vlan
+   :project: Zephyr
+
 IEEE 802.15.4
 =============
 
 .. doxygengroup:: ieee802154
+   :project: Zephyr
+
+IEEE 802.15.4 Management
+========================
+
+.. doxygengroup:: ieee802154_mgmt
    :project: Zephyr
 
 Network and application libraries


### PR DESCRIPTION
Inspired by #7666, I scanned for other doxygen defgroups that weren't
mention in the documentation and found these:

   vlan  (defined in net/ethernet_vlan.h)
   ieee802154_mgmt  (defined in net/ieee802154_mgmt.h)
   ethernet_mgmt  (defined in net/ethernet_mgmt.h)

Added these to networking .rst, and also added one more level to the
toctree directive to show these nested groups in the table of contents.

Signed-off-by: David B. Kinder <david.b.kinder@intel.com>