### PR TITLE
samples, subsys, tests: Use ARRAY_SIZE() whenever possible

### DIFF
--- a/samples/drivers/lcd_hd44780/src/main.c
+++ b/samples/drivers/lcd_hd44780/src/main.c
@@ -317,7 +317,7 @@ void pi_lcd_set_cursor(struct device *gpio_dev, u8_t col, u8_t row)
 {
 	size_t max_lines;
 
-	max_lines = (sizeof(lcd_data.row_offsets) / sizeof(*lcd_data.row_offsets));
+	max_lines = ARRAY_SIZE(lcd_data.row_offsets);
 	if (row >= max_lines) {
 		row = max_lines - 1;	/* Count rows starting w/0 */
 	}

--- a/subsys/console/getline.c
+++ b/subsys/console/getline.c
@@ -34,7 +34,7 @@ void console_getline_init(void)
 {
 	int i;
 
-	for (i = 0; i < sizeof(line_bufs) / sizeof(*line_bufs); i++) {
+	for (i = 0; i < ARRAY_SIZE(line_bufs); i++) {
 		k_fifo_put(&free_queue, &line_bufs[i]);
 	}
 

--- a/subsys/net/lib/lwm2m/ipso_light_control.c
+++ b/subsys/net/lib/lwm2m/ipso_light_control.c
@@ -182,7 +182,7 @@ static int ipso_light_control_init(struct device *dev)
 
 	light_control.obj_id = IPSO_OBJECT_LIGHT_CONTROL_ID;
 	light_control.fields = fields;
-	light_control.field_count = sizeof(fields) / sizeof(*fields);
+	light_control.field_count = ARRAY_SIZE(fields);
 	light_control.max_instance_count = MAX_INSTANCE_COUNT;
 	light_control.create_cb = light_control_create;
 	lwm2m_register_obj(&light_control);

--- a/subsys/net/lib/lwm2m/ipso_temp_sensor.c
+++ b/subsys/net/lib/lwm2m/ipso_temp_sensor.c
@@ -209,7 +209,7 @@ static int ipso_temp_sensor_init(struct device *dev)
 
 	temp_sensor.obj_id = IPSO_OBJECT_TEMP_SENSOR_ID;
 	temp_sensor.fields = fields;
-	temp_sensor.field_count = sizeof(fields) / sizeof(*fields);
+	temp_sensor.field_count = ARRAY_SIZE(fields);
 	temp_sensor.max_instance_count = MAX_INSTANCE_COUNT;
 	temp_sensor.create_cb = temp_sensor_create;
 	lwm2m_register_obj(&temp_sensor);

--- a/subsys/net/lib/lwm2m/lwm2m_obj_device.c
+++ b/subsys/net/lib/lwm2m/lwm2m_obj_device.c
@@ -340,7 +340,7 @@ static int lwm2m_device_init(struct device *dev)
 	/* initialize the device field data */
 	device.obj_id = LWM2M_OBJECT_DEVICE_ID;
 	device.fields = fields;
-	device.field_count = sizeof(fields) / sizeof(*fields);
+	device.field_count = ARRAY_SIZE(fields);
 	device.max_instance_count = 1;
 	device.create_cb = device_create;
 	lwm2m_register_obj(&device);

--- a/subsys/net/lib/lwm2m/lwm2m_obj_firmware.c
+++ b/subsys/net/lib/lwm2m/lwm2m_obj_firmware.c
@@ -339,7 +339,7 @@ static int lwm2m_firmware_init(struct device *dev)
 
 	firmware.obj_id = LWM2M_OBJECT_FIRMWARE_ID;
 	firmware.fields = fields;
-	firmware.field_count = sizeof(fields) / sizeof(*fields);
+	firmware.field_count = ARRAY_SIZE(fields);
 	firmware.max_instance_count = 1;
 	firmware.create_cb = firmware_create;
 	lwm2m_register_obj(&firmware);

--- a/subsys/net/lib/lwm2m/lwm2m_obj_security.c
+++ b/subsys/net/lib/lwm2m/lwm2m_obj_security.c
@@ -123,7 +123,7 @@ static int lwm2m_security_init(struct device *dev)
 
 	security.obj_id = LWM2M_OBJECT_SECURITY_ID;
 	security.fields = fields;
-	security.field_count = sizeof(fields) / sizeof(*fields);
+	security.field_count = ARRAY_SIZE(fields);
 	security.max_instance_count = MAX_INSTANCE_COUNT;
 	security.create_cb = security_create;
 	lwm2m_register_obj(&security);

--- a/subsys/net/lib/lwm2m/lwm2m_obj_server.c
+++ b/subsys/net/lib/lwm2m/lwm2m_obj_server.c
@@ -167,7 +167,7 @@ static int lwm2m_server_init(struct device *dev)
 
 	server.obj_id = LWM2M_OBJECT_SERVER_ID;
 	server.fields = fields;
-	server.field_count = sizeof(fields) / sizeof(*fields);
+	server.field_count = ARRAY_SIZE(fields);
 	server.max_instance_count = MAX_INSTANCE_COUNT;
 	server.create_cb = server_create;
 	lwm2m_register_obj(&server);

--- a/tests/kernel/mem_pool/mem_pool_concept/src/test_mpool_merge_fail_diff_size.c
+++ b/tests/kernel/mem_pool/mem_pool_concept/src/test_mpool_merge_fail_diff_size.c
@@ -35,7 +35,7 @@ void test_mpool_alloc_merge_failed_diff_size(void)
 		BLK_SIZE_MIN, BLK_SIZE_MIN, BLK_SIZE_MIN, BLK_SIZE_MIN,
 		BLK_SIZE_MID, BLK_SIZE_MID, BLK_SIZE_MID
 	};
-	int block_count = sizeof(block_size) / sizeof(size_t);
+	int block_count = ARRAY_SIZE(block_size);
 
 
 	for (int i = 0; i < block_count; i++) {

--- a/tests/net/lib/http_header_fields/src/main.c
+++ b/tests/net/lib/http_header_fields/src/main.c
@@ -592,7 +592,7 @@ void test_parse_url(void)
 	unsigned int i;
 	int rv;
 
-	elements = sizeof(url_tests) / sizeof(url_tests[0]);
+	elements = ARRAY_SIZE(url_tests);
 	for (i = 0; i < elements; i++) {
 		test = &url_tests[i];
 		memset(&u, 0, sizeof(u));


### PR DESCRIPTION
The ARRAY_SIZE() utility macro will actually test the parameter types,
and ensure that it is only called with arrays, and not arrays decayed
to pointers.

Changes were performed with a simple Coccinelle script.

Signed-off-by: Leandro Pereira <leandro.pereira@intel.com>