### PR TITLE
drivers: usb_dc_stm32: don't wait for semaphore in ISR context

### DIFF
--- a/drivers/usb/device/usb_dc_stm32.c
+++ b/drivers/usb/device/usb_dc_stm32.c
@@ -622,7 +622,7 @@ int usb_dc_ep_write(const u8_t ep, const u8_t *const data,
 		return -EINVAL;
 	}
 
-	ret = k_sem_take(&ep_state->write_sem, 1000);
+	ret = k_sem_take(&ep_state->write_sem, K_NO_WAIT);
 	if (ret) {
 		SYS_LOG_ERR("Unable to write ep 0x%02x (%d)", ep, ret);
 		return ret;


### PR DESCRIPTION
usb_dc_ep_write may be executed in an ISR context and should therefore
not take a semaphore with a timeout. The semaphore was initially
introduced to prevent USB buffer overwrite when writing to an endpoint
in a loop. This is not requested anymore since there is an existing USB
transfer API available.

Signed-off-by: Johannes Hutter <johannes@proglove.de>