### PR TITLE
kernel: Migrate to new logging subsys

### DIFF
--- a/kernel/userspace.c
+++ b/kernel/userspace.c
@@ -16,7 +16,10 @@
 #include <syscall_handler.h>
 #include <device.h>
 #include <init.h>
-#include <logging/sys_log.h>
+
+#define LOG_MODULE_NAME userspace
+#include <logging/log.h>
+LOG_MODULE_REGISTER();
 
 #define MAX_THREAD_BITS		(CONFIG_MAX_THREAD_BYTES * 8)
 
@@ -137,7 +140,7 @@ void *_impl_k_object_alloc(enum k_objects otype)
 
 	dyn_obj = z_thread_malloc(sizeof(*dyn_obj) + obj_size_get(otype));
 	if (!dyn_obj) {
-		SYS_LOG_WRN("could not allocate kernel object");
+		LOG_WRN("could not allocate kernel object");
 		return NULL;
 	}
 


### PR DESCRIPTION
Migrate from `SYS_LOG` to `LOG` logging mechanism.

Signed-off-by: Olivier Martin <olivier.martin@proglove.de>