### PR TITLE
net: config: Introduce a dedicated header for the library

### DIFF
--- a/include/net/net_app.h
+++ b/include/net/net_app.h
@@ -55,11 +55,6 @@ extern "C" {
  * @{
  */
 
-/** Flags that tell what kind of functionality is needed by the application. */
-#define NET_APP_NEED_ROUTER 0x00000001
-#define NET_APP_NEED_IPV6   0x00000002
-#define NET_APP_NEED_IPV4   0x00000004
-
 enum net_app_type {
 	NET_APP_UNSPEC = 0,
 	NET_APP_SERVER,
@@ -452,18 +447,6 @@ struct net_app_ctx {
 	/** Unused bits */
 	u8_t _padding : 5;
 };
-
-/**
- * @brief Initialize this network application.
- *
- * @param app_info String describing this application.
- * @param flags Flags related to this application startup.
- * @param timeout How long to wait the network setup before continuing
- * the startup.
- *
- * @return 0 if ok, <0 if error.
- */
-int net_app_init(const char *app_info, u32_t flags, s32_t timeout);
 
 #if defined(CONFIG_NET_CONTEXT_NET_PKT_POOL)
 /**

--- a/include/net/net_config.h
+++ b/include/net/net_config.h
@@ -1,0 +1,52 @@
+/** @file
+ * @brief Routines for network subsystem initialization.
+ */
+
+/*
+ * Copyright (c) 2017 Intel Corporation
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef __NET_CONFIG_H
+#define __NET_CONFIG_H
+
+#include <zephyr/types.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @brief Network configuration library
+ * @defgroup net_config Network Configuration Library
+ * @ingroup networking
+ * @{
+ */
+
+/** Flags that tell what kind of functionality is needed by the client. */
+#define NET_CONFIG_NEED_ROUTER 0x00000001
+#define NET_CONFIG_NEED_IPV6   0x00000002
+#define NET_CONFIG_NEED_IPV4   0x00000004
+
+/**
+ * @brief Initialize this network application.
+ *
+ * @param app_info String describing this application.
+ * @param flags Flags related to services needed by the client.
+ * @param timeout How long to wait the network setup before continuing
+ * the startup.
+ *
+ * @return 0 if ok, <0 if error.
+ */
+int net_config_init(const char *app_info, u32_t flags, s32_t timeout);
+
+/**
+ * @}
+ */
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* __NET_CONFIG_H */

--- a/subsys/net/lib/config/init.c
+++ b/subsys/net/lib/config/init.c
@@ -25,7 +25,7 @@
 #include <net/net_mgmt.h>
 #include <net/dns_resolve.h>
 
-#include <net/net_app.h>
+#include <net/net_config.h>
 
 #include "ieee802154_settings.h"
 #include "bt_settings.h"
@@ -243,7 +243,7 @@ static void setup_ipv6(struct net_if *iface, u32_t flags)
 		mask |= NET_EVENT_IPV6_ADDR_ADD;
 	}
 
-	if (flags & NET_APP_NEED_ROUTER) {
+	if (flags & NET_CONFIG_NEED_ROUTER) {
 		mask |= NET_EVENT_IPV6_ROUTER_ADD;
 	}
 
@@ -278,7 +278,7 @@ static void setup_ipv6(struct net_if *iface, u32_t flags)
 #define setup_ipv6(...)
 #endif /* CONFIG_NET_IPV6 */
 
-int net_app_init(const char *app_info, u32_t flags, s32_t timeout)
+int net_config_init(const char *app_info, u32_t flags, s32_t timeout)
 {
 #define LOOP_DIVIDER 10
 	struct net_if *iface = net_if_get_default();
@@ -294,11 +294,11 @@ int net_app_init(const char *app_info, u32_t flags, s32_t timeout)
 		return -ENODEV;
 	}
 
-	if (flags & NET_APP_NEED_IPV6) {
+	if (flags & NET_CONFIG_NEED_IPV6) {
 		count++;
 	}
 
-	if (flags & NET_APP_NEED_IPV4) {
+	if (flags & NET_CONFIG_NEED_IPV4) {
 		count++;
 	}
 
@@ -368,20 +368,20 @@ static int init_net_app(struct device *device)
 #endif
 
 	if (IS_ENABLED(CONFIG_NET_APP_NEED_IPV6)) {
-		flags |= NET_APP_NEED_IPV6;
+		flags |= NET_CONFIG_NEED_IPV6;
 	}
 
 	if (IS_ENABLED(CONFIG_NET_APP_NEED_IPV6_ROUTER)) {
-		flags |= NET_APP_NEED_ROUTER;
+		flags |= NET_CONFIG_NEED_ROUTER;
 	}
 
 	if (IS_ENABLED(CONFIG_NET_APP_NEED_IPV4)) {
-		flags |= NET_APP_NEED_IPV4;
+		flags |= NET_CONFIG_NEED_IPV4;
 	}
 
 	/* Initialize the application automatically if needed */
-	ret = net_app_init("Initializing network", flags,
-			   K_SECONDS(CONFIG_NET_APP_INIT_TIMEOUT));
+	ret = net_config_init("Initializing network", flags,
+			      K_SECONDS(CONFIG_NET_APP_INIT_TIMEOUT));
 	if (ret < 0) {
 		NET_ERR("Network initialization failed (%d)", ret);
 	}

--- a/tests/net/app/src/main.c
+++ b/tests/net/app/src/main.c
@@ -20,6 +20,7 @@
 #include <net/net_ip.h>
 #include <net/net_if.h>
 
+#include <net/net_config.h>
 #include <net/net_app.h>
 
 #define NET_LOG_ENABLED 1
@@ -237,7 +238,7 @@ static void app_init(void)
 {
 	int ret;
 
-	ret = net_app_init("Test app", 0, 1);
+	ret = net_config_init("Test app", 0, 1);
 	zassert_equal(ret, 0, "app init");
 }
 


### PR DESCRIPTION
Split out definition of net_app_init() and its parameter flags from
net_app.h header to new net_config.h header. As we do this, rename
the function to net_config_init() and flags to NET_CONFIG_NEED_*.
This is a second step in splitting out network configuration API
out of net_app API, started in the c60df1311 commit.

Signed-off-by: Paul Sokolovsky <paul.sokolovsky@linaro.org>