### PR TITLE
samples: net: Fix incorrect error check in echo_server

### DIFF
--- a/samples/net/echo_server/src/echo-server.c
+++ b/samples/net/echo_server/src/echo-server.c
@@ -83,7 +83,7 @@ struct net_pkt *build_reply_pkt(const char *name,
 		header_len += proto_len;
 
 		ret = net_pkt_pull(pkt, 0, header_len);
-		if (!ret) {
+		if (ret != 0) {
 			net_pkt_unref(reply_pkt);
 			return NULL;
 		}


### PR DESCRIPTION
Fix for a bug mentioned in #9033.

The logic for error checking after `net_pkt_pull` was inverted - `build_pkt_reply` would exit in case `net_pkt_pull` succeeded. In result no responses were sent by echo_server.

Signed-off-by: Robert Lubos <robert.lubos@nordicsemi.no>