### PR TITLE
tests: mslab_threadsafe: Check for return value

### DIFF
--- a/tests/kernel/mem_slab/mslab_threadsafe/src/test_mslab_threadsafe.c
+++ b/tests/kernel/mem_slab/mslab_threadsafe/src/test_mslab_threadsafe.c
@@ -29,13 +29,14 @@ static void tmslab_api(void *p1, void *p2, void *p3)
 {
 	void *block[BLK_NUM];
 	struct k_mem_slab *slab = slabs[atomic_inc(&slab_id) % SLAB_NUM];
-	int i = LOOP;
+	int i = LOOP, ret;
 
 	while (i--) {
 		memset(block, 0, sizeof(block));
 
 		for (int i = 0; i < BLK_NUM; i++) {
-			k_mem_slab_alloc(slab, &block[i], TIMEOUT);
+			ret = k_mem_slab_alloc(slab, &block[i], TIMEOUT);
+			zassert_false(ret, "memory is not allocated");
 		}
 		for (int i = 0; i < BLK_NUM; i++) {
 			if (block[i]) {


### PR DESCRIPTION
Check return value for k_mem_slab_alloc()

Fixes #6693

Signed-off-by: Punit Vara <punit.vara@intel.com>