### PR TITLE
net: tcp: Fix net_buf leak in case of low available net_buf count

### DIFF
--- a/subsys/net/ip/tcp.c
+++ b/subsys/net/ip/tcp.c
@@ -450,7 +450,7 @@ static int prepare_segment(struct net_tcp *tcp,
 		if (pkt_allocated) {
 			net_pkt_unref(pkt);
 		} else {
-			pkt->frags = tail;
+			net_pkt_frag_add(pkt, tail);
 		}
 
 		return -ENOMEM;


### PR DESCRIPTION
This net_buf leak happends when we are low on available net_buf
count. During TCP segment preparation we do allocate IP header
successfully, but we fail to allocate TCP header. In such case
pkt->frags is not NULL anymore (it contains IP header), but we
override it during TCP header allocation error path. This results
in net_buf containing IP header to never be deallocated, because
it does not belong to any net_pkt anymore.

Use net_pkt_frag_add() function to add tail for future net_pkt
deallocation, instead of assigning tail to pkt->frags pointer.

Fixes: c6407659f3e6 ("net: tcp: Add the frag back to caller allocated
  net_pkt")
Signed-off-by: Marcin Niestroj <m.niestroj@grinn-global.com>