### PR TITLE
drivers: i2s: i2s_cavs: Fix typo in IRQ priority

### DIFF
--- a/drivers/i2s/i2s_cavs.c
+++ b/drivers/i2s/i2s_cavs.c
@@ -760,7 +760,7 @@ struct queue_item tx_0_ring_buf[CONFIG_I2S_CAVS_TX_BLOCK_COUNT + 1];
 
 static void i2s1_irq_config(void)
 {
-	IRQ_CONNECT(I2S1_CAVS_IRQ, CONFIG_I2S_1_IRQ_PRI, i2s_cavs_isr,
+	IRQ_CONNECT(I2S1_CAVS_IRQ, CONFIG_I2S_CAVS_1_IRQ_PRI, i2s_cavs_isr,
 		    DEVICE_GET(i2s1_cavs), 0);
 }
 


### PR DESCRIPTION
The driver was using CONFIG_I2S_1_IRQ_PRI which doesn't exist.  It
should use CONFIG_I2S_CAVS_1_IRQ_PRI.

Signed-off-by: Kumar Gala <kumar.gala@linaro.org>