### PR TITLE
kernel: Kconfig: Remove redundant 'default n' properties

### DIFF
--- a/kernel/Kconfig
+++ b/kernel/Kconfig
@@ -86,14 +86,10 @@ config MAIN_THREAD_PRIORITY
 	  of the main() function. main() can then change its priority if desired.
 
 config COOP_ENABLED
-	bool
-	default y
-	default n if (NUM_COOP_PRIORITIES = 0)
+	def_bool (NUM_COOP_PRIORITIES != 0)
 
 config PREEMPT_ENABLED
-	bool
-	default y
-	default n if (NUM_PREEMPT_PRIORITIES = 0)
+	def_bool (NUM_PREEMPT_PRIORITIES != 0)
 
 config PRIORITY_CEILING
 	int
@@ -125,7 +121,6 @@ config NUM_METAIRQ_PRIORITIES
 config SCHED_DEADLINE
 	bool
 	prompt "Enable earliest-deadline-first scheduling"
-	default n
 	help
 	  This enables a simple "earliest deadline first" scheduling
 	  mode where threads can set "deadline" deltas measured in
@@ -170,7 +165,6 @@ config ISR_STACK_SIZE
 config THREAD_STACK_INFO
 	bool
 	prompt "Thread stack info"
-	default n
 	help
 	  This option allows each thread to store the thread stack info into
 	  the k_thread data structure.
@@ -178,7 +172,6 @@ config THREAD_STACK_INFO
 config  THREAD_CUSTOM_DATA
 	bool
 	prompt "Thread custom data"
-	default n
 	help
 	  This option allows each thread to store 32 bits of custom data,
 	  which can be accessed using the k_thread_custom_data_xxx() APIs.
@@ -196,7 +189,6 @@ config ERRNO
 config APPLICATION_MEMORY
 	bool
 	prompt "Split kernel and application memory"
-	default n
 	help
 	  For all read-write memory sections (namely bss, noinit, data),
 	  separate them into application and kernel areas. The application area
@@ -206,7 +198,6 @@ config APPLICATION_MEMORY
 config WAITQ_FAST
 	bool
 	prompt "Use scalable wait_q implementation"
-	default n
 	help
 	  When selected, the wait_q abstraction used in IPC primitives
 	  to pend threads for wakeup later will be implemented with a
@@ -236,7 +227,6 @@ menu "Kernel Debugging and Metrics"
 config INIT_STACKS
 	bool
 	prompt "Initialize stack areas"
-	default n
 	help
 	  This option instructs the kernel to initialize stack areas with a
 	  known value (0xaa) before they are first used, so that the high
@@ -246,7 +236,6 @@ config INIT_STACKS
 config KERNEL_DEBUG
 	bool
 	prompt "Kernel debugging"
-	default n
 	select INIT_STACKS
 	help
 	  Enable kernel debugging.
@@ -281,7 +270,6 @@ config BOOT_DELAY
 
 config BUILD_TIMESTAMP
 	bool
-	default n
 	prompt "Build Timestamp"
 	help
 	  Record a timestamp from the build and add it to the boot banner.
@@ -291,7 +279,6 @@ config BUILD_TIMESTAMP
 config INT_LATENCY_BENCHMARK
 	bool
 	prompt "Interrupt latency metrics [EXPERIMENTAL]"
-	default n
 	depends on ARCH="x86"
 	help
 	  This option enables the tracking of interrupt latency metrics;
@@ -303,7 +290,6 @@ config INT_LATENCY_BENCHMARK
 config EXECUTION_BENCHMARKING
 	bool
 	prompt "Timing metrics"
-	default n
 	help
 	  This option enables the tracking of various times inside the kernel
 	  the exact set of metrics being tracked is board-dependent.
@@ -313,7 +299,6 @@ config EXECUTION_BENCHMARKING
 config THREAD_MONITOR
 	bool
 	prompt "Thread monitoring [EXPERIMENTAL]"
