### PR TITLE
drivers: clock_control: Allow PLL clock configuration with HSI on STM…

### DIFF
--- a/drivers/clock_control/stm32f1x_ll_clock.c
+++ b/drivers/clock_control/stm32f1x_ll_clock.c
@@ -27,7 +27,6 @@
 #undef RCC_PREDIV1_SOURCE_PLL2
 #endif /* CONFIG_CLOCK_STM32_PLL_SRC_PLL2 */
 
-
 /**
  * @brief fill in pll configuration structure
  */
@@ -50,6 +49,11 @@ void config_pll_init(LL_UTILS_PLLInitTypeDef *pllinit)
 	pllinit->PLLMul = ((CONFIG_CLOCK_STM32_PLL_MULTIPLIER - 2)
 					<< RCC_CFGR_PLLMULL_Pos);
 
+#if defined(CONFIG_CLOCK_STM32_PLL_SRC_HSI)
+	/* If HSI is used as PLL source an automatic divisor of 2 will be
+	 * applied */
+	pllinit->Prediv = LL_RCC_PLLSOURCE_HSI_DIV_2;
+#else
 #ifdef CONFIG_SOC_STM32F10X_DENSITY_DEVICE
 	/* PLL prediv */
 #ifdef CONFIG_CLOCK_STM32_PLL_XTPRE
@@ -78,6 +82,7 @@ void config_pll_init(LL_UTILS_PLLInitTypeDef *pllinit)
 	 */
 	pllinit->Prediv = CONFIG_CLOCK_STM32_PLL_PREDIV1 - 1;
 #endif /* CONFIG_SOC_STM32F10X_DENSITY_DEVICE */
+#endif /* CONFIG_CLOCK_STM32_PLL_SRC_HSI */
 }
 
 #endif /* CONFIG_CLOCK_STM32_SYSCLK_SRC_PLL */

--- a/ext/hal/st/stm32cube/stm32f1xx/drivers/src/stm32f1xx_ll_utils.c
+++ b/ext/hal/st/stm32cube/stm32f1xx/drivers/src/stm32f1xx_ll_utils.c
@@ -559,15 +559,15 @@ static ErrorStatus UTILS_EnablePLLAndSwitchSystem(uint32_t SYSCLK_Frequency, LL_
   /* Update system clock configuration */
   if (status == SUCCESS)
   {
-#if defined(RCC_PLL2_SUPPORT)
+#if defined(RCC_PLL2_SUPPORT) && !defined(CONFIG_CLOCK_STM32_PLL_SRC_HSI)
     /* Enable PLL2 */
     LL_RCC_PLL2_Enable();
     while (LL_RCC_PLL2_IsReady() != 1U)
     {
       /* Wait for PLL2 ready */
     }
+#endif /* RCC_PLL2_SUPPORT && !defined(CONFIG_CLOCK_STM32_PLL_SRC_HSI) */
 
-#endif /* RCC_PLL2_SUPPORT */
     /* Enable PLL */
     LL_RCC_PLL_Enable();
     while (LL_RCC_PLL_IsReady() != 1U)


### PR DESCRIPTION
…32F1xx

The STM32F1xx allow to use the built-in oscillator to be used as PLL
input. This change sets sets both the fixed /2 prescaling divisor if HSI
is selected as input and prevents waiting for PLL2 to come online (which
only works for HSE input and will never happen with HSI input).

Signed-off-by: Daniel Egger <daniel@eggers-club.de>