### PR TITLE
net: net_app: Correctly notify server on TCP disconnection

### DIFF
--- a/subsys/net/lib/app/net_app.c
+++ b/subsys/net/lib/app/net_app.c
@@ -200,7 +200,7 @@ void _net_app_received(struct net_context *net_ctx,
 			 * context do not call the close callback.
 			 */
 			for (i = 0; i < CONFIG_NET_APP_SERVER_NUM_CONN; i++) {
-				if (!ctx->server.net_ctxs[i]) {
+				if (ctx->server.net_ctxs[i]) {
 					close = false;
 					break;
 				}


### PR DESCRIPTION
If a TCP disconnection occurs, the server is not notified (assuming a disconnection callback was registered).
This is because the check to not call the callback in net_app.c is wrong.