### PR TITLE
drivers: eth: mcux: use CONFIG_SYS_LOG_ETHERNET_LEVEL for syslog level

### DIFF
--- a/drivers/ethernet/eth_mcux.c
+++ b/drivers/ethernet/eth_mcux.c
@@ -13,7 +13,7 @@
  */
 
 #define SYS_LOG_DOMAIN "dev/eth_mcux"
-#define SYS_LOG_LEVEL SYS_LOG_LEVEL_DEBUG
+#define SYS_LOG_LEVEL CONFIG_SYS_LOG_ETHERNET_LEVEL
 #include <logging/sys_log.h>
 
 #include <board.h>


### PR DESCRIPTION
Don't hard code the syslog level to DEBUG, instead use the
CONFIG_SYS_LOG_ETHERNET_LEVEL setting like other ethernet drivers.

Signed-off-by: Michael Scott <michael@opensourcefoundries.com>