### PR TITLE
Bluetooth:Make BT_HCI_TX_STACK_SIZE a prompted config

### DIFF
--- a/subsys/bluetooth/host/Kconfig
+++ b/subsys/bluetooth/host/Kconfig
@@ -49,7 +49,7 @@ config BT_RX_BUF_LEN
 
 config BT_HCI_TX_STACK_SIZE
 	# Stack size needed for executing bt_send with specified driver
-	int
+	int "Size of the transmitting thread stack"
 	# Even if no driver is selected the following default is still
 	# needed e.g. for unit tests.
 	default 256


### PR DESCRIPTION
BT_HCI_TX_STACK_SIZE could not be set through proj.conf file since it
gets to be overwritten by the default/the setting paraters.

Warning:
BT_HCI_TX_STACK_SIZE (defined at subsys/bluetooth/host/Kconfig:50) was
assigned the value "640" but got the value "256" -- check dependencies

Adds a prompt to the BT_HCI_TX_STACK_SIZE config to allow applications
to override the default setting.

Signed-off-by: Arjun Warty <arjun.warty@nxp.com>