### PR TITLE
Revert "sched: Properly account for timeslicing in tickless mode"

### DIFF
--- a/kernel/include/ksched.h
+++ b/kernel/include/ksched.h
@@ -47,7 +47,6 @@ void *_get_next_switch_handle(void *interrupted);
 struct k_thread *_find_first_thread_to_unpend(_wait_q_t *wait_q,
 					      struct k_thread *from);
 void idle(void *a, void *b, void *c);
-void _ready_thread(struct k_thread *thread);
 
 /* find which one is the next thread to run */
 /* must be called with interrupts locked */
@@ -215,6 +214,16 @@ static inline int _is_valid_prio(int prio, void *entry_point)
 	}
 
 	return 1;
+}
+
+static inline void _ready_thread(struct k_thread *thread)
+{
+	if (_is_thread_ready(thread)) {
+		_add_thread_to_ready_q(thread);
+	}
+
+	sys_trace_thread_ready(thread);
+
 }
 
 static inline void _ready_one_thread(_wait_q_t *wq)

--- a/kernel/sched.c
+++ b/kernel/sched.c
@@ -658,21 +658,6 @@ void _update_time_slice_before_swap(void)
 }
 #endif /* CONFIG_TIMESLICING */
 
-void _ready_thread(struct k_thread *thread)
-{
-	if (_is_thread_ready(thread)) {
-		_add_thread_to_ready_q(thread);
-	}
-
-#if defined(CONFIG_TICKLESS_KERNEL) && !defined(CONFIG_SMP)
-	if (_is_thread_time_slicing(_get_next_ready_thread())) {
-		_set_time(_time_slice_duration);
-	}
-#endif
-
-	sys_trace_thread_ready(thread);
-}
-
 int _unpend_all(_wait_q_t *waitq)
 {
 	int need_sched = 0;


### PR DESCRIPTION
This reverts commit bc6fb65c81c4a23685410c4cdf55df2922f2d209.

Causes MPU faults on multiple platforms.

Signed-off-by: Anas Nashif <anas.nashif@intel.com>