### PR TITLE
logging: Add metadata to hexdump

### DIFF
--- a/include/logging/log.h
+++ b/include/logging/log.h
@@ -136,11 +136,12 @@ extern "C" {
  * @details It's meant to report severe errors, such as those from which it's
  * not possible to recover.
  *
- * @param data   Pointer to the data to be logged.
- * @param length Length of data (in bytes).
+ * @param _data   Pointer to the data to be logged.
+ * @param _length Length of data (in bytes).
+ * @param _str    Persistent, raw string.
  */
-#define LOG_HEXDUMP_ERR(data, length) \
-	_LOG_HEXDUMP(LOG_LEVEL_ERR, data, length)
+#define LOG_HEXDUMP_ERR(_data, _length, _str) \
+	_LOG_HEXDUMP(LOG_LEVEL_ERR, _data, _length, _str)
 
 /**
  * @brief Writes a WARNING level message to the log.
@@ -148,33 +149,36 @@ extern "C" {
  * @details It's meant to register messages related to unusual situations that
  * are not necessarily errors.
  *
- * @param data   Pointer to the data to be logged.
- * @param length Length of data (in bytes).
+ * @param _data   Pointer to the data to be logged.
+ * @param _length Length of data (in bytes).
+ * @param _str    Persistent, raw string.
  */
-#define LOG_HEXDUMP_WRN(data, length) \
-	_LOG_HEXDUMP(LOG_LEVEL_WRN, data, length)
+#define LOG_HEXDUMP_WRN(_data, _length, _str) \
+	_LOG_HEXDUMP(LOG_LEVEL_WRN, _data, _length, _str)
 
 /**
  * @brief Writes an INFO level message to the log.
  *
  * @details It's meant to write generic user oriented messages.
  *
- * @param data   Pointer to the data to be logged.
- * @param length Length of data (in bytes).
+ * @param _data   Pointer to the data to be logged.
+ * @param _length Length of data (in bytes).
+ * @param _str    Persistent, raw string.
  */
-#define LOG_HEXDUMP_INF(data, length) \
-	_LOG_HEXDUMP(LOG_LEVEL_INF, data, length)
+#define LOG_HEXDUMP_INF(_data, _length, _str) \
+	_LOG_HEXDUMP(LOG_LEVEL_INF, _data, _length, _str)
 
 /**
  * @brief Writes a DEBUG level message to the log.
  *
  * @details It's meant to write developer oriented information.
  *
- * @param data   Pointer to the data to be logged.
- * @param length Length of data (in bytes).
+ * @param _data   Pointer to the data to be logged.
+ * @param _length Length of data (in bytes).
+ * @param _str    Persistent, raw string.
  */
-#define LOG_HEXDUMP_DBG(data, length) \
-	_LOG_HEXDUMP(LOG_LEVEL_DBG, data, length)
+#define LOG_HEXDUMP_DBG(_data, _length, _str) \
+	_LOG_HEXDUMP(LOG_LEVEL_DBG, _data, _length, _str)
 
 /**
  * @brief Writes an ERROR hexdump message associated with the instance to the
@@ -186,11 +190,12 @@ extern "C" {
  * severe errors, such as those from which it's not possible to recover.
  *
  * @param _log_inst   Pointer to the log structure associated with the instance.
- * @param data   Pointer to the data to be logged.
- * @param length Length of data (in bytes).
+ * @param _data       Pointer to the data to be logged.
+ * @param _length     Length of data (in bytes).
+ * @param _str        Persistent, raw string.
  */
-#define LOG_INST_HEXDUMP_ERR(_log_inst, data, length) \
-	_LOG_HEXDUMP_INSTANCE(LOG_LEVEL_ERR, _log_inst, data, length)
+#define LOG_INST_HEXDUMP_ERR(_log_inst, _data, _length, _str) \
+	_LOG_HEXDUMP_INSTANCE(LOG_LEVEL_ERR, _log_inst, _data, _length, _str)
 
 /**
  * @brief Writes a WARNING level hexdump message associated with the instance to
@@ -200,11 +205,12 @@ extern "C" {
  * are not necessarily errors.
  *
  * @param _log_inst   Pointer to the log structure associated with the instance.
- * @param data   Pointer to the data to be logged.
- * @param length Length of data (in bytes).
+ * @param _data       Pointer to the data to be logged.
+ * @param _length     Length of data (in bytes).
+ * @param _str        Persistent, raw string.
  */
-#define LOG_INST_HEXDUMP_WRN(_log_inst, data, length) \
-	_LOG_HEXDUMP_INSTANCE(LOG_LEVEL_WRN, _log_inst, data, length)
+#define LOG_INST_HEXDUMP_WRN(_log_inst, _data, _length, _str) \
+	_LOG_HEXDUMP_INSTANCE(LOG_LEVEL_WRN, _log_inst, _data, _length, _str)
 
 /**
  * @brief Writes an INFO level hexdump message associated with the instance to
@@ -213,11 +219,12 @@ extern "C" {
  * @details It's meant to write generic user oriented messages.
  *
  * @param _log_inst   Pointer to the log structure associated with the instance.
- * @param data   Pointer to the data to be logged.
- * @param length Length of data (in bytes).
+ * @param _data       Pointer to the data to be logged.
+ * @param _length     Length of data (in bytes).
+ * @param _str        Persistent, raw string.
  */
-#define LOG_INST_HEXDUMP_INF(_log_inst, data, length) \
-	_LOG_HEXDUMP_INSTANCE(LOG_LEVEL_INF, _log_inst, data, length)
+#define LOG_INST_HEXDUMP_INF(_log_inst, _data, _length, _str) \
+	_LOG_HEXDUMP_INSTANCE(LOG_LEVEL_INF, _log_inst, _data, _length, _str)
 
 /**
  * @brief Writes a DEBUG level hexdump message associated with the instance to
@@ -226,11 +233,12 @@ extern "C" {
  * @details It's meant to write developer oriented information.
  *
  * @param _log_inst   Pointer to the log structure associated with the instance.
- * @param _data   Pointer to the data to be logged.
- * @param _length Length of data (in bytes).
+ * @param _data       Pointer to the data to be logged.
+ * @param _length     Length of data (in bytes).
+ * @param _str        Persistent, raw string.
  */
-#define LOG_INST_HEXDUMP_DBG(_log_inst, _data, _length)	\
-	_LOG_HEXDUMP_INSTANCE(LOG_LEVEL_DBG, _log_inst, _data, _length)
+#define LOG_INST_HEXDUMP_DBG(_log_inst, _data, _length, _str)	\
+	_LOG_HEXDUMP_INSTANCE(LOG_LEVEL_DBG, _log_inst, _data, _length, _str)
 
 /**
  * @brief Writes an formatted string to the log.

--- a/include/logging/log_core.h
+++ b/include/logging/log_core.h
@@ -226,33 +226,34 @@ extern "C" {
 /******************************************************************************/
 /****************** Macros for hexdump logging ********************************/
 /******************************************************************************/
-#define __LOG_HEXDUMP(_level, _id, _filter, _data, _length)	   \
-	do {							   \
-		if (_LOG_CONST_LEVEL_CHECK(_level) &&		   \
-		    (_level <= LOG_RUNTIME_FILTER(_filter))) {	   \
-			struct log_msg_ids src_level = {	   \
-				.level = _level,		   \
-				.source_id = _id,		   \
-				.domain_id = CONFIG_LOG_DOMAIN_ID  \
-			};					   \
-			log_hexdump(_data, _length, src_level);	   \
-		}						   \
+#define __LOG_HEXDUMP(_level, _id, _filter, _data, _length, _str)     \
+	do {							      \
+		if (_LOG_CONST_LEVEL_CHECK(_level) &&		      \
+		    (_level <= LOG_RUNTIME_FILTER(_filter))) {	      \
+			struct log_msg_ids src_level = {	      \
+				.level = _level,		      \
+				.source_id = _id,		      \
+				.domain_id = CONFIG_LOG_DOMAIN_ID     \
+			};					      \
+			log_hexdump(_str, _data, _length, src_level); \
+		}						      \
 	} while (0)
 
-#define _LOG_HEXDUMP(_level, _data, _length)		       \
+#define _LOG_HEXDUMP(_level, _data, _length, _str)	       \
 	__LOG_HEXDUMP(_level,				       \
 		      LOG_CURRENT_MODULE_ID(),		       \
 		      LOG_CURRENT_DYNAMIC_DATA_ADDR(),	       \
-		      _data, _length)
+		      _data, _length, _str)
 
-#define _LOG_HEXDUMP_INSTANCE(_level, _inst, _data, _length)	 \
-	__LOG_HEXDUMP(_level,					 \
-		      IS_ENABLED(CONFIG_LOG_RUNTIME_FILTERING) ? \
-		      LOG_DYNAMIC_ID_GET(_inst) :		 \
-		      LOG_CONST_ID_GET(_inst),			 \
-		      _inst,					 \
-		      _data,					 \
-		      _length)
+#define _LOG_HEXDUMP_INSTANCE(_level, _inst, _data, _length, _str) \
+	__LOG_HEXDUMP(_level,					   \
+		      IS_ENABLED(CONFIG_LOG_RUNTIME_FILTERING) ?   \
+		      LOG_DYNAMIC_ID_GET(_inst) :		   \
+		      LOG_CONST_ID_GET(_inst),			   \
+		      _inst,					   \
+		      _data,					   \
+		      _length,					   \
+		      _str)
 
 /******************************************************************************/
 /****************** Filtering macros ******************************************/
@@ -444,11 +445,13 @@ void log_n(const char *str,
 
 /** @brief Hexdump log.
  *
+ * @param str		String.
  * @param data		Data.
  * @param length	Data length.
  * @param src_level	Log identification.
  */
-void log_hexdump(const u8_t *data,
+void log_hexdump(const char *str,
+		 const u8_t *data,
 		 u32_t length,
 		 struct log_msg_ids src_level);
 

--- a/samples/subsys/logging/logger/src/sample_instance.c
+++ b/samples/subsys/logging/logger/src/sample_instance.c
@@ -16,7 +16,7 @@ void sample_instance_call(struct sample_instance *inst)
 	u8_t data[4] = { 1, 2, 3, 4 };
 
 	LOG_INST_INF(inst->log, "counter_value: %d", inst->cnt++);
-	LOG_INST_WRN(inst->log, "Example of hexdump:");
-	LOG_INST_HEXDUMP_WRN(inst->log, data, sizeof(data));
+	LOG_INST_HEXDUMP_WRN(inst->log, data, sizeof(data),
+					"Example of hexdump:");
 	memset(data, 0, sizeof(data));
 }

--- a/subsys/logging/log_core.c
+++ b/subsys/logging/log_core.c
@@ -128,11 +128,12 @@ void log_n(const char *str,
 	msg_finalize(msg, src_level);
 }
 
-void log_hexdump(const u8_t *data,
+void log_hexdump(const char *str,
+		 const u8_t *data,
 		 u32_t length,
 		 struct log_msg_ids src_level)
 {
-	struct log_msg *msg = log_msg_hexdump_create(data, length);
+	struct log_msg *msg = log_msg_hexdump_create(str, data, length);
 
 	if (msg == NULL) {
 		return;
@@ -155,7 +156,7 @@ int log_printk(const char *fmt, va_list ap)
 		length = (length > sizeof(formatted_str)) ?
 			 sizeof(formatted_str) : length;
 
-		msg = log_msg_hexdump_create(formatted_str, length);
+		msg = log_msg_hexdump_create(NULL, formatted_str, length);
 		if (!msg) {
 			return 0;
 		}

--- a/subsys/logging/log_output.c
+++ b/subsys/logging/log_output.c
@@ -260,16 +260,15 @@ static u32_t hexdump_line_print(struct log_msg *msg,
 	log_msg_hexdump_data_get(msg, buf, &length, offset);
 
 	if (length > 0) {
-		if (offset > 0) {
-			newline_print(ctx);
-			for (int i = 0; i < prefix_offset; i++) {
-				print(ctx, " ");
-			}
+		newline_print(ctx);
+
+		for (int i = 0; i < prefix_offset; i++) {
+			print(ctx, " ");
 		}
 
 		for (int i = 0; i < HEXDUMP_BYTES_IN_LINE; i++) {
 			if (i < length) {
-				print(ctx, " %02x", buf[i]);
+				print(ctx, "%02x ", buf[i]);
 			} else {
 				print(ctx, "   ");
 			}
@@ -297,6 +296,8 @@ static void hexdump_print(struct log_msg *msg,
 {
 	u32_t offset = 0;
 	u32_t length;
+
+	print(ctx, "%s", log_msg_str_get(msg));
 
 	do {
 		length = hexdump_line_print(msg, ctx, prefix_offset, offset);

--- a/tests/subsys/logging/log_core/src/log_core_test.c
+++ b/tests/subsys/logging/log_core/src/log_core_test.c
@@ -208,7 +208,7 @@ static void test_log_overflow(void)
 
 	LOG_INF("test");
 	LOG_INF("test");
-	LOG_HEXDUMP_INF(data, hexdump_len);
+	LOG_HEXDUMP_INF(data, hexdump_len, "test");
 
 	while (log_process(false)) {
 	}
@@ -219,7 +219,7 @@ static void test_log_overflow(void)
 	backend1_cb.exp_timestamps[2] = 3;
 
 	LOG_INF("test");
-	LOG_HEXDUMP_INF(data, max_hexdump_len+1);
+	LOG_HEXDUMP_INF(data, max_hexdump_len+1, "test");
 
 	while (log_process(false)) {
 	}

--- a/tests/subsys/logging/log_msg/src/log_msg_test.c
+++ b/tests/subsys/logging/log_msg/src/log_msg_test.c
@@ -143,7 +143,7 @@ void test_log_hexdump_msg(void)
 	}
 
 	/* allocation of buffer that fits in single buffer */
-	msg = log_msg_hexdump_create(data,
+	msg = log_msg_hexdump_create("test", data,
 				     LOG_MSG_HEXDUMP_BYTES_SINGLE_CHUNK - 4);
 
 	zassert_equal((used_slabs + 1),
@@ -159,7 +159,8 @@ void test_log_hexdump_msg(void)
 	used_slabs--;
 
 	/* allocation of buffer that fits in single buffer */
-	msg = log_msg_hexdump_create(data, LOG_MSG_HEXDUMP_BYTES_SINGLE_CHUNK);
+	msg = log_msg_hexdump_create("test", data,
+				     LOG_MSG_HEXDUMP_BYTES_SINGLE_CHUNK);
 
 	zassert_equal((used_slabs + 1),
 		      k_mem_slab_num_used_get(&log_msg_pool),
@@ -174,7 +175,7 @@ void test_log_hexdump_msg(void)
 	used_slabs--;
 
 	/* allocation of buffer that fits in 2 buffers */
-	msg = log_msg_hexdump_create(data,
+	msg = log_msg_hexdump_create("test", data,
 				     LOG_MSG_HEXDUMP_BYTES_SINGLE_CHUNK + 1);
 
 	zassert_equal((used_slabs + 2),
@@ -190,7 +191,7 @@ void test_log_hexdump_msg(void)
 	used_slabs -= 2;
 
 	/* allocation of buffer that fits in 3 buffers */
-	msg = log_msg_hexdump_create(data,
+	msg = log_msg_hexdump_create("test", data,
 				     LOG_MSG_HEXDUMP_BYTES_SINGLE_CHUNK +
 				     HEXDUMP_BYTES_CONT_MSG + 1);
 
@@ -223,7 +224,7 @@ void test_log_hexdump_data_get_single_chunk(void)
 
 	/* allocation of buffer that fits in single buffer */
 	wr_length = LOG_MSG_HEXDUMP_BYTES_SINGLE_CHUNK - 4;
-	msg = log_msg_hexdump_create(data, wr_length);
+	msg = log_msg_hexdump_create("test", data, wr_length);
 
 	offset = 0;
 	rd_length = wr_length - 1;
@@ -322,7 +323,7 @@ void test_log_hexdump_data_get_two_chunks(void)
 
 	/* allocation of buffer that fits in two chunks. */
 	wr_length = LOG_MSG_HEXDUMP_BYTES_SINGLE_CHUNK;
-	msg = log_msg_hexdump_create(data, wr_length);
+	msg = log_msg_hexdump_create("test", data, wr_length);
 
 	/* Read whole data from offset = 0*/
 	offset = 0;
@@ -415,7 +416,7 @@ void test_log_hexdump_data_get_multiple_chunks(void)
 
 	/* allocation of buffer that fits in two chunks. */
 	wr_length = 40;
-	msg = log_msg_hexdump_create(data, wr_length);
+	msg = log_msg_hexdump_create("test", data, wr_length);
 
 	/* Read whole data from offset = 0*/
 	offset = 0;


### PR DESCRIPTION
Extended hexdump API with a raw string attached to the data.

As requested by @jhedberg  and @pizi-nordic  in discussion in #9090. Extending hexdump API with a string parameter (metadata for hexdump data).
 
Signed-off-by: Krzysztof Chruscinski <krzysztof.chruscinski@nordicsemi.no>