### PR TITLE
doc: getting started: add Arch Linux package for Zephyr SDK

### DIFF
--- a/doc/getting_started/installation_linux.rst
+++ b/doc/getting_started/installation_linux.rst
@@ -11,6 +11,7 @@ applications on the following Linux distributions:
 * Ubuntu 16.04 LTS 64-bit
 * Fedora 25 64-bit
 * Clear Linux
+* Arch Linux (install `zephyr-sdk <https://aur.archlinux.org/packages/zephyr-sdk>`_ package from AUR)
 
 Where needed, alternative instructions are listed for specific Linux
 distributions.


### PR DESCRIPTION
Package was tested by building the Hello World sample for the QEMU Cortex-M3 machine and running it.

(Ideally, Zephyr SDK would be packaged for other distros as well, and some of the details in this guide, such as dependency installation would no longer need to be manually performed by the user and could be dropped from the guide for conciseness and fewer content to maintain.)