### PR TITLE
net: l2: Fixed wifi can not connect to open AP.

### DIFF
--- a/subsys/net/l2/wifi_mgmt.c
+++ b/subsys/net/l2/wifi_mgmt.c
@@ -31,10 +31,10 @@ static int wifi_connect(u32_t mgmt_request, struct net_if *iface,
 	    (params->ssid_length == 0) ||
 	    ((params->security == WIFI_SECURITY_TYPE_PSK) &&
 	     ((params->psk_length < 8) || (params->psk_length > 64) ||
-	      (params->psk_length == 0))) ||
+	      (params->psk_length == 0) || !params->psk)) ||
 	    ((params->channel != WIFI_CHANNEL_ANY) &&
 	     (params->channel > WIFI_CHANNEL_MAX)) ||
-	    !params->ssid || !params->psk) {
+	    !params->ssid) {
 		return -EINVAL;
 	}
 

--- a/subsys/net/l2/wifi_shell.c
+++ b/subsys/net/l2/wifi_shell.c
@@ -127,7 +127,7 @@ static int shell_cmd_connect(int argc, char *argv[])
 {
 	struct net_if *iface = net_if_get_default();
 	static struct wifi_connect_req_params cnx_params;
-	int idx = 0;
+	int idx = 3;
 
 	if (argc < 3) {
 		return -EINVAL;
@@ -142,19 +142,18 @@ static int shell_cmd_connect(int argc, char *argv[])
 
 	argv[1][cnx_params.ssid_length + 1] = '\0';
 
-	if (strlen(argv[3]) <= 2) {
+	if ((idx < argc) && (strlen(argv[idx]) <= 2)) {
 		cnx_params.channel = atoi(argv[3]);
 		if (cnx_params.channel == 0) {
 			cnx_params.channel = WIFI_CHANNEL_ANY;
 		}
 
-		idx = 4;
+		idx++;
 	} else {
 		cnx_params.channel = WIFI_CHANNEL_ANY;
-		idx = 3;
 	}
 
-	if (idx) {
+	if (idx < argc) {
 		cnx_params.psk = argv[idx];
 		cnx_params.psk_length = strlen(argv[idx]);
 		cnx_params.security = WIFI_SECURITY_TYPE_PSK;


### PR DESCRIPTION
When connect to open AP, the security is always set to
WIFI_SECURITY_TYPE_PSK.

Signed-off-by: Dong Xiang <dong.xiang@unisoc.com>