### PR TITLE
doc: fix early closing of GPIO doxygen defgroup

### DIFF
--- a/include/gpio.h
+++ b/include/gpio.h
@@ -35,8 +35,9 @@ extern "C" {
 /** @cond INTERNAL_HIDDEN */
 #define GPIO_ACCESS_BY_PIN 0
 #define GPIO_ACCESS_BY_PORT 1
-/** @endcond */
-/** @} */
+/**
+ * @endcond
+ */
 
 /**
  * @deprecated


### PR DESCRIPTION
GPIO API was not shown in doxygen output and on website because the
defgroup was closed prematurely. The closing brackets are still present
on the end of the file, so the additional closing can be safely deleted.

Fixes #8142

Signed-off-by: Johannes Hutter <johannes@proglove.de>