### PR TITLE
MISRA-C Checking function return

### DIFF
--- a/arch/arm/core/swap.c
+++ b/arch/arm/core/swap.c
@@ -41,11 +41,11 @@ extern const int _k_neg_eagain;
  * On ARMv6-M, the intlock key is represented by the PRIMASK register,
  * as BASEPRI is not available.
  *
- * @return may contain a return value setup by a call to
+ * @return -EAGAIN, or a return value set by a call to
  * _set_thread_return_value()
  *
  */
-unsigned int __swap(int key)
+int __swap(int key)
 {
 #ifdef CONFIG_USERSPACE
 	/* Save off current privilege mode */

--- a/arch/arm/core/thread_abort.c
+++ b/arch/arm/core/thread_abort.c
@@ -41,7 +41,7 @@ void _impl_k_thread_abort(k_tid_t thread)
 
 	if (_current == thread) {
 		if ((SCB->ICSR & SCB_ICSR_VECTACTIVE_Msk) == 0) {
-			_Swap(key);
+			(void)_Swap(key);
 			CODE_UNREACHABLE;
 		} else {
 			SCB->ICSR |= SCB_ICSR_PENDSVSET_Msk;

--- a/arch/posix/core/posix_core.c
+++ b/arch/posix/core/posix_core.c
@@ -347,9 +347,8 @@ static int ttable_get_empty_slot(void)
 	}
 
 	/* Clear new piece of table */
-	memset(&threads_table[threads_table_size],
-		0,
-		PC_ALLOC_CHUNK_SIZE * sizeof(struct threads_table_el));
+	(void)memset(&threads_table[threads_table_size], 0,
+		     PC_ALLOC_CHUNK_SIZE * sizeof(struct threads_table_el));
 
 	threads_table_size += PC_ALLOC_CHUNK_SIZE;
 

--- a/arch/posix/core/posix_core.c
+++ b/arch/posix/core/posix_core.c
@@ -511,7 +511,7 @@ void _impl_k_thread_abort(k_tid_t thread)
 			thread_idx,
 			__func__);
 
-		_Swap(key);
+		(void)_Swap(key);
 		CODE_UNREACHABLE; /* LCOV_EXCL_LINE */
 	}
 

--- a/arch/posix/core/swap.c
+++ b/arch/posix/core/swap.c
@@ -34,7 +34,7 @@
  *
  */
 
-unsigned int __swap(unsigned int key)
+int __swap(unsigned int key)
 {
 /*
  * struct k_thread * _kernel.current is the currently runnig thread

--- a/arch/x86/core/irq_manage.c
+++ b/arch/x86/core/irq_manage.c
@@ -95,7 +95,7 @@ void _arch_isr_direct_footer(int swap)
 			:
 			: "memory"
 			);
-		_Swap(flags);
+		(void)_Swap(flags);
 	}
 }
 

--- a/arch/xtensa/core/thread.c
+++ b/arch/xtensa/core/thread.c
@@ -66,7 +66,8 @@ void _new_thread(struct k_thread *thread, k_thread_stack_t *stack,
 #if XCHAL_CP_NUM > 0
 	/* Ensure CP state descriptor is correctly initialized */
 	cpStack = thread->arch.preempCoprocReg.cpStack; /* short hand alias */
-	memset(cpStack, 0, XT_CP_ASA); /* Set to zero to avoid bad surprises */
+	/* Set to zero to avoid bad surprises */
+	(void)memset(cpStack, 0, XT_CP_ASA);
 	/* Coprocessor's stack is allocated just after the k_thread */
 	cpSA = (u32_t *)(thread->arch.preempCoprocReg.cpStack + XT_CP_ASA);
 	/* Coprocessor's save area alignment is at leat 16 bytes */

--- a/arch/xtensa/core/xtensa-asm2.c
+++ b/arch/xtensa/core/xtensa-asm2.c
@@ -27,7 +27,7 @@ void *xtensa_init_stack(int *stack_top,
 	const int bsasz = BASE_SAVE_AREA_SIZE - 16;
 	void **bsa = (void **) (((char *) stack_top) - bsasz);
 
-	memset(bsa, 0, bsasz);
+	(void)memset(bsa, 0, bsasz);
 
 	bsa[BSA_PC_OFF/4] = _thread_entry;
 	bsa[BSA_PS_OFF/4] = (void *)(PS_WOE | PS_UM | PS_CALLINC(1));

--- a/boards/posix/native_posix/irq_handler.c
+++ b/boards/posix/native_posix/irq_handler.c
@@ -112,7 +112,7 @@ void posix_irq_handler(void)
 		&& (hw_irq_ctrl_get_cur_prio() == 256)
 		&& (_kernel.ready_q.cache != _current)) {
 
-		_Swap(irq_lock);
+		(void)_Swap(irq_lock);
 	}
 }
 

