### PR TITLE
net: ipv6: Set hop limit in net_pkt according to IPv6 header

### DIFF
--- a/subsys/net/ip/ipv6.c
+++ b/subsys/net/ip/ipv6.c
@@ -4227,6 +4227,7 @@ enum net_verdict net_ipv6_process_pkt(struct net_pkt *pkt)
 	net_pkt_set_next_hdr(pkt, &hdr->nexthdr);
 	net_pkt_set_ipv6_ext_len(pkt, 0);
 	net_pkt_set_ip_hdr_len(pkt, sizeof(struct net_ipv6_hdr));
+	net_pkt_set_ipv6_hop_limit(pkt, NET_IPV6_HDR(pkt)->hop_limit);
 
 	/* Fast path for main upper layer protocols. The handling of extension
 	 * headers can be slow so do this checking here. There cannot


### PR DESCRIPTION
The hop limit value in net_pkt was not updated according to
received IPv6 header.

Fixes #8182

Signed-off-by: Jukka Rissanen <jukka.rissanen@linux.intel.com>