### PR TITLE
lib: posix: Fix Out-of-bound write to char array 

### DIFF
--- a/lib/posix/fs.c
+++ b/lib/posix/fs.c
@@ -297,7 +297,7 @@ struct dirent *readdir(DIR *dirp)
 	memcpy(pdirent.d_name, fdirent.name, rc);
 
 	/* Make sure the name is NULL terminated */
-	pdirent.d_name[rc + 1] = '\0';
+	pdirent.d_name[rc] = '\0';
 	return &pdirent;
 }
 


### PR DESCRIPTION
lib: posix: Fix Out-of-bound write to char array

memcpy copies upto (rc-1)th index but the write of NULL character
to  the string is at (rc+1)th index skipping (rc)th index.
The fix addresses this as well.

CID: 186491

Fixes Issue #8280

Signed-off-by: Subramanian Meenakshi Sundaram subbu147@gmail.com