### PR TITLE
Add generic network L2 flags

### DIFF
--- a/include/net/ethernet.h
+++ b/include/net/ethernet.h
@@ -286,6 +286,11 @@ struct ethernet_context {
 	struct ethernet_lldp lldp[NET_VLAN_MAX_COUNT];
 #endif
 
+	/**
+	 * This tells what L2 features does ethernet support.
+	 */
+	enum net_l2_flags ethernet_l2_flags;
+
 #if defined(CONFIG_NET_GPTP)
 	/** The gPTP port number for this network device. We need to store the
 	 * port number here so that we do not need to fetch it for every

--- a/include/net/ieee802154.h
+++ b/include/net/ieee802154.h
@@ -43,6 +43,7 @@ struct ieee802154_security_ctx {
 
 /* This not meant to be used by any code but 802.15.4 L2 stack */
 struct ieee802154_context {
+	enum net_l2_flags flags;
 	u16_t pan_id;
 	u16_t channel;
 	struct k_sem ack_lock;

--- a/include/net/net_l2.h
+++ b/include/net/net_l2.h
@@ -27,6 +27,11 @@ extern "C" {
 
 struct net_if;
 
+enum net_l2_flags {
+	/** IP multicast supported */
+	NET_L2_MULTICAST			= BIT(0),
+};
+
 struct net_l2 {
 	/**
 	 * This function is used by net core to get iface's L2 layer parsing
@@ -50,9 +55,14 @@ struct net_l2 {
 
 	/**
 	 * This function is used to enable/disable traffic over a network
-	 * interface.
+	 * interface. The function returns <0 if error and >=0 if no error.
 	 */
 	int (*enable)(struct net_if *iface, bool state);
+
+	/**
+	 * Return L2 flags for the network interface.
+	 */
+	enum net_l2_flags (*get_flags)(struct net_if *iface);
 };
 
 #define NET_L2_GET_NAME(_name) (__net_l2_##_name)
@@ -87,13 +97,15 @@ NET_L2_DECLARE_PUBLIC(BLUETOOTH_L2);
 NET_L2_DECLARE_PUBLIC(OPENTHREAD_L2);
 #endif /* CONFIG_NET_L2_OPENTHREAD */
 
-#define NET_L2_INIT(_name, _recv_fn, _send_fn, _reserve_fn, _enable_fn)	\
+#define NET_L2_INIT(_name, _recv_fn, _send_fn, _reserve_fn, _enable_fn, \
+		    _get_flags_fn)					\
 	const struct net_l2 (NET_L2_GET_NAME(_name)) __used		\
 	__attribute__((__section__(".net_l2.init"))) = {		\
 		.recv = (_recv_fn),					\
 		.send = (_send_fn),					\
 		.reserve = (_reserve_fn),				\
 		.enable = (_enable_fn),					\
+		.get_flags = (_get_flags_fn),				\
 	}
 
 #define NET_L2_GET_DATA(name, sfx) (__net_l2_data_##name##sfx)

--- a/include/net/net_l2.h
+++ b/include/net/net_l2.h
@@ -30,6 +30,9 @@ struct net_if;
 enum net_l2_flags {
 	/** IP multicast supported */
 	NET_L2_MULTICAST			= BIT(0),
+
+	/** Do not joint solicited node multicast group */
+	NET_L2_MULTICAST_SKIP_JOIN_SOLICIT_NODE	= BIT(1),
 };
 
 struct net_l2 {

--- a/include/net/net_l2.h
+++ b/include/net/net_l2.h
@@ -33,6 +33,9 @@ enum net_l2_flags {
 
 	/** Do not joint solicited node multicast group */
 	NET_L2_MULTICAST_SKIP_JOIN_SOLICIT_NODE	= BIT(1),
+
+	/** Is promiscuous mode supported */
+	NET_L2_PROMISC_MODE			= BIT(2),
 };
 
 struct net_l2 {

--- a/subsys/net/ip/net_if.c
+++ b/subsys/net/ip/net_if.c
@@ -2382,21 +2382,25 @@ done:
 
 int net_if_set_promisc(struct net_if *iface)
 {
+	enum net_l2_flags l2_flags = 0;
 	int ret;
 
 	NET_ASSERT(iface);
 
-	/* This is currently only support for ethernet.
-	 * TODO: support also other L2 technologies.
-	 */
-#if defined(CONFIG_NET_L2_ETHERNET)
-	if (net_if_l2(iface) != &NET_L2_GET_NAME(ETHERNET)) {
+	if (net_if_l2(iface)->get_flags) {
+		l2_flags = net_if_l2(iface)->get_flags(iface);
+	}
+
+	if (!(l2_flags & NET_L2_PROMISC_MODE)) {
 		return -ENOTSUP;
 	}
 
-	ret = net_eth_promisc_mode(iface, true);
-	if (ret < 0) {
-		return ret;
+#if defined(CONFIG_NET_L2_ETHERNET)
+	if (net_if_l2(iface) == &NET_L2_GET_NAME(ETHERNET)) {
+		ret = net_eth_promisc_mode(iface, true);
+		if (ret < 0) {
+			return ret;
+		}
 	}
 #else
 	return -ENOTSUP;

--- a/subsys/net/ip/net_if.c
+++ b/subsys/net/ip/net_if.c
@@ -830,7 +830,9 @@ static void join_mcast_nodes(struct net_if *iface, struct in6_addr *addr)
 	if (flags & NET_L2_MULTICAST) {
 		join_mcast_allnodes(iface);
 
-		join_mcast_solicit_node(iface, addr);
+		if (!(flags & NET_L2_MULTICAST_SKIP_JOIN_SOLICIT_NODE)) {
+			join_mcast_solicit_node(iface, addr);
+		}
 	}
 }
 

--- a/subsys/net/l2/bluetooth/bluetooth.c
+++ b/subsys/net/l2/bluetooth/bluetooth.c
@@ -105,8 +105,13 @@ static int net_bt_enable(struct net_if *iface, bool state)
 	return 0;
 }
 
+static enum net_l2_flags net_bt_flags(struct net_if *iface)
+{
+	return NET_L2_MULTICAST;
+}
+
 NET_L2_INIT(BLUETOOTH_L2, net_bt_recv, net_bt_send, net_bt_reserve,
-	    net_bt_enable);
+	    net_bt_enable, net_bt_flags);
 
 static void ipsp_connected(struct bt_l2cap_chan *chan)
 {

--- a/subsys/net/l2/bluetooth/bluetooth.c
+++ b/subsys/net/l2/bluetooth/bluetooth.c
@@ -107,7 +107,7 @@ static int net_bt_enable(struct net_if *iface, bool state)
 
 static enum net_l2_flags net_bt_flags(struct net_if *iface)
 {
-	return NET_L2_MULTICAST;
+	return NET_L2_MULTICAST | NET_L2_MULTICAST_SKIP_JOIN_SOLICIT_NODE;
 }
 
 NET_L2_INIT(BLUETOOTH_L2, net_bt_recv, net_bt_send, net_bt_reserve,

--- a/subsys/net/l2/dummy/dummy.c
+++ b/subsys/net/l2/dummy/dummy.c
@@ -38,4 +38,10 @@ static inline u16_t dummy_reserve(struct net_if *iface, void *unused)
 	return 0;
 }
 
-NET_L2_INIT(DUMMY_L2, dummy_recv, dummy_send, dummy_reserve, NULL);
+static enum net_l2_flags dummy_flags(struct net_if *iface)
+{
+	return NET_L2_MULTICAST;
+}
+
+NET_L2_INIT(DUMMY_L2, dummy_recv, dummy_send, dummy_reserve, NULL, \
+	    dummy_flags);

--- a/subsys/net/l2/ethernet/ethernet.c
+++ b/subsys/net/l2/ethernet/ethernet.c
@@ -939,6 +939,10 @@ void ethernet_init(struct net_if *iface)
 
 	ctx->ethernet_l2_flags = NET_L2_MULTICAST;
 
+	if (net_eth_get_hw_capabilities(iface) & ETHERNET_PROMISC_MODE) {
+		ctx->ethernet_l2_flags |= NET_L2_PROMISC_MODE;
+	}
+
 #if defined(CONFIG_NET_VLAN)
 	if (!(net_eth_get_hw_capabilities(iface) & ETHERNET_HW_VLAN)) {
 		return;

--- a/subsys/net/l2/ethernet/ethernet.c
+++ b/subsys/net/l2/ethernet/ethernet.c
@@ -575,6 +575,13 @@ static inline int ethernet_enable(struct net_if *iface, bool state)
 	return 0;
 }
 
+enum net_l2_flags ethernet_flags(struct net_if *iface)
+{
+	struct ethernet_context *ctx = net_if_l2_data(iface);
+
+	return ctx->ethernet_l2_flags;
+}
+
 #if defined(CONFIG_NET_VLAN)
 struct net_if *net_eth_get_vlan_iface(struct net_if *iface, u16_t tag)
 {
@@ -805,7 +812,7 @@ int net_eth_vlan_disable(struct net_if *iface, u16_t tag)
 #endif
 
 NET_L2_INIT(ETHERNET_L2, ethernet_recv, ethernet_send, ethernet_reserve,
-	    ethernet_enable);
+	    ethernet_enable, ethernet_flags);
 
 static void carrier_on(struct k_work *work)
 {
@@ -929,6 +936,8 @@ void ethernet_init(struct net_if *iface)
 #endif
 
 	NET_DBG("Initializing Ethernet L2 %p for iface %p", ctx, iface);
+
+	ctx->ethernet_l2_flags = NET_L2_MULTICAST;
 
 #if defined(CONFIG_NET_VLAN)
 	if (!(net_eth_get_hw_capabilities(iface) & ETHERNET_HW_VLAN)) {

--- a/subsys/net/l2/ieee802154/ieee802154.c
+++ b/subsys/net/l2/ieee802154/ieee802154.c
@@ -305,9 +305,16 @@ static int ieee802154_enable(struct net_if *iface, bool state)
 	return ieee802154_stop(iface);
 }
 
+enum net_l2_flags ieee802154_flags(struct net_if *iface)
+{
+	struct ieee802154_context *ctx = net_if_l2_data(iface);
+
+	return ctx->flags;
+}
+
 NET_L2_INIT(IEEE802154_L2,
 	    ieee802154_recv, ieee802154_send,
-	    ieee802154_reserve, ieee802154_enable);
+	    ieee802154_reserve, ieee802154_enable, ieee802154_flags);
 
 void ieee802154_init(struct net_if *iface)
 {
@@ -319,6 +326,7 @@ void ieee802154_init(struct net_if *iface)
 	NET_DBG("Initializing IEEE 802.15.4 stack on iface %p", iface);
 
 	ctx->channel = IEEE802154_NO_CHANNEL;
+	ctx->flags = NET_L2_MULTICAST;
 
 	ieee802154_mgmt_init(iface);
 

--- a/subsys/net/l2/openthread/openthread.c
+++ b/subsys/net/l2/openthread/openthread.c
@@ -360,5 +360,10 @@ int ieee802154_radio_send(struct net_if *iface, struct net_pkt *pkt)
 	return -EIO;
 }
 
+static enum net_l2_flags openthread_flags(struct net_if *iface)
+{
+	return NET_L2_MULTICAST;
+}
+
 NET_L2_INIT(OPENTHREAD_L2, openthread_recv, openthread_send,
-	    openthread_reserve, NULL);
+	    openthread_reserve, NULL, openthread_flags);


### PR DESCRIPTION
Add support for different L2 bearers to inform caller what kind of features they support. See also #5846 for some discussion about this case. First patch adds L2 flags and adds multicast support flag. I also added promiscuous mode support flag in 3rd patch as that is quite useful information and was discussed separately when promisc mode was implemented.