### PR TITLE
CODEOWNERS: fix syntax

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -3,31 +3,31 @@
 # Do not use wildcard on all source yet
 # *                                        @galak @nashif
 
-.known-issues/*                          @inakypg @nashif
+.known-issues/                           @inakypg @nashif
 arch/arc/                                @vonhust @ruuddw
 arch/arm/                                @MaureenHelm @galak
-arch/arm/soc/arm/mps2/*                  @fvincenzo
+arch/arm/soc/arm/mps2/                   @fvincenzo
 arch/arm/soc/atmel_sam/sam4s             @fallrisk
 arch/arm/soc/nxp*/                       @MaureenHelm
 arch/arm/soc/st_stm32/                   @erwango
-arch/arm/soc/st_stm32/stm32f4/*          @rsalveti @idlethread
+arch/arm/soc/st_stm32/stm32f4/           @rsalveti @idlethread
 arch/arm/soc/ti_simplelink/cc32xx        @GAnthony
 arch/arm/soc/ti_simplelink/msp432p4xx    @Mani-Sadhasivam
 arch/nios2/                              @andrewboie @ramakrishnapallala
 arch/posix/                              @aescolar
 arch/riscv32/                            @fractalclone @kgugala @pgielda
 arch/x86/                                @andrewboie @ramakrishnapallala
-arch/x86/core/*                          @andrewboie
+arch/x86/core/                           @andrewboie
 arch/x86/core/crt0.S                     @ramakrishnapallala @nashif
-arch/x86/soc/intel_quark/quark_d2000/*   @nashif
-arch/x86/soc/intel_quark/quark_se/*      @nashif
-arch/x86/soc/intel_quark/quark_x1000/*   @nashif
+arch/x86/soc/intel_quark/quark_d2000/    @nashif
+arch/x86/soc/intel_quark/quark_se/       @nashif
+arch/x86/soc/intel_quark/quark_x1000/    @nashif
 arch/xtensa/                             @andrewboie @rgundi @andyross
 boards/arc/                              @vonhust @ruuddw
-boards/arc/arduino_101_sss/*             @nashif
-boards/arc/em_starterkit/*               @vonhust
-boards/arc/quark_se_c1000_ss_devboard/*  @nashif
-boards/arm/*                             @MaureenHelm @galak
+boards/arc/arduino_101_sss/              @nashif
+boards/arc/em_starterkit/                @vonhust
+boards/arc/quark_se_c1000_ss_devboard/   @nashif
+boards/arm/                              @MaureenHelm @galak
 boards/arm/96b_carbon/                   @rsalveti @idlethread
 boards/arm/96b_nitrogen/                 @idlethread
 boards/arm/96b_neonkey/                  @Mani-Sadhasivam
@@ -62,7 +62,7 @@ cmake/                                   @nashif @SebastianBoe
 /CMakeLists.txt                          @nashif @SebastianBoe
 doc/                                     @dbkinder
 doc/CMakeLists.txt                       @carlescufi
-doc/scripts/*                            @carlescufi
+doc/scripts/                             @carlescufi
 doc/subsystems/bluetooth/                @sjanc @jhedberg @Vudentz
 drivers/*/*mcux*                         @MaureenHelm
 drivers/*/*qmsi*                         @nashif
@@ -77,16 +77,16 @@ drivers/flash/                           @nashif
 drivers/flash/*stm32*                    @superna9999
 drivers/gpio/*stm32*                     @rsalveti @idlethread
 drivers/gpio/gpio_pulpino.c              @fractalclone @kgugala @pgielda
-drivers/ieee802154/*                     @jukkar @tbursztyka
-drivers/interrupt_controller/*           @andrewboie
-drivers/led/*                            @Mani-Sadhasivam
-drivers/led_strip/*                      @mbolivar
-drivers/pinmux/stm32/*                   @rsalveti @idlethread
+drivers/ieee802154/                      @jukkar @tbursztyka
+drivers/interrupt_controller/            @andrewboie
+drivers/led/                             @Mani-Sadhasivam
+drivers/led_strip/                       @mbolivar
+drivers/pinmux/stm32/                    @rsalveti @idlethread
 drivers/sensor/                          @bogdan-davidoaia @MaureenHelm
 drivers/serial/uart_altera_jtag_hal.c    @ramakrishnapallala
 drivers/serial/uart_riscv_qemu.c         @fractalclone @kgugala @pgielda
 drivers/net/slip.c                       @jukkar @tbursztyka
-drivers/spi/*                            @tbursztyka
+drivers/spi/                             @tbursztyka
 drivers/spi/spi_ll_stm32.*               @superna9999
 drivers/timer/altera_avalon_timer_hal.c  @ramakrishnapallala
 drivers/timer/pulpino_timer.c            @fractalclone @kgugala @pgielda
@@ -104,28 +104,28 @@ ext/hal/st/stm32cube/                    @erwango
 ext/lib/crypto/mbedtls/                  @nashif
 ext/lib/crypto/tinycrypt/                @lpereira
 include/adc.h                            @anangl
-include/arch/arc/*                       @vonhust @ruuddw
+include/arch/arc/                        @vonhust @ruuddw
 include/arch/arc/arch.h                  @andrewboie
 include/arch/arc/v2/irq.h                @andrewboie
-include/arch/arm/*                       @MaureenHelm @galak
+include/arch/arm/                        @MaureenHelm @galak
 include/arch/arm/cortex_m/irq.h          @andrewboie
-include/arch/nios2/*                     @andrewboie
+include/arch/nios2/                      @andrewboie
 include/arch/nios2/arch.h                @andrewboie
 include/arch/riscv32                     @fractalclone @kgugala @pgielda
-include/arch/x86/*                       @andrewboie @ramakrishnapallala
+include/arch/x86/                        @andrewboie @ramakrishnapallala
 include/arch/x86/arch.h                  @andrewboie
-include/arch/xtensa/*                    @andrewboie
+include/arch/xtensa/                     @andrewboie
 include/atomic.h                         @andrewboie @andyross
-include/bluetooth/*                      @sjanc @jhedberg @Vudentz
+include/bluetooth/                       @sjanc @jhedberg @Vudentz
 include/cache.h                          @andrewboie @andyross
 include/counter.h                        @anangl
 include/device.h                         @ramakrishnapallala @nashif
-include/drivers/bluetooth/*              @sjanc @jhedberg @Vudentz
+include/drivers/bluetooth/               @sjanc @jhedberg @Vudentz
 include/drivers/ioapic.h                 @andrewboie
 include/drivers/loapic.h                 @andrewboie
 include/drivers/mvic.h                   @andrewboie
 include/fs.h                             @nashif @ramakrishnapallala
-include/fs/*                             @nashif @ramakrishnapallala
+include/fs/                              @nashif @ramakrishnapallala
 include/init.h                           @andrewboie @andyross
 include/irq.h                            @andrewboie @andyross
 include/irq_offload.h                    @andrewboie @andyross
@@ -138,8 +138,8 @@ include/linker/linker-tool-gcc.h         @andrewboie @andyross
 include/linker/linker-tool.h             @andrewboie @andyross
 include/linker/section_tags.h            @andrewboie @andyross
 include/linker/sections.h                @andrewboie @andyross
-include/misc/*                           @andrewboie @andyross
-include/net/*                            @jukkar @tbursztyka @pfalcon
+include/misc/                            @andrewboie @andyross
+include/net/                             @jukkar @tbursztyka @pfalcon
 include/net/buf.h                        @jukkar @jhedberg @tbursztyka @pfalcon
 include/power.h                          @ramakrishnapallala @nashif
 include/sensor.h                         @bogdan-davidoaia
@@ -149,43 +149,43 @@ include/sw_isr_table.h                   @andrewboie @andyross
 include/sys_clock.h                      @andrewboie @andyross
 include/sys_io.h                         @andrewboie @andyross
 include/toolchain.h                      @andrewboie @andyross
-include/toolchain/*                      @andrewboie @andyross
+include/toolchain/                       @andrewboie @andyross
 include/zephyr.h                         @andrewboie @andyross
 kernel/                                  @andrewboie @andyross
 lib/posix/                            	 @ramakrishnapallala @nniranjhana
 kernel/device.c                          @ramakrishnapallala @nashif
 kernel/idle.c                            @ramakrishnapallala @nashif
 samples/bluetooth/                       @sjanc @jhedberg @Vudentz
-samples/boards/quark_se_c1000/power*/*   @ramakrishnapallala @nashif
+samples/boards/quark_se_c1000/power*/    @ramakrishnapallala @nashif
 samples/net/                             @jukkar @tbursztyka @pfalcon
 samples/net/dns_resolve/                 @jukkar @tbursztyka @pfalcon
