### PR TITLE
kernel: work_q: Document implications of default sys work_q priority

### DIFF
--- a/kernel/Kconfig
+++ b/kernel/Kconfig
@@ -330,6 +330,10 @@ config SYSTEM_WORKQUEUE_PRIORITY
 	default -1
 	default  0 if !COOP_ENABLED
 	default -2 if COOP_ENABLED && !PREEMPT_ENABLED
+	help
+	  By default, system work queue priority is the lowest cooperative
+	  priority. This means that any work handler, once started, won't
+	  be preempted by any other thread until finished.
 
 config OFFLOAD_WORKQUEUE_STACK_SIZE
 	int "Workqueue stack size for thread offload requests"


### PR DESCRIPTION
Default value of CONFIG_SYSTEM_WORKQUEUE_PRIORITY is -1, which means
it's run by the cooperative thread. Explicitly mention (in the Kconfig
help) that it means that any work handler submited to this default
queue won't be preempted by some other thread (which is generally
good, but worth documenting explicitly).

Signed-off-by: Paul Sokolovsky <paul.sokolovsky@linaro.org>