### PR TITLE
build: remove unused lib/libc/minimal/source/CMakeLists.txt

### DIFF
--- a/arch/nios2/soc/nios2-qemu/CMakeLists.txt
+++ b/arch/nios2/soc/nios2-qemu/CMakeLists.txt
@@ -1,0 +1,1 @@
+# intentionally left empty

--- a/arch/nios2/soc/nios2f-zephyr/CMakeLists.txt
+++ b/arch/nios2/soc/nios2f-zephyr/CMakeLists.txt
@@ -1,0 +1,1 @@
+# intentionally left empty

--- a/arch/xtensa/soc/sample_controller/CMakeLists.txt
+++ b/arch/xtensa/soc/sample_controller/CMakeLists.txt
@@ -1,0 +1,1 @@
+# intentionally left empty

--- a/lib/libc/minimal/source/CMakeLists.txt
+++ b/lib/libc/minimal/source/CMakeLists.txt
@@ -1,3 +1,0 @@
-add_subdirectory(stdout)
-add_subdirectory(string)
-add_subdirectory(stdlib)


### PR DESCRIPTION
lib/libc/minimal/source/CMakeLists.txt was introduced in 12f8f7616 but
it is not used by the build system.  CMakeLists.txt in the parent dir
lib/libc/minimal/CMakeLists.txt adds C files to the target with the
lines like:

    ${CMAKE_CURRENT_SOURCE_DIR}/source/stdlib/atoi.c
    ${CMAKE_CURRENT_SOURCE_DIR}/source/stdlib/strtol.c