### PR TITLE
boards: disco_l475_iot1: Move BT_SPI_BLUENRG selection to avoid warning

### DIFF
--- a/boards/arm/disco_l475_iot1/Kconfig.defconfig
+++ b/boards/arm/disco_l475_iot1/Kconfig.defconfig
@@ -116,6 +116,9 @@ choice BT_HCI_BUS_TYPE
 	default BT_SPI
 endchoice
 
+config BT_SPI_BLUENRG
+	default y
+
 config BT_BLUENRG_ACI
 	default y
 # Disable Flow control

--- a/boards/arm/disco_l475_iot1/disco_l475_iot1_defconfig
+++ b/boards/arm/disco_l475_iot1/disco_l475_iot1_defconfig
@@ -39,9 +39,6 @@ CONFIG_I2C=y
 # enable SPI
 CONFIG_SPI=y
 
-# bluetooth
-CONFIG_BT_SPI_BLUENRG=y
-
 # sensors configuration
 CONFIG_LIS3MDL_TRIGGER_NONE=y
 CONFIG_HTS221_TRIGGER_NONE=y


### PR DESCRIPTION
Unconditional CONFIG_BT_SPI_BLUENRG flag activation was generating
a systematic warning.
Move it in Kconfig.defconfig file to avoid the warning

Signed-off-by: Erwan Gouriou <erwan.gouriou@linaro.org>