### PR TITLE
net: getaddrinfo reentrancy fixes

### DIFF
--- a/include/net/socket.h
+++ b/include/net/socket.h
@@ -25,6 +25,7 @@
 #include <zephyr/types.h>
 #include <net/net_ip.h>
 #include <net/dns_resolve.h>
+#include <stdlib.h>
 
 #ifdef __cplusplus
 extern "C" {
@@ -233,7 +234,7 @@ static inline int getaddrinfo(const char *host, const char *service,
 
 static inline void freeaddrinfo(struct zsock_addrinfo *ai)
 {
-	ARG_UNUSED(ai);
+	free(ai);
 }
 
 #define addrinfo zsock_addrinfo

--- a/subsys/net/lib/sockets/getaddrinfo.c
+++ b/subsys/net/lib/sockets/getaddrinfo.c
@@ -25,7 +25,6 @@ struct getaddrinfo_state {
 };
 
 static struct zsock_addrinfo ai_arr[2];
-static struct getaddrinfo_state ai_state;
 
 static void dns_resolve_cb(enum dns_resolve_status status,
 			   struct dns_addrinfo *info, void *user_data)
@@ -88,6 +87,7 @@ int zsock_getaddrinfo(const char *host, const char *service,
 	int st1 = DNS_EAI_ADDRFAMILY, st2 = DNS_EAI_ADDRFAMILY;
 	struct sockaddr *ai_addr;
 	int ret;
+	struct getaddrinfo_state ai_state;
 
 	if (hints) {
 		family = hints->ai_family;


### PR DESCRIPTION
These changes should make getaddrinfo reentrant since all the globals it was using have been removed.

Currently depends on newlib since minimal libc doesn't have a malloc() yet, but all the current network tests enable newlib anyway AFAICT.

getaddrinfo split into two functions with the memory allocation taking place at the outside one; the system call will be implemented at the site of the _internal function.