### PR TITLE
net: lwm2m: fix observer attribute update logic

### DIFF
--- a/subsys/net/lib/lwm2m/lwm2m_engine.c
+++ b/subsys/net/lib/lwm2m/lwm2m_engine.c
@@ -332,7 +332,7 @@ static int update_attrs(void *ref, struct notification_attrs *out)
 	int i;
 
 	for (i = 0; i < CONFIG_LWM2M_NUM_ATTR; i++) {
-		if (ref == write_attr_pool[i].ref) {
+		if (ref != write_attr_pool[i].ref) {
 			continue;
 		}
 


### PR DESCRIPTION
A typo in update_attrs() was setting every observer to a PMIN of 0.
This meant we could send observer data as often as the process was
called.  This is out of spec as the default minimum is 10 seconds.

Fixes: https://github.com/zephyrproject-rtos/zephyr/issues/8189

Signed-off-by: Michael Scott <michael@opensourcefoundries.com>