### PR TITLE
libc: minimal: Add typedefs for "least" types

### DIFF
--- a/lib/libc/minimal/include/stdint.h
+++ b/lib/libc/minimal/include/stdint.h
@@ -49,6 +49,11 @@ typedef signed int          int_fast16_t;
 typedef signed int          int_fast32_t;
 typedef signed long long    int_fast64_t;
 
+typedef signed char         int_least8_t;
+typedef signed short        int_least16_t;
+typedef signed int          int_least32_t;
+typedef signed long long    int_least64_t;
+
 typedef unsigned char       uint8_t;
 typedef unsigned short      uint16_t;
 typedef unsigned int        uint32_t;
@@ -58,6 +63,11 @@ typedef unsigned int        uint_fast8_t;
 typedef unsigned int        uint_fast16_t;
 typedef unsigned int        uint_fast32_t;
 typedef unsigned long long  uint_fast64_t;
+
+typedef unsigned char       uint_least8_t;
+typedef unsigned short      uint_least16_t;
+typedef unsigned int        uint_least32_t;
+typedef unsigned long long  uint_least64_t;
 
 typedef int                 intptr_t;
 typedef unsigned int        uintptr_t;


### PR DESCRIPTION
Based on feedback integrating with TI SimpleLink HAL.

Signed-off-by: Paul Sokolovsky <paul.sokolovsky@linaro.org>