### PR TITLE
logging: add template for log configuration

### DIFF
--- a/doc/subsystems/logging/logger.rst
+++ b/doc/subsystems/logging/logger.rst
@@ -159,6 +159,17 @@ appear in exactly one of them. Each other file should use
    #include <logging/log.h>
    LOG_MODULE_DECLARE(foo); /* In all files comprising the module but one */
 
+Dedicated Kconfig template (:file:`subsys/logging/Kconfig.template.log_config`)
+can be used to create local log level configuration.
+
+Example below presents usage of the template. As a result CONFIG_FOO_LOG_LEVEL
+will be generated:
+
+.. code-block:: none
+   module = FOO
+   module-str = foo
+   source "subsys/logging/Kconfig.template.log_config"
+
 Logging in a module instance
 ============================
 

--- a/samples/subsys/logging/logger/CMakeLists.txt
+++ b/samples/subsys/logging/logger/CMakeLists.txt
@@ -1,5 +1,7 @@
 cmake_minimum_required(VERSION 3.8.2)
 
+set(KCONFIG_ROOT ${CMAKE_CURRENT_SOURCE_DIR}/Kconfig)
+
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
 project(NONE)
 

--- a/samples/subsys/logging/logger/Kconfig
+++ b/samples/subsys/logging/logger/Kconfig
@@ -1,0 +1,18 @@
+# Kconfig - Config options for logger sample app
+#
+# Copyright (c) 2018 Nordic Semiconductor ASA
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+
+mainmenu "Logger sample application"
+
+menu "Application configuration"
+
+module = SAMPLE_MODULE
+module-str = Sample module
+source "subsys/logging/Kconfig.template.log_config"
+
+endmenu
+
+source "$(ZEPHYR_BASE)/Kconfig.zephyr"

--- a/samples/subsys/logging/logger/src/sample_module.c
+++ b/samples/subsys/logging/logger/src/sample_module.c
@@ -4,10 +4,10 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 #include <zephyr.h>
-
-#define LOG_MODULE_NAME foo
 #include <logging/log.h>
 
+#define LOG_MODULE_NAME sample_module
+#define LOG_LEVEL CONFIG_SAMPLE_MODULE_LOG_LEVEL
 LOG_MODULE_REGISTER(LOG_MODULE_NAME);
 
 const char *sample_module_name_get(void)

--- a/subsys/logging/Kconfig.template.log_config
+++ b/subsys/logging/Kconfig.template.log_config
@@ -1,0 +1,28 @@
+choice
+	prompt "Max compiled-in log level for $(module-str)"
+	default $(module)_LOG_LEVEL_INF
+
+config $(module)_LOG_LEVEL_OFF
+	bool "Off"
+
+config $(module)_LOG_LEVEL_ERR
+	bool "Error"
+
+config $(module)_LOG_LEVEL_WRN
+	bool "Warning"
+
+config $(module)_LOG_LEVEL_INF
+	bool "Info"
+
+config $(module)_LOG_LEVEL_DBG
+	bool "Debug"
+
+endchoice
+
+config $(module)_LOG_LEVEL
+	int
+	default 0 if $(module)_LOG_LEVEL_OFF
+	default 1 if $(module)_LOG_LEVEL_ERR
+	default 2 if $(module)_LOG_LEVEL_WRN
+	default 3 if $(module)_LOG_LEVEL_INF
+	default 4 if $(module)_LOG_LEVEL_DBG


### PR DESCRIPTION
Added Kconfig template file to be used when log configuration
in a module is added. Added example usage of kconfig template
in logger sample.

It is using new kconfig feature added in: #9797 (issue #9761)

Signed-off-by: Krzysztof Chruscinski <krzysztof.chruscinski@nordicsemi.no>