### PR TITLE
clock_control: nRF5x: Non-blocking 32KHz crystal oscillator startup

### DIFF
--- a/drivers/clock_control/Kconfig.nrf5
+++ b/drivers/clock_control/Kconfig.nrf5
@@ -12,10 +12,11 @@ menuconfig CLOCK_CONTROL_NRF5
 	  Enable support for the Nordic Semiconductor nRF5x series SoC clock
 	  driver.
 
+if CLOCK_CONTROL_NRF5
+
 config CLOCK_CONTROL_NRF5_IRQ_PRIORITY
 	int
 	prompt "Power Clock Interrupt Priority"
-	depends on CLOCK_CONTROL_NRF5
 	range 0 7
 	default 1
 	help
@@ -24,19 +25,16 @@ config CLOCK_CONTROL_NRF5_IRQ_PRIORITY
 config CLOCK_CONTROL_NRF5_M16SRC_DRV_NAME
 	string
 	prompt "NRF5 16MHz clock device name"
-	depends on CLOCK_CONTROL_NRF5
 	default "clk_m16src"
 
 config CLOCK_CONTROL_NRF5_K32SRC_DRV_NAME
 	string
 	prompt "NRF5 32KHz clock device name"
-	depends on CLOCK_CONTROL_NRF5
 	default "clk_k32src"
 
 choice
 	prompt "32KHz clock source"
 	default CLOCK_CONTROL_NRF5_K32SRC_XTAL
-	depends on CLOCK_CONTROL_NRF5
 
 config CLOCK_CONTROL_NRF5_K32SRC_RC
 	bool
@@ -48,11 +46,20 @@ config CLOCK_CONTROL_NRF5_K32SRC_XTAL
 
 endchoice
 
+config CLOCK_CONTROL_NRF5_K32SRC_BLOCKING
+	bool
+	prompt "Blocking 32KHz crystal oscillator startup"
+	depends on CLOCK_CONTROL_NRF5_K32SRC_XTAL
+	help
+	  Clock control driver will spin wait in CPU sleep until 32KHz
+	  crystal oscillator starts up. If not enabled, RC oscillator will
+	  initially start running and automatically switch to crystal when
+	  ready.
+
 choice
 	prompt "32KHz clock accuracy"
 	default CLOCK_CONTROL_NRF5_K32SRC_500PPM if CLOCK_CONTROL_NRF5_K32SRC_RC
 	default CLOCK_CONTROL_NRF5_K32SRC_20PPM
-	depends on CLOCK_CONTROL_NRF5
 
 config CLOCK_CONTROL_NRF5_K32SRC_500PPM
 	bool
@@ -87,3 +94,5 @@ config CLOCK_CONTROL_NRF5_K32SRC_20PPM
 	prompt "0 ppm to 20 ppm"
 
 endchoice
+
+endif # CLOCK_CONTROL_NRF5

