### PR TITLE
kconfig: Change how BT affects SYSTEM_WORKQUEUE_PRIORITY

### DIFF
--- a/subsys/bluetooth/Kconfig
+++ b/subsys/bluetooth/Kconfig
@@ -35,6 +35,11 @@ config BT_CUSTOM
 
 endchoice
 
+# The Bluetooth subsystem requires the system workqueue to execute at
+# a cooperative priority.
+config SYSTEM_WORKQUEUE_PRIORITY
+	range -256 -1
+
 if BT_HCI
 
 config BT_HCI_RAW

--- a/subsys/bluetooth/common/dummy.c
+++ b/subsys/bluetooth/common/dummy.c
@@ -11,13 +11,6 @@
 
 #include <zephyr.h>
 
-/* The Bluetooth subsystem requires the system workqueue to execute at a
- * cooperative priority to function correctly. If this build assert triggers
- * verify your configuration to ensure that cooperative threads are enabled
- * and that the system workqueue priority is negative (cooperative).
- */
-BUILD_ASSERT(CONFIG_SYSTEM_WORKQUEUE_PRIORITY < 0);
-
 /* The Bluetooth subsystem requires the Tx thread to execute at higher priority
  * than the Rx thread as the Tx thread needs to process the acknowledgements
  * before new Rx data is processed. This is a necessity to correctly detect


### PR DESCRIPTION
Invalid configurations should be detected during configuration instead
of during compilation whenever possible.

This patch replaces a BUILD_ASSERT on CONFIG_SYSTEM_WORKQUEUE_PRIORITY
with what is intended to be an equivalent Kconfig restriction.

Signed-off-by: Sebastian Bøe <sebastian.boe@nordicsemi.no>