### PR TITLE
subsys: kconfig: Remove 'default n' properties and clean up a bit

### DIFF
--- a/subsys/bluetooth/Kconfig
+++ b/subsys/bluetooth/Kconfig
@@ -101,7 +101,6 @@ config BT_MAX_CONN
 if BT_CONN
 config BT_HCI_ACL_FLOW_CONTROL
 	bool "Controller to Host ACL flow control support"
-	default n
 	# Enable if building a Host-only build
 	default y if !BT_CTLR
 	# Enable if building a Controller-only build

--- a/subsys/bluetooth/common/Kconfig
+++ b/subsys/bluetooth/common/Kconfig
@@ -30,7 +30,6 @@ config BT_RPA
 	bool
 	select TINYCRYPT
 	select TINYCRYPT_AES
-	default n
 
 config BT_DEBUG
 	# Virtual/hidden option to make the conditions more intuitive

--- a/subsys/bluetooth/controller/Kconfig
+++ b/subsys/bluetooth/controller/Kconfig
@@ -71,8 +71,7 @@ config BT_CTLR_HCI_VS_BUILD_INFO
 
 if BT_LL_SW
 config BT_CTLR_DUP_FILTER_LEN
-	prompt "Number of addresses in the scan duplicate filter"
-	int
+	int "Number of addresses in the scan duplicate filter"
 	depends on BT_OBSERVER
 	default 16
 	help
@@ -80,8 +79,7 @@ config BT_CTLR_DUP_FILTER_LEN
 	  duplicates while scanning.
 
 config BT_CTLR_RX_BUFFERS
-	prompt "Number of Rx buffers"
-	int
+	int "Number of Rx buffers"
 	default 1
 	default 6 if BT_HCI_RAW
 	range 1 18
@@ -91,8 +89,7 @@ config BT_CTLR_RX_BUFFERS
 	  size of 1 byte can be received.
 
 config BT_CTLR_TX_BUFFERS
-	prompt "Number of Tx buffers"
-	int
+	int "Number of Tx buffers"
 	default 2
 	default 7 if BT_HCI_RAW
 	range 1 19
@@ -103,8 +100,7 @@ config BT_CTLR_TX_BUFFERS
 	  byte can be acknowledged.
 
 config BT_CTLR_TX_BUFFER_SIZE
-	prompt "Tx buffer size"
-	int
+	int "Tx buffer size"
 	range 27 16384
 	default 27
 	help
@@ -177,8 +173,7 @@ config BT_CTLR_TX_PWR_MINUS_40
 endchoice
 
 config BT_CTLR_COMPANY_ID
-	prompt "Company Id"
-	hex
+	hex "Company Id"
 	default 0x05F1
 	range 0x0000 0xFFFF
 	help
@@ -190,8 +185,7 @@ config BT_CTLR_COMPANY_ID
 	  https://www.bluetooth.com/specifications/assigned-numbers/company-identifiers
 
 config BT_CTLR_SUBVERSION_NUMBER
-	prompt "Subversion Number"
-	hex
+	hex "Subversion Number"
 	default 0xFFFF
 	range 0x0000 0xFFFF
 	help
@@ -231,9 +225,8 @@ config BT_CTLR_PRIVACY
 	  in the Controller.
 
 config BT_CTLR_RL_SIZE
-	prompt "LE Controller-based Privacy Resolving List size"
+	int "LE Controller-based Privacy Resolving List size"
 	depends on BT_CTLR_PRIVACY
-	int
 	default 8
 	range 1 8 if SOC_FAMILY_NRF
 	help
@@ -256,9 +249,8 @@ config BT_CTLR_DATA_LENGTH
 	  the Controller.
 
 config BT_CTLR_DATA_LENGTH_MAX
-	prompt "Maximum data length supported"
+	int "Maximum data length supported"
 	depends on BT_CTLR_DATA_LENGTH
-	int
 	default 27
 	range 27 251 if SOC_SERIES_NRF52X || BT_CTLR_DATA_LENGTH_CLEAR
 	range 27 27
@@ -351,8 +343,7 @@ config BT_CTLR_PHY_CODED
 endif # BT_CTLR_PHY
 
 config BT_CTLR_WORKER_PRIO
-	prompt "Radio and Ticker's Worker IRQ priority"
-	int
+	int "Radio and Ticker's Worker IRQ priority"
 	range 0 3 if SOC_SERIES_NRF51X
 	range 0 6 if SOC_SERIES_NRF52X
 	default 0
@@ -361,8 +352,7 @@ config BT_CTLR_WORKER_PRIO
 	  shall be less than or equal to the Ticker's Job priority value.
 
 config BT_CTLR_JOB_PRIO
-	prompt "Ticker's JOB IRQ priority"
-	int
+	int "Ticker's JOB IRQ priority"
 	range BT_CTLR_WORKER_PRIO 3 if SOC_SERIES_NRF51X
 	range BT_CTLR_WORKER_PRIO 6 if SOC_SERIES_NRF52X
 	default 0
@@ -392,9 +382,8 @@ config BT_CTLR_XTAL_ADVANCED
 	  current consumptions.
 
 config BT_CTLR_XTAL_THRESHOLD
-	prompt "Crystal shutdown threshold in uS"
+	int "Crystal shutdown threshold in uS"
 	depends on BT_CTLR_XTAL_ADVANCED
-	int
 	default 1500
 	help
 	  Configure the optimal delta in micro seconds between two consecutive
@@ -404,8 +393,7 @@ config BT_CTLR_XTAL_THRESHOLD
 config BT_CTLR_SCHED_ADVANCED
 	bool "Advanced scheduling"
 	depends on (BT_MAX_CONN != 0)
-	default y
-	default n if BT_PERIPHERAL && !BT_CENTRAL
+	default y if !(BT_PERIPHERAL && !BT_CENTRAL)
 	help
 	  Enable non-overlapping placement of observer, initiator and master
 	  roles in timespace. Uses window offset in connection updates and uses
@@ -501,8 +489,7 @@ menuconfig BT_CTLR_GPIO_PA
 if BT_CTLR_GPIO_PA
 
 config BT_CTLR_GPIO_PA_PIN
-	prompt "Power Amplifier GPIO pin number"
-	int
+	int "Power Amplifier GPIO pin number"
 	help
 	  GPIO Pin number connected to a Power Amplifier.
 
@@ -512,8 +499,7 @@ config BT_CTLR_GPIO_PA_POL_INV
 	  Enable inverted polarity (active low) for the PA pin.
 
 config BT_CTLR_GPIO_PA_OFFSET
-	prompt "Time from PA ON to Tx ready"
-	int
+	int "Time from PA ON to Tx ready"
 	default 5
 	range 0 10
 	help
@@ -532,8 +518,7 @@ menuconfig BT_CTLR_GPIO_LNA
 if BT_CTLR_GPIO_LNA
 
 config BT_CTLR_GPIO_LNA_PIN
-	prompt "Low Noise Amplifier GPIO pin number"
-	int
+	int "Low Noise Amplifier GPIO pin number"
 	help
 	  GPIO Pin number connected to a Low Noise Amplifier.
 
@@ -543,8 +528,7 @@ config BT_CTLR_GPIO_LNA_POL_INV
 	  Enable inverted polarity (active low) for the LNA pin.
 
 config BT_CTLR_GPIO_LNA_OFFSET
-	prompt "Time from LNA ON to Rx ready"
-	int
+	int "Time from LNA ON to Rx ready"
 	default 5
 	range 0 10
 	help
@@ -554,8 +538,8 @@ endif # BT_CTLR_GPIO_LNA
 
 config BT_CTLR_PA_LNA_GPIOTE_CHAN
 	# Hidden "nRF5 GPIO PA/LNA GPIOTE Channel"
-	depends on SOC_FAMILY_NRF && (BT_CTLR_GPIO_PA || BT_CTLR_GPIO_LNA)
 	int
+	depends on SOC_FAMILY_NRF && (BT_CTLR_GPIO_PA || BT_CTLR_GPIO_LNA)
 	default 0
 	default 3 if PWM_NRF5_SW
 	help

--- a/subsys/bluetooth/host/Kconfig
+++ b/subsys/bluetooth/host/Kconfig
@@ -213,8 +213,7 @@ config BT_CONN_TX_MAX
 
 config BT_ATT_ENFORCE_FLOW
 	bool "Enforce strict flow control semantics for incoming PDUs"
-	default y
-	default n if BOARD_QEMU_CORTEX_M3 || BOARD_QEMU_X86 || BOARD_NATIVE_POSIX
+	default y if !(BOARD_QEMU_CORTEX_M3 || BOARD_QEMU_X86 || BOARD_NATIVE_POSIX)
 	help
 	  Enforce flow control rules on incoming PDUs, preventing a peer
 	  from sending new requests until a previous one has been responded

--- a/subsys/bluetooth/shell/Kconfig
+++ b/subsys/bluetooth/shell/Kconfig
@@ -8,7 +8,6 @@
 
 config BT_SHELL
 	bool "Enable Bluetooth shell"
-	default n
 	select CONSOLE_SHELL
 	help
 	  Activate shell module that provides Bluetooth commands to the

--- a/subsys/console/Kconfig
+++ b/subsys/console/Kconfig
@@ -7,9 +7,7 @@
 menu "Console"
 
 config CONSOLE_SUBSYS
-	bool
-	default n
-	prompt "Console subsystem/support routines"
+	bool "Console subsystem/support routines"
 	help
 	  Console subsystem and helper functions
 

--- a/subsys/debug/Kconfig
+++ b/subsys/debug/Kconfig
@@ -10,7 +10,6 @@ menu "Debugging Options"
 
 config DEBUG
 	bool "Build kernel with debugging enabled"
-	default n
 	help
 	  Build a kernel suitable for debugging.  Right now, this option
 	  only disables optimization, more debugging variants can be selected
@@ -27,14 +26,12 @@ config ASAN
 
 config STACK_USAGE
 	bool "Generate stack usage information"
-	default n
 	help
 	  Generate an extra file that specifies the maximum amount of stack used,
 	  on a per-function basis.
 
 config STACK_SENTINEL
 	bool "Enable stack sentinel"
