### PR TITLE
log: make name param explicit

### DIFF
--- a/doc/subsystems/logging/logger.rst
+++ b/doc/subsystems/logging/logger.rst
@@ -145,10 +145,9 @@ module can be specified as well.
 
 .. code-block:: c
 
-   #define LOG_MODULE_NAME foo
    #define LOG_LEVEL CONFIG_FOO_LOG_LEVEL /* From foo module Kconfig */
    #include <logging/log.h>
-   LOG_MODULE_REGISTER(); /* One per given LOG_MODULE_NAME */
+   LOG_MODULE_REGISTER(foo); /* One per given log_module_name */
 
 If the module consists of multiple files, then ``LOG_MODULE_REGISTER()`` should
 appear in exactly one of them. Each other file should use
@@ -156,10 +155,9 @@ appear in exactly one of them. Each other file should use
 
 .. code-block:: c
 
-   #define LOG_MODULE_NAME foo
    #define LOG_LEVEL CONFIG_FOO_LOG_LEVEL /* From foo module Kconfig */
    #include <logging/log.h>
-   LOG_MODULE_DECLARE(); /* In all files comprising the module but one */
+   LOG_MODULE_DECLARE(foo); /* In all files comprising the module but one */
 
 Logging in a module instance
 ============================

--- a/include/logging/log.h
+++ b/include/logging/log.h
@@ -261,7 +261,12 @@ int log_printk(const char *fmt, va_list ap);
 	__attribute__ ((section("." STRINGIFY(				\
 				     LOG_ITEM_DYNAMIC_DATA(_name))))	\
 				     )					\
-	__attribute__((used))
+	__attribute__((used));						\
+	static inline const struct log_source_dynamic_data  *		\
+				__log_current_dynamic_data_get(void)	\
+	{								\
+		return &LOG_ITEM_DYNAMIC_DATA(_name);			\
+	}
 
 #define _LOG_RUNTIME_MODULE_REGISTER(_name)				\
 	_LOG_EVAL(							\
@@ -277,7 +282,12 @@ int log_printk(const char *fmt, va_list ap);
 		.name = STRINGIFY(_name),				     \
 		.level = _level						     \
 	}								     \
-	_LOG_RUNTIME_MODULE_REGISTER(_name)
+	_LOG_RUNTIME_MODULE_REGISTER(_name);				     \
+	static inline const struct log_source_const_data *		     \
+				__log_current_const_data_get(void)	     \
+	{								     \
+		return &LOG_ITEM_CONST_DATA(_name);			     \
+	}
 
 /**
  * @brief Create module-specific state and register the module with Logger.
@@ -298,10 +308,10 @@ int log_printk(const char *fmt, va_list ap);
  *       In other cases, this macro has no effect.
  * @see LOG_MODULE_DECLARE
  */
-#define LOG_MODULE_REGISTER()						\
+#define LOG_MODULE_REGISTER(log_module_name)				\
 	_LOG_EVAL(							\
 		_LOG_LEVEL(),						\
-		(_LOG_MODULE_REGISTER(LOG_MODULE_NAME, _LOG_LEVEL())),	\
+		(_LOG_MODULE_REGISTER(log_module_name, _LOG_LEVEL())),	\
 		()/*Empty*/						\
 	)
 
@@ -336,10 +346,10 @@ int log_printk(const char *fmt, va_list ap);
  *       this macro has no effect.
  * @see LOG_MODULE_REGISTER
  */
-#define LOG_MODULE_DECLARE()						\
+#define LOG_MODULE_DECLARE(log_module_name)				\
 	_LOG_EVAL(							\
 		_LOG_LEVEL(),						\
-		(_LOG_MODULE_DECLARE(LOG_MODULE_NAME, _LOG_LEVEL())),	\
+		(_LOG_MODULE_DECLARE(log_module_name, _LOG_LEVEL())),	\
 		()							\
 		)							\
 

