### PR TITLE
cmake: Use find_program on CMAKE_CXX_COMPILER

### DIFF
--- a/cmake/compiler/gcc.cmake
+++ b/cmake/compiler/gcc.cmake
@@ -49,7 +49,7 @@ else()
     set(cplusplus_compiler ${CMAKE_C_COMPILER})
   endif()
 endif()
-set(CMAKE_CXX_COMPILER ${cplusplus_compiler}     CACHE INTERNAL " " FORCE)
+find_program(CMAKE_CXX_COMPILER ${cplusplus_compiler} PATH ${TOOLCHAIN_HOME} NO_DEFAULT_PATH)
 
 set(NOSTDINC "")
 


### PR DESCRIPTION
'find_program' should be used instead of 'set' for determining the
paths of host programs. It resolves #9582 and various other issues.

Signed-off-by: Sebastian Bøe <sebastian.boe@nordicsemi.no>