### PR TITLE
genrest: Highlight Kconfig as Kconfig, not Python

### DIFF
--- a/doc/scripts/genrest.py
+++ b/doc/scripts/genrest.py
@@ -199,6 +199,8 @@ def write_sym_rst(sym, out_dir):
         heading += "s"
     sym_rst += "{}\n{}\n\n".format(heading, len(heading)*"=")
 
+    sym_rst += ".. highlight:: kconfig\n\n"
+
     sym_rst += "\n\n".join(
         "At ``{}:{}``, in menu ``{}``:\n\n"
         ".. parsed-literal::\n\n"


### PR DESCRIPTION
Sphinx defaults to Python highlighting, but a Kconfig lexer is available
as well
(http://pygments.org/docs/lexers/#pygments.lexers.configs.KconfigLexer).
Use it.

This only highlights Kconfig definitions without links (references to
other symbols), as Sphinx doesn't highlight '.. parsed-literal::' blocks
with links. It's an improvement over Python stuff getting highlighted at
least.

Side note: '.. highlight:: none' still gives '.. parsed-literal::'
blocks without links a different background color, for whatever reason.

Signed-off-by: Ulf Magnusson <Ulf.Magnusson@nordicsemi.no>