### PR TITLE
cmake: libc: minimal: Move sources from 'app' to a new CMake library

### DIFF
--- a/lib/libc/minimal/CMakeLists.txt
+++ b/lib/libc/minimal/CMakeLists.txt
@@ -1,13 +1,15 @@
-target_sources(app PRIVATE
-  ${CMAKE_CURRENT_SOURCE_DIR}/source/stdlib/atoi.c
-  ${CMAKE_CURRENT_SOURCE_DIR}/source/stdlib/strtol.c
-  ${CMAKE_CURRENT_SOURCE_DIR}/source/stdlib/strtoul.c
-  ${CMAKE_CURRENT_SOURCE_DIR}/source/string/strncasecmp.c
-  ${CMAKE_CURRENT_SOURCE_DIR}/source/string/strstr.c
-  ${CMAKE_CURRENT_SOURCE_DIR}/source/string/string.c
-  ${CMAKE_CURRENT_SOURCE_DIR}/source/stdout/prf.c
-  ${CMAKE_CURRENT_SOURCE_DIR}/source/stdout/stdout_console.c
-  ${CMAKE_CURRENT_SOURCE_DIR}/source/stdout/sprintf.c
-  ${CMAKE_CURRENT_SOURCE_DIR}/source/stdout/fprintf.c
-)
 zephyr_include_directories(include)
+
+zephyr_library()
+zephyr_library_sources(
+  source/stdlib/atoi.c
+  source/stdlib/strtol.c
+  source/stdlib/strtoul.c
+  source/string/strncasecmp.c
+  source/string/strstr.c
+  source/string/string.c
+  source/stdout/prf.c
+  source/stdout/stdout_console.c
+  source/stdout/sprintf.c
+  source/stdout/fprintf.c
+)


### PR DESCRIPTION
The minimal libc source files have been added to 'app'. The Zephyr
build system should not be adding source files to the 'app' library
unless necessary.

This patch creates a new Zephyr CMake Library in lib/libc/minimal and
adds the sources to it.

This resolves #8206 

Signed-off-by: Sebastian Bøe <sebastian.boe@nordicsemi.no>