### PR TITLE
Kconfig: Use a short, consistent style for prompts

### DIFF
--- a/arch/Kconfig
+++ b/arch/Kconfig
@@ -127,8 +127,7 @@ config DYNAMIC_OBJECTS
 	zero.
 
 config SIMPLE_FATAL_ERROR_HANDLER
-	prompt "Simple system fatal error handler"
-	bool
+	bool "Simple system fatal error handler"
 	default y if !MULTITHREADING
 	help
 	  Provides an implementation of _SysFatalErrorHandler() that hard hangs
@@ -141,16 +140,14 @@ menu "Interrupt Configuration"
 # Interrupt related configs
 #
 config GEN_ISR_TABLES
-	bool
-	prompt "Use generated IRQ tables"
+	bool "Use generated IRQ tables"
 	help
 	  This option controls whether a platform uses the gen_isr_tables
 	  script to generate its interrupt tables. This mechanism will create
 	  an appropriate hardware vector table and/or software IRQ table.
 
 config GEN_IRQ_VECTOR_TABLE
-	bool
-	prompt "Generate an interrupt vector table"
+	bool "Generate an interrupt vector table"
 	default y
 	depends on GEN_ISR_TABLES
 	help
@@ -162,8 +159,7 @@ config GEN_IRQ_VECTOR_TABLE
 	  supplied by the application or architecture code.
 
 config GEN_SW_ISR_TABLE
-	bool
-	prompt "Generate a software ISR table"
+	bool "Generate a software ISR table"
 	default y
 	depends on GEN_ISR_TABLES
 	help
@@ -267,8 +263,7 @@ menu "Floating Point Options"
 depends on CPU_HAS_FPU
 
 config FLOAT
-	bool
-	prompt "Floating point registers"
+	bool "Floating point registers"
 	help
 	  This option allows threads to use the floating point registers.
 	  By default, only a single thread may use the registers.
@@ -277,8 +272,7 @@ config FLOAT
 	  floating point register will get a fatal exception.
 
 config FP_SHARING
-	bool
-	prompt "Floating point register sharing"
+	bool "Floating point register sharing"
 	depends on FLOAT
 	help
 	  This option allows multiple threads to use the floating point

--- a/arch/arc/Kconfig
+++ b/arch/arc/Kconfig
@@ -59,8 +59,7 @@ config	DATA_ENDIANNESS_LITTLE
 	  implemented as big endian.
 
 config	NUM_IRQ_PRIO_LEVELS
-	int
-	prompt "Number of supported interrupt priority levels"
+	int "Number of supported interrupt priority levels"
 	range 1 16
 	help
 	  Interrupt priorities available will be 0 to NUM_IRQ_PRIO_LEVELS-1.
@@ -69,8 +68,7 @@ config	NUM_IRQ_PRIO_LEVELS
 	  The BSP must provide a valid default for proper operation.
 
 config	NUM_IRQS
-	int
-	prompt "Upper limit of interrupt numbers/IDs used"
+	int "Upper limit of interrupt numbers/IDs used"
 	range 17 256
 	help
 	  Interrupts available will be 0 to NUM_IRQS-1.
@@ -81,8 +79,7 @@ config	NUM_IRQS
 	  vector table.
 
 config	RGF_NUM_BANKS
-	int
-	prompt "Number of General Purpose Register Banks"
+	int "Number of General Purpose Register Banks"
 	depends on CPU_ARCV2
 	range 1 2
 	default 2
@@ -95,8 +92,7 @@ config	RGF_NUM_BANKS
 	  and restore general purpose registers.
 
 config ARC_FIRQ
-	bool
-	prompt "FIRQ enable"
+	bool "FIRQ enable"
 	default y
 	help
 	  Fast interrupts are supported (FIRQ). If FIRQ enabled, for interrupts
@@ -114,8 +110,7 @@ config	ARC_STACK_CHECKING
 	  enables code that allows using this debug feature
 
 config	FAULT_DUMP
-	int
-	prompt "Fault dump level"
+	int "Fault dump level"
 	default 2
 	range 0 2
 	help
@@ -139,15 +134,13 @@ config GEN_IRQ_START_VECTOR
 	default 16
 
 config HARVARD
-	prompt "Harvard Architecture"
-	bool
+	bool "Harvard Architecture"
 	help
 	  The ARC CPU can be configured to have two busses;
 	  one for instruction fetching and another that serves as a data bus.
 
 config CODE_DENSITY
-	prompt "Code Density Option"
-	bool
+	bool "Code Density Option"
 	help
 	  Enable code density option to get better code density
 
@@ -172,8 +165,7 @@ source "arch/arc/core/mpu/Kconfig"
 endmenu
 
 config CACHE_LINE_SIZE_DETECT
-	bool
-	prompt "Detect d-cache line size at runtime"
+	bool "Detect d-cache line size at runtime"
 	help
 	  This option enables querying the d-cache build register for finding
 	  the d-cache line size at the expense of taking more memory and code
@@ -183,8 +175,7 @@ config CACHE_LINE_SIZE_DETECT
 	  option and manually enter the value for CACHE_LINE_SIZE.
 
 config CACHE_LINE_SIZE
-	int
-	prompt "Cache line size" if !CACHE_LINE_SIZE_DETECT
+	int "Cache line size" if !CACHE_LINE_SIZE_DETECT
 	default 32
 	help
 	  Size in bytes of a CPU d-cache line.
@@ -195,8 +186,7 @@ config ARCH_CACHE_FLUSH_DETECT
 	bool
 
 config CACHE_FLUSHING
-	bool
-	prompt "Enable d-cache flushing mechanism"
+	bool "Enable d-cache flushing mechanism"
 	help
 	  This links in the sys_cache_flush() function, which provides a
 	  way to flush multiple lines of the d-cache.

--- a/arch/arc/core/mpu/Kconfig
+++ b/arch/arc/core/mpu/Kconfig
@@ -6,8 +6,7 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 config ARC_MPU_VER
-	int
-	prompt "ARC MPU version"
+	int "ARC MPU version"
 	range 2 4
 	default 2
 	help

--- a/arch/arm/core/cortex_m/Kconfig
+++ b/arch/arm/core/cortex_m/Kconfig
@@ -276,16 +276,14 @@ config DATA_ENDIANNESS_LITTLE
 	  implemented as big endian.
 
 config STACK_ALIGN_DOUBLE_WORD
-	bool
-	prompt "Align stacks on double-words (8 octets)"
+	bool "Align stacks on double-words (8 octets)"
 	default y
 	help
 	  This is needed to conform to AAPCS, the procedure call standard for
 	  the ARM. It wastes stack space.
 
 config RUNTIME_NMI
-	bool
-	prompt "Attach an NMI handler at runtime"
+	bool "Attach an NMI handler at runtime"
 	select REBOOT
 	help
 	  The kernel provides a simple NMI handler that simply hangs in a tight
@@ -294,8 +292,7 @@ config RUNTIME_NMI
 	  needed, enable this option and attach it via _NmiHandlerSet().
 
 config FAULT_DUMP
-	int
-	prompt "Fault dump level"
+	int "Fault dump level"
 	default 2
 	range 0 2
 	help
@@ -320,8 +317,7 @@ config GEN_ISR_TABLES
 	default y
 
 config ZERO_LATENCY_IRQS
-	bool
-	prompt "Enable zero-latency interrupts"
+	bool "Enable zero-latency interrupts"
 	depends on CPU_CORTEX_M_HAS_BASEPRI
 	help
 	  The kernel may reserve some of the highest interrupts priorities in
@@ -337,8 +333,7 @@ config ZERO_LATENCY_IRQS
 	  kernel functionality.
 
 config SW_VECTOR_RELAY
-	bool
-	prompt "Enable Software Vector Relay"
+	bool "Enable Software Vector Relay"
 	default y if BOOTLOADER_MCUBOOT
 	depends on ARMV6_M_ARMV8_M_BASELINE && !(CPU_CORTEX_M0_HAS_VECTOR_TABLE_REMAP || CPU_CORTEX_M_HAS_VTOR)
 	help
@@ -350,8 +345,7 @@ config SW_VECTOR_RELAY
 	  relocation table mechanisms.
 
 config PLATFORM_SPECIFIC_INIT
-	bool
-	prompt "Enable platform (SOC) specific startup hook"
+	bool "Enable platform (SOC) specific startup hook"
 	help
 	  The platform specific initialization code (_PlatformInit) is executed
 	  at the beginning of the startup code (__start).

--- a/arch/arm/soc/nxp_kinetis/k6x/Kconfig.soc
+++ b/arch/arm/soc/nxp_kinetis/k6x/Kconfig.soc
@@ -68,32 +68,28 @@ config SOC_PART_NUMBER_KINETIS_K6X
 	  the default value for this string.
 
 config K64_CORE_CLOCK_DIVIDER
-	int
-	prompt "Freescale K64 core clock divider"
+	int "Freescale K64 core clock divider"
 	default 1
 	help
 	  This option specifies the divide value for the K64 processor core clock
 	  from the system clock.
 
 config K64_BUS_CLOCK_DIVIDER
-	int
-	prompt "Freescale K64 bus clock divider"
+	int "Freescale K64 bus clock divider"
 	default 2
 	help
 	  This option specifies the divide value for the K64 bus clock from the
 	  system clock.
 
 config K64_FLEXBUS_CLOCK_DIVIDER
-	int
-	prompt "Freescale K64 FlexBus clock divider"
+	int "Freescale K64 FlexBus clock divider"
 	default 3
 	help
 	  This option specifies the divide value for the K64 FlexBus clock from the
 	  system clock.
 
 config K64_FLASH_CLOCK_DIVIDER
-	int
-	prompt "Freescale K64 flash clock divider"
+	int "Freescale K64 flash clock divider"
 	default 5
 	help
 	  This option specifies the divide value for the K64 flash clock from the

--- a/arch/arm/soc/nxp_kinetis/kwx/Kconfig.soc
+++ b/arch/arm/soc/nxp_kinetis/kwx/Kconfig.soc
@@ -88,24 +88,21 @@ config SOC_PART_NUMBER_KINETIS_KWX
 if SOC_MKW24D5 || SOC_MKW22D5
 
 config KW2XD_CORE_CLOCK_DIVIDER
-	int
-	prompt "KW2xD core clock divider"
+	int "KW2xD core clock divider"
 	default 1
 	help
 	  This option specifies the divide value for the KW2xD processor core
 	  clock from the system clock.
 
 config KW2XD_BUS_CLOCK_DIVIDER
-	int
-	prompt "KW2xD bus clock divider"
+	int "KW2xD bus clock divider"
 	default 1
 	help
 	  This option specifies the divide value for the KW2xD bus clock from
 	  the system clock.
 
 config KW2XD_FLASH_CLOCK_DIVIDER
-	int
-	prompt "KW2xD flash clock divider"
+	int "KW2xD flash clock divider"
 	default 2
 	help
 	  This option specifies the divide value for the KW2xD flash clock from

--- a/arch/x86/Kconfig
+++ b/arch/x86/Kconfig
@@ -64,8 +64,7 @@ config CPU_APOLLO_LAKE
 menu "Processor Capabilities"
 
 config X86_IAMCU
-	bool
-	prompt "IAMCU calling convention"
+	bool "IAMCU calling convention"
 	help
 	  The IAMCU calling convention changes the X86 C calling convention to
 	  pass some arguments via registers allowing for code size and performance
@@ -76,16 +75,14 @@ config X86_IAMCU
 
 menu "Memory Management"
 config X86_MMU
-	bool
-	prompt "Enable Memory Management Unit"
+	bool "Enable Memory Management Unit"
 	help
 	  This options enables the memory management unit present in x86. Enabling
 	  this will create boot time page table structure.
 
 config X86_PAE_MODE
-	bool
+	bool "Enable PAE page tables"
 	depends on X86_MMU
-	prompt "Enable PAE page tables"
 	help
 	  When selected the Page address extension mode is enabled. The PAE
 	  page tables provides a mechanism to selectively disable execution.
@@ -152,15 +149,13 @@ menu "Architecture Floating Point Options"
 depends on CPU_HAS_FPU
 
 config SSE
-	bool
-	prompt "SSE registers"
+	bool "SSE registers"
 	depends on FLOAT
 	help
 	  This option enables the use of SSE registers by threads.
 
 config SSE_FP_MATH
-	bool
-	prompt "Compiler-generated SSEx instructions"
+	bool "Compiler-generated SSEx instructions"
 	depends on SSE
 	help
 	  This option allows the compiler to generate SSEx instructions for
@@ -180,8 +175,7 @@ depends on REBOOT
 default REBOOT_RST_CNT
 
 config REBOOT_RST_CNT
-	bool
-	prompt "Reboot via RST_CNT register"
+	bool "Reboot via RST_CNT register"
 	help
 	  Reboot via the RST_CNT register, going back to BIOS.
 
@@ -196,8 +190,7 @@ config ISA_IA32
 	  instruction set architecture.
 
 config IA32_LEGACY_IO_PORTS
-	bool
-	prompt "Support IA32 legacy IO ports"
+	bool "Support IA32 legacy IO ports"
 	depends on ISA_IA32
 	help
 	  This option enables IA32 legacy IO ports. Note these are much slower
@@ -230,8 +223,7 @@ config CACHE_LINE_SIZE
 	  Detect automatically at runtime by selecting CACHE_LINE_SIZE_DETECT.
 
 config CLFLUSH_INSTRUCTION_SUPPORTED
-	bool
-	prompt "CLFLUSH instruction supported"
+	bool "CLFLUSH instruction supported"
 	depends on !CLFLUSH_DETECT && CACHE_FLUSHING
 	help
 	  An implementation of sys_cache_flush() that uses CLFLUSH is made
@@ -242,8 +234,7 @@ config CLFLUSH_INSTRUCTION_SUPPORTED
 	  CLFLUSH support thereby reducing both memory footprint and boot time.
 
 config CLFLUSH_DETECT
-	bool
-	prompt "Detect support of CLFLUSH instruction at runtime"
+	bool "Detect support of CLFLUSH instruction at runtime"
 	depends on CACHE_FLUSHING
 	help
 	  This option should be enabled if it is not known in advance whether the
@@ -262,8 +253,7 @@ config ARCH_CACHE_FLUSH_DETECT
 	depends on CLFLUSH_DETECT
 
 config CACHE_FLUSHING
-	bool
-	prompt "Enable cache flushing mechanism"
+	bool "Enable cache flushing mechanism"
 	help
 	  This links in the sys_cache_flush() function. A mechanism for flushing the
 	  cache must be selected as well. By default, that mechanism is discovered at

--- a/arch/x86/core/Kconfig
+++ b/arch/x86/core/Kconfig
@@ -7,15 +7,13 @@
 #
 
 config NESTED_INTERRUPTS
-	bool
-	prompt "Enable nested interrupts"
+	bool "Enable nested interrupts"
 	default y
 	help
 	  This option enables support for nested interrupts.
 
 config EXCEPTION_DEBUG
-	bool
-	prompt "Unhandled exception debugging"
+	bool "Unhandled exception debugging"
 	default y
 	depends on PRINTK
 	help
@@ -27,8 +25,7 @@ config EXCEPTION_DEBUG
 menu "Memory Layout Options"
 
 config IDT_NUM_VECTORS
-	int
-	prompt "Number of IDT vectors"
+	int "Number of IDT vectors"
 	default 256
 	range 32 256
 	help
@@ -37,8 +34,7 @@ config IDT_NUM_VECTORS
 	  supported in an IDT requiring 2048 bytes of memory.
 
 config MAX_IRQ_LINES
-	int
-	prompt "Number of IRQ lines"
+	int "Number of IRQ lines"
 	default 128
 	range 0 256
 	help
@@ -49,8 +45,7 @@ config MAX_IRQ_LINES
 	  interrupts.
 
 config SET_GDT
-	bool
-	prompt "Setup GDT as part of boot process"
+	bool "Setup GDT as part of boot process"
 	default y
 	help
 	  This option sets up the GDT as part of the boot process. However,
@@ -60,8 +55,7 @@ config SET_GDT
 	  will not be available.
 
 config GDT_DYNAMIC
-	bool
-	prompt "Store GDT in RAM so that it can be modified"
+	bool "Store GDT in RAM so that it can be modified"
 	depends on SET_GDT
 	help
 	  This option stores the GDT in RAM instead of ROM, so that it may
@@ -70,8 +64,7 @@ config GDT_DYNAMIC
 endmenu
 
 config DISABLE_SSBD
-	bool
-	prompt "Disable Speculative Store Bypass"
+	bool "Disable Speculative Store Bypass"
 	depends on USERSPACE
 	default y if !X86_NO_SPECTRE_V4
 	help

--- a/arch/x86/soc/intel_quark/quark_se/Kconfig
+++ b/arch/x86/soc/intel_quark/quark_se/Kconfig
@@ -28,8 +28,7 @@ config ARC_INIT
 	  Allows x86 processor to kickoff the ARC slave processor.
 
 config SYS_LOG_ARC_INIT_LEVEL
-	int
-	prompt "Quark SE Sensor Subsystem log level"
+	int "Quark SE Sensor Subsystem log level"
 	depends on SYS_LOG
 	default 0
 	help

--- a/drivers/adc/Kconfig
+++ b/drivers/adc/Kconfig
@@ -10,16 +10,14 @@
 # ADC options
 #
 menuconfig ADC
-	bool
-	prompt "ADC drivers"
+	bool "ADC drivers"
 	help
 	  Enable ADC (Analog to Digital Converter) driver configuration
 
 if ADC
 
 config SYS_LOG_ADC_LEVEL
-	int
-	prompt "ADC drivers log level"
+	int "ADC drivers log level"
 	depends on SYS_LOG
 	default 0
 	range 0 4
@@ -40,9 +38,8 @@ config SYS_LOG_ADC_LEVEL
 	  - 4 DEBUG, write SYS_LOG_DBG in addition to previous levels
 
 config ADC_INIT_PRIORITY
-	int
+	int "Init priority"
 	default 80
-	prompt "Init priority"
 	help
 	  ADC Device driver initialization priority.
 
@@ -55,9 +52,8 @@ config ADC_0_NAME
 	default "ADC_0"
 
 config ADC_0_IRQ_PRI
-	int
+	int "ADC 0 interrupt priority"
 	depends on ADC_0 && !HAS_DTS_ADC
-	prompt "ADC 0 interrupt priority"
 	default 2
 
 config ADC_1
@@ -69,9 +65,8 @@ config ADC_1_NAME
 	default "ADC_1"
 
 config ADC_1_IRQ_PRI
-	int
+	int "ADC 1 interrupt priority"
 	depends on ADC_1 && !HAS_DTS_ADC
-	prompt "ADC 1 interrupt priority"
 	default 2
 
 source "drivers/adc/Kconfig.dw"

--- a/drivers/aio/Kconfig
+++ b/drivers/aio/Kconfig
@@ -10,8 +10,7 @@
 # AIO/Comparator options
 #
 menuconfig AIO_COMPARATOR
-	bool
-	prompt "AIO/Comparator Configuration"
+	bool "AIO/Comparator Configuration"
 
 if AIO_COMPARATOR
 menuconfig AIO_COMPARATOR_QMSI

--- a/drivers/clock_control/Kconfig
+++ b/drivers/clock_control/Kconfig
@@ -10,8 +10,7 @@
 # Clock controller drivers
 #
 menuconfig CLOCK_CONTROL
-	bool
-	prompt "Hardware clock controller support"
+	bool "Hardware clock controller support"
 	help
 	  Enable support for hardware clock controller. Such hardware can
 	  provide clock for other subsystem, and thus can be also used for
@@ -21,8 +20,7 @@ menuconfig CLOCK_CONTROL
 if CLOCK_CONTROL
 
 config SYS_LOG_CLOCK_CONTROL_LEVEL
-	int
-	prompt "Hardware clock controller drivers log level"
+	int "Hardware clock controller drivers log level"
 	depends on SYS_LOG
 	default 0
 	help

--- a/drivers/clock_control/Kconfig.beetle
+++ b/drivers/clock_control/Kconfig.beetle
@@ -9,8 +9,7 @@
 if SOC_FAMILY_ARM
 
 menuconfig CLOCK_CONTROL_BEETLE
-	bool
-	prompt "BEETLE Clock Control"
+	bool "BEETLE Clock Control"
 	depends on SOC_SERIES_BEETLE
 	default y if SOC_SERIES_BEETLE
 	help

--- a/drivers/clock_control/Kconfig.mcux_ccm
+++ b/drivers/clock_control/Kconfig.mcux_ccm
@@ -6,8 +6,7 @@
 #
 
 menuconfig CLOCK_CONTROL_MCUX_CCM
-	bool
-	prompt "MCUX CCM driver"
+	bool "MCUX CCM driver"
 	depends on HAS_MCUX_CCM
 	help
 	  Enable support for mcux ccm driver.

--- a/drivers/clock_control/Kconfig.mcux_sim
+++ b/drivers/clock_control/Kconfig.mcux_sim
@@ -6,8 +6,7 @@
 #
 
 menuconfig CLOCK_CONTROL_MCUX_SIM
-	bool
-	prompt "MCUX SIM driver"
+	bool "MCUX SIM driver"
 	depends on HAS_MCUX_SIM
 	help
 	  Enable support for mcux sim driver.

--- a/drivers/clock_control/Kconfig.nrf5
+++ b/drivers/clock_control/Kconfig.nrf5
@@ -5,8 +5,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 menuconfig CLOCK_CONTROL_NRF5
-	bool
-	prompt "NRF5 Clock controller support"
+	bool "NRF5 Clock controller support"
 	depends on SOC_FAMILY_NRF
 	help
 	  Enable support for the Nordic Semiconductor nRF5x series SoC clock
@@ -15,21 +14,18 @@ menuconfig CLOCK_CONTROL_NRF5
 if CLOCK_CONTROL_NRF5
 
 config CLOCK_CONTROL_NRF5_IRQ_PRIORITY
-	int
-	prompt "Power Clock Interrupt Priority"
+	int "Power Clock Interrupt Priority"
 	range 0 7
 	default 1
 	help
 	  The interrupt priority for Power Clock interrupt.
 
 config CLOCK_CONTROL_NRF5_M16SRC_DRV_NAME
-	string
-	prompt "NRF5 16MHz clock device name"
+	string "NRF5 16MHz clock device name"
 	default "clk_m16src"
 
 config CLOCK_CONTROL_NRF5_K32SRC_DRV_NAME
-	string
-	prompt "NRF5 32KHz clock device name"
+	string "NRF5 32KHz clock device name"
 	default "clk_k32src"
 
 choice
@@ -37,18 +33,15 @@ choice
 	default CLOCK_CONTROL_NRF5_K32SRC_XTAL
 
 config CLOCK_CONTROL_NRF5_K32SRC_RC
-	bool
-	prompt "RC Oscillator"
+	bool "RC Oscillator"
 
 config CLOCK_CONTROL_NRF5_K32SRC_XTAL
-	bool
-	prompt "Crystal Oscillator"
+	bool "Crystal Oscillator"
 
 endchoice
 
 config CLOCK_CONTROL_NRF5_K32SRC_BLOCKING
-	bool
-	prompt "Blocking 32KHz crystal oscillator startup"
+	bool "Blocking 32KHz crystal oscillator startup"
 	depends on CLOCK_CONTROL_NRF5_K32SRC_XTAL
 	help
 	  Clock control driver will spin wait in CPU sleep until 32KHz
@@ -62,36 +55,28 @@ choice
 	default CLOCK_CONTROL_NRF5_K32SRC_20PPM
 
 config CLOCK_CONTROL_NRF5_K32SRC_500PPM
-	bool
-	prompt "251 ppm to 500 ppm"
+	bool "251 ppm to 500 ppm"
 
 config CLOCK_CONTROL_NRF5_K32SRC_250PPM
-	bool
-	prompt "151 ppm to 250 ppm"
+	bool "151 ppm to 250 ppm"
 
 config CLOCK_CONTROL_NRF5_K32SRC_150PPM
-	bool
-	prompt "101 ppm to 150 ppm"
+	bool "101 ppm to 150 ppm"
 
 config CLOCK_CONTROL_NRF5_K32SRC_100PPM
-	bool
-	prompt "76 ppm to 100 ppm"
+	bool "76 ppm to 100 ppm"
 
 config CLOCK_CONTROL_NRF5_K32SRC_75PPM
-	bool
-	prompt "51 ppm to 75 ppm"
+	bool "51 ppm to 75 ppm"
 
 config CLOCK_CONTROL_NRF5_K32SRC_50PPM
