### PR TITLE
doc: fix wrong board name in Nordic doc

### DIFF
--- a/boards/arm/nrf52_pca10040/doc/nrf52_pca10040.rst
+++ b/boards/arm/nrf52_pca10040/doc/nrf52_pca10040.rst
@@ -353,7 +353,7 @@ Then build and flash the application in the usual way.
 
 .. zephyr-app-commands::
    :zephyr-app: samples/hello_world
-   :board: nrf52840_pca10056
+   :board: nrf52_pca10040
    :goals: build flash
 
 Debugging


### PR DESCRIPTION
The nRF52-PCA10040 command line example with cmake was using a wrong
Nordic board name.

Signed-off-by: Olivier Gay <ogay@logitech.com>