### PR TITLE
soc: efr32fg1p: correct clock initialization sequence

### DIFF
--- a/arch/arm/soc/silabs_exx32/efr32fg1p/soc.c
+++ b/arch/arm/soc/silabs_exx32/efr32fg1p/soc.c
@@ -38,17 +38,21 @@ static const CMU_LFXOInit_TypeDef lfxoInit = CMU_LFXOINIT_DEFAULT;
 static ALWAYS_INLINE void clkInit(void)
 {
 #ifdef CONFIG_CMU_HFCLK_HFXO
-	CMU_HFXOInit(&hfxoInit);
-	CMU_OscillatorEnable(cmuOsc_HFXO, true, true);
-	CMU_ClockSelectSet(cmuClock_HF, cmuSelect_HFXO);
-	CMU_OscillatorEnable(cmuOsc_HFRCO, false, false);
+	if (CMU_ClockSelectGet(cmuClock_HF) != cmuSelect_HFXO) {
+		CMU_HFXOInit(&hfxoInit);
+		CMU_OscillatorEnable(cmuOsc_HFXO, true, true);
+		CMU_ClockSelectSet(cmuClock_HF, cmuSelect_HFXO);
+	}
 	SystemHFXOClockSet(CONFIG_CMU_HFXO_FREQ);
-#elif (defined CONFIG_CMU_HFCLK_LFXO)
-	CMU_LFXOInit(&lfxoInit);
-	CMU_OscillatorEnable(cmuOsc_LFXO, true, true);
-	CMU_ClockSelectSet(cmuClock_HF, cmuSelect_LFXO);
 	CMU_OscillatorEnable(cmuOsc_HFRCO, false, false);
+#elif (defined CONFIG_CMU_HFCLK_LFXO)
+	if (CMU_ClockSelectGet(cmuClock_HF) != cmuSelect_LFXO) {
+		CMU_LFXOInit(&lfxoInit);
+		CMU_OscillatorEnable(cmuOsc_LFXO, true, true);
+		CMU_ClockSelectSet(cmuClock_HF, cmuSelect_LFXO);
+	}
 	SystemLFXOClockSet(CONFIG_CMU_LFXO_FREQ);
+	CMU_OscillatorEnable(cmuOsc_HFRCO, false, false);
 #elif (defined CONFIG_CMU_HFCLK_HFRCO)
 	/*
 	 * This is the default clock, the controller starts with, so nothing to


### PR DESCRIPTION
This patch changes clock initialization sequence to initialize external
cristal oscillators only if it was not done before. Initialization of
external cristal oscillators may be performed by the bootloader.

Tested on BRD4250B evaluation board.

Fixes #9471

Signed-off-by: Piotr Mienkowski <piotr.mienkowski@gmail.com>