### PR TITLE
subsys: logging: fix trigger threshold corner case

### DIFF
--- a/subsys/logging/log_core.c
+++ b/subsys/logging/log_core.c
@@ -48,14 +48,6 @@ static inline void msg_finalize(struct log_msg *msg,
 
 	atomic_inc(&buffered_cnt);
 
-	if (!IS_ENABLED(CONFIG_LOG_INPLACE_PROCESS) &&
-	    CONFIG_LOG_PROCESS_TRIGGER_THRESHOLD) {
-		if (buffered_cnt == CONFIG_LOG_PROCESS_TRIGGER_THRESHOLD &&
-		    proc_tid) {
-			k_wakeup(proc_tid);
-		}
-	}
-
 	key = irq_lock();
 
 	log_list_add_tail(&list, msg);
@@ -64,6 +56,12 @@ static inline void msg_finalize(struct log_msg *msg,
 
 	if (IS_ENABLED(CONFIG_LOG_INPLACE_PROCESS) || panic_mode) {
 		(void)log_process(false);
+	} else if (!IS_ENABLED(CONFIG_LOG_INPLACE_PROCESS) &&
+		   CONFIG_LOG_PROCESS_TRIGGER_THRESHOLD) {
+		if (buffered_cnt == CONFIG_LOG_PROCESS_TRIGGER_THRESHOLD &&
+		    proc_tid) {
+			k_wakeup(proc_tid);
+		}
 	}
 }
 


### PR DESCRIPTION
There is a race condition with undesirable behavior if the log processing threshold is 1:

- msg_finalize() is called, the threshold is met, and k_wakeup() on the processing thread is called
- the msg_finalize() thread is scheduled out by calling k_wakeup()
- the log processing thread runs, but no messages are queued, so it goes back to sleep
- the msg_finalize() thread is scheduled back in and the message is queued for processing

Fix this by queueing the message before waking up the handler thread, so the log processing thread has work to do when it wakes up. (This also may improve responsiveness for larger threshold values.)
