### PR TITLE
drivers: sensor: Kconfig: Remove redundant 'default n' properties

### DIFF
--- a/drivers/sensor/Kconfig
+++ b/drivers/sensor/Kconfig
@@ -9,7 +9,6 @@
 menuconfig SENSOR
 	bool
 	prompt "Sensor Drivers"
-	default n
 	help
 	  Include sensor drivers in system config
 

--- a/drivers/sensor/adxl362/Kconfig
+++ b/drivers/sensor/adxl362/Kconfig
@@ -8,7 +8,6 @@
 menuconfig ADXL362
 	bool "ADXL362 sensor"
 	depends on SPI
-	default n
 	help
 	  Enable driver for ADXL362 Three-Axis Digital Accelerometers.
 

--- a/drivers/sensor/ak8975/Kconfig
+++ b/drivers/sensor/ak8975/Kconfig
@@ -10,7 +10,6 @@ menuconfig AK8975
 	bool
 	prompt "AK8975 Magnetometer"
 	depends on I2C
-	default n
 	help
 	  Enable driver for AK8975 magnetometer.
 
@@ -52,7 +51,6 @@ config MPU9150
 	bool
 	prompt "Enable MPU9180 support"
 	depends on AK8975
-	default n
 	help
 	  Enable this config option if the AK8975 sensor is part of a
 	  MPU9150 chip.

--- a/drivers/sensor/amg88xx/Kconfig
+++ b/drivers/sensor/amg88xx/Kconfig
@@ -9,7 +9,6 @@
 menuconfig AMG88XX
 	bool "AMG88XX Infrared Thermopile Sensor"
 	depends on I2C
-	default n
 	help
 	  Enable driver for AMG88XX infrared thermopile sensor.
 

--- a/drivers/sensor/apds9960/Kconfig
+++ b/drivers/sensor/apds9960/Kconfig
@@ -7,7 +7,6 @@
 menuconfig APDS9960
 	bool "APDS9960 Sensor"
 	depends on I2C
-	default n
 	help
 	  Enable driver for APDS9960 sensors.
 

--- a/drivers/sensor/bma280/Kconfig
+++ b/drivers/sensor/bma280/Kconfig
@@ -10,7 +10,6 @@ menuconfig BMA280
 	bool
 	prompt "BMA280 Three Axis Accelerometer Family"
 	depends on I2C
-	default n
 	help
 	  Enable driver for BMA280 I2C-based triaxial accelerometer sensor
 	  family.

--- a/drivers/sensor/bmc150_magn/Kconfig
+++ b/drivers/sensor/bmc150_magn/Kconfig
@@ -9,7 +9,6 @@
 menuconfig BMC150_MAGN
 	bool "BMC150_MAGN I2C Magnetometer Chip"
 	depends on I2C
-	default n
 	help
 	  Enable driver for BMC150 I2C-based magnetometer sensor.
 
@@ -68,21 +67,18 @@ endchoice
 config BMC150_MAGN_SAMPLING_RATE_RUNTIME
 	bool "Enable dynamic sampling rate"
 	depends on BMC150_MAGN
-	default n
 	help
 	  Enable alteration of sampling rate attribute at runtime.
 
 config BMC150_MAGN_SAMPLING_REP_XY
 	bool "Enable dynamic XY oversampling"
 	depends on BMC150_MAGN
-	default n
 	help
 	  Enable alteration of XY oversampling at runtime.
 
 config BMC150_MAGN_SAMPLING_REP_Z
 	bool "Enable dynamic Z oversampling"
 	depends on BMC150_MAGN
-	default n
 	help
 	  Enable alteration of Z oversampling at runtime.
 
@@ -91,7 +87,6 @@ endmenu
 config BMC150_MAGN_TRIGGER
 	bool "Enable triggers"
 	depends on BMC150_MAGN && GPIO
-	default n
 	help
 	  Enable triggers for BMC150 magnetometer
 
@@ -105,7 +100,6 @@ config BMC150_MAGN_TRIGGER_THREAD_STACK
 config BMC150_MAGN_TRIGGER_DRDY
 	bool "Enable data ready trigger"
 	depends on BMC150_MAGN_TRIGGER
-	default n
 	help
 	  Enable data ready interrupt for BMC150 magnetometer
 

