### PR TITLE
doc: getting_started: add instructions to build on Clear Linux

### DIFF
--- a/doc/getting_started/installation_linux.rst
+++ b/doc/getting_started/installation_linux.rst
@@ -10,8 +10,10 @@ applications on the following Linux distributions:
 
 * Ubuntu 16.04 LTS 64-bit
 * Fedora 25 64-bit
+* Clear Linux
 
-Where needed, alternative instructions are listed for Ubuntu and Fedora.
+Where needed, alternative instructions are listed for specific Linux
+distributions.
 
 Installing the Host's Operating System
 **************************************
@@ -43,6 +45,12 @@ Note that having a newer version available for an installed package
 ``dnf upgrade`` will install it, because it must also ensure dependencies
 and other restrictions are satisfied.
 
+On Clear Linux:
+
+.. code-block:: console
+
+   sudo swupd update
+
 Installing Requirements and Dependencies
 ****************************************
 
@@ -66,6 +74,13 @@ Install the required packages in a Fedora host system with:
 	 doxygen dfu-util dtc python3-pip \
 	 python3-ply python3-yaml dfu-util dtc python3-pykwalify \
          glibc-devel.i686 libstdc++-devel.i686 autoconf automake libtool
+
+Install the required packages in a Clear Linux host system with:
+
+.. code-block:: console
+
+   sudo swupd bundle-add c-basic dev-utils dfu-util dtc \
+     os-core-dev python-basic python3-basic
 
 Install additional packages required for development with Zephyr::
 
@@ -150,6 +165,15 @@ Follow these steps to install the SDK on your Linux host system.
       export ZEPHYR_TOOLCHAIN_VARIANT=zephyr
       export ZEPHYR_SDK_INSTALL_DIR=<sdk installation directory>
 
+   .. note::
+      Some Linux distributions have default CFLAGS and CXXFLAGS
+      environment variables already set. For all distros, they need to be
+      unset to prevent these settings from interfering with cmake:
+
+      .. code-block:: console
+
+         unset CFLAGS CXXFLAGS
+
   To use the same toolchain in new sessions in the future, you can set the
   variables in the file :file:`${HOME}/.zephyrrc`, for example:
 
@@ -159,6 +183,17 @@ Follow these steps to install the SDK on your Linux host system.
      export ZEPHYR_TOOLCHAIN_VARIANT=zephyr
      export ZEPHYR_SDK_INSTALL_DIR=/opt/zephyr-sdk
      EOF
+
+  .. note::
+     Some Linux distributions have default CFLAGS and CXXFLAGS
+     environment variables already set. For all distros, they need to be
+     unset to prevent these settings from interfering with cmake:
+
+     .. code-block:: console
+
+        cat <<EOF >> ~/.zephyrrc
+        unset CFLAGS CXXFLAGS
+        EOF
 
 .. note:: In previous releases of Zephyr, the ``ZEPHYR_TOOLCHAIN_VARIANT``
           variable was called ``ZEPHYR_GCC_VARIANT``.


### PR DESCRIPTION
This expands the Development Environment Setup on Linux guide to
include instructions for Clear Linux.

Tested on Clear Linux build 23610.

Signed-off-by: Daniel Leung <daniel.leung@intel.com>