### PR TITLE
drivers: Fix asserts in i.MX UART Driver

### DIFF
--- a/boards/arm/colibri_imx7d_m4/colibri_imx7d_m4.dts
+++ b/boards/arm/colibri_imx7d_m4/colibri_imx7d_m4.dts
@@ -49,7 +49,7 @@
 &uart2 {
 	status = "ok";
 	current-speed = <115200>;
-	modem-mode = <1>;
+	modem-mode = <64>;
 };
 
 &gpio1 {

--- a/drivers/serial/uart_imx.c
+++ b/drivers/serial/uart_imx.c
@@ -74,7 +74,7 @@ static int uart_imx_init(struct device *dev)
 	UART_Init(uart, &initConfig);
 
 	/* Set UART build-in hardware FIFO Watermark. */
-	UART_SetTxFifoWatermark(uart, 1);
+	UART_SetTxFifoWatermark(uart, 2);
 	UART_SetRxFifoWatermark(uart, 1);
 
 	/* restore interrupt state */

--- a/dts/bindings/serial/nxp,imx-uart.yaml
+++ b/dts/bindings/serial/nxp,imx-uart.yaml
@@ -48,7 +48,7 @@ properties:
     modem-mode:
      type: int
      category: required
-     description: Set the UART Port to modem mode 0 (dce) 1 (dte)
+     description: Set the UART Port to modem mode 0 (dce) 64 (dte)
      generation: define
 
 ...


### PR DESCRIPTION
After running some tests which enable assert macro I found some issues with the i.MX UART configuration.

This patch configures the Tx Fifo Watermark and Modem Mode accordingly.

Signed-off-by: Diego Sueiro <diego.sueiro@gmail.com>