### PR TITLE
drivers: gpio: sx1509b: Kconfig options depend on GPIO_SX1509B

### DIFF
--- a/drivers/gpio/Kconfig.sx1509b
+++ b/drivers/gpio/Kconfig.sx1509b
@@ -14,6 +14,7 @@ menuconfig GPIO_SX1509B
 
 config GPIO_SX1509B_INIT_PRIORITY
 	int "Init priority"
+	depends on GPIO_SX1509B
 	default 70
 	help
 	  Device driver initialization priority.
@@ -22,18 +23,21 @@ if !HAS_DTS_I2C_DEVICE
 
 config GPIO_SX1509B_DEV_NAME
 	string "SX1509B GPIO chip Device Name"
+	depends on GPIO_SX1509B
 	default "GPIO_P0"
 	help
 	  Specify the device name for the SX1509B I2C GPIO chip.
 
 config GPIO_SX1509B_I2C_ADDR
 	hex "SX1509B GPIO chip I2C slave address"
+	depends on GPIO_SX1509B
 	default 0x3e
 	help
 	  Specify the I2C slave address for the SX1509B I2C GPIO chip.
 
 config GPIO_SX1509B_I2C_MASTER_DEV_NAME
 	string "I2C Master to which SX1509B GPIO chip is connected"
+	depends on GPIO_SX1509B
 	help
 	  Specify the device name of the I2C master device to which SX1509B
 	  chip is binded.


### PR DESCRIPTION
When CONFIG_GPIO_SX1509B was not set, the related Kconfig options
were still showing up in .config.  Let's make them depend on
GPIO_SX1509B so they can go away when not being used.

Signed-off-by: Michael Scott <mike@foundries.io>