### PR TITLE
tests: cmsis_rtos_v1: Wait for longer duration in k_busy_wait

### DIFF
--- a/tests/cmsis_rtos_v1/src/kernel_apis.c
+++ b/tests/cmsis_rtos_v1/src/kernel_apis.c
@@ -8,7 +8,7 @@
 #include <kernel.h>
 #include <cmsis_os.h>
 
-#define WAIT_TIME_US 1000
+#define WAIT_TIME_US 1000000
 
 /**
  * @brief Test kernel start


### PR DESCRIPTION
For boards like nrf52 with low system clock (32768), k_busy_wait
for values less than 1 second (1000000 us) ends up waiting less
than the desired wait time because of decimal truncation while
converting wait time to hw clock cycles. Hence increased the wait
to 1 second.

Fixes: #9487 
Signed-off-by: Spoorthi K <spoorthi.k@intel.com>