### PR TITLE
samples: mesh/onoff_level_lighting_vnd_app: States binding corrections

### DIFF
--- a/samples/boards/nrf52/mesh/onoff_level_lighting_vnd_app/src/mesh/device_composition.h
+++ b/samples/boards/nrf52/mesh/onoff_level_lighting_vnd_app/src/mesh/device_composition.h
@@ -10,11 +10,12 @@
 
 #define CID_ZEPHYR 0x0002
 
-enum lightness { ONOFF = 0x01, LEVEL, ACTUAL, LINEAR, CTL, IGNORE = 0xFF };
-enum temperature { ONOFF_t = 0x01, LEVEL_t, CTL_t, IGNORE_t = 0xFF };
+enum lightness { ONPOWERUP = 0x01, ONOFF, LEVEL, ACTUAL, LINEAR, CTL, IGNORE};
+enum temperature { ONOFF_TEMP = 0x01, LEVEL_TEMP, CTL_TEMP, IGNORE_TEMP};
 
 struct generic_onoff_state {
 	u8_t onoff;
+	u8_t previous;
 	u8_t model_instance;
 	u8_t last_tid;
 	u16_t last_tx_addr;


### PR DESCRIPTION
Make corrections in state binding of Servers as per Mesh Model
Specifications. Previously, when OnPowerUp state equal to 0x02,
then Light Lightness actual state was not assign to last power
down value. Plus when Generic OnOff state changes by client,
then Light Lightness Actual state value get assigned as Light
Lightness Last value instead of default one.
All these issues has fixed here.

Signed-off-by: Vikrant More <vikrant8051@gmail.com>