### PR TITLE
ARP optimizations

### DIFF
--- a/subsys/net/ip/net_core.c
+++ b/subsys/net/ip/net_core.c
@@ -25,7 +25,6 @@
 
 #include <net/net_if.h>
 #include <net/net_mgmt.h>
-#include <net/arp.h>
 #include <net/net_pkt.h>
 #include <net/net_core.h>
 #include <net/dns_resolve.h>
@@ -387,13 +386,6 @@ static inline void l3_init(void)
 	NET_DBG("Network L3 init done");
 }
 
-static inline void l2_init(void)
-{
-	net_arp_init();
-
-	NET_DBG("Network L2 init done");
-}
-
 static int net_init(struct device *unused)
 {
 	int status = 0;
@@ -406,7 +398,6 @@ static int net_init(struct device *unused)
 
 	net_context_init();
 
-	l2_init();
 	l3_init();
 
 	net_mgmt_event_init();

--- a/subsys/net/ip/net_if.c
+++ b/subsys/net/ip/net_if.c
@@ -16,7 +16,6 @@
 #include <net/net_core.h>
 #include <net/net_pkt.h>
 #include <net/net_if.h>
-#include <net/arp.h>
 #include <net/net_mgmt.h>
 #include <net/ethernet.h>
 

--- a/subsys/net/ip/net_shell.c
+++ b/subsys/net/ip/net_shell.c
@@ -45,7 +45,7 @@
 #endif
 
 #if defined(CONFIG_NET_ARP)
-#include <net/arp.h>
+#include "ethernet/arp.h"
 #endif
 
 #if defined(CONFIG_NET_VLAN)

--- a/subsys/net/l2/ethernet/arp.c
+++ b/subsys/net/l2/ethernet/arp.c
@@ -226,7 +226,7 @@ static inline struct in_addr *if_get_addr(struct net_if *iface)
 	return NULL;
 }
 
-static inline struct net_pkt *prepare_arp(struct net_if *iface,
+static inline struct net_pkt *arp_prepare(struct net_if *iface,
 					  struct in_addr *next_addr,
 					  struct arp_entry *entry,
 					  struct net_pkt *pending)
@@ -400,7 +400,7 @@ struct net_pkt *net_arp_prepare(struct net_pkt *pkt)
 			entry = NULL;
 		}
 
