### PR TITLE
kconfig: Fail in CI if Kconfig files reference undefined symbols

### DIFF
--- a/drivers/serial/Kconfig.nrfx
+++ b/drivers/serial/Kconfig.nrfx
@@ -23,7 +23,7 @@ choice
 
 config UART_0_NRF_UART
 	bool "nRF UART 0"
-	depends on ((SOC_SERIES_NRF52X || SOC_SERIES_NRF51X) && (!SOC_NRF52810))
+	depends on SOC_SERIES_NRF52X || SOC_SERIES_NRF51X
 	select NRF_UART_PERIPHERAL
 	help
 	  Enable nRF UART without EasyDMA on port 0.

--- a/scripts/ci/list_undef_kconfig_refs.py
+++ b/scripts/ci/list_undef_kconfig_refs.py
@@ -1,0 +1,88 @@
+#!/usr/bin/env python3
+
+# Prints a message giving the locations of all references to undefined symbols
+# within the Kconfig files. Prints nothing if there are no undefined
+# references.
+#
+# The top-level Kconfig file is assumed to be called 'Kconfig'.
+
+import sys
+
+import kconfiglib
+
+
+def report():
+    # Returns a message (string) giving the locations of all references to
+    # undefined Kconfig symbols within the Kconfig files, or the empty string
+    # if there are no references to undefined symbols.
+    #
+    # Note: This function is called directly during CI.
+
+    kconf = kconfiglib.Kconfig()
+
+    undef_msg = ""
+
+    for name, sym in kconf.syms.items():
+        # - sym.nodes empty means the symbol is undefined (has no definition
+        #   locations)
+        #
+        # - Due to Kconfig internals, numbers show up as undefined Kconfig
+        #   symbols, but shouldn't be flagged
+        #
+        # - The MODULES symbol always exists but is unused in Zephyr
+        if not sym.nodes and not is_num(name) and name != "MODULES":
+            undef_msg += ref_locations_str(sym)
+
+    if undef_msg:
+        return "Error: Found references to undefined Kconfig symbols:\n" \
+               + undef_msg
+
+    return ""
+
+
+def is_num(name):
+    # Heuristic to see if a symbol name looks like a number. Internally,
+    # everything is a symbol, only undefined symbols (which numbers usually
+    # are) get their name as their value.
+
+    try:
+        int(name)
+        return True
+    except ValueError:
+        # Require hex constants to be prefixed with 0x in Kconfig files, so
+        # that we can tell that e.g. F00 is an undefined symbol reference.
+        if not name.startswith(("0x", "0X")):
+            return False
+
+        try:
+            int(name, 16)
+            return True
+        except ValueError:
+            return False
+
+
+def ref_locations_str(sym):
+    # Prints all locations where sym is referenced, along with the Kconfig
+    # definitions of the referencing items
+
+    msg = "\n{}\n{}".format(sym.name, len(sym.name)*"=")
+
+    def search(node):
+        nonlocal msg
+
+        while node:
+            if sym in node.referenced():
+                msg += "\n\n- Referenced at {}:{}:\n\n{}" \
+                       .format(node.filename, node.linenr, node)
+
+            if node.list:
+                search(node.list)
+
+            node = node.next
+
+    search(sym.kconfig.top_node)
+    return msg
+
+
+if __name__ == "__main__":
+    sys.stdout.write(report())


### PR DESCRIPTION
Add a helper module scripts/ci/list_undef_kconfig_refs.py that searches
the entire Kconfig tree and reports any references to undefined Kconfig
symbols. Use it to add a new check to scripts/ci/check-compliance.py.

Also allow list_undef_kconfig_refs.py to be run standalone.

Example error:

<pre>
Error: Found references to undefined Kconfig symbols:

BAR
===

- Referenced at Kconfig:12:

config FOO
      bool
      depends on BAR

- Referenced at Kconfig:16:

menu "menu"
      depends on BAR
</pre>