### PR TITLE
cmake: kconfig: Fix broken menuconfig due to misspelling

### DIFF
--- a/cmake/kconfig.cmake
+++ b/cmake/kconfig.cmake
@@ -106,7 +106,7 @@ set(merge_config_files_checksum_file ${PROJECT_BINARY_DIR}/.cmake.dotconfig.chec
 set(CREATE_NEW_DOTCONFIG 1)
 # Check if the checksum file exists too before trying to open it, though it
 # should under normal circumstances
-if(EXISTS ${DOTCONFIG} AND EXISTS ${merge_config_file_checksum_file})
+if(EXISTS ${DOTCONFIG} AND EXISTS ${merge_config_files_checksum_file})
   # Read out what the checksum was previously
   file(READ
     ${merge_config_files_checksum_file}


### PR DESCRIPTION
Due to a misspelling in the existence check for the stored checksum
file, zephyr/.config was always regenerated from the config fragments
(e.g. prj.conf), overwriting any custom zephyr/.config configuration
done in e.g. menuconfig.

This bug was introduced by commit 5402662dd9611 ("cmake: kconfig: Fix
rerunning cmake after Kconfig warnings").

Fixes: https://github.com/zephyrproject-rtos/zephyr/issues/9270

Signed-off-by: Ulf Magnusson <Ulf.Magnusson@nordicsemi.no>