### PR TITLE
eth: mcux: Add an option for randomized, but stable MAC address

### DIFF
--- a/drivers/ethernet/Kconfig.mcux
+++ b/drivers/ethernet/Kconfig.mcux
@@ -70,14 +70,31 @@ config ETH_MCUX_0_IRQ_PRI
 	help
 	  IRQ priority
 
+choice ETH_MCUX_0_MAC_SELECT
+	prompt "MAC address"
+	help
+	  Choose how to configure MAC address.
+
+config ETH_MCUX_0_UNIQUE_MAC
+	bool "Stable MAC address"
+	help
+	  Generate MAC address from MCU's unique identification register.
+
 config ETH_MCUX_0_RANDOM_MAC
 	bool "Random MAC address"
-	depends on ETH_MCUX_0 && ENTROPY_GENERATOR
-	default y
 	help
-	  Generate a random MAC address dynamically.
+	  Generate a random MAC address dynamically on each reboot.
+	  Note that using this choice and rebooting a board may leave
+	  stale MAC address in peers' ARP caches and lead to issues and
+	  delays in communication. (Use "ip neigh flush all" on Linux
+	  peers to clear ARP cache.)
 
-if ETH_MCUX_0 && ! ETH_MCUX_0_RANDOM_MAC
+config ETH_MCUX_0_MANUAL_MAC
+	bool "Manual MAC address"
+
+endchoice
+
+if ETH_MCUX_0_MANUAL_MAC
 
 config ETH_MCUX_0_MAC3
 	hex "MAC Address Byte 3"

--- a/drivers/ethernet/eth_mcux.c
+++ b/drivers/ethernet/eth_mcux.c
@@ -563,6 +563,17 @@ static void generate_mac(u8_t *mac_addr)
 	/* Locally administered, unicast */
 	mac_addr[5] = ((entropy >> 0) & 0xfc) | 0x02;
 }
+#elif defined(CONFIG_ETH_MCUX_0_UNIQUE_MAC)
+static void generate_mac(u8_t *mac_addr)
+{
+	/* Trivially "hash" up to 128 bits of MCU unique identifier */
+	u32_t id = SIM->UIDH ^ SIM->UIDMH ^ SIM->UIDML ^ SIM->UIDL;
+
+	mac_addr[3] = id >> 8;
+	mac_addr[4] = id >> 16;
+	/* Locally administered, unicast */
+	mac_addr[5] = ((id >> 0) & 0xfc) | 0x02;
+}
 #endif
 
 static int eth_0_init(struct device *dev)
@@ -598,7 +609,8 @@ static int eth_0_init(struct device *dev)
 	enet_config.macSpecialConfig |= kENET_ControlPromiscuousEnable;
 #endif
 
-#if defined(CONFIG_ETH_MCUX_0_RANDOM_MAC)
+#if defined(CONFIG_ETH_MCUX_0_UNIQUE_MAC) || \
+    defined(CONFIG_ETH_MCUX_0_RANDOM_MAC)
 	generate_mac(context->mac_addr);
 #endif
 
@@ -717,7 +729,7 @@ static struct eth_context eth_0_context = {
 		0x00,
 		0x04,
 		0x9f,
-#if !defined(CONFIG_ETH_MCUX_0_RANDOM_MAC)
+#if defined(CONFIG_ETH_MCUX_0_MANUAL_MAC)
 		CONFIG_ETH_MCUX_0_MAC3,
 		CONFIG_ETH_MCUX_0_MAC4,
 		CONFIG_ETH_MCUX_0_MAC5


### PR DESCRIPTION
The previous default, CONFIG_ETH_MCUX_0_RANDOM_MAC, result in a random
MAC address changed each reboot. As reboots happen quite often during
development, while Ethernet peers usually cache existing MAC addresses
in ARP cache, this led to situation when a board after reboot didn't
respond to pings or any other connection attempts for random amount of
time (upo to 10-20s). This was quite confusing and looked like some
problem in driver/hardware/connection/whatever.

Instead, introduce new option, CONFIG_ETH_MCUX_0_UNIQUE_MAC, to make
MAC address from MCU unique identification register. This results in
randomized/unique MAC address which is also stable over reboots and
avoids the situation described above.

Fixes: #3187

Signed-off-by: Paul Sokolovsky <paul.sokolovsky@linaro.org>