### PR TITLE
gpio: Fix imx driver edge selection when configuring by port

### DIFF
--- a/drivers/gpio/gpio_imx.c
+++ b/drivers/gpio/gpio_imx.c
@@ -68,7 +68,7 @@ static int imx_gpio_configure(struct device *dev,
 		for (i = 0; i < 32; i++) {
 			pin_config.pin = i;
 			GPIO_Init(config->base, &pin_config);
-			GPIO_SetIntEdgeSelect(config->base, pin, double_edge);
+			GPIO_SetIntEdgeSelect(config->base, i, double_edge);
 		}
 	}
 


### PR DESCRIPTION
Fixes a copy-paste error found by Coverity.

Coverity-CID: 186028

Signed-off-by: Maureen Helm <maureen.helm@nxp.com>

Fixes #7741 

cc: @diegosueiro 