-	default n
 	select THREAD_STACK_INFO
 	depends on !USERSPACE
 	help
@@ -59,8 +56,7 @@ config STACK_SENTINEL
 	  to use that hardware support.
 
 config PRINTK
-	bool
-	prompt "Send printk() to console"
+	bool "Send printk() to console"
 	depends on CONSOLE_HAS_DRIVER
 	default y
 	help
@@ -70,8 +66,7 @@ config PRINTK
 	  any mutual exclusion or buffering.
 
 config PRINTK_BUFFER_SIZE
-	int
-	prompt "printk() buffer size"
+	int "printk() buffer size"
 	depends on PRINTK
 	depends on USERSPACE
 	default 32
@@ -81,9 +76,7 @@ config PRINTK_BUFFER_SIZE
 	  the size of this buffer.
 
 config EARLY_CONSOLE
-	bool
-	prompt "Send stdout at the earliest stage possible"
-	default n
+	bool "Send stdout at the earliest stage possible"
 	help
 	  This option will enable stdout as early as possible, for debugging
 	  purpose. For instance, in case of STDOUT_CONSOLE being set it will
@@ -91,8 +84,7 @@ config EARLY_CONSOLE
 	  sent through the console at the earliest stage possible.
 
 config ASSERT
-	bool
-	prompt "Enable __ASSERT() macro"
+	bool "Enable __ASSERT() macro"
 	default y if TEST
 	help
 	  This enables the __ASSERT() macro in the kernel code. If an assertion
@@ -101,8 +93,7 @@ config ASSERT
 	  in a non-production system.
 
 config ASSERT_LEVEL
-	int
-	prompt "__ASSERT() level"
+	int "__ASSERT() level"
 	default 2
 	range 0 2
 	depends on ASSERT
@@ -115,9 +106,7 @@ config ASSERT_LEVEL
 	  Level 2: on + no warning
 
 config FORCE_NO_ASSERT
-	bool
-	prompt "Force-disable no assertions"
-	default n
+	bool "Force-disable no assertions"
 	help
 	  This boolean option disables Zephyr assertion testing even
 	  in circumstances (sanitycheck) where it is enabled via
@@ -125,17 +114,13 @@ config FORCE_NO_ASSERT
 	  around compiler bugs for specific tests.
 
 config OBJECT_TRACING
-	bool
-	prompt "Kernel object tracing"
-	default n
+	bool "Kernel object tracing"
 	help
 	  This option enable the feature for tracing kernel objects. This option
 	  is for debug purposes and increases the memory footprint of the kernel.
 
 config OVERRIDE_FRAME_POINTER_DEFAULT
-	bool
-	prompt "Override compiler defaults for -fomit-frame-pointer"
-	default n
+	bool "Override compiler defaults for -fomit-frame-pointer"
 	help
 	  Omitting the frame pointer prevents the compiler from putting the stack
 	  frame pointer into a register. Saves a few instructions in function
@@ -151,9 +136,7 @@ config OVERRIDE_FRAME_POINTER_DEFAULT
 	  of your compiler, otherwise choose N.
 
 config OMIT_FRAME_POINTER
-	bool
-	prompt "Omit frame pointer"
-	default n
+	bool "Omit frame pointer"
 	depends on OVERRIDE_FRAME_POINTER_DEFAULT
 	help
 	  Choose Y for best performance. On some architectures (including x86)
@@ -172,7 +155,6 @@ config OMIT_FRAME_POINTER
 #
 config DEBUG_INFO
 	bool "Enable system debugging information"
-	default n
 	help
 	  This option enables the addition of various information that can be
 	  used by debuggers in debugging the system, or enable additional
@@ -194,9 +176,7 @@ config EXCEPTION_STACK_TRACE
 #
 
 config OPENOCD_SUPPORT
-	bool
-	prompt "OpenOCD support [EXPERIMENTAL]"
-	default n
+	bool "OpenOCD support [EXPERIMENTAL]"
 	select THREAD_MONITOR
 	help
 	  This option exports an array of offsets to kernel structs, used by

--- a/subsys/dfu/Kconfig
+++ b/subsys/dfu/Kconfig
@@ -12,9 +12,7 @@
 menu "DFU options"
 
 config IMG_MANAGER
-	bool
-	prompt "DFU image manager"
-	default n
+	bool "DFU image manager"
 	help
 	  Enable support for managing DFU image.
 

--- a/subsys/disk/Kconfig
+++ b/subsys/disk/Kconfig
@@ -7,22 +7,18 @@
 menu "Disk"
 
 config DISK_ACCESS
-	bool
-	default n
-	prompt "Enable Disk Interface"
+	bool "Enable Disk Interface"
 	help
 	  Enable disk access over a supported media backend like FLASH or RAM
 
 config DISK_ACCESS_MAX_VOLUMES
-	int
+	int "Maximum Disk Interfaces"
 	default 8
-	prompt "Maximum Disk Interfaces"
 	help
 	  Maximum number of disk access interfaces supported
 
 config SYS_LOG_DISK_LEVEL
-	int
-	prompt "Disk log level"
+	int "Disk log level"
 	depends on SYS_LOG
 	default 0
 	help
@@ -54,8 +50,7 @@ endif # DISK_ACCESS
 if DISK_ACCESS_RAM
 
 config DISK_RAM_VOLUME_NAME
-	string
-	prompt "RAM Disk mount point or drive name"
+	string "RAM Disk mount point or drive name"
 	default "RAM"
 	help
 	  Disk name as per file system naming guidelines.
@@ -65,48 +60,41 @@ endif # DISK_ACCESS_RAM
 if DISK_ACCESS_FLASH
 
 config DISK_FLASH_VOLUME_NAME
-	string
-	prompt "Flash mount point or drive name"
+	string "Flash mount point or drive name"
 	default "NAND"
 	help
 	  Disk name as per file system naming guidelines.
 
 config DISK_FLASH_DEV_NAME
-	string
-	prompt "Flash device name to be used as storage backend"
+	string "Flash device name to be used as storage backend"
 
 config DISK_FLASH_START
-	hex
-	prompt "Flash device start address in hex"
+	hex "Flash device start address in hex"
 	help
 	  This is start address of the flash to be used as storage backend.
 
 config DISK_FLASH_MAX_RW_SIZE
-	int
-	prompt "Flash device max read-write size in decimal"
+	int "Flash device max read-write size in decimal"
 	help
 	  This is the maximum number of bytes that the
 	  flash_write API can accept per invocation.
 	  API.
 
 config DISK_FLASH_ERASE_ALIGNMENT
-	hex
-	prompt "Flash device erase alignment in hex"
+	hex "Flash device erase alignment in hex"
 	help
 	  This is the start address alignment required by
 	  the flash component.
 
 config DISK_ERASE_BLOCK_SIZE
-	hex
-	prompt "Flash device erasable block size in hex"
+	hex "Flash device erasable block size in hex"
 	help
 	  This is typically the minimum block size that
 	  is erased at one time in flash storage.
 	  Typically it is equal to the flash memory page size.
 
 config DISK_VOLUME_SIZE
-	hex
-	prompt "Flash device volume size in hex"
+	hex "Flash device volume size in hex"
 	help
 	  This is the file system volume size in bytes.
 

--- a/subsys/fs/Kconfig
+++ b/subsys/fs/Kconfig
@@ -7,19 +7,16 @@
 # Hidden. Automatically selected by file systems or FCB that need it
 config FS_FLASH_STORAGE_PARTITION
 	bool
-	default n
 
 menu "File Systems"
 
 config FILE_SYSTEM
 	bool "File system support"
-	default n
 	help
 	  Enables support for file system.
 
 config SYS_LOG_FS_LEVEL
-	int
-	prompt "File System log level"
+	int "File System log level"
 	depends on SYS_LOG
 	default 0
 	help
@@ -71,8 +68,7 @@ menu "NFFS Settings"
 	visible if FILE_SYSTEM_NFFS
 
 config FS_NFFS_FLASH_DEV_NAME
-	string
-	prompt "Flash device name to be used"
+	string "Flash device name to be used"
 
 config FS_NFFS_NUM_INODES
 	int "Maximum number of inodes"

--- a/subsys/fs/fcb/Kconfig
+++ b/subsys/fs/fcb/Kconfig
@@ -10,9 +10,7 @@
 #
 
 config FCB
-	bool
-	prompt "Flash Circular Buffer support"
-	default n
+	bool "Flash Circular Buffer support"
 	depends on FLASH_MAP
 	select FS_FLASH_STORAGE_PARTITION
 	help

--- a/subsys/fs/nvs/Kconfig
+++ b/subsys/fs/nvs/Kconfig
@@ -7,9 +7,7 @@
 #
 
 config NVS
-	bool
-	prompt "Non-volatile Storage"
-	default n
+	bool "Non-volatile Storage"
 	select FS_FLASH_STORAGE_PARTITION
 	help
 	  Enable support of Non-volatile Storage.
@@ -17,9 +15,7 @@ config NVS
 if NVS
 
 config NVS_PROTECT_FLASH
-	bool
-	prompt "Non-volatile Storage extra flash protection"
-	default n
+	bool "Non-volatile Storage extra flash protection"
 	help
 	  Enable extra protection against unnecessary writes to flash. This
 	  enables a extra read check, if data is not changed no write is
@@ -30,14 +26,12 @@ config NVS_PROTECT_FLASH
 config NVS_LOG
 	bool "Non-volatile Storage logging"
 	select SYS_LOG
-	default n
 	help
 	  Enable logs and checks for Non-volatile Storage.
 
 if NVS_LOG
 	config NVS_LOG_LEVEL
-		int
-		prompt "Non-volatile Storage Logging level"
+		int "Non-volatile Storage Logging level"
 		depends on SYS_LOG
 		default 1
 		range 0 4

--- a/subsys/logging/Kconfig
+++ b/subsys/logging/Kconfig
@@ -6,17 +6,14 @@
 menu "Logging Options"
 
 config SYS_LOG
-	bool
-	prompt "Enable Logging"
+	bool "Enable Logging"
 	depends on PRINTK
-	default n
 	help
 	  Global switch for logging, when turned off log calls will not be
 	  executed.
 
 config SYS_LOG_SHOW_TAGS
