### PR TITLE
drivers: pwm: nrf: Fix pwm_nrfx related configs

### DIFF
--- a/drivers/pwm/Kconfig.nrfx
+++ b/drivers/pwm/Kconfig.nrfx
@@ -6,6 +6,7 @@
 menuconfig PWM_NRFX
 	bool "nRF PWM nrfx driver"
 	depends on SOC_SERIES_NRF52X
+	select NRFX_PWM
 	help
 	  Enable support for nrfx Hardware PWM driver for nRF52 MCU series.
 

--- a/ext/hal/nordic/nrfx_config_nrf52840.h
+++ b/ext/hal/nordic/nrfx_config_nrf52840.h
@@ -956,34 +956,34 @@
 
 // <e> NRFX_PWM_ENABLED - nrfx_pwm - PWM peripheral driver
 //==========================================================
-#ifndef CONFIG_NRFX_PWM
+#ifdef CONFIG_NRFX_PWM
 #define NRFX_PWM_ENABLED 1
 #endif
 // <q> NRFX_PWM0_ENABLED  - Enable PWM0 instance
 
 
-#ifndef CONFIG_PWM_0
+#ifdef CONFIG_PWM_0
 #define NRFX_PWM0_ENABLED 1
 #endif
 
 // <q> NRFX_PWM1_ENABLED  - Enable PWM1 instance
 
 
-#ifndef CONFIG_PWM_1
+#ifdef CONFIG_PWM_1
 #define NRFX_PWM1_ENABLED 1
 #endif
 
 // <q> NRFX_PWM2_ENABLED  - Enable PWM2 instance
 
 
-#ifndef CONFIG_PWM_2
+#ifdef CONFIG_PWM_2
 #define NRFX_PWM2_ENABLED 1
 #endif
 
 // <q> NRFX_PWM3_ENABLED  - Enable PWM3 instance
 
 
-#ifndef CONFIG_PWM_3
+#ifdef CONFIG_PWM_3
 #define NRFX_PWM3_ENABLED 1
 #endif
 


### PR DESCRIPTION
This fixes two things:
- nrfx driver implementation is automatically added to the build when the shim for it (PWM_NRFX option) is enabled
- corrects PWM related entries in nrfx_config for nRF52840 (#ifndef -> #ifdef)