### PR TITLE
tests: kernel: timer: Add a test case to cover k_timer_start

### DIFF
--- a/tests/kernel/timer/timer_api/src/main.c
+++ b/tests/kernel/timer/timer_api/src/main.c
@@ -366,6 +366,26 @@ void test_timer_k_define(void)
 
 	/* cleanup environment */
 	k_timer_stop(&ktimer);
+
+	init_timer_data();
+	/** TESTPOINT: init timer via k_timer_init */
+	k_timer_start(&ktimer, DURATION, PERIOD);
+
+	/* Call the k_timer_start() again to make sure that
+	 * the initial timeout request gets cancelled and new
+	 * one will get added.
+	 */
+	busy_wait_ms(DURATION / 2);
+	k_timer_start(&ktimer, DURATION, PERIOD);
+	tdata.timestamp = k_uptime_get();
+	busy_wait_ms(DURATION + PERIOD * EXPIRE_TIMES + PERIOD / 2);
+
+	/** TESTPOINT: check expire and stop times */
+	TIMER_ASSERT(tdata.expire_cnt == EXPIRE_TIMES, &ktimer);
+	TIMER_ASSERT(tdata.stop_cnt == 1, &ktimer);
+
+	/* cleanup environment */
+	k_timer_stop(&ktimer);
 }
 
 static void user_data_timer_handler(struct k_timer *timer);


### PR DESCRIPTION
Added test to cover the case where the app can start the timer
even before the previous one is expired. In this case the timer
will start with latest settings or params.

Signed-off-by: Ramakrishna Pallala <ramakrishna.pallala@intel.com>