### PR TITLE
net: tc: dont yield during net_rc tx/rx workq init

### DIFF
--- a/subsys/net/ip/net_tc.c
+++ b/subsys/net/ip/net_tc.c
@@ -345,8 +345,6 @@ void net_tc_tx_init(void)
 			       K_THREAD_STACK_SIZEOF(tx_stack[i]),
 			       K_PRIO_COOP(thread_priority));
 	}
-
-	k_yield();
 }
 
 void net_tc_rx_init(void)
@@ -385,6 +383,4 @@ void net_tc_rx_init(void)
 			       K_THREAD_STACK_SIZEOF(rx_stack[i]),
 			       K_PRIO_COOP(thread_priority));
 	}
-
-	k_yield();
 }


### PR DESCRIPTION
We init the net_tc tx/rx work queues during net_init() with a
call to init_rx_queues().  The L2/L3 and networking drivers have been
setup at this point.  If we yield the current thread, we risk
a call to net_recv_data() which calls net_queue_rx() which calls
net_tc_submit_to_rx_queue() on an RX work queue which hasn't been
setup yet.

This manifests as a boot hang under seemingly random circumstances.

Fixes #8005 

Signed-off-by: Michael Scott <michael@opensourcefoundries.com>