### PR TITLE
subsys: usb/class/hid: make interrupt endpoint size configurable

### DIFF
--- a/subsys/usb/class/hid/Kconfig
+++ b/subsys/usb/class/hid/Kconfig
@@ -25,6 +25,7 @@ config HID_INT_EP_ADDR
 
 config HID_INTERRUPT_EP_MPS
 	int
+	prompt "USB HID Device Interrupt Endpoint size"
 	default 16
 	help
 	  USB HID Device interrupt endpoint size


### PR DESCRIPTION
The Kconfig option HID_INTERRUPT_EP_MPS does not have a prompt entry,
so it is not configurable in practice. Fix that.

Signed-off-by: Aurelien Jarno <aurelien@aurel32.net>