### PR TITLE
Add NATIVE_EXIT_TASK hooks

### DIFF
--- a/arch/posix/soc/inf_clock/soc.c
+++ b/arch/posix/soc/inf_clock/soc.c
@@ -213,6 +213,20 @@ void posix_boot_cpu(void)
 	}
 }
 
+static void run_native_exit_tasks(void)
+{
+	extern void (*__native_exit_tasks_start[])(void);
+	extern void (*__native_exit_tasks_end[])(void);
+
+	void (**fptr)(void);
+	for (fptr = __native_exit_tasks_start; fptr < __native_exit_tasks_end;
+		fptr++) {
+		if (*fptr) {
+			(*fptr)();
+		}
+	}
+}
+
 /**
  * Clean up all memory allocated by the SOC and POSIX core
  *
@@ -230,6 +244,7 @@ void posix_soc_clean_up(void)
 	if (cpu_halted) {
 
 		posix_core_clean_up();
+		run_native_exit_tasks();
 
 	} else if (soc_terminate == false) {
 

--- a/arch/posix/soc/inf_clock/soc.h
+++ b/arch/posix/soc/inf_clock/soc.h
@@ -14,7 +14,24 @@
 extern "C" {
 #endif
 
-void poisix_soc_clean_up(void);
+void posix_soc_clean_up(void);
+
+/**
+ * NATIVE_EXIT_TASK
+ *
+ * Register a function to be called during termination of the native application
+ * execution.
+ *
+ * The function must take no parameters and return nothing.
+ *
+ * This can be used to close files, free memory, etc.
+ *
+ * Note that this function will be called when neither the Zephyr kernel or
+ * any Zephyr thread is running anymore.
+ */
+#define NATIVE_EXIT_TASK(fn)	\
+	static void (*_CONCAT(__native_exit_task_, fn)) __used	\
+	__attribute__((__section__(".native_exit_tasks"))) = fn
 
 #ifdef __cplusplus
 }

--- a/boards/posix/native_posix/main.c
+++ b/boards/posix/native_posix/main.c
@@ -37,7 +37,7 @@ void posix_exit(int exit_code)
 	 */
 	posix_soc_clean_up();
 	hwm_cleanup();
-	exit(exit_code);
+	exit(max_exit_code);
 }
 
 /**

--- a/include/arch/posix/linker.ld
+++ b/include/arch/posix/linker.ld
@@ -29,7 +29,15 @@ SECTIONS
 
 #include <linker/common-ram.ld>
 
+	SECTION_PROLOGUE (native_exit_tasks, (OPTIONAL),)
+	{
+		__native_exit_tasks_start = .;
+		KEEP(*(".native_exit_tasks"));
+		__native_exit_tasks_end = .;
+	}
+
  __data_ram_end = .;
+
  } INSERT AFTER .data;
 
 /*

--- a/scripts/sanitycheck
+++ b/scripts/sanitycheck
@@ -2062,11 +2062,16 @@ class TestSuite:
 
         def calc_one_elf_size(name, goal):
             if not goal.failed:
-                i = self.instances[name]
-                sc = i.calculate_sizes()
-                goal.metrics["ram_size"] = sc.get_ram_size()
-                goal.metrics["rom_size"] = sc.get_rom_size()
-                goal.metrics["unrecognized"] = sc.unrecognized_sections()
+                if self.instances[name].platform.type != "native":
+                    i = self.instances[name]
+                    sc = i.calculate_sizes()
+                    goal.metrics["ram_size"] = sc.get_ram_size()
+                    goal.metrics["rom_size"] = sc.get_rom_size()
+                    goal.metrics["unrecognized"] = sc.unrecognized_sections()
+                else:
+                    goal.metrics["ram_size"] = 0
+                    goal.metrics["rom_size"] = 0
+                    goal.metrics["unrecognized"] = []
 
         mg = MakeGenerator(self.outdir)
         for i in self.instances.values():

--- a/tests/boards/native_posix/exit_task/CMakeLists.txt
+++ b/tests/boards/native_posix/exit_task/CMakeLists.txt
@@ -1,0 +1,5 @@
+include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
+project(NONE)
+
+FILE(GLOB app_sources src/*.c)
+target_sources(app PRIVATE ${app_sources})

--- a/tests/boards/native_posix/exit_task/prj.conf
+++ b/tests/boards/native_posix/exit_task/prj.conf
@@ -1,0 +1,1 @@
+# Deliberately empty

--- a/tests/boards/native_posix/exit_task/src/main.c
+++ b/tests/boards/native_posix/exit_task/src/main.c
@@ -1,0 +1,61 @@
+/*
+ * Copyright (c) 2018 Oticon A/S
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include "soc.h"
+
+/**
+ * @brief Test NATIVE_EXIT_TASK hook for native builds
+ *
+ * Verify that the NATIVE_EXIT_TASK hooks are registered and called on exit.
+ * Note that the ztest framework cannot be used as we are testing
+ * functionality which executes after all Zephyr threads have been terminated.
+ */
+static void test_exit_hook(void)
+{
+	static int hooks_count;
+
+	hooks_count++;
+	posix_print_trace("%s called %i of 5 times\n", __func__, hooks_count);
+	if (hooks_count == 5) {
+		posix_print_trace("PROJECT EXECUTION SUCCESSFUL\n");
+	}
+}
+
+static void test_exit_hook1(void)
+{
+	test_exit_hook();
+}
+
+static void test_exit_hook2(void)
+{
+	test_exit_hook();
+}
+
+static void test_exit_hook3(void)
+{
+	test_exit_hook();
+}
+
+static void test_exit_hook4(void)
+{
+	test_exit_hook();
+}
+
+static void test_exit_hook5(void)
+{
+	test_exit_hook();
+}
+
+NATIVE_EXIT_TASK(test_exit_hook1);
+NATIVE_EXIT_TASK(test_exit_hook2);
+NATIVE_EXIT_TASK(test_exit_hook3);
+NATIVE_EXIT_TASK(test_exit_hook4);
+NATIVE_EXIT_TASK(test_exit_hook5);
+
+void main(void)
+{
+	posix_exit(0);
+}

--- a/tests/boards/native_posix/exit_task/testcase.yaml
+++ b/tests/boards/native_posix/exit_task/testcase.yaml
@@ -1,0 +1,3 @@
+tests:
+  boards.native_posix:
+    arch_whitelist: posix


### PR DESCRIPTION
Some of the native application components or drivers need to do a proper cleanup before the executable exits.
So we provide a macro similar to SYS_INIT but which will be called just before exiting.
This can be used for freeing up resources, closing descriptors, or doing any neccessary signaling to any other host process.
+
Added a simple testcase for it.
+
In sanitycheck, do not calculate the size for native builds or check for unexpected sections.

--------------

Comment about the sanitycheck change: it just felt silly to add an extra section for this in the SizeCalculator. I assumed there is no use for the size reports in this target anyhow. But if there is, just tell.