### PR TITLE
drivers/i2c: kconfig: Clean up I2C Kconfigs a bit

### DIFF
--- a/drivers/i2c/Kconfig.esp32
+++ b/drivers/i2c/Kconfig.esp32
@@ -8,7 +8,7 @@
 
 menuconfig I2C_ESP32
 	bool "ESP32 I2C"
-	depends on I2C && SOC_ESP32
+	depends on SOC_ESP32
 	select GPIO_ESP32
 	help
 	  Enables the ESP32 I2C driver

--- a/drivers/i2c/Kconfig.gpio
+++ b/drivers/i2c/Kconfig.gpio
@@ -6,7 +6,6 @@
 
 config I2C_GPIO
 	bool "GPIO bit banging I2C support"
-	depends on I2C
 	select I2C_BITBANG
 	help
 	  Enable software driven (bit banging) I2C support using GPIO pins
@@ -20,31 +19,31 @@ config I2C_GPIO_0
 	  This tells the driver to configure the I2C device at boot, depending
 	  on the additional configuration options below.
 
+if I2C_GPIO_0
+
 config I2C_GPIO_0_NAME
 	string "GPIO Bit Bang I2C device 0 device name"
 	default "I2C_0"
-	depends on I2C_GPIO_0
 	help
 	  This is the device name for the I2C device, and is included in the
 	  device struct.
 
 config I2C_GPIO_0_GPIO
 	string "Bit Bang I2C device 0 GPIO name"
-	depends on I2C_GPIO_0
 	help
 	  This is the name of the GPIO device that controls the I2C lines.
 
 config I2C_GPIO_0_SCL_PIN
 	int "Bit Bang I2C device 0 GPIO pin number for SCL"
-	depends on I2C_GPIO_0
 	help
 	  This is the GPIO pin number for the I2S SCL line
 
 config I2C_GPIO_0_SDA_PIN
 	int "Bit Bang I2C device 0 GPIO pin number for SDA"
-	depends on I2C_GPIO_0
 	help
 	  This is the GPIO pin number for the I2S SDA line
+
+endif # I2C_GPIO_0
 
 # ---------- Port 1 ----------
 
@@ -55,31 +54,31 @@ config I2C_GPIO_1
 	  This tells the driver to configure the I2C device at boot, depending
 	  on the additional configuration options below.
 
+if I2C_GPIO_1
+
 config I2C_GPIO_1_NAME
 	string "Bit Bang I2C device 1 device name"
 	default "I2C_1"
-	depends on I2C_GPIO_1
 	help
 	  This is the device name for the I2C device, and is included in the
 	  device struct.
 
 config I2C_GPIO_1_GPIO
 	string "Bit Bang I2C device 1 GPIO name"
-	depends on I2C_GPIO_1
 	help
 	  This is the name of the GPIO device that controls the I2C lines.
 
 config I2C_GPIO_1_SCL_PIN
 	int "Bit Bang I2C device 1 GPIO pin number for SCL"
-	depends on I2C_GPIO_1
 	help
 	  This is the GPIO pin number for the I2S SCL line
 
 config I2C_GPIO_1_SDA_PIN
 	int "Bit Bang I2C device 1 GPIO pin number for SDA"
-	depends on I2C_GPIO_1
 	help
 	  This is the GPIO pin number for the I2S SDA line
+
+endif # I2C_GPIO_1
 
 # ---------- Port 2 ----------
 
@@ -90,31 +89,31 @@ config I2C_GPIO_2
 	  This tells the driver to configure the I2C device at boot, depending
 	  on the additional configuration options below.
 
+if I2C_GPIO_2
+
 config I2C_GPIO_2_NAME
 	string "Bit Bang I2C device 2 device name"
 	default "I2C_2"
-	depends on I2C_GPIO_2
 	help
 	  This is the device name for the I2C device, and is included in the
 	  device struct.
 
 config I2C_GPIO_2_GPIO
 	string "Bit Bang I2C device 2 GPIO name"
-	depends on I2C_GPIO_2
 	help
 	  This is the name of the GPIO device that controls the I2C lines.
 
 config I2C_GPIO_2_SCL_PIN
 	int "Bit Bang I2C device 2 GPIO pin number for SCL"
-	depends on I2C_GPIO_2
 	help
 	  This is the GPIO pin number for the I2S SCL line
 
 config I2C_GPIO_2_SDA_PIN
 	int "Bit Bang I2C device 2 GPIO pin number for SDA"
-	depends on I2C_GPIO_2
 	help
 	  This is the GPIO pin number for the I2S SDA line
+
+endif # I2C_GPIO_2
 
 # ---------- Port 3 ----------
 
@@ -125,29 +124,28 @@ config I2C_GPIO_3
 	  This tells the driver to configure the I2C device at boot, depending
 	  on the additional configuration options below.
 
+if I2C_GPIO_3
+
 config I2C_GPIO_3_NAME
 	string "Bit Bang I2C device 3 device name"
 	default "I2C_3"
-	depends on I2C_GPIO_3
 	help
 	  This is the device name for the I2C device, and is included in the
 	  device struct.
 
 config I2C_GPIO_3_GPIO
 	string "Bit Bang I2C device 3 GPIO name"
-	depends on I2C_GPIO_3
 	help
 	  This is the name of the GPIO device that controls the I2C lines.
 
 config I2C_GPIO_3_SCL_PIN
 	int "Bit Bang I2C device 3 GPIO pin number for SCL"
-	depends on I2C_GPIO_3
 	help
 	  This is the GPIO pin number for the I2C SCL line
 
 config I2C_GPIO_3_SDA_PIN
 	int "Bit Bang I2C device 3 GPIO pin number for SDA"
-	depends on I2C_GPIO_3
 	help
 	  This is the GPIO pin number for the I2C SDA line
 
+endif # I2C_GPIO_3

--- a/drivers/i2c/Kconfig.sbcon
+++ b/drivers/i2c/Kconfig.sbcon
@@ -6,7 +6,7 @@
 
 menuconfig I2C_SBCON
 	bool "I2C driver for ARM's SBCon two-wire serial bus interface"
-	depends on I2C && ARM
+	depends on ARM
 	select I2C_BITBANG
 
 if I2C_SBCON

--- a/drivers/i2c/slave/Kconfig
+++ b/drivers/i2c/slave/Kconfig
@@ -11,7 +11,6 @@
 #
 menuconfig I2C_SLAVE
 	bool "I2C Slave Drivers"
-	depends on I2C
 	help
 	  Enable I2C Slave Driver Configuration
 


### PR DESCRIPTION
- Get rid of duplicate I2C dependencies, which show up in the
  documentation as e.g. 'I2C && I2C'. The 'source's in
  drivers/i2c/Kconfig are already within an 'if I2C' block.

- Factor out I2C_GPIO_<n> dependencies in drivers/i2c/Kconfig.gpio into
  'if I2C_GPIO_<n>' blocks.

Signed-off-by: Ulf Magnusson <Ulf.Magnusson@nordicsemi.no>