-	bool
-	prompt "31 ppm to 50 ppm"
+	bool "31 ppm to 50 ppm"
 
 config CLOCK_CONTROL_NRF5_K32SRC_30PPM
-	bool
-	prompt "21 ppm to 30 ppm"
+	bool "21 ppm to 30 ppm"
 
 config CLOCK_CONTROL_NRF5_K32SRC_20PPM
-	bool
-	prompt "0 ppm to 20 ppm"
+	bool "0 ppm to 20 ppm"
 
 endchoice
 

--- a/drivers/clock_control/Kconfig.quark_se
+++ b/drivers/clock_control/Kconfig.quark_se
@@ -7,47 +7,40 @@
 #
 
 menuconfig CLOCK_CONTROL_QUARK_SE
-	bool
-	prompt "Quark SE Clock controller support"
+	bool "Quark SE Clock controller support"
 	help
 	 Enable support for the Quark SE clock driver.
 
 if CLOCK_CONTROL_QUARK_SE
 
 config CLOCK_CONTROL_QUARK_SE_PERIPHERAL
-	bool
-	prompt "Quark SE peripheral clock support"
+	bool "Quark SE peripheral clock support"
 	help
 	 Enable support for Quark SE peripheral clock which controls the
 	 clock of I2C, SPI, GPIO controllers and more.
 
 config CLOCK_CONTROL_QUARK_SE_PERIPHERAL_DRV_NAME
-	string
-	prompt "Quark SE peripheral clock device name"
+	string "Quark SE peripheral clock device name"
 	depends on CLOCK_CONTROL_QUARK_SE_PERIPHERAL
 	default "clk_peripheral"
 
 config CLOCK_CONTROL_QUARK_SE_EXTERNAL
-	bool
-	prompt "Quark SE external clock support"
+	bool "Quark SE external clock support"
 	help
 	 Enable support for Quark SE external sub-system clock.
 
 config CLOCK_CONTROL_QUARK_SE_EXTERNAL_DRV_NAME
-	string
-	prompt "Quark SE external clock device name"
+	string "Quark SE external clock device name"
 	depends on CLOCK_CONTROL_QUARK_SE_EXTERNAL
 	default "clk_external"
 
 config CLOCK_CONTROL_QUARK_SE_SENSOR
-	bool
-	prompt "Quark SE sensor clock support"
+	bool "Quark SE sensor clock support"
 	help
 	 Enable support for Quark SE sensor sub-system clock.
 
 config CLOCK_CONTROL_QUARK_SE_SENSOR_DRV_NAME
-	string
-	prompt "Quark SE sensor clock device name"
+	string "Quark SE sensor clock device name"
 	depends on CLOCK_CONTROL_QUARK_SE_SENSOR
 	default "clk_sensor"
 

--- a/drivers/clock_control/Kconfig.stm32
+++ b/drivers/clock_control/Kconfig.stm32
@@ -9,8 +9,7 @@
 if SOC_FAMILY_STM32
 
 menuconfig CLOCK_CONTROL_STM32_CUBE
-	bool
-	prompt "STM32 Reset & Clock Control"
+	bool "STM32 Reset & Clock Control"
 	depends on CLOCK_CONTROL
 	select USE_STM32_LL_UTILS
 	help

--- a/drivers/console/Kconfig
+++ b/drivers/console/Kconfig
@@ -8,8 +8,7 @@
 #
 
 menuconfig CONSOLE
-	bool
-	prompt "Console drivers"
+	bool "Console drivers"
 
 if CONSOLE
 
@@ -27,8 +26,7 @@ config CONSOLE_HAS_DRIVER
 	  that some kind of console exists.
 
 config CONSOLE_HANDLER
-	bool
-	prompt "Enable console input handler"
+	bool "Enable console input handler"
 	depends on UART_CONSOLE
 	select UART_INTERRUPT_DRIVEN
 	help
@@ -36,8 +34,7 @@ config CONSOLE_HANDLER
 	  interaction between serial console and the OS.
 
 config UART_CONSOLE
-	bool
-	prompt "Use UART for console"
+	bool "Use UART for console"
 	depends on SERIAL && SERIAL_HAS_DRIVER
 	select CONSOLE_HAS_DRIVER
 	help
@@ -55,8 +52,7 @@ config UART_CONSOLE_ON_DEV_NAME
 endif
 
 config UART_CONSOLE_INIT_PRIORITY
-	int
-	prompt "Init priority"
+	int "Init priority"
 	default 60
 	depends on UART_CONSOLE
 	help
@@ -65,8 +61,7 @@ config UART_CONSOLE_INIT_PRIORITY
 	  it uses.
 
 config UART_CONSOLE_DEBUG_SERVER_HOOKS
-	bool
-	prompt "Debug server hooks in debug console"
+	bool "Debug server hooks in debug console"
 	depends on UART_CONSOLE
 	help
 	  This option allows a debug server agent such as GDB to take over the
@@ -76,8 +71,7 @@ config UART_CONSOLE_DEBUG_SERVER_HOOKS
 	  code handle them if they are of no special significance to it.
 
 config UART_CONSOLE_MCUMGR
-	bool
-	prompt "Enable UART console mcumgr passthrough"
+	bool "Enable UART console mcumgr passthrough"
 	depends on UART_CONSOLE
 	help
 	  Enables the UART console to receive mcumgr frames for image upgrade
@@ -86,8 +80,7 @@ config UART_CONSOLE_MCUMGR
 	  (e.g., the shell).  If unset, incoming mcumgr frames are dropped.
 
 config USB_UART_CONSOLE
-	bool
-	prompt "Use USB port for console outputs"
+	bool "Use USB port for console outputs"
 	depends on SERIAL
 	select CONSOLE_HAS_DRIVER
 	select USB_CDC_ACM
@@ -99,8 +92,7 @@ config USB_UART_CONSOLE
 	  selected in conjunction with, say, USB Mass Storage.
 
 config USB_UART_DTR_WAIT
-	bool
-	prompt "Wait on DTR control signal"
+	bool "Wait on DTR control signal"
 	depends on USB_UART_CONSOLE
 	help
 	  Enable this option to use flow control on the console. The uart console
@@ -108,8 +100,7 @@ config USB_UART_DTR_WAIT
 	  Note: Disabling this might lead to missing console prints.
 
 config RAM_CONSOLE
-	bool
-	prompt "Use RAM console"
+	bool "Use RAM console"
 	select CONSOLE_HAS_DRIVER
 	help
 	  Emit console messages to a RAM buffer "ram_console" which can
@@ -125,8 +116,7 @@ config RAM_CONSOLE_BUFFER_SIZE
 	  length is exceeded.
 
 config RTT_CONSOLE
-	bool
-	prompt "Use RTT console"
+	bool "Use RTT console"
 	depends on HAS_SEGGER_RTT
 	select CONSOLE_HAS_DRIVER
 	help
@@ -164,22 +154,19 @@ config RTT_TX_RETRY_IN_INTERRUPT
 endif
 
 config IPM_CONSOLE_SENDER
-	bool
-	prompt "Inter-processor Mailbox console sender"
+	bool "Inter-processor Mailbox console sender"
 	select CONSOLE_HAS_DRIVER
 	help
 	  Enable the sending side of IPM console
 
 config IPM_CONSOLE_RECEIVER
-	bool
-	prompt "Inter-processor Mailbox console receiver"
+	bool "Inter-processor Mailbox console receiver"
 	select RING_BUFFER
 	help
 	  Enable the receiving side of IPM console
 
 config IPM_CONSOLE_STACK_SIZE
-	int
-	prompt "Stack size for IPM console receiver thread"
+	int "Stack size for IPM console receiver thread"
 	depends on IPM_CONSOLE_RECEIVER
 	default 512
 	help
@@ -188,8 +175,7 @@ config IPM_CONSOLE_STACK_SIZE
 	  stack size for these threads here.
 
 config IPM_CONSOLE_INIT_PRIORITY
-	int
-	prompt "IPM console init priority"
+	int "IPM console init priority"
 	default 60
 	depends on IPM_CONSOLE_SENDER || IPM_CONSOLE_RECEIVER
 	help
@@ -198,8 +184,7 @@ config IPM_CONSOLE_INIT_PRIORITY
 	  it uses.
 
 config	UART_PIPE
-	bool
-	prompt "Enable pipe UART driver"
+	bool "Enable pipe UART driver"
 	select UART_INTERRUPT_DRIVEN
 	help
 	  Enable pipe UART driver. This driver allows application to communicate
@@ -218,8 +203,7 @@ config UART_PIPE_ON_DEV_NAME
 endif
 
 config UART_MCUMGR
-	bool
-	prompt "Enable mcumgr UART driver"
+	bool "Enable mcumgr UART driver"
 	select UART_INTERRUPT_DRIVEN
 	help
 	  Enable the mcumgr UART driver. This driver allows the application to
@@ -240,8 +224,7 @@ config UART_MCUMGR_ON_DEV_NAME
 endif # !HAS_DTS
 
 config UART_MCUMGR_RX_BUF_SIZE
-	int
-	prompt "Size of receive buffer for mcumgr fragments received over UART, in bytes"
+	int "Size of receive buffer for mcumgr fragments received over UART, in bytes"
 	default 128
 	help
 	  Specifies the size of the mcumgr UART receive buffer, in bytes. This
@@ -249,8 +232,7 @@ config UART_MCUMGR_RX_BUF_SIZE
 	  client.
 
 config UART_MCUMGR_RX_BUF_COUNT
-	int
-	prompt "Number of receive buffers for mcumgr fragments received over UART"
+	int "Number of receive buffers for mcumgr fragments received over UART"
 	default 2
 	help
 	  Specifies the number of the mcumgr UART receive buffers.  Receive
@@ -262,8 +244,7 @@ config UART_MCUMGR_RX_BUF_COUNT
 endif # UART_MCUMGR
 
 config XTENSA_SIM_CONSOLE
-	bool
-	prompt "Use Xtensa simulator console"
+	bool "Use Xtensa simulator console"
 	depends on SIMULATOR_XTENSA
 	select CONSOLE_HAS_DRIVER
 	default y
@@ -287,16 +268,14 @@ config NATIVE_POSIX_STDIN_CONSOLE
 	  Feed the host terminal stdin to the Zephyr console/shell.
 
 config NATIVE_STDIN_POLL_PERIOD
-	int
-	prompt "Polling period for stdin"
+	int "Polling period for stdin"
 	depends on NATIVE_POSIX_STDIN_CONSOLE
 	default 20
 	help
 	  In ms, polling period for stdin
 
 config NATIVE_STDIN_PRIO
-	int
-	prompt "Priority of the stdin polling thread"
+	int "Priority of the stdin polling thread"
 	depends on NATIVE_POSIX_STDIN_CONSOLE
 	default 4
 	help
@@ -310,16 +289,14 @@ config NATIVE_POSIX_STDOUT_CONSOLE
 	  Zephyr's printk messages will be directed to the host terminal stdout.
 
 config XTENSA_CONSOLE_INIT_PRIORITY
-	int
-	prompt "Init priority"
+	int "Init priority"
 	default 60
 	depends on XTENSA_SIM_CONSOLE
 	help
 	  Device driver initialization priority.
 
 config NATIVE_POSIX_CONSOLE_INIT_PRIORITY
-	int
-	prompt "Init priority"
+	int "Init priority"
 	default 60
 	depends on NATIVE_POSIX_CONSOLE
 	help

--- a/drivers/counter/Kconfig.dtmr_cmsdk_apb
+++ b/drivers/counter/Kconfig.dtmr_cmsdk_apb
@@ -9,8 +9,7 @@
 if SOC_FAMILY_ARM
 
 config TIMER_DTMR_CMSDK_APB
-	bool
-	prompt "ARM CMSDK (Cortex-M System Design Kit) DTMR Timer driver"
+	bool "ARM CMSDK (Cortex-M System Design Kit) DTMR Timer driver"
 	help
 	  The dualtimer (DTMR) present in the platform is used as a timer.
 	  This option enables the support for the timer.
@@ -20,8 +19,7 @@ if TIMER_DTMR_CMSDK_APB
 # ---------- Timer 0 ----------
 
 config TIMER_DTMR_CMSDK_APB_0
-	bool
-	prompt "Timer 0 driver"
+	bool "Timer 0 driver"
 	help
 	  Enable support for Timer 0.
 
@@ -42,8 +40,7 @@ config TIMER_DTMR_CMSDK_APB_0_IRQ_PRI
 endif # TIMER_DTMR_CMSDK_APB
 
 config COUNTER_DTMR_CMSDK_APB
-	bool
-	prompt "ARM CMSDK (Cortex-M System Design Kit) DTMR Counter driver"
+	bool "ARM CMSDK (Cortex-M System Design Kit) DTMR Counter driver"
 	help
 	  The dualtimer (DTMR) present in the platform is used as a counter.
 	  This option enables the support for the counter.
@@ -53,8 +50,7 @@ if COUNTER_DTMR_CMSDK_APB
 # ---------- Counter 0 ----------
 
 config COUNTER_DTMR_CMSDK_APB_0
-	bool
-	prompt "Counter 0 driver"
+	bool "Counter 0 driver"
 	depends on !TIMER_DTMR_CMSDK_APB_0
 	help
 	  Enable support for Counter 0.

--- a/drivers/counter/Kconfig.qmsi
+++ b/drivers/counter/Kconfig.qmsi
@@ -7,8 +7,7 @@
 #
 
 config AON_COUNTER_QMSI
-	bool
-	prompt "AON counter driver"
+	bool "AON counter driver"
 	depends on COUNTER && QMSI
 	help
 	  Enable support for AON counter.
@@ -21,8 +20,7 @@ config AON_COUNTER_QMSI_DEV_NAME
 	  Specify the device name for AON counter driver.
 
 config AON_TIMER_QMSI
-	bool
-	prompt "AON periodic timer driver"
+	bool "AON periodic timer driver"
 	depends on COUNTER && QMSI
 	help
 	  Enable support for AON periodic timer.
@@ -41,8 +39,7 @@ config AON_TIMER_IRQ_PRI
 	  aon timer interrupt priority.
 
 config AON_API_REENTRANCY
-	bool
-	prompt "AON driver API reentrancy"
+	bool "AON driver API reentrancy"
 	depends on AON_TIMER_QMSI
 	help
 	  Enable support for AON driver API reentrancy.

--- a/drivers/counter/Kconfig.tmr_cmsdk_apb
+++ b/drivers/counter/Kconfig.tmr_cmsdk_apb
@@ -9,8 +9,7 @@
 if SOC_FAMILY_ARM
 
 config TIMER_TMR_CMSDK_APB
-	bool
-	prompt "ARM CMSDK (Cortex-M System Design Kit) Timer driver"
+	bool "ARM CMSDK (Cortex-M System Design Kit) Timer driver"
 	help
 	  The timers (TMR) present in the platform are used as timers.
 	  This option enables the support for the timers.
@@ -20,8 +19,7 @@ if TIMER_TMR_CMSDK_APB
 # ---------- Timer 0 ----------
 
 config TIMER_TMR_CMSDK_APB_0
-	bool
-	prompt "Timer 0 driver"
+	bool "Timer 0 driver"
 	help
 	  Enable support for Timer 0.
 
@@ -42,8 +40,7 @@ config TIMER_TMR_CMSDK_APB_0_IRQ_PRI
 # ---------- Timer 1 ----------
 
 config TIMER_TMR_CMSDK_APB_1
-	bool
-	prompt "Timer 1 driver"
+	bool "Timer 1 driver"
 	help
 	  Enable support for Timer 1.
 
@@ -64,8 +61,7 @@ config TIMER_TMR_CMSDK_APB_1_IRQ_PRI
 endif # TIMER_TMR_CMSDK_APB
 
 config COUNTER_TMR_CMSDK_APB
-	bool
-	prompt "ARM CMSDK (Cortex-M System Design Kit) Counter driver"
+	bool "ARM CMSDK (Cortex-M System Design Kit) Counter driver"
 	help
 	  The timers (TMR) present in the platform are used as counters.
 	  This option enables the support for the counters.
@@ -75,8 +71,7 @@ if COUNTER_TMR_CMSDK_APB
 # ---------- Counter 0 ----------
 
 config COUNTER_TMR_CMSDK_APB_0
-	bool
-	prompt "Counter 0 driver"
+	bool "Counter 0 driver"
 	depends on !TIMER_TMR_CMSDK_APB_0
 	help
 	  Enable support for Counter 0.
@@ -91,8 +86,7 @@ config COUNTER_TMR_CMSDK_APB_0_DEV_NAME
 # ---------- Counter 1 ----------
 
 config COUNTER_TMR_CMSDK_APB_1
-	bool
-	prompt "Counter 1 driver"
+	bool "Counter 1 driver"
 	depends on !TIMER_TMR_CMSDK_APB_1
 	help
 	  Enable support for Counter 1.

--- a/drivers/crypto/Kconfig
+++ b/drivers/crypto/Kconfig
@@ -10,8 +10,7 @@
 # CRYPTO options
 #
 menuconfig CRYPTO
-	bool
-	prompt "Crypto Drivers [EXPERIMENTAL]"
+	bool "Crypto Drivers [EXPERIMENTAL]"
 
 if CRYPTO
 

--- a/drivers/display/Kconfig
+++ b/drivers/display/Kconfig
@@ -7,8 +7,7 @@
 #
 
 menuconfig DISPLAY
-	bool
-	prompt "Display Drivers"
+	bool "Display Drivers"
 	help
 	  Enable display drivers
 

--- a/drivers/display/Kconfig.ili9340
+++ b/drivers/display/Kconfig.ili9340
@@ -104,8 +104,7 @@ choice
 	Specify the type of LCD connected to the ILI9340 display controller.
 
 config ILI9340_LCD_ADAFRUIT_1480
-	bool
-	prompt "Adafruit 2.2\" TFT 1480"
+	bool "Adafruit 2.2\" TFT 1480"
 
 endchoice
 

--- a/drivers/dma/Kconfig
+++ b/drivers/dma/Kconfig
@@ -10,8 +10,7 @@
 # DMA options
 #
 menuconfig DMA
-	bool
-	prompt "DMA driver Configuration"
+	bool "DMA driver Configuration"
 
 if DMA
 config DMA_0_NAME
@@ -51,8 +50,7 @@ config DMA_2_IRQ_PRI
 	  IRQ Priority for DMA Controller 2.
 
 config SYS_LOG_DMA_LEVEL
-	int
-	prompt "DMA Driver Log level"
+	int "DMA Driver Log level"
 	depends on SYS_LOG
 	default 0
 	range 0 4
@@ -66,8 +64,7 @@ config SYS_LOG_DMA_LEVEL
 	  4 DEBUG, write SYS_LOG_DBG in addition to previous levels
 
 config DCACHE_WRITEBACK
-	bool
-	prompt "Data Cache Writeback"
+	bool "Data Cache Writeback"
 	help
 	  Cache configuration for "Writeback".
 

--- a/drivers/entropy/Kconfig
+++ b/drivers/entropy/Kconfig
@@ -7,8 +7,7 @@
 #
 
 menuconfig ENTROPY_GENERATOR
-	bool
-	prompt "Entropy Drivers"
+	bool "Entropy Drivers"
 	help
 	  Include entropy drivers in system config.
 

--- a/drivers/ethernet/Kconfig
+++ b/drivers/ethernet/Kconfig
@@ -9,8 +9,7 @@
 menu "Ethernet Drivers"
 
 config SYS_LOG_ETHERNET_LEVEL
-	int
-	prompt "Ethernet driver log level"
+	int "Ethernet driver log level"
 	depends on SYS_LOG && NET_L2_ETHERNET
 	default 0
 	range 0 4
@@ -24,8 +23,7 @@ config SYS_LOG_ETHERNET_LEVEL
 	  4 DEBUG, write SYS_LOG_DBG in addition to previous levels
 
 config ETH_INIT_PRIORITY
-	int
-	prompt "Ethernet driver init priority"
+	int "Ethernet driver init priority"
 	depends on NET_L2_ETHERNET
 	default 80
 	help

--- a/drivers/ethernet/Kconfig.dw
+++ b/drivers/ethernet/Kconfig.dw
@@ -7,8 +7,7 @@
 #
 
 menuconfig ETH_DW
-	bool
-	prompt "Synopsys DesignWare Ethernet driver"
+	bool "Synopsys DesignWare Ethernet driver"
 	depends on NET_L2_ETHERNET
 	help
 	  Enable Synopsys DesignWare Ethernet driver.

--- a/drivers/ethernet/Kconfig.mcux
+++ b/drivers/ethernet/Kconfig.mcux
@@ -5,8 +5,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 menuconfig ETH_MCUX
-	bool
-	prompt "MCUX Ethernet driver"
+	bool "MCUX Ethernet driver"
 	depends on NET_L2_ETHERNET && HAS_MCUX
 	help
 	  Enable MCUX Ethernet driver.  Note, this driver performs one shot PHY

--- a/drivers/ethernet/Kconfig.sam_gmac
+++ b/drivers/ethernet/Kconfig.sam_gmac
@@ -5,8 +5,7 @@
 #
 
 menuconfig ETH_SAM_GMAC
-	bool
-	prompt "Atmel SAM Ethernet driver"
+	bool "Atmel SAM Ethernet driver"
 	depends on SOC_FAMILY_SAM
 	help
 	  Enable Atmel SAM MCU Family Ethernet driver.

--- a/drivers/ethernet/Kconfig.stm32_hal
+++ b/drivers/ethernet/Kconfig.stm32_hal
@@ -7,8 +7,7 @@
 #
 
 menuconfig ETH_STM32_HAL
-	bool
-	prompt "STM32 HAL Ethernet driver"
+	bool "STM32 HAL Ethernet driver"
 	depends on NET_L2_ETHERNET
 	select USE_STM32_HAL_ETH
 	help

--- a/drivers/flash/Kconfig
+++ b/drivers/flash/Kconfig
@@ -21,8 +21,7 @@ config FLASH_HAS_PAGE_LAYOUT
 	  retrieving the layout of flash memory pages.
 
 menuconfig FLASH
-	bool
-	prompt "Flash hardware support"
+	bool "Flash hardware support"
 	help
 	  Enable support for the flash hardware.
 

--- a/drivers/flash/Kconfig.qmsi
+++ b/drivers/flash/Kconfig.qmsi
@@ -5,8 +5,7 @@
 #
 
 menuconfig SOC_FLASH_QMSI
-	bool
-	prompt "QMSI flash driver"
+	bool "QMSI flash driver"
 	depends on QMSI && FLASH
 	select FLASH_HAS_DRIVER_ENABLED
 	help

--- a/drivers/flash/Kconfig.sam0
+++ b/drivers/flash/Kconfig.sam0
@@ -6,16 +6,14 @@
 if FLASH && SOC_FAMILY_SAM0
 
 menuconfig SOC_FLASH_SAM0
-	bool
-	prompt "Atmel SAM0 flash driver"
+	bool "Atmel SAM0 flash driver"
 	select FLASH_HAS_PAGE_LAYOUT
 	select FLASH_HAS_DRIVER_ENABLED
 	help
 	 Enable the Atmel SAM0 series internal flash driver.
 
 config SOC_FLASH_SAM0_EMULATE_BYTE_PAGES
-	bool
-	prompt "Emulate byte-sized pages"
+	bool "Emulate byte-sized pages"
 	depends on SOC_FLASH_SAM0
 	help
 	 Emulate a device with byte-sized pages by doing a

--- a/drivers/flash/Kconfig.stm32
+++ b/drivers/flash/Kconfig.stm32
@@ -9,8 +9,7 @@
 if FLASH && SOC_FAMILY_STM32
 
 menuconfig SOC_FLASH_STM32
-	bool
-	prompt "STM32 flash driver"
+	bool "STM32 flash driver"
 	depends on (SOC_SERIES_STM32F0X || SOC_SERIES_STM32F3X || SOC_SERIES_STM32F4X || SOC_SERIES_STM32L4X)
 	select FLASH_HAS_DRIVER_ENABLED
 	default y

--- a/drivers/flash/Kconfig.w25qxxdv
+++ b/drivers/flash/Kconfig.w25qxxdv
@@ -6,20 +6,17 @@
 
 
 menuconfig SPI_FLASH_W25QXXDV
-	bool
-	prompt "SPI NOR Flash Winbond W25QXXDV"
+	bool "SPI NOR Flash Winbond W25QXXDV"
 	select FLASH_HAS_DRIVER_ENABLED
 	depends on SPI && FLASH
 
 if SPI_FLASH_W25QXXDV
 
 config SPI_FLASH_W25QXXDV_SPI_NAME
