### PR TITLE
kernel: Do not use sys_clock_ticks_per_sec in _ms_to_ticks()

### DIFF
--- a/include/kernel.h
+++ b/include/kernel.h
@@ -1357,9 +1357,9 @@ static ALWAYS_INLINE s32_t _ms_to_ticks(s32_t ms)
 
 #ifdef _NEED_PRECISE_TICK_MS_CONVERSION
 	/* use 64-bit math to keep precision */
-	s64_t ms_ticks_per_sec = (s64_t)ms * sys_clock_ticks_per_sec;
-
-	return (s32_t)ceiling_fraction(ms_ticks_per_sec, MSEC_PER_SEC);
+	return (s32_t)ceiling_fraction(
+		(s64_t)ms * sys_clock_hw_cycles_per_sec,
+		(s64_t)MSEC_PER_SEC * sys_clock_hw_cycles_per_tick);
 #else
 	/* simple division keeps precision */
 	s32_t ms_per_tick = MSEC_PER_SEC / sys_clock_ticks_per_sec;

--- a/kernel/sched.c
+++ b/kernel/sched.c
@@ -641,9 +641,10 @@ void _update_time_slice_before_swap(void)
 	}
 
 	u32_t remaining = _get_remaining_program_time();
+	u32_t time_slice_ticks = _ms_to_ticks(_time_slice_duration);
 
