### PR TITLE
dts: Fix get_compat when parent compat is a list

### DIFF
--- a/scripts/dts/extract/globals.py
+++ b/scripts/dts/extract/globals.py
@@ -81,11 +81,11 @@ def get_compat(node_address):
         if 'props' in reduced[node_address].keys():
             compat = reduced[node_address]['props'].get('compatible')
 
-        if isinstance(compat, list):
-            compat = compat[0]
-
         if compat == None:
             compat = find_parent_prop(node_address, 'compatible')
+
+        if isinstance(compat, list):
+            compat = compat[0]
 
     except:
         pass


### PR DESCRIPTION
When a DTS node has no 'compatible' property and its parent node has a
list for its compatible property, return only the first element of the
parent's compatible list.

Submitting this for #9452