### PR TITLE
drivers: serial: nrf: Fix interrupts enabling/disabling

### DIFF
--- a/drivers/serial/uart_nrf5.c
+++ b/drivers/serial/uart_nrf5.c
@@ -377,7 +377,7 @@ static void uart_nrf5_irq_tx_enable(struct device *dev)
 {
 	volatile struct _uart *uart = UART_STRUCT(dev);
 
-	uart->INTENSET |= UART_IRQ_MASK_TX;
+	uart->INTENSET = UART_IRQ_MASK_TX;
 }
 
 /** Interrupt driven transfer disabling function */
@@ -385,7 +385,7 @@ static void uart_nrf5_irq_tx_disable(struct device *dev)
 {
 	volatile struct _uart *uart = UART_STRUCT(dev);
 
-	uart->INTENCLR |= UART_IRQ_MASK_TX;
+	uart->INTENCLR = UART_IRQ_MASK_TX;
 }
 
 /** Interrupt driven transfer ready function */
@@ -401,7 +401,7 @@ static void uart_nrf5_irq_rx_enable(struct device *dev)
 {
 	volatile struct _uart *uart = UART_STRUCT(dev);
 
-	uart->INTENSET |= UART_IRQ_MASK_RX;
+	uart->INTENSET = UART_IRQ_MASK_RX;
 }
 
 /** Interrupt driven receiver disabling function */
@@ -409,7 +409,7 @@ static void uart_nrf5_irq_rx_disable(struct device *dev)
 {
 	volatile struct _uart *uart = UART_STRUCT(dev);
 
-	uart->INTENCLR |= UART_IRQ_MASK_RX;
+	uart->INTENCLR = UART_IRQ_MASK_RX;
 }
 
 /** Interrupt driven transfer empty function */
@@ -433,7 +433,7 @@ static void uart_nrf5_irq_err_enable(struct device *dev)
 {
 	volatile struct _uart *uart = UART_STRUCT(dev);
 
-	uart->INTENSET |= UART_IRQ_MASK_ERROR;
+	uart->INTENSET = UART_IRQ_MASK_ERROR;
 }
 
 /** Interrupt driven error disabling function */
@@ -441,7 +441,7 @@ static void uart_nrf5_irq_err_disable(struct device *dev)
 {
 	volatile struct _uart *uart = UART_STRUCT(dev);
 
-	uart->INTENCLR |= UART_IRQ_MASK_ERROR;
+	uart->INTENCLR = UART_IRQ_MASK_ERROR;
 }
 
 /** Interrupt driven pending status function */


### PR DESCRIPTION
This patch corrects the way the INTENSET and INTENCLR registers are
accessed. When these registers are written with a bitmask, specified
bits are set or cleared in the INTEN (interrupt enabling) register,
so there is no need to read the previous state of these registers
(when they are read, the current state of INTEN is returned).
For INTENSET this patch eliminates only one unnecessary read, but for
INTENCLR the change is crucial because in the previous version any
write to the register disabled all the enabled interrupts.

Fixes #7755.