### PR TITLE
arch/arc: UART QMSI's baudrate is not present in Kconfig anymore

### DIFF
--- a/arch/arc/soc/quark_se_c1000_ss/Kconfig.defconfig
+++ b/arch/arc/soc/quark_se_c1000_ss/Kconfig.defconfig
@@ -138,9 +138,6 @@ config BT_UART_ON_DEV_NAME
 config UART_QMSI_0
 	def_bool y
 
-config UART_QMSI_0_BAUDRATE
-	default 1000000
-
 config UART_QMSI_0_HW_FC
 	def_bool y
 


### PR DESCRIPTION
It's generated through dts.

Signed-off-by: Tomasz Bursztyka <tomasz.bursztyka@linux.intel.com>