### PR TITLE
drivers: sensor: Lis2dh data reading fix

### DIFF
--- a/drivers/sensor/lis2dh/lis2dh.c
+++ b/drivers/sensor/lis2dh/lis2dh.c
@@ -121,18 +121,19 @@ static int lis2dh_sample_fetch(struct device *dev, enum sensor_channel chan)
 {
 	struct lis2dh_data *lis2dh = dev->driver_data;
 	size_t i;
-	int status;
+	int status = 0;
 
 	__ASSERT_NO_MSG(chan == SENSOR_CHAN_ALL ||
 			chan == SENSOR_CHAN_ACCEL_XYZ);
 
 	/*
-	 * since status and all accel data register addresses are consecutive,
-	 * a burst read can be used to read all the samples
+	 * Burst mode cannot be used with this sensor.
 	 */
-	status = lis2dh_burst_read(dev, LIS2DH_REG_STATUS,
-				   lis2dh->sample.raw,
-				   sizeof(lis2dh->sample.raw));
+	for(i = 0; i < sizeof(lis2dh->sample.raw); i++) {
+		status |= lis2dh_reg_read_byte(lis2dh->bus,
+			LIS2DH_REG_STATUS + i, &lis2dh->sample.raw[i]);
+	}
+
 	if (status < 0) {
 		SYS_LOG_WRN("Could not read accel axis data");
 		return status;

--- a/drivers/sensor/lis2dh/lis2dh.h
+++ b/drivers/sensor/lis2dh/lis2dh.h
@@ -259,7 +259,7 @@ static inline int lis2dh_reg_read_byte(struct device *dev, u8_t reg_addr,
 #endif
 }
 
-static inline int lis2dh_burst_write(struct device *bus, u8_t start_addr,
+static inline int lis2dh_burst_write(struct device *dev, u8_t start_addr,
 				     u8_t *buf, u8_t num_bytes)
 {
 	struct lis2dh_data *lis2dh = dev->driver_data;


### PR DESCRIPTION
For some reason I2C burst mode in lis2dh works unreliably and just fills the buffer with continuously repeating first byte. Reading bytes one-by-one solves the problem.
Also a compilation error is fixed in header file.