-	bool
-	prompt "Prepend level tags to logs"
+	bool "Prepend level tags to logs"
 	depends on SYS_LOG
 	default y
 	help
@@ -24,10 +21,8 @@ config SYS_LOG_SHOW_TAGS
 	  the C code.
 
 config SYS_LOG_SHOW_COLOR
-	bool
-	prompt "Use colored logs"
+	bool "Use colored logs"
 	depends on SYS_LOG
-	default n
 	help
 	  Use color in the logs. This requires an ANSI capable terminal.
 
@@ -66,16 +61,13 @@ config SYS_LOG_OVERRIDE_LEVEL
 	  4 DEBUG, override to write SYS_LOG_DBG in addition to previous levels
 
 config SYS_LOG_EXT_HOOK
-	bool
-	prompt "Use external hook function for logging"
+	bool "Use external hook function for logging"
 	depends on SYS_LOG
-	default n
 	help
 	  Use external hook function for logging.
 
 config SYS_LOG_BACKEND_NET
 	bool "Networking syslog backend"
-	default n
 	depends on SYS_LOG && NETWORKING
 	select SYS_LOG_EXT_HOOK
 	select NET_CONTEXT_NET_PKT_POOL
@@ -251,4 +243,3 @@ config LOG_BACKEND_UART_FORMAT_TIMESTAMP
 	  When enabled timestamp is formatted to hh:mm:ss:ms,us.
 endif
 endmenu
-

--- a/subsys/mgmt/Kconfig
+++ b/subsys/mgmt/Kconfig
@@ -9,31 +9,26 @@
 menu "Management"
 
 config MCUMGR_SMP_BT
-	bool
-	prompt "Bluetooth mcumgr SMP transport"
+	bool "Bluetooth mcumgr SMP transport"
 	select MCUMGR
 	select BT
 	select BT_PERIPHERAL
-	default n
 	help
 	  Enables handling of SMP commands received over Bluetooth.
 
 config MCUMGR_SMP_SHELL
-	bool
-	prompt "Shell mcumgr SMP transport"
+	bool "Shell mcumgr SMP transport"
 	select MCUMGR
 	select UART_CONSOLE_MCUMGR
 	select CONSOLE_SHELL
 	select BASE64
-	default n
 	help
 	  Enables handling of SMP commands received over shell.  This allows
 	  the shell to be use for both mcumgr commands and shell commands.
 
 if MCUMGR_SMP_SHELL
 config MCUMGR_SMP_SHELL_MTU
-	int
-	prompt "Shell SMP MTU"
+	int "Shell SMP MTU"
 	default 256
 	help
 	  Maximum size of SMP frames sent and received over shell.  This value
@@ -43,12 +38,10 @@ endif
 
 
 config MCUMGR_SMP_UART
-	bool
-	prompt "UART mcumgr SMP transport"
+	bool "UART mcumgr SMP transport"
 	select MCUMGR
 	select UART_MCUMGR
 	select BASE64
-	default n
 	help
 	  Enables handling of SMP commands received over UART.  This is a
 	  lightweight alternative to MCUMGR_SMP_SHELL.  It allows mcumgr
@@ -57,8 +50,7 @@ config MCUMGR_SMP_UART
 
 if MCUMGR_SMP_UART
 config MCUMGR_SMP_UART_MTU
-	int
-	prompt "UART SMP MTU"
+	int "UART SMP MTU"
 	default 256
 	help
 	  Maximum size of SMP frames sent and received over UART, in bytes.
@@ -68,16 +60,14 @@ config MCUMGR_SMP_UART_MTU
 endif
 
 config MCUMGR_BUF_COUNT
-	int
-	prompt "Number of mcumgr buffers"
+	int "Number of mcumgr buffers"
 	default 4
 	help
 	  The number of net_bufs to allocate for mcumgr.  These buffers are
 	  used for both requests and responses.
 
 config MCUMGR_BUF_SIZE
-	int
-	prompt "Size of each mcumgr buffer"
+	int "Size of each mcumgr buffer"
 	default 384
 	help
 	  The size, in bytes, of each mcumgr buffer.  This value must satisfy
@@ -85,8 +75,7 @@ config MCUMGR_BUF_SIZE
 	  MCUMGR_BUF_SIZE >= transport-specific-MTU + transport-overhead
 
 config MCUMGR_BUF_USER_DATA_SIZE
-	int
-	prompt "Size of mcumgr buffer user data"
+	int "Size of mcumgr buffer user data"
 	default 4
 	help
 	  The size, in bytes, of user data to allocate for each mcumgr buffer.

--- a/subsys/net/Kconfig
+++ b/subsys/net/Kconfig
@@ -10,7 +10,6 @@ menu "Networking"
 
 config NET_BUF
 	bool "Network buffer support"
-	default n
 	help
 	  This option enables support for generic network protocol
 	  buffers.
@@ -29,7 +28,6 @@ config NET_BUF_USER_DATA_SIZE
 config NET_BUF_LOG
 	bool "Network buffer logging"
 	select SYS_LOG
-	default n
 	help
 	  Enable logs and checks for the generic network buffers.
 
@@ -63,7 +61,6 @@ config NET_BUF_WARN_ALLOC_INTERVAL
 config NET_BUF_SIMPLE_LOG
 	bool "Network buffer memory debugging"
 	select SYS_LOG
-	default n
 	help
 	  Enable extra debug logs and checks for the generic network buffers.
 
@@ -71,7 +68,6 @@ endif # NET_BUF_LOG
 
 config NET_BUF_POOL_USAGE
 	bool "Network buffer pool usage tracking"
-	default n
 	help
 	  Enable network buffer pool tracking. This means that:
 	  * amount of free buffers in the pool is remembered
@@ -85,7 +81,6 @@ config  NETWORKING
 	select NET_BUF
 	select POLL
 	select ENTROPY_GENERATOR
-	default n
 	help
 	  This option enabled generic link layer and IP networking support.
 

--- a/subsys/net/Kconfig.hostname
+++ b/subsys/net/Kconfig.hostname
@@ -8,7 +8,6 @@
 
 config NET_HOSTNAME_ENABLE
 	bool "Add hostname to the device"
-	default n
 	help
 	  This is used for example in mDNS to respond to <hostname>.local
 	  mDNS queries.
@@ -23,7 +22,6 @@ config NET_HOSTNAME
 
 config NET_HOSTNAME_UNIQUE
 	bool "Make hostname unique"
-	default n
 	help
 	  This will append link address to hostname to create a unique
 	  hostname. For example, zephyr00005e005357 could be the hostname
@@ -31,7 +29,6 @@ config NET_HOSTNAME_UNIQUE
 
 config  NET_DEBUG_HOSTNAME
 	bool "Debug hostname configuration"
-	default n
 	depends on NET_LOG
 	help
 	  Enables hostname configuration functions to output debug messages

--- a/subsys/net/ip/Kconfig
+++ b/subsys/net/ip/Kconfig
@@ -11,7 +11,6 @@ menu "IP stack"
 # Hidden option
 config NET_RAW_MODE
 	bool
-	default n
 	help
 	  This is a very specific option used to built only the very minimal
 	  part of the net stack in order to get network drivers working without
@@ -36,7 +35,6 @@ source "subsys/net/ip/Kconfig.ipv4"
 
 config NET_SHELL
 	bool "Enable network shell utilities"
-	default n
 	select CONSOLE_SHELL
 	help
 	  Activate shell module that provides network commands like
@@ -101,12 +99,10 @@ config NET_MAX_ROUTERS
 config NET_ROUTE
 	bool
 	depends on NET_IPV6_NBR_CACHE
-	default n
 	default y if NET_IPV6_NBR_CACHE
 
 config NET_ROUTING
 	bool "IP routing between interfaces"
-	default n
 	depends on NET_ROUTE
 	help
 	  Allow IPv6 routing between different network interfaces and
@@ -129,7 +125,6 @@ config	NET_MAX_NEXTHOPS
 config NET_ROUTE_MCAST
 	bool
 	depends on NET_ROUTE
-	default n
 
 config	NET_MAX_MCAST_ROUTES
 	int "Max number of multicast routing entries stored."
@@ -141,7 +136,6 @@ config	NET_MAX_MCAST_ROUTES
 
 config NET_TCP
 	bool "Enable TCP"
-	default n
 	help
 	  The value depends on your network needs.
 
@@ -155,7 +149,6 @@ config NET_TCP_CHECKSUM
 
 config NET_DEBUG_TCP
 	bool "Debug TCP"
-	default n
 	depends on NET_TCP && NET_LOG
 	help
 	  Enables TCP handler output debug messages
@@ -243,7 +236,6 @@ config NET_UDP_CHECKSUM
 
 config NET_DEBUG_UDP
 	bool "Debug UDP"
-	default n
 	depends on NET_UDP && NET_LOG
 	help
 	  Enables UDP handler output debug messages
@@ -260,7 +252,6 @@ config NET_MAX_CONN
 config NET_CONN_CACHE
 	bool "Cache network connections"
 	depends on NET_UDP || NET_TCP
-	default n
 	help
 	  Caching takes slight more memory but will speedup connection
 	  handling of UDP and TCP connections.
@@ -275,7 +266,6 @@ config NET_MAX_CONTEXTS
 
 config NET_CONTEXT_NET_PKT_POOL
 	bool "Enable net_buf TX pool / context"
-	default n
 	default y if NET_TCP && NET_6LO
 	help
 	  If enabled, then it is possible to fine-tune network packet pool
@@ -301,14 +291,12 @@ config NET_CONTEXT_CHECK
 
 config NET_CONTEXT_PRIORITY
 	bool "Add priority support to net_context"
-	default n
 	help
 	  It is possible to prioritize network traffic. This requires
 	  also traffic class support to work as expected.
 
 config NET_TEST
 	bool "Network Testing"
-	default n
 	help
 	  Used for self-contained networking tests that do not require a
 	  network device.
@@ -319,7 +307,6 @@ config NET_SLIP_TAP
 	select UART_PIPE
 	select UART_INTERRUPT_DRIVEN
 	select SLIP_TAP
-	default n
 	default y if (QEMU_TARGET && !NET_TEST && !NET_L2_BT)
 	help
 	  SLIP TAP support is necessary when testing with QEMU. The host
