### PR TITLE
arch: i.MX add RDC peripheral permission setting for applications cores

### DIFF
--- a/arch/arm/soc/nxp_imx/mcimx6x_m4/Kconfig.defconfig.mcimx6x_m4
+++ b/arch/arm/soc/nxp_imx/mcimx6x_m4/Kconfig.defconfig.mcimx6x_m4
@@ -32,8 +32,4 @@ config UART_IMX
 
 endif # SERIAL
 
-config DOMAIN_ID
-	int
-	default 1
-
 endif # SOC_MCIMX6X_M4

--- a/arch/arm/soc/nxp_imx/mcimx6x_m4/soc.c
+++ b/arch/arm/soc/nxp_imx/mcimx6x_m4/soc.c
@@ -6,6 +6,7 @@
 
 #include <init.h>
 #include <soc.h>
+#include <dt-bindings/rdc/imx_rdc.h>
 #include <cortex_m/exc.h>
 #include "wdog_imx.h"
 
@@ -13,90 +14,64 @@
 static void SOC_RdcInit(void)
 {
 	/* Move M4 core to the configured RDC domain */
-	RDC_SetDomainID(RDC, rdcMdaM4, CONFIG_DOMAIN_ID, false);
+	RDC_SetDomainID(RDC, rdcMdaM4, M4_DOMAIN_ID, false);
 
 	/* Set access to WDOG3 for M4 core */
 	RDC_SetPdapAccess(RDC, rdcPdapWdog3,
-			RDC_DOMAIN_PERM(CONFIG_DOMAIN_ID, RDC_DOMAIN_PERM_RW),
+			RDC_DOMAIN_PERM(M4_DOMAIN_ID, RDC_DOMAIN_PERM_RW),
 			false, false);
 
 #ifdef CONFIG_UART_IMX_UART_1
 	/* Set access to UART_1 for M4 core */
-	RDC_SetPdapAccess(RDC, rdcPdapUart1,
-			RDC_DOMAIN_PERM(CONFIG_DOMAIN_ID, RDC_DOMAIN_PERM_RW),
-			false, false);
+	RDC_SetPdapAccess(RDC, rdcPdapUart1, UART_1_RDC, false, false);
 #endif /* CONFIG_UART_IMX_UART_1 */
 #ifdef CONFIG_UART_IMX_UART_2
 	/* Set access to UART_2 for M4 core */
-	RDC_SetPdapAccess(RDC, rdcPdapUart2,
-			RDC_DOMAIN_PERM(CONFIG_DOMAIN_ID, RDC_DOMAIN_PERM_RW),
-			false, false);
+	RDC_SetPdapAccess(RDC, rdcPdapUart2, UART_2_RDC, false, false);
 #endif /* CONFIG_UART_IMX_UART_2 */
 #ifdef CONFIG_UART_IMX_UART_3
 	/* Set access to UART_3 for M4 core */
-	RDC_SetPdapAccess(RDC, rdcPdapUart3,
-			RDC_DOMAIN_PERM(CONFIG_DOMAIN_ID, RDC_DOMAIN_PERM_RW),
-			false, false);
+	RDC_SetPdapAccess(RDC, rdcPdapUart3, UART_3_RDC, false, false);
 #endif /* CONFIG_UART_IMX_UART_3 */
 #ifdef CONFIG_UART_IMX_UART_4
 	/* Set access to UART_4 for M4 core */
-	RDC_SetPdapAccess(RDC, rdcPdapUart4,
-			RDC_DOMAIN_PERM(CONFIG_DOMAIN_ID, RDC_DOMAIN_PERM_RW),
-			false, false);
+	RDC_SetPdapAccess(RDC, rdcPdapUart4, UART_4_RDC, false, false);
 #endif /* CONFIG_UART_IMX_UART_4 */
 #ifdef CONFIG_UART_IMX_UART_5
 	/* Set access to UART_5 for M4 core */
-	RDC_SetPdapAccess(RDC, rdcPdapUart5,
-			RDC_DOMAIN_PERM(CONFIG_DOMAIN_ID, RDC_DOMAIN_PERM_RW),
-			false, false);
+	RDC_SetPdapAccess(RDC, rdcPdapUart5, UART_5_RDC, false, false);
 #endif /* CONFIG_UART_IMX_UART_5 */
 #ifdef CONFIG_UART_IMX_UART_6
 	/* Set access to UART_6 for M4 core */
-	RDC_SetPdapAccess(RDC, rdcPdapUart6,
-			RDC_DOMAIN_PERM(CONFIG_DOMAIN_ID, RDC_DOMAIN_PERM_RW),
-			false, false);
+	RDC_SetPdapAccess(RDC, rdcPdapUart6, UART_6_RDC, false, false);
 #endif /* CONFIG_UART_IMX_UART_6 */
 #ifdef CONFIG_GPIO_IMX_PORT_1
 	/* Set access to GPIO_1 for M4 core */
-	RDC_SetPdapAccess(RDC, rdcPdapGpio1,
-			RDC_DOMAIN_PERM(CONFIG_DOMAIN_ID, RDC_DOMAIN_PERM_RW),
-			false, false);
+	RDC_SetPdapAccess(RDC, rdcPdapGpio1, GPIO_1_RDC, false, false);
 #endif /* CONFIG_GPIO_IMX_PORT_1 */
 #ifdef CONFIG_GPIO_IMX_PORT_2
 	/* Set access to GPIO_2 for M4 core */
-	RDC_SetPdapAccess(RDC, rdcPdapGpio2,
-			RDC_DOMAIN_PERM(CONFIG_DOMAIN_ID, RDC_DOMAIN_PERM_RW),
-			false, false);
+	RDC_SetPdapAccess(RDC, rdcPdapGpio2, GPIO_2_RDC, false, false);
 #endif /* CONFIG_GPIO_IMX_PORT_2 */
 #ifdef CONFIG_GPIO_IMX_PORT_3
 	/* Set access to GPIO_3 for M4 core */
-	RDC_SetPdapAccess(RDC, rdcPdapGpio3,
-			RDC_DOMAIN_PERM(CONFIG_DOMAIN_ID, RDC_DOMAIN_PERM_RW),
-			false, false);
+	RDC_SetPdapAccess(RDC, rdcPdapGpio3, GPIO_3_RDC, false, false);
 #endif /* CONFIG_GPIO_IMX_PORT_3 */
 #ifdef CONFIG_GPIO_IMX_PORT_4
 	/* Set access to GPIO_4 for M4 core */
-	RDC_SetPdapAccess(RDC, rdcPdapGpio4,
-			RDC_DOMAIN_PERM(CONFIG_DOMAIN_ID, RDC_DOMAIN_PERM_RW),
-			false, false);
+	RDC_SetPdapAccess(RDC, rdcPdapGpio4, GPIO_4_RDC, false, false);
 #endif /* CONFIG_GPIO_IMX_PORT_4 */
 #ifdef CONFIG_GPIO_IMX_PORT_5
 	/* Set access to GPIO_5 for M4 core */
-	RDC_SetPdapAccess(RDC, rdcPdapGpio5,
-			RDC_DOMAIN_PERM(CONFIG_DOMAIN_ID, RDC_DOMAIN_PERM_RW),
-			false, false);
+	RDC_SetPdapAccess(RDC, rdcPdapGpio5, GPIO_5_RDC, false, false);
 #endif /* CONFIG_GPIO_IMX_PORT_5 */
 #ifdef CONFIG_GPIO_IMX_PORT_6
 	/* Set access to GPIO_6 for M4 core */
-	RDC_SetPdapAccess(RDC, rdcPdapGpio6,
-			RDC_DOMAIN_PERM(CONFIG_DOMAIN_ID, RDC_DOMAIN_PERM_RW),
-			false, false);
+	RDC_SetPdapAccess(RDC, rdcPdapGpio6, GPIO_6_RDC, false, false);
 #endif /* CONFIG_GPIO_IMX_PORT_6 */
 #ifdef CONFIG_GPIO_IMX_PORT_7
 	/* Set access to GPIO_7 for M4 core */
-	RDC_SetPdapAccess(RDC, rdcPdapGpio7,
-			RDC_DOMAIN_PERM(CONFIG_DOMAIN_ID, RDC_DOMAIN_PERM_RW),
-			false, false);
+	RDC_SetPdapAccess(RDC, rdcPdapGpio7, GPIO_7_RDC, false, false);
 #endif /* CONFIG_GPIO_IMX_PORT_7 */
 }
 

