### PR TITLE
Bluetooth: controller: Fix LE Extended Scanner Filter Policy dependency

### DIFF
--- a/subsys/bluetooth/controller/Kconfig
+++ b/subsys/bluetooth/controller/Kconfig
@@ -242,6 +242,7 @@ config BT_CTLR_RL_SIZE
 
 config BT_CTLR_EXT_SCAN_FP
 	bool "LE Extended Scanner Filter Policies"
+	depends on BT_OBSERVER
 	default y
 	help
 	  Enable support for Bluetooth v4.2 LE Extended Scanner Filter Policies


### PR DESCRIPTION
This adds dependency upon Observer role.

Signed-off-by: Mariusz Skamra <mariusz.skamra@codecoup.pl>