### PR TITLE
c++: Fix compilation of C++ file that includes i2c.h

### DIFF
--- a/include/i2c.h
+++ b/include/i2c.h
@@ -196,7 +196,8 @@ __syscall int i2c_configure(struct device *dev, u32_t dev_config);
 
 static inline int _impl_i2c_configure(struct device *dev, u32_t dev_config)
 {
-	const struct i2c_driver_api *api = dev->driver_api;
+	const struct i2c_driver_api *api =
+		(const struct i2c_driver_api *)dev->driver_api;
 
 	return api->configure(dev, dev_config);
 }
@@ -227,7 +228,8 @@ static inline int _impl_i2c_transfer(struct device *dev,
 				     struct i2c_msg *msgs, u8_t num_msgs,
 				     u16_t addr)
 {
-	const struct i2c_driver_api *api = dev->driver_api;
+	const struct i2c_driver_api *api =
+		(const struct i2c_driver_api *)dev->driver_api;
 
 	return api->transfer(dev, msgs, num_msgs, addr);
 }
@@ -261,7 +263,8 @@ __syscall int i2c_slave_register(struct device *dev,
 static inline int _impl_i2c_slave_register(struct device *dev,
 					   struct i2c_slave_config *cfg)
 {
-	const struct i2c_driver_api *api = dev->driver_api;
+	const struct i2c_driver_api *api =
+		(const struct i2c_driver_api *)dev->driver_api;
 
 	if (!api->slave_register) {
 		return -ENOTSUP;
@@ -291,7 +294,8 @@ __syscall int i2c_slave_unregister(struct device *dev,
 static inline int _impl_i2c_slave_unregister(struct device *dev,
 					     struct i2c_slave_config *cfg)
 {
-	const struct i2c_driver_api *api = dev->driver_api;
+	const struct i2c_driver_api *api =
+		(const struct i2c_driver_api *)dev->driver_api;
 
 	if (!api->slave_unregister) {
 		return -ENOTSUP;
@@ -316,7 +320,8 @@ __syscall int i2c_slave_driver_register(struct device *dev);
 
 static inline int _impl_i2c_slave_driver_register(struct device *dev)
 {
-	const struct i2c_slave_driver_api *api = dev->driver_api;
+	const struct i2c_slave_driver_api *api =
+		(const struct i2c_slave_driver_api *)dev->driver_api;
 
 	return api->driver_register(dev);
 }
@@ -337,7 +342,8 @@ __syscall int i2c_slave_driver_unregister(struct device *dev);
 
 static inline int _impl_i2c_slave_driver_unregister(struct device *dev)
 {
-	const struct i2c_slave_driver_api *api = dev->driver_api;
+	const struct i2c_slave_driver_api *api =
+		(const struct i2c_slave_driver_api *)dev->driver_api;
 
 	return api->driver_unregister(dev);
 }


### PR DESCRIPTION
Within a C++ file I include i2c.h and got 6 of the following errors:

zephyr/include/i2c.h:199:42: error: invalid conversion from
	‘const void*’ to ‘const i2c_driver_api*’ [-fpermissive]
  const struct i2c_driver_api *api = dev->driver_api;
                                     ~~~~~^~~~~~~~~~

I fixed it with a c style conversion for each instance, so
const struct i2c_driver_api *api = dev->driver_api;
becomes

const struct i2c_driver_api *api =
	(const struct i2c_driver_api *)dev->driver_api;

I handled the instances for i2c_slave_driver_api alike.

I tested this with a one of my own boards and communication with a
I2C sensor.

Signed-off-by: Alexander Polleti <metapsycholo@gmail.com>