### PR TITLE
serial: nsim: Fix impossible-to-enable CONFIG_UART_NSIM

### DIFF
--- a/drivers/serial/Kconfig.nsim
+++ b/drivers/serial/Kconfig.nsim
@@ -2,7 +2,7 @@ config UART_NSIM
 	bool "UART driver for MetaWare nSim"
 	default n
 	select SERIAL_HAS_DRIVER
-	depends on NSIM && SERIAL
+	depends on SERIAL
 	help
 	  This enables the UART driver for the MetaWare nSim simulator.
 

--- a/include/arch/arc/v2/linker.ld
+++ b/include/arch/arc/v2/linker.ld
@@ -14,7 +14,7 @@
 #include <autoconf.h>
 #include <linker/sections.h>
 
-#if defined(CONFIG_NSIM)
+#if defined(CONFIG_UART_NSIM)
 	EXTERN(_VectorTable)
 #endif
 

--- a/tests/drivers/build_all/testcase.yaml
+++ b/tests/drivers/build_all/testcase.yaml
@@ -43,7 +43,6 @@ tests:
     build_only: true
     platform_whitelist: em_starterkit
     extra_configs:
-      - CONFIG_NSIM=y
       - CONFIG_UART_NSIM=y
   test_clock:
     build_only: true


### PR DESCRIPTION
`CONFIG_UART_NSIM` depends on `CONFIG_NSIM`, which was removed in commit
9bc69a46fa09 ("boards: Update arc em_starterkit support from 2.2 to
2.3"). Remove the dependency, and also remove the `CONFIG_NSIM=y` setting
from the `test_nsim` test (which should now work).

Also change the condition for `EXTERN()`ing `_VectorTable` in
`include/arch/arc/v2/linker.ld` to check `CONFIG_UART_NSIM` instead of
`CONFIG_NSIM`. I'm guessing the `EXTERN()` is there to make the symbol
visible to nSIM, though I don't know anything about it.

Signed-off-by: Ulf Magnusson <Ulf.Magnusson@nordicsemi.no>