### PR TITLE
Consistently quote Kconfig string defaults + generate a warning for it

### DIFF
--- a/arch/arc/soc/quark_se_c1000_ss/Kconfig.defconfig
+++ b/arch/arc/soc/quark_se_c1000_ss/Kconfig.defconfig
@@ -8,7 +8,7 @@
 if SOC_QUARK_SE_C1000_SS
 
 config SOC
-	default quark_se_c1000_ss
+	default "quark_se_c1000_ss"
 
 config NUM_IRQ_PRIO_LEVELS
 	# This processor supports only 2 priority levels:

--- a/arch/arc/soc/snps_emsk/Kconfig.defconfig
+++ b/arch/arc/soc/snps_emsk/Kconfig.defconfig
@@ -9,7 +9,7 @@ if SOC_EMSK
 
 config SOC
 	string
-	default snps_emsk
+	default "snps_emsk"
 
 source "arch/arc/soc/snps_emsk/Kconfig.defconfig.em7d"
 source "arch/arc/soc/snps_emsk/Kconfig.defconfig.em11d"

--- a/arch/arm/soc/arm/Kconfig
+++ b/arch/arm/soc/arm/Kconfig
@@ -13,7 +13,7 @@ config SOC_FAMILY_ARM
 if SOC_FAMILY_ARM
 config SOC_FAMILY
 	string
-	default arm
+	default "arm"
 
 gsource "arch/arm/soc/arm/*/Kconfig.soc"
 endif # SOC_FAMILY_ARM

--- a/arch/arm/soc/arm/beetle/Kconfig.defconfig.beetle_r0
+++ b/arch/arm/soc/arm/beetle/Kconfig.defconfig.beetle_r0
@@ -9,6 +9,6 @@
 if SOC_BEETLE_R0
 
 config SOC
-	default beetle_r0
+	default "beetle_r0"
 
 endif # SOC_BEETLE_R0

--- a/arch/arm/soc/arm/beetle/Kconfig.defconfig.series
+++ b/arch/arm/soc/arm/beetle/Kconfig.defconfig.series
@@ -11,7 +11,7 @@ if SOC_SERIES_BEETLE
 gsource "arch/arm/soc/arm/beetle/Kconfig.defconfig.beetle*"
 
 config SOC_SERIES
-	default beetle
+	default "beetle"
 
 config NUM_IRQS
 	int

--- a/arch/arm/soc/arm/mps2/Kconfig.defconfig.mps2_an385
+++ b/arch/arm/soc/arm/mps2/Kconfig.defconfig.mps2_an385
@@ -7,7 +7,7 @@
 if SOC_MPS2_AN385
 
 config SOC
-	default mps2_an385
+	default "mps2_an385"
 
 config NUM_IRQS
 	int

--- a/arch/arm/soc/arm/mps2/Kconfig.defconfig.series
+++ b/arch/arm/soc/arm/mps2/Kconfig.defconfig.series
@@ -7,7 +7,7 @@
 if SOC_SERIES_MPS2
 
 config SOC_SERIES
-	default mps2
+	default "mps2"
 
 config SYS_CLOCK_HW_CYCLES_PER_SEC
 	int

--- a/arch/arm/soc/atmel_sam/Kconfig
+++ b/arch/arm/soc/atmel_sam/Kconfig
@@ -12,7 +12,7 @@ if SOC_FAMILY_SAM
 
 config SOC_FAMILY
 	string
-	default atmel_sam
+	default "atmel_sam"
 
 # Select SoC Part No. and configuration options
 gsource "arch/arm/soc/atmel_sam/*/Kconfig.soc"

--- a/arch/arm/soc/atmel_sam0/Kconfig
+++ b/arch/arm/soc/atmel_sam0/Kconfig
@@ -11,7 +11,7 @@ if SOC_FAMILY_SAM0
 
 config SOC_FAMILY
 	string
-	default atmel_sam0
+	default "atmel_sam0"
 
 
 gsource "arch/arm/soc/atmel_sam0/*/Kconfig.soc"

--- a/arch/arm/soc/nordic_nrf/Kconfig
+++ b/arch/arm/soc/nordic_nrf/Kconfig
@@ -13,7 +13,7 @@ config SOC_FAMILY_NRF
 if SOC_FAMILY_NRF
 config SOC_FAMILY
 	string
-	default nordic_nrf
+	default "nordic_nrf"
 
 gsource "arch/arm/soc/nordic_nrf/*/Kconfig.soc"
 endif # SOC_FAMILY_NRF

--- a/arch/arm/soc/nordic_nrf/nrf51/Kconfig.defconfig.nrf51822_QFAA
+++ b/arch/arm/soc/nordic_nrf/nrf51/Kconfig.defconfig.nrf51822_QFAA
@@ -10,7 +10,7 @@ if SOC_NRF51822_QFAA
 
 config SOC
 	string
-	default nRF51822_QFAA
+	default "nRF51822_QFAA"
 
 config ISR_STACK_SIZE
 	default 640

--- a/arch/arm/soc/nordic_nrf/nrf51/Kconfig.defconfig.nrf51822_QFAB
+++ b/arch/arm/soc/nordic_nrf/nrf51/Kconfig.defconfig.nrf51822_QFAB
@@ -10,7 +10,7 @@ if SOC_NRF51822_QFAB
 
 config SOC
 	string
-	default nRF51822_QFAB
+	default "nRF51822_QFAB"
 
 config ISR_STACK_SIZE
 	default 640

--- a/arch/arm/soc/nordic_nrf/nrf51/Kconfig.defconfig.nrf51822_QFAC
+++ b/arch/arm/soc/nordic_nrf/nrf51/Kconfig.defconfig.nrf51822_QFAC
@@ -10,6 +10,6 @@ if SOC_NRF51822_QFAC
 
 config SOC
 	string
-	default nRF51822_QFAC
+	default "nRF51822_QFAC"
 
 endif # SOC_NRF51822_QFAC

--- a/arch/arm/soc/nordic_nrf/nrf51/Kconfig.defconfig.series
+++ b/arch/arm/soc/nordic_nrf/nrf51/Kconfig.defconfig.series
@@ -11,7 +11,7 @@ if SOC_SERIES_NRF51X
 gsource "arch/arm/soc/nordic_nrf/nrf51/Kconfig.defconfig.nrf51*"
 
 config SOC_SERIES
-	default nrf51
+	default "nrf51"
 
 config SYS_CLOCK_HW_CYCLES_PER_SEC
 	int

--- a/arch/arm/soc/nordic_nrf/nrf52/Kconfig.defconfig.nrf52832_QFAA
+++ b/arch/arm/soc/nordic_nrf/nrf52/Kconfig.defconfig.nrf52832_QFAA
@@ -10,7 +10,7 @@ if SOC_NRF52832_QFAA
 
 config SOC
 	string
-	default nRF52832_QFAA
+	default "nRF52832_QFAA"
 
 config NUM_IRQS
 	int

--- a/arch/arm/soc/nordic_nrf/nrf52/Kconfig.defconfig.nrf52840_QIAA
+++ b/arch/arm/soc/nordic_nrf/nrf52/Kconfig.defconfig.nrf52840_QIAA
@@ -10,7 +10,7 @@ if SOC_NRF52840_QIAA
 
 config SOC
 	string
-	default nRF52840_QIAA
+	default "nRF52840_QIAA"
 
 config NUM_IRQS
 	int

--- a/arch/arm/soc/nordic_nrf/nrf52/Kconfig.defconfig.series
+++ b/arch/arm/soc/nordic_nrf/nrf52/Kconfig.defconfig.series
@@ -10,7 +10,7 @@ if SOC_SERIES_NRF52X
 gsource "arch/arm/soc/nordic_nrf/nrf52/Kconfig.defconfig.nrf52*"
 
 config SOC_SERIES
-	default nrf52
+	default "nrf52"
 
 config SYS_CLOCK_HW_CYCLES_PER_SEC
 	int

--- a/arch/arm/soc/nxp_imx/mcimx7_m4/Kconfig.defconfig.mcimx7_m4
+++ b/arch/arm/soc/nxp_imx/mcimx7_m4/Kconfig.defconfig.mcimx7_m4
@@ -9,7 +9,7 @@ if SOC_MCIMX7_M4
 
 config SOC
 	string
-	default mcimx7d
+	default "mcimx7d"
 
 config SYS_CLOCK_TICKS_PER_SEC
 	int

--- a/arch/arm/soc/nxp_imx/mcimx7_m4/Kconfig.defconfig.series
+++ b/arch/arm/soc/nxp_imx/mcimx7_m4/Kconfig.defconfig.series
@@ -8,7 +8,7 @@
 if SOC_SERIES_IMX7_M4
 
 config SOC_SERIES
-	default mcimx7_m4
+	default "mcimx7_m4"
 
 config NUM_IRQS
 	int

--- a/arch/arm/soc/nxp_imx/rt/Kconfig.defconfig.mimxrt1052
+++ b/arch/arm/soc/nxp_imx/rt/Kconfig.defconfig.mimxrt1052
@@ -9,7 +9,7 @@ if SOC_MIMXRT1052
 
 config SOC
 	string
-	default mimxrt1052
+	default "mimxrt1052"
 
 if CLOCK_CONTROL
 

--- a/arch/arm/soc/nxp_imx/rt/Kconfig.defconfig.series
+++ b/arch/arm/soc/nxp_imx/rt/Kconfig.defconfig.series
@@ -8,7 +8,7 @@
 if SOC_SERIES_IMX_RT
 
 config SOC_SERIES
-	default rt
+	default "rt"
 
 config NUM_IRQS
 	int

--- a/arch/arm/soc/nxp_kinetis/k6x/Kconfig.defconfig.mk64f12
+++ b/arch/arm/soc/nxp_kinetis/k6x/Kconfig.defconfig.mk64f12
@@ -10,7 +10,7 @@ if SOC_MK64F12
 
 config SOC
 	string
