### PR TITLE
sanitycheck: add runtime feature filtering

### DIFF
--- a/scripts/sanity_chk/sanitycheck-tc-schema.yaml
+++ b/scripts/sanity_chk/sanitycheck-tc-schema.yaml
@@ -71,6 +71,9 @@ mapping:
      "platform_whitelist":
        type: str
        required: no
+     "runtime_filter":
+       type: str
+       required: no
      "tags":
        type: str
        required: no
@@ -182,6 +185,9 @@ mapping:
                type: str
                required: no
              "platform_whitelist":
+               type: str
+               required: no
+             "runtime_filter":
                type: str
                required: no
              "tags":

--- a/scripts/sanitycheck
+++ b/scripts/sanitycheck
@@ -1243,6 +1243,7 @@ testcase_valid_keys = {"tags": {"type": "set", "required": False},
                        "extra_sections": {"type": "list", "default": []},
                        "platform_exclude": {"type": "set"},
                        "platform_whitelist": {"type": "set"},
+                       "runtime_filter": {"type": "str"},
                        "toolchain_exclude": {"type": "set"},
                        "toolchain_whitelist": {"type": "set"},
                        "filter": {"type": "str"},
@@ -1480,6 +1481,7 @@ class TestCase:
         self.skip = tc_dict["skip"]
         self.platform_exclude = tc_dict["platform_exclude"]
         self.platform_whitelist = tc_dict["platform_whitelist"]
+        self.runtime_filter = tc_dict["runtime_filter"]
         self.toolchain_exclude = tc_dict["toolchain_exclude"]
         self.toolchain_whitelist = tc_dict["toolchain_whitelist"]
         self.tc_filter = tc_dict["filter"]
@@ -1769,7 +1771,6 @@ class TestSuite:
         if not toolchain:
             raise SanityRuntimeError("E: Variable ZEPHYR_TOOLCHAIN_VARIANT is not defined")
 
-
         instances = []
         discards = {}
         platform_filter = options.platform
@@ -1868,6 +1869,19 @@ class TestSuite:
 
                     if tc.toolchain_whitelist and toolchain not in tc.toolchain_whitelist:
                         continue
+
+                    # Evaluate the platform filter for the current platform name
+                    runtime_kws = dict(options.device_settings)
+                    runtime_kws.update({
+                        "platform": plat.name,
+                        plat.name: True
+                    })
+                    if tc.runtime_filter != '' and \
+                       not expr_parser.parse(tc.runtime_filter, runtime_kws):
+                        info("%s@%s: build only, as the platform doesn't fullfil "
+                             "runtime requirements: '%s'" %
+                             (tc.name, plat.name, tc.runtime_filter))
+                        tc.build_only = True
 
                     if (tc.tc_filter and (plat.default or all_plats or platform_filter)
                             and toolchain in plat.supported_toolchains):
@@ -2477,6 +2491,14 @@ def parse_arguments():
         "--device-serial",
 		help="Serial device the board can be accessed through")
     parser.add_argument(
+        "--device-settings", action='append', type=str, default=[],
+	       help="Add settings to the platform, like for example what "
+                    "runtime features it supports (eg: ABC adds ABC as "
+                    "True, CDE=XYZ as CDE as a string XYZ; these can be "
+                    "used to match testcases that require said feature "
+                    "with the runtime_filter keyword to the testcase "
+                    "(eg: platform == 'quark_d2000_crb' and ABC or CDE)")
+    parser.add_argument(
             "--show-footprint", action="store_true",
             help="Show footprint statistics and deltas since last release."
             )
@@ -2689,6 +2711,19 @@ def main():
     if options.device_testing:
         if options.device_serial is None or len(options.platform) != 1:
             sys.exit(1)
