### PR TITLE
Fix policy 000 warning

### DIFF
--- a/cmake/app/boilerplate.cmake
+++ b/cmake/app/boilerplate.cmake
@@ -27,15 +27,17 @@ if(uname_output MATCHES "MSYS")
   set(MSYS 1)
 endif()
 
-# CMake version 3.8.2 is the minimum supported version. Version 3.9 is
-# supported but it introduced a warning that we do not wish to
-# show to users. Specifically, it displays a warning when an OLD
-# policy is used, but we need policy CMP0000 set to OLD to avoid
-# copy-pasting cmake_minimum_required across application
-# CMakeLists.txt files.
+# CMake version 3.8.2 is the real minimum supported version.
+#
+# Unfortunately CMake requires the toplevel CMakeLists.txt file to
+# define the required version, not even invoking it from an included
+# file, like boilerplate.cmake, is sufficient. It is however permitted
+# to have multiple invocations of cmake_minimum_required.
+#
+# Under these restraints we use a second 'cmake_minimum_required'
+# invocation in every toplevel CMakeLists.txt.
 cmake_minimum_required(VERSION 3.8.2)
 
-cmake_policy(SET CMP0000 OLD)
 cmake_policy(SET CMP0002 NEW)
 
 define_property(GLOBAL PROPERTY ZEPHYR_LIBS

--- a/doc/application/application.rst
+++ b/doc/application/application.rst
@@ -103,12 +103,19 @@ Follow these steps to create a new application directory. (Refer to
 
 #. Create an empty :file:`CMakeLists.txt` file in your application directory.
 
-#. Include the :file:`boilerplate.cmake` to pull in the Zephyr build system:
+#. Add boilerplate code that sets the minimum CMake version and pulls
+   in the Zephyr build system:
 
    .. code-block:: cmake
 
+      cmake_minimum_required(VERSION 3.8.2)
       include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
       project(NONE)
+
+   .. note:: cmake_minimum_required is also invoked from
+             :file:`boilerplate.cmake`. The most recent of the two
+             versions will be enforced by CMake.
+
 
 #. Place your application source code in the :file:`src` sub-directory. For
    this example, we'll assume you created a file named :file:`src/main.c`.

--- a/samples/application_development/external_lib/CMakeLists.txt
+++ b/samples/application_development/external_lib/CMakeLists.txt
@@ -1,3 +1,4 @@
+cmake_minimum_required(VERSION 3.8.2)
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
 project(NONE)
 

--- a/samples/application_development/out_of_tree_board/CMakeLists.txt
+++ b/samples/application_development/out_of_tree_board/CMakeLists.txt
@@ -1,3 +1,4 @@
+cmake_minimum_required(VERSION 3.8.2)
 # Re-direct the directory where the 'boards' directory is found from
 # $ZEPHYR_BASE to this directory.
 set(BOARD_ROOT ${CMAKE_CURRENT_LIST_DIR})

--- a/samples/basic/blink_led/CMakeLists.txt
+++ b/samples/basic/blink_led/CMakeLists.txt
@@ -1,3 +1,4 @@
+cmake_minimum_required(VERSION 3.8.2)
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
 project(NONE)
 

--- a/samples/basic/blinky/CMakeLists.txt
+++ b/samples/basic/blinky/CMakeLists.txt
@@ -1,3 +1,4 @@
+cmake_minimum_required(VERSION 3.8.2)
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
 project(NONE)
 

--- a/samples/basic/button/CMakeLists.txt
+++ b/samples/basic/button/CMakeLists.txt
@@ -1,3 +1,4 @@
+cmake_minimum_required(VERSION 3.8.2)
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
 project(NONE)
 

--- a/samples/basic/disco/CMakeLists.txt
+++ b/samples/basic/disco/CMakeLists.txt
@@ -1,3 +1,4 @@
+cmake_minimum_required(VERSION 3.8.2)
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
 project(NONE)
 

--- a/samples/basic/fade_led/CMakeLists.txt
+++ b/samples/basic/fade_led/CMakeLists.txt
@@ -1,3 +1,4 @@
+cmake_minimum_required(VERSION 3.8.2)
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
 project(NONE)
 

--- a/samples/basic/rgb_led/CMakeLists.txt
+++ b/samples/basic/rgb_led/CMakeLists.txt
@@ -1,3 +1,4 @@
+cmake_minimum_required(VERSION 3.8.2)
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
 project(NONE)
 

--- a/samples/basic/servo_motor/CMakeLists.txt
+++ b/samples/basic/servo_motor/CMakeLists.txt
@@ -1,3 +1,4 @@
+cmake_minimum_required(VERSION 3.8.2)
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
 project(NONE)
 

--- a/samples/basic/threads/CMakeLists.txt
+++ b/samples/basic/threads/CMakeLists.txt
@@ -1,3 +1,4 @@
+cmake_minimum_required(VERSION 3.8.2)
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
 project(NONE)
 

--- a/samples/bluetooth/beacon/CMakeLists.txt
+++ b/samples/bluetooth/beacon/CMakeLists.txt
@@ -1,3 +1,4 @@
+cmake_minimum_required(VERSION 3.8.2)
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
 project(NONE)
 

--- a/samples/bluetooth/central/CMakeLists.txt
+++ b/samples/bluetooth/central/CMakeLists.txt
@@ -1,3 +1,4 @@
+cmake_minimum_required(VERSION 3.8.2)
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
 project(NONE)
 

--- a/samples/bluetooth/central_hr/CMakeLists.txt
+++ b/samples/bluetooth/central_hr/CMakeLists.txt
@@ -1,3 +1,4 @@
+cmake_minimum_required(VERSION 3.8.2)
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
 project(NONE)
 

--- a/samples/bluetooth/eddystone/CMakeLists.txt
+++ b/samples/bluetooth/eddystone/CMakeLists.txt
@@ -1,3 +1,4 @@
+cmake_minimum_required(VERSION 3.8.2)
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
 project(NONE)
 

--- a/samples/bluetooth/handsfree/CMakeLists.txt
+++ b/samples/bluetooth/handsfree/CMakeLists.txt
@@ -1,3 +1,4 @@
+cmake_minimum_required(VERSION 3.8.2)
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
 project(NONE)
 

--- a/samples/bluetooth/hci_spi/CMakeLists.txt
+++ b/samples/bluetooth/hci_spi/CMakeLists.txt
@@ -1,3 +1,4 @@
+cmake_minimum_required(VERSION 3.8.2)
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
 project(NONE)
 

--- a/samples/bluetooth/hci_uart/CMakeLists.txt
+++ b/samples/bluetooth/hci_uart/CMakeLists.txt
@@ -1,3 +1,4 @@
+cmake_minimum_required(VERSION 3.8.2)
 if(BOARD STREQUAL bbc_microbit)
   set(CONF_FILE microbit.conf)
 else()

--- a/samples/bluetooth/hci_usb/CMakeLists.txt
+++ b/samples/bluetooth/hci_usb/CMakeLists.txt
@@ -1,3 +1,4 @@
+cmake_minimum_required(VERSION 3.8.2)
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
 project(NONE)
 

--- a/samples/bluetooth/ibeacon/CMakeLists.txt
+++ b/samples/bluetooth/ibeacon/CMakeLists.txt
@@ -1,3 +1,4 @@
+cmake_minimum_required(VERSION 3.8.2)
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
 project(NONE)
 

--- a/samples/bluetooth/ipsp/CMakeLists.txt
+++ b/samples/bluetooth/ipsp/CMakeLists.txt
@@ -1,3 +1,4 @@
+cmake_minimum_required(VERSION 3.8.2)
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
 project(NONE)
 

--- a/samples/bluetooth/mesh/CMakeLists.txt
+++ b/samples/bluetooth/mesh/CMakeLists.txt
@@ -1,3 +1,4 @@
+cmake_minimum_required(VERSION 3.8.2)
 set(QEMU_EXTRA_FLAGS -s)
 
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)

--- a/samples/bluetooth/mesh_demo/CMakeLists.txt
+++ b/samples/bluetooth/mesh_demo/CMakeLists.txt
@@ -1,3 +1,4 @@
+cmake_minimum_required(VERSION 3.8.2)
 set(QEMU_EXTRA_FLAGS -s)
 
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)

--- a/samples/bluetooth/peripheral/CMakeLists.txt
+++ b/samples/bluetooth/peripheral/CMakeLists.txt
@@ -1,3 +1,4 @@
+cmake_minimum_required(VERSION 3.8.2)
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
 project(NONE)
 

--- a/samples/bluetooth/peripheral_csc/CMakeLists.txt
+++ b/samples/bluetooth/peripheral_csc/CMakeLists.txt
@@ -1,3 +1,4 @@
+cmake_minimum_required(VERSION 3.8.2)
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
 project(NONE)
 

--- a/samples/bluetooth/peripheral_dis/CMakeLists.txt
+++ b/samples/bluetooth/peripheral_dis/CMakeLists.txt
@@ -1,3 +1,4 @@
+cmake_minimum_required(VERSION 3.8.2)
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
 project(NONE)
 

--- a/samples/bluetooth/peripheral_esp/CMakeLists.txt
+++ b/samples/bluetooth/peripheral_esp/CMakeLists.txt
@@ -1,3 +1,4 @@
+cmake_minimum_required(VERSION 3.8.2)
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
 project(NONE)
 

--- a/samples/bluetooth/peripheral_hids/CMakeLists.txt
+++ b/samples/bluetooth/peripheral_hids/CMakeLists.txt
@@ -1,3 +1,4 @@
+cmake_minimum_required(VERSION 3.8.2)
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
 project(NONE)
 

--- a/samples/bluetooth/peripheral_hr/CMakeLists.txt
+++ b/samples/bluetooth/peripheral_hr/CMakeLists.txt
@@ -1,3 +1,4 @@
+cmake_minimum_required(VERSION 3.8.2)
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
 project(NONE)
 

--- a/samples/bluetooth/peripheral_sc_only/CMakeLists.txt
+++ b/samples/bluetooth/peripheral_sc_only/CMakeLists.txt
@@ -1,3 +1,4 @@
+cmake_minimum_required(VERSION 3.8.2)
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
 project(NONE)
 

--- a/samples/bluetooth/scan_adv/CMakeLists.txt
+++ b/samples/bluetooth/scan_adv/CMakeLists.txt
@@ -1,3 +1,4 @@
+cmake_minimum_required(VERSION 3.8.2)
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
 project(NONE)
 

--- a/samples/boards/96b_argonkey/CMakeLists.txt
+++ b/samples/boards/96b_argonkey/CMakeLists.txt
@@ -1,3 +1,4 @@
+cmake_minimum_required(VERSION 3.8.2)
 # Copyright (c) 2018 STMicroelectronics
 #
 # SPDX-License-Identifier: Apache-2.0

--- a/samples/boards/altera_max10/pio/CMakeLists.txt
+++ b/samples/boards/altera_max10/pio/CMakeLists.txt
@@ -1,3 +1,4 @@
+cmake_minimum_required(VERSION 3.8.2)
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
 project(NONE)
 

--- a/samples/boards/arduino_101/environmental_sensing/ap/CMakeLists.txt
+++ b/samples/boards/arduino_101/environmental_sensing/ap/CMakeLists.txt
@@ -1,3 +1,4 @@
+cmake_minimum_required(VERSION 3.8.2)
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
 project(NONE)
 

--- a/samples/boards/arduino_101/environmental_sensing/sensor/CMakeLists.txt
+++ b/samples/boards/arduino_101/environmental_sensing/sensor/CMakeLists.txt
@@ -1,3 +1,4 @@
+cmake_minimum_required(VERSION 3.8.2)
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
 project(NONE)
 

--- a/samples/boards/microbit/display/CMakeLists.txt
+++ b/samples/boards/microbit/display/CMakeLists.txt
@@ -1,3 +1,4 @@
+cmake_minimum_required(VERSION 3.8.2)
 
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
 project(NONE)

--- a/samples/boards/microbit/pong/CMakeLists.txt
+++ b/samples/boards/microbit/pong/CMakeLists.txt
@@ -1,3 +1,4 @@
+cmake_minimum_required(VERSION 3.8.2)
 
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
 project(NONE)

--- a/samples/boards/microbit/sound/CMakeLists.txt
+++ b/samples/boards/microbit/sound/CMakeLists.txt
@@ -1,3 +1,4 @@
+cmake_minimum_required(VERSION 3.8.2)
 
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
 project(NONE)

--- a/samples/boards/nrf52/mesh/onoff-app/CMakeLists.txt
+++ b/samples/boards/nrf52/mesh/onoff-app/CMakeLists.txt
@@ -1,3 +1,4 @@
+cmake_minimum_required(VERSION 3.8.2)
 set(QEMU_EXTRA_FLAGS -s)
 
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)

--- a/samples/boards/nrf52/mesh/onoff_level_lighting_vnd_app/CMakeLists.txt
+++ b/samples/boards/nrf52/mesh/onoff_level_lighting_vnd_app/CMakeLists.txt
@@ -1,3 +1,4 @@
+cmake_minimum_required(VERSION 3.8.2)
 set(QEMU_EXTRA_FLAGS -s)
 
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)

--- a/samples/boards/nrf52/power_mgr/CMakeLists.txt
+++ b/samples/boards/nrf52/power_mgr/CMakeLists.txt
@@ -1,3 +1,4 @@
+cmake_minimum_required(VERSION 3.8.2)
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
 project(NONE)
 

--- a/samples/boards/olimex_stm32_e407/ccm/CMakeLists.txt
+++ b/samples/boards/olimex_stm32_e407/ccm/CMakeLists.txt
@@ -1,3 +1,4 @@
+cmake_minimum_required(VERSION 3.8.2)
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
 project(NONE)
 

--- a/samples/boards/quark_se_c1000/power_mgr/CMakeLists.txt
+++ b/samples/boards/quark_se_c1000/power_mgr/CMakeLists.txt
@@ -1,3 +1,4 @@
+cmake_minimum_required(VERSION 3.8.2)
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
 project(NONE)
 