--- a/drivers/adc/adc_ti_adc108s102.c
+++ b/drivers/adc/adc_ti_adc108s102.c
@@ -168,7 +168,7 @@ static int ti_adc108s102_read(struct device *dev,
 	s32_t delay;
 
 	/* Resetting all internal channel data */
-	memset(adc->chans, 0, ADC108S102_CHANNELS_SIZE);
+	(void)memset(adc->chans, 0, ADC108S102_CHANNELS_SIZE);
 
 	if (_verify_entries(seq_table) == 0) {
 		return -EINVAL;

--- a/drivers/bluetooth/hci/h5.c
+++ b/drivers/bluetooth/hci/h5.c
@@ -286,7 +286,7 @@ static void h5_send(const u8_t *payload, u8_t type, int len)
 
 	hexdump("<= ", payload, len);
 
-	memset(hdr, 0, sizeof(hdr));
+	(void)memset(hdr, 0, sizeof(hdr));
 
 	/* Set ACK for outgoing packet and stop delayed work */
 	H5_SET_ACK(hdr, h5.tx_ack);

--- a/drivers/bluetooth/hci/spi.c
+++ b/drivers/bluetooth/hci/spi.c
@@ -285,7 +285,7 @@ static void bt_spi_rx_thread(void)
 	u8_t size = 0;
 	int ret;
 
-	memset(&txmsg, 0xFF, SPI_MAX_MSG_LEN);
+	(void)memset(&txmsg, 0xFF, SPI_MAX_MSG_LEN);
 
 	while (true) {
 		k_sem_take(&sem_request, K_FOREVER);

--- a/drivers/bluetooth/hci/userchan.c
+++ b/drivers/bluetooth/hci/userchan.c
@@ -164,7 +164,7 @@ static int user_chan_open(u16_t index)
 		return -errno;
 	}
 
-	memset(&addr, 0, sizeof(addr));
+	(void)memset(&addr, 0, sizeof(addr));
 	addr.hci_family = AF_BLUETOOTH;
 	addr.hci_dev = index;
 	addr.hci_channel = HCI_CHANNEL_USER;

--- a/drivers/can/stm32_can.c
+++ b/drivers/can/stm32_can.c
@@ -285,7 +285,8 @@ static int can_stm32_init(struct device *dev)
 	data->mb2.tx_callback = NULL;
 
 	data->filter_usage = (1ULL << CAN_MAX_NUMBER_OF_FILTES) - 1ULL;
-	memset(data->rx_response, 0, sizeof(void *) * CONFIG_CAN_MAX_FILTER);
+	(void)memset(data->rx_response, 0,
+		     sizeof(void *) * CONFIG_CAN_MAX_FILTER);
 	data->response_type = 0;
 
 	clock = device_get_binding(STM32_CLOCK_CONTROL_NAME);
@@ -418,7 +419,7 @@ static int can_stm32_shift_arr(void **arr, int start, int count)
 		cnt = (CONFIG_CAN_MAX_FILTER - start - count) * sizeof(void *);
 		move_dest = start_ptr + count;
 		memmove(move_dest, start_ptr, cnt);
-		memset(start_ptr, 0, count * sizeof(void *));
+		(void)memset(start_ptr, 0, count * sizeof(void *));
 	} else if (count < 0) {
 		count = -count;
 
@@ -428,8 +429,8 @@ static int can_stm32_shift_arr(void **arr, int start, int count)
 
 		cnt = (CONFIG_CAN_MAX_FILTER - start) * sizeof(void *);
 		memmove(start_ptr - count, start_ptr, cnt);
-		memset(arr + CONFIG_CAN_MAX_FILTER - count, 0,
-		       count * sizeof(void *));
+		(void)memset(arr + CONFIG_CAN_MAX_FILTER - count, 0,
+			     count * sizeof(void *));
 	}
 
 	return 0;

--- a/drivers/crypto/crypto_ataes132a.c
+++ b/drivers/crypto/crypto_ataes132a.c
@@ -632,7 +632,7 @@ int ataes132a_aes_ecb_block(struct device *dev,
 	param_buffer[1] = key_id;
 	param_buffer[2] = 0x0;
 	memcpy(param_buffer + 3, pkt->in_buf, buf_len);
-	memset(param_buffer + 3 + buf_len, 0x0, 16 - buf_len);
+	(void)memset(param_buffer + 3 + buf_len, 0x0, 16 - buf_len);
 
 	return_code = ataes132a_send_command(dev, ATAES_LEGACY_OP, 0x00,
 					     param_buffer, buf_len + 3,

--- a/drivers/crypto/crypto_tc_shim.c
+++ b/drivers/crypto/crypto_tc_shim.c
@@ -294,7 +294,7 @@ static int tc_session_free(struct device *dev, struct cipher_ctx *sessn)
 	struct tc_shim_drv_state *data =  sessn->drv_sessn_state;
 
 	ARG_UNUSED(dev);
-	memset(data, 0, sizeof(struct tc_shim_drv_state));
+	(void)memset(data, 0, sizeof(struct tc_shim_drv_state));
 	data->in_use = 0;
 
 	return 0;

--- a/drivers/dma/dma_cavs.c
+++ b/drivers/dma/dma_cavs.c
@@ -164,7 +164,8 @@ static int dw_dma_config(struct device *dev, u32_t channel,
 		return -ENOMEM;
 	}
 
-	memset(chan_data->lli, 0, (sizeof(struct dw_lli2) * cfg->block_count));
+	(void)memset(chan_data->lli, 0,
+		     (sizeof(struct dw_lli2) * cfg->block_count));
 	lli_desc = chan_data->lli;
 	lli_desc_tail = lli_desc + cfg->block_count - 1;
 

--- a/drivers/dma/dma_sam_xdmac.c
+++ b/drivers/dma/dma_sam_xdmac.c
@@ -255,7 +255,7 @@ static int sam_xdmac_config(struct device *dev, u32_t channel,
 
 	dev_data->dma_channels[channel].callback = cfg->dma_callback;
 
-	memset(&transfer_cfg, 0, sizeof(transfer_cfg));
+	(void)memset(&transfer_cfg, 0, sizeof(transfer_cfg));
 	transfer_cfg.sa = cfg->head_block->source_address;
 	transfer_cfg.da = cfg->head_block->dest_address;
 	transfer_cfg.ublen = cfg->head_block->block_size >> data_size;

--- a/drivers/ethernet/eth_mcux.c
+++ b/drivers/ethernet/eth_mcux.c
@@ -785,7 +785,7 @@ static int eth_0_init(struct device *dev)
 #if defined(CONFIG_PTP_CLOCK_MCUX)
 	ts_tx_rd = 0;
 	ts_tx_wr = 0;
-	memset(ts_tx_pkt, 0, sizeof(ts_tx_pkt));
+	(void)memset(ts_tx_pkt, 0, sizeof(ts_tx_pkt));
 #endif
 
 	k_sem_init(&context->tx_buf_sem,

--- a/drivers/ethernet/eth_native_posix_adapt.c
+++ b/drivers/ethernet/eth_native_posix_adapt.c
@@ -61,7 +61,7 @@ int eth_iface_create(const char *if_name, bool tun_only)
 		return -errno;
 	}
 
-	memset(&ifr, 0, sizeof(ifr));
+	(void)memset(&ifr, 0, sizeof(ifr));
 
 #ifdef __linux
 	ifr.ifr_flags = (tun_only ? IFF_TUN : IFF_TAP) | IFF_NO_PI;

--- a/drivers/i2s/i2s_cavs.c
+++ b/drivers/i2s/i2s_cavs.c
@@ -327,7 +327,7 @@ static int i2s_cavs_configure(struct device *dev, enum i2s_dir dir,
 
 	if (i2s_cfg->frame_clk_freq == 0) {
 		strm->queue_drop(strm);
-		memset(&strm->cfg, 0, sizeof(struct i2s_config));
+		(void)memset(&strm->cfg, 0, sizeof(struct i2s_config));
 		strm->state = I2S_STATE_NOT_READY;
 		return 0;
 	}

--- a/drivers/i2s/i2s_sam_ssc.c
+++ b/drivers/i2s/i2s_sam_ssc.c
@@ -169,7 +169,7 @@ static int start_dma(struct device *dev_dma, u32_t channel,
 	struct dma_block_config blk_cfg;
 	int ret;
 
-	memset(&blk_cfg, 0, sizeof(blk_cfg));
+	(void)memset(&blk_cfg, 0, sizeof(blk_cfg));
 	blk_cfg.block_size = blk_size;
 	blk_cfg.source_address = (u32_t)src;
 	blk_cfg.dest_address = (u32_t)dst;
@@ -557,7 +557,7 @@ static int i2s_sam_configure(struct device *dev, enum i2s_dir dir,
 
 	if (i2s_cfg->frame_clk_freq == 0) {
 		stream->queue_drop(stream);
-		memset(&stream->cfg, 0, sizeof(struct i2s_config));
+		(void)memset(&stream->cfg, 0, sizeof(struct i2s_config));
 		stream->state = I2S_STATE_NOT_READY;
 		return 0;
 	}

--- a/drivers/ieee802154/ieee802154_uart_pipe.c
+++ b/drivers/ieee802154/ieee802154_uart_pipe.c
@@ -320,7 +320,7 @@ static int upipe_init(struct device *dev)
 {
 	struct upipe_context *upipe = dev->driver_data;
 
-	memset(upipe, 0, sizeof(struct upipe_context));
+	(void)memset(upipe, 0, sizeof(struct upipe_context));
 
 	uart_pipe_register(upipe->uart_pipe_buf, 1, upipe_rx);
 

--- a/drivers/interrupt_controller/ioapic_intr.c
+++ b/drivers/interrupt_controller/ioapic_intr.c
@@ -205,7 +205,7 @@ int ioapic_suspend(struct device *port)
 	u32_t rte_lo;
 
 	ARG_UNUSED(port);
-	memset(ioapic_suspend_buf, 0, (SUSPEND_BITS_REQD >> 3));
+	(void)memset(ioapic_suspend_buf, 0, (SUSPEND_BITS_REQD >> 3));
 	for (irq = 0; irq < CONFIG_IOAPIC_NUM_RTES; irq++) {
 		/*
 		 * The following check is to figure out the registered

--- a/drivers/interrupt_controller/loapic_intr.c
+++ b/drivers/interrupt_controller/loapic_intr.c
@@ -432,7 +432,7 @@ static int loapic_suspend(struct device *port)
 
 	ARG_UNUSED(port);
 
-	memset(loapic_suspend_buf, 0, (LOPIC_SUSPEND_BITS_REQD >> 3));
+	(void)memset(loapic_suspend_buf, 0, (LOPIC_SUSPEND_BITS_REQD >> 3));
 
 	for (loapic_irq = 0; loapic_irq < LOAPIC_IRQ_COUNT; loapic_irq++) {
 

--- a/drivers/led_strip/lpd880x.c
+++ b/drivers/led_strip/lpd880x.c
@@ -68,7 +68,7 @@ static int lpd880x_update(struct device *dev, void *data, size_t size)
 	};
 	size_t rc;
 
-	memset(reset_buf, 0x00, reset_size);
+	(void)memset(reset_buf, 0x00, reset_size);
 
 	rc = spi_write(drv_data->spi, &drv_data->config, &tx);
 	if (rc) {

--- a/drivers/led_strip/ws2812.c
+++ b/drivers/led_strip/ws2812.c
@@ -95,7 +95,7 @@ static int ws2812_reset_strip(struct ws2812_data *data)
 		.count = 1
 	};
 
-	memset(reset_buf, 0x00, sizeof(reset_buf));
+	(void)memset(reset_buf, 0x00, sizeof(reset_buf));
 
 	return spi_write(data->spi, &data->config, &tx);
 }

--- a/drivers/modem/wncm14a2a.c
+++ b/drivers/modem/wncm14a2a.c
@@ -304,8 +304,8 @@ static void socket_put(struct wncm14a2a_socket *sock)
 
 	sock->context = NULL;
 	sock->socket_id = 0;
-	memset(&sock->src, 0, sizeof(struct sockaddr));
-	memset(&sock->dst, 0, sizeof(struct sockaddr));
+	(void)memset(&sock->src, 0, sizeof(struct sockaddr));
+	(void)memset(&sock->dst, 0, sizeof(struct sockaddr));
 }
 
 char *wncm14a2a_sprint_ip_addr(const struct sockaddr *addr)
@@ -512,7 +512,7 @@ static int net_pkt_setup_ip_data(struct net_pkt *pkt,
 
 		net_buf_add(pkt->frags, NET_UDPH_LEN);
 		udp = net_udp_get_hdr(pkt, &hdr);
-		memset(udp, 0, NET_UDPH_LEN);
+		(void)memset(udp, 0, NET_UDPH_LEN);
 
 		/* Setup UDP header */
 		udp->src_port = src_port;
@@ -527,7 +527,7 @@ static int net_pkt_setup_ip_data(struct net_pkt *pkt,
 
 		net_buf_add(pkt->frags, NET_TCPH_LEN);
 		tcp = net_tcp_get_hdr(pkt, &hdr);
-		memset(tcp, 0, NET_TCPH_LEN);
+		(void)memset(tcp, 0, NET_TCPH_LEN);
 
 		/* Setup TCP header */
 		tcp->src_port = src_port;
@@ -621,7 +621,7 @@ static void on_cmd_atcmdinfo_rssi(struct net_buf **buf, u16_t len)
 	char value[64];
 
 	value_size = sizeof(value);
-	memset(value, 0, value_size);
+	(void)memset(value, 0, value_size);
 	while (*buf && len > 0 && i < value_size) {
 		value[i] = net_buf_pull_u8(*buf);
 		if (!(*buf)->len) {
@@ -777,7 +777,7 @@ static void on_cmd_sockread(struct net_buf **buf, u16_t len)
 	/* first comma marks the end of actual_length */
 	i = 0;
 	value_size = sizeof(value);
-	memset(value, 0, value_size);
+	(void)memset(value, 0, value_size);
 	while (*buf && i < value_size) {
 		value[i++] = net_buf_pull_u8(*buf);
 		len--;
@@ -1444,7 +1444,7 @@ static int wncm14a2a_init(struct device *dev)
 	__ASSERT(sizeof(pinconfig) == MAX_MDM_CONTROL_PINS,
 	       "Incorrect modem pinconfig!");
 
-	memset(&ictx, 0, sizeof(ictx));
+	(void)memset(&ictx, 0, sizeof(ictx));
 	for (i = 0; i < MDM_MAX_SOCKETS; i++) {
 		k_work_init(&ictx.sockets[i].recv_cb_work,
 			    sockreadrecv_cb_work);

--- a/drivers/pci/pci_interface.c
+++ b/drivers/pci/pci_interface.c
@@ -385,7 +385,7 @@ void pci_header_get(u32_t controller,
 
 	/* clear out the header */
 
-	memset(pci_dev_header, 0, sizeof(*pci_dev_header));
+	(void)memset(pci_dev_header, 0, sizeof(*pci_dev_header));
 
 	/* fill in the PCI header from the device */
 

--- a/drivers/sensor/dht/dht.c
+++ b/drivers/sensor/dht/dht.c
@@ -126,7 +126,7 @@ static int dht_sample_fetch(struct device *dev, enum sensor_channel chan)
 
 	/* store bits in buf */
 	j = 0;
-	memset(buf, 0, sizeof(buf));
+	(void)memset(buf, 0, sizeof(buf));
 	for (i = 0; i < DHT_DATA_BITS_NUM; i++) {
 		if (signal_duration[i] >= avg_duration) {
 			buf[j] = (buf[j] << 1) | 1;

--- a/drivers/sensor/lis2dh/lis2dh.c
+++ b/drivers/sensor/lis2dh/lis2dh.c
@@ -324,7 +324,7 @@ int lis2dh_init(struct device *dev)
 	 * pin. Register values are retained if power is not removed.
 	 * Default values see LIS2DH documentation page 30, chapter 6.
 	 */
-	memset(raw, 0, sizeof(raw));
+	(void)memset(raw, 0, sizeof(raw));
 	raw[LIS2DH_DATA_OFS] = LIS2DH_ACCEL_EN_BITS;
 
 	status = lis2dh_burst_write(dev, LIS2DH_REG_CTRL1, raw,

--- a/drivers/sensor/lis2dh/lis2dh_trigger.c
+++ b/drivers/sensor/lis2dh/lis2dh_trigger.c
@@ -406,7 +406,7 @@ int lis2dh_init_interrupt(struct device *dev)
 		return status;
 	}
 
-	memset(raw, 0, sizeof(raw));
+	(void)memset(raw, 0, sizeof(raw));
 	status = lis2dh_burst_write(dev, LIS2DH_REG_INT2_THS, raw, sizeof(raw));
 	if (status < 0) {
 		SYS_LOG_ERR("Burst write to INT2 THS failed (%d)", status);

--- a/drivers/sensor/vl53l0x/vl53l0x.c
+++ b/drivers/sensor/vl53l0x/vl53l0x.c
@@ -237,7 +237,7 @@ static int vl53l0x_init(struct device *dev)
 	drv_data->vl53l0x.I2cDevAddr = CONFIG_VL53L0X_I2C_ADDR;
 
 	/* Get info from sensor */
-	memset(&vl53l0x_dev_info, 0, sizeof(VL53L0X_DeviceInfo_t));
+	(void)memset(&vl53l0x_dev_info, 0, sizeof(VL53L0X_DeviceInfo_t));
 
 	ret = VL53L0X_GetDeviceInfo(&drv_data->vl53l0x, &vl53l0x_dev_info);
 	if (ret < 0) {

--- a/drivers/usb/device/usb_dc_dw.c
+++ b/drivers/usb/device/usb_dc_dw.c
@@ -801,7 +801,7 @@ int usb_dc_reset(void)
 	ret = usb_dw_reset();
 
 	/* Clear private data */
-	memset(&usb_dw_ctrl, 0, sizeof(usb_dw_ctrl));
+	(void)memset(&usb_dw_ctrl, 0, sizeof(usb_dw_ctrl));
 
 	return ret;
 }

--- a/drivers/usb/device/usb_dc_kinetis.c
+++ b/drivers/usb/device/usb_dc_kinetis.c
@@ -193,7 +193,7 @@ int usb_dc_reset(void)
 	for (u8_t i = 0; i < 16; i++) {
 		USB0->ENDPOINT[i].ENDPT = 0;
 	}
-	memset(bdt, 0, sizeof(bdt));
+	(void)memset(bdt, 0, sizeof(bdt));
 	dev_data.bd_active = 0;
 	dev_data.address = 0;
 
@@ -333,11 +333,11 @@ int usb_dc_ep_configure(const struct usb_dc_ep_cfg_data * const cfg)
 	}
 
 	USB0->ENDPOINT[ep_idx].ENDPT = 0;
-	memset(&bdt[idx_even], 0, sizeof(struct buf_descriptor));
-	memset(&bdt[idx_odd], 0, sizeof(struct buf_descriptor));
+	(void)memset(&bdt[idx_even], 0, sizeof(struct buf_descriptor));
+	(void)memset(&bdt[idx_odd], 0, sizeof(struct buf_descriptor));
 
 	if (k_mem_pool_alloc(&ep_buf_pool, block, cfg->ep_mps * 2, 10) == 0) {
-		memset(block->data, 0, cfg->ep_mps * 2);
+		(void)memset(block->data, 0, cfg->ep_mps * 2);
 	} else {
 		SYS_LOG_ERR("Memory allocation time-out");
 		return -ENOMEM;

--- a/drivers/usb/device/usb_dc_nrf5.c
+++ b/drivers/usb/device/usb_dc_nrf5.c
@@ -1671,28 +1671,28 @@ static void endpoint_ctx_deinit(void)
 		ep_ctx = in_endpoint_ctx(i);
 		__ASSERT_NO_MSG(ep_ctx);
 		k_mem_pool_free(&ep_ctx->buf.block);
-		memset(ep_ctx, 0, sizeof(*ep_ctx));
+		(void)memset(ep_ctx, 0, sizeof(*ep_ctx));
 	}
 
 	for (i = 0; i < CFG_EPOUT_CNT; i++) {
 		ep_ctx = out_endpoint_ctx(i);
 		__ASSERT_NO_MSG(ep_ctx);
 		k_mem_pool_free(&ep_ctx->buf.block);
-		memset(ep_ctx, 0, sizeof(*ep_ctx));
+		(void)memset(ep_ctx, 0, sizeof(*ep_ctx));
 	}
 
 	if (CFG_EP_ISOIN_CNT) {
 		ep_ctx = in_endpoint_ctx(NRF_USBD_EPIN(8));
 		__ASSERT_NO_MSG(ep_ctx);
 		k_mem_pool_free(&ep_ctx->buf.block);
-		memset(ep_ctx, 0, sizeof(*ep_ctx));
+		(void)memset(ep_ctx, 0, sizeof(*ep_ctx));
 	}
 
 	if (CFG_EP_ISOOUT_CNT) {
 		ep_ctx = out_endpoint_ctx(NRF_USBD_EPOUT(8));
 		__ASSERT_NO_MSG(ep_ctx);
 		k_mem_pool_free(&ep_ctx->buf.block);
-		memset(ep_ctx, 0, sizeof(*ep_ctx));
+		(void)memset(ep_ctx, 0, sizeof(*ep_ctx));
 	}
 }
 

--- a/drivers/usb/device/usb_dc_sam0.c
+++ b/drivers/usb/device/usb_dc_sam0.c
@@ -197,7 +197,7 @@ int usb_dc_attach(void)
 	regs->CTRLA.reg = USB_CTRLA_MODE_DEVICE | USB_CTRLA_RUNSTDBY;
 	regs->CTRLB.reg = USB_DEVICE_CTRLB_SPDCONF_HS;
 
-	memset(data->descriptors, 0, sizeof(data->descriptors));
+	(void)memset(data->descriptors, 0, sizeof(data->descriptors));
 	regs->DESCADD.reg = (uintptr_t)&data->descriptors[0];
 
 	regs->INTENSET.reg = USB_DEVICE_INTENSET_EORST;

--- a/drivers/watchdog/wdt_esp32.c
+++ b/drivers/watchdog/wdt_esp32.c
@@ -204,7 +204,7 @@ static int wdt_esp32_init(struct device *dev)
 {
 	struct wdt_esp32_data *data = dev->driver_data;
 
-	memset(&data->config, 0, sizeof(data->config));
+	(void)memset(&data->config, 0, sizeof(data->config));
 
 #ifdef CONFIG_WDT_DISABLE_AT_BOOT
 	wdt_esp32_disable(dev);

--- a/drivers/wifi/simplelink/simplelink_support.c
+++ b/drivers/wifi/simplelink/simplelink_support.c
@@ -161,7 +161,7 @@ static s32_t configure_simplelink(void)
 	ASSERT_ON_ERROR(retval, NETAPP_ERROR);
 
 	/* Remove all 64 RX filters (8*8) */
-	memset(rx_filterid_mask.FilterBitmap, 0xFF, 8);
+	(void)memset(rx_filterid_mask.FilterBitmap, 0xFF, 8);
 
 	retval = sl_WlanSet(SL_WLAN_RX_FILTERS_ID, SL_WLAN_RX_FILTER_REMOVE,
 			    sizeof(SlWlanRxFilterOperationCommandBuff_t),
@@ -263,8 +263,8 @@ void SimpleLinkWlanEventHandler(SlWlanEvent_t *wlan_event)
 			sl_conn.error = event_data->ReasonCode;
 		}
 
-		memset(&(sl_conn.ssid), 0x0, sizeof(sl_conn.ssid));
-		memset(&(sl_conn.bssid), 0x0, sizeof(sl_conn.bssid));
+		(void)memset(&(sl_conn.ssid), 0x0, sizeof(sl_conn.ssid));
+		(void)memset(&(sl_conn.bssid), 0x0, sizeof(sl_conn.bssid));
 
 		/* Continue the notification callback chain... */
 		nwp.cb(SL_WLAN_EVENT_DISCONNECT, &sl_conn);
@@ -288,7 +288,7 @@ void SimpleLinkWlanEventHandler(SlWlanEvent_t *wlan_event)
 			    sl_conn.bssid[2], sl_conn.bssid[3],
 			    sl_conn.bssid[4], sl_conn.bssid[5]);
 
-		memset(&(sl_conn.bssid), 0x0, sizeof(sl_conn.bssid));
+		(void)memset(&(sl_conn.bssid), 0x0, sizeof(sl_conn.bssid));
 		break;
 	default:
 		SYS_LOG_ERR("\n[WLAN EVENT] Unexpected event [0x%lx]",
@@ -496,7 +496,7 @@ void _simplelink_get_scan_result(int index,
 	__ASSERT_NO_MSG(index <= CONFIG_WIFI_SIMPLELINK_SCAN_COUNT);
 	net_entry = &nwp.net_entries[index];
 
-	memset(scan_result, 0x0, sizeof(struct wifi_scan_result));
+	(void)memset(scan_result, 0x0, sizeof(struct wifi_scan_result));
 
 	__ASSERT_NO_MSG(net_entry->SsidLen <= WIFI_SSID_MAX_LEN);
 	memcpy(scan_result->ssid, net_entry->Ssid, net_entry->SsidLen);
@@ -519,7 +519,7 @@ int _simplelink_start_scan(void)
 	s32_t ret;
 
 	/* Clear the results buffer */
-	memset(&nwp.net_entries, 0x0, sizeof(nwp.net_entries));
+	(void)memset(&nwp.net_entries, 0x0, sizeof(nwp.net_entries));
 
 	/* Attempt to get scan results from NWP
 	 * Note: If scan policy isn't set, invoking 'sl_WlanGetNetworkList()'
@@ -588,7 +588,7 @@ int _simplelink_init(simplelink_wifi_cb_t wifi_cb)
 	nwp.role = ROLE_RESERVED;
 	nwp.cb = wifi_cb;
 
-	memset(&sl_conn, 0x0, sizeof(sl_conn));
+	(void)memset(&sl_conn, 0x0, sizeof(sl_conn));
 
 	retval = configure_simplelink();
 	__ASSERT(retval >= 0, "Unable to configure SimpleLink");

--- a/include/atomic.h
+++ b/include/atomic.h
@@ -388,7 +388,7 @@ static inline void atomic_clear_bit(atomic_t *target, int bit)
 {
 	atomic_val_t mask = ATOMIC_MASK(bit);
 
-	atomic_and(ATOMIC_ELEM(target, bit), ~mask);
+	(void)atomic_and(ATOMIC_ELEM(target, bit), ~mask);
 }
 
 /**
@@ -406,7 +406,7 @@ static inline void atomic_set_bit(atomic_t *target, int bit)
 {
 	atomic_val_t mask = ATOMIC_MASK(bit);
 
-	atomic_or(ATOMIC_ELEM(target, bit), mask);
+	(void)atomic_or(ATOMIC_ELEM(target, bit), mask);
 }
 
 /**

--- a/include/misc/printk.h
+++ b/include/misc/printk.h
@@ -42,8 +42,8 @@ extern "C" {
  * @return N/A
  */
 #ifdef CONFIG_PRINTK
-extern __printf_like(1, 2) int printk(const char *fmt, ...);
-extern __printf_like(1, 0) int vprintk(const char *fmt, va_list ap);
+extern __printf_like(1, 2) void printk(const char *fmt, ...);
+extern __printf_like(1, 0) void vprintk(const char *fmt, va_list ap);
 extern __printf_like(3, 4) int snprintk(char *str, size_t size,
 					const char *fmt, ...);
 extern __printf_like(3, 0) int vsnprintk(char *str, size_t size,
@@ -52,17 +52,15 @@ extern __printf_like(3, 0) int vsnprintk(char *str, size_t size,
 extern __printf_like(3, 0) void _vprintk(int (*out)(int, void *), void *ctx,
 					 const char *fmt, va_list ap);
 #else
-static inline __printf_like(1, 2) int printk(const char *fmt, ...)
+static inline __printf_like(1, 2) void printk(const char *fmt, ...)
 {
 	ARG_UNUSED(fmt);
-	return 0;
 }
 
-static inline __printf_like(1, 0) int vprintk(const char *fmt, va_list ap)
+static inline __printf_like(1, 0) void vprintk(const char *fmt, va_list ap)
 {
 	ARG_UNUSED(fmt);
 	ARG_UNUSED(ap);
-	return 0;
 }
 
 static inline __printf_like(3, 4) int snprintk(char *str, size_t size,

--- a/include/syscall.h
+++ b/include/syscall.h
@@ -249,7 +249,7 @@ static inline u64_t _syscall_ret64_invoke0(u32_t call_id)
 {
 	u64_t ret;
 
-	_arch_syscall_invoke1((u32_t)&ret, call_id);
+	(void)_arch_syscall_invoke1((u32_t)&ret, call_id);
 	return ret;
 }
 
@@ -257,7 +257,7 @@ static inline u64_t _syscall_ret64_invoke1(u32_t arg1, u32_t call_id)
 {
 	u64_t ret;
 
-	_arch_syscall_invoke2(arg1, (u32_t)&ret, call_id);
+	(void)_arch_syscall_invoke2(arg1, (u32_t)&ret, call_id);
 	return ret;
 }
 
@@ -266,7 +266,7 @@ static inline u64_t _syscall_ret64_invoke2(u32_t arg1, u32_t arg2,
 {
 	u64_t ret;
 
-	_arch_syscall_invoke3(arg1, arg2, (u32_t)&ret, call_id);
+	(void)_arch_syscall_invoke3(arg1, arg2, (u32_t)&ret, call_id);
 	return ret;
 }
 

--- a/kernel/device.c
+++ b/kernel/device.c
@@ -51,7 +51,7 @@ void _sys_device_do_config_level(int level)
 								info++) {
 		struct device_config *device = info->config;
 
-		device->init(info);
+		(void)device->init(info);
 		_k_object_init(info);
 	}
 }

--- a/kernel/include/ksched.h
+++ b/kernel/include/ksched.h
@@ -38,7 +38,7 @@ int _is_thread_time_slicing(struct k_thread *thread);
 void _unpend_thread_no_timeout(struct k_thread *thread);
 int _pend_current_thread(int key, _wait_q_t *wait_q, s32_t timeout);
 void _pend_thread(struct k_thread *thread, _wait_q_t *wait_q, s32_t timeout);
-int _reschedule(int key);
+void _reschedule(int key);
 struct k_thread *_unpend_first_thread(_wait_q_t *wait_q);
 void _unpend_thread(struct k_thread *thread);
 int _unpend_all(_wait_q_t *wait_q);

--- a/kernel/include/kswap.h
+++ b/kernel/include/kswap.h
@@ -40,7 +40,7 @@ void _smp_release_global_lock(struct k_thread *thread);
  * Needed for SMP, where the scheduler requires spinlocking that we
  * don't want to have to do in per-architecture assembly.
  */
-static inline unsigned int _Swap(unsigned int key)
+static inline int _Swap(unsigned int key)
 {
 	struct k_thread *new_thread, *old_thread;
 	int ret = 0;
@@ -90,11 +90,11 @@ static inline unsigned int _Swap(unsigned int key)
 
 #else /* !CONFIG_USE_SWITCH */
 
-extern unsigned int __swap(unsigned int key);
+extern int __swap(unsigned int key);
 
-static inline unsigned int _Swap(unsigned int key)
+static inline int _Swap(unsigned int key)
 {
-	unsigned int ret;
+	int ret;
 	_check_stack_sentinel();
 	_update_time_slice_before_swap();
 

--- a/kernel/init.c
+++ b/kernel/init.c
@@ -387,7 +387,7 @@ static void switch_to_main_thread(void)
 	 * will never be rescheduled in.
 	 */
 
-	_Swap(irq_lock());
+	(void)_Swap(irq_lock());
 #endif
 }
 #endif /* CONFIG_MULTITHREDING */

--- a/kernel/init.c
+++ b/kernel/init.c
@@ -158,15 +158,15 @@ void k_call_stacks_analyze(void) { }
  */
 void _bss_zero(void)
 {
-	memset(&__bss_start, 0,
-		 ((u32_t) &__bss_end - (u32_t) &__bss_start));
+	(void)memset(&__bss_start, 0,
+		     ((u32_t) &__bss_end - (u32_t) &__bss_start));
 #ifdef CONFIG_CCM_BASE_ADDRESS
-	memset(&__ccm_bss_start, 0,
-		((u32_t) &__ccm_bss_end - (u32_t) &__ccm_bss_start));
+	(void)memset(&__ccm_bss_start, 0,
+		     ((u32_t) &__ccm_bss_end - (u32_t) &__ccm_bss_start));
 #endif
 #ifdef CONFIG_APPLICATION_MEMORY
-	memset(&__app_bss_start, 0,
-		 ((u32_t) &__app_bss_end - (u32_t) &__app_bss_start));
+	(void)memset(&__app_bss_start, 0,
+		     ((u32_t) &__app_bss_end - (u32_t) &__app_bss_start));
 #endif
 }
 
@@ -458,7 +458,7 @@ FUNC_NORETURN void _Cstart(void)
 	char dummy_thread_memory[sizeof(struct k_thread)];
 	struct k_thread *dummy_thread = (struct k_thread *)&dummy_thread_memory;
 
-	memset(dummy_thread_memory, 0, sizeof(dummy_thread_memory));
+	(void)memset(dummy_thread_memory, 0, sizeof(dummy_thread_memory));
 #endif
 #endif
 	/*

--- a/kernel/mailbox.c
+++ b/kernel/mailbox.c
@@ -35,7 +35,7 @@ K_STACK_DEFINE(async_msg_free, CONFIG_NUM_MBOX_ASYNC_MSGS);
 /* allocate an asynchronous message descriptor */
 static inline void mbox_async_alloc(struct k_mbox_async **async)
 {
-	k_stack_pop(&async_msg_free, (u32_t *)async, K_FOREVER);
+	(void)k_stack_pop(&async_msg_free, (u32_t *)async, K_FOREVER);
 }
 
 /* free an asynchronous message descriptor */
@@ -332,7 +332,7 @@ void k_mbox_async_put(struct k_mbox *mbox, struct k_mbox_msg *tx_msg,
 	async->tx_msg._syncing_thread = (struct k_thread *)&async->thread;
 	async->tx_msg._async_sem = sem;
 
-	mbox_message_put(mbox, &async->tx_msg, K_FOREVER);
+	(void)mbox_message_put(mbox, &async->tx_msg, K_FOREVER);
 }
 #endif
 

--- a/kernel/mem_domain.c
+++ b/kernel/mem_domain.c
@@ -80,7 +80,7 @@ void k_mem_domain_init(struct k_mem_domain *domain, u8_t num_parts,
 	key = irq_lock();
 
 	domain->num_partitions = num_parts;
-	memset(domain->partitions, 0, sizeof(domain->partitions));
+	(void)memset(domain->partitions, 0, sizeof(domain->partitions));
 
 	if (num_parts) {
 		u32_t i;

--- a/kernel/mempool.c
+++ b/kernel/mempool.c
@@ -91,7 +91,7 @@ int k_mem_pool_alloc(struct k_mem_pool *p, struct k_mem_block *block,
 			return ret;
 		}
 
-		_pend_current_thread(irq_lock(), &p->wait_q, timeout);
+		(void)_pend_current_thread(irq_lock(), &p->wait_q, timeout);
 
 		if (timeout != K_FOREVER) {
 			timeout = end - _tick_get();

--- a/kernel/mempool.c
+++ b/kernel/mempool.c
@@ -193,7 +193,7 @@ void *k_calloc(size_t nmemb, size_t size)
 
 	ret = k_malloc(bounds);
 	if (ret) {
-		memset(ret, 0, bounds);
+		(void)memset(ret, 0, bounds);
 	}
 	return ret;
 }

--- a/kernel/pipes.c
+++ b/kernel/pipes.c
@@ -54,7 +54,7 @@ K_STACK_DEFINE(pipe_async_msgs, CONFIG_NUM_PIPE_ASYNC_MSGS);
 /* Allocate an asynchronous message descriptor */
 static void pipe_async_alloc(struct k_pipe_async **async)
 {
-	k_stack_pop(&pipe_async_msgs, (u32_t *)async, K_FOREVER);
+	(void)k_stack_pop(&pipe_async_msgs, (u32_t *)async, K_FOREVER);
 }
 
 /* Free an asynchronous message descriptor */

--- a/kernel/pipes.c
+++ b/kernel/pipes.c
@@ -565,7 +565,7 @@ int _k_pipe_put_internal(struct k_pipe *pipe, struct k_pipe_async *async_desc,
 		 */
 		key = irq_lock();
 		_sched_unlock_no_reschedule();
-		_pend_current_thread(key, &pipe->wait_q.writers, timeout);
+		(void)_pend_current_thread(key, &pipe->wait_q.writers, timeout);
 	} else {
 		k_sched_unlock();
 	}
@@ -707,7 +707,7 @@ int _impl_k_pipe_get(struct k_pipe *pipe, void *data, size_t bytes_to_read,
 		_current->base.swap_data = &pipe_desc;
 		key = irq_lock();
 		_sched_unlock_no_reschedule();
-		_pend_current_thread(key, &pipe->wait_q.readers, timeout);
+		(void)_pend_current_thread(key, &pipe->wait_q.readers, timeout);
 	} else {
 		k_sched_unlock();
 	}

--- a/kernel/sched.c
+++ b/kernel/sched.c
@@ -334,7 +334,7 @@ struct k_thread *_unpend_first_thread(_wait_q_t *wait_q)
 	struct k_thread *t = _unpend1_no_timeout(wait_q);
 
 	if (t) {
-		_abort_thread_timeout(t);
+		(void)_abort_thread_timeout(t);
 	}
 
 	return t;
@@ -343,7 +343,7 @@ struct k_thread *_unpend_first_thread(_wait_q_t *wait_q)
 void _unpend_thread(struct k_thread *thread)
 {
 	_unpend_thread_no_timeout(thread);
-	_abort_thread_timeout(thread);
+	(void)_abort_thread_timeout(thread);
 }
 
 /* FIXME: this API is glitchy when used in SMP.  If the thread is

--- a/kernel/sched.c
+++ b/kernel/sched.c
@@ -376,7 +376,7 @@ void _thread_priority_set(struct k_thread *thread, int prio)
 	}
 }
 
-int _reschedule(int key)
+void _reschedule(int key)
 {
 #ifdef CONFIG_SMP
 	if (!_current_cpu->swap_ok) {
@@ -394,13 +394,13 @@ int _reschedule(int key)
 	return _Swap(key);
 #else
 	if (_get_next_ready_thread() != _current) {
-		return _Swap(key);
+		(void)_Swap(key);
+		return;
 	}
 #endif
 
  noswap:
 	irq_unlock(key);
-	return 0;
 }
 
 void k_sched_lock(void)

--- a/kernel/sched.c
+++ b/kernel/sched.c
@@ -789,10 +789,10 @@ void _impl_k_yield(void)
 	}
 
 #ifdef CONFIG_SMP
-	_Swap(irq_lock());
+	(void)_Swap(irq_lock());
 #else
 	if (_get_next_ready_thread() != _current) {
-		_Swap(irq_lock());
+		(void)_Swap(irq_lock());
 	}
 #endif
 }
@@ -827,7 +827,7 @@ void _impl_k_sleep(s32_t duration)
 	_remove_thread_from_ready_q(_current);
 	_add_thread_timeout(_current, NULL, ticks);
 
-	_Swap(key);
+	(void)_Swap(key);
 #endif
 }
 

--- a/kernel/smp.c
+++ b/kernel/smp.c
@@ -86,7 +86,7 @@ static void smp_init_top(int key, void *arg)
 	_arch_curr_cpu()->current = &dummy_thread;
 	unsigned int k = irq_lock();
 	smp_timer_init();
-	_Swap(k);
+	(void)_Swap(k);
 
 	CODE_UNREACHABLE;
 }

--- a/kernel/smp.c
+++ b/kernel/smp.c
@@ -96,7 +96,7 @@ void smp_init(void)
 {
 	atomic_t start_flag;
 
-	atomic_clear(&start_flag);
+	(void)atomic_clear(&start_flag);
 
 #if defined(CONFIG_SMP) && CONFIG_MP_NUM_CPUS > 1
 	_arch_start_cpu(1, _interrupt_stack1, CONFIG_ISR_STACK_SIZE,
@@ -113,5 +113,5 @@ void smp_init(void)
 			smp_init_top, &start_flag);
 #endif
 
-	atomic_set(&start_flag, 1);
+	(void)atomic_set(&start_flag, 1);
 }

--- a/kernel/thread.c
+++ b/kernel/thread.c
@@ -510,7 +510,7 @@ void _impl_k_thread_suspend(struct k_thread *thread)
 	sys_trace_thread_suspend(thread);
 
 	if (thread == _current) {
-		_Swap(key);
+		(void)_Swap(key);
 	} else {
 		irq_unlock(key);
 	}

--- a/kernel/thread.c
+++ b/kernel/thread.c
@@ -479,7 +479,7 @@ int _impl_k_thread_cancel(k_tid_t tid)
 		return -EINVAL;
 	}
 
-	_abort_thread_timeout(thread);
+	(void)_abort_thread_timeout(thread);
 	_thread_monitor_exit(thread);
 
 	irq_unlock(key);
@@ -553,7 +553,7 @@ void _k_thread_single_abort(struct k_thread *thread)
 			_unpend_thread_no_timeout(thread);
 		}
 		if (_is_thread_timeout_active(thread)) {
-			_abort_thread_timeout(thread);
+			(void)_abort_thread_timeout(thread);
 		}
 	}
 

--- a/kernel/thread_abort.c
+++ b/kernel/thread_abort.c
@@ -41,7 +41,7 @@ void _impl_k_thread_abort(k_tid_t thread)
 		irq_unlock(key);
 	} else {
 		if (_current == thread) {
-			_Swap(key);
+			(void)_Swap(key);
 			CODE_UNREACHABLE;
 		}
 

--- a/kernel/timer.c
+++ b/kernel/timer.c
@@ -206,7 +206,7 @@ u32_t _impl_k_timer_status_sync(struct k_timer *timer)
 	if (result == 0) {
 		if (timer->timeout.delta_ticks_from_prev != _INACTIVE) {
 			/* wait for timer to expire or stop */
-			_pend_current_thread(key, &timer->wait_q, K_FOREVER);
+			(void)_pend_current_thread(key, &timer->wait_q, K_FOREVER);
 
 			/* get updated timer status */
 			key = irq_lock();

--- a/kernel/timer.c
+++ b/kernel/timer.c
@@ -122,10 +122,7 @@ void _impl_k_timer_start(struct k_timer *timer, s32_t duration, s32_t period)
 
 	unsigned int key = irq_lock();
 
-	if (timer->timeout.delta_ticks_from_prev != _INACTIVE) {
-		_abort_timeout(&timer->timeout);
-	}
-
+	(void)_abort_timeout(&timer->timeout);
 	timer->period = period_in_ticks;
 	timer->status = 0;
 	_add_timeout(NULL, &timer->timeout, &timer->wait_q, duration_in_ticks);

--- a/kernel/userspace.c
+++ b/kernel/userspace.c
@@ -228,7 +228,7 @@ void *_impl_k_object_alloc(enum k_objects otype)
 	dyn_obj->kobj.name = (char *)&dyn_obj->data;
 	dyn_obj->kobj.type = otype;
 	dyn_obj->kobj.flags = K_OBJ_FLAG_ALLOC;
-	memset(dyn_obj->kobj.perms, 0, CONFIG_MAX_THREAD_BYTES);
+	(void)memset(dyn_obj->kobj.perms, 0, CONFIG_MAX_THREAD_BYTES);
 
 	/* Need to grab a new thread index for k_thread */
 	if (otype == K_OBJ_THREAD) {
@@ -570,7 +570,7 @@ void _k_object_recycle(void *object)
 	struct _k_object *ko = _k_object_find(object);
 
 	if (ko) {
-		memset(ko->perms, 0, sizeof(ko->perms));
+		(void)memset(ko->perms, 0, sizeof(ko->perms));
 		_thread_perms_set(ko, k_current_get());
 		ko->flags |= K_OBJ_FLAG_INITIALIZED;
 	}

--- a/kernel/work_q.c
+++ b/kernel/work_q.c
@@ -50,7 +50,7 @@ void k_work_q_start(struct k_work_q *work_q, k_thread_stack_t *stack,
 		    size_t stack_size, int prio)
 {
 	k_queue_init(&work_q->queue);
-	k_thread_create(&work_q->thread, stack, stack_size, work_q_main,
+	(void)k_thread_create(&work_q->thread, stack, stack_size, work_q_main,
 			work_q, 0, 0, prio, 0, 0);
 	_k_object_init(work_q);
 }

--- a/kernel/work_q.c
+++ b/kernel/work_q.c
@@ -131,7 +131,7 @@ int k_delayed_work_cancel(struct k_delayed_work *work)
 			return -EINVAL;
 		}
 	} else {
-		_abort_timeout(&work->timeout);
+		(void)_abort_timeout(&work->timeout);
 	}
 
 	/* Detach from workqueue */

--- a/lib/cmsis_rtos_v1/cmsis_mailq.c
+++ b/lib/cmsis_rtos_v1/cmsis_mailq.c
@@ -86,7 +86,7 @@ void *osMailCAlloc(osMailQId queue_id, uint32_t millisec)
 	}
 
 	if (retval == 0) {
-		memset(ptr, 0, queue_def->item_sz);
+		(void)memset(ptr, 0, queue_def->item_sz);
 		return ptr;
 	} else {
 		return NULL;
@@ -109,7 +109,7 @@ osStatus osMailPut(osMailQId queue_id, void *mail)
 		return osErrorValue;
 	}
 
-	memset(&mmsg, 0, sizeof(mmsg));
+	(void)memset(&mmsg, 0, sizeof(mmsg));
 	mmsg.tx_data = mail;
 	mmsg.rx_source_thread = K_ANY;
 	mmsg.tx_target_thread = K_ANY;
@@ -133,7 +133,7 @@ osEvent osMailGet(osMailQId queue_id, uint32_t millisec)
 		return evt;
 	}
 
-	memset(&mmsg, 0, sizeof(mmsg));
+	(void)memset(&mmsg, 0, sizeof(mmsg));
 	mmsg.rx_source_thread = K_ANY;
 	mmsg.tx_target_thread = K_ANY;
 

--- a/lib/cmsis_rtos_v1/cmsis_mempool.c
+++ b/lib/cmsis_rtos_v1/cmsis_mempool.c
@@ -47,7 +47,7 @@ void *osPoolCAlloc(osPoolId pool_id)
 
 	if (k_mem_slab_alloc((struct k_mem_slab *)(osPool->pool),
 				&ptr, TIME_OUT) == 0) {
-		memset(ptr, 0, osPool->item_sz);
+		(void)memset(ptr, 0, osPool->item_sz);
 		return ptr;
 	} else {
 		return NULL;

--- a/lib/cmsis_rtos_v1/cmsis_mutex.c
+++ b/lib/cmsis_rtos_v1/cmsis_mutex.c
@@ -26,7 +26,7 @@ osMutexId osMutexCreate(const osMutexDef_t *mutex_def)
 	}
 
 	if (k_mem_slab_alloc(&cmsis_mutex_slab, (void **)&mutex, 100) == 0) {
-		memset(mutex, 0, sizeof(struct k_mutex));
+		(void)memset(mutex, 0, sizeof(struct k_mutex));
 	} else {
 		return NULL;
 	}

--- a/lib/cmsis_rtos_v1/cmsis_semaphore.c
+++ b/lib/cmsis_rtos_v1/cmsis_semaphore.c
@@ -28,7 +28,7 @@ osSemaphoreId osSemaphoreCreate(const osSemaphoreDef_t *semaphore_def,
 
 	if (k_mem_slab_alloc(&cmsis_semaphore_slab,
 				(void **)&semaphore, 100) == 0) {
-		memset(semaphore, 0, sizeof(struct k_sem));
+		(void)memset(semaphore, 0, sizeof(struct k_sem));
 	} else {
 		return NULL;
 	}

--- a/lib/cmsis_rtos_v1/cmsis_timer.c
+++ b/lib/cmsis_rtos_v1/cmsis_timer.c
@@ -48,7 +48,7 @@ osTimerId osTimerCreate(const osTimerDef_t *timer_def, os_timer_type type,
 	}
 
 	if (k_mem_slab_alloc(&cmsis_timer_slab, (void **)&timer, 100) == 0) {
-		memset(timer, 0, sizeof(struct timer_obj));
+		(void)memset(timer, 0, sizeof(struct timer_obj));
 	} else {
 		return NULL;
 	}

--- a/lib/libc/minimal/source/stdlib/malloc.c
+++ b/lib/libc/minimal/source/stdlib/malloc.c
@@ -83,7 +83,7 @@ void *calloc(size_t nmemb, size_t size)
 	ret = malloc(size);
 
 	if (ret) {
-		memset(ret, 0, size);
+		(void)memset(ret, 0, size);
 	}
 
 	return ret;

--- a/lib/posix/fs.c
+++ b/lib/posix/fs.c
@@ -106,7 +106,7 @@ int open(const char *name, int flags)
 		errno = ENFILE;
 		return -1;
 	}
-	memset(ptr, 0, sizeof(struct fs_file_t));
+	(void)memset(ptr, 0, sizeof(struct fs_file_t));
 
 	rc = fs_open(ptr, name);
 	if (rc < 0) {
@@ -233,7 +233,7 @@ DIR *opendir(const char *dirname)
 		errno = EMFILE;
 		return NULL;
 	}
-	memset(ptr, 0, sizeof(struct fs_dir_t));
+	(void)memset(ptr, 0, sizeof(struct fs_dir_t));
 
 	rc = fs_opendir(ptr, dirname);
 	if (rc < 0) {

--- a/lib/posix/mqueue.c
+++ b/lib/posix/mqueue.c
@@ -97,7 +97,7 @@ mqd_t mq_open(const char *name, int oflags, ...)
 
 	mq_desc_ptr = k_malloc(sizeof(struct mqueue_desc));
 	if (mq_desc_ptr != NULL) {
-		memset(mq_desc_ptr, 0, sizeof(struct mqueue_desc));
+		(void)memset(mq_desc_ptr, 0, sizeof(struct mqueue_desc));
 		msg_queue_desc = (struct mqueue_desc *)mq_desc_ptr;
 		msg_queue_desc->mem_desc = mq_desc_ptr;
 	} else {
@@ -116,7 +116,7 @@ mqd_t mq_open(const char *name, int oflags, ...)
 
 		mq_obj_ptr = k_malloc(sizeof(mqueue_object));
 		if (mq_obj_ptr != NULL) {
-			memset(mq_obj_ptr, 0, sizeof(mqueue_object));
+			(void)memset(mq_obj_ptr, 0, sizeof(mqueue_object));
 			msg_queue = (mqueue_object *)mq_obj_ptr;
 			msg_queue->mem_obj = mq_obj_ptr;
 
@@ -126,7 +126,7 @@ mqd_t mq_open(const char *name, int oflags, ...)
 
 		mq_name_ptr = k_malloc(strlen(name) + 1);
 		if (mq_name_ptr != NULL) {
-			memset(mq_name_ptr, 0, strlen(name) + 1);
+			(void)memset(mq_name_ptr, 0, strlen(name) + 1);
 			msg_queue->name = mq_name_ptr;
 
 		} else {
@@ -137,8 +137,8 @@ mqd_t mq_open(const char *name, int oflags, ...)
 
 		mq_buf_ptr = k_malloc(msg_size * max_msgs * sizeof(u8_t));
 		if (mq_buf_ptr != NULL) {
-			memset(mq_buf_ptr, 0,
-			       msg_size * max_msgs * sizeof(u8_t));
+			(void)memset(mq_buf_ptr, 0,
+				     msg_size * max_msgs * sizeof(u8_t));
 			msg_queue->mem_buffer = mq_buf_ptr;
 		} else {
 			goto free_mq_buffer;

--- a/lib/posix/pthread_barrier.c
+++ b/lib/posix/pthread_barrier.c
@@ -11,6 +11,9 @@
 
 int pthread_barrier_wait(pthread_barrier_t *b)
 {
+	/* FIXME: This function should return PTHREAD_BARRIER_SERIAL_THREAD
+	 * for an arbitrary thread and 0 for the others.
+	 */
 	int key = irq_lock();
 
 	b->count++;
@@ -21,7 +24,8 @@ int pthread_barrier_wait(pthread_barrier_t *b)
 		while (_waitq_head(&b->wait_q)) {
 			_ready_one_thread(&b->wait_q);
 		}
-		return _reschedule(key);
+		_reschedule(key);
+		return 0;
 	} else {
 		return _pend_current_thread(key, &b->wait_q, K_FOREVER);
 	}

--- a/lib/posix/pthread_mutex.c
+++ b/lib/posix/pthread_mutex.c
@@ -141,7 +141,8 @@ int pthread_mutex_unlock(pthread_mutex_t *m)
 			m->lock_count++;
 			_ready_thread(thread);
 			_set_thread_return_value(thread, 0);
-			return _reschedule(key);
+			_reschedule(key);
+			return 0;
 		}
 		m->owner = NULL;
 

--- a/lib/posix/timer.c
+++ b/lib/posix/timer.c
@@ -59,7 +59,7 @@ int timer_create(clockid_t clockid, struct sigevent *evp, timer_t *timerid)
 	}
 
 	if (k_mem_slab_alloc(&posix_timer_slab, (void **)&timer, 100) == 0) {
-		memset(timer, 0, sizeof(struct timer_obj));
+		(void)memset(timer, 0, sizeof(struct timer_obj));
 	} else {
 		errno = ENOMEM;
 		return -1;

--- a/misc/printk.c
+++ b/misc/printk.c
@@ -266,7 +266,7 @@ static int char_out(int c, void *ctx_p)
 }
 
 #ifdef CONFIG_USERSPACE
-int vprintk(const char *fmt, va_list ap)
+void vprintk(const char *fmt, va_list ap)
 {
 	if (_is_user_context()) {
 		struct buf_out_context ctx = { 0 };
@@ -276,23 +276,18 @@ int vprintk(const char *fmt, va_list ap)
 		if (ctx.buf_count) {
 			buf_flush(&ctx);
 		}
-		return ctx.count;
 	} else {
 		struct out_context ctx = { 0 };
 
 		_vprintk(char_out, &ctx, fmt, ap);
-
-		return ctx.count;
 	}
 }
 #else
-int vprintk(const char *fmt, va_list ap)
+void vprintk(const char *fmt, va_list ap)
 {
 	struct out_context ctx = { 0 };
 
 	_vprintk(char_out, &ctx, fmt, ap);
-
-	return ctx.count;
 }
 #endif
 
@@ -331,23 +326,20 @@ Z_SYSCALL_HANDLER(k_str_out, c, n)
  *
  * @param fmt formatted string to output
  *
- * @return Number of characters printed
+ * @return N/A
  */
-int printk(const char *fmt, ...)
+void printk(const char *fmt, ...)
 {
-	int ret;
 	va_list ap;
 
 	va_start(ap, fmt);
 
 	if (IS_ENABLED(CONFIG_LOG_PRINTK)) {
-		ret = log_printk(fmt, ap);
+		log_printk(fmt, ap);
 	} else {
-		ret = vprintk(fmt, ap);
+		vprintk(fmt, ap);
 	}
 	va_end(ap);
-
-	return ret;
 }
 
 /**

--- a/misc/stats.c
+++ b/misc/stats.c
@@ -281,5 +281,5 @@ stats_init_and_reg(struct stats_hdr *shdr, u8_t size, u8_t cnt,
 void
 stats_reset(struct stats_hdr *hdr)
 {
-	memset(hdr + 1, 0, hdr->s_size * hdr->s_cnt);
+	(void)memset(hdr + 1, 0, hdr->s_size * hdr->s_cnt);
 }

--- a/samples/bluetooth/central_hr/src/main.c
+++ b/samples/bluetooth/central_hr/src/main.c
@@ -48,7 +48,7 @@ static u8_t discover_func(struct bt_conn *conn,
 
 	if (!attr) {
 		printk("Discover complete\n");
-		memset(params, 0, sizeof(*params));
+		(void)memset(params, 0, sizeof(*params));
 		return BT_GATT_ITER_STOP;
 	}
 

--- a/samples/bluetooth/hci_spi/src/main.c
+++ b/samples/bluetooth/hci_spi/src/main.c
@@ -182,7 +182,7 @@ static void bt_tx_thread(void *p1, void *p2, void *p3)
 	ARG_UNUSED(p2);
 	ARG_UNUSED(p3);
 
-	memset(txmsg, 0xFF, SPI_MAX_MSG_LEN);
+	(void)memset(txmsg, 0xFF, SPI_MAX_MSG_LEN);
 
 	while (1) {
 		tx.buf = header_slave;

--- a/samples/boards/arduino_101/environmental_sensing/sensor/src/main.c
+++ b/samples/boards/arduino_101/environmental_sensing/sensor/src/main.c
@@ -99,7 +99,7 @@ void main(void)
 		char row[16];
 
 		/* clear LCD */
-		memset(row, ' ', sizeof(row));
+		(void)memset(row, ' ', sizeof(row));
 		glcd_cursor_pos_set(glcd, 0, 0);
 		glcd_print(glcd, row, sizeof(row));
 		glcd_cursor_pos_set(glcd, 0, 1);

--- a/samples/boards/microbit/pong/src/ble.c
+++ b/samples/boards/microbit/pong/src/ble.c
@@ -171,7 +171,7 @@ static u8_t discover_func(struct bt_conn *conn,
 
 	if (!attr) {
 		printk("Discover complete\n");
-		memset(&discov_param, 0, sizeof(discov_param));
+		(void)memset(&discov_param, 0, sizeof(discov_param));
 		return BT_GATT_ITER_STOP;
 	}
 

--- a/samples/boards/olimex_stm32_e407/ccm/src/main.c
+++ b/samples/boards/olimex_stm32_e407/ccm/src/main.c
@@ -136,9 +136,9 @@ void main(void)
 	ccm_data_var_16 = ~CCM_DATA_VAR_16_VAL;
 	ccm_data_var_32 = ~CCM_DATA_VAR_32_VAL;
 
-	memset(ccm_data_array, 0xAA, sizeof(ccm_data_array));
-	memset(ccm_bss_array, 0xBB, sizeof(ccm_bss_array));
-	memset(ccm_noinit_array, 0xCC, sizeof(ccm_noinit_array));
+	(void)memset(ccm_data_array, 0xAA, sizeof(ccm_data_array));
+	(void)memset(ccm_bss_array, 0xBB, sizeof(ccm_bss_array));
+	(void)memset(ccm_noinit_array, 0xCC, sizeof(ccm_noinit_array));
 
 	printf("\nVariable values after writing:\n");
 	print_var_values();

--- a/samples/display/ili9340/src/main.c
+++ b/samples/display/ili9340/src/main.c
@@ -63,7 +63,7 @@ void main(void)
 
 	/* Clear ili9340 frame buffer before enabling LCD, reuse corner buffer
 	 */
-	memset(buf, 0, buf_size);
+	(void)memset(buf, 0, buf_size);
 	h_step = (w * h) / SCREEN_WIDTH;
 
 	for (int idx = 0; idx < SCREEN_HEIGHT; idx += h_step) {
@@ -76,7 +76,7 @@ void main(void)
 		/* Update the color of the rectangle buffer and write the buffer
 		 * to  one of the corners
 		 */
-		memset(buf, 0, buf_size);
+		(void)memset(buf, 0, buf_size);
 		for (size_t idx = color; idx < buf_size; idx += 3) {
 			*(buf + idx) = 255;
 		}

--- a/samples/net/coap_server/src/coap-server.c
+++ b/samples/net/coap_server/src/coap-server.c
@@ -737,7 +737,7 @@ static int large_get(struct coap_resource *resource,
 	size = min(coap_block_size_to_bytes(ctx.block_size),
 		   ctx.total_size - ctx.current);
 
-	memset(payload, 'A', min(size, sizeof(payload)));
+	(void)memset(payload, 'A', min(size, sizeof(payload)));
 
 	r = coap_packet_append_payload(&response, (u8_t *)payload, size);
 	if (r < 0) {
@@ -748,7 +748,7 @@ static int large_get(struct coap_resource *resource,
 	r = coap_next_block(&response, &ctx);
 	if (!r) {
 		/* Will return 0 when it's the last block. */
-		memset(&ctx, 0, sizeof(ctx));
+		(void)memset(&ctx, 0, sizeof(ctx));
 	}
 
 	return net_context_sendto(pkt, (const struct sockaddr *)&from,

--- a/samples/net/gptp/src/main.c
+++ b/samples/net/gptp/src/main.c
@@ -98,7 +98,7 @@ static int init_vlan(void)
 	struct ud ud;
 	int ret;
 
-	memset(&ud, 0, sizeof(ud));
+	(void)memset(&ud, 0, sizeof(ud));
 
 	net_if_foreach(iface_cb, &ud);
 

--- a/samples/net/http_server/src/main.c
+++ b/samples/net/http_server/src/main.c
@@ -405,7 +405,7 @@ void main(void)
 
 #elif ADDR_OPTION == 2
 	/* Accept any local listening address */
-	memset(&addr, 0, sizeof(addr));
+	(void)memset(&addr, 0, sizeof(addr));
 
 	net_sin(&addr)->sin_port = htons(ZEPHYR_PORT);
 
@@ -416,7 +416,7 @@ void main(void)
 
 #elif ADDR_OPTION == 3
 	/* Set the bind address according to your configuration */
-	memset(&addr, 0, sizeof(addr));
+	(void)memset(&addr, 0, sizeof(addr));
 
 	/* In this example, listen only IPv6 */
 	addr.family = AF_INET6;

--- a/samples/net/lldp/src/main.c
+++ b/samples/net/lldp/src/main.c
@@ -97,7 +97,7 @@ static int init_vlan(void)
 {
 	int ret;
 
-	memset(&ud, 0, sizeof(ud));
+	(void)memset(&ud, 0, sizeof(ud));
 
 	net_if_foreach(iface_cb, &ud);
 

--- a/samples/net/lwm2m_client/src/lwm2m-client.c
+++ b/samples/net/lwm2m_client/src/lwm2m-client.c
@@ -358,7 +358,7 @@ void main(void)
 		return;
 	}
 
-	memset(&client, 0x0, sizeof(client));
+	(void)memset(&client, 0x0, sizeof(client));
 	client.net_init_timeout = WAIT_TIME;
 	client.net_timeout = CONNECT_TIME;
 #if defined(CONFIG_NET_CONTEXT_NET_PKT_POOL)

--- a/samples/net/mqtt_publisher/src/main.c
+++ b/samples/net/mqtt_publisher/src/main.c
@@ -297,7 +297,7 @@ static void publisher(void)
 	int i, rc;
 
 	/* Set everything to 0 and later just assign the required fields. */
-	memset(&client_ctx, 0x00, sizeof(client_ctx));
+	(void)memset(&client_ctx, 0x00, sizeof(client_ctx));
 
 	/* connect, disconnect and malformed may be set to NULL */
 	client_ctx.mqtt_ctx.connect = connect_cb;

--- a/samples/net/rpl-mesh-qemu/root/src/main.c
+++ b/samples/net/rpl-mesh-qemu/root/src/main.c
@@ -30,7 +30,7 @@ void main(void)
 	}
 
 	/* Read prefix from KConfig and parse it */
-	memset(prefix_str, 0, sizeof(prefix_str));
+	(void)memset(prefix_str, 0, sizeof(prefix_str));
 	memcpy(prefix_str, CONFIG_NET_RPL_PREFIX,
 			min(strlen(CONFIG_NET_RPL_PREFIX), NET_IPV6_ADDR_LEN));
 

--- a/samples/net/rpl_border_router/src/http.c
+++ b/samples/net/rpl_border_router/src/http.c
@@ -280,7 +280,7 @@ static int http_basic_auth(struct http_ctx *ctx,
 		char *end, *colon;
 		int ret;
 
-		memset(output, 0, sizeof(output));
+		(void)memset(output, 0, sizeof(output));
 
 		end = strstr(ptr + 2, HTTP_CRLF);
 		if (!end) {
@@ -1926,7 +1926,7 @@ void start_http_server(struct net_if *iface)
 
 #elif ADDR_OPTION == 2
 	/* Accept any local listening address */
-	memset(&addr, 0, sizeof(addr));
+	(void)memset(&addr, 0, sizeof(addr));
 
 	net_sin(&addr)->sin_port = htons(ZEPHYR_PORT);
 
@@ -1937,7 +1937,7 @@ void start_http_server(struct net_if *iface)
 
 #elif ADDR_OPTION == 3
 	/* Set the bind address according to your configuration */
-	memset(&addr, 0, sizeof(addr));
+	(void)memset(&addr, 0, sizeof(addr));
 
 	/* In this example, listen only IPv6 */
 	addr.sa_family = AF_INET6;

--- a/samples/net/rpl_border_router/src/rpl.c
+++ b/samples/net/rpl_border_router/src/rpl.c
@@ -71,7 +71,7 @@ bool setup_rpl(struct net_if *iface, const char *addr_prefix)
 	/* As the addr_prefix is Kconfig option we need to copy it to temporary
 	 * buffer in order to be able to manipulate it.
 	 */
-	memset(prefix, 0, sizeof(prefix));
+	(void)memset(prefix, 0, sizeof(prefix));
 	memcpy(prefix, addr_prefix, min(strlen(addr_prefix),
 					NET_IPV6_ADDR_LEN));
 

--- a/samples/net/sockets/echo_server/src/tcp.c
+++ b/samples/net/sockets/echo_server/src/tcp.c
@@ -181,7 +181,7 @@ static void process_tcp4(void)
 	int ret;
 	struct sockaddr_in addr4;
 
-	memset(&addr4, 0, sizeof(addr4));
+	(void)memset(&addr4, 0, sizeof(addr4));
 	addr4.sin_family = AF_INET;
 	addr4.sin_port = htons(MY_PORT);
 
@@ -205,7 +205,7 @@ static void process_tcp6(void)
 	int ret;
 	struct sockaddr_in6 addr6;
 
-	memset(&addr6, 0, sizeof(addr6));
+	(void)memset(&addr6, 0, sizeof(addr6));
 	addr6.sin6_family = AF_INET6;
 	addr6.sin6_port = htons(MY_PORT);
 

--- a/samples/net/sockets/echo_server/src/udp.c
+++ b/samples/net/sockets/echo_server/src/udp.c
@@ -134,7 +134,7 @@ static void process_udp4(void)
 	int ret;
 	struct sockaddr_in addr4;
 
-	memset(&addr4, 0, sizeof(addr4));
+	(void)memset(&addr4, 0, sizeof(addr4));
 	addr4.sin_family = AF_INET;
 	addr4.sin_port = htons(MY_PORT);
 
@@ -158,7 +158,7 @@ static void process_udp6(void)
 	int ret;
 	struct sockaddr_in6 addr6;
 
-	memset(&addr6, 0, sizeof(addr6));
+	(void)memset(&addr6, 0, sizeof(addr6));
 	addr6.sin6_family = AF_INET6;
 	addr6.sin6_port = htons(MY_PORT);
 

--- a/samples/net/ws_console/src/ws_console.c
+++ b/samples/net/ws_console/src/ws_console.c
@@ -401,7 +401,7 @@ void start_ws_console(void)
 
 #elif ADDR_OPTION == 2
 	/* Accept any local listening address */
-	memset(&addr, 0, sizeof(addr));
+	(void)memset(&addr, 0, sizeof(addr));
 
 	net_sin(&addr)->sin_port = htons(ZEPHYR_PORT);
 
@@ -412,7 +412,7 @@ void start_ws_console(void)
 
 #elif ADDR_OPTION == 3
 	/* Set the bind address according to your configuration */
-	memset(&addr, 0, sizeof(addr));
+	(void)memset(&addr, 0, sizeof(addr));
 
 	/* In this example, listen only IPv6 */
 	addr.sa_family = AF_INET6;

--- a/samples/net/ws_echo_server/src/ws.c
+++ b/samples/net/ws_echo_server/src/ws.c
@@ -459,7 +459,7 @@ void start_server(void)
 
 #elif ADDR_OPTION == 2
 	/* Accept any local listening address */
-	memset(&addr, 0, sizeof(addr));
+	(void)memset(&addr, 0, sizeof(addr));
 
 	net_sin(&addr)->sin_port = htons(ZEPHYR_PORT);
 
@@ -470,7 +470,7 @@ void start_server(void)
 
 #elif ADDR_OPTION == 3
 	/* Set the bind address according to your configuration */
-	memset(&addr, 0, sizeof(addr));
+	(void)memset(&addr, 0, sizeof(addr));
 
 	/* In this example, listen only IPv6 */
 	addr.sa_family = AF_INET6;

--- a/samples/net/zperf/src/zperf_tcp_uploader.c
+++ b/samples/net/zperf/src/zperf_tcp_uploader.c
@@ -42,7 +42,7 @@ void zperf_tcp_upload(struct net_context *ctx,
 	last_loop_time = start_time;
 	printk(TAG "New session started\n");
 
-	memset(sample_packet, 'z', sizeof(sample_packet));
+	(void)memset(sample_packet, 'z', sizeof(sample_packet));
 
 	do {
 		int ret = 0;

--- a/samples/net/zperf/src/zperf_udp_uploader.c
+++ b/samples/net/zperf/src/zperf_udp_uploader.c
@@ -211,7 +211,7 @@ void zperf_udp_upload(struct net_context *context,
 	last_print_time = start_time;
 	last_loop_time = start_time;
 
-	memset(sample_packet, 'z', sizeof(sample_packet));
+	(void)memset(sample_packet, 'z', sizeof(sample_packet));
 
 	do {
 		struct zperf_udp_datagram datagram;

--- a/samples/sensor/grove_temperature/src/main.c
+++ b/samples/sensor/grove_temperature/src/main.c
@@ -54,7 +54,7 @@ void main(void)
 		char row[16];
 
 		/* clear LCD */
-		memset(row, ' ', sizeof(row));
+		(void)memset(row, ' ', sizeof(row));
 		glcd_cursor_pos_set(glcd, 0, 0);
 		glcd_print(glcd, row, sizeof(row));
 		glcd_cursor_pos_set(glcd, 0, 1);

--- a/samples/sensor/th02/src/main.c
+++ b/samples/sensor/th02/src/main.c
@@ -81,7 +81,7 @@ void main(void)
 		char row[16];
 
 		/* clear LCD */
-		memset(row, ' ', sizeof(row));
+		(void)memset(row, ' ', sizeof(row));
 		glcd_cursor_pos_set(glcd, 0, 0);
 		glcd_print(glcd, row, sizeof(row));
 		glcd_cursor_pos_set(glcd, 0, 1);

--- a/samples/subsys/logging/logger/src/sample_instance.c
+++ b/samples/subsys/logging/logger/src/sample_instance.c
@@ -18,5 +18,5 @@ void sample_instance_call(struct sample_instance *inst)
 	LOG_INST_INF(inst->log, "counter_value: %d", inst->cnt++);
 	LOG_INST_HEXDUMP_WRN(inst->log, data, sizeof(data),
 					"Example of hexdump:");
-	memset(data, 0, sizeof(data));
+	(void)memset(data, 0, sizeof(data));
 }

--- a/samples/xtensa_asm2/src/main.c
+++ b/samples/xtensa_asm2/src/main.c
@@ -258,7 +258,7 @@ int test_switch(void)
 
 	printk("%s\n", __func__);
 
-	memset(stack2, 0, sizeof(stack2));
+	(void)memset(stack2, 0, sizeof(stack2));
 
 	int *sp = xtensa_init_stack(&stack2[ARRAY_SIZE(stack2)],
 				    (void *)test_switch_bounce,

--- a/scripts/coccinelle/ignore_return.cocci
+++ b/scripts/coccinelle/ignore_return.cocci
@@ -1,0 +1,11 @@
+// Copyright (c) 2017 Intel Corporation
+//
+// SPDX-License-Identifier: Apache-2.0//
+
+@@
+expression e1,e2,e3;
+@@
+
+- memset(e1,e2,e3);
++ (void)memset(e1,e2,e3);
+

--- a/scripts/gen_syscall_header.py
+++ b/scripts/gen_syscall_header.py
@@ -74,6 +74,8 @@ def gen_make_syscall(ret, argc, tabcount):
     tabs(tabcount)
     if (ret != Retval.VOID):
         sys.stdout.write("return (ret)")
+    else:
+        sys.stdout.write("return (void)")
     if (argc <= 6 and ret != Retval.U64):
         sys.stdout.write("_arch")
     sys.stdout.write("_syscall%s_invoke%d(" %

--- a/soc/xtensa/esp32/soc.c
+++ b/soc/xtensa/esp32/soc.c
@@ -39,7 +39,8 @@ void __attribute__((section(".iram1"))) __start(void)
 		: "r"(&_init_start));
 
 	/* Zero out BSS.  Clobber _bss_start to avoid memset() elision. */
-	memset(&_bss_start, 0, (&_bss_end - &_bss_start) * sizeof(_bss_start));
+	(void)memset(&_bss_start, 0,
+		     (&_bss_end - &_bss_start) * sizeof(_bss_start));
 	__asm__ __volatile__ (
 		""
 		:

--- a/subsys/app_memory/app_memdomain.c
+++ b/subsys/app_memory/app_memdomain.c
@@ -21,7 +21,7 @@ void app_bss_zero(void)
 	{
 		struct app_region *region =
 			CONTAINER_OF(node, struct app_region, lnode);
-		memset(region->bmem_start, 0, region->bmem_size);
+		(void)memset(region->bmem_start, 0, region->bmem_size);
 	}
 }
 

--- a/subsys/bluetooth/common/rpa.c
+++ b/subsys/bluetooth/common/rpa.c
@@ -36,7 +36,7 @@ static int ah(const u8_t irk[16], const u8_t r[3], u8_t out[3])
 
 	/* r' = padding || r */
 	memcpy(res, r, 3);
-	memset(res + 3, 0, 13);
+	(void)memset(res + 3, 0, 13);
 
 	err = bt_encrypt_le(irk, res, res);
 	if (err) {

--- a/subsys/bluetooth/controller/hci/hci.c
+++ b/subsys/bluetooth/controller/hci/hci.c
@@ -221,7 +221,7 @@ static void reset(struct net_buf *buf, struct net_buf **evt)
 	hci_hbuf_total = 0;
 	hci_hbuf_sent = 0;
 	hci_hbuf_acked = 0;
-	memset(hci_hbuf_pend, 0, sizeof(hci_hbuf_pend));
+	(void)memset(hci_hbuf_pend, 0, sizeof(hci_hbuf_pend));
 	conn_count = 0;
 	if (buf) {
 		atomic_set_bit(&hci_state_mask, HCI_STATE_BIT_RESET);
@@ -269,7 +269,7 @@ static void set_ctl_to_host_flow(struct net_buf *buf, struct net_buf **evt)
 
 	hci_hbuf_sent = 0;
 	hci_hbuf_acked = 0;
-	memset(hci_hbuf_pend, 0, sizeof(hci_hbuf_pend));
+	(void)memset(hci_hbuf_pend, 0, sizeof(hci_hbuf_pend));
 	hci_hbuf_total = -hci_hbuf_total;
 }
 
@@ -468,7 +468,7 @@ static void read_supported_commands(struct net_buf *buf, struct net_buf **evt)
 	rp = cmd_complete(evt, sizeof(*rp));
 
 	rp->status = 0x00;
-	memset(&rp->commands[0], 0, sizeof(rp->commands));
+	(void)memset(&rp->commands[0], 0, sizeof(rp->commands));
 
 	/* Read Remote Version Info. */
 	rp->commands[2] |= BIT(7);
@@ -611,7 +611,7 @@ static void read_local_features(struct net_buf *buf, struct net_buf **evt)
 	rp = cmd_complete(evt, sizeof(*rp));
 
 	rp->status = 0x00;
-	memset(&rp->features[0], 0x00, sizeof(rp->features));
+	(void)memset(&rp->features[0], 0x00, sizeof(rp->features));
 	/* BR/EDR not supported and LE supported */
 	rp->features[4] = (1 << 5) | (1 << 6);
 }
@@ -722,7 +722,7 @@ static void le_read_local_features(struct net_buf *buf, struct net_buf **evt)
 
 	rp->status = 0x00;
 
-	memset(&rp->features[0], 0x00, sizeof(rp->features));
+	(void)memset(&rp->features[0], 0x00, sizeof(rp->features));
 	rp->features[0] = RADIO_BLE_FEAT & 0xFF;
 	rp->features[1] = (RADIO_BLE_FEAT >> 8)  & 0xFF;
 	rp->features[2] = (RADIO_BLE_FEAT >> 16)  & 0xFF;
@@ -1765,7 +1765,7 @@ static void vs_read_supported_commands(struct net_buf *buf,
 	rp = cmd_complete(evt, sizeof(*rp));
 
 	rp->status = 0x00;
-	memset(&rp->commands[0], 0, sizeof(rp->commands));
+	(void)memset(&rp->commands[0], 0, sizeof(rp->commands));
 
 	/* Set Version Information, Supported Commands, Supported Features. */
 	rp->commands[0] |= BIT(0) | BIT(1) | BIT(2);
@@ -1785,7 +1785,7 @@ static void vs_read_supported_features(struct net_buf *buf,
 	rp = cmd_complete(evt, sizeof(*rp));
 
 	rp->status = 0x00;
-	memset(&rp->features[0], 0x00, sizeof(rp->features));
+	(void)memset(&rp->features[0], 0x00, sizeof(rp->features));
 }
 
 #if defined(CONFIG_BT_HCI_VS_EXT)
@@ -1852,7 +1852,7 @@ static void vs_read_static_addrs(struct net_buf *buf, struct net_buf **evt)
 		BT_ADDR_SET_STATIC(&addr->bdaddr);
 
 		/* Mark IR as invalid */
-		memset(addr->ir, 0x00, sizeof(addr->ir));
+		(void)memset(addr->ir, 0x00, sizeof(addr->ir));
 
 		return;
 	}
@@ -1883,7 +1883,7 @@ static void vs_read_key_hierarchy_roots(struct net_buf *buf,
 		sys_put_le32(NRF_FICR->IR[3], &rp->ir[12]);
 	} else {
 		/* Mark IR as invalid */
-		memset(rp->ir, 0x00, sizeof(rp->ir));
+		(void)memset(rp->ir, 0x00, sizeof(rp->ir));
 	}
 
 	/* Fill in ER if present */
@@ -1897,15 +1897,15 @@ static void vs_read_key_hierarchy_roots(struct net_buf *buf,
 		sys_put_le32(NRF_FICR->ER[3], &rp->er[12]);
 	} else {
 		/* Mark ER as invalid */
-		memset(rp->er, 0x00, sizeof(rp->er));
+		(void)memset(rp->er, 0x00, sizeof(rp->er));
 	}
 
 	return;
 #else
 	/* Mark IR as invalid */
-	memset(rp->ir, 0x00, sizeof(rp->ir));
+	(void)memset(rp->ir, 0x00, sizeof(rp->ir));
 	/* Mark ER as invalid */
-	memset(rp->er, 0x00, sizeof(rp->er));
+	(void)memset(rp->er, 0x00, sizeof(rp->er));
 #endif /* CONFIG_SOC_FAMILY_NRF */
 }
 
@@ -2415,7 +2415,7 @@ static void le_conn_complete(u8_t status, struct radio_le_conn_cmplt *radio_cc,
 				 sizeof(*leecc));
 
 		if (status) {
-			memset(leecc, 0x00, sizeof(*leecc));
+			(void)memset(leecc, 0x00, sizeof(*leecc));
 			leecc->status = status;
 			return;
 		}
@@ -2436,7 +2436,8 @@ static void le_conn_complete(u8_t status, struct radio_le_conn_cmplt *radio_cc,
 			memcpy(&leecc->local_rpa.val[0], &radio_cc->own_addr[0],
 			       BDADDR_SIZE);
 		} else {
-			memset(&leecc->local_rpa.val[0], 0x0, BDADDR_SIZE);
+			(void)memset(&leecc->local_rpa.val[0], 0x0,
+				     BDADDR_SIZE);
 		}
 
 		memcpy(&leecc->peer_rpa.val[0], &radio_cc->peer_rpa[0],
@@ -2453,7 +2454,7 @@ static void le_conn_complete(u8_t status, struct radio_le_conn_cmplt *radio_cc,
 	lecc = meta_evt(buf, BT_HCI_EVT_LE_CONN_COMPLETE, sizeof(*lecc));
 
 	if (status) {
-		memset(lecc, 0x00, sizeof(*lecc));
+		(void)memset(lecc, 0x00, sizeof(*lecc));
 		lecc->status = status;
 		return;
 	}
@@ -2759,7 +2760,7 @@ static void le_remote_feat_complete(u8_t status, struct pdu_data *pdu_data,
 		       &pdu_data->llctrl.feature_rsp.features[0],
 		       sizeof(sep->features));
 	} else {
-		memset(&sep->features[0], 0x00, sizeof(sep->features));
+		(void)memset(&sep->features[0], 0x00, sizeof(sep->features));
 	}
 }
 

--- a/subsys/bluetooth/controller/ll_sw/ctrl.c
+++ b/subsys/bluetooth/controller/ll_sw/ctrl.c
@@ -6222,7 +6222,8 @@ static void mayfly_adv_stop(void *param)
 	/* prepare connection complete structure */
 	pdu_data_rx = (void *)node_rx->pdu_data;
 	radio_le_conn_cmplt = (void *)pdu_data_rx->lldata;
-	memset(radio_le_conn_cmplt, 0x00, sizeof(struct radio_le_conn_cmplt));
+	(void)memset(radio_le_conn_cmplt, 0x00,
+		     sizeof(struct radio_le_conn_cmplt));
 	radio_le_conn_cmplt->status = BT_HCI_ERR_ADV_TIMEOUT;
 
 	/* enqueue connection complete structure into queue */
@@ -7176,8 +7177,9 @@ static inline void event_fex_prep(struct connection *conn)
 			!conn->role ?
 			PDU_DATA_LLCTRL_TYPE_FEATURE_REQ :
 			PDU_DATA_LLCTRL_TYPE_SLAVE_FEATURE_REQ;
-		memset(&pdu_ctrl_tx->llctrl.feature_req.features[0], 0x00,
-		       sizeof(pdu_ctrl_tx->llctrl.feature_req.features));
+		(void)memset(&pdu_ctrl_tx->llctrl.feature_req.features[0],
+			     0x00,
+			     sizeof(pdu_ctrl_tx->llctrl.feature_req.features));
 		pdu_ctrl_tx->llctrl.feature_req.features[0] =
 			conn->llcp_features & 0xFF;
 		pdu_ctrl_tx->llctrl.feature_req.features[1] =
@@ -9557,8 +9559,8 @@ static u8_t feature_rsp_send(struct connection *conn,
 	pdu_ctrl_tx->len = offsetof(struct pdu_data_llctrl, feature_rsp) +
 		sizeof(struct pdu_data_llctrl_feature_rsp);
 	pdu_ctrl_tx->llctrl.opcode = PDU_DATA_LLCTRL_TYPE_FEATURE_RSP;
-	memset(&pdu_ctrl_tx->llctrl.feature_rsp.features[0], 0x00,
-		sizeof(pdu_ctrl_tx->llctrl.feature_rsp.features));
+	(void)memset(&pdu_ctrl_tx->llctrl.feature_rsp.features[0], 0x00,
+		     sizeof(pdu_ctrl_tx->llctrl.feature_rsp.features));
 	pdu_ctrl_tx->llctrl.feature_req.features[0] =
 		conn->llcp_features & 0xFF;
 	pdu_ctrl_tx->llctrl.feature_req.features[1] =

--- a/subsys/bluetooth/controller/ll_sw/ll_filter.c
+++ b/subsys/bluetooth/controller/ll_sw/ll_filter.c
@@ -759,7 +759,7 @@ u32_t ll_rl_add(bt_addr_le_t *id_addr, const u8_t pirk[16],
 		memcpy(rl[i].local_irk, lirk, 16);
 		rl[i].local_rpa = NULL;
 	}
-	memset(rl[i].curr_rpa.val, 0x00, sizeof(rl[i].curr_rpa));
+	(void)memset(rl[i].curr_rpa.val, 0x00, sizeof(rl[i].curr_rpa));
 	rl[i].rpas_ready = 0;
 	/* Default to Network Privacy */
 	rl[i].dev = 0;

--- a/subsys/bluetooth/controller/ll_sw/ll_test.c
+++ b/subsys/bluetooth/controller/ll_sw/ll_test.c
@@ -222,11 +222,11 @@ u32_t ll_test_tx(u8_t chan, u8_t len, u8_t type, u8_t phy)
 		break;
 
 	case 0x01:
-		memset(payload, 0x0f, len);
+		(void)memset(payload, 0x0f, len);
 		break;
 
 	case 0x02:
-		memset(payload, 0x55, len);
+		(void)memset(payload, 0x55, len);
 		break;
 
 	case 0x03:
@@ -234,19 +234,19 @@ u32_t ll_test_tx(u8_t chan, u8_t len, u8_t type, u8_t phy)
 		break;
 
 	case 0x04:
-		memset(payload, 0xff, len);
+		(void)memset(payload, 0xff, len);
 		break;
 
 	case 0x05:
-		memset(payload, 0x00, len);
+		(void)memset(payload, 0x00, len);
 		break;
 
 	case 0x06:
-		memset(payload, 0xf0, len);
+		(void)memset(payload, 0xf0, len);
 		break;
 
 	case 0x07:
-		memset(payload, 0xaa, len);
+		(void)memset(payload, 0xaa, len);
 		break;
 	}
 

--- a/subsys/bluetooth/controller/util/mem.c
+++ b/subsys/bluetooth/controller/util/mem.c
@@ -25,8 +25,8 @@ void mem_init(void *mem_pool, u16_t mem_size, u16_t mem_count,
 	/* Initialize next pointers to form a free list,
 	 * next pointer is stored in the first 32-bit of each block
 	 */
-	memset(((u8_t *)mem_pool + (mem_size * (--mem_count))), 0,
-	       sizeof(mem_pool));
+	(void)memset(((u8_t *)mem_pool + (mem_size * (--mem_count))), 0,
+		     sizeof(mem_pool));
 	while (mem_count--) {
 		u32_t next;
 

--- a/subsys/bluetooth/host/a2dp.c
+++ b/subsys/bluetooth/host/a2dp.c
@@ -41,7 +41,7 @@ static struct bt_a2dp connection[CONFIG_BT_MAX_CONN];
 
 void a2d_reset(struct bt_a2dp *a2dp_conn)
 {
-	memset(a2dp_conn, 0, sizeof(struct bt_a2dp));
+	(void)memset(a2dp_conn, 0, sizeof(struct bt_a2dp));
 }
 
 struct bt_a2dp *get_new_connection(struct bt_conn *conn)

--- a/subsys/bluetooth/host/at.c
+++ b/subsys/bluetooth/host/at.c
@@ -151,7 +151,7 @@ static int get_response_string(struct at_client *at, struct net_buf *buf,
 
 static void reset_buffer(struct at_client *at)
 {
-	memset(at->buf, 0, at->buf_max_len);
+	(void)memset(at->buf, 0, at->buf_max_len);
 	at->pos = 0;
 }
 

--- a/subsys/bluetooth/host/att.c
+++ b/subsys/bluetooth/host/att.c
@@ -107,7 +107,7 @@ static void att_req_destroy(struct bt_att_req *req)
 		req->destroy(req);
 	}
 
-	memset(req, 0, sizeof(*req));
+	(void)memset(req, 0, sizeof(*req));
 }
 
 static struct bt_att *att_get(struct bt_conn *conn)
@@ -459,7 +459,7 @@ static u8_t att_find_info_rsp(struct bt_att *att, u16_t start_handle,
 	struct bt_conn *conn = att->chan.chan.conn;
 	struct find_info_data data;
 
-	memset(&data, 0, sizeof(data));
+	(void)memset(&data, 0, sizeof(data));
 
 	data.buf = bt_att_create_pdu(conn, BT_ATT_OP_FIND_INFO_RSP, 0);
 	if (!data.buf) {
@@ -579,7 +579,7 @@ static u8_t att_find_type_rsp(struct bt_att *att, u16_t start_handle,
 	struct bt_conn *conn = att->chan.chan.conn;
 	struct find_type_data data;
 
-	memset(&data, 0, sizeof(data));
+	(void)memset(&data, 0, sizeof(data));
 
 	data.buf = bt_att_create_pdu(conn, BT_ATT_OP_FIND_TYPE_RSP, 0);
 	if (!data.buf) {
@@ -793,7 +793,7 @@ static u8_t att_read_type_rsp(struct bt_att *att, struct bt_uuid *uuid,
 	struct bt_conn *conn = att->chan.chan.conn;
 	struct read_type_data data;
 
-	memset(&data, 0, sizeof(data));
+	(void)memset(&data, 0, sizeof(data));
 
 	data.buf = bt_att_create_pdu(conn, BT_ATT_OP_READ_TYPE_RSP,
 				     sizeof(*data.rsp));
@@ -916,7 +916,7 @@ static u8_t att_read_rsp(struct bt_att *att, u8_t op, u8_t rsp, u16_t handle,
 		return BT_ATT_ERR_INVALID_HANDLE;
 	}
 
-	memset(&data, 0, sizeof(data));
+	(void)memset(&data, 0, sizeof(data));
 
 	data.buf = bt_att_create_pdu(conn, rsp, 0);
 	if (!data.buf) {
@@ -982,7 +982,7 @@ static u8_t att_read_mult_req(struct bt_att *att, struct net_buf *buf)
 	struct read_data data;
 	u16_t handle;
 
-	memset(&data, 0, sizeof(data));
+	(void)memset(&data, 0, sizeof(data));
 
 	data.buf = bt_att_create_pdu(conn, BT_ATT_OP_READ_MULT_RSP, 0);
 	if (!data.buf) {
@@ -1097,7 +1097,7 @@ static u8_t att_read_group_rsp(struct bt_att *att, struct bt_uuid *uuid,
 	struct bt_conn *conn = att->chan.chan.conn;
 	struct read_group_data data;
 
-	memset(&data, 0, sizeof(data));
+	(void)memset(&data, 0, sizeof(data));
 
 	data.buf = bt_att_create_pdu(conn, BT_ATT_OP_READ_GROUP_RSP,
 				     sizeof(*data.rsp));
@@ -1224,7 +1224,7 @@ static u8_t att_write_rsp(struct bt_conn *conn, u8_t op, u8_t rsp,
 		return BT_ATT_ERR_INVALID_HANDLE;
 	}
 
-	memset(&data, 0, sizeof(data));
+	(void)memset(&data, 0, sizeof(data));
 
 	/* Only allocate buf if required to respond */
 	if (rsp) {
@@ -1340,7 +1340,7 @@ static u8_t att_prep_write_rsp(struct bt_att *att, u16_t handle, u16_t offset,
 		return BT_ATT_ERR_INVALID_HANDLE;
 	}
 
-	memset(&data, 0, sizeof(data));
+	(void)memset(&data, 0, sizeof(data));
 
 	data.conn = conn;
 	data.offset = offset;
@@ -2120,7 +2120,7 @@ static int bt_att_accept(struct bt_conn *conn, struct bt_l2cap_chan **chan)
 			continue;
 		}
 
-		memset(att, 0, sizeof(*att));
+		(void)memset(att, 0, sizeof(*att));
 		att->chan.chan.ops = &ops;
 		k_sem_init(&att->tx_sem, CONFIG_BT_ATT_TX_MAX,
 			   CONFIG_BT_ATT_TX_MAX);

--- a/subsys/bluetooth/host/conn.c
+++ b/subsys/bluetooth/host/conn.c
@@ -227,7 +227,7 @@ static struct bt_conn *conn_new(void)
 		return NULL;
 	}
 
-	memset(conn, 0, sizeof(*conn));
+	(void)memset(conn, 0, sizeof(*conn));
 
 	atomic_set(&conn->ref, 1);
 
@@ -258,7 +258,7 @@ static struct bt_conn *sco_conn_new(void)
 		return NULL;
 	}
 
-	memset(sco_conn, 0, sizeof(*sco_conn));
+	(void)memset(sco_conn, 0, sizeof(*sco_conn));
 
 	atomic_set(&sco_conn->ref, 1);
 
@@ -297,7 +297,7 @@ struct bt_conn *bt_conn_create_br(const bt_addr_t *peer,
 
 	cp = net_buf_add(buf, sizeof(*cp));
 
-	memset(cp, 0, sizeof(*cp));
+	(void)memset(cp, 0, sizeof(*cp));
 
 	memcpy(&cp->bdaddr, peer, sizeof(cp->bdaddr));
 	cp->packet_type = sys_cpu_to_le16(0xcc18); /* DM1 DH1 DM3 DH5 DM5 DH5 */
@@ -354,7 +354,7 @@ struct bt_conn *bt_conn_create_sco(const bt_addr_t *peer)
 
 	cp = net_buf_add(buf, sizeof(*cp));
 
-	memset(cp, 0, sizeof(*cp));
+	(void)memset(cp, 0, sizeof(*cp));
 
 	BT_ERR("handle : %x", sco_conn->sco.acl->handle);
 
@@ -805,7 +805,7 @@ int bt_conn_le_start_encryption(struct bt_conn *conn, u8_t rand[8],
 
 	memcpy(cp->ltk, ltk, len);
 	if (len < sizeof(cp->ltk)) {
-		memset(cp->ltk + len, 0, sizeof(cp->ltk) - len);
+		(void)memset(cp->ltk + len, 0, sizeof(cp->ltk) - len);
 	}
 
 	return bt_hci_cmd_send_sync(BT_HCI_OP_LE_START_ENCRYPTION, buf, NULL);
@@ -1997,7 +1997,7 @@ int bt_conn_le_conn_update(struct bt_conn *conn,
 	}
 
 	conn_update = net_buf_add(buf, sizeof(*conn_update));
-	memset(conn_update, 0, sizeof(*conn_update));
+	(void)memset(conn_update, 0, sizeof(*conn_update));
 	conn_update->handle = sys_cpu_to_le16(conn->handle);
 	conn_update->conn_interval_min = sys_cpu_to_le16(param->interval_min);
 	conn_update->conn_interval_max = sys_cpu_to_le16(param->interval_max);

--- a/subsys/bluetooth/host/gatt.c
+++ b/subsys/bluetooth/host/gatt.c
@@ -954,7 +954,7 @@ static void sc_restore(struct bt_gatt_ccc_cfg *cfg)
 	sc_indicate(&gatt_sc, data->start, data->end);
 
 	/* Reset config data */
-	memset(cfg->data, 0, sizeof(cfg->data));
+	(void)memset(cfg->data, 0, sizeof(cfg->data));
 }
 
 static u8_t connected_cb(const struct bt_gatt_attr *attr, void *user_data)
@@ -1041,7 +1041,7 @@ static u8_t disconnected_cb(const struct bt_gatt_attr *attr, void *user_data)
 	}
 
 	/* Reset value while disconnected */
-	memset(&ccc->value, 0, sizeof(ccc->value));
+	(void)memset(&ccc->value, 0, sizeof(ccc->value));
 	if (ccc->cfg_changed) {
 		ccc->cfg_changed(attr, ccc->value);
 	}

--- a/subsys/bluetooth/host/hci_core.c
+++ b/subsys/bluetooth/host/hci_core.c
@@ -566,7 +566,7 @@ static int hci_le_create_conn(const struct bt_conn *conn)
 	}
 
 	cp = net_buf_add(buf, sizeof(*cp));
-	memset(cp, 0, sizeof(*cp));
+	(void)memset(cp, 0, sizeof(*cp));
 
 	/* Interval == window for continuous scanning */
 	cp->scan_interval = sys_cpu_to_le16(BT_GAP_SCAN_FAST_INTERVAL);
@@ -1153,7 +1153,7 @@ static int le_conn_param_req_reply(u16_t handle,
 	}
 
 	cp = net_buf_add(buf, sizeof(*cp));
-	memset(cp, 0, sizeof(*cp));
+	(void)memset(cp, 0, sizeof(*cp));
 
 	cp->handle = sys_cpu_to_le16(handle);
 	cp->interval_min = sys_cpu_to_le16(param->interval_min);
@@ -1306,7 +1306,7 @@ static int set_flow_control(void)
 	}
 
 	hbs = net_buf_add(buf, sizeof(*hbs));
-	memset(hbs, 0, sizeof(*hbs));
+	(void)memset(hbs, 0, sizeof(*hbs));
 	hbs->acl_mtu = sys_cpu_to_le16(CONFIG_BT_L2CAP_RX_MTU +
 				       sizeof(struct bt_l2cap_hdr));
 	hbs->acl_pkts = sys_cpu_to_le16(CONFIG_BT_ACL_RX_COUNT);
@@ -1690,8 +1690,8 @@ static void link_key_notify(struct net_buf *buf)
 		break;
 	default:
 		BT_WARN("Unsupported Link Key type %u", evt->key_type);
-		memset(conn->br.link_key->val, 0,
-		       sizeof(conn->br.link_key->val));
+		(void)memset(conn->br.link_key->val, 0,
+			     sizeof(conn->br.link_key->val));
 		break;
 	}
 
@@ -2137,7 +2137,7 @@ static void inquiry_result_with_rssi(struct net_buf *buf)
 		result->rssi = evt->rssi;
 
 		/* we could reuse slot so make sure EIR is cleared */
-		memset(result->eir, 0, sizeof(result->eir));
+		(void)memset(result->eir, 0, sizeof(result->eir));
 
 		/*
 		 * Get next report iteration by moving pointer to right offset
@@ -2467,7 +2467,7 @@ static int hci_id_add(const bt_addr_le_t *addr, u8_t val[16])
 #if defined(CONFIG_BT_PRIVACY)
 	memcpy(cp->local_irk, bt_dev.irk, 16);
 #else
-	memset(cp->local_irk, 0, 16);
+	(void)memset(cp->local_irk, 0, 16);
 #endif
 
 	return bt_hci_cmd_send_sync(BT_HCI_OP_LE_ADD_DEV_TO_RL, buf, NULL);
@@ -2891,8 +2891,8 @@ static void le_ltk_request(struct net_buf *buf)
 		memcpy(cp->ltk, conn->le.keys->ltk.val,
 		       conn->le.keys->enc_size);
 		if (conn->le.keys->enc_size < sizeof(cp->ltk)) {
-			memset(cp->ltk + conn->le.keys->enc_size, 0,
-			       sizeof(cp->ltk) - conn->le.keys->enc_size);
+			(void)memset(cp->ltk + conn->le.keys->enc_size, 0,
+				     sizeof(cp->ltk) - conn->le.keys->enc_size);
 		}
 
 		bt_hci_cmd_send(BT_HCI_OP_LE_LTK_REQ_REPLY, buf);
@@ -2917,8 +2917,8 @@ static void le_ltk_request(struct net_buf *buf)
 		memcpy(cp->ltk, conn->le.keys->slave_ltk.val,
 		       conn->le.keys->enc_size);
 		if (conn->le.keys->enc_size < sizeof(cp->ltk)) {
-			memset(cp->ltk + conn->le.keys->enc_size, 0,
-			       sizeof(cp->ltk) - conn->le.keys->enc_size);
+			(void)memset(cp->ltk + conn->le.keys->enc_size, 0,
+				     sizeof(cp->ltk) - conn->le.keys->enc_size);
 		}
 
 		bt_hci_cmd_send(BT_HCI_OP_LE_LTK_REQ_REPLY, buf);
@@ -3058,7 +3058,7 @@ static int start_le_scan(u8_t scan_type, u16_t interval, u16_t window)
 	struct net_buf *buf;
 	int err;
 
-	memset(&set_param, 0, sizeof(set_param));
+	(void)memset(&set_param, 0, sizeof(set_param));
 
 	set_param.scan_type = scan_type;
 
@@ -4741,7 +4741,7 @@ static int set_ad(u16_t hci_op, const struct bt_ad *ad, size_t ad_len)
 
 	set_data = net_buf_add(buf, sizeof(*set_data));
 
-	memset(set_data, 0, sizeof(*set_data));
+	(void)memset(set_data, 0, sizeof(*set_data));
 
 	for (c = 0; c < ad_len; c++) {
 		const struct bt_data *data = ad[c].data;
@@ -5009,7 +5009,7 @@ int bt_id_delete(u8_t id)
 	}
 
 #if defined(CONFIG_BT_PRIVACY)
-	memset(bt_dev.irk[id], 0, 16);
+	(void)memset(bt_dev.irk[id], 0, 16);
 #endif
 	bt_addr_le_copy(&bt_dev.id_addr[id], BT_ADDR_LE_ANY);
 
@@ -5153,7 +5153,7 @@ int bt_le_adv_start_internal(const struct bt_le_adv_param *param,
 		}
 	}
 
-	memset(&set_param, 0, sizeof(set_param));
+	(void)memset(&set_param, 0, sizeof(set_param));
 
 	set_param.min_interval = sys_cpu_to_le16(param->interval_min);
 	set_param.max_interval = sys_cpu_to_le16(param->interval_max);
@@ -5482,7 +5482,7 @@ int bt_br_discovery_start(const struct bt_br_discovery_param *param,
 
 	atomic_set_bit(bt_dev.flags, BT_DEV_INQUIRY);
 
-	memset(results, 0, sizeof(*results) * cnt);
+	(void)memset(results, 0, sizeof(*results) * cnt);
 
 	discovery_cb = cb;
 	discovery_results = results;

--- a/subsys/bluetooth/host/hci_ecc.c
+++ b/subsys/bluetooth/host/hci_ecc.c
@@ -144,7 +144,7 @@ static void emulate_le_p256_public_key_cmd(void)
 	evt->status = status;
 
 	if (status) {
-		memset(evt->key, 0, sizeof(evt->key));
+		(void)memset(evt->key, 0, sizeof(evt->key));
 	} else {
 		/* Convert X and Y coordinates from big-endian (provided
 		 * by crypto API) to little endian HCI.
@@ -188,7 +188,7 @@ static void emulate_le_generate_dhkey(void)
 
 	if (ret == TC_CRYPTO_FAIL) {
 		evt->status = BT_HCI_ERR_UNSPECIFIED;
-		memset(evt->dhkey, 0, sizeof(evt->dhkey));
+		(void)memset(evt->dhkey, 0, sizeof(evt->dhkey));
 	} else {
 		evt->status = 0;
 		/* Convert from big-endian (provided by crypto API) to

--- a/subsys/bluetooth/host/keys.c
+++ b/subsys/bluetooth/host/keys.c
@@ -202,7 +202,7 @@ void bt_keys_clear(struct bt_keys *keys)
 		settings_save_one(key, NULL);
 	}
 
-	memset(keys, 0, sizeof(*keys));
+	(void)memset(keys, 0, sizeof(*keys));
 }
 
 static void keys_clear_id(struct bt_keys *keys, void *data)
@@ -285,7 +285,7 @@ static int keys_set(int argc, char **argv, char *val)
 	if (!val) {
 		keys = bt_keys_find(BT_KEYS_ALL, id, &addr);
 		if (keys) {
-			memset(keys, 0, sizeof(*keys));
+			(void)memset(keys, 0, sizeof(*keys));
 			BT_DBG("Cleared keys for %s", bt_addr_le_str(&addr));
 		} else {
 			BT_WARN("Unable to find deleted keys for %s",

--- a/subsys/bluetooth/host/keys_br.c
+++ b/subsys/bluetooth/host/keys_br.c
@@ -67,7 +67,7 @@ void bt_keys_link_key_clear(struct bt_keys_link_key *link_key)
 {
 	BT_DBG("%s", bt_addr_str(&link_key->addr));
 
-	memset(link_key, 0, sizeof(*link_key));
+	(void)memset(link_key, 0, sizeof(*link_key));
 }
 
 void bt_keys_link_key_clear_addr(const bt_addr_t *addr)
@@ -75,7 +75,7 @@ void bt_keys_link_key_clear_addr(const bt_addr_t *addr)
 	struct bt_keys_link_key *key;
 
 	if (!addr) {
-		memset(key_pool, 0, sizeof(key_pool));
+		(void)memset(key_pool, 0, sizeof(key_pool));
 		return;
 	}
 

--- a/subsys/bluetooth/host/l2cap.c
+++ b/subsys/bluetooth/host/l2cap.c
@@ -671,7 +671,7 @@ static void l2cap_chan_tx_init(struct bt_l2cap_le_chan *chan)
 {
 	BT_DBG("chan %p", chan);
 
-	memset(&chan->tx, 0, sizeof(chan->tx));
+	(void)memset(&chan->tx, 0, sizeof(chan->tx));
 	k_sem_init(&chan->tx.credits, 0, UINT_MAX);
 	k_fifo_init(&chan->tx_queue);
 }
@@ -752,7 +752,7 @@ static void le_conn_req(struct bt_l2cap *l2cap, u8_t ident,
 				      sizeof(*rsp));
 
 	rsp = net_buf_add(buf, sizeof(*rsp));
-	memset(rsp, 0, sizeof(*rsp));
+	(void)memset(rsp, 0, sizeof(*rsp));
 
 	/* Check if there is a server registered */
 	server = l2cap_server_lookup_psm(psm);

--- a/subsys/bluetooth/host/l2cap_br.c
+++ b/subsys/bluetooth/host/l2cap_br.c
@@ -430,7 +430,7 @@ static int l2cap_br_info_req(struct bt_l2cap_br *l2cap, u8_t ident,
 		rsp->type = sys_cpu_to_le16(BT_L2CAP_INFO_FIXED_CHAN);
 		rsp->result = sys_cpu_to_le16(BT_L2CAP_INFO_SUCCESS);
 		/* fixed channel mask protocol data is 8 octets wide */
-		memset(net_buf_add(rsp_buf, 8), 0, 8);
+		(void)memset(net_buf_add(rsp_buf, 8), 0, 8);
 		rsp->data[0] = get_fixed_channels_mask();
 
 		hdr_info->len = sys_cpu_to_le16(sizeof(*rsp) + 8);
@@ -519,7 +519,7 @@ static void l2cap_br_conf(struct bt_l2cap_chan *chan)
 	hdr->code = BT_L2CAP_CONF_REQ;
 	hdr->ident = l2cap_br_get_ident();
 	conf = net_buf_add(buf, sizeof(*conf));
-	memset(conf, 0, sizeof(*conf));
+	(void)memset(conf, 0, sizeof(*conf));
 
 	conf->dcid = sys_cpu_to_le16(BR_CHAN(chan)->tx.cid);
 	/*
@@ -1009,7 +1009,7 @@ send_rsp:
 	hdr->code = BT_L2CAP_CONF_RSP;
 	hdr->ident = ident;
 	rsp = net_buf_add(buf, sizeof(*rsp));
-	memset(rsp, 0, sizeof(*rsp));
+	(void)memset(rsp, 0, sizeof(*rsp));
 
 	rsp->result = sys_cpu_to_le16(result);
 	rsp->scid = sys_cpu_to_le16(BR_CHAN(chan)->tx.cid);

--- a/subsys/bluetooth/host/mesh/adv.c
+++ b/subsys/bluetooth/host/mesh/adv.c
@@ -221,7 +221,7 @@ struct net_buf *bt_mesh_adv_create_from_pool(struct net_buf_pool *pool,
 	adv = get_id(net_buf_id(buf));
 	BT_MESH_ADV(buf) = adv;
 
-	memset(adv, 0, sizeof(*adv));
+	(void)memset(adv, 0, sizeof(*adv));
 
 	adv->type         = type;
 	adv->xmit         = xmit;

--- a/subsys/bluetooth/host/mesh/cfg_srv.c
+++ b/subsys/bluetooth/host/mesh/cfg_srv.c
@@ -556,7 +556,7 @@ void bt_mesh_app_key_del(struct bt_mesh_app_key *key, bool store)
 	}
 
 	key->net_idx = BT_MESH_KEY_UNUSED;
-	memset(key->keys, 0, sizeof(key->keys));
+	(void)memset(key->keys, 0, sizeof(key->keys));
 }
 
 static void app_key_del(struct bt_mesh_model *model,
@@ -1020,7 +1020,7 @@ static void send_mod_pub_status(struct bt_mesh_model *cfg_mod,
 	net_buf_simple_add_le16(&msg, elem_addr);
 
 	if (status != STATUS_SUCCESS) {
-		memset(net_buf_simple_add(&msg, 7), 0, 7);
+		(void)memset(net_buf_simple_add(&msg, 7), 0, 7);
 	} else {
 		u16_t idx_cred;
 
@@ -1230,7 +1230,7 @@ static void mod_sub_list_clear(struct bt_mesh_model *mod)
 	}
 
 	/* Clear all subscriptions (0x0000 is the unassigned address) */
-	memset(mod->groups, 0, sizeof(mod->groups));
+	(void)memset(mod->groups, 0, sizeof(mod->groups));
 }
 
 static void mod_pub_va_set(struct bt_mesh_model *model,
@@ -1305,7 +1305,7 @@ send_status:
 static void mod_sub_list_clear(struct bt_mesh_model *mod)
 {
 	/* Clear all subscriptions (0x0000 is the unassigned address) */
-	memset(mod->groups, 0, sizeof(mod->groups));
+	(void)memset(mod->groups, 0, sizeof(mod->groups));
 }
 
 static void mod_pub_va_set(struct bt_mesh_model *model,
@@ -3360,7 +3360,7 @@ void bt_mesh_cfg_reset(void)
 
 	bt_mesh_model_foreach(mod_reset, NULL);
 
-	memset(labels, 0, sizeof(labels));
+	(void)memset(labels, 0, sizeof(labels));
 }
 
 void bt_mesh_heartbeat(u16_t src, u16_t dst, u8_t hops, u16_t feat)
@@ -3527,6 +3527,6 @@ void bt_mesh_subnet_del(struct bt_mesh_subnet *sub, bool store)
 		bt_mesh_clear_subnet(sub);
 	}
 
-	memset(sub, 0, sizeof(*sub));
+	(void)memset(sub, 0, sizeof(*sub));
 	sub->net_idx = BT_MESH_KEY_UNUSED;
 }

--- a/subsys/bluetooth/host/mesh/friend.c
+++ b/subsys/bluetooth/host/mesh/friend.c
@@ -191,7 +191,7 @@ static void friend_clear(struct bt_mesh_friend *frnd)
 	frnd->fsn = 0;
 	frnd->queue_size = 0;
 	frnd->pending_req = 0;
-	memset(frnd->sub_list, 0, sizeof(frnd->sub_list));
+	(void)memset(frnd->sub_list, 0, sizeof(frnd->sub_list));
 }
 
 void bt_mesh_friend_clear_net_idx(u16_t net_idx)

--- a/subsys/bluetooth/host/mesh/lpn.c
+++ b/subsys/bluetooth/host/mesh/lpn.c
@@ -123,10 +123,10 @@ static inline void group_set(atomic_t *target, atomic_t *source)
 	int i;
 
 	for (i = 0; i < ARRAY_SIZE(bt_mesh.lpn.added); i++) {
-		atomic_or(&target[i], atomic_get(&source[i]));
+		(void)atomic_or(&target[i], atomic_get(&source[i]));
 	}
 #else
-	atomic_or(target, atomic_get(source));
+	(void)atomic_or(target, atomic_get(source));
 #endif
 }
 
@@ -136,10 +136,10 @@ static inline void group_clear(atomic_t *target, atomic_t *source)
 	int i;
 
 	for (i = 0; i < ARRAY_SIZE(bt_mesh.lpn.added); i++) {
-		atomic_and(&target[i], ~atomic_get(&source[i]));
+		(void)atomic_and(&target[i], ~atomic_get(&source[i]));
 	}
 #else
-	atomic_and(target, ~atomic_get(source));
+	(void)atomic_and(target, ~atomic_get(source));
 #endif
 }
 

--- a/subsys/bluetooth/host/mesh/main.c
+++ b/subsys/bluetooth/host/mesh/main.c
@@ -111,7 +111,7 @@ void bt_mesh_reset(void)
 		bt_mesh_clear_net();
 	}
 
-	memset(bt_mesh.dev_key, 0, sizeof(bt_mesh.dev_key));
+	(void)memset(bt_mesh.dev_key, 0, sizeof(bt_mesh.dev_key));
 
 	bt_mesh_scan_disable();
 	bt_mesh_beacon_disable();

--- a/subsys/bluetooth/host/mesh/net.c
+++ b/subsys/bluetooth/host/mesh/net.c
@@ -341,7 +341,7 @@ void friend_cred_clear(struct friend_cred *cred)
 	cred->addr = BT_MESH_ADDR_UNASSIGNED;
 	cred->lpn_counter = 0;
 	cred->frnd_counter = 0;
-	memset(cred->cred, 0, sizeof(cred->cred));
+	(void)memset(cred->cred, 0, sizeof(cred->cred));
 }
 
 int friend_cred_del(u16_t net_idx, u16_t addr)
@@ -451,7 +451,7 @@ int bt_mesh_net_create(u16_t idx, u8_t flags, const u8_t key[16],
 		return -EALREADY;
 	}
 
-	memset(msg_cache, 0, sizeof(msg_cache));
+	(void)memset(msg_cache, 0, sizeof(msg_cache));
 	msg_cache_next = 0;
 
 	sub = &bt_mesh.sub[0];
@@ -571,7 +571,7 @@ void bt_mesh_rpl_reset(void)
 
 		if (rpl->src) {
 			if (rpl->old_iv) {
-				memset(rpl, 0, sizeof(*rpl));
+				(void)memset(rpl, 0, sizeof(*rpl));
 			} else {
 				rpl->old_iv = true;
 			}
@@ -654,7 +654,7 @@ bool bt_mesh_net_iv_update(u32_t iv_index, bool iv_update)
 
 		if (iv_index > bt_mesh.iv_index + 1) {
 			BT_WARN("Performing IV Index Recovery");
-			memset(bt_mesh.rpl, 0, sizeof(bt_mesh.rpl));
+			(void)memset(bt_mesh.rpl, 0, sizeof(bt_mesh.rpl));
 			bt_mesh.iv_index = iv_index;
 			bt_mesh.seq = 0;
 			goto do_update;

--- a/subsys/bluetooth/host/mesh/prov.c
+++ b/subsys/bluetooth/host/mesh/prov.c
@@ -238,7 +238,7 @@ static void reset_link(void)
 	}
 
 	/* Clear everything except the retransmit delayed work config */
-	memset(&link, 0, offsetof(struct prov_link, tx.retransmit));
+	(void)memset(&link, 0, offsetof(struct prov_link, tx.retransmit));
 
 	link.rx.prev_id = XACT_NVAL;
 
@@ -603,7 +603,7 @@ static int prov_auth(u8_t method, u8_t action, u8_t size)
 			return -EINVAL;
 		}
 
-		memset(link.auth, 0, sizeof(link.auth));
+		(void)memset(link.auth, 0, sizeof(link.auth));
 		return 0;
 	case AUTH_METHOD_STATIC:
 		if (action || size) {
@@ -612,7 +612,8 @@ static int prov_auth(u8_t method, u8_t action, u8_t size)
 
 		memcpy(link.auth + 16 - prov->static_val_len,
 		       prov->static_val, prov->static_val_len);
-		memset(link.auth, 0, sizeof(link.auth) - prov->static_val_len);
+		(void)memset(link.auth, 0,
+			     sizeof(link.auth) - prov->static_val_len);
 		return 0;
 
 	case AUTH_METHOD_OUTPUT:
@@ -647,7 +648,8 @@ static int prov_auth(u8_t method, u8_t action, u8_t size)
 			str[size] = '\0';
 
 			memcpy(link.auth, str, size);
-			memset(link.auth + size, 0, sizeof(link.auth) - size);
+			(void)memset(link.auth + size, 0,
+				     sizeof(link.auth) - size);
 
 			return prov->output_string((char *)str);
 		} else {
@@ -659,7 +661,7 @@ static int prov_auth(u8_t method, u8_t action, u8_t size)
 			num %= div[size - 1];
 
 			sys_put_be32(num, &link.auth[12]);
-			memset(link.auth, 0, 12);
+			(void)memset(link.auth, 0, 12);
 
 			return prov->output_number(output, num);
 		}
@@ -1540,7 +1542,7 @@ int bt_mesh_pb_gatt_close(struct bt_conn *conn)
 	bt_conn_unref(link.conn);
 
 	pub_key = atomic_test_bit(link.flags, LOCAL_PUB_KEY);
-	memset(&link, 0, sizeof(link));
+	(void)memset(&link, 0, sizeof(link));
 
 	if (pub_key) {
 		atomic_set_bit(link.flags, LOCAL_PUB_KEY);

--- a/subsys/bluetooth/host/mesh/proxy.c
+++ b/subsys/bluetooth/host/mesh/proxy.c
@@ -141,11 +141,11 @@ static int filter_set(struct bt_mesh_proxy_client *client,
 
 	switch (type) {
 	case 0x00:
-		memset(client->filter, 0, sizeof(client->filter));
+		(void)memset(client->filter, 0, sizeof(client->filter));
 		client->filter_type = WHITELIST;
 		break;
 	case 0x01:
-		memset(client->filter, 0, sizeof(client->filter));
+		(void)memset(client->filter, 0, sizeof(client->filter));
 		client->filter_type = BLACKLIST;
 		break;
 	default:
@@ -544,7 +544,7 @@ static void proxy_connected(struct bt_conn *conn, u8_t err)
 
 	client->conn = bt_conn_ref(conn);
 	client->filter_type = NONE;
-	memset(client->filter, 0, sizeof(client->filter));
+	(void)memset(client->filter, 0, sizeof(client->filter));
 	net_buf_simple_reset(&client->buf);
 }
 
@@ -998,7 +998,7 @@ static int node_id_adv(struct bt_mesh_subnet *sub)
 		return err;
 	}
 
-	memset(tmp, 0, 6);
+	(void)memset(tmp, 0, 6);
 	memcpy(tmp + 6, proxy_svc_data + 11, 8);
 	sys_put_be16(bt_mesh_primary_addr(), tmp + 14);
 

--- a/subsys/bluetooth/host/mesh/settings.c
+++ b/subsys/bluetooth/host/mesh/settings.c
@@ -133,7 +133,7 @@ static int net_set(int argc, char **argv, char *val)
 
 	if (!val) {
 		bt_mesh_comp_unprovision();
-		memset(bt_mesh.dev_key, 0, sizeof(bt_mesh.dev_key));
+		(void)memset(bt_mesh.dev_key, 0, sizeof(bt_mesh.dev_key));
 		return 0;
 	}
 
@@ -281,7 +281,7 @@ static int rpl_set(int argc, char **argv, char *val)
 
 	if (!val) {
 		if (entry) {
-			memset(entry, 0, sizeof(*entry));
+			(void)memset(entry, 0, sizeof(*entry));
 		} else {
 			BT_WARN("Unable to find RPL entry for 0x%04x", src);
 		}
@@ -564,7 +564,7 @@ static int mod_set_sub(struct bt_mesh_model *mod, char *val)
 	int len, err;
 
 	/* Start with empty array regardless of cleared or set value */
-	memset(mod->groups, 0, sizeof(mod->groups));
+	(void)memset(mod->groups, 0, sizeof(mod->groups));
 
 	if (!val) {
 		BT_DBG("Cleared subscriptions for model");
@@ -738,7 +738,7 @@ static int subnet_init(struct bt_mesh_subnet *sub)
 		err = bt_mesh_net_keys_create(&sub->keys[1], sub->keys[1].net);
 		if (err) {
 			BT_ERR("Unable to generate keys for subnet");
-			memset(&sub->keys[0], 0, sizeof(sub->keys[0]));
+			(void)memset(&sub->keys[0], 0, sizeof(sub->keys[0]));
 			return -EIO;
 		}
 	}
@@ -996,7 +996,7 @@ static void clear_rpl(void)
 		snprintk(path, sizeof(path), "bt/mesh/RPL/%x", rpl->src);
 		settings_save_one(path, NULL);
 
-		memset(rpl, 0, sizeof(*rpl));
+		(void)memset(rpl, 0, sizeof(*rpl));
 	}
 }
 

--- a/subsys/bluetooth/host/mesh/shell.c
+++ b/subsys/bluetooth/host/mesh/shell.c
@@ -118,7 +118,7 @@ static int fault_clear(struct bt_mesh_model *model, uint16_t cid)
 		return -EINVAL;
 	}
 
-	memset(reg_faults, 0, sizeof(reg_faults));
+	(void)memset(reg_faults, 0, sizeof(reg_faults));
 
 	return 0;
 }
@@ -422,7 +422,7 @@ static int cmd_uuid(int argc, char *argv[])
 	}
 
 	memcpy(dev_uuid, uuid, len);
-	memset(dev_uuid + len, 0, sizeof(dev_uuid) - len);
+	(void)memset(dev_uuid + len, 0, sizeof(dev_uuid) - len);
 
 	printk("Device UUID set\n");
 
@@ -919,7 +919,7 @@ static int cmd_net_key_add(int argc, char *argv[])
 		size_t len;
 
 		len = hex2bin(argv[3], key_val, sizeof(key_val));
-		memset(key_val, 0, sizeof(key_val) - len);
+		(void)memset(key_val, 0, sizeof(key_val) - len);
 	} else {
 		memcpy(key_val, default_key, sizeof(key_val));
 	}
@@ -958,7 +958,7 @@ static int cmd_app_key_add(int argc, char *argv[])
 		size_t len;
 
 		len = hex2bin(argv[3], key_val, sizeof(key_val));
-		memset(key_val, 0, sizeof(key_val) - len);
+		(void)memset(key_val, 0, sizeof(key_val) - len);
 	} else {
 		memcpy(key_val, default_key, sizeof(key_val));
 	}
@@ -1112,7 +1112,7 @@ static int cmd_mod_sub_add_va(int argc, char *argv[])
 	elem_addr = strtoul(argv[1], NULL, 0);
 
 	len = hex2bin(argv[2], label, sizeof(label));
-	memset(label + len, 0, sizeof(label) - len);
+	(void)memset(label + len, 0, sizeof(label) - len);
 
 	mod_id = strtoul(argv[3], NULL, 0);
 
@@ -1158,7 +1158,7 @@ static int cmd_mod_sub_del_va(int argc, char *argv[])
 	elem_addr = strtoul(argv[1], NULL, 0);
 
 	len = hex2bin(argv[2], label, sizeof(label));
-	memset(label + len, 0, sizeof(label) - len);
+	(void)memset(label + len, 0, sizeof(label) - len);
 
 	mod_id = strtoul(argv[3], NULL, 0);
 
@@ -1851,7 +1851,7 @@ static int cmd_del_fault(int argc, char *argv[])
 	u8_t i;
 
 	if (argc < 2) {
-		memset(cur_faults, 0, sizeof(cur_faults));
+		(void)memset(cur_faults, 0, sizeof(cur_faults));
 		printk("All current faults cleared\n");
 		bt_mesh_fault_update(&elements[0]);
 		return 0;

--- a/subsys/bluetooth/host/mesh/transport.c
+++ b/subsys/bluetooth/host/mesh/transport.c
@@ -1443,7 +1443,7 @@ void bt_mesh_rx_reset(void)
 	if (IS_ENABLED(CONFIG_BT_SETTINGS)) {
 		bt_mesh_clear_rpl();
 	} else {
-		memset(bt_mesh.rpl, 0, sizeof(bt_mesh.rpl));
+		(void)memset(bt_mesh.rpl, 0, sizeof(bt_mesh.rpl));
 	}
 }
 
@@ -1477,5 +1477,5 @@ void bt_mesh_trans_init(void)
 void bt_mesh_rpl_clear(void)
 {
 	BT_DBG("");
-	memset(bt_mesh.rpl, 0, sizeof(bt_mesh.rpl));
+	(void)memset(bt_mesh.rpl, 0, sizeof(bt_mesh.rpl));
 }

--- a/subsys/bluetooth/host/sdp.c
+++ b/subsys/bluetooth/host/sdp.c
@@ -180,7 +180,7 @@ static void bt_sdp_disconnected(struct bt_l2cap_chan *chan)
 
 	BT_DBG("chan %p cid 0x%04x", ch, ch->tx.cid);
 
-	memset(sdp, 0, sizeof(*sdp));
+	(void)memset(sdp, 0, sizeof(*sdp));
 }
 
 /* @brief Creates an SDP PDU
@@ -1575,7 +1575,7 @@ static void sdp_client_params_iterator(struct bt_sdp_client *session)
 		/* Invalidate cached param in context */
 		session->param = NULL;
 		/* Reset continuation state in current context */
-		memset(&session->cstate, 0, sizeof(session->cstate));
+		(void)memset(&session->cstate, 0, sizeof(session->cstate));
 
 		/* Check if there's valid next UUID */
 		if (!sys_slist_is_empty(&session->reqs)) {
@@ -1880,7 +1880,8 @@ static void sdp_client_disconnected(struct bt_l2cap_chan *chan)
 	 * Reset session excluding L2CAP channel member. Let's the channel
 	 * resets autonomous.
 	 */
-	memset(&session->reqs, 0, sizeof(*session) - sizeof(session->chan));
+	(void)memset(&session->reqs, 0,
+		     sizeof(*session) - sizeof(session->chan));
 }
 
 static struct bt_l2cap_chan_ops sdp_client_chan_ops = {
@@ -1910,7 +1911,7 @@ static struct bt_sdp_client *sdp_client_new_session(struct bt_conn *conn)
 
 		err = sdp_client_chan_connect(session);
 		if (err) {
-			memset(session, 0, sizeof(*session));
+			(void)memset(session, 0, sizeof(*session));
 			BT_ERR("Cannot connect %d", err);
 			return NULL;
 		}

--- a/subsys/bluetooth/host/settings.c
+++ b/subsys/bluetooth/host/settings.c
@@ -118,7 +118,8 @@ static int set(int argc, char **argv, char *val)
 		settings_bytes_from_str(val, &bt_dev.id_addr, &len);
 		if (len < sizeof(bt_dev.id_addr[0])) {
 			BT_ERR("Invalid length ID address in storage");
-			memset(bt_dev.id_addr, 0, sizeof(bt_dev.id_addr));
+			(void)memset(bt_dev.id_addr, 0,
+				     sizeof(bt_dev.id_addr));
 			bt_dev.id_count = 0;
 		} else {
 			int i;
@@ -150,7 +151,7 @@ static int set(int argc, char **argv, char *val)
 		settings_bytes_from_str(val, bt_dev.irk, &len);
 		if (len < sizeof(bt_dev.irk[0])) {
 			BT_ERR("Invalid length IRK in storage");
-			memset(bt_dev.irk, 0, sizeof(bt_dev.irk));
+			(void)memset(bt_dev.irk, 0, sizeof(bt_dev.irk));
 		} else {
 			BT_DBG("IRK set to %s", bt_hex(bt_dev.irk[0], 16));
 		}

--- a/subsys/bluetooth/host/smp.c
+++ b/subsys/bluetooth/host/smp.c
@@ -793,14 +793,14 @@ static void bt_smp_br_disconnected(struct bt_l2cap_chan *chan)
 
 	k_delayed_work_cancel(&smp->work);
 
-	memset(smp, 0, sizeof(*smp));
+	(void)memset(smp, 0, sizeof(*smp));
 }
 
 static void smp_br_init(struct bt_smp_br *smp)
 {
 	/* Initialize SMP context without clearing L2CAP channel context */
-	memset((u8_t *)smp + sizeof(smp->chan), 0,
-	       sizeof(*smp) - (sizeof(smp->chan) + sizeof(smp->work)));
+	(void)memset((u8_t *)smp + sizeof(smp->chan), 0,
+		     sizeof(*smp) - (sizeof(smp->chan) + sizeof(smp->work)));
 
 	atomic_set_bit(&smp->allowed_cmds, BT_SMP_CMD_PAIRING_FAIL);
 }
@@ -864,8 +864,8 @@ static void smp_br_derive_ltk(struct bt_smp_br *smp)
 		return;
 	}
 
-	memset(keys->ltk.ediv, 0, sizeof(keys->ltk.ediv));
-	memset(keys->ltk.rand, 0, sizeof(keys->ltk.rand));
+	(void)memset(keys->ltk.ediv, 0, sizeof(keys->ltk.ediv));
+	(void)memset(keys->ltk.rand, 0, sizeof(keys->ltk.rand));
 	keys->enc_size = smp->enc_key_size;
 
 	if (link_key->flags & BT_LINK_KEY_AUTHENTICATED) {
@@ -1641,7 +1641,7 @@ static int smp_c1(const u8_t k[16], const u8_t r[16],
 	/* ra is concatenated with ia and padding to generate p2 */
 	memcpy(p2, ra->a.val, 6);
 	memcpy(p2 + 6, ia->a.val, 6);
-	memset(p2 + 12, 0, 4);
+	(void)memset(p2 + 12, 0, 4);
 
 	BT_DBG("p2 %s", bt_hex(p2, 16));
 
@@ -1733,8 +1733,8 @@ static void legacy_distribute_keys(struct bt_smp *smp)
 		/* distributed only enc_size bytes of key */
 		memcpy(info->ltk, key, keys->enc_size);
 		if (keys->enc_size < sizeof(info->ltk)) {
-			memset(info->ltk + keys->enc_size, 0,
-			       sizeof(info->ltk) - keys->enc_size);
+			(void)memset(info->ltk + keys->enc_size, 0,
+				     sizeof(info->ltk) - keys->enc_size);
 		}
 
 		smp_send(smp, buf, NULL);
@@ -2053,8 +2053,8 @@ static u8_t legacy_pairing_random(struct bt_smp *smp)
 		}
 
 		/* Rand and EDiv are 0 for the STK */
-		memset(ediv, 0, sizeof(ediv));
-		memset(rand, 0, sizeof(rand));
+		(void)memset(ediv, 0, sizeof(ediv));
+		(void)memset(rand, 0, sizeof(rand));
 		if (bt_conn_le_start_encryption(conn, rand, ediv, tmp,
 						get_encryption_key_size(smp))) {
 			BT_ERR("Failed to start encryption");
@@ -2246,8 +2246,8 @@ static u8_t smp_master_ident(struct bt_smp *smp, struct net_buf *buf)
 static int smp_init(struct bt_smp *smp)
 {
 	/* Initialize SMP context without clearing L2CAP channel context */
-	memset((u8_t *)smp + sizeof(smp->chan), 0,
-	       sizeof(*smp) - (sizeof(smp->chan) + sizeof(smp->work)));
+	(void)memset((u8_t *)smp + sizeof(smp->chan), 0,
+		     sizeof(*smp) - (sizeof(smp->chan) + sizeof(smp->work)));
 
 	/* Generate local random number */
 	if (bt_rand(smp->prnd, 16)) {
@@ -2682,7 +2682,7 @@ static u8_t compute_and_send_master_dhcheck(struct bt_smp *smp)
 {
 	u8_t e[16], r[16];
 
-	memset(r, 0, sizeof(r));
+	(void)memset(r, 0, sizeof(r));
 
 	switch (smp->method) {
 	case JUST_WORKS:
@@ -2721,7 +2721,7 @@ static u8_t compute_and_check_and_send_slave_dhcheck(struct bt_smp *smp)
 {
 	u8_t re[16], e[16], r[16];
 
-	memset(r, 0, sizeof(r));
+	(void)memset(r, 0, sizeof(r));
 
 	switch (smp->method) {
 	case JUST_WORKS:
@@ -3394,7 +3394,7 @@ static u8_t smp_dhkey_check(struct bt_smp *smp, struct net_buf *buf)
 		u8_t e[16], r[16], enc_size;
 		u8_t ediv[2], rand[8];
 
-		memset(r, 0, sizeof(r));
+		(void)memset(r, 0, sizeof(r));
 
 		switch (smp->method) {
 		case JUST_WORKS:
@@ -3422,8 +3422,8 @@ static u8_t smp_dhkey_check(struct bt_smp *smp, struct net_buf *buf)
 		enc_size = get_encryption_key_size(smp);
 
 		/* Rand and EDiv are 0 */
-		memset(ediv, 0, sizeof(ediv));
-		memset(rand, 0, sizeof(rand));
+		(void)memset(ediv, 0, sizeof(ediv));
+		(void)memset(rand, 0, sizeof(rand));
 		if (bt_conn_le_start_encryption(smp->chan.chan.conn, rand, ediv,
 						smp->tk, enc_size) < 0) {
 			return BT_SMP_ERR_UNSPECIFIED;
@@ -3605,7 +3605,7 @@ static void bt_smp_disconnected(struct bt_l2cap_chan *chan)
 		}
 	}
 
-	memset(smp, 0, sizeof(*smp));
+	(void)memset(smp, 0, sizeof(*smp));
 }
 
 static void bt_smp_encrypt_change(struct bt_l2cap_chan *chan,
@@ -3898,9 +3898,9 @@ static int sign_test(const char *prefix, const u8_t *key, const u8_t *m,
 
 	BT_DBG("%s: Sign message with len %u", prefix, len);
 
-	memset(msg, 0, sizeof(msg));
+	(void)memset(msg, 0, sizeof(msg));
 	memcpy(msg, m, len);
-	memset(msg + len, 0, sizeof(u32_t));
+	(void)memset(msg + len, 0, sizeof(u32_t));
 
 	memcpy(orig, msg, sizeof(msg));
 
@@ -4465,10 +4465,10 @@ void bt_smp_update_keys(struct bt_conn *conn)
 		bt_keys_add_type(conn->le.keys, BT_KEYS_LTK_P256);
 		memcpy(conn->le.keys->ltk.val, smp->tk,
 		       sizeof(conn->le.keys->ltk.val));
-		memset(conn->le.keys->ltk.rand, 0,
-		       sizeof(conn->le.keys->ltk.rand));
-		memset(conn->le.keys->ltk.ediv, 0,
-		       sizeof(conn->le.keys->ltk.ediv));
+		(void)memset(conn->le.keys->ltk.rand, 0,
+			     sizeof(conn->le.keys->ltk.rand));
+		(void)memset(conn->le.keys->ltk.ediv, 0,
+			     sizeof(conn->le.keys->ltk.ediv));
 	}
 }
 
@@ -4498,7 +4498,7 @@ bool bt_smp_get_tk(struct bt_conn *conn, u8_t *tk)
 	 */
 	memcpy(tk, smp->tk, enc_size);
 	if (enc_size < sizeof(smp->tk)) {
-		memset(tk + enc_size, 0, sizeof(smp->tk) - enc_size);
+		(void)memset(tk + enc_size, 0, sizeof(smp->tk) - enc_size);
 	}
 
 	return true;

--- a/subsys/bluetooth/host/uuid.c
+++ b/subsys/bluetooth/host/uuid.c
@@ -104,7 +104,7 @@ void bt_uuid_to_str(const struct bt_uuid *uuid, char *str, size_t len)
 			 tmp5, tmp4, tmp3, tmp2, tmp1, tmp0);
 		break;
 	default:
-		memset(str, 0, len);
+		(void)memset(str, 0, len);
 		return;
 	}
 }

--- a/subsys/bluetooth/shell/bt.c
+++ b/subsys/bluetooth/shell/bt.c
@@ -155,7 +155,7 @@ static void device_found(const bt_addr_le_t *addr, s8_t rssi, u8_t evtype,
 	char le_addr[BT_ADDR_LE_STR_LEN];
 	char name[NAME_LEN];
 
-	memset(name, 0, sizeof(name));
+	(void)memset(name, 0, sizeof(name));
 
 	bt_data_parse(buf, data_cb, name);
 
@@ -1544,7 +1544,7 @@ static void br_device_found(const bt_addr_t *addr, s8_t rssi,
 	char name[239];
 	int len = 240;
 
-	memset(name, 0, sizeof(name));
+	(void)memset(name, 0, sizeof(name));
 
 	while (len) {
 		if (len < 2) {

--- a/subsys/bluetooth/shell/gatt.c
+++ b/subsys/bluetooth/shell/gatt.c
@@ -110,7 +110,7 @@ static u8_t discover_func(struct bt_conn *conn,
 
 	if (!attr) {
 		printk("Discover complete\n");
-		memset(params, 0, sizeof(*params));
+		(void)memset(params, 0, sizeof(*params));
 		return BT_GATT_ITER_STOP;
 	}
 
@@ -211,7 +211,7 @@ static u8_t read_func(struct bt_conn *conn, u8_t err,
 	printk("Read complete: err %u length %u\n", err, length);
 
 	if (!data) {
-		memset(params, 0, sizeof(*params));
+		(void)memset(params, 0, sizeof(*params));
 		return BT_GATT_ITER_STOP;
 	}
 
@@ -294,7 +294,7 @@ static void write_func(struct bt_conn *conn, u8_t err,
 {
 	printk("Write complete: err %u\n", err);
 
-	memset(&write_params, 0, sizeof(write_params));
+	(void)memset(&write_params, 0, sizeof(write_params));
 }
 
 int cmd_gatt_write(int argc, char *argv[])

--- a/subsys/dfu/boot/mcuboot.c
+++ b/subsys/dfu/boot/mcuboot.c
@@ -210,7 +210,7 @@ static int boot_flag_write(int flag, u32_t bank_offs)
 		return rc;
 	}
 
-	memset(buf, BOOT_FLAG_UNSET, sizeof(buf));
+	(void)memset(buf, BOOT_FLAG_UNSET, sizeof(buf));
 	buf[0] = BOOT_FLAG_SET;
 
 	rc = boot_flash_write(offs, buf, sizeof(buf));

--- a/subsys/dfu/img_util/flash_img.c
+++ b/subsys/dfu/img_util/flash_img.c
@@ -94,8 +94,8 @@ static int flash_block_write(struct flash_img_context *ctx, off_t offset,
 
 	if (finished && ctx->buf_bytes > 0) {
 		/* pad the rest of ctx->buf and write it out */
-		memset(ctx->buf + ctx->buf_bytes, 0xFF,
-		       CONFIG_IMG_BLOCK_BUF_SIZE - ctx->buf_bytes);
+		(void)memset(ctx->buf + ctx->buf_bytes, 0xFF,
+			     CONFIG_IMG_BLOCK_BUF_SIZE - ctx->buf_bytes);
 
 		flash_write_protection_set(ctx->dev, false);
 		rc = flash_write(ctx->dev, offset + ctx->bytes_written,

--- a/subsys/fs/fat_fs.c
+++ b/subsys/fs/fat_fs.c
@@ -70,7 +70,7 @@ static int fatfs_open(struct fs_file_t *zfp, const char *file_name)
 	void *ptr;
 
 	if (k_mem_slab_alloc(&fatfs_filep_pool, &ptr, K_NO_WAIT) == 0) {
-		memset(ptr, 0, sizeof(FIL));
+		(void)memset(ptr, 0, sizeof(FIL));
 		zfp->filep = ptr;
 	} else {
 		return -ENOMEM;
@@ -233,7 +233,7 @@ static int fatfs_opendir(struct fs_dir_t *zdp, const char *path)
 	void *ptr;
 
 	if (k_mem_slab_alloc(&fatfs_dirp_pool, &ptr, K_NO_WAIT) == 0) {
-		memset(ptr, 0, sizeof(DIR));
+		(void)memset(ptr, 0, sizeof(DIR));
 		zdp->dirp = ptr;
 	} else {
 		return -ENOMEM;

--- a/subsys/fs/fcb/fcb.c
+++ b/subsys/fs/fcb/fcb.c
@@ -296,7 +296,7 @@ fcb_offset_last_n(struct fcb *fcb, u8_t entries,
 	}
 
 	i = 0;
-	memset(&loc, 0, sizeof(loc));
+	(void)memset(&loc, 0, sizeof(loc));
 	while (!fcb_getnext(fcb, &loc)) {
 		if (i == 0) {
 			/* Start from the beginning of fcb entries */

--- a/subsys/fs/fcb/fcb_append.c
+++ b/subsys/fs/fcb/fcb_append.c
@@ -119,7 +119,7 @@ fcb_append_finish(struct fcb *fcb, struct fcb_entry *loc)
 	u8_t crc8[fcb->f_align];
 	off_t off;
 
-	memset(crc8, 0xFF, sizeof(crc8));
+	(void)memset(crc8, 0xFF, sizeof(crc8));
 
 	rc = fcb_elem_crc8(fcb, loc, &crc8[0]);
 	if (rc) {

--- a/subsys/fs/nvs/nvs.c
+++ b/subsys/fs/nvs/nvs.c
@@ -56,7 +56,7 @@ static int _nvs_flash_al_wrt(struct nvs_fs *fs, u32_t addr, const void *data,
 	}
 	if (len) {
 		memcpy(buf, data, len);
-		memset(buf + len, 0xff, fs->write_block_size - len);
+		(void)memset(buf + len, 0xff, fs->write_block_size - len);
 		rc = flash_write(fs->flash_device, offset, buf,
 				 fs->write_block_size);
 		if (rc) {
@@ -159,7 +159,7 @@ static int _nvs_flash_cmp_const(struct nvs_fs *fs, u32_t addr, u8_t value,
 	u8_t cmp[NVS_BLOCK_SIZE];
 
 	block_size = NVS_BLOCK_SIZE & ~(fs->write_block_size - 1);
-	memset(cmp, value, block_size);
+	(void)memset(cmp, value, block_size);
 	while (len) {
 		bytes_to_cmp = min(block_size, len);
 		rc = _nvs_flash_block_cmp(fs, addr, cmp, bytes_to_cmp);
@@ -357,7 +357,7 @@ static int _nvs_sector_close(struct nvs_fs *fs)
 
 	ate_size = sizeof(struct nvs_ate);
 
-	memset(buf, 0, ate_size);
+	(void)memset(buf, 0, ate_size);
 
 	rc = _nvs_flash_al_wrt(fs, fs->ate_wra, buf, ate_size);
 	if (rc) {

--- a/subsys/net/buf.c
+++ b/subsys/net/buf.c
@@ -686,7 +686,7 @@ int net_buf_linearize(void *dst, size_t dst_len, struct net_buf *src,
 	frag = src;
 
 	/* clear dst */
-	memset(dst, 0, dst_len);
+	(void)memset(dst, 0, dst_len);
 
 	/* find the right fragment to start copying from */
 	while (frag && offset >= frag->len) {

--- a/subsys/net/ip/6lo.c
+++ b/subsys/net/ip/6lo.c
@@ -1262,8 +1262,8 @@ static inline bool uncompress_IPHC_header(struct net_pkt *pkt)
 	offset = uncompress_hoplimit(pkt, ipv6, offset);
 
 	/* First set to zero and copy relevant bits */
-	memset(&ipv6->src.s6_addr[0], 0, 16);
-	memset(&ipv6->dst.s6_addr[0], 0, 16);
+	(void)memset(&ipv6->src.s6_addr[0], 0, 16);
+	(void)memset(&ipv6->dst.s6_addr[0], 0, 16);
 
 	/* Uncompress Source Address */
 	if (CIPHC[1] & NET_6LO_IPHC_SAC_1) {

--- a/subsys/net/ip/connection.c
+++ b/subsys/net/ip/connection.c
@@ -363,7 +363,7 @@ int net_conn_unregister(struct net_conn_handle *handle)
 	NET_DBG("[%zu] connection handler %p removed",
 		(conn - conns) / sizeof(*conn), conn);
 
-	memset(conn, 0, sizeof(*conn));
+	(void)memset(conn, 0, sizeof(*conn));
 
 	return 0;
 }

--- a/subsys/net/ip/dhcpv4.c
+++ b/subsys/net/ip/dhcpv4.c
@@ -202,7 +202,7 @@ static struct net_pkt *dhcpv4_prepare_message(struct net_if *iface, u8_t type,
 	}
 
 	msg = (struct dhcp_msg *)(frag->data + NET_IPV4UDPH_LEN);
-	memset(msg, 0, sizeof(struct dhcp_msg));
+	(void)memset(msg, 0, sizeof(struct dhcp_msg));
 
 	msg->op = DHCPV4_MSG_BOOT_REQUEST;
 
@@ -699,7 +699,7 @@ static enum net_verdict dhcpv4_parse_options(struct net_if *iface,
 				return NET_DROP;
 			}
 
-			memset(&dns, 0, sizeof(dns));
+			(void)memset(&dns, 0, sizeof(dns));
 			frag = net_frag_read(frag, pos, &pos, 4,
 					     dns.sin_addr.s4_addr);
 			frag = net_frag_skip(frag, pos, &pos, length - 4);

--- a/subsys/net/ip/icmpv6.c
+++ b/subsys/net/ip/icmpv6.c
@@ -258,7 +258,7 @@ int net_icmpv6_set_na_hdr(struct net_pkt *pkt, struct net_icmpv6_na_hdr *hdr)
 	struct net_buf *frag;
 	u16_t pos;
 
-	memset(hdr->reserved, 0, sizeof(hdr->reserved));
+	(void)memset(hdr->reserved, 0, sizeof(hdr->reserved));
 
 	frag = net_pkt_write(pkt, pkt->frags,
 			     net_pkt_ip_hdr_len(pkt) +

--- a/subsys/net/ip/ipv4_autoconf.c
+++ b/subsys/net/ip/ipv4_autoconf.c
@@ -184,7 +184,7 @@ static void ipv4_autoconf_send(struct net_if_ipv4_autoconf *ipv4auto)
 		ipv4auto->probe_cnt = 0;
 		ipv4auto->announce_cnt = 0;
 		ipv4auto->conflict_cnt = 0;
-		memset(&ipv4auto->current_ip, 0, sizeof(struct in_addr));
+		(void)memset(&ipv4auto->current_ip, 0, sizeof(struct in_addr));
 		ipv4auto->requested_ip.s4_addr[0] = 169;
 		ipv4auto->requested_ip.s4_addr[1] = 254;
 		ipv4auto->requested_ip.s4_addr[2] = sys_rand32_get() % 254;
@@ -199,7 +199,7 @@ static void ipv4_autoconf_send(struct net_if_ipv4_autoconf *ipv4auto)
 		ipv4auto->probe_cnt = 0;
 		ipv4auto->announce_cnt = 0;
 		ipv4auto->conflict_cnt = 0;
-		memset(&ipv4auto->current_ip, 0, sizeof(struct in_addr));
+		(void)memset(&ipv4auto->current_ip, 0, sizeof(struct in_addr));
 		NET_DBG("%s: Starting probe for 169.254.%d.%d", "Renew",
 			ipv4auto->requested_ip.s4_addr[2],
 			ipv4auto->requested_ip.s4_addr[3]);

--- a/subsys/net/ip/ipv6_nbr.c
+++ b/subsys/net/ip/ipv6_nbr.c
@@ -1062,8 +1062,8 @@ static inline void set_llao(struct net_linkaddr *lladdr,
 
 	memcpy(&llao[NET_ICMPV6_OPT_DATA_OFFSET], lladdr->addr, lladdr->len);
 
-	memset(&llao[NET_ICMPV6_OPT_DATA_OFFSET + lladdr->len], 0,
-	       llao_len - lladdr->len - 2);
+	(void)memset(&llao[NET_ICMPV6_OPT_DATA_OFFSET + lladdr->len], 0,
+		     llao_len - lladdr->len - 2);
 }
 
 static void setup_headers(struct net_pkt *pkt, u8_t nd6_len,
@@ -2463,8 +2463,8 @@ static inline struct net_buf *handle_ra_6co(struct net_pkt *pkt,
 	 * field that are valid. So set remaining data to zero.
 	 */
 	if (context.context_len != sizeof(struct in6_addr)) {
-		memset(context.prefix.s6_addr + context.context_len, 0,
-		       sizeof(struct in6_addr) - context.context_len);
+		(void)memset(context.prefix.s6_addr + context.context_len, 0,
+			     sizeof(struct in6_addr) - context.context_len);
 	}
 
 	net_6lo_set_context(net_pkt_iface(pkt), &context);

--- a/subsys/net/ip/nbr.c
+++ b/subsys/net/ip/nbr.c
@@ -148,8 +148,8 @@ int net_nbr_unlink(struct net_nbr *nbr, struct net_linkaddr *lladdr)
 	net_neighbor_lladdr[nbr->idx].ref--;
 
 	if (!net_neighbor_lladdr[nbr->idx].ref) {
-		memset(net_neighbor_lladdr[nbr->idx].lladdr.addr, 0,
-		       sizeof(net_neighbor_lladdr[nbr->idx].lladdr.addr));
+		(void)memset(net_neighbor_lladdr[nbr->idx].lladdr.addr, 0,
+			     sizeof(net_neighbor_lladdr[nbr->idx].lladdr.addr));
 	}
 
 	nbr->idx = NET_NBR_LLADDR_UNKNOWN;

--- a/subsys/net/ip/net_context.c
+++ b/subsys/net/ip/net_context.c
@@ -214,8 +214,9 @@ int net_context_get(sa_family_t family,
 		net_context_set_type(&contexts[i], type);
 		net_context_set_ip_proto(&contexts[i], ip_proto);
 
-		memset(&contexts[i].remote, 0, sizeof(struct sockaddr));
-		memset(&contexts[i].local, 0, sizeof(struct sockaddr_ptr));
+		(void)memset(&contexts[i].remote, 0, sizeof(struct sockaddr));
+		(void)memset(&contexts[i].local, 0,
+			     sizeof(struct sockaddr_ptr));
 
 #if defined(CONFIG_NET_IPV6)
 		if (family == AF_INET6) {

--- a/subsys/net/ip/net_mgmt.c
+++ b/subsys/net/ip/net_mgmt.c
@@ -376,9 +376,8 @@ void net_mgmt_event_init(void)
 	in_event = -1;
 	out_event = -1;
 
-	memset(events, 0,
-	       CONFIG_NET_MGMT_EVENT_QUEUE_SIZE *
-	       sizeof(struct mgmt_event_entry));
+	(void)memset(events, 0, CONFIG_NET_MGMT_EVENT_QUEUE_SIZE *
+			sizeof(struct mgmt_event_entry));
 
 	k_thread_create(&mgmt_thread_data, mgmt_stack,
 			K_THREAD_STACK_SIZEOF(mgmt_stack),

--- a/subsys/net/ip/net_pkt.c
+++ b/subsys/net/ip/net_pkt.c
@@ -312,7 +312,7 @@ struct net_pkt *net_pkt_get_reserve(struct k_mem_slab *slab,
 		return NULL;
 	}
 
-	memset(pkt, 0, sizeof(struct net_pkt));
+	(void)memset(pkt, 0, sizeof(struct net_pkt));
 
 	net_pkt_set_ll_reserve(pkt, reserve_head);
 
@@ -1249,7 +1249,7 @@ u16_t net_pkt_append_memset(struct net_pkt *pkt, u16_t len, const u8_t data,
 		u16_t count = min(len, net_buf_tailroom(frag));
 		void *mem = net_buf_add(frag, count);
 
-		memset(mem, data, count);
+		(void)memset(mem, data, count);
 		len -= count;
 		appended += count;
 
@@ -1558,7 +1558,7 @@ static inline bool insert_data(struct net_pkt *pkt, struct net_buf *frag,
 			memcpy(frag->data + offset, data, count);
 		} else {
 			/* If there is no data, just clear the area */
-			memset(frag->data + offset, 0, count);
+			(void)memset(frag->data + offset, 0, count);
 		}
 
 		net_buf_add(frag, count);

--- a/subsys/net/ip/net_shell.c
+++ b/subsys/net/ip/net_shell.c
@@ -2244,7 +2244,7 @@ static char *http_str_output(char *output, int outlen, const char *str, int len)
 	}
 
 	if (len == 0) {
-		memset(output, 0, outlen);
+		(void)memset(output, 0, outlen);
 	} else {
 		memcpy(output, str, len);
 		output[len] = '\0';
@@ -2661,7 +2661,7 @@ int net_shell_cmd_mem(int argc, char *argv[])
 	if (IS_ENABLED(CONFIG_NET_CONTEXT_NET_PKT_POOL)) {
 		struct ctx_info info;
 
-		memset(&info, 0, sizeof(info));
+		(void)memset(&info, 0, sizeof(info));
 		net_context_foreach(context_info, &info);
 
 		if (!info.are_external_pools) {

--- a/subsys/net/ip/rpl.c
+++ b/subsys/net/ip/rpl.c
@@ -1067,7 +1067,7 @@ static void dao_retransmit_timer(struct k_work *work)
 static inline void net_rpl_instance_init(struct net_rpl_instance *instance,
 					 u8_t id)
 {
-	memset(instance, 0, sizeof(struct net_rpl_instance));
+	(void)memset(instance, 0, sizeof(struct net_rpl_instance));
 
 	instance->instance_id = id;
 	instance->default_route = NULL;
@@ -1135,7 +1135,7 @@ static struct net_rpl_dag *alloc_dag(struct net_if *iface,
 			continue;
 		}
 
-		memset(dag, 0, sizeof(*dag));
+		(void)memset(dag, 0, sizeof(*dag));
 
 		net_rpl_dag_set_used(dag);
 		dag->rank = NET_RPL_INFINITE_RANK;
@@ -1211,7 +1211,7 @@ static inline void set_ip_from_prefix(struct net_linkaddr *lladdr,
 				      struct net_rpl_prefix *prefix,
 				      struct in6_addr *addr)
 {
-	memset(addr, 0, sizeof(struct in6_addr));
+	(void)memset(addr, 0, sizeof(struct in6_addr));
 
 	net_ipv6_addr_create_iid(addr, lladdr);
 
@@ -1469,8 +1469,8 @@ bool net_rpl_set_prefix(struct net_if *iface,
 		       sizeof(struct net_rpl_prefix));
 	}
 
-	memset(&dag->prefix_info.prefix, 0,
-	       sizeof(dag->prefix_info.prefix));
+	(void)memset(&dag->prefix_info.prefix, 0,
+		     sizeof(dag->prefix_info.prefix));
 	memcpy(&dag->prefix_info.prefix, prefix, (prefix_len + 7) / 8);
 	dag->prefix_info.length = prefix_len;
 	dag->prefix_info.flags = NET_ICMPV6_RA_FLAG_AUTONOMOUS;
@@ -4304,7 +4304,7 @@ void net_rpl_init(void)
 		sizeof(net_rpl_neighbor_pool));
 
 #if defined(CONFIG_NET_STATISTICS_RPL)
-	memset(&net_stats.rpl, 0, sizeof(net_stats.rpl));
+	(void)memset(&net_stats.rpl, 0, sizeof(net_stats.rpl));
 #endif
 
 	rpl_dao_sequence = net_rpl_lollipop_init();

--- a/subsys/net/ip/tcp.c
+++ b/subsys/net/ip/tcp.c
@@ -269,7 +269,7 @@ struct net_tcp *net_tcp_alloc(struct net_context *context)
 		return NULL;
 	}
 
-	memset(&tcp_context[i], 0, sizeof(struct net_tcp));
+	(void)memset(&tcp_context[i], 0, sizeof(struct net_tcp));
 
 	tcp_context[i].flags = NET_TCP_IN_USE;
 	tcp_context[i].state = NET_TCP_CLOSED;
@@ -716,7 +716,7 @@ static inline void copy_sockaddr_to_sockaddr_ptr(struct net_tcp *tcp,
 						 const struct sockaddr *local,
 						 struct sockaddr_ptr *addr)
 {
-	memset(addr, 0, sizeof(struct sockaddr_ptr));
+	(void)memset(addr, 0, sizeof(struct sockaddr_ptr));
 
 #if defined(CONFIG_NET_IPV4)
 	if (local->sa_family == AF_INET) {
@@ -1566,7 +1566,7 @@ static void backlog_ack_timeout(struct k_work *work)
 	 */
 	send_reset(backlog->tcp->context, NULL, &backlog->remote);
 
-	memset(backlog, 0, sizeof(struct tcp_backlog_entry));
+	(void)memset(backlog, 0, sizeof(struct tcp_backlog_entry));
 }
 
 static int tcp_backlog_find(struct net_pkt *pkt, int *empty_slot)
@@ -1696,7 +1696,7 @@ static int tcp_backlog_ack(struct net_pkt *pkt, struct net_context *context)
 	context->tcp->send_mss = tcp_backlog[r].send_mss;
 
 	k_delayed_work_cancel(&tcp_backlog[r].ack_timer);
-	memset(&tcp_backlog[r], 0, sizeof(struct tcp_backlog_entry));
+	(void)memset(&tcp_backlog[r], 0, sizeof(struct tcp_backlog_entry));
 
 	return 0;
 }
@@ -1722,7 +1722,7 @@ static int tcp_backlog_rst(struct net_pkt *pkt)
 	}
 
 	k_delayed_work_cancel(&tcp_backlog[r].ack_timer);
-	memset(&tcp_backlog[r], 0, sizeof(struct tcp_backlog_entry));
+	(void)memset(&tcp_backlog[r], 0, sizeof(struct tcp_backlog_entry));
 
 	return 0;
 }
@@ -1806,7 +1806,7 @@ int net_tcp_unref(struct net_context *context)
 		}
 
 		k_delayed_work_cancel(&tcp_backlog[i].ack_timer);
-		memset(&tcp_backlog[i], 0, sizeof(tcp_backlog[i]));
+		(void)memset(&tcp_backlog[i], 0, sizeof(tcp_backlog[i]));
 	}
 
 	net_tcp_release(context->tcp);
@@ -2267,7 +2267,7 @@ static void pkt_get_sockaddr(sa_family_t family, struct net_pkt *pkt,
 		return;
 	}
 
-	memset(addr, 0, sizeof(*addr));
+	(void)memset(addr, 0, sizeof(*addr));
 
 #if defined(CONFIG_NET_IPV4)
 	if (family == AF_INET) {

--- a/subsys/net/ip/trickle.c
+++ b/subsys/net/ip/trickle.c
@@ -156,7 +156,7 @@ int net_trickle_create(struct net_trickle *trickle,
 {
 	NET_ASSERT(trickle && Imax > 0 && k > 0 && !CHECK_IMIN(Imin));
 
-	memset(trickle, 0, sizeof(struct net_trickle));
+	(void)memset(trickle, 0, sizeof(struct net_trickle));
 
 	trickle->Imin = Imin;
 	trickle->Imax = Imax;

--- a/subsys/net/ip/utils.c
+++ b/subsys/net/ip/utils.c
@@ -275,7 +275,7 @@ int net_addr_pton(sa_family_t family, const char *src,
 			}
 		}
 
-		memset(addr, 0, sizeof(struct in_addr));
+		(void)memset(addr, 0, sizeof(struct in_addr));
 
 		for (i = 0; i < sizeof(struct in_addr); i++) {
 			char *endptr;
@@ -763,7 +763,7 @@ int net_bytes_from_str(u8_t *buf, int buf_len, const char *src)
 		}
 	}
 
-	memset(buf, 0, buf_len);
+	(void)memset(buf, 0, buf_len);
 
 	for (i = 0; i < buf_len; i++) {
 		buf[i] = strtol(src, &endptr, 16);

--- a/subsys/net/l2/ethernet/arp.c
+++ b/subsys/net/l2/ethernet/arp.c
@@ -47,8 +47,8 @@ static void arp_entry_cleanup(struct arp_entry *entry, bool pending)
 
 	entry->iface = NULL;
 
-	memset(&entry->ip, 0, sizeof(struct in_addr));
-	memset(&entry->eth, 0, sizeof(struct net_eth_addr));
+	(void)memset(&entry->ip, 0, sizeof(struct in_addr));
+	(void)memset(&entry->eth, 0, sizeof(struct net_eth_addr));
 }
 
 static struct arp_entry *arp_entry_find(sys_slist_t *list,
@@ -310,7 +310,7 @@ static inline struct net_pkt *arp_prepare(struct net_if *iface,
 		       sizeof(struct net_eth_addr));
 	}
 
-	memset(&eth->dst.addr, 0xff, sizeof(struct net_eth_addr));
+	(void)memset(&eth->dst.addr, 0xff, sizeof(struct net_eth_addr));
 
 	hdr->hwtype = htons(NET_ARP_HTYPE_ETH);
 	hdr->protocol = htons(NET_ETH_PTYPE_IP);
@@ -318,7 +318,7 @@ static inline struct net_pkt *arp_prepare(struct net_if *iface,
 	hdr->protolen = sizeof(struct in_addr);
 	hdr->opcode = htons(NET_ARP_REQUEST);
 
-	memset(&hdr->dst_hwaddr.addr, 0x00, sizeof(struct net_eth_addr));
+	(void)memset(&hdr->dst_hwaddr.addr, 0x00, sizeof(struct net_eth_addr));
 
 	net_ipaddr_copy(&hdr->dst_ipaddr, next_addr);
 
@@ -334,7 +334,7 @@ static inline struct net_pkt *arp_prepare(struct net_if *iface,
 	if (my_addr) {
 		net_ipaddr_copy(&hdr->src_ipaddr, my_addr);
 	} else {
-		memset(&hdr->src_ipaddr, 0, sizeof(struct in_addr));
+		(void)memset(&hdr->src_ipaddr, 0, sizeof(struct in_addr));
 	}
 
 	return pkt;

--- a/subsys/net/l2/ethernet/gptp/gptp.c
+++ b/subsys/net/l2/ethernet/gptp/gptp.c
@@ -367,7 +367,7 @@ static void gptp_init_clock_ds(void)
 	prop_ds = GPTP_PROPERTIES_DS();
 
 	/* Initialize global data set. */
-	memset(global_ds, 0, sizeof(struct gptp_global_ds));
+	(void)memset(global_ds, 0, sizeof(struct gptp_global_ds));
 
 	/* Initialize default data set. */
 
@@ -390,7 +390,7 @@ static void gptp_init_clock_ds(void)
 	default_ds->time_source = GPTP_TS_INTERNAL_OSCILLATOR;
 
 	/* Initialize current data set. */
-	memset(current_ds, 0, sizeof(struct gptp_current_ds));
+	(void)memset(current_ds, 0, sizeof(struct gptp_current_ds));
 
 	/* Initialize parent data set. */
 
@@ -488,7 +488,7 @@ static void gptp_init_port_ds(int port)
 
 #if defined(CONFIG_NET_GPTP_STATISTICS)
 	/* Initialize stats data set. */
-	memset(port_param_ds, 0, sizeof(struct gptp_port_param_ds));
+	(void)memset(port_param_ds, 0, sizeof(struct gptp_port_param_ds));
 #endif
 }
 

--- a/subsys/net/l2/ethernet/gptp/gptp_messages.c
+++ b/subsys/net/l2/ethernet/gptp/gptp_messages.c
@@ -220,7 +220,7 @@ struct net_pkt *gptp_prepare_sync(int port)
 	hdr->reserved2 = 0;
 
 	/* PTP configuration. */
-	memset(&sync->reserved, 0, sizeof(sync->reserved));
+	(void)memset(&sync->reserved, 0, sizeof(sync->reserved));
 
 	net_buf_add(frag, sizeof(struct gptp_hdr) + sizeof(struct gptp_sync));
 
@@ -358,8 +358,8 @@ struct net_pkt *gptp_prepare_pdelay_req(int port)
 	       port_ds->port_id.clk_id, GPTP_CLOCK_ID_LEN);
 
 	/* PTP configuration. */
-	memset(&req->reserved1, 0, sizeof(req->reserved1));
-	memset(&req->reserved2, 0, sizeof(req->reserved2));
+	(void)memset(&req->reserved1, 0, sizeof(req->reserved1));
+	(void)memset(&req->reserved2, 0, sizeof(req->reserved2));
 
 	net_buf_add(frag, sizeof(struct gptp_hdr) +
 		    sizeof(struct gptp_pdelay_req));
@@ -622,7 +622,7 @@ struct net_pkt *gptp_prepare_announce(int port)
 	ann->tlv.type = GPTP_ANNOUNCE_MSG_PATH_SEQ_TYPE;
 
 	/* Clear reserved fields. */
-	memset(ann->reserved1, 0, sizeof(ann->reserved1));
+	(void)memset(ann->reserved1, 0, sizeof(ann->reserved1));
 	ann->reserved2 = 0;
 
 	hdr->message_length = htons(sizeof(struct gptp_hdr) +

--- a/subsys/net/l2/ethernet/gptp/gptp_mi.c
+++ b/subsys/net/l2/ethernet/gptp/gptp_mi.c
@@ -115,7 +115,7 @@ static void gptp_mi_init_port_sync_sync_rcv_sm(int port)
 	struct gptp_pss_rcv_state *pss_rcv;
 
 	pss_rcv = &GPTP_PORT_STATE(port)->pss_rcv;
-	memset(pss_rcv, 0, sizeof(struct gptp_pss_rcv_state));
+	(void)memset(pss_rcv, 0, sizeof(struct gptp_pss_rcv_state));
 
 	k_timer_init(&pss_rcv->rcv_sync_receipt_timeout_timer,
 		     gptp_mi_rcv_sync_receipt_timeout, NULL);
@@ -128,7 +128,7 @@ static void gptp_mi_init_port_sync_sync_send_sm(int port)
 	struct gptp_pss_send_state *pss_send;
 
 	pss_send = &GPTP_PORT_STATE(port)->pss_send;
-	memset(pss_send, 0, sizeof(struct gptp_pss_send_state));
+	(void)memset(pss_send, 0, sizeof(struct gptp_pss_send_state));
 
 	k_timer_init(&pss_send->half_sync_itv_timer,
 		     gptp_mi_half_sync_itv_timeout, NULL);
@@ -143,7 +143,7 @@ static void gptp_mi_init_site_sync_sync_sm(void)
 	struct gptp_site_sync_sync_state *site_ss;
 
 	site_ss = &GPTP_STATE()->site_ss;
-	memset(site_ss, 0, sizeof(struct gptp_site_sync_sync_state));
+	(void)memset(site_ss, 0, sizeof(struct gptp_site_sync_sync_state));
 	site_ss->state = GPTP_SSS_INITIALIZING;
 }
 
@@ -152,7 +152,7 @@ static void gptp_mi_init_clock_slave_sync_sm(void)
 	struct gptp_clk_slave_sync_state *clk_ss;
 
 	clk_ss = &GPTP_STATE()->clk_slave_sync;
-	memset(clk_ss, 0, sizeof(struct gptp_clk_slave_sync_state));
+	(void)memset(clk_ss, 0, sizeof(struct gptp_clk_slave_sync_state));
 	clk_ss->state = GPTP_CLK_SLAVE_SYNC_INITIALIZING;
 }
 
@@ -161,7 +161,8 @@ static void gptp_mi_init_port_announce_rcv_sm(int port)
 	struct gptp_port_announce_receive_state *pa_rcv;
 
 	pa_rcv = &GPTP_PORT_STATE(port)->pa_rcv;
-	memset(pa_rcv, 0, sizeof(struct gptp_port_announce_receive_state));
+	(void)memset(pa_rcv, 0,
+		     sizeof(struct gptp_port_announce_receive_state));
 	pa_rcv->state = GPTP_PA_RCV_DISCARD;
 }
 
@@ -170,7 +171,7 @@ static void gptp_mi_init_clock_master_sync_rcv_sm(void)
 	struct gptp_clk_master_sync_state *cms_rcv;
 
 	cms_rcv = &GPTP_STATE()->clk_master_sync_receive;
-	memset(cms_rcv, 0, sizeof(struct gptp_clk_master_sync_state));
+	(void)memset(cms_rcv, 0, sizeof(struct gptp_clk_master_sync_state));
 	cms_rcv->state = GPTP_CMS_RCV_INITIALIZING;
 }
 
@@ -208,15 +209,15 @@ static void gptp_mi_init_bmca_data(int port)
 
 	bmca_data = GPTP_PORT_BMCA_DATA(port);
 
-	memset(bmca_data, 0, sizeof(struct gptp_port_bmca_data));
+	(void)memset(bmca_data, 0, sizeof(struct gptp_port_bmca_data));
 
 	gptp_set_time_itv(&bmca_data->announce_interval, 1,
 			  CONFIG_NET_GPTP_INIT_LOG_ANNOUNCE_ITV);
 
-	memset(&bmca_data->port_priority, 0xFF,
-	       sizeof(struct gptp_priority_vector));
-	memset(&bmca_data->master_priority, 0xFF,
-	       sizeof(struct gptp_priority_vector));
+	(void)memset(&bmca_data->port_priority, 0xFF,
+		     sizeof(struct gptp_priority_vector));
+	(void)memset(&bmca_data->master_priority, 0xFF,
+		     sizeof(struct gptp_priority_vector));
 }
 
 static void announce_periodic_timer_handler(struct k_timer *timer)
@@ -1195,8 +1196,8 @@ static void gptp_updt_role_disabled_tree(void)
 	}
 
 	/* Set lastGmPriority to all ones. */
-	memset(&global_ds->last_gm_priority, 0xFF,
-	       sizeof(struct gptp_priority_vector));
+	(void)memset(&global_ds->last_gm_priority, 0xFF,
+		     sizeof(struct gptp_priority_vector));
 
 	/* Set pathTrace array to contain the single element thisClock. */
 	global_ds->path_trace.len = htons(GPTP_CLOCK_ID_LEN);
@@ -1226,7 +1227,7 @@ static int compute_best_vector(void)
 	gm_prio = &global_ds->gm_priority;
 
 	/* Write systemPriority into grandmaster. */
-	memset(gm_prio, 0, sizeof(struct gptp_priority_vector));
+	(void)memset(gm_prio, 0, sizeof(struct gptp_priority_vector));
 	gm_prio->root_system_id.grand_master_prio1 = default_ds->priority1;
 	gm_prio->root_system_id.grand_master_prio2 = default_ds->priority2;
 	gm_prio->root_system_id.clk_quality.clock_class =

--- a/subsys/net/l2/ieee802154/ieee802154_security.c
+++ b/subsys/net/l2/ieee802154/ieee802154_security.c
@@ -176,8 +176,8 @@ int ieee802154_security_init(struct ieee802154_security_ctx *sec_ctx)
 {
 	struct device *dev;
 
-	memset(&sec_ctx->enc, 0, sizeof(struct cipher_ctx));
-	memset(&sec_ctx->dec, 0, sizeof(struct cipher_ctx));
+	(void)memset(&sec_ctx->enc, 0, sizeof(struct cipher_ctx));
+	(void)memset(&sec_ctx->dec, 0, sizeof(struct cipher_ctx));
 
 	dev = device_get_binding(
 		CONFIG_NET_L2_IEEE802154_SECURITY_CRYPTO_DEV_NAME);

--- a/subsys/net/l2/ieee802154/ieee802154_shell.c
+++ b/subsys/net/l2/ieee802154/ieee802154_shell.c
@@ -186,7 +186,7 @@ static int shell_cmd_scan(int argc, char *argv[])
 		return -EINVAL;
 	}
 
-	memset(&params, 0, sizeof(struct ieee802154_req_params));
+	(void)memset(&params, 0, sizeof(struct ieee802154_req_params));
 
 	net_mgmt_init_event_callback(&scan_cb, scan_result_cb,
 				     NET_EVENT_IEEE802154_SCAN_RESULT);

--- a/subsys/net/l2/openthread/openthread_utils.c
+++ b/subsys/net/l2/openthread/openthread_utils.c
@@ -95,7 +95,7 @@ void add_ipv6_addr_to_ot(struct openthread_context *context)
 	struct net_if_ipv6 *ipv6;
 	int i;
 
-	memset(&addr, 0, sizeof(addr));
+	(void)memset(&addr, 0, sizeof(addr));
 
 	if (net_if_config_ipv6_get(iface, &ipv6) < 0) {
 		NET_DBG("Cannot allocate IPv6 address");

--- a/subsys/net/lib/app/client.c
+++ b/subsys/net/lib/app/client.c
@@ -350,8 +350,8 @@ int net_app_init_client(struct net_app_ctx *ctx,
 		return -EALREADY;
 	}
 
-	memset(&addr, 0, sizeof(addr));
-	memset(&remote_addr, 0, sizeof(remote_addr));
+	(void)memset(&addr, 0, sizeof(addr));
+	(void)memset(&remote_addr, 0, sizeof(remote_addr));
 
 	if (peer_addr) {
 		memcpy(&remote_addr, peer_addr, sizeof(remote_addr));

--- a/subsys/net/lib/app/net_app.c
+++ b/subsys/net/lib/app/net_app.c
@@ -17,7 +17,7 @@
 #define  MBEDTLS_PRINT printf
 #else
 #include <misc/printk.h>
-#define  MBEDTLS_PRINT printk
+#define  MBEDTLS_PRINT (int(*)(const char *, ...)) printk
 #endif /* CONFIG_STDOUT_CONSOLE */
 #include <zephyr.h>
 #include <string.h>

--- a/subsys/net/lib/app/net_app.c
+++ b/subsys/net/lib/app/net_app.c
@@ -2031,7 +2031,8 @@ reset:
 	do {
 	again:
 		len = ctx->tls.request_buf_len - 1;
-		memset(ctx->tls.request_buf, 0, ctx->tls.request_buf_len);
+		(void)memset(ctx->tls.request_buf, 0,
+			     ctx->tls.request_buf_len);
 
 		ret = mbedtls_ssl_read(&ctx->tls.mbedtls.ssl,
 				       ctx->tls.request_buf, len);

--- a/subsys/net/lib/app/server.c
+++ b/subsys/net/lib/app/server.c
@@ -214,11 +214,11 @@ int net_app_init_server(struct net_app_ctx *ctx,
 	}
 
 #if defined(CONFIG_NET_IPV4)
-	memset(&ctx->ipv4.local, 0, sizeof(ctx->ipv4.local));
+	(void)memset(&ctx->ipv4.local, 0, sizeof(ctx->ipv4.local));
 	ctx->ipv4.local.sa_family = AF_INET;
 #endif
 #if defined(CONFIG_NET_IPV6)
-	memset(&ctx->ipv6.local, 0, sizeof(ctx->ipv6.local));
+	(void)memset(&ctx->ipv6.local, 0, sizeof(ctx->ipv6.local));
 	ctx->ipv6.local.sa_family = AF_INET6;
 #endif
 

--- a/subsys/net/lib/coap/coap.c
+++ b/subsys/net/lib/coap/coap.c
@@ -409,7 +409,7 @@ int coap_packet_init(struct coap_packet *cpkt, struct net_pkt *pkt,
 		return -EINVAL;
 	}
 
-	memset(cpkt, 0, sizeof(*cpkt));
+	(void)memset(cpkt, 0, sizeof(*cpkt));
 	cpkt->pkt = pkt;
 	cpkt->frag = pkt->frags;
 	cpkt->offset = 0;
@@ -440,7 +440,7 @@ int coap_pending_init(struct coap_pending *pending,
 		      const struct coap_packet *request,
 		      const struct sockaddr *addr)
 {
-	memset(pending, 0, sizeof(*pending));
+	(void)memset(pending, 0, sizeof(*pending));
 	pending->id = coap_header_get_id(request);
 	memcpy(&pending->addr, addr, sizeof(*addr));
 
@@ -803,7 +803,7 @@ void coap_reply_init(struct coap_reply *reply,
 
 void coap_reply_clear(struct coap_reply *reply)
 {
-	memset(reply, 0, sizeof(*reply));
+	(void)memset(reply, 0, sizeof(*reply));
 }
 
 int coap_resource_notify(struct coap_resource *resource)

--- a/subsys/net/lib/coap/coap_link_format.c
+++ b/subsys/net/lib/coap/coap_link_format.c
@@ -514,7 +514,7 @@ int coap_well_known_core_get(struct coap_resource *resource,
 end:
 	/* So it's a last block, reset context */
 	if (!more) {
-		memset(&ctx, 0, sizeof(ctx));
+		(void)memset(&ctx, 0, sizeof(ctx));
 	}
 
 	return r;

--- a/subsys/net/lib/dns/llmnr_responder.c
+++ b/subsys/net/lib/dns/llmnr_responder.c
@@ -507,7 +507,7 @@ static int dns_read(struct net_context *ctx,
 		enum dns_rr_type qtype;
 		enum dns_class qclass;
 
-		memset(result->data, 0, net_buf_tailroom(result));
+		(void)memset(result->data, 0, net_buf_tailroom(result));
 		result->len = 0;
 
 		ret = dns_unpack_query(&dns_msg, result, &qtype, &qclass);

--- a/subsys/net/lib/dns/mdns_responder.c
+++ b/subsys/net/lib/dns/mdns_responder.c
@@ -341,7 +341,7 @@ static int dns_read(struct net_context *ctx,
 		enum dns_class qclass;
 		u8_t *lquery;
 
-		memset(result->data, 0, net_buf_tailroom(result));
+		(void)memset(result->data, 0, net_buf_tailroom(result));
 		result->len = 0;
 
 		ret = dns_unpack_query(&dns_msg, result, &qtype, &qclass);

--- a/subsys/net/lib/dns/resolve.c
+++ b/subsys/net/lib/dns/resolve.c
@@ -208,13 +208,13 @@ int dns_resolve_init(struct dns_resolve_context *ctx, const char *servers[],
 		return -ENOTEMPTY;
 	}
 
-	memset(ctx, 0, sizeof(*ctx));
+	(void)memset(ctx, 0, sizeof(*ctx));
 
 	if (servers) {
 		for (i = 0; idx < SERVER_COUNT && servers[i]; i++) {
 			struct sockaddr *addr = &ctx->servers[idx].dns_server;
 
-			memset(addr, 0, sizeof(*addr));
+			(void)memset(addr, 0, sizeof(*addr));
 
 			ret = net_ipaddr_parse(servers[i], strlen(servers[i]),
 					       addr);

--- a/subsys/net/lib/http/http_client.c
+++ b/subsys/net/lib/http/http_client.c
@@ -45,8 +45,8 @@ int client_reset(struct http_ctx *ctx)
 {
 	http_parser_init(&ctx->http.parser, HTTP_RESPONSE);
 
-	memset(ctx->http.rsp.http_status, 0,
-	       sizeof(ctx->http.rsp.http_status));
+	(void)memset(ctx->http.rsp.http_status, 0,
+		     sizeof(ctx->http.rsp.http_status));
 
 	ctx->http.rsp.cl_present = 0;
 	ctx->http.rsp.content_length = 0;
@@ -55,7 +55,8 @@ int client_reset(struct http_ctx *ctx)
 	ctx->http.rsp.message_complete = 0;
 	ctx->http.rsp.body_start = NULL;
 
-	memset(ctx->http.rsp.response_buf, 0, ctx->http.rsp.response_buf_len);
+	(void)memset(ctx->http.rsp.response_buf, 0,
+		     ctx->http.rsp.response_buf_len);
 	ctx->http.rsp.data_len = 0;
 
 	return 0;
@@ -649,7 +650,7 @@ int http_client_init(struct http_ctx *ctx,
 {
 	int ret;
 
-	memset(ctx, 0, sizeof(*ctx));
+	(void)memset(ctx, 0, sizeof(*ctx));
 
 	ret = net_app_init_tcp_client(&ctx->app_ctx,
 				      NULL,         /* use any local address */

--- a/subsys/net/lib/http/http_parser.c
+++ b/subsys/net/lib/http/http_parser.c
@@ -2305,7 +2305,7 @@ void http_parser_init(struct http_parser *parser, enum http_parser_type t)
 {
 	void *data = parser->data; /* preserve application data */
 
-	memset(parser, 0, sizeof(*parser));
+	(void)memset(parser, 0, sizeof(*parser));
 	parser->data = data;
 	parser->type = t;
 	parser->state =
@@ -2316,7 +2316,7 @@ void http_parser_init(struct http_parser *parser, enum http_parser_type t)
 
 void http_parser_settings_init(struct http_parser_settings *settings)
 {
-	memset(settings, 0, sizeof(*settings));
+	(void)memset(settings, 0, sizeof(*settings));
 }
 
 const char *http_errno_name(enum http_errno err)

--- a/subsys/net/lib/http/http_parser_url.c
+++ b/subsys/net/lib/http/http_parser_url.c
@@ -462,7 +462,7 @@ int http_parse_host(const char *buf, struct http_parser_url *u,
 void
 http_parser_url_init(struct http_parser_url *u)
 {
-	memset(u, 0, sizeof(*u));
+	(void)memset(u, 0, sizeof(*u));
 }
 
 int

--- a/subsys/net/lib/http/http_server.c
+++ b/subsys/net/lib/http/http_server.c
@@ -977,7 +977,8 @@ static int on_headers_complete(struct http_parser *parser)
 
 static int init_http_parser(struct http_ctx *ctx)
 {
-	memset(ctx->http.field_values, 0, sizeof(ctx->http.field_values));
+	(void)memset(ctx->http.field_values, 0,
+		     sizeof(ctx->http.field_values));
 
 	ctx->http.parser_settings.on_header_field = on_header_field;
 	ctx->http.parser_settings.on_header_value = on_header_value;
@@ -1017,7 +1018,7 @@ static void init_net(struct http_ctx *ctx,
 		     struct sockaddr *server_addr,
 		     u16_t port)
 {
-	memset(&ctx->local, 0, sizeof(ctx->local));
+	(void)memset(&ctx->local, 0, sizeof(ctx->local));
 
 	if (server_addr) {
 		memcpy(&ctx->local, server_addr, sizeof(ctx->local));
@@ -1050,7 +1051,7 @@ int http_server_init(struct http_ctx *ctx,
 		return -EINVAL;
 	}
 
-	memset(ctx, 0, sizeof(*ctx));
+	(void)memset(ctx, 0, sizeof(*ctx));
 
 	init_net(ctx, server_addr, HTTP_DEFAULT_PORT);
 

--- a/subsys/net/lib/lwm2m/ipso_light_control.c
+++ b/subsys/net/lib/lwm2m/ipso_light_control.c
@@ -176,9 +176,9 @@ static int ipso_light_control_init(struct device *dev)
 	int ret = 0;
 
 	/* Set default values */
-	memset(inst, 0, sizeof(*inst) * MAX_INSTANCE_COUNT);
-	memset(res, 0, sizeof(struct lwm2m_engine_res_inst) *
-		       MAX_INSTANCE_COUNT * LIGHT_MAX_ID);
+	(void)memset(inst, 0, sizeof(*inst) * MAX_INSTANCE_COUNT);
+	(void)memset(res, 0, sizeof(struct lwm2m_engine_res_inst) *
+			MAX_INSTANCE_COUNT * LIGHT_MAX_ID);
 
 	light_control.obj_id = IPSO_OBJECT_LIGHT_CONTROL_ID;
 	light_control.fields = fields;

--- a/subsys/net/lib/lwm2m/ipso_temp_sensor.c
+++ b/subsys/net/lib/lwm2m/ipso_temp_sensor.c
@@ -203,9 +203,9 @@ static int ipso_temp_sensor_init(struct device *dev)
 	int ret = 0;
 
 	/* Set default values */
-	memset(inst, 0, sizeof(*inst) * MAX_INSTANCE_COUNT);
-	memset(res, 0, sizeof(struct lwm2m_engine_res_inst) *
-		       MAX_INSTANCE_COUNT * TEMP_MAX_ID);
+	(void)memset(inst, 0, sizeof(*inst) * MAX_INSTANCE_COUNT);
+	(void)memset(res, 0, sizeof(struct lwm2m_engine_res_inst) *
+			MAX_INSTANCE_COUNT * TEMP_MAX_ID);
 
 	temp_sensor.obj_id = IPSO_OBJECT_TEMP_SENSOR_ID;
 	temp_sensor.fields = fields;

--- a/subsys/net/lib/lwm2m/lwm2m_engine.c
+++ b/subsys/net/lib/lwm2m/lwm2m_engine.c
@@ -371,8 +371,8 @@ static void clear_attrs(void *ref)
 
 	for (i = 0; i < CONFIG_LWM2M_NUM_ATTR; i++) {
 		if (ref == write_attr_pool[i].ref) {
-			memset(&write_attr_pool[i], 0,
-			       sizeof(write_attr_pool[i]));
+			(void)memset(&write_attr_pool[i], 0,
+				     sizeof(write_attr_pool[i]));
 		}
 	}
 }
@@ -584,7 +584,7 @@ static int engine_remove_observer(const u8_t *token, u8_t tkl)
 	}
 
 	sys_slist_remove(&engine_observer_list, prev_node, &found_obj->node);
-	memset(found_obj, 0, sizeof(*found_obj));
+	(void)memset(found_obj, 0, sizeof(*found_obj));
 
 	SYS_LOG_DBG("observer '%s' removed", sprint_token(token, tkl));
 
@@ -606,7 +606,7 @@ static void engine_remove_observer_by_id(u16_t obj_id, s32_t obj_inst_id)
 		}
 
 		sys_slist_remove(&engine_observer_list, prev_node, &obs->node);
-		memset(obs, 0, sizeof(*obs));
+		(void)memset(obs, 0, sizeof(*obs));
 	}
 }
 
@@ -789,12 +789,12 @@ int lwm2m_delete_obj_inst(u16_t obj_id, u16_t obj_inst_id)
 	/* reset obj_inst and res_inst data structure */
 	for (i = 0; i < obj_inst->resource_count; i++) {
 		clear_attrs(&obj_inst->resources[i]);
-		memset(obj_inst->resources + i, 0,
-		       sizeof(struct lwm2m_engine_res_inst));
+		(void)memset(obj_inst->resources + i, 0,
+			     sizeof(struct lwm2m_engine_res_inst));
 	}
 
 	clear_attrs(obj_inst);
-	memset(obj_inst, 0, sizeof(struct lwm2m_engine_obj_inst));
+	(void)memset(obj_inst, 0, sizeof(struct lwm2m_engine_obj_inst));
 #ifdef CONFIG_LWM2M_RD_CLIENT_SUPPORT
 	engine_trigger_update();
 #endif
@@ -820,15 +820,17 @@ static int get_option_int(const struct coap_packet *cpkt, u8_t opt)
 static void engine_clear_context(struct lwm2m_engine_context *context)
 {
 	if (context->in) {
-		memset(context->in, 0, sizeof(struct lwm2m_input_context));
+		(void)memset(context->in, 0,
+			     sizeof(struct lwm2m_input_context));
 	}
 
 	if (context->out) {
-		memset(context->out, 0, sizeof(struct lwm2m_output_context));
+		(void)memset(context->out, 0,
+			     sizeof(struct lwm2m_output_context));
 	}
 
 	if (context->path) {
-		memset(context->path, 0, sizeof(struct lwm2m_obj_path));
+		(void)memset(context->path, 0, sizeof(struct lwm2m_obj_path));
 	}
 
 	context->operation = 0;
@@ -964,14 +966,14 @@ void lwm2m_reset_message(struct lwm2m_message *msg, bool release)
 	}
 
 	if (release) {
-		memset(msg, 0, sizeof(*msg));
+		(void)memset(msg, 0, sizeof(*msg));
 	} else {
 		if (msg->cpkt.pkt) {
 			net_pkt_unref(msg->cpkt.pkt);
 		}
 
 		msg->message_timeout_cb = NULL;
-		memset(&msg->cpkt, 0, sizeof(msg->cpkt));
+		(void)memset(&msg->cpkt, 0, sizeof(msg->cpkt));
 	}
 }
 
@@ -1244,7 +1246,7 @@ static int string_to_path(char *pathstr, struct lwm2m_obj_path *path,
 	int i, tokstart = -1, toklen;
 	int end_index = strlen(pathstr) - 1;
 
-	memset(path, 0, sizeof(*path));
+	(void)memset(path, 0, sizeof(*path));
 	for (i = 0; i <= end_index; i++) {
 		/* search for first numeric */
 		if (tokstart == -1) {
@@ -2428,9 +2430,9 @@ static int lwm2m_write_attr_handler(struct lwm2m_engine_obj *obj,
 		if (options[i].len == plen) {
 			nattrs.flags &= ~BIT(type);
 
-			memset(nattr_ptrs[type], 0,
-			       type <= LWM2M_ATTR_PMAX ?
-			       sizeof(s32_t) : sizeof(float32_value_t));
+			(void)memset(nattr_ptrs[type], 0,
+				     type <= LWM2M_ATTR_PMAX ? sizeof(s32_t) :
+				     sizeof(float32_value_t));
 			continue;
 		}
 
@@ -2515,7 +2517,7 @@ static int lwm2m_write_attr_handler(struct lwm2m_engine_obj *obj,
 
 		if (!(BIT(type) & nattrs.flags)) {
 			SYS_LOG_DBG("Unset attr %s", LWM2M_ATTR_STR[type]);
-			memset(attr, 0, sizeof(*attr));
+			(void)memset(attr, 0, sizeof(*attr));
 
 			if (type <= LWM2M_ATTR_PMAX) {
 				update_observe_node = true;
@@ -2657,7 +2659,7 @@ static int lwm2m_write_attr_handler(struct lwm2m_engine_obj *obj,
 			    nattrs.pmin, max(nattrs.pmin, nattrs.pmax));
 		obs->min_period_sec = (u32_t)nattrs.pmin;
 		obs->max_period_sec = (u32_t)max(nattrs.pmin, nattrs.pmax);
-		memset(&nattrs, 0, sizeof(nattrs));
+		(void)memset(&nattrs, 0, sizeof(nattrs));
 	}
 
 	return 0;
@@ -3146,7 +3148,7 @@ static int handle_request(struct coap_packet *request,
 	bool last_block = false;
 
 	/* setup engine context */
-	memset(&context, 0, sizeof(struct lwm2m_engine_context));
+	(void)memset(&context, 0, sizeof(struct lwm2m_engine_context));
 	context.in   = &in;
 	context.out  = &out;
 	context.path = &path;
@@ -3724,7 +3726,7 @@ static int generate_notify_message(struct observe_node *obs,
 	}
 
 	/* setup engine context */
-	memset(&context, 0, sizeof(struct lwm2m_engine_context));
+	(void)memset(&context, 0, sizeof(struct lwm2m_engine_context));
 	context.out = &out;
 	engine_clear_context(&context);
 	/* dont clear the path */
@@ -3967,7 +3969,7 @@ int lwm2m_engine_start(struct lwm2m_ctx *client_ctx,
 	/* TODO: use security object for initial setup */
 
 	/* setup the local client port */
-	memset(&client_addr, 0, sizeof(client_addr));
+	(void)memset(&client_addr, 0, sizeof(client_addr));
 #if defined(CONFIG_NET_IPV6)
 	client_addr.sa_family = AF_INET6;
 	net_sin6(&client_addr)->sin6_port = htons(CONFIG_LWM2M_LOCAL_PORT);
@@ -4032,8 +4034,8 @@ error_start:
 
 static int lwm2m_engine_init(struct device *dev)
 {
-	memset(block1_contexts, 0,
-	       sizeof(struct block_context) * NUM_BLOCK1_CONTEXT);
+	(void)memset(block1_contexts, 0,
+		     sizeof(struct block_context) * NUM_BLOCK1_CONTEXT);
 
 	/* start thread to handle OBSERVER / NOTIFY events */
 	k_thread_create(&engine_thread_data,

--- a/subsys/net/lib/lwm2m/lwm2m_obj_firmware_pull.c
+++ b/subsys/net/lib/lwm2m/lwm2m_obj_firmware_pull.c
@@ -483,7 +483,7 @@ static void firmware_transfer(struct k_work *work)
 	server_addr[off + len] = '\0';
 
 	/* setup the local firmware download client port */
-	memset(&client_addr, 0, sizeof(client_addr));
+	(void)memset(&client_addr, 0, sizeof(client_addr));
 #if defined(CONFIG_NET_IPV6)
 	client_addr.sa_family = AF_INET6;
 	net_sin6(&client_addr)->sin6_port =
@@ -560,7 +560,7 @@ int lwm2m_firmware_start_transfer(char *package_uri)
 		net_app_release(&firmware_ctx.net_app_ctx);
 	}
 
-	memset(&firmware_ctx, 0, sizeof(struct lwm2m_ctx));
+	(void)memset(&firmware_ctx, 0, sizeof(struct lwm2m_ctx));
 	firmware_retry = 0;
 	firmware_ctx.net_init_timeout = NETWORK_INIT_TIMEOUT;
 	firmware_ctx.net_timeout = NETWORK_CONNECT_TIMEOUT;

--- a/subsys/net/lib/lwm2m/lwm2m_obj_security.c
+++ b/subsys/net/lib/lwm2m/lwm2m_obj_security.c
@@ -117,9 +117,9 @@ static int lwm2m_security_init(struct device *dev)
 	int ret = 0;
 
 	/* Set default values */
-	memset(inst, 0, sizeof(*inst) * MAX_INSTANCE_COUNT);
-	memset(res, 0, sizeof(struct lwm2m_engine_res_inst) *
-		       MAX_INSTANCE_COUNT * SECURITY_MAX_ID);
+	(void)memset(inst, 0, sizeof(*inst) * MAX_INSTANCE_COUNT);
+	(void)memset(res, 0, sizeof(struct lwm2m_engine_res_inst) *
+			MAX_INSTANCE_COUNT * SECURITY_MAX_ID);
 
 	security.obj_id = LWM2M_OBJECT_SECURITY_ID;
 	security.fields = fields;

--- a/subsys/net/lib/lwm2m/lwm2m_obj_server.c
+++ b/subsys/net/lib/lwm2m/lwm2m_obj_server.c
@@ -161,9 +161,9 @@ static int lwm2m_server_init(struct device *dev)
 	int ret = 0;
 
 	/* Set default values */
-	memset(inst, 0, sizeof(*inst) * MAX_INSTANCE_COUNT);
-	memset(res, 0, sizeof(struct lwm2m_engine_res_inst) *
-		       MAX_INSTANCE_COUNT * SERVER_MAX_ID);
+	(void)memset(inst, 0, sizeof(*inst) * MAX_INSTANCE_COUNT);
+	(void)memset(res, 0, sizeof(struct lwm2m_engine_res_inst) *
+			MAX_INSTANCE_COUNT * SERVER_MAX_ID);
 
 	server.obj_id = LWM2M_OBJECT_SERVER_ID;
 	server.fields = fields;

--- a/subsys/net/lib/lwm2m/lwm2m_rw_json.c
+++ b/subsys/net/lib/lwm2m/lwm2m_rw_json.c
@@ -124,7 +124,7 @@ static int json_next_token(struct lwm2m_input_context *in,
 	u8_t c;
 	bool escape = false;
 
-	memset(json, 0, sizeof(struct json_data));
+	(void)memset(json, 0, sizeof(struct json_data));
 	cont = 1;
 
 	/* We will be either at start, or at a specific position */
@@ -527,7 +527,7 @@ int do_read_op_json(struct lwm2m_engine_obj *obj,
 	struct json_out_formatter_data fd;
 	int ret;
 
-	memset(&fd, 0, sizeof(fd));
+	(void)memset(&fd, 0, sizeof(fd));
 	engine_set_out_user_data(context->out, &fd);
 	/* save the level for output processing */
 	fd.path_level = context->path->level;

--- a/subsys/net/lib/lwm2m/lwm2m_rw_oma_tlv.c
+++ b/subsys/net/lib/lwm2m/lwm2m_rw_oma_tlv.c
@@ -816,7 +816,7 @@ int do_read_op_tlv(struct lwm2m_engine_obj *obj,
 	struct tlv_out_formatter_data fd;
 	int ret;
 
-	memset(&fd, 0, sizeof(fd));
+	(void)memset(&fd, 0, sizeof(fd));
 	engine_set_out_user_data(context->out, &fd);
 	ret = lwm2m_perform_read_op(obj, context, content_format);
 	engine_clear_out_user_data(context->out);

--- a/subsys/net/lib/mqtt/mqtt_pkt.c
+++ b/subsys/net/lib/mqtt/mqtt_pkt.c
@@ -455,7 +455,7 @@ int mqtt_unpack_connect(u8_t *buf, u16_t length,
 	u8_t offset;
 	int rc;
 
-	memset(msg, 0x00, sizeof(struct mqtt_connect_msg));
+	(void)memset(msg, 0x00, sizeof(struct mqtt_connect_msg));
 
 	/* MQTT CONNECT packet min size, assuming no payload:
 	 * packet type + min rem length size + var size len

--- a/subsys/net/lib/sntp/sntp.c
+++ b/subsys/net/lib/sntp/sntp.c
@@ -168,7 +168,7 @@ int sntp_init(struct sntp_ctx *ctx, const char *srv_addr, u16_t srv_port,
 		return -EFAULT;
 	}
 
-	memset(ctx, 0, sizeof(struct sntp_ctx));
+	(void)memset(ctx, 0, sizeof(struct sntp_ctx));
 
 	rv = net_app_init_udp_client(&ctx->net_app_ctx, NULL, NULL, srv_addr,
 				     srv_port, timeout, ctx);

--- a/subsys/net/lib/sockets/sockets_tls.c
+++ b/subsys/net/lib/sockets/sockets_tls.c
@@ -264,7 +264,7 @@ static int tls_init(struct device *unused)
 		 "TLS communication may be insecure!");
 #endif /* defined(CONFIG_ENTROPY_HAS_DRIVER) */
 
-	memset(tls_contexts, 0, sizeof(tls_contexts));
+	(void)memset(tls_contexts, 0, sizeof(tls_contexts));
 
 	k_mutex_init(&context_lock);
 
@@ -298,7 +298,7 @@ static struct tls_context *tls_alloc(void)
 	for (i = 0; i < ARRAY_SIZE(tls_contexts); i++) {
 		if (!tls_contexts[i].is_used) {
 			tls = &tls_contexts[i];
-			memset(tls, 0, sizeof(*tls));
+			(void)memset(tls, 0, sizeof(*tls));
 			tls->is_used = true;
 			tls->options.verify_level = -1;
 
@@ -746,8 +746,8 @@ static int tls_mbedtls_reset(struct net_context *context)
 
 	context->tls->tls_established = false;
 #if defined(CONFIG_NET_SOCKETS_ENABLE_DTLS)
-	memset(&context->tls->dtls_peer_addr, 0,
-	       sizeof(context->tls->dtls_peer_addr));
+	(void)memset(&context->tls->dtls_peer_addr, 0,
+		     sizeof(context->tls->dtls_peer_addr));
 	context->tls->dtls_peer_addrlen = 0;
 #endif
 

--- a/subsys/net/lib/tls_credentials/tls_credentials.c
+++ b/subsys/net/lib/tls_credentials/tls_credentials.c
@@ -18,7 +18,7 @@ static struct k_mutex credential_lock;
 
 static int credentials_init(struct device *unused)
 {
-	memset(credentials, 0, sizeof(credentials));
+	(void)memset(credentials, 0, sizeof(credentials));
 
 	k_mutex_init(&credential_lock);
 
@@ -157,7 +157,7 @@ int tls_credential_delete(sec_tag_t tag, enum tls_credential_type type)
 		goto exit;
 	}
 
-	memset(credential, 0, sizeof(struct tls_credential));
+	(void)memset(credential, 0, sizeof(struct tls_credential));
 	credential->type = TLS_CREDENTIAL_NONE;
 
 exit:

--- a/subsys/net/lib/websocket/websocket.c
+++ b/subsys/net/lib/websocket/websocket.c
@@ -84,7 +84,7 @@ int ws_send_msg(struct http_ctx *ctx, u8_t *payload, size_t payload_len,
 		return -EINVAL;
 	}
 
-	memset(header, 0, sizeof(header));
+	(void)memset(header, 0, sizeof(header));
 
 	/* Is this the last packet? */
 	header[0] = final ? BIT(7) : 0;

--- a/subsys/usb/class/mass_storage.c
+++ b/subsys/usb/class/mass_storage.c
@@ -179,9 +179,9 @@ static void msd_state_machine_reset(void)
 
 static void msd_init(void)
 {
-	memset((void *)&cbw, 0, sizeof(struct CBW));
-	memset((void *)&csw, 0, sizeof(struct CSW));
-	memset(page, 0, sizeof(page));
+	(void)memset((void *)&cbw, 0, sizeof(struct CBW));
+	(void)memset((void *)&csw, 0, sizeof(struct CSW));
+	(void)memset(page, 0, sizeof(page));
 	addr = 0;
 	length = 0;
 }

--- a/subsys/usb/class/netusb/function_rndis.c
+++ b/subsys/usb/class/netusb/function_rndis.c
@@ -454,7 +454,7 @@ static int rndis_init_handle(u8_t *data, u32_t len)
 							rndis_payload_packet));
 
 	rsp->pkt_align_factor = sys_cpu_to_le32(0);
-	memset(rsp->__reserved, 0, sizeof(rsp->__reserved));
+	(void)memset(rsp->__reserved, 0, sizeof(rsp->__reserved));
 
 	rndis.state = INITIALIZED;
 
@@ -925,7 +925,7 @@ static void rndis_hdr_add(u8_t *buf, u32_t len)
 	struct rndis_payload_packet *hdr = (void *)buf;
 	u32_t offset = offsetof(struct rndis_payload_packet, payload_offset);
 
-	memset(hdr, 0, sizeof(*hdr));
+	(void)memset(hdr, 0, sizeof(*hdr));
 
 	hdr->type = sys_cpu_to_le32(RNDIS_DATA_PACKET);
 	hdr->len = sys_cpu_to_le32(len + sizeof(*hdr));

--- a/tests/bluetooth/tester/src/bttester.c
+++ b/tests/bluetooth/tester/src/bttester.c
@@ -41,7 +41,7 @@ static void supported_commands(u8_t *data, u16_t len)
 	u8_t buf[1];
 	struct core_read_supported_commands_rp *rp = (void *) buf;
 
-	memset(buf, 0, sizeof(buf));
+	(void)memset(buf, 0, sizeof(buf));
 
 	tester_set_bit(buf, CORE_READ_SUPPORTED_COMMANDS);
 	tester_set_bit(buf, CORE_READ_SUPPORTED_SERVICES);
@@ -57,7 +57,7 @@ static void supported_services(u8_t *data, u16_t len)
 	u8_t buf[1];
 	struct core_read_supported_services_rp *rp = (void *) buf;
 
-	memset(buf, 0, sizeof(buf));
+	(void)memset(buf, 0, sizeof(buf));
 
 	tester_set_bit(buf, BTP_SERVICE_ID_CORE);
 	tester_set_bit(buf, BTP_SERVICE_ID_GAP);

--- a/tests/bluetooth/tester/src/gap.c
+++ b/tests/bluetooth/tester/src/gap.c
@@ -83,7 +83,7 @@ static void supported_commands(u8_t *data, u16_t len)
 	u8_t cmds[3];
 	struct gap_read_supported_commands_rp *rp = (void *) &cmds;
 
-	memset(cmds, 0, sizeof(cmds));
+	(void)memset(cmds, 0, sizeof(cmds));
 
 	tester_set_bit(cmds, GAP_READ_SUPPORTED_COMMANDS);
 	tester_set_bit(cmds, GAP_READ_CONTROLLER_INDEX_LIST);
@@ -124,7 +124,7 @@ static void controller_info(u8_t *data, u16_t len)
 	struct bt_le_oob oob;
 	u32_t supported_settings;
 
-	memset(&rp, 0, sizeof(rp));
+	(void)memset(&rp, 0, sizeof(rp));
 
 	bt_le_oob_get_local(BT_ID_DEFAULT, &oob);
 	memcpy(rp.address, &oob.addr.a, sizeof(bt_addr_t));
@@ -520,7 +520,7 @@ static void set_io_cap(const u8_t *data, u16_t len)
 	u8_t status;
 
 	/* Reset io cap requirements */
-	memset(&cb, 0, sizeof(cb));
+	(void)memset(&cb, 0, sizeof(cb));
 	bt_conn_auth_cb_register(NULL);
 
 	switch (cmd->io_cap) {

--- a/tests/bluetooth/tester/src/gatt.c
+++ b/tests/bluetooth/tester/src/gatt.c
@@ -83,7 +83,7 @@ static void *gatt_buf_add(const void *data, size_t len)
 	if (data) {
 		memcpy(ptr, data, len);
 	} else {
-		memset(ptr, 0, len);
+		(void)memset(ptr, 0, len);
 	}
 
 	gatt_buf.len += len;
@@ -100,7 +100,7 @@ static void *gatt_buf_reserve(size_t len)
 
 static void gatt_buf_clear(void)
 {
-	memset(&gatt_buf, 0, sizeof(gatt_buf));
+	(void)memset(&gatt_buf, 0, sizeof(gatt_buf));
 }
 
 union uuid {
@@ -175,7 +175,7 @@ static void supported_commands(u8_t *data, u16_t len)
 	u8_t cmds[4];
 	struct gatt_read_supported_commands_rp *rp = (void *) cmds;
 
-	memset(cmds, 0, sizeof(cmds));
+	(void)memset(cmds, 0, sizeof(cmds));
 
 	tester_set_bit(cmds, GATT_READ_SUPPORTED_COMMANDS);
 	tester_set_bit(cmds, GATT_ADD_SERVICE);
@@ -376,7 +376,7 @@ static int alloc_characteristic(struct add_characteristic *ch)
 		return -EINVAL;
 	}
 
-	memset(&value, 0, sizeof(value));
+	(void)memset(&value, 0, sizeof(value));
 
 	if (ch->permissions & GATT_PERM_READ_AUTHORIZATION) {
 		tester_set_bit(value.flags, GATT_VALUE_READ_AUTHOR_FLAG);
@@ -531,7 +531,7 @@ static int alloc_descriptor(const struct bt_gatt_attr *attr,
 	} else if (!bt_uuid_cmp(d->uuid, BT_UUID_GATT_CCC)) {
 		attr_desc = add_ccc(attr);
 	} else {
-		memset(&value, 0, sizeof(value));
+		(void)memset(&value, 0, sizeof(value));
 
 		if (d->permissions & GATT_PERM_READ_AUTHORIZATION) {
 			tester_set_bit(value.flags,
@@ -911,7 +911,7 @@ static u8_t btp_opcode;
 
 static void discover_destroy(struct bt_gatt_discover_params *params)
 {
-	memset(params, 0, sizeof(*params));
+	(void)memset(params, 0, sizeof(*params));
 	gatt_buf_clear();
 }
 
@@ -1296,7 +1296,7 @@ static struct bt_gatt_read_params read_params;
 
 static void read_destroy(struct bt_gatt_read_params *params)
 {
-	memset(params, 0, sizeof(*params));
+	(void)memset(params, 0, sizeof(*params));
 	gatt_buf_clear();
 }
 
@@ -1565,7 +1565,7 @@ static u8_t notify_func(struct bt_conn *conn,
 
 	if (!data) {
 		SYS_LOG_DBG("Unsubscribed");
-		memset(params, 0, sizeof(*params));
+		(void)memset(params, 0, sizeof(*params));
 		return BT_GATT_ITER_STOP;
 	}
 
@@ -1604,7 +1604,7 @@ fail:
 							    GATT_CFG_INDICATE;
 
 	if (status == BTP_STATUS_FAILED) {
-		memset(&subscribe_params, 0, sizeof(subscribe_params));
+		(void)memset(&subscribe_params, 0, sizeof(subscribe_params));
 	}
 
 	tester_rsp(BTP_SERVICE_ID_GATT, op, CONTROLLER_INDEX, status);

--- a/tests/bluetooth/tester/src/l2cap.c
+++ b/tests/bluetooth/tester/src/l2cap.c
@@ -80,7 +80,7 @@ static void disconnected_cb(struct bt_l2cap_chan *l2cap_chan)
 	struct channel *chan = CONTAINER_OF(l2cap_chan, struct channel, le);
 	struct bt_conn_info info;
 
-	memset(&ev, 0, sizeof(struct l2cap_disconnected_ev));
+	(void)memset(&ev, 0, sizeof(struct l2cap_disconnected_ev));
 
 	/* TODO: ev.result */
 	ev.chan_id = chan->chan_id;
@@ -308,7 +308,7 @@ static void supported_commands(u8_t *data, u16_t len)
 	u8_t cmds[1];
 	struct l2cap_read_supported_commands_rp *rp = (void *) cmds;
 
-	memset(cmds, 0, sizeof(cmds));
+	(void)memset(cmds, 0, sizeof(cmds));
 
 	tester_set_bit(cmds, L2CAP_READ_SUPPORTED_COMMANDS);
 	tester_set_bit(cmds, L2CAP_CONNECT);

--- a/tests/bluetooth/tester/src/mesh.c
+++ b/tests/bluetooth/tester/src/mesh.c
@@ -65,7 +65,7 @@ static void supported_commands(u8_t *data, u16_t len)
 	net_buf_simple_init(buf, 0);
 
 	/* 1st octet */
-	memset(net_buf_simple_add(buf, 1), 0, 1);
+	(void)memset(net_buf_simple_add(buf, 1), 0, 1);
 	tester_set_bit(buf->data, MESH_READ_SUPPORTED_COMMANDS);
 	tester_set_bit(buf->data, MESH_CONFIG_PROVISIONING);
 	tester_set_bit(buf->data, MESH_PROVISION_NODE);
@@ -83,7 +83,7 @@ static void supported_commands(u8_t *data, u16_t len)
 	tester_set_bit(buf->data, MESH_LPN_POLL);
 	tester_set_bit(buf->data, MESH_MODEL_SEND);
 	/* 3rd octet */
-	memset(net_buf_simple_add(buf, 1), 0, 1);
+	(void)memset(net_buf_simple_add(buf, 1), 0, 1);
 #if defined(CONFIG_BT_TESTING)
 	tester_set_bit(buf->data, MESH_LPN_SUBSCRIBE);
 	tester_set_bit(buf->data, MESH_LPN_UNSUBSCRIBE);
@@ -164,7 +164,7 @@ static int fault_clear(struct bt_mesh_model *model, uint16_t company_id)
 		return -EINVAL;
 	}
 
-	memset(reg_faults, 0, sizeof(reg_faults));
+	(void)memset(reg_faults, 0, sizeof(reg_faults));
 
 	return 0;
 }
@@ -627,8 +627,8 @@ static void health_clear_faults(u8_t *data, u16_t len)
 {
 	SYS_LOG_DBG("");
 
-	memset(cur_faults, 0, sizeof(cur_faults));
-	memset(reg_faults, 0, sizeof(reg_faults));
+	(void)memset(cur_faults, 0, sizeof(cur_faults));
+	(void)memset(reg_faults, 0, sizeof(reg_faults));
 
 	bt_mesh_fault_update(&elements[0]);
 

--- a/tests/boards/intel_s1000_crb/src/dma_test.c
+++ b/tests/boards/intel_s1000_crb/src/dma_test.c
@@ -127,10 +127,10 @@ static int test_task(u32_t chan_id, u32_t blen, u32_t block_count)
 	printk("Preparing DMA Controller: Chan_ID=%u, BURST_LEN=%u\n",
 			chan_id, blen);
 
-	memset(rx_data, 0, sizeof(rx_data));
-	memset(rx_data2, 0, sizeof(rx_data2));
-	memset(rx_data3, 0, sizeof(rx_data3));
-	memset(rx_data4, 0, sizeof(rx_data4));
+	(void)memset(rx_data, 0, sizeof(rx_data));
+	(void)memset(rx_data2, 0, sizeof(rx_data2));
+	(void)memset(rx_data3, 0, sizeof(rx_data3));
+	(void)memset(rx_data4, 0, sizeof(rx_data4));
 
 	dma_block_cfg.next_block = &dma_block_cfg2;
 	dma_block_cfg2.next_block = &dma_block_cfg3;

--- a/tests/crypto/mbedtls/src/mbedtls.c
+++ b/tests/crypto/mbedtls/src/mbedtls.c
@@ -178,7 +178,7 @@ void test_mbedtls(void)
  * of a NULL pointer. We do however use that in our code for initializing
  * structures, which should work on every modern platform. Let's be sure.
  */
-	memset(&pointer, 0, sizeof(void *));
+	(void)memset(&pointer, 0, sizeof(void *));
 	if (pointer != NULL) {
 		mbedtls_printf("all-bits-zero is not a NULL pointer\n");
 		mbedtls_exit(MBEDTLS_EXIT_FAILURE);

--- a/tests/crypto/mbedtls/src/mbedtls.c
+++ b/tests/crypto/mbedtls/src/mbedtls.c
@@ -12,7 +12,7 @@
 #define  MBEDTLS_PRINT printf
 #else
 #include <misc/printk.h>
-#define  MBEDTLS_PRINT printk
+#define  MBEDTLS_PRINT (int(*)(const char *, ...)) printk
 #endif /* CONFIG_STDOUT_CONSOLE */
 
 #include <string.h>

--- a/tests/crypto/tinycrypt/src/ctr_prng.c
+++ b/tests/crypto/tinycrypt/src/ctr_prng.c
@@ -379,7 +379,7 @@ void test_ctr_prng_reseed(void)
 	 * make entropy different from original value - not really important
 	 * for the purpose of this test
 	 */
-	memset(entropy, 0xFF, sizeof(entropy));
+	(void)memset(entropy, 0xFF, sizeof(entropy));
 	rc = tc_ctr_prng_reseed(&ctx, entropy, sizeof(entropy), extra_input,
 				sizeof(extra_input));
 
@@ -394,7 +394,7 @@ void test_ctr_prng_reseed(void)
 	/* confirm entropy and additional_input are being used correctly
 	 * first, entropy only
 	 */
-	memset(&ctx, 0x0, sizeof(ctx));
+	(void)memset(&ctx, 0x0, sizeof(ctx));
 	for (i = 0; i < sizeof(entropy); i++) {
 		entropy[i] = i;
 	}
@@ -409,7 +409,7 @@ void test_ctr_prng_reseed(void)
 	"expected value different - check failed");
 
 	/* now, entropy and additional_input */
-	memset(&ctx, 0x00, sizeof(ctx));
+	(void)memset(&ctx, 0x00, sizeof(ctx));
 	for (i = 0; i < sizeof(extra_input); i++) {
 		extra_input[i] = i * 2;
 	}

--- a/tests/crypto/tinycrypt/src/ecc_dsa.c
+++ b/tests/crypto/tinycrypt/src/ecc_dsa.c
@@ -104,7 +104,7 @@ int sign_vectors(TCSha256State_t hash, char **d_vec, char **k_vec,
 		uECC_vli_nativeToBytes(private_bytes, NUM_ECC_BYTES, private);
 
 		/* validate ECDSA: hash message, sign digest, check r+s */
-		memset(k, 0, NUM_ECC_BYTES);
+		(void)memset(k, 0, NUM_ECC_BYTES);
 		string2scalar(k, NUM_ECC_WORDS, k_vec[i]);
 		string2scalar(exp_r, NUM_ECC_WORDS, r_vec[i]);
 		string2scalar(exp_s, NUM_ECC_WORDS, s_vec[i]);
@@ -125,7 +125,7 @@ int sign_vectors(TCSha256State_t hash, char **d_vec, char **k_vec,
 			hash_dwords = NUM_ECC_WORDS;
 		}
 
-		memset(digest, 0, NUM_ECC_BYTES - 4 * hash_dwords);
+		(void)memset(digest, 0, NUM_ECC_BYTES - 4 * hash_dwords);
 		uECC_vli_bytesToNative(digest + (NUM_ECC_WORDS - hash_dwords),
 				       digest_bytes, TC_SHA256_DIGEST_SIZE);
 
@@ -382,7 +382,7 @@ int vrfy_vectors(TCSha256State_t hash, char **msg_vec, char **qx_vec, char **qy_
 			hash_dwords = NUM_ECC_WORDS;
 		}
 
-		memset(digest, 0, NUM_ECC_BYTES - 4 * hash_dwords);
+		(void)memset(digest, 0, NUM_ECC_BYTES - 4 * hash_dwords);
 		uECC_vli_bytesToNative(digest + (NUM_ECC_WORDS - hash_dwords), digest_bytes,
 				       TC_SHA256_DIGEST_SIZE);
 

--- a/tests/crypto/tinycrypt/src/test_ecc_utils.c
+++ b/tests/crypto/tinycrypt/src/test_ecc_utils.c
@@ -142,7 +142,7 @@ void string2scalar(unsigned int *scalar, unsigned int num_word32, char *str)
 		k_panic();
 	}
 
-	memset(tmp, 0, padding / 2);
+	(void)memset(tmp, 0, padding / 2);
 
 	if (false == hex2bin(tmp + padding / 2, num_bytes, str, hexlen)) {
 		k_panic();
@@ -238,7 +238,7 @@ int keygen_vectors(char **d_vec, char **qx_vec, char **qy_vec, int tests,
 		 * Feed prvkey vector as padded random seed into ecc_make_key.
 		 * Internal mod-reduction will be zero-op and generate correct prv/pub
 		 */
-		memset(d, 0, sizeof(d));
+		(void)memset(d, 0, sizeof(d));
 		string2scalar(d, NUM_ECC_WORDS, d_vec[i]);
 
 		uint8_t pub_bytes[2 * NUM_ECC_BYTES];

--- a/tests/drivers/adc/adc_api/src/test_adc.c
+++ b/tests/drivers/adc/adc_api/src/test_adc.c
@@ -168,7 +168,7 @@ static struct device *init_adc(void)
 		"Setting up of the second channel failed with code %d", ret);
 #endif /* defined(ADC_2ND_CHANNEL_ID) */
 
-	memset(m_sample_buffer, 0, sizeof(m_sample_buffer));
+	(void)memset(m_sample_buffer, 0, sizeof(m_sample_buffer));
 
 	return adc_dev;
 }

--- a/tests/drivers/dma/chan_blen_transfer/src/test_dma.c
+++ b/tests/drivers/dma/chan_blen_transfer/src/test_dma.c
@@ -64,7 +64,7 @@ static int test_task(u32_t chan_id, u32_t blen)
 			chan_id, blen >> 3);
 
 	TC_PRINT("Starting the transfer\n");
-	memset(rx_data, 0, sizeof(rx_data));
+	(void)memset(rx_data, 0, sizeof(rx_data));
 	dma_block_cfg.block_size = sizeof(tx_data);
 	dma_block_cfg.source_address = (u32_t)tx_data;
 	dma_block_cfg.dest_address = (u32_t)rx_data;

--- a/tests/drivers/entropy/api/src/main.c
+++ b/tests/drivers/entropy/api/src/main.c
@@ -29,7 +29,7 @@ static int random_entropy(struct device *dev, char *buffer, char num)
 	int ret, i;
 	int count = 0;
 
-	memset(buffer, num, BUFFER_LENGTH);
+	(void)memset(buffer, num, BUFFER_LENGTH);
 
 	/* The BUFFER_LENGTH-1 is used so the driver will not
 	 * write the last byte of the buffer. If that last

--- a/tests/drivers/i2c/i2c_api/src/test_i2c.c
+++ b/tests/drivers/i2c/i2c_api/src/test_i2c.c
@@ -64,7 +64,7 @@ static int test_gy271(void)
 		return TC_FAIL;
 	}
 
-	memset(datas, 0, sizeof(datas));
+	(void)memset(datas, 0, sizeof(datas));
 
 	/* 3. verify i2c_read() */
 	if (i2c_read(i2c_dev, datas, 6, 0x1E)) {
@@ -108,7 +108,7 @@ static int test_burst_gy271(void)
 
 	k_sleep(1);
 
-	memset(datas, 0, sizeof(datas));
+	(void)memset(datas, 0, sizeof(datas));
 
 	/* 3. verify i2c_burst_read() */
 	if (i2c_burst_read(i2c_dev, 0x1E, 0x03, datas, 6)) {

--- a/tests/drivers/i2c/i2c_slave_api/src/main.c
+++ b/tests/drivers/i2c/i2c_slave_api/src/main.c
@@ -109,7 +109,7 @@ static void run_program_read(struct device *i2c, u8_t addr, unsigned int offset)
 			      offset, i2c_buffer, TEST_DATA_SIZE-offset);
 	zassert_equal(ret, 0, "Failed to write EEPROM");
 
-	memset(i2c_buffer, 0xFF, TEST_DATA_SIZE);
+	(void)memset(i2c_buffer, 0xFF, TEST_DATA_SIZE);
 
 	/* Read back EEPROM from I2C Master requests, then compare */
 	ret = i2c_burst_read(i2c, addr,

--- a/tests/drivers/spi/spi_loopback/src/spi.c
+++ b/tests/drivers/spi/spi_loopback/src/spi.c
@@ -159,7 +159,7 @@ static int spi_rx_half_start(struct device *dev, struct spi_config *spi_conf)
 
 	SYS_LOG_INF("Start");
 
-	memset(buffer_rx, 0, BUF_SIZE);
+	(void)memset(buffer_rx, 0, BUF_SIZE);
 
 	ret = spi_transceive(dev, spi_conf, &tx, &rx);
 	if (ret) {
@@ -214,7 +214,7 @@ static int spi_rx_half_end(struct device *dev, struct spi_config *spi_conf)
 
 	SYS_LOG_INF("Start");
 
-	memset(buffer_rx, 0, BUF_SIZE);
+	(void)memset(buffer_rx, 0, BUF_SIZE);
 
 	ret = spi_transceive(dev, spi_conf, &tx, &rx);
 	if (ret) {
@@ -277,7 +277,7 @@ static int spi_rx_every_4(struct device *dev, struct spi_config *spi_conf)
 
 	SYS_LOG_INF("Start");
 
-	memset(buffer_rx, 0, BUF_SIZE);
+	(void)memset(buffer_rx, 0, BUF_SIZE);
 
 	ret = spi_transceive(dev, spi_conf, &tx, &rx);
 	if (ret) {

--- a/tests/kernel/common/src/printk.c
+++ b/tests/kernel/common/src/printk.c
@@ -93,7 +93,7 @@ void test_printk(void)
 	ram_console[pos] = '\0';
 	zassert_true((strcmp(ram_console, expected) == 0), "printk failed");
 
-	memset(ram_console, 0, sizeof(ram_console));
+	(void)memset(ram_console, 0, sizeof(ram_console));
 	count = 0;
 
 	count += snprintk(ram_console + count, sizeof(ram_console) - count,

--- a/tests/kernel/fatal/src/main.c
+++ b/tests/kernel/fatal/src/main.c
@@ -119,7 +119,7 @@ void blow_up_stack(void)
 	char buf[OVERFLOW_STACKSIZE];
 
 	TC_PRINT("posting %zu bytes of junk to stack...\n", sizeof(buf));
-	memset(buf, 0xbb, sizeof(buf));
+	(void)memset(buf, 0xbb, sizeof(buf));
 }
 
 void stack_thread1(void)

--- a/tests/kernel/fp_sharing/src/main.c
+++ b/tests/kernel/fp_sharing/src/main.c
@@ -155,7 +155,7 @@ void load_store_low(void)
 		 * floating point values that have been saved.
 		 */
 
-		memset(&float_reg_set_store, 0, SIZEOF_FP_REGISTER_SET);
+		(void)memset(&float_reg_set_store, 0, SIZEOF_FP_REGISTER_SET);
 
 		/*
 		 * Utilize an architecture specific function to load all the

--- a/tests/kernel/mbox/mbox_usage/src/main.c
+++ b/tests/kernel/mbox/mbox_usage/src/main.c
@@ -32,7 +32,7 @@ static void msg_sender(struct k_mbox *pmbox, s32_t timeout)
 {
 	struct k_mbox_msg mmsg;
 
-	memset(&mmsg, 0, sizeof(mmsg));
+	(void)memset(&mmsg, 0, sizeof(mmsg));
 
 	switch (info_type) {
 	case PUT_GET_NULL:

--- a/tests/kernel/mem_pool/mem_pool_threadsafe/src/main.c
+++ b/tests/kernel/mem_pool/mem_pool_threadsafe/src/main.c
@@ -31,7 +31,7 @@ static void tmpool_api(void *p1, void *p2, void *p3)
 	int ret[BLK_NUM_MIN];
 	struct k_mem_pool *pool = pools[atomic_inc(&pool_id) % POOL_NUM];
 
-	memset(block, 0, sizeof(block));
+	(void)memset(block, 0, sizeof(block));
 
 	for (int i = 0; i < 4; i++) {
 		ret[i] = k_mem_pool_alloc(pool, &block[i], BLK_SIZE_MIN,

--- a/tests/kernel/mem_slab/mslab/src/main.c
+++ b/tests/kernel/mem_slab/mslab/src/main.c
@@ -61,7 +61,7 @@ void helper_thread(void)
 {
 	void *ptr[NUMBLOCKS];           /* Pointer to memory block */
 
-	memset(ptr, 0, sizeof(ptr));    /* keep static checkers happy */
+	(void)memset(ptr, 0, sizeof(ptr));    /* keep static checkers happy */
 	/* Wait for part 1 to complete */
 	k_sem_take(&SEM_REGRESSDONE, K_FOREVER);
 
@@ -215,7 +215,7 @@ void test_mslab(void)
 	void *ptr[NUMBLOCKS];           /* Pointer to memory block */
 
 	/* not strictly necessary, but keeps coverity checks happy */
-	memset(ptr, 0, sizeof(ptr));
+	(void)memset(ptr, 0, sizeof(ptr));
 
 	/* Part 1 of test */
 

--- a/tests/kernel/mem_slab/mslab_api/src/test_mslab_api.c
+++ b/tests/kernel/mem_slab/mslab_api/src/test_mslab_api.c
@@ -17,7 +17,7 @@ void tmslab_alloc_free(void *data)
 	struct k_mem_slab *pslab = (struct k_mem_slab *)data;
 	void *block[BLK_NUM];
 
-	memset(block, 0, sizeof(block));
+	(void)memset(block, 0, sizeof(block));
 	/**
 	 * TESTPOINT: The memory slab's buffer contains @a slab_num_blocks
 	 * memory blocks that are @a slab_block_size bytes long.

--- a/tests/kernel/mem_slab/mslab_threadsafe/src/test_mslab_threadsafe.c
+++ b/tests/kernel/mem_slab/mslab_threadsafe/src/test_mslab_threadsafe.c
@@ -43,7 +43,7 @@ static void tmslab_api(void *p1, void *p2, void *p3)
 	int i = LOOP, ret;
 
 	while (i--) {
-		memset(block, 0, sizeof(block));
+		(void)memset(block, 0, sizeof(block));
 
 		for (int i = 0; i < BLK_NUM; i++) {
 			ret = k_mem_slab_alloc(slab, &block[i], TIMEOUT);

--- a/tests/kernel/pipe/pipe/src/test_pipe.c
+++ b/tests/kernel/pipe/pipe/src/test_pipe.c
@@ -180,7 +180,7 @@ void pipe_get_single(void *p1, void *p2, void *p3)
 		k_sem_take(&get_sem, K_FOREVER);
 
 		/* reset the rx buffer for the next interation */
-		memset(rx_buffer, 0, sizeof(rx_buffer));
+		(void)memset(rx_buffer, 0, sizeof(rx_buffer));
 
 		min_xfer = (single_elements[index].min_size == ALL_BYTES ?
 			    single_elements[index].size :
@@ -258,7 +258,7 @@ void pipe_get_multiple(void *p1, void *p2, void *p3)
 
 
 		/* reset the rx buffer for the next interation */
-		memset(rx_buffer, 0, sizeof(rx_buffer));
+		(void)memset(rx_buffer, 0, sizeof(rx_buffer));
 
 		min_xfer = (multiple_elements[index].min_size == ALL_BYTES ?
 			    multiple_elements[index].size :

--- a/tests/lib/c_lib/src/main.c
+++ b/tests/lib/c_lib/src/main.c
@@ -123,7 +123,7 @@ char buffer[BUFSIZE];
 
 void test_memset(void)
 {
-	memset(buffer, 'a', BUFSIZE);
+	(void)memset(buffer, 'a', BUFSIZE);
 	zassert_true((buffer[0] == 'a'), "memset");
 	zassert_true((buffer[BUFSIZE - 1] == 'a'), "memset");
 }
@@ -136,8 +136,8 @@ void test_memset(void)
 
 void test_strlen(void)
 {
-	memset(buffer, '\0', BUFSIZE);
-	memset(buffer, 'b', 5); /* 5 is BUFSIZE / 2 */
+	(void)memset(buffer, '\0', BUFSIZE);
+	(void)memset(buffer, 'b', 5); /* 5 is BUFSIZE / 2 */
 	zassert_equal(strlen(buffer), 5, "strlen");
 }
 
@@ -185,7 +185,7 @@ void test_strncmp(void)
 
 void test_strcpy(void)
 {
-	memset(buffer, '\0', BUFSIZE);
+	(void)memset(buffer, '\0', BUFSIZE);
 	strcpy(buffer, "10 chars!\0");
 
 	zassert_true((strcmp(buffer, "10 chars!\0") == 0), "strcpy");
@@ -201,7 +201,7 @@ void test_strncpy(void)
 {
 	int ret;
 
-	memset(buffer, '\0', BUFSIZE);
+	(void)memset(buffer, '\0', BUFSIZE);
 	strncpy(buffer, "This is over 10 characters", BUFSIZE);
 
 	/* Purposely different values */
@@ -221,7 +221,7 @@ void test_strchr(void)
 	char *rs = NULL;
 	int ret;
 
-	memset(buffer, '\0', BUFSIZE);
+	(void)memset(buffer, '\0', BUFSIZE);
 	strncpy(buffer, "Copy 10", BUFSIZE);
 
 	rs = strchr(buffer, '1');

--- a/tests/lib/mem_alloc/src/main.c
+++ b/tests/lib/mem_alloc/src/main.c
@@ -95,7 +95,7 @@ void test_realloc(void)
 	ptr = malloc(orig_size);
 
 	zassert_not_null((ptr), "malloc failed, errno: %d", errno);
-	memset(ptr, 'p', orig_size);
+	(void)memset(ptr, 'p', orig_size);
 
 	reloc_ptr = realloc(ptr, new_size);
 
@@ -103,7 +103,7 @@ void test_realloc(void)
 	zassert_not_null((ptr), "malloc/realloc failed, errno: %d", errno);
 	ptr = reloc_ptr;
 
-	memset(filled_buf, 'p', BUF_LEN);
+	(void)memset(filled_buf, 'p', BUF_LEN);
 	zassert_true(((memcmp(ptr, filled_buf, BUF_LEN)) == 0),
 			"realloc failed to copy malloc data, errno: %d", errno);
 
@@ -131,7 +131,7 @@ void test_reallocarray(void)
 	ptr = malloc(orig_size);
 
 	zassert_not_null((ptr), "malloc failed, errno: %d", errno);
-	memset(ptr, 'p', orig_size);
+	(void)memset(ptr, 'p', orig_size);
 
 	char *reloc_ptr = reallocarray(ptr, 2, orig_size);
 
@@ -139,7 +139,7 @@ void test_reallocarray(void)
 	zassert_not_null((ptr), "malloc/reallocarray failed, errno: %d", errno);
 	ptr = reloc_ptr;
 
-	memset(filled_buf, 'p', BUF_LEN);
+	(void)memset(filled_buf, 'p', BUF_LEN);
 	zassert_true(((memcmp(ptr, filled_buf, BUF_LEN)) == 0),
 			"realloc failed to copy malloc data, errno: %d", errno);
 

--- a/tests/lib/rbtree/src/main.c
+++ b/tests/lib/rbtree/src/main.c
@@ -137,7 +137,7 @@ void _check_tree(int size, int use_foreach)
 	int nwalked = 0, i, ni;
 	struct rbnode *n, *last = NULL;
 
-	memset(walked_nodes, 0, sizeof(walked_nodes));
+	(void)memset(walked_nodes, 0, sizeof(walked_nodes));
 
 	if (use_foreach) {
 		RB_FOR_EACH(&tree, n) {
@@ -200,10 +200,10 @@ void test_tree(int size)
 	/* Small trees get checked after every op, big trees less often */
 	int small_tree = size <= 32;
 
-	memset(&tree, 0, sizeof(tree));
+	(void)memset(&tree, 0, sizeof(tree));
 	tree.lessthan_fn = node_lessthan;
-	memset(nodes, 0, sizeof(nodes));
-	memset(node_mask, 0, sizeof(node_mask));
+	(void)memset(nodes, 0, sizeof(nodes));
+	(void)memset(node_mask, 0, sizeof(node_mask));
 
 	for (j = 0; j < 10; j++) {
 		for (i = 0; i < size; i++) {

--- a/tests/net/arp/src/main.c
+++ b/tests/net/arp/src/main.c
@@ -192,7 +192,7 @@ static inline struct net_pkt *prepare_arp_reply(struct net_if *iface,
 
 	eth->type = htons(NET_ETH_PTYPE_ARP);
 
-	memset(&eth->dst.addr, 0xff, sizeof(struct net_eth_addr));
+	(void)memset(&eth->dst.addr, 0xff, sizeof(struct net_eth_addr));
 	memcpy(&eth->src.addr, net_if_get_link_addr(iface)->addr,
 	       sizeof(struct net_eth_addr));
 
@@ -249,7 +249,7 @@ static inline struct net_pkt *prepare_arp_request(struct net_if *iface,
 
 	eth->type = htons(NET_ETH_PTYPE_ARP);
 
-	memset(&eth->dst.addr, 0xff, sizeof(struct net_eth_addr));
+	(void)memset(&eth->dst.addr, 0xff, sizeof(struct net_eth_addr));
 	memcpy(&eth->src.addr, addr, sizeof(struct net_eth_addr));
 
 	hdr->hwtype = htons(NET_ARP_HTYPE_ETH);
@@ -258,7 +258,7 @@ static inline struct net_pkt *prepare_arp_request(struct net_if *iface,
 	hdr->protolen = sizeof(struct in_addr);
 	hdr->opcode = htons(NET_ARP_REQUEST);
 
-	memset(&hdr->dst_hwaddr.addr, 0x00, sizeof(struct net_eth_addr));
+	(void)memset(&hdr->dst_hwaddr.addr, 0x00, sizeof(struct net_eth_addr));
 	memcpy(&hdr->src_hwaddr.addr, addr, sizeof(struct net_eth_addr));
 
 	net_ipaddr_copy(&hdr->src_ipaddr, &req_hdr->src_ipaddr);

--- a/tests/net/dhcpv4/src/main.c
+++ b/tests/net/dhcpv4/src/main.c
@@ -235,7 +235,7 @@ static void set_ipv4_header(struct net_pkt *pkt)
 
 	ipv4->len = htons(length);
 
-	memset(ipv4->id, 0, 4); /* id and offset */
+	(void)memset(ipv4->id, 0, 4); /* id and offset */
 
 	ipv4->ttl = 0xFF;
 	ipv4->proto = IPPROTO_UDP;
@@ -466,7 +466,7 @@ static int tester_send(struct net_if *iface, struct net_pkt *pkt)
 	struct net_pkt *rpkt;
 	struct dhcp_msg msg;
 
-	memset(&msg, 0, sizeof(msg));
+	(void)memset(&msg, 0, sizeof(msg));
 
 	if (!pkt->frags) {
 		TC_PRINT("No data to send!\n");

--- a/tests/net/ipv6/src/main.c
+++ b/tests/net/ipv6/src/main.c
@@ -363,7 +363,7 @@ static void test_cmp_prefix(void)
 	zassert_true(st, "Prefix /65 compare failed");
 
 	/* Set all remaining bits in prefix2, it is now /128 */
-	memset(&prefix2.s6_addr[8], 0xff, 8);
+	(void)memset(&prefix2.s6_addr[8], 0xff, 8);
 
 	st = net_is_ipv6_prefix((u8_t *)&prefix1, (u8_t *)&prefix2, 65);
 	zassert_true(st, "Prefix /65 compare failed");

--- a/tests/net/lib/http_header_fields/src/main.c
+++ b/tests/net/lib/http_header_fields/src/main.c
@@ -595,7 +595,7 @@ void test_parse_url(void)
 	elements = ARRAY_SIZE(url_tests);
 	for (i = 0; i < elements; i++) {
 		test = &url_tests[i];
-		memset(&u, 0, sizeof(u));
+		(void)memset(&u, 0, sizeof(u));
 
 		rv = http_parser_parse_url(test->url,
 					   strlen(test->url),

--- a/tests/net/lib/mqtt_publisher/src/test_mqtt_publish.c
+++ b/tests/net/lib/mqtt_publisher/src/test_mqtt_publish.c
@@ -218,7 +218,7 @@ static int init_network(void)
 	int rc;
 
 	/* Set everything to 0 and later just assign the required fields. */
-	memset(&client_ctx, 0x00, sizeof(client_ctx));
+	(void)memset(&client_ctx, 0x00, sizeof(client_ctx));
 
 	/* connect, disconnect and malformed may be set to NULL */
 	client_ctx.mqtt_ctx.connect = connect_cb;

--- a/tests/net/lib/mqtt_subscriber/src/test_mqtt_subscribe.c
+++ b/tests/net/lib/mqtt_subscriber/src/test_mqtt_subscribe.c
@@ -243,7 +243,7 @@ static int init_network(void)
 	int rc;
 
 	/* Set everything to 0 and later just assign the required fields. */
-	memset(&client_ctx, 0x00, sizeof(client_ctx));
+	(void)memset(&client_ctx, 0x00, sizeof(client_ctx));
 
 	/* connect, disconnect and malformed may be set to NULL */
 	client_ctx.mqtt_ctx.connect = connect_cb;

--- a/tests/net/lib/tls_credentials/src/main.c
+++ b/tests/net/lib/tls_credentials/src/main.c
@@ -68,7 +68,7 @@ static void test_credential_get(void)
 	int ret;
 
 	/* Read existing credential */
-	memset(cred, 0, sizeof(cred));
+	(void)memset(cred, 0, sizeof(cred));
 	credlen = sizeof(cred);
 	ret = tls_credential_get(common_tag, TLS_CREDENTIAL_PRIVATE_KEY,
 				 cred, &credlen);

--- a/tests/net/net_pkt/src/main.c
+++ b/tests/net/net_pkt/src/main.c
@@ -851,8 +851,8 @@ static void test_fragment_compact(void)
 		       test_data, sizeof(test_data));
 
 		/* Followed by bytes of zeroes */
-		memset(net_buf_add(frags[i], sizeof(test_data)), 0,
-		       sizeof(test_data));
+		(void)memset(net_buf_add(frags[i], sizeof(test_data)), 0,
+			     sizeof(test_data));
 
 		total++;
 	}

--- a/tests/net/ptp/clock/src/main.c
+++ b/tests/net/ptp/clock/src/main.c
@@ -421,7 +421,7 @@ static void test_ptp_clock_iface(int idx)
 
 	ptp_clock_adjust(clk, rnd_value);
 
-	memset(&tm, 0, sizeof(tm));
+	(void)memset(&tm, 0, sizeof(tm));
 	ptp_clock_get(clk, &tm);
 
 	new_value = timestamp_to_nsec(&tm);

--- a/tests/net/socket/udp/src/main.c
+++ b/tests/net/socket/udp/src/main.c
@@ -52,7 +52,7 @@ static void prepare_sock_v6(const char *addr,
 	*sock = socket(AF_INET6, SOCK_DGRAM, IPPROTO_UDP);
 	zassert_true(*sock >= 0, "socket open failed");
 
-	memset(sockaddr, 0, sizeof(*sockaddr));
+	(void)memset(sockaddr, 0, sizeof(*sockaddr));
 	sockaddr->sin6_family = AF_INET6;
 	sockaddr->sin6_port = htons(port);
 	rv = inet_pton(AF_INET6, addr, &sockaddr->sin6_addr);

--- a/tests/net/traffic_class/src/main.c
+++ b/tests/net/traffic_class/src/main.c
@@ -567,7 +567,7 @@ static void traffic_class_send_data_mix(void)
 	 */
 	int total_packets = 0;
 
-	memset(send_priorities, 0, sizeof(send_priorities));
+	(void)memset(send_priorities, 0, sizeof(send_priorities));
 
 	traffic_class_send_priority(NET_PRIORITY_BK, MAX_PKT_TO_SEND, false);
 	total_packets += MAX_PKT_TO_SEND;
@@ -590,7 +590,7 @@ static void traffic_class_send_data_mix_all_1(void)
 {
 	int total_packets = 0;
 
-	memset(send_priorities, 0, sizeof(send_priorities));
+	(void)memset(send_priorities, 0, sizeof(send_priorities));
 
 	traffic_class_send_priority(NET_PRIORITY_BK, MAX_PKT_TO_SEND, false);
 	total_packets += MAX_PKT_TO_SEND;
@@ -635,7 +635,7 @@ static void traffic_class_send_data_mix_all_2(void)
 	int total_packets = 0;
 	int i;
 
-	memset(send_priorities, 0, sizeof(send_priorities));
+	(void)memset(send_priorities, 0, sizeof(send_priorities));
 
 	/* In this test send one packet for each queue instead of sending
 	 * n packets to same queue at a time.
@@ -876,7 +876,7 @@ static void traffic_class_recv_data_mix(void)
 	 */
 	int total_packets = 0;
 
-	memset(recv_priorities, 0, sizeof(recv_priorities));
+	(void)memset(recv_priorities, 0, sizeof(recv_priorities));
 
 	traffic_class_recv_priority(NET_PRIORITY_BK, MAX_PKT_TO_RECV, false);
 	total_packets += MAX_PKT_TO_RECV;
@@ -899,7 +899,7 @@ static void traffic_class_recv_data_mix_all_1(void)
 {
 	int total_packets = 0;
 
-	memset(recv_priorities, 0, sizeof(recv_priorities));
+	(void)memset(recv_priorities, 0, sizeof(recv_priorities));
 
 	traffic_class_recv_priority(NET_PRIORITY_BK, MAX_PKT_TO_RECV, false);
 	total_packets += MAX_PKT_TO_RECV;
@@ -944,7 +944,7 @@ static void traffic_class_recv_data_mix_all_2(void)
 	int total_packets = 0;
 	int i;
 
-	memset(recv_priorities, 0, sizeof(recv_priorities));
+	(void)memset(recv_priorities, 0, sizeof(recv_priorities));
 
 	/* In this test receive one packet for each queue instead of receiving
 	 * n packets to same queue at a time.

--- a/tests/net/utils/src/main.c
+++ b/tests/net/utils/src/main.c
@@ -1280,7 +1280,7 @@ void test_addr_parse(void)
 
 #if defined(CONFIG_NET_IPV4)
 	for (i = 0; i < ARRAY_SIZE(parse_ipv4_entries) - 1; i++) {
-		memset(&addr, 0, sizeof(addr));
+		(void)memset(&addr, 0, sizeof(addr));
 
 		ret = net_ipaddr_parse(
 			parse_ipv4_entries[i].address,
@@ -1309,7 +1309,7 @@ void test_addr_parse(void)
 #endif
 #if defined(CONFIG_NET_IPV6)
 	for (i = 0; i < ARRAY_SIZE(parse_ipv6_entries) - 1; i++) {
-		memset(&addr, 0, sizeof(addr));
+		(void)memset(&addr, 0, sizeof(addr));
 
 		ret = net_ipaddr_parse(
 			parse_ipv6_entries[i].address,

--- a/tests/net/websocket/src/server.c
+++ b/tests/net/websocket/src/server.c
@@ -289,7 +289,7 @@ void test_websocket_init_server(void)
 
 #elif ADDR_OPTION == 2
 	/* Accept any local listening address */
-	memset(&addr, 0, sizeof(addr));
+	(void)memset(&addr, 0, sizeof(addr));
 
 	net_sin(&addr)->sin_port = htons(ZEPHYR_PORT);
 
@@ -300,7 +300,7 @@ void test_websocket_init_server(void)
 
 #elif ADDR_OPTION == 3
 	/* Set the bind address according to your configuration */
-	memset(&addr, 0, sizeof(addr));
+	(void)memset(&addr, 0, sizeof(addr));
 
 	/* In this example, listen only IPv6 */
 	addr.sa_family = AF_INET6;

--- a/tests/subsys/fs/fcb/src/fcb_test_append_fill.c
+++ b/tests/subsys/fs/fcb/src/fcb_test_append_fill.c
@@ -56,7 +56,7 @@ void fcb_test_append_fill(void)
 	zassert_true(elem_cnts[0] == elem_cnts[1],
 		     "appendend counts should equal to each other");
 
-	memset(&aa_together_cnts, 0, sizeof(aa_together_cnts));
+	(void)memset(&aa_together_cnts, 0, sizeof(aa_together_cnts));
 	rc = fcb_walk(fcb, NULL, fcb_test_cnt_elems_cb, &aa_together);
 	zassert_true(rc == 0, "fcb_walk call failure");
 	zassert_true(aa_together.elem_cnts[0] == elem_cnts[0],
@@ -64,7 +64,7 @@ void fcb_test_append_fill(void)
 	zassert_true(aa_together.elem_cnts[1] == elem_cnts[1],
 		     "fcb_walk: elements count read different than expected");
 
-	memset(&aa_separate_cnts, 0, sizeof(aa_separate_cnts));
+	(void)memset(&aa_separate_cnts, 0, sizeof(aa_separate_cnts));
 	rc = fcb_walk(fcb, &test_fcb_sector[0], fcb_test_cnt_elems_cb,
 	  &aa_separate);
 	zassert_true(rc == 0, "fcb_walk call failure");

--- a/tests/subsys/fs/fcb/src/fcb_test_init.c
+++ b/tests/subsys/fs/fcb/src/fcb_test_init.c
@@ -13,7 +13,7 @@ void fcb_test_init(void)
 	struct fcb *fcb;
 
 	fcb = &test_fcb;
-	memset(fcb, 0, sizeof(*fcb));
+	(void)memset(fcb, 0, sizeof(*fcb));
 
 	rc = fcb_init(TEST_FCB_FLASH_AREA_ID, fcb);
 	zassert_true(rc == FCB_ERR_ARGS, "fcb_init call should fail");

--- a/tests/subsys/fs/fcb/src/fcb_test_multiple_scratch.c
+++ b/tests/subsys/fs/fcb/src/fcb_test_multiple_scratch.c
@@ -27,7 +27,7 @@ void fcb_test_multi_scratch(void)
 	 * Now fill up everything. We should be able to get 3 of the sectors
 	 * full.
 	 */
-	memset(elem_cnts, 0, sizeof(elem_cnts));
+	(void)memset(elem_cnts, 0, sizeof(elem_cnts));
 	while (1) {
 		rc = fcb_append(fcb, sizeof(test_data), &loc);
 		if (rc == FCB_ERR_NOSPACE) {
@@ -80,7 +80,7 @@ void fcb_test_multi_scratch(void)
 	rc = fcb_rotate(fcb);
 	zassert_true(rc == 0, "fcb_rotate call failure");
 
-	memset(&cnts, 0, sizeof(cnts));
+	(void)memset(&cnts, 0, sizeof(cnts));
 	rc = fcb_walk(fcb, NULL, fcb_test_cnt_elems_cb, &aa_arg);
 	zassert_true(rc == 0, "fcb_walk call failure");
 

--- a/tests/subsys/fs/fcb/src/fcb_test_reset.c
+++ b/tests/subsys/fs/fcb/src/fcb_test_reset.c
@@ -58,7 +58,7 @@ void fcb_test_reset(void)
 	/*
 	 * Pretend reset
 	 */
-	memset(fcb, 0, sizeof(*fcb));
+	(void)memset(fcb, 0, sizeof(*fcb));
 	fcb->f_sector_cnt = 2;
 	fcb->f_sectors = test_fcb_sector;
 
@@ -96,7 +96,7 @@ void fcb_test_reset(void)
 	rc = fcb_append(fcb, 34, &loc);
 	zassert_true(rc == 0, "fcb_append call failure");
 
-	memset(fcb, 0, sizeof(*fcb));
+	(void)memset(fcb, 0, sizeof(*fcb));
 	fcb->f_sector_cnt = 2;
 	fcb->f_sectors = test_fcb_sector;
 

--- a/tests/subsys/fs/fcb/src/fcb_test_rotate.c
+++ b/tests/subsys/fs/fcb/src/fcb_test_rotate.c
@@ -61,7 +61,7 @@ void fcb_test_rotate(void)
 	zassert_true(fcb->f_active_id == old_id,
 		     "flash location should be kept");
 
-	memset(cnts, 0, sizeof(cnts));
+	(void)memset(cnts, 0, sizeof(cnts));
 	rc = fcb_walk(fcb, NULL, fcb_test_cnt_elems_cb, &aa_arg);
 	zassert_true(rc == 0, "fcb_walk call failure");
 	zassert_true(aa_arg.elem_cnts[0] == elem_cnts[0] ||
@@ -89,7 +89,7 @@ void fcb_test_rotate(void)
 	zassert_true(fcb->f_active_id == old_id,
 		     "flash location should be kept");
 
-	memset(cnts, 0, sizeof(cnts));
+	(void)memset(cnts, 0, sizeof(cnts));
 	rc = fcb_walk(fcb, NULL, fcb_test_cnt_elems_cb, &aa_arg);
 	zassert_true(rc == 0, "fcb_walk call failure");
 	zassert_true(aa_arg.elem_cnts[0] == 1 || aa_arg.elem_cnts[1] == 1,

--- a/tests/subsys/fs/fcb/src/main.c
+++ b/tests/subsys/fs/fcb/src/main.c
@@ -106,7 +106,7 @@ void fcb_tc_pretest(int sectors)
 
 	fcb_test_wipe();
 	fcb = &test_fcb;
-	memset(fcb, 0, sizeof(*fcb));
+	(void)memset(fcb, 0, sizeof(*fcb));
 	fcb->f_sector_cnt = sectors;
 	fcb->f_sectors = test_fcb_sector; /* XXX */
 

--- a/tests/subsys/fs/multi-fs/src/test_ram_backend.c
+++ b/tests/subsys/fs/multi-fs/src/test_ram_backend.c
@@ -34,7 +34,7 @@ static int test_flash_ram_erase(struct device *dev, off_t offset, size_t len)
 
 	while (offset < end_offset) {
 		flash_get_page_info_by_offs(dev, offset, &info);
-		memset(rambuf + info.start_offset, 0xff, info.size);
+		(void)memset(rambuf + info.start_offset, 0xff, info.size);
 		offset = info.start_offset + info.size;
 	}
 

--- a/tests/subsys/fs/nffs_fs_api/common/test_performance.c
+++ b/tests/subsys/fs/nffs_fs_api/common/test_performance.c
@@ -91,7 +91,7 @@ void test_performance(void)
 
 	rc = fs_open(&file, NFFS_MNTP"/file");
 	zassert_equal(rc, 0, "cannot open file");
-	memset(nffs_test_buf, 0, RW_CHUNK_LENGTH);
+	(void)memset(nffs_test_buf, 0, RW_CHUNK_LENGTH);
 	for (i = 0; i < RW_DATA_LENGTH; ) {
 		rc = fs_write(&file, nffs_test_buf, RW_CHUNK_LENGTH);
 		zassert_equal(rc, RW_CHUNK_LENGTH, "cannot write file");
@@ -134,7 +134,7 @@ void test_performance(void)
 
 	rc = fs_open(&file, NFFS_MNTP"/file");
 	zassert_equal(rc, 0, "cannot open file");
-	memset(nffs_test_buf, 0, NFFS_BLOCK_MAX_DATA_SZ_MAX);
+	(void)memset(nffs_test_buf, 0, NFFS_BLOCK_MAX_DATA_SZ_MAX);
 	for (i = 0; i < RW_DATA_LENGTH; ) {
 		rc = fs_write(&file, nffs_test_buf, NFFS_BLOCK_MAX_DATA_SZ_MAX);
 		zassert_equal(rc, NFFS_BLOCK_MAX_DATA_SZ_MAX,

--- a/tests/subsys/fs/nffs_fs_api/common/test_ram_backend.c
+++ b/tests/subsys/fs/nffs_fs_api/common/test_ram_backend.c
@@ -34,7 +34,7 @@ static int test_flash_ram_erase(struct device *dev, off_t offset, size_t len)
 
 	while (offset < end_offset) {
 		flash_get_page_info_by_offs(dev, offset, &info);
-		memset(rambuf + info.start_offset, 0xff, info.size);
+		(void)memset(rambuf + info.start_offset, 0xff, info.size);
 		offset = info.start_offset + info.size;
 	}
 

--- a/tests/subsys/settings/fcb/src/settings_test_compress_reset.c
+++ b/tests/subsys/settings/fcb/src/settings_test_compress_reset.c
@@ -31,7 +31,7 @@ void test_config_compress_reset(void)
 		     "can't register FCB as configuration destination");
 
 	c2_var_count = 1;
-	memset(elems, 0, sizeof(elems));
+	(void)memset(elems, 0, sizeof(elems));
 
 	for (i = 0; ; i++) {
 		test_config_fill_area(test_ref_value, i);
@@ -46,7 +46,7 @@ void test_config_compress_reset(void)
 			 */
 			break;
 		}
-		memset(val_string, 0, sizeof(val_string));
+		(void)memset(val_string, 0, sizeof(val_string));
 
 		rc = settings_load();
 		zassert_true(rc == 0, "fcb read error");
@@ -65,7 +65,7 @@ void test_config_compress_reset(void)
 
 	config_wipe_srcs();
 
-	memset(&cf, 0, sizeof(cf));
+	(void)memset(&cf, 0, sizeof(cf));
 
 	cf.cf_fcb.f_magic = CONFIG_SETTINGS_FCB_MAGIC;
 	cf.cf_fcb.f_sectors = fcb_sectors;

--- a/tests/subsys/settings/fcb/src/settings_test_fcb.c
+++ b/tests/subsys/settings/fcb/src/settings_test_fcb.c
@@ -249,7 +249,7 @@ int c2_handle_set(int argc, char **argv, char *val)
 		if (val) {
 			strncpy(valptr, val, sizeof(val_string[0]));
 		} else {
-			memset(valptr, 0, sizeof(val_string[0]));
+			(void)memset(valptr, 0, sizeof(val_string[0]));
 		}
 
 		return 0;

--- a/tests/subsys/settings/fcb/src/settings_test_save_2_fcb.c
+++ b/tests/subsys/settings/fcb/src/settings_test_save_2_fcb.c
@@ -42,7 +42,7 @@ void test_config_save_2_fcb(void)
 	zassert_true(rc == 0, "fcb write error");
 
 	val8 = 0;
-	memset(val_string[0], 0, sizeof(val_string[0]));
+	(void)memset(val_string[0], 0, sizeof(val_string[0]));
 	rc = settings_load();
 	zassert_true(rc == 0, "fcb read error");
 	zassert_true(val8 == 42, "bad value read");
@@ -63,7 +63,7 @@ void test_config_save_2_fcb(void)
 		rc = settings_save();
 		zassert_true(rc == 0, "fcb write error");
 
-		memset(val_string, 0, sizeof(val_string));
+		(void)memset(val_string, 0, sizeof(val_string));
 
 		val8 = 0;
 		rc = settings_load();

--- a/tests/subsys/settings/src/settings_test_getset_bytes.c
+++ b/tests/subsys/settings/src/settings_test_getset_bytes.c
@@ -26,7 +26,7 @@ void test_config_getset_bytes(void)
 		tmp = strlen(str);
 		zassert_true(tmp < sizeof(str), "encoded string is to long");
 
-		memset(bytes, 0, sizeof(bytes));
+		(void)memset(bytes, 0, sizeof(bytes));
 		tmp = sizeof(bytes);
 
 		tmp = sizeof(bytes);

--- a/tests/subsys/storage/flash_map/src/main.c
+++ b/tests/subsys/storage/flash_map/src/main.c
@@ -48,7 +48,7 @@ void test_flash_area_to_sectors(void)
 	rc = flash_write_protection_set(flash_dev, true);
 	zassert_false(rc, "failed to enable flash write protection");
 
-	memset(wd, 0xa5, sizeof(wd));
+	(void)memset(wd, 0xa5, sizeof(wd));
 
 	sec_cnt = ARRAY_SIZE(fs_sectors);
 	rc = flash_area_get_sectors(FLASH_AREA_IMAGE_1, &sec_cnt, fs_sectors);
@@ -75,7 +75,7 @@ void test_flash_area_to_sectors(void)
 		zassert_true(rc == 0, "hal_flash_write() fail");
 
 		/* and read it back */
-		memset(rd, 0, sizeof(rd));
+		(void)memset(rd, 0, sizeof(rd));
 		rc = flash_area_read(fa, off + fs_sectors[i].fs_size -
 					 sizeof(rd),
 				     rd, sizeof(rd));
@@ -92,7 +92,7 @@ void test_flash_area_to_sectors(void)
 	zassert_true(rc == 0, "read data != write data");
 
 	/* should read back ff all throughout*/
-	memset(wd, 0xff, sizeof(wd));
+	(void)memset(wd, 0xff, sizeof(wd));
 	for (off = 0; off < fa->fa_size; off += sizeof(rd)) {
 		rc = flash_area_read(fa, off, rd, sizeof(rd));
 		zassert_true(rc == 0, "hal_flash_read() fail");

--- a/tests/ztest/src/ztest_mock.c
+++ b/tests/ztest/src/ztest_mock.c
@@ -108,7 +108,7 @@ struct parameter *alloc_parameter(void)
 	}
 	sys_bitfield_set_bit((mem_addr_t) params_allocation, allocation_index);
 	param = params + allocation_index;
-	memset(param, 0, sizeof(*param));
+	(void)memset(param, 0, sizeof(*param));
 	return param;
 }
 


### PR DESCRIPTION
This pr is part of #9884 feature. There still violations that will be addressed in others commits/pr.

Important points about this pr:

- Commit changing signature of __swap()
  - This function can return -EAGAIN but its return value was unsigned int. Nevertheless, this value was being propagate as int.
- Change printk()/vnprintk() signature to void