### PR TITLE
lib/cmsis_rtos_v1: Check if osKernelStart() is called from ISR

### DIFF
--- a/lib/cmsis_rtos_v1/cmsis_kernel.c
+++ b/lib/cmsis_rtos_v1/cmsis_kernel.c
@@ -31,7 +31,10 @@ osStatus osKernelInitialize(void)
  */
 osStatus osKernelStart(void)
 {
-	return osOK;
+	 if (_is_in_isr()) {
+		 return osErrorISR;
+	 }
+	 return osOK;
 }
 
 /**


### PR DESCRIPTION
Check if osKernelStart() is called from ISR and return error code
appropriately.

Signed-off-by: Spoorthi K <spoorthi.k@intel.com>