### PR TITLE
ld: Put 'sizeof(struct device)' in the generated offsets header

### DIFF
--- a/include/linker/linker-defs.h
+++ b/include/linker/linker-defs.h
@@ -22,6 +22,7 @@
 #include <toolchain.h>
 #include <linker/sections.h>
 #include <misc/util.h>
+#include <offsets.h>
 
 /* include platform dependent linker-defs */
 #ifdef CONFIG_X86
@@ -52,7 +53,7 @@
  */
 #ifdef CONFIG_DEVICE_POWER_MANAGEMENT
 #define DEVICE_COUNT \
-	((__device_init_end - __device_init_start) / _DEVICE_STRUCT_SIZE)
+	((__device_init_end - __device_init_start) / _DEVICE_STRUCT_SIZEOF)
 #define DEV_BUSY_SZ	(((DEVICE_COUNT + 31) / 32) * 4)
 #define DEVICE_BUSY_BITFIELD()			\
 		FILL(0x00) ;			\

--- a/kernel/include/kernel_offsets.h
+++ b/kernel/include/kernel_offsets.h
@@ -78,7 +78,7 @@ GEN_OFFSET_SYM(_thread_t, custom_data);
 GEN_ABSOLUTE_SYM(K_THREAD_SIZEOF, sizeof(struct k_thread));
 
 /* size of the device structure. Used by linker scripts */
-GEN_ABSOLUTE_SYM(_DEVICE_STRUCT_SIZE, sizeof(struct device));
+GEN_ABSOLUTE_SYM(_DEVICE_STRUCT_SIZEOF, sizeof(struct device));
 
 /* Access to enum values in asm code */
 GEN_ABSOLUTE_SYM(_SYSCALL_LIMIT, K_SYSCALL_LIMIT);

--- a/tests/ztest/include/offsets.h
+++ b/tests/ztest/include/offsets.h
@@ -1,0 +1,14 @@
+#ifndef __GEN_OFFSETS_H__
+#define __GEN_OFFSETS_H__
+
+/*
+ * This file is a fake replacement for
+ * $build_dir/zephyr/include/generated/offsets.h
+ *
+ * The unittest infrastructure does not know how to generate
+ * offsets.h, so until this is supported we fake it with this
+ * file. This allows us to test source files that include offsets.h,
+ * but don't actually use anything from it when unit testing.
+ */
+
+#endif


### PR DESCRIPTION
Rename _DEVICE_STRUCT_SIZE to _DEVICE_STRUCT_SIZEOF. This causes it to
be picked by the script 'gen_offset_header.py' and inserted into the
header file 'include/generated/offsets.h'.

Renaming from x_SIZE to x_SIZEOF will align it's name with the other
symbols that denote a sctruct's size, like K_THREAD_SIZEOF.

Furthermore, it will allow the symbol to be accessed through a header
file define, instead of only as an extern symbol. This is more
flexible, and more aligned with the other symbols in offsets.

Finally, if we are able to move all of offsets.c symbols into the
offsets.h header file we be able to remove offsets.o from the link and
thereby simplify the linking process.

Signed-off-by: Sebastian Bøe <sebastian.boe@nordicsemi.no>