### PR TITLE
net: gptp: Set stack size correctly for handler thread

### DIFF
--- a/subsys/net/l2/ethernet/gptp/gptp.c
+++ b/subsys/net/l2/ethernet/gptp/gptp.c
@@ -892,7 +892,7 @@ static void init_ports(void)
 	gptp_init_state_machine();
 
 	tid = k_thread_create(&gptp_thread_data, gptp_stack,
-			      sizeof(gptp_stack),
+			      K_THREAD_STACK_SIZEOF(gptp_stack),
 			      (k_thread_entry_t)gptp_thread,
 			      NULL, NULL, NULL, K_PRIO_COOP(5), 0, 0);
 }


### PR DESCRIPTION
The gptp stack size was not properly set, one must use
the K_THREAD_STACK_SIZEOF() macro to calculate stack size.

Signed-off-by: Jukka Rissanen <jukka.rissanen@linux.intel.com>