### PR TITLE
boards: native_posix: Build with Address Sanitizer by default

### DIFF
--- a/.shippable.yml
+++ b/.shippable.yml
@@ -29,6 +29,7 @@ build:
         options: "-e HOME=/home/buildslave --privileged=true --tty --net=bridge --user buildslave"
 
     ci:
+      - sudo apt-get install -y libasan1
       - export CCACHE_DIR=${SHIPPABLE_BUILD_DIR}/ccache/.ccache
       - >
         if [ "$IS_PULL_REQUEST" = "true" ]; then

--- a/arch/posix/CMakeLists.txt
+++ b/arch/posix/CMakeLists.txt
@@ -20,6 +20,12 @@ zephyr_link_libraries_ifdef(CONFIG_COVERAGE
 	-lgcov
 	)
 
+if (CONFIG_ASAN)
+	zephyr_compile_options(-fsanitize=address)
+	zephyr_link_libraries(-lasan)
+	zephyr_ld_options(-fsanitize=address)
+endif ()
+
 zephyr_compile_definitions(_POSIX_C_SOURCE=200809)
 
 zephyr_ld_options(

--- a/boards/posix/native_posix/Kconfig.defconfig
+++ b/boards/posix/native_posix/Kconfig.defconfig
@@ -23,4 +23,7 @@ config ETH_NATIVE_POSIX
 
 endif # NETWORKING
 
+config ASAN
+	def_bool y
+
 endif

--- a/subsys/debug/Kconfig
+++ b/subsys/debug/Kconfig
@@ -16,6 +16,19 @@ config DEBUG
 	  only disables optimization, more debugging variants can be selected
 	  from here to allow more debugging.
 
+config ASAN
+	bool "Build with address sanitizer"
+	depends on ARCH_POSIX
+	default n
+	help
+	  Builds Zephyr with Address Sanitizer enabled.  This is currently
+	  only supported by the POSIX port, and requires a recent-ish
+	  compiler with the `-fsanitize=address` command line option, and
+	  the libasan library.
+
+	  This is enabled by default in the POSIX port in an attempt to
+	  capture bugs in the CI system.
+
 config STACK_USAGE
 	bool "Generate stack usage information"
 	default n


### PR DESCRIPTION
Address Sanitizer helps finding issues related to memory: buffer
overflows, usage of uninitialized memory, etc.  This is available in
both Clang and GCC for a while, and, since the POSIX port is only
meant for testing, this will help find issues in the CI system.

Signed-off-by: Leandro Pereira <leandro.pereira@intel.com>