### PR TITLE
scripts: requirements.txt: fix PyYAML for python 3.7

### DIFF
--- a/scripts/requirements.txt
+++ b/scripts/requirements.txt
@@ -5,7 +5,7 @@ docutils==0.14
 sphinx_rtd_theme
 sphinxcontrib-svg2pdfconverter
 junit2html
-PyYAML==3.12
+PyYAML>=3.12
 ply==3.10
 hub==2.0
 gitlint


### PR DESCRIPTION
PyYAML 3.13 includes a fix necessary to install on Python 3.7:

    3.13 (2018-07-05)

    Rebuild wheels using latest Cython for Python 3.7 support.

Support it by accepting any PyYAML at least as recent as the current version in requirements.txt, currently 3.12.