### PR TITLE
dts/arm/st: Fix I2C1, I2C3 and SPI1 clock properties

### DIFF
--- a/dts/arm/st/stm32f0.dtsi
+++ b/dts/arm/st/stm32f0.dtsi
@@ -132,7 +132,7 @@
 			#address-cells = <1>;
 			#size-cells = <0>;
 			reg = <0x40005400 0x400>;
-			clocks = <&rcc STM32_CLOCK_BUS_APB1 0x00020000>;
+			clocks = <&rcc STM32_CLOCK_BUS_APB1 0x00200000>;
 			interrupts = <23 0>;
 			interrupt-names = "combined";
 			status = "disabled";

--- a/dts/arm/st/stm32f0.dtsi
+++ b/dts/arm/st/stm32f0.dtsi
@@ -157,7 +157,7 @@
 			#address-cells = <1>;
 			#size-cells = <0>;
 			reg = <0x40013000 0x400>;
-			clocks = <&rcc STM32_CLOCK_BUS_APB1 0x00001000>;
+			clocks = <&rcc STM32_CLOCK_BUS_APB2 0x00001000>;
 			interrupts = <25 3>;
 			status = "disabled";
 			label = "SPI_1";

--- a/dts/arm/st/stm32f1.dtsi
+++ b/dts/arm/st/stm32f1.dtsi
@@ -129,7 +129,7 @@
 			#address-cells = <1>;
 			#size-cells = <0>;
 			reg = <0x40005400 0x400>;
-			clocks = <&rcc STM32_CLOCK_BUS_APB1 0x00020000>;
+			clocks = <&rcc STM32_CLOCK_BUS_APB1 0x00200000>;
 			interrupts = <31 0>, <32 0>;
 			interrupt-names = "event", "error";
 			status = "disabled";

--- a/dts/arm/st/stm32f3.dtsi
+++ b/dts/arm/st/stm32f3.dtsi
@@ -139,7 +139,7 @@
 			#address-cells = <1>;
 			#size-cells = <0>;
 			reg = <0x40005400 0x400>;
-			clocks = <&rcc STM32_CLOCK_BUS_APB1 0x00020000>;
+			clocks = <&rcc STM32_CLOCK_BUS_APB1 0x00200000>;
 			interrupts = <31 0>, <32 0>;
 			interrupt-names = "event", "error";
 			status = "disabled";

--- a/dts/arm/st/stm32f4.dtsi
+++ b/dts/arm/st/stm32f4.dtsi
@@ -151,7 +151,7 @@
 			#address-cells = <1>;
 			#size-cells = <0>;
 			reg = <0x40005400 0x400>;
-			clocks = <&rcc STM32_CLOCK_BUS_APB1 0x00020000>;
+			clocks = <&rcc STM32_CLOCK_BUS_APB1 0x00200000>;
 			interrupts = <31 0>, <32 0>;
 			interrupt-names = "event", "error";
 			status = "disabled";

--- a/dts/arm/st/stm32l0.dtsi
+++ b/dts/arm/st/stm32l0.dtsi
@@ -141,7 +141,7 @@
 			#address-cells = <1>;
 			#size-cells = <0>;
 			reg = <0x40005400 0x400>;
-			clocks = <&rcc STM32_CLOCK_BUS_APB1 0x00020000>;
+			clocks = <&rcc STM32_CLOCK_BUS_APB1 0x00200000>;
 			interrupts = <23 0>;
 			interrupt-names = "combined";
 			status = "disabled";

--- a/dts/arm/st/stm32l072.dtsi
+++ b/dts/arm/st/stm32l072.dtsi
@@ -39,7 +39,7 @@
 			#address-cells = <1>;
 			#size-cells = <0>;
 			reg = <0x40007800 0x400>;
-			clocks = <&rcc STM32_CLOCK_BUS_APB1 0x00800000>;
+			clocks = <&rcc STM32_CLOCK_BUS_APB1 0x40000000>;
 			interrupts = <21 0>;
 			interrupt-names = "combined";
 			status = "disabled";

--- a/dts/arm/st/stm32l073.dtsi
+++ b/dts/arm/st/stm32l073.dtsi
@@ -27,7 +27,7 @@
 			#address-cells = <1>;
 			#size-cells = <0>;
 			reg = <0x40007800 0x400>;
-			clocks = <&rcc STM32_CLOCK_BUS_APB1 0x00800000>;
+			clocks = <&rcc STM32_CLOCK_BUS_APB1 0x40000000>;
 			interrupts = <21 0>;
 			interrupt-names = "combined";
 			status = "disabled";

--- a/dts/arm/st/stm32l4.dtsi
+++ b/dts/arm/st/stm32l4.dtsi
@@ -142,7 +142,7 @@
 			#address-cells = <1>;
 			#size-cells = <0>;
 			reg = <0x40005400 0x400>;
-			clocks = <&rcc STM32_CLOCK_BUS_APB1 0x00020000>;
+			clocks = <&rcc STM32_CLOCK_BUS_APB1 0x00200000>;
 			interrupts = <31 0>, <32 0>;
 			interrupt-names = "event", "error";
 			status = "disabled";


### PR DESCRIPTION
Set the correct bit to enable I2C1 in clock.
Set the correct bit to enable I2C3 clock on L0 series.
SPI1 is on APB2 on F0 series.

Signed-off-by: Yannis Damigos <giannis.damigos@gmail.com>