### PR TITLE
drivers: Use HAS_HW_NRF_* in SPI and I2C drivers' options dependencies

### DIFF
--- a/drivers/i2c/Kconfig.nrfx
+++ b/drivers/i2c/Kconfig.nrfx
@@ -24,14 +24,14 @@ choice I2C_0_NRF_TYPE
 
 config I2C_0_NRF_TWI
 	bool "nRF TWI 0"
-	depends on SOC_SERIES_NRF52X || SOC_SERIES_NRF51X
+	depends on HAS_HW_NRF_TWI0
 	select NRFX_TWI
 	help
 	  Enable nRF TWI Master without EasyDMA on port 0.
 
 config I2C_0_NRF_TWIM
 	bool "nRF TWIM 0"
-	depends on SOC_SERIES_NRF52X
+	depends on HAS_HW_NRF_TWIM0
 	select NRFX_TWIM
 	help
 	  Enable nRF TWI Master with EasyDMA on port 0.
@@ -50,14 +50,14 @@ choice I2C_1_NRF_TYPE
 
 config I2C_1_NRF_TWI
 	bool "nRF TWI 1"
-	depends on SOC_SERIES_NRF52X || SOC_SERIES_NRF51X
+	depends on HAS_HW_NRF_TWI1
 	select NRFX_TWI
 	help
 	  Enable nRF TWI Master without EasyDMA on port 1.
 
 config I2C_1_NRF_TWIM
 	bool "nRF TWIM 1"
-	depends on SOC_SERIES_NRF52X
+	depends on HAS_HW_NRF_TWIM1
 	select NRFX_TWIM
 	help
 	  Enable nRF TWI Master with EasyDMA on port 1.

--- a/drivers/spi/Kconfig.nrfx
+++ b/drivers/spi/Kconfig.nrfx
@@ -18,7 +18,6 @@ if SPI_0 && !I2C_0
 
 choice
 	prompt "SPI Port 0 Driver type"
-	optional
 
 config SPI_0_NRF_SPI
 	bool "nRF SPI 0"
@@ -107,7 +106,6 @@ if SPI_1 && !I2C_1
 
 choice
 	prompt "SPI Port 1 Driver type"
-	optional
 
 config SPI_1_NRF_SPI
 	bool "nRF SPI 1"
@@ -195,7 +193,6 @@ if SPI_2
 
 choice
 	prompt "SPI Port 2 Driver type"
-	optional
 
 config SPI_2_NRF_SPI
 	bool "nRF SPI 2"

--- a/drivers/spi/Kconfig.nrfx
+++ b/drivers/spi/Kconfig.nrfx
@@ -22,21 +22,23 @@ choice
 
 config SPI_0_NRF_SPI
 	bool "nRF SPI 0"
-	depends on SOC_SERIES_NRF52X || SOC_SERIES_NRF51X
+	depends on HAS_HW_NRF_SPI0
 	select NRFX_SPI
 	help
 	  Enable nRF SPI Master without EasyDMA on port 0.
 
 config SPI_0_NRF_SPIM
 	bool "nRF SPIM 0"
-	depends on SOC_NRF52840
+	# This driver is not available for nRF52832 because of the anomaly 58
+	# (SPIM: An additional byte is clocked out when RXD.MAXCNT = 1).
+	depends on HAS_HW_NRF_SPIM0 && !SOC_NRF52832
 	select NRFX_SPIM
 	help
 	  Enable nRF SPI Master with EasyDMA on port 0.
 
 config SPI_0_NRF_SPIS
 	bool "nRF SPIS 0"
-	depends on SOC_SERIES_NRF52X
+	depends on HAS_HW_NRF_SPIS0
 	depends on SPI_SLAVE
 	select NRFX_SPIS
 	help
@@ -109,21 +111,23 @@ choice
 
 config SPI_1_NRF_SPI
 	bool "nRF SPI 1"
-	depends on SOC_SERIES_NRF52X || SOC_SERIES_NRF51X
+	depends on HAS_HW_NRF_SPI1
 	select NRFX_SPI
 	help
 	  Enable nRF SPI Master without EasyDMA on port 1.
 
 config SPI_1_NRF_SPIM
 	bool "nRF SPIM 1"
-	depends on SOC_NRF52840
+	# This driver is not available for nRF52832 because of the anomaly 58
+	# (SPIM: An additional byte is clocked out when RXD.MAXCNT = 1).
+	depends on HAS_HW_NRF_SPIM1 && !SOC_NRF52832
 	select NRFX_SPIM
 	help
 	  Enable nRF SPI Master with EasyDMA on port 1.
 
 config SPI_1_NRF_SPIS
 	bool "nRF SPIS 1"
-	depends on SOC_SERIES_NRF52X || SOC_SERIES_NRF51X
+	depends on HAS_HW_NRF_SPIS1
 	depends on SPI_SLAVE
 	select NRFX_SPIS
 	help
@@ -195,21 +199,23 @@ choice
 
 config SPI_2_NRF_SPI
 	bool "nRF SPI 2"
-	depends on SOC_SERIES_NRF52X
+	depends on HAS_HW_NRF_SPI2
 	select NRFX_SPI
 	help
 	  Enable nRF SPI Master without EasyDMA on port 2.
 
 config SPI_2_NRF_SPIM
 	bool "nRF SPIM 2"
-	depends on SOC_NRF52840
+	# This driver is not available for nRF52832 because of the anomaly 58
+	# (SPIM: An additional byte is clocked out when RXD.MAXCNT = 1).
+	depends on HAS_HW_NRF_SPIM2 && !SOC_NRF52832
 	select NRFX_SPIM
 	help
 	  Enable nRF SPI Master with EasyDMA on port 2.
 
 config SPI_2_NRF_SPIS
 	bool "nRF SPIS 2"
-	depends on SOC_SERIES_NRF52X
+	depends on HAS_HW_NRF_SPIS2
 	depends on SPI_SLAVE
 	select NRFX_SPIS
 	help
@@ -277,7 +283,7 @@ if SPI_3
 
 config SPI_3_NRF_SPIM
 	bool
-	depends on SOC_NRF52840
+	depends on HAS_HW_NRF_SPIM3
 	select NRFX_SPIM
 	default y
 

--- a/drivers/watchdog/Kconfig.nrfx
+++ b/drivers/watchdog/Kconfig.nrfx
@@ -6,7 +6,7 @@
 
 menuconfig WDT_NRFX
 	bool "nRF WDT nrfx driver"
-	depends on SOC_FAMILY_NRF && CLOCK_CONTROL_NRF5
+	depends on SOC_FAMILY_NRF
 	select HAS_DTS_WDT
 	select NRFX_WDT
 	help


### PR DESCRIPTION
This PR replaces hard to maintain dependencies on SOC_SERIES_NRF* symbols in SPI and I2C drivers' options with the ones using the HAS_HW_NRF_* symbols.
Plus minor corrections in SPI and Watchdog drivers' Kconfigs.