### PR TITLE
drivers: watchdog: Migrate to new logging subsys

### DIFF
--- a/drivers/watchdog/Kconfig
+++ b/drivers/watchdog/Kconfig
@@ -28,19 +28,19 @@ config WDT_DISABLE_AT_BOOT
 	help
 	  Disable watchdog at Zephyr system startup.
 
-config SYS_LOG_WDT_LEVEL
+config LOG_WDT_LEVEL
 	int "Watchdog Driver Log level"
-	depends on SYS_LOG
+	depends on LOG
 	default 0
 	range 0 4
 	help
 	  Sets log level for Watchdog drivers.
 	  Levels are:
 	  0 OFF, do not write
-	  1 ERROR, only write SYS_LOG_ERR
-	  2 WARNING, write SYS_LOG_WRN in addition to previous level
-	  3 INFO, write SYS_LOG_INF in addition to previous levels
-	  4 DEBUG, write SYS_LOG_DBG in addition to previous levels
+	  1 ERROR, only write LOG_ERR
+	  2 WARNING, write LOG_WRN in addition to previous level
+	  3 INFO, write LOG_INF in addition to previous levels
+	  4 DEBUG, write LOG_DBG in addition to previous levels
 
 config HAS_WDT_MULTISTAGE
 	bool

--- a/drivers/watchdog/wdt_mcux_wdog.c
+++ b/drivers/watchdog/wdt_mcux_wdog.c
@@ -9,8 +9,8 @@
 #include <clock_control.h>
 #include <fsl_wdog.h>
 
-#define SYS_LOG_LEVEL CONFIG_SYS_LOG_WDT_LEVEL
-#include <logging/sys_log.h>
+#define LOG_LEVEL CONFIG_LOG_WDT_LEVEL
+#include <logging/log.h>
 
 #define MIN_TIMEOUT 4
 
@@ -34,7 +34,7 @@ static int mcux_wdog_setup(struct device *dev, u8_t options)
 	WDOG_Type *base = config->base;
 
 	if (!data->timeout_valid) {
-		SYS_LOG_ERR("No valid timeouts installed");
+		LOG_ERR("No valid timeouts installed");
 		return -EINVAL;
 	}
 
@@ -45,7 +45,7 @@ static int mcux_wdog_setup(struct device *dev, u8_t options)
 		(options & WDT_OPT_PAUSE_HALTED_BY_DBG) == 0;
 
 	WDOG_Init(base, &data->wdog_config);
-	SYS_LOG_DBG("Setup the watchdog");
+	LOG_DBG("Setup the watchdog");
 
 	return 0;
 }
@@ -58,7 +58,7 @@ static int mcux_wdog_disable(struct device *dev)
 
 	WDOG_Deinit(base);
 	data->timeout_valid = false;
-	SYS_LOG_DBG("Disabled the watchdog");
+	LOG_DBG("Disabled the watchdog");
 
 	return 0;
 }
