### PR TITLE
tests: Cleanup converting int result to string

### DIFF
--- a/tests/crypto/ctr_prng/src/ctr_prng.c
+++ b/tests/crypto/ctr_prng/src/ctr_prng.c
@@ -535,8 +535,6 @@ void test_robustness(void)
 	TC_PRINT("CTR PRNG robustness test succeeded\n");
 }
 
-#define RC_STR(rc)	(rc == TC_PASS ? PASS : FAIL)
-
 /*
  * Main task to test CTR PRNG
  */
@@ -551,7 +549,8 @@ void test_ctr_prng_vector(void)
 	elements = (int)sizeof(vectors) / sizeof(vectors[0]);
 	for (i = 0; i < elements; i++) {
 		rc = test_prng_vector(&vectors[i]);
-		TC_PRINT("[%s] test_prng_vector #%d\n", RC_STR(rc), i);
+		TC_PRINT("[%s] test_prng_vector #%d\n",
+			 TC_RESULT_TO_STR(rc), i);
 
 		/**TESTPOINT: Check if test passed*/
 		zassert_false(rc, "CTR PRNG vector test failed");

--- a/tests/include/tc_util.h
+++ b/tests/include/tc_util.h
@@ -57,18 +57,23 @@
 /* stack size and priority for test suite task */
 #define TASK_STACK_SIZE (1024 * 2)
 
-#define FAIL "FAIL"
-#define PASS "PASS"
-#define SKIP "SKIP"
 #define FMT_ERROR "%s - %s@%d. "
 
 #define TC_PASS 0
 #define TC_FAIL 1
 #define TC_SKIP 2
 
+static __unused const char *TC_RESULT_STR[] = {
+	[TC_PASS] = "PASS",
+	[TC_FAIL] = "FAIL",
+	[TC_SKIP] = "SKIP",
+};
+
+#define TC_RESULT_TO_STR(result) TC_RESULT_STR[result]
+
 #define TC_ERROR(fmt, ...)                               \
 	do {                                                 \
-		PRINT_DATA(FMT_ERROR, FAIL, __func__, __LINE__); \
+		PRINT_DATA(FMT_ERROR, "FAIL", __func__, __LINE__); \
 		PRINT_DATA(fmt, ##__VA_ARGS__);                  \
 	} while (0)
 
@@ -79,13 +84,7 @@
 /* prints result and the function name */
 #define _TC_END_RESULT(result, func)					\
 	do {								\
-		if ((result) == TC_PASS) {				\
-			TC_END(result, "%s - %s\n", PASS, func);	\
-		} else if ((result) == TC_FAIL) {			\
-			TC_END(result, "%s - %s\n", FAIL, func);	\
-		} else {						\
-			TC_END(result, "%s - %s\n", SKIP, func);	\
-		}							\
+		TC_END(result, "%s - %s\n", TC_RESULT_TO_STR(result), func); \
 		PRINT_LINE;						\
 	} while (0)
 #define TC_END_RESULT(result)                           \

--- a/tests/net/lib/http_header_fields/src/main.c
+++ b/tests/net/lib/http_header_fields/src/main.c
@@ -821,8 +821,6 @@ int test_header_cr_no_lf_error(int req)
 	return TC_FAIL;
 }
 
-#define RC_STR(rc)	(rc == TC_PASS ? PASS : FAIL)
-
 void test_http_header_fields(void)
 {
 	int rc;

--- a/tests/net/lib/mqtt_packet/src/mqtt_packet.c
+++ b/tests/net/lib/mqtt_packet/src/mqtt_packet.c
@@ -9,8 +9,6 @@
 #include <misc/util.h>	/* for ARRAY_SIZE */
 #include <ztest.h>
 
-#define RC_STR(rc)	(rc == TC_PASS ? PASS : FAIL)
-
 #define CLIENTID	"zephyr"
 #define CLIENTID_LEN	6
 #define TOPIC		"sensors"
@@ -735,7 +733,7 @@ int eval_buffers(u8_t *buf, u16_t buf_len, u8_t *expected,
 	return TC_PASS;
 
 exit_eval:
-	TC_PRINT("%s\n", FAIL);
+	TC_PRINT("FAIL\n");
 	TC_PRINT("Computed:");
 	print_array(buf, buf_len);
 	TC_PRINT("Expected:");
@@ -1020,7 +1018,8 @@ void test_mqtt_packet(void)
 		}
 
 		rc = test->eval_fcn(test);
-		TC_PRINT("[%s] %d - %s\n", RC_STR(rc), i + 1, test->test_name);
+		TC_PRINT("[%s] %d - %s\n", TC_RESULT_TO_STR(rc), i + 1,
+			test->test_name);
 
 		/**TESTPOINT: Check eval_fcn*/
 		zassert_false(rc, "mqtt_packet test error");


### PR DESCRIPTION
Introduce TC_RESULT_TO_STR to convert from an integer test result to a
string like "PASS", "FAIL", "SKIP".  Do this to remove the defines of
PASS/FAIL/SKIP since those names might get used by other code and to
have a single consistent way of doing the conversion.

Signed-off-by: Kumar Gala <kumar.gala@linaro.org>