### PR TITLE
tests: net: iface: Initialize port number

### DIFF
--- a/tests/net/iface/src/main.c
+++ b/tests/net/iface/src/main.c
@@ -549,6 +549,7 @@ static void select_src_iface(void)
 
 	net_ipaddr_copy(&ipv4.sin_addr, &dst_addr_2);
 	ipv4.sin_family = AF_INET;
+	ipv4.sin_port = 0;
 
 	iface = net_if_select_src_iface((struct sockaddr *)&ipv4);
 	zassert_equal_ptr(iface, iface1, "Invalid interface %p vs %p selected",
@@ -556,6 +557,7 @@ static void select_src_iface(void)
 
 	net_ipaddr_copy(&ipv6.sin6_addr, &dst_addr1);
 	ipv6.sin6_family = AF_INET6;
+	ipv6.sin6_port = 0;
 
 	iface = net_if_select_src_iface((struct sockaddr *)&ipv6);
 	zassert_equal_ptr(iface, iface1, "Invalid interface %p vs %p selected",


### PR DESCRIPTION
Coverity-CID: 187671
Coverity-CID: 187672

Fixes #9460
Fixes #9461

Signed-off-by: Jukka Rissanen <jukka.rissanen@linux.intel.com>