### PR TITLE
arch: x86: Better document that CR0.WP will also be set when CR0.PG is

### DIFF
--- a/arch/x86/core/crt0.S
+++ b/arch/x86/core/crt0.S
@@ -368,9 +368,9 @@ __csSet:
 	orl $0x800, %eax
 	wrmsr
 #endif
-	/* set CR0.PG bit (31st bit in CR0)*/
+	/* Enable paging (CR0.PG, bit 31) / write protect (CR0.WP, bit 16) */
 	movl %cr0, %eax
-	orl $CR0_PAGING_ENABLE, %eax
+	orl $CR0_PG_WP_ENABLE, %eax
 	movl %eax, %cr0
 
 #endif /* CONFIG_X86_MMU */

--- a/arch/x86/include/kernel_arch_data.h
+++ b/arch/x86/include/kernel_arch_data.h
@@ -386,7 +386,7 @@
 #define EFLAGS_MASK 0x00003200
 
 /* Enable paging and write protection */
-#define CR0_PAGING_ENABLE 0x80010000
+#define CR0_PG_WP_ENABLE 0x80010000
 /* Clear the 5th bit in  CR4 */
 #define CR4_PAE_DISABLE 0xFFFFFFEF
 /* Set the 5th bit in  CR4 */


### PR DESCRIPTION
Setting bit CR0.WP (bit 16) will inhibit supervisor threads from
writing to RO pages.  It's a necessary flag to be set, and the constant
name CR0_PAGING_ENABLE didn't reflect the fact that the 16th bit was
being set.

Signed-off-by: Leandro Pereira <leandro.pereira@intel.com>