### PR TITLE
doc: net: Add information about websocket server API

### DIFF
--- a/doc/subsystems/networking/overview.rst
+++ b/doc/subsystems/networking/overview.rst
@@ -107,6 +107,12 @@ can be disabled if not needed.
   be prioritized depending on application needs.
   See :ref:`traffic-class-support` for more details.
 
+* **Websocket** Websocket (RFC 6455) server side functionality is supported.
+  The HTTP server API will enable websocket support if
+  :option:`CONFIG_WEBSOCKET` is enabled. Client side websocket functionality is
+  currently not supported by the websocket API.
+  See :ref:`websocket-server-sample` for information how to use the API.
+
 Additionally these network technologies (link layers) are supported in
 Zephyr OS v1.7 and later:
 


### PR DESCRIPTION
Websocket server side support was not mentioned in network
overview.rst document.

Signed-off-by: Jukka Rissanen <jukka.rissanen@linux.intel.com>