### PR TITLE
gen_syscalls.py: do not output data to stdout

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -455,7 +455,7 @@ add_custom_command(OUTPUT include/generated/syscall_dispatch.c ${syscall_list_h}
   --json-file        ${syscalls_json}                     # Read this file
   --base-output      include/generated/syscalls           # Write to this dir
   --syscall-dispatch include/generated/syscall_dispatch.c # Write this file
-  > ${syscall_list_h}                                     # Write stdout to this file
+  --syscall-list     ${syscall_list_h}
   WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
   DEPENDS ${syscalls_json}
   )

--- a/scripts/gen_syscalls.py
+++ b/scripts/gen_syscalls.py
@@ -168,6 +168,8 @@ def parse_args():
                         help="Read syscall information from json file")
     parser.add_argument("-d", "--syscall-dispatch", required=True,
                         help="output C system call dispatch table file")
+    parser.add_argument("-l", "--syscall-list", required=True,
+                        help="output C system call list header")
     parser.add_argument("-o", "--base-output", required=True,
                         help="Base output directory for syscall macro headers")
     args = parser.parse_args()
@@ -206,7 +208,8 @@ def main():
     ids.sort()
     ids.extend(["K_SYSCALL_BAD", "K_SYSCALL_LIMIT"])
     handler_defines = "".join([handler_template % name for name in handlers])
-    sys.stdout.write(list_template % (",\n\t".join(ids), handler_defines))
+    with open(args.syscall_list, "w") as fp:
+        fp.write(list_template % (",\n\t".join(ids), handler_defines))
 
     os.makedirs(args.base_output, exist_ok=True)
     for fn, invo_list in invocations.items():


### PR DESCRIPTION
There's no particularly good reason to have one kind of
output from this script to be sent to stdout instead of
a filename specified by parameter, and it makes it
annoying to add debug print() statements.

Signed-off-by: Andrew Boie <andrew.p.boie@intel.com>