### PR TITLE
tests: net: ethernet_mgmt: Don't recalculate deltaBW with no link

### DIFF
--- a/tests/net/ethernet_mgmt/src/main.c
+++ b/tests/net/ethernet_mgmt/src/main.c
@@ -89,8 +89,14 @@ static void eth_fake_recalc_qav_delta_bandwidth(struct eth_fake_context *ctx)
 	bw = eth_fake_get_total_bandwidth(ctx);
 
 	for (i = 0; i < ARRAY_SIZE(ctx->priority_queues); ++i) {
-		ctx->priority_queues[i].delta_bandwidth =
-			(ctx->priority_queues[i].idle_slope * 100) / bw;
+		if (bw == 0) {
+			ctx->priority_queues[i].delta_bandwidth = 0;
+		} else {
+			ctx->priority_queues[i].delta_bandwidth =
+				(ctx->priority_queues[i].idle_slope * 100);
+
+			ctx->priority_queues[i].delta_bandwidth /= bw;
+		}
 	}
 }
 


### PR DESCRIPTION
Fixes #9462

Coverity ID: 187670

Attempts to recalculate deltaBandwidth with no link lead to division by
zero.

Signed-off-by: Tomasz Gorochowik <tgorochowik@antmicro.com>