### PR TITLE
scripts: dts/Generate compatible flags

### DIFF
--- a/dts/bindings/arc/arc,dccm.yaml
+++ b/dts/bindings/arc/arc,dccm.yaml
@@ -17,6 +17,7 @@ properties:
       category: required
       description: compatible strings
       constraint: "arc,dccm"
+      generation: define
 
     reg:
       type: array

--- a/dts/bindings/arc/arc,iccm.yaml
+++ b/dts/bindings/arc/arc,iccm.yaml
@@ -17,6 +17,7 @@ properties:
       category: required
       description: compatible strings
       constraint: "arc,iccm"
+      generation: define
 
     reg:
       type: array

--- a/dts/bindings/arm/atmel,sam0-sercom.yaml
+++ b/dts/bindings/arm/atmel,sam0-sercom.yaml
@@ -12,6 +12,7 @@ properties:
       category: required
       description: compatible strings
       constraint: "atmel,sam0-sercom"
+      generation: define
 
     reg:
       type: array

--- a/dts/bindings/arm/nxp,kinetis-sim.yaml
+++ b/dts/bindings/arm/nxp,kinetis-sim.yaml
@@ -17,6 +17,7 @@ properties:
       category: required
       description: compatible strings
       constraint: "nxp,kinetis-sim"
+      generation: define
 
     reg:
       type: int

--- a/dts/bindings/arm/nxp,lpc-mailbox.yaml
+++ b/dts/bindings/arm/nxp,lpc-mailbox.yaml
@@ -17,6 +17,7 @@ properties:
       category: required
       description: compatible strings
       constraint: "nxp,lpc-mailbox"
+      generation: define
 
   reg:
       type: array

--- a/dts/bindings/arm/st,stm32-ccm.yaml
+++ b/dts/bindings/arm/st,stm32-ccm.yaml
@@ -8,19 +8,19 @@ description: >
   This binding gives a base representation of the STM32 CCM (Core Coupled Memory)
 
 properties:
-  compatible:
-    type: string
-    category: required
-    constraint: "st,stm32-ccm"
+    compatible:
+      type: string
+      category: required
+      constraint: "st,stm32-ccm"
+      generation: define
 
-  reg:
-    type: int
-    description: mmio register space
-    generation: define
-    category: required
+    reg:
+      type: int
+      description: mmio register space
+      generation: define
+      category: required
 
 base_label: CCM
 use-property-label: yes
 
 ...
-

--- a/dts/bindings/arm/ti,cc2650-prcm.yaml
+++ b/dts/bindings/arm/ti,cc2650-prcm.yaml
@@ -13,6 +13,7 @@ properties:
       category: required
       description: compatible strings
       constraint: "ti,cc2650-prcm"
+      generation: define
 
     reg:
       type: array

--- a/dts/bindings/can/can-device.yaml
+++ b/dts/bindings/can/can-device.yaml
@@ -19,6 +19,7 @@ properties:
       type: string
       category: required
       description: compatible strings
+      generation: define
     reg:
       type: array
       description: register base address

--- a/dts/bindings/can/can.yaml
+++ b/dts/bindings/can/can.yaml
@@ -10,6 +10,11 @@ child:
     bus: can
 
 properties:
+    compatible:
+      type: string
+      category: required
+      description: compatible strings
+      generation: define
     "#address-cells":
       type: int
       category: required

--- a/dts/bindings/can/st,stm32-can.yaml
+++ b/dts/bindings/can/st,stm32-can.yaml
@@ -11,9 +11,6 @@ inherits:
 
 properties:
     compatible:
-      type: string
-      category: required
-      description: compatible strings
       constraint: "st,stm32-can"
 
     reg:

--- a/dts/bindings/clock/nxp,imx-ccm.yaml
+++ b/dts/bindings/clock/nxp,imx-ccm.yaml
@@ -17,6 +17,7 @@ properties:
       category: required
       description: compatible strings
       constraint: "nxp,imx-ccm"
+      generation: define
 
     reg:
       type: int

--- a/dts/bindings/clock/st,stm32-rcc.yaml
+++ b/dts/bindings/clock/st,stm32-rcc.yaml
@@ -12,6 +12,7 @@ properties:
       category: required
       description: compatible strings
       constraint: "st,stm32-rcc"
+      generation: define
 
     reg:
       type: array

--- a/dts/bindings/device_node.yaml.template
+++ b/dts/bindings/device_node.yaml.template
@@ -37,6 +37,7 @@ properties:
       category: required
       type: string
       description: compatible of node
+      generation: define
 
 # reg is used to denote mmio registers
     reg:

--- a/dts/bindings/gpio/arm,cmsdk-gpio.yaml
+++ b/dts/bindings/gpio/arm,cmsdk-gpio.yaml
@@ -12,6 +12,7 @@ properties:
       category: required
       description: compatible strings
       constraint: "arm,cmsdk-gpio"
+      generation: define
 
     reg:
       type: array

--- a/dts/bindings/gpio/atmel,sam0-gpio.yaml
+++ b/dts/bindings/gpio/atmel,sam0-gpio.yaml
@@ -12,6 +12,7 @@ properties:
       category: required
       description: compatible strings
       constraint: "atmel,sam0-gpio"
+      generation: define
 
     reg:
       type: int

--- a/dts/bindings/gpio/atmel.sam-gpio.yaml
+++ b/dts/bindings/gpio/atmel.sam-gpio.yaml
@@ -12,6 +12,7 @@ properties:
       category: required
       description: compatible strings
       constraint: "atmel,sam-gpio"
