### PR TITLE
logging: Handle 0 Hz frequency in log_output

### DIFF
--- a/subsys/logging/log_output.c
+++ b/subsys/logging/log_output.c
@@ -90,7 +90,7 @@ static int timestamp_print(struct log_msg *msg,
 
 	if (!format) {
 		length = print(ctx, "[%08lu] ", timestamp);
-	} else {
+	} else if (freq) {
 		u32_t reminder;
 		u32_t seconds;
 		u32_t hours;
@@ -111,6 +111,8 @@ static int timestamp_print(struct log_msg *msg,
 
 		length = print(ctx, "[%02d:%02d:%02d.%03d,%03d] ",
 			       hours, mins, seconds, ms, us);
+	} else {
+		length = 0;
 	}
 
 	return length;


### PR DESCRIPTION
It is possible that user provides 0 hz frquency to the log_output
(if CONFIG_SYS_CLOCK_HW_CYCLES_PER_SEC=0). In that case timestamp
must not be formatted to avoid division by 0.

Signed-off-by: Krzysztof Chruscinski <krzysztof.chruscinski@nordicsemi.no>