### PR TITLE
usb: function_eem: fix eem_read_cb

### DIFF
--- a/subsys/usb/class/netusb/function_eem.c
+++ b/subsys/usb/class/netusb/function_eem.c
@@ -99,6 +99,14 @@ static void eem_read_cb(u8_t ep, int size, void *priv)
 			goto done;
 		}
 
+		SYS_LOG_DBG("hdr 0x%x, eem_size %d, size %d",
+			    eem_hdr, eem_size, size);
+
+		if (!size || !eem_size) {
+			SYS_LOG_DBG("no payload");
+			break;
+		}
+
 		pkt = net_pkt_get_reserve_rx(0, K_FOREVER);
 		if (!pkt) {
 			SYS_LOG_ERR("Unable to alloc pkt\n");


### PR DESCRIPTION
This patch prevents eem_read_cb from trying to allocate a lot of memory.

It may happen that EEM payload size is zero, the eem_read_cb then tries to
allocate a buffer which is 0xfffc bytes large and luckily blocks.

(If someone wants to test it, rebase this PR on #7551)