### PR TITLE
samples: net: Fix incorrect use of ipv4 in ipv6 branch

### DIFF
--- a/samples/net/traffic_class/src/main.c
+++ b/samples/net/traffic_class/src/main.c
@@ -479,7 +479,7 @@ static int connect_udp(sa_family_t family, struct net_app_ctx *ctx,
 		net_context_set_option(ctx->ipv6.ctx, NET_OPT_PRIORITY,
 				       &priority, sizeof(u8_t));
 
-		net_context_get_option(ctx->ipv4.ctx, NET_OPT_PRIORITY,
+		net_context_get_option(ctx->ipv6.ctx, NET_OPT_PRIORITY,
 				       &priority, &optlen);
 	}
 #endif


### PR DESCRIPTION
Fixing copy paste error, where ipv4 member of
the structure is used in ipv6 branch.

CID: 187074
Fixes Issue #8992

Signed-off-by: Subramanian Meenakshi Sundaram <subbu147@gmail.com>