### PR TITLE
Bluetooth: Fix storing name in plain text

### DIFF
--- a/subsys/bluetooth/host/hci_core.c
+++ b/subsys/bluetooth/host/hci_core.c
@@ -4761,13 +4761,6 @@ int bt_set_name(const char *name)
 		return 0;
 	}
 
-	if (IS_ENABLED(CONFIG_BT_SETTINGS)) {
-		err = settings_save_one("bt/name", CONFIG_BT_DEVICE_NAME);
-		if (err) {
-			return err;
-		}
-	}
-
 	strncpy(bt_dev.name, name, sizeof(bt_dev.name));
 
 	/* Update advertising name if in use */
@@ -4782,6 +4775,20 @@ int bt_set_name(const char *name)
 		if (atomic_test_bit(bt_dev.flags, BT_DEV_ADVERTISING)) {
 			set_advertise_enable(false);
 			set_advertise_enable(true);
+		}
+	}
+
+	if (IS_ENABLED(CONFIG_BT_SETTINGS)) {
+		char buf[BT_SETTINGS_SIZE(CONFIG_BT_DEVICE_NAME_MAX - 1)];
+		char *str;
+
+		str = settings_str_from_bytes(bt_dev.name, len, buf,
+					      sizeof(buf));
+		if (str) {
+			err = settings_save_one("bt/name", str);
+			if (err) {
+				BT_WARN("Unable to store name");
+			}
 		}
 	}
 

--- a/subsys/bluetooth/host/settings.c
+++ b/subsys/bluetooth/host/settings.c
@@ -122,13 +122,9 @@ static int set(int argc, char **argv, char *val)
 	}
 
 	if (!strcmp(argv[0], "name")) {
-		if (strlen(val) >= sizeof(bt_dev.name)) {
-			BT_ERR("Invalid length for device name in storage: name"
-			       " will be truncated");
-		}
-
-		strncpy(bt_dev.name, val, sizeof(bt_dev.name) - 1);
-		bt_dev.name[sizeof(bt_dev.name) - 1] = '\0';
+		len = sizeof(bt_dev.name) - 1;
+		settings_bytes_from_str(val, &bt_dev.name, &len);
+		bt_dev.name[len] = '\0';
 
 		BT_DBG("Name set to %s", bt_dev.name);
 		return 0;


### PR DESCRIPTION
Settings consider the character space the end of the value, so instead
encode the name using settings_str_from_bytes and restore it with
settings_bytes_from_str.

Signed-off-by: Luiz Augusto von Dentz <luiz.von.dentz@intel.com>