### PR TITLE
usb: hid: fix write to interrupt IN endpoint

### DIFF
--- a/include/usb/class/usb_hid.h
+++ b/include/usb/class/usb_hid.h
@@ -154,6 +154,9 @@ struct hid_ops {
 void usb_hid_register_device(const u8_t *desc, size_t size,
 			     const struct hid_ops *op);
 
+/* Write to hid interrupt endpoint */
+int hid_int_ep_write(const u8_t *data, u32_t data_len, u32_t *bytes_ret);
+
 /* Initialize USB HID */
 int usb_hid_init(void);
 

--- a/samples/subsys/usb/hid-mouse/src/main.c
+++ b/samples/subsys/usb/hid-mouse/src/main.c
@@ -153,7 +153,6 @@ void main(void)
 		k_sem_take(&sem, K_FOREVER);
 
 		report[0] = status;
-		usb_write(CONFIG_HID_INT_EP_ADDR, report,
-			  sizeof(report), NULL);
+		hid_int_ep_write(report, sizeof(report), NULL);
 	}
 }

--- a/samples/subsys/usb/hid/src/main.c
+++ b/samples/subsys/usb/hid/src/main.c
@@ -108,8 +108,7 @@ void main(void)
 
 		report_1[1]++;
 
-		ret = usb_write(CONFIG_HID_INT_EP_ADDR, report_1,
-				sizeof(report_1), &wrote);
+		ret = hid_int_ep_write(report_1, sizeof(report_1), &wrote);
 		SYS_LOG_DBG("Wrote %d bytes with ret %d", wrote, ret);
 	}
 }

--- a/subsys/usb/class/hid/core.c
+++ b/subsys/usb/class/hid/core.c
@@ -17,6 +17,9 @@
 #include <usb_descriptor.h>
 #include <class/usb_hid.h>
 
+#define HID_INT_IN_EP_IDX			0
+#define HID_INT_OUT_EP_IDX			1
+
 struct usb_hid_config {
 	struct usb_if_descriptor if0;
 	struct usb_hid_descriptor if0_hid;
@@ -269,4 +272,10 @@ void usb_hid_register_device(const u8_t *desc, size_t size,
 	hid_device.report_size = size;
 
 	hid_device.ops = ops;
+}
+
+int hid_int_ep_write(const u8_t *data, u32_t data_len, u32_t *bytes_ret)
+{
+	return usb_write(hid_ep_data[HID_INT_IN_EP_IDX].ep_addr, data,
+			 data_len, bytes_ret);
 }


### PR DESCRIPTION
A HID application can no longer write to the default
interrupt IN endpoint because the addresses are assigned
dynamically. Add hid_int_ep_write() function  and leave
it to the hid-core to call the usb_write() with the correct
endpoint address.

fixes: #8424