### PR TITLE
kernel: remove deprecate k_call_stacks_analyze

### DIFF
--- a/include/kernel.h
+++ b/include/kernel.h
@@ -604,26 +604,6 @@ typedef void (*k_thread_user_cb_t)(const struct k_thread *thread,
 				   void *user_data);
 
 /**
- * @brief Analyze the main, idle, interrupt and system workqueue call stacks
- *
- * This routine calls @ref STACK_ANALYZE on the 4 call stacks declared and
- * maintained by the kernel. The sizes of those 4 call stacks are defined by:
- *
- * CONFIG_MAIN_STACK_SIZE
- * CONFIG_IDLE_STACK_SIZE
- * CONFIG_ISR_STACK_SIZE
- * CONFIG_SYSTEM_WORKQUEUE_STACK_SIZE
- *
- * @note CONFIG_INIT_STACKS and CONFIG_PRINTK must be set for this function to
- * produce output.
- *
- * @return N/A
- *
- * @deprecated This API is deprecated.  Use k_thread_foreach().
- */
-__deprecated extern void k_call_stacks_analyze(void);
-
-/**
  * @brief Iterate over all the threads in the system.
  *
  * This routine iterates over all the threads in the system and

--- a/kernel/init.c
+++ b/kernel/init.c
@@ -129,24 +129,6 @@ K_THREAD_STACK_DEFINE(_interrupt_stack3, CONFIG_ISR_STACK_SIZE);
 
 extern void idle(void *unused1, void *unused2, void *unused3);
 
-/* LCOV_EXCL_START */
-#if defined(CONFIG_INIT_STACKS) && defined(CONFIG_PRINTK)
-extern K_THREAD_STACK_DEFINE(sys_work_q_stack,
-			     CONFIG_SYSTEM_WORKQUEUE_STACK_SIZE);
-
-
-void k_call_stacks_analyze(void)
-{
-	printk("Kernel stacks:\n");
-	STACK_ANALYZE("main     ", _main_stack);
-	STACK_ANALYZE("idle     ", _idle_stack);
-	STACK_ANALYZE("interrupt", _interrupt_stack);
-	STACK_ANALYZE("workqueue", sys_work_q_stack);
-}
-#else
-void k_call_stacks_analyze(void) { }
-#endif
-/* LCOV_EXCL_STOP */
 
 /**
  *


### PR DESCRIPTION
This API was deperecated and is not being used in the tree anymore, so remove
it.

Signed-off-by: Anas Nashif <anas.nashif@intel.com>