### PR TITLE
dts: Cleanup warnings associated with unit_address_vs_reg and cpu node

### DIFF
--- a/boards/arm/mps2_an385/mps2_an385.dts
+++ b/boards/arm/mps2_an385/mps2_an385.dts
@@ -17,6 +17,7 @@
 	cpus {
 		cpu@0 {
 			compatible = "arm,cortex-m3";
+			reg = <0>;
 		};
 	};
 

--- a/boards/arm/v2m_beetle/v2m_beetle.dts
+++ b/boards/arm/v2m_beetle/v2m_beetle.dts
@@ -17,6 +17,7 @@
 	cpus {
 		cpu@0 {
 			compatible = "arm,cortex-m3";
+			reg = <0>;
 		};
 	};
 

--- a/dts/arm/silabs/efm32wg.dtsi
+++ b/dts/arm/silabs/efm32wg.dtsi
@@ -4,6 +4,7 @@
 	cpus {
 		cpu@0 {
 			compatible = "arm,cortex-m4f";
+			reg = <0>;
 		};
 	};
 

--- a/dts/arm/silabs/efr32fg1p.dtsi
+++ b/dts/arm/silabs/efr32fg1p.dtsi
@@ -4,6 +4,7 @@
 	cpus {
 		cpu@0 {
 			compatible = "arm,cortex-m4f";
+			reg = <0>;
 		};
 	};
 

--- a/dts/arm/ti/msp432p4xx.dtsi
+++ b/dts/arm/ti/msp432p4xx.dtsi
@@ -4,6 +4,7 @@
 	cpus {
 		cpu@0 {
 			compatible = "arm,cortex-m4f";
+			reg = <0>;
 		};
 	};
 


### PR DESCRIPTION
We get several warnings of the form:

	Warning (unit_address_vs_reg): /cpus/cpu@0: node has a
	unit name, but no reg property

Fix by adding reg property to missing cpu nodes.

Signed-off-by: Kumar Gala <kumar.gala@linaro.org>