### PR TITLE
ARMv8-M MPU driver implementation

### DIFF
--- a/arch/arm/core/cortex_m/mpu/CMakeLists.txt
+++ b/arch/arm/core/cortex_m/mpu/CMakeLists.txt
@@ -6,4 +6,5 @@ zephyr_library_sources_if_kconfig(               nxp_mpu.c)
 
 zephyr_library_include_directories(
   .
+  ../../../include/cortex_m
 )

--- a/arch/arm/core/cortex_m/mpu/CMakeLists.txt
+++ b/arch/arm/core/cortex_m/mpu/CMakeLists.txt
@@ -3,3 +3,7 @@ zephyr_library()
 zephyr_library_sources_ifdef(CONFIG_ARM_CORE_MPU arm_core_mpu.c)
 zephyr_library_sources_if_kconfig(               arm_mpu.c)
 zephyr_library_sources_if_kconfig(               nxp_mpu.c)
+
+zephyr_library_include_directories(
+  .
+)

--- a/arch/arm/core/cortex_m/mpu/arm_mpu.c
+++ b/arch/arm/core/cortex_m/mpu/arm_mpu.c
@@ -103,6 +103,13 @@ static inline int _get_region_attr_by_type(arm_mpu_region_attr_t *p_attr,
 		return 0;
 #endif
 	default:
+		/* Assert on MPU region types not supported in the
+		 * implementation.  If asserts are disabled, the error
+		 * can be tracked by the returned status (-EINVAL).
+		 */
+		__ASSERT(0,
+			"Failed to derive attributes for MPU region type %u\n",
+			type);
 		/* Size 0 region */
 		return -EINVAL;
 	}

--- a/arch/arm/core/cortex_m/mpu/arm_mpu.c
+++ b/arch/arm/core/cortex_m/mpu/arm_mpu.c
@@ -47,9 +47,9 @@ static void _region_init(u32_t index, struct arm_mpu_region *region_conf)
 	/* Configure the region */
 	MPU->RBAR = (region_conf->base & MPU_RBAR_ADDR_Msk)
 				| MPU_RBAR_VALID_Msk | index;
-	MPU->RASR = region_conf->attr | MPU_RASR_ENABLE_Msk;
+	MPU->RASR = region_conf->attr.rasr | MPU_RASR_ENABLE_Msk;
 	SYS_LOG_DBG("[%d] 0x%08x 0x%08x",
-		index, region_conf->base, region_conf->attr);
+		index, region_conf->base, region_conf->attr.rasr);
 }
 
 /* ARM Core MPU Driver API Implementation for ARM MPU */

--- a/arch/arm/core/cortex_m/mpu/arm_mpu.c
+++ b/arch/arm/core/cortex_m/mpu/arm_mpu.c
@@ -19,6 +19,11 @@
 	defined(CONFIG_CPU_CORTEX_M4) || \
 	defined(CONFIG_CPU_CORTEX_M7)
 #include <arm_mpu_v7_internal.h>
+#elif defined(CONFIG_CPU_CORTEX_M23) || \
+	defined(CONFIG_CPU_CORTEX_M33)
+#include <arm_mpu_v8_internal.h>
+#else
+#error "Unsupported ARM CPU"
 #endif
 
 /**
@@ -318,6 +323,9 @@ static int arm_mpu_init(struct device *arg)
 	SYS_LOG_DBG("total region count: %d", _get_num_regions());
 
 	arm_core_mpu_disable();
+
+	/* Architecture-specific configuration */
+	_mpu_init();
 
 	/* Configure regions */
 	for (r_index = 0; r_index < mpu_config.num_regions; r_index++) {

--- a/arch/arm/core/cortex_m/mpu/arm_mpu.c
+++ b/arch/arm/core/cortex_m/mpu/arm_mpu.c
@@ -14,6 +14,13 @@
 #include <logging/sys_log.h>
 #include <linker/linker-defs.h>
 
+#if defined(CONFIG_CPU_CORTEX_M0PLUS) || \
+	defined(CONFIG_CPU_CORTEX_M3) || \
+	defined(CONFIG_CPU_CORTEX_M4) || \
+	defined(CONFIG_CPU_CORTEX_M7)
+#include <arm_mpu_v7_internal.h>
+#endif
+
 /**
  *  Get the number of supported MPU regions.
  */
@@ -33,23 +40,6 @@ static inline u8_t _get_num_regions(void)
 
 	return (u8_t)type;
 #endif
-}
-
-/* This internal function performs MPU region initialization.
- *
- * Note:
- *   The caller must provide a valid region index.
- */
-static void _region_init(u32_t index, struct arm_mpu_region *region_conf)
-{
-	/* Select the region you want to access */
-	MPU->RNR = index;
-	/* Configure the region */
-	MPU->RBAR = (region_conf->base & MPU_RBAR_ADDR_Msk)
-				| MPU_RBAR_VALID_Msk | index;
-	MPU->RASR = region_conf->attr.rasr | MPU_RASR_ENABLE_Msk;
-	SYS_LOG_DBG("[%d] 0x%08x 0x%08x",
-		index, region_conf->base, region_conf->attr.rasr);
 }
 
 /* ARM Core MPU Driver API Implementation for ARM MPU */
