### PR TITLE
Get rid of Zephyr's prefer-later-defaults behavior

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,3 +40,6 @@ tags
 .xxproject
 .envrc
 .vscode
+
+# Disables the warning about the changed behavior for Kconfig defaults
+hide-defaults-note

--- a/Kconfig.zephyr
+++ b/Kconfig.zephyr
@@ -7,6 +7,19 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 
+# Include these first so that any properties (e.g. defaults) below can be
+# overriden in *.defconfig files (by defining symbols in multiple locations).
+# After merging all the symbol definitions, Kconfig picks the first property
+# (e.g. the first default) with a satisfied condition.
+#
+# Board defaults should be parsed before SoC defaults, because boards usually
+# overrides SoC values.
+#
+# $ENV_VAR_ARCH and $ENV_VAR_BOARD_DIR might be glob patterns
+gsource "$ENV_VAR_BOARD_DIR/Kconfig.defconfig"
+gsource "arch/$ENV_VAR_ARCH/soc/*/Kconfig.defconfig"
+
+
 source "arch/Kconfig"
 
 source "kernel/Kconfig"
@@ -24,16 +37,3 @@ source "subsys/Kconfig"
 source "ext/Kconfig"
 
 source "tests/Kconfig"
-
-#
-# The following are for Kconfig files for default values only.
-# These should be parsed at the end.
-#
-# Board defaults should be parsed after SoC defaults
-# because board usually overrides SoC values.
-#
-
-# $ENV_VAR_ARCH and $ENV_VAR_BOARD_DIR might be glob patterns
-
-gsource "arch/$ENV_VAR_ARCH/soc/*/Kconfig.defconfig"
-gsource "$ENV_VAR_BOARD_DIR/Kconfig.defconfig"

--- a/arch/Kconfig
+++ b/arch/Kconfig
@@ -8,6 +8,13 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 
+# Include these first so that any properties (e.g. defaults) below can be
+# overriden (by defining symbols in multiple locations)
+
+source "boards/Kconfig"
+# $ENV_VAR_ARCH might be a glob pattern
+gsource "arch/$ENV_VAR_ARCH/Kconfig"
+
 
 choice
 	prompt "Architecture"
@@ -81,8 +88,8 @@ config USERSPACE
 
 config PRIVILEGED_STACK_SIZE
 	int "Size of privileged stack"
-	default 256
 	default 384 if ARC
+	default 256
 	depends on ARCH_HAS_USERSPACE
 	help
 	  This option sets the privileged stack region size that will be used
@@ -318,9 +325,3 @@ config BOARD
 	  The Board is the first location where we search for a linker.ld file,
 	  if not found we look for the linker file in
 	  arch/<arch>/soc/<family>/<series>
-
-
-# $ENV_VAR_ARCH might be a glob pattern
-gsource "arch/$ENV_VAR_ARCH/Kconfig"
-
-source "boards/Kconfig"

--- a/arch/arc/Kconfig
+++ b/arch/arc/Kconfig
@@ -17,6 +17,10 @@ endchoice
 menu "ARC Options"
 	depends on ARC
 
+# Include these first so that any properties (e.g. defaults) below can be
+# overriden (by defining symbols in multiple locations)
+gsource "arch/arc/soc/*/Kconfig"
+
 config ARCH
 	default "arc"
 
@@ -200,7 +204,5 @@ config CACHE_FLUSHING
 	  If the d-cache is NOT present, set this to n.
 
 endmenu
-
-gsource "arch/arc/soc/*/Kconfig"
 
 endmenu

--- a/arch/arm/Kconfig
+++ b/arch/arm/Kconfig
@@ -17,6 +17,14 @@ endchoice
 menu "ARM Options"
 	depends on ARM
 
+menu "SoC Configuration"
+# Include these first so that any properties (e.g. defaults) below can be
+# overriden (by defining symbols in multiple locations)
+gsource "arch/arm/soc/*/Kconfig"
+endmenu
+
+source "arch/arm/core/Kconfig"
+
 config ARCH
 	default "arm"
 
@@ -24,12 +32,4 @@ config ARCH_DEFCONFIG
 	string
 	default "arch/arm/defconfig"
 
-
-source "arch/arm/core/Kconfig"
-
-menu "SoC Configuration"
-
-gsource "arch/arm/soc/*/Kconfig"
-
-endmenu
 endmenu

--- a/arch/arm/soc/atmel_sam/Kconfig.defconfig
+++ b/arch/arm/soc/atmel_sam/Kconfig.defconfig
@@ -4,10 +4,11 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 
+gsource "arch/arm/soc/atmel_sam/*/Kconfig.defconfig.series"
+
 if SOC_FAMILY_SAM
 
 config WATCHDOG
 	def_bool y
 
 endif
-gsource "arch/arm/soc/atmel_sam/*/Kconfig.defconfig.series"

--- a/arch/arm/soc/nordic_nrf/Kconfig.defconfig
+++ b/arch/arm/soc/nordic_nrf/Kconfig.defconfig
@@ -7,6 +7,8 @@
 
 if SOC_FAMILY_NRF
 
+gsource "arch/arm/soc/nordic_nrf/*/Kconfig.defconfig.series"
+
 config BUILD_OUTPUT_HEX
 	default y
 
@@ -30,7 +32,5 @@ config SOC_FLASH_NRF
 	def_bool y
 
 endif # FLASH
-
-gsource "arch/arm/soc/nordic_nrf/*/Kconfig.defconfig.series"
 
 endif # SOC_FAMILY_NRF

--- a/arch/nios2/Kconfig
+++ b/arch/nios2/Kconfig
@@ -13,6 +13,10 @@ endchoice
 menu "Nios II Options"
 	depends on NIOS2
 
+# Include these first so that any properties (e.g. defaults) below can be
+# overriden (by defining symbols in multiple locations)
+gsource "arch/nios2/soc/*/Kconfig"
+
 config ARCH
 	string
 	default "nios2"
@@ -108,7 +112,5 @@ config GP_ALL_DATA
 endchoice
 
 endmenu
-
-gsource "arch/nios2/soc/*/Kconfig"
 
 endmenu

--- a/arch/posix/Kconfig
+++ b/arch/posix/Kconfig
@@ -16,6 +16,10 @@ endchoice
 menu "POSIX (native) Options"
 	depends on ARCH_POSIX
 
+# Include these first so that any properties (e.g. defaults) below can be
+# overriden (by defining symbols in multiple locations)
+gsource "arch/posix/soc/*/Kconfig"
+
 config ARCH
 	default "posix"
 
