### PR TITLE
arch: arm: enable prefetch and cache on STM32L4 family

### DIFF
--- a/arch/arm/soc/st_stm32/stm32l4/soc.c
+++ b/arch/arm/soc/st_stm32/stm32l4/soc.c
@@ -31,6 +31,12 @@ static int stm32l4_init(struct device *arg)
 
 	key = irq_lock();
 
+	/* Enable flash instruction prefetch, instruction cache memory,
+	 * and data cache memory. */
+	LL_FLASH_EnablePrefetch();
+	LL_FLASH_EnableInstCache();
+	LL_FLASH_EnableDataCache();
+
 	_ClearFaults();
 
 	/* Install default handler that simply resets the CPU


### PR DESCRIPTION
The STM32L4 family has an adaptive real-time memory accelerator which
provides instruction prefetch, instruction cache and data cache.
Depending on the workload, it can significantly boost the performances.
Enable it during SoC initialization.

Signed-off-by: Aurelien Jarno <aurelien@aurel32.net>