### PR TITLE
cmake: replace PROJECT_SOURCE_DIR with ZEPHYR_BASE (#7173)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -337,9 +337,9 @@ add_custom_target(syscall_macros_h_target DEPENDS ${syscall_macros_h})
 add_custom_command(                       OUTPUT  ${syscall_macros_h}
   COMMAND
   ${PYTHON_EXECUTABLE}
-  ${PROJECT_SOURCE_DIR}/scripts/gen_syscall_header.py
+  ${ZEPHYR_BASE}/scripts/gen_syscall_header.py
   > ${syscall_macros_h}
-  DEPENDS ${PROJECT_SOURCE_DIR}/scripts/gen_syscall_header.py
+  DEPENDS ${ZEPHYR_BASE}/scripts/gen_syscall_header.py
   )
 
 
@@ -361,9 +361,9 @@ set(syscalls_subdirs_trigger ${CMAKE_CURRENT_BINARY_DIR}/misc/generated/syscalls
 execute_process(
   COMMAND
   ${PYTHON_EXECUTABLE}
-  ${PROJECT_SOURCE_DIR}/scripts/subfolder_list.py
-  --directory        ${PROJECT_SOURCE_DIR}/include # Walk this directory
-  --out-file         ${syscalls_subdirs_txt}       # Write this file
+  ${ZEPHYR_BASE}/scripts/subfolder_list.py
+  --directory        ${ZEPHYR_BASE}/include  # Walk this directory
+  --out-file         ${syscalls_subdirs_txt} # Write this file
   )
 file(STRINGS ${syscalls_subdirs_txt} PARSE_SYSCALLS_PATHS_DEPENDS)
 
@@ -374,7 +374,7 @@ if(${CMAKE_HOST_SYSTEM_NAME} STREQUAL Windows)
 
   # Also On Windows each header file must be monitored as file modifications are not reflected
   # on directory level.
-  file(GLOB_RECURSE PARSE_SYSCALLS_HEADER_DEPENDS ${PROJECT_SOURCE_DIR}/include/*.h)
+  file(GLOB_RECURSE PARSE_SYSCALLS_HEADER_DEPENDS ${ZEPHYR_BASE}/include/*.h)
 else()
   # The syscall parsing depends on the folders in order to detect add/removed/modified files.
   # When a folder is removed, CMake will try to find a target that creates that dependency.
@@ -392,10 +392,10 @@ else()
     ${syscalls_subdirs_txt}
     COMMAND
     ${PYTHON_EXECUTABLE}
-    ${PROJECT_SOURCE_DIR}/scripts/subfolder_list.py
-    --directory        ${PROJECT_SOURCE_DIR}/include # Walk this directory
-    --out-file         ${syscalls_subdirs_txt}       # Write this file
-    --trigger          ${syscalls_subdirs_trigger}   # Trigger file that will result in CMake rerun
+    ${ZEPHYR_BASE}/scripts/subfolder_list.py
+    --directory        ${ZEPHYR_BASE}/include      # Walk this directory
+    --out-file         ${syscalls_subdirs_txt}     # Write this file
+    --trigger          ${syscalls_subdirs_trigger} # Trigger file that will result in CMake rerun
     DEPENDS ${PARSE_SYSCALLS_PATHS_DEPENDS}
     )
 
@@ -416,9 +416,9 @@ add_custom_command(
   ${syscalls_json}
   COMMAND
   ${PYTHON_EXECUTABLE}
-  ${PROJECT_SOURCE_DIR}/scripts/parse_syscalls.py
-  --include          ${PROJECT_SOURCE_DIR}/include        # Read files from this dir
-  --json-file        ${syscalls_json}                     # Write this file
+  ${ZEPHYR_BASE}/scripts/parse_syscalls.py
+  --include          ${ZEPHYR_BASE}/include # Read files from this dir
+  --json-file        ${syscalls_json}       # Write this file
   DEPENDS ${syscalls_subdirs_txt} ${PARSE_SYSCALLS_HEADER_DEPENDS}
   )
 
@@ -427,7 +427,7 @@ add_custom_command(OUTPUT include/generated/syscall_dispatch.c ${syscall_list_h}
   # Also, some files are written to include/generated/syscalls/
   COMMAND
   ${PYTHON_EXECUTABLE}
-  ${PROJECT_SOURCE_DIR}/scripts/gen_syscalls.py
+  ${ZEPHYR_BASE}/scripts/gen_syscalls.py
   --json-file        ${syscalls_json}                     # Read this file
   --base-output      include/generated/syscalls           # Write to this dir
   --syscall-dispatch include/generated/syscall_dispatch.c # Write this file

--- a/arch/arc/soc/quark_se_c1000_ss/CMakeLists.txt
+++ b/arch/arc/soc/quark_se_c1000_ss/CMakeLists.txt
@@ -1,5 +1,5 @@
-zephyr_library_include_directories(${PROJECT_SOURCE_DIR}/drivers)
-zephyr_include_directories(${PROJECT_SOURCE_DIR}/arch/x86/soc/intel_quark)
+zephyr_library_include_directories(${ZEPHYR_BASE}/drivers)
+zephyr_include_directories(${ZEPHYR_BASE}/arch/x86/soc/intel_quark)
 
 zephyr_cc_option(-mcpu=quarkse_em -mno-sdata)
 

--- a/arch/arc/soc/snps_emsk/CMakeLists.txt
+++ b/arch/arc/soc/snps_emsk/CMakeLists.txt
@@ -1,4 +1,4 @@
-zephyr_library_include_directories(${PROJECT_SOURCE_DIR}/drivers)
+zephyr_library_include_directories(${ZEPHYR_BASE}/drivers)
 
 zephyr_cc_option(-mcpu=${GCC_M_CPU})
 zephyr_cc_option(-mno-sdata -mdiv-rem -mswap -mnorm)

--- a/arch/posix/CMakeLists.txt
+++ b/arch/posix/CMakeLists.txt
@@ -9,7 +9,7 @@ zephyr_compile_options(
   -MMD
   -MP
   ${ARCH_FLAG}
-  -include ${PROJECT_SOURCE_DIR}/arch/posix/include/posix_cheats.h
+  -include ${ZEPHYR_BASE}/arch/posix/include/posix_cheats.h
   )
 
 zephyr_compile_options_ifdef(CONFIG_COVERAGE

--- a/arch/x86/CMakeLists.txt
+++ b/arch/x86/CMakeLists.txt
@@ -31,7 +31,7 @@ else()
   set(GENIDT_EXTRA_ARGS "")
 endif()
 
-set(GENIDT ${PROJECT_SOURCE_DIR}/scripts/gen_idt.py)
+set(GENIDT ${ZEPHYR_BASE}/scripts/gen_idt.py)
 
 define_property(GLOBAL PROPERTY PROPERTY_OUTPUT_ARCH BRIEF_DOCS " " FULL_DOCS " ")
 set_property(GLOBAL PROPERTY PROPERTY_OUTPUT_ARCH "i386")
@@ -134,7 +134,7 @@ if(CONFIG_X86_MMU)
     OUTPUT mmu_tables.bin
     COMMAND
     ${PYTHON_EXECUTABLE}
-    ${PROJECT_SOURCE_DIR}/scripts/gen_mmu_x86.py
+    ${ZEPHYR_BASE}/scripts/gen_mmu_x86.py
     -i mmulist.bin
     -k $<TARGET_FILE:zephyr_prebuilt>
     -o mmu_tables.bin
@@ -174,7 +174,7 @@ if(CONFIG_GDT_DYNAMIC)
     OUTPUT gdt.bin
     COMMAND
     ${PYTHON_EXECUTABLE}
-    ${PROJECT_SOURCE_DIR}/scripts/gen_gdt.py
+    ${ZEPHYR_BASE}/scripts/gen_gdt.py
     --kernel $<TARGET_FILE:zephyr_prebuilt>
     --output-gdt gdt.bin
     $<$<BOOL:${CMAKE_VERBOSE_MAKEFILE}>:--verbose>

--- a/arch/x86/soc/atom/CMakeLists.txt
+++ b/arch/x86/soc/atom/CMakeLists.txt
@@ -1,5 +1,5 @@
 zephyr_library()
-zephyr_library_include_directories(${PROJECT_SOURCE_DIR}/drivers)
+zephyr_library_include_directories(${ZEPHYR_BASE}/drivers)
 
 zephyr_cc_option(-march=atom)
 zephyr_cc_option_fallback(-mtune=atom -mtune=generic)

--- a/arch/x86/soc/ia32/CMakeLists.txt
+++ b/arch/x86/soc/ia32/CMakeLists.txt
@@ -1,5 +1,5 @@
 zephyr_library()
-zephyr_library_include_directories(${PROJECT_SOURCE_DIR}/drivers)
+zephyr_library_include_directories(${ZEPHYR_BASE}/drivers)
 
 zephyr_cc_option(-march=pentium)
 

--- a/arch/x86/soc/intel_quark/quark_d2000/CMakeLists.txt
+++ b/arch/x86/soc/intel_quark/quark_d2000/CMakeLists.txt
@@ -1,4 +1,4 @@
-zephyr_library_include_directories(${PROJECT_SOURCE_DIR}/drivers)
+zephyr_library_include_directories(${ZEPHYR_BASE}/drivers)
 
 zephyr_compile_definitions_ifdef(
   CONFIG_SOC_QUARK_D2000

--- a/arch/x86/soc/intel_quark/quark_se/CMakeLists.txt
+++ b/arch/x86/soc/intel_quark/quark_se/CMakeLists.txt
@@ -1,4 +1,4 @@
-zephyr_library_include_directories(${PROJECT_SOURCE_DIR}/drivers)
+zephyr_library_include_directories(${ZEPHYR_BASE}/drivers)
 
 zephyr_compile_definitions_ifdef(
   CONFIG_SOC_QUARK_SE_C1000

--- a/arch/x86/soc/intel_quark/quark_x1000/CMakeLists.txt
+++ b/arch/x86/soc/intel_quark/quark_x1000/CMakeLists.txt
@@ -1,5 +1,5 @@
 
-zephyr_library_include_directories(${PROJECT_SOURCE_DIR}/drivers)
+zephyr_library_include_directories(${ZEPHYR_BASE}/drivers)
 
 zephyr_cc_option(-march=lakemont -mtune=lakemont -msoft-float)
 

--- a/arch/xtensa/soc/intel_s1000/CMakeLists.txt
+++ b/arch/xtensa/soc/intel_s1000/CMakeLists.txt
@@ -1,3 +1,3 @@
 zephyr_library()
-zephyr_library_include_directories(${PROJECT_SOURCE_DIR}/drivers)
+zephyr_library_include_directories(${ZEPHYR_BASE}/drivers)
 zephyr_library_sources(soc.c)

--- a/boards/arm/96b_argonkey/CMakeLists.txt
+++ b/boards/arm/96b_argonkey/CMakeLists.txt
@@ -1,3 +1,3 @@
 zephyr_library()
 zephyr_library_sources(pinmux.c)
-zephyr_library_include_directories(${PROJECT_SOURCE_DIR}/drivers)
+zephyr_library_include_directories(${ZEPHYR_BASE}/drivers)

--- a/boards/arm/96b_carbon/CMakeLists.txt
+++ b/boards/arm/96b_carbon/CMakeLists.txt
@@ -1,3 +1,3 @@
 zephyr_library()
 zephyr_library_sources(pinmux.c)
-zephyr_library_include_directories(${PROJECT_SOURCE_DIR}/drivers)
+zephyr_library_include_directories(${ZEPHYR_BASE}/drivers)

--- a/boards/arm/96b_neonkey/CMakeLists.txt
+++ b/boards/arm/96b_neonkey/CMakeLists.txt
@@ -1,3 +1,3 @@
 zephyr_library()
 zephyr_library_sources(pinmux.c)
-zephyr_library_include_directories(${PROJECT_SOURCE_DIR}/drivers)
+zephyr_library_include_directories(${ZEPHYR_BASE}/drivers)

--- a/boards/arm/arduino_due/CMakeLists.txt
+++ b/boards/arm/arduino_due/CMakeLists.txt
@@ -1,3 +1,3 @@
 zephyr_library()
-zephyr_library_include_directories(${PROJECT_SOURCE_DIR}/drivers)
+zephyr_library_include_directories(${ZEPHYR_BASE}/drivers)
 zephyr_library_sources_if_kconfig(pinmux.c)

--- a/boards/arm/cc2650_sensortag/CMakeLists.txt
+++ b/boards/arm/cc2650_sensortag/CMakeLists.txt
@@ -1,3 +1,3 @@
 zephyr_library()
 zephyr_library_sources(pinmux.c)
-zephyr_library_include_directories(${PROJECT_SOURCE_DIR}/drivers)
+zephyr_library_include_directories(${ZEPHYR_BASE}/drivers)

--- a/boards/arm/cc3220sf_launchxl/CMakeLists.txt
+++ b/boards/arm/cc3220sf_launchxl/CMakeLists.txt
@@ -3,4 +3,4 @@ zephyr_library_sources(
     pinmux.c
     dbghdr.c
     )
-zephyr_library_include_directories(${PROJECT_SOURCE_DIR}/drivers)
+zephyr_library_include_directories(${ZEPHYR_BASE}/drivers)

--- a/boards/arm/colibri_imx7d_m4/CMakeLists.txt
+++ b/boards/arm/colibri_imx7d_m4/CMakeLists.txt
@@ -5,5 +5,5 @@
 #
 
 zephyr_library()
-zephyr_library_include_directories(${PROJECT_SOURCE_DIR}/drivers)
+zephyr_library_include_directories(${ZEPHYR_BASE}/drivers)
 zephyr_library_sources(pinmux.c)

--- a/boards/arm/disco_l475_iot1/CMakeLists.txt
+++ b/boards/arm/disco_l475_iot1/CMakeLists.txt
@@ -1,3 +1,3 @@
 zephyr_library()
 zephyr_library_sources(pinmux.c)
-zephyr_library_include_directories(${PROJECT_SOURCE_DIR}/drivers)
+zephyr_library_include_directories(${ZEPHYR_BASE}/drivers)

--- a/boards/arm/dragino_lsn50/CMakeLists.txt
+++ b/boards/arm/dragino_lsn50/CMakeLists.txt
@@ -1,3 +1,3 @@
 zephyr_library()
 zephyr_library_sources(pinmux.c)
-zephyr_library_include_directories(${PROJECT_SOURCE_DIR}/drivers)
+zephyr_library_include_directories(${ZEPHYR_BASE}/drivers)

--- a/boards/arm/efm32wg_stk3800/CMakeLists.txt
+++ b/boards/arm/efm32wg_stk3800/CMakeLists.txt
@@ -1,5 +1,5 @@
 if(CONFIG_UART_GECKO)
   zephyr_library()
   zephyr_library_sources(board.c)
-  zephyr_library_include_directories(${PROJECT_SOURCE_DIR}/drivers)
+  zephyr_library_include_directories(${ZEPHYR_BASE}/drivers)
 endif()

--- a/boards/arm/frdm_k64f/CMakeLists.txt
+++ b/boards/arm/frdm_k64f/CMakeLists.txt
@@ -1,5 +1,5 @@
 if(CONFIG_PINMUX_MCUX)
   zephyr_library()
-  zephyr_library_include_directories(${PROJECT_SOURCE_DIR}/drivers)
+  zephyr_library_include_directories(${ZEPHYR_BASE}/drivers)
   zephyr_library_sources(pinmux.c)
 endif()

--- a/boards/arm/frdm_kl25z/CMakeLists.txt
+++ b/boards/arm/frdm_kl25z/CMakeLists.txt
@@ -1,5 +1,5 @@
 if(CONFIG_PINMUX_MCUX)
   zephyr_library()
-  zephyr_library_include_directories(${PROJECT_SOURCE_DIR}/drivers)
+  zephyr_library_include_directories(${ZEPHYR_BASE}/drivers)
   zephyr_library_sources(pinmux.c)
 endif()

--- a/boards/arm/frdm_kw41z/CMakeLists.txt
+++ b/boards/arm/frdm_kw41z/CMakeLists.txt
@@ -1,3 +1,3 @@
 zephyr_library()
 zephyr_library_sources(pinmux.c)
-zephyr_library_include_directories(${PROJECT_SOURCE_DIR}/drivers)
+zephyr_library_include_directories(${ZEPHYR_BASE}/drivers)

--- a/boards/arm/hexiwear_k64/CMakeLists.txt
+++ b/boards/arm/hexiwear_k64/CMakeLists.txt
@@ -1,3 +1,3 @@
 zephyr_library()
 zephyr_library_sources(pinmux.c)
-zephyr_library_include_directories(${PROJECT_SOURCE_DIR}/drivers)
+zephyr_library_include_directories(${ZEPHYR_BASE}/drivers)

--- a/boards/arm/hexiwear_kw40z/CMakeLists.txt
+++ b/boards/arm/hexiwear_kw40z/CMakeLists.txt
@@ -1,3 +1,3 @@
 zephyr_library()
 zephyr_library_sources(pinmux.c)
-zephyr_library_include_directories(${PROJECT_SOURCE_DIR}/drivers)
+zephyr_library_include_directories(${ZEPHYR_BASE}/drivers)

--- a/boards/arm/lpcxpresso54114_m0/CMakeLists.txt
+++ b/boards/arm/lpcxpresso54114_m0/CMakeLists.txt
@@ -6,6 +6,6 @@
 
 if(CONFIG_PINMUX_MCUX_LPC)
   zephyr_library()
-  zephyr_library_include_directories(${PROJECT_SOURCE_DIR}/drivers)
+  zephyr_library_include_directories(${ZEPHYR_BASE}/drivers)
   zephyr_library_sources(pinmux.c)
 endif()

--- a/boards/arm/lpcxpresso54114_m4/CMakeLists.txt
+++ b/boards/arm/lpcxpresso54114_m4/CMakeLists.txt
@@ -6,6 +6,6 @@
 
 if(CONFIG_PINMUX_MCUX_LPC)
   zephyr_library()
-  zephyr_library_include_directories(${PROJECT_SOURCE_DIR}/drivers)
+  zephyr_library_include_directories(${ZEPHYR_BASE}/drivers)
   zephyr_library_sources(pinmux.c)
 endif()

--- a/boards/arm/mimxrt1050_evk/CMakeLists.txt
+++ b/boards/arm/mimxrt1050_evk/CMakeLists.txt
@@ -5,5 +5,5 @@
 #
 
 zephyr_library()
-zephyr_library_include_directories(${PROJECT_SOURCE_DIR}/drivers)
+zephyr_library_include_directories(${ZEPHYR_BASE}/drivers)
 zephyr_library_sources(pinmux.c)

--- a/boards/arm/mps2_an385/CMakeLists.txt
+++ b/boards/arm/mps2_an385/CMakeLists.txt
@@ -1,3 +1,3 @@
 zephyr_library()
 zephyr_library_sources(pinmux.c)
-zephyr_library_include_directories(${PROJECT_SOURCE_DIR}/drivers)
+zephyr_library_include_directories(${ZEPHYR_BASE}/drivers)

--- a/boards/arm/nrf52_pca20020/CMakeLists.txt
+++ b/boards/arm/nrf52_pca20020/CMakeLists.txt
@@ -1,3 +1,3 @@
 zephyr_library()
 zephyr_library_sources(board.c)
-zephyr_library_include_directories(${PROJECT_SOURCE_DIR}/drivers)
+zephyr_library_include_directories(${ZEPHYR_BASE}/drivers)

--- a/boards/arm/nucleo_f030r8/CMakeLists.txt
+++ b/boards/arm/nucleo_f030r8/CMakeLists.txt
@@ -1,3 +1,3 @@
 zephyr_library()
 zephyr_library_sources(pinmux.c)
-zephyr_library_include_directories(${PROJECT_SOURCE_DIR}/drivers)
+zephyr_library_include_directories(${ZEPHYR_BASE}/drivers)

--- a/boards/arm/nucleo_f070rb/CMakeLists.txt
+++ b/boards/arm/nucleo_f070rb/CMakeLists.txt
@@ -1,3 +1,3 @@
 zephyr_library()
 zephyr_library_sources(pinmux.c)
-zephyr_library_include_directories(${PROJECT_SOURCE_DIR}/drivers)
+zephyr_library_include_directories(${ZEPHYR_BASE}/drivers)

--- a/boards/arm/nucleo_f091rc/CMakeLists.txt
+++ b/boards/arm/nucleo_f091rc/CMakeLists.txt
@@ -1,3 +1,3 @@
 zephyr_library()
 zephyr_library_sources(pinmux.c)
-zephyr_library_include_directories(${PROJECT_SOURCE_DIR}/drivers)
+zephyr_library_include_directories(${ZEPHYR_BASE}/drivers)

--- a/boards/arm/nucleo_f103rb/CMakeLists.txt
+++ b/boards/arm/nucleo_f103rb/CMakeLists.txt
@@ -1,3 +1,3 @@
 zephyr_library()
 zephyr_library_sources(pinmux.c)
-zephyr_library_include_directories(${PROJECT_SOURCE_DIR}/drivers)
+zephyr_library_include_directories(${ZEPHYR_BASE}/drivers)

--- a/boards/arm/nucleo_f334r8/CMakeLists.txt
+++ b/boards/arm/nucleo_f334r8/CMakeLists.txt
@@ -1,3 +1,3 @@
 zephyr_library()
 zephyr_library_sources(pinmux.c)
-zephyr_library_include_directories(${PROJECT_SOURCE_DIR}/drivers)
+zephyr_library_include_directories(${ZEPHYR_BASE}/drivers)

--- a/boards/arm/nucleo_f401re/CMakeLists.txt
+++ b/boards/arm/nucleo_f401re/CMakeLists.txt
@@ -1,3 +1,3 @@
 zephyr_library()
 zephyr_library_sources(pinmux.c)
-zephyr_library_include_directories(${PROJECT_SOURCE_DIR}/drivers)
+zephyr_library_include_directories(${ZEPHYR_BASE}/drivers)

--- a/boards/arm/nucleo_f411re/CMakeLists.txt
+++ b/boards/arm/nucleo_f411re/CMakeLists.txt
@@ -1,3 +1,3 @@
 zephyr_library()
 zephyr_library_sources(pinmux.c)
-zephyr_library_include_directories(${PROJECT_SOURCE_DIR}/drivers)
+zephyr_library_include_directories(${ZEPHYR_BASE}/drivers)

--- a/boards/arm/nucleo_f412zg/CMakeLists.txt
+++ b/boards/arm/nucleo_f412zg/CMakeLists.txt
@@ -1,3 +1,3 @@
 zephyr_library()
 zephyr_library_sources(pinmux.c)
-zephyr_library_include_directories(${PROJECT_SOURCE_DIR}/drivers)
+zephyr_library_include_directories(${ZEPHYR_BASE}/drivers)

--- a/boards/arm/nucleo_f413zh/CMakeLists.txt
+++ b/boards/arm/nucleo_f413zh/CMakeLists.txt
@@ -1,3 +1,3 @@
 zephyr_library()
 zephyr_library_sources(pinmux.c)
-zephyr_library_include_directories(${PROJECT_SOURCE_DIR}/drivers)
+zephyr_library_include_directories(${ZEPHYR_BASE}/drivers)

--- a/boards/arm/nucleo_f429zi/CMakeLists.txt
+++ b/boards/arm/nucleo_f429zi/CMakeLists.txt
@@ -1,3 +1,3 @@
 zephyr_library()
 zephyr_library_sources(pinmux.c)
-zephyr_library_include_directories(${PROJECT_SOURCE_DIR}/drivers)
+zephyr_library_include_directories(${ZEPHYR_BASE}/drivers)

--- a/boards/arm/nucleo_f446re/CMakeLists.txt
+++ b/boards/arm/nucleo_f446re/CMakeLists.txt
@@ -1,3 +1,3 @@
 zephyr_library()
 zephyr_library_sources(pinmux.c)
-zephyr_library_include_directories(${PROJECT_SOURCE_DIR}/drivers)
+zephyr_library_include_directories(${ZEPHYR_BASE}/drivers)

--- a/boards/arm/nucleo_l053r8/CMakeLists.txt
+++ b/boards/arm/nucleo_l053r8/CMakeLists.txt
@@ -1,3 +1,3 @@
 zephyr_library()
 zephyr_library_sources(pinmux.c)
-zephyr_library_include_directories(${PROJECT_SOURCE_DIR}/drivers)
+zephyr_library_include_directories(${ZEPHYR_BASE}/drivers)

--- a/boards/arm/nucleo_l073rz/CMakeLists.txt
+++ b/boards/arm/nucleo_l073rz/CMakeLists.txt
@@ -1,3 +1,3 @@
 zephyr_library()
 zephyr_library_sources(pinmux.c)
-zephyr_library_include_directories(${PROJECT_SOURCE_DIR}/drivers)
+zephyr_library_include_directories(${ZEPHYR_BASE}/drivers)

--- a/boards/arm/nucleo_l432kc/CMakeLists.txt
+++ b/boards/arm/nucleo_l432kc/CMakeLists.txt
@@ -1,3 +1,3 @@
 zephyr_library()
 zephyr_library_sources(pinmux.c)
-zephyr_library_include_directories(${PROJECT_SOURCE_DIR}/drivers)
+zephyr_library_include_directories(${ZEPHYR_BASE}/drivers)

--- a/boards/arm/nucleo_l476rg/CMakeLists.txt
+++ b/boards/arm/nucleo_l476rg/CMakeLists.txt
@@ -1,3 +1,3 @@
 zephyr_library()
 zephyr_library_sources(pinmux.c)
-zephyr_library_include_directories(${PROJECT_SOURCE_DIR}/drivers)
+zephyr_library_include_directories(${ZEPHYR_BASE}/drivers)

--- a/boards/arm/olimex_stm32_e407/CMakeLists.txt
+++ b/boards/arm/olimex_stm32_e407/CMakeLists.txt
@@ -1,3 +1,3 @@
 zephyr_library()
 zephyr_library_sources(pinmux.c)
-zephyr_library_include_directories(${PROJECT_SOURCE_DIR}/drivers)
+zephyr_library_include_directories(${ZEPHYR_BASE}/drivers)

--- a/boards/arm/olimex_stm32_h407/CMakeLists.txt
+++ b/boards/arm/olimex_stm32_h407/CMakeLists.txt
@@ -1,3 +1,3 @@
 zephyr_library()
 zephyr_library_sources(pinmux.c)
-zephyr_library_include_directories(${PROJECT_SOURCE_DIR}/drivers)
+zephyr_library_include_directories(${ZEPHYR_BASE}/drivers)

--- a/boards/arm/olimex_stm32_p405/CMakeLists.txt
+++ b/boards/arm/olimex_stm32_p405/CMakeLists.txt
@@ -1,3 +1,3 @@
 zephyr_library()
 zephyr_library_sources(pinmux.c)
-zephyr_library_include_directories(${PROJECT_SOURCE_DIR}/drivers)
+zephyr_library_include_directories(${ZEPHYR_BASE}/drivers)

--- a/boards/arm/olimexino_stm32/CMakeLists.txt
+++ b/boards/arm/olimexino_stm32/CMakeLists.txt
@@ -1,3 +1,3 @@
 zephyr_library()
 zephyr_library_sources(pinmux.c)
-zephyr_library_include_directories(${PROJECT_SOURCE_DIR}/drivers)
+zephyr_library_include_directories(${ZEPHYR_BASE}/drivers)

--- a/boards/arm/stm3210c_eval/CMakeLists.txt
+++ b/boards/arm/stm3210c_eval/CMakeLists.txt
@@ -1,3 +1,3 @@
 zephyr_library()
 zephyr_library_sources(pinmux.c)
-zephyr_library_include_directories(${PROJECT_SOURCE_DIR}/drivers)
+zephyr_library_include_directories(${ZEPHYR_BASE}/drivers)

--- a/boards/arm/stm32373c_eval/CMakeLists.txt
+++ b/boards/arm/stm32373c_eval/CMakeLists.txt
@@ -1,3 +1,3 @@
 zephyr_library()
 zephyr_library_sources(pinmux.c)
-zephyr_library_include_directories(${PROJECT_SOURCE_DIR}/drivers)
+zephyr_library_include_directories(${ZEPHYR_BASE}/drivers)

--- a/boards/arm/stm32_min_dev/CMakeLists.txt
+++ b/boards/arm/stm32_min_dev/CMakeLists.txt
@@ -1,3 +1,3 @@
 zephyr_library()
 zephyr_library_sources(pinmux.c)
-zephyr_library_include_directories(${PROJECT_SOURCE_DIR}/drivers)
+zephyr_library_include_directories(${ZEPHYR_BASE}/drivers)

--- a/boards/arm/stm32_mini_a15/CMakeLists.txt
+++ b/boards/arm/stm32_mini_a15/CMakeLists.txt
@@ -1,3 +1,3 @@
 zephyr_library()
 zephyr_library_sources(pinmux.c)
-zephyr_library_include_directories(${PROJECT_SOURCE_DIR}/drivers)
+zephyr_library_include_directories(${ZEPHYR_BASE}/drivers)

--- a/boards/arm/stm32f072_eval/CMakeLists.txt
+++ b/boards/arm/stm32f072_eval/CMakeLists.txt
@@ -1,3 +1,3 @@
 zephyr_library()
 zephyr_library_sources(pinmux.c)
-zephyr_library_include_directories(${PROJECT_SOURCE_DIR}/drivers)
+zephyr_library_include_directories(${ZEPHYR_BASE}/drivers)

--- a/boards/arm/stm32f072b_disco/CMakeLists.txt
+++ b/boards/arm/stm32f072b_disco/CMakeLists.txt
@@ -1,3 +1,3 @@
 zephyr_library()
 zephyr_library_sources(pinmux.c)
-zephyr_library_include_directories(${PROJECT_SOURCE_DIR}/drivers)
+zephyr_library_include_directories(${ZEPHYR_BASE}/drivers)

--- a/boards/arm/stm32f0_disco/CMakeLists.txt
+++ b/boards/arm/stm32f0_disco/CMakeLists.txt
@@ -1,3 +1,3 @@
 zephyr_library()
 zephyr_library_sources(pinmux.c)
-zephyr_library_include_directories(${PROJECT_SOURCE_DIR}/drivers)
+zephyr_library_include_directories(${ZEPHYR_BASE}/drivers)

--- a/boards/arm/stm32f3_disco/CMakeLists.txt
+++ b/boards/arm/stm32f3_disco/CMakeLists.txt
@@ -1,3 +1,3 @@
 zephyr_library()
 zephyr_library_sources(pinmux.c)
-zephyr_library_include_directories(${PROJECT_SOURCE_DIR}/drivers)
+zephyr_library_include_directories(${ZEPHYR_BASE}/drivers)

--- a/boards/arm/stm32f411e_disco/CMakeLists.txt
+++ b/boards/arm/stm32f411e_disco/CMakeLists.txt
@@ -1,3 +1,3 @@
 zephyr_library()
 zephyr_library_sources(pinmux.c)
-zephyr_library_include_directories(${PROJECT_SOURCE_DIR}/drivers)
+zephyr_library_include_directories(${ZEPHYR_BASE}/drivers)

--- a/boards/arm/stm32f412g_disco/CMakeLists.txt
+++ b/boards/arm/stm32f412g_disco/CMakeLists.txt
@@ -1,3 +1,3 @@
 zephyr_library()
 zephyr_library_sources(pinmux.c)
-zephyr_library_include_directories(${PROJECT_SOURCE_DIR}/drivers)
+zephyr_library_include_directories(${ZEPHYR_BASE}/drivers)

--- a/boards/arm/stm32f429i_disc1/CMakeLists.txt
+++ b/boards/arm/stm32f429i_disc1/CMakeLists.txt
@@ -1,3 +1,3 @@
 zephyr_library()
 zephyr_library_sources(pinmux.c)
-zephyr_library_include_directories(${PROJECT_SOURCE_DIR}/drivers)
+zephyr_library_include_directories(${ZEPHYR_BASE}/drivers)

--- a/boards/arm/stm32f469i_disco/CMakeLists.txt
+++ b/boards/arm/stm32f469i_disco/CMakeLists.txt
@@ -1,3 +1,3 @@
 zephyr_library()
 zephyr_library_sources(pinmux.c)
-zephyr_library_include_directories(${PROJECT_SOURCE_DIR}/drivers)
+zephyr_library_include_directories(${ZEPHYR_BASE}/drivers)

--- a/boards/arm/stm32f4_disco/CMakeLists.txt
+++ b/boards/arm/stm32f4_disco/CMakeLists.txt
@@ -1,3 +1,3 @@
 zephyr_library()
 zephyr_library_sources(pinmux.c)
-zephyr_library_include_directories(${PROJECT_SOURCE_DIR}/drivers)
+zephyr_library_include_directories(${ZEPHYR_BASE}/drivers)

--- a/boards/arm/stm32l476g_disco/CMakeLists.txt
+++ b/boards/arm/stm32l476g_disco/CMakeLists.txt
@@ -1,3 +1,3 @@
 zephyr_library()
 zephyr_library_sources(pinmux.c)
-zephyr_library_include_directories(${PROJECT_SOURCE_DIR}/drivers)
+zephyr_library_include_directories(${ZEPHYR_BASE}/drivers)

--- a/boards/arm/stm32l496g_disco/CMakeLists.txt
+++ b/boards/arm/stm32l496g_disco/CMakeLists.txt
@@ -1,3 +1,3 @@
 zephyr_library()
 zephyr_library_sources(pinmux.c)
-zephyr_library_include_directories(${PROJECT_SOURCE_DIR}/drivers)
+zephyr_library_include_directories(${ZEPHYR_BASE}/drivers)

--- a/boards/arm/usb_kw24d512/CMakeLists.txt
+++ b/boards/arm/usb_kw24d512/CMakeLists.txt
@@ -1,5 +1,5 @@
 if(CONFIG_PINMUX_MCUX)
   zephyr_library()
   zephyr_library_sources(pinmux.c)
-  zephyr_library_include_directories(${PROJECT_SOURCE_DIR}/drivers)
+  zephyr_library_include_directories(${ZEPHYR_BASE}/drivers)
 endif()

--- a/boards/arm/v2m_beetle/CMakeLists.txt
+++ b/boards/arm/v2m_beetle/CMakeLists.txt
@@ -1,5 +1,5 @@
 if(CONFIG_PINMUX_BEETLE)
   zephyr_library()
-  zephyr_library_include_directories(${PROJECT_SOURCE_DIR}/drivers)
+  zephyr_library_include_directories(${ZEPHYR_BASE}/drivers)
   zephyr_library_sources(pinmux.c)
 endif()

--- a/boards/riscv32/hifive1/CMakeLists.txt
+++ b/boards/riscv32/hifive1/CMakeLists.txt
@@ -1,4 +1,4 @@
 zephyr_library()
 zephyr_library_sources(pinmux.c)
 zephyr_library_sources(clock.c)
-zephyr_library_include_directories(${PROJECT_SOURCE_DIR}/drivers)
+zephyr_library_include_directories(${ZEPHYR_BASE}/drivers)

--- a/boards/x86/arduino_101/CMakeLists.txt
+++ b/boards/x86/arduino_101/CMakeLists.txt
@@ -1,3 +1,3 @@
 zephyr_library()
 zephyr_library_sources(pinmux.c)
-zephyr_library_include_directories(${PROJECT_SOURCE_DIR}/drivers)
+zephyr_library_include_directories(${ZEPHYR_BASE}/drivers)

--- a/boards/x86/galileo/CMakeLists.txt
+++ b/boards/x86/galileo/CMakeLists.txt
@@ -1,5 +1,5 @@
 if(CONFIG_PINMUX)
   zephyr_library()
   zephyr_library_sources(pinmux.c)
-  zephyr_library_include_directories(${PROJECT_SOURCE_DIR}/drivers)
+  zephyr_library_include_directories(${ZEPHYR_BASE}/drivers)
 endif()

--- a/boards/x86/quark_d2000_crb/CMakeLists.txt
+++ b/boards/x86/quark_d2000_crb/CMakeLists.txt
@@ -1,3 +1,3 @@
 zephyr_library()
 zephyr_library_sources(pinmux.c)
-zephyr_library_include_directories(${PROJECT_SOURCE_DIR}/drivers)
+zephyr_library_include_directories(${ZEPHYR_BASE}/drivers)

--- a/boards/x86/quark_se_c1000_devboard/CMakeLists.txt
+++ b/boards/x86/quark_se_c1000_devboard/CMakeLists.txt
@@ -3,4 +3,4 @@ zephyr_library_sources(
   pinmux.c
   board.c
   )
-zephyr_library_include_directories(${PROJECT_SOURCE_DIR}/drivers)
+zephyr_library_include_directories(${ZEPHYR_BASE}/drivers)

--- a/boards/x86/tinytile/CMakeLists.txt
+++ b/boards/x86/tinytile/CMakeLists.txt
@@ -1,3 +1,3 @@
 zephyr_library()
 zephyr_library_sources(pinmux.c)
-zephyr_library_include_directories(${PROJECT_SOURCE_DIR}/drivers)
+zephyr_library_include_directories(${ZEPHYR_BASE}/drivers)

--- a/cmake/app/boilerplate.cmake
+++ b/cmake/app/boilerplate.cmake
@@ -72,6 +72,14 @@ set(APPLICATION_BINARY_DIR ${CMAKE_CURRENT_BINARY_DIR} CACHE PATH "Application B
 set(__build_dir ${CMAKE_CURRENT_BINARY_DIR}/zephyr)
 
 set(PROJECT_BINARY_DIR ${__build_dir})
+
+# CMake's 'project' concept has proven to not be very useful for Zephyr
+# due in part to how Zephyr is organized and in part to it not fitting well
+# with cross compilation.
+# CMake therefore tries to rely as little as possible on project()
+# and its associated variables, e.g. PROJECT_SOURCE_DIR.
+# It is recommended to always use ZEPHYR_BASE instead of PROJECT_SOURCE_DIR
+# when trying to reference ENV${ZEPHYR_BASE}.
 set(PROJECT_SOURCE_DIR $ENV{ZEPHYR_BASE})
 
 # Convert path to use the '/' separator

--- a/cmake/dts.cmake
+++ b/cmake/dts.cmake
@@ -11,7 +11,7 @@
 set(GENERATED_DTS_BOARD_H    ${PROJECT_BINARY_DIR}/include/generated/generated_dts_board.h)
 set(GENERATED_DTS_BOARD_CONF ${PROJECT_BINARY_DIR}/include/generated/generated_dts_board.conf)
 set_ifndef(DTS_SOURCE ${BOARD_ROOT}/boards/${ARCH}/${BOARD_FAMILY}/${BOARD}.dts)
-set_ifndef(DTS_COMMON_OVERLAYS ${PROJECT_SOURCE_DIR}/dts/common/common.dts)
+set_ifndef(DTS_COMMON_OVERLAYS ${ZEPHYR_BASE}/dts/common/common.dts)
 
 message(STATUS "Generating zephyr/include/generated/generated_dts_board.h")
 
@@ -50,14 +50,14 @@ if(CONFIG_HAS_DTS)
     COMMAND ${CMAKE_C_COMPILER}
     -x assembler-with-cpp
     -nostdinc
-    -I${PROJECT_SOURCE_DIR}/arch/${ARCH}/soc
-    -isystem ${PROJECT_SOURCE_DIR}/include
-    -isystem ${PROJECT_SOURCE_DIR}/dts/${ARCH}
-    -isystem ${PROJECT_SOURCE_DIR}/dts
+    -I${ZEPHYR_BASE}/arch/${ARCH}/soc
+    -isystem ${ZEPHYR_BASE}/include
+    -isystem ${ZEPHYR_BASE}/dts/${ARCH}
+    -isystem ${ZEPHYR_BASE}/dts
     -include ${AUTOCONF_H}
     ${DTC_INCLUDE_FLAG_FOR_DTS}  # include the DTS source and overlays
-    -I${PROJECT_SOURCE_DIR}/dts/common
-    -I${PROJECT_SOURCE_DIR}/drivers
+    -I${ZEPHYR_BASE}/dts/common
+    -I${ZEPHYR_BASE}/drivers
     -undef -D__DTS__
     -P
     -E ${ZEPHYR_BASE}/misc/empty_file.c
@@ -89,7 +89,7 @@ if(CONFIG_HAS_DTS)
   if(EXISTS ${DTS_BOARD_FIXUP_FILE})
     set(DTS_BOARD_FIXUP ${DTS_BOARD_FIXUP_FILE})
   endif()
-  set_ifndef(DTS_SOC_FIXUP_FILE ${PROJECT_SOURCE_DIR}/arch/${ARCH}/soc/${SOC_PATH}/dts.fixup)
+  set_ifndef(DTS_SOC_FIXUP_FILE ${ZEPHYR_BASE}/arch/${ARCH}/soc/${SOC_PATH}/dts.fixup)
   if(EXISTS ${DTS_SOC_FIXUP_FILE})
     set(DTS_SOC_FIXUP ${DTS_SOC_FIXUP_FILE})
   endif()
@@ -102,9 +102,9 @@ if(CONFIG_HAS_DTS)
     set(DTS_FIXUPS --fixup ${DTS_FIXUPS})
   endif()
 
-  set(CMD_EXTRACT_DTS_INCLUDES ${PYTHON_EXECUTABLE} ${PROJECT_SOURCE_DIR}/scripts/dts/extract_dts_includes.py
+  set(CMD_EXTRACT_DTS_INCLUDES ${PYTHON_EXECUTABLE} ${ZEPHYR_BASE}/scripts/dts/extract_dts_includes.py
     --dts ${BOARD}.dts_compiled
-    --yaml ${PROJECT_SOURCE_DIR}/dts/bindings
+    --yaml ${ZEPHYR_BASE}/dts/bindings
     ${DTS_FIXUPS}
     --keyvalue ${GENERATED_DTS_BOARD_CONF}
     --include ${GENERATED_DTS_BOARD_H}

--- a/lib/posix/CMakeLists.txt
+++ b/lib/posix/CMakeLists.txt
@@ -1,7 +1,7 @@
 
 add_library(PTHREAD INTERFACE)
 
-target_include_directories(PTHREAD INTERFACE ${PROJECT_SOURCE_DIR}/include/posix)
+target_include_directories(PTHREAD INTERFACE ${ZEPHYR_BASE}/include/posix)
 
 zephyr_library()
 zephyr_library_sources(pthread_common.c)


### PR DESCRIPTION
I've simply followed @SebastianBoe's suggestion from the original issue and put the comment describing why we use `ZEPHYR_BASE` instead of `PROJECT_SOURCE_DIR` + replaced all the relevant entries.

Tested by building `hello_world` for several boards ensuring no errors.

~There's one thing that potentially needs correcting - [some of the lines](https://github.com/zephyrproject-rtos/zephyr/blob/master/CMakeLists.txt#L365-L366) had end-of-line comments, aligned with comments on other lines - and current patch breaks the alignment. That's the price of such alignment - git history pollution.~

~What would be the preferred way to deal with this (no relevant information in coding style doc):~
~1. just leave as is~
~1. correct in a separate patch~
~1. correct in the same patch with variable replacement~
~1. anything else?~ Already corrected, see discussion below.

This fixes #7173.



