### PR TITLE
net: ipv4: ARP message was sent instead of proper IPv4 message

### DIFF
--- a/include/net/net_pkt.h
+++ b/include/net/net_pkt.h
@@ -120,7 +120,10 @@ struct net_pkt {
 				 * Used only if defined(CONFIG_NET_ROUTE)
 				 */
 	u8_t family     : 4;	/* IPv4 vs IPv6 */
-	u8_t _unused    : 1;
+	u8_t ipv4_auto_arp_msg : 1; /* Is this pkt IPv4 autoconf ARP message.
+				     * Used only if
+				     * defined(CONFIG_NET_IPV4_AUTO)
+				     */
 
 	union {
 		/* IPv6 hop limit or IPv4 ttl for this network packet.
@@ -637,6 +640,19 @@ static inline void net_pkt_set_ieee802154_lqi(struct net_pkt *pkt,
 					      u8_t lqi)
 {
 	pkt->ieee802154_lqi = lqi;
+}
+#endif
+
+#if defined(CONFIG_NET_IPV4_AUTO)
+static inline bool net_pkt_ipv4_auto(struct net_pkt *pkt)
+{
+	return pkt->ipv4_auto_arp_msg;
+}
+
+static inline void net_pkt_set_ipv4_auto(struct net_pkt *pkt,
+					 bool is_auto_arp_msg)
+{
+	pkt->ipv4_auto_arp_msg = is_auto_arp_msg;
 }
 #endif
 

--- a/subsys/net/ip/ipv4_autoconf.c
+++ b/subsys/net/ip/ipv4_autoconf.c
@@ -51,6 +51,7 @@ static struct net_pkt *ipv4_autoconf_prepare_arp(struct net_if *iface)
 	net_pkt_frag_add(pkt, frag);
 	net_pkt_set_iface(pkt, iface);
 	net_pkt_set_family(pkt, AF_INET);
+	net_pkt_set_ipv4_auto(pkt, true);
 
 	return net_arp_prepare(pkt, &cfg->ipv4auto.requested_ip,
 			       &cfg->ipv4auto.current_ip);

--- a/subsys/net/l2/ethernet/ethernet.c
+++ b/subsys/net/l2/ethernet/ethernet.c
@@ -402,6 +402,15 @@ struct net_eth_hdr *net_eth_fill_header(struct ethernet_context *ctx,
 	return hdr;
 }
 
+#if defined(CONFIG_NET_IPV4_AUTO)
+static inline bool is_ipv4_auto_arp_msg(struct net_pkt *pkt)
+{
+	return net_pkt_ipv4_auto(pkt);
+}
+#else
+#define is_ipv4_auto_arp_msg(...) false
+#endif
+
 static enum net_verdict ethernet_send(struct net_if *iface,
 				      struct net_pkt *pkt)
 {
@@ -431,7 +440,7 @@ static enum net_verdict ethernet_send(struct net_if *iface,
 		}
 
 		/* Trying to send ARP message so no need to setup it twice */
-		if (ntohs(NET_ETH_HDR(pkt)->type) != NET_ETH_PTYPE_ARP) {
+		if (!is_ipv4_auto_arp_msg(pkt)) {
 			arp_pkt = net_arp_prepare(pkt, &NET_IPV4_HDR(pkt)->dst,
 						  NULL);
 			if (!arp_pkt) {


### PR DESCRIPTION
The ethernet sending routing sent ARP message instead of the
actual IPv4 data message.

Fixes #9348

Signed-off-by: Jukka Rissanen <jukka.rissanen@linux.intel.com>