### PR TITLE
Refactor the usage of net_sprint_ip*()

### DIFF
--- a/subsys/net/ip/dhcpv4.c
+++ b/subsys/net/ip/dhcpv4.c
@@ -319,24 +319,13 @@ static u32_t dhcpv4_send_request(struct net_if *iface)
 
 	iface->config.dhcpv4.attempts++;
 
-#if defined(CONFIG_NET_DEBUG_DHCPV4)
-	do {
-		char out[NET_IPV4_ADDR_LEN] = "0.0.0.0";
-
-		if (ciaddr) {
-			snprintk(out, sizeof(out), "%s",
-				 net_sprint_ipv4_addr(ciaddr));
-		}
-
-		NET_DBG("send request dst=%s xid=0x%x ciaddr=%s"
-			"%s%s timeout=%us",
-			net_sprint_ipv4_addr(server_addr),
-			iface->config.dhcpv4.xid, out,
-			with_server_id ? " +server-id" : "",
-			with_requested_ip ? " +requested-ip" : "",
-			timeout);
-	} while (0);
-#endif /* CONFIG_NET_DEBUG_DHCPV4 */
+	NET_DBG("send request dst=%s xid=0x%x ciaddr=%s%s%s timeout=%us",
+		net_sprint_ipv4_addr(server_addr),
+		iface->config.dhcpv4.xid,
+		net_sprint_ipv4_addr(ciaddr),
+		with_server_id ? " +server-id" : "",
+		with_requested_ip ? " +requested-ip" : "",
+		timeout);
 
 	iface->config.dhcpv4.timer_start = k_uptime_get();
 	iface->config.dhcpv4.request_time = timeout;

--- a/subsys/net/ip/icmpv4.c
+++ b/subsys/net/ip/icmpv4.c
@@ -106,14 +106,9 @@ static inline enum net_verdict icmpv4_handle_echo_request(struct net_pkt *pkt)
 	struct in_addr addr;
 	int ret;
 
-#if defined(CONFIG_NET_DEBUG_ICMPV4)
-	char out[sizeof("xxx.xxx.xxx.xxx")];
-
-	snprintk(out, sizeof(out), "%s",
-		 net_sprint_ipv4_addr(&NET_IPV4_HDR(pkt)->dst));
 	NET_DBG("Received Echo Request from %s to %s",
-		net_sprint_ipv4_addr(&NET_IPV4_HDR(pkt)->src), out);
-#endif /* CONFIG_NET_DEBUG_ICMPV4 */
+		net_sprint_ipv4_addr(&NET_IPV4_HDR(pkt)->src),
+		net_sprint_ipv4_addr(&NET_IPV4_HDR(pkt)->dst));
 
 	net_ipaddr_copy(&addr, &NET_IPV4_HDR(pkt)->src);
 	net_ipaddr_copy(&NET_IPV4_HDR(pkt)->src,
@@ -133,12 +128,9 @@ static inline enum net_verdict icmpv4_handle_echo_request(struct net_pkt *pkt)
 		return NET_DROP;
 	}
 
