### PR TITLE
Bluetooth: Introduce HCI driver quirks

### DIFF
--- a/include/bluetooth/hci.h
+++ b/include/bluetooth/hci.h
@@ -1830,6 +1830,65 @@ struct bt_hci_evt_le_chan_sel_algo {
 #define BT_EVT_MASK_LE_SCAN_REQ_RECEIVED         BT_EVT_BIT(18)
 #define BT_EVT_MASK_LE_CHAN_SEL_ALGO             BT_EVT_BIT(19)
 
+/** Allocate a HCI command buffer.
+  *
+  * This function allocates a new buffer for a HCI command. It is given
+  * the OpCode (encoded e.g. using the BT_OP macro) and the total length
+  * of the parameters. Opon successful return the buffer is ready to have
+  * the parameters encoded into it.
+  *
+  * @param opcode     Command OpCode.
+  * @param param_len  Length of command parameters.
+  *
+  * @return Newly allocated buffer.
+  */
+struct net_buf *bt_hci_cmd_create(u16_t opcode, u8_t param_len);
+
+/** Send a HCI command asynchronously.
+  *
+  * This function is used for sending a HCI command asynchronously. It can
+  * either be called for a buffer created using bt_hci_cmd_create(), or
+  * if the command has no parameters a NULL can be passed instead. The
+  * sending of the command will happen asynchronously, i.e. upon successful
+  * return from this function the caller only knows that it was queued
+  * successfully.
+  *
+  * If synchronous behavior, and retreival of the Command Complete paramters
+  * is desired, the bt_hci_cmd_send_sync() API should be used instead.
+  *
+  * @param opcode Command OpCode.
+  * @param buf    Command buffer or NULL (if no parameters).
+  *
+  * @return 0 on success or negative error value on failure.
+  */
+int bt_hci_cmd_send(u16_t opcode, struct net_buf *buf);
+
+/** Send a HCI command synchronously.
+  *
+  * This function is used for sending a HCI command synchronously. It can
+  * either be called for a buffer created using bt_hci_cmd_create(), or
+  * if the command has no parameters a NULL can be passed instead.
+  *
+  * The function will block until a Command Status or a Command Complete
+  * event is returned. If either of these have a non-zero status the function
+  * will return a negative error code and the response reference will not
+  * be set. If the command completed successfully and a non-NULL rsp parameter
+  * was given, this parameter will be set to point to a buffer containing
+  * the response parameters.
+  *
+  * @param opcode Command OpCode.
+  * @param buf    Command buffer or NULL (if no parameters).
+  * @param rsp    Place to store a reference to the command response. May
+  *               be NULL if the caller is not interested in the response
+  *               parameters. If non-NULL is passed the caller is responsible
+  *               for calling net_buf_unref() on the buffer when done parsing
+  *               it.
+  *
+  * @return 0 on success or negative error value on failure.
+  */
+int bt_hci_cmd_send_sync(u16_t opcode, struct net_buf *buf,
+			 struct net_buf **rsp);
+
 #ifdef __cplusplus
 }
 #endif

--- a/include/drivers/bluetooth/hci_driver.h
+++ b/include/drivers/bluetooth/hci_driver.h
@@ -25,6 +25,11 @@
 extern "C" {
 #endif
 
+enum {
+	/* The host should never send HCI_Reset */
+	BT_QUIRK_NO_RESET = BIT(0),
+};
+
 /**
  * @brief Check if an HCI event is high priority or not.
  *
@@ -112,6 +117,13 @@ struct bt_hci_driver {
 
 	/** Bus of the transport (BT_HCI_DRIVER_BUS_*) */
 	enum bt_hci_driver_bus bus;
+
+	/** Specific controller quirks. These are set by the HCI driver
+	 *  and acted upon by the host. They can either be statically
+	 *  set at buildtime, or set at runtime before the HCI driver's
+	 *  open() callback returns.
+	 */
+	u32_t quirks;
 
 	/**
 	 * @brief Open the HCI transport.

--- a/subsys/bluetooth/host/hci_core.c
+++ b/subsys/bluetooth/host/hci_core.c
@@ -3560,13 +3560,15 @@ static int common_init(void)
 	struct net_buf *rsp;
 	int err;
 
-	/* Send HCI_RESET */
-	err = bt_hci_cmd_send_sync(BT_HCI_OP_RESET, NULL, &rsp);
-	if (err) {
-		return err;
+	if (!(bt_dev.drv->quirks & BT_QUIRK_NO_RESET)) {
+		/* Send HCI_RESET */
+		err = bt_hci_cmd_send_sync(BT_HCI_OP_RESET, NULL, &rsp);
+		if (err) {
+			return err;
+		}
+		hci_reset_complete(rsp);
+		net_buf_unref(rsp);
 	}
-	hci_reset_complete(rsp);
-	net_buf_unref(rsp);
 
 	/* Read Local Supported Features */
 	err = bt_hci_cmd_send_sync(BT_HCI_OP_READ_LOCAL_FEATURES, NULL, &rsp);

--- a/subsys/bluetooth/host/hci_core.h
+++ b/subsys/bluetooth/host/hci_core.h
@@ -172,11 +172,6 @@ extern const struct bt_conn_auth_cb *bt_auth;
 
 bool bt_le_conn_params_valid(const struct bt_le_conn_param *param);
 
-struct net_buf *bt_hci_cmd_create(u16_t opcode, u8_t param_len);
-int bt_hci_cmd_send(u16_t opcode, struct net_buf *buf);
-int bt_hci_cmd_send_sync(u16_t opcode, struct net_buf *buf,
-			 struct net_buf **rsp);
-
 int bt_le_scan_update(bool fast_scan);
 
 bool bt_addr_le_is_bonded(const bt_addr_le_t *addr);


### PR DESCRIPTION
These two patches do two things:

 - Expose the HCI command APIs to driver
 - Introduce quirks for drivers which can be used to control host behavior

This is an alternate approach to what #7683 was trying to accomplish for #7160

FYI @cpriouzeau