### PR TITLE
doc: Fix RST error in Kconfig template documentation

### DIFF
--- a/doc/subsystems/logging/logger.rst
+++ b/doc/subsystems/logging/logger.rst
@@ -166,6 +166,7 @@ Example below presents usage of the template. As a result CONFIG_FOO_LOG_LEVEL
 will be generated:
 
 .. code-block:: none
+
    module = FOO
    module-str = foo
    source "subsys/logging/Kconfig.template.log_config"


### PR DESCRIPTION
A blank line is needed after '.. code-block::', or the code gets
misinterpreted as RST parameters:

```
...doc/subsystems/logging/logger.rst:168: WARNING: Error in "code-block" directive:
maximum 1 argument(s) allowed, 9 supplied.

.. code-block:: none
   module = FOO
   module-str = foo
   source "subsys/logging/Kconfig.template.log_config"
```