### PR TITLE
net: Move CONFIG_NET_OFFLOAD definition to net/ip/

### DIFF
--- a/subsys/net/ip/Kconfig
+++ b/subsys/net/ip/Kconfig
@@ -472,4 +472,17 @@ source "subsys/net/ip/Kconfig.rpl"
 
 source "subsys/net/ip/Kconfig.stats"
 
+config NET_OFFLOAD
+	bool "Offload IP stack [EXPERIMENTAL]"
+	help
+	  Enables TCP/IP stack to be offload to a co-processor.
+
+config NET_DEBUG_NET_OFFLOAD
+	bool "Debug Net Offload Layer"
+	default y if NET_LOG_GLOBAL
+	depends on NET_LOG
+	depends on NET_OFFLOAD
+	help
+	  Enables offload TCP/IP stack output debug messages.
+
 endmenu

--- a/subsys/net/l2/Kconfig
+++ b/subsys/net/l2/Kconfig
@@ -6,19 +6,6 @@
 
 menu "Link layer options"
 
-config NET_OFFLOAD
-	bool "Offload IP stack [EXPERIMENTAL]"
-	help
-	  Enables TCP/IP stack to be offload to a co-processor.
-
-config NET_DEBUG_NET_OFFLOAD
-	bool "Debug Net Offload Layer"
-	default y if NET_LOG_GLOBAL
-	depends on NET_LOG
-	depends on NET_OFFLOAD
-	help
-	  Enables offload TCP/IP stack output debug messages.
-
 config NET_L2_DUMMY
 	bool "Enable dummy l2 layer"
 	default y if !NET_L2_ETHERNET && NET_TEST


### PR DESCRIPTION
CONFIG_NET_OFFLOAD was defined in Kconfig of net/ip/l2/, but actually
used by the code in net/ip/.

Fixes: #8646

Signed-off-by: Paul Sokolovsky <paul.sokolovsky@linaro.org>