### PR TITLE
tests: arm: irq_vector_table: Fix Kconfig override

### DIFF
--- a/tests/kernel/arm_irq_vector_table/CMakeLists.txt
+++ b/tests/kernel/arm_irq_vector_table/CMakeLists.txt
@@ -1,3 +1,5 @@
+set(KCONFIG_ROOT ${CMAKE_CURRENT_SOURCE_DIR}/Kconfig)
+
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
 project(NONE)
 

--- a/tests/kernel/arm_irq_vector_table/Kconfig
+++ b/tests/kernel/arm_irq_vector_table/Kconfig
@@ -1,0 +1,4 @@
+config NUM_IRQS
+	int "Number of IRQs for this test, made overridable in the .conf file"
+	default 3
+source "$ZEPHYR_BASE/Kconfig.zephyr"


### PR DESCRIPTION
Since on ARM CONFIG_NUM_IRQS option has no prompt, it cannot be properly
overridden by a prj.conf fragment. Instead make it have a prompt for
this particular test to be able to override it properly.

Fixes #8200

Signed-off-by: Carles Cufi <carles.cufi@nordicsemi.no>