### PR TITLE
Bluetooth: SMP: Fix missing NULL-checks for bt_auth

### DIFF
--- a/subsys/bluetooth/host/smp.c
+++ b/subsys/bluetooth/host/smp.c
@@ -712,7 +712,7 @@ static void smp_pairing_br_complete(struct bt_smp_br *smp, u8_t status)
 			bt_keys_clear(keys);
 		}
 
-		if (bt_auth->pairing_failed) {
+		if (bt_auth && bt_auth->pairing_failed) {
 			bt_auth->pairing_failed(smp->chan.chan.conn);
 		}
 	} else {
@@ -722,7 +722,7 @@ static void smp_pairing_br_complete(struct bt_smp_br *smp, u8_t status)
 			bt_keys_store(keys);
 		}
 
-		if (bt_auth->pairing_complete) {
+		if (bt_auth && bt_auth->pairing_complete) {
 			bt_auth->pairing_complete(smp->chan.chan.conn,
 						  bond_flag);
 		}
@@ -1500,11 +1500,11 @@ static void smp_pairing_complete(struct bt_smp *smp, u8_t status)
 			bt_keys_store(smp->chan.chan.conn->le.keys);
 		}
 
-		if (bt_auth->pairing_complete) {
+		if (bt_auth && bt_auth->pairing_complete) {
 			bt_auth->pairing_complete(smp->chan.chan.conn,
 						  bond_flag);
 		}
-	} else if (bt_auth->pairing_failed) {
+	} else if (bt_auth && bt_auth->pairing_failed) {
 		bt_auth->pairing_failed(smp->chan.chan.conn);
 	}
 


### PR DESCRIPTION
The recently added pairing_complete & pairing_failed callbacks
were missing a NULL-check for bt_auth, since it is possible that
there's no authentication callback structure registered at all.

Signed-off-by: Johan Hedberg <johan.hedberg@intel.com>