### PR TITLE
arch: arm: stm32f2: remove core zephyr header inclusions from soc.h

### DIFF
--- a/arch/arm/soc/st_stm32/stm32f2/soc.h
+++ b/arch/arm/soc/st_stm32/stm32f2/soc.h
@@ -23,11 +23,13 @@
 
 #ifndef _ASMLANGUAGE
 
-#include <device.h>
-#include <misc/util.h>
-#include <random/rand32.h>
-
 #include <stm32f2xx.h>
+
+/* ARM CMSIS definitions must be included before kernel_includes.h.
+ * Therefore, it is essential to include kernel_includes.h after including
+ * core SOC-specific headers.
+ */
+#include <kernel_includes.h>
 
 #ifdef CONFIG_CLOCK_CONTROL_STM32_CUBE
 #include <stm32f2xx_ll_utils.h>


### PR DESCRIPTION
The stm32f2 version of soc.h misses the changes done in commit
aee97be ("arch: arm: soc: remove core zephyr header inclusions
from soc.h").

Signed-off-by: Istvan Bisz <istvan.bisz@t-online.hu>