### PR TITLE
Bluetooth: GATT: Fix const'ness of characteristic descriptor data

### DIFF
--- a/include/bluetooth/gatt.h
+++ b/include/bluetooth/gatt.h
@@ -582,7 +582,7 @@ ssize_t bt_gatt_attr_read_cep(struct bt_conn *conn,
  */
 #define BT_GATT_CEP(_value)						\
 	BT_GATT_DESCRIPTOR(BT_UUID_GATT_CEP, BT_GATT_PERM_READ,		\
-			  bt_gatt_attr_read_cep, NULL, _value)
+			  bt_gatt_attr_read_cep, NULL, (void *)_value)
 
 /** @brief Read Characteristic User Description Descriptor Attribute helper
  *
@@ -613,7 +613,7 @@ ssize_t bt_gatt_attr_read_cud(struct bt_conn *conn,
  */
 #define BT_GATT_CUD(_value, _perm)					\
 	BT_GATT_DESCRIPTOR(BT_UUID_GATT_CUD, _perm, bt_gatt_attr_read_cud, \
-			   NULL, _value)
+			   NULL, (void *)_value)
 
 /** @brief Read Characteristic Presentation format Descriptor Attribute helper
  *
@@ -643,7 +643,7 @@ ssize_t bt_gatt_attr_read_cpf(struct bt_conn *conn,
  */
 #define BT_GATT_CPF(_value)						\
 	BT_GATT_DESCRIPTOR(BT_UUID_GATT_CPF, BT_GATT_PERM_READ,		\
-			  bt_gatt_attr_read_cpf, NULL, (void * const)_value)
+			  bt_gatt_attr_read_cpf, NULL, (void *)_value)
 
 /** @def BT_GATT_DESCRIPTOR
  *  @brief Descriptor Declaration Macro.

--- a/subsys/bluetooth/host/gatt.c
+++ b/subsys/bluetooth/host/gatt.c
@@ -651,7 +651,7 @@ ssize_t bt_gatt_attr_read_cep(struct bt_conn *conn,
 			      const struct bt_gatt_attr *attr, void *buf,
 			      u16_t len, u16_t offset)
 {
-	struct bt_gatt_cep *value = attr->user_data;
+	const struct bt_gatt_cep *value = attr->user_data;
 	u16_t props = sys_cpu_to_le16(value->properties);
 
 	return bt_gatt_attr_read(conn, attr, buf, len, offset, &props,
@@ -662,7 +662,7 @@ ssize_t bt_gatt_attr_read_cud(struct bt_conn *conn,
 			      const struct bt_gatt_attr *attr, void *buf,
 			      u16_t len, u16_t offset)
 {
-	char *value = attr->user_data;
+	const char *value = attr->user_data;
 
 	return bt_gatt_attr_read(conn, attr, buf, len, offset, value,
 				 strlen(value));
@@ -672,7 +672,7 @@ ssize_t bt_gatt_attr_read_cpf(struct bt_conn *conn,
 			      const struct bt_gatt_attr *attr, void *buf,
 			      u16_t len, u16_t offset)
 {
-	struct bt_gatt_cpf *value = attr->user_data;
+	const struct bt_gatt_cpf *value = attr->user_data;
 
 	return bt_gatt_attr_read(conn, attr, buf, len, offset, value,
 				 sizeof(*value));


### PR DESCRIPTION
None of the data for the CEP, CUD and CPF descriptors needs to be
modified by the stack at runtime. Make it possible to pass constant
data to the descriptor macros, and make sure the descriptor handlers
cast the data back to be a constant.

Signed-off-by: Johan Hedberg <johan.hedberg@intel.com>