### PR TITLE
logging: Fix possible out-of-bound access in log_output

### DIFF
--- a/include/logging/log_msg.h
+++ b/include/logging/log_msg.h
@@ -273,7 +273,8 @@ u32_t log_msg_nargs_get(struct log_msg *msg);
  * @param msg		Standard log message.
  * @param arg_idx	Argument index.
  *
- * @return Argument value.
+ * @return Argument value or 0 if arg_idx exceeds number of arguments in the
+ *	   message.
  */
 u32_t log_msg_arg_get(struct log_msg *msg, u32_t arg_idx);
 

--- a/subsys/logging/log_msg.c
+++ b/subsys/logging/log_msg.c
@@ -116,6 +116,11 @@ u32_t log_msg_arg_get(struct log_msg *msg, u32_t arg_idx)
 {
 	u32_t arg;
 
+	/* Return early if requested argument not present in the message. */
+	if (arg_idx >= msg->hdr.params.std.nargs) {
+		return 0;
+	}
+
 	if (msg->hdr.params.std.nargs <= LOG_MSG_NARGS_SINGLE_CHUNK) {
 		arg = msg->payload.single.args[arg_idx];
 	} else {


### PR DESCRIPTION
Coverity issue #187067

Fixes #8999 
Signed-off-by: Krzysztof Chruscinski <krzysztof.chruscinski@nordicsemi.no>