### PR TITLE
drivers: eth: native_posix: Fix malformed echo response

### DIFF
--- a/drivers/ethernet/eth_native_posix.c
+++ b/drivers/ethernet/eth_native_posix.c
@@ -150,6 +150,7 @@ static inline struct net_if *get_iface(struct eth_context *ctx,
 static int read_data(struct eth_context *ctx, int fd)
 {
 	u16_t vlan_tag = NET_VLAN_TAG_UNSPEC;
+	int count = 0;
 	struct net_if *iface;
 	struct net_pkt *pkt;
 	struct net_buf *frag;
@@ -167,8 +168,6 @@ static int read_data(struct eth_context *ctx, int fd)
 	}
 
 	do {
-		int count = 0;
-
 		frag = net_pkt_get_frag(pkt, NET_BUF_TIMEOUT);
 		if (!frag) {
 			net_pkt_unref(pkt);


### PR DESCRIPTION
Native POSIX echo server sends malformed response to echo request of
size larger than 128 bytes (default size of each network data
fragment). Wireshark notices that by tagging echo request with "No
response seen". This commit fixes that issue.

Signed-off-by: Ruslan Mstoi <ruslan.mstoi@intel.com>