### PR TITLE
Refactor arm_mpu to use CMSIS directly

### DIFF
--- a/arch/arm/core/cortex_m/mpu/arm_mpu.c
+++ b/arch/arm/core/cortex_m/mpu/arm_mpu.c
@@ -248,7 +248,7 @@ void arm_core_mpu_enable(void)
 	/* Enable MPU and use the default memory map as a
 	 * background region for privileged software access.
 	 */
-	ARM_MPU_DEV->ctrl = ARM_MPU_ENABLE | ARM_MPU_PRIVDEFENA;
+	ARM_MPU_DEV->ctrl = MPU_CTRL_ENABLE_Msk | MPU_CTRL_PRIVDEFENA_Msk;
 }
 
 /**
@@ -475,7 +475,7 @@ static void _arm_mpu_config(void)
 	/* Enable MPU and use the default memory map as a
 	 * background region for privileged software access.
 	 */
-	ARM_MPU_DEV->ctrl = ARM_MPU_ENABLE | ARM_MPU_PRIVDEFENA;
+	ARM_MPU_DEV->ctrl = MPU_CTRL_ENABLE_Msk | MPU_CTRL_PRIVDEFENA_Msk;
 
 	/* Make sure that all the registers are set before proceeding */
 	__DSB();

--- a/arch/arm/core/cortex_m/mpu/arm_mpu.c
+++ b/arch/arm/core/cortex_m/mpu/arm_mpu.c
@@ -110,8 +110,8 @@ static void _region_init(u32_t index, u32_t region_addr,
 	/* Select the region you want to access */
 	ARM_MPU_DEV->rnr = index;
 	/* Configure the region */
-	ARM_MPU_DEV->rbar = (region_addr & REGION_BASE_ADDR_MASK)
-				| REGION_VALID | index;
+	ARM_MPU_DEV->rbar = (region_addr & MPU_RBAR_ADDR_Msk)
+				| MPU_RBAR_VALID_Msk | index;
 	ARM_MPU_DEV->rasr = region_attr | REGION_ENABLE;
 	SYS_LOG_DBG("[%d] 0x%08x 0x%08x", index, region_addr, region_attr);
 }
@@ -200,7 +200,7 @@ static inline int _is_in_region(u32_t r_index, u32_t start, u32_t size)
 	u32_t r_addr_end;
 
 	ARM_MPU_DEV->rnr = r_index;
-	r_addr_start = ARM_MPU_DEV->rbar & REGION_BASE_ADDR_MASK;
+	r_addr_start = ARM_MPU_DEV->rbar & MPU_RBAR_ADDR_Msk;
 	r_size_lshift = ((ARM_MPU_DEV->rasr & REGION_SIZE_MASK) >>
 			REGION_SIZE_OFFSET) + 1;
 	r_addr_end = r_addr_start + (1 << r_size_lshift) - 1;

--- a/arch/arm/core/cortex_m/mpu/arm_mpu.c
+++ b/arch/arm/core/cortex_m/mpu/arm_mpu.c
@@ -112,7 +112,7 @@ static void _region_init(u32_t index, u32_t region_addr,
 	/* Configure the region */
 	ARM_MPU_DEV->rbar = (region_addr & MPU_RBAR_ADDR_Msk)
 				| MPU_RBAR_VALID_Msk | index;
-	ARM_MPU_DEV->rasr = region_attr | REGION_ENABLE;
+	ARM_MPU_DEV->rasr = region_attr | MPU_RASR_ENABLE_Msk;
 	SYS_LOG_DBG("[%d] 0x%08x 0x%08x", index, region_addr, region_attr);
 }
 
@@ -184,7 +184,7 @@ static inline int _is_enabled_region(u32_t r_index)
 {
 	ARM_MPU_DEV->rnr = r_index;
 
-	return ARM_MPU_DEV->rasr & REGION_ENABLE_MASK;
+	return ARM_MPU_DEV->rasr & MPU_RASR_ENABLE_Msk;
 }
 
 /**
@@ -201,8 +201,8 @@ static inline int _is_in_region(u32_t r_index, u32_t start, u32_t size)
 
 	ARM_MPU_DEV->rnr = r_index;
 	r_addr_start = ARM_MPU_DEV->rbar & MPU_RBAR_ADDR_Msk;
-	r_size_lshift = ((ARM_MPU_DEV->rasr & REGION_SIZE_MASK) >>
-			REGION_SIZE_OFFSET) + 1;
+	r_size_lshift = ((ARM_MPU_DEV->rasr & MPU_RASR_SIZE_Msk) >>
+			MPU_RASR_SIZE_Pos) + 1;
 	r_addr_end = r_addr_start + (1 << r_size_lshift) - 1;
 
 	if (start >= r_addr_start && (start + size - 1) <= r_addr_end) {
@@ -223,7 +223,7 @@ static inline int _is_user_accessible_region(u32_t r_index, int write)
 	u32_t r_ap;
 
 	ARM_MPU_DEV->rnr = r_index;
-	r_ap = ARM_MPU_DEV->rasr & ACCESS_PERMS_MASK;
+	r_ap = ARM_MPU_DEV->rasr & MPU_RASR_AP_Msk;
 
 	/* always return true if this is the thread stack region */
 	if (_get_region_index_by_type(THREAD_STACK_REGION) == r_index) {
@@ -235,7 +235,7 @@ static inline int _is_user_accessible_region(u32_t r_index, int write)
 	}
 
 	/* For all user accessible permissions, their AP[1] bit is l */
