### PR TITLE
Fix struct offsets (DWARF v2 compatibility)

### DIFF
--- a/scripts/elf_helper.py
+++ b/scripts/elf_helper.py
@@ -144,7 +144,15 @@ class AggregateTypeMember:
         self.member_name = member_name
         self.member_type = member_type
         if isinstance(member_offset, list):
-            self.member_offset = member_offset[0]
+            # DWARF v2, location encoded as set of operations
+            # only "DW_OP_plus_uconst" with ULEB128 argument supported
+            if member_offset[0]==0x23:
+                self.member_offset = member_offset[1] & 0x7f
+                for i in range(1, len(member_offset)-1):
+                    if (member_offset[i] & 0x80):
+                        self.member_offset += (member_offset[i+1] & 0x7f) << i*7
+            else:
+                debug_die("not yet supported location operation")
         else:
             self.member_offset = member_offset
 


### PR DESCRIPTION
For DWARF v2, DW_AT_data_member_location is encoded as a set of operations. The member_offset is in that case a list that starts with an operation (typically DW_OP_plus_uconst), so member_offset[0] is not the offset.

This solves the kernel/poll test (issue #7885)