--- a/samples/cpp_synchronization/CMakeLists.txt
+++ b/samples/cpp_synchronization/CMakeLists.txt
@@ -1,3 +1,4 @@
+cmake_minimum_required(VERSION 3.8.2)
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
 project(NONE)
 

--- a/samples/display/grove_display/CMakeLists.txt
+++ b/samples/display/grove_display/CMakeLists.txt
@@ -1,3 +1,4 @@
+cmake_minimum_required(VERSION 3.8.2)
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
 project(NONE)
 

--- a/samples/display/ili9340/CMakeLists.txt
+++ b/samples/display/ili9340/CMakeLists.txt
@@ -1,3 +1,4 @@
+cmake_minimum_required(VERSION 3.8.2)
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
 project(NONE)
 

--- a/samples/drivers/CAN/CMakeLists.txt
+++ b/samples/drivers/CAN/CMakeLists.txt
@@ -1,3 +1,4 @@
+cmake_minimum_required(VERSION 3.8.2)
 
 set(KCONFIG_ROOT ${CMAKE_CURRENT_SOURCE_DIR}/Kconfig)
 

--- a/samples/drivers/crypto/CMakeLists.txt
+++ b/samples/drivers/crypto/CMakeLists.txt
@@ -1,3 +1,4 @@
+cmake_minimum_required(VERSION 3.8.2)
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
 project(NONE)
 

--- a/samples/drivers/current_sensing/CMakeLists.txt
+++ b/samples/drivers/current_sensing/CMakeLists.txt
@@ -1,3 +1,4 @@
+cmake_minimum_required(VERSION 3.8.2)
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
 project(NONE)
 

--- a/samples/drivers/entropy/CMakeLists.txt
+++ b/samples/drivers/entropy/CMakeLists.txt
@@ -1,3 +1,4 @@
+cmake_minimum_required(VERSION 3.8.2)
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
 project(NONE)
 

--- a/samples/drivers/flash_shell/CMakeLists.txt
+++ b/samples/drivers/flash_shell/CMakeLists.txt
@@ -1,3 +1,4 @@
+cmake_minimum_required(VERSION 3.8.2)
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
 project(NONE)
 

--- a/samples/drivers/gpio/CMakeLists.txt
+++ b/samples/drivers/gpio/CMakeLists.txt
@@ -1,3 +1,4 @@
+cmake_minimum_required(VERSION 3.8.2)
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
 project(NONE)
 

--- a/samples/drivers/i2c_fujitsu_fram/CMakeLists.txt
+++ b/samples/drivers/i2c_fujitsu_fram/CMakeLists.txt
@@ -1,3 +1,4 @@
+cmake_minimum_required(VERSION 3.8.2)
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
 project(NONE)
 

--- a/samples/drivers/lcd_hd44780/CMakeLists.txt
+++ b/samples/drivers/lcd_hd44780/CMakeLists.txt
@@ -1,3 +1,4 @@
+cmake_minimum_required(VERSION 3.8.2)
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
 project(NONE)
 

--- a/samples/drivers/led_apa102c/CMakeLists.txt
+++ b/samples/drivers/led_apa102c/CMakeLists.txt
@@ -1,3 +1,4 @@
+cmake_minimum_required(VERSION 3.8.2)
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
 project(NONE)
 

--- a/samples/drivers/led_lp3943/CMakeLists.txt
+++ b/samples/drivers/led_lp3943/CMakeLists.txt
@@ -1,3 +1,4 @@
+cmake_minimum_required(VERSION 3.8.2)
 macro(set_conf_file)
   if(EXISTS               ${APPLICATION_SOURCE_DIR}/boards/${BOARD}.conf)
     set(CONF_FILE "prj.conf ${APPLICATION_SOURCE_DIR}/boards/${BOARD}.conf")

--- a/samples/drivers/led_lpd8806/CMakeLists.txt
+++ b/samples/drivers/led_lpd8806/CMakeLists.txt
@@ -1,3 +1,4 @@
+cmake_minimum_required(VERSION 3.8.2)
 macro(set_conf_file)
   if(EXISTS               ${APPLICATION_SOURCE_DIR}/boards/${BOARD}.conf)
     set(CONF_FILE "prj.conf ${APPLICATION_SOURCE_DIR}/boards/${BOARD}.conf")

--- a/samples/drivers/led_pca9633/CMakeLists.txt
+++ b/samples/drivers/led_pca9633/CMakeLists.txt
@@ -1,3 +1,4 @@
+cmake_minimum_required(VERSION 3.8.2)
 macro(set_conf_file)
   if(EXISTS               ${APPLICATION_SOURCE_DIR}/boards/${BOARD}.conf)
     set(CONF_FILE "prj.conf ${APPLICATION_SOURCE_DIR}/boards/${BOARD}.conf")

--- a/samples/drivers/led_ws2812/CMakeLists.txt
+++ b/samples/drivers/led_ws2812/CMakeLists.txt
@@ -1,3 +1,4 @@
+cmake_minimum_required(VERSION 3.8.2)
 macro(set_conf_file)
   if(EXISTS               ${APPLICATION_SOURCE_DIR}/boards/${BOARD}.conf)
     set(CONF_FILE "prj.conf ${APPLICATION_SOURCE_DIR}/boards/${BOARD}.conf")

--- a/samples/drivers/random/CMakeLists.txt
+++ b/samples/drivers/random/CMakeLists.txt
@@ -1,3 +1,4 @@
+cmake_minimum_required(VERSION 3.8.2)
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
 project(NONE)
 

--- a/samples/drivers/rtc/CMakeLists.txt
+++ b/samples/drivers/rtc/CMakeLists.txt
@@ -1,3 +1,4 @@
+cmake_minimum_required(VERSION 3.8.2)
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
 project(NONE)
 

--- a/samples/drivers/soc_flash_nrf/CMakeLists.txt
+++ b/samples/drivers/soc_flash_nrf/CMakeLists.txt
@@ -1,3 +1,4 @@
+cmake_minimum_required(VERSION 3.8.2)
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
 project(NONE)
 

--- a/samples/drivers/spi_flash/CMakeLists.txt
+++ b/samples/drivers/spi_flash/CMakeLists.txt
@@ -1,3 +1,4 @@
+cmake_minimum_required(VERSION 3.8.2)
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
 project(NONE)
 

--- a/samples/drivers/spi_fujitsu_fram/CMakeLists.txt
+++ b/samples/drivers/spi_fujitsu_fram/CMakeLists.txt
@@ -1,3 +1,4 @@
+cmake_minimum_required(VERSION 3.8.2)
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
 project(NONE)
 

--- a/samples/drivers/watchdog/CMakeLists.txt
+++ b/samples/drivers/watchdog/CMakeLists.txt
@@ -1,3 +1,4 @@
+cmake_minimum_required(VERSION 3.8.2)
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
 project(NONE)
 

--- a/samples/hello_world/CMakeLists.txt
+++ b/samples/hello_world/CMakeLists.txt
@@ -1,3 +1,4 @@
+cmake_minimum_required(VERSION 3.8.2)
 
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
 project(NONE)

--- a/samples/mpu/mem_domain_apis_test/CMakeLists.txt
+++ b/samples/mpu/mem_domain_apis_test/CMakeLists.txt
@@ -1,3 +1,4 @@
+cmake_minimum_required(VERSION 3.8.2)
 
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
 project(NONE)

--- a/samples/mpu/mpu_stack_guard_test/CMakeLists.txt
+++ b/samples/mpu/mpu_stack_guard_test/CMakeLists.txt
@@ -1,3 +1,4 @@
+cmake_minimum_required(VERSION 3.8.2)
 
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
 project(NONE)

--- a/samples/mpu/mpu_test/CMakeLists.txt
+++ b/samples/mpu/mpu_test/CMakeLists.txt
@@ -1,3 +1,4 @@
+cmake_minimum_required(VERSION 3.8.2)
 
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
 project(NONE)

--- a/samples/net/coap_client/CMakeLists.txt
+++ b/samples/net/coap_client/CMakeLists.txt
@@ -1,3 +1,4 @@
+cmake_minimum_required(VERSION 3.8.2)
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
 project(NONE)
 

--- a/samples/net/coap_server/CMakeLists.txt
+++ b/samples/net/coap_server/CMakeLists.txt
@@ -1,3 +1,4 @@
+cmake_minimum_required(VERSION 3.8.2)
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
 project(NONE)
 

--- a/samples/net/coaps_client/CMakeLists.txt
+++ b/samples/net/coaps_client/CMakeLists.txt
@@ -1,3 +1,4 @@
+cmake_minimum_required(VERSION 3.8.2)
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
 project(NONE)
 

--- a/samples/net/coaps_server/CMakeLists.txt
+++ b/samples/net/coaps_server/CMakeLists.txt
@@ -1,3 +1,4 @@
+cmake_minimum_required(VERSION 3.8.2)
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
 project(NONE)
 

--- a/samples/net/dhcpv4_client/CMakeLists.txt
+++ b/samples/net/dhcpv4_client/CMakeLists.txt
@@ -1,3 +1,4 @@
+cmake_minimum_required(VERSION 3.8.2)
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
 project(NONE)
 

--- a/samples/net/dns_resolve/CMakeLists.txt
+++ b/samples/net/dns_resolve/CMakeLists.txt
@@ -1,3 +1,4 @@
+cmake_minimum_required(VERSION 3.8.2)
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
 project(NONE)
 

--- a/samples/net/echo_client/CMakeLists.txt
+++ b/samples/net/echo_client/CMakeLists.txt
@@ -1,3 +1,4 @@
+cmake_minimum_required(VERSION 3.8.2)
 macro(set_conf_file)
   if(EXISTS ${APPLICATION_SOURCE_DIR}/prj_${BOARD}.conf)
     set(CONF_FILE "${APPLICATION_SOURCE_DIR}/prj_${BOARD}.conf")

--- a/samples/net/echo_server/CMakeLists.txt
+++ b/samples/net/echo_server/CMakeLists.txt
@@ -1,3 +1,4 @@
+cmake_minimum_required(VERSION 3.8.2)
 macro(set_conf_file)
   if(EXISTS ${APPLICATION_SOURCE_DIR}/prj_${BOARD}.conf)
     set(CONF_FILE "${APPLICATION_SOURCE_DIR}/prj_${BOARD}.conf")

--- a/samples/net/eth_native_posix/CMakeLists.txt
+++ b/samples/net/eth_native_posix/CMakeLists.txt
@@ -1,3 +1,4 @@
+cmake_minimum_required(VERSION 3.8.2)
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
 project(NONE)
 

--- a/samples/net/gptp/CMakeLists.txt
+++ b/samples/net/gptp/CMakeLists.txt
@@ -1,3 +1,4 @@
+cmake_minimum_required(VERSION 3.8.2)
 set(KCONFIG_ROOT ${CMAKE_CURRENT_SOURCE_DIR}/Kconfig)
 
 macro(set_conf_file)

--- a/samples/net/http_client/CMakeLists.txt
+++ b/samples/net/http_client/CMakeLists.txt
@@ -1,3 +1,4 @@
+cmake_minimum_required(VERSION 3.8.2)
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
 project(NONE)
 

--- a/samples/net/http_server/CMakeLists.txt
+++ b/samples/net/http_server/CMakeLists.txt
@@ -1,3 +1,4 @@
+cmake_minimum_required(VERSION 3.8.2)
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
 project(NONE)
 

--- a/samples/net/ipv4_autoconf/CMakeLists.txt
+++ b/samples/net/ipv4_autoconf/CMakeLists.txt
@@ -1,3 +1,4 @@
+cmake_minimum_required(VERSION 3.8.2)
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
 project(NONE)
 

--- a/samples/net/irc_bot/CMakeLists.txt
+++ b/samples/net/irc_bot/CMakeLists.txt
@@ -1,3 +1,4 @@
+cmake_minimum_required(VERSION 3.8.2)
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
 project(NONE)
 

--- a/samples/net/leds_demo/CMakeLists.txt
+++ b/samples/net/leds_demo/CMakeLists.txt
@@ -1,3 +1,4 @@
+cmake_minimum_required(VERSION 3.8.2)
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
 project(NONE)
 

--- a/samples/net/lldp/CMakeLists.txt
+++ b/samples/net/lldp/CMakeLists.txt
@@ -1,3 +1,4 @@
+cmake_minimum_required(VERSION 3.8.2)
 set(KCONFIG_ROOT ${CMAKE_CURRENT_SOURCE_DIR}/Kconfig)
 
 macro(set_conf_file)

--- a/samples/net/lwm2m_client/CMakeLists.txt
+++ b/samples/net/lwm2m_client/CMakeLists.txt
@@ -1,3 +1,4 @@
+cmake_minimum_required(VERSION 3.8.2)
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
 project(NONE)
 

--- a/samples/net/mbedtls_dtlsclient/CMakeLists.txt
+++ b/samples/net/mbedtls_dtlsclient/CMakeLists.txt
@@ -1,3 +1,4 @@
+cmake_minimum_required(VERSION 3.8.2)
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
 project(NONE)
 

--- a/samples/net/mbedtls_dtlsserver/CMakeLists.txt
+++ b/samples/net/mbedtls_dtlsserver/CMakeLists.txt
@@ -1,3 +1,4 @@
+cmake_minimum_required(VERSION 3.8.2)
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
 project(NONE)
 

--- a/samples/net/mbedtls_sslclient/CMakeLists.txt
+++ b/samples/net/mbedtls_sslclient/CMakeLists.txt
@@ -1,3 +1,4 @@
+cmake_minimum_required(VERSION 3.8.2)
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
 project(NONE)
 

--- a/samples/net/mdns_responder/CMakeLists.txt
+++ b/samples/net/mdns_responder/CMakeLists.txt
@@ -1,3 +1,4 @@
+cmake_minimum_required(VERSION 3.8.2)
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
 project(NONE)
 