--- a/arch/arm/soc/nxp_imx/mcimx6x_m4/soc.h
+++ b/arch/arm/soc/nxp_imx/mcimx6x_m4/soc.h
@@ -18,13 +18,6 @@ extern "C" {
 #include "ccm_imx6sx.h"
 #include "clock_freq.h"
 
-#define RDC_DOMAIN_PERM_NONE  (0x0)
-#define RDC_DOMAIN_PERM_W     (0x1)
-#define RDC_DOMAIN_PERM_R     (0x2)
-#define RDC_DOMAIN_PERM_RW    (RDC_DOMAIN_PERM_W|RDC_DOMAIN_PERM_R)
-
-#define RDC_DOMAIN_PERM(domain, perm) (perm << (domain * 2))
-
 #endif /* !_ASMLANGUAGE */
 
 #ifdef __cplusplus

--- a/arch/arm/soc/nxp_imx/mcimx7_m4/Kconfig.defconfig.mcimx7_m4
+++ b/arch/arm/soc/nxp_imx/mcimx7_m4/Kconfig.defconfig.mcimx7_m4
@@ -57,8 +57,4 @@ config PWM_IMX
 
 endif # PWM
 
-config DOMAIN_ID
-	int
-	default 1
-
 endif # SOC_MCIMX7_M4

--- a/arch/arm/soc/nxp_imx/mcimx7_m4/soc.c
+++ b/arch/arm/soc/nxp_imx/mcimx7_m4/soc.c
@@ -6,6 +6,7 @@
 
 #include <init.h>
 #include <soc.h>
+#include <dt-bindings/rdc/imx_rdc.h>
 #include "wdog_imx.h"
 
 /* Initialize clock. */
@@ -23,7 +24,7 @@ void SOC_ClockInit(void)
 	CCM_ControlGate(CCM, ccmCcgrGateWdog3, ccmClockNeededRun);
 
 	RDC_SetPdapAccess(RDC, rdcPdapWdog3,
-			RDC_DOMAIN_PERM(CONFIG_DOMAIN_ID, RDC_DOMAIN_PERM_RW),
+			RDC_DOMAIN_PERM(M4_DOMAIN_ID, RDC_DOMAIN_PERM_RW),
 			false, false);
 
 	WDOG_DisablePowerdown(WDOG3);
@@ -48,7 +49,7 @@ void SOC_ClockInit(void)
 void SOC_RdcInit(void)
 {
 	/* Move M4 core to specific RDC domain */
-	RDC_SetDomainID(RDC, rdcMdaM4, CONFIG_DOMAIN_ID, false);
+	RDC_SetDomainID(RDC, rdcMdaM4, M4_DOMAIN_ID, false);
 }
 
 #ifdef CONFIG_GPIO_IMX
@@ -56,18 +57,14 @@ static void nxp_mcimx7_gpio_config(void)
 {
 
 #ifdef CONFIG_GPIO_IMX_PORT_1
-	RDC_SetPdapAccess(RDC, rdcPdapGpio1,
-			  RDC_DOMAIN_PERM(CONFIG_DOMAIN_ID, RDC_DOMAIN_PERM_RW),
-			  false, false);
+	RDC_SetPdapAccess(RDC, rdcPdapGpio1, GPIO_1_RDC, false, false);
 	/* Enable gpio clock gate */
 	CCM_ControlGate(CCM, ccmCcgrGateGpio1, ccmClockNeededRunWait);
 #endif /* CONFIG_GPIO_IMX_PORT_1 */
 
 
 #ifdef CONFIG_GPIO_IMX_PORT_2
-	RDC_SetPdapAccess(RDC, rdcPdapGpio2,
-			  RDC_DOMAIN_PERM(CONFIG_DOMAIN_ID, RDC_DOMAIN_PERM_RW),
-			  false, false);
+	RDC_SetPdapAccess(RDC, rdcPdapGpio2, GPIO_2_RDC, false, false);
 	/* Enable gpio clock gate */
 	CCM_ControlGate(CCM, ccmCcgrGateGpio2, ccmClockNeededRunWait);
 #endif /* CONFIG_GPIO_IMX_PORT_2 */
@@ -81,9 +78,7 @@ static void nxp_mcimx7_uart_config(void)
 
 #ifdef CONFIG_UART_IMX_UART_2
 	/* We need to grasp board uart exclusively */
-	RDC_SetPdapAccess(RDC, rdcPdapUart2,
-			RDC_DOMAIN_PERM(CONFIG_DOMAIN_ID, RDC_DOMAIN_PERM_RW),
-			false, false);
+	RDC_SetPdapAccess(RDC, rdcPdapUart2, UART_2_RDC, false, false);
 	/* Select clock derived from OSC clock(24M) */
 	CCM_UpdateRoot(CCM, ccmRootUart2, ccmRootmuxUartOsc24m, 0, 0);
 	/* Enable uart clock */
@@ -106,9 +101,7 @@ static void nxp_mcimx7_i2c_config(void)
 
 #ifdef CONFIG_I2C_1
 	/* In this example, we need to grasp board I2C exclusively */
-	RDC_SetPdapAccess(RDC, rdcPdapI2c1,
-			  RDC_DOMAIN_PERM(CONFIG_DOMAIN_ID, RDC_DOMAIN_PERM_RW),
-			  false, false);
+	RDC_SetPdapAccess(RDC, rdcPdapI2c1, I2C_1_RDC, false, false);
 	/* Select I2C clock derived from OSC clock(24M) */
 	CCM_UpdateRoot(CCM, ccmRootI2c1, ccmRootmuxI2cOsc24m, 0, 0);
 	/* Enable I2C clock */
@@ -118,9 +111,7 @@ static void nxp_mcimx7_i2c_config(void)
 
 #ifdef CONFIG_I2C_2
 	/* In this example, we need to grasp board I2C exclusively */
-	RDC_SetPdapAccess(RDC, rdcPdapI2c2,
-			  RDC_DOMAIN_PERM(CONFIG_DOMAIN_ID, RDC_DOMAIN_PERM_RW),
-			  false, false);
+	RDC_SetPdapAccess(RDC, rdcPdapI2c2, I2C_2_RDC, false, false);
 	/* Select I2C clock derived from OSC clock(24M) */
 	CCM_UpdateRoot(CCM, ccmRootI2c2, ccmRootmuxI2cOsc24m, 0, 0);
 	/* Enable I2C clock */
@@ -130,9 +121,7 @@ static void nxp_mcimx7_i2c_config(void)
 
 #ifdef CONFIG_I2C_3
 	/* In this example, we need to grasp board I2C exclusively */
-	RDC_SetPdapAccess(RDC, rdcPdapI2c3,
-			  RDC_DOMAIN_PERM(CONFIG_DOMAIN_ID, RDC_DOMAIN_PERM_RW),
-			  false, false);
+	RDC_SetPdapAccess(RDC, rdcPdapI2c3, I2C_3_RDC, false, false);
 	/* Select I2C clock derived from OSC clock(24M) */
 	CCM_UpdateRoot(CCM, ccmRootI2c3, ccmRootmuxI2cOsc24m, 0, 0);
 	/* Enable I2C clock */
@@ -142,9 +131,7 @@ static void nxp_mcimx7_i2c_config(void)
 
 #ifdef CONFIG_I2C_4
 	/* In this example, we need to grasp board I2C exclusively */
-	RDC_SetPdapAccess(RDC, rdcPdapI2c4,
-			  RDC_DOMAIN_PERM(CONFIG_DOMAIN_ID, RDC_DOMAIN_PERM_RW),
-			  false, false);
+	RDC_SetPdapAccess(RDC, rdcPdapI2c4, I2C_4_RDC, false, false);
 	/* Select I2C clock derived from OSC clock(24M) */
 	CCM_UpdateRoot(CCM, ccmRootI2c4, ccmRootmuxI2cOsc24m, 0, 0);
 	/* Enable I2C clock */
@@ -161,9 +148,7 @@ static void nxp_mcimx7_pwm_config(void)
 
 #ifdef CONFIG_PWM_1
 	/* We need to grasp board pwm exclusively */
-	RDC_SetPdapAccess(RDC, rdcPdapPwm1,
-			RDC_DOMAIN_PERM(CONFIG_DOMAIN_ID, RDC_DOMAIN_PERM_RW),
-			false, false);
+	RDC_SetPdapAccess(RDC, rdcPdapPwm1, PWM_1_RDC, false, false);
 	/* Select clock derived from OSC clock(24M) */
 	CCM_UpdateRoot(CCM, ccmRootPwm1, ccmRootmuxPwmOsc24m, 0, 0);
 	/* Enable pwm clock */
@@ -173,9 +158,7 @@ static void nxp_mcimx7_pwm_config(void)
 
 #ifdef CONFIG_PWM_2
 	/* We need to grasp board pwm exclusively */
-	RDC_SetPdapAccess(RDC, rdcPdapPwm2,
-			RDC_DOMAIN_PERM(CONFIG_DOMAIN_ID, RDC_DOMAIN_PERM_RW),
-			false, false);
+	RDC_SetPdapAccess(RDC, rdcPdapPwm2, PWM_2_RDC, false, false);
 	/* Select clock derived from OSC clock(24M) */
 	CCM_UpdateRoot(CCM, ccmRootPwm2, ccmRootmuxPwmOsc24m, 0, 0);
 	/* Enable pwm clock */
@@ -185,9 +168,7 @@ static void nxp_mcimx7_pwm_config(void)
 
 #ifdef CONFIG_PWM_3
 	/* We need to grasp board pwm exclusively */
-	RDC_SetPdapAccess(RDC, rdcPdapPwm3,
-			RDC_DOMAIN_PERM(CONFIG_DOMAIN_ID, RDC_DOMAIN_PERM_RW),
-			false, false);
+	RDC_SetPdapAccess(RDC, rdcPdapPwm3, PWM_3_RDC, false, false);
 	/* Select clock derived from OSC clock(24M) */
 	CCM_UpdateRoot(CCM, ccmRootPwm3, ccmRootmuxPwmOsc24m, 0, 0);
 	/* Enable pwm clock */
@@ -197,9 +178,7 @@ static void nxp_mcimx7_pwm_config(void)
 
 #ifdef CONFIG_PWM_4
 	/* We need to grasp board pwm exclusively */
-	RDC_SetPdapAccess(RDC, rdcPdapPwm4,
-			RDC_DOMAIN_PERM(CONFIG_DOMAIN_ID, RDC_DOMAIN_PERM_RW),
-			false, false);
+	RDC_SetPdapAccess(RDC, rdcPdapPwm4, PWM_4_RDC, false, false);
 	/* Select clock derived from OSC clock(24M) */
 	CCM_UpdateRoot(CCM, ccmRootPwm4, ccmRootmuxPwmOsc24m, 0, 0);
 	/* Enable pwm clock */

--- a/arch/arm/soc/nxp_imx/mcimx7_m4/soc.h
+++ b/arch/arm/soc/nxp_imx/mcimx7_m4/soc.h
@@ -19,13 +19,6 @@ extern "C" {
 #include "clock_freq.h"
 #include "soc_clk_freq.h"
 
-#define RDC_DOMAIN_PERM_NONE  (0x0)
-#define RDC_DOMAIN_PERM_W     (0x1)
-#define RDC_DOMAIN_PERM_R     (0x2)
-#define RDC_DOMAIN_PERM_RW    (RDC_DOMAIN_PERM_W|RDC_DOMAIN_PERM_R)
-
-#define RDC_DOMAIN_PERM(domain, perm) (perm << (domain * 2))
-
 #endif /* !_ASMLANGUAGE */
 
 #ifdef __cplusplus

--- a/dts/arm/nxp/nxp_imx6sx_m4.dtsi
+++ b/dts/arm/nxp/nxp_imx6sx_m4.dtsi
@@ -6,6 +6,7 @@
 
 #include <arm/armv7-m.dtsi>
 #include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/rdc/imx_rdc.h>
 
 / {
 	cpus {
@@ -74,6 +75,10 @@
 			compatible = "nxp,imx-uart";
 			reg = <0x42020000 0x00004000>;
 			interrupts = <26 0>;
+			rdc = <(RDC_DOMAIN_PERM(A9_DOMAIN_ID,\
+					       RDC_DOMAIN_PERM_RW)|\
+			       RDC_DOMAIN_PERM(M4_DOMAIN_ID,\
+					       RDC_DOMAIN_PERM_RW))>;
 			label = "UART_1";
 			status = "disabled";
 		};
@@ -82,6 +87,10 @@
 			compatible = "nxp,imx-uart";
 			reg = <0x421E8000 0x00004000>;
 			interrupts = <27 0>;
+			rdc = <(RDC_DOMAIN_PERM(A9_DOMAIN_ID,\
+					       RDC_DOMAIN_PERM_RW)|\
+			       RDC_DOMAIN_PERM(M4_DOMAIN_ID,\
+					       RDC_DOMAIN_PERM_RW))>;
 			label = "UART_2";
 			status = "disabled";
 		};
@@ -90,6 +99,10 @@
 			compatible = "nxp,imx-uart";
 			reg = <0x421EC000 0x00004000>;
 			interrupts = <28 0>;
+			rdc = <(RDC_DOMAIN_PERM(A9_DOMAIN_ID,\
+					       RDC_DOMAIN_PERM_RW)|\
+			       RDC_DOMAIN_PERM(M4_DOMAIN_ID,\
+					       RDC_DOMAIN_PERM_RW))>;
 			label = "UART_3";
 			status = "disabled";
 		};
@@ -98,6 +111,10 @@
 			compatible = "nxp,imx-uart";
 			reg = <0x421F0000 0x00004000>;
 			interrupts = <29 0>;
+			rdc = <(RDC_DOMAIN_PERM(A9_DOMAIN_ID,\
+					       RDC_DOMAIN_PERM_RW)|\
+			       RDC_DOMAIN_PERM(M4_DOMAIN_ID,\
+					       RDC_DOMAIN_PERM_RW))>;
 			label = "UART_4";
 			status = "disabled";
 		};
@@ -106,6 +123,10 @@
 			compatible = "nxp,imx-uart";
 			reg = <0x421F4000 0x00004000>;
 			interrupts = <30 0>;
+			rdc = <(RDC_DOMAIN_PERM(A9_DOMAIN_ID,\
+					       RDC_DOMAIN_PERM_RW)|\
+			       RDC_DOMAIN_PERM(M4_DOMAIN_ID,\
+					       RDC_DOMAIN_PERM_RW))>;
 			label = "UART_5";
 			status = "disabled";
 		};
