### PR TITLE
cmake: Set new CMAKE_EXTRA_GENERATOR_C_SYSTEM_INCLUDE_MACROS

### DIFF
--- a/cmake/app/boilerplate.cmake
+++ b/cmake/app/boilerplate.cmake
@@ -91,6 +91,8 @@ set(ZEPHYR_BINARY_DIR ${PROJECT_BINARY_DIR})
 set(ZEPHYR_BASE ${PROJECT_SOURCE_DIR})
 
 set(AUTOCONF_H ${__build_dir}/include/generated/autoconf.h)
+# add pre-processor definitions to allow eclipse to gray out sections
+set(CMAKE_EXTRA_GENERATOR_C_SYSTEM_INCLUDE_MACROS "${AUTOCONF_H}")
 # Re-configure (Re-execute all CMakeLists.txt code) when autoconf.h changes
 set_property(DIRECTORY APPEND PROPERTY CMAKE_CONFIGURE_DEPENDS ${AUTOCONF_H})
 


### PR DESCRIPTION
Set a new CMAKE_EXTRA_GENERATOR_C_SYSTEM_INCLUDE_MACROS to
add pre-processor definitions from autoconf.h. This feature allows for eclipse
graying out sections.

The CMakeExtraGeneratorDetermineCompilerMacrosAndIncludeDirs.cmake is
pached in _DETERMINE_GCC_SYSTEM_INCLUDE_DIRS. The C compiler command is called
additionally, with "-imacros ${CMAKE_EXTRA_GENERATOR_C_SYSTEM_INCLUDE_MACROS}"
argument to extend the standard C compiler macro definitions with
definitions from autoconf.h file.

The following patch is applied to the CMakeExtraGeneratorDetermineCompilerMacrosAndIncludeDirs.cmake
from CMake installation directory:
```
@@ -23,14 +23,36 @@ macro(_DETERMINE_GCC_SYSTEM_INCLUDE_DIRS _lang _resultIncludeDirs _resultDefines
     if (CMAKE_CXX_FLAGS MATCHES "(-std=[^ ]+)")
       set(_stdver "${CMAKE_MATCH_1}")
     endif ()
+    if (CMAKE_EXTRA_GENERATOR_CXX_SYSTEM_INCLUDE_MACROS)
+      message(STATUS "*CXX -imacros*")
+      execute_process(COMMAND ${_compilerExecutable} -imacros ${CMAKE_EXTRA_GENERATOR_CXX_SYSTEM_INCLUDE_MACROS} ${_arg1} ${_stdver} ${_stdlib} -v -E -x ${_lang} -dD dummy
+                      WORKING_DIRECTORY ${CMAKE_BINARY_DIR}/CMakeFiles
+                      ERROR_VARIABLE _gccOutput
+                      OUTPUT_VARIABLE _gccStdout )
+    else ()
+      message(STATUS "*CXX*")
+      execute_process(COMMAND ${_compilerExecutable} ${_arg1} ${_stdver} ${_stdlib} -v -E -x ${_lang} -dD dummy
+                      WORKING_DIRECTORY ${CMAKE_BINARY_DIR}/CMakeFiles
+                      ERROR_VARIABLE _gccOutput
+                      OUTPUT_VARIABLE _gccStdout )
+    endif ()
   else ()
     set(_compilerExecutable "${CMAKE_C_COMPILER}")
     set(_arg1 "${CMAKE_C_COMPILER_ARG1}")
+    if (CMAKE_EXTRA_GENERATOR_C_SYSTEM_INCLUDE_MACROS)
+      message(STATUS "*C -imacros*")
+      execute_process(COMMAND ${_compilerExecutable} -imacros ${CMAKE_EXTRA_GENERATOR_C_SYSTEM_INCLUDE_MACROS} ${_arg1} ${_stdver} ${_stdlib} -v -E -x ${_lang} -dD dummy
+                      WORKING_DIRECTORY ${CMAKE_BINARY_DIR}/CMakeFiles
+                      ERROR_VARIABLE _gccOutput
+                      OUTPUT_VARIABLE _gccStdout )
+    else ()
+      message(STATUS "*C*")
+      execute_process(COMMAND ${_compilerExecutable} ${_arg1} ${_stdver} ${_stdlib} -v -E -x ${_lang} -dD dummy
+                      WORKING_DIRECTORY ${CMAKE_BINARY_DIR}/CMakeFiles
+                      ERROR_VARIABLE _gccOutput
+                      OUTPUT_VARIABLE _gccStdout )
+    endif ()
   endif ()
-  execute_process(COMMAND ${_compilerExecutable} ${_arg1} ${_stdver} ${_stdlib} -v -E -x ${_lang} -dD dummy
-                  WORKING_DIRECTORY ${CMAKE_BINARY_DIR}/CMakeFiles
-                  ERROR_VARIABLE _gccOutput
-                  OUTPUT_VARIABLE _gccStdout )
   file(REMOVE "${CMAKE_BINARY_DIR}/CMakeFiles/dummy")
 
   # First find the system include dirs:
```
The second patch is a fix applied to the CMakeExtraGeneratorDetermineCompilerMacrosAndIncludeDirs.cmake
from CMake installation directory too. The defines with value 0 erronously are replaced with value ' '. 
```
@@ -66,10 +88,10 @@ macro(_DETERMINE_GCC_SYSTEM_INCLUDE_DIRS _lang _resultIncludeDirs _resultDefines
     #message(STATUS "m1: -${CMAKE_MATCH_1}- m2: -${CMAKE_MATCH_2}- m3: -${CMAKE_MATCH_3}-")
 
     list(APPEND ${_resultDefines} "${_name}")
-    if(_value)
-      list(APPEND ${_resultDefines} "${_value}")
-    else()
+    if ("${_value}" STREQUAL "")
       list(APPEND ${_resultDefines} " ")
+    else()
+      list(APPEND ${_resultDefines} "${_value}")
     endif()
   endforeach()
```
Signed-off-by: Istvan Bisz istvan.bisz@t-online.hu

