### PR TITLE
Bluetooth: GATT: fix registering services before stack is initialized

### DIFF
--- a/subsys/bluetooth/host/gatt.c
+++ b/subsys/bluetooth/host/gatt.c
@@ -308,8 +308,11 @@ int bt_gatt_service_register(struct bt_gatt_service *svc)
 		return err;
 	}
 
-	sc_indicate(&gatt_sc, svc->attrs[0].handle,
-		    svc->attrs[svc->attr_count - 1].handle);
+	/* Only indicate if the stack is initialized */
+	if (atomic_test_bit(bt_dev.flags, BT_DEV_READY)) {
+		sc_indicate(&gatt_sc, svc->attrs[0].handle,
+			    svc->attrs[svc->attr_count - 1].handle);
+	}
 
 	return 0;
 }
@@ -322,8 +325,11 @@ int bt_gatt_service_unregister(struct bt_gatt_service *svc)
 		return -ENOENT;
 	}
 
-	sc_indicate(&gatt_sc, svc->attrs[0].handle,
-		    svc->attrs[svc->attr_count - 1].handle);
+	/* Only indicate if the stack is initialized */
+	if (atomic_test_bit(bt_dev.flags, BT_DEV_READY)) {
+		sc_indicate(&gatt_sc, svc->attrs[0].handle,
+			    svc->attrs[svc->attr_count - 1].handle);
+	}
 
 	return 0;
 }


### PR DESCRIPTION
When registering and unregistering a BLE GATT service, a work item related to service changed indication is submitted to a potentially uninitialized work queue (#9785). This patch adds a check for stack
initialization before attempting to submit any item to the work queue.

@Vudentz could you please review my changes?
CC: @carlescufi @cvinayak 