### PR TITLE
dts/bindings: document use of value 'use-prop-name'

### DIFF
--- a/dts/bindings/device_node.yaml.template
+++ b/dts/bindings/device_node.yaml.template
@@ -28,7 +28,7 @@ properties:
 # A typical property entry will look like the following
 #   <name of property as it is in device tree>
 #     category: <required | optional>
-#     type: <string | int | array>
+#     type: <string | int | array | compound>
 #     description: <description of property>
 #     generation: <define | structure>
 
@@ -61,4 +61,11 @@ properties:
   - cell1    # name of second cell
   - cell2    # name of third cell
   - and so on and so forth
+
+# When the "generation" attribute is set to "define", value "use-prop-name"
+# could be added to indicate that generated #define should use property
+# name instead of controller generic name, for instance _CS_GPIO_ instead
+# of _GPIOS_
+
+# "type" attribute is currenty not used.
 ...


### PR DESCRIPTION
'use-prop-name' is not documented.
Update dts/bindings/device_node.yaml.template to fix this.

Fixes #9971

Signed-off-by: Erwan Gouriou <erwan.gouriou@linaro.org>