@@ -114,6 +135,10 @@
 			compatible = "nxp,imx-uart";
 			reg = <0x422A0000 0x00004000>;
 			interrupts = <17 0>;
+			rdc = <(RDC_DOMAIN_PERM(A9_DOMAIN_ID,\
+					       RDC_DOMAIN_PERM_RW)|\
+			       RDC_DOMAIN_PERM(M4_DOMAIN_ID,\
+					       RDC_DOMAIN_PERM_RW))>;
 			label = "UART_6";
 			status = "disabled";
 		};
@@ -122,6 +147,10 @@
 			compatible = "nxp,imx-gpio";
 			reg = <0x4209C000 0x4000>;
 			interrupts = <66 0>, <67 0>;
+			rdc = <(RDC_DOMAIN_PERM(A9_DOMAIN_ID,\
+					       RDC_DOMAIN_PERM_RW)|\
+			       RDC_DOMAIN_PERM(M4_DOMAIN_ID,\
+					       RDC_DOMAIN_PERM_RW))>;
 			label = "GPIO_1";
 			gpio-controller;
 			#gpio-cells = <2>;
@@ -132,6 +161,10 @@
 			compatible = "nxp,imx-gpio";
 			reg = <0x420A0000 0x4000>;
 			interrupts = <68 0>, <69 0>;
