### PR TITLE
drivers: serial: uart_fe310: Match Kconfig defines in comment

### DIFF
--- a/drivers/serial/uart_fe310.c
+++ b/drivers/serial/uart_fe310.c
@@ -410,7 +410,7 @@ static void uart_fe310_irq_cfg_func_0(void)
 }
 #endif
 
-#endif /* CONFIG_FE310_UART_0 */
+#endif /* CONFIG_UART_FE310_PORT_0 */
 
 #ifdef CONFIG_UART_FE310_PORT_1
 
@@ -449,4 +449,4 @@ static void uart_fe310_irq_cfg_func_1(void)
 }
 #endif
 
-#endif /* CONFIG_FE310_UART_1 */
+#endif /* CONFIG_UART_FE310_PORT_1 */


### PR DESCRIPTION
The trailing #endif comments used CONFIG_FE310_UART_{0,1} and they
should be CONFIG_UART_FE310_PORT_{0,1}.

Signed-off-by: Kumar Gala <kumar.gala@linaro.org>