### PR TITLE
tests: no-multithreading: disable on xtensa

### DIFF
--- a/tests/kernel/threads/no-multithreading/testcase.yaml
+++ b/tests/kernel/threads/no-multithreading/testcase.yaml
@@ -6,3 +6,4 @@ tests:
     # Pulls in GPIO by default, which needs missing APIs (why?!), but
     # its headers won't build with GPIO disabled.
     platform_exclude: galileo
+    arch_exclude: xtensa


### PR DESCRIPTION
Corner case that has been failing for a while and was not caught by
sanitycheck. Now sanitycheck finds that, so exclude xtensa and track
this in bug #9703.

Signed-off-by: Anas Nashif <anas.nashif@intel.com>