### PR TITLE
Fix compile errors related to errno.h

### DIFF
--- a/include/kernel.h
+++ b/include/kernel.h
@@ -15,6 +15,7 @@
 
 #if !defined(_ASMLANGUAGE)
 #include <kernel_includes.h>
+#include <errno.h>
 
 #ifdef __cplusplus
 extern "C" {

--- a/include/kernel_includes.h
+++ b/include/kernel_includes.h
@@ -19,7 +19,6 @@
 #include <toolchain.h>
 #include <linker/sections.h>
 #include <atomic.h>
-#include <errno.h>
 #include <misc/__assert.h>
 #include <sched_priq.h>
 #include <misc/dlist.h>


### PR DESCRIPTION
Because errno.h is defined in terms of a syscall we can get into trouble
when one syscall/<FOO.h> ends up include another syscall/<BAR.h>.

Moving errno.h from kernel_includes.h to kernel.h breaks the possible
inclusion issue on some ARM platforms (which arm_mpu.h ends up include
soc.h which ends up include kernel_includes.h which would include
errno.h).

Signed-off-by: Kumar Gala <kumar.gala@linaro.org>