### PR TITLE
arch: arm: nrf: Enable SEGGER RTT on all Nordic SoCs.

### DIFF
--- a/arch/arm/soc/nordic_nrf/nrf51/Kconfig.series
+++ b/arch/arm/soc/nordic_nrf/nrf51/Kconfig.series
@@ -17,5 +17,6 @@ config  SOC_SERIES_NRF51X
 	select XIP
 	select HAS_CMSIS
 	select HAS_NRFX
+	select HAS_SEGGER_RTT
 	help
 	  Enable support for NRF51 MCU series

--- a/arch/arm/soc/nordic_nrf/nrf52/Kconfig.series
+++ b/arch/arm/soc/nordic_nrf/nrf52/Kconfig.series
@@ -18,5 +18,6 @@ config  SOC_SERIES_NRF52X
 	select XIP
 	select HAS_CMSIS
 	select HAS_NRFX
+	select HAS_SEGGER_RTT
 	help
 	 Enable support for NRF52 MCU series

--- a/arch/arm/soc/nordic_nrf/nrf52/Kconfig.soc
+++ b/arch/arm/soc/nordic_nrf/nrf52/Kconfig.soc
@@ -183,17 +183,14 @@ depends on SOC_SERIES_NRF52X
 config SOC_NRF52810_QFAA
 	bool "NRF52810_QFAA"
 	select SOC_NRF52810
-	select HAS_SEGGER_RTT
 
 config SOC_NRF52832_QFAA
 	bool "NRF52832_QFAA"
 	select SOC_NRF52832
-	select HAS_SEGGER_RTT
 
 config SOC_NRF52840_QIAA
 	bool "NRF52840_QIAA"
 	select SOC_NRF52840
-	select HAS_SEGGER_RTT
 
 endchoice
 

--- a/samples/subsys/debug/sysview/sample.yaml
+++ b/samples/subsys/debug/sysview/sample.yaml
@@ -4,7 +4,7 @@ tests:
   test:
     filter: CONFIG_HAS_SEGGER_RTT
     tags: debug tracing
-    min_ram: 13
+    min_ram: 18
     harness: console
     harness_config:
       type: one_line


### PR DESCRIPTION
All chips from nRF51 and nRF52 series supports Segger RTT,
so we can enable it if given series is used.

Signed-off-by: Piotr Zięcik <piotr.ziecik@nordicsemi.no>