### PR TITLE
net/ethernet: There is no need to fill in the header in all frags

### DIFF
--- a/include/net/arp.h
+++ b/include/net/arp.h
@@ -62,7 +62,7 @@ typedef void (*net_arp_cb_t)(struct arp_entry *entry,
 			     void *user_data);
 int net_arp_foreach(net_arp_cb_t cb, void *user_data);
 
-void net_arp_clear_cache(void);
+void net_arp_clear_cache(struct net_if *iface);
 void net_arp_init(void);
 
 /**

--- a/subsys/net/ip/l2/ethernet/arp.c
+++ b/subsys/net/ip/l2/ethernet/arp.c
@@ -482,17 +482,21 @@ enum net_verdict net_arp_input(struct net_pkt *pkt)
 	return NET_OK;
 }
 
-void net_arp_clear_cache(void)
+void net_arp_clear_cache(struct net_if *iface)
 {
 	int i;
 
 	for (i = 0; i < CONFIG_NET_ARP_TABLE_SIZE; i++) {
+		if (iface && iface != arp_table[i].iface) {
+			continue;
+		}
+
 		if (arp_table[i].pending) {
 			net_pkt_unref(arp_table[i].pending);
 		}
-	}
 
-	memset(&arp_table, 0, sizeof(arp_table));
+		memset(&arp_table[i], 0, sizeof(struct arp_entry));
+	}
 }
 
 int net_arp_foreach(net_arp_cb_t cb, void *user_data)
@@ -514,5 +518,5 @@ int net_arp_foreach(net_arp_cb_t cb, void *user_data)
 
 void net_arp_init(void)
 {
-	net_arp_clear_cache();
+	net_arp_clear_cache(NULL);
 }

--- a/subsys/net/ip/l2/ethernet/arp.c
+++ b/subsys/net/ip/l2/ethernet/arp.c
@@ -221,10 +221,6 @@ struct net_pkt *net_arp_prepare(struct net_pkt *pkt)
 			return NULL;
 		}
 
-		net_eth_fill_header(ctx, pkt, header, htons(NET_ETH_PTYPE_IP),
-				    net_pkt_ll_src(pkt)->addr,
-				    net_pkt_ll_dst(pkt)->addr);
-
 		net_pkt_frag_insert(pkt, header);
 
 		net_pkt_compact(pkt);

--- a/subsys/net/ip/l2/ethernet/arp.c
+++ b/subsys/net/ip/l2/ethernet/arp.c
@@ -198,7 +198,6 @@ struct net_pkt *net_arp_prepare(struct net_pkt *pkt)
 {
 	struct arp_entry *entry, *free_entry = NULL, *non_pending = NULL;
 	struct ethernet_context *ctx;
-	struct net_buf *frag;
 	struct net_linkaddr *ll;
 	struct net_eth_hdr *hdr;
 	struct in_addr *addr;
@@ -290,22 +289,9 @@ struct net_pkt *net_arp_prepare(struct net_pkt *pkt)
 		net_sprint_ll_addr(ll->addr, sizeof(struct net_eth_addr)),
 		net_sprint_ipv4_addr(&NET_IPV4_HDR(pkt)->src));
 
-	frag = pkt->frags;
-	while (frag) {
-		/* If there is no room for link layer header, then
-		 * just send the packet as is.
-		 */
-		if (!net_buf_headroom(frag)) {
-			frag = frag->frags;
-			continue;
-		}
-
-		hdr = net_eth_fill_header(ctx, pkt, frag,
-					  htons(NET_ETH_PTYPE_IP),
-					  ll->addr, entry->eth.addr);
-
-		frag = frag->frags;
-	}
+	net_eth_fill_header(ctx, pkt, pkt->frags,
+			    htons(NET_ETH_PTYPE_IP),
+			    ll->addr, entry->eth.addr);
 
 	return pkt;
 }

--- a/subsys/net/ip/l2/ethernet/ethernet.c
+++ b/subsys/net/ip/l2/ethernet/ethernet.c
@@ -523,10 +523,8 @@ static inline u16_t ethernet_reserve(struct net_if *iface, void *unused)
 
 static inline int ethernet_enable(struct net_if *iface, bool state)
 {
-	ARG_UNUSED(iface);
-
 	if (!state) {
-		net_arp_clear_cache();
+		net_arp_clear_cache(iface);
 	}
 
 	return 0;

--- a/subsys/net/ip/l2/ethernet/ethernet.c
+++ b/subsys/net/ip/l2/ethernet/ethernet.c
@@ -377,7 +377,6 @@ static enum net_verdict ethernet_send(struct net_if *iface,
 				      struct net_pkt *pkt)
 {
 	struct ethernet_context *ctx = net_if_l2_data(iface);
-	struct net_buf *frag;
 	u16_t ptype;
 
 #ifdef CONFIG_NET_ARP
@@ -492,19 +491,11 @@ setup_hdr:
 	}
 #endif /* CONFIG_NET_VLAN */
 
-	/* Then go through the fragments and set the ethernet header.
+	/* Then set the ethernet header.
 	 */
-	frag = pkt->frags;
-
-	NET_ASSERT_INFO(frag, "No data!");
-
-	while (frag) {
-		net_eth_fill_header(ctx, pkt, frag, ptype,
-				    net_pkt_ll_src(pkt)->addr,
-				    net_pkt_ll_dst(pkt)->addr);
-
-		frag = frag->frags;
-	}
+	net_eth_fill_header(ctx, pkt, pkt->frags, ptype,
+			    net_pkt_ll_src(pkt)->addr,
+			    net_pkt_ll_dst(pkt)->addr);
 
 #ifdef CONFIG_NET_ARP
 send:

--- a/subsys/net/ip/net_shell.c
+++ b/subsys/net/ip/net_shell.c
@@ -1279,7 +1279,7 @@ int net_shell_cmd_arp(int argc, char *argv[])
 
 	if (strcmp(argv[arg], "flush") == 0) {
 		printk("Flushing ARP cache.\n");
-		net_arp_clear_cache();
+		net_arp_clear_cache(NULL);
 		return 0;
 	}
 #else


### PR DESCRIPTION
Only the first one requires it. Actually drivers know that already and
handle the frags list correctly.

In case ethernet has to run along with 15.4 on the same SoC, this will
optimize things quite a bit knowing that biggest ethernet frame will be
forcefully split in as many 128 bytes frags as necessary.

Signed-off-by: Tomasz Bursztyka <tomasz.bursztyka@linux.intel.com>