### PR TITLE
doc: fix misspellings in API documentation

### DIFF
--- a/include/bluetooth/bluetooth.h
+++ b/include/bluetooth/bluetooth.h
@@ -110,7 +110,7 @@ int bt_set_id_addr(const bt_addr_le_t *addr);
  *
  *  @param addrs Array where to store the configured identities.
  *  @param count Should be initialized to the array size. Once the function
- *               returns it will contain the number of returned identies.
+ *               returns it will contain the number of returned identities.
  */
 void bt_id_get(bt_addr_le_t *addrs, size_t *count);
 

--- a/include/logging/log_ctrl.h
+++ b/include/logging/log_ctrl.h
@@ -147,7 +147,7 @@ void log_filter_set(struct log_backend const *const backend,
  * @brief Enable backend with initial maximum filtering level.
  *
  * @param backend	Backend instance.
- * @param ctx		User csontext.
+ * @param ctx		User context.
  * @param level		Severity level.
  */
 void log_backend_enable(struct log_backend const *const backend,

--- a/include/net/net_pkt.h
+++ b/include/net/net_pkt.h
@@ -1196,7 +1196,7 @@ static inline bool net_pkt_append_all(struct net_pkt *pkt, u16_t len,
  *
  * @param pkt Network packet.
  * @param len Total length of input data
- * @param data Byte to initialise fragment with
+ * @param data Byte to initialize fragment with
  * @param timeout Affects the action taken should the net buf pool be empty.
  *        If K_NO_WAIT, then return immediately. If K_FOREVER, then
  *        wait as long as necessary. Otherwise, wait up to the specified


### PR DESCRIPTION
Fix misspellings in doxygen API comments missed during regular reviews.

Signed-off-by: David B. Kinder <david.b.kinder@intel.com>