### PR TITLE
tests: ztest: fixed off-by-one in sys_bitfield_find_first_clear

### DIFF
--- a/tests/ztest/src/ztest_mock.c
+++ b/tests/ztest/src/ztest_mock.c
@@ -72,7 +72,7 @@ int sys_bitfield_find_first_clear(const unsigned long *bitmap,
 		else if (neg_bitmap == ~0UL)	/* first bit */
 			return cnt * BITS_PER_UL;
 		else
-			return cnt * BITS_PER_UL + __builtin_ffsl(neg_bitmap);
+			return cnt * BITS_PER_UL + __builtin_ffsl(neg_bitmap) - 1;
 	}
 	return -1;
 }

--- a/tests/ztest/test/mock/src/main.c
+++ b/tests/ztest/test/mock/src/main.c
@@ -38,11 +38,26 @@ static void return_value_tests(void)
 	zassert_equal(returns_int(), 5, NULL);
 }
 
+static void multi_value_tests(void)
+{
+	/* Setup expects for three mock calls */
+	ztest_expect_value(expect_one_parameter,  a, 1);
+	ztest_expect_value(expect_two_parameters, a, 2);
+	ztest_expect_value(expect_two_parameters, b, 3);
+	ztest_returns_value(returns_int, 5);
+
+	/* Verify mock behavior */
+	expect_one_parameter(1);
+	zassert_equal(returns_int(), 5, NULL);
+	expect_two_parameters(2, 3);
+}
+
 void test_main(void)
 {
 	ztest_test_suite(mock_framework_tests,
 			 ztest_unit_test(parameter_tests),
-			 ztest_unit_test(return_value_tests)
+			 ztest_unit_test(return_value_tests),
+			 ztest_unit_test(multi_value_tests)
 			 );
 
 	ztest_run_test_suite(mock_framework_tests);


### PR DESCRIPTION
Calling __builtin_ffsl(neg_bitmap) returns first bit set in the word,
e.g. 4 if bitmap is 11111000. As this must translate to zero-based index
3, one must be subtracted from the result.

Signed-off-by: Morten Priess <mtpr@oticon.com>