### PR TITLE
arch/arc: Set the right priority for WDT on quark_se

### DIFF
--- a/arch/arc/soc/quark_se_c1000_ss/Kconfig.defconfig
+++ b/arch/arc/soc/quark_se_c1000_ss/Kconfig.defconfig
@@ -221,7 +221,7 @@ config WDT_QMSI
 	def_bool y
 
 config WDT_0_IRQ_PRI
-	default 2
+	default 0
 
 endif # WATCHDOG
 


### PR DESCRIPTION
ARC has only 2 priorities, 0 or 1. So let's set the right priority for
WDT.

It looks like some commit has changed that, somewhere. And wrong
priorities were lurking around.

Fixes #8096

Signed-off-by: Tomasz Bursztyka <tomasz.bursztyka@linux.intel.com>