### PR TITLE
kernel: Disable tick handling when !MULTITHREADING

### DIFF
--- a/include/drivers/system_timer.h
+++ b/include/drivers/system_timer.h
@@ -65,8 +65,13 @@ extern int sys_clock_device_ctrl(struct device *device,
 #endif
 
 extern s32_t _sys_idle_elapsed_ticks;
+
+#ifdef CONFIG_MULTITHREADING
 #define _sys_clock_tick_announce() \
 		_nano_sys_clock_tick_announce(_sys_idle_elapsed_ticks)
+#else
+#define _sys_clock_tick_announce() /**/
+#endif
 
 /**
  * @brief Account for the tick due to the timer interrupt


### PR DESCRIPTION
[The specific bug being addressed here is that the NRF5x timer is enabled always, gets picked up by tests/kernel/threads/no-multithreading, and then starts firing ticks into the timer subsystem that the kernel isn't configured to handle.  Unfortunately there's no way to disable "the system timer" in kconfig distinct from board-specific DTS, and the subject is complicated.  The nrf driver handles clock scaling and power/idle too, and a bootloader might want that.]

The kernel timer subsystem isn't part of the !MULTITHREADING
environment (no threads to wake up, though in principle it should be
possible to support timeout callbacks with some work in the future).
Protect it against platforms that select this but still enable a timer
driver.

Signed-off-by: Andy Ross <andrew.j.ross@intel.com>