### PR TITLE
release: 1.12 doc cleanup

### DIFF
--- a/doc/index.rst
+++ b/doc/index.rst
@@ -20,7 +20,6 @@ Zephyr Project Documentation
    ``http://docs.zephyrproject.org/<version>``. The following documentation
    versions are available:
 
-   `Zephyr 1.5.0`_ | `Zephyr 1.6.1`_ | `Zephyr 1.7.1`_ | `Zephyr 1.8.0`_ |
    `Zephyr 1.9.2`_ | `Zephyr 1.10.0`_ | `Zephyr 1.11.0`_ | `Zephyr 1.12.0`_
 
 For information about the changes and additions for releases, please
@@ -67,7 +66,3 @@ Indices and Tables
 .. _Zephyr 1.11.0: http://docs.zephyrproject.org/1.11.0/
 .. _Zephyr 1.10.0: http://docs.zephyrproject.org/1.10.0/
 .. _Zephyr 1.9.2: http://docs.zephyrproject.org/1.9.0/
-.. _Zephyr 1.8.0: http://docs.zephyrproject.org/1.8.0/
-.. _Zephyr 1.7.1: http://docs.zephyrproject.org/1.7.0/
-.. _Zephyr 1.6.1: http://docs.zephyrproject.org/1.6.0/
-.. _Zephyr 1.5.0: http://docs.zephyrproject.org/1.5.0/

--- a/doc/release-notes-1.12.rst
+++ b/doc/release-notes-1.12.rst
@@ -16,7 +16,7 @@ Major enhancements with this release include:
 - Ethernet network management interface
 - Networking traffic prioritization on a per-connection basis
 - Support for Ethernet statistical counters
-- Support for TAP net device on the the native POSIX port
+- Support for TAP net device on the native POSIX port
 - Command-line Zephyr meta-tool "west"
 - SPI slave support
 - Runtime non-volatile configuration data storage system (settings)


### PR DESCRIPTION
Fix typo in 1.12 release notes, remove old doc version links (before
1.9)

Signed-off-by: David B. Kinder <david.b.kinder@intel.com>