### PR TITLE
lib: cmsis_rtos_v1: Minor refactor of CMSIS implementation

### DIFF
--- a/include/cmsis_rtos_v1/cmsis_os.h
+++ b/include/cmsis_rtos_v1/cmsis_os.h
@@ -61,7 +61,7 @@
 #define osFeature_MessageQ     1       ///< Message Queues:  1=available, 0=not available
 #define osFeature_Signals      8       ///< maximum number of Signal Flags available per thread
 #define osFeature_Semaphore    30      ///< maximum count for \ref osSemaphoreCreate function
-#define osFeature_Wait         1       ///< osWait function: 1=available, 0=not available
+#define osFeature_Wait         0       ///< osWait function: 1=available, 0=not available
 #define osFeature_SysTick      1       ///< osKernelSysTick functions: 1=available, 0=not available
  
 #include <stdint.h>

--- a/lib/cmsis_rtos_v1/cmsis_signal.c
+++ b/lib/cmsis_rtos_v1/cmsis_signal.c
@@ -20,14 +20,15 @@ void *k_thread_other_custom_data_get(struct k_thread *thread_id)
 int32_t osSignalSet(osThreadId thread_id, int32_t signals)
 {
 	int sig, key;
-	osThreadDef_t *thread_def =
-		(osThreadDef_t *)k_thread_other_custom_data_get(
-						(struct k_thread *)thread_id);
 
-	if (_is_in_isr() || (thread_id == NULL) ||
+	if ((thread_id == NULL) || (!signals) ||
 		(signals >= (1 << (osFeature_Signals + 1)))) {
 		return 0x80000000;
 	}
+
+	osThreadDef_t *thread_def =
+		(osThreadDef_t *)k_thread_other_custom_data_get(
+						(struct k_thread *)thread_id);
 
 	key = irq_lock();
 	sig = thread_def->signal_results;
@@ -45,14 +46,15 @@ int32_t osSignalSet(osThreadId thread_id, int32_t signals)
 int32_t osSignalClear(osThreadId thread_id, int32_t signals)
 {
 	int sig, key;
-	osThreadDef_t *thread_def =
-		(osThreadDef_t *)k_thread_other_custom_data_get(
-						(struct k_thread *)thread_id);
 
-	if (_is_in_isr() || (thread_id == NULL) ||
+	if (_is_in_isr() || (thread_id == NULL) || (!signals) ||
 		(signals >= (1 << (osFeature_Signals + 1)))) {
 		return 0x80000000;
 	}
+
+	osThreadDef_t *thread_def =
+		(osThreadDef_t *)k_thread_other_custom_data_get(
+						(struct k_thread *)thread_id);
 
 	key = irq_lock();
 	sig = thread_def->signal_results;

--- a/lib/cmsis_rtos_v1/cmsis_thread.c
+++ b/lib/cmsis_rtos_v1/cmsis_thread.c
@@ -49,7 +49,7 @@ osThreadId osThreadCreate(const osThreadDef_t *thread_def, void *arg)
 		 thread_def->stacksize <= CONFIG_CMSIS_THREAD_MAX_STACK_SIZE,
 		 "invalid stack size\n");
 
-	if (thread_def->instances == 0) {
+	if ((thread_def == NULL) || (thread_def->instances == 0)) {
 		return NULL;
 	}
 
@@ -101,7 +101,7 @@ osPriority osThreadGetPriority(osThreadId thread_id)
 	k_tid_t thread = (k_tid_t)thread_id;
 	u32_t priority;
 
-	if (_is_in_isr()) {
+	if ((thread_id == NULL) || (_is_in_isr())) {
 		return osPriorityError;
 	}
 


### PR DESCRIPTION
Add few missing NULL checks to avoid crash. Also, minor
refactor of signal code and disable osFeature_Wait to
signify osWait function not implemented.

Signed-off-by: Praful Swarnakar <praful.swarnakar@intel.com>