### PR TITLE
doc: fix misspellings in API doxygen comments

### DIFF
--- a/include/can.h
+++ b/include/can.h
@@ -160,7 +160,7 @@ struct can_filter {
  * @typedef can_tx_callback_t
  * @brief Define the application callback handler function signature
  *
- * @param error_flags status of the preformed send operation
+ * @param error_flags status of the performed send operation
  */
 typedef void (*can_tx_callback_t)(u32_t error_flags);
 
@@ -211,7 +211,7 @@ typedef int (*can_send_t)(struct device *dev, struct can_msg *msg,
  *
  * This routine attaches a message queue to identifiers specified by
  * a filter. Whenever the filter matches, the message is pushed to the queue
- * If a message passes more than one filter the priotity of the match
+ * If a message passes more than one filter the priority of the match
  * is hardware dependent.
  * A message queue can be attached to more than one filter.
  * The message queue must me initialized before.
@@ -232,12 +232,12 @@ typedef int (*can_attach_msgq_t)(struct device *dev, struct k_msgq *msg_q,
  * This routine attaches an isr callback to identifiers specified by
  * a filter. Whenever the filter matches, the callback function is called
  * with isr context.
- * If a message passes more than one filter the priotity of the match
+ * If a message passes more than one filter the priority of the match
  * is hardware dependent.
  * A callback function can be attached to more than one filter.
  * *
  * @param dev    Pointer to the device structure for the driver instance.
- * @param isr    Callback functionpointer.
+ * @param isr    Callback function pointer.
  * @param filter Pointer to a can_filter structure defining the id filtering.
  *
  * @retval filter id on success.

--- a/include/kernel.h
+++ b/include/kernel.h
@@ -3652,7 +3652,7 @@ void k_pipe_cleanup(struct k_pipe *pipe);
  * @param size Size of the pipe's ring buffer (in bytes), or zero if no ring
  *             buffer is used.
  * @retval 0 on success
- * @retval -ENOMEM if memory couln't be allocated
+ * @retval -ENOMEM if memory couldn't be allocated
  */
 __syscall int k_pipe_alloc_init(struct k_pipe *pipe, size_t size);
 
@@ -4286,13 +4286,13 @@ static inline void _impl_k_poll_signal_reset(struct k_poll_signal *signal)
 }
 
 /**
- * @brief Fetch the signaled state and resylt value of a poll signal
+ * @brief Fetch the signaled state and result value of a poll signal
  *
  * @param signal A poll signal object
  * @param signaled An integer buffer which will be written nonzero if the
  *		   object was signaled
  * @param result An integer destination buffer which will be written with the
- *		   result value if the object was signaed, or an undefined
+ *		   result value if the object was signaled, or an undefined
  *		   value if it was not.
  */
 __syscall void k_poll_signal_check(struct k_poll_signal *signal,

--- a/include/misc/rb.h
+++ b/include/misc/rb.h
@@ -169,7 +169,7 @@ struct rbnode *_rb_foreach_next(struct rbtree *tree, struct _rb_foreach *f);
 /**
  * @brief Loop over rbtree with implicit container field logic
  *
- * As for RB_FOR_EACH(), but "node" can have an aribtrary type
+ * As for RB_FOR_EACH(), but "node" can have an arbitrary type
  * containing a struct rbnode.
  *
  * @param tree A pointer to a struct rbtree to walk

--- a/include/net/tcp.h
+++ b/include/net/tcp.h
@@ -33,7 +33,7 @@ extern "C" {
  *
  * @param pkt Network packet
  * @param hdr Where to place the header if it does not fit in first fragment
- * of the network packet. This might not be pupulated if TCP header fits in
+ * of the network packet. This might not be populated if TCP header fits in
  * net_buf fragment.
  *
  * @return Return pointer to header or NULL if something went wrong.

--- a/include/stats.h
+++ b/include/stats.h
@@ -105,28 +105,28 @@ struct stats_hdr {
 /**
  * @brief Declares a 32-bit stat entry inside a group struct.
  *
- * @param var__                 The name ot assign to the entry.
+ * @param var__                 The name to assign to the entry.
  */
 #define STATS_SECT_ENTRY(var__) u32_t var__;
 
 /**
  * @brief Declares a 16-bit stat entry inside a group struct.
  *
- * @param var__                 The name ot assign to the entry.
+ * @param var__                 The name to assign to the entry.
  */
 #define STATS_SECT_ENTRY16(var__) u16_t var__;
 
 /**
  * @brief Declares a 32-bit stat entry inside a group struct.
  *
- * @param var__                 The name ot assign to the entry.
+ * @param var__                 The name to assign to the entry.
  */
 #define STATS_SECT_ENTRY32(var__) u32_t var__;
 
 /**
  * @brief Declares a 64-bit stat entry inside a group struct.
  *
- * @param var__                 The name ot assign to the entry.
+ * @param var__                 The name to assign to the entry.
  */
 #define STATS_SECT_ENTRY64(var__) u64_t var__;
 

--- a/include/watchdog.h
+++ b/include/watchdog.h
@@ -238,7 +238,7 @@ struct wdt_driver_api {
  * This function is used for configuring global watchdog settings that
  * affect all timeouts. It should be called after installing timeouts.
  * After successful return, all installed timeouts are valid and must be
- * serviced periodically by callig wdt_feed().
+ * serviced periodically by calling wdt_feed().
  *
  * @param dev Pointer to the device structure for the driver instance.
  * @param options Configuration options as defined by the WDT_OPT_* constants
@@ -308,7 +308,7 @@ static inline int wdt_install_timeout(struct device *dev,
  * @brief Feed specified watchdog timeout.
  *
  * @param dev Pointer to the device structure for the driver instance.
- * @param channel_id Index of the feeded channel.
+ * @param channel_id Index of the fed channel.
  *
  * @retval 0 If successful.
  * @retval -EINVAL If there is no installed timeout for supplied channel.


### PR DESCRIPTION
Found some misspellings missed during normal code reviews

Signed-off-by: David B. Kinder <david.b.kinder@intel.com>