### PR TITLE
dts: bindings: consolidate binding for flash controller

### DIFF
--- a/dts/bindings/flash_controller/atmel,sam0-nvmctrl.yaml
+++ b/dts/bindings/flash_controller/atmel,sam0-nvmctrl.yaml
@@ -11,9 +11,6 @@ inherits:
 
 properties:
     compatible:
-      type: string
-      category: required
-      description: compatible strings
       constraint: "atmel,sam0-nvmctrl"
 
 ...

--- a/dts/bindings/flash_controller/flash-controller.yaml
+++ b/dts/bindings/flash_controller/flash-controller.yaml
@@ -7,6 +7,12 @@ description: >
     This binding gives the base structures for all flash controller devices
 
 properties:
+    compatible:
+      type: string
+      category: required
+      description: compatible strings
+      generation: define
+
     label:
       type: string
       category: required

--- a/dts/bindings/flash_controller/nordic,nrf51-flash-controller.yaml
+++ b/dts/bindings/flash_controller/nordic,nrf51-flash-controller.yaml
@@ -11,9 +11,6 @@ inherits:
 
 properties:
     compatible:
-      type: string
-      category: required
-      description: compatible strings
       constraint: "nrf,nrf51-flash-controller"
 
 ...

--- a/dts/bindings/flash_controller/nordic,nrf52-flash-controller.yaml
+++ b/dts/bindings/flash_controller/nordic,nrf52-flash-controller.yaml
@@ -11,9 +11,6 @@ inherits:
 
 properties:
     compatible:
-      type: string
-      category: required
-      description: compatible strings
       constraint: "nrf,nrf52-flash-controller"
 
 ...

--- a/dts/bindings/flash_controller/nxp,kinetis-ftfa.yaml
+++ b/dts/bindings/flash_controller/nxp,kinetis-ftfa.yaml
@@ -11,9 +11,6 @@ inherits:
 
 properties:
     compatible:
-      type: string
-      category: required
-      description: compatible strings
       constraint: "nxp,kinetis-ftfa"
 
 ...

--- a/dts/bindings/flash_controller/nxp,kinetis-ftfe.yaml
+++ b/dts/bindings/flash_controller/nxp,kinetis-ftfe.yaml
@@ -11,9 +11,6 @@ inherits:
 
 properties:
     compatible:
-      type: string
-      category: required
-      description: compatible strings
       constraint: "nxp,kinetis-ftfe"
 
 ...

--- a/dts/bindings/flash_controller/nxp,kinetis-ftfl.yaml
+++ b/dts/bindings/flash_controller/nxp,kinetis-ftfl.yaml
@@ -11,9 +11,6 @@ inherits:
 
 properties:
     compatible:
-      type: string
-      category: required
-      description: compatible strings
       constraint: "nxp,kinetis-ftfl"
 
 ...

--- a/dts/bindings/flash_controller/st,stm32f0-flash-controller.yaml
+++ b/dts/bindings/flash_controller/st,stm32f0-flash-controller.yaml
@@ -11,9 +11,6 @@ inherits:
 
 properties:
     compatible:
-      type: string
-      category: required
-      description: compatible strings
       constraint: "st,stm32f0-flash-controller"
 
 ...

--- a/dts/bindings/flash_controller/st,stm32f3-flash-controller.yaml
+++ b/dts/bindings/flash_controller/st,stm32f3-flash-controller.yaml
@@ -11,9 +11,6 @@ inherits:
 
 properties:
     compatible:
-      type: string
-      category: required
-      description: compatible strings
       constraint: "st,stm32f3-flash-controller"
 
 ...

--- a/dts/bindings/flash_controller/st,stm32f4-flash-controller.yaml
+++ b/dts/bindings/flash_controller/st,stm32f4-flash-controller.yaml
@@ -11,9 +11,6 @@ inherits:
 
 properties:
     compatible:
-      type: string
-      category: required
-      description: compatible strings
       constraint: "st,stm32f4-flash-controller"
 
 ...

--- a/dts/bindings/flash_controller/st,stm32l4-flash-controller.yaml
+++ b/dts/bindings/flash_controller/st,stm32l4-flash-controller.yaml
@@ -11,9 +11,6 @@ inherits:
 
 properties:
     compatible:
-      type: string
-      category: required
-      description: compatible strings
       constraint: "st,stm32l4-flash-controller"
 
 ...


### PR DESCRIPTION
All flash controllers have a mandatory compatible property.

Add it to the generic binding that is included by all.

Signed-off-by: Bobby Noelte <b0661n0e17e@gmail.com>