### PR TITLE
Meta-interrupts fix in native_posix

### DIFF
--- a/boards/posix/native_posix/board_soc.h
+++ b/boards/posix/native_posix/board_soc.h
@@ -24,6 +24,7 @@ extern "C" {
 #endif
 
 #define TIMER_TICK_IRQ 0
+#define OFFLOAD_SW_IRQ 1
 
 /*
  * This interrupt will awake the CPU if IRQs are not locked,

--- a/boards/posix/native_posix/irq_handler.c
+++ b/boards/posix/native_posix/irq_handler.c
@@ -107,12 +107,10 @@ void posix_irq_handler(void)
 	/* Call swap if all the following is true:
 	 * 1) may_swap was enabled
 	 * 2) We are not nesting irq_handler calls (interrupts)
-	 * 3) Current thread is preemptible
-	 * 4) Next thread to run in the ready queue is not this thread
+	 * 3) Next thread to run in the ready queue is not this thread
 	 */
 	if (may_swap
 		&& (hw_irq_ctrl_get_cur_prio() == 256)
-		&& (_current->base.preempt < _NON_PREEMPT_THRESHOLD)
 		&& (_kernel.ready_q.cache != _current)) {
 
 		_Swap(irq_lock);

--- a/boards/posix/native_posix/irq_handler.c
+++ b/boards/posix/native_posix/irq_handler.c
@@ -294,13 +294,31 @@ void posix_sw_clear_pending_IRQ(unsigned int IRQn)
 }
 
 /**
+ * Storage for functions offloaded to IRQ
+ */
+static irq_offload_routine_t off_routine;
+static void *off_parameter;
+
+/**
+ * IRQ handler for the SW interrupt assigned to irq_offload()
+ */
+static void offload_sw_irq_handler(void *a)
+{
+	ARG_UNUSED(a);
+	off_routine(off_parameter);
+}
+
+/**
  * @brief Run a function in interrupt context
  *
- * In this simple board, the function can just be run directly
+ * Raise the SW IRQ assigned to handled this
  */
 void irq_offload(irq_offload_routine_t routine, void *parameter)
 {
-	_kernel.nested++;
-	routine(parameter);
-	_kernel.nested--;
+	off_routine = routine;
+	off_parameter = parameter;
+	_isr_declare(OFFLOAD_SW_IRQ, 0, offload_sw_irq_handler, NULL);
+	_arch_irq_enable(OFFLOAD_SW_IRQ);
+	posix_sw_set_pending_IRQ(OFFLOAD_SW_IRQ);
+	_arch_irq_disable(OFFLOAD_SW_IRQ);
 }

--- a/tests/kernel/sched/preempt/testcase.yaml
+++ b/tests/kernel/sched/preempt/testcase.yaml
@@ -1,5 +1,4 @@
 tests:
   kernel.sched.preempt:
     tags: core
-    platform_exclude: native_posix
     filter: not CONFIG_SMP


### PR DESCRIPTION
Fix in native_posix so the new meta-interrupts can also be run:

* `irq_offload()` is now based on a SW interrupt.
* The interrupt swap decision for native_posix is aligned with the other architectures
* the new kernel/sched/preempt test is enabled for native_posix too.