### PR TITLE
kconfig: Shield experimental features under a Kconfig option

### DIFF
--- a/Kconfig.zephyr
+++ b/Kconfig.zephyr
@@ -7,6 +7,19 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 
+config EXPERIMENTAL
+	bool "Enable experimental/incomplete features"
+	default y
+	help
+	  Enable this option if you want to build Zephyr with incomplete
+	  and/or experimental features.
+
+	  Such features are often under heavy development and their APIs are
+	  subject to change, even if declared non-private.  Also, they might
+	  not be subject to the same kind of testing rigor applied to mature
+	  features.
+
+
 source "arch/Kconfig"
 
 source "kernel/Kconfig"

--- a/arch/Kconfig
+++ b/arch/Kconfig
@@ -62,7 +62,8 @@ config HW_STACK_PROTECTION
 	  made.
 
 config USERSPACE
-	bool "User mode threads (EXPERIMENTAL)"
+	bool "User mode threads"
+	depends on EXPERIMENTAL
 	depends on ARCH_HAS_USERSPACE
 	help
 	  When enabled, threads may be created or dropped down to user mode,

--- a/arch/nios2/soc/nios2-qemu/Kconfig.soc
+++ b/arch/nios2/soc/nios2-qemu/Kconfig.soc
@@ -1,5 +1,6 @@
 config SOC_NIOS2_QEMU
-	bool "Nios II - Experimental QEMU emulation"
+	bool "Nios II - QEMU emulation"
+	depends on EXPERIMENTAL
 	select HAS_MUL_INSTRUCTION
 	select HAS_DIV_INSTRUCTION
 	select HAS_MULX_INSTRUCTION

--- a/drivers/bluetooth/Kconfig
+++ b/drivers/bluetooth/Kconfig
@@ -25,8 +25,9 @@ if BT_CUSTOM
 endif
 
 config BT_NRF51_PM
-	bool "nRF51 Power Management [EXPERIMENTAL]"
+	bool "nRF51 Power Management"
 	depends on BT_H4
+	depends on EXPERIMENTAL
 	help
 	  Power Management support for Nordic BLE nRF51 chip. Allows to enable,
 	  disable the chip and handle wakeups.

--- a/drivers/bluetooth/hci/Kconfig
+++ b/drivers/bluetooth/hci/Kconfig
@@ -25,7 +25,8 @@ config BT_H4
 	  lines to be available.
 
 config BT_H5
-	bool "H:5 UART [EXPERIMENTAL]"
+	bool "H:5 UART"
+	depends on EXPERIMENTAL
 	select UART_INTERRUPT_DRIVEN
 	select BT_UART
 	depends on SERIAL

--- a/drivers/console/Kconfig.telnet
+++ b/drivers/console/Kconfig.telnet
@@ -67,8 +67,9 @@ config TELNET_CONSOLE_SEND_THRESHOLD
 	  buffer did not meet the line feed yet.
 
 config TELNET_CONSOLE_SUPPORT_COMMAND
-	bool "Add support for telnet commands (IAC) [Experimental]"
+	bool "Add support for telnet commands (IAC)"
 	default n
+	depends on EXPERIMENTAL
 	help
 	  Current support is so limited it's not interesting to enable it.
 	  However, if proven to be needed at some point, it will be possible

--- a/drivers/crypto/Kconfig
+++ b/drivers/crypto/Kconfig
@@ -11,7 +11,8 @@
 #
 menuconfig CRYPTO
 	bool
-	prompt "Crypto Drivers [EXPERIMENTAL]"
+	prompt "Crypto Drivers"
+	depends on EXPERIMENTAL
 	default n
 
 if CRYPTO

--- a/drivers/spi/Kconfig
+++ b/drivers/spi/Kconfig
@@ -25,7 +25,8 @@ config SPI_ASYNC
 	  This option enables the asynchronous API calls.
 
 config SPI_SLAVE
-	bool "Enable Slave support [EXPERIMENTAL]"
+	bool "Enable Slave support"
+	depends on EXPERIMENTAL
 	default n
 	help
 	  Enables Driver SPI slave operations. Slave support depends

--- a/kernel/Kconfig
+++ b/kernel/Kconfig
@@ -290,7 +290,8 @@ config BUILD_TIMESTAMP
 
 config INT_LATENCY_BENCHMARK
 	bool
-	prompt "Interrupt latency metrics [EXPERIMENTAL]"
+	prompt "Interrupt latency metrics"
+	depends on EXPERIMENTAL
 	default n
 	depends on ARCH="x86"
 	help
@@ -312,7 +313,8 @@ config EXECUTION_BENCHMARKING
 
 config THREAD_MONITOR
 	bool
-	prompt "Thread monitoring [EXPERIMENTAL]"
+	prompt "Thread monitoring"
+	depends on EXPERIMENTAL
 	default n
 	help
 	  This option instructs the kernel to maintain a list of all threads

--- a/misc/Kconfig
+++ b/misc/Kconfig
@@ -268,14 +268,16 @@ menu "System Monitoring Options"
 
 config PERFORMANCE_METRICS
 	bool
-	prompt "Enable performance metrics [EXPERIMENTAL]"
+	prompt "Enable performance metrics"
+	depends on EXPERIMENTAL
 	default n
 	help
 	  Enable Performance Metrics.
 
 config BOOT_TIME_MEASUREMENT
 	bool
