### PR TITLE
cmsis_rtos_v1: add semaphore negative tests, replace an else case

### DIFF
--- a/lib/cmsis_rtos_v1/cmsis_semaphore.c
+++ b/lib/cmsis_rtos_v1/cmsis_semaphore.c
@@ -68,11 +68,9 @@ int32_t osSemaphoreWait(osSemaphoreId semaphore_id, uint32_t timeout)
 	 */
 	if (status == 0) {
 		return k_sem_count_get(semaphore) + 1;
-	} else if (status == -EAGAIN) {
+	} else {
 		return 0;
 	}
-
-	return -1;
 }
 
 /**


### PR DESCRIPTION
Added couple of negative tests for osSemaphoreWait
and osSemaphoreRelease to increase code coverage.

Replaced an else if case in osSemaphoreWait with else
to account for both EBUSY and EAGAIN return values
from k_sem_take. The return value would be 0 for
osSemaphoreWait in both cases.