### PR TITLE
doc: fix broken table display

### DIFF
--- a/boards/xtensa/intel_s1000_crb/doc/intel_s1000.rst
+++ b/boards/xtensa/intel_s1000_crb/doc/intel_s1000.rst
@@ -193,6 +193,7 @@ The pinouts for flyswatter2 and the corresponding pinouts for CRB are
 shown below. Note that pin 6 on CRB is left unconnected.
 
 The corresponding pin mapping is
+
 +-------------+-----------+
 | Flyswatter2 |   S1000   |
 +=============+===========+


### PR DESCRIPTION
Needed a blank like before the table

Fixes: #8070

Signed-off-by: David B. Kinder <david.b.kinder@intel.com>