### PR TITLE
dts: x86: Fix wrong interrupt number for I2C

### DIFF
--- a/dts/x86/intel_curie.dtsi
+++ b/dts/x86/intel_curie.dtsi
@@ -117,7 +117,7 @@
 			#address-cells = <1>;
 			#size-cells = <0>;
 			reg = <0xb0002800 0x400>;
-			interrupts = <36 IRQ_TYPE_LEVEL_HIGH 2>;
+			interrupts = <0 IRQ_TYPE_LEVEL_HIGH 2>;
 			interrupt-parent = <&intc>;
 			label = "I2C_0";
 
@@ -130,7 +130,7 @@
 			#address-cells = <1>;
 			#size-cells = <0>;
 			reg = <0xb0002c00 0x400>;
-			interrupts = <37 IRQ_TYPE_LEVEL_HIGH 2>;
+			interrupts = <1 IRQ_TYPE_LEVEL_HIGH 2>;
 			interrupt-parent = <&intc>;
 			label = "I2C_1";
 


### PR DESCRIPTION
Wrong interrupt number was populated from dts. This
commit solves following issue:

Fixes #7793

Signed-off-by: Punit Vara <punit.vara@intel.com>