### PR TITLE
net/udp: Separating net_context from udp and other cleanup

### DIFF
--- a/subsys/net/ip/net_context.c
+++ b/subsys/net/ip/net_context.c
@@ -889,9 +889,11 @@ static int create_udp_packet(struct net_context *context,
 			return -ENOMEM;
 		}
 
-		tmp = net_udp_insert(context, pkt,
+		tmp = net_udp_insert(pkt,
 				     net_pkt_ip_hdr_len(pkt) +
 				     net_pkt_ipv6_ext_len(pkt),
+				     net_sin((struct sockaddr *)
+					     &context->local)->sin_port,
 				     addr6->sin6_port);
 		if (!tmp) {
 			return -ENOMEM;
@@ -912,7 +914,9 @@ static int create_udp_packet(struct net_context *context,
 			return -ENOMEM;
 		}
 
-		tmp = net_udp_insert(context, pkt, net_pkt_ip_hdr_len(pkt),
+		tmp = net_udp_insert(pkt, net_pkt_ip_hdr_len(pkt),
+				     net_sin((struct sockaddr *)
+					     &context->local)->sin_port,
 				     addr4->sin_port);
 		if (!tmp) {
 			return -ENOMEM;

--- a/subsys/net/ip/udp_internal.h
+++ b/subsys/net/ip/udp_internal.h
@@ -52,39 +52,23 @@ struct net_buf *net_udp_set_chksum(struct net_pkt *pkt, struct net_buf *frag);
 u16_t net_udp_get_chksum(struct net_pkt *pkt, struct net_buf *frag);
 
 /**
- * @brief Append UDP packet into net_pkt
- *
- * @param context Network context for a connection
- * @param pkt Network packet
- * @param port Destination port in network byte order.
- *
- * @return Return network packet that contains the UDP packet.
- */
-struct net_pkt *net_udp_append(struct net_context *context,
-			       struct net_pkt *pkt,
-			       u16_t port);
-
-/**
  * @brief Insert UDP packet into net_pkt after specific offset.
  *
- * @param context Network context for a connection
  * @param pkt Network packet
  * @param offset Offset where to insert (typically after IP header)
+ * @param src_port Destination port in network byte order.
  * @param dst_port Destination port in network byte order.
  *
  * @return Return network packet that contains the UDP packet or NULL if
  * there is an failure.
  */
-struct net_pkt *net_udp_insert(struct net_context *context,
-			       struct net_pkt *pkt,
+struct net_pkt *net_udp_insert(struct net_pkt *pkt,
 			       u16_t offset,
+			       u16_t src_port,
 			       u16_t dst_port);
 
 #else
-#define net_udp_append_raw(pkt, src_port, dst_port) (pkt)
-#define net_udp_append(context, pkt, port) (pkt)
-#define net_udp_insert_raw(pkt, offset, src_port, dst_port) (pkt)
-#define net_udp_insert(context, pkt, offset, port) (pkt)
+#define net_udp_insert(pkt, offset, src_port, dst_port) (pkt)
 #define net_udp_get_chksum(pkt, frag) (0)
 #define net_udp_set_chksum(pkt, frag) NULL
 #endif /* CONFIG_NET_UDP */


### PR DESCRIPTION
- Up to net_context to give the source port.
- net_udp_append is unused anywhere: let's remove it.
- left over macros on _raw versions removed as well.

Signed-off-by: Tomasz Bursztyka <tomasz.bursztyka@linux.intel.com>