### PR TITLE
dts/st: fix stm32l4 gpioh node address

### DIFF
--- a/dts/arm/st/stm32l4.dtsi
+++ b/dts/arm/st/stm32l4.dtsi
@@ -90,7 +90,7 @@
 				label = "GPIOC";
 			};
 
-			gpioh: gpio@480001c00 {
+			gpioh: gpio@48001c00 {
 				compatible = "st,stm32-gpio";
 				gpio-controller;
 				#gpio-cells = <2>;

--- a/dts/arm/st/stm32l496.dtsi
+++ b/dts/arm/st/stm32l496.dtsi
@@ -24,7 +24,7 @@
 		pinctrl: pin-controller@48000000 {
 			reg = <0x48000000 0x2400>;
 
-			gpioi: gpio@480002000 {
+			gpioi: gpio@48002000 {
 				compatible = "st,stm32-gpio";
 				gpio-controller;
 				#gpio-cells = <2>;


### PR DESCRIPTION
Fix erroneous address header in stm32l4.dtsi

Signed-off-by: Erwan Gouriou <erwan.gouriou@linaro.org>