@@ -82,71 +72,6 @@ void arm_core_mpu_disable(void)
 	defined(CONFIG_APPLICATION_MEMORY)
 
 /**
- * This internal function converts the region size to
- * the SIZE field value of MPU_RASR.
- *
- * Note: If size is not a power-of-two, it is rounded-up to the next
- * power-of-two value, and the returned SIZE field value corresponds
- * to that power-of-two value.
- */
-static inline u32_t _size_to_mpu_rasr_size(u32_t size)
-{
-	/* The minimal supported region size is 32 bytes */
-	if (size <= 32) {
-		return REGION_32B;
-	}
-
-	/*
-	 * A size value greater than 2^31 could not be handled by
-	 * round_up_to_next_power_of_two() properly. We handle
-	 * it separately here.
-	 */
-	if (size > (1 << 31)) {
-		return REGION_4G;
-	}
-
-	return ((32 - __builtin_clz(size - 1) - 2 + 1) << MPU_RASR_SIZE_Pos) &
-		MPU_RASR_SIZE_Msk;
-}
-
-/**
- * Generate the value of the MPU Region Attribute and Size Register
- * (MPU_RASR) that corresponds to the supplied MPU region attributes.
- * This function is internal to the driver.
- */
-static inline u32_t _get_region_attr(u32_t xn, u32_t ap, u32_t tex,
-				     u32_t c, u32_t b, u32_t s,
-				     u32_t srd, u32_t region_size)
-{
-	int size = _size_to_mpu_rasr_size(region_size);
-
-	return (((xn << MPU_RASR_XN_Pos) & MPU_RASR_XN_Msk)
-		| ((ap << MPU_RASR_AP_Pos) & MPU_RASR_AP_Msk)
-		| ((tex << MPU_RASR_TEX_Pos) & MPU_RASR_TEX_Msk)
-		| ((s << MPU_RASR_S_Pos) & MPU_RASR_S_Msk)
-		| ((c << MPU_RASR_C_Pos) & MPU_RASR_C_Msk)
-		| ((b << MPU_RASR_B_Pos) & MPU_RASR_B_Msk)
-		| ((srd << MPU_RASR_SRD_Pos) & MPU_RASR_SRD_Msk)
-		| (size));
-}
-
-/**
- * This internal function allocates default RAM cache-ability, share-ability
- * and execution allowance attributes along with the requested access
- * permissions and size.
- */
-static inline void _get_mpu_ram_region_attr(arm_mpu_region_attr_t *p_attr,
-	u32_t ap, u32_t base, u32_t size)
-{
-	/* in ARMv7-M MPU the base address is not required
-	 * to determine region attributes.
-	 */
-	(void) base;
-
-	p_attr->rasr = _get_region_attr(1, ap, 1, 1, 1, 1, 0, size);
-}
-
-/**
  * This internal function is utilized by the MPU driver to parse the intent
  * type (i.e. THREAD_STACK_REGION) and to fill-in the correct parameter
  * set to the provided attribute structure.
@@ -176,22 +101,6 @@ static inline int _get_region_attr_by_type(arm_mpu_region_attr_t *p_attr,
 		/* Size 0 region */
 		return -EINVAL;
 	}
-}
-
-/**
- * This internal function is utilized by the MPU driver to combine a given
- * MPU RAM attribute configuration and region size and return the correct
- * parameter set.
- */
-static inline void _get_ram_region_attr_by_conf(arm_mpu_region_attr_t *p_attr,
-	u32_t attr, u32_t base, u32_t size)
-{
-	/* in ARMv7-M MPU the base address is not required
-	 * to determine region attributes
-	 */
-	(void) base;
-
-	p_attr->rasr = attr | _size_to_mpu_rasr_size(size);
 }
 
 /**
@@ -231,57 +140,6 @@ static inline void _disable_region(u32_t r_index)
 	SYS_LOG_DBG("disable region 0x%x", r_index);
 	/* Disable region */
 	ARM_MPU_ClrRegion(r_index);
