### PR TITLE
drivers/flash: Remove irrelevant option in w25qxxdv driver

### DIFF
--- a/boards/x86/arduino_101/Kconfig.defconfig
+++ b/boards/x86/arduino_101/Kconfig.defconfig
@@ -40,7 +40,7 @@ config DISK_FLASH_START
 	default 0x0
 
 config DISK_FLASH_MAX_RW_SIZE
-	default SPI_FLASH_W25QXXDV_MAX_DATA_LEN
+	default 1024
 
 config DISK_ERASE_BLOCK_SIZE
 	default 0x1000

--- a/drivers/flash/Kconfig.w25qxxdv
+++ b/drivers/flash/Kconfig.w25qxxdv
@@ -74,11 +74,4 @@ config SPI_FLASH_W25QXXDV_FLASH_SIZE
 	help
 	  This is the flash capacity in bytes.
 
-config SPI_FLASH_W25QXXDV_MAX_DATA_LEN
-	int
-	range 1 256
-	default 256
-	help
-	  Maximum transmit or receive data length in one user data frame.
-
 endif # SPI_FLASH_W25QXXDV

--- a/drivers/flash/spi_flash_w25qxxdv.c
+++ b/drivers/flash/spi_flash_w25qxxdv.c
@@ -119,7 +119,7 @@ static int spi_flash_wb_read(struct device *dev, off_t offset, void *data,
 	struct spi_flash_data *const driver_data = dev->driver_data;
 	int ret;
 
-	if (len > CONFIG_SPI_FLASH_W25QXXDV_MAX_DATA_LEN || offset < 0) {
+	if (offset < 0) {
 		return -ENODEV;
 	}
 
@@ -142,7 +142,7 @@ static int spi_flash_wb_write(struct device *dev, off_t offset,
 	u8_t reg;
 	int ret;
 
-	if (len > CONFIG_SPI_FLASH_W25QXXDV_MAX_DATA_LEN || offset < 0) {
+	if (offset < 0) {
 		return -ENOTSUP;
 	}
 


### PR DESCRIPTION
CONFIG_SPI_FLASH_W25QXXDV_MAX_DATA_LEN is a left-over from old SPI API
usage. Now, there is no limit (besides the flash size) in SPI data
transaction.

Fixes #8327

Signed-off-by: Tomasz Bursztyka <tomasz.bursztyka@linux.intel.com>