### PR TITLE
drivers: usb: Fix build error for intel_s1000.

### DIFF
--- a/drivers/usb/device/usb_dc_dw.c
+++ b/drivers/usb/device/usb_dc_dw.c
@@ -826,19 +826,19 @@ int usb_dc_ep_check_cap(const struct usb_dc_ep_cfg_data * const cfg)
 		return -1;
 	}
 
-	if (cfg->ep_mps > QM_USB_MAX_PACKET_SIZE) {
+	if (cfg->ep_mps > DW_USB_MAX_PACKET_SIZE) {
 		SYS_LOG_WRN("unsupported packet size");
 		return -1;
 	}
 
 	if ((USB_DW_EP_ADDR2DIR(cfg->ep_addr) == USB_EP_DIR_OUT) &&
-	    (ep_idx >= QM_USB_OUT_EP_NUM)) {
+	    (ep_idx >= DW_USB_OUT_EP_NUM)) {
 		SYS_LOG_WRN("OUT endpoint address out of range");
 		return -1;
 	}
 
 	if ((USB_DW_EP_ADDR2DIR(cfg->ep_addr) == USB_EP_DIR_IN) &&
-	    (ep_idx >= QM_USB_IN_EP_NUM)) {
+	    (ep_idx >= DW_USB_IN_EP_NUM)) {
 		SYS_LOG_WRN("IN endpoint address out of range");
 		return -1;
 	}

--- a/drivers/usb/device/usb_dw_registers.h
+++ b/drivers/usb/device/usb_dw_registers.h
@@ -201,6 +201,10 @@ struct usb_dw_reg {
 /* USB register block base address */
 #define USB_DW ((struct usb_dw_reg *)USB_DW_BASE)
 
+#define DW_USB_IN_EP_NUM		(6)
+#define DW_USB_OUT_EP_NUM		(4)
+#define DW_USB_MAX_PACKET_SIZE		(64)
+
 #ifdef __cplusplus
 }
 #endif


### PR DESCRIPTION
As not all controllers using DW usb doesn't inherit
the qmsi related header, use of QM_USB_MAX_PACKET_SIZE,
QM_USB_IN_EP_NUM and QM_USB_OUT_EP_NUM break the build
for such platform. Hence defined new macros and corresponding
change done in driver.

Signed-off-by: Savinay Dharmappa <savinay.dharmappa@intel.com>