### PR TITLE
[RFC] net: Introduce NET_DBG_ERR() logging macro

### DIFF
--- a/include/net/net_core.h
+++ b/include/net/net_core.h
@@ -50,6 +50,18 @@ extern "C" {
 #define NET_ERR(fmt, ...) SYS_LOG_ERR(fmt, ##__VA_ARGS__)
 #define NET_WARN(fmt, ...) SYS_LOG_WRN(fmt, ##__VA_ARGS__)
 #define NET_INFO(fmt, ...) SYS_LOG_INF(fmt,  ##__VA_ARGS__)
+
+/* NET_DBG_ERR() is resolved to either NET_DBG() or NET_ERR()
+ * depending on the config option, and thus a way to promote
+ * logging which is "debug" in production mode to "error" when
+ * debugging.
+ */
+#if defined(CONFIG_SYS_LOG_DBG_ERR)
+#define NET_DBG_ERR(fmt, ...) NET_ERR(fmt, ##__VA_ARGS__)
+#else
+#define NET_DBG_ERR(fmt, ...) NET_DBG(fmt, ##__VA_ARGS__)
+#endif /* CONFIG_SYS_LOG_DBG_ERR */
+
 #define NET_ASSERT(cond) do {				     \
 		if (!(cond)) {					     \
 			NET_ERR("{assert: '" #cond "' failed}");     \
@@ -62,6 +74,7 @@ extern "C" {
 #else /* NET_LOG_ENABLED */
 #define NET_DBG(...)
 #define NET_ERR(...)
+#define NET_DBG_ERR(...)
 #define NET_INFO(...)
 #define NET_WARN(...)
 #define NET_ASSERT(...)

--- a/subsys/net/ip/Kconfig.debug
+++ b/subsys/net/ip/Kconfig.debug
@@ -30,6 +30,22 @@ config SYS_LOG_NET_LEVEL
 	  3 INFO, write SYS_LOG_INF in addition to previous levels
 	  4 DEBUG, write SYS_LOG_DBG in addition to previous levels
 
+config SYS_LOG_DBG_ERR
+	bool "Make certain IP stack conditions have ERR logging instead of DBG"
+	help
+	  There are some conditions which may happen (usually rarely)
+	  during normal TCP/IP operation, but otherwise affect TCP/IP
+	  flow considerably. An example of this is TCP FIN timeout -
+	  we have little choice but to completely close connection on
+	  our side, yet there can be a case that the peer didn't receive
+	  the FIN indeed, and think that connection is open. If such
+	  conditions occur frequently instead of rarely, they may
+	  mean an issue somewhere in the TCP/IP flow, so having them
+	  logged in clear manner may help with debugging. Such conditions
+	  are logged using special NET_DBG_ERR() macro. If this option
+	  is inactive, it will be equivalent to NET_DBG(). And if this
+	  options is active - to NET_ERR().
+
 config NET_LOG_GLOBAL
 	bool "Enable global network stack logging"
 	select NET_DEBUG_CORE


### PR DESCRIPTION
Depending on the Kconfig option CONFIG_SYS_LOG_DBG_ERR, this resolves
to either NET_DBG() ("production" mode) or NET_ERR() ("debugging"
mode). The idea is to make "exceptional" paths in TCP/IP flow (which
are otherwise are still handled by the stack) more visible during
debugging. Description of the option gives more detail:

There are some conditions which may happen (usually rarely)
during normal TCP/IP operation, but otherwise affect TCP/IP
flow considerably. An example of this is TCP FIN timeout -
we have little choice but to completely close connection on
our side, yet there can be a case that the peer didn't receive
the FIN indeed, and think that connection is open. If such
conditions occur frequently instead of rarely, they may
mean an issue somewhere in the TCP/IP flow, so having them
logged in clear manner may help with debugging. Such conditions
are logged using special NET_DBG_ERR() macro. If this option
is inactive, it will be equivalent to NET_DBG(). And if this
options is active - to NET_ERR().

Signed-off-by: Paul Sokolovsky <paul.sokolovsky@linaro.org>