### PR TITLE
dts/arm/st: Fix OTG_FS endpoint number for STM32F4 SoCs

### DIFF
--- a/dts/arm/st/stm32f412.dtsi
+++ b/dts/arm/st/stm32f412.dtsi
@@ -129,5 +129,9 @@
 				label = "PWM_14";
 			};
 		};
+
+		usbotg_fs: usb@50000000 {
+			num-bidir-endpoints = <6>;
+		};
 	};
 };

--- a/dts/arm/st/stm32f413.dtsi
+++ b/dts/arm/st/stm32f413.dtsi
@@ -161,5 +161,9 @@
 			status = "disabled";
 			label = "UART_10";
 		};
+
+		usbotg_fs: usb@50000000 {
+			num-bidir-endpoints = <6>;
+		};
 	};
 };

--- a/dts/arm/st/stm32f446.dtsi
+++ b/dts/arm/st/stm32f446.dtsi
@@ -6,3 +6,10 @@
 
 #include <st/stm32f401.dtsi>
 
+/ {
+	soc {
+		usbotg_fs: usb@50000000 {
+			num-bidir-endpoints = <6>;
+		};
+	};
+};

--- a/dts/arm/st/stm32f469.dtsi
+++ b/dts/arm/st/stm32f469.dtsi
@@ -5,3 +5,11 @@
  */
 
 #include <st/stm32f429.dtsi>
+
+/ {
+	soc {
+		usbotg_fs: usb@50000000 {
+			num-bidir-endpoints = <6>;
+		};
+	};
+};


### PR DESCRIPTION
STM32F412/413/446/469 SoCs have 6 bidirectional endpoints
according to the reference manuals RM0402, RM0430,
RM0390 and RM0386.

Signed-off-by: Yannis Damigos <giannis.damigos@gmail.com>