### PR TITLE
scripts: Fix use-property-label behavior for DTS

### DIFF
--- a/scripts/dts/extract/reg.py
+++ b/scripts/dts/extract/reg.py
@@ -46,10 +46,6 @@ class DTReg(DTDirective):
             size_cells = reduced[address]['props'].get('#size-cells', size_cells)
 
         post_label = "BASE_ADDRESS"
-        if yaml[node_compat].get('use-property-label', False):
-            label = node['props'].get('label', None)
-            if label:
-                post_label = label
 
         index = 0
         l_base = def_label.split('/')


### PR DESCRIPTION
When `use-property-label: yes` is requested in the DTS binding YAML, end the configuration identifier for the device base address with "BASE_ADDRESS"

## Example

Let's say we have a YAML binding `dts/bindings/gpio/foo,gpio.yaml` with the following options
```
base_label: FOO
use-property-label: yes
```

and in our DTS we have the following node
```
gpio@10000000 {
    compatible = "foo,gpio";
    reg = <0x10000000 0x1000>;
    label = "gpio0";
};
```

### Prior to the refactor in commit 08216f5

When the generated header file is created, it contains the definitions
```
#define FOO_GPIO0_BASE_ADDRESS    0x10000000
#define FOO_GPIO0_SIZE            4096
```

### Prior to this fix

When the generated header file is created, it contains the definitions
```
#define FOO_GPIO0_GPIO0    0x10000000
#define FOO_GPIO0_SIZE     4096
```

### With this fix

When the generated header file is created, it once again contains the definitions
```
#define FOO_GPIO0_BASE_ADDRESS    0x10000000
#define FOO_GPIO0_SIZE            4096
```