### PR TITLE
libc: minimal: Add placeholder math.h

### DIFF
--- a/lib/libc/minimal/include/math.h
+++ b/lib/libc/minimal/include/math.h
@@ -1,0 +1,23 @@
+/*
+ * Copyright (c) 2018 Linaro Limited
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+
+/* Dummy math.h to fulfill the requirements of certain libraries.
+ */
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+double ceil(double x);
+float ceilf(float x);
+double floor(double x);
+double log(double x);
+double sqrt(double x);
+
+#ifdef __cplusplus
+}
+#endif


### PR DESCRIPTION
Some 3rd-party components (e.g. vendor HALs) may include math.h.
They may also refer to some math.h functions e.g. in inline
functions (but not actually link to them), so a few prototypes
are provided to.

(Specifically, addition of this file/contents prompted by Cypress
PSOC6 integration work.)

Signed-off-by: Paul Sokolovsky <paul.sokolovsky@linaro.org>