### PR TITLE
boards: nrf52_blenano2: Add i2c's to nrf52_blenano2 board dts.

### DIFF
--- a/boards/arm/nrf52_blenano2/nrf52_blenano2.dts
+++ b/boards/arm/nrf52_blenano2/nrf52_blenano2.dts
@@ -27,6 +27,14 @@
 	status ="ok";
 };
 
+&i2c0 {
+	status = "ok";
+};
+
+&i2c1 {
+	status = "ok";
+};
+
 &uart0 {
 	compatible = "nordic,nrf-uart";
 	current-speed = <115200>;


### PR DESCRIPTION
Fixes #8391

Enables the i2c drivers for nrf52_blenano2 boards.
Required to enable i2c with this boards.
Fixed build failure in samples/sensor/tmp112 for nrf52_blenano2
by enabling i2c in dts.

Signed-off-by: Mandar Chandrakant Thorat <mandar.chandrakant.thorat@intel.com>