### PR TITLE
ci: use 0.2 docker image

### DIFF
--- a/.shippable.yml
+++ b/.shippable.yml
@@ -23,7 +23,7 @@ build:
         - ${SHIPPABLE_BUILD_DIR}/ccache
     pre_ci_boot:
         image_name: zephyrprojectrtos/ci
-        image_tag: v0.1
+        image_tag: v0.2
         pull: true
         options: "-e HOME=/home/buildslave --privileged=true --tty --net=bridge --user buildslave"
 


### PR DESCRIPTION
We do not have 0.1 anymore, use 0.2 instead.

Signed-off-by: Anas Nashif <anas.nashif@intel.com>