### PR TITLE
native_posix: Fix possible segfault in command line argument parsing

### DIFF
--- a/boards/posix/native_posix/cmdline_common.c
+++ b/boards/posix/native_posix/cmdline_common.c
@@ -143,6 +143,7 @@ void cmd_read_option_value(const char *str, void *dest, const char type,
 		break;
 	case 's':
 		*(char **)dest = (char *)str;
+		endptr = (char *)str + strlen(str);
 		break;
 	case 'u':
 		*(u32_t *)dest = strtoul(str, &endptr, 0);
@@ -164,7 +165,7 @@ void cmd_read_option_value(const char *str, void *dest, const char type,
 		break;
 	}
 
-	if (*endptr != 0) {
+	if (!error && *endptr != 0) {
 		error = 1;
 	}
 

--- a/boards/posix/native_posix/hw_models_top.c
+++ b/boards/posix/native_posix/hw_models_top.c
@@ -5,7 +5,7 @@
  */
 
 /**
- * Bare-bones HW model sufficient to run some of the sample apps
+ * Reduced set of HW models sufficient to run some of the sample apps
  * and regression tests
  */
 
@@ -93,8 +93,8 @@ static void hwm_sleep_until_next_timer(void)
 	}
 
 	if (signaled_end || (simu_time > end_of_time)) {
-		posix_print_trace("\nStopped right after %.3Lfs\n",
-				((long double)end_of_time)/1.0e6);
+		posix_print_trace("\nStopped at %.3Lfs\n",
+				((long double)simu_time)/1.0e6);
 
 		posix_exit(0);
 	}


### PR DESCRIPTION
Fix in command line parsing common functions, to prevent
a possible segfault when handling string type arguments
+
Minor fix in message printed on kill 
The message which was printed when killing the process was not
correct. Fixed it.
