### PR TITLE
native: ethernet: fix k_sleep() wait time

### DIFF
--- a/drivers/ethernet/eth_native_posix.c
+++ b/drivers/ethernet/eth_native_posix.c
@@ -237,7 +237,7 @@ static void eth_rx(struct eth_context *ctx)
 			}
 		}
 
-		k_sleep(MSEC(50));
+		k_sleep(K_MSEC(50));
 	}
 }
 


### PR DESCRIPTION
The input of k_sleep was wrongly converted from ms to ticks.
Fixed.

Fixes: #7656

Signed-off-by: Alberto Escolar Piedras <alpi@oticon.com>