### PR TITLE
Bluetooth: Fix central from failing to start encryption

### DIFF
--- a/subsys/bluetooth/host/conn.c
+++ b/subsys/bluetooth/host/conn.c
@@ -785,8 +785,8 @@ void bt_conn_identity_resolved(struct bt_conn *conn)
 	}
 }
 
-int bt_conn_le_start_encryption(struct bt_conn *conn, u8_t rand[8], u16_t ediv,
-				const u8_t *ltk, size_t len)
+int bt_conn_le_start_encryption(struct bt_conn *conn, u8_t rand[8],
+				u8_t ediv[2], const u8_t *ltk, size_t len)
 {
 	struct bt_hci_cp_le_start_encryption *cp;
 	struct net_buf *buf;
@@ -799,7 +799,7 @@ int bt_conn_le_start_encryption(struct bt_conn *conn, u8_t rand[8], u16_t ediv,
 	cp = net_buf_add(buf, sizeof(*cp));
 	cp->handle = sys_cpu_to_le16(conn->handle);
 	memcpy(&cp->rand, rand, sizeof(cp->rand));
-	cp->ediv = ediv;
+	memcpy(&cp->ediv, ediv, sizeof(cp->ediv));
 
 	memcpy(cp->ltk, ltk, len);
 	if (len < sizeof(cp->ltk)) {

--- a/subsys/bluetooth/host/conn_internal.h
+++ b/subsys/bluetooth/host/conn_internal.h
@@ -194,8 +194,8 @@ bool le_param_req(struct bt_conn *conn, struct bt_le_conn_param *param);
 
 #if defined(CONFIG_BT_SMP)
 /* rand and ediv should be in BT order */
-int bt_conn_le_start_encryption(struct bt_conn *conn, u8_t rand[8], u16_t ediv,
-				const u8_t *ltk, size_t len);
+int bt_conn_le_start_encryption(struct bt_conn *conn, u8_t rand[8],
+				u8_t ediv[2], const u8_t *ltk, size_t len);
 
 /* Notify higher layers that RPA was resolved */
 void bt_conn_identity_resolved(struct bt_conn *conn);

--- a/subsys/bluetooth/host/hci_core.c
+++ b/subsys/bluetooth/host/hci_core.c
@@ -2843,7 +2843,7 @@ static void le_ltk_request(struct net_buf *buf)
 #if !defined(CONFIG_BT_SMP_SC_ONLY)
 	if (conn->le.keys && (conn->le.keys->keys & BT_KEYS_SLAVE_LTK) &&
 	    !memcmp(conn->le.keys->slave_ltk.rand, &evt->rand, 8) &&
-	    conn->le.keys->slave_ltk.ediv == evt->ediv) {
+	    !memcmp(conn->le.keys->slave_ltk.ediv, &evt->ediv, 2)) {
 		buf = bt_hci_cmd_create(BT_HCI_OP_LE_LTK_REQ_REPLY,
 					sizeof(*cp));
 		if (!buf) {

--- a/subsys/bluetooth/host/keys.h
+++ b/subsys/bluetooth/host/keys.h
@@ -28,7 +28,7 @@ enum {
 
 struct bt_ltk {
 	u8_t			rand[8];
-	u16_t			ediv;
+	u8_t			ediv[2];
 	u8_t			val[16];
 };
 

--- a/subsys/bluetooth/host/smp.h
+++ b/subsys/bluetooth/host/smp.h
@@ -87,8 +87,8 @@ struct bt_smp_encrypt_info {
 
 #define BT_SMP_CMD_MASTER_IDENT			0x07
 struct bt_smp_master_ident {
-	u16_t ediv;
-	u64_t rand;
+	u8_t ediv[2];
+	u8_t rand[8];
 } __packed;
 
 #define BT_SMP_CMD_IDENT_INFO			0x08


### PR DESCRIPTION
This fixes a regression introduced in commit 6af5d1cd1f81
("Bluetooth: Compress bt_keys struct").

Instead of passing a value zero as the random number, the
value at the RAM address zero was being used by the start
encryption function call. It is now fixed by consistently
using byte-array to store EDiv and Rand values.

Signed-off-by: Vinayak Kariappa Chettimada <vich@nordicsemi.no>