### PR TITLE
tests: remove obsolete k_thread_cancel

### DIFF
--- a/tests/benchmarks/footprint/src/main.c
+++ b/tests/benchmarks/footprint/src/main.c
@@ -128,7 +128,6 @@ static pfunc func_array[] = {
 	(pfunc)k_yield,
 	(pfunc)k_wakeup,
 	(pfunc)k_current_get,
-	(pfunc)k_thread_cancel,
 	(pfunc)k_thread_abort,
 	(pfunc)k_thread_priority_get,
 	(pfunc)k_thread_priority_set,

--- a/tests/benchmarks/timing_info/src/thread_bench.c
+++ b/tests/benchmarks/timing_info/src/thread_bench.c
@@ -175,11 +175,10 @@ void system_thread_bench(void)
 	/* thread Termination*/
 	TIMING_INFO_PRE_READ();
 	thread_cancel_start_time = TIMING_INFO_OS_GET_TIME();
-	s32_t ret_value_thread_cancel  = k_thread_cancel(my_tid);
+	k_thread_abort(my_tid);
 
 	TIMING_INFO_PRE_READ();
 	thread_cancel_end_time = TIMING_INFO_OS_GET_TIME();
-	ARG_UNUSED(ret_value_thread_cancel);
 
 	/* Thread suspend*/
 	k_tid_t sus_res_tid = k_thread_create(&my_thread, my_stack_area,


### PR DESCRIPTION
k_thread_cancel was obsoleted, yet we still have a few tests using it.

Signed-off-by: Anas Nashif <anas.nashif@intel.com>