### PR TITLE
lib: libc: minimal: Get rid of the bit (256-byte) charmap table

### DIFF
--- a/lib/libc/minimal/source/string/strncasecmp.c
+++ b/lib/libc/minimal/source/string/strncasecmp.c
@@ -1,87 +1,28 @@
 /*
- * Copyright (c) 1987 Regents of the University of California.
- * All rights reserved.
+ * Copyright (c) 2018 Intel Corporation
  *
- * Redistribution and use in source and binary forms are permitted
- * provided that this notice is preserved and that due credit is given
- * to the University of California at Berkeley. The name of the University
- * may not be used to endorse or promote products derived from this
- * software without specific written prior permission. This software
- * is provided ``as is'' without express or implied warranty.
+ * SPDX-License-Identifier: Apache-2.0
  */
 
-/*
- * @deftypefn Supplemental int strncasecmp (const char *@var{s1}, const char *@var{s2})
- *
- * A case-insensitive @code{strncmp}.
- *
- * @end deftypefn
- */
-
-/* From:
- * http://opensource.apple.com/source/gcc_os/gcc_os-1671/libiberty/strncasecmp.c
- */
-
-#define size_t unsigned long
-
-
-/*
- * This array is designed for mapping upper and lower case letter
- * together for a case independent comparison.  The mappings are
- * based upon ascii character sequences.
- */
-static const unsigned char charmap[] = {
-	'\000', '\001', '\002', '\003', '\004', '\005', '\006', '\007',
-	'\010', '\011', '\012', '\013', '\014', '\015', '\016', '\017',
-	'\020', '\021', '\022', '\023', '\024', '\025', '\026', '\027',
-	'\030', '\031', '\032', '\033', '\034', '\035', '\036', '\037',
-	'\040', '\041', '\042', '\043', '\044', '\045', '\046', '\047',
-	'\050', '\051', '\052', '\053', '\054', '\055', '\056', '\057',
-	'\060', '\061', '\062', '\063', '\064', '\065', '\066', '\067',
-	'\070', '\071', '\072', '\073', '\074', '\075', '\076', '\077',
-	'\100', '\141', '\142', '\143', '\144', '\145', '\146', '\147',
-	'\150', '\151', '\152', '\153', '\154', '\155', '\156', '\157',
-	'\160', '\161', '\162', '\163', '\164', '\165', '\166', '\167',
-	'\170', '\171', '\172', '\133', '\134', '\135', '\136', '\137',
-	'\140', '\141', '\142', '\143', '\144', '\145', '\146', '\147',
-	'\150', '\151', '\152', '\153', '\154', '\155', '\156', '\157',
-	'\160', '\161', '\162', '\163', '\164', '\165', '\166', '\167',
-	'\170', '\171', '\172', '\173', '\174', '\175', '\176', '\177',
-	'\200', '\201', '\202', '\203', '\204', '\205', '\206', '\207',
-	'\210', '\211', '\212', '\213', '\214', '\215', '\216', '\217',
-	'\220', '\221', '\222', '\223', '\224', '\225', '\226', '\227',
-	'\230', '\231', '\232', '\233', '\234', '\235', '\236', '\237',
-	'\240', '\241', '\242', '\243', '\244', '\245', '\246', '\247',
-	'\250', '\251', '\252', '\253', '\254', '\255', '\256', '\257',
-	'\260', '\261', '\262', '\263', '\264', '\265', '\266', '\267',
-	'\270', '\271', '\272', '\273', '\274', '\275', '\276', '\277',
-	'\300', '\341', '\342', '\343', '\344', '\345', '\346', '\347',
-	'\350', '\351', '\352', '\353', '\354', '\355', '\356', '\357',
-	'\360', '\361', '\362', '\363', '\364', '\365', '\366', '\367',
-	'\370', '\371', '\372', '\333', '\334', '\335', '\336', '\337',
-	'\340', '\341', '\342', '\343', '\344', '\345', '\346', '\347',
-	'\350', '\351', '\352', '\353', '\354', '\355', '\356', '\357',
-	'\360', '\361', '\362', '\363', '\364', '\365', '\366', '\367',
-	'\370', '\371', '\372', '\373', '\374', '\375', '\376', '\377',
-};
+#include <stdlib.h>
+#include <ctype.h>
 
 int
-strncasecmp(s1, s2, n)
-	const char *s1, *s2;
-	register size_t n;
+strncasecmp(const char *s1, const char *s2, size_t n)
 {
-	register unsigned char u1, u2;
+	unsigned char c = 1;
 
-	for (; n != 0; --n) {
-		u1 = (unsigned char) *s1++;
-		u2 = (unsigned char) *s2++;
-		if (charmap[u1] != charmap[u2]) {
-			return charmap[u1] - charmap[u2];
-		}
+	for (; c && n != 0; n--) {
+		unsigned char lower1, lower2;
 
-		if (u1 == '\0') {
-			return 0;
+		c = *s1++;
+		lower1 = tolower(c);
+		lower2 = tolower(*s2++);
+
+		if (lower1 != lower2) {
+			return (lower1 > lower2) - (lower1 < lower2);
 		}
 	}
+
 	return 0;
 }


### PR DESCRIPTION
The charmap table used by strncasecmp() not only used precious 256
bytes of ROM, it also had wrong mappings outside the ASCII range
(123..218).

Rewrite strncasecmp() to call tolower() instead; might be a tiny wee
little bit slower than the current version, but it's not used in any
performance-sensitive parts of the code to justify the waste.

This reduces the ROM footprint for the ws_echo_server sample by ~224
bytes.

Signed-off-by: Leandro Pereira <leandro.pereira@intel.com>