-	string
-	prompt "SPI controller device name"
+	string "SPI controller device name"
 
 config SPI_FLASH_W25QXXDV_DRV_NAME
-	string
-	prompt "SPI flash device name"
+	string "SPI flash device name"
 	default "W25QXXDV"
 
 config SPI_FLASH_W25QXXDV_INIT_PRIORITY

--- a/drivers/gpio/Kconfig
+++ b/drivers/gpio/Kconfig
@@ -7,16 +7,14 @@
 #
 
 menuconfig GPIO
-	bool
-	prompt "GPIO Drivers"
+	bool "GPIO Drivers"
 	help
 	  Include GPIO drivers in system config
 
 if GPIO
 
 config SYS_LOG_GPIO_LEVEL
-	int
-	prompt "GPIO drivers log level"
+	int "GPIO drivers log level"
 	default 0
 	depends on SYS_LOG
 	help

--- a/drivers/gpio/Kconfig.cc2650
+++ b/drivers/gpio/Kconfig.cc2650
@@ -13,13 +13,11 @@ if GPIO_CC2650
 # A single block of GPIO exist.
 
 config GPIO_CC2650_NAME
-	string
+	string "GPIO driver name."
 	default "GPIO_0"
-	prompt "GPIO driver name."
 
 config GPIO_CC2650_INIT_PRIO
-	int
+	int "GPIO driver initialization priority."
 	default 40
-	prompt "GPIO driver initialization priority."
 
 endif # GPIO_CC2650

--- a/drivers/gpio/Kconfig.dw
+++ b/drivers/gpio/Kconfig.dw
@@ -7,9 +7,8 @@
 #
 
 menuconfig GPIO_DW
-	prompt "Designware GPIO"
+	bool "Designware GPIO"
 	depends on GPIO
-	bool
 	help
 	  Enable driver for Designware GPIO
 
@@ -19,9 +18,8 @@ config GPIO_DW_SHARED_IRQ
 	bool
 
 config GPIO_DW_INIT_PRIORITY
-	int
+	int "Init priority"
 	default 60
-	prompt "Init priority"
 	help
 	  Device driver initialization priority.
 

--- a/drivers/gpio/Kconfig.pcal9535a
+++ b/drivers/gpio/Kconfig.pcal9535a
@@ -15,8 +15,7 @@ menuconfig GPIO_PCAL9535A
 if GPIO_PCAL9535A
 
 config SYS_LOG_GPIO_PCAL9535A_LEVEL
-	int
-	prompt "PCAL9535A driver log level"
+	int "PCAL9535A driver log level"
 	depends on GPIO_PCAL9535A && SYS_LOG
 	default 0
 	help
@@ -35,9 +34,8 @@ config SYS_LOG_GPIO_PCAL9535A_LEVEL
 	  - 4 DEBUG, write SYS_LOG_DBG in addition to previous levels
 
 config GPIO_PCAL9535A_INIT_PRIORITY
-	int
+	int "Init priority"
 	default 70
-	prompt "Init priority"
 	help
 	  Device driver initialization priority.
 

--- a/drivers/gpio/Kconfig.qmsi
+++ b/drivers/gpio/Kconfig.qmsi
@@ -23,16 +23,14 @@ menuconfig GPIO_QMSI_SS
 if GPIO_QMSI || GPIO_QMSI_SS
 
 config GPIO_QMSI_INIT_PRIORITY
-	int
+	int "Init priority"
 	default 60
 	depends on GPIO_QMSI
-	prompt "Init priority"
 	help
 	  Device driver initialization priority.
 
 config GPIO_QMSI_API_REENTRANCY
-	bool
-	prompt "GPIO driver API reentrancy"
+	bool "GPIO driver API reentrancy"
 	depends on GPIO_QMSI
 	help
 	  Enable support for QMSI GPIO driver API reentrancy.

--- a/drivers/gpio/Kconfig.sch
+++ b/drivers/gpio/Kconfig.sch
@@ -15,10 +15,9 @@ menuconfig GPIO_SCH
 if GPIO_SCH
 
 config GPIO_SCH_INIT_PRIORITY
-	int
+	int "Init priority"
 	depends on GPIO_SCH
 	default 60
-	prompt "Init priority"
 	help
 	  Device driver initialization priority.
 

--- a/drivers/gpio/Kconfig.sx1509b
+++ b/drivers/gpio/Kconfig.sx1509b
@@ -13,9 +13,8 @@ menuconfig GPIO_SX1509B
 	  Enable driver for SX1509B I2C GPIO chip.
 
 config GPIO_SX1509B_INIT_PRIORITY
-	int
+	int "Init priority"
 	default 70
-	prompt "Init priority"
 	help
 	  Device driver initialization priority.
 

--- a/drivers/grove/Kconfig
+++ b/drivers/grove/Kconfig
@@ -8,15 +8,13 @@
 
 
 menuconfig GROVE
-	bool
-	prompt "Grove Device Drivers"
+	bool "Grove Device Drivers"
 	help
 	  Check this box to enable the Seeed Grove device drivers
 
 
 config SYS_LOG_GROVE_LEVEL
-	int
-	prompt "Grove Log level"
+	int "Grove Log level"
 	depends on SYS_LOG && GROVE
 	default 0
 	range 0 4
@@ -30,9 +28,8 @@ config SYS_LOG_GROVE_LEVEL
 	  4 DEBUG, write SYS_LOG_DBG in addition to previous levels
 
 config GROVE_LCD_RGB
-	bool
+	bool "Enable the Seeed Grove LCD RGB Backlight"
 	depends on GROVE
-	prompt "Enable the Seeed Grove LCD RGB Backlight"
 	help
 	  Setting this value will enable driver support for the Groove-LCD RGB
 	  Backlight.
@@ -46,24 +43,21 @@ config GROVE_LCD_RGB_I2C_MASTER_DEV_NAME
 	  Grove LCD is connected.
 
 config GROVE_LIGHT_SENSOR
-	bool
-	prompt "Enable the Seeed Grove Light Sensor"
+	bool "Enable the Seeed Grove Light Sensor"
 	depends on SENSOR && GROVE && ADC && NEWLIB_LIBC
 	help
 	  Setting this value will enable driver support for the Grove Light
 	  Sensor.
 
 config GROVE_LIGHT_SENSOR_NAME
-	string
-	prompt "Driver name"
+	string "Driver name"
 	depends on GROVE_LIGHT_SENSOR
 	default "GROVE_LIGHT_SENSOR"
 	help
 	  Specify the device name with which the sensor is identified.
 
 config GROVE_LIGHT_SENSOR_ADC_DEV_NAME
-	string
-	prompt "ADC where Grove Light Sensor is connected"
+	string "ADC where Grove Light Sensor is connected"
 	depends on GROVE_LIGHT_SENSOR
 	default "ADC_0"
 	help
@@ -71,8 +65,7 @@ config GROVE_LIGHT_SENSOR_ADC_DEV_NAME
 	  is connected.
 
 config GROVE_LIGHT_SENSOR_ADC_CHANNEL
-	int
-	prompt "ADC channel used by Grove Light Sensor"
+	int "ADC channel used by Grove Light Sensor"
 	depends on GROVE_LIGHT_SENSOR
 	default 10
 	help
@@ -80,16 +73,14 @@ config GROVE_LIGHT_SENSOR_ADC_CHANNEL
 	  connected.
 
 config GROVE_TEMPERATURE_SENSOR
-	bool
-	prompt "Enable the Seeed Grove Temperature Sensor"
+	bool "Enable the Seeed Grove Temperature Sensor"
 	depends on SENSOR && GROVE && ADC && NEWLIB_LIBC
 	help
 	  Setting this value will enable driver support for the Grove
 	  Temperature Sensor.
 
 config GROVE_TEMPERATURE_SENSOR_NAME
-	string
-	prompt "Driver name"
+	string "Driver name"
 	depends on GROVE_TEMPERATURE_SENSOR
 	default "GROVE_TEMPERATURE_SENSOR"
 	help
@@ -104,22 +95,19 @@ choice
 	  Choose the version of the Grove Temperature Sensor.
 
 config GROVE_TEMPERATURE_SENSOR_V1_0
-	bool
-	prompt "v1.0"
+	bool "v1.0"
 	help
 	  Version 1.0
 
 config GROVE_TEMPERATURE_SENSOR_V1_X
-	bool
-	prompt "v1.1/v1.2"
+	bool "v1.1/v1.2"
 	help
 	  Version 1.1 or 1.2
 
 endchoice
 
 config GROVE_TEMPERATURE_SENSOR_ADC_DEV_NAME
-	string
-	prompt "ADC where Grove Temperature Sensor is connected"
+	string "ADC where Grove Temperature Sensor is connected"
 	depends on GROVE_TEMPERATURE_SENSOR
 	default "ADC_0"
 	help
@@ -127,8 +115,7 @@ config GROVE_TEMPERATURE_SENSOR_ADC_DEV_NAME
 	  Sensor is connected.
 
 config GROVE_TEMPERATURE_SENSOR_ADC_CHANNEL
-	int
-	prompt "ADC channel used by Grove Temperature Sensor"
+	int "ADC channel used by Grove Temperature Sensor"
 	depends on GROVE_TEMPERATURE_SENSOR
 	default 10
 	help

--- a/drivers/i2s/Kconfig
+++ b/drivers/i2s/Kconfig
@@ -8,8 +8,7 @@
 # I2S Drivers
 #
 menuconfig I2S
-	bool
-	prompt "I2S bus drivers"
+	bool "I2S bus drivers"
 	help
 	  Enable support for the I2S (Inter-IC Sound) hardware bus.
 

--- a/drivers/interrupt_controller/Kconfig.shared_irq
+++ b/drivers/interrupt_controller/Kconfig.shared_irq
@@ -7,16 +7,14 @@
 #
 
 menuconfig SHARED_IRQ
-	bool
-	prompt "Shared interrupt driver"
+	bool "Shared interrupt driver"
 	help
 	 Include shared interrupt support in system. Shared interrupt
 	 support is NOT required in most systems. If in doubt answer no.
 
 config SHARED_IRQ_NUM_CLIENTS
-	int
+	int "The number of clients per instance"
 	depends on SHARED_IRQ
-	prompt "The number of clients per instance"
 	default 5
 	help
 	 Configures the maximum number of clients allowed per shared
@@ -24,10 +22,9 @@ config SHARED_IRQ_NUM_CLIENTS
 	 this value to the lowest practical value.
 
 config SHARED_IRQ_INIT_PRIORITY
-	int
+	int "Shared IRQ init priority"
 	depends on SHARED_IRQ
 	default 45
-	prompt "Shared IRQ init priority"
 	help
 	 Shared IRQ are initialized on POST_KERNEL init level. They
 	 have to be initialized before any device that uses them.

--- a/drivers/ipm/Kconfig
+++ b/drivers/ipm/Kconfig
@@ -1,6 +1,5 @@
 menuconfig IPM
-	bool
-	prompt "IPM drivers"
+	bool "IPM drivers"
 	help
 	  Include interrupt-based inter-processor mailboxes
 	  drivers in system configuration

--- a/drivers/net/Kconfig
+++ b/drivers/net/Kconfig
@@ -34,8 +34,7 @@
 # SLIP options
 #
 menuconfig SLIP
-	bool
-	prompt "SLIP driver"
+	bool "SLIP driver"
 	select UART_PIPE
 	select UART_INTERRUPT_DRIVEN
 
@@ -58,8 +57,7 @@ config	SLIP_MTU
 	  does not use this value.
 
 config	SYS_LOG_SLIP_LEVEL
-	int
-	prompt "SLIP driver log level"
+	int "SLIP driver log level"
 	depends on SYS_LOG && SLIP
 	default 0
 	range 0 4
@@ -100,15 +98,13 @@ endif
 # Net loopback options
 #
 menuconfig NET_LOOPBACK
-	bool
-	prompt "Net loopback driver"
+	bool "Net loopback driver"
 	select NET_L2_DUMMY
 
 if NET_LOOPBACK
 
 config  SYS_LOG_NET_LOOPBACK_LEVEL
-        int
-        prompt "Net loopback driver log level"
+        int "Net loopback driver log level"
         depends on SYS_LOG && NET_LOOPBACK
         default 0
         range 0 4

--- a/drivers/pci/Kconfig
+++ b/drivers/pci/Kconfig
@@ -8,16 +8,14 @@
 
 
 menuconfig PCI
-	bool
-	prompt "PCI Settings"
+	bool "PCI Settings"
 	depends on X86
 	help
 	  This options enables support of PCI bus for device drivers.
 
 if PCI
 config PCI_ENUMERATION
-	bool
-	prompt "Enable PCI device enumeration"
+	bool "Enable PCI device enumeration"
 	help
 	  This option enables the PCI enumeration for device drivers.
 	  This might be useful along with PCI_DEBUG to find out which
@@ -26,8 +24,7 @@ config PCI_ENUMERATION
 	  might be wise to disable this option to remove useless code.
 
 config PCI_LEGACY_BRIDGE
-	bool
-	prompt "PCI legacy bridge device support"
+	bool "PCI legacy bridge device support"
 	help
 	  This option adds support for PCI legacy bridge device, that
 	  allows direct setup of the PCI interrupt pin to IRQ number
@@ -54,8 +51,7 @@ config PCI_LEGACY_BRIDGE_DEVICE_ID
 	default 0
 
 config PCI_DEBUG
-	bool
-	prompt "Enable PCI debugging"
+	bool "Enable PCI debugging"
 	help
 	  This options enables PCI debugging functions
 

--- a/drivers/pinmux/Kconfig
+++ b/drivers/pinmux/Kconfig
@@ -24,8 +24,7 @@ config PINMUX_NAME
 	  The name of the pinmux driver.
 
 config PINMUX_INIT_PRIORITY
-	int
-	prompt "Init priority"
+	int "Init priority"
 	default 45
 	depends on PINMUX
 	help

--- a/drivers/pwm/Kconfig
+++ b/drivers/pwm/Kconfig
@@ -14,8 +14,7 @@ menuconfig PWM
 if PWM
 
 config SYS_LOG_PWM_LEVEL
-	int
-	prompt "PWM Driver Log level"
+	int "PWM Driver Log level"
 	depends on SYS_LOG
 	default 0
 	range 0 4

--- a/drivers/pwm/Kconfig.imx
+++ b/drivers/pwm/Kconfig.imx
@@ -6,8 +6,7 @@
 #
 
 menuconfig PWM_IMX
-	bool
-	prompt "i.MX PWM Driver"
+	bool "i.MX PWM Driver"
 	depends on PWM
 	help
 	  Enable support for i.MX pwm driver.

--- a/drivers/pwm/Kconfig.mcux_ftm
+++ b/drivers/pwm/Kconfig.mcux_ftm
@@ -6,8 +6,7 @@
 #
 
 menuconfig PWM_MCUX_FTM
-	bool
-	prompt "MCUX FTM PWM driver"
+	bool "MCUX FTM PWM driver"
 	depends on HAS_MCUX_FTM
 	help
 	  Enable support for mcux ftm pwm driver.

--- a/drivers/pwm/Kconfig.nrf5_sw
+++ b/drivers/pwm/Kconfig.nrf5_sw
@@ -25,8 +25,7 @@ config PWM_NRF5_SW_0_DEV_NAME
 	  PWM driver.
 
 config PWM_NRF5_SW_0_CLOCK_PRESCALER
-	int
-	prompt "Nordic Semiconductor nRF5x series S/W PWM Clock Prescaler"
+	int "Nordic Semiconductor nRF5x series S/W PWM Clock Prescaler"
 	default 0
 	range 0 9
 	help

--- a/drivers/pwm/Kconfig.pca9685
+++ b/drivers/pwm/Kconfig.pca9685
@@ -19,10 +19,9 @@ menuconfig PWM_PCA9685
 if PWM_PCA9685
 
 config PWM_PCA9685_INIT_PRIORITY
-	int
+	int "Init priority"
 	depends on PWM_PCA9685
 	default 70
-	prompt "Init priority"
 	help
 	  Device driver initialization priority.
 

--- a/drivers/pwm/Kconfig.qmsi
+++ b/drivers/pwm/Kconfig.qmsi
@@ -29,8 +29,7 @@ config PWM_QMSI_NUM_PORTS
 	  Specify how many PWM ports on the IP block.
 
 config PWM_QMSI_API_REENTRANCY
-	bool
-	prompt "PWM shim driver API reentrancy"
+	bool "PWM shim driver API reentrancy"
 	depends on PWM_QMSI
 	help
 	  Enable support for PWM shim driver API reentrancy.

--- a/drivers/rtc/Kconfig.mcux_rtc
+++ b/drivers/rtc/Kconfig.mcux_rtc
@@ -6,8 +6,7 @@
 #
 
 menuconfig RTC_MCUX
-	bool
-	prompt "MCUX RTC driver"
+	bool "MCUX RTC driver"
 	depends on RTC && HAS_MCUX_RTC
 	help
 	  Enable support for mcux rtc driver.

--- a/drivers/rtc/Kconfig.qmsi
+++ b/drivers/rtc/Kconfig.qmsi
@@ -7,15 +7,13 @@ config RTC_QMSI
 if RTC_QMSI
 
 config RTC_QMSI_API_REENTRANCY
-	bool
-	prompt "RTC shim driver API reentrancy"
+	bool "RTC shim driver API reentrancy"
 	help
 	  Enable support for RTC shim driver API reentrancy.
 
 config RTC_PRESCALER
-	int
+	int "Prescaler size"
 	default 1
-	prompt "Prescaler size"
 	help
 	  RTC prescaler used to determine ticks per second
 

--- a/drivers/sensor/Kconfig
+++ b/drivers/sensor/Kconfig
@@ -7,8 +7,7 @@
 #
 
 menuconfig SENSOR
-	bool
-	prompt "Sensor Drivers"
+	bool "Sensor Drivers"
 	help
 	  Include sensor drivers in system config
 
@@ -29,8 +28,7 @@ config SYS_LOG_SENSOR_LEVEL
 	  4 DEBUG, write SYS_LOG_DBG in addition to previous levels
 
 config SENSOR_INIT_PRIORITY
-	int
-	prompt "Sensor init priority"
+	int "Sensor init priority"
 	default 90
 	help
 	  Sensor initialization priority.

--- a/drivers/sensor/adt7420/Kconfig
+++ b/drivers/sensor/adt7420/Kconfig
@@ -6,8 +6,7 @@
 #
 
 menuconfig ADT7420
-	bool
-	prompt "ADT7420 Temperature Sensor"
+	bool "ADT7420 Temperature Sensor"
 	depends on I2C
 	help
 	  Enable the driver for Analog Devices ADT7420 High-Accuracy
@@ -18,8 +17,7 @@ if ADT7420
 if !HAS_DTS_I2C_DEVICE
 
 config ADT7420_NAME
-	string
-	prompt "Driver name"
+	string "Driver name"
 	default "ADT7420"
 	help
 	  Device name with which the ADT7420 sensor is identified.
@@ -36,8 +34,7 @@ config ADT7420_I2C_ADDR
 	  0x4B: A0 connected VDD and A1 connected to VDD.
 
 config ADT7420_I2C_MASTER_DEV_NAME
-	string
-	prompt "I2C master where ADT7420 is connected"
+	string "I2C master where ADT7420 is connected"
 	default "I2C_0"
 	help
 	  Specify the device name of the I2C master device to which the

--- a/drivers/sensor/ak8975/Kconfig
+++ b/drivers/sensor/ak8975/Kconfig
@@ -7,23 +7,20 @@
 #
 
 menuconfig AK8975
-	bool
-	prompt "AK8975 Magnetometer"
+	bool "AK8975 Magnetometer"
 	depends on I2C
 	help
 	  Enable driver for AK8975 magnetometer.
 
 config AK8975_NAME
-	string
-	prompt "Driver name"
+	string "Driver name"
 	default "AK8975"
 	depends on AK8975
 	help
 	  Device name with which the AK8975 sensor is identified.
 
 config AK8975_I2C_ADDR
-	hex
-	prompt "I2C address"
+	hex "I2C address"
 	depends on AK8975
 	default 0x0C
 	range 0x0C 0x0F
@@ -39,8 +36,7 @@ config AK8975_I2C_ADDR
 	  needs to be 0x0C.
 
 config AK8975_I2C_MASTER_DEV_NAME
-	string
-	prompt "I2C master where AK8975 is connected"
+	string "I2C master where AK8975 is connected"
 	depends on AK8975
 	default "I2C_0"
 	help
@@ -48,16 +44,14 @@ config AK8975_I2C_MASTER_DEV_NAME
 	  AK8975 chip is connected.
 
 config MPU9150
-	bool
-	prompt "Enable MPU9180 support"
+	bool "Enable MPU9180 support"
 	depends on AK8975
 	help
 	  Enable this config option if the AK8975 sensor is part of a
 	  MPU9150 chip.
 
 config MPU9150_I2C_ADDR
-	hex
-	prompt "MPU9180 I2C address"
+	hex "MPU9180 I2C address"
 	depends on AK8975 && MPU9150 && !MPU6050
 	range 0x68 0x69
 	default 0x68

--- a/drivers/sensor/apds9960/Kconfig
+++ b/drivers/sensor/apds9960/Kconfig
@@ -19,8 +19,7 @@ config  APDS9960_I2C_DEV_NAME
 	  chip is connected.
 
 config APDS9960_DRV_NAME
-	string
-	prompt "Driver name"
+	string "Driver name"
 	default "APDS9960"
 	depends on APDS9960
 	help

--- a/drivers/sensor/bma280/Kconfig
+++ b/drivers/sensor/bma280/Kconfig
@@ -7,8 +7,7 @@
 #
 
 menuconfig BMA280
-	bool
-	prompt "BMA280 Three Axis Accelerometer Family"
+	bool "BMA280 Three Axis Accelerometer Family"
 	depends on I2C
 	help
 	  Enable driver for BMA280 I2C-based triaxial accelerometer sensor
@@ -22,22 +21,19 @@ choice
 	  Choose desired chip type from the BMA280 family.
 
 config BMA280_CHIP_BMA280
-	bool
-	prompt "BMA280"
+	bool "BMA280"
 	help
 	  Choose this option to enable the BMA280 chip.
 
 config BMA280_CHIP_BMC150_ACCEL
-	bool
-	prompt "BMC150_ACCEL"
+	bool "BMC150_ACCEL"
 	help
 	  Choose this option to enable the accelerometer of the BMC150 chip.
 
 endchoice
 
 config BMA280_NAME
-	string
-	prompt "Driver name"
+	string "Driver name"
 	default "BMA280" if BMA280_CHIP_BMA280
 	default "BMC150_ACCEL" if BMA280_CHIP_BMC150_ACCEL
 	depends on BMA280
@@ -58,8 +54,7 @@ config BMA280_I2C_ADDR
 	  0x19: Use if the SDO pin is pulled to VDDIO.
 
 config BMA280_I2C_MASTER_DEV_NAME
-	string
-	prompt "I2C master device name"
+	string "I2C master device name"
 	depends on BMA280
 	default "I2C_0"
 	help
@@ -74,18 +69,15 @@ choice
 	  Specify the type of triggering to be used by the driver.
 
 config BMA280_TRIGGER_NONE
-	bool
-	prompt "No trigger"
+	bool "No trigger"
 
 config BMA280_TRIGGER_GLOBAL_THREAD
-	bool
-	prompt "Use global thread"
+	bool "Use global thread"
 	depends on GPIO
 	select BMA280_TRIGGER
 
 config BMA280_TRIGGER_OWN_THREAD
-	bool
-	prompt "Use own thread"
+	bool "Use own thread"
 	depends on GPIO
 	select BMA280_TRIGGER
 
@@ -96,8 +88,7 @@ config BMA280_TRIGGER
 	depends on BMA280
 
 config BMA280_GPIO_DEV_NAME
-	string
-	prompt "GPIO device"
+	string "GPIO device"
 	default "GPIO_0"
 	depends on BMA280 && BMA280_TRIGGER
 	help
@@ -105,8 +96,7 @@ config BMA280_GPIO_DEV_NAME
 	  are connected.
 
 config BMA280_GPIO_PIN_NUM
-	int
-	prompt "Interrupt GPIO pin number"
+	int "Interrupt GPIO pin number"
 	default 0
 	depends on BMA280 && BMA280_TRIGGER
 	help
@@ -114,16 +104,14 @@ config BMA280_GPIO_PIN_NUM
 	  will be received.
 
 config BMA280_THREAD_PRIORITY
