### PR TITLE
lib: posix: fix out-of-bound write

### DIFF
--- a/lib/posix/fs.c
+++ b/lib/posix/fs.c
@@ -293,7 +293,7 @@ struct dirent *readdir(DIR *dirp)
 	}
 
 	rc = strlen(fdirent.name);
-	rc = (rc <= PATH_MAX) ? rc : PATH_MAX;
+	rc = (rc < PATH_MAX) ? rc : (PATH_MAX - 1);
 	memcpy(pdirent.d_name, fdirent.name, rc);
 
 	/* Make sure the name is NULL terminated */


### PR DESCRIPTION
Ensure that path-name is in limits while storing

Coverity-CID: 186491
Fixes: #8280 

Signed-off-by: Paras Jain <parasjain2000@gmail.com>