### PR TITLE
doc: Remove undefined CONFIG_TASK_MONITOR

### DIFF
--- a/doc/zephyr.doxyfile
+++ b/doc/zephyr.doxyfile
@@ -1971,7 +1971,6 @@ PREDEFINED             = "CONFIG_SYS_CLOCK_EXISTS=y" \
                          "CONFIG_KERNEL_EVENT_LOGGER=y" \
                          "CONFIG_KERNEL_EVENT_LOGGER_DYNAMIC=y" \
                          "CONFIG_KERNEL_EVENT_LOGGER_CUSTOM_TIMESTAMP=y" \
-                         "CONFIG_TASK_MONITOR=y" \
                          "CONFIG_UART_INTERRUPT_DRIVEN=y" \
                          "CONFIG_UART_DRV_CMD=y" \
                          "CONFIG_SYS_POWER_MANAGEMENT=y" \


### PR DESCRIPTION
CONFIG_TASK_MONITOR isn't defined anywhere so remove reference to it.

Signed-off-by: Kumar Gala <kumar.gala@linaro.org>