### PR TITLE
samples: sysview: limit to systems with enough ram

### DIFF
--- a/samples/subsys/debug/sysview/sample.yaml
+++ b/samples/subsys/debug/sysview/sample.yaml
@@ -4,6 +4,7 @@ tests:
   test:
     filter: CONFIG_HAS_SEGGER_RTT
     tags: debug tracing
+    min_ram: 13
     harness: console
     harness_config:
       type: one_line


### PR DESCRIPTION
When we enabled SEGGER support on the ST SoCs we now how some systems
with really small amounts of memory that the sample can't be built for.
Set a min_ram to exclude such systems.

Signed-off-by: Kumar Gala <kumar.gala@linaro.org>