### PR TITLE
usb: hid: add OUT interrupt endpoint

### DIFF
--- a/include/usb/class/usb_hid.h
+++ b/include/usb/class/usb_hid.h
@@ -69,6 +69,9 @@ struct hid_ops {
 	 * the next transfer.
 	 */
 	hid_int_ready_callback int_in_ready;
+#ifdef CONFIG_ENABLE_HID_INT_OUT_EP
+	hid_int_ready_callback int_out_ready;
+#endif
 };
 
 /* HID Report Definitions */
@@ -156,6 +159,9 @@ void usb_hid_register_device(const u8_t *desc, size_t size,
 
 /* Write to hid interrupt endpoint */
 int hid_int_ep_write(const u8_t *data, u32_t data_len, u32_t *bytes_ret);
+
+/* Read from hid interrupt endpoint */
+int hid_int_ep_read(u8_t *data, u32_t max_data_len, u32_t *ret_bytes);
 
 /* Initialize USB HID */
 int usb_hid_init(void);

--- a/subsys/usb/class/hid/Kconfig
+++ b/subsys/usb/class/hid/Kconfig
@@ -15,6 +15,12 @@ config USB_DEVICE_HID
 
 if USB_DEVICE_HID
 
+config ENABLE_HID_INT_OUT_EP
+	bool
+	prompt "Enable USB HID Device Interrupt OUT Endpoint"
+	help
+	  Enable USB HID Device Interrupt OUT Endpoint.
+
 config HID_INTERRUPT_EP_MPS
 	int
 	prompt "USB HID Device Interrupt Endpoint size"


### PR DESCRIPTION
Make payload size configurable and add OUT interrupt endpoint.

I needed OUT interrupt for a HID project and picked the patch from #7303 and adapted for latest master. @sathishkuttan @SavinayDharmappa @aurel32 please review
