### PR TITLE
net: l2: update wifi mgmt to adapt non network offload wifi chip.

### DIFF
--- a/subsys/net/l2/wifi/wifi_mgmt.c
+++ b/subsys/net/l2/wifi/wifi_mgmt.c
@@ -18,6 +18,9 @@ static int wifi_connect(u32_t mgmt_request, struct net_if *iface,
 {
 	struct wifi_connect_req_params *params =
 		(struct wifi_connect_req_params *)data;
+	struct device *dev = net_if_get_device(iface);
+	struct net_wifi_mgmt_offload *off_api =
+		(struct net_wifi_mgmt_offload *) dev->driver_api;
 
 	NET_DBG("%s %u %u %u %s %u",
 		params->ssid, params->ssid_length,
@@ -36,15 +39,7 @@ static int wifi_connect(u32_t mgmt_request, struct net_if *iface,
 		return -EINVAL;
 	}
 
-	if (net_if_is_ip_offloaded(iface)) {
-		struct device *dev = net_if_get_device(iface);
-		struct net_wifi_mgmt_offload *off_api =
-			(struct net_wifi_mgmt_offload *) dev->driver_api;
-
-		return off_api->connect(dev, params);
-	}
-
-	return -ENETDOWN;
+	return off_api->connect(dev, params);
 }
 
 NET_MGMT_REGISTER_REQUEST_HANDLER(NET_REQUEST_WIFI_CONNECT, wifi_connect);
@@ -74,15 +69,11 @@ static void _scan_result_cb(struct net_if *iface, int status,
 static int wifi_scan(u32_t mgmt_request, struct net_if *iface,
 		     void *data, size_t len)
 {
-	if (net_if_is_ip_offloaded(iface)) {
-		struct device *dev = net_if_get_device(iface);
-		struct net_wifi_mgmt_offload *off_api =
-			(struct net_wifi_mgmt_offload *) dev->driver_api;
+	struct device *dev = net_if_get_device(iface);
+	struct net_wifi_mgmt_offload *off_api =
+		(struct net_wifi_mgmt_offload *) dev->driver_api;
 
-		return off_api->scan(dev, _scan_result_cb);
-	}
-
-	return -ENETDOWN;
+	return off_api->scan(dev, _scan_result_cb);
 }
 
 NET_MGMT_REGISTER_REQUEST_HANDLER(NET_REQUEST_WIFI_SCAN, wifi_scan);
@@ -91,15 +82,11 @@ NET_MGMT_REGISTER_REQUEST_HANDLER(NET_REQUEST_WIFI_SCAN, wifi_scan);
 static int wifi_disconnect(u32_t mgmt_request, struct net_if *iface,
 			   void *data, size_t len)
 {
-	if (net_if_is_ip_offloaded(iface)) {
-		struct device *dev = net_if_get_device(iface);
-		struct net_wifi_mgmt_offload *off_api =
-			(struct net_wifi_mgmt_offload *) dev->driver_api;
+	struct device *dev = net_if_get_device(iface);
+	struct net_wifi_mgmt_offload *off_api =
+		(struct net_wifi_mgmt_offload *) dev->driver_api;
 
-		return off_api->disconnect(dev);
-	}
-
-	return -ENETDOWN;
+	return off_api->disconnect(dev);
 }
 
 NET_MGMT_REGISTER_REQUEST_HANDLER(NET_REQUEST_WIFI_DISCONNECT, wifi_disconnect);


### PR DESCRIPTION
The wifi mgmt does only support TCP/IP offload wifi chip,
while non-offload wifi chip can not scan/connect to AP.

Signed-off-by: Dong Xiang <dong.xiang@unisoc.com>