### PR TITLE
CODEOWNERS: Update entry for sensor drivers

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -80,7 +80,7 @@ drivers/interrupt_controller/*           @andrewboie
 drivers/led/*                            @Mani-Sadhasivam
 drivers/led_strip/*                      @mbolivar
 drivers/pinmux/stm32/*                   @rsalveti @idlethread
-drivers/sensor/*                         @bogdan-davidoaia
+drivers/sensor/                          @bogdan-davidoaia @MaureenHelm
 drivers/serial/uart_altera_jtag_hal.c    @ramakrishnapallala
 drivers/serial/uart_riscv_qemu.c         @fractalclone @kgugala @pgielda
 drivers/net/slip.c                       @jukkar @tbursztyka


### PR DESCRIPTION
Adds @MaureenHelm as code owner for sensor drivers, and updates the
pattern to match subdirectories.

Signed-off-by: Maureen Helm <maureen.helm@nxp.com>