### PR TITLE
doc: fix kconfig misspellings

### DIFF
--- a/arch/arm/core/Kconfig
+++ b/arch/arm/core/Kconfig
@@ -120,7 +120,7 @@ config ARM_NSC_REGION_BASE_ADDRESS
 	  - Certain requirements/restrictions may apply regarding
 	  the size and the alignment of the starting address for
 	  a Non-Secure Callable section, depending on the available
-	  security atttribution unit (SAU or IDAU) for a given SOC.
+	  security attribution unit (SAU or IDAU) for a given SOC.
 
 config ARM_ENTRY_VENEERS_LIB_NAME
 	string "Entry Veneers symbol file"

--- a/kernel/Kconfig.power_mgmt
+++ b/kernel/Kconfig.power_mgmt
@@ -25,7 +25,7 @@ config PM_CONTROL_APP
 	bool
 	prompt "Handled at Application level"
 	help
-	  This option enbles the Application to handle all the Power
+	  This option enables the Application to handle all the Power
 	  Management flows for the platform.
 
 config PM_CONTROL_OS

--- a/subsys/bluetooth/host/Kconfig
+++ b/subsys/bluetooth/host/Kconfig
@@ -250,7 +250,7 @@ config BT_AUTO_PHY_UPDATE
 
 	  Disable this if you want PHY Update Procedure feature supported but
 	  want to rely on remote device to initiate the procedure at its
-	  descretion.
+	  discretion.
 
 config BT_SMP
 	bool "Security Manager Protocol support"

--- a/subsys/net/l2/openthread/Kconfig
+++ b/subsys/net/l2/openthread/Kconfig
@@ -127,7 +127,7 @@ config OPENTHREAD_NETWORK_NAME
 	string "Default network name"
 	default "ot_zephyr"
 	help
-	  Network name for Openthread
+	  Network name for OpenThread
 
 config OPENTHREAD_XPANID
 	string "Default Extended PAN ID"


### PR DESCRIPTION
Fix misspellings in kconfig files missed during regular reviews

Signed-off-by: David B. Kinder <david.b.kinder@intel.com>