### PR TITLE
doc: fix misspellings in docs

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -92,7 +92,7 @@ support systems:
   way to track developer discussions and to ask your own support questions to
   the Zephyr project community.  There are also specific `Zephyr mailing list
   subgroups`_ for announcements, builds, marketing, and Technical
-  Steering Committe notes, for example.
+  Steering Committee notes, for example.
   You can read through the message archives to follow
   past posts and discussions, a good thing to do to discover more about the
   Zephyr project.

--- a/doc/getting_started/getting_started.rst
+++ b/doc/getting_started/getting_started.rst
@@ -243,7 +243,7 @@ Running a Sample Application natively (POSIX OS)
 It is also possible to compile some of the sample and test applications to run
 as native process on a POSIX OS (e.g. Linux).
 To be able to do this, remember to have installed the 32 bit libC if your OS is
-natively 64bit. See the :ref:`native_posix` section on host depencencies
+natively 64bit. See the :ref:`native_posix` section on host dependencies
 for more information.
 
 To compile and run an application in this way, type:

--- a/samples/subsys/ipc/openamp/README.rst
+++ b/samples/subsys/ipc/openamp/README.rst
@@ -6,7 +6,7 @@ OpenAMP Sample Application
 Overview
 ********
 
-This application demostrates how to use OpenAMP with Zephyr. It is designed to
+This application demonstrates how to use OpenAMP with Zephyr. It is designed to
 demonstrate how to integrate OpenAMP with Zephyr both from a build perspective
 and code.
 


### PR DESCRIPTION
Caught some misspellings missed by the normal review process.

Signed-off-by: David B. Kinder <david.b.kinder@intel.com>