### PR TITLE
sanitycheck: Add fixture option for external hardware dependency

### DIFF
--- a/doc/subsystems/test/sanitycheck.rst
+++ b/doc/subsystems/test/sanitycheck.rst
@@ -385,6 +385,63 @@ extra_sections: <list of extra binary sections>
     extra, unexpected sections in the Zephyr binary unless they are named
     here. They will not be included in the size calculation.
 
+harness: <string>
+    A harness string needed to run the tests successfully. This can be as simple as
+    a loopback wiring or a complete hardware test setup for sensor and IO testing.
+    Usually pertains to external dependency domains but can be anything such as
+    console, sensor, net, keyboard, or Bluetooth.
+
+harness_config: <harness configuration options>
+    Extra harness configuration options to be used to select a board and/or
+    for handling generic Console with regex matching. Config can announce
+    what features it supports. This option will enable the test to run on
+    only those platforms that fulfill this external dependency.
+
+    The following options are currently supported:
+
+    type: <one_line|multi_line> (required)
+        Depends on the regex string to be matched
+
+    regex: <expression> (required)
+        Any string that the particular test case prints to confirm test
+        runs as expected.
+
+    ordered: <True|False> (default False)
+        Check the regular expression strings in orderly or randomly fashion
+
+    repeat: <integer>
+        Number of times to validate the repeated regex expression
+
+    fixture: <expression>
+        Specify a test case dependency on an external device(e.g., sensor),
+        and identify setups that fulfill this dependency. It depends on
+        specific test setup and board selection logic to pick the particular
+        board(s) out of multiple boards that fulfill the dependency in an
+        automation setup based on "fixture" keyword. Some sample fixture names
+        are fixture_i2c_hts221, fixture_i2c_bme280, fixture_i2c_FRAM,
+        fixture_ble_fw and fixture_gpio_loop.
+
+    The following is an example yaml file with a few harness_config options.
+
+    ::
+
+         sample:
+           name: HTS221 Temperature and Humidity Monitor
+         common:
+           tags: sensor
+           harness: console
+           harness_config:
+             type: multi_line
+             ordered: false
+             regex:
+               - "Temperature:(.*)C"
+               - "Relative Humidity:(.*)%"
+             fixture: fixture_i2c_hts221
+         tests:
+           test:
+             tags: samples sensor
+             depends_on: i2c
+
 filter: <expression>
     Filter whether the testcase should be run by evaluating an expression
     against an environment containing the following values:

--- a/scripts/sanity_chk/sanitycheck-tc-schema.yaml
+++ b/scripts/sanity_chk/sanitycheck-tc-schema.yaml
@@ -47,7 +47,10 @@ mapping:
        mapping:
          "type":
             type: str
-            required: yes
+            required: no
+         "fixture":
+            type: str
+            required: no
          "ordered":
             type: bool
             required: no
@@ -56,7 +59,7 @@ mapping:
             required: no
          "regex":
             type: seq
-            required: yes
+            required: no
             sequence:
               - type: str
      "min_ram":
@@ -160,7 +163,10 @@ mapping:
                mapping:
                  "type":
                     type: str
-                    required: yes
+                    required: no
+                 "fixture":
+                    type: str
+                    required: no
                  "ordered":
                     type: bool
                     required: no
@@ -169,7 +175,7 @@ mapping:
                     required: no
                  "regex":
                     type: seq
-                    required: yes
+                    required: no
                     sequence:
                       - type: str
              "min_ram":

--- a/scripts/sanitycheck
+++ b/scripts/sanitycheck
@@ -1172,7 +1172,7 @@ testcase_valid_keys = {"tags": {"type": "set", "required": False},
                        "toolchain_whitelist": {"type": "set"},
                        "filter": {"type": "str"},
                        "harness": {"type": "str"},
-                       "harness_config": {"type": "map"}
+                       "harness_config": {"type": "map", "default": {}}
                        }
 
 


### PR DESCRIPTION
Add a new option as fixture in harness configurations for utilizing
sanitycheck to identify test cases that require external hardware
such as sensor, ble, networking for validation. The config will be
added to yaml files with unique fixture name to identify each hardware
and allow automation to trigger test execution on setup having the
specific fixture enabled.

Signed-off-by: Praful Swarnakar <praful.swarnakar@intel.com>