@@ -329,14 +316,12 @@ config NET_SLIP_TAP
 
 config NET_TRICKLE
 	bool "Enable Trickle library"
-	default n
 	help
 	  Normally this is enabled automatically if needed,
 	  so say 'n' if unsure.
 
 config NET_DEBUG_TRICKLE
 	bool "Debug Trickle algorithm"
-	default n
 	depends on NET_TRICKLE && NET_LOG
 	help
 	  Enables Trickle library output debug messages
@@ -422,7 +407,6 @@ endchoice
 
 config NET_PKT_TIMESTAMP
 	bool "Enable network packet timestamp support"
-	default n
 	help
 	  Enable network packet timestamp support. This is needed for
 	  example in gPTP which needs to know how long it takes to send

--- a/subsys/net/ip/Kconfig.debug
+++ b/subsys/net/ip/Kconfig.debug
@@ -8,7 +8,6 @@
 
 menuconfig NET_LOG
 	bool "Enable network stack logging and debugging"
-	default n
 	select SYS_LOG
 	help
 	  Enable logging in various parts of the network stack.
@@ -18,8 +17,7 @@ menuconfig NET_LOG
 if NET_LOG
 
 config SYS_LOG_NET_LEVEL
-	int
-	prompt "Network Stack Logging level"
+	int "Network Stack Logging level"
 	default 1
 	depends on SYS_LOG
 	range 0 4
@@ -34,7 +32,6 @@ config SYS_LOG_NET_LEVEL
 
 config NET_LOG_GLOBAL
 	bool "Enable global network stack logging"
-	default n
 	select NET_DEBUG_CORE
 	select NET_DEBUG_IF
 	select NET_DEBUG_UTILS
@@ -64,44 +61,37 @@ config NET_LOG_GLOBAL
 
 config NET_DEBUG_CORE
 	bool "Debug core IP stack"
-	default n
 	help
 	  Enables core network stack code part to output debug messages
 
 config NET_DEBUG_IF
 	bool "Debug network interface code"
-	default n
 	help
 	  Enables network interface code part to output debug messages
 
 config NET_DEBUG_TC
 	bool "Debug network traffic class code"
-	default n
 	help
 	  Enables network traffic class code part to output debug messages
 
 config NET_DEBUG_UTILS
 	bool "Debug utility functions in IP stack"
-	default n
 	help
 	  Enables utility functions to output debug messages
 
 config NET_DEBUG_CONTEXT
 	bool "Debug network context allocation"
-	default n
 	help
 	  Enables printing of network context allocations and frees.
 
 config NET_DEBUG_NET_PKT
 	bool "Debug network packet and buffer allocation"
-	default n
 	select NET_BUF_POOL_USAGE
 	help
 	  Enables collection of network packet and buffer allocations and frees.
 
 config NET_DEBUG_NET_PKT_ALL
 	bool "Debug network packet and buffer individual allocation"
-	default n
 	depends on NET_DEBUG_NET_PKT
 	help
 	  Enables printing of network packet and buffer allocations and frees for
@@ -119,14 +109,12 @@ config NET_DEBUG_NET_PKT_EXTERNALS
 
 config NET_DEBUG_CONN
 	bool "Debug connection handling"
-	default n
 	help
 	  Enables connection debug messages
 
 config NET_DEBUG_ROUTE
 	bool "Debug route management"
 	depends on NET_ROUTE
-	default n
 	help
 	  Enables routing engine debug messages
 

--- a/subsys/net/ip/Kconfig.ipv4
+++ b/subsys/net/ip/Kconfig.ipv4
@@ -8,7 +8,6 @@
 
 menuconfig NET_IPV4
 	bool "IPv4"
-	default n
 	help
 	  Enable IPv4 support. If this is enabled then the device is
 	  able to send and receive IPv4 network packets.
@@ -40,26 +39,22 @@ config NET_IF_MCAST_IPV4_ADDR_COUNT
 config NET_DHCPV4
 	bool "Enable DHCPv4 client"
 	depends on NET_IPV4
-	default n
 
 if NET_LOG
 
 config NET_DEBUG_IPV4
 	bool "Debug core IPv4"
-	default n
 	help
 	  Enables core IPv4 code part to output debug messages
 
 config NET_DEBUG_ICMPV4
 	bool "Debug ICMPv4"
-	default n
 	help
 	  Enables ICMPv4 code part to output debug messages
 
 config NET_DEBUG_DHCPV4
 	bool "Debug DHCPv4 client"
 	depends on NET_DHCPV4
-	default n
 	help
 	  Enable debug diagnostic from DHCPV4 client.
 

--- a/subsys/net/ip/Kconfig.ipv6
+++ b/subsys/net/ip/Kconfig.ipv6
@@ -50,7 +50,6 @@ config NET_IPV6_MAX_NEIGHBORS
 
 config NET_IPV6_FRAGMENT
 	bool "Support IPv6 fragmentation"
-	default n
 	help
 	  IPv6 fragmentation is disabled by default. This saves memory and
 	  should not cause issues normally as we support anyway the minimum
@@ -121,7 +120,6 @@ config NET_IPV6_RA_RDNSS
 
 config NET_6LO
 	bool "Enable 6lowpan IPv6 Compression library"
-	default n
 	default y if NET_L2_IEEE802154
 	help
 	  6lowpan compression and fragmentation. It is enabled by default
@@ -129,7 +127,6 @@ config NET_6LO
 
 config NET_6LO_CONTEXT
 	bool "Enable 6lowpan context based compression"
-	default n
 	depends on NET_6LO
 	help
 	  Enables 6lowpan context based compression based on information
@@ -152,19 +149,16 @@ if NET_LOG
 
 config NET_DEBUG_IPV6
 	bool "Debug core IPv6"
-	default n
 	help
 	  Enables core IPv6 code part to output debug messages
 
 config NET_DEBUG_ICMPV6
 	bool "Debug ICMPv6"
-	default n
 	help
 	  Enables ICMPv6 code part to output debug messages
 
 config NET_DEBUG_IPV6_NBR_CACHE
 	bool "Debug IPv6 neighbor cache"
-	default n
 	help
 	  Enables Neighbor Cache code to output debug messages
 

--- a/subsys/net/ip/Kconfig.mgmt
+++ b/subsys/net/ip/Kconfig.mgmt
@@ -6,7 +6,6 @@
 
 menuconfig NET_MGMT
 	bool "Network Management API"
-	default n
 	help
 	  Add support for NM API that enables managing different aspects
 	  of the network stack as well as receiving notification on network
@@ -16,7 +15,6 @@ if NET_MGMT
 
 config NET_MGMT_EVENT
 	bool "Add support for runtime network event notifications"
-	default n
 	help
 	  This adds support for the stack to notify events towards any
 	  relevant listener. This can be necessary when application
@@ -51,7 +49,6 @@ config NET_MGMT_EVENT_QUEUE_SIZE
 
 config NET_MGMT_EVENT_INFO
 	bool "Enable passing information along with an event"
-	default n
 	help
 	  Event notifier will be able to provide information to an event,
 	  and listeners will then be able to get it. Such information depends
@@ -59,13 +56,11 @@ config NET_MGMT_EVENT_INFO
 
 config NET_DEBUG_MGMT_EVENT
 	bool "Enable debug output on Net MGMT event core"
-	default n
 	help
 	  Add debug messages output on how Net MGMT events are handled.
 
 config NET_DEBUG_MGMT_EVENT_STACK
 	bool "Enable stack analysis output on Net MGMT event core"
-	default n
 	select INIT_STACKS
 	help
 	  Add debug messages output on how much Net MGMT event stack is used.

--- a/subsys/net/ip/Kconfig.rpl
+++ b/subsys/net/ip/Kconfig.rpl
@@ -8,7 +8,6 @@
 
 menuconfig NET_RPL
 	bool "Enable RPL (Ripple) support"
-	default n
 	select NET_IPV6
 	select NET_IPV6_NBR_CACHE
 	select NET_ROUTE
@@ -104,7 +103,6 @@ endchoice
 config	NET_RPL_PROBING
 	bool "Enable RPL probing"
 	depends on NET_RPL
-	default n
 	help
 	  When enabled, probes will be sent periodically to keep
 	  parent link estimates up to date.
@@ -272,13 +270,11 @@ config	NET_RPL_DIS_INTERVAL
 config NET_STATISTICS_RPL
 	bool "Collect RPL statistics"
 	depends on NET_STATISTICS
-	default n
 	help
 	  Keep track of RPL related statistics
 
 config  NET_DEBUG_RPL
 	bool "Debug RPL"
-	default n
 	depends on NET_RPL && NET_LOG
 	help
 	  Enables RPL output debug messages

--- a/subsys/net/ip/Kconfig.stats
+++ b/subsys/net/ip/Kconfig.stats
@@ -8,7 +8,6 @@
 
 menuconfig NET_STATISTICS
 	bool "Network statistics"
-	default n
 	help
 	  Manage statistics accounting. This takes memory so say 'n' if unsure.
 
@@ -23,7 +22,6 @@ config NET_STATISTICS_PER_INTERFACE
 config NET_STATISTICS_USER_API
 	bool "Expose statistics through NET MGMT API"
 	select NET_MGMT
-	default n
 	help
 	  Enable this if you need to grab relevant statistics in your code,
 	  via calling net_mgmt() with relevant NET_REQUEST_STATS_GET_* command.
@@ -31,7 +29,6 @@ config NET_STATISTICS_USER_API
 config NET_STATISTICS_PERIODIC_OUTPUT
 	bool "Simple periodic output"
 	depends on NET_LOG
-	default n
 	help
 	  Print out all the statistics periodically through logging.
 	  This is meant for testing mostly.

--- a/subsys/net/l2/Kconfig
+++ b/subsys/net/l2/Kconfig
@@ -8,13 +8,11 @@ menu "Link layer options"
 
 config NET_OFFLOAD
 	bool "Offload IP stack [EXPERIMENTAL]"
-	default n
 	help
 	  Enables TCP/IP stack to be offload to a co-processor.
 
 config NET_DEBUG_NET_OFFLOAD
 	bool "Debug Net Offload Layer"
