### PR TITLE
tests: crypto: sha256: Add the missing test case for execution

### DIFF
--- a/tests/crypto/sha256/src/main.c
+++ b/tests/crypto/sha256/src/main.c
@@ -30,6 +30,7 @@ void test_main(void)
 		ztest_unit_test(test_sha256_5),
 		ztest_unit_test(test_sha256_6),
 		ztest_unit_test(test_sha256_7),
+		ztest_unit_test(test_sha256_8),
 		ztest_unit_test(test_sha256_9),
 		ztest_unit_test(test_sha256_10),
 		ztest_unit_test(test_sha256_11),


### PR DESCRIPTION
Add the missing sha256 crytographic algorithm testcase for
execution via ztest. The sub test case was not getting executed
as it was missed to be added in ztest suite.

Signed-off-by: Praful Swarnakar <praful.swarnakar@intel.com>