### PR TITLE
net: Fix credit-based shaper typos

### DIFF
--- a/subsys/net/ip/Kconfig
+++ b/subsys/net/ip/Kconfig
@@ -81,7 +81,7 @@ config NET_TC_MAPPING_STRICT
 	help
 	  This is the recommended default priority to traffic class mapping.
 	  Use it for implementations that do not support the credit-based
-	  sharper transmission selection algorithm.
+	  shaper transmission selection algorithm.
 	  See 802.1Q, chapter 8.6.6 for more information.
 
 config NET_TC_MAPPING_SR_CLASS_A_AND_B

--- a/subsys/net/ip/net_tc_mapping.h
+++ b/subsys/net/ip/net_tc_mapping.h
@@ -36,7 +36,7 @@
 #if defined(CONFIG_NET_TC_MAPPING_STRICT)
 
 /* This is the recommended priority to traffic class mapping for
- * implementations that do not support the credit-based sharper transmission
+ * implementations that do not support the credit-based shaper transmission
  * selection algorithm.
  * Ref: 802.1Q - chapter 8.6.6 - table 8-4
  */


### PR DESCRIPTION
The same typo copied to two places, do a: s/sharper/shaper/

Thanks @pfalcon for noticing that!