### PR TITLE
boards: intel_s1000: Fix runner invocation

### DIFF
--- a/boards/common/intel_s1000_crb.board.cmake
+++ b/boards/common/intel_s1000_crb.board.cmake
@@ -1,9 +1,0 @@
-set(BOARD_FLASH_RUNNER intel_s1000)
-set(BOARD_DEBUG_RUNNER intel_s1000)
-
-board_finalize_runner_args(intel_s1000
-  "--xt-ocd-dir=/opt/Tensilica/xocd-12.0.4/xt-ocd"
-  "--ocd-topology=topology_dsp0_flyswatter2.xml"
-  "--ocd-jtag-instr=dsp0_gdb.txt"
-  "--gdb-flash-file=load_elf.txt"
-)

--- a/boards/common/intel_s1000_crb.board.cmake
+++ b/boards/common/intel_s1000_crb.board.cmake
@@ -2,11 +2,8 @@ set(BOARD_FLASH_RUNNER intel_s1000)
 set(BOARD_DEBUG_RUNNER intel_s1000)
 
 board_finalize_runner_args(intel_s1000
-  "--board-dir=${ZEPHYR_BASE}/boards/xtensa/intel_s1000_crb/"
   "--xt-ocd-dir=/opt/Tensilica/xocd-12.0.4/xt-ocd"
   "--ocd-topology=topology_dsp0_flyswatter2.xml"
   "--ocd-jtag-instr=dsp0_gdb.txt"
   "--gdb-flash-file=load_elf.txt"
-  "--gdb=${TOOLCHAIN_HOME}/bin/xt-gdb"
-  "--kernel-elf=zephyr/zephyr.elf"
 )

--- a/boards/xtensa/intel_s1000_crb/board.cmake
+++ b/boards/xtensa/intel_s1000_crb/board.cmake
@@ -1,1 +1,9 @@
-include(${ZEPHYR_BASE}/boards/common/intel_s1000_crb.board.cmake)
+set(BOARD_FLASH_RUNNER intel_s1000)
+set(BOARD_DEBUG_RUNNER intel_s1000)
+
+board_finalize_runner_args(intel_s1000
+  "--xt-ocd-dir=/opt/Tensilica/xocd-12.0.4/xt-ocd"
+  "--ocd-topology=topology_dsp0_flyswatter2.xml"
+  "--ocd-jtag-instr=dsp0_gdb.txt"
+  "--gdb-flash-file=load_elf.txt"
+)


### PR DESCRIPTION
Fix the runner invocation for intel_s1000 board by getting
rid of board-dir, gdb and kernel-elf parameters.

Signed-off-by: Rajavardhan Gundi <rajavardhan.gundi@intel.com>