### PR TITLE
sam_e70: enable instruction and data caches on sam_e70

### DIFF
--- a/arch/arm/soc/atmel_sam/same70/soc.c
+++ b/arch/arm/soc/atmel_sam/same70/soc.c
@@ -227,6 +227,11 @@ static int atmel_same70_init(struct device *arg)
 
 	key = irq_lock();
 
+	SCB_EnableICache();
+	if (!(SCB->CCR & SCB_CCR_DC_Msk)) {
+		SCB_EnableDCache();
+	}
+
 	/* Clear all faults */
 	_ClearFaults();
 


### PR DESCRIPTION
The Cortex-M7 CPU included in the SAM e70 SoCs has instruction and data
caches that significantly boost the performances. Enable them during the
SoC initialization.

Fixes #8138

Signed-off-by: Anas Nashif <anas.nashif@intel.com>