### PR TITLE
[RFC] [DNM] drivers: nrf: Driver instantiation proposal

### DIFF
--- a/drivers/i2c/i2c_nrfx_twi.c
+++ b/drivers/i2c/i2c_nrfx_twi.c
@@ -153,11 +153,7 @@ static int init_twi(struct device *dev, const nrfx_twi_config_t *config)
 			    CONFIG_I2C_INIT_PRIORITY,			\
 			    &i2c_nrfx_twi_driver_api)
 
-#ifdef CONFIG_I2C_0_NRF_TWI
-I2C_NRFX_TWI_DEVICE(0);
-#endif
 
-#ifdef CONFIG_I2C_1_NRF_TWI
-I2C_NRFX_TWI_DEVICE(1);
-#endif
+#define DRIVER_INST(i, _) _EVAL(CONFIG_I2C_##i##_NRF_TWI, (I2C_NRFX_TWI_DEVICE(i);), ())
+UTIL_EVAL(UTIL_REPEAT(TWI_COUNT, DRIVER_INST, /*not used */))
 

--- a/drivers/spi/spi_nrfx_spi.c
+++ b/drivers/spi/spi_nrfx_spi.c
@@ -303,14 +303,6 @@ static int init_spi(struct device *dev, const nrfx_spi_config_t *config)
 			    POST_KERNEL, CONFIG_SPI_INIT_PRIORITY,	\
 			    &spi_nrfx_driver_api)
 
-#ifdef CONFIG_SPI_0_NRF_SPI
-SPI_NRFX_SPI_DEVICE(0);
-#endif
+#define DRIVER_INST(i, _) _EVAL(CONFIG_SPI_##i##_NRF_SPI, (SPI_NRFX_SPI_DEVICE(i);), ())
+UTIL_EVAL(UTIL_REPEAT(SPI_COUNT, DRIVER_INST, /*not used */))
 
-#ifdef CONFIG_SPI_1_NRF_SPI
-SPI_NRFX_SPI_DEVICE(1);
-#endif
-
-#ifdef CONFIG_SPI_2_NRF_SPI
-SPI_NRFX_SPI_DEVICE(2);
-#endif

--- a/include/misc/util.h
+++ b/include/misc/util.h
@@ -401,4 +401,21 @@ static inline s64_t arithmetic_shift_right(s64_t value, u8_t shift)
 #define MACRO_MAP_14(macro, a, ...) macro(a)MACRO_MAP_13(macro, __VA_ARGS__,)
 #define MACRO_MAP_15(macro, a, ...) macro(a)MACRO_MAP_14(macro, __VA_ARGS__,)
 
+
+#define _DEBRACKET(...) __VA_ARGS__
+
+#define _ARG_2_DEBRACKET(ignore_this, val, ...) _DEBRACKET val
+
+#define _EVAL(_test, _iftrue, _iffalse) \
+    _EVAL1(_test, _iftrue, _iffalse)
+
+#define _EVAL1(_test, _iftrue, _iffalse) \
+    _EVAL2(_ZZZZ##_test, _iftrue, _iffalse)
+
+#define _ZZZZ1 _LOG_YYYY,
+
+#define _EVAL2(one_or_two_args, _iftrue, _iffalse) \
+    _ARG_2_DEBRACKET(one_or_two_args _iftrue, _iffalse)
+
+
 #endif /* _UTIL__H_ */


### PR DESCRIPTION
There is ongoing discussion (and PR #8561) about code generation for driver instantiation. Here is a proposal how to do that using C preprocessor only. It is using macros already present in zephyr (UTIL_REPEAT and modified version of _LOG_EVAL).

If main goal of codegen is to allow dynamic/flexible instances generation then this macros seem to solve the problem without introducing external tools.

Concept is utilizing 2 preprocessor 'tricks':
- optional code creation based on a test result _EVAL(_test, _code_iftrue, _code_iffalse) which is used to create particular instance e.g. _EVAL(CONFIG_INSTANCE_##i##_ENABLED, (instance code), ())
- macro which which repeats call to another macro for requested number of times (with index as first parameter).

Signed-off-by: Krzysztof Chruscinski <krzysztof.chruscinski@nordicsemi.no>