### PR TITLE
net: http: One extra byte was sent in last chunk

### DIFF
--- a/subsys/net/lib/http/http.c
+++ b/subsys/net/lib/http/http.c
@@ -233,7 +233,7 @@ int http_send_chunk(struct http_ctx *ctx, const char *buf, size_t len,
 		}
 	}
 
-	ret = http_prepare_and_send(ctx, HTTP_CRLF, sizeof(HTTP_CRLF), dst,
+	ret = http_prepare_and_send(ctx, HTTP_CRLF, sizeof(HTTP_CRLF) - 1, dst,
 				    user_send_data);
 	if (ret < 0) {
 		return ret;


### PR DESCRIPTION
There was one extra byte sent in last chunk which caused
this error to be printed by curl

  * Illegal or missing hexadecimal sequence in chunked-encoding
  * stopped the pause stream!
  * Closing connection 0
  curl: (56) Illegal or missing hexadecimal sequence in chunked-encoding

Signed-off-by: Jukka Rissanen <jukka.rissanen@linux.intel.com>