### PR TITLE
lib/cmsis_rtos_v1: Check for mutex owner in cmsis

### DIFF
--- a/lib/cmsis_rtos_v1/cmsis_mutex.c
+++ b/lib/cmsis_rtos_v1/cmsis_mutex.c
@@ -84,8 +84,8 @@ osStatus osMutexRelease(osMutexId mutex_id)
 		return osErrorISR;
 	}
 
-	/* The mutex was not obtained before */
-	if (mutex->lock_count == 0) {
+	/* Mutex was not obtained before or was not owned by current thread */
+	if ((mutex->lock_count == 0) || (mutex->owner != _current)) {
 		return osErrorResource;
 	}
 

--- a/tests/cmsis_rtos_v1/src/mutex.c
+++ b/tests/cmsis_rtos_v1/src/mutex.c
@@ -101,6 +101,12 @@ void tThread_entry_lock_timeout(void const *arg)
 	status = osMutexWait((osMutexId)arg, TIMEOUT - 100);
 	zassert_true(status == osErrorTimeoutResource, NULL);
 
+	/* At this point, mutex is held by the other thread.
+	 * Trying to release it here should fail.
+	 */
+	status = osMutexRelease((osMutexId)arg);
+	zassert_true(status == osErrorResource, "Mutex unexpectedly released");
+
 	/* This delay ensures that the mutex gets released by the other
 	 * thread in the meantime
 	 */


### PR DESCRIPTION
Check for the mutex owner in the cmsis layer itself while releasing.
Fixes #9574.

Signed-off-by: Rajavardhan Gundi <rajavardhan.gundi@intel.com>