-		req = prepare_arp(net_pkt_iface(pkt), addr, entry, pkt);
+		req = arp_prepare(net_pkt_iface(pkt), addr, entry, pkt);
 
 		if (!entry) {
 			/* We cannot send the packet, the ARP cache is full
@@ -462,7 +462,7 @@ static inline void arp_update(struct net_if *iface,
 	}
 }
 
-static inline struct net_pkt *prepare_arp_reply(struct net_if *iface,
+static inline struct net_pkt *arp_prepare_reply(struct net_if *iface,
 						struct net_pkt *req)
 {
 	struct ethernet_context *ctx = net_if_l2_data(iface);
@@ -574,7 +574,7 @@ enum net_verdict net_arp_input(struct net_pkt *pkt)
 #endif /* CONFIG_NET_DEBUG_ARP */
 
 		/* Send reply */
-		reply = prepare_arp_reply(net_pkt_iface(pkt), pkt);
+		reply = arp_prepare_reply(net_pkt_iface(pkt), pkt);
 		if (reply) {
 			net_if_queue_tx(net_pkt_iface(reply), reply);
 		} else {

--- a/subsys/net/l2/ethernet/arp.c
+++ b/subsys/net/l2/ethernet/arp.c
@@ -18,12 +18,14 @@
 #include <net/net_pkt.h>
 #include <net/net_if.h>
 #include <net/net_stats.h>
-#include <net/arp.h>
+
+#include "arp.h"
 #include "net_private.h"
 
 #define NET_BUF_TIMEOUT K_MSEC(100)
 #define ARP_REQUEST_TIMEOUT K_SECONDS(2)
 
+static bool arp_cache_initialized;
 static struct arp_entry arp_table[CONFIG_NET_ARP_TABLE_SIZE];
 
 static inline struct arp_entry *find_entry(struct net_if *iface,
@@ -547,10 +549,16 @@ void net_arp_init(void)
 {
 	int i;
 
+	if (arp_cache_initialized) {
+		return;
+	}
+
 	net_arp_clear_cache(NULL);
 
 	for (i = 0; i < CONFIG_NET_ARP_TABLE_SIZE; i++) {
 		k_delayed_work_init(&arp_table[i].arp_request_timer,
 				    arp_request_timeout);
 	}
+
+	arp_cache_initialized = true;
 }

--- a/subsys/net/l2/ethernet/arp.h
+++ b/subsys/net/l2/ethernet/arp.h
@@ -1,9 +1,3 @@
-/** @file
- @brief ARP handler
-
- This is not to be included by the application.
- */
-
 /*
  * Copyright (c) 2016 Intel Corporation
  *

--- a/subsys/net/l2/ethernet/arp.h
+++ b/subsys/net/l2/ethernet/arp.h
@@ -47,7 +47,7 @@ enum net_verdict net_arp_input(struct net_pkt *pkt);
 
 struct arp_entry {
 	sys_snode_t node;
-	struct k_delayed_work arp_request_timer;
+	s64_t req_start;
 	struct net_if *iface;
 	struct net_pkt *pending;
 	struct in_addr ip;

--- a/subsys/net/l2/ethernet/arp.h
+++ b/subsys/net/l2/ethernet/arp.h
@@ -49,9 +49,11 @@ struct arp_entry {
 	sys_snode_t node;
 	s64_t req_start;
 	struct net_if *iface;
-	struct net_pkt *pending;
 	struct in_addr ip;
-	struct net_eth_addr eth;
+	union {
+		struct net_pkt *pending;
+		struct net_eth_addr eth;
+	};
 };
 
 typedef void (*net_arp_cb_t)(struct arp_entry *entry,

--- a/subsys/net/l2/ethernet/arp.h
+++ b/subsys/net/l2/ethernet/arp.h
@@ -13,6 +13,7 @@ extern "C" {
 
 #if defined(CONFIG_NET_ARP)
 
+#include <misc/slist.h>
 #include <net/ethernet.h>
 
 /**
@@ -45,6 +46,7 @@ struct net_pkt *net_arp_prepare(struct net_pkt *pkt);
 enum net_verdict net_arp_input(struct net_pkt *pkt);
 
 struct arp_entry {
+	sys_snode_t node;
 	struct k_delayed_work arp_request_timer;
 	struct net_if *iface;
 	struct net_pkt *pending;

--- a/subsys/net/l2/ethernet/ethernet.c
+++ b/subsys/net/l2/ethernet/ethernet.c
@@ -15,9 +15,9 @@
 #include <net/net_mgmt.h>
 #include <net/ethernet.h>
 #include <net/ethernet_mgmt.h>
-#include <net/arp.h>
 #include <net/gptp.h>
 
+#include "arp.h"
 #include "net_private.h"
 #include "ipv6.h"
 
@@ -881,6 +881,8 @@ void ethernet_init(struct net_if *iface)
 		}
 	}
 #endif
+
+	net_arp_init();
 
 	ctx->is_init = true;
 }

--- a/tests/net/arp/CMakeLists.txt
+++ b/tests/net/arp/CMakeLists.txt
@@ -1,6 +1,11 @@
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
 project(NONE)
 
-target_include_directories(app PRIVATE $ENV{ZEPHYR_BASE}/subsys/net/ip)
+target_include_directories(
+  app
+  PRIVATE
+  $ENV{ZEPHYR_BASE}/subsys/net/ip
+  $ENV{ZEPHYR_BASE}/subsys/net/l2/ethernet
+  )
 FILE(GLOB app_sources src/*.c)
 target_sources(app PRIVATE ${app_sources})

--- a/tests/net/arp/src/main.c
+++ b/tests/net/arp/src/main.c
@@ -20,8 +20,9 @@
 #include <net/net_core.h>
 #include <net/net_pkt.h>
 #include <net/net_ip.h>
-#include <net/arp.h>
 #include <ztest.h>
+
+#include "arp.h"
 
 #define NET_LOG_ENABLED 1
 #include "net_private.h"


### PR DESCRIPTION
A quick ROM/RAM occupation report before/after the optimizations with CONFIG_NET_ARP_TABLE_SIZE = 100
(functions names have slightly changed)

Without optimizations:

ROM:

      l2                                                                                1910     5.71%
        ethernet                                                                        1910     5.71%
          arp.c                                                                         1202     3.59%
            arp_request_timeout                                                           20     0.06%
            if_get_addr.isra.6                                                            30     0.09%
            net_arp_clear_cache                                                           84     0.25%
            net_arp_init                                                                  44     0.13%
            net_arp_input                                                                484     1.45%
            net_arp_prepare                                                              240     0.72%
            prepare_arp                                                                  300     0.90%
          ethernet.c                                                                     708     2.12%
            broadcast_eth_addr                                                             6     0.02%
            carrier_off                                                                    6     0.02%
            carrier_on                                                                     6     0.02%
            ethernet_enable                                                               12     0.04%
            ethernet_init                                                                 10     0.03%
            ethernet_recv                                                                256     0.77%
            ethernet_reserve                                                               4     0.01%
            ethernet_send                                                                296     0.89%
            net_eth_carrier_off                                                           28     0.08%
            net_eth_carrier_on                                                            28     0.08%
            net_eth_fill_header                                                           56     0.17%

On a total of: 33444

RAM:

      l2                                                                                6000    16.68%
        ethernet                                                                        6000    16.68%
          arp.c                                                                         6000    16.68%
            arp_table                                                                   6000    16.68%


--------------------------------


With optimizations:

ROM:

      l2                                                                                2398     7.04%
        ethernet                                                                        2398     7.04%
          arp.c                                                                         1684     4.94%
            arp_request_timeout                                                          148     0.43%
            cleanup_entry                                                                 48     0.14%
            find_entry                                                                    34     0.10%
            if_get_addr.isra.10                                                           30     0.09%
            net_arp_clear_cache                                                          196     0.58%
            net_arp_init                                                                 108     0.32%
            net_arp_input                                                                500     1.47%
            net_arp_prepare                                                              620     1.82%
          ethernet.c                                                                     714     2.10%
            broadcast_eth_addr                                                             6     0.02%
            carrier_off                                                                    6     0.02%
            carrier_on                                                                     6     0.02%
            ethernet_enable                                                               12     0.04%
            ethernet_init                                                                 16     0.05%
            ethernet_recv                                                                256     0.75%
            ethernet_reserve                                                               4     0.01%
            ethernet_send                                                                296     0.87%
            net_eth_carrier_off                                                           28     0.08%
            net_eth_carrier_on                                                            28     0.08%
            net_eth_fill_header                                                           56     0.16%

On a total of: 34068


RAM:

      l2                                                                                3265     9.82%
        ethernet                                                                        3265     9.82%
          arp.c                                                                         3265     9.82%
            arp_cache_initialized                                                          1     0.00%
            arp_entries                                                                 3200     9.62%
            arp_free_entries                                                               8     0.02%
            arp_pending_entries                                                            8     0.02%
            arp_request_timer                                                             40     0.12%
            arp_table                                                                      8     0.02%



And using slist have optimized the lookups, though I don't have numbers for these.