### PR TITLE
dts/nxp: Fix dtc v1.4.6 warnings on nxp boards/socs

### DIFF
--- a/boards/arm/colibri_imx7d_m4/colibri_imx7d_m4.dts
+++ b/boards/arm/colibri_imx7d_m4/colibri_imx7d_m4.dts
@@ -13,9 +13,9 @@
 	compatible = "nxp,mcimx7d_m4";
 
 	aliases {
-		gpio_1 = &gpio1;
-		gpio_2 = &gpio2;
-		uart_2 = &uart2;
+		gpio-1 = &gpio1;
+		gpio-2 = &gpio2;
+		uart-2 = &uart2;
 		led0   = &green_led;
 		sw0    = &user_switch_1;
 	};

--- a/boards/arm/colibri_imx7d_m4/colibri_imx7d_m4.dts
+++ b/boards/arm/colibri_imx7d_m4/colibri_imx7d_m4.dts
@@ -30,17 +30,25 @@
 
 	leds {
 		compatible = "gpio-leds";
+		#address-cells = <1>;
+		#size-cells = <0>;
+
 		green_led: led@0 {
 			gpios = <&gpio1 2 GPIO_INT_ACTIVE_LOW>;
 			label = "User LED1";
+			reg = <0>;
 		};
 	};
 
 	gpio_keys {
 		compatible = "gpio-keys";
+		#address-cells = <1>;
+		#size-cells = <0>;
+
 		user_switch_1: sw@0 {
 			gpios = <&gpio2 26 GPIO_INT_ACTIVE_LOW>;
 			label = "User SW1";
+			reg = <0>;
 		};
 	};
 };

--- a/boards/arm/frdm_k64f/frdm_k64f.dts
+++ b/boards/arm/frdm_k64f/frdm_k64f.dts
@@ -47,29 +47,40 @@
 
 	leds {
 		compatible = "gpio-leds";
+		#address-cells = <1>;
+		#size-cells = <0>;
+
 		red_led: led@0 {
 			gpios = <&gpiob 22 GPIO_INT_ACTIVE_LOW>;
 			label = "User LD1";
+			reg = <0>;
 		};
 		green_led: led@1 {
 			gpios = <&gpioe 26 GPIO_INT_ACTIVE_LOW>;
 			label = "User LD2";
+			reg = <1>;
 		};
 		blue_led: led@2 {
 			gpios = <&gpiob 21 GPIO_INT_ACTIVE_LOW>;
 			label = "User LD3";
+			reg = <2>;
 		};
 	};
 
 	gpio_keys {
 		compatible = "gpio-keys";
+		#address-cells = <1>;
+		#size-cells = <0>;
+
 		user_button_2: button@0 {
 			label = "User SW2";
 			gpios = <&gpioc 6 GPIO_INT_ACTIVE_LOW>;
+			reg = <0>;
 		};
 		user_button_3: button@1 {
 			label = "User SW3";
 			gpios = <&gpioa 4 GPIO_INT_ACTIVE_LOW>;
+			reg = <1>;
 		};
 	};
 };

--- a/boards/arm/frdm_kl25z/frdm_kl25z.dts
+++ b/boards/arm/frdm_kl25z/frdm_kl25z.dts
@@ -31,29 +31,40 @@
 
 	leds {
 		compatible = "gpio-leds";
+		#address-cells = <1>;
+		#size-cells = <0>;
+
 		red_led: led@0 {
 			gpios = <&gpiob 18 GPIO_INT_ACTIVE_LOW>;
 			label = "User LD1";
+			reg = <0>;
 		};
 		green_led: led@1 {
 			gpios = <&gpiob 19 GPIO_INT_ACTIVE_LOW>;
 			label = "User LD2";
+			reg = <1>;
 		};
 		blue_led: led@2 {
 			gpios = <&gpiod 1 GPIO_INT_ACTIVE_LOW>;
 			label = "User LD3";
+			reg = <2>;
 		};
 	};
 
 	gpio_keys {
 		compatible = "gpio-keys";
+		#address-cells = <1>;
+		#size-cells = <0>;
+
 		user_button_0: button@0 {
 			label = "User SW0";
 			gpios = <&gpioa 16 GPIO_INT_ACTIVE_LOW>;
+			reg = <0>;
 		};
 		user_button_1: button@1 {
 			label = "User SW1";
 			gpios = <&gpioa 17 GPIO_INT_ACTIVE_LOW>;
+			reg = <1>;
 		};
 	};
 };

