### PR TITLE
tests: mem_protect: Add description and doxygen groups

### DIFF
--- a/tests/kernel/mem_protect/app_memory/src/main.c
+++ b/tests/kernel/mem_protect/app_memory/src/main.c
@@ -9,6 +9,13 @@
 #include <linker/linker-defs.h>
 #include <ztest.h>
 
+/**
+ * @brief Memory protection tests
+ * @defgroup kernel_memprotect_tests Memory Protection Tests
+ * @ingroup all_tests
+ * @{
+ * @}
+ */
 struct test_struct {
 	int foo;
 	int bar;
@@ -47,6 +54,11 @@ int kernel_loc(void *ptr)
 	return data_loc(__kernel_ram_start, __kernel_ram_end, ptr);
 }
 
+/**
+ * @brief Test to determine the memory bounds
+ *
+ * @ingroup kernel_memprotect_tests
+ */
 void test_app_memory(void)
 {
 	printk("Memory bounds:\n");

--- a/tests/kernel/mem_protect/obj_validation/src/main.c
+++ b/tests/kernel/mem_protect/obj_validation/src/main.c
@@ -67,6 +67,13 @@ void object_permission_checks(struct k_sem *sem, bool skip_init)
 
 extern const k_tid_t _main_thread;
 
+/**
+ * @brief Tests to verify object permission
+ *
+ * @ingroup kernel_memprotect_tests
+ *
+ * @see k_object_alloc(), k_object_access_grant()
+ */
 void test_generic_object(void)
 {
 	struct k_sem stack_sem;

--- a/tests/kernel/mem_protect/stack_random/src/main.c
+++ b/tests/kernel/mem_protect/stack_random/src/main.c
@@ -36,6 +36,12 @@ void alternate_thread(void)
 K_THREAD_STACK_DEFINE(alt_thread_stack_area, STACKSIZE);
 static struct k_thread alt_thread_data;
 
+/**
+ * @brief Test stack pointer randomization
+ *
+ * @ingroup kernel_memprotect_tests
+ *
+ */
 void test_stack_pt_randomization(void)
 {
 	int i;

--- a/tests/kernel/mem_protect/stackprot/src/main.c
+++ b/tests/kernel/mem_protect/stackprot/src/main.c
@@ -6,17 +6,6 @@
  */
 
 
-/**
- * @brief test Stack Protector feature using canary
- *
- * This is the test program to test stack protection using canary.
- *
- * The main thread starts a second thread, which generates a stack check
- * failure.
- * By design, the second thread will not complete its execution and
- * will not set ret to TC_FAIL.
- */
-
 #include <zephyr.h>
 #include <ztest.h>
 
@@ -104,12 +93,18 @@ K_THREAD_STACK_DEFINE(alt_thread_stack_area, STACKSIZE);
 static struct k_thread alt_thread_data;
 
 /**
+ * @brief test Stack Protector feature using canary
  *
+ * @details This is the test program to test stack protection using canary.
+ * The main thread starts a second thread, which generates a stack check
+ * failure.
+ * By design, the second thread will not complete its execution and
+ * will not set ret to TC_FAIL.
  * This is the entry point to the test stack protection feature.
  * It starts the thread that tests stack protection, then prints out
  * a few messages before terminating.
  *
- * @return N/A
+ * @ingroup kernel_memprotect_tests
  */
 
 void test_stackprot(void)


### PR DESCRIPTION
Add descriptions and doxygen groups for app_memory,
    stack_protection, stack_randomization and
    obj_validation test cases.

Signed-off-by: Spoorthi K <spoorthi.k@intel.com>