### PR TITLE
doc: punctuation error

### DIFF
--- a/doc/devices/dts/device_tree.rst
+++ b/doc/devices/dts/device_tree.rst
@@ -228,7 +228,7 @@ The following is a more precise list of required files:
   * Board .dts file should specify the SRAM and FLASH devices, if present.
 
     * Flash device node might specify flash partitions. For more details see
-      :ref:'flash_partitions'
+      :ref:`flash_partitions`
 
   * Add board-specific YAML files, if required.  This would occur if the
     board has additional hardware that is not covered by the SoC family


### PR DESCRIPTION
fix the error in the doc. change ' to `.