### PR TITLE
[DNM][RFC] dts: Get SoC from dts and not from kconfig generated autoconfig.h

### DIFF
--- a/boards/arm/disco_l475_iot1/disco_l475_iot1.dts
+++ b/boards/arm/disco_l475_iot1/disco_l475_iot1.dts
@@ -45,6 +45,10 @@
 	};
 };
 
+&soc {
+	compatible = "STM32L475XG", "simple-bus";
+};
+
 &usart1 {
 	current-speed = <115200>;
 	pinctrl-0 = <&usart1_pins_a>;

--- a/dts/arm/st/mem.h
+++ b/dts/arm/st/mem.h
@@ -109,7 +109,7 @@
 #elif defined(CONFIG_SOC_STM32L073XZ)
 #define DT_FLASH_SIZE		__SIZE_K(192)
 #define DT_SRAM_SIZE		__SIZE_K(20)
-#elif defined(CONFIG_SOC_STM32L475XG)
+#elif defined(CONFIG_SOC_STM32L475XG) || defined(SOC_STM32L475XG)
 #define DT_FLASH_SIZE		__SIZE_K(1024)
 #define DT_SRAM_SIZE		__SIZE_K(96)
 #elif defined(CONFIG_SOC_STM32L476XG)
@@ -124,6 +124,9 @@
 #elif defined(CONFIG_SOC_STM32L433XC)
 #define DT_FLASH_SIZE		__SIZE_K(256)
 #define DT_SRAM_SIZE		__SIZE_K(64)
+#elif defined(CONFIG_SOC_DUMMY)
+#define DT_FLASH_SIZE		__SIZE_K(0)
+#define DT_SRAM_SIZE		__SIZE_K(0)
 #else
 #error "Flash, RAM, and CCM sizes not defined for this chip"
 #endif

--- a/dts/arm/st/stm32l475.dtsi
+++ b/dts/arm/st/stm32l475.dtsi
@@ -7,7 +7,7 @@
 #include <st/stm32l4.dtsi>
 
 / {
-	soc {
+	soc: soc {
 		pinctrl: pin-controller@48000000 {
 
 			gpiod: gpio@48000c00 {

--- a/scripts/dts/extract_early_compat.py
+++ b/scripts/dts/extract_early_compat.py
@@ -1,0 +1,55 @@
+#!/usr/bin/env python3
+#
+# Copyright (c) 2017, Linaro Limited
+# Copyright (c) 2018, Bobby Noelte
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+
+# vim: ai:ts=4:sw=4
+
+import sys
+import pprint
+from devicetree import parse_file
+
+def convert_string_to_label(s):
+    # Transmute ,-@/ to _
+    s = s.replace("-", "_")
+    s = s.replace(",", "_")
+    s = s.replace("@", "_")
+    s = s.replace("/", "_")
+    # Uppercase the string
+    s = s.upper()
+    return s
+
+def main(args):
+    if len(args) == 1:
+        print('Usage: %s filename.dts' % args[0])
+        return 1
+
+    with open(args[1], "r") as fd:
+        dts = parse_file(fd)
+        root_compat = dts['/']['props']['compatible']
+        soc_compat = dts['/']['children']['soc']['props']['compatible']
+
+        if not isinstance(soc_compat, list):
+            soc_compat = [soc_compat]
+
+        if not isinstance(root_compat, list):
+            root_compat = [root_compat]
+
+        for k in root_compat:
+            if k != 'simple-bus':
+                sys.stdout.write('-D%s ' % convert_string_to_label(k))
+
+        for k in soc_compat:
+            if k != 'simple-bus':
+                sys.stdout.write('-DSOC_%s ' % convert_string_to_label(k))
+
+        sys.stdout.write('\n')
+        sys.stdout.flush()
+
+    return 0
+
+if __name__ == '__main__':
+    sys.exit(main(sys.argv))


### PR DESCRIPTION
Example of how we can remove the dep between Kconfig & dts.  We still
need to deal with MCUBOOT define, but at least this shows how to deal
with the SoC defines.

Signed-off-by: Kumar Gala <kumar.gala@linaro.org>