### PR TITLE
shell: Fix command completion logic

### DIFF
--- a/subsys/shell/shell.c
+++ b/subsys/shell/shell.c
@@ -519,7 +519,7 @@ static struct shell_module *get_completion_module(char *str,
 	str = strchr(str, ' ');
 
 	/* only two parameters are possibles in case of no default module */
-	return str ? dest : NULL;
+	return str ? NULL : dest;
 }
 
 static u8_t completion(char *line, u8_t len)


### PR DESCRIPTION
Similar fix as in commit b26ca136726aee3927. Just later in the same
function. This is how the logic used to be before quite heavy redesign
that happened a while ago.

Signed-off-by: Johan Hedberg <johan.hedberg@intel.com>