### PR TITLE
Fix compile warnings associated with compiler defined types

### DIFF
--- a/drivers/bluetooth/hci/spi.c
+++ b/drivers/bluetooth/hci/spi.c
@@ -161,7 +161,7 @@ static inline u16_t bt_spi_get_evt(u8_t *rxmsg)
 }
 
 static void bt_spi_isr(struct device *unused1, struct gpio_callback *unused2,
-		       unsigned int unused3)
+		       u32_t unused3)
 {
 	BT_DBG("");
 

--- a/kernel/msg_q.c
+++ b/kernel/msg_q.c
@@ -71,8 +71,8 @@ int _impl_k_msgq_alloc_init(struct k_msgq *q, size_t msg_size,
 	int ret;
 	size_t total_size;
 
-	if (__builtin_umul_overflow((u32_t)msg_size, max_msgs,
-				    (u32_t *)&total_size)) {
+	if (__builtin_umul_overflow((unsigned int)msg_size, max_msgs,
+				    (unsigned int *)&total_size)) {
 		ret = -EINVAL;
 	} else {
 		buffer = z_thread_malloc(total_size);

--- a/lib/mempool/mempool.c
+++ b/lib/mempool/mempool.c
@@ -310,7 +310,7 @@ void _sys_mem_pool_block_free(struct sys_mem_pool_base *p, u32_t level,
 void *sys_mem_pool_alloc(struct sys_mem_pool *p, size_t size)
 {
 	struct sys_mem_pool_block *blk;
-	int level, block;
+	u32_t level, block;
 	char *ret;
 
 	k_mutex_lock(p->mutex, K_FOREVER);

--- a/subsys/usb/usb_device.c
+++ b/subsys/usb/usb_device.c
@@ -1133,7 +1133,8 @@ static struct usb_transfer_data *usb_ep_get_transfer(u8_t ep)
 static void usb_transfer_work(struct k_work *item)
 {
 	struct usb_transfer_data *trans;
-	int ret = 0, bytes;
+	int ret = 0;
+	u32_t bytes;
 	u8_t ep;
 
 	trans = CONTAINER_OF(item, struct usb_transfer_data, work);


### PR DESCRIPTION
Fix compiler warnings that crop up if we try and build zephyr and use the c-types as defined by the compiler.