### PR TITLE
tests: power: exclude arduino_101

### DIFF
--- a/tests/power/power_states/testcase.yaml
+++ b/tests/power/power_states/testcase.yaml
@@ -1,6 +1,6 @@
 tests:
   power_management.power_states:
     filter: (CONFIG_SOC_QUARK_SE_C1000 or CONFIG_SOC_QUARK_SE_C1000_SS)
-    platform_exclude: tinytile
+    platform_exclude: tinytile arduino_101 arduino_101_sss
     tags: power
     depends_on: rtc


### PR DESCRIPTION
The test errors on Arduino_101 due to
limitations in power management driver
on the platform. Hence excluding this.

Signed-off-by: Niranjhana N <niranjhana.n@intel.com>