### PR TITLE
coverage: tests: poll: Add test to validate multiple polling threads

### DIFF
--- a/tests/kernel/poll/src/main.c
+++ b/tests/kernel/poll/src/main.c
@@ -8,6 +8,7 @@
 extern void test_poll_no_wait(void);
 extern void test_poll_wait(void);
 extern void test_poll_multi(void);
+extern void test_poll_threadstate(void);
 extern void test_poll_grant_access(void);
 
 K_MEM_POOL_DEFINE(test_pool, 128, 128, 4, 4);
@@ -22,6 +23,7 @@ void test_main(void)
 	ztest_test_suite(poll_api,
 			 ztest_user_unit_test(test_poll_no_wait),
 			 ztest_unit_test(test_poll_wait),
-			 ztest_unit_test(test_poll_multi));
+			 ztest_unit_test(test_poll_multi),
+			 ztest_unit_test(test_poll_threadstate));
 	ztest_run_test_suite(poll_api);
 }

--- a/tests/kernel/poll/testcase.yaml
+++ b/tests/kernel/poll/testcase.yaml
@@ -1,3 +1,4 @@
 tests:
   kernel.poll:
     tags: kernel userspace
+    min_ram: 16


### PR DESCRIPTION
Add testcase for validating poll events by manipultaing thread
state to improve code coverage. Also, add multiple threads to
wait on same event.

Signed-off-by: Praful Swarnakar <praful.swarnakar@intel.com>