### PR TITLE
scripts: kconfig: Catch warnings generated during symbol evaluation + fix resulting warnings

### DIFF
--- a/scripts/kconfig/kconfig.py
+++ b/scripts/kconfig/kconfig.py
@@ -61,6 +61,13 @@ def main():
         kconf.load_config(config, replace=False)
 
 
+    # Write the merged configuration and the C header. This will evaluate all
+    # symbols, which might generate additional warnings, so do it before
+    # checking for warnings.
+    kconf.write_config(args.dotconfig)
+    kconf.write_autoconf(args.autoconf)
+
+
     # Print warnings for symbols whose actual value doesn't match the assigned
     # value
     for sym in kconf.defined_syms:
@@ -94,13 +101,6 @@ def main():
                      "to an actual problem, you can add it to the "
                      "whitelist at the top of {}."
                      .format(warning, sys.argv[0]))
-
-
-    # Write the merged configuration
-    kconf.write_config(args.dotconfig)
-
-    # Write the C header
-    kconf.write_autoconf(args.autoconf)
 
 
 # Message printed when a promptless symbol is assigned (and doesn't get the

--- a/subsys/bluetooth/host/Kconfig
+++ b/subsys/bluetooth/host/Kconfig
@@ -521,8 +521,8 @@ config BT_RFCOMM_L2CAP_MTU
 	default BT_RX_BUF_LEN
 	default BT_L2CAP_RX_MTU if BT_HCI_ACL_FLOW_CONTROL
 	depends on BT_RFCOMM
-	range BT_RX_BUF_LEN 32767
 	range BT_L2CAP_RX_MTU 32767 if BT_HCI_ACL_FLOW_CONTROL
+	range BT_RX_BUF_LEN 32767
 	help
 	  Maximum size of L2CAP PDU for RFCOMM frames.
 


### PR DESCRIPTION
Warnings generated during symbol evaluation were accidentally ignored, due to checking for warnings before writing `.config` and `autoconf.h` (which indirectly evaluates all symbols).

Move the warning checking code to after writing the configuration to catch such warnings. `kconfig.py` still gets rerun if any warnings-turned-errors show up.

Also include a fix for two accidentally swapped `range`s on the `BT_RFCOMM_L2CAP_MTU` symbol. Confusingly, earlier `range`s are still preferred in Zephyr, despite the custom prefer-later-defaults behavior.