### PR TITLE
esp32: add ESP-IDF bootloader option

### DIFF
--- a/boards/xtensa/esp32/CMakeLists.txt
+++ b/boards/xtensa/esp32/CMakeLists.txt
@@ -1,0 +1,11 @@
+
+if(CONFIG_BOOTLOADER_ESP_IDF)
+  add_custom_target(EspIdfBootloader
+	COMMAND PATH=$ENV{PATH}:${ESPRESSIF_TOOLCHAIN_PATH}/bin make IDF_PATH=${ESP_IDF_PATH} -C ${ESP_IDF_PATH}/examples/get-started/hello_world/ BUILD_DIR_BASE=${CMAKE_BINARY_DIR}/esp-idf defconfig
+	COMMAND PATH=$ENV{PATH}:${ESPRESSIF_TOOLCHAIN_PATH}/bin make IDF_PATH=${ESP_IDF_PATH} -C ${ESP_IDF_PATH}/examples/get-started/hello_world/ BUILD_DIR_BASE=${CMAKE_BINARY_DIR}/esp-idf bootloader
+	COMMAND PATH=$ENV{PATH}:${ESPRESSIF_TOOLCHAIN_PATH}/bin make IDF_PATH=${ESP_IDF_PATH} -C ${ESP_IDF_PATH}/examples/get-started/hello_world/ BUILD_DIR_BASE=${CMAKE_BINARY_DIR}/esp-idf partition_table
+	)
+
+  add_dependencies(app EspIdfBootloader)
+
+endif()

--- a/boards/xtensa/esp32/CMakeLists.txt
+++ b/boards/xtensa/esp32/CMakeLists.txt
@@ -1,11 +1,32 @@
 
 if(CONFIG_BOOTLOADER_ESP_IDF)
-  add_custom_target(EspIdfBootloader
-	COMMAND PATH=$ENV{PATH}:${ESPRESSIF_TOOLCHAIN_PATH}/bin make IDF_PATH=${ESP_IDF_PATH} -C ${ESP_IDF_PATH}/examples/get-started/hello_world/ BUILD_DIR_BASE=${CMAKE_BINARY_DIR}/esp-idf defconfig
-	COMMAND PATH=$ENV{PATH}:${ESPRESSIF_TOOLCHAIN_PATH}/bin make IDF_PATH=${ESP_IDF_PATH} -C ${ESP_IDF_PATH}/examples/get-started/hello_world/ BUILD_DIR_BASE=${CMAKE_BINARY_DIR}/esp-idf bootloader
-	COMMAND PATH=$ENV{PATH}:${ESPRESSIF_TOOLCHAIN_PATH}/bin make IDF_PATH=${ESP_IDF_PATH} -C ${ESP_IDF_PATH}/examples/get-started/hello_world/ BUILD_DIR_BASE=${CMAKE_BINARY_DIR}/esp-idf partition_table
-	)
+  include(ExternalProject)
+
+  ## we use hell-world project, but I think any can be used.
+  set(espidf_src_dir   ${ESP_IDF_PATH}/examples/get-started/hello_world/)
+  set(espidf_prefix    ${CMAKE_BINARY_DIR}/esp-idf)
+  set(espidf_build_dir ${espidf_prefix}/build)
+
+  ExternalProject_Add(
+    EspIdfBootloader
+    PREFIX ${espidf_prefix}
+    SOURCE_DIR ${espidf_src_dir}
+    BINARY_DIR ${espidf_src_dir}
+    CONFIGURE_COMMAND ""    # Skip configuring the project, e.g. with autoconf
+    BUILD_COMMAND
+    PATH=$ENV{PATH}:${ESPRESSIF_TOOLCHAIN_PATH}/bin
+    make
+    IDF_PATH=${ESP_IDF_PATH}
+    BUILD_DIR_BASE=${espidf_build_dir}
+    SDKCONFIG=${espidf_build_dir}/sdkconfig
+    defconfig bootloader partition_table
+    INSTALL_COMMAND ""      # This particular build system has no install command
+    )
 
   add_dependencies(app EspIdfBootloader)
+
+  board_finalize_runner_args(esp32 "--esp-flash-bootloader=${espidf_build_dir}/bootloader/bootloader.bin")
+
+  board_finalize_runner_args(esp32 "--esp-flash-partition_table=${espidf_build_dir}/partitions_singleapp.bin")
 
 endif()

--- a/misc/Kconfig
+++ b/misc/Kconfig
@@ -354,11 +354,11 @@ config BOOTLOADER_ESP_IDF
 	bool
 	prompt "ESP-IDF bootloader support"
 	default n
