### PR TITLE
Bluetooth: Mesh: Clarify confusing log message

### DIFF
--- a/subsys/bluetooth/host/mesh/transport.c
+++ b/subsys/bluetooth/host/mesh/transport.c
@@ -654,7 +654,8 @@ static int sdu_recv(struct bt_mesh_net_rx *rx, u32_t seq, u8_t hdr,
 					  rx->ctx.recv_dst, seq,
 					  BT_MESH_NET_IVI_RX(rx));
 		if (err) {
-			BT_WARN("Unable to decrypt with AppKey %u", i);
+			BT_WARN("Unable to decrypt with AppKey 0x%03x",
+				key->app_idx);
 			continue;
 
 		}


### PR DESCRIPTION
Normally App Keys are identified using the AppKey Index value (a 12
bit value in practice), whereas the stack-internal array index has
very little relevance.

Signed-off-by: Johan Hedberg <johan.hedberg@intel.com>