### PR TITLE
arm: core: cortex_m: add a barrier before the dummy FP instruction

### DIFF
--- a/arch/arm/core/cortex_m/prep_c.c
+++ b/arch/arm/core/cortex_m/prep_c.c
@@ -79,11 +79,13 @@ static inline void enable_floating_point(void)
 	 * does not automatically save the volatile FP registers until they
 	 * have first been touched. Perform a dummy move operation so that
 	 * the stack frames are created as expected before any thread
-	 * context switching can occur.
+	 * context switching can occur. It has to be surrounded by instruction
+	 * synchronisation barriers to ensure that the whole sequence is
+	 * serialized.
 	 */
 	__asm__ volatile(
+		"isb;\n\t"
 		"vmov s0, s0;\n\t"
-		"dsb;\n\t"
 		"isb;\n\t"
 		);
 }


### PR DESCRIPTION
On Cortex-M7 CPU (at least on STM32F723 with patches from https://github.com/zephyrproject-rtos/zephyr/pull/7284), the dummy move FPU instruction is executed before the FPU lazy state preservation is disabled. This patch adds a barrier before it to avoid that.

This can be easily reproduced with a simple example, like `hello_world`, by setting `CONFIG_FLOAT=y`. The system goes in an endless loop very early, before outputting anything on the console. This is something difficult to debug, as executing the instructions step by step in GDB hides the problem. I guess the other Cortex-M7 based platforms are also affected: NXP i.MX RT and Microchip SAM E70. I guess @MaureenHelm can test the first one.