--- a/samples/net/mqtt_publisher/CMakeLists.txt
+++ b/samples/net/mqtt_publisher/CMakeLists.txt
@@ -1,3 +1,4 @@
+cmake_minimum_required(VERSION 3.8.2)
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
 project(NONE)
 

--- a/samples/net/nats/CMakeLists.txt
+++ b/samples/net/nats/CMakeLists.txt
@@ -1,3 +1,4 @@
+cmake_minimum_required(VERSION 3.8.2)
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
 project(NONE)
 

--- a/samples/net/promiscuous_mode/CMakeLists.txt
+++ b/samples/net/promiscuous_mode/CMakeLists.txt
@@ -1,3 +1,4 @@
+cmake_minimum_required(VERSION 3.8.2)
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
 project(NONE)
 

--- a/samples/net/rpl-mesh-qemu/node/CMakeLists.txt
+++ b/samples/net/rpl-mesh-qemu/node/CMakeLists.txt
@@ -1,3 +1,4 @@
+cmake_minimum_required(VERSION 3.8.2)
 set(BOARD qemu_cortex_m3)
 set(CONF_FILE prj_qemu.conf)
 

--- a/samples/net/rpl-mesh-qemu/root/CMakeLists.txt
+++ b/samples/net/rpl-mesh-qemu/root/CMakeLists.txt
@@ -1,3 +1,4 @@
+cmake_minimum_required(VERSION 3.8.2)
 set(BOARD qemu_cortex_m3)
 set(CONF_FILE prj_qemu.conf)
 

--- a/samples/net/rpl_border_router/CMakeLists.txt
+++ b/samples/net/rpl_border_router/CMakeLists.txt
@@ -1,3 +1,4 @@
+cmake_minimum_required(VERSION 3.8.2)
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
 project(NONE)
 

--- a/samples/net/rpl_node/CMakeLists.txt
+++ b/samples/net/rpl_node/CMakeLists.txt
@@ -1,3 +1,4 @@
+cmake_minimum_required(VERSION 3.8.2)
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
 project(NONE)
 

--- a/samples/net/sntp_client/CMakeLists.txt
+++ b/samples/net/sntp_client/CMakeLists.txt
@@ -1,3 +1,4 @@
+cmake_minimum_required(VERSION 3.8.2)
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
 project(NONE)
 

--- a/samples/net/sockets/big_http_download/CMakeLists.txt
+++ b/samples/net/sockets/big_http_download/CMakeLists.txt
@@ -1,3 +1,4 @@
+cmake_minimum_required(VERSION 3.8.2)
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
 project(NONE)
 

--- a/samples/net/sockets/dumb_http_server/CMakeLists.txt
+++ b/samples/net/sockets/dumb_http_server/CMakeLists.txt
@@ -1,3 +1,4 @@
+cmake_minimum_required(VERSION 3.8.2)
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
 project(NONE)
 

--- a/samples/net/sockets/echo/CMakeLists.txt
+++ b/samples/net/sockets/echo/CMakeLists.txt
@@ -1,3 +1,4 @@
+cmake_minimum_required(VERSION 3.8.2)
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
 project(NONE)
 

--- a/samples/net/sockets/echo_async/CMakeLists.txt
+++ b/samples/net/sockets/echo_async/CMakeLists.txt
@@ -1,3 +1,4 @@
+cmake_minimum_required(VERSION 3.8.2)
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
 project(NONE)
 

--- a/samples/net/sockets/echo_client/CMakeLists.txt
+++ b/samples/net/sockets/echo_client/CMakeLists.txt
@@ -1,3 +1,4 @@
+cmake_minimum_required(VERSION 3.8.2)
 macro(set_conf_file)
   if(EXISTS                 ${APPLICATION_SOURCE_DIR}/boards/${BOARD}.conf)
     set(CONF_FILE "prj.conf ${APPLICATION_SOURCE_DIR}/boards/${BOARD}.conf")

--- a/samples/net/sockets/echo_server/CMakeLists.txt
+++ b/samples/net/sockets/echo_server/CMakeLists.txt
@@ -1,3 +1,4 @@
+cmake_minimum_required(VERSION 3.8.2)
 macro(set_conf_file)
   if(EXISTS                 ${APPLICATION_SOURCE_DIR}/boards/${BOARD}.conf)
     set(CONF_FILE "prj.conf ${APPLICATION_SOURCE_DIR}/boards/${BOARD}.conf")

--- a/samples/net/sockets/http_get/CMakeLists.txt
+++ b/samples/net/sockets/http_get/CMakeLists.txt
@@ -1,3 +1,4 @@
+cmake_minimum_required(VERSION 3.8.2)
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
 project(NONE)
 

--- a/samples/net/stats/CMakeLists.txt
+++ b/samples/net/stats/CMakeLists.txt
@@ -1,3 +1,4 @@
+cmake_minimum_required(VERSION 3.8.2)
 set(KCONFIG_ROOT ${CMAKE_CURRENT_SOURCE_DIR}/Kconfig)
 
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)

--- a/samples/net/syslog_net/CMakeLists.txt
+++ b/samples/net/syslog_net/CMakeLists.txt
@@ -1,3 +1,4 @@
+cmake_minimum_required(VERSION 3.8.2)
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
 project(NONE)
 

--- a/samples/net/telnet/CMakeLists.txt
+++ b/samples/net/telnet/CMakeLists.txt
@@ -1,3 +1,4 @@
+cmake_minimum_required(VERSION 3.8.2)
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
 project(NONE)
 

--- a/samples/net/throughput_server/CMakeLists.txt
+++ b/samples/net/throughput_server/CMakeLists.txt
@@ -1,3 +1,4 @@
+cmake_minimum_required(VERSION 3.8.2)
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
 project(NONE)
 

--- a/samples/net/traffic_class/CMakeLists.txt
+++ b/samples/net/traffic_class/CMakeLists.txt
@@ -1,3 +1,4 @@
+cmake_minimum_required(VERSION 3.8.2)
 set(KCONFIG_ROOT ${CMAKE_CURRENT_SOURCE_DIR}/Kconfig)
 
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)

--- a/samples/net/vlan/CMakeLists.txt
+++ b/samples/net/vlan/CMakeLists.txt
@@ -1,3 +1,4 @@
+cmake_minimum_required(VERSION 3.8.2)
 set(KCONFIG_ROOT ${CMAKE_CURRENT_SOURCE_DIR}/Kconfig)
 
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)

--- a/samples/net/wifi/CMakeLists.txt
+++ b/samples/net/wifi/CMakeLists.txt
@@ -1,3 +1,4 @@
+cmake_minimum_required(VERSION 3.8.2)
 set(KCONFIG_ROOT ${CMAKE_CURRENT_SOURCE_DIR}/Kconfig)
 
 macro(set_conf_file)

--- a/samples/net/wpan_serial/CMakeLists.txt
+++ b/samples/net/wpan_serial/CMakeLists.txt
@@ -1,3 +1,4 @@
+cmake_minimum_required(VERSION 3.8.2)
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
 project(NONE)
 

--- a/samples/net/wpanusb/CMakeLists.txt
+++ b/samples/net/wpanusb/CMakeLists.txt
@@ -1,3 +1,4 @@
+cmake_minimum_required(VERSION 3.8.2)
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
 project(NONE)
 

--- a/samples/net/ws_console/CMakeLists.txt
+++ b/samples/net/ws_console/CMakeLists.txt
@@ -1,3 +1,4 @@
+cmake_minimum_required(VERSION 3.8.2)
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
 project(NONE)
 

--- a/samples/net/ws_echo_server/CMakeLists.txt
+++ b/samples/net/ws_echo_server/CMakeLists.txt
@@ -1,3 +1,4 @@
+cmake_minimum_required(VERSION 3.8.2)
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
 project(NONE)
 

--- a/samples/net/zperf/CMakeLists.txt
+++ b/samples/net/zperf/CMakeLists.txt
@@ -1,3 +1,4 @@
+cmake_minimum_required(VERSION 3.8.2)
 macro(set_conf_file)
   if(PROFILER)
     set(CONF_FILE prj_${BOARD}_prof.conf)

--- a/samples/nfc/nfc_hello/CMakeLists.txt
+++ b/samples/nfc/nfc_hello/CMakeLists.txt
@@ -1,3 +1,4 @@
+cmake_minimum_required(VERSION 3.8.2)
 list(APPEND QEMU_EXTRA_FLAGS -serial tcp:localhost:8888)
 
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)

--- a/samples/philosophers/CMakeLists.txt
+++ b/samples/philosophers/CMakeLists.txt
@@ -1,3 +1,4 @@
+cmake_minimum_required(VERSION 3.8.2)
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
 project(NONE)
 

--- a/samples/sensor/adt7420/CMakeLists.txt
+++ b/samples/sensor/adt7420/CMakeLists.txt
@@ -1,3 +1,4 @@
+cmake_minimum_required(VERSION 3.8.2)
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
 project(NONE)
 

--- a/samples/sensor/amg88xx/CMakeLists.txt
+++ b/samples/sensor/amg88xx/CMakeLists.txt
@@ -1,3 +1,4 @@
+cmake_minimum_required(VERSION 3.8.2)
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
 project(NONE)
 

--- a/samples/sensor/apds9960/CMakeLists.txt
+++ b/samples/sensor/apds9960/CMakeLists.txt
@@ -1,3 +1,4 @@
+cmake_minimum_required(VERSION 3.8.2)
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
 project(NONE)
 

--- a/samples/sensor/bme280/CMakeLists.txt
+++ b/samples/sensor/bme280/CMakeLists.txt
@@ -1,3 +1,4 @@
+cmake_minimum_required(VERSION 3.8.2)
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
 project(NONE)
 

--- a/samples/sensor/bmg160/CMakeLists.txt
+++ b/samples/sensor/bmg160/CMakeLists.txt
@@ -1,3 +1,4 @@
+cmake_minimum_required(VERSION 3.8.2)
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
 project(NONE)
 

--- a/samples/sensor/bmi160/CMakeLists.txt
+++ b/samples/sensor/bmi160/CMakeLists.txt
@@ -1,3 +1,4 @@
+cmake_minimum_required(VERSION 3.8.2)
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
 project(NONE)
 

--- a/samples/sensor/bmm150/CMakeLists.txt
+++ b/samples/sensor/bmm150/CMakeLists.txt
@@ -1,3 +1,4 @@
+cmake_minimum_required(VERSION 3.8.2)
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
 project(NONE)
 

--- a/samples/sensor/ccs811/CMakeLists.txt
+++ b/samples/sensor/ccs811/CMakeLists.txt
@@ -1,3 +1,4 @@
+cmake_minimum_required(VERSION 3.8.2)
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
 project(NONE)
 

--- a/samples/sensor/fxas21002/CMakeLists.txt
+++ b/samples/sensor/fxas21002/CMakeLists.txt
@@ -1,3 +1,4 @@
+cmake_minimum_required(VERSION 3.8.2)
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
 project(NONE)
 

--- a/samples/sensor/fxos8700/CMakeLists.txt
+++ b/samples/sensor/fxos8700/CMakeLists.txt
@@ -1,3 +1,4 @@
+cmake_minimum_required(VERSION 3.8.2)
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
 project(NONE)
 

--- a/samples/sensor/grove_light/CMakeLists.txt
+++ b/samples/sensor/grove_light/CMakeLists.txt
@@ -1,3 +1,4 @@
+cmake_minimum_required(VERSION 3.8.2)
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
 project(NONE)
 

--- a/samples/sensor/grove_temperature/CMakeLists.txt
+++ b/samples/sensor/grove_temperature/CMakeLists.txt
@@ -1,3 +1,4 @@
+cmake_minimum_required(VERSION 3.8.2)
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
 project(NONE)
 

--- a/samples/sensor/hts221/CMakeLists.txt
+++ b/samples/sensor/hts221/CMakeLists.txt
@@ -1,3 +1,4 @@
+cmake_minimum_required(VERSION 3.8.2)
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
 project(NONE)
 

--- a/samples/sensor/magn_polling/CMakeLists.txt
+++ b/samples/sensor/magn_polling/CMakeLists.txt
@@ -1,3 +1,4 @@
+cmake_minimum_required(VERSION 3.8.2)
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
 project(NONE)
 

--- a/samples/sensor/max30101/CMakeLists.txt
+++ b/samples/sensor/max30101/CMakeLists.txt
@@ -1,3 +1,4 @@
+cmake_minimum_required(VERSION 3.8.2)
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
 project(NONE)
 

--- a/samples/sensor/max44009/CMakeLists.txt
+++ b/samples/sensor/max44009/CMakeLists.txt
@@ -1,3 +1,4 @@
+cmake_minimum_required(VERSION 3.8.2)
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
 project(NONE)
 

--- a/samples/sensor/mcp9808/CMakeLists.txt
+++ b/samples/sensor/mcp9808/CMakeLists.txt
@@ -1,3 +1,4 @@
+cmake_minimum_required(VERSION 3.8.2)
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
 project(NONE)
 

--- a/samples/sensor/mma8451q/CMakeLists.txt
+++ b/samples/sensor/mma8451q/CMakeLists.txt
@@ -1,3 +1,4 @@
+cmake_minimum_required(VERSION 3.8.2)
 #
 # Copyright (c) 2018 Lars Knudsen
 #

--- a/samples/sensor/sx9500/CMakeLists.txt
+++ b/samples/sensor/sx9500/CMakeLists.txt
@@ -1,3 +1,4 @@
+cmake_minimum_required(VERSION 3.8.2)
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
 project(NONE)
 

--- a/samples/sensor/th02/CMakeLists.txt
+++ b/samples/sensor/th02/CMakeLists.txt
@@ -1,3 +1,4 @@
+cmake_minimum_required(VERSION 3.8.2)
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
 project(NONE)
 

--- a/samples/sensor/thermometer/CMakeLists.txt
+++ b/samples/sensor/thermometer/CMakeLists.txt
@@ -1,3 +1,4 @@
+cmake_minimum_required(VERSION 3.8.2)
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
 project(NONE)
 

