### PR TITLE
Bluetooth: GATT: Make CCC cfg_changed optional

### DIFF
--- a/subsys/bluetooth/host/gatt.c
+++ b/subsys/bluetooth/host/gatt.c
@@ -548,7 +548,9 @@ static void gatt_ccc_changed(const struct bt_gatt_attr *attr,
 
 	if (value != ccc->value) {
 		ccc->value = value;
-		ccc->cfg_changed(attr, value);
+		if (ccc->cfg_changed) {
+			ccc->cfg_changed(attr, value);
+		}
 	}
 }
 


### PR DESCRIPTION
If cfg_changed has not been set consider that the application don't
care and just skip it.

Signed-off-by: Luiz Augusto von Dentz <luiz.von.dentz@intel.com>