### PR TITLE
sanitycheck: Add progress to verbose mode

### DIFF
--- a/scripts/sanitycheck
+++ b/scripts/sanitycheck
@@ -2602,6 +2602,14 @@ def chatty_test_cb(instances, goals, goal):
     if VERBOSE < 2 and not goal.finished:
         return
 
+    total_tests = len(goals)
+    total_tests_width = len(str(total_tests))
+    total_done = 0
+
+    for k, g in goals.items():
+        if g.finished:
+            total_done += 1
+
     if goal.failed:
         status = COLOR_RED + "FAILED" + COLOR_NORMAL + ": " + goal.reason
     elif goal.finished:
@@ -2609,7 +2617,9 @@ def chatty_test_cb(instances, goals, goal):
     else:
         status = goal.make_state
 
-    info("{:<25} {:<50} {}".format(i.platform.name, i.test.name, status))
+    info("{:>{}}/{} {:<25} {:<50} {}".format(
+        total_done, total_tests_width, total_tests, i.platform.name,
+        i.test.name, status))
     if goal.failed:
         log_info(goal.get_error_log())
 


### PR DESCRIPTION
In verbose mode (-v) progress of running test cases number out of total
number is not printed. Thus, if there are many test cases, it is
impossible to follow the progress. This commit adds printing of current
test case and total numbers to the verbose output.

Signed-off-by: Ruslan Mstoi <ruslan.mstoi@intel.com>