### PR TITLE
doc: i.MX updated doc for Zephyr release 1.13

### DIFF
--- a/doc/release-notes-1.13.rst
+++ b/doc/release-notes-1.13.rst
@@ -50,6 +50,8 @@ Architectures
 * arch: arm: clean up MPU code for ARM and NXP
 * arch: arm: Set Zero Latency IRQ to priority level zero
 * arch/arm: Fix locking in __pendsv
+* arch: arm: nxp_imx: Added RDC (Resource Domain Controller) configuration for
+  i.MX SoCs to share peripherals between the Cortex A and Cortex M4 cores.
 
 Boards & SoC Support
 ********************


### PR DESCRIPTION
i.MX updated doc section for Zephyr release 1.13:

Architectures:
    nxp_imx: Added RDC (Resource Domain Controller) configuration for i.MX SoCs
    to share peripherals between the Cortex A and Cortex M4 cores.


Signed-off-by: Diego Sueiro <diego.sueiro@gmail.com>