### PR TITLE
drivers: uart: Allow to pass arbitrary user data to irq callback

### DIFF
--- a/drivers/serial/uart_cc32xx.c
+++ b/drivers/serial/uart_cc32xx.c
@@ -17,7 +17,8 @@
 
 struct uart_cc32xx_dev_data_t {
 #ifdef CONFIG_UART_INTERRUPT_DRIVEN
-	uart_irq_callback_t cb; /**< Callback function pointer */
+	uart_irq_callback_user_data_t cb; /**< Callback function pointer */
+	void *cb_data; /**< Callback function arg */
 #endif /* CONFIG_UART_INTERRUPT_DRIVEN */
 };
 
@@ -243,11 +244,13 @@ static int uart_cc32xx_irq_update(struct device *dev)
 }
 
 static void uart_cc32xx_irq_callback_set(struct device *dev,
-					 uart_irq_callback_t cb)
+					 uart_irq_callback_user_data_t cb,
+					 void *cb_data)
 {
 	struct uart_cc32xx_dev_data_t * const dev_data = DEV_DATA(dev);
 
 	dev_data->cb = cb;
+	dev_data->cb_data = cb_data;
 }
 
 /**
@@ -272,7 +275,7 @@ static void uart_cc32xx_isr(void *arg)
 						    1);
 
 	if (dev_data->cb) {
-		dev_data->cb(dev);
+		dev_data->cb(dev_data->cb_data);
 	}
 	/*
 	 * Clear interrupts only after cb called, as Zephyr UART clients expect

--- a/drivers/serial/uart_cmsdk_apb.c
+++ b/drivers/serial/uart_cmsdk_apb.c
@@ -63,7 +63,8 @@ struct uart_cmsdk_apb {
 struct uart_cmsdk_apb_dev_data {
 	u32_t baud_rate;	/* Baud rate */
 #ifdef CONFIG_UART_INTERRUPT_DRIVEN
-	uart_irq_callback_t irq_cb;
+	uart_irq_callback_user_data_t irq_cb;
+	void *irq_cb_data;
 #endif
 	/* UART Clock control in Active State */
 	const struct arm_clock_control_t uart_cc_as;
@@ -392,9 +393,11 @@ static int uart_cmsdk_apb_irq_update(struct device *dev)
  * @return N/A
  */
 static void uart_cmsdk_apb_irq_callback_set(struct device *dev,
-					    uart_irq_callback_t cb)
+					    uart_irq_callback_user_data_t cb,
+					    void *cb_data)
 {
 	DEV_DATA(dev)->irq_cb = cb;
+	DEV_DATA(dev)->irq_cb_data = cb_data;
 }
 
 /**
@@ -417,7 +420,7 @@ void uart_cmsdk_apb_isr(void *arg)
 
 	/* Verify if the callback has been registered */
 	if (data->irq_cb) {
-		data->irq_cb(dev);
+		data->irq_cb(data->irq_cb_data);
 	}
 }
 

--- a/drivers/serial/uart_fe310.c
+++ b/drivers/serial/uart_fe310.c
@@ -58,7 +58,8 @@ struct uart_fe310_device_config {
 
 struct uart_fe310_data {
 #ifdef CONFIG_UART_INTERRUPT_DRIVEN
-	uart_irq_callback_t callback;
+	uart_irq_callback_user_data_t callback;
+	void *cb_data;
 #endif
 };
 
@@ -309,11 +310,13 @@ static int uart_fe310_irq_update(struct device *dev)
  * @return N/A
  */
 static void uart_fe310_irq_callback_set(struct device *dev,
-					uart_irq_callback_t cb)
+					uart_irq_callback_user_data_t cb,
+					void *cb_data)
 {
 	struct uart_fe310_data *data = DEV_DATA(dev);
 
 	data->callback = cb;
+	data->cb_data = cb_data;
 }
 
 static void uart_fe310_irq_handler(void *arg)