-	return r_ap & (0x2 << ACCESS_PERMS_OFFSET);
+	return r_ap & (0x2 << MPU_RASR_AP_Pos);
 }
 
 /* ARM Core MPU Driver API Implementation for ARM MPU */

--- a/arch/arm/soc/arm/beetle/soc.h
+++ b/arch/arm/soc/arm/beetle/soc.h
@@ -96,6 +96,7 @@
 #include "soc_power.h"
 #include "soc_registers.h"
 #include "soc_pll.h"
+#include "soc_mpu.h"
 
 /* System Control Register (SYSCON) */
 #define __BEETLE_SYSCON ((volatile struct syscon *)_BEETLE_SYSCON_BASE)

--- a/arch/arm/soc/arm/beetle/soc_mpu.h
+++ b/arch/arm/soc/arm/beetle/soc_mpu.h
@@ -1,0 +1,71 @@
+/*
+ * Copyright (c) 2018 Arm Limited.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * @file
+ * @brief ARM MPU-related macro definitions.
+ *
+ * ARM MPU macro definitions required for SOCs
+ * which are not ARM CMSIS-compliant.
+ */
+
+#if defined(CONFIG_ARM_MPU)
+/* MPU Control Register Definitions */
+#define MPU_CTRL_PRIVDEFENA_Pos             2U                                            /*!< MPU CTRL: PRIVDEFENA Position */
+#define MPU_CTRL_PRIVDEFENA_Msk            (1UL << MPU_CTRL_PRIVDEFENA_Pos)               /*!< MPU CTRL: PRIVDEFENA Mask */
+
+#define MPU_CTRL_HFNMIENA_Pos               1U                                            /*!< MPU CTRL: HFNMIENA Position */
+#define MPU_CTRL_HFNMIENA_Msk              (1UL << MPU_CTRL_HFNMIENA_Pos)                 /*!< MPU CTRL: HFNMIENA Mask */
+
+#define MPU_CTRL_ENABLE_Pos                 0U                                            /*!< MPU CTRL: ENABLE Position */
+#define MPU_CTRL_ENABLE_Msk                (1UL /*<< MPU_CTRL_ENABLE_Pos*/)               /*!< MPU CTRL: ENABLE Mask */
+
+/* MPU Region Number Register Definitions */
+#define MPU_RNR_REGION_Pos                  0U                                            /*!< MPU RNR: REGION Position */
+#define MPU_RNR_REGION_Msk                 (0xFFUL /*<< MPU_RNR_REGION_Pos*/)             /*!< MPU RNR: REGION Mask */
+
+/* MPU Region Base Address Register Definitions */
+#define MPU_RBAR_ADDR_Pos                   5U                                            /*!< MPU RBAR: ADDR Position */
+#define MPU_RBAR_ADDR_Msk                  (0x7FFFFFFUL << MPU_RBAR_ADDR_Pos)             /*!< MPU RBAR: ADDR Mask */
+
+#define MPU_RBAR_VALID_Pos                  4U                                            /*!< MPU RBAR: VALID Position */
+#define MPU_RBAR_VALID_Msk                 (1UL << MPU_RBAR_VALID_Pos)                    /*!< MPU RBAR: VALID Mask */
+
+#define MPU_RBAR_REGION_Pos                 0U                                            /*!< MPU RBAR: REGION Position */
+#define MPU_RBAR_REGION_Msk                (0xFUL /*<< MPU_RBAR_REGION_Pos*/)             /*!< MPU RBAR: REGION Mask */
+
+/* MPU Region Attribute and Size Register Definitions */
+#define MPU_RASR_ATTRS_Pos                 16U                                            /*!< MPU RASR: MPU Region Attribute field Position */
+#define MPU_RASR_ATTRS_Msk                 (0xFFFFUL << MPU_RASR_ATTRS_Pos)               /*!< MPU RASR: MPU Region Attribute field Mask */
+
+#define MPU_RASR_XN_Pos                    28U                                            /*!< MPU RASR: ATTRS.XN Position */
+#define MPU_RASR_XN_Msk                    (1UL << MPU_RASR_XN_Pos)                       /*!< MPU RASR: ATTRS.XN Mask */
+
+#define MPU_RASR_AP_Pos                    24U                                            /*!< MPU RASR: ATTRS.AP Position */
+#define MPU_RASR_AP_Msk                    (0x7UL << MPU_RASR_AP_Pos)                     /*!< MPU RASR: ATTRS.AP Mask */
+
+#define MPU_RASR_TEX_Pos                   19U                                            /*!< MPU RASR: ATTRS.TEX Position */
+#define MPU_RASR_TEX_Msk                   (0x7UL << MPU_RASR_TEX_Pos)                    /*!< MPU RASR: ATTRS.TEX Mask */
+
+#define MPU_RASR_S_Pos                     18U                                            /*!< MPU RASR: ATTRS.S Position */
+#define MPU_RASR_S_Msk                     (1UL << MPU_RASR_S_Pos)                        /*!< MPU RASR: ATTRS.S Mask */
+
+#define MPU_RASR_C_Pos                     17U                                            /*!< MPU RASR: ATTRS.C Position */
+#define MPU_RASR_C_Msk                     (1UL << MPU_RASR_C_Pos)                        /*!< MPU RASR: ATTRS.C Mask */
+
+#define MPU_RASR_B_Pos                     16U                                            /*!< MPU RASR: ATTRS.B Position */
+#define MPU_RASR_B_Msk                     (1UL << MPU_RASR_B_Pos)                        /*!< MPU RASR: ATTRS.B Mask */
+
+#define MPU_RASR_SRD_Pos                    8U                                            /*!< MPU RASR: Sub-Region Disable Position */
+#define MPU_RASR_SRD_Msk                   (0xFFUL << MPU_RASR_SRD_Pos)                   /*!< MPU RASR: Sub-Region Disable Mask */
+
+#define MPU_RASR_SIZE_Pos                   1U                                            /*!< MPU RASR: Region Size Field Position */
+#define MPU_RASR_SIZE_Msk                  (0x1FUL << MPU_RASR_SIZE_Pos)                  /*!< MPU RASR: Region Size Field Mask */
+
+#define MPU_RASR_ENABLE_Pos                 0U                                            /*!< MPU RASR: Region enable bit Position */
+#define MPU_RASR_ENABLE_Msk                (1UL /*<< MPU_RASR_ENABLE_Pos*/)               /*!< MPU RASR: Region enable bit Disable Mask */
+
+#endif /* CONFIG_ARM_MPU */