-}
-
-/**
- * This internal function checks if region is enabled or not.
- *
- * Note:
- *   The caller must provide a valid region number.
- */
-static inline int _is_enabled_region(u32_t r_index)
-{
-	MPU->RNR = r_index;
-
-	return MPU->RASR & MPU_RASR_ENABLE_Msk;
-}
-
-/**
- * This internal function checks if the given buffer is in the region.
- *
- * Note:
- *   The caller must provide a valid region number.
- */
-static inline int _is_in_region(u32_t r_index, u32_t start, u32_t size)
-{
-	u32_t r_addr_start;
-	u32_t r_size_lshift;
-	u32_t r_addr_end;
-
-	MPU->RNR = r_index;
-	r_addr_start = MPU->RBAR & MPU_RBAR_ADDR_Msk;
-	r_size_lshift = ((MPU->RASR & MPU_RASR_SIZE_Msk) >>
-			MPU_RASR_SIZE_Pos) + 1;
-	r_addr_end = r_addr_start + (1 << r_size_lshift) - 1;
-
-	if (start >= r_addr_start && (start + size - 1) <= r_addr_end) {
-		return 1;
-	}
-
-	return 0;
-}
-
-/**
- * This internal function returns the access permissions of an MPU region
- * specified by its region index.
- *
- * Note:
- *   The caller must provide a valid region number.
- */
-static inline u32_t _get_region_ap(u32_t r_index)
-{
-	MPU->RNR = r_index;
-	return (MPU->RASR & MPU_RASR_AP_Msk) >> MPU_RASR_AP_Pos;
 }
 
 /**
@@ -418,33 +276,6 @@ int arm_core_mpu_get_max_domain_partition_regions(void)
 		_get_region_index_by_type(THREAD_DOMAIN_PARTITION_REGION);
 }
 
-/* Only a single bit is set for all user accessible permissions.
- * In ARMv7-M MPU this is bit AP[1].
- */
-#define MPU_USER_READ_ACCESSIBLE_Msk (P_RW_U_RO & P_RW_U_RW & P_RO_U_RO & RO)
-
-/**
- * This internal function checks if the region is user accessible or not.
- *
- * Note:
- *   The caller must provide a valid region number.
- */
-static inline int _is_user_accessible_region(u32_t r_index, int write)
-{
-	u32_t r_ap = _get_region_ap(r_index);
-
-	/* always return true if this is the thread stack region */
-	if (_get_region_index_by_type(THREAD_STACK_REGION) == r_index) {
-		return 1;
-	}
-
-	if (write) {
-		return r_ap == P_RW_U_RW;
-	}
-
-	return r_ap & MPU_USER_READ_ACCESSIBLE_Msk;
-}
-
 /**
  * @brief validate the given buffer is user accessible or not
  *
@@ -452,28 +283,7 @@ static inline int _is_user_accessible_region(u32_t r_index, int write)
  */
 int arm_core_mpu_buffer_validate(void *addr, size_t size, int write)
 {
-	s32_t r_index;
-
-	/* Iterate all mpu regions in reversed order */
-	for (r_index = _get_num_regions() - 1; r_index >= 0;  r_index--) {
-		if (!_is_enabled_region(r_index) ||
-		    !_is_in_region(r_index, (u32_t)addr, size)) {
-			continue;
-		}
-
-		/* For ARM MPU, higher region number takes priority.
-		 * Since we iterate all mpu regions in reversed order, so
-		 * we can stop the iteration immediately once we find the
-		 * matched region that grants permission or denies access.
-		 */
-		if (_is_user_accessible_region(r_index, write)) {
-			return 0;
-		} else {
-			return -EPERM;
-		}
-	}
-
-	return -EPERM;
+	return _mpu_buffer_validate(addr, size, write);
 }
 #endif /* CONFIG_USERSPACE */
 #endif /* USERSPACE || MPU_STACK_GUARD || APPLICATION_MEMORY */