@@ -33,7 +37,5 @@ config ARCH_POSIX_RECOMMENDED_STACK_SIZE
 	  (In this architecture only part of the thread status is kept in the Zephyr
 	  thread stack, the real stack is the native underlying pthread stack.
 	  Therefore the allocated stack can be limited to this size)
-
-gsource "arch/posix/soc/*/Kconfig"
 
 endmenu

--- a/arch/riscv32/Kconfig
+++ b/arch/riscv32/Kconfig
@@ -13,6 +13,10 @@ endchoice
 menu "RISCV32 Options"
 	depends on RISCV32
 
+# Include these first so that any properties (e.g. defaults) below can be
+# overriden (by defining symbols in multiple locations)
+gsource "arch/riscv32/soc/*/Kconfig"
+
 config ARCH
 	string
 	default "riscv32"
@@ -60,7 +64,5 @@ config GEN_IRQ_VECTOR_TABLE
 	default n
 
 endmenu
-
-gsource "arch/riscv32/soc/*/Kconfig"
 
 endmenu

--- a/arch/x86/Kconfig
+++ b/arch/x86/Kconfig
@@ -16,6 +16,10 @@ endchoice
 menu "X86 Architecture Options"
 	depends on X86
 
+# Include these first so that any properties (e.g. defaults) below can be
+# overriden (by defining symbols in multiple locations)
+gsource "arch/x86/soc/*/Kconfig"
+
 config ARCH
 	default "x86"
 
@@ -218,8 +222,8 @@ config CACHE_LINE_SIZE_DETECT
 
 config CACHE_LINE_SIZE
 	int "Cache line size" if !CACHE_LINE_SIZE_DETECT
-	default 0
 	default 64 if CPU_ATOM
+	default 0
 	help
 	  Size in bytes of a CPU cache line.
 
@@ -314,7 +318,5 @@ config X86_FIXED_IRQ_MAPPING
 	  mapping between IDT vectors and IRQ lines.
 
 endmenu
-
-gsource "arch/x86/soc/*/Kconfig"
 
 endmenu

--- a/arch/xtensa/Kconfig
+++ b/arch/xtensa/Kconfig
@@ -12,18 +12,57 @@ endchoice
 menu "XTENSA Options"
 	depends on XTENSA
 
+menu "Specific core configuration"
+
+# Include these first so that any properties (e.g. defaults) below can be
+# overriden (by defining symbols in multiple locations)
+gsource "arch/xtensa/soc/*/Kconfig"
+
+config IRQ_OFFLOAD_INTNUM
+	int "IRQ offload SW interrupt index"
+	help
+	  The index of the software interrupt to be used for IRQ offload.
+
+	  Please note that in order for IRQ offload to work correctly the selected
+	  interrupt shall have its priority shall not exceed XCHAL_EXCM_LEVEL.
+
+config XTENSA_OMIT_HIGH_INTERRUPTS
+	bool "Skip generation of vectors for high priority interrupts"
+	help
+	  Setting this to y causes the interrupt vectors for "high
+	  priority" Xtensa interrupts (those not masked by the EXCM bit
+	  in PS) to be left ungenerated, so they can be handled by
+	  application code instead.  Note that high priority interrupts
+	  cannot safely be handled by C code anyway (they will interrupt
+	  register window exceptions, which cannot be made reentrant, so
+	  the code under the handler must not emit them), though some
+	  devices might still want to use built-in handling for things
+	  like watchdogs which do not need to return into interrupted
+	  code.  Default is "n" for legacy compatibility. Consider
+	  changing to "y" in the future.
+
+config XTENSA_ASM2
+	bool "New-style Xtensa context switch & interrupt layer"
+	select USE_SWITCH
+	help
+	  This selects a new implementation of context switching and
+	  interrupt handling.  Advantages are a much lower interrupt
+	  overhead and smaller code size, and this scheme is required
+	  for SMP.  Assumes/requires hardware that implements the
+	  register window extension, however.
+
+endmenu
+
 config ARCH
 	default "xtensa"
 
 config SIMULATOR_XTENSA
-        bool
-	prompt "Simulator Configuration"
+	bool "Simulator Configuration"
 	help
 	  Specify if the board configuration should be treated as a simulator.
 
 config SYS_CLOCK_HW_CYCLES_PER_SEC
-	int
-	prompt "Hardware clock cycles per second, 2000000 for ISS"
+	int "Hardware clock cycles per second, 2000000 for ISS"
 	default 2000000
 	range 1000000 1000000000
 	help
@@ -37,8 +76,7 @@ config XTENSA_NO_IPC
 	  instruction.
 
 config SW_ISR_TABLE
-	bool
-	prompt "Enable software interrupt handler table"
+	bool "Enable software interrupt handler table"
 	default y
 	help
 	  Enable an interrupt handler table implemented in software. This
@@ -47,8 +85,7 @@ config SW_ISR_TABLE
 	  the exception/interrupt exit stub is automatically done.
 
 config XTENSA_RESET_VECTOR
-	bool
-	prompt "Build reset vector code"
+	bool "Build reset vector code"
 	default y
 	help
 	  This option controls whether the initial reset vector code is built.
@@ -56,53 +93,10 @@ config XTENSA_RESET_VECTOR
 	  implement this in boot ROM.
 
 config XTENSA_USE_CORE_CRT1
-	bool
-	prompt "Use crt1.S from core"
+	bool "Use crt1.S from core"
 	default y
 	help
 	  SoC or boards might define their own __start by setting this setting
 	  to false.
-
-menu "Specific core configuration"
-
-config IRQ_OFFLOAD_INTNUM
-	int
-	prompt "IRQ offload SW interrupt index"
-	help
-	 The index of the software interrupt to be used for IRQ offload.
-
-	 Please note that in order for IRQ offload to work correctly the selected
-	 interrupt shall have its priority shall not exceed XCHAL_EXCM_LEVEL.
-
-config XTENSA_OMIT_HIGH_INTERRUPTS
-	bool
-	prompt "Skip generation of vectors for high priority interrupts"
-	help
-	Setting this to y causes the interrupt vectors for "high
-	priority" Xtensa interrupts (those not masked by the EXCM bit
-	in PS) to be left ungenerated, so they can be handled by
-	application code instead.  Note that high priority interrupts
-	cannot safely be handled by C code anyway (they will interrupt
-	register window exceptions, which cannot be made reentrant, so
-	the code under the handler must not emit them), though some
-	devices might still want to use built-in handling for things
-	like watchdogs which do not need to return into interrupted
-	code.  Default is "n" for legacy compatibility. Consider
-	changing to "y" in the future.
-
-config XTENSA_ASM2
-	bool
-	prompt "New-style Xtensa context switch & interrupt layer"
-	select USE_SWITCH
-	help
-	This selects a new implementation of context switching and
-	interrupt handling.  Advantages are a much lower interrupt
-	overhead and smaller code size, and this scheme is required
-	for SMP.  Assumes/requires hardware that implements the
-	register window extension, however.
-
-gsource "arch/xtensa/soc/*/Kconfig"
-
-endmenu
 
 endmenu

