### PR TITLE
Kconfig: Switch to improved globbing statements (+ document a small Kconfig extension)

### DIFF
--- a/Kconfig.zephyr
+++ b/Kconfig.zephyr
@@ -15,9 +15,9 @@
 # Board defaults should be parsed before SoC defaults, because boards usually
 # overrides SoC values.
 #
-# $ENV_VAR_ARCH and $ENV_VAR_BOARD_DIR might be glob patterns
-gsource "$ENV_VAR_BOARD_DIR/Kconfig.defconfig"
-gsource "arch/$ENV_VAR_ARCH/soc/*/Kconfig.defconfig"
+# Note: $ENV_VAR_ARCH and $ENV_VAR_BOARD_DIR might be glob patterns.
+source "$ENV_VAR_BOARD_DIR/Kconfig.defconfig"
+source "arch/$ENV_VAR_ARCH/soc/*/Kconfig.defconfig"
 
 
 source "arch/Kconfig"

--- a/arch/Kconfig
+++ b/arch/Kconfig
@@ -12,8 +12,8 @@
 # overriden (by defining symbols in multiple locations)
 
 source "boards/Kconfig"
-# $ENV_VAR_ARCH might be a glob pattern
-gsource "arch/$ENV_VAR_ARCH/Kconfig"
+# Note: $ENV_VAR_ARCH might be a glob pattern
+source "arch/$ENV_VAR_ARCH/Kconfig"
 
 
 choice

--- a/arch/arc/Kconfig
+++ b/arch/arc/Kconfig
@@ -10,7 +10,7 @@ choice
 	prompt "ARC SoC Selection"
 	depends on ARC
 
-	gsource "arch/arc/soc/*/Kconfig.soc"
+	source "arch/arc/soc/*/Kconfig.soc"
 endchoice
 
 
@@ -19,7 +19,7 @@ menu "ARC Options"
 
 # Include these first so that any properties (e.g. defaults) below can be
 # overriden (by defining symbols in multiple locations)
-gsource "arch/arc/soc/*/Kconfig"
+source "arch/arc/soc/*/Kconfig"
 
 config ARCH
 	default "arc"

--- a/arch/arm/Kconfig
+++ b/arch/arm/Kconfig
@@ -11,7 +11,7 @@ choice
 	default SOC_SERIES_KINETIS_K6X
 	depends on ARM
 
-	gsource "arch/arm/soc/*/Kconfig.soc"
+	source "arch/arm/soc/*/Kconfig.soc"
 endchoice
 
 menu "ARM Options"
@@ -20,7 +20,7 @@ menu "ARM Options"
 menu "SoC Configuration"
 # Include these first so that any properties (e.g. defaults) below can be
 # overriden (by defining symbols in multiple locations)
-gsource "arch/arm/soc/*/Kconfig"
+source "arch/arm/soc/*/Kconfig"
 endmenu
 
 source "arch/arm/core/Kconfig"

--- a/arch/arm/soc/arm/Kconfig
+++ b/arch/arm/soc/arm/Kconfig
@@ -14,5 +14,5 @@ config SOC_FAMILY
 	string
 	default "arm"
 
-gsource "arch/arm/soc/arm/*/Kconfig.soc"
+source "arch/arm/soc/arm/*/Kconfig.soc"
 endif # SOC_FAMILY_ARM

--- a/arch/arm/soc/arm/Kconfig.defconfig
+++ b/arch/arm/soc/arm/Kconfig.defconfig
@@ -5,4 +5,4 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 
-gsource "arch/arm/soc/arm/*/Kconfig.defconfig.series"
+source "arch/arm/soc/arm/*/Kconfig.defconfig.series"

--- a/arch/arm/soc/arm/Kconfig.soc
+++ b/arch/arm/soc/arm/Kconfig.soc
@@ -5,4 +5,4 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 
-gsource "arch/arm/soc/arm/*/Kconfig.series"
+source "arch/arm/soc/arm/*/Kconfig.series"

--- a/arch/arm/soc/arm/beetle/Kconfig.defconfig.series
+++ b/arch/arm/soc/arm/beetle/Kconfig.defconfig.series
@@ -8,7 +8,7 @@
 
 if SOC_SERIES_BEETLE
 
-gsource "arch/arm/soc/arm/beetle/Kconfig.defconfig.beetle*"
+source "arch/arm/soc/arm/beetle/Kconfig.defconfig.beetle*"
 
 config SOC_SERIES
 	default "beetle"

--- a/arch/arm/soc/arm/mps2/Kconfig.defconfig.series
+++ b/arch/arm/soc/arm/mps2/Kconfig.defconfig.series
@@ -13,6 +13,6 @@ config SYS_CLOCK_HW_CYCLES_PER_SEC
 	int
 	default 25000000
 
-gsource "arch/arm/soc/arm/mps2/Kconfig.defconfig.mps2*"
+source "arch/arm/soc/arm/mps2/Kconfig.defconfig.mps2*"
 
 endif # SOC_SERIES_MPS2

--- a/arch/arm/soc/atmel_sam/Kconfig
+++ b/arch/arm/soc/atmel_sam/Kconfig
@@ -14,6 +14,6 @@ config SOC_FAMILY
 	default "atmel_sam"
 
 # Select SoC Part No. and configuration options
