### PR TITLE
tests: adc_api: Fix delay problem with test

### DIFF
--- a/tests/drivers/adc/adc_api/src/test_adc.c
+++ b/tests/drivers/adc/adc_api/src/test_adc.c
@@ -297,7 +297,7 @@ static int test_task_asynchronous_call(void)
 	int ret;
 	const struct adc_sequence_options options = {
 		.extra_samplings = 4,
-		.interval_us = 10,
+		.interval_us = 30,
 	};
 	const struct adc_sequence sequence = {
 		.options     = &options,


### PR DESCRIPTION
Increase interval time so that asynchronous test get enough time to run
successfully.

Fixes #9830

Signed-off-by: Punit Vara <punit.vara@intel.com>