--- a/arch/arm/core/cortex_m/mpu/arm_mpu_v7_internal.h
+++ b/arch/arm/core/cortex_m/mpu/arm_mpu_v7_internal.h
@@ -5,6 +5,11 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+/* Global MPU configuration at system initialization. */
+static void _mpu_init(void)
+{
+	/* No specific configuration at init for ARMv7-M MPU. */
+}
 
 /* This internal function performs MPU region initialization.
  *

--- a/arch/arm/core/cortex_m/mpu/arm_mpu_v7_internal.h
+++ b/arch/arm/core/cortex_m/mpu/arm_mpu_v7_internal.h
@@ -1,0 +1,224 @@
+/*
+ * Copyright (c) 2017 Linaro Limited.
+ * Copyright (c) 2018 Nordic Semiconductor ASA.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+
+/* This internal function performs MPU region initialization.
+ *
+ * Note:
+ *   The caller must provide a valid region index.
+ */
+static void _region_init(u32_t index, struct arm_mpu_region *region_conf)
+{
+	/* Select the region you want to access */
+	MPU->RNR = index;
+	/* Configure the region */
+	MPU->RBAR = (region_conf->base & MPU_RBAR_ADDR_Msk)
+				| MPU_RBAR_VALID_Msk | index;
+	MPU->RASR = region_conf->attr.rasr | MPU_RASR_ENABLE_Msk;
+	SYS_LOG_DBG("[%d] 0x%08x 0x%08x",
+		index, region_conf->base, region_conf->attr.rasr);
+}
+
+#if defined(CONFIG_USERSPACE) || defined(CONFIG_MPU_STACK_GUARD) || \
+	defined(CONFIG_APPLICATION_MEMORY)
+
+static inline u8_t _get_num_regions(void);
+static inline u32_t _get_region_index_by_type(u32_t type);
+
+/**
+ * This internal function converts the region size to
+ * the SIZE field value of MPU_RASR.
+ *
+ * Note: If size is not a power-of-two, it is rounded-up to the next
+ * power-of-two value, and the returned SIZE field value corresponds
+ * to that power-of-two value.
+ */
+static inline u32_t _size_to_mpu_rasr_size(u32_t size)
+{
+	/* The minimal supported region size is 32 bytes */
+	if (size <= 32) {
+		return REGION_32B;
+	}
+
+	/*
+	 * A size value greater than 2^31 could not be handled by
+	 * round_up_to_next_power_of_two() properly. We handle
+	 * it separately here.
+	 */
+	if (size > (1 << 31)) {
+		return REGION_4G;
+	}
+
+	return ((32 - __builtin_clz(size - 1) - 2 + 1) << MPU_RASR_SIZE_Pos) &
+		MPU_RASR_SIZE_Msk;
+}
+
+/**
+ * Generate the value of the MPU Region Attribute and Size Register
+ * (MPU_RASR) that corresponds to the supplied MPU region attributes.
+ * This function is internal to the driver.
+ */
+static inline u32_t _get_region_attr(u32_t xn, u32_t ap, u32_t tex,
+				     u32_t c, u32_t b, u32_t s,
+				     u32_t srd, u32_t region_size)
+{
+	int size = _size_to_mpu_rasr_size(region_size);
+
+	return (((xn << MPU_RASR_XN_Pos) & MPU_RASR_XN_Msk)
+		| ((ap << MPU_RASR_AP_Pos) & MPU_RASR_AP_Msk)
+		| ((tex << MPU_RASR_TEX_Pos) & MPU_RASR_TEX_Msk)
+		| ((s << MPU_RASR_S_Pos) & MPU_RASR_S_Msk)
+		| ((c << MPU_RASR_C_Pos) & MPU_RASR_C_Msk)
+		| ((b << MPU_RASR_B_Pos) & MPU_RASR_B_Msk)
+		| ((srd << MPU_RASR_SRD_Pos) & MPU_RASR_SRD_Msk)
+		| (size));
+}
+
+/**
+ * This internal function allocates default RAM cache-ability, share-ability,
+ * and execution allowance attributes along with the requested access
+ * permissions and size.
+ */
+static inline void _get_mpu_ram_region_attr(arm_mpu_region_attr_t *p_attr,
+	u32_t ap, u32_t base, u32_t size)
+{
+	/* in ARMv7-M MPU the base address is not required
+	 * to determine region attributes.
+	 */
+	(void) base;
+
+	p_attr->rasr = _get_region_attr(1, ap, 1, 1, 1, 1, 0, size);
+}
+
+/**
+ * This internal function is utilized by the MPU driver to combine a given
+ * MPU RAM attribute configuration and region size and return the correct
+ * parameter set.
+ */
+static inline void _get_ram_region_attr_by_conf(arm_mpu_region_attr_t *p_attr,
+	u32_t attr, u32_t base, u32_t size)
+{
+	/* in ARMv7-M MPU the base address is not required
+	 * to determine region attributes
+	 */
+	(void) base;
+
+	p_attr->rasr = attr | _size_to_mpu_rasr_size(size);
+}
+
+/**
+ * This internal function checks if region is enabled or not.
+ *
+ * Note:
+ *   The caller must provide a valid region number.
+ */
+static inline int _is_enabled_region(u32_t r_index)
+{
+	MPU->RNR = r_index;
+
+	return MPU->RASR & MPU_RASR_ENABLE_Msk;
+}
+
+/**
+ * This internal function checks if the given buffer is in the region.
+ *
+ * Note:
+ *   The caller must provide a valid region number.
+ */
+static inline int _is_in_region(u32_t r_index, u32_t start, u32_t size)
+{
+	u32_t r_addr_start;
+	u32_t r_size_lshift;
+	u32_t r_addr_end;
+
+	MPU->RNR = r_index;
+	r_addr_start = MPU->RBAR & MPU_RBAR_ADDR_Msk;
+	r_size_lshift = ((MPU->RASR & MPU_RASR_SIZE_Msk) >>
+			MPU_RASR_SIZE_Pos) + 1;
+	r_addr_end = r_addr_start + (1 << r_size_lshift) - 1;
+
+	if (start >= r_addr_start && (start + size - 1) <= r_addr_end) {
+		return 1;
+	}
+
+	return 0;
+}
+
+/**
+ * This internal function returns the access permissions of an MPU region
+ * specified by its region index.
+ *
+ * Note:
+ *   The caller must provide a valid region number.
+ */
+static inline u32_t _get_region_ap(u32_t r_index)
+{
+	MPU->RNR = r_index;
+	return (MPU->RASR & MPU_RASR_AP_Msk) >> MPU_RASR_AP_Pos;
+}
+
+/* Only a single bit is set for all user accessible permissions.
+ * In ARMv7-M MPU this is bit AP[1].
+ */
+#define MPU_USER_READ_ACCESSIBLE_Msk (P_RW_U_RO & P_RW_U_RW & P_RO_U_RO & RO)
+
+#if defined(CONFIG_USERSPACE)
+/**
+ * This internal function checks if the region is user accessible or not.
+ *
+ * Note:
+ *   The caller must provide a valid region number.
+ */
+static inline int _is_user_accessible_region(u32_t r_index, int write)
+{
+	u32_t r_ap = _get_region_ap(r_index);
+
+	/* always return true if this is the thread stack region */
+	if (_get_region_index_by_type(THREAD_STACK_REGION) == r_index) {
+		return 1;
+	}
+
+	if (write) {
+		return r_ap == P_RW_U_RW;
+	}
+
+	return r_ap & MPU_USER_READ_ACCESSIBLE_Msk;
+}
+
+/**
+ * This internal function validates whether a given memory buffer
+ * is user accessible or not.
+ */
+static inline int _mpu_buffer_validate(void *addr, size_t size, int write)
+{
+	s32_t r_index;
+
+	/* Iterate all mpu regions in reversed order */
+	for (r_index = _get_num_regions() - 1; r_index >= 0;  r_index--) {
+		if (!_is_enabled_region(r_index) ||
+		    !_is_in_region(r_index, (u32_t)addr, size)) {
+			continue;
+		}
+
+		/* For ARM MPU, higher region number takes priority.
+		 * Since we iterate all mpu regions in reversed order, so
+		 * we can stop the iteration immediately once we find the
+		 * matched region that grants permission or denies access.
+		 */
+		if (_is_user_accessible_region(r_index, write)) {
+			return 0;
+		} else {
+			return -EPERM;
+		}
+	}
+
+	return -EPERM;
+
+}
+#endif /* CONFIG_USERSPACE */
+
+#endif /* USERSPACE || MPU_STACK_GUARD || APPLICATION_MEMORY */

