### PR TITLE
Bluetooth: controller: HAL: Separate simulated SOC in own header

### DIFF
--- a/subsys/bluetooth/controller/hal/nrf5/radio/radio_nrf5.h
+++ b/subsys/bluetooth/controller/hal/nrf5/radio/radio_nrf5.h
@@ -16,7 +16,9 @@
 #define HAL_EVENT_TIMER_SAMPLE_CC_OFFSET 3
 #define HAL_EVENT_TIMER_SAMPLE_TASK NRF_TIMER_TASK_CAPTURE3
 
-#if defined(CONFIG_SOC_SERIES_NRF51X)
+#if defined(CONFIG_SOC_SERIES_NWTSIM_NRFXX)
+#include "radio_sim_nrfxx.h"
+#elif defined(CONFIG_SOC_SERIES_NRF51X)
 #include "radio_nrf51.h"
 #elif defined(CONFIG_SOC_NRF52810)
 #include "radio_nrf52810.h"

--- a/subsys/bluetooth/controller/hal/nrf5/radio/radio_nrf52810.h
+++ b/subsys/bluetooth/controller/hal/nrf5/radio/radio_nrf52810.h
@@ -199,7 +199,6 @@ static inline void hal_radio_reset(void)
 
 static inline void hal_radio_ram_prio_setup(void)
 {
-#if !defined(CONFIG_SOC_SERIES_NWTSIM_NRFXX)
 	struct {
 		u32_t volatile reserved_0[0x5a0 >> 2];
 		u32_t volatile bridge_type;
@@ -236,7 +235,6 @@ static inline void hal_radio_ram_prio_setup(void)
 	NRF_AMLI->RAMPRI.I2S     = 0xFFFFFFFFUL;
 	NRF_AMLI->RAMPRI.PDM     = 0xFFFFFFFFUL;
 	NRF_AMLI->RAMPRI.PWM     = 0xFFFFFFFFUL;
-#endif /* !CONFIG_SOC_SERIES_NWTSIM_NRFXX */
 }
 
 static inline u32_t hal_radio_phy_mode_get(u8_t phy, u8_t flags)

--- a/subsys/bluetooth/controller/hal/nrf5/radio/radio_nrf52832.h
+++ b/subsys/bluetooth/controller/hal/nrf5/radio/radio_nrf52832.h
@@ -196,16 +196,13 @@
 
 static inline void hal_radio_reset(void)
 {
-#if !defined(CONFIG_SOC_SERIES_NWTSIM_NRFXX)
 	/* Anomalies 102, 106 and 107 */
 	*(volatile u32_t *)0x40001774 = ((*(volatile u32_t *)0x40001774) &
 					 0xfffffffe) | 0x01000000;
-#endif /* !CONFIG_SOC_SERIES_NWTSIM_NRFXX */
 }
 
 static inline void hal_radio_ram_prio_setup(void)
 {
-#if !defined(CONFIG_SOC_SERIES_NWTSIM_NRFXX)
 	struct {
 		u32_t volatile reserved_0[0x5a0 >> 2];
 		u32_t volatile bridge_type;
@@ -242,7 +239,6 @@ static inline void hal_radio_ram_prio_setup(void)
 	NRF_AMLI->RAMPRI.I2S     = 0xFFFFFFFFUL;
 	NRF_AMLI->RAMPRI.PDM     = 0xFFFFFFFFUL;
 	NRF_AMLI->RAMPRI.PWM     = 0xFFFFFFFFUL;
-#endif /* !CONFIG_SOC_SERIES_NWTSIM_NRFXX */
 }
 
 static inline u32_t hal_radio_phy_mode_get(u8_t phy, u8_t flags)


### PR DESCRIPTION
To avoid issues with differences between the simulated and the real
SOC let's separate the simulated one into its own header
