### PR TITLE
cmake: move ti_lm3s6965-specific code into the soc directory

### DIFF
--- a/arch/arm/core/cortex_m/reset.S
+++ b/arch/arm/core/cortex_m/reset.S
@@ -15,7 +15,6 @@
 #include <toolchain.h>
 #include <linker/sections.h>
 #include <arch/cpu.h>
-#include <offsets_short.h>
 #include "vector_table.h"
 
 _ASM_FILE_PROLOGUE
@@ -104,53 +103,3 @@ SECTION_SUBSEC_FUNC(TEXT,_reset_section,__start)
     isb
 
     b _PrepC
-
-#if defined(CONFIG_SOC_TI_LM3S6965_QEMU)
-
-GTEXT(_do_software_reboot)
-SECTION_FUNC(TEXT,_do_software_reboot)
-
-	eors r0, r0
-
-	/* move exception table back to 0 */
-	ldr r1, =0xe000e000
-	str r0, [r1, #0xd08] /* VTOR */
-
-	ldr r0, [r0, #4]
-	bx r0
-
-
-GTEXT(_force_exit_one_nested_irq)
-SECTION_FUNC(TEXT,_force_exit_one_nested_irq)
-
-	ldr r0, =_SCS_ICSR_RETTOBASE
-	ldr r1, =_SCS_ICSR
-	ldr r1, [r1]
-	ands.w r0, r1
-
-	/*
-	 *  If Z flag is set, we are nested, so un-nest one level and get back to
-	 *  this function to unwind the next level; else, exit the last interrupt
-	 *  by jumping to reboot code.
-	 */
-	ittee eq
-		ldreq lr, =0xfffffff1
-		ldreq r2, =_force_exit_one_nested_irq
-		ldrne lr, =0xfffffffd
-		ldrne r2, =_do_software_reboot
-
-	ldr ip, =_interrupt_stack
-	add.w ip, #(___esf_t_SIZEOF * 2) /* enough for a stack frame */
-	ldr r1, =0xfffffffe
-	and.w r2, r1
-	str r2, [ip, #(6 * 4)]
-	ldr r2, =0x01000000
-	str r2, [ip, #(7 * 4)]
-
-	ite eq
-		moveq sp, ip
-		msrne PSP, ip
-
-	bx lr
-
-#endif

--- a/arch/arm/core/cortex_m/scb.c
+++ b/arch/arm/core/cortex_m/scb.c
@@ -19,37 +19,6 @@
 #include <misc/util.h>
 #include <arch/arm/cortex_m/cmsis.h>
 
-#if defined(CONFIG_SOC_TI_LM3S6965_QEMU)
-/*
- * QEMU is missing the support for rebooting through the SYSRESETREQ mechanism.
- * Just jump back to __reset() of the image in flash, which address can
- * _always_ be found in the vector table reset slot located at address 0x4.
- */
-
-static void software_reboot(void)
-{
-	extern void _do_software_reboot(void);
-	extern void _force_exit_one_nested_irq(void);
-	/*
-	 * force enable interrupts locked via PRIMASK if somehow disabled: the
-	 * boot code does not enable them
-	 */
-	__asm__ volatile("cpsie i" :::);
-
-	if ((SCB->ICSR & SCB_ICSR_VECTACTIVE_Msk) == 0) {
-		_do_software_reboot();
-	} else {
-		__asm__ volatile(
-			"ldr r0,  =_force_exit_one_nested_irq\n\t"
-			"bx r0\n\t"
-			:::);
-	}
-}
-#define DO_REBOOT() software_reboot()
-#else
-#define DO_REBOOT() NVIC_SystemReset()
-#endif
-
 /**
  *
  * @brief Reset the system
@@ -59,8 +28,9 @@ static void software_reboot(void)
  * @return N/A
  */
 
-void sys_arch_reboot(int type)
+void __weak sys_arch_reboot(int type)
 {
 	ARG_UNUSED(type);
-	DO_REBOOT();
+
+	NVIC_SystemReset();
 }

--- a/soc/arm/ti_lm3s6965/CMakeLists.txt
+++ b/soc/arm/ti_lm3s6965/CMakeLists.txt
@@ -1,4 +1,6 @@
 zephyr_sources(
   soc.c
   soc_config.c
+  reboot.S
+  sys_arch_reboot.c
   )

--- a/soc/arm/ti_lm3s6965/reboot.S
+++ b/soc/arm/ti_lm3s6965/reboot.S
@@ -1,0 +1,61 @@
+/*
+ * Copyright (c) 2013-2014 Wind River Systems, Inc.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <board.h>
+#include <toolchain.h>
+#include <linker/sections.h>
+#include <arch/cpu.h>
+#include <offsets_short.h>
+
+_ASM_FILE_PROLOGUE
+
+GDATA(_interrupt_stack)
+
+GTEXT(_do_software_reboot)
+SECTION_FUNC(TEXT,_do_software_reboot)
+
+	eors r0, r0
+
+	/* move exception table back to 0 */
+	ldr r1, =0xe000e000
+	str r0, [r1, #0xd08] /* VTOR */
+
+	ldr r0, [r0, #4]
+	bx r0
+
+
+GTEXT(_force_exit_one_nested_irq)
+SECTION_FUNC(TEXT,_force_exit_one_nested_irq)
+
+	ldr r0, =_SCS_ICSR_RETTOBASE
+	ldr r1, =_SCS_ICSR
+	ldr r1, [r1]
+	ands.w r0, r1
+
+	/*
+	* If Z flag is set, we are nested, so un-nest one level and get
+	* back to this function to unwind the next level; else, exit the
+	* last interrupt by jumping to reboot code.
+	*/
+	ittee eq
+		ldreq lr, =0xfffffff1
+		ldreq r2, =_force_exit_one_nested_irq
+		ldrne lr, =0xfffffffd
+		ldrne r2, =_do_software_reboot
+
+	ldr ip, =_interrupt_stack
+	add.w ip, #(___esf_t_SIZEOF * 2) /* enough for a stack frame */
+	ldr r1, =0xfffffffe
+	and.w r2, r1
+	str r2, [ip, #(6 * 4)]
+	ldr r2, =0x01000000
+	str r2, [ip, #(7 * 4)]
+
+	ite eq
+		moveq sp, ip
+		msrne PSP, ip
+
+	bx lr

--- a/soc/arm/ti_lm3s6965/sys_arch_reboot.c
+++ b/soc/arm/ti_lm3s6965/sys_arch_reboot.c
@@ -1,0 +1,48 @@
+/*
+ * Copyright (c) 2013-2014 Wind River Systems, Inc.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <kernel.h>
+#include <arch/cpu.h>
+#include <misc/util.h>
+#include <arch/arm/cortex_m/cmsis.h>
+
+/**
+ *
+ * @brief Reset the system
+ *
+ * This routine resets the processor.
+ *
+ * @return N/A
+ */
+
+void sys_arch_reboot(int type)
+{
+	ARG_UNUSED(type);
+
+    /*
+     * QEMU is missing the support for rebooting through the SYSRESETREQ
+     * mechanism.  Just jump back to __reset() of the image in flash,
+     * which address can _always_ be found in the vector table reset slot
+     * located at address 0x4.
+     */
+	extern void _do_software_reboot(void);
+	extern void _force_exit_one_nested_irq(void);
+	/*
+	 * force enable interrupts locked via PRIMASK if somehow disabled: the
+	 * boot code does not enable them
+	 */
+	__asm__ volatile("cpsie i" :::);
+
+	if ((SCB->ICSR & SCB_ICSR_VECTACTIVE_Msk) == 0) {
+		_do_software_reboot();
+	} else {
+		__asm__ volatile(
+			"ldr r0,  =_force_exit_one_nested_irq\n\t"
+			"bx r0\n\t"
+			:::);
+	}
+}
+


### PR DESCRIPTION
As far as possible SoC-specific code should be contained to it's
directory and core systems should not be referencing specific
SoCs. This keeps the common code clean and makes it easier to maintain
out-of-tree SoCs.

To this end we move CONFIG_SOC_TI_LM3S6965_QEMU's soft-reset related
code out of arch/arm/core/cortex_m and into arch/arm/soc/ti_lm3s6965.

Signed-off-by: Sebastian Bøe <sebastian.boe@nordicsemi.no>