-gsource "arch/arm/soc/atmel_sam/*/Kconfig.soc"
+source "arch/arm/soc/atmel_sam/*/Kconfig.soc"
 
 endif # SOC_FAMILY_SAM

--- a/arch/arm/soc/atmel_sam/Kconfig.defconfig
+++ b/arch/arm/soc/atmel_sam/Kconfig.defconfig
@@ -4,7 +4,7 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 
-gsource "arch/arm/soc/atmel_sam/*/Kconfig.defconfig.series"
+source "arch/arm/soc/atmel_sam/*/Kconfig.defconfig.series"
 
 if SOC_FAMILY_SAM
 

--- a/arch/arm/soc/atmel_sam/Kconfig.soc
+++ b/arch/arm/soc/atmel_sam/Kconfig.soc
@@ -4,4 +4,4 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 
-gsource "arch/arm/soc/atmel_sam/*/Kconfig.series"
+source "arch/arm/soc/atmel_sam/*/Kconfig.series"

--- a/arch/arm/soc/atmel_sam0/Kconfig
+++ b/arch/arm/soc/atmel_sam0/Kconfig
@@ -13,5 +13,5 @@ config SOC_FAMILY
 	default "atmel_sam0"
 
 source arch/arm/soc/atmel_sam0/common/Kconfig.samd2x
-gsource "arch/arm/soc/atmel_sam0/*/Kconfig.soc"
+source "arch/arm/soc/atmel_sam0/*/Kconfig.soc"
 endif

--- a/arch/arm/soc/atmel_sam0/Kconfig.defconfig
+++ b/arch/arm/soc/atmel_sam0/Kconfig.defconfig
@@ -3,4 +3,4 @@
 # Copyright (c) 2017 Google LLC.
 # SPDX-License-Identifier: Apache-2.0
 
-gsource "arch/arm/soc/atmel_sam0/*/Kconfig.defconfig.series"
+source "arch/arm/soc/atmel_sam0/*/Kconfig.defconfig.series"

--- a/arch/arm/soc/atmel_sam0/Kconfig.soc
+++ b/arch/arm/soc/atmel_sam0/Kconfig.soc
@@ -3,4 +3,4 @@
 # Copyright (c) 2017 Google LLC.
 # SPDX-License-Identifier: Apache-2.0
 
-gsource "arch/arm/soc/atmel_sam0/*/Kconfig.series"
+source "arch/arm/soc/atmel_sam0/*/Kconfig.series"

--- a/arch/arm/soc/nordic_nrf/Kconfig
+++ b/arch/arm/soc/nordic_nrf/Kconfig
@@ -15,6 +15,6 @@ config SOC_FAMILY
 	default "nordic_nrf"
 
 source "arch/arm/soc/nordic_nrf/Kconfig.peripherals"
-gsource "arch/arm/soc/nordic_nrf/*/Kconfig.soc"
+source "arch/arm/soc/nordic_nrf/*/Kconfig.soc"
 
 endif # SOC_FAMILY_NRF

--- a/arch/arm/soc/nordic_nrf/Kconfig.defconfig
+++ b/arch/arm/soc/nordic_nrf/Kconfig.defconfig
@@ -7,7 +7,7 @@
 
 if SOC_FAMILY_NRF
 
-gsource "arch/arm/soc/nordic_nrf/*/Kconfig.defconfig.series"
+source "arch/arm/soc/nordic_nrf/*/Kconfig.defconfig.series"
 
 config BUILD_OUTPUT_HEX
 	default y

--- a/arch/arm/soc/nordic_nrf/Kconfig.soc
+++ b/arch/arm/soc/nordic_nrf/Kconfig.soc
@@ -5,5 +5,5 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 
-gsource "arch/arm/soc/nordic_nrf/*/Kconfig.series"
+source "arch/arm/soc/nordic_nrf/*/Kconfig.series"
 

--- a/arch/arm/soc/nordic_nrf/nrf51/Kconfig.defconfig.series
+++ b/arch/arm/soc/nordic_nrf/nrf51/Kconfig.defconfig.series
@@ -8,7 +8,7 @@
 
 if SOC_SERIES_NRF51X
 
-gsource "arch/arm/soc/nordic_nrf/nrf51/Kconfig.defconfig.nrf51*"
+source "arch/arm/soc/nordic_nrf/nrf51/Kconfig.defconfig.nrf51*"
 
 config SOC_SERIES
 	default "nrf51"

--- a/arch/arm/soc/nordic_nrf/nrf52/Kconfig.defconfig.series
+++ b/arch/arm/soc/nordic_nrf/nrf52/Kconfig.defconfig.series
@@ -7,7 +7,7 @@
 
 if SOC_SERIES_NRF52X
 
-gsource "arch/arm/soc/nordic_nrf/nrf52/Kconfig.defconfig.nrf52*"
+source "arch/arm/soc/nordic_nrf/nrf52/Kconfig.defconfig.nrf52*"
 
 config SOC_SERIES
 	default "nrf52"

