### PR TITLE
samples: net: Check the return value of nats_publish

### DIFF
--- a/samples/net/nats/src/main.c
+++ b/samples/net/nats/src/main.c
@@ -194,6 +194,7 @@ static void write_led(const struct nats *nats,
 		      bool state)
 {
 	char *pubstate;
+	int ret;
 
 	if (!led0) {
 		fake_led = state;
@@ -202,10 +203,13 @@ static void write_led(const struct nats *nats,
 	}
 
 	pubstate = state ? "on" : "off";
-	nats_publish(nats, "led0", 0, msg->reply_to, 0,
-		     pubstate, strlen(pubstate));
-
-	printk("*** Turning LED %s\n", pubstate);
+	ret = nats_publish(nats, "led0", 0, msg->reply_to, 0,
+			   pubstate, strlen(pubstate));
+	if (ret < 0) {
+		printk("Failed to publish: %d\n", ret);
+	} else {
+		printk("*** Turning LED %s\n", pubstate);
+	}
 }
 
 static int on_msg_received(const struct nats *nats,


### PR DESCRIPTION
Check and handle the return value of nats_publish() in main.c. Also, apply
the changes suggested by the tools uncrustify and checkpatch.

Signed-off-by: Satya Bhattacharya <satyacube@gmail.com>

Fixes #6258.