### PR TITLE
newlib: Fix typo in Kconfig related to NEWLIB_LIBC_ALIGNED_HEAP_SIZE

### DIFF
--- a/lib/libc/Kconfig
+++ b/lib/libc/Kconfig
@@ -19,7 +19,7 @@ config NEWLIB_LIBC
 config NEWLIB_LIBC_ALIGNED_HEAP_SIZE
 	int
 	prompt "Newlib aligned heap size"
-	depends on CONFIG_MPU_REQUIRES_POWER_OF_TWO_ALIGNMENT
+	depends on MPU_REQUIRES_POWER_OF_TWO_ALIGNMENT
 	depends on NEWLIB_LIBC
 	depends on USERSPACE
 	default 0


### PR DESCRIPTION
When we introduced NEWLIB_LIBC_ALIGNED_HEAP_SIZE in commit
42a2c96422cbeb46f27074960b0898d06658fdcd.  We accidently had the Kconfig
symbol depend on CONFIG_MPU_REQUIRES_POWER_OF_TWO_ALIGNMENT the leading
'CONFIG_' shouldn't exist.

Signed-off-by: Kumar Gala <kumar.gala@linaro.org>