### PR TITLE
net: getaddrinfo: Make availability depend on CONFIG_DNS_RESOLVER

### DIFF
--- a/subsys/net/lib/sockets/getaddrinfo.c
+++ b/subsys/net/lib/sockets/getaddrinfo.c
@@ -18,6 +18,8 @@
 
 #define AI_ARR_MAX	2
 
+#if defined(CONFIG_DNS_RESOLVER)
+
 struct getaddrinfo_state {
 	const struct zsock_addrinfo *hints;
 	struct k_sem sem;
@@ -180,3 +182,5 @@ int zsock_getaddrinfo(const char *host, const char *service,
 	}
 	return ret;
 }
+
+#endif


### PR DESCRIPTION
CONFIG_DNS_RESOLVER is the master switch for DNS resolution support,
for both native and socket APIs. Avoid confusing link errors by
compiling out both dns_resolve_name() and getaddrinfo() if that
option is not enabled.

Signed-off-by: Paul Sokolovsky <paul.sokolovsky@linaro.org>