### PR TITLE
arch: arc: fix a bug in mpu driver

### DIFF
--- a/arch/arc/core/mpu/arc_core_mpu.c
+++ b/arch/arc/core/mpu/arc_core_mpu.c
@@ -60,6 +60,7 @@ void configure_mpu_stack_guard(struct k_thread *thread)
 		arc_core_mpu_configure(THREAD_STACK_GUARD_REGION,
 			thread->arch.priv_stack_start - STACK_GUARD_SIZE,
 			STACK_GUARD_SIZE);
+		return;
 	}
 #endif
 	arc_core_mpu_configure(THREAD_STACK_GUARD_REGION,


### PR DESCRIPTION
for mpu stack guard, after arc_core_mpu_configure,
it should return

Signed-off-by: Wayne Ren <wei.ren@synopsys.com>