### PR TITLE
cmake: Don't propagate zephyr_library_compile_options

### DIFF
--- a/cmake/extensions.cmake
+++ b/cmake/extensions.cmake
@@ -473,7 +473,7 @@ function(zephyr_library_compile_options item)
   add_library(           ${lib_name} INTERFACE)
   target_compile_options(${lib_name} INTERFACE ${item} ${ARGN})
 
-  target_link_libraries(${ZEPHYR_CURRENT_LIBRARY} PUBLIC ${lib_name})
+  target_link_libraries(${ZEPHYR_CURRENT_LIBRARY} PRIVATE ${lib_name})
 endfunction()
 
 function(zephyr_library_cc_option)


### PR DESCRIPTION
zephyr_library_compile_options will apply compile options to a library
with high priority. Due to bug #8438 these compile options have been
applied not only to the library, but also to it's public interface and
therefore to any library that has been linking with the library.

With this patch we now use PRIVATE linking instead of PUBLIC linking
this fixes #8438 .

Signed-off-by: Sebastian Bøe <sebastian.boe@nordicsemi.no>