-	default n
 	default y if NET_LOG_GLOBAL
 	depends on NET_LOG
 	depends on NET_OFFLOAD
@@ -23,7 +21,6 @@ config NET_DEBUG_NET_OFFLOAD
 
 config NET_L2_DUMMY
 	bool "Enable dummy l2 layer"
-	default n
 	default y if !NET_L2_ETHERNET && NET_TEST
 	help
 	  Add a dummy L2 layer driver. This is usually only needed when
@@ -37,7 +34,6 @@ config NET_L2_BT
 	select BT_SMP
 	select BT_L2CAP_DYNAMIC_CHANNEL
 	select NET_6LO
-	default n
 	help
 	  Enable Bluetooth driver that send and receives IPv6 packets,
 	  does header compression on it and writes it to the
@@ -46,7 +42,6 @@ config NET_L2_BT
 config NET_L2_BT_ZEP1656
 	bool "***Workaround to work with Linux.***"
 	depends on NET_L2_BT
-	default n
 	help
 	  This workaround is necessary to interoperate with Linux up to 4.10 but
 	  it might not be compliant with RFC 7668 as it cause the stack to skip
@@ -68,7 +63,6 @@ config NET_L2_BT_SEC_LEVEL
 
 config NET_DEBUG_L2_BT
 	bool "Debug Bluetooth L2 layer"
-	default n
 	default y if NET_LOG_GLOBAL
 	depends on NET_LOG
 	depends on NET_L2_BT
@@ -80,11 +74,9 @@ config NET_L2_BT_MGMT
 	depends on NET_L2_BT
 	select NET_MGMT
 	select NET_MGMT_EVENT
-	default n
 
 config NET_L2_BT_SHELL
 	bool "Enable Bluetooth shell module"
-	default n
 	select CONSOLE_SHELL
 	select NET_L2_BT_MGMT
 	help
@@ -99,7 +91,6 @@ source "subsys/net/l2/openthread/Kconfig"
 
 config NET_L2_WIFI_MGMT
 	bool "Enable WiFi Management support"
-	default n
 	select NET_MGMT
 	select NET_MGMT_EVENT
 	select NET_MGMT_EVENT_INFO
@@ -108,7 +99,6 @@ config NET_L2_WIFI_MGMT
 
 config NET_DEBUG_L2_WIFI_MGMT
 	bool "Debug WiFi Management layer"
-	default n
 	default y if NET_LOG_GLOBAL
 	depends on NET_LOG && NET_L2_WIFI_MGMT
 	help
@@ -116,7 +106,6 @@ config NET_DEBUG_L2_WIFI_MGMT
 
 config NET_L2_WIFI_SHELL
 	bool "Enable WiFi shell module"
-	default n
 	select NET_L2_WIFI_MGMT
 	help
 	  This can be used for controlling WiFi through the console via

--- a/subsys/net/l2/ethernet/Kconfig
+++ b/subsys/net/l2/ethernet/Kconfig
@@ -6,7 +6,6 @@
 
 menuconfig NET_L2_ETHERNET
 	bool "Enable Ethernet support"
-	default n
 	help
 	  Add support for Ethernet, enabling selecting relevant hardware drivers.
 	  If NET_SLIP_TAP is selected, NET_L2_ETHERNET will enable to fully
@@ -16,7 +15,6 @@ if NET_L2_ETHERNET
 
 config NET_DEBUG_L2_ETHERNET
 	bool "Debug Ethernet L2 layer"
-	default n
 	default y if NET_LOG_GLOBAL
 	depends on NET_LOG
 	help
@@ -25,14 +23,12 @@ config NET_DEBUG_L2_ETHERNET
 config NET_L2_ETHERNET_MGMT
 	bool "Enable Ethernet network management interface"
 	depends on NET_MGMT && NET_MGMT_EVENT
-	default n
 	help
 	  Enable support net_mgmt Ethernet interface which can be used to
 	  configure at run-time Ethernet drivers and L2 settings.
 
 config NET_VLAN
 	bool "Enable virtual lan support"
-	default n
 	help
 	  Enables virtual lan (VLAN) support for Ethernet.
 
@@ -62,7 +58,6 @@ config NET_ARP_TABLE_SIZE
 config NET_DEBUG_ARP
 	bool "Debug IPv4 ARP"
 	depends on NET_ARP && NET_LOG
-	default n
 	default y if NET_LOG_GLOBAL
 	help
 	  Enables core ARP code part to output debug messages

--- a/subsys/net/l2/ethernet/gptp/Kconfig
+++ b/subsys/net/l2/ethernet/gptp/Kconfig
@@ -9,7 +9,6 @@ menuconfig NET_GPTP
 	depends on NET_L2_ETHERNET
 	select NET_PKT_TIMESTAMP
 	select PTP_CLOCK
-	default n
 	help
 	  Enable gPTP driver that send and receives gPTP packets
 	  and handles network packet timestamps.
@@ -18,7 +17,6 @@ if NET_GPTP
 
 config NET_DEBUG_GPTP
 	bool "Enable Debug Information for gPTP"
-	default n
 	depends on NET_LOG
 	help
 	  Enable logs for the gPTP stack.
@@ -32,7 +30,6 @@ config NET_GPTP_NUM_PORTS
 
 config NET_GPTP_VLAN
 	bool "Run gPTP over VLAN link"
-	default n
 	depends on NET_VLAN
 	select NET_L2_ETHERNET_MGMT
 	select NET_MGMT_EVENT
@@ -118,7 +115,6 @@ config NET_GPTP_PATH_TRACE_ELEMENTS
 
 config NET_GPTP_STATISTICS
 	bool "Collect gPTP statistics"
-	default n
 	help
 	  Enable this if you need to collect gPTP statistics. The statistics
 	  can be seen in net-shell if needed.

--- a/subsys/net/l2/ieee802154/Kconfig
+++ b/subsys/net/l2/ieee802154/Kconfig
@@ -6,7 +6,6 @@
 
 menuconfig NET_L2_IEEE802154
 	bool "Enable IEEE 802.15.4 Radio"
-	default n
 	help
 	  Add support for low rate WPAN IEEE 802.15.4 technology.
 
@@ -16,11 +15,9 @@ config NET_L2_IEEE802154_MGMT
 	bool
 	select NET_MGMT
 	select NET_MGMT_EVENT
-	default n
 
 config NET_L2_IEEE802154_SUB_GHZ
 	bool
-	default n
 	help
 	  Enable support for Sub-GHz devices. This will add a tiny bit more
 	  logic in L2 code for channel management. This option is automatically
@@ -28,7 +25,6 @@ config NET_L2_IEEE802154_SUB_GHZ
 
 config NET_DEBUG_L2_IEEE802154
 	bool "Enable IEEE 802.15.4 stack debug messages"
-	default n
 	default y if NET_LOG_GLOBAL
 	depends on NET_LOG
 	help
@@ -37,7 +33,6 @@ config NET_DEBUG_L2_IEEE802154
 
 config NET_DEBUG_L2_IEEE802154_DISPLAY_PACKET
 	bool "Enable IEEE 802.15.4 packet display"
-	default n
 	depends on NET_LOG
 	help
 	  Enable printing out in/out 802.15.4 packets. This is extremely
@@ -70,7 +65,6 @@ endif # NET_DEBUG_L2_IEEE802154_DISPLAY_PACKET
 
 config NET_L2_IEEE802154_ACK_REPLY
 	bool "Enable IEEE 802.15.4 ACK reply logic"
-	default n
 	help
 	  Enable inner stack's logic on handling ACK request. Note that
 	  if the hw driver has an AUTOACK feature, this is then unnecessary.
@@ -95,7 +89,6 @@ endchoice
 
 config NET_L2_IEEE802154_SHELL
 	bool "Enable IEEE 802.15.4 shell module"
-	default n
 	select CONSOLE_SHELL
 	depends on NET_L2_IEEE802154_RFD
 	help
@@ -131,12 +124,10 @@ config NET_L2_IEEE802154_REASSEMBLY_TIMEOUT
 config  NET_DEBUG_L2_IEEE802154_FRAGMENT
 	bool "Enable debug support for IEEE 802.15.4 fragmentation"
 	depends on NET_L2_IEEE802154_FRAGMENT && NET_LOG
-	default n
 	default y if NET_LOG_GLOBAL
 
 config NET_L2_IEEE802154_SECURITY
 	bool "Enable IEEE 802.15.4 security [EXPERIMENTAL]"
-	default n
 	help
 	  Enable 802.15.4 frame security handling, in order to bring data
 	  confidentiality and authenticity.

--- a/subsys/net/l2/openthread/Kconfig
+++ b/subsys/net/l2/openthread/Kconfig
@@ -10,8 +10,7 @@
 # OpenThread options
 #
 menuconfig NET_L2_OPENTHREAD
-	bool
-	prompt "OpenThread L2"
+	bool "OpenThread L2"
 	depends on FLASH
 	depends on FLASH_PAGE_LAYOUT
 	depends on CPLUSPLUS
@@ -23,16 +22,13 @@ if NET_L2_OPENTHREAD
 config OPENTHREAD_PLAT
 	bool
 	depends on NET_L2_OPENTHREAD
-	default n
 	help
 	  This option enables OpenThread platform
 
 if OPENTHREAD_PLAT
 
 menuconfig OPENTHREAD_DEBUG
-	bool
-	default n
-	prompt "OpenThread stack log support"
+	bool "OpenThread stack log support"
 	help
 	  This option enables log support for OpenThread
 
@@ -66,8 +62,7 @@ config	OPENTHREAD_LOG_LEVEL
 	default 4 if OPENTHREAD_LOG_LEVEL_DEBUG
 
 menuconfig OPENTHREAD_L2_DEBUG
-	bool
-	prompt "OpenThread L2 log support"
+	bool "OpenThread L2 log support"
 	help
 	  This option enables log support for OpenThread
 
@@ -89,14 +84,12 @@ config OPENTHREAD_L2_LOG_LEVEL_DEBUG
 endchoice
 
 config OPENTHREAD_L2_DEBUG_DUMP_15_4
-	bool
-	prompt "Dump 802.15.4 packets"
+	bool "Dump 802.15.4 packets"
 	help
 	  This option enables dumping of 802.15.4 packets
 
 config OPENTHREAD_L2_DEBUG_DUMP_IPV6
