### PR TITLE
boards: x86: arduino_101: set DISK_FLASH_MAX_RW_SIZE to 256

### DIFF
--- a/boards/x86/arduino_101/Kconfig.defconfig
+++ b/boards/x86/arduino_101/Kconfig.defconfig
@@ -40,7 +40,7 @@ config DISK_FLASH_START
 	default 0x0
 
 config DISK_FLASH_MAX_RW_SIZE
-	default 1024
+	default 256
 
 config DISK_ERASE_BLOCK_SIZE
 	default 0x1000


### PR DESCRIPTION
set DISK_FLASH_MAX_RW_SIZE to 256, as maximum bytes that can be
programed to SPI FLASH by Page Program Command is 256.

Fixes #8506

Signed-off-by: Savinay Dharmappa <savinay.dharmappa@intel.com>