### PR TITLE
scripts: generalize kobject -> enum naming

### DIFF
--- a/scripts/elf_helper.py
+++ b/scripts/elf_helper.py
@@ -25,8 +25,13 @@ def subsystem_to_enum(subsys):
     return "K_OBJ_DRIVER_" + subsys[:-11].upper()
 
 
-def kobject_to_enum(ko):
-    return "K_OBJ_" + ko[2:].upper()
+def kobject_to_enum(kobj):
+    if kobj.startswith("k_") or kobj.startswith("_k_"):
+        name = kobj[2:]
+    else:
+        name = kobj
+
+    return "K_OBJ_%s" % name.upper()
 
 
 DW_OP_addr = 0x3

--- a/scripts/gen_kobject_list.py
+++ b/scripts/gen_kobject_list.py
@@ -9,7 +9,7 @@ import argparse
 import pprint
 import os
 import struct
-from elf_helper import ElfHelper
+from elf_helper import ElfHelper, kobject_to_enum
 
 kobjects = [
     "k_alert",
@@ -150,12 +150,7 @@ def write_kobj_types_output(fp):
         if kobj == "device":
             continue
 
-        if kobj.startswith("k_"):
-            kobj = kobj[2:]
-        elif kobj.startswith("_k_"):
-            kobj = kobj[2:]
-
-        fp.write("K_OBJ_%s,\n" % kobj.upper())
+        fp.write("%s,\n" % kobject_to_enum(kobj))
 
     fp.write("/* Driver subsystems */\n")
     for subsystem in subsystems:
@@ -169,15 +164,7 @@ def write_kobj_otype_output(fp):
         if kobj == "device":
             continue
 
-        if kobj.startswith("k_"):
-            kobj = kobj[2:]
-        elif kobj.startswith("_k_"):
-            kobj = kobj[2:]
-
-        fp.write('case K_OBJ_%s: return "%s";\n' % (
-            kobj.upper(),
-            kobj
-        ))
+        fp.write('case %s: return "%s";\n' % (kobject_to_enum(kobj), kobj))
 
     fp.write("/* Driver subsystems */\n")
     for subsystem in subsystems:
@@ -195,9 +182,8 @@ def write_kobj_size_output(fp):
         if kobj == "device" or kobj == "_k_thread_stack_element":
             continue
 
-        kobj_enum = "K_OBJ_%s" % kobj[2:].upper();
-
-        fp.write('case %s: return sizeof(struct %s);\n' % (kobj_enum, kobj))
+        fp.write('case %s: return sizeof(struct %s);\n' %
+                (kobject_to_enum(kobj), kobj))
 
 def parse_args():
     global args


### PR DESCRIPTION
This was done inconsistently in a few place, centralize it.

Signed-off-by: Andrew Boie <andrew.p.boie@intel.com>