--- a/include/arch/arm/arch.h
+++ b/include/arch/arm/arch.h
@@ -247,12 +247,12 @@ extern "C" {
 #ifndef _ASMLANGUAGE
 #include <arch/arm/cortex_m/mpu/arm_mpu.h>
 
-#define K_MEM_PARTITION_P_NA_U_NA	(NO_ACCESS | NOT_EXEC)
-#define K_MEM_PARTITION_P_RW_U_RW	(P_RW_U_RW | NOT_EXEC)
-#define K_MEM_PARTITION_P_RW_U_RO	(P_RW_U_RO | NOT_EXEC)
-#define K_MEM_PARTITION_P_RW_U_NA	(P_RW_U_NA | NOT_EXEC)
-#define K_MEM_PARTITION_P_RO_U_RO	(P_RO_U_RO | NOT_EXEC)
-#define K_MEM_PARTITION_P_RO_U_NA	(P_RO_U_NA | NOT_EXEC)
+#define K_MEM_PARTITION_P_NA_U_NA	(NO_ACCESS | MPU_RASR_XN_Msk)
+#define K_MEM_PARTITION_P_RW_U_RW	(P_RW_U_RW | MPU_RASR_XN_Msk)
+#define K_MEM_PARTITION_P_RW_U_RO	(P_RW_U_RO | MPU_RASR_XN_Msk)
+#define K_MEM_PARTITION_P_RW_U_NA	(P_RW_U_NA | MPU_RASR_XN_Msk)
+#define K_MEM_PARTITION_P_RO_U_RO	(P_RO_U_RO | MPU_RASR_XN_Msk)
+#define K_MEM_PARTITION_P_RO_U_NA	(P_RO_U_NA | MPU_RASR_XN_Msk)
 
 /* Execution-allowed attributes */
 #define K_MEM_PARTITION_P_RWX_U_RWX	(P_RW_U_RW)
@@ -274,7 +274,7 @@ extern "C" {
 		__is_writable__; \
 	})
 #define K_MEM_PARTITION_IS_EXECUTABLE(attr) \
