### PR TITLE
Bluetooth: L2CAP: Allow finer control over receiving credits

### DIFF
--- a/include/bluetooth/l2cap.h
+++ b/include/bluetooth/l2cap.h
@@ -81,7 +81,7 @@ struct bt_l2cap_chan {
 #if defined(CONFIG_BT_L2CAP_DYNAMIC_CHANNEL)
 	bt_l2cap_chan_state_t		state;
 	/** Remote PSM to be connected */
-	u16_t			psm;
+	u16_t				psm;
 	/** Helps match request context during CoC */
 	u8_t				ident;
 	bt_security_t			required_sec_level;
@@ -91,13 +91,13 @@ struct bt_l2cap_chan {
 /** @brief LE L2CAP Endpoint structure. */
 struct bt_l2cap_le_endpoint {
 	/** Endpoint CID */
-	u16_t			cid;
+	u16_t				cid;
 	/** Endpoint Maximum Transmission Unit */
-	u16_t			mtu;
+	u16_t				mtu;
 	/** Endpoint Maximum PDU payload Size */
-	u16_t			mps;
+	u16_t				mps;
 	/** Endpoint initial credits */
-	u16_t			init_credits;
+	u16_t				init_credits;
 	/** Endpoint credits */
 	struct k_sem			credits;
 };
@@ -133,9 +133,9 @@ struct bt_l2cap_le_chan {
 /** @brief BREDR L2CAP Endpoint structure. */
 struct bt_l2cap_br_endpoint {
 	/** Endpoint CID */
-	u16_t			cid;
+	u16_t				cid;
 	/** Endpoint Maximum Transmission Unit */
-	u16_t			mtu;
+	u16_t				mtu;
 };
 
 /** @brief BREDR L2CAP Channel structure. */

--- a/include/bluetooth/l2cap.h
+++ b/include/bluetooth/l2cap.h
@@ -203,8 +203,14 @@ struct bt_l2cap_chan_ops {
 	 *
 	 *  @param chan The channel receiving data.
 	 *  @param buf Buffer containing incoming data.
+	 *
+	 *  @return 0 in case of success or negative value in case of error.
+	 *  If -EINPROGRESS is returned user has to confirm once the data has
+	 *  been processed by calling bt_l2cap_chan_recv_complete passing back
+	 *  the buffer received with its original user_data which contains the
+	 *  number of segments/credits used by the packet.
 	 */
-	void (*recv)(struct bt_l2cap_chan *chan, struct net_buf *buf);
+	int (*recv)(struct bt_l2cap_chan *chan, struct net_buf *buf);
 };
 
 /** @def BT_L2CAP_CHAN_SEND_RESERVE
@@ -323,6 +329,21 @@ int bt_l2cap_chan_disconnect(struct bt_l2cap_chan *chan);
  *  @return Bytes sent in case of success or negative value in case of error.
  */
 int bt_l2cap_chan_send(struct bt_l2cap_chan *chan, struct net_buf *buf);
+
+/** @brief Complete receiving L2CAP channel data
+ *
+ * Complete the reception of incoming data. This shall only be called if the
+ * channel recv callback has returned -EINPROGRESS to process some incoming
+ * data. The buffer shall contain the original user_data as that is used for
+ * storing the credits/segments used by the packet.
+ *
+ * @param chan Channel object.
+ * @param buf Buffer containing the data.
+ *
+ *  @return 0 in case of success or negative value in case of error.
+ */
+int bt_l2cap_chan_recv_complete(struct bt_l2cap_chan *chan,
+				struct net_buf *buf);
 
 #ifdef __cplusplus
 }

--- a/subsys/bluetooth/host/att.c
+++ b/subsys/bluetooth/host/att.c
@@ -1864,7 +1864,7 @@ static att_type_t att_op_get_type(u8_t op)
 	return ATT_UNKNOWN;
 }
 
-static void bt_att_recv(struct bt_l2cap_chan *chan, struct net_buf *buf)
+static int bt_att_recv(struct bt_l2cap_chan *chan, struct net_buf *buf)
 {
 	struct bt_att *att = ATT_CHAN(chan);
 	struct bt_att_hdr *hdr = (void *)buf->data;
@@ -1874,7 +1874,7 @@ static void bt_att_recv(struct bt_l2cap_chan *chan, struct net_buf *buf)
 
 	if (buf->len < sizeof(*hdr)) {
 		BT_ERR("Too small ATT PDU received");
-		return;
+		return 0;
 	}
 
 	BT_DBG("Received ATT code 0x%02x len %u", hdr->code, buf->len);
@@ -1894,19 +1894,19 @@ static void bt_att_recv(struct bt_l2cap_chan *chan, struct net_buf *buf)
 			send_err_rsp(chan->conn, hdr->code, 0,
 				     BT_ATT_ERR_NOT_SUPPORTED);
 		}
-		return;
+		return 0;
 	}
 
 	if (IS_ENABLED(CONFIG_BT_ATT_ENFORCE_FLOW)) {
 		if (handler->type == ATT_REQUEST &&
 		    atomic_test_and_set_bit(att->flags, ATT_PENDING_RSP)) {
 			BT_WARN("Ignoring unexpected request");
-			return;
+			return 0;
 		} else if (handler->type == ATT_INDICATION &&
 			   atomic_test_and_set_bit(att->flags,
 						   ATT_PENDING_CFM)) {
 			BT_WARN("Ignoring unexpected indication");
-			return;
+			return 0;
 		}
 	}
 