--- a/arch/arm/soc/nxp_imx/Kconfig
+++ b/arch/arm/soc/nxp_imx/Kconfig
@@ -14,7 +14,7 @@ config SOC_FAMILY
 	string
 	default "nxp_imx"
 
-gsource "arch/arm/soc/nxp_imx/*/Kconfig.soc"
+source "arch/arm/soc/nxp_imx/*/Kconfig.soc"
 
 config SOC_PART_NUMBER
 	string

--- a/arch/arm/soc/nxp_imx/Kconfig.defconfig
+++ b/arch/arm/soc/nxp_imx/Kconfig.defconfig
@@ -4,4 +4,4 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 
-gsource "arch/arm/soc/nxp_imx/*/Kconfig.defconfig.series"
+source "arch/arm/soc/nxp_imx/*/Kconfig.defconfig.series"

--- a/arch/arm/soc/nxp_imx/Kconfig.soc
+++ b/arch/arm/soc/nxp_imx/Kconfig.soc
@@ -4,4 +4,4 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 
-gsource "arch/arm/soc/nxp_imx/*/Kconfig.series"
+source "arch/arm/soc/nxp_imx/*/Kconfig.series"

--- a/arch/arm/soc/nxp_imx/rt/Kconfig.defconfig.series
+++ b/arch/arm/soc/nxp_imx/rt/Kconfig.defconfig.series
@@ -15,6 +15,6 @@ config NUM_IRQS
 	# must be >= the highest interrupt number used
 	default 160
 
-gsource "arch/arm/soc/nxp_imx/rt/Kconfig.defconfig.mimxrt*"
+source "arch/arm/soc/nxp_imx/rt/Kconfig.defconfig.mimxrt*"
 
 endif # SOC_SERIES_IMX_RT

--- a/arch/arm/soc/nxp_kinetis/Kconfig
+++ b/arch/arm/soc/nxp_kinetis/Kconfig
@@ -15,7 +15,7 @@ config SOC_FAMILY
 	string
 	default "nxp_kinetis"
 
-gsource "arch/arm/soc/nxp_kinetis/*/Kconfig.soc"
+source "arch/arm/soc/nxp_kinetis/*/Kconfig.soc"
 
 config SOC_PART_NUMBER
 	string

--- a/arch/arm/soc/nxp_kinetis/Kconfig.defconfig
+++ b/arch/arm/soc/nxp_kinetis/Kconfig.defconfig
@@ -1,1 +1,1 @@
-gsource "arch/arm/soc/nxp_kinetis/*/Kconfig.defconfig.series"
+source "arch/arm/soc/nxp_kinetis/*/Kconfig.defconfig.series"

--- a/arch/arm/soc/nxp_kinetis/Kconfig.soc
+++ b/arch/arm/soc/nxp_kinetis/Kconfig.soc
@@ -4,4 +4,4 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 
-gsource "arch/arm/soc/nxp_kinetis/*/Kconfig.series"
+source "arch/arm/soc/nxp_kinetis/*/Kconfig.series"

--- a/arch/arm/soc/nxp_kinetis/k6x/Kconfig.defconfig.series
+++ b/arch/arm/soc/nxp_kinetis/k6x/Kconfig.defconfig.series
@@ -16,6 +16,6 @@ config NUM_IRQS
 	# must be >= the highest interrupt number used
 	default 86
 
-gsource "arch/arm/soc/nxp_kinetis/k6x/Kconfig.defconfig.mk*"
+source "arch/arm/soc/nxp_kinetis/k6x/Kconfig.defconfig.mk*"
 
 endif # SOC_SERIES_KINETIS_K6X

--- a/arch/arm/soc/nxp_kinetis/kl2x/Kconfig.defconfig.series
+++ b/arch/arm/soc/nxp_kinetis/kl2x/Kconfig.defconfig.series
@@ -10,6 +10,6 @@ if SOC_SERIES_KINETIS_KL2X
 config SOC_SERIES
 	default "kl2x"
 
-gsource "arch/arm/soc/nxp_kinetis/kl2x/Kconfig.defconfig.mk*"
+source "arch/arm/soc/nxp_kinetis/kl2x/Kconfig.defconfig.mk*"
 
 endif # SOC_SERIES_KINETIS_KL2X

--- a/arch/arm/soc/nxp_kinetis/kwx/Kconfig.defconfig.series
+++ b/arch/arm/soc/nxp_kinetis/kwx/Kconfig.defconfig.series
@@ -10,6 +10,6 @@ if SOC_SERIES_KINETIS_KWX
 config SOC_SERIES
 	default "kwx"
 
-gsource "arch/arm/soc/nxp_kinetis/kwx/Kconfig.defconfig.mk*"
+source "arch/arm/soc/nxp_kinetis/kwx/Kconfig.defconfig.mk*"
 
 endif # SOC_SERIES_KINETIS_KWX

--- a/arch/arm/soc/nxp_lpc/Kconfig
+++ b/arch/arm/soc/nxp_lpc/Kconfig
@@ -14,7 +14,7 @@ config SOC_FAMILY
 	string
 	default "nxp_lpc"
 
-gsource "arch/arm/soc/nxp_lpc/*/Kconfig.soc"
+source "arch/arm/soc/nxp_lpc/*/Kconfig.soc"
 
 config SOC_PART_NUMBER
 	string

