### PR TITLE
drivers: wifi: winc1500: Use offload_context instead of user_data.

### DIFF
--- a/include/net/net_context.h
+++ b/include/net/net_context.h
@@ -276,6 +276,11 @@ struct net_context {
 		struct k_fifo accept_q;
 	};
 #endif /* CONFIG_NET_SOCKETS */
+
+#if defined(CONFIG_NET_OFFLOAD)
+	/** context for use by offload drivers */
+	void *offload_context;
+#endif /* CONFIG_NET_OFFLOAD */
 };
 
 static inline bool net_context_is_used(struct net_context *context)


### PR DESCRIPTION
The wifi_winc1500 driver's socket id is stored in
net_context->user_data, which may be overwritten later at
the socket layer, which also uses the net_context->user_data
field to store socket flags.

This patch introduces a dedicated offload_context field
for use by offload drivers, and updates the wifi_winc1500 offload
driver to use this field instead of user_data.

Fixes #8820

Signed-off-by: Gil Pitney <gil.pitney@linaro.org>