--- a/drivers/sensor/bmg160/Kconfig
+++ b/drivers/sensor/bmg160/Kconfig
@@ -9,7 +9,6 @@
 menuconfig BMG160
 	bool "Bosch BMG160 gyroscope support"
 	depends on I2C
-	default n
 	help
 	  Enable Bosch BMG160 gyroscope support.
 

--- a/drivers/sensor/bmi160/Kconfig
+++ b/drivers/sensor/bmi160/Kconfig
@@ -9,7 +9,6 @@
 menuconfig BMI160
 	bool "Bosch BMI160 inertial measurement unit"
 	depends on SPI
-	default n
 	help
 	  Enable Bosch BMI160 inertial measurement unit that provides acceleration
 	  and angular rate measurements.

--- a/drivers/sensor/bmm150/Kconfig
+++ b/drivers/sensor/bmm150/Kconfig
@@ -9,7 +9,6 @@
 menuconfig BMM150
 	bool "BMM150 I2C Geomagnetic Chip"
 	depends on I2C
-	default n
 	help
 	  Enable driver for BMM150 I2C-based Geomagnetic sensor.
 if BMM150
@@ -55,19 +54,16 @@ endchoice
 
 config BMM150_SAMPLING_RATE_RUNTIME
 	bool "Enable dynamic sampling rate"
-	default n
 	help
 	  Enable alteration of sampling rate attribute at runtime.
 
 config BMM150_SAMPLING_REP_XY
 	bool "Enable dynamic XY oversampling"
-	default n
 	help
 	  Enable alteration of XY oversampling at runtime.
 
 config BMM150_SAMPLING_REP_Z
 	bool "Enable dynamic Z oversampling"
-	default n
 	help
 	  Enable alteration of Z oversampling at runtime.
 

--- a/drivers/sensor/ccs811/Kconfig
+++ b/drivers/sensor/ccs811/Kconfig
@@ -10,7 +10,6 @@ menuconfig CCS811
 	bool
 	prompt "CCS811 Digital Gas Sensor"
 	depends on I2C
-	default n
 	help
 	  Enable driver for CCS811 Gas sensors.
 
@@ -58,7 +57,6 @@ config CCS811_GPIO_DEV_NAME
 config CCS811_GPIO_WAKEUP
 	bool
 	prompt "Enable GPIO Wakeup for CCS811"
-	default n
 	depends on CCS811
 	help
 	  Enable GPIO Wakeup support for CCS811
@@ -75,7 +73,6 @@ config CCS811_GPIO_WAKEUP_PIN_NUM
 config CCS811_GPIO_RESET
 	bool
 	prompt "Enable GPIO Reset for CCS811"
-	default n
 	depends on CCS811
 	help
 	  Enable GPIO Reset support for CCS811

--- a/drivers/sensor/dht/Kconfig
+++ b/drivers/sensor/dht/Kconfig
@@ -10,7 +10,6 @@ menuconfig DHT
 	bool
 	prompt "DHT Temperature and Humidity Sensor"
 	depends on GPIO
-	default n
 	help
 	  Enable driver for the DHT temperature and humidity sensor family.
 

--- a/drivers/sensor/fxas21002/Kconfig
+++ b/drivers/sensor/fxas21002/Kconfig
@@ -8,7 +8,6 @@
 menuconfig FXAS21002
 	bool "FXAS21002 gyroscope driver"
 	depends on I2C
-	default n
 	help
 	  Enable driver for the FXAS21002 gyroscope
 
@@ -88,7 +87,6 @@ endchoice
 
 config FXAS21002_TRIGGER
 	bool
-	default n
 
 if FXAS21002_TRIGGER
 
@@ -104,7 +102,6 @@ endif
 
 config FXAS21002_DRDY_INT1
 	bool "Data ready interrupt to INT1 pin"
-	default n
 	help
 	  Say Y to route data ready interrupt to INT1 pin. Say N to route to
 	  INT2 pin.

--- a/drivers/sensor/fxos8700/Kconfig
+++ b/drivers/sensor/fxos8700/Kconfig
@@ -8,7 +8,6 @@
 menuconfig FXOS8700
 	bool "FXOS8700 accelerometer/magnetometer driver"
 	depends on I2C
-	default n
 	help
 	  Enable driver for the FXOS8700 accelerometer/magnetometer
 
