### PR TITLE
drivers: entropy: nrf5: Fix ENTROPY_BUSYWAIT from hanging

### DIFF
--- a/drivers/entropy/entropy_nrf5.c
+++ b/drivers/entropy/entropy_nrf5.c
@@ -297,6 +297,8 @@ static int entropy_nrf5_get_entropy_isr(struct device *dev, u8_t *buf, u16_t len
 			buf[--len] = NRF_RNG->VALUE;
 
 			NRF_RNG->EVENTS_VALRDY = 0;
+
+			NVIC_ClearPendingIRQ(RNG_IRQn);
 		} while (len);
 
 		nrf_rng_task_trigger(NRF_RNG_TASK_STOP);


### PR DESCRIPTION
Missing clear pending RNG_IRQn when generating multiple
random numbers caused CPU to hang at __WFE call in the
loop waiting for new value.

This fixes commit ddb7f88f9ed5 ("drivers: entropy: nrf5: Fix
ENTROPY_BUSYWAIT implementation")

Fixes #9523.

Signed-off-by: Vinayak Kariappa Chettimada <vich@nordicsemi.no>