### PR TITLE
subsys: bluetooth: host: Inform the connection handle about the connection parameters

### DIFF
--- a/subsys/bluetooth/host/conn.c
+++ b/subsys/bluetooth/host/conn.c
@@ -1456,6 +1456,11 @@ void bt_conn_set_state(struct bt_conn *conn, bt_conn_state_t state)
 
 		bt_l2cap_connected(conn);
 		notify_connected(conn);
+		/*
+		 * Inform the connection handle about the connection
+		 * parameters
+		 */
+		notify_le_param_updated(conn);
 		break;
 	case BT_CONN_DISCONNECTED:
 		if (conn->type == BT_CONN_TYPE_SCO) {


### PR DESCRIPTION
In some cases, the bluetooth connection parameters are not updated
during the connection. So there is no way for a Zephyr appliication
to know these parameters.
Calling notify_le_param_updated() after the connection is
established allows the application to know the parameters
at the connection.

Signed-off-by: Olivier Martin <olivier.martin@proglove.de>