-	bool
-	prompt "Dump IPv6 packets"
+	bool "Dump IPv6 packets"
 	help
 	  This option enables dumping of IPv6 packets
 
@@ -111,28 +104,23 @@ config	OPENTHREAD_L2_LOG_LEVEL
 	default 4 if OPENTHREAD_L2_LOG_LEVEL_DEBUG
 
 config OPENTHREAD_THREAD_PRIORITY
-	int
-	prompt "OpenThread thread priority"
+	int "OpenThread thread priority"
 	default 8
 
 config OPENTHREAD_THREAD_STACK_SIZE
-	int
-	prompt "OpenThread thread stack size"
+	int "OpenThread thread stack size"
 	default 3072
 
 config OPENTHREAD_PKT_LIST_SIZE
-	int
-	prompt "List size for Ip6 packet buffering"
+	int "List size for Ip6 packet buffering"
 	default 10
 
 config OPENTHREAD_PANID
-	int
-	prompt "Default PAN ID"
+	int "Default PAN ID"
 	default 43981
 
 config OPENTHREAD_CHANNEL
-	int
-	prompt "Default Channel"
+	int "Default Channel"
 	default 11
 
 choice
@@ -147,38 +135,32 @@ config OPENTHREAD_MTD
 endchoice
 
 config OPENTHREAD_SHELL
-	bool
-	prompt "Enable OpenThread shell"
+	bool "Enable OpenThread shell"
 	select CONSOLE_SHELL
 	default y
 
 config OPENTHREAD_DIAG
-	bool
-	prompt "Diagnostic functions support"
+	bool "Diagnostic functions support"
 	help
 	  Enable OpenThread CLI diagnostic commands
 
 config OPENTHREAD_COMMISSIONER
-	bool
-	prompt "Commissioner functions support"
+	bool "Commissioner functions support"
 	help
 	  Enable commissioner capability in OpenThread stack
 
 config OPENTHREAD_JOINER
-	bool
-	prompt "Joiner functions support"
+	bool "Joiner functions support"
 	help
 	  Enable joiner capability in OpenThread stack
 
 config OPENTHREAD_JAM_DETECTION
-	bool
-	prompt "Jam detection support"
+	bool "Jam detection support"
 	help
 	  Enable jam detection in OpenThread stack
 
 config OT_PLAT_FLASH_PAGES_COUNT
-	int
-	prompt "Flash pages count used by OpenThread platform"
+	int "Flash pages count used by OpenThread platform"
 	default 4
 	help
 	  This option sets flash pages count used by OpenThread to store its settings. They are located at the end of flash.

--- a/subsys/net/lib/app/Kconfig
+++ b/subsys/net/lib/app/Kconfig
@@ -19,14 +19,12 @@ if NET_APP
 
 config NET_DEBUG_APP
 	bool "Debug net app library"
-	default n
 	default y if NET_LOG_GLOBAL
 	help
 	  Enables net app library to output debug messages
 
 config NET_APP_SERVER
 	bool "Enable server support"
-	default n
 	help
 	  Enables net app library server APIs.
 
@@ -41,13 +39,11 @@ config NET_APP_SERVER_NUM_CONN
 
 config NET_APP_CLIENT
 	bool "Enable client support"
-	default n
 	help
 	  Enables net app library client APIs.
 
 config NET_APP_TLS
 	bool "Enable TLS support for TCP applications"
-	default n
 	depends on NET_TCP
 	select MBEDTLS
 	help
@@ -57,7 +53,6 @@ config NET_APP_DTLS
 	bool "Enable DTLS support for UDP applications"
 	depends on NET_UDP
 	select MBEDTLS
-	default n
 	help
 	  Enables net app library to use DTLS for encrypted UDP communication.
 

--- a/subsys/net/lib/coap/Kconfig
+++ b/subsys/net/lib/coap/Kconfig
@@ -7,24 +7,19 @@
 #
 
 config COAP
-	bool
-	prompt "CoAP Support"
-	default n
+	bool "CoAP Support"
 	help
 	  This option enables the CoAP implementation.
 
 # This setting is only used by unit test. Do not enable it in applications
 config COAP_TEST_API_ENABLE
 	bool "Enable test API for CoAP unit tests"
-	default n
 	depends on COAP
 	help
 	  Do not enable this for normal use.
 
 config COAP_WELL_KNOWN_BLOCK_WISE
-	bool
-	prompt "CoAP ./well-known/core services block wise support"
-	default n
+	bool "CoAP ./well-known/core services block wise support"
 	depends on COAP
 	help
 	  This option enables the block wise support of CoAP response
@@ -34,8 +29,7 @@ config COAP_WELL_KNOWN_BLOCK_WISE
 	  of networks.
 
 config COAP_WELL_KNOWN_BLOCK_WISE_SIZE
-	int
-	prompt "CoAP ./well-known/core services block wise support"
+	int "CoAP ./well-known/core services block wise support"
 	default 32
 	depends on COAP_WELL_KNOWN_BLOCK_WISE
 	help
@@ -44,7 +38,6 @@ config COAP_WELL_KNOWN_BLOCK_WISE_SIZE
 
 config COAP_EXTENDED_OPTIONS_LEN
 	bool "Support for CoAP extended options"
-	default n
 	depends on COAP
 	help
 	  This option enables the parsing of extended CoAP options length.
@@ -71,7 +64,6 @@ config COAP_INIT_ACK_TIMEOUT_MS
 
 config NET_DEBUG_COAP
 	bool "Debug COAP"
-	default n
 	depends on COAP && NET_LOG
 	help
 	  Enables CoaP output debug messages

--- a/subsys/net/lib/config/Kconfig
+++ b/subsys/net/lib/config/Kconfig
@@ -57,14 +57,12 @@ config NET_APP_NEED_IPV4
 
 config NET_DEBUG_CONFIG
 	bool "Debug net config library"
-	default n
 	default y if NET_LOG_GLOBAL
 	help
 	  Enables net config library to output debug messages
 
 menuconfig NET_APP_SETTINGS
 	bool "Set network settings for applications"
-	default n
 	depends on NET_APP
 	select NET_MGMT
 	select NET_MGMT_EVENT
@@ -190,7 +188,6 @@ if NET_L2_BT
 
 config NET_APP_BT_NODE
 	bool "Enable Bluetooth node support"
-	default n
 	select NET_L2_BT_MGMT
 	help
 	  Enables application to operate in node mode which requires GATT

--- a/subsys/net/lib/dns/Kconfig
+++ b/subsys/net/lib/dns/Kconfig
@@ -5,9 +5,7 @@
 #
 
 config DNS_RESOLVER
-	bool
-	prompt "DNS resolver"
-	default n
+	bool "DNS resolver"
 	help
 	  This option enables the DNS client side support for Zephyr
 
@@ -15,14 +13,12 @@ if DNS_RESOLVER
 
 config MDNS_RESOLVER
 	bool "Enable mDNS support"
-	default n
 	help
 	  This option enables multicast DNS client side support.
 	  See RFC 6762 for details.
 
 config LLMNR_RESOLVER
 	bool "Enable LLMNR support"
-	default n
 	help
 	  This option enables link local multicast name resolution client side
 	  support. See RFC 4795 for details. LLMNR is typically used by Windows
@@ -32,8 +28,7 @@ config LLMNR_RESOLVER
 
 
 config DNS_RESOLVER_ADDITIONAL_BUF_CTR
-	int
-	prompt "Additional DNS buffers"
+	int "Additional DNS buffers"
 	default 0
 	help
 	  Number of additional buffers available for the DNS resolver.
@@ -42,8 +37,7 @@ config DNS_RESOLVER_ADDITIONAL_BUF_CTR
 	  DNS connections.
 
 config DNS_RESOLVER_ADDITIONAL_QUERIES
-	int
-	prompt "Additional DNS queries"
+	int "Additional DNS queries"
 	range 0 2
 	default 1
 	help
@@ -63,7 +57,6 @@ config DNS_RESOLVER_MAX_SERVERS
 
 menuconfig DNS_SERVER_IP_ADDRESSES
 	bool "Set DNS server IP addresses"
-	default n
 	help
 	  Allow DNS IP addresses to be set in config file for
 	  networking applications.
@@ -72,7 +65,6 @@ if DNS_SERVER_IP_ADDRESSES
 
 config DNS_SERVER1
 	string "DNS server 1"
-	default ""
 	help
 	  DNS server IP address 1. The address can be either IPv4 or IPv6
 	  address. An optional port number can be given.
@@ -89,25 +81,21 @@ config DNS_SERVER1
 
 config DNS_SERVER2
 	string "DNS server 2"
-	default ""
 	help
 	  See help in "DNS server 1" option.
 
 config DNS_SERVER3
 	string "DNS server 3"
-	default ""
 	help
 	  See help in "DNS server 1" option.
 
 config DNS_SERVER4
 	string "DNS server 4"
-	default ""
 	help
 	  See help in "DNS server 1" option.
 
 config DNS_SERVER5
 	string "DNS server 5"
-	default ""
 	help
 	  See help in "DNS server 1" option.
 
@@ -122,7 +110,6 @@ config DNS_NUM_CONCUR_QUERIES
 
 config NET_DEBUG_DNS_RESOLVE
 	bool "Debug DNS resolver"
-	default n
 	default y if NET_LOG_GLOBAL
 	help
 	  Enables DNS resolver code to output debug messages
@@ -131,7 +118,6 @@ endif # DNS_RESOLVER
 
 config MDNS_RESPONDER
 	bool "mDNS responder"
-	default n
 	select NET_IPV6_MLD if NET_IPV6
 	depends on NET_HOSTNAME_ENABLE
 	help
@@ -159,7 +145,6 @@ config MDNS_RESPONDER_INIT_PRIO
 
 config NET_DEBUG_MDNS_RESPONDER
 	bool "Debug mDNS responder"
-	default n
 	default y if NET_LOG_GLOBAL
 	help
 	  Enables mDNS responder code to output debug messages
@@ -175,7 +160,6 @@ endif # MDNS_RESPONDER
 
 config LLMNR_RESPONDER
 	bool "LLMNR responder"
