### PR TITLE
kconfig: Remove redundant 'default n' properties in arch/

### DIFF
--- a/arch/Kconfig
+++ b/arch/Kconfig
@@ -92,7 +92,6 @@ config PRIVILEGED_STACK_SIZE
 
 config STACK_GROWS_UP
 	bool "Stack grows towards higher memory addresses"
-	default n
 	help
 	  Select this option if the architecture has upward growing thread
 	  stacks. This is not common.
@@ -109,7 +108,6 @@ config MAX_THREAD_BYTES
 
 config DYNAMIC_OBJECTS
 	bool "Allow kernel objects to be allocated at runtime"
-	default n
 	depends on USERSPACE
 	help
 	Enabling this option allows for kernel objects to be requested from
@@ -124,7 +122,6 @@ config DYNAMIC_OBJECTS
 config SIMPLE_FATAL_ERROR_HANDLER
 	prompt "Simple system fatal error handler"
 	bool
-	default n
 	default y if !MULTITHREADING
 	help
 	  Provides an implementation of _SysFatalErrorHandler() that hard hangs
@@ -139,7 +136,6 @@ menu "Interrupt Configuration"
 config GEN_ISR_TABLES
 	bool
 	prompt "Use generated IRQ tables"
-	default n
 	help
 	  This option controls whether a platform uses the gen_isr_tables
 	  script to generate its interrupt tables. This mechanism will create
@@ -184,7 +180,6 @@ config GEN_IRQ_START_VECTOR
 
 config IRQ_OFFLOAD
 	bool "Enable IRQ offload"
-	default n
 	help
 	  Enable irq_offload() API which allows functions to be synchronously
 	  run in interrupt context. Mainly useful for test cases.
@@ -219,7 +214,6 @@ config ARCH_HAS_THREAD_ABORT
 config SYS_POWER_LOW_POWER_STATE_SUPPORTED
 	# Hidden
 	bool
-	default n
 	help
 	  This option signifies that the target supports the SYS_POWER_LOW_POWER_STATE
 	  configuration option.
@@ -227,7 +221,6 @@ config SYS_POWER_LOW_POWER_STATE_SUPPORTED
 config SYS_POWER_DEEP_SLEEP_SUPPORTED
 	# Hidden
 	bool
-	default n
 	help
 	  This option signifies that the target supports the SYS_POWER_DEEP_SLEEP
 	  configuration option.
@@ -235,7 +228,6 @@ config SYS_POWER_DEEP_SLEEP_SUPPORTED
 config BOOTLOADER_CONTEXT_RESTORE_SUPPORTED
 	# Hidden
 	bool
-	default n
 	help
 	  This option signifies that the target has options of bootloaders
 	  that support context restore upon resume from deep sleep
@@ -246,7 +238,6 @@ config BOOTLOADER_CONTEXT_RESTORE_SUPPORTED
 
 config CPU_HAS_FPU
 	bool
-	default n
 	help
 	  This option is enabled when the CPU has hardware floating point
 	  unit.
@@ -254,14 +245,12 @@ config CPU_HAS_FPU
 config CPU_HAS_MPU
 	bool
 	# Omit prompt to signify "hidden" option
-	default n
 	help
 	  This option is enabled when the CPU has a Memory Protection Unit (MPU).
 
 config MPU_REQUIRES_POWER_OF_TWO_ALIGNMENT
 	bool
 	# Omit prompt to signify "hidden" option
-	default n
 	help
 	  This option is enabled when the MPU requires a power of two alignment
 	  and size for MPU regions.
@@ -273,7 +262,6 @@ depends on CPU_HAS_FPU
 config FLOAT
 	bool
 	prompt "Floating point registers"
-	default n
 	help
 	  This option allows threads to use the floating point registers.
 	  By default, only a single thread may use the registers.
@@ -285,7 +273,6 @@ config FP_SHARING
 	bool
 	prompt "Floating point register sharing"
 	depends on FLOAT
-	default n
 	help
 	  This option allows multiple threads to use the floating point
 	  registers.

--- a/arch/arc/Kconfig
+++ b/arch/arc/Kconfig
@@ -126,8 +126,7 @@ config	FAULT_DUMP
 	  0: Off.
 
 config	XIP
-	default n if UART_NSIM
-	default y
+	default y if !UART_NSIM
 
 config GEN_ISR_TABLES
 	default y
@@ -138,7 +137,6 @@ config GEN_IRQ_START_VECTOR
 config HARVARD
 	prompt "Harvard Architecture"
 	bool
