### PR TITLE
arch: arm: extend "built-in" stack-overflow guarding for Secure Zephyr images on ARMv8-M MCUs

### DIFF
--- a/arch/arm/core/Kconfig
+++ b/arch/arm/core/Kconfig
@@ -78,6 +78,25 @@ config ARM_SECURE_FIRMWARE
 	  Secure Faults may only be handled by code executing in Secure
 	  state.
 
+config ARM_NONSECURE_FIRMWARE
+	bool
+	depends on !ARM_SECURE_FIRMWARE
+	default n
+	help
+	  This option indicates that we are building a Zephyr image that
+	  is intended to execute in Non-Secure state. Execution of this
+	  image is triggered by Secure firmware that executes in Secure
+	  state. The option is only applicable to ARMv8-M MCUs that
+	  implement the Security Extension.
+
+	  This option enables Zephyr to include code that executes in
+	  Non-Secure state only, as well as to exclude code that is
+	  designed to execute only in Secure state.
+
+	  Code executing in Non-Secure state has no access to Secure
+	  resources of the Cortex-M MCU, and, therefore, it shall avoid
+	  accessing them.
+
 menu "Architecture Floating Point Options"
 depends on CPU_HAS_FPU
 

--- a/arch/arm/core/Kconfig
+++ b/arch/arm/core/Kconfig
@@ -62,10 +62,13 @@ config ARM_SECURE_FIRMWARE
 	bool
 	default n
 	help
+	  This option indicates that we are building a Zephyr image that
+	  is intended to execute in Secure state. The option is only
+	  applicable to ARMv8-M MCUs that implement the Security Extension.
+
 	  This option enables Zephyr to include code that executes in
 	  Secure state, as well as to exclude code that is designed to
-	  execute only in Non-secure state. The option is only applicable
-	  to ARMv8-M MCUs that implement the Security Extension.
+	  execute only in Non-secure state.
 
 	  Code executing in Secure state has access to both the Secure
 	  and Non-Secure resources of the Cortex-M MCU.

--- a/arch/arm/core/Kconfig
+++ b/arch/arm/core/Kconfig
@@ -60,6 +60,7 @@ config ARM_STACK_PROTECTION
 
 config ARM_SECURE_FIRMWARE
 	bool
+	depends on ARMV8_M_SE
 	default n
 	help
 	  This option indicates that we are building a Zephyr image that
@@ -81,6 +82,7 @@ config ARM_SECURE_FIRMWARE
 config ARM_NONSECURE_FIRMWARE
 	bool
 	depends on !ARM_SECURE_FIRMWARE
+	depends on ARMV8_M_SE
 	default n
 	help
 	  This option indicates that we are building a Zephyr image that

--- a/arch/arm/core/Kconfig
+++ b/arch/arm/core/Kconfig
@@ -22,7 +22,7 @@ config CPU_CORTEX_M
 	select HAS_CMSIS
 	select HAS_FLASH_LOAD_OFFSET
 	select HAS_DTS
-	select ARCH_HAS_STACK_PROTECTION if ARM_CORE_MPU
+	select ARCH_HAS_STACK_PROTECTION if ARM_CORE_MPU || CPU_CORTEX_M_HAS_SPLIM
 	select ARCH_HAS_USERSPACE if ARM_CORE_MPU
 	help
 	  This option signifies the use of a CPU of the Cortex-M family.

--- a/arch/arm/core/cortex_m/Kconfig
+++ b/arch/arm/core/cortex_m/Kconfig
@@ -135,7 +135,7 @@ config CPU_CORTEX_M_HAS_VTOR
 config CPU_CORTEX_M_HAS_SPLIM
 	bool
 	# Omit prompt to signify "hidden" option
-	depends on ARMV8_M_MAINLINE
+	depends on ARMV8_M_MAINLINE || (ARMV8_M_SE && !ARM_NONSECURE_FIRMWARE)
 	default n
 	help
 	  This option signifies the CPU has the MSPLIM, PSPLIM registers.
@@ -145,8 +145,10 @@ config CPU_CORTEX_M_HAS_SPLIM
 	  can descend. MSPLIM, PSPLIM are always present in ARMv8-M
 	  MCUs that implement the ARMv8-M Main Extension (Mainline).
 
-	  In an ARMv8-M implementation with the Security Extension, the
-	  MSPLIM, PSPLIM registers have additional Secure instances.
+	  In an ARMv8-M Mainline implementation with the Security Extension
+	  the MSPLIM, PSPLIM registers have additional Secure instances.
+  	  In an ARMv8-M Baseline implementation with the Security Extension
+	  the MSPLIM, PSPLIM registers have only Secure instances.
 
 config CPU_CORTEX_M_HAS_PROGRAMMABLE_FAULT_PRIOS
 	bool
@@ -246,6 +248,7 @@ config ARMV8_M_SE
 	bool
 	# Omit prompt to signify "hidden" option
 	depends on ARMV8_M_BASELINE || ARMV8_M_MAINLINE
+	select CPU_CORTEX_M_HAS_SPLIM if !ARM_NONSECURE_FIRMWARE
 	help
 	  This option signifies the use of an ARMv8-M processor
 	  implementation (Baseline or Mainline) supporting the

--- a/arch/arm/core/cortex_m/Kconfig
+++ b/arch/arm/core/cortex_m/Kconfig
@@ -242,6 +242,15 @@ config ARMV8_M_MAINLINE
 	  ARMv8-M Main Extension includes additional features
 	  not present in the ARMv7-M architecture.
 
+config ARMV8_M_SE
+	bool
+	# Omit prompt to signify "hidden" option
+	depends on ARMV8_M_BASELINE || ARMV8_M_MAINLINE
+	help
+	  This option signifies the use of an ARMv8-M processor
+	  implementation (Baseline or Mainline) supporting the
+	  Security Extensions.
+
 config ARMV7_M_ARMV8_M_FP
 	bool
 	# Omit prompt to signify "hidden" option


### PR DESCRIPTION
- Completes work in #7215, by implementing stack-overflow guarding for Secure Zephyr images (for Cortex-M23 MCUs).
- No C-code; just K-config ontology implementation
- Adopts approach proposed in #6392.