### PR TITLE
subsys: mgmt: Remove unnecessary comparison

### DIFF
--- a/subsys/mgmt/smp.c
+++ b/subsys/mgmt/smp.c
@@ -138,7 +138,7 @@ zephyr_smp_write_at(struct cbor_encoder_writer *writer, size_t offset,
 	czw = (struct cbor_nb_writer *)writer;
 	nb = czw->nb;
 
-	if (offset < 0 || offset > nb->len) {
+	if (offset > nb->len) {
 		return MGMT_ERR_EINVAL;
 	}
 


### PR DESCRIPTION
In the function zephyr_smp_write_at the offset was checked
for negative values while it type is unsigned -
which cause static analyses issue.

Fixes #7737

Signed-off-by: Andrzej Puzdrowski <andrzej.puzdrowski@nordicsemi.no>