### PR TITLE
Bluetooth: SMP: Don't try to encrypt with a non-existing LTK

### DIFF
--- a/subsys/bluetooth/host/smp.c
+++ b/subsys/bluetooth/host/smp.c
@@ -3177,7 +3177,12 @@ static u8_t smp_security_request(struct bt_smp *smp, struct net_buf *buf)
 		auth = req->auth_req & BT_SMP_AUTH_MASK;
 	}
 
-	if (!conn->le.keys) {
+	if (conn->le.keys) {
+		/* Make sure we have an LTK to encrypt with */
+		if (!(conn->le.keys->keys & (BT_KEYS_LTK_P256 | BT_KEYS_LTK))) {
+			goto pair;
+		}
+	} else {
 		conn->le.keys = bt_keys_find(BT_KEYS_LTK_P256, &conn->le.dst);
 		if (!conn->le.keys) {
 			conn->le.keys = bt_keys_find(BT_KEYS_LTK,


### PR DESCRIPTION
When we receive a security request we need to make sure that any
existing keys contain an LTK to encrypt with. Otherwise there's a risk
of trying to encrypt with an all-zeroes LTK.

Fixes #3221

Signed-off-by: Johan Hedberg <johan.hedberg@intel.com>