### PR TITLE
arch: stm32f0/f1/f3/l0: remove core zephyr header inclusions

### DIFF
--- a/arch/arm/soc/st_stm32/stm32f0/soc.h
+++ b/arch/arm/soc/st_stm32/stm32f0/soc.h
@@ -24,11 +24,13 @@
 
 #ifndef _ASMLANGUAGE
 
-#include <device.h>
-#include <misc/util.h>
-#include <random/rand32.h>
-
 #include <stm32f0xx.h>
+
+/* ARM CMSIS definitions must be included before kernel_includes.h.
+ * Therefore, it is essential to include kernel_includes.h after including
+ * core SOC-specific headers.
+ */
+#include <kernel_includes.h>
 
 #ifdef CONFIG_SERIAL_HAS_DRIVER
 #include <stm32f0xx_ll_usart.h>

--- a/arch/arm/soc/st_stm32/stm32f1/soc.h
+++ b/arch/arm/soc/st_stm32/stm32f1/soc.h
@@ -24,11 +24,13 @@
 
 #ifndef _ASMLANGUAGE
 
-#include <device.h>
-#include <misc/util.h>
-#include <random/rand32.h>
-
 #include <stm32f1xx.h>
+
+/* ARM CMSIS definitions must be included before kernel_includes.h.
+ * Therefore, it is essential to include kernel_includes.h after including
+ * core SOC-specific headers.
+ */
+#include <kernel_includes.h>
 
 #ifdef CONFIG_SERIAL_HAS_DRIVER
 #include <stm32f1xx_ll_usart.h>

--- a/arch/arm/soc/st_stm32/stm32f3/soc.h
+++ b/arch/arm/soc/st_stm32/stm32f3/soc.h
@@ -25,11 +25,13 @@
 
 #ifndef _ASMLANGUAGE
 
-#include <device.h>
-#include <misc/util.h>
-#include <random/rand32.h>
-
 #include <stm32f3xx.h>
+
+/* ARM CMSIS definitions must be included before kernel_includes.h.
+ * Therefore, it is essential to include kernel_includes.h after including
+ * core SOC-specific headers.
+ */
+#include <kernel_includes.h>
 
 #ifdef CONFIG_SERIAL_HAS_DRIVER
 #include <stm32f3xx_ll_usart.h>

--- a/arch/arm/soc/st_stm32/stm32l0/soc.h
+++ b/arch/arm/soc/st_stm32/stm32l0/soc.h
@@ -23,11 +23,13 @@
 
 #ifndef _ASMLANGUAGE
 
-#include <device.h>
-#include <misc/util.h>
-#include <random/rand32.h>
-
 #include <stm32l0xx.h>
+
+/* ARM CMSIS definitions must be included before kernel_includes.h.
+ * Therefore, it is essential to include kernel_includes.h after including
+ * core SOC-specific headers.
+ */
+#include <kernel_includes.h>
 
 #include <stm32l0xx_ll_system.h>
 


### PR DESCRIPTION
Apply the changes done in commit aee97be to F0, F1, F3, L0 series.

Signed-off-by: Yannis Damigos <giannis.damigos@gmail.com>