### PR TITLE
tests: net: Run networking tests only for selected platforms

### DIFF
--- a/tests/net/6lo/testcase.yaml
+++ b/tests/net/6lo/testcase.yaml
@@ -1,3 +1,5 @@
+common:
+  platform_whitelist: native_posix qemu_x86 qemu_cortex_m3
 tests:
   net.6lo:
     tags: net 6loWPAN

--- a/tests/net/all/testcase.yaml
+++ b/tests/net/all/testcase.yaml
@@ -1,6 +1,8 @@
+common:
+  # Only used for compile testing so it is enough to use one platform here.
+  platform_whitelist: qemu_x86
 tests:
   net.build:
     build_only: true
     min_ram: 32
-    platform_whitelist: qemu_x86
     tags: net

--- a/tests/net/app/testcase.yaml
+++ b/tests/net/app/testcase.yaml
@@ -1,5 +1,6 @@
 common:
   depends_on: netif
+  platform_whitelist: native_posix qemu_x86 qemu_cortex_m3
 tests:
   net.app:
     min_ram: 32

--- a/tests/net/arp/testcase.yaml
+++ b/tests/net/arp/testcase.yaml
@@ -1,5 +1,6 @@
 common:
   depends_on: netif
+  platform_whitelist: native_posix qemu_x86 qemu_cortex_m3
 tests:
   net.arp:
     min_ram: 16

--- a/tests/net/buf/testcase.yaml
+++ b/tests/net/buf/testcase.yaml
@@ -1,3 +1,5 @@
+common:
+  platform_whitelist: native_posix qemu_x86 qemu_cortex_m3
 tests:
   net.buf:
     min_ram: 16

--- a/tests/net/checksum_offload/testcase.yaml
+++ b/tests/net/checksum_offload/testcase.yaml
@@ -1,5 +1,6 @@
 common:
   depends_on: netif
+  platform_whitelist: native_posix qemu_x86 qemu_cortex_m3
 tests:
   net.offload:
     min_ram: 16

--- a/tests/net/context/testcase.yaml
+++ b/tests/net/context/testcase.yaml
@@ -1,5 +1,6 @@
 common:
   depends_on: netif
+  platform_whitelist: native_posix qemu_x86 qemu_cortex_m3
 tests:
   net.context:
     min_ram: 16

--- a/tests/net/dhcpv4/testcase.yaml
+++ b/tests/net/dhcpv4/testcase.yaml
@@ -1,5 +1,6 @@
 common:
   depends_on: netif
+  platform_whitelist: native_posix qemu_x86 qemu_cortex_m3
 tests:
   net.dhcp:
     tags: net dhcpv4

--- a/tests/net/ethernet_mgmt/testcase.yaml
+++ b/tests/net/ethernet_mgmt/testcase.yaml
@@ -1,5 +1,6 @@
 common:
   depends_on: netif
+  platform_whitelist: native_posix qemu_x86 qemu_cortex_m3
 tests:
   net.ethernet_mgmt:
     min_ram: 32

--- a/tests/net/icmpv6/testcase.yaml
+++ b/tests/net/icmpv6/testcase.yaml
@@ -1,6 +1,6 @@
 common:
   depends_on: netif
-  platform_whitelist: native_posix qemu_x86
+  platform_whitelist: native_posix qemu_x86 qemu_cortex_m3
 tests:
   net.icmpv6:
     min_ram: 16

--- a/tests/net/ieee802154/fragment/testcase.yaml
+++ b/tests/net/ieee802154/fragment/testcase.yaml
@@ -1,3 +1,5 @@
+common:
+  platform_whitelist: native_posix qemu_x86 qemu_cortex_m3
 tests:
   net.ieee802154.fragment:
     tags: net ieee802154 fragment

--- a/tests/net/ieee802154/l2/testcase.yaml
+++ b/tests/net/ieee802154/l2/testcase.yaml
@@ -1,3 +1,5 @@
+common:
+  platform_whitelist: native_posix qemu_x86 qemu_cortex_m3
 tests:
   net.ieee802154.l2:
     min_ram: 16

