### PR TITLE
net: ip: kconfig: Simplify NET_RX_STACK_RPL definition

### DIFF
--- a/subsys/net/ip/Kconfig.stack
+++ b/subsys/net/ip/Kconfig.stack
@@ -27,18 +27,12 @@ config NET_RX_STACK_SIZE
 	  This value is a baseline and the actual RX stack size might
 	  be bigger depending on what features are enabled.
 
-if NET_RPL
+# User-assignable if NET_RPL is enabled, otherwise 0
 config NET_RX_STACK_RPL
-	int "RPL specific RX stack need"
-	default 300
+	int "RPL specific RX stack need" if NET_RPL
+	default 0
+	default 300 if NET_RPL
 	help
 	  How much extra RX stack space is required by RPL functionality.
-endif # NET_RPL
-
-if !NET_RPL
-config NET_RX_STACK_RPL
-	int
-	default 0
-endif # !NET_RPL
 
 endmenu


### PR DESCRIPTION
A condition can be put on a prompt to make a symbol conditionally
user-assignable (visible).

Kconfig note:

`default`'s don't care whether the symbol is visible (has a prompt with a
satisfied condition) or not. `if`/`depends on` just puts the same
condition on all the properties, disabling both the defaults and the
prompt at the same time. That might make it look like they're connected.