### PR TITLE
bluetooth: mesh: Fix incorrect reference to BT_SETTINGS

### DIFF
--- a/subsys/bluetooth/host/mesh/cfg_srv.c
+++ b/subsys/bluetooth/host/mesh/cfg_srv.c
@@ -3327,7 +3327,7 @@ static void mod_reset(struct bt_mesh_model *mod, struct bt_mesh_elem *elem,
 
 	mod_sub_list_clear(mod);
 
-	if (IS_ENABLED(BT_SETTINGS)) {
+	if (IS_ENABLED(CONFIG_BT_SETTINGS)) {
 		bt_mesh_store_mod_sub(mod);
 	}
 }


### PR DESCRIPTION
The test for IS_ENABLED(BT_SETTINGS) in mod_reset()
should be IS_ENABLED(CONFIG_BT_SETTINGS).

Fixes #9833

Signed-off-by: David Leach <david.leach@nxp.com>