### PR TITLE
sanitycheck: Recommend installing "ply" instead of "python3-ply"

### DIFF
--- a/scripts/sanity_chk/expr_parser.py
+++ b/scripts/sanity_chk/expr_parser.py
@@ -15,7 +15,7 @@ try:
     import ply.yacc as yacc
 except ImportError:
     print("PLY library for Python 3 not installed.")
-    print("Please install the python3-ply package using your workstation's")
+    print("Please install the ply package using your workstation's")
     print("package manager or the 'pip' tool.")
     sys.exit(1)
 


### PR DESCRIPTION
Since a distributions name for the ply package may change, the only
constant name which can be used for a recommendation is the name on
PyPi which happens to be "ply".

Signed-off-by: Daniel Egger <daniel@eggers-club.de>