### PR TITLE
drivers: i2s_cavs: Bidirectional I2S implementation for Intel S1000

### DIFF
--- a/drivers/dma/dma_cavs.h
+++ b/drivers/dma/dma_cavs.h
@@ -28,23 +28,9 @@ extern "C" {
 #define DW_CTLL_LLP_D_EN	(1 << 27)
 #define DW_CTLL_LLP_S_EN	(1 << 28)
 
-/* DMA descriptor used by HW version 2 */
-struct dw_lli2 {
-	u32_t sar;
-	u32_t dar;
-	u32_t llp;
-	u32_t ctrl_lo;
-	u32_t ctrl_hi;
-	u32_t sstat;
-	u32_t dstat;
-} __packed;
-
 /* data for each DMA channel */
 struct dma_chan_data {
 	u32_t direction;
-	struct dw_lli2 *lli;
-	u32_t cfg_lo;
-	u32_t cfg_hi;
 	void *blkcallback_arg;
 	void (*dma_blkcallback)(void *arg, u32_t channel,
 		int error_code);

--- a/drivers/i2s/Kconfig.cavs
+++ b/drivers/i2s/Kconfig.cavs
@@ -15,44 +15,62 @@ menuconfig I2S_CAVS
 
 if I2S_CAVS
 
-config I2S_CAVS_TX_BLOCK_COUNT
-	int "TX queue length"
-	default 4
-	help
-	  The maximum number of blocks that can be accommodated in the Tx queue.
-
-config I2S_CAVS_0_NAME
-	string "I2S 0 device name"
-	default "I2S_0"
-
-config I2S_CAVS_0_IRQ_PRI
-	int "Interrupt priority"
-	default 0
-
 config I2S_CAVS_DMA_NAME
 	string "DMA device name"
 	default "DMA_0"
 	help
 	  Name of the DMA device this device driver can use.
 
-config I2S_CAVS_0_DMA_TX_CHANNEL
-	int "DMA TX channel"
-	default 2
-	help
-	  DMA channel number to use for TX transfers.
+config I2S_CAVS_IRQ_PRI
+	int "Interrupt priority"
+	default 0
 
 config I2S_CAVS_1_NAME
 	string "I2S 1 device name"
 	default "I2S_1"
 
-config I2S_CAVS_1_IRQ_PRI
-	int "Interrupt priority"
-	default 0
-
 config I2S_CAVS_1_DMA_TX_CHANNEL
+	int "DMA TX channel"
+	default 2
+	help
+	  DMA channel number to use for I2S1 TX transfer.
+
+config I2S_CAVS_1_DMA_RX_CHANNEL
+	int "DMA RX channel"
+	default 3
+	help
+	  DMA channel number to use for I2S1 RX transfer.
+
+config I2S_CAVS_2_NAME
+	string "I2S 2 device name"
+	default "I2S_2"
+
+config I2S_CAVS_2_DMA_TX_CHANNEL
 	int "DMA TX channel"
 	default 4
 	help
-	  DMA channel number to use for TX transfers.
+	  DMA channel number to use for I2S2 TX transfer.
+
+config I2S_CAVS_2_DMA_RX_CHANNEL
+	int "DMA RX channel"
+	default 5
+	help
+	  DMA channel number to use for I2S2 RX transfer.
+
+config I2S_CAVS_3_NAME
+	string "I2S 3 device name"
+	default "I2S_3"
+
+config I2S_CAVS_3_DMA_TX_CHANNEL
+	int "DMA TX channel"
+	default 6
+	help
+	  DMA channel number to use for I2S3 TX transfer.
+
+config I2S_CAVS_3_DMA_RX_CHANNEL
+	int "DMA RX channel"
+	default 7
+	help
+	  DMA channel number to use for I2S3 RX transfer.
 
 endif # I2S_CAVS

--- a/drivers/i2s/i2s_cavs.c
+++ b/drivers/i2s/i2s_cavs.c
@@ -28,6 +28,9 @@
 #include <logging/log.h>
 LOG_MODULE_REGISTER(LOG_DOMAIN);
 
+/* length of the buffer queue */
+#define I2S_CAVS_BUF_Q_LEN			4
+
 #ifdef CONFIG_DCACHE_WRITEBACK
 #define DCACHE_INVALIDATE(addr, size) \
 	{ dcache_invalidate_region(addr, size); }
@@ -46,58 +49,50 @@ LOG_MODULE_REGISTER(LOG_DOMAIN);
 #define CAVS_SSP_WORD_PER_FRAME_MIN     1
 #define CAVS_SSP_WORD_PER_FRAME_MAX     8
 
-struct queue_item {
-	void *mem_block;
-	size_t size;
-};
+#define CAVS_I2S_DMA_BURST_SIZE		8
 
-/* Minimal ring buffer implementation:
- * buf - holds the pointer to Queue items
- * len - Max number of Queue items that can be referenced
- * head - current write index number
- * tail - current read index number
- */
-struct ring_buf {
-	struct queue_item *buf;
-	u16_t len;
-	u16_t head;
-	u16_t tail;
-};
-
-/* This indicates the Tx/Rx stream. Most members of the stream are
- * self-explanatory except for sem.
- * sem - This is initialized to CONFIG_I2S_CAVS_TX_BLOCK_COUNT. If at all
- * mem_block_queue gets filled with the MAX blocks configured, this semaphore
- * ensures nothing gets written into the mem_block_queue before a slot gets
- * freed (which happens when a block gets read out).
+/*
+ * This indicates the Tx/Rx stream. Most members of the stream are
+ * self-explanatory
+ *
+ * in_queue and out_queue are used as follows
+ *   transmit stream:
+ *      application provided buffer is queued to in_queue until loaded to DMA.
+ *      when DMA channel is idle, buffer is retrieved from in_queue and loaded
+ *      to DMA and queued to out_queue.
+ *      when DMA completes, buffer is retrieved from out_queue and freed.
+ *
+ *   receive stream:
+ *      driver allocates buffer from slab and loads DMA
+ *      buffer is queued to in_queue
+ *      when DMA completes, buffer is retrieved from in_queue and queued to
+ *      out_queue
+ *	when application reads, buffer is read (may optionally block) from
+ *      out_queue and presented to application.
  */
 struct stream {
 	s32_t state;
-	struct k_sem sem;
 	u32_t dma_channel;
 	struct dma_config dma_cfg;
-	struct i2s_config cfg;
-	struct ring_buf mem_block_queue;
-	void *mem_block;
-	bool last_block;
-	int (*stream_start)(struct stream *,
-			    volatile struct i2s_cavs_ssp *const, struct device *);
-	void (*stream_disable)(struct stream *,
-			       volatile struct i2s_cavs_ssp *const, struct device *);
-	void (*queue_drop)(struct stream *);
+	struct dma_block_config dma_block;
+	struct k_msgq in_queue;
+	void *in_msgs[I2S_CAVS_BUF_Q_LEN];
+	struct k_msgq out_queue;
+	void *out_msgs[I2S_CAVS_BUF_Q_LEN];
 };
 
 struct i2s_cavs_config {
 	struct i2s_cavs_ssp *regs;
 	struct i2s_cavs_mn_div *mn_regs;
 	u32_t irq_id;
-	void (*irq_config)(void);
 };
 
 /* Device run time data */
 struct i2s_cavs_dev_data {
+	struct i2s_config cfg;
 	struct device *dev_dma;
 	struct stream tx;
+	struct stream rx;
 };
 
 #define DEV_NAME(dev) ((dev)->config->name)
@@ -106,184 +101,139 @@ struct i2s_cavs_dev_data {
 #define DEV_DATA(dev) \
 	((struct i2s_cavs_dev_data *const)(dev)->driver_data)
 
-static struct device *get_dev_from_dma_channel(u32_t dma_channel);
-static void dma_tx_callback(void *, u32_t, int);
-static void tx_stream_disable(struct stream *,
-			      volatile struct i2s_cavs_ssp *const, struct device *);
+static struct device DEVICE_NAME_GET(i2s1_cavs);
+static struct device DEVICE_NAME_GET(i2s2_cavs);
+static struct device DEVICE_NAME_GET(i2s3_cavs);
 
-static inline u16_t modulo_inc(u16_t val, u16_t max)
-{
-	val++;
-	return (val < max) ? val : 0;
-}
-
-/*
- * Get data from the queue
- */
-static int queue_get(struct ring_buf *rb, u8_t mode, void **mem_block,
-		     size_t *size)
-{
-	unsigned int key;
-
-	key = irq_lock();
-
-	/* In case of ping-pong mode, the buffers are not freed after
-	 * reading. They are fixed in size. Another thread will populate
-	 * the pong buffer while the ping buffer is being read out and
-	 * vice versa. Hence, we just need to keep reading from buffer0
-	 * (ping buffer) followed by buffer1 (pong buffer) and the same
-	 * cycle continues.
-	 *
-	 * In case of non-ping-pong modes, each buffer is freed after it
-	 * is read. The tail pointer will keep progressing depending upon
-	 * the reads. The head pointer will move whenever there's a write.
-	 * If tail equals head, it would mean we have read everything there
-	 * is and the buffer is empty.
-	 */
-	if (rb->tail == rb->head) {
-		if ((mode & I2S_OPT_PINGPONG) == I2S_OPT_PINGPONG) {
-			/* Point back to the first element */
-			rb->tail = 0;
-		} else {
-			/* Ring buffer is empty */
-			irq_unlock(key);
-			return -ENOMEM;
-		}
-	}
-
-	*mem_block = rb->buf[rb->tail].mem_block;
-	*size = rb->buf[rb->tail].size;
-	rb->tail = modulo_inc(rb->tail, rb->len);
-
-	irq_unlock(key);
-
-	return 0;
-}
-
-/*
- * Put data in the queue
- */
-static int queue_put(struct ring_buf *rb, u8_t mode, void *mem_block,
-		     size_t size)
-{
-	u16_t head_next;
-	unsigned int key;
-
-	key = irq_lock();
-
-	head_next = rb->head;
-	head_next = modulo_inc(head_next, rb->len);
-
-	/* In case of ping-pong mode, the below comparison incorrectly
-	 * leads to complications as the buffers are always predefined.
-	 * Hence excluding ping-pong mode from this comparison.
-	 */
-	if ((mode & I2S_OPT_PINGPONG) != I2S_OPT_PINGPONG) {
-		if (head_next == rb->tail) {
-			/* Ring buffer is full */
-			irq_unlock(key);
-			return -ENOMEM;
-		}
-	}
-
-	rb->buf[rb->head].mem_block = mem_block;
-	rb->buf[rb->head].size = size;
-	rb->head = head_next;
-
-	irq_unlock(key);
-
-	return 0;
-}
-
-static int start_dma(struct device *dev_dma, u32_t channel,
-		     struct dma_config *cfg, void *src, void *dst,
-		     u32_t blk_size)
-{
-	int ret;
-
-	struct dma_block_config blk_cfg = {
-		.block_size = blk_size,
-		.source_address = (u32_t)src,
-		.dest_address = (u32_t)dst,
-	};
-
-	cfg->head_block = &blk_cfg;
-
-	ret = dma_config(dev_dma, channel, cfg);
-	if (ret < 0) {
-		LOG_ERR("dma_config failed: %d", ret);
-		return ret;
-	}
-
-	ret = dma_start(dev_dma, channel);
-	if (ret < 0) {
-		LOG_ERR("dma_start failed: %d", ret);
-	}
-
-	return ret;
-}
+static void i2s_dma_tx_callback(void *, u32_t, int);
+static void i2s_tx_stream_disable(struct i2s_cavs_dev_data *,
+		volatile struct i2s_cavs_ssp *const, struct device *);
+static void i2s_rx_stream_disable(struct i2s_cavs_dev_data *,
+		volatile struct i2s_cavs_ssp *const, struct device *);
 
 /* This function is executed in the interrupt context */
-static void dma_tx_callback(void *dev_dma, u32_t channel, int status)
+static void i2s_dma_tx_callback(void *arg, u32_t channel,
+		int status)
 {
-	struct device *dev = get_dev_from_dma_channel(channel);
+	struct device *dev = (struct device *)arg;
+	const struct i2s_cavs_config *const dev_cfg = DEV_CFG(dev);
+	struct i2s_cavs_dev_data *const dev_data = DEV_DATA(dev);
+
+	volatile struct i2s_cavs_ssp *const ssp = dev_cfg->regs;
+	struct stream *strm = &dev_data->tx;
+	void *buffer;
+	int ret;
+
+	ret = k_msgq_get(&strm->out_queue, &buffer, K_NO_WAIT);
+	if (ret == 0) {
+		/* transmission complete. free the buffer */
+		k_mem_slab_free(dev_data->cfg.mem_slab, &buffer);
+	} else {
+		LOG_ERR("no buffer in output queue for channel %u",
+				channel);
+	}
+
+	switch (strm->state) {
+
+	case I2S_STATE_RUNNING:
+		/* get the next buffer from queue */
+		ret = k_msgq_get(&strm->in_queue, &buffer, K_NO_WAIT);
+		if (ret == 0) {
+			/* reload the DMA */
+			dma_reload(dev_data->dev_dma, strm->dma_channel,
+					(u32_t)buffer, (u32_t)&ssp->ssd,
+					dev_data->cfg.block_size);
+			dma_start(dev_data->dev_dma, strm->dma_channel);
+			ssp->ssc1 |= SSCR1_TSRE;
+			k_msgq_put(&strm->out_queue, &buffer, K_NO_WAIT);
+		}
+		break;
+
+	case I2S_STATE_STOPPING:
+		strm->state = I2S_STATE_READY;
+		/* fall through */
+
+	case I2S_STATE_ERROR:
+		i2s_tx_stream_disable(dev_data, ssp, dev_data->dev_dma);
+		/* purge buffer queue */
+		while (k_msgq_get(&strm->in_queue, &buffer, K_NO_WAIT) == 0) {
+			k_mem_slab_free(dev_data->cfg.mem_slab, &buffer);
+		}
+		while (k_msgq_get(&strm->out_queue, &buffer, K_NO_WAIT) == 0) {
+			k_mem_slab_free(dev_data->cfg.mem_slab, &buffer);
+		}
+		break;
+	}
+}
+
+static void i2s_dma_rx_callback(void *arg, u32_t channel, int status)
+{
+	struct device *dev = (struct device *)arg;
 	const struct i2s_cavs_config *const dev_cfg = DEV_CFG(dev);
 	struct i2s_cavs_dev_data *const dev_data = DEV_DATA(dev);
 	volatile struct i2s_cavs_ssp *const ssp = dev_cfg->regs;
-	struct stream *strm = &dev_data->tx;
-	size_t mem_block_size;
+	struct stream *strm = &dev_data->rx;
+	void *buffer;
 	int ret;
 
-	__ASSERT_NO_MSG(strm->mem_block != NULL);
+	switch (strm->state) {
 
-	ARG_UNUSED(dev_dma);
-
-	if ((strm->cfg.options & I2S_OPT_PINGPONG) != I2S_OPT_PINGPONG) {
-		/* All block data sent */
-		k_mem_slab_free(strm->cfg.mem_slab, &strm->mem_block);
-		strm->mem_block = NULL;
-	}
-
-	/* Stop transmission if there was an error */
-	if (strm->state == I2S_STATE_ERROR) {
-		LOG_DBG("TX error detected");
-		goto tx_disable;
-	}
-
-	/* Stop transmission if we were requested */
-	if (strm->last_block) {
-		strm->state = I2S_STATE_READY;
-		goto tx_disable;
-	}
-
-	/* Prepare to send the next data block */
-	ret = queue_get(&strm->mem_block_queue, strm->cfg.options,
-			&strm->mem_block, &mem_block_size);
-	if (ret < 0) {
-		if (strm->state == I2S_STATE_STOPPING) {
-			strm->state = I2S_STATE_READY;
-		} else {
-			strm->state = I2S_STATE_ERROR;
+	case I2S_STATE_RUNNING:
+		/* retrieve buffer from input queue */
+		ret = k_msgq_get(&strm->in_queue, &buffer, K_NO_WAIT);
+		if (ret != 0) {
+			LOG_ERR("get buffer from in_queue %p failed (%d)",
+					&strm->in_queue, ret);
 		}
-		goto tx_disable;
+		/* put buffer to output queue */
+		ret = k_msgq_put(&strm->out_queue, &buffer, K_NO_WAIT);
+		if (ret != 0) {
+			LOG_ERR("buffer %p -> out_queue %p err %d",
+					buffer, &strm->out_queue, ret);
+		}
+		/* allocate new buffer for next audio frame */
+		ret = k_mem_slab_alloc(dev_data->cfg.mem_slab, &buffer,
+				K_NO_WAIT);
+		if (ret != 0) {
+			LOG_ERR("buffer alloc from slab %p err %d",
+					dev_data->cfg.mem_slab, ret);
+			strm->state = I2S_STATE_ERROR;
+			i2s_rx_stream_disable(dev_data, ssp, dev_data->dev_dma);
+		} else {
+			/* put buffer in input queue */
+			ret = k_msgq_put(&strm->in_queue, &buffer, K_NO_WAIT);
+			if (ret != 0) {
+				LOG_ERR("buffer %p -> in_queue %p err %d",
+						buffer, &strm->in_queue, ret);
+			}
+
+			DCACHE_INVALIDATE(buffer, dev_data->cfg.block_size);
+
+			/* reload the DMA */
+			dma_reload(dev_data->dev_dma, strm->dma_channel,
+					(u32_t)&ssp->ssd, (u32_t)buffer,
+					dev_data->cfg.block_size);
+			dma_start(dev_data->dev_dma, strm->dma_channel);
+			ssp->ssc1 |= SSCR1_RSRE;
+		}
+		break;
+	case I2S_STATE_STOPPING:
+		strm->state = I2S_STATE_READY;
+		/* fall-through */
+
+	case I2S_STATE_ERROR:
+		i2s_rx_stream_disable(dev_data, ssp, dev_data->dev_dma);
+		/*
+		 * retrieve all buffers from input & output queues and free them
+		 */
+		while (k_msgq_get(&strm->in_queue, &buffer, K_NO_WAIT) == 0) {
+			k_mem_slab_free(dev_data->cfg.mem_slab, &buffer);
+		}
+		while (k_msgq_get(&strm->out_queue, &buffer, K_NO_WAIT) == 0) {
+			k_mem_slab_free(dev_data->cfg.mem_slab, &buffer);
+		}
+		break;
 	}
-
-	k_sem_give(&strm->sem);
-
-	/* Assure cache coherency before DMA read operation */
-	DCACHE_CLEAN(strm->mem_block, mem_block_size);
-
-	ret = start_dma(dev_data->dev_dma, strm->dma_channel, &strm->dma_cfg,
-			strm->mem_block, (void *)&(ssp->ssd),
-			mem_block_size);
-	if (ret < 0) {
-		LOG_DBG("Failed to start TX DMA transfer: %d", ret);
-		goto tx_disable;
-	}
-	return;
-
-tx_disable:
-	tx_stream_disable(strm, ssp, dev_data->dev_dma);
 }
 
 static int i2s_cavs_configure(struct device *dev, enum i2s_dir dir,
@@ -293,11 +243,12 @@ static int i2s_cavs_configure(struct device *dev, enum i2s_dir dir,
 	struct i2s_cavs_dev_data *const dev_data = DEV_DATA(dev);
 	volatile struct i2s_cavs_ssp *const ssp = dev_cfg->regs;
 	volatile struct i2s_cavs_mn_div *const mn_div = dev_cfg->mn_regs;
+	struct dma_block_config *dma_block;
 	u8_t num_words = i2s_cfg->channels;
 	u8_t word_size_bits = i2s_cfg->word_size;
 	u8_t word_size_bytes;
 	u32_t bit_clk_freq, mclk;
-	struct stream *strm;
+	int ret;
 
 	u32_t ssc0;
 	u32_t ssc1;
@@ -315,52 +266,53 @@ static int i2s_cavs_configure(struct device *dev, enum i2s_dir dir,
 	u32_t frame_len = 0;
 	bool inverted_frame = false;
 
-	if (dir == I2S_DIR_TX) {
-		strm = &dev_data->tx;
-	} else {
-		LOG_ERR("TX direction must be selected");
-		return -EINVAL;
-	}
-
-	if (strm->state != I2S_STATE_NOT_READY &&
-	    strm->state != I2S_STATE_READY) {
-		LOG_ERR("invalid state");
+	if ((dev_data->tx.state != I2S_STATE_NOT_READY) &&
+			(dev_data->tx.state != I2S_STATE_READY) &&
+			(dev_data->rx.state != I2S_STATE_NOT_READY) &&
+			(dev_data->rx.state != I2S_STATE_READY)) {
+		LOG_ERR("invalid state tx(%u) rx(%u)", dev_data->tx.state,
+				dev_data->rx.state);
 		return -EINVAL;
 	}
 
 	if (i2s_cfg->frame_clk_freq == 0) {
-		strm->queue_drop(strm);
-		(void)memset(&strm->cfg, 0, sizeof(struct i2s_config));
-		strm->state = I2S_STATE_NOT_READY;
-		return 0;
+		LOG_ERR("Invalid frame_clk_freq %u",
+				i2s_cfg->frame_clk_freq);
+		return -EINVAL;
 	}
 
 	if (word_size_bits < CAVS_SSP_WORD_SIZE_BITS_MIN ||
 	    word_size_bits > CAVS_SSP_WORD_SIZE_BITS_MAX) {
-		LOG_ERR("Unsupported I2S word size");
+		LOG_ERR("Unsupported I2S word size %u", word_size_bits);
 		return -EINVAL;
 	}
 
 	if (num_words < CAVS_SSP_WORD_PER_FRAME_MIN ||
 	    num_words > CAVS_SSP_WORD_PER_FRAME_MAX) {
-		LOG_ERR("Unsupported words per frame number");
+		LOG_ERR("Unsupported words per frame number %u", num_words);
 		return -EINVAL;
 	}
 
-	memcpy(&strm->cfg, i2s_cfg, sizeof(struct i2s_config));
+	if ((i2s_cfg->options & I2S_OPT_PINGPONG) == I2S_OPT_PINGPONG) {
+		LOG_ERR("Ping-pong mode not supported");
+		return -ENOTSUP;
+	}
+
+	memcpy(&dev_data->cfg, i2s_cfg, sizeof(struct i2s_config));
 
 	/* reset SSP settings */
 	/* sscr0 dynamic settings are DSS, EDSS, SCR, FRDC, ECS */
 	ssc0 = SSCR0_MOD | SSCR0_PSP | SSCR0_RIM | SSCR0_TIM;
 
 	/* sscr1 dynamic settings are SFRMDIR, SCLKDIR, SCFR */
-	ssc1 = SSCR1_TTE | SSCR1_TTELP | SSCR1_RWOT | SSCR1_TRAIL;
+	ssc1 = SSCR1_TTE | SSCR1_TTELP | SSCR1_TRAIL | SSCR1_TSRE | SSCR1_RSRE;
 
 	/* sscr2 dynamic setting is LJDFD */
-	ssc2 = SSCR2_SDFD | SSCR2_TURM1;
+	ssc2 = 0;
 
 	/* sscr3 dynamic settings are TFT, RFT */
-	ssc3 = 0;
+	ssc3 = SSCR3_TX(CAVS_I2S_DMA_BURST_SIZE) |
+		SSCR3_RX(CAVS_I2S_DMA_BURST_SIZE);
 
 	/* sspsp dynamic settings are SCMODE, SFRMP, DMYSTRT, SFRMWDTH */
 	sspsp = 0;
@@ -372,10 +324,9 @@ static int i2s_cavs_configure(struct device *dev, enum i2s_dir dir,
 	ssto = 0x0;
 
 	/* sstsa dynamic setting is TTSA, set according to num_words */
-	sstsa = SSTSA_TXEN | BIT_MASK(num_words);
-
+	sstsa = BIT_MASK(num_words);
 	/* ssrsa dynamic setting is RTSA, set according to num_words */
-	ssrsa = SSRSA_RXEN | BIT_MASK(num_words);
+	ssrsa = BIT_MASK(num_words);
 
 	if (i2s_cfg->options & I2S_OPT_BIT_CLK_SLAVE) {
 		/* set BCLK mode as slave */
@@ -399,10 +350,10 @@ static int i2s_cavs_configure(struct device *dev, enum i2s_dir dir,
 
 	case I2S_FMT_CLK_NF_IB:
 		sspsp |= SSPSP_SCMODE(2);
-		inverted_frame = true; /* handled later with format */
 		break;
 
 	case I2S_FMT_CLK_IF_NB:
+		inverted_frame = true; /* handled later with format */
 		break;
 
 	case I2S_FMT_CLK_IF_IB:
@@ -460,7 +411,7 @@ static int i2s_cavs_configure(struct device *dev, enum i2s_dir dir,
 		frame_len = word_size_bits;
 
 		/* handle frame polarity, I2S default is falling/active low */
-		sspsp |= SSPSP_SFRMP(!inverted_frame);
+		sspsp |= SSPSP_SFRMP(!inverted_frame) | SSPSP_FSRT;
 		break;
 
 	case I2S_FMT_DATA_FORMAT_LEFT_JUSTIFIED:
@@ -507,92 +458,163 @@ static int i2s_cavs_configure(struct device *dev, enum i2s_dir dir,
 
 	/* Set up DMA channel parameters */
 	word_size_bytes = (word_size_bits + 7) / 8;
-	strm->dma_cfg.source_data_size = word_size_bytes;
-	strm->dma_cfg.dest_data_size = word_size_bytes;
+	dev_data->tx.dma_cfg.source_data_size = word_size_bytes;
+	dev_data->tx.dma_cfg.dest_data_size = word_size_bytes;
+	dev_data->rx.dma_cfg.source_data_size = word_size_bytes;
+	dev_data->rx.dma_cfg.dest_data_size = word_size_bytes;
 
-	strm->state = I2S_STATE_READY;
-	return 0;
-}
+	dma_block = dev_data->tx.dma_cfg.head_block;
+	dma_block->block_size = i2s_cfg->block_size;
+	dma_block->source_address = (u32_t)NULL;
+	dma_block->dest_address = (u32_t)&ssp->ssd;
 
-static int tx_stream_start(struct stream *strm,
-			   volatile struct i2s_cavs_ssp *const ssp,
-			   struct device *dev_dma)
-{
-	size_t mem_block_size;
-	int ret;
-
-	ret = queue_get(&strm->mem_block_queue, strm->cfg.options,
-			&strm->mem_block, &mem_block_size);
+	ret = dma_config(dev_data->dev_dma, dev_data->tx.dma_channel,
+			&dev_data->tx.dma_cfg);
 	if (ret < 0) {
+		LOG_ERR("dma_config failed: %d", ret);
 		return ret;
 	}
-	k_sem_give(&strm->sem);
 
-	/* Assure cache coherency before DMA read operation */
-	DCACHE_CLEAN(strm->mem_block, mem_block_size);
+	dma_block = dev_data->rx.dma_cfg.head_block;
+	dma_block->block_size = i2s_cfg->block_size;
+	dma_block->source_address = (u32_t)&ssp->ssd;
+	dma_block->dest_address = (u32_t)NULL;
 
-	ret = start_dma(dev_dma, strm->dma_channel, &strm->dma_cfg,
-			strm->mem_block, (void *)&(ssp->ssd),
-			mem_block_size);
+	ret = dma_config(dev_data->dev_dma, dev_data->rx.dma_channel,
+			&dev_data->rx.dma_cfg);
 	if (ret < 0) {
-		LOG_ERR("Failed to start TX DMA transfer: %d", ret);
+		LOG_ERR("dma_config failed: %d", ret);
 		return ret;
 	}
 
 	/* enable port */
 	ssp->ssc0 |= SSCR0_SSE;
 
-	/* Enable DMA service request handshake logic. Though DMA is
-	 * already started, it won't work without the handshake logic.
-	 */
-	ssp->ssc1 |= SSCR1_TSRE;
-	ssp->sstsa |= (0x1 << 8);
+	dev_data->tx.state = I2S_STATE_READY;
+	dev_data->rx.state = I2S_STATE_READY;
+	return 0;
+}
+
+static int i2s_tx_stream_start(struct i2s_cavs_dev_data *dev_data,
+			   volatile struct i2s_cavs_ssp *const ssp,
+			   struct device *dev_dma)
+{
+	int ret = 0;
+	void *buffer;
+	unsigned int key;
+	struct stream *strm = &dev_data->tx;
+
+	/* retrieve buffer from input queue */
+	ret = k_msgq_get(&strm->in_queue, &buffer, K_NO_WAIT);
+	if (ret != 0) {
+		LOG_ERR("No buffer in input queue to start transmission");
+		return ret;
+	}
+
+	ret = dma_reload(dev_dma, strm->dma_channel, (u32_t)buffer,
+			(u32_t)&ssp->ssd, dev_data->cfg.block_size);
+	if (ret != 0) {
+		LOG_ERR("dma_reload failed (%d)", ret);
+		return ret;
+	}
+
+	/* put buffer in output queue */
+	ret = k_msgq_put(&strm->out_queue, &buffer, K_NO_WAIT);
+	if (ret != 0) {
+		LOG_ERR("failed to put buffer in output queue");
+		return ret;
+	}
+
+	ret = dma_start(dev_dma, strm->dma_channel);
+
+	if (ret < 0) {
+		LOG_ERR("dma_start failed (%d)", ret);
+		return ret;
+	}
+
+	/* Enable transmit operation */
+	key = irq_lock();
+	ssp->sstsa |= SSTSA_TXEN;
+	irq_unlock(key);
 
 	return 0;
 }
 
-static void tx_stream_disable(struct stream *strm,
+static int i2s_rx_stream_start(struct i2s_cavs_dev_data *dev_data,
+		volatile struct i2s_cavs_ssp *const ssp, struct device *dev_dma)
+{
+	int ret = 0;
+	void *buffer;
+	unsigned int key;
+	struct stream *strm = &dev_data->rx;
+
+	/* allocate receive buffer from SLAB */
+	ret = k_mem_slab_alloc(dev_data->cfg.mem_slab, &buffer, K_NO_WAIT);
+	if (ret != 0) {
+		LOG_ERR("buffer alloc from mem_slab failed (%d)", ret);
+		return ret;
+	}
+
+	DCACHE_INVALIDATE(buffer, dev_data->cfg.block_size);
+
+	ret = dma_reload(dev_dma, strm->dma_channel, (u32_t)&ssp->ssd,
+			(u32_t)buffer, dev_data->cfg.block_size);
+	if (ret != 0) {
+		LOG_ERR("dma_reload failed (%d)", ret);
+		return ret;
+	}
+
+	/* put buffer in input queue */
+	ret = k_msgq_put(&strm->in_queue, &buffer, K_NO_WAIT);
+	if (ret != 0) {
+		LOG_ERR("failed to put buffer in output queue");
+		return ret;
+	}
+
+	LOG_INF("Starting DMA Ch%u", strm->dma_channel);
+	ret = dma_start(dev_dma, strm->dma_channel);
+	if (ret < 0) {
+		LOG_ERR("Failed to start DMA Ch%d (%d)", strm->dma_channel,
+				ret);
+		return ret;
+	}
+
+	/* Enable Receive operation */
+	key = irq_lock();
+	ssp->ssrsa |= SSRSA_RXEN;
+	irq_unlock(key);
+
+	return 0;
+}
+
+static void i2s_tx_stream_disable(struct i2s_cavs_dev_data *dev_data,
 			      volatile struct i2s_cavs_ssp *const ssp,
 			      struct device *dev_dma)
 {
+	struct stream *strm = &dev_data->tx;
+
 	/* Disable DMA service request handshake logic. Handshake is
 	 * not required now since DMA is not in operation.
 	 */
-	ssp->ssc1 &= ~SSCR1_TSRE;
-	ssp->sstsa &= ~(0x1 << 8);
+	ssp->sstsa &= ~SSTSA_TXEN;
 
+	LOG_INF("Stopping TX stream & DMA channel %u", strm->dma_channel);
 	dma_stop(dev_dma, strm->dma_channel);
-
-	if (((strm->cfg.options & I2S_OPT_PINGPONG) != I2S_OPT_PINGPONG) &&
-	    (strm->mem_block != NULL)) {
-		k_mem_slab_free(strm->cfg.mem_slab, &strm->mem_block);
-		strm->mem_block = NULL;
-	}
-	strm->mem_block_queue.head = 0;
-	strm->mem_block_queue.tail = 0;
 }
 
-static void tx_queue_drop(struct stream *strm)
+static void i2s_rx_stream_disable(struct i2s_cavs_dev_data *dev_data,
+			      volatile struct i2s_cavs_ssp *const ssp,
+			      struct device *dev_dma)
 {
-	size_t size;
-	void *mem_block;
-	unsigned int n = 0;
+	struct stream *strm = &dev_data->rx;
 
-	while (queue_get(&strm->mem_block_queue, strm->cfg.options,
-			 &mem_block, &size) == 0) {
-		if ((strm->cfg.options & I2S_OPT_PINGPONG)
-		    != I2S_OPT_PINGPONG) {
-			k_mem_slab_free(strm->cfg.mem_slab, &mem_block);
-			n++;
-		}
-	}
+	/* Disable DMA service request handshake logic. Handshake is
+	 * not required now since DMA is not in operation.
+	 */
+	ssp->ssrsa &= ~SSRSA_RXEN;
 
-	strm->mem_block_queue.head = 0;
-	strm->mem_block_queue.tail = 0;
-
-	for (; n > 0; n--) {
-		k_sem_give(&strm->sem);
-	}
+	LOG_INF("Stopping RX stream & DMA channel %u", strm->dma_channel);
+	dma_stop(dev_dma, strm->dma_channel);
 }
 
 static int i2s_cavs_trigger(struct device *dev, enum i2s_dir dir,
@@ -605,79 +627,107 @@ static int i2s_cavs_trigger(struct device *dev, enum i2s_dir dir,
 	unsigned int key;
 	int ret;
 
-	if (dir == I2S_DIR_TX) {
-		strm = &dev_data->tx;
-	} else {
-		LOG_ERR("TX direction must be selected");
-		return -EINVAL;
-	}
+	strm = (dir == I2S_DIR_TX) ? &dev_data->tx : &dev_data->rx;
 
+	key = irq_lock();
 	switch (cmd) {
 	case I2S_TRIGGER_START:
 		if (strm->state != I2S_STATE_READY) {
-			LOG_DBG("START trigger: invalid state");
+			irq_unlock(key);
+			LOG_ERR("START trigger: invalid state %u", strm->state);
 			return -EIO;
 		}
 
 		__ASSERT_NO_MSG(strm->mem_block == NULL);
 
-		ret = strm->stream_start(strm, ssp, dev_data->dev_dma);
+		if (dir == I2S_DIR_TX) {
+			ret = i2s_tx_stream_start(dev_data, ssp,
+					dev_data->dev_dma);
+		} else {
+			ret = i2s_rx_stream_start(dev_data, ssp,
+					dev_data->dev_dma);
+		}
+
 		if (ret < 0) {
+			irq_unlock(key);
 			LOG_DBG("START trigger failed %d", ret);
 			return ret;
 		}
 
 		strm->state = I2S_STATE_RUNNING;
-		strm->last_block = false;
 		break;
 
 	case I2S_TRIGGER_STOP:
-		key = irq_lock();
 		if (strm->state != I2S_STATE_RUNNING) {
 			irq_unlock(key);
 			LOG_DBG("STOP trigger: invalid state");
 			return -EIO;
 		}
 		strm->state = I2S_STATE_STOPPING;
-		irq_unlock(key);
-		strm->last_block = true;
 		break;
 
 	case I2S_TRIGGER_DRAIN:
-		key = irq_lock();
 		if (strm->state != I2S_STATE_RUNNING) {
 			irq_unlock(key);
 			LOG_DBG("DRAIN trigger: invalid state");
 			return -EIO;
 		}
 		strm->state = I2S_STATE_STOPPING;
-		irq_unlock(key);
 		break;
 
 	case I2S_TRIGGER_DROP:
 		if (strm->state == I2S_STATE_NOT_READY) {
+			irq_unlock(key);
 			LOG_DBG("DROP trigger: invalid state");
 			return -EIO;
 		}
-		strm->stream_disable(strm, ssp, dev_data->dev_dma);
-		strm->queue_drop(strm);
+		if (dir == I2S_DIR_TX) {
+			i2s_tx_stream_disable(dev_data, ssp, dev_data->dev_dma);
+		} else {
+			i2s_rx_stream_disable(dev_data, ssp, dev_data->dev_dma);
+		}
 		strm->state = I2S_STATE_READY;
 		break;
 
 	case I2S_TRIGGER_PREPARE:
 		if (strm->state != I2S_STATE_ERROR) {
+			irq_unlock(key);
 			LOG_DBG("PREPARE trigger: invalid state");
 			return -EIO;
 		}
 		strm->state = I2S_STATE_READY;
-		strm->queue_drop(strm);
 		break;
 
 	default:
+		irq_unlock(key);
 		LOG_ERR("Unsupported trigger command");
 		return -EINVAL;
 	}
 
+	irq_unlock(key);
+	return 0;
+}
+
+static int i2s_cavs_read(struct device *dev, void **mem_block, size_t *size)
+{
+	struct i2s_cavs_dev_data *const dev_data = DEV_DATA(dev);
+	struct stream *strm = &dev_data->rx;
+	void *buffer;
+	int ret = 0;
+
+	if ((strm->state == I2S_STATE_NOT_READY) ||
+		(strm->state == I2S_STATE_ERROR)) {
+		LOG_ERR("invalid state %d", strm->state);
+		return -EIO;
+	}
+
+	ret = k_msgq_get(&strm->out_queue, &buffer, dev_data->cfg.timeout);
+	if (ret != 0) {
+		return -EAGAIN;
+	}
+
+	*mem_block = buffer;
+	*size = dev_data->cfg.block_size;
 	return 0;
 }
 
@@ -687,22 +737,21 @@ static int i2s_cavs_write(struct device *dev, void *mem_block, size_t size)
 	struct stream *strm = &dev_data->tx;
 	int ret;
 
-	if (dev_data->tx.state != I2S_STATE_RUNNING &&
-	    dev_data->tx.state != I2S_STATE_READY) {
-		LOG_ERR("invalid state");
+	if (strm->state != I2S_STATE_RUNNING &&
+	    strm->state != I2S_STATE_READY) {
+		LOG_ERR("invalid state (%d)", strm->state);
 		return -EIO;
 	}
 
-	ret = k_sem_take(&dev_data->tx.sem, dev_data->tx.cfg.timeout);
-	if (ret < 0) {
-		LOG_ERR("Failure taking sem");
+	DCACHE_CLEAN(mem_block, size);
+
+	ret = k_msgq_put(&strm->in_queue, &mem_block, dev_data->cfg.timeout);
+	if (ret) {
+		LOG_ERR("k_msgq_put failed %d", ret);
 		return ret;
 	}
 
-	/* Add data to the end of the TX queue */
-	queue_put(&dev_data->tx.mem_block_queue, strm->cfg.options,
-		  mem_block, size);
-	return 0;
+	return ret;
 }
 
 /* clear IRQ sources atm */
@@ -718,17 +767,9 @@ static void i2s_cavs_isr(void *arg)
 	ssp->sss = temp;
 }
 
-static int i2s1_cavs_initialize(struct device *dev)
+static int i2s_cavs_initialize(struct device *dev)
 {
-	const struct i2s_cavs_config *const dev_cfg = DEV_CFG(dev);
 	struct i2s_cavs_dev_data *const dev_data = DEV_DATA(dev);
-
-	/* Configure interrupts */
-	dev_cfg->irq_config();
-
-	/* Initialize semaphores */
-	k_sem_init(&dev_data->tx.sem, CONFIG_I2S_CAVS_TX_BLOCK_COUNT,
-		   CONFIG_I2S_CAVS_TX_BLOCK_COUNT);
 
 	dev_data->dev_dma = device_get_binding(CONFIG_I2S_CAVS_DMA_NAME);
 	if (!dev_data->dev_dma) {
@@ -736,8 +777,18 @@ static int i2s1_cavs_initialize(struct device *dev)
 		return -ENODEV;
 	}
 
-	/* Enable module's IRQ */
-	irq_enable(dev_cfg->irq_id);
+	/* Initialize the buffer queues */
+	k_msgq_init(&dev_data->tx.in_queue, (char *)dev_data->tx.in_msgs,
+			sizeof(void *), I2S_CAVS_BUF_Q_LEN);
+	k_msgq_init(&dev_data->rx.in_queue, (char *)dev_data->rx.in_msgs,
+			sizeof(void *), I2S_CAVS_BUF_Q_LEN);
+	k_msgq_init(&dev_data->tx.out_queue, (char *)dev_data->tx.out_msgs,
+			sizeof(void *), I2S_CAVS_BUF_Q_LEN);
+	k_msgq_init(&dev_data->rx.out_queue, (char *)dev_data->rx.out_msgs,
+			sizeof(void *), I2S_CAVS_BUF_Q_LEN);
+
+	dev_data->tx.state = I2S_STATE_NOT_READY;
+	dev_data->rx.state = I2S_STATE_NOT_READY;
 
 	LOG_INF("Device %s initialized", DEV_NAME(dev));
 
@@ -746,57 +797,134 @@ static int i2s1_cavs_initialize(struct device *dev)
 
 static const struct i2s_driver_api i2s_cavs_driver_api = {
 	.configure = i2s_cavs_configure,
+	.read = i2s_cavs_read,
 	.write = i2s_cavs_write,
 	.trigger = i2s_cavs_trigger,
 };
-
-/* I2S1 */
-
-static struct device DEVICE_NAME_GET(i2s1_cavs);
-
-static struct device *get_dev_from_dma_channel(u32_t dma_channel)
-{
-	return &DEVICE_NAME_GET(i2s1_cavs);
-}
-
-struct queue_item i2s1_ring_buf[CONFIG_I2S_CAVS_TX_BLOCK_COUNT];
-
-static void i2s1_irq_config(void)
-{
-	IRQ_CONNECT(I2S1_CAVS_IRQ, CONFIG_I2S_CAVS_1_IRQ_PRI, i2s_cavs_isr,
-		    DEVICE_GET(i2s1_cavs), 0);
-}
 
 static const struct i2s_cavs_config i2s1_cavs_config = {
 	.regs = (struct i2s_cavs_ssp *)SSP_BASE(1),
 	.mn_regs = (struct i2s_cavs_mn_div *)SSP_MN_DIV_BASE(1),
 	.irq_id = I2S1_CAVS_IRQ,
-	.irq_config = i2s1_irq_config,
+};
+
+static const struct i2s_cavs_config i2s2_cavs_config = {
+	.regs = (struct i2s_cavs_ssp *)SSP_BASE(2),
+	.mn_regs = (struct i2s_cavs_mn_div *)SSP_MN_DIV_BASE(2),
+	.irq_id = I2S2_CAVS_IRQ,
+};
+
+static const struct i2s_cavs_config i2s3_cavs_config = {
+	.regs = (struct i2s_cavs_ssp *)SSP_BASE(3),
+	.mn_regs = (struct i2s_cavs_mn_div *)SSP_MN_DIV_BASE(3),
+	.irq_id = I2S3_CAVS_IRQ,
 };
 
 static struct i2s_cavs_dev_data i2s1_cavs_data = {
 	.tx = {
 		.dma_channel = CONFIG_I2S_CAVS_1_DMA_TX_CHANNEL,
 		.dma_cfg = {
-			.source_data_size = 1,
-			.dest_data_size = 1,
-			.source_burst_length = 1,
-			.dest_burst_length = 1,
-			.dma_callback = dma_tx_callback,
-			.complete_callback_en = 0,
+			.source_burst_length = CAVS_I2S_DMA_BURST_SIZE,
+			.dest_burst_length = CAVS_I2S_DMA_BURST_SIZE,
+			.dma_callback = i2s_dma_tx_callback,
+			.callback_arg = &DEVICE_NAME_GET(i2s1_cavs),
+			.complete_callback_en = 1,
 			.error_callback_en = 1,
 			.block_count = 1,
+			.head_block = &i2s1_cavs_data.tx.dma_block,
 			.channel_direction = MEMORY_TO_PERIPHERAL,
 			.dma_slot = DMA_HANDSHAKE_SSP1_TX,
 		},
-		.mem_block_queue.buf = i2s1_ring_buf,
-		.mem_block_queue.len = ARRAY_SIZE(i2s1_ring_buf),
-		.stream_start = tx_stream_start,
-		.stream_disable = tx_stream_disable,
-		.queue_drop = tx_queue_drop,
+	},
+	.rx = {
+		.dma_channel = CONFIG_I2S_CAVS_1_DMA_RX_CHANNEL,
+		.dma_cfg = {
+			.source_burst_length = CAVS_I2S_DMA_BURST_SIZE,
+			.dest_burst_length = CAVS_I2S_DMA_BURST_SIZE,
+			.dma_callback = i2s_dma_rx_callback,
+			.callback_arg = &DEVICE_NAME_GET(i2s1_cavs),
+			.complete_callback_en = 1,
+			.error_callback_en = 1,
+			.block_count = 1,
+			.head_block = &i2s1_cavs_data.rx.dma_block,
+			.channel_direction = PERIPHERAL_TO_MEMORY,
+			.dma_slot = DMA_HANDSHAKE_SSP1_RX,
+		},
+	}
+};
+
+static struct i2s_cavs_dev_data i2s2_cavs_data = {
+	.tx = {
+		.dma_channel = CONFIG_I2S_CAVS_2_DMA_TX_CHANNEL,
+		.dma_cfg = {
+			.source_burst_length = CAVS_I2S_DMA_BURST_SIZE,
+			.dest_burst_length = CAVS_I2S_DMA_BURST_SIZE,
+			.dma_callback = i2s_dma_tx_callback,
+			.callback_arg = &DEVICE_NAME_GET(i2s2_cavs),
+			.complete_callback_en = 1,
+			.error_callback_en = 1,
+			.block_count = 1,
+			.head_block = &i2s2_cavs_data.tx.dma_block,
+			.channel_direction = MEMORY_TO_PERIPHERAL,
+			.dma_slot = DMA_HANDSHAKE_SSP2_TX,
+		},
+	},
+	.rx = {
+		.dma_channel = CONFIG_I2S_CAVS_2_DMA_RX_CHANNEL,
+		.dma_cfg = {
+			.source_burst_length = CAVS_I2S_DMA_BURST_SIZE,
+			.dest_burst_length = CAVS_I2S_DMA_BURST_SIZE,
+			.dma_callback = i2s_dma_rx_callback,
+			.callback_arg = &DEVICE_NAME_GET(i2s2_cavs),
+			.complete_callback_en = 1,
+			.error_callback_en = 1,
+			.block_count = 1,
+			.head_block = &i2s2_cavs_data.rx.dma_block,
+			.channel_direction = PERIPHERAL_TO_MEMORY,
+			.dma_slot = DMA_HANDSHAKE_SSP2_RX,
+		},
 	},
 };
 
-DEVICE_AND_API_INIT(i2s1_cavs, CONFIG_I2S_CAVS_1_NAME, &i2s1_cavs_initialize,
+static struct i2s_cavs_dev_data i2s3_cavs_data = {
+	.tx = {
+		.dma_channel = CONFIG_I2S_CAVS_3_DMA_TX_CHANNEL,
+		.dma_cfg = {
+			.source_burst_length = CAVS_I2S_DMA_BURST_SIZE,
+			.dest_burst_length = CAVS_I2S_DMA_BURST_SIZE,
+			.dma_callback = i2s_dma_tx_callback,
+			.callback_arg = &DEVICE_NAME_GET(i2s3_cavs),
+			.complete_callback_en = 1,
+			.error_callback_en = 1,
+			.block_count = 1,
+			.head_block = &i2s3_cavs_data.tx.dma_block,
+			.channel_direction = MEMORY_TO_PERIPHERAL,
+			.dma_slot = DMA_HANDSHAKE_SSP3_TX,
+		},
+	},
+	.rx = {
+		.dma_channel = CONFIG_I2S_CAVS_3_DMA_RX_CHANNEL,
+		.dma_cfg = {
+			.source_burst_length = CAVS_I2S_DMA_BURST_SIZE,
+			.dest_burst_length = CAVS_I2S_DMA_BURST_SIZE,
+			.dma_callback = i2s_dma_rx_callback,
+			.callback_arg = &DEVICE_NAME_GET(i2s3_cavs),
+			.complete_callback_en = 1,
+			.error_callback_en = 1,
+			.block_count = 1,
+			.head_block = &i2s3_cavs_data.rx.dma_block,
+			.channel_direction = PERIPHERAL_TO_MEMORY,
+			.dma_slot = DMA_HANDSHAKE_SSP3_RX,
+		},
+	},
+};
+
+DEVICE_AND_API_INIT(i2s1_cavs, CONFIG_I2S_CAVS_1_NAME, i2s_cavs_initialize,
 		    &i2s1_cavs_data, &i2s1_cavs_config, POST_KERNEL,
+		    CONFIG_I2S_INIT_PRIORITY, &i2s_cavs_driver_api);
+DEVICE_AND_API_INIT(i2s2_cavs, CONFIG_I2S_CAVS_2_NAME, i2s_cavs_initialize,
+		    &i2s2_cavs_data, &i2s2_cavs_config, POST_KERNEL,
+		    CONFIG_I2S_INIT_PRIORITY, &i2s_cavs_driver_api);
+DEVICE_AND_API_INIT(i2s3_cavs, CONFIG_I2S_CAVS_3_NAME, i2s_cavs_initialize,
+		    &i2s3_cavs_data, &i2s3_cavs_config, POST_KERNEL,
 		    CONFIG_I2S_INIT_PRIORITY, &i2s_cavs_driver_api);

--- a/include/dma.h
+++ b/include/dma.h
@@ -164,12 +164,16 @@ struct dma_config {
 typedef int (*dma_api_config)(struct device *dev, u32_t channel,
 			      struct dma_config *config);
 
+typedef int (*dma_api_reload)(struct device *dev, u32_t channel,
+		u32_t src, u32_t dst, size_t size);
+
 typedef int (*dma_api_start)(struct device *dev, u32_t channel);
 
 typedef int (*dma_api_stop)(struct device *dev, u32_t channel);
 
 struct dma_driver_api {
 	dma_api_config config;
+	dma_api_reload reload;
 	dma_api_start start;
 	dma_api_stop stop;
 };
@@ -194,6 +198,27 @@ static inline int dma_config(struct device *dev, u32_t channel,
 	const struct dma_driver_api *api = dev->driver_api;
 
 	return api->config(dev, channel, config);
+}
+
+/**
+ * @brief Reload buffer(s) for a DMA channel
+ *
+ * @param dev     Pointer to the device structure for the driver instance.
+ * @param channel Numeric identification of the channel to configure
+ *                selected channel
+ * @param src     source address for the DMA transfer
+ * @param dst     destination address for the DMA transfer
+ * @param size    size of DMA transfer
+ *
+ * @retval 0 if successful.
+ * @retval Negative errno code if failure.
+ */
+static inline int dma_reload(struct device *dev, u32_t channel,
+		u32_t src, u32_t dst, size_t size)
+{
+	const struct dma_driver_api *api = dev->driver_api;
+
+	return api->reload(dev, channel, src, dst, size);
 }
 
 /**


### PR DESCRIPTION
This PR adds an implementation of bidirectional I2S for Intel S1000 in i2s_cavs driver.
Also included is the addition of the DMA `reload` API as in #8974