### PR TITLE
drivers: can: Fix Issue #8226

### DIFF
--- a/drivers/can/stm32_can.c
+++ b/drivers/can/stm32_can.c
@@ -71,7 +71,7 @@ static void can_stm32_isr(void *arg)
 	}
 
 	if ((can->TSR & CAN_TSR_RQCP1) | bus_off) {
-		data->mb0.error_flags =
+		data->mb1.error_flags =
 				can->TSR & CAN_TSR_TXOK1 ? CAN_TX_OK  :
 				can->TSR & CAN_TSR_TERR1 ? CAN_TX_ERR :
 				can->TSR & CAN_TSR_ALST1 ? CAN_TX_ARB_LOST :
@@ -291,7 +291,7 @@ int can_stm32_send(struct device *dev, struct can_msg *msg, s32_t timeout,
 		k_mutex_unlock(tx_mutex);
 		SYS_LOG_DBG("Transmit buffer full. Wait with timeout (%dms)",
 			    timeout);
-		if (k_sem_take(&data->tx_int_sem, timeout) == -EAGAIN) {
+		if (k_sem_take(&data->tx_int_sem, timeout)) {
 			return CAN_TIMEOUT;
 		}
 
@@ -314,6 +314,7 @@ int can_stm32_send(struct device *dev, struct can_msg *msg, s32_t timeout,
 	}
 
 	mb->tx_callback = callback;
+	k_sem_reset(&mb->tx_int_sem);
 
 	/* mailbix identifier register setup */
 	mailbox->TIR &= CAN_TI0R_TXRQ;
@@ -339,7 +340,6 @@ int can_stm32_send(struct device *dev, struct can_msg *msg, s32_t timeout,
 	k_mutex_unlock(tx_mutex);
 
 	if (callback == NULL) {
-		k_sem_reset(&mb->tx_int_sem);
 		k_sem_take(&mb->tx_int_sem, K_FOREVER);
 		return mb->error_flags;
 	}
@@ -690,14 +690,11 @@ static inline int can_stm32_attach(struct device *dev, void *response_ptr,
 	int filter_index_tmp = 0;
 	int filter_nr;
 
-	k_mutex_lock(&data->set_filter_mutex, K_FOREVER);
-
 	filter_nr = can_stm32_set_filter(filter, data, can, &filter_index_tmp);
 	if (filter_nr != CAN_NO_FREE_FILTER) {
 		data->rx_response[filter_index_tmp] = response_ptr;
 	}
 
-	k_mutex_unlock(&data->set_filter_mutex);
 	*filter_index = filter_index_tmp;
 	return filter_nr;
 }
@@ -709,8 +706,10 @@ int can_stm32_attach_msgq(struct device *dev, struct k_msgq *msgq,
 	int filter_index;
 	struct can_stm32_data *data = DEV_DATA(dev);
 
+	k_mutex_lock(&data->set_filter_mutex, K_FOREVER);
 	filter_nr = can_stm32_attach(dev, msgq, filter, &filter_index);
 	data->response_type |= (1ULL << filter_index);
+	k_mutex_unlock(&data->set_filter_mutex);
 	return filter_nr;
 }
 
@@ -721,8 +720,10 @@ int can_stm32_attach_isr(struct device *dev, can_rx_callback_t isr,
 	int filter_nr;
 	int filter_index;
 
+	k_mutex_lock(&data->set_filter_mutex, K_FOREVER);
 	filter_nr = can_stm32_attach(dev, isr, filter, &filter_index);
 	data->response_type &= ~(1ULL << filter_index);
+	k_mutex_unlock(&data->set_filter_mutex);
 	return filter_nr;
 }
 


### PR DESCRIPTION
This commit is a fix for Issue #8226
- Error flags are assigned to the correct mailbox now.
- set_filter_mutex is moved from can_stm32_attach to the wrappers
  can_stm32_attach_isr and can_stm32_attach_msgq. This protects
  response_type variable.
- Waiting for empty mailbox semaphore return value
  is checked for none zero values to check all error states.
- The mailbox tx_int_sem is reset before the sending is triggered.