### PR TITLE
dts: Cleanup warnings associated with gpio_keys that aren't buttons

### DIFF
--- a/boards/arm/colibri_imx7d_m4/colibri_imx7d_m4.dts
+++ b/boards/arm/colibri_imx7d_m4/colibri_imx7d_m4.dts
@@ -40,7 +40,7 @@
 
 	gpio_keys {
 		compatible = "gpio-keys";
-		user_switch_1: sw@0 {
+		user_switch_1: user_sw_1 {
 			gpios = <&gpio2 26 GPIO_INT_ACTIVE_LOW>;
 			label = "User SW1";
 		};

--- a/boards/arm/stm32f072_eval/stm32f072_eval.dts
+++ b/boards/arm/stm32f072_eval/stm32f072_eval.dts
@@ -40,27 +40,27 @@
 
 	gpio_keys {
 		compatible = "gpio-keys";
-		tamper: tamper@0 {
+		tamper: tamper_button {
 			label = "tamper button";
 			gpios = <&gpioc 13 GPIO_INT_ACTIVE_LOW>;
 		};
-		joy_sel: joystick@1 {
+		joy_sel: joystick_selection {
 			label = "joystick selection";
 			gpios = <&gpioa 0 GPIO_INT_ACTIVE_LOW>;
 		};
-		joy_down: joystick@2 {
+		joy_down: joystick_down {
 			label = "joystick down";
 			gpios = <&gpiof 10 GPIO_INT_ACTIVE_LOW>;
 		};
-		joy_up: joystick@3 {
+		joy_up: joystick_up {
 			label = "joystick up";
 			gpios = <&gpiof 9 GPIO_INT_ACTIVE_LOW>;
 		};
-		joy_left: joystick@4 {
+		joy_left: joystick_left {
 			label = "joystick left";
 			gpios = <&gpiof 2 GPIO_INT_ACTIVE_LOW>;
 		};
-		joy_right: joystick@5 {
+		joy_right: joystick_right {
 			label = "joystick right";
 			gpios = <&gpioe 3 GPIO_INT_ACTIVE_LOW>;
 		};

--- a/boards/arm/stm32f412g_disco/stm32f412g_disco.dts
+++ b/boards/arm/stm32f412g_disco/stm32f412g_disco.dts
@@ -39,23 +39,23 @@
 
 	gpio_keys {
 		compatible = "gpio-keys";
-		joy_sel: joystick@0 {
+		joy_sel: joystick_selection {
 			label = "joystick selection";
 			gpios = <&gpioa 0 GPIO_INT_ACTIVE_LOW>;
 		};
-		joy_down: joystick@1 {
+		joy_down: joystick_down {
 			label = "joystick down";
 			gpios = <&gpiog 1 GPIO_INT_ACTIVE_LOW>;
 		};
-		joy_up: joystick@2 {
+		joy_up: joystick_up {
 			label = "joystick up";
 			gpios = <&gpiog 0 GPIO_INT_ACTIVE_LOW>;
 		};
-		joy_left: joystick@3 {
+		joy_left: joystick_left {
 			label = "joystick left";
 			gpios = <&gpiof 15 GPIO_INT_ACTIVE_LOW>;
 		};
-		joy_right: joystick@4 {
+		joy_right: joystick_right {
 			label = "joystick right";
 			gpios = <&gpiof 14 GPIO_INT_ACTIVE_LOW>;
 		};

--- a/boards/arm/stm32l476g_disco/stm32l476g_disco.dts
+++ b/boards/arm/stm32l476g_disco/stm32l476g_disco.dts
@@ -35,23 +35,23 @@
 
 	gpio_keys {
 		compatible = "gpio-keys";
-		joy_center: joystick@0 {
+		joy_center: joystick_center {
 			label = "joystick center";
 			gpios = <&gpioa 0 GPIO_INT_ACTIVE_LOW>;
 		};
-		joy_down: joystick@1 {
+		joy_down: joystick_down {
 			label = "joystick down";
 			gpios = <&gpioa 5 GPIO_INT_ACTIVE_LOW>;
 		};
-		joy_up: joystick@2 {
+		joy_up: joystick_up {
 			label = "joystick up";
 			gpios = <&gpioa 3 GPIO_INT_ACTIVE_LOW>;
 		};
-		joy_left: joystick@3 {
+		joy_left: joystick_left {
 			label = "joystick left";
 			gpios = <&gpioa 1 GPIO_INT_ACTIVE_LOW>;
 		};
-		joy_right: joystick@4 {
+		joy_right: joystick_right {
 			label = "joystick right";
 			gpios = <&gpioa 2 GPIO_INT_ACTIVE_LOW>;
 		};

--- a/boards/arm/stm32l496g_disco/stm32l496g_disco.dts
+++ b/boards/arm/stm32l496g_disco/stm32l496g_disco.dts
@@ -27,23 +27,23 @@
 
 	gpio_keys {
 		compatible = "gpio-keys";
-		joy_sel: joystick@0 {
+		joy_sel: joystick_select {
 			label = "joystick select";
 			gpios = <&gpioc 13 GPIO_INT_ACTIVE_LOW>;
 		};
-		joy_down: joystick@1 {
+		joy_down: joystick_down {
 			label = "joystick down";
 			gpios = <&gpioi 10 GPIO_INT_ACTIVE_LOW>;
 		};
-		joy_up: joystick@2 {
+		joy_up: joystick_up {
 			label = "joystick up";
 			gpios = <&gpioi 8 GPIO_INT_ACTIVE_LOW>;
 		};
-		joy_left: joystick@3 {
+		joy_left: joystick_left {
 			label = "joystick left";
 			gpios = <&gpioi 9 GPIO_INT_ACTIVE_LOW>;
 		};
-		joy_right: joystick@4 {
+		joy_right: joystick_right {
 			label = "joystick right";
 			gpios = <&gpiof 11 GPIO_INT_ACTIVE_LOW>;
 		};

--- a/boards/arm/warp7_m4/warp7_m4.dts
+++ b/boards/arm/warp7_m4/warp7_m4.dts
@@ -30,7 +30,7 @@
 
 	gpio_keys {
 		compatible = "gpio-keys";
-		user_switch_1: sw@0 {
+		user_switch_1: user_sw_1 {
 			gpios = <&gpio7 1 GPIO_INT_ACTIVE_LOW>;
 			label = "User SW1";
 		};


### PR DESCRIPTION
We get several warnings of the form:

 	Warning (unit_address_vs_reg): /gpio_keys/joystick@0:
	node has a unit name, but no reg property

Fix by dropping the unit address and renaming the node names to include
more information about the gpio_key.

Signed-off-by: Kumar Gala <kumar.gala@linaro.org>