### PR TITLE
dts/bindings: Remove redundant clock properties in st,stm32-i2c...

### DIFF
--- a/dts/bindings/i2c/st,stm32-i2c-v1.yaml
+++ b/dts/bindings/i2c/st,stm32-i2c-v1.yaml
@@ -38,10 +38,4 @@ properties:
       category: optional
       description: readable string describing the interrupts
       generation: define
-
-    clocks:
-      type: array
-      category: required
-      description: Clock gate control information
-      generation: define
 ...

--- a/dts/bindings/i2c/st,stm32-i2c-v2.yaml
+++ b/dts/bindings/i2c/st,stm32-i2c-v2.yaml
@@ -38,10 +38,4 @@ properties:
       category: optional
       description: readable string describing the interrupts
       generation: define
-
-    clocks:
-      type: array
-      category: required
-      description: Clock gate control information
-      generation: define
 ...


### PR DESCRIPTION
Clock property is is provided in i2c.yaml binding,
remove it from st,stm32-i2c-vX.yaml

Signed-off-by: Erwan Gouriou <erwan.gouriou@linaro.org>