### PR TITLE
dts: stm32f429vX: Fix delete-node syntax

### DIFF
--- a/dts/arm/st/stm32f429vX.dtsi
+++ b/dts/arm/st/stm32f429vX.dtsi
@@ -16,10 +16,6 @@
 
 #include <st/stm32f429.dtsi>
 
-/ {
-	soc {
-		/delete-node/ &spi5;
+/delete-node/ &spi5;
 
-		/delete-node/ &spi6;
-	};
-};
+/delete-node/ &spi6;


### PR DESCRIPTION
Fix delete-node syntax.

Signed-off-by: Yannis Damigos <giannis.damigos@gmail.com>