-	default n
 	help
 	  The ARC CPU can be configured to have two busses;
 	  one for instruction fetching and another that serves as a data bus.
@@ -146,14 +144,12 @@ config HARVARD
 config CODE_DENSITY
 	prompt "Code Density Option"
 	bool
-	default n
 	help
 	  Enable code density option to get better code density
 
 config ARC_HAS_SECURE
 	bool
 	#  a hidden option
-	default n
 	help
 	  This option is enabled when ARC core supports secure mode
 
@@ -164,7 +160,6 @@ config ARC_MPU_ENABLE
 	bool "Enable MPU"
 	depends on CPU_HAS_MPU
 	select ARC_MPU
-	default n
 	help
 	  Enable MPU
 
@@ -175,7 +170,6 @@ endmenu
 config CACHE_LINE_SIZE_DETECT
 	bool
 	prompt "Detect d-cache line size at runtime"
-	default n
 	help
 	  This option enables querying the d-cache build register for finding
 	  the d-cache line size at the expense of taking more memory and code
@@ -195,11 +189,9 @@ config CACHE_LINE_SIZE
 
 config ARCH_CACHE_FLUSH_DETECT
 	bool
-	default n
 
 config CACHE_FLUSHING
 	bool
-	default n
 	prompt "Enable d-cache flushing mechanism"
 	help
 	  This links in the sys_cache_flush() function, which provides a

--- a/arch/arc/core/mpu/Kconfig
+++ b/arch/arc/core/mpu/Kconfig
@@ -17,14 +17,12 @@ config ARC_MPU_VER
 config ARC_CORE_MPU
 	bool "ARC Core MPU functionalities"
 	depends on CPU_HAS_MPU
-	default n
 	help
 	  ARC core MPU functionalities
 
 config MPU_STACK_GUARD
 	bool "Thread Stack Guards"
 	depends on ARC_CORE_MPU && !ARC_STACK_CHECKING
-	default n
 	help
 	  Enable thread stack guards via MPU. ARC supports built-in stack protection.
 	  If your core supports that, it is preferred over MPU stack guard
@@ -35,6 +33,5 @@ config ARC_MPU
 	select ARC_CORE_MPU
 	select THREAD_STACK_INFO
 	select MPU_REQUIRES_POWER_OF_TWO_ALIGNMENT if ARC_MPU_VER = 2
-	default n
 	help
 	  Target has ARC MPU (currently only works for EMSK 2.2/2.3 ARCEM7D)

--- a/arch/arm/core/Kconfig
+++ b/arch/arm/core/Kconfig
@@ -9,14 +9,12 @@
 config CPU_CORTEX
 	bool
 	# Omit prompt to signify "hidden" option
-	default n
 	help
 	  This option signifies the use of a CPU of the Cortex family.
 
 config CPU_CORTEX_M
 	bool
 	# Omit prompt to signify "hidden" option
-	default n
 	select CPU_CORTEX
 	select ARCH_HAS_CUSTOM_SWAP_TO_MAIN
 	select HAS_CMSIS
@@ -30,7 +28,6 @@ config CPU_CORTEX_M
 config CPU_HAS_SYSTICK
 	bool
 	# Omit prompt to signify "hidden" option
-	default n
 	help
 	  This option is enabled when the CPU has systick timer implemented.
 
@@ -38,7 +35,6 @@ config BUILTIN_STACK_GUARD
 	bool "Thread Stack Guards based on built-in ARM stack limit checking"
 	depends on CPU_CORTEX_M_HAS_SPLIM
 	select THREAD_STACK_INFO
-	default n
 	help
 	  Enable Thread/Interrupt Stack Guards via built-in Stack Pointer
 	  limit checking. The functionality must be supported by HW.
@@ -61,7 +57,6 @@ config ARM_STACK_PROTECTION
 config ARM_SECURE_FIRMWARE
 	bool
 	depends on ARMV8_M_SE
-	default n
 	help
 	  This option indicates that we are building a Zephyr image that
 	  is intended to execute in Secure state. The option is only
@@ -83,7 +78,6 @@ config ARM_NONSECURE_FIRMWARE
 	bool
 	depends on !ARM_SECURE_FIRMWARE
 	depends on ARMV8_M_SE
-	default n
 	help
 	  This option indicates that we are building a Zephyr image that
 	  is intended to execute in Non-Secure state. Execution of this

