### PR TITLE
Enforce COOP priorities for networking subsystem

### DIFF
--- a/kernel/Kconfig
+++ b/kernel/Kconfig
@@ -80,6 +80,7 @@ config MAIN_THREAD_PRIORITY
 	int
 	prompt "Priority of initialization/main thread"
 	default 0
+	default -1 if COOP_ENABLED
 	default -2 if !PREEMPT_ENABLED
 	help
 	  Priority at which the initialization thread runs, including the start

--- a/subsys/net/Kconfig
+++ b/subsys/net/Kconfig
@@ -91,6 +91,11 @@ config  NETWORKING
 
 if NETWORKING
 
+# The networking subsystem requires the system workqueue to execute at
+# a cooperative priority.
+config SYSTEM_WORKQUEUE_PRIORITY
+	range -256 -1
+
 source "subsys/net/Kconfig.hostname"
 
 source "subsys/net/ip/Kconfig"

--- a/subsys/net/Kconfig
+++ b/subsys/net/Kconfig
@@ -85,6 +85,7 @@ config  NETWORKING
 	select NET_BUF
 	select POLL
 	select ENTROPY_GENERATOR
+	select COOP_ENABLED
 	default n
 	help
 	  This option enabled generic link layer and IP networking support.

--- a/subsys/net/ip/net_core.c
+++ b/subsys/net/ip/net_core.c
@@ -419,4 +419,11 @@ static int net_init(struct device *unused)
 	return status;
 }
 
+/* The networking subsystem requires the main thread to execute at a
+ * cooperative priority to function correctly. If this build assert triggers
+ * verify your configuration to ensure that cooperative threads are enabled
+ * and that the main thread priority is negative (cooperative).
+ */
+BUILD_ASSERT(CONFIG_MAIN_THREAD_PRIORITY < 0);
+
 SYS_INIT(net_init, POST_KERNEL, CONFIG_NET_INIT_PRIO);


### PR DESCRIPTION
This is related to similar changes in #8377. The networking subsystem should not be accessed from preemptive thread so try to check this at compile time. Later we might need to add run-time checks but lets start with this atm.