### PR TITLE
tests/kernel/sched/deadline: Disable CONFIG_BT

### DIFF
--- a/tests/kernel/sched/deadline/prj.conf
+++ b/tests/kernel/sched/deadline/prj.conf
@@ -2,6 +2,7 @@ CONFIG_ZTEST=y
 CONFIG_MP_NUM_CPUS=1
 CONFIG_TEST_RANDOM_GENERATOR=y
 CONFIG_SCHED_DEADLINE=y
+CONFIG_BT=n
 
 # Deadline is not compatible with MULTIQ, so we have to pick something
 # specific instead of using the board-level default.


### PR DESCRIPTION
The BT threads are interfering with the main thread priority selection
and the test fails semi-spuriously on NRF5x boards with "threads ran
too soon" (i.e. not an EDF failure per se, but the fact that the new
threads at K_LOWEST_APPLICATION_PRIO are running instead of the test
thread).  This is a reasonable workaround for testing the
SCHED_DEADLINE ordering behavior, though.

Fixes #9843

Signed-off-by: Andy Ross <andrew.j.ross@intel.com>