### PR TITLE
kconfiglib: Add preprocessor and two warnings

### DIFF
--- a/scripts/kconfig/kconfig.py
+++ b/scripts/kconfig/kconfig.py
@@ -12,7 +12,7 @@ from kconfiglib import Kconfig, Symbol, BOOL, STRING, TRISTATE, TRI_TO_STR
 WARNING_WHITELIST = (
     # Warning generated when a symbol with unsatisfied dependencies is being
     # selected. These should be investigated, but whitelist them for now.
-    "unsatisfied direct dependencies",
+    "y-selected",
 
     # This symbol is only defined for ARC, but is set in some "shared" .conf
     # files


### PR DESCRIPTION
Update Kconfiglib to upstream revision 547fced630611 to get a new
Kconfig preprocessor in, documented in
https://github.com/torvalds/linux/blob/master/Documentation/kbuild/kconfig-macro-language.txt.

The preprocessor allows shell functions to be run directly from Kconfig.
Things like `default "prefix-$(shell,some-cmd)"` and
`depends on (success,some-cmd)` are supported.

The preprocessor might come in handy for Kconfig/DTS integration. I'm
thinking of extending it so that Python functions can be called as well.

There's also two new warnings:

 - Trying to use an int/hex symbol like a bool symbol in an expression
   (where it will always evaluate to n)

 - Having a `default` on an int/hex symbol that lies outside an active
   `range`.

The parser is more strict now as well (due to dropping some hacks for 3+
year old kernel versions).

A related fix for `scripts/kconfig.py` is also included:

The comment above the whitelist lies. I accidentally changed the warning
text for the select-with-unsatisfied-dependencies warning while
generalizing it (for `m`-valued dependencies, which you'd never get in
Zephyr).

Update the whitelist to detect the new warning text.

Last-minute piggyback:

Include a change that improved the parse time for U-Boot from 4 seconds
to about 0.6 seconds, related to symbols defined in multiple locations.
It might be helpful for Zephyr as well, as it also uses a lot of symbols
defined in multiple locations.