### PR TITLE
sanitycheck: Fix the logic for jobs

### DIFF
--- a/scripts/sanitycheck
+++ b/scripts/sanitycheck
@@ -191,11 +191,10 @@ from sanity_chk import expr_parser
 log_format = "%(levelname)s %(name)s::%(module)s.%(funcName)s():%(lineno)d: %(message)s"
 logging.basicConfig(format=log_format, level=30)
 
-if "ZEPHYR_BASE" not in os.environ:
+ZEPHYR_BASE = os.environ.get("ZEPHYR_BASE")
+if not ZEPHYR_BASE:
     sys.stderr.write("$ZEPHYR_BASE environment variable undefined.\n")
     exit(1)
-ZEPHYR_BASE = os.environ["ZEPHYR_BASE"]
-
 
 sys.path.insert(0, os.path.join(ZEPHYR_BASE, "scripts/"))
 
@@ -1305,7 +1304,7 @@ class Platform:
 
     yaml_platform_schema = scl.yaml_load(
         os.path.join(
-            os.environ['ZEPHYR_BASE'],
+            ZEPHYR_BASE,
             "scripts",
             "sanity_chk",
             "sanitycheck-platform-schema.yaml"))
@@ -1574,7 +1573,7 @@ class TestSuite:
     config_re = re.compile('(CONFIG_[A-Za-z0-9_]+)[=]\"?([^\"]*)\"?$')
 
     yaml_tc_schema = scl.yaml_load(
-        os.path.join(os.environ['ZEPHYR_BASE'],
+        os.path.join(ZEPHYR_BASE,
                      "scripts", "sanity_chk", "sanitycheck-tc-schema.yaml"))
 
     def __init__(self, board_root_list, testcase_roots, outdir):

--- a/scripts/sanitycheck
+++ b/scripts/sanitycheck
@@ -206,7 +206,7 @@ LAST_SANITY_XUNIT = os.path.join(ZEPHYR_BASE, "scripts", "sanity_chk",
                                  "last_sanity.xml")
 RELEASE_DATA = os.path.join(ZEPHYR_BASE, "scripts", "sanity_chk",
                             "sanity_last_release.csv")
-JOBS = multiprocessing.cpu_count()
+JOBS = multiprocessing.cpu_count() * 2
 
 if os.isatty(sys.stdout.fileno()):
     TERMINAL = True
@@ -2425,7 +2425,8 @@ def parse_arguments():
         help="Only build the code, do not execute any of it in QEMU")
     parser.add_argument(
         "-j", "--jobs", type=int,
-        help="Number of jobs for building, defaults to number of CPU threads")
+        help="Number of jobs for building, defaults to number of CPU threads "
+        "overcommited by factor 2")
 
     parser.add_argument(
         "--device-testing", action="store_true",

--- a/scripts/sanitycheck
+++ b/scripts/sanitycheck
@@ -206,7 +206,7 @@ LAST_SANITY_XUNIT = os.path.join(ZEPHYR_BASE, "scripts", "sanity_chk",
                                  "last_sanity.xml")
 RELEASE_DATA = os.path.join(ZEPHYR_BASE, "scripts", "sanity_chk",
                             "sanity_last_release.csv")
-CPU_COUNTS = multiprocessing.cpu_count()
+JOBS = multiprocessing.cpu_count()
 
 if os.isatty(sys.stdout.fileno()):
     TERMINAL = True
@@ -1074,7 +1074,7 @@ class MakeGenerator:
             tf.write("all: %s\n" % (" ".join(self.goals.keys())))
             tf.flush()
 
-            cmd = ["make", "-k", "-j", str(CPU_COUNTS), "-f", tf.name, "all"]
+            cmd = ["make", "-k", "-j", str(JOBS), "-f", tf.name, "all"]
 
             p = subprocess.Popen(cmd, stderr=subprocess.PIPE, stdout=devnull)
 
@@ -2009,7 +2009,7 @@ class TestSuite:
         self.goals = mg.execute(cb, cb_context)
 
         # Parallelize size calculation
-        executor = concurrent.futures.ThreadPoolExecutor(CPU_COUNTS)
+        executor = concurrent.futures.ThreadPoolExecutor(JOBS)
         futures = [executor.submit(calc_one_elf_size, name, goal)
                    for name, goal in self.goals.items()]
         concurrent.futures.wait(futures)
@@ -2648,7 +2648,7 @@ def generate_coverage(outdir, ignores):
 
 def main():
     start_time = time.time()
-    global VERBOSE, INLINE_LOGS, CPU_COUNTS, log_file
+    global VERBOSE, INLINE_LOGS, JOBS, log_file
     global options
     options = parse_arguments()
 
@@ -2671,13 +2671,13 @@ def main():
         log_file = open(options.log_file, "w")
 
     if options.jobs:
-        CPU_COUNTS = options.jobs
+        JOBS = options.jobs
 
-    # Decrease CPU_COUNTS for Ninja, if jobs weren't explicitly set
+    # Decrease JOBS for Ninja, if jobs weren't explicitly set
     if options.ninja and not options.jobs:
-        CPU_COUNTS = int(CPU_COUNTS * 0.75)
+        JOBS = int(JOBS * 0.75)
 
-    info("CPU_COUNTS: %d" % CPU_COUNTS);
+    info("JOBS: %d" % JOBS);
 
     if options.subset:
         subset, sets = options.subset.split("/")

--- a/scripts/sanitycheck
+++ b/scripts/sanitycheck
@@ -1074,18 +1074,9 @@ class MakeGenerator:
             tf.write("all: %s\n" % (" ".join(self.goals.keys())))
             tf.flush()
 
-            # Normally spawn 2x as many processes as CPUs.  Ninja,
-            # though, seems to have significant parallelism internally
-            # and results in rather high loads, so use 1.5x there to
-            # match what we see with GNU make.
-            loadmul = 2
-            if options.ninja:
-                    loadmul = 1.5
+            cmd = ["make", "-k", "-j", str(CPU_COUNTS), "-f", tf.name, "all"]
 
-            cmd = ["make", "-k", "-j",
-                   str(int(CPU_COUNTS * loadmul)), "-f", tf.name, "all"]
-            p = subprocess.Popen(cmd, stderr=subprocess.PIPE,
-                                 stdout=devnull)
+            p = subprocess.Popen(cmd, stderr=subprocess.PIPE, stdout=devnull)
 
             for line in iter(p.stderr.readline, b''):
                 line = line.decode("utf-8")
@@ -2434,8 +2425,7 @@ def parse_arguments():
         help="Only build the code, do not execute any of it in QEMU")
     parser.add_argument(
         "-j", "--jobs", type=int,
-        help="Number of cores to use when building, defaults to "
-        "number of CPUs * 2")
+        help="Number of jobs for building, defaults to number of CPU threads")
 
     parser.add_argument(
         "--device-testing", action="store_true",
@@ -2679,8 +2669,15 @@ def main():
     INLINE_LOGS = options.inline_logs
     if options.log_file:
         log_file = open(options.log_file, "w")
+
     if options.jobs:
         CPU_COUNTS = options.jobs
+
+    # Decrease CPU_COUNTS for Ninja, if jobs weren't explicitly set
+    if options.ninja and not options.jobs:
+        CPU_COUNTS = int(CPU_COUNTS * 0.75)
+
+    info("CPU_COUNTS: %d" % CPU_COUNTS);
 
     if options.subset:
         subset, sets = options.subset.split("/")


### PR DESCRIPTION
multiprocessing.cpu_count() already returns the number of threads (not cores), no need to multiply it by 2.
