### PR TITLE
soc: nRF52x: Add Kconfig options to enable DC/DC converter

### DIFF
--- a/arch/arm/soc/nordic_nrf/nrf52/Kconfig.soc
+++ b/arch/arm/soc/nordic_nrf/nrf52/Kconfig.soc
@@ -29,6 +29,11 @@ config SOC_NRF52840_QIAA
 
 endchoice
 
+config SOC_DCDC_NRF52X
+	bool
+	help
+	  Enable nRF52 series System on Chip DC/DC converter.
+
 config ARM_MPU_NRF52X
 	bool "Enable MPU on nRF52"
 	depends on CPU_HAS_MPU

--- a/arch/arm/soc/nordic_nrf/nrf52/soc.c
+++ b/arch/arm/soc/nordic_nrf/nrf52/soc.c
@@ -26,6 +26,7 @@ extern void _NmiInit(void);
 #endif
 
 #include "nrf.h"
+#include "nrf_power.h"
 
 #define __SYSTEM_CLOCK_64M (64000000UL)
 
@@ -422,6 +423,10 @@ static int nordicsemi_nrf52_init(struct device *arg)
 		}
 		NVIC_SystemReset();
 	}
+#endif
+
+#if defined(CONFIG_SOC_DCDC_NRF52X)
+	nrf_power_dcdcen_set(true);
 #endif
 
 	_ClearFaults();

--- a/boards/arm/nrf52840_pca10056/Kconfig
+++ b/boards/arm/nrf52840_pca10056/Kconfig
@@ -6,4 +6,9 @@
 
 if BOARD_NRF52840_PCA10056
 
+config BOARD_HAS_DCDC
+	bool "Board has DCDC circuitry"
+	select SOC_DCDC_NRF52X
+	default y
+
 endif # BOARD_NRF52840_PCA10056


### PR DESCRIPTION
Added a hidden Kconfig option in arch/arm/soc/nordic_nrf
which is selected by selecting DC/DC circuitry being present
in the board.

Signed-off-by: Vinayak Kariappa Chettimada <vich@nordicsemi.no>