### PR TITLE
kconfiglib: Update to use redesigned 'referenced' API

### DIFF
--- a/scripts/ci/list_undef_kconfig_refs.py
+++ b/scripts/ci/list_undef_kconfig_refs.py
@@ -47,7 +47,6 @@ def is_num(name):
 
     try:
         int(name)
-        return True
     except ValueError:
         # Require hex constants to be prefixed with 0x in Kconfig files, so
         # that we can tell that e.g. F00 is an undefined symbol reference.
@@ -56,9 +55,10 @@ def is_num(name):
 
         try:
             int(name, 16)
-            return True
         except ValueError:
             return False
+
+    return True
 
 
 def ref_locations_str(sym):
@@ -71,7 +71,7 @@ def ref_locations_str(sym):
         nonlocal msg
 
         while node:
-            if sym in node.referenced():
+            if sym in node.referenced:
                 msg += "\n\n- Referenced at {}:{}:\n\n{}" \
                        .format(node.filename, node.linenr, node)
 


### PR DESCRIPTION
Update Kconfiglib to get upstream commit eb6c21a9b33a2 ("Turn
MenuNode/Symbol/Choice.referenced() into a @property") in. It converts
the `MenuNode.referenced()` function into a property, which makes the API
more consistent (read-only stuff uses properties).

Also update `scripts/ci/list_undef_kconfig_refs.py` to access `.referenced`
as a property.

Piggyback a small is_num() simplification.