### PR TITLE
boards: nrf52840_pca10059: Fix pyOCD configuration

### DIFF
--- a/boards/arm/nrf52840_pca10059/board.cmake
+++ b/boards/arm/nrf52840_pca10059/board.cmake
@@ -1,6 +1,6 @@
 board_runner_args(nrfjprog "--nrf-family=NRF52")
 board_runner_args(jlink "--device=nrf52" "--speed=4000")
-board_runner_args(pyocd "--target=nrf52")
+board_runner_args(pyocd "--target=nrf52840")
 include(${ZEPHYR_BASE}/boards/common/nrfjprog.board.cmake)
 include(${ZEPHYR_BASE}/boards/common/jlink.board.cmake)
 include(${ZEPHYR_BASE}/boards/common/pyocd.board.cmake)


### PR DESCRIPTION
Use the correct pyOCD target type for the NRF52840.
This fixes b92436a13f39df93029e881994ebf5d7b071bc4e.

Tested with: Atmel ICE Debugger

Signed-off-by: Henrik Brix Andersen <henrik@brixandersen.dk>