### PR TITLE
mempool: Fix bit pointer state for N_MAX > 31

### DIFF
--- a/include/misc/mempool_base.h
+++ b/include/misc/mempool_base.h
@@ -31,7 +31,7 @@ struct sys_mem_pool_base {
 	size_t max_sz;
 	u16_t n_max;
 	u8_t n_levels;
-	u8_t max_inline_level;
+	s8_t max_inline_level;
 	struct sys_mem_pool_lvl *levels;
 	u8_t flags;
 };

--- a/lib/mempool/mempool.c
+++ b/lib/mempool/mempool.c
@@ -82,6 +82,8 @@ void _sys_mem_pool_base_init(struct sys_mem_pool_base *p)
 	size_t buflen = p->n_max * p->max_sz, sz = p->max_sz;
 	u32_t *bits = p->buf + buflen;
 
+	p->max_inline_level = -1;
+
 	for (i = 0; i < p->n_levels; i++) {
 		int nblocks = buflen / sz;
 


### PR DESCRIPTION
When a mempool is created with a large number of maximum-size blocks,
the logic for initializing max_inline_level (i.e. when to union the
bitmask with the pointer and when to use the pointer directly) was
wrong.  The default state was "zero", which implies that level 0
should be inlined, but that's wrong with >32 base blocks.
Additionally, the type was unsigned, making the "level zero is a
pointer" situation impossible to represent.

Fixes #6727

Signed-off-by: Andy Ross <andrew.j.ross@intel.com>