### PR TITLE
drivers: eth: gmac: Cast to type expected by HAL

### DIFF
--- a/drivers/ethernet/eth_sam_gmac.c
+++ b/drivers/ethernet/eth_sam_gmac.c
@@ -101,7 +101,7 @@ static inline void dcache_invalidate(u32_t addr, u32_t size)
 	u32_t start_addr = addr & (u32_t)~(GMAC_DCACHE_ALIGNMENT - 1);
 	u32_t size_full = size + addr - start_addr;
 
-	SCB_InvalidateDCache_by_Addr((u32_t *)start_addr, size_full);
+	SCB_InvalidateDCache_by_Addr((uint32_t *)start_addr, size_full);
 }
 
 static inline void dcache_clean(u32_t addr, u32_t size)
@@ -114,7 +114,7 @@ static inline void dcache_clean(u32_t addr, u32_t size)
 	u32_t start_addr = addr & (u32_t)~(GMAC_DCACHE_ALIGNMENT - 1);
 	u32_t size_full = size + addr - start_addr;
 
-	SCB_CleanDCache_by_Addr((u32_t *)start_addr, size_full);
+	SCB_CleanDCache_by_Addr((uint32_t *)start_addr, size_full);
 }
 
 /* gmac descriptiors helpers */


### PR DESCRIPTION
This is needed to avoid compilation warnings when using both the
built-in libc and newlib.
The warnings were caused by typedefs incompatibilities.

This was agreed to be the temporary solution at the TSC.

See #8469 for more details.

Signed-off-by: Tomasz Gorochowik <tgorochowik@antmicro.com>