--- a/tests/net/iface/testcase.yaml
+++ b/tests/net/iface/testcase.yaml
@@ -1,3 +1,5 @@
+common:
+  platform_whitelist: native_posix qemu_x86 qemu_cortex_m3
 tests:
   net.iface:
     min_ram: 16

--- a/tests/net/ip-addr/testcase.yaml
+++ b/tests/net/ip-addr/testcase.yaml
@@ -1,5 +1,6 @@
 common:
   depends_on: netif
+  platform_whitelist: native_posix qemu_x86 qemu_cortex_m3
 tests:
   net.ip-addr:
     min_ram: 16

--- a/tests/net/ipv6/testcase.yaml
+++ b/tests/net/ipv6/testcase.yaml
@@ -1,3 +1,5 @@
+common:
+  platform_whitelist: native_posix qemu_x86 qemu_cortex_m3
 tests:
   net.ipv6:
     tags: net ipv6

--- a/tests/net/ipv6_fragment/testcase.yaml
+++ b/tests/net/ipv6_fragment/testcase.yaml
@@ -1,5 +1,6 @@
 common:
   depends_on: netif
+  platform_whitelist: native_posix qemu_x86 qemu_cortex_m3
 tests:
   net.ipv6.fragment:
     tags: net ipv6 fragment

--- a/tests/net/lib/coap/testcase.yaml
+++ b/tests/net/lib/coap/testcase.yaml
@@ -1,3 +1,5 @@
+common:
+  platform_whitelist: native_posix qemu_x86 qemu_cortex_m3
 tests:
   net.coap:
     min_ram: 16

--- a/tests/net/lib/dns_packet/testcase.yaml
+++ b/tests/net/lib/dns_packet/testcase.yaml
@@ -1,3 +1,5 @@
+common:
+  platform_whitelist: native_posix qemu_x86 qemu_cortex_m3
 tests:
   net.dns:
     min_ram: 16

--- a/tests/net/lib/dns_resolve/testcase.yaml
+++ b/tests/net/lib/dns_resolve/testcase.yaml
@@ -1,6 +1,7 @@
 common:
   tags: dns net
   depends_on: netif
+  platform_whitelist: native_posix qemu_x86 qemu_cortex_m3
 tests:
   net.dns:
     min_ram: 21

--- a/tests/net/lib/http_header_fields/testcase.yaml
+++ b/tests/net/lib/http_header_fields/testcase.yaml
@@ -1,6 +1,7 @@
 common:
   tags: http net
   depends_on: netif
+  platform_whitelist: native_posix qemu_x86 qemu_cortex_m3
 tests:
   net.http:
     min_ram: 16

--- a/tests/net/lib/mqtt_packet/testcase.yaml
+++ b/tests/net/lib/mqtt_packet/testcase.yaml
@@ -1,5 +1,6 @@
 common:
   depends_on: netif
+  platform_whitelist: native_posix qemu_x86 qemu_cortex_m3
 tests:
   net.mqtt.packet:
     min_ram: 16

--- a/tests/net/lib/mqtt_publisher/testcase.yaml
+++ b/tests/net/lib/mqtt_publisher/testcase.yaml
@@ -2,9 +2,9 @@ common:
   tags: net mqtt
   harness: net
   depends_on: netif
+  platform_whitelist: native_posix qemu_x86 qemu_cortex_m3
 tests:
   net.mqtt:
     min_ram: 16
   net.mqtt.tls:
-    platform_whitelist: frdm_k64f qemu_x86
     extra_args: CONF_FILE="prj_tls.conf"

--- a/tests/net/lib/mqtt_subscriber/testcase.yaml
+++ b/tests/net/lib/mqtt_subscriber/testcase.yaml
@@ -1,5 +1,6 @@
 common:
   depends_on: netif
+  platform_whitelist: native_posix qemu_x86 qemu_cortex_m3
 tests:
   net.mqtt.subscriber:
     min_ram: 16

