### PR TITLE
checkpatch: support function pointers for unnamed function definition

### DIFF
--- a/scripts/checkpatch.pl
+++ b/scripts/checkpatch.pl
@@ -5973,7 +5973,7 @@ sub process {
 
 # check for function declarations that have arguments without identifier names
 		if (defined $stat &&
-		    $stat =~ /^.\s*(?:extern\s+)?$Type\s*$Ident\s*\(\s*([^{]+)\s*\)\s*;/s &&
+		    $stat =~ /^.\s*(?:extern\s+)?$Type\s*\(?\s*\*?\s*$Ident\s*\)\s*\(\s*([^{]+)\s*\)\s*;/s &&
 		    $1 ne "void") {
 			my $args = trim($1);
 			while ($args =~ m/\s*($Type\s*(?:$Ident|\(\s*\*\s*$Ident?\s*\)\s*$balanced_parens)?)/g) {


### PR DESCRIPTION
Current unnamed function definition argument does not include function
pointer cases and it reports warnings like:

WARNING: function definition argument 'void' should also have an identifier name
+unsigned int (*dummy)(void);

Support function pointers for unnamed function arguments.

Fixes #9411

Signed-off-by: Ajay Kishore <ajay.kishore@intel.com>