### PR TITLE
dts: arc: fixes the warning msgs during cmake

### DIFF
--- a/boards/arc/nsim_em/nsim_em.dts
+++ b/boards/arc/nsim_em/nsim_em.dts
@@ -27,6 +27,7 @@
 			compatible = "snps,arcv2-intc";
 			interrupt-controller;
 			#interrupt-cells = <2>;
+			reg = <0>;
 		};
 	};
 

--- a/dts/arc/emsk.dtsi
+++ b/dts/arc/emsk.dtsi
@@ -24,6 +24,7 @@
 			compatible = "snps,arcv2-intc";
 			interrupt-controller;
 			#interrupt-cells = <2>;
+			reg = <0>;
 		};
 	};
 

--- a/dts/bindings/interrupt-controller/snps,arcv2-intc.yaml
+++ b/dts/bindings/interrupt-controller/snps,arcv2-intc.yaml
@@ -5,6 +5,7 @@
 #
 ---
 title: ARCV2 Interrupt Controller
+id: snps,arcv2-intc
 version: 0.1
 
 description: >


### PR DESCRIPTION
fixes the warning msgs during cmake which are
caused by the missing info in dts files

Signed-off-by: Wayne Ren <wei.ren@synopsys.com>