### PR TITLE
POSIX arch: Do not disable warnings

### DIFF
--- a/arch/posix/CMakeLists.txt
+++ b/arch/posix/CMakeLists.txt
@@ -2,8 +2,6 @@ zephyr_cc_option_ifdef(CONFIG_LTO -flto)
 
 zephyr_compile_options(
   -fno-freestanding
-  -Wno-undef
-  -Wno-implicit-function-declaration
   -m32
   -MMD
   -MP

--- a/arch/posix/CMakeLists.txt
+++ b/arch/posix/CMakeLists.txt
@@ -25,7 +25,7 @@ if (CONFIG_ASAN)
 	zephyr_ld_options(-fsanitize=address)
 endif ()
 
-zephyr_compile_definitions(_POSIX_C_SOURCE=200809)
+zephyr_compile_definitions(_POSIX_C_SOURCE=200809 _XOPEN_SOURCE _XOPEN_SOURCE_EXTENDED)
 
 zephyr_ld_options(
   -ldl

--- a/arch/posix/core/swap.c
+++ b/arch/posix/core/swap.c
@@ -17,6 +17,7 @@
 #include <kernel_structs.h>
 #include "posix_core.h"
 #include "irq.h"
+#include "kswap.h"
 
 /**
  *

--- a/arch/posix/include/posix_soc_if.h
+++ b/arch/posix/include/posix_soc_if.h
@@ -14,13 +14,11 @@
  * or all its boards
  */
 
+#include "posix_trace.h"
+
 #ifdef __cplusplus
 extern "C" {
 #endif
-
-void posix_print_error_and_exit(const char *format, ...);
-void posix_print_warning(const char *format, ...);
-void posix_print_trace(const char *format, ...);
 
 void posix_halt_cpu(void);
 void posix_atomic_halt_cpu(unsigned int imask);

--- a/arch/posix/include/posix_trace.h
+++ b/arch/posix/include/posix_trace.h
@@ -1,0 +1,21 @@
+/*
+ * Copyright (c) 2018 Oticon A/S
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+#ifndef _POSIX_TRACE_H
+#define _POSIX_TRACE_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+void posix_print_error_and_exit(const char *format, ...);
+void posix_print_warning(const char *format, ...);
+void posix_print_trace(const char *format, ...);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/boards/posix/native_posix/cmdline.c
+++ b/boards/posix/native_posix/cmdline.c
@@ -13,6 +13,7 @@
 #include "timer_model.h"
 #include "cmdline.h"
 #include "toolchain.h"
+#include "posix_trace.h"
 
 static int s_argc, test_argc;
 static char **s_argv, **test_argv;

--- a/boards/posix/native_posix/cmdline_common.c
+++ b/boards/posix/native_posix/cmdline_common.c
@@ -10,7 +10,8 @@
 #include <stdlib.h>
 #include <stdio.h>
 #include <math.h>
-#include "posix_soc_if.h"
+#include "posix_trace.h"
+#include "posix_board_if.h"
 #include "zephyr/types.h"
 #include "cmdline_common.h"
 

--- a/boards/posix/native_posix/cmdline_common.h
+++ b/boards/posix/native_posix/cmdline_common.h
@@ -74,6 +74,9 @@ int cmd_is_option(const char *arg, const char *option, int with_value);
 int cmd_is_help_option(const char *arg);
 void cmd_read_option_value(const char *str, void *dest, const char type,
 			   const char *option);
+void cmd_args_set_defaults(struct args_struct_t args_struct[]);
+bool cmd_parse_one_arg(char *argv, struct args_struct_t args_struct[]);
+void cmd_print_switches_help(struct args_struct_t args_struct[]);
 
 #ifdef __cplusplus
 }

--- a/boards/posix/native_posix/native_rtc.c
+++ b/boards/posix/native_posix/native_rtc.c
@@ -11,6 +11,7 @@
 #include "native_rtc.h"
 #include "hw_models_top.h"
 #include "timer_model.h"
+#include "posix_trace.h"
 
 /**
  * Return the (simulation) time in microseconds

--- a/boards/posix/native_posix/timer_model.c
+++ b/boards/posix/native_posix/timer_model.c
@@ -26,7 +26,7 @@
 #include "irq_ctrl.h"
 #include "board_soc.h"
 #include "zephyr/types.h"
-#include "posix_soc_if.h"
+#include "posix_trace.h"
 #include "misc/util.h"
 #include "cmdline.h"
 #include "soc.h"

--- a/drivers/bluetooth/hci/userchan.c
+++ b/drivers/bluetooth/hci/userchan.c
@@ -15,10 +15,12 @@
 
 #include <errno.h>
 #include <stddef.h>
+#include <stdlib.h>
 #include <poll.h>
 #include <errno.h>
 #include <sys/socket.h>
 #include <string.h>
+#include <unistd.h>
 
 #include "soc.h"
 #include "cmdline.h" /* native_posix command line options header */

--- a/drivers/console/native_posix_console.c
+++ b/drivers/console/native_posix_console.c
@@ -9,6 +9,7 @@
 #include "init.h"
 #include "kernel.h"
 #include "console/console.h"
+#include "posix_board_if.h"
 #include <string.h>
 #include <sys/time.h>
 #include <sys/select.h>

--- a/drivers/entropy/fake_entropy_native_posix.c
+++ b/drivers/entropy/fake_entropy_native_posix.c
@@ -17,7 +17,7 @@
 #include "misc/util.h"
 #include <stdlib.h>
 #include <string.h>
-#include "posix_soc_if.h"
+#include "posix_trace.h"
 #include "soc.h"
 #include "cmdline.h" /* native_posix command line options header */
 

--- a/drivers/ethernet/eth_native_posix_adapt.c
+++ b/drivers/ethernet/eth_native_posix_adapt.c
@@ -12,7 +12,6 @@
  */
 
 #define _DEFAULT_SOURCE
-#define _XOPEN_SOURCE
 
 /* Host include files */
 #include <stdio.h>

--- a/drivers/ethernet/eth_native_posix_adapt.c
+++ b/drivers/ethernet/eth_native_posix_adapt.c
@@ -20,11 +20,13 @@
 #include <errno.h>
 #include <string.h>
 #include <stdbool.h>
+#include <unistd.h>
 #include <fcntl.h>
 #include <sys/ioctl.h>
 #include <sys/socket.h>
 #include <net/if.h>
 #include <time.h>
+#include "posix_trace.h"
 
 #ifdef __linux
 #include <linux/if_tun.h>
@@ -95,8 +97,7 @@ static int ssystem(const char *fmt, ...)
 	vsnprintf(cmd, sizeof(cmd), fmt, ap);
 	va_end(ap);
 
-	printk("%s\n", cmd);
-	fflush(stdout);
+	posix_print_trace("%s\n", cmd);
 
 	ret = system(cmd);
 

--- a/drivers/timer/native_posix_timer.c
+++ b/drivers/timer/native_posix_timer.c
@@ -18,7 +18,7 @@
 #include "sys_clock.h"
 #include "timer_model.h"
 #include "soc.h"
-#include "posix_soc_if.h"
+#include "posix_trace.h"
 
 static u64_t tick_period; /* System tick period in number of hw cycles */
 static s64_t silent_ticks;

--- a/subsys/shell/shell.c
+++ b/subsys/shell/shell.c
@@ -22,6 +22,10 @@
 
 #include <shell/shell.h>
 
+#if defined(CONFIG_NATIVE_POSIX_CONSOLE)
+#include "drivers/console/native_posix_console.h"
+#endif
+
 #define ARGC_MAX 10
 #define COMMAND_MAX_LEN 50
 #define MODULE_NAME_MAX_LEN 20

--- a/tests/boards/native_posix/native_tasks/src/main.c
+++ b/tests/boards/native_posix/native_tasks/src/main.c
@@ -6,6 +6,7 @@
 
 #include "soc.h"
 #include "kernel.h"
+#include "posix_board_if.h"
 
 /**
  * @brief Test NATIVE_TASK hook for native builds


### PR DESCRIPTION
Initially, missing function prototypes warnings and undefined macro warnings  were disabled to quickly prototype the posix arch and native_posix board.
But there is no excuse anymore to have these warnings disabled.
We enable them.

All the warnings due to this are fixed around in the code.