### PR TITLE
net: pkt: Fix comment typo in word tailroom

### DIFF
--- a/subsys/net/ip/net_pkt.c
+++ b/subsys/net/ip/net_pkt.c
@@ -1415,7 +1415,7 @@ static inline struct net_buf *adjust_write_offset(struct net_pkt *pkt,
 			return frag;
 		}
 
-		/* Offset is equal to fragment length. If some tailtoom exists,
+		/* Offset is equal to fragment length. If some tailroom exists,
 		 * offset start from same fragment otherwise offset starts from
 		 * beginning of next fragment.
 		 */


### PR DESCRIPTION
Fix comment typo in word tailroom

Signed-off-by: Ruslan Mstoi <ruslan.mstoi@intel.com>