-	default mk64f12
+	default "mk64f12"
 
 if ADC
 

--- a/arch/arm/soc/nxp_kinetis/k6x/Kconfig.defconfig.series
+++ b/arch/arm/soc/nxp_kinetis/k6x/Kconfig.defconfig.series
@@ -9,7 +9,7 @@
 if SOC_SERIES_KINETIS_K6X
 
 config SOC_SERIES
-	default k6x
+	default "k6x"
 
 config NUM_IRQS
 	int

--- a/arch/arm/soc/nxp_kinetis/kl2x/Kconfig.defconfig.mkl25z4
+++ b/arch/arm/soc/nxp_kinetis/kl2x/Kconfig.defconfig.mkl25z4
@@ -9,7 +9,7 @@ if SOC_MKL25Z4
 
 config SOC
 	string
-	default mkl25z4
+	default "mkl25z4"
 
 config NUM_IRQS
 	int

--- a/arch/arm/soc/nxp_kinetis/kl2x/Kconfig.defconfig.series
+++ b/arch/arm/soc/nxp_kinetis/kl2x/Kconfig.defconfig.series
@@ -8,7 +8,7 @@
 if SOC_SERIES_KINETIS_KL2X
 
 config SOC_SERIES
-	default kl2x
+	default "kl2x"
 
 gsource "arch/arm/soc/nxp_kinetis/kl2x/Kconfig.defconfig.mk*"
 

--- a/arch/arm/soc/nxp_kinetis/kwx/Kconfig.defconfig.mkw2xd512
+++ b/arch/arm/soc/nxp_kinetis/kwx/Kconfig.defconfig.mkw2xd512
@@ -11,7 +11,7 @@ if SOC_MKW22D5
 
 config SOC
 	string
-	default mkw22d5
+	default "mkw22d5"
 
 endif # SOC_MKW22D5
 
@@ -19,7 +19,7 @@ if SOC_MKW24D5
 
 config SOC
 	string
-	default mkw24d5
+	default "mkw24d5"
 
 endif # SOC_MKW24D5
 

--- a/arch/arm/soc/nxp_kinetis/kwx/Kconfig.defconfig.mkw40z4
+++ b/arch/arm/soc/nxp_kinetis/kwx/Kconfig.defconfig.mkw40z4
@@ -9,7 +9,7 @@ if SOC_MKW40Z4
 
 config SOC
 	string
-	default mkw40z4
+	default "mkw40z4"
 
 config NUM_IRQS
 	int

--- a/arch/arm/soc/nxp_kinetis/kwx/Kconfig.defconfig.mkw41z4
+++ b/arch/arm/soc/nxp_kinetis/kwx/Kconfig.defconfig.mkw41z4
@@ -9,7 +9,7 @@ if SOC_MKW41Z4
 
 config SOC
 	string
-	default mkw41z4
+	default "mkw41z4"
 
 config NUM_IRQS
 	int

--- a/arch/arm/soc/nxp_kinetis/kwx/Kconfig.defconfig.series
+++ b/arch/arm/soc/nxp_kinetis/kwx/Kconfig.defconfig.series
@@ -8,7 +8,7 @@
 if SOC_SERIES_KINETIS_KWX
 
 config SOC_SERIES
-	default kwx
+	default "kwx"
 
 gsource "arch/arm/soc/nxp_kinetis/kwx/Kconfig.defconfig.mk*"
 

--- a/arch/arm/soc/nxp_lpc/lpc54xxx/Kconfig.defconfig.lpc54114_m0
+++ b/arch/arm/soc/nxp_lpc/lpc54xxx/Kconfig.defconfig.lpc54114_m0
@@ -10,7 +10,7 @@ if SOC_LPC54114_M0
 
 config SOC
 	string
-	default lpc54114_m0
+	default "lpc54114_m0"
 
 if PINMUX
 

--- a/arch/arm/soc/nxp_lpc/lpc54xxx/Kconfig.defconfig.lpc54114_m4
+++ b/arch/arm/soc/nxp_lpc/lpc54xxx/Kconfig.defconfig.lpc54114_m4
@@ -9,7 +9,7 @@ if SOC_LPC54114_M4
 
 config SOC
 	string
-	default lpc54114
+	default "lpc54114"
 
 if PINMUX
 

--- a/arch/arm/soc/nxp_lpc/lpc54xxx/Kconfig.defconfig.series
+++ b/arch/arm/soc/nxp_lpc/lpc54xxx/Kconfig.defconfig.series
@@ -8,7 +8,7 @@
 if SOC_SERIES_LPC54XXX
 
 config SOC_SERIES
-	default lpc54xxx
+	default "lpc54xxx"
 
 config NUM_IRQS
 	int

--- a/arch/arm/soc/silabs_exx32/efm32wg/Kconfig.defconfig.efm32wg
+++ b/arch/arm/soc/silabs_exx32/efm32wg/Kconfig.defconfig.efm32wg
@@ -10,7 +10,7 @@ if SOC_EFM32WG
 
 config SOC
 	string
-	default efm32wg
+	default "efm32wg"
 
 config GPIO
 	def_bool y

--- a/arch/arm/soc/silabs_exx32/efm32wg/Kconfig.defconfig.series
+++ b/arch/arm/soc/silabs_exx32/efm32wg/Kconfig.defconfig.series
@@ -9,7 +9,7 @@
 if SOC_SERIES_EFM32WG
 
 config SOC_SERIES
-	default efm32wg
+	default "efm32wg"
 
 config NUM_IRQS
 	int

--- a/arch/arm/soc/st_stm32/Kconfig
+++ b/arch/arm/soc/st_stm32/Kconfig
@@ -19,7 +19,7 @@ config BUILD_OUTPUT_HEX
 
 config SOC_FAMILY
 	string
-	default st_stm32
+	default "st_stm32"
 
 config STM32_ARM_MPU_ENABLE
 	bool "Enable MPU on STM32"

--- a/arch/arm/soc/st_stm32/stm32f0/Kconfig.defconfig.series
+++ b/arch/arm/soc/st_stm32/stm32f0/Kconfig.defconfig.series
@@ -10,7 +10,7 @@ if SOC_SERIES_STM32F0X
 gsource "arch/arm/soc/st_stm32/stm32f0/Kconfig.defconfig.stm32f0*"
 
 config SOC_SERIES
-	default stm32f0
+	default "stm32f0"
 
 if GPIO_STM32
 

--- a/arch/arm/soc/st_stm32/stm32f0/Kconfig.defconfig.stm32f030x8
+++ b/arch/arm/soc/st_stm32/stm32f0/Kconfig.defconfig.stm32f030x8
@@ -9,7 +9,7 @@ if SOC_STM32F030X8
 
 config SOC
 	string
-	default stm32f030x8
+	default "stm32f030x8"
 
 config NUM_IRQS
 	int

--- a/arch/arm/soc/st_stm32/stm32f0/Kconfig.defconfig.stm32f051x8
+++ b/arch/arm/soc/st_stm32/stm32f0/Kconfig.defconfig.stm32f051x8
@@ -9,7 +9,7 @@ if SOC_STM32F051X8
 
 config SOC
 	string
-	default stm32f051x8
+	default "stm32f051x8"
 
 config NUM_IRQS
 	int

--- a/arch/arm/soc/st_stm32/stm32f0/Kconfig.defconfig.stm32f070xb
+++ b/arch/arm/soc/st_stm32/stm32f0/Kconfig.defconfig.stm32f070xb
@@ -9,7 +9,7 @@ if SOC_STM32F070XB
 
 config SOC
 	string
-	default stm32f070xb
+	default "stm32f070xb"
 
 config NUM_IRQS
 	int

--- a/arch/arm/soc/st_stm32/stm32f0/Kconfig.defconfig.stm32f072xb
+++ b/arch/arm/soc/st_stm32/stm32f0/Kconfig.defconfig.stm32f072xb
@@ -9,7 +9,7 @@ if SOC_STM32F072XB
 
 config SOC
 	string
-	default stm32f072xb
+	default "stm32f072xb"
 
 config NUM_IRQS
 	int

--- a/arch/arm/soc/st_stm32/stm32f0/Kconfig.defconfig.stm32f091xc
+++ b/arch/arm/soc/st_stm32/stm32f0/Kconfig.defconfig.stm32f091xc
@@ -9,7 +9,7 @@ if SOC_STM32F091XC
 
 config SOC
 	string
-	default stm32f091xc
+	default "stm32f091xc"
 
 config NUM_IRQS
 	int

--- a/arch/arm/soc/st_stm32/stm32f1/Kconfig.defconfig.series
+++ b/arch/arm/soc/st_stm32/stm32f1/Kconfig.defconfig.series
@@ -10,7 +10,7 @@ if SOC_SERIES_STM32F1X
 gsource "arch/arm/soc/st_stm32/stm32f1/Kconfig.defconfig.stm32f1*"
 
 config SOC_SERIES
-	default stm32f1
+	default "stm32f1"
 
 if GPIO_STM32
 

--- a/arch/arm/soc/st_stm32/stm32f1/Kconfig.defconfig.stm32f103xx
+++ b/arch/arm/soc/st_stm32/stm32f1/Kconfig.defconfig.stm32f103xx
@@ -9,7 +9,7 @@ if SOC_STM32F103XB || SOC_STM32F103X8
 
 config SOC
 	string
-	default stm32f103xb
+	default "stm32f103xb"
 
 config NUM_IRQS
 	int
@@ -28,7 +28,7 @@ if SOC_STM32F103XE
 
 config SOC
 	string
-	default stm32f103xe
+	default "stm32f103xe"
 
 config NUM_IRQS
 	int

