### PR TITLE
Kconfig: Get rid of ENV_VAR_* prefixes + use new preprocessor syntax for env. vars

### DIFF
--- a/Kconfig.zephyr
+++ b/Kconfig.zephyr
@@ -15,9 +15,9 @@
 # Board defaults should be parsed before SoC defaults, because boards usually
 # overrides SoC values.
 #
-# Note: $ENV_VAR_ARCH and $ENV_VAR_BOARD_DIR might be glob patterns.
-source "$ENV_VAR_BOARD_DIR/Kconfig.defconfig"
-source "arch/$ENV_VAR_ARCH/soc/*/Kconfig.defconfig"
+# Note: $ARCH and $BOARD_DIR might be glob patterns.
+source "$BOARD_DIR/Kconfig.defconfig"
+source "arch/$ARCH/soc/*/Kconfig.defconfig"
 
 
 source "arch/Kconfig"

--- a/Kconfig.zephyr
+++ b/Kconfig.zephyr
@@ -16,8 +16,8 @@
 # overrides SoC values.
 #
 # Note: $ARCH and $BOARD_DIR might be glob patterns.
-source "$BOARD_DIR/Kconfig.defconfig"
-source "arch/$ARCH/soc/*/Kconfig.defconfig"
+source "$(BOARD_DIR)/Kconfig.defconfig"
+source "arch/$(ARCH)/soc/*/Kconfig.defconfig"
 
 
 source "arch/Kconfig"

--- a/arch/Kconfig
+++ b/arch/Kconfig
@@ -13,7 +13,7 @@
 
 source "boards/Kconfig"
 # Note: $ARCH might be a glob pattern
-source "arch/$ARCH/Kconfig"
+source "arch/$(ARCH)/Kconfig"
 
 
 choice

--- a/arch/Kconfig
+++ b/arch/Kconfig
@@ -12,8 +12,8 @@
 # overriden (by defining symbols in multiple locations)
 
 source "boards/Kconfig"
-# Note: $ENV_VAR_ARCH might be a glob pattern
-source "arch/$ENV_VAR_ARCH/Kconfig"
+# Note: $ARCH might be a glob pattern
+source "arch/$ARCH/Kconfig"
 
 
 choice

--- a/boards/Kconfig
+++ b/boards/Kconfig
@@ -17,13 +17,13 @@ config QEMU_TARGET
 
 choice
 prompt "Board Selection"
-source "$BOARD_DIR/Kconfig.board"
+source "$(BOARD_DIR)/Kconfig.board"
 endchoice
 
 
 menu "Board Options"
 # There might not be any board options, hence the optional source
-osource "$BOARD_DIR/Kconfig"
+osource "$(BOARD_DIR)/Kconfig"
 endmenu
 
 menu "Shields"

--- a/boards/Kconfig
+++ b/boards/Kconfig
@@ -13,17 +13,17 @@ config QEMU_TARGET
 	  Mark all QEMU targets with this variable for checking whether we are
 	  running in an emulated environment.
 
-# Note: $ENV_VAR_BOARD_DIR might be a glob pattern
+# Note: $BOARD_DIR might be a glob pattern
 
 choice
 prompt "Board Selection"
-source "$ENV_VAR_BOARD_DIR/Kconfig.board"
+source "$BOARD_DIR/Kconfig.board"
 endchoice
 
 
 menu "Board Options"
 # There might not be any board options, hence the optional source
-osource "$ENV_VAR_BOARD_DIR/Kconfig"
+osource "$BOARD_DIR/Kconfig"
 endmenu
 
 menu "Shields"

--- a/cmake/kconfig.cmake
+++ b/cmake/kconfig.cmake
@@ -20,8 +20,8 @@ set(ENV{KCONFIG_AUTOHEADER} ${AUTOCONF_H})
 
 # Set environment variables so that Kconfig can prune Kconfig source
 # files for other architectures
