### PR TITLE
kernel: Fix list-node add again corruption case in timeout handling

### DIFF
--- a/kernel/include/timeout_q.h
+++ b/kernel/include/timeout_q.h
@@ -109,9 +109,9 @@ static inline void _handle_one_expired_timeout(struct _timeout *timeout)
 
 static inline void _handle_expired_timeouts(sys_dlist_t *expired)
 {
-	struct _timeout *timeout;
+	struct _timeout *timeout, *next;
 
-	SYS_DLIST_FOR_EACH_CONTAINER(expired, timeout, node) {
+	SYS_DLIST_FOR_EACH_CONTAINER_SAFE(expired, timeout, next, node) {
 		_handle_one_expired_timeout(timeout);
 	}
 }


### PR DESCRIPTION
The node of the timeout temporary list cannot be continued to
index the next node after being added again.

Fixes #10055

Signed-off-by: Findlay Feng <i@fengch.me>