### PR TITLE
clarify stack documentation and fix x86 security issue

### DIFF
--- a/include/kernel.h
+++ b/include/kernel.h
@@ -497,9 +497,15 @@ typedef struct _thread_base _thread_base_t;
 #if defined(CONFIG_THREAD_STACK_INFO)
 /* Contains the stack information of a thread */
 struct _thread_stack_info {
-	/* Stack Start */
+	/* Stack Start - Identical to K_THREAD_STACK_BUFFER() on the stack
+	 * object. Represents thread-writable stack area without any extras.
+	 */
 	u32_t start;
-	/* Stack Size */
+
+	/* Stack Size - Thread writable stack buffer size. Represents
+	 * the size of the actual area, starting from the start member,
+	 * that should be writable by the thread
+	 */
 	u32_t size;
 };
 

--- a/include/kernel.h
+++ b/include/kernel.h
@@ -4625,6 +4625,10 @@ static inline char *K_THREAD_STACK_BUFFER(k_thread_stack_t *sym)
  * parameter of k_thread_create(), it may not be the same as the
  * 'size' parameter. Use K_THREAD_STACK_SIZEOF() instead.
  *
+ * Some arches may round the size of the usable stack region up to satisfy
+ * alignment constraints. K_THREAD_STACK_SIZEOF() will return the aligned
+ * size.
+ *
  * @param sym Thread stack symbol name
  * @param size Size of the stack memory region
  * @req K-TSTACK-001
@@ -4673,12 +4677,8 @@ static inline char *K_THREAD_STACK_BUFFER(k_thread_stack_t *sym)
  * since the underlying implementation may actually create something larger
  * (for instance a guard area).
  *
- * The value returned here is guaranteed to match the 'size' parameter
- * passed to K_THREAD_STACK_DEFINE.
- *
- * Do not use this for stacks declared with K_THREAD_STACK_ARRAY_DEFINE(),
- * it is not guaranteed to return the original value since each array
- * element must be aligned.
+ * The value returned here is not guaranteed to match the 'size' parameter
+ * passed to K_THREAD_STACK_DEFINE and may be larger.
  *
  * @param sym Stack memory symbol
  * @return Size of the stack

--- a/tests/kernel/mem_protect/mem_protect/src/kobject.c
+++ b/tests/kernel/mem_protect/mem_protect/src/kobject.c
@@ -624,7 +624,7 @@ void kobject_test_user_1_18(void *p1, void *p2, void *p3)
 
 	k_thread_create(&kobject_test_reuse_4_tid,
 			kobject_stack_2,
-			(KOBJECT_STACK_SIZE * 5),
+			K_THREAD_STACK_SIZEOF(kobject_stack_2) + 1,
 			kobject_test_user_2_18,
 			NULL, NULL, NULL,
 			0, K_USER, K_NO_WAIT);


### PR DESCRIPTION
It's impossible for K_THREAD_STACK_SIZEOF() to return the same size passed to K_THREAD_STACK_DEFINE() on any architecture using user mode, there always has to be some rounding up to accommodate the granularity of memory protection regions, since the stack buffer must occupy that region without anything else in it.

x86 was not doing this, round the stack buffer size to the nearest page boundary.

A test for stack bounds overflow needed to be fixed since the arbitrary multiplier used didn't work once the size was rounded up to a 4K page.

Fixes: #8118 