### PR TITLE
board: efr32_slwstk6061a: add support for flashing via OpenOCD

### DIFF
--- a/boards/arm/efr32_slwstk6061a/board.cmake
+++ b/boards/arm/efr32_slwstk6061a/board.cmake
@@ -1,0 +1,2 @@
+board_runner_args(openocd)
+include(${ZEPHYR_BASE}/boards/common/openocd.board.cmake)

--- a/boards/arm/efr32_slwstk6061a/doc/efr32_slwstk6061a.rst
+++ b/boards/arm/efr32_slwstk6061a/doc/efr32_slwstk6061a.rst
@@ -145,6 +145,17 @@ Connect the EFR32-SLWSTK6061A to your host computer using the USB port and you
 should see a USB Serial Port. Use `J-Link`_ or Silicon Labs Simplicity Studio
 to flash the generated zephyr.bin.
 
+`OpenOCD`_ included in the Zephyr SDK v0.9.3 is too old and does not support the
+EFR32FG1P chip, neither does the latest OpenOCD 0.10.0 release. You will need to
+compile the newest version of the source code and install the tool yourself.
+Modify the following command if you install OpenOCD to a location different than
+the default /usr/local/.
+
+.. code-block:: console
+
+   cmake -GNinja -DBOARD=efr32_slwstk6061a -DOPENOCD=/usr/local/bin/openocd -DOPENOCD_DEFAULT_PATH=/usr/local/share/openocd/scripts ..
+   ninja flash
+
 Open a serial terminal (minicom, putty, etc.) with the following settings:
 
 - Speed: 115200
@@ -186,3 +197,6 @@ the following message:
 
 .. _J-Link-Downloads:
    https://www.segger.com/downloads/jlink
+
+.. _OpenOCD:
+    http://openocd.org/

--- a/boards/arm/efr32_slwstk6061a/support/openocd.cfg
+++ b/boards/arm/efr32_slwstk6061a/support/openocd.cfg
@@ -1,0 +1,25 @@
+if {[info exists env(OPENOCD_INTERFACE)]} {
+	set INTERFACE $env(OPENOCD_INTERFACE)
+} else {
+	# By default connect over Debug USB port using the J-Link interface
+	set INTERFACE "jlink"
+}
+
+source [find interface/$INTERFACE.cfg]
+
+transport select swd
+
+set CHIPNAME efr32fg1p
+
+source [find target/efm32.cfg]
+
+$_TARGETNAME configure -event gdb-attach {
+	echo "Debugger attaching: halting execution"
+	reset halt
+	gdb_breakpoint_override hard
+}
+
+$_TARGETNAME configure -event gdb-detach {
+	echo "Debugger detaching: resuming execution"
+	resume
+}


### PR DESCRIPTION
The version of OpenOCD provided by Zephyr SDK is too old and does not
contain support for EFR32FG1P chip. This patch assumes that user
compiles and installs the newest version of OpenOCD.

Signed-off-by: Piotr Mienkowski <piotr.mienkowski@gmail.com>