### PR TITLE
samples: net: rpl_border_router: Fix coverity issue with strlen

### DIFF
--- a/samples/net/rpl_border_router/src/coap.c
+++ b/samples/net/rpl_border_router/src/coap.c
@@ -437,7 +437,7 @@ static void node_obs_reply(struct coap_packet *response, void *user_data)
 		rank_str[i++] = payload[offset++];
 	}
 
-	if (i > strlen(rank_str)) {
+	if (i >= strlen(rank_str)) {
 		return;
 	}
 


### PR DESCRIPTION
This patch fixes a coverity issue reported in CID-186057.

Fixes Issue #8598

Signed-off-by: Andy Gross <andy.gross@linaro.org>