### PR TITLE
shell: Fix command completion logic

### DIFF
--- a/subsys/shell/shell.c
+++ b/subsys/shell/shell.c
@@ -494,7 +494,7 @@ static struct shell_module *get_completion_module(char *str,
 	 */
 	str = strchr(str, ' ');
 	if (default_module) {
-		return str ? dest : NULL;
+		return str ? NULL : dest;
 	}
 
 	if (!str) {


### PR DESCRIPTION
The original code (introduced by commit d5db35204a4) looked like this before
the last rewrite/cleanup:

       if (default_module != -1) {
               return (str == NULL) ? dest : -1;
       }

However with the cleanup the logic seems to have gotten reversed.

Fixes #8501

Signed-off-by: Johan Hedberg <johan.hedberg@intel.com>