### PR TITLE
subsys: mgmt: Fix broken OTA firmware update

### DIFF
--- a/subsys/mgmt/smp_shell.c
+++ b/subsys/mgmt/smp_shell.c
@@ -71,7 +71,7 @@ static int smp_shell_init(struct device *dev)
 	ARG_UNUSED(dev);
 
 	zephyr_smp_transport_init(&smp_shell_transport, smp_shell_tx_pkt,
-				  smp_shell_get_mtu);
+				  smp_shell_get_mtu, NULL, NULL);
 	shell_register_mcumgr_handler(smp_shell_rx_line, NULL);
 
 	return 0;

--- a/subsys/mgmt/smp_uart.c
+++ b/subsys/mgmt/smp_uart.c
@@ -92,7 +92,7 @@ static int smp_uart_init(struct device *dev)
 	ARG_UNUSED(dev);
 
 	zephyr_smp_transport_init(&smp_uart_transport, smp_uart_tx_pkt,
-				  smp_uart_get_mtu);
+				  smp_uart_get_mtu, NULL, NULL);
 	uart_mcumgr_register(smp_uart_rx_frag);
 
 	return 0;


### PR DESCRIPTION
    [DNM] ext: mcumgr: Refactor req & rsp buffer freeing
    
    This refactors the buffer free mechaninsm, so that application
    do not have to free the rsp buffer from tx context.
    
    Relates to https://github.com/apache/mynewt-mcumgr/pull/8
    
    Fixes 8636.
    Signed-off-by: Mariusz Skamra <mariusz.skamra@codecoup.pl>