### PR TITLE
Fix mpu_stack_guard_test and update README

### DIFF
--- a/samples/mpu/mpu_stack_guard_test/README.rst
+++ b/samples/mpu/mpu_stack_guard_test/README.rst
@@ -22,7 +22,7 @@ To build the test with the MPU disabled:
 
 .. zephyr-app-commands::
    :zephyr-app: samples/mpu/mpu_stack_guard_test
-   :board: v2m_beetle
+   :board: frdm_k64f
    :goals: build flash
    :compact:
 
@@ -30,7 +30,7 @@ To build the test with the MPU enabled and the stack guard feature present:
 
 .. zephyr-app-commands::
    :zephyr-app: samples/mpu/mpu_stack_guard_test
-   :board: v2m_beetle
+   :board: frdm_k64f
    :conf: prj_stack_guard.conf
    :goals: build flash
    :compact:
@@ -42,36 +42,35 @@ With the MPU enabled but the stack guard feature disabled:
 
 .. code-block:: console
 
-    ***** BOOTING ZEPHYR OS v1.8.99 - BUILD: Jun 15 2017 23:12:13 *****
-    STACK_ALIGN 4
+    ***** Booting Zephyr OS v1.13.0-rc1-14-gd47fada *****
+    STACK_ALIGN 0x8
     MPU STACK GUARD Test
-    Canary Initial Value = 0xf0cacc1a threads 0x20000b9c
-    Canary = 0xfffffff5     Test not passed.
-    ***** MPU FAULT *****
-      Executing thread ID (thread): 0x20000b9c
-      Faulting instruction address:  0x80025b0
-      Data Access Violation
-      Address: 0x8000edb
-    Fatal fault in thread 0x20000b9c! Aborting.
-    ***** HARD FAULT *****
-      Fault escalation (see below)
-    ***** MPU FAULT *****
-      Executing thread ID (thread): 0x20000b9c
-      Faulting instruction address:  0x8001db6
-      Data Access Violation
-      Address: 0x8000edb
-    Fatal fault in ISR! Spinning...
+    Canary Initial Value = 0xf0cacc1a threads 0x20000ff8
+    Canary = 0x20000128     Test not passed.
+    ***** BUS FAULT *****
+      Instruction bus error
+      NXP MPU error, port 3
+        Mode: Supervisor, Instruction Address: 0x20001030
+        Type: Read, Master: 0, Regions: 0x8800
+    ***** Hardware exception *****
+    Current thread ID = 0x20000ff8
+    Faulting instruction address = 0x20001030
+    Fatal fault in essential thread! Spinning...
 
 With the MPU enabled and the stack guard feature enabled:
 
 .. code-block:: console
 
-    ***** BOOTING ZEPHYR OS v1.8.99 - BUILD: Jun 15 2017 23:05:56 *****
-    STACK_ALIGN 20
+    ***** Booting Zephyr OS v1.13.0-rc1-14-gd47fada *****
+    STACK_ALIGN 0x20
     MPU STACK GUARD Test
-    Canary Initial Value = 0xf0cacc1a threads 0x20000be0
-    ***** MPU FAULT *****
-      Executing thread ID (thread): 0x20000be0
-      Faulting instruction address:  0x8001dc2
+    Canary Initial Value = 0xf0cacc1a threads 0x20001100
+    ***** BUS FAULT *****
       Stacking error
-    Fatal fault in thread 0x20000be0! Aborting.
+      NXP MPU error, port 3
+        Mode: Supervisor, Data Address: 0x200011b0
+        Type: Write, Master: 0, Regions: 0x8400
+    ***** Hardware exception *****
+    Current thread ID = 0x20001100
+    Faulting instruction address = 0x0
+    Fatal fault in thread 0x20001100! Aborting.

--- a/samples/mpu/mpu_stack_guard_test/sample.yaml
+++ b/samples/mpu/mpu_stack_guard_test/sample.yaml
@@ -11,7 +11,7 @@ tests:
       type: multi_line
       ordered: false
       regex:
-        - "Fatal fault in thread 0x[0-9a-f]+! Aborting."
+        - "Fatal fault in .*thread"
         - "STACK_ALIGN.*"
         - "Canary Initial Value = 0x[0-9a-f]+ threads 0x[0-9a-f]+"
   test_stack_guard:
@@ -20,3 +20,10 @@ tests:
     filter: CONFIG_MPU_STACK_GUARD
     tags: apps
     harness: console
+    harness_config:
+      type: multi_line
+      ordered: false
+      regex:
+        - "Fatal fault in thread 0x[0-9a-f]+! Aborting."
+        - "STACK_ALIGN.*"
+        - "Canary Initial Value = 0x[0-9a-f]+ threads 0x[0-9a-f]+"


### PR DESCRIPTION
The mpu_stack_guard sample was failing in both configurations due to incorrect regexes in sample.yaml.

cc: @hakehuang