+			rdc = <(RDC_DOMAIN_PERM(A9_DOMAIN_ID,\
+					       RDC_DOMAIN_PERM_RW)|\
+			       RDC_DOMAIN_PERM(M4_DOMAIN_ID,\
+					       RDC_DOMAIN_PERM_RW))>;
 			label = "GPIO_2";
 			gpio-controller;
 			#gpio-cells = <2>;
@@ -142,6 +175,10 @@
 			compatible = "nxp,imx-gpio";
 			reg = <0x420A4000 0x4000>;
 			interrupts = <70 0>, <71 0>;
+			rdc = <(RDC_DOMAIN_PERM(A9_DOMAIN_ID,\
+					       RDC_DOMAIN_PERM_RW)|\
+			       RDC_DOMAIN_PERM(M4_DOMAIN_ID,\
+					       RDC_DOMAIN_PERM_RW))>;
 			label = "GPIO_3";
 			gpio-controller;
 			#gpio-cells = <2>;
@@ -152,6 +189,10 @@
 			compatible = "nxp,imx-gpio";
 			reg = <0x420A8000 0x4000>;
 			interrupts = <72 0>, <73 0>;
+			rdc = <(RDC_DOMAIN_PERM(A9_DOMAIN_ID,\
+					       RDC_DOMAIN_PERM_RW)|\
+			       RDC_DOMAIN_PERM(M4_DOMAIN_ID,\
+					       RDC_DOMAIN_PERM_RW))>;
 			label = "GPIO_4";
 			gpio-controller;
 			#gpio-cells = <2>;
