### PR TITLE
[DNM][RFC] Make Newlib types match Zephyr

### DIFF
--- a/include/zephyr/newlib_types.h
+++ b/include/zephyr/newlib_types.h
@@ -1,0 +1,42 @@
+
+#undef  __INT8_TYPE__
+#define __INT8_TYPE__ signed char
+#undef  __INT16_TYPE__
+#define __INT16_TYPE__ signed short
+#undef  __INT32_TYPE__
+#define __INT32_TYPE__ signed int
+#undef  __INT64_TYPE__
+#define __INT64_TYPE__ signed long long
+
+#undef  __UINT8_TYPE__
+#define __UINT8_TYPE__ unsigned char
+#undef  __UINT16_TYPE__
+#define __UINT16_TYPE__ unsigned short
+#undef  __UINT32_TYPE__
+#define __UINT32_TYPE__ unsigned int
+#undef  __UINT64_TYPE__
+#define __UINT64_TYPE__ unsigned long long
+
+#undef  __INT_LEAST8_TYPE__
+#define __INT_LEAST8_TYPE__ signed char
+#undef  __INT_LEAST16_TYPE__
+#define __INT_LEAST16_TYPE__ signed short
+#undef  __INT_LEAST32_TYPE__
+#define __INT_LEAST32_TYPE__ signed int
+#undef  __INT_LEAST64_TYPE__
+#define __INT_LEAST64_TYPE__ signed long long
+
+#undef  __UINT_LEAST8_TYPE__
+#define __UINT_LEAST8_TYPE__ unsigned char
+#undef  __UINT_LEAST16_TYPE__
+#define __UINT_LEAST16_TYPE__ unsigned short
+#undef  __UINT_LEAST32_TYPE__
+#define __UINT_LEAST32_TYPE__ unsigned int
+#undef  __UINT_LEAST64_TYPE__
+#define __UINT_LEAST64_TYPE__ unsigned long long
+
+#undef  __INTPTR_TYPE__
+#define __INTPTR_TYPE__ int
+
+#undef  __UINTPTR_TYPE__
+#define __UINTPTR_TYPE__ unsigned int

--- a/lib/libc/Kconfig
+++ b/lib/libc/Kconfig
@@ -12,6 +12,7 @@ depends on !NATIVE_APPLICATION
 config NEWLIB_LIBC
 	bool "Build with newlib c library"
 	depends on !X86_64
+	default y
 	help
 	  Build with newlib library. The newlib library is expected to be
 	  part of the SDK in this case.

--- a/lib/libc/newlib/CMakeLists.txt
+++ b/lib/libc/newlib/CMakeLists.txt
@@ -25,6 +25,8 @@ endif()
 # used by the network stack
 zephyr_compile_definitions(__LINUX_ERRNO_EXTENSIONS__)
 
+zephyr_compile_options(-include ${ZEPHYR_BASE}/include/zephyr/newlib_types.h)
+
 zephyr_link_libraries(
   m
   c


### PR DESCRIPTION
This change is a work in progress, but to show how we can get newlib to match Zephyr's view of C99 types so we have less conflicts when enabling newlib.

This also, enables newlib by default to find out where CI fails.