### PR TITLE
tests/net: Fix L2 directory lookup for header inclusion

### DIFF
--- a/tests/net/ieee802154/crypto/CMakeLists.txt
+++ b/tests/net/ieee802154/crypto/CMakeLists.txt
@@ -1,6 +1,11 @@
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
 project(NONE)
 
-target_include_directories(app PRIVATE $ENV{ZEPHYR_BASE}/subsys/net/ip $ENV{ZEPHYR_BASE}/subsys/net/ip/l2/ieee802154)
+target_include_directories(
+  app
+  PRIVATE
+  $ENV{ZEPHYR_BASE}/subsys/net/ip
+  $ENV{ZEPHYR_BASE}/subsys/net/l2/ieee802154
+  )
 FILE(GLOB app_sources src/*.c)
 target_sources(app PRIVATE ${app_sources})

--- a/tests/net/ieee802154/fragment/CMakeLists.txt
+++ b/tests/net/ieee802154/fragment/CMakeLists.txt
@@ -1,6 +1,11 @@
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
 project(NONE)
 
-target_include_directories(app PRIVATE $ENV{ZEPHYR_BASE}/subsys/net/ip $ENV{ZEPHYR_BASE}/subsys/net/ip/l2/ieee802154)
+target_include_directories(
+  app
+  PRIVATE
+  $ENV{ZEPHYR_BASE}/subsys/net/ip
+  $ENV{ZEPHYR_BASE}/subsys/net/l2/ieee802154
+  )
 FILE(GLOB app_sources src/*.c)
 target_sources(app PRIVATE ${app_sources})

--- a/tests/net/ieee802154/l2/CMakeLists.txt
+++ b/tests/net/ieee802154/l2/CMakeLists.txt
@@ -1,6 +1,11 @@
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
 project(NONE)
 
-target_include_directories(app PRIVATE $ENV{ZEPHYR_BASE}/subsys/net/ip $ENV{ZEPHYR_BASE}/subsys/net/ip/l2/ieee802154)
+target_include_directories(
+  app
+  PRIVATE
+  $ENV{ZEPHYR_BASE}/subsys/net/ip
+  $ENV{ZEPHYR_BASE}/subsys/net/l2/ieee802154
+  )
 FILE(GLOB app_sources src/*.c)
 target_sources(app PRIVATE ${app_sources})


### PR DESCRIPTION
L2 directory is now located in subsys/net/l2

Fixes #8642

Signed-off-by: Tomasz Bursztyka <tomasz.bursztyka@linux.intel.com>