### PR TITLE
DMA: allow to use arbitrary user data in its callback

### DIFF
--- a/drivers/dma/dma_cavs.c
+++ b/drivers/dma/dma_cavs.c
@@ -97,7 +97,7 @@ static void dw_dma_isr(void *arg)
 			 * freed in the user callback function once
 			 * all the blocks are transferred.
 			 */
-			chan_data->dma_blkcallback(dev, channel, 0);
+			chan_data->dma_blkcallback(chan_data->blkcallback_arg, channel, 0);
 		}
 	}
 
@@ -108,7 +108,7 @@ static void dw_dma_isr(void *arg)
 		k_free(chan_data->lli);
 		chan_data->lli = NULL;
 		if (chan_data->dma_tfrcallback) {
-			chan_data->dma_tfrcallback(dev, channel, 0);
+			chan_data->dma_tfrcallback(chan_data->tfrcallback_arg, channel, 0);
 		}
 	}
 }
@@ -262,8 +262,10 @@ static int dw_dma_config(struct device *dev, u32_t channel,
 	 */
 	if (cfg->complete_callback_en) {
 		chan_data->dma_blkcallback = cfg->dma_callback;
+		chan_data->blkcallback_arg = cfg->callback_arg;
 	} else {
 		chan_data->dma_tfrcallback = cfg->dma_callback;
+		chan_data->tfrcallback_arg = cfg->callback_arg;
 	}
 
 	return 0;

--- a/drivers/dma/dma_cavs.h
+++ b/drivers/dma/dma_cavs.h
@@ -45,9 +45,11 @@ struct dma_chan_data {
 	struct dw_lli2 *lli;
 	u32_t cfg_lo;
 	u32_t cfg_hi;
-	void (*dma_blkcallback)(struct device *dev, u32_t channel,
+	void *blkcallback_arg;
+	void (*dma_blkcallback)(void *arg, u32_t channel,
 		int error_code);
-	void (*dma_tfrcallback)(struct device *dev, u32_t channel,
+	void *tfrcallback_arg;
+	void (*dma_tfrcallback)(void *arg, u32_t channel,
 		int error_code);
 };
 

--- a/drivers/dma/dma_nios2_msgdma.c
+++ b/drivers/dma/dma_nios2_msgdma.c
@@ -25,7 +25,8 @@ struct nios2_msgdma_dev_cfg {
 	alt_msgdma_standard_descriptor desc;
 	u32_t direction;
 	struct k_sem sem_lock;
-	void (*dma_callback)(struct device *dev, u32_t id,
+	void *callback_arg;
+	void (*dma_callback)(void *arg, u32_t id,
 			     int error_code);
 };
 
@@ -61,7 +62,7 @@ static void nios2_msgdma_callback(void *context)
 
 	LOG_DBG("msgdma csr status Reg: 0x%x", status);
 
-	dev_cfg->dma_callback((struct device *)context, 0, err_code);
+	dev_cfg->dma_callback(dev_cfg->callback_arg, 0, err_code);
 }
 
 static int nios2_msgdma_config(struct device *dev, u32_t channel,
@@ -103,6 +104,7 @@ static int nios2_msgdma_config(struct device *dev, u32_t channel,
 
 	k_sem_take(&dev_cfg->sem_lock, K_FOREVER);
 	dev_cfg->dma_callback = cfg->dma_callback;
+	dev_cfg->callback_arg = cfg->callback_arg;
 	dev_cfg->direction = cfg->channel_direction;
 	dma_block = cfg->head_block;
 	control =  ALTERA_MSGDMA_DESCRIPTOR_CONTROL_TRANSFER_COMPLETE_IRQ_MASK |

--- a/drivers/dma/dma_qmsi.c
+++ b/drivers/dma/dma_qmsi.c
@@ -41,7 +41,7 @@ struct dma_qmsi_driver_data {
 	u32_t device_power_state;
 	qm_dma_context_t saved_ctx;
 #endif
-	void (*dma_user_callback[QM_DMA_CHANNEL_NUM])(struct device *dev,
+	void (*dma_user_callback[QM_DMA_CHANNEL_NUM])(void *arg,
 						      u32_t channel_id,
 						      int error_code);
 };
@@ -60,7 +60,8 @@ static void dma_drv_callback(void *callback_context, u32_t len,
 	channel = context->index;
 	data = context->dev->driver_data;
 
-	data->dma_user_callback[channel](context->dev, channel, error_code);
+	data->dma_user_callback[channel](data->callback_data[channel],
+			channel, error_code);
 }
 
 static int width_index(u32_t num_bytes, u32_t *index)
@@ -171,6 +172,7 @@ static int dma_qmsi_chan_config(struct device *dev, u32_t channel,
 	/* TODO: add support for using other DMA transfer types. */
 	qmsi_cfg.transfer_type = QM_DMA_TYPE_SINGLE;
 
+	data->callback_data[channel] = config->callback_arg;
 	data->dma_user_callback[channel] = config->dma_callback;
 
 	dma_context[channel].index = channel;

--- a/drivers/dma/dma_sam_xdmac.c
+++ b/drivers/dma/dma_sam_xdmac.c
@@ -26,6 +26,7 @@ LOG_MODULE_REGISTER(dma_sam_xdmac)
 
 /* DMA channel configuration */
 struct sam_xdmac_channel_cfg {
+	void *callback_arg;
 	dma_callback callback;
 };
 
@@ -73,7 +74,8 @@ static void sam_xdmac_isr(void *arg)
 
 		/* Execute callback */
 		if (channel_cfg->callback) {
-			channel_cfg->callback(dev, channel, err);
+			channel_cfg->callback(channel_cfg->callback_arg,
+					channel, err);
 		}
 	}
 }
@@ -254,6 +256,7 @@ static int sam_xdmac_config(struct device *dev, u32_t channel,
 	}
 
 	dev_data->dma_channels[channel].callback = cfg->dma_callback;
+	dev_data->dma_channels[channel].callback_arg = cfg->callback_arg;
 
 	(void)memset(&transfer_cfg, 0, sizeof(transfer_cfg));
 	transfer_cfg.sa = cfg->head_block->source_address;

--- a/drivers/dma/dma_sam_xdmac.h
+++ b/drivers/dma/dma_sam_xdmac.h
@@ -18,7 +18,7 @@ extern "C" {
 #endif
 
 /** DMA transfer callback */
-typedef void (*dma_callback)(struct device *dev, u32_t channel, int error_code);
+typedef void (*dma_callback)(void *arg, u32_t channel, int error_code);
 
 /* XDMA_MBR_UBC */
 #define XDMA_UBC_NDE (0x1u << 24)

--- a/include/dma.h
+++ b/include/dma.h
@@ -149,7 +149,7 @@ struct dma_config {
 	u32_t  dest_burst_length :   16;
 	u32_t block_count;
 	struct dma_block_config *head_block;
-	void * callback_arg;
+	void *callback_arg;
 	void (*dma_callback)(void *callback_arg, u32_t channel,
 			     int error_code);
 };

--- a/include/dma.h
+++ b/include/dma.h
@@ -126,6 +126,8 @@ struct dma_block_config {
  *     block_count  is the number of blocks used for block chaining, this
  *     depends on availability of the DMA controller.
  *
+ *     callback_arg  private argument from DMA client.
+ *
  * dma_callback is the callback function pointer. If enabled, callback function
  *              will be invoked at transfer completion or when error happens
  *              (error_code: zero-transfer success, non zero-error happens).
@@ -147,7 +149,8 @@ struct dma_config {
 	u32_t  dest_burst_length :   16;
 	u32_t block_count;
 	struct dma_block_config *head_block;
-	void (*dma_callback)(struct device *dev, u32_t channel,
+	void * callback_arg;
+	void (*dma_callback)(void *callback_arg, u32_t channel,
 			     int error_code);
 };
 

--- a/tests/boards/altera_max10/msgdma/src/dma.c
+++ b/tests/boards/altera_max10/msgdma/src/dma.c
@@ -26,7 +26,7 @@ static char rx_data[DMA_BUFF_SIZE];
 static struct dma_config dma_cfg = {0};
 static struct dma_block_config dma_block_cfg = {0};
 
-static void dma_user_callback(struct device *dev, u32_t id, int error_code)
+static void dma_user_callback(void *arg, u32_t id, int error_code)
 {
 	if (error_code == 0) {
 		TC_PRINT("DMA completed successfully\n");

--- a/tests/boards/intel_s1000_crb/src/dma_test.c
+++ b/tests/boards/intel_s1000_crb/src/dma_test.c
@@ -67,7 +67,7 @@ static char rx_data2[RX_BUFF_SIZE] = { 0 };
 static char rx_data3[RX_BUFF_SIZE] = { 0 };
 static char rx_data4[RX_BUFF_SIZE] = { 0 };
 
-static void test_done(struct device *dev, u32_t id, int error_code)
+static void test_done(void *arg, u32_t id, int error_code)
 {
 	if (error_code == 0) {
 		printk("DMA transfer done\n");

--- a/tests/drivers/dma/chan_blen_transfer/src/test_dma.c
+++ b/tests/drivers/dma/chan_blen_transfer/src/test_dma.c
@@ -29,7 +29,7 @@
 static const char tx_data[] = "It is harder to be kind than to be wise";
 static char rx_data[RX_BUFF_SIZE] = { 0 };
 
-static void test_done(struct device *dev, u32_t id, int error_code)
+static void test_done(void *arg, u32_t id, int error_code)
 {
 	if (error_code == 0) {
 		TC_PRINT("DMA transfer done\n");

--- a/tests/drivers/dma/loop_transfer/src/dma.c
+++ b/tests/drivers/dma/loop_transfer/src/dma.c
@@ -50,8 +50,10 @@ static void test_error(void)
 	printk("DMA could not proceed, an error occurred\n");
 }
 
-static void dma_user_callback(struct device *dev, u32_t id, int error_code)
+static void dma_user_callback(void *arg, u32_t id, int error_code)
 {
+	struct device *dev = (struct device *)arg;
+
 	if (error_code == 0) {
 		test_transfer(dev, id);
 	} else {
@@ -79,6 +81,7 @@ void main(void)
 	dma_cfg.dest_data_size = 1;
 	dma_cfg.source_burst_length = 1;
 	dma_cfg.dest_burst_length = 1;
+	dma_cfg.callback_arg = dma;
 	dma_cfg.dma_callback = dma_user_callback;
 	dma_cfg.block_count = 1;
 	dma_cfg.head_block = &dma_block_cfg;


### PR DESCRIPTION
In the current 'dma_callback' function, the first argument  `struct device * dev` is assumed to be the pointer to the DMA device driver. However, a DMA client could need to access its private data as well in the callback function. So, it is better to make the first argument as a generic `void *arg` so that the client can set whatever data it likes to use in the callback function. 

The PR is trying to address the request of the issue: https://github.com/zephyrproject-rtos/zephyr/issues/8928