### PR TITLE
frdm_k64f: dts: Addition of a Flash Partion

### DIFF
--- a/boards/arm/frdm_k64f/frdm_k64f.dts
+++ b/boards/arm/frdm_k64f/frdm_k64f.dts
@@ -152,6 +152,12 @@
 		 * 0x0001ffff (sectors 16-31) is reserved for use
 		 * by the application.
 		 */
+#if defined(CONFIG_FS_FLASH_STORAGE_PARTITION)
+		 storage_partition: partition@1e000 {
+			label = "storage";
+			reg = <0x0001e000 0x00002000>;
+		};
+#endif
 
 		slot0_partition: partition@20000 {
 			label = "image-0";


### PR DESCRIPTION
Addition of a Flash partition to the 'frdm_k64f.dts' file in the
currently existing 'Application Area' (Partition Location: 0x0001e000
Partition Size: 0x00002000). This partitioned area can be used as a FCB
for Bluetooth and other applications.

Signed-off-by: Arjun Warty <arjun.warty@nxp.com>