### PR TITLE
net: fix return type of net_addr_type2str

### DIFF
--- a/include/net/net_ip.h
+++ b/include/net/net_ip.h
@@ -232,7 +232,7 @@ enum net_addr_type {
 } __packed;
 
 #if NET_LOG_ENABLED > 0
-static inline char *net_addr_type2str(enum net_addr_type type)
+static inline const char *net_addr_type2str(enum net_addr_type type)
 {
 	switch (type) {
 	case NET_ADDR_AUTOCONF:
@@ -251,7 +251,7 @@ static inline char *net_addr_type2str(enum net_addr_type type)
 	return "<unknown>";
 }
 #else /* NET_LOG_ENABLED */
-static inline char *net_addr_type2str(enum net_addr_type type)
+static inline const char *net_addr_type2str(enum net_addr_type type)
 {
 	ARG_UNUSED(type);
 


### PR DESCRIPTION
As we return stuff that is probably in the flash the return type should
be const char * and not char * as the user better doesn't try to change
them!

Signed-off-by: Alexander Polleti <metapsycholo@gmail.com>