### PR TITLE
doc: fix misspellings in API docs

### DIFF
--- a/include/bluetooth/bluetooth.h
+++ b/include/bluetooth/bluetooth.h
@@ -313,7 +313,7 @@ int bt_le_scan_stop(void);
  *
  *  A helper for parsing the basic data types used for Extended Inquiry
  *  Response (EIR), Advertising Data (AD), and OOB data blocks. The most
- *  common scenario is to call this helper on the adverstising data
+ *  common scenario is to call this helper on the advertising data
  *  received in the callback that was given to bt_le_scan_start().
  *
  *  @param ad        Advertising data as given to the bt_le_scan_cb_t callback.

--- a/include/i2c.h
+++ b/include/i2c.h
@@ -301,7 +301,7 @@ static inline int _impl_i2c_slave_unregister(struct device *dev,
 }
 
 /**
- * @brief Intructs the I2C Slave device to register itself to the I2C Controller
+ * @brief Instructs the I2C Slave device to register itself to the I2C Controller
  *
  * This routine instructs the I2C Slave device to register itself to the I2C
  * Controller.
@@ -322,7 +322,7 @@ static inline int _impl_i2c_slave_driver_register(struct device *dev)
 }
 
 /**
- * @brief Intructs the I2C Slave device to unregister itself from the I2C
+ * @brief Instructs the I2C Slave device to unregister itself from the I2C
  * Controller
  *
  * This routine instructs the I2C Slave device to unregister itself from the I2C

--- a/include/mgmt/smp.h
+++ b/include/mgmt/smp.h
@@ -65,7 +65,7 @@ typedef int zephyr_smp_transport_ud_copy_fn(struct net_buf *dst,
  * connection-specific information in the net_buf user data (e.g., the BLE
  * transport stores the connection reference that has to be decreased).
  *
- * @param nb                    Contains a user_data pointer to be free'd.
+ * @param nb                    Contains a user_data pointer to be freed.
  */
 typedef void zephyr_smp_transport_ud_free_fn(void *ud);
 


### PR DESCRIPTION
Fix doxygen misspellings affecting API documentation missed during
regular reviews.

Signed-off-by: David B. Kinder <david.b.kinder@intel.com>