### PR TITLE
Bluetooth: Mesh: Fix persistent storage behavior

### DIFF
--- a/subsys/bluetooth/host/mesh/access.c
+++ b/subsys/bluetooth/host/mesh/access.c
@@ -280,7 +280,6 @@ static void mod_init(struct bt_mesh_model *mod, struct bt_mesh_elem *elem,
 		mod->keys[i] = BT_MESH_KEY_UNUSED;
 	}
 
-	mod->flags = 0;
 	mod->elem_idx = elem - dev_comp->elem;
 	if (vnd) {
 		mod->mod_idx = mod - elem->vnd_models;

--- a/subsys/bluetooth/host/mesh/cfg_srv.c
+++ b/subsys/bluetooth/host/mesh/cfg_srv.c
@@ -260,6 +260,10 @@ static u8_t _mod_pub_set(struct bt_mesh_model *model, u16_t pub_addr,
 	}
 
 	if (pub_addr == BT_MESH_ADDR_UNASSIGNED) {
+		if (model->pub->addr == BT_MESH_ADDR_UNASSIGNED) {
+			return STATUS_SUCCESS;
+		}
+
 		model->pub->addr = BT_MESH_ADDR_UNASSIGNED;
 		model->pub->key = 0;
 		model->pub->cred = 0;

--- a/subsys/bluetooth/host/mesh/cfg_srv.c
+++ b/subsys/bluetooth/host/mesh/cfg_srv.c
@@ -3194,6 +3194,7 @@ int bt_mesh_cfg_srv_init(struct bt_mesh_model *model, bool primary)
 	}
 
 	k_delayed_work_init(&cfg->hb_pub.timer, hb_publish);
+	cfg->hb_pub.net_idx = BT_MESH_KEY_UNUSED;
 	cfg->hb_sub.expiry = 0;
 
 	cfg->model = model;

--- a/subsys/bluetooth/host/mesh/foundation.h
+++ b/subsys/bluetooth/host/mesh/foundation.h
@@ -137,10 +137,10 @@ u8_t bt_mesh_beacon_get(void);
 u8_t bt_mesh_gatt_proxy_get(void);
 u8_t bt_mesh_default_ttl_get(void);
 
-void bt_mesh_subnet_del(struct bt_mesh_subnet *sub);
+void bt_mesh_subnet_del(struct bt_mesh_subnet *sub, bool store);
 
 struct bt_mesh_app_key *bt_mesh_app_key_alloc(u16_t app_idx);
-void bt_mesh_app_key_del(struct bt_mesh_app_key *key);
+void bt_mesh_app_key_del(struct bt_mesh_app_key *key, bool store);
 
 #include <misc/byteorder.h>
 

--- a/subsys/bluetooth/host/mesh/main.c
+++ b/subsys/bluetooth/host/mesh/main.c
@@ -79,8 +79,6 @@ void bt_mesh_reset(void)
 		return;
 	}
 
-	bt_mesh_comp_unprovision();
-
 	bt_mesh.iv_index = 0;
 	bt_mesh.seq = 0;
 	bt_mesh.iv_update = 0;
@@ -116,6 +114,8 @@ void bt_mesh_reset(void)
 
 	bt_mesh_scan_disable();
 	bt_mesh_beacon_disable();
+
+	bt_mesh_comp_unprovision();
 
 	if (IS_ENABLED(CONFIG_BT_MESH_PROV)) {
 		bt_mesh_prov_reset();

--- a/subsys/bluetooth/host/mesh/settings.c
+++ b/subsys/bluetooth/host/mesh/settings.c
@@ -337,7 +337,7 @@ static int net_key_set(int argc, char **argv, char *val)
 		}
 
 		BT_DBG("Deleting NetKeyIndex 0x%03x", net_idx);
-		bt_mesh_subnet_del(sub);
+		bt_mesh_subnet_del(sub, false);
 		return 0;
 	}
 
@@ -404,7 +404,7 @@ static int app_key_set(int argc, char **argv, char *val)
 
 		app = bt_mesh_app_key_find(app_idx);
 		if (app) {
-			bt_mesh_app_key_del(app);
+			bt_mesh_app_key_del(app, false);
 		}
 
 		return 0;


### PR DESCRIPTION
These patches fix various things that were broken with the persistent storage behavior. I think this may be a good candidate for 1.12.1

@MariuszSkamra it'd be good to do a PTS test run on this PR.

@vikrant8051 this should fix the issue you saw with the node state not being completely restored if you did an intermediate node reset, reprovisioning and a power cycle.