### PR TITLE
arm: userspace: Do not overwrite r7 during syscall.

### DIFF
--- a/arch/arm/core/swap_helper.S
+++ b/arch/arm/core/swap_helper.S
@@ -365,10 +365,10 @@ _oops:
      * r4 - arg5
      * r5 - arg6
      * r6 - call_id
-     * r7 - saved link register
+     * r8 - saved link register
      */
 _do_syscall:
-    ldr r7, [r0, #24]   /* grab address of PC from stack frame */
+    ldr r8, [r0, #24]   /* grab address of PC from stack frame */
     ldr r1, =_arm_do_syscall
     str r1, [r0, #24]   /* overwrite the LR to point to _arm_do_syscall */
 

--- a/arch/arm/core/userspace.S
+++ b/arch/arm/core/userspace.S
@@ -120,7 +120,7 @@ SECTION_FUNC(TEXT, _arm_do_syscall)
     /*
      * r0-r5 contain arguments
      * r6 contains call_id
-     * r7 contains original LR
+     * r8 contains original LR
      */
     ldr ip, =_SYSCALL_BAD
     cmp r6, ip
@@ -189,6 +189,6 @@ dispatch_syscall:
      * return back to original function that called SVC, add 1 to force thumb
      * mode
      */
-    mov ip, r7
+    mov ip, r8
     orrs ip, ip, #1
     bx ip

--- a/include/arch/arm/arch.h
+++ b/include/arch/arm/arch.h
@@ -369,7 +369,7 @@ static inline u32_t _arch_syscall_invoke6(u32_t arg1, u32_t arg2, u32_t arg3,
 			 : [svid] "i" (_SVC_CALL_SYSTEM_CALL),
 			   "r" (ret), "r" (r1), "r" (r2), "r" (r3),
 			   "r" (r4), "r" (r5), "r" (r6)
-			 : "r7", "memory");
+			 : "r8", "memory");
 
 	return ret;
 }
@@ -389,7 +389,7 @@ static inline u32_t _arch_syscall_invoke5(u32_t arg1, u32_t arg2, u32_t arg3,
 			 : [svid] "i" (_SVC_CALL_SYSTEM_CALL),
 			   "r" (ret), "r" (r1), "r" (r2), "r" (r3),
 			   "r" (r4), "r" (r6)
-			 : "r7", "memory");
+			 : "r8", "memory");
 
 	return ret;
 }
@@ -408,7 +408,7 @@ static inline u32_t _arch_syscall_invoke4(u32_t arg1, u32_t arg2, u32_t arg3,
 			 : [svid] "i" (_SVC_CALL_SYSTEM_CALL),
 			   "r" (ret), "r" (r1), "r" (r2), "r" (r3),
 			   "r" (r6)
-			 : "r7", "memory");
+			 : "r8", "memory");
 
 	return ret;
 }
@@ -425,7 +425,7 @@ static inline u32_t _arch_syscall_invoke3(u32_t arg1, u32_t arg2, u32_t arg3,
 			 : "=r"(ret)
 			 : [svid] "i" (_SVC_CALL_SYSTEM_CALL),
 			   "r" (ret), "r" (r1), "r" (r2), "r" (r6)
-			 : "r7", "memory", "r3");
+			 : "r8", "memory", "r3");
 
 	return ret;
 }
@@ -440,7 +440,7 @@ static inline u32_t _arch_syscall_invoke2(u32_t arg1, u32_t arg2, u32_t call_id)
 			 : "=r"(ret)
 			 : [svid] "i" (_SVC_CALL_SYSTEM_CALL),
 			   "r" (ret), "r" (r1), "r" (r6)
-			 : "r7", "memory", "r2", "r3");
+			 : "r8", "memory", "r2", "r3");
 
 	return ret;
 }
@@ -454,7 +454,7 @@ static inline u32_t _arch_syscall_invoke1(u32_t arg1, u32_t call_id)
 			 : "=r"(ret)
 			 : [svid] "i" (_SVC_CALL_SYSTEM_CALL),
 			   "r" (ret), "r" (r6)
-			 : "r7", "memory", "r1", "r2", "r3");
+			 : "r8", "memory", "r1", "r2", "r3");
 	return ret;
 }
 
@@ -467,7 +467,7 @@ static inline u32_t _arch_syscall_invoke0(u32_t call_id)
 			 : "=r"(ret)
 			 : [svid] "i" (_SVC_CALL_SYSTEM_CALL),
 			   "r" (ret), "r" (r6)
-			 : "r7", "memory", "r1", "r2", "r3");
+			 : "r8", "memory", "r1", "r2", "r3");
 
 	return ret;
 }


### PR DESCRIPTION
The r7 register is used as a frame pointer on ARM Thumb. As result, it cannot be modified
by the assembly code in functions using stack frame.

This pull requests replaces r7 by r8, which is a general purpose register, fixes #7704.

All tests with CONFIG_USERSPACE=y passed without any problems.