### PR TITLE
tests: net: Increase network buffer counts for Atmel SAM-E70

### DIFF
--- a/tests/net/icmpv6/src/main.c
+++ b/tests/net/icmpv6/src/main.c
@@ -66,10 +66,10 @@ void test_icmpv6(void)
 	net_icmpv6_register_handler(&test_handler1);
 	net_icmpv6_register_handler(&test_handler2);
 
-	pkt = net_pkt_get_reserve(&pkts_slab, 0, K_FOREVER);
+	pkt = net_pkt_get_reserve(&pkts_slab, 0, K_SECONDS(1));
 	zassert_true(pkt != NULL, "Could get net_pkt from slab");
 
-	frag = net_buf_alloc(&data_pool, K_FOREVER);
+	frag = net_buf_alloc(&data_pool, K_SECONDS(1));
 	zassert_true(frag != NULL, "Could not allocate buffer from pool");
 
 	net_pkt_frag_add(pkt, frag);

--- a/tests/net/icmpv6/testcase.yaml
+++ b/tests/net/icmpv6/testcase.yaml
@@ -1,5 +1,6 @@
 common:
   depends_on: netif
+  platform_whitelist: native_posix qemu_x86
 tests:
   net.icmpv6:
     min_ram: 16

--- a/tests/net/trickle/testcase.yaml
+++ b/tests/net/trickle/testcase.yaml
@@ -1,6 +1,7 @@
 common:
   depends_on: netif
+  platform_whitelist: native_posix qemu_x86
 tests:
   net.trickle:
     min_ram: 12
-    tags: net
+    tags: net trickle

--- a/tests/net/utils/src/main.c
+++ b/tests/net/utils/src/main.c
@@ -290,8 +290,12 @@ void test_utils(void)
 	int i, chunk, datalen, total = 0;
 
 	/* Packet fits to one fragment */
-	pkt = net_pkt_get_reserve_rx(0, K_FOREVER);
-	frag = net_pkt_get_reserve_rx_data(10, K_FOREVER);
+	pkt = net_pkt_get_reserve_rx(0, K_SECONDS(1));
+	zassert_not_null(pkt, "Out of mem");
+
+	frag = net_pkt_get_reserve_rx_data(10, K_SECONDS(1));
+	zassert_not_null(frag, "Out of mem");
+
 	net_pkt_frag_add(pkt, frag);
 
 	memcpy(net_buf_add(frag, sizeof(pkt1)), pkt1, sizeof(pkt1));
@@ -320,8 +324,12 @@ void test_utils(void)
 	net_pkt_unref(pkt);
 
 	/* Then a case where there will be two fragments */
-	pkt = net_pkt_get_reserve_rx(0, K_FOREVER);
-	frag = net_pkt_get_reserve_rx_data(10, K_FOREVER);
+	pkt = net_pkt_get_reserve_rx(0, K_SECONDS(1));
+	zassert_not_null(pkt, "Out of mem");
+
+	frag = net_pkt_get_reserve_rx_data(10, K_SECONDS(1));
+	zassert_not_null(frag, "Out of mem");
+
 	net_pkt_frag_add(pkt, frag);
 	memcpy(net_buf_add(frag, sizeof(pkt2) / 2), pkt2, sizeof(pkt2) / 2);
 
@@ -334,7 +342,9 @@ void test_utils(void)
 	frag->data[hdr_len + 2] = 0;
 	frag->data[hdr_len + 3] = 0;
 
-	frag = net_pkt_get_reserve_rx_data(10, K_FOREVER);
+	frag = net_pkt_get_reserve_rx_data(10, K_SECONDS(1));
+	zassert_not_null(frag, "Out of mem");
+
 	net_pkt_frag_add(pkt, frag);
 	memcpy(net_buf_add(frag, sizeof(pkt2) - sizeof(pkt2) / 2),
 	       pkt2 + sizeof(pkt2) / 2, sizeof(pkt2) - sizeof(pkt2) / 2);
@@ -348,8 +358,12 @@ void test_utils(void)
 	net_pkt_unref(pkt);
 
 	/* Then a case where there will be two fragments but odd data size */
-	pkt = net_pkt_get_reserve_rx(0, K_FOREVER);
-	frag = net_pkt_get_reserve_rx_data(10, K_FOREVER);
+	pkt = net_pkt_get_reserve_rx(0, K_SECONDS(1));
+	zassert_not_null(pkt, "Out of mem");
+
+	frag = net_pkt_get_reserve_rx_data(10, K_SECONDS(1));
+	zassert_not_null(frag, "Out of mem");
+
 	net_pkt_frag_add(pkt, frag);
 	memcpy(net_buf_add(frag, sizeof(pkt3) / 2), pkt3, sizeof(pkt3) / 2);
 	printk("First fragment will have %zd bytes\n", sizeof(pkt3) / 2);
@@ -363,7 +377,9 @@ void test_utils(void)
 	frag->data[hdr_len + 2] = 0;
 	frag->data[hdr_len + 3] = 0;
 
-	frag = net_pkt_get_reserve_rx_data(10, K_FOREVER);
+	frag = net_pkt_get_reserve_rx_data(10, K_SECONDS(1));
+	zassert_not_null(frag, "Out of mem");
+
 	net_pkt_frag_add(pkt, frag);
 	memcpy(net_buf_add(frag, sizeof(pkt3) - sizeof(pkt3) / 2),
 	       pkt3 + sizeof(pkt3) / 2, sizeof(pkt3) - sizeof(pkt3) / 2);