-	int
-	prompt "Thread priority"
+	int "Thread priority"
 	depends on BMA280 && BMA280_TRIGGER_OWN_THREAD
 	default 10
 	help
 	  Priority of thread used by the driver to handle interrupts.
 
 config BMA280_THREAD_STACK_SIZE
-	int
-	prompt "Thread stack size"
+	int "Thread stack size"
 	depends on BMA280 && BMA280_TRIGGER_OWN_THREAD
 	default 1024
 	help
@@ -137,20 +125,16 @@ choice
 	  Measurement range for acceleration values.
 
 config BMA280_PMU_RANGE_2G
-	bool
-	prompt "+/-2g"
+	bool "+/-2g"
 
 config BMA280_PMU_RANGE_4G
-	bool
-	prompt "+/-4g"
+	bool "+/-4g"
 
 config BMA280_PMU_RANGE_8G
-	bool
-	prompt "+/-8g"
+	bool "+/-8g"
 
 config BMA280_PMU_RANGE_16G
-	bool
-	prompt "+/-16g"
+	bool "+/-16g"
 
 endchoice
 
@@ -162,35 +146,27 @@ choice
 	  Bandwidth of filtered acceleration data.
 
 config BMA280_PMU_BW_1
-	bool
-	prompt "7.81Hz"
+	bool "7.81Hz"
 
 config BMA280_PMU_BW_2
-	bool
-	prompt "15.63HZ"
+	bool "15.63HZ"
 
 config BMA280_PMU_BW_3
-	bool
-	prompt "31.25Hz"
+	bool "31.25Hz"
 
 config BMA280_PMU_BW_4
-	bool
-	prompt "62.5Hz"
+	bool "62.5Hz"
 
 config BMA280_PMU_BW_5
-	bool
-	prompt "125Hz"
+	bool "125Hz"
 
 config BMA280_PMU_BW_6
-	bool
-	prompt "250HZ"
+	bool "250HZ"
 
 config BMA280_PMU_BW_7
-	bool
-	prompt "500Hz"
+	bool "500Hz"
 
 config BMA280_PMU_BW_8
-	bool
-	prompt "unfiltered"
+	bool "unfiltered"
 
 endchoice

--- a/drivers/sensor/bmc150_magn/Kconfig
+++ b/drivers/sensor/bmc150_magn/Kconfig
@@ -47,20 +47,16 @@ choice
 	  frequency).
 
 config BMC150_MAGN_PRESET_LOW_POWER
-	bool
-	prompt "Low power (3, 3, 10)"
+	bool "Low power (3, 3, 10)"
 
 config BMC150_MAGN_PRESET_REGULAR
-	bool
-	prompt "Regular (9, 15, 10)"
+	bool "Regular (9, 15, 10)"
 
 config BMC150_MAGN_PRESET_ENHANCED_REGULAR
-	bool
-	prompt "Enhanced regular (15, 27, 10)"
+	bool "Enhanced regular (15, 27, 10)"
 
 config BMC150_MAGN_PRESET_HIGH_ACCURACY
-	bool
-	prompt "High accuracy (47, 83, 20)"
+	bool "High accuracy (47, 83, 20)"
 
 endchoice
 
@@ -112,9 +108,8 @@ config BMC150_MAGN_GPIO_DRDY_DEV_NAME
 	  is connected to.
 
 config BMC150_MAGN_GPIO_DRDY_INT_PIN
-	int
+	int "GPIO pin number for the data ready interrupt pin"
 	default 3
 	depends on BMC150_MAGN_TRIGGER_DRDY
-	prompt "GPIO pin number for the data ready interrupt pin"
 	help
 	  GPIO pin number for the data ready interrupt pin.

--- a/drivers/sensor/bmg160/Kconfig
+++ b/drivers/sensor/bmg160/Kconfig
@@ -58,8 +58,7 @@ choice
 	  Specify the type of triggering to be used by the driver.
 
 config BMG160_TRIGGER_NONE
-	bool
-	prompt "No trigger"
+	bool "No trigger"
 
 config BMG160_TRIGGER_GLOBAL_THREAD
 	bool "Use global thread"

--- a/drivers/sensor/bmi160/Kconfig
+++ b/drivers/sensor/bmi160/Kconfig
@@ -47,8 +47,7 @@ choice
 	  Specify the type of triggering to be used by the driver.
 
 config BMI160_TRIGGER_NONE
-	bool
-	prompt "No trigger"
+	bool "No trigger"
 
 config BMI160_TRIGGER_GLOBAL_THREAD
 	bool "Use global thread"

--- a/drivers/sensor/ccs811/Kconfig
+++ b/drivers/sensor/ccs811/Kconfig
@@ -7,8 +7,7 @@
 #
 
 menuconfig CCS811
-	bool
-	prompt "CCS811 Digital Gas Sensor"
+	bool "CCS811 Digital Gas Sensor"
 	depends on I2C
 	help
 	  Enable driver for CCS811 Gas sensors.
@@ -16,16 +15,14 @@ menuconfig CCS811
 if !HAS_DTS_I2C_DEVICE
 
 config CCS811_NAME
-	string
-	prompt "Driver name"
+	string "Driver name"
 	default "CCS811"
 	depends on CCS811
 	help
 	  Device name with which the CCS811 sensor is identified.
 
 config CCS811_I2C_ADDR
-	hex
-	prompt "I2C address for CCS811 Sensor"
+	hex "I2C address for CCS811 Sensor"
 	depends on CCS811
 	range 0x5a 0x5b
 	default "0x5b"
@@ -35,8 +32,7 @@ config CCS811_I2C_ADDR
 	  0x5b: I2C_ADDR connected to VDD.
 
 config CCS811_I2C_MASTER_DEV_NAME
-	string
-	prompt "I2C master where CCS811 is connected"
+	string "I2C master where CCS811 is connected"
 	depends on CCS811
 	default "I2C_1"
 	help
@@ -46,8 +42,7 @@ config CCS811_I2C_MASTER_DEV_NAME
 endif
 
 config CCS811_GPIO_DEV_NAME
-	string
-	prompt "GPIO device"
+	string "GPIO device"
 	default "GPIOC"
 	depends on CCS811
 	help
@@ -55,15 +50,13 @@ config CCS811_GPIO_DEV_NAME
 	  pin is connected.
 
 config CCS811_GPIO_WAKEUP
-	bool
-	prompt "Enable GPIO Wakeup for CCS811"
+	bool "Enable GPIO Wakeup for CCS811"
 	depends on CCS811
 	help
 	  Enable GPIO Wakeup support for CCS811
 
 config CCS811_GPIO_WAKEUP_PIN_NUM
-	int
-	prompt "GPIO Wakeup pin number"
+	int "GPIO Wakeup pin number"
 	default 0
 	depends on CCS811 && CCS811_GPIO_WAKEUP
 	help
@@ -71,15 +64,13 @@ config CCS811_GPIO_WAKEUP_PIN_NUM
 	  is connected
 
 config CCS811_GPIO_RESET
-	bool
-	prompt "Enable GPIO Reset for CCS811"
+	bool "Enable GPIO Reset for CCS811"
 	depends on CCS811
 	help
 	  Enable GPIO Reset support for CCS811
 
 config CCS811_GPIO_RESET_PIN_NUM
-	int
-	prompt "GPIO Reset pin number"
+	int "GPIO Reset pin number"
 	default 0
 	depends on CCS811 && CCS811_GPIO_RESET
 	help

--- a/drivers/sensor/dht/Kconfig
+++ b/drivers/sensor/dht/Kconfig
@@ -7,8 +7,7 @@
 #
 
 menuconfig DHT
-	bool
-	prompt "DHT Temperature and Humidity Sensor"
+	bool "DHT Temperature and Humidity Sensor"
 	depends on GPIO
 	help
 	  Enable driver for the DHT temperature and humidity sensor family.
@@ -21,22 +20,19 @@ choice
 	  Choose desired chip type from the DHT family.
 
 config DHT_CHIP_DHT11
-	bool
-	prompt "DHT11"
+	bool "DHT11"
 	help
 	  Choose this option to enable the DHT11 chip.
 
 config DHT_CHIP_DHT22
-	bool
-	prompt "DHT22"
+	bool "DHT22"
 	help
 	  Choose this option to enable the DHT22 chip.
 
 endchoice
 
 config DHT_NAME
-	string
-	prompt "Driver name"
+	string "Driver name"
 	default "DHT11" if DHT_CHIP_DHT11
 	default "DHT22" if DHT_CHIP_DHT22
 	depends on DHT
@@ -44,8 +40,7 @@ config DHT_NAME
 	  Device name with which the sensor is identified.
 
 config DHT_GPIO_DEV_NAME
-	string
-	prompt "GPIO device"
+	string "GPIO device"
 	default "GPIO_0"
 	depends on DHT
 	help
@@ -53,8 +48,7 @@ config DHT_GPIO_DEV_NAME
 	  is connected.
 
 config DHT_GPIO_PIN_NUM
-	int
-	prompt "Interrupt GPIO pin number"
+	int "Interrupt GPIO pin number"
 	default 0
 	depends on DHT
 	help

--- a/drivers/sensor/hdc1008/Kconfig
+++ b/drivers/sensor/hdc1008/Kconfig
@@ -7,23 +7,20 @@
 #
 
 menuconfig HDC1008
-	bool
-	prompt "HDC1008 Temperature and Humidity Sensor"
+	bool "HDC1008 Temperature and Humidity Sensor"
 	depends on I2C && GPIO
 	help
 	  Enable driver for HDC1008 temperature and humidity sensors.
 
 config HDC1008_NAME
-	string
-	prompt "Driver name"
+	string "Driver name"
 	default "HDC1008"
 	depends on HDC1008
 	help
 	  Device name with which the HDC1008 sensor is identified.
 
 config HDC1008_I2C_ADDR
-	hex
-	prompt "I2C Address for HDC1008"
+	hex "I2C Address for HDC1008"
 	depends on HDC1008
 	default "0x40"
 	help
@@ -33,8 +30,7 @@ config HDC1008_I2C_ADDR
 	  0x43: A0 connected VDD and A1 connected to VDD.
 
 config HDC1008_I2C_MASTER_DEV_NAME
-	string
-	prompt "I2C master where HDC1008 is connected"
+	string "I2C master where HDC1008 is connected"
 	depends on HDC1008
 	default "I2C_0"
 	help
@@ -42,8 +38,7 @@ config HDC1008_I2C_MASTER_DEV_NAME
 	  HDC1008 chip is connected.
 
 config HDC1008_GPIO_DEV_NAME
-	string
-	prompt "GPIO device"
+	string "GPIO device"
 	default "GPIO_0"
 	depends on HDC1008
 	help
@@ -51,8 +46,7 @@ config HDC1008_GPIO_DEV_NAME
 	  pin is connected.
 
 config HDC1008_GPIO_PIN_NUM
-	int
-	prompt "Interrupt GPIO pin number"
+	int "Interrupt GPIO pin number"
 	default 0
 	depends on HDC1008
 	help

--- a/drivers/sensor/hmc5883l/Kconfig
+++ b/drivers/sensor/hmc5883l/Kconfig
@@ -5,23 +5,20 @@
 #
 
 menuconfig HMC5883L
-	bool
-	prompt "HMC5883L magnetometer"
+	bool "HMC5883L magnetometer"
 	depends on I2C
 	help
 	  Enable driver for HMC5883L I2C-based magnetometer.
 
 config HMC5883L_NAME
-	string
-	prompt "Driver name"
+	string "Driver name"
 	default "HMC5883L"
 	depends on HMC5883L
 	help
 	  Device name with which the HMC5883L sensor is identified.
 
 config HMC5883L_I2C_MASTER_DEV_NAME
-	string
-	prompt "I2C master where HMC5883L is connected"
+	string "I2C master where HMC5883L is connected"
 	depends on HMC5883L
 	default "I2C_0"
 	help
@@ -36,18 +33,15 @@ choice
 	  Specify the type of triggering to be used by the driver.
 
 config HMC5883L_TRIGGER_NONE
-	bool
-	prompt "No trigger"
+	bool "No trigger"
 
 config HMC5883L_TRIGGER_GLOBAL_THREAD
-	bool
-	prompt "Use global thread"
+	bool "Use global thread"
 	depends on GPIO
 	select HMC5883L_TRIGGER
 
 config HMC5883L_TRIGGER_OWN_THREAD
-	bool
-	prompt "Use own thread"
+	bool "Use own thread"
 	depends on GPIO
 	select HMC5883L_TRIGGER
 
@@ -58,8 +52,7 @@ config HMC5883L_TRIGGER
 	depends on HMC5883L
 
 config HMC5883L_GPIO_DEV_NAME
-	string
-	prompt "GPIO device"
+	string "GPIO device"
 	default "GPIO_0"
 	depends on HMC5883L && HMC5883L_TRIGGER
 	help
@@ -67,8 +60,7 @@ config HMC5883L_GPIO_DEV_NAME
 	  pin is connected.
 
 config HMC5883L_GPIO_PIN_NUM
-	int
-	prompt "Interrupt GPIO pin number"
+	int "Interrupt GPIO pin number"
 	default 0
 	depends on HMC5883L && HMC5883L_TRIGGER
 	help
@@ -76,24 +68,21 @@ config HMC5883L_GPIO_PIN_NUM
 	  HMC5883L chip will be received.
 
 config HMC5883L_THREAD_PRIORITY
-	int
-	prompt "Thread priority"
+	int "Thread priority"
 	depends on HMC5883L && HMC5883L_TRIGGER_OWN_THREAD
 	default 10
 	help
 	  Priority of thread used by the driver to handle interrupts.
 
 config HMC5883L_THREAD_STACK_SIZE
-	int
-	prompt "Thread stack size"
+	int "Thread stack size"
 	depends on HMC5883L && HMC5883L_TRIGGER_OWN_THREAD
 	default 1024
 	help
 	  Stack size of thread used by the driver to handle interrupts.
 
 config HMC5883L_ODR
-	string
-	prompt "Output data rate"
+	string "Output data rate"
 	depends on HMC5883L
 	default "15"
 	help
@@ -102,8 +91,7 @@ config HMC5883L_ODR
 	  and 75.
 
 config HMC5883L_FS
-	string
-	prompt "Full-scale range"
+	string "Full-scale range"
 	depends on HMC5883L
 	default "1.3"
 	help

--- a/drivers/sensor/hts221/Kconfig
+++ b/drivers/sensor/hts221/Kconfig
@@ -5,8 +5,7 @@
 #
 
 menuconfig HTS221
-	bool
-	prompt "HTS221 temperature and humidity sensor"
+	bool "HTS221 temperature and humidity sensor"
 	depends on I2C
 	help
 	  Enable driver for HTS221 I2C-based temperature and humidity sensor.
@@ -14,16 +13,14 @@ menuconfig HTS221
 if !HAS_DTS_I2C_DEVICE
 
 config HTS221_NAME
-	string
-	prompt "Driver name"
+	string "Driver name"
 	default "HTS221"
 	depends on HTS221
 	help
 	  Device name with which the HTS221 sensor is identified.
 
 config HTS221_I2C_MASTER_DEV_NAME
-	string
-	prompt "I2C master where HTS221 is connected"
+	string "I2C master where HTS221 is connected"
 	depends on HTS221
 	default "I2C_0"
 	help
@@ -40,18 +37,15 @@ choice
 	  Specify the type of triggering to be used by the driver.
 
 config HTS221_TRIGGER_NONE
-	bool
-	prompt "No trigger"
+	bool "No trigger"
 
 config HTS221_TRIGGER_GLOBAL_THREAD
-	bool
-	prompt "Use global thread"
+	bool "Use global thread"
 	depends on GPIO
 	select HTS221_TRIGGER
 
 config HTS221_TRIGGER_OWN_THREAD
-	bool
-	prompt "Use own thread"
+	bool "Use own thread"
 	depends on GPIO
 	select HTS221_TRIGGER
 
@@ -62,8 +56,7 @@ config HTS221_TRIGGER
 	depends on HTS221
 
 config HTS221_GPIO_DEV_NAME
-	string
-	prompt "GPIO device"
+	string "GPIO device"
 	default "GPIO_0"
 	depends on HTS221 && HTS221_TRIGGER
 	help
@@ -71,8 +64,7 @@ config HTS221_GPIO_DEV_NAME
 	  is connected.
 
 config HTS221_GPIO_PIN_NUM
-	int
-	prompt "Interrupt GPIO pin number"
+	int "Interrupt GPIO pin number"
 	default 0
 	depends on HTS221 && HTS221_TRIGGER
 	help
@@ -80,24 +72,21 @@ config HTS221_GPIO_PIN_NUM
 	  chip will be received.
 
 config HTS221_THREAD_PRIORITY
-	int
-	prompt "Thread priority"
+	int "Thread priority"
 	depends on HTS221 && HTS221_TRIGGER_OWN_THREAD
 	default 10
 	help
 	  Priority of thread used by the driver to handle interrupts.
 
 config HTS221_THREAD_STACK_SIZE
-	int
-	prompt "Thread stack size"
+	int "Thread stack size"
 	depends on HTS221 && HTS221_TRIGGER_OWN_THREAD
 	default 1024
 	help
 	  Stack size of thread used by the driver to handle interrupts.
 
 config HTS221_ODR
-	string
-	prompt "Output data rate"
+	string "Output data rate"
 	depends on HTS221
 	default "1"
 	help

--- a/drivers/sensor/isl29035/Kconfig
+++ b/drivers/sensor/isl29035/Kconfig
@@ -7,23 +7,20 @@
 #
 
 menuconfig ISL29035
-	bool
-	prompt "ISL29035 light sensor"
+	bool "ISL29035 light sensor"
 	depends on I2C
 	help
 	  Enable driver for the ISL29035 light sensor.
 
 config ISL29035_NAME
-	string
-	prompt "Driver name"
+	string "Driver name"
 	default "ISL29035"
 	depends on ISL29035
 	help
 	  Device name with which the ISL29035 sensor is identified.
 
 config ISL29035_I2C_MASTER_DEV_NAME
-	string
-	prompt "I2C Master"
+	string "I2C Master"
 	depends on ISL29035
 	default "I2C_0"
 	help
@@ -31,8 +28,7 @@ config ISL29035_I2C_MASTER_DEV_NAME
 	  chip is connected.
 
 config ISL29035_THREAD_PRIORITY
-	int
-	prompt "Thread priority"
+	int "Thread priority"
 	depends on ISL29035
 	default 10
 	help
@@ -47,20 +43,16 @@ choice
 	  resolution.
 
 config ISL29035_LUX_RANGE_1K
-	bool
-	prompt "1000"
+	bool "1000"
 
 config ISL29035_LUX_RANGE_4K
-	bool
-	prompt "4000"
+	bool "4000"
 
 config ISL29035_LUX_RANGE_16K
-	bool
-	prompt "16000"
+	bool "16000"
 
 config ISL29035_LUX_RANGE_64K
-	bool
-	prompt "64000"
+	bool "64000"
 
 endchoice
 
@@ -73,20 +65,16 @@ choice
 	  Lower integration time values mean lower ADC resolution.
 
 config ISL29035_INTEGRATION_TIME_26
-	bool
-	prompt "0.0256 ms"
+	bool "0.0256 ms"
 
 config ISL29035_INTEGRATION_TIME_410
-	bool
-	prompt "0.41 ms"
+	bool "0.41 ms"
 
 config ISL29035_INTEGRATION_TIME_6500
-	bool
-	prompt "6.5 ms"
+	bool "6.5 ms"
 
 config ISL29035_INTEGRATION_TIME_105K
-	bool
-	prompt "105 ms"
+	bool "105 ms"
 
 endchoice
 
@@ -99,14 +87,12 @@ choice
 	  configured either for either ambient light or infrared sensing.
 
 config ISL29035_MODE_ALS
-	bool
-	prompt "ambient light"
+	bool "ambient light"
 	help
 	  Sensing mode for ambient light spectrum.
 
 config ISL29035_MODE_IR
-	bool
-	prompt "infrared"
+	bool "infrared"
 	help
 	  Sensing mode for infrared spectrum.
 
@@ -121,18 +107,15 @@ choice
 	  Only available for ambient light sensing mode.
 
 config ISL29035_TRIGGER_NONE
-	bool
-	prompt "No trigger"
+	bool "No trigger"
 
 config ISL29035_TRIGGER_GLOBAL_THREAD
-	bool
-	prompt "Use global thread"
+	bool "Use global thread"
 	depends on GPIO
 	select ISL29035_TRIGGER
 
 config ISL29035_TRIGGER_OWN_THREAD
-	bool
-	prompt "Use own thread"
+	bool "Use own thread"
 	depends on GPIO
 	select ISL29035_TRIGGER
 
@@ -143,8 +126,7 @@ config ISL29035_TRIGGER
 	depends on ISL29035
 
 config ISL29035_GPIO_DEV_NAME
-	string
-	prompt "GPIO device"
+	string "GPIO device"
 	default "GPIO_0"
 	depends on ISL29035 && ISL29035_TRIGGER
 	help
@@ -152,8 +134,7 @@ config ISL29035_GPIO_DEV_NAME
 	  pin is connected.
 
 config ISL29035_GPIO_PIN_NUM
-	int
-	prompt "GPIO pin number"
+	int "GPIO pin number"
 	default 0
 	depends on ISL29035 && ISL29035_TRIGGER
 	help
@@ -161,16 +142,14 @@ config ISL29035_GPIO_PIN_NUM
 	  connected.
 
 config ISL29035_THREAD_PRIORITY
-	int
-	prompt "Thread priority"
+	int "Thread priority"
 	depends on ISL29035 && ISL29035_TRIGGER_OWN_THREAD
 	default 10
 	help
 	  Priority of thread used by the driver to handle interrupts.
 
 config ISL29035_THREAD_STACK_SIZE
-	int
-	prompt "Thread stack size"
+	int "Thread stack size"
 	depends on ISL29035 && ISL29035_TRIGGER_OWN_THREAD
 	default 1024
 	help
@@ -186,19 +165,15 @@ choice
 	  to be triggered.
 
 config ISL29035_INT_PERSIST_1
-	bool
-	prompt "1"
+	bool "1"
 
 config ISL29035_INT_PERSIST_4
-	bool
-	prompt "4"
+	bool "4"
 
 config ISL29035_INT_PERSIST_8
-	bool
-	prompt "8"
+	bool "8"
 
 config ISL29035_INT_PERSIST_16
-	bool
-	prompt "16"
+	bool "16"
 
 endchoice

--- a/drivers/sensor/lis2dh/Kconfig
+++ b/drivers/sensor/lis2dh/Kconfig
@@ -7,8 +7,7 @@
 #
 
 menuconfig LIS2DH
-	bool
-	prompt "LIS2DH Three Axis Accelerometer"
+	bool "LIS2DH Three Axis Accelerometer"
 	depends on I2C || SPI
 	help
 	  Enable driver for LIS2DH SPI/I2C-based triaxial accelerometer sensor.
@@ -77,8 +76,7 @@ config LIS2DH_I2C_ADDR
 	  0x19: Choose this option if the SDO pin is pulled to VDDIO.
 
 config LIS2DH_I2C_MASTER_DEV_NAME
-	string
-	prompt "I2C master where LIS2DH is connected"
+	string "I2C master where LIS2DH is connected"
 	depends on LIS2DH && LIS2DH_BUS_I2C
 	default "I2C_0"
 	help

--- a/drivers/sensor/lis3dh/Kconfig
+++ b/drivers/sensor/lis3dh/Kconfig
@@ -7,23 +7,20 @@
 #
 
 menuconfig LIS3DH
-	bool
-	prompt "LIS3DH Three Axis Accelerometer"
+	bool "LIS3DH Three Axis Accelerometer"
 	depends on I2C
 	help
 	  Enable driver for LIS3DH I2C-based triaxial accelerometer sensor.
 
 config LIS3DH_NAME
-	string
-	prompt "Driver name"
+	string "Driver name"
 	default "LIS3DH"
 	depends on LIS3DH
 	help
 	  Device name with which the LIS3DH sensor is identified.
 
 config LIS3DH_I2C_ADDR
-	hex
-	prompt "LIS3DH I2C address"
+	hex "LIS3DH I2C address"
 	depends on LIS3DH
 	default 0x18
 	help
@@ -33,8 +30,7 @@ config LIS3DH_I2C_ADDR
 	  0x19: Choose this option if the SDO pin is pulled to VDDIO.
 
 config LIS3DH_I2C_MASTER_DEV_NAME
