### PR TITLE
logging: Avoid compile error if debug prints are disabled

### DIFF
--- a/include/logging/log.h
+++ b/include/logging/log.h
@@ -280,6 +280,39 @@ int log_printk(const char *fmt, va_list ap);
 #endif /*CONFIG_LOG_RUNTIME_FILTERING*/
 
 #else /* LOG enabled for the module. */
+/* No logging, so set the macros to do nothing */
+#undef LOG_ERR
+#define LOG_ERR(...)
+#undef LOG_WRN
+#define LOG_WRN(...)
+#undef LOG_INF
+#define LOG_INF(...)
+#undef LOG_DBG
+#define LOG_DBG(...)
+#undef LOG_INST_ERR
+#define LOG_INST_ERR(_log_inst, ...)
+#undef LOG_INST_WRN
+#define LOG_INST_WRN(_log_inst, ...)
+#undef LOG_INST_INF
+#define LOG_INST_INF(_log_inst, ...)
+#undef LOG_INST_DBG
+#define LOG_INST_DBG(_log_inst, ...)
+#undef LOG_HEXDUMP_ERR
+#define LOG_HEXDUMP_ERR(data, length)
+#undef LOG_HEXDUMP_WRN
+#define LOG_HEXDUMP_WRN(data, length)
+#undef LOG_HEXDUMP_INF
+#define LOG_HEXDUMP_INF(data, length)
+#undef LOG_HEXDUMP_DBG
+#define LOG_HEXDUMP_DBG(data, length)
+#undef LOG_INST_HEXDUMP_ERR
+#define LOG_INST_HEXDUMP_ERR(_log_inst, data, length)
+#undef LOG_INST_HEXDUMP_WRN
+#define LOG_INST_HEXDUMP_WRN(_log_inst, data, length)
+#undef LOG_INST_HEXDUMP_INF
+#define LOG_INST_HEXDUMP_INF(_log_inst, data, length)
+#undef LOG_INST_HEXDUMP_DBG
+#define LOG_INST_HEXDUMP_DBG(_log_inst, _data, _length)
 #define LOG_MODULE_REGISTER() /* Empty */
 #endif
 


### PR DESCRIPTION
If user has set this in .c file:

  #define LOG_MODULE_NAME abc
  #define LOG_LEVEL 0

  #include <logging/log.h>
  LOG_MODULE_REGISTER();

Here debug level is set to 0 which means that debug prints
are disabled. Then this compile error will be emitted:

  include/logging/log_instance.h:83:47: error: ‘log_dynamic_abc’
    undeclared (first use in this function);
    did you mean ‘log_dynamic_xyz’?

The commit avoids this by setting debug macros to be no-op.

Signed-off-by: Jukka Rissanen <jukka.rissanen@linux.intel.com>