### PR TITLE
tests: gen_isr_table: Add barriers after triggering the irq

### DIFF
--- a/tests/kernel/gen_isr_table/src/main.c
+++ b/tests/kernel/gen_isr_table/src/main.c
@@ -98,6 +98,7 @@ void isr4(void *param)
 	trigger_check[ISR4_OFFSET]++;
 }
 
+#ifndef CONFIG_CPU_CORTEX_M
 /* Need to turn optimization off. Otherwise compiler may generate incorrect
  * code, not knowing that trigger_irq() affects the value of trigger_check,
  * even if declared volatile.
@@ -107,11 +108,16 @@ void isr4(void *param)
  * accesses to trigger_check around calls to trigger_irq.
  */
 __attribute__((optimize("-O0")))
+#endif
 int test_irq(int offset)
 {
 #ifndef NO_TRIGGER_FROM_SW
 	TC_PRINT("triggering irq %d\n", IRQ_LINE(offset));
 	trigger_irq(IRQ_LINE(offset));
+#ifdef CONFIG_CPU_CORTEX_M
+	__DSB();
+	__ISB();
+#endif
 	if (trigger_check[offset] != 1) {
 		TC_PRINT("interrupt %d didn't run once, ran %d times\n",
 			 IRQ_LINE(offset),


### PR DESCRIPTION
Fixes the gen_isr_table kernel test on mimxrt1050_evk by using data and
instruction synchronization barriers instead of disabling compiler
optimization on arm platforms. According to [1] section 4.5, "if a
pended interrupt request needs to be recognized immediately after being
enabled in the NVIC, add a DSB instruction and then an ISB instruction"

[1] http://infocenter.arm.com/help/index.jsp?topic=/com.arm.doc.dai0321a/BIHJDAAE.html

Signed-off-by: Maureen Helm <maureen.helm@nxp.com>

Fixes #9441