-	(!((attr) & (NOT_EXEC)))
+	(!((attr) & (MPU_RASR_XN_Msk)))
 
 #endif /* _ASMLANGUAGE */
 #define _ARCH_MEM_PARTITION_ALIGN_CHECK(start, size) \

--- a/include/arch/arm/cortex_m/mpu/arm_mpu.h
+++ b/include/arch/arm/cortex_m/mpu/arm_mpu.h
@@ -36,22 +36,6 @@ struct arm_mpu {
 #define ARM_MPU_BASE	0xE000ED90
 
 /* ARM MPU RASR Register */
-/* Region enable bit offset */
-#define REGION_ENABLE_OFFSET	(0)
-/* Region enable bit mask */
-#define REGION_ENABLE_MASK	(0x1 << REGION_ENABLE_OFFSET)
-/* Region size bit offset */
-#define REGION_SIZE_OFFSET	(1)
-/* Region size bit mask */
-#define REGION_SIZE_MASK	(0x1F << REGION_SIZE_OFFSET)
-/* Access permissions bit offset */
-#define ACCESS_PERMS_OFFSET	(24)
-/* Access permissions bit mask */
-#define ACCESS_PERMS_MASK	(0x7 << ACCESS_PERMS_OFFSET)
-
-
-/* eXecute Never */
-#define NOT_EXEC        (0x1 << 28)
 
 /* Privileged No Access, Unprivileged No Access */
 #define NO_ACCESS	(0x0 << 24)
@@ -90,10 +74,10 @@ struct arm_mpu {
 /* Some helper defines for common regions */
 #define REGION_USER_RAM_ATTR(size) \
 		(NORMAL_OUTER_INNER_NON_CACHEABLE_NON_SHAREABLE | \
-		 NOT_EXEC | size | FULL_ACCESS)
+		 MPU_RASR_XN_Msk | size | FULL_ACCESS)
 #define REGION_RAM_ATTR(size) \
 		(NORMAL_OUTER_INNER_NON_CACHEABLE_NON_SHAREABLE | \
-		 NOT_EXEC | size | P_RW_U_NA)
+		 MPU_RASR_XN_Msk | size | P_RW_U_NA)
 #if defined(CONFIG_MPU_ALLOW_FLASH_WRITE)
 #define REGION_FLASH_ATTR(size) \
 		(NORMAL_OUTER_INNER_NON_CACHEABLE_NON_SHAREABLE | size | \
@@ -142,8 +126,6 @@ struct arm_mpu {
 #define REGION_1G       (0x1D << 1)
 #define REGION_2G       (0x1E << 1)
 #define REGION_4G       (0x1F << 1)
-
-#define REGION_ENABLE	(1 << 0)
 
 /* Region definition data structure */
 struct arm_mpu_region {

--- a/include/arch/arm/cortex_m/mpu/arm_mpu.h
+++ b/include/arch/arm/cortex_m/mpu/arm_mpu.h
@@ -35,11 +35,6 @@ struct arm_mpu {
 
 #define ARM_MPU_BASE	0xE000ED90
 
-#define REGION_VALID	(1 << 4)
-/* ARM MPU RBAR Register */
-/* Region base address mask */
-#define REGION_BASE_ADDR_MASK	0xFFFFFFE0
-
 /* ARM MPU RASR Register */
 /* Region enable bit offset */
 #define REGION_ENABLE_OFFSET	(0)

--- a/include/arch/arm/cortex_m/mpu/arm_mpu.h
+++ b/include/arch/arm/cortex_m/mpu/arm_mpu.h
@@ -35,14 +35,6 @@ struct arm_mpu {
 
 #define ARM_MPU_BASE	0xE000ED90
 
-/* ARM MPU CTRL Register */
-/* Enable MPU */
-#define ARM_MPU_ENABLE		(1 << 0)
-/* Enable MPU during hard fault, NMI, and FAULTMASK handlers */
-#define ARM_MPU_HFNMIENA	(1 << 1)
-/* Enable privileged software access to the default memory map */
-#define ARM_MPU_PRIVDEFENA	(1 << 2)
-
 #define REGION_VALID	(1 << 4)
 /* ARM MPU RBAR Register */
 /* Region base address mask */


### PR DESCRIPTION
Initial PR towards implementing #8018.
This PR refactors the ARM MPU implementation to use the CMSIS macro definitions directly.