@@ -322,7 +325,7 @@ static void uart_fe310_irq_handler(void *arg)
 	struct uart_fe310_data *data = DEV_DATA(dev);
 
 	if (data->callback)
-		data->callback(dev);
+		data->callback(data->cb_data);
 }
 
 #endif /* CONFIG_UART_INTERRUPT_DRIVEN */

--- a/drivers/serial/uart_gecko.c
+++ b/drivers/serial/uart_gecko.c
@@ -25,7 +25,8 @@ struct uart_gecko_config {
 
 struct uart_gecko_data {
 #ifdef CONFIG_UART_INTERRUPT_DRIVEN
-	uart_irq_callback_t callback;
+	uart_irq_callback_user_data_t callback;
+	void *cb_data;
 #endif
 };
 
@@ -203,11 +204,13 @@ static int uart_gecko_irq_update(struct device *dev)
 }
 
 static void uart_gecko_irq_callback_set(struct device *dev,
-				       uart_irq_callback_t cb)
+				       uart_irq_callback_user_data_t cb,
+				       void *cb_data)
 {
 	struct uart_gecko_data *data = dev->driver_data;
 
 	data->callback = cb;
+	data->cb_data = cb_data;
 }
 
 static void uart_gecko_isr(void *arg)
@@ -216,7 +219,7 @@ static void uart_gecko_isr(void *arg)
 	struct uart_gecko_data *data = dev->driver_data;
 
 	if (data->callback) {
-		data->callback(dev);
+		data->callback(data->cb_data);
 	}
 }
 #endif /* CONFIG_UART_INTERRUPT_DRIVEN */

--- a/drivers/serial/uart_imx.c
+++ b/drivers/serial/uart_imx.c
@@ -36,7 +36,8 @@ struct imx_uart_config {
 
 struct imx_uart_data {
 #ifdef CONFIG_UART_INTERRUPT_DRIVEN
-	uart_irq_callback_t callback;
+	uart_irq_callback_user_data_t callback;
+	void *cb_data;
 #endif
 };
 
@@ -228,11 +229,13 @@ static int uart_imx_irq_update(struct device *dev)
 }
 
 static void uart_imx_irq_callback_set(struct device *dev,
-		uart_irq_callback_t cb)
+		uart_irq_callback_user_data_t cb,
+		void *cb_data)
 {
 	struct imx_uart_data *data = dev->driver_data;
 
 	data->callback = cb;
+	data->cb_data = cb_data;
 }
 
 /**

--- a/drivers/serial/uart_mcux.c
+++ b/drivers/serial/uart_mcux.c
@@ -23,7 +23,8 @@ struct uart_mcux_config {
 
 struct uart_mcux_data {
 #ifdef CONFIG_UART_INTERRUPT_DRIVEN
-	uart_irq_callback_t callback;
+	uart_irq_callback_user_data_t callback;
+	void *cb_data;
 #endif
 };
 
@@ -206,11 +207,13 @@ static int uart_mcux_irq_update(struct device *dev)
 }
 
 static void uart_mcux_irq_callback_set(struct device *dev,
-				       uart_irq_callback_t cb)
+				       uart_irq_callback_user_data_t cb,
+				       void *cb_data)
 {
 	struct uart_mcux_data *data = dev->driver_data;
 
 	data->callback = cb;
+	data->cb_data = cb_data;
 }
 
 static void uart_mcux_isr(void *arg)
@@ -219,7 +222,7 @@ static void uart_mcux_isr(void *arg)
 	struct uart_mcux_data *data = dev->driver_data;
 
 	if (data->callback) {
-		data->callback(dev);
+		data->callback(data->cb_data);
 	}
 }
 #endif /* CONFIG_UART_INTERRUPT_DRIVEN */