--- a/cmake/app/boilerplate.cmake
+++ b/cmake/app/boilerplate.cmake
@@ -321,3 +321,20 @@ foreach(boilerplate_lib ${ZEPHYR_INTERFACE_LIBS_PROPERTY})
     ${boilerplate_lib}
     )
 endforeach()
+
+
+if(NOT EXISTS ${ZEPHYR_BASE}/hide-defaults-note)
+    message(STATUS "\n\
+*******************************\n\
+*** NOTE TO KCONFIG AUTHORS ***\n\
+*******************************\n\
+\n\
+The behavior of Kconfig 'default' properties in Zephyr has changed. The \n\
+earliest default with a satisfied condition is now used, instead of the \n\
+last one. This is standard Kconfig behavior.\n\
+\n\
+See http://docs.zephyrproject.org/porting/board_porting.html#old-zephyr-kconfig-behavior-for-defaults.\n\
+\n\
+To get rid of this note, create a file called 'hide-defaults-note' in the \n\
+Zephyr root directory. An empty file is fine.")
+endif()

--- a/doc/application/application-kconfig.include
+++ b/doc/application/application-kconfig.include
@@ -1,5 +1,5 @@
 mainmenu "Your Application Name"
 
-source "$ZEPHYR_BASE/Kconfig.zephyr"
+# Your application configuration options go here
 
-# Your application configuration options go here.
+source "$ZEPHYR_BASE/Kconfig.zephyr"

--- a/doc/application/application.rst
+++ b/doc/application/application.rst
@@ -797,19 +797,18 @@ Make sure to follow these steps in order.
 
       set(KCONFIG_ROOT ${CMAKE_CURRENT_SOURCE_DIR}/Kconfig)
 
-   Make sure to include the following lines in your :file:`Kconfig` file before
-   any application-specific configuration options:
+   Structure your :file:`Kconfig` file like this:
 
    .. literalinclude:: application-kconfig.include
 
    .. note::
 
        Environment variables in ``source`` statements are expanded directly,
-       so you do not need to define a ``option env="ZEPHYR_BASE"`` Kconfig
+       so you do not need to define an ``option env="ZEPHYR_BASE"`` Kconfig
        "bounce" symbol. If you use such a symbol, it must have the same name as
        the environment variable.
 
-       See the :ref:`kconfig_extensions_and_changes` section in the
+       See the :ref:`kconfig_extensions` section in the
        :ref:`board_porting_guide` for more information.
 
 #. Now include the mandatory boilerplate that integrates the

--- a/drivers/ethernet/Kconfig.mcux
+++ b/drivers/ethernet/Kconfig.mcux
@@ -116,8 +116,7 @@ endif
 
 config PTP_CLOCK_MCUX
 	bool "MCUX PTP clock driver support"
-	default n
-	default y if PTP_CLOCK
+	default y
 	depends on PTP_CLOCK && NET_PKT_TIMESTAMP
 	help
 	  Enable MCUX PTP clock support.

--- a/drivers/ethernet/Kconfig.sam_gmac
+++ b/drivers/ethernet/Kconfig.sam_gmac
@@ -160,8 +160,7 @@ config ETH_SAM_GMAC_PHY_ADDR
 
 config PTP_CLOCK_SAM_GMAC
 	bool "SAM GMAC PTP clock driver support"
-	default n
-	default y if NET_GPTP
+	default y
 	select PTP_CLOCK
 	depends on NET_GPTP
 	help

--- a/drivers/flash/Kconfig.w25qxxdv
+++ b/drivers/flash/Kconfig.w25qxxdv
@@ -16,7 +16,6 @@ if SPI_FLASH_W25QXXDV
 config SPI_FLASH_W25QXXDV_SPI_NAME
 	string
 	prompt "SPI controller device name"
-	default ""
 
 config SPI_FLASH_W25QXXDV_DRV_NAME
 	string
@@ -53,7 +52,6 @@ config SPI_FLASH_W25QXXDV_GPIO_SPI_CS
 
 config SPI_FLASH_W25QXXDV_GPIO_SPI_CS_DRV_NAME
 	string "GPIO driver's name to use to drive SPI CS through"
-	default ""
 	depends on SPI_FLASH_W25QXXDV_GPIO_SPI_CS
 	help
 	This option is mandatory to set which GPIO controller to use in order

--- a/drivers/gpio/Kconfig.nrf5
+++ b/drivers/gpio/Kconfig.nrf5
@@ -72,9 +72,9 @@ config GPIO_NRF5_INIT_PRIORITY
 config GPIO_NRF5_GPIOTE_CHAN_BASE
 	# hidden
 	int
-	default 0
-	default 1 if (BT_CTLR_GPIO_PA || BT_CTLR_GPIO_LNA)
-	default 3 if PWM_NRF5_SW
 	default 4 if (BT_CTLR_GPIO_PA || BT_CTLR_GPIO_LNA) && PWM_NRF5_SW
+	default 3 if PWM_NRF5_SW
+	default 1 if (BT_CTLR_GPIO_PA || BT_CTLR_GPIO_LNA)
+	default 0
 
 endif # GPIO_NRF5

--- a/drivers/gpio/Kconfig.sch
+++ b/drivers/gpio/Kconfig.sch
@@ -24,7 +24,6 @@ config GPIO_SCH_INIT_PRIORITY
 
 config GPIO_SCH_0
 	bool "Enable SCH GPIO port 0"
-	default 0
 	depends on GPIO_SCH
 
 config GPIO_SCH_0_DEV_NAME

--- a/drivers/i2c/Kconfig
+++ b/drivers/i2c/Kconfig
@@ -16,6 +16,18 @@ menuconfig I2C
 
 if I2C
 
