### PR TITLE
Kconfig: Clean up some symbol definitions

### DIFF
--- a/arch/x86/Kconfig
+++ b/arch/x86/Kconfig
@@ -200,7 +200,7 @@ config IA32_LEGACY_IO_PORTS
 	  than memory access, so they should be used in last resort.
 
 config CMOV
-	def_bool n
+	bool
 	help
 	  This option signifies the use of an Intel CPU that supports
 	  the CMOV instruction.

--- a/drivers/bluetooth/hci/Kconfig
+++ b/drivers/bluetooth/hci/Kconfig
@@ -87,7 +87,6 @@ if BT_SPI
 
 config BT_BLUENRG_ACI
 	bool "Enable ACI message with with BlueNRG-based devices"
-	default n
 	help
 	  Enable support for devices compatible with the BlueNRG Bluetooth
 	  Stack. Current driver supports: ST BLUENRG-MS.

--- a/drivers/ethernet/Kconfig.native_posix
+++ b/drivers/ethernet/Kconfig.native_posix
@@ -42,7 +42,6 @@ config ETH_NATIVE_POSIX_DEV_NAME
 
 config ETH_NATIVE_POSIX_PTP_CLOCK
 	bool "PTP clock driver support"
-	default n
 	select PTP_CLOCK
 	depends on NET_GPTP
 	help

--- a/drivers/i2c/slave/Kconfig
+++ b/drivers/i2c/slave/Kconfig
@@ -12,7 +12,6 @@
 menuconfig I2C_SLAVE
 	bool "I2C Slave Drivers"
 	depends on I2C
-	default n
 	help
 	  Enable I2C Slave Driver Configuration
 

--- a/drivers/i2c/slave/Kconfig.eeprom
+++ b/drivers/i2c/slave/Kconfig.eeprom
@@ -9,7 +9,6 @@
 config I2C_EEPROM_SLAVE
 	bool "I2C Slave EEPROM driver"
 	depends on I2C_SLAVE
-	default n
 	help
 	  Enable virtual I2C Slave EEPROM driver
 
@@ -41,7 +40,6 @@ config I2C_EEPROM_SLAVE_0_ADDRESS
 config I2C_EEPROM_SLAVE_1
 	bool "Enable I2C Slave EEPROM driver instance 1"
 	depends on I2C_EEPROM_SLAVE
-	default n
 
 config I2C_EEPROM_SLAVE_1_SIZE
 	int "I2C Slave EEPROM 1 Size in KiB"

--- a/drivers/led/Kconfig.pca9633
+++ b/drivers/led/Kconfig.pca9633
@@ -7,7 +7,6 @@
 menuconfig PCA9633
 	bool "PCA9633 LED driver"
 	depends on I2C
-	default n
 	help
 	  Enable LED driver for PCA9633.
 

--- a/drivers/serial/Kconfig.gecko
+++ b/drivers/serial/Kconfig.gecko
@@ -50,7 +50,6 @@ endif # UART_GECKO_1
 
 menuconfig USART_GECKO_0
 	bool "USART 0"
-	default n
 	help
 	  Enable USART 0.
 
@@ -67,7 +66,6 @@ endif # USART_GECKO_0
 
 menuconfig USART_GECKO_1
 	bool "USART 1"
-	default n
 	help
 	  Enable USART 1.
 

--- a/ext/lib/crypto/mbedtls/Kconfig.tls-generic
+++ b/ext/lib/crypto/mbedtls/Kconfig.tls-generic
@@ -15,13 +15,11 @@ config TLS_VERSION_1_0
 	bool "Enable support for TLS 1.0"
 	select TLS_MAC_MD5_ENABLED
 	select TLS_MAC_SHA1_ENABLED
-	default n
 
 config TLS_VERSION_1_1
 	bool "Enable support for TLS 1.1 (DTLS 1.0)"
 	select TLS_MAC_MD5_ENABLED
 	select TLS_MAC_SHA1_ENABLED
-	default n
 
 config TLS_VERSION_1_2
 	bool "Enable support for TLS 1.2 (DTLS 1.2)"
@@ -30,7 +28,6 @@ config TLS_VERSION_1_2
 config TLS_DTLS
 	bool "Enable support for DTLS"
 	depends on TLS_VERSION_1_1 || TLS_VERSION_1_2
-	default n
 
 endmenu
 
@@ -40,19 +37,15 @@ comment "Supported key exchange modes"
 
 config TLS_KEY_EXCHANGE_PSK_ENABLED
 	bool "Enable the PSK based ciphersuite modes"
