### PR TITLE
tests: userspace: Remove extra call to same testcase

### DIFF
--- a/tests/kernel/mem_protect/userspace/src/main.c
+++ b/tests/kernel/mem_protect/userspace/src/main.c
@@ -617,7 +617,6 @@ void test_main(void)
 			 ztest_unit_test(user_mode_enter),
 			 ztest_user_unit_test(write_kobject_user_pipe),
 			 ztest_user_unit_test(read_kobject_user_pipe),
-			 ztest_user_unit_test(read_kobject_user_pipe),
 			 ztest_unit_test(access_other_memdomain)
 		);
 	ztest_run_test_suite(userspace);


### PR DESCRIPTION
The test read_kobject_user_pipe() is called twice in
the test suite. There is no need of calling same test
twice. Removing the extra call.

Signed-off-by: Spoorthi K <spoorthi.k@intel.com>