### PR TITLE
net: Remove redundant NETWORKING dependency

### DIFF
--- a/subsys/net/ip/Kconfig
+++ b/subsys/net/ip/Kconfig
@@ -7,7 +7,6 @@
 #
 
 menu "IP stack"
-	depends on NETWORKING
 
 # Hidden option
 config NET_RAW_MODE


### PR DESCRIPTION
The 'source' of subsys/net/ip/Kconfig in subsys/net/Kconfig is already
within an 'if NETWORKING' block, so the NETWORKING dependency in
subsys/net/ip/Kconfig is redundant.

Remove the redundant dependency.

This gets rid of a bunch of 'NETWORKING && NETWORKING' dependencies in
the auto-generated Kconfig docs.

Signed-off-by: Ulf Magnusson <Ulf.Magnusson@nordicsemi.no>