### PR TITLE
portability: Towards C99/C11 compliance

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -264,6 +264,9 @@ zephyr_system_include_directories(${NOSTDINC})
 # Force an error when things like SYS_INIT(foo, ...) occur with a missing header.
 zephyr_cc_option(-Werror=implicit-int)
 
+# Prohibit void pointer arithmetic. Illegal in C99
+zephyr_cc_option(-Wpointer-arith)
+
 # Prohibit date/time macros, which would make the build non-deterministic
 # cc-option(-Werror=date-time)
 

--- a/arch/x86/core/fatal.c
+++ b/arch/x86/core/fatal.c
@@ -408,7 +408,7 @@ static FUNC_NORETURN __used void _df_handler_bottom(void)
 	 * one byte, since if a single push operation caused the fault ESP
 	 * wouldn't be decremented
 	 */
-	_x86_mmu_get_flags((void *)_df_esf.esp - 1, &pde_flags, &pte_flags);
+	_x86_mmu_get_flags((u8_t *)_df_esf.esp - 1, &pde_flags, &pte_flags);
 	if (pte_flags & MMU_ENTRY_PRESENT) {
 		printk("***** Double Fault *****\n");
 		reason = _NANO_ERR_CPU_EXCEPTION;

--- a/drivers/flash/flash_stm32.c
+++ b/drivers/flash/flash_stm32.c
@@ -118,7 +118,7 @@ static int flash_stm32_read(struct device *dev, off_t offset, void *data,
 		return 0;
 	}
 
-	memcpy(data, (void *) CONFIG_FLASH_BASE_ADDRESS + offset, len);
+	memcpy(data, (u8_t *) CONFIG_FLASH_BASE_ADDRESS + offset, len);
 
 	return 0;
 }