--- a/arch/arm/core/cortex_m/Kconfig
+++ b/arch/arm/core/cortex_m/Kconfig
@@ -68,7 +68,6 @@ config CPU_CORTEX_M7
 	# Omit prompt to signify "hidden" option
 	select ARMV7_M_ARMV8_M_MAINLINE
 	select ARMV7_M_ARMV8_M_FP if CPU_HAS_FPU
-	default n
 	help
 	  This option signifies the use of a Cortex-M7 CPU
 
@@ -77,7 +76,6 @@ if CPU_CORTEX_M
 config ISA_THUMB2
 	bool
 	# Omit prompt to signify "hidden" option
-	default n
 	help
 	  From: http://www.arm.com/products/processors/technologies/instruction-set-architectures.php
 
@@ -107,7 +105,6 @@ config CPU_CORTEX_M_HAS_BASEPRI
 	bool
 	# Omit prompt to signify "hidden" option
 	depends on ARMV7_M_ARMV8_M_MAINLINE
-	default n
 	help
 	  This option signifies the CPU has the BASEPRI register.
 
@@ -122,7 +119,6 @@ config CPU_CORTEX_M_HAS_VTOR
 	bool
 	# Omit prompt to signify "hidden" option
 	depends on !CPU_CORTEX_M0
-	default n
 	help
 	  This option signifies the CPU has the VTOR register.
 	  The VTOR indicates the offset of the vector table base
@@ -136,7 +132,6 @@ config CPU_CORTEX_M_HAS_SPLIM
 	bool
 	# Omit prompt to signify "hidden" option
 	depends on ARMV8_M_MAINLINE || (ARMV8_M_SE && !ARM_NONSECURE_FIRMWARE)
-	default n
 	help
 	  This option signifies the CPU has the MSPLIM, PSPLIM registers.
 
@@ -154,7 +149,6 @@ config CPU_CORTEX_M_HAS_PROGRAMMABLE_FAULT_PRIOS
 	bool
 	# Omit prompt to signify "hidden" option
 	depends on ARMV7_M_ARMV8_M_MAINLINE
-	default n
 	help
 	  This option signifies the CPU may trigger system faults
 	  (other than HardFault) with configurable priority, and,
@@ -163,7 +157,6 @@ config CPU_CORTEX_M_HAS_PROGRAMMABLE_FAULT_PRIOS
 config CPU_CORTEX_M0_HAS_VECTOR_TABLE_REMAP
 	bool
 	# Omit prompt to signify "hidden" option
-	default n
 	help
 	  This option signifies the Cortex-M0 has some mechanisms that can map
 	  the vector table to SRAM
@@ -171,14 +164,12 @@ config CPU_CORTEX_M0_HAS_VECTOR_TABLE_REMAP
 config CPU_CORTEX_M_HAS_CMSE
 	bool
 	depends on ARMV8_M_BASELINE || ARMV8_M_MAINLINE
-	default n
 	help
 	  This option signifies the Cortex-M CPU has the CMSE intrinsics.
 
 config ARMV6_M_ARMV8_M_BASELINE
 	bool
 	# Omit prompt to signify "hidden" option
-	default n
 	select ATOMIC_OPERATIONS_C
 	select ISA_THUMB2
 	help
@@ -197,7 +188,6 @@ config ARMV6_M_ARMV8_M_BASELINE
 config ARMV8_M_BASELINE
 	bool
 	# Omit prompt to signify "hidden" option
-	default n
 	select ARMV6_M_ARMV8_M_BASELINE
 	select CPU_CORTEX_M_HAS_CMSE
 	help
@@ -210,7 +200,6 @@ config ARMV8_M_BASELINE
 config ARMV7_M_ARMV8_M_MAINLINE
 	bool
 	# Omit prompt to signify "hidden" option
-	default n
 	select ATOMIC_OPERATIONS_BUILTIN
 	select ISA_THUMB2
 	select CPU_CORTEX_M_HAS_BASEPRI
@@ -290,7 +279,6 @@ config RUNTIME_NMI
 	bool
 	prompt "Attach an NMI handler at runtime"
 	select REBOOT
-	default n
 	help
 	  The kernel provides a simple NMI handler that simply hangs in a tight
 	  loop if triggered. This fills the requirement that there must be an
@@ -326,7 +314,6 @@ config GEN_ISR_TABLES
 config ZERO_LATENCY_IRQS
 	bool
 	prompt "Enable zero-latency interrupts"
