### PR TITLE
net: shell: conn: Always show TCP state

### DIFF
--- a/subsys/net/ip/net_shell.c
+++ b/subsys/net/ip/net_shell.c
@@ -1321,7 +1321,7 @@ int net_shell_cmd_conn(int argc, char *argv[])
 
 #if defined(CONFIG_NET_TCP)
 	printk("\nTCP        Context   Src port Dst port   Send-Seq   Send-Ack  MSS"
-	       "%s\n", IS_ENABLED(CONFIG_NET_DEBUG_TCP) ? "    State" : "");
+	       "    State\n");
 
 	count = 0;
 
@@ -1336,6 +1336,11 @@ int net_shell_cmd_conn(int argc, char *argv[])
 		net_tcp_foreach(tcp_sent_list_cb, &count);
 #endif /* CONFIG_NET_DEBUG_TCP */
 	}
+
+#if !defined(CONFIG_NET_DEBUG_TCP)
+	printk("\nEnable CONFIG_NET_DEBUG_TCP for additional info\n");
+#endif /* CONFIG_NET_DEBUG_TCP */
+
 #endif
 
 #if defined(CONFIG_NET_IPV6_FRAGMENT)

--- a/subsys/net/ip/tcp.c
+++ b/subsys/net/ip/tcp.c
@@ -760,7 +760,7 @@ int net_tcp_prepare_reset(struct net_tcp *tcp,
 
 const char *net_tcp_state_str(enum net_tcp_state state)
 {
-#if defined(CONFIG_NET_DEBUG_TCP)
+#if defined(CONFIG_NET_DEBUG_TCP) || defined(CONFIG_NET_SHELL)
 	switch (state) {
 	case NET_TCP_CLOSED:
 		return "CLOSED";


### PR DESCRIPTION
It's rather confusing to not see current TCP state in any way (it
makes distinguishing different TCP contexts very hard). And nobody
can know/remember that it's printed with CONFIG_NET_DEBUG_TCP
defined. So, just make it be printed always (initially I thought
about printing just numeric value if CONFIG_NET_DEBUG_TCP isn't
defined, but why, if we can print symbolic name easily).

Also, add a hint that defining CONFIG_NET_DEBUG_TCP will still
print even more info (like unacked pkt list) - similarly to
similar helpful hints we have in other parts of net shell.

Signed-off-by: Paul Sokolovsky <paul.sokolovsky@linaro.org>