### PR TITLE
misc: improve description of BOOTLOADER_SRAM_SIZE

### DIFF
--- a/misc/Kconfig
+++ b/misc/Kconfig
@@ -327,13 +327,16 @@ config IS_BOOTLOADER
 	  a separate Zephyr image payload.
 
 config BOOTLOADER_SRAM_SIZE
-	int "SRAM reserved for when Zephyr acts as a bootloader"
+	int "SRAM reserved for bootloader"
 	default 16
 	depends on !XIP || IS_BOOTLOADER
 	depends on ARM
 	help
 	  This option specifies the amount of SRAM (measure in kB) reserved for
-	  when Zephyr is to act as a bootloader.
+	  a bootloader image, when either:
+	  - the Zephyr image itself is to act as the bootloader, or
+	  - Zephyr is a !XIP image, which implicitly assumes existence of a
+	  bootloader that loads the Zephyr !XIP image onto SRAM.
 
 config BOOTLOADER_MCUBOOT
 	bool


### PR DESCRIPTION
This commit improves the help text of the BOOTLOADER_SRAM_SIZE
K-config option, to reflect its actual usage.

Signed-off-by: Ioannis Glaropoulos <Ioannis.Glaropoulos@nordicsemi.no>