### PR TITLE
arch: arm: swap: Remove old context switch code

### DIFF
--- a/arch/arm/core/swap_helper.S
+++ b/arch/arm/core/swap_helper.S
@@ -305,7 +305,7 @@ SECTION_FUNC(TEXT, __svc)
 
    /*
     * grab service call number:
-    * 0: context switch
+    * 0: Unused
     * 1: irq_offload (if configured)
     * 2: kernel panic or oops (software generated fatal exception)
     * 3: System call
@@ -326,9 +326,7 @@ SECTION_FUNC(TEXT, __svc)
     tst r2, #0x1
     bne _oops
 
-    cmp r1, #0
 #endif
-    beq _context_switch
 
     cmp r1, #2
     beq _oops
@@ -341,24 +339,6 @@ SECTION_FUNC(TEXT, __svc)
     /* exception return is done in _IntExit() */
     b _IntExit
 #endif
-
-_context_switch:
-
-    /*
-     * Unlock interrupts:
-     * - in a SVC call, so protected against context switches
-     * - allow PendSV, since it's running at prio 0xff
-     */
-    eors.n r0, r0
-    msr BASEPRI, r0
-
-     /* set PENDSV bit, pending the PendSV exception */
-    ldr r1, =_SCS_ICSR
-    ldr r2, =_SCS_ICSR_PENDSV
-    str r2, [r1, #0]
-
-    /* handler mode exit, to PendSV */
-    bx lr
 
 _oops:
     push {lr}


### PR DESCRIPTION
Remove unused context switch code from the helper assembly file that
manages the SuperVisor Call invocations (SVCs). This is no longer in use
in the code, since all calls to __swap() now go through PendSV directly.

Signed-off-by: Carles Cufi <carles.cufi@nordicsemi.no>