--- a/arch/arm/soc/st_stm32/stm32f1/Kconfig.defconfig.stm32f107xc
+++ b/arch/arm/soc/st_stm32/stm32f1/Kconfig.defconfig.stm32f107xc
@@ -9,7 +9,7 @@ if SOC_STM32F107XC
 
 config SOC
 	string
-	default stm32f107xc
+	default "stm32f107xc"
 
 config NUM_IRQS
 	int

--- a/arch/arm/soc/st_stm32/stm32f3/Kconfig.defconfig.series
+++ b/arch/arm/soc/st_stm32/stm32f3/Kconfig.defconfig.series
@@ -10,7 +10,7 @@ if SOC_SERIES_STM32F3X
 gsource "arch/arm/soc/st_stm32/stm32f3/Kconfig.defconfig.stm32f3*"
 
 config SOC_SERIES
-	default stm32f3
+	default "stm32f3"
 
 if GPIO_STM32
 

--- a/arch/arm/soc/st_stm32/stm32f3/Kconfig.defconfig.stm32f303xc
+++ b/arch/arm/soc/st_stm32/stm32f3/Kconfig.defconfig.stm32f303xc
@@ -9,7 +9,7 @@ if SOC_STM32F303XC
 
 config SOC
 	string
-	default stm32f303xc
+	default "stm32f303xc"
 
 config FLASH_PAGE_SIZE
 	hex

--- a/arch/arm/soc/st_stm32/stm32f3/Kconfig.defconfig.stm32f334x8
+++ b/arch/arm/soc/st_stm32/stm32f3/Kconfig.defconfig.stm32f334x8
@@ -9,7 +9,7 @@ if SOC_STM32F334X8
 
 config SOC
 	string
-	default stm32f334x8
+	default "stm32f334x8"
 
 config FLASH_PAGE_SIZE
 	hex

--- a/arch/arm/soc/st_stm32/stm32f3/Kconfig.defconfig.stm32f373xc
+++ b/arch/arm/soc/st_stm32/stm32f3/Kconfig.defconfig.stm32f373xc
@@ -9,7 +9,7 @@ if SOC_STM32F373XC
 
 config SOC
 	string
-	default stm32f373xc
+	default "stm32f373xc"
 
 config FLASH_PAGE_SIZE
 	hex

--- a/arch/arm/soc/st_stm32/stm32f4/Kconfig.defconfig.series
+++ b/arch/arm/soc/st_stm32/stm32f4/Kconfig.defconfig.series
@@ -10,7 +10,7 @@ if SOC_SERIES_STM32F4X
 gsource "arch/arm/soc/st_stm32/stm32f4/Kconfig.defconfig.stm32f4*"
 
 config SOC_SERIES
-	default stm32f4
+	default "stm32f4"
 
 if GPIO_STM32
 

--- a/arch/arm/soc/st_stm32/stm32f4/Kconfig.defconfig.stm32f401xe
+++ b/arch/arm/soc/st_stm32/stm32f4/Kconfig.defconfig.stm32f401xe
@@ -9,7 +9,7 @@ if SOC_STM32F401XE
 
 config SOC
 	string
-	default stm32f401xe
+	default "stm32f401xe"
 
 config NUM_IRQS
 	int

--- a/arch/arm/soc/st_stm32/stm32f4/Kconfig.defconfig.stm32f405xx
+++ b/arch/arm/soc/st_stm32/stm32f4/Kconfig.defconfig.stm32f405xx
@@ -9,7 +9,7 @@ if SOC_STM32F405XG
 
 config SOC
 	string
-	default stm32f405xx
+	default "stm32f405xx"
 
 config NUM_IRQS
 	int

--- a/arch/arm/soc/st_stm32/stm32f4/Kconfig.defconfig.stm32f407xx
+++ b/arch/arm/soc/st_stm32/stm32f4/Kconfig.defconfig.stm32f407xx
@@ -9,7 +9,7 @@ if SOC_STM32F407XG
 
 config SOC
 	string
-	default stm32f407xx
+	default "stm32f407xx"
 
 config NUM_IRQS
 	int

--- a/arch/arm/soc/st_stm32/stm32f4/Kconfig.defconfig.stm32f411xe
+++ b/arch/arm/soc/st_stm32/stm32f4/Kconfig.defconfig.stm32f411xe
@@ -9,7 +9,7 @@ if SOC_STM32F411XE
 
 config SOC
 	string
-	default stm32f411xe
+	default "stm32f411xe"
 
 config NUM_IRQS
 	int

--- a/arch/arm/soc/st_stm32/stm32f4/Kconfig.defconfig.stm32f412cg
+++ b/arch/arm/soc/st_stm32/stm32f4/Kconfig.defconfig.stm32f412cg
@@ -9,7 +9,7 @@ if SOC_STM32F412CG
 
 config SOC
 	string
-	default stm32f412cx
+	default "stm32f412cx"
 
 config NUM_IRQS
 	int

--- a/arch/arm/soc/st_stm32/stm32f4/Kconfig.defconfig.stm32f412zg
+++ b/arch/arm/soc/st_stm32/stm32f4/Kconfig.defconfig.stm32f412zg
@@ -9,7 +9,7 @@ if SOC_STM32F412ZG
 
 config SOC
 	string
-	default stm32f412zx
+	default "stm32f412zx"
 
 config NUM_IRQS
 	int

--- a/arch/arm/soc/st_stm32/stm32f4/Kconfig.defconfig.stm32f413xx
+++ b/arch/arm/soc/st_stm32/stm32f4/Kconfig.defconfig.stm32f413xx
@@ -9,7 +9,7 @@ if SOC_STM32F413XH
 
 config SOC
 	string
-	default stm32f413xx
+	default "stm32f413xx"
 
 config NUM_IRQS
 	int

--- a/arch/arm/soc/st_stm32/stm32f4/Kconfig.defconfig.stm32f417xx
+++ b/arch/arm/soc/st_stm32/stm32f4/Kconfig.defconfig.stm32f417xx
@@ -9,7 +9,7 @@ if SOC_STM32F417XE || SOC_STM32F417XG
 
 config SOC
 	string
-	default stm32f417xx
+	default "stm32f417xx"
 
 config NUM_IRQS
 	int

--- a/arch/arm/soc/st_stm32/stm32f4/Kconfig.defconfig.stm32f429xx
+++ b/arch/arm/soc/st_stm32/stm32f4/Kconfig.defconfig.stm32f429xx
@@ -9,7 +9,7 @@ if SOC_STM32F429XI
 
 config SOC
 	string
-	default stm32f429xx
+	default "stm32f429xx"
 
 config NUM_IRQS
 	int

--- a/arch/arm/soc/st_stm32/stm32f4/Kconfig.defconfig.stm32f446xe
+++ b/arch/arm/soc/st_stm32/stm32f4/Kconfig.defconfig.stm32f446xe
@@ -9,7 +9,7 @@ if SOC_STM32F446XE
 
 config SOC
 	string
-	default stm32f446xx
+	default "stm32f446xx"
 
 config NUM_IRQS
 	int

--- a/arch/arm/soc/st_stm32/stm32f4/Kconfig.defconfig.stm32f469xi
+++ b/arch/arm/soc/st_stm32/stm32f4/Kconfig.defconfig.stm32f469xi
@@ -9,7 +9,7 @@ if SOC_STM32F469XI
 
 config SOC
 	string
-	default stm32f469xx
+	default "stm32f469xx"
 
 config NUM_IRQS
 	int

--- a/arch/arm/soc/st_stm32/stm32l0/Kconfig.defconfig.series
+++ b/arch/arm/soc/st_stm32/stm32l0/Kconfig.defconfig.series
@@ -10,7 +10,7 @@ if SOC_SERIES_STM32L0X
 gsource "arch/arm/soc/st_stm32/stm32l0/Kconfig.defconfig.stm32l0*"
 
 config SOC_SERIES
-	default stm32l0
+	default "stm32l0"
 
 if GPIO_STM32
 

--- a/arch/arm/soc/st_stm32/stm32l0/Kconfig.defconfig.stm32l053x8
+++ b/arch/arm/soc/st_stm32/stm32l0/Kconfig.defconfig.stm32l053x8
@@ -9,7 +9,7 @@ if SOC_STM32L053X8
 
 config SOC
 	string
-	default stm32l053xx
+	default "stm32l053xx"
 
 config NUM_IRQS
 	int

--- a/arch/arm/soc/st_stm32/stm32l0/Kconfig.defconfig.stm32l072xz
+++ b/arch/arm/soc/st_stm32/stm32l0/Kconfig.defconfig.stm32l072xz
@@ -9,7 +9,7 @@ if SOC_STM32L072XZ
 
 config SOC
 	string
-	default stm32l072xx
+	default "stm32l072xx"
 
 config NUM_IRQS
 	int

--- a/arch/arm/soc/st_stm32/stm32l0/Kconfig.defconfig.stm32l073xz
+++ b/arch/arm/soc/st_stm32/stm32l0/Kconfig.defconfig.stm32l073xz
@@ -9,7 +9,7 @@ if SOC_STM32L073XZ
 
 config SOC
 	string
-	default stm32l073xx
+	default "stm32l073xx"
 
 config NUM_IRQS
 	int

--- a/arch/arm/soc/st_stm32/stm32l4/Kconfig.defconfig.series
+++ b/arch/arm/soc/st_stm32/stm32l4/Kconfig.defconfig.series
@@ -11,7 +11,7 @@ if SOC_SERIES_STM32L4X
 gsource "arch/arm/soc/st_stm32/stm32l4/Kconfig.defconfig.stm32l4*"
 
 config SOC_SERIES
-	default stm32l4
+	default "stm32l4"
 
 if I2C_STM32
 

--- a/arch/arm/soc/st_stm32/stm32l4/Kconfig.defconfig.stm32l432xx
+++ b/arch/arm/soc/st_stm32/stm32l4/Kconfig.defconfig.stm32l432xx
@@ -10,7 +10,7 @@ if SOC_STM32L432XC
 
 config SOC
 	string
