### PR TITLE
tests: benchmarks: sys_kernel: Enable benchmark for slower SoCs

### DIFF
--- a/tests/benchmarks/sys_kernel/src/lifo.c
+++ b/tests/benchmarks/sys_kernel/src/lifo.c
@@ -163,11 +163,11 @@ int lifo_test(void)
 	t = BENCH_START();
 
 	k_thread_create(&thread_data1, thread_stack1, STACK_SIZE, lifo_thread1,
-			 NULL, (void *) NUMBER_OF_LOOPS, NULL,
+			 NULL, (void *) number_of_loops, NULL,
 			 K_PRIO_COOP(3), 0, K_NO_WAIT);
 
 	k_thread_create(&thread_data2, thread_stack2, STACK_SIZE, lifo_thread2,
-			 (void *) &i, (void *) NUMBER_OF_LOOPS, NULL,
+			 (void *) &i, (void *) number_of_loops, NULL,
 			 K_PRIO_COOP(3), 0, K_NO_WAIT);
 
 	t = TIME_STAMP_DELTA_GET(t);
@@ -197,11 +197,11 @@ int lifo_test(void)
 	i = 0;
 
 	k_thread_create(&thread_data1, thread_stack1, STACK_SIZE, lifo_thread1,
-			 NULL, (void *) NUMBER_OF_LOOPS, NULL,
+			 NULL, (void *) number_of_loops, NULL,
 			 K_PRIO_COOP(3), 0, K_NO_WAIT);
 
 	k_thread_create(&thread_data2, thread_stack2, STACK_SIZE, lifo_thread3,
-			 (void *) &i, (void *) NUMBER_OF_LOOPS, NULL,
+			 (void *) &i, (void *) number_of_loops, NULL,
 			 K_PRIO_COOP(3), 0, K_NO_WAIT);
 
 	t = TIME_STAMP_DELTA_GET(t);
@@ -229,9 +229,9 @@ int lifo_test(void)
 	t = BENCH_START();
 
 	k_thread_create(&thread_data1, thread_stack1, STACK_SIZE, lifo_thread1,
-			 NULL, (void *) NUMBER_OF_LOOPS, NULL,
+			 NULL, (void *) number_of_loops, NULL,
 			 K_PRIO_COOP(3), 0, K_NO_WAIT);
