### PR TITLE
samples: zephyr_sizeofs: Print sizes of various structures used by Zephyr

### DIFF
--- a/samples/zephyr_sizeofs/CMakeLists.txt
+++ b/samples/zephyr_sizeofs/CMakeLists.txt
@@ -1,0 +1,5 @@
+
+include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
+project(NONE)
+
+target_sources(app PRIVATE src/main.c)

--- a/samples/zephyr_sizeofs/prj.conf
+++ b/samples/zephyr_sizeofs/prj.conf
@@ -1,0 +1,1 @@
+CONFIG_POLL=y

--- a/samples/zephyr_sizeofs/src/main.c
+++ b/samples/zephyr_sizeofs/src/main.c
@@ -1,0 +1,30 @@
+/*
+ * Copyright (c) 2018 Linaro Limited
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <zephyr.h>
+#include <misc/printk.h>
+
+#define SZ(x)  #x " = %u\n", (u32_t)sizeof(x)
+#define SZ_ALIAS(name, x)  name " = %u\n", (u32_t)sizeof(x)
+
+void main(void)
+{
+	printk(SZ(_wait_q_t));
+	printk(SZ_ALIAS("_POLL_EVENT", sys_dlist_t));
+	printk(SZ(sys_slist_t));
+	printk(SZ(sys_dlist_t));
+	printk(SZ(struct k_queue));
+	printk(SZ(struct k_fifo));
+	printk(SZ(struct k_lifo));
+	printk(SZ(struct k_thread));
+	printk(SZ(struct k_mutex));
+	printk(SZ(struct k_sem));
+	printk(SZ(struct k_poll_event));
+	printk(SZ(struct k_poll_signal));
+	printk(SZ(struct k_timer));
+	printk(SZ(struct _k_object));
+	printk(SZ(struct _k_object_assignment));
+}


### PR DESCRIPTION
This sample app prints sizeof() of various structures and types used
by Zephyr kernel and libs, and thus offers a convinient way to assess
Zephyr's memory efficiency and usage.

Signed-off-by: Paul Sokolovsky <paul.sokolovsky@linaro.org>