### PR TITLE
usb: remove all CONFIG_*_EP_ADDR options

### DIFF
--- a/arch/arm/soc/st_stm32/stm32f4/Kconfig.defconfig.series
+++ b/arch/arm/soc/st_stm32/stm32f4/Kconfig.defconfig.series
@@ -25,23 +25,6 @@ config GPIO_STM32_PORTH
 
 endif # GPIO_STM32
 
-if USB
-
-if USB_CDC_ACM
-
-config CDC_ACM_INT_EP_ADDR
-	default 0x81
-
-config CDC_ACM_IN_EP_ADDR
-	default 0x82
-
-config CDC_ACM_OUT_EP_ADDR
-	default 0x03
-
-endif # USB_CDC_ACM
-
-endif #USB
-
 if I2C_STM32
 
 config I2C_STM32_V1

--- a/subsys/usb/class/Kconfig
+++ b/subsys/usb/class/Kconfig
@@ -22,30 +22,6 @@ config CDC_ACM_PORT_NAME
 	help
 	  Port name through which CDC ACM class device driver is accessed
 
-config CDC_ACM_INT_EP_ADDR
-	hex "CDC ACM Interrupt Endpoint address"
-	depends on USB_CDC_ACM
-	default 0x85
-	range 0x81 0x8f
-	help
-	  CDC ACM class interrupt endpoint address
-
-config CDC_ACM_IN_EP_ADDR
-	hex "CDC ACM BULK IN Endpoint address"
-	depends on USB_CDC_ACM
-	default 0x84
-	range 0x81 0x8f
-	help
-	  CDC ACM class IN endpoint address
-
-config CDC_ACM_OUT_EP_ADDR
-	hex "CDC ACM BULK OUT Endpoint address"
-	depends on USB_CDC_ACM
-	default 0x03
-	range 0x01 0x0f
-	help
-	  CDC ACM class OUT endpoint address
-
 config CDC_ACM_INTERRUPT_EP_MPS
 	int
 	depends on USB_CDC_ACM
@@ -95,22 +71,6 @@ config MASS_STORAGE_DISK_NAME
 	help
 	  Mass storage device disk or drive name
 
-config MASS_STORAGE_IN_EP_ADDR
-	hex
-	depends on USB_MASS_STORAGE
-	default 0x82
-	range 0x81 0x8f
-	help
-	  Mass storage device class IN endpoint address
-
-config MASS_STORAGE_OUT_EP_ADDR
-	hex
-	depends on USB_MASS_STORAGE
-	default 0x01
-	range 0x01 0x0f
-	help
-	  Mass storage device class OUT endpoint address
-
 config MASS_STORAGE_BULK_EP_MPS
 	int
 	depends on USB_MASS_STORAGE
@@ -147,30 +107,6 @@ config USB_DEVICE_BLUETOOTH
 	default n
 	help
 	  USB Bluetooth device class driver
-
-config BLUETOOTH_INT_EP_ADDR
-	hex
-	depends on USB_DEVICE_BLUETOOTH
-	default 0x81
-	range 0x81 0x8f
-	help
-	  Bluetooth device class INT endpoint address
-
-config BLUETOOTH_OUT_EP_ADDR
-	hex
-	depends on USB_DEVICE_BLUETOOTH
-	default 0x02
-	range 0x01 0x0f
-	help
-	  Bluetooth device class OUT endpoint address
-
-config BLUETOOTH_IN_EP_ADDR
-	hex
-	depends on USB_DEVICE_BLUETOOTH
-	default 0x82
-	range 0x81 0x8f
-	help
-	  Bluetooth device class IN endpoint address
 
 config BLUETOOTH_INT_EP_MPS
 	int

