### PR TITLE
Clean up sensor driver Kconfigs

### DIFF
--- a/drivers/sensor/adxl362/Kconfig
+++ b/drivers/sensor/adxl362/Kconfig
@@ -11,14 +11,14 @@ menuconfig ADXL362
 	help
 	  Enable driver for ADXL362 Three-Axis Digital Accelerometers.
 
+if ADXL362
+
 config ADXL362_DEV_NAME
 	string "ADXL362 device name"
-	depends on ADXL362
 	default "ADXL362"
 
 config ADXL362_SPI_DEV_NAME
 	string "SPI device where ADXL362 is connected"
-	depends on ADXL362
 	default "SPI_0"
 	help
 	  Specify the device name of the SPI device to which ADXL362 is
@@ -26,7 +26,6 @@ config ADXL362_SPI_DEV_NAME
 
 config ADXL362_SPI_DEV_SLAVE
 	int "SPI Slave Select where ADXL362 is connected"
-	depends on ADXL362
 	default 2
 	help
 	  Specify the slave select pin of the SPI to which ADXL362 is
@@ -34,7 +33,6 @@ config ADXL362_SPI_DEV_SLAVE
 
 choice
 	prompt "Accelerometer range setting"
-	depends on ADXL362
 	default ADXL362_ACCEL_RANGE_RUNTIME
 
 config ADXL362_ACCEL_RANGE_RUNTIME
@@ -53,7 +51,6 @@ endchoice
 
 choice
 	prompt "Accelerometer sampling frequency."
-	depends on ADXL362
 	default ADXL362_ACCEL_ODR_RUNTIME
 
 config ADXL362_ACCEL_ODR_RUNTIME
@@ -78,3 +75,5 @@ config ADXL362_ACCEL_ODR_400
 	bool "400 Hz"
 
 endchoice
+
+endif # ADXL362

--- a/drivers/sensor/adxl372/Kconfig
+++ b/drivers/sensor/adxl372/Kconfig
@@ -7,7 +7,7 @@
 
 menuconfig ADXL372
 	bool "ADXL372 Three Axis High-g I2C/SPI accelerometer"
-	depends on SENSOR && (I2C || SPI)
+	depends on (I2C || SPI)
 	help
 	  Enable driver for ADXL372 Three-Axis Digital Accelerometers.
 

--- a/drivers/sensor/ak8975/Kconfig
+++ b/drivers/sensor/ak8975/Kconfig
@@ -12,16 +12,16 @@ menuconfig AK8975
 	help
 	  Enable driver for AK8975 magnetometer.
 
+if AK8975
+
 config AK8975_NAME
 	string "Driver name"
 	default "AK8975"
-	depends on AK8975
 	help
 	  Device name with which the AK8975 sensor is identified.
 
 config AK8975_I2C_ADDR
 	hex "I2C address"
-	depends on AK8975
 	default 0x0C
 	range 0x0C 0x0F
 	help
@@ -37,7 +37,6 @@ config AK8975_I2C_ADDR
 
 config AK8975_I2C_MASTER_DEV_NAME
 	string "I2C master where AK8975 is connected"
-	depends on AK8975
 	default "I2C_0"
 	help
 	  Specify the device name of the I2C master device to which the
@@ -45,16 +44,17 @@ config AK8975_I2C_MASTER_DEV_NAME
 
 config MPU9150
 	bool "Enable MPU9180 support"
-	depends on AK8975
 	help
 	  Enable this config option if the AK8975 sensor is part of a
 	  MPU9150 chip.
 
 config MPU9150_I2C_ADDR
 	hex "MPU9180 I2C address"
-	depends on AK8975 && MPU9150 && !MPU6050
+	depends on MPU9150 && !MPU6050
 	range 0x68 0x69
 	default 0x68
 	help
 	  I2C address of the MPU9150. If the driver for MPU6050 is enabled,
 	  its address will be used and this option made unavailable.
+
+endif # AK8975

--- a/drivers/sensor/apds9960/Kconfig
+++ b/drivers/sensor/apds9960/Kconfig
@@ -10,11 +10,12 @@ menuconfig APDS9960
 	help
 	  Enable driver for APDS9960 sensors.
 
+if APDS9960
+
 if !HAS_DTS_I2C_DEVICE
 
 config  APDS9960_I2C_DEV_NAME
 	string "I2C Master"
-	depends on APDS9960
 	default "I2C_0"
 	help
 	  The device name of the I2C master device to which the APDS9960
@@ -23,8 +24,9 @@ config  APDS9960_I2C_DEV_NAME
 config APDS9960_DRV_NAME
 	string "Driver name"
 	default "APDS9960"
-	depends on APDS9960
 	help
 	  Device name with which the APDS9960 is identified.
 
 endif # !HAS_DTS_I2C_DEVICE
+
+endif # APDS9960

--- a/drivers/sensor/bma280/Kconfig
+++ b/drivers/sensor/bma280/Kconfig
@@ -13,9 +13,10 @@ menuconfig BMA280
 	  Enable driver for BMA280 I2C-based triaxial accelerometer sensor
 	  family.
 
+if BMA280
+
 choice
 	prompt "Chip type"
-	depends on BMA280
 	default BMA280_CHIP_BMA280
 	help
 	  Choose desired chip type from the BMA280 family.
@@ -36,13 +37,11 @@ config BMA280_NAME
 	string "Driver name"
 	default "BMA280" if BMA280_CHIP_BMA280
 	default "BMC150_ACCEL" if BMA280_CHIP_BMC150_ACCEL
-	depends on BMA280
 	help
 	  Device name with which the sensor is identified.
 
 config BMA280_I2C_ADDR
 	hex "BMA280 I2C address"
-	depends on BMA280
 	default 0x18 if BMA280_CHIP_BMA280
 	default 0x10 if BMA280_CHIP_BMC150_ACCEL
 	help
@@ -55,7 +54,6 @@ config BMA280_I2C_ADDR
 
 config BMA280_I2C_MASTER_DEV_NAME
 	string "I2C master device name"
-	depends on BMA280
 	default "I2C_0"
 	help
 	  Specify the device name of the I2C master device to which chip is
@@ -63,7 +61,6 @@ config BMA280_I2C_MASTER_DEV_NAME
 
 choice
 	prompt "Trigger mode"
-	depends on BMA280
 	default BMA280_TRIGGER_GLOBAL_THREAD
 	help
 	  Specify the type of triggering to be used by the driver.
@@ -85,12 +82,11 @@ endchoice
 
 config BMA280_TRIGGER
 	bool
-	depends on BMA280
 
 config BMA280_GPIO_DEV_NAME
 	string "GPIO device"
 	default "GPIO_0"
-	depends on BMA280 && BMA280_TRIGGER
+	depends on BMA280_TRIGGER
 	help
 	  The device name of the GPIO device to which the chip's interrupt pins
 	  are connected.
@@ -98,28 +94,27 @@ config BMA280_GPIO_DEV_NAME
 config BMA280_GPIO_PIN_NUM
 	int "Interrupt GPIO pin number"
 	default 0
-	depends on BMA280 && BMA280_TRIGGER
+	depends on BMA280_TRIGGER
 	help
 	  The number of the GPIO on which the interrupt signal from the chip
 	  will be received.
 
 config BMA280_THREAD_PRIORITY
 	int "Thread priority"
-	depends on BMA280 && BMA280_TRIGGER_OWN_THREAD
+	depends on BMA280_TRIGGER_OWN_THREAD
 	default 10
 	help
 	  Priority of thread used by the driver to handle interrupts.
 
 config BMA280_THREAD_STACK_SIZE
 	int "Thread stack size"
-	depends on BMA280 && BMA280_TRIGGER_OWN_THREAD
+	depends on BMA280_TRIGGER_OWN_THREAD
 	default 1024
 	help
 	  Stack size of thread used by the driver to handle interrupts.
 
 choice
 	prompt "Acceleration measurement range"
-	depends on BMA280
 	default BMA280_PMU_RANGE_2G
 	help
 	  Measurement range for acceleration values.
@@ -140,7 +135,6 @@ endchoice
 
 choice
 	prompt "Acceleration data filter bandwidth"
-	depends on BMA280
 	default BMA280_PMU_BW_7
 	help
 	  Bandwidth of filtered acceleration data.
@@ -170,3 +164,5 @@ config BMA280_PMU_BW_8
 	bool "unfiltered"
 
 endchoice
+
+endif # BMA280

--- a/drivers/sensor/bmc150_magn/Kconfig
+++ b/drivers/sensor/bmc150_magn/Kconfig
@@ -12,15 +12,15 @@ menuconfig BMC150_MAGN
 	help
 	  Enable driver for BMC150 I2C-based magnetometer sensor.
 
+if BMC150_MAGN
+
 config BMC150_MAGN_DEV_NAME
 	string "BMC150_MAGN device name"
-	depends on BMC150_MAGN
 	default "bmc150_magn"
 
 config BMC150_MAGN_I2C_ADDR
 	hex "BMC150_MAGN I2C slave address"
 	default 0x12
-	depends on BMC150_MAGN
 	help
 	  Specify the I2C slave address for the BMC150_MAGN.
 
@@ -29,19 +29,16 @@ config BMC150_MAGN_I2C_ADDR
 
 config BMC150_MAGN_I2C_MASTER_DEV_NAME
 	string "I2C master where BMC150_MAGN is connected"
-	depends on BMC150_MAGN
 	default "I2C_0"
 	help
 	  Specify the device name of the I2C master device to which BMC150_MAGN
 	  is connected.
 
 menu "Attributes"
-	depends on BMC150_MAGN
 
 choice
 	prompt "Default preset"
 	default BMC150_MAGN_PRESET_REGULAR
-	depends on BMC150_MAGN
 	help
 	  Specify the default preset (x/y oversampling, z oversampling, sampling
 	  frequency).
@@ -62,19 +59,16 @@ endchoice
 
 config BMC150_MAGN_SAMPLING_RATE_RUNTIME
 	bool "Enable dynamic sampling rate"
-	depends on BMC150_MAGN
 	help
 	  Enable alteration of sampling rate attribute at runtime.
 
 config BMC150_MAGN_SAMPLING_REP_XY
 	bool "Enable dynamic XY oversampling"
-	depends on BMC150_MAGN
 	help
 	  Enable alteration of XY oversampling at runtime.
 
 config BMC150_MAGN_SAMPLING_REP_Z
 	bool "Enable dynamic Z oversampling"
-	depends on BMC150_MAGN
 	help
 	  Enable alteration of Z oversampling at runtime.
 
@@ -82,7 +76,7 @@ endmenu
 
 config BMC150_MAGN_TRIGGER
 	bool "Enable triggers"
-	depends on BMC150_MAGN && GPIO
+	depends on GPIO
 	help
 	  Enable triggers for BMC150 magnetometer
 
@@ -113,3 +107,5 @@ config BMC150_MAGN_GPIO_DRDY_INT_PIN
 	depends on BMC150_MAGN_TRIGGER_DRDY
 	help
 	  GPIO pin number for the data ready interrupt pin.
+
+endif # BMC150_MAGN

--- a/drivers/sensor/bme280/Kconfig
+++ b/drivers/sensor/bme280/Kconfig
@@ -13,14 +13,14 @@ menuconfig BME280
 	help
 	 Enable driver for BME280 I2C-based or SPI-based temperature and pressure sensor.
 
+if BME280
+
 config BME280_DEV_NAME
 	string "BME280 device name"
-	depends on BME280
 	default "BME280"
 
 choice
 	prompt "BME280 device select"
-	depends on BME280
 	default BME280_DEV_TYPE_I2C
 	help
 	  Select interface to communicate with BME280 sensor. This sensor can communicate
@@ -38,7 +38,7 @@ endchoice
 config BME280_I2C_ADDR
 	hex "BME280 I2C slave address"
 	default 0x76
-	depends on BME280 && BME280_DEV_TYPE_I2C
+	depends on BME280_DEV_TYPE_I2C
 	help
 	  Specify the I2C slave address for the BME280.
 
@@ -47,7 +47,7 @@ config BME280_I2C_ADDR
 
 config BME280_I2C_MASTER_DEV_NAME
 	string "I2C master where BME280 is connected"
-	depends on BME280 && BME280_DEV_TYPE_I2C
+	depends on BME280_DEV_TYPE_I2C
 	default "I2C_0"
 	help
 	 Specify the device name of the I2C master device to which BME280 is
