### PR TITLE
Bluetooth: Kconfig: Lower minimum required ACL buffer count

### DIFF
--- a/subsys/bluetooth/host/Kconfig
+++ b/subsys/bluetooth/host/Kconfig
@@ -158,7 +158,7 @@ config BT_ACL_RX_COUNT
 	int "Number of incoming ACL data buffers"
 	default 6
 	default BT_CTLR_RX_BUFFERS if BT_CTLR
-	range 2 64
+	range 1 64
 	help
 	  Number of buffers available for incoming ACL data.
 


### PR DESCRIPTION
The controller already has a minimum of 1, and the host should mirror
that (in particular to avoid Kconfig warnings). A single buffer is
unsafe in some scenarios (such as with LE SC enabled) however there
are valid scenarios where a single buffer makes sense, so leave it up
to the developer to choose this.

Signed-off-by: Johan Hedberg <johan.hedberg@intel.com>