### PR TITLE
boards: native_posix: Add option to build with Address Sanitizer

### DIFF
--- a/arch/posix/CMakeLists.txt
+++ b/arch/posix/CMakeLists.txt
@@ -19,6 +19,12 @@ zephyr_link_libraries_ifdef(CONFIG_COVERAGE
 	-lgcov
 	)
 
+if (CONFIG_ASAN)
+	zephyr_compile_options(-fsanitize=address)
+	zephyr_link_libraries(-lasan)
+	zephyr_ld_options(-fsanitize=address)
+endif ()
+
 zephyr_compile_definitions(_POSIX_C_SOURCE=200809)
 
 zephyr_ld_options(

--- a/subsys/debug/Kconfig
+++ b/subsys/debug/Kconfig
@@ -16,6 +16,15 @@ config DEBUG
 	  only disables optimization, more debugging variants can be selected
 	  from here to allow more debugging.
 
+config ASAN
+	bool "Build with address sanitizer"
+	depends on ARCH_POSIX
+	help
+	  Builds Zephyr with Address Sanitizer enabled.  This is currently
+	  only supported by the native_posix port, and requires a recent-ish
+	  compiler with the `-fsanitize=address` command line option, and
+	  the libasan library.
+
 config STACK_USAGE
 	bool "Generate stack usage information"
 	default n


### PR DESCRIPTION
Address Sanitizer helps finding issues related to memory: buffer
overflows, usage of uninitialized memory, etc.  This is available in
both Clang and GCC for a while, and, since the POSIX port is only
meant for testing, this will help find issues.

Signed-off-by: Leandro Pereira <leandro.pereira@intel.com>
Signed-off-by: Alberto Escolar Piedras <alpi@oticon.com>

Aims at superseding #8010 by not setting it by default, but still making it easier for users to set it.