@@ -1921,6 +1921,8 @@ static void bt_att_recv(struct bt_l2cap_chan *chan, struct net_buf *buf)
 		BT_DBG("ATT error 0x%02x", err);
 		send_err_rsp(chan->conn, hdr->code, 0, err);
 	}
+
+	return 0;
 }
 
 static struct bt_att *att_chan_get(struct bt_conn *conn)

--- a/subsys/bluetooth/host/l2cap.c
+++ b/subsys/bluetooth/host/l2cap.c
@@ -35,8 +35,6 @@
 #define L2CAP_LE_MAX_CREDITS		(CONFIG_BT_RX_BUF_COUNT - 1)
 #endif
 
-#define L2CAP_LE_CREDITS_THRESHOLD(_creds) (_creds / 2)
-
 #define L2CAP_LE_CID_DYN_START	0x0040
 #define L2CAP_LE_CID_DYN_END	0x007f
 #define L2CAP_LE_CID_IS_DYN(_cid) \
@@ -665,6 +663,11 @@ static void l2cap_chan_rx_init(struct bt_l2cap_le_chan *chan)
 	 */
 	chan->rx.mps = min(chan->rx.mtu + 2, L2CAP_MAX_LE_MPS);
 	k_sem_init(&chan->rx.credits, 0, UINT_MAX);
+
+	if (BT_DBG_ENABLED &&
+	    chan->rx.init_credits * chan->rx.mps < chan->rx.mtu + 2) {
+		BT_WARN("Not enough credits for a full packet");
+	}
 }
 
 static void l2cap_chan_tx_init(struct bt_l2cap_le_chan *chan)

--- a/subsys/bluetooth/host/l2cap_br.c
+++ b/subsys/bluetooth/host/l2cap_br.c
@@ -1343,7 +1343,7 @@ int bt_l2cap_br_chan_send(struct bt_l2cap_chan *chan, struct net_buf *buf)
 	return buf->len;
 }
 
-static void l2cap_br_recv(struct bt_l2cap_chan *chan, struct net_buf *buf)
+static int l2cap_br_recv(struct bt_l2cap_chan *chan, struct net_buf *buf)
 {
 	struct bt_l2cap_br *l2cap = CONTAINER_OF(chan, struct bt_l2cap_br, chan);
 	struct bt_l2cap_sig_hdr *hdr = (void *)buf->data;
@@ -1351,7 +1351,7 @@ static void l2cap_br_recv(struct bt_l2cap_chan *chan, struct net_buf *buf)
 
 	if (buf->len < sizeof(*hdr)) {
 		BT_ERR("Too small L2CAP signaling PDU");
-		return;
+		return 0;
 	}
 
 	len = sys_le16_to_cpu(hdr->len);
@@ -1362,12 +1362,12 @@ static void l2cap_br_recv(struct bt_l2cap_chan *chan, struct net_buf *buf)
 
 	if (buf->len != len) {
 		BT_ERR("L2CAP length mismatch (%u != %u)", buf->len, len);
-		return;
+		return 0;
 	}
 
 	if (!hdr->ident) {
 		BT_ERR("Invalid ident value in L2CAP PDU");
-		return;
+		return 0;
 	}
 
 	switch (hdr->code) {
@@ -1401,6 +1401,8 @@ static void l2cap_br_recv(struct bt_l2cap_chan *chan, struct net_buf *buf)
 				     BT_L2CAP_REJ_NOT_UNDERSTOOD, NULL, 0);
 		break;
 	}
