### PR TITLE
tests: msgq: Enhance tests to improve code coverage

### DIFF
--- a/tests/kernel/msgq/msgq_api/src/main.c
+++ b/tests/kernel/msgq/msgq_api/src/main.c
@@ -19,6 +19,8 @@ extern void test_msgq_put_fail(void);
 extern void test_msgq_get_fail(void);
 extern void test_msgq_purge_when_put(void);
 extern void test_msgq_attrs_get(void);
+extern void test_msgq_alloc(void);
+extern void test_msgq_pend_thread(void);
 #ifdef CONFIG_USERSPACE
 extern void test_msgq_user_thread(void);
 extern void test_msgq_user_thread_overflow(void);
@@ -26,8 +28,6 @@ extern void test_msgq_user_put_fail(void);
 extern void test_msgq_user_get_fail(void);
 extern void test_msgq_user_attrs_get(void);
 extern void test_msgq_user_purge_when_put(void);
-
-K_MEM_POOL_DEFINE(test_pool, 128, 128, 2, 4);
 #else
 #define dummy_test(_name) \
 	static void _name(void) \
@@ -43,6 +43,8 @@ dummy_test(test_msgq_user_attrs_get);
 dummy_test(test_msgq_user_purge_when_put);
 #endif /* CONFIG_USERSPACE */
 
+K_MEM_POOL_DEFINE(test_pool, 128, 128, 2, 4);
+
 extern struct k_msgq kmsgq;
 extern struct k_msgq msgq;
 extern struct k_sem end_sema;
@@ -55,9 +57,7 @@ void test_main(void)
 	k_thread_access_grant(k_current_get(), &kmsgq, &msgq, &end_sema,
 			      &tdata, &tstack, NULL);
 
-#ifdef CONFIG_USERSPACE
 	k_thread_resource_pool_assign(k_current_get(), &test_pool);
-#endif
 
 	ztest_test_suite(msgq_api,
 			 ztest_unit_test(test_msgq_thread),
@@ -72,6 +72,8 @@ void test_main(void)
 			 ztest_unit_test(test_msgq_attrs_get),
 			 ztest_user_unit_test(test_msgq_user_attrs_get),
 			 ztest_unit_test(test_msgq_purge_when_put),
-			 ztest_user_unit_test(test_msgq_user_purge_when_put));
+			 ztest_user_unit_test(test_msgq_user_purge_when_put),
+			 ztest_unit_test(test_msgq_pend_thread),
+			 ztest_unit_test(test_msgq_alloc));
 	ztest_run_test_suite(msgq_api);
 }

--- a/tests/kernel/msgq/msgq_api/src/test_msgq.h
+++ b/tests/kernel/msgq/msgq_api/src/test_msgq.h
@@ -17,4 +17,5 @@
 #define MSGQ_LEN 2
 #define MSG0 0xABCD
 #define MSG1 0x1234
+#define OVERFLOW_SIZE_MSG 0xDEADBEEF
 #endif /* __TEST_MSGQ_H__ */

--- a/tests/kernel/msgq/msgq_api/src/test_msgq_contexts.c
+++ b/tests/kernel/msgq/msgq_api/src/test_msgq_contexts.c
@@ -8,10 +8,17 @@
 
 /**TESTPOINT: init via K_MSGQ_DEFINE*/
 K_MSGQ_DEFINE(kmsgq, MSG_SIZE, MSGQ_LEN, 4);
+K_MSGQ_DEFINE(kmsgq_test_alloc, MSG_SIZE, MSGQ_LEN, 4);
 __kernel struct k_msgq msgq;
+__kernel struct k_msgq msgq1;
 K_THREAD_STACK_DEFINE(tstack, STACK_SIZE);
+K_THREAD_STACK_DEFINE(tstack1, STACK_SIZE);
+K_THREAD_STACK_DEFINE(tstack2, STACK_SIZE);
 __kernel struct k_thread tdata;
