### PR TITLE
Sanitizing switch() statements in kernel/*

### DIFF
--- a/kernel/poll.c
+++ b/kernel/poll.c
@@ -68,6 +68,7 @@ static inline int is_condition_met(struct k_poll_event *event, u32_t *state)
 		return 0;
 	default:
 		__ASSERT(0, "invalid event type (0x%x)\n", event->type);
+		break;
 	}
 
 	return 0;
@@ -119,6 +120,7 @@ static inline int register_event(struct k_poll_event *event,
 		break;
 	default:
 		__ASSERT(0, "invalid event type\n");
+		break;
 	}
 
 	event->poller = poller;
@@ -149,6 +151,7 @@ static inline void clear_event_registration(struct k_poll_event *event)
 		break;
 	default:
 		__ASSERT(0, "invalid event type\n");
+		break;
 	}
 }
 

--- a/kernel/userspace.c
+++ b/kernel/userspace.c
@@ -34,6 +34,7 @@ static void clear_perms_cb(struct _k_object *ko, void *ctx_ptr);
 
 const char *otype_to_str(enum k_objects otype)
 {
+	const char *ret;
 	/* -fdata-sections doesn't work right except in very very recent
 	 * GCC and these literal strings would appear in the binary even if
 	 * otype_to_str was omitted by the linker
@@ -45,12 +46,14 @@ const char *otype_to_str(enum k_objects otype)
 	 */
 #include <otype-to-str.h>
 	default:
-		return "?";
+		ret = "?";
+		break;
 	}
 #else
 	ARG_UNUSED(otype);
 	return NULL;
 #endif
+	return ret;
 }
 
 struct perm_ctx {
@@ -94,11 +97,16 @@ static sys_dlist_t obj_list = SYS_DLIST_STATIC_INIT(&obj_list);
 
 static size_t obj_size_get(enum k_objects otype)
 {
+	size_t ret;
+
 	switch (otype) {
 #include <otype-to-size.h>
 	default:
-		return sizeof(struct device);
+		ret = sizeof(struct device);
+		break;
 	}
+
+	return ret;
 }
 
 static int node_lessthan(struct rbnode *a, struct rbnode *b)
@@ -342,6 +350,7 @@ static void unref_check(struct _k_object *ko)
 		k_stack_cleanup((struct k_stack *)ko->name);
 		break;
 	default:
+		/* Nothing to do */
 		break;
 	}
 

--- a/kernel/userspace.c
+++ b/kernel/userspace.c
@@ -462,6 +462,10 @@ void _dump_object_error(int retval, void *obj, struct _k_object *ko,
 		break;
 	case -EADDRINUSE:
 		printk("%p %s in use\n", obj, otype_to_str(otype));
+		break;
+	default:
+		/* Not handled error */
+		break;
 	}
 }
 

--- a/scripts/gen_kobject_list.py
+++ b/scripts/gen_kobject_list.py
@@ -202,14 +202,14 @@ def write_kobj_otype_output(fp):
         if dep:
             fp.write("#ifdef %s\n" % dep)
 
-        fp.write('case %s: return "%s";\n' % (kobject_to_enum(kobj), kobj))
+        fp.write('case %s: ret = "%s"; break;\n' % (kobject_to_enum(kobj), kobj))
         if dep:
             fp.write("#endif\n")
 
     fp.write("/* Driver subsystems */\n")
     for subsystem in subsystems:
         subsystem = subsystem.replace("_driver_api", "")
-        fp.write('case K_OBJ_DRIVER_%s: return "%s driver";\n' % (
+        fp.write('case K_OBJ_DRIVER_%s: ret = "%s driver"; break;\n' % (
             subsystem.upper(),
             subsystem
         ))
@@ -225,7 +225,7 @@ def write_kobj_size_output(fp):
         if dep:
             fp.write("#ifdef %s\n" % dep)
 
-        fp.write('case %s: return sizeof(struct %s);\n' %
+        fp.write('case %s: ret = sizeof(struct %s); break;\n' %
                 (kobject_to_enum(kobj), kobj))
         if dep:
             fp.write("#endif\n")


### PR DESCRIPTION
This is part of MISRA-C fixes (tracked in #9893)