### PR TITLE
net: sockets should select dns Kconfig

### DIFF
--- a/subsys/net/lib/sockets/Kconfig
+++ b/subsys/net/lib/sockets/Kconfig
@@ -8,6 +8,7 @@
 
 menuconfig NET_SOCKETS
 	bool "BSD Sockets compatible API"
+	select DNS_RESOLVER
 	help
 	  Provide BSD Sockets like API on top of native Zephyr networking API.
 


### PR DESCRIPTION
Used by getaddrinfo().

Signed-off-by: Andrew Boie <andrew.p.boie@intel.com>