### PR TITLE
cmake: bluetooth: Don't #include gatt files from src files

### DIFF
--- a/samples/bluetooth/peripheral/CMakeLists.txt
+++ b/samples/bluetooth/peripheral/CMakeLists.txt
@@ -3,10 +3,10 @@ project(NONE)
 
 target_sources(app PRIVATE
   src/main.c
-  src/hrs.c
-  src/dis.c
-  src/bas.c
-  src/cts.c
+  ../gatt/hrs.c
+  ../gatt/dis.c
+  ../gatt/bas.c
+  ../gatt/cts.c
 )
 
 zephyr_library_include_directories($ENV{ZEPHYR_BASE}/samples/bluetooth)

--- a/samples/bluetooth/peripheral/src/bas.c
+++ b/samples/bluetooth/peripheral/src/bas.c
@@ -1,2 +1,0 @@
-/* Workaround build system bug that will put objects in source dir */
-#include "../../gatt/bas.c"

--- a/samples/bluetooth/peripheral/src/cts.c
+++ b/samples/bluetooth/peripheral/src/cts.c
@@ -1,2 +1,0 @@
-/* Workaround build system bug that will put objects in source dir */
-#include "../../gatt/cts.c"

--- a/samples/bluetooth/peripheral/src/dis.c
+++ b/samples/bluetooth/peripheral/src/dis.c
@@ -1,2 +1,0 @@
-/* Workaround build system bug that will put objects in source dir */
-#include "../../gatt/dis.c"

--- a/samples/bluetooth/peripheral/src/hrs.c
+++ b/samples/bluetooth/peripheral/src/hrs.c
@@ -1,2 +1,0 @@
-/* Workaround build system bug that will put objects in source dir */
-#include "../../gatt/hrs.c"

