### PR TITLE
include: remove unused macros from include/arch/*/arch.h

### DIFF
--- a/include/arch/arc/arch.h
+++ b/include/arch/arc/arch.h
@@ -20,11 +20,6 @@
 extern "C" {
 #endif
 
-/* APIs need to support non-byte addressable architectures */
-
-#define OCTET_TO_SIZEOFUNIT(X) (X)
-#define SIZEOFUNIT_TO_OCTET(X) (X)
-
 #include <generated_dts_board.h>
 #include <sw_isr_table.h>
 #ifdef CONFIG_CPU_ARCV2

--- a/include/arch/arm/arch.h
+++ b/include/arch/arm/arch.h
@@ -26,11 +26,6 @@ extern "C" {
 /* ARM GPRs are often designated by two different names */
 #define sys_define_gpr_with_alias(name1, name2) union { u32_t name1, name2; }
 
-/* APIs need to support non-byte addressable architectures */
-
-#define OCTET_TO_SIZEOFUNIT(X) (X)
-#define SIZEOFUNIT_TO_OCTET(X) (X)
-
 #ifdef CONFIG_CPU_CORTEX_M
 #include <arch/arm/cortex_m/exc.h>
 #include <arch/arm/cortex_m/irq.h>

--- a/include/arch/nios2/arch.h
+++ b/include/arch/nios2/arch.h
@@ -32,11 +32,6 @@ extern "C" {
 #define _NANO_ERR_KERNEL_OOPS (5)       /* Kernel oops (fatal to thread) */
 #define _NANO_ERR_KERNEL_PANIC (6)	/* Kernel panic (fatal to system) */
 
-/* APIs need to support non-byte addressable architectures */
-
-#define OCTET_TO_SIZEOFUNIT(X) (X)
-#define SIZEOFUNIT_TO_OCTET(X) (X)
-
 #ifndef _ASMLANGUAGE
 #include <zephyr/types.h>
 #include <irq.h>

--- a/include/arch/posix/arch.h
+++ b/include/arch/posix/arch.h
@@ -29,8 +29,6 @@ extern "C" {
 
 #define STACK_ALIGN 4
 #define STACK_ALIGN_SIZE 4
-#define OCTET_TO_SIZEOFUNIT(X) (X)
-#define SIZEOFUNIT_TO_OCTET(X) (X)
 
 #define _NANO_ERR_CPU_EXCEPTION (0)     /* Any unhandled exception */
 #define _NANO_ERR_INVALID_TASK_EXIT (1) /* Invalid task exit */

--- a/include/arch/riscv32/arch.h
+++ b/include/arch/riscv32/arch.h
@@ -35,11 +35,6 @@ extern "C" {
 #define STACK_ROUND_UP(x) ROUND_UP(x, STACK_ALIGN)
 #define STACK_ROUND_DOWN(x) ROUND_DOWN(x, STACK_ALIGN)
 
-/* APIs need to support non-byte addressable architectures */
-
-#define OCTET_TO_SIZEOFUNIT(X) (X)
-#define SIZEOFUNIT_TO_OCTET(X) (X)
-
 /* macros convert value of it's argument to a string */
 #define DO_TOSTR(s) #s
 #define TOSTR(s) DO_TOSTR(s)

--- a/include/arch/x86/arch.h
+++ b/include/arch/x86/arch.h
@@ -30,11 +30,6 @@
 extern "C" {
 #endif
 
-/* APIs need to support non-byte addressable architectures */
-
-#define OCTET_TO_SIZEOFUNIT(X) (X)
-#define SIZEOFUNIT_TO_OCTET(X) (X)
-
 /* GDT layout */
 #define CODE_SEG	0x08
 #define DATA_SEG	0x10

--- a/include/arch/xtensa/arch.h
+++ b/include/arch/xtensa/arch.h
@@ -28,8 +28,6 @@ extern "C" {
 #include <xtensa/config/core.h>
 
 #define STACK_ALIGN 16
-#define OCTET_TO_SIZEOFUNIT(X) (X)
-#define SIZEOFUNIT_TO_OCTET(X) (X)
 
 #define _NANO_ERR_HW_EXCEPTION (0)      /* MPU/Bus/Usage fault */
 #define _NANO_ERR_STACK_CHK_FAIL (2)    /* Stack corruption detected */

--- a/tests/benchmarks/app_kernel/src/master.c
+++ b/tests/benchmarks/app_kernel/src/master.c
@@ -18,7 +18,7 @@
 #include "master.h"
 
 char msg[MAX_MSG];
-char data_bench[OCTET_TO_SIZEOFUNIT(MESSAGE_SIZE)];
+char data_bench[MESSAGE_SIZE];
 
 #ifdef PIPE_BENCH
 struct k_pipe *test_pipes[] = {&PIPE_NOBUFF, &PIPE_SMALLBUFF, &PIPE_BIGBUFF};

--- a/tests/benchmarks/app_kernel/src/master.h
+++ b/tests/benchmarks/app_kernel/src/master.h
@@ -52,7 +52,7 @@
 #define SEMA_WAIT_TIME (5000)
 /* global data */
 extern char msg[MAX_MSG];
-extern char data_bench[OCTET_TO_SIZEOFUNIT(MESSAGE_SIZE)];
+extern char data_bench[MESSAGE_SIZE];
 extern struct k_pipe *test_pipes[];
 extern FILE *output_file;
 extern const char newline[];

--- a/tests/benchmarks/app_kernel/src/receiver.c
+++ b/tests/benchmarks/app_kernel/src/receiver.c
@@ -17,7 +17,7 @@
 
 #include "receiver.h"
 
-char data_recv[OCTET_TO_SIZEOFUNIT(MESSAGE_SIZE)] = { 0 };
+char data_recv[MESSAGE_SIZE] = { 0 };
 
 void dequtask(void);
 void waittask(void);

--- a/tests/benchmarks/app_kernel/src/receiver.h
+++ b/tests/benchmarks/app_kernel/src/receiver.h
@@ -22,6 +22,6 @@ struct getinfo{
 };
 
 /* global data */
-extern char data_recv[OCTET_TO_SIZEOFUNIT(MESSAGE_SIZE)];
+extern char data_recv[MESSAGE_SIZE];
 
 #endif /* _RECEIVER_H */


### PR DESCRIPTION
All architecture defines `OCTET_TO_SIZEOFUNIT` and `SIZEOFUNIT_TO_OCTET`
as identity functions. But the only user is `tests/benchmarks/app_kernel`.
It's effectively a no-op.  Remove them.

The initial commit (8ddf82cf70dc6f) already had them and there were a
few users of them (ie, in `kernel/microkernel`).  But those code are
gone when we moved to unified kernel.