### PR TITLE
dts: Fix warning related to arm,v{6,7,8}m-nvic yaml files

### DIFF
--- a/dts/bindings/interrupt-controller/arm,v6m-nvic.yaml
+++ b/dts/bindings/interrupt-controller/arm,v6m-nvic.yaml
@@ -1,5 +1,6 @@
 ---
 title: ARMv6-M NVIC Interrupt Controller
+id: arm,v6m-nvic
 version: 0.1
 
 description: >

--- a/dts/bindings/interrupt-controller/arm,v7m-nvic.yaml
+++ b/dts/bindings/interrupt-controller/arm,v7m-nvic.yaml
@@ -1,5 +1,6 @@
 ---
 title: ARMv7-M NVIC Interrupt Controller
+id: arm,v7m-nvic
 version: 0.1
 
 description: >

--- a/dts/bindings/interrupt-controller/arm,v8m-nvic.yaml
+++ b/dts/bindings/interrupt-controller/arm,v8m-nvic.yaml
@@ -1,5 +1,6 @@
 ---
 title: ARMv8-M NVIC Interrupt Controller
+id: arm,v8m-nvic
 version: 0.1
 
 description: >


### PR DESCRIPTION
The nvic yaml files were missing an id property.  So we'd get a warning
like:

extract_dts_includes.py: 'id' property missing in 'ARMv7-M NVIC Interrupt Controller' binding. Using '<unknown id>

Add the id to fix this warning.

Signed-off-by: Kumar Gala <kumar.gala@linaro.org>