### PR TITLE
doc: Add doxygen to Chocolatey package list

### DIFF
--- a/doc/getting_started/installation_win.rst
+++ b/doc/getting_started/installation_win.rst
@@ -69,7 +69,7 @@ packages from their respective websites.
 
    .. code-block:: console
 
-      choco install git python ninja dtc-msys2 gperf
+      choco install git python ninja dtc-msys2 gperf doxygen.install
 
 #. Close the Command Prompt window.
 


### PR DESCRIPTION
In order to build the documentation one needs Doxygen. Now that building
the documentation is supported on Windows, include this package.

Signed-off-by: Carles Cufi <carles.cufi@nordicsemi.no>