--- a/boards/arm/frdm_kw41z/frdm_kw41z.dts
+++ b/boards/arm/frdm_kw41z/frdm_kw41z.dts
@@ -33,29 +33,40 @@
 
 	leds {
 		compatible = "gpio-leds";
+		#address-cells = <1>;
+		#size-cells = <0>;
+
 		red_led: led@0 {
 			gpios = <&gpioc 1 GPIO_INT_ACTIVE_LOW>;
 			label = "User LD1";
+			reg = <0>;
 		};
 		green_led: led@1 {
 			gpios = <&gpioa 19 GPIO_INT_ACTIVE_LOW>;
 			label = "User LD2";
+			reg = <1>;
 		};
 		blue_led: led@2 {
 			gpios = <&gpioa 18 GPIO_INT_ACTIVE_LOW>;
 			label = "User LD3";
+			reg = <2>;
 		};
 	};
 
 	gpio_keys {
 		compatible = "gpio-keys";
+		#address-cells = <1>;
+		#size-cells = <0>;
+
 		user_button_3: button@0 {
 			label = "User SW3";
 			gpios = <&gpioc 4 GPIO_INT_ACTIVE_LOW>;
+			reg = <0>;
 		};
 		user_button_4: button@1 {
 			label = "User SW4";
 			gpios = <&gpioc 5 GPIO_INT_ACTIVE_LOW>;
+			reg = <1>;
 		};
 	};
 };

--- a/boards/arm/hexiwear_k64/hexiwear_k64.dts
+++ b/boards/arm/hexiwear_k64/hexiwear_k64.dts
@@ -44,17 +44,23 @@
 
 	leds {
 		compatible = "gpio-leds";
+		#address-cells = <1>;
+		#size-cells = <0>;
+
 		red_led: led@0 {
 			gpios = <&gpioc 8 GPIO_INT_ACTIVE_LOW>;
 			label = "User LD1";
+			reg = <0>;
 		};
 		green_led: led@1 {
 			gpios = <&gpiod 0 GPIO_INT_ACTIVE_LOW>;
 			label = "User LD2";
+			reg = <1>;
 		};
 		blue_led: led@2 {
 			gpios = <&gpioc 9 GPIO_INT_ACTIVE_LOW>;
 			label = "User LD3";
+			reg = <2>;
 		};
 	};
 };

--- a/boards/arm/lpcxpresso54114_m0/lpcxpresso54114_m0.dts
+++ b/boards/arm/lpcxpresso54114_m0/lpcxpresso54114_m0.dts
@@ -28,17 +28,23 @@
 
 	leds {
 		compatible = "gpio-leds";
+		#address-cells = <1>;
+		#size-cells = <0>;
+
 		red_led: led@0 {
 			gpios = <&gpio0 29 GPIO_INT_ACTIVE_LOW>;
 			label = "User LD1";
+			reg = <0>;
 		};
 		green_led: led@1 {
 			gpios = <&gpio1 10 GPIO_INT_ACTIVE_LOW>;
 			label = "User LD2";
+			reg = <1>;
 		};
 		blue_led: led@2 {
 			gpios = <&gpio1 9 GPIO_INT_ACTIVE_LOW>;
 			label = "User LD3";
+			reg = <2>;
 		};
 	};
 };

--- a/boards/arm/lpcxpresso54114_m4/lpcxpresso54114_m4.dts
+++ b/boards/arm/lpcxpresso54114_m4/lpcxpresso54114_m4.dts
@@ -28,17 +28,23 @@
 
 	leds {
 		compatible = "gpio-leds";
+		#address-cells = <1>;
+		#size-cells = <0>;
+
 		red_led: led@0 {
 			gpios = <&gpio0 29 GPIO_INT_ACTIVE_LOW>;
 			label = "User LD1";
+			reg = <0>;
 		};
 		green_led: led@1 {
 			gpios = <&gpio1 10 GPIO_INT_ACTIVE_LOW>;
 			label = "User LD2";
+			reg = <1>;
 		};
 		blue_led: led@2 {
 			gpios = <&gpio1 9 GPIO_INT_ACTIVE_LOW>;
 			label = "User LD3";
+			reg = <2>;
 		};
 	};
 };

--- a/boards/arm/mimxrt1050_evk/mimxrt1050_evk.dts
+++ b/boards/arm/mimxrt1050_evk/mimxrt1050_evk.dts
@@ -43,17 +43,25 @@
 
 	leds {
 		compatible = "gpio-leds";
+		#address-cells = <1>;
+		#size-cells = <0>;
+
 		green_led: led@0 {
 			gpios = <&gpio1 9 GPIO_INT_ACTIVE_LOW>;
 			label = "User LD1";
+			reg = <0>;
 		};
 	};
 
 	gpio_keys {
 		compatible = "gpio-keys";
+		#address-cells = <1>;
+		#size-cells = <0>;
+
 		user_button: button@0 {
 			label = "User SW8";
 			gpios = <&gpio5 0 GPIO_INT_ACTIVE_LOW>;
+			reg = <0>;
 		};
 	};
 };

