### PR TITLE
syscalls: Define the syscall id's with '#define' instead of enum

### DIFF
--- a/scripts/gen_syscalls.py
+++ b/scripts/gen_syscalls.py
@@ -27,6 +27,8 @@ list_template = """
 #ifndef _ZEPHYR_SYSCALL_LIST_H_
 #define _ZEPHYR_SYSCALL_LIST_H_
 
+%s
+
 #ifndef _ASMLANGUAGE
 
 #include <zephyr/types.h>
@@ -34,10 +36,6 @@ list_template = """
 #ifdef __cplusplus
 extern "C" {
 #endif
-
-enum {
-\t%s
-};
 
 %s
 
@@ -207,9 +205,14 @@ def main():
     # Listing header emitted to stdout
     ids.sort()
     ids.extend(["K_SYSCALL_BAD", "K_SYSCALL_LIMIT"])
+
+    ids_as_defines = ""
+    for i, item in enumerate(ids):
+        ids_as_defines += "#define {} {}\n".format(item, i)
+
     handler_defines = "".join([handler_template % name for name in handlers])
     with open(args.syscall_list, "w") as fp:
-        fp.write(list_template % (",\n\t".join(ids), handler_defines))
+        fp.write(list_template % (ids_as_defines, handler_defines))
 
     os.makedirs(args.base_output, exist_ok=True)
     for fn, invo_list in invocations.items():


### PR DESCRIPTION
We use the code generator 'gen_syscalls.py' to assign numeric
id's to each syscall. These id's have been defined using an enum
like this:

enum {
	K_SYSCALL_ADC_DISABLE,
	K_SYSCALL_ADC_ENABLE,
	K_SYSCALL_LIMIT
};

but enums can not be included by assembly files. So we have been
compiling the enum values and then extracting them into #define's when
needed.

In this situation there happen to not be any benefits of using
'enum' over #define's so we can simplify by initially defining
them with #define instead.

Signed-off-by: Sebastian Bøe <sebastian.boe@nordicsemi.no>