-	prompt "Boot time measurements [EXPERIMENTAL]"
+	prompt "Boot time measurements"
+	depends on EXPERIMENTAL
 	default n
 	depends on PERFORMANCE_METRICS
 	help

--- a/subsys/bluetooth/host/Kconfig
+++ b/subsys/bluetooth/host/Kconfig
@@ -476,7 +476,8 @@ config BT_TESTING
 	  Shall only be used for testing purposes.
 
 config BT_BREDR
-	bool "Bluetooth BR/EDR support [EXPERIMENTAL]"
+	bool "Bluetooth BR/EDR support"
+	depends on EXPERIMENTAL
 	depends on BT_HCI_HOST
 	select BT_PERIPHERAL
 	select BT_CENTRAL
@@ -495,7 +496,8 @@ config BT_MAX_SCO_CONN
 	  supported. The minimum (and default) number is 1.
 
 config BT_RFCOMM
-	bool "Bluetooth RFCOMM protocol support [EXPERIMENTAL]"
+	bool "Bluetooth RFCOMM protocol support"
+	depends on EXPERIMENTAL
 	help
 	  This option enables Bluetooth RFCOMM support
 
@@ -510,19 +512,22 @@ config BT_RFCOMM_L2CAP_MTU
 	  Maximum size of L2CAP PDU for RFCOMM frames.
 
 config BT_HFP_HF
-	bool "Bluetooth Handsfree profile HF Role support [EXPERIMENTAL]"
+	bool "Bluetooth Handsfree profile HF Role support"
+	depends on EXPERIMENTAL
 	depends on PRINTK
 	select BT_RFCOMM
 	help
 	  This option enables Bluetooth HF support
 
 config BT_AVDTP
-	bool "Bluetooth AVDTP protocol support [EXPERIMENTAL]"
+	bool "Bluetooth AVDTP protocol support"
+	depends on EXPERIMENTAL
 	help
 	  This option enables Bluetooth AVDTP support
 
 config BT_A2DP
-	bool "Bluetooth A2DP Profile [EXPERIMENTAL]"
+	bool "Bluetooth A2DP Profile"
+	depends on EXPERIMENTAL
 	select BT_AVDTP
 	help
 	  This option enables the A2DP profile

--- a/subsys/debug/Kconfig
+++ b/subsys/debug/Kconfig
@@ -186,7 +186,8 @@ config EXCEPTION_STACK_TRACE
 
 config OPENOCD_SUPPORT
 	bool
-	prompt "OpenOCD support [EXPERIMENTAL]"
+	prompt "OpenOCD support"
+	depends on EXPERIMENTAL
 	default n
 	select THREAD_MONITOR
 	help

--- a/subsys/net/ip/l2/Kconfig
+++ b/subsys/net/ip/l2/Kconfig
@@ -7,7 +7,8 @@
 menu "Link layer options"
 
 config NET_OFFLOAD
-	bool "Offload IP stack [EXPERIMENTAL]"
+	bool "Offload IP stack"
+	depends on EXPERIMENTAL
 	default n
 	help
 	  Enables TCP/IP stack to be offload to a co-processor.

--- a/subsys/net/ip/l2/ieee802154/Kconfig
+++ b/subsys/net/ip/l2/ieee802154/Kconfig
@@ -135,7 +135,8 @@ config  NET_DEBUG_L2_IEEE802154_FRAGMENT
 	default y if NET_LOG_GLOBAL
 
 config NET_L2_IEEE802154_SECURITY
-	bool "Enable IEEE 802.15.4 security [EXPERIMENTAL]"
+	bool "Enable IEEE 802.15.4 security"
+	depends on EXPERIMENTAL
 	default n
 	help
 	  Enable 802.15.4 frame security handling, in order to bring data

--- a/subsys/net/lib/app/Kconfig
+++ b/subsys/net/lib/app/Kconfig
@@ -7,7 +7,8 @@
 #
 
 menuconfig NET_APP
-	bool "Network application API support [EXPERIMENTAL]"
+	bool "Network application API support"
+	depends on EXPERIMENTAL
 	default y
 	select NET_MGMT
 	select NET_MGMT_EVENT

--- a/subsys/net/lib/websocket/Kconfig
+++ b/subsys/net/lib/websocket/Kconfig
@@ -4,7 +4,8 @@
 #
 
 menuconfig WEBSOCKET
-	bool "Websocket support [EXPERIMENTAL]"
+	bool "Websocket support"
+	depends on EXPERIMENTAL
 	default n
 	depends on HTTP
 	select NET_TCP

--- a/subsys/shell/Kconfig
+++ b/subsys/shell/Kconfig
@@ -10,7 +10,8 @@
 
 config CONSOLE_SHELL
 	bool
-	prompt "Enable console input handler [ Experimental ]"
+	prompt "Enable console input handler"
+	depends on EXPERIMENTAL
 	default n
 	select CONSOLE_HANDLER
 	help


### PR DESCRIPTION
This makes all features marked with an "experimental" tag in their
prompts depend on a CONFIG_EXPERIMENTAL option that defaults to "y".
Defaulting to "y" is consistent with the current behavior and
will not break anything.

The rationale is similar to the one available in Linux, and is
succintly explained in the help text for CONFIG_EXPERIMENTAL.

Signed-off-by: Leandro Pereira <leandro.pereira@intel.com>