### PR TITLE
doc: mark bt_test_cb API as not documented

### DIFF
--- a/doc/api/bluetooth.rst
+++ b/doc/api/bluetooth.rst
@@ -18,6 +18,7 @@ BR/EDR (Bluetooth Classic) APIs require :option:`CONFIG_BT_BREDR`.
 .. comment
    not documenting
    .. doxygengroup:: bluetooth
+   .. doxygengroup:: bt_test_cb
 
 Bluetooth Mesh Profile
 **********************


### PR DESCRIPTION
add a comment so the script for checking undocumented defgroups doesn't
report this internal API as not documented

Signed-off-by: David B. Kinder <david.b.kinder@intel.com>