### PR TITLE
arm: st_stm32: reduce boot MPU regions

### DIFF
--- a/arch/arm/soc/st_stm32/common/arm_mpu_regions.c
+++ b/arch/arm/soc/st_stm32/common/arm_mpu_regions.c
@@ -25,14 +25,6 @@ static struct arm_mpu_region mpu_regions[] = {
 	MPU_REGION_ENTRY("RAM_1",
 			 (CONFIG_SRAM_BASE_ADDRESS + REGION_SRAM_1_START),
 			 REGION_RAM_ATTR(REGION_SRAM_1_SIZE)),
-	/* Region 3 */
-	MPU_REGION_ENTRY("PERIPHERAL_0",
-			 APB1PERIPH_BASE,
-			 REGION_IO_ATTR(REGION_512M)),
-	/* Region 4 */
-	MPU_REGION_ENTRY("PPB_0",
-			 PPB_BASE,
-			 REGION_PPB_ATTR(REGION_256M)),
 };
 
 struct arm_mpu_config mpu_config = {


### PR DESCRIPTION
The PPB and Peripheral regions have been removed,
the Shareable options are only important with unlocked
dual cores. Just use the background mapping.

Related to #6896 and #7877

fixes #7877

Signed-off-by: Andrew Boie <andrew.p.boie@intel.com>