--- a/tests/net/lib/tls_credentials/testcase.yaml
+++ b/tests/net/lib/tls_credentials/testcase.yaml
@@ -1,3 +1,5 @@
+common:
+  platform_whitelist: native_posix qemu_x86 qemu_cortex_m3
 tests:
   net.tls_credentials:
     tags: net tls

--- a/tests/net/mgmt/testcase.yaml
+++ b/tests/net/mgmt/testcase.yaml
@@ -1,5 +1,6 @@
 common:
   depends_on: netif
+  platform_whitelist: native_posix qemu_x86 qemu_cortex_m3
 tests:
   net.management:
     min_ram: 16

--- a/tests/net/mld/testcase.yaml
+++ b/tests/net/mld/testcase.yaml
@@ -1,3 +1,5 @@
+common:
+  platform_whitelist: native_posix qemu_x86 qemu_cortex_m3
 tests:
   net.mld:
     tags: net mld

--- a/tests/net/neighbor/testcase.yaml
+++ b/tests/net/neighbor/testcase.yaml
@@ -1,5 +1,6 @@
 common:
   depends_on: netif
+  platform_whitelist: native_posix qemu_x86 qemu_cortex_m3
 tests:
   net.neighbour:
     min_ram: 16

--- a/tests/net/net_pkt/testcase.yaml
+++ b/tests/net/net_pkt/testcase.yaml
@@ -1,5 +1,6 @@
 common:
   depends_on: netif
+  platform_whitelist: native_posix qemu_x86 qemu_cortex_m3
 tests:
   net.packet:
     min_ram: 20

--- a/tests/net/promiscuous/testcase.yaml
+++ b/tests/net/promiscuous/testcase.yaml
@@ -1,3 +1,5 @@
+common:
+  platform_whitelist: native_posix qemu_x86 qemu_cortex_m3
 tests:
   net.promisc:
     min_ram: 16

--- a/tests/net/ptp/clock/testcase.yaml
+++ b/tests/net/ptp/clock/testcase.yaml
@@ -1,5 +1,6 @@
 common:
   depends_on: netif
+  platform_whitelist: native_posix qemu_x86 qemu_cortex_m3
 tests:
   net.ptp.clock:
     min_ram: 32

--- a/tests/net/route/testcase.yaml
+++ b/tests/net/route/testcase.yaml
@@ -1,5 +1,6 @@
 common:
   depends_on: netif
+  platform_whitelist: native_posix qemu_x86 qemu_cortex_m3
 tests:
   net.route:
     min_ram: 16

--- a/tests/net/rpl/testcase.yaml
+++ b/tests/net/rpl/testcase.yaml
@@ -1,5 +1,6 @@
 common:
   depends_on: netif
+  platform_whitelist: native_posix qemu_x86 qemu_cortex_m3
 tests:
   net.rpl:
     min_ram: 16

--- a/tests/net/socket/getaddrinfo/testcase.yaml
+++ b/tests/net/socket/getaddrinfo/testcase.yaml
@@ -1,5 +1,6 @@
 common:
   depends_on: netif
+  platform_whitelist: native_posix qemu_x86 qemu_cortex_m3
 tests:
   net.socket:
     min_ram: 21

--- a/tests/net/socket/tcp/testcase.yaml
+++ b/tests/net/socket/tcp/testcase.yaml
@@ -1,5 +1,6 @@
 common:
   depends_on: netif
+  platform_whitelist: native_posix qemu_x86 qemu_cortex_m3
 tests:
   net.socket.tcp:
     min_ram: 32

--- a/tests/net/socket/udp/testcase.yaml
+++ b/tests/net/socket/udp/testcase.yaml
@@ -1,5 +1,6 @@
 common:
   depends_on: netif
+  platform_whitelist: native_posix qemu_x86 qemu_cortex_m3
 tests:
   net.socket.udp:
     extra_configs:

--- a/tests/net/tcp/testcase.yaml
+++ b/tests/net/tcp/testcase.yaml
@@ -1,3 +1,5 @@
+common:
+  platform_whitelist: native_posix qemu_x86 qemu_cortex_m3
 tests:
   net.tcp:
     depends_on: netif

