### PR TITLE
arc: fix update of ERET on exc return

### DIFF
--- a/arch/arc/core/fault_s.S
+++ b/arch/arc/core/fault_s.S
@@ -149,6 +149,9 @@ _exc_return:
 #endif
 
 _exc_return_from_exc:
+	ld_s r0, [sp, ___isf_t_pc_OFFSET]
+	sr r0, [_ARC_V2_ERET]
+
 	_pop_irq_stack_frame
 	ld sp, [saved_value]
 	rtie


### PR DESCRIPTION
This code path for returning from an exception wasn't
updating ERET with ESF->pc, resulting in any updates to
the PC by the fault handler being ignored.

Signed-off-by: Andrew Boie <andrew.p.boie@intel.com>