### PR TITLE
subsys: net: rpl: fix null pointer dereference

### DIFF
--- a/subsys/net/ip/rpl.c
+++ b/subsys/net/ip/rpl.c
@@ -1382,6 +1382,7 @@ struct net_rpl_dag *net_rpl_set_root_with_version(struct net_if *iface,
 	NET_DBG("Node set to be a DAG root with DAG ID %s",
 		net_sprint_ipv6_addr(&dag->dag_id));
 
+	instance->iface = iface;
 	net_rpl_reset_dio_timer(instance);
 
 	return dag;


### PR DESCRIPTION
This patch fixes possible null pointer dereference in
net_stats_update_rpl_resets(...).

net_rpl_set_root_with_version(...) does not initialize instance->iface
and calls net_rpl_reset_dio_timer(...), which then calls
net_stats_update_rpl_resets(instance->iface).

fixes: #7862