### PR TITLE
kernel: k_poll: Introduce separate status for cancelled events

### DIFF
--- a/kernel/poll.c
+++ b/kernel/poll.c
@@ -337,7 +337,7 @@ static int signal_poll_event(struct k_poll_event *event, u32_t state)
 
 	_unpend_thread(thread);
 	_set_thread_return_value(thread,
-				 state == K_POLL_STATE_NOT_READY ? -EINTR : 0);
+				 state == K_POLL_STATE_CANCELLED ? -EINTR : 0);
 
 	if (!_is_thread_ready(thread)) {
 		goto ready_event;

--- a/kernel/queue.c
+++ b/kernel/queue.c
@@ -131,7 +131,7 @@ void _impl_k_queue_cancel_wait(struct k_queue *queue)
 		prepare_thread_to_run(first_pending_thread, NULL);
 	}
 #else
-	handle_poll_events(queue, K_POLL_STATE_NOT_READY);
+	handle_poll_events(queue, K_POLL_STATE_CANCELLED);
 #endif /* !CONFIG_POLL */
 
 	_reschedule(key);

--- a/subsys/net/lib/sockets/sockets.c
+++ b/subsys/net/lib/sockets/sockets.c
@@ -717,7 +717,8 @@ int _impl_zsock_poll(struct zsock_pollfd *fds, int nfds, int timeout)
 	}
 
 	ret = k_poll(poll_events, pev - poll_events, timeout);
-	if (ret != 0 && ret != -EAGAIN) {
+	/* EAGAIN when timeout expired, EINTR when cancelled (i.e. EOF) */
+	if (ret != 0 && ret != -EAGAIN && ret != -EINTR) {
 		errno = -ret;
 		return -1;
 	}

--- a/tests/kernel/poll/src/main.c
+++ b/tests/kernel/poll/src/main.c
@@ -7,6 +7,8 @@
 #include <ztest.h>
 extern void test_poll_no_wait(void);
 extern void test_poll_wait(void);
+extern void test_poll_cancel_main_low_prio(void);
+extern void test_poll_cancel_main_high_prio(void);
 extern void test_poll_multi(void);
 extern void test_poll_threadstate(void);
 extern void test_poll_grant_access(void);
@@ -23,6 +25,8 @@ void test_main(void)
 	ztest_test_suite(poll_api,
 			 ztest_user_unit_test(test_poll_no_wait),
 			 ztest_unit_test(test_poll_wait),
+			 ztest_unit_test(test_poll_cancel_main_low_prio),
+			 ztest_unit_test(test_poll_cancel_main_high_prio),
 			 ztest_unit_test(test_poll_multi),
 			 ztest_unit_test(test_poll_threadstate));
 	ztest_run_test_suite(poll_api);


### PR DESCRIPTION
Previously (as introduced in 48fadfe62), if k_poll() waited on a
queue (or subclass like fifo), and wait was cancelled on queue's
side using k_queue_cancel_wait(), k_poll returned -EINTR. But it
did not set event->state field (to anything else but
K_POLL_STATE_NOT_READY), so in case of waiting on multiple queues,
it was not possible to differentiate which of them was cancelled.

This in particular broke detection of network socket EOF conditions
in POSIX poll() implementation.

This situation is now resolved with introduction of explicit
K_POLL_STATE_CANCELLED state, which is now set for cancelled queue
(-EINTR return remains the same).

This change also elaborates docstring for the functions mentioned, to
document this behavior.

Fixes: #9032

Signed-off-by: Paul Sokolovsky <paul.sokolovsky@linaro.org>