+        settings = {}
+        for setting in options.device_settings:
+            if '=' in setting:
+                key, val = setting.split('=', 1)
+                if val.lower() == 'false':
+                    val = False
+                elif val.lower() == 'true':
+                    val = True
+            else:
+                val = True
+            settings[key] = val
+        # override the list from the cmdline with a key/val dict
+        options.device_settings = settings
 
     VERBOSE += options.verbose
     INLINE_LOGS = options.inline_logs

--- a/tests/drivers/gpio/gpio_basic_api/testcase.yaml
+++ b/tests/drivers/gpio/gpio_basic_api/testcase.yaml
@@ -4,4 +4,9 @@ tests:
     depends_on: gpio
     # FIXME: code is board specific, it should be generalised
     platform_whitelist: quark_se_c1000_devboard quark_d2000_crb esp32
-    harness: loopback # see documentation
+    # each test platform can map this to whatever they want, but we
+    # need to guarantee it is unique in terms of configuration (one or
+    # more TCs can share a fixture type, but no different fixtures
+    # shall be called the same).
+    runtime_filter: fixture_gpio_loopback_type_A
+    # no harness, this is ztest


### PR DESCRIPTION
This introduces the testcase keyword runtime_filter (wide open to a
different name) which allows a testcase to specify which extra
features a platform has to have to be able to run.

The intention of this is to be able to support (eg) a ztest case that
evaluates GPIO and needs a certain loopback setup interconnected in an
specific way (which we'll call fixture_gpio_loopback_type_A) and when
we are launching sanitycheck against a hardware target that supports
it, we can tell it, so it will run it:
```
  $ sanitycheck --platform BAR --device-testing --device-serial FOO \
    --device-settings fixture_gpio_loopback_type_A \
    -T tests/drivers/gpio/gpio_basic_api
```
because we know that the device with serial number FOO has been setup
with that fixture of type A, we indicate it to sanitycheck. Now, in
the testcase that demands that:
```
  tests:
    peripheral.gpio:
      tags: drivers gpio
      depends_on: gpio
      platform_whitelist: quark_se_c1000_devboard quark_d2000_crb esp32
-->   runtime_filter: fixture_gpio_loopback_type_A
```
a simple mention of the fixture allows us to filter to ensure that is
the case. When the device doesn't provide said fixture or runtime
feature, the testcase is converted to build only, so we at least gain
the build coverage.

It follows that if we run at top level:
```
  $ sanitycheck --platform BAR --device-testing --device-serial FOO \
    --device-settings fixture_gpio_loopback_type_A
```
it'll run all the testcases that match that platform, including theones
that support fixture_gpio_loopback_type_A, but not the ones who would
require fixture_SOME_OTHER_FEATURE. If our device supports both, we
could do:
```
  $ sanitycheck --platform BAR --device-testing --device-serial FOO \
    --device-settings fixture_gpio_loopback_type_A \
    --device-settings fixture_SOME_OTHER_FEATURE
```
This allows specifying multiple runtime requirements, as the filter
uses the same 'filter:' keyword mechanism:
```
  runtime_filter: |
    ( platform == "quark_d2000_crb" and fixture_gpio_loopback_type_A_d2k )
    or arduino_101 and fixture_gpio_loopback_type_A_a101_x86
    or arduino_101_sss and fixture_gpio_loopback_type_A_a101_arc
```
this would require different setups for different platforms/boards in
different ways as the setup might be different for each--but using a
sane naming convention, we know the loopback setup is similar but
because of the particularities of the platform, it might be connected
to it in different ways (eg: different SPI ports in the ARC or x86
SPI ports of an Arduino 101).

This is meant to:

- to be able to support multiple testcase backbones (not just
  sanitycheck)

- allow an open methodology to specify runtime requirements without
  limiting what sanitycheck can do in terms of build coverage

- free up the harness concept to be a process that decides "how to
  test for success"

The implementation is quite simple, requiring only a runtime_filter
keyword, adding the --device-settings commandline, to feed settings to
a device description and a quick filtering step in
TestSuite.apply_filters().

Signed-off-by: Inaky Perez-Gonzalez <inaky.perez-gonzalez@intel.com>