### PR TITLE
Fix some Kconfig nits

### DIFF
--- a/arch/arm/core/Kconfig
+++ b/arch/arm/core/Kconfig
@@ -144,7 +144,6 @@ choice
 
 config FP_HARDABI
 	bool "Floating point Hard ABI"
-	depends on FLOAT
 	help
 	  This option selects the Floating point ABI in which hardware floating
 	  point instructions are generated and uses FPU-specific calling
@@ -152,7 +151,6 @@ config FP_HARDABI
 
 config FP_SOFTABI
 	bool "Floating point Soft ABI"
-	depends on FLOAT
 	help
 	  This option selects the Floating point ABI in which hardware floating
 	  point instructions are generated but soft-float calling conventions.

--- a/samples/net/lldp/Kconfig
+++ b/samples/net/lldp/Kconfig
@@ -10,10 +10,6 @@
 
 mainmenu "LLDP sample application"
 
-config ZEPHYR_BASE
-	string
-	option env="ZEPHYR_BASE"
-
 source "$ZEPHYR_BASE/Kconfig.zephyr"
 
 if NET_LLDP


### PR DESCRIPTION
Commit messages say it all:

```
samples/net/lldp/Kconfig: Get rid of leftover 'option env'

'option env' is no longer required. Kconfiglib expands references to
environment variables directly.
```

```
arch: arm: kconfig: Remove redundant FLOAT dependencies

The choice that contains FP_HARDAPI and FP_SOFTAPI already depends on
FLOAT, so the choice symbols don't have to.
```