-#if defined(CONFIG_NET_DEBUG_ICMPV4)
-	snprintk(out, sizeof(out), "%s",
-		 net_sprint_ipv4_addr(&NET_IPV4_HDR(pkt)->dst));
 	NET_DBG("Sending Echo Reply from %s to %s",
-		net_sprint_ipv4_addr(&NET_IPV4_HDR(pkt)->src), out);
-#endif /* CONFIG_NET_DEBUG_ICMPV4 */
+		net_sprint_ipv4_addr(&NET_IPV4_HDR(pkt)->src),
+		net_sprint_ipv4_addr(&NET_IPV4_HDR(pkt)->dst));
 
 	if (net_send_data(pkt) < 0) {
 		net_stats_update_icmp_drop(net_pkt_iface(pkt));
@@ -212,18 +204,10 @@ int net_icmpv4_send_echo_request(struct net_if *iface,
 
 	net_ipv4_finalize(pkt, IPPROTO_ICMP);
 
-#if defined(CONFIG_NET_DEBUG_ICMPV4)
-	do {
-		char out[NET_IPV4_ADDR_LEN];
-
-		snprintk(out, sizeof(out), "%s",
-			 net_sprint_ipv4_addr(&NET_IPV4_HDR(pkt)->dst));
-
-		NET_DBG("Sending ICMPv4 Echo Request type %d"
-			" from %s to %s", NET_ICMPV4_ECHO_REQUEST,
-			net_sprint_ipv4_addr(&NET_IPV4_HDR(pkt)->src), out);
-	} while (0);
-#endif /* CONFIG_NET_DEBUG_ICMPV4 */
+	NET_DBG("Sending ICMPv4 Echo Request type %d from %s to %s",
+		NET_ICMPV4_ECHO_REQUEST,
+		net_sprint_ipv4_addr(&NET_IPV4_HDR(pkt)->src),
+		net_sprint_ipv4_addr(&NET_IPV4_HDR(pkt)->dst));
 
 	if (net_send_data(pkt) >= 0) {
 		net_stats_update_icmp_sent(iface);
@@ -319,17 +303,10 @@ int net_icmpv4_send_error(struct net_pkt *orig, u8_t type, u8_t code)
 	net_pkt_ll_dst(pkt)->addr = net_pkt_ll_src(orig)->addr;
 	net_pkt_ll_dst(pkt)->len = net_pkt_ll_src(orig)->len;
 
-#if defined(CONFIG_NET_DEBUG_ICMPV4)
-	do {
-		char out[sizeof("xxx.xxx.xxx.xxx")];
-
-		snprintk(out, sizeof(out), "%s",
-			 net_sprint_ipv4_addr(&NET_IPV4_HDR(pkt)->dst));
-		NET_DBG("Sending ICMPv4 Error Message type %d code %d "
-			"from %s to %s", type, code,
-			net_sprint_ipv4_addr(&NET_IPV4_HDR(pkt)->src), out);
-	} while (0);
-#endif /* CONFIG_NET_DEBUG_ICMPV4 */
+	NET_DBG("Sending ICMPv4 Error Message type %d code %d from %s to %s",
+		type, code,
+		net_sprint_ipv4_addr(&NET_IPV4_HDR(pkt)->src),
+		net_sprint_ipv4_addr(&NET_IPV4_HDR(pkt)->dst));
 
 	if (net_send_data(pkt) >= 0) {
 		net_stats_update_icmp_sent(iface);

--- a/subsys/net/ip/ipv4.c
+++ b/subsys/net/ip/ipv4.c
@@ -124,16 +124,9 @@ enum net_verdict net_ipv4_process_pkt(struct net_pkt *pkt)
 		goto drop;
 	}
 
-#if defined(CONFIG_NET_DEBUG_IPV4)
-	do {
-		char out[sizeof("xxx.xxx.xxx.xxx")];
-
-		snprintk(out, sizeof(out), "%s",
-			 net_sprint_ipv4_addr(&hdr->dst));
-		NET_DBG("IPv4 packet received from %s to %s",
-			net_sprint_ipv4_addr(&hdr->src), out);
-	} while (0);
-#endif /* CONFIG_NET_DEBUG_IPV4 */
+	NET_DBG("IPv4 packet received from %s to %s",
+		net_sprint_ipv4_addr(&hdr->src),
+		net_sprint_ipv4_addr(&hdr->dst));
 
 	net_pkt_set_ip_hdr_len(pkt, sizeof(struct net_ipv4_hdr));
 	net_pkt_set_ipv4_ttl(pkt, NET_IPV4_HDR(pkt)->ttl);

--- a/subsys/net/ip/net_private.h
+++ b/subsys/net/ip/net_private.h
@@ -54,6 +54,10 @@ extern enum net_verdict net_promisc_mode_input(struct net_pkt *pkt);
 
 char *net_sprint_addr(sa_family_t af, const void *addr);
 
+#define net_sprint_ipv4_addr(_addr) net_sprint_addr(AF_INET, _addr)
+
+#define net_sprint_ipv6_addr(_addr) net_sprint_addr(AF_INET6, _addr)
+
 #if defined(CONFIG_NET_GPTP)
 /**
  * @brief Initialize Precision Time Protocol Layer.
@@ -176,28 +180,6 @@ static inline char *net_sprint_ll_addr(const u8_t *ll, u8_t ll_len)
 	static char buf[sizeof("xx:xx:xx:xx:xx:xx:xx:xx")];
 
 	return net_sprint_ll_addr_buf(ll, ll_len, (char *)buf, sizeof(buf));
-}
-
-static inline char *net_sprint_ipv6_addr(const struct in6_addr *addr)
-{
-#if defined(CONFIG_NET_IPV6)
-	static char buf[NET_IPV6_ADDR_LEN];
-
-	return net_addr_ntop(AF_INET6, addr, (char *)buf, sizeof(buf));
-#else
-	return NULL;
-#endif
-}
-
-static inline char *net_sprint_ipv4_addr(const struct in_addr *addr)
-{
-#if defined(CONFIG_NET_IPV4)
-	static char buf[NET_IPV4_ADDR_LEN];
-
-	return net_addr_ntop(AF_INET, addr, (char *)buf, sizeof(buf));
-#else
-	return NULL;
-#endif
 }
 
 static inline void _hexdump(const u8_t *packet, size_t length, u8_t reserve)
@@ -333,27 +315,6 @@ static inline char *net_sprint_ll_addr(const u8_t *ll, u8_t ll_len)
 {
 	ARG_UNUSED(ll);
 	ARG_UNUSED(ll_len);
-
-	return NULL;
-}
-
-static inline char *net_sprint_ipv6_addr(const struct in6_addr *addr)
-{
-	ARG_UNUSED(addr);
-
-	return NULL;
-}
-
-static inline char *net_sprint_ipv4_addr(const struct in_addr *addr)
-{
-	ARG_UNUSED(addr);
-
-	return NULL;
-}
-
-static inline char *net_sprint_ip_addr(const struct net_addr *addr)
-{
-	ARG_UNUSED(addr);
 
 	return NULL;
 }

--- a/subsys/net/ip/net_private.h
+++ b/subsys/net/ip/net_private.h
@@ -52,6 +52,8 @@ extern void net_tc_submit_to_tx_queue(u8_t tc, struct net_pkt *pkt);
 extern void net_tc_submit_to_rx_queue(u8_t tc, struct net_pkt *pkt);
 extern enum net_verdict net_promisc_mode_input(struct net_pkt *pkt);
 
+char *net_sprint_addr(sa_family_t af, const void *addr);
+
 #if defined(CONFIG_NET_GPTP)
 /**
  * @brief Initialize Precision Time Protocol Layer.

--- a/subsys/net/ip/net_private.h
+++ b/subsys/net/ip/net_private.h
@@ -198,28 +198,6 @@ static inline char *net_sprint_ipv4_addr(const struct in_addr *addr)
 #endif
 }
 
-static inline char *net_sprint_ip_addr(const struct net_addr *addr)
-{
-	switch (addr->family) {
-	case AF_INET6:
-#if defined(CONFIG_NET_IPV6)
-		return net_sprint_ipv6_addr(&addr->in6_addr);
-#else
-		break;
-#endif
-	case AF_INET:
-#if defined(CONFIG_NET_IPV4)
-		return net_sprint_ipv4_addr(&addr->in_addr);
-#else
-		break;
-#endif
-	default:
-		break;
-	}
-
-	return NULL;
-}
-
 static inline void _hexdump(const u8_t *packet, size_t length, u8_t reserve)
 {
 	char output[sizeof("xxxxyyyy xxxxyyyy")];

--- a/subsys/net/ip/net_shell.c
+++ b/subsys/net/ip/net_shell.c
@@ -2656,13 +2656,9 @@ static inline void _remove_ipv6_ping_handler(void)
 
 static enum net_verdict _handle_ipv6_echo_reply(struct net_pkt *pkt)
 {
-	char addr[NET_IPV6_ADDR_LEN];
-
-	snprintk(addr, sizeof(addr), "%s",
-		 net_sprint_ipv6_addr(&NET_IPV6_HDR(pkt)->dst));
-
 	printk("Received echo reply from %s to %s\n",
-	       net_sprint_ipv6_addr(&NET_IPV6_HDR(pkt)->src), addr);
+		net_sprint_ipv6_addr(&NET_IPV6_HDR(pkt)->src),
+		net_sprint_ipv6_addr(&NET_IPV6_HDR(pkt)->dst));
 
 	k_sem_give(&ping_timeout);
 	_remove_ipv6_ping_handler();
@@ -2734,13 +2730,9 @@ static inline void _remove_ipv4_ping_handler(void)
 
 static enum net_verdict _handle_ipv4_echo_reply(struct net_pkt *pkt)
 {
-	char addr[NET_IPV4_ADDR_LEN];
-
-	snprintk(addr, sizeof(addr), "%s",
-		 net_sprint_ipv4_addr(&NET_IPV4_HDR(pkt)->dst));
-
 	printk("Received echo reply from %s to %s\n",
-	       net_sprint_ipv4_addr(&NET_IPV4_HDR(pkt)->src), addr);
+		net_sprint_ipv4_addr(&NET_IPV4_HDR(pkt)->src),
+		net_sprint_ipv4_addr(&NET_IPV4_HDR(pkt)->dst));
 
 	k_sem_give(&ping_timeout);
 	_remove_ipv4_ping_handler();
@@ -3000,27 +2992,24 @@ int net_shell_cmd_rpl(int argc, char *argv[])
 
 	printk("Instance DAGs   :\n");
 	for (i = 0, count = 0; i < CONFIG_NET_RPL_MAX_DAG_PER_INSTANCE; i++) {
-		char prefix[NET_IPV6_ADDR_LEN];
 
 		if (!instance->dags[i].is_used) {
 			continue;
 		}
 
-		snprintk(prefix, sizeof(prefix), "%s",
-			 net_sprint_ipv6_addr(
-				 &instance->dags[i].prefix_info.prefix));
-
 		printk("[%2d]%s %s prefix %s/%d rank %d/%d ver %d flags %c%c "
-		       "parent %p\n",
-		       ++count,
-		       &instance->dags[i] == instance->current_dag ? "*" : " ",
-		       net_sprint_ipv6_addr(&instance->dags[i].dag_id),
-		       prefix, instance->dags[i].prefix_info.length,
-		       instance->dags[i].rank, instance->dags[i].min_rank,
-		       instance->dags[i].version,
-		       instance->dags[i].is_grounded ? 'G' : 'g',
-		       instance->dags[i].is_joined ? 'J' : 'j',
-		       instance->dags[i].preferred_parent);
+			"parent %p\n",
+			++count,
+			&instance->dags[i] == instance->current_dag ? "*" : " ",
+			net_sprint_ipv6_addr(&instance->dags[i].dag_id),
+			net_sprint_ipv6_addr(
+					&instance->dags[i].prefix_info.prefix),
+			instance->dags[i].prefix_info.length,
+			instance->dags[i].rank, instance->dags[i].min_rank,
+			instance->dags[i].version,
+			instance->dags[i].is_grounded ? 'G' : 'g',
+			instance->dags[i].is_joined ? 'J' : 'j',
+			instance->dags[i].preferred_parent);
 	}
 	printk("\n");
 

--- a/subsys/net/ip/route.c
+++ b/subsys/net/ip/route.c
@@ -239,14 +239,12 @@ static int nbr_nexthop_put(struct net_nbr *nbr)
 #if defined(CONFIG_NET_DEBUG_ROUTE)
 #define net_route_info(str, route, dst)					\
 	do {								\
-		char out[NET_IPV6_ADDR_LEN];				\
 		struct in6_addr *naddr = net_route_get_nexthop(route);	\
 									\
 		NET_ASSERT_INFO(naddr, "Unknown nexthop address");	\
 									\
-		snprintk(out, sizeof(out), "%s",			\
-			 net_sprint_ipv6_addr(dst));			\
-		NET_DBG("%s route to %s via %s (iface %p)", str, out,	\
+		NET_DBG("%s route to %s via %s (iface %p)", str,	\
+			net_sprint_ipv6_addr(dst),			\
 			net_sprint_ipv6_addr(naddr), route->iface);	\
 	} while (0)
 #else
@@ -363,19 +361,16 @@ struct net_route_entry *net_route_add(struct net_if *iface,
 				     node);
 #if defined(CONFIG_NET_DEBUG_ROUTE)
 		do {
-			char out[NET_IPV6_ADDR_LEN];
 			struct in6_addr *tmp;
 			struct net_linkaddr_storage *llstorage;
-
-			snprintk(out, sizeof(out), "%s",
-				 net_sprint_ipv6_addr(&route->addr));
 
 			tmp = net_route_get_nexthop(route);
 			nbr = net_ipv6_nbr_lookup(iface, tmp);
 			llstorage = net_nbr_get_lladdr(nbr->idx);
 
 			NET_DBG("Removing the oldest route %s via %s [%s]",
-				out, net_sprint_ipv6_addr(tmp),
+				net_sprint_ipv6_addr(&route->addr),
+				net_sprint_ipv6_addr(tmp),
 				net_sprint_ll_addr(llstorage->addr,
 						   llstorage->len));
 		} while (0);

--- a/subsys/net/ip/rpl-of0.c
+++ b/subsys/net/ip/rpl-of0.c
@@ -116,27 +116,14 @@ net_rpl_of0_best_parent(struct net_if *iface,
 		return dag->preferred_parent;
 	}
 
-#if defined(CONFIG_NET_DEBUG_RPL)
-	do {
-		char out[NET_IPV6_ADDR_LEN];
-
-		snprintk(out, sizeof(out), "%s",
-			 net_sprint_ipv6_addr(
-				 net_rpl_get_parent_addr(iface,
-							 parent2)));
-
-		NET_DBG("Comparing parent %s (confidence %d, rank %d) with "
-			"parent %s (confidence %d, rank %d)",
-			net_sprint_ipv6_addr(
-				net_rpl_get_parent_addr(iface,
-							parent1)),
-			net_ipv6_nbr_data(nbr1)->link_metric,
-			parent1->rank,
-			out,
-			net_ipv6_nbr_data(nbr2)->link_metric,
-			parent2->rank);
-	} while (0);
-#endif /* CONFIG_NET_DEBUG_RPL */
+	NET_DBG("Comparing parent %s (confidence %d, rank %d) with "
+		"parent %s (confidence %d, rank %d)",
+		net_sprint_ipv6_addr(net_rpl_get_parent_addr(iface, parent1)),
+		net_ipv6_nbr_data(nbr1)->link_metric,
+		parent1->rank,
+		net_sprint_ipv6_addr(net_rpl_get_parent_addr(iface, parent2))),
+		net_ipv6_nbr_data(nbr2)->link_metric,
+		parent2->rank);
 
 	rank1 = NET_RPL_DAG_RANK(parent1->rank,
 				 parent1->dag->instance) *

--- a/subsys/net/ip/utils.c
+++ b/subsys/net/ip/utils.c
@@ -24,6 +24,16 @@
 #include <net/net_pkt.h>
 #include <net/net_core.h>
 
+char *net_sprint_addr(sa_family_t af, const void *addr)
+{
+#define NBUFS 3
+	static char buf[NBUFS][NET_IPV6_ADDR_LEN];
+	static int i;
+	char *s = buf[++i % NBUFS];
+
+	return net_addr_ntop(af, addr, s, NET_IPV6_ADDR_LEN);
+}
+
 const char *net_proto2str(enum net_ip_protocol proto)
 {
 	switch (proto) {

--- a/subsys/net/l2/ethernet/arp.c
+++ b/subsys/net/l2/ethernet/arp.c
@@ -575,19 +575,11 @@ enum net_verdict net_arp_input(struct net_pkt *pkt)
 			return NET_DROP;
 		}
 
-#if defined(CONFIG_NET_DEBUG_ARP)
-		do {
-			char out[sizeof("xxx.xxx.xxx.xxx")];
-			snprintk(out, sizeof(out), "%s",
-				 net_sprint_ipv4_addr(&arp_hdr->src_ipaddr));
-			NET_DBG("ARP request from %s [%s] for %s",
-				out,
-				net_sprint_ll_addr(
-					(u8_t *)&arp_hdr->src_hwaddr,
-					arp_hdr->hwlen),
-				net_sprint_ipv4_addr(&arp_hdr->dst_ipaddr));
-		} while (0);
-#endif /* CONFIG_NET_DEBUG_ARP */
+		NET_DBG("ARP request from %s [%s] for %s",
+			net_sprint_ipv4_addr(&arp_hdr->src_ipaddr),
+			net_sprint_ll_addr((u8_t *)&arp_hdr->src_hwaddr,
+						arp_hdr->hwlen),
+			net_sprint_ipv4_addr(&arp_hdr->dst_ipaddr));
 
 		/* Send reply */
 		reply = arp_prepare_reply(net_pkt_iface(pkt), pkt);

--- a/tests/net/arp/src/main.c
+++ b/tests/net/arp/src/main.c
@@ -466,23 +466,17 @@ void test_arp(void)
 
 	if (!net_ipv4_addr_cmp(&arp_hdr->dst_ipaddr,
 			       &NET_IPV4_HDR(pkt)->dst)) {
-		char out[sizeof("xxx.xxx.xxx.xxx")];
-
-		snprintk(out, sizeof(out), "%s",
-			 net_sprint_ipv4_addr(&arp_hdr->dst_ipaddr));
-		printk("ARP IP dest invalid %s, should be %s", out,
-		       net_sprint_ipv4_addr(&NET_IPV4_HDR(pkt)->dst));
+		printk("ARP IP dest invalid %s, should be %s",
+			net_sprint_ipv4_addr(&arp_hdr->dst_ipaddr),
+			net_sprint_ipv4_addr(&NET_IPV4_HDR(pkt)->dst));
 		zassert_true(0, "exiting");
 	}
 
 	if (!net_ipv4_addr_cmp(&arp_hdr->src_ipaddr,
 			       &NET_IPV4_HDR(pkt)->src)) {
-		char out[sizeof("xxx.xxx.xxx.xxx")];
-
-		snprintk(out, sizeof(out), "%s",
-			 net_sprint_ipv4_addr(&arp_hdr->src_ipaddr));
-		printk("ARP IP src invalid %s, should be %s", out,
-		       net_sprint_ipv4_addr(&NET_IPV4_HDR(pkt)->src));
+		printk("ARP IP src invalid %s, should be %s",
+			net_sprint_ipv4_addr(&arp_hdr->src_ipaddr),
+			net_sprint_ipv4_addr(&NET_IPV4_HDR(pkt)->src));
 		zassert_true(0, "exiting");
 	}
 
@@ -510,12 +504,9 @@ void test_arp(void)
 
 	if (!net_ipv4_addr_cmp(&arp_hdr->dst_ipaddr,
 			       &iface->config.ip.ipv4->gw)) {
-		char out[sizeof("xxx.xxx.xxx.xxx")];
-
-		snprintk(out, sizeof(out), "%s",
-			 net_sprint_ipv4_addr(&arp_hdr->dst_ipaddr));
-		printk("ARP IP dst invalid %s, should be %s\n", out,
-			 net_sprint_ipv4_addr(&iface->config.ip.ipv4->gw));
+		printk("ARP IP dst invalid %s, should be %s\n",
+			net_sprint_ipv4_addr(&arp_hdr->dst_ipaddr),
+			net_sprint_ipv4_addr(&iface->config.ip.ipv4->gw));
 		zassert_true(0, "exiting");
 	}
 


### PR DESCRIPTION
Refactor the usage of net_sprint_ip*() where multiple invocations are needed per single log call.