--- a/tests/net/trickle/testcase.yaml
+++ b/tests/net/trickle/testcase.yaml
@@ -1,6 +1,6 @@
 common:
   depends_on: netif
-  platform_whitelist: native_posix qemu_x86
+  platform_whitelist: native_posix qemu_x86 qemu_cortex_m3
 tests:
   net.trickle:
     min_ram: 12

--- a/tests/net/tx_timestamp/testcase.yaml
+++ b/tests/net/tx_timestamp/testcase.yaml
@@ -1,3 +1,5 @@
+common:
+  platform_whitelist: native_posix qemu_x86 qemu_cortex_m3
 tests:
   net.timestamp:
     min_ram: 16

--- a/tests/net/udp/testcase.yaml
+++ b/tests/net/udp/testcase.yaml
@@ -1,5 +1,6 @@
 common:
   depends_on: netif
+  platform_whitelist: native_posix qemu_x86 qemu_cortex_m3
 tests:
   net.udp:
     min_ram: 20

--- a/tests/net/utils/testcase.yaml
+++ b/tests/net/utils/testcase.yaml
@@ -1,6 +1,6 @@
 common:
   depends_on: netif
-  platform_whitelist: native_posix qemu_x86
+  platform_whitelist: native_posix qemu_x86 qemu_cortex_m3
 tests:
   net.util:
     min_ram: 24

--- a/tests/net/vlan/testcase.yaml
+++ b/tests/net/vlan/testcase.yaml
@@ -1,5 +1,6 @@
 common:
   depends_on: netif
+  platform_whitelist: native_posix qemu_x86 qemu_cortex_m3
 tests:
   net.vlan:
     min_ram: 32

--- a/tests/net/websocket/src/main.c
+++ b/tests/net/websocket/src/main.c
@@ -569,10 +569,6 @@ void test_v4_send_multi_msg(void)
 	test_send_multi_msg(&app_ctx_v4);
 }
 
-static void test_setup(void)
-{
-	return;
-}
 void test_main(void)
 {
 	ztest_test_suite(websocket,
@@ -588,7 +584,7 @@ void test_main(void)
 			 ztest_unit_test(test_v6_send_recv_6),
 			 ztest_unit_test(test_v6_send_recv_7),
 			 ztest_unit_test(test_v6_send_multi_msg),
-			 ztest_unit_test_setup_teardown(test_v6_close, test_setup, websocket_cleanup_server),
+			 ztest_unit_test(test_v6_close),
 			 ztest_unit_test(test_websocket_init_server),
 			 ztest_unit_test(test_v4_init),
 			 ztest_unit_test(test_v4_connect),
@@ -600,7 +596,7 @@ void test_main(void)
 			 ztest_unit_test(test_v4_send_recv_6),
 			 ztest_unit_test(test_v4_send_recv_7),
 			 ztest_unit_test(test_v4_send_multi_msg),
-			 ztest_unit_test_setup_teardown(test_v4_close, test_setup, websocket_cleanup_server)
+			 ztest_unit_test(test_v4_close)
 			 );
 
 	ztest_run_test_suite(websocket);

--- a/tests/net/websocket/src/server.c
+++ b/tests/net/websocket/src/server.c
@@ -357,9 +357,3 @@ void test_websocket_init_server(void)
 
 	ws_ctx = &http_ctx;
 }
-
-void websocket_cleanup_server(void)
-{
-	http_server_disable(&http_ctx);
-	http_release(&http_ctx);
-}

--- a/tests/net/websocket/testcase.yaml
+++ b/tests/net/websocket/testcase.yaml
@@ -1,5 +1,6 @@
 common:
   depends_on: netif
+  platform_whitelist: native_posix qemu_x86 qemu_cortex_m3
 tests:
   net.websocket:
       min_ram: 46


### PR DESCRIPTION
Run networking tests for native_posix, qemu_x86 and qemu_cortex_m3
platforms only as the tests are generic enough so no need to run
them in real physical device.

Signed-off-by: Jukka Rissanen <jukka.rissanen@linux.intel.com>