### PR TITLE
tests: posix: Function call return values need to be validated.

### DIFF
--- a/tests/posix/pthread_rwlock/src/posix_rwlock.c
+++ b/tests/posix/pthread_rwlock/src/posix_rwlock.c
@@ -80,7 +80,8 @@ static void test_rw_lock(void)
 
 	/* Creating N premptive threads in increasing order of priority */
 	for (i = 0; i < N_THR; i++) {
-		pthread_attr_init(&attr[i]);
+		zassert_false(pthread_attr_init(&attr[i]),
+				"Unable to create pthread object attrib\n";
 
 		/* Setting scheduling priority */
 		schedparam.priority = i + 1;

--- a/tests/posix/pthread_rwlock/src/posix_rwlock.c
+++ b/tests/posix/pthread_rwlock/src/posix_rwlock.c
@@ -81,7 +81,7 @@ static void test_rw_lock(void)
 	/* Creating N premptive threads in increasing order of priority */
 	for (i = 0; i < N_THR; i++) {
 		zassert_false(pthread_attr_init(&attr[i]),
-				"Unable to create pthread object attrib\n";
+				"Unable to create pthread object attrib\n");
 
 		/* Setting scheduling priority */
 		schedparam.priority = i + 1;

--- a/tests/posix/pthread_rwlock/src/posix_rwlock.c
+++ b/tests/posix/pthread_rwlock/src/posix_rwlock.c
@@ -80,7 +80,7 @@ static void test_rw_lock(void)
 
 	/* Creating N premptive threads in increasing order of priority */
 	for (i = 0; i < N_THR; i++) {
-		zassert_false(pthread_attr_init(&attr[i]),
+		zassert_false(pthread_attr_init(&attr[i]), 
 				"Unable to create pthread object attrib\n");
 
 		/* Setting scheduling priority */


### PR DESCRIPTION
In this fix we are checking the return value of pthread_attr_init before
asserting a pthread_attr_destroy and init retry.

Resolves #7084 
Coverity-CID: 185280

Signed-off-by: Sritej Kanakadandi Venkata Rama <sritej.kvr@gmail.com>