### PR TITLE
arch: arm: soc: nordic_nrf: nrf52: Add missing header

### DIFF
--- a/arch/arm/soc/nordic_nrf/nrf52/soc_power.h
+++ b/arch/arm/soc/nordic_nrf/nrf52/soc_power.h
@@ -7,6 +7,8 @@
 #ifndef _SOC_POWER_H_
 #define _SOC_POWER_H_
 
+#include <stdbool.h>
+
 #ifdef __cplusplus
 extern "C" {
 #endif


### PR DESCRIPTION
Add missing header required to use bool type.

Signed-off-by: Pawel Dunaj <pawel.dunaj@nordicsemi.no>