### PR TITLE
kernel: thread: fix _THREAD_DUMMY check in _check_stack_sentinel()

### DIFF
--- a/kernel/thread.c
+++ b/kernel/thread.c
@@ -196,7 +196,7 @@ void _check_stack_sentinel(void)
 {
 	u32_t *stack;
 
-	if (_current->base.thread_state == _THREAD_DUMMY) {
+	if (_current->base.thread_state & _THREAD_DUMMY) {
 		return;
 	}
 


### PR DESCRIPTION
All other checks of thread_state use a bit wise & operator incase
there are other flags attached to the thread_state.  Let's fix
the only outlier in _check_stack_sentinel() to be the same.

Signed-off-by: Michael Scott <michael@opensourcefoundries.com>