### PR TITLE
ext: Kconfig: Remove redundant 'default n' properties

### DIFF
--- a/ext/debug/segger/Kconfig
+++ b/ext/debug/segger/Kconfig
@@ -6,11 +6,9 @@
 
 config HAS_SEGGER_RTT
 	bool
-	default n
 
 config SEGGER_SYSTEMVIEW
 	bool
 	prompt "Segger SystemView support"
-	default n
 	depends on HAS_SEGGER_RTT
 	select RTT_CONSOLE

--- a/ext/hal/altera/Kconfig
+++ b/ext/hal/altera/Kconfig
@@ -10,6 +10,5 @@
 # before selecting the Altera HAL.
 menuconfig HAS_ALTERA_HAL
 	bool "Altera HAL drivers support"
-	default n
 	depends on NIOS2
 	depends on NEWLIB_LIBC

--- a/ext/hal/libmetal/Kconfig
+++ b/ext/hal/libmetal/Kconfig
@@ -7,7 +7,6 @@
 config LIBMETAL
 	bool
 	prompt "libmetal Support"
-	default n
 	help
 	  This option enables the libmetal HAL abstraction layer
 

--- a/ext/hal/nxp/imx/Kconfig
+++ b/ext/hal/nxp/imx/Kconfig
@@ -15,19 +15,16 @@ if HAS_IMX_HAL
 
 config HAS_IMX_RDC
 	bool
-	default n
 	help
 	  Set if the RDC module is present in the SoC.
 
 config HAS_IMX_CCM
 	bool
-	default n
 	help
 	  Set if the CCM module is present in the SoC.
 
 config HAS_IMX_GPIO
 	bool
-	default n
 	help
 	  Set if the GPIO module is present in the SoC.
 

--- a/ext/hal/nxp/mcux/Kconfig
+++ b/ext/hal/nxp/mcux/Kconfig
@@ -14,63 +14,53 @@ if HAS_MCUX
 
 config HAS_MCUX_ADC16
 	bool
-	default n
 	help
 	  Set if the 16-bit ADC (ADC16) module is present in the SoC.
 
 config HAS_MCUX_CCM
 	bool
-	default n
 	help
 	  Set if the clock control module (CCM) module is present in the SoC.
 
 config HAS_MCUX_FTM
 	bool
-	default n
 	help
 	  Set if the FlexTimer (FTM) module is present in the SoC.
 
 config HAS_MCUX_IGPIO
 	bool
-	default n
 	help
 	  Set if the iMX GPIO (IGPIO) module is present in the SoC.
 
 config HAS_MCUX_LPSCI
 	bool
-	default n
 	help
 	  Set if the low power uart (LPSCI) module is present in the SoC.
 
 config HAS_MCUX_LPUART
 	bool
-	default n
 	help
 	  Set if the low power uart (LPUART) module is present in the SoC.
 
 config HAS_MCUX_RNGA
 	bool
-	default n
 	help
 	  Set if the random number generator accelerator (RNGA) module is
 	  present in the SoC.
 
 config HAS_MCUX_RTC
 	bool
-	default n
 	help
 	  Set if the real time clock (RTC) modules is present in the SoC.
 
 config HAS_MCUX_SIM
 	bool
-	default n
 	help
 	  Set if the system integration module (SIM) module is present in the
 	  SoC.
 
 config HAS_MCUX_TRNG
 	bool
-	default n
 	help
 	  Set if the true random number generator (TRNG) module is present in
 	  the SoC.

--- a/ext/hal/qmsi/Kconfig
+++ b/ext/hal/qmsi/Kconfig
@@ -11,7 +11,6 @@ config HAS_QMSI
 
 menuconfig QMSI
 	bool "QMSI driver support"
-	default n
 	depends on HAS_QMSI
 	help
 	  automatically set when either of QMSI_LIBRARY or QMSI_BUILTIN
@@ -21,14 +20,12 @@ if HAS_QMSI
 
 config QMSI_BUILTIN
 	bool "Enable QMSI drivers through integrated sources"
