### PR TITLE
[RFC] Bluetooth: Add optional setup callback to HCI drivers

### DIFF
--- a/include/drivers/bluetooth/hci_driver.h
+++ b/include/drivers/bluetooth/hci_driver.h
@@ -129,6 +129,17 @@ struct bt_hci_driver {
 	int (*open)(void);
 
 	/**
+	 * @brief Optional driver setup routine.
+	 *
+	 * This provides the driver the ability to have some vendor-
+	 * specific commands sent after the host has sent the initial
+	 * HCI_Reset, but before the host sends any other commands.
+	 *
+	 * @return 0 on success or negative error number on failure.
+	 */
+	int (*setup)(void);
+
+	/**
 	 * @brief Send HCI buffer to controller.
 	 *
 	 * Send an HCI command or ACL data to the controller. The exact

--- a/subsys/bluetooth/host/hci_core.c
+++ b/subsys/bluetooth/host/hci_core.c
@@ -3568,6 +3568,15 @@ static int common_init(void)
 	hci_reset_complete(rsp);
 	net_buf_unref(rsp);
 
+	if (bt_dev.drv->setup) {
+		BT_DBG("Performing driver-specific setup");
+
+		err = bt_dev.drv->setup();
+		if (err) {
+			return err;
+		}
+	}
+
 	/* Read Local Supported Features */
 	err = bt_hci_cmd_send_sync(BT_HCI_OP_READ_LOCAL_FEATURES, NULL, &rsp);
 	if (err) {


### PR DESCRIPTION
This patch adds a new 'setup' callback for HCI drivers, which provides
them the ability to have some vendor- specific commands sent after the
host has sent the initial HCI_Reset, but before the host sends any
other commands.

Signed-off-by: Johan Hedberg <johan.hedberg@intel.com>