### PR TITLE
cmake: Don't use the environment variable CFLAGS

### DIFF
--- a/cmake/toolchain.cmake
+++ b/cmake/toolchain.cmake
@@ -8,6 +8,15 @@ set(CMAKE_FIND_ROOT_PATH_MODE_LIBRARY ONLY)
 set(CMAKE_FIND_ROOT_PATH_MODE_INCLUDE ONLY)
 set(CMAKE_FIND_ROOT_PATH_MODE_PACKAGE ONLY)
 
+# Don't inherit compiler flags from the environment
+foreach(var CFLAGS CXXFLAGS)
+  if(DEFINED ENV{${var}})
+    message(WARNING "The environment variable '${var}' was set to $ENV{${var}},
+but Zephyr ignores flags from the environment. Use 'cmake -DEXTRA_${var}=$ENV{${var}}' instead.")
+    unset(ENV{${var}})
+  endif()
+endforeach()
+
 # Until we completely deprecate it
 if(NOT DEFINED ENV{ZEPHYR_TOOLCHAIN_VARIANT})
   if(DEFINED ENV{ZEPHYR_GCC_VARIANT})

--- a/doc/getting_started/installation_linux.rst
+++ b/doc/getting_started/installation_linux.rst
@@ -162,15 +162,6 @@ Follow these steps to install the SDK on your Linux host system.
       export ZEPHYR_TOOLCHAIN_VARIANT=zephyr
       export ZEPHYR_SDK_INSTALL_DIR=<sdk installation directory>
 
-   .. note::
-      Some Linux distributions have default CFLAGS and CXXFLAGS
-      environment variables already set. For all distros, they need to be
-      unset to prevent these settings from interfering with cmake:
-
-      .. code-block:: console
-
-         unset CFLAGS CXXFLAGS
-
   To use the same toolchain in new sessions in the future, you can set the
   variables in the file :file:`${HOME}/.zephyrrc`, for example:
 
@@ -185,17 +176,6 @@ Follow these steps to install the SDK on your Linux host system.
      Use ``<sdk installation directory>`` in place of ``/opt/zephyr-sdk/`` in the
      above shown example if the SDK installation location is not default.
 
-
-  .. note::
-     Some Linux distributions have default CFLAGS and CXXFLAGS
-     environment variables already set. For all distros, they need to be
-     unset to prevent these settings from interfering with cmake:
-
-     .. code-block:: console
-
-        cat <<EOF >> ~/.zephyrrc
-        unset CFLAGS CXXFLAGS
-        EOF
 
 .. note:: In previous releases of Zephyr, the ``ZEPHYR_TOOLCHAIN_VARIANT``
           variable was called ``ZEPHYR_GCC_VARIANT``.


### PR DESCRIPTION
Some distros set the environment variable CFLAGS, this will
accidentally affect Zephyr builds.

To fix this we clear the environment variable from within the Zephyr
build system for the duration of the CMake execution.

Until now we have been instructing the user to clear it, but it is
easier for the user if we clear it for him.

The same applies to CXXFLAGS.

Signed-off-by: Sebastian Bøe <sebastian.boe@nordicsemi.no>