--- a/arch/arm/soc/nxp_lpc/Kconfig.defconfig
+++ b/arch/arm/soc/nxp_lpc/Kconfig.defconfig
@@ -4,4 +4,4 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 
-gsource "arch/arm/soc/nxp_lpc/*/Kconfig.defconfig.series"
+source "arch/arm/soc/nxp_lpc/*/Kconfig.defconfig.series"

--- a/arch/arm/soc/nxp_lpc/Kconfig.soc
+++ b/arch/arm/soc/nxp_lpc/Kconfig.soc
@@ -4,4 +4,4 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 
-gsource "arch/arm/soc/nxp_lpc/*/Kconfig.series"
+source "arch/arm/soc/nxp_lpc/*/Kconfig.series"

--- a/arch/arm/soc/nxp_lpc/lpc54xxx/Kconfig.defconfig.series
+++ b/arch/arm/soc/nxp_lpc/lpc54xxx/Kconfig.defconfig.series
@@ -15,6 +15,6 @@ config NUM_IRQS
 	# must be >= the highest interrupt number used
 	default 40
 
-gsource "arch/arm/soc/nxp_lpc/lpc54xxx/Kconfig.defconfig.lp*"
+source "arch/arm/soc/nxp_lpc/lpc54xxx/Kconfig.defconfig.lp*"
 
 endif # SOC_SERIES_LPC54XXX

--- a/arch/arm/soc/silabs_exx32/Kconfig
+++ b/arch/arm/soc/silabs_exx32/Kconfig
@@ -13,7 +13,7 @@ config SOC_FAMILY
 	string
 	default "silabs_exx32"
 
-gsource "arch/arm/soc/silabs_exx32/*/Kconfig.soc"
+source "arch/arm/soc/silabs_exx32/*/Kconfig.soc"
 
 config SOC_PART_NUMBER
 	string

--- a/arch/arm/soc/silabs_exx32/Kconfig.defconfig
+++ b/arch/arm/soc/silabs_exx32/Kconfig.defconfig
@@ -1,1 +1,1 @@
-gsource "arch/arm/soc/silabs_exx32/*/Kconfig.defconfig.series"
+source "arch/arm/soc/silabs_exx32/*/Kconfig.defconfig.series"

--- a/arch/arm/soc/silabs_exx32/Kconfig.soc
+++ b/arch/arm/soc/silabs_exx32/Kconfig.soc
@@ -4,4 +4,4 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 
-gsource "arch/arm/soc/silabs_exx32/*/Kconfig.series"
+source "arch/arm/soc/silabs_exx32/*/Kconfig.series"

--- a/arch/arm/soc/silabs_exx32/efm32wg/Kconfig.defconfig.series
+++ b/arch/arm/soc/silabs_exx32/efm32wg/Kconfig.defconfig.series
@@ -16,6 +16,6 @@ config NUM_IRQS
 	# must be >= the highest interrupt number used
 	default 39
 
-gsource "arch/arm/soc/silabs_exx32/efm32wg/Kconfig.defconfig.e*"
+source "arch/arm/soc/silabs_exx32/efm32wg/Kconfig.defconfig.e*"
 
 endif # SOC_SERIES_EFM32WG

--- a/arch/arm/soc/silabs_exx32/efr32fg1p/Kconfig.defconfig.series
+++ b/arch/arm/soc/silabs_exx32/efr32fg1p/Kconfig.defconfig.series
@@ -16,6 +16,6 @@ config NUM_IRQS
 	# must be >= the highest interrupt number used
 	default 33
 
-gsource "arch/arm/soc/silabs_exx32/efr32fg1p/Kconfig.defconfig.e*"
+source "arch/arm/soc/silabs_exx32/efr32fg1p/Kconfig.defconfig.e*"
 
 endif # SOC_SERIES_EFR32FG1P

--- a/arch/arm/soc/st_stm32/Kconfig
+++ b/arch/arm/soc/st_stm32/Kconfig
@@ -25,6 +25,6 @@ config STM32_ARM_MPU_ENABLE
 	help
 	  Enable MPU support on STM32 SoCs
 
-gsource "arch/arm/soc/st_stm32/*/Kconfig.soc"
+source "arch/arm/soc/st_stm32/*/Kconfig.soc"
 
 endif # SOC_FAMILY_STM32

--- a/arch/arm/soc/st_stm32/Kconfig.defconfig
+++ b/arch/arm/soc/st_stm32/Kconfig.defconfig
@@ -1,1 +1,1 @@
-gsource "arch/arm/soc/st_stm32/*/Kconfig.defconfig.series"
+source "arch/arm/soc/st_stm32/*/Kconfig.defconfig.series"

--- a/arch/arm/soc/st_stm32/Kconfig.soc
+++ b/arch/arm/soc/st_stm32/Kconfig.soc
@@ -5,4 +5,4 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 
-gsource "arch/arm/soc/st_stm32/*/Kconfig.series"
+source "arch/arm/soc/st_stm32/*/Kconfig.series"

--- a/arch/arm/soc/st_stm32/stm32f0/Kconfig.defconfig.series
+++ b/arch/arm/soc/st_stm32/stm32f0/Kconfig.defconfig.series
@@ -7,7 +7,7 @@
 
 if SOC_SERIES_STM32F0X
 
