### PR TITLE
Kconfig: Remove remaining redundant 'default n's in drivers/

### DIFF
--- a/drivers/adc/Kconfig.dw
+++ b/drivers/adc/Kconfig.dw
@@ -10,7 +10,6 @@ menuconfig ADC_DW
 	bool "ARC Designware Driver"
 	depends on ARC
 	select ADC_0
-	default n
 	help
 	  Enable the driver implementation of the Designware ADC IP.
 

--- a/drivers/adc/Kconfig.mcux
+++ b/drivers/adc/Kconfig.mcux
@@ -10,6 +10,5 @@ config ADC_MCUX_ADC16
 	bool "MCUX ADC16 driver"
 	depends on HAS_MCUX_ADC16
 	select HAS_DTS_ADC
-	default n
 	help
 	  Enable the MCUX ADC16 driver.

--- a/drivers/adc/Kconfig.qmsi
+++ b/drivers/adc/Kconfig.qmsi
@@ -10,7 +10,6 @@ menuconfig ADC_QMSI
 	bool "QMSI ADC Driver"
 	depends on QMSI
 	select ADC_0
-	default n
 	help
 	  Enable the driver implementation of the QMSI ADC IP.
 
@@ -18,7 +17,6 @@ menuconfig ADC_QMSI_SS
 	bool "QMSI ADC Driver for the Sensor Subsystem"
 	depends on QMSI
 	select ADC_0
-	default n
 	help
 	  Enable the driver implementation of the QMSI ADC IP.
 

--- a/drivers/adc/Kconfig.sam_afec
+++ b/drivers/adc/Kconfig.sam_afec
@@ -10,7 +10,6 @@ menuconfig ADC_SAM_AFEC
 	bool "SAM ADC Driver"
 	depends on SOC_FAMILY_SAM
 	select HAS_DTS_ADC
-	default n
 	help
 	  Enable Atmel SAM MCU Family Analog-to-Digital Converter (ADC) driver
 	  based on AFEC module.

--- a/drivers/adc/Kconfig.ti_adc108s102
+++ b/drivers/adc/Kconfig.ti_adc108s102
@@ -10,7 +10,6 @@ menuconfig ADC_TI_ADC108S102
 	bool "TI adc108s102 chip driver"
 	select SPI
 	select ADC_0
-	default n
 	help
 	  Enable support for TI's ADC chip adc108s102 driver.
 

--- a/drivers/aio/Kconfig
+++ b/drivers/aio/Kconfig
@@ -12,12 +12,10 @@
 menuconfig AIO_COMPARATOR
 	bool
 	prompt "AIO/Comparator Configuration"
-	default n
 
 if AIO_COMPARATOR
 menuconfig AIO_COMPARATOR_QMSI
 	bool "Enable QMSI AIO/comparator driver"
-	default n
 	depends on QMSI
 	help
 	  QMSI AIO/Comparator driver.

--- a/drivers/bluetooth/hci/Kconfig
+++ b/drivers/bluetooth/hci/Kconfig
@@ -87,7 +87,6 @@ if BT_SPI
 
 config BT_SPI_BLUENRG
 	bool "Enable compatibility with BlueNRG-based devices"
-	default n
 	help
 	  Enable support for devices compatible with the BlueNRG Bluetooth
 	  Stack. Current driver supports: ST X-NUCLEO BLE series.

--- a/drivers/can/Kconfig
+++ b/drivers/can/Kconfig
@@ -11,7 +11,6 @@
 #
 menuconfig CAN
 	bool "CAN Drivers"
-	default n
 	help
 	  Enable CAN Driver Configuration
 

--- a/drivers/can/Kconfig.stm32
+++ b/drivers/can/Kconfig.stm32
@@ -8,7 +8,6 @@
 
 config CAN_STM32
 	bool "STM32 CAN Driver"
-	default n
 	select USE_STM32_HAL_CAN
 	help
 	  Enable STM32 CAN Driver (tested on stm32F0 series)

--- a/drivers/clock_control/Kconfig
+++ b/drivers/clock_control/Kconfig
@@ -12,7 +12,6 @@
 menuconfig CLOCK_CONTROL
 	bool
 	prompt "Hardware clock controller support"
-	default n
 	help
 	  Enable support for hardware clock controller. Such hardware can
 	  provide clock for other subsystem, and thus can be also used for

--- a/drivers/clock_control/Kconfig.beetle
+++ b/drivers/clock_control/Kconfig.beetle
@@ -37,9 +37,8 @@ config ARM_CLOCK_CONTROL_DEV_NAME
 config CLOCK_CONTROL_BEETLE_ENABLE_PLL
 	bool "Enable PLL on Beetle"
 	depends on CLOCK_CONTROL && SOC_SERIES_BEETLE
-	default n
 	help
-	  Enable PLL on Beetle (default n).
+	  Enable PLL on Beetle.
 
 	  Select n if not sure.
 

--- a/drivers/clock_control/Kconfig.mcux_ccm
+++ b/drivers/clock_control/Kconfig.mcux_ccm
@@ -9,6 +9,5 @@ menuconfig CLOCK_CONTROL_MCUX_CCM
 	bool
 	prompt "MCUX CCM driver"
 	depends on HAS_MCUX_CCM
-	default n
 	help
 	  Enable support for mcux ccm driver.

--- a/drivers/clock_control/Kconfig.mcux_sim
+++ b/drivers/clock_control/Kconfig.mcux_sim
@@ -9,6 +9,5 @@ menuconfig CLOCK_CONTROL_MCUX_SIM
 	bool
 	prompt "MCUX SIM driver"
 	depends on HAS_MCUX_SIM
-	default n
 	help
 	  Enable support for mcux sim driver.

--- a/drivers/clock_control/Kconfig.nrf5
+++ b/drivers/clock_control/Kconfig.nrf5
@@ -8,7 +8,6 @@ menuconfig CLOCK_CONTROL_NRF5
 	bool
 	prompt "NRF5 Clock controller support"
 	depends on SOC_FAMILY_NRF
-	default n
 	help
 	  Enable support for the Nordic Semiconductor nRF5x series SoC clock
 	  driver.

--- a/drivers/clock_control/Kconfig.quark_se
+++ b/drivers/clock_control/Kconfig.quark_se
@@ -9,7 +9,6 @@
 menuconfig CLOCK_CONTROL_QUARK_SE
 	bool
 	prompt "Quark SE Clock controller support"
-	default n
 	help
 	 Enable support for the Quark SE clock driver.
 
@@ -18,7 +17,6 @@ if CLOCK_CONTROL_QUARK_SE
 config CLOCK_CONTROL_QUARK_SE_PERIPHERAL
 	bool
 	prompt "Quark SE peripheral clock support"
-	default n
 	help
 	 Enable support for Quark SE peripheral clock which controls the
 	 clock of I2C, SPI, GPIO controllers and more.
@@ -32,7 +30,6 @@ config CLOCK_CONTROL_QUARK_SE_PERIPHERAL_DRV_NAME
 config CLOCK_CONTROL_QUARK_SE_EXTERNAL
 	bool
 	prompt "Quark SE external clock support"
-	default n
 	help
 	 Enable support for Quark SE external sub-system clock.
 
@@ -45,7 +42,6 @@ config CLOCK_CONTROL_QUARK_SE_EXTERNAL_DRV_NAME
 config CLOCK_CONTROL_QUARK_SE_SENSOR
 	bool
 	prompt "Quark SE sensor clock support"
-	default n
 	help
 	 Enable support for Quark SE sensor sub-system clock.
 

--- a/drivers/clock_control/Kconfig.stm32
+++ b/drivers/clock_control/Kconfig.stm32
@@ -58,7 +58,6 @@ endchoice #CLOCK_STM32_SYSCLK_SRC
 config CLOCK_STM32_HSE_BYPASS
 	bool "HSE bypass"
 	depends on CLOCK_STM32_SYSCLK_SRC_HSE || CLOCK_STM32_PLL_SRC_HSE
-	default n
 	help
 	  Enable this option to bypass external high-speed clock (HSE).
 

--- a/drivers/counter/Kconfig
+++ b/drivers/counter/Kconfig
@@ -8,7 +8,6 @@
 
 menuconfig COUNTER
 	bool "Counter Drivers"
-	default n
 	help
 	  Enable support for counter and timer.
 

--- a/drivers/counter/Kconfig.dtmr_cmsdk_apb
+++ b/drivers/counter/Kconfig.dtmr_cmsdk_apb
@@ -11,7 +11,6 @@ if SOC_FAMILY_ARM
 config TIMER_DTMR_CMSDK_APB
 	bool
 	prompt "ARM CMSDK (Cortex-M System Design Kit) DTMR Timer driver"
-	default n
 	help
 	  The dualtimer (DTMR) present in the platform is used as a timer.
 	  This option enables the support for the timer.
@@ -23,7 +22,6 @@ if TIMER_DTMR_CMSDK_APB
 config TIMER_DTMR_CMSDK_APB_0
 	bool
 	prompt "Timer 0 driver"
-	default n
 	help
 	  Enable support for Timer 0.
 
@@ -46,7 +44,6 @@ endif # TIMER_DTMR_CMSDK_APB
 config COUNTER_DTMR_CMSDK_APB
 	bool
 	prompt "ARM CMSDK (Cortex-M System Design Kit) DTMR Counter driver"
-	default n
 	help
 	  The dualtimer (DTMR) present in the platform is used as a counter.
 	  This option enables the support for the counter.
@@ -59,7 +56,6 @@ config COUNTER_DTMR_CMSDK_APB_0
 	bool
 	prompt "Counter 0 driver"
 	depends on !TIMER_DTMR_CMSDK_APB_0
-	default n
 	help
 	  Enable support for Counter 0.
 

--- a/drivers/counter/Kconfig.qmsi
+++ b/drivers/counter/Kconfig.qmsi
@@ -10,7 +10,6 @@ config AON_COUNTER_QMSI
 	bool
 	prompt "AON counter driver"
 	depends on COUNTER && QMSI
-	default n
 	help
 	  Enable support for AON counter.
 
@@ -25,7 +24,6 @@ config AON_TIMER_QMSI
 	bool
 	prompt "AON periodic timer driver"
 	depends on COUNTER && QMSI
-	default n
 	help
 	  Enable support for AON periodic timer.
 
@@ -46,6 +44,5 @@ config AON_API_REENTRANCY
 	bool
 	prompt "AON driver API reentrancy"
 	depends on AON_TIMER_QMSI
-	default n
 	help
 	  Enable support for AON driver API reentrancy.

--- a/drivers/counter/Kconfig.tmr_cmsdk_apb
+++ b/drivers/counter/Kconfig.tmr_cmsdk_apb
@@ -11,7 +11,6 @@ if SOC_FAMILY_ARM
 config TIMER_TMR_CMSDK_APB
 	bool
 	prompt "ARM CMSDK (Cortex-M System Design Kit) Timer driver"
-	default n
 	help
 	  The timers (TMR) present in the platform are used as timers.
 	  This option enables the support for the timers.
@@ -23,7 +22,6 @@ if TIMER_TMR_CMSDK_APB
 config TIMER_TMR_CMSDK_APB_0
 	bool
 	prompt "Timer 0 driver"
-	default n
 	help
 	  Enable support for Timer 0.
 
@@ -46,7 +44,6 @@ config TIMER_TMR_CMSDK_APB_0_IRQ_PRI
 config TIMER_TMR_CMSDK_APB_1
 	bool
 	prompt "Timer 1 driver"
-	default n
 	help
 	  Enable support for Timer 1.
 
@@ -69,7 +66,6 @@ endif # TIMER_TMR_CMSDK_APB
 config COUNTER_TMR_CMSDK_APB
 	bool
 	prompt "ARM CMSDK (Cortex-M System Design Kit) Counter driver"
-	default n
 	help
 	  The timers (TMR) present in the platform are used as counters.
 	  This option enables the support for the counters.
@@ -82,7 +78,6 @@ config COUNTER_TMR_CMSDK_APB_0
 	bool
 	prompt "Counter 0 driver"
 	depends on !TIMER_TMR_CMSDK_APB_0
-	default n
 	help
 	  Enable support for Counter 0.
 
@@ -99,7 +94,6 @@ config COUNTER_TMR_CMSDK_APB_1
 	bool
 	prompt "Counter 1 driver"
 	depends on !TIMER_TMR_CMSDK_APB_1
-	default n
 	help
 	  Enable support for Counter 1.
 

--- a/drivers/crypto/Kconfig
+++ b/drivers/crypto/Kconfig
@@ -12,7 +12,6 @@
 menuconfig CRYPTO
 	bool
 	prompt "Crypto Drivers [EXPERIMENTAL]"
-	default n
 
 if CRYPTO
 
@@ -43,7 +42,6 @@ config SYS_LOG_CRYPTO_LEVEL
 
 config CRYPTO_TINYCRYPT_SHIM
 	bool "Enable TinyCrypt shim driver [EXPERIMENTAL]"
-	default n
 	select TINYCRYPT
 	select TINYCRYPT_AES
 	select TINYCRYPT_AES_CBC
@@ -70,7 +68,6 @@ config CRYPTO_TINYCRYPT_SHIM_DRV_NAME
 
 config CRYPTO_MBEDTLS_SHIM
 	bool "Enable mbedTLS shim driver [EXPERIMENTAL]"
-	default n
 	select MBEDTLS
 	select MBEDTLS_ENABLE_HEAP
 	help

--- a/drivers/crypto/Kconfig.ataes132a
+++ b/drivers/crypto/Kconfig.ataes132a
@@ -9,7 +9,6 @@
 menuconfig CRYPTO_ATAES132A
 	bool "Atmel ATAES132A 32k AES Serial EEPROM support"
 	depends on I2C
-	default n
 	help
 	  Enable Atmel ATAES132A 32k AES Serial EEPROM support.
 

--- a/drivers/display/Kconfig
+++ b/drivers/display/Kconfig
@@ -9,7 +9,6 @@
 menuconfig DISPLAY
 	bool
 	prompt "Display Drivers"
-	default n
 	help
 	  Enable display drivers
 

--- a/drivers/display/Kconfig.ili9340
+++ b/drivers/display/Kconfig.ili9340
@@ -9,7 +9,6 @@
 menuconfig ILI9340
 	bool "ILI9340 display driver"
 	depends on SPI
-	default n
 	help
 	Enable driver for ILI9340 display driver.
 
@@ -79,7 +78,6 @@ config ILI9340_CMD_DATA_PIN
 
 config ILI9340_GPIO_CS
 	bool "Use GPIO pin for chip select"
-	default n
 	help
 	Use GPIO pin for chips select.
 

--- a/drivers/dma/Kconfig
+++ b/drivers/dma/Kconfig
@@ -12,7 +12,6 @@
 menuconfig DMA
 	bool
 	prompt "DMA driver Configuration"
-	default n
 
 if DMA
 config DMA_0_NAME
@@ -69,7 +68,6 @@ config SYS_LOG_DMA_LEVEL
 config DCACHE_WRITEBACK
 	bool
 	prompt "Data Cache Writeback"
-	default n
 	help
 	  Cache configuration for "Writeback".
 

--- a/drivers/dma/Kconfig.cavs
+++ b/drivers/dma/Kconfig.cavs
@@ -8,6 +8,5 @@
 
 menuconfig DMA_CAVS
 	bool "Enable CAVS DMA driver"
-	default n
 	help
 	  CAVS DMA driver.

--- a/drivers/dma/Kconfig.nios2_msgdma
+++ b/drivers/dma/Kconfig.nios2_msgdma
@@ -8,6 +8,5 @@
 config DMA_NIOS2_MSGDMA
 	bool "Nios-II  Modular Scatter-Gather DMA(MSGDMA) driver"
 	depends on HAS_ALTERA_HAL
-	default n
 	help
 	  Enable Nios-II Modular Scatter-Gather DMA(MSGDMA) driver.

--- a/drivers/dma/Kconfig.qmsi
+++ b/drivers/dma/Kconfig.qmsi
@@ -8,7 +8,6 @@
 
 menuconfig DMA_QMSI
 	bool "Enable QMSI DMA driver"
-	default n
 	depends on QMSI
 	help
 	  QMSI DMA driver.

--- a/drivers/dma/Kconfig.sam_xdmac
+++ b/drivers/dma/Kconfig.sam_xdmac
@@ -8,6 +8,5 @@
 menuconfig DMA_SAM_XDMAC
 	bool "Atmel SAM DMA (XDMAC) driver"
 	depends on SOC_FAMILY_SAM
-	default n
 	help
 	  Enable Atmel SAM MCU Family Direct Memory Access (XDMAC) driver.

--- a/drivers/dma/Kconfig.stm32f4x
+++ b/drivers/dma/Kconfig.stm32f4x
@@ -8,7 +8,6 @@
 
 menuconfig DMA_STM32F4X
 	bool "Enable STM32F4x DMA driver"
-	default n
 	depends on SOC_SERIES_STM32F4X
 	help
 	  DMA driver for STM32F4x series SoCs.

--- a/drivers/entropy/Kconfig
+++ b/drivers/entropy/Kconfig
@@ -9,7 +9,6 @@
 menuconfig ENTROPY_GENERATOR
 	bool
 	prompt "Entropy Drivers"
-	default n
 	help
 	  Include entropy drivers in system config.
 