--- a/drivers/serial/uart_mcux_lpsci.c
+++ b/drivers/serial/uart_mcux_lpsci.c
@@ -23,7 +23,8 @@ struct mcux_lpsci_config {
 
 struct mcux_lpsci_data {
 #ifdef CONFIG_UART_INTERRUPT_DRIVEN
-	uart_irq_callback_t callback;
+	uart_irq_callback_user_data_t callback;
+	void *cb_data;
 #endif
 };
 
@@ -210,11 +211,13 @@ static int mcux_lpsci_irq_update(struct device *dev)
 }
 
 static void mcux_lpsci_irq_callback_set(struct device *dev,
-				       uart_irq_callback_t cb)
+				       uart_irq_callback_user_data_t cb,
+				       void *cb_data)
 {
 	struct mcux_lpsci_data *data = dev->driver_data;
 
 	data->callback = cb;
+	data->cb_data = cb_data;
 }
 
 static void mcux_lpsci_isr(void *arg)
@@ -223,7 +226,7 @@ static void mcux_lpsci_isr(void *arg)
 	struct mcux_lpsci_data *data = dev->driver_data;
 
 	if (data->callback) {
-		data->callback(dev);
+		data->callback(data->cb_data);
 	}
 }
 #endif /* CONFIG_UART_INTERRUPT_DRIVEN */

--- a/drivers/serial/uart_mcux_lpuart.c
+++ b/drivers/serial/uart_mcux_lpuart.c
@@ -23,7 +23,8 @@ struct mcux_lpuart_config {
 
 struct mcux_lpuart_data {
 #ifdef CONFIG_UART_INTERRUPT_DRIVEN
-	uart_irq_callback_t callback;
+	uart_irq_callback_user_data_t callback;
+	void *cb_data;
 #endif
 };
 
@@ -210,11 +211,13 @@ static int mcux_lpuart_irq_update(struct device *dev)
 }
 
 static void mcux_lpuart_irq_callback_set(struct device *dev,
-				       uart_irq_callback_t cb)
+				       uart_irq_callback_user_data_t cb,
+				       void *cb_data)
 {
 	struct mcux_lpuart_data *data = dev->driver_data;
 
 	data->callback = cb;
+	data->cb_data = cb_data;
 }
 
 static void mcux_lpuart_isr(void *arg)
@@ -223,7 +226,7 @@ static void mcux_lpuart_isr(void *arg)
 	struct mcux_lpuart_data *data = dev->driver_data;
 
 	if (data->callback) {
-		data->callback(dev);
+		data->callback(data->cb_data);
 	}
 }
 #endif /* CONFIG_UART_INTERRUPT_DRIVEN */

--- a/drivers/serial/uart_miv.c
+++ b/drivers/serial/uart_miv.c
@@ -138,7 +138,8 @@ struct uart_miv_device_config {
 
 struct uart_miv_data {
 #ifdef CONFIG_UART_INTERRUPT_DRIVEN
-	uart_irq_callback_t callback;
+	uart_irq_callback_user_data_t callback;
+	void *cb_data;
 #endif
 };
 
@@ -300,7 +301,7 @@ static void uart_miv_irq_handler(void *arg)
 	struct uart_miv_data *data = DEV_DATA(dev);
 
 	if (data->callback) {
-		data->callback(dev);
+		data->callback(data->cb_data);
 	}
 }
 
@@ -329,11 +330,13 @@ void uart_miv_rx_thread(void *arg1, void *arg2, void *arg3)
 }
 
 static void uart_miv_irq_callback_set(struct device *dev,
-				      uart_irq_callback_t cb)
+				      uart_irq_callback_user_data_t cb,
+				      void *cb_data)
 {
 	struct uart_miv_data *data = DEV_DATA(dev);
 
 	data->callback = cb;
+	data->cb_data = cb_data;
 }
 
 #endif /* CONFIG_UART_INTERRUPT_DRIVEN */

