### PR TITLE
[DNM] pyOCD frequency support

### DIFF
--- a/boards/arm/nrf52840_pca10059/board.cmake
+++ b/boards/arm/nrf52840_pca10059/board.cmake
@@ -1,6 +1,6 @@
 board_runner_args(nrfjprog "--nrf-family=NRF52")
 board_runner_args(jlink "--device=nrf52" "--speed=4000")
-board_runner_args(pyocd "--target=nrf52840")
+board_runner_args(pyocd "--target=nrf52840" "--frequency=4000000")
 include(${ZEPHYR_BASE}/boards/common/nrfjprog.board.cmake)
 include(${ZEPHYR_BASE}/boards/common/jlink.board.cmake)
 include(${ZEPHYR_BASE}/boards/common/pyocd.board.cmake)

--- a/boards/arm/nrf52_adafruit_feather/board.cmake
+++ b/boards/arm/nrf52_adafruit_feather/board.cmake
@@ -1,6 +1,6 @@
 board_runner_args(nrfjprog "--nrf-family=NRF52")
 board_runner_args(jlink "--device=nrf52" "--speed=4000")
-board_runner_args(pyocd "--target=nrf52")
+board_runner_args(pyocd "--target=nrf52" "--frequency=4000000")
 include(${ZEPHYR_BASE}/boards/common/nrfjprog.board.cmake)
 include(${ZEPHYR_BASE}/boards/common/jlink.board.cmake)
 include(${ZEPHYR_BASE}/boards/common/pyocd.board.cmake)


### PR DESCRIPTION
Add support for specifying the SWDCLK frequency in Hz for pyOCD and use it for the nrf52840_pca10059 and nrf52_adafruit_feather boards (I have not been able to test it with other boards).