-	default n
 
 config TLS_KEY_EXCHANGE_DHE_PSK_ENABLED
 	bool "Enable the DHE-PSK based ciphersuite modes"
-	default n
 
 config TLS_KEY_EXCHANGE_ECDHE_PSK_ENABLED
 	bool "Enable the ECDHE-PSK based ciphersuite modes"
-	default n
 
 config TLS_KEY_EXCHANGE_RSA_PSK_ENABLED
 	bool "Enable the RSA-PSK based ciphersuite modes"
-	default n
 
 config TLS_KEY_EXCHANGE_RSA_ENABLED
 	bool "Enable the RSA-only based ciphersuite modes"
@@ -60,92 +53,72 @@ config TLS_KEY_EXCHANGE_RSA_ENABLED
 
 config TLS_KEY_EXCHANGE_DHE_RSA_ENABLED
 	bool "Enable the DHE-RSA based ciphersuite modes"
-	default n
 
 config TLS_KEY_EXCHANGE_ECDHE_RSA_ENABLED
 	bool "Enable the ECDHE-RSA based ciphersuite modes"
-	default n
 
 config TLS_KEY_EXCHANGE_ECDHE_ECDSA_ENABLED
 	bool "Enable the ECDHE-ECDSA based ciphersuite modes"
-	default n
 
 config TLS_KEY_EXCHANGE_ECDH_ECDSA_ENABLED
 	bool "Enable the ECDH-ECDSA based ciphersuite modes"
-	default n
 
 config TLS_KEY_EXCHANGE_ECDH_RSA_ENABLED
 	bool "Enable the ECDH-RSA based ciphersuite modes"
-	default n
 
 config TLS_KEY_EXCHANGE_ECJPAKE_ENABLED
 	bool "Enable the ECJPAKE based ciphersuite modes"
-	default n
 
 if TLS_KEY_EXCHANGE_ECDHE_PSK_ENABLED || \
    TLS_KEY_EXCHANGE_ECDHE_RSA_ENABLED || \
    TLS_KEY_EXCHANGE_ECDHE_ECDSA_ENABLED || \
    TLS_KEY_EXCHANGE_ECDH_ECDSA_ENABLED || \
    TLS_KEY_EXCHANGE_ECDH_RSA_ENABLED || \
-   TLS_KEY_EXCHANGE_ECJPAKE_ENABLED \
+   TLS_KEY_EXCHANGE_ECJPAKE_ENABLED
 
 comment "Supported elliptic curves"
 
 config TLS_ECP_DP_SECP192R1_ENABLED
 	bool "Enable SECP192R1 elliptic curve"
-	default n
 
 config TLS_ECP_DP_SECP224R1_ENABLED
 	bool "Enable SECP224R1 elliptic curve"
-	default n
 
 config TLS_ECP_DP_SECP256R1_ENABLED
 	bool "Enable SECP256R1 elliptic curve"
-	default n
 
 config TLS_ECP_DP_SECP384R1_ENABLED
 	bool "Enable SECP384R1 elliptic curve"
-	default n
 
 config TLS_ECP_DP_SECP521R1_ENABLED
 	bool "Enable SECP521R1 elliptic curve"
-	default n
 
 config TLS_ECP_DP_SECP192K1_ENABLED
 	bool "Enable SECP192K1 elliptic curve"
-	default n
 
 config TLS_ECP_DP_SECP224K1_ENABLED
 	bool "Enable SECP224K1 elliptic curve"
-	default n
 
 config TLS_ECP_DP_SECP256K1_ENABLED
 	bool "Enable SECP256K1 elliptic curve"
-	default n
 
 config TLS_ECP_DP_BP256R1_ENABLED
 	bool "Enable BP256R1 elliptic curve"
-	default n
 
 config TLS_ECP_DP_BP384R1_ENABLED
 	bool "Enable BP384R1 elliptic curve"
-	default n
 
 config TLS_ECP_DP_BP512R1_ENABLED
 	bool "Enable BP512R1 elliptic curve"
-	default n
 
 config TLS_ECP_DP_CURVE25519_ENABLED
 	bool "Enable CURVE25519 elliptic curve"
-	default n
 
 config TLS_ECP_DP_CURVE448_ENABLED
 	bool "Enable CURVE448 elliptic curve"
-	default n
 
 config TLS_ECP_NIST_OPTIM
 	bool "Enable NSIT curves optimization"
-	default n
 
 endif
 
@@ -157,7 +130,6 @@ config TLS_CIPHER_AES_ENABLED
 
 config TLS_CIPHER_CAMELLIA_ENABLED
 	bool "Enable the Camellia block cipher"
