### PR TITLE
arch: stm32l4: Enable gpio interrupts correctly

### DIFF
--- a/arch/arm/soc/st_stm32/stm32l4/soc_gpio.c
+++ b/arch/arm/soc/st_stm32/stm32l4/soc_gpio.c
@@ -156,7 +156,7 @@ int stm32_gpio_enable_int(int port, int pin)
 		return -EINVAL;
 	}
 
-	*reg &= STM32L4X_SYSCFG_EXTICR_PIN_MASK << ((pin % 4) * 4);
+	*reg &= ~(STM32L4X_SYSCFG_EXTICR_PIN_MASK << ((pin % 4) * 4));
 	*reg |= port << ((pin % 4) * 4);
 
 	return 0; /* Nothing to do here for STM32L4s */


### PR DESCRIPTION
Enable gpio interrupts correctly and don't
disable the already enabled interrupts.

Fixes #9630

Signed-off-by: Yannis Damigos <giannis.damigos@gmail.com>