### PR TITLE
tests: sched: Enhance tests to improve code coverage

### DIFF
--- a/tests/kernel/sched/schedule_api/src/main.c
+++ b/tests/kernel/sched/schedule_api/src/main.c
@@ -23,7 +23,8 @@ void test_main(void)
 			 ztest_unit_test(test_sched_is_preempt_thread),
 			 ztest_unit_test(test_slice_reset),
 			 ztest_unit_test(test_slice_scheduling),
-			 ztest_unit_test(test_priority_scheduling)
+			 ztest_unit_test(test_priority_scheduling),
+			 ztest_unit_test(test_wakeup_expired_timer_thread)
 			 );
 	ztest_run_test_suite(threads_scheduling);
 }

--- a/tests/kernel/sched/schedule_api/src/test_sched.h
+++ b/tests/kernel/sched/schedule_api/src/test_sched.h
@@ -36,5 +36,6 @@ void test_sched_is_preempt_thread(void);
 void test_slice_reset(void);
 void test_slice_scheduling(void);
 void test_priority_scheduling(void);
+void test_wakeup_expired_timer_thread(void);
 
 #endif /* __TEST_SCHED_H__ */


### PR DESCRIPTION
call k_wakeup() if the timer has expired and the thread
is not even in the sleep state.

Signed-off-by: Ajay Kishore <ajay.kishore@intel.com>