### PR TITLE
net: Use packed enums when applicable

### DIFF
--- a/include/net/dhcpv4.h
+++ b/include/net/dhcpv4.h
@@ -38,7 +38,7 @@ enum net_dhcpv4_state {
 	NET_DHCPV4_RENEWING,
 	NET_DHCPV4_REBINDING,
 	NET_DHCPV4_BOUND,
-};
+} __packed;
 
 /**
  *  @brief Start DHCPv4 client on an iface

--- a/include/net/http.h
+++ b/include/net/http.h
@@ -53,12 +53,12 @@ enum http_state {
 	  HTTP_STATE_RECEIVING_HEADER,
 	  HTTP_STATE_HEADER_RECEIVED,
 	  HTTP_STATE_OPEN,
-};
+} __packed;
 
 enum http_url_flags {
 	HTTP_URL_STANDARD = 0,
 	HTTP_URL_WEBSOCKET,
-};
+} __packed;
 
 enum http_connection_type {
 	HTTP_CONNECTION = 1,

--- a/include/net/net_app.h
+++ b/include/net/net_app.h
@@ -59,7 +59,7 @@ enum net_app_type {
 	NET_APP_UNSPEC = 0,
 	NET_APP_SERVER,
 	NET_APP_CLIENT,
-};
+} __packed;
 
 struct net_app_ctx;
 

--- a/include/net/net_ip.h
+++ b/include/net/net_ip.h
@@ -206,7 +206,7 @@ enum net_priority {
 	NET_PRIORITY_VO = 5, /* Voice, < 10 ms latency and jitter  */
 	NET_PRIORITY_IC = 6, /* Internetwork control               */
 	NET_PRIORITY_NC = 7  /* Network control                    */
-};
+} __packed;
 
 /** IPv6/IPv4 network connection tuple */
 struct net_tuple {
@@ -229,7 +229,7 @@ enum net_addr_type {
 	NET_ADDR_DHCP,
 	NET_ADDR_MANUAL,
 	NET_ADDR_OVERRIDABLE,
-};
+} __packed;
 
 #if NET_LOG_ENABLED > 0
 static inline char *net_addr_type2str(enum net_addr_type type)
@@ -265,7 +265,7 @@ enum net_addr_state {
 	NET_ADDR_TENTATIVE = 0,
 	NET_ADDR_PREFERRED,
 	NET_ADDR_DEPRECATED,
-};
+} __packed;
 
 struct net_ipv6_hdr {
 	u8_t vtc;

--- a/include/net/net_l2.h
+++ b/include/net/net_l2.h
@@ -36,7 +36,7 @@ enum net_l2_flags {
 
 	/** Is promiscuous mode supported */
 	NET_L2_PROMISC_MODE			= BIT(2),
-};
+} __packed;
 
 struct net_l2 {
 	/**

--- a/include/net/net_linkaddr.h
+++ b/include/net/net_linkaddr.h
@@ -45,7 +45,7 @@ enum net_link_type {
 	NET_LINK_BLUETOOTH,
 	NET_LINK_ETHERNET,
 	NET_LINK_DUMMY,
-};
+} __packed;
 
 /**
  *  @brief Hardware link address structure


### PR DESCRIPTION
Make several enums, that are used inside structs, to be packed so
that they use only needed amount of memory.

Signed-off-by: Jukka Rissanen <jukka.rissanen@linux.intel.com>