-samples/net/http_server/*                @jukkar @tbursztyka
-samples/net/lwm2m_client/*               @mike-scott
-samples/net/mbedtls_sslclient/*          @jukkar
-samples/net/mqtt_publisher/*             @jukkar @tbursztyka
-samples/net/coap_client/*                @rveerama1
-samples/net/coap_server/*                @rveerama1
-samples/net/sockets/*                    @jukkar @tbursztyka @pfalcon
-samples/sensor/*                         @bogdan-davidoaia
+samples/net/http_server/                 @jukkar @tbursztyka
+samples/net/lwm2m_client/                @mike-scott
+samples/net/mbedtls_sslclient/           @jukkar
+samples/net/mqtt_publisher/              @jukkar @tbursztyka
+samples/net/coap_client/                 @rveerama1
+samples/net/coap_server/                 @rveerama1
+samples/net/sockets/                     @jukkar @tbursztyka @pfalcon
+samples/sensor/                          @bogdan-davidoaia
 samples/subsys/usb                       @jfischer-phytec-iot @finikorg
-scripts/expr_parser.py                   @andrewboie
-scripts/sanity_chk/*                     @andrewboie
+scripts/expr_parser.py                   @andrewboie @nashif
+scripts/sanity_chk/                      @andrewboie @nashif
 scripts/sanitycheck                      @andrewboie @nashif
-scripts/support/runner/*                 @mbolivar
-subsys/bluetooth/*                       @sjanc @jhedberg @Vudentz
-subsys/bluetooth/controller/*            @carlescufi @cvinayak
-subsys/fs/*                              @nashif
+scripts/support/runner/                  @mbolivar
+subsys/bluetooth/                        @sjanc @jhedberg @Vudentz
+subsys/bluetooth/controller/             @carlescufi @cvinayak
+subsys/fs/                               @nashif
 subsys/net/buf.c                         @jukkar @jhedberg @tbursztyka @pfalcon
-subsys/net/ip/*                          @jukkar @tbursztyka @pfalcon
-subsys/net/lib/*                         @jukkar @tbursztyka @pfalcon
-subsys/net/lib/dns/*                     @jukkar @tbursztyka @pfalcon
-subsys/net/lib/http/*                    @jukkar @tbursztyka
-subsys/net/lib/lwm2m/*                   @mike-scott
-subsys/net/lib/mqtt/*                    @jukkar @tbursztyka
-subsys/net/lib/coap/*                    @rveerama1
-subsys/net/lib/sockets/*                 @jukkar @tbursztyka @pfalcon
+subsys/net/ip/                           @jukkar @tbursztyka @pfalcon
+subsys/net/lib/                          @jukkar @tbursztyka @pfalcon
+subsys/net/lib/dns/                      @jukkar @tbursztyka @pfalcon
+subsys/net/lib/http/                     @jukkar @tbursztyka
+subsys/net/lib/lwm2m/                    @mike-scott
+subsys/net/lib/mqtt/                     @jukkar @tbursztyka
+subsys/net/lib/coap/                     @rveerama1
+subsys/net/lib/sockets/                  @jukkar @tbursztyka @pfalcon
 subsys/usb/                              @jfischer-phytec-iot @finikorg
-tests/boards/native_posix/*              @aescolar
+tests/boards/native_posix/               @aescolar
 tests/bluetooth/                         @sjanc @jhedberg @Vudentz @tarunkum
 tests/posix/                             @nniranjhana
 tests/crypto/                            @lpereira @pswarnak


### PR DESCRIPTION
According to https://help.github.com/articles/about-codeowners/:

The `docs/*` pattern will match files like
`docs/getting-started.md` but not further nested files like
`docs/build-app/troubleshooting.md`.

	docs/*  docs@example.com

In this example, @octocat owns any file in an apps directory
anywhere in your repository.

	apps/ @octocat

Signed-off-by: Anas Nashif <anas.nashif@intel.com>