### PR TITLE
arch/x86: always make BSS section MMU page align if X86_MMU

### DIFF
--- a/include/arch/x86/linker.ld
+++ b/include/arch/x86/linker.ld
@@ -209,16 +209,8 @@ SECTIONS
 
 	SECTION_PROLOGUE(_BSS_SECTION_NAME, (NOLOAD OPTIONAL),)
 	{
-	/*
-	 * Without Jailhouse, we get the page alignment here for free by
-	 * definition of the beginning of the "RAMable" region on the board
-	 * configurations. With Jailhouse, everything falls in RAM and we
-	 * try to glue sections in sequence, thus we have to realign here so
-	 * that gen_mmu.py does not complain.
-	 */
-#ifdef CONFIG_JAILHOUSE
 	MMU_PAGE_ALIGN
-#endif
+
 	/*
 	 * For performance, BSS section is forced to be both 4 byte aligned and
 	 * a multiple of 4 bytes.


### PR DESCRIPTION
If MMU is enabled, always make the BSS section MMU page aligned.
According to the comments, it is always aligned anyway.

Signed-off-by: Daniel Leung <daniel.leung@intel.com>