-	string
-	prompt "I2C master where LIS3DH is connected"
+	string "I2C master where LIS3DH is connected"
 	depends on LIS3DH
 	default "I2C_0"
 	help
@@ -49,18 +45,15 @@ choice
 	  Specify the type of triggering to be used by the driver.
 
 config LIS3DH_TRIGGER_NONE
-	bool
-	prompt "No trigger"
+	bool "No trigger"
 
 config LIS3DH_TRIGGER_GLOBAL_THREAD
-	bool
-	prompt "Use global thread"
+	bool "Use global thread"
 	depends on GPIO
 	select LIS3DH_TRIGGER
 
 config LIS3DH_TRIGGER_OWN_THREAD
-	bool
-	prompt "Use own thread"
+	bool "Use own thread"
 	depends on GPIO
 	select LIS3DH_TRIGGER
 
@@ -71,8 +64,7 @@ config LIS3DH_TRIGGER
 	depends on LIS3DH
 
 config LIS3DH_GPIO_DEV_NAME
-	string
-	prompt "GPIO device"
+	string "GPIO device"
 	default "GPIO_0"
 	depends on LIS3DH && LIS3DH_TRIGGER
 	help
@@ -80,8 +72,7 @@ config LIS3DH_GPIO_DEV_NAME
 	  are connected.
 
 config LIS3DH_GPIO_PIN_NUM
-	int
-	prompt "Interrupt GPIO pin number"
+	int "Interrupt GPIO pin number"
 	default 0
 	depends on LIS3DH && LIS3DH_TRIGGER
 	help
@@ -89,16 +80,14 @@ config LIS3DH_GPIO_PIN_NUM
 	  chip will be received.
 
 config LIS3DH_THREAD_PRIORITY
-	int
-	prompt "Thread priority"
+	int "Thread priority"
 	depends on LIS3DH && LIS3DH_TRIGGER_OWN_THREAD
 	default 10
 	help
 	  Priority of thread used by the driver to handle interrupts.
 
 config LIS3DH_THREAD_STACK_SIZE
-	int
-	prompt "Thread stack size"
+	int "Thread stack size"
 	depends on LIS3DH && LIS3DH_TRIGGER_OWN_THREAD
 	default 1024
 	help
@@ -112,20 +101,16 @@ choice
 	  Measurement full scale range for acceleration values.
 
 config LIS3DH_ACCEL_RANGE_2G
-	bool
-	prompt "+/-2g"
+	bool "+/-2g"
 
 config LIS3DH_ACCEL_RANGE_4G
-	bool
-	prompt "+/-4g"
+	bool "+/-4g"
 
 config LIS3DH_ACCEL_RANGE_8G
-	bool
-	prompt "+/-8g"
+	bool "+/-8g"
 
 config LIS3DH_ACCEL_RANGE_16G
-	bool
-	prompt "+/-16g"
+	bool "+/-16g"
 
 endchoice
 
@@ -137,12 +122,10 @@ choice
 	  Choose between normal or low power operation mode for chip.
 
 config LIS3DH_POWER_MODE_NORMAL
-	bool
-	prompt "normal"
+	bool "normal"
 
 config LIS3DH_POWER_MODE_LOW
-	bool
-	prompt "low"
+	bool "low"
 
 endchoice
 
@@ -154,46 +137,36 @@ choice
 	  Data rate frequency of acceleration data.
 
 config LIS3DH_ODR_1
-	bool
-	prompt "1Hz"
+	bool "1Hz"
 
 config LIS3DH_ODR_2
-	bool
-	prompt "10Hz"
+	bool "10Hz"
 
 config LIS3DH_ODR_3
-	bool
-	prompt "25Hz"
+	bool "25Hz"
 
 config LIS3DH_ODR_4
-	bool
-	prompt "50Hz"
+	bool "50Hz"
 
 config LIS3DH_ODR_5
-	bool
-	prompt "100Hz"
+	bool "100Hz"
 
 config LIS3DH_ODR_6
-	bool
-	prompt "200Hz"
+	bool "200Hz"
 
 config LIS3DH_ODR_7
-	bool
-	prompt "400Hz"
+	bool "400Hz"
 
 config LIS3DH_ODR_8
-	bool
-	prompt "1.6KHz"
+	bool "1.6KHz"
 	depends on LIS3DH_POWER_MODE_LOW
 
 config LIS3DH_ODR_9_NORMAL
-	bool
-	prompt "1.25KHz"
+	bool "1.25KHz"
 	depends on LIS3DH_POWER_MODE_NORMAL
 
 config LIS3DH_ODR_9_LOW
-	bool
-	prompt "5KHz"
+	bool "5KHz"
 	depends on LIS3DH_POWER_MODE_LOW
 
 endchoice

--- a/drivers/sensor/lis3mdl/Kconfig
+++ b/drivers/sensor/lis3mdl/Kconfig
@@ -5,8 +5,7 @@
 #
 
 menuconfig LIS3MDL
-	bool
-	prompt "LIS3MDL magnetometer"
+	bool "LIS3MDL magnetometer"
 	depends on I2C
 	help
 	  Enable driver for LIS3MDL I2C-based magnetometer.
@@ -14,16 +13,14 @@ menuconfig LIS3MDL
 if !HAS_DTS_I2C_DEVICE
 
 config LIS3MDL_NAME
-	string
-	prompt "Driver name"
+	string "Driver name"
 	default "LIS3MDL"
 	depends on LIS3MDL
 	help
 	  Device name with which the LIS3MDL sensor is identified.
 
 config LIS3MDL_I2C_ADDR
-	hex
-	prompt "I2C address"
+	hex "I2C address"
 	depends on LIS3MDL
 	default 0x1C
 	help
@@ -32,8 +29,7 @@ config LIS3MDL_I2C_ADDR
 	  is pulled to VDD.
 
 config LIS3MDL_I2C_MASTER_DEV_NAME
-	string
-	prompt "I2C master where LIS3MDL is connected"
+	string "I2C master where LIS3MDL is connected"
 	depends on LIS3MDL
 	default "I2C_0"
 	help
@@ -50,18 +46,15 @@ choice
 	  Specify the type of triggering to be used by the driver.
 
 config LIS3MDL_TRIGGER_NONE
-	bool
-	prompt "No trigger"
+	bool "No trigger"
 
 config LIS3MDL_TRIGGER_GLOBAL_THREAD
-	bool
-	prompt "Use global thread"
+	bool "Use global thread"
 	depends on GPIO
 	select LIS3MDL_TRIGGER
 
 config LIS3MDL_TRIGGER_OWN_THREAD
-	bool
-	prompt "Use own thread"
+	bool "Use own thread"
 	depends on GPIO
 	select LIS3MDL_TRIGGER
 
@@ -72,8 +65,7 @@ config LIS3MDL_TRIGGER
 	depends on LIS3MDL
 
 config LIS3MDL_GPIO_DEV_NAME
-	string
-	prompt "GPIO device"
+	string "GPIO device"
 	default "GPIO_0"
 	depends on LIS3MDL && LIS3MDL_TRIGGER
 	help
@@ -81,8 +73,7 @@ config LIS3MDL_GPIO_DEV_NAME
 	  are connected.
 
 config LIS3MDL_GPIO_PIN_NUM
-	int
-	prompt "Interrupt GPIO pin number"
+	int "Interrupt GPIO pin number"
 	default 0
 	depends on LIS3MDL && LIS3MDL_TRIGGER
 	help
@@ -90,24 +81,21 @@ config LIS3MDL_GPIO_PIN_NUM
 	  chip will be received.
 
 config LIS3MDL_THREAD_PRIORITY
-	int
-	prompt "Thread priority"
+	int "Thread priority"
 	depends on LIS3MDL && LIS3MDL_TRIGGER_OWN_THREAD
 	default 10
 	help
 	  Priority of thread used by the driver to handle interrupts.
 
 config LIS3MDL_THREAD_STACK_SIZE
-	int
-	prompt "Thread stack size"
+	int "Thread stack size"
 	depends on LIS3MDL && LIS3MDL_TRIGGER_OWN_THREAD
 	default 1024
 	help
 	  Stack size of thread used by the driver to handle interrupts.
 
 config LIS3MDL_ODR
-	string
-	prompt "Output data rate"
+	string "Output data rate"
 	depends on LIS3MDL
 	default "0.625"
 	help
@@ -116,8 +104,7 @@ config LIS3MDL_ODR
 	  40, 80, 155, 300, 560 and 1000.
 
 config LIS3MDL_FS
-	int
-	prompt "Full-scale range"
+	int "Full-scale range"
 	depends on LIS3MDL
 	default 4
 	help

--- a/drivers/sensor/lps22hb/Kconfig
+++ b/drivers/sensor/lps22hb/Kconfig
@@ -5,8 +5,7 @@
 #
 
 menuconfig LPS22HB
-	bool
-	prompt "LPS22HB pressure and temperature"
+	bool "LPS22HB pressure and temperature"
 	depends on I2C
 	help
 	  Enable driver for LPS22HB I2C-based pressure and temperature
@@ -15,16 +14,14 @@ menuconfig LPS22HB
 if !HAS_DTS_I2C_DEVICE
 
 config LPS22HB_DEV_NAME
-	string
-	prompt "Device name"
+	string "Device name"
 	default "LPS22HB"
 	depends on LPS22HB
 	help
 	  Device name used for LPS22HB sensor identification.
 
 config LPS22HB_I2C_ADDR
-	hex
-	prompt "I2C address"
+	hex "I2C address"
 	depends on LPS22HB
 	default 0x5D
 	range 0x5C 0x5D
@@ -34,8 +31,7 @@ config LPS22HB_I2C_ADDR
 	  pin is pulled to VDD.
 
 config LPS22HB_I2C_MASTER_DEV_NAME
-	string
-	prompt "I2C master where LPS22HB is connected"
+	string "I2C master where LPS22HB is connected"
 	depends on LPS22HB
 	default I2C_0_NAME
 	help
@@ -48,8 +44,7 @@ menu "Attributes"
 	depends on LPS22HB
 
 config LPS22HB_SAMPLING_RATE
-	int
-	prompt "Output data rate"
+	int "Output data rate"
 	depends on LPS22HB
 	default 25
 	help

--- a/drivers/sensor/lps25hb/Kconfig
+++ b/drivers/sensor/lps25hb/Kconfig
@@ -5,8 +5,7 @@
 #
 
 menuconfig LPS25HB
-	bool
-	prompt "LPS25HB pressure and temperature"
+	bool "LPS25HB pressure and temperature"
 	depends on I2C
 	help
 	  Enable driver for LPS25HB I2C-based pressure and temperature
@@ -15,16 +14,14 @@ menuconfig LPS25HB
 if !HAS_DTS_I2C_DEVICE
 
 config LPS25HB_DEV_NAME
-	string
-	prompt "Device name"
+	string "Device name"
 	default "lps25hb"
 	depends on LPS25HB
 	help
 	  Device name with which the LPS25HB sensor is identified.
 
 config LPS25HB_I2C_ADDR
-	hex
-	prompt "I2C address"
+	hex "I2C address"
 	depends on LPS25HB
 	default "0x5C"
 	help
@@ -33,8 +30,7 @@ config LPS25HB_I2C_ADDR
 	  pin is pulled to VDD.
 
 config LPS25HB_I2C_MASTER_DEV_NAME
-	string
-	prompt "I2C master where LPS25HB is connected"
+	string "I2C master where LPS25HB is connected"
 	depends on LPS25HB
 	default "I2C_0"
 	help
@@ -47,8 +43,7 @@ menu "Attributes"
 	depends on LPS25HB
 
 config LPS25HB_SAMPLING_RATE
-	int
-	prompt "Output data rate"
+	int "Output data rate"
 	depends on LPS25HB
 	default 25
 	help

--- a/drivers/sensor/lsm6ds0/Kconfig
+++ b/drivers/sensor/lsm6ds0/Kconfig
@@ -22,8 +22,7 @@ config LSM6DS0_DEV_NAME
 	default "lsm6ds0"
 
 config LSM6DS0_I2C_ADDR
-	hex
-	prompt "LSM6DS0 I2C address"
+	hex "LSM6DS0 I2C address"
 	depends on LSM6DS0
 	default 0x6B
 	help
@@ -100,8 +99,7 @@ menu "Attributes"
 	depends on LSM6DS0
 
 config LSM6DS0_GYRO_FULLSCALE
-	int
-	prompt "Gyroscope full-scale range"
+	int "Gyroscope full-scale range"
 	depends on LSM6DS0
 	default 245
 	help
@@ -110,8 +108,7 @@ config LSM6DS0_GYRO_FULLSCALE
 	  second. Valid values are 245, 500 and 2000.
 
 config LSM6DS0_GYRO_SAMPLING_RATE
-	int
-	prompt "Output data rate"
+	int "Output data rate"
 	depends on LSM6DS0
 	default 15
 	help
@@ -121,8 +118,7 @@ config LSM6DS0_GYRO_SAMPLING_RATE
 	  952.
 
 config LSM6DS0_ACCEL_FULLSCALE
-	int
-	prompt "Accelerometer full-scale range"
+	int "Accelerometer full-scale range"
 	depends on LSM6DS0
 	default 2
 	help
@@ -131,8 +127,7 @@ config LSM6DS0_ACCEL_FULLSCALE
 	  are 2, 4, 8 and 16.
 
 config LSM6DS0_ACCEL_SAMPLING_RATE
-	int
-	prompt "Output data rate"
+	int "Output data rate"
 	depends on LSM6DS0
 	default 10
 	help

--- a/drivers/sensor/lsm6dsl/Kconfig
+++ b/drivers/sensor/lsm6dsl/Kconfig
@@ -38,8 +38,7 @@ config LSM6DSL_DEV_NAME
 if !HAS_DTS_I2C_DEVICE
 
 config LSM6DSL_I2C_ADDR
-	hex
-	prompt "LSM6DSL I2C address"
+	hex "LSM6DSL I2C address"
 	depends on LSM6DSL && LSM6DSL_I2C
 	default 0x6A
 	range 0x6A 0x6B
@@ -119,18 +118,15 @@ choice LSM6DSL_TRIGGER_MODE
 	  Specify the type of triggering to be used by the driver.
 
 config LSM6DSL_TRIGGER_NONE
-	bool
-	prompt "No trigger"
+	bool "No trigger"
 
 config LSM6DSL_TRIGGER_GLOBAL_THREAD
-	bool
-	prompt "Use global thread"
+	bool "Use global thread"
 	depends on GPIO
 	select LSM6DSL_TRIGGER
 
 config LSM6DSL_TRIGGER_OWN_THREAD
-	bool
-	prompt "Use own thread"
+	bool "Use own thread"
 	depends on GPIO
 	select LSM6DSL_TRIGGER
 
@@ -143,16 +139,14 @@ config LSM6DSL_TRIGGER
 if !HAS_DTS_SPI_PINS
 
 config LSM6DSL_GPIO_DEV_NAME
-	string
-	prompt "GPIO device"
+	string "GPIO device"
 	depends on LSM6DSL && LSM6DSL_TRIGGER
 	help
 	  The device name of the GPIO device to which the LSM6DSL interrupt pin
 	  is connected.
 
 config LSM6DSL_GPIO_PIN_NUM
-	int
-	prompt "Interrupt GPIO pin number"
+	int "Interrupt GPIO pin number"
 	depends on LSM6DSL && LSM6DSL_TRIGGER
 	help
 	  The number of the GPIO on which the interrupt signal from the LSM6DSL
@@ -161,16 +155,14 @@ config LSM6DSL_GPIO_PIN_NUM
 endif #HAS_DTS_SPI_DEVICE
 
 config LSM6DSL_THREAD_PRIORITY
-	int
-	prompt "Thread priority"
+	int "Thread priority"
 	depends on LSM6DSL && LSM6DSL_TRIGGER_OWN_THREAD
 	default 10
 	help
 	  Priority of thread used by the driver to handle interrupts.
 
 config LSM6DSL_THREAD_STACK_SIZE
-	int
-	prompt "Thread stack size"
+	int "Thread stack size"
 	depends on LSM6DSL && LSM6DSL_TRIGGER_OWN_THREAD
 	default 1024
 	help
@@ -213,8 +205,7 @@ menu "Attributes"
 	depends on LSM6DSL
 
 config LSM6DSL_GYRO_FS
-	int
-	prompt "Gyroscope full-scale range"
+	int "Gyroscope full-scale range"
 	depends on LSM6DSL
 	default 0
 	help
@@ -249,8 +240,7 @@ config LSM6DSL_GYRO_ODR
 	  10: 6660Hz
 
 config LSM6DSL_ACCEL_FS
-	int
-	prompt "Accelerometer full-scale range"
+	int "Accelerometer full-scale range"
 	depends on LSM6DSL
 	default 0
 	help

--- a/drivers/sensor/lsm9ds0_gyro/Kconfig
+++ b/drivers/sensor/lsm9ds0_gyro/Kconfig
@@ -18,8 +18,7 @@ config LSM9DS0_GYRO_DEV_NAME
 	default "lsm9ds0_gyro"
 
 config LSM9DS0_GYRO_I2C_ADDR
-	hex
-	prompt "LSM9DS0_GYRO I2C slave address"
+	hex "LSM9DS0_GYRO I2C slave address"
 	default 0x6A
 	depends on LSM9DS0_GYRO
 	help
@@ -47,16 +46,13 @@ choice
 	  Specify the default full-scale.
 
 config LSM9DS0_GYRO_FULLSCALE_245
-	bool
-	prompt "245 DPS"
+	bool "245 DPS"
 
 config LSM9DS0_GYRO_FULLSCALE_500
-	bool
-	prompt "500 DPS"
+	bool "500 DPS"
 
 config LSM9DS0_GYRO_FULLSCALE_2000
-	bool
-	prompt "2000 DPS"
+	bool "2000 DPS"
 
 endchoice
 
@@ -74,20 +70,16 @@ choice
 	  Specify the default sampling rate frequency.
 
 config LSM9DS0_GYRO_SAMPLING_RATE_95
-	bool
-	prompt "95 Hz"
+	bool "95 Hz"
 
 config LSM9DS0_GYRO_SAMPLING_RATE_190
-	bool
-	prompt "190 Hz"
+	bool "190 Hz"
 
 config LSM9DS0_GYRO_SAMPLING_RATE_380
-	bool
-	prompt "380 Hz"
+	bool "380 Hz"
 
 config LSM9DS0_GYRO_SAMPLING_RATE_760
-	bool
-	prompt "760 Hz"
+	bool "760 Hz"
 
 endchoice
 
@@ -123,7 +115,6 @@ config LSM9DS0_GYRO_GPIO_DRDY_DEV_NAME
 	  is connected to.
 
 config LSM9DS0_GYRO_GPIO_DRDY_INT_PIN
-	int
+	int "GPIO pin number for the data ready interrupt pin"
 	default 3
 	depends on LSM9DS0_GYRO_TRIGGER_DRDY
-	prompt "GPIO pin number for the data ready interrupt pin"

--- a/drivers/sensor/lsm9ds0_mfd/Kconfig
+++ b/drivers/sensor/lsm9ds0_mfd/Kconfig
@@ -70,48 +70,37 @@ choice
 	  Specify the default sampling rate frequency for accelerometer.
 
 config LSM9DS0_MFD_ACCEL_SAMPLING_RATE_0
-	bool
-	prompt "0 Hz (power down)"
+	bool "0 Hz (power down)"
 
 config LSM9DS0_MFD_ACCEL_SAMPLING_RATE_3_125
-	bool
-	prompt "3.125 Hz"
+	bool "3.125 Hz"
 
 config LSM9DS0_MFD_ACCEL_SAMPLING_RATE_6_25
-	bool
-	prompt "6.25 Hz"
+	bool "6.25 Hz"
 
 config LSM9DS0_MFD_ACCEL_SAMPLING_RATE_12_5
-	bool
-	prompt "12.5 Hz"
+	bool "12.5 Hz"
 
 config LSM9DS0_MFD_ACCEL_SAMPLING_RATE_25
-	bool
-	prompt "25 Hz"
+	bool "25 Hz"
 
 config LSM9DS0_MFD_ACCEL_SAMPLING_RATE_50
-	bool
-	prompt "50 Hz"
+	bool "50 Hz"
 
 config LSM9DS0_MFD_ACCEL_SAMPLING_RATE_100
-	bool
-	prompt "100 Hz"
+	bool "100 Hz"
 
 config LSM9DS0_MFD_ACCEL_SAMPLING_RATE_200
-	bool
-	prompt "200 Hz"
+	bool "200 Hz"
 
 config LSM9DS0_MFD_ACCEL_SAMPLING_RATE_400
-	bool
-	prompt "400 Hz"
+	bool "400 Hz"
 
 config LSM9DS0_MFD_ACCEL_SAMPLING_RATE_800
-	bool
-	prompt "800 Hz"
+	bool "800 Hz"
 
 config LSM9DS0_MFD_ACCEL_SAMPLING_RATE_1600
-	bool
-	prompt "1600 Hz"
+	bool "1600 Hz"
 
 endchoice
 
@@ -130,24 +119,19 @@ choice
 	  Specify the default full-scale for accelerometer.
 
 config LSM9DS0_MFD_ACCEL_FULL_SCALE_2
-	bool
-	prompt "2G"
+	bool "2G"
 
 config LSM9DS0_MFD_ACCEL_FULL_SCALE_4
-	bool
-	prompt "4G"
+	bool "4G"
 
 config LSM9DS0_MFD_ACCEL_FULL_SCALE_6
-	bool
-	prompt "6G"
+	bool "6G"
 
 config LSM9DS0_MFD_ACCEL_FULL_SCALE_8
-	bool
-	prompt "8G"
+	bool "8G"
 
 config LSM9DS0_MFD_ACCEL_FULL_SCALE_16
-	bool
-	prompt "16G"
+	bool "16G"
 
 endchoice
 
@@ -181,28 +165,22 @@ choice
 	  Specify the default sampling rate frequency for magnetometer.
 
 config LSM9DS0_MFD_MAGN_SAMPLING_RATE_3_125
-	bool
-	prompt "3.125 Hz"
+	bool "3.125 Hz"
 
 config LSM9DS0_MFD_MAGN_SAMPLING_RATE_6_25
-	bool
-	prompt "6.25 Hz"
+	bool "6.25 Hz"
 
 config LSM9DS0_MFD_MAGN_SAMPLING_RATE_12_5
-	bool
-	prompt "12.5 Hz"
+	bool "12.5 Hz"
 
 config LSM9DS0_MFD_MAGN_SAMPLING_RATE_25
-	bool
-	prompt "25 Hz"
+	bool "25 Hz"
 
 config LSM9DS0_MFD_MAGN_SAMPLING_RATE_50
-	bool
-	prompt "50 Hz"
+	bool "50 Hz"
 
 config LSM9DS0_MFD_MAGN_SAMPLING_RATE_100
-	bool
-	prompt "100 Hz"
+	bool "100 Hz"
 
 endchoice
 
@@ -221,20 +199,16 @@ choice
 	  Specify the default full-scale for magnetometer.
 
 config LSM9DS0_MFD_MAGN_FULL_SCALE_2
-	bool
-	prompt "2 Gauss"
+	bool "2 Gauss"
 
 config LSM9DS0_MFD_MAGN_FULL_SCALE_4
-	bool
-	prompt "4 Gauss"
+	bool "4 Gauss"
 
 config LSM9DS0_MFD_MAGN_FULL_SCALE_8
-	bool
-	prompt "8 Gauss"
+	bool "8 Gauss"
 
 config LSM9DS0_MFD_MAGN_FULL_SCALE_12
-	bool
-	prompt "12 Gauss"
+	bool "12 Gauss"
 
 endchoice
 

--- a/drivers/sensor/max30101/Kconfig
+++ b/drivers/sensor/max30101/Kconfig
@@ -6,8 +6,7 @@
 #
 
 menuconfig MAX30101
-	bool
-	prompt "MAX30101 Pulse Oximeter and Heart Rate Sensor"
+	bool "MAX30101 Pulse Oximeter and Heart Rate Sensor"
 	depends on I2C
 
 if MAX30101
@@ -15,13 +14,11 @@ if MAX30101
 if !HAS_DTS_I2C_DEVICE
 
 config MAX30101_NAME
-	string
-	prompt "Driver name"
+	string "Driver name"
 	default "MAX30101"
 
 config MAX30101_I2C_NAME
-	string
-	prompt "I2C device name"
+	string "I2C device name"
 	default "I2C_0"
 
 endif # !HAS_DTS_I2C_DEVICE

