### PR TITLE
drivers/gpio_sam: Fix incorrect flag checking

### DIFF
--- a/drivers/gpio/gpio_sam.c
+++ b/drivers/gpio/gpio_sam.c
@@ -48,23 +48,20 @@ static int gpio_sam_config(struct device *dev, int access_op, u32_t pin,
 
 	/* Setup interrupt configuration. */
 	if (flags & GPIO_INT) {
+		if (flags & GPIO_INT_DOUBLE_EDGE) {
+			return -ENOTSUP;
+		}
+
 		/* Enable the interrupt. */
 		pio->PIO_IER = mask;
 
 		/* Enable the additional interrupt modes. */
 		pio->PIO_AIMER = mask;
 
-		switch (flags) {
-		case GPIO_INT_LEVEL:
-			pio->PIO_LSR = mask;
-			break;
-		case GPIO_INT_EDGE:
+		if (flags & GPIO_INT_EDGE) {
 			pio->PIO_ESR = mask;
-			break;
-		case GPIO_INT_DOUBLE_EDGE:
-			return -ENOTSUP;
-		default:
-			return -ENOTSUP;
+		} else {
+			pio->PIO_LSR = mask;
 		}
 
 		if (flags & GPIO_INT_ACTIVE_HIGH) {


### PR DESCRIPTION
Corrected the checking for edge/level interrupts in the flags
variable.

Signed-off-by: Rajavardhan Gundi <rajavardhan.gundi@intel.com>