@@ -64,7 +63,6 @@ endchoice
 config FXOS8700_TEMP
 	bool "Enable temperature"
 	depends on FXOS8700 && (FXOS8700_MODE_MAGN || FXOS8700_MODE_HYBRID)
-	default n
 	help
 	  Enable the temperature sensor. Note that the temperature sensor is
 	  uncalibrated and its output for a given temperature may vary from one
@@ -107,7 +105,6 @@ endchoice
 config FXOS8700_TRIGGER
 	bool
 	depends on FXOS8700
-	default n
 
 if !HAS_DTS_GPIO_DEVICE
 
@@ -124,7 +121,6 @@ endif
 config FXOS8700_DRDY_INT1
 	bool "Data ready interrupt to INT1 pin"
 	depends on FXOS8700_TRIGGER
-	default n
 	help
 	  Say Y to route data ready interrupt to INT1 pin. Say N to route to
 	  INT2 pin.
@@ -143,7 +139,6 @@ config FXOS8700_THREAD_STACK_SIZE
 
 menuconfig FXOS8700_PULSE
 	bool "Pulse detection"
-	default n
 	help
 	  Enable pulse detection
 
@@ -151,7 +146,6 @@ if FXOS8700_PULSE
 
 config FXOS8700_PULSE_INT1
 	bool "Pulse interrupt to INT1 pin"
-	default n
 	help
 	  Say Y to route pulse interrupt to INT1 pin. Say N to route to INT2 pin.
 

--- a/drivers/sensor/hdc1008/Kconfig
+++ b/drivers/sensor/hdc1008/Kconfig
@@ -10,7 +10,6 @@ menuconfig HDC1008
 	bool
 	prompt "HDC1008 Temperature and Humidity Sensor"
 	depends on I2C && GPIO
-	default n
 	help
 	  Enable driver for HDC1008 temperature and humidity sensors.
 

--- a/drivers/sensor/hmc5883l/Kconfig
+++ b/drivers/sensor/hmc5883l/Kconfig
@@ -8,7 +8,6 @@ menuconfig HMC5883L
 	bool
 	prompt "HMC5883L magnetometer"
 	depends on I2C
-	default n
 	help
 	  Enable driver for HMC5883L I2C-based magnetometer.
 

--- a/drivers/sensor/hp206c/Kconfig
+++ b/drivers/sensor/hp206c/Kconfig
@@ -8,7 +8,6 @@
 menuconfig HP206C
 	bool "HopeRF HP206C precision barometer and altimeter sensor"
 	depends on I2C
-	default n
 	help
 	  Enable HopeRF HP206C barometer and altimeter support.
 

--- a/drivers/sensor/hts221/Kconfig
+++ b/drivers/sensor/hts221/Kconfig
@@ -8,7 +8,6 @@ menuconfig HTS221
 	bool
 	prompt "HTS221 temperature and humidity sensor"
 	depends on I2C
-	default n
 	help
 	  Enable driver for HTS221 I2C-based temperature and humidity sensor.
 

--- a/drivers/sensor/isl29035/Kconfig
+++ b/drivers/sensor/isl29035/Kconfig
@@ -9,7 +9,6 @@
 menuconfig ISL29035
 	bool
 	prompt "ISL29035 light sensor"
-	default n
 	depends on I2C
 	help
 	  Enable driver for the ISL29035 light sensor.

--- a/drivers/sensor/lis2dh/Kconfig
+++ b/drivers/sensor/lis2dh/Kconfig
@@ -10,7 +10,6 @@ menuconfig LIS2DH
 	bool
 	prompt "LIS2DH Three Axis Accelerometer"
 	depends on I2C || SPI
-	default n
 	help
 	  Enable driver for LIS2DH SPI/I2C-based triaxial accelerometer sensor.
 

--- a/drivers/sensor/lis3dh/Kconfig
+++ b/drivers/sensor/lis3dh/Kconfig
@@ -10,7 +10,6 @@ menuconfig LIS3DH
 	bool
 	prompt "LIS3DH Three Axis Accelerometer"
 	depends on I2C
-	default n
 	help
 	  Enable driver for LIS3DH I2C-based triaxial accelerometer sensor.
 

