### PR TITLE
ld: Don't use --start-group and --end-group

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -721,13 +721,11 @@ set(zephyr_lnk
   ${LINKERFLAGPREFIX},-Map=${PROJECT_BINARY_DIR}/${KERNEL_MAP_NAME}
   -u_OffsetAbsSyms
   -u_ConfigAbsSyms
-  ${LINKERFLAGPREFIX},--start-group
   ${LINKERFLAGPREFIX},--whole-archive
   ${ZEPHYR_LIBS_PROPERTY}
   ${LINKERFLAGPREFIX},--no-whole-archive
   kernel
   ${OFFSETS_O_PATH}
-  ${LINKERFLAGPREFIX},--end-group
   ${LIB_INCLUDE_DIR}
   -L${PROJECT_BINARY_DIR}
   ${TOOLCHAIN_LIBS}


### PR DESCRIPTION
Remove the usage of --start-group and --end-group. Perhaps it had a
function previously, but as it is used here it has no effect.

--start-group and --end-group is used to designate that a set of libs
should be searched repeatedly until all unresolved references among
them are resolved. From the documentation:

     --start-group archives --end-group
         The specified archives are searched repeatedly until no
         new undefined references are created.  Normally, an
         archive is searched only once in the order that it is
         specified on the command line.  If a symbol in that
         archive is needed to resolve an undefined symbol
         referred to by an object in an archive that appears
         later on the command line, the linker would not be able
         to resolve that reference.  By grouping the archives,
         they all be searched repeatedly until all possible
         references are resolved.

         Using this option has a significant performance cost.
         It is best to use it only when there are unavoidable
         circular references between two or more archives.

Currently it is used on the 'ZEPHYR_LIBS_PROPERTY' libs, but this has
no effect, because they are being --whole-archive'd anyway. It is also
used on 'kernel' and 'OFFSETS_O_PATH'. But these libraries have no
circular references, so this has no effect either.

Consequently, removing these two flags is expected to simplify the
link command line and have no adverse effects.

Signed-off-by: Sebastian Bøe <sebastian.boe@nordicsemi.no>