-gsource "arch/arm/soc/st_stm32/stm32f0/Kconfig.defconfig.stm32f0*"
+source "arch/arm/soc/st_stm32/stm32f0/Kconfig.defconfig.stm32f0*"
 
 config SOC_SERIES
 	default "stm32f0"

--- a/arch/arm/soc/st_stm32/stm32f1/Kconfig.defconfig.series
+++ b/arch/arm/soc/st_stm32/stm32f1/Kconfig.defconfig.series
@@ -7,7 +7,7 @@
 
 if SOC_SERIES_STM32F1X
 
-gsource "arch/arm/soc/st_stm32/stm32f1/Kconfig.defconfig.stm32f1*"
+source "arch/arm/soc/st_stm32/stm32f1/Kconfig.defconfig.stm32f1*"
 
 config SOC_SERIES
 	default "stm32f1"

--- a/arch/arm/soc/st_stm32/stm32f2/Kconfig.defconfig.series
+++ b/arch/arm/soc/st_stm32/stm32f2/Kconfig.defconfig.series
@@ -7,7 +7,7 @@
 
 if SOC_SERIES_STM32F2X
 
-gsource "arch/arm/soc/st_stm32/stm32f2/Kconfig.defconfig.stm32f2*"
+source "arch/arm/soc/st_stm32/stm32f2/Kconfig.defconfig.stm32f2*"
 
 config SOC_SERIES
 	default "stm32f2"

--- a/arch/arm/soc/st_stm32/stm32f3/Kconfig.defconfig.series
+++ b/arch/arm/soc/st_stm32/stm32f3/Kconfig.defconfig.series
@@ -7,7 +7,7 @@
 
 if SOC_SERIES_STM32F3X
 
-gsource "arch/arm/soc/st_stm32/stm32f3/Kconfig.defconfig.stm32f3*"
+source "arch/arm/soc/st_stm32/stm32f3/Kconfig.defconfig.stm32f3*"
 
 config SOC_SERIES
 	default "stm32f3"

--- a/arch/arm/soc/st_stm32/stm32f4/Kconfig.defconfig.series
+++ b/arch/arm/soc/st_stm32/stm32f4/Kconfig.defconfig.series
@@ -7,7 +7,7 @@
 
 if SOC_SERIES_STM32F4X
 
-gsource "arch/arm/soc/st_stm32/stm32f4/Kconfig.defconfig.stm32f4*"
+source "arch/arm/soc/st_stm32/stm32f4/Kconfig.defconfig.stm32f4*"
 
 config SOC_SERIES
 	default "stm32f4"

--- a/arch/arm/soc/st_stm32/stm32f7/Kconfig.defconfig.series
+++ b/arch/arm/soc/st_stm32/stm32f7/Kconfig.defconfig.series
@@ -7,7 +7,7 @@
 
 if SOC_SERIES_STM32F7X
 
-gsource "arch/arm/soc/st_stm32/stm32f7/Kconfig.defconfig.stm32f7*"
+source "arch/arm/soc/st_stm32/stm32f7/Kconfig.defconfig.stm32f7*"
 
 config SOC_SERIES
 	default "stm32f7"

--- a/arch/arm/soc/st_stm32/stm32l0/Kconfig.defconfig.series
+++ b/arch/arm/soc/st_stm32/stm32l0/Kconfig.defconfig.series
@@ -7,7 +7,7 @@
 
 if SOC_SERIES_STM32L0X
 
-gsource "arch/arm/soc/st_stm32/stm32l0/Kconfig.defconfig.stm32l0*"
+source "arch/arm/soc/st_stm32/stm32l0/Kconfig.defconfig.stm32l0*"
 
 config SOC_SERIES
 	default "stm32l0"

--- a/arch/arm/soc/st_stm32/stm32l4/Kconfig.defconfig.series
+++ b/arch/arm/soc/st_stm32/stm32l4/Kconfig.defconfig.series
@@ -8,7 +8,7 @@
 
 if SOC_SERIES_STM32L4X
 
-gsource "arch/arm/soc/st_stm32/stm32l4/Kconfig.defconfig.stm32l4*"
+source "arch/arm/soc/st_stm32/stm32l4/Kconfig.defconfig.stm32l4*"
 
 config SOC_SERIES
 	default "stm32l4"

--- a/arch/arm/soc/ti_simplelink/Kconfig
+++ b/arch/arm/soc/ti_simplelink/Kconfig
@@ -10,5 +10,5 @@ config SOC_FAMILY
 	string
 	default "ti_simplelink"
 
-gsource "arch/arm/soc/ti_simplelink/*/Kconfig.soc"
+source "arch/arm/soc/ti_simplelink/*/Kconfig.soc"
 endif # SOC_FAMILY_TISIMPLELINK

--- a/arch/arm/soc/ti_simplelink/Kconfig.defconfig
+++ b/arch/arm/soc/ti_simplelink/Kconfig.defconfig
@@ -1,1 +1,1 @@
-gsource "arch/arm/soc/ti_simplelink/*/Kconfig.defconfig.series"
+source "arch/arm/soc/ti_simplelink/*/Kconfig.defconfig.series"