@@ -55,7 +55,7 @@ config BME280_I2C_MASTER_DEV_NAME
 
 config BME280_SPI_DEV_NAME
 	string "SPI device where BME280 is connected"
-	depends on BME280 && BME280_DEV_TYPE_SPI
+	depends on BME280_DEV_TYPE_SPI
 	default "SPI_0"
 	help
 	 Specify the device name of the SPI device to which BME280 is
@@ -63,18 +63,16 @@ config BME280_SPI_DEV_NAME
 
 config BME280_SPI_DEV_SLAVE
 	int "SPI Slave Select where BME280 is connected"
-	depends on BME280 && BME280_DEV_TYPE_SPI
+	depends on BME280_DEV_TYPE_SPI
 	default 3
 	help
 	 Specify the Slave Select pin of the SPI device to which BME280 CS is
 	 connected.
 
 menu "Attributes"
-	depends on BME280
 
 choice
 	prompt "BME280 temperature oversampling"
-	depends on BME280
 	default BME280_TEMP_OVER_2X
 	help
 	  Select temperature oversampling for the BME280 sensor.  Higher values
@@ -93,7 +91,6 @@ endchoice
 
 choice
 	prompt "BME280 pressure oversampling"
-	depends on BME280
 	default BME280_PRESS_OVER_16X
 	help
 	  Select pressure oversampling for the BME280 sensor.  Higher values
@@ -112,7 +109,6 @@ endchoice
 
 choice
 	prompt "BME280 humidity oversampling"
-	depends on BME280
 	default BME280_HUMIDITY_OVER_16X
 	help
 	  Select humidity oversampling for the BME280 sensor.  Higher values
@@ -131,7 +127,6 @@ endchoice
 
 choice
 	prompt "BME280 standby time"
-	depends on BME280
 	default BME280_STANDBY_1000MS
 	help
 	  Select standby time between measurements for the BME280 sensor.
@@ -156,7 +151,6 @@ endchoice
 
 choice
 	prompt "BME280 filter coefficient"
-	depends on BME280
 	default BME280_FILTER_4
 	help
 	  Select the filter coefficient for the BME280 sensor.
@@ -173,3 +167,5 @@ config BME280_FILTER_16
 endchoice
 
 endmenu
+
+endif # BME280

--- a/drivers/sensor/bmg160/Kconfig
+++ b/drivers/sensor/bmg160/Kconfig
@@ -12,23 +12,22 @@ menuconfig BMG160
 	help
 	  Enable Bosch BMG160 gyroscope support.
 
+if BMG160
+
 config BMG160_DRV_NAME
 	string "Driver's name"
-	depends on BMG160
 	default "bmg160"
 	help
 	  Name for the BMG160 driver which will be used for binding.
 
 config BMG160_I2C_PORT_NAME
 	string "I2C master controller port name"
-	depends on BMG160
 	default "I2C_0"
 	help
 	  Master I2C port name through which BMG160 chip is accessed.
 
 config BMG160_I2C_ADDR
 	hex "BMG160 I2C address"
-	depends on BMG160
 	default 0x68
 	help
 	  BMG160 chip's I2C address. Chip supports two addresses: 0x68 and 0x69 (if
@@ -37,7 +36,6 @@ config BMG160_I2C_ADDR
 choice
 	prompt "BMG160 I2C bus speed"
 	default BMG160_I2C_SPEED_STANDARD
-	depends on BMG160
 
 config BMG160_I2C_SPEED_STANDARD
 	bool "Standard"
@@ -52,7 +50,6 @@ endchoice
 
 choice
 	prompt "Trigger mode"
-	depends on BMG160
 	default BMG160_TRIGGER_GLOBAL_THREAD
 	help
 	  Specify the type of triggering to be used by the driver.
@@ -71,39 +68,37 @@ endchoice
 
 config BMG160_TRIGGER
 	bool
-	depends on BMG160
 
 config BMG160_THREAD_PRIORITY
 	int "Own thread priority"
-	depends on BMG160 && BMG160_TRIGGER_OWN_THREAD
+	depends on BMG160_TRIGGER_OWN_THREAD
 	default 10
 	help
 	  The priority of the thread used for handling interrupts.
 
 config BMG160_THREAD_STACK_SIZE
 	int "Own thread stack size"
-	depends on BMG160 && BMG160_TRIGGER_OWN_THREAD
+	depends on BMG160_TRIGGER_OWN_THREAD
 	default 1024
 	help
 	  The thread stack size.
 
 config BMG160_GPIO_PORT_NAME
 	string "GPIO controller port name"
-	depends on BMG160 && BMG160_TRIGGER
+	depends on BMG160_TRIGGER
 	default "GPIO_0"
 	help
 	  The gpio controller the interrupt pin is attached to.
 
 config BMG160_INT_PIN
 	hex "BMG160 INT PIN"
-	depends on BMG160 && BMG160_TRIGGER
+	depends on BMG160_TRIGGER
 	default 2
 	help
 	  BMG160 interrupt pin.
 
 choice
 	prompt "Gyroscope range setting."
-	depends on BMG160
 	default BMG160_RANGE_RUNTIME
 
 config BMG160_RANGE_RUNTIME
@@ -127,7 +122,6 @@ endchoice
 
 choice
 	prompt "Gyroscope sampling frequency."
-	depends on BMG160
 	default BMG160_ODR_RUNTIME
 
 config BMG160_ODR_RUNTIME
@@ -148,3 +142,5 @@ config BMG160_ODR_1000
 config BMG160_ODR_2000
 	bool "2000 Hz"
 endchoice
+
+endif # BMG160

--- a/drivers/sensor/bmi160/Kconfig
+++ b/drivers/sensor/bmi160/Kconfig
@@ -13,20 +13,19 @@ menuconfig BMI160
 	  Enable Bosch BMI160 inertial measurement unit that provides acceleration
 	  and angular rate measurements.
 
+if BMI160
+
 config BMI160_NAME
 	string "Driver's name"
-	depends on BMI160
 	default "BMI160"
 
 config BMI160_SPI_PORT_NAME
 	string "SPI master controller port name"
-	depends on BMI160
 	help
 	  Master SPI port name through which BMI160 chip is accessed.
 
 config BMI160_SLAVE
 	hex "BMI160 SPI slave select pin"
-	depends on BMI160
 	default 0
 	help
 	  BMI160 chip select pin.
@@ -34,14 +33,12 @@ config BMI160_SLAVE
 config BMI160_SPI_BUS_FREQ
 	int "BMI160 SPI bus speed in Hz"
 	default 640000
-	depends on BMI160
 	help
 	  This is the maximum supported SPI bus frequency. The chip supports a
 	  frequency up to 10MHz.
 
 choice
 	prompt "Trigger mode"
-	depends on BMI160
 	default BMI160_TRIGGER_GLOBAL_THREAD
 	help
 	  Specify the type of triggering to be used by the driver.
@@ -60,18 +57,17 @@ endchoice
 
 config BMI160_TRIGGER
 	bool
-	depends on BMI160
 
 config BMI160_THREAD_PRIORITY
 	int "Own thread priority"
-	depends on BMI160 && BMI160_TRIGGER_OWN_THREAD
+	depends on BMI160_TRIGGER_OWN_THREAD
 	default 10
 	help
 	  The priority of the thread used for handling interrupts.
 
 config BMI160_THREAD_STACK_SIZE
 	int "Own thread stack size"
-	depends on BMI160 && BMI160_TRIGGER_OWN_THREAD
+	depends on BMI160_TRIGGER_OWN_THREAD
 	default 1024
 	help
 	  The thread stack size.
@@ -79,7 +75,7 @@ config BMI160_THREAD_STACK_SIZE
 config BMI160_GPIO_DEV_NAME
 	string "Gpio device"
 	default "GPIO_1"
-	depends on BMI160 && BMI160_TRIGGER
+	depends on BMI160_TRIGGER
 	help
 	  The name of the GPIO device to which the BMI160 interrupt pin is
 	  connected.
@@ -87,35 +83,30 @@ config BMI160_GPIO_DEV_NAME
 config BMI160_GPIO_PIN_NUM
 	int "Interrupt GPIO pin number"
 	default 4
-	depends on BMI160 && BMI160_TRIGGER
+	depends on BMI160_TRIGGER
 	help
 	  The number of the GPIO pin which is connected to BMI160 interrupt pin.
 
 choice
 	prompt "Accelerometer power mode"
-	depends on BMI160
 	default BMI160_ACCEL_PMU_RUNTIME
 
 config BMI160_ACCEL_PMU_RUNTIME
 	bool "Set at runtime."
-	depends on BMI160
 
 config BMI160_ACCEL_PMU_SUSPEND
 	bool "suspended/not used"
-	depends on BMI160
 
 config BMI160_ACCEL_PMU_NORMAL
 	bool "normal"
-	depends on BMI160
 
 config BMI160_ACCEL_PMU_LOW_POWER
 	bool "low power"
-	depends on BMI160
 endchoice
 
 choice
 	prompt "Accelerometer range setting"
-	depends on BMI160 && (BMI160_ACCEL_PMU_RUNTIME || BMI160_ACCEL_PMU_NORMAL || BMI160_ACCEL_PMU_LOW_POWER)
+	depends on (BMI160_ACCEL_PMU_RUNTIME || BMI160_ACCEL_PMU_NORMAL || BMI160_ACCEL_PMU_LOW_POWER)
 	default BMI160_ACCEL_RANGE_RUNTIME
 
 config BMI160_ACCEL_RANGE_RUNTIME
@@ -136,7 +127,7 @@ endchoice
 
 choice
 	prompt "Accelerometer sampling frequency."
-	depends on BMI160 && (BMI160_ACCEL_PMU_RUNTIME || BMI160_ACCEL_PMU_NORMAL || BMI160_ACCEL_PMU_LOW_POWER)
+	depends on (BMI160_ACCEL_PMU_RUNTIME || BMI160_ACCEL_PMU_NORMAL || BMI160_ACCEL_PMU_LOW_POWER)
 	default BMI160_ACCEL_ODR_RUNTIME
 
 config BMI160_ACCEL_ODR_RUNTIME
@@ -185,29 +176,24 @@ endchoice
 
 choice
 	prompt "Gyroscope power mode"
-	depends on BMI160
 	default BMI160_GYRO_PMU_RUNTIME
 
 config BMI160_GYRO_PMU_RUNTIME
 	bool "Set at runtime."
-	depends on BMI160
 
 config BMI160_GYRO_PMU_SUSPEND
 	bool "suspended/not used"
-	depends on BMI160
 
 config BMI160_GYRO_PMU_NORMAL
 	bool "normal"
-	depends on BMI160
 
 config BMI160_GYRO_PMU_FAST_STARTUP
 	bool "fast start-up"
-	depends on BMI160
 endchoice
 
 choice
 	prompt "Gyroscope range setting."
-	depends on BMI160 && (BMI160_GYRO_PMU_RUNTIME || BMI160_GYRO_PMU_NORMAL || BMI160_GYRO_PMU_FAST_STARTUP)
+	depends on (BMI160_GYRO_PMU_RUNTIME || BMI160_GYRO_PMU_NORMAL || BMI160_GYRO_PMU_FAST_STARTUP)
 	default BMI160_GYRO_RANGE_RUNTIME
 
 config BMI160_GYRO_RANGE_RUNTIME
@@ -231,7 +217,7 @@ endchoice
 
 choice
 	prompt "Gyroscope sampling frequency."
-	depends on BMI160 && (BMI160_GYRO_PMU_RUNTIME || BMI160_GYRO_PMU_NORMAL || BMI160_GYRO_PMU_FAST_STARTUP)
+	depends on (BMI160_GYRO_PMU_RUNTIME || BMI160_GYRO_PMU_NORMAL || BMI160_GYRO_PMU_FAST_STARTUP)
 	default BMI160_GYRO_ODR_RUNTIME
 
 config BMI160_GYRO_ODR_RUNTIME
@@ -261,3 +247,5 @@ config BMI160_GYRO_ODR_1600
 config BMI160_GYRO_ODR_3200
 	bool "3200 Hz"
 endchoice
+
+endif # BMI160

--- a/drivers/sensor/ccs811/Kconfig
+++ b/drivers/sensor/ccs811/Kconfig
@@ -12,18 +12,18 @@ menuconfig CCS811
 	help
 	  Enable driver for CCS811 Gas sensors.
 
+if CCS811
+
 if !HAS_DTS_I2C_DEVICE
 
 config CCS811_NAME
 	string "Driver name"
 	default "CCS811"
