### PR TITLE
cmake: Use _FORTIFY_SOURCE only with optimizations enabled

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -66,7 +66,7 @@ zephyr_compile_definitions(
   __ZEPHYR__=1
 )
 
-if(NOT CONFIG_COVERAGE)
+if(NOT CONFIG_NO_OPTIMIZATIONS)
 zephyr_compile_definitions(
   _FORTIFY_SOURCE=2
 )


### PR DESCRIPTION
When compiling for native, some glibc versions has a check on the
use of _FORTIFY_SOURCE without optimizations enabled and gives a
preprocessor warning.

Signed-off-by: Thomas Ebert Hansen <thoh@oticon.com>