### PR TITLE
CODEOWNERS: Add @pfalcon for drivers/ethernet/

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -72,7 +72,7 @@ drivers/adc/                             @anangl
 drivers/bluetooth/                       @sjanc @jhedberg @Vudentz
 drivers/clock_control/*stm32f4*          @rsalveti @idlethread
 drivers/counter/                         @anangl
-drivers/ethernet/                        @jukkar @tbursztyka
+drivers/ethernet/                        @jukkar @tbursztyka @pfalcon
 drivers/flash/                           @nashif
 drivers/flash/*stm32*                    @superna9999
 drivers/gpio/*stm32*                     @rsalveti @idlethread


### PR DESCRIPTION
As I'm a reviewer for net/ip/, be sure to review also changes to
drivers/ethernet/, as that's closely related to the IP stack.

Signed-off-by: Paul Sokolovsky <paul.sokolovsky@linaro.org>