### PR TITLE
include: console: Include kernel.h for struct k_fifo

### DIFF
--- a/include/console.h
+++ b/include/console.h
@@ -8,6 +8,7 @@
 #define __CONSOLE_H__
 
 #include <zephyr/types.h>
+#include <kernel.h>
 
 #ifdef __cplusplus
 extern "C" {


### PR DESCRIPTION
console.h references struct k_fifo for an argument, so include header
where it's defined.

Fixes: #9536

Signed-off-by: Paul Sokolovsky <paul.sokolovsky@linaro.org>