### PR TITLE
logging: log_output: Data lost because of uninitialized variable

### DIFF
--- a/subsys/logging/log_output.c
+++ b/subsys/logging/log_output.c
@@ -6,6 +6,7 @@
 
 #include <logging/log_output.h>
 #include <logging/log_ctrl.h>
+#include <assert.h>
 #include <ctype.h>
 
 #define HEXDUMP_BYTES_IN_LINE 8
@@ -276,15 +277,17 @@ static void hexdump_print(struct log_msg *msg,
 static void raw_string_print(struct log_msg *msg,
 			     struct log_output_ctx *ctx)
 {
+	assert(ctx->length);
+
 	size_t offset = 0;
 	size_t length;
 
-	while (length > 0) {
+	do {
 		length = ctx->length;
 		log_msg_hexdump_data_get(msg, ctx->data, &length, offset);
 		offset += length;
 		ctx->func(ctx->data, length, ctx->ctx);
-	}
+	} while (length > 0);
 
 	print(ctx, "\r");
 }


### PR DESCRIPTION
Uninitialized variable error could lead to a situation where
printk calls processed by the logger were dropped.

Signed-off-by: Krzysztof Chruscinski <krzysztof.chruscinski@nordicsemi.no>