@@ -72,7 +72,7 @@ static int mcux_wdog_install_timeout(struct device *dev,
 	u32_t clock_freq;
 
 	if (data->timeout_valid) {
-		SYS_LOG_ERR("No more timeouts can be installed");
+		LOG_ERR("No more timeouts can be installed");
 		return -ENOMEM;
 	}
 
@@ -101,7 +101,7 @@ static int mcux_wdog_install_timeout(struct device *dev,
 
 	if ((data->wdog_config.timeoutValue < MIN_TIMEOUT) ||
 	    (data->wdog_config.timeoutValue < data->wdog_config.windowValue)) {
-		SYS_LOG_ERR("Invalid timeout");
+		LOG_ERR("Invalid timeout");
 		return -EINVAL;
 	}
 
@@ -119,12 +119,12 @@ static int mcux_wdog_feed(struct device *dev, int channel_id)
 	WDOG_Type *base = config->base;
 
 	if (channel_id != 0) {
-		SYS_LOG_ERR("Invalid channel id");
+		LOG_ERR("Invalid channel id");
 		return -EINVAL;
 	}
 
 	WDOG_Refresh(base);
-	SYS_LOG_DBG("Fed the watchdog");
+	LOG_DBG("Fed the watchdog");
 
 	return 0;
 }

--- a/drivers/watchdog/wdt_nrfx.c
+++ b/drivers/watchdog/wdt_nrfx.c
@@ -7,9 +7,10 @@
 #include <nrfx_wdt.h>
 #include <watchdog.h>
 
-#define SYS_LOG_DOMAIN "wdt_nrfx"
-#define SYS_LOG_LEVEL CONFIG_SYS_LOG_WDT_LEVEL
-#include <logging/sys_log.h>
+#define LOG_MODULE_NAME wdt_nrfx
+#define LOG_LEVEL CONFIG_LOG_WDT_LEVEL
+#include <logging/log.h>
+LOG_MODULE_REGISTER();
 
 DEVICE_DECLARE(wdt_nrfx);
 
@@ -130,7 +131,7 @@ static void wdt_nrf_enable(struct device *dev)
 {
 	ARG_UNUSED(dev);
 	/* Deprecated function. No implementation needed. */
-	SYS_LOG_ERR("Function not implemented!");
+	LOG_ERR("Function not implemented!");
 }
 
 static int wdt_nrf_set_config(struct device *dev, struct wdt_config *config)
@@ -138,7 +139,7 @@ static int wdt_nrf_set_config(struct device *dev, struct wdt_config *config)
 	ARG_UNUSED(dev);
 	ARG_UNUSED(config);
 	/* Deprecated function. No implementation needed. */
-	SYS_LOG_ERR("Function not implemented!");
+	LOG_ERR("Function not implemented!");
 	return 0;
 }
 
@@ -147,14 +148,14 @@ static void wdt_nrf_get_config(struct device *dev, struct wdt_config *config)
 	ARG_UNUSED(dev);
 	ARG_UNUSED(config);
 	/* Deprecated function. No implementation needed. */
-	SYS_LOG_ERR("Function not implemented!");
+	LOG_ERR("Function not implemented!");
 }
 
 static void wdt_nrf_reload(struct device *dev)
 {
 	ARG_UNUSED(dev);
 	/* Deprecated function. No implementation needed. */
-	SYS_LOG_ERR("Function not implemented!");
+	LOG_ERR("Function not implemented!");
 }
 
 static const struct wdt_driver_api wdt_nrf_api = {

--- a/drivers/watchdog/wdt_sam.c
+++ b/drivers/watchdog/wdt_sam.c
@@ -18,8 +18,9 @@
 #include <watchdog.h>
 #include <soc.h>
 
-#define SYS_LOG_DOMAIN "dev/wdt_sam"
-#include <logging/sys_log.h>
+#define LOG_MODULE_NAME wdt_sam
+#include <logging/log.h>
+LOG_MODULE_REGISTER();
 
 /* Device constant configuration parameters */
 struct wdt_sam_dev_cfg {
@@ -33,7 +34,7 @@ static void wdt_sam_enable(struct device *dev)
 {
 	ARG_UNUSED(dev);
 
-	SYS_LOG_ERR("Function not implemented!");
+	LOG_ERR("Function not implemented!");
 }
 
 static int wdt_sam_disable(struct device *dev)
@@ -50,7 +51,7 @@ static int wdt_sam_set_config(struct device *dev, struct wdt_config *config)
 	ARG_UNUSED(dev);
 	ARG_UNUSED(config);
 
-	SYS_LOG_ERR("Function not implemented!");
+	LOG_ERR("Function not implemented!");
 
 	return -ENOTSUP;
 }
@@ -60,14 +61,14 @@ static void wdt_sam_get_config(struct device *dev, struct wdt_config *config)
 	ARG_UNUSED(dev);
 	ARG_UNUSED(config);
 
-	SYS_LOG_ERR("Function not implemented!");
+	LOG_ERR("Function not implemented!");
 }
 
 static void wdt_sam_reload(struct device *dev)
 {
 	ARG_UNUSED(dev);
 
-	SYS_LOG_ERR("Function not implemented!");
+	LOG_ERR("Function not implemented!");
 }
 
 static const struct wdt_driver_api wdt_sam_api = {


### PR DESCRIPTION
Migrate from `SYS_LOG` to `LOG` logging mechanism.

Signed-off-by: Olivier Martin <olivier.martin@proglove.de>