### PR TITLE
ioapic: IOREGSEL register needs to be treated as 32 bits

### DIFF
--- a/drivers/interrupt_controller/ioapic_intr.c
+++ b/drivers/interrupt_controller/ioapic_intr.c
@@ -329,7 +329,7 @@ static u32_t __IoApicGet(s32_t offset)
 
 	key = irq_lock();
 
-	*((volatile char *)
+	*((volatile u32_t *)
 		(CONFIG_IOAPIC_BASE_ADDRESS + IOAPIC_IND)) = (char)offset;
 	value = *((volatile u32_t *)(CONFIG_IOAPIC_BASE_ADDRESS + IOAPIC_DATA));
 
@@ -356,7 +356,7 @@ static void __IoApicSet(s32_t offset, u32_t value)
 
 	key = irq_lock();
 
-	*(volatile char *)(CONFIG_IOAPIC_BASE_ADDRESS + IOAPIC_IND) = (char)offset;
+	*(volatile u32_t *)(CONFIG_IOAPIC_BASE_ADDRESS + IOAPIC_IND) = (char)offset;
 	*((volatile u32_t *)(CONFIG_IOAPIC_BASE_ADDRESS + IOAPIC_DATA)) = value;
 
 	irq_unlock(key);


### PR DESCRIPTION
If IOREGSEL register is not accessed with 32 bits, it may not be
intercepted by type 1 hypervisor correctly.

Signed-off-by: Zide Chen <zide.chen@intel.com>