### PR TITLE
cmake: Improve user error feedback when cmake -H$ZEPHYR_BASE is specified

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,3 +1,13 @@
+if(NOT DEFINED ZEPHYR_BINARY_DIR)
+  message(FATAL_ERROR "A user error has occured.
+cmake was invoked with '${CMAKE_CURRENT_LIST_DIR}' specified as the source directory,
+but it must be invoked with an application source directory,
+such as '${CMAKE_CURRENT_LIST_DIR}/samples/hello_world'.
+Debug variables:
+CMAKE_CACHEFILE_DIR: ${CMAKE_CACHEFILE_DIR}
+")
+endif()
+
 project(Zephyr-Kernel VERSION ${PROJECT_VERSION})
 enable_language(C CXX ASM)
 


### PR DESCRIPTION
Users are sometimes mistakenly invoking cmake with $ZEPHYR_BASE set as
the source directory.

This user-error can occur if the user believes that the toplevel
CMakeLists.txt file is at the root of the repo, or if the user uses
the wrong path when invoking cmake.

The error given when this user-error occurs is cryptic and undefined,
so we replace it with what should be an easy-to-understand error
message.

Signed-off-by: Sebastian Bøe <sebastian.boe@nordicsemi.no>