-	if (!remaining || (_time_slice_duration < remaining)) {
-		_set_time(_time_slice_duration);
+	if (!remaining || (_time_slice_ticks < remaining)) {
+		_set_time(_time_slice_ticks);
 	} else {
 		/* Account previous elapsed time and reprogram
 		 * timer with remaining time

--- a/kernel/sys_clock.c
+++ b/kernel/sys_clock.c
@@ -263,8 +263,8 @@ static inline void handle_timeouts(s32_t ticks)
 
 #ifdef CONFIG_TIMESLICING
 s32_t _time_slice_elapsed;
-s32_t _time_slice_duration = CONFIG_TIMESLICE_SIZE;
-int  _time_slice_prio_ceiling = CONFIG_TIMESLICE_PRIORITY;
+s32_t _time_slice_duration;
+int  _time_slice_prio_ceiling;
 
 /*
  * Always called from interrupt level, and always only from the system clock
@@ -285,7 +285,7 @@ static void handle_time_slicing(s32_t ticks)
 		return;
 	}
 
-	_time_slice_elapsed += __ticks_to_ms(ticks);
+	_time_slice_elapsed += ticks;
 	if (_time_slice_elapsed >= _time_slice_duration) {
 
 		unsigned int key;
@@ -297,8 +297,7 @@ static void handle_time_slicing(s32_t ticks)
 		irq_unlock(key);
 	}
 #ifdef CONFIG_TICKLESS_KERNEL
-	next_ts =
-	    _ms_to_ticks(_time_slice_duration - _time_slice_elapsed);
+	next_ts = _time_slice_duration - _time_slice_elapsed;
 #endif
 }
 #else

--- a/tests/kernel/sched/schedule_api/src/test_sched_timeslice_reset.c
+++ b/tests/kernel/sched/schedule_api/src/test_sched_timeslice_reset.c
@@ -19,24 +19,31 @@ static K_THREAD_STACK_ARRAY_DEFINE(tstack, NUM_THREAD, STACK_SIZE);
 K_SEM_DEFINE(sema, 0, NUM_THREAD);
 /*elapsed_slice taken by last thread*/
 static s64_t elapsed_slice;
-/*expected elapsed duration*/
-static s64_t expected_slice[NUM_THREAD] = {
-	HALF_SLICE_SIZE,        /* the ztest native thread taking a half timeslice*/
-	SLICE_SIZE,             /* the spawned thread taking a full timeslice, reset*/
-	SLICE_SIZE              /* the spawned thread taking a full timeslice, reset*/
-};
 static int thread_idx;
 
 static void thread_tslice(void *p1, void *p2, void *p3)
 {
 	s64_t t = k_uptime_delta(&elapsed_slice);
+	s64_t expected_slice_min, expected_slice_max;
+
+	if (thread_idx == 0) {
+		/*thread number 0 releases CPU after HALF_SLICE_SIZE*/
+		expected_slice_min = HALF_SLICE_SIZE;
+		expected_slice_max = HALF_SLICE_SIZE;
+	} else {
+		/*other threads are sliced with tick granulity*/
+		expected_slice_min = __ticks_to_ms(_ms_to_ticks(SLICE_SIZE));
+		expected_slice_max = __ticks_to_ms(_ms_to_ticks(SLICE_SIZE)+1);
+	}
 
 	#ifdef CONFIG_DEBUG
-	TC_PRINT("thread[%d] elapsed slice %lld, ", thread_idx, t);
-	TC_PRINT("expected %lld\n", expected_slice[thread_idx]);
+	TC_PRINT("thread[%d] elapsed slice: %lld, expected: <%lld, %lld>\n",
+		thread_idx, t, expected_slice_min, expected_slice_max);
 	#endif
+
 	/** TESTPOINT: timeslice should be reset for each preemptive thread*/
-	zassert_true(t <= expected_slice[thread_idx], NULL);
+	zassert_true(t >= expected_slice_min, NULL);
+	zassert_true(t <= expected_slice_max, NULL);
 	thread_idx = (thread_idx + 1) % NUM_THREAD;
 
 	u32_t t32 = k_uptime_get_32();

--- a/tests/kernel/sched/schedule_api/src/test_slice_scheduling.c
+++ b/tests/kernel/sched/schedule_api/src/test_slice_scheduling.c
@@ -37,20 +37,23 @@ static void thread_tslice(void *p1, void *p2, void *p3)
 	int thread_parameter = ((int)p1 == (NUM_THREAD - 1)) ? '\n' :
 			       ((int)p1 + 'A');
 
+	s64_t expected_slice_min = __ticks_to_ms(_ms_to_ticks(SLICE_SIZE));
+	s64_t expected_slice_max = __ticks_to_ms(_ms_to_ticks(SLICE_SIZE) + 1);
+
 	while (1) {
 		s64_t tdelta = k_uptime_delta(&elapsed_slice);
-
 		TC_PRINT("%c", thread_parameter);
 		/* Test Fails if thread exceed allocated time slice or
 		 * Any thread is scheduled out of order.
 		 */
-		zassert_true(((tdelta <= SLICE_SIZE) &&
+		zassert_true(((tdelta >= expected_slice_min) &&
+			      (tdelta <= expected_slice_max) &&
 			      ((int)p1 == thread_idx)), NULL);
 		thread_idx = (thread_idx + 1) % (NUM_THREAD);
 		u32_t t32 = k_uptime_get_32();
 
 		/* Keep the current thread busy for more than one slice,
-		 * even though,  when timeslice used up the next thread
+		 * even though, when timeslice used up the next thread
 		 * should be scheduled in.
 		 */
 		while (k_uptime_get_32() - t32 < BUSY_MS) {
@@ -102,9 +105,12 @@ void test_slice_scheduling(void)
 	while (count < ITRERATION_COUNT) {
 		k_uptime_delta(&elapsed_slice);
 
-		/* current thread (ztest native) consumed a half timeslice*/
+		/* Keep the current thread busy for more than one slice,
+		 * even though, when timeslice used up the next thread
+		 * should be scheduled in.
+		 */
 		t32 = k_uptime_get_32();
-		while (k_uptime_get_32() - t32 < SLICE_SIZE) {
+		while (k_uptime_get_32() - t32 < BUSY_MS) {
 #if defined(CONFIG_ARCH_POSIX)
 			posix_halt_cpu(); /*sleep until next irq*/
 #else

--- a/tests/kernel/workq/work_queue/src/main.c
+++ b/tests/kernel/workq/work_queue/src/main.c
@@ -15,6 +15,10 @@
 /* Each work item takes 100ms */
 #define WORK_ITEM_WAIT          100
 
+/* In fact, each work item could take up to this value */
+#define WORK_ITEM_WAIT_ALIGNED	\
+	__ticks_to_ms(_ms_to_ticks(WORK_ITEM_WAIT) + _TICK_ALIGN)
+
 /*
  * Wait 50ms between work submissions, to ensure co-op and prempt
  * preempt thread submit alternatively.
@@ -139,7 +143,7 @@ static void test_sequence(void)
 	test_items_submit();
 
 	TC_PRINT(" - Waiting for work to finish\n");
-	k_sleep((NUM_TEST_ITEMS + 1) * WORK_ITEM_WAIT);
+	k_sleep(NUM_TEST_ITEMS * WORK_ITEM_WAIT_ALIGNED);
 
 	check_results(NUM_TEST_ITEMS);
 	reset_results();
@@ -179,7 +183,7 @@ static void test_resubmit(void)
 	k_work_submit(&tests[0].work.work);
 
 	TC_PRINT(" - Waiting for work to finish\n");
-	k_sleep((NUM_TEST_ITEMS + 1) * WORK_ITEM_WAIT);
+	k_sleep(NUM_TEST_ITEMS * WORK_ITEM_WAIT_ALIGNED);
 
 	TC_PRINT(" - Checking results\n");
 	check_results(NUM_TEST_ITEMS);
@@ -294,7 +298,7 @@ static void test_delayed_cancel(void)
 			NULL, NULL, NULL, K_HIGHEST_THREAD_PRIO, 0, 0);
 
 	TC_PRINT(" - Waiting for work to finish\n");
-	k_sleep(2 * WORK_ITEM_WAIT);
+	k_sleep(WORK_ITEM_WAIT_ALIGNED);
 
 	TC_PRINT(" - Checking results\n");
 	check_results(0);
@@ -331,7 +335,7 @@ static void test_delayed_resubmit(void)
 	k_delayed_work_submit(&tests[0].work, WORK_ITEM_WAIT);
 
 	TC_PRINT(" - Waiting for work to finish\n");
-	k_sleep((NUM_TEST_ITEMS + 1) * WORK_ITEM_WAIT);
+	k_sleep(NUM_TEST_ITEMS * WORK_ITEM_WAIT_ALIGNED);
 
 	TC_PRINT(" - Checking results\n");
 	check_results(NUM_TEST_ITEMS);
@@ -378,7 +382,7 @@ static void test_delayed_resubmit_thread(void)
 			NULL, NULL, NULL, K_PRIO_COOP(10), 0, 0);
 
 	TC_PRINT(" - Waiting for work to finish\n");
-	k_sleep(WORK_ITEM_WAIT);
+	k_sleep(WORK_ITEM_WAIT_ALIGNED);
 
 	TC_PRINT(" - Checking results\n");
 	check_results(1);
@@ -403,7 +407,7 @@ static void test_delayed(void)
 	test_delayed_submit();
 
 	TC_PRINT(" - Waiting for delayed work to finish\n");
-	k_sleep((NUM_TEST_ITEMS + 2) * WORK_ITEM_WAIT);
+	k_sleep(NUM_TEST_ITEMS * WORK_ITEM_WAIT_ALIGNED);
 
 	TC_PRINT(" - Checking results\n");
 	check_results(NUM_TEST_ITEMS);


### PR DESCRIPTION
The value of sys_clock_ticks_per_sec is obtained using
simple integer division with rounding toward zero. As result
using this variable in _ms_to_ticks() introduces some error.

This PR eliminates sys_clock_ticks_per_sec from equation
used in _ms_to_ticks() removing introduced error.

Also, this PR fixes #8895.

Please note, that this PR is based on top of #9137.