### PR TITLE
tests: net: ptp: Check max number of interfaces

### DIFF
--- a/tests/net/ptp/clock/src/main.c
+++ b/tests/net/ptp/clock/src/main.c
@@ -276,6 +276,11 @@ static void iface_cb(struct net_if *iface, void *user_data)
 		static int ptp_iface_idx;
 		struct device *clk;
 
+		if (ud->eth_if_count >= ARRAY_SIZE(eth_interfaces)) {
+			DBG("Invalid interface %p\n", iface);
+			return;
+		}
+
 		clk = net_eth_get_ptp_clock(iface);
 		if (!clk) {
 			non_ptp_interface = ud->eth_if_count;


### PR DESCRIPTION
Add checks so that we do not overflow the network interface
array. Similar issues was fixed in commit b4dae007410d for
TX timestamp tests.

Fixes #9465

Signed-off-by: Jukka Rissanen <jukka.rissanen@linux.intel.com>