### PR TITLE
boards: nrf52840_pca10059: Add pyOCD configuration

### DIFF
--- a/boards/arm/nrf52840_pca10059/board.cmake
+++ b/boards/arm/nrf52840_pca10059/board.cmake
@@ -1,4 +1,6 @@
 board_runner_args(nrfjprog "--nrf-family=NRF52")
 board_runner_args(jlink "--device=nrf52" "--speed=4000")
+board_runner_args(pyocd "--target=nrf52")
 include(${ZEPHYR_BASE}/boards/common/nrfjprog.board.cmake)
 include(${ZEPHYR_BASE}/boards/common/jlink.board.cmake)
+include(${ZEPHYR_BASE}/boards/common/pyocd.board.cmake)


### PR DESCRIPTION
Add support for using non-jlink programmers through pyOCD.

Tested with: Atmel ICE Debugger

Signed-off-by: Henrik Brix Andersen <henrik@brixandersen.dk>