### PR TITLE
Revert "mimxrt1050_evk: disable sanitycheck on this board [REVERT ME]"

### DIFF
--- a/boards/arm/mimxrt1050_evk/mimxrt1050_evk.yaml
+++ b/boards/arm/mimxrt1050_evk/mimxrt1050_evk.yaml
@@ -8,7 +8,6 @@ identifier: mimxrt1050_evk
 name: NXP MIMXRT1050-EVK
 type: mcu
 arch: arm
-sanitycheck: false
 toolchain:
   - zephyr
   - gccarmemb


### PR DESCRIPTION
This reverts commit d147cc8dd43ad233666a8f3cde013e85662d0823.

The board was fixed in commit 4b22ba7e4ba82e9f63e10eef89722047858033fc.

Signed-off-by: Maureen Helm <maureen.helm@nxp.com>