### PR TITLE
Fix undefined reference to `__log_current_const_data_get' when using LOG_MODULE_DECLARE

### DIFF
--- a/include/logging/log.h
+++ b/include/logging/log.h
@@ -315,8 +315,13 @@ int log_printk(const char *fmt, va_list ap);
 		()/*Empty*/						\
 	)
 
-#define __DYNAMIC_MODULE_DECLARE(_name)				\
-	extern struct log_source_dynamic_data LOG_ITEM_DYNAMIC_DATA(_name)
+#define __DYNAMIC_MODULE_DECLARE(_name)					   \
+	extern struct log_source_dynamic_data LOG_ITEM_DYNAMIC_DATA(_name);\
+	static inline struct log_source_dynamic_data *			   \
+				__log_current_dynamic_data_get(void)	   \
+	{								   \
+		return &LOG_ITEM_DYNAMIC_DATA(_name);			   \
+	}
 
 #define _LOG_RUNTIME_MODULE_DECLARE(_name)			\
 	_LOG_EVAL(						\
@@ -325,9 +330,14 @@ int log_printk(const char *fmt, va_list ap);
 		()						\
 		)
 
-#define _LOG_MODULE_DECLARE(_name, _level)				\
+#define _LOG_MODULE_DECLARE(_name, _level)				     \
 	extern const struct log_source_const_data LOG_ITEM_CONST_DATA(_name) \
-	_LOG_RUNTIME_MODULE_DECLARE(_name)
+	_LOG_RUNTIME_MODULE_DECLARE(_name);				     \
+	static inline const struct log_source_const_data *		     \
+				__log_current_const_data_get(void)	     \
+	{								     \
+		return &LOG_ITEM_CONST_DATA(_name);			     \
+	}
 
 /**
  * @brief Macro for declaring a log module (not registering it).

--- a/tests/subsys/logging/log_core/src/test_module.c
+++ b/tests/subsys/logging/log_core/src/test_module.c
@@ -1,0 +1,19 @@
+/*
+ * Copyright (c) 2018 Nordic Semiconductor
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * @file
+ * @brief Test module for log core test
+ *
+ */
+
+#include <logging/log.h>
+LOG_MODULE_DECLARE(test);
+
+void test_func(void)
+{
+	LOG_ERR("test");
+}

--- a/tests/subsys/logging/log_core/testcase.yaml
+++ b/tests/subsys/logging/log_core/testcase.yaml
@@ -1,3 +1,5 @@
 tests:
   logging.log_core:
     tags: log_core logging
+    platform_exclude: altera_max10 qemu_nios2 nucleo_l053r8
+      nucleo_f030r8 quark_d2000_crb stm32f0_disco


### PR DESCRIPTION
Fixing compilation failure when LOG_MODULE_DECLARE() is used. Added test to cover usage of that macro.

One thing to note. With current scheme (LOG_MODULE_DECLARE/LOG_MODULE_REGISTER taking module name) it is forbidden to use LOG_MODULE_DECLARE() in headers thus logging in static inline function in header is impossible. That is because both macros creates static inline function with the same name: __log_current_dynamic_data_get().

Fixes #10026 