### PR TITLE
arm: nxp: mpu: Consolidate k64 mpu regions

### DIFF
--- a/arch/arm/soc/nxp_kinetis/k6x/nxp_mpu_regions.c
+++ b/arch/arm/soc/nxp_kinetis/k6x/nxp_mpu_regions.c
@@ -6,46 +6,46 @@
 #include <soc.h>
 #include <arch/arm/cortex_m/mpu/nxp_mpu.h>
 
-#define FLEXBUS_BASE_ADDRESS 0x08000000
-#define SRAM_L_BASE_ADDRESS 0x1FFF0000
-#define DEVICE_S_BASE_ADDRESS 0x20030000
-
 static struct nxp_mpu_region mpu_regions[] = {
 	/* Region 0 */
 	MPU_REGION_ENTRY("DEBUGGER_0",
 			 0,
 			 0xFFFFFFFF,
 			 REGION_DEBUG_ATTR),
+
+	/* The NXP MPU does not give precedence to memory regions like the ARM
+	 * MPU, which means that if one region grants access then another
+	 * region cannot revoke access. If an application enables hardware
+	 * stack protection, we need to disable supervisor writes from the core
+	 * to the stack guard region. As a result, we cannot have a single
+	 * background region that enables supervisor read/write access from the
+	 * core to the entire address space, and instead define two background
+	 * regions that together cover the entire address space except for
+	 * SRAM.
+	 */
+
 	/* Region 1 */
+	MPU_REGION_ENTRY("BACKGROUND_0",
+			 0,
+			 CONFIG_SRAM_BASE_ADDRESS-1,
+			 REGION_BACKGROUND_ATTR),
+	/* Region 2 */
+	MPU_REGION_ENTRY("BACKGROUND_1",
+			 CONFIG_SRAM_BASE_ADDRESS +
+				 (CONFIG_SRAM_SIZE * 1024),
+			 0xFFFFFFFF,
+			 REGION_BACKGROUND_ATTR),
+	/* Region 3 */
 	MPU_REGION_ENTRY("FLASH_0",
 			 CONFIG_FLASH_BASE_ADDRESS,
 			 0x07FFFFFF,
 			 REGION_FLASH_ATTR),
-	/* Region 2 */
-	/*
-	 * This region (Flexbus + FlexNVM) is bigger than the FLEXBUS one in
-	 * order to save 1 region allocation in the MPU.
-	 */
-	MPU_REGION_ENTRY("FLEXBUS_0",
-			 FLEXBUS_BASE_ADDRESS,
-			 0x1BFFFFFF,
-			 REGION_IO_ATTR),
-	/* Region 3 */
-	MPU_REGION_ENTRY("RAM_L_0",
-			 SRAM_L_BASE_ADDRESS,
-			 0x1FFFFFFF,
-			 REGION_RAM_ATTR),
 	/* Region 4 */
 	MPU_REGION_ENTRY("RAM_U_0",
 			 CONFIG_SRAM_BASE_ADDRESS,
 			 (CONFIG_SRAM_BASE_ADDRESS +
 				 (CONFIG_SRAM_SIZE * 1024) - 1),
 			 REGION_RAM_ATTR),
-	/* Region 5 */
-	MPU_REGION_ENTRY("DEVICE_0",
-			 DEVICE_S_BASE_ADDRESS,
-			 0xFFFFFFFF,
-			 REGION_IO_ATTR),
 };
 
 struct nxp_mpu_config mpu_config = {

--- a/include/arch/arm/cortex_m/mpu/nxp_mpu.h
+++ b/include/arch/arm/cortex_m/mpu/nxp_mpu.h
@@ -119,6 +119,8 @@
 
 #define REGION_DEBUG_ATTR  MPU_REGION_SU
 
+#define REGION_BACKGROUND_ATTR	MPU_REGION_SU_RW
+
 /* Region definition data structure */
 struct nxp_mpu_region {
 	/* Region Base Address */


### PR DESCRIPTION
Reduces the number of mpu regions statically reserved at boot time by
one, giving a total of five. We originally sought to reduce the total to
three: 1 background region with lowest precendence for supervisor r/w, 1
flash region, and 1 sram region. However, the nxp mpu hardware does not
give precedence to any region over another, and thus we cannot revoke
access from the background region with a higher priority region. This
means we cannot support hardware stack protection with a single
background region.

Instead, create two background regions that cover the entire address
space, except for sram.

Signed-off-by: Maureen Helm <maureen.helm@nxp.com>

Fixes #7705