--- a/drivers/sensor/max44009/Kconfig
+++ b/drivers/sensor/max44009/Kconfig
@@ -7,15 +7,13 @@
 #
 
 menuconfig MAX44009
-	bool
-	prompt "MAX44009 Light Sensor"
+	bool "MAX44009 Light Sensor"
 	depends on I2C
 	help
 	  Enable driver for MAX44009 light sensors.
 
 config MAX44009_DRV_NAME
-	string
-	prompt "Driver name"
+	string "Driver name"
 	default "MAX44009"
 	depends on MAX44009
 	help
@@ -23,8 +21,7 @@ config MAX44009_DRV_NAME
 
 
 config MAX44009_I2C_ADDR
-	hex
-	prompt "MAX44009 I2C address"
+	hex "MAX44009 I2C address"
 	depends on MAX44009
 	default "0x4a"
 	help
@@ -34,8 +31,7 @@ config MAX44009_I2C_ADDR
 	  0x4b: A0 connected to VCC.
 
 config MAX44009_I2C_DEV_NAME
-	string
-	prompt "I2C master where MAX44009 is connected"
+	string "I2C master where MAX44009 is connected"
 	depends on MAX44009
 	default "I2C_0"
 	help

--- a/drivers/sensor/mma8451q/Kconfig
+++ b/drivers/sensor/mma8451q/Kconfig
@@ -24,8 +24,7 @@ config MMA8451Q_I2C_NAME
 	default I2C_0_NAME
 
 config MMA8451Q_I2C_ADDRESS
-	hex
-	prompt "I2C address for MMA8451Q Sensor"
+	hex "I2C address for MMA8451Q Sensor"
 	depends on MMA8451Q
 	default 0x1D
 	help

--- a/drivers/sensor/mpu6050/Kconfig
+++ b/drivers/sensor/mpu6050/Kconfig
@@ -7,23 +7,20 @@
 #
 
 menuconfig MPU6050
-	bool
-	prompt "MPU6050 Six-Axis Motion Tracking Device"
+	bool "MPU6050 Six-Axis Motion Tracking Device"
 	depends on I2C
 	help
 	  Enable driver for MPU6050 I2C-based six-axis motion tracking device.
 
 config MPU6050_NAME
-	string
-	prompt "Driver name"
+	string "Driver name"
 	default "MPU6050"
 	depends on MPU6050
 	help
 	  Device name with which the MPU6050 sensor is identified.
 
 config MPU6050_I2C_ADDR
-	hex
-	prompt "I2C address"
+	hex "I2C address"
 	depends on MPU6050
 	default 0x68
 	range 0x68 0x69
@@ -33,8 +30,7 @@ config MPU6050_I2C_ADDR
 	  is pulled to VDD.
 
 config MPU6050_I2C_MASTER_DEV_NAME
-	string
-	prompt "I2C master where MPU6050 is connected"
+	string "I2C master where MPU6050 is connected"
 	depends on MPU6050
 	default "I2C_0"
 	help
@@ -49,18 +45,15 @@ choice
 	  Specify the type of triggering to be used by the driver.
 
 config MPU6050_TRIGGER_NONE
-	bool
-	prompt "No trigger"
+	bool "No trigger"
 
 config MPU6050_TRIGGER_GLOBAL_THREAD
-	bool
-	prompt "Use global thread"
+	bool "Use global thread"
 	depends on GPIO
 	select MPU6050_TRIGGER
 
 config MPU6050_TRIGGER_OWN_THREAD
-	bool
-	prompt "Use own thread"
+	bool "Use own thread"
 	depends on GPIO
 	select MPU6050_TRIGGER
 
@@ -71,8 +64,7 @@ config MPU6050_TRIGGER
 	depends on MPU6050
 
 config MPU6050_GPIO_DEV_NAME
-	string
-	prompt "GPIO device"
+	string "GPIO device"
 	default "GPIO_0"
 	depends on MPU6050 && MPU6050_TRIGGER
 	help
@@ -80,8 +72,7 @@ config MPU6050_GPIO_DEV_NAME
 	  is connected.
 
 config MPU6050_GPIO_PIN_NUM
-	int
-	prompt "Interrupt GPIO pin number"
+	int "Interrupt GPIO pin number"
 	default 0
 	depends on MPU6050 && MPU6050_TRIGGER
 	help
@@ -89,24 +80,21 @@ config MPU6050_GPIO_PIN_NUM
 	  chip will be received.
 
 config MPU6050_THREAD_PRIORITY
-	int
-	prompt "Thread priority"
+	int "Thread priority"
 	depends on MPU6050 && MPU6050_TRIGGER_OWN_THREAD
 	default 10
 	help
 	  Priority of thread used by the driver to handle interrupts.
 
 config MPU6050_THREAD_STACK_SIZE
-	int
-	prompt "Thread stack size"
+	int "Thread stack size"
 	depends on MPU6050 && MPU6050_TRIGGER_OWN_THREAD
 	default 1024
 	help
 	  Stack size of thread used by the driver to handle interrupts.
 
 config MPU6050_ACCEL_FS
-	int
-	prompt "Accelerometer full-scale range"
+	int "Accelerometer full-scale range"
 	depends on MPU6050
 	default 2
 	help
@@ -115,8 +103,7 @@ config MPU6050_ACCEL_FS
 	  values are 2, 4, 8 and 16.
 
 config MPU6050_GYRO_FS
-	int
-	prompt "Gyroscope full-scale range"
+	int "Gyroscope full-scale range"
 	depends on MPU6050
 	default 250
 	help

--- a/drivers/sensor/nrf5/Kconfig
+++ b/drivers/sensor/nrf5/Kconfig
@@ -7,15 +7,13 @@
 #
 
 menuconfig TEMP_NRF5
-	bool
-	prompt "nRF5 Temperature Sensor"
+	bool "nRF5 Temperature Sensor"
 	depends on SOC_FAMILY_NRF
 	help
 	  Enable driver for nRF5 temperature sensor.
 
 config TEMP_NRF5_NAME
-	string
-	prompt "Driver name"
+	string "Driver name"
 	default "TEMP_0"
 	depends on TEMP_NRF5
 	help

--- a/drivers/sensor/sht3xd/Kconfig
+++ b/drivers/sensor/sht3xd/Kconfig
@@ -7,15 +7,13 @@
 #
 
 menuconfig SHT3XD
-	bool
-	prompt "SHT3xD Temperature and Humidity Sensor"
+	bool "SHT3xD Temperature and Humidity Sensor"
 	depends on I2C
 	help
 	  Enable driver for SHT3xD temperature and humidity sensors.
 
 config SHT3XD_NAME
-	string
-	prompt "Driver name"
+	string "Driver name"
 	default "SHT3XD"
 	depends on SHT3XD
 	help
@@ -32,8 +30,7 @@ config SHT3XD_I2C_ADDR
 	  0x45: Choose this option if the ADDR pin is connected to VDD.
 
 config SHT3XD_I2C_MASTER_DEV_NAME
-	string
-	prompt "I2C master where SHT3xD is connected"
+	string "I2C master where SHT3xD is connected"
 	depends on SHT3XD
 	default "I2C_0"
 	help
@@ -48,18 +45,15 @@ choice
 	  Specify the type of triggering to be used by the driver.
 
 config SHT3XD_TRIGGER_NONE
-	bool
-	prompt "No trigger"
+	bool "No trigger"
 
 config SHT3XD_TRIGGER_GLOBAL_THREAD
-	bool
-	prompt "Use global thread"
+	bool "Use global thread"
 	depends on GPIO
 	select SHT3XD_TRIGGER
 
 config SHT3XD_TRIGGER_OWN_THREAD
-	bool
-	prompt "Use own thread"
+	bool "Use own thread"
 	depends on GPIO
 	select SHT3XD_TRIGGER
 
@@ -70,8 +64,7 @@ config SHT3XD_TRIGGER
 	depends on SHT3XD
 
 config SHT3XD_GPIO_DEV_NAME
-	string
-	prompt "GPIO device"
+	string "GPIO device"
 	default "GPIO_0"
 	depends on SHT3XD && SHT3XD_TRIGGER
 	help
@@ -79,8 +72,7 @@ config SHT3XD_GPIO_DEV_NAME
 	  pins are connected.
 
 config SHT3XD_GPIO_PIN_NUM
-	int
-	prompt "Interrupt GPIO pin number"
+	int "Interrupt GPIO pin number"
 	default 0
 	depends on SHT3XD && SHT3XD_TRIGGER
 	help
@@ -88,16 +80,14 @@ config SHT3XD_GPIO_PIN_NUM
 	  SHT3xD chip will be received.
 
 config SHT3XD_THREAD_PRIORITY
-	int
-	prompt "Thread priority"
+	int "Thread priority"
 	depends on SHT3XD && SHT3XD_TRIGGER_OWN_THREAD
 	default 10
 	help
 	  Priority of thread used by the driver to handle interrupts.
 
 config SHT3XD_THREAD_STACK_SIZE
-	int
-	prompt "Thread stack size"
+	int "Thread stack size"
 	depends on SHT3XD && SHT3XD_TRIGGER_OWN_THREAD
 	default 1024
 	help
@@ -112,16 +102,13 @@ choice
 	  noise level and energy consumption.
 
 config SHT3XD_REPEATABILITY_LOW
-	bool
-	prompt "low"
+	bool "low"
 
 config SHT3XD_REPEATABILITY_MEDIUM
-	bool
-	prompt "medium"
+	bool "medium"
 
 config SHT3XD_REPEATABILITY_HIGH
-	bool
-	prompt "high"
+	bool "high"
 
 endchoice
 
@@ -133,23 +120,18 @@ choice
 	  Number of measurements per second.
 
 config SHT3XD_MPS_05
-	bool
-	prompt "0.5"
+	bool "0.5"
 
 config SHT3XD_MPS_1
-	bool
-	prompt "1"
+	bool "1"
 
 config SHT3XD_MPS_2
-	bool
-	prompt "2"
+	bool "2"
 
 config SHT3XD_MPS_4
-	bool
-	prompt "4"
+	bool "4"
 
 config SHT3XD_MPS_10
-	bool
-	prompt "10"
+	bool "10"
 
 endchoice

--- a/drivers/sensor/sx9500/Kconfig
+++ b/drivers/sensor/sx9500/Kconfig
@@ -33,10 +33,9 @@ config SX9500_I2C_DEV_NAME
 	  connected.
 
 config SX9500_PROX_CHANNEL
-	int
+	int "Proximity channel to use"
 	default 3
 	depends on SX9500
-	prompt "Proximity channel to use"
 	help
 	  The SX9500 offers 4 separate proximity channels.  Choose which one
 	  you are using.  Valid numbers are 0 to 3.

--- a/drivers/sensor/th02/Kconfig
+++ b/drivers/sensor/th02/Kconfig
@@ -5,23 +5,20 @@
 #
 
 menuconfig TH02
-	bool
-	prompt "TH02 Temperature Sensor"
+	bool "TH02 Temperature Sensor"
 	depends on I2C
 	help
 	  Enable driver for the TH02 temperature sensor.
 
 if TH02
 config TH02_NAME
-	string
-	prompt "Driver name"
+	string "Driver name"
 	default "TH02"
 	help
 	  Device name with which the TH02 sensor is identified.
 
 config TH02_I2C_MASTER_DEV_NAME
-	string
-	prompt "I2C Master"
+	string "I2C Master"
 	default "I2C_0"
 	help
 	  The device name of the I2C master device to which the TH02

--- a/drivers/sensor/tmp007/Kconfig
+++ b/drivers/sensor/tmp007/Kconfig
@@ -7,23 +7,20 @@
 #
 
 menuconfig TMP007
-	bool
-	prompt "TMP007 Infrared Thermopile Sensor"
+	bool "TMP007 Infrared Thermopile Sensor"
 	depends on I2C
 	help
 	  Enable driver for TMP007 infrared thermopile sensors.
 
 config TMP007_NAME
-	string
-	prompt "Driver name"
+	string "Driver name"
 	default "TMP007"
 	depends on TMP007
 	help
 	  Device name with which the TMP007 sensor is identified.
 
 config TMP007_I2C_ADDR
-	hex
-	prompt "I2C address for TMP006 Sensor"
+	hex "I2C address for TMP006 Sensor"
 	depends on TMP007
 	default "0x40"
 	help
@@ -39,8 +36,7 @@ config TMP007_I2C_ADDR
 	  0x47: A0 connected SCL and A1 connected to VDD.
 
 config TMP007_I2C_MASTER_DEV_NAME
-	string
-	prompt "I2C master where TMP007 is connected"
+	string "I2C master where TMP007 is connected"
 	depends on TMP007
 	default "I2C_0"
 	help
@@ -55,18 +51,15 @@ choice
 	  Specify the type of triggering to be used by the driver.
 
 config TMP007_TRIGGER_NONE
-	bool
-	prompt "No trigger"
+	bool "No trigger"
 
 config TMP007_TRIGGER_GLOBAL_THREAD
-	bool
-	prompt "Use global thread"
+	bool "Use global thread"
 	depends on GPIO
 	select TMP007_TRIGGER
 
 config TMP007_TRIGGER_OWN_THREAD
-	bool
-	prompt "Use own thread"
+	bool "Use own thread"
 	depends on GPIO
 	select TMP007_TRIGGER
 
@@ -77,8 +70,7 @@ config TMP007_TRIGGER
 	depends on TMP007
 
 config TMP007_GPIO_DEV_NAME
-	string
-	prompt "GPIO device"
+	string "GPIO device"
 	default "GPIO_0"
 	depends on TMP007 && TMP007_TRIGGER
 	help
@@ -86,8 +78,7 @@ config TMP007_GPIO_DEV_NAME
 	  (alert) pin is connected.
 
 config TMP007_GPIO_PIN_NUM
-	int
-	prompt "Interrupt GPIO pin number"
+	int "Interrupt GPIO pin number"
 	default 0
 	depends on TMP007 && TMP007_TRIGGER
 	help
@@ -95,16 +86,14 @@ config TMP007_GPIO_PIN_NUM
 	  TMP007 chip will be received.
 
 config TMP007_THREAD_PRIORITY
-	int
-	prompt "Thread priority"
+	int "Thread priority"
 	depends on TMP007 && TMP007_TRIGGER_OWN_THREAD
 	default 10
 	help
 	  Priority of thread used by the driver to handle interrupts.
 
 config TMP007_THREAD_STACK_SIZE
-	int
-	prompt "Thread stack size"
+	int "Thread stack size"
 	depends on TMP007 && TMP007_TRIGGER_OWN_THREAD
 	default 1024
 	help

--- a/drivers/sensor/tmp112/Kconfig
+++ b/drivers/sensor/tmp112/Kconfig
@@ -7,8 +7,7 @@
 #
 
 menuconfig TMP112
-	bool
-	prompt "TMP112 Temperature Sensor"
+	bool "TMP112 Temperature Sensor"
 	depends on I2C
 	help
 	  Enable the driver for Texas Instruments TMP112 High-Accuracy Digital
@@ -18,8 +17,7 @@ menuconfig TMP112
 	  been successfully tested with this driver.
 
 config TMP112_NAME
-	string
-	prompt "Driver name"
+	string "Driver name"
 	default "TMP112"
 	depends on TMP112
 	help
@@ -39,8 +37,7 @@ config TMP112_I2C_ADDR
 
 
 config TMP112_I2C_MASTER_DEV_NAME
-	string
-	prompt "I2C master where TMP112 is connected"
+	string "I2C master where TMP112 is connected"
 	depends on TMP112
 	default "I2C_0"
 	help

--- a/drivers/sensor/vl53l0x/Kconfig
+++ b/drivers/sensor/vl53l0x/Kconfig
@@ -7,8 +7,7 @@
 #
 
 menuconfig VL53L0X
-	bool
-	prompt "VL53L0X time of flight sensor"
+	bool "VL53L0X time of flight sensor"
 	depends on SENSOR && I2C
 	select HAS_STLIB
 	help
@@ -17,24 +16,21 @@ menuconfig VL53L0X
 if !HAS_DTS_I2C_DEVICE
 
 config VL53L0X_NAME
-	string
-	prompt "Driver name"
+	string "Driver name"
 	default "VL53L0X"
 	depends on VL53L0X
 	help
 	  Device name with which the VL53L0X sensor is identified.
 
 config VL53L0X_I2C_ADDR
-	hex
-	prompt "Vl53l0x I2C address"
+	hex "Vl53l0x I2C address"
 	default 0x29
 	depends on VL53L0X
 	help
 	  address of the i2c used for the vl53l0x sensor
 
 config VL53L0X_I2C_MASTER_DEV_NAME
-	string
-	prompt "I2C master where VL53L0X is connected"
+	string "I2C master where VL53L0X is connected"
 	depends on VL53L0X
 	default "I2C_0"
 	help
@@ -50,8 +46,7 @@ config VL53L0X_XSHUT_CONTROL_ENABLE
 	    Enable it if XSHUT pin is controlled by host.
 
 config VL53L0X_XSHUT_GPIO_DEV_NAME
-	string
-	prompt "GPIO device"
+	string "GPIO device"
 	default "GPIO_6"
 	depends on VL53L0X_XSHUT_CONTROL_ENABLE
 	help
@@ -59,8 +54,7 @@ config VL53L0X_XSHUT_GPIO_DEV_NAME
 	  is connected.
 
 config VL53L0X_XSHUT_GPIO_PIN_NUM
-	int
-	prompt "Interrupt GPIO pin number"
+	int "Interrupt GPIO pin number"
 	default 6
 	depends on VL53L0X_XSHUT_CONTROL_ENABLE
 	help
@@ -68,8 +62,7 @@ config VL53L0X_XSHUT_GPIO_PIN_NUM
 	  is connected.
 
 config VL53L0X_PROXIMITY_THRESHOLD
-	int
-	prompt "Proximity threshold in millimeters"
+	int "Proximity threshold in millimeters"
 	default 100
 	depends on VL53L0X
 	help

--- a/drivers/serial/Kconfig
+++ b/drivers/serial/Kconfig
@@ -7,8 +7,7 @@
 #
 
 menuconfig SERIAL
-	bool
-	prompt "Serial Drivers"
+	bool "Serial Drivers"
 	help
 	  Enable options for serial drivers.
 
@@ -30,8 +29,7 @@ config SERIAL_SUPPORT_INTERRUPT
 	  to signal that the driver and hardware supports interrupts.
 
 config UART_INTERRUPT_DRIVEN
-	bool
-	prompt "Enable UART Interrupt support"
+	bool "Enable UART Interrupt support"
 	depends on SERIAL_SUPPORT_INTERRUPT
 	help
 	  This option enables interrupt support for UART allowing console

--- a/drivers/serial/Kconfig.nsim
+++ b/drivers/serial/Kconfig.nsim
@@ -14,8 +14,7 @@ config UART_NSIM_PORT_0_NAME
 	  struct.
 
 config UART_NSIM_PORT_0_BASE_ADDR
-	hex
-	prompt "Port 0 Register Address"
+	hex "Port 0 Register Address"
 	default 0x00000000
 	depends on UART_NSIM
 	help

--- a/drivers/timer/Kconfig
+++ b/drivers/timer/Kconfig
@@ -103,8 +103,7 @@ config LOAPIC_TIMER_IRQ_PRIORITY
 	  This options specifies the IRQ priority used by the LOAPIC timer.
 
 config TSC_CYCLES_PER_SEC
-	int
-	prompt "Frequency of x86 CPU timestamp counter"
+	int "Frequency of x86 CPU timestamp counter"
 	default 0
 	depends on LOAPIC_TIMER
 	help

--- a/drivers/usb/device/Kconfig
+++ b/drivers/usb/device/Kconfig
@@ -12,8 +12,7 @@ config USB_DEVICE_DRIVER
 	bool
 
 config USB_DW
-	bool
-	prompt "Designware USB Device Controller Driver"
+	bool "Designware USB Device Controller Driver"
 	select USB_DEVICE_DRIVER
 	help
 	  Designware USB Device Controller Driver.
@@ -25,15 +24,13 @@ config USB_DW_IRQ_PRI
 	  USB interrupt priority.
 
 config USB_DW_USB_2_0
-	bool
-	prompt "DesignWare Controller and PHY support for USB specification 2.0"
+	bool "DesignWare Controller and PHY support for USB specification 2.0"
 	depends on USB_DW
 	help
 	  Indicates whether or not USB specification version 2.0 is supported
 
 config USB_DC_STM32
-	bool
-	prompt "USB device controller driver for STM32 devices"
+	bool "USB device controller driver for STM32 devices"
 	depends on SOC_FAMILY_STM32
 	select USB_DEVICE_DRIVER
 	select USE_STM32_LL_USB if !SOC_SERIES_STM32F0X && !SOC_SERIES_STM32F3X && !SOC_SERIES_STM32L0X
@@ -45,16 +42,14 @@ config USB_DC_STM32
 	  processors.
 
 config USB_DC_SAM0
-	bool
-	prompt "SAM0 series USB Device Controller driver"
+	bool "SAM0 series USB Device Controller driver"
 	depends on SOC_FAMILY_SAM0
 	select USB_DEVICE_DRIVER
 	help
 	  SAM0 family USB device controller Driver.
 
 config USB_NRF52840
-	bool
-	prompt "Nordic Semiconductor nRF52840 USB Device Controller Driver"
+	bool "Nordic Semiconductor nRF52840 USB Device Controller Driver"
 	depends on SOC_NRF52840
 	select USB_DEVICE_DRIVER
 	select HAS_DTS_USB
@@ -62,15 +57,13 @@ config USB_NRF52840
 	  nRF52840 USB Device Controller Driver
 
 config USB_KINETIS
-	bool
-	prompt "Kinetis USB Device Controller Driver"
+	bool "Kinetis USB Device Controller Driver"
 	select USB_DEVICE_DRIVER
 	help
 	  Kinetis USB Device Controller Driver.
 
 config SYS_LOG_USB_DRIVER_LEVEL
-	int
-	prompt "USB driver log level"
+	int "USB driver log level"
 	depends on SYS_LOG
 	default 0
 	help

--- a/drivers/watchdog/Kconfig
+++ b/drivers/watchdog/Kconfig
@@ -7,8 +7,7 @@
 #
 
 menuconfig WATCHDOG
-	bool
-	prompt "Watchdog Support"
+	bool "Watchdog Support"
 	help
 	  Include support for watchdogs.
 
@@ -25,14 +24,12 @@ config WDT_0_NAME
 endif # HAS_DTS_WDT
 
 config WDT_DISABLE_AT_BOOT
-	bool
-	prompt "Disable at boot"
+	bool "Disable at boot"
 	help
 	  Disable watchdog at Zephyr system startup.
 
 config SYS_LOG_WDT_LEVEL
-	int
-	prompt "Watchdog Driver Log level"
+	int "Watchdog Driver Log level"
 	depends on SYS_LOG
 	default 0
 	range 0 4
@@ -49,8 +46,7 @@ config HAS_WDT_MULTISTAGE
 	bool
 
 config WDT_MULTISTAGE
-	bool
-	prompt "Enable multistage timeouts"
+	bool "Enable multistage timeouts"
 	depends on HAS_WDT_MULTISTAGE
 	help
 	  Enable multistage operation of watchdog timeouts.

--- a/drivers/watchdog/Kconfig.qmsi
+++ b/drivers/watchdog/Kconfig.qmsi
@@ -20,8 +20,7 @@ config WDT_0_IRQ_PRI
 	  Watchdog interrupt priority
 
 config WDT_QMSI_API_REENTRANCY
-	bool
-	prompt "WDT shim driver API reentrancy"
+	bool "WDT shim driver API reentrancy"
 	depends on WDT_QMSI
 	help
 	  Enable support for WDT shim driver API reentrancy.

--- a/ext/debug/segger/Kconfig
+++ b/ext/debug/segger/Kconfig
@@ -10,8 +10,7 @@ config HAS_SEGGER_RTT
 if HAS_SEGGER_RTT
 
 config SEGGER_SYSTEMVIEW
-	bool
-	prompt "Segger SystemView support"
+	bool "Segger SystemView support"
 	select RTT_CONSOLE
 
 config SEGGER_RTT_MAX_NUM_UP_BUFFERS

--- a/ext/hal/libmetal/Kconfig
+++ b/ext/hal/libmetal/Kconfig
@@ -5,14 +5,12 @@
 #
 
 config LIBMETAL
