### PR TITLE
arch: arm: soc: Add LL include file for I2S case (same as SPI)

### DIFF
--- a/arch/arm/soc/st_stm32/stm32f0/soc.h
+++ b/arch/arm/soc/st_stm32/stm32f0/soc.h
@@ -51,7 +51,7 @@
 #include <stm32f0xx_ll_i2c.h>
 #endif
 
-#ifdef CONFIG_SPI_STM32
+#if defined(CONFIG_SPI_STM32) || defined(CONFIG_I2S_STM32)
 #include <stm32f0xx_ll_spi.h>
 #endif
 

--- a/arch/arm/soc/st_stm32/stm32f1/soc.h
+++ b/arch/arm/soc/st_stm32/stm32f1/soc.h
@@ -47,7 +47,7 @@
 #include <stm32f1xx_ll_i2c.h>
 #endif
 
-#ifdef CONFIG_SPI_STM32
+#if defined(CONFIG_SPI_STM32) || defined(CONFIG_I2S_STM32)
 #include <stm32f1xx_ll_spi.h>
 #endif
 

--- a/arch/arm/soc/st_stm32/stm32f3/soc.h
+++ b/arch/arm/soc/st_stm32/stm32f3/soc.h
@@ -48,7 +48,7 @@
 #include <stm32f3xx_ll_i2c.h>
 #endif
 
-#ifdef CONFIG_SPI_STM32
+#if defined(CONFIG_SPI_STM32) || defined(CONFIG_I2S_STM32)
 #include <stm32f3xx_ll_spi.h>
 #endif
 

--- a/arch/arm/soc/st_stm32/stm32f4/soc.h
+++ b/arch/arm/soc/st_stm32/stm32f4/soc.h
@@ -47,7 +47,7 @@
 #include <stm32f4xx_ll_i2c.h>
 #endif
 
-#ifdef CONFIG_SPI_STM32
+#if defined(CONFIG_SPI_STM32) || defined(CONFIG_I2S_STM32)
 #include <stm32f4xx_ll_spi.h>
 #endif
 

--- a/arch/arm/soc/st_stm32/stm32l0/soc.h
+++ b/arch/arm/soc/st_stm32/stm32l0/soc.h
@@ -48,7 +48,7 @@
 #include <stm32l0xx_ll_i2c.h>
 #endif
 
-#ifdef CONFIG_SPI_STM32
+#if defined(CONFIG_SPI_STM32) || defined(CONFIG_I2S_STM32)
 #include <stm32l0xx_ll_spi.h>
 #endif
 


### PR DESCRIPTION
The STM32 SOCs F0xx/F1xx/F2xx/F3xx/F4xx/L0xx share same
LL include file with SPI (controller is same). So we need to
include it even when I2S_STM32 is enabled.

Signed-off-by: Armando Visconti <armando.visconti@st.com>