### PR TITLE
arm: __reset: Use BL instead of B to jump to _PrepC

### DIFF
--- a/arch/arm/core/cortex_m/reset.S
+++ b/arch/arm/core/cortex_m/reset.S
@@ -102,4 +102,9 @@ SECTION_SUBSEC_FUNC(TEXT,_reset_section,__start)
     */
     isb
 
-    b _PrepC
+    /*
+     * 'bl' jumps the furthest of the branch instructions that are
+     * supported on all platforms. So it is used when jumping to _PrepC
+     * (even though we do not intend to return).
+     */
+    bl _PrepC


### PR DESCRIPTION
The __reset vector is using the 'b' instruction to jump to _PrepC. 'b'
can only jump 2KB on Cortex-M0 platforms so this causes build failures
when _PrepC happens to be too far away from __reset.

To resolve this we use 'bl' instead as it can jump two thousand times
further[0].

This can also be resolved by porting the reset vector to C or by
placing the _PrepC function in a dedicated section that the linker
places next to __reset.

[0] http://infocenter.arm.com/help/topic/com.arm.doc.dui0489e/Cihfddaf.html

Signed-off-by: Sebastian Bøe <sebastian.boe@nordicsemi.no>