### PR TITLE
kconfiglib: Fix paths for gsource'd files in the documentation

### DIFF
--- a/scripts/kconfig/kconfiglib.py
+++ b/scripts/kconfig/kconfiglib.py
@@ -2178,15 +2178,20 @@ class Kconfig(object):
                     pattern = os.path.join(os.path.dirname(self._filename),
                                            pattern)
 
-                # If $srctree is set, glob relative to it
-                if self.srctree is not None:
+                if self.srctree is None:
+                    strip_srctree = False
+                else:
+                    # $srctree set and pattern not absolute?
+                    strip_srctree = not os.path.isabs(pattern)
+
+                    # If $srctree is set, glob relative to it
                     pattern = os.path.join(self.srctree, pattern)
 
                 # Sort the glob results to ensure a consistent ordering of
                 # Kconfig symbols, which indirectly ensures a consistent
                 # ordering in e.g. .config files
                 for filename in sorted(glob.iglob(pattern)):
-                    if self.srctree is not None and not os.path.isabs(filename):
+                    if strip_srctree:
                         # Strip the $srctree prefix from the filename and let
                         # the normal $srctree logic find the file. This makes
                         # the globbed filenames appear without a $srctree


### PR DESCRIPTION
`$srctree` was changed to an absolute path when the documentation building
was switched over to CMake, which uncovered a bug in Kconfiglib that
caused symbols in gsource'd files to show up with absolute paths in the
auto-generated Kconfig documentation.

This commit adds upstream commit ac692af07a123 ("Fix absolute $srctree
prefixes showing up on gsource'd files"), which fixes it.

Upstream commit message:

    When using gsource with $srctree set to an absolute path, the $srctree
    prefix would show up in MenuNode.filename, trickling its way into e.g.
    generated documentation.

    This was due to a broken test: os.path.isabs() was checked after
    joining the pattern with $srctree, making it mistake an absolute
    $srctree for an absolute path in the Kconfig file.

    Fix the test.