### PR TITLE
coverage: exclude k_call_stacks_analyze

### DIFF
--- a/kernel/init.c
+++ b/kernel/init.c
@@ -128,6 +128,7 @@ K_THREAD_STACK_DEFINE(_interrupt_stack3, CONFIG_ISR_STACK_SIZE);
 
 extern void idle(void *unused1, void *unused2, void *unused3);
 
+/* LCOV_EXCL_START */
 #if defined(CONFIG_INIT_STACKS) && defined(CONFIG_PRINTK)
 extern K_THREAD_STACK_DEFINE(sys_work_q_stack,
 			     CONFIG_SYSTEM_WORKQUEUE_STACK_SIZE);
@@ -144,6 +145,7 @@ void k_call_stacks_analyze(void)
 #else
 void k_call_stacks_analyze(void) { }
 #endif
+/* LCOV_EXCL_STOP */
 
 /**
  *


### PR DESCRIPTION
Do not count deprecated functions.

Signed-off-by: Anas Nashif <anas.nashif@intel.com>