### PR TITLE
Add malloc() and related functions to minimal libc

### DIFF
--- a/lib/libc/Kconfig
+++ b/lib/libc/Kconfig
@@ -56,4 +56,16 @@ config STDOUT_CONSOLE
 	  device, rather than suppressing it entirely. See also EARLY_CONSOLE
 	  option.
 
+# Minimal libc options
+
+config MINIMAL_LIBC_MALLOC_ARENA_SIZE
+	int
+	prompt "Size of the minimal libc malloc arena"
+	depends on !NEWLIB_LIBC
+	default 0
+	help
+	  Indicate the size of the memory arena used for minimal libc's
+	  malloc() implementation. This size value must be compatible with
+	  a sys_mem_pool definition with nmax of 1 and minsz of 16.
+
 endmenu

--- a/lib/libc/minimal/CMakeLists.txt
+++ b/lib/libc/minimal/CMakeLists.txt
@@ -5,6 +5,7 @@ zephyr_library_sources(
   source/stdlib/atoi.c
   source/stdlib/strtol.c
   source/stdlib/strtoul.c
+  source/stdlib/malloc.c
   source/string/strncasecmp.c
   source/string/strstr.c
   source/string/string.c

--- a/lib/libc/minimal/include/stdlib.h
+++ b/lib/libc/minimal/include/stdlib.h
@@ -18,6 +18,12 @@ unsigned long int strtoul(const char *str, char **endptr, int base);
 long int strtol(const char *str, char **endptr, int base);
 int atoi(const char *s);
 
+void *malloc(size_t size);
+void free(void *ptr);
+void *calloc(size_t nmemb, size_t size);
+void *realloc(void *ptr, size_t size);
+void *reallocarray(void *ptr, size_t nmemb, size_t size);
+
 #define abs(x) ((x) < 0 ? -(x) : (x))
 
 #ifdef __cplusplus

--- a/lib/libc/minimal/source/stdlib/malloc.c
+++ b/lib/libc/minimal/source/stdlib/malloc.c
@@ -1,0 +1,132 @@
+/*
+ * Copyright (c) 2018 Intel Corporation
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <stdlib.h>
+#include <zephyr.h>
+#include <init.h>
+#include <errno.h>
+#include <misc/mempool.h>
+#include <string.h>
+#include <logging/sys_log.h>
+
+#if (CONFIG_MINIMAL_LIBC_MALLOC_ARENA_SIZE > 0)
+K_MUTEX_DEFINE(malloc_mutex);
+SYS_MEM_POOL_DEFINE(z_malloc_mem_pool, &malloc_mutex, 16,
+		    CONFIG_MINIMAL_LIBC_MALLOC_ARENA_SIZE, 1, 4, .data);
+
+void *malloc(size_t size)
+{
+	void *ret;
+
+	ret = sys_mem_pool_alloc(&z_malloc_mem_pool, size);
+	if (!ret) {
+		errno = ENOMEM;
+	}
+
+	return ret;
+}
+
+static int malloc_prepare(struct device *unused)
+{
+	ARG_UNUSED(unused);
+
+#ifdef CONFIG_USERSPACE
+	k_object_access_all_grant(&malloc_mutex);
+#endif
+	sys_mem_pool_init(&z_malloc_mem_pool);
+
+	return 0;
+}
+
+SYS_INIT(malloc_prepare, APPLICATION, CONFIG_KERNEL_INIT_PRIORITY_DEFAULT);
+#else /* No malloc arena */
+void *malloc(size_t size)
+{
+	ARG_UNUSED(size);
+
+	SYS_LOG_DBG("CONFIG_MINIMAL_LIBC_MALLOC_ARENA_SIZE is 0\n");
+	errno = ENOMEM;
+
+	return NULL;
+}
+#endif
+
+void free(void *ptr)
+{
+	sys_mem_pool_free(ptr);
+}
+
+static bool size_t_mul_overflow(size_t a, size_t b, size_t *res)
+{
+#if __SIZEOF_SIZE_T__ == 4
+	return __builtin_umul_overflow((unsigned int)a, (unsigned int)b,
+				       (unsigned int *)res);
+#else /* __SIZEOF_SIZE_T__ == 8 */
+	return __builtin_umulll_overflow((unsigned long long)a,
+					 (unsigned long long)b,
+					 (unsigned long long *)res);
+#endif
+}
+
+void *calloc(size_t nmemb, size_t size)
+{
+	if (size_t_mul_overflow(nmemb, size, &size)) {
+		errno = ENOMEM;
+		return NULL;
+	}
+	return malloc(size);
+}
+
+void *realloc(void *ptr, size_t requested_size)
+{
+	struct sys_mem_pool_block *blk;
+	size_t block_size, total_requested_size;
+	void *new_ptr;
+
+	if (requested_size == 0) {
+		return NULL;
+	}
+
+	/* Stored right before the pointer passed to the user */
+	blk = (struct sys_mem_pool_block *)((char *)ptr - sizeof(*blk));
+
+	/* Determine size of previously allocated block by its level.
+	 * Most likely a bit larger than the original allocation
+	 */
+	block_size = _ALIGN4(blk->pool->base.max_sz);
+	for (int i = 1; i <= blk->level; i++) {
+		block_size = _ALIGN4(block_size / 4);
+	}
+
+	/* We really need this much memory */
+	total_requested_size = requested_size +
+		sizeof(struct sys_mem_pool_block);
+
+	if (block_size >= total_requested_size) {
+		/* Existing block large enough, nothing to do */
+		return ptr;
+	}
+
+	new_ptr = malloc(requested_size);
+	if (!new_ptr) {
+		return NULL;
+	}
+
+	memcpy(new_ptr, ptr, block_size - sizeof(struct sys_mem_pool_block));
+	free(ptr);
+
+	return new_ptr;
+}
+
+
+void *reallocarray(void *ptr, size_t nmemb, size_t size)
+{
+	if (size_t_mul_overflow(nmemb, size, &size)) {
+		errno = ENOMEM;
+		return NULL;
+	}
+	return realloc(ptr, size);
+}


### PR DESCRIPTION
The immediate need for this is to support getaddrinfo(), which requires a memory allocation.

Uses existing sys_mem_pool implementation.