### PR TITLE
Arch arm mpu assert additions and fixes

### DIFF
--- a/arch/arm/core/cortex_m/mpu/arm_mpu.c
+++ b/arch/arm/core/cortex_m/mpu/arm_mpu.c
@@ -143,7 +143,7 @@ static inline u32_t _get_region_index_by_type(u32_t type)
 }
 
 /**
- * This internal function check if region is enabled or not
+ * This internal function checks if region is enabled or not.
  */
 static inline int _is_enabled_region(u32_t r_index)
 {
@@ -153,7 +153,7 @@ static inline int _is_enabled_region(u32_t r_index)
 }
 
 /**
- * This internal function check if the given buffer in in the region
+ * This internal function checks if the given buffer is in the region.
  */
 static inline int _is_in_region(u32_t r_index, u32_t start, u32_t size)
 {
@@ -175,7 +175,7 @@ static inline int _is_in_region(u32_t r_index, u32_t start, u32_t size)
 }
 
 /**
- * This internal function check if the region is user accessible or not
+ * This internal function checks if the region is user accessible or not.
  */
 static inline int _is_user_accessible_region(u32_t r_index, int write)
 {
@@ -269,9 +269,10 @@ void arm_core_mpu_configure_user_context(struct k_thread *thread)
 	index = _get_region_index_by_type(THREAD_APP_DATA_REGION);
 	size = (u32_t)&__app_ram_end - (u32_t)&__app_ram_start;
 	region_attr = _get_region_attr_by_type(THREAD_APP_DATA_REGION, size);
-	if (size > 0)
+	if (size > 0) {
 		_region_init(index, (u32_t)&__app_ram_start, region_attr);
-#endif
+	}
+#endif /* CONFIG_APPLICATION_MEMORY */
 }
 
 /**

--- a/arch/arm/core/cortex_m/mpu/arm_mpu.c
+++ b/arch/arm/core/cortex_m/mpu/arm_mpu.c
@@ -96,7 +96,7 @@ static inline u8_t _get_num_regions(void)
 /* This internal function performs MPU region initialization.
  *
  * Note:
- *   The caller is responsible to supply a valid region index.
+ *   The caller must provide a valid region index.
  */
 static void _region_init(u32_t index, u32_t region_addr,
 			 u32_t region_attr)

--- a/arch/arm/core/cortex_m/mpu/arm_mpu.c
+++ b/arch/arm/core/cortex_m/mpu/arm_mpu.c
@@ -93,6 +93,11 @@ static inline u8_t _get_num_regions(void)
 	return (u8_t)type;
 }
 
+/* This internal function performs MPU region initialization.
+ *
+ * Note:
+ *   The caller is responsible to supply a valid region index.
+ */
 static void _region_init(u32_t index, u32_t region_addr,
 			 u32_t region_attr)
 {
@@ -144,6 +149,9 @@ static inline u32_t _get_region_index_by_type(u32_t type)
 
 /**
  * This internal function checks if region is enabled or not.
+ *
+ * Note:
+ *   The caller must provide a valid region number.
  */
 static inline int _is_enabled_region(u32_t r_index)
 {
@@ -154,6 +162,9 @@ static inline int _is_enabled_region(u32_t r_index)
 
 /**
  * This internal function checks if the given buffer is in the region.
+ *
+ * Note:
+ *   The caller must provide a valid region number.
  */
 static inline int _is_in_region(u32_t r_index, u32_t start, u32_t size)
 {
@@ -176,6 +187,9 @@ static inline int _is_in_region(u32_t r_index, u32_t start, u32_t size)
 
 /**
  * This internal function checks if the region is user accessible or not.
+ *
+ * Note:
+ *   The caller must provide a valid region number.
  */
 static inline int _is_user_accessible_region(u32_t r_index, int write)
 {

--- a/arch/arm/core/cortex_m/mpu/nxp_mpu.c
+++ b/arch/arm/core/cortex_m/mpu/nxp_mpu.c
@@ -120,7 +120,7 @@ static inline u32_t _get_region_index_by_type(u32_t type)
 }
 
 /**
- * This internal function check if region is enabled or not
+ * This internal function checks if region is enabled or not.
  */
 static inline int _is_enabled_region(u32_t r_index)
 {
@@ -128,7 +128,7 @@ static inline int _is_enabled_region(u32_t r_index)
 }
 
 /**
- * This internal function check if the given buffer in in the region
+ * This internal function checks if the given buffer is in the region.
  */
 static inline int _is_in_region(u32_t r_index, u32_t start, u32_t size)
 {
@@ -146,7 +146,7 @@ static inline int _is_in_region(u32_t r_index, u32_t start, u32_t size)
 }
 
 /**
- * This internal function check if the region is user accessible or not
+ * This internal function checks if the region is user accessible or not.
  */
 static inline int _is_user_accessible_region(u32_t r_index, int write)
 {
@@ -170,7 +170,7 @@ static void nxp_mpu_setup_sram_region(u32_t base, u32_t size)
 
 	/*
 	 * The NXP MPU manages the permissions of the overlapping regions
-	 * doing the logic OR in between them, hence they can't be used
+	 * doing the logical OR in between them, hence they can't be used
 	 * for stack/stack guard protection. For this reason the last region of
 	 * the MPU will be reserved.
 	 *
@@ -407,7 +407,7 @@ int arm_core_mpu_buffer_validate(void *addr, size_t size, int write)
 {
 	u32_t r_index;
 
-	/* Iterate all mpu regions */
+	/* Iterate all MPU regions */
 	for (r_index = 0; r_index < _get_num_regions(); r_index++) {
 		if (!_is_enabled_region(r_index) ||
 		    !_is_in_region(r_index, (u32_t)addr, size)) {


### PR DESCRIPTION
Addresses #7384.
Addresses an additional bug related to region out-of-bounds configuration (see relevant comment).
Adds some minor fixes to the code and comment enhancements.
