### PR TITLE
net: bluetooth: Enforce the minimum user_data size at Kconfig

### DIFF
--- a/subsys/bluetooth/common/dummy.c
+++ b/subsys/bluetooth/common/dummy.c
@@ -25,11 +25,6 @@ BUILD_ASSERT(CONFIG_SYSTEM_WORKQUEUE_PRIORITY < 0);
  */
 BUILD_ASSERT(CONFIG_BT_HCI_TX_PRIO < CONFIG_BT_RX_PRIO);
 
-/* The Bluetooth subsystem requires network buffers to have at least 4 bytes
- * reserved for user data.
- */
-BUILD_ASSERT(CONFIG_NET_BUF_USER_DATA_SIZE >= 4);
-
 #if defined(CONFIG_BT_CTLR)
 /* The Bluetooth Controller's priority receive thread priority shall be higher
  * than the Bluetooth Host's Tx and the Controller's receive thread priority.

--- a/subsys/net/Kconfig
+++ b/subsys/net/Kconfig
@@ -20,6 +20,7 @@ if NET_BUF
 config NET_BUF_USER_DATA_SIZE
 	int "Size of user_data available in every network buffer"
 	default 4
+	range 4 65535 if BT
 	range 0 65535
 	help
 	  Amount of memory reserved in each network buffer for user data. In


### PR DESCRIPTION
Invalid configurations should be detected during configuration instead
of during compilation whenever possible.

This patch replaces a BUILD_ASSERT on CONFIG_NET_BUF_USER_DATA_SIZE
with what is intended to be an equivalent Kconfig restriction.

Signed-off-by: Sebastian Bøe <sebastian.boe@nordicsemi.no>