### PR TITLE
kernel: minor improve in SYS_CLOCK_HW_CYCLES_PER_SEC help description

### DIFF
--- a/kernel/Kconfig
+++ b/kernel/Kconfig
@@ -537,7 +537,7 @@ config SYS_CLOCK_HW_CYCLES_PER_SEC
 	int "System clock's h/w timer frequency"
 	help
 	  This option specifies the frequency of the hardware timer used for the
-	  system clock (in Hz). This option is set by the board's Kconfig file
+	  system clock (in Hz). This option is set by the SOC's or board's Kconfig file
 	  and the user should generally avoid modifying it via the menu configuration.
 
 config SYS_CLOCK_EXISTS


### PR DESCRIPTION
Minor improvement in the help text description of Kconfig option
SYS_CLOCK_HW_CYCLES_PER_SEC, clarifying that the option can be
defined in either SOC or Board Kconfig file.