--- a/arch/arm/soc/ti_simplelink/Kconfig.soc
+++ b/arch/arm/soc/ti_simplelink/Kconfig.soc
@@ -1,4 +1,4 @@
 # Kconfig - Texas Instruments SimpleLink Family
 #
 
-gsource "arch/arm/soc/ti_simplelink/*/Kconfig.series"
+source "arch/arm/soc/ti_simplelink/*/Kconfig.series"

--- a/arch/arm/soc/ti_simplelink/cc32xx/Kconfig.defconfig.series
+++ b/arch/arm/soc/ti_simplelink/cc32xx/Kconfig.defconfig.series
@@ -3,7 +3,7 @@
 
 if SOC_SERIES_CC32XX
 
-gsource "arch/arm/soc/ti_simplelink/cc32xx/Kconfig.defconfig.cc32*"
+source "arch/arm/soc/ti_simplelink/cc32xx/Kconfig.defconfig.cc32*"
 
 config SOC_SERIES
 	default "cc32xx"

--- a/arch/arm/soc/ti_simplelink/msp432p4xx/Kconfig.defconfig.series
+++ b/arch/arm/soc/ti_simplelink/msp432p4xx/Kconfig.defconfig.series
@@ -7,7 +7,7 @@
 
 if SOC_SERIES_MSP432P4XX
 
-gsource "arch/arm/soc/ti_simplelink/msp432p4xx/Kconfig.defconfig.msp432p4*"
+source "arch/arm/soc/ti_simplelink/msp432p4xx/Kconfig.defconfig.msp432p4*"
 
 config SOC_SERIES
 	default "msp432p4xx"

--- a/arch/nios2/Kconfig
+++ b/arch/nios2/Kconfig
@@ -7,7 +7,7 @@
 choice
 	prompt "Nios II configuration selection"
 	depends on NIOS2
-	gsource "arch/nios2/soc/*/Kconfig.soc"
+	source "arch/nios2/soc/*/Kconfig.soc"
 endchoice
 
 menu "Nios II Options"
@@ -15,7 +15,9 @@ menu "Nios II Options"
 
 # Include these first so that any properties (e.g. defaults) below can be
 # overriden (by defining symbols in multiple locations)
-gsource "arch/nios2/soc/*/Kconfig"
+#
+# (No SoC-specific Kconfig files as of writing, hence the optional source.)
+osource "arch/nios2/soc/*/Kconfig"
 
 config ARCH
 	string

--- a/arch/posix/Kconfig
+++ b/arch/posix/Kconfig
@@ -10,7 +10,7 @@ choice
 	prompt "POSIX Configuration Selection"
 	depends on ARCH_POSIX
 
-	gsource "arch/posix/soc/*/Kconfig.soc"
+	source "arch/posix/soc/*/Kconfig.soc"
 endchoice
 
 menu "POSIX (native) Options"
@@ -18,7 +18,9 @@ menu "POSIX (native) Options"
 
 # Include these first so that any properties (e.g. defaults) below can be
 # overriden (by defining symbols in multiple locations)
-gsource "arch/posix/soc/*/Kconfig"
+#
+# (No SoC-specific Kconfig files as of writing, hence the optional source.)
+osource "arch/posix/soc/*/Kconfig"
 
 config ARCH
 	default "posix"

--- a/arch/riscv32/Kconfig
+++ b/arch/riscv32/Kconfig
@@ -7,7 +7,7 @@
 choice
 	prompt "RISCV32 configuration selection"
 	depends on RISCV32
-	gsource "arch/riscv32/soc/*/Kconfig.soc"
+	source "arch/riscv32/soc/*/Kconfig.soc"
 endchoice
 
 menu "RISCV32 Options"
@@ -15,7 +15,7 @@ menu "RISCV32 Options"
 
 # Include these first so that any properties (e.g. defaults) below can be
 # overriden (by defining symbols in multiple locations)
-gsource "arch/riscv32/soc/*/Kconfig"
+source "arch/riscv32/soc/*/Kconfig"
 
 config ARCH
 	string

--- a/arch/riscv32/soc/riscv-privilege/Kconfig
+++ b/arch/riscv32/soc/riscv-privilege/Kconfig
@@ -22,4 +22,4 @@ config RISCV_HAS_PLIC
 	  Does the SOC provide support for a Platform Level Interrupt Controller
 
 
-gsource "arch/riscv32/soc/riscv-privilege/*/Kconfig.soc"
+source "arch/riscv32/soc/riscv-privilege/*/Kconfig.soc"

--- a/arch/riscv32/soc/riscv-privilege/Kconfig.defconfig
+++ b/arch/riscv32/soc/riscv-privilege/Kconfig.defconfig
@@ -4,4 +4,4 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 #
-gsource "arch/riscv32/soc/riscv-privilege/*/Kconfig.defconfig.series"
+source "arch/riscv32/soc/riscv-privilege/*/Kconfig.defconfig.series"

--- a/arch/riscv32/soc/riscv-privilege/Kconfig.soc
+++ b/arch/riscv32/soc/riscv-privilege/Kconfig.soc
@@ -5,4 +5,4 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 
-gsource "arch/riscv32/soc/riscv-privilege/*/Kconfig.series"
+source "arch/riscv32/soc/riscv-privilege/*/Kconfig.series"

