### PR TITLE
include: kernel, misc: Add queue API to uniquely append element

### DIFF
--- a/include/kernel.h
+++ b/include/kernel.h
@@ -1978,6 +1978,34 @@ static inline bool k_queue_remove(struct k_queue *queue, void *data)
 }
 
 /**
+ * @brief Append an element to a queue only if it's not present already.
+ *
+ * This routine appends data item to @a queue. The first 32 bits of the
+ * data item are reserved for the kernel's use. Appending elements to k_queue
+ * relies on sys_slist_is_node_in_list which is not a constant time operation.
+ *
+ * @note Can be called by ISRs
+ *
+ * @param queue Address of the queue.
+ * @param data Address of the data item.
+ *
+ * @return true if data item was added, false if not
+ */
+static inline bool k_queue_unique_append(struct k_queue *queue, void *data)
+{
+	sys_sfnode_t *test;
+
+	SYS_SFLIST_FOR_EACH_NODE(&queue->data_q, test) {
+		if (test == (sys_sfnode_t *) data) {
+			return false;
+		}
+	}
+
+	k_queue_append(queue, data);
+	return true;
+}
+
+/**
  * @brief Query a queue to see if it has data available.
  *
  * Note that the data might be already gone by the time this function returns


### PR DESCRIPTION
Added the k_queue API to append unique element to the list. Existing k_queue_append API does not check if the element address already exists. This can create a problem if the same element address is appended to queue forming circular list giving unintended behavior for the application. The proposed API k_queue_unique_append takes care of checking if element exists already before appending. This API is complimentary to k_queue_remove which checks if the queue element is present before removing.

Signed-off-by: Dhananjay Gundapu Jayakrishnan dhananjay.jayakrishnan@proglove.de