### PR TITLE
doc: release notes: Finalize 1.12 release notes and docs

### DIFF
--- a/doc/index.rst
+++ b/doc/index.rst
@@ -21,7 +21,7 @@ Zephyr Project Documentation
    versions are available:
 
    `Zephyr 1.5.0`_ | `Zephyr 1.6.1`_ | `Zephyr 1.7.1`_ | `Zephyr 1.8.0`_ |
-   `Zephyr 1.9.2`_ | `Zephyr 1.10.0`_ | `Zephyr 1.11.0`_
+   `Zephyr 1.9.2`_ | `Zephyr 1.10.0`_ | `Zephyr 1.11.0`_ | `Zephyr 1.12.0`_
 
 For information about the changes and additions for releases, please
 consult the published :ref:`zephyr_release_notes` documentation.
@@ -63,6 +63,7 @@ Indices and Tables
 
 * :ref:`genindex`
 
+.. _Zephyr 1.12.0: http://docs.zephyrproject.org/1.12.0/
 .. _Zephyr 1.11.0: http://docs.zephyrproject.org/1.11.0/
 .. _Zephyr 1.10.0: http://docs.zephyrproject.org/1.10.0/
 .. _Zephyr 1.9.2: http://docs.zephyrproject.org/1.9.0/

--- a/doc/release-notes-1.12.rst
+++ b/doc/release-notes-1.12.rst
@@ -2,8 +2,8 @@
 
 .. _zephyr_1.12:
 
-Zephyr Kernel 1.12.0 (DRAFT)
-############################
+Zephyr Kernel 1.12.0
+####################
 
 We are pleased to announce the release of Zephyr kernel version 1.12.0.
 

--- a/doc/release-notes.rst
+++ b/doc/release-notes.rst
@@ -18,7 +18,7 @@ Git clone and checkout commands, such as:
 
    git clone https://github.com/zephyrproject-rtos/zephyr
    cd zephyr
-   git checkout tags/v1.11.0
+   git checkout tags/v1.12.0
 
 
 The project's technical documentation is also tagged to correspond with a
@@ -30,6 +30,7 @@ Zephyr Kernel Releases
 .. toctree::
    :maxdepth: 1
 
+   release-notes-1.12
    release-notes-1.11
    release-notes-1.10
    release-notes-1.9


### PR DESCRIPTION
Removes the "draft" tag from the 1.12 release notes and adds a 1.12 link
on the release notes page. Adds a link to the 1.12 docs on the home
page.

Signed-off-by: Maureen Helm <maureen.helm@nxp.com>