### PR TITLE
dts/bindings: Remove superfluous property definition

### DIFF
--- a/dts/bindings/serial/st,stm32-uart.yaml
+++ b/dts/bindings/serial/st,stm32-uart.yaml
@@ -27,10 +27,4 @@ properties:
       category: required
       description: required interrupts
       generation: define
-
-    clocks:
-      type: array
-      category: required
-      description: Clock gate control information
-      generation: define
 ...

--- a/dts/bindings/serial/st,stm32-usart.yaml
+++ b/dts/bindings/serial/st,stm32-usart.yaml
@@ -27,10 +27,4 @@ properties:
       category: required
       description: required interrupts
       generation: define
-
-    clocks:
-      type: array
-      category: required
-      description: Clock gate control information
-      generation: define
 ...


### PR DESCRIPTION
"clocks" property is defined in st,stm32-u(s)art.yaml
files while aslo defined in uart.yaml.
Remove redundant information.

Fixes #7974

Signed-off-by: Erwan Gouriou <erwan.gouriou@linaro.org>