### PR TITLE
drivers: dma_cavs: preserve DMA LLIs on stop

### DIFF
--- a/drivers/dma/dma_cavs.c
+++ b/drivers/dma/dma_cavs.c
@@ -328,19 +328,9 @@ static int dw_dma_transfer_start(struct device *dev, u32_t channel)
 static int dw_dma_transfer_stop(struct device *dev, u32_t channel)
 {
 	const struct dw_dma_dev_cfg *const dev_cfg = DEV_CFG(dev);
-	struct dw_dma_dev_data *const dev_data = DEV_DATA(dev);
-	struct dma_chan_data *chan_data;
 
 	if (channel >= DW_MAX_CHAN) {
 		return -EINVAL;
-	}
-
-	/* Free up the dynamic memory used in case it is not already freed.
-	 * This may have happened because of some errors.
-	 */
-	chan_data = &dev_data->chan[channel];
-	if (chan_data->lli) {
-		k_free(chan_data->lli);
 	}
 
 	/* mask block, transfer and error interrupts for channel */
@@ -348,6 +338,8 @@ static int dw_dma_transfer_stop(struct device *dev, u32_t channel)
 	dw_write(dev_cfg->base, DW_MASK_BLOCK, INT_MASK(channel));
 	dw_write(dev_cfg->base, DW_MASK_ERR, INT_MASK(channel));
 
+	/* disable the channel */
+	dw_write(dev_cfg->base, DW_DMA_CHAN_EN, CHAN_DISABLE(channel));
 	return 0;
 }
 


### PR DESCRIPTION
DMA channel linked list items (LLIs) are allocated when the channel is
configured.
The LLIs should not be freed until the channel is de-configured
Hence, k_free of LLI memory is removed from stop handler.
Also, added code to disable the channel in stop handler.

Fixes #8596