### PR TITLE
scripts/dts/extract/flash.py: fix load offset

### DIFF
--- a/scripts/dts/extract/flash.py
+++ b/scripts/dts/extract/flash.py
@@ -95,8 +95,7 @@ class DTFlash(DTDirective):
         if node and node is not self._flash_node:
             # only compute the load offset if the code partition
             # is not the same as the flash base address
-            load_offset = str(int(node['props']['reg'][0]) \
-                              - int(self._flash_node['props']['reg'][0]))
+            load_offset = node['props']['reg'][0]
             load_defs['CONFIG_FLASH_LOAD_OFFSET'] = load_offset
             load_size = node['props']['reg'][1]
             load_defs['CONFIG_FLASH_LOAD_SIZE'] = load_size


### PR DESCRIPTION
On the STM32F7, the first sectors are smaller (16K) than the following
sectors (128K) and therefore also faster to erase. They are therefore
more suitable to run a flash filesystem like NVS on them, and the
STM32F7 has a configuration option to define the boot address.
I am therefore trying to use the following unusual flash layout where
the storage partition is before the code partition:

```
        chosen {
                zephyr,flash = &slot0_partition;
        };
```
```
        flash0: flash@8000000 {
                compatible = "soc-nv-flash";
                label = "FLASH_STM32";
                reg = <0x08000000 DT_FLASH_SIZE>;
        
                write-block-size = <1>;

                partitions {
                        compatible = "fixed-partitions";
                        #address-cells = <1>;
                        #size-cells = <1>;

                        /*
                        * The first 32 KiB is reserved for the application.
                        */
                        storage_partition: partition@0 {
                                label = "storage";
                                reg = <0x00000000 0x00008000>;
                        };

                        /*
                        * The remaining 480 KiB is reserved for the code.
                        */
                        slot0_partition: partition@8000 {
                                label = "code";
                                reg = <0x00008000 0x00078000>;
                        };
                };
        };
```

When the code partition is not at the beginning of the flash, the load
offset is wrongly computed. The address in the device tree is already
relative to the beginning of the parent node, ie the beginning of the
flash memory space. There is therefore no need to subtract it.

Signed-off-by: Aurelien Jarno <aurelien@aurel32.net>