### PR TITLE
Arch arm v8m mpu remove hal

### DIFF
--- a/arch/arm/soc/arm/beetle/soc_mpu.h
+++ b/arch/arm/soc/arm/beetle/soc_mpu.h
@@ -11,61 +11,86 @@
  * ARM MPU macro definitions required for SOCs
  * which are not ARM CMSIS-compliant.
  */
+#include <stdint.h>
 
 #if defined(CONFIG_ARM_MPU)
+
+#define     __IM     volatile const
+#define     __OM     volatile
+#define     __IOM    volatile
+
+/**
+  \brief  Structure type to access the Memory Protection Unit (MPU).
+ */
+typedef struct {
+  __IM  u32_t TYPE;
+  __IOM u32_t CTRL;
+  __IOM u32_t RNR;
+  __IOM u32_t RBAR;
+  __IOM u32_t RASR;
+  __IOM u32_t RBAR_A1;
+  __IOM u32_t RASR_A1;
+  __IOM u32_t RBAR_A2;
+  __IOM u32_t RASR_A2;
+  __IOM u32_t RBAR_A3;
+  __IOM u32_t RASR_A3;
+} MPU_Type;
+
+#define MPU               ((MPU_Type       *)0xE000ED90UL)
+
 /* MPU Control Register Definitions */
-#define MPU_CTRL_PRIVDEFENA_Pos             2U                                            /*!< MPU CTRL: PRIVDEFENA Position */
-#define MPU_CTRL_PRIVDEFENA_Msk            (1UL << MPU_CTRL_PRIVDEFENA_Pos)               /*!< MPU CTRL: PRIVDEFENA Mask */
+#define MPU_CTRL_PRIVDEFENA_Pos             2U
+#define MPU_CTRL_PRIVDEFENA_Msk            (1UL << MPU_CTRL_PRIVDEFENA_Pos)
 
-#define MPU_CTRL_HFNMIENA_Pos               1U                                            /*!< MPU CTRL: HFNMIENA Position */
-#define MPU_CTRL_HFNMIENA_Msk              (1UL << MPU_CTRL_HFNMIENA_Pos)                 /*!< MPU CTRL: HFNMIENA Mask */
+#define MPU_CTRL_HFNMIENA_Pos               1U
+#define MPU_CTRL_HFNMIENA_Msk              (1UL << MPU_CTRL_HFNMIENA_Pos)
 
-#define MPU_CTRL_ENABLE_Pos                 0U                                            /*!< MPU CTRL: ENABLE Position */
-#define MPU_CTRL_ENABLE_Msk                (1UL /*<< MPU_CTRL_ENABLE_Pos*/)               /*!< MPU CTRL: ENABLE Mask */
+#define MPU_CTRL_ENABLE_Pos                 0U
+#define MPU_CTRL_ENABLE_Msk                (1UL /*<< MPU_CTRL_ENABLE_Pos*/)
 
 /* MPU Region Number Register Definitions */
-#define MPU_RNR_REGION_Pos                  0U                                            /*!< MPU RNR: REGION Position */
-#define MPU_RNR_REGION_Msk                 (0xFFUL /*<< MPU_RNR_REGION_Pos*/)             /*!< MPU RNR: REGION Mask */
+#define MPU_RNR_REGION_Pos                  0U
+#define MPU_RNR_REGION_Msk                 (0xFFUL /*<< MPU_RNR_REGION_Pos*/)
 
 /* MPU Region Base Address Register Definitions */
-#define MPU_RBAR_ADDR_Pos                   5U                                            /*!< MPU RBAR: ADDR Position */
-#define MPU_RBAR_ADDR_Msk                  (0x7FFFFFFUL << MPU_RBAR_ADDR_Pos)             /*!< MPU RBAR: ADDR Mask */
+#define MPU_RBAR_ADDR_Pos                   5U
+#define MPU_RBAR_ADDR_Msk                  (0x7FFFFFFUL << MPU_RBAR_ADDR_Pos)
 
-#define MPU_RBAR_VALID_Pos                  4U                                            /*!< MPU RBAR: VALID Position */
-#define MPU_RBAR_VALID_Msk                 (1UL << MPU_RBAR_VALID_Pos)                    /*!< MPU RBAR: VALID Mask */
+#define MPU_RBAR_VALID_Pos                  4U
+#define MPU_RBAR_VALID_Msk                 (1UL << MPU_RBAR_VALID_Pos)
 
-#define MPU_RBAR_REGION_Pos                 0U                                            /*!< MPU RBAR: REGION Position */
-#define MPU_RBAR_REGION_Msk                (0xFUL /*<< MPU_RBAR_REGION_Pos*/)             /*!< MPU RBAR: REGION Mask */
+#define MPU_RBAR_REGION_Pos                 0U
+#define MPU_RBAR_REGION_Msk                (0xFUL /*<< MPU_RBAR_REGION_Pos*/)
 
 /* MPU Region Attribute and Size Register Definitions */
-#define MPU_RASR_ATTRS_Pos                 16U                                            /*!< MPU RASR: MPU Region Attribute field Position */
-#define MPU_RASR_ATTRS_Msk                 (0xFFFFUL << MPU_RASR_ATTRS_Pos)               /*!< MPU RASR: MPU Region Attribute field Mask */
+#define MPU_RASR_ATTRS_Pos                 16U
+#define MPU_RASR_ATTRS_Msk                 (0xFFFFUL << MPU_RASR_ATTRS_Pos)
 
-#define MPU_RASR_XN_Pos                    28U                                            /*!< MPU RASR: ATTRS.XN Position */
-#define MPU_RASR_XN_Msk                    (1UL << MPU_RASR_XN_Pos)                       /*!< MPU RASR: ATTRS.XN Mask */
+#define MPU_RASR_XN_Pos                    28U
+#define MPU_RASR_XN_Msk                    (1UL << MPU_RASR_XN_Pos)
 
-#define MPU_RASR_AP_Pos                    24U                                            /*!< MPU RASR: ATTRS.AP Position */
-#define MPU_RASR_AP_Msk                    (0x7UL << MPU_RASR_AP_Pos)                     /*!< MPU RASR: ATTRS.AP Mask */
+#define MPU_RASR_AP_Pos                    24U
+#define MPU_RASR_AP_Msk                    (0x7UL << MPU_RASR_AP_Pos)
 
