### PR TITLE
imxrt1050: Disable low-power modes

### DIFF
--- a/arch/arm/soc/nxp_imx/rt/soc.c
+++ b/arch/arm/soc/nxp_imx/rt/soc.c
@@ -90,6 +90,11 @@ static ALWAYS_INLINE void clkInit(void)
 	CLOCK_SetDiv(kCLOCK_UartDiv, 0); /* Set UART divider to 1 */
 #endif
 
+	/* Keep the system clock running so SYSTICK can wake up the system from
+	 * wfi.
+	 */
+	CLOCK_SetMode(kCLOCK_ModeRun);
+
 }
 
 /**


### PR DESCRIPTION
The imxrt1050 is configured to use SYSTICK for the kernel timer, but
SYSTICK cannot wake up the soc from low-power modes. Disable low-power
modes on this soc until we have support for an alternative timer.

This fixes k_sleep on the EVKB version of the mimxrt1050_evk board. An
earlier version of the board (EVK, not EVKB), had A0 silicon which
by default did not enter low-power mode on a wfi.

Signed-off-by: Maureen Helm <maureen.helm@nxp.com>

Fixes #8466 

cc: @jhqian 