### PR TITLE
include/toolchain/gcc.h: Fix static assert detection

### DIFF
--- a/include/toolchain/gcc.h
+++ b/include/toolchain/gcc.h
@@ -18,11 +18,11 @@
 #define BUILD_ASSERT(EXPR) static_assert(EXPR, "")
 #define BUILD_ASSERT_MSG(EXPR, MSG) static_assert(EXPR, MSG)
 /*
- * GCC 4.6 and higher have _Static_assert built in, and its output is
- * easier to understand than the common BUILD_ASSERT macros.
+ * GCC 4.6 and higher have the C11 _Static_assert built in, and its
+ * output is easier to understand than the common BUILD_ASSERT macros.
  */
-#elif (__GNUC__ > 4 || (__GNUC__ == 4 && __GNUC_MINOR__ >= 6)) && \
-	(__STDC_VERSION__) > 199901L
+#elif (__GNUC__ > 4 || (__GNUC__ == 4 && __GNUC_MINOR__ >= 6)) || \
+	(__STDC_VERSION__) >= 201100
 #define BUILD_ASSERT(EXPR) _Static_assert(EXPR, "")
 #define BUILD_ASSERT_MSG(EXPR, MSG) _Static_assert(EXPR, MSG)
 #endif


### PR DESCRIPTION
The logic for using _Static_assert() was a little broken.  We were
using it when on GCC 4.6+ AND when __STDC_VERSION__ said we were on
C99 or better.  But it's not a C99 feature, it's a C11 feature.  And
if GCC provides it as an extension, that's unrelated to a particular
language version.  This should have been "GCC 4.6+ OR C11+".

This actually broke on the ESP-32 IDF toolchain, where (when using
-std=c99) the compiler was actually defining a C99 macro instead of
the C11 one, and choosing to use the wrong (and independently broken)
handling incorrectly.  Fixes #8093.

Signed-off-by: Andy Ross <andrew.j.ross@intel.com>