### PR TITLE
drivers: sensor: dht: Fix fetch fail when CONFIG_SYS_CLOCK_HW_CYCLES_…

### DIFF
--- a/drivers/sensor/dht/dht.c
+++ b/drivers/sensor/dht/dht.c
@@ -39,7 +39,7 @@ static s8_t dht_measure_signal_duration(struct dht_data *drv_data,
 		gpio_pin_read(drv_data->gpio, CONFIG_DHT_GPIO_PIN_NUM, &val);
 		elapsed_cycles = k_cycle_get_32() - start_cycles;
 
-		if (elapsed_cycles >= max_wait_cycles) {
+		if (elapsed_cycles > max_wait_cycles) {
 			return -1;
 		}
 	} while (val == signal_val);


### PR DESCRIPTION
…PER_SEC=32768

When CONFIG_SYS_CLOCK_HW_CYCLES_PER_SEC=32768 max_wait_cycles maybe small than 60us.
The fix change the condition,make sure the wait time exceeds 80us.

Fixed #9816

Signed-off-by: Frank Li <lgl88911@163.com>