### PR TITLE
Bluetooth: Fix identity creation through vendor HCI

### DIFF
--- a/subsys/bluetooth/host/hci_core.c
+++ b/subsys/bluetooth/host/hci_core.c
@@ -4844,7 +4844,7 @@ static void id_create(u8_t id, bt_addr_le_t *addr, u8_t *irk)
 	}
 
 #if defined(CONFIG_BT_PRIVACY)
-	if (atomic_test_bit(bt_dev.flags, BT_DEV_READY)) {
+	{
 		u8_t zero_irk[16] = { 0 };
 
 		if (irk && memcmp(irk, zero_irk, 16)) {

--- a/subsys/bluetooth/host/hci_core.c
+++ b/subsys/bluetooth/host/hci_core.c
@@ -5004,8 +5004,11 @@ int bt_setup_id_addr(void)
 		rp = (void *)rsp->data;
 		bt_dev.id_count = min(rp->num_addrs, CONFIG_BT_ID_MAX);
 		for (i = 0; i < bt_dev.id_count; i++) {
-			bt_dev.id_addr[i].type = BT_ADDR_LE_RANDOM;
-			bt_addr_copy(&bt_dev.id_addr[i].a, &rp->a[i].bdaddr);
+			bt_addr_le_t addr;
+
+			addr.type = BT_ADDR_LE_RANDOM;
+			bt_addr_copy(&addr.a, &rp->a[i].bdaddr);
+			id_create(i, &addr, NULL);
 		}
 
 		net_buf_unref(rsp);


### PR DESCRIPTION
The code creating identities from the Read_Static_Addresses vendor command was failing to create matching IRKs, resulting in an all-zeroes IRK to be used. Fix this by using the existing id_create() function which takes care of generaing an IRK when necessary.

This PR has an extra initial commit, since the bt_setup_id_addr() function needs to be moved in order to avoid a forward declaration.

Fixes #10003
    
