### PR TITLE
arch: soc: remove dependency for device.h in soc.h

### DIFF
--- a/arch/arm/soc/arm/beetle/soc.h
+++ b/arch/arm/soc/arm/beetle/soc.h
@@ -89,8 +89,7 @@
 
 #ifndef _ASMLANGUAGE
 
-#include <device.h>
-#include <misc/util.h>
+#include <kernel_includes.h>
 
 #include "soc_pins.h"
 #include "soc_power.h"

--- a/arch/arm/soc/atmel_sam/common/soc_gpio.h
+++ b/arch/arm/soc/atmel_sam/common/soc_gpio.h
@@ -13,7 +13,6 @@
 
 #include <zephyr/types.h>
 #include <soc.h>
-#include <gpio.h>
 
 /*
  * Pin flags/attributes

--- a/arch/arm/soc/atmel_sam/same70/soc.h
+++ b/arch/arm/soc/atmel_sam/same70/soc.h
@@ -46,6 +46,8 @@
 #include "../common/soc_pmc.h"
 #include "../common/soc_gpio.h"
 
+#include <kernel_includes.h>
+
 #endif /* _ASMLANGUAGE */
 
 /** Peripheral Hardware Request Line Identifier */

--- a/arch/arm/soc/nordic_nrf/nrf51/soc.h
+++ b/arch/arm/soc/nordic_nrf/nrf51/soc.h
@@ -15,9 +15,10 @@
 
 #include <nrf_common.h>
 #include <nrf.h>
-#include <device.h>
-#include <misc/util.h>
-#include <random/rand32.h>
+#include <kernel_includes.h>
+
+/* Add include for DTS generated information */
+#include <generated_dts_board.h>
 
 #endif /* !_ASMLANGUAGE */
 

--- a/arch/arm/soc/nordic_nrf/nrf52/soc.h
+++ b/arch/arm/soc/nordic_nrf/nrf52/soc.h
@@ -15,9 +15,10 @@
 
 #include <nrf_common.h>
 #include <nrf.h>
-#include <device.h>
-#include <misc/util.h>
-#include <random/rand32.h>
+#include <kernel_includes.h>
+
+/* Add include for DTS generated information */
+#include <generated_dts_board.h>
 
 #endif /* !_ASMLANGUAGE */
 

--- a/arch/arm/soc/nxp_imx/rt/soc.h
+++ b/arch/arm/soc/nxp_imx/rt/soc.h
@@ -16,8 +16,8 @@ extern "C" {
 #ifndef _ASMLANGUAGE
 
 #include <fsl_common.h>
-#include <device.h>
-#include <misc/util.h>
+#include <kernel_includes.h>
+
 
 #endif /* !_ASMLANGUAGE */
 

--- a/arch/arm/soc/st_stm32/stm32f4/soc.h
+++ b/arch/arm/soc/st_stm32/stm32f4/soc.h
@@ -24,11 +24,9 @@
 
 #ifndef _ASMLANGUAGE
 
-#include <device.h>
-#include <misc/util.h>
-#include <random/rand32.h>
-
 #include <stm32f4xx.h>
+
+#include <kernel_includes.h>
 
 #ifdef CONFIG_CLOCK_CONTROL_STM32_CUBE
 #include <stm32f4xx_ll_utils.h>

--- a/arch/arm/soc/st_stm32/stm32l4/soc.h
+++ b/arch/arm/soc/st_stm32/stm32l4/soc.h
@@ -22,8 +22,8 @@
 #ifndef _ASMLANGUAGE
 
 #include <autoconf.h>
-#include <device.h>
 #include <stm32l4xx.h>
+#include <kernel_includes.h>
 
 #define GPIO_REG_SIZE         0x400
 /* base address for where GPIO registers start */

--- a/include/arch/arm/cortex_m/mpu/arm_mpu.h
+++ b/include/arch/arm/cortex_m/mpu/arm_mpu.h
@@ -7,6 +7,7 @@
 #define _ARM_MPU_H_
 
 #include <arch/arm/cortex_m/mpu/arm_core_mpu_dev.h>
+#include <arch/arm/cortex_m/cmsis.h>
 
 struct arm_mpu {
 	/* 0xE000ED90 MPU Type Register */

--- a/include/kernel.h
+++ b/include/kernel.h
@@ -14,27 +14,7 @@
 #define _kernel__h_
 
 #if !defined(_ASMLANGUAGE)
-#include <stddef.h>
-#include <zephyr/types.h>
-#include <limits.h>
-#include <toolchain.h>
-#include <linker/sections.h>
-#include <atomic.h>
-#include <errno.h>
-#include <misc/__assert.h>
-#include <sched_priq.h>
-#include <misc/dlist.h>
-#include <misc/slist.h>
-#include <misc/sflist.h>
-#include <misc/util.h>
-#include <misc/mempool_base.h>
-#include <kernel_version.h>
-#include <random/rand32.h>
-#include <kernel_arch_thread.h>
-#include <syscall.h>
-#include <misc/printk.h>
-#include <arch/cpu.h>
-#include <misc/rb.h>
+#include <kernel_includes.h>
 
 #ifdef __cplusplus
 extern "C" {

--- a/include/kernel_includes.h
+++ b/include/kernel_includes.h
@@ -1,0 +1,38 @@
+/*
+ * Copyright (c) 2018 Intel Corporation
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * @file
+ *
+ * @brief Header files included by kernel.h.
+ */
+
+#ifndef _KERNEL_INCLUDES__H
+#define _KERNEL_INCLUDES__H
+
+#include <stddef.h>
+#include <zephyr/types.h>
+#include <limits.h>
+#include <toolchain.h>
+#include <linker/sections.h>
+#include <atomic.h>
+#include <errno.h>
+#include <misc/__assert.h>
+#include <sched_priq.h>
+#include <misc/dlist.h>
+#include <misc/slist.h>
+#include <misc/sflist.h>
+#include <misc/util.h>
+#include <misc/mempool_base.h>
+#include <kernel_version.h>
+#include <random/rand32.h>
+#include <kernel_arch_thread.h>
+#include <syscall.h>
+#include <misc/printk.h>
+#include <arch/cpu.h>
+#include <misc/rb.h>
+
+#endif /* _KERNEL_INCLUDES__H */


### PR DESCRIPTION
This pull request does the following things:

1. It instructs arm_mpu.h to include the `include/arch/arm/cortex_m/cmsis.h`. This is _required_ since now arm_mpu.h uses bitsets and flags directly from ARM CMSIS. This is the right thing to do.

However, `include/arch/arm/cortex_m/cmsis.h` includes `soc.h`; the reason is that it needs to have specific SOC (i.e. vendor) information to decide whether to add CMSIS-like defines for non-CMSIS compliant devices.

The problem is that soc.h ends up including kernel.h (through device.h) in many ARM SOCs. This introduces inclusion loops that break compilation.

2. So this PR tries to break these loops whenever they have shown to lead to build errors. In those cases `soc.h` files were modified _not_ to end up including kernel.h.

3. A new file, `kernel_includes.h` was introduced, that only gathers the header files to be included by kernel.h. We instruct soc.h to include `kernel_includes.h` to get required utility headers, but _not_ include all `kernel.h` header.

The PR is split in 3 commits that consist of:
- the introduction of kernel_includes.h [effectively, this is a _no_change_]
- the inclusion of ARM cmsis in `arm_mpu.h`
- the modification of SOC.h files.

