### PR TITLE
tests: kernel: Add test to validate k_stack_cleanup and k_stack_alloc…

### DIFF
--- a/tests/kernel/stack/stack_api/src/main.c
+++ b/tests/kernel/stack/stack_api/src/main.c
@@ -8,11 +8,10 @@
 extern void test_stack_thread2thread(void);
 extern void test_stack_thread2isr(void);
 extern void test_stack_pop_fail(void);
+extern void test_stack_alloc_thread2thread(void);
 #ifdef CONFIG_USERSPACE
 extern void test_stack_user_thread2thread(void);
 extern void test_stack_user_pop_fail(void);
-
-K_MEM_POOL_DEFINE(test_pool, 128, 128, 2, 4);
 #else
 #define dummy_test(_name) \
 	static void _name(void) \
@@ -23,6 +22,8 @@ K_MEM_POOL_DEFINE(test_pool, 128, 128, 2, 4);
 dummy_test(test_stack_user_thread2thread);
 dummy_test(test_stack_user_pop_fail);
 #endif /* CONFIG_USERSPACE */
+
+K_MEM_POOL_DEFINE(test_pool, 128, 128, 2, 4);
 
 extern struct k_stack kstack;
 extern struct k_stack stack;
@@ -42,15 +43,14 @@ void test_main(void)
 	k_thread_access_grant(k_current_get(), &kstack, &stack, &thread_data,
 			      &end_sema, &threadstack, NULL);
 
-#ifdef CONFIG_USERSPACE
 	k_thread_resource_pool_assign(k_current_get(), &test_pool);
-#endif
 
 	ztest_test_suite(stack_api,
 			 ztest_unit_test(test_stack_thread2thread),
 			 ztest_user_unit_test(test_stack_user_thread2thread),
 			 ztest_unit_test(test_stack_thread2isr),
 			 ztest_unit_test(test_stack_pop_fail),
-			 ztest_user_unit_test(test_stack_user_pop_fail));
+			 ztest_user_unit_test(test_stack_user_pop_fail),
+			 ztest_unit_test(test_stack_alloc_thread2thread));
 	ztest_run_test_suite(stack_api);
 }

--- a/tests/kernel/stack/stack_api/src/test_stack_contexts.c
+++ b/tests/kernel/stack/stack_api/src/test_stack_contexts.c
@@ -6,12 +6,12 @@
 
 #include <ztest.h>
 #include <irq_offload.h>
-
 #define STACK_SIZE 512
 #define STACK_LEN 2
 
 /**TESTPOINT: init via K_STACK_DEFINE*/
 K_STACK_DEFINE(kstack, STACK_LEN);
+K_STACK_DEFINE(kstack_test_alloc, STACK_LEN);
 __kernel struct k_stack stack;
 
 K_THREAD_STACK_DEFINE(threadstack, STACK_SIZE);
@@ -131,6 +131,37 @@ void test_stack_thread2isr(void)
 
 	/**TESTPOINT: test K_STACK_DEFINE stack*/
 	tstack_thread_isr(&kstack);
+}
+
+/**
+ * @see k_stack_alloc_init(), k_stack_push(), #K_STACK_DEFINE(x), k_stack_pop(),
+ * k_stack_cleanup()
+ */
+void test_stack_alloc_thread2thread(void)
+{
+	int ret;
+
+	k_stack_alloc_init(&kstack_test_alloc, STACK_LEN);
+
+	k_sem_init(&end_sema, 0, 1);
+	/**TESTPOINT: thread-thread data passing via stack*/
+	k_tid_t tid = k_thread_create(&thread_data, threadstack, STACK_SIZE,
+					tThread_entry, &kstack_test_alloc,
+					NULL, NULL, K_PRIO_PREEMPT(0), 0, 0);
+	tstack_push(&kstack_test_alloc);
+	k_sem_take(&end_sema, K_FOREVER);
+
+	k_sem_take(&end_sema, K_FOREVER);
+	tstack_pop(&kstack_test_alloc);
+
+	/* clear the spawn thread to avoid side effect */
+	k_thread_abort(tid);
+	k_stack_cleanup(&kstack_test_alloc);
+
+	/** Requested buffer allocation from the test pool.*/
+	ret = k_stack_alloc_init(&kstack_test_alloc, (STACK_SIZE/2)+1);
+	zassert_true(ret == -ENOMEM,
+			"resource pool is smaller then requested buffer");
 }
 
 /**


### PR DESCRIPTION
This test is intended to validate k_stack_cleanup() and k_stack_alloc_init(),
when CONFIG_USERSPACE is not defined .
Passed stack pointer in k_stack_alloc_init() is statically defined.

Signed-off-by: Ajay Kishore <ajay.kishore@intel.com>