--- a/include/logging/log_core.h
+++ b/include/logging/log_core.h
@@ -98,7 +98,7 @@ extern "C" {
 #define LOG_CURRENT_MODULE_ID()						\
 	_LOG_EVAL(							\
 	  _LOG_LEVEL(),							\
-	  (log_const_source_id(&LOG_ITEM_CONST_DATA(LOG_MODULE_NAME))),	\
+	  (log_const_source_id(__log_current_const_data_get())),	\
 	  (0)								\
 	)
 
@@ -109,7 +109,7 @@ extern "C" {
 #define LOG_CURRENT_DYNAMIC_DATA_ADDR()			\
 	_LOG_EVAL(					\
 	  _LOG_LEVEL(),					\
-	  (&LOG_ITEM_DYNAMIC_DATA(LOG_MODULE_NAME)),	\
+	  (__log_current_dynamic_data_get()),		\
 	  ((struct log_source_dynamic_data *)0)		\
 	)
 

--- a/samples/subsys/logging/logger/src/ext_log_system_adapter.c
+++ b/samples/subsys/logging/logger/src/ext_log_system_adapter.c
@@ -9,7 +9,8 @@
 
 #define LOG_MODULE_NAME ext_log_system
 #include <logging/log.h>
-LOG_MODULE_REGISTER();
+
+LOG_MODULE_REGISTER(ext_log_system);
 
 /** @brief Translation of custom log levels to logging subsystem levels. */
 static const u8_t log_level_lut[] = {

--- a/samples/subsys/logging/logger/src/main.c
+++ b/samples/subsys/logging/logger/src/main.c
@@ -14,9 +14,9 @@
 #include "ext_log_system.h"
 #include "ext_log_system_adapter.h"
 
-#define LOG_MODULE_NAME main
 #include <logging/log.h>
-LOG_MODULE_REGISTER();
+
+LOG_MODULE_REGISTER(main);
 
 /* size of stack area used by each thread */
 #define STACKSIZE 1024

--- a/samples/subsys/logging/logger/src/sample_module.c
+++ b/samples/subsys/logging/logger/src/sample_module.c
@@ -7,7 +7,8 @@
 
 #define LOG_MODULE_NAME foo
 #include <logging/log.h>
-LOG_MODULE_REGISTER();
+
+LOG_MODULE_REGISTER(LOG_MODULE_NAME);
 
 const char *sample_module_name_get(void)
 {

--- a/subsys/power/device.c
+++ b/subsys/power/device.c
@@ -11,10 +11,9 @@
 #include <device.h>
 #include "pm_policy.h"
 
-#define LOG_MODULE_NAME power
 #define LOG_LEVEL CONFIG_PM_LOG_LEVEL /* From power module Kconfig */
 #include <logging/log.h>
-LOG_MODULE_DECLARE();
+LOG_MODULE_DECLARE(power);
 
 /*
  * FIXME: Remove the conditional inclusion of

--- a/subsys/power/policy.c
+++ b/subsys/power/policy.c
@@ -9,10 +9,9 @@
 #include <soc.h>
 #include "pm_policy.h"
 
-#define LOG_MODULE_NAME power
 #define LOG_LEVEL CONFIG_PM_LOG_LEVEL /* From power module Kconfig */
 #include <logging/log.h>
-LOG_MODULE_DECLARE();
+LOG_MODULE_DECLARE(power);
 
 #ifdef CONFIG_TICKLESS_KERNEL
 #define SECS_TO_TICKS		CONFIG_TICKLESS_KERNEL_TIME_UNIT_IN_MICRO_SECS

--- a/subsys/power/power.c
+++ b/subsys/power/power.c
@@ -11,10 +11,9 @@
 #include <soc.h>
 #include "pm_policy.h"
 
-#define LOG_MODULE_NAME power
 #define LOG_LEVEL CONFIG_PM_LOG_LEVEL /* From power module Kconfig */
 #include <logging/log.h>
-LOG_MODULE_REGISTER();
+LOG_MODULE_REGISTER(power);
 
 static int post_ops_done = 1;
 static enum power_states pm_state;

--- a/tests/subsys/logging/log_core/src/log_core_test.c
+++ b/tests/subsys/logging/log_core/src/log_core_test.c
@@ -20,7 +20,8 @@
 
 #define LOG_MODULE_NAME test
 #include "logging/log.h"
-LOG_MODULE_REGISTER();
+
+LOG_MODULE_REGISTER(LOG_MODULE_NAME);
 
 struct backend_cb {
 	size_t counter;


### PR DESCRIPTION
Rather than having some implied name for the logging name, explicitly
pass it in the macros LOG_MODULE_REGISTER & LOG_MODULE_DECLARE.

Signed-off-by: Kumar Gala <kumar.gala@linaro.org>