### PR TITLE
doc: give nicer error if env not set up

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,6 +2,10 @@
 # Top level makefile for things not covered by cmake
 #
 
+ifndef ZEPHYR_BASE
+$(error The ZEPHYR_BASE environment variable must be set)
+endif
+
 BUILDDIR ?= doc/_build
 DOC_TAG ?= development
 SPHINXOPTS ?= -q


### PR DESCRIPTION
If one forgets to source the zephyr-env.sh script before starting a doc
build (using the top-level Makefile), a long screenful of error messages
go by and you can miss what the actual problem is.

Check if ZEPHYR_BASE is not set and give a nice short error message.

Signed-off-by: David B. Kinder <david.b.kinder@intel.com>