### PR TITLE
Add bound checking in net_addr_pton() 

### DIFF
--- a/subsys/net/ip/utils.c
+++ b/subsys/net/ip/utils.c
@@ -345,6 +345,9 @@ int net_addr_pton(sa_family_t family, const char *src,
 					i--;
 				}
 			} while (tmp-- != src);
+			if (i < 0){
+				return -EINVAL;
+			}
 
 			src++;
 		}


### PR DESCRIPTION
In samples/net/rpl-mesh-qemu:
When I  input :  "net ping fe80::210:2030:9b:d48efe80::210:2030:9b:d48e " in the shell ,  the kernel panic.
I found there is an  the issue in net_addr_pton() function.

Signed-off-by: walter-xie  41377148@qq.com