--- a/boards/arm/usb_kw24d512/usb_kw24d512.dts
+++ b/boards/arm/usb_kw24d512/usb_kw24d512.dts
@@ -33,21 +33,30 @@
 
 	leds {
 		compatible = "gpio-leds";
+		#address-cells = <1>;
+		#size-cells = <0>;
+
 		led_0: led@0 {
 			gpios = <&gpiod 4 GPIO_INT_ACTIVE_LOW>;
 			label = "User LD1";
+			reg = <0>;
 		};
 		led_1: led@1 {
 			gpios = <&gpiod 5 GPIO_INT_ACTIVE_LOW>;
 			label = "User LD2";
+			reg = <1>;
 		};
 	};
 
 	gpio_keys {
 		compatible = "gpio-keys";
+		#address-cells = <1>;
+		#size-cells = <0>;
+
 		user_button_1: button@0 {
 			label = "User SW1";
 			gpios = <&gpioc 4 GPIO_INT_ACTIVE_LOW>;
+			reg = <0>;
 		};
 	};
 };

--- a/dts/arm/nxp/nxp_k6x.dtsi
+++ b/dts/arm/nxp/nxp_k6x.dtsi
@@ -62,7 +62,7 @@
 			clk-divider-flash = <5>;
 
 			clock-controller;
-			#clocks-cells = <3>;
+			#clock-cells = <3>;
 		};
 
 		flash-controller@40020000 {

--- a/dts/arm/nxp/nxp_kl25z.dtsi
+++ b/dts/arm/nxp/nxp_kl25z.dtsi
@@ -75,7 +75,7 @@
 			clk-divider-flash = <5>;
 
 			clock-controller;
-			#clocks-cells = <3>;
+			#clock-cells = <3>;
 		};
 
 		uart0: uart@4006A000 {

--- a/dts/arm/nxp/nxp_kw2xd.dtsi
+++ b/dts/arm/nxp/nxp_kw2xd.dtsi
@@ -54,7 +54,7 @@
 			clk-divider-flash = <2>;
 
 			clock-controller;
-			#clocks-cells = <3>;
+			#clock-cells = <3>;
 		};
 
 		flash-controller@40020000 {

--- a/dts/arm/nxp/nxp_kw40z.dtsi
+++ b/dts/arm/nxp/nxp_kw40z.dtsi
@@ -47,7 +47,7 @@
 			label = "SIM";
 
 			clock-controller;
-			#clocks-cells = <3>;
+			#clock-cells = <3>;
 		};
 
 		flash-controller@40020000 {

--- a/dts/arm/nxp/nxp_kw41z.dtsi
+++ b/dts/arm/nxp/nxp_kw41z.dtsi
@@ -50,7 +50,7 @@
 			label = "SIM";
 
 			clock-controller;
-			#clocks-cells = <3>;
+			#clock-cells = <3>;
 		};
 
 		flash-controller@40020000 {

--- a/dts/arm/nxp/nxp_lpc54xxx.dtsi
+++ b/dts/arm/nxp/nxp_lpc54xxx.dtsi
@@ -8,11 +8,16 @@
 
 / {
 	cpus {
+		#address-cells = <1>;
+		#size-cells = <0>;
+
 		cpu@0 {
 			compatible = "arm,cortex-m4f";
+			reg = <0>;
 		};
 		cpu@1 {
 			compatible = "arm,cortex-m0+";
+			reg = <1>;
 		};
 	};
 

--- a/dts/arm/nxp/nxp_rt.dtsi
+++ b/dts/arm/nxp/nxp_rt.dtsi
@@ -66,7 +66,7 @@
 			label = "CCM";
 
 			clock-controller;
-			#clocks-cells = <3>;
+			#clock-cells = <3>;
 		};
 
 		gpio1: gpio@401b8000 {

--- a/dts/arm/nxp/nxp_rt.dtsi
+++ b/dts/arm/nxp/nxp_rt.dtsi
@@ -29,15 +29,15 @@
 			#address-cells = <1>;
 			#size-cells = <1>;
 
-			itcm0: itcm0 {
+			itcm0: itcm@0 {
 				reg = <0x00000000 0x20000>;
 			};
 
-			dtcm0: dtcm0 {
+			dtcm0: dtcm@20000000 {
 				reg = <0x20000000 0x20000>;
 			};
 
-			ocram0: ocram0 {
+			ocram0: ocram@20200000 {
 				reg = <0x20200000 0x40000>;
 			};
 		};


### PR DESCRIPTION
Fixes various new warnings seen when upgrading the device tree compiler to v1.4.6.