### PR TITLE
net: eth: Convert to use callbacks to query stats

### DIFF
--- a/drivers/ethernet/eth_native_posix.c
+++ b/drivers/ethernet/eth_native_posix.c
@@ -441,6 +441,15 @@ static struct device *eth_get_ptp_clock(struct device *dev)
 }
 #endif
 
+#if defined(CONFIG_NET_STATISTICS_ETHERNET)
+static struct net_stats_eth *get_stats(struct net_if *iface)
+{
+	struct eth_context *context = net_if_get_device(iface)->driver_data;
+
+	return &(context->stats);
+}
+#endif
+
 static const struct ethernet_api eth_if_api = {
 	.iface_api.init = eth_iface_init,
 	.iface_api.send = eth_send,
@@ -448,7 +457,7 @@ static const struct ethernet_api eth_if_api = {
 	.get_capabilities = eth_posix_native_get_capabilities,
 
 #if defined(CONFIG_NET_STATISTICS_ETHERNET)
-	.stats = &eth_context_data.stats,
+	.get_stats = get_stats,
 #endif
 #if defined(CONFIG_ETH_NATIVE_POSIX_PTP_CLOCK)
 	.get_ptp_clock = eth_get_ptp_clock,

--- a/include/net/ethernet.h
+++ b/include/net/ethernet.h
@@ -128,7 +128,7 @@ struct ethernet_api {
 	 * should be set by driver if statistics needs to be collected
 	 * for that driver.
 	 */
-	struct net_stats_eth *stats;
+	struct net_stats_eth *(*get_stats)(struct net_if *iface);
 #endif
 
 	/** Get the device capabilities */

--- a/subsys/net/l2/ethernet/eth_stats.h
+++ b/subsys/net/l2/ethernet/eth_stats.h
@@ -17,9 +17,14 @@ static inline void eth_stats_update_bytes_rx(struct net_if *iface,
 					     u32_t bytes)
 {
 	struct net_stats_eth *stats;
+	const struct ethernet_api *api = ((const struct ethernet_api *)
+		net_if_get_device(iface)->driver_api);
 
-	stats = ((const struct ethernet_api *)
-		 net_if_get_device(iface)->driver_api)->stats;
+	if (!api->get_stats) {
+		return;
+	}
+
+	stats = api->get_stats(iface);
 	if (!stats) {
 		return;
 	}
@@ -31,9 +36,14 @@ static inline void eth_stats_update_bytes_tx(struct net_if *iface,
 					     u32_t bytes)
 {
 	struct net_stats_eth *stats;
+	const struct ethernet_api *api = ((const struct ethernet_api *)
+		net_if_get_device(iface)->driver_api);
 
-	stats = ((const struct ethernet_api *)
-		 net_if_get_device(iface)->driver_api)->stats;
+	if (!api->get_stats) {
+		return;
+	}
+
+	stats = api->get_stats(iface);
 	if (!stats) {
 		return;
 	}
@@ -44,9 +54,14 @@ static inline void eth_stats_update_bytes_tx(struct net_if *iface,
 static inline void eth_stats_update_pkts_rx(struct net_if *iface)
 {
 	struct net_stats_eth *stats;
+	const struct ethernet_api *api = ((const struct ethernet_api *)
+		net_if_get_device(iface)->driver_api);
 
-	stats = ((const struct ethernet_api *)
-		 net_if_get_device(iface)->driver_api)->stats;
+	if (!api->get_stats) {
+		return;
+	}
+
+	stats = api->get_stats(iface);
 	if (!stats) {
 		return;
 	}
@@ -57,9 +72,14 @@ static inline void eth_stats_update_pkts_rx(struct net_if *iface)
 static inline void eth_stats_update_pkts_tx(struct net_if *iface)
 {
 	struct net_stats_eth *stats;
+	const struct ethernet_api *api = ((const struct ethernet_api *)
+		net_if_get_device(iface)->driver_api);
 
-	stats = ((const struct ethernet_api *)
-		 net_if_get_device(iface)->driver_api)->stats;
+	if (!api->get_stats) {
+		return;
+	}
+
+	stats = api->get_stats(iface);
 	if (!stats) {
 		return;
 	}
@@ -70,9 +90,14 @@ static inline void eth_stats_update_pkts_tx(struct net_if *iface)
 static inline void eth_stats_update_broadcast_rx(struct net_if *iface)
 {
 	struct net_stats_eth *stats;
+	const struct ethernet_api *api = ((const struct ethernet_api *)
+		net_if_get_device(iface)->driver_api);
 
-	stats = ((const struct ethernet_api *)
-		 net_if_get_device(iface)->driver_api)->stats;
+	if (!api->get_stats) {
+		return;
+	}
+
+	stats = api->get_stats(iface);
 	if (!stats) {
 		return;
 	}
@@ -83,9 +108,14 @@ static inline void eth_stats_update_broadcast_rx(struct net_if *iface)
 static inline void eth_stats_update_broadcast_tx(struct net_if *iface)
 {
 	struct net_stats_eth *stats;
+	const struct ethernet_api *api = ((const struct ethernet_api *)
+		net_if_get_device(iface)->driver_api);
 
-	stats = ((const struct ethernet_api *)
-		 net_if_get_device(iface)->driver_api)->stats;
+	if (!api->get_stats) {
+		return;
+	}
+
+	stats = api->get_stats(iface);
 	if (!stats) {
 		return;
 	}
@@ -96,9 +126,14 @@ static inline void eth_stats_update_broadcast_tx(struct net_if *iface)
 static inline void eth_stats_update_multicast_rx(struct net_if *iface)
 {
 	struct net_stats_eth *stats;
+	const struct ethernet_api *api = ((const struct ethernet_api *)
+		net_if_get_device(iface)->driver_api);
 
-	stats = ((const struct ethernet_api *)
-		 net_if_get_device(iface)->driver_api)->stats;
+	if (!api->get_stats) {
+		return;
+	}
+
+	stats = api->get_stats(iface);
 	if (!stats) {
 		return;
 	}
@@ -109,9 +144,14 @@ static inline void eth_stats_update_multicast_rx(struct net_if *iface)
 static inline void eth_stats_update_multicast_tx(struct net_if *iface)
 {
 	struct net_stats_eth *stats;
+	const struct ethernet_api *api = ((const struct ethernet_api *)
+		net_if_get_device(iface)->driver_api);
 
-	stats = ((const struct ethernet_api *)
-		 net_if_get_device(iface)->driver_api)->stats;
+	if (!api->get_stats) {
+		return;
+	}
+
+	stats = api->get_stats(iface);
 	if (!stats) {
 		return;
 	}

--- a/subsys/net/l2/ethernet/ethernet_stats.c
+++ b/subsys/net/l2/ethernet/ethernet_stats.c
@@ -28,8 +28,13 @@ static int eth_stats_get(u32_t mgmt_request, struct net_if *iface,
 		}
 
 		eth = net_if_get_device(iface)->driver_api;
+
+		if (eth->get_stats == NULL) {
+			return -ENOENT;
+		}
+
 		len_chk = sizeof(struct net_stats_eth);
-		src = eth->stats;
+		src = eth->get_stats(iface);
 		break;
 	}
 


### PR DESCRIPTION
The advantage to this approach allows drivers for
devices that already keep statistics data on hardware
registers to use those instead, rather than try to
replicate it the same counters again within the driver
itself.

The eth_native_posix.c driver though do not benefit
from this, is modified to use the new callback system.

@jukkar, @anashif