### PR TITLE
usb: netusb: Add ethernet_init()

### DIFF
--- a/subsys/usb/class/netusb/netusb.c
+++ b/subsys/usb/class/netusb/netusb.c
@@ -579,6 +579,8 @@ static void netusb_init(struct net_if *iface)
 
 	netusb.iface = iface;
 
+	ethernet_init(iface);
+
 	net_if_set_link_addr(iface, mac, sizeof(mac), NET_LINK_ETHERNET);
 
 	net_if_down(iface);


### PR DESCRIPTION
After PR #8608 every driver should call ethernet_init(), fixes missing
chunks of that PR.

Fixes: #8752

Signed-off-by: Andrei Emeltchenko <andrei.emeltchenko@intel.com>