### PR TITLE
Sanitycheck fixes

### DIFF
--- a/scripts/sanity_chk/harness.py
+++ b/scripts/sanity_chk/harness.py
@@ -64,7 +64,8 @@ class Test(Harness):
             "MPU FAULT",
             "Kernel Panic",
             "Kernel OOPS",
-            "BUS FAULT"
+            "BUS FAULT",
+            "CPU Page Fault"
             ]
 
     def handle(self, line):

--- a/scripts/sanity_chk/harness.py
+++ b/scripts/sanity_chk/harness.py
@@ -12,6 +12,7 @@ class Harness:
         self.tests = {}
         self.id = None
         self.fail_on_fault = True
+        self.fault = False
 
     def configure(self, instance):
         config = instance.test.harness_config
@@ -76,7 +77,10 @@ class Test(Harness):
             self.tests[name] = match.group(1)
 
         if self.RUN_PASSED in line:
-            self.state = "passed"
+            if self.fault:
+                self.state = "failed"
+            else:
+                self.state = "passed"
 
         if self.RUN_FAILED in line:
             self.state = "failed"
@@ -84,5 +88,5 @@ class Test(Harness):
         if self.fail_on_fault:
             for fault in self.faults:
                 if fault in line:
-                    self.state = "failed"
+                    self.fault = True
 

--- a/scripts/sanitycheck
+++ b/scripts/sanitycheck
@@ -526,13 +526,15 @@ class QEMUHandler(Handler):
         timeout_time = start_time + timeout
         p = select.poll()
         p.register(in_fp, select.POLLIN)
+        out_state = None
 
         metrics = {}
         line = ""
         while True:
             this_timeout = int((timeout_time - time.time()) * 1000)
             if this_timeout < 0 or not p.poll(this_timeout):
-                out_state = "timeout"
+                if not out_state:
+                    out_state = "timeout"
                 break
 
             try:
@@ -558,8 +560,20 @@ class QEMUHandler(Handler):
 
             harness.handle(line)
             if harness.state:
-                out_state = harness.state
-                break
+                # if we have registered a fail make sure the state is not
+                # overridden by a false success message coming from the
+                # testsuite
+                if out_state != 'failed':
+                    out_state = harness.state
+
+                # if we get some state, that means test is doing well, we reset
+                # the timeout and wait for 5 more seconds just in case we have
+                # crashed after test has completed
+
+                if harness.type:
+                    break
+                else:
+                    timeout_time = time.time() + 2
 
             # TODO: Add support for getting numerical performance data
             # from test cases. Will involve extending test case reporting

--- a/tests/kernel/mem_protect/syscalls/testcase.yaml
+++ b/tests/kernel/mem_protect/syscalls/testcase.yaml
@@ -1,4 +1,4 @@
 tests:
   kernel.memory_protection.syscalls:
     filter: CONFIG_ARCH_HAS_USERSPACE
-    tags: core security userspace
+    tags: core security userspace ignore_faults


### PR DESCRIPTION
* tests: syscalls: ignore faults, they are intentional

  We are blowing up the kernel here intentionally, so ignore the faults on some 
  platforms. 

* sanitycheck: do not abort logging on faults 

  We have been dropping lines after finding a fault which resulted in missing 
  information in the log. Make sure we continue and only report failure at the end 
   of the execution. 

* sanitycheck: capture delayed faults

  Do not close console after PASS is reported, wait a bit for any remaining 
  messages from the tests, sometimes we have faults that need to be parsed. This 
  now works for Qemu handler, support for other handlers to follow.

Fixes #9646