+# Include these first so that any properties (e.g. defaults) below can be
+# overriden (by defining symbols in multiple locations)
+source "drivers/i2c/Kconfig.dw"
+source "drivers/i2c/Kconfig.esp32"
+source "drivers/i2c/slave/Kconfig"
+source "drivers/i2c/Kconfig.gpio"
+source "drivers/i2c/Kconfig.nrfx"
+source "drivers/i2c/Kconfig.qmsi"
+source "drivers/i2c/Kconfig.sbcon"
+source "drivers/i2c/Kconfig.stm32"
+
+
 config I2C_INIT_PRIORITY
 	int "Init priority"
 	default 60
@@ -291,20 +303,5 @@ config I2C_NIOS2
 	depends on HAS_ALTERA_HAL
 	help
 	  Enable the Nios-II I2C driver.
-
-source "drivers/i2c/Kconfig.dw"
-
-source "drivers/i2c/Kconfig.esp32"
-source "drivers/i2c/slave/Kconfig"
-
-source "drivers/i2c/Kconfig.gpio"
-
-source "drivers/i2c/Kconfig.nrfx"
-
-source "drivers/i2c/Kconfig.qmsi"
-
-source "drivers/i2c/Kconfig.sbcon"
-
-source "drivers/i2c/Kconfig.stm32"
 
 endif # I2C

--- a/drivers/ieee802154/Kconfig.cc1200
+++ b/drivers/ieee802154/Kconfig.cc1200
@@ -16,7 +16,6 @@ config IEEE802154_CC1200_DRV_NAME
 
 config IEEE802154_CC1200_SPI_DRV_NAME
 	string "SPI driver's name to use to access CC1200"
-	default ""
 	help
 	  This option is mandatory to set which SPI controller to use in order
 	  to actually control the CC1200 chip.
@@ -44,7 +43,6 @@ config IEEE802154_CC1200_GPIO_SPI_CS
 
 config IEEE802154_CC1200_GPIO_SPI_CS_DRV_NAME
 	string "GPIO driver's name to use to drive SPI CS through"
-	default ""
 	depends on IEEE802154_CC1200_GPIO_SPI_CS
 	help
 	  This option is mandatory to set which GPIO controller to use in order

--- a/drivers/ieee802154/Kconfig.cc2520
+++ b/drivers/ieee802154/Kconfig.cc2520
@@ -20,7 +20,6 @@ config IEEE802154_CC2520_DRV_NAME
 
 config IEEE802154_CC2520_SPI_DRV_NAME
 	string "SPI driver's name to use to access CC2520"
-	default ""
 	help
 	  This option is mandatory to set which SPI controller to use in order
 	  to actually control the CC2520 chip.
@@ -48,7 +47,6 @@ config IEEE802154_CC2520_GPIO_SPI_CS
 
 config IEEE802154_CC2520_GPIO_SPI_CS_DRV_NAME
 	string "GPIO driver's name to use to drive SPI CS through"
-	default ""
 	depends on IEEE802154_CC2520_GPIO_SPI_CS
 	help
 	This option is mandatory to set which GPIO controller to use in order

--- a/drivers/sensor/bmi160/Kconfig
+++ b/drivers/sensor/bmi160/Kconfig
@@ -21,7 +21,6 @@ config BMI160_NAME
 config BMI160_SPI_PORT_NAME
 	string "SPI master controller port name"
 	depends on BMI160
-	default ""
 	help
 	  Master SPI port name through which BMI160 chip is accessed.
 

--- a/drivers/spi/Kconfig.dw
+++ b/drivers/spi/Kconfig.dw
@@ -46,7 +46,6 @@ if SPI_DW_PORT_0_CLOCK_GATE
 
 config SPI_DW_PORT_0_CLOCK_GATE_DRV_NAME
 	string
-	default ""
 
 config SPI_DW_PORT_0_CLOCK_GATE_SUBSYS
 	int "Clock controller's subsystem"
@@ -69,7 +68,6 @@ if SPI_DW_PORT_1_CLOCK_GATE
 
 config SPI_DW_PORT_1_CLOCK_GATE_DRV_NAME
 	string
-	default ""
 
 config SPI_DW_PORT_1_CLOCK_GATE_SUBSYS
 	int "Clock controller's subsystem"

--- a/ext/debug/segger/Kconfig
+++ b/ext/debug/segger/Kconfig
@@ -51,9 +51,9 @@ endchoice
 
 config SEGGER_RTT_MODE
 	int 
-	default 0
-	default 1 if SEGGER_RTT_MODE_NO_BLOCK_TRIM
 	default 2 if SEGGER_RTT_MODE_BLOCK_IF_FIFO_FULL
+	default 1 if SEGGER_RTT_MODE_NO_BLOCK_TRIM
+	default 0
 
 config SEGGER_RTT_MEMCPY_USE_BYTELOOP
 	bool "Use a simple byte-loop instead of standard memcpy"

--- a/kernel/Kconfig
+++ b/kernel/Kconfig
@@ -26,8 +26,8 @@ config MULTITHREADING
 config NUM_COOP_PRIORITIES
 	int
 	prompt "Number of coop priorities" if MULTITHREADING
-	default 16
 	default 1 if !MULTITHREADING
+	default 16
 	range 0 128
 	help
 	  Number of cooperative priorities configured in the system. Gives access
@@ -56,8 +56,8 @@ config NUM_COOP_PRIORITIES
 config NUM_PREEMPT_PRIORITIES
 	int
 	prompt "Number of preemptible priorities" if MULTITHREADING
-	default 15
 	default 0 if !MULTITHREADING
+	default 15
 	range 0 128
 	help
 	  Number of preemptible priorities available in the system. Gives access
@@ -79,8 +79,8 @@ config NUM_PREEMPT_PRIORITIES
 config MAIN_THREAD_PRIORITY
 	int
 	prompt "Priority of initialization/main thread"
-	default 0
 	default -2 if !PREEMPT_ENABLED
+	default 0
 	help
 	  Priority at which the initialization thread runs, including the start
 	  of the main() function. main() can then change its priority if desired.
@@ -132,8 +132,8 @@ config SCHED_DEADLINE
 config MAIN_STACK_SIZE
 	int
 	prompt "Size of stack for initialization and main thread"
-	default 1024
 	default 512 if ZTEST
+	default 1024
 	help
 	  When the initialization is complete, the thread executing it then
 	  executes the main() routine, so as to reuse the stack used by the
