### PR TITLE
lib/crc: Add CRC32 support

### DIFF
--- a/include/crc32.h
+++ b/include/crc32.h
@@ -1,0 +1,56 @@
+/*
+ * Copyright (c) 2018 Workaround GmbH.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * @file
+ *
+ * @brief CRC 32 computation function
+ */
+
+#ifndef __CRC32_H
+#define __CRC32_H
+
+#include <zephyr/types.h>
+#include <stdbool.h>
+#include <stddef.h>
+
+/**
+ * @defgroup checksum Checksum
+ */
+
+/**
+ * @defgroup crc32 CRC 32
+ * @ingroup checksum
+ * @{
+ */
+
+/**
+ * @brief Generate IEEE conform CRC32 checksum.
+ *
+ * @param  *data        Pointer to data on which the CRC should be calculated.
+ * @param  len          Data length.
+ *
+ * @return CRC32 value.
+ *
+ */
+u32_t crc32_ieee(const u8_t *data, size_t len);
+
+/**
+ * @brief Update an IEEE conforming CRC32 checksum.
+ *
+ * @param crc   CRC32 checksum that needs to be updated.
+ * @param *data Pointer to data on which the CRC should be calculated.
+ * @param len   Data length.
+ *
+ * @return CRC32 value.
+ *
+ */
+u32_t crc32_ieee_update(u32_t crc, const u8_t *data, size_t len);
+
+/**
+ * @}
+ */
+#endif

--- a/lib/crc/CMakeLists.txt
+++ b/lib/crc/CMakeLists.txt
@@ -1,1 +1,1 @@
-zephyr_sources(crc16_sw.c crc8_sw.c)
+zephyr_sources(crc32_sw.c crc16_sw.c crc8_sw.c)

--- a/lib/crc/crc32_sw.c
+++ b/lib/crc/crc32_sw.c
@@ -1,0 +1,26 @@
+/*
+ * Copyright (c) 2018 Workaround GmbH.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <crc32.h>
+
+u32_t crc32_ieee(const u8_t *data, size_t len)
+{
+	return crc32_ieee_update(0x0, data, len);
+}
+
+u32_t crc32_ieee_update(u32_t crc, const u8_t *data, size_t len)
+{
+	crc = ~crc;
+	for (size_t i = 0; i < len; i++) {
+		crc = crc ^ data[i];
+
+		for (u8_t j = 0; j < 8; j++) {
+			crc = (crc >> 1) ^ (0xEDB88320 & -(crc & 1));
+		}
+	}
+
+	return (~crc);
+}

--- a/tests/unit/lib/crc/main.c
+++ b/tests/unit/lib/crc/main.c
@@ -6,8 +6,20 @@
 
 #include <ztest.h>
 
+#include <lib/crc/crc32_sw.c>
 #include <lib/crc/crc16_sw.c>
 #include <lib/crc/crc8_sw.c>
+
+void test_crc32_ieee(void)
+{
+	u8_t test1[] = { 'A' };
+	u8_t test2[] = { '1', '2', '3', '4', '5', '6', '7', '8', '9' };
+	u8_t test3[] = { 'Z', 'e', 'p', 'h', 'y', 'r' };
+
+	zassert_equal(crc32_ieee(test1, sizeof(test1)), 0xD3D99E8B, NULL);
+	zassert_equal(crc32_ieee(test2, sizeof(test2)), 0xCBF43926, NULL);
+	zassert_equal(crc32_ieee(test3, sizeof(test3)), 0x20089AA4, NULL);
+}
 
 void test_crc16(void)
 {
@@ -100,6 +112,7 @@ void test_crc8_ccitt(void)
 void test_main(void)
 {
 	ztest_test_suite(test_crc,
+			 ztest_unit_test(test_crc32_ieee),
 			 ztest_unit_test(test_crc16),
 			 ztest_unit_test(test_crc16_ansi),
 			 ztest_unit_test(test_crc16_ccitt),


### PR DESCRIPTION
It only adds CRC32 IEEE support at the moment.

Signed-off-by: Olivier Martin <olivier.martin@proglove.de>