### PR TITLE
samples: shared_mem: Reduce CMake required version to 3.8.2

### DIFF
--- a/samples/basic/userspace/shared_mem/CMakeLists.txt
+++ b/samples/basic/userspace/shared_mem/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.9.1)
+cmake_minimum_required(VERSION 3.8.2)
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
 project(NONE)
 


### PR DESCRIPTION
There is no reason why this sample should have a higher version required
of CMake in order to build.

Signed-off-by: Carles Cufi <carles.cufi@nordicsemi.no>