### PR TITLE
net: lwm2m: lower priority of engine thread

### DIFF
--- a/subsys/net/lib/lwm2m/lwm2m_engine.c
+++ b/subsys/net/lib/lwm2m/lwm2m_engine.c
@@ -3939,7 +3939,10 @@ static int lwm2m_engine_init(struct device *dev)
 			&engine_thread_stack[0],
 			K_THREAD_STACK_SIZEOF(engine_thread_stack),
 			(k_thread_entry_t) lwm2m_engine_service,
-			NULL, NULL, NULL, K_PRIO_COOP(7), 0, K_NO_WAIT);
+			NULL, NULL, NULL,
+			/* Lowest priority cooperative thread */
+			K_PRIO_COOP(CONFIG_NUM_COOP_PRIORITIES - 1),
+			0, K_NO_WAIT);
 	SYS_LOG_DBG("LWM2M engine thread started");
 	return 0;
 }


### PR DESCRIPTION
The LwM2M engine thread is used for various periodic triggers.
None of these are in a critical path that requires super sensitive
timing and the current K_PRIO_COOP(7) setting was causing the
Bluetooth RX thread to have to wait too long for certain actions
to complete.

Let's lower the priority to -1 (effectively) to eliminate these
conflicts.

Signed-off-by: Michael Scott <michael@opensourcefoundries.com>