### PR TITLE
libminimal: remove unused cmakelists.txt

### DIFF
--- a/lib/libc/minimal/source/CMakeLists.txt
+++ b/lib/libc/minimal/source/CMakeLists.txt
@@ -1,3 +1,0 @@
-add_subdirectory(stdout)
-add_subdirectory(string)
-add_subdirectory(stdlib)


### PR DESCRIPTION
All source code files are already included in the top
CMakeLists.txt. The other two CMakeLists.txt in
subdirectories are not actually used. So, remove the
unused ones.

Signed-off-by: Jun Li <jun.r.li@intel.com>