-	default stm32l432xx
+	default "stm32l432xx"
 
 config NUM_IRQS
 	int

--- a/arch/arm/soc/st_stm32/stm32l4/Kconfig.defconfig.stm32l475xg
+++ b/arch/arm/soc/st_stm32/stm32l4/Kconfig.defconfig.stm32l475xg
@@ -9,7 +9,7 @@ if SOC_STM32L475XG
 
 config SOC
 	string
-	default stm32l475xx
+	default "stm32l475xx"
 
 config NUM_IRQS
 	int

--- a/arch/arm/soc/st_stm32/stm32l4/Kconfig.defconfig.stm32l476xx
+++ b/arch/arm/soc/st_stm32/stm32l4/Kconfig.defconfig.stm32l476xx
@@ -10,7 +10,7 @@ if SOC_STM32L476XG
 
 config SOC
 	string
-	default stm32l476xx
+	default "stm32l476xx"
 
 config NUM_IRQS
 	int

--- a/arch/arm/soc/st_stm32/stm32l4/Kconfig.defconfig.stm32l496xx
+++ b/arch/arm/soc/st_stm32/stm32l4/Kconfig.defconfig.stm32l496xx
@@ -10,7 +10,7 @@ if SOC_STM32L496XG
 
 config SOC
 	string
-	default stm32l496xx
+	default "stm32l496xx"
 
 config NUM_IRQS
 	int

--- a/arch/arm/soc/ti_lm3s6965/Kconfig.defconfig
+++ b/arch/arm/soc/ti_lm3s6965/Kconfig.defconfig
@@ -9,7 +9,7 @@
 if SOC_TI_LM3S6965
 
 config SOC
-	default ti_lm3s6965
+	default "ti_lm3s6965"
 
 config NUM_IRQS
 	int

--- a/arch/arm/soc/ti_simplelink/Kconfig
+++ b/arch/arm/soc/ti_simplelink/Kconfig
@@ -9,7 +9,7 @@ config SOC_FAMILY_TISIMPLELINK
 if SOC_FAMILY_TISIMPLELINK
 config SOC_FAMILY
 	string
-	default ti_simplelink
+	default "ti_simplelink"
 
 gsource "arch/arm/soc/ti_simplelink/*/Kconfig.soc"
 endif # SOC_FAMILY_TISIMPLELINK

--- a/arch/arm/soc/ti_simplelink/cc2650/Kconfig.defconfig.series
+++ b/arch/arm/soc/ti_simplelink/cc2650/Kconfig.defconfig.series
@@ -6,7 +6,7 @@
 if SOC_SERIES_CC2650
 
 config SOC_SERIES
-	default cc2650
+	default "cc2650"
 
 config SYS_CLOCK_HW_CYCLES_PER_SEC
 	default 48000000

--- a/arch/arm/soc/ti_simplelink/cc32xx/Kconfig.defconfig.cc3220sf
+++ b/arch/arm/soc/ti_simplelink/cc32xx/Kconfig.defconfig.cc3220sf
@@ -5,7 +5,7 @@ if SOC_CC3220SF
 
 config SOC
 	string
-	default cc3220sf
+	default "cc3220sf"
 
 config NUM_IRQS
 	int

--- a/arch/arm/soc/ti_simplelink/cc32xx/Kconfig.defconfig.series
+++ b/arch/arm/soc/ti_simplelink/cc32xx/Kconfig.defconfig.series
@@ -6,6 +6,6 @@ if SOC_SERIES_CC32XX
 gsource "arch/arm/soc/ti_simplelink/cc32xx/Kconfig.defconfig.cc32*"
 
 config SOC_SERIES
-	default cc32xx
+	default "cc32xx"
 
 endif # SOC_SERIES_CC32XX

--- a/arch/arm/soc/ti_simplelink/msp432p4xx/Kconfig.defconfig.msp432p401r
+++ b/arch/arm/soc/ti_simplelink/msp432p4xx/Kconfig.defconfig.msp432p401r
@@ -9,7 +9,7 @@ if SOC_MSP432P401R
 
 config SOC
 	string
-	default msp432p401r
+	default "msp432p401r"
 
 config SYS_CLOCK_HW_CYCLES_PER_SEC
 	int

--- a/arch/arm/soc/ti_simplelink/msp432p4xx/Kconfig.defconfig.series
+++ b/arch/arm/soc/ti_simplelink/msp432p4xx/Kconfig.defconfig.series
@@ -10,6 +10,6 @@ if SOC_SERIES_MSP432P4XX
 gsource "arch/arm/soc/ti_simplelink/msp432p4xx/Kconfig.defconfig.msp432p4*"
 
 config SOC_SERIES
-	default msp432p4xx
+	default "msp432p4xx"
 
 endif # SOC_SERIES_MSP432P4XX

--- a/arch/nios2/soc/nios2-qemu/Kconfig.defconfig
+++ b/arch/nios2/soc/nios2-qemu/Kconfig.defconfig
@@ -2,7 +2,7 @@ if SOC_NIOS2_QEMU
 
 config SOC
 	string
-	default nios2-qemu
+	default "nios2-qemu"
 
 config SYS_CLOCK_HW_CYCLES_PER_SEC
 	int

--- a/arch/nios2/soc/nios2f-zephyr/Kconfig.defconfig
+++ b/arch/nios2/soc/nios2f-zephyr/Kconfig.defconfig
@@ -2,7 +2,7 @@ if SOC_NIOS2F_ZEPHYR
 
 config SOC
 	string
-	default nios2f-zephyr
+	default "nios2f-zephyr"
 
 config SYS_CLOCK_HW_CYCLES_PER_SEC
 	int

--- a/arch/posix/soc/inf_clock/Kconfig.defconfig
+++ b/arch/posix/soc/inf_clock/Kconfig.defconfig
@@ -7,6 +7,6 @@
 if SOC_POSIX
 
 config SOC
-	default inf_clock
+	default "inf_clock"
 
 endif

--- a/arch/x86/soc/atom/Kconfig.defconfig
+++ b/arch/x86/soc/atom/Kconfig.defconfig
@@ -9,7 +9,7 @@
 if SOC_ATOM
 
 config SOC
-	default atom
+	default "atom"
 
 config SYS_CLOCK_HW_CYCLES_PER_SEC
 	default 150000000 if LOAPIC_TIMER

--- a/arch/x86/soc/ia32/Kconfig.defconfig
+++ b/arch/x86/soc/ia32/Kconfig.defconfig
@@ -9,7 +9,7 @@
 if SOC_IA32
 
 config SOC
-	default ia32
+	default "ia32"
 
 config SYS_CLOCK_HW_CYCLES_PER_SEC
 	default 150000000 if LOAPIC_TIMER

--- a/arch/x86/soc/intel_quark/quark_d2000/Kconfig.defconfig.quark_d2000
+++ b/arch/x86/soc/intel_quark/quark_d2000/Kconfig.defconfig.quark_d2000
@@ -9,6 +9,6 @@
 if SOC_QUARK_D2000
 
 config SOC
-	default quark_d2000
+	default "quark_d2000"
 
 endif # SOC_QUARK_D2000

--- a/arch/x86/soc/intel_quark/quark_d2000/Kconfig.defconfig.series
+++ b/arch/x86/soc/intel_quark/quark_d2000/Kconfig.defconfig.series
@@ -7,7 +7,7 @@
 if SOC_SERIES_QUARK_D2000
 
 config SOC_SERIES
-	default quark_d2000
+	default "quark_d2000"
 
 config X86_IAMCU
         def_bool y

--- a/arch/x86/soc/intel_quark/quark_se/Kconfig.defconfig.curie
+++ b/arch/x86/soc/intel_quark/quark_se/Kconfig.defconfig.curie
@@ -9,6 +9,6 @@
 if SOC_QUARK_SE_CURIE
 
 config SOC
-	default curie
+	default "curie"
 
 endif

--- a/arch/x86/soc/intel_quark/quark_se/Kconfig.defconfig.quark_se_c1000
+++ b/arch/x86/soc/intel_quark/quark_se/Kconfig.defconfig.quark_se_c1000
@@ -9,6 +9,6 @@
 if SOC_QUARK_SE_C1000
 
 config SOC
-	default quark_se_c1000
+	default "quark_se_c1000"
 
 endif

--- a/arch/x86/soc/intel_quark/quark_se/Kconfig.defconfig.series
+++ b/arch/x86/soc/intel_quark/quark_se/Kconfig.defconfig.series
@@ -7,7 +7,7 @@
 if SOC_SERIES_QUARK_SE
 
 config SOC_SERIES
-	default quark_se
+	default "quark_se"
 
 config X86_IAMCU
 	def_bool y

--- a/arch/x86/soc/intel_quark/quark_x1000/Kconfig.defconfig.quark_x1000
+++ b/arch/x86/soc/intel_quark/quark_x1000/Kconfig.defconfig.quark_x1000
@@ -9,6 +9,6 @@
 if SOC_QUARK_X1000
 
 config SOC
-	default quark_x1000
+	default "quark_x1000"
 
 endif # SOC_QUARK_X1000

--- a/arch/x86/soc/intel_quark/quark_x1000/Kconfig.defconfig.series
+++ b/arch/x86/soc/intel_quark/quark_x1000/Kconfig.defconfig.series
@@ -10,7 +10,7 @@
 if SOC_SERIES_QUARK_X1000
 
 config SOC_SERIES
-	default quark_x1000
+	default "quark_x1000"
 
 config SYS_CLOCK_HW_CYCLES_PER_SEC
 	default 25000000  if HPET_TIMER

--- a/arch/xtensa/soc/D_108mini/Kconfig.defconfig
+++ b/arch/xtensa/soc/D_108mini/Kconfig.defconfig
@@ -8,7 +8,7 @@ if SOC_D_108MINI
 
 config SOC
 	string
