### PR TITLE
RFC: usb: drivers: Enable USB on stm32f429i_disc1 board

### DIFF
--- a/boards/arm/stm32f429i_disc1/pinmux.c
+++ b/boards/arm/stm32f429i_disc1/pinmux.c
@@ -22,6 +22,10 @@ static const struct pin_config pinconf[] = {
 	{STM32_PIN_PA2, STM32F4_PINMUX_FUNC_PA2_USART2_TX},
 	{STM32_PIN_PA3, STM32F4_PINMUX_FUNC_PA3_USART2_RX},
 #endif  /* CONFIG_UART_STM32_PORT_2 */
+#ifdef CONFIG_USB_DC_STM32
+	{STM32_PIN_PA11, STM32F4_PINMUX_FUNC_PA11_OTG_FS_DM},
+	{STM32_PIN_PA12, STM32F4_PINMUX_FUNC_PA12_OTG_FS_DP},
+#endif  /* CONFIG_USB_DC_STM32 */
 };
 
 static int pinmux_stm32_init(struct device *port)

--- a/boards/arm/stm32f429i_disc1/stm32f429i_disc1.dts
+++ b/boards/arm/stm32f429i_disc1/stm32f429i_disc1.dts
@@ -56,3 +56,7 @@
 	pinctrl-names = "default";
 	status = "ok";
 };
+
+&usbotg_fs {
+	status = "ok";
+};

--- a/boards/arm/stm32f429i_disc1/stm32f429i_disc1.yaml
+++ b/boards/arm/stm32f429i_disc1/stm32f429i_disc1.yaml
@@ -5,3 +5,5 @@ arch: arm
 toolchain:
   - zephyr
   - gccarmemb
+supported:
+  - usb_device

--- a/boards/arm/stm32f429i_disc1/support/openocd.cfg
+++ b/boards/arm/stm32f429i_disc1/support/openocd.cfg
@@ -1,4 +1,4 @@
-source [find board/st_nucleo_f4.cfg]
+source [find board/stm32f429disc1.cfg]
 
 $_TARGETNAME configure -event gdb-attach {
 	echo "Debugger attaching: halting execution"


### PR DESCRIPTION
Enable USB controller for 32F429IDISCOVERY board:
https://www.st.com/en/evaluation-tools/32f429idiscovery.html

Signed-off-by: Andrei Emeltchenko <andrei.emeltchenko@intel.com>