### PR TITLE
net: Too long timeout was passed to k_sleep

### DIFF
--- a/subsys/net/lib/app/net_app.c
+++ b/subsys/net/lib/app/net_app.c
@@ -1297,7 +1297,7 @@ int _net_app_tls_sendto(struct net_pkt *pkt,
 		 * a bit and hope things are ok after that. If not, then
 		 * return error.
 		 */
-		k_sleep(MSEC(50));
+		k_sleep(K_MSEC(50));
 
 		if (!ctx->tls.handshake_done) {
 			NET_DBG("TLS handshake not yet done, pkt %p not sent",

--- a/tests/net/checksum_offload/src/main.c
+++ b/tests/net/checksum_offload/src/main.c
@@ -776,7 +776,7 @@ static void rx_chksum_offload_disabled_test_v6(void)
 	}
 
 	/* Let the receiver to receive the packets */
-	k_sleep(MSEC(10));
+	k_sleep(K_MSEC(10));
 }
 
 static void rx_chksum_offload_disabled_test_v4(void)
@@ -839,7 +839,7 @@ static void rx_chksum_offload_disabled_test_v4(void)
 	}
 
 	/* Let the receiver to receive the packets */
-	k_sleep(MSEC(10));
+	k_sleep(K_MSEC(10));
 }
 
 static void rx_chksum_offload_enabled_test_v6(void)
@@ -902,7 +902,7 @@ static void rx_chksum_offload_enabled_test_v6(void)
 	}
 
 	/* Let the receiver to receive the packets */
-	k_sleep(MSEC(10));
+	k_sleep(K_MSEC(10));
 }
 
 static void rx_chksum_offload_enabled_test_v4(void)
@@ -965,7 +965,7 @@ static void rx_chksum_offload_enabled_test_v4(void)
 	}
 
 	/* Let the receiver to receive the packets */
-	k_sleep(MSEC(10));
+	k_sleep(K_MSEC(10));
 }
 
 void test_main(void)

--- a/tests/net/traffic_class/src/main.c
+++ b/tests/net/traffic_class/src/main.c
@@ -513,7 +513,7 @@ static void traffic_class_send_priority(enum net_priority prio,
 		/* This sleep is needed here so that the sending side
 		 * can run properly.
 		 */
-		k_sleep(MSEC(1));
+		k_sleep(K_MSEC(1));
 	}
 }
 
@@ -794,7 +794,7 @@ static void traffic_class_recv_packets_with_prio(enum net_priority prio,
 	zassert_equal(ret, 0, "Send UDP pkt failed\n");
 
 	/* Let the receiver to receive the packets */
-	k_sleep(MSEC(1));
+	k_sleep(K_MSEC(1));
 }
 
 static void traffic_class_recv_priority(enum net_priority prio,
@@ -820,7 +820,7 @@ static void traffic_class_recv_priority(enum net_priority prio,
 		/* This sleep is needed here so that the receiving side
 		 * can run properly.
 		 */
-		k_sleep(MSEC(1));
+		k_sleep(K_MSEC(1));
 	}
 }
 


### PR DESCRIPTION
The code was using MSEC() macro in few places instead of more
proper K_MSEC(). The MSEC() takes seconds as a parameter and
K_MSEC() takes milliseconds.

Fixes #7657

Signed-off-by: Jukka Rissanen <jukka.rissanen@linux.intel.com>