### PR TITLE
arch: stm32: remove .hex binary build by default

### DIFF
--- a/arch/arm/soc/st_stm32/Kconfig
+++ b/arch/arm/soc/st_stm32/Kconfig
@@ -14,9 +14,6 @@ config SOC_FAMILY_STM32
 
 if SOC_FAMILY_STM32
 
-config BUILD_OUTPUT_HEX
-        default y
-
 config SOC_FAMILY
 	string
 	default "st_stm32"


### PR DESCRIPTION
BUILD_OUTPUT_HEX was enabled by default for stm32 SoCs.
This should not be the default setting and besides it has no
effect because of 'default n' in misc/Kconfig that seems to
prevail.
Removing the 'default y' for  stm32 to avoid confusion.

Fixes #8193

Signed-off-by: Erwan Gouriou <erwan.gouriou@linaro.org>