### PR TITLE
kernel: Fix double-list-removal corruption case in timeout handling

### DIFF
--- a/kernel/include/timeout_q.h
+++ b/kernel/include/timeout_q.h
@@ -109,10 +109,9 @@ static inline void _handle_one_expired_timeout(struct _timeout *timeout)
 
 static inline void _handle_expired_timeouts(sys_dlist_t *expired)
 {
-	struct _timeout *timeout, *next;
+	struct _timeout *timeout;
 
-	SYS_DLIST_FOR_EACH_CONTAINER_SAFE(expired, timeout, next, node) {
-		sys_dlist_remove(&timeout->node);
+	SYS_DLIST_FOR_EACH_CONTAINER(expired, timeout, node) {
 		_handle_one_expired_timeout(timeout);
 	}
 }

--- a/kernel/sys_clock.c
+++ b/kernel/sys_clock.c
@@ -167,8 +167,6 @@ u32_t k_uptime_delta_32(s64_t *reftime)
  * interrupt.
  */
 
-volatile int _handling_timeouts;
-
 static inline void handle_timeouts(s32_t ticks)
 {
 	sys_dlist_t expired;
@@ -197,8 +195,6 @@ static inline void handle_timeouts(s32_t ticks)
 	 * of a timeout which delta is 0, since timeouts of 0 ticks are
 	 * prohibited.
 	 */
-
-	_handling_timeouts = 1;
 
 	while (next) {
 
@@ -254,8 +250,6 @@ static inline void handle_timeouts(s32_t ticks)
 	irq_unlock(key);
 
 	_handle_expired_timeouts(&expired);
-
-	_handling_timeouts = 0;
 }
 #else
 	#define handle_timeouts(ticks) do { } while ((0))


### PR DESCRIPTION
This fixes #8669, and is distressingly subtle for a one-line patch:

The list iteration code in _handle_expired_timeouts() would remove the
timeout from our (temporary -- the dlist header is on the stack of our
calling function) list of expired timeouts before invoking the
handler.  But sys_dlist_remove() only fixes up the containing list
pointers, leaving garbage in the node.  If the action of that handler
is to re-add the timeout (which is very common!) then that will then
try to remove it AGAIN from the same list.

Even then, the common case is that the expired list contains only one
item, so the result is a perfectly valid empty list that affects
nothing.  But if you have more than one, you get a corrupt cycle in
the iteration list and things get weird.

As it happens, there's no value in trying to remove this timeout from
the temporary list at all.  Just iterate over it naturally.

Really, this design is fragile: we shouldn't be reusing the list nodes
in struct _timeout for this purpose and should figure out some other
mechanism.  But this fix should be good for now.
