### PR TITLE
tests/kernel/threads/no-multithreading: Disable USERSPACE

### DIFF
--- a/kernel/init.c
+++ b/kernel/init.c
@@ -505,6 +505,7 @@ FUNC_NORETURN void _Cstart(void)
 	enable_interrupts();
 	bg_thread_main(NULL, NULL, NULL);
 
+	irq_lock();
 	while (1) {
 	}
 #endif

--- a/tests/kernel/threads/no-multithreading/prj.conf
+++ b/tests/kernel/threads/no-multithreading/prj.conf
@@ -1,5 +1,12 @@
 CONFIG_ZTEST=y
 CONFIG_MULTITHREADING=n
-CONFIG_USERSPACE=n
 CONFIG_BT=n
 CONFIG_USB=n
+
+# Running without multithreading implies the lack of MMU support.
+# Setting CONFIG_USERSPACE=n alone is not enough to disable userspace.
+# The TEST_USERSPACE symbol (designed to enable userspace by default
+# on tests platforms that support it) defaults to =y and will
+# automatically select it back.
+CONFIG_TEST_USERSPACE=n
+CONFIG_USERSPACE=n


### PR DESCRIPTION
Building with !MULTITHREADING is designed for bootloaders and similar
minimal-functionality use cases.  It's pathologically silly to combine
it with MMU drivers and address space partitioning, even though on
some architectures that technically works (on ARM, it seems not to).

The test intent was to disable this originally, but it turns out that
doesn't work.  There is a TEST_USERSPACE kconfig symbol that also
needs to be explicitly turned off, otherwise it will reselect
USERSPACE against our wishes.

Signed-off-by: Andy Ross <andrew.j.ross@intel.com>