### PR TITLE
arch: arm: enable prefetch on STM32L4 family

### DIFF
--- a/arch/arm/soc/st_stm32/stm32l4/soc.c
+++ b/arch/arm/soc/st_stm32/stm32l4/soc.c
@@ -31,6 +31,9 @@ static int stm32l4_init(struct device *arg)
 
 	key = irq_lock();
 
+	/* Enable flash instruction prefetch */
+	LL_FLASH_EnablePrefetch();
+
 	_ClearFaults();
 
 	/* Install default handler that simply resets the CPU


### PR DESCRIPTION
The STM32L4 family has an adaptive real-time memory accelerator which
provides instruction prefetch, instruction cache and data cache. The
instruction and data caches are enabled by default, while the prefetch is
not.

Depending on the workload, enabling the prefetch can provide a 5 to 10%
speedup. This patch enables it during SoC initialization.

Signed-off-by: Aurelien Jarno <aurelien@aurel32.net>