### PR TITLE
scripts: dts: extract: Fix handling of interrupt prop being a list of…

### DIFF
--- a/scripts/dts/extract/interrupts.py
+++ b/scripts/dts/extract/interrupts.py
@@ -51,6 +51,12 @@ class DTInterrupts(DTDirective):
         l_base = def_label.split('/')
         index = 0
 
+        # Newer versions of dtc might have the interrupt propertly look like
+        # interrupts = <1 2>, <3 4>;
+        # So we need to flatten the list in that case
+        if isinstance(props[0], list):
+            props = [item for sublist in props for item in sublist]
+
         while props:
             prop_def = {}
             prop_alias = {}


### PR DESCRIPTION
… lists

Before dtc 1.4.7 we'd get something like the following for an interrupt
property in which #interrupt-cells is 2.

interrupts = <1 2 3 4>;

After dtc 1.4.7 we get:

interrupts = <1 2>, <3 4>;

We should handle both cases in the extract interrupt handling code.  So
if we see a list of lists, we flatten it to a single list to normalize
the property.

Fixes: #9558

Signed-off-by: Kumar Gala <kumar.gala@linaro.org>