### PR TITLE
arch: x86: Kconfig: Fix CACHE_LINE_SIZE default for CPU_ATOM

### DIFF
--- a/arch/x86/Kconfig
+++ b/arch/x86/Kconfig
@@ -196,8 +196,7 @@ config CMOV
 	  the CMOV instruction.
 
 config CACHE_LINE_SIZE_DETECT
-	bool
-	prompt "Detect cache line size at runtime"
+	bool "Detect cache line size at runtime"
 	default y
 	help
 	  This option enables querying the CPUID register for finding the cache line
@@ -208,11 +207,9 @@ config CACHE_LINE_SIZE_DETECT
 	  manually enter the value for CACHE_LINE_SIZE.
 
 config CACHE_LINE_SIZE
-	int
-	prompt "Cache line size" if !CACHE_LINE_SIZE_DETECT
-	default 0 if CACHE_LINE_SIZE_DETECT
-	default 64 if CPU_ATOM
+	int "Cache line size" if !CACHE_LINE_SIZE_DETECT
 	default 0
+	default 64 if CPU_ATOM
 	help
 	  Size in bytes of a CPU cache line.
 


### PR DESCRIPTION
With Zephyr's prefer-later-defaults behavior, the default value of
`CACHE_LINE_SIZE` was always 0, because `default 0` acts like
`default 0 if y`.

Change the code to what was probably the intention (default to 0 unless
`CPU_ATOM`).

It looks like `CACHE_LINE_SIZE` is never used in the code when
`CACHE_LINE_SIZE_DETECT` is on, so maybe things could be simplified
further.

Piggy-back some prompt style consistency cleanups.