### PR TITLE
uart_console: delete char using BS(08H) or DEL(7FH)

### DIFF
--- a/drivers/console/uart_console.c
+++ b/drivers/console/uart_console.c
@@ -137,6 +137,7 @@ static struct k_fifo *lines_queue;
 static u8_t (*completion_cb)(char *line, u8_t len);
 
 /* Control characters */
+#define BS                 0x08
 #define ESC                0x1b
 #define DEL                0x7f
 
@@ -516,6 +517,7 @@ void uart_console_isr(struct device *unused)
 		/* Handle special control characters */
 		if (!isprint(byte)) {
 			switch (byte) {
+			case BS:
 			case DEL:
 				if (cur > 0) {
 					del_char(&cmd->line[--cur], end);


### PR DESCRIPTION
Some serial tools such as 'minicom' send BS when press backspace,
not DEL, so delete char can use BS or DEL.

Fixes: #7959

Signed-off-by: qianfan Zhao <qianfanguijin@163.com>