### PR TITLE
subsys: logging: Allow to redefine syslog_hook_default

### DIFF
--- a/subsys/logging/sys_log.c
+++ b/subsys/logging/sys_log.c
@@ -6,7 +6,7 @@
 
 #include <logging/sys_log.h>
 
-void syslog_hook_default(const char *fmt, ...)
+void __attribute__((weak)) syslog_hook_default(const char *fmt, ...)
 {
 	(void)(fmt);  /* Prevent warning about unused argument */
 }


### PR DESCRIPTION
Some application might want to define a default syslog_hook
(for instance using printk) to use before the one installed by
syslog_hook_install() when `CONFIG_SYS_LOG_EXT_HOOK=y`.
The default syslog_hook could also be used in case we fail
to install one.

Signed-off-by: Olivier Martin <olivier.martin@proglove.de>