### PR TITLE
kconfig: Consistently exclude implicit submenus in menu paths (+doc/Makefile piggyback)

### DIFF
--- a/doc/Makefile
+++ b/doc/Makefile
@@ -72,7 +72,7 @@ htmldocs: doxy html
 content: scripts/extract_content.py
 	$(Q)$<
 
-kconfig: scripts/genrest/genrest.py
+kconfig: scripts/genrest.py
 	$(Q)PYTHONPATH="${ZEPHYR_BASE}/scripts/kconfig:${PYTHONPATH}" \
 	    srctree=../ ENV_VAR_BOARD_DIR=boards/*/*/ ENV_VAR_ARCH=* KERNELVERSION=1.9.99 SRCARCH=x86 \
 	    python3 $< ../Kconfig reference/kconfig/

--- a/doc/Makefile
+++ b/doc/Makefile
@@ -23,7 +23,7 @@ ALLSPHINXOPTS   = -d $(BUILDDIR)/doctrees $(PAPEROPT_$(PAPER)) $(SPHINXOPTS) .
 # the i18n builder cannot share the environment and doctrees with the others
 I18NSPHINXOPTS  = $(PAPEROPT_$(PAPER)) $(SPHINXOPTS) .
 
-.PHONY: help clean html dirhtml singlehtml pickle json htmlhelp qthelp devhelp epub latex latexpdf text man changes linkcheck doctest coverage gettext
+.PHONY: help clean content kconfig prep html dirhtml singlehtml pickle json htmlhelp qthelp devhelp epub latex latexpdf text man changes linkcheck doctest coverage gettext
 
 doxy-code:
 	$(Q)(cat zephyr.doxyfile ; echo "STRIP_FROM_PATH=${ZEPHYR_BASE}" ) | doxygen -  2>&1 | tee doc.log
@@ -69,13 +69,13 @@ clean:
 
 htmldocs: doxy html
 
-content: scripts/extract_content.py
-	$(Q)$<
+content:
+	$(Q)scripts/extract_content.py
 
-kconfig: scripts/genrest.py
+kconfig:
 	$(Q)PYTHONPATH="${ZEPHYR_BASE}/scripts/kconfig:${PYTHONPATH}" \
 	    srctree=../ ENV_VAR_BOARD_DIR=boards/*/*/ ENV_VAR_ARCH=* KERNELVERSION=1.9.99 SRCARCH=x86 \
-	    python3 $< ../Kconfig reference/kconfig/
+	    python3 scripts/genrest.py ../Kconfig reference/kconfig/
 
 
 prep: doxy content kconfig

--- a/doc/scripts/genrest.py
+++ b/doc/scripts/genrest.py
@@ -49,9 +49,8 @@ are organized based on their common characteristics and on what new symbols
 they add to the configuration menus.
 
 The configuration options' information below is extracted directly from
-:program:`Kconfig` using the :file:`~/doc/scripts/genrest/genrest.py` script.
-Click on the option name in the table below for detailed information about
-each option.
+:program:`Kconfig` using the :file:`~/doc/scripts/genrest.py` script. Click on
+the option name in the table below for detailed information about each option.
 
 Supported Options
 *****************

--- a/doc/scripts/genrest/genrest.py
+++ b/doc/scripts/genrest/genrest.py
@@ -177,12 +177,21 @@ def write_sym_rst(sym, out_dir):
     def menu_path(node):
         path = ""
 
-        menu = node.parent
-        while menu is not kconf.top_node:
-            # Fancy Unicode arrow. Added in '93, so ought to be pretty
-            # safe.
-            path = " → " + menu.prompt[0] + path
-            menu = menu.parent
+        while True:
+            # This excludes indented submenus created in the menuconfig
+            # interface when items depend on the preceding symbol.
+            # is_menuconfig means anything that would be shown as a separate
+            # menu (not indented): proper 'menu's, menuconfig symbols, and
+            # choices.
+            node = node.parent
+            while not node.is_menuconfig:
+                node = node.parent
+
+            if node is kconf.top_node:
+                break
+
+            # Fancy Unicode arrow. Added in '93, so ought to be pretty safe.
+            path = " → " + node.prompt[0] + path
 
         return "(top menu)" + path
 

--- a/scripts/kconfig/menuconfig.py
+++ b/scripts/kconfig/menuconfig.py
@@ -2006,10 +2006,10 @@ def _menu_path_info(node):
 
     path = ""
 
-    menu = node.parent
-    while menu is not _kconf.top_node:
-        path = " -> " + menu.prompt[0] + path
-        menu = menu.parent
+    node = _parent_menu(node)
+    while node is not _kconf.top_node:
+        path = " -> " + node.prompt[0] + path
+        node = _parent_menu(node)
 
     return "(top menu)" + path
 


### PR DESCRIPTION
Make all places that print menu paths use the same format. Previously, implicit submenus (shown indented) were excluded in the path at the top of the menuconfig interface, but were included elsewhere.

This pull requests piggybacks some minor `doc/Makefile` cleanups and moves `doc/scripts/genrest/genrest.py` to `doc/scripts/genrest.py`.

See the commit messages for more information. 