### PR TITLE
doc: update doc build tools documentation

### DIFF
--- a/doc/README.rst
+++ b/doc/README.rst
@@ -48,10 +48,10 @@ Installing the documentation processors
 Our documentation processing has been tested to run with:
 
 * Doxygen version 1.8.13
-* Sphinx version 1.6.7
-* Breathe version 4.7.3
+* Sphinx version 1.7.5
+* Breathe version 4.9.1
 * docutils version 0.14
-* sphinx_rtd_theme version 0.2.4
+* sphinx_rtd_theme version 0.4.0
 
 Begin by cloning a copy of the git repository for the Zephyr project and
 setting up your development environment as described in :ref:`getting_started`

--- a/scripts/requirements.txt
+++ b/scripts/requirements.txt
@@ -1,6 +1,6 @@
 wheel==0.30.0
-breathe==4.7.3
-sphinx==1.6.5
+breathe==4.9.1
+sphinx==1.7.5
 docutils==0.14
 sphinx_rtd_theme
 junit2html


### PR DESCRIPTION
Update the doc build tools versions listed in requirements.txt (and
mentioned in the doc building instructions).

Signed-off-by: David B. Kinder <david.b.kinder@intel.com>