### PR TITLE
doc: fix reference to props file

### DIFF
--- a/boards/arc/nsim_em/doc/board.rst
+++ b/boards/arc/nsim_em/doc/board.rst
@@ -19,7 +19,7 @@ There are two sub configurations in board:
 * nsim_sem which includes secure em features and ARC MPUv3
 
 For detailed arc features, please refer to
-:file:`boards/arc/nsim_em/support/nsim_em.props` and
+:file:`boards/arc/nsim_em/support/nsim.props` and
 :file:`boards/arc/nsim_em/support/nsim_sem.props`.
 
 


### PR DESCRIPTION
Fix reference to misspelled file name in nsim_em documentation

Signed-off-by: David B. Kinder <david.b.kinder@intel.com>