### PR TITLE
scripts: ci: Set SOC_DIR for check-compliance.py

### DIFF
--- a/scripts/ci/check-compliance.py
+++ b/scripts/ci/check-compliance.py
@@ -105,6 +105,7 @@ def run_kconfig_undef_ref_check(tc, commit_range):
     os.environ["srctree"] = repository_path
 
     # Parse the entire Kconfig tree, to make sure we see all symbols
+    os.environ["SOC_DIR"] = "soc/"
     os.environ["BOARD_DIR"] = "boards/*/*"
     os.environ["ARCH"] = "*"
 


### PR DESCRIPTION
To avoid having to set it externally, set the SOC_DIR environment
variable directly in the compliance script.

Signed-off-by: Carles Cufi <carles.cufi@nordicsemi.no>