### PR TITLE
arm: Clear primask during startup for all architecture variants

### DIFF
--- a/arch/arm/include/kernel_arch_func.h
+++ b/arch/arm/include/kernel_arch_func.h
@@ -77,6 +77,7 @@ _arch_switch_to_main_thread(struct k_thread *main_thread,
 #if defined(CONFIG_ARMV6_M_ARMV8_M_BASELINE)
 		"cpsie i \t\n"
 #elif defined(CONFIG_ARMV7_M_ARMV8_M_MAINLINE)
+		"cpsie if \t\n"
 		"movs %%r1, #0 \n\t"
 		"msr BASEPRI, %%r1 \n\t"
 #else


### PR DESCRIPTION
A bootloader may leave primask set, so clear it during startup when we
enable interrupts and switch to the main thread. Previously we only did
this for architecture variants which don't support basepri, but now we
do it for all architecture variants.

Fixes a failure on mimxrt1050_evk with the latency_measure test and
shell_module sample when using an nxp internal bootloader.

Signed-off-by: Maureen Helm <maureen.helm@nxp.com>

Fixes #9650 
Fixes #9651 