### PR TITLE
drivers/rtc: Fix how prescaler is used in QMSI driver

### DIFF
--- a/drivers/rtc/rtc_qmsi.c
+++ b/drivers/rtc/rtc_qmsi.c
@@ -93,7 +93,7 @@ static int rtc_qmsi_set_config(struct device *dev, struct rtc_config *cfg)
 	 * values defined by clk_rtc_div and by QMSI's clk_rtc_div_t match for
 	 * both D2000 and SE.
 	 */
-	qm_cfg.prescaler = (clk_rtc_div_t)CONFIG_RTC_PRESCALER;
+	qm_cfg.prescaler = (clk_rtc_div_t)CONFIG_RTC_PRESCALER - 1;
 
 	if (IS_ENABLED(CONFIG_RTC_QMSI_API_REENTRANCY)) {
 		k_sem_take(RP_GET(dev), K_FOREVER);


### PR DESCRIPTION
The issue was introduced by commit-id 27bdb83.
RTC_DIVIDER used to be 0 by default, now it's 1.

Fixes #8098

Signed-off-by: Tomasz Bursztyka <tomasz.bursztyka@linux.intel.com>