### PR TITLE
Fix mempool lock

### DIFF
--- a/include/misc/mempool.h
+++ b/include/misc/mempool.h
@@ -59,7 +59,7 @@ struct sys_mem_pool_block {
 			.n_max = nmax,					\
 			.n_levels = _MPOOL_LVLS(maxsz, minsz),		\
 			.levels = _mpool_lvls_##name,			\
-			.flags = SYS_MEM_POOL_KERNEL			\
+			.flags = SYS_MEM_POOL_USER			\
 		},							\
 		.mutex = kmutex,					\
 	}

--- a/include/misc/mempool_base.h
+++ b/include/misc/mempool_base.h
@@ -23,8 +23,8 @@ struct sys_mem_pool_lvl {
 	sys_dlist_t free_list;
 };
 
-#define SYS_MEM_POOL_KERNEL	0
-#define SYS_MEM_POOL_USER	1
+#define SYS_MEM_POOL_KERNEL	BIT(0)
+#define SYS_MEM_POOL_USER	BIT(1)
 
 struct sys_mem_pool_base {
 	void *buf;


### PR DESCRIPTION
SYS_MEM_POOL_KERNEL must be defined as bitmask, otherwise we end up with code that will never run