### PR TITLE
doc: Make Sphinx output directory configurable

### DIFF
--- a/doc/CMakeLists.txt
+++ b/doc/CMakeLists.txt
@@ -23,6 +23,11 @@ else()
   separate_arguments(SPHINXOPTS)
 endif()
 
+if(NOT DEFINED SPHINX_OUTPUT_DIR)
+  set(SPHINX_OUTPUT_DIR ${CMAKE_CURRENT_BINARY_DIR}/html
+)
+endif()
+
 if(NOT DEFINED DOC_TAG)
   set(DOC_TAG development)
 endif()
@@ -110,7 +115,7 @@ add_custom_target(
   html
   COMMAND ${CMAKE_COMMAND} -E env
   ZEPHYR_BUILD=${CMAKE_CURRENT_BINARY_DIR}
-  ${SPHINXBUILD} -w ${SPHINX_LOG} -N -t ${DOC_TAG} -b html ${ALLSPHINXOPTS} ${RST_OUT}/doc ${CMAKE_CURRENT_BINARY_DIR}/html
+  ${SPHINXBUILD} -w ${SPHINX_LOG} -N -t ${DOC_TAG} -b html ${ALLSPHINXOPTS} ${RST_OUT}/doc ${SPHINX_OUTPUT_DIR}
   # Merge the Doxygen and Sphinx logs into a single file
   COMMAND ${CMAKE_COMMAND} -P ${ZEPHYR_BASE}/cmake/util/fmerge.cmake ${DOC_LOG} ${DOXY_LOG} ${SPHINX_LOG}
   COMMAND ${PYTHON_EXECUTABLE} ${KI_SCRIPT} --config-dir ${CONFIG_DIR} --errors ${DOC_WARN} --warnings ${DOC_WARN} ${DOC_LOG}


### PR DESCRIPTION
In order to be able to place the generated HTML content directly in a
folder of the user's choice, make the Sphinx HTML output folder
configurable.

Signed-off-by: Carles Cufi <carles.cufi@nordicsemi.no>