### PR TITLE
net: gptp: Various gPTP fixes and improvements

### DIFF
--- a/subsys/net/l2/ethernet/gptp/Kconfig
+++ b/subsys/net/l2/ethernet/gptp/Kconfig
@@ -65,7 +65,7 @@ config NET_GPTP_INIT_LOG_PDELAY_REQ_ITV
 	help
 	  Defines the interval at which a Path Delay Request will be sent.
 	  The value is the converted in nanoseconds as follow:
-	  nanoseconds = (10^9) * 2^(16 + value)
+	  nanoseconds = (10^9) * 2^(value)
 
 config NET_GPTP_INIT_LOG_SYNC_ITV
 	int "Set initial sync interval in Log2 base"
@@ -73,7 +73,7 @@ config NET_GPTP_INIT_LOG_SYNC_ITV
 	help
 	  Defines the interval at which a Sync message will be sent.
 	  The value is the converted in nanoseconds as follow:
-	  nanoseconds = (10^9) * 2^(16 + value)
+	  nanoseconds = (10^9) * 2^(value)
 
 config NET_GPTP_INIT_LOG_ANNOUNCE_ITV
 	int "Set initial announce interval in Log2 base"
@@ -81,7 +81,7 @@ config NET_GPTP_INIT_LOG_ANNOUNCE_ITV
 	help
 	  Defines the interval at which an Announce message will be sent.
 	  The value is the converted in nanoseconds as follow:
-	  nanoseconds = (10^9) * 2^(16 + value)
+	  nanoseconds = (10^9) * 2^(value)
 
 config NET_GPTP_SYNC_RECEIPT_TIMEOUT
 	int "Number of sync intervals to wait"

--- a/subsys/net/l2/ethernet/gptp/Kconfig
+++ b/subsys/net/l2/ethernet/gptp/Kconfig
@@ -85,7 +85,7 @@ config NET_GPTP_INIT_LOG_ANNOUNCE_ITV
 
 config NET_GPTP_SYNC_RECEIPT_TIMEOUT
 	int "Number of sync intervals to wait"
-	default 6
+	default 3
 	help
 	  Defines the number of sync intervals to wait without receiving
 	  synchronization information before assuming that the master is no

--- a/subsys/net/l2/ethernet/gptp/gptp_mi.c
+++ b/subsys/net/l2/ethernet/gptp/gptp_mi.c
@@ -314,7 +314,7 @@ static void gptp_mi_pss_rcv_compute(int port)
 	port_ds->sync_receipt_timeout_time_itv = port_ds->sync_receipt_timeout;
 	port_ds->sync_receipt_timeout_time_itv *= NSEC_PER_SEC;
 	port_ds->sync_receipt_timeout_time_itv *=
-		GPTP_POW2(16 + sync_rcv->log_msg_interval);
+		GPTP_POW2(sync_rcv->log_msg_interval);
 
 	pss->local_port_number = port;
 
@@ -322,7 +322,7 @@ static void gptp_mi_pss_rcv_compute(int port)
 
 	pss->sync_receipt_timeout_time = gptp_get_current_time_nanosecond(port);
 	pss->sync_receipt_timeout_time +=
-		(port_ds->sync_receipt_timeout_time_itv >> 16);
+		port_ds->sync_receipt_timeout_time_itv;
 
 	pss->sync_info.rate_ratio = state->rate_ratio;
 }
@@ -332,8 +332,7 @@ static void start_rcv_sync_timer(struct gptp_port_ds *port_ds,
 {
 	s32_t duration;
 
-	duration = (port_ds->sync_receipt_timeout_time_itv >> 16) /
-		(NSEC_PER_SEC / MSEC_PER_SEC);
+	duration = port_ds->sync_receipt_timeout_time_itv;
 
 	k_timer_start(&state->rcv_sync_receipt_timeout_timer, duration, 0);
 }

--- a/subsys/net/l2/ethernet/gptp/gptp_private.h
+++ b/subsys/net/l2/ethernet/gptp/gptp_private.h
@@ -26,8 +26,6 @@ extern "C" {
 #define GPTP_THREAD_WAIT_TIMEOUT_MS 1
 #define GPTP_MULTIPLE_PDELAY_RESP_WAIT K_MINUTES(5)
 
-#define USCALED_NS_TO_MS(val) ((val >> 16) / 1000000)
-
 #if defined(CONFIG_NET_GPTP_STATISTICS)
 #define GPTP_STATS_INC(port, var) (GPTP_PORT_PARAM_DS(port)->var++)
 #else


### PR DESCRIPTION
This PR changes a few things in the gPTP related code:
* Changes how the ptp clock in sam gmac is initialized - it is now initialized correctly based on the value of MCK - earlier the clock rate was always set based on the values received from the grand master - this approach did not work correctly on sam gmac, after disconnecting from the ptp network, the clock on sam gmac always started drifting away from real time (~10 minutes every hour) - with this approach we will still be able to sync our clock to other masters, but the rate will be constant, and correct
* Fixes the so called 'multiple-masters' issue (described like that by ptpTrackHound)
* Other minor fixes and cleanups.