### PR TITLE
Bluetooth: Mesh: Fix build error when LPN is not enabled

### DIFF
--- a/subsys/bluetooth/host/mesh/transport.c
+++ b/subsys/bluetooth/host/mesh/transport.c
@@ -415,7 +415,8 @@ static int send_seg(struct bt_mesh_net_tx *net_tx, struct net_buf_simple *sdu,
 		}
 	}
 
-	if (bt_mesh_lpn_established()) {
+	if (IS_ENABLED(CONFIG_BT_MESH_LOW_POWER) &&
+	    bt_mesh_lpn_established()) {
 		bt_mesh_lpn_poll();
 	}
 


### PR DESCRIPTION
Some versions of gcc do not seem to compile out the inaccessible code
in this case and instead give the following error:

subsys/bluetooth/host/mesh/transport.c:419: undefined reference to
`bt_mesh_lpn_poll'

This happens at least when building samples/bluetooth/mesh for
native_posix on Fedora 28.

Signed-off-by: Johan Hedberg <johan.hedberg@intel.com>