+      generation: define
 
     reg:
       type: int

--- a/dts/bindings/gpio/gpio-keys.yaml
+++ b/dts/bindings/gpio/gpio-keys.yaml
@@ -17,6 +17,7 @@ properties:
       category: required
       description: compatible strings
       constraint: "gpio-keys"
+      generation: define
 
     gpios:
       type: compound

--- a/dts/bindings/gpio/gpio-leds.yaml
+++ b/dts/bindings/gpio/gpio-leds.yaml
@@ -17,6 +17,7 @@ properties:
       category: required
       description: compatible strings
       constraint: "gpio-leds"
+      generation: define
 
     gpios:
       type: compound

--- a/dts/bindings/gpio/intel,qmsi-gpio.yaml
+++ b/dts/bindings/gpio/intel,qmsi-gpio.yaml
@@ -17,6 +17,7 @@ properties:
       category: required
       description: compatible strings
       constraint: "intel,qmsi-gpio"
+      generation: define
 
     reg:
       type: int

--- a/dts/bindings/gpio/intel,qmsi-ss-gpio.yaml
+++ b/dts/bindings/gpio/intel,qmsi-ss-gpio.yaml
@@ -17,6 +17,7 @@ properties:
       category: required
       description: compatible strings
       constraint: "intel,qmsi-ss-gpio"
+      generation: define
 
     reg:
       type: int

--- a/dts/bindings/gpio/nordic,nrf-gpio.yaml
+++ b/dts/bindings/gpio/nordic,nrf-gpio.yaml
@@ -4,12 +4,12 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 ---
-title: nRF GPIO
+title: NRF5 GPIO
 id: nordic,nrf-gpio
 version: 0.1
 
 description: >
-    This is a representation of the nRF GPIO nodes
+    This is a representation of the NRF GPIO nodes
 
 properties:
     compatible:
@@ -17,6 +17,7 @@ properties:
       category: required
       description: compatible strings
       constraint: "nordic,nrf-gpio"
+      generation: define
 
     reg:
       type: int

--- a/dts/bindings/gpio/nordic,nrf-gpiote.yaml
+++ b/dts/bindings/gpio/nordic,nrf-gpiote.yaml
@@ -4,12 +4,12 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 ---
-title: nRF GPIOTE
+title: NRF5 GPIOTE
 id: nordic,nrf-gpiote
 version: 0.1
 
 description: >
-    This is a representation of the nRF GPIOTE node
+    This is a representation of the NRF GPIOTE node
 
 properties:
     compatible:
@@ -17,6 +17,7 @@ properties:
       category: required
       description: compatible strings
       constraint: "nordic,nrf-gpiote"
+      generation: define
 
     reg:
       type: int

--- a/dts/bindings/gpio/nxp,imx-gpio.yaml
+++ b/dts/bindings/gpio/nxp,imx-gpio.yaml
@@ -17,6 +17,7 @@ properties:
       category: required
       description: compatible strings
       constraint: "nxp,imx-gpio"
+      generation: define
 
     reg:
       type: int

--- a/dts/bindings/gpio/nxp,kinetis-gpio.yaml
+++ b/dts/bindings/gpio/nxp,kinetis-gpio.yaml
@@ -12,6 +12,7 @@ properties:
       category: required
       description: compatible strings
       constraint: "nxp,kinetis-gpio"
+      generation: define
 
     reg:
       type: int

--- a/dts/bindings/gpio/semtech,sx1509b-gpio.yaml
+++ b/dts/bindings/gpio/semtech,sx1509b-gpio.yaml
@@ -17,5 +17,4 @@ inherits:
 properties:
     compatible:
       constraint: "semtech,sx1509b"
-
 ...

--- a/dts/bindings/gpio/snps,designware-gpio.yaml
+++ b/dts/bindings/gpio/snps,designware-gpio.yaml
@@ -17,6 +17,7 @@ properties:
       category: required
       description: compatible strings
       constraint: "snps,designware-gpio"
+      generation: define
 
     reg:
       type: int

--- a/dts/bindings/gpio/st,stm32-gpio.yaml
+++ b/dts/bindings/gpio/st,stm32-gpio.yaml
@@ -17,6 +17,7 @@ properties:
       category: required
       description: compatible strings
       constraint: "st,stm32-gpio"
+      generation: define
 
     reg:
       type: int

--- a/dts/bindings/gpio/ti,cc2650-gpio.yaml
+++ b/dts/bindings/gpio/ti,cc2650-gpio.yaml
@@ -12,6 +12,7 @@ properties:
       category: required
       description: compatible strings
       constraint: "ti,cc2650-gpio"
+      generation: define
 
     reg:
       type: int

--- a/dts/bindings/i2c/arm,versatile-i2c.yaml
+++ b/dts/bindings/i2c/arm,versatile-i2c.yaml
@@ -16,9 +16,6 @@ inherits:
 
 properties:
     compatible:
-      type: string
-      category: required
-      description: compatible strings
       constraint: "arm,versatile-i2c"
 
     reg:

--- a/dts/bindings/i2c/atmel,sam-i2c-twi.yaml
+++ b/dts/bindings/i2c/atmel,sam-i2c-twi.yaml
@@ -16,9 +16,6 @@ inherits:
 
 properties:
     compatible:
-      type: string
-      category: required
-      description: compatible strings
       constraint: "atmel,sam-i2c-twi"
 
     reg:

