### PR TITLE
boards: nucleo_f429zi: Fix typo in the docs

### DIFF
--- a/boards/arm/nucleo_f429zi/doc/nucleof429zi.rst
+++ b/boards/arm/nucleo_f429zi/doc/nucleof429zi.rst
@@ -79,7 +79,7 @@ More information about STM32F429ZI can be found here:
 Supported Features
 ==================
 
-The Zephyr nucleo_f249zi board configuration supports the following hardware features:
+The Zephyr nucleo_f429zi board configuration supports the following hardware features:
 
 +-----------+------------+-------------------------------------+
 | Interface | Controller | Driver/Component                    |


### PR DESCRIPTION
Docs had one case of calling the board nucleo_f249zi instead of
nucleo_f429zi

Signed-off-by: Kumar Gala <kumar.gala@linaro.org>