### PR TITLE
spi: spi_ll_stm32: (fix) Clear OVR bit condition

### DIFF
--- a/drivers/spi/spi_ll_stm32.c
+++ b/drivers/spi/spi_ll_stm32.c
@@ -55,6 +55,12 @@ static int spi_stm32_get_err(SPI_TypeDef *spi)
 	if (sr & SPI_STM32_ERR_MSK) {
 		SYS_LOG_ERR("%s: err=%d", __func__,
 			    sr & SPI_STM32_ERR_MSK);
+
+		/* OVR error must be explicitly cleared */
+		if (LL_SPI_IsActiveFlag_OVR(spi)) {
+			LL_SPI_ClearFlag_OVR(spi);
+		}
+
 		return -EIO;
 	}
 


### PR DESCRIPTION
The OVR condition in the Status Register requires a
particular sequence in order to be cleared. If not
done properly it stays set forever.

Signed-off-by: Armando Visconti <armando.visconti@st.com>