### PR TITLE
cmake: Remove duplicate invocations of target_link_libraries on app

### DIFF
--- a/samples/net/rpl_border_router/CMakeLists.txt
+++ b/samples/net/rpl_border_router/CMakeLists.txt
@@ -35,5 +35,4 @@ foreach(inc_file
     )
 endforeach()
 
-target_link_libraries_ifdef(CONFIG_MBEDTLS app mbedTLS)
 target_include_directories(app PRIVATE $ENV{ZEPHYR_BASE}/subsys/net/ip)

--- a/samples/net/ws_console/CMakeLists.txt
+++ b/samples/net/ws_console/CMakeLists.txt
@@ -24,5 +24,3 @@ endforeach()
 generate_inc_file_for_target(app src/index.html ${gen_dir}/index.html.gz.inc --gzip)
 generate_inc_file_for_target(app src/style.css ${gen_dir}/style.css.gz.inc --gzip)
 generate_inc_file_for_target(app src/favicon.ico ${gen_dir}/favicon.ico.gz.inc --gzip)
-
-target_link_libraries_ifdef(CONFIG_MBEDTLS app mbedTLS)

--- a/samples/net/ws_echo_server/CMakeLists.txt
+++ b/samples/net/ws_echo_server/CMakeLists.txt
@@ -23,5 +23,3 @@ foreach(inc_file
 endforeach()
 
 generate_inc_file_for_target(app src/ws.js ${gen_dir}/ws.js.gz.inc --gzip)
-
-target_link_libraries_ifdef(CONFIG_MBEDTLS app mbedTLS)

--- a/tests/net/websocket/CMakeLists.txt
+++ b/tests/net/websocket/CMakeLists.txt
@@ -17,5 +17,3 @@ foreach(inc_file
     ${ZEPHYR_BINARY_DIR}/include/generated/${inc_file}.inc
     )
 endforeach()
-
-target_link_libraries_ifdef(CONFIG_MBEDTLS app mbedTLS)


### PR DESCRIPTION
It is not necessary to link 'app' with mbedTLS because mbedTLS is
covered by the 'APP_LINK_WITH_MBEDTLS' mechanism that automatically
links 'app' with mbedTLS.

This patch removes the redundant target_link_libraries invocations.

Signed-off-by: Sebastian Bøe <sebastian.boe@nordicsemi.no>