### PR TITLE
ARCH: arm: stm32: correction of inclusion issue on soc.h

### DIFF
--- a/arch/arm/soc/st_stm32/stm32f4/soc.h
+++ b/arch/arm/soc/st_stm32/stm32f4/soc.h
@@ -24,9 +24,8 @@
 
 #ifndef _ASMLANGUAGE
 
-#include <stm32f4xx.h>
-
 #include <kernel_includes.h>
+#include <stm32f4xx.h>
 
 #ifdef CONFIG_CLOCK_CONTROL_STM32_CUBE
 #include <stm32f4xx_ll_utils.h>

--- a/arch/arm/soc/st_stm32/stm32l4/soc.h
+++ b/arch/arm/soc/st_stm32/stm32l4/soc.h
@@ -22,8 +22,8 @@
 #ifndef _ASMLANGUAGE
 
 #include <autoconf.h>
-#include <stm32l4xx.h>
 #include <kernel_includes.h>
+#include <stm32l4xx.h>
 
 #define GPIO_REG_SIZE         0x400
 /* base address for where GPIO registers start */


### PR DESCRIPTION
This commit correct the issue #8563 introduce by remove of core zephyr
header inclusions from soc.h header.

