### PR TITLE
LwM2M subsys changes prior to bootstrap support

### DIFF
--- a/include/net/lwm2m.h
+++ b/include/net/lwm2m.h
@@ -81,7 +81,7 @@ typedef void *(*lwm2m_engine_get_data_cb_t)(u16_t obj_inst_id,
 typedef int (*lwm2m_engine_set_data_cb_t)(u16_t obj_inst_id,
 				       u8_t *data, u16_t data_len,
 				       bool last_block, size_t total_size);
-typedef int (*lwm2m_engine_exec_cb_t)(u16_t obj_inst_id);
+typedef int (*lwm2m_engine_user_cb_t)(u16_t obj_inst_id);
 
 
 /* LWM2M Device Object */
@@ -144,8 +144,8 @@ void lwm2m_firmware_set_write_cb(lwm2m_engine_set_data_cb_t cb);
 lwm2m_engine_set_data_cb_t lwm2m_firmware_get_write_cb(void);
 
 #if defined(CONFIG_LWM2M_FIRMWARE_UPDATE_PULL_SUPPORT)
-void lwm2m_firmware_set_update_cb(lwm2m_engine_exec_cb_t cb);
-lwm2m_engine_exec_cb_t lwm2m_firmware_get_update_cb(void);
+void lwm2m_firmware_set_update_cb(lwm2m_engine_user_cb_t cb);
+lwm2m_engine_user_cb_t lwm2m_firmware_get_update_cb(void);
 #endif
 #endif
 
@@ -205,7 +205,7 @@ int lwm2m_engine_register_pre_write_callback(char *path,
 int lwm2m_engine_register_post_write_callback(char *path,
 					      lwm2m_engine_set_data_cb_t cb);
 int lwm2m_engine_register_exec_callback(char *path,
-					lwm2m_engine_exec_cb_t cb);
+					lwm2m_engine_user_cb_t cb);
 
 /* resource data bit values */
 #define LWM2M_RES_DATA_READ_ONLY	0

--- a/include/net/lwm2m.h
+++ b/include/net/lwm2m.h
@@ -206,6 +206,10 @@ int lwm2m_engine_register_post_write_callback(char *path,
 					      lwm2m_engine_set_data_cb_t cb);
 int lwm2m_engine_register_exec_callback(char *path,
 					lwm2m_engine_user_cb_t cb);
+int lwm2m_engine_register_create_callback(u16_t obj_id,
+					  lwm2m_engine_user_cb_t cb);
+int lwm2m_engine_register_delete_callback(u16_t obj_id,
+					  lwm2m_engine_user_cb_t cb);
 
 /* resource data bit values */
 #define LWM2M_RES_DATA_READ_ONLY	0

--- a/subsys/net/lib/lwm2m/lwm2m_engine.c
+++ b/subsys/net/lib/lwm2m/lwm2m_engine.c
@@ -1883,7 +1883,7 @@ int lwm2m_engine_register_post_write_callback(char *pathstr,
 }
 
 int lwm2m_engine_register_exec_callback(char *pathstr,
-					lwm2m_engine_exec_cb_t cb)
+					lwm2m_engine_user_cb_t cb)
 {
 	int ret;
 	struct lwm2m_engine_res_inst *res = NULL;

--- a/subsys/net/lib/lwm2m/lwm2m_engine.c
+++ b/subsys/net/lib/lwm2m/lwm2m_engine.c
@@ -3124,7 +3124,8 @@ static int handle_request(struct coap_packet *request,
 	}
 
 	/* parse the URL path into components */
-	r = coap_find_options(in.in_cpkt, COAP_OPTION_URI_PATH, options, 4);
+	r = coap_find_options(in.in_cpkt, COAP_OPTION_URI_PATH, options,
+			      ARRAY_SIZE(options));
 	if (r <= 0) {
 		/* '/' is used by bootstrap-delete only */
 

--- a/subsys/net/lib/lwm2m/lwm2m_engine.c
+++ b/subsys/net/lib/lwm2m/lwm2m_engine.c
@@ -685,6 +685,7 @@ int lwm2m_create_obj_inst(u16_t obj_id, u16_t obj_inst_id,
 			  struct lwm2m_engine_obj_inst **obj_inst)
 {
 	struct lwm2m_engine_obj *obj;
+	int ret;
 
 	*obj_inst = NULL;
 	obj = get_engine_obj(obj_id);
@@ -718,6 +719,17 @@ int lwm2m_create_obj_inst(u16_t obj_id, u16_t obj_inst_id,
 	(*obj_inst)->obj = obj;
 	(*obj_inst)->obj_inst_id = obj_inst_id;
 	engine_register_obj_inst(*obj_inst);
+
+	if (obj->user_create_cb) {
+		ret = obj->user_create_cb(obj_inst_id);
+		if (ret < 0) {
+			SYS_LOG_ERR("Error in user obj create %u/%u: %d",
+				    obj_id, obj_inst_id, ret);
+			lwm2m_delete_obj_inst(obj_id, obj_inst_id);
+			return ret;
+		}
+	}
+
 #ifdef CONFIG_LWM2M_RD_CLIENT_SUPPORT
 	engine_trigger_update();
 #endif
@@ -738,6 +750,15 @@ int lwm2m_delete_obj_inst(u16_t obj_id, u16_t obj_inst_id)
 	obj_inst = get_engine_obj_inst(obj_id, obj_inst_id);
 	if (!obj_inst) {
 		return -ENOENT;
+	}
+
+	if (obj->user_delete_cb) {
+		ret = obj->user_delete_cb(obj_inst_id);
+		if (ret < 0) {
+			SYS_LOG_ERR("Error in user obj delete %u/%u: %d",
+				    obj_id, obj_inst_id, ret);
+			/* don't return error */
+		}
 	}
 
 	engine_unregister_obj_inst(obj_inst);
@@ -1894,6 +1915,36 @@ int lwm2m_engine_register_exec_callback(char *pathstr,
 	}
 
 	res->execute_cb = cb;
+	return 0;
+}
+
+int lwm2m_engine_register_create_callback(u16_t obj_id,
+					  lwm2m_engine_user_cb_t cb)
+{
+	struct lwm2m_engine_obj *obj = NULL;
+
+	obj = get_engine_obj(obj_id);
+	if (!obj) {
+		SYS_LOG_ERR("unable to find obj: %u", obj_id);
+		return -ENOENT;
+	}
+
+	obj->user_create_cb = cb;
+	return 0;
+}
+
+int lwm2m_engine_register_delete_callback(u16_t obj_id,
+					  lwm2m_engine_user_cb_t cb)
+{
+	struct lwm2m_engine_obj *obj = NULL;
+
+	obj = get_engine_obj(obj_id);
+	if (!obj) {
+		SYS_LOG_ERR("unable to find obj: %u", obj_id);
+		return -ENOENT;
+	}
+
+	obj->user_delete_cb = cb;
 	return 0;
 }
 

--- a/subsys/net/lib/lwm2m/lwm2m_obj_firmware.c
+++ b/subsys/net/lib/lwm2m/lwm2m_obj_firmware.c
@@ -57,7 +57,7 @@ static struct lwm2m_engine_obj_inst inst;
 static struct lwm2m_engine_res_inst res[FIRMWARE_MAX_ID];
 
 static lwm2m_engine_set_data_cb_t write_cb;
-static lwm2m_engine_exec_cb_t update_cb;
+static lwm2m_engine_user_cb_t update_cb;
 
 #ifdef CONFIG_LWM2M_FIRMWARE_UPDATE_PULL_SUPPORT
 extern int lwm2m_firmware_start_transfer(char *package_uri);
@@ -256,19 +256,19 @@ lwm2m_engine_set_data_cb_t lwm2m_firmware_get_write_cb(void)
 	return write_cb;
 }
 
-void lwm2m_firmware_set_update_cb(lwm2m_engine_exec_cb_t cb)
+void lwm2m_firmware_set_update_cb(lwm2m_engine_user_cb_t cb)
 {
 	update_cb = cb;
 }
 
-lwm2m_engine_exec_cb_t lwm2m_firmware_get_update_cb(void)
+lwm2m_engine_user_cb_t lwm2m_firmware_get_update_cb(void)
 {
 	return update_cb;
 }
 
 static int firmware_update_cb(u16_t obj_inst_id)
 {
-	lwm2m_engine_exec_cb_t callback;
+	lwm2m_engine_user_cb_t callback;
 	u8_t state;
 	int ret;
 

--- a/subsys/net/lib/lwm2m/lwm2m_object.h
+++ b/subsys/net/lib/lwm2m/lwm2m_object.h
@@ -169,6 +169,8 @@ struct lwm2m_engine_obj {
 	/* object event callbacks */
 	lwm2m_engine_obj_create_cb_t create_cb;
 	lwm2m_engine_obj_delete_cb_t delete_cb;
+	lwm2m_engine_user_cb_t user_create_cb;
+	lwm2m_engine_user_cb_t user_delete_cb;
 
 	/* object member data */
 	u16_t obj_id;

--- a/subsys/net/lib/lwm2m/lwm2m_object.h
+++ b/subsys/net/lib/lwm2m/lwm2m_object.h
@@ -230,7 +230,7 @@ struct lwm2m_engine_res_inst {
 	lwm2m_engine_get_data_cb_t	read_cb;
 	lwm2m_engine_get_data_cb_t	pre_write_cb;
 	lwm2m_engine_set_data_cb_t	post_write_cb;
-	lwm2m_engine_exec_cb_t		execute_cb;
+	lwm2m_engine_user_cb_t		execute_cb;
 
 	u8_t  *multi_count_var;
 	void  *data_ptr;


### PR DESCRIPTION
A few changes prior to the bootstrap support patches:
- Make some callbacks / callback types more generic / re-useable
- Add object create / delete callbacks
- Use ARRAY_SIZE for options in handle_request() instead of hard coded value
- Bugfix for handling optional TLV resources (which aren't present)