@@ -162,6 +203,10 @@
 			compatible = "nxp,imx-gpio";
 			reg = <0x420AC000 0x4000>;
 			interrupts = <74 0>, <74 0>;
+			rdc = <(RDC_DOMAIN_PERM(A9_DOMAIN_ID,\
+					       RDC_DOMAIN_PERM_RW)|\
+			       RDC_DOMAIN_PERM(M4_DOMAIN_ID,\
+					       RDC_DOMAIN_PERM_RW))>;
 			label = "GPIO_5";
 			gpio-controller;
 			#gpio-cells = <2>;
@@ -172,6 +217,10 @@
 			compatible = "nxp,imx-gpio";
 			reg = <0x420B0000 0x4000>;
 			interrupts = <76 0>, <77 0>;
+			rdc = <(RDC_DOMAIN_PERM(A9_DOMAIN_ID,\
+					       RDC_DOMAIN_PERM_RW)|\
+			       RDC_DOMAIN_PERM(M4_DOMAIN_ID,\
+					       RDC_DOMAIN_PERM_RW))>;
 			label = "GPIO_6";
 			gpio-controller;
 			#gpio-cells = <2>;
@@ -182,6 +231,10 @@
 			compatible = "nxp,imx-gpio";
 			reg = <0x420B4000 0x4000>;
 			interrupts = <78 0>, <79 0>;
