### PR TITLE
adc: sam: Fixed adc_api test for the SAM E70.

### DIFF
--- a/drivers/adc/adc_sam_afec.c
+++ b/drivers/adc/adc_sam_afec.c
@@ -212,11 +212,6 @@ static int start_read(struct device *dev, const struct adc_sequence *sequence)
 		return -EINVAL;
 	}
 
-	if (sequence->options->interval_us != 0) {
-		SYS_LOG_ERR("Spaced intervals not supported");
-		return -EINVAL;
-	}
-
 	u8_t num_active_channels = 0;
 	u8_t channel = 0;
 


### PR DESCRIPTION
The interval_us is supported by the adc_context code. It is not a feature that the driver writer needs to code to support. Fixes bug #9723.

Signed-off-by: Justin Watson <jwatson5@gmail.com>