--- a/arch/arm/core/cortex_m/mpu/arm_mpu_v7_internal.h
+++ b/arch/arm/core/cortex_m/mpu/arm_mpu_v7_internal.h
@@ -54,7 +54,7 @@ static inline u32_t _size_to_mpu_rasr_size(u32_t size)
 	 * round_up_to_next_power_of_two() properly. We handle
 	 * it separately here.
 	 */
-	if (size > (1 << 31)) {
+	if (size > (1UL << 31)) {
 		return REGION_4G;
 	}
 
@@ -144,7 +144,7 @@ static inline int _is_in_region(u32_t r_index, u32_t start, u32_t size)
 	r_addr_start = MPU->RBAR & MPU_RBAR_ADDR_Msk;
 	r_size_lshift = ((MPU->RASR & MPU_RASR_SIZE_Msk) >>
 			MPU_RASR_SIZE_Pos) + 1;
-	r_addr_end = r_addr_start + (1 << r_size_lshift) - 1;
+	r_addr_end = r_addr_start + (1UL << r_size_lshift) - 1;
 
 	if (start >= r_addr_start && (start + size - 1) <= r_addr_end) {
 		return 1;

--- a/arch/arm/core/cortex_m/mpu/arm_mpu_v8_internal.h
+++ b/arch/arm/core/cortex_m/mpu/arm_mpu_v8_internal.h
@@ -62,7 +62,7 @@ static void _region_init(u32_t index, struct arm_mpu_region *region_conf)
 static inline void _get_mpu_ram_region_attr(arm_mpu_region_attr_t *p_attr,
 	u32_t ap, u32_t base, u32_t size)
 {
-	p_attr->rbar = ((1 << MPU_RBAR_XN_Pos) & MPU_RBAR_XN_Msk)
+	p_attr->rbar = ((1UL << MPU_RBAR_XN_Pos) & MPU_RBAR_XN_Msk)
 		| ((ap << MPU_RBAR_AP_Pos) & MPU_RBAR_AP_Msk);
 	p_attr->mair_idx = MPU_MAIR_INDEX_SRAM;
 	p_attr->r_limit = REGION_LIMIT_ADDR(base, size);

--- a/arch/arm/core/cortex_m/mpu/arm_mpu_v8_internal.h
+++ b/arch/arm/core/cortex_m/mpu/arm_mpu_v8_internal.h
@@ -1,0 +1,139 @@
+/*
+ * Copyright (c) 2017 Linaro Limited.
+ * Copyright (c) 2018 Nordic Semiconductor ASA.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <cmse.h>
+
+/* Global MPU configuration at system initialization. */
+static void _mpu_init(void)
+{
+	/* Configure the cache-ability attributes for all the
+	 * different types of memory regions.
+	 */
+
+	/* Flash region(s): Attribute-0
+	 * SRAM region(s): Attribute-1
+	 */
+	MPU->MAIR0 =
+		((MPU_MAIR_ATTR_FLASH << MPU_MAIR0_Attr0_Pos) &
+			MPU_MAIR0_Attr0_Msk)
+		|
+		((MPU_MAIR_ATTR_SRAM << MPU_MAIR0_Attr1_Pos) &
+			MPU_MAIR0_Attr1_Msk);
+}
+
+/* This internal function performs MPU region initialization.
+ *
+ * Note:
+ *   The caller must provide a valid region index.
+ */
+static void _region_init(u32_t index, struct arm_mpu_region *region_conf)
+{
+	ARM_MPU_SetRegion(
+		/* RNR */
+		index,
+		/* RBAR */
+		(region_conf->base & MPU_RBAR_BASE_Msk)
+		| (region_conf->attr.rbar &
+			(MPU_RBAR_XN_Msk | MPU_RBAR_AP_Msk | MPU_RBAR_SH_Msk)),
+		/* RLAR */
+		(region_conf->attr.r_limit & MPU_RLAR_LIMIT_Msk)
+		| ((region_conf->attr.mair_idx << MPU_RLAR_AttrIndx_Pos)
+			& MPU_RLAR_AttrIndx_Msk)
+		| MPU_RLAR_EN_Msk
+	);
+
+	SYS_LOG_DBG("[%d] 0x%08x 0x%08x 0x%08x 0x%08x",
+			index, region_conf->base, region_conf->attr.rbar,
+			region_conf->attr.mair_idx, region_conf->attr.r_limit);
+}
+
+#if defined(CONFIG_USERSPACE) || defined(CONFIG_MPU_STACK_GUARD) || \
+	defined(CONFIG_APPLICATION_MEMORY)
+
+/**
+ * This internal function allocates default RAM cache-ability, share-ability,
+ * and execution allowance attributes along with the requested access
+ * permissions and size.
+ */
+static inline void _get_mpu_ram_region_attr(arm_mpu_region_attr_t *p_attr,
+	u32_t ap, u32_t base, u32_t size)
+{
+	p_attr->rbar = ((1 << MPU_RBAR_XN_Pos) & MPU_RBAR_XN_Msk)
+		| ((ap << MPU_RBAR_AP_Pos) & MPU_RBAR_AP_Msk);
+	p_attr->mair_idx = MPU_MAIR_INDEX_SRAM;
+	p_attr->r_limit = REGION_LIMIT_ADDR(base, size);
+}
+
+/**
+ * This internal function is utilized by the MPU driver to combine a given
+ * MPU RAM attribute configuration and region size and fill-in a structure with
+ * the correct parameter set.
+ */
+static inline void _get_ram_region_attr_by_conf(arm_mpu_region_attr_t *p_attr,
+	u32_t ap_attr, u32_t base, u32_t size)
+{
+	p_attr->rbar = ap_attr  & (MPU_RBAR_XN_Msk | MPU_RBAR_AP_Msk);
+	p_attr->mair_idx = MPU_MAIR_INDEX_SRAM;
+	p_attr->r_limit = REGION_LIMIT_ADDR(base, size);
+}
+
+/**
+ * This internal function checks if region is enabled or not.
+ *
+ * Note:
+ *   The caller must provide a valid region number.
+ */
+static inline int _is_enabled_region(u32_t r_index)
+{
+	MPU->RNR = r_index;
+
+	return MPU->RLAR & MPU_RLAR_EN_Msk;
+}
+
+/**
+ * This internal function checks if the given buffer is in the region.
+ *
+ * Note:
+ *   The caller must provide a valid region number.
+ */
+static inline int _is_in_region(u32_t r_index, u32_t start, u32_t size)
+{
+	u32_t region_start_addr = arm_cmse_mpu_region_get(start);
+	u32_t region_end_addr = arm_cmse_mpu_region_get(start + size - 1);
+
+	/* MPU regions are contiguous so return true if both start and end address
+	 * are in the same region and this region is indexed by r_index.
+	 */
+	if ((region_start_addr == r_index) && (region_end_addr == r_index)) {
+		return 1;
+	}
+
+	return 0;
+}
+
+/**
+ * This internal function validates whether a given memory buffer
+ * is user accessible or not.
+ */
+static inline int _mpu_buffer_validate(void *addr, size_t size, int write)
+{
+	u32_t _addr = (u32_t)addr;
+	u32_t _size = (u32_t)size;
+
+	if (write) {
+		if (arm_cmse_addr_range_readwrite_ok(_addr, _size, 1)) {
+			return 0;
+		}
+	} else {
+		if (arm_cmse_addr_range_read_ok(_addr, _size, 1)) {
+			return 0;
+		}
+	}
+
+	return -EPERM;
+}
+#endif /* USERSPACE || MPU_STACK_GUARD || APPLICATION_MEMORY */

--- a/include/arch/arm/cortex_m/mpu/arm_mpu.h
+++ b/include/arch/arm/cortex_m/mpu/arm_mpu.h
@@ -50,6 +50,16 @@
 #endif /* _ASMLANGUAGE */
 #endif /* USERSPACE */
 
+/* Region definition data structure */
+struct arm_mpu_region {
+	/* Region Base Address */
+	u32_t base;
+	/* Region Name */
+	const char *name;
+	/* Region Attributes */
+	arm_mpu_region_attr_t attr;
+};
+
 /* MPU configuration data structure */
 struct arm_mpu_config {
 	/* Number of regions */
@@ -57,6 +67,13 @@ struct arm_mpu_config {
 	/* Regions */
 	struct arm_mpu_region *mpu_regions;
 };
+
+#define MPU_REGION_ENTRY(_name, _base, _attr) \
+	{\
+		.name = _name, \
+		.base = _base, \
+		.attr = _attr, \
+	}
 
 /* Reference to the MPU configuration */
 extern struct arm_mpu_config mpu_config;

--- a/include/arch/arm/cortex_m/mpu/arm_mpu.h
+++ b/include/arch/arm/cortex_m/mpu/arm_mpu.h
@@ -14,6 +14,11 @@
 	defined(CONFIG_CPU_CORTEX_M4) || \
 	defined(CONFIG_CPU_CORTEX_M7)
 #include <arch/arm/cortex_m/mpu/arm_mpu_v7m.h>
+#elif defined(CONFIG_CPU_CORTEX_M23) || \
+	defined(CONFIG_CPU_CORTEX_M33)
+#include <arch/arm/cortex_m/mpu/arm_mpu_v8m.h>
+#else
+#error "Unsupported ARM CPU"
 #endif
 
 #ifdef CONFIG_USERSPACE

--- a/include/arch/arm/cortex_m/mpu/arm_mpu_v7m.h
+++ b/include/arch/arm/cortex_m/mpu/arm_mpu_v7m.h
@@ -102,34 +102,29 @@
 
 /* Some helper defines for common regions */
 #define REGION_RAM_ATTR(size) \
+{ \
 	(NORMAL_OUTER_INNER_WRITE_BACK_WRITE_READ_ALLOCATE_NON_SHAREABLE | \
-	 MPU_RASR_XN_Msk | size | P_RW_U_NA_Msk)
+	 MPU_RASR_XN_Msk | size | P_RW_U_NA_Msk) \
+}
 #if defined(CONFIG_MPU_ALLOW_FLASH_WRITE)
 #define REGION_FLASH_ATTR(size) \
+{ \
 	(NORMAL_OUTER_INNER_WRITE_THROUGH_NON_SHAREABLE | size | \
-		P_RW_U_RO_Msk)
+		P_RW_U_RO_Msk) \
+}
 #else
 #define REGION_FLASH_ATTR(size) \
-	(NORMAL_OUTER_INNER_WRITE_THROUGH_NON_SHAREABLE | size | RO_Msk)
+{ \
+	(NORMAL_OUTER_INNER_WRITE_THROUGH_NON_SHAREABLE | size | RO_Msk) \
+}
 #endif
-#define REGION_PPB_ATTR(size) (STRONGLY_ORDERED_SHAREABLE | size | \
-		P_RW_U_NA_Msk)
-#define REGION_IO_ATTR(size) (DEVICE_NON_SHAREABLE | size | P_RW_U_NA_Msk)
+#define REGION_PPB_ATTR(size) { (STRONGLY_ORDERED_SHAREABLE | size | \
+		P_RW_U_NA_Msk) }
+#define REGION_IO_ATTR(size) { (DEVICE_NON_SHAREABLE | size | P_RW_U_NA_Msk) }
 
