### PR TITLE
Logger deps cleanup

### DIFF
--- a/doc/subsystems/logging/logger.rst
+++ b/doc/subsystems/logging/logger.rst
@@ -49,15 +49,14 @@ For each level following set of macros are available:
 There are two configuration categories: configurations per module and global
 configuration. When logging is enabled globally, it works for modules. However,
 modules can disable logging locally. Every module can specify its own logging
-level. The module must define the :c:macro:`LOG_LEVEL` macro before including
-the :file:`include/logging/log.h` header file to do so. Unless a global
-override is set, the module logging level will be honored. The global override
-can only increase the logging level. It cannot be used to lower module logging
-levels that were previously set higher. It is also possible to globally limit
-logs by providing maximal severity level present in the system, where maximal
-means lowest severity (e.g. if maximal level in the system is set to info, it
-means that errors, warnings and info levels are present but debug messages are
-excluded).
+level. The module must define the :c:macro:`LOG_LEVEL` macro before using the
+API. Unless a global override is set, the module logging level will be honored.
+The global override can only increase the logging level. It cannot be used to
+lower module logging levels that were previously set higher. It is also possible
+to globally limit logs by providing maximal severity level present in the
+system, where maximal means lowest severity (e.g. if maximal level in the system
+is set to info, it means that errors, warnings and info levels are present but
+debug messages are excluded).
 
 Each module which is using the logger must specify its unique name and
 register itself to the logger. If module consists of more than one file,

