### PR TITLE
logger: Provide 8 and 9 parameter logging macros

### DIFF
--- a/include/logging/log_core.h
+++ b/include/logging/log_core.h
@@ -90,6 +90,12 @@ extern "C" {
 #define _LOG_INTERNAL_7(_src_level, _str, ...) \
 		_LOG_INTERNAL_LONG(_src_level, _str, __VA_ARGS__)
 
+#define _LOG_INTERNAL_8(_src_level, _str, ...) \
+		_LOG_INTERNAL_LONG(_src_level, _str, __VA_ARGS__)
+
+#define _LOG_INTERNAL_9(_src_level, _str, ...) \
+		_LOG_INTERNAL_LONG(_src_level, _str, __VA_ARGS__)
+
 #define _LOG_LEVEL_CHECK(_level, _check_level, _default_level) \
 	(_level <= _LOG_RESOLVED_LEVEL(_check_level, _default_level))
 

--- a/subsys/logging/log_output.c
+++ b/subsys/logging/log_output.c
@@ -210,6 +210,39 @@ static void std_print(struct log_msg *msg,
 		      log_msg_arg_get(msg, 4),
 		      log_msg_arg_get(msg, 5));
 		break;
+	case 7:
+		print(ctx, str,
+		      log_msg_arg_get(msg, 0),
+		      log_msg_arg_get(msg, 1),
+		      log_msg_arg_get(msg, 2),
+		      log_msg_arg_get(msg, 3),
+		      log_msg_arg_get(msg, 4),
+		      log_msg_arg_get(msg, 5),
+		      log_msg_arg_get(msg, 6));
+		break;
+	case 8:
+		print(ctx, str,
+		      log_msg_arg_get(msg, 0),
+		      log_msg_arg_get(msg, 1),
+		      log_msg_arg_get(msg, 2),
+		      log_msg_arg_get(msg, 3),
+		      log_msg_arg_get(msg, 4),
+		      log_msg_arg_get(msg, 5),
+		      log_msg_arg_get(msg, 6),
+		      log_msg_arg_get(msg, 7));
+		break;
+	case 9:
+		print(ctx, str,
+		      log_msg_arg_get(msg, 0),
+		      log_msg_arg_get(msg, 1),
+		      log_msg_arg_get(msg, 2),
+		      log_msg_arg_get(msg, 3),
+		      log_msg_arg_get(msg, 4),
+		      log_msg_arg_get(msg, 5),
+		      log_msg_arg_get(msg, 6),
+		      log_msg_arg_get(msg, 7),
+		      log_msg_arg_get(msg, 8));
+		break;
 	}
 }
 


### PR DESCRIPTION
It is quite reasonable to provide logging macros that can have
8 or 9 parameters.

Signed-off-by: Jukka Rissanen <jukka.rissanen@linux.intel.com>