### PR TITLE
kernel: userspace: reserve stack space to store local data

### DIFF
--- a/include/kernel.h
+++ b/include/kernel.h
@@ -503,6 +503,12 @@ struct _mem_domain_info {
 
 #endif /* CONFIG_USERSPACE */
 
+#ifdef CONFIG_THREAD_USERSPACE_LOCAL_DATA
+struct _thread_userspace_local_data {
+	int errno_var;
+};
+#endif
+
 /**
  * @ingroup thread_apis
  * Thread Structure
@@ -538,14 +544,12 @@ struct k_thread {
 	void *custom_data;
 #endif
 
+#ifdef CONFIG_THREAD_USERSPACE_LOCAL_DATA
+	struct _thread_userspace_local_data *userspace_local_data;
+#endif
+
 #ifdef CONFIG_ERRNO
-#ifdef CONFIG_USERSPACE
-	/* Set to the lowest area in the thread stack since this needs to
-	 * be directly read/writable by user mode. Not ideal, but best we
-	 * can do until we have thread-local storage
-	 */
-	int *errno_location;
-#else
+#ifndef CONFIG_USERSPACE
 	/** per-thread errno variable */
 	int errno_var;
 #endif

--- a/kernel/Kconfig
+++ b/kernel/Kconfig
@@ -164,9 +164,19 @@ config  THREAD_CUSTOM_DATA
 	  This option allows each thread to store 32 bits of custom data,
 	  which can be accessed using the k_thread_custom_data_xxx() APIs.
 
+config THREAD_USERSPACE_LOCAL_DATA
+	bool
+	depends on USERSPACE
+
+config THREAD_USERSPACE_LOCAL_DATA_ARCH_DEFER_SETUP
+	bool
+	depends on THREAD_USERSPACE_LOCAL_DATA
+	default y if ARCH="arc"
+
 config ERRNO
 	bool "Enable errno support"
 	default y
+	select THREAD_USERSPACE_LOCAL_DATA if USERSPACE
 	help
 	  Enable per-thread errno in the kernel. Application and library code must
 	  include errno.h provided by the C library (libc) to use the errno

--- a/kernel/errno.c
+++ b/kernel/errno.c
@@ -29,7 +29,7 @@ int *_impl_z_errno(void)
 	/* Initialized to the lowest address in the stack so the thread can
 	 * directly read/write it
 	 */
-	return _current->errno_location;
+	return &_current->userspace_local_data->errno_var;
 }
 
 Z_SYSCALL_HANDLER0_SIMPLE(z_errno);


### PR DESCRIPTION
This enables reserving little space on the top of stack to store
data local to thread when CONFIG_USERSPACE. The first customer
of this is errno.

Note that ARC, due to how it lays out the user stack and
privilege stack, sets the pointer itself rather than
relying on the common way.

Fixes: #9067

Signed-off-by: Daniel Leung <daniel.leung@intel.com>