--- a/dts/bindings/i2c/atmel,sam-i2c-twihs.yaml
+++ b/dts/bindings/i2c/atmel,sam-i2c-twihs.yaml
@@ -16,9 +16,6 @@ inherits:
 
 properties:
     compatible:
-      type: string
-      category: required
-      description: compatible strings
       constraint: "atmel,sam-i2c-twihs"
 
     reg:

--- a/dts/bindings/i2c/fsl,imx7d-i2c.yaml
+++ b/dts/bindings/i2c/fsl,imx7d-i2c.yaml
@@ -16,9 +16,6 @@ inherits:
 
 properties:
     compatible:
-      type: string
-      category: required
-      description: compatible strings
       constraint: "fsl,imx7d-i2c"
 
     reg:

--- a/dts/bindings/i2c/i2c-device.yaml
+++ b/dts/bindings/i2c/i2c-device.yaml
@@ -19,6 +19,7 @@ properties:
       type: string
       category: required
       description: compatible strings
+      generation: define
     reg:
       type: array
       description: address on i2c bus

--- a/dts/bindings/i2c/i2c.yaml
+++ b/dts/bindings/i2c/i2c.yaml
@@ -15,6 +15,11 @@ child:
     bus: i2c
 
 properties:
+    compatible:
+      type: string
+      category: required
+      description: compatible strings
+      generation: define
     "#address-cells":
       type: int
       category: required

--- a/dts/bindings/i2c/intel,qmsi-i2c.yaml
+++ b/dts/bindings/i2c/intel,qmsi-i2c.yaml
@@ -16,9 +16,6 @@ inherits:
 
 properties:
     compatible:
-      type: string
-      category: required
-      description: compatible strings
       constraint: "intel,qmsi-i2c"
 
     reg:

--- a/dts/bindings/i2c/intel,qmsi-ss-i2c.yaml
+++ b/dts/bindings/i2c/intel,qmsi-ss-i2c.yaml
@@ -16,9 +16,6 @@ inherits:
 
 properties:
     compatible:
-      type: string
-      category: required
-      description: compatible strings
       constraint: "intel,qmsi-ss-i2c"
 
     reg:

--- a/dts/bindings/i2c/nxp,kinetis-i2c.yaml
+++ b/dts/bindings/i2c/nxp,kinetis-i2c.yaml
@@ -16,9 +16,6 @@ inherits:
 
 properties:
     compatible:
-      type: string
-      category: required
-      description: compatible strings
       constraint: "nxp,kinetis-i2c"
 
     reg:

--- a/dts/bindings/i2c/snps,designware-i2c.yaml
+++ b/dts/bindings/i2c/snps,designware-i2c.yaml
@@ -16,9 +16,6 @@ inherits:
 
 properties:
     compatible:
-      type: string
-      category: required
-      description: compatible strings
       constraint: "snps,designware-i2c"
 
     reg:

--- a/dts/bindings/i2c/st,stm32-i2c-v1.yaml
+++ b/dts/bindings/i2c/st,stm32-i2c-v1.yaml
@@ -16,9 +16,6 @@ inherits:
 
 properties:
     compatible:
-      type: string
-      category: required
-      description: compatible strings
       constraint: "st,stm32-i2c-v1"
 
     reg:

--- a/dts/bindings/i2c/st,stm32-i2c-v2.yaml
+++ b/dts/bindings/i2c/st,stm32-i2c-v2.yaml
@@ -16,9 +16,6 @@ inherits:
 
 properties:
     compatible:
-      type: string
-      category: required
-      description: compatible strings
       constraint: "st,stm32-i2c-v2"
 
     reg:

--- a/dts/bindings/i2c/ti,cc32xx-i2c.yaml
+++ b/dts/bindings/i2c/ti,cc32xx-i2c.yaml
@@ -10,9 +10,6 @@ inherits:
 
 properties:
     compatible:
-      type: string
-      category: required
-      description: compatible strings
       constraint: "ti,cc32xx-i2c"
 
     reg:

--- a/dts/bindings/iio/adc/adc.yaml
+++ b/dts/bindings/iio/adc/adc.yaml
@@ -12,6 +12,12 @@ description: >
     This binding gives the base structures for all ADC devices
 
 properties:
+    compatible:
+      type: string
+      category: required
+      description: compatible strings
+      generation: define
+
     clocks:
       type: array
       category: required

--- a/dts/bindings/iio/adc/nxp,kinetis-adc16.yaml
+++ b/dts/bindings/iio/adc/nxp,kinetis-adc16.yaml
@@ -16,9 +16,6 @@ inherits:
 
 properties:
     compatible:
-      type: string
-      category: required
-      description: compatible strings
       constraint: "nxp,kinetis-adc16"
 
     reg:

--- a/dts/bindings/interrupt-controller/arm,v6m-nvic.yaml
+++ b/dts/bindings/interrupt-controller/arm,v6m-nvic.yaml
@@ -12,6 +12,7 @@ properties:
       type: string
       description: compatible strings
       constraint: "arm,v6m-nvic"
+      generation: define
 
     reg:
       category: required

--- a/dts/bindings/interrupt-controller/arm,v7m-nvic.yaml
+++ b/dts/bindings/interrupt-controller/arm,v7m-nvic.yaml
@@ -12,6 +12,7 @@ properties:
       type: string
       description: compatible strings
       constraint: "arm,v7m-nvic"
+      generation: define
 
     reg:
       category: required

