### PR TITLE
drivers: pinmux: add PINMUX_DEV CMakeLists.txt

### DIFF
--- a/drivers/pinmux/dev/CMakeLists.txt
+++ b/drivers/pinmux/dev/CMakeLists.txt
@@ -1,0 +1,3 @@
+zephyr_sources_ifdef(CONFIG_PINMUX_DEV_ARM_V2M_BEETLE	pinmux_dev_arm_beetle.c)
+zephyr_sources_ifdef(CONFIG_PINMUX_DEV_ATMEL_SAM3X	pinmux_dev_atmel_sam3x.c)
+zephyr_sources_ifdef(CONFIG_PINMUX_DEV_STM32		pinmux_dev_stm32.c)


### PR DESCRIPTION
The drivers/pinmux/dev directory doesn't containe any CMakeLists.txt
file, preventing to enable the PINMUX_DEV option. Fix that by providing
one.

Signed-off-by: Aurelien Jarno <aurelien@aurel32.net>