### PR TITLE
kconfig: Remove remaining 'option env' bounce symbols

### DIFF
--- a/samples/can/Kconfig
+++ b/samples/can/Kconfig
@@ -8,10 +8,6 @@
 
 mainmenu "Controller Area Network sample application"
 
-config ZEPHYR_BASE
-	string
-	option env="ZEPHYR_BASE"
-
 source "$ZEPHYR_BASE/Kconfig.zephyr"
 
 config CAN_DEV

--- a/samples/net/stats/Kconfig
+++ b/samples/net/stats/Kconfig
@@ -8,10 +8,6 @@
 
 mainmenu "Network statistics sample application"
 
-config ZEPHYR_BASE
-	string
-	option env="ZEPHYR_BASE"
-
 source "$ZEPHYR_BASE/Kconfig.zephyr"
 
 config SAMPLE_PERIOD

--- a/samples/net/traffic_class/Kconfig
+++ b/samples/net/traffic_class/Kconfig
@@ -8,10 +8,6 @@
 
 mainmenu "Networking traffic class sample application"
 
-config ZEPHYR_BASE
-	string
-	option env="ZEPHYR_BASE"
-
 source "$ZEPHYR_BASE/Kconfig.zephyr"
 
 config SAMPLE_VLAN_TAG

--- a/samples/net/vlan/Kconfig
+++ b/samples/net/vlan/Kconfig
@@ -8,10 +8,6 @@
 
 mainmenu "Networking VLAN sample application"
 
-config ZEPHYR_BASE
-	string
-	option env="ZEPHYR_BASE"
-
 source "$ZEPHYR_BASE/Kconfig.zephyr"
 
 config SAMPLE_VLAN_TAG

--- a/samples/net/wifi/Kconfig
+++ b/samples/net/wifi/Kconfig
@@ -1,9 +1,5 @@
 mainmenu "Wi-Fi sample"
 
-config ZEPHYR_BASE
-	string
-	option env="ZEPHYR_BASE"
-
 source "$ZEPHYR_BASE/Kconfig.zephyr"
 
 if WIFI_WINC1500

--- a/tests/benchmarks/object_footprint/Kconfig
+++ b/tests/benchmarks/object_footprint/Kconfig
@@ -1,13 +1,5 @@
 mainmenu "Zephyr Object Sizes"
 
-config ZEPHYR_BASE
-	string
-	option env="ZEPHYR_BASE"
-
-config APPLICATION_BASE
-	string
-	option env="PROJECT_BASE"
-
 source "$ZEPHYR_BASE/Kconfig.zephyr"
 
 config OBJECTS_PRINTK

--- a/tests/drivers/spi/spi_loopback/Kconfig
+++ b/tests/drivers/spi/spi_loopback/Kconfig
@@ -1,9 +1,5 @@
 mainmenu "SPI Loopback Test"
 
-config ZEPHYR_BASE
-	string
-	option env="ZEPHYR_BASE"
-
 source "$ZEPHYR_BASE/Kconfig.zephyr"
 
 config SPI_LOOPBACK_DRV_NAME


### PR DESCRIPTION
These are no longer needed since commit 4dc9e5b2de33 ("kconfig: Get rid
of 'option env' bounce symbols"). The C tools are likely to get rid of
them soon too.

The APPLICATION_BASE symbol (option env="PROJECT_BASE") triggered a
compatibility warning, because 'option env' symbols now need to have the
same name as the environment variables they reference to be compatible
with Kconfiglib. APPLICATION_BASE is unused, so just remove it.

Signed-off-by: Ulf Magnusson <Ulf.Magnusson@nordicsemi.no>