### PR TITLE
Doc: installation_linux.rst: Feedback Updates

### DIFF
--- a/doc/getting_started/installation_linux.rst
+++ b/doc/getting_started/installation_linux.rst
@@ -54,9 +54,9 @@ On Clear Linux:
 Installing Requirements and Dependencies
 ****************************************
 
-Install the following with either apt-get or dnf.
+Install the following required packages using either apt-get or dnf.
 
-Install the required packages in a Ubuntu host system with:
+On Ubuntu host system:
 
 .. code-block:: console
 
@@ -65,17 +65,17 @@ Install the required packages in a Ubuntu host system with:
      python3-ply python3-pip python3-setuptools python3-wheel xz-utils file \
      make gcc-multilib autoconf automake libtool
 
-Install the required packages in a Fedora host system with:
+On Fedora host system:
 
 .. code-block:: console
 
    sudo dnf group install "Development Tools" "C Development Tools and Libraries"
    sudo dnf install git cmake ninja-build gperf ccache\
-	 doxygen dfu-util dtc python3-pip \
-	 python3-ply python3-yaml dfu-util dtc python3-pykwalify \
-         glibc-devel.i686 libstdc++-devel.i686 autoconf automake libtool
+     doxygen dfu-util dtc python3-pip \
+     python3-ply python3-yaml dfu-util dtc python3-pykwalify \
+     glibc-devel.i686 libstdc++-devel.i686 autoconf automake libtool
 
-Install the required packages in a Clear Linux host system with:
+On Clear Linux host system:
 
 .. code-block:: console
 
@@ -139,6 +139,7 @@ Follow these steps to install the SDK on your Linux host system.
 
    .. code-block:: console
 
+      cd <sdk download directory>
       sh zephyr-sdk-0.9.3-setup.run
 
    .. important::
@@ -178,6 +179,11 @@ Follow these steps to install the SDK on your Linux host system.
      export ZEPHYR_TOOLCHAIN_VARIANT=zephyr
      export ZEPHYR_SDK_INSTALL_DIR=/opt/zephyr-sdk
      EOF
+
+  .. note::
+     Use ``<sdk installation directory>`` in place of ``/opt/zephyr-sdk/`` in the
+     above shown example if the SDK installation location is not default.
+
 
   .. note::
      Some Linux distributions have default CFLAGS and CXXFLAGS


### PR DESCRIPTION
Modified the web page to  make it direct and easier to understand.

Major changes being the selection of the directory in the Zephyr SDK
Installation and a Note added for the '.zephyrrc' to include the SDK
installation location if not default.

Minor changes involving the elimination of repeated use of same sentence
with different Host OS and indentation correction in the Fedora section
since it showed up in 'white text' rather than code block.

SDK's '.zephyrrc' documentation needed to have the default location and
the user defined location

Signed-off-by: Arjun Warty <arjun.warty@nxp.com>