### PR TITLE
tests: kernel: sched: schedule_api: Increase stack size.

### DIFF
--- a/tests/kernel/sched/schedule_api/src/test_sched.h
+++ b/tests/kernel/sched/schedule_api/src/test_sched.h
@@ -10,11 +10,7 @@
 #include <zephyr.h>
 #include <ztest.h>
 
-#if defined(CONFIG_RISCV32) || defined(CONFIG_X86)
-#define STACK_SIZE 512
-#else
-#define STACK_SIZE (256 + CONFIG_TEST_EXTRA_STACKSIZE)
-#endif
+#define STACK_SIZE (512 + CONFIG_TEST_EXTRA_STACKSIZE)
 
 struct thread_data {
 	k_tid_t tid;


### PR DESCRIPTION
The stack size was way too less. Increasing the size to minimum
of 512 for all platforms.

Fixes #9527 #9611
Signed-off-by: Adithya Baglody <adithya.nagaraj.baglody@intel.com>