### PR TITLE
kconfig: Define the IRQ priorities for CAVS & DW ICTL

### DIFF
--- a/drivers/interrupt_controller/Kconfig
+++ b/drivers/interrupt_controller/Kconfig
@@ -148,6 +148,13 @@ config DW_ICTL_OFFSET
 	help
 	  Parent interrupt number to which DW_ICTL maps
 
+config DW_ICTL_IRQ_PRI
+	int "DW ICTL IRQ priority"
+	depends on DW_ICTL
+	default 0
+	help
+	  IRQ priority of DW ICTL interrupt
+
 config DW_ISR_TBL_OFFSET
 	int "Offset in the SW ISR Table"
 	default 0

--- a/drivers/interrupt_controller/Kconfig.s1000
+++ b/drivers/interrupt_controller/Kconfig.s1000
@@ -25,6 +25,13 @@ config CAVS_ICTL_0_NAME
 	depends on CAVS_ICTL
 	default "CAVS_0"
 
+config CAVS_ICTL_0_IRQ_PRI
+	int "CAVS 0 IRQ priority"
+	depends on CAVS_ICTL
+	default 0
+	help
+	  IRQ priority of CAVS 0 interrupt
+
 config CAVS_ICTL_0_OFFSET
 	hex "Parent interrupt number to which CAVS_0 maps"
 	default 0x00
@@ -34,6 +41,13 @@ config CAVS_ICTL_1_NAME
 	string "CAVS 1 Driver name"
 	depends on CAVS_ICTL
 	default "CAVS_1"
+
+config CAVS_ICTL_1_IRQ_PRI
+	int "CAVS 1 IRQ priority"
+	depends on CAVS_ICTL
+	default 0
+	help
+	  IRQ priority of CAVS 1 interrupt
 
 config CAVS_ICTL_1_OFFSET
 	hex "Parent interrupt number to which CAVS_1 maps"
@@ -45,6 +59,13 @@ config CAVS_ICTL_2_NAME
 	depends on CAVS_ICTL
 	default "CAVS_2"
 
+config CAVS_ICTL_2_IRQ_PRI
+	int "CAVS 2 IRQ priority"
+	depends on CAVS_ICTL
+	default 0
+	help
+	  IRQ priority of CAVS 2 interrupt
+
 config CAVS_ICTL_2_OFFSET
 	hex "Parent interrupt number to which CAVS_2 maps"
 	default 0x00
@@ -54,6 +75,13 @@ config CAVS_ICTL_3_NAME
 	string "CAVS 3 Driver name"
 	depends on CAVS_ICTL
 	default "CAVS_3"
+
+config CAVS_ICTL_3_IRQ_PRI
+	int "CAVS 3 IRQ priority"
+	depends on CAVS_ICTL
+	default 0
+	help
+	  IRQ priority of CAVS 3 interrupt
 
 config CAVS_ICTL_3_OFFSET
 	hex "Parent interrupt number to which CAVS_3 maps"


### PR DESCRIPTION
CAVS_ICTL_0_IRQ_PRI to CAVS_ICTL_3_IRQ_PRI and DW_ICTL_IRQ_PRI
are now defined in Kconfig. This addresses the issue #7811.

This was not throwing up any compilation error earlier as the IRQ
priorities are all hardwired in Xtensa and hence are unconfigurable.
They are dummy for Xtensa arch but may be applicable if used in some
other arch.

Fixes #7811

Signed-off-by: Rajavardhan Gundi <rajavardhan.gundi@intel.com>