### PR TITLE
tests: subsys: settings: fcb: Fix failure on nrf52_pca10040

### DIFF
--- a/tests/subsys/settings/fcb/nrf52_pca10040.overlay
+++ b/tests/subsys/settings/fcb/nrf52_pca10040.overlay
@@ -1,0 +1,28 @@
+&flash0 {
+	/*
+	 * For more information, see:
+	 * http://docs.zephyrproject.org/devices/dts/flash_partitions.html
+	 */
+	partitions {
+		compatible = "fixed-partitions";
+		#address-cells = <1>;
+		#size-cells = <1>;
+
+		boot_partition: partition@0 {
+			label = "mcuboot";
+			reg = <0x00000000 0xc000>;
+		};
+		slot0_partition: partition@c000 {
+			label = "image-0";
+			reg = <0x0000C000 0x32000>;
+		};
+		slot1_partition: partition@3e000 {
+			label = "image-1";
+			reg = <0x0003E000 0x32000>;
+		};
+		scratch_partition: partition@70000 {
+			label = "image-scratch";
+			reg = <0x00070000 0x10000>;
+		};
+	};
+};


### PR DESCRIPTION
Tests failed on the target because flash area reserved
for fcb data storage was to small.
This path add dts overlay file for nrf52_pac10040 board which
increases this flash area to proper size.

Fixes #8038

Signed-off-by: Andrzej Puzdrowski <andrzej.puzdrowski@nordicsemi.no>