### PR TITLE
samples: mesh/onoff_level_lighting_vnd_app: corrected state binding & overall architecture 

### DIFF
--- a/samples/boards/nrf52/mesh/onoff_level_lighting_vnd_app/src/mesh/device_composition.c
+++ b/samples/boards/nrf52/mesh/onoff_level_lighting_vnd_app/src/mesh/device_composition.c
@@ -41,28 +41,28 @@ static struct bt_mesh_health_srv health_srv = {
 BT_MESH_HEALTH_PUB_DEFINE(health_pub, 0);
 
 /* Definitions of models publication context (Start) */
-BT_MESH_MODEL_PUB_DEFINE(gen_onoff_srv_pub_root, NULL, 2 + 2);
-BT_MESH_MODEL_PUB_DEFINE(gen_onoff_cli_pub_root, NULL, 2 + 2);
+BT_MESH_MODEL_PUB_DEFINE(gen_onoff_srv_pub_root, NULL, 3);
+BT_MESH_MODEL_PUB_DEFINE(gen_onoff_cli_pub_root, NULL, 4);
 
-BT_MESH_MODEL_PUB_DEFINE(gen_level_srv_pub_root, NULL, 2 + 2);
-BT_MESH_MODEL_PUB_DEFINE(gen_level_cli_pub_root, NULL, 2 + 4);
+BT_MESH_MODEL_PUB_DEFINE(gen_level_srv_pub_root, NULL, 5);
+BT_MESH_MODEL_PUB_DEFINE(gen_level_cli_pub_root, NULL, 7);
 
-BT_MESH_MODEL_PUB_DEFINE(gen_power_onoff_srv_pub, NULL, 2 + 2);
-BT_MESH_MODEL_PUB_DEFINE(gen_power_onoff_cli_pub, NULL, 2 + 2);
+BT_MESH_MODEL_PUB_DEFINE(gen_power_onoff_srv_pub, NULL, 1);
+BT_MESH_MODEL_PUB_DEFINE(gen_power_onoff_cli_pub, NULL, 1);
 
-BT_MESH_MODEL_PUB_DEFINE(light_lightness_srv_pub, NULL, 2 + 5);
-BT_MESH_MODEL_PUB_DEFINE(light_lightness_cli_pub, NULL, 2 + 2);
+BT_MESH_MODEL_PUB_DEFINE(light_lightness_srv_pub, NULL, 5);
+BT_MESH_MODEL_PUB_DEFINE(light_lightness_cli_pub, NULL, 5);
 
-BT_MESH_MODEL_PUB_DEFINE(light_ctl_srv_pub, NULL, 2 + 6);
-BT_MESH_MODEL_PUB_DEFINE(light_ctl_cli_pub, NULL, 2 + 4);
+BT_MESH_MODEL_PUB_DEFINE(light_ctl_srv_pub, NULL, 9);
+BT_MESH_MODEL_PUB_DEFINE(light_ctl_cli_pub, NULL, 9);
 
-BT_MESH_MODEL_PUB_DEFINE(vnd_pub, NULL, 2 + 2);
+BT_MESH_MODEL_PUB_DEFINE(vnd_pub, NULL, 2);
 
-BT_MESH_MODEL_PUB_DEFINE(gen_onoff_srv_pub_s0, NULL, 2 + 2);
-BT_MESH_MODEL_PUB_DEFINE(gen_onoff_cli_pub_s0, NULL, 2 + 2);
+BT_MESH_MODEL_PUB_DEFINE(gen_onoff_srv_pub_s0, NULL, 3);
+BT_MESH_MODEL_PUB_DEFINE(gen_onoff_cli_pub_s0, NULL, 4);
 
-BT_MESH_MODEL_PUB_DEFINE(gen_level_srv_pub_s0, NULL, 2 + 2);
-BT_MESH_MODEL_PUB_DEFINE(gen_level_cli_pub_s0, NULL, 2 + 2 + 2);
+BT_MESH_MODEL_PUB_DEFINE(gen_level_srv_pub_s0, NULL, 5);
+BT_MESH_MODEL_PUB_DEFINE(gen_level_cli_pub_s0, NULL, 7);
 /* Definitions of models publication context (End) */
 
 /* Definitions of models user data (Start) */


### PR DESCRIPTION
Update models publication message lengths as per Mesh Model
Specification. Fixed bug in binding of Light Lightness Actual
state & Generic Level state of Root Element. Update message
handlers & correct number of bytes that every handlers should
consider for their further processing as per Bluetooth SIG Mesh
Model Specification. Removed TID implementations wherever it is
not required as per Bluetooth SIG Mesh Model Specification.
Removed unnecessary comments. Add status code value to get publish
along with Light Lightness range status message.