### PR TITLE
logging: Avoid compile warning because of wrong type

### DIFF
--- a/include/logging/log_core.h
+++ b/include/logging/log_core.h
@@ -60,13 +60,13 @@ extern "C" {
 	log_0(_str, _src_level)
 
 #define _LOG_INTERNAL_1(_src_level, _str, _arg0) \
-	log_1(_str, (u32_t)_arg0, _src_level)
+	log_1(_str, (u32_t)(_arg0), _src_level)
 
 #define _LOG_INTERNAL_2(_src_level, _str, _arg0, _arg1)	\
-	log_2(_str, (u32_t)_arg0, (u32_t)_arg1, _src_level)
+	log_2(_str, (u32_t)(_arg0), (u32_t)(_arg1), _src_level)
 
 #define _LOG_INTERNAL_3(_src_level, _str, _arg0, _arg1, _arg2) \
-	log_3(_str, (u32_t)_arg0, (u32_t)_arg1, (u32_t)_arg2, _src_level)
+	log_3(_str, (u32_t)(_arg0), (u32_t)(_arg1), (u32_t)(_arg2), _src_level)
 
 #define __LOG_ARG_CAST(_x) (u32_t)(_x),
 


### PR DESCRIPTION
The macro parameters need to be protected by (), otherwise it
is possible to get this kind of warning

   include/logging/log_core.h:214:6: note: expected
     ‘u32_t {aka unsigned int}’ but argument is of type ‘char *’
     void log_3(const char *str,

This can happen for example if the macro parameter is not plain
variable. Example:

  NET_DBG("Route %p nexthop %s", route,
         nexthop ? net_sprint_ipv6_addr(nexthop) : "<unknown>");

Signed-off-by: Jukka Rissanen <jukka.rissanen@linux.intel.com>