### PR TITLE
drivers: entropy: stm32: add support for STM32F7

### DIFF
--- a/arch/arm/soc/st_stm32/stm32f7/Kconfig.defconfig.series
+++ b/arch/arm/soc/st_stm32/stm32f7/Kconfig.defconfig.series
@@ -28,4 +28,11 @@ config GPIO_STM32_PORTI
 
 endif # GPIO_STM32
 
+if ENTROPY_GENERATOR
+
+config ENTROPY_STM32_RNG
+	def_bool y
+
+endif # ENTROPY_GENERATOR
+
 endif # SOC_SERIES_STM32F7X

--- a/arch/arm/soc/st_stm32/stm32f7/soc.h
+++ b/arch/arm/soc/st_stm32/stm32f7/soc.h
@@ -42,6 +42,10 @@
 #include <stm32f7xx_ll_usart.h>
 #endif
 
+#ifdef CONFIG_ENTROPY_STM32_RNG
+#include <stm32f7xx_ll_rng.h>
+#endif
+
 #endif /* !_ASMLANGUAGE */
 
 #endif /* _STM32F7_SOC_H_ */

--- a/drivers/entropy/Kconfig.stm32
+++ b/drivers/entropy/Kconfig.stm32
@@ -14,4 +14,5 @@ menuconfig ENTROPY_STM32_RNG
 	help
 	  This option enables the RNG processor, which is a entropy number
 	  generator, based on a continuous analog noise, that provides
-	  a entropy 32-bit value to the host when read.
+	  a entropy 32-bit value to the host when read. It is available for
+	  F4 (except STM32F401 & STM32F411), L4 and F7 series.

--- a/drivers/entropy/entropy_stm32.c
+++ b/drivers/entropy/entropy_stm32.c
@@ -17,8 +17,8 @@
 #include <clock_control.h>
 #include <clock_control/stm32_clock_control.h>
 
-#if !defined(CONFIG_SOC_SERIES_STM32L4X) && !defined(CONFIG_SOC_SERIES_STM32F4X)
-#error RNG only available on STM32F4 and STM32L4 series
+#if !defined(CONFIG_SOC_SERIES_STM32L4X) && !defined(CONFIG_SOC_SERIES_STM32F4X) && !defined(CONFIG_SOC_SERIES_STM32F7X)
+#error RNG only available on STM32F4, STM32F7 and STM32L4 series
 #elif defined(CONFIG_SOC_STM32F401XE)
 #error RNG not available on STM32F401 based SoCs
 #elif defined(CONFIG_SOC_STM32F411XE)


### PR DESCRIPTION
All the STM32F7 SoCs have a TRNG. Adding support for it is just a matter
of tweaking the #ifdef and including the right file from HAL.

Signed-off-by: Aurelien Jarno <aurelien@aurel32.net>