### PR TITLE
doc: fix wrong board name in NXP LPCXpresso54114 doc

### DIFF
--- a/boards/arm/lpcxpresso54114_m0/doc/lpcxpresso54114_m0.rst
+++ b/boards/arm/lpcxpresso54114_m0/doc/lpcxpresso54114_m0.rst
@@ -36,7 +36,7 @@ You can debug an application in the usual way. Here is an example for the
 
 .. zephyr-app-commands::
    :zephyr-app: samples/subsys/ipc/ipm_mcux
-   :board: lpcxpresso54114
+   :board: lpcxpresso54114_m4
    :goals: debug
 
 Open a serial terminal (minicom, putty, etc.) and connect the board with the

--- a/boards/arm/lpcxpresso54114_m4/doc/lpcxpresso54114.rst
+++ b/boards/arm/lpcxpresso54114_m4/doc/lpcxpresso54114.rst
@@ -1,7 +1,7 @@
 .. _lpcxpresso54114:
 
-NXP LPCXPRESSO54114
-#####################
+NXP LPCXPRESSO54114 (M4 Core)
+#############################
 
 Overview
 ********
@@ -127,7 +127,7 @@ You can debug an application in the usual way. Here is an example for the
 
 .. zephyr-app-commands::
    :zephyr-app: samples/hello_world
-   :board: lpcxpresso54114
+   :board: lpcxpresso54114_m4
    :goals: debug
 
 Open a serial terminal (minicom, putty, etc.) and connect the board with the


### PR DESCRIPTION
The LPCXpresso54114 command line example was using a wrong board
name which has been renamed after adding the support for the
Cortex-M0+ core.

Fixes #9649

Signed-off-by: Stanislav Poboril <stanislav.poboril@nxp.com>