### PR TITLE
arch/x86: update linker definition for x86 real mode

### DIFF
--- a/include/arch/x86/linker.ld
+++ b/include/arch/x86/linker.ld
@@ -67,7 +67,7 @@ ENTRY(CONFIG_KERNEL_ENTRY)
 SECTIONS
 	{
 	GROUP_START(ROMABLE_REGION)
-#ifdef CONFIG_JAILHOUSE
+#ifdef CONFIG_REALMODE
 	/* 16-bit sections */
 	. = PHYS_RAM_ADDR;
 
@@ -80,7 +80,7 @@ SECTIONS
 	. = ALIGN(8);
 
 	_image_rom_start = PHYS_LOAD_ADDR;
-#ifndef CONFIG_JAILHOUSE
+#ifndef CONFIG_REALMODE
 	_image_text_start = PHYS_LOAD_ADDR;
 #else
 	_image_text_start = .;


### PR DESCRIPTION
When building the real mode, the linker definition has to place
the real mode entry code at the start of flash area.

Signed-off-by: Daniel Leung <daniel.leung@intel.com>