-	default n
 	select QMSI
 	help
 	  Link with local QMSI sources instead of external library.
 
 config QMSI_LIBRARY
 	bool "Enable QMSI drivers using external library"
-	default n
 	select QMSI
 	help
 	  This option enables QMSI device drivers. These drivers are actually shim
@@ -46,7 +43,6 @@ config QMSI_INSTALL_PATH
 
 config SOC_WATCH
 	bool "Enable SoCWatch drivers and related instrumentation"
-	default n
 	depends on KERNEL_EVENT_LOGGER
 	help
 	  This option enables the SoCWatch driver and related instrumentation.

--- a/ext/hal/st/stm32cube/Kconfig
+++ b/ext/hal/st/stm32cube/Kconfig
@@ -13,455 +13,342 @@ if HAS_STM32CUBE
 
 config USE_STM32_HAL_ADC
 	bool
-	default n
 
 config USE_STM32_HAL_ADC_EX
 	bool
-	default n
 
 config USE_STM32_HAL_CAN
 	bool
-	default n
 
 config USE_STM32_HAL_CEC
 	bool
-	default n
 
 config USE_STM32_HAL_COMP
 	bool
-	default n
 
 config USE_STM32_HAL_CORTEX
 	bool
-	default n
 
 config USE_STM32_HAL_CRC
 	bool
-	default n
 
 config USE_STM32_HAL_CRC_EX
 	bool
-	default n
 
 config USE_STM32_HAL_CRYPT
 	bool
-	default n
 
 config USE_STM32_HAL_CRYPT_EX
 	bool
-	default n
 
 config USE_STM32_HAL_DAC
 	bool
-	default n
 
 config USE_STM32_HAL_DAC_EX
 	bool
-	default n
 
 config USE_STM32_HAL_DCMI
 	bool
-	default n
 
 config USE_STM32_HAL_DCMI_EX
 	bool
-	default n
 
 config USE_STM32_HAL_DFSDM
 	bool
-	default n
 
 config USE_STM32_HAL_DFSDM_EX
 	bool
-	default n
 
 config USE_STM32_HAL_DMA
 	bool
-	default n
 
 config USE_STM32_HAL_DMA2D
 	bool
-	default n
 
 config USE_STM32_HAL_DMA_EX
 	bool
-	default n
 
 config USE_STM32_HAL_DSI
 	bool
-	default n
 
 config USE_STM32_HAL_ETH
 	bool
-	default n
 
 config USE_STM32_HAL_FIREWALL
 	bool
-	default n
 
 config USE_STM32_HAL_FLASH
 	bool
-	default n
 
 config USE_STM32_HAL_FLASH_EX
 	bool
-	default n
 
 config USE_STM32_HAL_FLASH_RAMFUNC
 	bool
-	default n
 
 config USE_STM32_HAL_FMPI2C
 	bool
-	default n
 
 config USE_STM32_HAL_FMPI2C_EX
 	bool
-	default n
 
 config USE_STM32_HAL_GFXMMU
 	bool
-	default n
 
 config USE_STM32_HAL_GPIO
 	bool
-	default n
 
 config USE_STM32_HAL_GPIO_EX
 	bool
-	default n
 
 config USE_STM32_HAL_HASH
 	bool
-	default n
 
 config USE_STM32_HAL_HASH_EX
 	bool
-	default n
 
 config USE_STM32_HAL_HCD
 	bool
-	default n
 
 config USE_STM32_HAL_HRTIM
 	bool
-	default n
 
 config USE_STM32_HAL_I2C
 	bool
-	default n
 
 config USE_STM32_HAL_I2C_EX
 	bool
-	default n
 
 config USE_STM32_HAL_I2S
 	bool
-	default n
 
 config USE_STM32_HAL_I2S_EX
 	bool
-	default n
 
 config USE_STM32_HAL_IRDA
 	bool
-	default n
 
 config USE_STM32_HAL_IWDG
 	bool