-#define MPU_RASR_TEX_Pos                   19U                                            /*!< MPU RASR: ATTRS.TEX Position */
-#define MPU_RASR_TEX_Msk                   (0x7UL << MPU_RASR_TEX_Pos)                    /*!< MPU RASR: ATTRS.TEX Mask */
+#define MPU_RASR_TEX_Pos                   19U
+#define MPU_RASR_TEX_Msk                   (0x7UL << MPU_RASR_TEX_Pos)
 
-#define MPU_RASR_S_Pos                     18U                                            /*!< MPU RASR: ATTRS.S Position */
-#define MPU_RASR_S_Msk                     (1UL << MPU_RASR_S_Pos)                        /*!< MPU RASR: ATTRS.S Mask */
+#define MPU_RASR_S_Pos                     18U
+#define MPU_RASR_S_Msk                     (1UL << MPU_RASR_S_Pos)
 
-#define MPU_RASR_C_Pos                     17U                                            /*!< MPU RASR: ATTRS.C Position */
-#define MPU_RASR_C_Msk                     (1UL << MPU_RASR_C_Pos)                        /*!< MPU RASR: ATTRS.C Mask */
+#define MPU_RASR_C_Pos                     17U
+#define MPU_RASR_C_Msk                     (1UL << MPU_RASR_C_Pos)
 
-#define MPU_RASR_B_Pos                     16U                                            /*!< MPU RASR: ATTRS.B Position */
-#define MPU_RASR_B_Msk                     (1UL << MPU_RASR_B_Pos)                        /*!< MPU RASR: ATTRS.B Mask */
+#define MPU_RASR_B_Pos                     16U
+#define MPU_RASR_B_Msk                     (1UL << MPU_RASR_B_Pos)
 
-#define MPU_RASR_SRD_Pos                    8U                                            /*!< MPU RASR: Sub-Region Disable Position */
-#define MPU_RASR_SRD_Msk                   (0xFFUL << MPU_RASR_SRD_Pos)                   /*!< MPU RASR: Sub-Region Disable Mask */
+#define MPU_RASR_SRD_Pos                    8U
+#define MPU_RASR_SRD_Msk                   (0xFFUL << MPU_RASR_SRD_Pos)
 
-#define MPU_RASR_SIZE_Pos                   1U                                            /*!< MPU RASR: Region Size Field Position */
-#define MPU_RASR_SIZE_Msk                  (0x1FUL << MPU_RASR_SIZE_Pos)                  /*!< MPU RASR: Region Size Field Mask */
+#define MPU_RASR_SIZE_Pos                   1U
+#define MPU_RASR_SIZE_Msk                  (0x1FUL << MPU_RASR_SIZE_Pos)
 
-#define MPU_RASR_ENABLE_Pos                 0U                                            /*!< MPU RASR: Region enable bit Position */
-#define MPU_RASR_ENABLE_Msk                (1UL /*<< MPU_RASR_ENABLE_Pos*/)               /*!< MPU RASR: Region enable bit Disable Mask */
+#define MPU_RASR_ENABLE_Pos                 0U
+#define MPU_RASR_ENABLE_Msk                (1UL /*<< MPU_RASR_ENABLE_Pos*/)
 
 #endif /* CONFIG_ARM_MPU */