-	depends on CCS811
 	help
 	  Device name with which the CCS811 sensor is identified.
 
 config CCS811_I2C_ADDR
 	hex "I2C address for CCS811 Sensor"
-	depends on CCS811
 	range 0x5a 0x5b
 	default "0x5b"
 	help
@@ -33,7 +33,6 @@ config CCS811_I2C_ADDR
 
 config CCS811_I2C_MASTER_DEV_NAME
 	string "I2C master where CCS811 is connected"
-	depends on CCS811
 	default "I2C_1"
 	help
 	  Specify the device name of the I2C master device to which the
@@ -44,35 +43,34 @@ endif
 config CCS811_GPIO_DEV_NAME
 	string "GPIO device"
 	default "GPIOC"
-	depends on CCS811
 	help
 	  The device name of the GPIO device to which the CCS811 WAKE
 	  pin is connected.
 
 config CCS811_GPIO_WAKEUP
 	bool "Enable GPIO Wakeup for CCS811"
-	depends on CCS811
 	help
 	  Enable GPIO Wakeup support for CCS811
 
 config CCS811_GPIO_WAKEUP_PIN_NUM
 	int "GPIO Wakeup pin number"
 	default 0
-	depends on CCS811 && CCS811_GPIO_WAKEUP
+	depends on CCS811_GPIO_WAKEUP
 	help
 	  The number of the GPIO pin on which the WAKE pin of CCS811
 	  is connected
 
 config CCS811_GPIO_RESET
 	bool "Enable GPIO Reset for CCS811"
-	depends on CCS811
 	help
 	  Enable GPIO Reset support for CCS811
 
 config CCS811_GPIO_RESET_PIN_NUM
 	int "GPIO Reset pin number"
 	default 0
-	depends on CCS811 && CCS811_GPIO_RESET
+	depends on CCS811_GPIO_RESET
 	help
 	  The number of the GPIO pin on which the RESET pin of CCS811
 	  is connected
+
+endif # CCS811

--- a/drivers/sensor/dht/Kconfig
+++ b/drivers/sensor/dht/Kconfig
@@ -12,9 +12,10 @@ menuconfig DHT
 	help
 	  Enable driver for the DHT temperature and humidity sensor family.
 
+if DHT
+
 choice
 	prompt "Chip type"
-	depends on DHT
 	default DHT_CHIP_DHT11
 	help
 	  Choose desired chip type from the DHT family.
@@ -35,14 +36,12 @@ config DHT_NAME
 	string "Driver name"
 	default "DHT11" if DHT_CHIP_DHT11
 	default "DHT22" if DHT_CHIP_DHT22
-	depends on DHT
 	help
 	  Device name with which the sensor is identified.
 
 config DHT_GPIO_DEV_NAME
 	string "GPIO device"
 	default "GPIO_0"
-	depends on DHT
 	help
 	  The device name of the GPIO device to which the chip's data pin
 	  is connected.
@@ -50,6 +49,7 @@ config DHT_GPIO_DEV_NAME
 config DHT_GPIO_PIN_NUM
 	int "Interrupt GPIO pin number"
 	default 0
-	depends on DHT
 	help
 	  The number of the GPIO on which the chip's data pin is connected.
+
+endif # DHT

--- a/drivers/sensor/fxos8700/Kconfig
+++ b/drivers/sensor/fxos8700/Kconfig
@@ -11,21 +11,20 @@ menuconfig FXOS8700
 	help
 	  Enable driver for the FXOS8700 accelerometer/magnetometer
 
+if FXOS8700
+
 if !HAS_DTS_I2C_DEVICE
 
 config FXOS8700_NAME
 	string "Device name"
-	depends on FXOS8700
 	default "FXOS8700"
 
 config FXOS8700_I2C_NAME
 	string "I2C device name"
-	depends on FXOS8700
 	default I2C_0_NAME
 
 config FXOS8700_I2C_ADDRESS
 	hex "I2C address"
-	depends on FXOS8700
 	range 0x1c 0x1f
 	default 0x1d
 	help
@@ -36,7 +35,6 @@ endif # !HAS_DTS_I2C_DEVICE
 
 config FXOS8700_WHOAMI
 	hex "WHOAMI value"
-	depends on FXOS8700
 	range 0x00 0xff
 	default 0xc7
 	help
@@ -46,7 +44,6 @@ config FXOS8700_WHOAMI
 
 choice
 	prompt "Mode"
-	depends on FXOS8700
 	default FXOS8700_MODE_ACCEL
 
 config FXOS8700_MODE_ACCEL
@@ -62,7 +59,7 @@ endchoice
 
 config FXOS8700_TEMP
 	bool "Enable temperature"
-	depends on FXOS8700 && (FXOS8700_MODE_MAGN || FXOS8700_MODE_HYBRID)
+	depends on (FXOS8700_MODE_MAGN || FXOS8700_MODE_HYBRID)
 	help
 	  Enable the temperature sensor. Note that the temperature sensor is
 	  uncalibrated and its output for a given temperature may vary from one
@@ -70,7 +67,6 @@ config FXOS8700_TEMP
 
 choice
 	prompt "Range"
-	depends on FXOS8700
 	default FXOS8700_RANGE_8G
 
 config FXOS8700_RANGE_8G
@@ -86,7 +82,6 @@ endchoice
 
 choice
 	prompt "Trigger mode"
-	depends on FXOS8700
 	default FXOS8700_TRIGGER_NONE
 
 config FXOS8700_TRIGGER_NONE
@@ -104,7 +99,6 @@ endchoice
 
 config FXOS8700_TRIGGER
 	bool
-	depends on FXOS8700
 
 if !HAS_DTS_GPIO_DEVICE
 
@@ -227,3 +221,5 @@ config FXOS8700_PULSE_WIND
 endif # FXOS8700_PULSE
 
 endif # FXOS8700_TRIGGER
+
+endif # FXOS8700

--- a/drivers/sensor/hdc1008/Kconfig
+++ b/drivers/sensor/hdc1008/Kconfig
@@ -12,18 +12,18 @@ menuconfig HDC1008
 	help
 	  Enable driver for HDC1008 temperature and humidity sensors.
 
+if HDC1008
+
 if !HAS_DTS_I2C_DEVICE
 
 config HDC1008_NAME
 	string "Driver name"
 	default "HDC1008"
-	depends on HDC1008
 	help
 	  Device name with which the HDC1008 sensor is identified.
 
 config HDC1008_I2C_ADDR
 	hex "I2C Address for HDC1008"
-	depends on HDC1008
 	default "0x40"
 	help
 	  0x40: A0 connected GND and A1 connected to GND.
@@ -33,7 +33,6 @@ config HDC1008_I2C_ADDR
 
 config HDC1008_I2C_MASTER_DEV_NAME
 	string "I2C master where HDC1008 is connected"
-	depends on HDC1008
 	default "I2C_0"
 	help
 	  Specify the device name of the I2C master device to which the
@@ -46,7 +45,6 @@ if !HAS_DTS_GPIO_DEVICE
 config HDC1008_GPIO_DEV_NAME
 	string "GPIO device"
 	default "GPIO_0"
-	depends on HDC1008
 	help
 	  The device name of the GPIO device to which the HDC1008 data-ready
 	  pin is connected.
@@ -54,9 +52,10 @@ config HDC1008_GPIO_DEV_NAME
 config HDC1008_GPIO_PIN_NUM
 	int "Interrupt GPIO pin number"
 	default 0
-	depends on HDC1008
 	help
 	  The number of the GPIO on which the data-ready signal from the HDC1008
 	  chip will be received.
 
 endif # !HAS_DTS_GPIO_DEVICE
+
+endif # HDC1008

--- a/drivers/sensor/hmc5883l/Kconfig
+++ b/drivers/sensor/hmc5883l/Kconfig
@@ -10,16 +10,16 @@ menuconfig HMC5883L
 	help
 	  Enable driver for HMC5883L I2C-based magnetometer.
 
+if HMC5883L
+
 config HMC5883L_NAME
 	string "Driver name"
 	default "HMC5883L"
-	depends on HMC5883L
 	help
 	  Device name with which the HMC5883L sensor is identified.
 
 config HMC5883L_I2C_MASTER_DEV_NAME
 	string "I2C master where HMC5883L is connected"
-	depends on HMC5883L
 	default "I2C_0"
 	help
 	  Specify the device name of the I2C master device to which HMC5883L
@@ -27,7 +27,6 @@ config HMC5883L_I2C_MASTER_DEV_NAME
 
 choice
 	prompt "Trigger mode"
-	depends on HMC5883L
 	default HMC5883L_TRIGGER_GLOBAL_THREAD
 	help
 	  Specify the type of triggering to be used by the driver.
@@ -49,12 +48,11 @@ endchoice
 
 config HMC5883L_TRIGGER
 	bool
-	depends on HMC5883L
 
 config HMC5883L_GPIO_DEV_NAME
 	string "GPIO device"
 	default "GPIO_0"
-	depends on HMC5883L && HMC5883L_TRIGGER
+	depends on HMC5883L_TRIGGER
 	help
 	  The device name of the GPIO device to which the HMC5883L interrupt
 	  pin is connected.
@@ -62,28 +60,27 @@ config HMC5883L_GPIO_DEV_NAME
 config HMC5883L_GPIO_PIN_NUM
 	int "Interrupt GPIO pin number"
 	default 0
-	depends on HMC5883L && HMC5883L_TRIGGER
+	depends on HMC5883L_TRIGGER
 	help
 	  The number of the GPIO on which the interrupt signal from the
 	  HMC5883L chip will be received.
 
 config HMC5883L_THREAD_PRIORITY
 	int "Thread priority"
-	depends on HMC5883L && HMC5883L_TRIGGER_OWN_THREAD
+	depends on HMC5883L_TRIGGER_OWN_THREAD
 	default 10
 	help
 	  Priority of thread used by the driver to handle interrupts.
 
 config HMC5883L_THREAD_STACK_SIZE
 	int "Thread stack size"
-	depends on HMC5883L && HMC5883L_TRIGGER_OWN_THREAD
+	depends on HMC5883L_TRIGGER_OWN_THREAD
 	default 1024
 	help
 	  Stack size of thread used by the driver to handle interrupts.
 
 config HMC5883L_ODR
 	string "Output data rate"
-	depends on HMC5883L
 	default "15"
 	help
 	  Magnetometer output data rate expressed in samples per second.
@@ -92,9 +89,10 @@ config HMC5883L_ODR
 
 config HMC5883L_FS
 	string "Full-scale range"
-	depends on HMC5883L
 	default "1.3"
 	help
 	  Magnetometer full-scale range.
 	  An X value for the config represents a range of +/- X gauss. Valid
 	  values are 0.88, 1.3, 1.9, 2.5, 4, 4.7, 5.6 and 8.1.
+
+endif # HMC5883L

--- a/drivers/sensor/hp206c/Kconfig
+++ b/drivers/sensor/hp206c/Kconfig
@@ -11,42 +11,42 @@ menuconfig HP206C
 	help
 	  Enable HopeRF HP206C barometer and altimeter support.
 
+if HP206C
+
 config  HP206C_DRV_NAME
 	string "Driver's name"
-	depends on HP206C
 	default "hp206c"
 	help
 	  Name for the HP206C driver which will be used for binding.
 
 config HP206C_I2C_PORT_NAME
 	string "I2C master controller port name"
-	depends on HP206C
 	default "I2C_0"
 	help
 	  Master I2C port name through which HP206C chip is accessed.
 
 config HP206C_OSR_RUNTIME
 	bool "Oversampling rate set at runtime"
-	depends on HP206C
 	default y
 
 config HP206C_OSR
 	int "Oversampling rate"
-	depends on HP206C && !HP206C_OSR_RUNTIME
+	depends on !HP206C_OSR_RUNTIME
 	default 4096
 	help
 	  Allowed values: 4096, 2048, 1024, 512, 256, 128
 
 config HP206C_ALT_OFFSET_RUNTIME
 	bool "Altitude offset set at runtime"
-	depends on HP206C
 	default y
 
 config HP206C_ALT_OFFSET
 	int "Altitude offset (in cm)"
-	depends on HP206C && !HP206C_ALT_OFFSET_RUNTIME
+	depends on !HP206C_ALT_OFFSET_RUNTIME
 	default 0
 	help
 	  Value, in cm, that will be used to compensate altitude calculation.
 	  For more info on how to choose this value, consult section 6.1.1 in
 	  the datasheet.
