### PR TITLE
doc: relnotes: Add security vulnerability information

### DIFF
--- a/doc/release-notes-1.12.rst
+++ b/doc/release-notes-1.12.rst
@@ -24,6 +24,18 @@ Major enhancements with this release include:
 
 The following sections provide detailed lists of changes by component.
 
+Security Vulnerability Related
+******************************
+
+* A suitably sized k_malloc() request can result in a smaller than
+  requested buffer.  Use of that buffer could result in writes to
+  unallocated memory.  Proper overflow checks were added to fix this
+  issue in k_malloc and k_calloc.
+
+  * kernel: mempool: Check for overflow in k_malloc()
+  * kernel: mempool: Always check for overflow in k_calloc()
+  * tests: mempool: Add overflow checks
+
 Kernel
 ******
 


### PR DESCRIPTION
This patch adds notes for the security related changes going into
release 1.12.

Signed-off-by: Andy Gross <andy.gross@linaro.org>