-	default n
 	depends on CPU_CORTEX_M_HAS_BASEPRI
 	help
 	  The kernel may reserve some of the highest interrupts priorities in
@@ -344,7 +331,6 @@ config ZERO_LATENCY_IRQS
 config SW_VECTOR_RELAY
 	bool
 	prompt "Enable Software Vector Relay"
-	default n
 	default y if BOOTLOADER_MCUBOOT
 	depends on ARMV6_M_ARMV8_M_BASELINE && !(CPU_CORTEX_M0_HAS_VECTOR_TABLE_REMAP || CPU_CORTEX_M_HAS_VTOR)
 	help
@@ -358,7 +344,6 @@ config SW_VECTOR_RELAY
 config PLATFORM_SPECIFIC_INIT
 	bool
 	prompt "Enable platform (SOC) specific startup hook"
-	default n
 	help
 	  The platform specific initialization code (_PlatformInit) is executed
 	  at the beginning of the startup code (__start).

--- a/arch/arm/core/cortex_m/mpu/Kconfig
+++ b/arch/arm/core/cortex_m/mpu/Kconfig
@@ -10,14 +10,12 @@ config ARM_CORE_MPU
 	bool "ARM Core MPU functionalities"
 	depends on CPU_HAS_MPU
 	select THREAD_STACK_INFO
-	default n
 	help
 	  ARM Core MPU functionalities
 
 config MPU_STACK_GUARD
 	bool "Thread Stack Guards"
 	depends on ARM_CORE_MPU
-	default n
 	help
 	  Enable Thread Stack Guards via MPU
 
@@ -29,7 +27,6 @@ config ARM_MPU
 	select ARM_CORE_MPU
 	select ARCH_HAS_EXECUTABLE_PAGE_BIT
 	select MPU_REQUIRES_POWER_OF_TWO_ALIGNMENT
-	default n
 	help
 	  MCU has ARM MPU
 
@@ -39,13 +36,11 @@ config NXP_MPU
 	depends on SOC_FAMILY_KINETIS
 	select ARM_CORE_MPU
 	select ARCH_HAS_EXECUTABLE_PAGE_BIT
-	default n
 	help
 	  MCU has NXP MPU
 
 config MPU_ALLOW_FLASH_WRITE
 	bool "Add MPU access to write to flash"
 	depends on ARM_MPU || NXP_MPU
-	default n
 	help
 	  Enable this to allow MPU RWX access to flash memory

--- a/arch/arm/soc/arm/Kconfig
+++ b/arch/arm/soc/arm/Kconfig
@@ -8,7 +8,6 @@
 config SOC_FAMILY_ARM
 	bool
 	# omit prompt to signify a "hidden" option
-	default n
 
 if SOC_FAMILY_ARM
 config SOC_FAMILY

--- a/arch/arm/soc/arm/beetle/Kconfig.soc
+++ b/arch/arm/soc/arm/beetle/Kconfig.soc
@@ -19,6 +19,5 @@ config ARM_MPU_ENABLE
 	bool "Enable MPU on ARM Beetle"
 	depends on CPU_HAS_MPU
 	select ARM_MPU
-	default n
 	help
 	  Enable MPU support on ARM Beetle SoCs

--- a/arch/arm/soc/atmel_sam/Kconfig
+++ b/arch/arm/soc/atmel_sam/Kconfig
@@ -6,7 +6,6 @@
 config SOC_FAMILY_SAM
 	bool
 	# omit prompt to signify a "hidden" option
-	default n
 
 if SOC_FAMILY_SAM
 

--- a/arch/arm/soc/atmel_sam/sam3x/Kconfig.soc
+++ b/arch/arm/soc/atmel_sam/sam3x/Kconfig.soc
@@ -19,7 +19,6 @@ if SOC_SERIES_SAM3X
 
 config SOC_ATMEL_SAM3X_EXT_SLCK
 	bool "Atmel SAM3 to use external crystal oscillator for slow clock"
-	default n
 	help
 	  Says y if you want to use external 32 kHz crystal
 	  oscillator to drive the slow clock. Note that this
@@ -32,7 +31,6 @@ config SOC_ATMEL_SAM3X_EXT_SLCK
 
 config SOC_ATMEL_SAM3X_EXT_MAINCK
 	bool "Atmel SAM3 to use external crystal oscillator for main clock"
-	default n
 	help
 	  The main clock is being used to drive the PLL, and
 	  thus driving the processor clock.

