### PR TITLE
boards: add usb to stm32f4_disco

### DIFF
--- a/boards/arm/stm32f4_disco/doc/stm32f4_disco.rst
+++ b/boards/arm/stm32f4_disco/doc/stm32f4_disco.rst
@@ -94,6 +94,8 @@ The Zephyr stm32f4_disco board configuration supports the following hardware fea
 +-----------+------------+-------------------------------------+
 | PWM       | on-chip    | pwm                                 |
 +-----------+------------+-------------------------------------+
+| USB       | on-chip    | usb                                 |
++-----------+------------+-------------------------------------+
 
 Other hardware features are not yet supported on Zephyr porting.
 
@@ -121,6 +123,8 @@ Default Zephyr Peripheral Mapping:
 - LD4 : PD12
 - LD5 : PD14
 - LD6 : PD15
+- USB DM : PA11
+- USB DP : PA12
 
 System Clock
 ============

--- a/boards/arm/stm32f4_disco/stm32f4_disco.dts
+++ b/boards/arm/stm32f4_disco/stm32f4_disco.dts
@@ -72,3 +72,7 @@
 		status = "ok";
 	};
 };
+
+&usbotg_fs {
+	status = "ok";
+};

--- a/boards/arm/stm32f4_disco/stm32f4_disco.yaml
+++ b/boards/arm/stm32f4_disco/stm32f4_disco.yaml
@@ -7,3 +7,4 @@ toolchain:
   - gnuarmemb
 supported:
   - pwm
+  - usb


### PR DESCRIPTION
This patch adds USB capabilities to the stm32f4 discovery board.
As the board has a MicroUSB port that I would like to use as stdout I just added USB.
The needed entry within pinmux.c is already there but USB was missing in the dts file and documentation.

I tested it with the samples/subsys/usb/console.

Signed-off-by: Alexander Polleti <metapsycholo@gmail.com>