### PR TITLE
net: if: vlan: Implement packet priority to PCP conversion

### DIFF
--- a/include/net/net_ip.h
+++ b/include/net/net_ip.h
@@ -1024,6 +1024,19 @@ static inline enum net_priority net_vlan2priority(u8_t priority)
 	return vlan2priority[priority];
 }
 
+/**
+ * @brief Convert network packet priority to network packet VLAN priority.
+ *
+ * @param priority Packet priority
+ *
+ * @return VLAN priority (PCP)
+ */
+static inline u8_t net_priority2vlan(enum net_priority priority)
+{
+	/* The conversion works both ways */
+	return (u8_t)net_vlan2priority(priority);
+}
+
 #ifdef __cplusplus
 }
 #endif

--- a/subsys/net/ip/l2/ethernet/ethernet.c
+++ b/subsys/net/ip/l2/ethernet/ethernet.c
@@ -309,11 +309,10 @@ static enum net_verdict set_vlan_tag(struct ethernet_context *ctx,
 static void set_vlan_priority(struct ethernet_context *ctx,
 			      struct net_pkt *pkt)
 {
-	/* FIXME: Currently just convert packet priority to VLAN
-	 * priority. This needs to be fixed as VLAN priority is not necessarily
-	 * the same as packet priority.
-	 */
-	net_pkt_set_vlan_priority(pkt, net_pkt_priority(pkt));
+	u8_t vlan_priority;
+
+	vlan_priority = net_priority2vlan(net_pkt_priority(pkt));
+	net_pkt_set_vlan_priority(pkt, vlan_priority);
 }
 #endif /* CONFIG_NET_VLAN */
 


### PR DESCRIPTION
This is actually the same as #7229 in which we missed this side of
conversion (only PCP to packet priority was implemented).

The conversion is actually the same both ways, thus it uses the map
added earlier.

Signed-off-by: Tomasz Gorochowik <tgorochowik@antmicro.com>