### PR TITLE
arch: arm: nordic: nrf52: Enable instruction cache

### DIFF
--- a/arch/arm/soc/nordic_nrf/nrf52/Kconfig.soc
+++ b/arch/arm/soc/nordic_nrf/nrf52/Kconfig.soc
@@ -52,3 +52,8 @@ config GPIO_AS_PINRESET
 	bool "GPIO as pin reset (reset button)"
 	depends on SOC_SERIES_NRF52X
 	default y
+
+config NRF_ENABLE_ICACHE
+	bool "Enable the instruction cache (I-Cache)"
+	depends on SOC_SERIES_NRF52X
+	default y

--- a/arch/arm/soc/nordic_nrf/nrf52/soc.c
+++ b/arch/arm/soc/nordic_nrf/nrf52/soc.c
@@ -387,6 +387,12 @@ static int nordicsemi_nrf52_init(struct device *arg)
 #ifdef CONFIG_SOC_NRF52840
 	nordicsemi_nrf52840_init();
 #endif
+
+#ifdef CONFIG_NRF_ENABLE_ICACHE
+	/* Enable the instruction cache */
+	NRF_NVMC->ICACHECNF = NVMC_ICACHECNF_CACHEEN_Msk;
+#endif /* CONFIG_NRF_ENABLE_ICACHE */
+
 	/* Enable the FPU if the compiler used floating point unit
 	 * instructions. Since the FPU consumes energy, remember to
 	 * disable FPU use in the compiler if floating point unit


### PR DESCRIPTION
Enable the instruction cache by default in order to achieve a speedup of
up to 20% in code execution.

Signed-off-by: Carles Cufi <carles.cufi@nordicsemi.no>