### PR TITLE
tests: kconfig: Remove redundant 'default n' properties

### DIFF
--- a/tests/Kconfig
+++ b/tests/Kconfig
@@ -10,7 +10,6 @@ source "tests/ztest/Kconfig"
 
 config TEST
 	bool "Mark project as a test"
-	default n
 	select COVERAGE if NATIVE_APPLICATION
 	help
 	  Mark a project or an application as a test. This will enable a few
@@ -27,7 +26,6 @@ config TEST_EXTRA_STACKSIZE
 config COVERAGE
 	bool "Create coverage data"
 	depends on NATIVE_APPLICATION
-	default n
 	help
 	  This option will build your application with the -coverage option
 	  which will generate data that can be used to create coverage reports.
@@ -60,7 +58,6 @@ config TEST_FLASH_DRIVERS
 	depends on BOARD_QEMU_X86
 	select FLASH_HAS_DRIVER_ENABLED
 	select FLASH_HAS_PAGE_LAYOUT
-	default n
 	help
 	  This option will help test the flash drivers. This should be enabled
 	  only when using qemu_x86.

--- a/tests/benchmarks/object_footprint/Kconfig
+++ b/tests/benchmarks/object_footprint/Kconfig
@@ -4,7 +4,6 @@ source "$ZEPHYR_BASE/Kconfig.zephyr"
 
 config OBJECTS_PRINTK
 	bool "use printk"
-	default n
 
 config OBJECTS_WHILELOOP
 	bool "run whileloop"
@@ -12,27 +11,21 @@ config OBJECTS_WHILELOOP
 
 config OBJECTS_THREAD
 	bool "enable thread"
-	default n
 
 config OBJECTS_SEMAPHORE
 	bool "enable semaphore"
-	default n
 
 config OBJECTS_LIFO
 	bool "enable lifo"
-	default n
 
 config OBJECTS_FIFO
 	bool "enable fifo"
-	default n
 
 config OBJECTS_STACK
 	bool "enable stack"
-	default n
 
 config OBJECTS_TIMER
 	bool "enable timer"
-	default n
 
 config THREAD_STACK_SIZE
 	int "set thread stack size"

--- a/tests/drivers/spi/spi_loopback/Kconfig
+++ b/tests/drivers/spi/spi_loopback/Kconfig
@@ -9,7 +9,6 @@ config SPI_LOOPBACK_DRV_NAME
 config SPI_LOOPBACK_CS_GPIO
 	bool "SPI port CS pin is controlled via a GPIO port during test"
 	depends on GPIO
-	default n
 
 config SPI_LOOPBACK_CS_CTRL_GPIO_DRV_NAME
 	string

--- a/tests/ztest/Kconfig
+++ b/tests/ztest/Kconfig
@@ -6,7 +6,6 @@
 
 config ZTEST
 	bool "Zephyr testing framework"
-	default n
 	select TEST
 	help
 	  Enable the Zephyr testing framework. You should enable this only
@@ -20,7 +19,6 @@ config ZTEST_STACKSIZE
 config ZTEST_FAIL_FAST
 	bool "Abort on first failing test"
 	depends on ZTEST
-	default n
 	help
 	  Stop and abort on first failing test. Do not continue with other
 	  tests that might be in the queue.
@@ -39,7 +37,6 @@ config ZTEST_ASSERT_VERBOSE
 config ZTEST_MOCKING
 	bool "Mocking support functions"
 	depends on ZTEST
-	default n
 	help
 	  Enable mocking support for Ztest. This allows the test to set
 	  return values and expected parameters to functions.


### PR DESCRIPTION
Bool symbols implicitly default to 'n'.

A 'default n' can make sense e.g. in a Kconfig.defconfig file, if you
want to override a 'default y' on the base definition of the symbol. It
isn't used like that on any of these symbols though.

Signed-off-by: Ulf Magnusson <Ulf.Magnusson@nordicsemi.no>