### PR TITLE
arch: x86: set output format/arch per arch

### DIFF
--- a/arch/x86/CMakeLists.txt
+++ b/arch/x86/CMakeLists.txt
@@ -7,6 +7,16 @@ else()
   zephyr_compile_definitions(PERF_OPT)
 endif()
 
+if(CONFIG_X86_IAMCU)
+  set_property(GLOBAL APPEND PROPERTY PROPERTY_LINKER_SCRIPT_DEFINES -D__IAMCU)
+  set_property(GLOBAL        PROPERTY PROPERTY_OUTPUT_FORMAT         "elf32-iamcu")
+  set_property(GLOBAL        PROPERTY PROPERTY_OUTPUT_ARCH           "iamcu:intel")
+else()
+  set_property(GLOBAL PROPERTY PROPERTY_OUTPUT_ARCH "i386")
+  set_property(GLOBAL PROPERTY PROPERTY_OUTPUT_FORMAT "elf32-i386")
+endif()
+
+
 
 if(CMAKE_C_COMPILER_ID STREQUAL "Clang")
   if(CONFIG_X86_IAMCU)
@@ -33,9 +43,6 @@ endif()
 set(GENIDT ${ZEPHYR_BASE}/scripts/gen_idt.py)
 
 define_property(GLOBAL PROPERTY PROPERTY_OUTPUT_ARCH BRIEF_DOCS " " FULL_DOCS " ")
-set_property(GLOBAL PROPERTY PROPERTY_OUTPUT_ARCH "i386")
-
-set_property(GLOBAL PROPERTY PROPERTY_OUTPUT_FORMAT "elf32-i386")
 
 # Use gen_idt.py and objcopy to generate irq_int_vector_map.o and
 # staticIdt.o from the elf file zephyr_prebuilt

--- a/arch/x86/soc/ia32/CMakeLists.txt
+++ b/arch/x86/soc/ia32/CMakeLists.txt
@@ -4,9 +4,6 @@ zephyr_library_include_directories(${ZEPHYR_BASE}/drivers)
 zephyr_cc_option(-march=pentium)
 
 if(CONFIG_X86_IAMCU)
-  set_property(GLOBAL APPEND PROPERTY PROPERTY_LINKER_SCRIPT_DEFINES -D__IAMCU)
-  set_property(GLOBAL        PROPERTY PROPERTY_OUTPUT_FORMAT         "elf32-iamcu")
-  set_property(GLOBAL        PROPERTY PROPERTY_OUTPUT_ARCH           "iamcu:intel")
   zephyr_cc_option(-msoft-float)
 endif()
 

--- a/arch/x86/soc/intel_quark/quark_d2000/CMakeLists.txt
+++ b/arch/x86/soc/intel_quark/quark_d2000/CMakeLists.txt
@@ -7,9 +7,3 @@ zephyr_compile_definitions_ifdef(
   )
 
 zephyr_cc_option(-march=lakemont -mtune=lakemont -msoft-float)
-
-if(CONFIG_X86_IAMCU)
-  set_property(GLOBAL APPEND PROPERTY PROPERTY_LINKER_SCRIPT_DEFINES -D__IAMCU)
-  set_property(GLOBAL        PROPERTY PROPERTY_OUTPUT_FORMAT         "elf32-iamcu")
-  set_property(GLOBAL        PROPERTY PROPERTY_OUTPUT_ARCH           "iamcu:intel")
-endif()

--- a/arch/x86/soc/intel_quark/quark_se/CMakeLists.txt
+++ b/arch/x86/soc/intel_quark/quark_se/CMakeLists.txt
@@ -8,12 +8,6 @@ zephyr_compile_definitions_ifdef(
 
 zephyr_cc_option(-march=lakemont -mtune=lakemont -msoft-float)
 
-if(CONFIG_X86_IAMCU)
-  set_property(GLOBAL APPEND PROPERTY PROPERTY_LINKER_SCRIPT_DEFINES -D__IAMCU)
-  set_property(GLOBAL        PROPERTY PROPERTY_OUTPUT_FORMAT         "elf32-iamcu")
-  set_property(GLOBAL        PROPERTY PROPERTY_OUTPUT_ARCH           "iamcu:intel")
-endif()
-
 zephyr_sources(
   soc.c
   soc_config.c


### PR DESCRIPTION
Instead of doing this per platform, set the output format and arch on
architecture level.

Signed-off-by: Anas Nashif <anas.nashif@intel.com>