### PR TITLE
doc: Remove unnecessary copy statements

### DIFF
--- a/doc/CMakeLists.txt
+++ b/doc/CMakeLists.txt
@@ -105,8 +105,6 @@ add_custom_target(
 
 set(KI_SCRIPT ${ZEPHYR_BASE}/scripts/filter-known-issues.py)
 set(CONFIG_DIR ${ZEPHYR_BASE}/.known-issues/doc)
-configure_file(${CMAKE_CURRENT_LIST_DIR}/conf.py ${RST_OUT}/doc/conf.py COPYONLY)
-configure_file(${CMAKE_CURRENT_LIST_DIR}/substitutions.txt ${RST_OUT}/doc/substitutions.txt COPYONLY)
 
 add_custom_target(
   html


### PR DESCRIPTION
Since we're now copying the whole doc/ folder into the output folder,
there's no need anymore to copy certain files by hand.

Signed-off-by: Carles Cufi <carles.cufi@nordicsemi.no>