### PR TITLE
kernel: fix errno access for user mode

### DIFF
--- a/include/arch/arc/arch.h
+++ b/include/arch/arc/arch.h
@@ -16,10 +16,6 @@
 #ifndef _ARC_ARCH__H_
 #define _ARC_ARCH__H_
 
-#ifdef __cplusplus
-extern "C" {
-#endif
-
 #include <generated_dts_board.h>
 #include <sw_isr_table.h>
 #ifdef CONFIG_CPU_ARCV2
@@ -32,6 +28,10 @@ extern "C" {
 #include <arch/arc/v2/arcv2_irq_unit.h>
 #include <arch/arc/v2/asm_inline.h>
 #include <arch/arc/v2/addr_types.h>
+#endif
+
+#ifdef __cplusplus
+extern "C" {
 #endif
 
 #if defined(CONFIG_MPU_STACK_GUARD) || defined(CONFIG_USERSPACE)

--- a/include/arch/arm/arch.h
+++ b/include/arch/arm/arch.h
@@ -19,10 +19,6 @@
 /* Add include for DTS generated information */
 #include <generated_dts_board.h>
 
-#ifdef __cplusplus
-extern "C" {
-#endif
-
 /* ARM GPRs are often designated by two different names */
 #define sys_define_gpr_with_alias(name1, name2) union { u32_t name1, name2; }
 
@@ -38,6 +34,9 @@ extern "C" {
 #include <arch/arm/cortex_m/nmi.h>
 #endif
 
+#ifdef __cplusplus
+extern "C" {
+#endif
 
 /**
  * @brief Declare the STACK_ALIGN_SIZE

--- a/include/kernel.h
+++ b/include/kernel.h
@@ -538,8 +538,16 @@ struct k_thread {
 #endif
 
 #ifdef CONFIG_ERRNO
+#ifdef CONFIG_USERSPACE
+	/* Set to the lowest area in the thread stack since this needs to
+	 * be directly read/writable by user mode. Not ideal, but best we
+	 * can do until we have thread-local storage
+	 */
+	int *errno_location;
+#else
 	/** per-thread errno variable */
 	int errno_var;
+#endif
 #endif
 
 #if defined(CONFIG_THREAD_STACK_INFO)

--- a/include/misc/errno_private.h
+++ b/include/misc/errno_private.h
@@ -1,0 +1,36 @@
+/*
+ * Copyright (c) 2018 Intel Corporation.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef _MISC_ERRNO_PRIVATE_H_
+#define _MISC_ERRNO_PRIVATE_H_
+
+#include <toolchain.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/* NOTE: located here to avoid include dependency loops between errno.h
+ * and kernel.h
+ */
+
+/**
+ * return a pointer to a memory location containing errno
+ *
+ * errno is thread-specific, and can't just be a global. This pointer
+ * is guaranteed to be read/writable from user mode.
+ *
+ * @return Memory location of errno data for current thread
+ */
+__syscall int *z_errno(void);
+
+#ifdef __cplusplus
+}
+#endif
+
+#include <syscalls/errno_private.h>
+
+#endif /* _MISC_ERRNO_PRIVATE_H */

--- a/include/syscall.h
+++ b/include/syscall.h
@@ -12,6 +12,7 @@
 #include <zephyr/types.h>
 #include <syscall_list.h>
 #include <syscall_macros.h>
+#include <arch/cpu.h>
 
 #ifdef __cplusplus
 extern "C" {

--- a/kernel/errno.c
+++ b/kernel/errno.c
@@ -13,6 +13,7 @@
  */
 
 #include <kernel_structs.h>
+#include <syscall_handler.h>
 
 /*
  * Define _k_neg_eagain for use in assembly files as errno.h is
@@ -22,8 +23,20 @@
 const int _k_neg_eagain = -EAGAIN;
 
 #ifdef CONFIG_ERRNO
-int *__errno(void)
+#ifdef CONFIG_USERSPACE
+int *_impl_z_errno(void)
+{
+	/* Initialized to the lowest address in the stack so the thread can
+	 * directly read/write it
+	 */
+	return _current->errno_location;
+}
+
+Z_SYSCALL_HANDLER0_SIMPLE(z_errno);
+#else
+int *_impl_z_errno(void)
 {
 	return &_current->errno_var;
 }
-#endif
+#endif /* CONFIG_USERSPACE */
+#endif /* CONFIG_ERRNO */

--- a/kernel/thread.c
+++ b/kernel/thread.c
@@ -312,6 +312,7 @@ void _setup_new_thread(struct k_thread *new_thread,
 	_k_object_init(new_thread);
 	_k_object_init(stack);
 	new_thread->stack_obj = stack;
+	new_thread->errno_location = (int *)K_THREAD_STACK_BUFFER(stack);
 
 	/* Any given thread has access to itself */
 	k_object_access_grant(new_thread, new_thread);

--- a/lib/libc/minimal/include/errno.h
+++ b/lib/libc/minimal/include/errno.h
@@ -17,13 +17,13 @@
 #ifndef __INCerrnoh
 #define __INCerrnoh
 
+#include <misc/errno_private.h>
+
 #ifdef __cplusplus
 extern "C" {
 #endif
 
-
-extern int *__errno(void);
-#define errno (*__errno())
+#define errno (*z_errno())
 
 /*
  * POSIX Error codes

--- a/lib/libc/newlib/libc-hooks.c
+++ b/lib/libc/newlib/libc-hooks.c
@@ -11,6 +11,7 @@
 #include <linker/linker-defs.h>
 #include <misc/util.h>
 #include <kernel_internal.h>
+#include <misc/errno_private.h>
 
 #define USED_RAM_END_ADDR   POINTER_TO_UINT(&_end)
 
@@ -177,4 +178,9 @@ void z_newlib_get_heap_bounds(void **base, size_t *size)
 {
 	*base = heap_base;
 	*size = MAX_HEAP_SIZE;
+}
+
+int *__errno(void)
+{
+	return z_errno();
 }


### PR DESCRIPTION
The errno "variable" is required to be thread-specific.
It gets defined to a macro which dereferences a pointer
returned by a kernel function.

In user mode, we cannot simply read/write the thread struct.
We do not have thread-local storage mechanism, so for now
use the lowest address of the thread stack to store this
value, since this is guaranteed to be read/writable by
a user thread.

The downside of this approach is potential stack corruption
if the stack pointer goes down this far but does not exceed
the location, since a fault won't be generated in this case.

Signed-off-by: Andrew Boie <andrew.p.boie@intel.com>