### PR TITLE
dts: add parentheses around argument in macro __SIZE_K

### DIFF
--- a/dts/arm/nordic/mem.h
+++ b/dts/arm/nordic/mem.h
@@ -6,7 +6,7 @@
 #ifndef __DT_BINDING_ST_MEM_H
 #define __DT_BINDING_ST_MEM_H
 
-#define __SIZE_K(x) (x * 1024)
+#define __SIZE_K(x) ((x) * 1024)
 
 #if defined(CONFIG_SOC_NRF51822_QFAA)
 #define DT_FLASH_SIZE		__SIZE_K(256)

--- a/dts/arm/silabs/mem.h
+++ b/dts/arm/silabs/mem.h
@@ -1,7 +1,7 @@
 #ifndef __DT_BINDING_ST_MEM_H
 #define __DT_BINDING_ST_MEM_H
 
-#define __SIZE_K(x) (x * 1024)
+#define __SIZE_K(x) ((x) * 1024)
 
 #if defined(CONFIG_SOC_PART_NUMBER_EFM32WG990F256)
 #define DT_FLASH_SIZE		__SIZE_K(256)

--- a/dts/arm/st/mem.h
+++ b/dts/arm/st/mem.h
@@ -6,7 +6,7 @@
 #ifndef __DT_BINDING_ST_MEM_H
 #define __DT_BINDING_ST_MEM_H
 
-#define __SIZE_K(x) (x * 1024)
+#define __SIZE_K(x) ((x) * 1024)
 
 #if defined(CONFIG_SOC_STM32F030X8)
 #define DT_FLASH_SIZE		__SIZE_K(64)

--- a/dts/arm/ti/mem.h
+++ b/dts/arm/ti/mem.h
@@ -7,7 +7,7 @@
 #ifndef __DT_BINDING_TI_MEM_H
 #define __DT_BINDING_TI_MEM_H
 
-#define __SIZE_K(x) (x * 1024)
+#define __SIZE_K(x) ((x) * 1024)
 
 #if defined(CONFIG_SOC_CC3220SF)
 #define DT_SFLASH_SIZE		__SIZE_K(1024)


### PR DESCRIPTION
I suggest using parentheses around argument x in case someone wants to do calculations like __SIZE_K(TOTAL - 32)
