### PR TITLE
arch: arc: fix the bug in exception return for secure mode

### DIFF
--- a/arch/arc/core/fault_s.S
+++ b/arch/arc/core/fault_s.S
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2014 Wind River Systems, Inc.
+ * Copyright (c) 2018 Synopsys.
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -122,7 +123,12 @@ _exc_return:
 	st_s r2, [r1, _kernel_offset_to_current]
 
 #ifdef CONFIG_ARC_HAS_SECURE
-	/* ERM to IRM */
+	/*
+	 * sync up the ERSEC_STAT.ERM and SEC_STAT.IRM.
+	 * use a fake interrupt return to simulate an exception turn.
+	 * ERM and IRM record which mode the cpu should return, 1: secure
+	 * 0: normal
+	 */
 	lr r3,[_ARC_V2_ERSEC_STAT]
 	btst r3, 31
 	bset.nz r3, r3, 3
@@ -170,10 +176,15 @@ SECTION_SUBSEC_FUNC(TEXT,__fault,__ev_trap)
 	mov r6, _SYSCALL_BAD
 
 valid_syscall_id:
+#ifdef CONFIG_ARC_HAS_SECURE
+	lr ilink, [_ARC_V2_ERSEC_STAT]
+	push ilink
+#endif
 	lr ilink, [_ARC_V2_ERET]
 	push ilink
 	lr ilink, [_ARC_V2_ERSTATUS]
 	push ilink
+
 
 	bclr ilink, ilink, _ARC_V2_STATUS32_U_BIT
 	sr ilink, [_ARC_V2_ERSTATUS]

--- a/arch/arc/core/fault_s.S
+++ b/arch/arc/core/fault_s.S
@@ -71,6 +71,10 @@ SECTION_SUBSEC_FUNC(TEXT,__fault,__ev_maligned)
 	/* save caller saved registers */
 	_create_irq_stack_frame
 
+#ifdef CONFIG_ARC_HAS_SECURE
+	lr r0,[_ARC_V2_ERSEC_STAT]
+	st_s r0, [sp, ___isf_t_sec_stat_OFFSET]
+#endif
 	lr r0,[_ARC_V2_ERSTATUS]
 	st_s r0, [sp, ___isf_t_status32_OFFSET]
 	lr r0,[_ARC_V2_ERET]
@@ -117,6 +121,16 @@ _exc_return:
 	ld_s r2, [r1, _kernel_offset_to_ready_q_cache]
 	st_s r2, [r1, _kernel_offset_to_current]
 
+#ifdef CONFIG_ARC_HAS_SECURE
+	/* ERM to IRM */
+	lr r3,[_ARC_V2_ERSEC_STAT]
+	btst r3, 31
+	bset.nz r3, r3, 3
+	bclr.z r3, r3, 3
+	/* sflag r3 */
+	/* sflag instruction is not supported in current ARC GNU */
+	.long 0x00ff302f
+#endif
 	/* clear AE bit to forget this was an exception */
 	lr r3, [_ARC_V2_STATUS32]
 	and r3,r3,(~_ARC_V2_STATUS32_AE)
@@ -190,6 +204,10 @@ _do_other_trap:
 	/* save caller saved registers */
 	_create_irq_stack_frame
 
+#ifdef CONFIG_ARC_HAS_SECURE
+	lr r0,[_ARC_V2_ERSEC_STAT]
+	st_s r0, [sp, ___isf_t_sec_stat_OFFSET]
+#endif
 	lr r0,[_ARC_V2_ERSTATUS]
 	st_s r0, [sp, ___isf_t_status32_OFFSET]
 	lr r0,[_ARC_V2_ERET]

--- a/arch/arc/core/offsets/offsets.c
+++ b/arch/arc/core/offsets/offsets.c
@@ -58,6 +58,9 @@ GEN_OFFSET_SYM(_isf_t, ldi_base);
 GEN_OFFSET_SYM(_isf_t, jli_base);
 #endif
 GEN_OFFSET_SYM(_isf_t, pc);