@@ -23,7 +22,6 @@ source "drivers/entropy/Kconfig.native_posix"
 
 config ENTROPY_HAS_DRIVER
 	bool
-	default n
 	help
 	  This is an option to be enabled by individual entropy driver
 	  to signal that there is a true entropy driver.

--- a/drivers/entropy/Kconfig.esp32
+++ b/drivers/entropy/Kconfig.esp32
@@ -7,7 +7,6 @@
 config ENTROPY_ESP32_RNG
 	bool "ESP32 entropy number generator driver"
 	depends on ENTROPY_GENERATOR && SOC_ESP32
-	default n
 	select ENTROPY_HAS_DRIVER
 	help
 	  This option enables the entropy number generator for ESP32 SoCs.

--- a/drivers/entropy/Kconfig.mcux
+++ b/drivers/entropy/Kconfig.mcux
@@ -7,7 +7,6 @@
 menuconfig ENTROPY_MCUX_RNGA
 	bool "MCUX RNGA driver"
 	depends on ENTROPY_GENERATOR && HAS_MCUX_RNGA
-	default n
 	select ENTROPY_HAS_DRIVER
 	help
 	  This option enables the random number generator accelerator (RNGA)
@@ -16,7 +15,6 @@ menuconfig ENTROPY_MCUX_RNGA
 menuconfig ENTROPY_MCUX_TRNG
 	bool "MCUX TRNG driver"
 	depends on ENTROPY_GENERATOR && HAS_MCUX_TRNG
-	default n
 	select ENTROPY_HAS_DRIVER
 	help
 	  This option enables the true random number generator (TRNG)

--- a/drivers/entropy/Kconfig.native_posix
+++ b/drivers/entropy/Kconfig.native_posix
@@ -2,7 +2,6 @@
 menuconfig FAKE_ENTROPY_NATIVE_POSIX
 	bool "Native posix entropy driver"
 	depends on ENTROPY_GENERATOR && ARCH_POSIX
-	default n
 	select ENTROPY_HAS_DRIVER
 	help
 	  This option enables the test random number generator for the

--- a/drivers/entropy/Kconfig.stm32
+++ b/drivers/entropy/Kconfig.stm32
@@ -8,7 +8,6 @@ menuconfig ENTROPY_STM32_RNG
 	bool "STM32 RNG driver"
 	depends on SOC_FAMILY_STM32
 	depends on ENTROPY_GENERATOR
-	default n
 	select ENTROPY_HAS_DRIVER
 	select USE_STM32_LL_RNG
 	help

--- a/drivers/ethernet/Kconfig.dw
+++ b/drivers/ethernet/Kconfig.dw
@@ -10,18 +10,15 @@ menuconfig ETH_DW
 	bool
 	prompt "Synopsys DesignWare Ethernet driver"
 	depends on NET_L2_ETHERNET
-	default n
 	help
 	  Enable Synopsys DesignWare Ethernet driver.
 
 if ETH_DW
 config ETH_DW_SHARED_IRQ
 	bool
-	default n
 
 config ETH_DW_0
 	bool "Synopsys DesignWare Ethernet port 0"
-	default n
 	help
 	 Include port 0 driver
 

--- a/drivers/ethernet/Kconfig.enc28j60
+++ b/drivers/ethernet/Kconfig.enc28j60
@@ -10,7 +10,6 @@ menuconfig ETH_ENC28J60
 	bool "ENC28J60C Ethernet Controller"
 	depends on NET_L2_ETHERNET
 	depends on SPI
-	default n
 	help
 	  ENC28J60C Stand-Alone Ethernet Controller
 	  with SPI Interface
@@ -43,7 +42,6 @@ config ETH_EN28J60_TIMEOUT
 config ETH_ENC28J60_0
 	bool "ENC28J60C Ethernet port 0"
 	depends on ETH_ENC28J60
-	default n
 	help
 	  Include port 0 driver
 
@@ -85,14 +83,12 @@ config ETH_ENC28J60_0_SLAVE
 
 config ETH_ENC28J60_0_GPIO_SPI_CS
 	bool "Manage SPI CS through a GPIO pin"
-	default n
 	help
 	This option is useful if one needs to manage SPI CS through a GPIO
 	pin to by-pass the SPI controller's CS logic.
 
 config ETH_ENC28J60_0_SPI_CS_PORT_NAME
 	string "SPI cs port name"
-	default ""
 	depends on ETH_ENC28J60_0_GPIO_SPI_CS
 	help
 	Master SPI port name through which ENC28J60C chip is accessed.

--- a/drivers/ethernet/Kconfig.mcux
+++ b/drivers/ethernet/Kconfig.mcux
@@ -8,7 +8,6 @@ menuconfig ETH_MCUX
 	bool
 	prompt "MCUX Ethernet driver"
 	depends on NET_L2_ETHERNET && HAS_MCUX
-	default n
 	help
 	  Enable MCUX Ethernet driver.  Note, this driver performs one shot PHY
 	  setup.  There is no support for PHY disconnect, reconnect or
@@ -17,7 +16,6 @@ menuconfig ETH_MCUX
 if ETH_MCUX
 config ETH_MCUX_PROMISCUOUS_MODE
 	bool "Enable promiscuous mode"
-	default n
 	help
 	  Place the Ethernet receiver in promiscuous mode. This may be useful
 	  for debugging and not needed for normal work.
@@ -31,7 +29,6 @@ config ETH_MCUX_PHY_TICK_MS
 
 config ETH_MCUX_PHY_EXTRA_DEBUG
 	bool "Enable additional detailed PHY debug"
-	default n
 	help
 	  Enable additional PHY related debug information related to
 	  PHY status polling.
@@ -54,7 +51,6 @@ config ETH_MCUX_TX_BUFFERS
 
 config ETH_MCUX_0
 	bool "MCUX Ethernet port 0"
-	default n
 	help
 	 Include port 0 driver
 

--- a/drivers/ethernet/Kconfig.native_posix
+++ b/drivers/ethernet/Kconfig.native_posix
@@ -7,7 +7,6 @@
 menuconfig ETH_NATIVE_POSIX
 	bool "Native Posix Ethernet driver"
 	depends on ARCH_POSIX && NET_L2_ETHERNET
-	default n
 	help
 	  Enable native posix ethernet driver. Note, this driver is run inside
 	  a process in your host system.

--- a/drivers/ethernet/Kconfig.sam_gmac
+++ b/drivers/ethernet/Kconfig.sam_gmac
@@ -8,7 +8,6 @@ menuconfig ETH_SAM_GMAC
 	bool
 	prompt "Atmel SAM Ethernet driver"
 	depends on SOC_FAMILY_SAM
-	default n
 	help
 	  Enable Atmel SAM MCU Family Ethernet driver.
 

--- a/drivers/ethernet/Kconfig.stm32_hal
+++ b/drivers/ethernet/Kconfig.stm32_hal
@@ -10,7 +10,6 @@ menuconfig ETH_STM32_HAL
 	bool
 	prompt "STM32 HAL Ethernet driver"
 	depends on NET_L2_ETHERNET
-	default n
 	select USE_STM32_HAL_ETH
 	help
 	  Enable STM32 HAL based Ethernet driver.

--- a/drivers/flash/Kconfig
+++ b/drivers/flash/Kconfig
@@ -11,13 +11,11 @@
 #
 config FLASH_HAS_DRIVER_ENABLED
 	bool
-	default n
 	help
 	  This option is enabled when any flash driver is enabled.
 
 config FLASH_HAS_PAGE_LAYOUT
 	bool
-	default n
 	help
 	  This option is enabled when the SoC flash driver supports
 	  retrieving the layout of flash memory pages.
@@ -25,21 +23,18 @@ config FLASH_HAS_PAGE_LAYOUT
 menuconfig FLASH
 	bool
 	prompt "Flash hardware support"
-	default n
 	help
 	  Enable support for the flash hardware.
 
 config FLASH_PAGE_LAYOUT
 	bool "API for retrieving the layout of pages"
 	depends on FLASH && FLASH_HAS_PAGE_LAYOUT
-	default n
 	help
 	  Enables API for retrieving the layout of flash memory pages.
 
 config SOC_FLASH_NRF
 	bool "Nordic Semiconductor nRF flash driver"
 	depends on FLASH && SOC_FAMILY_NRF
-	default n
 	select FLASH_HAS_PAGE_LAYOUT
 	select FLASH_HAS_DRIVER_ENABLED
 	help
@@ -57,7 +52,6 @@ config SOC_FLASH_MCUX
 	depends on FLASH && HAS_MCUX
 	select FLASH_HAS_PAGE_LAYOUT
 	select FLASH_HAS_DRIVER_ENABLED
-	default n
 	help
 	  Enables the MCUX flash shim driver.
 	  WARNING: This driver will disable the system interrupts for
@@ -68,7 +62,6 @@ config SOC_FLASH_MCUX
 config SOC_FLASH_NIOS2_QSPI
 	bool "Nios-II QSPI flash driver"
 	depends on FLASH && HAS_ALTERA_HAL
-	default n
 	select FLASH_HAS_DRIVER_ENABLED
 	help
 	  Enables the Nios-II QSPI flash driver.

--- a/drivers/flash/Kconfig.qmsi
+++ b/drivers/flash/Kconfig.qmsi
@@ -9,7 +9,6 @@ menuconfig SOC_FLASH_QMSI
 	prompt "QMSI flash driver"
 	depends on QMSI && FLASH
 	select FLASH_HAS_DRIVER_ENABLED
-	default n
 	help
 	  Enable QMSI Quark flash driver.
 
@@ -40,7 +39,6 @@ config SOC_FLASH_QMSI_SYS_SIZE
 
 config SOC_FLASH_QMSI_API_REENTRANCY
 	bool "flash driver API reentrancy for QMSI shim driver"
-	default n
 	help
 	 Enable support for QMSI flash driver API reentrancy.
 

--- a/drivers/flash/Kconfig.sam0
+++ b/drivers/flash/Kconfig.sam0
@@ -8,7 +8,6 @@ if FLASH && SOC_FAMILY_SAM0
 menuconfig SOC_FLASH_SAM0
 	bool
 	prompt "Atmel SAM0 flash driver"
-	default n
 	select FLASH_HAS_PAGE_LAYOUT
 	select FLASH_HAS_DRIVER_ENABLED
 	help
@@ -18,7 +17,6 @@ config SOC_FLASH_SAM0_EMULATE_BYTE_PAGES
 	bool
 	prompt "Emulate byte-sized pages"
 	depends on SOC_FLASH_SAM0
-	default n
 	help
 	 Emulate a device with byte-sized pages by doing a
 	 read/modify/erase/write.  Needed for NFFS.

--- a/drivers/flash/Kconfig.w25qxxdv
+++ b/drivers/flash/Kconfig.w25qxxdv
@@ -47,7 +47,6 @@ config SPI_FLASH_W25QXXDV_SPI_SLAVE
 
 config SPI_FLASH_W25QXXDV_GPIO_SPI_CS
 	bool "Manage SPI CS through a GPIO pin"
-	default n
 	help
 	This option is useful if one needs to manage SPI CS through a GPIO
 	pin to by-pass the SPI controller's CS logic.

--- a/drivers/gpio/Kconfig
+++ b/drivers/gpio/Kconfig
@@ -9,7 +9,6 @@
 menuconfig GPIO
 	bool
 	prompt "GPIO Drivers"
-	default n
 	help
 	  Include GPIO drivers in system config
 
@@ -78,5 +77,7 @@ source "drivers/gpio/Kconfig.sam0"
 source "drivers/gpio/Kconfig.sam"
 
 source "drivers/gpio/Kconfig.sx1509b"
+
+source "drivers/gpio/Kconfig.imx"
 
 endif # GPIO

--- a/drivers/gpio/Kconfig.altera_nios2
+++ b/drivers/gpio/Kconfig.altera_nios2
@@ -9,7 +9,6 @@
 menuconfig GPIO_ALTERA_NIOS2
 	bool "Altera Nios-II PIO Controllers"
 	depends on GPIO && HAS_ALTERA_HAL
-	default n
 	help
 	  Enable config options to support the PIO controllers
 	  on Altera Nios-II family processors.
@@ -20,7 +19,6 @@ if GPIO_ALTERA_NIOS2
 
 config GPIO_ALTERA_NIOS2_OUTPUT
 	bool "Enable driver for Altera Nios-II PIO Output Port"
-	default n
 	help
 	  Build the driver to utilize PIO controller Output Port.
 

--- a/drivers/gpio/Kconfig.atmel_sam3
+++ b/drivers/gpio/Kconfig.atmel_sam3
@@ -9,7 +9,6 @@
 menuconfig GPIO_ATMEL_SAM3
 	bool "Atmel SAM3 PIO Controllers"
 	depends on GPIO && SOC_SERIES_SAM3X
-	default n
 	help
 	  Enable config options to support the PIO controllers
 	  on Atmel SAM3 family processors.
@@ -20,7 +19,6 @@ if GPIO_ATMEL_SAM3
 
 config GPIO_ATMEL_SAM3_PORTA
 	bool "Enable driver for Atmel SAM3 PIO Port A"
-	default n
 	help
 	  Build the driver to utilize PIO controller Port A.
 
@@ -40,7 +38,6 @@ config GPIO_ATMEL_SAM3_PORTA_IRQ_PRI
 
 config GPIO_ATMEL_SAM3_PORTB
 	bool "Enable driver for Atmel SAM3 PIO Port B"
-	default n
 	help
 	  Build the driver to utilize PIO controller Port B.
 
@@ -60,7 +57,6 @@ config GPIO_ATMEL_SAM3_PORTB_IRQ_PRI
 
 config GPIO_ATMEL_SAM3_PORTC
 	bool "Enable driver for Atmel SAM3 PIO Port C"
-	default n
 	help
 	  Build the driver to utilize PIO controller Port C.
 
@@ -80,7 +76,6 @@ config GPIO_ATMEL_SAM3_PORTC_IRQ_PRI
 
 config GPIO_ATMEL_SAM3_PORTD
 	bool "Enable driver for Atmel SAM3 PIO Port D"
-	default n
 	help
 	  Build the driver to utilize PIO controller Port D.
 

--- a/drivers/gpio/Kconfig.cc2650
+++ b/drivers/gpio/Kconfig.cc2650
@@ -5,7 +5,6 @@
 menuconfig GPIO_CC2650
 	bool "TI CC2650 GPIO driver"
 	depends on GPIO && SOC_SERIES_CC2650
-	default n
 	help
 	  Enable the GPIO driver on boards equipped with TI CC2650.
 

--- a/drivers/gpio/Kconfig.cc32xx
+++ b/drivers/gpio/Kconfig.cc32xx
@@ -4,7 +4,6 @@
 menuconfig GPIO_CC32XX
 	bool "TI CC32XX GPIO driver"
 	depends on GPIO && SOC_FAMILY_TISIMPLELINK
-	default n
 	help
 	  Enable the GPIO driver on TI SimpleLink CC32xx boards
 
@@ -13,7 +12,6 @@ if GPIO_CC32XX
 config GPIO_CC32XX_A0
 	bool "GPIO block A0"
 	depends on GPIO_CC32XX
-	default n
 	help
 	  Include support for the GPIO port A0.
 
@@ -33,7 +31,6 @@ config GPIO_CC32XX_A0_IRQ_PRI
 config GPIO_CC32XX_A1
 	bool "GPIO block A1"
 	depends on GPIO_CC32XX
-	default n
 	help
 	  Include support for the GPIO port A1.
 
@@ -53,7 +50,6 @@ config GPIO_CC32XX_A1_IRQ_PRI
 config GPIO_CC32XX_A2
 	bool "GPIO block A2"
 	depends on GPIO_CC32XX
-	default n
 	help
 	  Include support for the GPIO port A2.
 
@@ -73,7 +69,6 @@ config GPIO_CC32XX_A2_IRQ_PRI
 config GPIO_CC32XX_A3
 	bool "GPIO block A3"
 	depends on GPIO_CC32XX
-	default n
 	help
 	  Include support for the GPIO port A3.
 

--- a/drivers/gpio/Kconfig.cmsdk_ahb
+++ b/drivers/gpio/Kconfig.cmsdk_ahb
@@ -9,7 +9,6 @@
 menuconfig GPIO_CMSDK_AHB
 	bool "ARM CMSDK (Cortex-M System Design Kit) AHB GPIO Controllers"
 	depends on GPIO && SOC_SERIES_BEETLE
-	default n
 	help
 	  Enable config options to support the ARM CMSDK GPIO controllers.
 
@@ -22,7 +21,6 @@ if GPIO_CMSDK_AHB
 config GPIO_CMSDK_AHB_PORT0
 	bool "Enable driver for GPIO Port 0"
 	depends on GPIO_CMSDK_AHB
-	default n
 	help
 	  Build the driver to utilize GPIO controller Port 0.
 
@@ -45,7 +43,6 @@ config GPIO_CMSDK_AHB_PORT0_IRQ_PRI
 config GPIO_CMSDK_AHB_PORT1
 	bool "Enable driver for GPIO Port 1"
 	depends on GPIO_CMSDK_AHB
-	default n
 	help
 	  Build the driver to utilize GPIO controller Port 1.
 
