### PR TITLE
net: tc: Priority to Traffic Class mapping improvements

### DIFF
--- a/include/net/net_ip.h
+++ b/include/net/net_ip.h
@@ -196,8 +196,8 @@ extern const struct in6_addr in6addr_loopback;
 
 /** Network packet priority settings described in IEEE 802.1Q Annex I.1 */
 enum net_priority {
-	NET_PRIORITY_BK = 0, /* Background (lowest)                */
-	NET_PRIORITY_BE = 1, /* Best effort (default)              */
+	NET_PRIORITY_BK = 1, /* Background (lowest)                */
+	NET_PRIORITY_BE = 0, /* Best effort (default)              */
 	NET_PRIORITY_EE = 2, /* Excellent effort                   */
 	NET_PRIORITY_CA = 3, /* Critical applications (highest)    */
 	NET_PRIORITY_VI = 4, /* Video, < 100 ms latency and jitter */

--- a/subsys/net/ip/Kconfig
+++ b/subsys/net/ip/Kconfig
@@ -70,6 +70,39 @@ config NET_TC_RX_COUNT
 	  handled equally. In this implementation, the higher traffic class
 	  value corresponds to lower thread priority.
 
+choice
+	prompt "Priority to traffic class mapping"
+	help
+	  Select mapping to use to map network packet priorities to traffic
+	  classes.
+
+config NET_TC_MAPPING_STRICT
+	bool "Strict priority mapping"
+	help
+	  This is the recommended default priority to traffic class mapping.
+	  Use it for implementations that do not support the credit-based
+	  sharper transmission selection algorithm.
+	  See 802.1Q, chapter 8.6.6 for more information.
+
+config NET_TC_MAPPING_SR_CLASS_A_AND_B
+	bool "SR class A and class B mapping"
+	depends on NET_TC_TX_COUNT >= 2
+	depends on NET_TC_RX_COUNT >= 2
+	help
+	  This is the recommended priority to traffic class mapping for a
+	  system that supports SR (Stream Reservation) class A and SR class B.
+	  See 802.1Q, chapter 34.5 for more information.
+
+config NET_TC_MAPPING_SR_CLASS_B_ONLY
+	bool "SR class B only mapping"
+	depends on NET_TC_TX_COUNT >= 2
+	depends on NET_TC_RX_COUNT >= 2
+	help
+	  This is the recommended priority to traffic class mapping for a
+	  system that supports SR (Stream Reservation) class B only.
+	  See 802.1Q, chapter 34.5 for more information.
+endchoice
+
 config NET_TX_DEFAULT_PRIORITY
 	int "Default network packet priority if none have been set"
 	default 1

--- a/subsys/net/ip/net_tc.c
+++ b/subsys/net/ip/net_tc.c
@@ -52,8 +52,8 @@ int net_tx_priority2tc(enum net_priority prio)
 	 * chapter 34.5 table 34-1
 	 *
 	 *  Priority         Acronym   Traffic types
-	 *  0 (lowest)       BK        Background
-	 *  1 (default)      BE        Best effort
+	 *  1 (lowest)       BK        Background
+	 *  0 (default)      BE        Best effort
 	 *  2                EE        Excellent effort
 	 *  3                CA        Critical applications
 	 *  4                VI        Video, < 100 ms latency and jitter
@@ -79,13 +79,13 @@ int net_tx_priority2tc(enum net_priority prio)
 		0, 0, 1, 1, 2, 2, 3, 4
 #endif
 #if NET_TC_TX_COUNT == 6
-		0, 1, 2, 2, 3, 3, 4, 5
+		1, 0, 2, 2, 3, 3, 4, 5
 #endif
 #if NET_TC_TX_COUNT == 7
-		0, 1, 2, 3, 4, 4, 5, 6
+		1, 0, 2, 3, 4, 4, 5, 6
 #endif
 #if NET_TC_TX_COUNT == 8
-		0, 1, 2, 3, 4, 5, 6, 7
+		1, 0, 2, 3, 4, 5, 6, 7
 #endif
 	};
 