-	default n
 
 config TLS_CIPHER_DES_ENABLED
 	bool "Enable the DES block cipher"
@@ -165,7 +137,6 @@ config TLS_CIPHER_DES_ENABLED
 
 config TLS_CIPHER_CCM_ENABLED
 	bool "Enable the Counter with CBC-MAC (CCM) mode for 128-bit block cipher"
-	default n
 	depends on TLS_CIPHER_AES_ENABLED || TLS_CIPHER_CAMELLIA_ENABLED
 
 config TLS_CIPHER_CBC_ENABLED
@@ -188,20 +159,17 @@ config TLS_MAC_SHA256_ENABLED
 
 config TLS_MAC_SHA512_ENABLED
 	bool "Enable the SHA-384 and SHA-512 hash algorithms"
-	default n
 
 endmenu
 
 config TLS_PEM_CERTIFICATE_FORMAT
 	bool "Enable support for PEM certificate format"
-	default n
 	help
 	  By default only DER (binary) format of certificates is supported. Enable
 	  this option to enable support for PEM format.
 
 config TLS_USER_CONFIG_ENABLE
 	bool "Enable user mbedTLS config file"
-	default n
 	help
 	  Enable user mbedTLS config file that will be included at the end of
 	  the generic config file.
@@ -209,7 +177,6 @@ config TLS_USER_CONFIG_ENABLE
 config TLS_USER_CONFIG_FILE
 	string "User configuration file for mbedTLS"
 	depends on TLS_USER_CONFIG_ENABLE
-	default ""
 	help
 	  User config file that can contain mbedTLS configs that were not
 	  covered by the generic config file.

--- a/misc/Kconfig
+++ b/misc/Kconfig
@@ -56,8 +56,7 @@ config TEXT_SECTION_OFFSET
 	  may require smaller or larger values.
 
 config HAVE_CUSTOM_LINKER_SCRIPT
-	prompt "Custom linker scripts provided"
-	def_bool n
+	bool "Custom linker scripts provided"
 	help
 	  Set this option if you have a custom linker script which needed to
 	  be define in CUSTOM_LINKER_SCRIPT.
@@ -251,7 +250,6 @@ config BUILD_OUTPUT_STRIPPED
 
 config APPLICATION_DEFINED_SYSCALL
 	bool "Scan application folder for any syscall definition"
-	default n
 	help
 	  Scan additional folders inside application source folder
 	  for application defined syscalls.
@@ -346,9 +344,7 @@ config BOOTLOADER_MCUBOOT
 	      Tree in order to place and link the image at the slot0 offset
 
 config BOOTLOADER_ESP_IDF
-	bool
-	prompt "ESP-IDF bootloader support"
-	default n
+	bool "ESP-IDF bootloader support"
 	depends on SOC_ESP32
 	help
 	  This option will trigger the compilation of the ESP-IDF booloader
@@ -356,9 +352,7 @@ config BOOTLOADER_ESP_IDF
 	  At flash time, the bootloader will be flashed with the zephyr image
 
 config REALMODE
-	bool
-	prompt "boot from x86 real mode"
-	default n
+	bool "boot from x86 real mode"
 	depends on X86
 	help
 	  This option enabled Zephyr to start in x86 real mode, instead of

--- a/subsys/app_memory/Kconfig
+++ b/subsys/app_memory/Kconfig
@@ -1,9 +1,8 @@
-
 menu "General Kernel Options"
+
 config APP_SHARED_MEM
-	bool
-	prompt "Application shared memory with app_memory"
-	default n
+	bool "Application shared memory with app_memory"
 	help
-	 This is a wrapper around app_memory to simplify usage.
+	  This is a wrapper around app_memory to simplify usage.
+
 endmenu

--- a/subsys/net/ip/Kconfig.ipv4
+++ b/subsys/net/ip/Kconfig.ipv4
@@ -44,8 +44,7 @@ config NET_DHCPV4
 config NET_IPV4_AUTO
 	bool "Enable IPv4 autoconfiguration [EXPERIMENTAL]"
 	depends on NET_IPV4 && NET_ARP
-	default n
-	  help
+	help
 	  Enables IPv4 auto IP address configuration (see RFC 3927)
 
 if NET_LOG
@@ -69,7 +68,6 @@ config NET_DEBUG_DHCPV4
 config NET_DEBUG_IPV4_AUTOCONF
 	bool "Debug IPv4 autoconf client"
 	depends on NET_IPV4_AUTO
-	default n
 	help
 	  Enable debug diagnostic from IPv4 autoconf client.
 

