### PR TITLE
Bluetooth: SMP: Fix minor coding style issues

### DIFF
--- a/subsys/bluetooth/host/smp.c
+++ b/subsys/bluetooth/host/smp.c
@@ -723,7 +723,8 @@ static void smp_pairing_br_complete(struct bt_smp_br *smp, u8_t status)
 		}
 
 		if (bt_auth->pairing_complete) {
-			bt_auth->pairing_complete(smp->chan.chan.conn, bond_flag);
+			bt_auth->pairing_complete(smp->chan.chan.conn,
+						  bond_flag);
 		}
 	}
 
@@ -1501,7 +1502,7 @@ static void smp_pairing_complete(struct bt_smp *smp, u8_t status)
 
 		if (bt_auth->pairing_complete) {
 			bt_auth->pairing_complete(smp->chan.chan.conn,
-				bond_flag);
+						  bond_flag);
 		}
 	} else if (bt_auth->pairing_failed) {
 		bt_auth->pairing_failed(smp->chan.chan.conn);


### PR DESCRIPTION
commit 9b6ad4067be40b8c8aa1da67fc39eb53fb50ace5 introduced some minor
coding style issues related to line splitting. Fix these.

Signed-off-by: Johan Hedberg <johan.hedberg@intel.com>