-	default D_108mini
+	default "D_108mini"
 
 config IRQ_OFFLOAD_INTNUM
 	default 7

--- a/arch/xtensa/soc/D_212GP/Kconfig.defconfig
+++ b/arch/xtensa/soc/D_212GP/Kconfig.defconfig
@@ -8,7 +8,7 @@ if SOC_D_212GP
 
 config SOC
 	string
-	default D_212GP
+	default "D_212GP"
 
 config IRQ_OFFLOAD_INTNUM
 	default 7

--- a/arch/xtensa/soc/D_233L/Kconfig.defconfig
+++ b/arch/xtensa/soc/D_233L/Kconfig.defconfig
@@ -8,7 +8,7 @@ if SOC_D_233L
 
 config SOC
 	string
-	default D_233L
+	default "D_233L"
 
 config IRQ_OFFLOAD_INTNUM
 	default 7

--- a/arch/xtensa/soc/XRC_D2PM_5swIrq/Kconfig.defconfig
+++ b/arch/xtensa/soc/XRC_D2PM_5swIrq/Kconfig.defconfig
@@ -8,7 +8,7 @@ if SOC_XRC_D2PM_5SWIRQ
 
 config SOC
 	string
-	default XRC_D2PM_5swIrq
+	default "XRC_D2PM_5swIrq"
 
 config IRQ_OFFLOAD_INTNUM
 	default 22

--- a/arch/xtensa/soc/XRC_FUSION_AON_ALL_LM/Kconfig.defconfig
+++ b/arch/xtensa/soc/XRC_FUSION_AON_ALL_LM/Kconfig.defconfig
@@ -8,7 +8,7 @@ if SOC_XRC_FUSION_AON_ALL_LM
 
 config SOC
 	string
-	default XRC_FUSION_AON_ALL_LM
+	default "XRC_FUSION_AON_ALL_LM"
 
 config IRQ_OFFLOAD_INTNUM
 	default 13

--- a/arch/xtensa/soc/esp32/Kconfig.defconfig
+++ b/arch/xtensa/soc/esp32/Kconfig.defconfig
@@ -7,7 +7,7 @@ if SOC_ESP32
 
 config SOC
 	string
-	default esp32
+	default "esp32"
 
 config IRQ_OFFLOAD_INTNUM
 	default 7

--- a/arch/xtensa/soc/hifi2_std/Kconfig.defconfig
+++ b/arch/xtensa/soc/hifi2_std/Kconfig.defconfig
@@ -8,7 +8,7 @@ if SOC_HIFI2_STD
 
 config SOC
 	string
-	default hifi2_std
+	default "hifi2_std"
 
 config IRQ_OFFLOAD_INTNUM
 	default 7

--- a/arch/xtensa/soc/hifi3_bd5/Kconfig.defconfig
+++ b/arch/xtensa/soc/hifi3_bd5/Kconfig.defconfig
@@ -8,7 +8,7 @@ if SOC_HIFI3_BD5
 
 config SOC
 	string
-	default hifi3_bd5
+	default "hifi3_bd5"
 
 config IRQ_OFFLOAD_INTNUM
 	default 13

--- a/arch/xtensa/soc/hifi3_bd5_call0/Kconfig.defconfig
+++ b/arch/xtensa/soc/hifi3_bd5_call0/Kconfig.defconfig
@@ -8,7 +8,7 @@ if SOC_HIFI3_BD5_CALL0
 
 config SOC
 	string
-	default hifi3_bd5_call0
+	default "hifi3_bd5_call0"
 
 config IRQ_OFFLOAD_INTNUM
 	default 13

--- a/arch/xtensa/soc/hifi4_bd7/Kconfig.defconfig
+++ b/arch/xtensa/soc/hifi4_bd7/Kconfig.defconfig
@@ -8,7 +8,7 @@ if SOC_HIFI4_BD7
 
 config SOC
 	string
-	default hifi4_bd7
+	default "hifi4_bd7"
 
 config IRQ_OFFLOAD_INTNUM
 	default 4

--- a/arch/xtensa/soc/hifi_mini/Kconfig.defconfig
+++ b/arch/xtensa/soc/hifi_mini/Kconfig.defconfig
@@ -8,7 +8,7 @@ if SOC_HIFI_MINI
 
 config SOC
 	string
-	default hifi_mini
+	default "hifi_mini"
 
 config IRQ_OFFLOAD_INTNUM
 	default 13

--- a/arch/xtensa/soc/hifi_mini_4swIrq/Kconfig.defconfig
+++ b/arch/xtensa/soc/hifi_mini_4swIrq/Kconfig.defconfig
@@ -8,7 +8,7 @@ if SOC_HIFI_MINI_4SWIRQ
 
 config SOC
 	string
-	default hifi_mini_4swIrq
+	default "hifi_mini_4swIrq"
 
 config IRQ_OFFLOAD_INTNUM
 	default 1

--- a/arch/xtensa/soc/intel_s1000/Kconfig.defconfig
+++ b/arch/xtensa/soc/intel_s1000/Kconfig.defconfig
@@ -7,7 +7,7 @@ if SOC_INTEL_S1000
 
 config SOC
 	string
-	default intel_s1000
+	default "intel_s1000"
 
 config IRQ_OFFLOAD_INTNUM
 	default 0

--- a/arch/xtensa/soc/sample_controller/Kconfig.defconfig
+++ b/arch/xtensa/soc/sample_controller/Kconfig.defconfig
@@ -8,7 +8,7 @@ if SOC_XTENSA_SAMPLE_CONTROLLER
 
 config SOC
 	string
-	default sample_controller
+	default "sample_controller"
 
 config IRQ_OFFLOAD_INTNUM
 	default 7

--- a/boards/arm/96b_argonkey/Kconfig.defconfig
+++ b/boards/arm/96b_argonkey/Kconfig.defconfig
@@ -8,7 +8,7 @@
 if BOARD_96B_ARGONKEY
 
 config BOARD
-	default 96b_argonkey
+	default "96b_argonkey"
 
 if UART_CONSOLE
 

--- a/boards/arm/96b_carbon/Kconfig.defconfig
+++ b/boards/arm/96b_carbon/Kconfig.defconfig
@@ -8,7 +8,7 @@
 if BOARD_96B_CARBON
 
 config BOARD
-	default 96b_carbon
+	default "96b_carbon"
 
 if UART_CONSOLE
 

--- a/boards/arm/96b_carbon_nrf51/Kconfig.defconfig
+++ b/boards/arm/96b_carbon_nrf51/Kconfig.defconfig
@@ -7,7 +7,7 @@
 if BOARD_96B_CARBON_NRF51
 
 config BOARD
-	default 96b_carbon_nrf51
+	default "96b_carbon_nrf51"
 
 if UART_NRF5
 

--- a/boards/arm/96b_neonkey/Kconfig.defconfig
+++ b/boards/arm/96b_neonkey/Kconfig.defconfig
@@ -8,7 +8,7 @@
 if BOARD_96B_NEONKEY
 
 config BOARD
-	default 96b_neonkey
+	default "96b_neonkey"
 
 if UART_CONSOLE
 

--- a/boards/arm/96b_nitrogen/Kconfig.defconfig
+++ b/boards/arm/96b_nitrogen/Kconfig.defconfig
@@ -7,7 +7,7 @@
 if BOARD_96B_NITROGEN
 
 config BOARD
-	default 96b_nitrogen
+	default "96b_nitrogen"
 
 if GPIO_NRF5
 

--- a/boards/arm/adafruit_feather_m0_basic_proto/Kconfig.defconfig
+++ b/boards/arm/adafruit_feather_m0_basic_proto/Kconfig.defconfig
@@ -7,6 +7,6 @@
 if BOARD_ADAFRUIT_FEATHER_M0_BASIC_PROTO
 
 config BOARD
-	default adafruit_feather_m0_basic_proto
+	default "adafruit_feather_m0_basic_proto"
 
 endif

--- a/boards/arm/adafruit_trinket_m0/Kconfig.defconfig
+++ b/boards/arm/adafruit_trinket_m0/Kconfig.defconfig
@@ -6,6 +6,6 @@
 if BOARD_ADAFRUIT_TRINKET_M0
 
 config BOARD
-	default adafruit_trinket_m0
+	default "adafruit_trinket_m0"
 
 endif

--- a/boards/arm/arduino_due/Kconfig.defconfig
+++ b/boards/arm/arduino_due/Kconfig.defconfig
@@ -7,7 +7,7 @@
 if BOARD_ARDUINO_DUE
 
 config BOARD
-	default arduino_due
+	default "arduino_due"
 
 if GPIO
 

--- a/boards/arm/arduino_zero/Kconfig.defconfig
+++ b/boards/arm/arduino_zero/Kconfig.defconfig
@@ -6,6 +6,6 @@
 if BOARD_ARDUINO_ZERO
 
 config BOARD
-	default arduino_zero
+	default "arduino_zero"
 
 endif # BOARD_ARDUINO_ZERO

--- a/boards/arm/bbc_microbit/Kconfig.defconfig
+++ b/boards/arm/bbc_microbit/Kconfig.defconfig
@@ -7,7 +7,7 @@
 if BOARD_BBC_MICROBIT
 
 config BOARD
-	default bbc_microbit
+	default "bbc_microbit"
 
 if GPIO_NRF5
 

--- a/boards/arm/cc2650_sensortag/Kconfig.defconfig
+++ b/boards/arm/cc2650_sensortag/Kconfig.defconfig
@@ -6,6 +6,6 @@
 if BOARD_CC2650_SENSORTAG
 
 config BOARD
-	default cc2650_sensortag
+	default "cc2650_sensortag"
 
 endif # BOARD_CC2650_SENSORTAG

