### PR TITLE
net: tcp: fix spurious TCP retries

### DIFF
--- a/subsys/net/ip/tcp.c
+++ b/subsys/net/ip/tcp.c
@@ -939,15 +939,14 @@ static void restart_timer(struct net_tcp *tcp)
 		tcp->flags |= NET_TCP_RETRYING;
 		tcp->retry_timeout_shift = 0;
 		k_delayed_work_submit(&tcp->retry_timer, retry_timeout(tcp));
-	} else if (CONFIG_NET_TCP_TIME_WAIT_DELAY != 0) {
-		if (tcp->fin_sent && tcp->fin_rcvd) {
-			/* We know sent_list is empty, which means if
-			 * fin_sent is true it must have been ACKd
-			 */
-			k_delayed_work_submit(&tcp->retry_timer,
-					      CONFIG_NET_TCP_TIME_WAIT_DELAY);
-			net_context_ref(tcp->context);
-		}
+	} else if (CONFIG_NET_TCP_TIME_WAIT_DELAY != 0 &&
+			(tcp->fin_sent && tcp->fin_rcvd)) {
+		/* We know sent_list is empty, which means if
+		 * fin_sent is true it must have been ACKd
+		 */
+		k_delayed_work_submit(&tcp->retry_timer,
+				      CONFIG_NET_TCP_TIME_WAIT_DELAY);
+		net_context_ref(tcp->context);
 	} else {
 		k_delayed_work_cancel(&tcp->retry_timer);
 		tcp->flags &= ~NET_TCP_RETRYING;


### PR DESCRIPTION
Spurious TCP retries were observed using Wireshark while continuously
sending TCP packets at an interval faster than the initial RTO.

If the send list is empty and CONFIG_NET_TCP_TIME_WAIT_DELAY is used,
the retry timer will not be correctly stopped when receiving a valid
ACK. As a consequence, the timer might be running when a new packet is
queued, but the logics in net_tcp_queue_data() will not restart the
timer as it is already running. This will make the retry timer to expire
prematurely, potentially while sending packets.

The nested condition is merged into a single condition, allowing the
final else clause to be reached when a valid ACK is received.

Signed-off-by: Florian Vaussard <florian.vaussard@gmail.com>