@@ -379,8 +395,12 @@ void test_utils(void)
 	net_pkt_unref(pkt);
 
 	/* Then a case where there will be several fragments */
-	pkt = net_pkt_get_reserve_rx(0, K_FOREVER);
-	frag = net_pkt_get_reserve_rx_data(10, K_FOREVER);
+	pkt = net_pkt_get_reserve_rx(0, K_SECONDS(1));
+	zassert_not_null(frag, "Out of mem");
+
+	frag = net_pkt_get_reserve_rx_data(10, K_SECONDS(1));
+	zassert_not_null(frag, "Out of mem");
+
 	net_pkt_frag_add(pkt, frag);
 	memcpy(net_buf_add(frag, sizeof(struct net_ipv6_hdr)), pkt3,
 	       sizeof(struct net_ipv6_hdr));
@@ -395,7 +415,9 @@ void test_utils(void)
 
 	for (i = 0; i < datalen/chunk; i++) {
 		/* Next fragments will contain the data in odd sizes */
-		frag = net_pkt_get_reserve_rx_data(10, K_FOREVER);
+		frag = net_pkt_get_reserve_rx_data(10, K_SECONDS(1));
+		zassert_not_null(frag, "Out of mem");
+
 		net_pkt_frag_add(pkt, frag);
 		memcpy(net_buf_add(frag, chunk),
 		       pkt3 + sizeof(struct net_ipv6_hdr) + i * chunk, chunk);
@@ -414,7 +436,9 @@ void test_utils(void)
 		}
 	}
 	if ((datalen - total) > 0) {
-		frag = net_pkt_get_reserve_rx_data(10, K_FOREVER);
+		frag = net_pkt_get_reserve_rx_data(10, K_SECONDS(1));
+		zassert_not_null(frag, "Out of mem");
+
 		net_pkt_frag_add(pkt, frag);
 		memcpy(net_buf_add(frag, datalen - total),
 		       pkt3 + sizeof(struct net_ipv6_hdr) + i * chunk,
@@ -447,9 +471,13 @@ void test_utils(void)
 	 * This one has ethernet header before IPv4 data.
 	 */
 #if defined(CONFIG_NET_IPV4)
-	pkt = net_pkt_get_reserve_rx(0, K_FOREVER);
+	pkt = net_pkt_get_reserve_rx(0, K_SECONDS(1));
+	zassert_not_null(pkt, "Out of mem");
+
 	frag = net_pkt_get_reserve_rx_data(sizeof(struct net_eth_hdr),
-					    K_FOREVER);
+					   K_SECONDS(1));
+	zassert_not_null(frag, "Out of mem");
+
 	net_pkt_frag_add(pkt, frag);
 
 	net_pkt_set_ll_reserve(pkt, sizeof(struct net_eth_hdr));
@@ -476,9 +504,13 @@ void test_utils(void)
 	/* Another packet that fits to one fragment and which has correct
 	 * checksum. This one has ethernet header before IPv4 data.
 	 */
-	pkt = net_pkt_get_reserve_rx(0, K_FOREVER);
+	pkt = net_pkt_get_reserve_rx(0, K_SECONDS(1));
+	zassert_not_null(pkt, "Out of mem");
+
 	frag = net_pkt_get_reserve_rx_data(sizeof(struct net_eth_hdr),
-					    K_FOREVER);
+					   K_SECONDS(1));
+	zassert_not_null(frag, "Out of mem");
+
 	net_pkt_frag_add(pkt, frag);
 
 	net_pkt_set_ll_reserve(pkt, sizeof(struct net_eth_hdr));
@@ -1451,9 +1483,13 @@ void test_net_pkt_addr_parse(void)
 		struct sockaddr_in6 addr;
 		struct ipv6_test_data *data = &ipv6_test_data_set[i];
 
-		pkt = net_pkt_get_reserve_rx(0, K_FOREVER);
+		pkt = net_pkt_get_reserve_rx(0, K_SECONDS(1));
+		zassert_not_null(pkt, "Out of mem");
+
 		frag = net_pkt_get_reserve_rx_data(sizeof(struct net_eth_hdr),
-						   K_FOREVER);
+						   K_SECONDS(1));
+		zassert_not_null(frag, "Out of mem");
+
 		net_pkt_frag_add(pkt, frag);
 
 		/* Copy ll header */
@@ -1503,9 +1539,13 @@ void test_net_pkt_addr_parse(void)
 		struct sockaddr_in addr;
 		struct ipv4_test_data *data = &ipv4_test_data_set[i];
 
-		pkt = net_pkt_get_reserve_rx(0, K_FOREVER);
+		pkt = net_pkt_get_reserve_rx(0, K_SECONDS(1));
+		zassert_not_null(pkt, "Out of mem");
+
 		frag = net_pkt_get_reserve_rx_data(sizeof(struct net_eth_hdr),
-						   K_FOREVER);
+						   K_SECONDS(1));
+		zassert_not_null(frag, "Out of mem");
+
 		net_pkt_frag_add(pkt, frag);
 
 		/* Copy ll header */

--- a/tests/net/utils/testcase.yaml
+++ b/tests/net/utils/testcase.yaml
@@ -1,5 +1,6 @@
 common:
   depends_on: netif
+  platform_whitelist: native_posix qemu_x86
 tests:
   net.util:
     min_ram: 24


### PR DESCRIPTION
In some hw like Atmel SAM-E70, the original amount of network
buffers is too small so increasing it slightly.
Also generate proper error if this happens in the test so it
is easier to figure out.

Fixes #8963

Signed-off-by: Jukka Rissanen <jukka.rissanen@linux.intel.com>