### PR TITLE
shell: Add support for custom line2argv callback

### DIFF
--- a/subsys/shell/shell.c
+++ b/subsys/shell/shell.c
@@ -371,7 +371,11 @@ int shell_exec(char *line)
 	const struct shell_cmd *cmd;
 	int argc, err;
 
-	argc = line2argv(line, argv, ARRAY_SIZE(argv));
+	if (default_module && default_module->line2argv) {
+		argc = default_module->line2argv(line, argv, ARRAY_SIZE(argv));
+	} else {
+		argc = line2argv(line, argv, ARRAY_SIZE(argv));
+	}
 	if (!argc) {
 		return -EINVAL;
 	}


### PR DESCRIPTION
This allows to define shells which are using different syntax for
commands parsing eg. foocmd=param1,param2.

This is usefull for providing compatibility with existing external
tools while allowing to use Zephyr's shell subsystem.

Signed-off-by: Szymon Janc <szymon.janc@codecoup.pl>