--- a/drivers/serial/uart_msp432p4xx.c
+++ b/drivers/serial/uart_msp432p4xx.c
@@ -21,7 +21,8 @@ struct uart_msp432p4xx_dev_data_t {
 	/* UART config structure */
 	eUSCI_UART_Config uartConfig;
 #ifdef CONFIG_UART_INTERRUPT_DRIVEN
-	uart_irq_callback_t cb; /**< Callback function pointer */
+	uart_irq_callback_user_data_t cb; /**< Callback function pointer */
+	void *cb_data;  /**< Callback function arg */
 #endif /* CONFIG_UART_INTERRUPT_DRIVEN */
 };
 
@@ -299,11 +300,13 @@ static int uart_msp432p4xx_irq_update(struct device *dev)
 }
 
 static void uart_msp432p4xx_irq_callback_set(struct device *dev,
-					 uart_irq_callback_t cb)
+					 uart_irq_callback_user_data_t cb,
+					 void *cb_data)
 {
 	struct uart_msp432p4xx_dev_data_t * const dev_data = DEV_DATA(dev);
 
 	dev_data->cb = cb;
+	dev_data->cb_data = cb_data;
 }
 
 /**
@@ -326,7 +329,7 @@ static void uart_msp432p4xx_isr(void *arg)
 						(unsigned long)config->base);
 
 	if (dev_data->cb) {
-		dev_data->cb(dev);
+		dev_data->cb(dev_data->cb_data);
 	}
 	/*
 	 * Clear interrupts only after cb called, as Zephyr UART clients expect

--- a/drivers/serial/uart_nrfx_uart.c
+++ b/drivers/serial/uart_nrfx_uart.c
@@ -17,7 +17,8 @@ static NRF_UART_Type *const uart0_addr = (NRF_UART_Type *)CONFIG_UART_0_BASE;
 
 #ifdef CONFIG_UART_0_INTERRUPT_DRIVEN
 
-static uart_irq_callback_t irq_callback; /**< Callback function pointer */
+static uart_irq_callback_user_data_t irq_callback; /**< Callback function pointer */
+static void *irq_cb_data; /**< Callback function arg */
 
 /* Variable used to override the state of the TXDRDY event in the initial state
  * of the driver. This event is not set by the hardware until a first byte is
@@ -331,10 +332,12 @@ static int uart_nrfx_irq_update(struct device *dev)
 
 /** Set the callback function */
 static void uart_nrfx_irq_callback_set(struct device *dev,
-				       uart_irq_callback_t cb)
+				       uart_irq_callback_user_data_t cb,
+				       void *cb_data)
 {
 	(void)dev;
 	irq_callback = cb;
+	irq_cb_data = cb_data;
 }
 
 /**
@@ -348,10 +351,10 @@ static void uart_nrfx_irq_callback_set(struct device *dev,
  */
 static void uart_nrfx_isr(void *arg)
 {
-	struct device *dev = arg;
+	ARG_UNUSED(arg);
 
 	if (irq_callback) {
-		irq_callback(dev);
+		irq_callback(irq_cb_data);
 	}
 }
 #endif /* CONFIG_UART_0_INTERRUPT_DRIVEN */

--- a/drivers/serial/uart_nrfx_uarte.c
+++ b/drivers/serial/uart_nrfx_uarte.c
@@ -25,7 +25,8 @@ struct uarte_nrfx_data {
 	u8_t rx_data;
 
 #ifdef UARTE_INTERRUPT_DRIVEN
-	uart_irq_callback_t cb; /**< Callback function pointer */
+	uart_irq_callback_user_data_t cb; /**< Callback function pointer */
+	void *cb_data; /**< Callback function arg */
 	u8_t *tx_buffer;
 #endif /* UARTE_INTERRUPT_DRIVEN */
 };
@@ -84,7 +85,7 @@ static void uarte_nrfx_isr(void *arg)
 	const struct uarte_nrfx_data *data = get_dev_data(dev);
 
 	if (data->cb) {
-		data->cb(dev);
+		data->cb(data->cb_data);
 	}
 }
 #endif /* UARTE_INTERRUPT_DRIVEN */
