### PR TITLE
Add `CLOCK_REALTIME` to Posix

### DIFF
--- a/arch/posix/include/posix_cheats.h
+++ b/arch/posix/include/posix_cheats.h
@@ -26,6 +26,7 @@
 #ifdef CONFIG_PTHREAD_IPC
 
 #define timespec zap_timespec
+#define timeval  zap_timeval
 #define pthread_mutex_t zap_pthread_mutex_t
 #define pthread_mutexattr_t    zap_pthread_mutexattr_t
 #define pthread_cond_t         zap_pthread_cond_t
@@ -129,6 +130,7 @@
 /* Clock */
 #define clock_gettime(...)		zap_clock_gettime(__VA_ARGS__)
 #define clock_settime(...)		zap_clock_settime(__VA_ARGS__)
+#define gettimeofday(...)		zap_clock_gettimeofday(__VA_ARGS__)
 
 /* Timer */
 #define timer_create(...)	zap_timer_create(__VA_ARGS__)

--- a/include/posix/time.h
+++ b/include/posix/time.h
@@ -49,18 +49,8 @@ static inline s32_t _ts_to_ms(const struct timespec *to)
 	return (to->tv_sec * MSEC_PER_SEC) + (to->tv_nsec / NSEC_PER_MSEC);
 }
 
-/**
- * @brief Set clock time.
- *
- * See IEEE 1003.1
- */
-static inline int clock_settime(clockid_t clock_id, const struct timespec *ts)
-{
-	errno = ENOSYS;
-	return -1;
-}
-
 int clock_gettime(clockid_t clock_id, struct timespec *ts);
+int clock_settime(clockid_t clock_id, const struct timespec *ts);
 /* Timer APIs */
 int timer_create(clockid_t clockId, struct sigevent *evp, timer_t *timerid);
 int timer_delete(timer_t timerid);

--- a/include/posix/time.h
+++ b/include/posix/time.h
@@ -20,6 +20,11 @@ struct itimerspec {
 	struct timespec it_value;     /* Timer expiration */
 };
 
+struct timeval {
+	signed int  tv_sec;
+	signed int  tv_usec;
+};
+
 #include <kernel.h>
 #include <errno.h>
 #include "sys/types.h"
@@ -62,6 +67,8 @@ int timer_delete(timer_t timerid);
 int timer_gettime(timer_t timerid, struct itimerspec *its);
 int timer_settime(timer_t timerid, int flags, const struct itimerspec *value,
 		  struct itimerspec *ovalue);
+
+int gettimeofday(struct timeval *tv, const void *tz);
 
 #ifdef __cplusplus
 }

--- a/lib/posix/clock.c
+++ b/lib/posix/clock.c
@@ -58,6 +58,40 @@ int clock_gettime(clockid_t clock_id, struct timespec *ts)
 }
 
 /**
+ * @brief Set the time of the specified clock.
+ *
+ * See IEEE 1003.1.
+ *
+ * Note that only the `CLOCK_REALTIME` clock can be set using this
+ * call.
+ */
+int clock_settime(clockid_t clock_id, const struct timespec *tp)
+{
+	struct timespec base;
+	int res;
+
+	if (clock_id != CLOCK_REALTIME) {
+		errno = EINVAL;
+		return -1;
+	}
+
+	res = clock_gettime(clock_id, &base);
+	if (res != 0) {
+		return res;
+	}
+
+	s64_t delta = (s64_t)NSEC_PER_SEC * (tp->tv_sec - base.tv_sec) +
+		(tp->tv_nsec - base.tv_nsec);
+
+	base.tv_sec = delta / NSEC_PER_SEC;
+	base.tv_nsec = delta % NSEC_PER_SEC;
+
+	rt_clock_base = base;
+
+	return 0;
+}
+
+/**
  * @brief Get current real time.
  *
  * See IEEE 1003.1

--- a/lib/posix/clock.c
+++ b/lib/posix/clock.c
@@ -29,3 +29,24 @@ int clock_gettime(clockid_t clock_id, struct timespec *ts)
 
 	return 0;
 }
+
+/**
+ * @brief Get current real time.
+ *
+ * See IEEE 1003.1
+ */
+int gettimeofday(struct timeval *tv, const void *tz)
+{
+	struct timespec ts;
+	int res;
+
+	/* As per POSIX, "if tzp is not a null pointer, the behavior
+	 * is unspecified."  "tzp" is the "tz" parameter above. */
+	ARG_UNUSED(tv);
+
+	res = clock_gettime(CLOCK_REALTIME, &ts);
+	tv->tv_sec = ts.tv_sec;
+	tv->tv_usec = ts.tv_nsec / NSEC_PER_USEC;
+
+	return res;
+}

--- a/lib/posix/clock.c
+++ b/lib/posix/clock.c
@@ -8,6 +8,15 @@
 #include <posix/time.h>
 #include <posix/sys/types.h>
 