+			rdc = <(RDC_DOMAIN_PERM(A9_DOMAIN_ID,\
+					       RDC_DOMAIN_PERM_RW)|\
+			       RDC_DOMAIN_PERM(M4_DOMAIN_ID,\
+					       RDC_DOMAIN_PERM_RW))>;
 			label = "GPIO_7";
 			gpio-controller;
 			#gpio-cells = <2>;

--- a/dts/arm/nxp/nxp_imx7d_m4.dtsi
+++ b/dts/arm/nxp/nxp_imx7d_m4.dtsi
@@ -7,6 +7,7 @@
 #include <arm/armv7-m.dtsi>
 #include <dt-bindings/gpio/gpio.h>
 #include <dt-bindings/i2c/i2c.h>
+#include <dt-bindings/rdc/imx_rdc.h>
 
 / {
 	cpus {
@@ -78,6 +79,10 @@
 			compatible = "nxp,imx-gpio";
 			reg = <0x30200000 0x10000>;
 			interrupts = <64 0>, <65 0>;
+			rdc = <(RDC_DOMAIN_PERM(A7_DOMAIN_ID,\
+					       RDC_DOMAIN_PERM_RW)|\
+			       RDC_DOMAIN_PERM(M4_DOMAIN_ID,\
+					       RDC_DOMAIN_PERM_RW))>;
 			label = "GPIO_1";
 			gpio-controller;
 			#gpio-cells = <2>;
@@ -88,6 +93,10 @@
 			compatible = "nxp,imx-gpio";
 			reg = <0x30210000 0x10000>;
 			interrupts = <66 0>, <67 0>;
+			rdc = <(RDC_DOMAIN_PERM(A7_DOMAIN_ID,\
+					       RDC_DOMAIN_PERM_RW)|\
+			       RDC_DOMAIN_PERM(M4_DOMAIN_ID,\
+					       RDC_DOMAIN_PERM_RW))>;
 			label = "GPIO_2";
 			gpio-controller;
 			#gpio-cells = <2>;
@@ -98,6 +107,10 @@
 			compatible = "nxp,imx-gpio";
 			reg = <0x30220000 0x10000>;
 			interrupts = <68 0>, <69 0>;
+			rdc = <(RDC_DOMAIN_PERM(A7_DOMAIN_ID,\
+					       RDC_DOMAIN_PERM_RW)|\
+			       RDC_DOMAIN_PERM(M4_DOMAIN_ID,\
+					       RDC_DOMAIN_PERM_RW))>;
 			label = "GPIO_3";
 			gpio-controller;
 			#gpio-cells = <2>;
@@ -108,6 +121,10 @@
 			compatible = "nxp,imx-gpio";
 			reg = <0x30230000 0x10000>;
 			interrupts = <70 0>, <71 0>;
+			rdc = <(RDC_DOMAIN_PERM(A7_DOMAIN_ID,\
+					       RDC_DOMAIN_PERM_RW)|\
+			       RDC_DOMAIN_PERM(M4_DOMAIN_ID,\
+					       RDC_DOMAIN_PERM_RW))>;
 			label = "GPIO_4";
 			gpio-controller;
 			#gpio-cells = <2>;
@@ -118,6 +135,10 @@
 			compatible = "nxp,imx-gpio";
 			reg = <0x30240000 0x10000>;
 			interrupts = <72 0>, <73 0>;
+			rdc = <(RDC_DOMAIN_PERM(A7_DOMAIN_ID,\
+					       RDC_DOMAIN_PERM_RW)|\
+			       RDC_DOMAIN_PERM(M4_DOMAIN_ID,\
+					       RDC_DOMAIN_PERM_RW))>;
 			label = "GPIO_5";
 			gpio-controller;
 			#gpio-cells = <2>;
@@ -128,6 +149,10 @@
 			compatible = "nxp,imx-gpio";
 			reg = <0x30250000 0x10000>;
 			interrupts = <74 0>, <75 0>;
+			rdc = <(RDC_DOMAIN_PERM(A7_DOMAIN_ID,\
+					       RDC_DOMAIN_PERM_RW)|\
+			       RDC_DOMAIN_PERM(M4_DOMAIN_ID,\
+					       RDC_DOMAIN_PERM_RW))>;
 			label = "GPIO_6";
 			gpio-controller;
 			#gpio-cells = <2>;
@@ -139,6 +164,10 @@
 			reg = <0x30260000 0x10000>;
 			interrupts = <76 0>, <77 0>;
 			label = "GPIO_7";
+			rdc = <(RDC_DOMAIN_PERM(A7_DOMAIN_ID,\
+					       RDC_DOMAIN_PERM_RW)|\
+			       RDC_DOMAIN_PERM(M4_DOMAIN_ID,\
+					       RDC_DOMAIN_PERM_RW))>;
 			gpio-controller;
 			#gpio-cells = <2>;
 			status = "disabled";
@@ -151,6 +180,10 @@
 			compatible = "nxp,imx-uart";
 			reg = <0x30860000 0x10000>;
 			interrupts = <26 3>;
+			rdc = <(RDC_DOMAIN_PERM(A7_DOMAIN_ID,\
+					       RDC_DOMAIN_PERM_RW)|\
+			       RDC_DOMAIN_PERM(M4_DOMAIN_ID,\
+					       RDC_DOMAIN_PERM_RW))>;
 			label = "UART_1";
 			status = "disabled";
 		};
@@ -159,6 +192,10 @@
 			compatible = "nxp,imx-uart";
 			reg = <0x30890000 0x10000>;
 			interrupts = <27 3>;
+			rdc = <(RDC_DOMAIN_PERM(A7_DOMAIN_ID,\
+					       RDC_DOMAIN_PERM_RW)|\
+			       RDC_DOMAIN_PERM(M4_DOMAIN_ID,\
+					       RDC_DOMAIN_PERM_RW))>;
 			label = "UART_2";
 			status = "disabled";
 		};
