### PR TITLE
samples: Quote BOARD value in custom board definition

### DIFF
--- a/samples/application_development/out_of_tree_board/boards/arm/nrf52840_pca10056/Kconfig.defconfig
+++ b/samples/application_development/out_of_tree_board/boards/arm/nrf52840_pca10056/Kconfig.defconfig
@@ -7,7 +7,7 @@
 if BOARD_NRF52840_PCA10056
 
 config BOARD
-	default nrf52840_pca10056
+	default "nrf52840_pca10056"
 
 if GPIO_NRF5
 


### PR DESCRIPTION
Gets rid of a warning added in commit 6eabea3a7e6f ("Kconfiglib: Warn
for unquoted string defaults"), which will soon be an error (because a
simple warning whitelist will be used).

Signed-off-by: Ulf Magnusson <Ulf.Magnusson@nordicsemi.no>