--- a/dts/bindings/interrupt-controller/arm,v8m-nvic.yaml
+++ b/dts/bindings/interrupt-controller/arm,v8m-nvic.yaml
@@ -12,6 +12,7 @@ properties:
       type: string
       description: compatible strings
       constraint: "arm,v8m-nvic"
+      generation: define
 
     reg:
       category: required

--- a/dts/bindings/interrupt-controller/intel,cavs-intc.yaml
+++ b/dts/bindings/interrupt-controller/intel,cavs-intc.yaml
@@ -11,6 +11,7 @@ properties:
       type: string
       description: compatible strings
       constraint: "intel,cavs-intc"
+      generation: define
 
   reg:
       category: required

--- a/dts/bindings/interrupt-controller/intel,ioapic.yaml
+++ b/dts/bindings/interrupt-controller/intel,ioapic.yaml
@@ -12,6 +12,7 @@ properties:
       type: string
       description: compatible strings
       constraint: "intel,ioapic"
+      generation: define
 
   reg:
       category: required

--- a/dts/bindings/interrupt-controller/intel,mvic.yaml
+++ b/dts/bindings/interrupt-controller/intel,mvic.yaml
@@ -12,6 +12,7 @@ properties:
       type: string
       description: compatible strings
       constraint: "intel,mvic"
+      generation: define
 
   reg:
       category: required

--- a/dts/bindings/interrupt-controller/snps,arcv2-intc.yaml
+++ b/dts/bindings/interrupt-controller/snps,arcv2-intc.yaml
@@ -17,6 +17,7 @@ properties:
       type: string
       description: compatible strings
       constraint: "snps,arcv2-intc"
+      generation: define
 
     reg:
       category: required

--- a/dts/bindings/interrupt-controller/snps,designware-intc.yaml
+++ b/dts/bindings/interrupt-controller/snps,designware-intc.yaml
@@ -11,6 +11,7 @@ properties:
       type: string
       description: compatible strings
       constraint: "snps,designware-intc"
+      generation: define
 
   reg:
       category: required

--- a/dts/bindings/interrupt-controller/xtensa,intc.yaml
+++ b/dts/bindings/interrupt-controller/xtensa,intc.yaml
@@ -11,6 +11,7 @@ properties:
       type: string
       description: compatible strings
       constraint: "xtensa,core-intc"
+      generation: define
 
   reg:
       category: required

--- a/dts/bindings/led/nxp,pca9633.yaml
+++ b/dts/bindings/led/nxp,pca9633.yaml
@@ -10,8 +10,5 @@ inherits:
 
 properties:
     compatible:
-      type: string
-      category: required
-      description: compatible strings
       constraint: "nxp,pca9633"
 ...

--- a/dts/bindings/led/ti,lp3943.yaml
+++ b/dts/bindings/led/ti,lp3943.yaml
@@ -10,8 +10,5 @@ inherits:
 
 properties:
     compatible:
-      type: string
-      category: required
-      description: compatible strings
       constraint: "ti,lp3943"
 ...

--- a/dts/bindings/led_strip/apa,apa-102.yaml
+++ b/dts/bindings/led_strip/apa,apa-102.yaml
@@ -10,8 +10,5 @@ inherits:
 
 properties:
     compatible:
-      type: string
-      category: required
-      description: compatible strings
       constraint: "apa,apa102"
 ...

--- a/dts/bindings/memory-controllers/nxp,imx-semc.yaml
+++ b/dts/bindings/memory-controllers/nxp,imx-semc.yaml
@@ -18,6 +18,7 @@ properties:
       category: required
       description: compatible strings
       constraint: "nxp,imx-semc"
+      generation: define
 
     reg:
       type: array

--- a/dts/bindings/modem/wnc,m14a2a.yaml
+++ b/dts/bindings/modem/wnc,m14a2a.yaml
@@ -19,6 +19,7 @@ properties:
       type: string
       category: required
       constraint: "wnc,m14a2a"
+      generation: define
 
     mdm-boot-mode-sel-gpios:
       type: compound

--- a/dts/bindings/mtd/partition.yaml
+++ b/dts/bindings/mtd/partition.yaml
@@ -12,6 +12,7 @@ properties:
       category: required
       description: compatible strings
       constraint: "fixed-partitions"
+      generation: define
 
     partition\d+:
       type: string

--- a/dts/bindings/mtd/soc-nv-flash.yaml
+++ b/dts/bindings/mtd/soc-nv-flash.yaml
@@ -12,6 +12,7 @@ properties:
       category: required
       description: compatible strings
       constraint: "soc-nv-flash"
+      generation: define
 
     label:
       type: string

--- a/dts/bindings/pinctrl/atmel,sam0-pinmux.yaml
+++ b/dts/bindings/pinctrl/atmel,sam0-pinmux.yaml
@@ -12,6 +12,7 @@ properties:
       category: required
       description: compatible strings
       constraint: "atmel,sam0-pinmux"
+      generation: define
 
     reg:
       type: int

--- a/dts/bindings/pinctrl/nxp,kinetis-pinmux.yaml
+++ b/dts/bindings/pinctrl/nxp,kinetis-pinmux.yaml
@@ -12,6 +12,7 @@ properties:
       category: required
       description: compatible strings
       constraint: "nxp,kinetis-pinmux"
+      generation: define
 
     reg:
       type: int

--- a/dts/bindings/pinctrl/st,stm32-pinmux.yaml
+++ b/dts/bindings/pinctrl/st,stm32-pinmux.yaml
@@ -12,6 +12,7 @@ properties:
       category: required
       description: compatible strings
       constraint: "st,stm32-pinmux"
