### PR TITLE
dma: stm32f4: check whether memory to memory is allowed

### DIFF
--- a/drivers/dma/dma_stm32f4x.c
+++ b/drivers/dma/dma_stm32f4x.c
@@ -364,7 +364,6 @@ static int dma_stm32_config(struct device *dev, u32_t id,
 	struct dma_stm32_stream_reg *regs = &ddata->stream[id].regs;
 	int ret;
 
-
 	if (id >= DMA_STM32_MAX_STREAMS) {
 		return -EINVAL;
 	}
@@ -376,6 +375,12 @@ static int dma_stm32_config(struct device *dev, u32_t id,
 	if (config->head_block->block_size > DMA_STM32_MAX_DATA_ITEMS) {
 		SYS_LOG_ERR("DMA error: Data size too big: %d\n",
 		       config->head_block->block_size);
+		return -EINVAL;
+	}
+
+	if ((MEMORY_TO_MEMORY == stream->direction) && (!ddata->mem2mem)) {
+		SYS_LOG_ERR("DMA error: Memcopy not supported for device %s",
+				dev->config->name);
 		return -EINVAL;
 	}
 
@@ -541,6 +546,7 @@ static void dma_stm32_irq_7(void *arg) { dma_stm32_irq_handler(arg, 7); }
 static void dma_stm32_1_config(struct dma_stm32_device *ddata)
 {
 	ddata->base = DMA_STM32_1_BASE;
+	ddata->mem2mem = false;
 
 	IRQ_CONNECT(DMA1_Stream0_IRQn, DMA_STM32_IRQ_PRI,
 		    dma_stm32_irq_0, DEVICE_GET(dma_stm32_1), 0);


### PR DESCRIPTION
This patch checks whether memory to memory is allowed for the device.
Tested it with tests/drivers/dma with one of the 2 settings:
CONFIG_DMA1_NAME=DMA_0 -> test fails with error message on console
	and an error at configuration.
CONFIG_DMA2_NAME=DMA_0 -> test succeeds
Fixes: #7547

Signed-off-by: Alexander Polleti <metapsycholo@gmail.com>