@@ -144,10 +144,10 @@ config MAIN_STACK_SIZE
 config IDLE_STACK_SIZE
 	int
 	prompt "Size of stack for idle thread"
-	default 256
-	default 320 if ARC || (ARM && CPU_HAS_FPU)
-	default 512 if RISCV32
 	default 1024 if XTENSA
+	default 512 if RISCV32
+	default 320 if ARC || (ARM && CPU_HAS_FPU)
+	default 256
 	help
 	  Depending on the work that the idle task must do, most likely due to
 	  power management but possibly to other features like system event
@@ -371,9 +371,9 @@ config SYSTEM_WORKQUEUE_STACK_SIZE
 
 config SYSTEM_WORKQUEUE_PRIORITY
 	int "System workqueue priority"
-	default -1
-	default  0 if !COOP_ENABLED
 	default -2 if COOP_ENABLED && !PREEMPT_ENABLED
+	default  0 if !COOP_ENABLED
+	default -1
 	help
 	  By default, system work queue priority is the lowest cooperative
 	  priority. This means that any work handler, once started, won't

--- a/misc/Kconfig
+++ b/misc/Kconfig
@@ -43,8 +43,8 @@ endif
 
 config TEXT_SECTION_OFFSET
 	hex "TEXT section offset"
-	default 0
 	default 0x200 if BOOTLOADER_MCUBOOT
+	default 0
 	help
 	  If the application is built for chain-loading by a bootloader this
 	  variable is required to be set to value that leaves sufficient

--- a/samples/drivers/CAN/Kconfig
+++ b/samples/drivers/CAN/Kconfig
@@ -8,8 +8,6 @@
 
 mainmenu "Controller Area Network sample application"
 
-source "$ZEPHYR_BASE/Kconfig.zephyr"
-
 config CAN_DEV
 	string "Name of the CAN device"
 	default "CAN_1"
@@ -46,3 +44,6 @@ config LOOPBACK_MODE
 	help
 	  Set the controller to loopback mode.
 	  This allows testing without a second board.
+
+
+source "$ZEPHYR_BASE/Kconfig.zephyr"

--- a/samples/net/gptp/Kconfig
+++ b/samples/net/gptp/Kconfig
@@ -15,8 +15,6 @@
 
 mainmenu "gPTP sample application"
 
-source "$ZEPHYR_BASE/Kconfig.zephyr"
-
 if NET_GPTP
 
 config NET_SAMPLE_IFACE2_MY_IPV6_ADDR
@@ -58,3 +56,6 @@ config NET_SAMPLE_IFACE3_VLAN_TAG
 	  application.
 
 endif
+
+
+source "$ZEPHYR_BASE/Kconfig.zephyr"

--- a/samples/net/gptp/Kconfig
+++ b/samples/net/gptp/Kconfig
@@ -15,10 +15,6 @@
 
 mainmenu "gPTP sample application"
 
-config ZEPHYR_BASE
-	string
-	option env="ZEPHYR_BASE"
-
 source "$ZEPHYR_BASE/Kconfig.zephyr"
 
 if NET_GPTP

--- a/samples/net/stats/Kconfig
+++ b/samples/net/stats/Kconfig
@@ -8,8 +8,6 @@
 
 mainmenu "Network statistics sample application"
 
-source "$ZEPHYR_BASE/Kconfig.zephyr"
-
 config SAMPLE_PERIOD
 	int "How often to print statistics (in seconds)"
 	default 30
@@ -17,3 +15,6 @@ config SAMPLE_PERIOD
 	depends on NET_STATISTICS
 	help
 	  Print statistics after every n. seconds
+
+
+source "$ZEPHYR_BASE/Kconfig.zephyr"

--- a/samples/net/traffic_class/Kconfig
+++ b/samples/net/traffic_class/Kconfig
@@ -8,8 +8,6 @@
 
 mainmenu "Networking traffic class sample application"
 
-source "$ZEPHYR_BASE/Kconfig.zephyr"
-
 config SAMPLE_VLAN_TAG
 	int "Virtual lan tag used in sample app"
 	default 100
@@ -45,3 +43,6 @@ config SAMPLE_PEER_IPV4_ADDR_2
 	string "Peer IPv4 address for second interface"
 	help
 	  The value depends on your network setup.
+
+
+source "$ZEPHYR_BASE/Kconfig.zephyr"

--- a/samples/net/vlan/Kconfig
+++ b/samples/net/vlan/Kconfig
@@ -8,8 +8,6 @@
 
 mainmenu "Networking VLAN sample application"
 
-source "$ZEPHYR_BASE/Kconfig.zephyr"
-
 config SAMPLE_VLAN_TAG
 	int "Virtual lan tag used in VLAN sample app"
 	default 100
@@ -35,3 +33,6 @@ config SAMPLE_IPV4_ADDR_2
 	string "My IPv4 address for second interface"
 	help
 	  The value depends on your network setup.
+
+
+source "$ZEPHYR_BASE/Kconfig.zephyr"

--- a/samples/net/wifi/Kconfig
+++ b/samples/net/wifi/Kconfig
@@ -1,7 +1,5 @@
 mainmenu "Wi-Fi sample"
 
-source "$ZEPHYR_BASE/Kconfig.zephyr"
-
 if WIFI_WINC1500
 
 config WINC1500_GPIO_DRV_NAME
@@ -17,3 +15,6 @@ config WINC1500_GPIO_RESET_N
 	int "Pin number for Winc1500 RESET_N signal"
 
 endif # WIFI_WINC1500
+
+
+source "$ZEPHYR_BASE/Kconfig.zephyr"

--- a/scripts/kconfig/kconfiglib.py
+++ b/scripts/kconfig/kconfiglib.py
@@ -3286,7 +3286,6 @@ class Symbol(object):
                 # Used to implement the warning below
                 has_default = False
 
-                found = False
                 for val_sym, cond in self.defaults:
                     if expr_value(cond):
                         has_default = self._write_to_conf = True
@@ -3297,9 +3296,9 @@ class Symbol(object):
                             val_num = int(val, base)
                         else:
                             val_num = 0  # strtoll() on empty string
-                        found = True
-                        #break
-                if not found:
+
+                        break
+                else:
                     val_num = 0  # strtoll() on empty string
 
                 # This clamping procedure runs even if there's no default
@@ -3336,7 +3335,7 @@ class Symbol(object):
                     if expr_value(cond):
                         val = val_sym.str_value
                         self._write_to_conf = True
