### PR TITLE
net: ipv6: Drop packet with multiple HBHO

### DIFF
--- a/subsys/net/ip/ipv6.c
+++ b/subsys/net/ip/ipv6.c
@@ -542,6 +542,11 @@ enum net_verdict net_ipv6_process_pkt(struct net_pkt *pkt)
 			goto drop;
 
 		case NET_IPV6_NEXTHDR_HBHO:
+			if (ext_bitmap & NET_IPV6_EXT_HDR_BITMAP_HBHO) {
+				NET_ERR("Dropping packet with multiple HBHO");
+				goto drop;
+			}
+
 			frag = net_frag_read_u8(frag, offset, &offset,
 						(u8_t *)&length);
 			if (!frag) {
@@ -553,11 +558,6 @@ enum net_verdict net_ipv6_process_pkt(struct net_pkt *pkt)
 
 			/* HBH option needs to be the first one */
 			if (first_option != NET_IPV6_NEXTHDR_HBHO) {
-				goto bad_hdr;
-			}
-
-			/* Hop by hop option */
-			if (ext_bitmap & NET_IPV6_EXT_HDR_BITMAP_HBHO) {
 				goto bad_hdr;
 			}
 


### PR DESCRIPTION
If a malformed packet with multiple HBHO is received echo server
replies with ICMPv6 type 4 code 1: "Parameter problem unrecognized Next
Header type encountered". This ICMPv6 message has wrong IPv6 payload
length and ICMPv6 checksum. RFC 8200 in chapter 4.1 states:

   Each extension header should occur at most once, except for the
   Destination Options header, which should occur at most twice (once
   before a Routing header and once before the upper-layer header).

Hence, this patch changes the code to drop the packet instead of
sending ICMPv6 type 4 code 1.

Signed-off-by: Ruslan Mstoi <ruslan.mstoi@intel.com>