### PR TITLE
tests: a fix for ARC and MPU VER 3

### DIFF
--- a/tests/kernel/mem_protect/userspace/src/main.c
+++ b/tests/kernel/mem_protect/userspace/src/main.c
@@ -689,7 +689,18 @@ void test_main(void)
 	 * Next, the app_memory must be initialized in order to
 	 * calculate size of the dynamically created subsections.
 	 */
+#if defined(CONFIG_ARC)
+	/*
+	 * appmem_init_app_memory will accees all partitions
+	 * For CONFIG_ARC_MPU_VER == 3, these partiontons are not added
+	 * into MPU now, so need to disable mpu first to do app_bss_zero()
+	 */
+	arc_core_mpu_disable();
 	appmem_init_app_memory();
+	arc_core_mpu_enable();
+#else
+	appmem_init_app_memory();
+#endif
 	/* Domain is initialized with partition part0 */
 	appmem_init_domain_dom0(part0);
 	/* Next, the partition must be added to the domain */


### PR DESCRIPTION
For ARC MPU version 3, the defined partitions are not added to MPU
when appmem_init_app_memory is doning app_bss_zero().

So need to disable mpu first to allow appmem_init_app_memory to
access all partitions.

What's more, it's not an arc only issue, for MPU which does not support mpu overlap, it will some similar issue.

Because before through 'appmem_add_thread_xxx()' to add the partitions, there are no corresponding mpu entries in hardware. So the 'appmem_init_app_memory' should raise the mpu violation error as it will do bss zero to all parations.

Why it passed for some archs? Because one background/default mpu entry is set up to cover the regions which are not in mpu hardware through 'appmem_add_thread_xxx()' . But this background/default mpu entry will bring the risk that privileged thread blow up the kernel.

A better solution is to move appmem_init_app_memory into sys init phase where mpu is not enabled.

However it seems  appmem_init_app_memory relies on the information provided by `FOR_EACH(appmem_init_part, ...)`,  we cannot simply put appmem_init_app_memory into sys init phase.

So for arc,  we choose to disable mpu firt, then enable it later for appmem_init_app_memory.


Fixes #9560
