### PR TITLE
doc: switch master to use RTD theme

### DIFF
--- a/doc/_templates/breadcrumbs.html
+++ b/doc/_templates/breadcrumbs.html
@@ -1,0 +1,14 @@
+{% extends "!breadcrumbs.html" %}
+{% block breadcrumbs %}
+  <!-- {{ docs_title }} -->
+  {# parameterize default name "Docs" in breadcrumb via docs_title in conf.py #}
+  {% if not docs_title %}
+  {% set docs_title = "Docs" %}
+  {% endif %}
+
+  <li><a href="{{ pathto(master_doc) }}">{{ docs_title }}</a> &raquo;</li>
+  {% for doc in parents %}
+     <li><a href="{{ doc.link|e }}">{{ doc.title }}</a> &raquo;</li>
+  {% endfor %}
+  <li>{{ title }}</li>
+{% endblock %}

--- a/doc/_templates/layout.html
+++ b/doc/_templates/layout.html
@@ -1,0 +1,10 @@
+{% extends "!layout.html" %}
+{% block document %}
+  {% if is_release %}
+    <div class="wy-alert wy-alert-danger">
+      The <a href="/{{ pagename }}.html">latest development version</a>
+      of this page may be more current than this released {{ version }} version.
+    </div>
+  {% endif %}
+  {{ super() }}
+{% endblock %}

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -149,19 +149,9 @@ rst_epilog = """
 
 # -- Options for HTML output ----------------------------------------------
 
-try:
-    import sphinx_rtd_theme
-except ImportError:
-    html_theme = 'zephyr'
-    html_theme_path = ['{}/doc/themes'.format(ZEPHYR_BASE)]
-else:
-    html_theme = "sphinx_rtd_theme"
-    html_theme_path = [sphinx_rtd_theme.get_html_theme_path()]
-
-if tags.has('daily') or tags.has('release'):
-    html_theme = 'zephyr-docs-theme'
-    html_theme_path = ['{}/doc/themes'.format(ZEPHYR_BASE)]
-
+import sphinx_rtd_theme
+html_theme = "sphinx_rtd_theme"
+html_theme_path = [sphinx_rtd_theme.get_html_theme_path()]
 
 if tags.has('release'):
     is_release = True


### PR DESCRIPTION
This PR removes use of the customized zephyr_docs_theme, replacing it
with the new read_the_docs theme.  It ignores the tags that were
previously used to switch the theme for "development" vs. "daily" or
"release" and always uses the RTD theme.  (The "daily" vs. "release" is
still honored to change the breadcrumb and doc version to "latest" if
"daily" is specified (as we did for the current doc build process),
otherwise it uses the version extracted from the
VERSION file in the source code (as would be appropriate for the docs
for a tagged release.)

This also pulls in using template extensions for breadcrumb and the
notice about latest having more up-to-date content when the "release"
tag is set.

Signed-off-by: David B. Kinder <david.b.kinder@intel.com>