### PR TITLE
sched: Properly account for timeslicing in tickless mode (take two)

### DIFF
--- a/kernel/include/ksched.h
+++ b/kernel/include/ksched.h
@@ -47,6 +47,7 @@ void *_get_next_switch_handle(void *interrupted);
 struct k_thread *_find_first_thread_to_unpend(_wait_q_t *wait_q,
 					      struct k_thread *from);
 void idle(void *a, void *b, void *c);
+void z_reset_timeslice(void);
 
 /* find which one is the next thread to run */
 /* must be called with interrupts locked */
@@ -221,6 +222,10 @@ static inline void _ready_thread(struct k_thread *thread)
 	if (_is_thread_ready(thread)) {
 		_add_thread_to_ready_q(thread);
 	}
+
+#if defined(CONFIG_TICKLESS_KERNEL) && !defined(CONFIG_SMP)
+	z_reset_timeslice();
+#endif
 
 	sys_trace_thread_ready(thread);
 

--- a/kernel/sched.c
+++ b/kernel/sched.c
@@ -632,6 +632,15 @@ int _is_thread_time_slicing(struct k_thread *thread)
 	return ret;
 }
 
+#ifdef CONFIG_TICKLESS_KERNEL
+void z_reset_timeslice(void)
+{
+	if (_is_thread_time_slicing(_get_next_ready_thread())) {
+		_set_time(_time_slice_duration);
+	}
+}
+#endif
+
 /* Must be called with interrupts locked */
 /* Should be called only immediately before a thread switch */
 void _update_time_slice_before_swap(void)


### PR DESCRIPTION
The first version of this patch caused a bunch of failures on ARM hardware platforms because, apparently, of the change of _ready_thread() from an inline to a proper function.  I don't have an answer for why that happens and am continuing to investigate.

But this patch seems to work (it really should!  It's a proper noop on builds without CONFIG_TICKLESS_KERNEL) and fixes the original bug.