### PR TITLE
CODEOWNERS: Assign maintainers for Nordic SoC .dtsi files

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -110,6 +110,7 @@ drivers/usb/                             @jfischer-phytec-iot @finikorg
 drivers/usb/device/usb_dc_stm32.c        @ydamigos @loicpoulain
 drivers/i2c/i2c_ll_stm32*                @ldts @ydamigos
 dts/arm/st/                              @erwango
+dts/arm/nordic/                          @ioannisg @carlescufi
 ext/fs/                                  @nashif @ramakrishnapallala
 ext/hal/cmsis/                           @MaureenHelm @galak
 ext/hal/nordic/                          @carlescufi @anangl


### PR DESCRIPTION
Assign a list of maintainers for Nordic SoC Device Tree include
headers.

Signed-off-by: Ioannis Glaropoulos <Ioannis.Glaropoulos@nordicsemi.no>