### PR TITLE
doc: update known-issues filter

### DIFF
--- a/.known-issues/doc/duplicate.conf
+++ b/.known-issues/doc/duplicate.conf
@@ -1,0 +1,6 @@
+#
+^(?P<filename>[-._/\w]+/doc/api/file_system.rst):(?P<lineno>[0-9]+): WARNING: Duplicate declaration.
+#
+^(?P<filename>[-._/\w]+/doc/api/io_interfaces.rst):(?P<lineno>[0-9]+): WARNING: Duplicate declaration.
+#
+^(?P<filename>[-._/\w]+/doc/subsystems/sensor.rst):(?P<lineno>[0-9]+): WARNING: Duplicate declaration.


### PR DESCRIPTION
New versions of Sphinx/Breathe are throwing a new  warning that
we'll need to filter before upgrading to breathe 4.9.1 and sphinx 1.7.5

This change won't impact our current builds but will prevent new known
warning messages when we upgrade the doc build tools.

Signed-off-by: David B. Kinder <david.b.kinder@intel.com>