### PR TITLE
net: ipv6: Fix NA debug print

### DIFF
--- a/subsys/net/ip/ipv6.c
+++ b/subsys/net/ip/ipv6.c
@@ -1606,10 +1606,11 @@ send_na:
 			       tgt,
 			       flags);
 	if (!ret) {
-		NET_DBG("Cannot send NA (%d)", ret);
 		net_pkt_unref(pkt);
 		return NET_OK;
 	}
+
+	NET_DBG("Cannot send NA (%d)", ret);
 
 	return NET_DROP;
 


### PR DESCRIPTION
If Neighbor Advertisement cannot be sent, then print info about it.
Earlier we printed info when NA succeeded.

Signed-off-by: Jukka Rissanen <jukka.rissanen@linux.intel.com>