### PR TITLE
tests: boards: intel_s1000_crb: Fix build error.

### DIFF
--- a/tests/boards/intel_s1000_crb/src/test_hid.c
+++ b/tests/boards/intel_s1000_crb/src/test_hid.c
@@ -112,8 +112,7 @@ void hid_thread(void)
 
 		report_1[1]++;
 
-		ret = usb_write(CONFIG_HID_INT_EP_ADDR, report_1,
-				sizeof(report_1), &wrote);
+		ret = hid_int_ep_write(report_1, sizeof(report_1), &wrote);
 		SYS_LOG_DBG("Wrote %d bytes with ret %d", wrote, ret);
 	}
 }


### PR DESCRIPTION
 A HID application can no longer write to the default
 interrupt IN endpoint because the addresses are assigned
 dynamically. Add hid_int_ep_write() function  and leave
 it to the hid-core to call the usb_write() with the correct
 endpoint address.

Signed-off-by: Savinay Dharmappa <savinay.dharmappa@intel.com>