### PR TITLE
tests: net: tx_timestamp: Check max number of interfaces

### DIFF
--- a/tests/net/tx_timestamp/src/main.c
+++ b/tests/net/tx_timestamp/src/main.c
@@ -323,6 +323,11 @@ static void iface_cb(struct net_if *iface, void *user_data)
 	    net_if_get_by_iface(iface));
 
 	if (net_if_l2(iface) == &NET_L2_GET_NAME(ETHERNET)) {
+		if (ud->eth_if_count >= ARRAY_SIZE(eth_interfaces)) {
+			DBG("Invalid interface %p\n", iface);
+			return;
+		}
+
 		eth_interfaces[ud->eth_if_count++] = iface;
 	}
 


### PR DESCRIPTION
Add checks so that we do not overflow the network interface
array.

Fixes #8715

Signed-off-by: Jukka Rissanen <jukka.rissanen@linux.intel.com>