+      generation: define
 
     reg:
       type: int

--- a/dts/bindings/pinctrl/ti,cc2650-pinmux.yaml
+++ b/dts/bindings/pinctrl/ti,cc2650-pinmux.yaml
@@ -12,6 +12,7 @@ properties:
       category: required
       description: compatible strings
       constraint: "ti,cc2650-pinmux"
+      generation: define
 
     reg:
       type: int

--- a/dts/bindings/pwm/fsl,imx7d-pwm.yaml
+++ b/dts/bindings/pwm/fsl,imx7d-pwm.yaml
@@ -16,9 +16,6 @@ inherits:
 
 properties:
     compatible:
-      type: string
-      category: required
-      description: compatible strings
       constraint: "fsl,imx7d-pwm"
 
     reg:

--- a/dts/bindings/pwm/nxp,kinetis-ftm.yaml
+++ b/dts/bindings/pwm/nxp,kinetis-ftm.yaml
@@ -16,9 +16,6 @@ inherits:
 
 properties:
     compatible:
-      type: string
-      category: required
-      description: compatible strings
       constraint: "nxp,kinetis-ftm"
 
     reg:

--- a/dts/bindings/pwm/pwm.yaml
+++ b/dts/bindings/pwm/pwm.yaml
@@ -12,6 +12,12 @@ description: >
     This binding gives the base structures for all PWM devices
 
 properties:
+    compatible:
+      type: string
+      category: required
+      description: compatible strings
+      generation: define
+
     clocks:
       type: array
       category: required

--- a/dts/bindings/pwm/st,stm32-pwm.yaml
+++ b/dts/bindings/pwm/st,stm32-pwm.yaml
@@ -8,9 +8,6 @@ description: >
 
 properties:
     compatible:
-      type: string
-      category: required
-      description: compatible strings
       constraint: "st,stm32-pwm"
 
     label:

--- a/dts/bindings/rtc/intel,qmsi-rtc.yaml
+++ b/dts/bindings/rtc/intel,qmsi-rtc.yaml
@@ -16,9 +16,6 @@ inherits:
 
 properties:
     compatible:
-      type: string
-      category: required
-      description: compatible strings
       constraint: "intel,qmsi-rtc"
 
     reg:

--- a/dts/bindings/rtc/nxp,kinetis-rtc.yaml
+++ b/dts/bindings/rtc/nxp,kinetis-rtc.yaml
@@ -16,9 +16,6 @@ inherits:
 
 properties:
     compatible:
-      type: string
-      category: required
-      description: compatible strings
       constraint: "nxp,kinetis-rtc"
 
     reg:

--- a/dts/bindings/rtc/rtc.yaml
+++ b/dts/bindings/rtc/rtc.yaml
@@ -13,6 +13,11 @@ description: >
 
 
 properties:
+    compatible:
+      type: string
+      category: required
+      description: compatible strings
+      generation: define
     clock-frequency:
       type: int
       category: optional

--- a/dts/bindings/serial/altera,jtag-uart.yaml
+++ b/dts/bindings/serial/altera,jtag-uart.yaml
@@ -11,9 +11,6 @@ inherits:
 
 properties:
     compatible:
-      type: string
-      category: required
-      description: compatible strings
       constraint: "altera,jtag-uart"
 
     reg:

--- a/dts/bindings/serial/arm,cmsdk-uart.yaml
+++ b/dts/bindings/serial/arm,cmsdk-uart.yaml
@@ -11,9 +11,6 @@ inherits:
 
 properties:
     compatible:
-      type: string
-      category: required
-      description: compatible strings
       constraint: "arm,cmsdk-uart"
 
     reg:

--- a/dts/bindings/serial/atmel,sam-uart.yaml
+++ b/dts/bindings/serial/atmel,sam-uart.yaml
@@ -11,9 +11,6 @@ inherits:
 
 properties:
     compatible:
-      type: string
-      category: required
-      description: compatible strings
       constraint: "atmel,sam-uart"
 
     reg:

--- a/dts/bindings/serial/atmel,sam-usart.yaml
+++ b/dts/bindings/serial/atmel,sam-usart.yaml
@@ -11,9 +11,6 @@ inherits:
 
 properties:
     compatible:
-      type: string
-      category: required
-      description: compatible strings
       constraint: "atmel,sam-usart"
 
     reg:

--- a/dts/bindings/serial/atmel,sam0-uart.yaml
+++ b/dts/bindings/serial/atmel,sam0-uart.yaml
@@ -11,9 +11,6 @@ inherits:
 
 properties:
     compatible:
-      type: string
-      category: required
-      description: compatible strings
       constraint: "atmel,sam0-uart"
 
     reg:

--- a/dts/bindings/serial/intel,qmsi-uart.yaml
+++ b/dts/bindings/serial/intel,qmsi-uart.yaml
@@ -16,9 +16,6 @@ inherits:
 
 properties:
     compatible:
-      type: string
-      category: required
-      description: compatible strings
       constraint: "intel,qmsi-uart"
 
     reg:

--- a/dts/bindings/serial/nordic,nrf-uart.yaml
+++ b/dts/bindings/serial/nordic,nrf-uart.yaml
@@ -11,9 +11,6 @@ inherits:
 
 properties:
     compatible:
-      type: string
-      category: required
-      description: compatible strings
       constraint: "nordic,nrf-uart"
 
     reg:

