### PR TITLE
arch: arm: stm32: enable instruction and data caches on STM32F7

### DIFF
--- a/arch/arm/soc/st_stm32/stm32f7/soc.c
+++ b/arch/arm/soc/st_stm32/stm32f7/soc.c
@@ -32,6 +32,11 @@ static int st_stm32f7_init(struct device *arg)
 
 	key = irq_lock();
 
+	SCB_EnableICache();
+	if (!(SCB->CCR & SCB_CCR_DC_Msk)) {
+		SCB_EnableDCache();
+	}
+
 	_ClearFaults();
 
 	/* Install default handler that simply resets the CPU


### PR DESCRIPTION
The Cortex-M7 CPU included in the STM32F7 SoCs has instruction and data
caches that significantly boost the performances. Enable them during the
SoC initialization. Note that the D-cache should only be enabled if it
is disabled, to workaround CMSIS issue #331.

Signed-off-by: Aurelien Jarno <aurelien@aurel32.net>