### PR TITLE
xtensa: removed obsolete headers

### DIFF
--- a/arch/xtensa/core/cpu_idle.c
+++ b/arch/xtensa/core/cpu_idle.c
@@ -3,8 +3,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <xtensa/tie/xt_core.h>
-#include <xtensa/tie/xt_interrupt.h>
 #include <tracing.h>
 
 /*


### PR DESCRIPTION
Went in by mistake in a bad rebase, fixes #9753.

Signed-off-by: Anas Nashif <anas.nashif@intel.com>