### PR TITLE
drivers: gpio: Migrate to new logging subsys

### DIFF
--- a/drivers/gpio/Kconfig
+++ b/drivers/gpio/Kconfig
@@ -13,10 +13,10 @@ menuconfig GPIO
 
 if GPIO
 
-config SYS_LOG_GPIO_LEVEL
+config LOG_GPIO_LEVEL
 	int "GPIO drivers log level"
 	default 0
-	depends on SYS_LOG
+	depends on LOG
 	help
 	  Sets log level for GPIO drivers
 
@@ -24,13 +24,13 @@ config SYS_LOG_GPIO_LEVEL
 
 	  - 0 OFF, do not write
 
-	  - 1 ERROR, only write SYS_LOG_ERR
+	  - 1 ERROR, only write LOG_ERR
 
-	  - 2 WARNING, write SYS_LOG_WRN in addition to previous level
+	  - 2 WARNING, write LOG_WRN in addition to previous level
 
-	  - 3 INFO, write SYS_LOG_INF in addition to previous levels
+	  - 3 INFO, write LOG_INF in addition to previous levels
 
-	  - 4 DEBUG, write SYS_LOG_DBG in addition to previous levels
+	  - 4 DEBUG, write LOG_DBG in addition to previous levels
 
 source "drivers/gpio/Kconfig.dw"
 

--- a/drivers/gpio/Kconfig.pcal9535a
+++ b/drivers/gpio/Kconfig.pcal9535a
@@ -14,25 +14,6 @@ menuconfig GPIO_PCAL9535A
 
 if GPIO_PCAL9535A
 
-config SYS_LOG_GPIO_PCAL9535A_LEVEL
-	int "PCAL9535A driver log level"
-	depends on GPIO_PCAL9535A && SYS_LOG
-	default 0
-	help
-	  Sets log level for clock PCAL9535A driver
-
-	  Levels are:
-
-	  - 0 OFF, do not write
-
-	  - 1 ERROR, only write SYS_LOG_ERR
-
-	  - 2 WARNING, write SYS_LOG_WRN in addition to previous level
-
-	  - 3 INFO, write SYS_LOG_INF in addition to previous levels
-
-	  - 4 DEBUG, write SYS_LOG_DBG in addition to previous levels
-
 config GPIO_PCAL9535A_INIT_PRIORITY
 	int "Init priority"
 	default 70

--- a/drivers/gpio/gpio_pcal9535a.c
+++ b/drivers/gpio/gpio_pcal9535a.c
@@ -19,8 +19,8 @@
 
 #include "gpio_pcal9535a.h"
 
-#define SYS_LOG_LEVEL CONFIG_SYS_LOG_GPIO_PCAL9535A_LEVEL
-#include <logging/sys_log.h>
+#define LOG_LEVEL CONFIG_LOG_GPIO_LEVEL
+#include <logging/log.h>
 
 /* Register definitions */
 #define REG_INPUT_PORT0			0x00
