### PR TITLE
net: sockets: close: Call net_context_accept only for listening socket

### DIFF
--- a/subsys/net/lib/sockets/sockets.c
+++ b/subsys/net/lib/sockets/sockets.c
@@ -106,8 +106,11 @@ int _impl_zsock_close(int sock)
 	 * as these are fail-free operations and we're closing
 	 * socket anyway.
 	 */
-	(void)net_context_accept(ctx, NULL, K_NO_WAIT, NULL);
-	(void)net_context_recv(ctx, NULL, K_NO_WAIT, NULL);
+	if (net_context_get_state(ctx) == NET_CONTEXT_LISTENING) {
+		(void)net_context_accept(ctx, NULL, K_NO_WAIT, NULL);
+	} else {
+		(void)net_context_recv(ctx, NULL, K_NO_WAIT, NULL);
+	}
 
 	zsock_flush_queue(ctx);
 


### PR DESCRIPTION
The previous code "optimized" and called both net_context_accept()
and net_context_recv() blindly to reset the corresponding callbacks.
But this leads to "wrong state" logging if debugging is enabled, so
clean that up.

Signed-off-by: Paul Sokolovsky <paul.sokolovsky@linaro.org>