### PR TITLE
boards: arm: argonkey: Remove default on choice symbol

### DIFF
--- a/boards/arm/96b_argonkey/Kconfig.defconfig
+++ b/boards/arm/96b_argonkey/Kconfig.defconfig
@@ -53,8 +53,9 @@ endchoice
 config LSM6DSL_SENSORHUB
 	default y
 
-config LSM6DSL_EXT0_LIS2MDL
-	default y
+choice LSM6DSL_EXTERNAL_SENSOR_0
+	default LSM6DSL_EXT0_LIS2MDL
+endchoice
 
 endif # LSM6DSL
 

--- a/drivers/sensor/lsm6dsl/Kconfig
+++ b/drivers/sensor/lsm6dsl/Kconfig
@@ -198,16 +198,17 @@ config LSM6DSL_ENABLE_INTERNAL_PULLUP
 	bool "Enabled internals pull-up resistors"
 	default y
 
-choice
+choice LSM6DSL_EXTERNAL_SENSOR_0
 	prompt "External sensor 0"
-	default LSM6DSL_EXT0_LIS2MDL
 	help
 	  Choose the external sensor 0 connected to LSM6DS3.
 
 config LSM6DSL_EXT0_LIS2MDL
 	bool "LIS2MDL"
+
 config LSM6DSL_EXT0_LPS22HB
 	bool "LPS22HB"
+
 endchoice
 
 endif #LSM6DSL_SENSORHUB


### PR DESCRIPTION
The choice symbol LSM6DSL_EXT0_LIS2MDL was given a 'default' in
Kboards/arm/96b_argonkey/Kconfig.defconfig, but 'default' has no effect
on choice symbols, triggering a warning from Kconfiglib.

Instead of adding a default to the choice symbol, change the default of
the 'choice' itself by giving it name and adding the default in
Kconfig.defconfig.

This requires that we remove the default on the "base" definition of the
'choice', due to some messiness related to the Zephyr-specific
prefer-later-defaults behavior (see the 'Zephyr-specific Kconfig
behavior for defaults' section in the Board Porting Guide). Choices were
overlooked when that patch was added to the C tools, meaning choices
still prefer earlier defaults. The crux is that Kconfig.defconfig files
are included last.

Signed-off-by: Ulf Magnusson <Ulf.Magnusson@nordicsemi.no>