### PR TITLE
doc: update .gitignore file list

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,8 +32,7 @@ doc/latex
 doc/themes/zephyr-docs-theme
 sanity-out/
 scripts/grub
-doc/reference/kconfig/CONFIG_*
-doc/reference/kconfig/index.rst
+doc/reference/kconfig/*.rst
 doc/doc.warnings
 tags
 .project


### PR DESCRIPTION
Changes to kconfig documentation generation added some new files
(choice*.rst) that need to be added to the .gitignore list.  Actually,
all the doc/reference/kconfig/*.rst files should be ignored.

Signed-off-by: David B. Kinder <david.b.kinder@intel.com>