### PR TITLE
net: gptp: Init only the ports we have configured

### DIFF
--- a/subsys/net/l2/ethernet/gptp/gptp_mi.c
+++ b/subsys/net/l2/ethernet/gptp/gptp_mi.c
@@ -211,7 +211,8 @@ void gptp_mi_init_state_machine(void)
 {
 	int port;
 
-	for (port = GPTP_PORT_START; port < GPTP_PORT_END; port++) {
+	for (port = GPTP_PORT_START;
+	     port < (GPTP_PORT_START + CONFIG_NET_GPTP_NUM_PORTS); port++) {
 		gptp_mi_init_port_sync_sync_rcv_sm(port);
 		gptp_mi_init_port_sync_sync_send_sm(port);
 		gptp_mi_init_port_announce_rcv_sm(port);


### PR DESCRIPTION
The MI state machine was init with too many ports, even if
we only had one of them.

Signed-off-by: Jukka Rissanen <jukka.rissanen@linux.intel.com>