--- a/arch/arm/soc/atmel_sam/sam4s/Kconfig.soc
+++ b/arch/arm/soc/atmel_sam/sam4s/Kconfig.soc
@@ -17,7 +17,6 @@ if SOC_SERIES_SAM4S
 
 config SOC_ATMEL_SAM4S_EXT_SLCK
 	bool "Atmel SAM4S to use external crystal oscillator for slow clock"
-	default n
 	help
 	  Says y if you want to use external 32 kHz crystal
 	  oscillator to drive the slow clock. Note that this
@@ -30,7 +29,6 @@ config SOC_ATMEL_SAM4S_EXT_SLCK
 
 config SOC_ATMEL_SAM4S_EXT_MAINCK
 	bool "Atmel SAM4S to use external crystal oscillator for main clock"
-	default n
 	help
 	  The main clock is being used to drive the PLL, and
 	  thus driving the processor clock.

--- a/arch/arm/soc/atmel_sam/same70/Kconfig.soc
+++ b/arch/arm/soc/atmel_sam/same70/Kconfig.soc
@@ -40,7 +40,6 @@ if SOC_SERIES_SAME70
 
 config SOC_ATMEL_SAME70_EXT_SLCK
 	bool "Use external crystal oscillator for slow clock"
-	default n
 	help
 	  Say y if you want to use external 32 kHz crystal
 	  oscillator to drive the slow clock. Note that this
@@ -53,7 +52,6 @@ config SOC_ATMEL_SAME70_EXT_SLCK
 
 config SOC_ATMEL_SAME70_EXT_MAINCK
 	bool "Use external crystal oscillator for main clock"
-	default n
 	help
 	  The main clock is being used to drive the PLL, and
 	  thus driving the processor clock.

--- a/arch/arm/soc/atmel_sam0/Kconfig
+++ b/arch/arm/soc/atmel_sam0/Kconfig
@@ -5,7 +5,6 @@
 
 config SOC_FAMILY_SAM0
 	bool
-	default n
 
 if SOC_FAMILY_SAM0
 

--- a/arch/arm/soc/atmel_sam0/samd21/Kconfig.soc
+++ b/arch/arm/soc/atmel_sam0/samd21/Kconfig.soc
@@ -55,7 +55,6 @@ if SOC_SERIES_SAMD21
 
 config SOC_ATMEL_SAMD_XOSC32K
 	bool "Enable the external 32 kHz crystal oscillator"
-	default n
 	help
 	  Say y to enable the external 32 kHZ crystal oscillator at
 	  startup.  This can then be selected as the main clock source
@@ -63,7 +62,6 @@ config SOC_ATMEL_SAMD_XOSC32K
 
 config SOC_ATMEL_SAMD_XOSC
 	bool "Enable the external crystal oscillator"
-	default n
 	help
 	  Say y to enable the external crystal oscillator at startup.
 

--- a/arch/arm/soc/nordic_nrf/Kconfig
+++ b/arch/arm/soc/nordic_nrf/Kconfig
@@ -8,7 +8,6 @@
 config SOC_FAMILY_NRF
 	bool
 	# omit prompt to signify a "hidden" option
-	default n
 
 if SOC_FAMILY_NRF
 config SOC_FAMILY

--- a/arch/arm/soc/nordic_nrf/nrf52/Kconfig.soc
+++ b/arch/arm/soc/nordic_nrf/nrf52/Kconfig.soc
@@ -201,7 +201,6 @@ config ARM_MPU_NRF52X
 	bool "Enable MPU on nRF52"
 	depends on CPU_HAS_MPU
 	select ARM_MPU
-	default n
 	help
 	  Enable MPU support on Nordic Semiconductor nRF52x series ICs.
 

--- a/arch/arm/soc/nxp_imx/Kconfig
+++ b/arch/arm/soc/nxp_imx/Kconfig
@@ -8,7 +8,6 @@ config SOC_FAMILY_IMX
 	bool
 	select HAS_SEGGER_RTT
 	# omit prompt to signify a "hidden" option
-	default n
 
 if SOC_FAMILY_IMX
 config SOC_FAMILY

--- a/arch/arm/soc/nxp_imx/rt/Kconfig.soc
+++ b/arch/arm/soc/nxp_imx/rt/Kconfig.soc
@@ -41,7 +41,6 @@ config ARM_MPU_IMX_RT
 	bool "Enable MPU on i.MX RT"
 	depends on CPU_HAS_MPU
 	select ARM_MPU