-                        #break
+                        break
 
         # env_var corresponds to SYMBOL_AUTO in the C implementation, and is
         # also set on the defconfig_list symbol there. Test for the
@@ -3392,7 +3391,7 @@ class Symbol(object):
                         val = min(expr_value(default), cond_val)
                         if val:
                             self._write_to_conf = True
-                        #break
+                        break
 
                 # Weak reverse dependencies are only considered if our
                 # direct dependencies are met

--- a/subsys/bluetooth/controller/Kconfig
+++ b/subsys/bluetooth/controller/Kconfig
@@ -80,8 +80,8 @@ config BT_CTLR_DUP_FILTER_LEN
 
 config BT_CTLR_RX_BUFFERS
 	int "Number of Rx buffers"
-	default 1
 	default 6 if BT_HCI_RAW
+	default 1
 	range 1 18
 	help
 	  Set the number of Rx PDUs to be buffered in the controller. In a 7.5ms
@@ -90,8 +90,8 @@ config BT_CTLR_RX_BUFFERS
 
 config BT_CTLR_TX_BUFFERS
 	int "Number of Tx buffers"
-	default 2
 	default 7 if BT_HCI_RAW
+	default 2
 	range 1 19
 	help
 	  Set the number of Tx PDUs to be queued for transmission in the
@@ -541,8 +541,8 @@ config BT_CTLR_PA_LNA_GPIOTE_CHAN
 	# Hidden "nRF5 GPIO PA/LNA GPIOTE Channel"
 	int
 	depends on SOC_FAMILY_NRF && (BT_CTLR_GPIO_PA || BT_CTLR_GPIO_LNA)
-	default 0
 	default 3 if PWM_NRF5_SW
+	default 0
 	help
 	  Select the nRF5 GPIOTE channel to use for PA/LNA GPIO feature.
 

--- a/subsys/bluetooth/host/Kconfig
+++ b/subsys/bluetooth/host/Kconfig
@@ -25,8 +25,8 @@ config BT_HCI_CMD_COUNT
 
 config BT_RX_BUF_COUNT
 	int "Number of HCI RX buffers"
-	default 10
 	default 3 if BT_RECV_IS_RX_THREAD
+	default 10
 	range 2 255
 	help
 	  Number of buffers available for incoming ACL packets or HCI events
@@ -34,9 +34,9 @@ config BT_RX_BUF_COUNT
 
 config BT_RX_BUF_LEN
 	int "Maximum supported HCI RX buffer length"
-	default 76
-	default 77 if BT_MESH_PROXY
 	default 264 if BT_BREDR
+	default 77 if BT_MESH_PROXY
+	default 76
 	range 73 2000
 	help
 	  Maximum data size for each HCI RX buffer. This size includes
@@ -48,16 +48,17 @@ config BT_RX_BUF_LEN
 	  (4 bytes) and the ACL header (also 4 bytes) which yields 73 bytes.
 
 config BT_HCI_TX_STACK_SIZE
-	# Stack size needed for executing bt_send with specified driver
 	int
-	# Even if no driver is selected the following default is still
-	# needed e.g. for unit tests.
-	default 256
 	default 256 if BT_H4
 	default 256 if BT_H5
 	default 416 if BT_SPI
 	default 640 if BT_CTLR
 	default 256 if BT_USERCHAN
+	# Even if no driver is selected the following default is still
+	# needed e.g. for unit tests.
+	default 256
+	help
+	  Stack size needed for executing bt_send with specified driver
 
 config BT_HCI_TX_PRIO
 	# Hidden option for Co-Operative Tx thread priority
@@ -73,17 +74,18 @@ config BT_WAIT_NOP
 	  This option should be selected if the controller used
 	  exhibits such behavior.
 
-# Headroom that the driver needs for sending and receiving buffers.
-# Add a new 'default' entry for each new driver.
 config BT_HCI_RESERVE
 	int
-	# Even if no driver is selected the following default is still
-	# needed e.g. for unit tests.
-	default 0
 	default 0 if BT_H4
 	default 1 if BT_H5
 	default 1 if BT_SPI
 	default 1 if BT_USERCHAN
+	# Even if no driver is selected the following default is still
+	# needed e.g. for unit tests.
+	default 0
+	help
+	  Headroom that the driver needs for sending and receiving buffers. Add a
+	  new 'default' entry for each new driver.
 
 config BT_RECV_IS_RX_THREAD
 	# Hidden option set by the HCI driver to indicate that there's
@@ -97,10 +99,10 @@ config BT_RECV_IS_RX_THREAD
 config BT_RX_STACK_SIZE
 	int "Size of the receiving thread stack"
 	depends on BT_HCI_HOST || BT_RECV_IS_RX_THREAD
-	default 1024
-	default 2048 if BT_SETTINGS
-	default 2048 if BT_MESH
 	default 512 if BT_HCI_RAW
+	default 2048 if BT_MESH
+	default 2048 if BT_SETTINGS
+	default 1024
 	range 512 65536 if BT_HCI_RAW
 	range 1100 65536 if BT_MESH
 	range 1024 65536
@@ -156,19 +158,19 @@ if BT_CONN
 if BT_HCI_ACL_FLOW_CONTROL
 config BT_ACL_RX_COUNT
 	int "Number of incoming ACL data buffers"
-	default 6
 	default BT_CTLR_RX_BUFFERS if BT_CTLR
+	default 6
 	range 1 64
 	help
 	  Number of buffers available for incoming ACL data.
 
 config BT_L2CAP_RX_MTU
 	int "Maximum supported L2CAP MTU for incoming data"
-	default 23
-	default 65 if BT_SMP
 	default 200 if BT_BREDR
-	range 23 1300
+	default 65 if BT_SMP
+	default 23
 	range 65 1300 if BT_SMP
+	range 23 1300
 	help
 	  Maximum size of each incoming L2CAP PDU.
 endif # BT_HCI_ACL_FLOW_CONTROL
@@ -194,18 +196,18 @@ config BT_L2CAP_TX_FRAG_COUNT
 
 config BT_L2CAP_TX_MTU
 	int "Maximum supported L2CAP MTU for L2CAP TX buffers"
-	default 23
-	default 65 if BT_SMP
 	default 253 if BT_BREDR
-	range 23 2000
+	default 65 if BT_SMP
+	default 23
 	range 65 2000 if BT_SMP
+	range 23 2000
 	help
 	  Maximum L2CAP MTU for L2CAP TX buffers.
 
 config BT_CONN_TX_MAX
 	int "Maximum number of pending TX buffers"