-	bool
-	prompt "libmetal Support"
+	bool "libmetal Support"
 	help
 	  This option enables the libmetal HAL abstraction layer
 
 config LIBMETAL_SRC_PATH
-	string
-	prompt "libmetal library source path"
+	string "libmetal library source path"
 	default "libmetal"
 	help
 	  This option specifies the path to the source for the libmetal library

--- a/ext/lib/crypto/mbedtls/Kconfig
+++ b/ext/lib/crypto/mbedtls/Kconfig
@@ -18,8 +18,7 @@
 
 
 menuconfig MBEDTLS
-	bool
-	prompt "mbedTLS Support"
+	bool "mbedTLS Support"
 	help
 	  This option enables the mbedTLS cryptography library.
 

--- a/ext/lib/crypto/tinycrypt/Kconfig
+++ b/ext/lib/crypto/tinycrypt/Kconfig
@@ -7,46 +7,40 @@
 #
 
 config TINYCRYPT
-	bool
-	prompt "TinyCrypt Support"
+	bool "TinyCrypt Support"
 	help
 	  This option enables the TinyCrypt cryptography library.
 
 config TINYCRYPT_CTR_PRNG
-	bool
-	prompt "PRNG in counter mode"
+	bool "PRNG in counter mode"
 	depends on TINYCRYPT
 	help
 	  This option enables support for the pseudo-random number
 	  generator in counter mode.
 
 config TINYCRYPT_SHA256
-	bool
-	prompt "SHA-256 Hash function support"
+	bool "SHA-256 Hash function support"
 	depends on TINYCRYPT
 	help
 	  This option enables support for SHA-256
 	  hash function primitive.
 
 config TINYCRYPT_SHA256_HMAC
-	bool
-	prompt "HMAC (via SHA256) message auth support"
+	bool "HMAC (via SHA256) message auth support"
 	depends on TINYCRYPT_SHA256
 	help
 	  This option enables support for HMAC using SHA-256
 	  message authentication code.
 
 config TINYCRYPT_SHA256_HMAC_PRNG
-	bool
-	prompt "PRNG (via HMAC-SHA256) support"
+	bool "PRNG (via HMAC-SHA256) support"
 	depends on TINYCRYPT_SHA256_HMAC
 	help
 	  This option enables support for pseudo-random number
 	  generator.
 
 config TINYCRYPT_ECC_DH
-	bool
-	prompt "ECC_DH anonymous key agreement protocol"
+	bool "ECC_DH anonymous key agreement protocol"
 	depends on TINYCRYPT
 	select ENTROPY_GENERATOR
 	help
@@ -57,8 +51,7 @@ config TINYCRYPT_ECC_DH
 	  generator.
 
 config TINYCRYPT_ECC_DSA
-	bool
-	prompt "ECC_DSA digital signature algorithm"
+	bool "ECC_DSA digital signature algorithm"
 	depends on TINYCRYPT
 	select ENTROPY_GENERATOR
 	help
@@ -69,36 +62,31 @@ config TINYCRYPT_ECC_DSA
 	  generator.
 
 config TINYCRYPT_AES
-	bool
-	prompt "AES-128 decrypt/encrypt"
+	bool "AES-128 decrypt/encrypt"
 	depends on TINYCRYPT
 	help
 	  This option enables support for AES-128 decrypt and encrypt.
 
 config TINYCRYPT_AES_CBC
-	bool
-	prompt "AES-128 block cipher"
+	bool "AES-128 block cipher"
 	depends on TINYCRYPT_AES
 	help
 	  This option enables support for AES-128 block cipher mode.
 
 config TINYCRYPT_AES_CTR
-	bool
-	prompt "AES-128 counter mode"
+	bool "AES-128 counter mode"
 	depends on TINYCRYPT_AES
 	help
 	  This option enables support for AES-128 counter mode.
 
 config TINYCRYPT_AES_CCM
-	bool
-	prompt "AES-128 CCM mode"
+	bool "AES-128 CCM mode"
 	depends on TINYCRYPT_AES
 	help
 	  This option enables support for AES-128 CCM mode.
 
 config TINYCRYPT_AES_CMAC
-	bool
-	prompt "AES-128 CMAC mode"
+	bool "AES-128 CMAC mode"
 	depends on TINYCRYPT_AES
 	help
 	  This option enables support for AES-128 CMAC mode.

--- a/ext/lib/encoding/tinycbor/Kconfig
+++ b/ext/lib/encoding/tinycbor/Kconfig
@@ -18,61 +18,52 @@
 #
 
 config TINYCBOR
-	bool
-	prompt "tinyCBOR Support"
+	bool "tinyCBOR Support"
 	help
 	  This option enables the tinyCBOR library.
 
 if TINYCBOR
 
 config CBOR_NO_DFLT_WRITER
-	bool
-	prompt "No default writer support"
+	bool "No default writer support"
 	help
 	  This option specifies whether a default writer exists.
 
 config CBOR_NO_DFLT_READER
-	bool
-	prompt "No default reader support"
+	bool "No default reader support"
 	help
 	  This option specifies whether a default reader exists.
 
 config CBOR_ENCODER_NO_CHECK_USER
-	bool
-	prompt "No encoder checks for user args for validity"
+	bool "No encoder checks for user args for validity"
 	help
 	  This option specifies whether a check user exists for a cbor encoder.
 
 config CBOR_PARSER_MAX_RECURSIONS
-	int
-	prompt "Parser max recursions"
+	int "Parser max recursions"
 	default 1024
 	help
 	  This option specifies max recursions for the parser.
 
 config CBOR_PARSER_NO_STRICT_CHECKS
-	bool
-	prompt "No strict parser checks"
+	bool "No strict parser checks"
 	help
 	  This option enables the strict parser checks.
 
 config CBOR_FLOATING_POINT
-	bool
+	bool "Floating point support"
 	select NEWLIB_LIBC
-	prompt "Floating point support"
 	help
 	  This option enables floating point support.
 
 config CBOR_HALF_FLOAT_TYPE
-	bool
+	bool "Half float type support"
 	select NEWLIB_LIBC
-	prompt "Half float type support"
 	help
 	  This option enables half float type support.
 
 config CBOR_WITHOUT_OPEN_MEMSTREAM
-	bool
-	prompt "Without open memstream"
+	bool "Without open memstream"
 	default y
 	help
 	  This option enables open memstream support.

--- a/ext/lib/ipc/open-amp/Kconfig
+++ b/ext/lib/ipc/open-amp/Kconfig
@@ -5,15 +5,13 @@
 #
 
 config OPENAMP
-	bool
-	prompt "OpenAMP Support"
+	bool "OpenAMP Support"
 	select LIBMETAL
 	help
 	  This option enables the OpenAMP IPC library
 
 config OPENAMP_SRC_PATH
-	string
-	prompt "OpenAMP library source path"
+	string "OpenAMP library source path"
 	default "open-amp"
 	help
 	  This option specifies the path to the source for the open-amp library

--- a/ext/lib/mgmt/mcumgr/Kconfig
+++ b/ext/lib/mgmt/mcumgr/Kconfig
@@ -16,8 +16,7 @@
 # under the License.
 
 config MCUMGR
-    bool
-    prompt "mcumgr Support"
+    bool "mcumgr Support"
     select TINYCBOR
     help
       This option enables the mcumgr management library.

--- a/ext/lib/mgmt/mcumgr/cmd/fs_mgmt/Kconfig
+++ b/ext/lib/mgmt/mcumgr/cmd/fs_mgmt/Kconfig
@@ -16,24 +16,21 @@
 # Under the License.
 
 menuconfig MCUMGR_CMD_FS_MGMT
-    bool
-    prompt "Enable mcumgr handlers for file management"
+    bool "Enable mcumgr handlers for file management"
     depends on FILE_SYSTEM
     help
       Enables mcumgr handlers for file management
 
 if MCUMGR_CMD_FS_MGMT
 config FS_MGMT_UL_CHUNK_SIZE
-    int
-    prompt "Maximum chunk size for file uploads"
+    int "Maximum chunk size for file uploads"
     default 512
     help
       Limits the maximum chunk size for file uploads, in bytes.  A buffer of
       this size gets allocated on the stack during handling of a file upload command.
 
 config FS_MGMT_DL_CHUNK_SIZE
-    int
-    prompt "Maximum chunk size for file downloads"
+    int "Maximum chunk size for file downloads"
     default 512
     help
       Limits the maximum chunk size for file downloads, in bytes.  A buffer of
@@ -41,8 +38,7 @@ config FS_MGMT_DL_CHUNK_SIZE
       command.
 
 config FS_MGMT_PATH_SIZE
-    int
-    prompt "Maximum file path length"
+    int "Maximum file path length"
     default 64
     help
       Limits the maximum path length for file operations, in bytes.  A buffer

--- a/ext/lib/mgmt/mcumgr/cmd/img_mgmt/Kconfig
+++ b/ext/lib/mgmt/mcumgr/cmd/img_mgmt/Kconfig
@@ -16,8 +16,7 @@
 # Under the License.
 
 menuconfig MCUMGR_CMD_IMG_MGMT
-    bool
-    prompt "Enable mcumgr handlers for image management"
+    bool "Enable mcumgr handlers for image management"
     select FLASH
     select MPU_ALLOW_FLASH_WRITE if CPU_HAS_MPU
     select IMG_MANAGER
@@ -26,8 +25,7 @@ menuconfig MCUMGR_CMD_IMG_MGMT
 
 if MCUMGR_CMD_IMG_MGMT
 config IMG_MGMT_UL_CHUNK_SIZE
-    int
-    prompt "Maximum chunk size for image uploads"
+    int "Maximum chunk size for image uploads"
     default 512
     help
       Limits the maximum chunk size for image uploads, in bytes.  A buffer of

--- a/ext/lib/mgmt/mcumgr/cmd/log_mgmt/Kconfig
+++ b/ext/lib/mgmt/mcumgr/cmd/log_mgmt/Kconfig
@@ -16,23 +16,20 @@
 # Under the License.
 
 menuconfig MCUMGR_CMD_LOG_MGMT
-    bool
-    prompt "Enable mcumgr handlers for log management"
+    bool "Enable mcumgr handlers for log management"
     help
       Enables mcumgr handlers for log management
 
 if MCUMGR_CMD_LOG_MGMT
 config LOG_MGMT_CHUNK_SIZE
-    int
-    prompt "Maximum chunk size for log downloads"
+    int "Maximum chunk size for log downloads"
     default 512
     help
       Limits the maximum chunk size for log downloads, in bytes.  A buffer of
       this size gets allocated on the stack during handling of the log show command.
 
 config LOG_MGMT_NAME_LEN
-    int
-    prompt "Maximum log name length"
+    int "Maximum log name length"
     default 64
     help
       Limits the maximum length of log names, in bytes.  If a log's name length
@@ -41,8 +38,7 @@ config LOG_MGMT_NAME_LEN
       management commands.
 
 config LOG_MGMT_BODY_LEN
-    int
-    prompt "Maximum log body length"
+    int "Maximum log body length"
     default 128
     help
       Limits the maximum length of log entry bodies, in bytes.  If a log

--- a/ext/lib/mgmt/mcumgr/cmd/os_mgmt/Kconfig
+++ b/ext/lib/mgmt/mcumgr/cmd/os_mgmt/Kconfig
@@ -16,16 +16,14 @@
 # Under the License.
 
 menuconfig MCUMGR_CMD_OS_MGMT
-    bool
-    prompt "Enable mcumgr handlers for OS management"
+    bool "Enable mcumgr handlers for OS management"
     select REBOOT
     help
       Enables mcumgr handlers for OS management
 
 if MCUMGR_CMD_OS_MGMT
 config OS_MGMT_RESET_MS
-    int
-    prompt "Delay before executing reset command (ms)"
+    int "Delay before executing reset command (ms)"
     default 250
     help
       When a reset command is received, the system waits this many milliseconds

--- a/ext/lib/mgmt/mcumgr/cmd/stat_mgmt/Kconfig
+++ b/ext/lib/mgmt/mcumgr/cmd/stat_mgmt/Kconfig
@@ -16,16 +16,14 @@
 # Under the License.
 
 menuconfig MCUMGR_CMD_STAT_MGMT
-    bool
-    prompt "Enable mcumgr handlers for statistics management"
+    bool "Enable mcumgr handlers for statistics management"
     depends on STATS
     help
       Enables mcumgr handlers for statistics management.
 
 if MCUMGR_CMD_STAT_MGMT
 config STAT_MGMT_MAX_NAME_LEN
-    int
-    prompt "Maximum stat group name length"
+    int "Maximum stat group name length"
     default 32
     help
       Limits the maximum stat group name length in mcumgr requests, in bytes.

--- a/kernel/Kconfig
+++ b/kernel/Kconfig
@@ -10,8 +10,7 @@
 menu "General Kernel Options"
 
 config MULTITHREADING
-	bool
-	prompt "Multi-threading"
+	bool "Multi-threading"
 	default y
 	help
 	  If disabled, only the main thread is available, so a main() function
@@ -24,8 +23,7 @@ config MULTITHREADING
 	  when you REALLY know what you are doing.
 
 config NUM_COOP_PRIORITIES
-	int
-	prompt "Number of coop priorities" if MULTITHREADING
+	int "Number of coop priorities" if MULTITHREADING
 	default 1 if !MULTITHREADING
 	default 16
 	range 0 128
@@ -54,8 +52,7 @@ config NUM_COOP_PRIORITIES
 	  priority, and be the only thread at that priority.
 
 config NUM_PREEMPT_PRIORITIES
-	int
-	prompt "Number of preemptible priorities" if MULTITHREADING
+	int "Number of preemptible priorities" if MULTITHREADING
 	default 0 if !MULTITHREADING
 	default 15
 	range 0 128
@@ -77,8 +74,7 @@ config NUM_PREEMPT_PRIORITIES
 	  priority, and be the only thread at that priority.
 
 config MAIN_THREAD_PRIORITY
-	int
-	prompt "Priority of initialization/main thread"
+	int "Priority of initialization/main thread"
 	default -2 if !PREEMPT_ENABLED
 	default 0
 	help
@@ -92,13 +88,11 @@ config PREEMPT_ENABLED
 	def_bool (NUM_PREEMPT_PRIORITIES != 0)
 
 config PRIORITY_CEILING
-	int
-	prompt "Priority inheritance ceiling"
+	int "Priority inheritance ceiling"
 	default 0
 
 config NUM_METAIRQ_PRIORITIES
-	int
-	prompt "Number of very-high priority 'preemptor' threads"
+	int "Number of very-high priority 'preemptor' threads"
 	default 0
 	help
 	 This defines a set of priorities at the (numerically) lowest
@@ -119,8 +113,7 @@ config NUM_METAIRQ_PRIORITIES
 	 from application code.
 
 config SCHED_DEADLINE
-	bool
-	prompt "Enable earliest-deadline-first scheduling"
+	bool "Enable earliest-deadline-first scheduling"
 	help
 	  This enables a simple "earliest deadline first" scheduling
 	  mode where threads can set "deadline" deltas measured in
@@ -130,8 +123,7 @@ config SCHED_DEADLINE
 
 
 config MAIN_STACK_SIZE
-	int
-	prompt "Size of stack for initialization and main thread"
+	int "Size of stack for initialization and main thread"
 	default 512 if ZTEST
 	default 1024
 	help
@@ -142,8 +134,7 @@ config MAIN_STACK_SIZE
 	  After initialization is complete, the thread runs main().
 
 config IDLE_STACK_SIZE
-	int
-	prompt "Size of stack for idle thread"
+	int "Size of stack for idle thread"
 	default 1024 if XTENSA
 	default 512 if RISCV32
 	default 320 if ARC || (ARM && CPU_HAS_FPU)
@@ -155,30 +146,26 @@ config IDLE_STACK_SIZE
 	  may need more stack space than the default value.
 
 config ISR_STACK_SIZE
-	int
-	prompt "ISR and initialization stack size (in bytes)"
+	int "ISR and initialization stack size (in bytes)"
 	default 2048
 	help
 	  This option specifies the size of the stack used by interrupt
 	  service routines (ISRs), and during kernel initialization.
 
 config THREAD_STACK_INFO
-	bool
-	prompt "Thread stack info"
+	bool "Thread stack info"
 	help
 	  This option allows each thread to store the thread stack info into
 	  the k_thread data structure.
 
 config  THREAD_CUSTOM_DATA
-	bool
-	prompt "Thread custom data"
+	bool "Thread custom data"
 	help
 	  This option allows each thread to store 32 bits of custom data,
 	  which can be accessed using the k_thread_custom_data_xxx() APIs.
 
 config ERRNO
-	bool
-	prompt "Enable errno support"
+	bool "Enable errno support"
 	default y
 	help
 	  Enable per-thread errno in the kernel. Application and library code must
@@ -187,8 +174,7 @@ config ERRNO
 	  _get_errno() symbol.
 
 config APPLICATION_MEMORY
-	bool
-	prompt "Split kernel and application memory"
+	bool "Split kernel and application memory"
 	help
 	  For all read-write memory sections (namely bss, noinit, data),
 	  separate them into application and kernel areas. The application area
@@ -259,8 +245,7 @@ choice WAITQ_ALGORITHM
 	  options.
 
 config WAITQ_SCALABLE
-	bool
-	prompt "Use scalable wait_q implementation"
+	bool "Use scalable wait_q implementation"
 	help
 	  When selected, the wait_q will be implemented with a
 	  balanced tree.  Choose this if you expect to have many
@@ -272,8 +257,7 @@ config WAITQ_SCALABLE
 	  performance path).
 
 config WAITQ_DUMB
-	bool
-	prompt "Simple linked-list wait_q"
+	bool "Simple linked-list wait_q"
 	help
 	  When selected, the wait_q will be implemented with a
 	  doubly-linked list.  Choose this if you expect to have only
@@ -284,8 +268,7 @@ endchoice # WAITQ_ALGORITHM
 menu "Kernel Debugging and Metrics"
 
 config INIT_STACKS
-	bool
-	prompt "Initialize stack areas"
+	bool "Initialize stack areas"
 	help
 	  This option instructs the kernel to initialize stack areas with a
 	  known value (0xaa) before they are first used, so that the high
@@ -293,8 +276,7 @@ config INIT_STACKS
 	  for threads.
 
 config KERNEL_DEBUG
-	bool
-	prompt "Kernel debugging"
+	bool "Kernel debugging"
 	select INIT_STACKS
 	help
 	  Enable kernel debugging.
@@ -302,8 +284,7 @@ config KERNEL_DEBUG
 	  Note that debugging the kernel internals can be very verbose.
 
 config BOOT_BANNER
-	bool
-	prompt "Boot banner"
+	bool "Boot banner"
 	default y
 	depends on CONSOLE_HAS_DRIVER
 	select PRINTK
@@ -314,8 +295,7 @@ config BOOT_BANNER
 	  option is enabled.
 
 config BOOT_DELAY
-	int
-	prompt "Boot delay in milliseconds"
+	int "Boot delay in milliseconds"
 	default 0
 	help
 	  This option delays bootup for the specified amount of
@@ -328,16 +308,14 @@ config BOOT_DELAY
 	  all serial ports have DCD.
 
 config BUILD_TIMESTAMP
-	bool
-	prompt "Build Timestamp"
+	bool "Build Timestamp"
 	help
 	  Record a timestamp from the build and add it to the boot banner.
 	  Note that this will make the build unreproducible: building
 	  Zephyr twice will result in different binaries.
 
 config INT_LATENCY_BENCHMARK
-	bool
-	prompt "Interrupt latency metrics [EXPERIMENTAL]"
+	bool "Interrupt latency metrics [EXPERIMENTAL]"
 	depends on ARCH="x86"
 	help
 	  This option enables the tracking of interrupt latency metrics;
@@ -347,8 +325,7 @@ config INT_LATENCY_BENCHMARK
 	  each time int_latency_show() is called thereafter.
 
 config EXECUTION_BENCHMARKING
-	bool
-	prompt "Timing metrics"
+	bool "Timing metrics"
 	help
 	  This option enables the tracking of various times inside the kernel
 	  the exact set of metrics being tracked is board-dependent.
@@ -356,8 +333,7 @@ config EXECUTION_BENCHMARKING
 	  In other architectures only a subset are enabled.
 
 config THREAD_MONITOR
