### PR TITLE
logging: Fix static log filtering

### DIFF
--- a/include/logging/log.h
+++ b/include/logging/log.h
@@ -259,14 +259,15 @@ int log_printk(const char *fmt, va_list ap);
 	_LOG_EVAL(							\
 		CONFIG_LOG_RUNTIME_FILTERING,				\
 		(; __DYNAMIC_MODULE_REGISTER(_name)),			\
-		()\
+		()							\
 	)
 
-#define _LOG_MODULE_REGISTER(_name, level)				     \
+#define _LOG_MODULE_REGISTER(_name, _level)				     \
 	const struct log_source_const_data LOG_ITEM_CONST_DATA(_name)	     \
 	__attribute__ ((section("." STRINGIFY(LOG_ITEM_CONST_DATA(_name))))) \
 	__attribute__((used)) = {					     \
-		.name = STRINGIFY(_name)				     \
+		.name = STRINGIFY(_name),				     \
+		.level = _level						     \
 	}								     \
 	_LOG_RUNTIME_MODULE_REGISTER(_name)
 

--- a/include/logging/log_core.h
+++ b/include/logging/log_core.h
@@ -39,7 +39,7 @@ extern "C" {
 #define __LOG_RESOLVED_LEVEL2(one_or_two_args, _level, _default) \
 	__LOG_ARG_2(one_or_two_args _level, _default)
 
-#define LOG_DEBRACKET(x) x
+#define LOG_DEBRACKET(...) __VA_ARGS__
 
 #define __LOG_ARG_2(ignore_this, val, ...) val
 #define __LOG_ARG_2_DEBRACKET(ignore_this, val, ...) LOG_DEBRACKET val


### PR DESCRIPTION
LOG_MODULE_REGISTER() was missing setting compiled-in log level
which was evaluated when message was filtered if runtime filtering
was disabled. As the outcome logs were not printed when runtime
filtering was disabled."

#9027 I've accidentally removed setting log level in the structure associated with given module. As a result it was set to 0 and logger was filtering out all messages when runtime filtering was not used.

Signed-off-by: Krzysztof Chruscinski <krzysztof.chruscinski@nordicsemi.no>