+
+endif # HP206C

--- a/drivers/sensor/hts221/Kconfig
+++ b/drivers/sensor/hts221/Kconfig
@@ -10,18 +10,18 @@ menuconfig HTS221
 	help
 	  Enable driver for HTS221 I2C-based temperature and humidity sensor.
 
+if HTS221
+
 if !HAS_DTS_I2C_DEVICE
 
 config HTS221_NAME
 	string "Driver name"
 	default "HTS221"
-	depends on HTS221
 	help
 	  Device name with which the HTS221 sensor is identified.
 
 config HTS221_I2C_MASTER_DEV_NAME
 	string "I2C master where HTS221 is connected"
-	depends on HTS221
 	default "I2C_0"
 	help
 	  Specify the device name of the I2C master device to which HTS221 is
@@ -31,7 +31,6 @@ endif
 
 choice HTS221_TRIGGER_MODE
 	prompt "Trigger mode"
-	depends on HTS221
 	default HTS221_TRIGGER_GLOBAL_THREAD
 	help
 	  Specify the type of triggering to be used by the driver.
@@ -53,12 +52,11 @@ endchoice # HTS221_TRIGGER_MODE
 
 config HTS221_TRIGGER
 	bool
-	depends on HTS221
 
 config HTS221_GPIO_DEV_NAME
 	string "GPIO device"
 	default "GPIO_0"
-	depends on HTS221 && HTS221_TRIGGER
+	depends on HTS221_TRIGGER
 	help
 	  The device name of the GPIO device to which the HTS221 interrupt pin
 	  is connected.
@@ -66,29 +64,30 @@ config HTS221_GPIO_DEV_NAME
 config HTS221_GPIO_PIN_NUM
 	int "Interrupt GPIO pin number"
 	default 0
-	depends on HTS221 && HTS221_TRIGGER
+	depends on HTS221_TRIGGER
 	help
 	  The number of the GPIO on which the interrupt signal from the HTS221
 	  chip will be received.
 
 config HTS221_THREAD_PRIORITY
 	int "Thread priority"
-	depends on HTS221 && HTS221_TRIGGER_OWN_THREAD
+	depends on HTS221_TRIGGER_OWN_THREAD
 	default 10
 	help
 	  Priority of thread used by the driver to handle interrupts.
 
 config HTS221_THREAD_STACK_SIZE
 	int "Thread stack size"
-	depends on HTS221 && HTS221_TRIGGER_OWN_THREAD
+	depends on HTS221_TRIGGER_OWN_THREAD
 	default 1024
 	help
 	  Stack size of thread used by the driver to handle interrupts.
 
 config HTS221_ODR
 	string "Output data rate"
-	depends on HTS221
 	default "1"
 	help
 	  Sensor output data rate expressed in samples per second.
 	  Data rates supported by the chip are 1, 7 and 12.5.
+
+endif # HTS221

--- a/drivers/sensor/isl29035/Kconfig
+++ b/drivers/sensor/isl29035/Kconfig
@@ -12,16 +12,16 @@ menuconfig ISL29035
 	help
 	  Enable driver for the ISL29035 light sensor.
 
+if ISL29035
+
 config ISL29035_NAME
 	string "Driver name"
 	default "ISL29035"
-	depends on ISL29035
 	help
 	  Device name with which the ISL29035 sensor is identified.
 
 config ISL29035_I2C_MASTER_DEV_NAME
 	string "I2C Master"
-	depends on ISL29035
 	default "I2C_0"
 	help
 	  The device name of the I2C master device to which the ISL29035
@@ -29,7 +29,6 @@ config ISL29035_I2C_MASTER_DEV_NAME
 
 config ISL29035_THREAD_PRIORITY
 	int "Thread priority"
-	depends on ISL29035
 	default 10
 	help
 	  Priority of thread used to handle the timer and threshold triggers.
@@ -37,7 +36,6 @@ config ISL29035_THREAD_PRIORITY
 choice
 	prompt "Full scale lux range"
 	default ISL29035_LUX_RANGE_1K
-	depends on ISL29035
 	help
 	  Maximum allowable lux value. Lower range values offer better
 	  resolution.
@@ -59,7 +57,6 @@ endchoice
 choice
 	prompt "Integration time"
 	default ISL29035_INTEGRATION_TIME_105K
-	depends on ISL29035
 	help
 	  The sampling period of the internal ADC of the light sensor.
 	  Lower integration time values mean lower ADC resolution.
@@ -80,7 +77,6 @@ endchoice
 
 choice
 	prompt "Active sensing mode"
-	depends on ISL29035
 	default ISL29035_MODE_ALS
 	help
 	  Sensing mode in which the ISL29035 will function. The chip can be
@@ -100,7 +96,7 @@ endchoice
 
 choice
 	prompt "Trigger mode"
-	depends on ISL29035 && ISL29035_MODE_ALS && GPIO
+	depends on ISL29035_MODE_ALS && GPIO
 	default ISL29035_TRIGGER_NONE
 	help
 	  Specify the type of triggering to be used by the driver.
@@ -123,12 +119,11 @@ endchoice
 
 config ISL29035_TRIGGER
 	bool
-	depends on ISL29035
 
 config ISL29035_GPIO_DEV_NAME
 	string "GPIO device"
 	default "GPIO_0"
-	depends on ISL29035 && ISL29035_TRIGGER
+	depends on ISL29035_TRIGGER
 	help
 	  The device name of the GPIO device to which the ISL29035 interrupt
 	  pin is connected.
@@ -136,28 +131,28 @@ config ISL29035_GPIO_DEV_NAME
 config ISL29035_GPIO_PIN_NUM
 	int "GPIO pin number"
 	default 0
-	depends on ISL29035 && ISL29035_TRIGGER
+	depends on ISL29035_TRIGGER
 	help
 	  The number of the GPIO pin to which the ISL29035 interrupt pin is
 	  connected.
 
 config ISL29035_THREAD_PRIORITY
 	int "Thread priority"
-	depends on ISL29035 && ISL29035_TRIGGER_OWN_THREAD
+	depends on ISL29035_TRIGGER_OWN_THREAD
 	default 10
 	help
 	  Priority of thread used by the driver to handle interrupts.
 
 config ISL29035_THREAD_STACK_SIZE
 	int "Thread stack size"
-	depends on ISL29035 && ISL29035_TRIGGER_OWN_THREAD
+	depends on ISL29035_TRIGGER_OWN_THREAD
 	default 1024
 	help
 	  Stack size of thread used by the driver to handle interrupts.
 
 choice
 	prompt "Interrupt persist cycles"
-	depends on ISL29035 && ISL29035_TRIGGER
+	depends on ISL29035_TRIGGER
 	default ISL29035_INT_PERSIST_1
 	help
 	  Number of consecutive integration cycles for which the data samples
@@ -177,3 +172,5 @@ config ISL29035_INT_PERSIST_16
 	bool "16"
 
 endchoice
+
+endif # ISL29035

--- a/drivers/sensor/lis2dh/Kconfig
+++ b/drivers/sensor/lis2dh/Kconfig
@@ -12,16 +12,16 @@ menuconfig LIS2DH
 	help
 	  Enable driver for LIS2DH SPI/I2C-based triaxial accelerometer sensor.
 
+if LIS2DH
+
 config LIS2DH_NAME
 	string "Driver name"
 	default "LIS2DH"
-	depends on LIS2DH
 	help
 	  Device name with which the LIS2DH sensor is identified.
 
 choice
 	prompt "Sensor Bus Type"
-	depends on LIS2DH
 	default LIS2DH_BUS_SPI
 	help
 	  Specify bus type, SPI versus I2C, to which the sensor is attached.
@@ -42,7 +42,7 @@ endchoice
 
 config LIS2DH_SPI_MASTER_DEV_NAME
 	string "SPI master device name"
-	depends on LIS2DH && LIS2DH_BUS_SPI
+	depends on LIS2DH_BUS_SPI
 	default "SPI_0"
 	help
 	  Specify the device name of the SPI master device to which LIS2DH is
@@ -50,7 +50,7 @@ config LIS2DH_SPI_MASTER_DEV_NAME
 
 config LIS2DH_SPI_SS_1
 	int "LIS2DH SPI slave 1 select number"
-	depends on LIS2DH && LIS2DH_BUS_SPI
+	depends on LIS2DH_BUS_SPI
 	range 1 4
 	default 1
 	help
@@ -58,7 +58,7 @@ config LIS2DH_SPI_SS_1
 
 config LIS2DH_SPI_FREQUENCY
 	int "SPI clock frequency"
-	depends on LIS2DH && LIS2DH_BUS_SPI
+	depends on LIS2DH_BUS_SPI
 	range 125000 10000000
 	default 4000000
 	help
@@ -67,7 +67,7 @@ config LIS2DH_SPI_FREQUENCY
 
 config LIS2DH_I2C_ADDR
 	hex "LIS2DH I2C address"
-	depends on LIS2DH && LIS2DH_BUS_I2C
+	depends on LIS2DH_BUS_I2C
 	default 0x18
 	help
 	  I2C address of the LIS2DH sensor.
@@ -77,7 +77,7 @@ config LIS2DH_I2C_ADDR
 
 config LIS2DH_I2C_MASTER_DEV_NAME
 	string "I2C master where LIS2DH is connected"
-	depends on LIS2DH && LIS2DH_BUS_I2C
+	depends on LIS2DH_BUS_I2C
 	default "I2C_0"
 	help
 	  Specify the device name of the I2C master device to which LIS2DH is
@@ -85,7 +85,6 @@ config LIS2DH_I2C_MASTER_DEV_NAME
 
 choice
 	prompt "Trigger mode"
-	depends on LIS2DH
 	default LIS2DH_TRIGGER_GLOBAL_THREAD
 	help
 	  Specify the type of triggering to be used by the driver.
@@ -107,12 +106,11 @@ endchoice
 
 config LIS2DH_TRIGGER
 	bool
-	depends on LIS2DH
 
 config LIS2DH_GPIO_DEV_NAME
 	string "GPIO device"
 	default "GPIO_0"
-	depends on LIS2DH && LIS2DH_TRIGGER
+	depends on LIS2DH_TRIGGER
 	help
 	  The device name of the GPIO device to which the LIS2DH interrupt pins
 	  are connected.
@@ -121,7 +119,7 @@ config LIS2DH_INT1_GPIO_PIN
 	int "Interrupt 1 GPIO pin number"
 	range 0 254
 	default 25
-	depends on LIS2DH && LIS2DH_TRIGGER
+	depends on LIS2DH_TRIGGER
 	help
 	  The number of the GPIO on which the interrupt 1 signal from the LIS2DH
 	  chip will be received.
@@ -130,28 +128,27 @@ config LIS2DH_INT2_GPIO_PIN
 	int "Interrupt 2 GPIO pin number"
 	range 0 254
 	default 26
-	depends on LIS2DH && LIS2DH_TRIGGER
+	depends on LIS2DH_TRIGGER
 	help
 	  The number of the GPIO on which the interrupt 2 signal from the LIS2DH
 	  chip will be received.
 
 config LIS2DH_THREAD_PRIORITY
 	int "Thread priority"
-	depends on LIS2DH && LIS2DH_TRIGGER_OWN_THREAD
+	depends on LIS2DH_TRIGGER_OWN_THREAD
 	default 10
 	help
 	  Priority of thread used by the driver to handle interrupts.
 
 config LIS2DH_THREAD_STACK_SIZE
 	int "Thread stack size"
-	depends on LIS2DH && LIS2DH_TRIGGER_OWN_THREAD
+	depends on LIS2DH_TRIGGER_OWN_THREAD
 	default 1024
 	help
 	  Stack size of thread used by the driver to handle interrupts.
 
 choice
 	prompt "Acceleration measurement range"
-	depends on LIS2DH
 	default LIS2DH_ACCEL_RANGE_RUNTIME
 	help
 	  Initial measurement full scale range for acceleration values.
@@ -175,7 +172,6 @@ endchoice
 
 choice
 	prompt "Power mode"
-	depends on LIS2DH
 	default LIS2DH_POWER_MODE_NORMAL
 	help
 	  Choose between normal or low power operation mode for chip at init.
@@ -190,7 +186,6 @@ endchoice
 
 choice
 	prompt "Output data rate frequency"
-	depends on LIS2DH
 	default LIS2DH_ODR_RUNTIME
 	help
 	  Initial data rate frequency of acceleration data at initialization.
