### PR TITLE
cmake: Rework how APPLICATION_MEMORY separates kernelspace

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -532,101 +532,21 @@ or make sure it is not created when it has no source files.")
   endif()
 endforeach()
 
+# Some generators invoke LD from a different directory[0]. So to be
+# able to construct portable paths to libs from linker scripts we need
+# to feed a path prefix to LD. This is necessary, e.g. when separating
+# kernelspace and userspace directories.
+# [0] https://gitlab.kitware.com/cmake/cmake/issues/17448
+if(CONFIG_APPLICATION_MEMORY AND (CMAKE_GENERATOR STREQUAL "Ninja"))
+  set_property(GLOBAL APPEND PROPERTY
+    PROPERTY_LINKER_SCRIPT_DEFINES
+    -DLD_PATH_PREFIX=zephyr/
+    )
+endif()
+
 get_property(OUTPUT_FORMAT        GLOBAL PROPERTY PROPERTY_OUTPUT_FORMAT)
 
 get_property(LINKER_SCRIPT_DEFINES GLOBAL PROPERTY PROPERTY_LINKER_SCRIPT_DEFINES)
-
-if(CONFIG_APPLICATION_MEMORY)
-  # Objects default to being in kernel space, and then we exclude
-  # certain items.
-  set(kernel_object_file_list
-    ${ZEPHYR_LIBS_PROPERTY}
-    kernel
-    )
-  list(
-    REMOVE_ITEM
-    kernel_object_file_list
-    app
-    )
-
-  # The zephyr libraries in zephyr/lib/ and zephyr/test/ belong in
-  # userspace.
-
-  # NB: The business logic for determing what source files are in
-  # kernel space and what source files are in user space is
-  # fragile. Fix ASAP.
-  #
-  # The intended design is that certain directories are designated as
-  # containing userspace code and others for kernel space code. The
-  # implementation we have however is not working on directories of
-  # code, it is working on zephyr libraries. It is exploiting the fact
-  # that zephyr libraries follow a naming scheme as described in
-  # extensions.cmake:zephyr_library_get_current_dir_lib_name
-  #
-  # But code from test/ and lib/ that is placed in the "zephyr"
-  # library (with zephyr_sources()) will not be in a library that is
-  # prefixed with lib__ or test__ and will end up in the wrong address
-  # space.
-  set(application_space_dirs
-    lib
-    tests
-    )
-  foreach(f ${kernel_object_file_list})
-    foreach(app_dir ${application_space_dirs})
-      if(${f} MATCHES "^${app_dir}__") # Begins with ${app_dir}__, e.g. lib__libc
-        list(
-          REMOVE_ITEM
-          kernel_object_file_list
-          ${f}
-          )
-      endif()
-    endforeach()
-  endforeach()
-
-  # Create a list ks, with relative paths to kernel space libs.
-  foreach(f ${kernel_object_file_list})
-    get_target_property(target_name       ${f} NAME)
-    get_target_property(target_binary_dir ${f} BINARY_DIR)
-
-    string(REPLACE
-      ${PROJECT_BINARY_DIR}
-      ""
-      fixed_path
-      ${target_binary_dir}
-      )
-
-    # Append / if not empty
-    if(fixed_path)
-      set(fixed_path "${fixed_path}/")
-    endif()
-
-    # Cut off leading / if present
-    if(fixed_path MATCHES "^/.+")
-      string(SUBSTRING ${fixed_path} 1 -1 fixed_path)
-    endif()
-
-    set(fixed_path "${fixed_path}lib${target_name}.a")
-
-    if(CMAKE_GENERATOR STREQUAL "Ninja")
-      # Ninja invokes the linker from the root of the build directory
-      # (APPLICATION_BINARY_DIR) instead of from the build/zephyr
-      # directory (PROJECT_BINARY_DIR). So for linker-defs.h to get
-      # the correct path we need to prefix with zephyr/.
-      set(fixed_path "zephyr/${fixed_path}")
-    endif()
-
-    list(APPEND ks ${fixed_path})
-  endforeach()
-
-  # We are done constructing kernel_object_file_list, now we inject
-  # this list into the linker script through the define
-  # KERNELSPACE_OBJECT_FILES
-  set(def -DKERNELSPACE_OBJECT_FILES=)
-  foreach(f ${ks})
-    set(def "${def} ${f}")
-  endforeach()
-  list(APPEND LINKER_SCRIPT_DEFINES ${def})
-endif() # CONFIG_APPLICATION_MEMORY
 
 # Declare MPU userspace dependencies before the linker scripts to make
 # sure the order of dependencies are met

--- a/include/linker/linker-defs.h
+++ b/include/linker/linker-defs.h
@@ -113,11 +113,25 @@
  */
 
 #ifdef CONFIG_APPLICATION_MEMORY
-/*
- * KERNELSPACE_OBJECT_FILES is a space-separated list of object files
- * and libraries that belong in kernelspace.
- */
+
+#ifdef LD_PATH_PREFIX
+#define PREFIX LD_PATH_PREFIX
+#else
+#define PREFIX
+#endif
+
+#define KERNELSPACE_OBJECT_FILES             \
+	UTIL_CAT(PREFIX,libzephyr.a)             \
+	UTIL_CAT(PREFIX,kernel*.a)               \
+	UTIL_CAT(PREFIX,drivers*.a)				 \
+	UTIL_CAT(PREFIX,misc*.a)				 \
+	UTIL_CAT(PREFIX,boards*.a)				 \
+	UTIL_CAT(PREFIX,ext*.a)					 \
+	UTIL_CAT(PREFIX,subsys*.a)				 \
+	UTIL_CAT(PREFIX,arch*.a)
+
 #define MAYBE_EXCLUDE_SOME_FILES EXCLUDE_FILE (KERNELSPACE_OBJECT_FILES)
+
 #else
 #define MAYBE_EXCLUDE_SOME_FILES
 #endif /* CONFIG_APPLICATION_MEMORY */


### PR DESCRIPTION
The CONFIG_APPLICATION_MEMORY feature has been using ZEPHYR_LIBS to
partition libraries into userspace and kernelspace. For reasons
outlined in #8441 we are attempting to drop the ZEPHYR_LIBS list.

This patch rewrites CONFIG_APPLICATION_MEMORY to not use ZEPHYR_LIBS.

The new mechanism maintains a list of build directories that contain
kernelspace libraries.

Signed-off-by: Sebastian Bøe <sebastian.boe@nordicsemi.no>