### PR TITLE
Revert "sam_e70: enable instruction and data caches on sam_e70"

### DIFF
--- a/arch/arm/soc/atmel_sam/same70/soc.c
+++ b/arch/arm/soc/atmel_sam/same70/soc.c
@@ -227,11 +227,6 @@ static int atmel_same70_init(struct device *arg)
 
 	key = irq_lock();
 
-	SCB_EnableICache();
-	if (!(SCB->CCR & SCB_CCR_DC_Msk)) {
-		SCB_EnableDCache();
-	}
-
 	/* Clear all faults */
 	_ClearFaults();
 


### PR DESCRIPTION
Reverts zephyrproject-rtos/zephyr#9647

We need to revert this PR. seems to be breaking a few things inside sam e70.
We can recreate this PR once we understand how the cache is behaving when the MPU is turned on.
Currently all MPU regions always disable the cache. So when we enable the cache in soc init and disable them in the mpu regions init. We might be causing some issue.
Until root cause is found we should revert this.

This reverts commit c0907762f3f15116732f434937fc3a5737c3d40b.