--- a/arch/x86/Kconfig
+++ b/arch/x86/Kconfig
@@ -10,7 +10,7 @@ choice
 	prompt "x86 SoC Selection"
 	depends on X86
 
-	gsource "arch/x86/soc/*/Kconfig.soc"
+	source "arch/x86/soc/*/Kconfig.soc"
 endchoice
 
 menu "X86 Architecture Options"
@@ -18,7 +18,7 @@ menu "X86 Architecture Options"
 
 # Include these first so that any properties (e.g. defaults) below can be
 # overriden (by defining symbols in multiple locations)
-gsource "arch/x86/soc/*/Kconfig"
+source "arch/x86/soc/*/Kconfig"
 
 config ARCH
 	default "x86"

--- a/arch/x86/soc/intel_quark/Kconfig
+++ b/arch/x86/soc/intel_quark/Kconfig
@@ -13,6 +13,6 @@ config SOC_FAMILY
 	default "intel_quark"
 endif
 
-gsource "arch/x86/soc/intel_quark/*/Kconfig.soc"
+source "arch/x86/soc/intel_quark/*/Kconfig.soc"
 
-gsource "arch/x86/soc/intel_quark/*/Kconfig"
+source "arch/x86/soc/intel_quark/*/Kconfig"

--- a/arch/x86/soc/intel_quark/Kconfig.defconfig
+++ b/arch/x86/soc/intel_quark/Kconfig.defconfig
@@ -1,1 +1,1 @@
-gsource "arch/x86/soc/intel_quark/*/Kconfig.defconfig.series"
+source "arch/x86/soc/intel_quark/*/Kconfig.defconfig.series"

--- a/arch/x86/soc/intel_quark/Kconfig.soc
+++ b/arch/x86/soc/intel_quark/Kconfig.soc
@@ -4,4 +4,4 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 
-gsource "arch/x86/soc/intel_quark/*/Kconfig.series"
+source "arch/x86/soc/intel_quark/*/Kconfig.series"

--- a/arch/x86/soc/intel_quark/quark_se/Kconfig.defconfig.series
+++ b/arch/x86/soc/intel_quark/quark_se/Kconfig.defconfig.series
@@ -201,7 +201,7 @@ config USB_DW_IRQ_PRI
 	default 3
 endif # USB
 
-gsource "arch/x86/soc/intel_quark/quark_se/Kconfig.defconfig.quark_se*"
-gsource "arch/x86/soc/intel_quark/quark_se/Kconfig.defconfig.curie*"
+source "arch/x86/soc/intel_quark/quark_se/Kconfig.defconfig.quark_se*"
+source "arch/x86/soc/intel_quark/quark_se/Kconfig.defconfig.curie*"
 
 endif # SOC_SERIES_QUARK_SE

--- a/arch/xtensa/Kconfig
+++ b/arch/xtensa/Kconfig
@@ -6,7 +6,7 @@
 choice
 	prompt "XTENSA core Selection"
 	depends on XTENSA
-	gsource "arch/xtensa/soc/*/Kconfig.soc"
+	source "arch/xtensa/soc/*/Kconfig.soc"
 endchoice
 
 menu "XTENSA Options"
@@ -16,7 +16,9 @@ menu "Specific core configuration"
 
 # Include these first so that any properties (e.g. defaults) below can be
 # overriden (by defining symbols in multiple locations)
-gsource "arch/xtensa/soc/*/Kconfig"
+#
+# (No SoC-specific Kconfig files as of writing, hence the optional source.)
+osource "arch/xtensa/soc/*/Kconfig"
 
 config IRQ_OFFLOAD_INTNUM
 	int "IRQ offload SW interrupt index"

--- a/boards/Kconfig
+++ b/boards/Kconfig
@@ -13,16 +13,17 @@ config QEMU_TARGET
 	  Mark all QEMU targets with this variable for checking whether we are
 	  running in an emulated environment.
 
-# $ENV_VAR_BOARD_DIR might be a glob pattern
+# Note: $ENV_VAR_BOARD_DIR might be a glob pattern
 
 choice
 prompt "Board Selection"
-gsource "$ENV_VAR_BOARD_DIR/Kconfig.board"
+source "$ENV_VAR_BOARD_DIR/Kconfig.board"
 endchoice
 
 
 menu "Board Options"
-gsource "$ENV_VAR_BOARD_DIR/Kconfig"
+# There might not be any board options, hence the optional source
+osource "$ENV_VAR_BOARD_DIR/Kconfig"
 endmenu
 
 menu "Shields"

--- a/doc/porting/board_porting.rst
+++ b/doc/porting/board_porting.rst
@@ -406,6 +406,9 @@ The following Kconfig extensions are available:
 
       orsource "Kconfig[12]"
 
+- ``def_int``, ``def_hex``, and ``def_string`` keywords, which are analogous to
+  ``def_bool``. These set the type and add a ``default`` at the same time.
+
 Old Zephyr Kconfig behavior for defaults
 ========================================
 

