### PR TITLE
Address inconsistencies in watchdog timer Kconfig options

### DIFF
--- a/drivers/watchdog/Kconfig
+++ b/drivers/watchdog/Kconfig
@@ -14,6 +14,16 @@ menuconfig WATCHDOG
 
 if WATCHDOG
 
+if !HAS_DTS_WDT
+
+config WDT_0_NAME
+	string "Watchdog driver instance name"
+	default "WATCHDOG_0"
+	help
+	  Set the name used by the watchdog device during registation.
+
+endif # HAS_DTS_WDT
+
 config WDT_DISABLE_AT_BOOT
 	bool
 	prompt "Disable at boot"

--- a/drivers/watchdog/Kconfig.cmsdk_apb
+++ b/drivers/watchdog/Kconfig.cmsdk_apb
@@ -25,11 +25,4 @@ config WDOG_CMSDK_APB_START_AT_BOOT
 	  it must be reloaded before the counter reaches 0, otherwise
 	  the MCU will be reset.
 
-config WDOG_CMSDK_APB_DEVICE_NAME
-	string "Device name for CMSDK APB Watchdog"
-	depends on WDOG_CMSDK_APB
-	default "WATCHDOG_0"
-	help
-	  Set the name used by WDOG device during registration.
-
 endif # SOC_FAMILY_ARM

--- a/drivers/watchdog/Kconfig.esp32
+++ b/drivers/watchdog/Kconfig.esp32
@@ -12,13 +12,6 @@ menuconfig WDT_ESP32
 	help
 	  Enable WDT driver for ESP32.
 
-config WDT_ESP32_DISABLE_AT_BOOT
-	bool "Disable WDT during boot"
-	depends on WDT_ESP32
-	default y
-	help
-	  Select this option to disable the WDT during boot.
-
 config WDT_ESP32_DEVICE_NAME
 	string "Device name for Watchdog (WDT)"
 	depends on WDT_ESP32

--- a/drivers/watchdog/Kconfig.esp32
+++ b/drivers/watchdog/Kconfig.esp32
@@ -12,13 +12,6 @@ menuconfig WDT_ESP32
 	help
 	  Enable WDT driver for ESP32.
 
-config WDT_ESP32_DEVICE_NAME
-	string "Device name for Watchdog (WDT)"
-	depends on WDT_ESP32
-	default "WATCHDOG_0"
-	help
-	  Set the name used by WDT device during registration.
-
 config WDT_ESP32_IRQ
 	int "IRQ line for watchdog interrupt"
 	depends on WDT_ESP32

--- a/drivers/watchdog/Kconfig.qmsi
+++ b/drivers/watchdog/Kconfig.qmsi
@@ -14,13 +14,6 @@ config WDT_QMSI
 	  This driver is simply a shim driver based on the watchdog
 	  driver provided by the QMSI BSP.
 
-config WDT_0_NAME
-	string "Watchdog driver instance name"
-	default "WATCHDOG_0"
-	depends on WDT_QMSI
-	help
-	  Watchdog driver instance name
-
 config WDT_0_IRQ_PRI
 	int "Interrupt priority"
 	depends on WDT_QMSI

--- a/drivers/watchdog/Kconfig.sam
+++ b/drivers/watchdog/Kconfig.sam
@@ -18,10 +18,3 @@ config WDT_SAM_DISABLE_AT_BOOT
 	default y
 	help
 	  Select this option to disable the WDT during boot.
-
-config WDT_SAM_DEVICE_NAME
-	string "Device name for Watchdog (WDT)"
-	depends on WDT_SAM
-	default "WDT"
-	help
-	  Set the name used by WDT device during registration.

--- a/drivers/watchdog/Kconfig.stm32
+++ b/drivers/watchdog/Kconfig.stm32
@@ -22,13 +22,6 @@ config IWDG_STM32_START_AT_BOOT
 	  it must be reloaded before the counter reaches 0, otherwise
 	  the MCU will be reset.
 
-config IWDG_STM32_DEVICE_NAME
-	string "Device name for Independent Watchdog (IWDG)"
-	depends on IWDG_STM32
-	default "IWDG"
-	help
-	  Set the name used by IWDG device during registration.
-
 config IWDG_STM32_TIMEOUT
 	int "Value for IWDG timeout in [us]"
 	depends on IWDG_STM32