@@ -405,11 +406,13 @@ static int uarte_nrfx_irq_update(struct device *dev)
 
 /** Set the callback function */
 static void uarte_nrfx_irq_callback_set(struct device *dev,
-					uart_irq_callback_t cb)
+					uart_irq_callback_user_data_t cb,
+					void *cb_data)
 {
 	struct uarte_nrfx_data *data = get_dev_data(dev);
 
 	data->cb = cb;
+	data->cb_data = cb_data;
 }
 #endif /* UARTE_INTERRUPT_DRIVEN */
 

--- a/drivers/serial/uart_ns16550.c
+++ b/drivers/serial/uart_ns16550.c
@@ -222,7 +222,8 @@ struct uart_ns16550_dev_data_t {
 
 #ifdef CONFIG_UART_INTERRUPT_DRIVEN
 	u8_t iir_cache;	/**< cache of IIR since it clears when read */
-	uart_irq_callback_t	cb;	/**< Callback function pointer */
+	uart_irq_callback_user_data_t cb;	/**< Callback function pointer */
+	void *cb_data;	/**< Callback function arg */
 #endif
 
 #ifdef CONFIG_UART_NS16550_DLF
@@ -609,11 +610,13 @@ static int uart_ns16550_irq_update(struct device *dev)
  * @return N/A
  */
 static void uart_ns16550_irq_callback_set(struct device *dev,
-					  uart_irq_callback_t cb)
+					  uart_irq_callback_user_data_t cb,
+					  void *cb_data)
 {
 	struct uart_ns16550_dev_data_t * const dev_data = DEV_DATA(dev);
 
 	dev_data->cb = cb;
+	dev_data->cb_data = cb_data;
 }
 
 /**
@@ -631,7 +634,7 @@ static void uart_ns16550_isr(void *arg)
 	struct uart_ns16550_dev_data_t * const dev_data = DEV_DATA(dev);
 
 	if (dev_data->cb) {
-		dev_data->cb(dev);
+		dev_data->cb(dev_data->cb_data);
 	}
 }
 

--- a/drivers/serial/uart_qmsi.c
+++ b/drivers/serial/uart_qmsi.c
@@ -46,14 +46,16 @@ static int uart_qmsi_init(struct device *dev);
 
 #ifndef CONFIG_DEVICE_POWER_MANAGEMENT
 struct uart_qmsi_drv_data {
-	uart_irq_callback_t user_cb;
+	uart_irq_callback_user_data_t user_cb;
+	void *cb_data;
 	u8_t iir_cache;
 };
 
 #define uart_qmsi_set_power_state(...)
 #else
 struct uart_qmsi_drv_data {
-	uart_irq_callback_t user_cb;
+	uart_irq_callback_user_data_t user_cb;
+	void *cb_data;
 	u8_t iir_cache;
 	u32_t device_power_state;
 	qm_uart_context_t ctx;
@@ -348,11 +350,13 @@ static int uart_qmsi_irq_update(struct device *dev)
 }
 
 static void uart_qmsi_irq_callback_set(struct device *dev,
-				       uart_irq_callback_t cb)
+				       uart_irq_callback_user_data_t cb,
+				       void *cb_data)
 {
 	struct uart_qmsi_drv_data *drv_data = dev->driver_data;
 
 	drv_data->user_cb = cb;
+	drv_data->cb_data = cb_data;
 }
 
 static void uart_qmsi_isr(void *arg)
@@ -361,7 +365,7 @@ static void uart_qmsi_isr(void *arg)
 	struct uart_qmsi_drv_data *drv_data = dev->driver_data;
 
 	if (drv_data->user_cb)
-		drv_data->user_cb(dev);
+		drv_data->user_cb(drv_data->cb_data);
 
 	device_busy_clear(dev);
 }

--- a/drivers/serial/uart_sam.c
+++ b/drivers/serial/uart_sam.c
@@ -80,7 +80,8 @@ struct uart_sam_dev_data {
 	u32_t baud_rate;
 
 #ifdef CONFIG_UART_INTERRUPT_DRIVEN
-	uart_irq_callback_t irq_cb;	/* Interrupt Callback */
+	uart_irq_callback_user_data_t irq_cb;	/* Interrupt Callback */
+	void *irq_cb_data;	/* Interrupt Callback Arg */
 #endif /* CONFIG_UART_INTERRUPT_DRIVEN */
 };
 
