### PR TITLE
ext: hal: altera: Add ifdef protection for __LINUX_ERRNO_EXTENSIONS__

### DIFF
--- a/ext/hal/altera/altera_hal/HAL/inc/sys/alt_errno.h
+++ b/ext/hal/altera/altera_hal/HAL/inc/sys/alt_errno.h
@@ -65,7 +65,9 @@
 extern int* (*alt_errno) (void);
 
 /* Must define this so that values such as EBADFD are defined in errno.h. */
+#ifndef __LINUX_ERRNO_EXTENSIONS__
 #define __LINUX_ERRNO_EXTENSIONS__
+#endif
 
 #include <errno.h>
 


### PR DESCRIPTION
__LINUX_ERRNO_EXTENSIONS__ gets defined in HAL/inc/sys/alt_errno.h,
however we also need to define this if we are building with newlib.  So
add a simple ifdef guard to only define __LINUX_ERRNO_EXTENSIONS__ if
its not defined already.

Signed-off-by: Kumar Gala <kumar.gala@linaro.org>