### PR TITLE
logging: Fix fail when log locally disabled

### DIFF
--- a/include/logging/log.h
+++ b/include/logging/log.h
@@ -256,9 +256,7 @@ int log_printk(const char *fmt, va_list ap);
  * - Instance logging is used and there is no need to create module entry.
  */
 
-#if defined(LOG_MODULE_NAME) &&					 \
-	((defined(LOG_LEVEL) && (LOG_LEVEL > LOG_LEVEL_NONE)) || \
-	(!defined(LOG_LEVEL) && (CONFIG_LOG_DEFAULT_LEVEL > LOG_LEVEL_NONE)))
+#if LOG_MODULE_PRESENT
 #if CONFIG_LOG_RUNTIME_FILTERING
 #define LOG_MODULE_REGISTER()						       \
 	_LOG_CONST_ITEM_REGISTER(LOG_MODULE_NAME,			       \
@@ -279,9 +277,9 @@ int log_printk(const char *fmt, va_list ap);
 						CONFIG_LOG_DEFAULT_LEVEL))
 #endif /*CONFIG_LOG_RUNTIME_FILTERING*/
 
-#else /* LOG enabled for the module. */
+#else /* LOG_MODULE_PRESENT */
 #define LOG_MODULE_REGISTER() /* Empty */
-#endif
+#endif /* LOG_MODULE_PRESENT */
 
 /**
  * @}

--- a/include/logging/log_instance.h
+++ b/include/logging/log_instance.h
@@ -109,37 +109,6 @@ static inline u32_t log_dynamic_source_id(struct log_source_dynamic_data *data)
 			sizeof(struct log_source_dynamic_data);
 }
 
-/**
- *  @def LOG_CONST_ID_GET
- *  @brief Macro for getting ID of the element of the section.
- *
- *  @param _addr Address of the element.
- */
-/**
- * @def LOG_CURRENT_MODULE_ID
- * @brief Macro for getting ID of current module.
- */
-#ifdef CONFIG_LOG
-#define LOG_CONST_ID_GET(_addr) \
-	log_const_source_id((const struct log_source_const_data *)_addr)
-#define LOG_CURRENT_MODULE_ID()	\
-	log_const_source_id(&LOG_ITEM_CONST_DATA(LOG_MODULE_NAME))
-#else
-#define LOG_CONST_ID_GET(_addr) 0
-#define LOG_CURRENT_MODULE_ID() 0
-#endif
-
-/** @brief Macro for getting ID of the element of the section.
- *
- *  @param _addr Address of the element.
- */
-#if CONFIG_LOG
-#define LOG_DYNAMIC_ID_GET(_addr) \
-	log_dynamic_source_id((struct log_source_dynamic_data *)_addr)
-#else
-#define LOG_DYNAMIC_ID_GET(_addr) 0
-#endif
-
 /******************************************************************************/
 /****************** Filtering macros ******************************************/
 /******************************************************************************/
@@ -191,15 +160,6 @@ static inline u32_t log_dynamic_source_id(struct log_source_dynamic_data *data)
 		.name = _str_name,					     \
 		.level  = (_level),					     \
 	}
-
-#if CONFIG_LOG_RUNTIME_FILTERING
-#define _LOG_DYNAMIC_ITEM_REGISTER(_name)				       \
-	struct log_source_dynamic_data LOG_ITEM_DYNAMIC_DATA(_name)	       \
-	__attribute__ ((section("." STRINGIFY(LOG_ITEM_DYNAMIC_DATA(_name))))) \
-	__attribute__((used))
-#else
-#define _LOG_DYNAMIC_ITEM_REGISTER(_name) /* empty */
-#endif
 
 /** @def LOG_INSTANCE_PTR_DECLARE
  * @brief Macro for declaring a logger instance pointer in the module structure.


### PR DESCRIPTION
When log is locally disabled then structures associated with the module
are not created. Logger API macros were evaluating those structues even
when log was disabled for given module. That resulted in compilation
error. Macros has been improved to not touch those structures when
log is disabled for given module.

Signed-off-by: Krzysztof Chruscinski <krzysztof.chruscinski@nordicsemi.no>