### PR TITLE
scripts: dts: extract: clock.py fix node alias name

### DIFF
--- a/scripts/dts/extract/clocks.py
+++ b/scripts/dts/extract/clocks.py
@@ -77,6 +77,21 @@ class DTClocks(DTDirective):
                             clock_consumer_label, clock_cells_string,
                             clock_cell_name, str(clock_index)])
                     prop_def[clock_label] = str(cell)
+                    if clock_index == 0 and \
+                        len(clocks) == (len(clock_cells) + 1):
+                        index = ''
+                    else:
+                        index = str(clock_index)
+                    if node_address in aliases:
+                        for alias in aliases[node_address]:
+                            if clock_cells_string == clock_cell_name:
+                                clock_alias_label = self.get_label_string([
+                                    alias, clock_cells_string, index])
+                            else:
+                                clock_alias_label = self.get_label_string([
+                                    alias, clock_cells_string,
+                                    clock_cell_name, index])
+                            prop_alias[clock_alias_label] = clock_label
                     # alias
                     if i < nr_clock_cells:
                         # clocks info for first clock


### PR DESCRIPTION
A node alias name should be applied to the all property names.

Before this patch, the alias name is applied erroneously
just for CLOCK_CONTROLLER, skipping the CLOCK_BITS and CLOCK_BUS
property names.

Signed-off-by: Istvan Bisz istvan.bisz@t-online.hu

For example:
```
/ {
	aliases {
…
		dtconfig_sdmmc1 = &sdio;
…
	};
};
```

