### PR TITLE
usb: set SN string descriptor at runtime

### DIFF
--- a/subsys/usb/usb_descriptor.h
+++ b/subsys/usb/usb_descriptor.h
@@ -35,6 +35,7 @@
 
 int usb_get_str_descriptor_idx(void *ptr);
 
+u8_t *usb_update_sn_string_descriptor(void);
 u8_t *usb_get_device_descriptor(void);
 
 #endif /* __USB_DESCRIPTOR_H__ */


### PR DESCRIPTION
implement a method that can set SN string descriptor at runtime.
but runtime SN and default SN configured in Kconfig must has the
same length.

Signed-off-by: qianfan Zhao <qianfanguijin@163.com>