### PR TITLE
Refactor IPv4 header length handling

### DIFF
--- a/include/net/net_ip.h
+++ b/include/net/net_ip.h
@@ -286,7 +286,7 @@ struct net_ipv6_frag_hdr {
 struct net_ipv4_hdr {
 	u8_t vhl;
 	u8_t tos;
-	u8_t len[2];
+	u16_t len;
 	u8_t id[2];
 	u8_t offset[2];
 	u8_t ttl;

--- a/subsys/net/ip/connection.c
+++ b/subsys/net/ip/connection.c
@@ -867,8 +867,7 @@ enum net_verdict net_conn_input(enum net_ip_protocol proto, struct net_pkt *pkt)
 
 		if (IS_ENABLED(CONFIG_NET_IPV4) &&
 		    net_pkt_family(pkt) == AF_INET) {
-			data_len = NET_IPV4_HDR(pkt)->len[0] * 256 +
-				NET_IPV4_HDR(pkt)->len[1];
+			data_len = ntohs(NET_IPV4_HDR(pkt)->len);
 		} else if (IS_ENABLED(CONFIG_NET_IPV6) &&
 			   net_pkt_family(pkt) == AF_INET6) {
 			data_len = NET_IPV6_HDR(pkt)->len[0] * 256 +

--- a/subsys/net/ip/ipv4.c
+++ b/subsys/net/ip/ipv4.c
@@ -33,9 +33,7 @@ struct net_pkt *net_ipv4_create(struct net_pkt *pkt,
 				struct net_if *iface,
 				u8_t next_header_proto)
 {
-	struct net_buf *header;
-
-	header = net_pkt_get_frag(pkt, K_FOREVER);
+	struct net_buf *header = net_pkt_get_frag(pkt, K_FOREVER);
 
 	net_pkt_frag_insert(pkt, header);
 
@@ -154,11 +152,9 @@ enum net_verdict net_ipv4_process_pkt(struct net_pkt *pkt)
 	case IPPROTO_ICMP:
 		verdict = net_icmpv4_input(pkt);
 		break;
-	case IPPROTO_UDP:
-		verdict = net_conn_input(IPPROTO_UDP, pkt);
-		break;
 	case IPPROTO_TCP:
-		verdict = net_conn_input(IPPROTO_TCP, pkt);
+	case IPPROTO_UDP:
+		verdict = net_conn_input(hdr->proto, pkt);
 		break;
 	}
 

--- a/subsys/net/ip/ipv4.c
+++ b/subsys/net/ip/ipv4.c
@@ -70,8 +70,7 @@ void net_ipv4_finalize(struct net_pkt *pkt, u8_t next_header_proto)
 
 	total_len = net_pkt_get_len(pkt);
 
-	NET_IPV4_HDR(pkt)->len[0] = total_len >> 8;
-	NET_IPV4_HDR(pkt)->len[1] = total_len & 0xff;
+	NET_IPV4_HDR(pkt)->len = htons(total_len);
 
 	NET_IPV4_HDR(pkt)->chksum = 0;
 
@@ -109,7 +108,7 @@ enum net_verdict net_ipv4_process_pkt(struct net_pkt *pkt)
 {
 	struct net_ipv4_hdr *hdr = NET_IPV4_HDR(pkt);
 	int real_len = net_pkt_get_len(pkt);
-	int pkt_len = (hdr->len[0] << 8) + hdr->len[1];
+	int pkt_len = ntohs(hdr->len);
 	enum net_verdict verdict = NET_DROP;
 
 	if (real_len != pkt_len) {

--- a/subsys/net/ip/utils.c
+++ b/subsys/net/ip/utils.c
@@ -467,8 +467,7 @@ u16_t net_calc_chksum(struct net_pkt *pkt, u8_t proto)
 	switch (net_pkt_family(pkt)) {
 #if defined(CONFIG_NET_IPV4)
 	case AF_INET:
-		upper_layer_len = (NET_IPV4_HDR(pkt)->len[0] << 8) +
-			NET_IPV4_HDR(pkt)->len[1] -
+		upper_layer_len = ntohs(NET_IPV4_HDR(pkt)->len) -
 			net_pkt_ipv6_ext_len(pkt) -
 			net_pkt_ip_hdr_len(pkt);
 

--- a/subsys/net/l2/ethernet/ethernet.c
+++ b/subsys/net/l2/ethernet/ethernet.c
@@ -99,8 +99,7 @@ static inline void ethernet_update_length(struct net_if *iface,
 	 */
 
 	if (net_pkt_family(pkt) == AF_INET) {
-		len = ((NET_IPV4_HDR(pkt)->len[0] << 8) +
-		       NET_IPV4_HDR(pkt)->len[1]);
+		len = ntohs(NET_IPV4_HDR(pkt)->len);
 	} else {
 		len = ((NET_IPV6_HDR(pkt)->len[0] << 8) +
 		       NET_IPV6_HDR(pkt)->len[1]) +

--- a/subsys/usb/class/netusb/function_ecm.c
+++ b/subsys/usb/class/netusb/function_ecm.c
@@ -97,7 +97,7 @@ static size_t ecm_eth_size(void *ecm_pkt, size_t len)
 	switch (ntohs(hdr->type)) {
 	case NET_ETH_PTYPE_IP:
 	case NET_ETH_PTYPE_ARP:
-		ip_len = sys_get_be16(((struct net_ipv4_hdr *)ip_data)->len);
+		ip_len = ntohs(((struct net_ipv4_hdr *)ip_data)->len);
 		break;
 	case NET_ETH_PTYPE_IPV6:
 		ip_len = sys_get_be16(((struct net_ipv6_hdr *)ip_data)->len);

--- a/tests/net/dhcpv4/src/main.c
+++ b/tests/net/dhcpv4/src/main.c
@@ -233,8 +233,7 @@ static void set_ipv4_header(struct net_pkt *pkt)
 	length = sizeof(offer) + sizeof(struct net_ipv4_hdr) +
 		 sizeof(struct net_udp_hdr);
 
-	ipv4->len[1] = length;
-	ipv4->len[0] = length >> 8;
+	ipv4->len = htons(length);
 
 	memset(ipv4->id, 0, 4); /* id and offset */
 

--- a/tests/net/tcp/src/main.c
+++ b/tests/net/tcp/src/main.c
@@ -278,9 +278,8 @@ static void setup_ipv4_tcp(struct net_pkt *pkt,
 
 	ipv4.vhl = 0x45;
 	ipv4.tos = 0;
-	ipv4.len[0] = 0;
-	ipv4.len[1] = NET_TCPH_LEN + sizeof(data) +
-		sizeof(struct net_ipv4_hdr);
+	ipv4.len = htons(NET_TCPH_LEN + sizeof(data) +
+				sizeof(struct net_ipv4_hdr));
 
 	ipv4.proto = IPPROTO_TCP;
 

--- a/tests/net/udp/src/main.c
+++ b/tests/net/udp/src/main.c
@@ -318,9 +318,9 @@ static void setup_ipv4_udp(struct net_pkt *pkt,
 {
 	NET_IPV4_HDR(pkt)->vhl = 0x45;
 	NET_IPV4_HDR(pkt)->tos = 0;
-	NET_IPV4_HDR(pkt)->len[0] = 0;
-	NET_IPV4_HDR(pkt)->len[1] = NET_UDPH_LEN +
-		sizeof(struct net_ipv4_hdr) + strlen(payload);
+	NET_IPV4_HDR(pkt)->len = htons(NET_UDPH_LEN +
+					sizeof(struct net_ipv4_hdr) +
+					strlen(payload));
 
 	NET_IPV4_HDR(pkt)->proto = IPPROTO_UDP;
 


### PR DESCRIPTION
Change the length to uint16_t and work with it through standard htons/ntohs() macros.