### PR TITLE
tests: net: arp: Check NULL in unicast test

### DIFF
--- a/tests/net/arp/src/main.c
+++ b/tests/net/arp/src/main.c
@@ -341,6 +341,7 @@ void test_arp(void)
 				      &src,
 				      NET_ADDR_MANUAL,
 				      0);
+	zassert_not_null(ifaddr, "Cannot add address");
 	ifaddr->addr_state = NET_ADDR_PREFERRED;
 
 	/* Application data for testing */


### PR DESCRIPTION
Coverity-CID: 186047
Fixes #7724

Signed-off-by: Jukka Rissanen <jukka.rissanen@linux.intel.com>