@@ -68,7 +65,6 @@ config GPIO_CMSDK_AHB_PORT1_IRQ_PRI
 config GPIO_CMSDK_AHB_PORT2
 	bool "Enable driver for GPIO Port 2"
 	depends on GPIO_CMSDK_AHB
-	default n
 	help
 	  Build the driver to utilize GPIO controller Port 2.
 
@@ -91,7 +87,6 @@ config GPIO_CMSDK_AHB_PORT2_IRQ_PRI
 config GPIO_CMSDK_AHB_PORT3
 	bool "Enable driver for GPIO Port 3"
 	depends on GPIO_CMSDK_AHB
-	default n
 	help
 	  Build the driver to utilize GPIO controller Port 3.
 

--- a/drivers/gpio/Kconfig.dw
+++ b/drivers/gpio/Kconfig.dw
@@ -8,7 +8,6 @@
 
 menuconfig GPIO_DW
 	prompt "Designware GPIO"
-	default n
 	depends on GPIO
 	bool
 	help
@@ -18,7 +17,6 @@ if GPIO_DW
 
 config GPIO_DW_SHARED_IRQ
 	bool
-	default n
 
 config GPIO_DW_INIT_PRIORITY
 	int
@@ -30,7 +28,6 @@ config GPIO_DW_INIT_PRIORITY
 config GPIO_DW_CLOCK_GATE
 	bool "Enable clock gating"
 	select CLOCK_CONTROL
-	default n
 
 config GPIO_DW_CLOCK_GATE_DRV_NAME
 	string
@@ -39,7 +36,6 @@ config GPIO_DW_CLOCK_GATE_DRV_NAME
 
 config GPIO_DW_0
 	bool "Designware GPIO block 0"
-	default n
 	help
 	  Include Designware GPIO driver
 
@@ -92,7 +88,6 @@ endif
 
 config GPIO_DW_1
 	bool "Designware GPIO block 1"
-	default n
 	help
 	  Include Designware GPIO driver
 
@@ -145,7 +140,6 @@ endif
 
 config GPIO_DW_2
 	bool "Designware GPIO block 1"
-	default n
 	help
 	  Include Designware GPIO driver
 
@@ -198,7 +192,6 @@ endif
 
 config GPIO_DW_3
 	bool "Designware GPIO block 1"
-	default n
 	help
 	  Include Designware GPIO driver
 

--- a/drivers/gpio/Kconfig.esp32
+++ b/drivers/gpio/Kconfig.esp32
@@ -9,7 +9,6 @@
 menuconfig GPIO_ESP32
 	bool "ESP32 GPIO"
 	depends on GPIO && SOC_ESP32
-	default n
 	help
 	  Enables the ESP32 GPIO driver
 

--- a/drivers/gpio/Kconfig.fe310
+++ b/drivers/gpio/Kconfig.fe310
@@ -8,7 +8,6 @@
 menuconfig GPIO_FE310
 	bool "SiFive Freedom E310 Processor GPIO driver"
 	depends on GPIO && SOC_RISCV32_FE310
-	default n
 	help
 	  Enable driver for the SiFive Freedom E310 GPIO controller.
 

--- a/drivers/gpio/Kconfig.gecko
+++ b/drivers/gpio/Kconfig.gecko
@@ -8,7 +8,6 @@
 menuconfig GPIO_GECKO
 	bool "Gecko GPIO driver"
 	depends on GPIO && HAS_SILABS_GECKO
-	default n
 	help
 	  Enable the Gecko gpio driver.
 
@@ -28,7 +27,6 @@ config GPIO_GECKO_COMMON_PRI
 
 config GPIO_GECKO_PORTA
 	bool "Port A"
-	default n
 	help
 	  Enable Port A.
 
@@ -39,7 +37,6 @@ config GPIO_GECKO_PORTA_NAME
 
 config GPIO_GECKO_PORTB
 	bool "Port B"
-	default n
 	help
 	  Enable Port B.
 
@@ -50,7 +47,6 @@ config GPIO_GECKO_PORTB_NAME
 
 config GPIO_GECKO_PORTC
 	bool "Port C"
-	default n
 	help
 	  Enable Port C.
 
@@ -61,7 +57,6 @@ config GPIO_GECKO_PORTC_NAME
 
 config GPIO_GECKO_PORTD
 	bool "Port D"
-	default n
 	help
 	  Enable Port D.
 
@@ -72,7 +67,6 @@ config GPIO_GECKO_PORTD_NAME
 
 config GPIO_GECKO_PORTE
 	bool "Port E"
-	default n
 	help
 	  Enable Port E.
 
@@ -83,7 +77,6 @@ config GPIO_GECKO_PORTE_NAME
 
 config GPIO_GECKO_PORTF
 	bool "Port F"
-	default n
 	help
 	  Enable Port F.
 

--- a/drivers/gpio/Kconfig.imx
+++ b/drivers/gpio/Kconfig.imx
@@ -8,7 +8,6 @@
 menuconfig GPIO_IMX
 	bool "IMX GPIO driver"
 	depends on GPIO && HAS_IMX_GPIO
-	default n
 	help
 	  Enable the IMX GPIO driver.
 
@@ -16,43 +15,36 @@ if GPIO_IMX
 
 config GPIO_IMX_PORT_1
 	bool "Port 1"
-	default n
 	help
 	  Enable Port 1.
 
 config GPIO_IMX_PORT_2
 	bool "Port 2"
-	default n
 	help
 	  Enable Port 2.
 
 config GPIO_IMX_PORT_3
 	bool "Port 3"
-	default n
 	help
 	  Enable Port 3.
 
 config GPIO_IMX_PORT_4
 	bool "Port 4"
-	default n
 	help
 	  Enable Port 4.
 
 config GPIO_IMX_PORT_5
 	bool "Port 5"
-	default n
 	help
 	  Enable Port 5.
 
 config GPIO_IMX_PORT_6
 	bool "Port 6"
-	default n
 	help
 	  Enable Port 6.
 
 config GPIO_IMX_PORT_7
 	bool "Port 7"
-	default n
 	help
 	  Enable Port 7.
 

--- a/drivers/gpio/Kconfig.mcux
+++ b/drivers/gpio/Kconfig.mcux
@@ -10,7 +10,6 @@ menuconfig GPIO_MCUX
 	bool "MCUX GPIO driver"
 	depends on GPIO && HAS_MCUX
 	select HAS_DTS_GPIO
-	default n
 	help
 	  Enable the MCUX pinmux driver.
 
@@ -19,35 +18,30 @@ if GPIO_MCUX
 config GPIO_MCUX_PORTA
 	bool "Port A"
 	depends on PINMUX_MCUX_PORTA
-	default n
 	help
 	  Enable Port A.
 
 config GPIO_MCUX_PORTB
 	bool "Port B"
 	depends on PINMUX_MCUX_PORTB
-	default n
 	help
 	  Enable Port B.
 
 config GPIO_MCUX_PORTC
 	bool "Port C"
 	depends on PINMUX_MCUX_PORTC
-	default n
 	help
 	  Enable Port C.
 
 config GPIO_MCUX_PORTD
 	bool "Port D"
 	depends on PINMUX_MCUX_PORTD
-	default n
 	help
 	  Enable Port D.
 
 config GPIO_MCUX_PORTE
 	bool "Port E"
 	depends on PINMUX_MCUX_PORTE
-	default n
 	help
 	  Enable Port E.
 

--- a/drivers/gpio/Kconfig.mcux_igpio
+++ b/drivers/gpio/Kconfig.mcux_igpio
@@ -8,7 +8,6 @@
 menuconfig GPIO_MCUX_IGPIO
 	bool "MCUX IGPIO driver"
 	depends on GPIO && HAS_MCUX_IGPIO
-	default n
 	help
 	  Enable the MCUX IGPIO driver.
 
@@ -16,31 +15,26 @@ if GPIO_MCUX_IGPIO
 
 config GPIO_MCUX_IGPIO_1
 	bool "Port 1"
-	default n
 	help
 	  Enable Port 1.
 
 config GPIO_MCUX_IGPIO_2
 	bool "Port 2"
-	default n
 	help
 	  Enable Port 2.
 
 config GPIO_MCUX_IGPIO_3
 	bool "Port 3"
-	default n
 	help
 	  Enable Port 3.
 
 config GPIO_MCUX_IGPIO_4
 	bool "Port 4"
-	default n
 	help
 	  Enable Port 4.
 
 config GPIO_MCUX_IGPIO_5
 	bool "Port 5"
-	default n
 	help
 	  Enable Port 5.
 

--- a/drivers/gpio/Kconfig.mcux_lpc
+++ b/drivers/gpio/Kconfig.mcux_lpc
@@ -8,7 +8,6 @@
 menuconfig GPIO_MCUX_LPC
 	bool "MCUX LPC GPIO driver"
 	depends on GPIO && HAS_MCUX
-	default n
 	help
 	  Enable the MCUX LPC pinmux driver.
 
@@ -17,7 +16,6 @@ if GPIO_MCUX_LPC
 config GPIO_MCUX_LPC_PORT0
 	bool "Port 0"
 	depends on PINMUX_MCUX_LPC_PORT0
-	default n
 	help
 	  Enable Port 0.
 
@@ -29,7 +27,6 @@ config GPIO_MCUX_LPC_PORT0_NAME
 config GPIO_MCUX_LPC_PORT1
 	bool "Port 1"
 	depends on PINMUX_MCUX_LPC_PORT1
-	default n
 	help
 	  Enable Port 1.
 

--- a/drivers/gpio/Kconfig.mmio32
+++ b/drivers/gpio/Kconfig.mmio32
@@ -6,7 +6,6 @@
 
 config GPIO_MMIO32
 	bool
-	default n
 	help
 	  This is a driver for accessing a simple, fixed purpose, 32-bit
 	  memory-mapped i/o register using the same APIs as GPIO drivers. This

--- a/drivers/gpio/Kconfig.pcal9535a
+++ b/drivers/gpio/Kconfig.pcal9535a
@@ -9,7 +9,6 @@
 menuconfig GPIO_PCAL9535A
 	bool "PCAL9535A I2C-based GPIO chip"
 	depends on GPIO && I2C
-	default n
 	help
 	  Enable driver for PCAL9535A I2C-based GPIO chip.
 
@@ -45,7 +44,6 @@ config GPIO_PCAL9535A_INIT_PRIORITY
 config GPIO_PCAL9535A_0
 	bool "PCAL9535A GPIO chip #0"
 	depends on GPIO_PCAL9535A
-	default n
 	help
 	  Enable config options for the PCAL9535A I2C-based GPIO chip #0.
 
@@ -65,7 +63,6 @@ config GPIO_PCAL9535A_0_I2C_ADDR
 config GPIO_PCAL9535A_0_I2C_MASTER_DEV_NAME
 	string "I2C Master where PCAL9535A GPIO chip #0 is connected"
 	depends on GPIO_PCAL9535A_0
-	default ""
 	help
 	  Specify the device name of the I2C master device to which this
 	  PCAL9535A chip #0 is binded.
@@ -73,7 +70,6 @@ config GPIO_PCAL9535A_0_I2C_MASTER_DEV_NAME
 config GPIO_PCAL9535A_1
 	bool "PCAL9535A GPIO chip #1"
 	depends on GPIO_PCAL9535A
-	default n
 	help
 	  Enable config options for the PCAL9535A I2C-based GPIO chip #1.
 
@@ -93,7 +89,6 @@ config GPIO_PCAL9535A_1_I2C_ADDR
 config GPIO_PCAL9535A_1_I2C_MASTER_DEV_NAME
 	string "I2C Master where PCAL9535A GPIO chip #1 is connected"
 	depends on GPIO_PCAL9535A_1
-	default ""
 	help
 	  Specify the device name of the I2C master device to which this
 	  PCAL9535A chip #1 is binded.
@@ -101,7 +96,6 @@ config GPIO_PCAL9535A_1_I2C_MASTER_DEV_NAME
 config GPIO_PCAL9535A_2
 	bool "PCAL9535A GPIO chip #2"
 	depends on GPIO_PCAL9535A
-	default n
 	help
 	  Enable config options for the PCAL9535A I2C-based GPIO chip #2.
 
@@ -121,7 +115,6 @@ config GPIO_PCAL9535A_2_I2C_ADDR
 config GPIO_PCAL9535A_2_I2C_MASTER_DEV_NAME
 	string "I2C Master where PCAL9535A GPIO chip #2 is connected"
 	depends on GPIO_PCAL9535A_2
-	default ""
 	help
 	  Specify the device name of the I2C master device to which this
 	  PCAL9535A chip #2 is binded.
@@ -129,7 +122,6 @@ config GPIO_PCAL9535A_2_I2C_MASTER_DEV_NAME
 config GPIO_PCAL9535A_3
 	bool "PCAL9535A GPIO chip #3"
 	depends on GPIO_PCAL9535A
-	default n
 	help
 	  Enable config options for the PCAL9535A I2C-based GPIO chip #3.
 
@@ -149,7 +141,6 @@ config GPIO_PCAL9535A_3_I2C_ADDR
 config GPIO_PCAL9535A_3_I2C_MASTER_DEV_NAME
 	string "I2C Master where PCAL9535A GPIO chip #3 is connected"
 	depends on GPIO_PCAL9535A_3
-	default ""
 	help
 	  Specify the device name of the I2C master device to which this
 	  PCAL9535A chip #3 is binded.

--- a/drivers/gpio/Kconfig.pulpino
+++ b/drivers/gpio/Kconfig.pulpino
@@ -8,7 +8,6 @@
 menuconfig GPIO_PULPINO
 	bool "Pulpino GPIO controller driver"
 	depends on GPIO && SOC_RISCV32_PULPINO
-	default n
 	help
 	  Enable driver for the Pulpino GPIO controller.
 

--- a/drivers/gpio/Kconfig.qmsi
+++ b/drivers/gpio/Kconfig.qmsi
@@ -9,7 +9,6 @@
 menuconfig GPIO_QMSI
 	bool "QMSI GPIO driver"
 	depends on GPIO && QMSI
-	default n
 	help
 	  Enable the GPIO driver found on Intel Microcontroller
 	  boards, using the QMSI library.
@@ -17,7 +16,6 @@ menuconfig GPIO_QMSI
 menuconfig GPIO_QMSI_SS
 	bool "QMSI GPIO SS driver"
 	depends on GPIO && QMSI && ARC
-	default n
 	help
 	  Enable the GPIO driver found on Intel Microcontroller
 	  boards, on the sensor subsystem, using the QMSI library.
@@ -36,7 +34,6 @@ config GPIO_QMSI_API_REENTRANCY
 	bool
 	prompt "GPIO driver API reentrancy"
 	depends on GPIO_QMSI
-	default n
 	help
 	  Enable support for QMSI GPIO driver API reentrancy.
 
@@ -44,13 +41,11 @@ if GPIO_QMSI
 
 config GPIO_QMSI_0
 	bool "QMSI GPIO block 0"
-	default n
 	help
 	  Include support for the GPIO port 0 using QMSI.
 
 config GPIO_QMSI_1
 	bool "QMSI GPIO block 1"
-	default n
 	help
 	  Include support for the GPIO port 1 using QMSI.
 
@@ -60,13 +55,11 @@ if GPIO_QMSI_SS
 
 config GPIO_QMSI_SS_0
 	bool "QMSI GPIO SS block 0"
-	default n
 	help
 	  Include support for the GPIO SS port 0 using QMSI.
 
 config GPIO_QMSI_SS_1
 	bool "QMSI GPIO SS block 1"
-	default n
 	help
 	  Include support for the GPIO SS port 1 using QMSI.
 

--- a/drivers/gpio/Kconfig.sam
+++ b/drivers/gpio/Kconfig.sam
@@ -6,6 +6,5 @@
 menuconfig GPIO_SAM
 	bool "Atmel SAM GPIO (PORT) driver"
 	depends on GPIO && SOC_FAMILY_SAM
-	default n
 	help
 	  Enable support for the Atmel SAM 'PORT' GPIO controllers.

--- a/drivers/gpio/Kconfig.sam0
+++ b/drivers/gpio/Kconfig.sam0
@@ -6,6 +6,5 @@
 menuconfig GPIO_SAM0
 	bool "Atmel SAM0 GPIO (PORT) driver"
 	depends on GPIO && SOC_FAMILY_SAM0
-	default n
 	help
 	  Enable support for the Atmel SAM0 'PORT' GPIO controllers.

--- a/drivers/gpio/Kconfig.sch
+++ b/drivers/gpio/Kconfig.sch
@@ -9,7 +9,6 @@
 menuconfig GPIO_SCH
 	bool "Intel SCH GPIO controller"
 	depends on GPIO
-	default n
 	help
 	  Enable the SCH GPIO driver found on Intel boards
 
@@ -35,7 +34,6 @@ config GPIO_SCH_0_DEV_NAME
 
 config GPIO_SCH_1
 	bool "Enable SCH GPIO port 1"
-	default n
 	depends on GPIO_SCH
 
 config GPIO_SCH_1_DEV_NAME

--- a/drivers/gpio/Kconfig.stm32
+++ b/drivers/gpio/Kconfig.stm32
@@ -9,7 +9,6 @@ menuconfig GPIO_STM32
 	bool "GPIO Driver for STM32 family of MCUs"
 	depends on GPIO && SOC_FAMILY_STM32
 	select HAS_DTS_GPIO
