### PR TITLE
samples: mesh: boards: nrf52: upgrade to pass PTS, improved vendor model, randomize pulishers TID on boot

### DIFF
--- a/samples/boards/nrf52/mesh/onoff_level_lighting_vnd_app/src/main.c
+++ b/samples/boards/nrf52/mesh/onoff_level_lighting_vnd_app/src/main.c
@@ -101,7 +101,7 @@ void update_light_state(void)
 
 	printk("power-> %d, color-> %d\n", power, color);
 
-	if (gen_onoff_srv_root_user_data.onoff == 0x01) {
+	if (gen_onoff_srv_root_user_data.onoff == STATE_ON) {
 		/* LED1 On */
 		gpio_pin_write(led_device[0], LED0_GPIO_PIN, 0);
 	} else {

--- a/samples/boards/nrf52/mesh/onoff_level_lighting_vnd_app/src/main.c
+++ b/samples/boards/nrf52/mesh/onoff_level_lighting_vnd_app/src/main.c
@@ -143,4 +143,6 @@ void main(void)
 	if (err) {
 		printk("Bluetooth init failed (err %d)\n", err);
 	}
+
+	randomize_publishers_TID();
 }

--- a/samples/boards/nrf52/mesh/onoff_level_lighting_vnd_app/src/mesh/device_composition.h
+++ b/samples/boards/nrf52/mesh/onoff_level_lighting_vnd_app/src/mesh/device_composition.h
@@ -46,8 +46,8 @@ struct generic_onoff_state {
 };
 
 struct generic_level_state {
-	int level;
-	int last_level;
+	s16_t level;
+	s16_t last_level;
 	s32_t last_delta;
 	u8_t last_tid;
 	u16_t last_tx_addr;

--- a/samples/boards/nrf52/mesh/onoff_level_lighting_vnd_app/src/mesh/device_composition.h
+++ b/samples/boards/nrf52/mesh/onoff_level_lighting_vnd_app/src/mesh/device_composition.h
@@ -10,6 +10,17 @@
 
 #define CID_ZEPHYR 0x0002
 
+#define STATE_OFF	0x00
+#define STATE_ON	0x01
+#define STATE_DEFAULT	0x01
+#define STATE_RESTORE	0x02
+
+/* Following 4 values are as per Mesh Model specification */
+#define LIGHTNESS_MIN	0x0001
+#define LIGHTNESS_MAX	0xFFFF
+#define TEMP_MIN	0x0320
+#define TEMP_MAX	0x4E20
+
 /* Refer 7.2 of Mesh Model Specification */
 #define RANGE_SUCCESSFULLY_UPDATED	0x00
 #define CANNOT_SET_RANGE_MIN		0x01
@@ -20,7 +31,6 @@ enum temperature { ONOFF_TEMP = 0x01, LEVEL_TEMP, CTL_TEMP, IGNORE_TEMP };
 
 struct generic_onoff_state {
 	u8_t onoff;
-	u8_t model_instance;
 	u8_t last_tid;
 	u16_t last_tx_addr;
 };
@@ -29,14 +39,12 @@ struct generic_level_state {
 	int level;
 	int last_level;
 	s32_t last_delta;
-	u8_t model_instance;
 	u8_t last_tid;
 	u16_t last_tx_addr;
 };
 
 struct generic_onpowerup_state {
 	u8_t onpowerup;
-	u8_t model_instance;
 	u8_t last_tid;
 	u16_t last_tx_addr;
 };

--- a/samples/boards/nrf52/mesh/onoff_level_lighting_vnd_app/src/mesh/device_composition.h
+++ b/samples/boards/nrf52/mesh/onoff_level_lighting_vnd_app/src/mesh/device_composition.h
@@ -43,9 +43,7 @@ struct generic_onpowerup_state {
 
 struct vendor_state {
 	int current;
-	int previous;
 	u32_t response;
-	u8_t model_instance;
 	u8_t last_tid;
 	u16_t last_tx_addr;
 };

--- a/samples/boards/nrf52/mesh/onoff_level_lighting_vnd_app/src/mesh/device_composition.h
+++ b/samples/boards/nrf52/mesh/onoff_level_lighting_vnd_app/src/mesh/device_composition.h
@@ -10,12 +10,16 @@
 
 #define CID_ZEPHYR 0x0002
 
-enum lightness { ONPOWERUP = 0x01, ONOFF, LEVEL, ACTUAL, LINEAR, CTL, IGNORE};
-enum temperature { ONOFF_TEMP = 0x01, LEVEL_TEMP, CTL_TEMP, IGNORE_TEMP};
+/* Refer 7.2 of Mesh Model Specification */
+#define RANGE_SUCCESSFULLY_UPDATED	0x00
+#define CANNOT_SET_RANGE_MIN		0x01
+#define CANNOT_SET_RANGE_MAX		0x02
+
+enum lightness { ONPOWERUP = 0x01, ONOFF, LEVEL, ACTUAL, LINEAR, CTL, IGNORE };
+enum temperature { ONOFF_TEMP = 0x01, LEVEL_TEMP, CTL_TEMP, IGNORE_TEMP };
 
 struct generic_onoff_state {
 	u8_t onoff;
-	u8_t previous;
 	u8_t model_instance;
 	u8_t last_tid;
 	u16_t last_tx_addr;
@@ -23,6 +27,8 @@ struct generic_onoff_state {
 
 struct generic_level_state {
 	int level;
+	int last_level;
+	s32_t last_delta;
 	u8_t model_instance;
 	u8_t last_tid;
 	u16_t last_tx_addr;

--- a/samples/boards/nrf52/mesh/onoff_level_lighting_vnd_app/src/mesh/device_composition.h
+++ b/samples/boards/nrf52/mesh/onoff_level_lighting_vnd_app/src/mesh/device_composition.h
@@ -26,7 +26,17 @@
 #define CANNOT_SET_RANGE_MIN		0x01
 #define CANNOT_SET_RANGE_MAX		0x02
 
-enum lightness { ONPOWERUP = 0x01, ONOFF, LEVEL, ACTUAL, LINEAR, CTL, IGNORE };
+enum lightness {
+	ONPOWERUP = 0x01,
+	ONOFF,
+	LEVEL,
+	DELTA_LEVEL,
+	ACTUAL,
+	LINEAR,
+	CTL,
+	IGNORE
+};
+
 enum temperature { ONOFF_TEMP = 0x01, LEVEL_TEMP, CTL_TEMP, IGNORE_TEMP };
 
 struct generic_onoff_state {

--- a/samples/boards/nrf52/mesh/onoff_level_lighting_vnd_app/src/mesh/publisher.c
+++ b/samples/boards/nrf52/mesh/onoff_level_lighting_vnd_app/src/mesh/publisher.c
@@ -15,6 +15,28 @@
 
 #define GENERIC_LEVEL
 
+static bool is_randomization_of_TIDs_done;
+static u8_t tid_level;
+
+#ifndef VND_MODEL_TEST
+static u8_t tid_onoff;
+#else
+static u8_t tid_vnd;
+#endif
+
+void randomize_publishers_TID(void)
+{
+	bt_rand(&tid_level, sizeof(tid_level));
+
+#ifndef VND_MODEL_TEST
+	bt_rand(&tid_onoff, sizeof(tid_onoff));
+#else
+	bt_rand(&tid_vnd, sizeof(tid_vnd));
+#endif
+
+	is_randomization_of_TIDs_done = true;
+}
+
 static u32_t button_read(struct device *port, u32_t pin)
 {
 	u32_t val = 0;
@@ -26,13 +48,10 @@ static u32_t button_read(struct device *port, u32_t pin)
 void publish(struct k_work *work)
 {
 	int err = 0;
-	static u8_t tid_level;
 
-#ifndef VND_MODEL_TEST
-	static u8_t tid_onoff;
-#else
-	static u8_t tid_vnd;
-#endif
+	if (is_randomization_of_TIDs_done == false) {
+		return;
+	}
 
 	if (button_read(button_device[0], SW0_GPIO_PIN) == 0) {
 

--- a/samples/boards/nrf52/mesh/onoff_level_lighting_vnd_app/src/mesh/publisher.c
+++ b/samples/boards/nrf52/mesh/onoff_level_lighting_vnd_app/src/mesh/publisher.c
@@ -45,7 +45,7 @@ void publish(struct k_work *work)
 #else
 		bt_mesh_model_msg_init(vnd_models[0].pub->msg,
 				       BT_MESH_MODEL_OP_3(0x02, CID_ZEPHYR));
-		net_buf_simple_add_le16(vnd_models[0].pub->msg, 0xFF01);
+		net_buf_simple_add_le16(vnd_models[0].pub->msg, 0x0001);
 		net_buf_simple_add_u8(vnd_models[0].pub->msg, tid_vnd++);
 		err = bt_mesh_model_publish(&vnd_models[0]);
 #endif
@@ -61,7 +61,7 @@ void publish(struct k_work *work)
 #else
 		bt_mesh_model_msg_init(vnd_models[0].pub->msg,
 				       BT_MESH_MODEL_OP_3(0x02, CID_ZEPHYR));
-		net_buf_simple_add_le16(vnd_models[0].pub->msg, 0xFF00);
+		net_buf_simple_add_le16(vnd_models[0].pub->msg, 0x0000);
 		net_buf_simple_add_u8(vnd_models[0].pub->msg, tid_vnd++);
 		err = bt_mesh_model_publish(&vnd_models[0]);
 #endif

--- a/samples/boards/nrf52/mesh/onoff_level_lighting_vnd_app/src/mesh/publisher.h
+++ b/samples/boards/nrf52/mesh/onoff_level_lighting_vnd_app/src/mesh/publisher.h
@@ -21,6 +21,7 @@
 #define LEVEL_U75  49152
 #define LEVEL_U100 65535
 
+void randomize_publishers_TID(void);
 void publish(struct k_work *work);
 
 #endif


### PR DESCRIPTION
Updated state Binding as per PTS test requirements. Now if gen_onoff_server &
gen_onpowerup_server received Prohibited values then they will not react on it further. Plus make necessary changes wherever required for message handlers as per Mesh Model
Specification which is mostly regarding to default & range values. Now right Status code would get publish in response to set lightness & temperature range. Also upgrade Message handler
gen_delta_set_unack() algorithm as per PTS requirements.

Update Vendor model message handlers & make it to work as per TID like other Models defined by SIG. Removed union based data extraction mechanism. Improved code readability by declaring some pre-processor definitions in device_composition.c

Remove model_instance variable from some structures define in device_composition.h & its relevant code. Now on reboot, NODE as client do not start message publishing with TID = 1. Instead of that it would start with any random value from 0 to 255. Added extra case under state binding's switch statement for Lightness i.e DELTA_LEVEL. Also upgrade binding between

1. root element's LEVEL state & Light Lightness Actual state.
2. Light Lightness Linear state & Light Lightness Actual state.
3. Light CTL lightness state & Light Lightness Actual state

Signed-off-by: Vikrant More <vikrant8051@gmail.com>