--- a/drivers/watchdog/iwdg_stm32.c
+++ b/drivers/watchdog/iwdg_stm32.c
@@ -173,7 +173,7 @@ static struct iwdg_stm32_data iwdg_stm32_dev_data = {
 	.Instance = IWDG
 };
 
-DEVICE_AND_API_INIT(iwdg_stm32, CONFIG_IWDG_STM32_DEVICE_NAME,
+DEVICE_AND_API_INIT(iwdg_stm32, CONFIG_WDT_0_NAME,
 		    iwdg_stm32_init, &iwdg_stm32_dev_data, NULL,
 		    POST_KERNEL, CONFIG_KERNEL_INIT_PRIORITY_DEVICE,
 		    &iwdg_stm32_api);

--- a/drivers/watchdog/wdog_cmsdk_apb.c
+++ b/drivers/watchdog/wdog_cmsdk_apb.c
@@ -202,7 +202,7 @@ static int wdog_cmsdk_apb_init(struct device *dev)
 	return 0;
 }
 
-DEVICE_AND_API_INIT(wdog_cmsdk_apb, CONFIG_WDOG_CMSDK_APB_DEVICE_NAME,
+DEVICE_AND_API_INIT(wdog_cmsdk_apb, CONFIG_WDT_0_NAME,
 		    wdog_cmsdk_apb_init,
 		    NULL, NULL,
 		    PRE_KERNEL_1, CONFIG_KERNEL_INIT_PRIORITY_DEVICE,

--- a/drivers/watchdog/wdt_esp32.c
+++ b/drivers/watchdog/wdt_esp32.c
@@ -206,7 +206,7 @@ static int wdt_esp32_init(struct device *dev)
 
 	memset(&data->config, 0, sizeof(data->config));
 
-#ifdef CONFIG_ESP32_DISABLE_AT_BOOT
+#ifdef CONFIG_WDT_DISABLE_AT_BOOT
 	wdt_esp32_disable(dev);
 #endif
 

--- a/drivers/watchdog/wdt_esp32.c
+++ b/drivers/watchdog/wdt_esp32.c
@@ -228,7 +228,7 @@ static const struct wdt_driver_api wdt_api = {
 	.reload = wdt_esp32_reload
 };
 
-DEVICE_AND_API_INIT(wdt_esp32, CONFIG_WDT_ESP32_DEVICE_NAME, wdt_esp32_init,
+DEVICE_AND_API_INIT(wdt_esp32, CONFIG_WDT_0_NAME, wdt_esp32_init,
 		    &shared_data, NULL,
 		    PRE_KERNEL_1, CONFIG_KERNEL_INIT_PRIORITY_DEVICE,
 		    &wdt_api);

--- a/drivers/watchdog/wdt_sam.c
+++ b/drivers/watchdog/wdt_sam.c
@@ -90,7 +90,7 @@ static const struct wdt_sam_dev_cfg wdt_sam_config = {
 	.regs = WDT
 };
 
-DEVICE_AND_API_INIT(wdt_sam, CONFIG_WDT_SAM_DEVICE_NAME, wdt_sam_init,
+DEVICE_AND_API_INIT(wdt_sam, CONFIG_WDT_0_NAME, wdt_sam_init,
 		    NULL, &wdt_sam_config,
 		    PRE_KERNEL_1, CONFIG_KERNEL_INIT_PRIORITY_DEVICE,
 		    &wdt_sam_api);

--- a/drivers/watchdog/wdt_sam0.c
+++ b/drivers/watchdog/wdt_sam0.c
@@ -153,6 +153,6 @@ static int wdt_sam0_init(struct device *dev)
 
 static struct wdt_sam0_dev_data wdt_sam0_data;
 
-DEVICE_AND_API_INIT(wdt_sam0, CONFIG_WDT_SAM0_LABEL, wdt_sam0_init,
+DEVICE_AND_API_INIT(wdt_sam0, CONFIG_WDT_0_NAME, wdt_sam0_init,
 		    &wdt_sam0_data, NULL, PRE_KERNEL_1,
 		    CONFIG_KERNEL_INIT_PRIORITY_DEVICE, &wdt_sam0_api);


### PR DESCRIPTION
Two patches in the series:

1. ESP32 driver now uses CONFIG_WDT_DISABLE_AT_BOOT instead of an ESP32-specific option
2. All drivers now uses the same CONFIG_WDT_0_NAME for their watchdog timer instances, making writing test code easier.

Fixes #8094 