--- a/samples/sensor/tmp112/CMakeLists.txt
+++ b/samples/sensor/tmp112/CMakeLists.txt
@@ -1,3 +1,4 @@
+cmake_minimum_required(VERSION 3.8.2)
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
 project(NONE)
 

--- a/samples/sensor/vl53l0x/CMakeLists.txt
+++ b/samples/sensor/vl53l0x/CMakeLists.txt
@@ -1,3 +1,4 @@
+cmake_minimum_required(VERSION 3.8.2)
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
 project(NONE)
 

--- a/samples/subsys/console/echo/CMakeLists.txt
+++ b/samples/subsys/console/echo/CMakeLists.txt
@@ -1,3 +1,4 @@
+cmake_minimum_required(VERSION 3.8.2)
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
 project(NONE)
 

--- a/samples/subsys/console/getchar/CMakeLists.txt
+++ b/samples/subsys/console/getchar/CMakeLists.txt
@@ -1,3 +1,4 @@
+cmake_minimum_required(VERSION 3.8.2)
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
 project(NONE)
 

--- a/samples/subsys/console/getline/CMakeLists.txt
+++ b/samples/subsys/console/getline/CMakeLists.txt
@@ -1,3 +1,4 @@
+cmake_minimum_required(VERSION 3.8.2)
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
 project(NONE)
 

--- a/samples/subsys/debug/sysview/CMakeLists.txt
+++ b/samples/subsys/debug/sysview/CMakeLists.txt
@@ -1,3 +1,4 @@
+cmake_minimum_required(VERSION 3.8.2)
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
 project(NONE)
 

--- a/samples/subsys/ipc/ipm_mailbox/ap/CMakeLists.txt
+++ b/samples/subsys/ipc/ipm_mailbox/ap/CMakeLists.txt
@@ -1,3 +1,4 @@
+cmake_minimum_required(VERSION 3.8.2)
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
 project(NONE)
 

--- a/samples/subsys/ipc/ipm_mailbox/sensor/CMakeLists.txt
+++ b/samples/subsys/ipc/ipm_mailbox/sensor/CMakeLists.txt
@@ -1,3 +1,4 @@
+cmake_minimum_required(VERSION 3.8.2)
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
 project(NONE)
 

--- a/samples/subsys/ipc/ipm_mcux/CMakeLists.txt
+++ b/samples/subsys/ipc/ipm_mcux/CMakeLists.txt
@@ -1,3 +1,4 @@
+cmake_minimum_required(VERSION 3.8.2)
 # Copyright (c) 2017, NXP
 #
 # SPDX-License-Identifier: Apache-2.0

--- a/samples/subsys/ipc/ipm_mcux/remote/CMakeLists.txt
+++ b/samples/subsys/ipc/ipm_mcux/remote/CMakeLists.txt
@@ -1,3 +1,4 @@
+cmake_minimum_required(VERSION 3.8.2)
 # Copyright (c) 2017, NXP
 #
 # SPDX-License-Identifier: Apache-2.0

--- a/samples/subsys/ipc/openamp/CMakeLists.txt
+++ b/samples/subsys/ipc/openamp/CMakeLists.txt
@@ -1,3 +1,4 @@
+cmake_minimum_required(VERSION 3.8.2)
 # Copyright (c) 2018 Nordic Semiconductor ASA
 #
 # SPDX-License-Identifier: Apache-2.0

--- a/samples/subsys/ipc/openamp/remote/CMakeLists.txt
+++ b/samples/subsys/ipc/openamp/remote/CMakeLists.txt
@@ -1,3 +1,4 @@
+cmake_minimum_required(VERSION 3.8.2)
 # Copyright (c) 2018 Nordic Semiconductor ASA
 #
 # SPDX-License-Identifier: Apache-2.0

--- a/samples/subsys/logging/kernel_event_logger/CMakeLists.txt
+++ b/samples/subsys/logging/kernel_event_logger/CMakeLists.txt
@@ -1,3 +1,4 @@
+cmake_minimum_required(VERSION 3.8.2)
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
 project(NONE)
 

--- a/samples/subsys/logging/logger/CMakeLists.txt
+++ b/samples/subsys/logging/logger/CMakeLists.txt
@@ -1,3 +1,4 @@
+cmake_minimum_required(VERSION 3.8.2)
 
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
 project(NONE)

--- a/samples/subsys/mgmt/mcumgr/smp_svr/CMakeLists.txt
+++ b/samples/subsys/mgmt/mcumgr/smp_svr/CMakeLists.txt
@@ -1,3 +1,4 @@
+cmake_minimum_required(VERSION 3.8.2)
 # Top-level CMakeLists.txt for the skeleton application.
 #
 # Copyright (c) 2017 Open Source Foundries Limited

--- a/samples/subsys/nvs/CMakeLists.txt
+++ b/samples/subsys/nvs/CMakeLists.txt
@@ -1,3 +1,4 @@
+cmake_minimum_required(VERSION 3.8.2)
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
 project(NONE)
 

--- a/samples/subsys/shell/shell_module/CMakeLists.txt
+++ b/samples/subsys/shell/shell_module/CMakeLists.txt
@@ -1,3 +1,4 @@
+cmake_minimum_required(VERSION 3.8.2)
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
 project(NONE)
 

--- a/samples/subsys/usb/cdc_acm/CMakeLists.txt
+++ b/samples/subsys/usb/cdc_acm/CMakeLists.txt
@@ -1,3 +1,4 @@
+cmake_minimum_required(VERSION 3.8.2)
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
 project(NONE)
 

--- a/samples/subsys/usb/console/CMakeLists.txt
+++ b/samples/subsys/usb/console/CMakeLists.txt
@@ -1,3 +1,4 @@
+cmake_minimum_required(VERSION 3.8.2)
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
 project(NONE)
 

--- a/samples/subsys/usb/dfu/CMakeLists.txt
+++ b/samples/subsys/usb/dfu/CMakeLists.txt
@@ -1,3 +1,4 @@
+cmake_minimum_required(VERSION 3.8.2)
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
 project(NONE)
 

--- a/samples/subsys/usb/hid-mouse/CMakeLists.txt
+++ b/samples/subsys/usb/hid-mouse/CMakeLists.txt
@@ -1,3 +1,4 @@
+cmake_minimum_required(VERSION 3.8.2)
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
 project(NONE)
 

--- a/samples/subsys/usb/hid/CMakeLists.txt
+++ b/samples/subsys/usb/hid/CMakeLists.txt
@@ -1,3 +1,4 @@
+cmake_minimum_required(VERSION 3.8.2)
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
 project(NONE)
 

--- a/samples/subsys/usb/mass/CMakeLists.txt
+++ b/samples/subsys/usb/mass/CMakeLists.txt
@@ -1,3 +1,4 @@
+cmake_minimum_required(VERSION 3.8.2)
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
 project(NONE)
 

--- a/samples/subsys/usb/testusb/CMakeLists.txt
+++ b/samples/subsys/usb/testusb/CMakeLists.txt
@@ -1,3 +1,4 @@
+cmake_minimum_required(VERSION 3.8.2)
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
 project(NONE)
 

--- a/samples/subsys/usb/webusb/CMakeLists.txt
+++ b/samples/subsys/usb/webusb/CMakeLists.txt
@@ -1,3 +1,4 @@
+cmake_minimum_required(VERSION 3.8.2)
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
 project(NONE)
 

--- a/samples/synchronization/CMakeLists.txt
+++ b/samples/synchronization/CMakeLists.txt
@@ -1,3 +1,4 @@
+cmake_minimum_required(VERSION 3.8.2)
 
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
 project(NONE)

--- a/samples/testing/integration/CMakeLists.txt
+++ b/samples/testing/integration/CMakeLists.txt
@@ -1,3 +1,4 @@
+cmake_minimum_required(VERSION 3.8.2)
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
 project(NONE)
 

--- a/samples/xtensa_asm2/CMakeLists.txt
+++ b/samples/xtensa_asm2/CMakeLists.txt
@@ -1,3 +1,4 @@
+cmake_minimum_required(VERSION 3.8.2)
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
 project(NONE)
 

--- a/tests/application_development/cpp/CMakeLists.txt
+++ b/tests/application_development/cpp/CMakeLists.txt
@@ -1,3 +1,4 @@
+cmake_minimum_required(VERSION 3.8.2)
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
 project(NONE)
 

--- a/tests/application_development/gen_inc_file/CMakeLists.txt
+++ b/tests/application_development/gen_inc_file/CMakeLists.txt
@@ -1,3 +1,4 @@
+cmake_minimum_required(VERSION 3.8.2)
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
 project(NONE)
 

--- a/tests/benchmarks/app_kernel/CMakeLists.txt
+++ b/tests/benchmarks/app_kernel/CMakeLists.txt
@@ -1,3 +1,4 @@
+cmake_minimum_required(VERSION 3.8.2)
 if(BOARD STREQUAL "minnowboard")
   set(CONF_FILE prj_fp.conf)
 endif()

--- a/tests/benchmarks/boot_time/CMakeLists.txt
+++ b/tests/benchmarks/boot_time/CMakeLists.txt
@@ -1,3 +1,4 @@
+cmake_minimum_required(VERSION 3.8.2)
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
 project(NONE)
 

--- a/tests/benchmarks/footprint/CMakeLists.txt
+++ b/tests/benchmarks/footprint/CMakeLists.txt
@@ -1,3 +1,4 @@
+cmake_minimum_required(VERSION 3.8.2)
 if(NOT DEFINED TEST)
   set(TEST min) # Have TEST default to min
 endif()

--- a/tests/benchmarks/latency_measure/CMakeLists.txt
+++ b/tests/benchmarks/latency_measure/CMakeLists.txt
@@ -1,3 +1,4 @@
+cmake_minimum_required(VERSION 3.8.2)
 set(small_freq_divider_frdm_k64f TRUE)
 set(small_freq_divider_arduino_due TRUE)
 set(small_freq_divider_qemu_cortex_m3 TRUE)

--- a/tests/benchmarks/object_footprint/CMakeLists.txt
+++ b/tests/benchmarks/object_footprint/CMakeLists.txt
@@ -1,3 +1,4 @@
+cmake_minimum_required(VERSION 3.8.2)
 set(KCONFIG_ROOT ${CMAKE_CURRENT_SOURCE_DIR}/Kconfig)
 
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)

--- a/tests/benchmarks/sys_kernel/CMakeLists.txt
+++ b/tests/benchmarks/sys_kernel/CMakeLists.txt
@@ -1,3 +1,4 @@
+cmake_minimum_required(VERSION 3.8.2)
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
 project(NONE)
 

--- a/tests/benchmarks/timing_info/CMakeLists.txt
+++ b/tests/benchmarks/timing_info/CMakeLists.txt
@@ -1,3 +1,4 @@
+cmake_minimum_required(VERSION 3.8.2)
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
 project(NONE)
 

--- a/tests/bluetooth/bluetooth/CMakeLists.txt
+++ b/tests/bluetooth/bluetooth/CMakeLists.txt
@@ -1,3 +1,4 @@
+cmake_minimum_required(VERSION 3.8.2)
 set(NO_QEMU_SERIAL_BT_SERVER 1)
 
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)

--- a/tests/bluetooth/init/CMakeLists.txt
+++ b/tests/bluetooth/init/CMakeLists.txt
@@ -1,3 +1,4 @@
+cmake_minimum_required(VERSION 3.8.2)
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
 project(NONE)
 

--- a/tests/bluetooth/mesh/CMakeLists.txt
+++ b/tests/bluetooth/mesh/CMakeLists.txt
@@ -1,3 +1,4 @@
+cmake_minimum_required(VERSION 3.8.2)
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
 project(NONE)
 

--- a/tests/bluetooth/mesh_shell/CMakeLists.txt
+++ b/tests/bluetooth/mesh_shell/CMakeLists.txt
@@ -1,3 +1,4 @@
+cmake_minimum_required(VERSION 3.8.2)
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
 project(NONE)
 

--- a/tests/bluetooth/shell/CMakeLists.txt
+++ b/tests/bluetooth/shell/CMakeLists.txt
@@ -1,3 +1,4 @@
+cmake_minimum_required(VERSION 3.8.2)
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
 project(NONE)
 

--- a/tests/bluetooth/tester/CMakeLists.txt
+++ b/tests/bluetooth/tester/CMakeLists.txt
@@ -1,3 +1,4 @@
+cmake_minimum_required(VERSION 3.8.2)
 if(BOARD STREQUAL "qemu_cortex_m3")
 set(CONF_FILE qemu.conf)
 else()

--- a/tests/boards/altera_max10/i2c_master/CMakeLists.txt
+++ b/tests/boards/altera_max10/i2c_master/CMakeLists.txt
@@ -1,3 +1,4 @@
+cmake_minimum_required(VERSION 3.8.2)
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
 project(NONE)
 

--- a/tests/boards/altera_max10/msgdma/CMakeLists.txt
+++ b/tests/boards/altera_max10/msgdma/CMakeLists.txt
@@ -1,3 +1,4 @@
+cmake_minimum_required(VERSION 3.8.2)
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
 project(NONE)
 

--- a/tests/boards/altera_max10/qspi/CMakeLists.txt
+++ b/tests/boards/altera_max10/qspi/CMakeLists.txt
@@ -1,3 +1,4 @@
+cmake_minimum_required(VERSION 3.8.2)
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
 project(NONE)
 

--- a/tests/boards/altera_max10/sysid/CMakeLists.txt
+++ b/tests/boards/altera_max10/sysid/CMakeLists.txt
@@ -1,3 +1,4 @@
+cmake_minimum_required(VERSION 3.8.2)
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
 project(NONE)
 

--- a/tests/boards/intel_s1000_crb/CMakeLists.txt
+++ b/tests/boards/intel_s1000_crb/CMakeLists.txt
@@ -1,3 +1,4 @@
+cmake_minimum_required(VERSION 3.8.2)
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
 project(NONE)
 

