### PR TITLE
tests: spinlock: Add description and doxygen groups

### DIFF
--- a/tests/kernel/spinlock/src/main.c
+++ b/tests/kernel/spinlock/src/main.c
@@ -17,6 +17,24 @@ static struct k_spinlock bounce_lock;
 
 volatile int bounce_owner, bounce_done;
 
+/**
+ * @brief Tests for spinlock
+ *
+ * @defgroup kernel_spinlock_tests Spinlock Tests
+ *
+ * @ingroup all_tests
+ *
+ * @{
+ * @}
+ */
+
+/**
+ * @brief Test basic spinlock
+ *
+ * @ingroup kernel_spinlock_tests
+ *
+ * @see k_spin_lock(), k_spin_unlock()
+ */
 void test_spinlock_basic(void)
 {
 	k_spinlock_key_t key;
@@ -83,6 +101,13 @@ void cpu1_fn(int key, void *arg)
 	}
 }
 
+/**
+ * @brief Test spinlock with bounce
+ *
+ * @ingroup kernel_spinlock_tests
+ *
+ * @see _arch_start_cpu()
+ */
 void test_spinlock_bounce(void)
 {
 	int i;


### PR DESCRIPTION
Add test description, RTM links and doxygen groups
for spinlock tests

Signed-off-by: Spoorthi K <spoorthi.k@intel.com>