### PR TITLE
Nrf52 blenano2 i2c fixes

### DIFF
--- a/boards/arm/bbc_microbit/Kconfig.board
+++ b/boards/arm/bbc_microbit/Kconfig.board
@@ -6,4 +6,5 @@
 
 config BOARD_BBC_MICROBIT
 	bool "BBC MICRO:BIT"
+	select HAS_DTS_I2C
 	depends on SOC_NRF51822_QFAA

--- a/boards/arm/bbc_microbit/bbc_microbit.dts
+++ b/boards/arm/bbc_microbit/bbc_microbit.dts
@@ -21,13 +21,13 @@
 &uart0 {
 	status = "ok";
 	current-speed = <115200>;
-	sda-pin = <30>;
-	scl-pin = <0>;
 };
 
 &i2c0 {
 	status = "ok";
 	clock-frequency = <I2C_BITRATE_FAST>;
+	sda-pin = <30>;
+	scl-pin = <0>;
 };
 
 &flash0 {

--- a/boards/arm/nrf52_blenano2/Kconfig.board
+++ b/boards/arm/nrf52_blenano2/Kconfig.board
@@ -8,4 +8,5 @@
 config BOARD_NRF52_BLENANO2
 	bool "nRF52 BLENANO2"
 	select HAS_DTS_GPIO
+	select HAS_DTS_I2C
 	depends on SOC_NRF52832_QFAA

--- a/boards/arm/nrf52_blenano2/nrf52_blenano2.dts
+++ b/boards/arm/nrf52_blenano2/nrf52_blenano2.dts
@@ -27,14 +27,6 @@
 	status ="ok";
 };
 
-&i2c0 {
-	status = "ok";
-};
-
-&i2c1 {
-	status = "ok";
-};
-
 &uart0 {
 	compatible = "nordic,nrf-uart";
 	current-speed = <115200>;
@@ -42,6 +34,7 @@
 };
 
 &i2c0 {
+	status = "ok";
 	sda-pin = <28>;
 	scl-pin = <2>;
 };


### PR DESCRIPTION
This pull request selects HAS_DTS_I2C in nrf52_blenano2 and bbc_microbit board definitions with minor fixes.

Fixes #8511 