### PR TITLE
WIP net:tcp: NET_CONN_CB: Don't ref/unref net context

### DIFF
--- a/subsys/net/ip/tcp.c
+++ b/subsys/net/ip/tcp.c
@@ -83,10 +83,10 @@ static struct tcp_backlog_entry {
 	{								\
 		enum net_verdict result;				\
 									\
-		net_context_ref(user_data);				\
+		/*net_context_ref(user_data);*/				\
 		result = _##name(conn, pkt, ip_hdr,			\
 				 proto_hdr, user_data);			\
-		net_context_unref(user_data);				\
+		/*net_context_unref(user_data);*/				\
 		return result;						\
 	}								\
 	static enum net_verdict _##name(struct net_conn *conn,		\


### PR DESCRIPTION
This change is supposed to prove that NET_CONN_CB() macro itself is
not needed, as it doesn't do anything beyond refing/unrefing context.

Signed-off-by: Paul Sokolovsky <paul.sokolovsky@linaro.org>