### PR TITLE
Bluetooth: mesh: Fix missing semicolon

### DIFF
--- a/subsys/bluetooth/host/mesh/health_srv.c
+++ b/subsys/bluetooth/host/mesh/health_srv.c
@@ -390,7 +390,7 @@ int bt_mesh_health_srv_init(struct bt_mesh_model *model, bool primary)
 		return -EINVAL;
 	}
 
-	model->pub->update = health_pub_update,
+	model->pub->update = health_pub_update;
 
 	k_delayed_work_init(&srv->attn_timer, attention_off);
 


### PR DESCRIPTION
Fix a missing semicolon at the end of a statement.

Signed-off-by: Carles Cufi <carles.cufi@nordicsemi.no>