### PR TITLE
nrf52_pca10040: get the erase block size from dts

### DIFF
--- a/boards/arm/nrf52_pca10040/nrf52_pca10040.yaml
+++ b/boards/arm/nrf52_pca10040/nrf52_pca10040.yaml
@@ -7,3 +7,5 @@ toolchain:
   - gnuarmemb
 ram: 64
 flash: 512
+supported:
+  - nvs

--- a/dts/arm/nordic/nrf52832.dtsi
+++ b/dts/arm/nordic/nrf52832.dtsi
@@ -27,6 +27,7 @@
 				compatible = "soc-nv-flash";
 				label = "NRF_FLASH";
 				reg = <0x00000000 DT_FLASH_SIZE>;
+				erase-block-size = <4096>;
 				write-block-size = <4>;
 			};
 	};


### PR DESCRIPTION
Sample expect that to come from DTS, previously it was hardcoded in the
sample.

Signed-off-by: Anas Nashif <anas.nashif@intel.com>