### PR TITLE
samples: Include regex matching in samples

### DIFF
--- a/samples/drivers/gpio/sample.yaml
+++ b/samples/drivers/gpio/sample.yaml
@@ -5,4 +5,9 @@ tests:
     platform_whitelist: quark_se_c1000_devboard arduino_101
       arduino_101_sss arduino_due
     tags: drivers
+    harness: console
+    harness_config:
+        type: one_line
+        regex:
+            - "Toggling GPIO_(.*)"
     depends_on: gpio

--- a/samples/drivers/rtc/sample.yaml
+++ b/samples/drivers/rtc/sample.yaml
@@ -3,4 +3,11 @@ sample:
 tests:
   test:
     tags: drivers
+    harness: console
+    harness_config:
+        type: multi_line
+        ordered: true
+        regex:
+            - "Test RTC driver"
+            - "Alarm"
     depends_on: rtc

--- a/samples/drivers/spi_flash/sample.yaml
+++ b/samples/drivers/spi_flash/sample.yaml
@@ -4,4 +4,15 @@ tests:
   test:
     platform_whitelist: arduino_101
     tags: apps
+    harness: console
+    harness_config:
+        type: multi_line
+        ordered: true
+        regex:
+            - "Test 1: Flash erase"
+            - "Flash erase succeeded!"
+            - "Test 2: Flash write"
+            - "Attempted to write 55 aa"
+            - "Data read 55 aa"
+            - "Data read matches with data written. Good!!"
     depends_on: spi

--- a/samples/drivers/watchdog/sample.yaml
+++ b/samples/drivers/watchdog/sample.yaml
@@ -3,4 +3,12 @@ sample:
 tests:
   test:
     tags: drivers
+    harness: console
+    harness_config:
+        type: multi_line
+        ordered: true
+        regex:
+            - "Watchdog sample application"
+            - "Feeding watchdog..."
+            - "Waiting for reset..."
     depends_on: watchdog


### PR DESCRIPTION
Add harness console and include regex for output
pattern matching to determine correctness of
sample execution.

Signed-off-by: Spoorthi K <spoorthi.k@intel.com>