+#ifdef CONFIG_ARC_HAS_SECURE
+GEN_OFFSET_SYM(_isf_t, sec_stat);
+#endif
 GEN_OFFSET_SYM(_isf_t, status32);
 GEN_ABSOLUTE_SYM(___isf_t_SIZEOF, sizeof(_isf_t));
 

--- a/arch/arc/core/userspace.S
+++ b/arch/arc/core/userspace.S
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 Synopsys.
+ * Copyright (c) 2018 Synopsys.
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -12,40 +12,35 @@
 #include <syscall.h>
 
 .macro clear_scratch_regs
-	mov	r1, 0
-	mov 	r2, 0
-	mov	r3, 0
-	mov	r4, 0
-	mov	r5, 0
-	mov	r6, 0
-	mov	r7, 0
-	mov	r8, 0
-	mov 	r9, 0
-	mov	r10, 0
-	mov	r11, 0
-	mov	r12, 0
-
-	mov 	fp, 0
-	mov 	r29, 0
-	mov 	r30, 0
-	mov	blink, 0
+	mov r1, 0
+	mov r2, 0
+	mov r3, 0
+	mov r4, 0
+	mov r5, 0
+	mov r6, 0
+	mov r7, 0
+	mov r8, 0
+	mov r9, 0
+	mov r10, 0
+	mov r11, 0
+	mov r12, 0
 .endm
 
 .macro clear_callee_regs
-	mov	r25, 0
-	mov	r24, 0
-	mov	r23, 0
-	mov	r22, 0
-	mov	r21, 0
-	mov	r20, 0
-	mov	r19, 0
-	mov	r18, 0
-	mov	r17, 0
-	mov	r16, 0
+	mov r25, 0
+	mov r24, 0
+	mov r23, 0
+	mov r22, 0
+	mov r21, 0
+	mov r20, 0
+	mov r19, 0
+	mov r18, 0
+	mov r17, 0
+	mov r16, 0
 
-	mov	r15, 0
-	mov	r14, 0
-	mov	r13, 0
+	mov r15, 0
+	mov r14, 0
+	mov r13, 0
 .endm
 
 GTEXT(_arc_userspace_enter)
@@ -144,6 +139,11 @@ _arc_go_to_user_space:
 
 	clear_scratch_regs
 
+	mov fp, 0
+	mov r29, 0
+	mov r30, 0
+	mov blink, 0
+
 	rtie
 
 /**
@@ -166,24 +166,30 @@ SECTION_FUNC(TEXT, _arc_do_syscall)
 
 	jl [r6]
 
+	/*
+	 * no need to clear callee regs, as they will be saved and restored
+	 * automatically
+	 */
+	clear_scratch_regs
+
+	mov r29, 0
+	mov r30, 0
+
 	pop_s blink
 
 	/* through fake exception return, go back to the caller */
 	kflag _ARC_V2_STATUS32_AE
 
-#ifdef CONFIG_ARC_HAS_SECURE
-	lr r6, [_ARC_V2_SEC_STAT]
-	/* the mode returns from exception return is secure mode */
-	bset r6, r6, 31
-	sr r6, [_ARC_V2_ERSEC_STAT]
-#endif
-	/* the status and return addesss are saved in trap_s handler */
+	/* the status and return address are saved in trap_s handler */
 	pop r6
 	sr r6, [_ARC_V2_ERSTATUS]
 	pop r6
 	sr r6, [_ARC_V2_ERET]
+#ifdef CONFIG_ARC_HAS_SECURE
+	pop r6
+	sr r6, [_ARC_V2_ERSEC_STAT]
+#endif
 
-	/* no nned to clear callee regs */
-	clear_scratch_regs
+	mov r6, 0
 
 	rtie


### PR DESCRIPTION
* current codes use a faked interrupt return to do a thread switch
  in exception return.
* so the different between exception return and interrupt return
  should be carefully considered.
* when secure is enabled, the sec_stat should also be pushed in
  exception entry.
* when secure is enabled, SEC_STAT.IRM must be configured corrrectly
  for interrupt return.
* For the case of faked interrupt return in exception return, the
  correct value of SEC_STAT.IRM comes from ER_SEC_STAT.ERM.

Signed-off-by: Wayne Ren <wei.ren@synopsys.com>