### PR TITLE
tests: ztest: ztest_mock to support multiple calls to same mock

### DIFF
--- a/tests/ztest/src/ztest_mock.c
+++ b/tests/ztest/src/ztest_mock.c
@@ -144,15 +144,17 @@ static void insert_value(struct parameter *param, const char *fn,
 {
 	struct parameter *value;
 
-	value = find_and_delete_value(param, fn, name);
-	if (!value) {
-		value = alloc_parameter();
-	}
-
+	value = alloc_parameter();
 	value->fn = fn;
 	value->name = name;
 	value->value = val;
 
+	/* Seek to end of linked list to ensure correct discovery order in find_and_delete_value */
+	while (param->next) {
+		param = param->next;
+	}
+
+	/* Append to end of linked list */
 	value->next = param->next;
 	param->next = value;
 }


### PR DESCRIPTION
Updated ztest_mock.c to support multiple calls to same mock function
within a single function under test. This allows sequencing mock
return values for improved decision coverage in a test, or simply
when a given function under test calls the same function more than
once with different parameters, or different return values.

Signed-off-by: Morten Priess <mtpr@oticon.com>

Fixes: #8587