-	for (i = 0; i < NUMBER_OF_LOOPS / 2; i++) {
+	for (i = 0; i < number_of_loops / 2; i++) {
 		int element[2];
 		int *pelement;
 

--- a/tests/benchmarks/sys_kernel/src/mwfifo.c
+++ b/tests/benchmarks/sys_kernel/src/mwfifo.c
@@ -163,10 +163,10 @@ int fifo_test(void)
 	t = BENCH_START();
 
 	k_thread_create(&thread_data1, thread_stack1, STACK_SIZE, fifo_thread1,
-			 NULL, (void *) NUMBER_OF_LOOPS, NULL,
+			 NULL, (void *) number_of_loops, NULL,
 			 K_PRIO_COOP(3), 0, K_NO_WAIT);
 	k_thread_create(&thread_data2, thread_stack2, STACK_SIZE, fifo_thread2,
-			 (void *) &i, (void *) NUMBER_OF_LOOPS, NULL,
+			 (void *) &i, (void *) number_of_loops, NULL,
 			 K_PRIO_COOP(3), 0, K_NO_WAIT);
 
 	t = TIME_STAMP_DELTA_GET(t);
@@ -195,10 +195,10 @@ int fifo_test(void)
 
 	i = 0;
 	k_thread_create(&thread_data1, thread_stack1, STACK_SIZE, fifo_thread1,
-			 NULL, (void *) NUMBER_OF_LOOPS, NULL,
+			 NULL, (void *) number_of_loops, NULL,
 			 K_PRIO_COOP(3), 0, K_NO_WAIT);
 	k_thread_create(&thread_data2, thread_stack2, STACK_SIZE, fifo_thread3,
-			 (void *) &i, (void *) NUMBER_OF_LOOPS, NULL,
+			 (void *) &i, (void *) number_of_loops, NULL,
 			 K_PRIO_COOP(3), 0, K_NO_WAIT);
 
 	t = TIME_STAMP_DELTA_GET(t);
@@ -226,12 +226,12 @@ int fifo_test(void)
 	t = BENCH_START();
 
 	k_thread_create(&thread_data1, thread_stack1, STACK_SIZE, fifo_thread1,
-			 NULL, (void *) (NUMBER_OF_LOOPS / 2), NULL,
+			 NULL, (void *) (number_of_loops / 2), NULL,
 			 K_PRIO_COOP(3), 0, K_NO_WAIT);
 	k_thread_create(&thread_data2, thread_stack2, STACK_SIZE, fifo_thread1,
-			 NULL, (void *) (NUMBER_OF_LOOPS / 2), NULL,
+			 NULL, (void *) (number_of_loops / 2), NULL,
 			 K_PRIO_COOP(3), 0, K_NO_WAIT);
-	for (i = 0; i < NUMBER_OF_LOOPS / 2; i++) {
+	for (i = 0; i < number_of_loops / 2; i++) {
 		int element[2];
 		int *pelement;
 

--- a/tests/benchmarks/sys_kernel/src/sema.c
+++ b/tests/benchmarks/sys_kernel/src/sema.c
@@ -127,10 +127,10 @@ int sema_test(void)
 	t = BENCH_START();
 
 	k_thread_create(&thread_data1, thread_stack1, STACK_SIZE, sema_thread1,
-			 NULL, (void *) NUMBER_OF_LOOPS, NULL,
+			 NULL, (void *) number_of_loops, NULL,
 			 K_PRIO_COOP(3), 0, K_NO_WAIT);
 	k_thread_create(&thread_data2, thread_stack2, STACK_SIZE, sema_thread2,
-			 (void *) &i, (void *) NUMBER_OF_LOOPS, NULL,
+			 (void *) &i, (void *) number_of_loops, NULL,
 			 K_PRIO_COOP(3), 0, K_NO_WAIT);
 
 	t = TIME_STAMP_DELTA_GET(t);
@@ -152,10 +152,10 @@ int sema_test(void)
 	t = BENCH_START();
 
 	k_thread_create(&thread_data1, thread_stack1, STACK_SIZE, sema_thread1,
-			 NULL, (void *) NUMBER_OF_LOOPS, NULL,
+			 NULL, (void *) number_of_loops, NULL,
 			 K_PRIO_COOP(3), 0, K_NO_WAIT);
 	k_thread_create(&thread_data2, thread_stack2, STACK_SIZE, sema_thread3,
-			 (void *) &i, (void *) NUMBER_OF_LOOPS, NULL,
+			 (void *) &i, (void *) number_of_loops, NULL,
 			 K_PRIO_COOP(3), 0, K_NO_WAIT);
 
 	t = TIME_STAMP_DELTA_GET(t);
@@ -177,9 +177,9 @@ int sema_test(void)
 	t = BENCH_START();
 
 	k_thread_create(&thread_data1, thread_stack1, STACK_SIZE, sema_thread1,
-			 NULL, (void *) NUMBER_OF_LOOPS, NULL,
+			 NULL, (void *) number_of_loops, NULL,
 			 K_PRIO_COOP(3), 0, K_NO_WAIT);
-	for (i = 0; i < NUMBER_OF_LOOPS; i++) {
+	for (i = 0; i < number_of_loops; i++) {
 		k_sem_give(&sem1);
 		k_sem_take(&sem2, K_FOREVER);
 	}

--- a/tests/benchmarks/sys_kernel/src/stack.c
+++ b/tests/benchmarks/sys_kernel/src/stack.c
@@ -161,10 +161,10 @@ int stack_test(void)
 	t = BENCH_START();
 
 	k_thread_create(&thread_data1, thread_stack1, STACK_SIZE, stack_thread1,
-			 0, (void *) NUMBER_OF_LOOPS, NULL,
+			 0, (void *) number_of_loops, NULL,
 			 K_PRIO_COOP(3), 0, K_NO_WAIT);
 	k_thread_create(&thread_data2, thread_stack2, STACK_SIZE, stack_thread2,
-			 (void *) &i, (void *) NUMBER_OF_LOOPS, NULL,
+			 (void *) &i, (void *) number_of_loops, NULL,
 			 K_PRIO_COOP(3), 0, K_NO_WAIT);
 
 	t = TIME_STAMP_DELTA_GET(t);
@@ -188,10 +188,10 @@ int stack_test(void)
 
 	i = 0;
 	k_thread_create(&thread_data1, thread_stack1, STACK_SIZE, stack_thread1,
-			 0, (void *) NUMBER_OF_LOOPS, NULL,
+			 0, (void *) number_of_loops, NULL,
 			 K_PRIO_COOP(3), 0, K_NO_WAIT);
 	k_thread_create(&thread_data2, thread_stack2, STACK_SIZE, stack_thread3,
-			 (void *) &i, (void *) NUMBER_OF_LOOPS, NULL,
+			 (void *) &i, (void *) number_of_loops, NULL,
 			 K_PRIO_COOP(3), 0, K_NO_WAIT);
 
 	t = TIME_STAMP_DELTA_GET(t);
@@ -216,10 +216,10 @@ int stack_test(void)
 	t = BENCH_START();
 
 	k_thread_create(&thread_data1, thread_stack1, STACK_SIZE, stack_thread1,
-			 0, (void *) NUMBER_OF_LOOPS, NULL,
+			 0, (void *) number_of_loops, NULL,
 			 K_PRIO_COOP(3), 0, K_NO_WAIT);
 
-	for (i = 0; i < NUMBER_OF_LOOPS / 2; i++) {
+	for (i = 0; i < number_of_loops / 2; i++) {
 		u32_t data;
 
 		data = 2 * i;

--- a/tests/benchmarks/sys_kernel/src/syskernel.c
+++ b/tests/benchmarks/sys_kernel/src/syskernel.c
@@ -29,6 +29,9 @@ const char sz_fail[] = "FAILED";
 /* time necessary to read the time */
 u32_t tm_off;
 
+/* Holds the loop count that need to be carried out. */
+u32_t number_of_loops;
+
 /**
  *
  * @brief Get the time ticks before test starts
@@ -68,7 +71,7 @@ int check_result(int i, u32_t t)
 		fprintf(output_file, sz_case_end_fmt);
 		return 0;
 	}
-	if (i != NUMBER_OF_LOOPS) {
+	if (i != number_of_loops) {
 		fprintf(output_file, sz_case_result_fmt, sz_fail);
 		fprintf(output_file, sz_case_details_fmt, "loop counter = ");
 		fprintf(output_file, "%i !!!", i);
@@ -79,7 +82,7 @@ int check_result(int i, u32_t t)
 	fprintf(output_file, sz_case_details_fmt,
 			"Average time for 1 iteration: ");
 	fprintf(output_file, sz_case_timing_fmt,
-			SYS_CLOCK_HW_CYCLES_TO_NS_AVG(t, NUMBER_OF_LOOPS));
+			SYS_CLOCK_HW_CYCLES_TO_NS_AVG(t, number_of_loops));
 
 	fprintf(output_file, sz_case_end_fmt);
 	return 1;
@@ -139,8 +142,25 @@ void main(void)
 	int	    continuously = 0;
 	int	    test_result;
 
+	number_of_loops = NUMBER_OF_LOOPS;
+
+	/* The following code is needed to make the benchmakring run on
+	 * slower platforms.
+	 */
+	u64_t time_stamp = _sys_clock_tick_count;
+
+	k_sleep(1);
+
+	u64_t time_stamp_2 = _sys_clock_tick_count;
+
+	if (time_stamp_2 - time_stamp > 1) {
+		number_of_loops = 10;
+	}
+
 	init_output(&continuously);
 	bench_test_init();
+
+
 
 	do {
 		fprintf(output_file, sz_module_title_fmt,
@@ -150,7 +170,7 @@ void main(void)
 		fprintf(output_file,
 			"\n\nEach test below is repeated %d times;\n"
 			"average time for one iteration is displayed.",
-			NUMBER_OF_LOOPS);
+			number_of_loops);
 
 		test_result = 0;
 

--- a/tests/benchmarks/sys_kernel/src/syskernel.h
+++ b/tests/benchmarks/sys_kernel/src/syskernel.h
@@ -28,6 +28,8 @@ extern const char sz_success[];
 extern const char sz_partial[];
 extern const char sz_fail[];
 
+extern u32_t number_of_loops;
+
 #define sz_module_title_fmt	"\nMODULE: %s"
 #define sz_module_result_fmt	"\n\nPROJECT EXECUTION %s\n"
 #define sz_module_end_fmt	"\nEND MODULE"


### PR DESCRIPTION
Few SoCs whose clock speed is very less will cause multiple ticks
to occur for 1 sec of sleep. For such a platform we cant run
the loops for over 5000 because the tick handler will get executed.
Thus rendering the test useless for such platforms. By reducing
the number of iterations we get the required benchmark results.

Fixes: GH-7906

Signed-off-by: Adithya Baglody <adithya.nagaraj.baglody@intel.com>