### PR TITLE
lib: cmsis_rtos_v1: fix couple of nonconformities

### DIFF
--- a/lib/cmsis_rtos_v1/cmsis_mailq.c
+++ b/lib/cmsis_rtos_v1/cmsis_mailq.c
@@ -124,7 +124,7 @@ osEvent osMailGet(osMailQId queue_id, uint32_t millisec)
 {
 	osMailQDef_t *queue_def = (osMailQDef_t *)queue_id;
 	struct k_mbox_msg mmsg;
-	osEvent evt;
+	osEvent evt = {0};
 	int retval;
 
 	if (queue_def == NULL) {
@@ -146,6 +146,7 @@ osEvent osMailGet(osMailQId queue_id, uint32_t millisec)
 
 	if (retval == 0) {
 		evt.status = osEventMail;
+		evt.value.p = mmsg.tx_data;
 	} else if (retval == -EAGAIN) {
 		evt.status = osEventTimeout;
 	} else if (retval == -ENOMSG) {
@@ -154,7 +155,6 @@ osEvent osMailGet(osMailQId queue_id, uint32_t millisec)
 		evt.status = osErrorValue;
 	}
 
-	evt.value.p = mmsg.tx_data;
 	evt.def.mail_id = queue_id;
 
 	return evt;

--- a/lib/cmsis_rtos_v1/cmsis_msgq.c
+++ b/lib/cmsis_rtos_v1/cmsis_msgq.c
@@ -48,6 +48,8 @@ osStatus osMessagePut(osMessageQId queue_id, uint32_t info, uint32_t millisec)
 
 	if (retval == 0) {
 		return osOK;
+	} else if (retval == -EAGAIN) {
+		return osErrorTimeoutResource;
 	} else {
 		return osErrorResource;
 	}
@@ -60,7 +62,7 @@ osEvent osMessageGet(osMessageQId queue_id, uint32_t millisec)
 {
 	osMessageQDef_t *queue_def = (osMessageQDef_t *)queue_id;
 	u32_t info;
-	osEvent evt;
+	osEvent evt = {0};
 	int retval;
 
 	if (queue_def == NULL) {
@@ -78,6 +80,7 @@ osEvent osMessageGet(osMessageQId queue_id, uint32_t millisec)
 
 	if (retval == 0) {
 		evt.status = osEventMessage;
+		evt.value.v = info;
 	} else if (retval == -EAGAIN) {
 		evt.status = osEventTimeout;
 	} else if (retval == -ENOMSG) {
@@ -86,7 +89,6 @@ osEvent osMessageGet(osMessageQId queue_id, uint32_t millisec)
 		evt.status = osErrorValue;
 	}
 
-	evt.value.v = info;
 	evt.def.message_id = queue_id;
 
 	return evt;


### PR DESCRIPTION
Add osErrorTimeoutResource as return value when message
cannot be put in queue during waiting period. Also set
message value only when message is received.

Signed-off-by: Niranjhana N <niranjhana.n@intel.com>