### PR TITLE
boards: reel_board: Remove old reference to GPIO_NRF5

### DIFF
--- a/boards/arm/reel_board/Kconfig.defconfig
+++ b/boards/arm/reel_board/Kconfig.defconfig
@@ -9,16 +9,6 @@ if BOARD_REEL_BOARD
 config BOARD
 	default "reel_board"
 
-if GPIO_NRF5
-
-config GPIO_NRF5_P0
-	default y
-
-config GPIO_NRF5_P1
-	default y
-
-endif # GPIO_NRF5
-
 if UART_NRFX
 
 config UART_0_NRF_TX_PIN


### PR DESCRIPTION
PR #8729 removed the old GPIO_NRF5 driver in favor of an
nrfx-based one. The reel_board still references the old one,
causing CI failures.

Signed-off-by: Carles Cufi <carles.cufi@nordicsemi.no>