### PR TITLE
Bluetooth: UUID: add UUIDs for missing HIDS characteristics

### DIFF
--- a/include/bluetooth/uuid.h
+++ b/include/bluetooth/uuid.h
@@ -207,6 +207,10 @@ struct bt_uuid_128 {
  *  @brief BAS Characteristic Battery Level
  */
 #define BT_UUID_BAS_BATTERY_LEVEL         BT_UUID_DECLARE_16(0x2a19)
+/** @def BT_UUID_HIDS_BOOT_KB_IN_REPORT
+ *  @brief HID Characteristic Boot Keyboard Input Report
+ */
+#define BT_UUID_HIDS_BOOT_KB_IN_REPORT    BT_UUID_DECLARE_16(0x2a22)
 /** @def BT_UUID_DIS_SYSTEM_ID
  *  @brief DIS Characteristic System ID
  */
@@ -247,6 +251,14 @@ struct bt_uuid_128 {
  *  @brief Magnetic Declination Characteristic
  */
 #define BT_UUID_MAGN_DECLINATION          BT_UUID_DECLARE_16(0x2a2c)
+/** @def BT_UUID_HIDS_BOOT_KB_OUT_REPORT
+ *  @brief HID Boot Keyboard Output Report Characteristic
+ */
+#define BT_UUID_HIDS_BOOT_KB_OUT_REPORT   BT_UUID_DECLARE_16(0x2a32)
+/** @def BT_UUID_HIDS_BOOT_MOUSE_IN_REPORT
+ *  @brief HID Boot Mouse Input Report Characteristic
+ */
+#define BT_UUID_HIDS_BOOT_MOUSE_IN_REPORT BT_UUID_DECLARE_16(0x2a33)
 /** @def BT_UUID_HRS_MEASUREMENT
  *  @brief HRS Characteristic Measurement Interval
  */
@@ -275,6 +287,10 @@ struct bt_uuid_128 {
  *  @brief HID Report Characteristic
  */
 #define BT_UUID_HIDS_REPORT               BT_UUID_DECLARE_16(0x2a4d)
+/** @def BT_UUID_HIDS_PROTOCOL_MODE
+ *  @brief HID Protocol Mode Characteristic
+ */
+#define BT_UUID_HIDS_PROTOCOL_MODE        BT_UUID_DECLARE_16(0x2a4e)
 /** @def BT_UUID_CSC_MEASUREMENT
  *  @brief CSC Measurement Characteristic
  */


### PR DESCRIPTION
Adding UUIDs for following characteristics of HID Service:
- Protocol Mode
- Boot Keyboard Input Report
- Boot Keyboard Output Report
- Boot Mouse Input Report

Signed-off-by: Kamil Piszczek <Kamil.Piszczek@nordicsemi.no>