### PR TITLE
Bluetooth: controller: Fix to use max. tx power in DTM test mode

### DIFF
--- a/subsys/bluetooth/controller/hal/nrf5/radio/radio.c
+++ b/subsys/bluetooth/controller/hal/nrf5/radio/radio.c
@@ -115,6 +115,11 @@ void radio_tx_power_set(u32_t power)
 	NRF_RADIO->TXPOWER = power;
 }
 
+void radio_tx_power_max_set(void)
+{
+	NRF_RADIO->TXPOWER = hal_radio_tx_power_max_get();
+}
+
 void radio_freq_chan_set(u32_t chan)
 {
 	NRF_RADIO->FREQUENCY = chan;

--- a/subsys/bluetooth/controller/hal/nrf5/radio/radio_nrf51.h
+++ b/subsys/bluetooth/controller/hal/nrf5/radio/radio_nrf51.h
@@ -50,6 +50,11 @@ static inline u32_t hal_radio_phy_mode_get(u8_t phy, u8_t flags)
 	return mode;
 }
 
+static inline u32_t hal_radio_tx_power_max_get(void)
+{
+	return RADIO_TXPOWER_TXPOWER_Pos4dBm;
+}
+
 static inline u32_t hal_radio_tx_ready_delay_us_get(u8_t phy, u8_t flags)
 {
 	ARG_UNUSED(phy);

--- a/subsys/bluetooth/controller/hal/nrf5/radio/radio_nrf52832.h
+++ b/subsys/bluetooth/controller/hal/nrf5/radio/radio_nrf52832.h
@@ -273,6 +273,11 @@ static inline u32_t hal_radio_phy_mode_get(u8_t phy, u8_t flags)
 	return mode;
 }
 
+static inline u32_t hal_radio_tx_power_max_get(void)
+{
+	return RADIO_TXPOWER_TXPOWER_Pos4dBm;
+}
+
 static inline u32_t hal_radio_tx_ready_delay_us_get(u8_t phy, u8_t flags)
 {
 	ARG_UNUSED(flags);

--- a/subsys/bluetooth/controller/hal/nrf5/radio/radio_nrf52840.h
+++ b/subsys/bluetooth/controller/hal/nrf5/radio/radio_nrf52840.h
@@ -449,6 +449,11 @@ static inline u32_t hal_radio_phy_mode_get(u8_t phy, u8_t flags)
 	return mode;
 }
 
+static inline u32_t hal_radio_tx_power_max_get(void)
+{
+	return RADIO_TXPOWER_TXPOWER_Pos8dBm;
+}
+
 static inline u32_t hal_radio_tx_ready_delay_us_get(u8_t phy, u8_t flags)
 {
 	switch (phy) {

--- a/subsys/bluetooth/controller/hal/radio.h
+++ b/subsys/bluetooth/controller/hal/radio.h
@@ -17,6 +17,7 @@ void radio_setup(void);
 void radio_reset(void);
 void radio_phy_set(u8_t phy, u8_t flags);
 void radio_tx_power_set(u32_t power);
+void radio_tx_power_max_set(void);
 void radio_freq_chan_set(u32_t chan);
 void radio_whiten_iv_set(u32_t iv);
 void radio_aa_set(u8_t *aa);

--- a/subsys/bluetooth/controller/ll_sw/ll_test.c
+++ b/subsys/bluetooth/controller/ll_sw/ll_test.c
@@ -186,7 +186,7 @@ static u32_t init(u8_t chan, u8_t phy, void (*isr)(void))
 	/* NOTE: No whitening in test mode. */
 	radio_phy_set(test_phy, test_phy_flags);
 	radio_tmr_tifs_set(150);
-	radio_tx_power_set(0);
+	radio_tx_power_max_set();
 	radio_freq_chan_set((chan << 1) + 2);
 	radio_aa_set((u8_t *)&test_sync_word);
 	radio_crc_configure(0x65b, 0x555555);


### PR DESCRIPTION
According to the Bluetooth Specification v5.0, Direct Test
Mode shall use maximum Tx power.

Fixed by adding nRF5x Radio HAL interfaces to get supported
maximum Tx power for SoC selected, and DTM testing sets the
Radio peripheral to use maximum Tx power.

Fixes #7243

Signed-off-by: Vinayak Kariappa Chettimada <vich@nordicsemi.no>