### PR TITLE
ci: Print the toolchain database when CI fails

### DIFF
--- a/.shippable.yml
+++ b/.shippable.yml
@@ -74,6 +74,11 @@ build:
       - rm test_file.txt
       - ccache -s
     on_failure:
+      - >
+         if [ -f "$HOME/.cache/zephyr/ToolchainCapabilityDatabase.cmake" ]; then
+           echo "Dumping the capability database in case we are affected by #9992"
+           cat $HOME/.cache/zephyr/ToolchainCapabilityDatabase.cmake
+         fi;
       - rm -rf ccache $HOME/.cache/zephyr
       - mkdir -p shippable/testresults
       - mkdir -p shippable/codecoverage


### PR DESCRIPTION
CI is failing sporadically with a corrupted
ToolchainCapabilityDatabase.cmake file.

To gain insight into how the file is corrupted we print it to the log.

Signed-off-by: Sebastian Bøe <sebastian.boe@nordicsemi.no>