-	default n
 	select NET_IPV6_MLD if NET_IPV6
 	depends on NET_HOSTNAME_ENABLE
 	help
@@ -207,7 +191,6 @@ config LLMNR_RESPONDER_INIT_PRIO
 
 config NET_DEBUG_LLMNR_RESPONDER
 	bool "Debug LLMNR responder"
-	default n
 	default y if NET_LOG_GLOBAL
 	help
 	  Enables LLMNR responder code to output debug messages

--- a/subsys/net/lib/http/Kconfig
+++ b/subsys/net/lib/http/Kconfig
@@ -5,7 +5,6 @@
 
 config HTTP
 	bool "HTTP support"
-	default n
 	help
 	  This option enables the HTTP library
 
@@ -13,7 +12,6 @@ if HTTP
 
 config HTTP_SERVER
 	bool "HTTP server support"
-	default n
 	select HTTP_PARSER
 	select HTTP_PARSER_URL
 	select NET_APP_SERVER
@@ -22,7 +20,6 @@ config HTTP_SERVER
 
 config HTTP_CLIENT
 	bool "HTTP client support"
-	default n
 	select HTTP_PARSER
 	select HTTP_PARSER_URL
 	select NET_APP_CLIENT
@@ -41,7 +38,6 @@ config HTTP_HEADERS
 
 config HTTPS
 	bool "HTTPS support"
-	default n
 	select NET_APP_TLS
 	help
 	  Enables HTTPS support.
@@ -73,14 +69,12 @@ config HTTP_CLIENT_NETWORK_TIMEOUT
 
 config  NET_DEBUG_HTTP
 	bool "Debug HTTP"
-	default n
 	depends on HTTP && NET_LOG
 	help
 	  Enables HTTP output debug messages
 
 config  NET_DEBUG_HTTP_CONN
 	bool "Debug HTTP connections"
-	default n
 	depends on HTTP && NET_LOG
 	help
 	  Enables HTTP connection tracking.
@@ -89,7 +83,6 @@ endif # HTTP
 
 config HTTP_PARSER
 	bool "HTTP Parser support"
-	default n
 	select HTTP_PARSER_URL
 	help
 	  This option enables the http_parser library from nodejs.
@@ -98,7 +91,6 @@ config HTTP_PARSER
 
 config HTTP_PARSER_URL
 	bool "HTTP Parser for URL support"
-	default n
 	help
 	  This option enables the URI parser library based on source from nodejs.
 	  This parser requires some string-related routines commonly
@@ -106,7 +98,6 @@ config HTTP_PARSER_URL
 
 config HTTP_PARSER_STRICT
 	bool "HTTP strict parsing"
-	default n
 	depends on (HTTP_PARSER || HTTP_PARSER_URL)
 	help
 	  This option enables the strict parsing option

--- a/subsys/net/lib/lwm2m/Kconfig
+++ b/subsys/net/lib/lwm2m/Kconfig
@@ -6,7 +6,6 @@
 
 menuconfig LWM2M
 	bool "OMA LWM2M protocol stack"
-	default n
 	select COAP
 	select NET_APP_CLIENT
 	select HTTP_PARSER_URL
@@ -147,7 +146,6 @@ config LWM2M_NUM_BLOCK1_CONTEXT
 config LWM2M_FIRMWARE_UPDATE_PULL_COAP_PROXY_SUPPORT
 	bool "Firmware Update object pull via CoAP-CoAP/HTTP proxy support"
 	depends on LWM2M_FIRMWARE_UPDATE_PULL_SUPPORT
-	default n
 	help
 	  Include support for pulling firmware file via a CoAP-CoAP/HTTP proxy.
 

--- a/subsys/net/lib/lwm2m/Kconfig.ipso
+++ b/subsys/net/lib/lwm2m/Kconfig.ipso
@@ -6,7 +6,6 @@
 
 menuconfig LWM2M_IPSO_SUPPORT
 	bool "IPSO Alliance Smart Object Support"
-	default n
 	depends on LWM2M
 	help
 	  This option adds general support for IPSO objects
@@ -15,7 +14,6 @@ if LWM2M_IPSO_SUPPORT
 
 config LWM2M_IPSO_TEMP_SENSOR
 	bool "IPSO Temperature Sensor Support"
-	default n
 	help
 	  This IPSO object should be used with a temperature sensor to
 	  report a temperature measurement. It also provides resources for
@@ -33,7 +31,6 @@ config LWM2M_IPSO_TEMP_SENSOR_INSTANCE_COUNT
 
 config LWM2M_IPSO_LIGHT_CONTROL
 	bool "IPSO Light Control Support"
-	default n
 	help
 	  This Object is used to control a light source, such as a LED or other
 	  light. It allows a light to be turned on or off and its dimmer

--- a/subsys/net/lib/mqtt/Kconfig
+++ b/subsys/net/lib/mqtt/Kconfig
@@ -8,14 +8,12 @@
 
 config  MQTT_LIB
 	bool "MQTT Library Support"
-	default n
 	select NET_APP_CLIENT
 	help
 	  Enable the Zephyr MQTT Library
 
 config MQTT_MSG_MAX_SIZE
-	int
-	prompt "Max size of a MQTT message"
+	int "Max size of a MQTT message"
 	depends on MQTT_LIB
 	default 128
 	range 128 1024
@@ -24,8 +22,7 @@ config MQTT_MSG_MAX_SIZE
 	  longer than CONFIG_MQTT_MSG_SIZE will be processed.
 
 config MQTT_ADDITIONAL_BUFFER_CTR
-	int
-	prompt "Additional buffers available for the MQTT application"
+	int "Additional buffers available for the MQTT application"
 	depends on MQTT_LIB
 	default 0
 	help
@@ -34,8 +31,7 @@ config MQTT_ADDITIONAL_BUFFER_CTR
 	  relation between application contexts and internal buffers.
 
 config MQTT_SUBSCRIBE_MAX_TOPICS
-	int
-	prompt "Max number of topics to subscribe to"
+	int "Max number of topics to subscribe to"
 	depends on MQTT_LIB
 	default 1
 	range 1 8
@@ -44,10 +40,8 @@ config MQTT_SUBSCRIBE_MAX_TOPICS
 	  messages during reception.
 
 config MQTT_LIB_TLS
-	bool
-	prompt "Enable TLS support for the MQTT application"
+	bool "Enable TLS support for the MQTT application"
 	depends on MQTT_LIB
-	default n
 	select NET_APP_TLS
 	help
 	  Enables MQTT library with TLS support

--- a/subsys/net/lib/sntp/Kconfig
+++ b/subsys/net/lib/sntp/Kconfig
@@ -6,7 +6,6 @@
 
 menuconfig SNTP
 	bool "SNTP Support"
-	default n
 	select NET_APP_CLIENT
 	help
 	  Enable SNTP client library
@@ -15,7 +14,6 @@ if SNTP
 
 config NET_DEBUG_SNTP
 	bool "Debug SNTP"
-	default n
 	help
 	  Enable debug message of SNTP client library
 

--- a/subsys/net/lib/sockets/Kconfig
+++ b/subsys/net/lib/sockets/Kconfig
@@ -8,7 +8,6 @@
 
 menuconfig NET_SOCKETS
 	bool "BSD Sockets compatible API"
-	default n
 	help
 	  Provide BSD Sockets like API on top of native Zephyr networking API.
 
@@ -16,7 +15,6 @@ if NET_SOCKETS
 
 config NET_SOCKETS_POSIX_NAMES
 	bool "Standard POSIX names for Sockets API"
-	default n
 	help
 	  By default, Sockets API function are prefixed with ``zsock_`` to avoid
 	  namespacing issues. If this option is enabled, they will be provided
@@ -34,7 +32,6 @@ config NET_SOCKETS_POLL_MAX
 
 config NET_DEBUG_SOCKETS
 	bool "Debug BSD Sockets compatible API calls"
