### PR TITLE
kernel: Improve tick <-> ms conversion.

### DIFF
--- a/include/kernel.h
+++ b/include/kernel.h
@@ -1336,14 +1336,15 @@ __syscall void *k_thread_custom_data_get(void);
 	#define _NON_OPTIMIZED_TICKS_PER_SEC
 #endif
 
-#ifdef _NON_OPTIMIZED_TICKS_PER_SEC
-extern s32_t _ms_to_ticks(s32_t ms);
-#else
 static ALWAYS_INLINE s32_t _ms_to_ticks(s32_t ms)
 {
+#ifdef _NON_OPTIMIZED_TICKS_PER_SEC
+	s64_t ms_ticks_per_sec = (s64_t)ms * sys_clock_ticks_per_sec;
+	return (s32_t)ceiling_fraction(ms_ticks_per_sec, MSEC_PER_SEC);
+#else
 	return (s32_t)ceiling_fraction((u32_t)ms, _ms_per_tick);
-}
 #endif
+}
 
 /* added tick needed to account for tick in progress */
 #ifdef CONFIG_TICKLESS_KERNEL

--- a/include/kernel.h
+++ b/include/kernel.h
@@ -1319,16 +1319,7 @@ __syscall void *k_thread_custom_data_get(void);
 
 /* kernel clocks */
 
-#if	(sys_clock_ticks_per_sec == 1000) || \
-	(sys_clock_ticks_per_sec == 500)  || \
-	(sys_clock_ticks_per_sec == 250)  || \
-	(sys_clock_ticks_per_sec == 125)  || \
-	(sys_clock_ticks_per_sec == 100)  || \
-	(sys_clock_ticks_per_sec == 50)   || \
-	(sys_clock_ticks_per_sec == 25)   || \
-	(sys_clock_ticks_per_sec == 20)   || \
-	(sys_clock_ticks_per_sec == 10)   || \
-	(sys_clock_ticks_per_sec == 1)
+#if	(MSEC_PER_SEC % sys_clock_ticks_per_sec) == 0
 
 	#define _ms_per_tick (MSEC_PER_SEC / sys_clock_ticks_per_sec)
 #else

--- a/include/kernel.h
+++ b/include/kernel.h
@@ -1353,13 +1353,6 @@ static ALWAYS_INLINE s32_t _ms_to_ticks(s32_t ms)
 #endif
 }
 
-/* added tick needed to account for tick in progress */
-#ifdef CONFIG_TICKLESS_KERNEL
-#define _TICK_ALIGN 0
-#else
-#define _TICK_ALIGN 1
-#endif
-
 static inline s64_t __ticks_to_ms(s64_t ticks)
 {
 #ifdef CONFIG_SYS_CLOCK_EXISTS
@@ -1380,6 +1373,13 @@ static inline s64_t __ticks_to_ms(s64_t ticks)
 	return 0;
 #endif
 }
+
+/* added tick needed to account for tick in progress */
+#ifdef CONFIG_TICKLESS_KERNEL
+#define _TICK_ALIGN 0
+#else
+#define _TICK_ALIGN 1
+#endif
 
 struct k_timer {
 	/*

--- a/kernel/sched.c
+++ b/kernel/sched.c
@@ -80,15 +80,6 @@ static inline int _is_idle(struct k_thread *thread)
 #endif
 }
 
-#ifdef _NON_OPTIMIZED_TICKS_PER_SEC
-s32_t _ms_to_ticks(s32_t ms)
-{
-	s64_t ms_ticks_per_sec = (s64_t)ms * sys_clock_ticks_per_sec;
-
-	return (s32_t)ceiling_fraction(ms_ticks_per_sec, MSEC_PER_SEC);
-}
-#endif
-
 int _is_t1_higher_prio_than_t2(struct k_thread *t1, struct k_thread *t2)
 {
 	if (t1->base.prio < t2->base.prio) {

--- a/tests/kernel/early_sleep/src/main.c
+++ b/tests/kernel/early_sleep/src/main.c
@@ -94,8 +94,9 @@ static void test_early_sleep(void)
 	 */
 	k_thread_priority_set(k_current_get(), 0);
 
-	TC_PRINT("msec per tick: %d, ticks to sleep: %d\n",
-			_ms_per_tick, TEST_TICKS_TO_SLEEP);
+	TC_PRINT("msec per tick: %lld.%03lld, ticks to sleep: %d\n",
+			__ticks_to_ms(1000) / 1000, __ticks_to_ms(1000) % 1000,
+			TEST_TICKS_TO_SLEEP);
 
 	/* Create a lower priority thread */
 	helper_ttid = k_thread_create(&helper_tdata,


### PR DESCRIPTION
The kernel incorrectly assumed, that system timer frequency is always
divisible without remainder by couple "natural" tick rates (like 100).
As result on some SoCs, time calculations was not correct, producing
strange effects (invalid sleep times, incorrect k_uptime_get() and so on).

This commit enables accurate, but costly (using 64-bit math) tick <-> ms
conversion if the selected tick interval is not exact due to hardware
limitations.

Signed-off-by: Piotr Zięcik <piotr.ziecik@nordicsemi.no>

Note: This PR solves the described problem only for non-tickless kernel. Patches for tickless mode will follow.