### PR TITLE
drivers: flash: w25qxxdv: Add configuration options for delay and device ID

### DIFF
--- a/drivers/flash/Kconfig.w25qxxdv
+++ b/drivers/flash/Kconfig.w25qxxdv
@@ -68,10 +68,24 @@ config SPI_FLASH_W25QXXDV_GPIO_SPI_CS_PIN
 	This option is mandatory to set which GPIO pin to use in order
 	to actually emulate the SPI CS.
 
+config SPI_FLASH_W25QXXDV_GPIO_CS_WAIT_DELAY
+	int "Delay time in us"
+	default 0
+        depends on SPI_FLASH_W25QXXDV_GPIO_SPI_CS
+	help
+	This is the wait delay (in us) to allow for CS switching to take effect
+
 config SPI_FLASH_W25QXXDV_FLASH_SIZE
 	int "Flash size in bytes"
 	default 2097152
 	help
 	  This is the flash capacity in bytes.
+
+config SPI_FLASH_W25QXXDV_DEVICE_ID
+	hex "Device ID in hex"
+	default 0x00ef4015
+	help
+	  This is the device ID of the flash chip to use, which is 0x00ef4015 for
+          the W25QXXDV
 
 endif # SPI_FLASH_W25QXXDV

--- a/drivers/flash/spi_flash_w25qxxdv.c
+++ b/drivers/flash/spi_flash_w25qxxdv.c
@@ -84,7 +84,7 @@ static inline int spi_flash_wb_id(struct device *dev)
 	temp_data |= ((u32_t) buf[1]) << 8;
 	temp_data |= (u32_t) buf[2];
 
-	if (temp_data != W25QXXDV_RDID_VALUE) {
+	if (temp_data != CONFIG_SPI_FLASH_W25QXXDV_DEVICE_ID) {
 		return -ENODEV;
 	}
 
@@ -341,7 +341,7 @@ static int spi_flash_wb_configure(struct device *dev)
 	}
 
 	data->cs_ctrl.gpio_pin = CONFIG_SPI_FLASH_W25QXXDV_GPIO_SPI_CS_PIN;
-	data->cs_ctrl.delay = 0;
+	data->cs_ctrl.delay = CONFIG_SPI_FLASH_W25QXXDV_GPIO_CS_WAIT_DELAY;
 
 	data->spi_cfg.cs = &data->cs_ctrl;
 #endif /* CONFIG_SPI_FLASH_W25QXXDV_GPIO_SPI_CS */


### PR DESCRIPTION
Adds support for configuring the CS toggling delay and using a
different device ID so that compatible flash chips can also be
used by this driver.

Signed-off-by: Jamie McCrae <jamie.mccrae@lairdtech.com>