### PR TITLE
net: tcp: Remove NET_TCP_FINAL_* flags

### DIFF
--- a/subsys/net/ip/tcp.c
+++ b/subsys/net/ip/tcp.c
@@ -540,7 +540,6 @@ int net_tcp_prepare_segment(struct net_tcp *tcp, u8_t flags,
 	}
 
 	if (flags & NET_TCP_FIN) {
-		tcp->flags |= NET_TCP_FINAL_SENT;
 		/* RFC793 says about ACK bit: "Once a connection is
 		 * established this is always sent." as teardown
 		 * happens when connection is established, it must

--- a/subsys/net/ip/tcp_internal.h
+++ b/subsys/net/ip/tcp_internal.h
@@ -29,11 +29,7 @@ extern "C" {
 /** Is this TCP context/socket used or not */
 #define NET_TCP_IN_USE BIT(0)
 
-/** Is the final segment sent */
-#define NET_TCP_FINAL_SENT BIT(1)
-
-/** Is the final segment received */
-#define NET_TCP_FINAL_RECV BIT(2)
+/* BIT(1), BIT(2) are unused and available */
 
 /** Is the socket shutdown for read/write */
 #define NET_TCP_IS_SHUTDOWN BIT(3)


### PR DESCRIPTION
These were at most set, but never used. They appear to be artifacts
of importing code from the FNET stack.

Addresses: #9570

Signed-off-by: Paul Sokolovsky <paul.sokolovsky@linaro.org>