### PR TITLE
tests: power: make multicore test build_only

### DIFF
--- a/tests/power/multicore/arc/testcase.yaml
+++ b/tests/power/multicore/arc/testcase.yaml
@@ -1,4 +1,5 @@
 tests:
   test:
+    build_only: true
     platform_whitelist: quark_se_c1000_ss_devboard
     tags: pm

--- a/tests/power/multicore/lmt/testcase.yaml
+++ b/tests/power/multicore/lmt/testcase.yaml
@@ -1,5 +1,6 @@
 tests:
   test:
+    build_only: true
     platform_whitelist: quark_se_c1000_devboard
     extra_args: TEST_CASE=sleep-success
     tags: pm


### PR DESCRIPTION
Currently, we do not have infrastructure to
flash both cores in sync as required by the
test, hence making these build_only.

Signed-off-by: Niranjhana N <niranjhana.n@intel.com>