### PR TITLE
Bluetooth: Fix using correct IRK when generating RPA

### DIFF
--- a/subsys/bluetooth/host/hci_core.c
+++ b/subsys/bluetooth/host/hci_core.c
@@ -375,7 +375,7 @@ static int le_set_private_addr(u8_t id)
 		return 0;
 	}
 
-	err = bt_rpa_create(bt_dev.irk[0], &rpa);
+	err = bt_rpa_create(bt_dev.irk[id], &rpa);
 	if (!err) {
 		err = set_random_address(&rpa);
 		if (!err) {


### PR DESCRIPTION
The code in le_set_private_addr() was hardcoding identity 0, even
though it is given a specific identity as an input parameter.

Signed-off-by: Johan Hedberg <johan.hedberg@intel.com>