### PR TITLE
ci: Update to 0.2 docker image

### DIFF
--- a/.shippable.yml
+++ b/.shippable.yml
@@ -4,10 +4,10 @@ compiler: gcc
 
 env:
     global:
-        - SDK=0.9.1
+        - SDK=0.9.2
         - SANITYCHECK_OPTIONS=" --inline-logs -R"
         - SANITYCHECK_OPTIONS_RETRY="${SANITYCHECK_OPTIONS} --only-failed --outdir=out-2nd-pass"
-        - ZEPHYR_SDK_INSTALL_DIR=/opt/sdk/zephyr-sdk-0.9.1
+        - ZEPHYR_SDK_INSTALL_DIR=/opt/sdk/zephyr-sdk-0.9.2
         - ZEPHYR_GCC_VARIANT=zephyr
         - USE_CCACHE=1
         - MATRIX_BUILDS="2"
@@ -23,7 +23,7 @@ build:
         - ${SHIPPABLE_BUILD_DIR}/ccache
     pre_ci_boot:
         image_name: zephyrprojectrtos/ci
-        image_tag: v0.1
+        image_tag: v0.2
         pull: true
         options: "-e HOME=/home/buildslave --privileged=true --tty --net=bridge --user buildslave"
 


### PR DESCRIPTION
For some reason the 0.1 release of the docker image isn't around, so try
and use 0.2 for the 1.9 branch.

Signed-off-by: Kumar Gala <kumar.gala@linaro.org>