### PR TITLE
menuconfig: Add search and save/load improvements from upstream

### DIFF
--- a/scripts/kconfig/kconfiglib.py
+++ b/scripts/kconfig/kconfiglib.py
@@ -2179,6 +2179,16 @@ class Kconfig(object):
                                    "set".format(node.item.name, env_var),
                                    self._filename, self._linenr)
 
+                    if env_var != node.item.name:
+                        self._warn("Kconfiglib expands environment variables "
+                                   "in strings directly, meaning you do not "
+                                   "need 'option env=...' \"bounce\" symbols. "
+                                   "For compatibility with the C tools, "
+                                   "rename {} to {} (so that the symbol name "
+                                   "matches the environment variable name)."
+                                   .format(node.item.name, env_var),
+                                   self._filename, self._linenr)
+
                 elif self._check_token(_T_DEFCONFIG_LIST):
                     if not self.defconfig_list:
                         self.defconfig_list = node.item
@@ -2301,10 +2311,11 @@ class Kconfig(object):
         # than the first line
 
         help_lines = []
-        # Small optimization
+        # Small optimizations
         add_help_line = help_lines.append
+        indentation = _indentation
 
-        while line and (line.isspace() or _indentation(line) >= indent):
+        while line and (line.isspace() or indentation(line) >= indent):
             # De-indent 'line' by 'indent' spaces and rstrip() it to remove any
             # newlines (which gets rid of other trailing whitespace too, but
             # that's fine).


### PR DESCRIPTION
 - Show the value of each symbol in the jump-to dialog.

 - Search names and prompts separately in the jump-to dialog.
   Previously, '_BAR$' wouldn't match FOO_BAR if it had a prompt,
   because '_BAR$' was matched against the string 'FOO_BAR "prompt"'.

 - Show the working directory in save/load dialog boxes. Paths will be
   relative to it, and Carles Cufi pointed out that it might not be
   obvious.

   Also allow ~ to be used to refer to the home directory.

 - Implement scroll offset for edit boxes. This makes it clearer when
   they're scrolled horizontally.

Piggyback an update of Kconfiglib to the latest version (no functional
changes).

Signed-off-by: Ulf Magnusson <Ulf.Magnusson@nordicsemi.no>