### PR TITLE
Bluetooth: ATT: Fix clearing context at disconnect

### DIFF
--- a/subsys/bluetooth/host/att.c
+++ b/subsys/bluetooth/host/att.c
@@ -2041,7 +2041,6 @@ static void bt_att_disconnected(struct bt_l2cap_chan *chan)
 	att_reset(att);
 
 	bt_gatt_disconnected(ch->chan.conn);
-	memset(att, 0, sizeof(*att));
 }
 
 #if defined(CONFIG_BT_SMP)
@@ -2109,8 +2108,8 @@ static int bt_att_accept(struct bt_conn *conn, struct bt_l2cap_chan **chan)
 			continue;
 		}
 
+		memset(att, 0, sizeof(*att));
 		att->chan.chan.ops = &ops;
-		atomic_set(att->flags, 0);
 		k_sem_init(&att->tx_sem, CONFIG_BT_ATT_TX_MAX,
 			   CONFIG_BT_ATT_TX_MAX);
 


### PR DESCRIPTION
When att_disconnected is called a thread may be waiting for the tx_sem
but that is memset to 0, furthermore there exists a flag
ATT_DISCONNECTED to indicate the context is no longer valid so the use
of memset is not really required.

Fixes #8083

Signed-off-by: Luiz Augusto von Dentz <luiz.von.dentz@intel.com>