### PR TITLE
Replace ifdefs in net_context

### DIFF
--- a/include/net/net_if.h
+++ b/include/net/net_if.h
@@ -551,6 +551,9 @@ static inline struct net_offload *net_if_offload(struct net_if *iface)
 {
 	return iface->if_dev->offload;
 }
+#else
+#define net_if_is_ip_offloaded(...) false
+#define net_if_offload(...) NULL
 #endif
 
 /**
@@ -1266,9 +1269,50 @@ void net_if_ipv6_dad_failed(struct net_if *iface, const struct in6_addr *addr);
  * @return Pointer to IPv6 address, NULL if not found.
  */
 struct in6_addr *net_if_ipv6_get_global_addr(struct net_if **iface);
+
 #else
-#define net_if_ipv6_select_src_addr(...)
+#define net_if_config_ipv6_get(...) -EOPNOTSUPP
+#define net_if_config_ipv6_put(...) -EOPNOTSUPP
+#define net_if_ipv6_addr_lookup(...) NULL
+#define net_if_ipv6_addr_lookup_by_iface(...) NULL
+#define net_if_ipv6_addr_add(...) NULL
+#define net_if_ipv6_addr_update_lifetime(...)
+#define net_if_ipv6_prefix_rm(...) false
+#define net_if_ipv6_maddr_add(...) NULL
+#define net_if_ipv6_maddr_rm(...) false
+#define net_if_ipv6_maddr_lookup(...) NULL
+#define net_if_mcast_mon_register(...)
+#define net_if_mcast_mon_unregister(...)
+#define net_if_mcast_monitor(...)
+#define net_if_ipv6_maddr_join(...)
+#define net_if_ipv6_maddr_is_joined(...) false
+#define net_if_ipv6_maddr_leave(...)
+#define net_if_ipv6_prefix_lookup(...) NULL
+#define net_if_ipv6_prefix_add(...)
+#define net_if_ipv6_prefix_rm(...) false
+#define net_if_ipv6_prefix_set_lf(...)
+#define net_if_ipv6_prefix_set_timer(...)
+#define net_if_ipv6_prefix_unset_timer(...)
+#define net_if_ipv6_addr_onlink(...) false
+#define net_if_ipv6_router_lookup(...) NULL
+#define net_if_ipv6_router_find_default(...) NULL
+#define net_if_ipv6_router_update_lifetime(...)
+#define net_if_ipv6_router_add(...) NULL
+#define net_if_ipv6_router_rm(...) false
+#define net_if_ipv6_get_hop_limit(...) 0
+#define net_ipv6_set_hop_limit(...)
+#define net_if_ipv6_set_base_reachable_time(...)
+#define net_if_ipv6_get_reachable_time(...) 0
+#define net_if_ipv6_calc_reachable_time(...) 0
+#define net_if_ipv6_set_reachable_time(...)
+#define net_if_ipv6_set_retrans_timer(...)
+#define net_if_ipv6_get_retrans_timer(...) 0
+#define net_if_ipv6_select_src_addr(...) NULL
 #define net_if_ipv6_select_src_iface(...) NULL
+#define net_if_ipv6_get_ll(...) NULL
+#define net_if_ipv6_get_ll_addr(...) NULL
+#define net_if_ipv6_dad_failed(...)
+#define net_if_ipv6_get_global_addr(...) NULL
 #endif /* CONFIG_NET_IPV6 */
 
 #if defined(CONFIG_NET_IPV4)
@@ -1494,8 +1538,25 @@ static inline void net_if_ipv4_set_gw(struct net_if *iface,
 
 	net_ipaddr_copy(&iface->config.ip.ipv4->gw, gw);
 }
+
 #else
+#define net_if_config_ipv4_get(...) -EOPNOTSUPP
+#define net_if_config_ipv4_put(...) -EOPNOTSUPP
+#define net_if_ipv4_get_ttl(...) 0
+#define net_if_ipv4_addr_lookup(...) NULL
+#define net_if_ipv4_addr_add(...) NULL
+#define net_if_ipv4_addr_rm(...) false
+#define net_if_ipv4_maddr_add(...) NULL
+#define net_if_ipv4_maddr_rm(...) false
+#define net_if_ipv4_maddr_lookup(...) NULL
+#define net_if_ipv4_router_lookup(...) NULL
+#define net_if_ipv4_router_add(...) NULL
+#define net_if_ipv4_addr_mask_cmp(...) false
 #define net_if_ipv4_select_src_iface(...) NULL
+#define net_if_ipv4_select_src_addr(...) NULL
+#define net_if_ipv4_get_ll(...) NULL
+#define net_if_ipv4_set_netmask(...)
+#define net_if_ipv4_set_gw(...)
 #endif /* CONFIG_NET_IPV4 */
 
 /**

--- a/include/net/net_ip.h
+++ b/include/net/net_ip.h
@@ -79,9 +79,15 @@ enum net_sock_type {
 /** IPv6 address structure */
 struct in6_addr {
 	union {
+#if defined CONFIG_NET_IPV6
 		u8_t		u6_addr8[16];
 		u16_t		u6_addr16[8]; /* In big endian */
 		u32_t		u6_addr32[4]; /* In big endian */
+#else
+		u8_t		*u6_addr8;
+		u16_t		*u6_addr16;
+		u32_t		*u6_addr32;
+#endif
 	} in6_u;
 #define s6_addr			in6_u.u6_addr8
 #define s6_addr16		in6_u.u6_addr16
@@ -162,12 +168,8 @@ struct sockaddr_storage {
 struct net_addr {
 	sa_family_t family;
 	union {
-#if defined(CONFIG_NET_IPV6)
 		struct in6_addr in6_addr;
-#endif
-#if defined(CONFIG_NET_IPV4)
 		struct in_addr in_addr;
-#endif
 	};
 };
 

--- a/include/net/net_offload.h
+++ b/include/net/net_offload.h
@@ -432,6 +432,16 @@ static inline int net_offload_put(struct net_if *iface,
 }
 #endif
 
+#else
+#define net_offload_get(...) -EOPNOTSUPP
+#define net_offload_bind(...) -EOPNOTSUPP
+#define net_offload_listen(...) -EOPNOTSUPP
+#define net_offload_connect(...) -EOPNOTSUPP
+#define net_offload_accept(...) -EOPNOTSUPP
+#define net_offload_send(...) -EOPNOTSUPP
+#define net_offload_sendto(...) -EOPNOTSUPP
+#define net_offload_recv(...) -EOPNOTSUPP
+#define net_offload_put(...) -EOPNOTSUPP
 #endif /* CONFIG_NET_OFFLOAD */
 
 /**


### PR DESCRIPTION
This patch set clears up net_context by replacing #ifdefs with IS_ENABLED(). This causes IPv6 and IPv4 functions to be seen by the compiler, so the function prototypes need to be defined so that the preprocessor can remove the functions that are now turned into simple return values by the preprocessor. The worse part is that both IPv4 and IPv6 addressing is now visible to the preprocessor and compiler, meaning that we need to come up with a solution in order not to reserve memory for IPv6 address sizes where only IPv4 is used.

This is one cleanup for #8725.