### PR TITLE
net/ethernet: Add a way to configure MAC address filters into devices

### DIFF
--- a/include/net/ethernet.h
+++ b/include/net/ethernet.h
@@ -84,6 +84,9 @@ enum ethernet_hw_caps {
 
 	/** Priority queues available */
 	ETHERNET_PRIORITY_QUEUES	= BIT(11),
+
+	/** MAC address filtering supported */
+	ETHERNET_HW_FILTERING		= BIT(12),
 };
 
 enum ethernet_config_type {
@@ -95,6 +98,7 @@ enum ethernet_config_type {
 	ETHERNET_CONFIG_TYPE_QAV_IDLE_SLOPE,
 	ETHERNET_CONFIG_TYPE_PROMISC_MODE,
 	ETHERNET_CONFIG_TYPE_PRIORITY_QUEUES_NUM,
+	ETHERNET_CONFIG_TYPE_FILTER,
 };
 
 struct ethernet_qav_queue_param {
@@ -103,6 +107,20 @@ struct ethernet_qav_queue_param {
 		unsigned int delta_bandwidth;
 		unsigned int idle_slope;
 	};
+};
+
+enum ethernet_filter_type {
+	ETHERNET_FILTER_TYPE_SRC_MAC_ADDRESS,
+	ETHERNET_FILTER_TYPE_DST_MAC_ADDRESS,
+};
+
+struct ethernet_filter {
+	/** Type of filter */
+	enum ethernet_filter_type type;
+	/** MAC address to filter */
+	struct net_eth_addr mac_address;
+	/** Set (true) or unset (false) the filter */
+	bool set;
 };
 
 struct ethernet_config {
@@ -123,6 +141,8 @@ struct ethernet_config {
 		struct ethernet_qav_queue_param qav_queue_param;
 
 		int priority_queues_num;
+
+		struct ethernet_filter filter;
 	};
 /* @endcond */
 };

--- a/tests/net/ethernet_mgmt/src/main.c
+++ b/tests/net/ethernet_mgmt/src/main.c
@@ -109,6 +109,7 @@ static int eth_fake_set_config(struct device *dev,
 				     sizeof(ctx->mac_address),
 				     NET_LINK_ETHERNET);
 		break;
+
 	case ETHERNET_CONFIG_TYPE_QAV_DELTA_BANDWIDTH:
 	case ETHERNET_CONFIG_TYPE_QAV_IDLE_SLOPE:
 		queue_id = config->qav_queue_param.queue_id;


### PR DESCRIPTION
Some Ethernet devices can filter out incoming packets through a list of
valid MAC addresses, so let's add a way to expose this capability, using
it through the ethernet device API.

Fixes #7596

Signed-off-by: Tomasz Bursztyka <tomasz.bursztyka@linux.intel.com>