### PR TITLE
arch: arm: stm32f7: remove core zephyr header inclusions from soc.h

### DIFF
--- a/arch/arm/soc/st_stm32/stm32f7/soc.h
+++ b/arch/arm/soc/st_stm32/stm32f7/soc.h
@@ -23,9 +23,9 @@
 
 #ifndef _ASMLANGUAGE
 
-#include <device.h>
-#include <misc/util.h>
 #include <stm32f7xx.h>
+
+#include <kernel_includes.h>
 
 #ifdef CONFIG_CLOCK_CONTROL_STM32_CUBE
 #include <stm32f7xx_ll_utils.h>


### PR DESCRIPTION
The stm32f7 version of soc.h misses the changes done in commit
aee97be7107b ("arch: arm: soc: remove core zephyr header inclusions
from soc.h") as it was not merged at that time. Fix that.

Signed-off-by: Aurelien Jarno <aurelien@aurel32.net>