### PR TITLE
syscalls: Correct the type of _k_syscall_table

### DIFF
--- a/arch/arm/core/userspace.S
+++ b/arch/arm/core/userspace.S
@@ -25,7 +25,7 @@ GTEXT(z_arch_user_string_nlen_fixup)
 GDATA(_kernel)
 
 /* Imports */
-GTEXT(_k_syscall_table)
+GDATA(_k_syscall_table)
 
 /**
  *

--- a/arch/x86/core/userspace.S
+++ b/arch/x86/core/userspace.S
@@ -19,7 +19,7 @@ GTEXT(z_arch_user_string_nlen_fault_end)
 GTEXT(z_arch_user_string_nlen_fixup)
 
 /* Imports */
-GTEXT(_k_syscall_table)
+GDATA(_k_syscall_table)
 
 /* Landing site for syscall SW IRQ. Marshal arguments and call C function for
  * further processing. We're on the kernel stack for the invoking thread.


### PR DESCRIPTION
_k_syscall_table is an array of function pointers and is declared as
such in C sources, this makes it an STT_OBJECT[0] in the symbol
table. But when the same symbol is declared in assembly, it is
declared to be a function, which would make the symbol an STT_FUNC.

When linking with LTO this type inconsistency results in the warning:

real-ld: Warning: type of symbol `_k_syscall_table' changed from 2 to
1 in /tmp/cc84ofK0.ltrans8.ltrans.o

To fix this warning we declare the table with GDATA instead of GTEXT,
which will change the type from 'function' to 'object'.

[0]
https://docs.oracle.com/cd/E19455-01/816-0559/chapter6-79797/index.html

Signed-off-by: Sebastian Bøe <sebastian.boe@nordicsemi.no>