### PR TITLE
drivers: usb_dc_kinetis: fix gcc 7.3.1 warning

### DIFF
--- a/drivers/usb/device/usb_dc_kinetis.c
+++ b/drivers/usb/device/usb_dc_kinetis.c
@@ -572,7 +572,7 @@ int usb_dc_ep_write(const u8_t ep, const u8_t *const data,
 		    const u32_t data_len, u32_t * const ret_bytes)
 {
 	u8_t ep_idx = EP_ADDR2IDX(ep);
-	bool odd = dev_data.ep_ctrl[ep_idx].status.in_odd;
+	u8_t odd = dev_data.ep_ctrl[ep_idx].status.in_odd;
 	u8_t bd_idx = get_bdt_idx(ep, odd);
 	u8_t *bufp = (u8_t *)bdt[bd_idx].buf_addr;
 	u32_t len_to_send = data_len;


### PR DESCRIPTION
Use the same variable type for the odd bit handling
and fix the boolean expression warning with gcc 7.3.1.