@@ -321,11 +322,13 @@ static int uart_sam_irq_update(struct device *dev)
 }
 
 static void uart_sam_irq_callback_set(struct device *dev,
-				      uart_irq_callback_t cb)
+				      uart_irq_callback_user_data_t cb,
+				      void *data)
 {
 	struct uart_sam_dev_data *const dev_data = DEV_DATA(dev);
 
 	dev_data->irq_cb = cb;
+	dev_data->irq_cb_data = cb_data;
 }
 
 static void uart_sam_isr(void *arg)
@@ -334,7 +337,7 @@ static void uart_sam_isr(void *arg)
 	struct uart_sam_dev_data *const dev_data = DEV_DATA(dev);
 
 	if (dev_data->irq_cb) {
-		dev_data->irq_cb(dev);
+		dev_data->irq_cb(dev_data->irq_cb_data);
 	}
 }
 

--- a/drivers/serial/uart_sam0.c
+++ b/drivers/serial/uart_sam0.c
@@ -27,7 +27,8 @@ struct uart_sam0_dev_cfg {
 /* Device run time data */
 struct uart_sam0_dev_data {
 #ifdef CONFIG_UART_INTERRUPT_DRIVEN
-	uart_irq_callback_t cb;
+	uart_irq_callback_user_data_t cb;
+	void *cb_data;
 #endif
 };
 
@@ -154,7 +155,7 @@ static void uart_sam0_isr(void *arg)
 	struct uart_sam0_dev_data *const dev_data = DEV_DATA(dev);
 
 	if (dev_data->cb) {
-		dev_data->cb(dev);
+		dev_data->cb(dev_data->cb_data);
 	}
 }
 
@@ -240,11 +241,13 @@ static int uart_sam0_irq_is_pending(struct device *dev)
 static int uart_sam0_irq_update(struct device *dev) { return 1; }
 
 static void uart_sam0_irq_callback_set(struct device *dev,
-				       uart_irq_callback_t cb)
+				       uart_irq_callback_user_data_t cb,
+				       void *cb_data)
 {
 	struct uart_sam0_dev_data *const dev_data = DEV_DATA(dev);
 
 	dev_data->cb = cb;
+	dev_data->cb_data = cb_data;
 }
 #endif
 

--- a/drivers/serial/uart_stellaris.c
+++ b/drivers/serial/uart_stellaris.c
@@ -70,7 +70,8 @@ struct uart_stellaris_dev_data_t {
 	u32_t baud_rate;	/* Baud rate */
 
 #ifdef CONFIG_UART_INTERRUPT_DRIVEN
-	uart_irq_callback_t	cb;	/**< Callback function pointer */
+	uart_irq_callback_user_data_t cb;	/**< Callback function pointer */
+	void *cb_data;	/**< Callback function arg */
 #endif
 };
 
