### PR TITLE
Fix USB Bluetooth (HCI SPI)

### DIFF
--- a/drivers/bluetooth/hci/Kconfig
+++ b/drivers/bluetooth/hci/Kconfig
@@ -35,6 +35,7 @@ config BT_H5
 
 config BT_SPI
 	bool "SPI HCI"
+	select BT_RECV_IS_RX_THREAD
 	depends on SPI
 	help
 	  Supports Bluetooth ICs using SPI as the communication protocol.

--- a/subsys/usb/class/bluetooth.c
+++ b/subsys/usb/class/bluetooth.c
@@ -142,9 +142,10 @@ static void bluetooth_bulk_out_callback(u8_t ep,
 		return;
 	}
 
-	usb_read(ep, net_buf_add(buf, len), len, NULL);
-
+	net_buf_reserve(buf, CONFIG_BT_HCI_RESERVE);
 	bt_buf_set_type(buf, BT_BUF_ACL_OUT);
+
+	usb_read(ep, net_buf_add(buf, len), len, NULL);
 
 	net_buf_put(&tx_queue, buf);
 }
@@ -167,6 +168,7 @@ static int bluetooth_class_handler(struct usb_setup_packet *setup,
 		return -ENOMEM;
 	}
 
+	net_buf_reserve(buf, CONFIG_BT_HCI_RESERVE);
 	bt_buf_set_type(buf, BT_BUF_CMD);
 
 	net_buf_add_mem(buf, *data, *len);


### PR DESCRIPTION
This PR:
- adds TX thread to bluetooth class in order call bt_send in thread context.
- Fixes assert/mem corrupt issue due to unreserved headroom (for BT packet H4 type)
- Introduces transfer API for ACL ep out