### PR TITLE
samples: net: Explicitly ignore socket close return value

### DIFF
--- a/samples/net/sockets/echo_client/src/tcp.c
+++ b/samples/net/sockets/echo_client/src/tcp.c
@@ -218,13 +218,13 @@ void stop_tcp(void)
 {
 	if (IS_ENABLED(CONFIG_NET_IPV6)) {
 		if (conf.ipv6.tcp.sock > 0) {
-			close(conf.ipv6.tcp.sock);
+			(void)close(conf.ipv6.tcp.sock);
 		}
 	}
 
 	if (IS_ENABLED(CONFIG_NET_IPV4)) {
 		if (conf.ipv4.tcp.sock > 0) {
-			close(conf.ipv4.tcp.sock);
+			(void)close(conf.ipv4.tcp.sock);
 		}
 	}
 }

--- a/samples/net/sockets/echo_client/src/udp.c
+++ b/samples/net/sockets/echo_client/src/udp.c
@@ -222,13 +222,13 @@ void stop_udp(void)
 {
 	if (IS_ENABLED(CONFIG_NET_IPV6)) {
 		if (conf.ipv6.udp.sock > 0) {
-			close(conf.ipv6.udp.sock);
+			(void)close(conf.ipv6.udp.sock);
 		}
 	}
 
 	if (IS_ENABLED(CONFIG_NET_IPV4)) {
 		if (conf.ipv4.udp.sock > 0) {
-			close(conf.ipv4.udp.sock);
+			(void)close(conf.ipv4.udp.sock);
 		}
 	}
 }

--- a/samples/net/sockets/echo_server/src/tcp.c
+++ b/samples/net/sockets/echo_server/src/tcp.c
@@ -218,14 +218,14 @@ void stop_tcp(void)
 	if (IS_ENABLED(CONFIG_NET_IPV6)) {
 		k_thread_abort(tcp6_thread_id);
 		if (conf.ipv6.tcp.sock > 0) {
-			close(conf.ipv6.tcp.sock);
+			(void)close(conf.ipv6.tcp.sock);
 		}
 	}
 
 	if (IS_ENABLED(CONFIG_NET_IPV4)) {
 		k_thread_abort(tcp4_thread_id);
 		if (conf.ipv4.tcp.sock > 0) {
-			close(conf.ipv4.tcp.sock);
+			(void)close(conf.ipv4.tcp.sock);
 		}
 	}
 }

--- a/samples/net/sockets/echo_server/src/udp.c
+++ b/samples/net/sockets/echo_server/src/udp.c
@@ -165,14 +165,14 @@ void stop_udp(void)
 	if (IS_ENABLED(CONFIG_NET_IPV6)) {
 		k_thread_abort(udp6_thread_id);
 		if (conf.ipv6.udp.sock > 0) {
-			close(conf.ipv6.udp.sock);
+			(void)close(conf.ipv6.udp.sock);
 		}
 	}
 
 	if (IS_ENABLED(CONFIG_NET_IPV4)) {
 		k_thread_abort(udp4_thread_id);
 		if (conf.ipv4.udp.sock > 0) {
-			close(conf.ipv4.udp.sock);
+			(void)close(conf.ipv4.udp.sock);
 		}
 	}
 }


### PR DESCRIPTION
Fixes #8994

Coverity ID :187072

Explicitly ignore return value of socket close.

Signed-off-by: Robert Lubos <robert.lubos@nordicsemi.no>