### PR TITLE
cmake: Refactor usage of target_link_libraries on Zephyr libraries

### DIFF
--- a/cmake/app/boilerplate.cmake
+++ b/cmake/app/boilerplate.cmake
@@ -318,6 +318,7 @@ foreach(boilerplate_lib ${ZEPHYR_INTERFACE_LIBS_PROPERTY})
   target_link_libraries_ifdef(
     CONFIG_APP_LINK_WITH_${boilerplate_lib_upper_case}
     app
+    PUBLIC
     ${boilerplate_lib}
     )
 endforeach()

--- a/cmake/extensions.cmake
+++ b/cmake/extensions.cmake
@@ -428,7 +428,7 @@ macro(zephyr_library_named name)
 
   zephyr_append_cmake_library(${name})
 
-  target_link_libraries(${name} zephyr_interface)
+  target_link_libraries(${name} PUBLIC zephyr_interface)
 endmacro()
 
 
@@ -448,7 +448,7 @@ function(zephyr_library_include_directories)
 endfunction()
 
 function(zephyr_library_link_libraries item)
-  target_link_libraries(${ZEPHYR_CURRENT_LIBRARY} ${item} ${ARGN})
+  target_link_libraries(${ZEPHYR_CURRENT_LIBRARY} PUBLIC ${item} ${ARGN})
 endfunction()
 
 function(zephyr_library_compile_definitions item)
@@ -473,7 +473,7 @@ function(zephyr_library_compile_options item)
   add_library(           ${lib_name} INTERFACE)
   target_compile_options(${lib_name} INTERFACE ${item} ${ARGN})
 
-  target_link_libraries(${ZEPHYR_CURRENT_LIBRARY} ${lib_name})
+  target_link_libraries(${ZEPHYR_CURRENT_LIBRARY} PUBLIC ${lib_name})
 endfunction()
 
 function(zephyr_library_cc_option)

--- a/samples/application_development/external_lib/CMakeLists.txt
+++ b/samples/application_development/external_lib/CMakeLists.txt
@@ -55,4 +55,4 @@ add_dependencies(
 set_target_properties(mylib_lib PROPERTIES IMPORTED_LOCATION             ${MYLIB_LIB_DIR}/libmylib.a)
 set_target_properties(mylib_lib PROPERTIES INTERFACE_INCLUDE_DIRECTORIES ${MYLIB_INCLUDE_DIR})
 
-target_link_libraries(app mylib_lib)
+target_link_libraries(app PUBLIC mylib_lib)

--- a/samples/boards/nrf52/mesh/onoff_level_lighting_vnd_app/CMakeLists.txt
+++ b/samples/boards/nrf52/mesh/onoff_level_lighting_vnd_app/CMakeLists.txt
@@ -3,7 +3,7 @@ set(QEMU_EXTRA_FLAGS -s)
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
 project(NONE)
 
-target_link_libraries(app subsys__bluetooth)
+target_link_libraries(app PUBLIC subsys__bluetooth)
 
 target_sources(app PRIVATE
 	       src/main.c


### PR DESCRIPTION
CMake has several prototypes/signatures for the function
'target_link_libraries'. This commit migrates the usage of
'target_link_libraries' on Zephyr CMake libraries from the old 'plain'
signature to the new '<PRIVATE|PUBLIC|INTERFACE>' signature.

For technical reasons the two signatures can not be mixed. Each
library must exclusively use either the old or new signature.

The 'old' plain signature is equivalent to using the PUBLIC
signature. Migrating to use 'PUBLIC' is therefore expected to be a
safe change.

After the migration it will be possible to use the PRIVATE and
INTERFACE signatures on Zephyr CMake libraries. This is useful for
instance to fix issue 8438.

Signed-off-by: Sebastian Bøe <sebastian.boe@nordicsemi.no>