### PR TITLE
net: if: Lower ram usage for IP address lifetime handling

### DIFF
--- a/include/net/net_if.h
+++ b/include/net/net_if.h
@@ -49,8 +49,16 @@ struct net_if_addr {
 	/** IP address */
 	struct net_addr address;
 
-	/** Timer that triggers renewal */
-	struct k_delayed_work lifetime;
+#if defined(CONFIG_NET_IPV6)
+	/** Used for track timers */
+	sys_snode_t node;
+
+	/** Address lifetime timer start time */
+	s64_t lifetime_timer_start;
+
+	/** lifetime timer timeout */
+	u32_t lifetime_timer_timeout;
+#endif
 
 #if defined(CONFIG_NET_IPV6_DAD)
 	/** Duplicate address detection (DAD) timer */

--- a/samples/net/rpl_border_router/src/http.c
+++ b/samples/net/rpl_border_router/src/http.c
@@ -12,6 +12,7 @@
 
 #include <zephyr.h>
 #include <stdio.h>
+#include <stdlib.h>
 
 /* For Basic auth, we need base64 decoder which can be found
  * in mbedtls library.
@@ -497,6 +498,19 @@ out:
 	return ret;
 }
 
+static inline u32_t remaining_lifetime(struct net_if_addr *ifaddr)
+{
+	s32_t remaining;
+
+	if (ifaddr->lifetime_timer_timeout == 0) {
+		return 0;
+	}
+
+	remaining = k_uptime_get() - ifaddr->lifetime_timer_start;
+
+	return abs(remaining) / K_MSEC(1000);
+}
+
 static void append_unicast_addr(struct net_if *iface, struct user_data *data)
 {
 	char addr[NET_IPV6_ADDR_LEN], lifetime[10];
@@ -525,9 +539,8 @@ static void append_unicast_addr(struct net_if *iface, struct user_data *data)
 		if (unicast->is_infinite) {
 			snprintk(lifetime, sizeof(lifetime), "%s", "infinite");
 		} else {
-			snprintk(lifetime, sizeof(lifetime), "%d",
-				 k_delayed_work_remaining_get(
-					 &unicast->lifetime));
+			snprintk(lifetime, sizeof(lifetime), "%u",
+				 remaining_lifetime(unicast));
 		}
 
 		ret = append_and_send_data(data, false,

--- a/subsys/net/ip/ipv6.c
+++ b/subsys/net/ip/ipv6.c
@@ -19,6 +19,7 @@
 #endif
 
 #include <errno.h>
+#include <stdlib.h>
 #include <net/net_core.h>
 #include <net/net_pkt.h>
 #include <net/net_stats.h>
@@ -2432,9 +2433,17 @@ static inline void handle_prefix_onlink(struct net_pkt *pkt,
 
 #define TWO_HOURS (2 * 60 * 60)
 
-static inline u32_t remaining(struct k_delayed_work *work)
+static inline u32_t remaining_lifetime(struct net_if_addr *ifaddr)
 {
-	return k_delayed_work_remaining_get(work) / K_SECONDS(1);
+	s32_t remaining;
+
+	if (ifaddr->lifetime_timer_timeout == 0) {
+		return 0;
+	}
+
+	remaining = k_uptime_get() - ifaddr->lifetime_timer_start;
+
+	return abs(remaining) / K_MSEC(1000);
 }
 
 static inline void handle_prefix_autonomous(struct net_pkt *pkt,
@@ -2462,7 +2471,7 @@ static inline void handle_prefix_autonomous(struct net_pkt *pkt,
 		/* RFC 4862 ch 5.5.3 */
 		if ((prefix_info->valid_lifetime > TWO_HOURS) ||
 		    (prefix_info->valid_lifetime >
-		     remaining(&ifaddr->lifetime))) {
+		     remaining_lifetime(ifaddr))) {
 			NET_DBG("Timer updating for address %s "
 				"long lifetime %u secs",
 				net_sprint_ipv6_addr(&addr),


### PR DESCRIPTION
Instead of having one delayed_work struct / IP address, use
only one delayed_work struct for lifetime timer. This saves
over 20 bytes / allocated address struct.

Signed-off-by: Jukka Rissanen <jukka.rissanen@linux.intel.com>