### PR TITLE
net: icmpv4: Set the ICMPv4 header correctly

### DIFF
--- a/subsys/net/ip/icmpv4.c
+++ b/subsys/net/ip/icmpv4.c
@@ -34,7 +34,7 @@ struct net_icmp_hdr *net_icmpv4_set_hdr(struct net_pkt *pkt,
 	u16_t pos;
 
 	icmp_hdr = net_pkt_icmp_data(pkt);
-	if (net_icmp_header_fits(pkt, icmp_hdr)) {
+	if (net_icmp_header_fits(pkt, icmp_hdr) && (hdr == icmp_hdr)) {
 		return icmp_hdr;
 	}
 


### PR DESCRIPTION
The code did not check if the icmpv4 header struct is already
pointing to net_buf or not. This meant that the code did not
set the ICMPv4 options and types correctly.

Signed-off-by: Jukka Rissanen <jukka.rissanen@linux.intel.com>