### PR TITLE
Bluetooth: controller: Fix disabling LE Encryption support

### DIFF
--- a/subsys/bluetooth/controller/Kconfig
+++ b/subsys/bluetooth/controller/Kconfig
@@ -196,11 +196,12 @@ comment "BLE Controller features"
 if BT_CONN
 
 config BT_CTLR_LE_ENC
-	bool
+	bool "LE Encryption"
 	depends on !BT_CTLR_DATA_LENGTH_CLEAR && !BT_CTLR_PHY_2M_NRF
 	default y
-	# Enable support for Bluetooth v4.0 LE Encryption feature in the
-	# Controller.
+	help
+	  Enable support for Bluetooth v4.0 LE Encryption feature in the
+	  Controller.
 
 config BT_CTLR_CONN_PARAM_REQ
 	bool "Connection Parameter Request"


### PR DESCRIPTION
Symbols without prompt cannot be configured from application configuration file.

warning: BT_CTLR_LE_ENC (defined at subsys/bluetooth/controller/Kconfig:198) was assigned the value
'n' but got the value 'y'.  This symbol has no prompt, meaning assignments in configuration files
have no effect on it. It can only be set indirectly, via Kconfig defaults (e.g. in a
Kconfig.defconfig file) or through being 'select'ed or 'imply'd (note: try to avoid Kconfig
'select's except for trivial promptless "helper" symbols without dependencies, as it ignores
dependencies and forces symbols on). You can check symbol information (including dependencies) in
the 'menuconfig' interface (see the Application Development Primer section of the manual), or in the
Kconfig reference at http://docs.zephyrproject.org/reference/kconfig/CONFIG_BT_CTLR_LE_ENC.html

Signed-off-by: Szymon Janc <szymon.janc@codecoup.pl>