### PR TITLE
doc: cmake: Use flexible variables for inclusion

### DIFF
--- a/doc/CMakeLists.txt
+++ b/doc/CMakeLists.txt
@@ -28,12 +28,12 @@ if(NOT DEFINED DOC_TAG)
 endif()
 
 # Internal variables.
-set(ALLSPHINXOPTS  -d ${CMAKE_BINARY_DIR}/doctrees ${SPHINXOPTS})
+set(ALLSPHINXOPTS  -d ${CMAKE_CURRENT_BINARY_DIR}/doctrees ${SPHINXOPTS})
 # the i18n builder cannot share the environment and doctrees with the others
 set(I18NSPHINXOPTS  ${SPHINXOPTS})
 
-set(DOXYFILE ${CMAKE_CURRENT_SOURCE_DIR}/zephyr.doxyfile)
-set(BUILD_DOXYFILE ${CMAKE_BINARY_DIR}/build.doxyfile)
+set(DOXYFILE ${CMAKE_CURRENT_LIST_DIR}/zephyr.doxyfile)
+set(BUILD_DOXYFILE ${CMAKE_CURRENT_BINARY_DIR}/build.doxyfile)
 set(DOC_LOG doc.log)
 set(DOXY_LOG doxy.log)
 set(SPHINX_LOG sphinx.log)
@@ -51,23 +51,23 @@ add_custom_target(
     -DARGS="${ARGS}"
     -DOUTPUT_FILE=${DOXY_LOG}
     -DERROR_FILE=${DOXY_LOG}
-    -DWORKING_DIRECTORY=${CMAKE_CURRENT_SOURCE_DIR}
+    -DWORKING_DIRECTORY=${CMAKE_CURRENT_LIST_DIR}
     -P ${ZEPHYR_BASE}/cmake/util/execute_process.cmake
 )
 
 add_custom_target(
   pristine
   COMMAND ${CMAKE_COMMAND} -P ${ZEPHYR_BASE}/cmake/pristine.cmake
-  COMMAND ${CMAKE_COMMAND} -E remove_directory ${CMAKE_CURRENT_SOURCE_DIR}/html
-  COMMAND ${CMAKE_COMMAND} -E remove_directory ${CMAKE_CURRENT_SOURCE_DIR}/xml
-  COMMAND ${CMAKE_COMMAND} -E remove_directory ${CMAKE_CURRENT_SOURCE_DIR}/doxygen
-  COMMAND ${CMAKE_COMMAND} -E remove_directory ${CMAKE_CURRENT_SOURCE_DIR}/latex
-  COMMAND ${CMAKE_COMMAND} -E remove ${CMAKE_CURRENT_SOURCE_DIR}/reference/kconfig/*.rst
-  COMMAND ${CMAKE_COMMAND} -E remove_directory ${CMAKE_CURRENT_SOURCE_DIR}/samples
-  COMMAND ${CMAKE_COMMAND} -E remove_directory ${CMAKE_CURRENT_SOURCE_DIR}/boards
-  COMMAND ${CMAKE_COMMAND} -E remove ${CMAKE_CURRENT_SOURCE_DIR}/${DOXY_LOG}
-  COMMAND ${CMAKE_COMMAND} -E remove ${CMAKE_CURRENT_SOURCE_DIR}/${SPHINX_LOG}
-  COMMAND ${CMAKE_COMMAND} -E remove ${CMAKE_CURRENT_SOURCE_DIR}/${DOC_LOG}
+  COMMAND ${CMAKE_COMMAND} -E remove_directory ${CMAKE_CURRENT_LIST_DIR}/html
+  COMMAND ${CMAKE_COMMAND} -E remove_directory ${CMAKE_CURRENT_LIST_DIR}/xml
+  COMMAND ${CMAKE_COMMAND} -E remove_directory ${CMAKE_CURRENT_LIST_DIR}/doxygen
+  COMMAND ${CMAKE_COMMAND} -E remove_directory ${CMAKE_CURRENT_LIST_DIR}/latex
+  COMMAND ${CMAKE_COMMAND} -E remove ${CMAKE_CURRENT_LIST_DIR}/reference/kconfig/*.rst
+  COMMAND ${CMAKE_COMMAND} -E remove_directory ${CMAKE_CURRENT_LIST_DIR}/samples
+  COMMAND ${CMAKE_COMMAND} -E remove_directory ${CMAKE_CURRENT_LIST_DIR}/boards
+  COMMAND ${CMAKE_COMMAND} -E remove ${CMAKE_CURRENT_LIST_DIR}/${DOXY_LOG}
+  COMMAND ${CMAKE_COMMAND} -E remove ${CMAKE_CURRENT_LIST_DIR}/${SPHINX_LOG}
+  COMMAND ${CMAKE_COMMAND} -E remove ${CMAKE_CURRENT_LIST_DIR}/${DOC_LOG}
 )
 
 add_custom_target(
@@ -78,7 +78,7 @@ add_custom_target(
 add_custom_target(
   content
   COMMAND ${PYTHON_EXECUTABLE} scripts/extract_content.py
-  WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
+  WORKING_DIRECTORY ${CMAKE_CURRENT_LIST_DIR}
 )
 
 if(WIN32)
@@ -97,7 +97,7 @@ add_custom_target(
   KERNELVERSION=${PROJECT_VERSION}
   SRCARCH=x86
   ${PYTHON_EXECUTABLE} scripts/genrest.py ../Kconfig reference/kconfig/
-  WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
+  WORKING_DIRECTORY ${CMAKE_CURRENT_LIST_DIR}
 )
 
 set(KI_SCRIPT ${ZEPHYR_BASE}/scripts/filter-known-issues.py)
@@ -105,12 +105,12 @@ set(CONFIG_DIR ${ZEPHYR_BASE}/.known-issues/doc)
 
 add_custom_target(
   html
-  COMMAND ${SPHINXBUILD} -w ${SPHINX_LOG} -N -t ${DOC_TAG} -b html ${ALLSPHINXOPTS} ${CMAKE_CURRENT_SOURCE_DIR} ${CMAKE_BINARY_DIR}/html
+  COMMAND ${SPHINXBUILD} -w ${SPHINX_LOG} -N -t ${DOC_TAG} -b html ${ALLSPHINXOPTS} ${CMAKE_CURRENT_LIST_DIR} ${CMAKE_CURRENT_BINARY_DIR}/html
   # Merge the Doxygen and Sphinx logs into a single file
   COMMAND ${CMAKE_COMMAND} -P ${ZEPHYR_BASE}/cmake/util/fmerge.cmake ${DOC_LOG} ${DOXY_LOG} ${SPHINX_LOG}
   COMMAND ${PYTHON_EXECUTABLE} ${KI_SCRIPT} --config-dir ${CONFIG_DIR} --errors ${DOC_WARN} --warnings ${DOC_WARN} ${DOC_LOG}
   COMMAND ${CMAKE_COMMAND} -E remove_directory samples
   COMMAND ${CMAKE_COMMAND} -E remove_directory boards
   DEPENDS doxy content kconfig
-  WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
+  WORKING_DIRECTORY ${CMAKE_CURRENT_LIST_DIR}
 )


### PR DESCRIPTION
In order to be able to use this CMakeLists.txt file from other projects,
use the proper variables so that they refer to their own paths.

Signed-off-by: Carles Cufi <carles.cufi@nordicsemi.no>