-	default n
 
 config USE_STM32_HAL_JPEG
 	bool
-	default n
 
 config USE_STM32_HAL_LCD
 	bool
-	default n
 
 config USE_STM32_HAL_LPTIM
 	bool
-	default n
 
 config USE_STM32_HAL_LTDC
 	bool
-	default n
 
 config USE_STM32_HAL_LTDC_EX
 	bool
-	default n
 
 config USE_STM32_HAL_MDIOS
 	bool
-	default n
 
 config USE_STM32_HAL_MMC
 	bool
-	default n
 
 config USE_STM32_HAL_NAND
 	bool
-	default n
 
 config USE_STM32_HAL_NOR
 	bool
-	default n
 
 config USE_STM32_HAL_OPAMP
 	bool
-	default n
 
 config USE_STM32_HAL_OPAMP_EX
 	bool
-	default n
 
 config USE_STM32_HAL_OSPI
 	bool
-	default n
 
 config USE_STM32_HAL_PCCARD
 	bool
-	default n
 
 config USE_STM32_HAL_PCD
 	bool
-	default n
 
 config USE_STM32_HAL_PCD_EX
 	bool
-	default n
 
 config USE_STM32_HAL_PWR
 	bool
-	default n
 
 config USE_STM32_HAL_PWR_EX
 	bool
-	default n
 
 config USE_STM32_HAL_QSPI
 	bool
-	default n
 
 config USE_STM32_HAL_RCC
 	bool
-	default n
 
 config USE_STM32_HAL_RCC_EX
 	bool
-	default n
 
 config USE_STM32_HAL_RNG
 	bool
-	default n
 
 config USE_STM32_HAL_RTC
 	bool
-	default n
 
 config USE_STM32_HAL_RTC_EX
 	bool
-	default n
 
 config USE_STM32_HAL_SAI
 	bool
-	default n
 
 config USE_STM32_HAL_SAI_EX
 	bool
-	default n
 
 config USE_STM32_HAL_SD
 	bool
-	default n
 
 config USE_STM32_HAL_SDADC
 	bool
-	default n
 
 config USE_STM32_HAL_SD_EX
 	bool
-	default n
 
 config USE_STM32_HAL_SDRAM
 	bool
-	default n
 
 config USE_STM32_HAL_SMARTCARD
 	bool
-	default n
 
 config USE_STM32_HAL_SMARTCARD_EX
 	bool
-	default n
 
 config USE_STM32_HAL_SMBUS
 	bool
-	default n
 
 config USE_STM32_HAL_SPDIFRX
 	bool
-	default n
 
 config USE_STM32_HAL_SPI
 	bool
-	default n
 
 config USE_STM32_HAL_SPI_EX
 	bool
-	default n
 
 config USE_STM32_HAL_SRAM
 	bool
-	default n
 
 config USE_STM32_HAL_SWPMI
 	bool
-	default n
 
 config USE_STM32_HAL_TIM
 	bool
-	default n
 
 config USE_STM32_HAL_TIME_EX
 	bool
-	default n
 
 config USE_STM32_HAL_TIM_EX
 	bool
-	default n
 
 config USE_STM32_HAL_TSC
 	bool
-	default n
 
 config USE_STM32_HAL_UART
 	bool
-	default n
 
 config USE_STM32_HAL_UART_EX
 	bool
-	default n
 
 config USE_STM32_HAL_USART
 	bool
-	default n
 
 config USE_STM32_HAL_USART_EX
 	bool
-	default n
 
 config USE_STM32_HAL_WWDG
 	bool
-	default n
 
 config USE_STM32_LL_ADC
 	bool
-	default n
 
 config USE_STM32_LL_COMP
 	bool
-	default n
 
 config USE_STM32_LL_CRC
 	bool
-	default n
 
 config USE_STM32_LL_CRS
 	bool
-	default n
 
 config USE_STM32_LL_DAC
 	bool
-	default n
 
 config USE_STM32_LL_DMA
 	bool
