### PR TITLE
drivers: i2s: intel_s1000: Support for fractional divider to generate BCLK

### DIFF
--- a/arch/xtensa/soc/intel_s1000/soc.c
+++ b/arch/xtensa/soc/intel_s1000/soc.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 Intel Corporation
+ * Copyright (c) 2018 Intel Corporation
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -171,4 +171,33 @@ void setup_ownership_i2s(void)
 	u32_t value = I2S_OWNSEL(0) | I2S_OWNSEL(1) |
 			 I2S_OWNSEL(2) | I2S_OWNSEL(3);
 	*(volatile u32_t *)SUE_DSPIOPO_REG |= value;
+}
+
+u32_t soc_get_ref_clk_freq(void)
+{
+	u32_t bootstrap;
+	static u32_t freq = 0;
+
+	if (0 == freq) {
+		/* if bootstraps have not been read before, read them */
+
+		bootstrap = *((volatile u32_t *)SOC_S1000_GLB_CTRL_STRAPS);
+
+		bootstrap &= SOC_S1000_STRAP_REF_CLK;
+
+		switch (bootstrap) {
+			case SOC_S1000_STRAP_REF_CLK_19P2:
+				freq = 19200000;
+				break;
+			case SOC_S1000_STRAP_REF_CLK_24P576:
+				freq = 24576000;
+				break;
+			case SOC_S1000_STRAP_REF_CLK_38P4:
+			default:
+				freq = 38400000;
+				break;
+		}
+	}
+
+	return freq;
 }

--- a/arch/xtensa/soc/intel_s1000/soc.c
+++ b/arch/xtensa/soc/intel_s1000/soc.c
@@ -171,14 +171,17 @@ void setup_ownership_i2s(void)
 	u32_t value = I2S_OWNSEL(0) | I2S_OWNSEL(1) |
 			 I2S_OWNSEL(2) | I2S_OWNSEL(3);
 	*(volatile u32_t *)SUE_DSPIOPO_REG |= value;