-set(ENV{ENV_VAR_ARCH}      ${ARCH})
-set(ENV{ENV_VAR_BOARD_DIR} ${BOARD_DIR})
+set(ENV{ARCH}      ${ARCH})
+set(ENV{BOARD_DIR} ${BOARD_DIR})
 
 add_custom_target(
   menuconfig
@@ -29,8 +29,8 @@ add_custom_target(
   srctree=${ZEPHYR_BASE}
   KERNELVERSION=${PROJECT_VERSION}
   KCONFIG_CONFIG=${DOTCONFIG}
-  ENV_VAR_ARCH=$ENV{ENV_VAR_ARCH}
-  ENV_VAR_BOARD_DIR=$ENV{ENV_VAR_BOARD_DIR}
+  ARCH=$ENV{ARCH}
+  BOARD_DIR=$ENV{BOARD_DIR}
   ${PYTHON_EXECUTABLE} ${ZEPHYR_BASE}/scripts/kconfig/menuconfig.py ${KCONFIG_ROOT}
   WORKING_DIRECTORY ${PROJECT_BINARY_DIR}/kconfig
   USES_TERMINAL

--- a/doc/CMakeLists.txt
+++ b/doc/CMakeLists.txt
@@ -115,8 +115,8 @@ add_custom_target(
   COMMAND ${CMAKE_COMMAND} -E env
   PYTHONPATH="${ZEPHYR_BASE}/scripts/kconfig${SEP}$ENV{PYTHONPATH}"
   srctree=${ZEPHYR_BASE}
-  ENV_VAR_BOARD_DIR=boards/*/*/
-  ENV_VAR_ARCH=*
+  BOARD_DIR=boards/*/*/
+  ARCH=*
   KERNELVERSION=${PROJECT_VERSION}
   SRCARCH=x86
   ${PYTHON_EXECUTABLE} scripts/genrest.py Kconfig ${RST_OUT}/doc/reference/kconfig/

--- a/doc/application/application-kconfig.include
+++ b/doc/application/application-kconfig.include
@@ -2,4 +2,4 @@ mainmenu "Your Application Name"
 
 # Your application configuration options go here
 
-source "$ZEPHYR_BASE/Kconfig.zephyr"
+source "$(ZEPHYR_BASE)/Kconfig.zephyr"

--- a/samples/drivers/CAN/Kconfig
+++ b/samples/drivers/CAN/Kconfig
@@ -46,4 +46,4 @@ config LOOPBACK_MODE
 	  This allows testing without a second board.
 
 
-source "$ZEPHYR_BASE/Kconfig.zephyr"
+source "$(ZEPHYR_BASE)/Kconfig.zephyr"

--- a/samples/net/gptp/Kconfig
+++ b/samples/net/gptp/Kconfig
@@ -58,4 +58,4 @@ config NET_SAMPLE_IFACE3_VLAN_TAG
 endif
 
 
-source "$ZEPHYR_BASE/Kconfig.zephyr"
+source "$(ZEPHYR_BASE)/Kconfig.zephyr"

--- a/samples/net/lldp/Kconfig
+++ b/samples/net/lldp/Kconfig
@@ -10,7 +10,7 @@
 
 mainmenu "LLDP sample application"
 
-source "$ZEPHYR_BASE/Kconfig.zephyr"
+source "$(ZEPHYR_BASE)/Kconfig.zephyr"
 
 if NET_LLDP
 

--- a/samples/net/stats/Kconfig
+++ b/samples/net/stats/Kconfig
@@ -17,4 +17,4 @@ config SAMPLE_PERIOD
 	  Print statistics after every n. seconds
 
 
-source "$ZEPHYR_BASE/Kconfig.zephyr"
+source "$(ZEPHYR_BASE)/Kconfig.zephyr"

--- a/samples/net/traffic_class/Kconfig
+++ b/samples/net/traffic_class/Kconfig
@@ -45,4 +45,4 @@ config SAMPLE_PEER_IPV4_ADDR_2
 	  The value depends on your network setup.
 
 
-source "$ZEPHYR_BASE/Kconfig.zephyr"
+source "$(ZEPHYR_BASE)/Kconfig.zephyr"

--- a/samples/net/vlan/Kconfig
+++ b/samples/net/vlan/Kconfig
@@ -35,4 +35,4 @@ config SAMPLE_IPV4_ADDR_2
 	  The value depends on your network setup.
 
 
-source "$ZEPHYR_BASE/Kconfig.zephyr"
+source "$(ZEPHYR_BASE)/Kconfig.zephyr"

--- a/samples/net/wifi/Kconfig
+++ b/samples/net/wifi/Kconfig
@@ -17,4 +17,4 @@ config WINC1500_GPIO_RESET_N
 endif # WIFI_WINC1500
 
 
-source "$ZEPHYR_BASE/Kconfig.zephyr"
+source "$(ZEPHYR_BASE)/Kconfig.zephyr"

--- a/scripts/ci/check-compliance.py
+++ b/scripts/ci/check-compliance.py
@@ -105,8 +105,8 @@ def run_kconfig_undef_ref_check(tc, commit_range):
     os.environ["srctree"] = repository_path
 
     # Parse the entire Kconfig tree, to make sure we see all symbols
-    os.environ["ENV_VAR_BOARD_DIR"] = "boards/*/*"
-    os.environ["ENV_VAR_ARCH"] = "*"
+    os.environ["BOARD_DIR"] = "boards/*/*"
+    os.environ["ARCH"] = "*"
 
     # Enable strict Kconfig mode in Kconfiglib, which assumes there's just a
     # single Kconfig tree and warns for all references to undefined symbols

--- a/tests/benchmarks/object_footprint/Kconfig
+++ b/tests/benchmarks/object_footprint/Kconfig
@@ -1,6 +1,6 @@
 mainmenu "Zephyr Object Sizes"
 
-source "$ZEPHYR_BASE/Kconfig.zephyr"
+source "$(ZEPHYR_BASE)/Kconfig.zephyr"
 
 config OBJECTS_PRINTK
 	bool "use printk"

--- a/tests/drivers/i2c/i2c_slave_api/Kconfig
+++ b/tests/drivers/i2c/i2c_slave_api/Kconfig
@@ -1,5 +1,5 @@
 mainmenu "I2C Slave API Test"
 
-source "$ZEPHYR_BASE/Kconfig.zephyr"
+source "$(ZEPHYR_BASE)/Kconfig.zephyr"
 
-source "$ZEPHYR_BASE/tests/drivers/i2c/i2c_slave_api/common/Kconfig"
+source "$(ZEPHYR_BASE)/tests/drivers/i2c/i2c_slave_api/common/Kconfig"

--- a/tests/drivers/spi/spi_loopback/Kconfig
+++ b/tests/drivers/spi/spi_loopback/Kconfig
@@ -1,6 +1,6 @@
 mainmenu "SPI Loopback Test"
 
-source "$ZEPHYR_BASE/Kconfig.zephyr"
+source "$(ZEPHYR_BASE)/Kconfig.zephyr"
 
 config SPI_LOOPBACK_DRV_NAME
 	string "SPI device name to use for test"

--- a/tests/kernel/arm_irq_vector_table/Kconfig
+++ b/tests/kernel/arm_irq_vector_table/Kconfig
@@ -1,4 +1,5 @@
 config NUM_IRQS
 	int "Number of IRQs for this test, made overridable in the .conf file"
 	default 3
-source "$ZEPHYR_BASE/Kconfig.zephyr"
+
+source "$(ZEPHYR_BASE)/Kconfig.zephyr"


### PR DESCRIPTION
Commit messages say it all:

```
Kconfig: Use new preprocessor syntax for env. variables

With the new Kconfig preprocessor (described in
https://github.com/torvalds/linux/blob/master/Documentation/kbuild/
kconfig-macro-language.txt), the syntax for expanding environment
variables is $(FOO) rather than $FOO.

$(FOO) is a general preprocessor variable expansion, which falls back to
environment variables if the variable isn't set (like in Make). It can
also be used in prompts, 'comment's, etc.

The old syntax will probably be supported forever in Kconfiglib for
backwards compatibility, but might as well make it consistent now that
people might start using the preprocessor more.
```

```
Kconfig: Rename $ENV_VAR_{ARCH,BOARD_DIR} to $ARCH/$BOARD_DIR
    
The prefixes might be a leftover from the old 'option env="..."' symbols
(which are no longer needed). Since environment variables can be
referenced directly now, there's no point in having a prefix.
```