### PR TITLE
kernel: Enable interrupts for MULTITHREADING=n on supported architect…

### DIFF
--- a/include/arch/arm/cortex_m/asm_inline_gcc.h
+++ b/include/arch/arm/cortex_m/asm_inline_gcc.h
@@ -175,6 +175,8 @@ static ALWAYS_INLINE void _arch_irq_unlock(unsigned int key)
 #endif /* CONFIG_ARMV6_M_ARMV8_M_BASELINE */
 }
 
+/* Used to unconditionally enable interrupts when MULTITHREADING=n */
+#define Z_ARCH_INT_ENABLE() _arch_irq_unlock(0)
 
 #endif /* _ASMLANGUAGE */
 

--- a/include/arch/x86/arch.h
+++ b/include/arch/x86/arch.h
@@ -445,6 +445,9 @@ static ALWAYS_INLINE void _arch_irq_unlock(unsigned int key)
 	_do_irq_unlock();
 }
 
+/* Used to unconditionally enable interrupts when MULTITHREADING=n */
+#define Z_ARCH_INT_ENABLE() _arch_irq_unlock(0x200)
+
 /**
  * The NANO_SOFT_IRQ macro must be used as the value for the @a irq parameter
  * to NANO_CPU_INT_REGISTER when connecting to an interrupt that does not

--- a/kernel/init.c
+++ b/kernel/init.c
@@ -436,6 +436,18 @@ sys_rand32_fallback:
 extern uintptr_t __stack_chk_guard;
 #endif /* CONFIG_STACK_CANARIES */
 
+#ifndef CONFIG_MULTITHREADING
+static void enable_interrupts(void)
+{
+#ifdef Z_ARCH_INT_ENABLE
+	Z_ARCH_INT_ENABLE();
+#else
+# pragma message "Z_ARCH_INT_ENABLE not defined for this architecture."
+# pragma message "Entry to MULTITHREADING=n app code will be with interrupts disabled."
+#endif
+}
+#endif
+
 /**
  *
  * @brief Initialize kernel
@@ -490,6 +502,7 @@ FUNC_NORETURN void _Cstart(void)
 	prepare_multithreading(dummy_thread);
 	switch_to_main_thread();
 #else
+	enable_interrupts();
 	bg_thread_main(NULL, NULL, NULL);
 
 	while (1) {


### PR DESCRIPTION
…ures

Some applications have a use case for a tiny MULTITHREADING=n build
(which lacks most of the kernel) but still want special-purpose
drivers in that mode that might need to handle interupts.  This
creates a chicken and egg problem, as arch code (for obvious reasons)
runs _Cstart() with interrupts disabled, and enables them only on
switching into a newly created thread context.  Zephyr does not have a
"turn interrupts on now, please" API at the architecture level.

So this creates one as an arch-specific wrapper around
_arch_irq_unlock().  It's implemented as an optional macro the arch
can define to enable this behavior, falling back to the previous
scheme (and printing a helpful message) if it doesn't find it defined.
Only ARM and x86 are enabled in this patch.

Fixes #8393

Signed-off-by: Andy Ross <andrew.j.ross@intel.com>