### PR TITLE
cmake: Deprecate the 2 symbols _SYSCALL_{LIMIT,BAD}

### DIFF
--- a/arch/arc/core/fault_s.S
+++ b/arch/arc/core/fault_s.S
@@ -16,6 +16,7 @@
 #include <linker/sections.h>
 #include <arch/cpu.h>
 #include <swap_macros.h>
+#include <syscall.h>
 
 GTEXT(_Fault)
 GTEXT(_do_kernel_oops)
@@ -165,12 +166,12 @@ SECTION_SUBSEC_FUNC(TEXT,__fault,__ev_trap)
 	cmp ilink, _TRAP_S_CALL_SYSTEM_CALL
 	bne _do_non_syscall_trap
 /* do sys_call */
-	mov ilink, _SYSCALL_LIMIT
+	mov ilink, K_SYSCALL_LIMIT
 	cmp r6, ilink
 	blt valid_syscall_id
 
 	mov r0, r6
-	mov r6, _SYSCALL_BAD
+	mov r6, K_SYSCALL_BAD
 
 valid_syscall_id:
 #ifdef CONFIG_ARC_HAS_SECURE

--- a/arch/arm/core/swap_helper.S
+++ b/arch/arm/core/swap_helper.S
@@ -16,6 +16,7 @@
 #include <offsets_short.h>
 #include <toolchain.h>
 #include <arch/cpu.h>
+#include <syscall.h>
 
 _ASM_FILE_PROLOGUE
 
@@ -387,13 +388,13 @@ _do_syscall:
     str r1, [r0, #24]   /* overwrite the LR to point to _arm_do_syscall */
 
     /* validate syscall limit, only set priv mode if valid */
-    ldr ip, =_SYSCALL_LIMIT
+    ldr ip, =K_SYSCALL_LIMIT
     cmp r6, ip
     blt valid_syscall_id
 
     /* bad syscall id.  Set arg0 to bad id and set call_id to SYSCALL_BAD */
     str r6, [r0, #0]
-    ldr r6, =_SYSCALL_BAD
+    ldr r6, =K_SYSCALL_BAD
 
 valid_syscall_id:
     /* set mode to privileged, r2 still contains value from CONTROL */

--- a/arch/arm/core/userspace.S
+++ b/arch/arm/core/userspace.S
@@ -126,7 +126,7 @@ SECTION_FUNC(TEXT, _arm_do_syscall)
      * r6 contains call_id
      * r8 contains original LR
      */
-    ldr ip, =_SYSCALL_BAD
+    ldr ip, =K_SYSCALL_BAD
     cmp r6, ip
     bne valid_syscall
 

--- a/arch/x86/core/userspace.S
+++ b/arch/x86/core/userspace.S
@@ -8,7 +8,7 @@
 #include <arch/x86/asm.h>
 #include <arch/cpu.h>
 #include <offsets_short.h>
-#include <arch/x86/syscall.h>
+#include <syscall.h>
 
 /* Exports */
 GTEXT(_x86_syscall_entry_stub)
@@ -31,7 +31,7 @@ SECTION_FUNC(TEXT, _x86_syscall_entry_stub)
 	/* call_id is in ESI. bounds-check it, must be less than
 	 * K_SYSCALL_LIMIT
 	 */
-	cmp	$_SYSCALL_LIMIT, %esi
+	cmp	$K_SYSCALL_LIMIT, %esi
 	jae	_bad_syscall
 
 _id_ok:
@@ -83,7 +83,7 @@ _bad_syscall:
 	 * anyway, it's going to generate a kernel oops
 	 */
 	mov	%esi, %eax
-	mov	$_SYSCALL_BAD, %esi
+	mov	$K_SYSCALL_BAD, %esi
 	jmp	_id_ok
 
 

--- a/include/syscall.h
+++ b/include/syscall.h
@@ -8,11 +8,12 @@
 #ifndef _ZEPHYR_SYSCALL_H_
 #define _ZEPHYR_SYSCALL_H_
 
+#include <syscall_list.h>
+#include <arch/syscall.h>
+
 #ifndef _ASMLANGUAGE
 #include <zephyr/types.h>
-#include <syscall_list.h>
 #include <syscall_macros.h>
-#include <arch/syscall.h>
 
 #ifdef __cplusplus
 extern "C" {

--- a/kernel/include/kernel_offsets.h
+++ b/kernel/include/kernel_offsets.h
@@ -80,8 +80,4 @@ GEN_ABSOLUTE_SYM(K_THREAD_SIZEOF, sizeof(struct k_thread));
 /* size of the device structure. Used by linker scripts */
 GEN_ABSOLUTE_SYM(_DEVICE_STRUCT_SIZE, sizeof(struct device));
 
-/* Access to enum values in asm code */
-GEN_ABSOLUTE_SYM(_SYSCALL_LIMIT, K_SYSCALL_LIMIT);
-GEN_ABSOLUTE_SYM(_SYSCALL_BAD, K_SYSCALL_BAD);
-
 #endif /* _kernel_offsets__h_ */


### PR DESCRIPTION
There exist two symbols that became equivalent when PR #9383 was
merged; _SYSCALL_LIMIT and K_SYSCALL_LIMIT. This patch deprecates the
redundant _SYSCALL_LIMIT symbol.

_SYSCALL_LIMIT was initally introduced because before PR #9383 was
merged K_SYSCALL_LIMIT was an enum, which couldn't be included into
assembly files. PR #9383 converted it into a define, which can be
included into assembly files, making _SYSCALL_LIMIT redundant.

Likewise for _SYSCALL_BAD.

Signed-off-by: Sebastian Bøe <sebastian.boe@nordicsemi.no>