### PR TITLE
misc: dlist: Fixed dlist.h error to pass checkpatch.pl script.

### DIFF
--- a/include/misc/dlist.h
+++ b/include/misc/dlist.h
@@ -103,7 +103,7 @@ typedef struct _dnode sys_dnode_t;
  */
 #define SYS_DLIST_FOR_EACH_NODE_SAFE(__dl, __dn, __dns)			\
 	for (__dn = sys_dlist_peek_head(__dl),				\
-		     __dns = sys_dlist_peek_next(__dl, __dn);  		\
+		     __dns = sys_dlist_peek_next(__dl, __dn);		\
 	     __dn; __dn = __dns,					\
 		     __dns = sys_dlist_peek_next(__dl, __dn))
 
@@ -191,7 +191,7 @@ static inline void sys_dlist_init(sys_dlist_t *list)
 	list->tail = (sys_dnode_t *)list;
 }
 
-#define SYS_DLIST_STATIC_INIT(ptr_to_list) {{(ptr_to_list)}, {(ptr_to_list)}}
+#define SYS_DLIST_STATIC_INIT(ptr_to_list) { {(ptr_to_list)}, {(ptr_to_list)} }
 
 /**
  * @brief check if a node is the list's head


### PR DESCRIPTION
This error is here for a quite long time. It will pop up whenever one will have a need to modify this file.

1. Fixed error: space required after that close brace '}'
2. Fixed warnings:  please, no space before tabs
3. Not fixed warnings: do not add new typedefs

Signed-off-by: Jakub Rzeszutko <jakub.rzeszutko@nordicsemi.no>