-	default n
 
 config USE_STM32_LL_DMA2D
 	bool
-	default n
 
 config USE_STM32_LL_EXTI
 	bool
-	default n
 
 config USE_STM32_LL_FMC
 	bool
-	default n
 
 config USE_STM32_LL_FSMC
 	bool
-	default n
 
 config USE_STM32_LL_GPIO
 	bool
-	default n
 
 config USE_STM32_LL_HRTIM
 	bool
-	default n
 
 config USE_STM32_LL_I2C
 	bool
-	default n
 
 config USE_STM32_LL_LPTIM
 	bool
-	default n
 
 config USE_STM32_LL_LPUART
 	bool
-	default n
 
 config USE_STM32_LL_OPAMP
 	bool
-	default n
 
 config USE_STM32_LL_PWR
 	bool
-	default n
 
 config USE_STM32_LL_RCC
 	bool
-	default n
 
 config USE_STM32_LL_RNG
 	bool
-	default n
 
 config USE_STM32_LL_RTC
 	bool
-	default n
 
 config USE_STM32_LL_SDMMC
 	bool
-	default n
 
 config USE_STM32_LL_SPI
 	bool
-	default n
 
 config USE_STM32_LL_SWPMI
 	bool
-	default n
 
 config USE_STM32_LL_TIM
 	bool
-	default n
 
 config USE_STM32_LL_USART
 	bool
-	default n
 
 config USE_STM32_LL_USB
 	bool
-	default n
 
 config USE_STM32_LL_UTILS
 	bool
-	default n
 
 endif
 

--- a/ext/hal/ti/simplelink/Kconfig
+++ b/ext/hal/ti/simplelink/Kconfig
@@ -8,7 +8,6 @@ config HAS_CC3220SDK
 # Selecting ERRNO lets host driver use Zephyr's __errno
 config SIMPLELINK_HOST_DRIVER
 	bool "Build the SimpleLink WiFi Host Driver"
-	default n
 	depends on HAS_CC3220SDK
 	depends on MULTITHREADING
 	select NEWLIB_LIBC

--- a/ext/lib/crypto/mbedtls/Kconfig
+++ b/ext/lib/crypto/mbedtls/Kconfig
@@ -20,7 +20,6 @@
 menuconfig MBEDTLS
 	bool
 	prompt "mbedTLS Support"
-	default n
 	help
 	  This option enables the mbedTLS cryptography library.
 
@@ -70,7 +69,6 @@ config MBEDTLS_SSL_MAX_CONTENT_LEN
 config MBEDTLS_DEBUG
 	bool "mbed TLS debug activation"
 	depends on MBEDTLS_BUILTIN
-	default n
 	help
 	  Enable debugging activation for mbed TLS configuration. If you use
 	  mbedTLS/Zephyr integration (e.g. net_app), this will activate debug
@@ -99,7 +97,6 @@ config MBEDTLS_DEBUG_LEVEL
 config MBEDTLS_TEST
 	bool "Compile internal self test functions"
 	depends on MBEDTLS_BUILTIN
-	default n
 	help
 	  Enable self test function for the crypto algorithms
 
@@ -113,7 +110,6 @@ config MBEDTLS_INSTALL_PATH
 
 config MBEDTLS_ENABLE_HEAP
 	bool "Enable global heap for mbed TLS"
-	default n
 	help
 	  This option enables the mbedtls to use the heap. This setting must
 	  be global so that various applications and libraries in Zephyr do not

--- a/ext/lib/crypto/tinycrypt/Kconfig
+++ b/ext/lib/crypto/tinycrypt/Kconfig
@@ -9,7 +9,6 @@
 config TINYCRYPT
 	bool
 	prompt "TinyCrypt Support"
-	default n
 	help
 	  This option enables the TinyCrypt cryptography library.
 
@@ -17,7 +16,6 @@ config TINYCRYPT_CTR_PRNG
 	bool
 	prompt "PRNG in counter mode"
 	depends on TINYCRYPT
