### PR TITLE
[DNM] LD: Don't force a reference to the symbol _OffsetAbsSyms

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -719,13 +719,11 @@ set_property(TARGET
 
 set(zephyr_lnk
   ${LINKERFLAGPREFIX},-Map=${PROJECT_BINARY_DIR}/${KERNEL_MAP_NAME}
-  -u_OffsetAbsSyms
   -u_ConfigAbsSyms
   ${LINKERFLAGPREFIX},--whole-archive
   ${ZEPHYR_LIBS_PROPERTY}
   ${LINKERFLAGPREFIX},--no-whole-archive
   kernel
-  ${OFFSETS_O_PATH}
   ${LIB_INCLUDE_DIR}
   -L${PROJECT_BINARY_DIR}
   ${TOOLCHAIN_LIBS}

--- a/arch/arc/core/fault_s.S
+++ b/arch/arc/core/fault_s.S
@@ -16,6 +16,7 @@
 #include <linker/sections.h>
 #include <arch/cpu.h>
 #include <swap_macros.h>
+#include <syscall.h>
 
 GTEXT(_Fault)
 GTEXT(_do_kernel_oops)
@@ -165,12 +166,12 @@ SECTION_SUBSEC_FUNC(TEXT,__fault,__ev_trap)
 	cmp ilink, _TRAP_S_CALL_SYSTEM_CALL
 	bne _do_non_syscall_trap
 /* do sys_call */
-	mov ilink, _SYSCALL_LIMIT
+	mov ilink, K_SYSCALL_LIMIT
 	cmp r6, ilink
 	blt valid_syscall_id
 
 	mov r0, r6
-	mov r6, _SYSCALL_BAD
+	mov r6, K_SYSCALL_BAD
 
 valid_syscall_id:
 #ifdef CONFIG_ARC_HAS_SECURE

--- a/arch/arm/core/swap_helper.S
+++ b/arch/arm/core/swap_helper.S
@@ -16,6 +16,7 @@
 #include <offsets_short.h>
 #include <toolchain.h>
 #include <arch/cpu.h>
+#include <syscall.h>
 
 _ASM_FILE_PROLOGUE
 
@@ -387,13 +388,13 @@ _do_syscall:
     str r1, [r0, #24]   /* overwrite the LR to point to _arm_do_syscall */
 
     /* validate syscall limit, only set priv mode if valid */
-    ldr ip, =_SYSCALL_LIMIT
+    ldr ip, =K_SYSCALL_LIMIT
     cmp r6, ip
     blt valid_syscall_id
 
     /* bad syscall id.  Set arg0 to bad id and set call_id to SYSCALL_BAD */
     str r6, [r0, #0]
-    ldr r6, =_SYSCALL_BAD
+    ldr r6, =K_SYSCALL_BAD
 
 valid_syscall_id:
     /* set mode to privileged, r2 still contains value from CONTROL */

--- a/arch/arm/core/userspace.S
+++ b/arch/arm/core/userspace.S
@@ -126,7 +126,7 @@ SECTION_FUNC(TEXT, _arm_do_syscall)
      * r6 contains call_id
      * r8 contains original LR
      */
-    ldr ip, =_SYSCALL_BAD
+    ldr ip, =K_SYSCALL_BAD
     cmp r6, ip
     bne valid_syscall
 

--- a/arch/x86/core/userspace.S
+++ b/arch/x86/core/userspace.S
@@ -8,7 +8,7 @@
 #include <arch/x86/asm.h>
 #include <arch/cpu.h>
 #include <offsets_short.h>
-#include <arch/x86/syscall.h>
+#include <syscall.h>
 
 /* Exports */
 GTEXT(_x86_syscall_entry_stub)
@@ -31,7 +31,7 @@ SECTION_FUNC(TEXT, _x86_syscall_entry_stub)
 	/* call_id is in ESI. bounds-check it, must be less than
 	 * K_SYSCALL_LIMIT
 	 */
-	cmp	$_SYSCALL_LIMIT, %esi
+	cmp	$K_SYSCALL_LIMIT, %esi
 	jae	_bad_syscall
 
 _id_ok:
@@ -83,7 +83,7 @@ _bad_syscall:
 	 * anyway, it's going to generate a kernel oops
 	 */
 	mov	%esi, %eax
-	mov	$_SYSCALL_BAD, %esi
+	mov	$K_SYSCALL_BAD, %esi
 	jmp	_id_ok
 
 

--- a/include/linker/linker-defs.h
+++ b/include/linker/linker-defs.h
@@ -22,6 +22,7 @@
 #include <toolchain.h>
 #include <linker/sections.h>
 #include <misc/util.h>
+#include <offsets.h>
 
 /* include platform dependent linker-defs */
 #ifdef CONFIG_X86
@@ -52,7 +53,7 @@
  */
 #ifdef CONFIG_DEVICE_POWER_MANAGEMENT
 #define DEVICE_COUNT \
-	((__device_init_end - __device_init_start) / _DEVICE_STRUCT_SIZE)
+	((__device_init_end - __device_init_start) / _DEVICE_STRUCT_SIZEOF)
 #define DEV_BUSY_SZ	(((DEVICE_COUNT + 31) / 32) * 4)
 #define DEVICE_BUSY_BITFIELD()			\
 		FILL(0x00) ;			\

--- a/include/syscall.h
+++ b/include/syscall.h
@@ -8,11 +8,12 @@
 #ifndef _ZEPHYR_SYSCALL_H_
 #define _ZEPHYR_SYSCALL_H_
 
+#include <syscall_list.h>
+#include <arch/syscall.h>
+
 #ifndef _ASMLANGUAGE
 #include <zephyr/types.h>
-#include <syscall_list.h>
 #include <syscall_macros.h>
-#include <arch/syscall.h>
 
 #ifdef __cplusplus
 extern "C" {

--- a/kernel/include/kernel_offsets.h
+++ b/kernel/include/kernel_offsets.h
@@ -80,8 +80,4 @@ GEN_ABSOLUTE_SYM(K_THREAD_SIZEOF, sizeof(struct k_thread));
 /* size of the device structure. Used by linker scripts */
 GEN_ABSOLUTE_SYM(_DEVICE_STRUCT_SIZE, sizeof(struct device));
 
-/* Access to enum values in asm code */
-GEN_ABSOLUTE_SYM(_SYSCALL_LIMIT, K_SYSCALL_LIMIT);
-GEN_ABSOLUTE_SYM(_SYSCALL_BAD, K_SYSCALL_BAD);
-
 #endif /* _kernel_offsets__h_ */

--- a/kernel/include/kernel_offsets.h
+++ b/kernel/include/kernel_offsets.h
@@ -78,7 +78,7 @@ GEN_OFFSET_SYM(_thread_t, custom_data);
 GEN_ABSOLUTE_SYM(K_THREAD_SIZEOF, sizeof(struct k_thread));
 
 /* size of the device structure. Used by linker scripts */
-GEN_ABSOLUTE_SYM(_DEVICE_STRUCT_SIZE, sizeof(struct device));
+GEN_ABSOLUTE_SYM(_DEVICE_STRUCT_SIZEOF, sizeof(struct device));
 
 /* Access to enum values in asm code */
 GEN_ABSOLUTE_SYM(_SYSCALL_LIMIT, K_SYSCALL_LIMIT);

--- a/scripts/gen_syscalls.py
+++ b/scripts/gen_syscalls.py
@@ -27,6 +27,8 @@ list_template = """
 #ifndef _ZEPHYR_SYSCALL_LIST_H_
 #define _ZEPHYR_SYSCALL_LIST_H_
 
+%s
+
 #ifndef _ASMLANGUAGE
 
 #include <zephyr/types.h>
@@ -34,10 +36,6 @@ list_template = """
 #ifdef __cplusplus
 extern "C" {
 #endif
-
-enum {
-\t%s
-};
 
 %s
 
@@ -207,9 +205,14 @@ def main():
     # Listing header emitted to stdout
     ids.sort()
     ids.extend(["K_SYSCALL_BAD", "K_SYSCALL_LIMIT"])
+
+    ids_as_defines = ""
+    for i, item in enumerate(ids):
+        ids_as_defines += "#define {} {}\n".format(item, i)
+
     handler_defines = "".join([handler_template % name for name in handlers])
     with open(args.syscall_list, "w") as fp:
-        fp.write(list_template % (",\n\t".join(ids), handler_defines))
+        fp.write(list_template % (ids_as_defines, handler_defines))
 
     os.makedirs(args.base_output, exist_ok=True)
     for fn, invo_list in invocations.items():


### PR DESCRIPTION
A reference to the symbol '_OffsetAbsSyms' is being artificially
forced by a command line argument to the linker.

As far as possible one should not be passing flags to the linker through the
build system. Instead one should write appropriate linker scripts.

This patch removes the command line argument to the linker.

TODO: Find out why we need to force the symbol and if necessary how to
continue to force it.

Signed-off-by: Sebastian Bøe <sebastian.boe@nordicsemi.no>