### PR TITLE
build: fix git describe call on older Git versions

### DIFF
--- a/cmake/app/boilerplate.cmake
+++ b/cmake/app/boilerplate.cmake
@@ -251,7 +251,8 @@ include(${ZEPHYR_BASE}/cmake/toolchain.cmake)
 
 find_package(Git QUIET)
 if(GIT_FOUND)
-  execute_process(COMMAND ${GIT_EXECUTABLE} -C ${ZEPHYR_BASE} describe
+  execute_process(COMMAND ${GIT_EXECUTABLE} describe
+    WORKING_DIRECTORY ${ZEPHYR_BASE}
     OUTPUT_VARIABLE BUILD_VERSION
     OUTPUT_STRIP_TRAILING_WHITESPACE)
 endif()


### PR DESCRIPTION
Older Git versions still do not support the -C argument for specifying
the working directory. Switch to using cmake WORKING_DIRECTORY instead.

This fixes #7287 again after commit 5e7e1cb.

Signed-off-by: Henrik Brix Andersen <henrik@brixandersen.dk>