### PR TITLE
subsys: net: automatic resize net buf for mcumgr

### DIFF
--- a/subsys/net/Kconfig
+++ b/subsys/net/Kconfig
@@ -20,7 +20,8 @@ if NET_BUF
 config NET_BUF_USER_DATA_SIZE
 	int "Size of user_data available in every network buffer"
 	default 4
-	range 0 65535
+	range MCUMGR_BUF_USER_DATA_SIZE 65535 if MCUMGR
+	range 0 65535 if !MCUMGR
 	help
 	  Amount of memory reserved in each network buffer for user data. In
 	  most cases this can be left as the default value.


### PR DESCRIPTION
if any of mcumgr backend is enabled then the size of user_data
available in every network buffer must be set at last to the Size
of mcumgr buffer user data. This patch force this via Kconfig.

Signed-off-by: Andrzej Puzdrowski <andrzej.puzdrowski@nordicsemi.no>