### PR TITLE
tests/booting/stub: remove CONFIG_ARC_INIT

### DIFF
--- a/tests/booting/stub/prj.conf
+++ b/tests/booting/stub/prj.conf
@@ -1,4 +1,3 @@
 # Our only mission is to start the ARC in an Arduino platform so we
 # can pipe its output to the serial port.
-CONFIG_ARC_INIT=y
 CONFIG_BOOT_BANNER=n


### PR DESCRIPTION
This stub was forcing this configuration option that is not neccesary
and the configuration system is complaining about it, failing most
Arduino101 stub builds.

Signed-off-by: Inaky Perez-Gonzalez <inaky.perez-gonzalez@intel.com>