### PR TITLE
linker: riscv: Relocate .eh_frame symbol

### DIFF
--- a/include/arch/riscv32/common/linker.ld
+++ b/include/arch/riscv32/common/linker.ld
@@ -83,6 +83,7 @@ SECTIONS
 		*(.text)
 		*(".text.*")
 		*(.gnu.linkonce.t.*)
+		*(.eh_frame)
 	} GROUP_LINK_IN(ROMABLE_REGION)
 
     _image_text_end = .;


### PR DESCRIPTION
The .eh_frame symbol was causing __data_rom_start to contain the wrong
offset into the ROM, resulting in corrupt data copied into RAM by
_data_copy(). Fix by placing the .eh_frame in the .text section as is
done in include/arch/x86/linker.ld

## Demonstrating the problem with samples/hello_world

Build with Zephyr SDK 0.9.3 with `-DBOARD=hifive1`

### Before this fix:
```
$ readelf -S zephyr/zephyr.elf 
There are 23 section headers, starting at offset 0x3d1e8:

Section Headers:
  [Nr] Name              Type            Addr     Off    Size   ES Flg Lk Inf Al
  [ 0]                   NULL            00000000 000000 000000 00      0   0  0
  [ 1] vector            PROGBITS        20400000 000094 000010 00  AX  0   0  4
  [ 2] exceptions        PROGBITS        20400010 0000a4 000268 00  AX  0   0  4
  [ 3] text              PROGBITS        20400278 00030c 002c14 00 WAX  0   0  4
  [ 4] devconfig         PROGBITS        20402e8c 002f20 000060 00  WA  0   0  4
  [ 5] rodata            PROGBITS        20402eec 002f80 000544 00   A  0   0  4
  [ 6] .eh_frame         PROGBITS        20403430 0034c4 000028 00   A  0   0  4
  [ 7] datas             PROGBITS        80000000 0034ec 000018 00  WA  0   0  4
  [ 8] initlevel         PROGBITS        80000018 003504 000060 00  WA  0   0  4
  [ 9] bss               NOBITS          80000078 003568 000240 00  WA  0   0  8
  [10] noinit            NOBITS          800002c0 003568 000e00 00  WA  0   0 16
  [11] .debug_info       PROGBITS        00000000 003564 017f0a 00      0   0  1
  [12] .debug_abbrev     PROGBITS        00000000 01b46e 0053c2 00      0   0  1
  [13] .debug_aranges    PROGBITS        00000000 020830 000988 00      0   0 16
  [14] .debug_line       PROGBITS        00000000 0211b8 00adf5 00      0   0  1
  [15] .debug_str        PROGBITS        00000000 02bfad 004195 01  MS  0   0  1
  [16] .comment          PROGBITS        00000000 030142 000011 01  MS  0   0  1
  [17] .debug_frame      PROGBITS        00000000 030154 0019b4 00      0   0  4
  [18] .debug_ranges     PROGBITS        00000000 031b10 0012c0 00      0   0 16
  [19] .debug_loc        PROGBITS        00000000 032dd0 005eb4 00      0   0  1
  [20] .symtab           SYMTAB          00000000 038c84 001e80 10     21 130  4
  [21] .strtab           STRTAB          00000000 03ab04 00260c 00      0   0  1
  [22] .shstrtab         STRTAB          00000000 03d110 0000d7 00      0   0  1
Key to Flags:
  W (write), A (alloc), X (execute), M (merge), S (strings)
  I (info), L (link order), G (group), T (TLS), E (exclude), x (unknown)
  O (extra OS processing required) o (OS specific), p (processor specific)
```

### After this fix:
```
$ readelf -S zephyr/zephyr.elf 
There are 22 section headers, starting at offset 0x3d1d0:

Section Headers:
  [Nr] Name              Type            Addr     Off    Size   ES Flg Lk Inf Al
  [ 0]                   NULL            00000000 000000 000000 00      0   0  0
  [ 1] vector            PROGBITS        20400000 000094 000010 00  AX  0   0  4
  [ 2] exceptions        PROGBITS        20400010 0000a4 000268 00  AX  0   0  4
  [ 3] text              PROGBITS        20400278 00030c 002c3c 00 WAX  0   0  4
  [ 4] devconfig         PROGBITS        20402eb4 002f48 000060 00  WA  0   0  4
  [ 5] rodata            PROGBITS        20402f14 002fa8 000544 00   A  0   0  4
  [ 6] datas             PROGBITS        80000000 0034ec 000018 00  WA  0   0  4
  [ 7] initlevel         PROGBITS        80000018 003504 000060 00  WA  0   0  4
  [ 8] bss               NOBITS          80000078 003568 000240 00  WA  0   0  8
  [ 9] noinit            NOBITS          800002c0 003568 000e00 00  WA  0   0 16
  [10] .debug_info       PROGBITS        00000000 003564 017f0a 00      0   0  1
  [11] .debug_abbrev     PROGBITS        00000000 01b46e 0053c2 00      0   0  1
  [12] .debug_aranges    PROGBITS        00000000 020830 000988 00      0   0 16
  [13] .debug_line       PROGBITS        00000000 0211b8 00adf5 00      0   0  1
  [14] .debug_str        PROGBITS        00000000 02bfad 004195 01  MS  0   0  1
  [15] .comment          PROGBITS        00000000 030142 000011 01  MS  0   0  1
  [16] .debug_frame      PROGBITS        00000000 030154 0019b4 00      0   0  4
  [17] .debug_ranges     PROGBITS        00000000 031b10 0012c0 00      0   0 16
  [18] .debug_loc        PROGBITS        00000000 032dd0 005eb4 00      0   0  1
  [19] .symtab           SYMTAB          00000000 038c84 001e70 10     20 129  4
  [20] .strtab           STRTAB          00000000 03aaf4 00260c 00      0   0  1
  [21] .shstrtab         STRTAB          00000000 03d100 0000cd 00      0   0  1
Key to Flags:
  W (write), A (alloc), X (execute), M (merge), S (strings)
  I (info), L (link order), G (group), T (TLS), E (exclude), x (unknown)
  O (extra OS processing required) o (OS specific), p (processor specific)
```