--- a/doc/porting/board_porting.rst
+++ b/doc/porting/board_porting.rst
@@ -336,19 +336,18 @@ as the corresponding environment variables.
 
 .. note::
 
-    As of writing, there are plans to remove ``option env`` from the C tools as
-    well.
+    ``option env`` has been removed from the C tools in Linux 4.18 as well.
 
 The following Kconfig extensions are available:
 
-- The ``gsource`` statement, which includes each file matching a given wildcard
-  pattern.
+- The ``source`` statement supports glob patterns and includes each matching
+  file. A pattern is required to match at least one file.
 
   Consider the following example:
 
   .. code-block:: none
 
-      gsource "foo/bar/*/Kconfig"
+      source "foo/bar/*/Kconfig"
 
   If the pattern ``foo/bar/*/Kconfig`` matches the files
   :file:`foo/bar/baz/Kconfig` and :file:`foo/bar/qaz/Kconfig`, the statement
@@ -359,39 +358,25 @@ The following Kconfig extensions are available:
       source "foo/bar/baz/Kconfig"
       source "foo/bar/qaz/Kconfig"
 
-  .. note
+  .. note::
 
       The wildcard patterns accepted are the same as for the Python `glob
       <https://docs.python.org/3/library/glob.html>`_ module.
 
-  If no files match the pattern, ``gsource`` has no effect. This means that
-  ``gsource`` also functions as an "optional" include statement (similar to
-  ``-include`` in Make):
+  If no files match the pattern, an error is generated.
 
-  .. code-block:: none
-
-      gsource "foo/include-if-exists"
+  For cases where it's okay for a pattern to match no files (or for a plain
+  filename to not exist), a separate ``osource`` (*optional source*) statement
+  is available. ``osource`` is a no-op in case of no matches.
 
   .. note::
 
-     Wildcard patterns that do not include any wildcard symbols (e.g., ``*``)
-     only match exactly the filename given, and only match it if the file
-     exists.
+      ``source`` and ``osource`` are analogous to ``include`` and
+      ``-include`` in Make.
 
-  It might help to think of *g* as standing for *generalized* rather than
-  *glob* in this case.
-
-  .. note::
-
-      Only use ``gsource`` if you need it. Trying to ``source`` a non-existent
-      file produces an error, while ``gsource`` silently ignores missing files.
-      ``source`` also makes it clearer which files are being included.
-
-- The ``rsource`` statement, which includes a file specified with a relative
-  path.
-
-  The path is relative to the directory of the :file:`Kconfig` file that has
-  the ``rsource`` statement.
+- An ``rsource`` statement is available for including files specified with a
+  relative path. The path is relative to the directory of the :file:`Kconfig`
+  file that contains the ``rsource`` statement.
 
   As an example, assume that :file:`foo/Kconfig` is the top-level
   :file:`Kconfig` file, and that :file:`foo/bar/Kconfig` has the following
@@ -408,14 +393,18 @@ The following Kconfig extensions are available:
   ``rsource`` can be used to create :file:`Kconfig` "subtrees" that can be
   moved around freely.
 
-- The ``grsource`` statement, which combines ``gsource`` and ``rsource``.
+  .. note::
+
+     ``rsource`` also supports glob patterns.
+
+- An ``orsource`` statement, which combines ``osource`` and ``rsource``.
 
   For example, the following statement will include :file:`Kconfig1` and
   :file:`Kconfig2` from the current directory (if they exist):
 
   .. code-block:: none
 
-      grsource "Kconfig[12]"
+      orsource "Kconfig[12]"
 
 Old Zephyr Kconfig behavior for defaults
 ========================================

--- a/drivers/i2s/Kconfig
+++ b/drivers/i2s/Kconfig
@@ -37,6 +37,6 @@ config SYS_LOG_I2S_LEVEL
 
 comment "Device Drivers"
 
-gsource "drivers/i2s/Kconfig.*"
+source "drivers/i2s/Kconfig.*"
 
 endif # I2S


### PR DESCRIPTION
Commit messages say it all:

```
Kconfig: Switch to improved globbing statements

A design flaw of 'gsource' is that there's no way to require at least
one file to match the glob pattern. This could lead to silent errors.

Switch to a new design, where a plain 'source' is globbing and requires
at least one file to match. A separate 'osource' (optional source)
statement is available for cases where it's okay for a pattern (or plain
filename) to not match any files.

'orsource' combines 'osource' and 'rsource' (relative source).

This commit search-replaces 'gsource' with 'source', but backwards
compatibility with 'gsource' is still maintained by making it an alias
for 'osource' (and by making 'grsource' an alias for 'orsource').

The three Kconfig files arch/{nios2,posix,xtensa}/Kconfig source
arch/{nios2,posix,xtensa}/soc/*/Kconfig, which doesn't match any files.
Use 'osource' for those. The soc/*/Kconfig files seem to be for
additional SoC-specific symbols, only none exist yet on those ARCHes.

Also use 'osource' for the source of $ENV_VAR_BOARD_DIR/Kconfig in
boards/Kconfig, which doesn't exist for all boards.
```

```
Kconfig: Document new def_{int,hex,string} extensions

These work like def_bool, setting the type and adding a default at the
same time. This extension fixes some Kconfig inconsistency.
```