--- a/drivers/sensor/lis3mdl/Kconfig
+++ b/drivers/sensor/lis3mdl/Kconfig
@@ -8,7 +8,6 @@ menuconfig LIS3MDL
 	bool
 	prompt "LIS3MDL magnetometer"
 	depends on I2C
-	default n
 	help
 	  Enable driver for LIS3MDL I2C-based magnetometer.
 

--- a/drivers/sensor/lps22hb/Kconfig
+++ b/drivers/sensor/lps22hb/Kconfig
@@ -8,7 +8,6 @@ menuconfig LPS22HB
 	bool
 	prompt "LPS22HB pressure and temperature"
 	depends on I2C
-	default n
 	help
 	  Enable driver for LPS22HB I2C-based pressure and temperature
 	  sensor.

--- a/drivers/sensor/lps25hb/Kconfig
+++ b/drivers/sensor/lps25hb/Kconfig
@@ -8,7 +8,6 @@ menuconfig LPS25HB
 	bool
 	prompt "LPS25HB pressure and temperature"
 	depends on I2C
-	default n
 	help
 	  Enable driver for LPS25HB I2C-based pressure and temperature
 	  sensor.

--- a/drivers/sensor/lsm6ds0/Kconfig
+++ b/drivers/sensor/lsm6ds0/Kconfig
@@ -10,7 +10,6 @@
 menuconfig LSM6DS0
 	bool "LSM6DS0 I2C accelerometer and gyroscope Chip"
 	depends on I2C
-	default n
 	help
 	  Enable driver for LSM6DS0 I2C-based accelerometer and gyroscope
 	  sensor.
@@ -93,7 +92,6 @@ config LSM6DS0_GYRO_ENABLE_Z_AXIS
 config LSM6DS0_ENABLE_TEMP
 	bool "Enable temperature"
 	depends on LSM6DS0
-	default n
 	help
 	  Enable/disable temperature totally by stripping everything related in
 	  driver.

--- a/drivers/sensor/lsm6dsl/Kconfig
+++ b/drivers/sensor/lsm6dsl/Kconfig
@@ -10,7 +10,6 @@
 menuconfig LSM6DSL
 	bool "LSM6DSL I2C/SPI accelerometer and gyroscope Chip"
 	depends on SENSOR && (I2C || SPI)
-	default n
 	help
 	  Enable driver for LSM6DSL accelerometer and gyroscope
 	  sensor.
@@ -88,7 +87,6 @@ endif #HAS_DTS_SPI_DEVICE
 
 config LSM6DSL_SPI_GPIO_CS
 	bool "LSM6DSL SPI CS through a GPIO pin"
-	default n
 	depends on LSM6DSL && LSM6DSL_SPI
 	help
 	  This option is useful if one needs to manage SPI CS through a GPIO
@@ -181,14 +179,12 @@ config LSM6DSL_THREAD_STACK_SIZE
 config LSM6DSL_ENABLE_TEMP
 	bool "Enable temperature"
 	depends on LSM6DSL
-	default n
 	help
 	  Enable/disable temperature
 
 config LSM6DSL_SENSORHUB
 	bool "Enable I2C sensorhub feature"
 	depends on LSM6DSL
-	default n
 	help
 	  Enable/disable internal sensorhub
 

--- a/drivers/sensor/lsm9ds0_gyro/Kconfig
+++ b/drivers/sensor/lsm9ds0_gyro/Kconfig
@@ -9,7 +9,6 @@
 menuconfig LSM9DS0_GYRO
 	bool "LSM9DS0 I2C gyroscope Chip"
 	depends on I2C
-	default n
 	help
 	  Enable driver for LSM9DS0 I2C-based gyroscope sensor.
 
@@ -64,7 +63,6 @@ endchoice
 config LSM9DS0_GYRO_FULLSCALE_RUNTIME
 	bool "Enable dynamic full-scale"
 	depends on LSM9DS0_GYRO
-	default n
 	help
 	  Enable alteration of full-scale attribute at runtime.
 
@@ -96,7 +94,6 @@ endchoice
 config LSM9DS0_GYRO_SAMPLING_RATE_RUNTIME
 	bool "Enable dynamic sampling rate"
 	depends on LSM9DS0_GYRO
-	default n
 	help
 	  Enable alteration of sampling rate frequency at runtime.
 
