### PR TITLE
subsys: fs/nvs: fix writes when write_block_size != 1

### DIFF
--- a/subsys/fs/nvs/nvs.c
+++ b/subsys/fs/nvs/nvs.c
@@ -43,15 +43,17 @@ static int _nvs_flash_al_wrt(struct nvs_fs *fs, u32_t addr, const void *data,
 		/* flash protection set error */
 		return rc;
 	}
-	blen = len & ~(fs->write_block_size);
-	rc = flash_write(fs->flash_device, offset, data, blen);
-	if (rc) {
-		/* flash write error */
-		return rc;
+	blen = len & ~(fs->write_block_size - 1);
+	if (blen > 0) {
+		rc = flash_write(fs->flash_device, offset, data, blen);
+		if (rc) {
+			/* flash write error */
+			return rc;
+		}
+		len -= blen;
+		offset += blen;
+		data += blen;
 	}
-	len -= blen;
-	offset += blen;
-	data += blen;
 	if (len) {
 		memcpy(buf, data, len);
 		memset(buf + len, 0xff, fs->write_block_size - len);


### PR DESCRIPTION
The current code computes the block-aligned len by ANDing the len with
~write_block_size instead of ~(write_block_size - 1).

In addition the compute value can be 0 (for lengths that are less than
the block size), so the first flash write might have to be skipped.

Signed-off-by: Aurelien Jarno <aurelien@aurel32.net>