### PR TITLE
dts: Cleanup warnings associated with interrupt controller nodes

### DIFF
--- a/boards/arc/nsim_em/nsim_em.dts
+++ b/boards/arc/nsim_em/nsim_em.dts
@@ -23,11 +23,10 @@
 			reg = <1>;
 		};
 
-		intc: arcv2-intc@0 {
+		intc: arcv2-intc {
 			compatible = "snps,arcv2-intc";
 			interrupt-controller;
 			#interrupt-cells = <2>;
-			reg = <0>;
 		};
 	};
 

--- a/dts/arc/emsk.dtsi
+++ b/dts/arc/emsk.dtsi
@@ -20,11 +20,10 @@
 			reg = <1>;
 		};
 
-		intc: arcv2-intc@0 {
+		intc: arcv2-intc {
 			compatible = "snps,arcv2-intc";
 			interrupt-controller;
 			#interrupt-cells = <2>;
-			reg = <0>;
 		};
 	};
 

--- a/dts/arc/quark_se_c1000_ss.dtsi
+++ b/dts/arc/quark_se_c1000_ss.dtsi
@@ -19,7 +19,7 @@
 			reg = <1>;
 		};
 
-		core_intc: arcv2-intc@0 {
+		core_intc: arcv2-intc {
 			compatible = "snps,arcv2-intc";
 			interrupt-controller;
 			#interrupt-cells = <2>;

--- a/dts/x86/intel_quark_d2000.dtsi
+++ b/dts/x86/intel_quark_d2000.dtsi
@@ -19,7 +19,7 @@
 			reg = <0>;
 		};
 
-		intc: mvic@0 {
+		intc: mvic {
 			compatible = "intel,mvic";
 			interrupt-controller;
 			#interrupt-cells = <2>;


### PR DESCRIPTION
We get several warnings of the form:

	Warning (unit_address_vs_reg): /cpus/arcv2-intc@0:
	node has a unit name, but no reg property

Fix by removing the unit address from the nodes.  Some cases we had a
reg property and a unit address for such interrupt controllers, in those
cases remove both the reg & unit address in the node name.

Signed-off-by: Kumar Gala <kumar.gala@linaro.org>