### PR TITLE
cmake: default to linking 'app' with the interface library 'FS'

### DIFF
--- a/subsys/fs/CMakeLists.txt
+++ b/subsys/fs/CMakeLists.txt
@@ -1,4 +1,5 @@
 if(CONFIG_FILE_SYSTEM)
+  zephyr_interface_library_named(FS)
   zephyr_link_interface_ifdef(CONFIG_FAT_FILESYSTEM_ELM ELMFAT)
   zephyr_link_interface_ifdef(CONFIG_FILE_SYSTEM_NFFS   NFFS)
 
@@ -8,8 +9,10 @@ if(CONFIG_FILE_SYSTEM)
   zephyr_library_sources_ifdef(CONFIG_FILE_SYSTEM_NFFS   nffs_fs.c)
   zephyr_library_sources_ifdef(CONFIG_FILE_SYSTEM_SHELL  shell.c)
 
-  zephyr_library_link_libraries_ifdef(CONFIG_FAT_FILESYSTEM_ELM ELMFAT)
-  zephyr_library_link_libraries_ifdef(CONFIG_FILE_SYSTEM_NFFS   NFFS)
+  zephyr_library_link_libraries(FS)
+
+  target_link_libraries_ifdef(CONFIG_FAT_FILESYSTEM_ELM FS INTERFACE ELMFAT)
+  target_link_libraries_ifdef(CONFIG_FILE_SYSTEM_NFFS   FS INTERFACE NFFS)
 endif()
 
 add_subdirectory_ifdef(CONFIG_FCB  ./fcb)

--- a/subsys/fs/Kconfig
+++ b/subsys/fs/Kconfig
@@ -33,6 +33,14 @@ config SYS_LOG_FS_LEVEL
 
 if FILE_SYSTEM
 
+config APP_LINK_WITH_FS
+	bool "Link 'app' with FS"
+	default y
+	help
+	  Add FS header files to the 'app' include path. It may be
+	  disabled if the include paths for FS are causing aliasing
+	  issues for 'app'.
+
 config FAT_FILESYSTEM_ELM
 	bool "ELM FAT File System"
 	select DISK_ACCESS

--- a/subsys/settings/src/CMakeLists.txt
+++ b/subsys/settings/src/CMakeLists.txt
@@ -1,5 +1,3 @@
-zephyr_include_directories($ENV{ZEPHYR_BASE}/ext/fs/nffs/include)
-
 zephyr_sources(
   settings_store.c
   settings.c

--- a/tests/posix/fs/CMakeLists.txt
+++ b/tests/posix/fs/CMakeLists.txt
@@ -3,6 +3,5 @@ project(NONE)
 
 target_include_directories(app PRIVATE $ENV{ZEPHYR_BASE}/include/)
 
-target_link_libraries(app ELMFAT)
 FILE(GLOB app_sources src/*.c)
 target_sources(app PRIVATE ${app_sources})

--- a/tests/subsys/fs/fat_fs_api/CMakeLists.txt
+++ b/tests/subsys/fs/fat_fs_api/CMakeLists.txt
@@ -1,6 +1,5 @@
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
 project(NONE)
 
-target_link_libraries(app ELMFAT)
 FILE(GLOB app_sources src/*.c)
 target_sources(app PRIVATE ${app_sources})

--- a/tests/subsys/fs/fat_fs_dual_drive/CMakeLists.txt
+++ b/tests/subsys/fs/fat_fs_dual_drive/CMakeLists.txt
@@ -1,6 +1,5 @@
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
 project(NONE)
 
-target_link_libraries(app ELMFAT)
 FILE(GLOB app_sources src/*.c)
 target_sources(app PRIVATE ${app_sources})

--- a/tests/subsys/fs/multi-fs/CMakeLists.txt
+++ b/tests/subsys/fs/multi-fs/CMakeLists.txt
@@ -7,7 +7,5 @@ zephyr_compile_definitions(
   -DFLASH_AREA_STORAGE_SIZE=1048576
 )
 
-target_link_libraries(app ELMFAT)
-target_link_libraries(app NFFS)
 FILE(GLOB app_sources src/*.c)
 target_sources(app PRIVATE ${app_sources})

--- a/tests/subsys/fs/nffs_fs_api/basic/CMakeLists.txt
+++ b/tests/subsys/fs/nffs_fs_api/basic/CMakeLists.txt
@@ -41,6 +41,5 @@ endif()
 
 
 zephyr_include_directories(../common)
-target_link_libraries(app NFFS)
 FILE(GLOB app_sources ../common/*.c src/*.c)
 target_sources(app PRIVATE ${app_sources})

--- a/tests/subsys/fs/nffs_fs_api/cache/CMakeLists.txt
+++ b/tests/subsys/fs/nffs_fs_api/cache/CMakeLists.txt
@@ -41,6 +41,5 @@ endif()
 
 
 zephyr_include_directories(../common)
-target_link_libraries(app NFFS)
 FILE(GLOB app_sources ../common/*.c src/*.c)
 target_sources(app PRIVATE ${app_sources})

--- a/tests/subsys/fs/nffs_fs_api/large/CMakeLists.txt
+++ b/tests/subsys/fs/nffs_fs_api/large/CMakeLists.txt
@@ -41,6 +41,5 @@ endif()
 
 
 zephyr_include_directories(../common)
-target_link_libraries(app NFFS)
 FILE(GLOB app_sources ../common/*.c src/*.c)
 target_sources(app PRIVATE ${app_sources})

--- a/tests/subsys/fs/nffs_fs_api/performance/CMakeLists.txt
+++ b/tests/subsys/fs/nffs_fs_api/performance/CMakeLists.txt
@@ -41,6 +41,5 @@ endif()
 
 
 zephyr_include_directories(../common)
-target_link_libraries(app NFFS)
 FILE(GLOB app_sources ../common/*.c src/*.c)
 target_sources(app PRIVATE ${app_sources})


### PR DESCRIPTION
This patch removes the need for application build script code to
explicitly link 'app' with a filesystem implementation.

It does this by introducing a zephyr interface library called 'FS'
that contains the usage requirements for linking with the filesystem
library subsys__fs and using Kconfig to default to linking the 'app'
library with this interface library.
