### PR TITLE
arm_mpu: reduce boot MPU regions for various soc

### DIFF
--- a/arch/arm/soc/arm/beetle/arm_mpu_regions.c
+++ b/arch/arm/soc/arm/beetle/arm_mpu_regions.c
@@ -16,22 +16,6 @@ static struct arm_mpu_region mpu_regions[] = {
 	MPU_REGION_ENTRY("RAM_0",
 			 CONFIG_SRAM_BASE_ADDRESS,
 			 REGION_RAM_ATTR(REGION_128K)),
-	/* Region 2 */
-	MPU_REGION_ENTRY("APB_0",
-			 _BEETLE_APB_BASE,
-			 REGION_IO_ATTR(REGION_64K)),
-	/* Region 3 */
-	MPU_REGION_ENTRY("AHB_0",
-			 _BEETLE_AHB_BASE,
-			 REGION_IO_ATTR(REGION_64K)),
-	/* Region 4 */
-	MPU_REGION_ENTRY("BITBAND_0",
-			 _BEETLE_BITBAND_BASE,
-			 REGION_IO_ATTR(REGION_32M)),
-	/* Region 5 */
-	MPU_REGION_ENTRY("PPB_0",
-			 _BEETLE_PPB_BASE,
-			 REGION_PPB_ATTR(REGION_1M)),
 };
 
 struct arm_mpu_config mpu_config = {

--- a/arch/arm/soc/nordic_nrf/nrf52/mpu_regions.c
+++ b/arch/arm/soc/nordic_nrf/nrf52/mpu_regions.c
@@ -22,18 +22,6 @@ static struct arm_mpu_region mpu_regions[] = {
 	MPU_REGION_ENTRY("SRAM_0",
 			 CONFIG_SRAM_BASE_ADDRESS,
 			 REGION_RAM_ATTR(REGION_SRAM_0_SIZE)),
-	/* Region 2 */
-	MPU_REGION_ENTRY("FACTUSERCFG_0",
-			 XICR_BASE,
-			 REGION_IO_ATTR(REGION_8K)),
-	/* Region 3 */
-	MPU_REGION_ENTRY("PERIPH_0",
-			 PERIPH_BASE,
-			 REGION_IO_ATTR(REGION_512M)),
-	/* Region 4 */
-	MPU_REGION_ENTRY("PPB_0",
-			 M4_PPB_BASE,
-			 REGION_PPB_ATTR(REGION_64K)),
 };
 
 struct arm_mpu_config mpu_config = {

--- a/arch/arm/soc/nxp_imx/rt/arm_mpu_regions.c
+++ b/arch/arm/soc/nxp_imx/rt/arm_mpu_regions.c
@@ -21,14 +21,6 @@ static struct arm_mpu_region mpu_regions[] = {
 	MPU_REGION_ENTRY("SRAM_0",
 			 CONFIG_SRAM_BASE_ADDRESS,
 			 REGION_RAM_ATTR(REGION_SRAM_0_SIZE)),
-	/* Region 2 */
-	MPU_REGION_ENTRY("PERIPH_0",
-			 PERIPH_BASE,
-			 REGION_IO_ATTR(REGION_4M)),
-	/* Region 3 */
-	MPU_REGION_ENTRY("PPB_0",
-			 PPB_BASE,
-			 REGION_PPB_ATTR(REGION_1M)),
 };
 
 struct arm_mpu_config mpu_config = {


### PR DESCRIPTION
The PPB, Peripheral, and any other I/O regions have been
removed, the Shareable options are only important with
unlocked dual cores. Just use the background mapping,
which is RWX for supervisor and no access for user mode.

The flash region needs to be kept to indicate read-only
policy. The RAM regions need to be kept to disable execution.

Fixes #6896

Signed-off-by: Andrew Boie <andrew.p.boie@intel.com>