### PR TITLE
kernel: pipes: fix k_pipe_block_put() when not enough space

### DIFF
--- a/tests/kernel/pipe/pipe_api/src/main.c
+++ b/tests/kernel/pipe/pipe_api/src/main.c
@@ -19,6 +19,8 @@ extern void test_pipe_get_fail(void);
 extern void test_pipe_block_put(void);
 extern void test_pipe_block_put_sema(void);
 extern void test_pipe_get_put(void);
+extern void test_half_pipe_get_put(void);
+extern void test_half_pipe_block_put_sema(void);
 #ifdef CONFIG_USERSPACE
 extern void test_pipe_user_thread2thread(void);
 extern void test_pipe_user_put_fail(void);
@@ -27,7 +29,7 @@ extern void test_resource_pool_auto_free(void);
 #endif
 
 /* k objects */
-extern struct k_pipe pipe, kpipe, put_get_pipe;
+extern struct k_pipe pipe, kpipe, khalfpipe, put_get_pipe;
 extern struct k_sem end_sema;
 extern struct k_stack tstack;
 extern struct k_thread tdata;
@@ -51,7 +53,7 @@ void test_main(void)
 {
 	k_thread_access_grant(k_current_get(), &pipe,
 			      &kpipe, &end_sema, &tdata, &tstack,
-			      &put_get_pipe, NULL);
+			      &khalfpipe, &put_get_pipe, NULL);
 
 	k_thread_resource_pool_assign(k_current_get(), &test_pool);
 
@@ -65,6 +67,8 @@ void test_main(void)
 			 ztest_unit_test(test_pipe_get_fail),
 			 ztest_unit_test(test_pipe_block_put),
 			 ztest_unit_test(test_pipe_block_put_sema),
-			 ztest_unit_test(test_pipe_get_put));
+			 ztest_unit_test(test_pipe_get_put),
+			 ztest_unit_test(test_half_pipe_block_put_sema),
+			 ztest_unit_test(test_half_pipe_get_put));
 	ztest_run_test_suite(pipe_api);
 }


### PR DESCRIPTION
If k_pipe_block_put() is called and the pipe does not have enough
space to accomodate all the data in the memory pool, the subsequent
get operation will cause a CPU fault. The CPU fault is caused by
the timeout struct in the dummy thread not being initialized and
thus the scheduler will read bad memory. After fixing this,
another issue came up where the get operation would stall with
k_pipe_block_put() in same situation. This is due to the async
descriptor not being setup correctly. So fix this too.

This was discovered when debugging #9273.

Signed-off-by: Daniel Leung <daniel.leung@intel.com>