### PR TITLE
net: ethernet: Show interface for dropped RX packet

### DIFF
--- a/subsys/net/ip/l2/ethernet/ethernet.c
+++ b/subsys/net/ip/l2/ethernet/ethernet.c
@@ -156,7 +156,7 @@ static enum net_verdict ethernet_recv(struct net_if *iface,
 		family = AF_INET6;
 		break;
 	default:
-		NET_DBG("Unknown hdr type 0x%04x", type);
+		NET_DBG("Unknown hdr type 0x%04x iface %p", type, iface);
 		return NET_DROP;
 	}
 


### PR DESCRIPTION
For debugging purposes it is useful to know which interface
the dropped packet was received.

Signed-off-by: Jukka Rissanen <jukka.rissanen@linux.intel.com>