### PR TITLE
drivers: apds9960: Use dts generated I2C name for binding

### DIFF
--- a/drivers/sensor/apds9960/Kconfig
+++ b/drivers/sensor/apds9960/Kconfig
@@ -14,7 +14,7 @@ menuconfig APDS9960
 config  APDS9960_I2C_DEV_NAME
 	string "I2C Master"
 	depends on APDS9960
-	default I2C_SS_0_NAME
+	default "I2C_0"
 	help
 	  The device name of the I2C master device to which the APDS9960
 	  chip is connected.


### PR DESCRIPTION
This commit removes old Kconfig dependency on I2C name and
replaced with new dts generated I2C name.

Fixes #7804

This issue was produced because of
9ddd8d1e4d7daa9b1d37af0e8a23de1c1900d7d5

Signed-off-by: Punit Vara <punit.vara@intel.com>