### PR TITLE
Bluetooth: controller: Remove redundant include of cmsis.h

### DIFF
--- a/drivers/clock_control/nrf5_power_clock.c
+++ b/drivers/clock_control/nrf5_power_clock.c
@@ -11,7 +11,6 @@
 #include <device.h>
 #include <clock_control.h>
 #include <misc/__assert.h>
-#include <arch/arm/cortex_m/cmsis.h>
 #if defined(CONFIG_USB) && defined(CONFIG_SOC_NRF52840)
 #include <nrf_power.h>
 #include <drivers/clock_control/nrf5_clock_control.h>

--- a/drivers/timer/nrf_rtc_timer.c
+++ b/drivers/timer/nrf_rtc_timer.c
@@ -8,7 +8,6 @@
 #include <clock_control.h>
 #include <system_timer.h>
 #include <drivers/clock_control/nrf5_clock_control.h>
-#include <arch/arm/cortex_m/cmsis.h>
 #include <sys_clock.h>
 
 /*

--- a/subsys/bluetooth/controller/hal/nrf5/ecb.c
+++ b/subsys/bluetooth/controller/hal/nrf5/ecb.c
@@ -7,9 +7,6 @@
 
 #include <string.h>
 #include <soc.h>
-#if !defined(CONFIG_ARCH_POSIX)
-#include <arch/arm/cortex_m/cmsis.h>
-#endif
 
 #include "util/mem.h"
 #include "hal/ecb.h"

--- a/subsys/bluetooth/controller/hal/nrf5/radio/radio.c
+++ b/subsys/bluetooth/controller/hal/nrf5/radio/radio.c
@@ -5,9 +5,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 #include <soc.h>
-#if !defined(CONFIG_ARCH_POSIX)
-#include <arch/arm/cortex_m/cmsis.h>
-#endif
 
 #include "util/mem.h"
 #include "hal/ccm.h"


### PR DESCRIPTION
Remove the redundant include of cmsis.h as soc.h already
includes it as necessary.

Signed-off-by: Vinayak Kariappa Chettimada <vich@nordicsemi.no>