### PR TITLE
Bluetooth: SMP Don't return STK if it hasn't been generated yet

### DIFF
--- a/subsys/bluetooth/host/smp.c
+++ b/subsys/bluetooth/host/smp.c
@@ -4412,6 +4412,10 @@ bool bt_smp_get_tk(struct bt_conn *conn, u8_t *tk)
 		return false;
 	}
 
+	if (!atomic_test_bit(smp->flags, SMP_FLAG_ENC_PENDING)) {
+		return false;
+	}
+
 	enc_size = get_encryption_key_size(smp);
 
 	/*


### PR DESCRIPTION
The SMP_FLAG_ENC_PENDING flag indicates that we've generated an STK
and are waiting for encryption to happen. In case the remote enables
encryption prematurely we should not try to encrypt with whatever is
stored in smp->tk, rather reject the pairing attempt.

Fixes #3222

Signed-off-by: Johan Hedberg <johan.hedberg@intel.com>