### PR TITLE
net: ethernet: Clean up net_eth_fill_header() function

### DIFF
--- a/include/net/ethernet.h
+++ b/include/net/ethernet.h
@@ -378,7 +378,6 @@ struct net_if *net_eth_get_vlan_iface(struct net_if *iface, u16_t tag)
  *
  * @param ctx Ethernet context
  * @param pkt Network packet
- * @param frag Ethernet header in packet
  * @param ptype Upper level protocol type (in network byte order)
  * @param src Source ethernet address
  * @param dst Destination ethernet address
@@ -387,7 +386,6 @@ struct net_if *net_eth_get_vlan_iface(struct net_if *iface, u16_t tag)
  */
 struct net_eth_hdr *net_eth_fill_header(struct ethernet_context *ctx,
 					struct net_pkt *pkt,
-					struct net_buf *frag,
 					u32_t ptype,
 					u8_t *src,
 					u8_t *dst);

--- a/subsys/net/ip/l2/ethernet/arp.c
+++ b/subsys/net/ip/l2/ethernet/arp.c
@@ -139,7 +139,7 @@ static inline struct net_pkt *prepare_arp(struct net_if *iface,
 	net_pkt_set_vlan_tag(pkt, vlan_tag);
 #endif
 
-	eth = net_eth_fill_header(ctx, pkt, frag, htons(NET_ETH_PTYPE_ARP),
+	eth = net_eth_fill_header(ctx, pkt, htons(NET_ETH_PTYPE_ARP),
 				  NULL, NULL);
 
 	/* If entry is not set, then we are just about to send
@@ -285,7 +285,7 @@ struct net_pkt *net_arp_prepare(struct net_pkt *pkt)
 		net_sprint_ll_addr(ll->addr, sizeof(struct net_eth_addr)),
 		net_sprint_ipv4_addr(&NET_IPV4_HDR(pkt)->src));
 
-	net_eth_fill_header(ctx, pkt, pkt->frags,
+	net_eth_fill_header(ctx, pkt,
 			    htons(NET_ETH_PTYPE_IP),
 			    ll->addr, entry->eth.addr);
 
@@ -389,7 +389,7 @@ static inline struct net_pkt *prepare_arp_reply(struct net_if *iface,
 	net_pkt_set_vlan_tag(pkt, net_pkt_vlan_tag(req));
 #endif
 
-	net_eth_fill_header(ctx, pkt, frag, htons(NET_ETH_PTYPE_ARP),
+	net_eth_fill_header(ctx, pkt, htons(NET_ETH_PTYPE_ARP),
 			    net_if_get_link_addr(iface)->addr,
 			    eth_query->src.addr);
 

--- a/subsys/net/ip/l2/ethernet/ethernet.c
+++ b/subsys/net/ip/l2/ethernet/ethernet.c
@@ -326,11 +326,12 @@ struct net_eth_hdr *net_eth_fill_header(struct ethernet_context *ctx,
 {
 	struct net_eth_hdr *hdr;
 
-	NET_ASSERT(net_buf_headroom(frag) > sizeof(struct net_eth_addr));
-
 #if defined(CONFIG_NET_VLAN)
 	if (net_eth_is_vlan_enabled(ctx, net_pkt_iface(pkt))) {
 		struct net_eth_vlan_hdr *hdr_vlan;
+
+		NET_ASSERT(net_buf_headroom(frag) >=
+			   sizeof(struct net_eth_vlan_hdr));
 
 		hdr_vlan = (struct net_eth_vlan_hdr *)(frag->data -
 						       net_pkt_ll_reserve(pkt));
@@ -357,6 +358,8 @@ struct net_eth_hdr *net_eth_fill_header(struct ethernet_context *ctx,
 		return (struct net_eth_hdr *)hdr_vlan;
 	}
 #endif
+
+	NET_ASSERT(net_buf_headroom(frag) >= sizeof(struct net_eth_hdr));
 
 	hdr = (struct net_eth_hdr *)(frag->data - net_pkt_ll_reserve(pkt));
 

--- a/subsys/net/ip/l2/ethernet/ethernet.c
+++ b/subsys/net/ip/l2/ethernet/ethernet.c
@@ -319,12 +319,12 @@ static void set_vlan_priority(struct ethernet_context *ctx,
 
 struct net_eth_hdr *net_eth_fill_header(struct ethernet_context *ctx,
 					struct net_pkt *pkt,
-					struct net_buf *frag,
 					u32_t ptype,
 					u8_t *src,
 					u8_t *dst)
 {
 	struct net_eth_hdr *hdr;
+	struct net_buf *frag = pkt->frags;
 
 #if defined(CONFIG_NET_VLAN)
 	if (net_eth_is_vlan_enabled(ctx, net_pkt_iface(pkt))) {
@@ -498,7 +498,7 @@ setup_hdr:
 
 	/* Then set the ethernet header.
 	 */
-	net_eth_fill_header(ctx, pkt, pkt->frags, ptype,
+	net_eth_fill_header(ctx, pkt, ptype,
 			    net_pkt_ll_src(pkt)->addr,
 			    net_pkt_ll_dst(pkt)->addr);
 


### PR DESCRIPTION
There's an apparent typo in testing net_buf headroom. Also, after
adding VLAN header support, its size should be used too.

Signed-off-by: Paul Sokolovsky <paul.sokolovsky@linaro.org>