### PR TITLE
net: lwm2m: wait for interface up in lwm2m_engine_start()

### DIFF
--- a/subsys/net/lib/lwm2m/Kconfig
+++ b/subsys/net/lib/lwm2m/Kconfig
@@ -8,6 +8,8 @@ menuconfig LWM2M
 	bool "OMA LWM2M protocol stack"
 	select COAP
 	select NET_APP_CLIENT
+	select NET_MGMT
+	select NET_MGMT_EVENT
 	select HTTP_PARSER_URL
 	help
 	  This option adds logic for managing OMA LWM2M data


### PR DESCRIPTION
The LwM2M subsystem should make sure that the network interface
is up before proceeding with communications.

Let's add a wait in lwm2m_engine_start() that will timeout after
60 seconds, letting the client decide if it should retry, etc.

Signed-off-by: Michael Scott <mike@foundries.io>