+/*
+ * `k_uptime_get` returns a timestamp based on an always increasing
+ * value from the system start.  To support the `CLOCK_REALTIME`
+ * clock, this `rt_clock_base` records the time that the system was
+ * started.  This can either be set via 'clock_settime', or could be
+ * set from a real time clock, if such hardware is present.
+ */
+static struct timespec rt_clock_base;
+
 /**
  * @brief Get clock time specified by clock_id.
  *
@@ -16,8 +25,19 @@
 int clock_gettime(clockid_t clock_id, struct timespec *ts)
 {
 	u64_t elapsed_msecs;
+	struct timespec base;
 
-	if (clock_id != CLOCK_MONOTONIC) {
+	switch (clock_id) {
+	case CLOCK_MONOTONIC:
+		base.tv_sec = 0;
+		base.tv_nsec = 0;
+		break;
+
+	case CLOCK_REALTIME:
+		base = rt_clock_base;
+		break;
+
+	default:
 		errno = EINVAL;
 		return -1;
 	}
@@ -26,6 +46,13 @@ int clock_gettime(clockid_t clock_id, struct timespec *ts)
 	ts->tv_sec = (s32_t) (elapsed_msecs / MSEC_PER_SEC);
 	ts->tv_nsec = (s32_t) ((elapsed_msecs % MSEC_PER_SEC) *
 					USEC_PER_MSEC * NSEC_PER_USEC);
+
+	ts->tv_sec += base.tv_sec;
+	ts->tv_nsec += base.tv_nsec;
+	if (ts->tv_nsec > NSEC_PER_SEC) {
+		ts->tv_sec++;
+		ts->tv_nsec -= NSEC_PER_SEC;
+	}
 
 	return 0;
 }

--- a/tests/posix/clock/src/main.c
+++ b/tests/posix/clock/src/main.c
@@ -36,9 +36,76 @@ void test_posix_clock(void)
 	printk("POSIX clock APIs test done\n");
 }
 
+void test_posix_realtime(void)
+{
+	/* Make sure the realtime and monotonic clocks start out the
+	 * same.  This is not true on posix and where there is a
+	 * realtime clock, so don't keep this code.
+	 */
+
+	int ret;
+	struct timespec rts, mts;
+	printk("POSIX clock set APIs\n");
+	ret = clock_gettime(CLOCK_MONOTONIC, &mts);
+	zassert_equal(ret, 0, "Fail to get monotonic clock");
+
+	ret = clock_gettime(CLOCK_REALTIME, &rts);
+	zassert_equal(ret, 0, "Fail to get realtime clock");
+
+	zassert_equal(rts.tv_sec, mts.tv_sec, "Seconds not equal");
+	zassert_equal(rts.tv_nsec, mts.tv_nsec, "Nanoseconds not equal");
+
+	/* Set a particular time.  In this case, the output of:
+	 * `date +%s -d 2018-01-01T15:45:01Z`
+	 */
+	struct timespec nts;
+	nts.tv_sec = 1514821501;
+	nts.tv_nsec = NSEC_PER_SEC / 2;
+	ret = clock_settime(CLOCK_MONOTONIC, &nts);
+	zassert_not_equal(ret, 0, "Should not be able to set monotonic time");
+
+	ret = clock_settime(CLOCK_REALTIME, &nts);
+	zassert_equal(ret, 0, "Fail to set realtime clock");
+
+	/*
+	 * Loop for 20 10ths of a second, sleeping a little bit for
+	 * each, making sure that the arithmetic roughly makes sense.
+	 * This tries to catch all of the boundary conditions of the
+	 * clock to make sure there are no errors in the arithmetic.
+	 */
+	s64_t last_delta = 0;
+	for (int i = 1; i <= 20; i++) {
+		usleep(90 * USEC_PER_MSEC);
+		ret = clock_gettime(CLOCK_REALTIME, &rts);
+		zassert_equal(ret, 0, "Fail to read realitime clock");
+
+		s64_t delta =
+			((s64_t)rts.tv_sec * NSEC_PER_SEC -
+			 (s64_t)nts.tv_sec * NSEC_PER_SEC) +
+			((s64_t)rts.tv_nsec - (s64_t)nts.tv_nsec);
+
+		/* Make the delta 10ths of a second. */
+		delta /= (NSEC_PER_SEC / 1000);
+
+		zassert_true(delta > last_delta, "Clock moved backward");
+		s64_t error = delta - last_delta;
+
+		/* printk("Delta %d: %lld\n", i, delta); */
+
+		/* Allow for a little drift */
+		zassert_true(error > 90, "Clock inaccurate");
+		zassert_true(error < 110, "Clock inaccurate");
+
+		last_delta = delta;
+	}
+
+	printk("POSIX clock set APIs test done\n");
+}
+
 void test_main(void)
 {
 	ztest_test_suite(test_posix_clock_api,
-			ztest_unit_test(test_posix_clock));
+			ztest_unit_test(test_posix_clock),
+			ztest_unit_test(test_posix_realtime));
 	ztest_run_test_suite(test_posix_clock_api);
 }


### PR DESCRIPTION
These patches add the `CLOCK_REALTIME` to the posix clock API. It uses the monotonic clock, but keeps an offset, which will be set with `clock_settime()`.

Fixes #7764