### PR TITLE
net: lwm2m: retry registration update 6 seconds before expiration

### DIFF
--- a/subsys/net/lib/lwm2m/lwm2m_rd_client.c
+++ b/subsys/net/lib/lwm2m/lwm2m_rd_client.c
@@ -62,7 +62,7 @@
 
 #define LWM2M_RD_CLIENT_URI "rd"
 
-#define SECONDS_TO_UPDATE_EARLY	2
+#define SECONDS_TO_UPDATE_EARLY	6
 #define STATE_MACHINE_UPDATE_INTERVAL K_MSEC(500)
 
 /* Leave room for 32 hexadeciaml digits (UUID) + NULL */
@@ -640,7 +640,10 @@ static int sm_registration_done(void)
 	int ret = 0;
 	bool forced_update;
 
-	/* check for lifetime seconds - 1 so that we can update early */
+	/*
+	 * check for lifetime seconds - SECONDS_TO_UPDATE_EARLY
+	 * so that we can update early and avoid lifetime timeout
+	 */
 	if (sm_is_registered() &&
 	    (client.trigger_update ||
 	     ((client.lifetime - SECONDS_TO_UPDATE_EARLY) <=


### PR DESCRIPTION
When the priority of the LwM2M engine was lowered, it causes an
occasional registration update to fall outside of the registration
lifetime.  This shows up as the following error:
Failed with code 4.4. Retrying registration

Let's try and retry a bit earlier to account for the priority
change.

Signed-off-by: Michael Scott <michael@opensourcefoundries.com>