--- a/subsys/usb/class/bluetooth.c
+++ b/subsys/usb/class/bluetooth.c
@@ -40,6 +40,10 @@ NET_BUF_POOL_DEFINE(tx_pool, CONFIG_BT_HCI_CMD_COUNT, CMD_BUF_SIZE,
 #define BT_BUF_ACL_SIZE BT_L2CAP_BUF_SIZE(BT_L2CAP_MTU)
 NET_BUF_POOL_DEFINE(acl_tx_pool, 2, BT_BUF_ACL_SIZE, sizeof(u8_t), NULL);
 
+#define BLUETOOTH_INT_EP_ADDR		0x81
+#define BLUETOOTH_OUT_EP_ADDR		0x02
+#define BLUETOOTH_IN_EP_ADDR		0x82
+
 /* HCI RX/TX threads */
 static K_THREAD_STACK_DEFINE(rx_thread_stack, 512);
 static struct k_thread rx_thread_data;
@@ -71,7 +75,7 @@ USBD_CLASS_DESCR_DEFINE(primary) struct usb_bluetooth_config bluetooth_cfg = {
 	.if0_int_ep = {
 		.bLength = sizeof(struct usb_ep_descriptor),
 		.bDescriptorType = USB_ENDPOINT_DESC,
-		.bEndpointAddress = CONFIG_BLUETOOTH_INT_EP_ADDR,
+		.bEndpointAddress = BLUETOOTH_INT_EP_ADDR,
 		.bmAttributes = USB_DC_EP_INTERRUPT,
 		.wMaxPacketSize =
 			sys_cpu_to_le16(
@@ -83,7 +87,7 @@ USBD_CLASS_DESCR_DEFINE(primary) struct usb_bluetooth_config bluetooth_cfg = {
 	.if0_out_ep = {
 		.bLength = sizeof(struct usb_ep_descriptor),
 		.bDescriptorType = USB_ENDPOINT_DESC,
-		.bEndpointAddress = CONFIG_BLUETOOTH_OUT_EP_ADDR,
+		.bEndpointAddress = BLUETOOTH_OUT_EP_ADDR,
 		.bmAttributes = USB_DC_EP_BULK,
 		.wMaxPacketSize =
 			sys_cpu_to_le16(
@@ -95,7 +99,7 @@ USBD_CLASS_DESCR_DEFINE(primary) struct usb_bluetooth_config bluetooth_cfg = {
 	.if0_in_ep = {
 		.bLength = sizeof(struct usb_ep_descriptor),
 		.bDescriptorType = USB_ENDPOINT_DESC,
-		.bEndpointAddress = CONFIG_BLUETOOTH_IN_EP_ADDR,
+		.bEndpointAddress = BLUETOOTH_IN_EP_ADDR,
 		.bmAttributes = USB_DC_EP_BULK,
 		.wMaxPacketSize =
 			sys_cpu_to_le16(
@@ -111,15 +115,15 @@ USBD_CLASS_DESCR_DEFINE(primary) struct usb_bluetooth_config bluetooth_cfg = {
 static struct usb_ep_cfg_data bluetooth_ep_data[] = {
 	{
 		.ep_cb = usb_transfer_ep_callback,
-		.ep_addr = CONFIG_BLUETOOTH_INT_EP_ADDR,
+		.ep_addr = BLUETOOTH_INT_EP_ADDR,
 	},
 	{
 		.ep_cb = usb_transfer_ep_callback,
-		.ep_addr = CONFIG_BLUETOOTH_OUT_EP_ADDR,
+		.ep_addr = BLUETOOTH_OUT_EP_ADDR,
 	},
 	{
 		.ep_cb = usb_transfer_ep_callback,
-		.ep_addr = CONFIG_BLUETOOTH_IN_EP_ADDR,
+		.ep_addr = BLUETOOTH_IN_EP_ADDR,
 	},
 };
 

--- a/subsys/usb/class/cdc_acm.c
+++ b/subsys/usb/class/cdc_acm.c
@@ -72,6 +72,10 @@
 /* Serial state notification timeout */
 #define CDC_CONTROL_SERIAL_STATE_TIMEOUT_US 100000
 
+#define CDC_ACM_INT_EP_ADDR		0x85
+#define CDC_ACM_IN_EP_ADDR		0x84
+#define CDC_ACM_OUT_EP_ADDR		0x03
+
 #define ACM_INT_EP_IDX			0
 #define ACM_OUT_EP_IDX			1
 #define ACM_IN_EP_IDX			2
@@ -159,7 +163,7 @@ USBD_CLASS_DESCR_DEFINE(primary) struct usb_cdc_acm_config cdc_acm_cfg = {
 	.if0_int_ep = {
 		.bLength = sizeof(struct usb_ep_descriptor),
 		.bDescriptorType = USB_ENDPOINT_DESC,
-		.bEndpointAddress = CONFIG_CDC_ACM_INT_EP_ADDR,
+		.bEndpointAddress = CDC_ACM_INT_EP_ADDR,
 		.bmAttributes = USB_DC_EP_INTERRUPT,
 		.wMaxPacketSize =
 			sys_cpu_to_le16(
@@ -182,7 +186,7 @@ USBD_CLASS_DESCR_DEFINE(primary) struct usb_cdc_acm_config cdc_acm_cfg = {
 	.if1_in_ep = {
 		.bLength = sizeof(struct usb_ep_descriptor),
 		.bDescriptorType = USB_ENDPOINT_DESC,
-		.bEndpointAddress = CONFIG_CDC_ACM_IN_EP_ADDR,
+		.bEndpointAddress = CDC_ACM_IN_EP_ADDR,
 		.bmAttributes = USB_DC_EP_BULK,
 		.wMaxPacketSize =
 			sys_cpu_to_le16(
@@ -193,7 +197,7 @@ USBD_CLASS_DESCR_DEFINE(primary) struct usb_cdc_acm_config cdc_acm_cfg = {
 	.if1_out_ep = {
 		.bLength = sizeof(struct usb_ep_descriptor),
 		.bDescriptorType = USB_ENDPOINT_DESC,
-		.bEndpointAddress = CONFIG_CDC_ACM_OUT_EP_ADDR,
+		.bEndpointAddress = CDC_ACM_OUT_EP_ADDR,
 		.bmAttributes = USB_DC_EP_BULK,
 		.wMaxPacketSize =
 			sys_cpu_to_le16(
@@ -440,15 +444,15 @@ static void cdc_interface_config(u8_t bInterfaceNumber)
 static struct usb_ep_cfg_data cdc_acm_ep_data[] = {
 	{
 		.ep_cb	= cdc_acm_int_in,
-		.ep_addr = CONFIG_CDC_ACM_INT_EP_ADDR
+		.ep_addr = CDC_ACM_INT_EP_ADDR
 	},
 	{
 		.ep_cb	= cdc_acm_bulk_out,
-		.ep_addr = CONFIG_CDC_ACM_OUT_EP_ADDR
+		.ep_addr = CDC_ACM_OUT_EP_ADDR
 	},
 	{
 		.ep_cb = cdc_acm_bulk_in,
-		.ep_addr = CONFIG_CDC_ACM_IN_EP_ADDR
+		.ep_addr = CDC_ACM_IN_EP_ADDR
 	}
 };
 

--- a/subsys/usb/class/hid/Kconfig
+++ b/subsys/usb/class/hid/Kconfig
@@ -15,14 +15,6 @@ config USB_DEVICE_HID
 
 if USB_DEVICE_HID
 
-config HID_INT_EP_ADDR
-	hex
-	prompt "USB HID Device Interrupt Endpoint address"
-	default 0x81
-	range 0x81 0x8F
-	help
-	  USB HID Device interrupt endpoint address
-
 config HID_INTERRUPT_EP_MPS
 	int
 	prompt "USB HID Device Interrupt Endpoint size"

--- a/subsys/usb/class/hid/core.c
+++ b/subsys/usb/class/hid/core.c
@@ -17,6 +17,8 @@
 #include <usb_descriptor.h>
 #include <class/usb_hid.h>
 
+#define HID_INT_EP_ADDR				0x81
+
 #define HID_INT_IN_EP_IDX			0
 #define HID_INT_OUT_EP_IDX			1
 
@@ -57,7 +59,7 @@ USBD_CLASS_DESCR_DEFINE(primary) struct usb_hid_config hid_cfg = {
 	.if0_int_ep = {
 		.bLength = sizeof(struct usb_ep_descriptor),
 		.bDescriptorType = USB_ENDPOINT_DESC,
-		.bEndpointAddress = CONFIG_HID_INT_EP_ADDR,
+		.bEndpointAddress = HID_INT_EP_ADDR,
 		.bmAttributes = USB_DC_EP_INTERRUPT,
 		.wMaxPacketSize =
 			sys_cpu_to_le16(
@@ -205,7 +207,7 @@ static void hid_int_in(u8_t ep, enum usb_dc_ep_cb_status_code ep_status)
 static struct usb_ep_cfg_data hid_ep_data[] = {
 	{
 		.ep_cb = hid_int_in,
-		.ep_addr = CONFIG_HID_INT_EP_ADDR
+		.ep_addr = HID_INT_EP_ADDR
 	}
 };
 

--- a/subsys/usb/class/mass_storage.c
+++ b/subsys/usb/class/mass_storage.c
@@ -59,6 +59,9 @@
 #define THREAD_OP_WRITE_QUEUED		3
 #define THREAD_OP_WRITE_DONE		4
 
+#define MASS_STORAGE_IN_EP_ADDR		0x82
+#define MASS_STORAGE_OUT_EP_ADDR	0x01
+
 struct usb_mass_config {
 	struct usb_if_descriptor if0;
 	struct usb_ep_descriptor if0_in_ep;
@@ -82,7 +85,7 @@ USBD_CLASS_DESCR_DEFINE(primary) struct usb_mass_config mass_cfg = {
 	.if0_in_ep = {
 		.bLength = sizeof(struct usb_ep_descriptor),
 		.bDescriptorType = USB_ENDPOINT_DESC,
-		.bEndpointAddress = CONFIG_MASS_STORAGE_IN_EP_ADDR,
+		.bEndpointAddress = MASS_STORAGE_IN_EP_ADDR,
 		.bmAttributes = USB_DC_EP_BULK,
 		.wMaxPacketSize =
 			sys_cpu_to_le16(CONFIG_MASS_STORAGE_BULK_EP_MPS),
@@ -92,7 +95,7 @@ USBD_CLASS_DESCR_DEFINE(primary) struct usb_mass_config mass_cfg = {
 	.if0_out_ep = {
 		.bLength = sizeof(struct usb_ep_descriptor),
 		.bDescriptorType = USB_ENDPOINT_DESC,
-		.bEndpointAddress = CONFIG_MASS_STORAGE_OUT_EP_ADDR,
+		.bEndpointAddress = MASS_STORAGE_OUT_EP_ADDR,
 		.bmAttributes = USB_DC_EP_BULK,
 		.wMaxPacketSize =
 			sys_cpu_to_le16(CONFIG_MASS_STORAGE_BULK_EP_MPS),
@@ -125,11 +128,11 @@ static void mass_storage_bulk_in(u8_t ep,
 static struct usb_ep_cfg_data mass_ep_data[] = {
 	{
 		.ep_cb	= mass_storage_bulk_out,
-		.ep_addr = CONFIG_MASS_STORAGE_OUT_EP_ADDR
+		.ep_addr = MASS_STORAGE_OUT_EP_ADDR
 	},
 	{
 		.ep_cb = mass_storage_bulk_in,
-		.ep_addr = CONFIG_MASS_STORAGE_IN_EP_ADDR
+		.ep_addr = MASS_STORAGE_IN_EP_ADDR
 	}
 };
 

--- a/subsys/usb/class/netusb/Kconfig
+++ b/subsys/usb/class/netusb/Kconfig
@@ -45,27 +45,6 @@ config USB_DEVICE_NETWORK_RNDIS
 
 if USB_DEVICE_NETWORK_ECM
 
-config CDC_ECM_INT_EP_ADDR
-	hex "CDC ECM Interrupt Endpoint address"
-	default 0x83
-	range 0x81 0x8F
-	help
-	  CDC ECM class interrupt endpoint address
-
-config CDC_ECM_IN_EP_ADDR
-	hex "CDC ECM BULK IN Endpoint address"
-	default 0x82
-	range 0x81 0x8F
-	help
-	  CDC ECM class IN endpoint address
-
-config CDC_ECM_OUT_EP_ADDR
-	hex "CDC ECM BULK OUT Endpoint address"
-	default 0x01
-	range 0x01 0x0F
-	help
-	  CDC ECM class OUT endpoint address
-
 config CDC_ECM_INTERRUPT_EP_MPS
 	int
 	default 16
@@ -91,16 +70,6 @@ endif # USB_DEVICE_NETWORK_ECM
 
 if USB_DEVICE_NETWORK_EEM
 
-config CDC_EEM_OUT_EP_ADDR
-	hex "CDC EEM BULK OUT Endpoint address"
-	default 0x01
-	range 0x01 0x0F
-
-config CDC_EEM_IN_EP_ADDR
-	hex "CDC EEM BULK IN Endpoint address"
-	default 0x82
-	range 0x81 0x8F
-
 config CDC_EEM_BULK_EP_MPS
 	int
 	default 64
@@ -108,27 +77,6 @@ config CDC_EEM_BULK_EP_MPS
 endif #USB_DEVICE_NETWORK_EEM
 
 if USB_DEVICE_NETWORK_RNDIS
-
-config RNDIS_INT_EP_ADDR
-	hex "RNDIS Interrupt Endpoint address"
-	default 0x83
-	range 0x81 0x8F
-	help
-	  RNDIS interrupt endpoint address
-
-config RNDIS_IN_EP_ADDR
-	hex "RNDIS BULK IN Endpoint address"
-	default 0x82
-	range 0x81 0x8F
-	help
-	  RNDIS bulk IN endpoint address
-
-config RNDIS_OUT_EP_ADDR
-	hex "RNDIS BULK OUT Endpoint address"
-	default 0x01
-	range 0x01 0x0F
-	help
-	  RNDIS bulk OUT endpoint address
 
 config RNDIS_INTERRUPT_EP_MPS
 	int

--- a/subsys/usb/class/netusb/function_ecm.c
+++ b/subsys/usb/class/netusb/function_ecm.c
@@ -39,17 +39,17 @@ static struct usb_ep_cfg_data ecm_ep_data[] = {
 	/* Configuration ECM */
 	{
 		.ep_cb = ecm_int_in,
-		.ep_addr = CONFIG_CDC_ECM_INT_EP_ADDR
+		.ep_addr = CDC_ECM_INT_EP_ADDR
 	},
 	{
 		/* high-level transfer mgmt */
 		.ep_cb = usb_transfer_ep_callback,
-		.ep_addr = CONFIG_CDC_ECM_OUT_EP_ADDR
+		.ep_addr = CDC_ECM_OUT_EP_ADDR
 	},
 	{
 		/* high-level transfer mgmt */
 		.ep_cb = usb_transfer_ep_callback,
-		.ep_addr = CONFIG_CDC_ECM_IN_EP_ADDR
+		.ep_addr = CDC_ECM_IN_EP_ADDR
 	},
 };
 

--- a/subsys/usb/class/netusb/function_eem.c
+++ b/subsys/usb/class/netusb/function_eem.c
@@ -27,12 +27,12 @@ static struct usb_ep_cfg_data eem_ep_data[] = {
 	{
 		/* Use transfer API */
 		.ep_cb = usb_transfer_ep_callback,
-		.ep_addr = CONFIG_CDC_EEM_OUT_EP_ADDR
+		.ep_addr = CDC_EEM_OUT_EP_ADDR
 	},
 	{
 		/* Use transfer API */
 		.ep_cb = usb_transfer_ep_callback,
-		.ep_addr = CONFIG_CDC_EEM_IN_EP_ADDR
+		.ep_addr = CDC_EEM_IN_EP_ADDR
 	},
 };
 

--- a/subsys/usb/class/netusb/function_rndis.c
+++ b/subsys/usb/class/netusb/function_rndis.c
@@ -142,15 +142,15 @@ static void rndis_bulk_in(u8_t ep, enum usb_dc_ep_cb_status_code ep_status);
 static struct usb_ep_cfg_data rndis_ep_data[] = {
 	{
 		.ep_cb = rndis_int_in,
-		.ep_addr = CONFIG_RNDIS_INT_EP_ADDR
+		.ep_addr = RNDIS_INT_EP_ADDR
 	},
 	{
 		.ep_cb = rndis_bulk_out,
-		.ep_addr = CONFIG_RNDIS_OUT_EP_ADDR
+		.ep_addr = RNDIS_OUT_EP_ADDR
 	},
 	{
 		.ep_cb = rndis_bulk_in,
-		.ep_addr = CONFIG_RNDIS_IN_EP_ADDR
+		.ep_addr = RNDIS_IN_EP_ADDR
 	},
 };
 

--- a/subsys/usb/class/netusb/netusb.c
+++ b/subsys/usb/class/netusb/netusb.c
@@ -110,7 +110,7 @@ USBD_CLASS_DESCR_DEFINE(primary) struct usb_rndis_config rndis_cfg = {
 	.if0_int_ep = {
 		.bLength = sizeof(struct usb_ep_descriptor),
 		.bDescriptorType = USB_ENDPOINT_DESC,
-		.bEndpointAddress = CONFIG_RNDIS_INT_EP_ADDR,
+		.bEndpointAddress = RNDIS_INT_EP_ADDR,
 		.bmAttributes = USB_DC_EP_INTERRUPT,
 		.wMaxPacketSize =
 			sys_cpu_to_le16(
@@ -135,7 +135,7 @@ USBD_CLASS_DESCR_DEFINE(primary) struct usb_rndis_config rndis_cfg = {
 	.if1_in_ep = {
 		.bLength = sizeof(struct usb_ep_descriptor),
 		.bDescriptorType = USB_ENDPOINT_DESC,
-		.bEndpointAddress = CONFIG_RNDIS_IN_EP_ADDR,
+		.bEndpointAddress = RNDIS_IN_EP_ADDR,
 		.bmAttributes = USB_DC_EP_BULK,
 		.wMaxPacketSize =
 			sys_cpu_to_le16(
@@ -146,7 +146,7 @@ USBD_CLASS_DESCR_DEFINE(primary) struct usb_rndis_config rndis_cfg = {
 	.if1_out_ep = {
 		.bLength = sizeof(struct usb_ep_descriptor),
 		.bDescriptorType = USB_ENDPOINT_DESC,
-		.bEndpointAddress = CONFIG_RNDIS_OUT_EP_ADDR,
+		.bEndpointAddress = RNDIS_OUT_EP_ADDR,
 		.bmAttributes = USB_DC_EP_BULK,
 		.wMaxPacketSize =
 			sys_cpu_to_le16(
@@ -230,7 +230,7 @@ USBD_CLASS_DESCR_DEFINE(primary) struct usb_cdc_ecm_config cdc_ecm_cfg = {
 	.if0_int_ep = {
 		.bLength = sizeof(struct usb_ep_descriptor),
 		.bDescriptorType = USB_ENDPOINT_DESC,
-		.bEndpointAddress = CONFIG_CDC_ECM_INT_EP_ADDR,
+		.bEndpointAddress = CDC_ECM_INT_EP_ADDR,
 		.bmAttributes = USB_DC_EP_INTERRUPT,
 		.wMaxPacketSize =
 			sys_cpu_to_le16(
@@ -269,7 +269,7 @@ USBD_CLASS_DESCR_DEFINE(primary) struct usb_cdc_ecm_config cdc_ecm_cfg = {
 	.if1_1_in_ep = {
 		.bLength = sizeof(struct usb_ep_descriptor),
 		.bDescriptorType = USB_ENDPOINT_DESC,
-		.bEndpointAddress = CONFIG_CDC_ECM_IN_EP_ADDR,
+		.bEndpointAddress = CDC_ECM_IN_EP_ADDR,
 		.bmAttributes = USB_DC_EP_BULK,
 		.wMaxPacketSize =
 			sys_cpu_to_le16(
@@ -280,7 +280,7 @@ USBD_CLASS_DESCR_DEFINE(primary) struct usb_cdc_ecm_config cdc_ecm_cfg = {
 	.if1_1_out_ep = {
 		.bLength = sizeof(struct usb_ep_descriptor),
 		.bDescriptorType = USB_ENDPOINT_DESC,
-		.bEndpointAddress = CONFIG_CDC_ECM_OUT_EP_ADDR,
+		.bEndpointAddress = CDC_ECM_OUT_EP_ADDR,
 		.bmAttributes = USB_DC_EP_BULK,
 		.wMaxPacketSize =
 			sys_cpu_to_le16(
@@ -329,7 +329,7 @@ USBD_CLASS_DESCR_DEFINE(primary) struct usb_cdc_eem_config cdc_eem_cfg = {
 	.if0_in_ep = {
 		.bLength = sizeof(struct usb_ep_descriptor),
 		.bDescriptorType = USB_ENDPOINT_DESC,
-		.bEndpointAddress = CONFIG_CDC_EEM_IN_EP_ADDR,
+		.bEndpointAddress = CDC_EEM_IN_EP_ADDR,
 		.bmAttributes = USB_DC_EP_BULK,
 		.wMaxPacketSize =
 			sys_cpu_to_le16(
@@ -341,7 +341,7 @@ USBD_CLASS_DESCR_DEFINE(primary) struct usb_cdc_eem_config cdc_eem_cfg = {
 	.if0_out_ep = {
 		.bLength = sizeof(struct usb_ep_descriptor),
 		.bDescriptorType = USB_ENDPOINT_DESC,
-		.bEndpointAddress = CONFIG_CDC_EEM_OUT_EP_ADDR,
+		.bEndpointAddress = CDC_EEM_OUT_EP_ADDR,
 		.bmAttributes = USB_DC_EP_BULK,
 		.wMaxPacketSize =
 			sys_cpu_to_le16(

--- a/subsys/usb/class/netusb/netusb.h
+++ b/subsys/usb/class/netusb/netusb.h
@@ -10,6 +10,17 @@
 
 #define NETUSB_MTU 1500
 
+#define CDC_ECM_INT_EP_ADDR		0x83
+#define CDC_ECM_IN_EP_ADDR		0x82
+#define CDC_ECM_OUT_EP_ADDR		0x01
+
+#define CDC_EEM_OUT_EP_ADDR		0x01
+#define CDC_EEM_IN_EP_ADDR		0x82
+
+#define RNDIS_INT_EP_ADDR		0x83
+#define RNDIS_IN_EP_ADDR		0x82
+#define RNDIS_OUT_EP_ADDR		0x01
+
 struct netusb_function {
 	int num_ep;
 	struct usb_ep_cfg_data *ep;


### PR DESCRIPTION
Remove all CONFIG_*_EP_ADDR options but keep the default
values for it, as they are necessary to find ep_addr in
usb_ep_cfg_data associated with bEndpointAddress in
interface descriptor.