@@ -105,8 +105,8 @@ int net_rx_priority2tc(enum net_priority prio)
 	 * chapter 34.5 table 34-1
 	 *
 	 *  Priority         Acronym   Traffic types
-	 *  0 (lowest)       BK        Background
-	 *  1 (default)      BE        Best effort
+	 *  1 (lowest)       BK        Background
+	 *  0 (default)      BE        Best effort
 	 *  2                EE        Excellent effort
 	 *  3                CA        Critical applications
 	 *  4                VI        Video, < 100 ms latency and jitter
@@ -132,13 +132,13 @@ int net_rx_priority2tc(enum net_priority prio)
 		0, 0, 1, 1, 2, 2, 3, 4
 #endif
 #if NET_TC_RX_COUNT == 6
-		0, 1, 2, 2, 3, 3, 4, 5
+		1, 0, 2, 2, 3, 3, 4, 5
 #endif
 #if NET_TC_RX_COUNT == 7
-		0, 1, 2, 3, 4, 4, 5, 6
+		1, 0, 2, 3, 4, 4, 5, 6
 #endif
 #if NET_TC_RX_COUNT == 8
-		0, 1, 2, 3, 4, 5, 6, 7
+		1, 0, 2, 3, 4, 5, 6, 7
 #endif
 	};
 

--- a/subsys/net/ip/net_tc.c
+++ b/subsys/net/ip/net_tc.c
@@ -18,6 +18,7 @@
 
 #include "net_private.h"
 #include "net_stats.h"
