### PR TITLE
drivers: gpio: SiFive GPIO allows fewer than 32 pins

### DIFF
--- a/drivers/gpio/gpio_sifive.c
+++ b/drivers/gpio/gpio_sifive.c
@@ -372,164 +372,228 @@ DEVICE_AND_API_INIT(gpio_sifive_0, CONFIG_GPIO_SIFIVE_GPIO_NAME,
 
 static void gpio_sifive_cfg_0(void)
 {
+#ifdef CONFIG_SIFIVE_GPIO_0_IRQ_0
 	IRQ_CONNECT(CONFIG_SIFIVE_GPIO_0_IRQ_0,
 		    CONFIG_GPIO_SIFIVE_0_PRIORITY,
 		    gpio_sifive_irq_handler,
 		    DEVICE_GET(gpio_sifive_0),
 		    0);
+#endif
+#ifdef CONFIG_SIFIVE_GPIO_0_IRQ_1
 	IRQ_CONNECT(CONFIG_SIFIVE_GPIO_0_IRQ_1,
 		    CONFIG_GPIO_SIFIVE_1_PRIORITY,
 		    gpio_sifive_irq_handler,
 		    DEVICE_GET(gpio_sifive_0),
 		    0);
+#endif
+#ifdef CONFIG_SIFIVE_GPIO_0_IRQ_2
 	IRQ_CONNECT(CONFIG_SIFIVE_GPIO_0_IRQ_2,
 		    CONFIG_GPIO_SIFIVE_2_PRIORITY,
 		    gpio_sifive_irq_handler,
 		    DEVICE_GET(gpio_sifive_0),
 		    0);
+#endif
+#ifdef CONFIG_SIFIVE_GPIO_0_IRQ_3
 	IRQ_CONNECT(CONFIG_SIFIVE_GPIO_0_IRQ_3,
 		    CONFIG_GPIO_SIFIVE_3_PRIORITY,
 		    gpio_sifive_irq_handler,
 		    DEVICE_GET(gpio_sifive_0),
 		    0);
+#endif
+#ifdef CONFIG_SIFIVE_GPIO_0_IRQ_4
 	IRQ_CONNECT(CONFIG_SIFIVE_GPIO_0_IRQ_4,
 		    CONFIG_GPIO_SIFIVE_4_PRIORITY,
 		    gpio_sifive_irq_handler,
 		    DEVICE_GET(gpio_sifive_0),
 		    0);
+#endif
+#ifdef CONFIG_SIFIVE_GPIO_0_IRQ_5
 	IRQ_CONNECT(CONFIG_SIFIVE_GPIO_0_IRQ_5,
 		    CONFIG_GPIO_SIFIVE_5_PRIORITY,
 		    gpio_sifive_irq_handler,
 		    DEVICE_GET(gpio_sifive_0),
 		    0);
+#endif
+#ifdef CONFIG_SIFIVE_GPIO_0_IRQ_6
 	IRQ_CONNECT(CONFIG_SIFIVE_GPIO_0_IRQ_6,
 		    CONFIG_GPIO_SIFIVE_6_PRIORITY,
 		    gpio_sifive_irq_handler,
 		    DEVICE_GET(gpio_sifive_0),
 		    0);
+#endif
+#ifdef CONFIG_SIFIVE_GPIO_0_IRQ_7
 	IRQ_CONNECT(CONFIG_SIFIVE_GPIO_0_IRQ_7,
 		    CONFIG_GPIO_SIFIVE_7_PRIORITY,
 		    gpio_sifive_irq_handler,
 		    DEVICE_GET(gpio_sifive_0),
 		    0);
+#endif
+#ifdef CONFIG_SIFIVE_GPIO_0_IRQ_8
 	IRQ_CONNECT(CONFIG_SIFIVE_GPIO_0_IRQ_8,
 		    CONFIG_GPIO_SIFIVE_8_PRIORITY,
 		    gpio_sifive_irq_handler,
 		    DEVICE_GET(gpio_sifive_0),
 		    0);
+#endif
+#ifdef CONFIG_SIFIVE_GPIO_0_IRQ_9
 	IRQ_CONNECT(CONFIG_SIFIVE_GPIO_0_IRQ_9,
 		    CONFIG_GPIO_SIFIVE_9_PRIORITY,
 		    gpio_sifive_irq_handler,
 		    DEVICE_GET(gpio_sifive_0),
 		    0);
+#endif
+#ifdef CONFIG_SIFIVE_GPIO_0_IRQ_10
 	IRQ_CONNECT(CONFIG_SIFIVE_GPIO_0_IRQ_10,
 		    CONFIG_GPIO_SIFIVE_10_PRIORITY,
 		    gpio_sifive_irq_handler,
 		    DEVICE_GET(gpio_sifive_0),
 		    0);
+#endif
+#ifdef CONFIG_SIFIVE_GPIO_0_IRQ_11
 	IRQ_CONNECT(CONFIG_SIFIVE_GPIO_0_IRQ_11,
 		    CONFIG_GPIO_SIFIVE_11_PRIORITY,
 		    gpio_sifive_irq_handler,
 		    DEVICE_GET(gpio_sifive_0),
 		    0);
+#endif
+#ifdef CONFIG_SIFIVE_GPIO_0_IRQ_12
 	IRQ_CONNECT(CONFIG_SIFIVE_GPIO_0_IRQ_12,
 		    CONFIG_GPIO_SIFIVE_12_PRIORITY,
 		    gpio_sifive_irq_handler,
 		    DEVICE_GET(gpio_sifive_0),
 		    0);
+#endif
+#ifdef CONFIG_SIFIVE_GPIO_0_IRQ_13
 	IRQ_CONNECT(CONFIG_SIFIVE_GPIO_0_IRQ_13,
 		    CONFIG_GPIO_SIFIVE_13_PRIORITY,
 		    gpio_sifive_irq_handler,
 		    DEVICE_GET(gpio_sifive_0),
 		    0);
+#endif
+#ifdef CONFIG_SIFIVE_GPIO_0_IRQ_14
 	IRQ_CONNECT(CONFIG_SIFIVE_GPIO_0_IRQ_14,
 		    CONFIG_GPIO_SIFIVE_14_PRIORITY,
 		    gpio_sifive_irq_handler,
 		    DEVICE_GET(gpio_sifive_0),
 		    0);
+#endif
+#ifdef CONFIG_SIFIVE_GPIO_0_IRQ_15
 	IRQ_CONNECT(CONFIG_SIFIVE_GPIO_0_IRQ_15,
 		    CONFIG_GPIO_SIFIVE_15_PRIORITY,
 		    gpio_sifive_irq_handler,
 		    DEVICE_GET(gpio_sifive_0),
 		    0);
+#endif
+#ifdef CONFIG_SIFIVE_GPIO_0_IRQ_16
 	IRQ_CONNECT(CONFIG_SIFIVE_GPIO_0_IRQ_16,
 		    CONFIG_GPIO_SIFIVE_16_PRIORITY,
 		    gpio_sifive_irq_handler,
 		    DEVICE_GET(gpio_sifive_0),
 		    0);
+#endif
+#ifdef CONFIG_SIFIVE_GPIO_0_IRQ_17
 	IRQ_CONNECT(CONFIG_SIFIVE_GPIO_0_IRQ_17,
 		    CONFIG_GPIO_SIFIVE_17_PRIORITY,
 		    gpio_sifive_irq_handler,
 		    DEVICE_GET(gpio_sifive_0),
 		    0);
+#endif
+#ifdef CONFIG_SIFIVE_GPIO_0_IRQ_18
 	IRQ_CONNECT(CONFIG_SIFIVE_GPIO_0_IRQ_18,
 		    CONFIG_GPIO_SIFIVE_18_PRIORITY,
 		    gpio_sifive_irq_handler,
 		    DEVICE_GET(gpio_sifive_0),
 		    0);
+#endif
+#ifdef CONFIG_SIFIVE_GPIO_0_IRQ_19
 	IRQ_CONNECT(CONFIG_SIFIVE_GPIO_0_IRQ_19,
 		    CONFIG_GPIO_SIFIVE_19_PRIORITY,
 		    gpio_sifive_irq_handler,
 		    DEVICE_GET(gpio_sifive_0),
 		    0);
+#endif
+#ifdef CONFIG_SIFIVE_GPIO_0_IRQ_20
 	IRQ_CONNECT(CONFIG_SIFIVE_GPIO_0_IRQ_20,
 		    CONFIG_GPIO_SIFIVE_20_PRIORITY,
 		    gpio_sifive_irq_handler,
 		    DEVICE_GET(gpio_sifive_0),
 		    0);
+#endif
+#ifdef CONFIG_SIFIVE_GPIO_0_IRQ_21
 	IRQ_CONNECT(CONFIG_SIFIVE_GPIO_0_IRQ_21,
 		    CONFIG_GPIO_SIFIVE_21_PRIORITY,
 		    gpio_sifive_irq_handler,
 		    DEVICE_GET(gpio_sifive_0),
 		    0);
+#endif
+#ifdef CONFIG_SIFIVE_GPIO_0_IRQ_22
 	IRQ_CONNECT(CONFIG_SIFIVE_GPIO_0_IRQ_22,
 		    CONFIG_GPIO_SIFIVE_22_PRIORITY,
 		    gpio_sifive_irq_handler,
 		    DEVICE_GET(gpio_sifive_0),
 		    0);
+#endif
+#ifdef CONFIG_SIFIVE_GPIO_0_IRQ_23
 	IRQ_CONNECT(CONFIG_SIFIVE_GPIO_0_IRQ_23,
 		    CONFIG_GPIO_SIFIVE_23_PRIORITY,
 		    gpio_sifive_irq_handler,
 		    DEVICE_GET(gpio_sifive_0),
 		    0);
+#endif
+#ifdef CONFIG_SIFIVE_GPIO_0_IRQ_24
 	IRQ_CONNECT(CONFIG_SIFIVE_GPIO_0_IRQ_24,
 		    CONFIG_GPIO_SIFIVE_24_PRIORITY,
 		    gpio_sifive_irq_handler,
 		    DEVICE_GET(gpio_sifive_0),
 		    0);
+#endif
+#ifdef CONFIG_SIFIVE_GPIO_0_IRQ_25
 	IRQ_CONNECT(CONFIG_SIFIVE_GPIO_0_IRQ_25,
 		    CONFIG_GPIO_SIFIVE_25_PRIORITY,
 		    gpio_sifive_irq_handler,
 		    DEVICE_GET(gpio_sifive_0),
 		    0);
+#endif
+#ifdef CONFIG_SIFIVE_GPIO_0_IRQ_26
 	IRQ_CONNECT(CONFIG_SIFIVE_GPIO_0_IRQ_26,
 		    CONFIG_GPIO_SIFIVE_26_PRIORITY,
 		    gpio_sifive_irq_handler,
 		    DEVICE_GET(gpio_sifive_0),
 		    0);
+#endif
+#ifdef CONFIG_SIFIVE_GPIO_0_IRQ_27
 	IRQ_CONNECT(CONFIG_SIFIVE_GPIO_0_IRQ_27,
 		    CONFIG_GPIO_SIFIVE_27_PRIORITY,
 		    gpio_sifive_irq_handler,
 		    DEVICE_GET(gpio_sifive_0),
 		    0);
+#endif
+#ifdef CONFIG_SIFIVE_GPIO_0_IRQ_28
 	IRQ_CONNECT(CONFIG_SIFIVE_GPIO_0_IRQ_28,
 		    CONFIG_GPIO_SIFIVE_28_PRIORITY,
 		    gpio_sifive_irq_handler,
 		    DEVICE_GET(gpio_sifive_0),
 		    0);
+#endif
+#ifdef CONFIG_SIFIVE_GPIO_0_IRQ_29
 	IRQ_CONNECT(CONFIG_SIFIVE_GPIO_0_IRQ_29,
 		    CONFIG_GPIO_SIFIVE_29_PRIORITY,
 		    gpio_sifive_irq_handler,
 		    DEVICE_GET(gpio_sifive_0),
 		    0);
+#endif
+#ifdef CONFIG_SIFIVE_GPIO_0_IRQ_30
 	IRQ_CONNECT(CONFIG_SIFIVE_GPIO_0_IRQ_30,
 		    CONFIG_GPIO_SIFIVE_30_PRIORITY,
 		    gpio_sifive_irq_handler,
 		    DEVICE_GET(gpio_sifive_0),
 		    0);
+#endif
+#ifdef CONFIG_SIFIVE_GPIO_0_IRQ_31
 	IRQ_CONNECT(CONFIG_SIFIVE_GPIO_0_IRQ_31,
 		    CONFIG_GPIO_SIFIVE_31_PRIORITY,
 		    gpio_sifive_irq_handler,
 		    DEVICE_GET(gpio_sifive_0),
 		    0);
+#endif
 }


### PR DESCRIPTION
SiFive Freedom cores can be configured to have fewer than 32 GPIO pins. To accommodate this, the GPIO driver should only install handlers for defined interrupts.

The FE310 DTS specifies the following GPIO node with 32 interrupts:
```
gpio0: gpio@10012000 {
	compatible = "sifive,gpio0";
	interrupt-parent = <&plic>;
	interrupts = <8 9 10 11 12 13 14 15 16 17 18 19 20 21 22 23 24 25
		26 27 28 29 30 31 32 33 34 35 36 37 38 39>;
	reg = <0x10012000 0x1000>;
	reg-names = "control";
	status = "disabled";
};
```

However, if I create a board for the SiFive E31 Arty Evaluation platform, its DTS specifies the following GPIO node:
```
gpio0: gpio@20002000 {
	compatible = "sifive,gpio0";
	interrupt-parent = <&plic>;
	interrupts = <7 8 9 10 11 12 13 14 15 16 17 18 19 20 21 22>;
	reg = <0x20002000 0x1000>;
	reg-names = "control";
	status = "disabled";
};
```

The Zephyr build fails on this because it expects 32 GPIO IRQs but only 16 get defined.

Ideally, this should be replaced by DTS-based codegen.