### PR TITLE
doc: fix misspellings in test documentation

### DIFF
--- a/tests/kernel/alert/alert_api/src/main.c
+++ b/tests/kernel/alert/alert_api/src/main.c
@@ -329,8 +329,8 @@ void test_isr_kinit_alert(void)
  *
  * This test checks alert_recv(timeout) against the following cases:
  *  1. The current task times out while waiting for the event.
- *  2. There is already an event waiting (signalled from a task).
- *  3. The current task must wait on the event until it is signalled
+ *  2. There is already an event waiting (signaled from a task).
+ *  3. The current task must wait on the event until it is signaled
  *     from either another task or an ISR.
  */
 void test_thread_alert_timeout(void)
@@ -368,8 +368,8 @@ void test_thread_alert_timeout(void)
  *
  * This test checks alert_recv(K_FOREVER) against
  * the following cases:
- *  1. There is already an event waiting (signalled from a task and ISR).
- *  2. The current task must wait on the event until it is signalled
+ *  1. There is already an event waiting (signaled from a task and ISR).
+ *  2. The current task must wait on the event until it is signaled
  *     from either another task or an ISR.
  */
 void test_thread_alert_wait(void)

--- a/tests/kernel/arm_runtime_nmi/src/arm_runtime_nmi.c
+++ b/tests/kernel/arm_runtime_nmi/src/arm_runtime_nmi.c
@@ -31,7 +31,7 @@ static void nmi_test_isr(void)
 }
 
 /**
- * @brief test the behaviour of CONFIG_RUNTIME_NMI at run time
+ * @brief test the behavior of CONFIG_RUNTIME_NMI at run time
  *
  * @details this test is to validate _NmiHandlerSet() api.
  * First we configure the NMI isr using _NmiHandlerSet() api.

--- a/tests/kernel/mem_heap/mheap_api_concept/src/test_mheap_api.c
+++ b/tests/kernel/mem_heap/mheap_api_concept/src/test_mheap_api.c
@@ -15,7 +15,7 @@
  * @details The test allocates 4 blocks from heap memory pool
  * using k_malloc() API. It also tries to allocate a block of size
  * 64 bytes which fails as all the memory is allocated up. It then
- * validates k_free() API by feeing up all the blocks which were
+ * validates k_free() API by freeing up all the blocks which were
  * allocated from the heap memory.
  */
 void test_mheap_malloc_free(void)

--- a/tests/kernel/mem_pool/mem_pool_threadsafe/src/main.c
+++ b/tests/kernel/mem_pool/mem_pool_threadsafe/src/main.c
@@ -53,7 +53,7 @@ static void tmpool_api(void *p1, void *p2, void *p3)
  *
  * @details The test creates 4 threads of equal priority and
  * invokes memory pool APIs on same memory domain. Checks for
- * the synronization of threads on the resource memory pool.
+ * the synchronization of threads on the resource memory pool.
  * Each thread allocates 4 blocks of size 4 bytes (all blocks
  * in memory pool) with timeout of 200 ms and frees up all the
  * blocks

--- a/tests/kernel/mem_slab/mslab_api/src/test_mslab_api.c
+++ b/tests/kernel/mem_slab/mslab_api/src/test_mslab_api.c
@@ -184,7 +184,7 @@ void test_mslab_alloc_align(void)
  * the allocation fails with return value -ENOMEM. Then the
  * system up time is obtained, memory block allocation is
  * tried with timeout of 2000 ms. Now the allocation API
- * returns -EAGAIN as the wating period is timeout. The
+ * returns -EAGAIN as the waiting period is timeout. The
  * test case also checks if timeout has really happened by
  * checking delta period between the allocation request
  * was made and return of -EAGAIN.

--- a/tests/kernel/mem_slab/mslab_threadsafe/src/test_mslab_threadsafe.c
+++ b/tests/kernel/mem_slab/mslab_threadsafe/src/test_mslab_threadsafe.c
@@ -52,8 +52,8 @@ static void tmslab_api(void *p1, void *p2, void *p3)
 /**
  * @brief Verify alloc and free from multiple equal priority threads
  *
- * @details Test creates 4 preemptive threads of equal priorty. Then
- * validates the syncronization of threads by allocating and
+ * @details Test creates 4 preemptive threads of equal priority. Then
+ * validates the synchronization of threads by allocating and
  * freeing up the memory blocks in memory slab.
  */
 void test_mslab_threadsafe(void)

--- a/tests/kernel/threads/lifecycle/lifecycle_api/src/test_threads_spawn.c
+++ b/tests/kernel/threads/lifecycle/lifecycle_api/src/test_threads_spawn.c
@@ -92,7 +92,7 @@ void test_threads_spawn_delay(void)
  * @brief Spawn thread with forever delay and highest priority
  *
  * @details Create an user thread with forever delay and yield
- * the current thread. Eventhough the current thread has yielded,
+ * the current thread. Even though the current thread has yielded,
  * the thread will not be put in ready queue since it has forever delay,
  * the thread is explicitly started using k_thread_start() and checked
  * if thread has started executing.

--- a/tests/kernel/threads/scheduling/schedule_api/src/test_priority_scheduling.c
+++ b/tests/kernel/threads/scheduling/schedule_api/src/test_priority_scheduling.c
@@ -57,7 +57,7 @@ static void thread_tslice(void *p1, void *p2, void *p3)
  *
  * @details Create multiple threads of different priorities - all are preemptive,
  * current thread is also made preemptive. Check how the threads get chance to
- * exeucte based on their priorities
+ * execute based on their priorities
  */
 void test_priority_scheduling(void)
 {

--- a/tests/kernel/threads/scheduling/schedule_api/src/test_sched_timeslice_and_lock.c
+++ b/tests/kernel/threads/scheduling/schedule_api/src/test_sched_timeslice_and_lock.c
@@ -138,7 +138,7 @@ void test_busy_wait_cooperative(void)
 /**
  * @brief Validate k_wakeup()
  *
- * @details Create 3 threads with main thead with priority 0
+ * @details Create 3 threads with main thread with priority 0
  * and other threads with -1, 0 ,+1 priority. Now -1 priority
  * thread gets executed and it is made to sleep for 10 sec.
  * Now, wake up the -1 priority thread and check if it starts

--- a/tests/posix/mutex/src/posix_mutex.c
+++ b/tests/posix/mutex/src/posix_mutex.c
@@ -52,7 +52,7 @@ void *recursive_mutex_entry(void *p1)
 }
 
 /**
- * @brief Test to demostrate PTHREAD_MUTEX_NORMAL
+ * @brief Test to demonstrate PTHREAD_MUTEX_NORMAL
  *
  * @details Mutex type is setup as normal. pthread_mutex_trylock
  *	    and pthread_mutex_lock are tested with mutex type being
@@ -111,7 +111,7 @@ static void test_mutex_normal(void)
 }
 
 /**
- * @brief Test to demostrate PTHREAD_MUTEX_RECURSIVE
+ * @brief Test to demonstrate PTHREAD_MUTEX_RECURSIVE
  *
  * @details Mutex type is setup as recursive. mutex will be locked
  *	    twice and unlocked for the same number of time.


### PR DESCRIPTION
Found some misspellings missed during normal review

Signed-off-by: David B. Kinder <david.b.kinder@intel.com>