### PR TITLE
tests: posix: Fix pthread attribute initialization

### DIFF
--- a/tests/posix/pthread_rwlock/src/posix_rwlock.c
+++ b/tests/posix/pthread_rwlock/src/posix_rwlock.c
@@ -80,7 +80,6 @@ static void test_rw_lock(void)
 
 	/* Creating N premptive threads in increasing order of priority */
 	for (i = 0; i < N_THR; i++) {
-		pthread_attr_destroy(&attr[i]);
 		pthread_attr_init(&attr[i]);
 
 		/* Setting scheduling priority */


### PR DESCRIPTION
Fix pthread_rwlock test pthread attributes initialization.

Fixes #7569

Signed-off-by: Ramakrishna Pallala <ramakrishna.pallala@intel.com>