### PR TITLE
Revert recent single-thread changes

### DIFF
--- a/include/arch/arm/cortex_m/asm_inline_gcc.h
+++ b/include/arch/arm/cortex_m/asm_inline_gcc.h
@@ -175,8 +175,6 @@ static ALWAYS_INLINE void _arch_irq_unlock(unsigned int key)
 #endif /* CONFIG_ARMV6_M_ARMV8_M_BASELINE */
 }
 
-/* Used to unconditionally enable interrupts when MULTITHREADING=n */
-#define Z_ARCH_INT_ENABLE() _arch_irq_unlock(0)
 
 #endif /* _ASMLANGUAGE */
 

--- a/include/arch/x86/arch.h
+++ b/include/arch/x86/arch.h
@@ -445,9 +445,6 @@ static ALWAYS_INLINE void _arch_irq_unlock(unsigned int key)
 	_do_irq_unlock();
 }
 
-/* Used to unconditionally enable interrupts when MULTITHREADING=n */
-#define Z_ARCH_INT_ENABLE() _arch_irq_unlock(0x200)
-
 /**
  * The NANO_SOFT_IRQ macro must be used as the value for the @a irq parameter
  * to NANO_CPU_INT_REGISTER when connecting to an interrupt that does not

--- a/include/drivers/system_timer.h
+++ b/include/drivers/system_timer.h
@@ -65,13 +65,8 @@ extern int sys_clock_device_ctrl(struct device *device,
 #endif
 
 extern s32_t _sys_idle_elapsed_ticks;
-
-#ifdef CONFIG_MULTITHREADING
 #define _sys_clock_tick_announce() \
 		_nano_sys_clock_tick_announce(_sys_idle_elapsed_ticks)
-#else
-#define _sys_clock_tick_announce() /**/
-#endif
 
 /**
  * @brief Account for the tick due to the timer interrupt

--- a/kernel/init.c
+++ b/kernel/init.c
@@ -436,18 +436,6 @@ sys_rand32_fallback:
 extern uintptr_t __stack_chk_guard;
 #endif /* CONFIG_STACK_CANARIES */
 
-#ifndef CONFIG_MULTITHREADING
-static void enable_interrupts(void)
-{
-#ifdef Z_ARCH_INT_ENABLE
-	Z_ARCH_INT_ENABLE();
-#else
-# pragma message "Z_ARCH_INT_ENABLE not defined for this architecture."
-# pragma message "Entry to MULTITHREADING=n app code will be with interrupts disabled."
-#endif
-}
-#endif
-
 /**
  *
  * @brief Initialize kernel
@@ -502,7 +490,6 @@ FUNC_NORETURN void _Cstart(void)
 	prepare_multithreading(dummy_thread);
 	switch_to_main_thread();
 #else
-	enable_interrupts();
 	bg_thread_main(NULL, NULL, NULL);
 
 	irq_lock();


### PR DESCRIPTION
Single thread keep introducing more issues, decided to remove the feature
completely and push any required changes for after 1.13.

See #9808, fixes #9703, reverts #9668