### PR TITLE
doc: fix misspellings in Kconfig files

### DIFF
--- a/arch/arm/core/cortex_m/Kconfig
+++ b/arch/arm/core/cortex_m/Kconfig
@@ -127,9 +127,9 @@ config CPU_CORTEX_M_HAS_VTOR
 	  This option signifies the CPU has the VTOR register.
 	  The VTOR indicates the offset of the vector table base
 	  address from memory address 0x00000000. Always present
-	  in CPUs implementing the ARMv7-M or ARMv8-M architetures.
+	  in CPUs implementing the ARMv7-M or ARMv8-M architectures.
 	  Optional in CPUs implementing ARMv6-M, ARMv8-M Baseline
-	  architetures (except for Cortex-M0, where it is never
+	  architectures (except for Cortex-M0, where it is never
 	  implemented).
 
 config CPU_CORTEX_M_HAS_SPLIM

--- a/drivers/can/Kconfig
+++ b/drivers/can/Kconfig
@@ -45,14 +45,14 @@ config CAN_PHASE_SEG1_PROP_SEG
 	default 5
 	range 1 16
 	help
-	  Time quantums of phase buffer 1 segment + propagation segment (ISO 11898-1)
+	  Time quanta of phase buffer 1 segment + propagation segment (ISO 11898-1)
 
 config CAN_PHASE_SEG2
 	int "Phase_Seg2"
 	default 6
 	range 1 8
 	help
-	  Time quantums of phase buffer 2 segment (ISO 11898-1)
+	  Time quanta of phase buffer 2 segment (ISO 11898-1)
 
 config CAN_SJW
 	int "SJW"

--- a/drivers/wifi/winc1500/Kconfig.winc1500
+++ b/drivers/wifi/winc1500/Kconfig.winc1500
@@ -89,7 +89,7 @@ config WIFI_WINC1500_MAX_PACKET_SIZE
 	default 1500
 	help
 	 Set the maximum size of a network packet going through the chip.
-	 This sets the size of each buffer, in each buffe pools.
+	 This sets the size of each buffer, in each buffer pools.
 	 Do not modify it unless you know what you are doing.
 
 config WIFI_WINC1500_OFFLOAD_MAX_SOCKETS

--- a/subsys/bluetooth/host/mesh/Kconfig
+++ b/subsys/bluetooth/host/mesh/Kconfig
@@ -173,7 +173,7 @@ config BT_MESH_IVU_DIVIDER
 	  the state at least for 96 hours (Update in Progress has an
 	  additional upper limit of 144 hours).
 
-	  In order to fulfil the above requirement, even if the node might
+	  In order to fulfill the above requirement, even if the node might
 	  be powered off once in a while, we need to store persistently
 	  how many hours the node has been in the state. This doesn't
 	  necessarily need to happen every hour (thanks to the flexible

--- a/subsys/net/ip/Kconfig
+++ b/subsys/net/ip/Kconfig
@@ -184,7 +184,7 @@ config NET_TCP_TIME_WAIT_DELAY
 	  engineering choice, and may be changed if experience indicates
 	  it is desirable to do so." For low-resource systems, having
 	  large MSL may lead to quick resource exhaustion (and related
-	  DoS attacks). At the same time, the issue of packet mis-delivery
+	  DoS attacks). At the same time, the issue of packet misdelivery
 	  is largely alleviated in the modern TCP stacks by using random,
 	  non-repeating port numbers and initial sequence numbers. Due
 	  to this, Zephyr uses much lower value of 250ms by default.


### PR DESCRIPTION
Found some misspellings missed during normal reviews.

Signed-off-by: David B. Kinder <david.b.kinder@intel.com>