### PR TITLE
net: tls: Add missing entropy header in sockets_tls.c

### DIFF
--- a/subsys/net/lib/sockets/sockets_tls.c
+++ b/subsys/net/lib/sockets/sockets_tls.c
@@ -13,6 +13,7 @@
 #include <stdbool.h>
 
 #include <init.h>
+#include <entropy.h>
 #include <misc/util.h>
 #include <net/net_context.h>
 #include <net/socket.h>


### PR DESCRIPTION
sockets_tls subsystem uses entropy driver, yet it does not include entropy header. This commit fixes this.

Signed-off-by: Robert Lubos <robert.lubos@nordicsemi.no>