### PR TITLE
lib/cmsis_rtos_v1: Remove redundant stack size check

### DIFF
--- a/lib/cmsis_rtos_v1/cmsis_thread.c
+++ b/lib/cmsis_rtos_v1/cmsis_thread.c
@@ -45,8 +45,7 @@ osThreadId osThreadCreate(const osThreadDef_t *thread_def, void *arg)
 	k_thread_stack_t
 	   (*stk_ptr)[K_THREAD_STACK_LEN(CONFIG_CMSIS_THREAD_MAX_STACK_SIZE)];
 
-	__ASSERT(thread_def->stacksize >= 0 &&
-		 thread_def->stacksize <= CONFIG_CMSIS_THREAD_MAX_STACK_SIZE,
+	__ASSERT(thread_def->stacksize <= CONFIG_CMSIS_THREAD_MAX_STACK_SIZE,
 		 "invalid stack size\n");
 
 	if (thread_def->instances == 0) {


### PR DESCRIPTION
stacksize is an unsigned integer and hence there's no need to
check whether it is >= 0 since it is always true. This fixes
the Github issue #9637.

Fixes #9637.

Signed-off-by: Rajavardhan Gundi <rajavardhan.gundi@intel.com>