### PR TITLE
doc: use https for docs.zephyrproject.org references

### DIFF
--- a/doc/README.rst
+++ b/doc/README.rst
@@ -6,7 +6,7 @@ Zephyr documentation Generation
 These instructions will walk you through generating the Zephyr Project's
 documentation on your local system using the same documentation sources
 as we use to create the online documentation found at
-http://docs.zephyrproject.org
+https://docs.zephyrproject.org
 
 Documentation overview
 **********************
@@ -26,13 +26,13 @@ their respective websites.
 The project's documentation contains the following items:
 
 * ReStructuredText source files used to generate documentation found at the
-  http://docs.zephyrproject.org website. Most of the reStructuredText sources
+  https://docs.zephyrproject.org website. Most of the reStructuredText sources
   are found in the ``/doc`` directory, but others are stored within the
   code source tree near their specific component (such as ``/samples`` and
   ``/boards``)
 
 * Doxygen-generated material used to create all API-specific documents
-  also found at http://docs.zephyrproject.org
+  also found at https://docs.zephyrproject.org
 
 * Script-generated material for kernel configuration options based on Kconfig
   files found in the source code tree

--- a/doc/contribute/contribute_guidelines.rst
+++ b/doc/contribute/contribute_guidelines.rst
@@ -51,7 +51,7 @@ There are some imported or reused components of the Zephyr project that
 use other licensing, as described in `Zephyr Licensing`_.
 
 .. _Zephyr Licensing:
-   http://docs.zephyrproject.org/LICENSING.html
+   https://docs.zephyrproject.org/LICENSING.html
 
 Importing code into the Zephyr OS from other projects that use a license
 other than the Apache 2.0 license needs to be fully understood in
@@ -66,7 +66,7 @@ See `Contributing non-Apache 2.0 components`_ for more information about
 this contributing and review process for imported components.
 
 .. _Contributing non-Apache 2.0 components:
-   http://docs.zephyrproject.org/contribute/contribute_non-apache.html
+   https://docs.zephyrproject.org/contribute/contribute_non-apache.html
 
 .. _DCO:
 
@@ -140,13 +140,13 @@ and how to set up your development environment as introduced in the Zephyr
 `Getting Started Guide`_.
 
 .. _Getting Started Guide:
-   http://docs.zephyrproject.org/getting_started/getting_started.html
+   https://docs.zephyrproject.org/getting_started/getting_started.html
 
 You should be familiar with common developer tools such as Git and CMake, and
 platforms such as GitHub.
 
 If you haven't already done so, you'll need to create a (free) GitHub account
-on http://github.com and have Git tools available on your development system.
+on https://github.com and have Git tools available on your development system.
 
 .. note::
    The Zephyr development workflow supports all 3 major operating systems
@@ -172,7 +172,7 @@ configurations, and a collection of subsystem tests.  All of these are
 available for developers to contribute to and enhance.
 
 .. _Source Tree Structure:
-   http://docs.zephyrproject.org/kernel/overview/source_tree.html
+   https://docs.zephyrproject.org/kernel/overview/source_tree.html
 
 Pull Requests and Issues
 ************************

--- a/doc/contribute/doc-guidelines.rst
+++ b/doc/contribute/doc-guidelines.rst
@@ -19,7 +19,7 @@ and about `Sphinx extensions`_ from their respective websites.
 .. _Sphinx extensions: http://www.sphinx-doc.org/en/stable/contents.html
 .. _reStructuredText: http://docutils.sourceforge.net/docs/ref/rst/restructuredtext.html
 .. _Sphinx Inline Markup:  http://sphinx-doc.org/markup/inline.html#inline-markup
-.. _Zephyr documentation:  http://docs.zephyrproject.org
+.. _Zephyr documentation:  https://docs.zephyrproject.org
 
 This document provides a quick reference for commonly used reST and
 Sphinx-defined directives and roles used to create the documentation

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -9,7 +9,7 @@ Zephyr Project Documentation
    Welcome to the Zephyr Project's documentation version |version|!
 
    Documentation for the development branch of Zephyr can be found at
-   http://docs.zephyrproject.org/
+   https://docs.zephyrproject.org/
 
 .. only:: (development or daily)
 
@@ -17,7 +17,7 @@ Zephyr Project Documentation
    master tree under development (version |version|).
 
    Documentation for tagged released versions of Zephyr can be found at
-   ``http://docs.zephyrproject.org/<version>``. The following documentation
+   ``https://docs.zephyrproject.org/<version>``. The following documentation
    versions are available:
 
    `Zephyr 1.9.2`_ | `Zephyr 1.10.0`_ | `Zephyr 1.11.0`_ |
@@ -67,8 +67,8 @@ Source code for the Zephyr Project is maintained in the Zephyr Project's
 
 * :ref:`genindex`
 
-.. _Zephyr 1.13.0: http://docs.zephyrproject.org/1.13.0/
-.. _Zephyr 1.12.0: http://docs.zephyrproject.org/1.12.0/
-.. _Zephyr 1.11.0: http://docs.zephyrproject.org/1.11.0/
-.. _Zephyr 1.10.0: http://docs.zephyrproject.org/1.10.0/
-.. _Zephyr 1.9.2: http://docs.zephyrproject.org/1.9.0/
+.. _Zephyr 1.13.0: https://docs.zephyrproject.org/1.13.0/
+.. _Zephyr 1.12.0: https://docs.zephyrproject.org/1.12.0/
+.. _Zephyr 1.11.0: https://docs.zephyrproject.org/1.11.0/
+.. _Zephyr 1.10.0: https://docs.zephyrproject.org/1.10.0/
+.. _Zephyr 1.9.2: https://docs.zephyrproject.org/1.9.0/

--- a/doc/kernel/overview/source_tree.rst
+++ b/doc/kernel/overview/source_tree.rst
@@ -25,7 +25,7 @@ which are not described here.
 
 :file:`doc`
     Zephyr technical documentation source files and tools used to
-    generate the http://docs.zephyrproject.org web content.
+    generate the https://docs.zephyrproject.org web content.
 
 :file:`drivers`
     Device driver code.

--- a/doc/release-notes-1.10.rst
+++ b/doc/release-notes-1.10.rst
@@ -138,7 +138,7 @@ Build and Infrastructure
   either simple one-to-one translations of KBuild features or introduce
   new concepts that replace KBuild concepts. Please re-read the Getting
   Started guide
-  (http://docs.zephyrproject.org/getting_started/getting_started.html)
+  (https://docs.zephyrproject.org/getting_started/getting_started.html)
   with updated instructions for setting up and developing on your host-OS.
   You *will* need to port your own out-of-tree scripts and Makefiles to
   CMake.

--- a/doc/release-notes-1.13.rst
+++ b/doc/release-notes-1.13.rst
@@ -259,7 +259,7 @@ Documentation
 *************
 * Simplified and more maintainable theme applied to documentation.
   Latest and previous four releases regenerated and published to
-  http://docs.zephyrproject.org
+  https://docs.zephyrproject.org
 * Updated contributing guidelines
 * General organization cleanup and spell check on docs including content
   generated from Kconfig files and doxygen API comments.


### PR DESCRIPTION
doc site now supports https access

Signed-off-by: David B. Kinder <david.b.kinder@intel.com>