-	default n
 	default y if NET_LOG_GLOBAL
 	help
 	  Enables logging for sockets code. (Logging level is defined by

--- a/subsys/net/lib/websocket/Kconfig
+++ b/subsys/net/lib/websocket/Kconfig
@@ -5,19 +5,17 @@
 
 menuconfig WEBSOCKET
 	bool "Websocket support [EXPERIMENTAL]"
-	default n
 	depends on HTTP
 	select NET_TCP
 	select BASE64
 	help
-	This option enables the websocket library.
+	  This option enables the websocket library.
 
 if WEBSOCKET
 
 config NET_DEBUG_WEBSOCKET
 	bool "Debug websocket library"
-	default n
 	help
-	Enables websocket library to output debug messages
+	  Enables websocket library to output debug messages
 
 endif # WEBSOCKET

--- a/subsys/random/Kconfig
+++ b/subsys/random/Kconfig
@@ -6,10 +6,8 @@
 #
 
 config TEST_RANDOM_GENERATOR
-	bool
-	prompt "Non-random number generator"
+	bool "Non-random number generator"
 	depends on !ENTROPY_HAS_DRIVER
-	default n
 	help
 	  This option signifies that the kernel's random number APIs are
 	  permitted to return values that are not truly random.
@@ -22,16 +20,14 @@ choice
 	default ENTROPY_DEVICE_RANDOM_GENERATOR
 
 config X86_TSC_RANDOM_GENERATOR
-	bool
-	prompt "x86 timestamp counter based number generator"
+	bool "x86 timestamp counter based number generator"
 	depends on TEST_RANDOM_GENERATOR && X86
 	help
 	  This options enables number generator based on timestamp counter
 	  of x86 boards, obtained with rdtsc instruction.
 
 config TIMER_RANDOM_GENERATOR
-	bool
-	prompt "System timer clock based number generator"
+	bool "System timer clock based number generator"
 	depends on TEST_RANDOM_GENERATOR
 	help
 	  This options enables number generator based on system timer
@@ -39,8 +35,7 @@ config TIMER_RANDOM_GENERATOR
 	  testing only.
 
 config ENTROPY_DEVICE_RANDOM_GENERATOR
-	bool
-	prompt "Use entropy driver to generate random numbers"
+	bool "Use entropy driver to generate random numbers"
 	depends on ENTROPY_HAS_DRIVER
 	help
 	  Enables a random number generator that uses the enabled
@@ -48,8 +43,7 @@ config ENTROPY_DEVICE_RANDOM_GENERATOR
 	  numbers.
 
 config XOROSHIRO_RANDOM_GENERATOR
-	bool
-	prompt "Use Xoroshiro128+ as PRNG"
+	bool "Use Xoroshiro128+ as PRNG"
 	depends on ENTROPY_HAS_DRIVER
 	help
 	  Enables the Xoroshiro128+ pseudo-random number generator, that

--- a/subsys/settings/Kconfig
+++ b/subsys/settings/Kconfig
@@ -5,9 +5,7 @@
 #
 
 menuconfig SETTINGS
-	bool
-	default n
-	prompt "Enable settings subsystem with non-volatile storage"
+	bool "Enable settings subsystem with non-volatile storage"
 	# Only NFFS is currently supported as FS.
 	# The reason in that FatFs doesn't implement the fs_rename() API
 	depends on (FILE_SYSTEM && FILE_SYSTEM_NFFS) || (FCB && FLASH_PAGE_LAYOUT)
@@ -39,25 +37,22 @@ config SETTINGS_FS
 endchoice
 
 config SETTINGS_FCB_NUM_AREAS
-	int
+	int "Number of flash areas used by the settings subsystem"
 	default 8
 	depends on SETTINGS && SETTINGS_FCB
-	prompt "Number of flash areas used by the settings subsystem"
 	help
 	  Number of areas to allocate in the settings FCB. A smaller number is
 	  used if the flash hardware cannot support this value.
 
 config SETTINGS_FCB_MAGIC
-	hex
-	prompt "FCB magic for the settings subsystem"
+	hex "FCB magic for the settings subsystem"
 	default 0xc0ffeeee
 	depends on SETTINGS && SETTINGS_FCB
 	help
 	  Magic 32-bit word for to identify valid settings area
 
 config SETTINGS_FCB_FLASH_AREA
-	int
-	prompt "Flash area id used for settings"
+	int "Flash area id used for settings"
 	default 4
 	depends on SETTINGS && SETTINGS_FCB
 	help
@@ -65,25 +60,22 @@ config SETTINGS_FCB_FLASH_AREA
 	  expected to operate.
 
 config SETTINGS_FS_DIR
-	string
-	prompt "Serialization directory"
+	string "Serialization directory"
 	default "/settings"
 	depends on SETTINGS && SETTINGS_FS
 	help
 	  Directory where the settings data is stored
 
 config SETTINGS_FS_FILE
-	string
-	prompt "Default settings file"
+	string "Default settings file"
 	default "/settings/run"
 	depends on SETTINGS && SETTINGS_FS
 	help
 	  Full path to the default settings file.
 
 config SETTINGS_FS_MAX_LINES
-	int
-	prompt "Compression threshold"
+	int "Compression threshold"
 	default 32
 	depends on SETTINGS && SETTINGS_FS
 	help
-	  'Limit how many items stored in a file before compressing'
+	  Limit how many items stored in a file before compressing

--- a/subsys/shell/Kconfig
+++ b/subsys/shell/Kconfig
@@ -9,9 +9,7 @@
 
 
 config CONSOLE_SHELL
-	bool
-	prompt "Enable console input handler [ Experimental ]"
-	default n
+	bool "Enable console input handler [ Experimental ]"
 	select CONSOLE_HANDLER
 	select CONSOLE_SUBSYS
 	help
@@ -21,8 +19,7 @@ config CONSOLE_SHELL
 if CONSOLE_SHELL
 
 config CONSOLE_SHELL_STACKSIZE
-	int
-	prompt "Console handler shell stack size"
+	int "Console handler shell stack size"
 	default 2000
 	help
 	  Stack size for the console handler shell.

--- a/subsys/shell/modules/Kconfig
+++ b/subsys/shell/modules/Kconfig
@@ -9,7 +9,6 @@
 
 config KERNEL_SHELL
 	bool "Enable kernel shell"
-	default n
 	help
 	  This shell provides access to basic kernel data like version, uptime
 	  and other useful information.

--- a/subsys/storage/flash_map/Kconfig
+++ b/subsys/storage/flash_map/Kconfig
@@ -10,17 +10,13 @@
 #
 
 menuconfig FLASH_MAP
-	bool
-	prompt "Flash map abstraction module"
-	default n
+	bool "Flash map abstraction module"
 	depends on FLASH_HAS_DRIVER_ENABLED
 	help
 	  Enable support of flash map abstraction.
 
 config FLASH_MAP_CUSTOM
-	bool
-	prompt "Custom flash map description"
-	default n
+	bool "Custom flash map description"
 	depends on FLASH_MAP
 	help
 	  This option enables custom flash map description.

--- a/subsys/usb/Kconfig
+++ b/subsys/usb/Kconfig
@@ -7,10 +7,8 @@
 #
 
 menuconfig USB_DEVICE_STACK
-	bool
-	prompt "USB device stack"
+	bool "USB device stack"
 	depends on USB_DEVICE_DRIVER || ARCH_POSIX
-	default n
 	help
 	  Enable USB device stack.
 
@@ -72,10 +70,8 @@ config USB_DEVICE_SN
 	  USB device SerialNumber string. MUST be configured by vendor.
 
 config USB_COMPOSITE_DEVICE
-	bool
-	prompt "Enable composite device driver"
+	bool "Enable composite device driver"
 	depends on USB
-	default n
 	help
 	  Enable composite USB device driver.
 
@@ -87,9 +83,7 @@ config USB_COMPOSITE_BUFFER_SIZE
 	default 256 if USB_DEVICE_NETWORK_RNDIS
 
 config USB_DEVICE_BOS
-	bool
-	prompt "Enable USB Binary Device Object Store (BOS)"
-	default n
+	bool "Enable USB Binary Device Object Store (BOS)"
 
 source "subsys/usb/class/Kconfig"
 

--- a/subsys/usb/class/Kconfig
+++ b/subsys/usb/class/Kconfig
@@ -9,9 +9,7 @@
 if USB_DEVICE_STACK
 
 config USB_CDC_ACM
-	bool
-	prompt "USB CDC ACM Device Class Driver"
-	default n
+	bool "USB CDC ACM Device Class Driver"
 	help
 	  USB CDC ACM device class driver
 
@@ -57,10 +55,8 @@ config SYS_LOG_USB_CDC_ACM_LEVEL
 	  - 4 DEBUG, write SYS_LOG_DBG in addition to previous levels
 
 config USB_MASS_STORAGE
-	bool
-	prompt "USB Mass Storage Device Class Driver"
+	bool "USB Mass Storage Device Class Driver"
 	select DISK_ACCESS
-	default n
 	help
 	  USB Mass Storage device class driver
 
@@ -100,11 +96,9 @@ config SYS_LOG_USB_MASS_STORAGE_LEVEL
 	  - 4 DEBUG, write SYS_LOG_DBG in addition to previous levels
 
 config USB_DEVICE_BLUETOOTH
-	bool
-	prompt "USB Bluetooth Device Class Driver"
+	bool "USB Bluetooth Device Class Driver"
 	select BT
 	select BT_HCI_RAW
-	default n
 	help
 	  USB Bluetooth device class driver
 
@@ -142,11 +136,9 @@ source "subsys/usb/class/netusb/Kconfig"
 source "subsys/usb/class/hid/Kconfig"
 
 config USB_DFU_CLASS
-	bool
-	prompt "USB DFU Class Driver"
-	depends on IMG_MANAGER
+	bool "USB DFU Class Driver"
 	select MPU_ALLOW_FLASH_WRITE
-	default n
+	depends on IMG_MANAGER
 	help
 	  USB DFU class driver
 

--- a/subsys/usb/class/hid/Kconfig
+++ b/subsys/usb/class/hid/Kconfig
@@ -7,9 +7,7 @@
 #
 
 config USB_DEVICE_HID
-	bool
-	prompt "USB Human Interface Device support"
-	default n
+	bool "USB Human Interface Device support"
 	help
 	  Enables USB Human Interface Device support.
 

--- a/subsys/usb/class/netusb/Kconfig
+++ b/subsys/usb/class/netusb/Kconfig
@@ -11,34 +11,27 @@ menu "USB Device Networking support"
 
 config USB_DEVICE_NETWORK
 	bool
-	default n
 	select NET_L2_ETHERNET
 
 config USB_DEVICE_NETWORK_ECM
-	bool
-	prompt "USB Ethernet Control Model (ECM) Networking device"
+	bool "USB Ethernet Control Model (ECM) Networking device"
 	select USB_DEVICE_NETWORK
-	default n
 	help
 	  Ethernet Control Model (ECM) is a part of  Communications Device
 	  Class (CDC) USB protocol specified by USB-IF.
 
 config USB_DEVICE_NETWORK_EEM
-	bool
-	prompt "USB Ethernet Emulation Model (EEM) Networking device"
+	bool "USB Ethernet Emulation Model (EEM) Networking device"
 	select USB_DEVICE_NETWORK
-	default n
 	help
 	  Ethernet Emulation Model (EEM) is part of  Communications Device
 	  Class (CDC) USB protocol and can be used to encapsulate Ethernet
 	  frames for transport over USB.
 
 config USB_DEVICE_NETWORK_RNDIS
-	bool
-	prompt "USB Remote NDIS (RNDIS) Networking device"
+	bool "USB Remote NDIS (RNDIS) Networking device"
 	select USB_DEVICE_NETWORK
 	select USB_COMPOSITE_DEVICE
-	default n
 	help
 	  Remote NDIS (RNDIS) is commonly used Microsoft vendor protocol with
 	  Specification available from Microsoft web site.


### PR DESCRIPTION
Bool symbols implicitly default to `n`.

A `default n` can make sense e.g. in a `Kconfig.defconfig` file, if you want to override a `default y` on the base definition of the symbol. It isn't used like that on any of these symbols though.

Remove some `default ""` properties on string symbols too.

Also make definitions more consistent by converting some

    config FOO
    	<type>
    	prompt "foo"

definitions to a shorter form:

    config FOO
    	<type> "foo"

This shorthand works for `int`/`hex`/`string` symbols too, not just for `bool` symbols.