### PR TITLE
net: ipv6: Fix memory leak caused by NS request failure

### DIFF
--- a/subsys/net/ip/ipv6.c
+++ b/subsys/net/ip/ipv6.c
@@ -2140,6 +2140,10 @@ int net_ipv6_send_ns(struct net_if *iface,
 
 		if (net_is_ipv6_addr_unspecified(&NET_IPV6_HDR(pkt)->src)) {
 			NET_DBG("No source address for NS");
+			if (pending) {
+				net_pkt_unref(pending);
+			}
+
 			goto drop;
 		}
 


### PR DESCRIPTION
When an echo request is sent to an unknown neighbor, a Neighbor Solicitation request is sent, however if the source address cannot be determined the NS request is dropped but the pending packet is not freed.

Signed-off-by: Léonard Bise <leonard.bise@gmail.com>