-	default n
 	help
 	  Enable MPU support on NXP i.MX RT series SoCs.
 

--- a/arch/arm/soc/nxp_kinetis/Kconfig
+++ b/arch/arm/soc/nxp_kinetis/Kconfig
@@ -9,7 +9,6 @@ config SOC_FAMILY_KINETIS
 	bool
 	select HAS_SEGGER_RTT
 	# omit prompt to signify a "hidden" option
-	default n
 
 if SOC_FAMILY_KINETIS
 config SOC_FAMILY
@@ -30,13 +29,11 @@ config SOC_PART_NUMBER
 
 config HAS_OSC
 	bool
-	default n
 	help
 	  Set if the oscillator (OSC) module is present in the SoC.
 
 config HAS_MCG
 	bool
-	default n
 	help
 	  Set if the multipurpose clock generator (MCG) module is present in the SoC.
 
@@ -44,7 +41,6 @@ config HAS_SYSMPU
 	bool "Enable MPU on NXP Kinetis"
 	depends on CPU_HAS_MPU
 	select NXP_MPU
-	default n
 	help
 	  Enable MPU support on NXP Kinetis SoCs
 

--- a/arch/arm/soc/nxp_lpc/Kconfig
+++ b/arch/arm/soc/nxp_lpc/Kconfig
@@ -8,7 +8,6 @@ config SOC_FAMILY_LPC
 	bool
 	select HAS_SEGGER_RTT
 	# omit prompt to signify a "hidden" option
-	default n
 
 if SOC_FAMILY_LPC
 config SOC_FAMILY

--- a/arch/arm/soc/nxp_lpc/lpc54xxx/Kconfig.soc
+++ b/arch/arm/soc/nxp_lpc/lpc54xxx/Kconfig.soc
@@ -37,7 +37,6 @@ config SOC_PART_NUMBER_LPC54XXX
 
 config SLAVE_CORE_MCUX
 	bool "Enable LPC54114 Cortex-M0 slave core"
-	default n
 	depends on HAS_MCUX
 	help
 	  Driver for slave core startup

--- a/arch/arm/soc/silabs_exx32/Kconfig
+++ b/arch/arm/soc/silabs_exx32/Kconfig
@@ -7,7 +7,6 @@
 config SOC_FAMILY_EXX32
 	bool
 	# omit prompt to signify a "hidden" option
-	default n
 
 if SOC_FAMILY_EXX32
 config SOC_FAMILY
@@ -26,7 +25,6 @@ config SOC_PART_NUMBER
 
 config HAS_CMU
 	bool
-	default n
 	help
 	  Set if the clock management unit (CMU) is present in the SoC.
 

--- a/arch/arm/soc/st_stm32/Kconfig
+++ b/arch/arm/soc/st_stm32/Kconfig
@@ -8,7 +8,6 @@
 config SOC_FAMILY_STM32
 	bool
 	# omit prompt to signify a "hidden" option
-	default n
 	select HAS_DTS_I2C_DEVICE if I2C
 	select HAS_DTS_SPI_DEVICE if SPI
 
@@ -22,7 +21,6 @@ config STM32_ARM_MPU_ENABLE
 	bool "Enable MPU on STM32"
 	depends on CPU_HAS_MPU
 	select ARM_MPU
-	default n
 	help
 	  Enable MPU support on STM32 SoCs
 

--- a/arch/arm/soc/ti_simplelink/Kconfig
+++ b/arch/arm/soc/ti_simplelink/Kconfig
@@ -4,7 +4,6 @@
 config SOC_FAMILY_TISIMPLELINK
 	bool
 	# omit prompt to signify a "hidden" option
-	default n
 
 if SOC_FAMILY_TISIMPLELINK
 config SOC_FAMILY

--- a/arch/arm/soc/ti_simplelink/cc32xx/Kconfig.soc
+++ b/arch/arm/soc/ti_simplelink/cc32xx/Kconfig.soc
@@ -15,9 +15,7 @@ endchoice
 if SOC_CC3220SF
 
 config CC3220SF_DEBUG
-	bool "Prepend debug header, disabling flash verification"
-	depends on XIP
-	default y if XIP
-	default n if !XIP
+	bool "Prepend debug header, disabling flash verification" if XIP
+	default XIP
 
 endif # SOC_CC3220SF

--- a/arch/nios2/Kconfig
+++ b/arch/nios2/Kconfig
@@ -50,15 +50,12 @@ config NUM_IRQS
 
 config HAS_MUL_INSTRUCTION
 	bool
