### PR TITLE
lib: kconfig: Remove redundant 'default n' properties

### DIFF
--- a/lib/Kconfig
+++ b/lib/Kconfig
@@ -18,7 +18,6 @@ config JSON_LIBRARY
 config RING_BUFFER
 	bool
 	prompt "Enable ring buffers"
-	default n
 	help
 	  Enable usage of ring buffers. This is similar to kernel FIFOs but ring
 	  buffers manage their own buffer memory and can store arbitrary data.
@@ -27,7 +26,6 @@ config RING_BUFFER
 config BASE64
 	bool
 	prompt "Enable base64 encoding and decoding"
-	default n
 	help
 	  Enable base64 encoding and decoding functionality
 

--- a/lib/libc/Kconfig
+++ b/lib/libc/Kconfig
@@ -34,7 +34,6 @@ config NEWLIB_LIBC_ALIGNED_HEAP_SIZE
 
 config NEWLIB_LIBC_FLOAT_PRINTF
 	bool "Build with newlib float printf"
-	default n
 	depends on NEWLIB_LIBC
 	help
 	  Build with floating point printf enabled. This will increase the size of
@@ -42,7 +41,6 @@ config NEWLIB_LIBC_FLOAT_PRINTF
 
 config NEWLIB_LIBC_FLOAT_SCANF
 	bool "Build with newlib float scanf"
-	default n
 	depends on NEWLIB_LIBC
 	help
 	  Build with floating point scanf enabled. This will increase the size of
@@ -52,8 +50,7 @@ config STDOUT_CONSOLE
 	bool
 	prompt "Send stdout to console"
 	depends on CONSOLE_HAS_DRIVER
-	default n
-	default y if NEWLIB_LIBC
+	default NEWLIB_LIBC
 	help
 	  This option directs standard output (e.g. printf) to the console
 	  device, rather than suppressing it entirely. See also EARLY_CONSOLE

--- a/lib/posix/Kconfig
+++ b/lib/posix/Kconfig
@@ -7,7 +7,6 @@
 config PTHREAD_IPC
 	bool
 	prompt "POSIX pthread IPC API"
-	default n
 	help
 	  This enables a mostly-standards-compliant implementation of
 	  the pthread mutex, condition variable and barrier IPC
@@ -41,7 +40,6 @@ config MAX_TIMER_COUNT
 config POSIX_MQUEUE
 	bool
 	prompt "Enable POSIX message queue"
-	default n
 	help
 	  This enabled POSIX message queue related APIs.
 
@@ -75,7 +73,6 @@ if FILE_SYSTEM
 config POSIX_FS
 	bool
 	prompt "Enable POSIX file system API support"
-	default n
 	help
 	  This enabled POSIX style file system related APIs.
 


### PR DESCRIPTION
Bool symbols implicitly default to 'n'.

A 'default n' can make sense e.g. in a Kconfig.defconfig file, if you
want to override a 'default y' on the base definition of the symbol. It
isn't used like that on any of these symbols though.

Also simplify the default on STDOUT_CONSOLE. Defaults can be arbitrary
expressions, not just fixed values.