### PR TITLE
scripts: west: downgrade missing ZEPHYR_BASE to a warning

### DIFF
--- a/scripts/meta/west/main.py
+++ b/scripts/meta/west/main.py
@@ -37,9 +37,8 @@ def validate_context(args, unknown):
         os.environ['ZEPHYR_BASE'] = args.zephyr_base
     else:
         if 'ZEPHYR_BASE' not in os.environ:
-            raise InvalidWestContext(
-                '--zephyr-base missing and no ZEPHYR_BASE '
-                'in the environment')
+            log.wrn('--zephyr-base missing and no ZEPHYR_BASE',
+                    'in the environment')
         else:
             args.zephyr_base = os.environ['ZEPHYR_BASE']
 


### PR DESCRIPTION
This is not strictly necessary for flashing and debugging, and is
causing issues in Linux environments where users run "make flash" as
root instead of installing udev rules.

Fixes: #7676

(Though we will need to revisit this when adding commands that run
CMake).