### PR TITLE
Bluetooth: IPSP: Fix pointing to invalid file

### DIFF
--- a/samples/bluetooth/ipsp/README.rst
+++ b/samples/bluetooth/ipsp/README.rst
@@ -18,8 +18,8 @@ Zephyr tree.
 Testing with a Linux host
 =========================
 
-To test IPSP please take a look at samples/net/README, in addition to running
-echo-client you must enable 6LowPAN module in Linux with the following commands
+Make sure the Linux kernel has been built with Bluetooth 6LoWPAN module
+(CONFIG_BT_6LOWPAN=y) then proceed to enable it with with the following commands
 (as root):
 
 .. code-block:: console


### PR DESCRIPTION
sample/net/README no longer exists so this removes its mention since
it is already described how to use echo-client at the end of the
document. Also state that CONFIG_BT_6LOWPAN shall be set in order to
use Bluetooth 6LoWPAN module with Linux.

Fixes #9727

Signed-off-by: Luiz Augusto von Dentz <luiz.von.dentz@intel.com>