--- a/drivers/clock_control/nrf5_power_clock.c
+++ b/drivers/clock_control/nrf5_power_clock.c
@@ -23,8 +23,9 @@ static u8_t k32src_initialized;
 
 static int _m16src_start(struct device *dev, clock_control_subsys_t sub_system)
 {
-	u32_t imask;
 	bool blocking;
+	u32_t imask;
+	u32_t stat;
 
 	/* If the clock is already started then just increment refcount.
 	 * If the start and stop don't happen in pairs, a rollover will
@@ -94,7 +95,8 @@ hf_already_started:
 	 */
 	__ASSERT_NO_MSG(m16src_ref);
 
-	if (NRF_CLOCK->HFCLKSTAT & CLOCK_HFCLKSTAT_STATE_Msk) {
+	stat = CLOCK_HFCLKSTAT_SRC_Xtal | CLOCK_HFCLKSTAT_STATE_Msk;
+	if ((NRF_CLOCK->HFCLKSTAT & stat) == stat) {
 		return 0;
 	} else {
 		return -EINPROGRESS;
@@ -146,6 +148,7 @@ static int _k32src_start(struct device *dev, clock_control_subsys_t sub_system)
 {
 	u32_t lf_clk_src;
 	u32_t imask;
+	u32_t stat;
 
 #if defined(CONFIG_CLOCK_CONTROL_NRF5_K32SRC_BLOCKING)
 	u32_t intenset;
@@ -246,7 +249,9 @@ static int _k32src_start(struct device *dev, clock_control_subsys_t sub_system)
 	}
 
 lf_already_started:
-	if (NRF_CLOCK->LFCLKSTAT & CLOCK_LFCLKSTAT_STATE_Msk) {
+	stat = (NRF_CLOCK->LFCLKSRCCOPY & CLOCK_LFCLKSRCCOPY_SRC_Msk) |
+	       CLOCK_LFCLKSTAT_STATE_Msk;
+	if ((NRF_CLOCK->LFCLKSTAT & stat) == stat) {
 		return 0;
 	} else {
 		return -EINPROGRESS;

--- a/subsys/bluetooth/controller/ll_sw/ctrl.c
+++ b/subsys/bluetooth/controller/ll_sw/ctrl.c
@@ -18,6 +18,7 @@
 #include "ll.h"
 
 #if defined(CONFIG_SOC_FAMILY_NRF)
+#include <drivers/clock_control/nrf5_clock_control.h>
 #include <drivers/entropy/nrf5_entropy.h>
 #endif /* CONFIG_SOC_FAMILY_NRF */
 
@@ -160,6 +161,8 @@ static struct {
 
 	u32_t ticks_anchor;
 	u32_t remainder_anchor;
+
+	u8_t  is_k32src_stable;
 
 	u8_t  volatile ticker_id_prepare;
 	u8_t  volatile ticker_id_event;
@@ -4613,6 +4616,28 @@ static void mayfly_xtal_stop(void *params)
 
 	DEBUG_RADIO_CLOSE(0);
 }
+
+#define DRV_NAME CONFIG_CLOCK_CONTROL_NRF5_K32SRC_DRV_NAME
+#define K32SRC   CLOCK_CONTROL_NRF5_K32SRC
+static void k32src_wait(void)
+{
+	if (!_radio.is_k32src_stable) {
+		struct device *clk_k32;
+
+		_radio.is_k32src_stable = 1;
+
+		clk_k32 = device_get_binding(DRV_NAME);
+		LL_ASSERT(clk_k32);
+
+		while (clock_control_on(clk_k32, (void *)K32SRC)) {
+			DEBUG_CPU_SLEEP(1);
+			cpu_sleep();
+			DEBUG_CPU_SLEEP(0);
+		}
+	}
+}
+#undef K32SRC
+#undef DRV_NAME
 
 #if defined(CONFIG_BT_CTLR_XTAL_ADVANCED)
 #define XON_BITMASK BIT(31) /* XTAL has been retained from previous prepare */
@@ -10070,6 +10095,9 @@ u32_t radio_adv_enable(u16_t interval, u8_t chan_map, u8_t filter_policy,
 		conn->rssi_sample_count = 0;
 #endif /* CONFIG_BT_CTLR_CONN_RSSI */
 
+		/* wait for stable 32KHz clock */
+		k32src_wait();
+
 		_radio.advertiser.conn = conn;
 	} else {
 		conn = NULL;
@@ -10548,6 +10576,9 @@ u32_t radio_connect_enable(u8_t adv_addr_type, u8_t *adv_addr, u16_t interval,
 	conn->rssi_reported = 0x7F;
 	conn->rssi_sample_count = 0;
 #endif /* CONFIG_BT_CTLR_CONN_RSSI */
+
+	/* wait for stable 32KHz clock */
+	k32src_wait();
 
 	_radio.scanner.conn = conn;
 


### PR DESCRIPTION
Added Kconfig option and implementation to support a
non-blocking startup of 32KHz crystal oscillator.

This will reduce the time from boot to application start
while the crystal startup happens in background.

Signed-off-by: Vinayak Kariappa Chettimada <vich@nordicsemi.no>