### PR TITLE
ci: use latest docker image v0.4-rc7

### DIFF
--- a/.shippable.yml
+++ b/.shippable.yml
@@ -24,7 +24,7 @@ build:
         - ${SHIPPABLE_BUILD_DIR}/ccache
     pre_ci_boot:
         image_name: zephyrprojectrtos/ci
-        image_tag: v0.4-rc6
+        image_tag: v0.4-rc7
         pull: true
         options: "-e HOME=/home/buildslave --privileged=true --tty --net=bridge --user buildslave"
 


### PR DESCRIPTION
This one comes with gcc-arm-none-eabi-7-2018-q2-update

Signed-off-by: Anas Nashif <anas.nashif@intel.com>