### PR TITLE
boards/x86: up_squared: fix UART interrupt triggers

### DIFF
--- a/boards/x86/up_squared/up_squared.dts
+++ b/boards/x86/up_squared/up_squared.dts
@@ -30,7 +30,7 @@
 			reg = <0x91524000 0x1000>;
 			label = "UART_0";
 			clock-frequency = <1843200>;
-			interrupts = <4 IRQ_TYPE_LEVEL_HIGH 3>;
+			interrupts = <4 IRQ_TYPE_LEVEL_LOW 3>;
 			interrupt-parent = <&intc>;
 
 			status = "ok";
@@ -42,7 +42,7 @@
 			reg = <0x91522000 0x1000>;
 			label = "UART_1";
 			clock-frequency = <1843200>;
-			interrupts = <5 IRQ_TYPE_LEVEL_HIGH 3>;
+			interrupts = <5 IRQ_TYPE_LEVEL_LOW 3>;
 			interrupt-parent = <&intc>;
 
 			status = "ok";


### PR DESCRIPTION
The triggers for UART interrupts are actually active-low.

Signed-off-by: Daniel Leung <danielcp@gmail.com>