### PR TITLE
samples: xtensa_asm2: Cleanup stray IS_TEST reference

### DIFF
--- a/samples/xtensa_asm2/CMakeLists.txt
+++ b/samples/xtensa_asm2/CMakeLists.txt
@@ -1,5 +1,3 @@
-set(IS_TEST 1)
-
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
 project(NONE)
 


### PR DESCRIPTION
We removed IS_TEST a while ago.  Remove this stray reference

Signed-off-by: Kumar Gala <kumar.gala@linaro.org>