### PR TITLE
serial: sam: Fix compile error

### DIFF
--- a/drivers/serial/uart_sam.c
+++ b/drivers/serial/uart_sam.c
@@ -323,7 +323,7 @@ static int uart_sam_irq_update(struct device *dev)
 
 static void uart_sam_irq_callback_set(struct device *dev,
 				      uart_irq_callback_user_data_t cb,
-				      void *data)
+				      void *cb_data)
 {
 	struct uart_sam_dev_data *const dev_data = DEV_DATA(dev);
 


### PR DESCRIPTION
commit 57286afdd60bc0522aa09848f4862e930c75eb7d introduced a compile
error in the uart_sam driver.  The function uart_sam_irq_callback_set
should have be updated to have the callback data variable called
cb_data instead of data.

Signed-off-by: Kumar Gala <kumar.gala@linaro.org>