--- a/tests/boards/native_posix/native_tasks/CMakeLists.txt
+++ b/tests/boards/native_posix/native_tasks/CMakeLists.txt
@@ -1,3 +1,4 @@
+cmake_minimum_required(VERSION 3.8.2)
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
 project(NONE)
 

--- a/tests/boards/native_posix/rtc/CMakeLists.txt
+++ b/tests/boards/native_posix/rtc/CMakeLists.txt
@@ -1,3 +1,4 @@
+cmake_minimum_required(VERSION 3.8.2)
 
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
 project(NONE)

--- a/tests/booting/stub/CMakeLists.txt
+++ b/tests/booting/stub/CMakeLists.txt
@@ -1,3 +1,4 @@
+cmake_minimum_required(VERSION 3.8.2)
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
 project(NONE)
 

--- a/tests/cmsis_rtos_v1/CMakeLists.txt
+++ b/tests/cmsis_rtos_v1/CMakeLists.txt
@@ -1,3 +1,4 @@
+cmake_minimum_required(VERSION 3.8.2)
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
 project(NONE)
 

--- a/tests/crypto/aes/CMakeLists.txt
+++ b/tests/crypto/aes/CMakeLists.txt
@@ -1,3 +1,4 @@
+cmake_minimum_required(VERSION 3.8.2)
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
 project(NONE)
 

--- a/tests/crypto/cbc_mode/CMakeLists.txt
+++ b/tests/crypto/cbc_mode/CMakeLists.txt
@@ -1,3 +1,4 @@
+cmake_minimum_required(VERSION 3.8.2)
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
 project(NONE)
 

--- a/tests/crypto/ccm_mode/CMakeLists.txt
+++ b/tests/crypto/ccm_mode/CMakeLists.txt
@@ -1,3 +1,4 @@
+cmake_minimum_required(VERSION 3.8.2)
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
 project(NONE)
 

--- a/tests/crypto/cmac_mode/CMakeLists.txt
+++ b/tests/crypto/cmac_mode/CMakeLists.txt
@@ -1,3 +1,4 @@
+cmake_minimum_required(VERSION 3.8.2)
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
 project(NONE)
 

--- a/tests/crypto/ctr_mode/CMakeLists.txt
+++ b/tests/crypto/ctr_mode/CMakeLists.txt
@@ -1,3 +1,4 @@
+cmake_minimum_required(VERSION 3.8.2)
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
 project(NONE)
 

--- a/tests/crypto/ctr_prng/CMakeLists.txt
+++ b/tests/crypto/ctr_prng/CMakeLists.txt
@@ -1,3 +1,4 @@
+cmake_minimum_required(VERSION 3.8.2)
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
 project(NONE)
 

--- a/tests/crypto/ecc_dh/CMakeLists.txt
+++ b/tests/crypto/ecc_dh/CMakeLists.txt
@@ -1,3 +1,4 @@
+cmake_minimum_required(VERSION 3.8.2)
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
 project(NONE)
 

--- a/tests/crypto/ecc_dsa/CMakeLists.txt
+++ b/tests/crypto/ecc_dsa/CMakeLists.txt
@@ -1,3 +1,4 @@
+cmake_minimum_required(VERSION 3.8.2)
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
 project(NONE)
 

--- a/tests/crypto/hmac/CMakeLists.txt
+++ b/tests/crypto/hmac/CMakeLists.txt
@@ -1,3 +1,4 @@
+cmake_minimum_required(VERSION 3.8.2)
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
 project(NONE)
 

--- a/tests/crypto/hmac_prng/CMakeLists.txt
+++ b/tests/crypto/hmac_prng/CMakeLists.txt
@@ -1,3 +1,4 @@
+cmake_minimum_required(VERSION 3.8.2)
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
 project(NONE)
 

--- a/tests/crypto/mbedtls/CMakeLists.txt
+++ b/tests/crypto/mbedtls/CMakeLists.txt
@@ -1,3 +1,4 @@
+cmake_minimum_required(VERSION 3.8.2)
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
 project(NONE)
 

--- a/tests/crypto/rand32/CMakeLists.txt
+++ b/tests/crypto/rand32/CMakeLists.txt
@@ -1,3 +1,4 @@
+cmake_minimum_required(VERSION 3.8.2)
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
 project(NONE)
 

--- a/tests/crypto/sha256/CMakeLists.txt
+++ b/tests/crypto/sha256/CMakeLists.txt
@@ -1,3 +1,4 @@
+cmake_minimum_required(VERSION 3.8.2)
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
 project(NONE)
 

--- a/tests/drivers/adc/adc_api/CMakeLists.txt
+++ b/tests/drivers/adc/adc_api/CMakeLists.txt
@@ -1,3 +1,4 @@
+cmake_minimum_required(VERSION 3.8.2)
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
 project(NONE)
 

--- a/tests/drivers/adc/adc_simple/CMakeLists.txt
+++ b/tests/drivers/adc/adc_simple/CMakeLists.txt
@@ -1,3 +1,4 @@
+cmake_minimum_required(VERSION 3.8.2)
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
 project(NONE)
 

--- a/tests/drivers/aio/api/CMakeLists.txt
+++ b/tests/drivers/aio/api/CMakeLists.txt
@@ -1,3 +1,4 @@
+cmake_minimum_required(VERSION 3.8.2)
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
 project(NONE)
 

--- a/tests/drivers/aio/app/CMakeLists.txt
+++ b/tests/drivers/aio/app/CMakeLists.txt
@@ -1,3 +1,4 @@
+cmake_minimum_required(VERSION 3.8.2)
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
 project(NONE)
 

--- a/tests/drivers/aon_counter/aon_api/CMakeLists.txt
+++ b/tests/drivers/aon_counter/aon_api/CMakeLists.txt
@@ -1,3 +1,4 @@
+cmake_minimum_required(VERSION 3.8.2)
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
 project(NONE)
 

--- a/tests/drivers/build_all/CMakeLists.txt
+++ b/tests/drivers/build_all/CMakeLists.txt
@@ -1,3 +1,4 @@
+cmake_minimum_required(VERSION 3.8.2)
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
 project(NONE)
 

--- a/tests/drivers/dma/chan_blen_transfer/CMakeLists.txt
+++ b/tests/drivers/dma/chan_blen_transfer/CMakeLists.txt
@@ -1,3 +1,4 @@
+cmake_minimum_required(VERSION 3.8.2)
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
 project(NONE)
 

--- a/tests/drivers/dma/loop_transfer/CMakeLists.txt
+++ b/tests/drivers/dma/loop_transfer/CMakeLists.txt
@@ -1,3 +1,4 @@
+cmake_minimum_required(VERSION 3.8.2)
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
 project(NONE)
 

--- a/tests/drivers/entropy/api/CMakeLists.txt
+++ b/tests/drivers/entropy/api/CMakeLists.txt
@@ -1,3 +1,4 @@
+cmake_minimum_required(VERSION 3.8.2)
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
 project(NONE)
 

--- a/tests/drivers/gpio/gpio_basic_api/CMakeLists.txt
+++ b/tests/drivers/gpio/gpio_basic_api/CMakeLists.txt
@@ -1,3 +1,4 @@
+cmake_minimum_required(VERSION 3.8.2)
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
 project(NONE)
 

--- a/tests/drivers/i2c/i2c_api/CMakeLists.txt
+++ b/tests/drivers/i2c/i2c_api/CMakeLists.txt
@@ -1,3 +1,4 @@
+cmake_minimum_required(VERSION 3.8.2)
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
 project(NONE)
 

--- a/tests/drivers/i2c/i2c_slave_api/CMakeLists.txt
+++ b/tests/drivers/i2c/i2c_slave_api/CMakeLists.txt
@@ -1,3 +1,4 @@
+cmake_minimum_required(VERSION 3.8.2)
 set(KCONFIG_ROOT ${CMAKE_CURRENT_SOURCE_DIR}/Kconfig)
 
 macro(set_conf_file)

--- a/tests/drivers/i2s/i2s_api/CMakeLists.txt
+++ b/tests/drivers/i2s/i2s_api/CMakeLists.txt
@@ -1,3 +1,4 @@
+cmake_minimum_required(VERSION 3.8.2)
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
 project(NONE)
 

--- a/tests/drivers/i2s/i2s_speed/CMakeLists.txt
+++ b/tests/drivers/i2s/i2s_speed/CMakeLists.txt
@@ -1,3 +1,4 @@
+cmake_minimum_required(VERSION 3.8.2)
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
 project(NONE)
 

--- a/tests/drivers/ipm/CMakeLists.txt
+++ b/tests/drivers/ipm/CMakeLists.txt
@@ -1,3 +1,4 @@
+cmake_minimum_required(VERSION 3.8.2)
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
 project(NONE)
 

--- a/tests/drivers/pci_enum/CMakeLists.txt
+++ b/tests/drivers/pci_enum/CMakeLists.txt
@@ -1,3 +1,4 @@
+cmake_minimum_required(VERSION 3.8.2)
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
 project(NONE)
 

--- a/tests/drivers/pinmux/pinmux_basic_api/CMakeLists.txt
+++ b/tests/drivers/pinmux/pinmux_basic_api/CMakeLists.txt
@@ -1,3 +1,4 @@
+cmake_minimum_required(VERSION 3.8.2)
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
 project(NONE)
 

--- a/tests/drivers/pwm/pwm_api/CMakeLists.txt
+++ b/tests/drivers/pwm/pwm_api/CMakeLists.txt
@@ -1,3 +1,4 @@
+cmake_minimum_required(VERSION 3.8.2)
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
 project(NONE)
 

--- a/tests/drivers/rtc/rtc_basic_api/CMakeLists.txt
+++ b/tests/drivers/rtc/rtc_basic_api/CMakeLists.txt
@@ -1,3 +1,4 @@
+cmake_minimum_required(VERSION 3.8.2)
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
 project(NONE)
 

--- a/tests/drivers/spi/spi_loopback/CMakeLists.txt
+++ b/tests/drivers/spi/spi_loopback/CMakeLists.txt
@@ -1,3 +1,4 @@
+cmake_minimum_required(VERSION 3.8.2)
 set(KCONFIG_ROOT ${CMAKE_CURRENT_SOURCE_DIR}/Kconfig)
 
 macro(set_conf_file)

--- a/tests/drivers/uart/uart_basic_api/CMakeLists.txt
+++ b/tests/drivers/uart/uart_basic_api/CMakeLists.txt
@@ -1,3 +1,4 @@
+cmake_minimum_required(VERSION 3.8.2)
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
 project(NONE)
 

--- a/tests/drivers/watchdog/wdt_basic_api/CMakeLists.txt
+++ b/tests/drivers/watchdog/wdt_basic_api/CMakeLists.txt
@@ -1,3 +1,4 @@
+cmake_minimum_required(VERSION 3.8.2)
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
 project(NONE)
 

--- a/tests/kernel/alert/alert_api/CMakeLists.txt
+++ b/tests/kernel/alert/alert_api/CMakeLists.txt
@@ -1,3 +1,4 @@
+cmake_minimum_required(VERSION 3.8.2)
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
 project(NONE)
 

--- a/tests/kernel/arm_irq_vector_table/CMakeLists.txt
+++ b/tests/kernel/arm_irq_vector_table/CMakeLists.txt
@@ -1,3 +1,4 @@
+cmake_minimum_required(VERSION 3.8.2)
 set(KCONFIG_ROOT ${CMAKE_CURRENT_SOURCE_DIR}/Kconfig)
 
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)

--- a/tests/kernel/arm_runtime_nmi/CMakeLists.txt
+++ b/tests/kernel/arm_runtime_nmi/CMakeLists.txt
@@ -1,3 +1,4 @@
+cmake_minimum_required(VERSION 3.8.2)
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
 project(NONE)
 

--- a/tests/kernel/boot_page_table/CMakeLists.txt
+++ b/tests/kernel/boot_page_table/CMakeLists.txt
@@ -1,3 +1,4 @@
+cmake_minimum_required(VERSION 3.8.2)
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
 project(NONE)
 

--- a/tests/kernel/common/CMakeLists.txt
+++ b/tests/kernel/common/CMakeLists.txt
@@ -1,3 +1,4 @@
+cmake_minimum_required(VERSION 3.8.2)
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
 project(NONE)
 

--- a/tests/kernel/context/CMakeLists.txt
+++ b/tests/kernel/context/CMakeLists.txt
@@ -1,3 +1,4 @@
+cmake_minimum_required(VERSION 3.8.2)
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
 project(NONE)
 

--- a/tests/kernel/critical/CMakeLists.txt
+++ b/tests/kernel/critical/CMakeLists.txt
@@ -1,3 +1,4 @@
+cmake_minimum_required(VERSION 3.8.2)
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
 project(NONE)
 

--- a/tests/kernel/device/CMakeLists.txt
+++ b/tests/kernel/device/CMakeLists.txt
@@ -1,3 +1,4 @@
+cmake_minimum_required(VERSION 3.8.2)
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
 project(NONE)
 

--- a/tests/kernel/early_sleep/CMakeLists.txt
+++ b/tests/kernel/early_sleep/CMakeLists.txt
@@ -1,3 +1,4 @@
+cmake_minimum_required(VERSION 3.8.2)
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
 project(NONE)
 

--- a/tests/kernel/errno/CMakeLists.txt
+++ b/tests/kernel/errno/CMakeLists.txt
@@ -1,3 +1,4 @@
+cmake_minimum_required(VERSION 3.8.2)
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
 project(NONE)
 

--- a/tests/kernel/fatal/CMakeLists.txt
+++ b/tests/kernel/fatal/CMakeLists.txt
@@ -1,3 +1,4 @@
+cmake_minimum_required(VERSION 3.8.2)
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
 project(NONE)
 

--- a/tests/kernel/fifo/fifo_api/CMakeLists.txt
+++ b/tests/kernel/fifo/fifo_api/CMakeLists.txt
@@ -1,3 +1,4 @@
+cmake_minimum_required(VERSION 3.8.2)
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
 project(NONE)
 

