### PR TITLE
dts: Cleanup warnings associated with unit_address_vs_reg on intel_curie

### DIFF
--- a/dts/x86/intel_curie.dtsi
+++ b/dts/x86/intel_curie.dtsi
@@ -104,7 +104,7 @@
 			#gpio-cells = <2>;
 		};
 
-		usb_cdc: virtualcom@0 {
+		usb_cdc: virtualcom {
 			compatible = "intel,qmsi-usb";
 			label = "CDC_ACM";
 		};


### PR DESCRIPTION
We get several warnings of the form:

	Warning (unit_address_vs_reg): /soc/virtualcom@0:
	node has a unit name, but no reg property

Fix by dropping the unit address from the node name.

Signed-off-by: Kumar Gala <kumar.gala@linaro.org>