### PR TITLE
 arch: st_stm32: Remove I2C and SPI instances from common defconfig

### DIFF
--- a/arch/arm/soc/st_stm32/common/Kconfig.defconfig.series
+++ b/arch/arm/soc/st_stm32/common/Kconfig.defconfig.series
@@ -51,14 +51,14 @@ config PWM_STM32
 
 endif # PWM
 
-if SPI && (SPI_1 || SPI_2 || SPI_3)
+if SPI
 
 config SPI_STM32
 	def_bool y
 
 endif # SPI
 
-if I2C && (I2C_1 || I2C_2 || I2C_3)
+if I2C
 
 config I2C_STM32
 	def_bool y


### PR DESCRIPTION
Remove I2C and SPI instances when enabling I2C_STM32 and
SPI_STM32 drivers.

It allows to enable the drivers if ports I2C_4, SPI_4,
SPI_5, SPI_6 are selected.

Signed-off-by: Yannis Damigos <giannis.damigos@gmail.com>