### PR TITLE
drivers: net: loopback: Fix setting of SYS_LOG_LEVEL

### DIFF
--- a/drivers/net/loopback.c
+++ b/drivers/net/loopback.c
@@ -12,7 +12,7 @@
  */
 
 #define SYS_LOG_DOMAIN "netlo"
-#define SYS_LOG_LEVEL CONFIG_SYS_LOG_NETLO_LEVEL
+#define SYS_LOG_LEVEL CONFIG_SYS_LOG_NET_LOOPBACK_LEVEL
 #include <logging/sys_log.h>
 
 #include <misc/printk.h>


### PR DESCRIPTION
We had a typo in the Kconfig symbol that was being used to try and set
SYS_LOG_LEVEL.  It should be CONFIG_SYS_LOG_NET_LOOPBACK_LEVEL.

Signed-off-by: Kumar Gala <kumar.gala@linaro.org>