### PR TITLE
Newlib errno fix - enable extended errno defines

### DIFF
--- a/ext/hal/altera/altera_hal/HAL/inc/sys/alt_errno.h
+++ b/ext/hal/altera/altera_hal/HAL/inc/sys/alt_errno.h
@@ -65,7 +65,9 @@
 extern int* (*alt_errno) (void);
 
 /* Must define this so that values such as EBADFD are defined in errno.h. */
+#ifndef __LINUX_ERRNO_EXTENSIONS__
 #define __LINUX_ERRNO_EXTENSIONS__
+#endif
 
 #include <errno.h>
 

--- a/lib/libc/newlib/CMakeLists.txt
+++ b/lib/libc/newlib/CMakeLists.txt
@@ -15,6 +15,10 @@ if(LIBC_LIBRARY_DIR)
   set(LIBC_LIBRARY_DIR_FLAG -L${LIBC_LIBRARY_DIR})
 endif()
 
+# define __LINUX_ERRNO_EXTENSIONS__ so we get errno defines like -ESHUTDOWN
+# used by the network stack
+zephyr_compile_definitions(__LINUX_ERRNO_EXTENSIONS__)
+
 zephyr_link_libraries(
   m
   c


### PR DESCRIPTION
We are using extended errno values in the network stack (-ESHUTDOWN).  To support this with newlib we need to set -D__LINUX_ERRNO_EXTENSIONS__ when we build with newlib.  We can see the issue with (need to enable CONFIG_NEWLIB_LIBC=y support):

./scripts/sanitycheck -p qemu_x86 -s samples/net/http_client/test_tls