### PR TITLE
net: Fix dependency to offload driver in Kconfig

### DIFF
--- a/subsys/net/ip/Kconfig
+++ b/subsys/net/ip/Kconfig
@@ -413,7 +413,7 @@ config NET_DEFAULT_IF_IEEE802154
 
 config NET_DEFAULT_IF_OFFLOAD
 	bool "Offloaded interface"
-	depends on NET_L2_OFFLOAD
+	depends on NET_OFFLOAD
 
 config NET_DEFAULT_IF_DUMMY
 	bool "Dummy testing interface"


### PR DESCRIPTION
The CONFIG_NET_DEFAULT_IF_OFFLOAD should depend on CONFIG_NET_OFFLOAD

Fixes #7797

Signed-off-by: Jukka Rissanen <jukka.rissanen@linux.intel.com>