### PR TITLE
samples: nats: Fix warning when building with newlib

### DIFF
--- a/samples/net/nats/src/nats.c
+++ b/samples/net/nats/src/nats.c
@@ -65,7 +65,7 @@ static bool is_subject_valid(const char *subject, size_t len)
 
 			break;
 		default:
-			if (isalnum(subject[pos])) {
+			if (isalnum((unsigned char)subject[pos])) {
 				continue;
 			}
 
@@ -85,7 +85,7 @@ static bool is_sid_valid(const char *sid, size_t len)
 	}
 
 	for (pos = 0; pos < len; pos++) {
-		if (!isalnum(sid[pos])) {
+		if (!isalnum((unsigned char)sid[pos])) {
 			return false;
 		}
 	}


### PR DESCRIPTION
If we use newlib the isdigit (and other similar functions) return an
error as char can possibly be viewed as signed:

usr/include/ctype.h:57:54: error: array subscript has type ‘char’ [-Werror=char-subscripts]
 #define __ctype_lookup(__c) ((__ctype_ptr__+sizeof(""[__c]))[(int)(__c)])

Explicity cast to unsigned char so we deal with both this warning and
possible warning when -Wpointer-sign is enabled.

Signed-off-by: Kumar Gala <kumar.gala@linaro.org>