### PR TITLE
Bluetooth: GATT: Fix notifications

### DIFF
--- a/subsys/bluetooth/host/gatt.c
+++ b/subsys/bluetooth/host/gatt.c
@@ -798,8 +798,8 @@ static u8_t notify_cb(const struct bt_gatt_attr *attr, void *user_data)
 		if (data->type == BT_GATT_CCC_INDICATE) {
 			err = gatt_indicate(conn, data->params);
 		} else {
-			err = gatt_notify(conn, attr->handle, data->data,
-					  data->len);
+			err = gatt_notify(conn, data->attr->handle,
+					  data->data, data->len);
 		}
 
 		bt_conn_unref(conn);
@@ -818,7 +818,6 @@ int bt_gatt_notify(struct bt_conn *conn, const struct bt_gatt_attr *attr,
 		   const void *data, u16_t len)
 {
 	struct notify_data nfy;
-	u16_t value_handle = attr->handle;
 
 	__ASSERT(attr && attr->handle, "invalid parameters\n");
 
@@ -830,11 +829,11 @@ int bt_gatt_notify(struct bt_conn *conn, const struct bt_gatt_attr *attr,
 			return -EINVAL;
 		}
 
-		value_handle += 1;
+		attr++;
 	}
 
 	if (conn) {
-		return gatt_notify(conn, attr->handle + 1, data, len);
+		return gatt_notify(conn, attr->handle, data, len);
 	}
 
 	nfy.err = -ENOTCONN;
@@ -843,7 +842,7 @@ int bt_gatt_notify(struct bt_conn *conn, const struct bt_gatt_attr *attr,
 	nfy.data = data;
 	nfy.len = len;
 
-	bt_gatt_foreach_attr(value_handle, 0xffff, notify_cb, &nfy);
+	bt_gatt_foreach_attr(attr->handle, 0xffff, notify_cb, &nfy);
 
 	return nfy.err;
 }


### PR DESCRIPTION
Recent commits which made the choice of attribute to pass to
bt_gatt_notify() more flexible contained some unfortunate bugs in
handling the attributes and their values. In particular, both calls to
gatt_notify() would in certain circumstances pass the wrong handle
value. This should now be fixed.

Signed-off-by: Johan Hedberg <johan.hedberg@intel.com>