--- a/samples/bluetooth/peripheral_csc/CMakeLists.txt
+++ b/samples/bluetooth/peripheral_csc/CMakeLists.txt
@@ -2,6 +2,10 @@ include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
 project(NONE)
 
 FILE(GLOB app_sources src/*.c)
-target_sources(app PRIVATE ${app_sources})
+target_sources(app PRIVATE
+  ${app_sources}
+  ../gatt/dis.c
+  ../gatt/bas.c
+  )
 
 zephyr_library_include_directories($ENV{ZEPHYR_BASE}/samples/bluetooth)

--- a/samples/bluetooth/peripheral_csc/src/bas.c
+++ b/samples/bluetooth/peripheral_csc/src/bas.c
@@ -1,2 +1,0 @@
-/* Workaround build system bug that will put objects in source dir */
-#include "../../gatt/bas.c"

--- a/samples/bluetooth/peripheral_csc/src/dis.c
+++ b/samples/bluetooth/peripheral_csc/src/dis.c
@@ -1,2 +1,0 @@
-/* Workaround build system bug that will put objects in source dir */
-#include "../../gatt/dis.c"

--- a/samples/bluetooth/peripheral_dis/CMakeLists.txt
+++ b/samples/bluetooth/peripheral_dis/CMakeLists.txt
@@ -2,6 +2,9 @@ include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
 project(NONE)
 
 FILE(GLOB app_sources src/*.c)
-target_sources(app PRIVATE ${app_sources})
+target_sources(app PRIVATE
+  ${app_sources}
+  ../gatt/dis.c
+  )
 
 zephyr_library_include_directories($ENV{ZEPHYR_BASE}/samples/bluetooth)

--- a/samples/bluetooth/peripheral_dis/src/dis.c
+++ b/samples/bluetooth/peripheral_dis/src/dis.c
@@ -1,2 +1,0 @@
-/* Workaround build system bug that will put objects in source dir */
-#include "../../gatt/dis.c"

--- a/samples/bluetooth/peripheral_esp/CMakeLists.txt
+++ b/samples/bluetooth/peripheral_esp/CMakeLists.txt
@@ -3,8 +3,8 @@ project(NONE)
 
 target_sources(app PRIVATE
   src/main.c
-  src/bas.c
-  src/dis.c
+  ../gatt/bas.c
+  ../gatt/dis.c
 )
 
 zephyr_library_include_directories($ENV{ZEPHYR_BASE}/samples/bluetooth)

--- a/samples/bluetooth/peripheral_esp/src/bas.c
+++ b/samples/bluetooth/peripheral_esp/src/bas.c
@@ -1,2 +1,0 @@
-/* Workaround build system bug that will put objects in source dir */
-#include "../../gatt/bas.c"

--- a/samples/bluetooth/peripheral_esp/src/dis.c
+++ b/samples/bluetooth/peripheral_esp/src/dis.c
@@ -1,2 +1,0 @@
-/* Workaround build system bug that will put objects in source dir */
-#include "../../gatt/dis.c"

--- a/samples/bluetooth/peripheral_hids/CMakeLists.txt
+++ b/samples/bluetooth/peripheral_hids/CMakeLists.txt
@@ -2,6 +2,11 @@ include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
 project(NONE)
 
 FILE(GLOB app_sources src/*.c)
-target_sources(app PRIVATE ${app_sources})
+target_sources(app PRIVATE
+  ${app_sources}
+  ../gatt/hog.c
+  ../gatt/dis.c
+  ../gatt/bas.c
+  )
 
 zephyr_library_include_directories($ENV{ZEPHYR_BASE}/samples/bluetooth)

--- a/samples/bluetooth/peripheral_hids/src/bas.c
+++ b/samples/bluetooth/peripheral_hids/src/bas.c
@@ -1,2 +1,0 @@
-/* Workaround build system bug that will put objects in source dir */
-#include "../../gatt/bas.c"

--- a/samples/bluetooth/peripheral_hids/src/dis.c
+++ b/samples/bluetooth/peripheral_hids/src/dis.c
@@ -1,2 +1,0 @@
-/* Workaround build system bug that will put objects in source dir */
-#include "../../gatt/dis.c"

--- a/samples/bluetooth/peripheral_hids/src/hog.c
+++ b/samples/bluetooth/peripheral_hids/src/hog.c
@@ -1,2 +1,0 @@
-/* Workaround build system bug that will put objects in source dir */
-#include "../../gatt/hog.c"

--- a/samples/bluetooth/peripheral_hr/CMakeLists.txt
+++ b/samples/bluetooth/peripheral_hr/CMakeLists.txt
@@ -2,6 +2,11 @@ include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
 project(NONE)
 
 FILE(GLOB app_sources src/*.c)
-target_sources(app PRIVATE ${app_sources})
+target_sources(app PRIVATE
+  ${app_sources}
+  ../gatt/hrs.c
+  ../gatt/dis.c
+  ../gatt/bas.c
+  )
 
 zephyr_library_include_directories($ENV{ZEPHYR_BASE}/samples/bluetooth)

--- a/samples/bluetooth/peripheral_hr/src/bas.c
+++ b/samples/bluetooth/peripheral_hr/src/bas.c
@@ -1,2 +1,0 @@
-/* Workaround build system bug that will put objects in source dir */
-#include "../../gatt/bas.c"

--- a/samples/bluetooth/peripheral_hr/src/dis.c
+++ b/samples/bluetooth/peripheral_hr/src/dis.c
@@ -1,2 +1,0 @@
-/* Workaround build system bug that will put objects in source dir */
-#include "../../gatt/dis.c"

--- a/samples/bluetooth/peripheral_hr/src/hrs.c
+++ b/samples/bluetooth/peripheral_hr/src/hrs.c
@@ -1,2 +1,0 @@
-/* Workaround build system bug that will put objects in source dir */
-#include "../../gatt/hrs.c"


### PR DESCRIPTION
Due to a bug in KBuild, bluetooth samples needed to #include the gatt
sources to re-use code between samples. This bug was not ported to
CMake so we can stop applying this workaround.

gatt source files are now directly added to the 'app' library instead
of having adapter source files in the app's src directory that
\#include's the gatt files.

Signed-off-by: Sebastian Bøe <sebastian.boe@nordicsemi.no>