--- a/include/logging/log.h
+++ b/include/logging/log.h
@@ -21,13 +21,6 @@ extern "C" {
  * @{
  */
 
-
-#define LOG_LEVEL_NONE  0
-#define LOG_LEVEL_ERR   1
-#define LOG_LEVEL_WRN   2
-#define LOG_LEVEL_INF   3
-#define LOG_LEVEL_DBG   4
-
 /**
  * @brief Writes an ERROR level message to the log.
  *

--- a/include/logging/log.h
+++ b/include/logging/log.h
@@ -21,6 +21,12 @@ extern "C" {
  * @{
  */
 
+#define LOG_LEVEL_NONE  0
+#define LOG_LEVEL_ERR   1
+#define LOG_LEVEL_WRN   2
+#define LOG_LEVEL_INF   3
+#define LOG_LEVEL_DBG   4
+
 /**
  * @brief Writes an ERROR level message to the log.
  *
@@ -31,7 +37,6 @@ extern "C" {
  * followed by as many values as specifiers.
  */
 #define LOG_ERR(...)    _LOG(LOG_LEVEL_ERR, __VA_ARGS__)
-
 
 /**
  * @brief Writes a WARNING level message to the log.
@@ -242,37 +247,45 @@ extern "C" {
  */
 int log_printk(const char *fmt, va_list ap);
 
-/* Register a module unless explicitly skipped (using LOG_SKIP_MODULE_REGISTER).
- * Skipping may be used in 2 cases:
+
+#define __DYNAMIC_MODULE_REGISTER(_name)\
+	struct log_source_dynamic_data LOG_ITEM_DYNAMIC_DATA(_name)	\
+	__attribute__ ((section("." STRINGIFY(				\
+				     LOG_ITEM_DYNAMIC_DATA(_name))))	\
+				     )					\
+	__attribute__((used))
+
+#define _LOG_RUNTIME_MODULE_REGISTER(_name)				\
+	_LOG_EVAL(							\
+		CONFIG_LOG_RUNTIME_FILTERING,				\
+		(; __DYNAMIC_MODULE_REGISTER(_name)),			\
+		()\
+	)
+
+#define _LOG_MODULE_REGISTER(_name, level)				     \
+	const struct log_source_const_data LOG_ITEM_CONST_DATA(_name)	     \
+	__attribute__ ((section("." STRINGIFY(LOG_ITEM_CONST_DATA(_name))))) \
+	__attribute__((used)) = {					     \
+		.name = STRINGIFY(_name)				     \
+	}								     \
+	_LOG_RUNTIME_MODULE_REGISTER(_name)
+
+/** @brief Macro for registering a module.
+ *
+ * Module registration can be skipped in two cases:
  * - Module consists of more than one file and must be registered only by one
  *   file.
  * - Instance logging is used and there is no need to create module entry.
+ *
+ * @note Module is registered only if LOG_LEVEL for given module is non-zero or
+ *       it is not defined and CONFIG_LOG_DEFAULT_LOG_LEVEL is non-zero.
  */
-
-#if LOG_MODULE_PRESENT
-#if CONFIG_LOG_RUNTIME_FILTERING
-#define LOG_MODULE_REGISTER()						       \
-	_LOG_CONST_ITEM_REGISTER(LOG_MODULE_NAME,			       \
-				 STRINGIFY(LOG_MODULE_NAME),		       \
-				 _LOG_RESOLVED_LEVEL(LOG_LEVEL,                \
-						CONFIG_LOG_DEFAULT_LEVEL));    \
-	struct log_source_dynamic_data LOG_ITEM_DYNAMIC_DATA(LOG_MODULE_NAME)  \
-	__attribute__ ((section("." STRINGIFY(				       \
-				     LOG_ITEM_DYNAMIC_DATA(LOG_MODULE_NAME)))) \
-				     )					       \
-		__attribute__((used))
-#else /*CONFIG_LOG_RUNTIME_FILTERING*/
-
-#define LOG_MODULE_REGISTER()						       \
-	_LOG_CONST_ITEM_REGISTER(LOG_MODULE_NAME,			       \
-				 STRINGIFY(LOG_MODULE_NAME),		       \
-				 _LOG_RESOLVED_LEVEL(LOG_LEVEL,                \
-						CONFIG_LOG_DEFAULT_LEVEL))
-#endif /*CONFIG_LOG_RUNTIME_FILTERING*/
-
-#else /* LOG_MODULE_PRESENT */
-#define LOG_MODULE_REGISTER() /* Empty */
-#endif /* LOG_MODULE_PRESENT */
+#define LOG_MODULE_REGISTER()						\
+	_LOG_EVAL(							\
+		_LOG_LEVEL(),						\
+		(_LOG_MODULE_REGISTER(LOG_MODULE_NAME, _LOG_LEVEL())),	\
+		()/*Empty*/						\
+	)
 
 /**
  * @}

--- a/include/logging/log_core.h
+++ b/include/logging/log_core.h
@@ -14,27 +14,11 @@
 extern "C" {
 #endif
 
-#ifndef CONFIG_LOG_DEFAULT_LEVEL
-#define CONFIG_LOG_DEFAULT_LEVEL LOG_LEVEL_NONE
-#endif
-
-#ifndef CONFIG_LOG_MAX_LEVEL
-#define CONFIG_LOG_MAX_LEVEL LOG_LEVEL_NONE
-#endif
-
+#if !CONFIG_LOG
+#define CONFIG_LOG_DEFAULT_LEVEL 0
 #define CONFIG_LOG_DOMAIN_ID 0
-
-#define LOG_LEVEL_BITS          3
-
-/* Conditions determining if logger is used in a module on any level. */
-#if CONFIG_LOG &&						\
-	((defined(LOG_LEVEL) && LOG_LEVEL) ||			\
-	(!defined(LOG_LEVEL) && CONFIG_LOG_DEFAULT_LEVEL))
-#define LOG_MODULE_PRESENT 1
-#else
-#define LOG_MODULE_PRESENT 0
+#define CONFIG_LOG_MAX_LEVEL 0
 #endif
-
 
 /** @brief Macro for returning local level value if defined or default.
  *
@@ -53,10 +37,46 @@ extern "C" {
 #define _LOG_XXXX4 _LOG_YYYY,
 
 #define __LOG_RESOLVED_LEVEL2(one_or_two_args, _level, _default) \
-	__LOG_RESOLVED_LEVEL3(one_or_two_args _level, _default)
+	__LOG_ARG_2(one_or_two_args _level, _default)
 
-#define __LOG_RESOLVED_LEVEL3(ignore_this, val, ...) val
+#define LOG_DEBRACKET(x) x
 
+#define __LOG_ARG_2(ignore_this, val, ...) val
+#define __LOG_ARG_2_DEBRACKET(ignore_this, val, ...) LOG_DEBRACKET val
+
+/**
+ * @brief Macro for conditional code generation if provided log level allows.
+ *
+ * Macro behaves similarly to standard #if #else #endif clause. The difference is
+ * that it is evaluated when used and not when header file is included.
+ *
+ * @param _eval_level Evaluated level. If level evaluates to one of existing log
+ *		      log level (1-4) then macro evaluates to _iftrue.
+ * @param _iftrue     Code that should be inserted when evaluated to true. Note,
+ *		      that parameter must be provided in brackets.
+ * @param _iffalse    Code that should be inserted when evaluated to false.
+ *		      Note, that parameter must be provided in brackets.
+ */
+#define _LOG_EVAL(_eval_level, _iftrue, _iffalse) \
+	_LOG_EVAL1(_eval_level, _iftrue, _iffalse)
+
+#define _LOG_EVAL1(_eval_level, _iftrue, _iffalse) \
+	_LOG_EVAL2(_LOG_ZZZZ##_eval_level, _iftrue, _iffalse)
+
+#define _LOG_ZZZZ1 _LOG_YYYY,
+#define _LOG_ZZZZ2 _LOG_YYYY,
+#define _LOG_ZZZZ3 _LOG_YYYY,
+#define _LOG_ZZZZ4 _LOG_YYYY,
+
+#define _LOG_EVAL2(one_or_two_args, _iftrue, _iffalse) \
+	__LOG_ARG_2_DEBRACKET(one_or_two_args _iftrue, _iffalse)
+
+/** @brief Macro for getting log level for given module.
+ *
+ * It is evaluated to LOG_LEVEL if defined. Otherwise CONFIG_LOG_DEFAULT_LEVEL
+ * is used.
+ */
+#define _LOG_LEVEL() _LOG_RESOLVED_LEVEL(LOG_LEVEL, CONFIG_LOG_DEFAULT_LEVEL)
 
 /**
  *  @def LOG_CONST_ID_GET
@@ -64,41 +84,45 @@ extern "C" {
  *
  *  @param _addr Address of the element.
  */
+#define LOG_CONST_ID_GET(_addr)						       \
+	_LOG_EVAL(							       \
+	  _LOG_LEVEL(),							       \
+	  (log_const_source_id((const struct log_source_const_data *)_addr)),  \
+	  (0)								       \
+	)
+
 /**
  * @def LOG_CURRENT_MODULE_ID
  * @brief Macro for getting ID of current module.
  */
+#define LOG_CURRENT_MODULE_ID()						\
+	_LOG_EVAL(							\
+	  _LOG_LEVEL(),							\
+	  (log_const_source_id(&LOG_ITEM_CONST_DATA(LOG_MODULE_NAME))),	\
+	  (0)								\
+	)
+
 /**
  * @def LOG_CURRENT_DYNAMIC_DATA_ADDR
  * @brief Macro for getting address of dynamic structure of current module.
  */
-#if LOG_MODULE_PRESENT
-#define LOG_CONST_ID_GET(_addr) \
-	log_const_source_id((const struct log_source_const_data *)_addr)
-
-#define LOG_CURRENT_MODULE_ID()	\
-	log_const_source_id(&LOG_ITEM_CONST_DATA(LOG_MODULE_NAME))
-
-#define LOG_CURRENT_DYNAMIC_DATA_ADDR() \
-	(&LOG_ITEM_DYNAMIC_DATA(LOG_MODULE_NAME))
-#else /* LOG_MODULE_PRESENT */
-#define LOG_CONST_ID_GET(_addr) 0
-
-#define LOG_CURRENT_MODULE_ID() 0
-
-#define LOG_CURRENT_DYNAMIC_DATA_ADDR() ((struct log_source_dynamic_data *)0)
-#endif /* LOG_MODULE_PRESENT */
+#define LOG_CURRENT_DYNAMIC_DATA_ADDR()			\
+	_LOG_EVAL(					\
+	  _LOG_LEVEL(),					\
+	  (&LOG_ITEM_DYNAMIC_DATA(LOG_MODULE_NAME)),	\
+	  ((struct log_source_dynamic_data *)0)		\
+	)
 
 /** @brief Macro for getting ID of the element of the section.
  *
  *  @param _addr Address of the element.
  */
-#if LOG_MODULE_PRESENT
-#define LOG_DYNAMIC_ID_GET(_addr) \
-	log_dynamic_source_id((struct log_source_dynamic_data *)_addr)
-#else
-#define LOG_DYNAMIC_ID_GET(_addr) 0
-#endif
+#define LOG_DYNAMIC_ID_GET(_addr)					     \
+	_LOG_EVAL(							     \
+	  _LOG_LEVEL(),							     \
+	  (log_dynamic_source_id((struct log_source_dynamic_data *)_addr)),  \
+	  (0)								     \
+	)
 
 /******************************************************************************/
 /****************** Internal macros for log frontend **************************/
@@ -166,23 +190,22 @@ extern "C" {
 /******************************************************************************/
 /****************** Macros for standard logging *******************************/
 /******************************************************************************/
-#define __LOG(_level, _id, _filter, ...)				   \
-	do {								   \
-		if (_LOG_CONST_LEVEL_CHECK(_level) &&			   \
-		    (_level <= LOG_RUNTIME_FILTER(_filter))) {		   \
-			struct log_msg_ids src_level = {		   \
-				.level = _level,			   \
-				.source_id = _id,			   \
-				.domain_id = CONFIG_LOG_DOMAIN_ID	   \
-			};						   \
-			__LOG_INTERNAL(src_level, __VA_ARGS__);		   \
-		} else {						   \
-			/* arg checker evaluated when log is filtered out  \
-			 * to ensure that __VA_ARGS__ are evaluated only   \
-			 * once giving always same side effects.	   \
-			 */						   \
-			log_printf_arg_checker(__VA_ARGS__);		   \
-		}							   \
+#define __LOG(_level, _id, _filter, ...)				    \
+	do {								    \
+		if (_LOG_CONST_LEVEL_CHECK(_level) &&			    \
+		    (_level <= LOG_RUNTIME_FILTER(_filter))) {		    \
+			struct log_msg_ids src_level = {		    \
+				.level = _level,			    \
+				.source_id = _id,			    \
+				.domain_id = CONFIG_LOG_DOMAIN_ID	    \
+			};						    \
+			__LOG_INTERNAL(src_level, __VA_ARGS__);		    \
+		} else {						    \
+			/* arg checker evaluated when log is filtered out */\
+			/* to ensure that __VA_ARGS__ are evaluated only */ \
+			/* once giving always same side effects.*/	    \
+			log_printf_arg_checker(__VA_ARGS__);		    \
+		}							    \
 	} while (0)
 
 #define _LOG(_level, ...)			       \
@@ -234,6 +257,9 @@ extern "C" {
 /******************************************************************************/
 /****************** Filtering macros ******************************************/
 /******************************************************************************/
+
+/** @brief Number of bits used to encode log level. */
+#define LOG_LEVEL_BITS 3
 
 /** @brief Filter slot size. */
 #define LOG_FILTER_SLOT_SIZE LOG_LEVEL_BITS

--- a/include/logging/log_instance.h
+++ b/include/logging/log_instance.h
@@ -12,6 +12,12 @@
 extern "C" {
 #endif
 
+#define LOG_LEVEL_NONE  0
+#define LOG_LEVEL_ERR   1
+#define LOG_LEVEL_WRN   2
+#define LOG_LEVEL_INF   3
+#define LOG_LEVEL_DBG   4
+
 /** @brief Constant data associated with the source of log messages. */
 struct log_source_const_data {
 	const char *name;
@@ -23,135 +29,11 @@ struct log_source_dynamic_data {
 	u32_t filters;
 };
 
-extern struct log_source_const_data __log_const_start[0];
-extern struct log_source_const_data __log_const_end[0];
-
-
 /** @brief Creates name of variable and section for constant log data.
  *
  *  @param _name Name.
  */
 #define LOG_ITEM_CONST_DATA(_name) UTIL_CAT(log_const_, _name)
-
-/** @brief Get name of the log source.
- *
- * @param source_id Source ID.
- * @return Name.
- */
-static inline const char *log_name_get(u32_t source_id)
-{
-	return __log_const_start[source_id].name;
-}
-
-/** @brief Get compiled level of the log source.
- *
- * @param source_id Source ID.
- * @return Level.
- */
-static inline u8_t log_compiled_level_get(u32_t source_id)
-{
-	return __log_const_start[source_id].level;
-}
-
-/** @brief Get index of the log source based on the address of the constant data
- *         associated with the source.
- *
- * @param data Address of the constant data.
- *
- * @return Source ID.
- */
-static inline u32_t log_const_source_id(
-				const struct log_source_const_data *data)
-{
-	return ((void *)data - (void *)__log_const_start)/
-			sizeof(struct log_source_const_data);
-}
-
-/** @brief Get number of registered sources. */
-static inline u32_t log_sources_count(void)
-{
-	return log_const_source_id(__log_const_end);
-}
-
-extern struct log_source_dynamic_data __log_dynamic_start[0];
-extern struct log_source_dynamic_data __log_dynamic_end[0];
-
-/** @brief Creates name of variable and section for runtime log data.
- *
- *  @param _name Name.
- */
-#define LOG_ITEM_DYNAMIC_DATA(_name) UTIL_CAT(log_dynamic_, _name)
-
-#define LOG_INSTANCE_DYNAMIC_DATA(_module_name, _inst) \
-	LOG_ITEM_DYNAMIC_DATA(LOG_INSTANCE_FULL_NAME(_module_name, _inst))
-
-/** @brief Get pointer to the filter set of the log source.
- *
- * @param source_id Source ID.
- *
- * @return Pointer to the filter set.
- */
-static inline u32_t *log_dynamic_filters_get(u32_t source_id)
-{
-	return &__log_dynamic_start[source_id].filters;
-}
-
-/** @brief Get index of the log source based on the address of the dynamic data
- *         associated with the source.
- *
- * @param data Address of the dynamic data.
- *
- * @return Source ID.
- */
-static inline u32_t log_dynamic_source_id(struct log_source_dynamic_data *data)
-{
-	return ((void *)data - (void *)__log_dynamic_start)/
-			sizeof(struct log_source_dynamic_data);
-}
-
-/******************************************************************************/
-/****************** Filtering macros ******************************************/
-/******************************************************************************/
-
-/** @brief Filter slot size. */
-#define LOG_FILTER_SLOT_SIZE LOG_LEVEL_BITS
-
-/** @brief Number of slots in one word. */
-#define LOG_FILTERS_NUM_OF_SLOTS (32 / LOG_FILTER_SLOT_SIZE)
-
-/** @brief Slot mask. */
-#define LOG_FILTER_SLOT_MASK ((1 << LOG_FILTER_SLOT_SIZE) - 1)
-
-/** @brief Bit offset of a slot.
- *
- *  @param _id Slot ID.
- */
-#define LOG_FILTER_SLOT_SHIFT(_id) (LOG_FILTER_SLOT_SIZE * (_id))
-
-#define LOG_FILTER_SLOT_GET(_filters, _id) \
-	((*(_filters) >> LOG_FILTER_SLOT_SHIFT(_id)) & LOG_FILTER_SLOT_MASK)
-
-#define LOG_FILTER_SLOT_SET(_filters, _id, _filter)		     \
-	do {							     \
-		*(_filters) &= ~(LOG_FILTER_SLOT_MASK <<	     \
-				 LOG_FILTER_SLOT_SHIFT(_id));	     \
-		*(_filters) |= ((_filter) & LOG_FILTER_SLOT_MASK) << \
-			       LOG_FILTER_SLOT_SHIFT(_id);	     \
-	} while (0)
-
-#define LOG_FILTER_AGGR_SLOT_IDX 0
-
-#define LOG_FILTER_AGGR_SLOT_GET(_filters) \
-	LOG_FILTER_SLOT_GET(_filters, LOG_FILTER_AGGR_SLOT_IDX)
-
-#define LOG_FILTER_FIRST_BACKEND_SLOT_IDX 1
-
-#if CONFIG_LOG_RUNTIME_FILTERING
-#define LOG_RUNTIME_FILTER(_filter) \
-	LOG_FILTER_SLOT_GET(&(_filter)->filters, LOG_FILTER_AGGR_SLOT_IDX)
-#else
-#define LOG_RUNTIME_FILTER(_filter) LOG_LEVEL_DBG
-#endif
 
 #define _LOG_CONST_ITEM_REGISTER(_name, _str_name, _level)		     \
 	const struct log_source_const_data LOG_ITEM_CONST_DATA(_name)	     \

--- a/include/logging/log_instance.h
+++ b/include/logging/log_instance.h
@@ -12,12 +12,6 @@
 extern "C" {
 #endif
 
-#define LOG_LEVEL_NONE  0
-#define LOG_LEVEL_ERR   1
-#define LOG_LEVEL_WRN   2
-#define LOG_LEVEL_INF   3
-#define LOG_LEVEL_DBG   4
-
 /** @brief Constant data associated with the source of log messages. */
 struct log_source_const_data {
 	const char *name;


### PR DESCRIPTION
There was a limitation in including log.h. It was required to define LOG_LEVEL before including log.h. On the other hand log level where defined in log.h (which is a good place). Because of that limitation user could not include log.h in any header thus could not use defined log level (like in #8816).

The reason for that was macros like:
```
#if LOG_LEVEL
#define MACRO(x) xxx
#else 
#define MACRO(x) /*empty*/
#endif 
```

Macro like that was evaluated when header was included for the first time. 

In this pull request i've attempted to create a macro (inspired by IS_ENABLED) which would do same thing but evaluation would happen in place of the MACRO(x) call and not when header is included.

Macro_LOG_EVAL(_level, _iftrue, _iffalse) was defined. It evaluates first parameter and if is valid log level (1-4) then _iftrue code is used else _iffalse is used. With this macro MACRO(x) definition can be changed to:
```
/* brackets needed to allow using commas in code which is injected */
_LOG_EVAL(LOG_LEVEL,(xxx), ())
```

After this change LOG_LEVEL must be defined before log API is used and not before log.h is included.

PR contains also some cleanup in log_instance.h: internal macros/functions moved to log_core.h which is considered internal to the logger and not API header.
