### PR TITLE
Bluetooth: controller: Fix empty_pkt_us_get for 2M phy.

### DIFF
--- a/subsys/bluetooth/controller/ll_sw/ctrl.c
+++ b/subsys/bluetooth/controller/ll_sw/ctrl.c
@@ -619,7 +619,7 @@ static inline u32_t empty_pkt_us_get(u8_t phy)
 	case BIT(0):
 		return 80;
 	case BIT(1):
-		return 40;
+		return 44;
 	case BIT(2):
 		return 720;
 	}


### PR DESCRIPTION
An empty packet on 2M phy is one more byte compared to 1M phy because
of the preamble.
The empty packet is then 11 bytes, which takes 44 us to transmit.