### PR TITLE
bluetooth: Make controller crypto functions optional

### DIFF
--- a/subsys/bluetooth/controller/CMakeLists.txt
+++ b/subsys/bluetooth/controller/CMakeLists.txt
@@ -7,9 +7,13 @@ zephyr_library_sources(
   ticker/ticker.c
   ll_sw/ll_addr.c
   ll_sw/ll_tx_pwr.c
-  crypto/crypto.c
   hci/hci_driver.c
   hci/hci.c
+  )
+
+zephyr_library_sources_ifdef(
+  CONFIG_BT_CTLR_CRYPTO
+  crypto/crypto.c
   )
 
 if(CONFIG_BT_LL_SW)

--- a/subsys/bluetooth/controller/Kconfig
+++ b/subsys/bluetooth/controller/Kconfig
@@ -33,6 +33,13 @@ endchoice
 
 comment "BLE Controller configuration"
 
+config BT_CTLR_CRYPTO
+	bool "Enable crypto functions in Controller"
+	default y
+	help
+	  Use random number generation and AES encryption support functions
+	  provided by the controller.
+
 config BT_CTLR_RX_PRIO_STACK_SIZE
 	# Hidden option for Controller's Co-Operative high priority Rx thread
 	# stack size.

--- a/subsys/bluetooth/host/Kconfig
+++ b/subsys/bluetooth/host/Kconfig
@@ -124,10 +124,10 @@ source "subsys/bluetooth/host/mesh/Kconfig"
 
 config BT_HOST_CRYPTO
 	# Hidden option that compiles in random number generation and AES
-	# encryption support using TinyCrypt library if software-based
-	# controller is disabled.
+	# encryption support using TinyCrypt library if this is not provided
+	# by the controller implementation.
 	bool
-	default y if !BT_CTLR
+	default y if !BT_CTLR_CRYPTO
 	select TINYCRYPT
 	select TINYCRYPT_AES
 	select TINYCRYPT_SHA256


### PR DESCRIPTION
Provide flexibility in choosing to use the host defined crypto
functions or the ones provided by the controller

Signed-off-by: Joakim Andersson <joakim.andersson@nordicsemi.no>