### PR TITLE
boards: correct config for openocd for stm32373c

### DIFF
--- a/boards/arm/stm32373c_eval/support/openocd.cfg
+++ b/boards/arm/stm32373c_eval/support/openocd.cfg
@@ -1,4 +1,4 @@
-source [find board/st_nucleo_f3.cfg]
+source [find board/stm32f3discovery.cfg]
 
 $_TARGETNAME configure -event gdb-attach {
         echo "Debugger attaching: halting execution"


### PR DESCRIPTION
The config file sourced in openocd.cfg is the nuclean_f3 one instead of the one for
the stm32373c.

This makes it impossible to flash the stm32373c evaluation board rev.B:
	Error: open failed
	in procedure 'init'
	in procedure 'ocd_bouncer'

	error: command exited with status 1:
	/opt/zephyr-sdk/sysroots/x86_64-pokysdk-linux/usr/bin/openocd -s
	/opt/zephyr-sdk/sysroots/x86_64-pokysdk-linux/usr/share/openocd/scripts
	-f
	/home/maudat/repo_upstream/zephyr/boards/arm/stm32373c_eval/support/openocd.cfg
	-c init -c targets -c 'reset halt' -c 'flash write_image erase
	/home/maudat/repo_upstream/zephyr/samples/basic/blinky/build/zephyr/zephyr.bin
	0x8000000' -c 'reset halt' -c 'verify_image
	/home/maudat/repo_upstream/zephyr/samples/basic/blinky/build/zephyr/zephyr.bin
	0x8000000' -c 'reset run' -c shutdown

Replace the file sourced by stm32f3discovery.cfg to flash successfully.

Signed-off-by: Mathieu Audat <mathieu.audat@savoirfairelinux.com>
Signed-off-by: Sebastien Bourdelin <sebastien.bourdelin@savoirfairelinux.com>