### PR TITLE
doc: pdf: update linking, document build target, and fix ninja dependency issue

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,3 +14,6 @@ SPHINXOPTS ?= -q
 # ---------------------------------------------------------------------------
 htmldocs:
 	mkdir -p ${BUILDDIR} && cmake -GNinja -DDOC_TAG=${DOC_TAG} -DSPHINXOPTS=${SPHINXOPTS} -B${BUILDDIR} -Hdoc/ && ninja -C ${BUILDDIR} htmldocs
+
+pdfdocs:
+	mkdir -p ${BUILDDIR} && cmake -GNinja -DDOC_TAG=${DOC_TAG} -DSPHINXOPTS=${SPHINXOPTS} -B${BUILDDIR} -Hdoc/ && ninja -C ${BUILDDIR} pdfdocs

--- a/doc/CMakeLists.txt
+++ b/doc/CMakeLists.txt
@@ -145,8 +145,8 @@ add_custom_target(
 #
 # LaTEX section
 #
-add_custom_target(
-  latex
+add_custom_command(
+  OUTPUT ${SPHINX_OUTPUT_DIR_LATEX}/zephyr.tex
   COMMAND ${CMAKE_COMMAND} -E env
   ZEPHYR_BUILD=${CMAKE_CURRENT_BINARY_DIR}
   ${SPHINXBUILD} -w ${SPHINX_LOG} -N -t ${DOC_TAG} -b latex -t svgconvert ${ALLSPHINXOPTS} ${RST_OUT}/doc ${SPHINX_OUTPUT_DIR_LATEX}
@@ -155,6 +155,11 @@ add_custom_target(
   COMMAND ${PYTHON_EXECUTABLE} ${KI_SCRIPT} --config-dir ${CONFIG_DIR} --errors ${DOC_WARN} --warnings ${DOC_WARN} ${DOC_LOG}
   COMMAND ${PYTHON_EXECUTABLE} ${FIX_TEX_SCRIPT} ${SPHINX_OUTPUT_DIR_LATEX}/zephyr.tex
   WORKING_DIRECTORY ${CMAKE_CURRENT_LIST_DIR}
+)
+
+add_custom_target(
+  latex
+  DEPENDS ${SPHINX_OUTPUT_DIR_LATEX}/zephyr.tex
   ${SPHINX_USES_TERMINAL}
 )
 
@@ -213,6 +218,7 @@ if(NOT ${LATEXMK} STREQUAL LATEXMK-NOTFOUND)
 
 add_custom_target(
   pdfdocs
+  DEPENDS latexdocs pdf
 )
 add_dependencies(pdfdocs pdf)
 

--- a/doc/README.rst
+++ b/doc/README.rst
@@ -1,6 +1,6 @@
 .. _zephyr_doc:
 
-Zephyr documentation Generation
+Zephyr Documentation Generation
 ###############################
 
 These instructions will walk you through generating the Zephyr Project's
@@ -52,6 +52,8 @@ Our documentation processing has been tested to run with:
 * Breathe version 4.9.1
 * docutils version 0.14
 * sphinx_rtd_theme version 0.4.0
+* sphinxcontrib-svg2pdfconverter version 0.1.0
+* Latexmk version version 4.56
 
 In order to install the documentation tools, clone a copy of the git repository
 for the Zephyr project and set up your development environment as described in
@@ -98,14 +100,19 @@ folder, here are the commands to generate the html content locally:
 
    # Use cmake to configure a Ninja-based build system:
    cmake -GNinja ..
-   # Now run ninja on the generated build system:
+
+   # To generate HTML output, run ninja on the generated build system:
    ninja htmldocs
    # If you modify or add .rst files, run ninja again:
    ninja htmldocs
 
+   # To generate PDF output, run ninja on the generated build system:
+   ninja pdfdocs
+
 Depending on your development system, it will take up to 15 minutes to
 collect and generate the HTML content.  When done, you can view the HTML
-output with your browser started at ``doc/_build/html/index.html``
+output with your browser started at ``doc/_build/html/index.html`` and
+the PDF file is available at ``doc/_build/pdf/zephyr.pdf``.
 
 If you want to build the documentation from scratch just delete the contents
 of the build folder and run ``cmake`` and then ``ninja`` again.
@@ -118,7 +125,12 @@ there:
 
    cd ~/zephyr
    source zephyr-env.sh
+
+   # To generate HTML output
    make htmldocs
+
+   # To generate PDF output
+   make pdfdocs
 
 Filtering expected warnings
 ***************************

--- a/doc/contribute/contribute_guidelines.rst
+++ b/doc/contribute/contribute_guidelines.rst
@@ -48,10 +48,7 @@ Components using other Licenses
 ===============================
 
 There are some imported or reused components of the Zephyr project that
-use other licensing, as described in `Zephyr Licensing`_.
-
-.. _Zephyr Licensing:
-   https://docs.zephyrproject.org/LICENSING.html
+use other licensing, as described in :ref:`Zephyr_Licensing`.
 
 Importing code into the Zephyr OS from other projects that use a license
 other than the Apache 2.0 license needs to be fully understood in
@@ -62,11 +59,15 @@ By carefully reviewing potential contributions and also enforcing a
 the Zephyr community can develop products with the Zephyr Project
 without concerns over patent or copyright issues.
 
-See `Contributing non-Apache 2.0 components`_ for more information about
+See :ref:`contribute_non-Apache` for more information about
 this contributing and review process for imported components.
 
-.. _Contributing non-Apache 2.0 components:
-   https://docs.zephyrproject.org/contribute/contribute_non-apache.html
+.. only:: latex
+
+   .. toctree::
+      :maxdepth: 1
+
+      ../LICENSING.rst
 
 .. _DCO:
 
@@ -137,10 +138,7 @@ Prerequisites
 As a contributor, you'll want to be familiar with the Zephyr project, how to
 configure, install, and use it as explained in the `Zephyr Project website`_
 and how to set up your development environment as introduced in the Zephyr
-`Getting Started Guide`_.
-
-.. _Getting Started Guide:
-   https://docs.zephyrproject.org/getting_started/getting_started.html
+:ref:`getting_started`.
 
 You should be familiar with common developer tools such as Git and CMake, and
 platforms such as GitHub.
@@ -165,14 +163,11 @@ To clone the main Zephyr Project repository use::
 
     git clone https://github.com/zephyrproject-rtos/zephyr
 
-The Zephyr project directory structure is described in `Source Tree Structure`_
+The Zephyr project directory structure is described in :ref:`source_tree_v2`
 documentation. In addition to the Zephyr kernel itself, you'll also find the
 sources for technical documentation, sample code, supported board
 configurations, and a collection of subsystem tests.  All of these are
 available for developers to contribute to and enhance.
-
-.. _Source Tree Structure:
-   https://docs.zephyrproject.org/kernel/overview/source_tree.html
 
 Pull Requests and Issues
 ************************

--- a/samples/subsys/usb/webusb/README.rst
+++ b/samples/subsys/usb/webusb/README.rst
@@ -24,8 +24,7 @@ real usecase, implement applications based on the WebUSB API.
 Building and flashing
 *********************
 
-Refer to
-https://www.zephyrproject.org/doc/boards/x86/arduino_101/doc/board.html
+Refer to :ref:`arduino_101`
 for details on building and flashing the image into an Arduino 101.
 
 Testing with latest Google Chrome on host


### PR DESCRIPTION
* Adds to the documentation how to build PDF.
* Converts the http links within the Zephyr document into references. This allows the links within the PDF file to jump to the correct sections instead of going to the Internet.
* The chain of dependencies works for make but not for Ninja. Make it explicit so Ninja will work to generate PDF.

This fixes some of the issues raised with the previous PR on generating PDF file. Related to #6782.