### PR TITLE
drivers: entropy: Migrate to new logging subsys

### DIFF
--- a/drivers/entropy/Kconfig
+++ b/drivers/entropy/Kconfig
@@ -32,18 +32,18 @@ config ENTROPY_NAME
 	help
 	  Specify the device name to be used for the ENTROPY driver.
 
-config SYS_LOG_ENTROPY_LEVEL
+config LOG_ENTROPY_LEVEL
 	int "Random Log level"
-	depends on SYS_LOG
+	depends on LOG
 	default 0
 	range 0 4
 	help
 	  Sets log level for entropy driver.
 	  Levels are:
 	  - 0 OFF: do not write
-	  - 1 ERROR: only write SYS_LOG_ERR
-	  - 2 WARNING: write SYS_LOG_WRN in addition to previous level
-	  - 3 INFO: write SYS_LOG_INF in addition to previous levels
-	  - 4 DEBUG: write SYS_LOG_DBG in addition to previous levels
+	  - 1 ERROR: only write LOG_ERR
+	  - 2 WARNING: write LOG_WRN in addition to previous level
+	  - 3 INFO: write LOG_INF in addition to previous levels
+	  - 4 DEBUG: write LOG_DBG in addition to previous levels
 
 endif


### PR DESCRIPTION
Migrate from `SYS_LOG` to `LOG` logging mechanism.

Signed-off-by: Olivier Martin <olivier.martin@proglove.de>