### PR TITLE
drivers/sensor/fxas21002: Fix racing conditions during initialization

### DIFF
--- a/drivers/sensor/fxas21002/fxas21002.c
+++ b/drivers/sensor/fxas21002/fxas21002.c
@@ -245,6 +245,8 @@ static int fxas21002_init(struct device *dev)
 		return -EIO;
 	}
 
+	k_sem_init(&data->sem, 0, UINT_MAX);
+
 #if CONFIG_FXAS21002_TRIGGER
 	if (fxas21002_trigger_init(dev)) {
 		SYS_LOG_ERR("Could not initialize interrupts");
@@ -263,9 +265,7 @@ static int fxas21002_init(struct device *dev)
 							FXAS21002_POWER_ACTIVE,
 							config->dr);
 	k_busy_wait(transition_time);
-
-
-	k_sem_init(&data->sem, 1, UINT_MAX);
+	k_sem_give(&data->sem);
 
 	SYS_LOG_DBG("Init complete");
 


### PR DESCRIPTION
Two racing conditions were identified during the initialization of the
drver when the trigger function was enabled:

1 - The fxas21002_handle_int was trying to acquire the semaphore before
    it gets initialized. To solve this we need to initialize the
    semaphore before calling the fxas21002_trigger_init function.

2 - During the fxas21002_trigger initialization the i2c bus is used at
    the same time as the fxas21002_get_transition_time is being
    called. To fix this we need to acquire the semaphore before calling
    fxas21002_get_transition_time function.

These two scenarios was reproducible in the WaRP7 board with i.MX7 SoC.

Signed-off-by: Diego Sueiro <diego.sueiro@gmail.com>