### PR TITLE
subsys: settings: Fix file exist error.

### DIFF
--- a/subsys/settings/src/settings_init.c
+++ b/subsys/settings/src/settings_init.c
@@ -115,6 +115,12 @@ int settings_subsys_init(void)
 	 * Must be called after root FS has been initialized.
 	 */
 	err = fs_mkdir(CONFIG_SETTINGS_FS_DIR);
+	/*
+	 * The following lines mask the file exist error.
+	 */
+	if (err == -EEXIST) {
+		err = 0;
+	}
 #elif defined(CONFIG_SETTINGS_FCB)
 	settings_init_fcb(); /* func rises kernel panic once error */
 	err = 0;


### PR DESCRIPTION
Fix file exist error within settings_subsys_init in order to correctly
reload existing settings when CONFIG_SETTINGS_FS is enabled.

Signed-off-by: Daniele Biagetti <daniele.biagetti@cblelectronics.com>