### PR TITLE
net: Avoid holes in structs

### DIFF
--- a/include/net/net_context.h
+++ b/include/net/net_context.h
@@ -212,14 +212,6 @@ struct net_context {
 	 */
 	struct sockaddr remote;
 
-	/** Option values */
-	struct {
-#if defined(CONFIG_NET_CONTEXT_PRIORITY)
-		/** Priority of the network data sent via this net_context */
-		u8_t priority;
-#endif
-	} options;
-
 	/** Connection handle */
 	struct net_conn_handle *conn_handler;
 
@@ -248,19 +240,6 @@ struct net_context {
 	net_pkt_get_pool_func_t data_pool;
 #endif /* CONFIG_NET_CONTEXT_NET_PKT_POOL */
 
-#if defined(CONFIG_NET_CONTEXT_SYNC_RECV)
-	/**
-	 * Semaphore to signal synchronous recv call completion.
-	 */
-	struct k_sem recv_data_wait;
-#endif /* CONFIG_NET_CONTEXT_SYNC_RECV */
-
-	/** Network interface assigned to this context */
-	u8_t iface;
-
-	/** Flags for the context */
-	u8_t flags;
-
 #if defined(CONFIG_NET_TCP)
 	/** TCP connection information */
 	struct net_tcp *tcp;
@@ -270,6 +249,13 @@ struct net_context {
 	/** net_app connection information */
 	void *net_app;
 #endif /* CONFIG_NET_APP */
+
+#if defined(CONFIG_NET_CONTEXT_SYNC_RECV)
+	/**
+	 * Semaphore to signal synchronous recv call completion.
+	 */
+	struct k_sem recv_data_wait;
+#endif /* CONFIG_NET_CONTEXT_SYNC_RECV */
 
 #if defined(CONFIG_NET_SOCKETS)
 	/** Per-socket packet or connection queues */
@@ -288,6 +274,20 @@ struct net_context {
 	/** context for use by offload drivers */
 	void *offload_context;
 #endif /* CONFIG_NET_OFFLOAD */
+
+	/** Option values */
+	struct {
+#if defined(CONFIG_NET_CONTEXT_PRIORITY)
+		/** Priority of the network data sent via this net_context */
+		u8_t priority;
+#endif
+	} options;
+
+	/** Network interface assigned to this context */
+	u8_t iface;
+
+	/** Flags for the context */
+	u8_t flags;
 };
 
 static inline bool net_context_is_used(struct net_context *context)

--- a/include/net/net_if.h
+++ b/include/net/net_if.h
@@ -77,6 +77,9 @@ struct net_if_addr {
  * Stores the multicast IP addresses assigned to this network interface.
  */
 struct net_if_mcast_addr {
+	/** IP address */
+	struct net_addr address;
+
 	/** Is this multicast IP address used or not */
 	u8_t is_used : 1;
 
@@ -84,9 +87,6 @@ struct net_if_mcast_addr {
 	u8_t is_joined : 1;
 
 	u8_t _unused : 6;
-
-	/** IP address */
-	struct net_addr address;
 };
 
 #if defined(CONFIG_NET_IPV6)
@@ -351,9 +351,6 @@ struct net_if_dev {
 	/** The hardware link address */
 	struct net_linkaddr link_addr;
 
-	/** The hardware MTU */
-	u16_t mtu;
-
 #if defined(CONFIG_NET_OFFLOAD)
 	/** TCP/IP Offload functions.
 	 * If non-NULL, then the TCP/IP stack is located
@@ -362,6 +359,9 @@ struct net_if_dev {
 	 */
 	struct net_offload *offload;
 #endif /* CONFIG_NET_OFFLOAD */
+
+	/** The hardware MTU */
+	u16_t mtu;
 };
 
 /**

--- a/include/net/net_pkt.h
+++ b/include/net/net_pkt.h
@@ -104,6 +104,9 @@ struct net_pkt {
 	sys_snode_t sent_list;
 #endif
 
+	/** Reference counter */
+	u8_t ref;
+
 	u8_t sent_or_eof: 1;	/* For outgoing packet: is this sent or not
 				 * For incoming packet of a socket: last
 				 * packet before EOF
@@ -127,29 +130,6 @@ struct net_pkt {
 		u8_t ipv4_ttl;
 	};
 
-#if defined(CONFIG_NET_IPV6)
-	u16_t ipv6_ext_len;	/* length of extension headers */
-	u8_t ipv6_ext_opt_len; /* IPv6 ND option length */
-
-	/* Where is the start of the last header before payload data
-	 * in IPv6 packet. This is offset value from start of the IPv6
-	 * packet. Note that this value should be updated by who ever
-	 * adds IPv6 extension headers to the network packet.
-	 */
-	u16_t ipv6_prev_hdr_start;
-
-#if defined(CONFIG_NET_IPV6_FRAGMENT)
-	u16_t ipv6_fragment_offset;	/* Fragment offset of this packet */
-	u32_t ipv6_fragment_id;	/* Fragment id */
-	u16_t ipv6_frag_hdr_start;	/* Where starts the fragment header */
-#endif /* CONFIG_NET_IPV6_FRAGMENT */
-#endif /* CONFIG_NET_IPV6 */
-
-#if defined(CONFIG_IEEE802154)
-	u8_t ieee802154_rssi; /* Received Signal Strength Indication */
-	u8_t ieee802154_lqi;  /* Link Quality Indicator */
-#endif
-
 #if NET_TC_COUNT > 1
 	/** Network packet priority, can be left out in which case packet
 	 * is not prioritised.
@@ -165,10 +145,31 @@ struct net_pkt {
 	 */
 	u16_t vlan_tci;
 #endif /* CONFIG_NET_VLAN */
-	/* @endcond */
 
-	/** Reference counter */
-	u8_t ref;
+#if defined(CONFIG_NET_IPV6)
+	u16_t ipv6_ext_len;	/* length of extension headers */
+
+	/* Where is the start of the last header before payload data
+	 * in IPv6 packet. This is offset value from start of the IPv6
+	 * packet. Note that this value should be updated by who ever
+	 * adds IPv6 extension headers to the network packet.
+	 */
+	u16_t ipv6_prev_hdr_start;
+
+#if defined(CONFIG_NET_IPV6_FRAGMENT)
+	u16_t ipv6_fragment_offset;	/* Fragment offset of this packet */
+	u32_t ipv6_fragment_id;	/* Fragment id */
+	u16_t ipv6_frag_hdr_start;	/* Where starts the fragment header */
+#endif /* CONFIG_NET_IPV6_FRAGMENT */
+
+	u8_t ipv6_ext_opt_len; /* IPv6 ND option length */
+#endif /* CONFIG_NET_IPV6 */
+
+#if defined(CONFIG_IEEE802154)
+	u8_t ieee802154_rssi; /* Received Signal Strength Indication */
+	u8_t ieee802154_lqi;  /* Link Quality Indicator */
+#endif
+	/* @endcond */
 };
 
 /** @cond ignore */

--- a/subsys/net/ip/icmpv4.h
+++ b/subsys/net/ip/icmpv4.h
@@ -38,9 +38,9 @@ typedef enum net_verdict (*icmpv4_callback_handler_t)(struct net_pkt *pkt);
 
 struct net_icmpv4_handler {
 	sys_snode_t node;
+	icmpv4_callback_handler_t handler;
 	u8_t type;
 	u8_t code;
-	icmpv4_callback_handler_t handler;
 };
 
 /**

--- a/subsys/net/ip/icmpv6.h
+++ b/subsys/net/ip/icmpv6.h
@@ -133,9 +133,9 @@ const char *net_icmpv6_type2str(int icmpv6_type);
 
 struct net_icmpv6_handler {
 	sys_snode_t node;
+	icmpv6_callback_handler_t handler;
 	u8_t type;
 	u8_t code;
-	icmpv6_callback_handler_t handler;
 };
 
 /**

--- a/subsys/net/ip/rpl.h
+++ b/subsys/net/ip/rpl.h
@@ -208,6 +208,12 @@ struct net_rpl_node_energy_object {
  * @brief DAG Metric Container. RFC 6551, ch 2.1
  */
 struct net_rpl_metric_container {
+	/** Metric container information */
+	union metric_object {
+		struct net_rpl_node_energy_object energy;
+		u16_t etx;
+	} obj;
+
 	/** Type of the container */
 	u8_t type;
 
@@ -225,12 +231,6 @@ struct net_rpl_metric_container {
 
 	/** Length of the object body */
 	u8_t length;
-
-	/** Metric container information */
-	union metric_object {
-		struct net_rpl_node_energy_object energy;
-		u16_t etx;
-	} obj;
 };
 
 /**
@@ -437,14 +437,6 @@ struct net_rpl_instance {
 	/** DAO lifetime timer. */
 	struct k_delayed_work dao_lifetime_timer;
 
-#if defined(CONFIG_NET_RPL_DAO_ACK)
-	/** DAO retransmit timer */
-	struct k_delayed_work dao_retransmit_timer;
-
-	/** DAO number of retransmissions */
-	u8_t dao_transmissions;
-#endif
-
 	/** Network interface to send DAO */
 	struct net_if *iface;
 
@@ -528,6 +520,14 @@ struct net_rpl_instance {
 
 	/** Is DAO lifetime timer active or not. */
 	bool dao_lifetime_timer_active;
+
+#if defined(CONFIG_NET_RPL_DAO_ACK)
+	/** DAO number of retransmissions */
+	u8_t dao_transmissions;
+
+	/** DAO retransmit timer */
+	struct k_delayed_work dao_retransmit_timer;
+#endif
 };
 
 /**

--- a/subsys/net/ip/tcp.c
+++ b/subsys/net/ip/tcp.c
@@ -48,11 +48,11 @@ static struct net_tcp tcp_context[NET_MAX_TCP_CONTEXT];
 
 static struct tcp_backlog_entry {
 	struct net_tcp *tcp;
-	struct sockaddr remote;
 	u32_t send_seq;
 	u32_t send_ack;
-	u16_t send_mss;
 	struct k_delayed_work ack_timer;
+	struct sockaddr remote;
+	u16_t send_mss;
 } tcp_backlog[CONFIG_NET_TCP_BACKLOG_SIZE];
 
 #if defined(CONFIG_NET_TCP_ACK_TIMEOUT)

--- a/subsys/net/ip/tcp_internal.h
+++ b/subsys/net/ip/tcp_internal.h
@@ -145,19 +145,6 @@ struct net_tcp {
 	/** Last ACK value sent */
 	u32_t sent_ack;
 
-	/** Current retransmit period */
-	u32_t retry_timeout_shift : 5;
-	/** Flags for the TCP */
-	u32_t flags : 8;
-	/** Current TCP state */
-	u32_t state : 4;
-	/* An outbound FIN packet has been sent */
-	u32_t fin_sent : 1;
-	/* An inbound FIN packet has been received */
-	u32_t fin_rcvd : 1;
-	/** Remaining bits in this u32_t */
-	u32_t _padding : 13;
-
 	/** Accept callback to be called when the connection has been
 	 * established.
 	 */
@@ -177,6 +164,19 @@ struct net_tcp {
 	 * Send MSS for the peer
 	 */
 	u16_t send_mss;
+
+	/** Current retransmit period */
+	u32_t retry_timeout_shift : 5;
+	/** Flags for the TCP */
+	u32_t flags : 8;
+	/** Current TCP state */
+	u32_t state : 4;
+	/* An outbound FIN packet has been sent */
+	u32_t fin_sent : 1;
+	/* An inbound FIN packet has been received */
+	u32_t fin_rcvd : 1;
+	/** Remaining bits in this u32_t */
+	u32_t _padding : 13;
 };
 
 typedef void (*net_tcp_cb_t)(struct net_tcp *tcp, void *user_data);

--- a/subsys/net/l2/ethernet/gptp/gptp_data_set.h
+++ b/subsys/net/l2/ethernet/gptp/gptp_data_set.h
@@ -173,15 +173,6 @@ struct gptp_global_ds {
 	/** Last Grand Master Phase Change. */
 	struct gptp_scaled_ns last_gm_phase_change;
 
-	/** Path trace to be sent in announce message. */
-	struct gptp_path_trace path_trace;
-
-	/** Grand Master priority vector. */
-	struct gptp_priority_vector gm_priority;
-
-	/** Previous Grand Master priority vector. */
-	struct gptp_priority_vector last_gm_priority;
-
 	/** Global flags. */
 	struct gptp_flags global_flags;
 
@@ -224,6 +215,15 @@ struct gptp_global_ds {
 	/** Selected port bit array. */
 	u32_t selected_array;
 
+	/** Path trace to be sent in announce message. */
+	struct gptp_path_trace path_trace;
+
+	/** Grand Master priority vector. */
+	struct gptp_priority_vector gm_priority;
+
+	/** Previous Grand Master priority vector. */
+	struct gptp_priority_vector last_gm_priority;
+
 	/** Steps removed from selected master. */
 	u16_t master_steps_removed;
 
@@ -252,9 +252,6 @@ struct gptp_global_ds {
  * Data Set representing capabilities of the time-aware system.
  */
 struct gptp_default_ds {
-	/** System current flags. */
-	struct gptp_flags flags;
-
 	/** Quality of the local clock. */
 	struct gptp_clock_quality clk_quality;
 
@@ -263,6 +260,9 @@ struct gptp_default_ds {
 
 	/** Clock Identity of the local clock. */
 	u8_t clk_id[GPTP_CLOCK_ID_LEN];
+
+	/** System current flags. */
+	struct gptp_flags flags;
 
 	/** Current UTC offset. */
 	u16_t cur_utc_offset;
@@ -320,9 +320,6 @@ struct gptp_current_ds {
  * Data Set representing the parent capabilities.
  */
 struct gptp_parent_ds {
-	/** Port Identity of the Master Port attached to this system. */
-	struct gptp_port_identity port_id;
-
 	/** Ratio of the frequency of the GM with the local clock. */
 	s32_t cumulative_rate_ratio;
 
@@ -331,6 +328,9 @@ struct gptp_parent_ds {
 
 	/** Clock Class of the Grand Master clock. */
 	struct gptp_clock_quality gm_clk_quality;
+
+	/** Port Identity of the Master Port attached to this system. */
+	struct gptp_port_identity port_id;
 
 	/** Primary Priority of the Grand Master clock. */
 	u8_t gm_priority1;
@@ -376,15 +376,6 @@ struct gptp_time_prop_ds {
  * Data Set representing port capabilities.
  */
 struct gptp_port_ds {
-	/** Port Identity of the port. */
-	struct gptp_port_identity port_id;
-
-	/** Sync event transmission interval for the port. */
-	struct gptp_uscaled_ns half_sync_itv;
-
-	/** Path Delay Request transmission interval for the port. */
-	struct gptp_uscaled_ns pdelay_req_itv;
-
 	/** Maximum interval between sync messages. */
 	u64_t sync_receipt_timeout_time_itv;
 
@@ -399,6 +390,15 @@ struct gptp_port_ds {
 
 	/** Estimate of the ratio of the frequency with the peer. */
 	double neighbor_rate_ratio;
+
+	/** Port Identity of the port. */
+	struct gptp_port_identity port_id;
+
+	/** Sync event transmission interval for the port. */
+	struct gptp_uscaled_ns half_sync_itv;
+
+	/** Path Delay Request transmission interval for the port. */
+	struct gptp_uscaled_ns pdelay_req_itv;
 
 	/** Maximum number of Path Delay Requests without a response. */
 	u16_t allowed_lost_responses;

--- a/subsys/net/l2/ethernet/gptp/gptp_md.h
+++ b/subsys/net/l2/ethernet/gptp/gptp_md.h
@@ -28,9 +28,6 @@ extern "C" {
  * This structure applies for MDSyncReceive as well as MDSyncSend.
  */
 struct gptp_md_sync_info {
-	/** PortIdentity of this port. */
-	struct gptp_port_identity src_port_id;
-
 	/* Time of the current grandmaster compared to the previous. */
 	struct gptp_scaled_ns last_gm_phase_change;
 
@@ -48,6 +45,9 @@ struct gptp_md_sync_info {
 
 	/** Most recent rateRatio from the PortSyncSync. */
 	double rate_ratio;
+
+	/** PortIdentity of this port. */
+	struct gptp_port_identity src_port_id;
 
 	/* Time Base Indicator of the current Grand Master. */
 	u16_t gm_time_base_indicator;

--- a/subsys/net/l2/ethernet/gptp/gptp_mi.h
+++ b/subsys/net/l2/ethernet/gptp/gptp_mi.h
@@ -28,14 +28,14 @@ extern "C" {
  * This structure applies for MDSyncReceive as well as MDSyncSend.
  */
 struct gptp_mi_port_sync_sync {
-	/** Port to which the Sync Information belongs to. */
-	u16_t local_port_number;
-
 	/** Time at which the sync receipt timeout occurs. */
 	u64_t sync_receipt_timeout_time;
 
 	/** Copy of the gptp_md_sync_info to be transmitted. */
 	struct gptp_md_sync_info sync_info;
+
+	/** Port to which the Sync Information belongs to. */
+	u16_t local_port_number;
 };
 
 /**

--- a/subsys/net/l2/ethernet/gptp/gptp_state.h
+++ b/subsys/net/l2/ethernet/gptp/gptp_state.h
@@ -285,12 +285,6 @@ struct gptp_pss_rcv_state {
 
 /* PortSyncSyncSend state machine variables. */
 struct gptp_pss_send_state {
-	/** Sync send to be transmitted to the MD Sync Send State Machine. */
-	struct gptp_md_sync_info sync_send;
-
-	/** Source Port Identity of the last received PortSyncSync. */
-	struct gptp_port_identity last_src_port_id;
-
 	/** Precise Origin Timestamp of the last received PortSyncSync. */
 	struct net_ptp_time last_precise_orig_ts;
 
@@ -330,6 +324,9 @@ struct gptp_pss_send_state {
 	/** Received Port Number of the last received PortSyncSync. */
 	u16_t last_rcvd_port_num;
 
+	/** Sync send to be transmitted to the MD Sync Send State Machine. */
+	struct gptp_md_sync_info sync_send;
+
 	/** A PortSyncSync structure is ready to be processed. */
 	bool rcvd_pss_sync;
 
@@ -338,6 +335,9 @@ struct gptp_pss_send_state {
 
 	/** Flag when the half_sync_itv_timer has expired twice. */
 	bool sync_itv_timer_expired;
+
+	/** Source Port Identity of the last received PortSyncSync. */
+	struct gptp_port_identity last_src_port_id;
 
 	/** Flag when the syncReceiptTimeoutTime has expired. */
 	bool send_sync_receipt_timeout_timer_expired;
@@ -495,14 +495,14 @@ struct gptp_port_bmca_data {
 	/** Announce receipt timeout time interval. */
 	struct gptp_uscaled_ns ann_rcpt_timeout_time_interval;
 
-	/** Last announce message flags. */
-	struct gptp_flags ann_flags;
-
 	/** Origin and state of the port's spanning tree information. */
 	enum gptp_info_is info_is;
 
 	/** Last announce message time source. */
 	enum gptp_time_source ann_time_source;
+
+	/** Last announce message flags. */
+	struct gptp_flags ann_flags;
 
 	/** The value of steps removed for the port. */
 	u16_t port_steps_removed;

--- a/subsys/net/lib/dns/dns_pack.h
+++ b/subsys/net/lib/dns/dns_pack.h
@@ -37,7 +37,6 @@
  */
 struct dns_msg_t {
 	u8_t *msg;
-	u16_t msg_size;
 
 	int response_type;
 	u16_t response_position;
@@ -45,6 +44,7 @@ struct dns_msg_t {
 
 	u16_t query_offset;
 	u16_t answer_offset;
+	u16_t msg_size;
 };
 
 #define DNS_MSG_INIT(b, s)	{.msg = b, .msg_size = s,	\


### PR DESCRIPTION
Move struct members around in networking code so that we avoid
unnecessary holes inside structs. No functionality changes by
this commit.

Signed-off-by: Jukka Rissanen <jukka.rissanen@linux.intel.com>