### PR TITLE
sanitycheck: set state correctly in case of a crash

### DIFF
--- a/scripts/sanitycheck
+++ b/scripts/sanitycheck
@@ -1088,6 +1088,8 @@ class MakeGenerator:
                     continue
 
                 state, name, _, error = m.groups()
+                if state:
+                    verbose("State: {}".format(state))
                 if error:
                     goal = self.goals[error]
                     # Sometimes QEMU will run an image and then crash out, which
@@ -1096,6 +1098,7 @@ class MakeGenerator:
                     # Need to distinguish this case from a compilation failure.
                     if goal.handler:
                         goal.fail("handler_crash")
+                        goal.make_state = 'finished'
                     else:
                         goal.fail("build_error")
                 else:


### PR DESCRIPTION
sanitycheck not printing QEMU console in some cases where a crash
happens and when state is not set correctly.

Signed-off-by: Anas Nashif <anas.nashif@intel.com>