-	bool
-	prompt "Thread monitoring [EXPERIMENTAL]"
+	bool "Thread monitoring [EXPERIMENTAL]"
 	help
 	  This option instructs the kernel to maintain a list of all threads
 	  (excluding those that have not yet started or have already
@@ -445,8 +421,7 @@ config TIMESLICE_PRIORITY
 	  not subject to time slicing.
 
 config POLL
-	bool
-	prompt "Async I/O Framework"
+	bool "Async I/O Framework"
 	help
 	  Asynchronous notification framework. Enable the k_poll() and
 	  k_poll_signal() APIs.  The former can wait on multiple events
@@ -480,8 +455,7 @@ config NUM_PIPE_ASYNC_MSGS
 	  pipe messages.
 
 config HEAP_MEM_POOL_SIZE
-	int
-	prompt "Heap memory pool size (in bytes)"
+	int "Heap memory pool size (in bytes)"
 	default 0 if !POSIX_MQUEUE
 	default 1024 if POSIX_MQUEUE
 	help
@@ -508,8 +482,7 @@ config ARCH_HAS_CUSTOM_BUSY_WAIT
 	  enable this option in that case.
 
 config SYS_CLOCK_TICKS_PER_SEC
-	int
-	prompt "System tick frequency (in ticks/second)"
+	int "System tick frequency (in ticks/second)"
 	default 100
 	help
 	  This option specifies the frequency of the system clock in Hz.
@@ -547,8 +520,7 @@ config SYS_CLOCK_EXISTS
 	  This option specifies that the kernel lacks timer support.
 
 config XIP
-	bool
-	prompt "Execute in place"
+	bool "Execute in place"
 	help
 	  This option allows the kernel to operate with its text and read-only
 	  sections residing in ROM (or similar read-only memory). Not all boards
@@ -559,8 +531,7 @@ config XIP
 menu "Initialization Priorities"
 
 config KERNEL_INIT_PRIORITY_OBJECTS
-	int
-	prompt "Kernel objects initialization priority"
+	int "Kernel objects initialization priority"
 	default 30
 	help
 	  Kernel objects use this priority for initialization. This
@@ -568,15 +539,13 @@ config KERNEL_INIT_PRIORITY_OBJECTS
 	  priority.
 
 config KERNEL_INIT_PRIORITY_DEFAULT
-	int
-	prompt "Default init priority"
+	int "Default init priority"
 	default 40
 	help
 	  Default minimal init priority for each init level.
 
 config KERNEL_INIT_PRIORITY_DEVICE
-	int
-	prompt "Default init priority for device drivers"
+	int "Default init priority for device drivers"
 	default 50
 	help
 	  Device driver, that depends on common components, such as
@@ -584,8 +553,7 @@ config KERNEL_INIT_PRIORITY_DEVICE
 	  uses this init priority.
 
 config APPLICATION_INIT_PRIORITY
-	int
-	prompt "Default init priority for application level drivers"
+	int "Default init priority for application level drivers"
 	default 90
 	help
 	  This priority level is for end-user drivers such as sensors and display
@@ -597,8 +565,7 @@ endmenu
 menu "Security Options"
 
 config RETPOLINE
-	bool
-	prompt "Build with retpolines enabled"
+	bool "Build with retpolines enabled"
 	default y if !X86_NO_SPECTRE_V2
 	help
 	  This is recommended on platforms with speculative executions, to protect
@@ -610,8 +577,7 @@ config RETPOLINE
 	  [1] https://support.google.com/faqs/answer/7625886
 
 config STACK_CANARIES
-	bool
-	prompt "Compiler stack canaries"
+	bool "Compiler stack canaries"
 	help
 	  This option enables compiler stack canaries support kernel functions.
 
@@ -640,8 +606,7 @@ config EXECUTE_XOR_WRITE
 	  If unsure, say Y.
 
 config STACK_POINTER_RANDOM
-	int
-	prompt "Initial stack pointer randomization bounds"
+	int "Initial stack pointer randomization bounds"
 	depends on !STACK_GROWS_UP
 	default 0
 	help
@@ -662,8 +627,7 @@ config STACK_POINTER_RANDOM
 endmenu
 
 config MAX_DOMAIN_PARTITIONS
-	int
-	prompt "Maximum number of partitions per memory domain"
+	int "Maximum number of partitions per memory domain"
 	default 16
 	range 0 255
 	depends on USERSPACE
@@ -672,8 +636,7 @@ config MAX_DOMAIN_PARTITIONS
 
 menu "SMP Options"
 config USE_SWITCH
-	bool
-	prompt "Use new-style _arch_switch instead of __swap"
+	bool "Use new-style _arch_switch instead of __swap"
 	help
 	  The _arch_switch() API is a lower level context switching
 	  primitive than the original __swap mechanism.  It is required
@@ -683,15 +646,13 @@ config USE_SWITCH
 	  overhead and may be slower.
 
 config SMP
-	bool
-	prompt "Enable symmetric multithreading support"
+	bool "Enable symmetric multithreading support"
 	help
 	  When true, kernel will be built with SMP support, allowing
 	  more than one CPU to schedule Zephyr tasks at a time.
 
 config MP_NUM_CPUS
-	int
-	prompt "Number of CPUs/cores"
+	int "Number of CPUs/cores"
 	default 1
 	help
 	  Number of multiprocessing-capable cores available to the

--- a/kernel/Kconfig.event_logger
+++ b/kernel/Kconfig.event_logger
@@ -5,8 +5,7 @@
 #
 
 menuconfig KERNEL_EVENT_LOGGER
-	bool
-	prompt "Enable kernel event logger features"
+	bool "Enable kernel event logger features"
 	select RING_BUFFER
 	help
 	  This feature enables the usage of the profiling logger. Provides the
@@ -16,23 +15,20 @@ menuconfig KERNEL_EVENT_LOGGER
 
 if KERNEL_EVENT_LOGGER
 config KERNEL_EVENT_LOGGER_BUFFER_SIZE
-	int
-	prompt "Kernel event logger buffer size"
+	int "Kernel event logger buffer size"
 	default 128
 	help
 	  Buffer size in 32-bit words.
 
 config KERNEL_EVENT_LOGGER_DYNAMIC
-	bool
-	prompt "Kernel event logger dynamic enabling"
+	bool "Kernel event logger dynamic enabling"
 	help
 	  If enabled, kernel event logger is not logging any data to the ring buffer
 	  It is up to the application to set the appropriate flags to enable/disable the
 	  logging of each event type.
 
 config KERNEL_EVENT_LOGGER_CUSTOM_TIMESTAMP
-	bool
-	prompt "Kernel event logger custom timestamp"
+	bool "Kernel event logger custom timestamp"
 	help
 	  This flag enables the possibility to set the timer function to be used to
 	  populate kernel event logger timestamp. This has to be done at runtime by
@@ -41,21 +37,18 @@ config KERNEL_EVENT_LOGGER_CUSTOM_TIMESTAMP
 menu "Kernel event logging points"
 
 config KERNEL_EVENT_LOGGER_CONTEXT_SWITCH
-	bool
-	prompt "Context switch event logging point"
+	bool "Context switch event logging point"
 	help
 	  Enable the context switch event messages.
 
 config KERNEL_EVENT_LOGGER_INTERRUPT
-	bool
-	prompt "Interrupt event logging point"
+	bool "Interrupt event logging point"
 	help
 	  Enable interrupt event messages. These messages provide the following
 	  information: The time when interrupts occur.
 
 config KERNEL_EVENT_LOGGER_SLEEP
-	bool
-	prompt "Sleep event logging point"
+	bool "Sleep event logging point"
 	depends on SYS_POWER_MANAGEMENT
 	help
 	  Enable low power condition event messages. These messages provide the
@@ -66,8 +59,7 @@ config KERNEL_EVENT_LOGGER_SLEEP
 		- The ID of the interrupt that woke the CPU up.
 
 config KERNEL_EVENT_LOGGER_THREAD
-	bool
-	prompt "Thread event logging point"
+	bool "Thread event logging point"
 	help
 	  Enable thread event messages. These messages provide the following
 	  information:

--- a/kernel/Kconfig.power_mgmt
+++ b/kernel/Kconfig.power_mgmt
@@ -6,8 +6,7 @@
 #
 
 menuconfig SYS_POWER_MANAGEMENT
-	bool
-	prompt "Power management"
+	bool "Power management"
 	help
 	  This option enables the board to implement extra power management
 	  policies whenever the kernel becomes idle. The kernel informs the
@@ -16,8 +15,7 @@ menuconfig SYS_POWER_MANAGEMENT
 
 if SYS_POWER_MANAGEMENT
 config SYS_POWER_LOW_POWER_STATE
-	bool
-	prompt "Low power state"
+	bool "Low power state"
 	depends on SYS_POWER_LOW_POWER_STATE_SUPPORTED
 	help
 	  This option enables the kernel to interface with a power manager
@@ -27,8 +25,7 @@ config SYS_POWER_LOW_POWER_STATE
 	  saving most power.
 
 config SYS_POWER_DEEP_SLEEP
-	bool
-	prompt "Deep sleep state"
+	bool "Deep sleep state"
 	depends on SYS_POWER_DEEP_SLEEP_SUPPORTED
 	help
 	  This option enables the kernel to interface with a power manager
@@ -40,8 +37,7 @@ config SYS_POWER_DEEP_SLEEP
 	  restoration of states that were saved at the time of suspend.
 
 config DEVICE_POWER_MANAGEMENT
-	bool
-	prompt "Device power management"
+	bool "Device power management"
 	help
 	  This option enables the device power management interface.  The
 	  interface consists of hook functions implemented by device drivers
@@ -52,8 +48,7 @@ config DEVICE_POWER_MANAGEMENT
 	  may also save and restore states in these hook functions.
 
 config TICKLESS_IDLE
-	bool
-	prompt "Tickless idle"
+	bool "Tickless idle"
 	default y
 	help
 	  This option suppresses periodic system clock interrupts whenever the
@@ -62,8 +57,7 @@ config TICKLESS_IDLE
 	  service each tick as it occurs.
 
 config TICKLESS_IDLE_THRESH
-	int
-	prompt "Tickless idle threshold"
+	int "Tickless idle threshold"
 	default 3
 	depends on TICKLESS_IDLE
 	help
@@ -73,8 +67,7 @@ config TICKLESS_IDLE_THRESH
 	  for suppression to happen.
 
 config TICKLESS_KERNEL
-	bool
-	prompt "Tickless kernel"
+	bool "Tickless kernel"
 	depends on TICKLESS_IDLE
 	help
 	  This option enables a fully event driven kernel. Periodic system
@@ -82,8 +75,7 @@ config TICKLESS_KERNEL
 	  requires Tickless Idle option to be enabled.
 
 config TICKLESS_KERNEL_TIME_UNIT_IN_MICRO_SECS
-	int
-	prompt "Tickless kernel time unit in micro seconds"
+	int "Tickless kernel time unit in micro seconds"
 	default 1000
 	depends on TICKLESS_KERNEL
 	help
@@ -95,8 +87,7 @@ config TICKLESS_KERNEL_TIME_UNIT_IN_MICRO_SECS
 	  system speed can support would cause scheduling errors.
 
 config BUSY_WAIT_USES_ALTERNATE_CLOCK
-	bool
-	prompt "Busy wait uses alternate clock in tickless kernel mode"
+	bool "Busy wait uses alternate clock in tickless kernel mode"
 	help
 	  In tickless kernel mode, the system clock will be stopped when
 	  there are no timer events programmed. If the system clock is to

--- a/lib/Kconfig
+++ b/lib/Kconfig
@@ -9,23 +9,20 @@ source "lib/libc/Kconfig"
 menu "Additional libraries"
 
 config JSON_LIBRARY
-	bool
-	prompt "Build JSON library"
+	bool "Build JSON library"
 	help
 	  Build a minimal JSON parsing/encoding library. Used by sample
 	  applications such as the NATS client.
 
 config RING_BUFFER
-	bool
-	prompt "Enable ring buffers"
+	bool "Enable ring buffers"
 	help
 	  Enable usage of ring buffers. This is similar to kernel FIFOs but ring
 	  buffers manage their own buffer memory and can store arbitrary data.
 	  For optimal performance, use buffer sizes that are a power of 2.
 
 config BASE64
-	bool
-	prompt "Enable base64 encoding and decoding"
+	bool "Enable base64 encoding and decoding"
 	help
 	  Enable base64 encoding and decoding functionality
 

--- a/lib/cmsis_rtos_v1/Kconfig
+++ b/lib/cmsis_rtos_v1/Kconfig
@@ -4,8 +4,7 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 config CMSIS_RTOS_V1
-	bool
-	prompt "CMSIS RTOS v1 API"
+	bool "CMSIS RTOS v1 API"
 	default n
 	help
 	  This enables CMSIS RTOS v1 API support. This is an OS-integration
@@ -14,16 +13,14 @@ config CMSIS_RTOS_V1
 
 if CMSIS_RTOS_V1
 config  THREAD_CUSTOM_DATA
-	bool
-	prompt "Thread custom data"
+	bool "Thread custom data"
 	default y
 	help
 	  This option allows each thread to store 32 bits of custom data,
 	  which can be accessed using the k_thread_custom_data_xxx() APIs.
 
 config POLL
-	bool
-	prompt "Async I/O Framework"
+	bool "Async I/O Framework"
 	default y
 	help
 	  Asynchronous notification framework. Enable the k_poll() and
@@ -32,8 +29,7 @@ config POLL
 	  the availability of some kernel objects (semaphores and fifos).
 
 config CMSIS_MAX_THREAD_COUNT
-	int
-	prompt "Maximum thread count in CMSIS RTOS application"
+	int "Maximum thread count in CMSIS RTOS application"
 	default 10
 	range 0 255
 	help
@@ -42,31 +38,27 @@ config CMSIS_MAX_THREAD_COUNT
 	  related constraints.
 
 config CMSIS_THREAD_MAX_STACK_SIZE
-	int
-	prompt "Max stack size threads can be allocated in CMSIS RTOS application"
+	int "Max stack size threads can be allocated in CMSIS RTOS application"
 	default 512
 	help
 	  Mention max stack size threads can be allocated in CMSIS RTOS application.
 
 config CMSIS_TIMER_MAX_COUNT
-	int
-	prompt "Maximum timer count in CMSIS application"
+	int "Maximum timer count in CMSIS application"
 	default 5
 	range 0 255
 	help
 	  Mention maximum number of timers in CMSIS compliant application.
 
 config CMSIS_MUTEX_MAX_COUNT
-	int
-	prompt "Maximum mutex count in CMSIS application"
+	int "Maximum mutex count in CMSIS application"
 	default 5
 	range 0 255
 	help
 	  Mention maximum number of mutexes in CMSIS compliant application.
 
 config CMSIS_SEMAPHORE_MAX_COUNT
-	int
-	prompt "Maximum semaphore count in CMSIS application"
+	int "Maximum semaphore count in CMSIS application"
 	default 5
 	range 0 255
 	help

--- a/lib/libc/Kconfig
+++ b/lib/libc/Kconfig
@@ -10,15 +10,13 @@ menu "C Library"
 depends on !NATIVE_APPLICATION
 
 config NEWLIB_LIBC
-	bool
-	prompt "Build with newlib c library"
+	bool "Build with newlib c library"
 	help
 	  Build with newlib library. The newlib library is expected to be
 	  part of the SDK in this case.
 
 config NEWLIB_LIBC_ALIGNED_HEAP_SIZE
-	int
-	prompt "Newlib aligned heap size"
+	int "Newlib aligned heap size"
 	depends on MPU_REQUIRES_POWER_OF_TWO_ALIGNMENT
 	depends on NEWLIB_LIBC
 	depends on USERSPACE
@@ -47,8 +45,7 @@ config NEWLIB_LIBC_FLOAT_SCANF
 	  the image.
 
 config STDOUT_CONSOLE
-	bool
-	prompt "Send stdout to console"
+	bool "Send stdout to console"
 	depends on CONSOLE_HAS_DRIVER
 	default NEWLIB_LIBC
 	help
@@ -59,8 +56,7 @@ config STDOUT_CONSOLE
 # Minimal libc options
 
 config MINIMAL_LIBC_MALLOC_ARENA_SIZE
-	int
-	prompt "Size of the minimal libc malloc arena"
+	int "Size of the minimal libc malloc arena"
 	depends on !NEWLIB_LIBC
 	default 0
 	help

--- a/lib/posix/Kconfig
+++ b/lib/posix/Kconfig
@@ -5,8 +5,7 @@
 #
 
 config PTHREAD_IPC
-	bool
-	prompt "POSIX pthread IPC API"
+	bool "POSIX pthread IPC API"
 	help
 	  This enables a mostly-standards-compliant implementation of
 	  the pthread mutex, condition variable and barrier IPC
@@ -14,54 +13,47 @@ config PTHREAD_IPC
 
 if PTHREAD_IPC
 config MAX_PTHREAD_COUNT
-	int
-	prompt "Maximum pthread count in POSIX application"
+	int "Maximum pthread count in POSIX application"
 	default 5
 	range 0 255
 	help
 	  Mention maximum number of threads in POSIX compliant application.
 
 config SEM_VALUE_MAX
-	int
-	prompt "Maximum semaphore limit"
+	int "Maximum semaphore limit"
 	default 32767
 	range 1 32767
 	help
 	  Maximum semaphore count in POSIX compliant Application.
 
 config MAX_TIMER_COUNT
-	int
-	prompt "Maximum timer count in POSIX application"
+	int "Maximum timer count in POSIX application"
 	default 5
 	range 0 255
 	help
 	  Mention maximum number of timers in POSIX compliant application.
 
 config POSIX_MQUEUE
-	bool
-	prompt "Enable POSIX message queue"
+	bool "Enable POSIX message queue"
 	help
 	  This enabled POSIX message queue related APIs.
 
 if POSIX_MQUEUE
 config	MSG_COUNT_MAX
-	int
-	prompt "Maximum number of messages in message queue"
+	int "Maximum number of messages in message queue"
 	default 16
 	help
 	  Mention maximum number of messages in message queue in POSIX compliant
 	  application.
 
 config	MSG_SIZE_MAX
-	int
-	prompt "Maximum size of a message"
+	int "Maximum size of a message"
 	default 16
 	help
 	  Mention maximum size of message in bytes.
 
 config	MQUEUE_NAMELEN_MAX
-	int
-	prompt "Maximum size of a name length"
+	int "Maximum size of a name length"
 	default 16
 	range 2 255
 	help
@@ -71,15 +63,13 @@ endif
 
 if FILE_SYSTEM
 config POSIX_FS
-	bool
-	prompt "Enable POSIX file system API support"
+	bool "Enable POSIX file system API support"
 	help
 	  This enabled POSIX style file system related APIs.
 
 if POSIX_FS
 config	POSIX_MAX_OPEN_FILES
-	int
-	prompt "Maximum number of open file descriptors"
+	int "Maximum number of open file descriptors"
 	default 16
 	help
 	  Mention maximum number of open file descriptors.

--- a/misc/Kconfig
+++ b/misc/Kconfig
@@ -166,8 +166,7 @@ config NO_OPTIMIZATIONS
 endchoice
 
 config COMPILER_OPT
-	string
-	prompt "Custom compiler options"
+	string "Custom compiler options"
 	help
 	  This option is a free-form string that is passed to the compiler
 	  when building all parts of a project (i.e. kernel).
@@ -260,14 +259,12 @@ endmenu
 menu "System Monitoring Options"
 
 config PERFORMANCE_METRICS
-	bool
-	prompt "Enable performance metrics [EXPERIMENTAL]"
+	bool "Enable performance metrics [EXPERIMENTAL]"
 	help
 	  Enable Performance Metrics.
 
 config BOOT_TIME_MEASUREMENT
-	bool
-	prompt "Boot time measurements [EXPERIMENTAL]"
+	bool "Boot time measurements [EXPERIMENTAL]"
 	depends on PERFORMANCE_METRICS
 	help
 	  This option enables the recording of timestamps during system start
@@ -277,8 +274,7 @@ config BOOT_TIME_MEASUREMENT
 	  recorded in terms of CPU clock cycles since system reset.
 
 config CPU_CLOCK_FREQ_MHZ
-	int
-	prompt "CPU Clock Frequency in MHz"
+	int "CPU Clock Frequency in MHz"
 	default 20
 	depends on BOOT_TIME_MEASUREMENT
 	help
@@ -286,16 +282,14 @@ config CPU_CLOCK_FREQ_MHZ
 	  convert Intel RDTSC timestamp to microseconds.
 
 config STATS
-	bool
-	prompt "Statistics support"
+	bool "Statistics support"
 	help
 	  Enable per-module event counters for troubleshooting, maintenance,
 	  and usage monitoring.  Statistics can be retrieved with the mcumgr
 	  management subsystem.
 
 config STATS_NAMES
-	bool
-	prompt "Statistic names"
+	bool "Statistic names"
 	depends on STATS
 	help
 	  Include a full name string for each statistic in the build.  If this
@@ -327,8 +321,7 @@ config BOOTLOADER_SRAM_SIZE
 	  bootloader that loads the Zephyr !XIP image onto SRAM.
 
 config BOOTLOADER_MCUBOOT
-	bool
-	prompt "MCUboot bootloader support"
+	bool "MCUboot bootloader support"
 	help
 	  This option signifies that the target uses MCUboot as a bootloader,
 	  or in other words that the image is to be chain-loaded by MCUboot.
@@ -359,16 +352,14 @@ config REALMODE
 	  protected mode.
 
 config BOOTLOADER_KEXEC
-	bool
-	prompt "Boot using Linux kexec() system call"
+	bool "Boot using Linux kexec() system call"
 	depends on X86
 	help
 	  This option signifies that Linux boots the kernel using kexec system call
 	  and utility. This method is used to boot the kernel over the network.
 
 config BOOTLOADER_UNKNOWN
-	bool
-	prompt "Generic boot loader support"
+	bool "Generic boot loader support"
 	depends on X86
 	help
 	  This option signifies that the target has a generic bootloader
@@ -377,8 +368,7 @@ config BOOTLOADER_UNKNOWN
 	  the board may have to do extra work to ensure a proper startup.
 
 config BOOTLOADER_CONTEXT_RESTORE
-	bool
-	prompt "Boot loader has context restore support"
+	bool "Boot loader has context restore support"
 	default y
 	depends on SYS_POWER_DEEP_SLEEP && BOOTLOADER_CONTEXT_RESTORE_SUPPORTED
 	help

--- a/subsys/dfu/Kconfig
+++ b/subsys/dfu/Kconfig
@@ -31,9 +31,8 @@ config MCUBOOT_IMG_MANAGER
 endchoice
 
 config IMG_BLOCK_BUF_SIZE
-	int
+	int "Image writer buffer size"
 	depends on MCUBOOT_IMG_MANAGER
-	prompt "Image writer buffer size"
 	default 512
 	help
 	  Size (in Bytes) of buffer for image writer. Must be a multiple of

--- a/subsys/logging/Kconfig
+++ b/subsys/logging/Kconfig
@@ -27,8 +27,7 @@ config SYS_LOG_SHOW_COLOR
 	  Use color in the logs. This requires an ANSI capable terminal.
 
 config SYS_LOG_DEFAULT_LEVEL
-	int
-	prompt "Default log level"
+	int "Default log level"
 	depends on SYS_LOG
 	default 0
 	range 0 4
@@ -43,8 +42,7 @@ config SYS_LOG_DEFAULT_LEVEL
 	  4 DEBUG, default to write SYS_LOG_DBG in addition to previous levels
 
 config SYS_LOG_OVERRIDE_LEVEL
-	int
-	prompt "Override lowest log level"
+	int "Override lowest log level"
 	depends on SYS_LOG
 	default 0
 	range 0 4

--- a/subsys/net/Kconfig
+++ b/subsys/net/Kconfig
@@ -33,8 +33,7 @@ config NET_BUF_LOG
 
 if NET_BUF_LOG
 config SYS_LOG_NET_BUF_LEVEL
-	int
-	prompt "Network buffer Logging level"
+	int "Network buffer Logging level"
 	depends on SYS_LOG
 	default 1
 	range 0 4
@@ -48,8 +47,7 @@ config SYS_LOG_NET_BUF_LEVEL
 	  4 DEBUG, write SYS_LOG_DBG in addition to previous levels
 
 config NET_BUF_WARN_ALLOC_INTERVAL
-	int
-	prompt "Interval of Network buffer allocation warnings"
+	int "Interval of Network buffer allocation warnings"
 	default 1
 	range 0 60
 	help

--- a/subsys/net/lib/dns/Kconfig
+++ b/subsys/net/lib/dns/Kconfig
@@ -150,8 +150,7 @@ config NET_DEBUG_MDNS_RESPONDER
 	  Enables mDNS responder code to output debug messages
 
 config MDNS_RESOLVER_ADDITIONAL_BUF_CTR
-	int
-	prompt "Additional DNS buffers"
+	int "Additional DNS buffers"
 	default 0
 	help
 	  Number of additional buffers available for the mDNS responder.
@@ -196,8 +195,7 @@ config NET_DEBUG_LLMNR_RESPONDER
 	  Enables LLMNR responder code to output debug messages
 
 config LLMNR_RESOLVER_ADDITIONAL_BUF_CTR
-	int
-	prompt "Additional DNS buffers"
+	int "Additional DNS buffers"
 	default 0
 	help
 	  Number of additional buffers available for the LLMNR responder.

--- a/subsys/usb/class/Kconfig
+++ b/subsys/usb/class/Kconfig
@@ -35,8 +35,7 @@ config CDC_ACM_BULK_EP_MPS
 	  CDC ACM class bulk endpoints size
 
 config SYS_LOG_USB_CDC_ACM_LEVEL
-	int
-	prompt "USB CDC ACM device class driver log level"
+	int "USB CDC ACM device class driver log level"
 	depends on USB_CDC_ACM && SYS_LOG
 	default 0
 	help
@@ -76,8 +75,7 @@ config MASS_STORAGE_BULK_EP_MPS
 	  Mass storage device class bulk endpoints size
 
 config SYS_LOG_USB_MASS_STORAGE_LEVEL
-	int
-	prompt "USB Mass Storage device class driver log level"
+	int "USB Mass Storage device class driver log level"
 	depends on USB_MASS_STORAGE && SYS_LOG
 	default 0
 	help
@@ -119,8 +117,7 @@ config BLUETOOTH_BULK_EP_MPS
 	  Bluetooth device class bulk endpoint size
 
 config USB_DEVICE_LOOPBACK
-	bool
-	prompt "USB Loopback Function Driver"
+	bool "USB Loopback Function Driver"
 	help
 	  USB Loopback Function Driver
 

--- a/subsys/usb/class/hid/Kconfig
+++ b/subsys/usb/class/hid/Kconfig
@@ -14,8 +14,7 @@ config USB_DEVICE_HID
 if USB_DEVICE_HID
 
 config HID_INTERRUPT_EP_MPS
-	int
-	prompt "USB HID Device Interrupt Endpoint size"
+	int "USB HID Device Interrupt Endpoint size"
 	default 16
 	help
 	  USB HID Device interrupt endpoint size

--- a/subsys/usb/class/netusb/Kconfig
+++ b/subsys/usb/class/netusb/Kconfig
@@ -88,8 +88,7 @@ endif # USB_DEVICE_NETWORK_RNDIS
 if USB_DEVICE_NETWORK
 
 config SYS_LOG_USB_DEVICE_NETWORK_DEBUG_LEVEL
-	int
-	prompt "USB Device Network debug log level"
+	int "USB Device Network debug log level"
 	default 1
 	help
 	  Sets log level for USB Device Network class

--- a/tests/drivers/spi/spi_loopback/Kconfig
+++ b/tests/drivers/spi/spi_loopback/Kconfig
@@ -11,8 +11,7 @@ config SPI_LOOPBACK_CS_GPIO
 	depends on GPIO
 
 config SPI_LOOPBACK_CS_CTRL_GPIO_DRV_NAME
-	string
-	prompt "The GPIO port which is used to control CS"
+	string "The GPIO port which is used to control CS"
 	depends on SPI_LOOPBACK_CS_GPIO
 	default "GPIO_0"
 


### PR DESCRIPTION
Consistently use

    config FOO
            bool/int/hex/string "Prompt text"

instead of

    config FOO
            bool/int/hex/string
            prompt "Prompt text"

(...and a bunch of other variations that e.g. swap the order of the
type and the `prompt`, or put other properties between them).

The shorthand is fully equivalent to using `prompt`. It saves lines and
avoids tricking people into thinking there is some semantic difference.

Most of the grunt work was done by a modified version of
https://unix.stackexchange.com/questions/26284/how-can-i-use-sed-to-replace-a-multi-line-string/26290#26290, but some of the rarer variations had to be
converted manually.