### PR TITLE
net/pkt: Rename link layer address accessors relevantly

### DIFF
--- a/include/net/net_pkt.h
+++ b/include/net/net_pkt.h
@@ -183,7 +183,7 @@ static inline struct k_work *net_pkt_work(struct net_pkt *pkt)
 }
 
 /* The interface real ll address */
-static inline struct net_linkaddr *net_pkt_ll_if(struct net_pkt *pkt)
+static inline struct net_linkaddr *net_pkt_lladdr_if(struct net_pkt *pkt)
 {
 	return net_if_get_link_addr(pkt->iface);
 }
@@ -594,29 +594,29 @@ static inline u8_t *net_pkt_ll(struct net_pkt *pkt)
 	return net_pkt_ip_data(pkt) - net_pkt_ll_reserve(pkt);
 }
 
-static inline struct net_linkaddr *net_pkt_ll_src(struct net_pkt *pkt)
+static inline struct net_linkaddr *net_pkt_lladdr_src(struct net_pkt *pkt)
 {
 	return &pkt->lladdr_src;
 }
 
-static inline struct net_linkaddr *net_pkt_ll_dst(struct net_pkt *pkt)
+static inline struct net_linkaddr *net_pkt_lladdr_dst(struct net_pkt *pkt)
 {
 	return &pkt->lladdr_dst;
+}
+
+static inline void net_pkt_lladdr_swap(struct net_pkt *pkt)
+{
+	u8_t *addr = net_pkt_lladdr_src(pkt)->addr;
+
+	net_pkt_lladdr_src(pkt)->addr = net_pkt_lladdr_dst(pkt)->addr;
+	net_pkt_lladdr_dst(pkt)->addr = addr;
 }
 
 static inline void net_pkt_ll_clear(struct net_pkt *pkt)
 {
 	memset(net_pkt_ll(pkt), 0, net_pkt_ll_reserve(pkt));
-	net_pkt_ll_src(pkt)->addr = NULL;
-	net_pkt_ll_src(pkt)->len = 0;
-}
-
-static inline void net_pkt_ll_swap(struct net_pkt *pkt)
-{
-	u8_t *addr = net_pkt_ll_src(pkt)->addr;
-
-	net_pkt_ll_src(pkt)->addr = net_pkt_ll_dst(pkt)->addr;
-	net_pkt_ll_dst(pkt)->addr = addr;
+	net_pkt_lladdr_src(pkt)->addr = NULL;
+	net_pkt_lladdr_src(pkt)->len = 0;
 }
 
 #if defined(CONFIG_IEEE802154) || defined(CONFIG_IEEE802154_RAW_MODE)

