### PR TITLE
gen_isr_tables: Delete the dead code accompanying .intList.num_isrs

### DIFF
--- a/arch/common/gen_isr_tables.py
+++ b/arch/common/gen_isr_tables.py
@@ -45,9 +45,8 @@ def read_intlist(intlist_path):
     include/linker/intlist.ld:
 
      struct {
-       u32_t num_isrs;
-       u32_t num_vectors; <- typically CONFIG_NUM_IRQS
-       struct _isr_list isrs[];  <- of size num_isrs
+       u32_t num_vectors;       <- typically CONFIG_NUM_IRQS
+       struct _isr_list isrs[]; <- Usually of smaller size than num_vectors
     }
 
     Followed by instances of struct _isr_list created by IRQ_CONNECT()
@@ -69,7 +68,7 @@ def read_intlist(intlist_path):
 
     prefix = endian_prefix()
 
-    intlist_header_fmt = prefix + "III"
+    intlist_header_fmt = prefix + "II"
     intlist_entry_fmt = prefix + "iiII"
 
     with open(intlist_path, "rb") as fp:
@@ -83,7 +82,6 @@ def read_intlist(intlist_path):
 
     intlist["num_vectors"]    = header[0]
     intlist["offset"]         = header[1]
-    intlist["num_isrs"]       = header[2]
 
     intlist["interrupts"] = [i for i in
             struct.iter_unpack(intlist_entry_fmt, intdata)]
@@ -213,14 +211,12 @@ def main():
     nvec = intlist["num_vectors"]
     offset = intlist["offset"]
     prefix = endian_prefix()
-    numisrs = intlist["num_isrs"]
 
     spurious_handler = "&_irq_spurious"
     sw_irq_handler   = "ISR_WRAPPER"
 
     debug('offset is ' + str(offset))
     debug('num_vectors is ' + str(nvec))
-    debug('num_isrs is ' + str(numisrs))
 
     # Set default entries in both tables
     if args.sw_isr_table:

--- a/arch/common/isr_tables.c
+++ b/arch/common/isr_tables.c
@@ -52,9 +52,3 @@ struct _isr_table_entry __sw_isr_table _sw_isr_table[IRQ_TABLE_SIZE] = {
 	[0 ...(IRQ_TABLE_SIZE - 1)] = {(void *)0x42, (void *)&_irq_spurious},
 };
 #endif
-
-/* Linker needs this */
-GEN_ABS_SYM_BEGIN(isr_tables_syms)
-GEN_ABSOLUTE_SYM(__ISR_LIST_SIZEOF, sizeof(struct _isr_list));
-GEN_ABS_SYM_END
-

--- a/arch/x86/core/offsets/offsets.c
+++ b/arch/x86/core/offsets/offsets.c
@@ -77,10 +77,8 @@ GEN_OFFSET_SYM(NANO_ESF, eflags);
 /* tTaskStateSegment structure member offsets */
 
 
-/* size of the ISR_LIST structure. Used by linker scripts */
+/* size of the MMU_REGION structure. Used by linker scripts */
 
-GEN_ABSOLUTE_SYM(__ISR_LIST_SIZEOF, sizeof(ISR_LIST));
 GEN_ABSOLUTE_SYM(__MMU_REGION_SIZEOF, sizeof(struct mmu_region));
-
 
 GEN_ABS_SYM_END

--- a/include/arch/x86/linker.ld
+++ b/include/arch/x86/linker.ld
@@ -326,11 +326,8 @@ SECTIONS
 	{
 	KEEP(*(.spurIsr))
 	KEEP(*(.spurNoErrIsr))
-	__INT_LIST_START__ = .;
-	LONG((__INT_LIST_END__ - __INT_LIST_START__) / __ISR_LIST_SIZEOF)
 	KEEP(*(.intList))
 	KEEP(*(.gnu.linkonce.intList.*))
-	__INT_LIST_END__ = .;
 	} > IDT_LIST
 
 #ifdef CONFIG_X86_MMU

--- a/include/linker/intlist.ld
+++ b/include/linker/intlist.ld
@@ -10,9 +10,8 @@
  * What we create here is a data structure:
  *
  * struct {
- *	u32_t num_isrs;
- *	u32_t num_vectors;
- *	struct _isr_list isrs[];  <- of size num_isrs
+ *	u32_t num_vectors;       <- typically CONFIG_NUM_IRQS
+ *	struct _isr_list isrs[]; <- Usually of smaller size than num_vectors
  * }
  *
  * Which indicates the memory address of the number of isrs that were
@@ -36,10 +35,7 @@
 SECTION_PROLOGUE(.intList,,)
 {
 	KEEP(*(.irq_info))
-	LONG((__INT_LIST_END__ - __INT_LIST_START__) / __ISR_LIST_SIZEOF)
-	__INT_LIST_START__ = .;
 	KEEP(*(.intList))
-	__INT_LIST_END__ = .;
 } GROUP_LINK_IN(IDT_LIST)
 #else
 /DISCARD/ :

--- a/scripts/gen_idt.py
+++ b/scripts/gen_idt.py
@@ -180,7 +180,7 @@ def get_symbols(obj):
 # };
 
 
-intlist_header_fmt = "<IIi"
+intlist_header_fmt = "<II"
 
 # struct genidt_entry_s {
 #	uint32_t isr;


### PR DESCRIPTION
intList has been populated with the number of isrs, aka interrupts,
but nothing has been using this information so we drop it and
everything used to construct it.

Signed-off-by: Sebastian Bøe <sebastian.boe@nordicsemi.no>