-
-/* Region definition data structure */
-struct arm_mpu_region {
-	/* Region Base Address */
-	u32_t base;
-	/* Region Name */
-	const char *name;
-	/* Region Attributes */
-	u32_t attr;
+struct arm_mpu_region_attr {
+	/* Attributes belonging to RASR (including the encoded region size) */
+	u32_t rasr;
 };
 
-#define MPU_REGION_ENTRY(_name, _base, _attr) \
-	{\
-		.name = _name, \
-		.base = _base, \
-		.attr = _attr, \
-	}
+typedef struct arm_mpu_region_attr arm_mpu_region_attr_t;

--- a/include/arch/arm/cortex_m/mpu/arm_mpu_v8m.h
+++ b/include/arch/arm/cortex_m/mpu/arm_mpu_v8m.h
@@ -1,0 +1,132 @@
+/*
+ * Copyright (c) 2018 Linaro Limited.
+ * Copyright (c) 2018 Nordic Semiconductor ASA.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/* Privileged No Access, Unprivileged No Access */
+/*#define NO_ACCESS       0x0 */
+/*#define NO_ACCESS_Msk   ((NO_ACCESS << MPU_RASR_AP_Pos) & MPU_RASR_AP_Msk) */
+/* Privileged No Access, Unprivileged No Access */
+/*#define P_NA_U_NA       0x0 */
+/*#define P_NA_U_NA_Msk   ((P_NA_U_NA << MPU_RASR_AP_Pos) & MPU_RASR_AP_Msk) */
+/* Privileged Read Write, Unprivileged No Access */
+#define P_RW_U_NA       0x0
+#define P_RW_U_NA_Msk   ((P_RW_U_NA << MPU_RBAR_AP_Pos) & MPU_RBAR_AP_Msk)
+/* Privileged Read Write, Unprivileged Read Only */
+/*#define P_RW_U_RO       0x2 */
+/*#define P_RW_U_RO_Msk   ((P_RW_U_RO << MPU_RASR_AP_Pos) & MPU_RASR_AP_Msk)*/
+/* Privileged Read Write, Unprivileged Read Write */
+#define P_RW_U_RW       0x1
+#define P_RW_U_RW_Msk   ((P_RW_U_RW << MPU_RBAR_AP_Pos) & MPU_RBAR_AP_Msk)
+/* Privileged Read Write, Unprivileged Read Write */
+#define FULL_ACCESS     0x1
+#define FULL_ACCESS_Msk ((FULL_ACCESS << MPU_RBAR_AP_Pos) & MPU_RBAR_AP_Msk)
+/* Privileged Read Only, Unprivileged No Access */
+#define P_RO_U_NA       0x2
+#define P_RO_U_NA_Msk   ((P_RO_U_NA << MPU_RBAR_AP_Pos) & MPU_RBAR_AP_Msk)
+/* Privileged Read Only, Unprivileged Read Only */
+#define P_RO_U_RO       0x3
+#define P_RO_U_RO_Msk   ((P_RO_U_RO << MPU_RBAR_AP_Pos) & MPU_RBAR_AP_Msk)
+/* Privileged Read Only, Unprivileged Read Only */
+#define RO              0x3
+#define RO_Msk          ((RO << MPU_RBAR_AP_Pos) & MPU_RBAR_AP_Msk)
+
+/* Attribute flag for not-allowing execution (eXecute Never) */
+#define NOT_EXEC MPU_RBAR_XN_Msk
+
+/* Attribute flags for share-ability */
+#define NON_SHAREABLE       0x0
+#define NON_SHAREABLE_Msk \
+	((NON_SHAREABLE << MPU_RBAR_SH_Pos) & MPU_RBAR_SH_Msk)
+#define OUTER_SHAREABLE 0x2
+#define OUTER_SHAREABLE_Msk \
+	((OUTER_SHAREABLE << MPU_RBAR_SH_Pos) & MPU_RBAR_SH_Msk)
+#define INNER_SHAREABLE 0x3
+#define INNER_SHAREABLE_Msk \
+	((INNER_SHAREABLE << MPU_RBAR_SH_Pos) & MPU_RBAR_SH_Msk)
+
+/* Helper define to calculate the region limit address. */
+#define REGION_LIMIT_ADDR(base, size) \
+	(((base & MPU_RBAR_BASE_Msk) + size - 1) & MPU_RLAR_LIMIT_Msk)
+
+
+/* Attribute flags for cache-ability */
+
+/* Read/Write Allocation Configurations for Cacheable Memory */
+#define R_NON_W_NON     0x0 /* Do not allocate Read/Write */
+#define R_NON_W_ALLOC   0x1 /* Do not allocate Read, Allocate Write */
+#define R_ALLOC_W_NON   0x2 /* Allocate Read, Do not allocate Write */
+#define R_ALLOC_W_ALLOC 0x3 /* Allocate Read/Write */
+
+/* Memory Attributes for Normal Memory */
+#define NORMAL_O_WT_NT  0x80 /* Normal, Outer Write-through non-transient */
+#define NORMAL_O_WB_NT  0xC0 /* Normal, Outer Write-back non-transient */
+
+#define NORMAL_I_WT_NT  0x08 /* Normal, Inner Write-through non-transient */
+#define NORMAL_I_WB_NT  0x0C /* Normal, Inner Write-back non-transient */
+
+#define NORMAL_OUTER_INNER_WRITE_THROUGH_READ_ALLOCATE_NON_TRANS \
+	((NORMAL_O_WT_NT | (R_ALLOC_W_NON << 4)) \
+	 | \
+	 (NORMAL_I_WT_NT | R_ALLOC_W_NON)) \
+
+#define NORMAL_OUTER_INNER_WRITE_BACK_WRITE_READ_ALLOCATE_NON_TRANS \
+	((NORMAL_O_WB_NT | (R_ALLOC_W_ALLOC << 4)) \
+	 | \
+	 (NORMAL_I_WB_NT | R_ALLOC_W_ALLOC))
+
+/* Common cache-ability configuration for Flash, SRAM regions */
+#define MPU_CACHE_ATTRIBUTES_FLASH \
+	NORMAL_OUTER_INNER_WRITE_THROUGH_READ_ALLOCATE_NON_TRANS
+#define MPU_CACHE_ATTRIBUTES_SRAM \
+	NORMAL_OUTER_INNER_WRITE_BACK_WRITE_READ_ALLOCATE_NON_TRANS
+
+/* Global MAIR configurations */
+#define MPU_MAIR_ATTR_FLASH  MPU_CACHE_ATTRIBUTES_FLASH
+#define MPU_MAIR_INDEX_FLASH 0
+#define MPU_MAIR_ATTR_SRAM   MPU_CACHE_ATTRIBUTES_SRAM
+#define MPU_MAIR_INDEX_SRAM  1
+
+/* Some helper defines for common regions */
+#define REGION_RAM_ATTR(base, size) \
+	{\
+		.rbar = NOT_EXEC | \
+			P_RW_U_NA_Msk | NON_SHAREABLE_Msk, /* AP, XN, SH */ \
+		/* Cache-ability */ \
+		.mair_idx = MPU_MAIR_INDEX_SRAM, \
+		.r_limit = REGION_LIMIT_ADDR(base, size),  /* Region Limit */ \
+	}
+
+#if defined(CONFIG_MPU_ALLOW_FLASH_WRITE)
+/* Note that the access permissions allow for un-privileged writes, contrary
+ * to ARMv7-M where un-privileged code has Read-Only permissions.
+ */
+#define REGION_FLASH_ATTR(base, size) \
+	{\
+		.rbar = P_RW_U_RW_Msk | NON_SHAREABLE_Msk, /* AP, XN, SH */ \
+		/* Cache-ability */ \
+		.mair_idx = MPU_MAIR_INDEX_FLASH, \
+		.r_limit = REGION_LIMIT_ADDR(base, size),  /* Region Limit */ \
+	}
+#else /* CONFIG_MPU_ALLOW_FLASH_WRITE */
+#define REGION_FLASH_ATTR(base, size) \
+	{\
+		.rbar = RO_Msk | NON_SHAREABLE_Msk, /* AP, XN, SH */ \
+		/* Cache-ability */ \
+		.mair_idx = MPU_MAIR_INDEX_FLASH, \
+		.r_limit = REGION_LIMIT_ADDR(base, size),  /* Region Limit */ \
+	}
+#endif /* CONFIG_MPU_ALLOW_FLASH_WRITE */
+
+struct arm_mpu_region_attr {
+	/* Attributes belonging to RBAR */
+	u8_t rbar: 5;
+	 /* MAIR index for attribute indirection */
+	u8_t mair_idx: 3;
+	 /* Region Limit Address value to be written to the RLAR register. */
+	u32_t r_limit;
+};
+
+ typedef struct arm_mpu_region_attr arm_mpu_region_attr_t;


### PR DESCRIPTION
This pull request implements the ARMv8-M MPU driver and integrates it to the memory protection system of Zephyr. 
- first set of commits do required refactoring to make it easier to later integrate the V8-M driver. They do not bring in any behavioral changes.
- a separate commit moves the ARMv7-M specific implementation into an internal include file, thus, hiding the code from `arm_mpu.c`.
- the actual ARMv8-M MPU driver implementation is done in a single commit. Similar to ARMv7-M, this is done in an internal include file.
- a last commit adds "UL" in certain integer shift operations.
