### PR TITLE
kernel: sched: use _is_thread_ready() in should_preempt()

### DIFF
--- a/kernel/sched.c
+++ b/kernel/sched.c
@@ -122,7 +122,7 @@ static int should_preempt(struct k_thread *th, int preempt_ok)
 	}
 
 	/* Or if we're pended/suspended/dummy (duh) */
-	if (!_current || _is_thread_prevented_from_running(_current)) {
+	if (!_current || !_is_thread_ready(_current)) {
 		return 1;
 	}
 


### PR DESCRIPTION
We are using _is_thread_prevented_from_running() to see if the
_current thread can be preempted in should_preempt().  The idea
being that even if the _current thread is a high priority coop
thread, we can still preempt it when it's pending, suspended,
etc.

This does not take into account if the thread is sleeping.

k_sleep() merely removes the thread from the ready_q and calls
Swap().  The scheduler will swap away from the thread temporarily
and then on the next cycle get stuck to the sleeping thread for
however long the sleep timeout is, doing exactly nothing because
other functions like _ready_thread() use _is_thread_ready() as a
check before proceeding.

We should use !_is_thread_ready() to take into account when threads
are waiting on a timer, and let other threads run in the meantime.

Fixes: https://github.com/zephyrproject-rtos/zephyr/issues/8128

Signed-off-by: Michael Scott <michael@opensourcefoundries.com>