@@ -167,6 +204,10 @@
 			compatible = "nxp,imx-uart";
 			reg = <0x30880000 0x10000>;
 			interrupts = <28 3>;
+			rdc = <(RDC_DOMAIN_PERM(A7_DOMAIN_ID,\
+					       RDC_DOMAIN_PERM_RW)|\
+			       RDC_DOMAIN_PERM(M4_DOMAIN_ID,\
+					       RDC_DOMAIN_PERM_RW))>;
 			label = "UART_3";
 			status = "disabled";
 		};
@@ -175,6 +216,10 @@
 			compatible = "nxp,imx-uart";
 			reg = <0x30A60000 0x10000>;
 			interrupts = <29 3>;
+			rdc = <(RDC_DOMAIN_PERM(A7_DOMAIN_ID,\
+					       RDC_DOMAIN_PERM_RW)|\
+			       RDC_DOMAIN_PERM(M4_DOMAIN_ID,\
+					       RDC_DOMAIN_PERM_RW))>;
 			label = "UART_4";
 			status = "disabled";
 		};
@@ -183,6 +228,10 @@
 			compatible = "nxp,imx-uart";
 			reg = <0x30A70000 0x10000>;
 			interrupts = <30 3>;
+			rdc = <(RDC_DOMAIN_PERM(A7_DOMAIN_ID,\
+					       RDC_DOMAIN_PERM_RW)|\
+			       RDC_DOMAIN_PERM(M4_DOMAIN_ID,\
+					       RDC_DOMAIN_PERM_RW))>;
 			label = "UART_5";
 			status = "disabled";
 		};
@@ -191,6 +240,10 @@
 			compatible = "nxp,imx-uart";
 			reg = <0x30A80000 0x10000>;
 			interrupts = <16 3>;
+			rdc = <(RDC_DOMAIN_PERM(A7_DOMAIN_ID,\
+					       RDC_DOMAIN_PERM_RW)|\
+			       RDC_DOMAIN_PERM(M4_DOMAIN_ID,\
+					       RDC_DOMAIN_PERM_RW))>;
 			label = "UART_6";
 			status = "disabled";
 		};
@@ -199,6 +252,10 @@
 			compatible = "nxp,imx-uart";
 			reg = <0x30A90000 0x10000>;
 			interrupts = <126 3>;
+			rdc = <(RDC_DOMAIN_PERM(A7_DOMAIN_ID,\
+					       RDC_DOMAIN_PERM_RW)|\
+			       RDC_DOMAIN_PERM(M4_DOMAIN_ID,\
+					       RDC_DOMAIN_PERM_RW))>;
 			label = "UART_7";
 			status = "disabled";
 		};
@@ -210,6 +267,10 @@
 			#size-cells = <0>;
 			reg = <0x30A20000 0x10000>;
 			interrupts = <35 0>;
+			rdc = <(RDC_DOMAIN_PERM(A7_DOMAIN_ID,\
+					       RDC_DOMAIN_PERM_RW)|\
+			       RDC_DOMAIN_PERM(M4_DOMAIN_ID,\
+					       RDC_DOMAIN_PERM_RW))>;
 			label = "I2C_1";
 			status = "disabled";
 		};
@@ -221,6 +282,10 @@
 			#size-cells = <0>;
 			reg = <0x30A30000 0x10000>;
 			interrupts = <36 0>;
+			rdc = <(RDC_DOMAIN_PERM(A7_DOMAIN_ID,\
+					       RDC_DOMAIN_PERM_RW)|\
+			       RDC_DOMAIN_PERM(M4_DOMAIN_ID,\
+					       RDC_DOMAIN_PERM_RW))>;
 			label = "I2C_2";
 			status = "disabled";
 		};
@@ -232,6 +297,10 @@
 			#size-cells = <0>;
 			reg = <0x30A40000 0x10000>;
 			interrupts = <37 0>;
+			rdc = <(RDC_DOMAIN_PERM(A7_DOMAIN_ID,\
+					       RDC_DOMAIN_PERM_RW)|\
+			       RDC_DOMAIN_PERM(M4_DOMAIN_ID,\
+					       RDC_DOMAIN_PERM_RW))>;
 			label = "I2C_3";
 			status = "disabled";
 		};
@@ -243,6 +312,10 @@
 			#size-cells = <0>;
 			reg = <0x30A50000 0x10000>;
 			interrupts = <38 0>;
