### PR TITLE
arch: arm: nxp: Fixup HAS_MCUX_RTC

### DIFF
--- a/arch/arm/soc/nxp_kinetis/kwx/Kconfig.soc
+++ b/arch/arm/soc/nxp_kinetis/kwx/Kconfig.soc
@@ -48,11 +48,11 @@ config SOC_MKW41Z4
 	select HAS_MCUX
 	select HAS_MCUX_ADC16
 	select HAS_MCUX_LPUART
+	select HAS_MCUX_RTC
 	select HAS_MCUX_SIM
 	select HAS_MCUX_TRNG
 	select HAS_OSC
 	select HAS_MCG
-	select HAS_RTC
 
 endchoice
 

--- a/drivers/rtc/Kconfig.mcux_rtc
+++ b/drivers/rtc/Kconfig.mcux_rtc
@@ -8,7 +8,7 @@
 menuconfig RTC_MCUX
 	bool
 	prompt "MCUX RTC driver"
-	depends on RTC && HAS_MCUX
+	depends on RTC && HAS_MCUX_RTC
 	default n
 	help
 	  Enable support for mcux rtc driver.

--- a/ext/hal/nxp/mcux/Kconfig
+++ b/ext/hal/nxp/mcux/Kconfig
@@ -55,6 +55,12 @@ config HAS_MCUX_RNGA
 	  Set if the random number generator accelerator (RNGA) module is
 	  present in the SoC.
 
+config HAS_MCUX_RTC
+	bool
+	default n
+	help
+	  Set if the real time clock (RTC) modules is present in the SoC.
+
 config HAS_MCUX_SIM
 	bool
 	default n


### PR DESCRIPTION
When the RTC support get added we had a select on HAS_RTC, however this
Kconfig symbol didn't exist.  Clean this up to match the pattern of
HAS_MCUX_RTC.  The driver now depends on that and the SoC selects it.

Signed-off-by: Kumar Gala <kumar.gala@linaro.org>