### PR TITLE
ext: lib: crypto: Added feature allowing external mbedTLS Kconfig

### DIFF
--- a/ext/lib/crypto/mbedtls/CMakeLists.txt
+++ b/ext/lib/crypto/mbedtls/CMakeLists.txt
@@ -94,8 +94,10 @@ if(CONFIG_MBEDTLS_BUILTIN)
   zephyr_library_sources(library/xtea.c)
 
   zephyr_library_link_libraries(mbedTLS)
-else()
-  assert(CONFIG_MBEDTLS_LIBRARY "MBEDTLS was enabled, but neither BUILTIN or LIBRARY was selected.")
+
+  target_link_libraries(mbedTLS INTERFACE zephyr_interface)
+
+elseif(CONFIG_MBEDTLS_LIBRARY)
 
   # NB: CONFIG_MBEDTLS_LIBRARY is not regression tested and is
   # therefore susceptible to bit rot
@@ -112,6 +114,12 @@ else()
   # Lib mbedtls_external depends on libgcc (I assume?) so to allow
   # mbedtls_external to link with gcc we need to ensure it is placed
   # after mbedtls_external on the linkers command line.
+
+  target_link_libraries(mbedTLS INTERFACE zephyr_interface)
+
+else()
+
+  assert(CONFIG_MBEDTLS_OUT_OF_TREE "MBEDTLS was enabled, but neither BUILTIN or LIBRARY was selected.")
+
 endif()
 
-target_link_libraries(mbedTLS INTERFACE zephyr_interface)

--- a/ext/lib/crypto/mbedtls/Kconfig
+++ b/ext/lib/crypto/mbedtls/Kconfig
@@ -17,6 +17,15 @@
 #
 
 
+config MBEDTLS_OUT_OF_TREE
+	bool
+	help
+	  This internal option controls if mbedTLS is provided out-of-tree.
+	  Enabling it removes all mbedTLS related configuration options allowing
+	  out-of-tree configuration to replace them.
+
+if !MBEDTLS_OUT_OF_TREE
+
 menuconfig MBEDTLS
 	bool "mbedTLS Support"
 	help
@@ -145,5 +154,7 @@ config APP_LINK_WITH_MBEDTLS
 	  Add MBEDTLS header files to the 'app' include path. It may be
 	  disabled if the include paths for MBEDTLS are causing aliasing
 	  issues for 'app'.
+
+endif
 
 endif


### PR DESCRIPTION
This changes allows to configure mbedTLS from different Kconfig and CMakeLists.txt files. This will be useful if other software (e.g. downloaded with the west tool) want to provided its own mbedTLS library with completely different configuration. Current way of configuring it is not convenient for user, because he have to manually put library path. Additionally currently all mbedTLS library files (includes, binaries and config header) must be in single directory.