### PR TITLE
[RFC] subsys: storage: flash_map: add API for check flash driver support

### DIFF
--- a/include/flash_map.h
+++ b/include/flash_map.h
@@ -77,6 +77,16 @@ u8_t flash_area_align(const struct flash_area *fa);
 int flash_area_get_sectors(int fa_id, u32_t *count,
 			   struct flash_sector *sectors);
 
+/**
+ * Check whether given flash area has supporting flash driver
+ * in the system.
+ *
+ * @param fa Flash area.
+ *
+ * @return 1 On success. -ENODEV if no driver match.
+ */
+int flash_area_has_driver(const struct flash_area *fa);
+
 #ifdef __cplusplus
 }
 #endif

--- a/subsys/storage/flash_map/flash_map.c
+++ b/subsys/storage/flash_map/flash_map.c
@@ -264,6 +264,15 @@ u8_t flash_area_align(const struct flash_area *fa)
 	return flash_get_write_block_size(dev);
 }
 
+int flash_area_has_driver(const struct flash_area *fa)
+{
+	if (get_flash_dev_from_id(fa->fa_device_id) == NULL) {
+		return -ENODEV;
+	}
+
+	return 1;
+}
+
 static int flash_map_init(struct device *dev)
 {
 	unsigned int i;


### PR DESCRIPTION
Some applications might want to check whether flash_areas binds to
any flash drive in the system. It might be better to do that while
sanity check at application start-up then while regular run process.
Example of such application is the mcuboot.

This patch introduce such API for checking whether device bindings
were resolved properly during system startup.

Signed-off-by: Andrzej Puzdrowski <andrzej.puzdrowski@nordicsemi.no>