### PR TITLE
mcumgr: Allow to configure taskstat and echo commands support

### DIFF
--- a/ext/lib/mgmt/mcumgr/cmd/os_mgmt/Kconfig
+++ b/ext/lib/mgmt/mcumgr/cmd/os_mgmt/Kconfig
@@ -29,4 +29,12 @@ config OS_MGMT_RESET_MS
       When a reset command is received, the system waits this many milliseconds
       before performing the reset.  This delay allows time for the mcumgr
       response to be delivered.
+
+config OS_MGMT_TASKSTAT
+    bool "Support for taskstat command"
+    default y
+
+config OS_MGMT_ECHO
+    bool "Support for echo command"
+    default y
 endif

--- a/ext/lib/mgmt/mcumgr/cmd/os_mgmt/src/os_mgmt.c
+++ b/ext/lib/mgmt/mcumgr/cmd/os_mgmt/src/os_mgmt.c
@@ -26,17 +26,27 @@
 #include "os_mgmt/os_mgmt_impl.h"
 #include "os_mgmt_config.h"
 
+#ifdef CONFIG_OS_MGMT_ECHO
 static mgmt_handler_fn os_mgmt_echo;
+#endif
+
 static mgmt_handler_fn os_mgmt_reset;
+
+#ifdef CONFIG_OS_MGMT_TASKSTAT
 static mgmt_handler_fn os_mgmt_taskstat_read;
+#endif
 
 static const struct mgmt_handler os_mgmt_group_handlers[] = {
+#ifdef CONFIG_OS_MGMT_ECHO
     [OS_MGMT_ID_ECHO] = {
         os_mgmt_echo, os_mgmt_echo
     },
+#endif
+#ifdef CONFIG_OS_MGMT_TASKSTAT
     [OS_MGMT_ID_TASKSTAT] = {
         os_mgmt_taskstat_read, NULL
     },
+#endif
     [OS_MGMT_ID_RESET] = {
         NULL, os_mgmt_reset
     },
@@ -54,6 +64,7 @@ static struct mgmt_group os_mgmt_group = {
 /**
  * Command handler: os echo
  */
+#ifdef CONFIG_OS_MGMT_ECHO
 static int
 os_mgmt_echo(struct mgmt_ctxt *ctxt)
 {
@@ -89,7 +100,9 @@ os_mgmt_echo(struct mgmt_ctxt *ctxt)
 
     return 0;
 }
+#endif
 
+#ifdef CONFIG_OS_MGMT_TASKSTAT
 /**
  * Encodes a single taskstat entry.
  */
@@ -173,6 +186,7 @@ os_mgmt_taskstat_read(struct mgmt_ctxt *ctxt)
 
     return 0;
 }
+#endif
 
 /**
  * Command handler: os reset


### PR DESCRIPTION
Those commands are not required for OTA and disabling them saves
628 bytes of flash.

Signed-off-by: Szymon Janc <szymon.janc@codecoup.pl>