### PR TITLE
native tests: fix kernel sched preempt for arch posix

### DIFF
--- a/tests/kernel/sched/preempt/src/main.c
+++ b/tests/kernel/sched/preempt/src/main.c
@@ -113,6 +113,18 @@ void wakeup_src_thread(int id)
 	while (do_sleep
 	       && !(worker_threads[id].base.thread_state & _THREAD_PENDING)) {
 		/* spin, waiting on the sleep timeout */
+#if defined(CONFIG_ARCH_POSIX)
+		/**
+		 * In the posix arch busy wait loops waiting for something to
+		 * happen need to halt the CPU due to the infinitely fast clock
+		 * assumption. (Or in plain English: otherwise you hang in this
+		 * loop. Because the posix arch emulates having 1 CPU by only
+		 * enabling 1 thread at a time. And because it assumes code
+		 * executes in 0 time: it always waits for the code to finish
+		 * and it letting the cpu sleep before letting time pass)
+		 */
+		posix_halt_cpu();
+#endif
 	}
 
 	/* We are lowest priority, SOMEONE must have run */

--- a/tests/kernel/sched/preempt/testcase.yaml
+++ b/tests/kernel/sched/preempt/testcase.yaml
@@ -1,5 +1,4 @@
 tests:
   kernel.sched.preempt:
     tags: core
-    platform_exclude: native_posix
     filter: not CONFIG_SMP


### PR DESCRIPTION
The test kernel.sched.preempt was hanging in the posix arch,
due to a busy wait loop in wakeup_src_thread() added in
a803af2fa74706f54786d3b72561c36981d92253.

We fix it by halting the cpu to let time pass in the posix
arch.

Reenabling the testcase in this board by reverting
e8a906c29c5cce770cd39f5c21210f0b9b0828d7

Signed-off-by: Alberto Escolar Piedras <alpi@oticon.com>