### PR TITLE
drivers: uart_ns16550: restore config UART_NS16550_PORT_1_PCI

### DIFF
--- a/drivers/serial/Kconfig.ns16550
+++ b/drivers/serial/Kconfig.ns16550
@@ -156,6 +156,12 @@ config UART_NS16550_PORT_1_DLF
 	help
 	  Value for DLF register.
 
+config UART_NS16550_PORT_1_PCI
+	bool "Port 1 is PCI-based"
+	depends on UART_NS16550_PCI && UART_NS16550_PORT_1
+	help
+	  Obtain port information from PCI.
+
 # ---------- Port 2 ----------
 
 menuconfig UART_NS16550_PORT_2


### PR DESCRIPTION
The CONFIG_UART_NS16550_PORT_1_PCI was accidentally removed in
commit 26b474c987ce2666d25f79d8768753ba78172166. So adds it back.
This allows PCI driver to probe the resources for port 1.

Signed-off-by: Daniel Leung <daniel.leung@intel.com>