### PR TITLE
samples: net: Check the return value of close()

### DIFF
--- a/samples/net/sockets/dumb_http_server/src/socket_dumb_http.c
+++ b/samples/net/sockets/dumb_http_server/src/socket_dumb_http.c
@@ -46,6 +46,7 @@ int main(void)
 	int serv;
 	struct sockaddr_in bind_addr;
 	static int counter;
+	int ret;
 
 	serv = socket(AF_INET, SOCK_STREAM, IPPROTO_TCP);
 	CHECK(serv);
@@ -122,8 +123,13 @@ int main(void)
 		}
 
 close_client:
-		close(client);
-		printf("Connection from %s closed\n", addr_str);
+		ret = close(client);
+		if (ret == 0) {
+			printf("Connection from %s closed\n", addr_str);
+		} else {
+			printf("Got error %d while closing the "
+			       "socket\n", errno);
+		}
 
 #if defined(__ZEPHYR__) && defined(CONFIG_NET_BUF_POOL_USAGE)
 		struct k_mem_slab *rx, *tx;


### PR DESCRIPTION
Check the return value of close() in socket_dumb_http.c
If the return value is non-zero, print the error code

Fixes #8413.

Signed-off-by: Satya Bhattacharya <satyacube@gmail.com>