### PR TITLE
samples: mesh/onoff_level_lighting_vnd_app: corrected state binding & overall architecture

### DIFF
--- a/samples/boards/nrf52/mesh/onoff_level_lighting_vnd_app/src/mesh/device_composition.c
+++ b/samples/boards/nrf52/mesh/onoff_level_lighting_vnd_app/src/mesh/device_composition.c
@@ -41,28 +41,28 @@ static struct bt_mesh_health_srv health_srv = {
 BT_MESH_HEALTH_PUB_DEFINE(health_pub, 0);
 
 /* Definitions of models publication context (Start) */
-BT_MESH_MODEL_PUB_DEFINE(gen_onoff_srv_pub_root, NULL, 2 + 2);
-BT_MESH_MODEL_PUB_DEFINE(gen_onoff_cli_pub_root, NULL, 2 + 2);
+BT_MESH_MODEL_PUB_DEFINE(gen_onoff_srv_pub_root, NULL, 2 + 3);
+BT_MESH_MODEL_PUB_DEFINE(gen_onoff_cli_pub_root, NULL, 2 + 4);
 
-BT_MESH_MODEL_PUB_DEFINE(gen_level_srv_pub_root, NULL, 2 + 2);
-BT_MESH_MODEL_PUB_DEFINE(gen_level_cli_pub_root, NULL, 2 + 4);
+BT_MESH_MODEL_PUB_DEFINE(gen_level_srv_pub_root, NULL, 2 + 5);
+BT_MESH_MODEL_PUB_DEFINE(gen_level_cli_pub_root, NULL, 2 + 7);
 
-BT_MESH_MODEL_PUB_DEFINE(gen_power_onoff_srv_pub, NULL, 2 + 2);
-BT_MESH_MODEL_PUB_DEFINE(gen_power_onoff_cli_pub, NULL, 2 + 2);
+BT_MESH_MODEL_PUB_DEFINE(gen_power_onoff_srv_pub, NULL, 2 + 1);
+BT_MESH_MODEL_PUB_DEFINE(gen_power_onoff_cli_pub, NULL, 2 + 1);
 
 BT_MESH_MODEL_PUB_DEFINE(light_lightness_srv_pub, NULL, 2 + 5);
-BT_MESH_MODEL_PUB_DEFINE(light_lightness_cli_pub, NULL, 2 + 2);
+BT_MESH_MODEL_PUB_DEFINE(light_lightness_cli_pub, NULL, 2 + 5);
 
-BT_MESH_MODEL_PUB_DEFINE(light_ctl_srv_pub, NULL, 2 + 6);
-BT_MESH_MODEL_PUB_DEFINE(light_ctl_cli_pub, NULL, 2 + 4);
+BT_MESH_MODEL_PUB_DEFINE(light_ctl_srv_pub, NULL, 2 + 9);
+BT_MESH_MODEL_PUB_DEFINE(light_ctl_cli_pub, NULL, 2 + 9);
 
-BT_MESH_MODEL_PUB_DEFINE(vnd_pub, NULL, 2 + 2);
+BT_MESH_MODEL_PUB_DEFINE(vnd_pub, NULL, 3 + 2);
 
-BT_MESH_MODEL_PUB_DEFINE(gen_onoff_srv_pub_s0, NULL, 2 + 2);
-BT_MESH_MODEL_PUB_DEFINE(gen_onoff_cli_pub_s0, NULL, 2 + 2);
+BT_MESH_MODEL_PUB_DEFINE(gen_onoff_srv_pub_s0, NULL, 2 + 3);
+BT_MESH_MODEL_PUB_DEFINE(gen_onoff_cli_pub_s0, NULL, 2 + 4);
 
-BT_MESH_MODEL_PUB_DEFINE(gen_level_srv_pub_s0, NULL, 2 + 2);
-BT_MESH_MODEL_PUB_DEFINE(gen_level_cli_pub_s0, NULL, 2 + 2 + 2);
+BT_MESH_MODEL_PUB_DEFINE(gen_level_srv_pub_s0, NULL, 2 + 5);
+BT_MESH_MODEL_PUB_DEFINE(gen_level_cli_pub_s0, NULL, 2 + 7);
 /* Definitions of models publication context (End) */
 
 /* Definitions of models user data (Start) */

--- a/samples/boards/nrf52/mesh/onoff_level_lighting_vnd_app/src/mesh/device_composition.c
+++ b/samples/boards/nrf52/mesh/onoff_level_lighting_vnd_app/src/mesh/device_composition.c
@@ -1335,20 +1335,20 @@ static const struct bt_mesh_model_op gen_level_cli_op[] = {
 
 /* Mapping of message handlers for Generic Power OnOff Server (0x1006) */
 static const struct bt_mesh_model_op gen_power_onoff_srv_op[] = {
-	{ BT_MESH_MODEL_OP_2(0x82, 0x11), 2, gen_onpowerup_get },
+	{ BT_MESH_MODEL_OP_2(0x82, 0x11), 0, gen_onpowerup_get },
 	BT_MESH_MODEL_OP_END,
 };
 
 /* Mapping of message handlers for Generic Power OnOff Setup Server (0x1007) */
 static const struct bt_mesh_model_op gen_power_onoff_setup_srv_op[] = {
-	{ BT_MESH_MODEL_OP_2(0x82, 0x13), 2, gen_onpowerup_set },
-	{ BT_MESH_MODEL_OP_2(0x82, 0x14), 2, gen_onpowerup_set_unack },
+	{ BT_MESH_MODEL_OP_2(0x82, 0x13), 1, gen_onpowerup_set },
+	{ BT_MESH_MODEL_OP_2(0x82, 0x14), 1, gen_onpowerup_set_unack },
 	BT_MESH_MODEL_OP_END,
 };
 
 /* Mapping of message handlers for Generic Power OnOff Client (0x1008) */
 static const struct bt_mesh_model_op gen_power_onoff_cli_op[] = {
-	{ BT_MESH_MODEL_OP_2(0x82, 0x12), 2, gen_onpowerup_status },
+	{ BT_MESH_MODEL_OP_2(0x82, 0x12), 1, gen_onpowerup_status },
 	BT_MESH_MODEL_OP_END,
 };
 
@@ -1411,7 +1411,7 @@ static const struct bt_mesh_model_op light_ctl_cli_op[] = {
 	{ BT_MESH_MODEL_OP_2(0x82, 0x60), 4, light_ctl_status },
 	{ BT_MESH_MODEL_OP_2(0x82, 0x63), 5, light_ctl_temp_range_status },
 	{ BT_MESH_MODEL_OP_2(0x82, 0x66), 4, light_ctl_temp_status },
-	{ BT_MESH_MODEL_OP_2(0x82, 0x68), 4, light_ctl_default_status },
+	{ BT_MESH_MODEL_OP_2(0x82, 0x68), 6, light_ctl_default_status },
 	BT_MESH_MODEL_OP_END,
 };
 
@@ -1425,7 +1425,7 @@ static const struct bt_mesh_model_op light_ctl_temp_srv_op[] = {
 
 /* Mapping of message handlers for Vendor (0x4321) */
 static const struct bt_mesh_model_op vnd_ops[] = {
-	{ BT_MESH_MODEL_OP_3(0x00, CID_ZEPHYR), 0, vnd_msg_handler },
+	{ BT_MESH_MODEL_OP_3(0x00, CID_ZEPHYR), 2, vnd_msg_handler },
 	BT_MESH_MODEL_OP_END,
 };
 

--- a/samples/boards/nrf52/mesh/onoff_level_lighting_vnd_app/src/mesh/device_composition.c
+++ b/samples/boards/nrf52/mesh/onoff_level_lighting_vnd_app/src/mesh/device_composition.c
@@ -557,19 +557,13 @@ static void gen_onpowerup_set_unack(struct bt_mesh_model *model,
 				    struct bt_mesh_msg_ctx *ctx,
 				    struct net_buf_simple *buf)
 {
-	u8_t tid, tmp8;
+	u8_t tmp8;
 	struct net_buf_simple *msg = model->pub->msg;
 	struct generic_onpowerup_state *state = model->user_data;
 
 	tmp8 = net_buf_simple_pull_u8(buf);
-	tid = net_buf_simple_pull_u8(buf);
 
-	if (state->last_tid == tid && state->last_tx_addr == ctx->addr) {
-		return;
-	}
-
-	state->last_tid = tid;
-	state->last_tx_addr = ctx->addr;
+	/* Here, Model specification is silent about tid implementation */
 
 	if (tmp8 > 0x02) {
 		return;
@@ -807,19 +801,12 @@ static void light_lightness_default_set_unack(struct bt_mesh_model *model,
 					      struct bt_mesh_msg_ctx *ctx,
 					      struct net_buf_simple *buf)
 {
-	u8_t tid;
 	struct net_buf_simple *msg = model->pub->msg;
 	struct light_lightness_state *state = model->user_data;
 
 	state->def = net_buf_simple_pull_le16(buf);
-	tid = net_buf_simple_pull_u8(buf);
 
-	if (state->last_tid == tid && state->last_tx_addr == ctx->addr) {
-		return;
-	}
-
-	state->last_tid = tid;
-	state->last_tx_addr = ctx->addr;
+	/* Here, Model specification is silent about tid implementation */
 
 	/* Do some work here to save value of state->def on SoC flash */
 
@@ -850,25 +837,13 @@ static void light_lightness_range_set_unack(struct bt_mesh_model *model,
 					    struct bt_mesh_msg_ctx *ctx,
 					    struct net_buf_simple *buf)
 {
-	/* u8_t tid; */
 	struct net_buf_simple *msg = model->pub->msg;
 	struct light_lightness_state *state = model->user_data;
 
 	state->lightness_range_min = net_buf_simple_pull_le16(buf);
 	state->lightness_range_max = net_buf_simple_pull_le16(buf);
 
-	/* Here, Model specification is silent about tid implementation.
-	 *
-	 * tid = net_buf_simple_pull_u8(buf);
-	 *
-	 * if (state->last_tid == tid && state->last_tx_addr == ctx->addr) {
-	 *	return;
-	 * }
-	 *
-	 * state->last_tid = tid;
-	 * state->last_tx_addr = ctx->addr;
-	 *
-	 */
+	/* Here, Model specification is silent about tid implementation */
 
 	/* Do some work here to save values of
 	 * state->lightness_range_min & state->lightness_range_max
@@ -881,6 +856,7 @@ static void light_lightness_range_set_unack(struct bt_mesh_model *model,
 		bt_mesh_model_msg_init(msg,
 				       BT_MESH_MODEL_OP_2(0x82, 0x58));
 
+		net_buf_simple_add_u8(msg, state->status_code);
 		net_buf_simple_add_le16(msg, state->lightness_range_min);
 		net_buf_simple_add_le16(msg, state->lightness_range_max);
 
@@ -936,7 +912,10 @@ static void light_lightness_range_status(struct bt_mesh_model *model,
 					 struct bt_mesh_msg_ctx *ctx,
 					 struct net_buf_simple *buf)
 {
-	printk("Acknownledgement from LIGHT_LIGHTNESS_SRV (range_min) = %04x",
+	printk("Acknownledgement from LIGHT_LIGHTNESS_SRV (status code) = %02x",
+	       net_buf_simple_pull_u8(buf));
+
+	printk("  (range_min) = %04x",
 	       net_buf_simple_pull_le16(buf));
 
 	printk("  (range_max) = %04x\n",
@@ -1061,7 +1040,6 @@ static void light_ctl_default_set_unack(struct bt_mesh_model *model,
 					struct bt_mesh_msg_ctx *ctx,
 					struct net_buf_simple *buf)
 {
-	/* u8_t tid; */
 	u16_t tmp16;
 	struct net_buf_simple *msg = model->pub->msg;
 	struct light_ctl_state *state = model->user_data;
@@ -1114,7 +1092,6 @@ static void light_ctl_temp_range_set_unack(struct bt_mesh_model *model,
 					   struct bt_mesh_msg_ctx *ctx,
 					   struct net_buf_simple *buf)
 {
-	/* u8_t tid; */
 	u16_t tmp[2];
 	struct net_buf_simple *msg = model->pub->msg;
 	struct light_ctl_state *state = model->user_data;
@@ -1182,7 +1159,10 @@ static void light_ctl_temp_range_status(struct bt_mesh_model *model,
 					struct bt_mesh_msg_ctx *ctx,
 					struct net_buf_simple *buf)
 {
-	printk("Acknownledgement from LIGHT_CTL_SRV (temp_range_min) = %04x",
+	printk("Acknownledgement from LIGHT_CTL_SRV (status code) = %02x",
+	       net_buf_simple_pull_u8(buf));
+
+	printk("  (temp_range_min) = %04x",
 	       net_buf_simple_pull_le16(buf));
 
 	printk("  (temp_range_max) = %04x\n",

--- a/samples/boards/nrf52/mesh/onoff_level_lighting_vnd_app/src/mesh/device_composition.c
+++ b/samples/boards/nrf52/mesh/onoff_level_lighting_vnd_app/src/mesh/device_composition.c
@@ -127,9 +127,6 @@ static void state_binding(u8_t lightness, u8_t temperature)
 			light_lightness_srv_user_data.actual = 0;
 			light_lightness_srv_user_data.linear = 0;
 		} else if (gen_onoff_srv_root_user_data.onoff == 0x01) {
-			gen_level_srv_root_user_data.level =
-				light_lightness_srv_user_data.actual - 32768;
-
 			tmp = ((float)
 			       light_lightness_srv_user_data.actual / 65535);
 			light_lightness_srv_user_data.linear =
@@ -152,9 +149,6 @@ static void state_binding(u8_t lightness, u8_t temperature)
 					light_lightness_srv_user_data.def;
 			}
 
-			gen_level_srv_root_user_data.level =
-				light_lightness_srv_user_data.actual - 32768;
-
 			tmp = ((float)
 			       light_lightness_srv_user_data.actual / 65535);
 			light_lightness_srv_user_data.linear =
@@ -176,9 +170,6 @@ static void state_binding(u8_t lightness, u8_t temperature)
 			light_lightness_srv_user_data.actual;
 		break;
 	case ACTUAL: /* Lightness update as per Light Lightness Actual state */
-		gen_level_srv_root_user_data.level =
-			light_lightness_srv_user_data.actual - 32768;
-
 		tmp = ((float) light_lightness_srv_user_data.actual / 65535);
 		light_lightness_srv_user_data.linear =
 			(u16_t) (65535 * tmp * tmp);
@@ -192,18 +183,12 @@ static void state_binding(u8_t lightness, u8_t temperature)
 			sqrt(((float) light_lightness_srv_user_data.linear /
 			      65535));
 
-		gen_level_srv_root_user_data.level =
-			light_lightness_srv_user_data.actual - 32768;
-
 		light_lightness_srv_user_data.last =
 			light_lightness_srv_user_data.actual;
 		break;
 	case CTL: /* Lightness update as per Light CTL Lightness state */
 		light_lightness_srv_user_data.actual =
 			light_ctl_srv_user_data.lightness;
-
-		gen_level_srv_root_user_data.level =
-			light_lightness_srv_user_data.actual - 32768;
 
 		tmp = ((float) light_lightness_srv_user_data.actual / 65535);
 		light_lightness_srv_user_data.linear =
@@ -215,6 +200,9 @@ static void state_binding(u8_t lightness, u8_t temperature)
 	default:
 		break;
 	}
+
+	gen_level_srv_root_user_data.level =
+		light_lightness_srv_user_data.actual - 32768;
 
 	light_ctl_srv_user_data.lightness =
 		light_lightness_srv_user_data.actual;


### PR DESCRIPTION
Update models publication message lengths as per Mesh Model
Specification. Fixed bug in binding of Light Lightness Actual
state & Generic Level state of Root Element. Update message
handlers & correct number of bytes that every handlers should
consider for their further processing as per Bluetooth SIG Mesh
Model Specification. Removed TID implementations wherever it is
not required as per Bluetooth SIG Mesh Model Specification.
Removed unnecessary comments. Add status code value to get publish
along with Light Lightness range status message.