### PR TITLE
drivers: eth: native_posix: Exec program after creating zeth

### DIFF
--- a/drivers/ethernet/Kconfig.native_posix
+++ b/drivers/ethernet/Kconfig.native_posix
@@ -27,6 +27,30 @@ config ETH_NATIVE_POSIX_SETUP_SCRIPT
 	  CONFIG_ETH_NATIVE_POSIX_DRV_NAME option to the end of the options
 	  list when calling the host setup script.
 
+config ETH_NATIVE_POSIX_STARTUP_SCRIPT
+	string "Host startup script"
+	default ""
+	help
+	  This option sets the name of the script that is run when the host TAP
+	  network interface is created and setup script has been run.
+	  The startup script could launch e.g., wireshark to capture
+	  the network traffic for the freshly started network interface.
+	  Note that the network interface name CONFIG_ETH_NATIVE_POSIX_DRV_NAME
+	  is appended at the end of this startup script name.
+	  Example script for starting wireshark is provided in
+	  ${ZEPHYR_BASE}/samples/net/eth_native_posix/net_start_wireshark.sh
+	  file.
+
+config ETH_NATIVE_POSIX_STARTUP_SCRIPT_USER
+	string "Username to run the host startup script"
+	default ""
+	help
+	  By default the startup script is run as a root user. Set here the
+	  username to run the script if running it as a root user is not
+	  desired. Note that this setting is only for startup script and not
+	  for the setup script. The setup script needs to be run always as
+	  a root user.
+
 config ETH_NATIVE_POSIX_DRV_NAME
 	string "Ethernet driver name"
 	default "zeth"

--- a/drivers/ethernet/eth_native_posix.c
+++ b/drivers/ethernet/eth_native_posix.c
@@ -422,6 +422,8 @@ static void eth_iface_init(struct net_if *iface)
 		create_rx_handler(ctx);
 
 		eth_setup_host(ctx->if_name);
+
+		eth_start_script(ctx->if_name);
 	}
 }
 

--- a/drivers/ethernet/eth_native_posix_adapt.c
+++ b/drivers/ethernet/eth_native_posix_adapt.c
@@ -114,6 +114,23 @@ int eth_setup_host(const char *if_name)
 		       if_name);
 }
 
+int eth_start_script(const char *if_name)
+{
+	if (CONFIG_ETH_NATIVE_POSIX_STARTUP_SCRIPT[0] == '\0') {
+		return 0;
+	}
+
+	if (CONFIG_ETH_NATIVE_POSIX_STARTUP_SCRIPT_USER[0] == '\0') {
+		return ssystem("%s %s", CONFIG_ETH_NATIVE_POSIX_STARTUP_SCRIPT,
+			       if_name);
+	} else {
+		return ssystem("sudo -u %s %s %s",
+			       CONFIG_ETH_NATIVE_POSIX_STARTUP_SCRIPT_USER,
+			       CONFIG_ETH_NATIVE_POSIX_STARTUP_SCRIPT,
+			       if_name);
+	}
+}
+
 int eth_wait_data(int fd)
 {
 	struct timeval timeout;

--- a/drivers/ethernet/eth_native_posix_priv.h
+++ b/drivers/ethernet/eth_native_posix_priv.h
@@ -14,6 +14,7 @@
 int eth_iface_create(const char *if_name, bool tun_only);
 int eth_iface_remove(int fd);
 int eth_setup_host(const char *if_name);
+int eth_start_script(const char *if_name);
 int eth_wait_data(int fd);
 ssize_t eth_read_data(int fd, void *buf, size_t buf_len);
 ssize_t eth_write_data(int fd, void *buf, size_t buf_len);

--- a/samples/net/eth_native_posix/net_start_wireshark.sh
+++ b/samples/net/eth_native_posix/net_start_wireshark.sh
@@ -1,0 +1,35 @@
+#!/bin/sh
+#
+# Copyright (c) 2018 Intel Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# This script can be called by native-posix board when TAP network interface
+# is created. This script will start wireshark so that it is possible to
+# monitor the network traffic for the interface.
+
+if [ ! -z "$1" ]; then
+    IFACE="$1"
+else
+    IFACE="zeth"
+fi
+
+WIRESHARK="wireshark -k -i $IFACE"
+
+echo "Starting \"$WIRESHARK\" as \"`id -u -n`\" user."
+
+$WIRESHARK &
+
+# The startup of wireshark is slow so sleep here a bit so that everything
+# in wireshark is setup properly before continuing with zephyr startup.
+sleep 5


### PR DESCRIPTION
Allow user to configure a program that is executed after the
network interface is created and IP address is setup.
This can be used e.g., to start wireshark to capture
the network traffic of the interface.

Signed-off-by: Jukka Rissanen <jukka.rissanen@linux.intel.com>