### PR TITLE
codeowner: Fix wildcard issue for arch/arm/soc/st_stm32/

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -9,7 +9,7 @@ arch/arm/                                @MaureenHelm @galak
 arch/arm/soc/arm/mps2/*                  @fvincenzo
 arch/arm/soc/atmel_sam/sam4s             @fallrisk
 arch/arm/soc/nxp*/                       @MaureenHelm
-arch/arm/soc/st_stm32/*                  @erwango
+arch/arm/soc/st_stm32/                   @erwango
 arch/arm/soc/st_stm32/stm32f4/*          @rsalveti @idlethread
 arch/arm/soc/ti_simplelink/cc32xx        @GAnthony
 arch/arm/soc/ti_simplelink/msp432p4xx    @Mani-Sadhasivam


### PR DESCRIPTION
I was not requested reviews for PR impacting subdirectories
of arch/arm/soc/st_stm32/.
Remove '*' to fix this.

Signed-off-by: Erwan Gouriou <erwan.gouriou@linaro.org>