### PR TITLE
[DNM] ext: debug: segger: rtt: Block by default

### DIFF
--- a/ext/debug/segger/rtt/SEGGER_RTT_Conf.h
+++ b/ext/debug/segger/rtt/SEGGER_RTT_Conf.h
@@ -86,7 +86,7 @@ Revision: $Rev: 4351 $
 
 #define SEGGER_RTT_PRINTF_BUFFER_SIZE             (64u)    // Size of buffer for RTT printf to bulk-send chars via RTT     (Default: 64)
 
-#define SEGGER_RTT_MODE_DEFAULT                   SEGGER_RTT_MODE_NO_BLOCK_SKIP // Mode for pre-initialized terminal channel (buffer 0)
+#define SEGGER_RTT_MODE_DEFAULT                   SEGGER_RTT_MODE_BLOCK_IF_FIFO_FULL // Mode for pre-initialized terminal channel (buffer 0)
 
 //
 // Target is not allowed to perform other RTT operations while string still has not been stored completely.


### PR DESCRIPTION
In order to avoid rapid logging dropping messages if the FIFO is full,
block instead (with interrupts disabled). This might have an impact on
interrupt latency, but at least log messages will not be lost.

Signed-off-by: Carles Cufi <carles.cufi@nordicsemi.no>