@@ -105,7 +102,6 @@ endmenu
 config LSM9DS0_GYRO_TRIGGERS
 	bool "Enable triggers"
 	depends on LSM9DS0_GYRO && GPIO
-	default n
 
 config LSM9DS0_GYRO_THREAD_STACK_SIZE
 	int "Thread stack size"
@@ -117,7 +113,6 @@ config LSM9DS0_GYRO_THREAD_STACK_SIZE
 config LSM9DS0_GYRO_TRIGGER_DRDY
 	bool "Enable data ready trigger"
 	depends on LSM9DS0_GYRO_TRIGGERS
-	default n
 
 config LSM9DS0_GYRO_GPIO_DRDY_DEV_NAME
 	string "GPIO device where LSM9DS0_GYRO data ready interrupt is connected"

--- a/drivers/sensor/lsm9ds0_mfd/Kconfig
+++ b/drivers/sensor/lsm9ds0_mfd/Kconfig
@@ -10,7 +10,6 @@
 menuconfig LSM9DS0_MFD
 	bool "LSM9DS0 I2C accelerometer, magnetometer and temperature sensor chip"
 	depends on I2C
-	default n
 	help
 	  Enable driver for LSM9DS0 I2C-based MFD sensor.
 
@@ -56,7 +55,6 @@ config LSM9DS0_MFD_MAGN_ENABLE
 config LSM9DS0_MFD_TEMP_ENABLE
 	bool "Enable temperature sensor"
 	depends on LSM9DS0_MFD
-	default n
 	help
 	  Enable/disable temperature sensor totally by stripping everything
 	  related in driver.
@@ -120,7 +118,6 @@ endchoice
 config LSM9DS0_MFD_ACCEL_SAMPLING_RATE_RUNTIME
 	bool "Enable dynamic sampling rate for accelerometer"
 	depends on LSM9DS0_MFD_ACCEL_ENABLE
-	default n
 	help
 	  Enable alteration of accelerometer sampling rate attribute at
 	  runtime.
@@ -157,7 +154,6 @@ endchoice
 config LSM9DS0_MFD_ACCEL_FULL_SCALE_RUNTIME
 	bool "Enable dynamic full-scale for accelerometer"
 	depends on LSM9DS0_MFD_ACCEL_ENABLE
-	default n
 	help
 	  Enable alteration of accelerometer full-scale attribute at
 	  runtime.
@@ -213,7 +209,6 @@ endchoice
 config LSM9DS0_MFD_MAGN_SAMPLING_RATE_RUNTIME
 	bool "Enable dynamic sampling rate for magnetometer"
 	depends on LSM9DS0_MFD_MAGN_ENABLE
-	default n
 	help
 	  Enable alteration of magnetometer sampling rate attribute at
 	  runtime.
@@ -246,7 +241,6 @@ endchoice
 config LSM9DS0_MFD_MAGN_FULL_SCALE_RUNTIME
 	bool "Enable dynamic full-scale for magnetometer"
 	depends on LSM9DS0_MFD_MAGN_ENABLE
-	default n
 	help
 	  Enable alteration of magnetometer full-scale attribute at
 	  runtime.

--- a/drivers/sensor/max30101/Kconfig
+++ b/drivers/sensor/max30101/Kconfig
@@ -9,7 +9,6 @@ menuconfig MAX30101
 	bool
 	prompt "MAX30101 Pulse Oximeter and Heart Rate Sensor"
 	depends on I2C
-	default n
 
 if MAX30101
 
@@ -46,7 +45,6 @@ config MAX30101_SMP_AVE
 
 config MAX30101_FIFO_ROLLOVER_EN
 	bool "FIFO rolls on full"
-	default n
 	help
 	  Controls the behavior of the FIFO when the FIFO becomes completely
 	  filled with data. If set, the FIFO address rolls over to zero and the

--- a/drivers/sensor/max44009/Kconfig
+++ b/drivers/sensor/max44009/Kconfig
@@ -10,7 +10,6 @@ menuconfig MAX44009
 	bool
 	prompt "MAX44009 Light Sensor"
 	depends on I2C
-	default n
 	help
 	  Enable driver for MAX44009 light sensors.
 

