### PR TITLE
drivers: wifi: simplelink: enable Fast Connect policy

### DIFF
--- a/boards/arm/cc3220sf_launchxl/doc/cc3220sf_launchxl.rst
+++ b/boards/arm/cc3220sf_launchxl/doc/cc3220sf_launchxl.rst
@@ -59,6 +59,8 @@ driver support.
 +-----------+------------+-----------------------+
 | I2C       | on-chip    | i2c                   |
 +-----------+------------+-----------------------+
+| SPI_0     | on-chip    | WiFi host driver      |
++-----------+------------+-----------------------+
 
 .. note::
 
@@ -209,6 +211,42 @@ build target:
    :board: cc3220sf_launchxl
    :maybe-skip-config:
    :goals: debug
+
+
+WiFi Support
+************
+
+The SimpleLink Host Driver, imported from the SimpleLink SDK, has been ported
+to Zephyr, and communicates over a dedicated SPI to the network co-processor.
+It is available as a Zephyr WiFi device driver in
+:file:`drivers/wifi/simplelink`.
+
+Currently only the Zephyr WiFi management operations are exported.
+
+Usage:
+======
+
+Set :option:`CONFIG_WIFI_SIMPLELINK` to ``y`` to enable WiFi.
+See :file:`samples/net/wifi/boards/cc3220sf_launchxl.conf`.
+
+Provisioning:
+=============
+
+SimpleLink provides a few rather sophisticated WiFi provisioning methods.
+To keep it simple for Zephyr development and demos, the SimpleLink
+"Fast Connect" policy is enabled, with one-shot scanning.
+This enables the cc3220sf_launchxl to automatically reconnect to the last
+good known access point (AP), without having to restart a scan, and
+re-specify the SSID and password.
+
+To connect to an AP, first run the Zephyr WiFi shell sample application,
+and connect to a known AP with SSID and password.
+
+See :ref:`wifi_sample`
+
+Once the connection succeeds, the network co-processor keeps the AP identity in
+its persistent memory.  Newly loaded WiFi applications then need not explicitly
+execute any WiFi scan or connect operations, until the need to change to a new AP.
 
 References
 **********

--- a/drivers/wifi/simplelink/simplelink_support.c
+++ b/drivers/wifi/simplelink/simplelink_support.c
@@ -98,12 +98,9 @@ static s32_t configure_simplelink(void)
 		return -1;
 	}
 
-	/* Remove Auto Connection Policy, to avoid multiple re-connect tries:
-	 * Note: this doesn't actually work.
-	 * NWP still issues multiple reconnects on a connection failure.
-	 */
+	/* Use Fast Connect Policy, to automatically connect to last AP: */
 	retval = sl_WlanPolicySet(SL_WLAN_POLICY_CONNECTION,
-				  SL_WLAN_CONNECTION_POLICY(0, 0, 0, 0),
+				  SL_WLAN_CONNECTION_POLICY(1, 1, 0, 0),
 				  NULL, 0);
 	ASSERT_ON_ERROR(retval, WLAN_ERROR);
 


### PR DESCRIPTION
This enables the cc3220sf_launchxl to automatically
reconnect to the last good known access point (AP).

This method avoids the need to:
- perform a wifi scan for access points on bootup (saving power);
- include hard-coded SSID/passwords in the wifi application.
- include the wifi shell in the wifi application.
- rely on more complex provisioning methods;

Signed-off-by: Gil Pitney <gil.pitney@linaro.org>