--- a/dts/bindings/serial/nordic,nrf-uarte.yaml
+++ b/dts/bindings/serial/nordic,nrf-uarte.yaml
@@ -11,9 +11,6 @@ inherits:
 
 properties:
     compatible:
-      type: string
-      category: required
-      description: compatible strings
       constraint: "nordic,nrf-uarte"
 
     reg:

--- a/dts/bindings/serial/ns16550.yaml
+++ b/dts/bindings/serial/ns16550.yaml
@@ -11,9 +11,6 @@ inherits:
 
 properties:
     compatible:
-      type: string
-      category: required
-      description: compatible strings
       constraint: "ns16550"
 
     reg:

--- a/dts/bindings/serial/nxp,imx-uart.yaml
+++ b/dts/bindings/serial/nxp,imx-uart.yaml
@@ -16,9 +16,6 @@ inherits:
 
 properties:
     compatible:
-      type: string
-      category: required
-      description: compatible strings
       constraint: "nxp,imx-uart"
 
     reg:

--- a/dts/bindings/serial/nxp,kinetis-lpsci.yaml
+++ b/dts/bindings/serial/nxp,kinetis-lpsci.yaml
@@ -11,9 +11,6 @@ inherits:
 
 properties:
     compatible:
-      type: string
-      category: required
-      description: compatible strings
       constraint: "nxp,kinetis-lpsci"
 
     reg:

--- a/dts/bindings/serial/nxp,kinetis-lpuart.yaml
+++ b/dts/bindings/serial/nxp,kinetis-lpuart.yaml
@@ -11,9 +11,6 @@ inherits:
 
 properties:
     compatible:
-      type: string
-      category: required
-      description: compatible strings
       constraint: "nxp,kinetis-lpuart"
 
     reg:

--- a/dts/bindings/serial/nxp,kinetis-uart.yaml
+++ b/dts/bindings/serial/nxp,kinetis-uart.yaml
@@ -11,9 +11,6 @@ inherits:
 
 properties:
     compatible:
-      type: string
-      category: required
-      description: compatible strings
       constraint: "nxp,kinetis-uart"
 
     reg:

--- a/dts/bindings/serial/nxp,lpc-usart.yaml
+++ b/dts/bindings/serial/nxp,lpc-usart.yaml
@@ -16,9 +16,6 @@ inherits:
 
 properties:
     compatible:
-      type: string
-      category: required
-      description: compatible strings
       constraint: "nxp,lpc-usart"
 
     reg:

--- a/dts/bindings/serial/riscv,qemu-uart.yaml
+++ b/dts/bindings/serial/riscv,qemu-uart.yaml
@@ -11,9 +11,6 @@ inherits:
 
 properties:
     compatible:
-      type: string
-      category: required
-      description: compatible strings
       constraint: "riscv,qemu-uart"
 
     reg:

--- a/dts/bindings/serial/silabs,efm32-uart.yaml
+++ b/dts/bindings/serial/silabs,efm32-uart.yaml
@@ -11,9 +11,6 @@ inherits:
 
 properties:
     compatible:
-      type: string
-      category: required
-      description: compatible strings
       constraint: "silabs,efm32-uart"
 
     reg:

--- a/dts/bindings/serial/silabs,efm32-usart.yaml
+++ b/dts/bindings/serial/silabs,efm32-usart.yaml
@@ -11,9 +11,6 @@ inherits:
 
 properties:
     compatible:
-      type: string
-      category: required
-      description: compatible strings
       constraint: "silabs,efm32-usart"
 
     reg:

--- a/dts/bindings/serial/st,stm32-lpuart.yaml
+++ b/dts/bindings/serial/st,stm32-lpuart.yaml
@@ -11,9 +11,6 @@ inherits:
 
 properties:
     compatible:
-      type: string
-      category: required
-      description: compatible strings
       constraint: "st,stm32-lpuart"
 
     reg:

--- a/dts/bindings/serial/st,stm32-uart.yaml
+++ b/dts/bindings/serial/st,stm32-uart.yaml
@@ -11,9 +11,6 @@ inherits:
 
 properties:
     compatible:
-      type: string
-      category: required
-      description: compatible strings
       constraint: "st,stm32-uart"
 
     reg:

--- a/dts/bindings/serial/st,stm32-usart.yaml
+++ b/dts/bindings/serial/st,stm32-usart.yaml
@@ -11,9 +11,6 @@ inherits:
 
 properties:
     compatible:
-      type: string
-      category: required
-      description: compatible strings
       constraint: "st,stm32-usart"
 
     reg:

--- a/dts/bindings/serial/ti,cc32xx-uart.yaml
+++ b/dts/bindings/serial/ti,cc32xx-uart.yaml
@@ -11,9 +11,6 @@ inherits:
 
 properties:
     compatible:
-      type: string
-      category: required
-      description: compatible strings
       constraint: "ti,cc32xx-uart"
 
     reg:

--- a/dts/bindings/serial/ti,msp432p4xx-uart.yaml
+++ b/dts/bindings/serial/ti,msp432p4xx-uart.yaml
@@ -11,9 +11,6 @@ inherits:
 
 properties:
     compatible:
-      type: string
-      category: required
-      description: compatible strings
       constraint: "ti,msp432p4xx-uart"
 
     reg:

--- a/dts/bindings/serial/ti,stellaris-uart.yaml
+++ b/dts/bindings/serial/ti,stellaris-uart.yaml
@@ -11,9 +11,6 @@ inherits:
 
 properties:
     compatible:
