### PR TITLE
doc: fix desription SoC tree structure example

### DIFF
--- a/doc/application/application.rst
+++ b/doc/application/application.rst
@@ -481,7 +481,7 @@ the Zephyr tree, for example:
         └── arm
             └── st_stm32
                     ├── common
-                            └── stm32l0
+                    └── stm32l0
 
 
 


### PR DESCRIPTION
Example of st_stm32 soc tree structure was instantiating
'stm32l0' dir as subdir of 'common' which is not the case.

Signed-off-by: Erwan Gouriou <erwan.gouriou@linaro.org>