### PR TITLE
sanitycheck: fix false passed on localized error message

### DIFF
--- a/scripts/sanitycheck
+++ b/scripts/sanitycheck
@@ -1076,7 +1076,11 @@ class MakeGenerator:
 
             cmd = ["make", "-k", "-j", str(JOBS), "-f", tf.name, "all"]
 
-            p = subprocess.Popen(cmd, stderr=subprocess.PIPE, stdout=devnull)
+            # assure language neutral environemnt
+            make_env = os.environ.copy()
+            make_env['LC_MESSAGES'] = 'C.UTF-8'
+            p = subprocess.Popen(cmd, stderr=subprocess.PIPE,
+                                 stdout=devnull, env=make_env)
 
             for line in iter(p.stderr.readline, b''):
                 line = line.decode("utf-8")


### PR DESCRIPTION
Fix false passed on localized error message in make invocation.

Fixes #8348

Signed-off-by: Bobby Noelte <b0661n0e17e@gmail.com>