### PR TITLE
 bluetooth: gatt: Add GAP Central Address Resolution characteristic 

### DIFF
--- a/include/bluetooth/uuid.h
+++ b/include/bluetooth/uuid.h
@@ -387,6 +387,10 @@ struct bt_uuid_128 {
  *  @brief Barometric Pressure Trend Characteristic
  */
 #define BT_UUID_BAR_PRESSURE_TREND        BT_UUID_DECLARE_16(0x2aa3)
+/** @def BT_UUID_CENTRAL_ADDR_RES
+ *  @brief Central Address Resolution Characteristic
+ */
+#define BT_UUID_CENTRAL_ADDR_RES          BT_UUID_DECLARE_16(0x2aa6)
 /** @def BT_UUID_MESH_PROV_DATA_IN
  *  @brief Mesh Provisioning Data In
  */

--- a/subsys/bluetooth/host/gatt.c
+++ b/subsys/bluetooth/host/gatt.c
@@ -99,6 +99,18 @@ static ssize_t read_appearance(struct bt_conn *conn,
 				 sizeof(appearance));
 }
 
+#if defined(CONFIG_BT_CENTRAL) && defined(CONFIG_BT_PRIVACY)
+static ssize_t read_central_addr_res(struct bt_conn *conn,
+				     const struct bt_gatt_attr *attr, void *buf,
+				     u16_t len, u16_t offset)
+{
+	u8_t central_addr_res = BT_GATT_CENTRAL_ADDR_RES_SUPP;
+
+	return bt_gatt_attr_read(conn, attr, buf, len, offset,
+				 &central_addr_res, sizeof(central_addr_res));
+}
+#endif /* CONFIG_BT_CENTRAL && CONFIG_BT_PRIVACY */
+
 static struct bt_gatt_attr gap_attrs[] = {
 	BT_GATT_PRIMARY_SERVICE(BT_UUID_GAP),
 #if defined(CONFIG_BT_DEVICE_NAME_GATT_WRITABLE)
@@ -113,6 +125,11 @@ static struct bt_gatt_attr gap_attrs[] = {
 #endif /* CONFIG_BT_DEVICE_NAME_GATT_WRITABLE */
 	BT_GATT_CHARACTERISTIC(BT_UUID_GAP_APPEARANCE, BT_GATT_CHRC_READ,
 			       BT_GATT_PERM_READ, read_appearance, NULL, NULL),
+#if defined(CONFIG_BT_CENTRAL) && defined(CONFIG_BT_PRIVACY)
+	BT_GATT_CHARACTERISTIC(BT_UUID_CENTRAL_ADDR_RES,
+			       BT_GATT_CHRC_READ, BT_GATT_PERM_READ,
+			       read_central_addr_res, NULL, NULL),
+#endif /* CONFIG_BT_CENTRAL && CONFIG_BT_PRIVACY */
 };
 
 static struct bt_gatt_service gap_svc = BT_GATT_SERVICE(gap_attrs);

--- a/subsys/bluetooth/host/gatt_internal.h
+++ b/subsys/bluetooth/host/gatt_internal.h
@@ -8,6 +8,9 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+#define BT_GATT_CENTRAL_ADDR_RES_NOT_SUPP	0
+#define BT_GATT_CENTRAL_ADDR_RES_SUPP		1
+
 void bt_gatt_init(void);
 void bt_gatt_connected(struct bt_conn *conn);
 void bt_gatt_disconnected(struct bt_conn *conn);


### PR DESCRIPTION
This adds Central Address Resolution characteristic that is required
to check by peer if it's about to send directed advertisements where
initiator address is set to RPA.
Zephyr supports the Address Resolution, so the characteristic value
is hard-coded.
Please check Core 5.0 Vol 3 Part C 12.4 CENTRAL ADDRESS RESOLUTION
Related PTS test case: GAP/CONN/ACEP/BV-03-C