### PR TITLE
Fix the CI check for references to undefined symbols for external projects

### DIFF
--- a/doc/CMakeLists.txt
+++ b/doc/CMakeLists.txt
@@ -104,7 +104,7 @@ add_custom_target(
   ENV_VAR_ARCH=*
   KERNELVERSION=${PROJECT_VERSION}
   SRCARCH=x86
-  ${PYTHON_EXECUTABLE} scripts/genrest.py ../Kconfig ${RST_OUT}/doc/reference/kconfig/
+  ${PYTHON_EXECUTABLE} scripts/genrest.py Kconfig ${RST_OUT}/doc/reference/kconfig/
   WORKING_DIRECTORY ${CMAKE_CURRENT_LIST_DIR}
 )
 

--- a/scripts/ci/check-compliance.py
+++ b/scripts/ci/check-compliance.py
@@ -101,6 +101,9 @@ def run_checkpatch(tc, commit_range):
 
 
 def run_kconfig_undef_ref_check(tc, commit_range):
+    # Look up Kconfig files relative to ZEPHYR_BASE
+    os.environ["srctree"] = repository_path
+
     # Parse the entire Kconfig tree, to make sure we see all symbols
     os.environ["ENV_VAR_BOARD_DIR"] = "boards/*/*"
     os.environ["ENV_VAR_ARCH"] = "*"


### PR DESCRIPTION
Commit messages say it all:

```
check-compliance: Fix undef. Kconfig symbol check for external projects

Threw an exception about Kconfig files not being found. They need to be
looked up relative to ZEPHYR_BASE.
```

```
Kconfiglib: Fix $srctree behavior for the top-level Kconfig file

Due a design goof, the top-level Kconfig file passed to
Kconfig.__init__() wasn't looked up relative to $srctree. This broke a
planned fix for an issue with the CI check for references to undefined
Kconfig files in external projects.

Update Kconfiglib to upstream revision 953cc12464dae to fix it.
```