### PR TITLE
arch: stm32: Fix inclusion of SPI headers

### DIFF
--- a/arch/arm/soc/st_stm32/stm32f3/soc.h
+++ b/arch/arm/soc/st_stm32/stm32f3/soc.h
@@ -42,11 +42,14 @@
 #include <stm32f3xx_ll_bus.h>
 #include <stm32f3xx_ll_rcc.h>
 #include <stm32f3xx_ll_system.h>
-#include <stm32f3xx_ll_spi.h>
 #endif /* CONFIG_CLOCK_CONTROL_STM32_CUBE */
 
 #ifdef CONFIG_I2C
 #include <stm32f3xx_ll_i2c.h>
+#endif
+
+#ifdef CONFIG_SPI_STM32
+#include <stm32f3xx_ll_spi.h>
 #endif
 
 #ifdef CONFIG_IWDG_STM32

--- a/arch/arm/soc/st_stm32/stm32f4/soc.h
+++ b/arch/arm/soc/st_stm32/stm32f4/soc.h
@@ -37,7 +37,6 @@
 #include <stm32f4xx_ll_bus.h>
 #include <stm32f4xx_ll_rcc.h>
 #include <stm32f4xx_ll_system.h>
-#include <stm32f4xx_ll_spi.h>
 #endif /* CONFIG_CLOCK_CONTROL_STM32_CUBE */
 
 #ifdef CONFIG_SERIAL_HAS_DRIVER
@@ -46,6 +45,10 @@
 
 #ifdef CONFIG_I2C
 #include <stm32f4xx_ll_i2c.h>
+#endif
+
+#ifdef CONFIG_SPI_STM32
+#include <stm32f4xx_ll_spi.h>
 #endif
 
 #ifdef CONFIG_ENTROPY_STM32_RNG

--- a/arch/arm/soc/st_stm32/stm32l4/soc.h
+++ b/arch/arm/soc/st_stm32/stm32l4/soc.h
@@ -41,8 +41,11 @@
 #include <stm32l4xx_ll_bus.h>
 #include <stm32l4xx_ll_rcc.h>
 #include <stm32l4xx_ll_system.h>
-#include <stm32l4xx_ll_spi.h>
 #endif /* CONFIG_CLOCK_CONTROL_STM32_CUBE */
+
+#ifdef CONFIG_SPI_STM32
+#include <stm32l4xx_ll_spi.h>
+#endif
 
 #ifdef CONFIG_I2C
 #include <stm32l4xx_ll_i2c.h>


### PR DESCRIPTION
In some STM32 series, SPI LL headers where included under
CONFIG_CLOCK_CONTROL_STM32_CUBE flag definition.
Fix this and use CONFIG_SPI_STM32 instead.

Signed-off-by: Erwan Gouriou <erwan.gouriou@linaro.org>