### PR TITLE
dts/st: enables possibility to define Flash and SRAM out of tree

### DIFF
--- a/dts/arm/st/mem.h
+++ b/dts/arm/st/mem.h
@@ -125,7 +125,9 @@
 #define DT_FLASH_SIZE		__SIZE_K(256)
 #define DT_SRAM_SIZE		__SIZE_K(64)
 #else
-#error "Flash, RAM, and CCM sizes not defined for this chip"
+#if !defined(DT_FLASH_SIZE) || !defined(DT_SRAM_SIZE)
+#error "Flash, RAM, or CCM sizes not defined for this chip"
+#endif /* !DT_FLASH_SIZE || !DT_FLASH_SIZE */
 #endif
 
 #endif /* __DT_BINDING_ST_MEM_H */


### PR DESCRIPTION
In case of out of tree SoC, mem.h will trigger and error since
it is not aware of new SoC CONFIG_SOC_<reference>.
Modify error condition in order to generate the error only if
the flash and error size are not defined at this point (even in
out of tree case).

Fixes #9978

Signed-off-by: Erwan Gouriou <erwan.gouriou@linaro.org>