### PR TITLE
Extend zephyr supervisor

### DIFF
--- a/boards/CMakeLists.txt
+++ b/boards/CMakeLists.txt
@@ -1,6 +1,8 @@
 # To avoid a lot of empty CMakeLists.txt files we assume it is not an
 # error if it is missing
 
+add_definitions(-D__ZEPHYR_SUPERVISOR__)
+
 if(EXISTS ${BOARD_DIR}/CMakeLists.txt)
   if(BOARD_ROOT)
     add_subdirectory(${BOARD_DIR} boards/${ARCH}/${BOARD})

--- a/kernel/CMakeLists.txt
+++ b/kernel/CMakeLists.txt
@@ -1,5 +1,7 @@
 # kernel is a normal CMake library and not a zephyr_library because it
 # should not be --whole-archive'd
+add_definitions(-D__ZEPHYR_SUPERVISOR__)
+
 add_library(kernel
   alert.c
   device.c
@@ -23,15 +25,6 @@ add_library(kernel
   version.c
   work_q.c
   smp.c
-  )
-
-# Kernel files has the macro __ZEPHYR_SUPERVISOR__ set so that it
-# optimizes the code when userspace is enabled.
-set_target_properties(
-  kernel
-  PROPERTIES
-  COMPILE_DEFINITIONS
-  __ZEPHYR_SUPERVISOR__
   )
 
 target_sources_ifdef(CONFIG_INT_LATENCY_BENCHMARK kernel PRIVATE int_latency_bench.c)

--- a/misc/CMakeLists.txt
+++ b/misc/CMakeLists.txt
@@ -1,3 +1,5 @@
+add_definitions(-D__ZEPHYR_SUPERVISOR__)
+
 zephyr_sources_if_kconfig(printk.c)
 zephyr_sources_if_kconfig(reboot.c)
 zephyr_sources_if_kconfig(stats.c)

--- a/subsys/CMakeLists.txt
+++ b/subsys/CMakeLists.txt
@@ -1,3 +1,5 @@
+add_definitions(-D__ZEPHYR_SUPERVISOR__)
+
 add_subdirectory_ifdef(CONFIG_APP_SHARED_MEM       app_memory)
 add_subdirectory(debug)
 add_subdirectory(logging)


### PR DESCRIPTION
cmake: Add boards/, misc/, and subsys/ to kernelspace

The -D__ZEPHYR_SUPERVISOR__ define should be set on source code in
kernelspace. It was set on kernel, arch, and drivers, but surprisingly
not on boards, misc, or subsys.

This patch adds the define to these three directories as well.