### PR TITLE
bluetooth: host: fix redundant reference count

### DIFF
--- a/subsys/bluetooth/host/hci_core.c
+++ b/subsys/bluetooth/host/hci_core.c
@@ -253,15 +253,15 @@ int bt_hci_cmd_send_sync(u16_t opcode, struct net_buf *buf,
 		if (!buf) {
 			return -ENOBUFS;
 		}
+	} else {
+		/* Make sure the buffer stays around until the command completes */
+		net_buf_ref(buf);
 	}
 
 	BT_DBG("buf %p opcode 0x%04x len %u", buf, opcode, buf->len);
 
 	k_sem_init(&sync_sem, 0, 1);
 	cmd(buf)->sync = &sync_sem;
-
-	/* Make sure the buffer stays around until the command completes */
-	/* net_buf_ref(buf); */
 
 	net_buf_put(&bt_dev.cmd_tx_queue, buf);
 

--- a/subsys/bluetooth/host/hci_core.c
+++ b/subsys/bluetooth/host/hci_core.c
@@ -261,7 +261,7 @@ int bt_hci_cmd_send_sync(u16_t opcode, struct net_buf *buf,
 	cmd(buf)->sync = &sync_sem;
 
 	/* Make sure the buffer stays around until the command completes */
-	net_buf_ref(buf);
+	/* net_buf_ref(buf); */
 
 	net_buf_put(&bt_dev.cmd_tx_queue, buf);
 

--- a/subsys/bluetooth/host/hci_core.c
+++ b/subsys/bluetooth/host/hci_core.c
@@ -254,7 +254,7 @@ int bt_hci_cmd_send_sync(u16_t opcode, struct net_buf *buf,
 			return -ENOBUFS;
 		}
 	} else {
-		/* Make sure the buffer stays around until the command completes */
+		/* Make sure the buffer stays around until the command completes. */
 		net_buf_ref(buf);
 	}
 


### PR DESCRIPTION
bt_hci_cmd_create creates a buffer with a reference count of 1, so there is no need to increase the reference count again. Test found that it caused the buffer not be released.