### PR TITLE
bluetooth: controller: Set peer address and role on dir-adv timeout

### DIFF
--- a/subsys/bluetooth/controller/hci/hci.c
+++ b/subsys/bluetooth/controller/hci/hci.c
@@ -2414,9 +2414,15 @@ static void le_conn_complete(u8_t status, struct radio_le_conn_cmplt *radio_cc,
 		leecc = meta_evt(buf, BT_HCI_EVT_LE_ENH_CONN_COMPLETE,
 				 sizeof(*leecc));
 
+		memset(leecc, 0x00, sizeof(*leecc));
+		leecc->status = status;
+		leecc->role = radio_cc->role;
+
+		leecc->peer_addr.type = radio_cc->peer_addr_type;
+		memcpy(&leecc->peer_addr.a.val[0], &radio_cc->peer_addr[0],
+		       BDADDR_SIZE);
+
 		if (status) {
-			memset(leecc, 0x00, sizeof(*leecc));
-			leecc->status = status;
 			return;
 		}
 
@@ -2451,18 +2457,18 @@ static void le_conn_complete(u8_t status, struct radio_le_conn_cmplt *radio_cc,
 #endif /* CONFIG_BT_CTLR_PRIVACY */
 
 	lecc = meta_evt(buf, BT_HCI_EVT_LE_CONN_COMPLETE, sizeof(*lecc));
+	memset(lecc, 0x00, sizeof(*lecc));
 
-	if (status) {
-		memset(lecc, 0x00, sizeof(*lecc));
-		lecc->status = status;
-		return;
-	}
-
-	lecc->status = 0x00;
-	lecc->handle = sys_cpu_to_le16(handle);
+	lecc->status = status;
 	lecc->role = radio_cc->role;
 	lecc->peer_addr.type = radio_cc->peer_addr_type;
 	memcpy(&lecc->peer_addr.a.val[0], &radio_cc->peer_addr[0], BDADDR_SIZE);
+
+	if (status) {
+		return;
+	}
+
+	lecc->handle = sys_cpu_to_le16(handle);
 	lecc->interval = sys_cpu_to_le16(radio_cc->interval);
 	lecc->latency = sys_cpu_to_le16(radio_cc->latency);
 	lecc->supv_timeout = sys_cpu_to_le16(radio_cc->timeout);

--- a/subsys/bluetooth/controller/ll_sw/ctrl.c
+++ b/subsys/bluetooth/controller/ll_sw/ctrl.c
@@ -6219,11 +6219,19 @@ static void mayfly_adv_stop(void *param)
 	node_rx->hdr.handle = 0xffff;
 	node_rx->hdr.type = NODE_RX_TYPE_CONNECTION;
 
+	struct pdu_adv *pdu_adv = (void *)&_radio.advertiser.adv_data.data
+					  [_radio.advertiser.adv_data.first][0];
+
 	/* prepare connection complete structure */
 	pdu_data_rx = (void *)node_rx->pdu_data;
 	radio_le_conn_cmplt = (void *)pdu_data_rx->lldata;
 	memset(radio_le_conn_cmplt, 0x00, sizeof(struct radio_le_conn_cmplt));
 	radio_le_conn_cmplt->status = BT_HCI_ERR_ADV_TIMEOUT;
+	radio_le_conn_cmplt->role = 0x01;
+	radio_le_conn_cmplt->peer_addr_type = pdu_adv->rx_addr;
+	memcpy(&radio_le_conn_cmplt->peer_addr[0],
+		   &pdu_adv->direct_ind.tgt_addr[0],
+		   BDADDR_SIZE);
 
 	/* enqueue connection complete structure into queue */
 	packet_rx_enqueue();


### PR DESCRIPTION
The controller did not set the identity of the peer it failed to
establish a connection with using directed advertiser, and the role
was set to master when it should be slave.