--- a/drivers/flash/soc_flash_nios2_qspi.c
+++ b/drivers/flash/soc_flash_nios2_qspi.c
@@ -217,7 +217,8 @@ static int flash_nios2_qspi_write_block(struct device *dev, int block_offset,
 
 		/* prepare the word to be written */
 		memcpy((u8_t *)&word_to_write + padding,
-				data + buffer_offset, bytes_to_copy);
+				(const u8_t *)data + buffer_offset,
+				bytes_to_copy);
 
 		/* enable write */
 		IOWR_32DIRECT(qspi_dev->csr_base,
@@ -298,7 +299,8 @@ static int flash_nios2_qspi_write(struct device *dev, off_t offset,
 
 		rc = flash_nios2_qspi_write_block(dev,
 				block_offset, write_offset,
-				data + buffer_offset, length_to_write);
+				(const u8_t *)data + buffer_offset,
+				length_to_write);
 		if (rc < 0) {
 			goto qspi_write_err;
 		}
@@ -347,7 +349,8 @@ static int flash_nios2_qspi_read(struct device *dev, off_t offset,
 
 		/* read from flash 32 bits at a time */
 		word_to_read = IORD_32DIRECT(qspi_dev->data_base, read_offset);
-		memcpy(data + buffer_offset, &word_to_read, bytes_to_copy);
+		memcpy((u8_t *)data + buffer_offset, &word_to_read,
+		       bytes_to_copy);
 
 		/* update offset and length variables */
 		read_offset += bytes_to_copy;

--- a/drivers/ieee802154/ieee802154_uart_pipe.c
+++ b/drivers/ieee802154/ieee802154_uart_pipe.c
@@ -340,7 +340,7 @@ static inline u8_t *get_mac(struct device *dev)
 
 #if defined(CONFIG_IEEE802154_UPIPE_RANDOM_MAC)
 	UNALIGNED_PUT(sys_cpu_to_be32(sys_rand32_get()),
-		      (u32_t *) ((void *)upipe->mac_addr+4));
+		      (u32_t *) ((u8_t *)upipe->mac_addr+4));
 #else
 	upipe->mac_addr[4] = CONFIG_IEEE802154_UPIPE_MAC4;
 	upipe->mac_addr[5] = CONFIG_IEEE802154_UPIPE_MAC5;

--- a/drivers/spi/spi_sam0.c
+++ b/drivers/spi/spi_sam0.c
@@ -157,7 +157,7 @@ static void spi_sam0_finish(SercomSpi *regs)
 static void spi_sam0_fast_tx(SercomSpi *regs, const struct spi_buf *tx_buf)
 {
 	const u8_t *p = tx_buf->buf;
-	const u8_t *pend = tx_buf->buf + tx_buf->len;
+	const u8_t *pend = (u8_t *)tx_buf->buf + tx_buf->len;
 	u8_t ch;
 
 	while (p != pend) {
@@ -215,7 +215,7 @@ static void spi_sam0_fast_txrx(SercomSpi *regs,
 			       const struct spi_buf *rx_buf)
 {
 	const u8_t *tx = tx_buf->buf;
-	const u8_t *txend = tx_buf->buf + tx_buf->len;
+	const u8_t *txend = (u8_t *)tx_buf->buf + tx_buf->len;
 	u8_t *rx = rx_buf->buf;
 	size_t len = rx_buf->len;
 

--- a/drivers/usb/device/usb_dc_kinetis.c
+++ b/drivers/usb/device/usb_dc_kinetis.c
@@ -345,8 +345,8 @@ int usb_dc_ep_configure(const struct usb_dc_ep_cfg_data * const cfg)
 
 	bdt[idx_even].buf_addr = (u32_t)block->data;
 	SYS_LOG_INF("idx_even %x", (u32_t)block->data);
-	bdt[idx_odd].buf_addr = (u32_t)(block->data + cfg->ep_mps);
-	SYS_LOG_INF("idx_odd %x", (u32_t)(block->data + cfg->ep_mps));
+	bdt[idx_odd].buf_addr = (u32_t)((u8_t *)block->data + cfg->ep_mps);
+	SYS_LOG_INF("idx_odd %x", (u32_t)((u8_t *)block->data + cfg->ep_mps));
 
 	if (cfg->ep_addr & USB_EP_DIR_IN) {
 		dev_data.ep_ctrl[ep_idx].mps_in = cfg->ep_mps;

--- a/ext/fs/nffs/src/nffs_write.c
+++ b/ext/fs/nffs/src/nffs_write.c
@@ -353,7 +353,9 @@ nffs_write_chunk(struct nffs_inode_entry *inode_entry, uint32_t file_offset,
 
         data_offset = cache_block->ncb_file_offset + chunk_off - file_offset;
         rc = nffs_write_over_block(cache_block->ncb_block.nb_hash_entry,
-                                   chunk_off, data + data_offset, chunk_sz);
+                                   chunk_off,
+                                   (const uint8_t *)data + data_offset,
+                                   chunk_sz);
         if (rc != 0) {
             return rc;
         }

--- a/ext/hal/libmetal/README
+++ b/ext/hal/libmetal/README
@@ -4,10 +4,8 @@ libmetal
 Origin:
    https://github.com/OpenAMP/libmetal
 
-Status:
-   b4b5beab4b71388d63c732470b6d6da606ae8ffc
-
-   When we import libmetal we removed the tests/ and examples/ dir to reduce
+Import instructions:
+   When we import libmetal we remove the tests/ and examples/ dir to reduce
    the amount of code imported.
 
 Purpose:
@@ -29,7 +27,7 @@ URL:
    https://github.com/OpenAMP/libmetal
 
 commit:
-   b4b5beab4b71388d63c732470b6d6da606ae8ffc
+   a4f763094cb26cd8f7abdff251f57a6a802c039d
 
 Maintained-by:
    External

--- a/ext/hal/libmetal/libmetal/.travis.yml
+++ b/ext/hal/libmetal/libmetal/.travis.yml
@@ -8,14 +8,15 @@ dist: trusty
 
 env:
   global:
-    - ZEPHYR_GCC_VARIANT=zephyr
+    - ZEPHYR_TOOLCHAIN_VARIANT=zephyr
     - ZEPHYR_SDK_INSTALL_DIR=/opt/zephyr-sdk
     - ZEPHYR_BASE=$TRAVIS_BUILD_DIR/deps/zephyr
-    - ZEPHYR_SDK_VERSION=0.9.2
+    - ZEPHYR_SDK_VERSION=0.9.3
     - ZEPHYR_SDK_DOWNLOAD_FOLDER=https://github.com/zephyrproject-rtos/meta-zephyr-sdk/releases/download/$ZEPHYR_SDK_VERSION
     - ZEPHYR_SDK_SETUP_BINARY=zephyr-sdk-$ZEPHYR_SDK_VERSION-setup.run
     - ZEPHYR_SDK_DOWNLOAD_URL=$ZEPHYR_SDK_DOWNLOAD_FOLDER/$ZEPHYR_SDK_SETUP_BINARY
-    - FREERTOS_ZIP_URL=https://downloads.sourceforge.net/project/freertos/FreeRTOS/V10.0.1/FreeRTOSv10.0.1.zip
+    - FREERTOS_ZIP_URL=https://cfhcable.dl.sourceforge.net/project/freertos/FreeRTOS/V10.0.1/FreeRTOSv10.0.1.zip
+    - GCC_ARM_COMPILER_PACKAGE=gcc-arm-embedded_7-2018q2-1~trusty1_amd64.deb
 
 matrix:
   fast_finish: true
@@ -47,8 +48,8 @@ before_install:
     fi
 # This is to kick start CI on generic platform. Will need to have a proper way to get the required packages
   - if [[ "$TARGET" == "generic" || "$TARGET" == "freertos" ]]; then
-      wget http://ppa.launchpad.net/team-gcc-arm-embedded/ppa/ubuntu/pool/main/g/gcc-arm-none-eabi/gcc-arm-embedded_7-2017q4-1~trusty3_amd64.deb &&
-      sudo dpkg -i gcc-arm-embedded_7-2017q4-1~trusty3_amd64.deb;
+      wget http://ppa.launchpad.net/team-gcc-arm-embedded/ppa/ubuntu/pool/main/g/gcc-arm-none-eabi/${GCC_ARM_COMPILER_PACKAGE} &&
+      sudo dpkg -i ${GCC_ARM_COMPILER_PACKAGE};
     fi
   - if [[ "$TARGET" == "freertos" ]]; then
       wget $FREERTOS_ZIP_URL &&

--- a/ext/hal/libmetal/libmetal/cmake/depends.cmake
+++ b/ext/hal/libmetal/libmetal/cmake/depends.cmake
@@ -1,4 +1,6 @@
-find_package (Doxygen)
+if (WITH_DOC)
+  find_package (Doxygen)
+endif (WITH_DOC)
 
 if ("${CMAKE_SYSTEM_NAME}" STREQUAL "Linux")
 

--- a/ext/hal/libmetal/libmetal/lib/CMakeLists.txt
+++ b/ext/hal/libmetal/libmetal/lib/CMakeLists.txt
@@ -63,7 +63,7 @@ endif (WITH_DEFAULT_LOGGER)
 if (WITH_ZEPHYR)
   zephyr_library_named(metal)
   add_dependencies(metal offsets_h)
-  target_sources (metal PRIVATE ${_sources})
+  zephyr_library_sources(${_sources})
   zephyr_include_directories(${CMAKE_CURRENT_BINARY_DIR}/include)
 else (WITH_ZEPHYR)
   # Build a shared library if so configured.

--- a/ext/hal/libmetal/libmetal/lib/cache.h
+++ b/ext/hal/libmetal/libmetal/lib/cache.h
@@ -32,7 +32,7 @@ extern "C" {
  */
 static inline void metal_cache_flush(void *addr, unsigned int len)
 {
-	return __metal_cache_flush(addr, len);
+	__metal_cache_flush(addr, len);
 }
 
 /**
@@ -45,7 +45,7 @@ static inline void metal_cache_flush(void *addr, unsigned int len)
  */
 static inline void metal_cache_invalidate(void *addr, unsigned int len)
 {
-	return __metal_cache_invalidate(addr, len);
+	__metal_cache_invalidate(addr, len);
 }
 
 /** @} */

--- a/ext/hal/libmetal/libmetal/lib/compiler.h
+++ b/ext/hal/libmetal/libmetal/lib/compiler.h
@@ -14,6 +14,8 @@
 
 #if defined(__GNUC__)
 # include <metal/compiler/gcc/compiler.h>
+#elif defined(__ICCARM__)
+# include <metal/compiler/iar/compiler.h>
 #else
 # error "Missing compiler support"
 #endif

--- a/ext/hal/libmetal/libmetal/lib/compiler/CMakeLists.txt
+++ b/ext/hal/libmetal/libmetal/lib/compiler/CMakeLists.txt
@@ -1,3 +1,4 @@
 add_subdirectory (gcc)
+add_subdirectory (iar)
 
 # vim: expandtab:ts=2:sw=2:smartindent

--- a/ext/hal/libmetal/libmetal/lib/compiler/iar/CMakeLists.txt
+++ b/ext/hal/libmetal/libmetal/lib/compiler/iar/CMakeLists.txt
@@ -1,0 +1,3 @@
+collect (PROJECT_LIB_HEADERS compiler.h)
+
+# vim: expandtab:ts=2:sw=2:smartindent

--- a/ext/hal/libmetal/libmetal/lib/compiler/iar/compiler.h
+++ b/ext/hal/libmetal/libmetal/lib/compiler/iar/compiler.h
@@ -1,0 +1,27 @@
+/*
+ * Copyright (c) 2018, ST Microelectronics. All rights reserved.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+/*
+ * @file	iar/compiler.h
+ * @brief	IAR specific primitives for libmetal.
+ */
+
+#ifndef __METAL_IAR_COMPILER__H__
+#define __METAL_IAR_COMPILER__H__
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#define restrict __restrict__
+#define metal_align(n) __attribute__((aligned(n)))
+#define metal_weak __attribute__((weak))
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* __METAL_IAR_COMPILER__H__ */

--- a/ext/hal/libmetal/libmetal/lib/io.h
+++ b/ext/hal/libmetal/libmetal/lib/io.h
@@ -233,12 +233,9 @@ metal_io_read(struct metal_io_region *io, unsigned long offset,
 		return atomic_load_explicit((atomic_uint *)ptr, order);
 	else if (ptr && sizeof(atomic_ulong) == width)
 		return atomic_load_explicit((atomic_ulong *)ptr, order);
-	else if (ptr && sizeof(atomic_ullong) == width)
 #ifndef NO_ATOMIC_64_SUPPORT
+	else if (ptr && sizeof(atomic_ullong) == width)
 		return atomic_load_explicit((atomic_ullong *)ptr, order);
-
-#else
-		return metal_processor_io_read64((atomic_ullong *)ptr, order);
 #endif
 	metal_assert(0);
 	return 0; /* quiet compiler */
@@ -269,11 +266,9 @@ metal_io_write(struct metal_io_region *io, unsigned long offset,
 		atomic_store_explicit((atomic_uint *)ptr, value, order);
 	else if (ptr && sizeof(atomic_ulong) == width)
 		atomic_store_explicit((atomic_ulong *)ptr, value, order);
-	else if (ptr && sizeof(atomic_ullong) == width)
 #ifndef NO_ATOMIC_64_SUPPORT
+	else if (ptr && sizeof(atomic_ullong) == width)
 		atomic_store_explicit((atomic_ullong *)ptr, value, order);
-#else
-		metal_processor_io_write64((atomic_ullong *)ptr, value, order);
 #endif
 	else
 		metal_assert (0);

--- a/ext/hal/libmetal/libmetal/lib/processor/microblaze/cpu.h
+++ b/ext/hal/libmetal/libmetal/lib/processor/microblaze/cpu.h
@@ -17,28 +17,4 @@
 
 #define metal_cpu_yield()
 
-static inline void metal_processor_io_write64(void *ptr, uint64_t value,
-					      memory_order order)
-{
-	void *tmp = &value;
-
-	atomic_store_explicit((atomic_ulong *)ptr, *((atomic_ulong *)tmp), order);
-	tmp += sizeof(atomic_ulong);
-	ptr += sizeof(atomic_ulong);
-	atomic_store_explicit((atomic_ulong *)ptr, *((atomic_ulong *)tmp), order);
-}
-
-static inline uint64_t metal_processor_io_read64(void *ptr, memory_order order)
-{
-	uint64_t long_ret;
-	void *tmp = &long_ret;
-
-	*((atomic_ulong *)tmp) = atomic_load_explicit((atomic_ulong *)ptr, order);
-	tmp += sizeof(atomic_ulong);
-	ptr += sizeof(atomic_ulong);
-	*((atomic_ulong *)tmp) = atomic_load_explicit((atomic_ulong *)ptr, order);
-
-	return long_ret;
-}
-
 #endif /* __METAL_MICROBLAZE__H__ */

--- a/ext/hal/libmetal/libmetal/lib/system/freertos/irq.c
+++ b/ext/hal/libmetal/libmetal/lib/system/freertos/irq.c
@@ -234,15 +234,12 @@ int metal_irq_unregister(int irq,
 
 unsigned int metal_irq_save_disable(void)
 {
-	sys_irq_save_disable();
-	return 0;
+	return sys_irq_save_disable();
 }
 
 void metal_irq_restore_enable(unsigned int flags)
 {
-	(void)flags;
-
-	sys_irq_restore_enable();
+	sys_irq_restore_enable(flags);
 }
 
 void metal_irq_enable(unsigned int vector)

--- a/ext/hal/libmetal/libmetal/lib/system/freertos/mutex.h
+++ b/ext/hal/libmetal/libmetal/lib/system/freertos/mutex.h
@@ -16,24 +16,22 @@
 #ifndef __METAL_FREERTOS_MUTEX__H__
 #define __METAL_FREERTOS_MUTEX__H__
 
-#include <metal/assert.h>
-#include "FreeRTOS.h"
-#include "semphr.h"
-
+#include <metal/atomic.h>
+#include <stdlib.h>
 
 #ifdef __cplusplus
 extern "C" {
 #endif
 
 typedef struct {
-	SemaphoreHandle_t m;
+	atomic_int v;
 } metal_mutex_t;
 
 /*
  * METAL_MUTEX_INIT - used for initializing an mutex elmenet in a static struct
  * or global
  */
-#define METAL_MUTEX_INIT(m) { NULL }
+#define METAL_MUTEX_INIT(m)		{ ATOMIC_VAR_INIT(0) }
 /*
  * METAL_MUTEX_DEFINE - used for defining and initializing a global or
  * static singleton mutex
@@ -42,40 +40,34 @@ typedef struct {
 
 static inline void __metal_mutex_init(metal_mutex_t *mutex)
 {
-	metal_assert(mutex);
-	mutex->m = xSemaphoreCreateMutex();
-	metal_assert(mutex->m != NULL);
+	atomic_store(&mutex->v, 0);
 }
 
 static inline void __metal_mutex_deinit(metal_mutex_t *mutex)
 {
-	metal_assert(mutex && mutex->m != NULL);
-	vSemaphoreDelete(mutex->m);
-	mutex->m=NULL;
+	(void)mutex;
 }
 
 static inline int __metal_mutex_try_acquire(metal_mutex_t *mutex)
 {
-	metal_assert(mutex && mutex->m != NULL);
-	return xSemaphoreTake(mutex->m, ( TickType_t ) 0 );
+	return 1 - atomic_flag_test_and_set(&mutex->v);
 }
 
 static inline void __metal_mutex_acquire(metal_mutex_t *mutex)
 {
-	metal_assert(mutex && mutex->m != NULL);
-	xSemaphoreTake(mutex->m, portMAX_DELAY);
+	while (atomic_flag_test_and_set(&mutex->v)) {
+		;
+	}
 }
 
 static inline void __metal_mutex_release(metal_mutex_t *mutex)
 {
-	metal_assert(mutex && mutex->m != NULL);
-	xSemaphoreGive(mutex->m);
+	atomic_flag_clear(&mutex->v);
 }
 
 static inline int __metal_mutex_is_acquired(metal_mutex_t *mutex)
 {
-	metal_assert(mutex && mutex->m != NULL);
-	return (NULL == xSemaphoreGetMutexHolder(mutex->m)) ? 0 : 1;
+	return atomic_load(&mutex->v);
 }
 
 #ifdef __cplusplus

--- a/ext/hal/libmetal/libmetal/lib/system/freertos/sys.h
+++ b/ext/hal/libmetal/libmetal/lib/system/freertos/sys.h
@@ -38,12 +38,12 @@ struct metal_state {
 /**
  * @brief restore interrupts to state before disable_global_interrupt()
  */
-void sys_irq_restore_enable(void);
+void sys_irq_restore_enable(unsigned int flags);
 
 /**
  * @brief disable all interrupts
  */
-void sys_irq_save_disable(void);
+unsigned int sys_irq_save_disable(void);
 
 #endif /* METAL_INTERNAL */
 

--- a/ext/hal/libmetal/libmetal/lib/system/freertos/template/sys.c
+++ b/ext/hal/libmetal/libmetal/lib/system/freertos/template/sys.c
@@ -14,13 +14,15 @@
 #include <metal/utilities.h>
 #include <stdint.h>
 
-void sys_irq_restore_enable(void)
+void sys_irq_restore_enable(unsigned int flags)
 {
+	metal_unused(flags);
 	/* Add implementation here */
 }
 
-void sys_irq_save_disable(void)
+unsigned int sys_irq_save_disable(void)
 {
+	return 0;
 	/* Add implementation here */
 }
 

--- a/ext/hal/libmetal/libmetal/lib/system/freertos/zynq7/sys.c
+++ b/ext/hal/libmetal/libmetal/lib/system/freertos/zynq7/sys.c
@@ -28,21 +28,19 @@
 /* Mask off lower bits of addr */
 #define     ARM_AR_MEM_TTB_SECT_SIZE_MASK          (~(ARM_AR_MEM_TTB_SECT_SIZE-1UL))
 
-/* default value setting for disabling interrupts */
-static unsigned int int_old_val = XIL_EXCEPTION_ALL;
-
-void sys_irq_restore_enable(void)
+void sys_irq_restore_enable(unsigned int flags)
 {
-	Xil_ExceptionEnableMask(~int_old_val);
+	Xil_ExceptionEnableMask(~flags);
 }
 
-void sys_irq_save_disable(void)
+unsigned int sys_irq_save_disable(void)
 {
-	int_old_val = mfcpsr() & XIL_EXCEPTION_ALL;
+	unsigned int state = mfcpsr() & XIL_EXCEPTION_ALL;
 
-	if (XIL_EXCEPTION_ALL != int_old_val) {
+	if (XIL_EXCEPTION_ALL != state) {
 		Xil_ExceptionDisableMask(XIL_EXCEPTION_ALL);
 	}
+	return state;
 }
 
 void metal_machine_cache_flush(void *addr, unsigned int len)

--- a/ext/hal/libmetal/libmetal/lib/system/freertos/zynqmp_a53/sys.c
+++ b/ext/hal/libmetal/libmetal/lib/system/freertos/zynqmp_a53/sys.c
@@ -22,21 +22,19 @@
 #define MB (1024 * 1024UL)
 #define GB (1024 * 1024 * 1024UL)
 
-/* default value setting for disabling interrupts */
-static unsigned int int_old_val = XIL_EXCEPTION_ALL;
-
-void sys_irq_restore_enable(void)
+void sys_irq_restore_enable(unsigned int flags)
 {
-	Xil_ExceptionEnableMask(~int_old_val);
+	Xil_ExceptionEnableMask(~flags);
 }
 
-void sys_irq_save_disable(void)
+unsigned int sys_irq_save_disable(void)
 {
-	int_old_val = mfcpsr() & XIL_EXCEPTION_ALL;
+	unsigned int state = mfcpsr() & XIL_EXCEPTION_ALL;
 
-	if (XIL_EXCEPTION_ALL != int_old_val) {
+	if (XIL_EXCEPTION_ALL != state) {
 		Xil_ExceptionDisableMask(XIL_EXCEPTION_ALL);
 	}
+	return state;
 }
 
 void metal_machine_cache_flush(void *addr, unsigned int len)

--- a/ext/hal/libmetal/libmetal/lib/system/freertos/zynqmp_r5/sys.c
+++ b/ext/hal/libmetal/libmetal/lib/system/freertos/zynqmp_r5/sys.c
@@ -22,21 +22,19 @@
 
 #define MPU_REGION_SIZE_MIN 0x20
 
-/* default value setting for disabling interrupts */
-static unsigned int int_old_val = XIL_EXCEPTION_ALL;
-
-void sys_irq_restore_enable(void)
+void sys_irq_restore_enable(unsigned int flags)
 {
-	Xil_ExceptionEnableMask(~int_old_val);
+	Xil_ExceptionEnableMask(~flags);
 }
 
-void sys_irq_save_disable(void)
+unsigned int sys_irq_save_disable(void)
 {
-	int_old_val = mfcpsr() & XIL_EXCEPTION_ALL;
+	unsigned int state = mfcpsr() & XIL_EXCEPTION_ALL;
 
-	if (XIL_EXCEPTION_ALL != int_old_val) {
+	if (XIL_EXCEPTION_ALL != state) {
 		Xil_ExceptionDisableMask(XIL_EXCEPTION_ALL);
 	}
+	return state;
 }
 
 void metal_machine_cache_flush(void *addr, unsigned int len)

--- a/ext/hal/libmetal/libmetal/lib/system/generic/irq.c
+++ b/ext/hal/libmetal/libmetal/lib/system/generic/irq.c
@@ -234,15 +234,12 @@ int metal_irq_unregister(int irq,
 
 unsigned int metal_irq_save_disable(void)
 {
-	sys_irq_save_disable();
-	return 0;
+	return sys_irq_save_disable();
 }
 
 void metal_irq_restore_enable(unsigned int flags)
 {
-	(void)flags;
-
-	sys_irq_restore_enable();
+	sys_irq_restore_enable(flags);
 }
 
 void metal_irq_enable(unsigned int vector)

--- a/ext/hal/libmetal/libmetal/lib/system/generic/microblaze_generic/sys.c
+++ b/ext/hal/libmetal/libmetal/lib/system/generic/microblaze_generic/sys.c
@@ -22,36 +22,36 @@
 
 #define MSR_IE  0x2UL /* MicroBlaze status register interrupt enable mask */
 
-static unsigned int int_old_val = 0;
-
 #if (XPAR_MICROBLAZE_USE_MSR_INSTR != 0)
-void sys_irq_save_disable(void)
+unsigned int sys_irq_save_disable(void)
 {
+	unsigned int state;
+
 	asm volatile("  mfs     %0, rmsr	\n"
 		     "  msrclr  r0, %1		\n"
-		     :  "=r"(int_old_val)
+		     :  "=r"(state)
 		     :  "i"(MSR_IE)
 		     :  "memory");
 
-	int_old_val &= MSR_IE;
+	return state &= MSR_IE;
 }
 #else /* XPAR_MICROBLAZE_USE_MSR_INSTR == 0 */
-void sys_irq_save_disable(void)
+unsigned int sys_irq_save_disable(void)
 {
-	unsigned int tmp;
+	unsigned int tmp, state;
 
 	asm volatile ("  mfs   %0, rmsr		\n"
 		      "  andi  %1, %0, %2	\n"
 		      "  mts   rmsr, %1		\n"
-		      :  "=r"(int_old_val), "=r"(tmp)
+		      :  "=r"(state), "=r"(tmp)
 		      :  "i"(~MSR_IE)
 		      :  "memory");
 
-	int_old_val &= MSR_IE;
+	return state &= MSR_IE;
 }
 #endif /* XPAR_MICROBLAZE_USE_MSR_INSTR */
 
-void sys_irq_restore_enable(void)
+void sys_irq_restore_enable(unsigned int flags)
 {
 	unsigned int tmp;
 
@@ -59,7 +59,7 @@ void sys_irq_restore_enable(void)
 		     "  or      %0, %0, %1	\n"
 		     "  mts     rmsr, %0	\n"
 		     :  "=r"(tmp)
-		     :  "r"(int_old_val)
+		     :  "r"(~flags)
 		     :  "memory");
 }
 

--- a/ext/hal/libmetal/libmetal/lib/system/generic/sys.h
+++ b/ext/hal/libmetal/libmetal/lib/system/generic/sys.h
@@ -47,12 +47,12 @@ struct metal_state {
 /**
  * @brief restore interrupts to state before disable_global_interrupt()
  */
-void sys_irq_restore_enable(void);
+void sys_irq_restore_enable(unsigned int flags);
 
 /**
  * @brief disable all interrupts
  */
-void sys_irq_save_disable(void);
+unsigned int sys_irq_save_disable(void);
 
 #endif /* METAL_INTERNAL */
 

--- a/ext/hal/libmetal/libmetal/lib/system/generic/template/sys.c
+++ b/ext/hal/libmetal/libmetal/lib/system/generic/template/sys.c
@@ -14,13 +14,15 @@
 #include <metal/utilities.h>
 #include <stdint.h>
 
-void sys_irq_restore_enable(void)
+void sys_irq_restore_enable(unsigned int flags)
 {
+	metal_unused(flags);
 	/* Add implementation here */
 }
 
-void sys_irq_save_disable(void)
+unsigned int sys_irq_save_disable(void)
 {
+	return 0;
 	/* Add implementation here */
 }
 

--- a/ext/hal/libmetal/libmetal/lib/system/generic/zynq7/sys.c
+++ b/ext/hal/libmetal/libmetal/lib/system/generic/zynq7/sys.c
@@ -25,21 +25,19 @@
 /* Mask off lower bits of addr */
 #define     ARM_AR_MEM_TTB_SECT_SIZE_MASK          (~(ARM_AR_MEM_TTB_SECT_SIZE-1UL))
 
-/* default value setting for disabling interrupts */
-static unsigned int int_old_val = XIL_EXCEPTION_ALL;
-
-void sys_irq_restore_enable(void)
+void sys_irq_restore_enable(unsigned int flags)
 {
-	Xil_ExceptionEnableMask(~int_old_val);
+	Xil_ExceptionEnableMask(~flags);
 }
 
-void sys_irq_save_disable(void)
+unsigned int sys_irq_save_disable(void)
 {
-	int_old_val = mfcpsr() & XIL_EXCEPTION_ALL;
+	unsigned int state = mfcpsr() & XIL_EXCEPTION_ALL;
 
-	if (XIL_EXCEPTION_ALL != int_old_val) {
+	if (XIL_EXCEPTION_ALL != state) {
 		Xil_ExceptionDisableMask(XIL_EXCEPTION_ALL);
 	}
+	return state;
 }
 
 void metal_machine_cache_flush(void *addr, unsigned int len)

--- a/ext/hal/libmetal/libmetal/lib/system/generic/zynqmp_a53/sys.c
+++ b/ext/hal/libmetal/libmetal/lib/system/generic/zynqmp_a53/sys.c
@@ -22,21 +22,19 @@
 #define MB (1024 * 1024UL)
 #define GB (1024 * 1024 * 1024UL)
 
-/* default value setting for disabling interrupts */
-static unsigned int int_old_val = XIL_EXCEPTION_ALL;
-
-void sys_irq_restore_enable(void)
+void sys_irq_restore_enable(unsigned int flags)
 {
-	Xil_ExceptionEnableMask(~int_old_val);
+	Xil_ExceptionEnableMask(~flags);
 }
 
-void sys_irq_save_disable(void)
+unsigned int sys_irq_save_disable(void)
 {
-	int_old_val = mfcpsr() & XIL_EXCEPTION_ALL;
+	unsigned int state = mfcpsr() & XIL_EXCEPTION_ALL;
 
-	if (XIL_EXCEPTION_ALL != int_old_val) {
+	if (XIL_EXCEPTION_ALL != state) {
 		Xil_ExceptionDisableMask(XIL_EXCEPTION_ALL);
 	}
+	return state;
 }
 
 void metal_machine_cache_flush(void *addr, unsigned int len)

--- a/ext/hal/libmetal/libmetal/lib/system/generic/zynqmp_r5/sys.c
+++ b/ext/hal/libmetal/libmetal/lib/system/generic/zynqmp_r5/sys.c
@@ -22,21 +22,19 @@
 
 #define MPU_REGION_SIZE_MIN 0x20
 
-/* default value setting for disabling interrupts */
-static unsigned int int_old_val = XIL_EXCEPTION_ALL;
-
-void sys_irq_restore_enable(void)
+void sys_irq_restore_enable(unsigned int flags)
 {
-	Xil_ExceptionEnableMask(~int_old_val);
+	Xil_ExceptionEnableMask(~flags);
 }
 
-void sys_irq_save_disable(void)
+unsigned int sys_irq_save_disable(void)
 {
-	int_old_val = mfcpsr() & XIL_EXCEPTION_ALL;
+	unsigned int state = mfcpsr() & XIL_EXCEPTION_ALL;
 
-	if (XIL_EXCEPTION_ALL != int_old_val) {
+	if (XIL_EXCEPTION_ALL != state) {
 		Xil_ExceptionDisableMask(XIL_EXCEPTION_ALL);
 	}
+	return state;
 }
 
 void metal_machine_cache_flush(void *addr, unsigned int len)

--- a/ext/hal/libmetal/libmetal/lib/system/linux/device.c
+++ b/ext/hal/libmetal/libmetal/lib/system/linux/device.c
@@ -430,7 +430,7 @@ static int metal_linux_dev_open(struct metal_bus *bus,
 
 		/* Reset device data. */
 		memset(ldev, 0, sizeof(*ldev));
-		strncpy(ldev->dev_name, dev_name, sizeof(ldev->dev_name));
+		strncpy(ldev->dev_name, dev_name, sizeof(ldev->dev_name) - 1);
 		ldev->fd = -1;
 		ldev->ldrv = ldrv;
 		ldev->device.bus = bus;

--- a/include/kernel.h
+++ b/include/kernel.h
@@ -99,7 +99,7 @@ typedef struct {
 #define _OBJECT_TRACING_INIT .__next = NULL,
 #else
 #define _OBJECT_TRACING_INIT
-#define _OBJECT_TRACING_NEXT_PTR(type)
+#define _OBJECT_TRACING_NEXT_PTR(type) u8_t __dummy_next[0]
 #endif
 
 #ifdef CONFIG_POLL

--- a/include/logging/log_backend.h
+++ b/include/logging/log_backend.h
@@ -148,7 +148,7 @@ static inline const struct log_backend *log_backend_get(u32_t idx)
  */
 static inline int log_backend_count_get(void)
 {
-	return ((void *)__log_backends_end - (void *)__log_backends_start) /
+	return ((u8_t *)__log_backends_end - (u8_t *)__log_backends_start) /
 			sizeof(struct log_backend);
 }
 

--- a/include/logging/log_core.h
+++ b/include/logging/log_core.h
@@ -335,7 +335,7 @@ static inline u8_t log_compiled_level_get(u32_t source_id)
 static inline u32_t log_const_source_id(
 				const struct log_source_const_data *data)
 {
-	return ((char *)data - (char *)__log_const_start)/
+	return ((u8_t *)data - (u8_t *)__log_const_start)/
 			sizeof(struct log_source_const_data);
 }
 
@@ -377,7 +377,7 @@ static inline u32_t *log_dynamic_filters_get(u32_t source_id)
  */
 static inline u32_t log_dynamic_source_id(struct log_source_dynamic_data *data)
 {
-	return ((char *)data - (char *)__log_dynamic_start)/
+	return ((u8_t *)data - (u8_t *)__log_dynamic_start)/
 			sizeof(struct log_source_dynamic_data);
 }
 

--- a/include/misc/sflist.h
+++ b/include/misc/sflist.h
@@ -314,7 +314,7 @@ static inline void sys_sfnode_flags_set(sys_sfnode_t *node, u8_t flags)
  */
 static inline bool sys_sflist_is_empty(sys_sflist_t *list);
 
-Z_GENLIST_IS_EMPTY(sflist);
+Z_GENLIST_IS_EMPTY(sflist)
 
 /**
  * @brief Peek the next node from current node, node is not NULL
@@ -327,7 +327,7 @@ Z_GENLIST_IS_EMPTY(sflist);
  */
 static inline sys_sfnode_t *sys_sflist_peek_next_no_check(sys_sfnode_t *node);
 
-Z_GENLIST_PEEK_NEXT_NO_CHECK(sflist, sfnode);
+Z_GENLIST_PEEK_NEXT_NO_CHECK(sflist, sfnode)
 
 /**
  * @brief Peek the next node from current node
@@ -338,7 +338,7 @@ Z_GENLIST_PEEK_NEXT_NO_CHECK(sflist, sfnode);
  */
 static inline sys_sfnode_t *sys_sflist_peek_next(sys_sfnode_t *node);
 
-Z_GENLIST_PEEK_NEXT(sflist, sfnode);
+Z_GENLIST_PEEK_NEXT(sflist, sfnode)
 
 /**
  * @brief Prepend a node to the given list
@@ -351,7 +351,7 @@ Z_GENLIST_PEEK_NEXT(sflist, sfnode);
 static inline void sys_sflist_prepend(sys_sflist_t *list,
 				      sys_sfnode_t *node);
 
-Z_GENLIST_PREPEND(sflist, sfnode);
+Z_GENLIST_PREPEND(sflist, sfnode)
 
 /**
  * @brief Append a node to the given list
@@ -364,7 +364,7 @@ Z_GENLIST_PREPEND(sflist, sfnode);
 static inline void sys_sflist_append(sys_sflist_t *list,
 				     sys_sfnode_t *node);
 
-Z_GENLIST_APPEND(sflist, sfnode);
+Z_GENLIST_APPEND(sflist, sfnode)
 
 /**
  * @brief Append a list to the given list
@@ -382,7 +382,7 @@ Z_GENLIST_APPEND(sflist, sfnode);
 static inline void sys_sflist_append_list(sys_sflist_t *list,
 					  void *head, void *tail);
 
-Z_GENLIST_APPEND_LIST(sflist, sfnode);
+Z_GENLIST_APPEND_LIST(sflist, sfnode)
 
 /**
  * @brief merge two sflists, appending the second one to the first
@@ -396,7 +396,7 @@ Z_GENLIST_APPEND_LIST(sflist, sfnode);
 static inline void sys_sflist_merge_sflist(sys_sflist_t *list,
 					   sys_sflist_t *list_to_append);
 
-Z_GENLIST_MERGE_LIST(sflist);
+Z_GENLIST_MERGE_LIST(sflist)
 
 /**
  * @brief Insert a node to the given list
@@ -411,7 +411,7 @@ static inline void sys_sflist_insert(sys_sflist_t *list,
 				     sys_sfnode_t *prev,
 				     sys_sfnode_t *node);
 
-Z_GENLIST_INSERT(sflist, sfnode);
+Z_GENLIST_INSERT(sflist, sfnode)
 
 /**
  * @brief Fetch and remove the first node of the given list
@@ -425,7 +425,7 @@ Z_GENLIST_INSERT(sflist, sfnode);
  */
 static inline sys_sfnode_t *sys_sflist_get_not_empty(sys_sflist_t *list);
 
-Z_GENLIST_GET_NOT_EMPTY(sflist, sfnode);
+Z_GENLIST_GET_NOT_EMPTY(sflist, sfnode)
 
 /**
  * @brief Fetch and remove the first node of the given list
@@ -438,7 +438,7 @@ Z_GENLIST_GET_NOT_EMPTY(sflist, sfnode);
  */
 static inline sys_sfnode_t *sys_sflist_get(sys_sflist_t *list);
 
-Z_GENLIST_GET(sflist, sfnode);
+Z_GENLIST_GET(sflist, sfnode)
 
 /**
  * @brief Remove a node
@@ -454,7 +454,7 @@ static inline void sys_sflist_remove(sys_sflist_t *list,
 				     sys_sfnode_t *prev_node,
 				     sys_sfnode_t *node);
 
-Z_GENLIST_REMOVE(sflist, sfnode);
+Z_GENLIST_REMOVE(sflist, sfnode)
 
 /**
  * @brief Find and remove a node from a list
@@ -469,7 +469,7 @@ Z_GENLIST_REMOVE(sflist, sfnode);
 static inline bool sys_sflist_find_and_remove(sys_sflist_t *list,
 					      sys_sfnode_t *node);
 
-Z_GENLIST_FIND_AND_REMOVE(sflist, sfnode);
+Z_GENLIST_FIND_AND_REMOVE(sflist, sfnode)
 
 #ifdef __cplusplus
 }

--- a/include/misc/slist.h
+++ b/include/misc/slist.h
@@ -252,7 +252,7 @@ static inline sys_snode_t *sys_slist_peek_tail(sys_slist_t *list)
  */
 static inline bool sys_slist_is_empty(sys_slist_t *list);
 
-Z_GENLIST_IS_EMPTY(slist);
+Z_GENLIST_IS_EMPTY(slist)
 
 /**
  * @brief Peek the next node from current node, node is not NULL
@@ -265,7 +265,7 @@ Z_GENLIST_IS_EMPTY(slist);
  */
 static inline sys_snode_t *sys_slist_peek_next_no_check(sys_snode_t *node);
 
-Z_GENLIST_PEEK_NEXT_NO_CHECK(slist, snode);
+Z_GENLIST_PEEK_NEXT_NO_CHECK(slist, snode)
 
 /**
  * @brief Peek the next node from current node
@@ -276,7 +276,7 @@ Z_GENLIST_PEEK_NEXT_NO_CHECK(slist, snode);
  */
 static inline sys_snode_t *sys_slist_peek_next(sys_snode_t *node);
 
-Z_GENLIST_PEEK_NEXT(slist, snode);
+Z_GENLIST_PEEK_NEXT(slist, snode)
 
 /**
  * @brief Prepend a node to the given list
@@ -289,7 +289,7 @@ Z_GENLIST_PEEK_NEXT(slist, snode);
 static inline void sys_slist_prepend(sys_slist_t *list,
 				     sys_snode_t *node);
 
-Z_GENLIST_PREPEND(slist, snode);
+Z_GENLIST_PREPEND(slist, snode)
 
 /**
  * @brief Append a node to the given list
@@ -302,7 +302,7 @@ Z_GENLIST_PREPEND(slist, snode);
 static inline void sys_slist_append(sys_slist_t *list,
 				    sys_snode_t *node);
 
-Z_GENLIST_APPEND(slist, snode);
+Z_GENLIST_APPEND(slist, snode)
 
 /**
  * @brief Append a list to the given list
@@ -320,7 +320,7 @@ Z_GENLIST_APPEND(slist, snode);
 static inline void sys_slist_append_list(sys_slist_t *list,
 					 void *head, void *tail);
 
-Z_GENLIST_APPEND_LIST(slist, snode);
+Z_GENLIST_APPEND_LIST(slist, snode)
 
 /**
  * @brief merge two slists, appending the second one to the first
@@ -334,7 +334,7 @@ Z_GENLIST_APPEND_LIST(slist, snode);
 static inline void sys_slist_merge_slist(sys_slist_t *list,
 					 sys_slist_t *list_to_append);
 
-Z_GENLIST_MERGE_LIST(slist);
+Z_GENLIST_MERGE_LIST(slist)
 
 /**
  * @brief Insert a node to the given list
@@ -349,7 +349,7 @@ static inline void sys_slist_insert(sys_slist_t *list,
 				    sys_snode_t *prev,
 				    sys_snode_t *node);
 
-Z_GENLIST_INSERT(slist, snode);
+Z_GENLIST_INSERT(slist, snode)
 
 /**
  * @brief Fetch and remove the first node of the given list
@@ -363,7 +363,7 @@ Z_GENLIST_INSERT(slist, snode);
  */
 static inline sys_snode_t *sys_slist_get_not_empty(sys_slist_t *list);
 
-Z_GENLIST_GET_NOT_EMPTY(slist, snode);
+Z_GENLIST_GET_NOT_EMPTY(slist, snode)
 
 /**
  * @brief Fetch and remove the first node of the given list
@@ -376,7 +376,7 @@ Z_GENLIST_GET_NOT_EMPTY(slist, snode);
  */
 static inline sys_snode_t *sys_slist_get(sys_slist_t *list);
 
-Z_GENLIST_GET(slist, snode);
+Z_GENLIST_GET(slist, snode)
 
 /**
  * @brief Remove a node
@@ -392,7 +392,7 @@ static inline void sys_slist_remove(sys_slist_t *list,
 				    sys_snode_t *prev_node,
 				    sys_snode_t *node);
 
-Z_GENLIST_REMOVE(slist, snode);
+Z_GENLIST_REMOVE(slist, snode)
 
 /**
  * @brief Find and remove a node from a list
@@ -407,7 +407,7 @@ Z_GENLIST_REMOVE(slist, snode);
 static inline bool sys_slist_find_and_remove(sys_slist_t *list,
 					     sys_snode_t *node);
 
-Z_GENLIST_FIND_AND_REMOVE(slist, snode);
+Z_GENLIST_FIND_AND_REMOVE(slist, snode)
 
 #ifdef __cplusplus
 }

--- a/kernel/pipes.c
+++ b/kernel/pipes.c
@@ -627,7 +627,7 @@ int _impl_k_pipe_get(struct k_pipe *pipe, void *data, size_t bytes_to_read,
 				  sys_dlist_get(&xfer_list);
 	while ((thread != NULL) && (num_bytes_read < bytes_to_read)) {
 		desc = (struct k_pipe_desc *)thread->base.swap_data;
-		bytes_copied = pipe_xfer(data + num_bytes_read,
+		bytes_copied = pipe_xfer((u8_t *)data + num_bytes_read,
 					  bytes_to_read - num_bytes_read,
 					  desc->buffer, desc->bytes_to_xfer);
 
@@ -651,7 +651,7 @@ int _impl_k_pipe_get(struct k_pipe *pipe, void *data, size_t bytes_to_read,
 
 	if ((writer != NULL) && (num_bytes_read < bytes_to_read)) {
 		desc = (struct k_pipe_desc *)writer->base.swap_data;
-		bytes_copied = pipe_xfer(data + num_bytes_read,
+		bytes_copied = pipe_xfer((u8_t *)data + num_bytes_read,
 					  bytes_to_read - num_bytes_read,
 					  desc->buffer, desc->bytes_to_xfer);
 
@@ -700,7 +700,7 @@ int _impl_k_pipe_get(struct k_pipe *pipe, void *data, size_t bytes_to_read,
 
 	struct k_pipe_desc  pipe_desc;
 
-	pipe_desc.buffer        = data + num_bytes_read;
+	pipe_desc.buffer        = (u8_t *)data + num_bytes_read;
 	pipe_desc.bytes_to_xfer = bytes_to_read - num_bytes_read;
 
 	if (timeout != K_NO_WAIT) {

--- a/lib/libc/minimal/source/string/string.c
+++ b/lib/libc/minimal/source/string/string.c
@@ -203,7 +203,7 @@ void *memmove(void *d, const void *s, size_t n)
 	char *dest = d;
 	const char *src  = s;
 
-	if ((size_t) (d - s) < n) {
+	if ((size_t) (dest - src) < n) {
 		/*
 		 * The <src> buffer overlaps with the start of the <dest> buffer.
 		 * Copy backwards to prevent the premature corruption of <src>.

--- a/lib/mempool/mempool.c
+++ b/lib/mempool/mempool.c
@@ -17,12 +17,12 @@ static bool level_empty(struct sys_mem_pool_base *p, int l)
 
 static void *block_ptr(struct sys_mem_pool_base *p, size_t lsz, int block)
 {
-	return p->buf + lsz * block;
+	return (u8_t *)p->buf + lsz * block;
 }
 
 static int block_num(struct sys_mem_pool_base *p, void *block, int sz)
 {
-	return (block - p->buf) / sz;
+	return ((u8_t *)block - (u8_t *)p->buf) / sz;
 }
 
 /* Places a 32 bit output pointer in word, and an integer bit index
@@ -73,14 +73,14 @@ static size_t buf_size(struct sys_mem_pool_base *p)
 
 static bool block_fits(struct sys_mem_pool_base *p, void *block, size_t bsz)
 {
-	return (block + bsz - 1 - p->buf) < buf_size(p);
+	return ((u8_t *)block + bsz - 1 - (u8_t *)p->buf) < buf_size(p);
 }
 
 void _sys_mem_pool_base_init(struct sys_mem_pool_base *p)
 {
 	int i;
 	size_t buflen = p->n_max * p->max_sz, sz = p->max_sz;
-	u32_t *bits = p->buf + buflen;
+	u32_t *bits = (u32_t *)((u8_t *)p->buf + buflen);
 
 	p->max_inline_level = -1;
 

--- a/scripts/gen_syscalls.py
+++ b/scripts/gen_syscalls.py
@@ -147,7 +147,7 @@ def analyze_fn(match_group):
     flat_args = [sys_id, func_name] + flat_args
     argslist = ", ".join(flat_args)
 
-    invocation = "%s(%s);" % (macro, argslist)
+    invocation = "%s(%s)" % (macro, argslist)
 
     handler = "_handler_" + func_name
 

--- a/subsys/bluetooth/controller/crypto/crypto.c
+++ b/subsys/bluetooth/controller/crypto/crypto.c
@@ -13,16 +13,18 @@
 
 int bt_rand(void *buf, size_t len)
 {
+	u8_t *buf8 = buf;
+
 	while (len) {
 		u32_t v = sys_rand32_get();
 
 		if (len >= sizeof(v)) {
-			memcpy(buf, &v, sizeof(v));
+			memcpy(buf8, &v, sizeof(v));
 
-			buf += sizeof(v);
+			buf8 += sizeof(v);
 			len -= sizeof(v);
 		} else {
-			memcpy(buf, &v, len);
+			memcpy(buf8, &v, len);
 			break;
 		}
 	}

--- a/subsys/bluetooth/host/gatt.c
+++ b/subsys/bluetooth/host/gatt.c
@@ -389,7 +389,7 @@ ssize_t bt_gatt_attr_read(struct bt_conn *conn, const struct bt_gatt_attr *attr,
 	BT_DBG("handle 0x%04x offset %u length %u", attr->handle, offset,
 	       len);
 
-	memcpy(buf, value + offset, len);
+	memcpy(buf, (u8_t *)value + offset, len);
 
 	return len;
 }
@@ -1408,7 +1408,7 @@ static u16_t parse_include(struct bt_conn *conn, const void *pdu,
 
 	/* Parse include found */
 	for (length--, pdu = rsp->data; length >= rsp->len;
-	     length -= rsp->len, pdu += rsp->len) {
+	     length -= rsp->len, pdu = (const u8_t *)pdu + rsp->len) {
 		struct bt_gatt_attr *attr;
 		const struct bt_att_data *data = pdu;
 		struct gatt_incl *incl = (void *)data->value;
@@ -1501,7 +1501,7 @@ static u16_t parse_characteristic(struct bt_conn *conn, const void *pdu,
 
 	/* Parse characteristics found */
 	for (length--, pdu = rsp->data; length >= rsp->len;
-	     length -= rsp->len, pdu += rsp->len) {
+	     length -= rsp->len, pdu = (const u8_t *)pdu + rsp->len) {
 		struct bt_gatt_attr *attr;
 		const struct bt_att_data *data = pdu;
 		struct gatt_chrc *chrc = (void *)data->value;
@@ -1629,7 +1629,7 @@ static u16_t parse_service(struct bt_conn *conn, const void *pdu,
 
 	/* Parse services found */
 	for (length--, pdu = rsp->data; length >= rsp->len;
-	     length -= rsp->len, pdu += rsp->len) {
+	     length -= rsp->len, pdu = (const u8_t *)pdu + rsp->len) {
 		struct bt_gatt_attr attr = {};
 		struct bt_gatt_service_val value;
 		const struct bt_att_group_data *data = pdu;
@@ -1774,7 +1774,7 @@ static void gatt_find_info_rsp(struct bt_conn *conn, u8_t err,
 
 	/* Parse descriptors found */
 	for (length--, pdu = rsp->info; length >= len;
-	     length -= len, pdu += len) {
+	     length -= len, pdu = (const u8_t *)pdu + len) {
 		struct bt_gatt_attr *attr;
 
 		info.i16 = pdu;
@@ -2126,7 +2126,7 @@ static int gatt_prepare_write(struct bt_conn *conn,
 
 	/* Update params */
 	params->offset += len;
-	params->data += len;
+	params->data = (const u8_t *)params->data + len;
 	params->length -= len;
 
 	BT_DBG("handle 0x%04x offset %u len %u", params->handle, params->offset,

--- a/subsys/bluetooth/host/hci_ecc.c
+++ b/subsys/bluetooth/host/hci_ecc.c
@@ -224,7 +224,7 @@ static void clear_ecc_events(struct net_buf *buf)
 {
 	struct bt_hci_cp_le_set_event_mask *cmd;
 
-	cmd = (void *)buf->data  + sizeof(struct bt_hci_cmd_hdr);
+	cmd = (void *)(buf->data + sizeof(struct bt_hci_cmd_hdr));
 
 	/*
 	 * don't enable controller ECC events as those will be generated from

--- a/subsys/fs/nvs/nvs.c
+++ b/subsys/fs/nvs/nvs.c
@@ -29,6 +29,7 @@ static inline size_t _nvs_al_size(struct nvs_fs *fs, size_t len)
 static int _nvs_flash_al_wrt(struct nvs_fs *fs, u32_t addr, const void *data,
 		      size_t len)
 {
+	const u8_t *data8 = (const u8_t *)data;
 	int rc = 0;
 	off_t offset;
 	size_t blen;
@@ -50,17 +51,17 @@ static int _nvs_flash_al_wrt(struct nvs_fs *fs, u32_t addr, const void *data,
 	}
 	blen = len & ~(fs->write_block_size - 1);
 	if (blen > 0) {
-		rc = flash_write(fs->flash_device, offset, data, blen);
+		rc = flash_write(fs->flash_device, offset, data8, blen);
 		if (rc) {
 			/* flash write error */
 			goto end;
 		}
 		len -= blen;
 		offset += blen;
-		data += blen;
+		data8 += blen;
 	}
 	if (len) {
-		memcpy(buf, data, len);
+		memcpy(buf, data8, len);
 		(void)memset(buf + len, 0xff, fs->write_block_size - len);
 		rc = flash_write(fs->flash_device, offset, buf,
 				 fs->write_block_size);
@@ -132,6 +133,7 @@ static int _nvs_flash_ate_rd(struct nvs_fs *fs, u32_t addr,
 static int _nvs_flash_block_cmp(struct nvs_fs *fs, u32_t addr, const void *data,
 			 size_t len)
 {
+	const u8_t *data8 = (const u8_t *)data;
 	int rc;
 	size_t bytes_to_cmp, block_size;
 	u8_t buf[NVS_BLOCK_SIZE];
@@ -143,13 +145,13 @@ static int _nvs_flash_block_cmp(struct nvs_fs *fs, u32_t addr, const void *data,
 		if (rc) {
 			return rc;
 		}
-		rc = memcmp(data, buf, bytes_to_cmp);
+		rc = memcmp(data8, buf, bytes_to_cmp);
 		if (rc) {
 			return 1;
 		}
 		len -= bytes_to_cmp;
 		addr += bytes_to_cmp;
-		data += bytes_to_cmp;
+		data8 += bytes_to_cmp;
 	}
 	return 0;
 }

--- a/subsys/net/buf.c
+++ b/subsys/net/buf.c
@@ -698,7 +698,7 @@ int net_buf_linearize(void *dst, size_t dst_len, struct net_buf *src,
 	copied = 0;
 	while (frag && len > 0) {
 		to_copy = min(len, frag->len - offset);
-		memcpy(dst + copied, frag->data + offset, to_copy);
+		memcpy((u8_t *)dst + copied, frag->data + offset, to_copy);
 
 		copied += to_copy;
 
@@ -727,15 +727,15 @@ size_t net_buf_append_bytes(struct net_buf *buf, size_t len,
 {
 	struct net_buf *frag = net_buf_frag_last(buf);
 	size_t added_len = 0;
+	const u8_t *value8 = value;
 
 	do {
 		u16_t count = min(len, net_buf_tailroom(frag));
 
-		net_buf_add_mem(frag, value, count);
-
+		net_buf_add_mem(frag, value8, count);
 		len -= count;
 		added_len += count;
-		value += count;
+		value8 += count;
 
 		if (len == 0) {
 			return added_len;

--- a/subsys/net/ip/nbr.c
+++ b/subsys/net/ip/nbr.c
@@ -63,7 +63,7 @@ static inline struct net_nbr *get_nbr(struct net_nbr *start, int idx)
 {
 	NET_ASSERT(idx < CONFIG_NET_IPV6_MAX_NEIGHBORS);
 
-	return (struct net_nbr *)((void *)start +
+	return (struct net_nbr *)((u8_t *)start +
 			((sizeof(struct net_nbr) +
 			  start->size + start->extra_data_size) * idx));
 }

--- a/subsys/net/ip/route.c
+++ b/subsys/net/ip/route.c
@@ -65,7 +65,7 @@ static inline struct net_nbr *get_nexthop_nbr(struct net_nbr *start, int idx)
 	NET_ASSERT_INFO(idx < CONFIG_NET_MAX_NEXTHOPS, "idx %d >= max %d",
 			idx, CONFIG_NET_MAX_NEXTHOPS);
 
-	return (struct net_nbr *)((void *)start +
+	return (struct net_nbr *)((u8_t *)start +
 			((sizeof(struct net_nbr) + start->size) * idx));
 }
 

--- a/subsys/net/l2/ieee802154/ieee802154.c
+++ b/subsys/net/l2/ieee802154/ieee802154.c
@@ -233,7 +233,7 @@ static enum net_verdict ieee802154_recv(struct net_if *iface,
 
 	ieee802154_acknowledge(iface, &mpdu);
 
-	net_pkt_set_ll_reserve(pkt, mpdu.payload - (void *)net_pkt_ll(pkt));
+	net_pkt_set_ll_reserve(pkt, (u8_t *)mpdu.payload - net_pkt_ll(pkt));
 	net_buf_pull(pkt->frags, net_pkt_ll_reserve(pkt));
 
 	set_pkt_ll_addr(net_pkt_lladdr_src(pkt), mpdu.mhr.fs->fc.pan_id_comp,

--- a/subsys/shell/shell.c
+++ b/subsys/shell/shell.c
@@ -44,8 +44,8 @@ static inline const struct shell_cmd_entry *shell_root_cmd_get(u32_t id)
 
 static inline u32_t shell_root_cmd_count(void)
 {
-	return ((void *)__shell_root_cmds_end -
-			(void *)__shell_root_cmds_start)/
+	return ((u8_t *)__shell_root_cmds_end -
+			(u8_t *)__shell_root_cmds_start)/
 				sizeof(struct shell_cmd_entry);
 }
 

--- a/tests/kernel/mem_protect/x86_mmu_api/src/userbuffer_validate.c
+++ b/tests/kernel/mem_protect/x86_mmu_api/src/userbuffer_validate.c
@@ -27,8 +27,8 @@ void reset_flag(void);
 void reset_multi_pte_page_flag(void);
 void reset_multi_pde_flag(void);
 
-#define ADDR_PAGE_1 ((void *)__bss_start + SKIP_SIZE * MMU_PAGE_SIZE)
-#define ADDR_PAGE_2 ((void *)__bss_start + (SKIP_SIZE + 1) * MMU_PAGE_SIZE)
+#define ADDR_PAGE_1 ((u8_t *)__bss_start + SKIP_SIZE * MMU_PAGE_SIZE)
+#define ADDR_PAGE_2 ((u8_t *)__bss_start + (SKIP_SIZE + 1) * MMU_PAGE_SIZE)
 #define PRESET_PAGE_1_VALUE (X86_MMU_GET_PTE(ADDR_PAGE_1)->p = 1)
 #define PRESET_PAGE_2_VALUE (X86_MMU_GET_PTE(ADDR_PAGE_2)->p = 1)
 

--- a/tests/net/buf/src/main.c
+++ b/tests/net/buf/src/main.c
@@ -340,7 +340,7 @@ static void net_buf_test_big_buf(void)
 	}
 
 	ipv6 = (struct ipv6_hdr *)(frag->data - net_buf_headroom(frag));
-	udp = (struct udp_hdr *)((void *)ipv6 + sizeof(*ipv6));
+	udp = (struct udp_hdr *)((u8_t *)ipv6 + sizeof(*ipv6));
 
 	net_buf_frag_add(buf, frag);
 	net_buf_unref(buf);
@@ -393,7 +393,7 @@ static void net_buf_test_multi_frags(void)
 	}
 
 	ipv6 = (struct ipv6_hdr *)(frags[i]->data - net_buf_headroom(frags[i]));
-	udp = (struct udp_hdr *)((void *)ipv6 + sizeof(*ipv6));
+	udp = (struct udp_hdr *)((u8_t *)ipv6 + sizeof(*ipv6));
 
 	net_buf_unref(buf);
 

--- a/tests/net/net_pkt/src/main.c
+++ b/tests/net/net_pkt/src/main.c
@@ -77,7 +77,7 @@ static void test_ipv6_multi_frags(void)
 	/* Place the IP + UDP header in the first fragment */
 	if (!net_buf_tailroom(frag)) {
 		ipv6 = (struct ipv6_hdr *)(frag->data);
-		udp = (struct udp_hdr *)((void *)ipv6 + sizeof(*ipv6));
+		udp = (struct udp_hdr *)((u8_t *)ipv6 + sizeof(*ipv6));
 		if (net_buf_tailroom(frag) < sizeof(ipv6)) {
 			printk("Not enough space for IPv6 header, "
 			       "needed %zd bytes, has %zd bytes\n",
@@ -93,7 +93,7 @@ static void test_ipv6_multi_frags(void)
 			zassert_true(false, "No space for UDP header");
 		}
 
-		net_pkt_set_appdata(pkt, (void *)udp + sizeof(*udp));
+		net_pkt_set_appdata(pkt, (u8_t *)udp + sizeof(*udp));
 		net_pkt_set_appdatalen(pkt, 0);
 	}
 
@@ -198,7 +198,7 @@ static void test_fragment_copy(void)
 	/* Place the IP + UDP header in the first fragment */
 	if (net_buf_tailroom(frag)) {
 		ipv6 = (struct ipv6_hdr *)(frag->data);
-		udp = (struct udp_hdr *)((void *)ipv6 + sizeof(*ipv6));
+		udp = (struct udp_hdr *)((u8_t *)ipv6 + sizeof(*ipv6));
 		if (net_buf_tailroom(frag) < sizeof(*ipv6)) {
 			printk("Not enough space for IPv6 header, "
 			       "needed %zd bytes, has %zd bytes\n",
@@ -218,7 +218,7 @@ static void test_fragment_copy(void)
 
 		memcpy(net_buf_add(frag, 15), example_data, 15);
 
-		net_pkt_set_appdata(pkt, (void *)udp + sizeof(*udp) + 15);
+		net_pkt_set_appdata(pkt, (u8_t *)udp + sizeof(*udp) + 15);
 		net_pkt_set_appdatalen(pkt, 0);
 	}
 
@@ -332,7 +332,7 @@ static void test_pkt_read_append(void)
 	/* Place the IP + UDP header in the first fragment */
 	if (!net_buf_tailroom(frag)) {
 		ipv6 = (struct ipv6_hdr *)(frag->data);
-		udp = (struct udp_hdr *)((void *)ipv6 + sizeof(*ipv6));
+		udp = (struct udp_hdr *)((u8_t *)ipv6 + sizeof(*ipv6));
 		if (net_buf_tailroom(frag) < sizeof(ipv6)) {
 			printk("Not enough space for IPv6 header, "
 			       "needed %zd bytes, has %zd bytes\n",
@@ -348,7 +348,7 @@ static void test_pkt_read_append(void)
 			zassert_true(false, "No space for UDP header");
 		}
 
-		net_pkt_set_appdata(pkt, (void *)udp + sizeof(*udp));
+		net_pkt_set_appdata(pkt, (u8_t *)udp + sizeof(*udp));
 		net_pkt_set_appdatalen(pkt, 0);
 	}
 


### PR DESCRIPTION
This lessens the use of GNU extensions and permits code to compile with our Clang-based compiler.
Issues still remain, but these may require discussion; hopefully, the changes herein are acceptable. Code readability remains unharmed :)

Issue #9879.