### PR TITLE
linker: Re-implement {APP,KERNEL}_INPUT_SECTION

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -618,15 +618,14 @@ if(CONFIG_APPLICATION_MEMORY)
     list(APPEND ks ${fixed_path})
   endforeach()
 
-  # We are done constructing kernel_object_file_list, now we inject this
-  # information into the linker script through -D's
-  list(LENGTH kernel_object_file_list NUM_KERNEL_OBJECT_FILES)
-  list(APPEND LINKER_SCRIPT_DEFINES -DNUM_KERNEL_OBJECT_FILES=${NUM_KERNEL_OBJECT_FILES})
-  set(i 0)
+  # We are done constructing kernel_object_file_list, now we inject
+  # this list into the linker script through the define
+  # KERNELSPACE_OBJECT_FILES
+  set(def -DKERNELSPACE_OBJECT_FILES=)
   foreach(f ${ks})
-    list(APPEND LINKER_SCRIPT_DEFINES -DKERNEL_OBJECT_FILE_${i}=${f})
-    math(EXPR i "${i}+1")
+    set(def "${def} ${f}")
   endforeach()
+  list(APPEND LINKER_SCRIPT_DEFINES ${def})
 endif() # CONFIG_APPLICATION_MEMORY
 
 # Declare MPU userspace dependencies before the linker scripts to make

--- a/include/linker/linker-defs.h
+++ b/include/linker/linker-defs.h
@@ -112,6 +112,11 @@
  * their shell commands are automatically initialized by the kernel.
  */
 
+/*
+ * APP_INPUT_SECTION should be invoked on sections that should be in
+ * 'app' space. KERNEL_INPUT_SECTION should be invoked on sections
+ * that should be in 'kernel' space.
+ */
 #ifdef CONFIG_APPLICATION_MEMORY
 
 #ifndef NUM_KERNEL_OBJECT_FILES
@@ -130,14 +135,13 @@
     UTIL_LISTIFY(NUM_KERNEL_OBJECT_FILES, X, sect)
 #define APP_INPUT_SECTION(sect)	\
     *(EXCLUDE_FILE (UTIL_LISTIFY(NUM_KERNEL_OBJECT_FILES, Y, ~)) sect)
-#define APP_SMEM_SECTION()	KEEP(*(SORT(data_smem_[_a-zA-Z0-9]*)))
 
 #else
 #define KERNEL_INPUT_SECTION(sect)	*(sect)
 #define APP_INPUT_SECTION(sect)		*(sect)
-#define APP_SMEM_SECTION()	KEEP(*(SORT(data_smem_[_a-zA-Z0-9]*)))
-#endif
+#endif /* CONFIG_APPLICATION_MEMORY */
 
+#define APP_SMEM_SECTION() KEEP(*(SORT(data_smem_[_a-zA-Z0-9]*)))
 
 #ifdef CONFIG_X86 /* LINKER FILES: defines used by linker script */
 /* Should be moved to linker-common-defs.h */


### PR DESCRIPTION
This rewrites the implementation of the APP_INPUT_SECTION and
KERNEL_INPUT_SECTION macros such that an unbounded amount of
kernelspace libraries can be used.

This resolves #7703

The new implementation has a caveat/limitation; the linker script
developer must invoke APP_INPUT_SECTION before KERNEL_INPUT_SECTION.

All in-tree linker scripts happened to already be doing this so no
in-tree porting was necessary.