@@ -236,3 +231,5 @@ config LIS2DH_ODR_9_LOW
 	depends on LIS2DH_POWER_MODE_LOW
 
 endchoice
+
+endif # LIS2DH

--- a/drivers/sensor/lis3dh/Kconfig
+++ b/drivers/sensor/lis3dh/Kconfig
@@ -12,16 +12,16 @@ menuconfig LIS3DH
 	help
 	  Enable driver for LIS3DH I2C-based triaxial accelerometer sensor.
 
+if LIS3DH
+
 config LIS3DH_NAME
 	string "Driver name"
 	default "LIS3DH"
-	depends on LIS3DH
 	help
 	  Device name with which the LIS3DH sensor is identified.
 
 config LIS3DH_I2C_ADDR
 	hex "LIS3DH I2C address"
-	depends on LIS3DH
 	default 0x18
 	help
 	  I2C address of the LIS3DH sensor.
@@ -31,7 +31,6 @@ config LIS3DH_I2C_ADDR
 
 config LIS3DH_I2C_MASTER_DEV_NAME
 	string "I2C master where LIS3DH is connected"
-	depends on LIS3DH
 	default "I2C_0"
 	help
 	  Specify the device name of the I2C master device to which LIS3DH is
@@ -39,7 +38,6 @@ config LIS3DH_I2C_MASTER_DEV_NAME
 
 choice
 	prompt "Trigger mode"
-	depends on LIS3DH
 	default LIS3DH_TRIGGER_GLOBAL_THREAD
 	help
 	  Specify the type of triggering to be used by the driver.
@@ -61,12 +59,11 @@ endchoice
 
 config LIS3DH_TRIGGER
 	bool
-	depends on LIS3DH
 
 config LIS3DH_GPIO_DEV_NAME
 	string "GPIO device"
 	default "GPIO_0"
-	depends on LIS3DH && LIS3DH_TRIGGER
+	depends on LIS3DH_TRIGGER
 	help
 	  The device name of the GPIO device to which the LIS3DH interrupt pins
 	  are connected.
@@ -74,28 +71,27 @@ config LIS3DH_GPIO_DEV_NAME
 config LIS3DH_GPIO_PIN_NUM
 	int "Interrupt GPIO pin number"
 	default 0
-	depends on LIS3DH && LIS3DH_TRIGGER
+	depends on LIS3DH_TRIGGER
 	help
 	  The number of the GPIO on which the interrupt signal from the LIS3DH
 	  chip will be received.
 
 config LIS3DH_THREAD_PRIORITY
 	int "Thread priority"
-	depends on LIS3DH && LIS3DH_TRIGGER_OWN_THREAD
+	depends on LIS3DH_TRIGGER_OWN_THREAD
 	default 10
 	help
 	  Priority of thread used by the driver to handle interrupts.
 
 config LIS3DH_THREAD_STACK_SIZE
 	int "Thread stack size"
-	depends on LIS3DH && LIS3DH_TRIGGER_OWN_THREAD
+	depends on LIS3DH_TRIGGER_OWN_THREAD
 	default 1024
 	help
 	  Stack size of thread used by the driver to handle interrupts.
 
 choice
 	prompt "Acceleration measurement range"
-	depends on LIS3DH
 	default LIS3DH_ACCEL_RANGE_2G
 	help
 	  Measurement full scale range for acceleration values.
@@ -116,7 +112,6 @@ endchoice
 
 choice
 	prompt "Power mode"
-	depends on LIS3DH
 	default LIS3DH_POWER_MODE_NORMAL
 	help
 	  Choose between normal or low power operation mode for chip.
@@ -131,7 +126,6 @@ endchoice
 
 choice
 	prompt "Data rate frequency"
-	depends on LIS3DH
 	default LIS3DH_ODR_1
 	help
 	  Data rate frequency of acceleration data.
@@ -170,3 +164,5 @@ config LIS3DH_ODR_9_LOW
 	depends on LIS3DH_POWER_MODE_LOW
 
 endchoice
+
+endif # LIS3DH

--- a/drivers/sensor/lis3mdl/Kconfig
+++ b/drivers/sensor/lis3mdl/Kconfig
@@ -10,18 +10,18 @@ menuconfig LIS3MDL
 	help
 	  Enable driver for LIS3MDL I2C-based magnetometer.
 
+if LIS3MDL
+
 if !HAS_DTS_I2C_DEVICE
 
 config LIS3MDL_NAME
 	string "Driver name"
 	default "LIS3MDL"
-	depends on LIS3MDL
 	help
 	  Device name with which the LIS3MDL sensor is identified.
 
 config LIS3MDL_I2C_ADDR
 	hex "I2C address"
-	depends on LIS3MDL
 	default 0x1C
 	help
 	  I2C address of the LIS3MDL sensor.
@@ -30,7 +30,6 @@ config LIS3MDL_I2C_ADDR
 
 config LIS3MDL_I2C_MASTER_DEV_NAME
 	string "I2C master where LIS3MDL is connected"
-	depends on LIS3MDL
 	default "I2C_0"
 	help
 	  Specify the device name of the I2C master device to which LIS3MDL is
@@ -40,7 +39,6 @@ endif
 
 choice LIS3MDL_TRIGGER_MODE
 	prompt "Trigger mode"
-	depends on LIS3MDL
 	default LIS3MDL_TRIGGER_GLOBAL_THREAD
 	help
 	  Specify the type of triggering to be used by the driver.
@@ -62,12 +60,11 @@ endchoice # LIS3MDL_TRIGGER_MODE
 
 config LIS3MDL_TRIGGER
 	bool
-	depends on LIS3MDL
 
 config LIS3MDL_GPIO_DEV_NAME
 	string "GPIO device"
 	default "GPIO_0"
-	depends on LIS3MDL && LIS3MDL_TRIGGER
+	depends on LIS3MDL_TRIGGER
 	help
 	  The device name of the GPIO device to which the LIS3MDL interrupt pins
 	  are connected.
@@ -75,28 +72,27 @@ config LIS3MDL_GPIO_DEV_NAME
 config LIS3MDL_GPIO_PIN_NUM
 	int "Interrupt GPIO pin number"
 	default 0
-	depends on LIS3MDL && LIS3MDL_TRIGGER
+	depends on LIS3MDL_TRIGGER
 	help
 	  The number of the GPIO on which the interrupt signal from the LIS3MDL
 	  chip will be received.
 
 config LIS3MDL_THREAD_PRIORITY
 	int "Thread priority"
-	depends on LIS3MDL && LIS3MDL_TRIGGER_OWN_THREAD
+	depends on LIS3MDL_TRIGGER_OWN_THREAD
 	default 10
 	help
 	  Priority of thread used by the driver to handle interrupts.
 
 config LIS3MDL_THREAD_STACK_SIZE
 	int "Thread stack size"
-	depends on LIS3MDL && LIS3MDL_TRIGGER_OWN_THREAD
+	depends on LIS3MDL_TRIGGER_OWN_THREAD
 	default 1024
 	help
 	  Stack size of thread used by the driver to handle interrupts.
 
 config LIS3MDL_ODR
 	string "Output data rate"
-	depends on LIS3MDL
 	default "0.625"
 	help
 	  Magnetometer output data rate expressed in samples per second.
@@ -105,9 +101,10 @@ config LIS3MDL_ODR
 
 config LIS3MDL_FS
 	int "Full-scale range"
-	depends on LIS3MDL
 	default 4
 	help
 	  Magnetometer full-scale range.
 	  An X value for the config represents a range of +/- X gauss. Valid
 	  values are 4, 8, 12 and 16.
+
+endif # LIS3MDL

--- a/drivers/sensor/lps22hb/Kconfig
+++ b/drivers/sensor/lps22hb/Kconfig
@@ -11,18 +11,18 @@ menuconfig LPS22HB
 	  Enable driver for LPS22HB I2C-based pressure and temperature
 	  sensor.
 
+if LPS22HB
+
 if !HAS_DTS_I2C_DEVICE
 
 config LPS22HB_DEV_NAME
 	string "Device name"
 	default "LPS22HB"
-	depends on LPS22HB
 	help
 	  Device name used for LPS22HB sensor identification.
 
 config LPS22HB_I2C_ADDR
 	hex "I2C address"
-	depends on LPS22HB
 	default 0x5D
 	range 0x5C 0x5D
 	help
@@ -32,7 +32,6 @@ config LPS22HB_I2C_ADDR
 
 config LPS22HB_I2C_MASTER_DEV_NAME
 	string "I2C master where LPS22HB is connected"
-	depends on LPS22HB
 	default I2C_0_NAME
 	help
 	  Specify the device name of the I2C master device to which
@@ -41,14 +40,14 @@ config LPS22HB_I2C_MASTER_DEV_NAME
 endif
 
 menu "Attributes"
-	depends on LPS22HB
 
 config LPS22HB_SAMPLING_RATE
 	int "Output data rate"
-	depends on LPS22HB
 	default 25
 	help
 	  Sensor output data rate expressed in samples per second.
 	  Data rates supported by the chip are 1, 10, 25, 50, 75.
 
 endmenu
+
+endif # LPS22HB

--- a/drivers/sensor/lps25hb/Kconfig
+++ b/drivers/sensor/lps25hb/Kconfig
@@ -11,18 +11,18 @@ menuconfig LPS25HB
 	  Enable driver for LPS25HB I2C-based pressure and temperature
 	  sensor.
 
+if LPS25HB
+
 if !HAS_DTS_I2C_DEVICE
 
 config LPS25HB_DEV_NAME
 	string "Device name"
 	default "lps25hb"
-	depends on LPS25HB
 	help
 	  Device name with which the LPS25HB sensor is identified.
 
 config LPS25HB_I2C_ADDR
 	hex "I2C address"
-	depends on LPS25HB
 	default "0x5C"
 	help
 	  I2C address of the LPS25HB sensor.
@@ -31,7 +31,6 @@ config LPS25HB_I2C_ADDR
 
 config LPS25HB_I2C_MASTER_DEV_NAME
 	string "I2C master where LPS25HB is connected"
-	depends on LPS25HB
 	default "I2C_0"
 	help
 	  Specify the device name of the I2C master device to which
@@ -40,14 +39,14 @@ config LPS25HB_I2C_MASTER_DEV_NAME
 endif
 
 menu "Attributes"
-	depends on LPS25HB
 
 config LPS25HB_SAMPLING_RATE
 	int "Output data rate"
-	depends on LPS25HB
 	default 25
 	help
 	  Sensor output data rate expressed in samples per second.
 	  Data rates supported by the chip are 1, 7, 13, 25.
 
 endmenu
+
+endif # LPS25HB

--- a/drivers/sensor/lsm6ds0/Kconfig
+++ b/drivers/sensor/lsm6ds0/Kconfig
@@ -14,16 +14,16 @@ menuconfig LSM6DS0
 	  Enable driver for LSM6DS0 I2C-based accelerometer and gyroscope
 	  sensor.
 
+if LSM6DS0
+
 if !HAS_DTS_I2C_DEVICE
 
 config LSM6DS0_DEV_NAME
 	string "LSM6DS0 device name"
-	depends on LSM6DS0
 	default "lsm6ds0"
 
 config LSM6DS0_I2C_ADDR
 	hex "LSM6DS0 I2C address"
-	depends on LSM6DS0
 	default 0x6B
 	help
 	  I2C address of the LSM6DS0 sensor.
@@ -32,7 +32,6 @@ config LSM6DS0_I2C_ADDR
 
 config LSM6DS0_I2C_MASTER_DEV_NAME
 	string "I2C master where LSM6DS0 chip is connected"
-	depends on LSM6DS0
 	default "I2C_0"
 	help
 	  Specify the device name of the I2C master device to which LSM6DS0 is
@@ -42,7 +41,6 @@ endif
 
 config LSM6DS0_ACCEL_ENABLE_X_AXIS
 	bool "Enable accelerometer X axis"
-	depends on LSM6DS0
 	default y
 	help
 	  Enable/disable accelerometer X axis totally by stripping everything
@@ -50,7 +48,6 @@ config LSM6DS0_ACCEL_ENABLE_X_AXIS
 
 config LSM6DS0_ACCEL_ENABLE_Y_AXIS
 	bool "Enable accelerometer Y axis"
-	depends on LSM6DS0
 	default y
 	help
 	  Enable/disable accelerometer Y axis totally by stripping everything
@@ -58,7 +55,6 @@ config LSM6DS0_ACCEL_ENABLE_Y_AXIS
 
 config LSM6DS0_ACCEL_ENABLE_Z_AXIS
 	bool "Enable accelerometer Z axis"
