### PR TITLE
lib/cmsis_rtos_v1: Fix boundary conditions in the signals module

### DIFF
--- a/lib/cmsis_rtos_v1/cmsis_signal.c
+++ b/lib/cmsis_rtos_v1/cmsis_signal.c
@@ -7,7 +7,8 @@
 #include <kernel_structs.h>
 #include <cmsis_os.h>
 
-#define NSEC_PER_MSEC (NSEC_PER_USEC * USEC_PER_MSEC)
+#define NSEC_PER_MSEC		(NSEC_PER_USEC * USEC_PER_MSEC)
+#define MAX_VALID_SIGNAL_VAL	((1 << osFeature_Signals) - 1)
 
 void *k_thread_other_custom_data_get(struct k_thread *thread_id)
 {
@@ -22,7 +23,7 @@ int32_t osSignalSet(osThreadId thread_id, int32_t signals)
 	int sig, key;
 
 	if ((thread_id == NULL) || (!signals) ||
-		(signals >= (1 << (osFeature_Signals + 1)))) {
+		(signals & 0x80000000) || (signals > MAX_VALID_SIGNAL_VAL)) {
 		return 0x80000000;
 	}
 
@@ -48,7 +49,7 @@ int32_t osSignalClear(osThreadId thread_id, int32_t signals)
 	int sig, key;
 
 	if (_is_in_isr() || (thread_id == NULL) || (!signals) ||
-		(signals >= (1 << (osFeature_Signals + 1)))) {
+		(signals & 0x80000000) || (signals > MAX_VALID_SIGNAL_VAL)) {
 		return 0x80000000;
 	}
 
@@ -81,7 +82,7 @@ osEvent osSignalWait(int32_t signals, uint32_t millisec)
 	}
 
 	/* Check if signals is within the permitted range */
-	if (signals >= (1 << (osFeature_Signals + 1))) {
+	if ((signals & 0x80000000) || (signals > MAX_VALID_SIGNAL_VAL)) {
 		evt.status = osErrorValue;
 		return evt;
 	}


### PR DESCRIPTION
Fixed the boundary conditions around osFeature_Signals.
Fixes #9857.

Signed-off-by: Rajavardhan Gundi <rajavardhan.gundi@intel.com>