### PR TITLE
hal: stm32f2x: usbotg_fs: fix VBUS sensing deactivation

### DIFF
--- a/ext/hal/st/stm32cube/stm32f2xx/README
+++ b/ext/hal/st/stm32cube/stm32f2xx/README
@@ -35,3 +35,16 @@ License Link:
    http://www.st.com/resource/en/license_agreement/dm00218346.pdf
 
 Patch List:
+
+   *Fix VBUS sensing deactivation
+     The error is detected if USART1 TX configured to PA9 and RX to PA10.
+     The serial cable removal stops the USB communication.
+     In case of VBUS sensing deactivation, erroneously
+     both USB_OTG_GCCFG_VBUSBSEN and USB_OTG_GCCFG_NOVBUSSENS are set in GCCFG.
+     Correct handling is:
+      - VBUS sensing deactivation: set USB_OTG_GCCFG_NOVBUSSENS in GCCFG.
+      - VBUS sensing activation:   set USB_OTG_GCCFG_VBUSBSEN in GCCFG.
+    Impacted files:
+     ext/hal/st/stm32cube/stm32f2xx/drivers/src/stm32f2xx_ll_usb.c
+    ST Bug Tracker ID: 34714
+

--- a/ext/hal/st/stm32cube/stm32f2xx/drivers/src/stm32f2xx_ll_usb.c
+++ b/ext/hal/st/stm32cube/stm32f2xx/drivers/src/stm32f2xx_ll_usb.c
@@ -200,14 +200,16 @@ HAL_StatusTypeDef USB_DevInit (USB_OTG_GlobalTypeDef *USBx, USB_OTG_CfgTypeDef c
 {
   uint32_t i = 0U;
 
-  /*Activate VBUS Sensing B */
-  USBx->GCCFG |= USB_OTG_GCCFG_VBUSBSEN;
-  
   if (cfg.vbus_sensing_enable == 0U)
   {
     USBx->GCCFG |= USB_OTG_GCCFG_NOVBUSSENS;
   }
-   
+  else
+  {
+    /* Activate VBUS Sensing B */
+    USBx->GCCFG |= USB_OTG_GCCFG_VBUSBSEN;
+  }
+
   /* Restart the Phy Clock */
   USBx_PCGCCTL = 0U;
 


### PR DESCRIPTION
The error is detected if USART1 TX configured to PA9 and RX to PA10.
The serial cable removal stops the USB communication.
In case of VBUS sensing deactivation, erroneously
both USB_OTG_GCCFG_VBUSBSEN and
USB_OTG_GCCFG_NOVBUSSENS are set in GCCFG.
Correct handling is:
 - VBUS sensing deactivation: set USB_OTG_GCCFG_NOVBUSSENS in GCCFG.
 - VBUS sensing activation:   set USB_OTG_GCCFG_VBUSBSEN in GCCFG.

ST Bug Tracker ID: 34714
  
Signed-off-by: Istvan Bisz <istvan.bisz@t-online.hu>