### PR TITLE
net: lwm2m: dont release reply for duplicate block transfer

### DIFF
--- a/subsys/net/lib/lwm2m/lwm2m_engine.h
+++ b/subsys/net/lib/lwm2m/lwm2m_engine.h
@@ -40,6 +40,10 @@
 /* length of time in milliseconds to wait for buffer allocations */
 #define BUF_ALLOC_TIMEOUT K_SECONDS(1)
 
+/* coap reply status */
+#define COAP_REPLY_STATUS_NONE		0
+#define COAP_REPLY_STATUS_ERROR		1
+
 struct lwm2m_message;
 
 /* Establish a message timeout callback */

--- a/subsys/net/lib/lwm2m/lwm2m_obj_firmware_pull.c
+++ b/subsys/net/lib/lwm2m/lwm2m_obj_firmware_pull.c
@@ -308,6 +308,9 @@ do_firmware_transfer_reply_cb(const struct coap_packet *response,
 		/* restore main firmware block context */
 		memcpy(&firmware_block_ctx, &received_block_ctx,
 		       sizeof(firmware_block_ctx));
+
+		/* set reply->user_data to error to avoid releasing */
+		reply->user_data = (void *)COAP_REPLY_STATUS_ERROR;
 		return 0;
 	}
 


### PR DESCRIPTION
During normal use, a CoAP packet can be resent due to network congestion
and other causes.  During block transfer the LwM2M client checks to make
sure the block received is the one we expect and if not generates a
"duplicate" warning.  When this happened, we were releasing the reply
handler and when the correct block was received the client would generate
a "No handler" error.

To avoid releasing the reply handler too early, let's set the coap_reply
"user_data" field to an error condition (1).  Then, once the reply
processing is complete we can check the user_data field to be sure that
it's ok to release the reply handler.

Signed-off-by: Michael Scott <michael@opensourcefoundries.com>