### PR TITLE
misc: stats: fix for coverity cid 186049

### DIFF
--- a/misc/stats.c
+++ b/misc/stats.c
@@ -281,5 +281,9 @@ stats_init_and_reg(struct stats_hdr *shdr, u8_t size, u8_t cnt,
 void
 stats_reset(struct stats_hdr *hdr)
 {
-	memset(hdr + 1, 0, hdr->s_size * hdr->s_cnt);
+	void *stats_data;
+
+	/* Statistical data are place right after the statistic group header */
+	stats_data = hdr + 1;
+	memset(stats_data, 0, hdr->s_size * hdr->s_cnt);
 }


### PR DESCRIPTION
Statistic data are placed right after the statistic group header.
f. stats_reset doesn't know the full statistic type structure so the
data area should be treated as RAW memory are.

fixes #7722

Signed-off-by: Andrzej Puzdrowski <andrzej.puzdrowski@nordicsemi.no>