### PR TITLE
Bluetooth: Mesh: Fix (re)transmit interval handling

### DIFF
--- a/include/bluetooth/mesh/access.h
+++ b/include/bluetooth/mesh/access.h
@@ -197,8 +197,8 @@ struct bt_mesh_model_op {
  *  @brief Encode transmission count & interval steps.
  *
  *  @param count   Number of retransmissions (first transmission is excluded).
- *  @param int_ms  Interval steps in milliseconds. Must be greater than 0
- *                 and a multiple of 10.
+ *  @param int_ms  Interval steps in milliseconds. Must be greater than 0,
+ *                 less than or equal to 320, and a multiple of 10.
  *
  *  @return Mesh transmit value that can be used e.g. for the default
  *          values of the configuration model data.

--- a/subsys/bluetooth/host/mesh/adv.h
+++ b/subsys/bluetooth/host/mesh/adv.h
@@ -30,8 +30,8 @@ struct bt_mesh_adv {
 
 	u8_t      type:2,
 		  busy:1;
-	u8_t      count:3,
-		  adv_int:5;
+	u8_t      xmit;
+
 	union {
 		/* Address, used e.g. for Friend Queue messages */
 		u16_t addr;
@@ -46,14 +46,13 @@ struct bt_mesh_adv {
 typedef struct bt_mesh_adv *(*bt_mesh_adv_alloc_t)(int id);
 
 /* xmit_count: Number of retransmissions, i.e. 0 == 1 transmission */
-struct net_buf *bt_mesh_adv_create(enum bt_mesh_adv_type type, u8_t xmit_count,
-				   u8_t xmit_int, s32_t timeout);
+struct net_buf *bt_mesh_adv_create(enum bt_mesh_adv_type type, u8_t xmit,
+				   s32_t timeout);
 
 struct net_buf *bt_mesh_adv_create_from_pool(struct net_buf_pool *pool,
 					     bt_mesh_adv_alloc_t get_id,
 					     enum bt_mesh_adv_type type,
-					     u8_t xmit_count, u8_t xmit_int,
-					     s32_t timeout);
+					     u8_t xmit, s32_t timeout);
 
 void bt_mesh_adv_send(struct net_buf *buf, const struct bt_mesh_send_cb *cb,
 		      void *cb_data);

--- a/subsys/bluetooth/host/mesh/beacon.c
+++ b/subsys/bluetooth/host/mesh/beacon.c
@@ -33,12 +33,10 @@
 #define BEACON_TYPE_SECURE         0x01
 
 /* 3 transmissions, 20ms interval */
-#define UNPROV_XMIT_COUNT          2
-#define UNPROV_XMIT_INT            20
+#define UNPROV_XMIT                BT_MESH_TRANSMIT(2, 20)
 
 /* 1 transmission, 20ms interval */
-#define PROV_XMIT_COUNT            0
-#define PROV_XMIT_INT              20
+#define PROV_XMIT                  BT_MESH_TRANSMIT(0, 20)
 
 static struct k_delayed_work beacon_timer;
 
@@ -134,8 +132,8 @@ static int secure_beacon_send(void)
 			continue;
 		}
 
-		buf = bt_mesh_adv_create(BT_MESH_ADV_BEACON, PROV_XMIT_COUNT,
-					 PROV_XMIT_INT, K_NO_WAIT);
+		buf = bt_mesh_adv_create(BT_MESH_ADV_BEACON, PROV_XMIT,
+					 K_NO_WAIT);
 		if (!buf) {
 			BT_ERR("Unable to allocate beacon buffer");
 			return -ENOBUFS;
@@ -160,8 +158,7 @@ static int unprovisioned_beacon_send(void)
 
 	BT_DBG("");
 
-	buf = bt_mesh_adv_create(BT_MESH_ADV_BEACON, UNPROV_XMIT_COUNT,
-				 UNPROV_XMIT_INT, K_NO_WAIT);
+	buf = bt_mesh_adv_create(BT_MESH_ADV_BEACON, UNPROV_XMIT, K_NO_WAIT);
 	if (!buf) {
 		BT_ERR("Unable to allocate beacon buffer");
 		return -ENOBUFS;
@@ -187,8 +184,8 @@ static int unprovisioned_beacon_send(void)
 	if (prov->uri) {
 		size_t len;
 
-		buf = bt_mesh_adv_create(BT_MESH_ADV_URI, UNPROV_XMIT_COUNT,
-					 UNPROV_XMIT_INT, K_NO_WAIT);
+		buf = bt_mesh_adv_create(BT_MESH_ADV_URI, UNPROV_XMIT,
+					 K_NO_WAIT);
 		if (!buf) {
 			BT_ERR("Unable to allocate URI buffer");
 			return -ENOBUFS;

--- a/subsys/bluetooth/host/mesh/friend.c
+++ b/subsys/bluetooth/host/mesh/friend.c
@@ -40,8 +40,7 @@
 /* PDUs from Friend to the LPN should only be transmitted once with the
  * smallest possible interval (20ms).
  */
-#define FRIEND_XMIT_COUNT   0
-#define FRIEND_XMIT_INT     20
+#define FRIEND_XMIT         BT_MESH_TRANSMIT(0, 20)
 
 struct friend_pdu_info {
 	u16_t  src;
@@ -96,8 +95,7 @@ static struct net_buf *friend_buf_alloc(u16_t src)
 	do {
 		buf = bt_mesh_adv_create_from_pool(&friend_buf_pool, adv_alloc,
 						   BT_MESH_ADV_DATA,
-						   FRIEND_XMIT_COUNT,
-						   FRIEND_XMIT_INT, K_NO_WAIT);
+						   FRIEND_XMIT, K_NO_WAIT);
 		if (!buf) {
 			discard_buffer();
 		}

--- a/subsys/bluetooth/host/mesh/net.c
+++ b/subsys/bluetooth/host/mesh/net.c
@@ -1170,9 +1170,7 @@ static void bt_mesh_net_relay(struct net_buf_simple *sbuf,
 		transmit = bt_mesh_net_transmit_get();
 	}
 
-	buf = bt_mesh_adv_create(BT_MESH_ADV_DATA,
-				 BT_MESH_TRANSMIT_COUNT(transmit),
-				 BT_MESH_TRANSMIT_INT(transmit), K_NO_WAIT);
+	buf = bt_mesh_adv_create(BT_MESH_ADV_DATA, transmit, K_NO_WAIT);
 	if (!buf) {
 		BT_ERR("Out of relay buffers");
 		return;

--- a/subsys/bluetooth/host/mesh/prov.c
+++ b/subsys/bluetooth/host/mesh/prov.c
@@ -34,8 +34,7 @@
 #include "prov.h"
 
 /* 3 transmissions, 20ms interval */
-#define PROV_XMIT_COUNT        2
-#define PROV_XMIT_INT          20
+#define PROV_XMIT              BT_MESH_TRANSMIT(2, 20)
 
 #define AUTH_METHOD_NO_OOB     0x00
 #define AUTH_METHOD_STATIC     0x01
@@ -264,8 +263,7 @@ static struct net_buf *adv_buf_create(void)
 {
 	struct net_buf *buf;
 
-	buf = bt_mesh_adv_create(BT_MESH_ADV_PROV, PROV_XMIT_COUNT,
-				 PROV_XMIT_INT, BUF_TIMEOUT);
+	buf = bt_mesh_adv_create(BT_MESH_ADV_PROV, PROV_XMIT, BUF_TIMEOUT);
 	if (!buf) {
 		BT_ERR("Out of provisioning buffers");
 		return NULL;

--- a/subsys/bluetooth/host/mesh/transport.c
+++ b/subsys/bluetooth/host/mesh/transport.c
@@ -115,9 +115,7 @@ static int send_unseg(struct bt_mesh_net_tx *tx, struct net_buf_simple *sdu,
 	BT_DBG("src 0x%04x dst 0x%04x app_idx 0x%04x sdu_len %u",
 	       tx->src, tx->ctx->addr, tx->ctx->app_idx, sdu->len);
 
-	buf = bt_mesh_adv_create(BT_MESH_ADV_DATA,
-				 BT_MESH_TRANSMIT_COUNT(tx->xmit),
-				 BT_MESH_TRANSMIT_INT(tx->xmit), BUF_TIMEOUT);
+	buf = bt_mesh_adv_create(BT_MESH_ADV_DATA, tx->xmit, BUF_TIMEOUT);
 	if (!buf) {
 		BT_ERR("Out of network buffers");
 		return -ENOBUFS;
@@ -356,9 +354,7 @@ static int send_seg(struct bt_mesh_net_tx *net_tx, struct net_buf_simple *sdu,
 		u16_t len;
 		int err;
 
-		seg = bt_mesh_adv_create(BT_MESH_ADV_DATA,
-					 BT_MESH_TRANSMIT_COUNT(net_tx->xmit),
-					 BT_MESH_TRANSMIT_INT(net_tx->xmit),
+		seg = bt_mesh_adv_create(BT_MESH_ADV_DATA, net_tx->xmit,
 					 BUF_TIMEOUT);
 		if (!seg) {
 			BT_ERR("Out of segment buffers");
@@ -930,9 +926,7 @@ int bt_mesh_ctl_send(struct bt_mesh_net_tx *tx, u8_t ctl_op, void *data,
 	       tx->ctx->addr, tx->ctx->send_ttl, ctl_op);
 	BT_DBG("len %zu: %s", data_len, bt_hex(data, data_len));
 
-	buf = bt_mesh_adv_create(BT_MESH_ADV_DATA,
-				 BT_MESH_TRANSMIT_COUNT(tx->xmit),
-				 BT_MESH_TRANSMIT_INT(tx->xmit), BUF_TIMEOUT);
+	buf = bt_mesh_adv_create(BT_MESH_ADV_DATA, tx->xmit, BUF_TIMEOUT);
 	if (!buf) {
 		BT_ERR("Out of transport buffers");
 		return -ENOBUFS;


### PR DESCRIPTION
The adv_send() function was incorrectly decoding the 5-bit value (it
was using it directly as milliseconds), which effectively lead to the
code always picking the controller's minimum supported interval.

Fix this issue, but do it by simplifying the (re)transmission state
tracking so that the state is always stored in the original "packed"
8-bit value, where 5 bits are reserved for the interval, and 3 for the
count.

Fixes #7972

Signed-off-by: Johan Hedberg <johan.hedberg@intel.com>