### PR TITLE
drivers: nrfx: Allow simultaneous use of SPI_0 and I2C_0 on nRF52810

### DIFF
--- a/drivers/i2c/Kconfig.nrfx
+++ b/drivers/i2c/Kconfig.nrfx
@@ -16,8 +16,11 @@ menuconfig I2C_NRFX
 
 if I2C_NRFX
 
-# Nordic TWIx0 and SPIx0 instances can not be used at the same time.
-if I2C_0 && !SPI_0
+# In most Nordic SoCs the SPI and TWI peripherals with the same instance
+# number share certain resources and cannot be used at the same time.
+# In nRF52810 there are only single instances of these peripherals and
+# they are arranged in a different way so this limitation does not apply.
+if I2C_0 && (!SPI_0 || SOC_NRF52810)
 
 choice I2C_0_NRF_TYPE
 	prompt "I2C Port 0 Driver type"
@@ -40,7 +43,7 @@ config I2C_0_NRF_TWIM
 
 endchoice
 
-endif # I2C_0 && !SPI_0
+endif # I2C_0 && (!SPI_0 || SOC_NRF52810)
 
 # Nordic TWIx1 and SPIx1 instances can not be used at the same time.
 if I2C_1 && !SPI_1

--- a/drivers/spi/Kconfig.nrfx
+++ b/drivers/spi/Kconfig.nrfx
@@ -13,8 +13,11 @@ menuconfig SPI_NRFX
 
 if SPI_NRFX
 
-# Nordic TWIx0 and SPIx0 instances can not be used at the same time.
-if SPI_0 && !I2C_0
+# In most Nordic SoCs the SPI and TWI peripherals with the same instance
+# number share certain resources and cannot be used at the same time.
+# In nRF52810 there are only single instances of these peripherals and
+# they are arranged in a different way so this limitation does not apply.
+if SPI_0 && (!I2C_0 || SOC_NRF52810)
 
 choice
 	prompt "SPI Port 0 Driver type"
@@ -99,7 +102,7 @@ config SPI_0_NRF_DEF
 
 endif # SPI_0_NRF_SPIS
 
-endif # SPI_0 && !I2C_0
+endif # SPI_0 && (!I2C_0 || SOC_NRF52810)
 
 # Nordic TWIx1 and SPIx1 instances can not be used at the same time.
 if SPI_1 && !I2C_1


### PR DESCRIPTION
In most Nordic SoCs the SPI and TWI peripherals with the same instance
number share certain resources and cannot be used at the same time.
In nRF52810 there are only single instances of these peripherals and
they are arranged in a different way so this limitation does not apply.

Signed-off-by: Andrzej Głąbek <andrzej.glabek@nordicsemi.no>