### PR TITLE
mailmap: add entry for ruuddw

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -19,3 +19,4 @@ Naga Raja Rao Tulasi <tulasi.r@tcs.com> <tulasi.r@tcs.com>
 Felipe Neves <ryukokki.felipe@gmail.com> <ryukokki.felipe@gmail.com>
 Amir Kaplan <amir.kaplan@intel.com> <amir.kaplan@intel.com>
 Anas Nashif <anas.nashif@intel.com> <anas.nashif@intel.com>
+Ruud Derwig <Ruud.Derwig@synopsys.com> <Ruud.Derwig@synopsys.com>


### PR DESCRIPTION
Somehow CI did not catch this, so add an entry to get consistent logs.

Signed-off-by: Anas Nashif <anas.nashif@intel.com>