### PR TITLE
qemu: support alternate path of qemu binaries

### DIFF
--- a/cmake/emu/qemu.cmake
+++ b/cmake/emu/qemu.cmake
@@ -3,10 +3,21 @@ if("${ARCH}" STREQUAL "x86")
 else()
   set_ifndef(QEMU_binary_suffix ${ARCH})
 endif()
+
+set(qemu_alternate_path $ENV{QEMU_BIN_PATH})
+if(qemu_alternate_path)
+find_program(
+  QEMU
+  PATHS ${qemu_alternate_path}
+  NO_DEFAULT_PATH
+  NAMES qemu-system-${QEMU_binary_suffix}
+  )
+else()
 find_program(
   QEMU
   qemu-system-${QEMU_binary_suffix}
   )
+endif()
 
 set(qemu_targets
   run

--- a/doc/application/application.rst
+++ b/doc/application/application.rst
@@ -378,6 +378,12 @@ hardware. Follow these instructions to run an application via QEMU:
 Each time you execute the run command, your application is rebuilt and run
 again.
 
+
+.. note:: The ``run`` target will use the QEMU binary available from the Zephyr
+          SDK by default. To use an alternate version of QEMU, for example the
+          version installed on your host or a custom version, set the
+          environment variable ``QEMU_BIN_PATH`` to the alternate path.
+
 .. _application_debugging:
 .. _custom_board_definition:
 


### PR DESCRIPTION
Support using an alternate QEMU path for when we want to use a qemu
version not available in the SDK.

Signed-off-by: Anas Nashif <anas.nashif@intel.com>