### PR TITLE
net: eth: Vendor specific statistics

### DIFF
--- a/include/net/net_stats.h
+++ b/include/net/net_stats.h
@@ -341,6 +341,13 @@ struct net_stats_eth_hw_timestamp {
 	net_stats_t tx_hwtstamp_skipped;
 };
 
+#ifdef CONFIG_NET_STATISTICS_ETHERNET_VENDOR
+struct net_stats_eth_vendor {
+	const char * const key;
+	u32_t value;
+};
+#endif
+
 /* Ethernet specific statistics */
 struct net_stats_eth {
 	struct net_stats_bytes bytes;
@@ -356,6 +363,10 @@ struct net_stats_eth {
 	net_stats_t tx_dropped;
 	net_stats_t tx_timeout_count;
 	net_stats_t tx_restart_queue;
+#ifdef CONFIG_NET_STATISTICS_ETHERNET_VENDOR
+	/** Array is terminated with an entry containing a NULL key */
+	struct net_stats_eth_vendor *vendor;
+#endif
 };
 
 #if defined(CONFIG_NET_STATISTICS_USER_API)

--- a/subsys/net/ip/Kconfig.stats
+++ b/subsys/net/ip/Kconfig.stats
@@ -99,4 +99,13 @@ config NET_STATISTICS_ETHERNET
 	  requires support from the ethernet driver. The driver needs
 	  to collect the statistics.
 
+config NET_STATISTICS_ETHERNET_VENDOR
+	bool "Vendor specific Ethernet statistics"
+	depends on NET_STATISTICS_ETHERNET
+	help
+	  Allows Ethernet drivers to provide statistics information
+	  from vendor specific hardware registers in a form of
+	  key-value pairs. Deciphering the information may require
+	  vendor documentation.
+
 endif # NET_STATISTICS

--- a/subsys/net/ip/net_shell.c
+++ b/subsys/net/ip/net_shell.c
@@ -618,6 +618,20 @@ static void print_eth_stats(struct net_if *iface, struct net_stats_eth *data)
 	printk("Bcast sent       : %u\n", data->broadcast.tx);
 	printk("Mcast received   : %u\n", data->multicast.rx);
 	printk("Mcast sent       : %u\n", data->multicast.tx);
+
+#if defined(CONFIG_NET_STATISTICS_ETHERNET_VENDOR)
+	if (data->vendor) {
+		printk("Vendor specific statistics for Ethernet interface %p [%d]:\n",
+			iface, net_if_get_by_iface(iface));
+		size_t i = 0;
+
+		do {
+			printk("%s : %u\n", data->vendor[i].key,
+				data->vendor[i].value);
+			i++;
+		} while (data->vendor[i].key);
+	}
+#endif /* CONFIG_NET_STATISTICS_ETHERNET_VENDOR */
 }
 #endif /* CONFIG_NET_STATISTICS_ETHERNET && CONFIG_NET_STATISTICS_USER_API */
 


### PR DESCRIPTION
Allows ethernet drivers to provide vendor specific statistics
and details in the form of key-value pairs with the name of
the staticstic and its value.

The new string tables will be behind a new config:
	NET_STATISTICS_ETHERNET_VENDOR

Suggested-by: Jukka Rissanen <jukka.rissanen@intel.com>
Signed-off-by: Jonathan Yong <jonathan.yong@intel.com>