### PR TITLE
kernel: stack: Fix k_stack_pop api

### DIFF
--- a/kernel/stack.c
+++ b/kernel/stack.c
@@ -154,11 +154,11 @@ int _impl_k_stack_pop(struct k_stack *stack, u32_t *data, s32_t timeout)
 	}
 
 	result = _pend_current_thread(key, &stack->wait_q, timeout);
+	if (result == -EAGAIN)
+		return -EAGAIN;
 
-	if (result == 0) {
-		*data = (u32_t)_current->base.swap_data;
-	}
-	return result;
+	*data = (u32_t)_current->base.swap_data;
+	return 0;
 }
 
 #ifdef CONFIG_USERSPACE


### PR DESCRIPTION
_pend_current_thread can return any arbitrary value set by
_set_thred_return_value(), it happens that most cases set 0. This
function can not rely on this behavior otherwise it may return an
invalid value and/or not set data's value.

Signed-off-by: Flavio Ceolin <flavio.ceolin@intel.com>