### PR TITLE
cmake: Suppress the stderr from 'git describe' on successfull runs

### DIFF
--- a/cmake/app/boilerplate.cmake
+++ b/cmake/app/boilerplate.cmake
@@ -256,7 +256,15 @@ if(GIT_FOUND)
   execute_process(COMMAND ${GIT_EXECUTABLE} describe
     WORKING_DIRECTORY ${ZEPHYR_BASE}
     OUTPUT_VARIABLE BUILD_VERSION
-    OUTPUT_STRIP_TRAILING_WHITESPACE)
+    OUTPUT_STRIP_TRAILING_WHITESPACE
+    ERROR_VARIABLE stderr
+    RESULT_VARIABLE return_code
+    )
+  if(return_code)
+    message(FATAL_ERROR "${stderr}")
+  elseif(CMAKE_VERBOSE_MAKEFILE)
+    message(STATUS "git describe stderr: ${stderr}")
+  endif()
 endif()
 
 set(SOC_NAME ${CONFIG_SOC})


### PR DESCRIPTION
A confusing warning has popped up since 3.13. It can be observed as
so:

> Zephyr version: 1.13.99
> Parsing Kconfig tree in /home/sebo/zephyr/Kconfig
> Merging /home/sebo/zephyr/samples/hello_world/prj.conf
> warning: tag 'zephyr-v1.13.0' is really 'v1.13.0' here
> -- Generating zephyr/include/generated/generated_dts_board.h

This warning is more confusing than useful so we suppress stderr from
'git describe' when the command runs successfully.

Signed-off-by: Sebastian Bøe <sebastian.boe@nordicsemi.no>