### PR TITLE
tests: net: tcp: Use correct network interface for sending

### DIFF
--- a/tests/net/tcp/src/main.c
+++ b/tests/net/tcp/src/main.c
@@ -60,6 +60,9 @@ static struct in_addr peer_v4_inaddr = { { { 192, 0, 2, 250 } } };
 static struct sockaddr_in my_v4_addr;
 static struct sockaddr_in peer_v4_addr;
 
+static struct net_if *my_iface;
+static struct net_if *peer_iface;
+
 #define NET_TCP_HDR(pkt)  net_pkt_tcp_data(pkt)
 
 #define MY_TCP_PORT 5545
@@ -568,7 +571,7 @@ static void set_port(sa_family_t family, struct sockaddr *raddr,
 static bool test_register(void)
 {
 	struct net_conn_handle *handlers[CONFIG_NET_MAX_CONN];
-	struct net_if *iface = net_if_get_default();
+	struct net_if *iface = my_iface;
 	struct net_if_addr *ifaddr;
 	struct ud *ud;
 	int ret, i = 0;
@@ -1330,14 +1333,9 @@ NET_DEVICE_INIT_INSTANCE(net_tcp_test_peer, "net_tcp_test_peer", peer,
 
 static bool test_init_tcp_context(void)
 {
-	struct net_if *iface = net_if_get_default();
+	struct net_if *iface = my_iface;
 	struct net_if_addr *ifaddr;
 	int ret;
-
-	if (!iface) {
-		TC_ERROR("Interface is NULL\n");
-		return false;
-	}
 
 	ifaddr = net_if_ipv6_addr_add(iface, &my_v6_inaddr,
 				      NET_ADDR_MANUAL, 0);
@@ -1474,7 +1472,7 @@ static bool test_tcp_seq_validity(void)
 
 static bool test_init_tcp_reply_context(void)
 {
-	struct net_if *iface = net_if_get_default() + 1;
+	struct net_if *iface = peer_iface;
 	struct net_if_addr *ifaddr;
 	int ret;
 
@@ -1660,13 +1658,34 @@ static bool test_init_tcp_connect(void)
 
 static bool test_init(void)
 {
-	struct net_if_addr *ifaddr;
 	struct net_if *iface = net_if_get_default();
+	struct net_if_addr *ifaddr;
+	const struct net_if_api *api;
 
 	if (!iface) {
 		TC_ERROR("Interface is NULL\n");
 		return false;
 	}
+
+	/* Make sure that we always use the correct network interface when
+	 * simulating the local and peer devices. To do this, we check what
+	 * device API corresponds to what network interface sending function.
+	 * This way we can use the correct network interface to set the IP
+	 * addresses etc.
+	 * The network interfaces might be set in different order depending on
+	 * used target board and linker. We cannot guarantee that network
+	 * interfaces are always set the same way in the linker section.
+	 */
+	api = net_if_get_device(iface)->driver_api;
+	if (api->send != tester_send) {
+		my_iface = iface + 1;
+		peer_iface = iface;
+	} else {
+		my_iface = iface;
+		peer_iface = iface + 1;
+	}
+
+	iface = my_iface;
 
 	ifaddr = net_if_ipv6_addr_add(iface, &my_v6_inaddr,
 				      NET_ADDR_MANUAL, 0);


### PR DESCRIPTION
The test app creates two network interfaces, one for simulating
local device and the other one for peer device. Make sure that
the tests use correct network interface in each test. We cannot
guarantee that net_if_get_default() will always return correct
interface in different architectures as that depends how the
net_if structs are placed in corresponding linker section.

Signed-off-by: Jukka Rissanen <jukka.rissanen@linux.intel.com>