### PR TITLE
net: relax net_ip.h check

### DIFF
--- a/include/net/net_ip.h
+++ b/include/net/net_ip.h
@@ -133,19 +133,12 @@ struct sockaddr_in_ptr {
 	struct in_addr		*sin_addr;     /* IPv4 address */
 };
 
-#if defined(CONFIG_NET_IPV6)
-#define NET_SOCKADDR_MAX_SIZE (sizeof(struct sockaddr_in6))
-#define NET_SOCKADDR_PTR_MAX_SIZE (sizeof(struct sockaddr_in6_ptr))
-#elif defined(CONFIG_NET_IPV4)
+#if defined(CONFIG_NET_IPV4) && !defined(CONFIG_NET_IPV6)
 #define NET_SOCKADDR_MAX_SIZE (sizeof(struct sockaddr_in))
 #define NET_SOCKADDR_PTR_MAX_SIZE (sizeof(struct sockaddr_in_ptr))
 #else
-#if !defined(CONFIG_NET_RAW_MODE)
-#error "Either IPv6 or IPv4 needs to be selected."
-#else
 #define NET_SOCKADDR_MAX_SIZE (sizeof(struct sockaddr_in6))
 #define NET_SOCKADDR_PTR_MAX_SIZE (sizeof(struct sockaddr_in6_ptr))
-#endif
 #endif
 
 struct sockaddr {


### PR DESCRIPTION
This allows network stack headers to be included even if
no L3 networking support is enabled in Kconfig.

Signed-off-by: Andrew Boie <andrew.p.boie@intel.com>