### PR TITLE
drivers: serial: Revert change to init level for nrfx uart driver.

### DIFF
--- a/drivers/serial/uart_nrfx_uart.c
+++ b/drivers/serial/uart_nrfx_uart.c
@@ -413,7 +413,8 @@ DEVICE_AND_API_INIT(uart_nrfx_uart0,
 		    uart_nrfx_init,
 		    NULL,
 		    NULL,
-		    POST_KERNEL,
+		    /* Initialize UART device before UART console. */
+		    PRE_KERNEL_1,
 		    CONFIG_KERNEL_INIT_PRIORITY_DEVICE,
 		    &uart_nrfx_uart_driver_api);
 


### PR DESCRIPTION
The nrfx uart driver will get stuck in uart_poll_out function since
the uart_console driver has been initialized at PRE_KERNEL_1 level
and is making calls to the uart driver before the uart driver has been
initialized.