-	depends on LSM6DS0
 	default y
 	help
 	  Enable/disable accelerometer Z axis totally by stripping everything
@@ -66,7 +62,6 @@ config LSM6DS0_ACCEL_ENABLE_Z_AXIS
 
 config LSM6DS0_GYRO_ENABLE_X_AXIS
 	bool "Enable gyroscope X axis"
-	depends on LSM6DS0
 	default y
 	help
 	  Enable/disable gyroscope X axis totally by stripping everything
@@ -74,7 +69,6 @@ config LSM6DS0_GYRO_ENABLE_X_AXIS
 
 config LSM6DS0_GYRO_ENABLE_Y_AXIS
 	bool "Enable gyroscope Y axis"
-	depends on LSM6DS0
 	default y
 	help
 	  Enable/disable gyroscope Y axis totally by stripping everything
@@ -82,7 +76,6 @@ config LSM6DS0_GYRO_ENABLE_Y_AXIS
 
 config LSM6DS0_GYRO_ENABLE_Z_AXIS
 	bool "Enable gyroscope Z axis"
-	depends on LSM6DS0
 	default y
 	help
 	  Enable/disable gyroscope Z axis totally by stripping everything
@@ -90,17 +83,14 @@ config LSM6DS0_GYRO_ENABLE_Z_AXIS
 
 config LSM6DS0_ENABLE_TEMP
 	bool "Enable temperature"
-	depends on LSM6DS0
 	help
 	  Enable/disable temperature totally by stripping everything related in
 	  driver.
 
 menu "Attributes"
-	depends on LSM6DS0
 
 config LSM6DS0_GYRO_FULLSCALE
 	int "Gyroscope full-scale range"
-	depends on LSM6DS0
 	default 245
 	help
 	  Specify the default gyroscope full-scale range.
@@ -109,7 +99,6 @@ config LSM6DS0_GYRO_FULLSCALE
 
 config LSM6DS0_GYRO_SAMPLING_RATE
 	int "Output data rate"
-	depends on LSM6DS0
 	default 15
 	help
 	  Specify the default gyroscope output data rate expressed in samples
@@ -119,7 +108,6 @@ config LSM6DS0_GYRO_SAMPLING_RATE
 
 config LSM6DS0_ACCEL_FULLSCALE
 	int "Accelerometer full-scale range"
-	depends on LSM6DS0
 	default 2
 	help
 	  Specify the default accelerometer full-scale range.
@@ -128,7 +116,6 @@ config LSM6DS0_ACCEL_FULLSCALE
 
 config LSM6DS0_ACCEL_SAMPLING_RATE
 	int "Output data rate"
-	depends on LSM6DS0
 	default 10
 	help
 	  Specify the default accelerometer output data rate expressed in
@@ -136,3 +123,5 @@ config LSM6DS0_ACCEL_SAMPLING_RATE
 	  Data rates supported by the chip are 0, 10, 50, 119, 238, 476, 952.
 
 endmenu
+
+endif # LSM6DS0

--- a/drivers/sensor/lsm6dsl/Kconfig
+++ b/drivers/sensor/lsm6dsl/Kconfig
@@ -9,7 +9,7 @@
 
 menuconfig LSM6DSL
 	bool "LSM6DSL I2C/SPI accelerometer and gyroscope Chip"
-	depends on SENSOR && (I2C || SPI)
+	depends on (I2C || SPI)
 	help
 	  Enable driver for LSM6DSL accelerometer and gyroscope
 	  sensor.

--- a/drivers/sensor/lsm6dsl/Kconfig
+++ b/drivers/sensor/lsm6dsl/Kconfig
@@ -14,9 +14,10 @@ menuconfig LSM6DSL
 	  Enable driver for LSM6DSL accelerometer and gyroscope
 	  sensor.
 
+if LSM6DSL
+
 choice LSM6DSL_BUS_TYPE
 	prompt "Interface to AP"
-	depends on LSM6DSL
 	help
 	  Select interface the LSM6DSL driver is connected to AP
 
@@ -39,7 +40,7 @@ if !HAS_DTS_I2C_DEVICE
 
 config LSM6DSL_I2C_ADDR
 	hex "LSM6DSL I2C address"
-	depends on LSM6DSL && LSM6DSL_I2C
+	depends on LSM6DSL_I2C
 	default 0x6A
 	range 0x6A 0x6B
 	help
@@ -49,7 +50,7 @@ config LSM6DSL_I2C_ADDR
 
 config LSM6DSL_I2C_MASTER_DEV_NAME
 	string "I2C master name where LSM6DSL chip is connected"
-	depends on LSM6DSL && LSM6DSL_I2C
+	depends on LSM6DSL_I2C
 	default "I2C_2"
 	help
 	  Specify the device name of the I2C master device to which LSM6DSL is
@@ -61,7 +62,7 @@ if !HAS_DTS_SPI_DEVICE
 
 config LSM6DSL_SPI_SELECT_SLAVE
 	hex "LSM6DSL SPI slave select pin"
-	depends on LSM6DSL && LSM6DSL_SPI
+	depends on LSM6DSL_SPI
 	default 1
 	help
 	  LSM6DSL SPI chip select pin (active low).
@@ -69,14 +70,14 @@ config LSM6DSL_SPI_SELECT_SLAVE
 config LSM6DSL_SPI_BUS_FREQ
 	int "LSM6DSL SPI bus speed in Hz"
 	default 8000000
-	depends on LSM6DSL && LSM6DSL_SPI
+	depends on LSM6DSL_SPI
 	help
 	  This is the maximum supported SPI bus frequency. The chip supports a
 	  frequency up to 10MHz.
 
 config LSM6DSL_SPI_MASTER_DEV_NAME
 	string "SPI master name where LSM6DSL chip is connected"
-	depends on LSM6DSL && LSM6DSL_SPI
+	depends on LSM6DSL_SPI
 	default "SPI_2"
 	help
 	  Specify the device name of the spi master device to which LSM6DSL is
@@ -86,7 +87,7 @@ endif #HAS_DTS_SPI_DEVICE
 
 config LSM6DSL_SPI_GPIO_CS
 	bool "LSM6DSL SPI CS through a GPIO pin"
-	depends on LSM6DSL && LSM6DSL_SPI
+	depends on LSM6DSL_SPI
 	help
 	  This option is useful if one needs to manage SPI CS through a GPIO
 	  pin to by-pass the SPI controller's CS logic.
@@ -113,7 +114,6 @@ endif # !HAS_DTS_SPI_PINS
 
 choice LSM6DSL_TRIGGER_MODE
 	prompt "Trigger mode"
-	depends on LSM6DSL
 	help
 	  Specify the type of triggering to be used by the driver.
 
@@ -134,20 +134,19 @@ endchoice
 
 config LSM6DSL_TRIGGER
 	bool
-	depends on LSM6DSL
 
 if !HAS_DTS_SPI_PINS
 
 config LSM6DSL_GPIO_DEV_NAME
 	string "GPIO device"
-	depends on LSM6DSL && LSM6DSL_TRIGGER
+	depends on LSM6DSL_TRIGGER
 	help
 	  The device name of the GPIO device to which the LSM6DSL interrupt pin
 	  is connected.
 
 config LSM6DSL_GPIO_PIN_NUM
 	int "Interrupt GPIO pin number"
-	depends on LSM6DSL && LSM6DSL_TRIGGER
+	depends on LSM6DSL_TRIGGER
 	help
 	  The number of the GPIO on which the interrupt signal from the LSM6DSL
 	  chip will be received.
@@ -156,27 +155,25 @@ endif #HAS_DTS_SPI_DEVICE
 
 config LSM6DSL_THREAD_PRIORITY
 	int "Thread priority"
-	depends on LSM6DSL && LSM6DSL_TRIGGER_OWN_THREAD
+	depends on LSM6DSL_TRIGGER_OWN_THREAD
 	default 10
 	help
 	  Priority of thread used by the driver to handle interrupts.
 
 config LSM6DSL_THREAD_STACK_SIZE
 	int "Thread stack size"
-	depends on LSM6DSL && LSM6DSL_TRIGGER_OWN_THREAD
+	depends on LSM6DSL_TRIGGER_OWN_THREAD
 	default 1024
 	help
 	  Stack size of thread used by the driver to handle interrupts.
 
 config LSM6DSL_ENABLE_TEMP
 	bool "Enable temperature"
-	depends on LSM6DSL
 	help
 	  Enable/disable temperature
 
 config LSM6DSL_SENSORHUB
 	bool "Enable I2C sensorhub feature"
-	depends on LSM6DSL
 	help
 	  Enable/disable internal sensorhub
 
@@ -202,11 +199,9 @@ endchoice
 endif #LSM6DSL_SENSORHUB
 
 menu "Attributes"
-	depends on LSM6DSL
 
 config LSM6DSL_GYRO_FS
 	int "Gyroscope full-scale range"
-	depends on LSM6DSL
 	default 0
 	help
 	  Specify the default gyroscope full-scale range.
@@ -221,7 +216,6 @@ config LSM6DSL_GYRO_FS
 
 config LSM6DSL_GYRO_ODR
 	int "Gyroscope Output data rate frequency"
-	depends on LSM6DSL
 	range 0 10
 	default 0
 	help
@@ -241,7 +235,6 @@ config LSM6DSL_GYRO_ODR
 
 config LSM6DSL_ACCEL_FS
 	int "Accelerometer full-scale range"
-	depends on LSM6DSL
 	default 0
 	help
 	  Specify the default accelerometer full-scale range.
@@ -255,7 +248,6 @@ config LSM6DSL_ACCEL_FS
 
 config LSM6DSL_ACCEL_ODR
 	int "Accelerometer Output data rate frequency"
-	depends on LSM6DSL
 	range 0 10
 	default 0
 	help
@@ -273,3 +265,5 @@ config LSM6DSL_ACCEL_ODR
 	  9: 3330Hz
 	  10: 6660Hz
 endmenu
+
+endif # LSM6DSL

--- a/drivers/sensor/lsm9ds0_gyro/Kconfig
+++ b/drivers/sensor/lsm9ds0_gyro/Kconfig
@@ -12,15 +12,15 @@ menuconfig LSM9DS0_GYRO
 	help
 	  Enable driver for LSM9DS0 I2C-based gyroscope sensor.
 
+if LSM9DS0_GYRO
+
 config LSM9DS0_GYRO_DEV_NAME
 	string "LSM9DS0_GYRO device name"
-	depends on LSM9DS0_GYRO
 	default "lsm9ds0_gyro"
 
 config LSM9DS0_GYRO_I2C_ADDR
 	hex "LSM9DS0_GYRO I2C slave address"
 	default 0x6A
-	depends on LSM9DS0_GYRO
 	help
 	  Specify the I2C slave address for the LSM9DS0_GYRO.
 
@@ -29,19 +29,16 @@ config LSM9DS0_GYRO_I2C_ADDR
 
 config LSM9DS0_GYRO_I2C_MASTER_DEV_NAME
 	string "I2C master where LSM9DS0 gyroscope is connected"
-	depends on LSM9DS0_GYRO
 	default "I2C_0"
 	help
 	  Specify the device name of the I2C master device to which LSM9DS0_GYRO
 	  is connected.
 
 menu "Attributes"
-	depends on LSM9DS0_GYRO
 
 choice
 	prompt "Default full-scale"
 	default LSM9DS0_GYRO_FULLSCALE_245
-	depends on LSM9DS0_GYRO
 	help
 	  Specify the default full-scale.
 
@@ -58,14 +55,12 @@ endchoice
 
 config LSM9DS0_GYRO_FULLSCALE_RUNTIME
 	bool "Enable dynamic full-scale"
-	depends on LSM9DS0_GYRO
 	help
 	  Enable alteration of full-scale attribute at runtime.
 
 choice
 	prompt "Default sampling rate frequency"
 	default LSM9DS0_GYRO_SAMPLING_RATE_95
-	depends on LSM9DS0_GYRO
 	help
 	  Specify the default sampling rate frequency.
 
@@ -85,7 +80,6 @@ endchoice
 
 config LSM9DS0_GYRO_SAMPLING_RATE_RUNTIME
 	bool "Enable dynamic sampling rate"
-	depends on LSM9DS0_GYRO
 	help
 	  Enable alteration of sampling rate frequency at runtime.
 
