### PR TITLE
scripts: check-compliance: Allow to run from any path

### DIFF
--- a/scripts/ci/check-compliance.py
+++ b/scripts/ci/check-compliance.py
@@ -61,7 +61,7 @@ def get_shas(refspec):
 
 def run_gitlint(tc, commit_range):
     proc = subprocess.Popen('gitlint --commits %s' %(commit_range),
-            cwd=repository_path, shell=True, stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
+                shell=True, stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
 
     msg = ""
     if proc.wait() != 0:


### PR DESCRIPTION
Allow check-compliance.py to be run from any path with a valid Git tree,
removing the unnecessary and artificial limitation imposed in the case
of gitlint.

Signed-off-by: Carles Cufi <carles.cufi@nordicsemi.no>