--- a/tests/kernel/fifo/fifo_timeout/CMakeLists.txt
+++ b/tests/kernel/fifo/fifo_timeout/CMakeLists.txt
@@ -1,3 +1,4 @@
+cmake_minimum_required(VERSION 3.8.2)
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
 project(NONE)
 

--- a/tests/kernel/fifo/fifo_usage/CMakeLists.txt
+++ b/tests/kernel/fifo/fifo_usage/CMakeLists.txt
@@ -1,3 +1,4 @@
+cmake_minimum_required(VERSION 3.8.2)
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
 project(NONE)
 

--- a/tests/kernel/fp_sharing/CMakeLists.txt
+++ b/tests/kernel/fp_sharing/CMakeLists.txt
@@ -1,3 +1,4 @@
+cmake_minimum_required(VERSION 3.8.2)
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
 project(NONE)
 

--- a/tests/kernel/gen_isr_table/CMakeLists.txt
+++ b/tests/kernel/gen_isr_table/CMakeLists.txt
@@ -1,3 +1,4 @@
+cmake_minimum_required(VERSION 3.8.2)
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
 project(NONE)
 

--- a/tests/kernel/init/CMakeLists.txt
+++ b/tests/kernel/init/CMakeLists.txt
@@ -1,3 +1,4 @@
+cmake_minimum_required(VERSION 3.8.2)
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
 project(NONE)
 

--- a/tests/kernel/irq_offload/CMakeLists.txt
+++ b/tests/kernel/irq_offload/CMakeLists.txt
@@ -1,3 +1,4 @@
+cmake_minimum_required(VERSION 3.8.2)
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
 project(NONE)
 

--- a/tests/kernel/lifo/lifo_api/CMakeLists.txt
+++ b/tests/kernel/lifo/lifo_api/CMakeLists.txt
@@ -1,3 +1,4 @@
+cmake_minimum_required(VERSION 3.8.2)
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
 project(NONE)
 

--- a/tests/kernel/lifo/lifo_usage/CMakeLists.txt
+++ b/tests/kernel/lifo/lifo_usage/CMakeLists.txt
@@ -1,3 +1,4 @@
+cmake_minimum_required(VERSION 3.8.2)
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
 project(NONE)
 

--- a/tests/kernel/mbox/mbox_api/CMakeLists.txt
+++ b/tests/kernel/mbox/mbox_api/CMakeLists.txt
@@ -1,3 +1,4 @@
+cmake_minimum_required(VERSION 3.8.2)
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
 project(NONE)
 

--- a/tests/kernel/mbox/mbox_usage/CMakeLists.txt
+++ b/tests/kernel/mbox/mbox_usage/CMakeLists.txt
@@ -1,3 +1,4 @@
+cmake_minimum_required(VERSION 3.8.2)
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
 project(NONE)
 

--- a/tests/kernel/mem_heap/mheap_api_concept/CMakeLists.txt
+++ b/tests/kernel/mem_heap/mheap_api_concept/CMakeLists.txt
@@ -1,3 +1,4 @@
+cmake_minimum_required(VERSION 3.8.2)
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
 project(NONE)
 

--- a/tests/kernel/mem_pool/mem_pool/CMakeLists.txt
+++ b/tests/kernel/mem_pool/mem_pool/CMakeLists.txt
@@ -1,3 +1,4 @@
+cmake_minimum_required(VERSION 3.8.2)
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
 project(NONE)
 

--- a/tests/kernel/mem_pool/mem_pool_api/CMakeLists.txt
+++ b/tests/kernel/mem_pool/mem_pool_api/CMakeLists.txt
@@ -1,3 +1,4 @@
+cmake_minimum_required(VERSION 3.8.2)
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
 project(NONE)
 

--- a/tests/kernel/mem_pool/mem_pool_concept/CMakeLists.txt
+++ b/tests/kernel/mem_pool/mem_pool_concept/CMakeLists.txt
@@ -1,3 +1,4 @@
+cmake_minimum_required(VERSION 3.8.2)
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
 project(NONE)
 

--- a/tests/kernel/mem_pool/mem_pool_threadsafe/CMakeLists.txt
+++ b/tests/kernel/mem_pool/mem_pool_threadsafe/CMakeLists.txt
@@ -1,3 +1,4 @@
+cmake_minimum_required(VERSION 3.8.2)
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
 project(NONE)
 

--- a/tests/kernel/mem_pool/sys_mem_pool/CMakeLists.txt
+++ b/tests/kernel/mem_pool/sys_mem_pool/CMakeLists.txt
@@ -1,3 +1,4 @@
+cmake_minimum_required(VERSION 3.8.2)
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
 project(NONE)
 

--- a/tests/kernel/mem_protect/app_memory/CMakeLists.txt
+++ b/tests/kernel/mem_protect/app_memory/CMakeLists.txt
@@ -1,3 +1,4 @@
+cmake_minimum_required(VERSION 3.8.2)
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
 project(NONE)
 

--- a/tests/kernel/mem_protect/mem_protect/CMakeLists.txt
+++ b/tests/kernel/mem_protect/mem_protect/CMakeLists.txt
@@ -1,3 +1,4 @@
+cmake_minimum_required(VERSION 3.8.2)
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
 project(NONE)
 

--- a/tests/kernel/mem_protect/obj_validation/CMakeLists.txt
+++ b/tests/kernel/mem_protect/obj_validation/CMakeLists.txt
@@ -1,3 +1,4 @@
+cmake_minimum_required(VERSION 3.8.2)
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
 project(NONE)
 

--- a/tests/kernel/mem_protect/protection/CMakeLists.txt
+++ b/tests/kernel/mem_protect/protection/CMakeLists.txt
@@ -1,3 +1,4 @@
+cmake_minimum_required(VERSION 3.8.2)
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
 project(NONE)
 

--- a/tests/kernel/mem_protect/stack_random/CMakeLists.txt
+++ b/tests/kernel/mem_protect/stack_random/CMakeLists.txt
@@ -1,3 +1,4 @@
+cmake_minimum_required(VERSION 3.8.2)
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
 project(NONE)
 

--- a/tests/kernel/mem_protect/stackprot/CMakeLists.txt
+++ b/tests/kernel/mem_protect/stackprot/CMakeLists.txt
@@ -1,3 +1,4 @@
+cmake_minimum_required(VERSION 3.8.2)
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
 project(NONE)
 

--- a/tests/kernel/mem_protect/syscalls/CMakeLists.txt
+++ b/tests/kernel/mem_protect/syscalls/CMakeLists.txt
@@ -1,3 +1,4 @@
+cmake_minimum_required(VERSION 3.8.2)
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
 project(NONE)
 

--- a/tests/kernel/mem_protect/userspace/CMakeLists.txt
+++ b/tests/kernel/mem_protect/userspace/CMakeLists.txt
@@ -1,3 +1,4 @@
+cmake_minimum_required(VERSION 3.8.2)
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
 project(NONE)
 

--- a/tests/kernel/mem_protect/x86_mmu_api/CMakeLists.txt
+++ b/tests/kernel/mem_protect/x86_mmu_api/CMakeLists.txt
@@ -1,3 +1,4 @@
+cmake_minimum_required(VERSION 3.8.2)
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
 project(NONE)
 

--- a/tests/kernel/mem_slab/mslab/CMakeLists.txt
+++ b/tests/kernel/mem_slab/mslab/CMakeLists.txt
@@ -1,3 +1,4 @@
+cmake_minimum_required(VERSION 3.8.2)
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
 project(NONE)
 

--- a/tests/kernel/mem_slab/mslab_api/CMakeLists.txt
+++ b/tests/kernel/mem_slab/mslab_api/CMakeLists.txt
@@ -1,3 +1,4 @@
+cmake_minimum_required(VERSION 3.8.2)
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
 project(NONE)
 

--- a/tests/kernel/mem_slab/mslab_concept/CMakeLists.txt
+++ b/tests/kernel/mem_slab/mslab_concept/CMakeLists.txt
@@ -1,3 +1,4 @@
+cmake_minimum_required(VERSION 3.8.2)
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
 project(NONE)
 

--- a/tests/kernel/mem_slab/mslab_threadsafe/CMakeLists.txt
+++ b/tests/kernel/mem_slab/mslab_threadsafe/CMakeLists.txt
@@ -1,3 +1,4 @@
+cmake_minimum_required(VERSION 3.8.2)
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
 project(NONE)
 

--- a/tests/kernel/mp/CMakeLists.txt
+++ b/tests/kernel/mp/CMakeLists.txt
@@ -1,3 +1,4 @@
+cmake_minimum_required(VERSION 3.8.2)
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
 project(NONE)
 

--- a/tests/kernel/msgq/msgq_api/CMakeLists.txt
+++ b/tests/kernel/msgq/msgq_api/CMakeLists.txt
@@ -1,3 +1,4 @@
+cmake_minimum_required(VERSION 3.8.2)
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
 project(NONE)
 

--- a/tests/kernel/mutex/mutex/CMakeLists.txt
+++ b/tests/kernel/mutex/mutex/CMakeLists.txt
@@ -1,3 +1,4 @@
+cmake_minimum_required(VERSION 3.8.2)
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
 project(NONE)
 

--- a/tests/kernel/mutex/mutex_api/CMakeLists.txt
+++ b/tests/kernel/mutex/mutex_api/CMakeLists.txt
@@ -1,3 +1,4 @@
+cmake_minimum_required(VERSION 3.8.2)
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
 project(NONE)
 

--- a/tests/kernel/obj_tracing/CMakeLists.txt
+++ b/tests/kernel/obj_tracing/CMakeLists.txt
@@ -1,3 +1,4 @@
+cmake_minimum_required(VERSION 3.8.2)
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
 project(NONE)
 

--- a/tests/kernel/pending/CMakeLists.txt
+++ b/tests/kernel/pending/CMakeLists.txt
@@ -1,3 +1,4 @@
+cmake_minimum_required(VERSION 3.8.2)
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
 project(NONE)
 

--- a/tests/kernel/pipe/pipe/CMakeLists.txt
+++ b/tests/kernel/pipe/pipe/CMakeLists.txt
@@ -1,3 +1,4 @@
+cmake_minimum_required(VERSION 3.8.2)
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
 project(NONE)
 

--- a/tests/kernel/pipe/pipe_api/CMakeLists.txt
+++ b/tests/kernel/pipe/pipe_api/CMakeLists.txt
@@ -1,3 +1,4 @@
+cmake_minimum_required(VERSION 3.8.2)
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
 project(NONE)
 

--- a/tests/kernel/poll/CMakeLists.txt
+++ b/tests/kernel/poll/CMakeLists.txt
@@ -1,3 +1,4 @@
+cmake_minimum_required(VERSION 3.8.2)
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
 project(NONE)
 

--- a/tests/kernel/profiling/profiling_api/CMakeLists.txt
+++ b/tests/kernel/profiling/profiling_api/CMakeLists.txt
@@ -1,3 +1,4 @@
+cmake_minimum_required(VERSION 3.8.2)
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
 project(NONE)
 

--- a/tests/kernel/queue/CMakeLists.txt
+++ b/tests/kernel/queue/CMakeLists.txt
@@ -1,3 +1,4 @@
+cmake_minimum_required(VERSION 3.8.2)
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
 project(NONE)
 

--- a/tests/kernel/sched/preempt/CMakeLists.txt
+++ b/tests/kernel/sched/preempt/CMakeLists.txt
@@ -1,3 +1,4 @@
+cmake_minimum_required(VERSION 3.8.2)
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
 project(NONE)
 

--- a/tests/kernel/sched/schedule_api/CMakeLists.txt
+++ b/tests/kernel/sched/schedule_api/CMakeLists.txt
@@ -1,3 +1,4 @@
+cmake_minimum_required(VERSION 3.8.2)
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
 project(NONE)
 

--- a/tests/kernel/semaphore/sema_api/CMakeLists.txt
+++ b/tests/kernel/semaphore/sema_api/CMakeLists.txt
@@ -1,3 +1,4 @@
+cmake_minimum_required(VERSION 3.8.2)
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
 project(NONE)
 

--- a/tests/kernel/semaphore/semaphore/CMakeLists.txt
+++ b/tests/kernel/semaphore/semaphore/CMakeLists.txt
@@ -1,3 +1,4 @@
+cmake_minimum_required(VERSION 3.8.2)
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
 project(NONE)
 

--- a/tests/kernel/sleep/CMakeLists.txt
+++ b/tests/kernel/sleep/CMakeLists.txt
@@ -1,3 +1,4 @@
+cmake_minimum_required(VERSION 3.8.2)
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
 project(NONE)
 

--- a/tests/kernel/smp/CMakeLists.txt
+++ b/tests/kernel/smp/CMakeLists.txt
@@ -1,3 +1,4 @@
+cmake_minimum_required(VERSION 3.8.2)
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
 project(NONE)
 

--- a/tests/kernel/spinlock/CMakeLists.txt
+++ b/tests/kernel/spinlock/CMakeLists.txt
@@ -1,3 +1,4 @@
+cmake_minimum_required(VERSION 3.8.2)
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
 project(NONE)
 

--- a/tests/kernel/stack/stack_api/CMakeLists.txt
+++ b/tests/kernel/stack/stack_api/CMakeLists.txt
@@ -1,3 +1,4 @@
+cmake_minimum_required(VERSION 3.8.2)
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
 project(NONE)
 

--- a/tests/kernel/stack/stack_usage/CMakeLists.txt
+++ b/tests/kernel/stack/stack_usage/CMakeLists.txt
@@ -1,3 +1,4 @@
+cmake_minimum_required(VERSION 3.8.2)
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
 project(NONE)
 

--- a/tests/kernel/static_idt/CMakeLists.txt
+++ b/tests/kernel/static_idt/CMakeLists.txt
@@ -1,3 +1,4 @@
+cmake_minimum_required(VERSION 3.8.2)
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
 project(NONE)
 

--- a/tests/kernel/threads/dynamic_thread/CMakeLists.txt
+++ b/tests/kernel/threads/dynamic_thread/CMakeLists.txt
@@ -1,3 +1,4 @@
+cmake_minimum_required(VERSION 3.8.2)
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
 project(NONE)
 

