### PR TITLE
drivers: flash: w25qxxdv: Avoid locking when not threaded

### DIFF
--- a/drivers/flash/spi_flash_w25qxxdv.h
+++ b/drivers/flash/spi_flash_w25qxxdv.h
@@ -20,7 +20,9 @@ struct spi_flash_data {
 	struct spi_cs_control cs_ctrl;
 #endif /* CONFIG_SPI_FLASH_W25QXXDV_GPIO_SPI_CS */
 	struct spi_config spi_cfg;
+#if defined(CONFIG_MULTITHREADING)
 	struct k_sem sem;
+#endif /* CONFIG_MULTITHREADING */
 };
 
 


### PR DESCRIPTION
When using CONFIG_MULTITHREADING=n, the semaphore primitives are
non-functional and useless. Remove their usage when this option is
enabled.

Signed-off-by: Johannes Hutter <johannes@proglove.de>