+
+	return 0;
 }
 
 static void l2cap_br_conn_pend(struct bt_l2cap_chan *chan, u8_t status)

--- a/subsys/bluetooth/host/rfcomm.c
+++ b/subsys/bluetooth/host/rfcomm.c
@@ -1443,7 +1443,7 @@ int bt_rfcomm_dlc_send(struct bt_rfcomm_dlc *dlc, struct net_buf *buf)
 	return buf->len;
 }
 
-static void rfcomm_recv(struct bt_l2cap_chan *chan, struct net_buf *buf)
+static int rfcomm_recv(struct bt_l2cap_chan *chan, struct net_buf *buf)
 {
 	struct bt_rfcomm_session *session = RFCOMM_SESSION(chan);
 	struct bt_rfcomm_hdr *hdr = (void *)buf->data;
@@ -1452,7 +1452,7 @@ static void rfcomm_recv(struct bt_l2cap_chan *chan, struct net_buf *buf)
 	/* Need to consider FCS also*/
 	if (buf->len < (sizeof(*hdr) + 1)) {
 		BT_ERR("Too small RFCOMM Frame");
-		return;
+		return 0;
 	}
 
 	dlci = BT_RFCOMM_GET_DLCI(hdr->address);
@@ -1465,7 +1465,7 @@ static void rfcomm_recv(struct bt_l2cap_chan *chan, struct net_buf *buf)
 	fcs = *(net_buf_tail(buf) - 1);
 	if (!rfcomm_check_fcs(fcs_len, buf->data, fcs)) {
 		BT_ERR("FCS check failed");
-		return;
+		return 0;
 	}
 
 	if (BT_RFCOMM_LEN_EXTENDED(hdr->length)) {
@@ -1500,6 +1500,8 @@ static void rfcomm_recv(struct bt_l2cap_chan *chan, struct net_buf *buf)
 			frame_type);
 		break;
 	}