--- a/tests/kernel/threads/no-multithreading/CMakeLists.txt
+++ b/tests/kernel/threads/no-multithreading/CMakeLists.txt
@@ -1,3 +1,4 @@
+cmake_minimum_required(VERSION 3.8.2)
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
 project(NONE)
 

--- a/tests/kernel/threads/thread_apis/CMakeLists.txt
+++ b/tests/kernel/threads/thread_apis/CMakeLists.txt
@@ -1,3 +1,4 @@
+cmake_minimum_required(VERSION 3.8.2)
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
 project(NONE)
 

--- a/tests/kernel/threads/thread_init/CMakeLists.txt
+++ b/tests/kernel/threads/thread_init/CMakeLists.txt
@@ -1,3 +1,4 @@
+cmake_minimum_required(VERSION 3.8.2)
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
 project(NONE)
 

--- a/tests/kernel/tickless/tickless/CMakeLists.txt
+++ b/tests/kernel/tickless/tickless/CMakeLists.txt
@@ -1,3 +1,4 @@
+cmake_minimum_required(VERSION 3.8.2)
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
 project(NONE)
 

--- a/tests/kernel/tickless/tickless_concept/CMakeLists.txt
+++ b/tests/kernel/tickless/tickless_concept/CMakeLists.txt
@@ -1,3 +1,4 @@
+cmake_minimum_required(VERSION 3.8.2)
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
 project(NONE)
 

--- a/tests/kernel/timer/timer_api/CMakeLists.txt
+++ b/tests/kernel/timer/timer_api/CMakeLists.txt
@@ -1,3 +1,4 @@
+cmake_minimum_required(VERSION 3.8.2)
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
 project(NONE)
 

--- a/tests/kernel/timer/timer_monotonic/CMakeLists.txt
+++ b/tests/kernel/timer/timer_monotonic/CMakeLists.txt
@@ -1,3 +1,4 @@
+cmake_minimum_required(VERSION 3.8.2)
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
 project(NONE)
 

--- a/tests/kernel/workq/work_queue/CMakeLists.txt
+++ b/tests/kernel/workq/work_queue/CMakeLists.txt
@@ -1,3 +1,4 @@
+cmake_minimum_required(VERSION 3.8.2)
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
 project(NONE)
 

--- a/tests/kernel/workq/work_queue_api/CMakeLists.txt
+++ b/tests/kernel/workq/work_queue_api/CMakeLists.txt
@@ -1,3 +1,4 @@
+cmake_minimum_required(VERSION 3.8.2)
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
 project(NONE)
 

--- a/tests/kernel/xip/CMakeLists.txt
+++ b/tests/kernel/xip/CMakeLists.txt
@@ -1,3 +1,4 @@
+cmake_minimum_required(VERSION 3.8.2)
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
 project(NONE)
 

--- a/tests/lib/base64/CMakeLists.txt
+++ b/tests/lib/base64/CMakeLists.txt
@@ -1,3 +1,4 @@
+cmake_minimum_required(VERSION 3.8.2)
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
 project(NONE)
 

--- a/tests/lib/c_lib/CMakeLists.txt
+++ b/tests/lib/c_lib/CMakeLists.txt
@@ -1,3 +1,4 @@
+cmake_minimum_required(VERSION 3.8.2)
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
 project(NONE)
 

--- a/tests/lib/json/CMakeLists.txt
+++ b/tests/lib/json/CMakeLists.txt
@@ -1,3 +1,4 @@
+cmake_minimum_required(VERSION 3.8.2)
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
 project(NONE)
 

--- a/tests/lib/mem_alloc/CMakeLists.txt
+++ b/tests/lib/mem_alloc/CMakeLists.txt
@@ -1,3 +1,4 @@
+cmake_minimum_required(VERSION 3.8.2)
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
 project(NONE)
 

--- a/tests/lib/rbtree/CMakeLists.txt
+++ b/tests/lib/rbtree/CMakeLists.txt
@@ -1,3 +1,4 @@
+cmake_minimum_required(VERSION 3.8.2)
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
 project(NONE)
 

--- a/tests/lib/ringbuffer/CMakeLists.txt
+++ b/tests/lib/ringbuffer/CMakeLists.txt
@@ -1,3 +1,4 @@
+cmake_minimum_required(VERSION 3.8.2)
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
 project(NONE)
 

--- a/tests/lib/sprintf/CMakeLists.txt
+++ b/tests/lib/sprintf/CMakeLists.txt
@@ -1,3 +1,4 @@
+cmake_minimum_required(VERSION 3.8.2)
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
 project(NONE)
 

--- a/tests/misc/test_build/CMakeLists.txt
+++ b/tests/misc/test_build/CMakeLists.txt
@@ -1,3 +1,4 @@
+cmake_minimum_required(VERSION 3.8.2)
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
 project(NONE)
 

--- a/tests/net/6lo/CMakeLists.txt
+++ b/tests/net/6lo/CMakeLists.txt
@@ -1,3 +1,4 @@
+cmake_minimum_required(VERSION 3.8.2)
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
 project(NONE)
 

--- a/tests/net/all/CMakeLists.txt
+++ b/tests/net/all/CMakeLists.txt
@@ -1,3 +1,4 @@
+cmake_minimum_required(VERSION 3.8.2)
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
 project(NONE)
 

--- a/tests/net/app/CMakeLists.txt
+++ b/tests/net/app/CMakeLists.txt
@@ -1,3 +1,4 @@
+cmake_minimum_required(VERSION 3.8.2)
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
 project(NONE)
 

--- a/tests/net/arp/CMakeLists.txt
+++ b/tests/net/arp/CMakeLists.txt
@@ -1,3 +1,4 @@
+cmake_minimum_required(VERSION 3.8.2)
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
 project(NONE)
 

--- a/tests/net/buf/CMakeLists.txt
+++ b/tests/net/buf/CMakeLists.txt
@@ -1,3 +1,4 @@
+cmake_minimum_required(VERSION 3.8.2)
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
 project(NONE)
 

--- a/tests/net/checksum_offload/CMakeLists.txt
+++ b/tests/net/checksum_offload/CMakeLists.txt
@@ -1,3 +1,4 @@
+cmake_minimum_required(VERSION 3.8.2)
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
 project(NONE)
 

--- a/tests/net/context/CMakeLists.txt
+++ b/tests/net/context/CMakeLists.txt
@@ -1,3 +1,4 @@
+cmake_minimum_required(VERSION 3.8.2)
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
 project(NONE)
 

--- a/tests/net/dhcpv4/CMakeLists.txt
+++ b/tests/net/dhcpv4/CMakeLists.txt
@@ -1,3 +1,4 @@
+cmake_minimum_required(VERSION 3.8.2)
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
 project(NONE)
 

--- a/tests/net/ethernet_mgmt/CMakeLists.txt
+++ b/tests/net/ethernet_mgmt/CMakeLists.txt
@@ -1,3 +1,4 @@
+cmake_minimum_required(VERSION 3.8.2)
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
 project(NONE)
 

--- a/tests/net/icmpv6/CMakeLists.txt
+++ b/tests/net/icmpv6/CMakeLists.txt
@@ -1,3 +1,4 @@
+cmake_minimum_required(VERSION 3.8.2)
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
 project(NONE)
 

--- a/tests/net/ieee802154/crypto/CMakeLists.txt
+++ b/tests/net/ieee802154/crypto/CMakeLists.txt
@@ -1,3 +1,4 @@
+cmake_minimum_required(VERSION 3.8.2)
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
 project(NONE)
 

--- a/tests/net/ieee802154/fragment/CMakeLists.txt
+++ b/tests/net/ieee802154/fragment/CMakeLists.txt
@@ -1,3 +1,4 @@
+cmake_minimum_required(VERSION 3.8.2)
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
 project(NONE)
 

--- a/tests/net/ieee802154/l2/CMakeLists.txt
+++ b/tests/net/ieee802154/l2/CMakeLists.txt
@@ -1,3 +1,4 @@
+cmake_minimum_required(VERSION 3.8.2)
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
 project(NONE)
 

--- a/tests/net/iface/CMakeLists.txt
+++ b/tests/net/iface/CMakeLists.txt
@@ -1,3 +1,4 @@
+cmake_minimum_required(VERSION 3.8.2)
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
 project(NONE)
 

--- a/tests/net/ip-addr/CMakeLists.txt
+++ b/tests/net/ip-addr/CMakeLists.txt
@@ -1,3 +1,4 @@
+cmake_minimum_required(VERSION 3.8.2)
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
 project(NONE)
 

--- a/tests/net/ipv6/CMakeLists.txt
+++ b/tests/net/ipv6/CMakeLists.txt
@@ -1,3 +1,4 @@
+cmake_minimum_required(VERSION 3.8.2)
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
 project(NONE)
 

--- a/tests/net/ipv6_fragment/CMakeLists.txt
+++ b/tests/net/ipv6_fragment/CMakeLists.txt
@@ -1,3 +1,4 @@
+cmake_minimum_required(VERSION 3.8.2)
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
 project(NONE)
 

--- a/tests/net/lib/coap/CMakeLists.txt
+++ b/tests/net/lib/coap/CMakeLists.txt
@@ -1,3 +1,4 @@
+cmake_minimum_required(VERSION 3.8.2)
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
 project(NONE)
 

--- a/tests/net/lib/dns_packet/CMakeLists.txt
+++ b/tests/net/lib/dns_packet/CMakeLists.txt
@@ -1,3 +1,4 @@
+cmake_minimum_required(VERSION 3.8.2)
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
 project(NONE)
 

--- a/tests/net/lib/dns_resolve/CMakeLists.txt
+++ b/tests/net/lib/dns_resolve/CMakeLists.txt
@@ -1,3 +1,4 @@
+cmake_minimum_required(VERSION 3.8.2)
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
 project(NONE)
 

--- a/tests/net/lib/http_header_fields/CMakeLists.txt
+++ b/tests/net/lib/http_header_fields/CMakeLists.txt
@@ -1,3 +1,4 @@
+cmake_minimum_required(VERSION 3.8.2)
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
 project(NONE)
 

--- a/tests/net/lib/mqtt_packet/CMakeLists.txt
+++ b/tests/net/lib/mqtt_packet/CMakeLists.txt
@@ -1,3 +1,4 @@
+cmake_minimum_required(VERSION 3.8.2)
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
 project(NONE)
 

--- a/tests/net/lib/mqtt_publisher/CMakeLists.txt
+++ b/tests/net/lib/mqtt_publisher/CMakeLists.txt
@@ -1,3 +1,4 @@
+cmake_minimum_required(VERSION 3.8.2)
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
 project(NONE)
 

--- a/tests/net/lib/mqtt_subscriber/CMakeLists.txt
+++ b/tests/net/lib/mqtt_subscriber/CMakeLists.txt
@@ -1,3 +1,4 @@
+cmake_minimum_required(VERSION 3.8.2)
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
 project(NONE)
 

--- a/tests/net/lib/tls_credentials/CMakeLists.txt
+++ b/tests/net/lib/tls_credentials/CMakeLists.txt
@@ -1,3 +1,4 @@
+cmake_minimum_required(VERSION 3.8.2)
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
 project(NONE)
 

--- a/tests/net/mgmt/CMakeLists.txt
+++ b/tests/net/mgmt/CMakeLists.txt
@@ -1,3 +1,4 @@
+cmake_minimum_required(VERSION 3.8.2)
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
 project(NONE)
 

--- a/tests/net/mld/CMakeLists.txt
+++ b/tests/net/mld/CMakeLists.txt
@@ -1,3 +1,4 @@
+cmake_minimum_required(VERSION 3.8.2)
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
 project(NONE)
 

--- a/tests/net/neighbor/CMakeLists.txt
+++ b/tests/net/neighbor/CMakeLists.txt
@@ -1,3 +1,4 @@
+cmake_minimum_required(VERSION 3.8.2)
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
 project(NONE)
 

--- a/tests/net/net_pkt/CMakeLists.txt
+++ b/tests/net/net_pkt/CMakeLists.txt
@@ -1,3 +1,4 @@
+cmake_minimum_required(VERSION 3.8.2)
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
 project(NONE)
 

--- a/tests/net/promiscuous/CMakeLists.txt
+++ b/tests/net/promiscuous/CMakeLists.txt
@@ -1,3 +1,4 @@
+cmake_minimum_required(VERSION 3.8.2)
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
 project(NONE)
 

--- a/tests/net/ptp/clock/CMakeLists.txt
+++ b/tests/net/ptp/clock/CMakeLists.txt
@@ -1,3 +1,4 @@
+cmake_minimum_required(VERSION 3.8.2)
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
 project(NONE)
 

--- a/tests/net/route/CMakeLists.txt
+++ b/tests/net/route/CMakeLists.txt
@@ -1,3 +1,4 @@
+cmake_minimum_required(VERSION 3.8.2)
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
 project(NONE)
 

--- a/tests/net/rpl/CMakeLists.txt
+++ b/tests/net/rpl/CMakeLists.txt
@@ -1,3 +1,4 @@
+cmake_minimum_required(VERSION 3.8.2)
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
 project(NONE)
 

--- a/tests/net/socket/getaddrinfo/CMakeLists.txt
+++ b/tests/net/socket/getaddrinfo/CMakeLists.txt
@@ -1,3 +1,4 @@
+cmake_minimum_required(VERSION 3.8.2)
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
 project(NONE)
 

--- a/tests/net/socket/tcp/CMakeLists.txt
+++ b/tests/net/socket/tcp/CMakeLists.txt
@@ -1,3 +1,4 @@
+cmake_minimum_required(VERSION 3.8.2)
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
 project(NONE)
 

--- a/tests/net/socket/udp/CMakeLists.txt
+++ b/tests/net/socket/udp/CMakeLists.txt
@@ -1,3 +1,4 @@
+cmake_minimum_required(VERSION 3.8.2)
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
 project(NONE)
 