--- a/subsys/net/lib/sockets/Kconfig
+++ b/subsys/net/lib/sockets/Kconfig
@@ -24,15 +24,13 @@ config NET_SOCKETS_POSIX_NAMES
 	  option enabled, it will still apply only to sockets.
 
 config NET_SOCKETS_POLL_MAX
-	int
-	prompt "Max number of supported poll() entries"
+	int "Max number of supported poll() entries"
 	default 3
 	help
 	  Maximum number of entries supported for poll() call.
 
 config NET_SOCKETS_SOCKOPT_TLS
 	bool "Enable TCP TLS socket option support [EXPERIMENTAL]"
-	default n
 	select TLS_CREDENTIALS
 	help
 	  Enable TLS socket option support which automatically establishes

--- a/subsys/net/lib/tls_credentials/Kconfig
+++ b/subsys/net/lib/tls_credentials/Kconfig
@@ -6,7 +6,6 @@
 
 menuconfig TLS_CREDENTIALS
 	bool "TLS credentials management"
-	default n
 	help
 	  Enable TLS credentials management subsystem.
 

--- a/subsys/usb/Kconfig
+++ b/subsys/usb/Kconfig
@@ -15,8 +15,7 @@ menuconfig USB_DEVICE_STACK
 if USB_DEVICE_STACK
 
 config SYS_LOG_USB_DEVICE_LEVEL
-	int
-	prompt "Sets log level for the USB device stack"
+	int "Sets log level for the USB device stack"
 	default 0
 	depends on SYS_LOG
 	help
@@ -35,36 +34,31 @@ config SYS_LOG_USB_DEVICE_LEVEL
 	  - 4 DEBUG, write SYS_LOG_DBG in addition to previous levels
 
 config USB_DEVICE_VID
-	hex
-	prompt "USB Vendor ID"
+	hex "USB Vendor ID"
 	default 0x2FE3
 	help
 	  USB device vendor ID. MUST be configured by vendor.
 
 config USB_DEVICE_PID
-	hex
-	prompt "USB Product ID"
+	hex "USB Product ID"
 	default 0x100
 	help
 	  USB device product ID. MUST be configured by vendor.
 
 config USB_DEVICE_MANUFACTURER
-	string
-	prompt "USB manufacturer name"
+	string "USB manufacturer name"
 	default "ZEPHYR"
 	help
 	  USB device Manufacturer string. MUST be configured by vendor.
 
 config USB_DEVICE_PRODUCT
-	string
-	prompt "USB product name"
+	string "USB product name"
 	default "USB-DEV"
 	help
 	  USB device Product string. MUST be configured by vendor.
 
 config USB_DEVICE_SN
-	string
-	prompt "USB serial number"
+	string "USB serial number"
 	default "0.01"
 	help
 	  USB device SerialNumber string. MUST be configured by vendor.
@@ -76,8 +70,7 @@ config USB_COMPOSITE_DEVICE
 	  Enable composite USB device driver.
 
 config USB_COMPOSITE_BUFFER_SIZE
-	int
-	prompt "Set buffer size for Class Handler"
+	int "Set buffer size for Class Handler"
 	depends on USB_COMPOSITE_DEVICE
 	default 64
 	default 256 if USB_DEVICE_NETWORK_RNDIS
@@ -86,9 +79,7 @@ config USB_DEVICE_BOS
 	bool "Enable USB Binary Device Object Store (BOS)"
 
 config USB_DEVICE_OS_DESC
-	bool
-	prompt "Enable MS OS Descriptors support"
-	default n
+	bool "Enable MS OS Descriptors support"
 
 source "subsys/usb/class/Kconfig"
 

--- a/tests/drivers/i2c/i2c_slave_api/common/Kconfig
+++ b/tests/drivers/i2c/i2c_slave_api/common/Kconfig
@@ -9,12 +9,11 @@
 config I2C_VIRTUAL
 	bool "Virtual I2C Driver for Slave development"
 	depends on I2C
-	default n
 	help
 	  This driver exposes a virtual I2C driver used to debug virtual
 	  I2C slave drivers.
 
 config I2C_VIRTUAL_NAME
 	string "Virtual Port device name"
-	depends on I2C_VIRTUAL
 	default "I2C_VIRTUAL"
+	depends on I2C_VIRTUAL


### PR DESCRIPTION
- Remove redundant `n` defaults. `n` is the default value for `bool`
  symbols.

  This makes the auto-generated documentation clearer as well: You get
  `implicitly defaults to n` instead of
  `- n if <propagated dependencies>`.

- Shorten

      <type>
      prompt "foo"

  to

      <type> "foo"

  This works for all types, not just `bool`.

- Various formatting nits.