### PR TITLE
net: dhcpv4: Do not debug print IP address using NULL pointer

### DIFF
--- a/subsys/net/ip/dhcpv4.c
+++ b/subsys/net/ip/dhcpv4.c
@@ -322,7 +322,7 @@ static u32_t dhcpv4_send_request(struct net_if *iface)
 	NET_DBG("send request dst=%s xid=0x%x ciaddr=%s%s%s timeout=%us",
 		net_sprint_ipv4_addr(server_addr),
 		iface->config.dhcpv4.xid,
-		net_sprint_ipv4_addr(ciaddr),
+		ciaddr ? net_sprint_ipv4_addr(ciaddr) : "<unknown>",
 		with_server_id ? " +server-id" : "",
 		with_requested_ip ? " +requested-ip" : "",
 		timeout);


### PR DESCRIPTION
The ciaddr can be null in requesting state so do not try to print
it in that case.

Fixes #9575

Signed-off-by: Jukka Rissanen <jukka.rissanen@linux.intel.com>