### PR TITLE
arch: arm: fix undefined variable bug

### DIFF
--- a/arch/arm/core/fault.c
+++ b/arch/arm/core/fault.c
@@ -271,8 +271,8 @@ static u32_t _MpuFault(const NANO_ESF *esf, int fromHardFault)
 #else
 				guard_start = thread->stack_info.start;
 #endif
-				if (mmfar >= guard_start &&
-					mmfar < guard_start +
+				if (SCB->MMFAR >= guard_start &&
+					SCB->MMFAR < guard_start +
 					MPU_GUARD_ALIGN_AND_SIZE) {
 					/* Thread stack corruption */
 					reason = _NANO_ERR_STACK_CHK_FAIL;


### PR DESCRIPTION
This commit fixes a compilation bug for an undefined variable
(mmfar), which is only conditionally defined. Instead of mmfar
we use the ARM register value directly.

Fixes #7942

Signed-off-by: Ioannis Glaropoulos <Ioannis.Glaropoulos@nordicsemi.no>