### PR TITLE
doc: fix doxygen error for BUILD_ASSERT_MSG

### DIFF
--- a/doc/zephyr.doxyfile.in
+++ b/doc/zephyr.doxyfile.in
@@ -1985,6 +1985,7 @@ PREDEFINED             = "CONFIG_SYS_CLOCK_EXISTS=y" \
                          "NET_MGMT_DEFINE_REQUEST_HANDLER(x)=" \
                          "DEVICE_DEFINE()=" \
                          "DEVICE_AND_API_INIT()=" \
+                         "BUILD_ASSERT_MSG()=" \
                          "__deprecated=" \
                          "__packed=" \
                          "__aligned(x)=" \


### PR DESCRIPTION
Similar to #8042, doxygen has issues with function macros (those that
don't end with a semicolon). Workaround is to have doxygen treat these
as predefined by the doxygen preprocessor.  Fixes a problem showing up
in PR #9140.

Signed-off-by: David B. Kinder <david.b.kinder@intel.com>