--- a/subsys/net/ip/6lo.c
+++ b/subsys/net/ip/6lo.c
@@ -315,13 +315,13 @@ static inline u8_t compress_sa(struct net_ipv6_hdr *ipv6,
 			memcpy(&IPHC[offset], &ipv6->src.s6_addr[14], 2);
 			offset += 2;
 		} else {
-			if (!net_pkt_ll_src(pkt)) {
+			if (!net_pkt_lladdr_src(pkt)) {
 				NET_ERR("Invalid src ll address");
 				return 0;
 			}
 
-			if (net_ipv6_addr_based_on_ll(&ipv6->src,
-						      net_pkt_ll_src(pkt))) {
+			if (net_ipv6_addr_based_on_ll(
+				    &ipv6->src, net_pkt_lladdr_src(pkt))) {
 				NET_DBG("SAM_11 src address is fully elided");
 
 				/* Address is fully elided */
@@ -371,7 +371,7 @@ static inline u8_t compress_sa_ctx(struct net_ipv6_hdr *ipv6,
 		memcpy(&IPHC[offset], &ipv6->src.s6_addr[14], 2);
 		offset += 2;
 	} else if (net_ipv6_addr_based_on_ll(&ipv6->src,
-					     net_pkt_ll_src(pkt))) {
+					     net_pkt_lladdr_src(pkt))) {
 		NET_DBG("SAM_11 src address is fully elided");
 
 		/* Address is fully elided */
@@ -467,13 +467,13 @@ static inline u8_t compress_da(struct net_ipv6_hdr *ipv6,
 			memcpy(&IPHC[offset], &ipv6->dst.s6_addr[14], 2);
 			offset += 2;
 		} else {
-			if (!net_pkt_ll_dst(pkt)) {
+			if (!net_pkt_lladdr_dst(pkt)) {
 				NET_ERR("Invalid dst ll address");
 				return 0;
 			}
 
-			if (net_ipv6_addr_based_on_ll(&ipv6->dst,
-						      net_pkt_ll_dst(pkt))) {
+			if (net_ipv6_addr_based_on_ll(
+				    &ipv6->dst, net_pkt_lladdr_dst(pkt))) {
 				NET_DBG("DAM_11 dst addr fully elided");
 
 				/* Address is fully elided */
@@ -522,7 +522,7 @@ static inline u8_t compress_da_ctx(struct net_ipv6_hdr *ipv6,
 		offset += 2;
 	} else {
 		if (net_ipv6_addr_based_on_ll(&ipv6->dst,
-					      net_pkt_ll_dst(pkt))) {
+					      net_pkt_lladdr_dst(pkt))) {
 			NET_DBG("DAM_11 dst addr fully elided");
 
 			/* Address is fully elided */
@@ -909,7 +909,7 @@ static inline u8_t uncompress_sa(struct net_pkt *pkt,
 	case NET_6LO_IPHC_SAM_11:
 		NET_DBG("SAM_11 generate src addr from ll");
 
-		net_ipv6_addr_create_iid(&ipv6->src, net_pkt_ll_src(pkt));
+		net_ipv6_addr_create_iid(&ipv6->src, net_pkt_lladdr_src(pkt));
 		break;
 	}
 
@@ -955,7 +955,7 @@ static inline u8_t uncompress_sa_ctx(struct net_pkt *pkt,
 		 * the encapsulating header.
 		 * (e.g., 802.15.4 or IPv6 source address).
 		 */
-		net_ipv6_addr_create_iid(&ipv6->src, net_pkt_ll_src(pkt));
+		net_ipv6_addr_create_iid(&ipv6->src, net_pkt_lladdr_src(pkt));
 
 		/* net_ipv6_addr_create_iid will copy first 8 bytes
 		 * as link local prefix.
@@ -1066,7 +1066,7 @@ static inline u8_t uncompress_da(struct net_pkt *pkt,
 	case NET_6LO_IPHC_DAM_11:
 		NET_DBG("DAM_11 generate dst addr from ll");
 
-		net_ipv6_addr_create_iid(&ipv6->dst, net_pkt_ll_dst(pkt));
+		net_ipv6_addr_create_iid(&ipv6->dst, net_pkt_lladdr_dst(pkt));
 		break;
 	}
 
@@ -1119,7 +1119,7 @@ static inline u8_t uncompress_da_ctx(struct net_pkt *pkt,
 		 * the encapsulating header.
 		 * (e.g., 802.15.4 or IPv6 source address).
 		 */
-		net_ipv6_addr_create_iid(&ipv6->dst, net_pkt_ll_dst(pkt));
+		net_ipv6_addr_create_iid(&ipv6->dst, net_pkt_lladdr_dst(pkt));
 
 		/* net_ipv6_addr_create_iid will copy first 8 bytes
 		 * as link local prefix.

--- a/subsys/net/ip/icmpv4.c
+++ b/subsys/net/ip/icmpv4.c
@@ -300,8 +300,8 @@ int net_icmpv4_send_error(struct net_pkt *orig, u8_t type, u8_t code)
 
 	net_ipv4_finalize(pkt, IPPROTO_ICMP);
 
-	net_pkt_ll_dst(pkt)->addr = net_pkt_ll_src(orig)->addr;
-	net_pkt_ll_dst(pkt)->len = net_pkt_ll_src(orig)->len;
+	net_pkt_lladdr_dst(pkt)->addr = net_pkt_lladdr_src(orig)->addr;
+	net_pkt_lladdr_dst(pkt)->len = net_pkt_lladdr_src(orig)->len;
 
 	NET_DBG("Sending ICMPv4 Error Message type %d code %d from %s to %s",
 		type, code,

--- a/subsys/net/ip/icmpv6.c
+++ b/subsys/net/ip/icmpv6.c
@@ -363,13 +363,13 @@ static enum net_verdict handle_echo_request(struct net_pkt *orig)
 #endif
 	}
 
-	net_pkt_ll_src(pkt)->addr = net_pkt_ll_dst(orig)->addr;
-	net_pkt_ll_src(pkt)->len = net_pkt_ll_dst(orig)->len;
+	net_pkt_lladdr_src(pkt)->addr = net_pkt_lladdr_dst(orig)->addr;
+	net_pkt_lladdr_src(pkt)->len = net_pkt_lladdr_dst(orig)->len;
 
 	/* We must not set the destination ll address here but trust
 	 * that it is set properly using a value from neighbor cache.
 	 */
-	net_pkt_ll_dst(pkt)->addr = NULL;
+	net_pkt_lladdr_dst(pkt)->addr = NULL;
 
 	/* ICMPv6 fields */
 	ret = net_icmpv6_get_hdr(pkt, &icmp_hdr);
@@ -498,10 +498,10 @@ int net_icmpv6_send_error(struct net_pkt *orig, u8_t type, u8_t code,
 		net_ipaddr_copy(&NET_IPV6_HDR(pkt)->dst, &addr);
 	}
 
-	net_pkt_ll_src(pkt)->addr = net_pkt_ll_dst(orig)->addr;
-	net_pkt_ll_src(pkt)->len = net_pkt_ll_dst(orig)->len;
-	net_pkt_ll_dst(pkt)->addr = net_pkt_ll_src(orig)->addr;
-	net_pkt_ll_dst(pkt)->len = net_pkt_ll_src(orig)->len;
+	net_pkt_lladdr_src(pkt)->addr = net_pkt_lladdr_dst(orig)->addr;
+	net_pkt_lladdr_src(pkt)->len = net_pkt_lladdr_dst(orig)->len;
+	net_pkt_lladdr_dst(pkt)->addr = net_pkt_lladdr_src(orig)->addr;
+	net_pkt_lladdr_dst(pkt)->len = net_pkt_lladdr_src(orig)->len;
 
 	/* Clear and then set the chksum */
 	err = net_icmpv6_set_chksum(pkt);

--- a/subsys/net/ip/ipv6_nbr.c
+++ b/subsys/net/ip/ipv6_nbr.c
@@ -686,11 +686,11 @@ static struct net_pkt *update_ll_reserve(struct net_pkt *pkt,
 	 */
 	if (0) {
 		NET_DBG("ll src %s",
-			net_sprint_ll_addr(net_pkt_ll_src(pkt)->addr,
-					   net_pkt_ll_src(pkt)->len));
+			net_sprint_ll_addr(net_pkt_lladdr_src(pkt)->addr,
+					   net_pkt_lladdr_src(pkt)->len));
 		NET_DBG("ll dst %s",
-			net_sprint_ll_addr(net_pkt_ll_dst(pkt)->addr,
-					   net_pkt_ll_dst(pkt)->len));
+			net_sprint_ll_addr(net_pkt_lladdr_dst(pkt)->addr,
+					   net_pkt_lladdr_dst(pkt)->len));
 		NET_DBG("ip src %s",
 			net_sprint_ipv6_addr(&NET_IPV6_HDR(pkt)->src));
 		NET_DBG("ip dst %s",
@@ -883,7 +883,7 @@ ignore_frag_error:
 	 * contain public IPv6 address information so in that case we should
 	 * not enter this branch.
 	 */
-	if ((net_pkt_ll_dst(pkt)->addr &&
+	if ((net_pkt_lladdr_dst(pkt)->addr &&
 	     ((IS_ENABLED(CONFIG_NET_ROUTING) &&
 	      net_is_ipv6_ll_addr(&NET_IPV6_HDR(pkt)->dst)) ||
 	      !IS_ENABLED(CONFIG_NET_ROUTING))) ||
@@ -953,8 +953,8 @@ try_send:
 
 		lladdr = net_nbr_get_lladdr(nbr->idx);
 
-		net_pkt_ll_dst(pkt)->addr = lladdr->addr;
-		net_pkt_ll_dst(pkt)->len = lladdr->len;
+		net_pkt_lladdr_dst(pkt)->addr = lladdr->addr;
+		net_pkt_lladdr_dst(pkt)->len = lladdr->len;
 
 		NET_DBG("Neighbor %p addr %s", nbr,
 			net_sprint_ll_addr(lladdr->addr, lladdr->len));
@@ -1113,8 +1113,8 @@ static inline struct net_nbr *handle_ns_neighbor(struct net_pkt *pkt,
 	 * 2 * 8 bytes - 2 - padding.
 	 * The formula above needs to be adjusted.
 	 */
-	if (net_pkt_ll_src(pkt)->len < nbr_lladdr.len) {
-		nbr_lladdr.len = net_pkt_ll_src(pkt)->len;
+	if (net_pkt_lladdr_src(pkt)->len < nbr_lladdr.len) {
+		nbr_lladdr.len = net_pkt_lladdr_src(pkt)->len;
 	}
 
 	return nbr_add(pkt, &nbr_lladdr, false, NET_IPV6_NBR_STATE_INCOMPLETE);
@@ -2198,8 +2198,8 @@ static inline struct net_buf *handle_ra_neighbor(struct net_pkt *pkt,
 	llstorage.len = NET_LINK_ADDR_MAX_LENGTH;
 	lladdr.len = NET_LINK_ADDR_MAX_LENGTH;
 	lladdr.addr = llstorage.addr;
-	if (net_pkt_ll_src(pkt)->len < lladdr.len) {
-		lladdr.len = net_pkt_ll_src(pkt)->len;
+	if (net_pkt_lladdr_src(pkt)->len < lladdr.len) {
+		lladdr.len = net_pkt_lladdr_src(pkt)->len;
 	}
 
 	frag = net_frag_read(frag, offset, pos, lladdr.len, lladdr.addr);

--- a/subsys/net/ip/net_if.c
+++ b/subsys/net/ip/net_if.c
@@ -156,7 +156,7 @@ static bool net_if_tx(struct net_if *iface, struct net_pkt *pkt)
 
 	debug_check_packet(pkt);
 
-	dst = net_pkt_ll_dst(pkt);
+	dst = net_pkt_lladdr_dst(pkt);
 	context = net_pkt_context(pkt);
 	context_token = net_pkt_token(pkt);
 
@@ -242,7 +242,7 @@ static inline void init_iface(struct net_if *iface)
 enum net_verdict net_if_send_data(struct net_if *iface, struct net_pkt *pkt)
 {
 	struct net_context *context = net_pkt_context(pkt);
-	struct net_linkaddr *dst = net_pkt_ll_dst(pkt);
+	struct net_linkaddr *dst = net_pkt_lladdr_dst(pkt);
 	void *token = net_pkt_token(pkt);
 	enum net_verdict verdict;
 	int status = -EIO;
@@ -261,9 +261,9 @@ enum net_verdict net_if_send_data(struct net_if *iface, struct net_pkt *pkt)
 	 * https://github.com/zephyrproject-rtos/zephyr/issues/3111
 	 */
 	if (!atomic_test_bit(iface->if_dev->flags, NET_IF_POINTOPOINT) &&
-	    !net_pkt_ll_src(pkt)->addr) {
-		net_pkt_ll_src(pkt)->addr = net_pkt_ll_if(pkt)->addr;
-		net_pkt_ll_src(pkt)->len = net_pkt_ll_if(pkt)->len;
+	    !net_pkt_lladdr_src(pkt)->addr) {
+		net_pkt_lladdr_src(pkt)->addr = net_pkt_lladdr_if(pkt)->addr;
+		net_pkt_lladdr_src(pkt)->len = net_pkt_lladdr_if(pkt)->len;
 	}
 
 #if defined(CONFIG_NET_LOOPBACK)

--- a/subsys/net/ip/route.c
+++ b/subsys/net/ip/route.c
@@ -782,7 +782,7 @@ int net_route_packet(struct net_pkt *pkt, struct in6_addr *nexthop)
 	 */
 	if (net_if_l2(net_pkt_iface(pkt)) != &NET_L2_GET_NAME(DUMMY)) {
 #endif
-		if (!net_pkt_ll_src(pkt)->addr) {
+		if (!net_pkt_lladdr_src(pkt)->addr) {
 			NET_DBG("Link layer source address not set");
 			return -EINVAL;
 		}
@@ -790,7 +790,7 @@ int net_route_packet(struct net_pkt *pkt, struct in6_addr *nexthop)
 		/* Sanitycheck: If src and dst ll addresses are going to be
 		 * same, then something went wrong in route lookup.
 		 */
-		if (!memcmp(net_pkt_ll_src(pkt)->addr, lladdr->addr,
+		if (!memcmp(net_pkt_lladdr_src(pkt)->addr, lladdr->addr,
 			    lladdr->len)) {
 			NET_ERR("Src ll and Dst ll are same");
 			return -EINVAL;
@@ -804,13 +804,13 @@ int net_route_packet(struct net_pkt *pkt, struct in6_addr *nexthop)
 	/* Set the destination and source ll address in the packet.
 	 * We set the destination address to be the nexthop recipient.
 	 */
-	net_pkt_ll_src(pkt)->addr = net_pkt_ll_if(pkt)->addr;
-	net_pkt_ll_src(pkt)->type = net_pkt_ll_if(pkt)->type;
-	net_pkt_ll_src(pkt)->len = net_pkt_ll_if(pkt)->len;
+	net_pkt_lladdr_src(pkt)->addr = net_pkt_lladdr_if(pkt)->addr;
+	net_pkt_lladdr_src(pkt)->type = net_pkt_lladdr_if(pkt)->type;
+	net_pkt_lladdr_src(pkt)->len = net_pkt_lladdr_if(pkt)->len;
 
-	net_pkt_ll_dst(pkt)->addr = lladdr->addr;
-	net_pkt_ll_dst(pkt)->type = lladdr->type;
-	net_pkt_ll_dst(pkt)->len = lladdr->len;
+	net_pkt_lladdr_dst(pkt)->addr = lladdr->addr;
+	net_pkt_lladdr_dst(pkt)->type = lladdr->type;
+	net_pkt_lladdr_dst(pkt)->len = lladdr->len;
 
 	net_pkt_set_iface(pkt, nbr->iface);
 

--- a/subsys/net/ip/rpl.c
+++ b/subsys/net/ip/rpl.c
@@ -2828,12 +2828,12 @@ static enum net_verdict handle_dio(struct net_pkt *pkt)
 	nbr = net_ipv6_nbr_lookup(net_pkt_iface(pkt),
 				  &NET_IPV6_HDR(pkt)->src);
 	if (!nbr) {
-		NET_ASSERT_INFO(net_pkt_ll_src(pkt)->len,
+		NET_ASSERT_INFO(net_pkt_lladdr_src(pkt)->len,
 				"Link layer address not set");
 
 		nbr = net_ipv6_nbr_add(net_pkt_iface(pkt),
 				       &NET_IPV6_HDR(pkt)->src,
-				       net_pkt_ll_src(pkt),
+				       net_pkt_lladdr_src(pkt),
 				       0,
 				       NET_IPV6_NBR_STATE_REACHABLE);
 		if (!nbr) {
@@ -3557,8 +3557,8 @@ static enum net_verdict handle_dao(struct net_pkt *pkt)
 
 		NET_DBG("Neighbor %s [%s] already in neighbor cache",
 			net_sprint_ipv6_addr(dao_sender),
-			net_sprint_ll_addr(net_pkt_ll_src(pkt)->addr,
-					   net_pkt_ll_src(pkt)->len));
+			net_sprint_ll_addr(net_pkt_lladdr_src(pkt)->addr,
+					   net_pkt_lladdr_src(pkt)->len));
 
 		nbr_lladdr = net_nbr_get_lladdr(ipv6_nbr->idx);
 		if (!nbr_lladdr) {
@@ -3566,7 +3566,7 @@ static enum net_verdict handle_dao(struct net_pkt *pkt)
 			return NET_DROP;
 		}
 
-		src_lladdr = net_pkt_ll_src(pkt);
+		src_lladdr = net_pkt_lladdr_src(pkt);
 		if (!src_lladdr || !src_lladdr->addr) {
 			NET_ERR("Invalid src lladdr in net pkt");
 			return NET_DROP;
@@ -3590,7 +3590,7 @@ static enum net_verdict handle_dao(struct net_pkt *pkt)
 
 	if (!ipv6_nbr) {
 		ipv6_nbr = net_ipv6_nbr_add(net_pkt_iface(pkt), dao_sender,
-					    net_pkt_ll_src(pkt), false,
+					    net_pkt_lladdr_src(pkt), false,
 					    NET_IPV6_NBR_STATE_REACHABLE);
 		if (ipv6_nbr) {
 			/* Set reachable timer */
@@ -3599,13 +3599,15 @@ static enum net_verdict handle_dao(struct net_pkt *pkt)
 
 			NET_DBG("Neighbor %s [%s] added to neighbor cache",
 				net_sprint_ipv6_addr(dao_sender),
-				net_sprint_ll_addr(net_pkt_ll_src(pkt)->addr,
-						   net_pkt_ll_src(pkt)->len));
+				net_sprint_ll_addr(
+					net_pkt_lladdr_src(pkt)->addr,
+					net_pkt_lladdr_src(pkt)->len));
 		} else {
 			NET_DBG("Out of memory, dropping DAO from %s [%s]",
 				net_sprint_ipv6_addr(dao_sender),
-				net_sprint_ll_addr(net_pkt_ll_src(pkt)->addr,
-						   net_pkt_ll_src(pkt)->len));
+				net_sprint_ll_addr(
+					net_pkt_lladdr_src(pkt)->addr,
+					net_pkt_lladdr_src(pkt)->len));
 			return NET_DROP;
 		}
 	}
@@ -4121,7 +4123,7 @@ static int net_rpl_update_header_empty(struct net_pkt *pkt)
 
 			nbr = net_nbr_lookup(&net_rpl_parents.table,
 					     net_pkt_iface(pkt),
-					     net_pkt_ll_src(pkt));
+					     net_pkt_lladdr_src(pkt));
 
 			parent = nbr_data(nbr);
 			if (parent) {

--- a/subsys/net/ip/tcp.c
+++ b/subsys/net/ip/tcp.c
@@ -162,12 +162,12 @@ static inline u32_t retry_timeout(const struct net_tcp *tcp)
 				CONFIG_NET_TCP_INIT_RETRANSMISSION_TIMEOUT;
 }
 
-#define is_6lo_technology(pkt)						    \
+#define is_6lo_technology(pkt)						\
 	(IS_ENABLED(CONFIG_NET_IPV6) &&	net_pkt_family(pkt) == AF_INET6 &&  \
-	 ((IS_ENABLED(CONFIG_NET_L2_BT) &&			    \
-	   net_pkt_ll_dst(pkt)->type == NET_LINK_BLUETOOTH) ||		    \
-	  (IS_ENABLED(CONFIG_NET_L2_IEEE802154) &&			    \
-	   net_pkt_ll_dst(pkt)->type == NET_LINK_IEEE802154)))
+	 ((IS_ENABLED(CONFIG_NET_L2_BT) &&				\
+	   net_pkt_lladdr_dst(pkt)->type == NET_LINK_BLUETOOTH) ||	\
+	  (IS_ENABLED(CONFIG_NET_L2_IEEE802154) &&			\
+	   net_pkt_lladdr_dst(pkt)->type == NET_LINK_IEEE802154)))
 
 /* The ref should not be done for Bluetooth and IEEE 802.15.4 which use
  * IPv6 header compression (6lo). For BT and 802.15.4 we copy the pkt

--- a/subsys/net/l2/bluetooth/bluetooth.c
+++ b/subsys/net/l2/bluetooth/bluetooth.c
@@ -198,14 +198,14 @@ static void ipsp_recv(struct bt_l2cap_chan *chan, struct net_buf *buf)
 	}
 
 	/* Set destination address */
-	net_pkt_ll_dst(pkt)->addr = ctxt->src.val;
-	net_pkt_ll_dst(pkt)->len = sizeof(ctxt->src);
-	net_pkt_ll_dst(pkt)->type = NET_LINK_BLUETOOTH;
+	net_pkt_lladdr_dst(pkt)->addr = ctxt->src.val;
+	net_pkt_lladdr_dst(pkt)->len = sizeof(ctxt->src);
+	net_pkt_lladdr_dst(pkt)->type = NET_LINK_BLUETOOTH;
 
 	/* Set source address */
-	net_pkt_ll_src(pkt)->addr = ctxt->dst.val;
-	net_pkt_ll_src(pkt)->len = sizeof(ctxt->dst);
-	net_pkt_ll_src(pkt)->type = NET_LINK_BLUETOOTH;
+	net_pkt_lladdr_src(pkt)->addr = ctxt->dst.val;
+	net_pkt_lladdr_src(pkt)->len = sizeof(ctxt->dst);
+	net_pkt_lladdr_src(pkt)->type = NET_LINK_BLUETOOTH;
 
 	/* Add data buffer as fragment of RX buffer, take a reference while
 	 * doing so since L2CAP will unref the buffer after return.

--- a/subsys/net/l2/dummy/dummy.c
+++ b/subsys/net/l2/dummy/dummy.c
@@ -12,12 +12,12 @@
 static inline enum net_verdict dummy_recv(struct net_if *iface,
 					  struct net_pkt *pkt)
 {
-	net_pkt_ll_src(pkt)->addr = NULL;
-	net_pkt_ll_src(pkt)->len = 0;
-	net_pkt_ll_src(pkt)->type = NET_LINK_DUMMY;
-	net_pkt_ll_dst(pkt)->addr = NULL;
-	net_pkt_ll_dst(pkt)->len = 0;
-	net_pkt_ll_dst(pkt)->type = NET_LINK_DUMMY;
+	net_pkt_lladdr_src(pkt)->addr = NULL;
+	net_pkt_lladdr_src(pkt)->len = 0;
+	net_pkt_lladdr_src(pkt)->type = NET_LINK_DUMMY;
+	net_pkt_lladdr_dst(pkt)->addr = NULL;
+	net_pkt_lladdr_dst(pkt)->len = 0;
+	net_pkt_lladdr_dst(pkt)->type = NET_LINK_DUMMY;
 
 	return NET_CONTINUE;
 }

--- a/subsys/net/l2/ethernet/arp.c
+++ b/subsys/net/l2/ethernet/arp.c
@@ -461,8 +461,8 @@ static inline void arp_update(struct net_if *iface,
 	}
 
 	/* Set the dst in the pending packet */
-	net_pkt_ll_dst(entry->pending)->len = sizeof(struct net_eth_addr);
-	net_pkt_ll_dst(entry->pending)->addr =
+	net_pkt_lladdr_dst(entry->pending)->len = sizeof(struct net_eth_addr);
+	net_pkt_lladdr_dst(entry->pending)->addr =
 		(u8_t *) &NET_ETH_HDR(entry->pending)->dst.addr;
 
 	NET_DBG("dst %s pending %p frag %p",

--- a/subsys/net/l2/ethernet/ethernet.c
+++ b/subsys/net/l2/ethernet/ethernet.c
@@ -169,12 +169,12 @@ static enum net_verdict ethernet_recv(struct net_if *iface,
 	}
 
 	/* Set the pointers to ll src and dst addresses */
-	lladdr = net_pkt_ll_src(pkt);
+	lladdr = net_pkt_lladdr_src(pkt);
 	lladdr->addr = ((struct net_eth_hdr *)net_pkt_ll(pkt))->src.addr;
 	lladdr->len = sizeof(struct net_eth_addr);
 	lladdr->type = NET_LINK_ETHERNET;
 
-	lladdr = net_pkt_ll_dst(pkt);
+	lladdr = net_pkt_lladdr_dst(pkt);
 	lladdr->addr = ((struct net_eth_hdr *)net_pkt_ll(pkt))->dst.addr;
 	lladdr->len = sizeof(struct net_eth_addr);
 	lladdr->type = NET_LINK_ETHERNET;
@@ -183,12 +183,14 @@ static enum net_verdict ethernet_recv(struct net_if *iface,
 	if (vlan_enabled) {
 		print_vlan_ll_addrs(pkt, type, ntohs(hdr_vlan->vlan.tci),
 				    net_pkt_get_len(pkt),
-				    net_pkt_ll_src(pkt), net_pkt_ll_dst(pkt));
+				    net_pkt_lladdr_src(pkt),
+				    net_pkt_lladdr_dst(pkt));
 	} else
 #endif
 	{
 		print_ll_addrs(pkt, type, net_pkt_get_len(pkt),
-			       net_pkt_ll_src(pkt), net_pkt_ll_dst(pkt));
+			       net_pkt_lladdr_src(pkt),
+			       net_pkt_lladdr_dst(pkt));
 	}
 
 	if (!net_eth_is_addr_broadcast((struct net_eth_addr *)lladdr->addr) &&
@@ -242,10 +244,11 @@ static inline bool check_if_dst_is_broadcast_or_mcast(struct net_if *iface,
 	if (net_ipv4_addr_cmp(&NET_IPV4_HDR(pkt)->dst,
 			      net_ipv4_broadcast_address())) {
 		/* Broadcast address */
-		net_pkt_ll_dst(pkt)->addr = (u8_t *)broadcast_eth_addr.addr;
-		net_pkt_ll_dst(pkt)->len = sizeof(struct net_eth_addr);
-		net_pkt_ll_src(pkt)->addr = net_if_get_link_addr(iface)->addr;
-		net_pkt_ll_src(pkt)->len = sizeof(struct net_eth_addr);
+		net_pkt_lladdr_dst(pkt)->addr = (u8_t *)broadcast_eth_addr.addr;
+		net_pkt_lladdr_dst(pkt)->len = sizeof(struct net_eth_addr);
+		net_pkt_lladdr_src(pkt)->addr =
+			net_if_get_link_addr(iface)->addr;
+		net_pkt_lladdr_src(pkt)->len = sizeof(struct net_eth_addr);
 
 		return true;
 	} else if (NET_IPV4_HDR(pkt)->dst.s4_addr[0] == 224) {
@@ -259,9 +262,10 @@ static inline bool check_if_dst_is_broadcast_or_mcast(struct net_if *iface,
 
 		hdr->dst.addr[3] = hdr->dst.addr[3] & 0x7f;
 
-		net_pkt_ll_dst(pkt)->len = sizeof(struct net_eth_addr);
-		net_pkt_ll_src(pkt)->addr = net_if_get_link_addr(iface)->addr;
-		net_pkt_ll_src(pkt)->len = sizeof(struct net_eth_addr);
+		net_pkt_lladdr_dst(pkt)->len = sizeof(struct net_eth_addr);
+		net_pkt_lladdr_src(pkt)->addr =
+			net_if_get_link_addr(iface)->addr;
+		net_pkt_lladdr_src(pkt)->len = sizeof(struct net_eth_addr);
 
 		return true;
 	}
@@ -426,11 +430,12 @@ static enum net_verdict ethernet_send(struct net_if *iface,
 		struct net_pkt *arp_pkt;
 
 		if (check_if_dst_is_broadcast_or_mcast(iface, pkt)) {
-			if (!net_pkt_ll_dst(pkt)->addr) {
+			if (!net_pkt_lladdr_dst(pkt)->addr) {
 				struct net_eth_addr *dst;
 
 				dst = &NET_ETH_HDR(pkt)->dst;
-				net_pkt_ll_dst(pkt)->addr = (u8_t *)dst->addr;
+				net_pkt_lladdr_dst(pkt)->addr =
+					(u8_t *)dst->addr;
 			}
 
 			goto setup_hdr;
@@ -462,10 +467,10 @@ static enum net_verdict ethernet_send(struct net_if *iface,
 			}
 		}
 
-		net_pkt_ll_src(pkt)->addr = (u8_t *)&NET_ETH_HDR(pkt)->src;
-		net_pkt_ll_src(pkt)->len = sizeof(struct net_eth_addr);
-		net_pkt_ll_dst(pkt)->addr = (u8_t *)&NET_ETH_HDR(pkt)->dst;
-		net_pkt_ll_dst(pkt)->len = sizeof(struct net_eth_addr);
+		net_pkt_lladdr_src(pkt)->addr = (u8_t *)&NET_ETH_HDR(pkt)->src;
+		net_pkt_lladdr_src(pkt)->len = sizeof(struct net_eth_addr);
+		net_pkt_lladdr_dst(pkt)->addr = (u8_t *)&NET_ETH_HDR(pkt)->dst;
+		net_pkt_lladdr_dst(pkt)->len = sizeof(struct net_eth_addr);
 
 		/* For ARP message, we do not touch the packet further but will
 		 * send it as it is because the arp.c has prepared the packet
@@ -485,17 +490,17 @@ static enum net_verdict ethernet_send(struct net_if *iface,
 	 * substitute the src address using the real ll address.
 	 */
 	if (net_eth_is_addr_broadcast((struct net_eth_addr *)
-					net_pkt_ll_src(pkt)->addr) ||
+					net_pkt_lladdr_src(pkt)->addr) ||
 	    net_eth_is_addr_multicast((struct net_eth_addr *)
-					net_pkt_ll_src(pkt)->addr)) {
-		net_pkt_ll_src(pkt)->addr = net_pkt_ll_if(pkt)->addr;
-		net_pkt_ll_src(pkt)->len = net_pkt_ll_if(pkt)->len;
+					net_pkt_lladdr_src(pkt)->addr)) {
+		net_pkt_lladdr_src(pkt)->addr = net_pkt_lladdr_if(pkt)->addr;
+		net_pkt_lladdr_src(pkt)->len = net_pkt_lladdr_if(pkt)->len;
 	}
 
 	/* If the destination address is not set, then use broadcast
 	 * or multicast address.
 	 */
-	if (!net_pkt_ll_dst(pkt)->addr) {
+	if (!net_pkt_lladdr_dst(pkt)->addr) {
 #if defined(CONFIG_NET_IPV6)
 		if (net_pkt_family(pkt) == AF_INET6 &&
 		    net_is_ipv6_addr_mcast(&NET_IPV6_HDR(pkt)->dst)) {
@@ -507,19 +512,19 @@ static enum net_verdict ethernet_send(struct net_if *iface,
 			       (u8_t *)(&NET_IPV6_HDR(pkt)->dst) + 12,
 				sizeof(struct net_eth_addr) - 2);
 
-			net_pkt_ll_dst(pkt)->addr = (u8_t *)dst->addr;
+			net_pkt_lladdr_dst(pkt)->addr = (u8_t *)dst->addr;
 		} else
 #endif
 		{
-			net_pkt_ll_dst(pkt)->addr =
+			net_pkt_lladdr_dst(pkt)->addr =
 				(u8_t *)broadcast_eth_addr.addr;
 		}
 
-		net_pkt_ll_dst(pkt)->len = sizeof(struct net_eth_addr);
+		net_pkt_lladdr_dst(pkt)->len = sizeof(struct net_eth_addr);
 
 		NET_DBG("Destination address was not set, using %s",
-			net_sprint_ll_addr(net_pkt_ll_dst(pkt)->addr,
-					   net_pkt_ll_dst(pkt)->len));
+			net_sprint_ll_addr(net_pkt_lladdr_dst(pkt)->addr,
+					   net_pkt_lladdr_dst(pkt)->len));
 	}
 
 setup_hdr:
@@ -548,8 +553,8 @@ send_frame:
 	 */
 	if (ptype != htons(NET_ETH_PTYPE_ARP)) {
 		net_eth_fill_header(ctx, pkt, ptype,
-				    net_pkt_ll_src(pkt)->addr,
-				    net_pkt_ll_dst(pkt)->addr);
+				    net_pkt_lladdr_src(pkt)->addr,
+				    net_pkt_lladdr_dst(pkt)->addr);
 	}
 
 	net_if_queue_tx(iface, pkt);

--- a/subsys/net/l2/ethernet/lldp/lldp.c
+++ b/subsys/net/l2/ethernet/lldp/lldp.c
@@ -128,10 +128,10 @@ static int lldp_send(struct ethernet_lldp *lldp)
 		goto out;
 	}
 
-	net_pkt_ll_src(pkt)->addr = net_if_get_link_addr(lldp->iface)->addr;
-	net_pkt_ll_src(pkt)->len = sizeof(struct net_eth_addr);
-	net_pkt_ll_dst(pkt)->addr = (u8_t *)lldp_multicast_eth_addr.addr;
-	net_pkt_ll_dst(pkt)->len = sizeof(struct net_eth_addr);
+	net_pkt_lladdr_src(pkt)->addr = net_if_get_link_addr(lldp->iface)->addr;
+	net_pkt_lladdr_src(pkt)->len = sizeof(struct net_eth_addr);
+	net_pkt_lladdr_dst(pkt)->addr = (u8_t *)lldp_multicast_eth_addr.addr;
+	net_pkt_lladdr_dst(pkt)->len = sizeof(struct net_eth_addr);
 
 	hdr = NET_ETH_HDR(pkt);
 	hdr->type = htons(NET_ETH_PTYPE_LLDP);

--- a/subsys/net/l2/ieee802154/ieee802154.c
+++ b/subsys/net/l2/ieee802154/ieee802154.c
@@ -141,25 +141,25 @@ enum net_verdict ieee802154_manage_recv_packet(struct net_if *iface,
 	/* Upper IP stack expects the link layer address to be in
 	 * big endian format so we must swap it here.
 	 */
-	if (net_pkt_ll_src(pkt)->addr &&
-	    net_pkt_ll_src(pkt)->len == IEEE802154_EXT_ADDR_LENGTH) {
-		sys_mem_swap(net_pkt_ll_src(pkt)->addr,
-			     net_pkt_ll_src(pkt)->len);
+	if (net_pkt_lladdr_src(pkt)->addr &&
+	    net_pkt_lladdr_src(pkt)->len == IEEE802154_EXT_ADDR_LENGTH) {
+		sys_mem_swap(net_pkt_lladdr_src(pkt)->addr,
+			     net_pkt_lladdr_src(pkt)->len);
 	}
 
-	if (net_pkt_ll_dst(pkt)->addr &&
-	    net_pkt_ll_dst(pkt)->len == IEEE802154_EXT_ADDR_LENGTH) {
-		sys_mem_swap(net_pkt_ll_dst(pkt)->addr,
-			     net_pkt_ll_dst(pkt)->len);
+	if (net_pkt_lladdr_dst(pkt)->addr &&
+	    net_pkt_lladdr_dst(pkt)->len == IEEE802154_EXT_ADDR_LENGTH) {
+		sys_mem_swap(net_pkt_lladdr_dst(pkt)->addr,
+			     net_pkt_lladdr_dst(pkt)->len);
 	}
 
 	/** Uncompress will drop the current fragment. Pkt ll src/dst address
 	 * will then be wrong and must be updated according to the new fragment.
 	 */
-	src = net_pkt_ll_src(pkt)->addr ?
-		net_pkt_ll_src(pkt)->addr - net_pkt_ll(pkt) : 0;
-	dst = net_pkt_ll_dst(pkt)->addr ?
-		net_pkt_ll_dst(pkt)->addr - net_pkt_ll(pkt) : 0;
+	src = net_pkt_lladdr_src(pkt)->addr ?
+		net_pkt_lladdr_src(pkt)->addr - net_pkt_ll(pkt) : 0;
+	dst = net_pkt_lladdr_dst(pkt)->addr ?
+		net_pkt_lladdr_dst(pkt)->addr - net_pkt_ll(pkt) : 0;
 
 #ifdef CONFIG_NET_L2_IEEE802154_FRAGMENT
 	verdict = ieee802154_reassemble(pkt);
@@ -173,8 +173,8 @@ enum net_verdict ieee802154_manage_recv_packet(struct net_if *iface,
 		goto out;
 	}
 #endif
-	net_pkt_ll_src(pkt)->addr = src ? net_pkt_ll(pkt) + src : NULL;
-	net_pkt_ll_dst(pkt)->addr = dst ? net_pkt_ll(pkt) + dst : NULL;
+	net_pkt_lladdr_src(pkt)->addr = src ? net_pkt_ll(pkt) + src : NULL;
+	net_pkt_lladdr_dst(pkt)->addr = dst ? net_pkt_ll(pkt) + dst : NULL;
 
 	pkt_hexdump(RX_PKT_TITLE, pkt, true, false);
 out:
@@ -236,10 +236,10 @@ static enum net_verdict ieee802154_recv(struct net_if *iface,
 	net_pkt_set_ll_reserve(pkt, mpdu.payload - (void *)net_pkt_ll(pkt));
 	net_buf_pull(pkt->frags, net_pkt_ll_reserve(pkt));
 
-	set_pkt_ll_addr(net_pkt_ll_src(pkt), mpdu.mhr.fs->fc.pan_id_comp,
+	set_pkt_ll_addr(net_pkt_lladdr_src(pkt), mpdu.mhr.fs->fc.pan_id_comp,
 			mpdu.mhr.fs->fc.src_addr_mode, mpdu.mhr.src_addr);
 
-	set_pkt_ll_addr(net_pkt_ll_dst(pkt), false,
+	set_pkt_ll_addr(net_pkt_lladdr_dst(pkt), false,
 			mpdu.mhr.fs->fc.dst_addr_mode, mpdu.mhr.dst_addr);
 
 	if (!ieee802154_decipher_data_frame(iface, pkt, &mpdu)) {
@@ -274,7 +274,7 @@ static enum net_verdict ieee802154_send(struct net_if *iface,
 			return NET_DROP;
 		}
 
-		if (!ieee802154_create_data_frame(ctx, net_pkt_ll_dst(pkt),
+		if (!ieee802154_create_data_frame(ctx, net_pkt_lladdr_dst(pkt),
 						  frag, reserved_space)) {
 			return NET_DROP;
 		}

--- a/subsys/net/l2/ieee802154/ieee802154_frame.c
+++ b/subsys/net/l2/ieee802154/ieee802154_frame.c
@@ -925,7 +925,7 @@ bool ieee802154_decipher_data_frame(struct net_if *iface, struct net_pkt *pkt,
 	if (!ieee802154_decrypt_auth(&ctx->sec_ctx, net_pkt_ll(pkt),
 				     net_pkt_ll_reserve(pkt),
 				     net_pkt_get_len(pkt),
-				     net_pkt_ll_src(pkt)->addr,
+				     net_pkt_lladdr_src(pkt)->addr,
 				     sys_le32_to_cpu(
 					mpdu->mhr.aux_sec->frame_counter))) {
 		NET_ERR("Could not decipher the frame");

--- a/tests/net/6lo/src/main.c
+++ b/tests/net/6lo/src/main.c
@@ -317,11 +317,11 @@ static struct net_pkt *create_pkt(struct net_6lo_data *data)
 	net_pkt_set_iface(pkt, net_if_get_default());
 	net_pkt_set_ip_hdr_len(pkt, NET_IPV6H_LEN);
 
-	net_pkt_ll_src(pkt)->addr = src_mac;
-	net_pkt_ll_src(pkt)->len = 8;
+	net_pkt_lladdr_src(pkt)->addr = src_mac;
+	net_pkt_lladdr_src(pkt)->len = 8;
 
-	net_pkt_ll_dst(pkt)->addr = dst_mac;
-	net_pkt_ll_dst(pkt)->len = 8;
+	net_pkt_lladdr_dst(pkt)->addr = dst_mac;
+	net_pkt_lladdr_dst(pkt)->len = 8;
 
 	frag = net_pkt_get_frag(pkt, K_FOREVER);
 	if (!frag) {

--- a/tests/net/rpl/src/main.c
+++ b/tests/net/rpl/src/main.c
@@ -110,8 +110,8 @@ static void set_pkt_ll_addr(struct device *dev, struct net_pkt *pkt)
 {
 	struct net_rpl_test *rpl = dev->driver_data;
 
-	struct net_linkaddr *src = net_pkt_ll_src(pkt);
-	struct net_linkaddr *dst = net_pkt_ll_dst(pkt);
+	struct net_linkaddr *src = net_pkt_lladdr_src(pkt);
+	struct net_linkaddr *dst = net_pkt_lladdr_dst(pkt);
 
 	dst->len = lladdr_src.len;
 	dst->addr = lladdr_src.addr;
@@ -135,7 +135,7 @@ static int tester_send(struct net_if *iface, struct net_pkt *pkt)
 	data_failure = false;
 
 	if (feed_data) {
-		net_pkt_ll_swap(pkt);
+		net_pkt_lladdr_swap(pkt);
 
 		if (net_recv_data(iface, pkt) < 0) {
 			TC_ERROR("Data receive failed.");
@@ -172,7 +172,7 @@ static int tester_send(struct net_if *iface, struct net_pkt *pkt)
 		} else {
 			/* Pass sent DIO message back to us */
 			if (msg_sending == NET_RPL_DODAG_INFO_OBJ) {
-				net_pkt_ll_swap(pkt);
+				net_pkt_lladdr_swap(pkt);
 
 				if (!net_recv_data(iface, pkt)) {
 					/* We must not unref the msg,


### PR DESCRIPTION
*_ll_src/*_ll_dst/*_ll_swap/*_ll_if were not self explanatory, ll
meaning "link layer" it's ambiguous what the names meant.
Changing to:
*_lladdr_src/*_lladdr_dst/*_lladdr_swap/*_lladdr_if to fix this.

Signed-off-by: Tomasz Bursztyka <tomasz.bursztyka@linux.intel.com>