### PR TITLE
samples/mesh: Fix dev_uuid initialization from identity address

### DIFF
--- a/samples/boards/nrf52/mesh/onoff-app/src/main.c
+++ b/samples/boards/nrf52/mesh/onoff-app/src/main.c
@@ -578,13 +578,6 @@ static void bt_ready(int err)
 
 	SYS_LOG_INF("Bluetooth initialized");
 
-	/* Use identity address as device UUID */
-	if (bt_le_oob_get_local(BT_ID_DEFAULT, &oob)) {
-		SYS_LOG_ERR("Identity Address unavailable");
-	} else {
-		memcpy(dev_uuid, oob.addr.a.val, 6);
-	}
-
 	err = bt_mesh_init(&prov, &comp);
 	if (err) {
 		SYS_LOG_ERR("Initializing mesh failed (err %d)", err);
@@ -593,6 +586,13 @@ static void bt_ready(int err)
 
 	if (IS_ENABLED(CONFIG_SETTINGS)) {
 		settings_load();
+	}
+
+	/* Use identity address as device UUID */
+	if (bt_le_oob_get_local(BT_ID_DEFAULT, &oob)) {
+		SYS_LOG_ERR("Identity Address unavailable");
+	} else {
+		memcpy(dev_uuid, oob.addr.a.val, 6);
 	}
 
 	bt_mesh_prov_enable(BT_MESH_PROV_GATT | BT_MESH_PROV_ADV);

--- a/samples/boards/nrf52/mesh/onoff_level_lighting_vnd_app/src/mesh/ble_mesh.c
+++ b/samples/boards/nrf52/mesh/onoff_level_lighting_vnd_app/src/mesh/ble_mesh.c
@@ -62,13 +62,6 @@ void bt_ready(int err)
 
 	printk("Bluetooth initialized\n");
 
-	/* Use identity address as device UUID */
-	if (bt_le_oob_get_local(BT_ID_DEFAULT, &oob)) {
-		printk("Identity Address unavailable\n");
-	} else {
-		memcpy(dev_uuid, oob.addr.a.val, 6);
-	}
-
 	err = bt_mesh_init(&prov, &comp);
 	if (err) {
 		printk("Initializing mesh failed (err %d)\n", err);
@@ -77,6 +70,13 @@ void bt_ready(int err)
 
 	if (IS_ENABLED(CONFIG_SETTINGS)) {
 		settings_load();
+	}
+
+	/* Use identity address as device UUID */
+	if (bt_le_oob_get_local(BT_ID_DEFAULT, &oob)) {
+		printk("Identity Address unavailable\n");
+	} else {
+		memcpy(dev_uuid, oob.addr.a.val, 6);
 	}
 
 	bt_mesh_prov_enable(BT_MESH_PROV_GATT | BT_MESH_PROV_ADV);

--- a/subsys/bluetooth/host/mesh/main.c
+++ b/subsys/bluetooth/host/mesh/main.c
@@ -13,6 +13,7 @@
 #include <net/buf.h>
 #include <bluetooth/bluetooth.h>
 #include <bluetooth/conn.h>
+#include <bluetooth/uuid.h>
 #include <bluetooth/mesh.h>
 
 #define BT_DBG_ENABLED IS_ENABLED(CONFIG_BT_MESH_DEBUG)
@@ -131,6 +132,14 @@ int bt_mesh_prov_enable(bt_mesh_prov_bearer_t bearers)
 {
 	if (bt_mesh_is_provisioned()) {
 		return -EALREADY;
+	}
+
+	if (IS_ENABLED(CONFIG_BT_DEBUG)) {
+		const struct bt_mesh_prov *prov = bt_mesh_prov_get();
+		struct bt_uuid_128 uuid = { .uuid.type = BT_UUID_TYPE_128 };
+
+		memcpy(uuid.val, prov->uuid, 16);
+		BT_INFO("Device UUID: %s", bt_uuid_str(&uuid.uuid));
 	}
 
 	if (IS_ENABLED(CONFIG_BT_MESH_PB_ADV) &&

--- a/subsys/bluetooth/host/mesh/prov.c
+++ b/subsys/bluetooth/host/mesh/prov.c
@@ -1593,12 +1593,6 @@ int bt_mesh_prov_init(const struct bt_mesh_prov *prov_info)
 
 #endif /* CONFIG_BT_MESH_PB_ADV */
 
-	if (IS_ENABLED(CONFIG_BT_DEBUG)) {
-		struct bt_uuid_128 uuid = { .uuid.type = BT_UUID_TYPE_128 };
-		memcpy(uuid.val, prov->uuid, 16);
-		BT_INFO("Device UUID: %s", bt_uuid_str(&uuid.uuid));
-	}
-
 	return 0;
 }
 


### PR DESCRIPTION
With the recent changes to identity address handling the local
identity address is only guaranteed to be available once
settings_load() has been called. Move the initialization of dev_uuid
to the appropriate place.

Signed-off-by: Johan Hedberg <johan.hedberg@intel.com>