--- a/boards/arm/cc3220sf_launchxl/Kconfig.defconfig
+++ b/boards/arm/cc3220sf_launchxl/Kconfig.defconfig
@@ -4,7 +4,7 @@
 if BOARD_CC3220SF_LAUNCHXL
 
 config BOARD
-	default cc3220sf_launchxl
+	default "cc3220sf_launchxl"
 
 if I2C
 

--- a/boards/arm/colibri_imx7d_m4/Kconfig.defconfig
+++ b/boards/arm/colibri_imx7d_m4/Kconfig.defconfig
@@ -8,7 +8,7 @@
 if BOARD_COLIBRI_IMX7D_M4
 
 config BOARD
-	default colibri_imx7d_m4
+	default "colibri_imx7d_m4"
 
 if GPIO_IMX
 

--- a/boards/arm/curie_ble/Kconfig.defconfig
+++ b/boards/arm/curie_ble/Kconfig.defconfig
@@ -7,7 +7,7 @@
 if BOARD_CURIE_BLE
 
 config BOARD
-	default curie_ble
+	default "curie_ble"
 
 if UART_NRF5
 

--- a/boards/arm/disco_l475_iot1/Kconfig.defconfig
+++ b/boards/arm/disco_l475_iot1/Kconfig.defconfig
@@ -8,7 +8,7 @@
 if BOARD_DISCO_L475_IOT1
 
 config BOARD
-	default disco_l475_iot1
+	default "disco_l475_iot1"
 
 if CLOCK_STM32_SYSCLK_SRC_PLL
 

--- a/boards/arm/dragino_lsn50/Kconfig.defconfig
+++ b/boards/arm/dragino_lsn50/Kconfig.defconfig
@@ -8,7 +8,7 @@
 if BOARD_DRAGINO_LSN50
 
 config BOARD
-	default dragino_lsn50
+	default "dragino_lsn50"
 
 if UART_CONSOLE
 

--- a/boards/arm/efm32wg_stk3800/Kconfig.defconfig
+++ b/boards/arm/efm32wg_stk3800/Kconfig.defconfig
@@ -8,7 +8,7 @@
 if BOARD_EFM32WG_STK3800
 
 config BOARD
-	default efm32wg_stk3800
+	default "efm32wg_stk3800"
 
 config CMU_HFXO_FREQ
 	default 48000000

--- a/boards/arm/frdm_k64f/Kconfig.defconfig
+++ b/boards/arm/frdm_k64f/Kconfig.defconfig
@@ -8,7 +8,7 @@
 if BOARD_FRDM_K64F
 
 config BOARD
-	default frdm_k64f
+	default "frdm_k64f"
 
 config OSC_XTAL0_FREQ
 	default 50000000

--- a/boards/arm/frdm_kl25z/Kconfig.defconfig
+++ b/boards/arm/frdm_kl25z/Kconfig.defconfig
@@ -8,7 +8,7 @@
 if BOARD_FRDM_KL25Z
 
 config BOARD
-	default frdm_kl25z
+	default "frdm_kl25z"
 
 config OSC_XTAL0_FREQ
 	default 8000000

--- a/boards/arm/frdm_kw41z/Kconfig.defconfig
+++ b/boards/arm/frdm_kw41z/Kconfig.defconfig
@@ -8,7 +8,7 @@
 if BOARD_FRDM_KW41Z
 
 config BOARD
-	default frdm_kw41z
+	default "frdm_kw41z"
 
 config OSC_XTAL0_FREQ
 	default 32000000

--- a/boards/arm/hexiwear_k64/Kconfig.defconfig
+++ b/boards/arm/hexiwear_k64/Kconfig.defconfig
@@ -8,7 +8,7 @@
 if BOARD_HEXIWEAR_K64
 
 config BOARD
-	default hexiwear_k64
+	default "hexiwear_k64"
 
 config OSC_XTAL0_FREQ
 	default 12000000

--- a/boards/arm/hexiwear_kw40z/Kconfig.defconfig
+++ b/boards/arm/hexiwear_kw40z/Kconfig.defconfig
@@ -8,7 +8,7 @@
 if BOARD_HEXIWEAR_KW40Z
 
 config BOARD
-	default hexiwear_kw40z
+	default "hexiwear_kw40z"
 
 config OSC_XTAL0_FREQ
 	default 32000000

--- a/boards/arm/lpcxpresso54114_m0/Kconfig.defconfig
+++ b/boards/arm/lpcxpresso54114_m0/Kconfig.defconfig
@@ -8,7 +8,7 @@
 if BOARD_LPCXPRESSO54114_M0
 
 config BOARD
-	default lpcxpresso54114_m0
+	default "lpcxpresso54114_m0"
 
 if USART_MCUX_LPC
 config USART_MCUX_LPC_0

--- a/boards/arm/lpcxpresso54114_m4/Kconfig.defconfig
+++ b/boards/arm/lpcxpresso54114_m4/Kconfig.defconfig
@@ -8,7 +8,7 @@
 if BOARD_LPCXPRESSO54114_M4
 
 config BOARD
-	default lpcxpresso54114_m4
+	default "lpcxpresso54114_m4"
 
 if USART_MCUX_LPC
 

--- a/boards/arm/mimxrt1050_evk/Kconfig.defconfig
+++ b/boards/arm/mimxrt1050_evk/Kconfig.defconfig
@@ -8,7 +8,7 @@
 if BOARD_MIMXRT1050_EVK
 
 config BOARD
-	default mimxrt1050_evk
+	default "mimxrt1050_evk"
 
 if GPIO_MCUX_IGPIO
 

--- a/boards/arm/mps2_an385/Kconfig.defconfig
+++ b/boards/arm/mps2_an385/Kconfig.defconfig
@@ -7,7 +7,7 @@
 if BOARD_MPS2_AN385
 
 config BOARD
-	default mps2_an385
+	default "mps2_an385"
 
 if GPIO
 

--- a/boards/arm/msp_exp432p401r_launchxl/Kconfig.defconfig
+++ b/boards/arm/msp_exp432p401r_launchxl/Kconfig.defconfig
@@ -4,6 +4,6 @@
 if BOARD_MSP_EXP432P401R_LAUNCHXL
 
 config BOARD
-	default msp_exp432p401r_launchxl
+	default "msp_exp432p401r_launchxl"
 
 endif # BOARD_MSP_EXP432P401R_LAUNCHXL

--- a/boards/arm/nrf51_ble400/Kconfig.defconfig
+++ b/boards/arm/nrf51_ble400/Kconfig.defconfig
@@ -7,7 +7,7 @@
 if BOARD_NRF51_BLE400
 
 config BOARD
-	default nrf51_ble400
+	default "nrf51_ble400"
 
 if GPIO_NRF5
 

--- a/boards/arm/nrf51_blenano/Kconfig.defconfig
+++ b/boards/arm/nrf51_blenano/Kconfig.defconfig
@@ -7,7 +7,7 @@
 if BOARD_NRF51_BLENANO
 
 config BOARD
-	default nrf51_blenano
+	default "nrf51_blenano"
 
 if GPIO_NRF5
 

--- a/boards/arm/nrf51_pca10028/Kconfig.defconfig
+++ b/boards/arm/nrf51_pca10028/Kconfig.defconfig
@@ -7,7 +7,7 @@
 if BOARD_NRF51_PCA10028
 
 config BOARD
-	default nrf51_pca10028
+	default "nrf51_pca10028"
 
 if GPIO_NRF5
 

--- a/boards/arm/nrf51_vbluno51/Kconfig.defconfig
+++ b/boards/arm/nrf51_vbluno51/Kconfig.defconfig
@@ -7,7 +7,7 @@
 if BOARD_NRF51_VBLUNO51
 
 config BOARD
-	default nrf51_vbluno51
+	default "nrf51_vbluno51"
 
 if GPIO_NRF5
 

--- a/boards/arm/nrf52840_pca10056/Kconfig.defconfig
+++ b/boards/arm/nrf52840_pca10056/Kconfig.defconfig
@@ -7,7 +7,7 @@
 if BOARD_NRF52840_PCA10056
 
 config BOARD
-	default nrf52840_pca10056
+	default "nrf52840_pca10056"
 
 if GPIO_NRF5
 

--- a/boards/arm/nrf52_blenano2/Kconfig.defconfig
+++ b/boards/arm/nrf52_blenano2/Kconfig.defconfig
@@ -7,7 +7,7 @@
 if BOARD_NRF52_BLENANO2
 
 config BOARD
-	default nrf52_blenano2
+	default "nrf52_blenano2"
 
 if GPIO_NRF5
 

--- a/boards/arm/nrf52_pca10040/Kconfig.defconfig
+++ b/boards/arm/nrf52_pca10040/Kconfig.defconfig
@@ -7,7 +7,7 @@
 if BOARD_NRF52_PCA10040
 
 config BOARD
-	default nrf52_pca10040
+	default "nrf52_pca10040"
 
 if GPIO_NRF5
 

--- a/boards/arm/nrf52_pca20020/Kconfig.defconfig
+++ b/boards/arm/nrf52_pca20020/Kconfig.defconfig
@@ -7,7 +7,7 @@
 if BOARD_NRF52_PCA20020
 
 config BOARD
-	default nrf52_pca20020
+	default "nrf52_pca20020"
 
 if GPIO_NRF5
 

--- a/boards/arm/nrf52_sparkfun/Kconfig.defconfig
+++ b/boards/arm/nrf52_sparkfun/Kconfig.defconfig
@@ -8,7 +8,7 @@
 if BOARD_NRF52_SPARKFUN
 
 config BOARD
-	default nrf52_sparkfun
+	default "nrf52_sparkfun"
 
 if GPIO_NRF5
 

--- a/boards/arm/nrf52_vbluno52/Kconfig.defconfig
+++ b/boards/arm/nrf52_vbluno52/Kconfig.defconfig
@@ -7,7 +7,7 @@
 if BOARD_NRF52_VBLUNO52
 
 config BOARD
