### PR TITLE
Arch arm nrf cleanup soc headers

### DIFF
--- a/arch/arm/soc/nordic_nrf/nrf51/soc.c
+++ b/arch/arm/soc/nordic_nrf/nrf51/soc.c
@@ -14,9 +14,7 @@
  */
 
 #include <kernel.h>
-#include <device.h>
 #include <init.h>
-#include <soc.h>
 
 #ifdef CONFIG_RUNTIME_NMI
 extern void _NmiInit(void);

--- a/arch/arm/soc/nordic_nrf/nrf51/soc.h
+++ b/arch/arm/soc/nordic_nrf/nrf51/soc.h
@@ -16,12 +16,6 @@
 #include <nrf_common.h>
 #include <nrf.h>
 
-/* ARM CMSIS definitions must be included before kernel_includes.h.
- * Therefore, it is essential to include kernel_includes.h after including
- * core SOC-specific headers.
- */
-#include <kernel_includes.h>
-
 /* Add include for DTS generated information */
 #include <generated_dts_board.h>
 

--- a/arch/arm/soc/nordic_nrf/nrf52/mpu_mem_cfg.h
+++ b/arch/arm/soc/nordic_nrf/nrf52/mpu_mem_cfg.h
@@ -6,7 +6,6 @@
 #ifndef _NRF52X_MPU_MEM_CFG_H_
 #define _NRF52X_MPU_MEM_CFG_H_
 
-#include <soc.h>
 #include <arch/arm/cortex_m/mpu/arm_mpu.h>
 
 /* Flash Region Definitions */

--- a/arch/arm/soc/nordic_nrf/nrf52/mpu_regions.c
+++ b/arch/arm/soc/nordic_nrf/nrf52/mpu_regions.c
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <soc.h>
+#include <misc/slist.h>
 #include <arch/arm/cortex_m/mpu/arm_mpu.h>
 
 #include "mpu_mem_cfg.h"

--- a/arch/arm/soc/nordic_nrf/nrf52/soc.c
+++ b/arch/arm/soc/nordic_nrf/nrf52/soc.c
@@ -13,9 +13,7 @@
  */
 
 #include <kernel.h>
-#include <device.h>
 #include <init.h>
-#include <soc.h>
 #include <cortex_m/exc.h>
 
 #ifdef CONFIG_RUNTIME_NMI

--- a/arch/arm/soc/nordic_nrf/nrf52/soc.h
+++ b/arch/arm/soc/nordic_nrf/nrf52/soc.h
@@ -16,12 +16,6 @@
 #include <nrf_common.h>
 #include <nrf.h>
 
-/* ARM CMSIS definitions must be included before kernel_includes.h.
- * Therefore, it is essential to include kernel_includes.h after including
- * core SOC-specific headers.
- */
-#include <kernel_includes.h>
-
 /* Add include for DTS generated information */
 #include <generated_dts_board.h>
 

--- a/subsys/bluetooth/controller/hal/nrf5/cntr.c
+++ b/subsys/bluetooth/controller/hal/nrf5/cntr.c
@@ -5,7 +5,9 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <soc.h>
+#include <misc/dlist.h>
+#include <misc/mempool_base.h>
+
 #include "hal/cntr.h"
 
 #include "common/log.h"

--- a/subsys/bluetooth/controller/hal/nrf5/ecb.c
+++ b/subsys/bluetooth/controller/hal/nrf5/ecb.c
@@ -6,7 +6,9 @@
  */
 
 #include <string.h>
-#include <soc.h>
+
+#include <misc/dlist.h>
+#include <misc/mempool_base.h>
 
 #include "util/mem.h"
 #include "hal/ecb.h"

--- a/subsys/bluetooth/controller/hal/nrf5/radio/radio.c
+++ b/subsys/bluetooth/controller/hal/nrf5/radio/radio.c
@@ -4,7 +4,10 @@
  *
  * SPDX-License-Identifier: Apache-2.0
  */
-#include <soc.h>
+
+#include <misc/dlist.h>
+#include <misc/mempool_base.h>
+#include <toolchain.h>
 
 #include "util/mem.h"
 #include "hal/ccm.h"

--- a/subsys/bluetooth/controller/hal/nrf5/ticker.c
+++ b/subsys/bluetooth/controller/hal/nrf5/ticker.c
@@ -6,8 +6,8 @@
  */
 
 #include <stdbool.h>
-
-#include <zephyr/types.h>
+#include <misc/dlist.h>
+#include <misc/mempool_base.h>
 
 #include "hal/cntr.h"
 

--- a/subsys/bluetooth/controller/hal/ticker.h
+++ b/subsys/bluetooth/controller/hal/ticker.h
@@ -5,6 +5,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+#include <stdbool.h>
+
 #if defined(CONFIG_SOC_FAMILY_NRF)
 #include "hal/nrf5/ticker.h"
 #endif /* CONFIG_SOC_FAMILY_NRF */


### PR DESCRIPTION
This pull-request attempts to eliminate inclusion cycles in Zephyr builds for nRF SOCs, due to `soc.h` including `kernel_includes.h` 
- cycles are formed as kernel_includes.h ends up including soc.h again, via arch.h, arm_mpu.h etc.
- cycles imposed restrictions on inclusion order (see #8629)

We want to get rid of the above. From now own, including `soc.h` shall **only** bring in HAL definitions specific to the SOC, including CMSIS.

Ideally, this clean-up should be done in all SOCs.

Note, that by removing kernel_includes.h, several source files (particularly in the BLE nRF subsystem) needed to explicitly include kernel-util headers.