-	default n
 	help
 	  This option instructs the kernel to maintain a list of all threads
 	  (excluding those that have not yet started or have already
@@ -403,7 +388,6 @@ config TIMESLICE_PRIORITY
 config POLL
 	bool
 	prompt "Async I/O Framework"
-	default n
 	help
 	  Asynchronous notification framework. Enable the k_poll() and
 	  k_poll_signal() APIs.  The former can wait on multiple events
@@ -451,7 +435,6 @@ endmenu
 config ARCH_HAS_CUSTOM_SWAP_TO_MAIN
 	bool
 	# hidden
-	default n
 	help
 	  It's possible that an architecture port cannot use _Swap() to swap to
 	  the _main() thread, but instead must do something custom. It must
@@ -460,7 +443,6 @@ config ARCH_HAS_CUSTOM_SWAP_TO_MAIN
 config ARCH_HAS_CUSTOM_BUSY_WAIT
 	bool
 	# hidden
-	default n
 	help
 	  It's possible that an architecture port cannot or does not want to use
 	  the provided k_busy_wait(), but instead must do something custom. It must
@@ -500,10 +482,8 @@ config SYS_CLOCK_HW_CYCLES_PER_SEC
 	  and the user should generally avoid modifying it via the menu configuration.
 
 config SYS_CLOCK_EXISTS
-	bool
+	def_bool (SYS_CLOCK_TICKS_PER_SEC != 0)
 	# omit prompt to signify a "hidden" option
-	default y
-	default n if (SYS_CLOCK_TICKS_PER_SEC = 0)
 	help
 	  This option specifies that the kernel lacks timer support.
 
@@ -573,7 +553,6 @@ config RETPOLINE
 config STACK_CANARIES
 	bool
 	prompt "Compiler stack canaries"
-	default n
 	help
 	  This option enables compiler stack canaries support kernel functions.
 
@@ -636,7 +615,6 @@ menu "SMP Options"
 config USE_SWITCH
 	bool
 	prompt "Use new-style _arch_switch instead of __swap"
-	default n
 	help
 	  The _arch_switch() API is a lower level context switching
 	  primitive than the original __swap mechanism.  It is required
@@ -648,7 +626,6 @@ config USE_SWITCH
 config SMP
 	bool
 	prompt "Enable symmetric multithreading support"
-	default n
 	help
 	  When true, kernel will be built with SMP support, allowing
 	  more than one CPU to schedule Zephyr tasks at a time.

--- a/kernel/Kconfig.event_logger
+++ b/kernel/Kconfig.event_logger
@@ -7,7 +7,6 @@
 menuconfig KERNEL_EVENT_LOGGER
 	bool
 	prompt "Enable kernel event logger features"
-	default n
 	select RING_BUFFER
 	help
 	  This feature enables the usage of the profiling logger. Provides the
@@ -26,7 +25,6 @@ config KERNEL_EVENT_LOGGER_BUFFER_SIZE
 config KERNEL_EVENT_LOGGER_DYNAMIC
 	bool
 	prompt "Kernel event logger dynamic enabling"
-	default n
 	help
 	  If enabled, kernel event logger is not logging any data to the ring buffer
 	  It is up to the application to set the appropriate flags to enable/disable the
@@ -35,7 +33,6 @@ config KERNEL_EVENT_LOGGER_DYNAMIC
 config KERNEL_EVENT_LOGGER_CUSTOM_TIMESTAMP
 	bool
 	prompt "Kernel event logger custom timestamp"
-	default n
 	help
 	  This flag enables the possibility to set the timer function to be used to
 	  populate kernel event logger timestamp. This has to be done at runtime by
@@ -46,14 +43,12 @@ menu "Kernel event logging points"
 config KERNEL_EVENT_LOGGER_CONTEXT_SWITCH
 	bool
 	prompt "Context switch event logging point"
-	default n
 	help
 	  Enable the context switch event messages.
 
 config KERNEL_EVENT_LOGGER_INTERRUPT
 	bool
 	prompt "Interrupt event logging point"
-	default n
 	help
 	  Enable interrupt event messages. These messages provide the following
 	  information: The time when interrupts occur.
@@ -61,7 +56,6 @@ config KERNEL_EVENT_LOGGER_INTERRUPT
 config KERNEL_EVENT_LOGGER_SLEEP
 	bool
 	prompt "Sleep event logging point"
-	default n
 	depends on SYS_POWER_MANAGEMENT
 	help
 	  Enable low power condition event messages. These messages provide the
@@ -74,7 +68,6 @@ config KERNEL_EVENT_LOGGER_SLEEP
 config KERNEL_EVENT_LOGGER_THREAD
 	bool
 	prompt "Thread event logging point"
-	default n
 	help
 	  Enable thread event messages. These messages provide the following
 	  information:

--- a/kernel/Kconfig.power_mgmt
+++ b/kernel/Kconfig.power_mgmt
@@ -8,7 +8,6 @@
 menuconfig SYS_POWER_MANAGEMENT
 	bool
 	prompt "Power management"
-	default n
 	help
 	  This option enables the board to implement extra power management
 	  policies whenever the kernel becomes idle. The kernel informs the
@@ -19,7 +18,6 @@ if SYS_POWER_MANAGEMENT
 config SYS_POWER_LOW_POWER_STATE
 	bool
 	prompt "Low power state"
-	default n
 	depends on SYS_POWER_LOW_POWER_STATE_SUPPORTED
 	help
 	  This option enables the kernel to interface with a power manager
@@ -31,7 +29,6 @@ config SYS_POWER_LOW_POWER_STATE
 config SYS_POWER_DEEP_SLEEP
 	bool
 	prompt "Deep sleep state"
-	default n
 	depends on SYS_POWER_DEEP_SLEEP_SUPPORTED
 	help
 	  This option enables the kernel to interface with a power manager
@@ -45,7 +42,6 @@ config SYS_POWER_DEEP_SLEEP
 config DEVICE_POWER_MANAGEMENT
 	bool
 	prompt "Device power management"
-	default n
 	help
 	  This option enables the device power management interface.  The
 	  interface consists of hook functions implemented by device drivers
@@ -79,7 +75,6 @@ config TICKLESS_IDLE_THRESH
 config TICKLESS_KERNEL
 	bool
 	prompt "Tickless kernel"
-	default n
 	depends on TICKLESS_IDLE
 	help
 	  This option enables a fully event driven kernel. Periodic system
@@ -102,7 +97,6 @@ config TICKLESS_KERNEL_TIME_UNIT_IN_MICRO_SECS
 config BUSY_WAIT_USES_ALTERNATE_CLOCK
 	bool
 	prompt "Busy wait uses alternate clock in tickless kernel mode"
-	default n
 	help
 	  In tickless kernel mode, the system clock will be stopped when
 	  there are no timer events programmed. If the system clock is to


### PR DESCRIPTION
Bool symbols implicitly default to 'n'.

A 'default n' can make sense e.g. in a Kconfig.defconfig file, if you
want to override a 'default y' on the base definition of the symbol. It
isn't used like that on any of these symbols though.

Also simplify the definitions of COOP_ENABLED, PREEMPT_ENABLED, and
SYS_CLOCK_EXISTS. 'default' (and def_bool) can take any expression, not
just a fixed value.

(It would work without the parentheses around the comparisons too.)

Signed-off-by: Ulf Magnusson <Ulf.Magnusson@nordicsemi.no>