### PR TITLE
doc: fix doxygen error for device.h macros

### DIFF
--- a/doc/zephyr.doxyfile
+++ b/doc/zephyr.doxyfile
@@ -1983,6 +1983,8 @@ PREDEFINED             = "CONFIG_SYS_CLOCK_EXISTS=y" \
                          "CONFIG_USERSPACE=y" \
                          "CONFIG_BT_BREDR=y" \
                          "NET_MGMT_DEFINE_REQUEST_HANDLER(x)=" \
+                         "DEVICE_DEFINE()=" \
+                         "DEVICE_AND_API_INIT()=" \
                          "__deprecated=" \
                          "__packed=" \
                          "__aligned(x)=" \


### PR DESCRIPTION
Doxygen has issues with function macros (those that don't end with a
semicolon).  Workaround is to have doxygen treat these as predefined by
the doxygen preprocessor.

Fixes: #7367

Signed-off-by: David B. Kinder <david.b.kinder@intel.com>