### PR TITLE
tests: net: trickle: Initialize test variables earlier

### DIFF
--- a/tests/net/trickle/src/main.c
+++ b/tests/net/trickle/src/main.c
@@ -44,7 +44,7 @@ static bool cb_2_called;
  */
 #define CHECK_LONG_TIMEOUT 0
 #if CHECK_LONG_TIMEOUT > 0
-#define WAIT_TIME_LONG (10 * MSEC_PER_SEC)
+#define WAIT_TIME_LONG K_SECONDS(10)
 #endif
 
 #define T1_IMIN 30
@@ -93,6 +93,9 @@ static void test_trickle_start(void)
 {
 	int ret;
 
+	cb_1_called = false;
+	cb_2_called = false;
+
 	ret = net_trickle_start(&t1, cb_1, &t1);
 	zassert_false(ret, "Trickle 1 start failed");
 
@@ -133,11 +136,9 @@ static void test_trickle_2_status(void)
 
 static void test_trickle_1_wait(void)
 {
-	cb_1_called = false;
 	k_sem_take(&wait, WAIT_TIME);
 
-	zassert_true(cb_1_called,
-			"Trickle 1 no timeout");
+	zassert_true(cb_1_called, "Trickle 1 no timeout");
 
 	zassert_true(net_trickle_is_running(&t1), "Trickle 1 not running");
 }
@@ -146,12 +147,12 @@ static void test_trickle_1_wait(void)
 static void test_trickle_1_wait_long(void)
 {
 	cb_1_called = false;
+
 	k_sem_take(&wait, WAIT_TIME_LONG);
 
-	zassert_true(!cb_1_called, "Trickle 1 no timeout");
+	zassert_false(cb_1_called, "Trickle 1 no timeout");
 
-	zassert_true(!net_trickle_is_running(&t1), "Trickle 1 not running");
-
+	zassert_true(net_trickle_is_running(&t1), "Trickle 1 not running");
 }
 #else
 static void test_trickle_1_wait_long(void)
@@ -162,11 +163,9 @@ static void test_trickle_1_wait_long(void)
 
 static void test_trickle_2_wait(void)
 {
-	cb_2_called = false;
 	k_sem_take(&wait, WAIT_TIME);
 
-	zassert_true(cb_2_called,
-			"Trickle 2 no timeout");
+	zassert_true(cb_2_called, "Trickle 2 no timeout");
 
 	zassert_true(net_trickle_is_running(&t2), "Trickle 2 not running");
 }


### PR DESCRIPTION
The cb_[1|2]_called variables were initialized just before running
the test. This was too late as in same cases the Trickle timer
was triggered before this init, which then caused the test to fail
even thou there was no actual timer failure.

This was seen with frdm_k64f and when CONFIG_BOOT_DELAY=1000 was set.

Fixes #8658

Signed-off-by: Jukka Rissanen <jukka.rissanen@linux.intel.com>