### PR TITLE
Jlink updates

### DIFF
--- a/boards/arm/mimxrt1050_evk/board.cmake
+++ b/boards/arm/mimxrt1050_evk/board.cmake
@@ -4,5 +4,5 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 
-board_runner_args(jlink "--device=Cortex-M7")
+board_runner_args(jlink "--device=MCIMXRT1052")
 include(${ZEPHYR_BASE}/boards/common/jlink.board.cmake)

--- a/doc/tools/opensda.rst
+++ b/doc/tools/opensda.rst
@@ -107,8 +107,15 @@ application binary. :ref:`nxp_opensda_firmware` with this application.
 Flashing
 ========
 
-The Segger J-Link firmware does not support command line flashing, therefore
-the CMake ``flash`` target is not supported.
+Use the CMake ``flash`` target with the argument ``OPENSDA_FW=jlink`` to build
+your Zephyr application, invoke the J-Link Commander, and program your Zephyr
+application to flash. Some boards set the argument by default, so it is not
+always necessary to set explicitly.
+
+  .. zephyr-app-commands::
+     :zephyr-app: samples/hello_world
+     :gen-args: -DOPENSDA_FW=jlink
+     :goals: flash
 
 Debugging
 =========


### PR DESCRIPTION
- Update the OpenSDA document for flashing with jlink. The feature was implemented quite a while ago, but the documentation update was missed.
- Update the jlink device name for the mimxrt1050_evk