### PR TITLE
native_posix: Let users use math functions

### DIFF
--- a/boards/posix/native_posix/CMakeLists.txt
+++ b/boards/posix/native_posix/CMakeLists.txt
@@ -10,3 +10,7 @@ zephyr_library_sources(
 	cmdline_common.c
 	cmdline.c
 	)
+
+zephyr_ld_options(
+  -lm
+)


### PR DESCRIPTION
native_posix relies on the host C library even if users think
they are selecting one of the lib/libc C libraries.

For the math functions to be available at link time we need
to link to the host math library when building for this board

Fixes: #8502