### PR TITLE
logging: Make prefixes the same length

### DIFF
--- a/subsys/logging/log_output.c
+++ b/subsys/logging/log_output.c
@@ -24,8 +24,8 @@
 static const char *const severity[] = {
 	NULL,
 	"err",
-	"warn",
-	"info",
+	"wrn",
+	"inf",
 	"dbg"
 };
 


### PR DESCRIPTION
Make the severity level prefixes the same length. This helps both
readability of mixed level logs, and it's also consistent with how the
levels are named in the public API macros.

Signed-off-by: Johan Hedberg <johan.hedberg@intel.com>