### PR TITLE
subsys: bluetooth: host: Return a NULL buffer when bt_l2cap_create_pdu() fails

### DIFF
--- a/subsys/bluetooth/host/att.c
+++ b/subsys/bluetooth/host/att.c
@@ -1954,6 +1954,9 @@ struct net_buf *bt_att_create_pdu(struct bt_conn *conn, u8_t op, size_t len)
 	}
 
 	buf = bt_l2cap_create_pdu(NULL, 0);
+	if (buf == NULL) {
+		return NULL;
+	}
 
 	hdr = net_buf_add(buf, sizeof(*hdr));
 	hdr->code = op;

--- a/subsys/bluetooth/host/conn.c
+++ b/subsys/bluetooth/host/conn.c
@@ -1935,7 +1935,9 @@ struct net_buf *bt_conn_create_pdu(struct net_buf_pool *pool, size_t reserve)
 	}
 
 	buf = net_buf_alloc(pool, K_FOREVER);
-	__ASSERT_NO_MSG(buf);
+	if (buf == NULL) {
+		return NULL;
+	}
 
 	reserve += sizeof(struct bt_hci_acl_hdr) + CONFIG_BT_HCI_RESERVE;
 	net_buf_reserve(buf, reserve);


### PR DESCRIPTION
Zephyr's application could request more quickly bluetooth
memory allocations than the bluetooth stack can send them.

We should not assert when we cannot allocate the memory but we
should inform the caller.

Signed-off-by: Olivier Martin <olivier.martin@proglove.de>