### PR TITLE
tests: benchmarks: sys_kernel: Exclude arduino_due.

### DIFF
--- a/tests/benchmarks/sys_kernel/testcase.yaml
+++ b/tests/benchmarks/sys_kernel/testcase.yaml
@@ -2,4 +2,5 @@ tests:
   benchmark.kernel:
     arch_exclude: nios2 riscv32 xtensa
     min_ram: 32
+    platform_exclude: arduino_due
     tags: benchmark


### PR DESCRIPTION
Arduino due runs at a higher frequency hence the systick will
overflow during the benchmark resulting in incorrect values.

Fixes: GH-7906

Signed-off-by: Adithya Baglody <adithya.nagaraj.baglody@intel.com>