### PR TITLE
kernel: Fix k_stack_alloc_init behavior

### DIFF
--- a/kernel/stack.c
+++ b/kernel/stack.c
@@ -79,8 +79,7 @@ Z_SYSCALL_HANDLER(k_stack_alloc_init, stack, num_entries)
 	Z_OOPS(Z_SYSCALL_OBJ_NEVER_INIT(stack, K_OBJ_STACK));
 	Z_OOPS(Z_SYSCALL_VERIFY(num_entries > 0));
 
-	_impl_k_stack_alloc_init((struct k_stack *)stack, num_entries);
-	return 0;
+	return _impl_k_stack_alloc_init((struct k_stack *)stack, num_entries);
 }
 #endif
 


### PR DESCRIPTION
The implementation of this syscall can return either 0 or -ENOMEM, but
when USERSPACE is enabled and it is called through syscall it always
return 0.

Just change this syscall implementation to return the value of
_impl_k_stack_alloc_init

Signed-off-by: Flavio Ceolin <flavio.ceolin@intel.com>