### PR TITLE
tests/kernel/common: Add rigorous integer typing test

### DIFF
--- a/tests/kernel/common/src/intmath.c
+++ b/tests/kernel/common/src/intmath.c
@@ -1,10 +1,55 @@
 /*
  * Copyright (c) 2015 Wind River Systems, Inc.
+ * Copyright (c) 2018 Intel Corporation
  *
  * SPDX-License-Identifier: Apache-2.0
  */
 
 #include <ztest.h>
+
+/* Built-time math test.  Zephyr code depends on a standard C ABI with
+ * 2's complement signed math.  As this isn't technically guaranteed
+ * by the compiler or language standard, validate it explicitly here.
+ */
+
+/* Recent GCC's can detect integer overflow in static expressions and
+ * will warn about it heplfully.  But obviously integer overflow is
+ * the whole point here, so turn that warning off.
+ */
+#ifdef __GNUC__
+#pragma GCC diagnostic ignored "-Woverflow"
+#endif
+
+/* Two's complement negation check: "-N" must equal "(~N)+1" */
+#define NEG_CHECK(T, N) BUILD_ASSERT((-((T)N)) == (~((T)N))+1)
+
+/* Checks that MAX+1==MIN in the given type */
+#define ROLLOVER_CHECK(T, MAX, MIN) BUILD_ASSERT((T)((T)1 + (T)MAX) == (T)MIN)
+
+ROLLOVER_CHECK(unsigned int, 0xffffffff, 0);
+ROLLOVER_CHECK(unsigned short, 0xffff, 0);
+ROLLOVER_CHECK(unsigned char, 0xff, 0);
+
+NEG_CHECK(signed char, 1);
+NEG_CHECK(signed char, 0);
+NEG_CHECK(signed char, -1);
+NEG_CHECK(signed char, 0x80);
+NEG_CHECK(signed char, 0x7f);
+ROLLOVER_CHECK(signed char, 127, -128);
+
+NEG_CHECK(short, 1);
+NEG_CHECK(short, 0);
+NEG_CHECK(short, -1);
+NEG_CHECK(short, 0x8000);
+NEG_CHECK(short, 0x7fff);
+ROLLOVER_CHECK(short, 32767, -32768);
+
+NEG_CHECK(int, 1);
+NEG_CHECK(int, 0);
+NEG_CHECK(int, -1);
+NEG_CHECK(int, 0x80000000);
+NEG_CHECK(int, 0x7fffffff);
+ROLLOVER_CHECK(int, 2147483647, -2147483648);
 
 void test_intmath(void)
 {


### PR DESCRIPTION
Zephyr code routinely assumes conventional ILP32/LP64 integer
behavior, and occasionally relies on it to perform some nice tricks.
This is despite the fact that this behavior (while pervasively adopted
and in use on all architectures we care about supporting) isn't
actually guaranteed by the language standard which allows much looser
semantics than actual exist on hardware.

Put it into the intmath section of this test as a build time thing.

Signed-off-by: Andy Ross <andrew.j.ross@intel.com>