### PR TITLE
esp32: update to ESP-IDF v3.0-dev-2648-gb2ff235b

### DIFF
--- a/arch/xtensa/core/cpu_idle.c
+++ b/arch/xtensa/core/cpu_idle.c
@@ -3,8 +3,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <xtensa/tie/xt_core.h>
-#include <xtensa/tie/xt_interrupt.h>
 #include <logging/kernel_event_logger.h>
 
 /*

--- a/arch/xtensa/core/fatal.c
+++ b/arch/xtensa/core/fatal.c
@@ -11,6 +11,10 @@
 #include <misc/printk.h>
 #include <xtensa/specreg.h>
 
+#ifdef XT_SIMULATOR
+#include <xtensa/simcall.h>
+#endif
+
 const NANO_ESF _default_esf = {
 	{0xdeaddead}, /* sp */
 	0xdeaddead, /* pc */

--- a/arch/xtensa/include/xtensa_rtos.h
+++ b/arch/xtensa/include/xtensa_rtos.h
@@ -32,7 +32,6 @@
 
 #include    <xtensa/corebits.h>
 #include    <xtensa/config/system.h>
-#include    <xtensa/simcall.h>
 
 
 /*

--- a/boards/xtensa/esp32/doc/esp32.rst
+++ b/boards/xtensa/esp32/doc/esp32.rst
@@ -84,7 +84,7 @@ of ESP-IDF:
 .. code-block:: console
 
    cd ${ESP_IDF_PATH}
-   git checkout dc8c33892e0
+   git checkout b2ff235bd00
 
 Flashing
 ========

--- a/drivers/timer/xtensa_sys_timer.c
+++ b/drivers/timer/xtensa_sys_timer.c
@@ -8,15 +8,9 @@
 #include <system_timer.h>
 #include <xtensa_rtos.h>
 
-#include <xtensa/tie/xt_timer.h>
-
 #include <xtensa_timer.h>
 #include <kernel_structs.h>
 #include "irq.h"
-
-#ifdef XT_BOARD
-#include    <xtensa/xtbsp.h>
-#endif
 
 #include    "xtensa_rtos.h"
 


### PR DESCRIPTION
Recent ESP-IDF provides OS-agnostic wifi binary, needed by #3723
These changes adapt the zephyr code to this IDF version.

Closes #8240

Signed-off-by: Gautier Seidel <gautier.seidel@tado.com>