-	default nrf52_vbluno52
+	default "nrf52_vbluno52"
 
 if GPIO_NRF5
 

--- a/boards/arm/nucleo_f030r8/Kconfig.defconfig
+++ b/boards/arm/nucleo_f030r8/Kconfig.defconfig
@@ -8,7 +8,7 @@
 if BOARD_NUCLEO_F030R8
 
 config BOARD
-	default nucleo_f030r8
+	default "nucleo_f030r8"
 
 if UART_CONSOLE
 

--- a/boards/arm/nucleo_f070rb/Kconfig.defconfig
+++ b/boards/arm/nucleo_f070rb/Kconfig.defconfig
@@ -8,7 +8,7 @@
 if BOARD_NUCLEO_F070RB
 
 config BOARD
-	default nucleo_f070rb
+	default "nucleo_f070rb"
 
 if UART_CONSOLE
 

--- a/boards/arm/nucleo_f091rc/Kconfig.defconfig
+++ b/boards/arm/nucleo_f091rc/Kconfig.defconfig
@@ -8,7 +8,7 @@
 if BOARD_NUCLEO_F091RC
 
 config BOARD
-	default nucleo_f091rc
+	default "nucleo_f091rc"
 
 if UART_CONSOLE
 

--- a/boards/arm/nucleo_f103rb/Kconfig.defconfig
+++ b/boards/arm/nucleo_f103rb/Kconfig.defconfig
@@ -8,7 +8,7 @@
 if BOARD_NUCLEO_F103RB
 
 config BOARD
-	default nucleo_f103rb
+	default "nucleo_f103rb"
 
 if UART_CONSOLE
 

--- a/boards/arm/nucleo_f334r8/Kconfig.defconfig
+++ b/boards/arm/nucleo_f334r8/Kconfig.defconfig
@@ -8,7 +8,7 @@
 if BOARD_NUCLEO_F334R8
 
 config BOARD
-	default nucleo_f334r8
+	default "nucleo_f334r8"
 
 if UART_CONSOLE
 

--- a/boards/arm/nucleo_f401re/Kconfig.defconfig
+++ b/boards/arm/nucleo_f401re/Kconfig.defconfig
@@ -8,7 +8,7 @@
 if BOARD_NUCLEO_F401RE
 
 config BOARD
-	default nucleo_f401re
+	default "nucleo_f401re"
 
 if UART_CONSOLE
 

--- a/boards/arm/nucleo_f411re/Kconfig.defconfig
+++ b/boards/arm/nucleo_f411re/Kconfig.defconfig
@@ -8,7 +8,7 @@
 if BOARD_NUCLEO_F411RE
 
 config BOARD
-	default nucleo_f411re
+	default "nucleo_f411re"
 
 if UART_CONSOLE
 

--- a/boards/arm/nucleo_f412zg/Kconfig.defconfig
+++ b/boards/arm/nucleo_f412zg/Kconfig.defconfig
@@ -8,7 +8,7 @@
 if BOARD_NUCLEO_F412ZG
 
 config BOARD
-	default nucleo_f412zg
+	default "nucleo_f412zg"
 
 if UART_CONSOLE
 

--- a/boards/arm/nucleo_f413zh/Kconfig.defconfig
+++ b/boards/arm/nucleo_f413zh/Kconfig.defconfig
@@ -8,7 +8,7 @@
 if BOARD_NUCLEO_F413ZH
 
 config BOARD
-	default nucleo_f413zh
+	default "nucleo_f413zh"
 
 
 if UART_CONSOLE

--- a/boards/arm/nucleo_f429zi/Kconfig.defconfig
+++ b/boards/arm/nucleo_f429zi/Kconfig.defconfig
@@ -8,7 +8,7 @@
 if BOARD_NUCLEO_F429ZI
 
 config BOARD
-	default nucleo_f429zi
+	default "nucleo_f429zi"
 
 if UART_CONSOLE
 

--- a/boards/arm/nucleo_f446re/Kconfig.defconfig
+++ b/boards/arm/nucleo_f446re/Kconfig.defconfig
@@ -8,7 +8,7 @@
 if BOARD_NUCLEO_F446RE
 
 config BOARD
-	default nucleo_f446re
+	default "nucleo_f446re"
 
 if UART_CONSOLE
 

--- a/boards/arm/nucleo_l053r8/Kconfig.defconfig
+++ b/boards/arm/nucleo_l053r8/Kconfig.defconfig
@@ -8,7 +8,7 @@
 if BOARD_NUCLEO_L053R8
 
 config BOARD
-	default nucleo_l053r8
+	default "nucleo_l053r8"
 
 if UART_CONSOLE
 

--- a/boards/arm/nucleo_l073rz/Kconfig.defconfig
+++ b/boards/arm/nucleo_l073rz/Kconfig.defconfig
@@ -8,7 +8,7 @@
 if BOARD_NUCLEO_L073RZ
 
 config BOARD
-	default nucleo_l073rz
+	default "nucleo_l073rz"
 
 if UART_CONSOLE
 

--- a/boards/arm/nucleo_l432kc/Kconfig.defconfig
+++ b/boards/arm/nucleo_l432kc/Kconfig.defconfig
@@ -9,7 +9,7 @@
 if BOARD_NUCLEO_L432KC
 
 config BOARD
-	default nucleo_l432kc
+	default "nucleo_l432kc"
 
 if UART_CONSOLE
 

--- a/boards/arm/nucleo_l476rg/Kconfig.defconfig
+++ b/boards/arm/nucleo_l476rg/Kconfig.defconfig
@@ -9,7 +9,7 @@
 if BOARD_NUCLEO_L476RG
 
 config BOARD
-	default nucleo_l476rg
+	default "nucleo_l476rg"
 
 if UART_CONSOLE
 

--- a/boards/arm/olimex_stm32_e407/Kconfig.defconfig
+++ b/boards/arm/olimex_stm32_e407/Kconfig.defconfig
@@ -8,7 +8,7 @@
 if BOARD_OLIMEX_STM32_E407
 
 config BOARD
-	default olimex_stm32_e407
+	default "olimex_stm32_e407"
 
 if UART_CONSOLE
 

--- a/boards/arm/olimex_stm32_h407/Kconfig.defconfig
+++ b/boards/arm/olimex_stm32_h407/Kconfig.defconfig
@@ -8,7 +8,7 @@
 if BOARD_OLIMEX_STM32_H407
 
 config BOARD
-	default olimex_stm32_h407
+	default "olimex_stm32_h407"
 
 if UART_CONSOLE
 

--- a/boards/arm/olimex_stm32_p405/Kconfig.defconfig
+++ b/boards/arm/olimex_stm32_p405/Kconfig.defconfig
@@ -8,7 +8,7 @@
 if BOARD_OLIMEX_STM32_P405
 
 config BOARD
-	default olimex_stm32_p405
+	default "olimex_stm32_p405"
 
 if UART_CONSOLE
 

--- a/boards/arm/olimexino_stm32/Kconfig.defconfig
+++ b/boards/arm/olimexino_stm32/Kconfig.defconfig
@@ -8,7 +8,7 @@
 if BOARD_OLIMEXINO_STM32
 
 config BOARD
-	default olimexino_stm32
+	default "olimexino_stm32"
 
 if UART_CONSOLE
 

--- a/boards/arm/qemu_cortex_m3/Kconfig.defconfig
+++ b/boards/arm/qemu_cortex_m3/Kconfig.defconfig
@@ -5,6 +5,6 @@ config BUILD_OUTPUT_BIN
         default n
 
 config BOARD
-	default qemu_cortex_m3
+	default "qemu_cortex_m3"
 
 endif # BOARD_QEMU_CORTEX_M3

--- a/boards/arm/quark_se_c1000_ble/Kconfig.defconfig
+++ b/boards/arm/quark_se_c1000_ble/Kconfig.defconfig
@@ -7,7 +7,7 @@
 if BOARD_QUARK_SE_C1000_BLE
 
 config BOARD
-	default quark_se_c1000_ble
+	default "quark_se_c1000_ble"
 
 if UART_NRF5
 

--- a/boards/arm/sam4s_xplained/Kconfig.defconfig
+++ b/boards/arm/sam4s_xplained/Kconfig.defconfig
@@ -8,7 +8,7 @@ if BOARD_SAM4S_XPLAINED
 
 config BOARD
 	string
-	default sam4s_xplained
+	default "sam4s_xplained"
 
 if I2C
 

--- a/boards/arm/sam_e70_xplained/Kconfig.defconfig
+++ b/boards/arm/sam_e70_xplained/Kconfig.defconfig
@@ -8,7 +8,7 @@ if BOARD_SAM_E70_XPLAINED
 
 config BOARD
 	string
-	default sam_e70_xplained
+	default "sam_e70_xplained"
 
 if I2S
 config I2S_SAM_SSC

--- a/boards/arm/stm3210c_eval/Kconfig.defconfig
+++ b/boards/arm/stm3210c_eval/Kconfig.defconfig
@@ -8,7 +8,7 @@
 if BOARD_STM3210C_EVAL
 
 config BOARD
-	default stm3210c_eval
+	default "stm3210c_eval"
 
 if UART_CONSOLE
 

--- a/boards/arm/stm32373c_eval/Kconfig.defconfig
+++ b/boards/arm/stm32373c_eval/Kconfig.defconfig
@@ -8,7 +8,7 @@
 if BOARD_STM32373C_EVAL
 
 config BOARD
-	default stm32373c_eval
+	default "stm32373c_eval"
 
 if UART_CONSOLE
 

--- a/boards/arm/stm32_min_dev/Kconfig.defconfig
+++ b/boards/arm/stm32_min_dev/Kconfig.defconfig
@@ -8,7 +8,7 @@
 if BOARD_STM32_MIN_DEV
 
 config BOARD
