### PR TITLE
net: sched: It's ok to preempt coop threads if they're polling

### DIFF
--- a/kernel/sched.c
+++ b/kernel/sched.c
@@ -172,7 +172,8 @@ static void update_cache(int preempt_ok)
 		/* Don't preempt cooperative threads unless the caller allows
 		 * it (i.e. k_yield())
 		 */
-		if (!preempt_ok && !_is_preempt(_current) && !is_metairq(th)) {
+		if (!preempt_ok && _is_thread_ready(_current) &&
+		    !_is_preempt(_current) && !is_metairq(th)) {
 			th = _current;
 		}
 	}


### PR DESCRIPTION
commit 1856e2206d12 ("kernel/sched: Don't preempt cooperative threads")
changed the behavior of update_cache() in kernel/sched.c so that
high priority threads couldn't be preempted (they are after all
high priority threads).

In kernel/workq.c: work_q_main() the function call to k_queue_get()
can end up using k_poll() if CONFIG_POLL is enabled (such as with
any application with CONFIG_NETWORKING).  Calls to k_poll will
pend threads but for some reason the POLLING state is cleared
right before the pend call.  Then it's cleared again in
signal_poll_event().

Due to the above commit where high priority threads can't be
preempted, we were seeing a random deadlock situation in
work_q_main() where the next high priority thread to be added to
the readyq was a thread that was supposed to be POLLING
(hard to tell when the state was cleared), and when the thread was
unpended, it would return from k_queue_get() with a NULL work.
The work_q_main() function immediate calls k_queue_get() again and
the scheduler immediately unpends the same thread.  Rinse and repeat.

1) Let's keep the POLLING flag in thread_state enabled until it's
cleared in signal_poll_event().
2) In update_cache() we use the POLLING flag to avoid the re-selection
of polling high priority threads.  This should avoid the spin in
work_q_main() since the polling thread will not be unpended until
a signal is hit or it's cancelled.

Fixes: https://github.com/zephyrproject-rtos/zephyr/issues/8049

Signed-off-by: Michael Scott <michael@opensourcefoundries.com>