+
+	return 0;
 }
 
 static void rfcomm_encrypt_change(struct bt_l2cap_chan *chan,

--- a/subsys/bluetooth/host/sdp.c
+++ b/subsys/bluetooth/host/sdp.c
@@ -1333,7 +1333,7 @@ static const struct {
  *
  *  @return None
  */
-static void bt_sdp_recv(struct bt_l2cap_chan *chan, struct net_buf *buf)
+static int bt_sdp_recv(struct bt_l2cap_chan *chan, struct net_buf *buf)
 {
 	struct bt_l2cap_br_chan *ch = CONTAINER_OF(chan,
 			struct bt_l2cap_br_chan, chan);
@@ -1348,7 +1348,7 @@ static void bt_sdp_recv(struct bt_l2cap_chan *chan, struct net_buf *buf)
 
 	if (buf->len < sizeof(*hdr)) {
 		BT_ERR("Too small SDP PDU received");
-		return;
+		return 0;
 	}
 
 	BT_DBG("Received SDP code 0x%02x len %u", hdr->op_code, buf->len);
@@ -1372,6 +1372,8 @@ static void bt_sdp_recv(struct bt_l2cap_chan *chan, struct net_buf *buf)
 		BT_WARN("SDP error 0x%02x", err);
 		send_err_rsp(chan, err, hdr->tid);
 	}
+
+	return 0;
 }
 
 /* @brief Callback for SDP connection accept
@@ -1713,7 +1715,7 @@ static void sdp_client_notify_result(struct bt_sdp_client *session,
 	}
 }
 
-static void sdp_client_receive(struct bt_l2cap_chan *chan, struct net_buf *buf)
+static int sdp_client_receive(struct bt_l2cap_chan *chan, struct net_buf *buf)
 {
 	struct bt_sdp_client *session = SDP_CLIENT_CHAN(chan);
 	struct bt_sdp_hdr *hdr = (void *)buf->data;
@@ -1725,12 +1727,12 @@ static void sdp_client_receive(struct bt_l2cap_chan *chan, struct net_buf *buf)
 
 	if (buf->len < sizeof(*hdr)) {
 		BT_ERR("Too small SDP PDU");
-		return;
+		return 0;
 	}
 
 	if (hdr->op_code == BT_SDP_ERROR_RSP) {
 		BT_INFO("Error SDP PDU response");
-		return;
+		return 0;
 	}
 
 	len = sys_be16_to_cpu(hdr->param_len);
@@ -1741,12 +1743,12 @@ static void sdp_client_receive(struct bt_l2cap_chan *chan, struct net_buf *buf)
 
 	if (buf->len != len) {
 		BT_ERR("SDP PDU length mismatch (%u != %u)", buf->len, len);
-		return;
+		return 0;
 	}
 
 	if (tid != session->tid) {
 		BT_ERR("Mismatch transaction ID value in SDP PDU");
-		return;
+		return 0;
 	}
 
 	switch (hdr->op_code) {
@@ -1756,12 +1758,12 @@ static void sdp_client_receive(struct bt_l2cap_chan *chan, struct net_buf *buf)
 		/* Check valid buf len for attribute list and cont state */
 		if (buf->len < frame_len + SDP_CONT_STATE_LEN_SIZE) {
 			BT_ERR("Invalid frame payload length");
-			return;
+			return 0;
 		}
 		/* Check valid range of attributes length */
 		if (frame_len < 2) {
 			BT_ERR("Invalid attributes data length");
-			return;
+			return 0;
 		}
 
 		/* Get PDU continuation state */
@@ -1770,13 +1772,13 @@ static void sdp_client_receive(struct bt_l2cap_chan *chan, struct net_buf *buf)
 		if (cstate->length > BT_SDP_MAX_PDU_CSTATE_LEN) {
 			BT_ERR("Invalid SDP PDU Continuation State length %u",
 			       cstate->length);
-			return;
+			return 0;
 		}
 
 		if ((frame_len + SDP_CONT_STATE_LEN_SIZE + cstate->length) >
 		     buf->len) {
 			BT_ERR("Invalid frame payload length");
-			return;
+			return 0;
 		}
 
 		/*
@@ -1834,6 +1836,8 @@ iterate:
 		BT_DBG("PDU 0x%0x response not handled", hdr->op_code);
 		break;
 	}
+
+	return 0;
 }
 
 static int sdp_client_chan_connect(struct bt_sdp_client *session)

--- a/subsys/bluetooth/host/smp_null.c
+++ b/subsys/bluetooth/host/smp_null.c
@@ -38,7 +38,7 @@ int bt_smp_sign(struct bt_conn *conn, struct net_buf *buf)
 	return -ENOTSUP;
 }
 
-static void bt_smp_recv(struct bt_l2cap_chan *chan, struct net_buf *buf)
+static int bt_smp_recv(struct bt_l2cap_chan *chan, struct net_buf *buf)
 {
 	struct bt_conn *conn = chan->conn;
 	struct bt_smp_pairing_fail *rsp;
@@ -60,6 +60,8 @@ static void bt_smp_recv(struct bt_l2cap_chan *chan, struct net_buf *buf)
 	rsp->reason = BT_SMP_ERR_PAIRING_NOTSUPP;
 
 	bt_l2cap_send(conn, BT_L2CAP_CID_SMP, buf);
+
+	return 0;
 }
 
 static int bt_smp_accept(struct bt_conn *conn, struct bt_l2cap_chan **chan)

--- a/subsys/bluetooth/shell/bt.c
+++ b/subsys/bluetooth/shell/bt.c
@@ -1699,7 +1699,7 @@ static int cmd_bredr_discovery(int argc, char *argv[])
 #if defined(CONFIG_BT_L2CAP_DYNAMIC_CHANNEL)
 static u32_t l2cap_rate;
 
-static void l2cap_recv_metrics(struct bt_l2cap_chan *chan, struct net_buf *buf)
+static int l2cap_recv_metrics(struct bt_l2cap_chan *chan, struct net_buf *buf)
 {
 	static u32_t len;
 	static u32_t cycle_stamp;
@@ -1719,15 +1719,19 @@ static void l2cap_recv_metrics(struct bt_l2cap_chan *chan, struct net_buf *buf)
 		len += buf->len;
 		l2cap_rate = ((u64_t)len << 3) * 1000000000 / delta;
 	}
+
+	return 0;
 }
 
-static void l2cap_recv(struct bt_l2cap_chan *chan, struct net_buf *buf)
+static int l2cap_recv(struct bt_l2cap_chan *chan, struct net_buf *buf)
 {
 	printk("Incoming data channel %p len %u\n", chan, buf->len);
 
 	if (buf->len) {
 		hexdump(buf->data, buf->len);
 	}
+
+	return 0;
 }
 
 static void l2cap_connected(struct bt_l2cap_chan *chan)
@@ -1907,9 +1911,11 @@ static int cmd_l2cap_metrics(int argc, char *argv[])
 #endif
 
 #if defined(CONFIG_BT_BREDR)
-static void l2cap_bredr_recv(struct bt_l2cap_chan *chan, struct net_buf *buf)
+static int l2cap_bredr_recv(struct bt_l2cap_chan *chan, struct net_buf *buf)
 {
 	printk("Incoming data channel %p len %u\n", chan, buf->len);
+
+	return 0;
 }
 
 static void l2cap_bredr_connected(struct bt_l2cap_chan *chan)

--- a/subsys/net/buf.c
+++ b/subsys/net/buf.c
@@ -730,9 +730,9 @@ size_t net_buf_append_bytes(struct net_buf *buf, size_t len,
 
 	do {
 		u16_t count = min(len, net_buf_tailroom(frag));
-		void *data = net_buf_add(frag, count);
 
-		memcpy(data, value, count);
+		net_buf_add_mem(frag, value, count);
+
 		len -= count;
 		added_len += count;
 		value += count;

--- a/subsys/net/l2/bluetooth/bluetooth.c
+++ b/subsys/net/l2/bluetooth/bluetooth.c
@@ -183,7 +183,7 @@ static void ipsp_disconnected(struct bt_l2cap_chan *chan)
 #endif
 }
 
-static void ipsp_recv(struct bt_l2cap_chan *chan, struct net_buf *buf)
+static int ipsp_recv(struct bt_l2cap_chan *chan, struct net_buf *buf)
 {
 	struct bt_context *ctxt = CHAN_CTXT(chan);
 	struct net_pkt *pkt;
@@ -194,7 +194,7 @@ static void ipsp_recv(struct bt_l2cap_chan *chan, struct net_buf *buf)
 	/* Get packet for bearer / protocol related data */
 	pkt = net_pkt_get_reserve_rx(0, BUF_TIMEOUT);
 	if (!pkt) {
-		return;
+		return -ENOMEM;
 	}
 
 	/* Set destination address */
@@ -216,6 +216,8 @@ static void ipsp_recv(struct bt_l2cap_chan *chan, struct net_buf *buf)
 		NET_DBG("Packet dropped by NET stack");
 		net_pkt_unref(pkt);
 	}
