### PR TITLE
Arch arm properly report stack corruption

### DIFF
--- a/arch/arm/core/fatal.c
+++ b/arch/arm/core/fatal.c
@@ -41,6 +41,8 @@
  *
  * @param reason the reason that the handler was called
  * @param pEsf pointer to the exception stack frame
+ *
+ * @return This function does not return.
  */
 void _NanoFatalErrorHandler(unsigned int reason,
 					  const NANO_ESF *pEsf)

--- a/arch/arm/core/sys_fatal_error_handler.c
+++ b/arch/arm/core/sys_fatal_error_handler.c
@@ -36,7 +36,7 @@
  * @param reason fatal error reason
  * @param pEsf pointer to exception stack frame
  *
- * @return N/A
+ * @return This function does not return.
  */
 void __weak _SysFatalErrorHandler(unsigned int reason,
 					 const NANO_ESF *pEsf)

--- a/tests/kernel/fatal/src/main.c
+++ b/tests/kernel/fatal/src/main.c
@@ -235,7 +235,7 @@ void test_fatal(void)
 			(k_thread_entry_t)stack_thread2,
 			NULL, NULL, NULL, K_PRIO_PREEMPT(PRIORITY), 0,
 			K_NO_WAIT);
-#ifdef CONFIG_ARM
+#ifdef CONFIG_NXP_MPU
 	/* FIXME: See #7706 */
 	zassert_true(crash_reason == _NANO_ERR_STACK_CHK_FAIL ||
 		     crash_reason == _NANO_ERR_HW_EXCEPTION, NULL);


### PR DESCRIPTION
Allows ARM builds to report Stack Corruption.
Fixes issues reported in #7706 