### PR TITLE
cmake: Improve the error message when the compiler is not executable

### DIFF
--- a/cmake/compiler/gcc.cmake
+++ b/cmake/compiler/gcc.cmake
@@ -24,6 +24,19 @@ TOOLCHAIN_HOME: ${TOOLCHAIN_HOME}
 ")
 endif()
 
+execute_process(
+  COMMAND ${CMAKE_C_COMPILER} --version
+  RESULT_VARIABLE ret
+  OUTPUT_QUIET
+  ERROR_QUIET
+  )
+if(ret)
+  message(FATAL_ERROR "Executing the below command failed. Are permissions set correctly?
+'${CMAKE_C_COMPILER} --version'
+"
+    )
+endif()
+
 if(CONFIG_CPLUSPLUS)
   set(cplusplus_compiler ${CROSS_COMPILE}${C++})
 else()
@@ -45,7 +58,7 @@ foreach(file_name include include-fixed)
     COMMAND ${CMAKE_C_COMPILER} --print-file-name=${file_name}
     OUTPUT_VARIABLE _OUTPUT
     )
-  string(REGEX REPLACE "\n" "" _OUTPUT ${_OUTPUT})
+  string(REGEX REPLACE "\n" "" _OUTPUT "${_OUTPUT}")
 
   if(MSYS)
     # TODO: Remove this when


### PR DESCRIPTION
When the SDK/toolchain has been incorrectly installed such that the
user does not have permissions to execute it an incomprehensible
errror message occurs.

This patch tests that executing 'gcc --version' does not give an error
code and errors out with an appropriate error message if it does.

This fixes #8977

Signed-off-by: Sebastian Bøe <sebastian.boe@nordicsemi.no>