-	default n
 	help
 	  Enable GPIO driver for STM32 line of MCUs
 
@@ -17,46 +16,35 @@ if GPIO_STM32
 
 config GPIO_STM32_PORTA
 	bool "Enable GPIO port A support"
-	default n
 
 config GPIO_STM32_PORTB
 	bool "Enable GPIO port B support"
-	default n
 
 config GPIO_STM32_PORTC
 	bool "Enable GPIO port C support"
-	default n
 
 config GPIO_STM32_PORTD
 	bool "Enable GPIO port D support"
-	default n
 
 config GPIO_STM32_PORTE
 	bool "Enable GPIO port E support"
-	default n
 
 config GPIO_STM32_PORTF
 	bool "Enable GPIO port F support"
-	default n
 
 config GPIO_STM32_PORTG
 	bool "Enable GPIO port G support"
-	default n
 
 config GPIO_STM32_PORTH
 	bool "Enable GPIO port H support"
-	default n
 
 config GPIO_STM32_PORTI
 	bool "Enable GPIO port I support"
-	default n
 
 config GPIO_STM32_PORTJ
 	bool "Enable GPIO port J support"
-	default n
 
 config GPIO_STM32_PORTK
 	bool "Enable GPIO port K support"
-	default n
 
 endif # GPIO_STM32

--- a/drivers/gpio/Kconfig.sx1509b
+++ b/drivers/gpio/Kconfig.sx1509b
@@ -9,7 +9,6 @@
 menuconfig GPIO_SX1509B
 	bool "SX1509B I2C GPIO chip"
 	depends on GPIO && I2C
-	default n
 	help
 	  Enable driver for SX1509B I2C GPIO chip.
 
@@ -36,7 +35,6 @@ config GPIO_SX1509B_I2C_ADDR
 
 config GPIO_SX1509B_I2C_MASTER_DEV_NAME
 	string "I2C Master to which SX1509B GPIO chip is connected"
-	default ""
 	help
 	  Specify the device name of the I2C master device to which SX1509B
 	  chip is binded.

--- a/drivers/grove/Kconfig
+++ b/drivers/grove/Kconfig
@@ -10,7 +10,6 @@
 menuconfig GROVE
 	bool
 	prompt "Grove Device Drivers"
-	default n
 	help
 	  Check this box to enable the Seeed Grove device drivers
 
@@ -32,7 +31,6 @@ config SYS_LOG_GROVE_LEVEL
 
 config GROVE_LCD_RGB
 	bool
-	default n
 	depends on GROVE
 	prompt "Enable the Seeed Grove LCD RGB Backlight"
 	help
@@ -51,7 +49,6 @@ config GROVE_LIGHT_SENSOR
 	bool
 	prompt "Enable the Seeed Grove Light Sensor"
 	depends on SENSOR && GROVE && ADC && NEWLIB_LIBC
-	default n
 	help
 	  Setting this value will enable driver support for the Grove Light
 	  Sensor.
@@ -86,7 +83,6 @@ config GROVE_TEMPERATURE_SENSOR
 	bool
 	prompt "Enable the Seeed Grove Temperature Sensor"
 	depends on SENSOR && GROVE && ADC && NEWLIB_LIBC
-	default n
 	help
 	  Setting this value will enable driver support for the Grove
 	  Temperature Sensor.

--- a/drivers/i2c/Kconfig
+++ b/drivers/i2c/Kconfig
@@ -11,7 +11,6 @@
 #
 menuconfig I2C
 	bool "I2C Drivers"
-	default n
 	help
 	  Enable I2C Driver Configuration
 
@@ -38,7 +37,6 @@ config SYS_LOG_I2C_LEVEL
 
 config I2C_0
 	bool "Enable I2C Port 0"
-	default n
 
 config I2C_0_NAME
 	string "Port 0 device name"
@@ -64,7 +62,6 @@ config I2C_0_IRQ_PRI
 
 config I2C_1
 	bool "Enable I2C Port 1"
-	default n
 
 config I2C_1_NAME
 	string "Port 1 device name"
@@ -90,7 +87,6 @@ config I2C_1_IRQ_PRI
 
 config I2C_2
 	bool "Enable I2C Port 2"
-	default n
 
 config I2C_2_NAME
 	string "Port 2 device name"
@@ -116,7 +112,6 @@ config I2C_2_IRQ_PRI
 
 config I2C_3
 	bool "Enable I2C Port 3"
-	default n
 
 config I2C_3_NAME
 	string "Port 3 device name"
@@ -142,7 +137,6 @@ config I2C_3_IRQ_PRI
 
 config I2C_4
 	bool "Enable I2C Port 4"
-	default n
 
 config I2C_4_NAME
 	string "Port 4 device name"
@@ -169,7 +163,6 @@ config I2C_4_IRQ_PRI
 config I2C_ATMEL_SAM3
 	bool "[deprecated] Atmel SAM3X I2C Driver"
 	depends on SOC_SERIES_SAM3X
-	default n
 	help
 	  This driver is deprecated and will be removed. Use
 	  "Atmel SAM (TWI) I2C driver" instead.
@@ -182,7 +175,6 @@ config I2C_SAM_TWIHS
 	bool "Atmel SAM (TWIHS) I2C driver"
 	depends on SOC_FAMILY_SAM
 	select HAS_DTS_I2C
-	default n
 	help
 	  Enable Atmel SAM MCU Family (TWIHS) I2C bus driver.
 
@@ -190,7 +182,6 @@ config I2C_SAM_TWI
 	bool "Atmel SAM (TWI) I2C driver"
 	depends on SOC_FAMILY_SAM
 	select HAS_DTS_I2C
-	default n
 	help
 	  Enable Atmel SAM MCU Family (TWI) I2C bus driver.
 
@@ -198,7 +189,6 @@ config I2C_MCUX
 	bool "MCUX I2C driver"
 	depends on HAS_MCUX
 	select HAS_DTS_I2C
-	default n
 	help
 	  Enable the mcux I2C driver.
 
@@ -206,20 +196,17 @@ config I2C_CC32XX
 	bool "CC32XX I2C driver"
 	depends on SOC_SERIES_CC32XX
 	select HAS_DTS_I2C
-	default n
 	help
 	  Enable the CC32XX I2C driver.
 
 config I2C_BITBANG
 	bool
-	default n
 	help
 	  Enable library used for software driven (bit banging) I2C support
 
 config I2C_NIOS2
 	bool "Nios-II I2C driver"
 	depends on HAS_ALTERA_HAL
-	default n
 	help
 	  Enable the Nios-II I2C driver.
 

--- a/drivers/i2c/Kconfig.dw
+++ b/drivers/i2c/Kconfig.dw
@@ -6,7 +6,6 @@
 
 menuconfig I2C_DW
 	bool "Design Ware I2C support"
-	default n
 	help
 	  Enable Design Ware I2C support on the selected board
 
@@ -18,7 +17,6 @@ config I2C_DW_CLOCK_SPEED
 
 config I2C_DW_SHARED_IRQ
 	bool
-	default n
 
 choice
 	prompt "I2C_0 Interrupts via"

--- a/drivers/i2c/Kconfig.esp32
+++ b/drivers/i2c/Kconfig.esp32
@@ -10,7 +10,6 @@ menuconfig I2C_ESP32
 	bool "ESP32 I2C"
 	depends on I2C && SOC_ESP32
 	select GPIO_ESP32
-	default n
 	help
 	  Enables the ESP32 I2C driver
 
@@ -28,11 +27,9 @@ config I2C_0_DEFAULT_CFG
 
 config I2C_ESP32_0_TX_LSB_FIRST
 	bool "Port 0 Transmit LSB first"
-	default n
 
 config I2C_ESP32_0_RX_LSB_FIRST
 	bool "Port 0 Receive LSB first"
-	default n
 
 config I2C_ESP32_0_IRQ
 	int "Port 0 IRQ line"
@@ -56,11 +53,9 @@ config I2C_1_DEFAULT_CFG
 
 config I2C_ESP32_1_TX_LSB_FIRST
 	bool "Port 1 Transmit LSB first"
-	default n
 
 config I2C_ESP32_1_RX_LSB_FIRST
 	bool "Port 1 Receive LSB first"
-	default n
 
 config I2C_ESP32_1_IRQ
 	int "Port 1 IRQ line"

--- a/drivers/i2c/Kconfig.gpio
+++ b/drivers/i2c/Kconfig.gpio
@@ -8,7 +8,6 @@ config I2C_GPIO
 	bool "GPIO bit banging I2C support"
 	depends on I2C
 	select I2C_BITBANG
-	default n
 	help
 	  Enable software driven (bit banging) I2C support using GPIO pins
 
@@ -16,7 +15,6 @@ config I2C_GPIO
 
 config I2C_GPIO_0
 	bool "Enable GPIO Bit Bang I2C device 0"
-	default n
 	depends on I2C_GPIO
 	help
 	  This tells the driver to configure the I2C device at boot, depending
@@ -52,7 +50,6 @@ config I2C_GPIO_0_SDA_PIN
 
 config I2C_GPIO_1
 	bool "Enable GPIO Bit Bang I2C device 1"
-	default n
 	depends on I2C_GPIO
 	help
 	  This tells the driver to configure the I2C device at boot, depending
@@ -88,7 +85,6 @@ config I2C_GPIO_1_SDA_PIN
 
 config I2C_GPIO_2
 	bool "Enable GPIO Bit Bang I2C device 2"
-	default n
 	depends on I2C_GPIO
 	help
 	  This tells the driver to configure the I2C device at boot, depending
@@ -124,7 +120,6 @@ config I2C_GPIO_2_SDA_PIN
 
 config I2C_GPIO_3
 	bool "Enable GPIO Bit Bang I2C device 3"
-	default n
 	depends on I2C_GPIO
 	help
 	  This tells the driver to configure the I2C device at boot, depending

--- a/drivers/i2c/Kconfig.qmsi
+++ b/drivers/i2c/Kconfig.qmsi
@@ -7,7 +7,6 @@
 menuconfig I2C_QMSI
 	bool "QMSI I2C driver"
 	depends on QMSI
-	default n
 	help
 	  This option enable the QMSI I2C driver.
 
@@ -40,7 +39,6 @@ endif # I2C_QMSI
 menuconfig I2C_QMSI_SS
 	bool "QMSI I2C driver for the Sensor Subsystem"
 	depends on QMSI
-	default n
 	help
 	  This option enable the Sensor QMSI I2C driver.
 
@@ -51,11 +49,9 @@ if I2C_QMSI_SS
 
 config I2C_SS_0
 	bool "Enable I2C_SS_0"
-	default n
 
 config I2C_SS_1
 	bool "Enable I2C SS Port 1"
-	default n
 
 config I2C_SS_SDA_HOLD
 	int

--- a/drivers/i2c/Kconfig.sbcon
+++ b/drivers/i2c/Kconfig.sbcon
@@ -8,13 +8,11 @@ menuconfig I2C_SBCON
 	bool "I2C driver for ARM's SBCon two-wire serial bus interface"
 	depends on I2C && ARM
 	select I2C_BITBANG
-	default n
 
 if I2C_SBCON
 
 config I2C_SBCON_0
 	bool "Enable SBCon device 0"
-	default n
 
 config I2C_SBCON_0_NAME
 	depends on I2C_SBCON_0
@@ -23,7 +21,6 @@ config I2C_SBCON_0_NAME
 
 config I2C_SBCON_1
 	bool "Enable SBCon device 1"
-	default n
 
 config I2C_SBCON_1_NAME
 	depends on I2C_SBCON_1
@@ -32,7 +29,6 @@ config I2C_SBCON_1_NAME
 
 config I2C_SBCON_2
 	bool "Enable SBCon device 2"
-	default n
 
 config I2C_SBCON_2_NAME
 	depends on I2C_SBCON_2
@@ -41,7 +37,6 @@ config I2C_SBCON_2_NAME
 
 config I2C_SBCON_3
 	bool "Enable SBCon device 3"
-	default n
 
 config I2C_SBCON_3_NAME
 	depends on I2C_SBCON_3

--- a/drivers/i2c/Kconfig.stm32
+++ b/drivers/i2c/Kconfig.stm32
@@ -17,7 +17,6 @@ config I2C_STM32_V1
 	depends on SOC_SERIES_STM32F1X || SOC_SERIES_STM32F4X
 	select HAS_DTS_I2C
 	select USE_STM32_LL_I2C
-	default n
 	help
 	  Enable I2C support on the STM32 F1 and F4X family of processors. This
 	  driver also supports the F2 and L1 series.
@@ -28,7 +27,6 @@ config I2C_STM32_V2
 	select HAS_DTS_I2C
 	select USE_STM32_LL_I2C
 	select USE_STM32_LL_RCC if SOC_SERIES_STM32F0X || SOC_SERIES_STM32F3X
-	default n
 	help
 	  Enable I2C support on the STM32 F0, F3 and L4X family of processors.
 	  This driver also supports the F7 and L0 series.
@@ -36,7 +34,6 @@ config I2C_STM32_V2
 config I2C_STM32_INTERRUPT
 	bool "STM32 MCU I2C Interrupt Support"
 	depends on I2C_STM32_V1 || I2C_STM32_V2
-	default n
 	help
 	  Enable Interrupt support for the I2C Driver
 

--- a/drivers/i2s/Kconfig
+++ b/drivers/i2s/Kconfig
@@ -10,7 +10,6 @@
 menuconfig I2S
 	bool
 	prompt "I2S bus drivers"
-	default n
 	help
 	  Enable support for the I2S (Inter-IC Sound) hardware bus.
 

--- a/drivers/i2s/Kconfig.cavs
+++ b/drivers/i2s/Kconfig.cavs
@@ -9,7 +9,6 @@ menuconfig I2S_CAVS
 	bool "Intel I2S (SSP) Bus Driver"
 	depends on BOARD_INTEL_S1000_CRB
 	select DMA
-	default n
 	help
 	  Enable Inter Sound (I2S) bus driver for Intel_S1000 based on
 	  Synchronous Serial Port (SSP) module.

--- a/drivers/i2s/Kconfig.sam_ssc
+++ b/drivers/i2s/Kconfig.sam_ssc
@@ -9,7 +9,6 @@ menuconfig I2S_SAM_SSC
 	bool "Atmel SAM MCU family I2S (SSC) Bus Driver"
 	depends on SOC_FAMILY_SAM
 	select DMA
-	default n
 	help
 	  Enable Inter Sound (I2S) bus driver for Atmel SAM MCU family based on
 	  Synchronous Serial Controller (SSC) module.

--- a/drivers/ieee802154/Kconfig
+++ b/drivers/ieee802154/Kconfig
@@ -11,7 +11,6 @@
 #
 menuconfig IEEE802154
 	bool "IEEE 802.15.4 drivers options"
-	default n
 	default y if NET_L2_IEEE802154 || NET_L2_OPENTHREAD
 
 if IEEE802154
@@ -37,7 +36,6 @@ config SYS_LOG_IEEE802154_DRIVER_LEVEL
 
 config IEEE802154_RAW_MODE
 	bool "Use IEEE 802.15.4 driver without the MAC stack"
-	default n if NET_L2_IEEE802154
 	select NET_RAW_MODE
 	help
 	  This option enables using the drivers in a so-called "raw" mode,
@@ -59,7 +57,6 @@ menuconfig IEEE802154_UPIPE
 	bool "UART PIPE fake radio driver support for QEMU"
 	depends on (BOARD_QEMU_X86 || BOARD_QEMU_CORTEX_M3) && NETWORKING
 	select UART_PIPE
-	default n
 
 config IEEE802154_UPIPE_DRV_NAME
 	string "UART PIPE Driver name"

--- a/drivers/ieee802154/Kconfig.cc1200
+++ b/drivers/ieee802154/Kconfig.cc1200
@@ -5,7 +5,6 @@ menuconfig IEEE802154_CC1200
 	bool "TI CC1200 Driver support"
 	depends on NETWORKING
 	select NET_L2_IEEE802154_SUB_GHZ
-	default n
 
 if IEEE802154_CC1200
 
@@ -39,7 +38,6 @@ config IEEE802154_CC1200_SPI_SLAVE
 
 config IEEE802154_CC1200_GPIO_SPI_CS
 	bool "Manage SPI CS through a GPIO pin"
-	default n
 	help
 	  This option is useful if one needs to manage SPI CS through a GPIO
 	  pin to by-pass the SPI controller's CS logic.

--- a/drivers/ieee802154/Kconfig.cc2520
+++ b/drivers/ieee802154/Kconfig.cc2520
@@ -9,7 +9,6 @@
 menuconfig IEEE802154_CC2520
 	bool "TI CC2520 Driver support"
 	depends on NETWORKING
-	default n
 
 if IEEE802154_CC2520
 
@@ -43,7 +42,6 @@ config IEEE802154_CC2520_SPI_SLAVE
 
 config IEEE802154_CC2520_GPIO_SPI_CS
 	bool "Manage SPI CS through a GPIO pin"
-	default n
 	help
 	This option is useful if one needs to manage SPI CS through a GPIO
 	pin to by-pass the SPI controller's CS logic.
@@ -121,7 +119,6 @@ endif # IEEE802154_CC2520_RANDOM_MAC
 
 config IEEE802154_CC2520_CRYPTO
 	bool "Enable hardware crypto helper on cc2520"
