### PR TITLE
quark_se_c1000_devboard: Enable testing for the platform

### DIFF
--- a/boards/x86/quark_se_c1000_devboard/quark_se_c1000_devboard.yaml
+++ b/boards/x86/quark_se_c1000_devboard/quark_se_c1000_devboard.yaml
@@ -18,3 +18,5 @@ supported:
   - dma
 ram: 52
 flash: 144
+testing:
+  default: true


### PR DESCRIPTION
This enables sanitycheck builds for the board, i.e. all tests with
usb_device supported.

Signed-off-by: Andrei Emeltchenko <andrei.emeltchenko@intel.com>