### PR TITLE
ext: hal: nordic: Update nrfx to version 1.2.0

### DIFF
--- a/drivers/gpio/gpio_nrfx.c
+++ b/drivers/gpio/gpio_nrfx.c
@@ -47,11 +47,7 @@ static inline const struct gpio_nrfx_cfg *get_port_cfg(struct device *port)
 static int gpiote_channel_alloc(u32_t abs_pin, nrf_gpiote_polarity_t polarity)
 {
 	for (u8_t channel = 0; channel < GPIOTE_CH_NUM; ++channel) {
-		/* @TODO Add GPIOTE HAL function for checking
-		 * if channel is enabled
-		 */
-		if ((NRF_GPIOTE->CONFIG[channel] & GPIOTE_CONFIG_MODE_Msk)
-		    == GPIOTE_CONFIG_MODE_Disabled) {
+		if (!nrf_gpiote_te_is_enabled(channel)) {
 			nrf_gpiote_events_t evt =
 				offsetof(NRF_GPIOTE_Type, EVENTS_IN[channel]);
 

--- a/ext/hal/nordic/nrfx/drivers/src/nrfx_qdec.c
+++ b/ext/hal/nordic/nrfx/drivers/src/nrfx_qdec.c
@@ -107,12 +107,15 @@ nrfx_err_t nrfx_qdec_init(nrfx_qdec_config_t const * p_config,
     m_qdec_event_handler = event_handler;
 
     nrf_qdec_sampleper_set(p_config->sampleper);
-    nrf_gpio_cfg_input(p_config->pselled, NRF_GPIO_PIN_NOPULL);
     nrf_gpio_cfg_input(p_config->psela, NRF_GPIO_PIN_NOPULL);
     nrf_gpio_cfg_input(p_config->pselb, NRF_GPIO_PIN_NOPULL);
+    if (p_config->pselled != NRF_QDEC_LED_NOT_CONNECTED)
+    {
+        nrf_gpio_cfg_input(p_config->pselled, NRF_GPIO_PIN_NOPULL);
+        nrf_qdec_ledpre_set(p_config->ledpre);
+        nrf_qdec_ledpol_set(p_config->ledpol);
+    }
     nrf_qdec_pio_assign(p_config->psela, p_config->pselb, p_config->pselled);
-    nrf_qdec_ledpre_set(p_config->ledpre);
-    nrf_qdec_ledpol_set(p_config->ledpol);
     nrf_qdec_shorts_enable(NRF_QDEC_SHORT_REPORTRDY_READCLRACC_MASK);
 
     if (p_config->dbfen)

--- a/ext/hal/nordic/nrfx/drivers/src/nrfx_twim.c
+++ b/ext/hal/nordic/nrfx/drivers/src/nrfx_twim.c
@@ -373,6 +373,7 @@ __STATIC_INLINE nrfx_err_t twim_xfer(twim_control_block_t        * p_cb,
         nrf_twim_shorts_set(p_twim, NRF_TWIM_SHORT_LASTTX_STARTRX_MASK |
                                     NRF_TWIM_SHORT_LASTRX_STOP_MASK);
         p_cb->int_mask = NRF_TWIM_INT_STOPPED_MASK | NRF_TWIM_INT_ERROR_MASK;
+        nrf_twim_task_trigger(p_twim, NRF_TWIM_TASK_RESUME);
         break;
     case NRFX_TWIM_XFER_TX:
         nrf_twim_tx_buffer_set(p_twim, p_xfer_desc->p_primary_buf, p_xfer_desc->primary_length);

--- a/ext/hal/nordic/nrfx/hal/nrf_gpio.h
+++ b/ext/hal/nordic/nrfx/hal/nrf_gpio.h
@@ -322,6 +322,15 @@ __STATIC_INLINE nrf_gpio_pin_sense_t nrf_gpio_pin_sense_get(uint32_t pin_number)
 __STATIC_INLINE nrf_gpio_pin_dir_t nrf_gpio_pin_dir_get(uint32_t pin_number);
 
 /**
+ * @brief Function for reading the pull configuration of a GPIO pin.
+ *
+ * @param pin_number Specifies the pin number to read.
+ *
+ * @retval Pull configuration.
+ */
+__STATIC_INLINE nrf_gpio_pin_pull_t nrf_gpio_pin_pull_get(uint32_t pin_number);
+
+/**
  * @brief Function for setting output direction on selected pins on a given port.
  *
  * @param p_reg    Pointer to the peripheral registers structure.
@@ -680,6 +689,15 @@ __STATIC_INLINE nrf_gpio_pin_dir_t nrf_gpio_pin_dir_get(uint32_t pin_number)
 
     return (nrf_gpio_pin_dir_t)((reg->PIN_CNF[pin_number] &
                                  GPIO_PIN_CNF_DIR_Msk) >> GPIO_PIN_CNF_DIR_Pos);
+}
+
+
+__STATIC_INLINE nrf_gpio_pin_pull_t nrf_gpio_pin_pull_get(uint32_t pin_number)
+{
+    NRF_GPIO_Type * reg = nrf_gpio_pin_port_decode(&pin_number);
+
+    return (nrf_gpio_pin_pull_t)((reg->PIN_CNF[pin_number] &
+                                  GPIO_PIN_CNF_PULL_Msk) >> GPIO_PIN_CNF_PULL_Pos);
 }
 
 

--- a/ext/hal/nordic/nrfx/hal/nrf_gpiote.h
+++ b/ext/hal/nordic/nrfx/hal/nrf_gpiote.h
@@ -292,6 +292,15 @@ __STATIC_INLINE void nrf_gpiote_task_force(uint32_t idx, nrf_gpiote_outinit_t in
  */
 __STATIC_INLINE void nrf_gpiote_te_default(uint32_t idx);
 
+/**@brief Function for checking if particular Task-Event is enabled.
+ *
+ * @param[in]  idx        Task-Event index.
+ *
+ * @retval true  If the Task-Event mode is set to Task or Event.
+ * @retval false If the Task-Event mode is set to Disabled.
+ */
+__STATIC_INLINE bool nrf_gpiote_te_is_enabled(uint32_t idx);
+
 #ifndef SUPPRESS_INLINE_IMPLEMENTATION
 __STATIC_INLINE void nrf_gpiote_task_set(nrf_gpiote_tasks_t task)
 {
@@ -407,6 +416,11 @@ __STATIC_INLINE void nrf_gpiote_task_force(uint32_t idx, nrf_gpiote_outinit_t in
 __STATIC_INLINE void nrf_gpiote_te_default(uint32_t idx)
 {
     NRF_GPIOTE->CONFIG[idx] = 0;
+}
+
+__STATIC_INLINE bool nrf_gpiote_te_is_enabled(uint32_t idx)
+{
+    return (NRF_GPIOTE->CONFIG[idx] & GPIOTE_CONFIG_MODE_Msk) != GPIOTE_CONFIG_MODE_Disabled;
 }
 #endif //SUPPRESS_INLINE_IMPLEMENTATION
 

--- a/ext/hal/nordic/nrfx/hal/nrf_ppi.h
+++ b/ext/hal/nordic/nrfx/hal/nrf_ppi.h
@@ -214,6 +214,25 @@ __STATIC_INLINE void nrf_ppi_channel_endpoint_setup(nrf_ppi_channel_t channel,
                                                     uint32_t          eep,
                                                     uint32_t          tep);
 
+/**
+ * @brief Function for setting up the event endpoint for a given PPI channel.
+ *
+ * @param[in] eep Event register address.
+ * @param[in] channel Channel to which the given endpoint is assigned.
+ */
+__STATIC_INLINE void nrf_ppi_event_endpoint_setup(nrf_ppi_channel_t channel,
+                                                  uint32_t          eep);
+
+/**
+ * @brief Function for setting up the task endpoint for a given PPI channel.
+ *
+ * @param[in] tep Task register address.
+ * @param[in] channel Channel to which the given endpoint is assigned.
+ */
+__STATIC_INLINE void nrf_ppi_task_endpoint_setup(nrf_ppi_channel_t channel,
+                                                 uint32_t          tep);
+
+
 #if defined(PPI_FEATURE_FORKS_PRESENT) || defined(__NRFX_DOXYGEN__)
 /**
  * @brief Function for setting up task endpoint for a given PPI fork.
@@ -389,6 +408,18 @@ __STATIC_INLINE void nrf_ppi_channel_endpoint_setup(nrf_ppi_channel_t channel,
                                                     uint32_t          tep)
 {
     NRF_PPI->CH[(uint32_t) channel].EEP = eep;
+    NRF_PPI->CH[(uint32_t) channel].TEP = tep;
+}
+
+__STATIC_INLINE void nrf_ppi_event_endpoint_setup(nrf_ppi_channel_t channel,
+                                                  uint32_t          eep)
+{
+    NRF_PPI->CH[(uint32_t) channel].EEP = eep;
+}
+
+__STATIC_INLINE void nrf_ppi_task_endpoint_setup(nrf_ppi_channel_t channel,
+                                                 uint32_t          tep)
+{
     NRF_PPI->CH[(uint32_t) channel].TEP = tep;
 }
 

--- a/ext/hal/nordic/nrfx/hal/nrf_qdec.h
+++ b/ext/hal/nordic/nrfx/hal/nrf_qdec.h
@@ -45,6 +45,13 @@ extern "C" {
  */
 
 /**
+ * @brief This value can be provided as a parameter for the @ref nrf_qdec_pio_assign
+ *        function call to specify that a LED signal shall not be use by the QDEC and
+ *        connected to a physical pin.
+ */
+#define NRF_QDEC_LED_NOT_CONNECTED  0xFFFFFFFF
+
+/**
  * @enum nrf_qdec_task_t
  * @brief QDEC tasks.
  */

--- a/ext/hal/nordic/nrfx/hal/nrf_usbd.h
+++ b/ext/hal/nordic/nrfx/hal/nrf_usbd.h
@@ -531,11 +531,11 @@ void nrf_usbd_int_disable(uint32_t int_mask)
  */
 typedef enum
 {
-    NRF_USBD_EVENTCAUSE_ISOOUTCRC_MASK    = USBD_EVENTCAUSE_ISOOUTCRC_Msk, /**< CRC error was detected on isochronous OUT endpoint 8. */
-    NRF_USBD_EVENTCAUSE_SUSPEND_MASK      = USBD_EVENTCAUSE_SUSPEND_Msk  , /**< Signals that the USB lines have been seen idle long enough for the device to enter suspend. */
-    NRF_USBD_EVENTCAUSE_RESUME_MASK       = USBD_EVENTCAUSE_RESUME_Msk   , /**< Signals that a RESUME condition (K state or activity restart) has been detected on the USB lines. */
-    NRF_USBD_EVENTCAUSE_READY_MASK        = USBD_EVENTCAUSE_READY_Msk,     /**< MAC is ready for normal operation, rised few us after USBD enabling */
-    NRF_USBD_EVENTCAUSE_WUREQ_MASK        = (1U << 10)                     /**< The USBD peripheral has exited Low Power mode */
+    NRF_USBD_EVENTCAUSE_ISOOUTCRC_MASK    = USBD_EVENTCAUSE_ISOOUTCRC_Msk,      /**< CRC error was detected on isochronous OUT endpoint 8. */
+    NRF_USBD_EVENTCAUSE_SUSPEND_MASK      = USBD_EVENTCAUSE_SUSPEND_Msk,        /**< Signals that the USB lines have been seen idle long enough for the device to enter suspend. */
+    NRF_USBD_EVENTCAUSE_RESUME_MASK       = USBD_EVENTCAUSE_RESUME_Msk,         /**< Signals that a RESUME condition (K state or activity restart) has been detected on the USB lines. */
+	NRF_USBD_EVENTCAUSE_WUREQ_MASK        = USBD_EVENTCAUSE_USBWUALLOWED_Msk,   /**< The USBD peripheral has exited Low Power mode */
+    NRF_USBD_EVENTCAUSE_READY_MASK        = USBD_EVENTCAUSE_READY_Msk,          /**< MAC is ready for normal operation, rised few us after USBD enabling */
 }nrf_usbd_eventcause_mask_t;
 
 /**
@@ -613,8 +613,8 @@ typedef enum
  */
 typedef enum
 {
-    NRF_USBD_ISOSPLIT_OneDir = USBD_ISOSPLIT_SPLIT_OneDir, /**< Full buffer dedicated to either iso IN or OUT */
-    NRF_USBD_ISOSPLIT_Half   = USBD_ISOSPLIT_SPLIT_HalfIN, /**< Buffer divided in half */
+    NRF_USBD_ISOSPLIT_ONEDIR = USBD_ISOSPLIT_SPLIT_OneDir, /**< Full buffer dedicated to either iso IN or OUT */
+    NRF_USBD_ISOSPLIT_HALF   = USBD_ISOSPLIT_SPLIT_HalfIN, /**< Buffer divided in half */
 }nrf_usbd_isosplit_t;
 
 /**

--- a/ext/hal/nordic/nrfx/nrfx.h
+++ b/ext/hal/nordic/nrfx/nrfx.h
@@ -1,21 +1,21 @@
-/**
+/*
  * Copyright (c) 2017 - 2018, Nordic Semiconductor ASA
  * All rights reserved.
- * 
+ *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:
- * 
+ *
  * 1. Redistributions of source code must retain the above copyright notice, this
  *    list of conditions and the following disclaimer.
- * 
+ *
  * 2. Redistributions in binary form must reproduce the above copyright
  *    notice, this list of conditions and the following disclaimer in the
  *    documentation and/or other materials provided with the distribution.
- * 
+ *
  * 3. Neither the name of the copyright holder nor the names of its
  *    contributors may be used to endorse or promote products derived from this
  *    software without specific prior written permission.
- * 
+ *
  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
  * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
  * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE


### PR DESCRIPTION
This PR updates nrfx to the recently released version containing needed enhancements of GPIOTE and PPI HALs. The gpio shim for nrfx driver is updated with the new function from the GPIOTE HAL.

Needed by #9320.