+
+	return 0;
 }
 
 static struct net_buf *ipsp_alloc_buf(struct bt_l2cap_chan *chan)

--- a/tests/bluetooth/tester/src/l2cap.c
+++ b/tests/bluetooth/tester/src/l2cap.c
@@ -35,7 +35,7 @@ static struct net_buf *alloc_buf_cb(struct bt_l2cap_chan *chan)
 
 static u8_t recv_cb_buf[DATA_MTU + sizeof(struct l2cap_data_received_ev)];
 
-static void recv_cb(struct bt_l2cap_chan *l2cap_chan, struct net_buf *buf)
+static int recv_cb(struct bt_l2cap_chan *l2cap_chan, struct net_buf *buf)
 {
 	struct l2cap_data_received_ev *ev = (void *) recv_cb_buf;
 	struct channel *chan = CONTAINER_OF(l2cap_chan, struct channel, le);
@@ -46,6 +46,8 @@ static void recv_cb(struct bt_l2cap_chan *l2cap_chan, struct net_buf *buf)
 
 	tester_send(BTP_SERVICE_ID_L2CAP, L2CAP_EV_DATA_RECEIVED,
 		    CONTROLLER_INDEX, recv_cb_buf, sizeof(*ev) + buf->len);
+
+	return 0;
 }
 
 static void connected_cb(struct bt_l2cap_chan *l2cap_chan)


### PR DESCRIPTION
These changes add the possibility to control rx credits, it adds a return to recv which can be set to -EINPROGRESS to process packets asynchronously and then confirm with reception with bt_l2cap_chan_recv. In addition to this it also removes the use of a threshold to updates the rx credits and replaces with a simpler logic of restoring the init_credits after each packet is reassembled.