### PR TITLE
userspace: adjust syscall generation scripts

### DIFF
--- a/scripts/gen_syscalls.py
+++ b/scripts/gen_syscalls.py
@@ -83,6 +83,81 @@ u32_t %s(u32_t arg1, u32_t arg2, u32_t arg3,
 """
 
 
+typename_regex = re.compile(r'(.*?)([A-Za-z0-9_]+)$')
+
+
+class SyscallParseException(Exception):
+    pass
+
+
+def typename_split(item):
+    if "[" in item:
+        raise SyscallParseException(
+            "Please pass arrays to syscalls as pointers, unable to process '%s'" %
+            item)
+
+    if "(" in item:
+        raise SyscallParseException(
+            "Please use typedefs for function pointers")
+
+    mo = typename_regex.match(item)
+    if not mo:
+        raise SyscallParseException("Malformed system call invocation")
+
+    m = mo.groups()
+    return (m[0].strip(), m[1])
+
+
+def analyze_fn(match_group):
+    func, args = match_group
+
+    try:
+        if args == "void":
+            args = []
+        else:
+            args = [typename_split(a.strip()) for a in args.split(",")]
+
+        func_type, func_name = typename_split(func)
+    except SyscallParseException:
+        sys.stderr.write("In declaration of %s\n" % func)
+        raise
+
+    sys_id = "K_SYSCALL_" + func_name.upper()
+
+    if func_type == "void":
+        suffix = "_VOID"
+        is_void = True
+    else:
+        is_void = False
+        if func_type in ["s64_t", "u64_t"]:
+            suffix = "_RET64"
+        else:
+            suffix = ""
+
+    is_void = (func_type == "void")
+
+    # Get the proper system call macro invocation, which depends on the
+    # number of arguments, the return type, and whether the implementation
+    # is an inline function
+    macro = "K_SYSCALL_DECLARE%d%s" % (len(args), suffix)
+
+    # Flatten the argument lists and generate a comma separated list
+    # of t0, p0, t1, p1, ... tN, pN as expected by the macros
+    flat_args = [i for sublist in args for i in sublist]
+    if not is_void:
+        flat_args = [func_type] + flat_args
+    flat_args = [sys_id, func_name] + flat_args
+    argslist = ", ".join(flat_args)
+
+    invocation = "%s(%s);" % (macro, argslist)
+
+    handler = "_handler_" + func_name
+
+    # Entry in _k_syscall_table
+    table_entry = "[%s] = %s" % (sys_id, handler)
+
+    return (handler, invocation, sys_id, table_entry)
+
 def parse_args():
     global args
     parser = argparse.ArgumentParser(
@@ -109,7 +184,9 @@ def main():
     table_entries = []
     handlers = []
 
-    for fn, handler, inv, sys_id, entry in syscalls:
+    for match_group, fn in syscalls:
+        handler, inv, sys_id, entry = analyze_fn(match_group)
+
         if fn not in invocations:
             invocations[fn] = []
 

--- a/scripts/parse_syscalls.py
+++ b/scripts/parse_syscalls.py
@@ -18,81 +18,6 @@ __syscall\s+                    # __syscall attribute, must be first
 [)]                             # Closing parenthesis
 ''', re.MULTILINE | re.VERBOSE)
 
-typename_regex = re.compile(r'(.*?)([A-Za-z0-9_]+)$')
-
-
-class SyscallParseException(Exception):
-    pass
-
-
-def typename_split(item):
-    if "[" in item:
-        raise SyscallParseException(
-            "Please pass arrays to syscalls as pointers, unable to process '%s'" %
-            item)
-
-    if "(" in item:
-        raise SyscallParseException(
-            "Please use typedefs for function pointers")
-
-    mo = typename_regex.match(item)
-    if not mo:
-        raise SyscallParseException("Malformed system call invocation")
-
-    m = mo.groups()
-    return (m[0].strip(), m[1])
-
-
-def analyze_fn(match_group, fn):
-    func, args = match_group
-
-    try:
-        if args == "void":
-            args = []
-        else:
-            args = [typename_split(a.strip()) for a in args.split(",")]
-
-        func_type, func_name = typename_split(func)
-    except SyscallParseException:
-        sys.stderr.write("In declaration of %s\n" % func)
-        raise
-
-    sys_id = "K_SYSCALL_" + func_name.upper()
-
-    if func_type == "void":
-        suffix = "_VOID"
-        is_void = True
-    else:
-        is_void = False
-        if func_type in ["s64_t", "u64_t"]:
-            suffix = "_RET64"
-        else:
-            suffix = ""
-
-    is_void = (func_type == "void")
-
-    # Get the proper system call macro invocation, which depends on the
-    # number of arguments, the return type, and whether the implementation
-    # is an inline function
-    macro = "K_SYSCALL_DECLARE%d%s" % (len(args), suffix)
-
-    # Flatten the argument lists and generate a comma separated list
-    # of t0, p0, t1, p1, ... tN, pN as expected by the macros
-    flat_args = [i for sublist in args for i in sublist]
-    if not is_void:
-        flat_args = [func_type] + flat_args
-    flat_args = [sys_id, func_name] + flat_args
-    argslist = ", ".join(flat_args)
-
-    invocation = "%s(%s);" % (macro, argslist)
-
-    handler = "_handler_" + func_name
-
-    # Entry in _k_syscall_table
-    table_entry = "[%s] = %s" % (sys_id, handler)
-
-    return (fn, handler, invocation, sys_id, table_entry)
-
 
 def analyze_headers(multiple_directories):
     ret = []
@@ -109,7 +34,7 @@ def analyze_headers(multiple_directories):
 
                 with open(path, "r", encoding="utf-8") as fp:
                     try:
-                        result = [analyze_fn(mo.groups(), fn)
+                        result = [(mo.groups(), fn)
                                   for mo in api_regex.finditer(fp.read())]
                     except Exception:
                         sys.stderr.write("While parsing %s\n" % fn)


### PR DESCRIPTION
parse_syscalls.py was doing too much and was generating
derived and partial string output information that was
completed later by gen_syscalls.py.

Now parse_syscalls.py just breaks up system call information into
non-derived data which is fully processed by gen_syscalls.py.

The goal is to ease maintenance of system call generation with
all the mechanism on what to do with system call information in
one script location rather than two of them.

Signed-off-by: Andrew Boie <andrew.p.boie@intel.com>