### PR TITLE
Ethernet start and stop support

### DIFF
--- a/drivers/ethernet/eth_native_posix.c
+++ b/drivers/ethernet/eth_native_posix.c
@@ -539,12 +539,37 @@ static int vlan_setup(struct device *dev, struct net_if *iface,
 }
 #endif /* CONFIG_NET_VLAN */
 
+static int eth_start_device(struct device *dev)
+{
+	struct eth_context *context = dev->driver_data;
+	int ret;
+
+	context->status = true;
+
+	ret = eth_if_up(context->if_name);
+
+	eth_setup_host(context->if_name);
+
+	return ret;
+}
+
+static int eth_stop_device(struct device *dev)
+{
+	struct eth_context *context = dev->driver_data;
+
+	context->status = false;
+
+	return eth_if_down(context->if_name);
+}
+
 static const struct ethernet_api eth_if_api = {
 	.iface_api.init = eth_iface_init,
 	.iface_api.send = eth_send,
 
 	.get_capabilities = eth_posix_native_get_capabilities,
 	.set_config = set_config,
+	.start = eth_start_device,
+	.stop = eth_stop_device,
 
 #if defined(CONFIG_NET_VLAN)
 	.vlan_setup = vlan_setup,

--- a/drivers/ethernet/eth_native_posix_adapt.c
+++ b/drivers/ethernet/eth_native_posix_adapt.c
@@ -191,3 +191,13 @@ int eth_promisc_mode(const char *if_name, bool enable)
 		       if_name, enable ? "on" : "off");
 }
 #endif /* CONFIG_NET_PROMISCUOUS_MODE */
+
+int eth_if_up(const char *if_name)
+{
+	return ssystem("ip link set dev %s up", if_name);
+}
+
+int eth_if_down(const char *if_name)
+{
+	return ssystem("ip link set dev %s down", if_name);
+}

--- a/drivers/ethernet/eth_native_posix_priv.h
+++ b/drivers/ethernet/eth_native_posix_priv.h
@@ -18,6 +18,8 @@ int eth_start_script(const char *if_name);
 int eth_wait_data(int fd);
 ssize_t eth_read_data(int fd, void *buf, size_t buf_len);
 ssize_t eth_write_data(int fd, void *buf, size_t buf_len);
+int eth_if_up(const char *if_name);
+int eth_if_down(const char *if_name);
 
 #if defined(CONFIG_NET_GPTP)
 int eth_clock_gettime(struct net_ptp_time *time);

--- a/include/net/ethernet.h
+++ b/include/net/ethernet.h
@@ -185,6 +185,12 @@ struct ethernet_api {
 	struct net_stats_eth *(*get_stats)(struct device *dev);
 #endif
 
+	/** Start the device */
+	int (*start)(struct device *dev);
+
+	/** Stop the device */
+	int (*stop)(struct device *dev);
+
 	/** Get the device capabilities */
 	enum ethernet_hw_caps (*get_capabilities)(struct device *dev);
 

--- a/subsys/net/l2/ethernet/ethernet.c
+++ b/subsys/net/l2/ethernet/ethernet.c
@@ -576,8 +576,19 @@ static inline u16_t ethernet_reserve(struct net_if *iface, void *unused)
 
 static inline int ethernet_enable(struct net_if *iface, bool state)
 {
+	const struct ethernet_api *eth =
+		net_if_get_device(iface)->driver_api;
+
 	if (!state) {
 		net_arp_clear_cache(iface);
+
+		if (eth->stop) {
+			eth->stop(net_if_get_device(iface));
+		}
+	} else {
+		if (eth->start) {
+			eth->start(net_if_get_device(iface));
+		}
 	}
 
 	return 0;

--- a/tests/net/ipv6/src/main.c
+++ b/tests/net/ipv6/src/main.c
@@ -246,9 +246,9 @@ out:
 
 struct net_test_ipv6 net_test_data;
 
-static struct net_if_api net_test_if_api = {
-	.init = net_test_iface_init,
-	.send = tester_send,
+static const struct ethernet_api net_test_if_api = {
+	.iface_api.init = net_test_iface_init,
+	.iface_api.send = tester_send,
 };
 
 #define _ETH_L2_LAYER ETHERNET_L2


### PR DESCRIPTION
It is possible to start (ifup) or stop (ifdown) ethernet network interface. This is mostly useful for native_posix ethernet driver which does not have physical cable that can toggled by user.