### PR TITLE
tests: sprintf: Wformat-truncation warning fix

### DIFF
--- a/arch/posix/CMakeLists.txt
+++ b/arch/posix/CMakeLists.txt
@@ -1,7 +1,6 @@
 zephyr_cc_option_ifdef(CONFIG_LTO -flto)
 
 zephyr_compile_options(
-  -Wno-format-truncation
   -fno-freestanding
   -Wno-undef
   -Wno-implicit-function-declaration

--- a/tests/lib/sprintf/src/main.c
+++ b/tests/lib/sprintf/src/main.c
@@ -278,9 +278,21 @@ void test_vsprintf(void)
 
 void test_snprintf(void)
 {
+#if defined(__GNUC__) && __GNUC__ >= 7
+	/*
+	 * GCC 7 and newer are smart enough to realize that in the statements
+	 * below, the output will not fit in 0 or 4 bytes, but that it requires
+	 * 9.
+	 * So it throws a warning in compile time. But in this case we are
+	 * actually testing that snprintf's return value is what it should be
+	 * while truncating the output. So let's suppress this warning here.
+	 */
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wformat-truncation"
+#endif
+
 	int len;
 	char buffer[100];
-
 
 	/*******************/
 	buffer[0] = '\0';
@@ -302,6 +314,9 @@ void test_snprintf(void)
 		     "snprintf(%%x).  Expected '%s', got '%s'\n",
 		     "dea", buffer);
 
+#if defined(__GNUC__) && __GNUC__ >= 7
+#pragma GCC diagnostic pop
+#endif
 }
 
 /**


### PR DESCRIPTION
Fix to #5732

GCC 7 and newer are smart enough to realize that in test_snprintf()
the output will not fit in 0 or 4 bytes, but that it requires 9.
So it throws a warning in compile time. But in this case we are
actually testing that snprintf's return value is what it should be
while truncating the output. So let's suppress this warning here.
+
Reverting 5124711 as this issue is no more.