### PR TITLE
nxp_imx: Move i.MX RT PLL selects to Kconfig.soc

### DIFF
--- a/arch/arm/soc/nxp_imx/rt/Kconfig.defconfig.mimxrt1052
+++ b/arch/arm/soc/nxp_imx/rt/Kconfig.defconfig.mimxrt1052
@@ -10,9 +10,6 @@ if SOC_MIMXRT1052
 config SOC
 	string
 	default "mimxrt1052"
-	select INIT_ARM_PLL
-	select INIT_SYS_PLL
-	select INIT_USB1_PLL
 
 if CLOCK_CONTROL
 

--- a/arch/arm/soc/nxp_imx/rt/Kconfig.soc
+++ b/arch/arm/soc/nxp_imx/rt/Kconfig.soc
@@ -17,6 +17,9 @@ config SOC_MIMXRT1051
 	select HAS_MCUX_LPUART
 	select CPU_HAS_FPU
 	select CPU_HAS_MPU
+	select INIT_ARM_PLL
+	select INIT_SYS_PLL
+	select INIT_USB1_PLL
 
 config SOC_MIMXRT1052
 	bool "SOC_MIMXRT1052"
@@ -26,6 +29,9 @@ config SOC_MIMXRT1052
 	select HAS_MCUX_LPUART
 	select CPU_HAS_FPU
 	select CPU_HAS_MPU
+	select INIT_ARM_PLL
+	select INIT_SYS_PLL
+	select INIT_USB1_PLL
 
 endchoice
 


### PR DESCRIPTION
PLL configuration options for i.MX RT SoCs were added in commit
3fd25c64c779ee06e43bfc7c8fb304cbe01d8e5d, but the selects were
incorrectly added to the SoC defconfig rather than Kconfig.soc. This
resulted in the PLL options not being configured and the part not
booting properly.

Signed-off-by: Maureen Helm <maureen.helm@nxp.com>

cc: @jhqian 