### PR TITLE
Bluetooth: Fix assertion condition in bt_gatt_discover

### DIFF
--- a/subsys/bluetooth/host/gatt.c
+++ b/subsys/bluetooth/host/gatt.c
@@ -1618,7 +1618,7 @@ int bt_gatt_discover(struct bt_conn *conn,
 	__ASSERT(params && params->func, "invalid parameters\n");
 	__ASSERT((params->start_handle && params->end_handle),
 		 "invalid parameters\n");
-	__ASSERT((params->start_handle < params->end_handle),
+	__ASSERT((params->start_handle <= params->end_handle),
 		 "invalid parameters\n");
 
 	if (conn->state != BT_CONN_CONNECTED) {


### PR DESCRIPTION
This fixes invalid assert condition.

As stated in Bluetooth Core v5.0 Vol 3 Part F
3.4.4.1 Read By Type Request &&
3.4.4.9 Read by Group Type Request
"The starting handle shall be less than or equal to the
ending handle."

3.4.3.1 Find Information Request &&
3.4.3.3 Find By Type Value Request
"Only attributes with attribute handles between and
including the Starting Handle parameter and the Ending
Handle parameter that match the requested attribute type
and the attribute value that have sufficient permissions
to allow reading will be returned."

Signed-off-by: Mariusz Skamra <mariusz.skamra@codecoup.pl>