### PR TITLE
drivers/sensor/fxos8700: Fix racing conditions during initialization

### DIFF
--- a/drivers/sensor/fxos8700/fxos8700.c
+++ b/drivers/sensor/fxos8700/fxos8700.c
@@ -332,6 +332,8 @@ static int fxos8700_init(struct device *dev)
 		return -EIO;
 	}
 
+	k_sem_init(&data->sem, 0, UINT_MAX);
+
 #if CONFIG_FXOS8700_TRIGGER
 	if (fxos8700_trigger_init(dev)) {
 		SYS_LOG_ERR("Could not initialize interrupts");
@@ -344,8 +346,7 @@ static int fxos8700_init(struct device *dev)
 		SYS_LOG_ERR("Could not set active");
 		return -EIO;
 	}
-
-	k_sem_init(&data->sem, 1, UINT_MAX);
+	k_sem_give(&data->sem);
 
 	SYS_LOG_DBG("Init complete");
 


### PR DESCRIPTION
Two racing conditions were identified during the initialization of the
drver when the trigger function was enabled:

1 - The fxos8700_handle_int was trying to acquire the semaphore before
    it gets initialized. To solve this we need to initialize the
    semaphore before calling the fxos8700_trigger_init function.

2 - During the fxos8700_trigger initialization the i2c bus is used at
    the same time as the fxos8700_set_power is being called. To fix
    this we need to acquire the semaphore before calling
    fxos8700_set_power function.

These two scenarios was reproducible in the WaRP7 board with i.MX7 SoC.

Signed-off-by: Diego Sueiro <diego.sueiro@gmail.com>