### PR TITLE
usb: cdc_acm: Set bInterfaceProtocol to No Protocol (0)

### DIFF
--- a/subsys/usb/usb_descriptor.c
+++ b/subsys/usb/usb_descriptor.c
@@ -230,7 +230,7 @@ static struct dev_common_descriptor common_desc = {
 			.bNumEndpoints = 1,
 			.bInterfaceClass = COMMUNICATION_DEVICE_CLASS,
 			.bInterfaceSubClass = ACM_SUBCLASS,
-			.bInterfaceProtocol = V25TER_PROTOCOL,
+			.bInterfaceProtocol = 0,
 			.iInterface = 0,
 		},
 		/* Header Functional Descriptor */


### PR DESCRIPTION
Do not set protocol in interface descriptor. Although this field has
been ignored by major OSs during the last decades, this creates a big
deal of problems with ModemManager sending unexpected AT commands when
plugging in a dev board.

Fixes: #6646

Signed-off-by: Andrei Emeltchenko <andrei.emeltchenko@intel.com>