### PR TITLE
doc: windows: Clarify Python paths

### DIFF
--- a/doc/README.rst
+++ b/doc/README.rst
@@ -53,17 +53,17 @@ Our documentation processing has been tested to run with:
 * docutils version 0.14
 * sphinx_rtd_theme version 0.4.0
 
-Begin by cloning a copy of the git repository for the Zephyr project and
-setting up your development environment as described in :ref:`getting_started`
-or specifically for Ubuntu in :ref:`installation_linux`.
+In order to install the documentation tools, clone a copy of the git repository
+for the Zephyr project and set up your development environment as described in
+:ref:`getting_started`. This will ensure all the required tools are installed
+on your system.
 
-Other than ``doxygen``, the documentation tools should be installed
-using ``pip3`` (as documented in the development environment set up
-instructions).
-
-The documentation generation tools are included in the set of tools
-expected for the Zephyr build environment and so are included in
-``requirements.txt``
+.. note::
+   On Windows, the Sphinx executable ``sphinx-build.exe`` is placed in
+   the ``Scripts`` folder of your Python installation path.
+   Dependending on how you have installed Python, you may need to
+   add this folder to your ``PATH`` environment variable. Follow
+   the instructions in `Windows Python Path`_ to add those if needed.
 
 Documentation presentation theme
 ********************************
@@ -145,3 +145,4 @@ found there.
 
 .. _reStructuredText: http://sphinx-doc.org/rest.html
 .. _Sphinx: http://sphinx-doc.org/
+.. _Windows Python Path: https://docs.python.org/3/using/windows.html#finding-the-python-executable

--- a/doc/getting_started/installation_win.rst
+++ b/doc/getting_started/installation_win.rst
@@ -85,12 +85,17 @@ packages from their respective websites.
 #. Install the required Python modules::
 
       cd %userprofile%\zephyr
-      pip3 install --user -r scripts/requirements.txt
+      pip3 install -r scripts/requirements.txt
+
+.. note::
+      Although pip can install packages in the user's directory by means
+      of the ``--user`` flag, this makes it harder for the Command Prompt
+      to find the executables in Python modules installed by ``pip3``.
 
 #. If you require pyocd, an open source python2 library for programming and
    debugging ARM Cortex-M microcontrollers, use this command::
 
-      pip2 install --user -r scripts/py2-requirements.txt
+      pip2 install -r scripts/py2-requirements.txt
 
 #. The build system should now be ready to work with any toolchain installed in
    your system. In the next step you'll find instructions for installing


### PR DESCRIPTION
In order to make things simpler for the user, remove the
`--user` flag when invoking pip and pip3 so that executables are placed
in the <Python>\Scripts folder, which is added to the PATH
automatically.
Additionally clarify and clean up the documentation tools section.

Signed-off-by: Carles Cufi <carles.cufi@nordicsemi.no>