### PR TITLE
net: sockets: Verify that TCP context exists when updating window length

### DIFF
--- a/subsys/net/lib/sockets/sockets.c
+++ b/subsys/net/lib/sockets/sockets.c
@@ -442,7 +442,8 @@ static inline ssize_t zsock_recv_stream(struct net_context *ctx,
 		}
 	} while (recv_len == 0);
 
-	if (!(flags & ZSOCK_MSG_PEEK)) {
+	if (!(flags & ZSOCK_MSG_PEEK) &&
+	    (net_context_get_state(ctx) != NET_CONTEXT_UNCONNECTED)) {
 		net_context_update_recv_wnd(ctx, recv_len);
 	}
 


### PR DESCRIPTION
Socket may still consume received data after TCP connection was closed and TCP context deallocated, therefore it is needed to verify that TCP context still exists before using it. Otherwise TCP layer throws an error, which can be seen for example in `http_get` sample.

Signed-off-by: Robert Lubos <robert.lubos@nordicsemi.no>