### PR TITLE
drivers: can: Set a initial state to the can device before HAL_CAN_Init

### DIFF
--- a/drivers/can/stm32_can.c
+++ b/drivers/can/stm32_can.c
@@ -205,6 +205,8 @@ int can_stm32_runtime_configure(struct device *dev, enum can_mode mode,
 	hcan.Init.BS2  = bs2;
 	hcan.Init.Prescaler = prescaler;
 
+	hcan.State = HAL_CAN_STATE_RESET;
+
 	hal_ret = HAL_CAN_Init(&hcan);
 	if (hal_ret != HAL_OK) {
 		SYS_LOG_ERR("HAL_CAN_Init failed: %d", hal_ret);


### PR DESCRIPTION
As part of HAL_CAN_Init we check the initial state of the can handle.
Setting it to HAL_CAN_STATE_RESET as an initial state to start the
Init properly.

Also included a bunch of changes to satisfy uncrustify on the file.

Resolves: #8416
Coverity-CID: 186580

Signed-off-by: Sritej Kanakadandi Venkata Rama <sritej.kvr@gmail.com>