-	default n
 	depends on NET_L2_IEEE802154_SECURITY
 	help
 	  This option will expose the hardware AES encryption from CC2520.

--- a/drivers/ieee802154/Kconfig.kw41z
+++ b/drivers/ieee802154/Kconfig.kw41z
@@ -10,7 +10,6 @@ menuconfig  IEEE802154_KW41Z
 	bool "NXP KW41Z Driver support"
 	depends on NETWORKING
 	select NEWLIB_LIBC
-	default n
 
 if IEEE802154_KW41Z
 
@@ -30,7 +29,6 @@ config IEEE802154_KW41Z_INIT_PRIO
 
 config KW41_DBG_TRACE
 	bool "Enabled simplified debug tracing of events"
-	default n
 	help
 	  The value depends on your debugging needs. This generates an encoded
 	  trace of events without going to debug logging to avoid timing impact

--- a/drivers/ieee802154/Kconfig.mcr20a
+++ b/drivers/ieee802154/Kconfig.mcr20a
@@ -9,7 +9,6 @@
 menuconfig  IEEE802154_MCR20A
 	bool "NXP MCR20A Driver support"
 	depends on NETWORKING && SPI
-	default n
 
 if IEEE802154_MCR20A
 
@@ -47,7 +46,6 @@ endif # !HAS_DTS_SPI_DEVICE
 
 config IEEE802154_MCR20A_GPIO_SPI_CS
 	bool "Manage SPI CS through a GPIO pin"
-	default n
 	help
 	This option is useful if one needs to manage SPI CS through a GPIO
 	pin to by-pass the SPI controller's CS logic.
@@ -56,7 +54,6 @@ if !HAS_DTS_SPI_PINS
 
 config IEEE802154_MCR20A_GPIO_SPI_CS_DRV_NAME
 	string "GPIO driver's name to use to drive SPI CS through"
-	default ""
 	depends on IEEE802154_MCR20A_GPIO_SPI_CS
 	help
 	This option is mandatory to set which GPIO controller to use in order
@@ -92,7 +89,6 @@ endif # !HAS_DTS_GPIO_DEVICE
 
 config MCR20A_IS_PART_OF_KW2XD_SIP
 	bool "MCR20A device is part of KW2xD SiP"
-	default n
 	help
 	  If this option is set, the driver does not perform a hardware
 	  reset and the CLK_OUT frequency is not set, instead these settings

--- a/drivers/ieee802154/Kconfig.nrf5
+++ b/drivers/ieee802154/Kconfig.nrf5
@@ -10,7 +10,6 @@ menuconfig IEEE802154_NRF5
 	bool "nRF52 series IEEE 802.15.4 Driver"
 	depends on NETWORKING && SOC_NRF52840
 	select HAS_NORDIC_DRIVERS
-	default n
 
 if IEEE802154_NRF5
 

--- a/drivers/interrupt_controller/Kconfig
+++ b/drivers/interrupt_controller/Kconfig
@@ -10,7 +10,6 @@ menu "Interrupt Controllers"
 
 config LOAPIC
 	bool "LOAPIC"
-	default n
 	select IOAPIC
 	depends on X86
 	help
@@ -25,7 +24,6 @@ config LOAPIC_BASE_ADDRESS
 
 config LOAPIC_SPURIOUS_VECTOR
 	bool "Handle LOAPIC spurious interrupts"
-	default n
 	depends on LOAPIC
 	help
 	  A special situation may occur when a processor raises its task
@@ -57,7 +55,6 @@ config IOAPIC
 
 config IOAPIC_DEBUG
 	bool "IO-APIC Debugging"
-	default n
 	depends on IOAPIC
 	help
 	  Enable debugging for IO-APIC driver.
@@ -85,7 +82,6 @@ config IOAPIC_MASK_RTE
 
 config MVIC
 	bool "Intel Quark D2000 Interrupt Controller (MVIC)"
-	default n
 	depends on X86
 	select X86_FIXED_IRQ_MAPPING
 	help
@@ -127,7 +123,6 @@ config PLIC
 
 config DW_ICTL
 	bool "Designware Interrupt Controller"
-	default n
 	depends on MULTI_LEVEL_INTERRUPTS
 	help
 	  Designware Interrupt Controller can be used as a 2nd level interrupt

--- a/drivers/interrupt_controller/Kconfig.multilevel
+++ b/drivers/interrupt_controller/Kconfig.multilevel
@@ -7,7 +7,6 @@
 
 config MULTI_LEVEL_INTERRUPTS
 	bool "Multi-level Interrupts"
-	default n
 	depends on GEN_SW_ISR_TABLE
 	help
 	  Multiple levels of interrupts are normally used to increase the
@@ -26,7 +25,6 @@ config MAX_IRQ_PER_AGGREGATOR
 
 config 2ND_LEVEL_INTERRUPTS
 	bool "Second-level Interrupts"
-	default n
 	depends on MULTI_LEVEL_INTERRUPTS
 	help
 	  Second level interrupts are used to increase the number of
@@ -85,7 +83,6 @@ config 2ND_LVL_INTR_03_OFFSET
 
 config 3RD_LEVEL_INTERRUPTS
 	bool "Third-level Interrupts"
-	default n
 	depends on 2ND_LEVEL_INTERRUPTS
 	help
 	  Third level interrupts are used to increase the number of

--- a/drivers/interrupt_controller/Kconfig.s1000
+++ b/drivers/interrupt_controller/Kconfig.s1000
@@ -7,7 +7,6 @@
 
 config CAVS_ICTL
 	bool "CAVS Interrupt Logic"
-	default n
 	depends on MULTI_LEVEL_INTERRUPTS
 	help
 	  These are 4 in number supporting a max of 32 interrupts each.

--- a/drivers/interrupt_controller/Kconfig.shared_irq
+++ b/drivers/interrupt_controller/Kconfig.shared_irq
@@ -9,7 +9,6 @@
 menuconfig SHARED_IRQ
 	bool
 	prompt "Shared interrupt driver"
-	default n
 	help
 	 Include shared interrupt support in system. Shared interrupt
 	 support is NOT required in most systems. If in doubt answer no.

--- a/drivers/ipm/Kconfig
+++ b/drivers/ipm/Kconfig
@@ -1,21 +1,18 @@
 menuconfig IPM
 	bool
 	prompt "IPM drivers"
-	default n
 	help
 	  Include interrupt-based inter-processor mailboxes
 	  drivers in system configuration
 
 config IPM_QUARK_SE
 	bool "Quark SE IPM driver"
-	default n
 	depends on IPM
 	help
 	  Driver for Quark SE mailboxes
 
 config IPM_QUARK_SE_MASTER
 	bool "Quark SE IPM master controller"
-	default n
 	depends on IPM_QUARK_SE
 	help
 	  Enable this for the first CPU that initializes IPM.
@@ -24,7 +21,6 @@ config IPM_QUARK_SE_MASTER
 
 config IPM_MCUX
 	bool "MCUX IPM driver"
-	default n
 	depends on IPM && HAS_MCUX
 	help
 	  Driver for MCUX mailbox

--- a/drivers/led/Kconfig
+++ b/drivers/led/Kconfig
@@ -8,7 +8,6 @@
 
 menuconfig LED
 	bool "LED drivers"
-	default n
 	help
 	  Include LED drivers in the system configuration.
 

--- a/drivers/led/Kconfig.lp3943
+++ b/drivers/led/Kconfig.lp3943
@@ -7,7 +7,6 @@
 menuconfig LP3943
 	bool "LP3943 LED driver"
 	depends on I2C
-	default n
 	help
 	  Enable LED driver for LP3943.
 

--- a/drivers/led_strip/Kconfig
+++ b/drivers/led_strip/Kconfig
@@ -9,7 +9,6 @@
 
 menuconfig LED_STRIP
 	bool "LED strip drivers"
-	default n
 	help
 		Include LED strip drivers in the system configuration.
 
@@ -41,7 +40,6 @@ config LED_STRIP_INIT_PRIORITY
 # is not normally needed.
 config LED_STRIP_RGB_SCRATCH
 	bool
-	default n
 
 source "drivers/led_strip/Kconfig.lpd880x"
 

--- a/drivers/led_strip/Kconfig.apa102
+++ b/drivers/led_strip/Kconfig.apa102
@@ -8,7 +8,6 @@ menuconfig APA102_STRIP
 	bool "APA102 SPI LED strip driver"
 	depends on SPI
 	select LED_STRIP_RGB_SCRATCH
-	default n
 	help
 	 Enable the LED strip driver for a chain of APA102 RGB LEDs.
 	 These are sold as DotStar by Adafruit and Superled by others.

--- a/drivers/led_strip/Kconfig.lpd880x
+++ b/drivers/led_strip/Kconfig.lpd880x
@@ -7,7 +7,6 @@
 menuconfig LPD880X_STRIP
 	bool "Enable LPD880x SPI LED strip driver"
 	depends on SPI
-	default n
 	help
 		Enable LED strip driver for daisy chains of LPD880x
 		(LPD8803, LPD8806, or compatible) devices.

--- a/drivers/led_strip/Kconfig.ws2812
+++ b/drivers/led_strip/Kconfig.ws2812
@@ -11,7 +11,6 @@
 menuconfig WS2812_STRIP
 	bool "Enable WS2812 (and compatible) LED strip driver"
 	depends on SPI
-	default n
 	help
 		Enable LED strip driver for daisy chains of WS2812-ish
 		(or WS2812B, WS2813, SK6812, or compatible) devices.

--- a/drivers/net/Kconfig
+++ b/drivers/net/Kconfig
@@ -74,7 +74,6 @@ config	SYS_LOG_SLIP_LEVEL
 
 config	SLIP_STATISTICS
 	bool "SLIP network connection statistics"
-	default n
 	help
 	  This option enables statistics support for SLIP driver.
 
@@ -88,7 +87,6 @@ config  SLIP_TAP
 
 config	SLIP_MAC_ADDR
 	string "MAC address for the interface"
