### PR TITLE
sanitycheck: fix spammy build output

### DIFF
--- a/scripts/sanitycheck
+++ b/scripts/sanitycheck
@@ -913,7 +913,7 @@ class MakeGenerator:
         else:
             generator = "Unix Makefiles"
             generator_cmd = "$(MAKE)"
-            verb = "VERBOSE=1" if VERBOSE else "VERBOSE=0"
+            verb = "VERBOSE=1" if VERBOSE else ""
 
         if phase == 'running':
             return MakeGenerator.MAKE_RULE_TMPL_RUN.format(


### PR DESCRIPTION
VERBOSE if set to any value enables verbose build output,
setting to 0 does not have the intended effect.

Signed-off-by: Andrew Boie <andrew.p.boie@intel.com>