### PR TITLE
samples: nvs: Use flash erase block size from dts

### DIFF
--- a/dts/arm/nordic/nrf51822.dtsi
+++ b/dts/arm/nordic/nrf51822.dtsi
@@ -27,6 +27,7 @@
 				compatible = "soc-nv-flash";
 				label = "NRF_FLASH";
 				reg = <0x00000000 DT_FLASH_SIZE>;
+				erase-block-size = <1024>;
 				write-block-size = <4>;
 			};
 	};

--- a/samples/subsys/nvs/src/main.c
+++ b/samples/subsys/nvs/src/main.c
@@ -45,7 +45,7 @@
 #include <string.h>
 #include <nvs/nvs.h>
 
-#define NVS_SECTOR_SIZE 1024 /* Multiple of FLASH_PAGE_SIZE */
+#define NVS_SECTOR_SIZE FLASH_ERASE_BLOCK_SIZE /* Multiple of FLASH_PAGE_SIZE */
 #define NVS_SECTOR_COUNT 3 /* At least 2 sectors */
 #define NVS_STORAGE_OFFSET FLASH_AREA_STORAGE_OFFSET /* Start address of the
 						      * filesystem in flash


### PR DESCRIPTION
The nvs sample assumed a 1 KB flash erase block size, which caused the
sample to fail on frdm_k64f because its erase block size is 4 KB. Get
the erase block size from dts instead.

Signed-off-by: Maureen Helm <maureen.helm@nxp.com>

cc: @aurel32 