generates before this PR:
```
/* sdmmc@40012C00 */
#define ST_STM32_SDIO_40012C00_BASE_ADDRESS			0x40012c00
#define ST_STM32_SDIO_40012C00_CLOCK_BITS_0			2048
#define ST_STM32_SDIO_40012C00_CLOCK_BUS_0			3
#define ST_STM32_SDIO_40012C00_CLOCK_CONTROLLER			"STM32_CLK_RCC"
#define ST_STM32_SDIO_40012C00_DMA_RX_INSTANCE			1073898584
#define ST_STM32_SDIO_40012C00_DMA_TX_INSTANCE			1073898656
#define ST_STM32_SDIO_40012C00_IRQ_0				49
#define ST_STM32_SDIO_40012C00_IRQ_0_PRIORITY			0
#define ST_STM32_SDIO_40012C00_LABEL				"SDMMC_1"
#define ST_STM32_SDIO_40012C00_SD_DETECT_GPIOS_CONTROLLER	"GPIOD"
#define ST_STM32_SDIO_40012C00_SD_DETECT_GPIOS_FLAGS		0
#define ST_STM32_SDIO_40012C00_SD_DETECT_GPIOS_PIN		3
#define ST_STM32_SDIO_40012C00_SD_POWER_ON_GPIOS_CONTROLLER	"GPIOC"
#define ST_STM32_SDIO_40012C00_SD_POWER_ON_GPIOS_FLAGS		0
#define ST_STM32_SDIO_40012C00_SD_POWER_ON_GPIOS_PIN		0
#define ST_STM32_SDIO_40012C00_SIZE				1024
#define DTCONFIG_SDMMC1_BASE_ADDRESS				ST_STM32_SDIO_40012C00_BASE_ADDRESS
#define DTCONFIG_SDMMC1_CLOCK_CONTROLLER			ST_STM32_SDIO_40012C00_CLOCK_CONTROLLER
#define DTCONFIG_SDMMC1_DMA_RX_INSTANCE				ST_STM32_SDIO_40012C00_DMA_RX_INSTANCE
#define DTCONFIG_SDMMC1_DMA_TX_INSTANCE				ST_STM32_SDIO_40012C00_DMA_TX_INSTANCE
#define DTCONFIG_SDMMC1_IRQ					ST_STM32_SDIO_40012C00_IRQ_0
#define DTCONFIG_SDMMC1_IRQ_PRIORITY				ST_STM32_SDIO_40012C00_IRQ_0_PRIORITY
#define DTCONFIG_SDMMC1_LABEL					ST_STM32_SDIO_40012C00_LABEL
#define DTCONFIG_SDMMC1_SD_DETECT_GPIOS_CONTROLLER		ST_STM32_SDIO_40012C00_SD_DETECT_GPIOS_CONTROLLER
#define DTCONFIG_SDMMC1_SD_DETECT_GPIOS_FLAGS			ST_STM32_SDIO_40012C00_SD_DETECT_GPIOS_FLAGS
#define DTCONFIG_SDMMC1_SD_DETECT_GPIOS_PIN			ST_STM32_SDIO_40012C00_SD_DETECT_GPIOS_PIN
#define DTCONFIG_SDMMC1_SD_POWER_ON_GPIOS_CONTROLLER		ST_STM32_SDIO_40012C00_SD_POWER_ON_GPIOS_CONTROLLER
#define DTCONFIG_SDMMC1_SD_POWER_ON_GPIOS_FLAGS			ST_STM32_SDIO_40012C00_SD_POWER_ON_GPIOS_FLAGS
#define DTCONFIG_SDMMC1_SD_POWER_ON_GPIOS_PIN			ST_STM32_SDIO_40012C00_SD_POWER_ON_GPIOS_PIN
#define DTCONFIG_SDMMC1_SIZE					ST_STM32_SDIO_40012C00_SIZE
#define ST_STM32_SDIO_40012C00_CLOCK_BITS			ST_STM32_SDIO_40012C00_CLOCK_BITS_0
#define ST_STM32_SDIO_40012C00_CLOCK_BUS			ST_STM32_SDIO_40012C00_CLOCK_BUS_0
```
generates after this PR:
```
/* sdmmc@40012C00 */
#define ST_STM32_SDIO_40012C00_BASE_ADDRESS			0x40012c00
#define ST_STM32_SDIO_40012C00_CLOCK_BITS_0			2048
#define ST_STM32_SDIO_40012C00_CLOCK_BUS_0			3
#define ST_STM32_SDIO_40012C00_CLOCK_CONTROLLER			"STM32_CLK_RCC"
#define ST_STM32_SDIO_40012C00_DMA_RX_INSTANCE			1073898584
#define ST_STM32_SDIO_40012C00_DMA_TX_INSTANCE			1073898656
#define ST_STM32_SDIO_40012C00_IRQ_0				49
#define ST_STM32_SDIO_40012C00_IRQ_0_PRIORITY			0
#define ST_STM32_SDIO_40012C00_LABEL				"SDMMC_1"
#define ST_STM32_SDIO_40012C00_SD_DETECT_GPIOS_CONTROLLER	"GPIOD"
#define ST_STM32_SDIO_40012C00_SD_DETECT_GPIOS_FLAGS		0
#define ST_STM32_SDIO_40012C00_SD_DETECT_GPIOS_PIN		3
#define ST_STM32_SDIO_40012C00_SD_POWER_ON_GPIOS_CONTROLLER	"GPIOC"
#define ST_STM32_SDIO_40012C00_SD_POWER_ON_GPIOS_FLAGS		0
#define ST_STM32_SDIO_40012C00_SD_POWER_ON_GPIOS_PIN		0
#define ST_STM32_SDIO_40012C00_SIZE				1024
#define DTCONFIG_SDMMC1_BASE_ADDRESS				ST_STM32_SDIO_40012C00_BASE_ADDRESS
#define DTCONFIG_SDMMC1_CLOCK_BITS				ST_STM32_SDIO_40012C00_CLOCK_BITS_0
#define DTCONFIG_SDMMC1_CLOCK_BUS				ST_STM32_SDIO_40012C00_CLOCK_BUS_0
#define DTCONFIG_SDMMC1_CLOCK_CONTROLLER			ST_STM32_SDIO_40012C00_CLOCK_CONTROLLER
#define DTCONFIG_SDMMC1_DMA_RX_INSTANCE				ST_STM32_SDIO_40012C00_DMA_RX_INSTANCE
#define DTCONFIG_SDMMC1_DMA_TX_INSTANCE				ST_STM32_SDIO_40012C00_DMA_TX_INSTANCE
#define DTCONFIG_SDMMC1_IRQ					ST_STM32_SDIO_40012C00_IRQ_0
#define DTCONFIG_SDMMC1_IRQ_PRIORITY				ST_STM32_SDIO_40012C00_IRQ_0_PRIORITY
#define DTCONFIG_SDMMC1_LABEL					ST_STM32_SDIO_40012C00_LABEL
#define DTCONFIG_SDMMC1_SD_DETECT_GPIOS_CONTROLLER		ST_STM32_SDIO_40012C00_SD_DETECT_GPIOS_CONTROLLER
#define DTCONFIG_SDMMC1_SD_DETECT_GPIOS_FLAGS			ST_STM32_SDIO_40012C00_SD_DETECT_GPIOS_FLAGS
#define DTCONFIG_SDMMC1_SD_DETECT_GPIOS_PIN			ST_STM32_SDIO_40012C00_SD_DETECT_GPIOS_PIN
#define DTCONFIG_SDMMC1_SD_POWER_ON_GPIOS_CONTROLLER		ST_STM32_SDIO_40012C00_SD_POWER_ON_GPIOS_CONTROLLER
#define DTCONFIG_SDMMC1_SD_POWER_ON_GPIOS_FLAGS			ST_STM32_SDIO_40012C00_SD_POWER_ON_GPIOS_FLAGS
#define DTCONFIG_SDMMC1_SD_POWER_ON_GPIOS_PIN			ST_STM32_SDIO_40012C00_SD_POWER_ON_GPIOS_PIN
#define DTCONFIG_SDMMC1_SIZE					ST_STM32_SDIO_40012C00_SIZE
#define ST_STM32_SDIO_40012C00_CLOCK_BITS			ST_STM32_SDIO_40012C00_CLOCK_BITS_0
#define ST_STM32_SDIO_40012C00_CLOCK_BUS			ST_STM32_SDIO_40012C00_CLOCK_BUS_0
```