--- a/include/arch/arm/arch.h
+++ b/include/arch/arm/arch.h
@@ -258,36 +258,6 @@ extern "C" {
 #ifdef CONFIG_ARM_MPU
 #ifndef _ASMLANGUAGE
 #include <arch/arm/cortex_m/mpu/arm_mpu.h>
-
-#define K_MEM_PARTITION_P_NA_U_NA	(NO_ACCESS | MPU_RASR_XN_Msk)
-#define K_MEM_PARTITION_P_RW_U_RW	(P_RW_U_RW | MPU_RASR_XN_Msk)
-#define K_MEM_PARTITION_P_RW_U_RO	(P_RW_U_RO | MPU_RASR_XN_Msk)
-#define K_MEM_PARTITION_P_RW_U_NA	(P_RW_U_NA | MPU_RASR_XN_Msk)
-#define K_MEM_PARTITION_P_RO_U_RO	(P_RO_U_RO | MPU_RASR_XN_Msk)
-#define K_MEM_PARTITION_P_RO_U_NA	(P_RO_U_NA | MPU_RASR_XN_Msk)
-
-/* Execution-allowed attributes */
-#define K_MEM_PARTITION_P_RWX_U_RWX	(P_RW_U_RW)
-#define K_MEM_PARTITION_P_RWX_U_RX	(P_RW_U_RO)
-#define K_MEM_PARTITION_P_RX_U_RX	(P_RO_U_RO)
-
-#define K_MEM_PARTITION_IS_WRITABLE(attr) \
-	({ \
-		int __is_writable__; \
-		switch (attr) { \
-		case P_RW_U_RW: \
-		case P_RW_U_RO: \
-		case P_RW_U_NA: \
-			__is_writable__ = 1; \
-			break; \
-		default: \
-			__is_writable__ = 0; \
-		} \
-		__is_writable__; \
-	})
-#define K_MEM_PARTITION_IS_EXECUTABLE(attr) \
-	(!((attr) & (MPU_RASR_XN_Msk)))
-
 #endif /* _ASMLANGUAGE */
 #define _ARCH_MEM_PARTITION_ALIGN_CHECK(start, size) \
 	BUILD_ASSERT_MSG(!(((size) & ((size) - 1))) && (size) >= 32 && \

--- a/include/arch/arm/cortex_m/mpu/arm_mpu.h
+++ b/include/arch/arm/cortex_m/mpu/arm_mpu.h
@@ -9,33 +9,6 @@
 #include <arch/arm/cortex_m/mpu/arm_core_mpu_dev.h>
 #include <arch/arm/cortex_m/cmsis.h>
 
-struct arm_mpu {
-	/* 0xE000ED90 MPU Type Register */
-	volatile u32_t type;
-	/* 0xE000ED94 MPU Control Register */
-	volatile u32_t ctrl;
-	/* 0xE000ED98 MPU Region Number Register */
-	volatile u32_t rnr;
-	/* 0xE000ED9C MPU Region Base Address Register */
-	volatile u32_t rbar;
-	/* 0xE000EDA0 MPU Region Attribute and Size Register */
-	volatile u32_t rasr;
-	/* 0xE000EDA4 Alias of RBAR */
-	volatile u32_t rbar_a1;
-	/* 0xE000EDA8 Alias of RASR */
-	volatile u32_t rasr_a1;
-	/* 0xE000EDAC Alias of RBAR */
-	volatile u32_t rbar_a2;
-	/* 0xE000EDB0 Alias of RASR */
-	volatile u32_t rasr_a2;
-	/* 0xE000EDB4 Alias of RBAR */
-	volatile u32_t rbar_a3;
-	/* 0xE000EDB8 Alias of RASR */
-	volatile u32_t rasr_a3;
-};
-
-#define ARM_MPU_BASE	0xE000ED90
-
 /* ARM MPU RASR Register */
 
 /* Privileged No Access, Unprivileged No Access */

--- a/include/arch/arm/cortex_m/mpu/arm_mpu.h
+++ b/include/arch/arm/cortex_m/mpu/arm_mpu.h
@@ -12,38 +12,44 @@
 /* ARM MPU RASR Register */
 
 /* Privileged No Access, Unprivileged No Access */
-#define NO_ACCESS	(0x0 << 24)
+#define NO_ACCESS	((0x0 << MPU_RASR_AP_Pos) & MPU_RASR_AP_Msk)
 /* Privileged No Access, Unprivileged No Access */
-#define P_NA_U_NA	(0x0 << 24)
+#define P_NA_U_NA	((0x0 << MPU_RASR_AP_Pos) & MPU_RASR_AP_Msk)
 /* Privileged Read Write, Unprivileged No Access */
-#define P_RW_U_NA	(0x1 << 24)
+#define P_RW_U_NA	((0x1 << MPU_RASR_AP_Pos) & MPU_RASR_AP_Msk)
 /* Privileged Read Write, Unprivileged Read Only */
-#define P_RW_U_RO	(0x2 << 24)
+#define P_RW_U_RO	((0x2 << MPU_RASR_AP_Pos) & MPU_RASR_AP_Msk)
 /* Privileged Read Write, Unprivileged Read Write */
-#define P_RW_U_RW	(0x3 << 24)
+#define P_RW_U_RW	((0x3 << MPU_RASR_AP_Pos) & MPU_RASR_AP_Msk)
 /* Privileged Read Write, Unprivileged Read Write */
-#define FULL_ACCESS	(0x3 << 24)
+#define FULL_ACCESS	((0x3 << MPU_RASR_AP_Pos) & MPU_RASR_AP_Msk)
 /* Privileged Read Only, Unprivileged No Access */
-#define P_RO_U_NA	(0x5 << 24)
+#define P_RO_U_NA	((0x5 << MPU_RASR_AP_Pos) & MPU_RASR_AP_Msk)
 /* Privileged Read Only, Unprivileged Read Only */
-#define P_RO_U_RO	(0x6 << 24)
+#define P_RO_U_RO	((0x6 << MPU_RASR_AP_Pos) & MPU_RASR_AP_Msk)
 /* Privileged Read Only, Unprivileged Read Only */
-#define RO		(0x7 << 24)
+#define RO		((0x7 << MPU_RASR_AP_Pos) & MPU_RASR_AP_Msk)
 
-#define STRONGLY_ORDERED_SHAREABLE			(1 << 18)
-#define DEVICE_SHAREABLE				((1 << 16) | (1 << 18))
-#define NORMAL_OUTER_INNER_WRITE_THROUGH_SHAREABLE	((1 << 17) | (1 << 18))
-#define NORMAL_OUTER_INNER_WRITE_THROUGH_NON_SHAREABLE	(1 << 17)
+/* The following definitions are for internal use in this file. */
+#define STRONGLY_ORDERED_SHAREABLE      MPU_RASR_S_Msk
+#define DEVICE_SHAREABLE                (MPU_RASR_B_Msk | MPU_RASR_S_Msk)
+#define NORMAL_OUTER_INNER_WRITE_THROUGH_SHAREABLE \
+		(MPU_RASR_C_Msk | MPU_RASR_S_Msk)
+#define NORMAL_OUTER_INNER_WRITE_THROUGH_NON_SHAREABLE	MPU_RASR_C_Msk
 #define NORMAL_OUTER_INNER_WRITE_BACK_SHAREABLE	\
-				((1 << 17) | (1 << 16) | (1 << 18))
-#define NORMAL_OUTER_INNER_WRITE_BACK_NON_SHAREABLE	((1 << 17) | (1 << 16))
-#define NORMAL_OUTER_INNER_NON_CACHEABLE_SHAREABLE	((1 << 19) | (1 << 18))
-#define NORMAL_OUTER_INNER_NON_CACHEABLE_NON_SHAREABLE	(1 << 19)
+		(MPU_RASR_C_Msk | MPU_RASR_B_Msk | MPU_RASR_S_Msk)
+#define NORMAL_OUTER_INNER_WRITE_BACK_NON_SHAREABLE \
+		(MPU_RASR_C_Msk | MPU_RASR_B_Msk)
+#define NORMAL_OUTER_INNER_NON_CACHEABLE_SHAREABLE \
+		((1 << MPU_RASR_TEX_Pos) | MPU_RASR_S_Msk)
+#define NORMAL_OUTER_INNER_NON_CACHEABLE_NON_SHAREABLE \
+		(1 << MPU_RASR_TEX_Pos)
 #define NORMAL_OUTER_INNER_WRITE_BACK_WRITE_READ_ALLOCATE_SHAREABLE \
-				((1 << 19) | (1 << 17) | (1 << 16) | (1 << 18))
+	((1 << MPU_RASR_TEX_Pos) |\
+	 MPU_RASR_C_Msk | MPU_RASR_B_Msk | MPU_RASR_S_Msk)
 #define NORMAL_OUTER_INNER_WRITE_BACK_WRITE_READ_ALLOCATE_NONSHAREABLE \
-				((1 << 19) | (1 << 17) | (1 << 18))
-#define DEVICE_NON_SHAREABLE				(2 << 19)
+	((1 << MPU_RASR_TEX_Pos) | MPU_RASR_C_Msk | MPU_RASR_S_Msk)
+#define DEVICE_NON_SHAREABLE            (2 << MPU_RASR_TEX_Pos)
 
 /* Some helper defines for common regions */
 #define REGION_USER_RAM_ATTR(size) \
@@ -63,43 +69,43 @@
 #define REGION_PPB_ATTR(size) (STRONGLY_ORDERED_SHAREABLE | size | P_RW_U_NA)
 #define REGION_IO_ATTR(size) (DEVICE_NON_SHAREABLE | size | P_RW_U_NA)
 
-#define SUB_REGION_0_DISABLED	(0x01 << 8)
-#define SUB_REGION_1_DISABLED	(0x02 << 8)
-#define SUB_REGION_2_DISABLED	(0x04 << 8)
-#define SUB_REGION_3_DISABLED	(0x08 << 8)
-#define SUB_REGION_4_DISABLED	(0x10 << 8)
-#define SUB_REGION_5_DISABLED	(0x20 << 8)
-#define SUB_REGION_6_DISABLED	(0x40 << 8)
-#define SUB_REGION_7_DISABLED	(0x80 << 8)
+#define SUB_REGION_0_DISABLED	((0x01 << MPU_RASR_SRD_Pos) & MPU_RASR_SRD_Msk)
+#define SUB_REGION_1_DISABLED	((0x02 << MPU_RASR_SRD_Pos) & MPU_RASR_SRD_Msk)
+#define SUB_REGION_2_DISABLED	((0x04 << MPU_RASR_SRD_Pos) & MPU_RASR_SRD_Msk)
+#define SUB_REGION_3_DISABLED	((0x08 << MPU_RASR_SRD_Pos) & MPU_RASR_SRD_Msk)
+#define SUB_REGION_4_DISABLED	((0x10 << MPU_RASR_SRD_Pos) & MPU_RASR_SRD_Msk)
+#define SUB_REGION_5_DISABLED	((0x20 << MPU_RASR_SRD_Pos) & MPU_RASR_SRD_Msk)
+#define SUB_REGION_6_DISABLED	((0x40 << MPU_RASR_SRD_Pos) & MPU_RASR_SRD_Msk)
+#define SUB_REGION_7_DISABLED	((0x80 << MPU_RASR_SRD_Pos) & MPU_RASR_SRD_Msk)
 
-#define REGION_32B      (0x04 << 1)
-#define REGION_64B      (0x05 << 1)
-#define REGION_128B     (0x06 << 1)
-#define REGION_256B     (0x07 << 1)
-#define REGION_512B     (0x08 << 1)
-#define REGION_1K       (0x09 << 1)
-#define REGION_2K       (0x0A << 1)
-#define REGION_4K       (0x0B << 1)
-#define REGION_8K       (0x0C << 1)
-#define REGION_16K      (0x0D << 1)
-#define REGION_32K      (0x0E << 1)
-#define REGION_64K      (0x0F << 1)
-#define REGION_128K     (0x10 << 1)
-#define REGION_256K     (0x11 << 1)
-#define REGION_512K     (0x12 << 1)
-#define REGION_1M       (0x13 << 1)
-#define REGION_2M       (0x14 << 1)
-#define REGION_4M       (0x15 << 1)
-#define REGION_8M       (0x16 << 1)
-#define REGION_16M      (0x17 << 1)
-#define REGION_32M      (0x18 << 1)
-#define REGION_64M      (0x19 << 1)
-#define REGION_128M     (0x1A << 1)
-#define REGION_256M     (0x1B << 1)
-#define REGION_512M     (0x1C << 1)
-#define REGION_1G       (0x1D << 1)
-#define REGION_2G       (0x1E << 1)
-#define REGION_4G       (0x1F << 1)
+#define REGION_32B      ((0x04 << MPU_RASR_SIZE_Pos) & MPU_RASR_SIZE_Msk)
+#define REGION_64B      ((0x05 << MPU_RASR_SIZE_Pos) & MPU_RASR_SIZE_Msk)
+#define REGION_128B     ((0x06 << MPU_RASR_SIZE_Pos) & MPU_RASR_SIZE_Msk)
+#define REGION_256B     ((0x07 << MPU_RASR_SIZE_Pos) & MPU_RASR_SIZE_Msk)
+#define REGION_512B     ((0x08 << MPU_RASR_SIZE_Pos) & MPU_RASR_SIZE_Msk)
+#define REGION_1K       ((0x09 << MPU_RASR_SIZE_Pos) & MPU_RASR_SIZE_Msk)
+#define REGION_2K       ((0x0A << MPU_RASR_SIZE_Pos) & MPU_RASR_SIZE_Msk)
+#define REGION_4K       ((0x0B << MPU_RASR_SIZE_Pos) & MPU_RASR_SIZE_Msk)
+#define REGION_8K       ((0x0C << MPU_RASR_SIZE_Pos) & MPU_RASR_SIZE_Msk)
+#define REGION_16K      ((0x0D << MPU_RASR_SIZE_Pos) & MPU_RASR_SIZE_Msk)
+#define REGION_32K      ((0x0E << MPU_RASR_SIZE_Pos) & MPU_RASR_SIZE_Msk)
+#define REGION_64K      ((0x0F << MPU_RASR_SIZE_Pos) & MPU_RASR_SIZE_Msk)
+#define REGION_128K     ((0x10 << MPU_RASR_SIZE_Pos) & MPU_RASR_SIZE_Msk)
+#define REGION_256K     ((0x11 << MPU_RASR_SIZE_Pos) & MPU_RASR_SIZE_Msk)
+#define REGION_512K     ((0x12 << MPU_RASR_SIZE_Pos) & MPU_RASR_SIZE_Msk)
+#define REGION_1M       ((0x13 << MPU_RASR_SIZE_Pos) & MPU_RASR_SIZE_Msk)
+#define REGION_2M       ((0x14 << MPU_RASR_SIZE_Pos) & MPU_RASR_SIZE_Msk)
+#define REGION_4M       ((0x15 << MPU_RASR_SIZE_Pos) & MPU_RASR_SIZE_Msk)
+#define REGION_8M       ((0x16 << MPU_RASR_SIZE_Pos) & MPU_RASR_SIZE_Msk)
+#define REGION_16M      ((0x17 << MPU_RASR_SIZE_Pos) & MPU_RASR_SIZE_Msk)
+#define REGION_32M      ((0x18 << MPU_RASR_SIZE_Pos) & MPU_RASR_SIZE_Msk)
+#define REGION_64M      ((0x19 << MPU_RASR_SIZE_Pos) & MPU_RASR_SIZE_Msk)
+#define REGION_128M     ((0x1A << MPU_RASR_SIZE_Pos) & MPU_RASR_SIZE_Msk)
+#define REGION_256M     ((0x1B << MPU_RASR_SIZE_Pos) & MPU_RASR_SIZE_Msk)
+#define REGION_512M     ((0x1C << MPU_RASR_SIZE_Pos) & MPU_RASR_SIZE_Msk)
+#define REGION_1G       ((0x1D << MPU_RASR_SIZE_Pos) & MPU_RASR_SIZE_Msk)
+#define REGION_2G       ((0x1E << MPU_RASR_SIZE_Pos) & MPU_RASR_SIZE_Msk)
+#define REGION_4G       ((0x1F << MPU_RASR_SIZE_Pos) & MPU_RASR_SIZE_Msk)
 
 /* Region definition data structure */
 struct arm_mpu_region {

--- a/include/arch/arm/cortex_m/mpu/arm_mpu.h
+++ b/include/arch/arm/cortex_m/mpu/arm_mpu.h
@@ -9,120 +9,46 @@
 #include <arch/arm/cortex_m/mpu/arm_core_mpu_dev.h>
 #include <arch/arm/cortex_m/cmsis.h>
 
-/* ARM MPU RASR Register */
-
-/* Privileged No Access, Unprivileged No Access */
-#define NO_ACCESS	((0x0 << MPU_RASR_AP_Pos) & MPU_RASR_AP_Msk)
-/* Privileged No Access, Unprivileged No Access */
-#define P_NA_U_NA	((0x0 << MPU_RASR_AP_Pos) & MPU_RASR_AP_Msk)
-/* Privileged Read Write, Unprivileged No Access */
-#define P_RW_U_NA	((0x1 << MPU_RASR_AP_Pos) & MPU_RASR_AP_Msk)
-/* Privileged Read Write, Unprivileged Read Only */
-#define P_RW_U_RO	((0x2 << MPU_RASR_AP_Pos) & MPU_RASR_AP_Msk)
-/* Privileged Read Write, Unprivileged Read Write */
-#define P_RW_U_RW	((0x3 << MPU_RASR_AP_Pos) & MPU_RASR_AP_Msk)
-/* Privileged Read Write, Unprivileged Read Write */
-#define FULL_ACCESS	((0x3 << MPU_RASR_AP_Pos) & MPU_RASR_AP_Msk)
-/* Privileged Read Only, Unprivileged No Access */
-#define P_RO_U_NA	((0x5 << MPU_RASR_AP_Pos) & MPU_RASR_AP_Msk)
-/* Privileged Read Only, Unprivileged Read Only */
-#define P_RO_U_RO	((0x6 << MPU_RASR_AP_Pos) & MPU_RASR_AP_Msk)
-/* Privileged Read Only, Unprivileged Read Only */
-#define RO		((0x7 << MPU_RASR_AP_Pos) & MPU_RASR_AP_Msk)
-
-/* The following definitions are for internal use in this file. */
-#define STRONGLY_ORDERED_SHAREABLE      MPU_RASR_S_Msk
-#define DEVICE_SHAREABLE                (MPU_RASR_B_Msk | MPU_RASR_S_Msk)
-#define NORMAL_OUTER_INNER_WRITE_THROUGH_SHAREABLE \
-		(MPU_RASR_C_Msk | MPU_RASR_S_Msk)
-#define NORMAL_OUTER_INNER_WRITE_THROUGH_NON_SHAREABLE	MPU_RASR_C_Msk
-#define NORMAL_OUTER_INNER_WRITE_BACK_SHAREABLE	\
-		(MPU_RASR_C_Msk | MPU_RASR_B_Msk | MPU_RASR_S_Msk)
-#define NORMAL_OUTER_INNER_WRITE_BACK_NON_SHAREABLE \
-		(MPU_RASR_C_Msk | MPU_RASR_B_Msk)
-#define NORMAL_OUTER_INNER_NON_CACHEABLE_SHAREABLE \
-		((1 << MPU_RASR_TEX_Pos) | MPU_RASR_S_Msk)
-#define NORMAL_OUTER_INNER_NON_CACHEABLE_NON_SHAREABLE \
-		(1 << MPU_RASR_TEX_Pos)
-#define NORMAL_OUTER_INNER_WRITE_BACK_WRITE_READ_ALLOCATE_SHAREABLE \
-	((1 << MPU_RASR_TEX_Pos) |\
-	 MPU_RASR_C_Msk | MPU_RASR_B_Msk | MPU_RASR_S_Msk)
-#define NORMAL_OUTER_INNER_WRITE_BACK_WRITE_READ_ALLOCATE_NONSHAREABLE \
-	((1 << MPU_RASR_TEX_Pos) | MPU_RASR_C_Msk | MPU_RASR_S_Msk)
-#define DEVICE_NON_SHAREABLE            (2 << MPU_RASR_TEX_Pos)
-
-/* Some helper defines for common regions */
-#define REGION_USER_RAM_ATTR(size) \
-		(NORMAL_OUTER_INNER_NON_CACHEABLE_NON_SHAREABLE | \
-		 MPU_RASR_XN_Msk | size | FULL_ACCESS)
-#define REGION_RAM_ATTR(size) \
-		(NORMAL_OUTER_INNER_NON_CACHEABLE_NON_SHAREABLE | \
-		 MPU_RASR_XN_Msk | size | P_RW_U_NA)
-#if defined(CONFIG_MPU_ALLOW_FLASH_WRITE)
-#define REGION_FLASH_ATTR(size) \
-		(NORMAL_OUTER_INNER_NON_CACHEABLE_NON_SHAREABLE | size | \
-		 P_RW_U_RO)
-#else
-#define REGION_FLASH_ATTR(size) \
-		(NORMAL_OUTER_INNER_NON_CACHEABLE_NON_SHAREABLE | size | RO)
+#if defined(CONFIG_CPU_CORTEX_M0PLUS) || \
+	defined(CONFIG_CPU_CORTEX_M3) || \
+	defined(CONFIG_CPU_CORTEX_M4) || \
+	defined(CONFIG_CPU_CORTEX_M7)
+#include <arch/arm/cortex_m/mpu/arm_mpu_v7m.h>
 #endif
-#define REGION_PPB_ATTR(size) (STRONGLY_ORDERED_SHAREABLE | size | P_RW_U_NA)
-#define REGION_IO_ATTR(size) (DEVICE_NON_SHAREABLE | size | P_RW_U_NA)
 
-#define SUB_REGION_0_DISABLED	((0x01 << MPU_RASR_SRD_Pos) & MPU_RASR_SRD_Msk)
-#define SUB_REGION_1_DISABLED	((0x02 << MPU_RASR_SRD_Pos) & MPU_RASR_SRD_Msk)
-#define SUB_REGION_2_DISABLED	((0x04 << MPU_RASR_SRD_Pos) & MPU_RASR_SRD_Msk)
-#define SUB_REGION_3_DISABLED	((0x08 << MPU_RASR_SRD_Pos) & MPU_RASR_SRD_Msk)
-#define SUB_REGION_4_DISABLED	((0x10 << MPU_RASR_SRD_Pos) & MPU_RASR_SRD_Msk)
-#define SUB_REGION_5_DISABLED	((0x20 << MPU_RASR_SRD_Pos) & MPU_RASR_SRD_Msk)
-#define SUB_REGION_6_DISABLED	((0x40 << MPU_RASR_SRD_Pos) & MPU_RASR_SRD_Msk)
-#define SUB_REGION_7_DISABLED	((0x80 << MPU_RASR_SRD_Pos) & MPU_RASR_SRD_Msk)
+#ifdef CONFIG_USERSPACE
+#ifndef _ASMLANGUAGE
+/* Read-Write access permission attributes */
+#define K_MEM_PARTITION_P_NA_U_NA	(NO_ACCESS | NOT_EXEC)
+#define K_MEM_PARTITION_P_RW_U_RW	(P_RW_U_RW | NOT_EXEC)
+#define K_MEM_PARTITION_P_RW_U_RO	(P_RW_U_RO | NOT_EXEC)
+#define K_MEM_PARTITION_P_RW_U_NA	(P_RW_U_NA | NOT_EXEC)
+#define K_MEM_PARTITION_P_RO_U_RO	(P_RO_U_RO | NOT_EXEC)
+#define K_MEM_PARTITION_P_RO_U_NA	(P_RO_U_NA | NOT_EXEC)
 
-#define REGION_32B      ((0x04 << MPU_RASR_SIZE_Pos) & MPU_RASR_SIZE_Msk)
-#define REGION_64B      ((0x05 << MPU_RASR_SIZE_Pos) & MPU_RASR_SIZE_Msk)
-#define REGION_128B     ((0x06 << MPU_RASR_SIZE_Pos) & MPU_RASR_SIZE_Msk)
-#define REGION_256B     ((0x07 << MPU_RASR_SIZE_Pos) & MPU_RASR_SIZE_Msk)
-#define REGION_512B     ((0x08 << MPU_RASR_SIZE_Pos) & MPU_RASR_SIZE_Msk)
-#define REGION_1K       ((0x09 << MPU_RASR_SIZE_Pos) & MPU_RASR_SIZE_Msk)
-#define REGION_2K       ((0x0A << MPU_RASR_SIZE_Pos) & MPU_RASR_SIZE_Msk)
-#define REGION_4K       ((0x0B << MPU_RASR_SIZE_Pos) & MPU_RASR_SIZE_Msk)
-#define REGION_8K       ((0x0C << MPU_RASR_SIZE_Pos) & MPU_RASR_SIZE_Msk)
-#define REGION_16K      ((0x0D << MPU_RASR_SIZE_Pos) & MPU_RASR_SIZE_Msk)
-#define REGION_32K      ((0x0E << MPU_RASR_SIZE_Pos) & MPU_RASR_SIZE_Msk)
-#define REGION_64K      ((0x0F << MPU_RASR_SIZE_Pos) & MPU_RASR_SIZE_Msk)
-#define REGION_128K     ((0x10 << MPU_RASR_SIZE_Pos) & MPU_RASR_SIZE_Msk)
-#define REGION_256K     ((0x11 << MPU_RASR_SIZE_Pos) & MPU_RASR_SIZE_Msk)
-#define REGION_512K     ((0x12 << MPU_RASR_SIZE_Pos) & MPU_RASR_SIZE_Msk)
-#define REGION_1M       ((0x13 << MPU_RASR_SIZE_Pos) & MPU_RASR_SIZE_Msk)
-#define REGION_2M       ((0x14 << MPU_RASR_SIZE_Pos) & MPU_RASR_SIZE_Msk)
-#define REGION_4M       ((0x15 << MPU_RASR_SIZE_Pos) & MPU_RASR_SIZE_Msk)
-#define REGION_8M       ((0x16 << MPU_RASR_SIZE_Pos) & MPU_RASR_SIZE_Msk)
-#define REGION_16M      ((0x17 << MPU_RASR_SIZE_Pos) & MPU_RASR_SIZE_Msk)
-#define REGION_32M      ((0x18 << MPU_RASR_SIZE_Pos) & MPU_RASR_SIZE_Msk)
-#define REGION_64M      ((0x19 << MPU_RASR_SIZE_Pos) & MPU_RASR_SIZE_Msk)
-#define REGION_128M     ((0x1A << MPU_RASR_SIZE_Pos) & MPU_RASR_SIZE_Msk)
-#define REGION_256M     ((0x1B << MPU_RASR_SIZE_Pos) & MPU_RASR_SIZE_Msk)
-#define REGION_512M     ((0x1C << MPU_RASR_SIZE_Pos) & MPU_RASR_SIZE_Msk)
-#define REGION_1G       ((0x1D << MPU_RASR_SIZE_Pos) & MPU_RASR_SIZE_Msk)
-#define REGION_2G       ((0x1E << MPU_RASR_SIZE_Pos) & MPU_RASR_SIZE_Msk)
-#define REGION_4G       ((0x1F << MPU_RASR_SIZE_Pos) & MPU_RASR_SIZE_Msk)
+/* Execution-allowed attributes */
+#define K_MEM_PARTITION_P_RWX_U_RWX	(P_RW_U_RW)
+#define K_MEM_PARTITION_P_RWX_U_RX	(P_RW_U_RO)
+#define K_MEM_PARTITION_P_RX_U_RX	(P_RO_U_RO)
 
-/* Region definition data structure */
-struct arm_mpu_region {
-	/* Region Base Address */
-	u32_t base;
-	/* Region Name */
-	const char *name;
-	/* Region Attributes */
-	u32_t attr;
-};
-
-#define MPU_REGION_ENTRY(_name, _base, _attr) \
-	{\
-		.name = _name, \
-		.base = _base, \
-		.attr = _attr, \
-	}
+#define K_MEM_PARTITION_IS_WRITABLE(attr) \
+	({ \
+		int __is_writable__; \
+		switch (attr) { \
+		case P_RW_U_RW: \
+		case P_RW_U_RO: \
+		case P_RW_U_NA: \
+			__is_writable__ = 1; \
+			break; \
+		default: \
+			__is_writable__ = 0; \
+		} \
+		__is_writable__; \
+	})
+#define K_MEM_PARTITION_IS_EXECUTABLE(attr) \
+	(!((attr) & (NOT_EXEC)))
+#endif /* _ASMLANGUAGE */
+#endif /* USERSPACE */
 
 /* MPU configuration data structure */
 struct arm_mpu_config {

--- a/include/arch/arm/cortex_m/mpu/arm_mpu_v7m.h
+++ b/include/arch/arm/cortex_m/mpu/arm_mpu_v7m.h
@@ -1,0 +1,124 @@
+/*
+ * Copyright (c) 2018 Linaro Limited.
+ * Copyright (c) 2018 Nordic Semiconductor ASA.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/* Privileged No Access, Unprivileged No Access */
+#define NO_ACCESS	((0x0 << MPU_RASR_AP_Pos) & MPU_RASR_AP_Msk)
+/* Privileged No Access, Unprivileged No Access */
+#define P_NA_U_NA	((0x0 << MPU_RASR_AP_Pos) & MPU_RASR_AP_Msk)
+/* Privileged Read Write, Unprivileged No Access */
+#define P_RW_U_NA	((0x1 << MPU_RASR_AP_Pos) & MPU_RASR_AP_Msk)
+/* Privileged Read Write, Unprivileged Read Only */
+#define P_RW_U_RO	((0x2 << MPU_RASR_AP_Pos) & MPU_RASR_AP_Msk)
+/* Privileged Read Write, Unprivileged Read Write */
+#define P_RW_U_RW	((0x3 << MPU_RASR_AP_Pos) & MPU_RASR_AP_Msk)
+/* Privileged Read Write, Unprivileged Read Write */
+#define FULL_ACCESS	((0x3 << MPU_RASR_AP_Pos) & MPU_RASR_AP_Msk)
+/* Privileged Read Only, Unprivileged No Access */
+#define P_RO_U_NA	((0x5 << MPU_RASR_AP_Pos) & MPU_RASR_AP_Msk)
+/* Privileged Read Only, Unprivileged Read Only */
+#define P_RO_U_RO	((0x6 << MPU_RASR_AP_Pos) & MPU_RASR_AP_Msk)
+/* Privileged Read Only, Unprivileged Read Only */
+#define RO		((0x7 << MPU_RASR_AP_Pos) & MPU_RASR_AP_Msk)
+
+/* Attribute flag for not-allowing execution (eXecute Never) */
+#define NOT_EXEC MPU_RASR_XN_Msk
+
+/* The following definitions are for internal use in arm_mpu.h. */
+#define STRONGLY_ORDERED_SHAREABLE      MPU_RASR_S_Msk
+#define DEVICE_SHAREABLE                (MPU_RASR_B_Msk | MPU_RASR_S_Msk)
+#define NORMAL_OUTER_INNER_WRITE_THROUGH_SHAREABLE \
+		(MPU_RASR_C_Msk | MPU_RASR_S_Msk)
+#define NORMAL_OUTER_INNER_WRITE_THROUGH_NON_SHAREABLE	MPU_RASR_C_Msk
+#define NORMAL_OUTER_INNER_WRITE_BACK_SHAREABLE	\
+		(MPU_RASR_C_Msk | MPU_RASR_B_Msk | MPU_RASR_S_Msk)
+#define NORMAL_OUTER_INNER_WRITE_BACK_NON_SHAREABLE \
+		(MPU_RASR_C_Msk | MPU_RASR_B_Msk)
+#define NORMAL_OUTER_INNER_NON_CACHEABLE_SHAREABLE \
+		((1 << MPU_RASR_TEX_Pos) | MPU_RASR_S_Msk)
+#define NORMAL_OUTER_INNER_NON_CACHEABLE_NON_SHAREABLE \
+		(1 << MPU_RASR_TEX_Pos)
+#define NORMAL_OUTER_INNER_WRITE_BACK_WRITE_READ_ALLOCATE_SHAREABLE \
+	((1 << MPU_RASR_TEX_Pos) |\
+	 MPU_RASR_C_Msk | MPU_RASR_B_Msk | MPU_RASR_S_Msk)
+#define NORMAL_OUTER_INNER_WRITE_BACK_WRITE_READ_ALLOCATE_NONSHAREABLE \
+	((1 << MPU_RASR_TEX_Pos) | MPU_RASR_C_Msk | MPU_RASR_S_Msk)
+#define DEVICE_NON_SHAREABLE            (2 << MPU_RASR_TEX_Pos)
+
+/* Bit-masks to disable sub-regions. */
+#define SUB_REGION_0_DISABLED	((0x01 << MPU_RASR_SRD_Pos) & MPU_RASR_SRD_Msk)
+#define SUB_REGION_1_DISABLED	((0x02 << MPU_RASR_SRD_Pos) & MPU_RASR_SRD_Msk)
+#define SUB_REGION_2_DISABLED	((0x04 << MPU_RASR_SRD_Pos) & MPU_RASR_SRD_Msk)
+#define SUB_REGION_3_DISABLED	((0x08 << MPU_RASR_SRD_Pos) & MPU_RASR_SRD_Msk)
+#define SUB_REGION_4_DISABLED	((0x10 << MPU_RASR_SRD_Pos) & MPU_RASR_SRD_Msk)
+#define SUB_REGION_5_DISABLED	((0x20 << MPU_RASR_SRD_Pos) & MPU_RASR_SRD_Msk)
+#define SUB_REGION_6_DISABLED	((0x40 << MPU_RASR_SRD_Pos) & MPU_RASR_SRD_Msk)
+#define SUB_REGION_7_DISABLED	((0x80 << MPU_RASR_SRD_Pos) & MPU_RASR_SRD_Msk)
+
+#define REGION_32B      ((0x04 << MPU_RASR_SIZE_Pos) & MPU_RASR_SIZE_Msk)
+#define REGION_64B      ((0x05 << MPU_RASR_SIZE_Pos) & MPU_RASR_SIZE_Msk)
+#define REGION_128B     ((0x06 << MPU_RASR_SIZE_Pos) & MPU_RASR_SIZE_Msk)
+#define REGION_256B     ((0x07 << MPU_RASR_SIZE_Pos) & MPU_RASR_SIZE_Msk)
+#define REGION_512B     ((0x08 << MPU_RASR_SIZE_Pos) & MPU_RASR_SIZE_Msk)
+#define REGION_1K       ((0x09 << MPU_RASR_SIZE_Pos) & MPU_RASR_SIZE_Msk)
+#define REGION_2K       ((0x0A << MPU_RASR_SIZE_Pos) & MPU_RASR_SIZE_Msk)
+#define REGION_4K       ((0x0B << MPU_RASR_SIZE_Pos) & MPU_RASR_SIZE_Msk)
+#define REGION_8K       ((0x0C << MPU_RASR_SIZE_Pos) & MPU_RASR_SIZE_Msk)
+#define REGION_16K      ((0x0D << MPU_RASR_SIZE_Pos) & MPU_RASR_SIZE_Msk)
+#define REGION_32K      ((0x0E << MPU_RASR_SIZE_Pos) & MPU_RASR_SIZE_Msk)
+#define REGION_64K      ((0x0F << MPU_RASR_SIZE_Pos) & MPU_RASR_SIZE_Msk)
+#define REGION_128K     ((0x10 << MPU_RASR_SIZE_Pos) & MPU_RASR_SIZE_Msk)
+#define REGION_256K     ((0x11 << MPU_RASR_SIZE_Pos) & MPU_RASR_SIZE_Msk)
+#define REGION_512K     ((0x12 << MPU_RASR_SIZE_Pos) & MPU_RASR_SIZE_Msk)
+#define REGION_1M       ((0x13 << MPU_RASR_SIZE_Pos) & MPU_RASR_SIZE_Msk)
+#define REGION_2M       ((0x14 << MPU_RASR_SIZE_Pos) & MPU_RASR_SIZE_Msk)
+#define REGION_4M       ((0x15 << MPU_RASR_SIZE_Pos) & MPU_RASR_SIZE_Msk)
+#define REGION_8M       ((0x16 << MPU_RASR_SIZE_Pos) & MPU_RASR_SIZE_Msk)
+#define REGION_16M      ((0x17 << MPU_RASR_SIZE_Pos) & MPU_RASR_SIZE_Msk)
+#define REGION_32M      ((0x18 << MPU_RASR_SIZE_Pos) & MPU_RASR_SIZE_Msk)
+#define REGION_64M      ((0x19 << MPU_RASR_SIZE_Pos) & MPU_RASR_SIZE_Msk)
+#define REGION_128M     ((0x1A << MPU_RASR_SIZE_Pos) & MPU_RASR_SIZE_Msk)
+#define REGION_256M     ((0x1B << MPU_RASR_SIZE_Pos) & MPU_RASR_SIZE_Msk)
+#define REGION_512M     ((0x1C << MPU_RASR_SIZE_Pos) & MPU_RASR_SIZE_Msk)
+#define REGION_1G       ((0x1D << MPU_RASR_SIZE_Pos) & MPU_RASR_SIZE_Msk)
+#define REGION_2G       ((0x1E << MPU_RASR_SIZE_Pos) & MPU_RASR_SIZE_Msk)
+#define REGION_4G       ((0x1F << MPU_RASR_SIZE_Pos) & MPU_RASR_SIZE_Msk)
+
+/* Some helper defines for common regions */
+#define REGION_USER_RAM_ATTR(size) \
+		(NORMAL_OUTER_INNER_NON_CACHEABLE_NON_SHAREABLE | \
+		 MPU_RASR_XN_Msk | size | FULL_ACCESS)
+#define REGION_RAM_ATTR(size) \
+		(NORMAL_OUTER_INNER_NON_CACHEABLE_NON_SHAREABLE | \
+		 MPU_RASR_XN_Msk | size | P_RW_U_NA)
+#if defined(CONFIG_MPU_ALLOW_FLASH_WRITE)
+#define REGION_FLASH_ATTR(size) \
+		(NORMAL_OUTER_INNER_NON_CACHEABLE_NON_SHAREABLE | size | \
+		 P_RW_U_RO)
+#else
+#define REGION_FLASH_ATTR(size) \
+		(NORMAL_OUTER_INNER_NON_CACHEABLE_NON_SHAREABLE | size | RO)
+#endif
+#define REGION_PPB_ATTR(size) (STRONGLY_ORDERED_SHAREABLE | size | P_RW_U_NA)
+#define REGION_IO_ATTR(size) (DEVICE_NON_SHAREABLE | size | P_RW_U_NA)
+
+
+/* Region definition data structure */
+struct arm_mpu_region {
+	/* Region Base Address */
+	u32_t base;
+	/* Region Name */
+	const char *name;
+	/* Region Attributes */
+	u32_t attr;
+};
+
+#define MPU_REGION_ENTRY(_name, _base, _attr) \
+	{\
+		.name = _name, \
+		.base = _base, \
+		.attr = _attr, \
+	}


### PR DESCRIPTION
This pull request refactors the arm_mpu.h header, as part of the **preparations for adding support for ARMv8-M MPU (#8018 )**. Contains the following:
- removal of the redundant MPU HAL definition in arm_mpu.h and use of the CMSIS MPU HAL API directly
- adding the HAL API explicitly for beetle (which does not include CMSIS)
- use the CMSIS Bitsets and flags in defines present in arm_mpu.h
- move the ARMv7-M specific defines and convenience macros in a new file, arm_mpu_v7m.h. 

The PR does not change the current functionality.
Advice to review commit by commit.  

Super-set of #8603  (rebased over #8603)