### PR TITLE
tests: posix: Function call return values need to be validated.

### DIFF
--- a/tests/posix/pthread_rwlock/src/posix_rwlock.c
+++ b/tests/posix/pthread_rwlock/src/posix_rwlock.c
@@ -80,7 +80,8 @@ static void test_rw_lock(void)
 
 	/* Creating N premptive threads in increasing order of priority */
 	for (i = 0; i < N_THR; i++) {
-		pthread_attr_init(&attr[i]);
+		zassert_equal(pthread_attr_init(&attr[i]), 0,
+			      "Unable to create pthread object attrib");
 
 		/* Setting scheduling priority */
 		schedparam.priority = i + 1;


### PR DESCRIPTION
In this fix we are asserting the return value of pthread_attr_init.

Resolves #7084
Coverity-CID: 185280

Signed-off-by: Sritej Kanakadandi Venkata Rama <sritej.kvr@gmail.com>