### PR TITLE
tests/kernel/mem_slab: Fix memory overcommit

### DIFF
--- a/tests/kernel/mem_slab/mslab_threadsafe/src/test_mslab_threadsafe.c
+++ b/tests/kernel/mem_slab/mslab_threadsafe/src/test_mslab_threadsafe.c
@@ -16,7 +16,7 @@
 #define BLK_SIZE1 8
 #define BLK_SIZE2 4
 
-K_MEM_SLAB_DEFINE(mslab1, BLK_SIZE1, BLK_NUM, BLK_ALIGN);
+K_MEM_SLAB_DEFINE(mslab1, BLK_SIZE1, BLK_NUM * THREAD_NUM, BLK_ALIGN);
 static struct k_mem_slab mslab2, *slabs[SLAB_NUM] = { &mslab1, &mslab2 };
 static K_THREAD_STACK_ARRAY_DEFINE(tstack, THREAD_NUM, STACK_SIZE);
 static struct k_thread tdata[THREAD_NUM];


### PR DESCRIPTION
This test spawned 4 threads all of which try to allocate 3 blocks from
the same mem_slab before freeing any, leading to a maximum of 12
in-flight allocations.  But the slab contained only 3 blocks!

Most of the time it passed, but CI caught it failing on occasion,
possibly more often now due to recent scheduler changes.  Fixes #8069
(hopefully).

Signed-off-by: Andy Ross <andrew.j.ross@intel.com>