### PR TITLE
log: make name param explicit

### DIFF
--- a/doc/subsystems/logging/logger.rst
+++ b/doc/subsystems/logging/logger.rst
@@ -145,10 +145,9 @@ module can be specified as well.
 
 .. code-block:: c
 
-   #define LOG_MODULE_NAME foo
    #define LOG_LEVEL CONFIG_FOO_LOG_LEVEL /* From foo module Kconfig */
    #include <logging/log.h>
-   LOG_MODULE_REGISTER(); /* One per given LOG_MODULE_NAME */
+   LOG_MODULE_REGISTER(foo); /* One per given log_module_name */
 
 If the module consists of multiple files, then ``LOG_MODULE_REGISTER()`` should
 appear in exactly one of them. Each other file should use
@@ -156,10 +155,9 @@ appear in exactly one of them. Each other file should use
 
 .. code-block:: c
 
-   #define LOG_MODULE_NAME foo
    #define LOG_LEVEL CONFIG_FOO_LOG_LEVEL /* From foo module Kconfig */
    #include <logging/log.h>
-   LOG_MODULE_DECLARE(); /* In all files comprising the module but one */
+   LOG_MODULE_DECLARE(foo); /* In all files comprising the module but one */
 
 Logging in a module instance
 ============================

--- a/include/logging/log.h
+++ b/include/logging/log.h
@@ -298,10 +298,10 @@ int log_printk(const char *fmt, va_list ap);
  *       In other cases, this macro has no effect.
  * @see LOG_MODULE_DECLARE
  */
-#define LOG_MODULE_REGISTER()						\
+#define LOG_MODULE_REGISTER(log_module_name)				\
 	_LOG_EVAL(							\
 		_LOG_LEVEL(),						\
-		(_LOG_MODULE_REGISTER(LOG_MODULE_NAME, _LOG_LEVEL())),	\
+		(_LOG_MODULE_REGISTER(log_module_name, _LOG_LEVEL())),	\
 		()/*Empty*/						\
 	)
 
@@ -336,10 +336,10 @@ int log_printk(const char *fmt, va_list ap);
  *       this macro has no effect.
  * @see LOG_MODULE_REGISTER
  */
-#define LOG_MODULE_DECLARE()						\
+#define LOG_MODULE_DECLARE(log_module_name)				\
 	_LOG_EVAL(							\
 		_LOG_LEVEL(),						\
-		(_LOG_MODULE_DECLARE(LOG_MODULE_NAME, _LOG_LEVEL())),	\
+		(_LOG_MODULE_DECLARE(log_module_name, _LOG_LEVEL())),	\
 		()							\
 		)							\
 

--- a/samples/subsys/logging/logger/src/ext_log_system_adapter.c
+++ b/samples/subsys/logging/logger/src/ext_log_system_adapter.c
@@ -9,7 +9,8 @@
 
 #define LOG_MODULE_NAME ext_log_system
 #include <logging/log.h>
-LOG_MODULE_REGISTER();
+
+LOG_MODULE_REGISTER(ext_log_system);
 
 /** @brief Translation of custom log levels to logging subsystem levels. */
 static const u8_t log_level_lut[] = {

--- a/samples/subsys/logging/logger/src/main.c
+++ b/samples/subsys/logging/logger/src/main.c
@@ -14,9 +14,9 @@
 #include "ext_log_system.h"
 #include "ext_log_system_adapter.h"
 
-#define LOG_MODULE_NAME main
 #include <logging/log.h>
-LOG_MODULE_REGISTER();
+
+LOG_MODULE_REGISTER(main);
 
 /* size of stack area used by each thread */
 #define STACKSIZE 1024

--- a/samples/subsys/logging/logger/src/sample_module.c
+++ b/samples/subsys/logging/logger/src/sample_module.c
@@ -7,7 +7,8 @@
 
 #define LOG_MODULE_NAME foo
 #include <logging/log.h>
-LOG_MODULE_REGISTER();
+
+LOG_MODULE_REGISTER(LOG_MODULE_NAME);
 
 const char *sample_module_name_get(void)
 {

--- a/tests/subsys/logging/log_core/src/log_core_test.c
+++ b/tests/subsys/logging/log_core/src/log_core_test.c
@@ -20,7 +20,8 @@
 
 #define LOG_MODULE_NAME test
 #include "logging/log.h"
-LOG_MODULE_REGISTER();
+
+LOG_MODULE_REGISTER(LOG_MODULE_NAME);
 
 struct backend_cb {
 	size_t counter;


### PR DESCRIPTION
Rather than having some implied name for the logging name, explicitly
pass it in the macros LOG_MODULE_REGISTER & LOG_MODULE_DECLARE.

Signed-off-by: Kumar Gala <kumar.gala@linaro.org>