-	default ""
 	help
 	  Specify a MAC address for the SLIP interface in the form of
 	  six hex 8-bit chars separated by colons (e.g.:

--- a/drivers/pci/Kconfig
+++ b/drivers/pci/Kconfig
@@ -18,7 +18,6 @@ if PCI
 config PCI_ENUMERATION
 	bool
 	prompt "Enable PCI device enumeration"
-	default n
 	help
 	  This option enables the PCI enumeration for device drivers.
 	  This might be useful along with PCI_DEBUG to find out which
@@ -29,7 +28,6 @@ config PCI_ENUMERATION
 config PCI_LEGACY_BRIDGE
 	bool
 	prompt "PCI legacy bridge device support"
-	default n
 	help
 	  This option adds support for PCI legacy bridge device, that
 	  allows direct setup of the PCI interrupt pin to IRQ number
@@ -58,7 +56,6 @@ config PCI_LEGACY_BRIDGE_DEVICE_ID
 config PCI_DEBUG
 	bool
 	prompt "Enable PCI debugging"
-	default n
 	help
 	  This options enables PCI debugging functions
 

--- a/drivers/pinmux/Kconfig
+++ b/drivers/pinmux/Kconfig
@@ -11,7 +11,6 @@
 #
 menuconfig PINMUX
 	bool "Enable board pinmux driver"
-	default n
 
 if PINMUX
 
@@ -42,7 +41,6 @@ config PINMUX_INIT_PRIORITY
 config PINMUX_QMSI
 	bool "Enable QMSI pinmux dev driver"
 	depends on PINMUX && QMSI
-	default n
 	help
 	  Enables the pinmux dev driver for QMSI supported boards.
 

--- a/drivers/pinmux/Kconfig.beetle
+++ b/drivers/pinmux/Kconfig.beetle
@@ -9,6 +9,5 @@
 menuconfig PINMUX_BEETLE
 	bool "ARM V2M Beetle Pin multiplexer driver"
 	depends on PINMUX && SOC_SERIES_BEETLE
-	default n
 	help
 	  Enable driver for ARM V2M Beetle Pin multiplexer.

--- a/drivers/pinmux/Kconfig.esp32
+++ b/drivers/pinmux/Kconfig.esp32
@@ -9,7 +9,6 @@
 menuconfig PINMUX_ESP32
 	bool "ESP32 Pin multiplexer driver"
 	depends on PINMUX && SOC_ESP32
-	default n
 	help
 	  Enable driver for ESP32 Pin multiplexer.
 

--- a/drivers/pinmux/Kconfig.fe310
+++ b/drivers/pinmux/Kconfig.fe310
@@ -8,7 +8,6 @@
 menuconfig PINMUX_FE310
 	bool "SiFive Freedom E310 SOC pinmux driver"
 	depends on PINMUX && SOC_SERIES_RISCV32_FE310
-	default n
 	help
 	  Enable driver for the SiFive Freedom E310 SOC pinmux driver
 

--- a/drivers/pinmux/Kconfig.mcux
+++ b/drivers/pinmux/Kconfig.mcux
@@ -8,7 +8,6 @@
 menuconfig PINMUX_MCUX
 	bool "MCUX pinmux driver"
 	depends on HAS_MCUX
-	default n
 	help
 	  Enable the MCUX pinmux driver.
 
@@ -16,7 +15,6 @@ if PINMUX_MCUX
 
 config PINMUX_MCUX_PORTA
 	bool "Port A"
-	default n
 	help
 	  Enable Port A.
 
@@ -27,7 +25,6 @@ config PINMUX_MCUX_PORTA_NAME
 
 config PINMUX_MCUX_PORTB
 	bool "Port B"
-	default n
 	help
 	  Enable Port B.
 
@@ -38,7 +35,6 @@ config PINMUX_MCUX_PORTB_NAME
 
 config PINMUX_MCUX_PORTC
 	bool "Port C"
-	default n
 	help
 	  Enable Port C.
 
@@ -49,7 +45,6 @@ config PINMUX_MCUX_PORTC_NAME
 
 config PINMUX_MCUX_PORTD
 	bool "Port D"
-	default n
 	help
 	  Enable Port D.
 
@@ -60,7 +55,6 @@ config PINMUX_MCUX_PORTD_NAME
 
 config PINMUX_MCUX_PORTE
 	bool "Port E"
-	default n
 	help
 	  Enable Port E.
 

--- a/drivers/pinmux/Kconfig.mcux_lpc
+++ b/drivers/pinmux/Kconfig.mcux_lpc
@@ -8,7 +8,6 @@
 menuconfig PINMUX_MCUX_LPC
 	bool "MCUX LPC pinmux driver"
 	depends on HAS_MCUX
-	default n
 	help
 	  Enable the MCUX LPC pinmux driver.
 
@@ -16,7 +15,6 @@ if PINMUX_MCUX_LPC
 
 config PINMUX_MCUX_LPC_PORT0
 	bool "Port 0"
-	default n
 	help
 	  Enable Port 0.
 
@@ -27,7 +25,6 @@ config PINMUX_MCUX_LPC_PORT0_NAME
 
 config PINMUX_MCUX_LPC_PORT1
 	bool "Port 1"
-	default n
 	help
 	  Enable Port 1.
 

--- a/drivers/pinmux/Kconfig.sam0
+++ b/drivers/pinmux/Kconfig.sam0
@@ -6,6 +6,5 @@
 menuconfig PINMUX_SAM0
 	bool "Atmel SAM0 pin multiplexer driver"
 	depends on PINMUX && SOC_FAMILY_SAM0
-	default n
 	help
 	  Enable support for the Atmel SAM0 PORT pin multiplexer.

--- a/drivers/pinmux/dev/Kconfig
+++ b/drivers/pinmux/dev/Kconfig
@@ -9,7 +9,6 @@
 config PINMUX_DEV
 	bool "Configure pinmux for early board testing"
 	depends on PINMUX
-	default n
 	help
 	  Enables the use of the pinmux_set and pinmux_get functions for early
 	  prototyping on new hardware.  WARNING: When using these options, it
@@ -28,14 +27,12 @@ config PINMUX_DEV_ATMEL_SAM3X
 	help
 	  Enables the pinmux dev driver for boards based on the
 	  Atmel SAM3X family of microcontrollers.
-	  default n
 
 config PINMUX_DEV_STM32
 	bool "Enable pinmux dev driver for the ST STM32 family."
 	depends on PINMUX_DEV && SOC_FAMILY_STM32
 	help
 	  Enables the STM32 pinmux dev driver.
-	  default n
 
 config PINMUX_DEV_ARM_V2M_BEETLE
 	bool "Enable pinmux dev driver for ARM V2M Beetle boards"
@@ -43,4 +40,3 @@ config PINMUX_DEV_ARM_V2M_BEETLE
 	help
 	  Enables the pinmux dev driver for boards based on the
 	  ARM Beetle SoC MCUs.
-	  default n

--- a/drivers/ptp_clock/Kconfig
+++ b/drivers/ptp_clock/Kconfig
@@ -6,6 +6,5 @@
 
 menuconfig PTP_CLOCK
 	bool "Precision Time Protocol Clock driver support"
-	default n
 	help
 	  Enable options for Precision Time Protocol Clock drivers.

--- a/drivers/pwm/Kconfig
+++ b/drivers/pwm/Kconfig
@@ -8,7 +8,6 @@
 
 menuconfig PWM
 	bool "PWM (Pulse Width Modulation) Drivers"
-	default n
 	help
 	  Enable config options for PWM drivers.
 
@@ -31,19 +30,15 @@ config SYS_LOG_PWM_LEVEL
 
 config PWM_0
 	bool "Enable PWM port 0"
-	default n
 
 config PWM_1
 	bool "Enable PWM port 1"
-	default n
 
 config PWM_2
 	bool "Enable PWM port 2"
-	default n
 
 config PWM_3
 	bool "Enable PWM port 3"
-	default n
 
 source "drivers/pwm/Kconfig.pca9685"
 

--- a/drivers/pwm/Kconfig.dw
+++ b/drivers/pwm/Kconfig.dw
@@ -9,7 +9,6 @@
 menuconfig PWM_DW
 	bool "DesignWare PWM"
 	depends on PWM
-	default n
 	help
 	  Enable driver to utilize PWM on the DesignWare Timer IP block.
 	  Care must be taken if one is also to use the timer feature, as

--- a/drivers/pwm/Kconfig.esp32
+++ b/drivers/pwm/Kconfig.esp32
@@ -9,7 +9,6 @@
 menuconfig PWM_LED_ESP32
 	bool "ESP32 PWM LED driver"
 	depends on PWM
-	default n
 	help
 	  This option enables the PWM LED driver for ESP32 family of
 	  processors. Say y if you wish to use PWM LED port on ESP32.

--- a/drivers/pwm/Kconfig.mcux_ftm
+++ b/drivers/pwm/Kconfig.mcux_ftm
@@ -9,6 +9,5 @@ menuconfig PWM_MCUX_FTM
 	bool
 	prompt "MCUX FTM PWM driver"
 	depends on HAS_MCUX_FTM
-	default n
 	help
 	  Enable support for mcux ftm pwm driver.

--- a/drivers/pwm/Kconfig.nrfx
+++ b/drivers/pwm/Kconfig.nrfx
@@ -50,7 +50,6 @@ config PWM_0_NRF_CH1_PIN
 
 config PWM_0_NRF_CH1_INVERTED
 	bool "CH1 inverted"
-	default n
 	help
 	  Inverses the polarity.
 
@@ -121,7 +120,6 @@ config PWM_1_NRF_CH1_PIN
 
 config PWM_1_NRF_CH1_INVERTED
 	bool "CH1 inverted"
-	default n
 	help
 	  Inverses the polarity.
 
@@ -193,7 +191,6 @@ config PWM_2_NRF_CH1_PIN
 
 config PWM_2_NRF_CH1_INVERTED
 	bool "CH1 inverted"
-	default n
 	help
 	  Inverses the polarity.
 
@@ -264,7 +261,6 @@ config PWM_3_NRF_CH1_PIN
 
 config PWM_3_NRF_CH1_INVERTED
 	bool "CH1 inverted"
-	default n
 	help
 	  Inverses the polarity.
 

--- a/drivers/pwm/Kconfig.pca9685
+++ b/drivers/pwm/Kconfig.pca9685
@@ -13,7 +13,6 @@
 menuconfig PWM_PCA9685
 	bool "PCA9685 I2C-based PWM chip"
 	depends on PWM && I2C
-	default n
 	help
 	  Enable driver for PCA9685 I2C-based PWM chip.
 
@@ -30,7 +29,6 @@ config PWM_PCA9685_INIT_PRIORITY
 config PWM_PCA9685_0
 	bool "PCA9685 PWM chip #0"
 	depends on PWM_PCA9685
-	default n
 	help
 	  Enable config options for the PCA9685 I2C-based PWM chip #0.
 
@@ -51,7 +49,6 @@ config PWM_PCA9685_0_I2C_ADDR
 config PWM_PCA9685_0_I2C_MASTER_DEV_NAME
 	string "I2C Master where PCA9685 PWM chip #0 is connected"
 	depends on PWM_PCA9685_0
-	default ""
 	help
 	  Specify the device name of the I2C master device to which this
 	  PCA9685 chip #0 is binded.

--- a/drivers/pwm/Kconfig.qmsi
+++ b/drivers/pwm/Kconfig.qmsi
@@ -9,7 +9,6 @@
 menuconfig PWM_QMSI
 	bool "QMSI PWM Driver"
 	depends on QMSI && PWM
-	default n
 	help
 	  Enable QMSI PWM driver. This driver will use the QMSI library to
 	  access the SOC underlying timer IP block. This driver uses the
@@ -33,6 +32,5 @@ config PWM_QMSI_API_REENTRANCY
 	bool
 	prompt "PWM shim driver API reentrancy"
 	depends on PWM_QMSI
-	default n
 	help
 	  Enable support for PWM shim driver API reentrancy.

--- a/drivers/pwm/Kconfig.stm32
+++ b/drivers/pwm/Kconfig.stm32
@@ -8,7 +8,6 @@
 
 menuconfig PWM_STM32
 	bool "STM32 MCU PWM driver"
-	default n
 	depends on PWM && SOC_FAMILY_STM32
 	select USE_STM32_HAL_TIM
 	help
@@ -19,7 +18,6 @@ menuconfig PWM_STM32
 config PWM_STM32_1
 	bool "STM32 PWM 1 Output"
 	depends on PWM_STM32
-	default n
 	help
 	  Enable output for PWM1 in the driver. Say y here
 	  if you want to use PWM1 output.
@@ -27,7 +25,6 @@ config PWM_STM32_1
 config PWM_STM32_2
 	bool "STM32 PWM 2 Output"
 	depends on PWM_STM32
-	default n
 	help
 	  Enable output for PWM2 in the driver. Say y here
 	  if you want to use PWM2 output.
@@ -35,7 +32,6 @@ config PWM_STM32_2
 config PWM_STM32_3
 	bool "STM32 PWM 3 Output"
 	depends on PWM_STM32
-	default n
 	help
 	  Enable output for PWM3 in the driver. Say y here
 	  if you want to use PWM3 output.
@@ -43,7 +39,6 @@ config PWM_STM32_3
 config PWM_STM32_4
 	bool "STM32 PWM 4 Output"
 	depends on PWM_STM32
-	default n
 	help
 	  Enable output for PWM4 in the driver. Say y here
 	  if you want to use PWM4 output.
@@ -51,7 +46,6 @@ config PWM_STM32_4
 config PWM_STM32_5
 	bool "STM32 PWM 5 Output"
 	depends on PWM_STM32
-	default n
 	help
 	  Enable output for PWM5 in the driver. Say y here
 	  if you want to use PWM5 output.
@@ -59,7 +53,6 @@ config PWM_STM32_5
 config PWM_STM32_6
 	bool "STM32 PWM 6 Output"
 	depends on PWM_STM32
-	default n
 	help
 	  Enable output for PWM6 in the driver. Say y here
 	  if you want to use PWM6 output.
@@ -67,7 +60,6 @@ config PWM_STM32_6
 config PWM_STM32_7
 	bool "STM32 PWM 7 Output"
 	depends on PWM_STM32
-	default n
 	help
 	  Enable output for PWM7 in the driver. Say y here
 	  if you want to use PWM7 output.
@@ -75,7 +67,6 @@ config PWM_STM32_7
 config PWM_STM32_8
 	bool "STM32 PWM 8 Output"
 	depends on PWM_STM32
-	default n
 	help
 	  Enable output for PWM8 in the driver. Say y here
 	  if you want to use PWM8 output.
@@ -83,7 +74,6 @@ config PWM_STM32_8
 config PWM_STM32_9
 	bool "STM32 PWM 9 Output"
 	depends on PWM_STM32
-	default n
 	help
 	  Enable output for PWM9 in the driver. Say y here
 	  if you want to use PWM9 output.
@@ -91,7 +81,6 @@ config PWM_STM32_9
 config PWM_STM32_10
 	bool "STM32 PWM 10 Output"
 	depends on PWM_STM32
-	default n
 	help
 	  Enable output for PWM10 in the driver. Say y here
 	  if you want to use PWM10 output.
@@ -99,7 +88,6 @@ config PWM_STM32_10
 config PWM_STM32_11
 	bool "STM32 PWM 11 Output"
 	depends on PWM_STM32
-	default n
 	help
 	  Enable output for PWM11 in the driver. Say y here
 	  if you want to use PWM11 output.
@@ -107,7 +95,6 @@ config PWM_STM32_11
 config PWM_STM32_12
 	bool "STM32 PWM 12 Output"
 	depends on PWM_STM32
-	default n
 	help
 	  Enable output for PWM12 in the driver. Say y here
 	  if you want to use PWM12 output.
@@ -115,7 +102,6 @@ config PWM_STM32_12
 config PWM_STM32_13
 	bool "STM32 PWM 13 Output"
 	depends on PWM_STM32
-	default n
 	help
 	  Enable output for PWM13 in the driver. Say y here
 	  if you want to use PWM13 output.
@@ -123,7 +109,6 @@ config PWM_STM32_13
 config PWM_STM32_14
 	bool "STM32 PWM 14 Output"
 	depends on PWM_STM32
-	default n
 	help
 	  Enable output for PWM14 in the driver. Say y here
 	  if you want to use PWM14 output.
@@ -131,7 +116,6 @@ config PWM_STM32_14
 config PWM_STM32_15
 	bool "STM32 PWM 15 Output"
 	depends on PWM_STM32
-	default n
 	help
 	  Enable output for PWM15 in the driver. Say y here
 	  if you want to use PWM15 output.
@@ -139,7 +123,6 @@ config PWM_STM32_15
 config PWM_STM32_16
 	bool "STM32 PWM 16 Output"
 	depends on PWM_STM32
-	default n
 	help
 	  Enable output for PWM16 in the driver. Say y here
 	  if you want to use PWM16 output.
@@ -147,7 +130,6 @@ config PWM_STM32_16
 config PWM_STM32_17
 	bool "STM32 PWM 17 Output"
 	depends on PWM_STM32
-	default n
 	help
 	  Enable output for PWM17 in the driver. Say y here
 	  if you want to use PWM17 output.
@@ -155,7 +137,6 @@ config PWM_STM32_17
 config PWM_STM32_18
 	bool "STM32 PWM 18 Output"
 	depends on PWM_STM32
-	default n
 	help
 	  Enable output for PWM18 in the driver. Say y here
 	  if you want to use PWM18 output.
@@ -163,7 +144,6 @@ config PWM_STM32_18
 config PWM_STM32_19
 	bool "STM32 PWM 19 Output"
 	depends on PWM_STM32
-	default n
 	help
 	  Enable output for PWM19 in the driver. Say y here
 	  if you want to use PWM19 output.
@@ -171,7 +151,6 @@ config PWM_STM32_19
 config PWM_STM32_20
 	bool "STM32 PWM 20 Output"
 	depends on PWM_STM32
-	default n
 	help
 	  Enable output for PWM20 in the driver. Say y here
 	  if you want to use PWM20 output.

--- a/drivers/rtc/Kconfig
+++ b/drivers/rtc/Kconfig
@@ -11,7 +11,6 @@
 #
 menuconfig RTC
 	bool "Real-Time Clock"
-	default n
 	help
 	  Enable options for Real-Time Clock drivers.
 

--- a/drivers/rtc/Kconfig.mcux_rtc
+++ b/drivers/rtc/Kconfig.mcux_rtc
@@ -9,6 +9,5 @@ menuconfig RTC_MCUX
 	bool
 	prompt "MCUX RTC driver"
 	depends on RTC && HAS_MCUX_RTC
-	default n
 	help
 	  Enable support for mcux rtc driver.

--- a/drivers/rtc/Kconfig.qmsi
+++ b/drivers/rtc/Kconfig.qmsi
@@ -1,7 +1,6 @@
 config RTC_QMSI
 	bool "QMSI RTC Driver"
 	depends on QMSI
-	default n
 	help
 	  Build QMSI RTC driver.
 
@@ -10,7 +9,6 @@ if RTC_QMSI
 config RTC_QMSI_API_REENTRANCY
 	bool
 	prompt "RTC shim driver API reentrancy"
-	default n
 	help
 	  Enable support for RTC shim driver API reentrancy.
 

--- a/drivers/serial/Kconfig
+++ b/drivers/serial/Kconfig
@@ -9,7 +9,6 @@
 menuconfig SERIAL
 	bool
 	prompt "Serial Drivers"
-	default n
 	help
 	  Enable options for serial drivers.
 
@@ -19,7 +18,6 @@ comment "Capabilities"
 
 config SERIAL_HAS_DRIVER
 	bool
-	default n
 	help
 	  This is an option to be enabled by individual serial driver
 	  to signal that there is a serial driver. This is being used
@@ -27,7 +25,6 @@ config SERIAL_HAS_DRIVER
 
 config SERIAL_SUPPORT_INTERRUPT
 	bool
-	default n
 	help
 	  This is an option to be enabled by individual serial driver
 	  to signal that the driver and hardware supports interrupts.
@@ -35,7 +32,6 @@ config SERIAL_SUPPORT_INTERRUPT
 config UART_INTERRUPT_DRIVEN
 	bool
 	prompt "Enable UART Interrupt support"
-	default n
 	depends on SERIAL_SUPPORT_INTERRUPT
 	help
 	  This option enables interrupt support for UART allowing console
@@ -43,7 +39,6 @@ config UART_INTERRUPT_DRIVEN
 
 config UART_LINE_CTRL
 	bool "Enable Serial Line Control API"
-	default n
 	help
 	  This enables the API for apps to control the serial line,
 	  such as baud rate, CTS and RTS.
@@ -54,7 +49,6 @@ config UART_LINE_CTRL
 
 config UART_DRV_CMD
 	bool "Enable driver commands API"
-	default n
 	help
 	  This enables the API to send extra commands to drivers.
 	  This allows drivers to expose hardware specific functions.

--- a/drivers/serial/Kconfig.altera_jtag
+++ b/drivers/serial/Kconfig.altera_jtag
@@ -1,6 +1,5 @@
 menuconfig UART_ALTERA_JTAG
 	bool "Nios II JTAG UART driver"
-	default n
 	select SERIAL_HAS_DRIVER
 	help
 	  Enable the Altera JTAG UART driver, built in to many Nios II CPU

--- a/drivers/serial/Kconfig.cc32xx
+++ b/drivers/serial/Kconfig.cc32xx
@@ -1,7 +1,6 @@
 menuconfig UART_CC32XX
 	depends on SOC_SERIES_CC32XX
 	bool "CC32XX UART driver"
-	default n
 	select SERIAL_HAS_DRIVER
 	select SERIAL_SUPPORT_INTERRUPT
 	depends on SOC_FAMILY_TISIMPLELINK

--- a/drivers/serial/Kconfig.cmsdk_apb
+++ b/drivers/serial/Kconfig.cmsdk_apb
@@ -8,7 +8,6 @@
 
 menuconfig UART_CMSDK_APB
 	bool "ARM CMSDK APB UART driver"
-	default n
 	select SERIAL_HAS_DRIVER
 	select SERIAL_SUPPORT_INTERRUPT
 	depends on SOC_FAMILY_ARM
@@ -21,7 +20,6 @@ if UART_CMSDK_APB
 
 config UART_CMSDK_APB_PORT0
 	bool "Enable driver for UART 0"
-	default n
 	help
 	  Build the driver to utilize UART controller Port 0.
 
@@ -29,7 +27,6 @@ config UART_CMSDK_APB_PORT0
 
 config UART_CMSDK_APB_PORT1
 	bool "Enable driver for UART 1"
-	default n
 	help
 	  Build the driver to utilize UART controller Port 1.
 
@@ -37,7 +34,6 @@ config UART_CMSDK_APB_PORT1
 
 config UART_CMSDK_APB_PORT2
 	bool "Enable driver for UART 2"
-	default n
 	help
 	  Build the driver to utilize UART controller Port 2.
 
@@ -45,7 +41,6 @@ config UART_CMSDK_APB_PORT2
 
 config UART_CMSDK_APB_PORT3
 	bool "Enable driver for UART 3"
-	default n
 	help
 	  Build the driver to utilize UART controller Port 3.
 
@@ -53,7 +48,6 @@ config UART_CMSDK_APB_PORT3
 
 config UART_CMSDK_APB_PORT4
 	bool "Enable driver for UART 4"
-	default n
 	help
 	  Build the driver to utilize UART controller Port 4.
 

--- a/drivers/serial/Kconfig.esp32
+++ b/drivers/serial/Kconfig.esp32
@@ -1,6 +1,5 @@
 menuconfig UART_ESP32
 	bool "ESP32 UART driver"
-	default n
 	select SERIAL_HAS_DRIVER
 	depends on SOC_ESP32
 	help

--- a/drivers/serial/Kconfig.fe310
+++ b/drivers/serial/Kconfig.fe310
@@ -8,7 +8,6 @@
 menuconfig UART_FE310
 	bool "SiFive Freedom E310 serial driver"
 	depends on SOC_RISCV32_FE310
-	default n
 	select SERIAL_HAS_DRIVER
 	select SERIAL_SUPPORT_INTERRUPT
 	help
@@ -18,7 +17,6 @@ menuconfig UART_FE310
 
 menuconfig UART_FE310_PORT_0
 	bool "Enable FE310 Port 0"
-	default n
 	depends on UART_FE310
 	help
 	  This tells the driver to configure the UART port at boot, depending on
@@ -66,7 +64,6 @@ config UART_FE310_PORT_0_TXCNT_IRQ
 
 menuconfig UART_FE310_PORT_1
 	bool "Enable FE310 Port 1"
-	default n
 	depends on UART_FE310
 	help
 	  This tells the driver to configure the UART port at boot, depending on

--- a/drivers/serial/Kconfig.gecko
+++ b/drivers/serial/Kconfig.gecko
@@ -9,7 +9,6 @@ menuconfig UART_GECKO
 	bool "Gecko uart driver"
 	depends on HAS_SILABS_GECKO
 	depends on GPIO_GECKO
-	default n
 	select SERIAL_HAS_DRIVER
 	select SERIAL_SUPPORT_INTERRUPT
 	help
@@ -19,7 +18,6 @@ if UART_GECKO
 
 menuconfig UART_GECKO_0
 	bool "UART 0"
-	default n
 	help
 	  Enable UART 0.
 
@@ -36,7 +34,6 @@ endif # UART_GECKO_0
 
 menuconfig UART_GECKO_1
 	bool "UART 1"
-	default n
 	help
 	  Enable UART 1.
 

--- a/drivers/serial/Kconfig.imx
+++ b/drivers/serial/Kconfig.imx
@@ -8,7 +8,6 @@
 
 menuconfig UART_IMX
 	bool "NXP i.MX7 family processor UART driver"
-	default n
 	select SERIAL_HAS_DRIVER
 	select SERIAL_SUPPORT_INTERRUPT
 	depends on HAS_IMX_HAL
@@ -18,7 +17,6 @@ menuconfig UART_IMX
 
 config UART_IMX_UART_1
 	bool "Enable NXP i.MX7 UART1 Port"
-	default n
 	depends on UART_IMX
 	help
 	  Enable support for UART1 port in the driver. Say y here
@@ -26,7 +24,6 @@ config UART_IMX_UART_1
 
 config UART_IMX_UART_2
 	bool "Enable NXP i.MX7 UART2 Port"
-	default n
 	depends on UART_IMX
 	help
 	  Enable support for UART2 port in the driver. Say y here
@@ -34,7 +31,6 @@ config UART_IMX_UART_2
 
 config UART_IMX_UART_3
 	bool "Enable NXP i.MX7 UART3 Port"
-	default n
 	depends on UART_IMX
 	help
 	  Enable support for UART3 port in the driver. Say y here
@@ -42,7 +38,6 @@ config UART_IMX_UART_3
 
 config UART_IMX_UART_4
 	bool "Enable NXP i.MX7 UART4 Port"
-	default n
 	depends on UART_IMX
 	help
 	  Enable support for UART4 port in the driver. Say y here
@@ -50,7 +45,6 @@ config UART_IMX_UART_4
 
 config UART_IMX_UART_5
 	bool "Enable NXP i.MX7 UART5 Port"
-	default n
 	depends on UART_IMX
 	help
 	  Enable support for UART5 port in the driver. Say y here
@@ -58,7 +52,6 @@ config UART_IMX_UART_5
 
 config UART_IMX_UART_6
 	bool "Enable NXP i.MX7 UART6 Port"
-	default n
 	depends on UART_IMX
 	help
 	  Enable support for UART6 port in the driver. Say y here
@@ -66,7 +59,6 @@ config UART_IMX_UART_6
 
 config UART_IMX_UART_7
 	bool "Enable NXP i.MX7 UART7 Port"
-	default n
 	depends on UART_IMX
 	help
 	  Enable support for UART7 port in the driver. Say y here

--- a/drivers/serial/Kconfig.mcux
+++ b/drivers/serial/Kconfig.mcux
@@ -8,7 +8,6 @@
 menuconfig UART_MCUX
 	bool "MCUX uart driver"
 	depends on HAS_MCUX && CLOCK_CONTROL
-	default n
 	select SERIAL_HAS_DRIVER
 	select SERIAL_SUPPORT_INTERRUPT
 	help
@@ -18,37 +17,31 @@ if UART_MCUX
 
 menuconfig UART_MCUX_0
 	bool "UART 0"
-	default n
 	help
 	  Enable UART 0.
 
 menuconfig UART_MCUX_1
 	bool "UART 1"
-	default n
 	help
 	  Enable UART 1.
 
 menuconfig UART_MCUX_2
 	bool "UART 2"
-	default n
 	help
 	  Enable UART 2.
 
 menuconfig UART_MCUX_3
 	bool "UART 3"
-	default n
 	help
 	  Enable UART 3.
 
 menuconfig UART_MCUX_4
 	bool "UART 4"
-	default n
 	help
 	  Enable UART 4.
 
 menuconfig UART_MCUX_5
 	bool "UART 5"
-	default n
 	help
 	  Enable UART 5.
 

--- a/drivers/serial/Kconfig.mcux_lpc_usart
+++ b/drivers/serial/Kconfig.mcux_lpc_usart
@@ -7,7 +7,6 @@
 menuconfig USART_MCUX_LPC
 	bool "MCUX USART driver"
 	depends on HAS_MCUX
-	default n
 	select SERIAL_HAS_DRIVER
 	help
 	  Enable the MCUX USART driver.
@@ -16,7 +15,6 @@ if USART_MCUX_LPC
 
 menuconfig USART_MCUX_LPC_0
 	bool "USART 0"
-	default n
 	help
 	  Enable USART 0.
 

--- a/drivers/serial/Kconfig.mcux_lpsci
+++ b/drivers/serial/Kconfig.mcux_lpsci
@@ -8,7 +8,6 @@
 menuconfig UART_MCUX_LPSCI
 	bool "MCUX LPSCI driver"
 	depends on HAS_MCUX_LPSCI && CLOCK_CONTROL
-	default n
 	select SERIAL_HAS_DRIVER
 	select SERIAL_SUPPORT_INTERRUPT
 	help
@@ -18,7 +17,6 @@ if UART_MCUX_LPSCI
 
 menuconfig UART_MCUX_LPSCI_0
 	bool "UART 0"
-	default n
 	help
 	  Enable UART 0.
 

--- a/drivers/serial/Kconfig.mcux_lpuart
+++ b/drivers/serial/Kconfig.mcux_lpuart
@@ -8,7 +8,6 @@
 menuconfig UART_MCUX_LPUART
 	bool "MCUX LPUART driver"
 	depends on HAS_MCUX_LPUART && CLOCK_CONTROL
-	default n
 	select SERIAL_HAS_DRIVER
 	select SERIAL_SUPPORT_INTERRUPT
 	help
@@ -18,13 +17,11 @@ if UART_MCUX_LPUART
 
 menuconfig UART_MCUX_LPUART_0
 	bool "UART 0"
-	default n
 	help
 	  Enable UART 0.
 
 menuconfig UART_MCUX_LPUART_1
 	bool "UART 1"
-	default n
 	help
 	  Enable UART 1.
 

--- a/drivers/serial/Kconfig.miv
+++ b/drivers/serial/Kconfig.miv
@@ -6,14 +6,12 @@
 menuconfig UART_MIV
 	bool "Mi-V serial driver"
 	depends on SOC_RISCV32_MIV
-	default n
 	select SERIAL_HAS_DRIVER
 	help
 	  This option enables the Mi-V serial driver.
 
 menuconfig UART_MIV_PORT_0
 	bool "Enable Mi-V Port 0"
-	default n
 	depends on UART_MIV
 	help
 	  This tells the driver to configure the UART port at boot, depending on

--- a/drivers/serial/Kconfig.msp432p4xx
+++ b/drivers/serial/Kconfig.msp432p4xx
@@ -1,7 +1,6 @@
 menuconfig UART_MSP432P4XX
 	depends on SOC_SERIES_MSP432P4XX
 	bool "MSP432P4XX UART driver"
-	default n
 	select SERIAL_HAS_DRIVER
 	select SERIAL_SUPPORT_INTERRUPT
 	depends on SOC_FAMILY_TISIMPLELINK

--- a/drivers/serial/Kconfig.ns16550
+++ b/drivers/serial/Kconfig.ns16550
@@ -1,6 +1,5 @@
 menuconfig UART_NS16550
 	bool "NS16550 serial driver"
-	default n
 	select SERIAL_HAS_DRIVER
 	select SERIAL_SUPPORT_INTERRUPT
 	help
@@ -10,7 +9,6 @@ menuconfig UART_NS16550
 
 config UART_NS16550_PCI
 	bool "Enable PCI Support"
-	default n
 	depends on PCI && UART_NS16550
 	help
 	  This enables NS16550 to probe for PCI-based serial devices.
@@ -20,7 +18,6 @@ config UART_NS16550_PCI
 
 config UART_NS16550_DLF
 	bool "Enable Divisor Latch Fraction (DLF) support"
-	default n
 	depends on UART_NS16550
 	help
 	  This enables support for divisor latch fraction (DLF).
@@ -30,7 +27,6 @@ config UART_NS16550_DLF
 
 config UART_NS16550_LINE_CTRL
 	bool "Enable Serial Line Control for Apps"
-	default n
 	depends on UART_LINE_CTRL && UART_NS16550
 	help
 	  This enables the API for apps to control the serial line,
@@ -40,7 +36,6 @@ config UART_NS16550_LINE_CTRL
 
 config UART_NS16550_DRV_CMD
 	bool "Enable Driver Commands"
-	default n
 	depends on UART_DRV_CMD && UART_NS16550
 	help
 	  This enables the API for apps to send commands to driver.
@@ -49,7 +44,6 @@ config UART_NS16550_DRV_CMD
 
 config UART_NS16750
 	bool "Enable 64-bytes FIFO for UART 16750"
-	default n
 	depends on UART_NS16550
 	help
 	  This enables support for 64-bytes FIFO if UART controller is 16750.
@@ -58,7 +52,6 @@ config UART_NS16750
 
 menuconfig UART_NS16550_PORT_0
 	bool "Enable NS16550 Port 0"
-	default n
 	depends on UART_NS16550
 	help
 	  This tells the driver to configure the UART port at boot, depending on
@@ -108,7 +101,6 @@ config UART_NS16550_PORT_0_DLF
 
 config UART_NS16550_PORT_0_PCI
 	bool "Port 0 is PCI-based"
-	default n
 	depends on UART_NS16550_PCI && UART_NS16550_PORT_0
 	help
 	  Obtain port information from PCI.
@@ -117,7 +109,6 @@ config UART_NS16550_PORT_0_PCI
 
 menuconfig UART_NS16550_PORT_1
 	bool "Enable NS16550 Port 1"
-	default n
 	depends on UART_NS16550
 	help
 	  This tells the driver to configure the UART port at boot, depending on
@@ -169,7 +160,6 @@ config UART_NS16550_PORT_1_DLF
 
 menuconfig UART_NS16550_PORT_2
 	bool "Enable NS16550 Port 2"
-	default n
 	depends on UART_NS16550
 	help
 	  This tells the driver to configure the UART port at boot, depending on

--- a/drivers/serial/Kconfig.nsim
+++ b/drivers/serial/Kconfig.nsim
@@ -1,6 +1,5 @@
 config UART_NSIM
 	bool "UART driver for MetaWare nSim"
-	default n
 	select SERIAL_HAS_DRIVER
 	depends on SERIAL
 	help

--- a/drivers/serial/Kconfig.qmsi
+++ b/drivers/serial/Kconfig.qmsi
@@ -1,7 +1,6 @@
 menuconfig UART_QMSI
 	depends on QMSI
 	bool "QMSI UART driver"
-	default n
 	select SERIAL_HAS_DRIVER
 	select SERIAL_SUPPORT_INTERRUPT
 	help
@@ -13,7 +12,6 @@ menuconfig UART_QMSI
 config UART_QMSI_0
 	depends on UART_QMSI
 	bool "Enable UART 0 controller"
-	default n
 
 config UART_QMSI_0_HW_FC
 	depends on UART_QMSI_0
@@ -23,7 +21,6 @@ config UART_QMSI_0_HW_FC
 config UART_QMSI_1
 	depends on UART_QMSI
 	bool "Enable UART 1 controller"
-	default n
 
 config UART_QMSI_1_HW_FC
 	depends on UART_QMSI_1

--- a/drivers/serial/Kconfig.riscv_qemu
+++ b/drivers/serial/Kconfig.riscv_qemu
@@ -8,7 +8,6 @@
 menuconfig UART_RISCV_QEMU
 	bool "riscv-qemu UART driver"
 	depends on SOC_RISCV32_QEMU
-	default n
 	select SERIAL_HAS_DRIVER
 	help
 	  Enable the riscv-qemu UART driver.

--- a/drivers/serial/Kconfig.sam0
+++ b/drivers/serial/Kconfig.sam0
@@ -8,6 +8,5 @@ menuconfig UART_SAM0
 	depends on SOC_FAMILY_SAM0
 	select SERIAL_HAS_DRIVER
 	select SERIAL_SUPPORT_INTERRUPT
-	default n
 	help
 	  This option enables the SERCOMx USART driver for Atmel SAM0 MCUs.

--- a/drivers/serial/Kconfig.stellaris
+++ b/drivers/serial/Kconfig.stellaris
@@ -1,6 +1,5 @@
 menuconfig UART_STELLARIS
 	bool "Stellaris serial driver"
-	default n
 	select SERIAL_HAS_DRIVER
 	select SERIAL_SUPPORT_INTERRUPT
 	help
@@ -12,7 +11,6 @@ menuconfig UART_STELLARIS
 
 menuconfig UART_STELLARIS_PORT_0
 	bool "Enable Stellaris UART Port 0"
-	default n
 	depends on UART_STELLARIS
 	help
 	  This tells the driver to configure the UART port at boot, depending on
@@ -22,7 +20,6 @@ menuconfig UART_STELLARIS_PORT_0
 
 menuconfig UART_STELLARIS_PORT_1
 	bool "Enable Stellaris UART Port 1"
-	default n
 	depends on UART_STELLARIS
 	help
 	  This tells the driver to configure the UART port at boot, depending on
@@ -32,7 +29,6 @@ menuconfig UART_STELLARIS_PORT_1
 
 menuconfig UART_STELLARIS_PORT_2
 	bool "Enable Stellaris UART Port 2"
-	default n
 	depends on UART_STELLARIS
 	help
 	  This tells the driver to configure the UART port at boot, depending on

--- a/drivers/serial/Kconfig.stm32
+++ b/drivers/serial/Kconfig.stm32
@@ -7,7 +7,6 @@
 
 menuconfig UART_STM32
 	bool "STM32 MCU serial driver"
-	default n
 	select SERIAL_HAS_DRIVER
 	select SERIAL_SUPPORT_INTERRUPT
 	depends on SOC_FAMILY_STM32
@@ -22,7 +21,6 @@ if UART_STM32
 
 config UART_STM32_PORT_1
 	bool "Enable STM32 USART1 Port"
-	default n
 	depends on UART_STM32
 	help
 	  Enable support for USART1 port in the driver.
@@ -32,7 +30,6 @@ config UART_STM32_PORT_1
 
 config UART_STM32_PORT_2
 	bool "Enable STM32 USART2 Port"
-	default n
 	depends on UART_STM32
 	help
 	  Enable support for USART2 port in the driver.
@@ -42,7 +39,6 @@ config UART_STM32_PORT_2
 
 config UART_STM32_PORT_3
 	bool "Enable STM32 USART3 Port"
-	default n
 	depends on UART_STM32
 	help
 	  Enable support for USART3 port in the driver.
@@ -52,7 +48,6 @@ config UART_STM32_PORT_3
 
 config UART_STM32_PORT_4
 	bool "Enable STM32 U(S)ART4 Port"
-	default n
 	depends on UART_STM32
 	help
 	  Enable support for U(S)ART4 port in the driver.
@@ -62,7 +57,6 @@ config UART_STM32_PORT_4
 
 config UART_STM32_PORT_5
 	bool "Enable STM32 U(S)ART5 Port"
-	default n
 	depends on UART_STM32
 	help
 	  Enable support for U(S)ART5 port in the driver.
@@ -72,7 +66,6 @@ config UART_STM32_PORT_5
 
 config UART_STM32_PORT_6
 	bool "Enable STM32 USART6 Port"
-	default n
 	depends on UART_STM32
 	help
 	  Enable support for USART6 port in the driver.
@@ -82,7 +75,6 @@ config UART_STM32_PORT_6
 
 config UART_STM32_PORT_7
 	bool "Enable STM32 U(S)ART7 Port"
-	default n
 	depends on UART_STM32
 	help
 	  Enable support for U(S)ART7 port in the driver.
@@ -92,7 +84,6 @@ config UART_STM32_PORT_7
 
 config UART_STM32_PORT_8
 	bool "Enable STM32 U(S)ART8 Port"
-	default n
 	depends on UART_STM32
 	help
 	  Enable support for U(S)ART8 port in the driver.
@@ -102,7 +93,6 @@ config UART_STM32_PORT_8
 
 config UART_STM32_PORT_9
 	bool "Enable STM32 UART9 Port"
-	default n
 	depends on UART_STM32
 	help
 	  Enable support for UART9 port in the driver.
@@ -112,7 +102,6 @@ config UART_STM32_PORT_9
 
 config UART_STM32_PORT_10
 	bool "Enable STM32 UART10 Port"
-	default n
 	depends on UART_STM32
 	help
 	  Enable support for UART10 port in the driver.
@@ -124,7 +113,6 @@ if SOC_SERIES_STM32L0X || SOC_SERIES_STM32L4X
 
 config UART_STM32_LPUART_1
 	bool "Enable STM32 LPUART1 Port"
-	default n
 	depends on UART_STM32
 	help
 	  Enable support for LPUART1 port in the driver.

--- a/drivers/serial/Kconfig.uart_sam
+++ b/drivers/serial/Kconfig.uart_sam
@@ -10,7 +10,6 @@ menuconfig UART_SAM
 	depends on SOC_FAMILY_SAM
 	select SERIAL_HAS_DRIVER
 	select SERIAL_SUPPORT_INTERRUPT
-	default n
 	help
 	  This option enables the UARTx driver for Atmel SAM MCUs.
 
@@ -19,7 +18,6 @@ menuconfig UART_SAM
 config UART_SAM_PORT_0
 	bool "Enable UART0"
 	depends on UART_SAM
-	default n
 	help
 	  Enable UART0 at boot.
 
@@ -28,7 +26,6 @@ config UART_SAM_PORT_0
 config UART_SAM_PORT_1
 	bool "Enable UART1"
 	depends on UART_SAM
-	default n
 	help
 	  Enable UART1 at boot.
 
@@ -55,7 +52,6 @@ endif # UART_SAM_PORT_1
 config UART_SAM_PORT_2
 	bool "Enable UART2"
 	depends on UART_SAM
-	default n
 	help
 	  Enable UART2 at boot
 
@@ -64,7 +60,6 @@ config UART_SAM_PORT_2
 config UART_SAM_PORT_3
 	bool "Enable UART3"
 	depends on UART_SAM
-	default n
 	help
 	  Enable UART3 at boot
 
@@ -88,7 +83,6 @@ endif # UART_SAM_PORT_3
 config UART_SAM_PORT_4
 	bool "Enable UART4"
 	depends on UART_SAM
-	default n
 	help
 	  Enable UART4 at boot
 

--- a/drivers/serial/Kconfig.usart_sam
+++ b/drivers/serial/Kconfig.usart_sam
@@ -9,7 +9,6 @@ menuconfig USART_SAM
 	depends on SOC_FAMILY_SAM
 	select SERIAL_HAS_DRIVER
 	select SERIAL_SUPPORT_INTERRUPT
-	default n
 	help
 	  This option enables the USARTx driver for Atmel SAM MCUs.
 
@@ -18,7 +17,6 @@ menuconfig USART_SAM
 config USART_SAM_PORT_0
 	bool "Enable USART0"
 	depends on USART_SAM
-	default n
 	help
 	  Enable USART0 at boot
 
@@ -27,7 +25,6 @@ config USART_SAM_PORT_0
 config USART_SAM_PORT_1
 	bool "Enable USART1"
 	depends on USART_SAM
-	default n
 	help
 	  Enable USART1 at boot
 
@@ -36,6 +33,5 @@ config USART_SAM_PORT_1
 config USART_SAM_PORT_2
 	bool "Enable USART2"
 	depends on USART_SAM
-	default n
 	help
 	  Enable USART2 at boot

--- a/drivers/spi/Kconfig
+++ b/drivers/spi/Kconfig
@@ -11,7 +11,6 @@
 #
 menuconfig SPI
 	bool "SPI hardware bus support"
-	default n
 	help
 	  Enable support for the SPI hardware bus.
 
@@ -19,14 +18,12 @@ if SPI
 
 config SPI_ASYNC
 	bool "Enable Asynchronous call support"
-	default n
 	select POLL
 	help
 	  This option enables the asynchronous API calls.
 
 config SPI_SLAVE
 	bool "Enable Slave support [EXPERIMENTAL]"
-	default n
 	help
 	  Enables Driver SPI slave operations. Slave support depends
 	  on the driver and the hardware it runs on.
@@ -59,7 +56,6 @@ config SYS_LOG_SPI_LEVEL
 
 config	SPI_0
 	bool "SPI port 0"
-	default n
 	help
 	  Enable SPI controller port 0.
 
@@ -99,7 +95,6 @@ endif # SPI_0
 
 config SPI_1
 	bool "SPI port 1"
-	default n
 	help
 	  Enable SPI controller port 1.
 
@@ -139,7 +134,6 @@ endif # SPI_1
 
 config SPI_2
 	bool "SPI port 2"
-	default n
 	help
 	  Enable SPI controller port 2.
 
@@ -179,7 +173,6 @@ endif # SPI_2
 
 config SPI_3
 	bool "SPI port 3"
-	default n
 	help
 	  Enable SPI controller port 3.
 
@@ -209,7 +202,6 @@ endif # SPI_3
 
 config SPI_4
 	bool "SPI port 4"
-	default n
 	help
 	  Enable SPI controller port 4.
 
@@ -235,7 +227,6 @@ endif # SPI_4
 
 config SPI_5
 	bool "SPI port 5"
-	default n
 	help
 	  Enable SPI controller port 5.
 
@@ -262,7 +253,6 @@ endif # SPI_5
 config SPI_INTEL
 	bool "Intel SPI controller driver"
 	depends on CPU_MINUTEIA
-	default n
 	help
 	  Enable support for Intel's SPI controllers. Such controller
 	  was formerly found on XScale chips. It can be found nowadays

--- a/drivers/spi/Kconfig.dw
+++ b/drivers/spi/Kconfig.dw
@@ -8,7 +8,6 @@
 
 menuconfig SPI_DW
 	bool "Designware SPI controller driver"
-	default n
 	help
 	  Enable support for Designware's SPI controllers.
 
@@ -42,7 +41,6 @@ config SPI_DW_PORT_0_INTERRUPT_SINGLE_LINE
 config SPI_DW_PORT_0_CLOCK_GATE
 	bool "Enable clock gating"
 	depends on CLOCK_CONTROL
-	default n
 
 if SPI_DW_PORT_0_CLOCK_GATE
 
@@ -66,7 +64,6 @@ config SPI_DW_PORT_1_INTERRUPT_SINGLE_LINE
 config SPI_DW_PORT_1_CLOCK_GATE
 	bool "Enable clock gating"
 	depends on CLOCK_CONTROL
-	default n
 
 if SPI_DW_PORT_1_CLOCK_GATE
 
@@ -93,7 +90,6 @@ config SPI_DW_PORT_2_INTERRUPT_SINGLE_LINE
 config SPI_DW_PORT_2_CLOCK_GATE
 	bool "Enable clock gating"
 	depends on CLOCK_CONTROL
-	default n
 
 if SPI_DW_PORT_2_CLOCK_GATE
 
@@ -120,7 +116,6 @@ config SPI_DW_PORT_3_INTERRUPT_SINGLE_LINE
 config SPI_DW_PORT_3_CLOCK_GATE
 	bool "Enable clock gating"
 	depends on CLOCK_CONTROL
-	default n
 
 if SPI_DW_PORT_3_CLOCK_GATE
 

--- a/drivers/spi/Kconfig.mcux_dspi
+++ b/drivers/spi/Kconfig.mcux_dspi
@@ -10,7 +10,6 @@ menuconfig SPI_MCUX_DSPI
 	bool "MCUX SPI driver"
 	depends on HAS_MCUX && CLOCK_CONTROL
 	select HAS_DTS_SPI
-	default n
 	help
 	  Enable support for mcux spi driver.
 

--- a/drivers/spi/Kconfig.sam0
+++ b/drivers/spi/Kconfig.sam0
@@ -7,6 +7,5 @@ menuconfig SPI_SAM0
 	bool "Atmel SAM0 series SERCOM SPI driver"
 	depends on SOC_FAMILY_SAM0
 	select HAS_DTS_SPI
-	default n
 	help
 	  Enable support for the SAM0 SERCOM SPI driver.

--- a/drivers/spi/Kconfig.stm32
+++ b/drivers/spi/Kconfig.stm32
@@ -11,7 +11,6 @@ menuconfig SPI_STM32
 	depends on SPI && SOC_FAMILY_STM32
 	select HAS_DTS_SPI
 	select USE_STM32_LL_SPI
-	default n
 	help
 	  Enable SPI support on the STM32 family of processors.
 
@@ -24,7 +23,6 @@ config SPI_STM32_HAS_FIFO
 
 config SPI_STM32_INTERRUPT
 	bool "STM32 MCU SPI Interrupt Support"
-	default n
 	help
 	  Enable Interrupt support for the SPI Driver of STM32 family.
 

--- a/drivers/timer/Kconfig
+++ b/drivers/timer/Kconfig
@@ -12,7 +12,6 @@ menu "Timer Drivers"
 
 config HPET_TIMER
 	bool "HPET timer"
-	default n
 	depends on X86
 	select IOAPIC
 	select LOAPIC
@@ -23,7 +22,6 @@ config HPET_TIMER
 
 config HPET_TIMER_LEGACY_EMULATION
 	bool "HPET timer legacy emulation mode"
-	default n
 	depends on HPET_TIMER
 	help
 	  This option switches HPET to legacy emulation mode.
@@ -32,7 +30,6 @@ config HPET_TIMER_LEGACY_EMULATION
 
 config HPET_TIMER_DEBUG
 	bool "Enable HPET debug output"
-	default n
 	depends on HPET_TIMER && PRINTK
 	help
 	  This option enables HPET debugging output.
@@ -88,7 +85,6 @@ endchoice
 config LOAPIC_TIMER
 	bool "LOAPIC timer"
 	depends on (LOAPIC || MVIC) && X86
-	default n
 	help
 	  This option selects LOAPIC timer as a system timer.
 
@@ -170,7 +166,6 @@ config PULPINO_TIMER
 
 config RISCV_MACHINE_TIMER
 	bool "RISCV Machine Timer"
-	default n
 	depends on SOC_FAMILY_RISCV_PRIVILEGE
 	help
 	  This module implements a kernel device driver for the generic RISCV machine
@@ -228,7 +223,6 @@ config XTENSA_TIMER_IRQ_PRIORITY
 
 config SYSTEM_CLOCK_DISABLE
 	bool "API to disable system clock"
-	default n
 	help
 	  This option enables the sys_clock_disable() API in the kernel. It is
 	  needed by some subsystems (which will automatically select it), but is
@@ -236,7 +230,6 @@ config SYSTEM_CLOCK_DISABLE
 
 config TIMER_READS_ITS_FREQUENCY_AT_RUNTIME
 	bool "Timer queries its hardware to find its frequency at runtime"
-	default n
 	help
 	  The drivers select this option automatically when needed. Do not modify
 	  this unless you have a very good reason for it.

--- a/drivers/usb/Kconfig
+++ b/drivers/usb/Kconfig
@@ -8,7 +8,6 @@
 
 menuconfig USB
 	bool "USB"
-	default n
 	help
 	  Enable USB drivers.
 

--- a/drivers/usb/device/Kconfig
+++ b/drivers/usb/device/Kconfig
@@ -10,13 +10,11 @@ if USB
 
 config USB_DEVICE_DRIVER
 	bool
-	default n
 
 config USB_DW
 	bool
 	prompt "Designware USB Device Controller Driver"
 	select USB_DEVICE_DRIVER
-	default n
 	help
 	  Designware USB Device Controller Driver.
 
@@ -30,7 +28,6 @@ config USB_DW_USB_2_0
 	bool
 	prompt "DesignWare Controller and PHY support for USB specification 2.0"
 	depends on USB_DW
-	default n
 	help
 	  Indicates whether or not USB specification version 2.0 is supported
 
@@ -43,7 +40,6 @@ config USB_DC_STM32
 	select USE_STM32_HAL_PCD
 	select USE_STM32_HAL_PCD_EX
 	select HAS_DTS_USB
-	default n
 	help
 	  Enable USB support on the STM32 F0, F1, F3, F4, L0 and L4 family of
 	  processors.
@@ -53,7 +49,6 @@ config USB_DC_SAM0
 	prompt "SAM0 series USB Device Controller driver"
 	depends on SOC_FAMILY_SAM0
 	select USB_DEVICE_DRIVER
-	default n
 	help
 	  SAM0 family USB device controller Driver.
 
@@ -63,7 +58,6 @@ config USB_NRF52840
 	depends on SOC_NRF52840
 	select USB_DEVICE_DRIVER
 	select HAS_DTS_USB
-	default n
 	help
 	  nRF52840 USB Device Controller Driver
 
@@ -71,7 +65,6 @@ config USB_KINETIS
 	bool
 	prompt "Kinetis USB Device Controller Driver"
 	select USB_DEVICE_DRIVER
-	default n
 	help
 	  Kinetis USB Device Controller Driver.
 
@@ -98,7 +91,6 @@ config SYS_LOG_USB_DRIVER_LEVEL
 config USB_DC_STM32_DISCONN_ENABLE
 	bool
 	depends on USB_DC_STM32
-	default n
 	help
 	  Say Y if your board uses USB DISCONNECT pin to enable the
 	  pull-up resistor on USB DP.

--- a/drivers/watchdog/Kconfig.cmsdk_apb
+++ b/drivers/watchdog/Kconfig.cmsdk_apb
@@ -18,7 +18,6 @@ config WDOG_CMSDK_APB
 config WDOG_CMSDK_APB_START_AT_BOOT
 	bool "Start Watchdog during boot"
 	depends on WDOG_CMSDK_APB
-	default n
 	help
 	  Enable this setting to allow WDOG to be automatically started
 	  during device initialization. Note that once WDOG is started

--- a/drivers/watchdog/Kconfig.mcux_wdog
+++ b/drivers/watchdog/Kconfig.mcux_wdog
@@ -9,6 +9,5 @@ menuconfig WDT_MCUX_WDOG
 	bool "MCUX WDOG driver"
 	depends on HAS_MCUX && CLOCK_CONTROL
 	select HAS_DTS_WDT
-	default n
 	help
 	  Enable the mcux wdog driver.

--- a/drivers/watchdog/Kconfig.nrfx
+++ b/drivers/watchdog/Kconfig.nrfx
@@ -9,6 +9,5 @@ menuconfig WDT_NRFX
 	depends on SOC_FAMILY_NRF && CLOCK_CONTROL_NRF5
 	select HAS_DTS_WDT
 	select NRFX_WDT
-	default n
 	help
 	  Enable support for nrfx WDT driver for nRF MCU series.

--- a/drivers/watchdog/Kconfig.qmsi
+++ b/drivers/watchdog/Kconfig.qmsi
@@ -8,7 +8,6 @@
 
 config WDT_QMSI
 	bool "QMSI Watchdog driver"
-	default n
 	help
 	  This option enables the QMSI watchdog driver.
 	  This driver is simply a shim driver based on the watchdog
@@ -24,6 +23,5 @@ config WDT_QMSI_API_REENTRANCY
 	bool
 	prompt "WDT shim driver API reentrancy"
 	depends on WDT_QMSI
-	default n
 	help
 	  Enable support for WDT shim driver API reentrancy.

--- a/drivers/wifi/Kconfig
+++ b/drivers/wifi/Kconfig
@@ -8,7 +8,6 @@
 
 menuconfig WIFI
 	bool "add support for WiFi Drivers"
-	default n
 
 if WIFI
 
@@ -38,7 +37,6 @@ config WIFI_INIT_PRIORITY
 
 config WIFI_OFFLOAD
 	bool "Support offloaded WiFi device drivers"
-	default n
 	select NET_OFFLOAD
 	help
 	  Enable support for Full-MAC WiFi devices.

--- a/drivers/wifi/Kconfig.simplelink
+++ b/drivers/wifi/Kconfig.simplelink
@@ -8,7 +8,6 @@
 
 menuconfig WIFI_SIMPLELINK
 	bool "SimpleLink WiFi driver support"
-	default n
 	depends on WIFI
 	select SIMPLELINK_HOST_DRIVER
 	select WIFI_OFFLOAD

--- a/drivers/wifi/winc1500/Kconfig.winc1500
+++ b/drivers/wifi/winc1500/Kconfig.winc1500
@@ -8,7 +8,6 @@
 
 menuconfig WIFI_WINC1500
 	bool "WINC1500 driver support"
-	default n
 	select ATMEL_WINC1500
 	select WIFI_OFFLOAD
 	select NET_L2_WIFI_MGMT
@@ -41,7 +40,6 @@ config WIFI_WINC1500_SPI_FREQ
 
 config WIFI_WINC1500_GPIO_SPI_CS
 	bool "Manage SPI CS through a GPIO pin"
-	default n
 	help
 	  This option is useful if one needs to manage SPI CS through a GPIO
 	  pin to by-pass the SPI controller's CS logic.


### PR DESCRIPTION
This pull request removes the remaining redundant `default n` properties in `drivers/`, after https://github.com/zephyrproject-rtos/zephyr/pull/8577 and https://github.com/zephyrproject-rtos/zephyr/pull/8578. Felt a bit silly splitting it into a million separate PRs. I split it up per directory.

The commit `drivers: gpio: Kconfig: Remove redundant 'default n' properties`
also adds a missing `source "drivers/gpio/Kconfig.imx"`.

Some commits also remove a few redundant `default ""` on `string` symbols. The auto-generated Kconfig documentation now mentions the implicit default value for symbols/choices without defaults. See https://github.com/zephyrproject-rtos/zephyr/pull/8540.

There's some discussion in https://github.com/zephyrproject-rtos/zephyr/pull/8577 already, so could continue there if there's objections or questions.