### PR TITLE
drivers: serial: uart_sam: Fix typo in param name.

### DIFF
--- a/drivers/serial/uart_sam.c
+++ b/drivers/serial/uart_sam.c
@@ -323,7 +323,7 @@ static int uart_sam_irq_update(struct device *dev)
 
 static void uart_sam_irq_callback_set(struct device *dev,
 				      uart_irq_callback_user_data_t cb,
-				      void *data)
+				      void *cb_data)
 {
 	struct uart_sam_dev_data *const dev_data = DEV_DATA(dev);
 


### PR DESCRIPTION
The refactor to add callback user data param in 57286afd, contained
typo just for this driver. It sneaked past the PR CI due to the fact
that issue affected just a couple of platforms, and we select just
a few of them randomly for PR CI (vs full CI).

Signed-off-by: Paul Sokolovsky <paul.sokolovsky@linaro.org>