### PR TITLE
net: tcp: Add MSS option on sending SYN request

### DIFF
--- a/subsys/net/ip/tcp.c
+++ b/subsys/net/ip/tcp.c
@@ -1830,8 +1830,14 @@ static inline int send_syn_segment(struct net_context *context,
 {
 	struct net_pkt *pkt = NULL;
 	int ret;
+	u8_t options[NET_TCP_MAX_OPT_SIZE];
+	u8_t optionlen = 0;
 
-	ret = net_tcp_prepare_segment(context->tcp, flags, NULL, 0,
+	if (flags == NET_TCP_SYN) {
+		net_tcp_set_syn_opt(context->tcp, options, &optionlen);
+	}
+
+	ret = net_tcp_prepare_segment(context->tcp, flags, options, optionlen,
 				      local, remote, &pkt);
 	if (ret) {
 		return ret;


### PR DESCRIPTION
Currently, we add TCP options only to SYN+ACK reply to peer's SYN
(i.e. passive open). For consistency, add them also when we send
SYN ourselves (active open). In both cases, we add just MSS option
currently.

Signed-off-by: Paul Sokolovsky <paul.sokolovsky@linaro.org>