### PR TITLE
kernel: sched: Use ticks as time unit in time slicing.

### DIFF
--- a/kernel/sched.c
+++ b/kernel/sched.c
@@ -641,9 +641,10 @@ void _update_time_slice_before_swap(void)
 	}
 
 	u32_t remaining = _get_remaining_program_time();
+	u32_t time_slice_ticks = _ms_to_ticks(_time_slice_duration);
 
-	if (!remaining || (_time_slice_duration < remaining)) {
-		_set_time(_time_slice_duration);
+	if (!remaining || (_time_slice_ticks < remaining)) {
+		_set_time(_time_slice_ticks);
 	} else {
 		/* Account previous elapsed time and reprogram
 		 * timer with remaining time

--- a/kernel/sys_clock.c
+++ b/kernel/sys_clock.c
@@ -263,8 +263,8 @@ static inline void handle_timeouts(s32_t ticks)
 
 #ifdef CONFIG_TIMESLICING
 s32_t _time_slice_elapsed;
-s32_t _time_slice_duration = CONFIG_TIMESLICE_SIZE;
-int  _time_slice_prio_ceiling = CONFIG_TIMESLICE_PRIORITY;
+s32_t _time_slice_duration;
+int  _time_slice_prio_ceiling;
 
 /*
  * Always called from interrupt level, and always only from the system clock
@@ -285,7 +285,7 @@ static void handle_time_slicing(s32_t ticks)
 		return;
 	}
 
-	_time_slice_elapsed += __ticks_to_ms(ticks);
+	_time_slice_elapsed += ticks;
 	if (_time_slice_elapsed >= _time_slice_duration) {
 
 		unsigned int key;
@@ -297,8 +297,7 @@ static void handle_time_slicing(s32_t ticks)
 		irq_unlock(key);
 	}
 #ifdef CONFIG_TICKLESS_KERNEL
-	next_ts =
-	    _ms_to_ticks(_time_slice_duration - _time_slice_elapsed);
+	next_ts = _time_slice_duration - _time_slice_elapsed;
 #endif
 }
 #else


### PR DESCRIPTION
The time slicing settings was kept in milliseconds while all related operations was based on ticks. Continuous back and forth conversion between ticks and milliseconds introduced an accumulating error due to rounding in _ms_to_ticks() and __ticks_to_ms(). As result configured time slice duration was not achieved.

This PR removes excessive ticks <-> ms conversion by using ticks as time unit for all operations related to time slicing.

Also, it fixes #8896, #8897 and #9310
