### PR TITLE
cmake: Support specifying Kconfig options on the CLI

### DIFF
--- a/cmake/kconfig.cmake
+++ b/cmake/kconfig.cmake
@@ -36,6 +36,30 @@ add_custom_target(
   USES_TERMINAL
   )
 
+# Support assigning Kconfig symbols on the command-line with CMake
+# cache variables prefixed with 'CONFIG_'. This feature is
+# experimental and undocumented until it has undergone more
+# user-testing.
+unset(EXTRA_KCONFIG_OPTIONS)
+get_cmake_property(cache_variable_names CACHE_VARIABLES)
+foreach (name ${cache_variable_names})
+  if("${name}" MATCHES "^CONFIG_")
+    # When a cache variable starts with 'CONFIG_', it is assumed to be
+    # a CLI Kconfig symbol assignment.
+    set(EXTRA_KCONFIG_OPTIONS
+      "${EXTRA_KCONFIG_OPTIONS}\n${name}=${${name}}"
+      )
+  endif()
+endforeach()
+
+if(EXTRA_KCONFIG_OPTIONS)
+  set(EXTRA_KCONFIG_OPTIONS_FILE ${PROJECT_BINARY_DIR}/misc/generated/extra_kconfig_options.conf)
+  file(WRITE
+    ${EXTRA_KCONFIG_OPTIONS_FILE}
+    ${EXTRA_KCONFIG_OPTIONS}
+    )
+endif()
+
 # Bring in extra configuration files dropped in by the user or anyone else;
 # make sure they are set at the end so we can override any other setting
 file(GLOB config_files ${APPLICATION_BINARY_DIR}/*.conf)
@@ -45,6 +69,7 @@ set(
   ${BOARD_DEFCONFIG}
   ${CONF_FILE_AS_LIST}
   ${OVERLAY_CONFIG}
+  ${EXTRA_KCONFIG_OPTIONS_FILE}
   ${config_files}
 )
 

--- a/doc/application/application.rst
+++ b/doc/application/application.rst
@@ -840,6 +840,19 @@ Below is a simple example :file:`CMakeList.txt`:
 
    target_sources(app PRIVATE src/main.c)
 
+CMakeCache.txt
+==============
+
+CMake uses a CMakeCache.txt file as persistent key/value string
+storage used to cache values between runs, including compile and build
+options and paths to library dependencies. This cache file is created
+when CMake is run in an empty build folder.
+
+For more details about the CMakeCache.txt file see the official CMake
+documentation `runningcmake`_ .
+
+.. _runningcmake: http://cmake.org/runningcmake/
+
 .. _application_configuration:
 
 Application Configuration
@@ -851,13 +864,15 @@ Kconfig Configuration
 =====================
 
 The initial configuration for an application is produced by merging
-configuration settings from two sources:
+configuration settings from three sources:
 
 1. A :makevar:`BOARD`-specific configuration file, stored in
    :file:`boards/ARCHITECTURE/BOARD/BOARD_defconfig` in the Zephyr base
    directory.
 
-2. One or more application-specific configuration files.
+2. Any CMakeCache entries entries that are prefixed with :makevar:`CONFIG_`.
+
+3. One or more application-specific configuration files.
 
 The application-specific configuration file(s) can be specified in any of the
 following ways. The simplest option is to just have a single :file:`prj.conf`
@@ -879,12 +894,8 @@ file.
 3. Otherwise, if a file :file:`prj.conf` exists in the application directory,
    the settings in it are used.
 
-4. Otherwise, there are no application-specific settings, and just the settings
-   in the :makevar:`BOARD`-specific configuration are used.
-
-Configuration settings that are specified in neither the :makevar:`BOARD`
-configuration file nor in the application configuration file(s) fall back on
-their default value, as given in the :file:`Kconfig` files.
+Configuration settings that have not been specified fall back on their
+default value, as given in the :file:`Kconfig` files.
 
 The merged configuration is saved in :file:`zephyr/.config` in the build
 directory.


### PR DESCRIPTION
_NB: This replaces the original #8458 PR (was not able to re-open it)._

This resolves #5723 by adding support for assigning to Kconfig options
from the CMake CLI.

CMake CLI Kconfig options can be specified like so:

'cmake -DCONFIG_ASSERT=y'

The lifetime of such an option is the same as the lifetime of a CMake
cache variable, and in principle any method of populating the
CMakeCache could be used, such as cmake-gui.

This has been implemented by scanning the CMakeCache variables before
Kconfig is executed and writing any that are prefixed with 'CONFIG_'
to a new Kconfig fragment in the build directory that is merged in
with a high precedence.

Signed-off-by: Sebastian Bøe <sebastian.boe@nordicsemi.no>