### PR TITLE
native: Add command line options to control real timeness

### DIFF
--- a/boards/posix/native_posix/cmdline.c
+++ b/boards/posix/native_posix/cmdline.c
@@ -8,6 +8,7 @@
 #include "cmdline_common.h"
 #include "zephyr/types.h"
 #include "hw_models_top.h"
+#include "timer_model.h"
 #include "cmdline.h"
 #include "toolchain.h"
 
@@ -24,6 +25,20 @@ static void cmd_stop_at_found(char *argv, int offset)
 					   "(%s)\n", argv);
 	}
 	hwm_set_end_of_time(args.stop_at*1e6);
+}
+
+static void cmd_realtime_found(char *argv, int offset)
+{
+	ARG_UNUSED(argv);
+	ARG_UNUSED(offset);
+	hwtimer_set_real_time(true);
+}
+
+static void cmd_no_realtime_found(char *argv, int offset)
+{
+	ARG_UNUSED(argv);
+	ARG_UNUSED(offset);
+	hwtimer_set_real_time(false);
 }
 
 #if defined(CONFIG_FAKE_ENTROPY_NATIVE_POSIX)
@@ -53,8 +68,20 @@ void native_handle_cmd_line(int argc, char *argv[])
 		 * destination, callback,
 		 * description
 		 */
+		{false, false, true,
+		"rt", "", 'b',
+		NULL, cmd_realtime_found,
+		"Slow down the execution to the host real time"},
+
+		{false, false, true,
+		"no-rt", "", 'b',
+		NULL, cmd_no_realtime_found,
+		"Do NOT slow down the execution to real time, but advance "
+		"Zephyr's time as fast as possible and decoupled from the host "
+		"time"},
+
 		{false, false, false,
-		  "stop_at", "time", 'd',
+		 "stop_at", "time", 'd',
 		(void *)&args.stop_at, cmd_stop_at_found,
 		"In simulated seconds, when to stop automatically"},
 

--- a/boards/posix/native_posix/doc/board.rst
+++ b/boards/posix/native_posix/doc/board.rst
@@ -164,6 +164,10 @@ available options::
    $ zephyr/zephyr.exe --help
 
      [-h] [--h] [--help] [-?]  :Display this help
+     [-rt]                     :Slow down the execution to the host real time
+     [-no-rt]                  :Do NOT slow down the execution to real time, but
+                                advance Zephyr's time as fast as possible and
+                                decoupled from the host time
      [-stop_at=<time>]         :In simulated seconds, when to stop automatically
      [-seed=<r_seed>]          :Seed for the entropy device
      [-testargs <arg>...]      :Any argument that follows will be ignored
@@ -374,8 +378,7 @@ The following peripherals are currently provided with this board:
   This peripheral driver also provides the needed functionality for this
   architecture-specific :c:func:`k_busy_wait`.
 
-  This timer, is configured by default with
-  :option:`CONFIG_NATIVE_POSIX_SLOWDOWN_TO_REAL_TIME`
+  This timer, may be configured
   to slow down the execution to real host time.
   This will provide the illusion that the simulated time is running at the same
   speed as the real host time.
@@ -384,6 +387,9 @@ The following peripherals are currently provided with this board:
   the execution before raising its next timer interrupt.
   Normally the Zephyr application and HW models run in very little time
   on the host CPU, so this is a good enough approach.
+  To configure the timer to slow down the execution, either set the option
+  :option:`CONFIG_NATIVE_POSIX_SLOWDOWN_TO_REAL_TIME`
+  or use the command line switch --rt.
 
 **Entropy device**:
   An entropy device based on the host :c:func:`random` API.

--- a/boards/posix/native_posix/timer_model.h
+++ b/boards/posix/native_posix/timer_model.h
@@ -8,6 +8,7 @@
 #define _NATIVE_POSIX_TIMER_MODEL_H
 
 #include "hw_models_top.h"
+#include <stdbool.h>
 
 #ifdef __cplusplus
 extern "C" {
@@ -15,6 +16,7 @@ extern "C" {
 
 void hwtimer_init(void);
 void hwtimer_cleanup(void);
+void hwtimer_set_real_time(bool new_rt);
 void hwtimer_timer_reached(void);
 void hwtimer_wake_in_time(u64_t time);
 void hwtimer_set_silent_ticks(s64_t sys_ticks);


### PR DESCRIPTION
For the native_posix board,
added the command line options -rt and -no-rt to control
if the execution should be slowed down to real time or not.

CONFIG_NATIVE_POSIX_SLOWDOWN_TO_REAL_TIME still works, but
now it just sets a default.