### PR TITLE
ext: nffs: bugfix of possible to corrupt filename

### DIFF
--- a/ext/fs/nffs/src/nffs_inode.c
+++ b/ext/fs/nffs/src/nffs_inode.c
@@ -641,7 +641,7 @@ nffs_inode_update(struct nffs_inode_entry *inode_entry)
     struct nffs_inode inode;
     uint32_t area_offset;
     uint8_t area_idx;
-    char *filename;
+    char filename[NFFS_INODE_FILENAME_BUF_SZ];
     int filename_len;
     int rc;
 
@@ -664,12 +664,10 @@ nffs_inode_update(struct nffs_inode_entry *inode_entry)
     STATS_INC(nffs_stats, nffs_readcnt_update);
     rc = nffs_flash_read(area_idx,
                          area_offset + sizeof (struct nffs_disk_inode),
-                         nffs_flash_buf, filename_len);
+                         filename, filename_len);
     if (rc != 0) {
         return rc;
     }
-
-    filename = (char *)nffs_flash_buf;
 
     rc = nffs_misc_reserve_space(sizeof disk_inode + filename_len,
                                  &area_idx, &area_offset);


### PR DESCRIPTION
Origin: Apache Mynewt NFFS
URL: https://github.com/apache/mynewt-nffs/tree/master
Commit: a2f679afe6323310ab1000385f41115df7da326e
Maintained-by: External

This patch introduce version which fixes following bug:

While inode is updated it is possible that Garbage Collection
is called which caused overwrite of inode's filename as the same
buffer was used to keep the filename and copping data in GC.

This patch uses buffer on the stack for keeping filename while inode
is updated which fix the issue.

The patch cause 128 B increase of stack consumption during inode
update the file name might be corrupted

Fixes #9749

Signed-off-by: Andrzej Puzdrowski <andrzej.puzdrowski@nordicsemi.no>