### PR TITLE
kernel: Allow to use k_sem_take() without MULTITHREADING

### DIFF
--- a/kernel/sem.c
+++ b/kernel/sem.c
@@ -142,6 +142,7 @@ void _impl_k_sem_give(struct k_sem *sem)
 Z_SYSCALL_HANDLER1_SIMPLE_VOID(k_sem_give, K_OBJ_SEM, struct k_sem *);
 #endif
 
+#ifdef CONFIG_MULTITHREADING
 int _impl_k_sem_take(struct k_sem *sem, s32_t timeout)
 {
 	__ASSERT(!_is_in_isr() || timeout == K_NO_WAIT, "");
@@ -161,6 +162,28 @@ int _impl_k_sem_take(struct k_sem *sem, s32_t timeout)
 
 	return _pend_current_thread(key, &sem->wait_q, timeout);
 }
+#else /* CONFIG_MULTITHREADING */
+int _impl_k_sem_take(struct k_sem *sem, s32_t timeout)
+{
+	__ASSERT(!_is_in_isr() || timeout == K_NO_WAIT, "");
+
+	u32_t start = k_uptime_get_32();
+
+	do {
+		unsigned int key = irq_lock();
+
+		if (likely(sem->count > 0)) {
+			sem->count--;
+			irq_unlock(key);
+			return 0;
+		}
+
+		irq_unlock(key);
+	} while ((k_uptime_get_32() - start) < timeout);
+
+	return -EBUSY;
+}
+#endif /* CONFIG_MULTITHREADING */
 
 #ifdef CONFIG_USERSPACE
 Z_SYSCALL_HANDLER(k_sem_take, sem, timeout)


### PR DESCRIPTION
There is no thread queue if `CONFIG_MULTITHREADING=n `is set.

With the current implementation, `_impl_k_sem_take()` calls `_pend_current_thread()` that moves the current thread in the waiting queue.
But when there is no MULTITHREADING support, there is only one thread.

This change implements `_impl_k_sem_take()` as a busy loop when no MULTITHREADING support.
It means the semaphore would have to be released in the ISR to exit the loop.

This issue has been triggered while porting MCUBoot (no multithreading support) to my platform. Some drivers needed during the boot process were using semaphore.

Signed-off-by: Olivier Martin <olivier.martin@proglove.com>