### PR TITLE
kernel: Deprecate sys_clock_us_per_tick variable.

### DIFF
--- a/drivers/timer/hpet.c
+++ b/drivers/timer/hpet.c
@@ -580,11 +580,10 @@ int _sys_clock_driver_init(struct device *device)
  */
 
 	/*
-	 * Convert the 'sys_clock_us_per_tick' value
-	 * from microseconds to femptoseconds
+	 * Get tick time (in femptoseconds).
 	 */
 
-	tickFempto = (u64_t)sys_clock_us_per_tick * 1000000000;
+	tickFempto = 1000000000000000ull / sys_clock_ticks_per_sec;
 
 	/*
 	 * This driver shall read the COUNTER_CLK_PERIOD value from the general

--- a/drivers/timer/native_posix_timer.c
+++ b/drivers/timer/native_posix_timer.c
@@ -103,7 +103,7 @@ int _sys_clock_driver_init(struct device *device)
 {
 	ARG_UNUSED(device);
 
-	tick_period = sys_clock_us_per_tick;
+	tick_period = 1000000ul / sys_clock_ticks_per_sec;
 
 	hwtimer_enable(tick_period);
 

--- a/include/sys_clock.h
+++ b/include/sys_clock.h
@@ -21,6 +21,7 @@ extern "C" {
 #endif
 
 #ifndef _ASMLANGUAGE
+#include <toolchain.h>
 #include <zephyr/types.h>
 
 #if defined(CONFIG_SYS_CLOCK_EXISTS) && \
@@ -46,8 +47,10 @@ extern int sys_clock_hw_cycles_per_sec;
 /*
  * sys_clock_us_per_tick global variable represents a number
  * of microseconds in one OS timer tick
+ *
+ * Note: This variable is deprecated and will be removed soon!
  */
-extern int sys_clock_us_per_tick;
+__deprecated extern int sys_clock_us_per_tick;
 
 /*
  * sys_clock_hw_cycles_per_tick global variable represents a number
@@ -75,8 +78,7 @@ extern int sys_clock_hw_cycles_per_tick;
 
 /* SYS_CLOCK_HW_CYCLES_TO_NS64 converts CPU clock cycles to nanoseconds */
 #define SYS_CLOCK_HW_CYCLES_TO_NS64(X) \
-	(((u64_t)(X) * sys_clock_us_per_tick * NSEC_PER_USEC) / \
-	 sys_clock_hw_cycles_per_tick)
+	(((u64_t)(X) * NSEC_PER_SEC) / sys_clock_hw_cycles_per_sec)
 
 /*
  * SYS_CLOCK_HW_CYCLES_TO_NS_AVG converts CPU clock cycles to nanoseconds

--- a/samples/net/zperf/src/zperf_internal.h
+++ b/samples/net/zperf/src/zperf_internal.h
@@ -30,8 +30,8 @@
 
 #define HW_CYCLES_TO_USEC(__hw_cycle__) \
 	( \
-		((u64_t)(__hw_cycle__) * (u64_t)sys_clock_us_per_tick) / \
-		((u64_t)sys_clock_hw_cycles_per_tick) \
+		((u64_t)(__hw_cycle__) * (u64_t)USEC_PER_SEC) / \
+		((u64_t)sys_clock_hw_cycles_per_sec) \
 	)
 
 #define HW_CYCLES_TO_SEC(__hw_cycle__) \
@@ -42,8 +42,8 @@
 
 #define USEC_TO_HW_CYCLES(__usec__) \
 	( \
-		((u64_t)(__usec__) * (u64_t)sys_clock_hw_cycles_per_tick) / \
-		((u64_t)sys_clock_us_per_tick) \
+		((u64_t)(__usec__) * (u64_t)sys_clock_hw_cycles_per_sec) / \
+		((u64_t)USEC_PER_SEC) \
 	)
 
 #define SEC_TO_HW_CYCLES(__sec__) \

--- a/tests/kernel/context/src/main.c
+++ b/tests/kernel/context/src/main.c
@@ -245,7 +245,7 @@ static void _test_kernel_cpu_idle(int atomic)
 			k_cpu_idle();
 		}
 		/* calculating milliseconds per tick*/
-		tms += sys_clock_us_per_tick / USEC_PER_MSEC;
+		tms += __ticks_to_ms(1);
 		tms2 = k_uptime_get_32();
 		zassert_false(tms2 < tms, "Bad ms per tick value computed,"
 			      "got %d which is less than %d\n",

--- a/tests/kernel/tickless/tickless_concept/src/main.c
+++ b/tests/kernel/tickless/tickless_concept/src/main.c
@@ -16,7 +16,7 @@ static struct k_thread tdata[NUM_THREAD];
 #define CONFIG_TICKLESS_IDLE_THRESH 20
 #endif
 /*millisecond per tick*/
-#define MSEC_PER_TICK (sys_clock_us_per_tick / USEC_PER_MSEC)
+#define MSEC_PER_TICK (__ticks_to_ms(1))
 /*sleep duration tickless*/
 #define SLEEP_TICKLESS (CONFIG_TICKLESS_IDLE_THRESH * MSEC_PER_TICK)
 /*sleep duration with tick*/

--- a/tests/kernel/timer/timer_monotonic/src/main.c
+++ b/tests/kernel/timer/timer_monotonic/src/main.c
@@ -54,7 +54,6 @@ void test_timer(void)
 
 	errors = 0;
 
-	TC_PRINT("sys_clock_us_per_tick = %d\n", sys_clock_us_per_tick);
 	TC_PRINT("sys_clock_hw_cycles_per_tick = %d\n",
 		 sys_clock_hw_cycles_per_tick);
 	TC_PRINT("sys_clock_hw_cycles_per_sec = %d\n",


### PR DESCRIPTION
On some architectures tick time cannot be expressed as integer
number of microseconds, introducing error in calculations using
sys_clock_us_per_tick variable.

This commit deprecates the sys_clock_us_per_tick variable and
replaces its usage by more precise calculations based on
sys_clock_hw_cycles_per_sec and sys_clock_ticks_per_sec.
