### PR TITLE
tests: disable preempt testcase for native_posix

### DIFF
--- a/tests/kernel/sched/preempt/testcase.yaml
+++ b/tests/kernel/sched/preempt/testcase.yaml
@@ -1,4 +1,5 @@
 tests:
   kernel.sched.preempt:
     tags: core
+    platform_exclude: native_posix
     filter: not CONFIG_SMP


### PR DESCRIPTION
Disabling testcase due to hang during sanitycheck run while we figure
out the real cause of this.

Signed-off-by: Anas Nashif <anas.nashif@intel.com>