### PR TITLE
logging: Refactor log_output module

### DIFF
--- a/include/logging/log_output.h
+++ b/include/logging/log_output.h
@@ -36,30 +36,70 @@ extern "C" {
  *
  * @return Number of bytes processed.
  */
-typedef int (*log_output_func_t)(u8_t *data, size_t length, void *ctx);
+typedef int (*log_output_func_t)(u8_t *buf, size_t size, void *ctx);
 
-struct log_output_ctx {
-	log_output_func_t func;
-	u8_t *data;
-	size_t length;
+/* @brief Control block structure for log_output instance.  */
+struct log_output_control_block {
 	size_t offset;
 	void *ctx;
 };
 
-/** @brief Function for processing log messages to readable strings.
+/** @brief Log_output instance structure. */
+struct log_output {
+	log_output_func_t func;
+	struct log_output_control_block *control_block;
+	u8_t *buf;
+	size_t size;
+};
+
+/** @brief Create log_output instance.
+ *
+ * @param _name Instance name.
+ * @param _func Function for processing output data.
+ * @param _buf  Pointer to the output buffer.
+ * @param _size Size of the output buffer.
+ */
+#define LOG_OUTPUT_DEFINE(_name, _func, _buf, _size)			\
+	static struct log_output_control_block _name##_control_block;	\
+	static const struct log_output _name = {			\
+		.func = _func,						\
+		.control_block = &_name##_control_block,		\
+		.buf = _buf,						\
+		.size = _size,						\
+	}
+
+/** @brief Process log messages to readable strings.
  *
  * Function is using provided context with the buffer and output function to
  * process formatted string and output the data.
  *
+ * @param log_output Pointer to the log output instance.
  * @param msg Log message.
- * @param ctx Context.
  * @param flags Optional flags.
  */
-void log_output_msg_process(struct log_msg *msg,
-			    struct log_output_ctx *ctx,
+void log_output_msg_process(const struct log_output *log_output,
+			    struct log_msg *msg,
 			    u32_t flags);
 
-/** @brief Function for setting timestamp frequency.
+/** @brief Flush output buffer.
+ *
+ * @param log_output Pointer to the log output instance.
+ */
+void log_output_flush(const struct log_output *log_output);
+
+/** @brief Function for setting user context passed to the output function.
+ *
+ * @param log_output	Pointer to the log output instance.
+ * @param ctx		User context.
+ */
+static inline void log_output_ctx_set(const struct log_output *log_output,
+				      void *ctx)
+{
+	log_output->control_block->ctx = ctx;
+}
+
+
+/** @brief Set timestamp frequency.
  *
  * @param freq Frequency in Hz.
  */

--- a/subsys/logging/log_output.c
+++ b/subsys/logging/log_output.c
@@ -43,55 +43,69 @@ static u32_t timestamp_div;
 typedef int (*out_func_t)(int c, void *ctx);
 
 extern int _prf(int (*func)(), void *dest, char *format, va_list vargs);
-extern void _vprintk(out_func_t out, void *ctx, const char *fmt, va_list ap);
+extern void _vprintk(out_func_t out, void *log_output, const char *fmt, va_list ap);
 
 static int out_func(int c, void *ctx)
 {
-	struct log_output_ctx *out_ctx = (struct log_output_ctx *)ctx;
+	const struct log_output *out_ctx =
+					(const struct log_output *)ctx;
 
-	out_ctx->data[out_ctx->offset] = (u8_t)c;
-	out_ctx->offset++;
+	out_ctx->buf[out_ctx->control_block->offset] = (u8_t)c;
+	out_ctx->control_block->offset++;
 
-	if (out_ctx->offset == out_ctx->length) {
-		out_ctx->func(out_ctx->data, out_ctx->length, out_ctx->ctx);
-		out_ctx->offset = 0;
+	assert(out_ctx->control_block->offset <= out_ctx->size);
+
+	if (out_ctx->control_block->offset == out_ctx->size) {
+		log_output_flush(out_ctx);
 	}
 
 	return 0;
 }
 
-static int print(struct log_output_ctx *ctx, const char *fmt, ...)
+static int print_formatted(const struct log_output *log_output,
+			   const char *fmt, ...)
 {
 	va_list args;
 	int length = 0;
 
 	va_start(args, fmt);
 #ifndef CONFIG_NEWLIB_LIBC
-	length = _prf(out_func, ctx, (char *)fmt, args);
+	length = _prf(out_func, (void *)log_output, (char *)fmt, args);
 #else
-	_vprintk(out_func, ctx, fmt, args);
+	_vprintk(out_func, (void *)log_output, fmt, args);
 #endif
 	va_end(args);
 
 	return length;
 }
 
-static void flush(struct log_output_ctx *ctx)
+void log_output_flush(const struct log_output *log_output)
 {
-	ctx->func(ctx->data, ctx->offset, ctx->ctx);
+	int offset = 0;
+	int len = log_output->control_block->offset;
+	int processed;
+
+	do {
+		processed = log_output->func(&log_output->buf[offset], len,
+					     log_output->control_block->ctx);
+		len -= processed;
+		offset += processed;
+	} while (len);
+
+	log_output->control_block->offset = 0;
 }
 
 static int timestamp_print(struct log_msg *msg,
-			   struct log_output_ctx *ctx,
+			   const struct log_output *log_output,
 			   bool format)
 {
 	int length;
 	u32_t timestamp = log_msg_timestamp_get(msg);
 
 	if (!format) {
-		length = print(ctx, "[%08lu] ", timestamp);
+		length = print_formatted(log_output, "[%08lu] ", timestamp);
 	} else if (freq) {
-		u32_t reminder;
+		u32_t remainder;
 		u32_t seconds;
 		u32_t hours;
 		u32_t mins;
@@ -105,12 +119,13 @@ static int timestamp_print(struct log_msg *msg,
 		mins = seconds / 60;
 		seconds -= mins * 60;
 
-		reminder = timestamp % freq;
-		ms = (reminder * 1000) / freq;
-		us = (1000 * (1000 * reminder - (ms * freq))) / freq;
+		remainder = timestamp % freq;
+		ms = (remainder * 1000) / freq;
+		us = (1000 * (1000 * remainder - (ms * freq))) / freq;
 
-		length = print(ctx, "[%02d:%02d:%02d.%03d,%03d] ",
-			       hours, mins, seconds, ms, us);
+		length = print_formatted(log_output,
+					 "[%02d:%02d:%02d.%03d,%03d] ",
+					 hours, mins, seconds, ms, us);
 	} else {
 		length = 0;
 	}
@@ -119,7 +134,7 @@ static int timestamp_print(struct log_msg *msg,
 }
 
 static void color_print(struct log_msg *msg,
-			struct log_output_ctx *ctx,
+			const struct log_output *log_output,
 			bool color,
 			bool start)
 {
@@ -130,74 +145,74 @@ static void color_print(struct log_msg *msg,
 			const char *color = start ?
 					 colors[level] : LOG_COLOR_CODE_DEFAULT;
 
-			print(ctx, "%s", color);
+			print_formatted(log_output, "%s", color);
 		}
 	}
 }
 
 static void color_prefix(struct log_msg *msg,
-			 struct log_output_ctx *ctx,
+			 const struct log_output *log_output,
 			 bool color)
 {
-	color_print(msg, ctx, color, true);
+	color_print(msg, log_output, color, true);
 }
 
 static void color_postfix(struct log_msg *msg,
-			  struct log_output_ctx *ctx,
+			  const struct log_output *log_output,
 			  bool color)
 {
-	color_print(msg, ctx, color, false);
+	color_print(msg, log_output, color, false);
 }
 
 
 static int ids_print(struct log_msg *msg,
-		     struct log_output_ctx *ctx)
+		     const struct log_output *log_output)
 {
 	u32_t domain_id = log_msg_domain_id_get(msg);
 	u32_t source_id = log_msg_source_id_get(msg);
 	u32_t level = log_msg_level_get(msg);
 
-	return print(ctx, "<%s> %s: ", severity[level],
+	return print_formatted(log_output, "<%s> %s: ", severity[level],
 		     log_source_name_get(domain_id, source_id));
 }
 
-static void newline_print(struct log_output_ctx *ctx)
+static void newline_print(const struct log_output *ctx)
 {
-	print(ctx, "\r\n");
+	print_formatted(ctx, "\r\n");
 }
 
 static void std_print(struct log_msg *msg,
-		      struct log_output_ctx *ctx)
+		      const struct log_output *log_output)
 {
 	const char *str = log_msg_str_get(msg);
 
 	switch (log_msg_nargs_get(msg)) {
 	case 0:
-		print(ctx, str);
+		print_formatted(log_output, str);
 		break;
 	case 1:
-		print(ctx, str, log_msg_arg_get(msg, 0));
+		print_formatted(log_output, str, log_msg_arg_get(msg, 0));
 		break;
 	case 2:
-		print(ctx, str,
+		print_formatted(log_output, str,
 		      log_msg_arg_get(msg, 0),
 		      log_msg_arg_get(msg, 1));
 		break;
 	case 3:
-		print(ctx, str,
+		print_formatted(log_output, str,
 		      log_msg_arg_get(msg, 0),
 		      log_msg_arg_get(msg, 1),
 		      log_msg_arg_get(msg, 2));
 		break;
 	case 4:
-		print(ctx, str,
+		print_formatted(log_output, str,
 		      log_msg_arg_get(msg, 0),
 		      log_msg_arg_get(msg, 1),
 		      log_msg_arg_get(msg, 2),
 		      log_msg_arg_get(msg, 3));
 		break;
 	case 5:
-		print(ctx, str,
+		print_formatted(log_output, str,
 		      log_msg_arg_get(msg, 0),
 		      log_msg_arg_get(msg, 1),
 		      log_msg_arg_get(msg, 2),
@@ -205,7 +220,7 @@ static void std_print(struct log_msg *msg,
 		      log_msg_arg_get(msg, 4));
 		break;
 	case 6:
-		print(ctx, str,
+		print_formatted(log_output, str,
 		      log_msg_arg_get(msg, 0),
 		      log_msg_arg_get(msg, 1),
 		      log_msg_arg_get(msg, 2),
@@ -214,7 +229,7 @@ static void std_print(struct log_msg *msg,
 		      log_msg_arg_get(msg, 5));
 		break;
 	case 7:
-		print(ctx, str,
+		print_formatted(log_output, str,
 		      log_msg_arg_get(msg, 0),
 		      log_msg_arg_get(msg, 1),
 		      log_msg_arg_get(msg, 2),
@@ -224,7 +239,7 @@ static void std_print(struct log_msg *msg,
 		      log_msg_arg_get(msg, 6));
 		break;
 	case 8:
-		print(ctx, str,
+		print_formatted(log_output, str,
 		      log_msg_arg_get(msg, 0),
 		      log_msg_arg_get(msg, 1),
 		      log_msg_arg_get(msg, 2),
@@ -235,7 +250,7 @@ static void std_print(struct log_msg *msg,
 		      log_msg_arg_get(msg, 7));
 		break;
 	case 9:
-		print(ctx, str,
+		print_formatted(log_output, str,
 		      log_msg_arg_get(msg, 0),
 		      log_msg_arg_get(msg, 1),
 		      log_msg_arg_get(msg, 2),
@@ -246,11 +261,14 @@ static void std_print(struct log_msg *msg,
 		      log_msg_arg_get(msg, 7),
 		      log_msg_arg_get(msg, 8));
 		break;
+	default:
+		/* Unsupported number of arguments. */
+		assert(true);
 	}
 }
 
 static u32_t hexdump_line_print(struct log_msg *msg,
-				struct log_output_ctx *ctx,
+				const struct log_output *log_output,
 				int prefix_offset,
 				u32_t offset)
 {
@@ -260,29 +278,30 @@ static u32_t hexdump_line_print(struct log_msg *msg,
 	log_msg_hexdump_data_get(msg, buf, &length, offset);
 
 	if (length > 0) {
-		newline_print(ctx);
+		newline_print(log_output);
 
 		for (int i = 0; i < prefix_offset; i++) {
-			print(ctx, " ");
+			print_formatted(log_output, " ");
 		}
 
 		for (int i = 0; i < HEXDUMP_BYTES_IN_LINE; i++) {
 			if (i < length) {
-				print(ctx, "%02x ", buf[i]);
+				print_formatted(log_output, "%02x ", buf[i]);
 			} else {
-				print(ctx, "   ");
+				print_formatted(log_output, "   ");
 			}
 		}
 
-		print(ctx, "|");
+		print_formatted(log_output, "|");
 
 		for (int i = 0; i < HEXDUMP_BYTES_IN_LINE; i++) {
 			if (i < length) {
 				char c = (char)buf[i];
 
-				print(ctx, "%c", isprint((int)c) ? c : '.');
+				print_formatted(log_output, "%c",
+				      isprint((int)c) ? c : '.');
 			} else {
-				print(ctx, " ");
+				print_formatted(log_output, " ");
 			}
 		}
 	}
@@ -291,16 +310,17 @@ static u32_t hexdump_line_print(struct log_msg *msg,
 }
 
 static void hexdump_print(struct log_msg *msg,
-			  struct log_output_ctx *ctx,
+			  const struct log_output *log_output,
 			  int prefix_offset)
 {
 	u32_t offset = 0;
 	u32_t length;
 
-	print(ctx, "%s", log_msg_str_get(msg));
+	print_formatted(log_output, "%s", log_msg_str_get(msg));
 
 	do {
-		length = hexdump_line_print(msg, ctx, prefix_offset, offset);
+		length = hexdump_line_print(msg, log_output, prefix_offset,
+					    offset);
 
 		if (length < HEXDUMP_BYTES_IN_LINE) {
 			break;
@@ -311,25 +331,27 @@ static void hexdump_print(struct log_msg *msg,
 }
 
 static void raw_string_print(struct log_msg *msg,
-			     struct log_output_ctx *ctx)
+			     const struct log_output *log_output)
 {
-	assert(ctx->length);
+	assert(log_output->size);
 
 	size_t offset = 0;
 	size_t length;
 
 	do {
-		length = ctx->length;
-		log_msg_hexdump_data_get(msg, ctx->data, &length, offset);
+		length = log_output->size;
+		/* Sting is stored in a hexdump message. */
+		log_msg_hexdump_data_get(msg, log_output->buf, &length, offset);
+		log_output->control_block->offset = length;
+		log_output_flush(log_output);
 		offset += length;
-		ctx->func(ctx->data, length, ctx->ctx);
 	} while (length > 0);
 
-	print(ctx, "\r");
+	print_formatted(log_output, "\r");
 }
 
 static int prefix_print(struct log_msg *msg,
-			struct log_output_ctx *ctx,
+			const struct log_output *log_output,
 			u32_t flags)
 {
 	int length = 0;
@@ -338,41 +360,42 @@ static int prefix_print(struct log_msg *msg,
 		bool stamp_format = flags & LOG_OUTPUT_FLAG_FORMAT_TIMESTAMP;
 		bool colors_on = flags & LOG_OUTPUT_FLAG_COLORS;
 
-		length += timestamp_print(msg, ctx, stamp_format);
-		color_prefix(msg, ctx, colors_on);
-		length += ids_print(msg, ctx);
+		length += timestamp_print(msg, log_output, stamp_format);
+		color_prefix(msg, log_output, colors_on);
+		length += ids_print(msg, log_output);
 	}
 
 	return length;
 }
 
 static void postfix_print(struct log_msg *msg,
-			  struct log_output_ctx *ctx,
+			  const struct log_output *log_output,
 			  u32_t flags)
 {
 	if (!log_msg_is_raw_string(msg)) {
-		color_postfix(msg, ctx, (flags & LOG_OUTPUT_FLAG_COLORS));
-		newline_print(ctx);
+		color_postfix(msg, log_output,
+			      (flags & LOG_OUTPUT_FLAG_COLORS));
+		newline_print(log_output);
 	}
 }
 
-void log_output_msg_process(struct log_msg *msg,
-			    struct log_output_ctx *ctx,
+void log_output_msg_process(const struct log_output *log_output,
+			    struct log_msg *msg,
 			    u32_t flags)
 {
-	int prefix_offset = prefix_print(msg, ctx, flags);
+	int prefix_offset = prefix_print(msg, log_output, flags);
 
 	if (log_msg_is_std(msg)) {
-		std_print(msg, ctx);
+		std_print(msg, log_output);
 	} else if (log_msg_is_raw_string(msg)) {
-		raw_string_print(msg, ctx);
+		raw_string_print(msg, log_output);
 	} else {
-		hexdump_print(msg, ctx, prefix_offset);
+		hexdump_print(msg, log_output, prefix_offset);
 	}
 
-	postfix_print(msg, ctx, flags);
+	postfix_print(msg, log_output, flags);
 
-	flush(ctx);
+	log_output_flush(log_output);
 }
 
 void log_output_timestamp_freq_set(u32_t frequency)


### PR DESCRIPTION
Module refactored: splitted data into read-only part and control block,
adding macro for creating log_output instance

There are no functional changes in the module rather cleaning up initial implementation.
Signed-off-by: Krzysztof Chruscinski <krzysztof.chruscinski@nordicsemi.no>