### PR TITLE
cmake: Kernel and offset libraries linking flags

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -40,12 +40,17 @@ set_property(   GLOBAL PROPERTY PROPERTY_OUTPUT_FORMAT elf32-little${ARCH})
 # compiler options needed by all source files. All zephyr libraries,
 # including the library named "zephyr" link with this library to
 # obtain these flags.
+# Linker flags will be propagated to executable targets which links
+# to zephyr_interface, either directly or through other libraries which
+# depends upon zephyr_interface, e.g. zephyr itself.
 add_library(zephyr_interface INTERFACE)
+zephyr_link_libraries(${TOOLCHAIN_LIBS})
 
 # zephyr is a catchall CMake library for source files that can be
 # built purely with the include paths, defines, and other compiler
 # flags that come with zephyr_interface.
 zephyr_library_named(zephyr)
+target_link_libraries(zephyr INTERFACE -u_ConfigAbsSyms)
 
 zephyr_include_directories(
   kernel/include
@@ -712,7 +717,6 @@ set_property(TARGET
 set(zephyr_lnk
   ${LINKERFLAGPREFIX},-Map=${PROJECT_BINARY_DIR}/${KERNEL_MAP_NAME}
   -u_OffsetAbsSyms
-  -u_ConfigAbsSyms
   ${LINKERFLAGPREFIX},--start-group
   ${LINKERFLAGPREFIX},--whole-archive
   ${ZEPHYR_LIBS_PROPERTY}
@@ -722,7 +726,6 @@ set(zephyr_lnk
   ${LINKERFLAGPREFIX},--end-group
   ${LIB_INCLUDE_DIR}
   -L${PROJECT_BINARY_DIR}
-  ${TOOLCHAIN_LIBS}
   )
 
 if(CONFIG_GEN_ISR_TABLES)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -50,7 +50,12 @@ zephyr_link_libraries(kernel ${TOOLCHAIN_LIBS})
 # built purely with the include paths, defines, and other compiler
 # flags that come with zephyr_interface.
 zephyr_library_named(zephyr)
-target_link_libraries(zephyr INTERFACE -u_ConfigAbsSyms)
+
+# Correctly, the link flag -u_ConfigAbsSyms should be placed as INTERFACE cause
+# it is only required when linking to zephyr.
+# But as described in #8614, the below is not possible.
+# zephyr_library_link_libraries(INTERFACE -u_ConfigAbsSyms)
+zephyr_library_link_libraries(-u_ConfigAbsSyms)
 
 zephyr_include_directories(
   kernel/include
@@ -483,13 +488,22 @@ set(OFFSETS_O_PATH ${CMAKE_CURRENT_BINARY_DIR}/CMakeFiles/offsets.dir/arch/${ARC
 set(OFFSETS_H_PATH ${PROJECT_BINARY_DIR}/include/generated/offsets.h)
 
 add_library(          offsets STATIC ${OFFSETS_C_PATH})
-target_link_libraries(offsets zephyr_interface)
+target_link_libraries(offsets INTERFACE -u_OffsetAbsSyms)
 add_dependencies(     offsets
   syscall_list_h_target
   syscall_macros_h_target
   driver_validation_h_target
   kobj_types_h_target
   )
+
+# Kernel is a Zephyr interface dependency, which means everyone using zephyr_interface has an
+# indirect dependency, which for other libraries is fine.
+# However offsets does not need to link to kernel as there is no dependency.
+# Instead kernel depends on generated offset.h so to avoid a non-existing circular dependency,
+# offset lib only requires the compile options and include directories from zephyr_interface.
+target_compile_options(    offsets PRIVATE $<TARGET_PROPERTY:zephyr_interface,INTERFACE_COMPILE_OPTIONS>)
+target_compile_definitions(offsets PRIVATE $<TARGET_PROPERTY:zephyr_interface,INTERFACE_COMPILE_DEFINITIONS>)
+target_include_directories(offsets PRIVATE $<TARGET_PROPERTY:zephyr_interface,INTERFACE_INCLUDE_DIRECTORIES>)
 
 add_custom_command(
   OUTPUT ${OFFSETS_H_PATH}
@@ -716,12 +730,10 @@ set_property(TARGET
 
 set(zephyr_lnk
   ${LINKERFLAGPREFIX},-Map=${PROJECT_BINARY_DIR}/${KERNEL_MAP_NAME}
-  -u_OffsetAbsSyms
   ${LINKERFLAGPREFIX},--start-group
   ${LINKERFLAGPREFIX},--whole-archive
   ${ZEPHYR_LIBS_PROPERTY}
   ${LINKERFLAGPREFIX},--no-whole-archive
-  ${OFFSETS_O_PATH}
   ${LINKERFLAGPREFIX},--end-group
   ${LIB_INCLUDE_DIR}
   -L${PROJECT_BINARY_DIR}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -44,7 +44,7 @@ set_property(   GLOBAL PROPERTY PROPERTY_OUTPUT_FORMAT elf32-little${ARCH})
 # to zephyr_interface, either directly or through other libraries which
 # depends upon zephyr_interface, e.g. zephyr itself.
 add_library(zephyr_interface INTERFACE)
-zephyr_link_libraries(${TOOLCHAIN_LIBS})
+zephyr_link_libraries(kernel ${TOOLCHAIN_LIBS})
 
 # zephyr is a catchall CMake library for source files that can be
 # built purely with the include paths, defines, and other compiler
@@ -721,7 +721,6 @@ set(zephyr_lnk
   ${LINKERFLAGPREFIX},--whole-archive
   ${ZEPHYR_LIBS_PROPERTY}
   ${LINKERFLAGPREFIX},--no-whole-archive
-  kernel
   ${OFFSETS_O_PATH}
   ${LINKERFLAGPREFIX},--end-group
   ${LIB_INCLUDE_DIR}

--- a/kernel/CMakeLists.txt
+++ b/kernel/CMakeLists.txt
@@ -55,4 +55,4 @@ target_sources_ifdef(
 
 add_dependencies(kernel offsets_h)
 
-target_link_libraries(kernel zephyr_interface)
+target_link_libraries(kernel zephyr_interface offsets)


### PR DESCRIPTION
Fixes: #8440

This commit moves linking flags which are required when linking to
kernel and offset static libraries to be defined together with the
library definitions.

Thus, the library kernel / offset propagates the flags which are
required when linking to those libraries.
This places knowledge where it correctly belongs.

Signed-off-by: Torsten Rasmussen <torsten.rasmussen@nordicsemi.no>