### PR TITLE
SoC: STM32F4: enable DMA options for soc

### DIFF
--- a/soc/arm/st_stm32/stm32f4/Kconfig.defconfig.series
+++ b/soc/arm/st_stm32/stm32f4/Kconfig.defconfig.series
@@ -32,4 +32,11 @@ config I2C_STM32_V1
 
 endif # I2C_STM32
 
+if DMA
+
+config DMA_STM32F4X
+	def_bool y
+
+endif # DMA
+
 endif # SOC_SERIES_STM32F4X


### PR DESCRIPTION
Enable 'DMA_STM32F4X' when 'DMA' is enabled.

Signed-off-by: Jun Li <jun.r.li@intel.com>