### PR TITLE
posix: Fix pthread_barrier_wait() return value

### DIFF
--- a/include/posix/pthread.h
+++ b/include/posix/pthread.h
@@ -332,7 +332,9 @@ static inline int pthread_mutexattr_destroy(pthread_mutexattr_t *m)
 	struct pthread_barrier name = {				\
 		.wait_q = _WAIT_Q_INIT(&name.wait_q),		\
 		.max = count,					\
-	}
+}
+
+#define PTHREAD_BARRIER_SERIAL_THREAD 0
 
 /**
  * @brief POSIX threading compatibility API

--- a/lib/posix/pthread_barrier.c
+++ b/lib/posix/pthread_barrier.c
@@ -11,7 +11,7 @@
 
 int pthread_barrier_wait(pthread_barrier_t *b)
 {
-	int key = irq_lock();
+	int key = irq_lock(), ret, serial = 0;
 
 	b->count++;
 
@@ -21,8 +21,11 @@ int pthread_barrier_wait(pthread_barrier_t *b)
 		while (_waitq_head(&b->wait_q)) {
 			_ready_one_thread(&b->wait_q);
 		}
-		return _reschedule(key);
+		serial = PTHREAD_BARRIER_SERIAL_THREAD;
+		ret = _reschedule(key);
 	} else {
-		return _pend_current_thread(key, &b->wait_q, K_FOREVER);
+		ret = _pend_current_thread(key, &b->wait_q, K_FOREVER);
 	}
+
+	return ret ? ret : serial;
 }


### PR DESCRIPTION
The return value from this function is supposed to return
"PTHREAD_BARRIER_SERIAL_WAIT" from exactly one of the calling threads,
otherwise zero or an error code.

Fixes #9953

Signed-off-by: Andy Ross <andrew.j.ross@intel.com>