### PR TITLE
boards: 96b_argonkey, fix lsm6dsl label name

### DIFF
--- a/boards/arm/96b_argonkey/96b_argonkey.dts
+++ b/boards/arm/96b_argonkey/96b_argonkey.dts
@@ -60,7 +60,7 @@
 		reg = <1>;
 		spi-max-frequency = <1000000>;
 		irq-gpios = <&gpiob 1 0>;
-		label = "LSM6DSL-SPI";
+		label = "LSM6DSL_SPI";
 	};
 };
 


### PR DESCRIPTION
Replace LSM6DSL-SPI by LSM6DSL_SPI

Signed-off-by: Erwan Gouriou <erwan.gouriou@linaro.org>