### PR TITLE
Lis2dh fix

### DIFF
--- a/drivers/sensor/lis2dh/lis2dh.h
+++ b/drivers/sensor/lis2dh/lis2dh.h
@@ -259,7 +259,7 @@ static inline int lis2dh_reg_read_byte(struct device *dev, u8_t reg_addr,
 #endif
 }
 
-static inline int lis2dh_burst_write(struct device *bus, u8_t start_addr,
+static inline int lis2dh_burst_write(struct device *dev, u8_t start_addr,
 				     u8_t *buf, u8_t num_bytes)
 {
 	struct lis2dh_data *lis2dh = dev->driver_data;

--- a/drivers/sensor/lis2dh/lis2dh.h
+++ b/drivers/sensor/lis2dh/lis2dh.h
@@ -235,7 +235,8 @@ static inline int lis2dh_burst_read(struct device *dev, u8_t start_addr,
 
 	return lis2dh_spi_access(lis2dh, start_addr, buf, num_bytes);
 #elif defined(CONFIG_LIS2DH_BUS_I2C)
-	return i2c_burst_read(lis2dh->bus, LIS2DH_BUS_ADDRESS, start_addr,
+	return i2c_burst_read(lis2dh->bus, LIS2DH_BUS_ADDRESS,
+			      start_addr | LIS2DH_AUTOINCREMENT_ADDR,
 			      buf, num_bytes);
 #else
 	return -ENODEV;
@@ -269,7 +270,8 @@ static inline int lis2dh_burst_write(struct device *dev, u8_t start_addr,
 
 	return lis2dh_spi_access(lis2dh, start_addr, buf, num_bytes);
 #elif defined(CONFIG_LIS2DH_BUS_I2C)
-	return i2c_burst_write(lis2dh->bus, LIS2DH_BUS_ADDRESS, start_addr,
+	return i2c_burst_write(lis2dh->bus, LIS2DH_BUS_ADDRESS,
+			       start_addr | LIS2DH_AUTOINCREMENT_ADDR,
 			       buf, num_bytes);
 #else
 	return -ENODEV;


### PR DESCRIPTION
This PR is fixing the bug reported into PR 7912 in the proper way, i.e. using the AUTOINCREMENT bit for I2C burst read/write operations.