-	default 7
 	default BT_CTLR_TX_BUFFERS if BT_CTLR
+	default 7
 	range 1 128
 	help
 	  Maximum number of pending TX buffers that have not yet
@@ -322,8 +324,8 @@ config BT_GATT_READ_MULTIPLE
 
 config BT_MAX_PAIRED
 	int "Maximum number of paired devices"
-	default 1
 	default 0 if !BT_SMP
+	default 1
 	range 0 128
 	help
 	  Maximum number of paired Bluetooth devices. The minimum (and
@@ -540,8 +542,8 @@ config BT_RFCOMM
 
 config BT_RFCOMM_L2CAP_MTU
 	int "L2CAP MTU for RFCOMM frames"
-	default BT_RX_BUF_LEN
 	default BT_L2CAP_RX_MTU if BT_HCI_ACL_FLOW_CONTROL
+	default BT_RX_BUF_LEN
 	depends on BT_RFCOMM
 	range BT_L2CAP_RX_MTU 32767 if BT_HCI_ACL_FLOW_CONTROL
 	range BT_RX_BUF_LEN 32767

--- a/subsys/bluetooth/host/mesh/Kconfig
+++ b/subsys/bluetooth/host/mesh/Kconfig
@@ -69,8 +69,8 @@ if BT_MESH_PROXY
 
 config BT_MESH_PROXY_FILTER_SIZE
 	int "Maximum number of filter entries per Proxy Client"
-	default 1
 	default 3 if BT_MESH_GATT_PROXY
+	default 1
 	range 1 32767
 	help
 	  This option specifies how many Proxy Filter entries the local

--- a/subsys/net/ip/Kconfig
+++ b/subsys/net/ip/Kconfig
@@ -276,8 +276,8 @@ config NET_DEBUG_UDP
 config NET_MAX_CONN
 	int "How many network connections are supported"
 	depends on NET_UDP || NET_TCP
-	default 4
 	default 8 if NET_IPV6 && NET_IPV4
+	default 4
 	help
 	  The value depends on your network needs. The value
 	  should include both UDP and TCP connections.
@@ -363,40 +363,40 @@ endif # NET_RAW_MODE
 
 config NET_PKT_RX_COUNT
 	int "How many packet receives can be pending at the same time"
-	default 4
 	default 14 if NET_L2_ETHERNET
+	default 4
 	help
 	  Each RX buffer will occupy smallish amount of memory.
 	  See include/net/net_pkt.h and the sizeof(struct net_pkt)
 
 config NET_PKT_TX_COUNT
 	int "How many packet sends can be pending at the same time"
-	default 4
 	default 14 if NET_L2_ETHERNET
+	default 4
 	help
 	  Each TX buffer will occupy smallish amount of memory.
 	  See include/net/net_pkt.h and the sizeof(struct net_pkt)
 
 config NET_BUF_RX_COUNT
 	int "How many network buffers are allocated for receiving data"
-	default 16
 	default 36 if NET_L2_ETHERNET
+	default 16
 	help
 	  Each data buffer will occupy CONFIG_NET_BUF_DATA_SIZE + smallish
 	  header (sizeof(struct net_buf)) amount of data.
 
 config NET_BUF_TX_COUNT
 	int "How many network buffers are allocated for sending data"
-	default 16
 	default 36 if NET_L2_ETHERNET
+	default 16
 	help
 	  Each data buffer will occupy CONFIG_NET_BUF_DATA_SIZE + smallish
 	  header (sizeof(struct net_buf)) amount of data.
 
 config NET_BUF_DATA_SIZE
 	int "Size of each network data fragment"
-	default 128
 	default 125 if NET_L2_IEEE802154
+	default 128
 	help
 	  This value tells what is the size of the data fragment that is
 	  received from the network.

--- a/subsys/net/ip/Kconfig.ipv4
+++ b/subsys/net/ip/Kconfig.ipv4
@@ -22,16 +22,16 @@ config NET_INITIAL_TTL
 
 config NET_IF_MAX_IPV4_COUNT
 	int "Max number of IPv4 network interfaces in the system"
-	default 1
 	default NET_VLAN_COUNT if NET_VLAN
+	default 1
 	help
-	This tells how many network interfaces there will be in the system
-	that will have IPv4 enabled.
+	  This tells how many network interfaces there will be in the system
+	  that will have IPv4 enabled.
 
 config NET_IF_UNICAST_IPV4_ADDR_COUNT
 	int "Max number of unicast IPv4 addresses per network interface"
-	default 1
 	default 2 if NET_IPV4_AUTO
+	default 1
 
 config NET_IF_MCAST_IPV4_ADDR_COUNT
 	int "Max number of multicast IPv4 addresses per network interface"

--- a/subsys/net/ip/Kconfig.ipv6
+++ b/subsys/net/ip/Kconfig.ipv6
@@ -17,11 +17,11 @@ if NET_IPV6
 
 config NET_IF_MAX_IPV6_COUNT
 	int "Max number of IPv6 network interfaces in the system"
-	default 1
 	default NET_VLAN_COUNT if NET_VLAN
+	default 1
 	help
-	This tells how many network interfaces there will be in the system
-	that will have IPv6 enabled.
+	  This tells how many network interfaces there will be in the system
+	  that will have IPv6 enabled.
 
 config NET_IF_UNICAST_IPV6_ADDR_COUNT
 	int "Max number of unicast IPv6 addresses per network interface"

--- a/subsys/net/ip/Kconfig.stack
+++ b/subsys/net/ip/Kconfig.stack
@@ -30,8 +30,8 @@ config NET_RX_STACK_SIZE
 # User-assignable if NET_RPL is enabled, otherwise 0
 config NET_RX_STACK_RPL
 	int "RPL specific RX stack need" if NET_RPL
-	default 0
 	default 300 if NET_RPL
+	default 0
 	help
 	  How much extra RX stack space is required by RPL functionality.
 

--- a/subsys/net/l2/openthread/Kconfig
+++ b/subsys/net/l2/openthread/Kconfig
@@ -55,11 +55,11 @@ endif
 
 config	OPENTHREAD_LOG_LEVEL
 	int
-	default 0
 	default 1 if OPENTHREAD_LOG_LEVEL_ERROR
 	default 2 if OPENTHREAD_LOG_LEVEL_WARNING
 	default 3 if OPENTHREAD_LOG_LEVEL_INFO
 	default 4 if OPENTHREAD_LOG_LEVEL_DEBUG
+	default 0
 
 menuconfig OPENTHREAD_L2_DEBUG
 	bool "OpenThread L2 log support"
@@ -97,11 +97,11 @@ endif
 
 config	OPENTHREAD_L2_LOG_LEVEL
 	int
-	default 0
 	default 1 if OPENTHREAD_L2_LOG_LEVEL_ERROR
 	default 2 if OPENTHREAD_L2_LOG_LEVEL_WARNING
 	default 3 if OPENTHREAD_L2_LOG_LEVEL_INFO
 	default 4 if OPENTHREAD_L2_LOG_LEVEL_DEBUG
+	default 0
 
 config OPENTHREAD_THREAD_PRIORITY
 	int "OpenThread thread priority"

--- a/subsys/net/lib/http/Kconfig
+++ b/subsys/net/lib/http/Kconfig
@@ -29,8 +29,8 @@ config HTTP_CLIENT
 config HTTP_HEADERS
 	int "HTTP header field max number of items"
 	depends on HTTP_SERVER
-	default 8
 	default 20 if WEBSOCKET
+	default 8
 	help
 	  Number of HTTP header field items that an HTTP server
 	  application will handle. If websocket is enabled, then the

--- a/subsys/net/lib/lwm2m/Kconfig
+++ b/subsys/net/lib/lwm2m/Kconfig
@@ -24,8 +24,8 @@ config SYS_LOG_LWM2M_LEVEL
 
 config LWM2M_ENGINE_STACK_SIZE
 	int "LWM2M engine stack size"
-	default 1024
 	default 1536 if NET_LOG_GLOBAL
+	default 1024
 	help
 	 Set the stack size for the LWM2M library engine (used for handling
 	 OBSERVE and NOTIFY events)
@@ -128,9 +128,9 @@ config LWM2M_FIRMWARE_UPDATE_PULL_LOCAL_PORT
 
 config LWM2M_COAP_BLOCK_SIZE
 	int "LWM2M CoAP block-wise transfer size"
-	default 256
 	default 64 if NET_L2_BT
 	default 64 if NET_L2_IEEE802154
+	default 256
 	range 16 1024
 	help
 	  CoAP block size used by LWM2M when performing block-wise

--- a/subsys/usb/Kconfig
+++ b/subsys/usb/Kconfig
@@ -72,8 +72,8 @@ config USB_COMPOSITE_DEVICE
 config USB_COMPOSITE_BUFFER_SIZE
 	int "Set buffer size for Class Handler"
 	depends on USB_COMPOSITE_DEVICE
-	default 64
 	default 256 if USB_DEVICE_NETWORK_RNDIS
+	default 64
 
 config USB_DEVICE_BOS
 	bool "Enable USB Binary Device Object Store (BOS)"

--- a/tests/Kconfig
+++ b/tests/Kconfig
@@ -16,8 +16,8 @@ config TEST
 
 config TEST_EXTRA_STACKSIZE
 	int "Test function extra thread stack size"
-	default 0
 	default 768 if XTENSA
+	default 0
 	help
 	  Additional stack for tests on some platform where default is not
 	  enough.

--- a/tests/drivers/i2c/i2c_slave_api/Kconfig
+++ b/tests/drivers/i2c/i2c_slave_api/Kconfig
@@ -1,9 +1,5 @@
 mainmenu "I2C Slave API Test"
 
-config ZEPHYR_BASE
-	string
-	option env="ZEPHYR_BASE"
-
 source "$ZEPHYR_BASE/Kconfig.zephyr"
 
 source "$ZEPHYR_BASE/tests/drivers/i2c/i2c_slave_api/common/Kconfig"


### PR DESCRIPTION
This PR gets rid of Zephyr's prefer-later-defaults behavior for Kconfig defaults.

The commit message for `Kconfig: Use the first default with a satisfied condition` (below) gives some motivations.

Documentation updates are included as well, and `boilerplate.cmake` prints a note about the new behavior so that it's easier to discover. See the other commit messages.

```
Kconfig: Use the first default with a satisfied condition

Up until now, Zephyr has patched Kconfig to use the last 'default' with a
satisfied condition, instead of the first one. I'm not sure why the patch was
added (it predates Kconfiglib), but I suspect it's related to Kconfig.defconfig
files.

There are at least three problems with the patch:

  1. It's inconsistent with how Kconfig works in other projects, which might
     confuse newcomers.

  2. Due to oversights, earlier 'range' properties are still preferred, as well
     as earlier 'default' properties on choices.

     In addition to being inconsistent, this makes it impossible to override
     'range' properties and choice 'default' properties if the base definition
     of the symbol/choice already has 'range'/'default' properties.

     I've seen errors caused by the inconsistency, and I suspect there are
     more.

  3. A fork of Kconfiglib that adds the patch needs to be maintained.

Get rid of the patch and go back to standard Kconfig behavior, as follows:

  1. Include the Kconfig.defconfig files first instead of last in
     Kconfig.zephyr.

  2. Include boards/Kconfig and arch/<arch>/Kconfig first instead of last in
     arch/Kconfig.

  3. Include arch/<arch>/soc/*/Kconfig first instead of last in
     arch/<arch>/Kconfig.

  4. Swap a few other 'source's to preserve behavior for some scattered symbols
     with multiple definitions.

     Swap 'source's in some no-op cases too, where it might match the intent.

  5. Reverse the defaults on symbol definitions that have more than one
     default.

     Skip defaults that are mutually exclusive, e.g. where each default has an
     'if <some board>' condition. They are already safe.

  6. Remove the prefer-later-defaults patch from Kconfiglib.

Testing was done with a Python script that lists all Kconfig symbols/choices
with multiple defaults, along with a whitelist of fixed symbols. The script
also verifies that there are no "unreachable" defaults hidden by defaults
without conditions

As an additional test, zephyr/.config was generated before and after the change
for several samples and checked to be identical (after sorting).

This commit includes some default-related cleanups as well:

  - Simplify some symbol definitions, e.g. where a default has 'if FOO' when
    the symbol already has 'depends on FOO'.

  - Remove some redundant 'default ""' for string symbols. This is the implicit
    default.

Piggyback fixes for swapped ranges on BT_L2CAP_RX_MTU and
BT_L2CAP_TX_MTU (caused by confusing inconsistency).

Piggyback some fixes for style nits too, e.g. unindented help texts.
```