+
+	value = DSP_RES_ALLOC_GENO_MDIVOSEL;
+	*(volatile u32_t *)DSP_RES_ALLOC_GEN_OWNER |= value;
 }
 
 u32_t soc_get_ref_clk_freq(void)
 {
 	u32_t bootstrap;
-	static u32_t freq = 0;
+	static u32_t freq;
 
-	if (0 == freq) {
+	if (freq == 0) {
 		/* if bootstraps have not been read before, read them */
 
 		bootstrap = *((volatile u32_t *)SOC_S1000_GLB_CTRL_STRAPS);
@@ -186,16 +189,16 @@ u32_t soc_get_ref_clk_freq(void)
 		bootstrap &= SOC_S1000_STRAP_REF_CLK;
 
 		switch (bootstrap) {
-			case SOC_S1000_STRAP_REF_CLK_19P2:
-				freq = 19200000;
-				break;
-			case SOC_S1000_STRAP_REF_CLK_24P576:
-				freq = 24576000;
-				break;
-			case SOC_S1000_STRAP_REF_CLK_38P4:
-			default:
-				freq = 38400000;
-				break;
+		case SOC_S1000_STRAP_REF_CLK_19P2:
+			freq = 19200000;
+			break;
+		case SOC_S1000_STRAP_REF_CLK_24P576:
+			freq = 24576000;
+			break;
+		case SOC_S1000_STRAP_REF_CLK_38P4:
+		default:
+			freq = 38400000;
+			break;
 		}
 	}
 

--- a/arch/xtensa/soc/intel_s1000/soc.h
+++ b/arch/xtensa/soc/intel_s1000/soc.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 Intel Corporation
+ * Copyright (c) 2018 Intel Corporation
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -107,6 +107,8 @@
 
 #define SSP_SIZE				0x0000200
 #define SSP_BASE(x)				(0x00077000 + (x) * SSP_SIZE)
+#define SSP_MN_DIV_BASE				(0x00078D00)
+
 
 #define SOC_INTEL_S1000_MCK_XTAL_FREQ_HZ	38400000
 
@@ -119,6 +121,15 @@
 #define USB_DW_BASE				0x000A0000
 #define USB_DW_IRQ				0x00000806
 
+/* Global Control registers */
+#define SOC_S1000_GLB_CTRL_BASE			(0x00081C00)
+
+#define SOC_S1000_GLB_CTRL_STRAPS		(SOC_S1000_GLB_CTRL_BASE + 0x40)
+#define SOC_S1000_STRAP_REF_CLK			(BIT_MASK(2) << 3)
+#define SOC_S1000_STRAP_REF_CLK_38P4		(0 << 3)
+#define SOC_S1000_STRAP_REF_CLK_19P2		(1 << 3)
+#define SOC_S1000_STRAP_REF_CLK_24P576		(2 << 3)
+
 extern void _soc_irq_enable(u32_t irq);
 extern void _soc_irq_disable(u32_t irq);
 extern void setup_ownership_dma0(void);
@@ -126,5 +137,6 @@ extern void setup_ownership_dma1(void);
 extern void setup_ownership_dma2(void);
 extern void dcache_writeback_region(void *addr, size_t size);
 extern void setup_ownership_i2s(void);
+extern u32_t soc_get_ref_clk_freq(void);
 
 #endif /* __INC_SOC_H */

--- a/arch/xtensa/soc/intel_s1000/soc.h
+++ b/arch/xtensa/soc/intel_s1000/soc.h
@@ -107,8 +107,8 @@
 
 #define SSP_SIZE				0x0000200
 #define SSP_BASE(x)				(0x00077000 + (x) * SSP_SIZE)
-#define SSP_MN_DIV_BASE				(0x00078D00)
-
+#define SSP_MN_DIV_SIZE				(8)
+#define SSP_MN_DIV_BASE(x)		(0x00078D00 + ((x) * SSP_MN_DIV_SIZE))
 
 #define SOC_INTEL_S1000_MCK_XTAL_FREQ_HZ	38400000
 
@@ -118,6 +118,12 @@
 #define SUE_DSP_RES_ALLOC_REG_BASE		0x00071A60
 #define SUE_DSPIOPO_REG			(SUE_DSP_RES_ALLOC_REG_BASE + 0x08)
 #define I2S_OWNSEL(x)				(0x1 << (8 + (x)))
+
+/* Address and bit field definition for general ownership register */
+#define DSP_RES_ALLOC_GEN_OWNER		(SUE_DSP_RES_ALLOC_REG_BASE + 0x0C)
+#define DSP_RES_ALLOC_GENO_DIOPTOSEL		(BIT(2))
+#define DSP_RES_ALLOC_GENO_MDIVOSEL		(BIT(1))
+
 #define USB_DW_BASE				0x000A0000
 #define USB_DW_IRQ				0x00000806
 

--- a/drivers/i2s/i2s_cavs.c
+++ b/drivers/i2s/i2s_cavs.c
@@ -380,7 +380,6 @@ static int i2s_cavs_configure(struct device *dev, enum i2s_dir dir,
 	} else {
 		/* enable BCLK output */
 		ssioc = SSIOC_SCOE;
-
 	}
 
 	if (i2s_cfg->options & I2S_OPT_FRAME_CLK_SLAVE) {
@@ -771,7 +770,7 @@ static void i2s1_irq_config(void)
 
 static const struct i2s_cavs_config i2s1_cavs_config = {
 	.regs = (struct i2s_cavs_ssp *)SSP_BASE(1),
-	.mn_regs = &((struct i2s_cavs_mn_div *)SSP_MN_DIV_BASE)[1],
+	.mn_regs = (struct i2s_cavs_mn_div *)SSP_MN_DIV_BASE(1),
 	.irq_id = I2S1_CAVS_IRQ,
 	.irq_config = i2s1_irq_config,
 };

--- a/drivers/i2s/i2s_cavs.h
+++ b/drivers/i2s/i2s_cavs.h
@@ -130,6 +130,15 @@ struct i2s_cavs_ssp {
 #define SSIOC_SFCR		(1 << 4)
 #define SSIOC_SCOE		(1 << 5)
 
+struct i2s_cavs_mn_div {
+	u32_t mval;		/* 0x00 - M value */
+	u32_t nval;		/* 0x04 - N value */
+};
+
+/* MVAL & NVAL bits */
+#define I2S_MNVAL_MASK		(BIT_MASK(24))
+#define I2S_MNVAL(x)		((x) & I2S_MNVAL_MASK)
+
 #ifdef __cplusplus
 }
 #endif


### PR DESCRIPTION
Fixes #7699 