### PR TITLE
net: Add INET_ADDRSTRLEN and use it at least in net_config

### DIFF
--- a/include/net/net_ip.h
+++ b/include/net/net_ip.h
@@ -179,7 +179,10 @@ struct net_addr {
 extern const struct in6_addr in6addr_any;
 extern const struct in6_addr in6addr_loopback;
 
+/* Defined by POSIX. INET6_ADDRSTRLEN accounts for mapped IPv4 addresses. */
+#define INET_ADDRSTRLEN 16
 #define INET6_ADDRSTRLEN 46
+
 #define NET_IPV6_ADDR_LEN sizeof("xxxx:xxxx:xxxx:xxxx:xxxx:xxxx:xxxx:xxxx")
 #define NET_IPV4_ADDR_LEN sizeof("xxx.xxx.xxx.xxx")
 

--- a/subsys/net/lib/config/init.c
+++ b/subsys/net/lib/config/init.c
@@ -41,7 +41,7 @@ static void ipv4_addr_add_handler(struct net_mgmt_event_callback *cb,
 				  struct net_if *iface)
 {
 #if defined(CONFIG_NET_DEBUG_APP) && CONFIG_SYS_LOG_NET_LEVEL > 2
-	char hr_addr[NET_IPV4_ADDR_LEN];
+	char hr_addr[INET_ADDRSTRLEN];
 #endif
 	int i;
 
@@ -60,16 +60,16 @@ static void ipv4_addr_add_handler(struct net_mgmt_event_callback *cb,
 #if defined(CONFIG_NET_DEBUG_APP) && CONFIG_SYS_LOG_NET_LEVEL > 2
 		NET_INFO("IPv4 address: %s",
 			 net_addr_ntop(AF_INET, &if_addr->address.in_addr,
-				       hr_addr, NET_IPV4_ADDR_LEN));
+				       hr_addr, sizeof(hr_addr)));
 		NET_INFO("Lease time: %u seconds",
 			 iface->config.dhcpv4.lease_time);
 		NET_INFO("Subnet: %s",
 			 net_addr_ntop(AF_INET,
 				       &iface->config.ip.ipv4->netmask,
-				       hr_addr, NET_IPV4_ADDR_LEN));
+				       hr_addr, sizeof(hr_addr)));
 		NET_INFO("Router: %s",
 			 net_addr_ntop(AF_INET, &iface->config.ip.ipv4->gw,
-				       hr_addr, NET_IPV4_ADDR_LEN));
+				       hr_addr, sizeof(hr_addr)));
 #endif
 		break;
 	}
@@ -103,7 +103,7 @@ static void setup_dhcpv4(struct net_if *iface)
 static void setup_ipv4(struct net_if *iface)
 {
 #if defined(CONFIG_NET_DEBUG_APP) && CONFIG_SYS_LOG_NET_LEVEL > 2
-	char hr_addr[NET_IPV4_ADDR_LEN];
+	char hr_addr[INET_ADDRSTRLEN];
 #endif
 	struct in_addr addr;
 
@@ -135,7 +135,7 @@ static void setup_ipv4(struct net_if *iface)
 
 #if defined(CONFIG_NET_DEBUG_APP) && CONFIG_SYS_LOG_NET_LEVEL > 2
 	NET_INFO("IPv4 address: %s",
-		 net_addr_ntop(AF_INET, &addr, hr_addr, NET_IPV4_ADDR_LEN));
+		 net_addr_ntop(AF_INET, &addr, hr_addr, sizeof(hr_addr)));
 #endif
 
 	if (sizeof(CONFIG_NET_CONFIG_MY_IPV4_NETMASK) > 1) {


### PR DESCRIPTION
POSIX defines INET_ADDRSTRLEN and INET6_ADDRSTRLEN as max sizes of
textual form of IP addresses (including terminating NUL):
http://pubs.opengroup.org/onlinepubs/9699919799/basedefs/netinet_in.h.html

We already define INET6_ADDRSTRLEN, so it makes sense to define
INET_ADDRSTRLEN too.

But in parallel to those, we also have NET_IPV4_ADDR_LEN and
NET_IPV6_ADDR_LEN, and that's what most of the code uses. But it
doesn't make sense to have 2 parallel definitions, and it would
make sense to just switch to POSIX defines.

The caveat is that INET6_ADDRSTRLEN is defined to be 46, while
max size of native IPv6 is 40 (with NUL). That's because
INET6_ADDRSTRLEN accounts for IPv6-mapped IPv4 addresses, as
explained in
https://stackoverflow.com/questions/39443413/why-is-inet6-addrstrlen-defined-as-46-in-c

E.g.:

ffff:ffff:ffff:ffff:ffff:ffff:255.255.255.255

So, it doesn't feel easy to replace current NET_IPV6_ADDR_LEN with
INET6_ADDRSTRLEN, given that many such buffers are allocated on
stack.

I think that switching to POSIX names, just define e.g.
INET6_ADDRSTRLEN_SHORT and use that for the output buffers,
where native IPv6 addresses are guaranteed.

Signed-off-by: Paul Sokolovsky <paul.sokolovsky@linaro.org>