### PR TITLE
usb: usb_descriptor: fix null pointer dereference

### DIFF
--- a/subsys/usb/usb_descriptor.c
+++ b/subsys/usb/usb_descriptor.c
@@ -354,6 +354,12 @@ static int usb_fix_descriptor(struct usb_desc_header *head)
 			if (str_descr_idx) {
 				ascii7_to_utf16le(head);
 			} else {
+				if (!cfg_descr) {
+					SYS_LOG_ERR("Incomplete device "
+						    "descriptor");
+					return -1;
+				}
+
 				SYS_LOG_DBG("Now the wTotalLength is %d",
 					    (u8_t *)head - (u8_t *)cfg_descr);
 				cfg_descr->wTotalLength =


### PR DESCRIPTION
Fix possible null pointer dereference if the device descriptor is not complete.

Fixes: #8700
Coverity-ID: 186841