### PR TITLE
Doc armv8m specifics in 1.13 release notes

### DIFF
--- a/doc/release-notes-1.13.rst
+++ b/doc/release-notes-1.13.rst
@@ -47,6 +47,10 @@ Architectures
 * arm: nxp: mpu: Consolidate k64 mpu regions
 * arm: Print NXP MPU error information in BusFault dump
 * arch: ARM: Change the march used by cortex-m0 and cortex-m0plus
+* arch: arm: integrate ARM CMSE with CMake
+* arch: arm: basic Arm TrustZone-M functionality for Cortex-M23 and Cortex-M33
+* arch: arm: built-in stack protection using Armv8-M SPLIM registers
+* arch: arm: API for using TT intrinsics in Secure/Non-Secure Armv8-M firmware
 * arch: arm: clean up MPU code for ARM and NXP
 * arch: arm: Set Zero Latency IRQ to priority level zero
 * arch/arm: Fix locking in __pendsv

--- a/doc/release-notes-1.13.rst
+++ b/doc/release-notes-1.13.rst
@@ -20,7 +20,7 @@ Major enhancements with this release include:
 * Introduced reworked ADC API and updated Nordic, NXP, Atmel, and Designware
   drivers
 * Support OS driven Power Management framework
-
+* Basic support for Arm TrustZone in Armv8-M
 
 The following sections provide detailed lists of changes by component.
 


### PR DESCRIPTION
Some points to add in the release notes, for Armv8-M and TrustZone.