@@ -93,7 +87,7 @@ endmenu
 
 config LSM9DS0_GYRO_TRIGGERS
 	bool "Enable triggers"
-	depends on LSM9DS0_GYRO && GPIO
+	depends on GPIO
 
 config LSM9DS0_GYRO_THREAD_STACK_SIZE
 	int "Thread stack size"
@@ -118,3 +112,5 @@ config LSM9DS0_GYRO_GPIO_DRDY_INT_PIN
 	int "GPIO pin number for the data ready interrupt pin"
 	default 3
 	depends on LSM9DS0_GYRO_TRIGGER_DRDY
+
+endif # LSM9DS0_GYRO

--- a/drivers/sensor/lsm9ds0_mfd/Kconfig
+++ b/drivers/sensor/lsm9ds0_mfd/Kconfig
@@ -13,15 +13,15 @@ menuconfig LSM9DS0_MFD
 	help
 	  Enable driver for LSM9DS0 I2C-based MFD sensor.
 
+if LSM9DS0_MFD
+
 config LSM9DS0_MFD_DEV_NAME
 	string "LSM9DS0_MFD device name"
-	depends on LSM9DS0_MFD
 	default "lsm9ds0_mfd"
 
 config LSM9DS0_MFD_I2C_ADDR
 	hex "LSM9DS0_MFD I2C slave address"
 	default 0x1E
-	depends on LSM9DS0_MFD
 	help
 	  Specify the I2C slave address for the LSM9DS0_MFD.
 
@@ -30,7 +30,6 @@ config LSM9DS0_MFD_I2C_ADDR
 
 config LSM9DS0_MFD_I2C_MASTER_DEV_NAME
 	string "I2C master where LSM9DS0 gyroscope is connected"
-	depends on LSM9DS0_MFD
 	default "I2C_0"
 	help
 	  Specify the device name of the I2C master device to which LSM9DS0_MFD
@@ -38,7 +37,6 @@ config LSM9DS0_MFD_I2C_MASTER_DEV_NAME
 
 config LSM9DS0_MFD_ACCEL_ENABLE
 	bool "Enable accelerometer"
-	depends on LSM9DS0_MFD
 	default y
 	help
 	  Enable/disable accelerometer totally by stripping everything related
@@ -46,7 +44,6 @@ config LSM9DS0_MFD_ACCEL_ENABLE
 
 config LSM9DS0_MFD_MAGN_ENABLE
 	bool "Enable magnetometer"
-	depends on LSM9DS0_MFD
 	default y
 	help
 	  Enable/disable magnetometer totally by stripping everything related in
@@ -54,13 +51,11 @@ config LSM9DS0_MFD_MAGN_ENABLE
 
 config LSM9DS0_MFD_TEMP_ENABLE
 	bool "Enable temperature sensor"
-	depends on LSM9DS0_MFD
 	help
 	  Enable/disable temperature sensor totally by stripping everything
 	  related in driver.
 
 menu "Attributes"
-	depends on LSM9DS0_MFD
 
 choice
 	prompt "Accelerometer sampling rate"
@@ -220,3 +215,5 @@ config LSM9DS0_MFD_MAGN_FULL_SCALE_RUNTIME
 	  runtime.
 
 endmenu
+
+endif # LSM9DS0_MFD

--- a/drivers/sensor/max44009/Kconfig
+++ b/drivers/sensor/max44009/Kconfig
@@ -12,17 +12,17 @@ menuconfig MAX44009
 	help
 	  Enable driver for MAX44009 light sensors.
 
+if MAX44009
+
 config MAX44009_DRV_NAME
 	string "Driver name"
 	default "MAX44009"
-	depends on MAX44009
 	help
 	  Device name with which the MAX44009 light is identified.
 
 
 config MAX44009_I2C_ADDR
 	hex "MAX44009 I2C address"
-	depends on MAX44009
 	default "0x4a"
 	help
 	  I2C address of the MAX44009 sensor. Possible configurations:
@@ -32,8 +32,9 @@ config MAX44009_I2C_ADDR
 
 config MAX44009_I2C_DEV_NAME
 	string "I2C master where MAX44009 is connected"
-	depends on MAX44009
 	default "I2C_0"
 	help
 	  Specify the device name of the I2C master device to which the
 	  MAX44009 chip is connected.
+
+endif # MAX44009

--- a/drivers/sensor/mcp9808/Kconfig
+++ b/drivers/sensor/mcp9808/Kconfig
@@ -12,22 +12,21 @@ menuconfig MCP9808
 	help
 	 Enable driver for MCP9808 temperature sensor.
 
+if MCP9808
+
 config MCP9808_DEV_NAME
 	string "MCP9808 device name"
-	depends on MCP9808
 	default "MCP9808"
 
 
 config MCP9808_I2C_ADDR
 	hex "MCP9808 I2C slave address"
-	depends on MCP9808
 	default 0x18
 	help
 	 Specify the I2C slave address for the MCP9808.
 
 config MCP9808_I2C_DEV_NAME
 	string "I2C master where MCP9808 is connected"
-	depends on MCP9808
 	default "I2C_0"
 	help
 	 Specify the device name of the I2C master device to which MCP9808 is
@@ -35,7 +34,6 @@ config MCP9808_I2C_DEV_NAME
 
 choice
 	prompt "MCP9808 trigger mode"
-	depends on MCP9808
 	default MCP9808_TRIGGER_NONE
 
 config MCP9808_TRIGGER_NONE
@@ -55,28 +53,29 @@ endchoice
 
 config MCP9808_TRIGGER
 	bool
-	depends on MCP9808
 
 config MCP9808_GPIO_CONTROLLER
 	string "GPIO controller for MCP9808 interrupt"
-	depends on MCP9808 && MCP9808_TRIGGER
+	depends on MCP9808_TRIGGER
 	default "GPIO_0"
 	help
 	  The GPIO controller the MCP9808 interrupt is connected to.
 
 config MCP9808_GPIO_PIN
 	int "GPIO pin for MCP9808 interrupt"
-	depends on MCP9808 && MCP9808_TRIGGER
+	depends on MCP9808_TRIGGER
 	default 3
 	help
 	  The GPIO pin the MCP9808 interrupt is connected to.
 
 config MCP9808_THREAD_STACK_SIZE
 	int "Sensor delayed work thread stack size"
-	depends on MCP9808 && MCP9808_TRIGGER_OWN_THREAD
+	depends on MCP9808_TRIGGER_OWN_THREAD
 	default 1024
 
 config MCP9808_THREAD_PRIORITY
 	int "MCP9808 thread priority"
-	depends on MCP9808 && MCP9808_TRIGGER_OWN_THREAD
+	depends on MCP9808_TRIGGER_OWN_THREAD
 	default 10
+
+endif # MCP9808

--- a/drivers/sensor/mma8451q/Kconfig
+++ b/drivers/sensor/mma8451q/Kconfig
@@ -11,21 +11,20 @@ menuconfig MMA8451Q
 	help
 	  Enable driver for MMA8451Q Accelerometer.
 
+if MMA8451Q
+
 if !HAS_DTS_I2C_DEVICE
 
 config MMA8451Q_NAME
 	string "Device name"
-	depends on MMA8451Q
 	default "MMA8451Q"
 
 config MMA8451Q_I2C_NAME
 	string "I2C device name"
-	depends on MMA8451Q
 	default I2C_0_NAME
 
 config MMA8451Q_I2C_ADDRESS
 	hex "I2C address for MMA8451Q Sensor"
-	depends on MMA8451Q
 	default 0x1D
 	help
 	  I2C address of the MMA8451Q sensor.
@@ -35,14 +34,12 @@ endif # !HAS_DTS_I2C_DEVICE
 
 config MMA8451Q_WHOAMI
 	hex "WHOAMI value"
-	depends on MMA8451Q
 	default 0x1A
 	help
 	  The whoami value for MMA8451Q (0x1A).
 
 choice
 	prompt "Range"
-	depends on MMA8451Q
 	default MMA8451Q_RANGE_2G
 
 config MMA8451Q_RANGE_8G
@@ -55,3 +52,5 @@ config MMA8451Q_RANGE_2G
 	bool "2g (0.244 mg/LSB)"
 
 endchoice
+
+endif # MMA8451Q

--- a/drivers/sensor/mpu6050/Kconfig
+++ b/drivers/sensor/mpu6050/Kconfig
@@ -12,16 +12,16 @@ menuconfig MPU6050
 	help
 	  Enable driver for MPU6050 I2C-based six-axis motion tracking device.
 
+if MPU6050
+
 config MPU6050_NAME
 	string "Driver name"
 	default "MPU6050"
-	depends on MPU6050
 	help
 	  Device name with which the MPU6050 sensor is identified.
 
 config MPU6050_I2C_ADDR
 	hex "I2C address"
-	depends on MPU6050
 	default 0x68
 	range 0x68 0x69
 	help
@@ -31,7 +31,6 @@ config MPU6050_I2C_ADDR
 
 config MPU6050_I2C_MASTER_DEV_NAME
 	string "I2C master where MPU6050 is connected"
-	depends on MPU6050
 	default "I2C_0"
 	help
 	  Specify the device name of the I2C master device to which MPU6050 is
@@ -39,7 +38,6 @@ config MPU6050_I2C_MASTER_DEV_NAME
 
 choice
 	prompt "Trigger mode"
-	depends on MPU6050
 	default MPU6050_TRIGGER_GLOBAL_THREAD
 	help
 	  Specify the type of triggering to be used by the driver.
@@ -61,12 +59,11 @@ endchoice
 
 config MPU6050_TRIGGER
 	bool
-	depends on MPU6050
 
 config MPU6050_GPIO_DEV_NAME
 	string "GPIO device"
 	default "GPIO_0"
-	depends on MPU6050 && MPU6050_TRIGGER
+	depends on MPU6050_TRIGGER
 	help
 	  The device name of the GPIO device to which the MPU6050 interrupt pin
 	  is connected.
@@ -74,28 +71,27 @@ config MPU6050_GPIO_DEV_NAME
 config MPU6050_GPIO_PIN_NUM
 	int "Interrupt GPIO pin number"
 	default 0
-	depends on MPU6050 && MPU6050_TRIGGER
+	depends on MPU6050_TRIGGER
 	help
 	  The number of the GPIO on which the interrupt signal from the MPU6050
 	  chip will be received.
 
 config MPU6050_THREAD_PRIORITY
 	int "Thread priority"
-	depends on MPU6050 && MPU6050_TRIGGER_OWN_THREAD
+	depends on MPU6050_TRIGGER_OWN_THREAD
 	default 10
 	help
 	  Priority of thread used by the driver to handle interrupts.
 
 config MPU6050_THREAD_STACK_SIZE
 	int "Thread stack size"
-	depends on MPU6050 && MPU6050_TRIGGER_OWN_THREAD
+	depends on MPU6050_TRIGGER_OWN_THREAD
 	default 1024
 	help
 	  Stack size of thread used by the driver to handle interrupts.
 
 config MPU6050_ACCEL_FS
 	int "Accelerometer full-scale range"
-	depends on MPU6050
 	default 2
 	help
 	  Magnetometer full-scale range.
@@ -104,9 +100,10 @@ config MPU6050_ACCEL_FS
 
 config MPU6050_GYRO_FS
 	int "Gyroscope full-scale range"
-	depends on MPU6050
 	default 250
 	help
 	  Gyroscope full-scale range.
 	  An X value for the config represents a range of +/- X degrees/second.
 	  Valid values are 250, 500, 1000, 2000.
+
+endif # MPU6050

--- a/drivers/sensor/nrf5/Kconfig
+++ b/drivers/sensor/nrf5/Kconfig
@@ -12,18 +12,20 @@ menuconfig TEMP_NRF5
 	help
 	  Enable driver for nRF5 temperature sensor.
 
+if TEMP_NRF5
+
 config TEMP_NRF5_NAME
 	string "Driver name"
 	default "TEMP_0"
-	depends on TEMP_NRF5
 	help
 	  Device name with which the nRF5 temperature sensor is identified.
 
 config TEMP_NRF5_PRI
 	int "TEMP interrupt priority"
-	depends on TEMP_NRF5
 	range 0 1 if SOC_SERIES_NRF51X
 	range 0 5 if SOC_SERIES_NRF52X
 	default 1
 	help
 	  nRF5X TEMP IRQ priority.
+
+endif # TEMP_NRF5

