### PR TITLE
dts: bindings: scan application dir for bindings

### DIFF
--- a/cmake/dts.cmake
+++ b/cmake/dts.cmake
@@ -12,6 +12,7 @@ set(GENERATED_DTS_BOARD_H    ${PROJECT_BINARY_DIR}/include/generated/generated_d
 set(GENERATED_DTS_BOARD_CONF ${PROJECT_BINARY_DIR}/include/generated/generated_dts_board.conf)
 set_ifndef(DTS_SOURCE ${BOARD_ROOT}/boards/${ARCH}/${BOARD_FAMILY}/${BOARD}.dts)
 set_ifndef(DTS_COMMON_OVERLAYS ${ZEPHYR_BASE}/dts/common/common.dts)
+set_ifndef(DTS_APP_BINDINGS ${APPLICATION_SOURCE_DIR}/dts/bindings)
 
 message(STATUS "Generating zephyr/include/generated/generated_dts_board.h")
 
@@ -102,9 +103,13 @@ if(CONFIG_HAS_DTS)
     set(DTS_FIXUPS --fixup ${DTS_FIXUPS})
   endif()
 
+  if(NOT EXISTS ${DTS_APP_BINDINGS})
+    set(DTS_APP_BINDINGS)
+  endif()
+
   set(CMD_EXTRACT_DTS_INCLUDES ${PYTHON_EXECUTABLE} ${ZEPHYR_BASE}/scripts/dts/extract_dts_includes.py
     --dts ${BOARD}.dts_compiled
-    --yaml ${ZEPHYR_BASE}/dts/bindings
+    --yaml ${ZEPHYR_BASE}/dts/bindings ${DTS_APP_BINDINGS}
     ${DTS_FIXUPS}
     --keyvalue ${GENERATED_DTS_BOARD_CONF}
     --include ${GENERATED_DTS_BOARD_H}


### PR DESCRIPTION
In addtion to zephyr/dts/bindings als scan the dts/bindings
directory within the application source directory for bindings.

Allows to have application specific bindings and drivers.

Signed-off-by: Bobby Noelte <b0661n0e17e@gmail.com>