### PR TITLE
 doc: updated doc for Zephyr release 1.12 .

### DIFF
--- a/doc/release-notes-1.12.rst
+++ b/doc/release-notes-1.12.rst
@@ -30,6 +30,7 @@ Architectures
 Boards
 ******
 
+* nios2: Added device tree support for qemu_nios2 and altera_max10
 
 Drivers and Sensors
 *******************


### PR DESCRIPTION
    Updated doc for release 1.12 for :-

    1. Added device tree support for nios2 based boards.

Signed-off-by: Savinay Dharmappa <savinay.dharmappa@intel.com>