### PR TITLE
arch: arm: nrf: conditionally compile mpu_regions.c

### DIFF
--- a/arch/arm/soc/nordic_nrf/nrf52/CMakeLists.txt
+++ b/arch/arm/soc/nordic_nrf/nrf52/CMakeLists.txt
@@ -3,7 +3,8 @@ zephyr_compile_definitions_ifdef(CONFIG_SOC_NRF52832 NRF52832_XXAA)
 zephyr_compile_definitions_ifdef(CONFIG_SOC_NRF52840 NRF52840_XXAA)
 
 zephyr_sources(
-  mpu_regions.c
   power.c
   soc.c
   )
+
+zephyr_sources_ifdef(CONFIG_ARM_MPU_NRF52X mpu_regions.c)


### PR DESCRIPTION
This commit enforces conditional compilation of mpu_regions.c
in nrf52/CMakeLists.txt depending on whether ARM_MPU_NRF52X
K-option is defined.

Signed-off-by: Ioannis Glaropoulos <Ioannis.Glaropoulos@nordicsemi.no>