### PR TITLE
boards: Kconfig: Remove redundant 'default n' properties

### DIFF
--- a/boards/Kconfig
+++ b/boards/Kconfig
@@ -9,7 +9,6 @@ config BOARD_DEPRECATED
 
 config QEMU_TARGET
 	bool
-	default n
 	help
 	  Mark all QEMU targets with this variable for checking whether we are
 	  running in an emulated environment.

--- a/boards/arm/hexiwear_k64/Kconfig
+++ b/boards/arm/hexiwear_k64/Kconfig
@@ -9,6 +9,5 @@ if BOARD_HEXIWEAR_K64
 
 config BATTERY_SENSE
 	bool "Enable the battery sense circuit"
-	default n
 
 endif # BOARD_HEXIWEAR_K64

--- a/boards/posix/native_posix/Kconfig
+++ b/boards/posix/native_posix/Kconfig
@@ -7,7 +7,6 @@ config NATIVE_POSIX_SLOWDOWN_TO_REAL_TIME
 	bool "Slow down execution to real time"
 	depends on BOARD_NATIVE_POSIX
 	default y if !TEST
-	default n if TEST
 	help
 	  When selected the execution of the process will be slowed down to real time.
 	  (if there is a lot of load it may be slower than real time)

--- a/boards/x86/x86_jailhouse/Kconfig.defconfig
+++ b/boards/x86/x86_jailhouse/Kconfig.defconfig
@@ -11,6 +11,5 @@ config JAILHOUSE
 config JAILHOUSE_X2APIC
 	depends on JAILHOUSE
 	bool "When in Jailhouse inmate cell mode, access APIC in x2APIC mode"
-	default n
 
 endif # BOARD_X86_JAILHOUSE


### PR DESCRIPTION
Bool symbols implicitly default to 'n'.

A 'default n' can make sense e.g. in a Kconfig.defconfig file, if you
want to override a 'default y' on the base definition of the symbol. It
isn't used like that for any of the removed properties though.