### PR TITLE
syscalls: Scan multiple folders to build complete syscall list

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -430,13 +430,20 @@ else()
   set_property(DIRECTORY APPEND PROPERTY CMAKE_CONFIGURE_DEPENDS ${syscalls_subdirs_txt})
 endif()
 
+# SYSCALL_INCLUDE_DIRECTORY will include the directories that needs to be
+# searched for syscall declarations if CONFIG_APPLICATION_DEFINED_SYSCALL is set
+if(CONFIG_APPLICATION_DEFINED_SYSCALL)
+  set(SYSCALL_INCLUDE_DIRECTORY --include ${APPLICATION_SOURCE_DIR})
+endif()
+
 add_custom_command(
   OUTPUT
   ${syscalls_json}
   COMMAND
   ${PYTHON_EXECUTABLE}
   ${ZEPHYR_BASE}/scripts/parse_syscalls.py
-  --include          ${ZEPHYR_BASE}/include        # Read files from this dir
+   --include          ${ZEPHYR_BASE}/include        # Read files from this dir
+  ${SYSCALL_INCLUDE_DIRECTORY}
   --json-file        ${syscalls_json}              # Write this file
   DEPENDS ${syscalls_subdirs_trigger} ${PARSE_SYSCALLS_HEADER_DEPENDS}
   )

--- a/misc/Kconfig
+++ b/misc/Kconfig
@@ -249,6 +249,13 @@ config BUILD_OUTPUT_STRIPPED
 	  Build a stripped binary. This will build a zephyr.stripped file need
 	  by some platforms.
 
+config APPLICATION_DEFINED_SYSCALL
+	bool "Scan application folder for any syscall definition"
+	default n
+	help
+	  Scan additional folders inside application source folder
+	  for application defined syscalls.
+
 endmenu
 endmenu
 

--- a/scripts/parse_syscalls.py
+++ b/scripts/parse_syscalls.py
@@ -94,27 +94,28 @@ def analyze_fn(match_group, fn):
     return (fn, handler, invocation, sys_id, table_entry)
 
 
-def analyze_headers(base_path):
+def analyze_headers(multiple_directories):
     ret = []
 
-    for root, dirs, files in os.walk(base_path):
-        for fn in files:
+    for base_path in multiple_directories:
+        for root, dirs, files in os.walk(base_path):
+            for fn in files:
 
-            # toolchain/common.h has the definition of __syscall which we
-            # don't want to trip over
-            path = os.path.join(root, fn)
-            if not fn.endswith(".h") or path.endswith(os.path.join(os.sep, 'toolchain', 'common.h')):
-                continue
+                # toolchain/common.h has the definition of __syscall which we
+                # don't want to trip over
+                path = os.path.join(root, fn)
+                if not fn.endswith(".h") or path.endswith(os.path.join(os.sep, 'toolchain', 'common.h')):
+                    continue
 
-            with open(path, "r", encoding="utf-8") as fp:
-                try:
-                    result = [analyze_fn(mo.groups(), fn)
-                              for mo in api_regex.finditer(fp.read())]
-                except Exception:
-                    sys.stderr.write("While parsing %s\n" % fn)
-                    raise
+                with open(path, "r", encoding="utf-8") as fp:
+                    try:
+                        result = [analyze_fn(mo.groups(), fn)
+                                  for mo in api_regex.finditer(fp.read())]
+                    except Exception:
+                        sys.stderr.write("While parsing %s\n" % fn)
+                        raise
 
-            ret.extend(result)
+                    ret.extend(result)
 
     return ret
 
@@ -125,7 +126,7 @@ def parse_args():
         description=__doc__,
         formatter_class=argparse.RawDescriptionHelpFormatter)
 
-    parser.add_argument("-i", "--include", required=True,
+    parser.add_argument("-i", "--include", required=True, action='append',
                         help="Base include directory")
     parser.add_argument(
         "-j", "--json-file", required=True,


### PR DESCRIPTION
    Previously the syscall list was generated only from the include
    folder. This is a limitation when the application tries to create
    system calls. This patch create a simple way to include these
    new syscalls without the application touching the kernel.

    This can be enabled by a Kconfig CONFIG_APPLICATION_DEFINED_SYSCALL.
    Once enabled the application source directory will be scanned to
    find all application defined syscalls.


Signed-off-by: Adithya Baglody <adithya.nagaraj.baglody@intel.com>