### PR TITLE
boards: stm32f3_disco: Add usb_device to supported features

### DIFF
--- a/boards/arm/stm32f3_disco/stm32f3_disco.yaml
+++ b/boards/arm/stm32f3_disco/stm32f3_disco.yaml
@@ -10,3 +10,4 @@ supported:
   - gpio
   - i2c
   - spi
+  - usb_device


### PR DESCRIPTION
Add usb_device in board's metadata yaml file.

Signed-off-by: Yannis Damigos <giannis.damigos@gmail.com>