### PR TITLE
doc: net: Fix source tree layout documentation

### DIFF
--- a/doc/subsystems/networking/overview.rst
+++ b/doc/subsystems/networking/overview.rst
@@ -126,10 +126,14 @@ Zephyr OS v1.7 and later:
 Source Tree Layout
 ******************
 
-The IP stack source code tree is organized as follows:
+The networking stack source code tree is organized as follows:
 
 ``subsys/net/ip/``
   This is where the IP stack code is located.
+
+``subsys/net/l2/``
+  This is where the IP stack layer 2 code is located. This includes generic
+  support for Bluetooth IPSP adaptation, Ethernet, IEEE 802.15.4 and WiFI.
 
 ``subsys/net/lib/``
   Application-level protocols (DNS, MQTT, etc.) and additional stack


### PR DESCRIPTION
The subsys/net/l2 directory was recently introduced so add it to
the documentation.

Signed-off-by: Jukka Rissanen <jukka.rissanen@linux.intel.com>