### PR TITLE
boards: arm: nrf52840: default IEEE802154_NRF5 if IEEE802154 enabled

### DIFF
--- a/boards/arm/nrf52840_pca10056/Kconfig.defconfig
+++ b/boards/arm/nrf52840_pca10056/Kconfig.defconfig
@@ -42,4 +42,11 @@ config USB_DEVICE_STACK
 
 endif # USB
 
+if IEEE802154
+
+config IEEE802154_NRF5
+	def_bool y
+
+endif # IEEE802154
+
 endif # BOARD_NRF52840_PCA10056


### PR DESCRIPTION
As the nRF52840 supports 802.15.4 natively, we should default y
for IEEE802154_NRF5 if IEEE802154 is enabled.

Signed-off-by: Michael Scott <michael@opensourcefoundries.com>