--- a/tests/net/tcp/CMakeLists.txt
+++ b/tests/net/tcp/CMakeLists.txt
@@ -1,3 +1,4 @@
+cmake_minimum_required(VERSION 3.8.2)
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
 project(NONE)
 

--- a/tests/net/traffic_class/CMakeLists.txt
+++ b/tests/net/traffic_class/CMakeLists.txt
@@ -1,3 +1,4 @@
+cmake_minimum_required(VERSION 3.8.2)
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
 project(NONE)
 

--- a/tests/net/trickle/CMakeLists.txt
+++ b/tests/net/trickle/CMakeLists.txt
@@ -1,3 +1,4 @@
+cmake_minimum_required(VERSION 3.8.2)
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
 project(NONE)
 

--- a/tests/net/tx_timestamp/CMakeLists.txt
+++ b/tests/net/tx_timestamp/CMakeLists.txt
@@ -1,3 +1,4 @@
+cmake_minimum_required(VERSION 3.8.2)
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
 project(NONE)
 

--- a/tests/net/udp/CMakeLists.txt
+++ b/tests/net/udp/CMakeLists.txt
@@ -1,3 +1,4 @@
+cmake_minimum_required(VERSION 3.8.2)
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
 project(NONE)
 

--- a/tests/net/utils/CMakeLists.txt
+++ b/tests/net/utils/CMakeLists.txt
@@ -1,3 +1,4 @@
+cmake_minimum_required(VERSION 3.8.2)
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
 project(NONE)
 

--- a/tests/net/vlan/CMakeLists.txt
+++ b/tests/net/vlan/CMakeLists.txt
@@ -1,3 +1,4 @@
+cmake_minimum_required(VERSION 3.8.2)
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
 project(NONE)
 

--- a/tests/net/websocket/CMakeLists.txt
+++ b/tests/net/websocket/CMakeLists.txt
@@ -1,3 +1,4 @@
+cmake_minimum_required(VERSION 3.8.2)
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
 project(NONE)
 

--- a/tests/posix/clock/CMakeLists.txt
+++ b/tests/posix/clock/CMakeLists.txt
@@ -1,3 +1,4 @@
+cmake_minimum_required(VERSION 3.8.2)
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
 project(NONE)
 

--- a/tests/posix/fs/CMakeLists.txt
+++ b/tests/posix/fs/CMakeLists.txt
@@ -1,3 +1,4 @@
+cmake_minimum_required(VERSION 3.8.2)
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
 project(NONE)
 

--- a/tests/posix/mqueue/CMakeLists.txt
+++ b/tests/posix/mqueue/CMakeLists.txt
@@ -1,3 +1,4 @@
+cmake_minimum_required(VERSION 3.8.2)
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
 project(NONE)
 

--- a/tests/posix/mutex/CMakeLists.txt
+++ b/tests/posix/mutex/CMakeLists.txt
@@ -1,3 +1,4 @@
+cmake_minimum_required(VERSION 3.8.2)
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
 project(NONE)
 

--- a/tests/posix/posix_checks/CMakeLists.txt
+++ b/tests/posix/posix_checks/CMakeLists.txt
@@ -1,3 +1,4 @@
+cmake_minimum_required(VERSION 3.8.2)
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
 project(NONE)
 

--- a/tests/posix/pthread/CMakeLists.txt
+++ b/tests/posix/pthread/CMakeLists.txt
@@ -1,3 +1,4 @@
+cmake_minimum_required(VERSION 3.8.2)
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
 project(NONE)
 

--- a/tests/posix/pthread_cancel/CMakeLists.txt
+++ b/tests/posix/pthread_cancel/CMakeLists.txt
@@ -1,3 +1,4 @@
+cmake_minimum_required(VERSION 3.8.2)
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
 project(NONE)
 

--- a/tests/posix/pthread_equal/CMakeLists.txt
+++ b/tests/posix/pthread_equal/CMakeLists.txt
@@ -1,3 +1,4 @@
+cmake_minimum_required(VERSION 3.8.2)
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
 project(NONE)
 

--- a/tests/posix/pthread_join/CMakeLists.txt
+++ b/tests/posix/pthread_join/CMakeLists.txt
@@ -1,3 +1,4 @@
+cmake_minimum_required(VERSION 3.8.2)
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
 project(NONE)
 

--- a/tests/posix/pthread_key/CMakeLists.txt
+++ b/tests/posix/pthread_key/CMakeLists.txt
@@ -1,3 +1,4 @@
+cmake_minimum_required(VERSION 3.8.2)
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
 project(NONE)
 

--- a/tests/posix/pthread_rwlock/CMakeLists.txt
+++ b/tests/posix/pthread_rwlock/CMakeLists.txt
@@ -1,3 +1,4 @@
+cmake_minimum_required(VERSION 3.8.2)
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
 project(NONE)
 

--- a/tests/posix/semaphore/CMakeLists.txt
+++ b/tests/posix/semaphore/CMakeLists.txt
@@ -1,3 +1,4 @@
+cmake_minimum_required(VERSION 3.8.2)
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
 project(NONE)
 

--- a/tests/posix/timer/CMakeLists.txt
+++ b/tests/posix/timer/CMakeLists.txt
@@ -1,3 +1,4 @@
+cmake_minimum_required(VERSION 3.8.2)
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
 project(NONE)
 

--- a/tests/power/multicore/arc/CMakeLists.txt
+++ b/tests/power/multicore/arc/CMakeLists.txt
@@ -1,3 +1,4 @@
+cmake_minimum_required(VERSION 3.8.2)
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
 project(NONE)
 

--- a/tests/power/multicore/lmt/CMakeLists.txt
+++ b/tests/power/multicore/lmt/CMakeLists.txt
@@ -1,3 +1,4 @@
+cmake_minimum_required(VERSION 3.8.2)
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
 project(NONE)
 

--- a/tests/power/power_states/CMakeLists.txt
+++ b/tests/power/power_states/CMakeLists.txt
@@ -1,3 +1,4 @@
+cmake_minimum_required(VERSION 3.8.2)
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
 project(NONE)
 

--- a/tests/shell/CMakeLists.txt
+++ b/tests/shell/CMakeLists.txt
@@ -1,3 +1,4 @@
+cmake_minimum_required(VERSION 3.8.2)
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
 project(NONE)
 

--- a/tests/subsys/dfu/img_util/CMakeLists.txt
+++ b/tests/subsys/dfu/img_util/CMakeLists.txt
@@ -1,3 +1,4 @@
+cmake_minimum_required(VERSION 3.8.2)
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
 project(NONE)
 

--- a/tests/subsys/dfu/mcuboot/CMakeLists.txt
+++ b/tests/subsys/dfu/mcuboot/CMakeLists.txt
@@ -1,3 +1,4 @@
+cmake_minimum_required(VERSION 3.8.2)
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
 project(NONE)
 

--- a/tests/subsys/fs/fat_fs_api/CMakeLists.txt
+++ b/tests/subsys/fs/fat_fs_api/CMakeLists.txt
@@ -1,3 +1,4 @@
+cmake_minimum_required(VERSION 3.8.2)
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
 project(NONE)
 

--- a/tests/subsys/fs/fat_fs_dual_drive/CMakeLists.txt
+++ b/tests/subsys/fs/fat_fs_dual_drive/CMakeLists.txt
@@ -1,3 +1,4 @@
+cmake_minimum_required(VERSION 3.8.2)
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
 project(NONE)
 

--- a/tests/subsys/fs/fcb/CMakeLists.txt
+++ b/tests/subsys/fs/fcb/CMakeLists.txt
@@ -1,3 +1,4 @@
+cmake_minimum_required(VERSION 3.8.2)
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
 project(NONE)
 

--- a/tests/subsys/fs/multi-fs/CMakeLists.txt
+++ b/tests/subsys/fs/multi-fs/CMakeLists.txt
@@ -1,3 +1,4 @@
+cmake_minimum_required(VERSION 3.8.2)
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
 project(NONE)
 

--- a/tests/subsys/fs/nffs_fs_api/basic/CMakeLists.txt
+++ b/tests/subsys/fs/nffs_fs_api/basic/CMakeLists.txt
@@ -1,3 +1,4 @@
+cmake_minimum_required(VERSION 3.8.2)
 if(BOARD STREQUAL nrf51_pca10028)
     set(CONF_FILE nrf5x.conf)
 elseif(BOARD STREQUAL nrf52_pca10040)

--- a/tests/subsys/fs/nffs_fs_api/cache/CMakeLists.txt
+++ b/tests/subsys/fs/nffs_fs_api/cache/CMakeLists.txt
@@ -1,3 +1,4 @@
+cmake_minimum_required(VERSION 3.8.2)
 if(BOARD STREQUAL nrf51_pca10028)
     set(CONF_FILE nrf5x.conf)
 elseif(BOARD STREQUAL nrf52_pca10040)

--- a/tests/subsys/fs/nffs_fs_api/large/CMakeLists.txt
+++ b/tests/subsys/fs/nffs_fs_api/large/CMakeLists.txt
@@ -1,3 +1,4 @@
+cmake_minimum_required(VERSION 3.8.2)
 if(BOARD STREQUAL nrf51_pca10028)
     set(CONF_FILE nrf5x.conf)
 elseif(BOARD STREQUAL nrf52_pca10040)

--- a/tests/subsys/fs/nffs_fs_api/performance/CMakeLists.txt
+++ b/tests/subsys/fs/nffs_fs_api/performance/CMakeLists.txt
@@ -1,3 +1,4 @@
+cmake_minimum_required(VERSION 3.8.2)
 if(BOARD STREQUAL nrf51_pca10028)
     set(CONF_FILE nrf5x.conf)
 elseif(BOARD STREQUAL nrf52_pca10040)

--- a/tests/subsys/logging/log_core/CMakeLists.txt
+++ b/tests/subsys/logging/log_core/CMakeLists.txt
@@ -1,3 +1,4 @@
+cmake_minimum_required(VERSION 3.8.2)
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
 project(NONE)
 

--- a/tests/subsys/logging/log_list/CMakeLists.txt
+++ b/tests/subsys/logging/log_list/CMakeLists.txt
@@ -1,3 +1,4 @@
+cmake_minimum_required(VERSION 3.8.2)
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
 project(NONE)
 

--- a/tests/subsys/logging/log_msg/CMakeLists.txt
+++ b/tests/subsys/logging/log_msg/CMakeLists.txt
@@ -1,3 +1,4 @@
+cmake_minimum_required(VERSION 3.8.2)
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
 project(NONE)
 

--- a/tests/subsys/logging/logger-hook/CMakeLists.txt
+++ b/tests/subsys/logging/logger-hook/CMakeLists.txt
@@ -1,3 +1,4 @@
+cmake_minimum_required(VERSION 3.8.2)
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
 project(NONE)
 

--- a/tests/subsys/settings/fcb/CMakeLists.txt
+++ b/tests/subsys/settings/fcb/CMakeLists.txt
@@ -1,3 +1,4 @@
+cmake_minimum_required(VERSION 3.8.2)
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
 project(NONE)
 

--- a/tests/subsys/settings/fcb_init/CMakeLists.txt
+++ b/tests/subsys/settings/fcb_init/CMakeLists.txt
@@ -1,3 +1,4 @@
+cmake_minimum_required(VERSION 3.8.2)
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
 project(NONE)
 

--- a/tests/subsys/settings/nffs/CMakeLists.txt
+++ b/tests/subsys/settings/nffs/CMakeLists.txt
@@ -1,3 +1,4 @@
+cmake_minimum_required(VERSION 3.8.2)
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
 project(NONE)
 

--- a/tests/subsys/storage/flash_map/CMakeLists.txt
+++ b/tests/subsys/storage/flash_map/CMakeLists.txt
@@ -1,3 +1,4 @@
+cmake_minimum_required(VERSION 3.8.2)
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
 project(NONE)
 

--- a/tests/subsys/usb/bos/CMakeLists.txt
+++ b/tests/subsys/usb/bos/CMakeLists.txt
@@ -1,3 +1,4 @@
+cmake_minimum_required(VERSION 3.8.2)
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
 project(NONE)
 

--- a/tests/subsys/usb/os_desc/CMakeLists.txt
+++ b/tests/subsys/usb/os_desc/CMakeLists.txt
@@ -1,3 +1,4 @@
+cmake_minimum_required(VERSION 3.8.2)
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
 project(NONE)
 

--- a/tests/unit/bluetooth/at/CMakeLists.txt
+++ b/tests/unit/bluetooth/at/CMakeLists.txt
@@ -1,3 +1,4 @@
+cmake_minimum_required(VERSION 3.8.2)
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
 project(NONE)
 

--- a/tests/ztest/test/base/CMakeLists.txt
+++ b/tests/ztest/test/base/CMakeLists.txt
@@ -1,3 +1,4 @@
+cmake_minimum_required(VERSION 3.8.2)
 if(BOARD STREQUAL unit_testing)
   list(APPEND SOURCES src/main.c)
 

--- a/tests/ztest/test/mock/CMakeLists.txt
+++ b/tests/ztest/test/mock/CMakeLists.txt
@@ -1,3 +1,4 @@
+cmake_minimum_required(VERSION 3.8.2)
 if(BOARD STREQUAL unit_testing)
   list(APPEND SOURCES src/main.c)
 


### PR DESCRIPTION
Prepend the text 'cmake_minimum_required(VERSION 3.8.2)' into the
application and test build scripts.

Modern versions of CMake will spam users with a deprecation warning
when the toplevel CMakeLists.txt does not specify a CMake
version. This is documented in bug #8355.

To resolve this we include a dummy cmake_minimum_required() line into
the toplevel build scripts. This version is then overridden by
boileplate.cmake to avoid duplicating the true minimum required
version between all build scripts.

Also change CMake policy CMP000 from OLD to NEW which in turn
finally rids us of the verbose warning and fixes #8355.

The extra boilerplate is is considered more acceptable than the
verbosity of the CMP0000 policy.