### PR TITLE
cmake: fix git describe command line

### DIFF
--- a/cmake/app/boilerplate.cmake
+++ b/cmake/app/boilerplate.cmake
@@ -251,8 +251,7 @@ include(${ZEPHYR_BASE}/cmake/toolchain.cmake)
 
 find_package(Git QUIET)
 if(GIT_FOUND)
-  execute_process(COMMAND ${GIT_EXECUTABLE} --work-tree=${ZEPHYR_BASE} describe
-    WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
+  execute_process(COMMAND ${GIT_EXECUTABLE} -C ${ZEPHYR_BASE} describe
     OUTPUT_VARIABLE BUILD_VERSION
     OUTPUT_STRIP_TRAILING_WHITESPACE)
 endif()


### PR DESCRIPTION
The "git describe" call for setting the boot banner is broken. The
--work-tree option sets the checked out work tree, not the directory
containing .git, which is where git describe needs to look for
information on tags.

Use -C instead so it's as if Git were run from the zephyr base
directory.