### PR TITLE
arch/arc: Set the right priority for ADC/AON on quark_se

### DIFF
--- a/arch/arc/soc/quark_se_c1000_ss/Kconfig.defconfig
+++ b/arch/arc/soc/quark_se_c1000_ss/Kconfig.defconfig
@@ -128,6 +128,8 @@ endif # I2C
 if ADC
 config ADC_QMSI_SS
 	def_bool y
+config ADC_0_IRQ_PRI
+	default 0
 endif
 
 if BT_H4
@@ -241,7 +243,7 @@ config AON_TIMER_QMSI
 	def_bool y
 
 config AON_TIMER_IRQ_PRI
-	default 2
+	default 0
 
 endif # COUNTER
 


### PR DESCRIPTION
ARC has only 2 priorities, 0 or 1. So let's set the right priority for ADC and
AON.

Fixes #8302

Signed-off-by: Anas Nashif <anas.nashif@intel.com>