### PR TITLE
LwM2M: Observe-related bugfixes

### DIFF
--- a/subsys/net/lib/lwm2m/lwm2m_engine.c
+++ b/subsys/net/lib/lwm2m/lwm2m_engine.c
@@ -413,6 +413,7 @@ static int engine_add_observer(struct lwm2m_message *msg,
 			       u16_t format)
 {
 	struct lwm2m_engine_obj *obj = NULL;
+	struct lwm2m_engine_obj_field *obj_field = NULL;
 	struct lwm2m_engine_obj_inst *obj_inst = NULL;
 	struct observe_node *obs;
 	struct sockaddr *addr;
@@ -500,6 +501,21 @@ static int engine_add_observer(struct lwm2m_message *msg,
 				    path->obj_id, path->obj_inst_id,
 				    path->res_id);
 			return -ENOENT;
+		}
+
+		/* load object field data */
+		obj_field = lwm2m_get_engine_obj_field(obj,
+				obj_inst->resources[i].res_id);
+		if (!obj_field) {
+			SYS_LOG_ERR("unable to find obj_field: %u/%u/%u",
+				    path->obj_id, path->obj_inst_id,
+				    path->res_id);
+			return -ENOENT;
+		}
+
+		/* check for READ permission on matching resource */
+		if (!LWM2M_HAS_PERM(obj_field, LWM2M_PERM_R)) {
+			return -EPERM;
 		}
 
 		ret = update_attrs(&obj_inst->resources[i], &attrs);

--- a/subsys/net/lib/lwm2m/lwm2m_engine.c
+++ b/subsys/net/lib/lwm2m/lwm2m_engine.c
@@ -3329,9 +3329,12 @@ static int handle_request(struct coap_packet *request,
 							accept);
 				if (r < 0) {
 					SYS_LOG_ERR("add OBSERVE error: %d", r);
+					goto error;
 				}
 			} else {
 				SYS_LOG_ERR("OBSERVE request missing token");
+				r = -EINVAL;
+				goto error;
 			}
 		} else if (observe == 1) {
 			/* remove observer */

--- a/subsys/net/lib/lwm2m/lwm2m_engine.c
+++ b/subsys/net/lib/lwm2m/lwm2m_engine.c
@@ -3337,7 +3337,7 @@ static int handle_request(struct coap_packet *request,
 			/* remove observer */
 			r = engine_remove_observer(token, tkl);
 			if (r < 0) {
-				SYS_LOG_ERR("remove obserer error: %d", r);
+				SYS_LOG_ERR("remove observe error: %d", r);
 			}
 		}
 
@@ -3665,7 +3665,7 @@ static int notify_message_reply_cb(const struct coap_packet *response,
 		if (reply->tkl > 0) {
 			ret = engine_remove_observer(reply->token, reply->tkl);
 			if (ret) {
-				SYS_LOG_ERR("remove obserer error: %d", ret);
+				SYS_LOG_ERR("remove observe error: %d", ret);
 			}
 		} else {
 			SYS_LOG_ERR("notify reply missing token -- ignored.");


### PR DESCRIPTION
This patch series mainly focuses on:
https://github.com/zephyrproject-rtos/zephyr/issues/8286

- Check for READ permission on observe requests against resources
- Fix a few error messages typos
- Return early when an error is generated during observe processing

Fixes https://github.com/zephyrproject-rtos/zephyr/issues/8286