### PR TITLE
drivers/gpio: stm32 fix gpio device init prio

### DIFF
--- a/drivers/gpio/gpio_stm32.c
+++ b/drivers/gpio/gpio_stm32.c
@@ -207,7 +207,7 @@ DEVICE_AND_API_INIT(gpio_stm32_## __suffix,				\
 		    &gpio_stm32_data_## __suffix,			\
 		    &gpio_stm32_cfg_## __suffix,			\
 		    POST_KERNEL,					\
-		    CONFIG_KERNEL_INIT_PRIORITY_DEVICE,			\
+		    CONFIG_KERNEL_INIT_PRIORITY_DEFAULT,			\
 		    &gpio_stm32_driver);
 
 


### PR DESCRIPTION
STM32 GPIO device initialization priority was set to
CONFIG_KERNEL_INIT_PRIORITY_DEFAULT
Following introduction of __ZEPHYR_SUPERVISOR__ macro (#6835),
drivers intialization order have been reordered which blocks
some use cases now.
Increase GPIO init priority to get it initialized before SPI
and avoid a deadlock.

Fixes #7663


Signed-off-by: Erwan Gouriou <erwan.gouriou@linaro.org>