### PR TITLE
drivers: i2c: nrfx: Move device tree selection to driver Kconfig

### DIFF
--- a/boards/arm/bbc_microbit/Kconfig.board
+++ b/boards/arm/bbc_microbit/Kconfig.board
@@ -6,5 +6,4 @@
 
 config BOARD_BBC_MICROBIT
 	bool "BBC MICRO:BIT"
-	select HAS_DTS_I2C
 	depends on SOC_NRF51822_QFAA

--- a/boards/arm/nrf52810_pca10040/Kconfig.board
+++ b/boards/arm/nrf52810_pca10040/Kconfig.board
@@ -7,5 +7,4 @@
 config  BOARD_NRF52810_PCA10040
 	bool "nRF52810 PCA10040"
 	select HAS_DTS_GPIO
-	select HAS_DTS_I2C
 	depends on SOC_NRF52810_QFAA

--- a/boards/arm/nrf52840_pca10056/Kconfig.board
+++ b/boards/arm/nrf52840_pca10056/Kconfig.board
@@ -7,5 +7,4 @@
 config  BOARD_NRF52840_PCA10056
 	bool "NRF52840 PCA10056"
 	select HAS_DTS_GPIO
-	select HAS_DTS_I2C
 	depends on SOC_NRF52840_QIAA

--- a/boards/arm/nrf52_blenano2/Kconfig.board
+++ b/boards/arm/nrf52_blenano2/Kconfig.board
@@ -8,5 +8,4 @@
 config BOARD_NRF52_BLENANO2
 	bool "nRF52 BLENANO2"
 	select HAS_DTS_GPIO
-	select HAS_DTS_I2C
 	depends on SOC_NRF52832_QFAA

--- a/boards/arm/nrf52_pca10040/Kconfig.board
+++ b/boards/arm/nrf52_pca10040/Kconfig.board
@@ -7,5 +7,4 @@
 config  BOARD_NRF52_PCA10040
 	bool "nRF52 PCA10040"
 	select HAS_DTS_GPIO
-	select HAS_DTS_I2C
 	depends on SOC_NRF52832_QFAA

--- a/boards/arm/nrf52_pca20020/Kconfig.board
+++ b/boards/arm/nrf52_pca20020/Kconfig.board
@@ -6,7 +6,6 @@
 
 config  BOARD_NRF52_PCA20020
 	bool "nRF52 PCA20020"
-	select HAS_DTS_I2C
 	select GPIO
 	select HAS_DTS_I2C_DEVICE
 	select HAS_DTS_GPIO

--- a/drivers/i2c/Kconfig.nrfx
+++ b/drivers/i2c/Kconfig.nrfx
@@ -8,6 +8,7 @@
 menuconfig I2C_NRFX
 	bool "nRF TWI nrfx drivers"
 	depends on SOC_FAMILY_NRF
+	select HAS_DTS_I2C
 	help
 	  Enable support for nrfx TWI drivers for nRF MCU series.
 	  Peripherals with the same instance ID cannot be used together,


### PR DESCRIPTION
Move HAS_DTS_I2C from board to the driver Kconfig.

Signed-off-by: Kumar Gala <kumar.gala@linaro.org>