### PR TITLE
doc: fix incorrect defgroup comment in Queue tests

### DIFF
--- a/tests/kernel/queue/src/test_queue_user.c
+++ b/tests/kernel/queue/src/test_queue_user.c
@@ -19,7 +19,7 @@ K_MEM_POOL_DEFINE(test_pool, 16, 64, 4, 4);
 
 /**
  * @brief Tests for queue
- * @defgroup kernel_queue_tests
+ * @defgroup kernel_queue_tests Queues
  * @ingroup all_tests
  * @{
  * @}


### PR DESCRIPTION
defgroup was missing the group title parameter

Signed-off-by: David B. Kinder <david.b.kinder@intel.com>