-	default n
 
 config HAS_DIV_INSTRUCTION
 	bool
-	default n
 
 config HAS_MULX_INSTRUCTION
 	bool
-	default n
 
 config INCLUDE_RESET_VECTOR
 	bool "Include Reset vector"
@@ -72,7 +69,6 @@ config INCLUDE_RESET_VECTOR
 
 config EXTRA_EXCEPTION_INFO
 	bool "Extra exception debug information"
-	default n
 	help
 	  Have exceptions print additional useful debugging information in
 	  human-readable form, at the expense of code size. For example,

--- a/arch/riscv32/Kconfig
+++ b/arch/riscv32/Kconfig
@@ -25,20 +25,17 @@ menu "RISCV32 Processor Options"
 
 config INCLUDE_RESET_VECTOR
 	bool "Include Reset vector"
-	default n
 	help
 	  Include the reset vector stub that inits CPU and then jumps to __start
 
 config RISCV_SOC_CONTEXT_SAVE
 	bool "Enable SOC-based context saving in IRQ handler"
-	default n
 	help
 	  Enable SOC-based context saving, for SOCS which require saving of
 	  extra registers when entering an interrupt/exception
 
 config RISCV_SOC_INTERRUPT_INIT
 	bool "Enable SOC-based interrupt initialization"
-	default n
 	help
 	  Enable SOC-based interrupt initialization
 	  (call soc_interrupt_init, within _IntLibInit when enabled)
@@ -53,7 +50,6 @@ config RISCV_GENERIC_TOOLCHAIN
 
 config RISCV_HAS_CPU_IDLE
 	bool "Does SOC has CPU IDLE instruction"
-	default n
 	help
 	  Does SOC has CPU IDLE instruction
 

--- a/arch/riscv32/soc/riscv-privilege/Kconfig
+++ b/arch/riscv32/soc/riscv-privilege/Kconfig
@@ -9,7 +9,6 @@
 config SOC_FAMILY_RISCV_PRIVILEGE
 	bool
 	# omit prompt to signify a "hidden" option
-	default n
 
 config SOC_FAMILY
 	string
@@ -18,7 +17,6 @@ config SOC_FAMILY
 
 config RISCV_HAS_PLIC
 	bool "Does the SOC provide support for a Platform Level Interrupt Controller"
-	default n
 	depends on SOC_FAMILY_RISCV_PRIVILEGE
 	help
 	  Does the SOC provide support for a Platform Level Interrupt Controller

--- a/arch/x86/Kconfig
+++ b/arch/x86/Kconfig
@@ -51,7 +51,6 @@ menu "Processor Capabilities"
 
 config X86_IAMCU
 	bool
-	default n
 	prompt "IAMCU calling convention"
 	help
 	  The IAMCU calling convention changes the X86 C calling convention to
@@ -64,7 +63,6 @@ config X86_IAMCU
 menu "Memory Management"
 config X86_MMU
 	bool
-	default n
 	prompt "Enable Memory Management Unit"
 	help
 	  This options enables the memory management unit present in x86. Enabling
@@ -73,7 +71,6 @@ config X86_MMU
 config X86_PAE_MODE
 	bool
 	depends on X86_MMU
-	default n
 	prompt "Enable PAE page tables"
 	help
 	  When selected the Page address extension mode is enabled. The PAE
@@ -144,7 +141,6 @@ config SSE
 	bool
 	prompt "SSE registers"
 	depends on FLOAT
-	default n
 	help
 	  This option enables the use of SSE registers by threads.
 
@@ -152,7 +148,6 @@ config SSE_FP_MATH
 	bool
 	prompt "Compiler-generated SSEx instructions"
 	depends on SSE
-	default n
 	help
 	  This option allows the compiler to generate SSEx instructions for
 	  performing floating point math. This can greatly improve performance
@@ -189,7 +184,6 @@ config ISA_IA32
 config IA32_LEGACY_IO_PORTS
 	bool
 	prompt "Support IA32 legacy IO ports"
-	default n
 	depends on ISA_IA32
 	help
 	  This option enables IA32 legacy IO ports. Note these are much slower
@@ -228,7 +222,6 @@ config CLFLUSH_INSTRUCTION_SUPPORTED
 	bool
 	prompt "CLFLUSH instruction supported"
 	depends on !CLFLUSH_DETECT && CACHE_FLUSHING
