### PR TITLE
doc: tweak table CSS for caption location

### DIFF
--- a/doc/static/zephyr-custom.css
+++ b/doc/static/zephyr-custom.css
@@ -91,6 +91,10 @@ table.align-center {
    display: table !important;
 }
 
+/* put the table caption at the bottom, as done for figures */
+table {
+   caption-side: bottom;
+}
 
 .code-block-caption {
     color: #000;


### PR DESCRIPTION
Table captions and figure captions, by default, appear in different
locations.  Move table captions below the table to match figures.

Signed-off-by: David B. Kinder <david.b.kinder@intel.com>