### PR TITLE
arch: arm: clean-up "default n" entries in Kconfig option definitions

### DIFF
--- a/arch/arm/core/Kconfig
+++ b/arch/arm/core/Kconfig
@@ -99,7 +99,6 @@ depends on ARM_SECURE_FIRMWARE
 config ARM_FIRMWARE_HAS_SECURE_ENTRY_FUNCS
 	bool "Secure Firmware has Secure Entry functions"
 	depends on ARM_SECURE_FIRMWARE
-	default n
 	help
 	  Option indicates that ARM Secure Firmware contains
 	  Secure Entry functions that may be called from

--- a/arch/arm/core/cortex_m/tz/Kconfig
+++ b/arch/arm/core/cortex_m/tz/Kconfig
@@ -8,6 +8,5 @@
 
 config ARM_SAU
 	bool "ARM Security Attribution Unit"
-	default n
 	help
 	  MCU implements the ARM Security Attribution Unit (SAU).


### PR DESCRIPTION
This commit removes the depreciated "default n" entries from
boolean K-config options in arch/arm.

Signed-off-by: Ioannis Glaropoulos <Ioannis.Glaropoulos@nordicsemi.no>

The "default n" entries were introduced when merging #6748 into master.