### PR TITLE
drivers/serial: ns16550: extend to support 4 ports

### DIFF
--- a/drivers/serial/Kconfig.ns16550
+++ b/drivers/serial/Kconfig.ns16550
@@ -185,3 +185,38 @@ config UART_NS16550_PORT_2_DLF
 	depends on UART_NS16550_PORT_2 && UART_NS16550_DLF
 	help
 	  Value for DLF register.
+
+config UART_NS16550_PORT_2_PCI
+	bool "Port 2 is PCI-based"
+	depends on UART_NS16550_PCI && UART_NS16550_PORT_2
+	help
+	  Obtain port information from PCI.
+
+# ---------- Port 3 ----------
+
+menuconfig UART_NS16550_PORT_3
+	bool "Enable NS16550 Port 3"
+	depends on UART_NS16550
+	help
+	  This tells the driver to configure the UART port at boot, depending on
+	  the additional configure options below.
+
+config UART_NS16550_PORT_3_OPTIONS
+	int "Port 3 Options"
+	default 0
+	depends on UART_NS16550_PORT_3
+	help
+	  Options used for port initialization.
+
+config UART_NS16550_PORT_3_DLF
+	hex "Port 3 DLF value"
+	default 0x0
+	depends on UART_NS16550_PORT_3 && UART_NS16550_DLF
+	help
+	  Value for DLF register.
+
+config UART_NS16550_PORT_3_PCI
+	bool "Port 3 is PCI-based"
+	depends on UART_NS16550_PCI && UART_NS16550_PORT_3
+	help
+	  Obtain port information from PCI.

--- a/drivers/serial/uart_ns16550.c
+++ b/drivers/serial/uart_ns16550.c
@@ -866,6 +866,16 @@ static const struct uart_ns16550_device_config uart_ns16550_dev_cfg_2 = {
 };
 
 static struct uart_ns16550_dev_data_t uart_ns16550_dev_data_2 = {
+#ifdef CONFIG_UART_NS16550_PORT_2_PCI
+	.pci_dev.class_type = UART_NS16550_PORT_2_PCI_CLASS,
+	.pci_dev.bus = UART_NS16550_PORT_2_PCI_BUS,
+	.pci_dev.dev = UART_NS16550_PORT_2_PCI_DEV,
+	.pci_dev.vendor_id = UART_NS16550_PORT_2_PCI_VENDOR_ID,
+	.pci_dev.device_id = UART_NS16550_PORT_2_PCI_DEVICE_ID,
+	.pci_dev.function = UART_NS16550_PORT_2_PCI_FUNC,
+	.pci_dev.bar = UART_NS16550_PORT_2_PCI_BAR,
+#endif /* CONFIG_UART_NS16550_PORT_2_PCI */
+
 	.port = CONFIG_UART_NS16550_PORT_2_BASE_ADDR,
 	.baud_rate = CONFIG_UART_NS16550_PORT_2_BAUD_RATE,
 	.options = CONFIG_UART_NS16550_PORT_2_OPTIONS,
@@ -894,3 +904,57 @@ static void irq_config_func_2(struct device *dev)
 #endif
 
 #endif /* CONFIG_UART_NS16550_PORT_2 */
+
+#ifdef CONFIG_UART_NS16550_PORT_3
+
+#ifdef CONFIG_UART_INTERRUPT_DRIVEN
+static void irq_config_func_3(struct device *port);
+#endif
+
+static const struct uart_ns16550_device_config uart_ns16550_dev_cfg_3 = {
+	.sys_clk_freq = CONFIG_UART_NS16550_PORT_3_CLK_FREQ,
+
+#ifdef CONFIG_UART_INTERRUPT_DRIVEN
+	.irq_config_func = irq_config_func_3,
+#endif
+};
+
+static struct uart_ns16550_dev_data_t uart_ns16550_dev_data_3 = {
+#ifdef CONFIG_UART_NS16550_PORT_3_PCI
+	.pci_dev.class_type = UART_NS16550_PORT_3_PCI_CLASS,
+	.pci_dev.bus = UART_NS16550_PORT_3_PCI_BUS,
+	.pci_dev.dev = UART_NS16550_PORT_3_PCI_DEV,
+	.pci_dev.vendor_id = UART_NS16550_PORT_3_PCI_VENDOR_ID,
+	.pci_dev.device_id = UART_NS16550_PORT_3_PCI_DEVICE_ID,
+	.pci_dev.function = UART_NS16550_PORT_3_PCI_FUNC,
+	.pci_dev.bar = UART_NS16550_PORT_3_PCI_BAR,
+#endif /* CONFIG_UART_NS16550_PORT_3_PCI */
+
+	.port = CONFIG_UART_NS16550_PORT_3_BASE_ADDR,
+	.baud_rate = CONFIG_UART_NS16550_PORT_3_BAUD_RATE,
+	.options = CONFIG_UART_NS16550_PORT_3_OPTIONS,
+
+#ifdef CONFIG_UART_NS16550_PORT_3_DLF
+	.dlf = CONFIG_UART_NS16550_PORT_3_DLF,
+#endif
+};
+
+DEVICE_AND_API_INIT(uart_ns16550_3, CONFIG_UART_NS16550_PORT_3_NAME, &uart_ns16550_init,
+		    &uart_ns16550_dev_data_3, &uart_ns16550_dev_cfg_3,
+		    PRE_KERNEL_1, CONFIG_KERNEL_INIT_PRIORITY_DEVICE,
+		    &uart_ns16550_driver_api);
+
+#ifdef CONFIG_UART_INTERRUPT_DRIVEN
+static void irq_config_func_3(struct device *dev)
+{
+	ARG_UNUSED(dev);
+
+	IRQ_CONNECT(CONFIG_UART_NS16550_PORT_3_IRQ,
+		    CONFIG_UART_NS16550_PORT_3_IRQ_PRI,
+		    uart_ns16550_isr, DEVICE_GET(uart_ns16550_3),
+		    CONFIG_UART_NS16550_PORT_3_IRQ_FLAGS);
+	irq_enable(CONFIG_UART_NS16550_PORT_3_IRQ);
+}
+#endif
+
+#endif /* CONFIG_UART_NS16550_PORT_3 */


### PR DESCRIPTION
This extends the NS16550 driver to support 4 ports.
Also, this adds the necessary bits to enable PCI enumeration
on port 2.

Signed-off-by: Daniel Leung <daniel.leung@intel.com>