### PR TITLE
Bluetooth: Reorganize Kconfig options for BLE controller

### DIFF
--- a/subsys/bluetooth/CMakeLists.txt
+++ b/subsys/bluetooth/CMakeLists.txt
@@ -4,7 +4,12 @@ target_include_directories(subsys__bluetooth INTERFACE ${CMAKE_CURRENT_SOURCE_DI
 
 add_subdirectory(common)
 add_subdirectory_ifdef(CONFIG_BT_HCI host)
-add_subdirectory_ifdef(CONFIG_BT_CTLR controller)
 add_subdirectory_ifdef(CONFIG_BT_SHELL shell)
+
+if(CONFIG_BT_CTLR)
+  if(CONFIG_BT_LL_SW)
+    add_subdirectory(controller)
+  endif()
+endif()
 
 target_link_libraries(subsys__bluetooth INTERFACE zephyr_interface)

--- a/subsys/bluetooth/controller/CMakeLists.txt
+++ b/subsys/bluetooth/controller/CMakeLists.txt
@@ -7,6 +7,8 @@ zephyr_library_sources(
   ticker/ticker.c
   ll_sw/ll_addr.c
   ll_sw/ll_tx_pwr.c
+  ll_sw/ctrl.c
+  ll_sw/ll.c
   hci/hci_driver.c
   hci/hci.c
   )
@@ -16,28 +18,25 @@ zephyr_library_sources_ifdef(
   crypto/crypto.c
   )
 
-if(CONFIG_BT_LL_SW)
-  zephyr_library_sources(
-    ll_sw/ctrl.c
-    ll_sw/ll.c
-    )
-  zephyr_library_sources_ifdef(
-    CONFIG_BT_BROADCASTER
-    ll_sw/ll_adv.c
-    )
-  zephyr_library_sources_ifdef(
-    CONFIG_BT_OBSERVER
-    ll_sw/ll_scan.c
-    )
-  zephyr_library_sources_ifdef(
-    CONFIG_BT_CENTRAL
-    ll_sw/ll_master.c
-    )
-  zephyr_library_sources_ifdef(
-    CONFIG_BT_CTLR_DTM
-    ll_sw/ll_test.c
-    )
-endif()
+zephyr_library_sources_ifdef(
+  CONFIG_BT_BROADCASTER
+  ll_sw/ll_adv.c
+  )
+
+zephyr_library_sources_ifdef(
+  CONFIG_BT_OBSERVER
+  ll_sw/ll_scan.c
+  )
+
+zephyr_library_sources_ifdef(
+  CONFIG_BT_CENTRAL
+  ll_sw/ll_master.c
+  )
+
+zephyr_library_sources_ifdef(
+  CONFIG_BT_CTLR_DTM
+  ll_sw/ll_test.c
+  )
 
 zephyr_library_sources_ifdef(
   CONFIG_BT_CTLR_FILTER

--- a/subsys/bluetooth/controller/Kconfig
+++ b/subsys/bluetooth/controller/Kconfig
@@ -9,7 +9,6 @@ comment "BLE Controller support"
 
 config BT_CTLR
 	bool "Bluetooth Controller"
-	select BT_RECV_IS_RX_THREAD
 	help
 	  Enables support for SoC native controller implementations.
 
@@ -23,6 +22,7 @@ choice
 
 config BT_LL_SW
 	bool "Software-based BLE Link Layer"
+	select BT_RECV_IS_RX_THREAD
 	select ENTROPY_GENERATOR
 	select ENTROPY_NRF5_RNG if SOC_FAMILY_NRF
 	select ENTROPY_NRF5_BIAS_CORRECTION if SOC_FAMILY_NRF
@@ -559,8 +559,6 @@ config BT_CTLR_PA_LNA_GPIOTE_CHAN
 	help
 	  Select the nRF5 GPIOTE channel to use for PA/LNA GPIO feature.
 
-endif # BT_LL_SW
-
 comment "BLE Controller debug configuration"
 
 config BT_CTLR_ASSERT_HANDLER
@@ -588,5 +586,7 @@ config BT_CTLR_DEBUG_PINS
 	  Turn on debug GPIO toggling for the BLE Controller. This is useful
 	  when debugging with a logic analyzer or profiling certain sections of
 	  the code.
+
+endif # BT_LL_SW
 
 endif # BT_CTLR


### PR DESCRIPTION
Split meaning of BT_CTLR and BT_LL_SW, since they always are the same.
This way BT_CTLR means that there an controller implemented,
and BT_LL_SW refers to the specific implementation.
This allows alternative controller implementations.

Signed-off-by: Joakim Andersson <joakim.andersson@nordicsemi.no>