-	default n
 	help
 	  This option enables support for the pseudo-random number
 	  generator in counter mode.
@@ -26,7 +24,6 @@ config TINYCRYPT_SHA256
 	bool
 	prompt "SHA-256 Hash function support"
 	depends on TINYCRYPT
-	default n
 	help
 	  This option enables support for SHA-256
 	  hash function primitive.
@@ -35,7 +32,6 @@ config TINYCRYPT_SHA256_HMAC
 	bool
 	prompt "HMAC (via SHA256) message auth support"
 	depends on TINYCRYPT_SHA256
-	default n
 	help
 	  This option enables support for HMAC using SHA-256
 	  message authentication code.
@@ -44,7 +40,6 @@ config TINYCRYPT_SHA256_HMAC_PRNG
 	bool
 	prompt "PRNG (via HMAC-SHA256) support"
 	depends on TINYCRYPT_SHA256_HMAC
-	default n
 	help
 	  This option enables support for pseudo-random number
 	  generator.
@@ -54,7 +49,6 @@ config TINYCRYPT_ECC_DH
 	prompt "ECC_DH anonymous key agreement protocol"
 	depends on TINYCRYPT
 	select ENTROPY_GENERATOR
-	default n
 	help
 	  This option enables support for the Elliptic curve
 	  Diffie-Hellman anonymous key agreement protocol.
@@ -67,7 +61,6 @@ config TINYCRYPT_ECC_DSA
 	prompt "ECC_DSA digital signature algorithm"
 	depends on TINYCRYPT
 	select ENTROPY_GENERATOR
-	default n
 	help
 	  This option enables support for the Elliptic Curve Digital
 	  Signature Algorithm (ECDSA).
@@ -79,7 +72,6 @@ config TINYCRYPT_AES
 	bool
 	prompt "AES-128 decrypt/encrypt"
 	depends on TINYCRYPT
-	default n
 	help
 	  This option enables support for AES-128 decrypt and encrypt.
 
@@ -87,7 +79,6 @@ config TINYCRYPT_AES_CBC
 	bool
 	prompt "AES-128 block cipher"
 	depends on TINYCRYPT_AES
-	default n
 	help
 	  This option enables support for AES-128 block cipher mode.
 
@@ -95,7 +86,6 @@ config TINYCRYPT_AES_CTR
 	bool
 	prompt "AES-128 counter mode"
 	depends on TINYCRYPT_AES
-	default n
 	help
 	  This option enables support for AES-128 counter mode.
 
@@ -103,7 +93,6 @@ config TINYCRYPT_AES_CCM
 	bool
 	prompt "AES-128 CCM mode"
 	depends on TINYCRYPT_AES
-	default n
 	help
 	  This option enables support for AES-128 CCM mode.
 
@@ -111,6 +100,5 @@ config TINYCRYPT_AES_CMAC
 	bool
 	prompt "AES-128 CMAC mode"
 	depends on TINYCRYPT_AES
-	default n
 	help
 	  This option enables support for AES-128 CMAC mode.

--- a/ext/lib/encoding/tinycbor/Kconfig
+++ b/ext/lib/encoding/tinycbor/Kconfig
@@ -20,7 +20,6 @@
 config TINYCBOR
 	bool
 	prompt "tinyCBOR Support"
-	default n
 	help
 	  This option enables the tinyCBOR library.
 
@@ -29,21 +28,18 @@ if TINYCBOR
 config CBOR_NO_DFLT_WRITER
 	bool
 	prompt "No default writer support"
-	default n
 	help
 	  This option specifies whether a default writer exists.
 
 config CBOR_NO_DFLT_READER
 	bool
 	prompt "No default reader support"
-	default n
 	help
 	  This option specifies whether a default reader exists.
 
 config CBOR_ENCODER_NO_CHECK_USER
 	bool
 	prompt "No encoder checks for user args for validity"
-	default n
 	help
 	  This option specifies whether a check user exists for a cbor encoder.
 