+			rdc = <(RDC_DOMAIN_PERM(A7_DOMAIN_ID,\
+					       RDC_DOMAIN_PERM_RW)|\
+			       RDC_DOMAIN_PERM(M4_DOMAIN_ID,\
+					       RDC_DOMAIN_PERM_RW))>;
 			label = "I2C_4";
 			status = "disabled";
 		};
@@ -252,6 +325,10 @@
 			reg = <0x30660000 0x10000>;
 			interrupts = <81 0>;
 			prescaler = <0>;
+			rdc = <(RDC_DOMAIN_PERM(A7_DOMAIN_ID,\
+					       RDC_DOMAIN_PERM_RW)|\
+			       RDC_DOMAIN_PERM(M4_DOMAIN_ID,\
+					       RDC_DOMAIN_PERM_RW))>;
 			label = "PWM_1";
 			status = "disabled";
 		};
@@ -261,6 +338,10 @@
 			reg = <0x30670000 0x10000>;
 			interrupts = <82 0>;
 			prescaler = <0>;
+			rdc = <(RDC_DOMAIN_PERM(A7_DOMAIN_ID,\
+					       RDC_DOMAIN_PERM_RW)|\
+			       RDC_DOMAIN_PERM(M4_DOMAIN_ID,\
+					       RDC_DOMAIN_PERM_RW))>;
 			label = "PWM_2";
 			status = "disabled";
 		};
@@ -270,6 +351,10 @@
 			reg = <0x30680000 0x10000>;
 			interrupts = <83 0>;
 			prescaler = <0>;
+			rdc = <(RDC_DOMAIN_PERM(A7_DOMAIN_ID,\
+					       RDC_DOMAIN_PERM_RW)|\
+			       RDC_DOMAIN_PERM(M4_DOMAIN_ID,\
+					       RDC_DOMAIN_PERM_RW))>;
 			label = "PWM_3";
 			status = "disabled";
 		};
@@ -279,6 +364,10 @@
 			reg = <0x30690000 0x10000>;
 			interrupts = <84 0>;
 			prescaler = <0>;
+			rdc = <(RDC_DOMAIN_PERM(A7_DOMAIN_ID,\
+					       RDC_DOMAIN_PERM_RW)|\
+			       RDC_DOMAIN_PERM(M4_DOMAIN_ID,\
+					       RDC_DOMAIN_PERM_RW))>;
 			label = "PWM_4";
 			status = "disabled";
 		};

--- a/dts/bindings/gpio/nxp,imx-gpio.yaml
+++ b/dts/bindings/gpio/nxp,imx-gpio.yaml
@@ -36,6 +36,12 @@ properties:
       description: Human readable string describing the device (used by Zephyr for API name)
       generation: define
 
+    rdc:
+     type: int
+     category: required
+     description: Set the RDC permission for this peripheral
+     generation: define
+
 "#cells":
   - pin
   - flags

--- a/dts/bindings/i2c/fsl,imx7d-i2c.yaml
+++ b/dts/bindings/i2c/fsl,imx7d-i2c.yaml
@@ -31,3 +31,9 @@ properties:
       category: required
       description: required interrupts
       generation: define
+
+    rdc:
+     type: int
+     category: required
+     description: Set the RDC permission for this peripheral
+     generation: define

--- a/dts/bindings/pwm/fsl,imx7d-pwm.yaml
+++ b/dts/bindings/pwm/fsl,imx7d-pwm.yaml
@@ -39,4 +39,10 @@ properties:
      description: Set the PWM prescale between 0 and 4096
      generation: define
 
+    rdc:
+     type: int
+     category: required
+     description: Set the RDC permission for this peripheral
+     generation: define
+
 ...

--- a/dts/bindings/serial/nxp,imx-uart.yaml
+++ b/dts/bindings/serial/nxp,imx-uart.yaml
@@ -51,4 +51,10 @@ properties:
      description: Set the UART Port to modem mode 0 (dce) 64 (dte)
      generation: define
 
+    rdc:
+     type: int
+     category: required
+     description: Set the RDC permission for this peripheral
+     generation: define
+
 ...

--- a/include/dt-bindings/rdc/imx_rdc.h
+++ b/include/dt-bindings/rdc/imx_rdc.h
@@ -1,0 +1,21 @@
+/*
+ * Copyright (c) 2018, Diego Sueiro
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef __IMX_RDC_H
+#define __IMX_RDC_H
+
+#define A7_DOMAIN_ID	0
+#define A9_DOMAIN_ID	0
+#define M4_DOMAIN_ID	1
+
+#define RDC_DOMAIN_PERM_NONE  (0x0)
+#define RDC_DOMAIN_PERM_W     (0x1)
+#define RDC_DOMAIN_PERM_R     (0x2)
+#define RDC_DOMAIN_PERM_RW    (RDC_DOMAIN_PERM_W|RDC_DOMAIN_PERM_R)
+
+#define RDC_DOMAIN_PERM(domain, perm) (perm << (domain * 2))
+
+#endif /* __IMX_RDC_H */


### PR DESCRIPTION
This patch adds the RDC (Resource Domain Controller) peripheral
permissions settings for the i.MX applications cores (Cortex A9 on
i.MX6 and Cortex A7 on i.MX7).

This will enable both Linux (on application's core) and Zephyr (on M4
core) to share the peripherals and coexist.

A complete solution should involve the SEMA4 to control the peripherals
access and prevent resource deadlocking and misusage.

Signed-off-by: Diego Sueiro <diego.sueiro@gmail.com>