### PR TITLE
CMakeLists.txt: Set application shared memory dependency

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1029,7 +1029,7 @@ if(CONFIG_CPU_HAS_MPU AND CONFIG_USERSPACE)
         add_custom_target(
           ${APP_SMEM_DEP} ALL
           DEPENDS app
-          DEPENDS ${PRIV_STACK_DEP}
+          DEPENDS ${ALIGN_SIZING_DEP}
          )
 
         add_custom_command(
@@ -1095,7 +1095,7 @@ if(CONFIG_ARM)
   add_custom_target(
     linker_priv_stacks_script
     DEPENDS
-    ${ALIGN_SIZING_DEP}
+    ${ALIGN_SIZING_DEP} ${APP_SMEM_DEP}
     linker_priv_stacks.cmd
     offsets_h
     )


### PR DESCRIPTION
The scripts for app_smem need to be ready before the script for
privilaged stack is run. This is needed because there is a small
possibility that the stacks get aligned (due to app_smem)
after privilaged stack script is run. This causes the gperf
to create an incorrect hash.

Signed-off-by: Adithya Baglody <adithya.nagaraj.baglody@intel.com>