### PR TITLE
Bluetooth: controller: Remove include guards in internal files

### DIFF
--- a/subsys/bluetooth/controller/hal/ccm.h
+++ b/subsys/bluetooth/controller/hal/ccm.h
@@ -5,9 +5,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#ifndef _CCM_H_
-#define _CCM_H_
-
 struct ccm {
 	u8_t  key[16];
 	u64_t counter;
@@ -15,5 +12,3 @@ struct ccm {
 	u8_t  resv1:7;
 	u8_t  iv[8];
 } __packed;
-
-#endif /* _CCM_H_ */

--- a/subsys/bluetooth/controller/hal/cntr.h
+++ b/subsys/bluetooth/controller/hal/cntr.h
@@ -5,13 +5,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#ifndef _CNTR_H_
-#define _CNTR_H_
-
 void cntr_init(void);
 u32_t cntr_start(void);
 u32_t cntr_stop(void);
 u32_t cntr_cnt_get(void);
 void cntr_cmp_set(u8_t cmp, u32_t value);
-
-#endif /* _CNTR_H_ */

--- a/subsys/bluetooth/controller/hal/cpu.h
+++ b/subsys/bluetooth/controller/hal/cpu.h
@@ -5,14 +5,9 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#ifndef _CPU_H_
-#define _CPU_H_
-
 static inline void cpu_sleep(void)
 {
 	__WFE();
 	__SEV();
 	__WFE();
 }
-
-#endif /* _CPU_H_ */

--- a/subsys/bluetooth/controller/hal/debug.h
+++ b/subsys/bluetooth/controller/hal/debug.h
@@ -5,9 +5,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#ifndef _HAL_DEBUG_H_
-#define _HAL_DEBUG_H_
-
 #ifdef CONFIG_BT_CTLR_ASSERT_HANDLER
 void bt_ctlr_assert_handle(char *file, u32_t line);
 #define LL_ASSERT(cond) if (!(cond)) { \
@@ -19,5 +16,3 @@ void bt_ctlr_assert_handle(char *file, u32_t line);
 #endif
 
 #include "nrf5/debug.h"
-
-#endif /* _HAL_DEBUG_H_ */

--- a/subsys/bluetooth/controller/hal/ecb.h
+++ b/subsys/bluetooth/controller/hal/ecb.h
@@ -5,9 +5,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#ifndef _ECB_H_
-#define _ECB_H_
-
 typedef void (*ecb_fp) (u32_t status, u8_t *cipher_be, void *context);
 
 struct ecb {
@@ -30,5 +27,3 @@ u32_t ecb_encrypt_nonblocking(struct ecb *ecb);
 void isr_ecb(void *param);
 
 u32_t ecb_ut(void);
-
-#endif /* _ECB_H_ */

--- a/subsys/bluetooth/controller/hal/nrf5/debug.h
+++ b/subsys/bluetooth/controller/hal/nrf5/debug.h
@@ -5,9 +5,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#ifndef _DEBUG_H_
-#define _DEBUG_H_
-
 #ifdef CONFIG_BT_CTLR_DEBUG_PINS
 #if defined(CONFIG_BOARD_NRF52840_PCA10056)
 #define DEBUG_PORT       NRF_P1
@@ -245,5 +242,3 @@
 #define DEBUG_RADIO_START_M(flag)
 
 #endif /* CONFIG_BT_CTLR_DEBUG_PINS */
-
-#endif /* _DEBUG_H_ */

--- a/subsys/bluetooth/controller/hal/radio.h
+++ b/subsys/bluetooth/controller/hal/radio.h
@@ -5,9 +5,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#ifndef _RADIO_H_
-#define _RADIO_H_
-
 typedef void (*radio_isr_fp) (void);
 
 void isr_radio(void);
@@ -99,5 +96,3 @@ void radio_ar_configure(u32_t nirk, void *irk);
 u32_t radio_ar_match_get(void);
 void radio_ar_status_reset(void);
 u32_t radio_ar_has_match(void);
-
-#endif

--- a/subsys/bluetooth/controller/hci/hci_internal.h
+++ b/subsys/bluetooth/controller/hci/hci_internal.h
@@ -5,9 +5,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#ifndef _HCI_CONTROLLER_H_
-#define _HCI_CONTROLLER_H_
-
 #if defined(CONFIG_BT_HCI_ACL_FLOW_CONTROL)
 extern s32_t    hci_hbuf_total;
 extern u32_t    hci_hbuf_sent;
@@ -43,4 +40,3 @@ int hci_acl_handle(struct net_buf *acl, struct net_buf **evt);
 void hci_acl_encode(struct radio_pdu_node_rx *node_rx, struct net_buf *buf);
 void hci_num_cmplt_encode(struct net_buf *buf, u16_t handle, u8_t num);
 #endif
-#endif /* _HCI_CONTROLLER_H_ */

--- a/subsys/bluetooth/controller/include/ll.h
+++ b/subsys/bluetooth/controller/include/ll.h
@@ -5,9 +5,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#ifndef _LL_H_
-#define _LL_H_
-
 int ll_init(struct k_sem *sem_rx);
 void ll_reset(void);
 
@@ -101,5 +98,3 @@ void ll_rx_mem_release(void **node_rx);
 void ll_timeslice_ticker_id_get(u8_t * const instance_index, u8_t * const user_id);
 void ll_radio_state_abort(void);
 u32_t ll_radio_state_is_idle(void);
-
-#endif /* _LL_H_ */

--- a/subsys/bluetooth/controller/ll_sw/ctrl.h
+++ b/subsys/bluetooth/controller/ll_sw/ctrl.h
@@ -5,9 +5,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#ifndef _CTRL_H_
-#define _CTRL_H_
-
 /*****************************************************************************
  * Zephyr Kconfig defined
  ****************************************************************************/
@@ -374,5 +371,3 @@ u8_t radio_rx_fc_get(u16_t *handle);
 extern void radio_active_callback(u8_t active);
 extern void radio_event_callback(void);
 extern void ll_adv_scan_state_cb(u8_t bm);
-
-#endif

--- a/subsys/bluetooth/controller/ll_sw/ll_filter.c
+++ b/subsys/bluetooth/controller/ll_sw/ll_filter.c
@@ -25,7 +25,6 @@
 #include "common/log.h"
 
 #include "hal/debug.h"
-#include "pdu.h"
 
 /* Hardware whitelist */
 static struct ll_filter wl_filter;

--- a/subsys/bluetooth/controller/ll_sw/pdu.h
+++ b/subsys/bluetooth/controller/ll_sw/pdu.h
@@ -5,9 +5,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#ifndef _PDU_H_
-#define _PDU_H_
-
 #define BDADDR_SIZE 6
 
 /* PDU Sizes */
@@ -414,5 +411,3 @@ struct pdu_data {
 #endif /* CONFIG_BT_CTLR_PROFILE_ISR */
 	} __packed;
 } __packed;
-
-#endif /* _PDU_H_ */

--- a/subsys/bluetooth/controller/ticker/ticker.h
+++ b/subsys/bluetooth/controller/ticker/ticker.h
@@ -5,9 +5,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#ifndef _TICKER_H_
-#define _TICKER_H_
-
 /** \defgroup Timer API return codes.
 *
 * @{
@@ -109,5 +106,3 @@ u32_t ticker_job_idle_get(u8_t instance_index, u8_t user_id,
 void ticker_job_sched(u8_t instance_index, u8_t user_id);
 u32_t ticker_ticks_now_get(void);
 u32_t ticker_ticks_diff_get(u32_t ticks_now, u32_t ticks_old);
-
-#endif

--- a/subsys/bluetooth/controller/util/mayfly.h
+++ b/subsys/bluetooth/controller/util/mayfly.h
@@ -5,9 +5,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#ifndef _MAYFLY_H_
-#define _MAYFLY_H_
-
 #define MAYFLY_CALL_ID_0       0
 #define MAYFLY_CALL_ID_1       1
 #define MAYFLY_CALL_ID_2       2
@@ -33,5 +30,3 @@ extern void mayfly_enable_cb(u8_t caller_id, u8_t callee_id, u8_t enable);
 extern u32_t mayfly_is_enabled(u8_t caller_id, u8_t callee_id);
 extern u32_t mayfly_prio_is_equal(u8_t caller_id, u8_t callee_id);
 extern void mayfly_pend(u8_t caller_id, u8_t callee_id);
-
-#endif /* _MAYFLY_H_ */

--- a/subsys/bluetooth/controller/util/mem.h
+++ b/subsys/bluetooth/controller/util/mem.h
@@ -5,9 +5,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#ifndef _MEM_H_
-#define _MEM_H_
-
 #ifndef MALIGN
 #define MALIGN(x) __attribute__((aligned(x)))
 #endif
@@ -28,5 +25,3 @@ void mem_rcopy(u8_t *dst, u8_t const *src, u16_t len);
 u8_t mem_nz(u8_t *src, u16_t len);
 
 u32_t mem_ut(void);
-
-#endif /* _MEM_H_ */

--- a/subsys/bluetooth/controller/util/memq.h
+++ b/subsys/bluetooth/controller/util/memq.h
@@ -5,9 +5,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#ifndef _MEMQ_H_
-#define _MEMQ_H_
-
 struct _memq_link {
 	struct _memq_link *next;
 	void              *mem;
@@ -20,5 +17,3 @@ memq_link_t *memq_init(memq_link_t *link, memq_link_t **head,
 memq_link_t *memq_enqueue(memq_link_t *link, void *mem, memq_link_t **tail);
 memq_link_t *memq_peek(memq_link_t *head, memq_link_t *tail, void **mem);
 memq_link_t *memq_dequeue(memq_link_t *tail, memq_link_t **head, void **mem);
-
-#endif /* _MEMQ_H_ */

--- a/subsys/bluetooth/controller/util/util.h
+++ b/subsys/bluetooth/controller/util/util.h
@@ -5,9 +5,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#ifndef _UTIL_H_
-#define _UTIL_H_
-
 #ifndef DOUBLE_BUFFER_SIZE
 #define DOUBLE_BUFFER_SIZE 2
 #endif
@@ -17,5 +14,3 @@
 #endif
 
 u8_t util_ones_count_get(u8_t *octets, u8_t octets_len);
-
-#endif


### PR DESCRIPTION
Remove include guards in internal files; it is an agreed
convention to not have include guards in internal header
files in Bluetooth subsystem.

Signed-off-by: Vinayak Kariappa Chettimada <vich@nordicsemi.no>