### PR TITLE
Revert "sanitycheck: set state correctly in case of a crash"

### DIFF
--- a/scripts/sanitycheck
+++ b/scripts/sanitycheck
@@ -1088,8 +1088,6 @@ class MakeGenerator:
                     continue
 
                 state, name, _, error = m.groups()
-                if state:
-                    verbose("State: {}".format(state))
                 if error:
                     goal = self.goals[error]
                     # Sometimes QEMU will run an image and then crash out, which
@@ -1098,7 +1096,6 @@ class MakeGenerator:
                     # Need to distinguish this case from a compilation failure.
                     if goal.handler:
                         goal.fail("handler_crash")
-                        goal.make_state = 'finished'
                     else:
                         goal.fail("build_error")
                 else:


### PR DESCRIPTION
This reverts commit d74a56bd63440bac02372bc1dea96e40c4491c1e.

Still not soving the issue and introducing additional problems.

Signed-off-by: Anas Nashif <anas.nashif@intel.com>