### PR TITLE
doc: tweak CSS for option table display

### DIFF
--- a/doc/static/zephyr-custom.css
+++ b/doc/static/zephyr-custom.css
@@ -29,3 +29,8 @@ th,td {
 .rst-content div.breathe-sectiondef {
   padding-left: 0 !important;
 }
+
+/* tweak display of option tables to make first column wider */
+col.option {
+  width: 25%;
+}


### PR DESCRIPTION
Noticed in docs.zephyrproject.org/subsystems/test/sanitycheck.html that
the first column of the option table display is too narrow (for short
option names that are shown on the same line as the description).  This
PR tweaks the CSS to widen the first column enough to stop wrapping in
most cases.

Signed-off-by: David B. Kinder <david.b.kinder@intel.com>