### PR TITLE
dts: Cleanup warnings associated with flash and memory nodes

### DIFF
--- a/boards/arm/mps2_an385/mps2_an385.dts
+++ b/boards/arm/mps2_an385/mps2_an385.dts
@@ -20,12 +20,12 @@
 		};
 	};
 
-	sram0: memory {
+	sram0: memory@20000000 {
 		compatible = "mmio-sram";
 		reg = <0x20000000 0x400000>;
 	};
 
-	flash0: flash {
+	flash0: flash@0 {
 		reg = <0 0x400000>;
 	};
 

--- a/boards/arm/v2m_beetle/v2m_beetle.dts
+++ b/boards/arm/v2m_beetle/v2m_beetle.dts
@@ -20,12 +20,12 @@
 		};
 	};
 
-	sram0: memory {
+	sram0: memory@20000000 {
 		compatible = "mmio-sram";
 		reg = <0x20000000 0x20000>;
 	};
 
-	flash0: flash {
+	flash0: flash@0 {
 		reg = <0 0x40000>;
 	};
 

--- a/dts/arm/silabs/efm32wg.dtsi
+++ b/dts/arm/silabs/efm32wg.dtsi
@@ -7,9 +7,14 @@
 		};
 	};
 
-	flash0: flash {
+	flash0: flash@0 {
 		compatible = "soc-nv-flash";
 		label = "FLASH_0";
+	};
+
+	sram0: memory@20000000 {
+		device_type = "memory";
+		compatible = "mmio-sram";
 	};
 
 	soc {

--- a/dts/arm/silabs/efm32wg990f256.dtsi
+++ b/dts/arm/silabs/efm32wg990f256.dtsi
@@ -8,11 +8,11 @@
 #include <silabs/efm32wg.dtsi>
 
 / {
-	flash {
+	flash@0 {
 		reg = <0 DT_SIZE_K(256)>;
 	};
 
-	sram0: memory {
+	sram0: memory@20000000 {
 		reg = <0x20000000 DT_SIZE_K(32)>;
 	};
 };

--- a/dts/arm/silabs/efr32fg1p.dtsi
+++ b/dts/arm/silabs/efr32fg1p.dtsi
@@ -7,9 +7,14 @@
 		};
 	};
 
-	flash0: flash {
+	flash0: flash@0 {
 		compatible = "soc-nv-flash";
 		label = "FLASH_0";
+	};
+
+	sram0: memory@20000000 {
+		device_type = "memory";
+		compatible = "mmio-sram";
 	};
 
 	soc {

--- a/dts/arm/silabs/efr32fg1p133f256gm48.dtsi
+++ b/dts/arm/silabs/efr32fg1p133f256gm48.dtsi
@@ -8,11 +8,11 @@
 #include <silabs/efr32fg1p.dtsi>
 
 / {
-	flash {
+	flash@0 {
 		reg = <0 DT_SIZE_K(256)>;
 	};
 
-	sram0: memory {
+	sram0: memory@20000000 {
 		reg = <0x20000000 DT_SIZE_K(32)>;
 	};
 };

--- a/dts/arm/ti/msp432p401r.dtsi
+++ b/dts/arm/ti/msp432p401r.dtsi
@@ -8,11 +8,11 @@
 #include <ti/msp432p4xx.dtsi>
 
 / {
-	sram0: memory {
+	sram0: memory@20000000 {
 		reg = <0x20000000 DT_SIZE_K(64)>;
 	};
 
-	flash0: serial-flash {
+	flash0: serial-flash@0 {
 		reg = <0x0 DT_SIZE_K(256)>;
 	};
 };

--- a/dts/arm/ti/msp432p4xx.dtsi
+++ b/dts/arm/ti/msp432p4xx.dtsi
@@ -7,11 +7,11 @@
 		};
 	};
 
-	sram0: memory {
+	sram0: memory@20000000 {
 		compatible = "sram";
 	};
 
-	flash0: serial-flash {
+	flash0: serial-flash@0 {
 		compatible = "serial-flash";
 	};
 


### PR DESCRIPTION
We get several warnings of the form:

	Warning (unit_address_vs_reg): /flash: node has a reg or ranges
	property, but no unit name

or

	Warning (unit_address_vs_reg): /memory: node has a reg or ranges
	property, but no unit name

Fix by adding unit address that is missing to flash & memory nodes.
Additionally the Silabs memory nodes didn't have a compatiable or
device_type, so add those properties as well.

Signed-off-by: Kumar Gala <kumar.gala@linaro.org>