+#include "net_tc_mapping.h"
 
 /* Stacks for TX work queue */
 NET_STACK_ARRAY_DEFINE(TX, tx_stack,
@@ -46,108 +47,22 @@ void net_tc_submit_to_rx_queue(u8_t tc, struct net_pkt *pkt)
 
 int net_tx_priority2tc(enum net_priority prio)
 {
-	/*
-	 * Use the example priority -> traffic class mapper found in
-	 * IEEE 802.1Q chapter I.3, chapter 8.6.6 table 8.4 and
-	 * chapter 34.5 table 34-1
-	 *
-	 *  Priority         Acronym   Traffic types
-	 *  1 (lowest)       BK        Background
-	 *  0 (default)      BE        Best effort
-	 *  2                EE        Excellent effort
-	 *  3                CA        Critical applications
-	 *  4                VI        Video, < 100 ms latency and jitter
-	 *  5                VO        Voice, < 10 ms latency and jitter
-	 *  6                IC        Internetwork control
-	 *  7 (highest)      NC        Network control
-	 */
-	/* Priority is the index to this array */
-	static const u8_t tc[] = {
-#if NET_TC_TX_COUNT == 1
-		0, 0, 0, 0, 0, 0, 0, 0
-#endif
-#if NET_TC_TX_COUNT == 2
-		0, 0, 0, 0, 1, 1, 1, 1
-#endif
-#if NET_TC_TX_COUNT == 3
-		0, 0, 0, 0, 1, 1, 2, 2
-#endif
-#if NET_TC_TX_COUNT == 4
-		0, 0, 1, 1, 2, 2, 3, 3
-#endif
-#if NET_TC_TX_COUNT == 5
-		0, 0, 1, 1, 2, 2, 3, 4
-#endif
-#if NET_TC_TX_COUNT == 6
-		1, 0, 2, 2, 3, 3, 4, 5
-#endif
-#if NET_TC_TX_COUNT == 7
-		1, 0, 2, 3, 4, 4, 5, 6
-#endif
-#if NET_TC_TX_COUNT == 8
-		1, 0, 2, 3, 4, 5, 6, 7
-#endif
-	};
-
-	if (prio >= ARRAY_SIZE(tc)) {
+	if (prio > NET_PRIORITY_NC) {
 		/* Use default value suggested in 802.1Q */
 		prio = NET_PRIORITY_BE;
 	}
 
-	return tc[prio];
+	return tx_prio2tc_map[prio];
 }
 
 int net_rx_priority2tc(enum net_priority prio)
 {
-	/*
-	 * Use the example priority -> traffic class mapper found in
-	 * IEEE 802.1Q chapter I.3, chapter 8.6.6 table 8.4 and
-	 * chapter 34.5 table 34-1
-	 *
-	 *  Priority         Acronym   Traffic types
-	 *  1 (lowest)       BK        Background
-	 *  0 (default)      BE        Best effort
-	 *  2                EE        Excellent effort
-	 *  3                CA        Critical applications
-	 *  4                VI        Video, < 100 ms latency and jitter
-	 *  5                VO        Voice, < 10 ms latency and jitter
-	 *  6                IC        Internetwork control
-	 *  7 (highest)      NC        Network control
-	 */
-	/* Priority is the index to this array */
-	static const u8_t tc[] = {
-#if NET_TC_RX_COUNT == 1
-		0, 0, 0, 0, 0, 0, 0, 0
-#endif
-#if NET_TC_RX_COUNT == 2
-		0, 0, 0, 0, 1, 1, 1, 1
-#endif
-#if NET_TC_RX_COUNT == 3
-		0, 0, 0, 0, 1, 1, 2, 2
-#endif
-#if NET_TC_RX_COUNT == 4
-		0, 0, 1, 1, 2, 2, 3, 3
-#endif
-#if NET_TC_RX_COUNT == 5
-		0, 0, 1, 1, 2, 2, 3, 4
-#endif
-#if NET_TC_RX_COUNT == 6
-		1, 0, 2, 2, 3, 3, 4, 5
-#endif
-#if NET_TC_RX_COUNT == 7
-		1, 0, 2, 3, 4, 4, 5, 6
-#endif
-#if NET_TC_RX_COUNT == 8
-		1, 0, 2, 3, 4, 5, 6, 7
-#endif
-	};
-
-	if (prio >= ARRAY_SIZE(tc)) {
+	if (prio > NET_PRIORITY_NC) {
 		/* Use default value suggested in 802.1Q */
 		prio = NET_PRIORITY_BE;
 	}
 
-	return tc[prio];
+	return rx_prio2tc_map[prio];
 }
 
 /* Convert traffic class to thread priority */

--- a/subsys/net/ip/net_tc_mapping.h
+++ b/subsys/net/ip/net_tc_mapping.h
@@ -1,0 +1,138 @@
+/** @file
+ * @brief Various priority to traffic class mappings
+ *
+ * This is not to be included by the application.
+ */
+
+/*
+ * Copyright (c) 2018 Intel Corporation.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef __TC_MAPPING_H
+#define __TC_MAPPING_H
+
+#include <zephyr/types.h>
+
+/* All the maps below use priorities and indexes, below is the list of them
+ * according to 802.1Q - table I-2.
+ *
+ *  Priority         Acronym   Traffic types
+ *  1 (lowest)       BK        Background
+ *  0 (default)      BE        Best effort
+ *  2                EE        Excellent effort
+ *  3                CA        Critical applications
+ *  4                VI        Video, < 100 ms latency and jitter
+ *  5                VO        Voice, < 10 ms latency and jitter
+ *  6                IC        Internetwork control
+ *  7 (highest)      NC        Network control
+ */
+
+/* Helper macros used to generate the map to use */
+#define PRIORITY2TC_GEN_INNER(TYPE, COUNT) priority2tc_ ## TYPE ## _ ## COUNT
+#define PRIORITY2TC_GEN(TYPE, COUNT) PRIORITY2TC_GEN_INNER(TYPE, COUNT)
+
+#if defined(CONFIG_NET_TC_MAPPING_STRICT)
+
+/* This is the recommended priority to traffic class mapping for
+ * implementations that do not support the credit-based sharper transmission
+ * selection algorithm.
+ * Ref: 802.1Q - chapter 8.6.6 - table 8-4
+ */
+
+#if NET_TC_TX_COUNT == 1 || NET_TC_RX_COUNT == 1
+static const u8_t priority2tc_strict_1[] = {0, 0, 0, 0, 0, 0, 0, 0};
+#endif
+#if NET_TC_TX_COUNT == 2 || NET_TC_RX_COUNT == 2
+static const u8_t priority2tc_strict_2[] = {0, 0, 0, 0, 1, 1, 1, 1};
+#endif
+#if NET_TC_TX_COUNT == 3 || NET_TC_RX_COUNT == 3
+static const u8_t priority2tc_strict_3[] = {0, 0, 0, 0, 1, 1, 2, 2};
+#endif
+#if NET_TC_TX_COUNT == 4 || NET_TC_RX_COUNT == 4
+static const u8_t priority2tc_strict_4[] = {0, 0, 1, 1, 2, 2, 3, 3};
+#endif
+#if NET_TC_TX_COUNT == 5 || NET_TC_RX_COUNT == 5
+static const u8_t priority2tc_strict_5[] = {0, 0, 1, 1, 2, 2, 3, 4};
+#endif
+#if NET_TC_TX_COUNT == 6 || NET_TC_RX_COUNT == 6
+static const u8_t priority2tc_strict_6[] = {1, 0, 2, 2, 3, 3, 4, 5};
+#endif
+#if NET_TC_TX_COUNT == 7 || NET_TC_RX_COUNT == 7
+static const u8_t priority2tc_strict_7[] = {1, 0, 2, 3, 4, 4, 5, 6};
+#endif
+#if NET_TC_TX_COUNT == 8 || NET_TC_RX_COUNT == 8
+static const u8_t priority2tc_strict_8[] = {1, 0, 2, 3, 4, 5, 6, 7};
+#endif
+
+static const u8_t *tx_prio2tc_map = PRIORITY2TC_GEN(strict, NET_TC_TX_COUNT);
+static const u8_t *rx_prio2tc_map = PRIORITY2TC_GEN(strict, NET_TC_RX_COUNT);
+
+#elif defined(CONFIG_NET_TC_MAPPING_SR_CLASS_A_AND_B)
+
+/* This is the recommended priority to traffic class mapping for a system that
+ * supports SR (Stream Reservation) class A and SR class B.
+ * Ref: 802.1Q - chapter 34.5 - table 34-1
+ */
+
+#if NET_TC_TX_COUNT == 2 || NET_TC_RX_COUNT == 2
+static const u8_t priority2tc_sr_ab_2[] = {0, 0, 1, 1, 0, 0, 0, 0};
+#endif
+#if NET_TC_TX_COUNT == 3 || NET_TC_RX_COUNT == 3
+static const u8_t priority2tc_sr_ab_3[] = {0, 0, 1, 2, 0, 0, 0, 0};
+#endif
+#if NET_TC_TX_COUNT == 4 || NET_TC_RX_COUNT == 4
+static const u8_t priority2tc_sr_ab_4[] = {0, 0, 2, 3, 1, 1, 1, 1};
+#endif
+#if NET_TC_TX_COUNT == 5 || NET_TC_RX_COUNT == 5
+static const u8_t priority2tc_sr_ab_5[] = {0, 0, 3, 4, 1, 1, 2, 2};
+#endif
+#if NET_TC_TX_COUNT == 6 || NET_TC_RX_COUNT == 6
+static const u8_t priority2tc_sr_ab_6[] = {0, 0, 4, 5, 1, 1, 2, 3};
+#endif
+#if NET_TC_TX_COUNT == 7 || NET_TC_RX_COUNT == 7
+static const u8_t priority2tc_sr_ab_7[] = {0, 0, 5, 6, 1, 2, 3, 4};
+#endif
+#if NET_TC_TX_COUNT == 8 || NET_TC_RX_COUNT == 8
+static const u8_t priority2tc_sr_ab_8[] = {1, 0, 6, 7, 2, 3, 4, 5};
+#endif
+
+static const u8_t *tx_prio2tc_map = PRIORITY2TC_GEN(sr_ab, NET_TC_TX_COUNT);
+static const u8_t *rx_prio2tc_map = PRIORITY2TC_GEN(sr_ab, NET_TC_RX_COUNT);
+
+#elif defined(CONFIG_NET_TC_MAPPING_SR_CLASS_B_ONLY)
+
+/* This is the recommended priority to traffic class mapping for a system that
+ * supports SR (Stream Reservation) class B only.
+ * Ref: 802.1Q - chapter 34.5 - table 34-2
+ */
+
+#if NET_TC_TX_COUNT == 2 || NET_TC_RX_COUNT == 2
+static const u8_t priority2tc_sr_b_2[] = {0, 0, 1, 0, 0, 0, 0, 0};
+#endif
+#if NET_TC_TX_COUNT == 3 || NET_TC_RX_COUNT == 3
+static const u8_t priority2tc_sr_b_3[] = {0, 0, 2, 0, 1, 1, 1, 1};
+#endif
+#if NET_TC_TX_COUNT == 4 || NET_TC_RX_COUNT == 4
+static const u8_t priority2tc_sr_b_4[] = {0, 0, 3, 0, 1, 1, 2, 2};
+#endif
+#if NET_TC_TX_COUNT == 5 || NET_TC_RX_COUNT == 5
+static const u8_t priority2tc_sr_b_5[] = {0, 0, 4, 1, 2, 2, 3, 3};
+#endif
+#if NET_TC_TX_COUNT == 6 || NET_TC_RX_COUNT == 6
+static const u8_t priority2tc_sr_b_6[] = {0, 0, 5, 1, 2, 2, 3, 4};
+#endif
+#if NET_TC_TX_COUNT == 7 || NET_TC_RX_COUNT == 7
+static const u8_t priority2tc_sr_b_7[] = {1, 0, 6, 2, 3, 3, 4, 5};
+#endif
+#if NET_TC_TX_COUNT == 8 || NET_TC_RX_COUNT == 8
+static const u8_t priority2tc_sr_b_8[] = {1, 0, 7, 2, 3, 4, 5, 6};
+#endif
+
+static const u8_t *tx_prio2tc_map = PRIORITY2TC_GEN(sr_b, NET_TC_TX_COUNT);
+static const u8_t *rx_prio2tc_map = PRIORITY2TC_GEN(sr_b, NET_TC_RX_COUNT);
+
+#endif
+
+#endif /* __TC_MAPPING_H */

--- a/tests/net/traffic_class/testcase.yaml
+++ b/tests/net/traffic_class/testcase.yaml
@@ -121,3 +121,143 @@ tests:
     extra_configs:
       - CONFIG_NET_TC_RX_COUNT=7
       - CONFIG_NET_TC_TX_COUNT=8
+  net.traffic_class.2_sr_ab:
+    extra_configs:
+      - CONFIG_NET_TC_MAPPING_SR_CLASS_A_AND_B=y
+      - CONFIG_NET_TC_TX_COUNT=2
+      - CONFIG_NET_TC_RX_COUNT=2
+  net.traffic_class.3_sr_ab:
+    extra_configs:
+      - CONFIG_NET_TC_MAPPING_SR_CLASS_A_AND_B=y
+      - CONFIG_NET_TC_TX_COUNT=3
+      - CONFIG_NET_TC_RX_COUNT=3
+  net.traffic_class.4_sr_ab:
+    extra_configs:
+      - CONFIG_NET_TC_MAPPING_SR_CLASS_A_AND_B=y
+      - CONFIG_NET_TC_TX_COUNT=4
+      - CONFIG_NET_TC_RX_COUNT=4
+  net.traffic_class.5_sr_ab:
+    extra_configs:
+      - CONFIG_NET_TC_MAPPING_SR_CLASS_A_AND_B=y
+      - CONFIG_NET_TC_TX_COUNT=5
+      - CONFIG_NET_TC_RX_COUNT=5
+  net.traffic_class.6_sr_ab:
+    extra_configs:
+      - CONFIG_NET_TC_MAPPING_SR_CLASS_A_AND_B=y
+      - CONFIG_NET_TC_TX_COUNT=6
+      - CONFIG_NET_TC_RX_COUNT=6
+  net.traffic_class.7_sr_ab:
+    extra_configs:
+      - CONFIG_NET_TC_MAPPING_SR_CLASS_A_AND_B=y
+      - CONFIG_NET_TC_TX_COUNT=7
+      - CONFIG_NET_TC_RX_COUNT=7
+  net.traffic_class.8_sr_ab:
+    extra_configs:
+      - CONFIG_NET_TC_MAPPING_SR_CLASS_A_AND_B=y
+      - CONFIG_NET_TC_TX_COUNT=8
+      - CONFIG_NET_TC_RX_COUNT=8
+  net.traffic_class.tx_2_rx_3_sr_ab:
+    extra_configs:
+      - CONFIG_NET_TC_MAPPING_SR_CLASS_A_AND_B=y
+      - CONFIG_NET_TC_RX_COUNT=3
+      - CONFIG_NET_TC_TX_COUNT=2
+  net.traffic_class.tx_3_rx_8_sr_ab:
+    extra_configs:
+      - CONFIG_NET_TC_MAPPING_SR_CLASS_A_AND_B=y
+      - CONFIG_NET_TC_RX_COUNT=8
+      - CONFIG_NET_TC_TX_COUNT=3
+  net.traffic_class.rx_4_tx_8_sr_ab:
+    extra_configs:
+      - CONFIG_NET_TC_MAPPING_SR_CLASS_A_AND_B=y
+      - CONFIG_NET_TC_RX_COUNT=4
+      - CONFIG_NET_TC_TX_COUNT=8
+  net.traffic_class.rx_5_tx_7_sr_ab:
+    extra_configs:
+      - CONFIG_NET_TC_MAPPING_SR_CLASS_A_AND_B=y
+      - CONFIG_NET_TC_RX_COUNT=5
+      - CONFIG_NET_TC_TX_COUNT=7
+  net.traffic_class.tx_6_rx_2_sr_ab:
+    extra_configs:
+      - CONFIG_NET_TC_MAPPING_SR_CLASS_A_AND_B=y
+      - CONFIG_NET_TC_RX_COUNT=2
+      - CONFIG_NET_TC_TX_COUNT=6
+  net.traffic_class.tx_7_rx_5_sr_ab:
+    extra_configs:
+      - CONFIG_NET_TC_MAPPING_SR_CLASS_A_AND_B=y
+      - CONFIG_NET_TC_RX_COUNT=5
+      - CONFIG_NET_TC_TX_COUNT=7
+  net.traffic_class.tx_8_rx_7_sr_ab:
+    extra_configs:
+      - CONFIG_NET_TC_MAPPING_SR_CLASS_A_AND_B=y
+      - CONFIG_NET_TC_RX_COUNT=7
+      - CONFIG_NET_TC_TX_COUNT=8
+  net.traffic_class.2_sr_b:
+    extra_configs:
+      - CONFIG_NET_TC_MAPPING_SR_CLASS_B_ONLY=y
+      - CONFIG_NET_TC_TX_COUNT=2
+      - CONFIG_NET_TC_RX_COUNT=2
+  net.traffic_class.3_sr_b:
+    extra_configs:
+      - CONFIG_NET_TC_MAPPING_SR_CLASS_B_ONLY=y
+      - CONFIG_NET_TC_TX_COUNT=3
+      - CONFIG_NET_TC_RX_COUNT=3
+  net.traffic_class.4_sr_b:
+    extra_configs:
+      - CONFIG_NET_TC_MAPPING_SR_CLASS_B_ONLY=y
+      - CONFIG_NET_TC_TX_COUNT=4
+      - CONFIG_NET_TC_RX_COUNT=4
+  net.traffic_class.5_sr_b:
+    extra_configs:
+      - CONFIG_NET_TC_MAPPING_SR_CLASS_B_ONLY=y
+      - CONFIG_NET_TC_TX_COUNT=5
+      - CONFIG_NET_TC_RX_COUNT=5
+  net.traffic_class.6_sr_b:
+    extra_configs:
+      - CONFIG_NET_TC_MAPPING_SR_CLASS_B_ONLY=y
+      - CONFIG_NET_TC_TX_COUNT=6
+      - CONFIG_NET_TC_RX_COUNT=6
+  net.traffic_class.7_sr_b:
+    extra_configs:
+      - CONFIG_NET_TC_MAPPING_SR_CLASS_B_ONLY=y
+      - CONFIG_NET_TC_TX_COUNT=7
+      - CONFIG_NET_TC_RX_COUNT=7
+  net.traffic_class.8_sr_b:
+    extra_configs:
+      - CONFIG_NET_TC_MAPPING_SR_CLASS_B_ONLY=y
+      - CONFIG_NET_TC_TX_COUNT=8
+      - CONFIG_NET_TC_RX_COUNT=8
+  net.traffic_class.tx_2_rx_3_sr_b:
+    extra_configs:
+      - CONFIG_NET_TC_MAPPING_SR_CLASS_B_ONLY=y
+      - CONFIG_NET_TC_RX_COUNT=3
+      - CONFIG_NET_TC_TX_COUNT=2
+  net.traffic_class.tx_3_rx_8_sr_b:
+    extra_configs:
+      - CONFIG_NET_TC_MAPPING_SR_CLASS_B_ONLY=y
+      - CONFIG_NET_TC_RX_COUNT=8
+      - CONFIG_NET_TC_TX_COUNT=3
+  net.traffic_class.rx_4_tx_8_sr_b:
+    extra_configs:
+      - CONFIG_NET_TC_MAPPING_SR_CLASS_B_ONLY=y
+      - CONFIG_NET_TC_RX_COUNT=4
+      - CONFIG_NET_TC_TX_COUNT=8
+  net.traffic_class.rx_5_tx_7_sr_b:
+    extra_configs:
+      - CONFIG_NET_TC_MAPPING_SR_CLASS_B_ONLY=y
+      - CONFIG_NET_TC_RX_COUNT=5
+      - CONFIG_NET_TC_TX_COUNT=7
+  net.traffic_class.tx_6_rx_2_sr_b:
+    extra_configs:
+      - CONFIG_NET_TC_MAPPING_SR_CLASS_B_ONLY=y
+      - CONFIG_NET_TC_RX_COUNT=2
+      - CONFIG_NET_TC_TX_COUNT=6
+  net.traffic_class.tx_7_rx_5_sr_b:
+    extra_configs:
+      - CONFIG_NET_TC_MAPPING_SR_CLASS_B_ONLY=y
+      - CONFIG_NET_TC_RX_COUNT=5
+      - CONFIG_NET_TC_TX_COUNT=7
+  net.traffic_class.tx_8_rx_7_sr_b:
+    extra_configs:
+      - CONFIG_NET_TC_MAPPING_SR_CLASS_B_ONLY=y
+      - CONFIG_NET_TC_RX_COUNT=7
+      - CONFIG_NET_TC_TX_COUNT=8


### PR DESCRIPTION
This commits adds new priority to traffic class mappings and allows
users to choose which mapping to use through menuconfig.

The new mappings are recommended in 802.1 (chapter 33.5) for
time-sensitive applications supporting the credit-based sharper
algorithm.

Please review, thanks!