### PR TITLE
libc: minimal: Add sys/fcntl.h enough to compile net/lib/sockets

### DIFF
--- a/lib/libc/minimal/include/sys/fcntl.h
+++ b/lib/libc/minimal/include/sys/fcntl.h
@@ -1,0 +1,15 @@
+/*
+ * Copyright (c) 2018 Linaro Limited
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef __INC_sys_fcntl_h__
+#define __INC_sys_fcntl_h__
+
+#define O_NONBLOCK 0x4000
+
+#define F_GETFL 3
+#define F_SETFL 4
+
+#endif /* __INC_sys_fcntl_h__ */


### PR DESCRIPTION
Contains defines enough to compile BSD Sockets subsystem. Values are
compatible with Newlib.

Signed-off-by: Paul Sokolovsky <paul.sokolovsky@linaro.org>