--- a/drivers/sensor/pms7003/Kconfig
+++ b/drivers/sensor/pms7003/Kconfig
@@ -12,12 +12,14 @@ menuconfig PMS7003
 	help
 	  Enable driver for pms7003 particulate matter sensor.
 
+if PMS7003
+
 config PMS7003_UART_DEVICE
 	string "UART device"
-	depends on PMS7003
 	default "UART_3"
 
 config PMS7003_DRIVER_NAME
 	string "Driver name"
-	depends on PMS7003
 	default "PMS7003"
+
+endif # PMS7003

--- a/drivers/sensor/sht3xd/Kconfig
+++ b/drivers/sensor/sht3xd/Kconfig
@@ -12,16 +12,16 @@ menuconfig SHT3XD
 	help
 	  Enable driver for SHT3xD temperature and humidity sensors.
 
+if SHT3XD
+
 config SHT3XD_NAME
 	string "Driver name"
 	default "SHT3XD"
-	depends on SHT3XD
 	help
 	  Device name with which the SHT3xD sensor is identified.
 
 config SHT3XD_I2C_ADDR
 	hex "SHT3XD I2C address"
-	depends on SHT3XD
 	default "0x44"
 	help
 	  I2C address of the SHT3xD sensor.
@@ -31,7 +31,6 @@ config SHT3XD_I2C_ADDR
 
 config SHT3XD_I2C_MASTER_DEV_NAME
 	string "I2C master where SHT3xD is connected"
-	depends on SHT3XD
 	default "I2C_0"
 	help
 	  Specify the device name of the I2C master device to which the
@@ -39,7 +38,6 @@ config SHT3XD_I2C_MASTER_DEV_NAME
 
 choice
 	prompt "Trigger mode"
-	depends on SHT3XD
 	default SHT3XD_TRIGGER_NONE
 	help
 	  Specify the type of triggering to be used by the driver.
@@ -61,12 +59,11 @@ endchoice
 
 config SHT3XD_TRIGGER
 	bool
-	depends on SHT3XD
 
 config SHT3XD_GPIO_DEV_NAME
 	string "GPIO device"
 	default "GPIO_0"
-	depends on SHT3XD && SHT3XD_TRIGGER
+	depends on SHT3XD_TRIGGER
 	help
 	  The device name of the GPIO device to which the SHT3xD interrupt
 	  pins are connected.
@@ -74,28 +71,27 @@ config SHT3XD_GPIO_DEV_NAME
 config SHT3XD_GPIO_PIN_NUM
 	int "Interrupt GPIO pin number"
 	default 0
-	depends on SHT3XD && SHT3XD_TRIGGER
+	depends on SHT3XD_TRIGGER
 	help
 	  The number of the GPIO on which the interrupt signal from the
 	  SHT3xD chip will be received.
 
 config SHT3XD_THREAD_PRIORITY
 	int "Thread priority"
-	depends on SHT3XD && SHT3XD_TRIGGER_OWN_THREAD
+	depends on SHT3XD_TRIGGER_OWN_THREAD
 	default 10
 	help
 	  Priority of thread used by the driver to handle interrupts.
 
 config SHT3XD_THREAD_STACK_SIZE
 	int "Thread stack size"
-	depends on SHT3XD && SHT3XD_TRIGGER_OWN_THREAD
+	depends on SHT3XD_TRIGGER_OWN_THREAD
 	default 1024
 	help
 	  Stack size of thread used by the driver to handle interrupts.
 
 choice
 	prompt "Measurement repeatability"
-	depends on SHT3XD
 	default SHT3XD_REPEATABILITY_HIGH
 	help
 	  Repeatability modes differ with respect to measurement duration,
@@ -114,7 +110,6 @@ endchoice
 
 choice
 	prompt "Measurements per second"
-	depends on SHT3XD
 	default SHT3XD_MPS_1
 	help
 	  Number of measurements per second.
@@ -135,3 +130,5 @@ config SHT3XD_MPS_10
 	bool "10"
 
 endchoice
+
+endif # SHT3XD

--- a/drivers/sensor/sx9500/Kconfig
+++ b/drivers/sensor/sx9500/Kconfig
@@ -12,21 +12,20 @@ menuconfig SX9500
 	help
 	  Enable driver for SX9500 I2C-based SAR proximity sensor.
 
+if SX9500
+
 config SX9500_DEV_NAME
 	string "SX9500 device name"
-	depends on SX9500
 	default "SX9500"
 
 config SX9500_I2C_ADDR
 	hex "SX9500 I2C slave address"
-	depends on SX9500
 	default 0x2B
 	help
 	  Specify the I2C slave address for the SX9500.
 
 config SX9500_I2C_DEV_NAME
 	string "I2C master where SX9500 is connected"
-	depends on SX9500
 	default "I2C_0"
 	help
 	  Specify the device name of the I2C master device to which SX9500 is
@@ -35,14 +34,12 @@ config SX9500_I2C_DEV_NAME
 config SX9500_PROX_CHANNEL
 	int "Proximity channel to use"
 	default 3
-	depends on SX9500
 	help
 	  The SX9500 offers 4 separate proximity channels.  Choose which one
 	  you are using.  Valid numbers are 0 to 3.
 
 choice
 	prompt "SX9500 trigger mode"
-	depends on SX9500
 	default SX9500_TRIGGER_GLOBAL_THREAD
 
 config SX9500_TRIGGER_NONE
@@ -62,11 +59,10 @@ endchoice
 
 config SX9500_TRIGGER
 	bool
-	depends on SX9500
 
 config SX9500_GPIO_CONTROLLER
 	string "GPIO controller for SX9500 interrupt"
-	depends on SX9500 && SX9500_TRIGGER
+	depends on SX9500_TRIGGER
 	default "GPIO_0"
 	help
 	  Specify the device name of the GPIO controller the SX9500 interrupt
@@ -74,15 +70,17 @@ config SX9500_GPIO_CONTROLLER
 
 config SX9500_GPIO_PIN
 	int "GPIO pin for SX9500 interrupt"
-	depends on SX9500 && SX9500_TRIGGER
+	depends on SX9500_TRIGGER
 	default 3
 
 config SX9500_THREAD_STACK_SIZE
 	int "Sensor delayed work thread stack size"
-	depends on SX9500 && SX9500_TRIGGER_OWN_THREAD
+	depends on SX9500_TRIGGER_OWN_THREAD
 	default 1024
 
 config SX9500_THREAD_PRIORITY
 	int "Thread priority"
-	depends on SX9500 && SX9500_TRIGGER_OWN_THREAD
+	depends on SX9500_TRIGGER_OWN_THREAD
 	default 10
+
+endif # SX9500

--- a/drivers/sensor/tmp007/Kconfig
+++ b/drivers/sensor/tmp007/Kconfig
@@ -12,16 +12,16 @@ menuconfig TMP007
 	help
 	  Enable driver for TMP007 infrared thermopile sensors.
 
+if TMP007
+
 config TMP007_NAME
 	string "Driver name"
 	default "TMP007"
-	depends on TMP007
 	help
 	  Device name with which the TMP007 sensor is identified.
 
 config TMP007_I2C_ADDR
 	hex "I2C address for TMP006 Sensor"
-	depends on TMP007
 	default "0x40"
 	help
 	  I2C address of the TMP007 sensor.
@@ -37,7 +37,6 @@ config TMP007_I2C_ADDR
 
 config TMP007_I2C_MASTER_DEV_NAME
 	string "I2C master where TMP007 is connected"
-	depends on TMP007
 	default "I2C_0"
 	help
 	  Specify the device name of the I2C master device to which the
@@ -45,7 +44,6 @@ config TMP007_I2C_MASTER_DEV_NAME
 
 choice
 	prompt "Trigger mode"
-	depends on TMP007
 	default TMP007_TRIGGER_NONE
 	help
 	  Specify the type of triggering to be used by the driver.
@@ -67,12 +65,11 @@ endchoice
 
 config TMP007_TRIGGER
 	bool
-	depends on TMP007
 
 config TMP007_GPIO_DEV_NAME
 	string "GPIO device"
 	default "GPIO_0"
-	depends on TMP007 && TMP007_TRIGGER
+	depends on TMP007_TRIGGER
 	help
 	  The device name of the GPIO device to which the TMP007 interrupt
 	  (alert) pin is connected.
@@ -80,21 +77,23 @@ config TMP007_GPIO_DEV_NAME
 config TMP007_GPIO_PIN_NUM
 	int "Interrupt GPIO pin number"
 	default 0
-	depends on TMP007 && TMP007_TRIGGER
+	depends on TMP007_TRIGGER
 	help
 	  The number of the GPIO pin on which the interrupt signal from the
 	  TMP007 chip will be received.
 
 config TMP007_THREAD_PRIORITY
 	int "Thread priority"
-	depends on TMP007 && TMP007_TRIGGER_OWN_THREAD
+	depends on TMP007_TRIGGER_OWN_THREAD
 	default 10
 	help
 	  Priority of thread used by the driver to handle interrupts.
 
 config TMP007_THREAD_STACK_SIZE
 	int "Thread stack size"
-	depends on TMP007 && TMP007_TRIGGER_OWN_THREAD
+	depends on TMP007_TRIGGER_OWN_THREAD
 	default 1024
 	help
 	  Stack size of thread used by the driver to handle interrupts.
+
+endif # TMP007

--- a/drivers/sensor/tmp112/Kconfig
+++ b/drivers/sensor/tmp112/Kconfig
@@ -16,16 +16,16 @@ menuconfig TMP112
 	  The TMP102 is compatible with the TMP112 but is less accurate and has
 	  been successfully tested with this driver.
 
+if TMP112
+
 config TMP112_NAME
 	string "Driver name"
 	default "TMP112"
-	depends on TMP112
 	help
 	  Device name with which the TMP112 sensor is identified.
 
 config TMP112_I2C_ADDR
 	hex "I2C address for TMP112"
-	depends on TMP112
 	default 0x48
 	help
 	  I2C address of the TMP112 sensor.
@@ -38,8 +38,9 @@ config TMP112_I2C_ADDR
 
 config TMP112_I2C_MASTER_DEV_NAME
 	string "I2C master where TMP112 is connected"
-	depends on TMP112
 	default "I2C_0"
 	help
 	  Specify the device name of the I2C master device to which the
 	  TMP112 chip is connected.
+
+endif # TMP112

--- a/drivers/sensor/vl53l0x/Kconfig
+++ b/drivers/sensor/vl53l0x/Kconfig
@@ -13,25 +13,24 @@ menuconfig VL53L0X
 	help
 	  Enable driver for VL53L0X I2C-based time of flight sensor.
 
+if VL53L0X
+
 if !HAS_DTS_I2C_DEVICE
 
 config VL53L0X_NAME
 	string "Driver name"
 	default "VL53L0X"
-	depends on VL53L0X
 	help
 	  Device name with which the VL53L0X sensor is identified.
 
 config VL53L0X_I2C_ADDR
 	hex "Vl53l0x I2C address"
 	default 0x29
-	depends on VL53L0X
 	help
 	  address of the i2c used for the vl53l0x sensor
 
 config VL53L0X_I2C_MASTER_DEV_NAME
 	string "I2C master where VL53L0X is connected"
-	depends on VL53L0X
 	default "I2C_0"
 	help
 	  Specify the device name of the I2C master device to which VL53L0X is
@@ -41,7 +40,6 @@ endif
 
 config VL53L0X_XSHUT_CONTROL_ENABLE
 	bool "Enable XSHUT pin control"
-	depends on VL53L0X
 	help
 	    Enable it if XSHUT pin is controlled by host.
 
@@ -64,6 +62,7 @@ config VL53L0X_XSHUT_GPIO_PIN_NUM
 config VL53L0X_PROXIMITY_THRESHOLD
 	int "Proximity threshold in millimeters"
 	default 100
-	depends on VL53L0X
 	help
 	  Threshold used for proximity detection when sensor is used with SENSOR_CHAN_PROX.
+
+endif # VL53L0X

--- a/drivers/sensor/vl53l0x/Kconfig
+++ b/drivers/sensor/vl53l0x/Kconfig
@@ -8,7 +8,7 @@
 
 menuconfig VL53L0X
 	bool "VL53L0X time of flight sensor"
-	depends on SENSOR && I2C
+	depends on I2C
 	select HAS_STLIB
 	help
 	  Enable driver for VL53L0X I2C-based time of flight sensor.


### PR DESCRIPTION
- Eliminate repetitive Kconfig "depends on" in sensor drivers
- Remove redundant Kconfig "depends on SENSOR" in sensor drivers