### PR TITLE
samples: net: big_http_download: Ignore close() return value.

### DIFF
--- a/samples/net/sockets/big_http_download/src/big_http_download.c
+++ b/samples/net/sockets/big_http_download/src/big_http_download.c
@@ -172,7 +172,7 @@ void download(struct addrinfo *ai)
 	}
 
 error:
-	close(sock);
+	(void)close(sock);
 }
 
 int main(void)


### PR DESCRIPTION
We aren't interested in doing error handling for close(), close()
is itself on error handling path, and its purpose if to free
socket resources.

Coverity-CID: 186062
Fixes: #7713

Signed-off-by: Paul Sokolovsky <paul.sokolovsky@linaro.org>