--- a/drivers/sensor/mcp9808/Kconfig
+++ b/drivers/sensor/mcp9808/Kconfig
@@ -9,7 +9,6 @@
 menuconfig MCP9808
 	bool "MCP9808 temperature sensor"
 	depends on I2C
-	default n
 	help
 	 Enable driver for MCP9808 temperature sensor.
 

--- a/drivers/sensor/mpu6050/Kconfig
+++ b/drivers/sensor/mpu6050/Kconfig
@@ -10,7 +10,6 @@ menuconfig MPU6050
 	bool
 	prompt "MPU6050 Six-Axis Motion Tracking Device"
 	depends on I2C
-	default n
 	help
 	  Enable driver for MPU6050 I2C-based six-axis motion tracking device.
 

--- a/drivers/sensor/nrf5/Kconfig
+++ b/drivers/sensor/nrf5/Kconfig
@@ -10,7 +10,6 @@ menuconfig TEMP_NRF5
 	bool
 	prompt "nRF5 Temperature Sensor"
 	depends on SOC_FAMILY_NRF
-	default n
 	help
 	  Enable driver for nRF5 temperature sensor.
 

--- a/drivers/sensor/pms7003/Kconfig
+++ b/drivers/sensor/pms7003/Kconfig
@@ -9,7 +9,6 @@
 menuconfig PMS7003
 	bool "PMS7003 particulate matter sensor"
 	depends on SERIAL
-	default n
 	help
 	  Enable driver for pms7003 particulate matter sensor.
 

--- a/drivers/sensor/sht3xd/Kconfig
+++ b/drivers/sensor/sht3xd/Kconfig
@@ -10,7 +10,6 @@ menuconfig SHT3XD
 	bool
 	prompt "SHT3xD Temperature and Humidity Sensor"
 	depends on I2C
-	default n
 	help
 	  Enable driver for SHT3xD temperature and humidity sensors.
 

--- a/drivers/sensor/sx9500/Kconfig
+++ b/drivers/sensor/sx9500/Kconfig
@@ -9,7 +9,6 @@
 menuconfig SX9500
 	bool "SX9500 I2C SAR Proximity Chip"
 	depends on I2C
-	default n
 	help
 	  Enable driver for SX9500 I2C-based SAR proximity sensor.
 

--- a/drivers/sensor/th02/Kconfig
+++ b/drivers/sensor/th02/Kconfig
@@ -7,7 +7,6 @@
 menuconfig TH02
 	bool
 	prompt "TH02 Temperature Sensor"
-	default n
 	depends on I2C
 	help
 	  Enable driver for the TH02 temperature sensor.

--- a/drivers/sensor/tmp007/Kconfig
+++ b/drivers/sensor/tmp007/Kconfig
@@ -10,7 +10,6 @@ menuconfig TMP007
 	bool
 	prompt "TMP007 Infrared Thermopile Sensor"
 	depends on I2C
-	default n
 	help
 	  Enable driver for TMP007 infrared thermopile sensors.
 

--- a/drivers/sensor/tmp112/Kconfig
+++ b/drivers/sensor/tmp112/Kconfig
@@ -10,7 +10,6 @@ menuconfig TMP112
 	bool
 	prompt "TMP112 Temperature Sensor"
 	depends on I2C
-	default n
 	help
 	  Enable the driver for Texas Instruments TMP112 High-Accuracy Digital
 	  Temperature Sensors.

--- a/drivers/sensor/vl53l0x/Kconfig
+++ b/drivers/sensor/vl53l0x/Kconfig
@@ -10,7 +10,6 @@ menuconfig VL53L0X
 	bool
 	prompt "VL53L0X time of flight sensor"
 	depends on SENSOR && I2C
-	default n
 	select HAS_STLIB
 	help
 	  Enable driver for VL53L0X I2C-based time of flight sensor.
@@ -47,7 +46,6 @@ endif
 config VL53L0X_XSHUT_CONTROL_ENABLE
 	bool "Enable XSHUT pin control"
 	depends on VL53L0X
-	default n
 	help
 	    Enable it if XSHUT pin is controlled by host.
 


### PR DESCRIPTION
Bool symbols implicitly default to 'n'.

A 'default n' can make sense e.g. in a Kconfig.defconfig file, if you
want to override a 'default y' on the base definition of the symbol. It
isn't used like that on any of these symbols though.