### PR TITLE
net: Add bound checking in net_addr_pton()

### DIFF
--- a/subsys/net/ip/utils.c
+++ b/subsys/net/ip/utils.c
@@ -344,6 +344,10 @@ int net_addr_pton(sa_family_t family, const char *src,
 				if (*tmp == ':') {
 					i--;
 				}
+
+				if (i < 0) {
+					return -EINVAL;
+				}
 			} while (tmp-- != src);
 
 			src++;


### PR DESCRIPTION
In samples/net/rpl-mesh-qemu:
When I input : "net ping fe80::210:2030:9b:d48efe80::210:2030:9b:d48e " in the shell , the kernel panic.
I found there is an the issue in net_addr_pton() function. Fix it.

Signed-off-by: Walter Xie <41377148@qq.com>
