### PR TITLE
arch: st_stm32: Fix IRQs number of various SoCs

### DIFF
--- a/arch/arm/soc/st_stm32/stm32f0/Kconfig.defconfig.stm32f051x8
+++ b/arch/arm/soc/st_stm32/stm32f0/Kconfig.defconfig.stm32f051x8
@@ -13,6 +13,6 @@ config SOC
 
 config NUM_IRQS
 	int
-	default 29
+	default 31
 
 endif # SOC_STM32F051X8

--- a/arch/arm/soc/st_stm32/stm32f0/Kconfig.defconfig.stm32f091xc
+++ b/arch/arm/soc/st_stm32/stm32f0/Kconfig.defconfig.stm32f091xc
@@ -13,6 +13,6 @@ config SOC
 
 config NUM_IRQS
 	int
-	default 32
+	default 31
 
 endif # SOC_STM32F091XC

--- a/arch/arm/soc/st_stm32/stm32f1/Kconfig.defconfig.stm32f103xx
+++ b/arch/arm/soc/st_stm32/stm32f1/Kconfig.defconfig.stm32f103xx
@@ -13,7 +13,7 @@ config SOC
 
 config NUM_IRQS
 	int
-	default 59
+	default 43
 
 if GPIO_STM32
 
@@ -32,7 +32,7 @@ config SOC
 
 config NUM_IRQS
 	int
-	default 68
+	default 60
 
 if GPIO_STM32
 

--- a/arch/arm/soc/st_stm32/stm32f2/Kconfig.defconfig.stm32f207xx
+++ b/arch/arm/soc/st_stm32/stm32f2/Kconfig.defconfig.stm32f207xx
@@ -13,6 +13,6 @@ config SOC
 
 config NUM_IRQS
 	int
-	default 80
+	default 81
 
 endif

--- a/arch/arm/soc/st_stm32/stm32f4/Kconfig.defconfig.stm32f411xe
+++ b/arch/arm/soc/st_stm32/stm32f4/Kconfig.defconfig.stm32f411xe
@@ -13,6 +13,6 @@ config SOC
 
 config NUM_IRQS
 	int
-	default 85
+	default 86
 
 endif # SOC_STM32F411XE

--- a/arch/arm/soc/st_stm32/stm32f4/Kconfig.defconfig.stm32f446xe
+++ b/arch/arm/soc/st_stm32/stm32f4/Kconfig.defconfig.stm32f446xe
@@ -13,7 +13,7 @@ config SOC
 
 config NUM_IRQS
 	int
-	default 96
+	default 97
 
 if GPIO_STM32
 

--- a/arch/arm/soc/st_stm32/stm32l4/Kconfig.defconfig.stm32l432xx
+++ b/arch/arm/soc/st_stm32/stm32l4/Kconfig.defconfig.stm32l432xx
@@ -14,7 +14,7 @@ config SOC
 
 config NUM_IRQS
 	int
-	default 82
+	default 83
 
 if GPIO_STM32
 


### PR DESCRIPTION
It corrects the IRQs number of various SoCs.
IRQs number is in conformity with the IRQn_Type
enumeration in SoC header files of STM32Cube
HAL.

Signed-off-by: Yannis Damigos <giannis.damigos@gmail.com>