### PR TITLE
kernel: handle early entropy issues

### DIFF
--- a/kernel/include/kernel_internal.h
+++ b/kernel/include/kernel_internal.h
@@ -206,6 +206,12 @@ extern void smp_timer_init(void);
 extern void z_newlib_get_heap_bounds(void **base, size_t *size);
 #endif
 
+extern u32_t z_early_boot_rand32_get(void);
+
+#if CONFIG_STACK_POINTER_RANDOM
+extern int z_stack_adjust_initialized;
+#endif
+
 #ifdef __cplusplus
 }
 #endif


### PR DESCRIPTION
We generalize querying the entropy driver directly with
a new internal API, which is now used by CONFIG_STACK_RANDOM
and stack canary initialization.

Signed-off-by: Andrew Boie <andrew.p.boie@intel.com>