### PR TITLE
Spinlockification

### DIFF
--- a/arch/arm/core/thread_abort.c
+++ b/arch/arm/core/thread_abort.c
@@ -49,5 +49,5 @@ void _impl_k_thread_abort(k_tid_t thread)
 	}
 
 	/* The abort handler might have altered the ready queue. */
-	_reschedule(key);
+	_reschedule_irqlock(key);
 }

--- a/arch/arm/core/thread_abort.c
+++ b/arch/arm/core/thread_abort.c
@@ -41,7 +41,7 @@ void _impl_k_thread_abort(k_tid_t thread)
 
 	if (_current == thread) {
 		if ((SCB->ICSR & SCB_ICSR_VECTACTIVE_Msk) == 0) {
-			(void)_Swap(key);
+			(void)_Swap_irqlock(key);
 			CODE_UNREACHABLE;
 		} else {
 			SCB->ICSR |= SCB_ICSR_PENDSVSET_Msk;

--- a/arch/posix/core/posix_core.c
+++ b/arch/posix/core/posix_core.c
@@ -531,7 +531,7 @@ void _impl_k_thread_abort(k_tid_t thread)
 	}
 
 	/* The abort handler might have altered the ready queue. */
-	_reschedule(key);
+	_reschedule_irqlock(key);
 }
 #endif
 

--- a/arch/posix/core/posix_core.c
+++ b/arch/posix/core/posix_core.c
@@ -510,7 +510,7 @@ void _impl_k_thread_abort(k_tid_t thread)
 			thread_idx,
 			__func__);
 
-		(void)_Swap(key);
+		(void)_Swap_irqlock(key);
 		CODE_UNREACHABLE; /* LCOV_EXCL_LINE */
 	}
 

--- a/arch/x86/core/irq_manage.c
+++ b/arch/x86/core/irq_manage.c
@@ -95,7 +95,7 @@ void _arch_isr_direct_footer(int swap)
 			:
 			: "memory"
 			);
-		(void)_Swap(flags);
+		(void)_Swap_irqlock(flags);
 	}
 }
 

--- a/boards/posix/native_posix/irq_handler.c
+++ b/boards/posix/native_posix/irq_handler.c
@@ -112,7 +112,7 @@ void posix_irq_handler(void)
 		&& (hw_irq_ctrl_get_cur_prio() == 256)
 		&& (_kernel.ready_q.cache != _current)) {
 
-		(void)_Swap(irq_lock);
+		(void)_Swap_irqlock(irq_lock);
 	}
 }
 

--- a/boards/posix/nrf52_bsim/irq_handler.c
+++ b/boards/posix/nrf52_bsim/irq_handler.c
@@ -170,7 +170,7 @@ void posix_irq_handler(void)
 		&& (CPU_will_be_awaken_from_WFE == false)
 		&& (_kernel.ready_q.cache != _current)) {
 
-		_Swap(irq_lock);
+		_Swap_irqlock(irq_lock);
 	}
 }
 