-      type: string
-      category: required
-      description: compatible strings
       constraint: "ti,stellaris-uart"
 
     reg:

--- a/dts/bindings/serial/uart-device.yaml
+++ b/dts/bindings/serial/uart-device.yaml
@@ -19,6 +19,7 @@ properties:
       type: string
       category: required
       description: compatible strings
+      generation: define
     label:
       type: string
       category: required

--- a/dts/bindings/serial/uart.yaml
+++ b/dts/bindings/serial/uart.yaml
@@ -10,6 +10,11 @@ child:
     bus: uart
 
 properties:
+    compatible:
+      type: string
+      category: required
+      description: compatible strings
+      generation: define
     clock-frequency:
       type: int
       category: optional

--- a/dts/bindings/spi/atmel,sam0-spi.yaml
+++ b/dts/bindings/spi/atmel,sam0-spi.yaml
@@ -16,9 +16,6 @@ inherits:
 
 properties:
     compatible:
-      type: string
-      category: required
-      description: compatible strings
       constraint: "atmel,sam0-spi"
 
     reg:

--- a/dts/bindings/spi/nxp,imx-flexspi.yaml
+++ b/dts/bindings/spi/nxp,imx-flexspi.yaml
@@ -16,9 +16,6 @@ inherits:
 
 properties:
     compatible:
-      type: string
-      category: required
-      description: compatible strings
       constraint: "nxp,imx-flexspi"
 
     reg:

--- a/dts/bindings/spi/nxp,kinetis-dspi.yaml
+++ b/dts/bindings/spi/nxp,kinetis-dspi.yaml
@@ -16,9 +16,6 @@ inherits:
 
 properties:
     compatible:
-      type: string
-      category: required
-      description: compatible strings
       constraint: "nxp,kinetis-dspi"
 
     reg:

--- a/dts/bindings/spi/snps,designware-spi.yaml
+++ b/dts/bindings/spi/snps,designware-spi.yaml
@@ -16,9 +16,6 @@ inherits:
 
 properties:
     compatible:
-      type: string
-      category: required
-      description: compatible strings
       constraint: "snps,designware-spi"
 
     reg:

--- a/dts/bindings/spi/spi-device.yaml
+++ b/dts/bindings/spi/spi-device.yaml
@@ -19,6 +19,7 @@ properties:
       type: string
       category: required
       description: compatible strings
+      generation: define
     reg:
       type: array
       description: Chip select address of device

--- a/dts/bindings/spi/spi.yaml
+++ b/dts/bindings/spi/spi.yaml
@@ -15,6 +15,11 @@ child:
     bus: spi
 
 properties:
+    compatible:
+      type: string
+      category: required
+      description: compatible strings
+      generation: define
     "#address-cells":
       type: int
       category: required

--- a/dts/bindings/spi/st,stm32-spi-fifo.yaml
+++ b/dts/bindings/spi/st,stm32-spi-fifo.yaml
@@ -17,9 +17,6 @@ inherits:
 
 properties:
     compatible:
-      type: string
-      category: required
-      description: compatible strings
       constraint: "st,stm32-spi-fifo"
 
     reg:

--- a/dts/bindings/spi/st,stm32-spi.yaml
+++ b/dts/bindings/spi/st,stm32-spi.yaml
@@ -16,9 +16,6 @@ inherits:
 
 properties:
     compatible:
-      type: string
-      category: required
-      description: compatible strings
       constraint: "st,stm32-spi"
 
     reg:

--- a/dts/bindings/timer/arm,cmsdk-dtimer.yaml
+++ b/dts/bindings/timer/arm,cmsdk-dtimer.yaml
@@ -12,6 +12,7 @@ properties:
       category: required
       description: compatible strings
       constraint: "arm,cmsdk-dtimer"
+      generation: define
 
     reg:
       type: array

--- a/dts/bindings/timer/arm,cmsdk-timer.yaml
+++ b/dts/bindings/timer/arm,cmsdk-timer.yaml
@@ -12,6 +12,7 @@ properties:
       category: required
       description: compatible strings
       constraint: "arm,cmsdk-timer"
+      generation: define
 
     reg:
       type: array

--- a/dts/bindings/timer/st,stm32-timers.yaml
+++ b/dts/bindings/timer/st,stm32-timers.yaml
@@ -21,6 +21,7 @@ properties:
       category: required
       description: compatible strings
       constraint: "st,stm32-timers"
+      generation: define
 
     label:
       type: string

--- a/dts/bindings/usb/usb.yaml
+++ b/dts/bindings/usb/usb.yaml
@@ -16,6 +16,7 @@ properties:
       type: string
       category: required
       description: compatible strings
+      generation: define
 
     label:
       type: string

--- a/dts/bindings/watchdog/arm,cmsdk-watchdog.yaml
+++ b/dts/bindings/watchdog/arm,cmsdk-watchdog.yaml
@@ -12,6 +12,7 @@ properties:
       category: required
       description: compatible strings
       constraint: "arm,cmsdk-watchdog"
+      generation: define
 
     reg:
       type: array

--- a/dts/bindings/watchdog/atmel,sam0-watchdog.yaml
+++ b/dts/bindings/watchdog/atmel,sam0-watchdog.yaml
@@ -12,6 +12,7 @@ properties:
       category: required
       description: compatible strings
       constraint: "atmel,sam0-watchdog"
+      generation: define
 
     reg:
       type: int