-	default stm32_min_dev
+	default "stm32_min_dev"
 
 if UART_CONSOLE
 

--- a/boards/arm/stm32_mini_a15/Kconfig.defconfig
+++ b/boards/arm/stm32_mini_a15/Kconfig.defconfig
@@ -8,7 +8,7 @@
 if BOARD_STM32_MINI_A15
 
 config BOARD
-	default stm32_mini_a15
+	default "stm32_mini_a15"
 
 config BOARD_DEPRECATED
 	default "1.11"

--- a/boards/arm/stm32f072_eval/Kconfig.defconfig
+++ b/boards/arm/stm32f072_eval/Kconfig.defconfig
@@ -8,7 +8,7 @@
 if BOARD_STM32F072_EVAL
 
 config BOARD
-	default stm32f072_eval
+	default "stm32f072_eval"
 
 if UART_CONSOLE
 

--- a/boards/arm/stm32f072b_disco/Kconfig.defconfig
+++ b/boards/arm/stm32f072b_disco/Kconfig.defconfig
@@ -8,7 +8,7 @@
 if BOARD_STM32F072B_DISCO
 
 config BOARD
-	default stm32f072b_disco
+	default "stm32f072b_disco"
 
 if UART_CONSOLE
 

--- a/boards/arm/stm32f0_disco/Kconfig.defconfig
+++ b/boards/arm/stm32f0_disco/Kconfig.defconfig
@@ -8,7 +8,7 @@
 if BOARD_STM32F0_DISCO
 
 config BOARD
-	default stm32f0_disco
+	default "stm32f0_disco"
 
 if UART_CONSOLE
 

--- a/boards/arm/stm32f3_disco/Kconfig.defconfig
+++ b/boards/arm/stm32f3_disco/Kconfig.defconfig
@@ -8,7 +8,7 @@
 if BOARD_STM32F3_DISCO
 
 config BOARD
-	default stm32f3_disco
+	default "stm32f3_disco"
 
 if UART_CONSOLE
 

--- a/boards/arm/stm32f411e_disco/Kconfig.defconfig
+++ b/boards/arm/stm32f411e_disco/Kconfig.defconfig
@@ -8,7 +8,7 @@
 if BOARD_STM32F411E_DISCO
 
 config BOARD
-	default stm32f411e_disco
+	default "stm32f411e_disco"
 
 if UART_CONSOLE
 

--- a/boards/arm/stm32f412g_disco/Kconfig.defconfig
+++ b/boards/arm/stm32f412g_disco/Kconfig.defconfig
@@ -6,7 +6,7 @@
 if BOARD_STM32F412G_DISCO
 
 config BOARD
-	default stm32f412g_disco
+	default "stm32f412g_disco"
 
 if UART_CONSOLE
 

--- a/boards/arm/stm32f429i_disc1/Kconfig.defconfig
+++ b/boards/arm/stm32f429i_disc1/Kconfig.defconfig
@@ -8,7 +8,7 @@
 if BOARD_STM32F429I_DISC1
 
 config BOARD
-	default stm32f429i_disc1
+	default "stm32f429i_disc1"
 
 if UART_CONSOLE
 

--- a/boards/arm/stm32f469i_disco/Kconfig.defconfig
+++ b/boards/arm/stm32f469i_disco/Kconfig.defconfig
@@ -8,7 +8,7 @@
 if BOARD_STM32F469I_DISCO
 
 config BOARD
-	default stm32f469i_disco
+	default "stm32f469i_disco"
 
 if UART_CONSOLE
 

--- a/boards/arm/stm32f4_disco/Kconfig.defconfig
+++ b/boards/arm/stm32f4_disco/Kconfig.defconfig
@@ -8,7 +8,7 @@
 if BOARD_STM32F4_DISCO
 
 config BOARD
-	default stm32f4_disco
+	default "stm32f4_disco"
 
 if UART_CONSOLE
 

--- a/boards/arm/stm32l476g_disco/Kconfig.defconfig
+++ b/boards/arm/stm32l476g_disco/Kconfig.defconfig
@@ -8,7 +8,7 @@
 if BOARD_STM32L476G_DISCO
 
 config BOARD
-	default stm32l476g_disco
+	default "stm32l476g_disco"
 
 if UART_CONSOLE
 

--- a/boards/arm/stm32l496g_disco/Kconfig.defconfig
+++ b/boards/arm/stm32l496g_disco/Kconfig.defconfig
@@ -9,7 +9,7 @@
 if BOARD_STM32L496G_DISCO
 
 config BOARD
-	default stm32l496g_disco
+	default "stm32l496g_disco"
 
 if UART_CONSOLE
 

--- a/boards/arm/usb_kw24d512/Kconfig.defconfig
+++ b/boards/arm/usb_kw24d512/Kconfig.defconfig
@@ -8,7 +8,7 @@
 if BOARD_USB_KW24D512
 
 config BOARD
-	default usb_kw24d512
+	default "usb_kw24d512"
 
 config OSC_XTAL0_FREQ
 	# The MCU is configured to use 4 MHz external

--- a/boards/arm/v2m_beetle/Kconfig.defconfig
+++ b/boards/arm/v2m_beetle/Kconfig.defconfig
@@ -9,7 +9,7 @@
 if BOARD_V2M_BEETLE
 
 config BOARD
-	default v2m_beetle
+	default "v2m_beetle"
 
 if GPIO
 

--- a/boards/x86/galileo/Kconfig.defconfig
+++ b/boards/x86/galileo/Kconfig.defconfig
@@ -5,7 +5,7 @@ config BUILD_OUTPUT_STRIPPED
 	def_bool y
 
 config BOARD
-	default galileo
+	default "galileo"
 
 config I2C
 	def_bool y

--- a/boards/x86/minnowboard/Kconfig.defconfig
+++ b/boards/x86/minnowboard/Kconfig.defconfig
@@ -2,7 +2,7 @@
 if BOARD_MINNOWBOARD
 
 config BOARD
-	default minnowboard
+	default "minnowboard"
 
 config BUILD_OUTPUT_STRIPPED
 	def_bool y

--- a/boards/x86/qemu_x86/Kconfig.defconfig
+++ b/boards/x86/qemu_x86/Kconfig.defconfig
@@ -6,6 +6,6 @@ config BUILD_OUTPUT_BIN
         default n
 
 config BOARD
-	default qemu_x86
+	default "qemu_x86"
 
 endif # BOARD_QEMU_X86

--- a/boards/x86/x86_jailhouse/Kconfig.defconfig
+++ b/boards/x86/x86_jailhouse/Kconfig.defconfig
@@ -2,7 +2,7 @@
 if BOARD_X86_JAILHOUSE
 
 config BOARD
-	default x86_jailhouse
+	default "x86_jailhouse"
 
 config JAILHOUSE
 	bool "Zephyr port to boot as a (x86) Jailhouse inmate cell payload"

--- a/boards/xtensa/esp32/Kconfig.defconfig
+++ b/boards/xtensa/esp32/Kconfig.defconfig
@@ -6,6 +6,6 @@
 if BOARD_ESP32
 
 config BOARD
-	default esp32
+	default "esp32"
 
 endif # BOARD_ESP32

--- a/boards/xtensa/intel_s1000_crb/Kconfig.defconfig
+++ b/boards/xtensa/intel_s1000_crb/Kconfig.defconfig
@@ -5,7 +5,7 @@
 if BOARD_INTEL_S1000_CRB
 
 config BOARD
-	default intel_s1000_crb
+	default "intel_s1000_crb"
 
 config BOARD_XTENSA
 	def_bool y

--- a/boards/xtensa/qemu_xtensa/Kconfig.defconfig
+++ b/boards/xtensa/qemu_xtensa/Kconfig.defconfig
@@ -8,6 +8,6 @@ config BUILD_OUTPUT_BIN
         default n
 
 config BOARD
-	default qemu_xtensa
+	default "qemu_xtensa"
 
 endif # BOARD_QEMU_XTENSA

--- a/boards/xtensa/xt-sim/Kconfig.defconfig
+++ b/boards/xtensa/xt-sim/Kconfig.defconfig
@@ -4,6 +4,6 @@
 if BOARD_XT_SIM
 
 config BOARD
-	default xt-sim
+	default "xt-sim"
 
 endif # BOARD_SIMULATOR_XTENSA

--- a/scripts/kconfig/kconfiglib.py
+++ b/scripts/kconfig/kconfiglib.py
@@ -4754,7 +4754,18 @@ def _check_sym_sanity(sym):
                     .format(TYPE_TO_STR[sym.orig_type], _name_and_loc(sym),
                             expr_str(default)))
 
-            if sym.orig_type in (INT, HEX) and \
+            if sym.orig_type == STRING:
+                if not default.is_constant and not default.nodes and \
+                   default.name != default.name.upper():
+                    # 'default foo' on a string symbol could be either a symbol
+                    # reference or someone leaving out the quotes. Guess that
+                    # the quotes were left out if 'foo' isn't all-uppercase
+                    # (and no symbol named 'foo' exists).
+                    sym.kconfig._warn("style: quotes recommended around "
+                                      "default value for string symbol "
+                                      + _name_and_loc(sym))
+
+            elif sym.orig_type in (INT, HEX) and \
                not _int_hex_ok(default, sym.orig_type):
 
                 sym.kconfig._warn("the {0} symbol {1} has a non-{0} default {2}"


### PR DESCRIPTION
This series first quotes all currently unquoted Kconfig `string` symbol `default`s, then adds a warning for them to Kconfiglib.

Unquoted string defaults work through a quirk of Kconfig (undefined symbols get their name as their string value), but look confusing. Quoting was done inconsistently too.

A heuristic is used for the warning (does the `default` have any lowercase characters?), as unquoted string `default`s are indistinguishable from references to (undefined) symbols in general.

Suggested by Kumar Gala.