### PR TITLE
Bluetooth: Allow use of Characteristic attribute to notify/indicate

### DIFF
--- a/include/bluetooth/gatt.h
+++ b/include/bluetooth/gatt.h
@@ -683,12 +683,14 @@ ssize_t bt_gatt_attr_read_cpf(struct bt_conn *conn,
  *  all peer that have notification enabled via CCC otherwise do a direct
  *  notification only the given connection.
  *
- *  The attribute object must be the so called Characteristic Value Descriptor,
- *  its usually declared with BT_GATT_DESCRIPTOR after BT_GATT_CHARACTERISTIC
- *  and before BT_GATT_CCC.
+ *  The attribute object can be the so called Characteristic Declaration,
+ *  which is usually declared with BT_GATT_CHARACTERISTIC followed by
+ *  BT_GATT_CCC, or the Characteristic Value Declaration which is automatically
+ *  created after the Characteristic Declaration when using
+ *  BT_GATT_CHARACTERISTIC.
  *
  *  @param conn Connection object.
- *  @param attr Characteristic Value Descriptor attribute.
+ *  @param attr Characteristic or Characteristic Value attribute.
  *  @param data Pointer to Attribute data.
  *  @param len Attribute value length.
  */

--- a/samples/bluetooth/gatt/bas.c
+++ b/samples/bluetooth/gatt/bas.c
@@ -69,5 +69,5 @@ void bas_notify(void)
 		battery = 100;
 	}
 
-	bt_gatt_notify(NULL, &attrs[2], &battery, sizeof(battery));
+	bt_gatt_notify(NULL, &attrs[1], &battery, sizeof(battery));
 }

--- a/samples/bluetooth/gatt/cts.c
+++ b/samples/bluetooth/gatt/cts.c
@@ -110,5 +110,5 @@ void cts_notify(void)
 	}
 
 	ct_update = 0;
-	bt_gatt_notify(NULL, &attrs[3], &ct, sizeof(ct));
+	bt_gatt_notify(NULL, &attrs[1], &ct, sizeof(ct));
 }

--- a/samples/bluetooth/gatt/hrs.c
+++ b/samples/bluetooth/gatt/hrs.c
@@ -78,5 +78,5 @@ void hrs_notify(void)
 	hrm[0] = 0x06; /* uint8, sensor contact */
 	hrm[1] = heartrate;
 
-	bt_gatt_notify(NULL, &attrs[2], &hrm, sizeof(hrm));
+	bt_gatt_notify(NULL, &attrs[1], &hrm, sizeof(hrm));
 }

--- a/samples/bluetooth/peripheral_csc/src/main.c
+++ b/samples/bluetooth/peripheral_csc/src/main.c
@@ -246,7 +246,7 @@ static void ctrl_point_ind(struct bt_conn *conn, u8_t req_op, u8_t status,
 		memcpy(ind->data, data, data_len);
 	}
 
-	bt_gatt_notify(conn, &csc_attrs[9], buf, sizeof(buf));
+	bt_gatt_notify(conn, &csc_attrs[8], buf, sizeof(buf));
 }
 
 struct csc_measurement_nfy {
@@ -299,7 +299,7 @@ static void measurement_nfy(struct bt_conn *conn, u32_t cwr, u16_t lwet,
 		memcpy(nfy->data + len, &data, sizeof(data));
 	}
 
-	bt_gatt_notify(NULL, &csc_attrs[2], buf, sizeof(buf));
+	bt_gatt_notify(NULL, &csc_attrs[1], buf, sizeof(buf));
 }
 
 static u16_t lwet; /* Last Wheel Event Time */

--- a/samples/boards/microbit/pong/src/ble.c
+++ b/samples/boards/microbit/pong/src/ble.c
@@ -541,6 +541,6 @@ void ble_init(void)
 	bt_conn_cb_register(&conn_callbacks);
 
 
-	local_attr = &pong_attrs[2];
+	local_attr = &pong_attrs[1];
 	bt_gatt_service_register(&pong_svc);
 }

--- a/subsys/bluetooth/host/mesh/proxy.c
+++ b/subsys/bluetooth/host/mesh/proxy.c
@@ -885,13 +885,13 @@ static int proxy_send(struct bt_conn *conn, const void *data, u16_t len)
 
 #if defined(CONFIG_BT_MESH_GATT_PROXY)
 	if (gatt_svc == MESH_GATT_PROXY) {
-		return bt_gatt_notify(conn, &proxy_attrs[4], data, len);
+		return bt_gatt_notify(conn, &proxy_attrs[3], data, len);
 	}
 #endif
 
 #if defined(CONFIG_BT_MESH_PB_GATT)
 	if (gatt_svc == MESH_GATT_PROV) {
-		return bt_gatt_notify(conn, &prov_attrs[4], data, len);
+		return bt_gatt_notify(conn, &prov_attrs[3], data, len);
 	}
 #endif
 


### PR DESCRIPTION
This makes bt_gatt_notify/bt_gatt_indicate easier to use since characteristic value is normally declared with BT_GATT_CHARACTERISTIC.