### PR TITLE
For native_posix set the compiler to C standard 2011

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -120,8 +120,6 @@ zephyr_compile_options(
 )
 
 zephyr_compile_options(
-  $<$<COMPILE_LANGUAGE:C>:-std=c99>
-
   $<$<COMPILE_LANGUAGE:CXX>:-std=c++11>
   $<$<COMPILE_LANGUAGE:CXX>:-fcheck-new>
   $<$<COMPILE_LANGUAGE:CXX>:-ffunction-sections>
@@ -991,6 +989,13 @@ get_property(GKSF GLOBAL PROPERTY GENERATED_KERNEL_SOURCE_FILES)
 
 get_property(TOPT GLOBAL PROPERTY TOPT)
 set_ifndef(  TOPT -T)
+
+get_property(CSTD GLOBAL PROPERTY CSTD)
+set_ifndef(CSTD c99)
+
+zephyr_compile_options(
+  $<$<COMPILE_LANGUAGE:C>:-std=${CSTD}>
+)
 
 configure_file(
      $ENV{ZEPHYR_BASE}/include/arch/arm/cortex_m/scripts/app_data_alignment.ld

--- a/boards/posix/native_posix/CMakeLists.txt
+++ b/boards/posix/native_posix/CMakeLists.txt
@@ -14,3 +14,10 @@ zephyr_library_sources(
 zephyr_ld_options(
   -lm
 )
+
+# Override the C standard used for compilation to C 2011
+# This is due to some tests using _Static_assert which is a 2011 feature, but
+# otherwise relying on compilers supporting it also when set to C99.
+# This was in general ok, but with some host compilers and C library versions
+# it led to problems. So we override it to 2011 for native_posix.
+set_property(GLOBAL PROPERTY CSTD c11)


### PR DESCRIPTION
Allow archs/boards/apps to override the C standard version.
+
For native_posix, override the C standard used for compilation to C 2011
This is due to some tests using _Static_assert which is a 2011 feature, but otherwise relying on compilers supporting it also when set to C99.
This was in general ok, but with some host compilers and C library versions it led to problems. So we override it to 2011 for native_posix board.

Fixes: #8529