@@ -57,7 +53,6 @@ config CBOR_PARSER_MAX_RECURSIONS
 config CBOR_PARSER_NO_STRICT_CHECKS
 	bool
 	prompt "No strict parser checks"
-	default n
 	help
 	  This option enables the strict parser checks.
 
@@ -65,7 +60,6 @@ config CBOR_FLOATING_POINT
 	bool
 	select NEWLIB_LIBC
 	prompt "Floating point support"
-	default n
 	help
 	  This option enables floating point support.
 
@@ -73,7 +67,6 @@ config CBOR_HALF_FLOAT_TYPE
 	bool
 	select NEWLIB_LIBC
 	prompt "Half float type support"
-	default n
 	help
 	  This option enables half float type support.
 

--- a/ext/lib/ipc/open-amp/Kconfig
+++ b/ext/lib/ipc/open-amp/Kconfig
@@ -8,7 +8,6 @@ config OPENAMP
 	bool
 	prompt "OpenAMP Support"
 	select LIBMETAL
-	default n
 	help
 	  This option enables the OpenAMP IPC library
 

--- a/ext/lib/mgmt/mcumgr/Kconfig
+++ b/ext/lib/mgmt/mcumgr/Kconfig
@@ -19,7 +19,6 @@ config MCUMGR
     bool
     prompt "mcumgr Support"
     select TINYCBOR
-    default n
     help
       This option enables the mcumgr management library.
 

--- a/ext/lib/mgmt/mcumgr/cmd/fs_mgmt/Kconfig
+++ b/ext/lib/mgmt/mcumgr/cmd/fs_mgmt/Kconfig
@@ -19,7 +19,6 @@ menuconfig MCUMGR_CMD_FS_MGMT
     bool
     prompt "Enable mcumgr handlers for file management"
     depends on FILE_SYSTEM
-    default n
     help
       Enables mcumgr handlers for file management
 

--- a/ext/lib/mgmt/mcumgr/cmd/img_mgmt/Kconfig
+++ b/ext/lib/mgmt/mcumgr/cmd/img_mgmt/Kconfig
@@ -21,8 +21,6 @@ menuconfig MCUMGR_CMD_IMG_MGMT
     select FLASH
     select MPU_ALLOW_FLASH_WRITE if CPU_HAS_MPU
     select IMG_MANAGER
-
-    default n
     help
       Enables mcumgr handlers for image management
 

--- a/ext/lib/mgmt/mcumgr/cmd/log_mgmt/Kconfig
+++ b/ext/lib/mgmt/mcumgr/cmd/log_mgmt/Kconfig
@@ -18,7 +18,6 @@
 menuconfig MCUMGR_CMD_LOG_MGMT
     bool
     prompt "Enable mcumgr handlers for log management"
-    default n
     help
       Enables mcumgr handlers for log management
 

--- a/ext/lib/mgmt/mcumgr/cmd/os_mgmt/Kconfig
+++ b/ext/lib/mgmt/mcumgr/cmd/os_mgmt/Kconfig
@@ -19,7 +19,6 @@ menuconfig MCUMGR_CMD_OS_MGMT
     bool
     prompt "Enable mcumgr handlers for OS management"
     select REBOOT
-    default n
     help
       Enables mcumgr handlers for OS management
 

--- a/ext/lib/mgmt/mcumgr/cmd/stat_mgmt/Kconfig
+++ b/ext/lib/mgmt/mcumgr/cmd/stat_mgmt/Kconfig
@@ -19,7 +19,6 @@ menuconfig MCUMGR_CMD_STAT_MGMT
     bool
     prompt "Enable mcumgr handlers for statistics management"
     depends on STATS
-    default n
     help
       Enables mcumgr handlers for statistics management.
 


### PR DESCRIPTION
Bool symbols implicitly default to `n`.

A `default n` could make sense e.g. in a `Kconfig.defconfig` file, if you
wanted to override a `default y` on the base definition of the symbol,
but it doesn't seem to be used like that on any of these symbols.