+__kernel struct k_thread tdata1;
+__kernel struct k_thread tdata2;
 static char __aligned(4) tbuffer[MSG_SIZE * MSGQ_LEN];
+static char __aligned(4) tbuffer1[MSG_SIZE];
 static u32_t data[MSGQ_LEN] = { MSG0, MSG1 };
 __kernel struct k_sem end_sema;
 
@@ -206,6 +213,89 @@ void test_msgq_isr(void)
 
 	msgq_isr(&stack_msgq);
 	msgq_isr(&kmsgq);
+}
+
+/**
+ * @see k_msgq_get()
+ */
+static void thread_entry_get_data(void *p1, void *p2, void *p3)
+{
+	u32_t rx_buf[MSGQ_LEN];
+	int i = 0;
+
+	while (k_msgq_get(p1, &rx_buf[i], K_NO_WAIT) != 0) {
+		++i;
+	}
+
+	k_sem_give(&end_sema);
+}
+
+/**
+ * @see k_msgq_put()
+ */
+static void pend_thread_entry(void *p1, void *p2, void *p3)
+{
+	int ret;
+
+	ret = k_msgq_put(p1, &data[1], TIMEOUT);
+	zassert_equal(ret, 0, NULL);
+}
+
+/**
+ * @see k_msgq_put(), k_msgq_purge()
+ */
+static void msgq_thread_data_passing(struct k_msgq *pmsgq)
+{
+
+	while (k_msgq_put(pmsgq, &data[0], K_NO_WAIT) != 0) {
+	}
+
+	k_tid_t tid = k_thread_create(&tdata2, tstack2, STACK_SIZE,
+					pend_thread_entry, pmsgq, NULL,
+					NULL, K_PRIO_PREEMPT(0), 0, 0);
+
+	k_tid_t tid1 = k_thread_create(&tdata1, tstack1, STACK_SIZE,
+					thread_entry_get_data, pmsgq, NULL,
+					NULL, K_PRIO_PREEMPT(1), 0, 0);
+
+	k_sem_take(&end_sema, K_FOREVER);
+	k_thread_abort(tid);
+	k_thread_abort(tid1);
+
+	/**TESTPOINT: msgq purge*/
+	k_msgq_purge(pmsgq);
+}
+
+/**
+ * @see k_msgq_init()
+ */
+void test_msgq_pend_thread(void)
+{
+	k_msgq_init(&msgq1, tbuffer1, MSG_SIZE, 1);
+	k_sem_init(&end_sema, 0, 1);
+
+	msgq_thread_data_passing(&msgq1);
+}
+
+/**
+ * @see k_msgq_alloc_init(), k_msgq_cleanup()
+ */
+void test_msgq_alloc(void)
+{
+	int ret;
+
+	k_msgq_alloc_init(&kmsgq_test_alloc, MSG_SIZE, MSGQ_LEN);
+	msgq_isr(&kmsgq_test_alloc);
+	k_msgq_cleanup(&kmsgq_test_alloc);
+
+	/** Requesting buffer allocation from the test pool.*/
+	ret = k_msgq_alloc_init(&kmsgq_test_alloc, MSG_SIZE * 64, MSGQ_LEN);
+	zassert_true(ret == -ENOMEM,
+		"resource pool is smaller then requested buffer");
+
+	/* Requesting a huge size of MSG to validate overflow*/
+	ret = k_msgq_alloc_init(&kmsgq_test_alloc, OVERFLOW_SIZE_MSG, MSGQ_LEN);
+	zassert_true(ret == -EINVAL, "Invalid request");
 }
 
 /**


### PR DESCRIPTION
This test is intended to validate k_msgq_alloc_init()
and k_msgq_cleanup(), when CONFIG_USERSPACE is not defined.
Also added test to validate k_msgq_get() api, if any thread is
pending to write in message queue.

Signed-off-by: Ajay Kishore <ajay.kishore@intel.com>