### PR TITLE
logging: Add log initialization to system startup

### DIFF
--- a/include/logging/log_ctrl.h
+++ b/include/logging/log_ctrl.h
@@ -29,12 +29,18 @@ extern "C" {
 
 typedef u32_t (*timestamp_get_t)(void);
 
-/**
- * @brief Function for initializing logger core.
+/** @brief Function system initialization of the logger.
  *
- * @return 0 on success or error.
+ * Function is called during start up to allow logging before user can
+ * explicitly initialize the logger.
  */
-int log_init(void);
+void log_core_init(void);
+
+/**
+ * @brief Function for user initialization of the logger.
+ *
+ */
+void log_init(void);
 
 /**
  * @brief Function for providing timestamp function.
@@ -138,7 +144,7 @@ void log_backend_enable(struct log_backend const *const backend,
  */
 void log_backend_disable(struct log_backend const *const backend);
 
-#if defined(CONFIG_LOG) && CONFIG_LOG
+#if CONFIG_LOG
 #define LOG_INIT() log_init()
 #define LOG_PANIC() log_panic()
 #define LOG_PROCESS() log_process(false)

--- a/include/logging/log_msg.h
+++ b/include/logging/log_msg.h
@@ -182,6 +182,9 @@ union log_msg_chunk {
 
 extern struct k_mem_slab log_msg_pool;
 
+/** @brief Function for initialization of the log message pool. */
+void log_msg_pool_init(void);
+
 /** @brief Function for indicating that message is in use.
  *
  *  @details Message can be used (read) by multiple users. Internal reference

--- a/kernel/init.c
+++ b/kernel/init.c
@@ -30,6 +30,7 @@
 #include <kernel_internal.h>
 #include <kswap.h>
 #include <entropy.h>
+#include <logging/log_ctrl.h>
 
 /* kernel build timestamp items */
 #define BUILD_TIMESTAMP "BUILD: " __DATE__ " " __TIME__
@@ -458,6 +459,10 @@ FUNC_NORETURN void _Cstart(void)
 	 */
 
 	_IntLibInit();
+
+	if (IS_ENABLED(CONFIG_LOG)) {
+		log_core_init();
+	}
 
 	/* perform any architecture-specific initialization */
 	kernel_arch_init();

--- a/samples/subsys/logging/logger/src/main.c
+++ b/samples/subsys/logging/logger/src/main.c
@@ -172,7 +172,8 @@ static void performance_showcase(void)
 	u32_t window = 2;
 
 	do {
-		LOG_INF("performance test - log message %d", cnt++);
+		LOG_INF("performance test - log message %d", cnt);
+		cnt++;
 		current_timestamp = timestamp_get();
 	} while (current_timestamp < (start_timestamp + window));
 
@@ -191,12 +192,9 @@ static void external_log_system_showcase(void)
 
 void main(void)
 {
-	int err = LOG_INIT();
+	LOG_INIT();
 
-	if (err == 0) {
-		err = log_set_timestamp_func(timestamp_get, timestamp_freq());
-	}
-
+	int err = log_set_timestamp_func(timestamp_get, timestamp_freq());
 	(void)err;
 
 	module_logging_showcase();

--- a/subsys/logging/log_msg.c
+++ b/subsys/logging/log_msg.c
@@ -11,7 +11,14 @@
 #define MSG_SIZE sizeof(union log_msg_chunk)
 #define NUM_OF_MSGS (CONFIG_LOG_BUFFER_SIZE / MSG_SIZE)
 
-K_MEM_SLAB_DEFINE(log_msg_pool, MSG_SIZE, NUM_OF_MSGS, sizeof(u32_t));
+struct k_mem_slab log_msg_pool;
+static u8_t __noinit __aligned(sizeof(u32_t))
+		log_msg_pool_buf[CONFIG_LOG_BUFFER_SIZE];
+
+void log_msg_pool_init(void)
+{
+	k_mem_slab_init(&log_msg_pool, log_msg_pool_buf, MSG_SIZE, NUM_OF_MSGS);
+}
 
 void log_msg_get(struct log_msg *msg)
 {

--- a/tests/subsys/logging/log_core/src/log_core_test.c
+++ b/tests/subsys/logging/log_core/src/log_core_test.c
@@ -114,9 +114,8 @@ static void log_setup(bool backend2_enable)
 {
 	stamp = 0;
 
-	zassert_equal(0,
-		      log_init(),
-		      "Expects successful initialization.");
+	log_init();
+
 	zassert_equal(0, log_set_timestamp_func(timestamp_get, 0),
 		      "Expects successful timestamp function setting.");
 


### PR DESCRIPTION
Log API can be used before user can explicitly initialize the logger.
In order to ensure that logger core is ready to buffer log messages
it must be initialize as early as possible. Initialization does not
include initialization of default backend since driver may not be
ready and backend is needed only when log messages are processed.

PR replaces #8742 

Signed-off-by: Krzysztof Chruscinski <krzysztof.chruscinski@nordicsemi.no>