### PR TITLE
doc: fix kconfig misspellings

### DIFF
--- a/boards/arc/nsim_em/Kconfig.board
+++ b/boards/arc/nsim_em/Kconfig.board
@@ -10,5 +10,5 @@ config BOARD_NSIM_EM
 	select HAS_DTS
 	help
 	  The DesignWare ARC Nsim EM board is a virtual board based on
-	  nsim simulator. It's used to show the ARC EM core feuatures.
-	  It just has a console based on hostlink feature of nsim simulator
+	  nsim simulator. It's used to show the ARC EM core features.
+	  It just has a console based on hostlink feature of nsim simulator.

--- a/kernel/Kconfig
+++ b/kernel/Kconfig
@@ -222,7 +222,7 @@ config SCHED_SCALABLE
 	  When selected, the scheduler ready queue will be implemented
 	  as a red/black tree.  This has rather slower constant-time
 	  insertion and removal overhead, and on most platforms (that
-	  are not otherwise using the rbtree somehwere) requires an
+	  are not otherwise using the rbtree somewhere) requires an
 	  extra ~2kb of code.  But the resulting behavior will scale
 	  cleanly and quickly into the many thousands of threads.  Use
 	  this on platforms where you may have many threads (very

--- a/misc/Kconfig
+++ b/misc/Kconfig
@@ -347,7 +347,7 @@ config BOOTLOADER_ESP_IDF
 	bool "ESP-IDF bootloader support"
 	depends on SOC_ESP32
 	help
-	  This option will trigger the compilation of the ESP-IDF booloader
+	  This option will trigger the compilation of the ESP-IDF bootloader
 	  inside the build folder.
 	  At flash time, the bootloader will be flashed with the zephyr image
 

--- a/subsys/bluetooth/host/mesh/Kconfig
+++ b/subsys/bluetooth/host/mesh/Kconfig
@@ -156,7 +156,7 @@ config BT_MESH_ADV_BUF_COUNT
 	range 6 256
 	help
 	  Number of advertising buffers available. This should be chosen
-	  based on what kind of features the local node shoule have. E.g.
+	  based on what kind of features the local node should have. E.g.
 	  a relay will perform better the more buffers it has. Another
 	  thing to consider is outgoing segmented messages. There must
 	  be at least three more advertising buffers than the maximum

--- a/subsys/logging/Kconfig
+++ b/subsys/logging/Kconfig
@@ -188,7 +188,7 @@ config LOG_MAX_LEVEL
 config LOG_PRINTK
 	bool "Enable processing of printk messages."
 	help
-	  LOG_PRINTK messages are formatten in place and logged unconditionally.
+	  LOG_PRINTK messages are formatted in place and logged unconditionally.
 
 config LOG_PRINTK_MAX_STRING_LENGTH
 	int "Maximum string length supported by LOG_PRINTK"


### PR DESCRIPTION
Fix misspellings in Kconfig files missed during normal reviews

Signed-off-by: David B. Kinder <david.b.kinder@intel.com>