### PR TITLE
 drivers: i2c_ll_stm32_v1: improve NACK handling

### DIFF
--- a/drivers/i2c/i2c_ll_stm32_v1.c
+++ b/drivers/i2c/i2c_ll_stm32_v1.c
@@ -335,7 +335,13 @@ s32_t stm32_i2c_msg_write(struct device *dev, struct i2c_msg *msg,
 			LL_I2C_TransmitData8(i2c, slave | I2C_REQUEST_WRITE);
 		}
 		while (!LL_I2C_IsActiveFlag_ADDR(i2c)) {
-			;
+			if (LL_I2C_IsActiveFlag_AF(i2c)) {
+				LL_I2C_ClearFlag_AF(i2c);
+				LL_I2C_GenerateStopCondition(i2c);
+				SYS_LOG_DBG("%s: NACK", __func__);
+
+				return -EIO;
+			}
 		}
 		LL_I2C_ClearFlag_ADDR(i2c);
 	}
@@ -415,7 +421,13 @@ s32_t stm32_i2c_msg_read(struct device *dev, struct i2c_msg *msg,
 		}
 
 		while (!LL_I2C_IsActiveFlag_ADDR(i2c)) {
-			;
+			if (LL_I2C_IsActiveFlag_AF(i2c)) {
+				LL_I2C_ClearFlag_AF(i2c);
+				LL_I2C_GenerateStopCondition(i2c);
+				SYS_LOG_DBG("%s: NACK", __func__);
+
+				return -EIO;
+			}
 		}
 
 		if (len == 1) {

--- a/drivers/i2c/i2c_ll_stm32_v1.c
+++ b/drivers/i2c/i2c_ll_stm32_v1.c
@@ -199,6 +199,7 @@ void stm32_i2c_error_isr(void *arg)
 
 	if (LL_I2C_IsActiveFlag_AF(i2c)) {
 		LL_I2C_ClearFlag_AF(i2c);
+		LL_I2C_GenerateStopCondition(i2c);
 		data->current.is_nack = 1;
 		k_sem_give(&data->device_sync_sem);
 
@@ -346,6 +347,7 @@ s32_t stm32_i2c_msg_write(struct device *dev, struct i2c_msg *msg,
 			}
 			if (LL_I2C_IsActiveFlag_AF(i2c)) {
 				LL_I2C_ClearFlag_AF(i2c);
+				LL_I2C_GenerateStopCondition(i2c);
 				SYS_LOG_DBG("%s: NACK", __func__);
 
 				return -EIO;


### PR DESCRIPTION
According to the reference manual, the transmitter which receives a NACK must
reset the communication:
– If Slave: lines are released by hardware
– If Master: a Stop or repeated Start condition must be generated by software

In polling mode, if a NACK is received during address transmission the driver
waits forever the ADDR flag. We need to check AF flag and stop the transmission
if it is set.
