### PR TITLE
arch: arm: soc: add explanatory comment for kernel headers' inclusion

### DIFF
--- a/arch/arm/soc/arm/beetle/soc.h
+++ b/arch/arm/soc/arm/beetle/soc.h
@@ -89,6 +89,10 @@
 
 #ifndef _ASMLANGUAGE
 
+/* ARM CMSIS definitions must be included before kernel_includes.h.
+ * Therefore, it is essential to include kernel_includes.h after including
+ * core SOC-specific headers.
+ */
 #include <kernel_includes.h>
 
 #include "soc_pins.h"

--- a/arch/arm/soc/atmel_sam/same70/soc.h
+++ b/arch/arm/soc/atmel_sam/same70/soc.h
@@ -46,6 +46,10 @@
 #include "../common/soc_pmc.h"
 #include "../common/soc_gpio.h"
 
+/* ARM CMSIS definitions must be included before kernel_includes.h.
+ * Therefore, it is essential to include kernel_includes.h after including
+ * core SOC-specific headers.
+ */
 #include <kernel_includes.h>
 
 #endif /* _ASMLANGUAGE */

--- a/arch/arm/soc/nordic_nrf/nrf51/soc.h
+++ b/arch/arm/soc/nordic_nrf/nrf51/soc.h
@@ -15,6 +15,11 @@
 
 #include <nrf_common.h>
 #include <nrf.h>
+
+/* ARM CMSIS definitions must be included before kernel_includes.h.
+ * Therefore, it is essential to include kernel_includes.h after including
+ * core SOC-specific headers.
+ */
 #include <kernel_includes.h>
 
 /* Add include for DTS generated information */

--- a/arch/arm/soc/nordic_nrf/nrf52/soc.h
+++ b/arch/arm/soc/nordic_nrf/nrf52/soc.h
@@ -15,6 +15,11 @@
 
 #include <nrf_common.h>
 #include <nrf.h>
+
+/* ARM CMSIS definitions must be included before kernel_includes.h.
+ * Therefore, it is essential to include kernel_includes.h after including
+ * core SOC-specific headers.
+ */
 #include <kernel_includes.h>
 
 /* Add include for DTS generated information */

--- a/arch/arm/soc/nxp_imx/rt/soc.h
+++ b/arch/arm/soc/nxp_imx/rt/soc.h
@@ -16,6 +16,11 @@ extern "C" {
 #ifndef _ASMLANGUAGE
 
 #include <fsl_common.h>
+
+/* ARM CMSIS definitions must be included before kernel_includes.h.
+ * Therefore, it is essential to include kernel_includes.h after including
+ * core SOC-specific headers.
+ */
 #include <kernel_includes.h>
 
 

--- a/arch/arm/soc/st_stm32/stm32f4/soc.h
+++ b/arch/arm/soc/st_stm32/stm32f4/soc.h
@@ -26,6 +26,10 @@
 
 #include <stm32f4xx.h>
 
+/* ARM CMSIS definitions must be included before kernel_includes.h.
+ * Therefore, it is essential to include kernel_includes.h after including
+ * core SOC-specific headers.
+ */
 #include <kernel_includes.h>
 
 #ifdef CONFIG_CLOCK_CONTROL_STM32_CUBE

--- a/arch/arm/soc/st_stm32/stm32f7/soc.h
+++ b/arch/arm/soc/st_stm32/stm32f7/soc.h
@@ -25,6 +25,10 @@
 
 #include <stm32f7xx.h>
 
+/* ARM CMSIS definitions must be included before kernel_includes.h.
+ * Therefore, it is essential to include kernel_includes.h after including
+ * core SOC-specific headers.
+ */
 #include <kernel_includes.h>
 
 #ifdef CONFIG_CLOCK_CONTROL_STM32_CUBE

--- a/arch/arm/soc/st_stm32/stm32l4/soc.h
+++ b/arch/arm/soc/st_stm32/stm32l4/soc.h
@@ -23,6 +23,11 @@
 
 #include <autoconf.h>
 #include <stm32l4xx.h>
+
+/* ARM CMSIS definitions must be included before kernel_includes.h.
+ * Therefore, it is essential to include kernel_includes.h after including
+ * core SOC-specific headers.
+ */
 #include <kernel_includes.h>
 
 #define GPIO_REG_SIZE         0x400


### PR DESCRIPTION
This commit adds an explanatory comment in all soc.h headers
where kernel_includes.h is included, to stress that it needs
to be included after SOC-specific headers are brought in.

Signed-off-by: Ioannis Glaropoulos <Ioannis.Glaropoulos@nordicsemi.no>