### PR TITLE
arm: clean up MPU code for ARM and NXP

### DIFF
--- a/include/arch/arm/cortex_m/mpu/arm_core_mpu_dev.h
+++ b/include/arch/arm/cortex_m/mpu/arm_core_mpu_dev.h
@@ -30,11 +30,21 @@ extern "C" {
  * be managed inside the MPU driver and not escalated.
  */
 /* Thread Stack Region Intent Type */
-#define THREAD_STACK_USER_REGION 0x0	/* fake region for user mode stack */
-#define THREAD_STACK_REGION 0x1
-#define THREAD_APP_DATA_REGION 0x2
-#define THREAD_STACK_GUARD_REGION 0x3
-#define THREAD_DOMAIN_PARTITION_REGION 0x4
+enum {
+#ifdef CONFIG_USERSPACE
+	THREAD_STACK_REGION,
+#endif
+#ifdef CONFIG_APPLICATION_MEMORY
+	THREAD_APP_DATA_REGION,
+#endif
+#ifdef CONFIG_MPU_STACK_GUARD
+	THREAD_STACK_GUARD_REGION,
+#endif
+#ifdef CONFIG_USERSPACE
+	THREAD_DOMAIN_PARTITION_REGION,
+#endif
+	THREAD_MPU_REGION_LAST
+};
 
 #if defined(CONFIG_ARM_CORE_MPU)
 struct k_mem_domain;


### PR DESCRIPTION
* We are now *much* better at not reserving unnecessary
system MPU regions based on configuration. The #defines
for intent are now an enumerated type. As a bonus, the
implementation of _get_region_index_by_type() is much
simpler. Previously we were wasting regions for stack guard
and application memory if they were not configured.

* Certain parts of the MPU code are now properly ifdef'd
based on configuration.

* THREAD_STACK_REGION and THREAD_STACK_USER_REGION was a
confusing construction and has now been replaced with
just THREAD_STACK_REGION, which represents the MPU region
for a user mode thread stack. Supervisor mode stacks
do not require an MPU region.

* The bounds of CONFIG_APPLICATION_MEMORY never changes
and we just do it once during initialization instead of
every context switch.

* Assertions have been added to catch out-of-bounds cases.

Fixes: #7384

Signed-off-by: Andrew Boie <andrew.p.boie@intel.com>