### PR TITLE
net: ieee802154: fix csma-ca backoff

### DIFF
--- a/subsys/net/ip/l2/ieee802154/ieee802154_radio_csma_ca.c
+++ b/subsys/net/ip/l2/ieee802154/ieee802154_radio_csma_ca.c
@@ -41,7 +41,7 @@ loop:
 		retries--;
 
 		if (be) {
-			u8_t bo_n = sys_rand32_get() & (2 << (be + 1));
+			u8_t bo_n = sys_rand32_get() & ((1 << be) - 1);
 
 			k_busy_wait(bo_n * 20);
 		}


### PR DESCRIPTION
This patch changes the value to be random between zero and 2^be-1, as defined by the standard.

The previous implementation generated either a power-of-two number or zero for bo_n, because it only overlaps a single bit with the random number. The overlap is very rare, as in random, and results in the backoff time being zero most of the time.

fixes https://github.com/zephyrproject-rtos/zephyr/issues/8452

Signed-off-by: Franco Saworski <franco.saworski@blik.io>