### PR TITLE
arch: xtensa: remove extra #endif

### DIFF
--- a/arch/xtensa/core/xtensa_vectors.S
+++ b/arch/xtensa/core/xtensa_vectors.S
@@ -178,7 +178,6 @@
 #endif
 #endif
 
-#endif
     #ifdef XT_INTEXC_HOOKS
     /* Call interrupt hook if present to (pre)handle interrupts. */
     movi    a4, _xt_intexc_hooks


### PR DESCRIPTION
Remove extra #endif that should have been removed when the
corresponding #ifdef CONFIG_KERNEL_EVENT_LOGGER_SLEEP was
removed in commit a2248782a25e205be9b37a03fc47131856ba406d

Signed-off-by: Sathish Kuttan <sathish.k.kuttan@intel.com>

Fixes #9786