### PR TITLE
userspace: align _k_object to 4 bytes

### DIFF
--- a/include/kernel.h
+++ b/include/kernel.h
@@ -178,7 +178,7 @@ struct _k_object {
 	u8_t type;
 	u8_t flags;
 	u32_t data;
-} __packed;
+} __packed __aligned(4);
 
 struct _k_object_assignment {
 	struct k_thread *thread;


### PR DESCRIPTION
We want the struct to be packed to conserve space, but the
perms field needs to always be on a 4-byte boundary since
we do bitfield operations on it, arches like ARC require
that the sys_bitfield_* operations be aligned to a 4 byte
boundary.

Instances of struct _k_object will now be 4-byte aligned
if in an array (which they are), even though the members
are still packed.

Fixes: #7776

Signed-off-by: Andrew Boie <andrew.p.boie@intel.com>