### PR TITLE
dts: Cleanup warnings associated with alias_paths using '-'

### DIFF
--- a/boards/nios2/altera_max10/altera_max10.dts
+++ b/boards/nios2/altera_max10/altera_max10.dts
@@ -7,7 +7,7 @@
 	compatible = "altera,nios2f";
 
 	aliases {
-		uart_0 = &uart0;
+		uart-0 = &uart0;
 	};
 
 	chosen {

--- a/boards/nios2/qemu_nios2/qemu_nios2.dts
+++ b/boards/nios2/qemu_nios2/qemu_nios2.dts
@@ -7,7 +7,7 @@
 	compatible = "qemu,nios2";
 
 	aliases {
-		uart_0 = &uart0;
+		uart-0 = &uart0;
 	};
 
 	chosen {

--- a/boards/riscv32/qemu_riscv32/qemu_riscv32.dts
+++ b/boards/riscv32/qemu_riscv32/qemu_riscv32.dts
@@ -7,7 +7,7 @@
 	compatible = "qemu,riscv32";
 
 	aliases {
-		uart_0 = &uart0;
+		uart-0 = &uart0;
 	};
 
 	chosen {


### PR DESCRIPTION
We get several warnings of the form:

	 Warning (alias_paths): /aliases: aliases property name
	 must include only lowercase and '-'

Signed-off-by: Kumar Gala <kumar.gala@linaro.org>