--- a/include/kernel.h
+++ b/include/kernel.h
@@ -3631,6 +3631,7 @@ struct k_pipe {
 	size_t         bytes_used;      /**< # bytes used in buffer */
 	size_t         read_index;      /**< Where in buffer to read from */
 	size_t         write_index;     /**< Where in buffer to write */
+	struct k_spinlock lock;		/**< Synchronization lock */
 
 	struct {
 		_wait_q_t      readers; /**< Reader wait queue */

--- a/include/kernel.h
+++ b/include/kernel.h
@@ -2370,6 +2370,7 @@ struct k_lifo {
 
 struct k_stack {
 	_wait_q_t wait_q;
+	struct k_spinlock lock;
 	u32_t *base, *next, *top;
 
 	_OBJECT_TRACING_NEXT_PTR(k_stack)

--- a/include/kernel.h
+++ b/include/kernel.h
@@ -1728,6 +1728,7 @@ static inline u32_t k_uptime_delta_32(s64_t *reftime)
 
 struct k_queue {
 	sys_sflist_t data_q;
+	struct k_spinlock lock;
 	union {
 		_wait_q_t wait_q;
 

--- a/include/kernel.h
+++ b/include/kernel.h
@@ -3449,6 +3449,7 @@ struct k_mbox_msg {
 struct k_mbox {
 	_wait_q_t tx_msg_queue;
 	_wait_q_t rx_msg_queue;
+	struct k_spinlock lock;
 
 	_OBJECT_TRACING_NEXT_PTR(k_mbox)
 };

--- a/include/kernel.h
+++ b/include/kernel.h
@@ -3148,6 +3148,7 @@ static inline unsigned int _impl_k_sem_count_get(struct k_sem *sem)
  */
 struct k_msgq {
 	_wait_q_t wait_q;
+	struct k_spinlock lock;
 	size_t msg_size;
 	u32_t max_msgs;
 	char *buffer_start;

--- a/include/kernel.h
+++ b/include/kernel.h
@@ -2526,6 +2526,7 @@ typedef void (*k_work_handler_t)(struct k_work *work);
 struct k_work_q {
 	struct k_queue queue;
 	struct k_thread thread;
+	struct k_spinlock lock;
 };
 
 enum {

--- a/include/kernel_includes.h
+++ b/include/kernel_includes.h
@@ -34,5 +34,6 @@
 #include <arch/cpu.h>
 #include <misc/rb.h>
 #include <sys_clock.h>
+#include <spinlock.h>
 
 #endif /* ZEPHYR_INCLUDE_KERNEL_INCLUDES_H_ */

--- a/include/spinlock.h
+++ b/include/spinlock.h
@@ -81,4 +81,18 @@ static ALWAYS_INLINE void k_spin_unlock(struct k_spinlock *l,
 	_arch_irq_unlock(key.key);
 }
 
+/* Internal function: releases the lock, but leaves local interrupts
+ * disabled
+ */
+static ALWAYS_INLINE void k_spin_release(struct k_spinlock *l)
+{
+#ifdef SPIN_VALIDATE
+	__ASSERT(z_spin_unlock_valid(l), "Not my spinlock!");
+#endif
+#ifdef CONFIG_SMP
+	atomic_clear(&l->locked);
+#endif
+}
+
+
 #endif /* ZEPHYR_INCLUDE_SPINLOCK_H_ */

--- a/include/spinlock.h
+++ b/include/spinlock.h
@@ -8,6 +8,22 @@
 
 #include <atomic.h>
 
+/* These stubs aren't provided by the mocking framework, and I can't
+ * find a proper place to put them as mocking seems not to have a
+ * proper "arch" layer.
+ */
+#ifdef ZTEST_UNITTEST
+static inline int _arch_irq_lock(void)
+{
+	return 0;
+}
+
+static inline void _arch_irq_unlock(int key)
+{
+	ARG_UNUSED(key);
+}
+#endif
+
 #if defined(CONFIG_ASSERT) && (CONFIG_MP_NUM_CPUS < 4)
 #include <misc/__assert.h>
 struct k_spinlock;
@@ -37,6 +53,7 @@ struct k_spinlock {
 
 static ALWAYS_INLINE k_spinlock_key_t k_spin_lock(struct k_spinlock *l)
 {
+	ARG_UNUSED(l);
 	k_spinlock_key_t k;
 
 	/* Note that we need to use the underlying arch-specific lock

--- a/include/spinlock.h
+++ b/include/spinlock.h
@@ -9,7 +9,10 @@
 #include <atomic.h>
 
 #if defined(CONFIG_ASSERT) && (CONFIG_MP_NUM_CPUS < 4)
-#include <kernel_structs.h>
+#include <misc/__assert.h>
+struct k_spinlock;
+int z_spin_lock_valid(struct k_spinlock *l);
+int z_spin_unlock_valid(struct k_spinlock *l);
 #define SPIN_VALIDATE
 #endif
 
@@ -43,11 +46,7 @@ static ALWAYS_INLINE k_spinlock_key_t k_spin_lock(struct k_spinlock *l)
 	k.key = _arch_irq_lock();
 
 #ifdef SPIN_VALIDATE
-	if (l->thread_cpu) {
-		__ASSERT((l->thread_cpu & 3) != _current_cpu->id,
-			 "Recursive spinlock");
-	}
-	l->thread_cpu = _current_cpu->id | (u32_t)_current;
+	__ASSERT(z_spin_lock_valid(l), "Recursive spinlock");
 #endif
 
 #ifdef CONFIG_SMP
@@ -61,12 +60,10 @@ static ALWAYS_INLINE k_spinlock_key_t k_spin_lock(struct k_spinlock *l)
 static ALWAYS_INLINE void k_spin_unlock(struct k_spinlock *l,
 					k_spinlock_key_t key)
 {
+	ARG_UNUSED(l);
 #ifdef SPIN_VALIDATE
-	__ASSERT(l->thread_cpu == (_current_cpu->id | (u32_t)_current),
-		 "Not my spinlock!");
-	l->thread_cpu = 0;
+	__ASSERT(z_spin_unlock_valid(l), "Not my spinlock!");
 #endif
-
 
 #ifdef CONFIG_SMP
 	/* Strictly we don't need atomic_clear() here (which is an
@@ -86,6 +83,7 @@ static ALWAYS_INLINE void k_spin_unlock(struct k_spinlock *l,
  */
 static ALWAYS_INLINE void k_spin_release(struct k_spinlock *l)
 {
+	ARG_UNUSED(l);
 #ifdef SPIN_VALIDATE
 	__ASSERT(z_spin_unlock_valid(l), "Not my spinlock!");
 #endif

--- a/kernel/include/ksched.h
+++ b/kernel/include/ksched.h
@@ -54,6 +54,16 @@ struct k_thread *_find_first_thread_to_unpend(_wait_q_t *wait_q,
 void idle(void *a, void *b, void *c);
 void z_time_slice(int ticks);
 
+static inline void _pend_curr_unlocked(_wait_q_t *wait_q, s32_t timeout)
+{
+	(void) _pend_curr_irqlock(_arch_irq_lock(), wait_q, timeout);
+}
+
+static inline void _reschedule_unlocked(void)
+{
+	(void) _reschedule_irqlock(_arch_irq_lock());
+}
+
 /* find which one is the next thread to run */
 /* must be called with interrupts locked */
 #ifdef CONFIG_SMP

--- a/kernel/include/ksched.h
+++ b/kernel/include/ksched.h
@@ -38,9 +38,12 @@ void _move_thread_to_end_of_prio_q(struct k_thread *thread);
 void _remove_thread_from_ready_q(struct k_thread *thread);
 int _is_thread_time_slicing(struct k_thread *thread);
 void _unpend_thread_no_timeout(struct k_thread *thread);
-int _pend_current_thread(u32_t key, _wait_q_t *wait_q, s32_t timeout);
+int _pend_curr(struct k_spinlock *lock, k_spinlock_key_t key,
+	       _wait_q_t *wait_q, s32_t timeout);
+int _pend_curr_irqlock(u32_t key, _wait_q_t *wait_q, s32_t timeout);
 void _pend_thread(struct k_thread *thread, _wait_q_t *wait_q, s32_t timeout);
-void _reschedule(u32_t key);
+void _reschedule(struct k_spinlock *lock, k_spinlock_key_t key);
+void _reschedule_irqlock(u32_t key);
 struct k_thread *_unpend_first_thread(_wait_q_t *wait_q);
 void _unpend_thread(struct k_thread *thread);
 int _unpend_all(_wait_q_t *wait_q);
@@ -61,7 +64,6 @@ static ALWAYS_INLINE struct k_thread *_get_next_ready_thread(void)
 	return _kernel.ready_q.cache;
 }
 #endif
-
 
 static inline bool _is_idle_thread(void *entry_point)
 {

--- a/kernel/include/kswap.h
+++ b/kernel/include/kswap.h
@@ -103,6 +103,14 @@ static inline int _Swap(struct k_spinlock *lock, k_spinlock_key_t key)
 	return do_swap(key.key, lock, 1);
 }
 
+static inline void _Swap_unlocked(void)
+{
+	struct k_spinlock lock = {};
+	k_spinlock_key_t key = k_spin_lock(&lock);
+
+	(void) _Swap(&lock, key);
+}
+
 #else /* !CONFIG_USE_SWITCH */
 
 extern int __swap(unsigned int key);
@@ -135,6 +143,11 @@ static ALWAYS_INLINE int _Swap(struct k_spinlock *lock, k_spinlock_key_t key)
 {
 	k_spin_release(lock);
 	return _Swap_irqlock(key.key);
+}
+
+static inline void _Swap_unlocked(void)
+{
+	(void) _Swap_irqlock(_arch_irq_lock());
 }
 
 #endif

--- a/kernel/init.c
+++ b/kernel/init.c
@@ -391,7 +391,7 @@ static void switch_to_main_thread(void)
 	 * will never be rescheduled in.
 	 */
 
-	(void)_Swap(irq_lock());
+	(void)_Swap_irqlock(irq_lock());
 #endif
 }
 #endif /* CONFIG_MULTITHREADING */

--- a/kernel/init.c
+++ b/kernel/init.c
@@ -390,8 +390,7 @@ static void switch_to_main_thread(void)
 	 * current fake thread is not on a wait queue or ready queue, so it
 	 * will never be rescheduled in.
 	 */
-
-	(void)_Swap_irqlock(irq_lock());
+	_Swap_unlocked();
 #endif
 }
 #endif /* CONFIG_MULTITHREADING */

--- a/kernel/mailbox.c
+++ b/kernel/mailbox.c
@@ -105,6 +105,7 @@ void k_mbox_init(struct k_mbox *mbox_ptr)
 {
 	_waitq_init(&mbox_ptr->tx_msg_queue);
 	_waitq_init(&mbox_ptr->rx_msg_queue);
+	mbox_ptr->lock = (struct k_spinlock) {};
 	SYS_TRACING_OBJ_INIT(k_mbox, mbox_ptr);
 }
 
@@ -178,7 +179,6 @@ static void mbox_message_dispose(struct k_mbox_msg *rx_msg)
 {
 	struct k_thread *sending_thread;
 	struct k_mbox_msg *tx_msg;
-	unsigned int key;
 
 	/* do nothing if message was disposed of when it was received */
 	if (rx_msg->_syncing_thread == NULL) {
@@ -216,11 +216,10 @@ static void mbox_message_dispose(struct k_mbox_msg *rx_msg)
 #endif
 
 	/* synchronous send: wake up sending thread */
-	key = irq_lock();
 	_set_thread_return_value(sending_thread, 0);
 	_mark_thread_as_not_pending(sending_thread);
 	_ready_thread(sending_thread);
-	_reschedule_irqlock(key);
+	_reschedule_unlocked();
 }
 
 /**
@@ -243,7 +242,7 @@ static int mbox_message_put(struct k_mbox *mbox, struct k_mbox_msg *tx_msg,
 	struct k_thread *sending_thread;
 	struct k_thread *receiving_thread;
 	struct k_mbox_msg *rx_msg;
-	unsigned int key;
+	k_spinlock_key_t key;
 
 	/* save sender id so it can be used during message matching */
 	tx_msg->rx_source_thread = _current;
@@ -253,7 +252,7 @@ static int mbox_message_put(struct k_mbox *mbox, struct k_mbox_msg *tx_msg,
 	sending_thread->base.swap_data = tx_msg;
 
 	/* search mailbox's rx queue for a compatible receiver */
-	key = irq_lock();
+	key = k_spin_lock(&mbox->lock);
 
 	_WAIT_Q_FOR_EACH(&mbox->rx_msg_queue, receiving_thread) {
 		rx_msg = (struct k_mbox_msg *)receiving_thread->base.swap_data;
@@ -276,7 +275,7 @@ static int mbox_message_put(struct k_mbox *mbox, struct k_mbox_msg *tx_msg,
 			 */
 			if ((sending_thread->base.thread_state & _THREAD_DUMMY)
 			    != 0) {
-				_reschedule_irqlock(key);
+				_reschedule(&mbox->lock, key);
 				return 0;
 			}
 #endif
@@ -285,14 +284,14 @@ static int mbox_message_put(struct k_mbox *mbox, struct k_mbox_msg *tx_msg,
 			 * synchronous send: pend current thread (unqueued)
 			 * until the receiver consumes the message
 			 */
-			return _pend_curr_irqlock(key, NULL, K_FOREVER);
+			return _pend_curr(&mbox->lock, key, NULL, K_FOREVER);
 
 		}
 	}
 
 	/* didn't find a matching receiver: don't wait for one */
 	if (timeout == K_NO_WAIT) {
-		irq_unlock(key);
+		k_spin_unlock(&mbox->lock, key);
 		return -ENOMSG;
 	}
 
@@ -300,13 +299,13 @@ static int mbox_message_put(struct k_mbox *mbox, struct k_mbox_msg *tx_msg,
 	/* asynchronous send: dummy thread waits on tx queue for receiver */
 	if ((sending_thread->base.thread_state & _THREAD_DUMMY) != 0) {
 		_pend_thread(sending_thread, &mbox->tx_msg_queue, K_FOREVER);
-		irq_unlock(key);
+		k_spin_unlock(&mbox->lock, key);
 		return 0;
 	}
 #endif
 
 	/* synchronous send: sender waits on tx queue for receiver or timeout */
-	return _pend_curr_irqlock(key, &mbox->tx_msg_queue, timeout);
+	return _pend_curr(&mbox->lock, key, &mbox->tx_msg_queue, timeout);
 }
 
 int k_mbox_put(struct k_mbox *mbox, struct k_mbox_msg *tx_msg, s32_t timeout)
@@ -425,14 +424,14 @@ int k_mbox_get(struct k_mbox *mbox, struct k_mbox_msg *rx_msg, void *buffer,
 {
 	struct k_thread *sending_thread;
 	struct k_mbox_msg *tx_msg;
-	unsigned int key;
+	k_spinlock_key_t key;
 	int result;
 
 	/* save receiver id so it can be used during message matching */
 	rx_msg->tx_target_thread = _current;
 
 	/* search mailbox's tx queue for a compatible sender */
-	key = irq_lock();
+	key = k_spin_lock(&mbox->lock);
 
 	_WAIT_Q_FOR_EACH(&mbox->tx_msg_queue, sending_thread) {
 		tx_msg = (struct k_mbox_msg *)sending_thread->base.swap_data;
@@ -441,7 +440,7 @@ int k_mbox_get(struct k_mbox *mbox, struct k_mbox_msg *rx_msg, void *buffer,
 			/* take sender out of mailbox's tx queue */
 			_unpend_thread(sending_thread);
 
-			irq_unlock(key);
+			k_spin_unlock(&mbox->lock, key);
 
 			/* consume message data immediately, if needed */
 			return mbox_message_data_check(rx_msg, buffer);
@@ -452,13 +451,13 @@ int k_mbox_get(struct k_mbox *mbox, struct k_mbox_msg *rx_msg, void *buffer,
 
 	if (timeout == K_NO_WAIT) {
 		/* don't wait for a matching sender to appear */
-		irq_unlock(key);
+		k_spin_unlock(&mbox->lock, key);
 		return -ENOMSG;
 	}
 
 	/* wait until a matching sender appears or a timeout occurs */
 	_current->base.swap_data = rx_msg;
-	result = _pend_curr_irqlock(key, &mbox->rx_msg_queue, timeout);
+	result = _pend_curr(&mbox->lock, key, &mbox->rx_msg_queue, timeout);
 
 	/* consume message data immediately, if needed */
 	if (result == 0) {

--- a/kernel/mem_slab.c
+++ b/kernel/mem_slab.c
@@ -109,7 +109,7 @@ int k_mem_slab_alloc(struct k_mem_slab *slab, void **mem, s32_t timeout)
 		result = -ENOMEM;
 	} else {
 		/* wait for a free block or timeout */
-		result = _pend_current_thread(key, &slab->wait_q, timeout);
+		result = _pend_curr_irqlock(key, &slab->wait_q, timeout);
 		if (result == 0) {
 			*mem = _current->base.swap_data;
 		}
@@ -129,7 +129,7 @@ void k_mem_slab_free(struct k_mem_slab *slab, void **mem)
 	if (pending_thread != NULL) {
 		_set_thread_return_value_with_data(pending_thread, 0, *mem);
 		_ready_thread(pending_thread);
-		_reschedule(key);
+		_reschedule_irqlock(key);
 	} else {
 		**(char ***)mem = slab->free_list;
 		slab->free_list = *(char **)mem;

--- a/kernel/mem_slab.c
+++ b/kernel/mem_slab.c
@@ -17,6 +17,8 @@
 extern struct k_mem_slab _k_mem_slab_list_start[];
 extern struct k_mem_slab _k_mem_slab_list_end[];
 
+static struct k_spinlock lock;
+
 #ifdef CONFIG_OBJECT_TRACING
 struct k_mem_slab *_trace_list_k_mem_slab;
 #endif	/* CONFIG_OBJECT_TRACING */
@@ -90,7 +92,7 @@ void k_mem_slab_init(struct k_mem_slab *slab, void *buffer,
 
 int k_mem_slab_alloc(struct k_mem_slab *slab, void **mem, s32_t timeout)
 {
-	unsigned int key = irq_lock();
+	k_spinlock_key_t key = k_spin_lock(&lock);
 	int result;
 
 	/* block size must be word aligned */
@@ -109,31 +111,31 @@ int k_mem_slab_alloc(struct k_mem_slab *slab, void **mem, s32_t timeout)
 		result = -ENOMEM;
 	} else {
 		/* wait for a free block or timeout */
-		result = _pend_curr_irqlock(key, &slab->wait_q, timeout);
+		result = _pend_curr(&lock, key, &slab->wait_q, timeout);
 		if (result == 0) {
 			*mem = _current->base.swap_data;
 		}
 		return result;
 	}
 
-	irq_unlock(key);
+	k_spin_unlock(&lock, key);
 
 	return result;
 }
 
 void k_mem_slab_free(struct k_mem_slab *slab, void **mem)
 {
-	int key = irq_lock();
+	k_spinlock_key_t key = k_spin_lock(&lock);
 	struct k_thread *pending_thread = _unpend_first_thread(&slab->wait_q);
 
 	if (pending_thread != NULL) {
 		_set_thread_return_value_with_data(pending_thread, 0, *mem);
 		_ready_thread(pending_thread);
-		_reschedule_irqlock(key);
+		_reschedule(&lock, key);
 	} else {
 		**(char ***)mem = slab->free_list;
 		slab->free_list = *(char **)mem;
 		slab->num_used--;
-		irq_unlock(key);
+		k_spin_unlock(&lock, key);
 	}
 }

--- a/kernel/mempool.c
+++ b/kernel/mempool.c
@@ -90,7 +90,7 @@ int k_mem_pool_alloc(struct k_mem_pool *p, struct k_mem_block *block,
 			return ret;
 		}
 
-		(void)_pend_current_thread(irq_lock(), &p->wait_q, timeout);
+		(void)_pend_curr_irqlock(irq_lock(), &p->wait_q, timeout);
 
 		if (timeout != K_FOREVER) {
 			timeout = end - z_tick_get();
@@ -119,7 +119,7 @@ void k_mem_pool_free_id(struct k_mem_block_id *id)
 	need_sched = _unpend_all(&p->wait_q);
 
 	if (need_sched && !_is_in_isr()) {
-		_reschedule(key);
+		_reschedule_irqlock(key);
 	} else {
 		irq_unlock(key);
 	}

--- a/kernel/mempool.c
+++ b/kernel/mempool.c
@@ -90,7 +90,7 @@ int k_mem_pool_alloc(struct k_mem_pool *p, struct k_mem_block *block,
 			return ret;
 		}
 
-		(void)_pend_curr_irqlock(irq_lock(), &p->wait_q, timeout);
+		_pend_curr_unlocked(&p->wait_q, timeout);
 
 		if (timeout != K_FOREVER) {
 			timeout = end - z_tick_get();

--- a/kernel/msg_q.c
+++ b/kernel/msg_q.c
@@ -127,7 +127,7 @@ int _impl_k_msgq_put(struct k_msgq *q, void *data, s32_t timeout)
 			/* wake up waiting thread */
 			_set_thread_return_value(pending_thread, 0);
 			_ready_thread(pending_thread);
-			_reschedule(key);
+			_reschedule_irqlock(key);
 			return 0;
 		} else {
 			/* put message in queue */
@@ -145,7 +145,7 @@ int _impl_k_msgq_put(struct k_msgq *q, void *data, s32_t timeout)
 	} else {
 		/* wait for put message success, failure, or timeout */
 		_current->base.swap_data = data;
-		return _pend_current_thread(key, &q->wait_q, timeout);
+		return _pend_curr_irqlock(key, &q->wait_q, timeout);
 	}
 
 	irq_unlock(key);
@@ -216,7 +216,7 @@ int _impl_k_msgq_get(struct k_msgq *q, void *data, s32_t timeout)
 			/* wake up waiting thread */
 			_set_thread_return_value(pending_thread, 0);
 			_ready_thread(pending_thread);
-			_reschedule(key);
+			_reschedule_irqlock(key);
 			return 0;
 		}
 		result = 0;
@@ -226,7 +226,7 @@ int _impl_k_msgq_get(struct k_msgq *q, void *data, s32_t timeout)
 	} else {
 		/* wait for get message success or timeout */
 		_current->base.swap_data = data;
-		return _pend_current_thread(key, &q->wait_q, timeout);
+		return _pend_curr_irqlock(key, &q->wait_q, timeout);
 	}
 
 	irq_unlock(key);
@@ -291,7 +291,7 @@ void _impl_k_msgq_purge(struct k_msgq *q)
 	q->used_msgs = 0;
 	q->read_ptr = q->write_ptr;
 
-	_reschedule(key);
+	_reschedule_irqlock(key);
 }
 
 #ifdef CONFIG_USERSPACE

--- a/kernel/mutex.c
+++ b/kernel/mutex.c
@@ -45,6 +45,13 @@
 extern struct k_mutex _k_mutex_list_start[];
 extern struct k_mutex _k_mutex_list_end[];
 
+/* We use a global spinlock here because some of the synchronization
+ * is protecting things like owner thread priorities which aren't
+ * "part of" a single k_mutex.  Should move those bits of the API
+ * under the scheduler lock so we can break this up.
+ */
+static struct k_spinlock lock;
+
 #ifdef CONFIG_OBJECT_TRACING
 
 struct k_mutex *_trace_list_k_mutex;
@@ -117,7 +124,7 @@ static void adjust_owner_prio(struct k_mutex *mutex, s32_t new_prio)
 int _impl_k_mutex_lock(struct k_mutex *mutex, s32_t timeout)
 {
 	int new_prio;
-	u32_t key;
+	k_spinlock_key_t key;
 
 	sys_trace_void(SYS_TRACE_ID_MUTEX_LOCK);
 	_sched_lock();
@@ -154,7 +161,7 @@ int _impl_k_mutex_lock(struct k_mutex *mutex, s32_t timeout)
 	new_prio = new_prio_for_inheritance(_current->base.prio,
 					    mutex->owner->base.prio);
 
-	key = irq_lock();
+	key = k_spin_lock(&lock);
 
 	K_DEBUG("adjusting prio up on mutex %p\n", mutex);
 
@@ -162,7 +169,7 @@ int _impl_k_mutex_lock(struct k_mutex *mutex, s32_t timeout)
 		adjust_owner_prio(mutex, new_prio);
 	}
 
-	s32_t got_mutex = _pend_curr_irqlock(key, &mutex->wait_q, timeout);
+	int got_mutex = _pend_curr(&lock, key, &mutex->wait_q, timeout);
 
 	K_DEBUG("on mutex %p got_mutex value: %d\n", mutex, got_mutex);
 
@@ -188,9 +195,9 @@ int _impl_k_mutex_lock(struct k_mutex *mutex, s32_t timeout)
 
 	K_DEBUG("adjusting prio down on mutex %p\n", mutex);
 
-	key = irq_lock();
+	key = k_spin_lock(&lock);
 	adjust_owner_prio(mutex, new_prio);
-	irq_unlock(key);
+	k_spin_unlock(&lock, key);
 
 	k_sched_unlock();
 
@@ -208,7 +215,6 @@ Z_SYSCALL_HANDLER(k_mutex_lock, mutex, timeout)
 
 void _impl_k_mutex_unlock(struct k_mutex *mutex)
 {
-	u32_t key;
 	struct k_thread *new_owner;
 
 	__ASSERT(mutex->lock_count > 0U, "");
@@ -227,7 +233,7 @@ void _impl_k_mutex_unlock(struct k_mutex *mutex)
 		goto k_mutex_unlock_return;
 	}
 
-	key = irq_lock();
+	k_spinlock_key_t key = k_spin_lock(&lock);
 
 	adjust_owner_prio(mutex, mutex->owner_orig_prio);
 
@@ -241,7 +247,7 @@ void _impl_k_mutex_unlock(struct k_mutex *mutex)
 	if (new_owner != NULL) {
 		_ready_thread(new_owner);
 
-		irq_unlock(key);
+		k_spin_unlock(&lock, key);
 
 		_set_thread_return_value(new_owner, 0);
 
@@ -253,9 +259,9 @@ void _impl_k_mutex_unlock(struct k_mutex *mutex)
 		mutex->owner_orig_prio = new_owner->base.prio;
 	} else {
 		mutex->lock_count = 0;
+		k_spin_unlock(&lock, key);
 	}
 
-	irq_unlock(key);
 
 k_mutex_unlock_return:
 	k_sched_unlock();

--- a/kernel/mutex.c
+++ b/kernel/mutex.c
@@ -162,7 +162,7 @@ int _impl_k_mutex_lock(struct k_mutex *mutex, s32_t timeout)
 		adjust_owner_prio(mutex, new_prio);
 	}
 
-	s32_t got_mutex = _pend_current_thread(key, &mutex->wait_q, timeout);
+	s32_t got_mutex = _pend_curr_irqlock(key, &mutex->wait_q, timeout);
 
 	K_DEBUG("on mutex %p got_mutex value: %d\n", mutex, got_mutex);
 

--- a/kernel/pipes.c
+++ b/kernel/pipes.c
@@ -548,7 +548,7 @@ int _k_pipe_put_internal(struct k_pipe *pipe, struct k_pipe_async *async_desc,
 
 		_pend_thread((struct k_thread *) &async_desc->thread,
 			     &pipe->wait_q.writers, K_FOREVER);
-		_reschedule(key);
+		_reschedule_irqlock(key);
 		return 0;
 	}
 #endif
@@ -566,7 +566,7 @@ int _k_pipe_put_internal(struct k_pipe *pipe, struct k_pipe_async *async_desc,
 		 */
 		key = irq_lock();
 		_sched_unlock_no_reschedule();
-		(void)_pend_current_thread(key, &pipe->wait_q.writers, timeout);
+		(void)_pend_curr_irqlock(key, &pipe->wait_q.writers, timeout);
 	} else {
 		k_sched_unlock();
 	}
@@ -708,7 +708,7 @@ int _impl_k_pipe_get(struct k_pipe *pipe, void *data, size_t bytes_to_read,
 		_current->base.swap_data = &pipe_desc;
 		key = irq_lock();
 		_sched_unlock_no_reschedule();
-		(void)_pend_current_thread(key, &pipe->wait_q.readers, timeout);
+		(void)_pend_curr_irqlock(key, &pipe->wait_q.readers, timeout);
 	} else {
 		k_sched_unlock();
 	}

--- a/kernel/poll.c
+++ b/kernel/poll.c
@@ -231,7 +231,7 @@ int _impl_k_poll(struct k_poll_event *events, int num_events, s32_t timeout)
 
 	_wait_q_t wait_q = _WAIT_Q_INIT(&wait_q);
 
-	int swap_rc = _pend_current_thread(key, &wait_q, timeout);
+	int swap_rc = _pend_curr_irqlock(key, &wait_q, timeout);
 
 	/*
 	 * Clear all event registrations. If events happen while we're in this
@@ -424,7 +424,7 @@ int _impl_k_poll_signal_raise(struct k_poll_signal *signal, int result)
 
 	int rc = signal_poll_event(poll_event, K_POLL_STATE_SIGNALED);
 
-	_reschedule(key);
+	_reschedule_irqlock(key);
 	return rc;
 }
 

--- a/kernel/queue.c
+++ b/kernel/queue.c
@@ -85,6 +85,7 @@ SYS_INIT(init_queue_module, PRE_KERNEL_1, CONFIG_KERNEL_INIT_PRIORITY_OBJECTS);
 void _impl_k_queue_init(struct k_queue *queue)
 {
 	sys_sflist_init(&queue->data_q);
+	queue->lock = (struct k_spinlock) {};
 	_waitq_init(&queue->wait_q);
 #if defined(CONFIG_POLL)
 	sys_dlist_init(&queue->poll_events);
@@ -122,7 +123,7 @@ static inline void handle_poll_events(struct k_queue *queue, u32_t state)
 
 void _impl_k_queue_cancel_wait(struct k_queue *queue)
 {
-	u32_t key = irq_lock();
+	k_spinlock_key_t key = k_spin_lock(&queue->lock);
 #if !defined(CONFIG_POLL)
 	struct k_thread *first_pending_thread;
 
@@ -135,7 +136,7 @@ void _impl_k_queue_cancel_wait(struct k_queue *queue)
 	handle_poll_events(queue, K_POLL_STATE_CANCELLED);
 #endif /* !CONFIG_POLL */
 
-	_reschedule_irqlock(key);
+	_reschedule(&queue->lock, key);
 }
 
 #ifdef CONFIG_USERSPACE
@@ -146,7 +147,7 @@ Z_SYSCALL_HANDLER1_SIMPLE_VOID(k_queue_cancel_wait, K_OBJ_QUEUE,
 static s32_t queue_insert(struct k_queue *queue, void *prev, void *data,
 			  bool alloc)
 {
-	u32_t key = irq_lock();
+	k_spinlock_key_t key = k_spin_lock(&queue->lock);
 #if !defined(CONFIG_POLL)
 	struct k_thread *first_pending_thread;
 
@@ -154,7 +155,7 @@ static s32_t queue_insert(struct k_queue *queue, void *prev, void *data,
 
 	if (first_pending_thread != NULL) {
 		prepare_thread_to_run(first_pending_thread, data);
-		_reschedule_irqlock(key);
+		_reschedule(&queue->lock, key);
 		return 0;
 	}
 #endif /* !CONFIG_POLL */
@@ -165,6 +166,7 @@ static s32_t queue_insert(struct k_queue *queue, void *prev, void *data,
 
 		anode = z_thread_malloc(sizeof(*anode));
 		if (anode == NULL) {
+			k_spin_unlock(&queue->lock, key);
 			return -ENOMEM;
 		}
 		anode->data = data;
@@ -179,7 +181,7 @@ static s32_t queue_insert(struct k_queue *queue, void *prev, void *data,
 	handle_poll_events(queue, K_POLL_STATE_DATA_AVAILABLE);
 #endif /* CONFIG_POLL */
 
-	_reschedule_irqlock(key);
+	_reschedule(&queue->lock, key);
 	return 0;
 }
 
@@ -234,7 +236,7 @@ void k_queue_append_list(struct k_queue *queue, void *head, void *tail)
 {
 	__ASSERT(head && tail, "invalid head or tail");
 
-	unsigned int key = irq_lock();
+	k_spinlock_key_t key = k_spin_lock(&queue->lock);
 #if !defined(CONFIG_POLL)
 	struct k_thread *thread = NULL;
 
@@ -257,7 +259,7 @@ void k_queue_append_list(struct k_queue *queue, void *head, void *tail)
 	handle_poll_events(queue, K_POLL_STATE_DATA_AVAILABLE);
 #endif /* !CONFIG_POLL */
 
-	_reschedule_irqlock(key);
+	_reschedule(&queue->lock, key);
 }
 
 void k_queue_merge_slist(struct k_queue *queue, sys_slist_t *list)
@@ -282,7 +284,7 @@ static void *k_queue_poll(struct k_queue *queue, s32_t timeout)
 {
 	struct k_poll_event event;
 	int err, elapsed = 0, done = 0;
-	unsigned int key;
+	k_spinlock_key_t key;
 	void *val;
 	u32_t start;
 
@@ -302,12 +304,9 @@ static void *k_queue_poll(struct k_queue *queue, s32_t timeout)
 			return NULL;
 		}
 
-		/* sys_sflist_* aren't threadsafe, so must be always protected
-		 * by irq_lock.
-		 */
-		key = irq_lock();
+		key = k_spin_lock(&queue->lock);
 		val = z_queue_node_peek(sys_sflist_get(&queue->data_q), true);
-		irq_unlock(key);
+		k_spin_unlock(&queue->lock, key);
 
 		if ((val == NULL) && (timeout != K_FOREVER)) {
 			elapsed = k_uptime_get_32() - start;
@@ -321,32 +320,30 @@ static void *k_queue_poll(struct k_queue *queue, s32_t timeout)
 
 void *_impl_k_queue_get(struct k_queue *queue, s32_t timeout)
 {
-	unsigned int key;
+	k_spinlock_key_t key = k_spin_lock(&queue->lock);
 	void *data;
-
-	key = irq_lock();
 
 	if (likely(!sys_sflist_is_empty(&queue->data_q))) {
 		sys_sfnode_t *node;
 
 		node = sys_sflist_get_not_empty(&queue->data_q);
 		data = z_queue_node_peek(node, true);
-		irq_unlock(key);
+		k_spin_unlock(&queue->lock, key);
 		return data;
 	}
 
 	if (timeout == K_NO_WAIT) {
-		irq_unlock(key);
+		k_spin_unlock(&queue->lock, key);
 		return NULL;
 	}
 
 #if defined(CONFIG_POLL)
-	irq_unlock(key);
+	k_spin_unlock(&queue->lock, key);
 
 	return k_queue_poll(queue, timeout);
 
 #else
-	int ret = _pend_curr_irqlock(key, &queue->wait_q, timeout);
+	int ret = _pend_curr(&queue->lock, key, &queue->wait_q, timeout);
 
 	return (ret != 0) ? NULL : _current->base.swap_data;
 #endif /* CONFIG_POLL */

--- a/kernel/queue.c
+++ b/kernel/queue.c
@@ -135,7 +135,7 @@ void _impl_k_queue_cancel_wait(struct k_queue *queue)
 	handle_poll_events(queue, K_POLL_STATE_CANCELLED);
 #endif /* !CONFIG_POLL */
 
-	_reschedule(key);
+	_reschedule_irqlock(key);
 }
 
 #ifdef CONFIG_USERSPACE
@@ -154,7 +154,7 @@ static s32_t queue_insert(struct k_queue *queue, void *prev, void *data,
 
 	if (first_pending_thread != NULL) {
 		prepare_thread_to_run(first_pending_thread, data);
-		_reschedule(key);
+		_reschedule_irqlock(key);
 		return 0;
 	}
 #endif /* !CONFIG_POLL */
@@ -179,7 +179,7 @@ static s32_t queue_insert(struct k_queue *queue, void *prev, void *data,
 	handle_poll_events(queue, K_POLL_STATE_DATA_AVAILABLE);
 #endif /* CONFIG_POLL */
 
-	_reschedule(key);
+	_reschedule_irqlock(key);
 	return 0;
 }
 
@@ -257,7 +257,7 @@ void k_queue_append_list(struct k_queue *queue, void *head, void *tail)
 	handle_poll_events(queue, K_POLL_STATE_DATA_AVAILABLE);
 #endif /* !CONFIG_POLL */
 
-	_reschedule(key);
+	_reschedule_irqlock(key);
 }
 
 void k_queue_merge_slist(struct k_queue *queue, sys_slist_t *list)
@@ -346,7 +346,7 @@ void *_impl_k_queue_get(struct k_queue *queue, s32_t timeout)
 	return k_queue_poll(queue, timeout);
 
 #else
-	int ret = _pend_current_thread(key, &queue->wait_q, timeout);
+	int ret = _pend_curr_irqlock(key, &queue->wait_q, timeout);
 
 	return (ret != 0) ? NULL : _current->base.swap_data;
 #endif /* CONFIG_POLL */

--- a/kernel/sched.c
+++ b/kernel/sched.c
@@ -490,7 +490,7 @@ void _thread_priority_set(struct k_thread *thread, int prio)
 	sys_trace_thread_priority_set(thread);
 
 	if (need_sched) {
-		_reschedule_irqlock(irq_lock());
+		_reschedule_unlocked();
 	}
 }
 
@@ -545,7 +545,7 @@ void k_sched_unlock(void)
 	K_DEBUG("scheduler unlocked (%p:%d)\n",
 		_current, _current->base.sched_locked);
 
-	_reschedule_irqlock(irq_lock());
+	_reschedule_unlocked();
 #endif
 }
 
@@ -859,13 +859,7 @@ void _impl_k_yield(void)
 		}
 	}
 
-#ifdef CONFIG_SMP
-	(void)_Swap_irqlock(irq_lock());
-#else
-	if (_get_next_ready_thread() != _current) {
-		(void)_Swap_irqlock(irq_lock());
-	}
-#endif
+	_Swap_unlocked();
 }
 
 #ifdef CONFIG_USERSPACE

--- a/kernel/sched.c
+++ b/kernel/sched.c
@@ -871,7 +871,6 @@ s32_t _impl_k_sleep(s32_t duration)
 #ifdef CONFIG_MULTITHREADING
 	u32_t expected_wakeup_time;
 	s32_t ticks;
-	unsigned int key;
 
 	__ASSERT(!_is_in_isr(), "");
 	__ASSERT(duration != K_FOREVER, "");
@@ -886,12 +885,18 @@ s32_t _impl_k_sleep(s32_t duration)
 
 	ticks = _TICK_ALIGN + _ms_to_ticks(duration);
 	expected_wakeup_time = ticks + z_tick_get_32();
-	key = irq_lock();
+
+	/* Spinlock purely for local interrupt locking to prevent us
+	 * from being interrupted while _current is in an intermediate
+	 * state.  Should unify this implementation with pend().
+	 */
+	struct k_spinlock local_lock = {};
+	k_spinlock_key_t key = k_spin_lock(&local_lock);
 
 	_remove_thread_from_ready_q(_current);
 	_add_thread_timeout(_current, ticks);
 
-	(void)_Swap_irqlock(key);
+	(void)_Swap(&local_lock, key);
 
 	ticks = expected_wakeup_time - z_tick_get_32();
 	if (ticks > 0) {
@@ -917,25 +922,18 @@ Z_SYSCALL_HANDLER(k_sleep, duration)
 
 void _impl_k_wakeup(k_tid_t thread)
 {
-	unsigned int key = irq_lock();
-
-	/* verify first if thread is not waiting on an object */
 	if (_is_thread_pending(thread)) {
-		irq_unlock(key);
 		return;
 	}
 
 	if (_abort_thread_timeout(thread) < 0) {
-		irq_unlock(key);
 		return;
 	}
 
 	_ready_thread(thread);
 
-	if (_is_in_isr()) {
-		irq_unlock(key);
-	} else {
-		_reschedule_irqlock(key);
+	if (!_is_in_isr()) {
+		_reschedule_unlocked();
 	}
 }
 

--- a/kernel/sched.c
+++ b/kernel/sched.c
@@ -434,7 +434,7 @@ int _pend_current_thread(u32_t key, _wait_q_t *wait_q, s32_t timeout)
 	pending_current = _current;
 #endif
 	pend(_current, wait_q, timeout);
-	return _Swap(key);
+	return _Swap_irqlock(key);
 }
 
 struct k_thread *_unpend_first_thread(_wait_q_t *wait_q)
@@ -498,7 +498,7 @@ void _reschedule(u32_t key)
 		goto noswap;
 	}
 
-	(void)_Swap(key);
+	(void)_Swap_irqlock(key);
 	return;
 
  noswap:
@@ -841,10 +841,10 @@ void _impl_k_yield(void)
 	}
 
 #ifdef CONFIG_SMP
-	(void)_Swap(irq_lock());
+	(void)_Swap_irqlock(irq_lock());
 #else
 	if (_get_next_ready_thread() != _current) {
-		(void)_Swap(irq_lock());
+		(void)_Swap_irqlock(irq_lock());
 	}
 #endif
 }
@@ -878,7 +878,7 @@ s32_t _impl_k_sleep(s32_t duration)
 	_remove_thread_from_ready_q(_current);
 	_add_thread_timeout(_current, ticks);
 
-	(void)_Swap(key);
+	(void)_Swap_irqlock(key);
 
 	ticks = expected_wakeup_time - z_tick_get_32();
 	if (ticks > 0) {

--- a/kernel/sched.c
+++ b/kernel/sched.c
@@ -498,15 +498,8 @@ void _reschedule(u32_t key)
 		goto noswap;
 	}
 
-#ifdef CONFIG_SMP
 	(void)_Swap(key);
 	return;
-#else
-	if (_get_next_ready_thread() != _current) {
-		(void)_Swap(key);
-		return;
-	}
-#endif
 
  noswap:
 	irq_unlock(key);

--- a/kernel/sched.c
+++ b/kernel/sched.c
@@ -489,7 +489,7 @@ void _thread_priority_set(struct k_thread *thread, int prio)
 	}
 	sys_trace_thread_priority_set(thread);
 
-	if (need_sched) {
+	if (need_sched && _current->base.sched_locked == 0) {
 		_reschedule_unlocked();
 	}
 }

--- a/kernel/sem.c
+++ b/kernel/sem.c
@@ -119,7 +119,7 @@ void _impl_k_sem_give(struct k_sem *sem)
 	sys_trace_void(SYS_TRACE_ID_SEMA_GIVE);
 	do_sem_give(sem);
 	sys_trace_end_call(SYS_TRACE_ID_SEMA_GIVE);
-	_reschedule(key);
+	_reschedule_irqlock(key);
 }
 
 #ifdef CONFIG_USERSPACE
@@ -148,7 +148,7 @@ int _impl_k_sem_take(struct k_sem *sem, s32_t timeout)
 
 	sys_trace_end_call(SYS_TRACE_ID_SEMA_TAKE);
 
-	return _pend_current_thread(key, &sem->wait_q, timeout);
+	return _pend_curr_irqlock(key, &sem->wait_q, timeout);
 }
 
 #ifdef CONFIG_USERSPACE

--- a/kernel/smp.c
+++ b/kernel/smp.c
@@ -84,9 +84,8 @@ static void smp_init_top(int key, void *arg)
 	};
 
 	_arch_curr_cpu()->current = &dummy_thread;
-	unsigned int k = irq_lock();
 	smp_timer_init();
-	(void)_Swap(k);
+	_Swap_unlocked();
 
 	CODE_UNREACHABLE;
 }

--- a/kernel/stack.c
+++ b/kernel/stack.c
@@ -112,7 +112,7 @@ void _impl_k_stack_push(struct k_stack *stack, u32_t data)
 
 		_set_thread_return_value_with_data(first_pending_thread,
 						   0, (void *)data);
-		_reschedule(key);
+		_reschedule_irqlock(key);
 		return;
 	} else {
 		*(stack->next) = data;
@@ -155,7 +155,7 @@ int _impl_k_stack_pop(struct k_stack *stack, u32_t *data, s32_t timeout)
 		return -EBUSY;
 	}
 
-	result = _pend_current_thread(key, &stack->wait_q, timeout);
+	result = _pend_curr_irqlock(key, &stack->wait_q, timeout);
 	if (result == -EAGAIN) {
 		return -EAGAIN;
 	}

--- a/kernel/thread.c
+++ b/kernel/thread.c
@@ -271,7 +271,7 @@ void _impl_k_thread_start(struct k_thread *thread)
 
 	_mark_thread_as_started(thread);
 	_ready_thread(thread);
-	_reschedule(key);
+	_reschedule_irqlock(key);
 }
 
 #ifdef CONFIG_USERSPACE
@@ -541,7 +541,7 @@ void _impl_k_thread_suspend(struct k_thread *thread)
 	sys_trace_thread_suspend(thread);
 
 	if (thread == _current) {
-		_reschedule(key);
+		_reschedule_irqlock(key);
 	} else {
 		irq_unlock(key);
 	}
@@ -564,7 +564,7 @@ void _impl_k_thread_resume(struct k_thread *thread)
 	_k_thread_single_resume(thread);
 
 	sys_trace_thread_resume(thread);
-	_reschedule(key);
+	_reschedule_irqlock(key);
 }
 
 #ifdef CONFIG_USERSPACE

--- a/kernel/thread.c
+++ b/kernel/thread.c
@@ -540,7 +540,7 @@ void _impl_k_thread_suspend(struct k_thread *thread)
 	sys_trace_thread_suspend(thread);
 
 	if (thread == _current) {
-		(void)_Swap(key);
+		_reschedule(key);
 	} else {
 		irq_unlock(key);
 	}

--- a/kernel/thread_abort.c
+++ b/kernel/thread_abort.c
@@ -37,17 +37,7 @@ void _impl_k_thread_abort(k_tid_t thread)
 	_k_thread_single_abort(thread);
 	_thread_monitor_exit(thread);
 
-	if (_is_in_isr()) {
-		irq_unlock(key);
-	} else {
-		if (_current == thread) {
-			(void)_Swap(key);
-			CODE_UNREACHABLE;
-		}
-
-		/* The abort handler might have altered the ready queue. */
-		_reschedule(key);
-	}
+	_reschedule(key);
 }
 #endif
 

--- a/kernel/thread_abort.c
+++ b/kernel/thread_abort.c
@@ -37,7 +37,7 @@ void _impl_k_thread_abort(k_tid_t thread)
 	_k_thread_single_abort(thread);
 	_thread_monitor_exit(thread);
 
-	_reschedule(key);
+	_reschedule_irqlock(key);
 }
 #endif
 

--- a/kernel/timer.c
+++ b/kernel/timer.c
@@ -172,7 +172,7 @@ void _impl_k_timer_stop(struct k_timer *timer)
 	if (_is_in_isr()) {
 		irq_unlock(key);
 	} else {
-		_reschedule(key);
+		_reschedule_irqlock(key);
 	}
 }
 
@@ -205,7 +205,7 @@ u32_t _impl_k_timer_status_sync(struct k_timer *timer)
 	if (result == 0) {
 		if (!_is_inactive_timeout(&timer->timeout)) {
 			/* wait for timer to expire or stop */
-			(void)_pend_current_thread(key, &timer->wait_q, K_FOREVER);
+			(void)_pend_curr_irqlock(key, &timer->wait_q, K_FOREVER);
 
 			/* get updated timer status */
 			key = irq_lock();

--- a/lib/posix/pthread_barrier.c
+++ b/lib/posix/pthread_barrier.c
@@ -24,9 +24,9 @@ int pthread_barrier_wait(pthread_barrier_t *b)
 		while (_waitq_head(&b->wait_q)) {
 			_ready_one_thread(&b->wait_q);
 		}
-		_reschedule(key);
+		_reschedule_irqlock(key);
 		return 0;
 	} else {
-		return _pend_current_thread(key, &b->wait_q, K_FOREVER);
+		return _pend_curr_irqlock(key, &b->wait_q, K_FOREVER);
 	}
 }

--- a/lib/posix/pthread_cond.c
+++ b/lib/posix/pthread_cond.c
@@ -18,7 +18,7 @@ static int cond_wait(pthread_cond_t *cv, pthread_mutex_t *mut, int timeout)
 	mut->lock_count = 0;
 	mut->owner = NULL;
 	_ready_one_thread(&mut->wait_q);
-	ret = _pend_current_thread(key, &cv->wait_q, timeout);
+	ret = _pend_curr_irqlock(key, &cv->wait_q, timeout);
 
 	/* FIXME: this extra lock (and the potential context switch it
 	 * can cause) could be optimized out.  At the point of the
@@ -49,7 +49,7 @@ int pthread_cond_signal(pthread_cond_t *cv)
 	int key = irq_lock();
 
 	_ready_one_thread(&cv->wait_q);
-	_reschedule(key);
+	_reschedule_irqlock(key);
 
 	return 0;
 }
@@ -62,7 +62,7 @@ int pthread_cond_broadcast(pthread_cond_t *cv)
 		_ready_one_thread(&cv->wait_q);
 	}
 
-	_reschedule(key);
+	_reschedule_irqlock(key);
 
 	return 0;
 }

--- a/lib/posix/pthread_mutex.c
+++ b/lib/posix/pthread_mutex.c
@@ -48,7 +48,7 @@ static int acquire_mutex(pthread_mutex_t *m, int timeout)
 		return EINVAL;
 	}
 
-	rc = _pend_current_thread(key, &m->wait_q, timeout);
+	rc = _pend_curr_irqlock(key, &m->wait_q, timeout);
 	if (rc != 0) {
 		rc = ETIMEDOUT;
 	}
@@ -141,7 +141,7 @@ int pthread_mutex_unlock(pthread_mutex_t *m)
 			m->lock_count++;
 			_ready_thread(thread);
 			_set_thread_return_value(thread, 0);
-			_reschedule(key);
+			_reschedule_irqlock(key);
 			return 0;
 		}
 		m->owner = NULL;

--- a/samples/portability/cmsis_rtos_v2/philosophers/sample.yaml
+++ b/samples/portability/cmsis_rtos_v2/philosophers/sample.yaml
@@ -5,7 +5,7 @@ common:
   tags: cmsis_rtos_v2_philosopher
   min_ram: 32
   min_flash: 34
-  platform_exclude: qemu_xtensa
+  platform_exclude: qemu_xtensa qemu_x86_64
   harness: console
   harness_config:
     type: multi_line

--- a/tests/benchmarks/sched/README.rst
+++ b/tests/benchmarks/sched/README.rst
@@ -6,13 +6,13 @@ latencies (not scaling performance) of specific low level scheduling
 primitives independent of overhead from application or API
 abstractions.  It works very simply: a main thread creates a "partner"
 thread at a higher priority, the partner then sleeps using
-_pend_current_thread().  From this initial state:
+_pend_curr_irqlock().  From this initial state:
 
 1. The main thread calls _unpend_first_thread()
 2. The main thread calls _ready_thread()
 3. The main thread calls k_yield()
    (the kernel switches to the partner thread)
-4. The partner thread then runs and calls _pend_current_thread() again
+4. The partner thread then runs and calls _pend_curr_irqlock() again
    (the kernel switches to the main thread)
 5. The main thread returns from k_yield()
 

--- a/tests/benchmarks/sched/src/main.c
+++ b/tests/benchmarks/sched/src/main.c
@@ -13,14 +13,14 @@
  * of specific low level scheduling primitives independent of overhead
  * from application or API abstractions.  It works very simply: a main
  * thread creates a "partner" thread at a higher priority, the partner
- * then sleeps using _pend_current_thread().  From this initial
+ * then sleeps using _pend_curr_irqlock().  From this initial
  * state:
  *
  * 1. The main thread calls _unpend_first_thread()
  * 2. The main thread calls _ready_thread()
  * 3. The main thread calls k_yield()
  *    (the kernel switches to the partner thread)
- * 4. The partner thread then runs and calls _pend_current_thread() again
+ * 4. The partner thread then runs and calls _pend_curr_irqlock() again
  *    (the kernel switches to the main thread)
  * 5. The main thread returns from k_yield()
  *
@@ -90,7 +90,7 @@ static void partner_fn(void *arg1, void *arg2, void *arg3)
 	while (true) {
 		unsigned int key = irq_lock();
 
-		_pend_current_thread(key, &waitq, K_FOREVER);
+		_pend_curr_irqlock(key, &waitq, K_FOREVER);
 		stamp(PARTNER_AWAKE_PENDING);
 	}
 }

--- a/tests/kernel/fatal/src/main.c
+++ b/tests/kernel/fatal/src/main.c
@@ -141,7 +141,7 @@ void stack_thread2(void)
 	/* Test that stack overflow check due to swap works */
 	blow_up_stack();
 	TC_PRINT("swapping...\n");
-	_Swap(irq_lock());
+	_Swap_irqlock(irq_lock());
 	TC_ERROR("should never see this\n");
 	rv = TC_FAIL;
 	irq_unlock(key);

--- a/tests/kernel/fatal/src/main.c
+++ b/tests/kernel/fatal/src/main.c
@@ -141,7 +141,7 @@ void stack_thread2(void)
 	/* Test that stack overflow check due to swap works */
 	blow_up_stack();
 	TC_PRINT("swapping...\n");
-	_Swap_irqlock(irq_lock());
+	_Swap_unlocked();
 	TC_ERROR("should never see this\n");
 	rv = TC_FAIL;
 	irq_unlock(key);

--- a/tests/kernel/sched/schedule_api/src/main.c
+++ b/tests/kernel/sched/schedule_api/src/main.c
@@ -6,6 +6,10 @@
 
 #include "test_sched.h"
 
+/* Shared threads */
+K_THREAD_STACK_DEFINE(tstack, STACK_SIZE);
+K_THREAD_STACK_ARRAY_DEFINE(tstacks, MAX_NUM_THREAD, STACK_SIZE);
+
 /**
  * @brief Test scheduling
  *

--- a/tests/kernel/sched/schedule_api/src/test_priority_scheduling.c
+++ b/tests/kernel/sched/schedule_api/src/test_priority_scheduling.c
@@ -5,8 +5,8 @@
  */
 
 #include <ztest.h>
+#include "test_sched.h"
 
-#define STACK_SIZE (384 + CONFIG_TEST_EXTRA_STACKSIZE)
 /* nrf 51 has lower ram, so creating less number of threads */
 #if CONFIG_SRAM_SIZE <= 24
 	#define NUM_THREAD 2
@@ -19,7 +19,7 @@
 #define ITRERATION_COUNT 5
 #define BASE_PRIORITY 1
 
-static K_THREAD_STACK_ARRAY_DEFINE(tstack, NUM_THREAD, STACK_SIZE);
+BUILD_ASSERT(NUM_THREAD <= MAX_NUM_THREAD);
 
 /* Semaphore on which Ztest thread wait*/
 static K_SEM_DEFINE(sema2, 0, NUM_THREAD);
@@ -76,7 +76,7 @@ void test_priority_scheduling(void)
 
 	/* Create Threads with different Priority*/
 	for (int i = 0; i < NUM_THREAD; i++) {
-		tid[i] = k_thread_create(&t[i], tstack[i], STACK_SIZE,
+		tid[i] = k_thread_create(&t[i], tstacks[i], STACK_SIZE,
 					 thread_tslice, (void *)(intptr_t) i, NULL, NULL,
 					 K_PRIO_PREEMPT(BASE_PRIORITY + i), 0, 0);
 	}

--- a/tests/kernel/sched/schedule_api/src/test_sched.h
+++ b/tests/kernel/sched/schedule_api/src/test_sched.h
@@ -10,7 +10,12 @@
 #include <zephyr.h>
 #include <ztest.h>
 
-#define STACK_SIZE (512 + CONFIG_TEST_EXTRA_STACKSIZE)
+#define MAX_NUM_THREAD 10
+#define STACK_SIZE (640 + CONFIG_TEST_EXTRA_STACKSIZE)
+
+K_THREAD_STACK_EXTERN(tstack);
+extern k_thread_stack_t
+	tstacks[MAX_NUM_THREAD][K_THREAD_STACK_LEN(STACK_SIZE)];
 
 struct thread_data {
 	k_tid_t tid;

--- a/tests/kernel/sched/schedule_api/src/test_sched_is_preempt_thread.c
+++ b/tests/kernel/sched/schedule_api/src/test_sched_is_preempt_thread.c
@@ -6,12 +6,9 @@
 
 #include <ztest.h>
 #include <irq_offload.h>
-
-/*macro definition*/
-#define STACK_SIZE 512
+#include "test_sched.h"
 
 /*local variables*/
-static K_THREAD_STACK_DEFINE(tstack, STACK_SIZE);
 static struct k_thread tdata;
 static struct k_sem end_sema;
 

--- a/tests/kernel/sched/schedule_api/src/test_sched_priority.c
+++ b/tests/kernel/sched/schedule_api/src/test_sched_priority.c
@@ -6,7 +6,6 @@
 
 #include "test_sched.h"
 
-static K_THREAD_STACK_DEFINE(tstack, STACK_SIZE);
 static struct k_thread tdata;
 static int last_prio;
 

--- a/tests/kernel/sched/schedule_api/src/test_sched_timeslice_and_lock.c
+++ b/tests/kernel/sched/schedule_api/src/test_sched_timeslice_and_lock.c
@@ -7,13 +7,13 @@
 #include "test_sched.h"
 #define THREADS_NUM     3
 #define DURATION	1
-static K_THREAD_STACK_ARRAY_DEFINE(tstack, THREADS_NUM, STACK_SIZE);
+
+BUILD_ASSERT(THREADS_NUM <= MAX_NUM_THREAD);
 
 static struct thread_data tdata[THREADS_NUM];
 static struct k_thread tthread[THREADS_NUM];
 static int old_prio, init_prio;
 
-K_THREAD_STACK_DEFINE(t_stack, STACK_SIZE);
 struct k_thread t;
 
 K_SEM_DEFINE(pend_sema, 0, 1);
@@ -55,7 +55,7 @@ static void setup_threads(void)
 static void spawn_threads(int sleep_sec)
 {
 	for (int i = 0; i < THREADS_NUM; i++) {
-		tdata[i].tid = k_thread_create(&tthread[i], tstack[i],
+		tdata[i].tid = k_thread_create(&tthread[i], tstacks[i],
 					       STACK_SIZE, thread_entry,
 					       (void *)i, (void *)sleep_sec,
 					       NULL, tdata[i].priority, 0, 0);
@@ -208,7 +208,7 @@ void test_pending_thread_wakeup(void)
 	k_thread_priority_set(k_current_get(), K_PRIO_PREEMPT(1));
 
 	/* Create a thread which waits for semaphore */
-	k_tid_t tid = k_thread_create(&t, t_stack, STACK_SIZE,
+	k_tid_t tid = k_thread_create(&t, tstack, STACK_SIZE,
 				      (k_thread_entry_t)coop_thread,
 				      NULL, NULL, NULL,
 				      K_PRIO_COOP(1), 0, 0);
@@ -368,7 +368,7 @@ void test_unlock_preemptible(void)
  */
 void test_wakeup_expired_timer_thread(void)
 {
-	k_tid_t tid = k_thread_create(&tthread[0], t_stack, STACK_SIZE,
+	k_tid_t tid = k_thread_create(&tthread[0], tstack, STACK_SIZE,
 					thread_handler, NULL, NULL, NULL,
 					K_PRIO_PREEMPT(0), 0, 0);
 	k_sem_take(&timer_sema, K_FOREVER);

--- a/tests/kernel/sched/schedule_api/src/test_sched_timeslice_reset.c
+++ b/tests/kernel/sched/schedule_api/src/test_sched_timeslice_reset.c
@@ -7,9 +7,10 @@
 #include <ztest.h>
 #include "test_sched.h"
 
-#define STACK_SIZE (512 + CONFIG_TEST_EXTRA_STACKSIZE)
 #define NUM_THREAD 3
-static K_THREAD_STACK_ARRAY_DEFINE(tstack, NUM_THREAD, STACK_SIZE);
+
+BUILD_ASSERT(NUM_THREAD <= MAX_NUM_THREAD);
+
 /* slice size in millisecond*/
 #define SLICE_SIZE 200
 /* busy for more than one slice*/
@@ -85,7 +86,7 @@ void test_slice_reset(void)
 		k_thread_priority_set(k_current_get(), K_PRIO_PREEMPT(j));
 		/* create delayed threads with equal preemptive priority*/
 		for (int i = 0; i < NUM_THREAD; i++) {
-			tid[i] = k_thread_create(&t[i], tstack[i], STACK_SIZE,
+			tid[i] = k_thread_create(&t[i], tstacks[i], STACK_SIZE,
 						 thread_tslice, NULL, NULL, NULL,
 						 K_PRIO_PREEMPT(j), 0, 0);
 		}

--- a/tests/kernel/sched/schedule_api/src/test_slice_scheduling.c
+++ b/tests/kernel/sched/schedule_api/src/test_slice_scheduling.c
@@ -5,8 +5,8 @@
  */
 
 #include <ztest.h>
+#include "test_sched.h"
 
-#define STACK_SIZE (384 + CONFIG_TEST_EXTRA_STACKSIZE)
 /* nrf 51 has lower ram, so creating less number of threads */
 #if CONFIG_SRAM_SIZE <= 24
 	#define NUM_THREAD 2
@@ -18,7 +18,7 @@
 #endif
 #define BASE_PRIORITY 0
 #define ITRERATION_COUNT 5
-static K_THREAD_STACK_ARRAY_DEFINE(tstack, NUM_THREAD, STACK_SIZE);
+BUILD_ASSERT(NUM_THREAD <= MAX_NUM_THREAD);
 /* slice size in millisecond*/
 #define SLICE_SIZE 200
 /* busy for more than one slice*/
@@ -87,7 +87,7 @@ void test_slice_scheduling(void)
 
 	/* create threads with equal preemptive priority*/
 	for (int i = 0; i < NUM_THREAD; i++) {
-		tid[i] = k_thread_create(&t[i], tstack[i], STACK_SIZE,
+		tid[i] = k_thread_create(&t[i], tstacks[i], STACK_SIZE,
 					 thread_tslice, (void *)(intptr_t) i, NULL, NULL,
 					 K_PRIO_PREEMPT(BASE_PRIORITY), 0, 0);
 	}


### PR DESCRIPTION
Big refactoring to get the kernel internals using spinlocks pervasively.

The interesting patches are early in the series.  Later ones are mostly boilerplate changes.

A few spots have been identified as design points that might need new decisions in the future.  In almost all cases I picked "keep existing synchronization strategy in place" vs. "do the perfect thing".
