### PR TITLE
net: Add INET_ADDRSTRLEN POSIX define

### DIFF
--- a/include/net/net_ip.h
+++ b/include/net/net_ip.h
@@ -179,7 +179,11 @@ struct net_addr {
 extern const struct in6_addr in6addr_any;
 extern const struct in6_addr in6addr_loopback;
 
+/* Defined by POSIX. INET6_ADDRSTRLEN accounts for mapped IPv4 addresses. */
+#define INET_ADDRSTRLEN 16
 #define INET6_ADDRSTRLEN 46
+
+/* These are for internal usage of the stack */
 #define NET_IPV6_ADDR_LEN sizeof("xxxx:xxxx:xxxx:xxxx:xxxx:xxxx:xxxx:xxxx")
 #define NET_IPV4_ADDR_LEN sizeof("xxx.xxx.xxx.xxx")
 


### PR DESCRIPTION
POSIX defines INET_ADDRSTRLEN and INET6_ADDRSTRLEN as max sizes of
textual form of IP addresses (including terminating NUL):
http://pubs.opengroup.org/onlinepubs/9699919799/basedefs/netinet_in.h.html

We already define INET6_ADDRSTRLEN, so it makes sense to define
INET_ADDRSTRLEN too.

Signed-off-by: Paul Sokolovsky <paul.sokolovsky@linaro.org>