### PR TITLE
subsys: random: xoroshiro128: Use entropy get isr during init

### DIFF
--- a/subsys/random/rand32_xoroshiro128.c
+++ b/subsys/random/rand32_xoroshiro128.c
@@ -58,7 +58,17 @@ static int xoroshiro128_initialize(struct device *dev)
 		return -EINVAL;
 	}
 
-	if (entropy_get_entropy(dev, (uint8_t *)&state, sizeof(state)) < 0) {
+	s32_t rc = entropy_get_entropy_isr(dev, (uint8_t *)&state,
+					   sizeof(state), ENTROPY_BUSYWAIT);
+
+	if (rc == -ENOTSUP) {
+		/* Driver does not provide an ISR-specific API, assume it can
+		 * be called from ISR context
+		 */
+		rc = entropy_get_entropy(dev, (u8_t *)&state, sizeof(state));
+	}
+
+	if (rc < 0) {
 		return -EINVAL;
 	}
 


### PR DESCRIPTION
Current implementation of the xoroshiro depends on the ISR being
triggered when the interrupts is locked. This patch proposes
implementing the init with entropy_get_isr. This implementation
can be called at PRE_KERNEL_2 stage, even when the interrupts
are locked.

Fixes: #8199

Signed-off-by: Adithya Baglody <adithya.nagaraj.baglody@intel.com>