### PR TITLE
drivers: clock_control: Migrate to new logging subsys

### DIFF
--- a/drivers/clock_control/Kconfig
+++ b/drivers/clock_control/Kconfig
@@ -19,9 +19,9 @@ menuconfig CLOCK_CONTROL
 
 if CLOCK_CONTROL
 
-config SYS_LOG_CLOCK_CONTROL_LEVEL
+config LOG_CLOCK_CONTROL_LEVEL
 	int "Hardware clock controller drivers log level"
-	depends on SYS_LOG
+	depends on LOG
 	default 0
 	help
 	  Sets log level for clock controller drivers
@@ -30,13 +30,13 @@ config SYS_LOG_CLOCK_CONTROL_LEVEL
 
 	  - 0 OFF, do not write
 
-	  - 1 ERROR, only write SYS_LOG_ERR
+	  - 1 ERROR, only write LOG_ERR
 
-	  - 2 WARNING, write SYS_LOG_WRN in addition to previous level
+	  - 2 WARNING, write LOG_WRN in addition to previous level
 
-	  - 3 INFO, write SYS_LOG_INF in addition to previous levels
+	  - 3 INFO, write LOG_INF in addition to previous levels
 
-	  - 4 DEBUG, write SYS_LOG_DBG in addition to previous levels
+	  - 4 DEBUG, write LOG_DBG in addition to previous levels
 
 source "drivers/clock_control/Kconfig.nrf5"
 

--- a/drivers/clock_control/clock_control_mcux_ccm.c
+++ b/drivers/clock_control/clock_control_mcux_ccm.c
@@ -9,8 +9,8 @@
 #include <dt-bindings/clock/imx_ccm.h>
 #include <fsl_clock.h>
 
-#define SYS_LOG_LEVEL CONFIG_SYS_LOG_CLOCK_CONTROL_LEVEL
-#include <logging/sys_log.h>
+#define LOG_LEVEL CONFIG_LOG_CLOCK_CONTROL_LEVEL
+#include <logging/log.h>
 
 static int mcux_ccm_on(struct device *dev,
 			      clock_control_subsys_t sub_system)

--- a/drivers/clock_control/clock_control_mcux_sim.c
+++ b/drivers/clock_control/clock_control_mcux_sim.c
@@ -9,8 +9,8 @@
 #include <dt-bindings/clock/kinetis_sim.h>
 #include <fsl_clock.h>
 
-#define SYS_LOG_LEVEL CONFIG_SYS_LOG_CLOCK_CONTROL_LEVEL
-#include <logging/sys_log.h>
+#define LOG_LEVEL CONFIG_LOG_CLOCK_CONTROL_LEVEL
+#include <logging/log.h>
 
 static int mcux_sim_on(struct device *dev, clock_control_subsys_t sub_system)
 {

--- a/drivers/clock_control/quark_se_clock_control.c
+++ b/drivers/clock_control/quark_se_clock_control.c
@@ -19,8 +19,8 @@
 #include <clock_control.h>
 #include <clock_control/quark_se_clock_control.h>
 
-#define SYS_LOG_LEVEL CONFIG_SYS_LOG_CLOCK_CONTROL_LEVEL
-#include <logging/sys_log.h>
+#define LOG_LEVEL CONFIG_LOG_CLOCK_CONTROL_LEVEL
+#include <logging/log.h>
 
 #ifdef CONFIG_ARC
 #define WRITE(__data, __base_address)		\
@@ -46,13 +46,13 @@ static inline int quark_se_clock_control_on(struct device *dev,
 	u32_t subsys = POINTER_TO_INT(sub_system);
 
 	if (sub_system == CLOCK_CONTROL_SUBSYS_ALL) {
-		SYS_LOG_DBG("Enabling all clock gates on dev %p", dev);
+		LOG_DBG("Enabling all clock gates on dev %p", dev);
 		WRITE(0xffffffff, info->base_address);
 
 		return 0;
 	}
 
-	SYS_LOG_DBG("Enabling clock gate on dev %p subsystem %u", dev, subsys);
+	LOG_DBG("Enabling clock gate on dev %p subsystem %u", dev, subsys);
 
 	return TEST_CLEAR_BIT(info->base_address, subsys);
 }
@@ -65,13 +65,13 @@ static inline int quark_se_clock_control_off(struct device *dev,
 	u32_t subsys = POINTER_TO_INT(sub_system);
 
 	if (sub_system == CLOCK_CONTROL_SUBSYS_ALL) {
-		SYS_LOG_DBG("Disabling all clock gates on dev %p", dev);
+		LOG_DBG("Disabling all clock gates on dev %p", dev);
 		WRITE(0x00000000, info->base_address);
 
 		return 0;
 	}
 
-	SYS_LOG_DBG("clock gate on dev %p subsystem %u", dev, subsys);
+	LOG_DBG("clock gate on dev %p subsystem %u", dev, subsys);
 
 	return TEST_CLEAR_BIT(info->base_address, subsys);
 }
@@ -84,7 +84,7 @@ static const struct clock_control_driver_api quark_se_clock_control_api = {
 
 int quark_se_clock_control_init(struct device *dev)
 {
-	SYS_LOG_DBG("Quark_SE clock controller on: %p", dev);
+	LOG_DBG("Quark_SE clock controller on: %p", dev);
 	return 0;
 }
 


### PR DESCRIPTION
Migrate from `SYS_LOG` to `LOG` logging mechanism.

Signed-off-by: Olivier Martin <olivier.martin@proglove.de>