### PR TITLE
ext: tinycrypt: Update revision

### DIFF
--- a/drivers/crypto/crypto_tc_shim.c
+++ b/drivers/crypto/crypto_tc_shim.c
@@ -61,7 +61,7 @@ static int do_cbc_decrypt(struct cipher_ctx *ctx, struct cipher_pkt *op,
 	if (tc_cbc_mode_decrypt(op->out_buf,
 			op->out_buf_max,
 			op->in_buf + TC_AES_BLOCK_SIZE,
-			op->in_len,
+			op->in_len - TC_AES_BLOCK_SIZE,
 			op->in_buf, &data->session_key) == TC_CRYPTO_FAIL) {
 		SYS_LOG_ERR("Func TC internal error during CBC decryption");
 		return -EIO;

--- a/ext/lib/crypto/tinycrypt/README
+++ b/ext/lib/crypto/tinycrypt/README
@@ -3,7 +3,7 @@ open source project.  The original upstream code can be found at:
 
 https://github.com/01org/tinycrypt
 
-At revision 3a5ca91f28eb586740660daf78fccad44e5a826f, version 0.2.8
+At revision 3ea1a609e7aff9f2d8d13803e1076b7a8e551804, version 0.2.8
 
 Any changes to the local version should include Zephyr's TinyCrypt
 maintainer in the review.  That can be found via the git history.

--- a/ext/lib/crypto/tinycrypt/source/cbc_mode.c
+++ b/ext/lib/crypto/tinycrypt/source/cbc_mode.c
@@ -91,7 +91,7 @@ int tc_cbc_mode_decrypt(uint8_t *out, unsigned int outlen, const uint8_t *in,
 	    outlen == 0 ||
 	    (inlen % TC_AES_BLOCK_SIZE) != 0 ||
 	    (outlen % TC_AES_BLOCK_SIZE) != 0 ||
-	    outlen != inlen - TC_AES_BLOCK_SIZE) {
+	    outlen != inlen) {
 		return TC_CRYPTO_FAIL;
 	}
 
@@ -101,7 +101,7 @@ int tc_cbc_mode_decrypt(uint8_t *out, unsigned int outlen, const uint8_t *in,
 	 * that would not otherwise be possible.
 	 */
 	p = iv;
-	for (n = m = 0; n < inlen; ++n) {
+	for (n = m = 0; n < outlen; ++n) {
 		if ((n % TC_AES_BLOCK_SIZE) == 0) {
 			(void)tc_aes_decrypt(buffer, in, sched);
 			in += TC_AES_BLOCK_SIZE;

--- a/ext/lib/crypto/tinycrypt/source/cmac_mode.c
+++ b/ext/lib/crypto/tinycrypt/source/cmac_mode.c
@@ -36,7 +36,7 @@
 #include <tinycrypt/utils.h>
 
 /* max number of calls until change the key (2^48).*/
-const static uint64_t MAX_CALLS = ((uint64_t)1 << 48);
+static const uint64_t MAX_CALLS = ((uint64_t)1 << 48);
 
 /*
  *  gf_wrap -- In our implementation, GF(2^128) is represented as a 16 byte

--- a/tests/crypto/cbc_mode/src/cbc_mode.c
+++ b/tests/crypto/cbc_mode/src/cbc_mode.c
@@ -140,7 +140,7 @@ void test_sp_800_38a_encrypt_decrypt(void)
 
 	/**TESTPOINT: Check test 2*/
 	zassert_true(tc_cbc_mode_decrypt(decrypted,
-		length - TC_AES_BLOCK_SIZE, p, length, encrypted,
+		length, p, length, encrypted,
 		&a), "CBC test #2 (decryption SP 800-38a tests) failed");
 
 	result = check_result(2, plaintext, sizeof(decrypted),


### PR DESCRIPTION
Update tinycrypt to latest revision, two commits after 0.2.8 release.

These commits are only bug fixes and one of them is fixing incorrect
buffer size in decryption with CBC mode.

This algorithm is being used by tinycrypt shim and is tested in samples/drivers/crypto/.

Signed-off-by: Flavio Ceolin <flavio.ceolin@intel.com>