### PR TITLE
drivers: i2c: Move "Use 10-bit addressing" option to i2c_msg

### DIFF
--- a/drivers/i2c/i2c_nrfx_twi.c
+++ b/drivers/i2c/i2c_nrfx_twi.c
@@ -36,6 +36,10 @@ static int i2c_nrfx_twi_transfer(struct device *dev, struct i2c_msg *msgs,
 				 u8_t num_msgs, u16_t addr)
 {
 	for (size_t i = 0; i < num_msgs; i++) {
+		if (I2C_MSG_ADDR_10_BITS & msgs[i].flags) {
+			return -ENOTSUP;
+		}
+
 		nrfx_twi_xfer_desc_t cur_xfer = {
 			.p_primary_buf  = msgs[i].buf,
 			.primary_length = msgs[i].len,

--- a/drivers/i2c/i2c_nrfx_twim.c
+++ b/drivers/i2c/i2c_nrfx_twim.c
@@ -36,6 +36,10 @@ static int i2c_nrfx_twim_transfer(struct device *dev, struct i2c_msg *msgs,
 				  u8_t num_msgs, u16_t addr)
 {
 	for (size_t i = 0; i < num_msgs; i++) {
+		if (I2C_MSG_ADDR_10_BITS & msgs[i].flags) {
+			return -ENOTSUP;
+		}
+
 		nrfx_twim_xfer_desc_t cur_xfer = {
 			.p_primary_buf  = msgs[i].buf,
 			.primary_length = msgs[i].len,

--- a/include/i2c.h
+++ b/include/i2c.h
@@ -52,7 +52,7 @@ extern "C" {
 #define I2C_SPEED_GET(cfg) 		(((cfg) & I2C_SPEED_MASK) \
 						>> I2C_SPEED_SHIFT)
 
-/** Use 10-bit addressing. */
+/** Use 10-bit addressing. DEPRECATED - Use I2C_MSG_ADDR_10_BITS instead. */
 #define I2C_ADDR_10_BITS		(1 << 0)
 
 /** Controller to act as Master. */
@@ -63,7 +63,7 @@ extern "C" {
  */
 
 /** Slave device responds to 10-bit addressing. */
-#define I2C_SLAVE_FLAGS_ADDR_10_BITS		I2C_ADDR_10_BITS
+#define I2C_SLAVE_FLAGS_ADDR_10_BITS	(1 << 0)
 
 /*
  * I2C_MSG_* are I2C Message flags.
@@ -84,6 +84,9 @@ extern "C" {
 
 /** RESTART I2C transaction for this message. */
 #define I2C_MSG_RESTART			(1 << 2)
+
+/** Use 10-bit addressing for this message. */
+#define I2C_MSG_ADDR_10_BITS		(1 << 3)
 
 /**
  * @brief One I2C Message.


### PR DESCRIPTION
Fixes #3806
Added new message flag I2C_MSG_ADDR_10_BITS while keeping the old flag for 10 bit addressing for backward compatibility.
Modified nrf i2c driver to check this flag instead, now all other drivers should be modified in the same way.
