### PR TITLE
Bluetooth: Add connection context to bt_conn.

### DIFF
--- a/include/bluetooth/conn.h
+++ b/include/bluetooth/conn.h
@@ -147,7 +147,19 @@ struct bt_conn_info {
 
 		struct bt_conn_br_info br;
 	};
+
+	void *conn_ctx;
 };
+
+/** @brief Set the connection link context
+ *
+ * @param conn Connection object.
+ * @param context Connection link context.
+ *
+ * @return Zero on success or (negative) error code on failure.
+ *
+ */
+int bt_conn_set_connection_link_context(struct bt_conn *conn, void *context);
 
 /** @brief Get connection info
  *

--- a/subsys/bluetooth/host/conn.c
+++ b/subsys/bluetooth/host/conn.c
@@ -1663,10 +1663,21 @@ const bt_addr_le_t *bt_conn_get_dst(const struct bt_conn *conn)
 	return &conn->le.dst;
 }
 
+int bt_conn_set_connection_link_context(struct bt_conn *conn, void *context)
+{
+	if ((conn == NULL) || (context == NULL)) {
+		return -EINVAL;
+	}
+
+	conn->conn_ctx = context;
+	return 0;
+}
+
 int bt_conn_get_info(const struct bt_conn *conn, struct bt_conn_info *info)
 {
 	info->type = conn->type;
 	info->role = conn->role;
+	info->conn_ctx = conn->conn_ctx;
 
 	switch (conn->type) {
 	case BT_CONN_TYPE_LE:

--- a/subsys/bluetooth/host/conn_internal.h
+++ b/subsys/bluetooth/host/conn_internal.h
@@ -122,6 +122,9 @@ struct bt_conn {
 		struct bt_conn_sco	sco;
 #endif
 	};
+
+	/* Connection context */
+	void *conn_ctx;
 };
 
 /* Process incoming data for a connection */


### PR DESCRIPTION
This will be useful for services that have many
clients and have to switch between them. This would
remove the need of mapping by application the context
data to a bt_conn instance.

Signed-off-by: Kamil Gawor <Kamil.Gawor@nordicsemi.no>