### PR TITLE
subsys: fs/nvs: fix write block size issues

### DIFF
--- a/subsys/fs/nvs/nvs.c
+++ b/subsys/fs/nvs/nvs.c
@@ -100,7 +100,7 @@ int _nvs_sector_init(struct nvs_fs *fs, off_t offset)
 	sector_hdr.fd_id = fs->sector_id;
 	sector_hdr._pad = 0;
 	sector_hdr_len = _nvs_len_in_flash(fs, sizeof(struct _nvs_sector_hdr));
-	rc = nvs_flash_write(fs, offset, &sector_hdr, sector_hdr_len);
+	rc = nvs_flash_write(fs, offset, &sector_hdr, sizeof(sector_hdr));
 	if (rc) {
 		return rc;
 	}
@@ -508,7 +508,7 @@ int nvs_append(struct nvs_fs *fs, struct nvs_entry *entry)
 	data_hdr.id = entry->id;
 	data_hdr.len = _nvs_len_in_flash(fs, entry->len);
 
-	rc = nvs_flash_write(fs, fs->write_location, &data_hdr, hdr_len);
+	rc = nvs_flash_write(fs, fs->write_location, &data_hdr, sizeof(data_hdr));
 	if (rc) {
 		goto err;
 	}
@@ -528,7 +528,6 @@ int nvs_append_close(struct nvs_fs *fs, const struct nvs_entry *entry)
 	int rc;
 	struct _nvs_data_slt data_slt;
 	off_t addr;
-	u16_t slt_len;
 
 	k_mutex_lock(&fs->nvs_lock, K_FOREVER);
 	/* crc16_ccitt is calculated on flash data, set correct offset */
@@ -537,8 +536,7 @@ int nvs_append_close(struct nvs_fs *fs, const struct nvs_entry *entry)
 				     _nvs_len_in_flash(fs, entry->len));
 	data_slt._pad = 0xFFFF;
 	addr = _nvs_slt_addr_in_flash(fs, entry);
-	slt_len = _nvs_len_in_flash(fs, sizeof(struct _nvs_data_slt));
-	rc = nvs_flash_write(fs, addr, &data_slt, slt_len);
+	rc = nvs_flash_write(fs, addr, &data_slt, sizeof(data_slt));
 	k_mutex_unlock(&fs->nvs_lock);
 	return rc;
 }
@@ -584,7 +582,7 @@ int nvs_rotate(struct nvs_fs *fs)
 	head.len = fs->sector_size
 		   - (fs->write_location & (fs->sector_size - 1))
 		   - slt_len - hdr_len + sec_hdr_len;
-	rc = nvs_flash_write(fs, fs->write_location, &head, hdr_len);
+	rc = nvs_flash_write(fs, fs->write_location, &head, sizeof(head));
 	if (rc) {
 		goto out;
 	}

--- a/subsys/fs/nvs/nvs.c
+++ b/subsys/fs/nvs/nvs.c
@@ -98,7 +98,6 @@ int _nvs_sector_init(struct nvs_fs *fs, off_t offset)
 	}
 	sector_hdr.fd_magic = fs->magic;
 	sector_hdr.fd_id = fs->sector_id;
-	sector_hdr._pad = 0;
 	sector_hdr_len = _nvs_len_in_flash(fs, sizeof(struct _nvs_sector_hdr));
 	rc = nvs_flash_write(fs, offset, &sector_hdr, sizeof(sector_hdr));
 	if (rc) {
@@ -534,7 +533,6 @@ int nvs_append_close(struct nvs_fs *fs, const struct nvs_entry *entry)
 	addr = entry->data_addr + fs->offset;
 	data_slt.crc16 = crc16_ccitt(0xFFFF, (const u8_t *) addr,
 				     _nvs_len_in_flash(fs, entry->len));
-	data_slt._pad = 0xFFFF;
 	addr = _nvs_slt_addr_in_flash(fs, entry);
 	rc = nvs_flash_write(fs, addr, &data_slt, sizeof(data_slt));
 	k_mutex_unlock(&fs->nvs_lock);

--- a/subsys/fs/nvs/nvs.c
+++ b/subsys/fs/nvs/nvs.c
@@ -196,6 +196,8 @@ int _nvs_gc(struct nvs_fs *fs, off_t addr)
 			/* entry is not found, copy needed - but find the last
 			 * entry first
 			 */
+			last_entry.len = 0;
+			last_entry.data_addr = 0;
 			walker_last = walker;
 			while (walker_last.id != NVS_ID_SECTOR_END) {
 				rd_addr = _nvs_head_addr_in_flash(

--- a/subsys/fs/nvs/nvs.c
+++ b/subsys/fs/nvs/nvs.c
@@ -120,7 +120,7 @@ int _nvs_sector_is_used(struct nvs_fs *fs, off_t offset)
 	offset &= ~(fs->sector_size - 1);
 	for (addr = 0; addr < fs->sector_size; addr += sizeof(buf)) {
 		rc = flash_read(fs->flash_device,
-				fs->offset + addr,
+				fs->offset + offset + addr,
 				&buf, sizeof(buf));
 		if (rc) {
 			return rc;

--- a/subsys/fs/nvs/nvs_priv.h
+++ b/subsys/fs/nvs/nvs_priv.h
@@ -41,7 +41,6 @@ struct nvs_entry {
 struct _nvs_sector_hdr {
 	u32_t fd_magic;
 	u16_t fd_id;
-	u16_t _pad;
 };
 
 struct _nvs_data_hdr {
@@ -51,7 +50,6 @@ struct _nvs_data_hdr {
 
 struct _nvs_data_slt {
 	u16_t crc16;
-	u16_t _pad;
 };
 
 

--- a/subsys/fs/nvs/nvs_priv.h
+++ b/subsys/fs/nvs/nvs_priv.h
@@ -61,6 +61,8 @@ int nvs_get_first_entry(struct nvs_fs *fs, struct nvs_entry *entry);
 int nvs_get_last_entry(struct nvs_fs *fs, struct nvs_entry *entry);
 int nvs_check_crc(struct nvs_fs *fs, struct nvs_entry *entry);
 int nvs_rotate(struct nvs_fs *fs);
+int nvs_compute_crc(struct nvs_fs *fs, const struct nvs_entry *entry,
+		    u16_t *crc16);
 int nvs_flash_read(struct nvs_fs *fs, off_t offset, void *data, size_t len);
 int nvs_flash_write(struct nvs_fs *fs, off_t offset, const void *data,
 	size_t len);


### PR DESCRIPTION
This patch series is an alternative to #7600 to fix write block size issues. It ensures that all writes to the flash are done in multiple of the write block size, even if the data to write is smaller, by adding some padding. It also make sure that the flash read and write match the destination or source buffer to avoid stack corruption or data leakage.

This fixes #7671 for me, running on a nucleo_l432kc board (8-byte write block, smaller writes not possible).

@Laczen, note that it only fixes the write block size issues, I guess there are more things to extract from your patch, at least the tests and associated documentation.

@MaureenHelm, could you please try it out on your frdm_k64 platform? Thanks.
