### PR TITLE
include: power: Make sure required header files are included

### DIFF
--- a/include/power.h
+++ b/include/power.h
@@ -13,6 +13,8 @@ extern "C" {
 
 #ifdef CONFIG_SYS_POWER_MANAGEMENT
 
+#include <zephyr/types.h>
+
 /* Constants identifying power state categories */
 #define SYS_PM_ACTIVE_STATE		0 /* SOC and CPU are in active state */
 #define SYS_PM_LOW_POWER_STATE		1 /* CPU low power state */


### PR DESCRIPTION
It seems power.h header does not include necessary header files. For this reason compilation fails as s32_t is undefined.