### PR TITLE
kconfig: BT: Default to using BT_CTLR when BT

### DIFF
--- a/boards/arm/nrf52810_pca10040/Kconfig
+++ b/boards/arm/nrf52810_pca10040/Kconfig
@@ -11,4 +11,9 @@ config BOARD_ENABLE_DCDC
         select SOC_DCDC_NRF52X
         default y
 
+# BT_CTLR depends on BT. When BT is enabled we should default to also
+# enabling the controller.
+config BT_CTLR
+	default y if BT
+
 endif # BOARD_NRF52810_PCA10040


### PR DESCRIPTION
As reported in issue #9494, BT samples are using the off-chip
UART-based BT controller on 52810. But the on-chip BT controller is
supported on 52810, so this is the reasonable default when BT is
enabled.

This patch enables BT_CTLR by default when BT is enabled.

This resolves #9494.

Signed-off-by: Sebastian Bøe <sebastian.boe@nordicsemi.no>