+	depends on SOC_ESP32
 	help
 	  This option will trigger the compilation of the ESP-IDF booloader
 	  inside the build folder.
 	  At flash time, the bootloader will be flashed with the zephyr image
-	depends on SOC_ESP32
 
 config BOOTLOADER_KEXEC
 	bool

--- a/misc/Kconfig
+++ b/misc/Kconfig
@@ -350,6 +350,16 @@ config BOOTLOADER_MCUBOOT
 	    * Including dts/common/mcuboot.overlay when building the Device
 	      Tree in order to place and link the image at the slot0 offset
 
+config BOOTLOADER_ESP_IDF
+	bool
+	prompt "ESP-IDF bootloader support"
+	default n
+	help
+	  This option will trigger the compilation of the ESP-IDF booloader
+	  inside the build folder.
+	  At flash time, the bootloader will be flashed with the zephyr image
+	depends on SOC_ESP32
+
 config BOOTLOADER_KEXEC
 	bool
 	prompt "Boot using Linux kexec() system call"

--- a/scripts/meta/west/runner/esp32.py
+++ b/scripts/meta/west/runner/esp32.py
@@ -14,7 +14,8 @@ class Esp32BinaryRunner(ZephyrBinaryRunner):
     '''Runner front-end for espidf.'''
 
     def __init__(self, cfg, device, baud=921600, flash_size='detect',
-                 flash_freq='40m', flash_mode='dio', espidf='espidf'):
+                 flash_freq='40m', flash_mode='dio', espidf='espidf',
+                 bootloader_bin=None, partition_table_bin=None):
         super(Esp32BinaryRunner, self).__init__(cfg)
         self.elf = cfg.kernel_elf
         self.device = device
@@ -23,6 +24,8 @@ class Esp32BinaryRunner(ZephyrBinaryRunner):
         self.flash_freq = flash_freq
         self.flash_mode = flash_mode
         self.espidf = espidf
+        self.bootloader_bin = bootloader_bin
+        self.partition_table_bin = partition_table_bin
 
     @classmethod
     def name(cls):
@@ -53,6 +56,10 @@ class Esp32BinaryRunner(ZephyrBinaryRunner):
             '--esp-tool',
             help='''if given, complete path to espidf. default is to search for
             it in [ESP_IDF_PATH]/components/esptool_py/esptool/esptool.py''')
+        parser.add_argument('--esp-flash-bootloader',
+                            help='Bootloader image to flash')
+        parser.add_argument('--esp-flash-partition_table',
+                            help='Partition table to flash')
 
     @classmethod
     def create(cls, cfg, args):
@@ -65,7 +72,9 @@ class Esp32BinaryRunner(ZephyrBinaryRunner):
         return Esp32BinaryRunner(
             cfg, args.esp_device, baud=args.esp_baud_rate,
             flash_size=args.esp_flash_size, flash_freq=args.esp_flash_freq,
-            flash_mode=args.esp_flash_mode, espidf=espidf)
+            flash_mode=args.esp_flash_mode, espidf=espidf,
+            bootloader_bin=args.esp_flash_bootloader,
+            partition_table_bin=args.esp_flash_partition_table)
 
     def do_run(self, command, **kwargs):
         bin_name = path.splitext(self.elf)[0] + path.extsep + 'bin'
@@ -75,8 +84,14 @@ class Esp32BinaryRunner(ZephyrBinaryRunner):
                      '--after', 'hard_reset', 'write_flash', '-u',
                      '--flash_mode', self.flash_mode,
                      '--flash_freq', self.flash_freq,
-                     '--flash_size', self.flash_size,
-                     '0x1000', bin_name]
+                     '--flash_size', self.flash_size]
+
+        if self.bootloader_bin:
+            cmd_flash.extend(['0x1000', self.bootloader_bin])
+            cmd_flash.extend(['0x8000', self.partition_table_bin])
+            cmd_flash.extend(['0x10000', bin_name])
+        else:
+            cmd_flash.extend(['0x1000', bin_name])
 
         log.inf("Converting ELF to BIN")
         self.check_call(cmd_convert)


### PR DESCRIPTION
Closes #8382 

Signed-off-by: Gautier Seidel <gautier.seidel@tado.com>

@SebastianBoe:
  - do you have major comments?
  - I struggle on how to remove the folder esp-idf with a ```make clean```. Do you have any pointer?

todo: patch ```runner/esp32.py``` to flash bootloader along with the zephyr image