### PR TITLE
sanitycheck: whitelist logging sections

### DIFF
--- a/scripts/sanitycheck
+++ b/scripts/sanitycheck
@@ -660,7 +660,9 @@ class SizeCalculator:
                    "net_if", "net_if_dev", "net_stack", "net_l2_data",
                    "_k_queue_area", "_net_buf_pool_area", "app_datas",
                    "kobject_data", "mmu_tables", "app_pad", "priv_stacks",
-                   "ccm_data", "usb_descriptor", "usb_data", "usb_bos_desc"]
+                   "ccm_data", "usb_descriptor", "usb_data", "usb_bos_desc",
+                   'log_backends_sections', 'log_dynamic_sections',
+                   'log_const_sections']
     # These get copied into RAM only on non-XIP
     ro_sections = ["text", "ctors", "init_array", "reset", "object_access",
                    "rodata", "devconfig", "net_l2", "vector", "_bt_settings_area"]


### PR DESCRIPTION
Whitelist recently add sections in the logging subsystem.

Signed-off-by: Anas Nashif <anas.nashif@intel.com>