--- a/dts/bindings/watchdog/nordic,nrf-watchdog.yaml
+++ b/dts/bindings/watchdog/nordic,nrf-watchdog.yaml
@@ -17,6 +17,7 @@ properties:
       category: required
       description: compatible strings
       constraint: "nordic,nrf-watchdog"
+      generation: define
 
     reg:
       type: int

--- a/dts/bindings/watchdog/nxp,kinetis-wdog.yaml
+++ b/dts/bindings/watchdog/nxp,kinetis-wdog.yaml
@@ -17,6 +17,7 @@ properties:
       category: required
       description: compatible strings
       constraint: "nxp,kinetis-wdog"
+      generation: define
 
     reg:
       type: int

--- a/scripts/dts/extract/compatible.py
+++ b/scripts/dts/extract/compatible.py
@@ -1,0 +1,50 @@
+#
+# Copyright (c) 2018 Bobby Noelte
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+
+from extract.globals import *
+from extract.directive import DTDirective
+
+##
+# @brief Manage compatible directives.
+#
+# Handles:
+# - compatible
+#
+class DTCompatible(DTDirective):
+
+    def __init__(self):
+        pass
+
+    ##
+    # @brief Extract compatible
+    #
+    # @param node_address Address of node owning the
+    #                     compatible definition.
+    # @param yaml YAML definition for the owning node.
+    # @param prop compatible property name
+    # @param names (unused)
+    # @param def_label Define label string of node owning the
+    #                  compatible definition.
+    #
+    def extract(self, node_address, yaml, prop, names, def_label):
+
+        # compatible definition
+        compatible = reduced[node_address]['props'][prop]
+        if not isinstance(compatible, list):
+            compatible = [compatible, ]
+
+        for i, comp in enumerate(compatible):
+            # Generate #define's
+            compat_label = convert_string_to_label(str(comp))
+            compat_defs = 'CONFIG_DT_COMPAT_' + compat_label
+            load_defs = {
+                compat_defs: "",
+            }
+            insert_defs(node_address, load_defs, {})
+
+##
+# @brief Management information for compatible.
+compatible = DTCompatible()

--- a/scripts/dts/extract/globals.py
+++ b/scripts/dts/extract/globals.py
@@ -121,6 +121,11 @@ def get_phandles(root, name, handles):
 
 
 def insert_defs(node_address, new_defs, new_aliases):
+
+    for key in new_defs.keys():
+        if key.startswith('CONFIG_DT_COMPAT_'):
+            node_address = 'Compatibles'
+
     if node_address in defs:
         if 'aliases' in defs[node_address]:
             defs[node_address]['aliases'].update(new_aliases)

--- a/scripts/dts/extract_dts_includes.py
+++ b/scripts/dts/extract_dts_includes.py
@@ -21,6 +21,7 @@ from devicetree import parse_file
 from extract.globals import *
 
 from extract.clocks import clocks
+from extract.compatible import compatible
 from extract.interrupts import interrupts
 from extract.reg import reg
 from extract.flash import flash
@@ -443,6 +444,8 @@ def extract_property(node_compat, yaml, node_address, prop, prop_val, names,
             reg.extract(node_address, yaml, prop, names, def_label)
     elif prop == 'interrupts' or prop == 'interrupts-extended':
         interrupts.extract(node_address, yaml, prop, names, def_label)
+    elif prop == 'compatible':
+        compatible.extract(node_address, yaml, prop, names, def_label)
     elif 'pinctrl-' in prop:
         pinctrl.extract(node_address, yaml, prop, names, def_label)
     elif 'clocks' in prop:


### PR DESCRIPTION
Generate CONFIG_DT_COMPAT_xx flags using nodes compatible property.

These flags could be used for SW build control.
Following is an example of this new 'Compatibles' section in generated_dts_board.h for board disco_l475_iot1 in sample/hello_world:
```
/* Compatibles */
#define CONFIG_DT_COMPAT_ARM_V7M_NVIC			
#define CONFIG_DT_COMPAT_FIXED_PARTITIONS		
#define CONFIG_DT_COMPAT_GPIO_KEYS			
#define CONFIG_DT_COMPAT_GPIO_LEDS			
#define CONFIG_DT_COMPAT_SOC_NV_FLASH			
#define CONFIG_DT_COMPAT_ST_HTS221			
#define CONFIG_DT_COMPAT_ST_LIS3MDL_MAGN		
#define CONFIG_DT_COMPAT_ST_LPS22HB_PRESS		
#define CONFIG_DT_COMPAT_ST_LSM6DSL			
#define CONFIG_DT_COMPAT_ST_SPBTLE_RF			
#define CONFIG_DT_COMPAT_ST_STM32L4_FLASH_CONTROLLER	
#define CONFIG_DT_COMPAT_ST_STM32_GPIO			
#define CONFIG_DT_COMPAT_ST_STM32_I2C_V2		
#define CONFIG_DT_COMPAT_ST_STM32_PINMUX		
#define CONFIG_DT_COMPAT_ST_STM32_RCC			
#define CONFIG_DT_COMPAT_ST_STM32_RTC			
#define CONFIG_DT_COMPAT_ST_STM32_SPI_FIFO		
#define CONFIG_DT_COMPAT_ST_STM32_TIMERS		
#define CONFIG_DT_COMPAT_ST_STM32_UART			
#define CONFIG_DT_COMPAT_ST_STM32_USART			
#define CONFIG_DT_COMPAT_ST_VL53L0X	
```