@@ -89,13 +89,13 @@ static int _read_port_regs(struct device *dev, u8_t reg,
 
 	ret = i2c_burst_read(i2c_master, i2c_addr, reg, buf->byte, 2);
 	if (ret) {
-		SYS_LOG_ERR("PCAL9535A[0x%X]: error reading register 0x%X (%d)",
-			    i2c_addr, reg, ret);
+		LOG_ERR("PCAL9535A[0x%X]: error reading register 0x%X (%d)",
+			i2c_addr, reg, ret);
 		goto error;
 	}
 
-	SYS_LOG_DBG("PCAL9535A[0x%X]: Read: REG[0x%X] = 0x%X, REG[0x%X] = 0x%X",
-		    i2c_addr, reg, buf->byte[0], (reg + 1), buf->byte[1]);
+	LOG_DBG("PCAL9535A[0x%X]: Read: REG[0x%X] = 0x%X, REG[0x%X] = 0x%X",
+		i2c_addr, reg, buf->byte[0], (reg + 1), buf->byte[1]);
 
 error:
 	return ret;
@@ -123,14 +123,14 @@ static int _write_port_regs(struct device *dev, u8_t reg,
 	u16_t i2c_addr = config->i2c_slave_addr;
 	int ret;
 
-	SYS_LOG_DBG("PCAL9535A[0x%X]: Write: REG[0x%X] = 0x%X, REG[0x%X] = "
-		    "0x%X", i2c_addr, reg, buf->byte[0], (reg + 1),
-		    buf->byte[1]);
+	LOG_DBG("PCAL9535A[0x%X]: Write: REG[0x%X] = 0x%X, REG[0x%X] = "
+		"0x%X", i2c_addr, reg, buf->byte[0], (reg + 1),
+		buf->byte[1]);
 
 	ret = i2c_burst_write(i2c_master, i2c_addr, reg, buf->byte, 2);
 	if (ret) {
-		SYS_LOG_ERR("PCAL9535A[0x%X]: error writing from register 0x%X "
-			    "(%d)", i2c_addr, reg, ret);
+		LOG_ERR("PCAL9535A[0x%X]: error writing from register 0x%X "
+			"(%d)", i2c_addr, reg, ret);
 	}
 
 	return ret;
@@ -351,7 +351,7 @@ static int gpio_pcal9535a_config(struct device *dev, int access_op,
 {
 	int ret;
 
-#if (CONFIG_SYS_LOG_GPIO_PCAL9535A_LEVEL >= SYS_LOG_LEVEL_DEBUG)
+#if (CONFIG_LOG_GPIO_LEVEL >= LOG_LEVEL_DEBUG)
 	const struct gpio_pcal9535a_config * const config =
 		dev->config->config_info;
 	u16_t i2c_addr = config->i2c_slave_addr;
@@ -363,22 +363,22 @@ static int gpio_pcal9535a_config(struct device *dev, int access_op,
 
 	ret = _setup_pin_dir(dev, access_op, pin, flags);
 	if (ret) {
-		SYS_LOG_ERR("PCAL9535A[0x%X]: error setting pin direction (%d)",
-			    i2c_addr, ret);
+		LOG_ERR("PCAL9535A[0x%X]: error setting pin direction (%d)",
+			i2c_addr, ret);
 		goto done;
 	}
 
 	ret = _setup_pin_polarity(dev, access_op, pin, flags);
 	if (ret) {
-		SYS_LOG_ERR("PCAL9535A[0x%X]: error setting pin polarity (%d)",
-			    i2c_addr, ret);
+		LOG_ERR("PCAL9535A[0x%X]: error setting pin polarity (%d)",
+			i2c_addr, ret);
 		goto done;
 	}
 
 	ret = _setup_pin_pullupdown(dev, access_op, pin, flags);
 	if (ret) {
-		SYS_LOG_ERR("PCAL9535A[0x%X]: error setting pin pull up/down "
-			    "(%d)", i2c_addr, ret);
+		LOG_ERR("PCAL9535A[0x%X]: error setting pin pull up/down "
+			"(%d)", i2c_addr, ret);
 		goto done;
 	}
 

--- a/drivers/gpio/gpio_sch.c
+++ b/drivers/gpio/gpio_sch.c
@@ -17,8 +17,8 @@
 #include "gpio_sch.h"
 #include "gpio_utils.h"
 
-#define SYS_LOG_LEVEL CONFIG_SYS_LOG_GPIO_LEVEL
-#include <logging/sys_log.h>
+#define LOG_LEVEL CONFIG_LOG_GPIO_LEVEL
+#include <logging/log.h>
 
 /* Define GPIO_SCH_LEGACY_IO_PORTS_ACCESS
  * inside soc.h if the GPIO controller
@@ -101,8 +101,8 @@ static void _gpio_pin_config(struct device *dev, u32_t pin, int flags)
 			active_low = 1;
 		}
 
-		SYS_LOG_DBG("Setting up pin %d to active_high %d and "
-			    "active_low %d", active_high, active_low);
+		LOG_DBG("Setting up pin %d to active_high %d and "
+			"active_low %d", active_high, active_low);
 	}
 
 	/* We store the gtpe/gtne settings. These will be used once
@@ -215,7 +215,7 @@ static void _gpio_sch_manage_callback(struct device *dev)
 	/* Start the thread only when relevant */
 	if (!sys_slist_is_empty(&gpio->callbacks) && gpio->cb_enabled) {
 		if (!gpio->poll) {
-			SYS_LOG_DBG("Starting SCH GPIO polling thread");
+			LOG_DBG("Starting SCH GPIO polling thread");
 			gpio->poll = 1;
 			k_thread_create(&gpio->polling_thread,
 					gpio->polling_stack,
@@ -314,7 +314,7 @@ static int gpio_sch_init(struct device *dev)
 
 	k_timer_init(&gpio->poll_timer, NULL, NULL);
 
-	SYS_LOG_DBG("SCH GPIO Intel Driver initialized on device: %p", dev);
+	LOG_DBG("SCH GPIO Intel Driver initialized on device: %p", dev);
 
 	return 0;
 }


### PR DESCRIPTION
Migrate from `SYS_LOG` to `LOG` logging mechanism.

Signed-off-by: Olivier Martin <olivier.martin@proglove.de>