### PR TITLE
Bluetooth: Add advertising data parsing helper

### DIFF
--- a/include/bluetooth/bluetooth.h
+++ b/include/bluetooth/bluetooth.h
@@ -279,6 +279,23 @@ int bt_le_scan_start(const struct bt_le_scan_param *param, bt_le_scan_cb_t cb);
  */
 int bt_le_scan_stop(void);
 
+/** @brief Helper for parsing advertising (or EIR or OOB) data.
+ *
+ *  A helper for parsing the basic data types used for Extended Inquiry
+ *  Response (EIR), Advertising Data (AD), and OOB data blocks. The most
+ *  common scenario is to call this helper on the adverstising data
+ *  received in the callback that was given to bt_le_scan_start().
+ *
+ *  @param ad        Advertising data as given to the bt_le_scan_cb_t callback.
+ *  @param func      Callback function which will be called for each element
+ *                   that's found in the data. The callback should return
+ *                   true to continue parsing, or false to stop parsing.
+ *  @param user_data User data to be passed to the callback.
+ */
+void bt_data_parse(struct net_buf_simple *ad,
+		   bool (*func)(struct bt_data *data, void *user_data),
+		   void *user_data);
+
 struct bt_le_oob {
 	/** LE address. If local privacy is enabled this is Resolvable Private
 	 *  Address.

--- a/samples/bluetooth/central_hr/src/main.c
+++ b/samples/bluetooth/central_hr/src/main.c
@@ -124,28 +124,27 @@ static void connected(struct bt_conn *conn, u8_t conn_err)
 	}
 }
 
-static bool eir_found(u8_t type, const u8_t *data, u8_t data_len,
-		      void *user_data)
+static bool eir_found(struct bt_data *data, void *user_data)
 {
 	bt_addr_le_t *addr = user_data;
 	int i;
 
-	printk("[AD]: %u data_len %u\n", type, data_len);
+	printk("[AD]: %u data_len %u\n", data->type, data->data_len);
 
-	switch (type) {
+	switch (data->type) {
 	case BT_DATA_UUID16_SOME:
 	case BT_DATA_UUID16_ALL:
-		if (data_len % sizeof(u16_t) != 0) {
+		if (data->data_len % sizeof(u16_t) != 0) {
 			printk("AD malformed\n");
 			return true;
 		}
 
-		for (i = 0; i < data_len; i += sizeof(u16_t)) {
+		for (i = 0; i < data->data_len; i += sizeof(u16_t)) {
 			struct bt_uuid *uuid;
 			u16_t u16;
 			int err;
 
-			memcpy(&u16, &data[i], sizeof(u16));
+			memcpy(&u16, &data->data[i], sizeof(u16));
 			uuid = BT_UUID_DECLARE_16(sys_le16_to_cpu(u16));
 			if (bt_uuid_cmp(uuid, BT_UUID_HRS)) {
 				continue;
@@ -166,35 +165,6 @@ static bool eir_found(u8_t type, const u8_t *data, u8_t data_len,
 	return true;
 }
 
-static void ad_parse(struct net_buf_simple *ad,
-		     bool (*func)(u8_t type, const u8_t *data,
-				  u8_t data_len, void *user_data),
-		     void *user_data)
-{
-	while (ad->len > 1) {
-		u8_t len = net_buf_simple_pull_u8(ad);
-		u8_t type;
-
-		/* Check for early termination */
-		if (len == 0) {
-			return;
-		}
-
-		if (len > ad->len) {
-			printk("AD malformed\n");
-			return;
-		}
-
-		type = net_buf_simple_pull_u8(ad);
-
-		if (!func(type, ad->data, len - 1, user_data)) {
-			return;
-		}
-
-		net_buf_simple_pull(ad, len - 1);
-	}
-}
-
 static void device_found(const bt_addr_le_t *addr, s8_t rssi, u8_t type,
 			 struct net_buf_simple *ad)
 {
@@ -206,8 +176,7 @@ static void device_found(const bt_addr_le_t *addr, s8_t rssi, u8_t type,
 
 	/* We're only interested in connectable events */
 	if (type == BT_LE_ADV_IND || type == BT_LE_ADV_DIRECT_IND) {
-		/* TODO: Move this to a place it can be shared */
-		ad_parse(ad, eir_found, (void *)addr);
+		bt_data_parse(ad, eir_found, (void *)addr);
 	}
 }
 


### PR DESCRIPTION
These two patches introduce a helper for parsing advetising data, and convert a few low-hanging fruit to use it.