### PR TITLE
drivers: i2c_ll_stm32: Migrate to new logging subsys

### DIFF
--- a/drivers/i2c/Kconfig
+++ b/drivers/i2c/Kconfig
@@ -36,7 +36,7 @@ config I2C_INIT_PRIORITY
 
 config SYS_LOG_I2C_LEVEL
 	int "I2C log level"
-	depends on SYS_LOG
+	depends on SYS_LOG || LOG
 	default 0
 	help
 	  Sets log level for I2C drivers.

--- a/drivers/i2c/i2c_ll_stm32.c
+++ b/drivers/i2c/i2c_ll_stm32.c
@@ -15,8 +15,9 @@
 #include "i2c-priv.h"
 #include "i2c_ll_stm32.h"
 
-#define SYS_LOG_LEVEL CONFIG_SYS_LOG_I2C_LEVEL
-#include <logging/sys_log.h>
+#define LOG_LEVEL CONFIG_SYS_LOG_I2C_LEVEL
+#include <logging/log.h>
+LOG_MODULE_REGISTER(i2c_ll_stm32);
 
 int i2c_stm32_runtime_configure(struct device *dev, u32_t config)
 {
@@ -202,7 +203,7 @@ static int i2c_stm32_init(struct device *dev)
 
 	ret = i2c_stm32_runtime_configure(dev, I2C_MODE_MASTER | bitrate_cfg);
 	if (ret < 0) {
-		SYS_LOG_ERR("i2c: failure initializing");
+		LOG_ERR("i2c: failure initializing");
 		return ret;
 	}
 

--- a/drivers/i2c/i2c_ll_stm32_v1.c
+++ b/drivers/i2c/i2c_ll_stm32_v1.c
@@ -17,8 +17,9 @@
 #include <i2c.h>
 #include "i2c_ll_stm32.h"
 
-#define SYS_LOG_LEVEL CONFIG_SYS_LOG_I2C_LEVEL
-#include <logging/sys_log.h>
+#define LOG_LEVEL CONFIG_SYS_LOG_I2C_LEVEL
+#include <logging/log.h>
+LOG_MODULE_DECLARE(i2c_ll_stm32);
 
 #define I2C_REQUEST_WRITE	0x00
 #define I2C_REQUEST_READ	0x01
@@ -242,11 +243,10 @@ s32_t stm32_i2c_msg_write(struct device *dev, struct i2c_msg *msg,
 	if (data->current.is_nack || data->current.is_err) {
 
 		if (data->current.is_nack)
-			SYS_LOG_DBG("%s: NACK", __func__);
+			LOG_DBG("%s: NACK", __func__);
 
 		if (data->current.is_err)
-			SYS_LOG_DBG("%s: ERR %d", __func__,
-				    data->current.is_err);
+			LOG_DBG("%s: ERR %d", __func__, data->current.is_err);
 
 		data->current.is_nack = 0;
 		data->current.is_err = 0;
@@ -287,7 +287,7 @@ s32_t stm32_i2c_msg_read(struct device *dev, struct i2c_msg *msg,
 
 	LL_I2C_DisableIT_BUF(i2c);
 	if (data->current.is_err) {
-		SYS_LOG_DBG("%s: ERR %d", __func__, data->current.is_err);
+		LOG_DBG("%s: ERR %d", __func__, data->current.is_err);
 		data->current.is_err = 0;
 		ret = -EIO;
 	}
@@ -338,7 +338,7 @@ s32_t stm32_i2c_msg_write(struct device *dev, struct i2c_msg *msg,
 			if (LL_I2C_IsActiveFlag_AF(i2c)) {
 				LL_I2C_ClearFlag_AF(i2c);
 				LL_I2C_GenerateStopCondition(i2c);
-				SYS_LOG_DBG("%s: NACK", __func__);
+				LOG_DBG("%s: NACK", __func__);
 
 				return -EIO;
 			}
@@ -354,7 +354,7 @@ s32_t stm32_i2c_msg_write(struct device *dev, struct i2c_msg *msg,
 			if (LL_I2C_IsActiveFlag_AF(i2c)) {
 				LL_I2C_ClearFlag_AF(i2c);
 				LL_I2C_GenerateStopCondition(i2c);
-				SYS_LOG_DBG("%s: NACK", __func__);
+				LOG_DBG("%s: NACK", __func__);
 
 				return -EIO;
 			}
@@ -424,7 +424,7 @@ s32_t stm32_i2c_msg_read(struct device *dev, struct i2c_msg *msg,
 			if (LL_I2C_IsActiveFlag_AF(i2c)) {
 				LL_I2C_ClearFlag_AF(i2c);
 				LL_I2C_GenerateStopCondition(i2c);
-				SYS_LOG_DBG("%s: NACK", __func__);
+				LOG_DBG("%s: NACK", __func__);
 
 				return -EIO;
 			}

--- a/drivers/i2c/i2c_ll_stm32_v2.c
+++ b/drivers/i2c/i2c_ll_stm32_v2.c
@@ -18,8 +18,9 @@
 #include "i2c-priv.h"
 #include "i2c_ll_stm32.h"
 
-#define SYS_LOG_LEVEL CONFIG_SYS_LOG_I2C_LEVEL
-#include <logging/sys_log.h>
+#define LOG_LEVEL CONFIG_SYS_LOG_I2C_LEVEL
+#include <logging/log.h>
+LOG_MODULE_DECLARE(i2c_ll_stm32);
 
 static inline void msg_init(struct device *dev, struct i2c_msg *msg,
 			    u8_t *next_msg_flags, u16_t slave,
@@ -197,7 +198,7 @@ int i2c_stm32_slave_register(struct device *dev,
 
 	ret = i2c_stm32_runtime_configure(dev, bitrate_cfg);
 	if (ret < 0) {
-		SYS_LOG_ERR("i2c: failure initializing");
+		LOG_ERR("i2c: failure initializing");
 		return ret;
 	}
 
@@ -211,7 +212,7 @@ int i2c_stm32_slave_register(struct device *dev,
 
 	data->slave_attached = true;
 
-	SYS_LOG_DBG("i2c: slave registered");
+	LOG_DBG("i2c: slave registered");
 
 	LL_I2C_EnableIT_ADDR(i2c);
 
@@ -244,7 +245,7 @@ int i2c_stm32_slave_unregister(struct device *dev,
 
 	LL_I2C_Disable(i2c);
 
-	SYS_LOG_DBG("i2c: slave unregistered");
+	LOG_DBG("i2c: slave unregistered");
 
 	return 0;
 }
@@ -396,18 +397,18 @@ int stm32_i2c_msg_write(struct device *dev, struct i2c_msg *msg,
 	return 0;
 error:
 	if (data->current.is_arlo) {
-		SYS_LOG_DBG("%s: ARLO %d", __func__,
+		LOG_DBG("%s: ARLO %d", __func__,
 				    data->current.is_arlo);
 		data->current.is_arlo = 0;
 	}
 
 	if (data->current.is_nack) {
-		SYS_LOG_DBG("%s: NACK", __func__);
+		LOG_DBG("%s: NACK", __func__);
 		data->current.is_nack = 0;
 	}
 
 	if (data->current.is_err) {
-		SYS_LOG_DBG("%s: ERR %d", __func__,
+		LOG_DBG("%s: ERR %d", __func__,
 				    data->current.is_err);
 		data->current.is_err = 0;
 	}
@@ -445,18 +446,18 @@ int stm32_i2c_msg_read(struct device *dev, struct i2c_msg *msg,
 	return 0;
 error:
 	if (data->current.is_arlo) {
-		SYS_LOG_DBG("%s: ARLO %d", __func__,
+		LOG_DBG("%s: ARLO %d", __func__,
 				    data->current.is_arlo);
 		data->current.is_arlo = 0;
 	}
 
 	if (data->current.is_nack) {
-		SYS_LOG_DBG("%s: NACK", __func__);
+		LOG_DBG("%s: NACK", __func__);
 		data->current.is_nack = 0;
 	}
 
 	if (data->current.is_err) {
-		SYS_LOG_DBG("%s: ERR %d", __func__,
+		LOG_DBG("%s: ERR %d", __func__,
 				    data->current.is_err);
 		data->current.is_err = 0;
 	}
@@ -517,7 +518,7 @@ int stm32_i2c_msg_write(struct device *dev, struct i2c_msg *msg,
 	return 0;
 error:
 	LL_I2C_ClearFlag_NACK(i2c);
-	SYS_LOG_DBG("%s: NACK", __func__);
+	LOG_DBG("%s: NACK", __func__);
 
 	return -EIO;
 }
@@ -601,7 +602,7 @@ int stm32_i2c_configure_timing(struct device *dev, u32_t clock)
 	} while (presc < 16);
 
 	if (presc >= 16) {
-		SYS_LOG_DBG("I2C:failed to find prescaler value");
+		LOG_DBG("I2C:failed to find prescaler value");
 		return -EINVAL;
 	}
 


### PR DESCRIPTION
Migrate to `LOG` logging mechanism.

Signed-off-by: Yannis Damigos <giannis.damigos@gmail.com>