### PR TITLE
loapic timer: LVTT should be programmed before ICR

### DIFF
--- a/drivers/timer/loapic_timer.c
+++ b/drivers/timer/loapic_timer.c
@@ -351,8 +351,8 @@ void _timer_int_handler(void *unused /* parameter is not used */
 		}
 
 		/* Return the timer to periodic mode */
-		initial_count_register_set(cycles_per_tick - 1);
 		periodic_mode_set();
+		initial_count_register_set(cycles_per_tick - 1);
 		timer_known_to_have_expired = false;
 		timer_mode = TIMER_MODE_PERIODIC;
 	}
@@ -521,8 +521,8 @@ void _timer_idle_enter(s32_t ticks /* system ticks */
 	}
 
 	/* Set timer to one-shot mode */
-	initial_count_register_set(programmed_cycles);
 	one_shot_mode_set();
+	initial_count_register_set(programmed_cycles);
 	timer_mode = TIMER_MODE_ONE_SHOT;
 #endif
 }
@@ -655,12 +655,12 @@ int _sys_clock_driver_init(struct device *device)
 #ifndef CONFIG_MVIC
 	divide_configuration_register_set();
 #endif
-	initial_count_register_set(cycles_per_tick - 1);
 #ifdef CONFIG_TICKLESS_KERNEL
 	one_shot_mode_set();
 #else
 	periodic_mode_set();
 #endif
+	initial_count_register_set(cycles_per_tick - 1);
 #ifdef CONFIG_DEVICE_POWER_MANAGEMENT
 	loapic_timer_device_power_state = DEVICE_PM_ACTIVE_STATE;
 #endif


### PR DESCRIPTION
Intel SDM Vol3 10.5.4.1 states that "A write to LVT Timer Register that
changes the timer mode disarms the local APIC timer".

This implies that LVT Timer register needs to be programmed before
Initial Count register, otherwise the LOAPIC timer could not be armed.

Signed-off-by: Zide Chen <zide.chen@intel.com>