@@ -572,11 +573,13 @@ static int uart_stellaris_irq_update(struct device *dev)
  * @return N/A
  */
 static void uart_stellaris_irq_callback_set(struct device *dev,
-					    uart_irq_callback_t cb)
+					    uart_irq_callback_user_data_t cb,
+					    void *cb_data)
 {
 	struct uart_stellaris_dev_data_t * const dev_data = DEV_DATA(dev);
 
 	dev_data->cb = cb;
+	dev_data->cb_data = cb_data;
 }
 
 /**
@@ -594,7 +597,7 @@ static void uart_stellaris_isr(void *arg)
 	struct uart_stellaris_dev_data_t * const dev_data = DEV_DATA(dev);
 
 	if (dev_data->cb) {
-		dev_data->cb(dev);
+		dev_data->cb(dev_data->cb_data);
 	}
 }
 

--- a/drivers/serial/uart_stm32.c
+++ b/drivers/serial/uart_stm32.c
@@ -208,11 +208,13 @@ static int uart_stm32_irq_update(struct device *dev)
 }
 
 static void uart_stm32_irq_callback_set(struct device *dev,
-					uart_irq_callback_t cb)
+					uart_irq_callback_user_data_t cb,
+					void *cb_data)
 {
 	struct uart_stm32_data *data = DEV_DATA(dev);
 
 	data->user_cb = cb;
+	data->user_data = cb_data;
 }
 
 static void uart_stm32_isr(void *arg)
@@ -221,7 +223,7 @@ static void uart_stm32_isr(void *arg)
 	struct uart_stm32_data *data = DEV_DATA(dev);
 
 	if (data->user_cb) {
-		data->user_cb(dev);
+		data->user_cb(data->user_data);
 	}
 }
 

--- a/drivers/serial/uart_stm32.h
+++ b/drivers/serial/uart_stm32.h
@@ -26,7 +26,8 @@ struct uart_stm32_data {
 	/* clock device */
 	struct device *clock;
 #ifdef CONFIG_UART_INTERRUPT_DRIVEN
-	uart_irq_callback_t user_cb;
+	uart_irq_callback_user_data_t user_cb;
+	void *user_data;
 #endif
 };
 

--- a/drivers/serial/usart_sam.c
+++ b/drivers/serial/usart_sam.c
@@ -64,7 +64,8 @@ struct usart_sam_dev_data {
 	u32_t baud_rate;
 
 #ifdef CONFIG_UART_INTERRUPT_DRIVEN
-	uart_irq_callback_t irq_cb;	/* Interrupt Callback */
+	uart_irq_callback_user_data_t irq_cb;	/* Interrupt Callback */
+	void *cb_data;	/* Interrupt Callback Arg */
 #endif /* CONFIG_UART_INTERRUPT_DRIVEN */
 };
 
@@ -308,11 +309,13 @@ static int usart_sam_irq_update(struct device *dev)
 }
 
 static void usart_sam_irq_callback_set(struct device *dev,
-				       uart_irq_callback_t cb)
+				       uart_irq_callback_user_data_t cb,
+				       void *cb_data)
 {
 	struct usart_sam_dev_data *const dev_data = DEV_DATA(dev);
 
 	dev_data->irq_cb = cb;
+	dev_data->cb_data = cb_data;
 }
 
 static void usart_sam_isr(void *arg)
@@ -321,7 +324,7 @@ static void usart_sam_isr(void *arg)
 	struct usart_sam_dev_data *const dev_data = DEV_DATA(dev);
 
 	if (dev_data->irq_cb) {
-		dev_data->irq_cb(dev);
+		dev_data->irq_cb(dev_data->cb_data);
 	}
 }
 


### PR DESCRIPTION
Zephyr UART drivers offer very low-level functionality. Oftentimes,
it would be useful to provide higher-level wrappers around UART
device which would offer additional functionality. However, UART
driver irq callback routine receives just a pointer to (low-level)
UART device, and it's not possible to get to a wrapper structure
(without introducing expensive external mapping structures). This
is an indirect reason why the current UARt wrappers - uart_pipe,
console - are instantiated statically just for one underlying UART
device and cannot be reused for multiple devices.

Solve this by allowing to pass an arbitrary user data to irq
callback, set by new uart_irq_callback_user_data_set() function.
Existing uart_irq_callback_set() keeps setting a callback which
will receive pointer to the device.

While public API maintains compatibility, drivers themselves need
to be updated to support arbitrary user data storage/passing (as
legacy uart_irq_callback_set() functionality is now implemented in
terms of it).

Signed-off-by: Paul Sokolovsky <paul.sokolovsky@linaro.org>