-	default n
 	help
 	  An implementation of sys_cache_flush() that uses CLFLUSH is made
 	  available, instead of the one using WBINVD.
@@ -241,7 +234,6 @@ config CLFLUSH_DETECT
 	bool
 	prompt "Detect support of CLFLUSH instruction at runtime"
 	depends on CACHE_FLUSHING
-	default n
 	help
 	  This option should be enabled if it is not known in advance whether the
 	  CPU supports the CLFLUSH instruction or not.
@@ -260,7 +252,6 @@ config ARCH_CACHE_FLUSH_DETECT
 
 config CACHE_FLUSHING
 	bool
-	default n
 	prompt "Enable cache flushing mechanism"
 	help
 	  This links in the sys_cache_flush() function. A mechanism for flushing the
@@ -269,7 +260,6 @@ config CACHE_FLUSHING
 
 config PIC_DISABLE
 	bool "Disable PIC"
-	default n
 	help
 	  This option disables all interrupts on the PIC
 
@@ -312,7 +302,6 @@ config XIP
 
 config X86_FIXED_IRQ_MAPPING
 	bool
-	default n
 	help
 	  Specify whether the current interrupt controller in use has a fixed
 	  mapping between IDT vectors and IRQ lines.

--- a/arch/x86/core/Kconfig
+++ b/arch/x86/core/Kconfig
@@ -63,7 +63,6 @@ config GDT_DYNAMIC
 	bool
 	prompt "Store GDT in RAM so that it can be modified"
 	depends on SET_GDT
-	default n
 	help
 	  This option stores the GDT in RAM instead of ROM, so that it may
 	  be modified at runtime at the expense of some memory.

--- a/arch/x86/soc/intel_quark/Kconfig
+++ b/arch/x86/soc/intel_quark/Kconfig
@@ -6,7 +6,6 @@
 
 config SOC_FAMILY_QUARK
 	bool
-	default n
 
 if SOC_FAMILY_QUARK
 config SOC_FAMILY

--- a/arch/x86/soc/intel_quark/quark_se/Kconfig
+++ b/arch/x86/soc/intel_quark/quark_se/Kconfig
@@ -24,7 +24,6 @@ config SS_RESET_VECTOR
 
 config ARC_INIT
 	bool "Quark SE ARC Kickoff"
-	default n
 	help
 	  Allows x86 processor to kickoff the ARC slave processor.
 
@@ -52,7 +51,6 @@ config SYS_LOG_ARC_INIT_LEVEL
 config ARC_GDB_ENABLE
 	bool "Allows the usage of GDB with the ARC processor."
 	depends on ARC_INIT
-	default n
 	help
 	  This option will stop the master processor from boot-strapping
 	  the ARC slave processor. This will allow GDB to halt and

--- a/arch/xtensa/Kconfig
+++ b/arch/xtensa/Kconfig
@@ -18,7 +18,6 @@ config ARCH
 config SIMULATOR_XTENSA
         bool
 	prompt "Simulator Configuration"
-	default n
 	help
 	  Specify if the board configuration should be treated as a simulator.
 
@@ -33,7 +32,6 @@ config SYS_CLOCK_HW_CYCLES_PER_SEC
 config XTENSA_NO_IPC
 	bool "Core has no IPC support"
 	select ATOMIC_OPERATIONS_C
-	default n
 	help
 	  Uncheck this if you core does not implement "SCOMPARE1" register and "s32c1i"
 	  instruction.
@@ -79,7 +77,6 @@ config IRQ_OFFLOAD_INTNUM
 config XTENSA_OMIT_HIGH_INTERRUPTS
 	bool
 	prompt "Skip generation of vectors for high priority interrupts"
-	default n
 	help
 	Setting this to y causes the interrupt vectors for "high
 	priority" Xtensa interrupts (those not masked by the EXCM bit
@@ -96,7 +93,6 @@ config XTENSA_OMIT_HIGH_INTERRUPTS
 config XTENSA_ASM2
 	bool
 	prompt "New-style Xtensa context switch & interrupt layer"
-	default n
 	select USE_SWITCH
 	help
 	This selects a new implementation of context switching and


### PR DESCRIPTION
Bool symbols implicitly default to 'n'.
    
A `default n` can make sense e.g. in a `Kconfig.defconfig` file, if you want to override a `default y` on the base definition of the symbol. It isn't used like that on any of these symbols though.

The commit for `arch/arc` also has a fix for `XIP` always defaulting to `y`, regardless of the setting of `UART_NSIM`.