### PR TITLE
dts/arm/st: Fix dtc warning in stm32 *-pinctrl.dtsi files

### DIFF
--- a/dts/arm/st/stm32f0-pinctrl.dtsi
+++ b/dts/arm/st/stm32f0-pinctrl.dtsi
@@ -9,43 +9,43 @@
 / {
 	soc {
 		pinctrl: pin-controller@48000000 {
-			usart1_pins_a: usart1@0 {
+			usart1_pins_a: usart1_a {
 				rx_tx {
 					rx = <STM32_PIN_PB7 (STM32_PINMUX_ALT_FUNC_0 | STM32_PUPDR_NO_PULL)>;
 					tx = <STM32_PIN_PB6 (STM32_PINMUX_ALT_FUNC_0 | STM32_PUSHPULL_NOPULL)>;
 				};
 			};
-			usart1_pins_b: usart1@1 {
+			usart1_pins_b: usart1_b {
 				rx_tx {
 					rx = <STM32_PIN_PA10 (STM32_PINMUX_ALT_FUNC_1 | STM32_PUPDR_NO_PULL)>;
 					tx = <STM32_PIN_PA9 (STM32_PINMUX_ALT_FUNC_1 | STM32_PUSHPULL_NOPULL)>;
 				};
 			};
-			usart2_pins_a: usart2@0 {
+			usart2_pins_a: usart2_a {
 				rx_tx {
 					rx = <STM32_PIN_PA3 (STM32_PINMUX_ALT_FUNC_1 | STM32_PUPDR_NO_PULL)>;
 					tx = <STM32_PIN_PA2 (STM32_PINMUX_ALT_FUNC_1 | STM32_PUSHPULL_NOPULL)>;
 				};
 			};
-			usart2_pins_b: usart2@1 {
+			usart2_pins_b: usart2_b {
 				rx_tx {
 					rx = <STM32_PIN_PA15 (STM32_PINMUX_ALT_FUNC_1 | STM32_PUPDR_NO_PULL)>;
 					tx = <STM32_PIN_PA14 (STM32_PINMUX_ALT_FUNC_1 | STM32_PUSHPULL_NOPULL)>;
 				};
 			};
-			usart2_pins_d: usart2@2 {
+			usart2_pins_d: usart2_d {
 				rx_tx {
 					rx = <STM32_PIN_PD6 (STM32_PINMUX_ALT_FUNC_0 | STM32_PUPDR_NO_PULL)>;
 					tx = <STM32_PIN_PD5 (STM32_PINMUX_ALT_FUNC_0 | STM32_PUSHPULL_NOPULL)>;
 				};
 			};
-			can_pins_a: can@0 {
+			can_pins_a: can_a {
 				rx_tx {
 					rx = <STM32_PIN_PB8 (STM32_PINMUX_ALT_FUNC_4 | STM32_PUPDR_PULL_UP)>;
 					tx = <STM32_PIN_PB9 (STM32_PINMUX_ALT_FUNC_4 | STM32_PUPDR_NO_PULL)>;
 				};
 			};
-			can_pins_b: can@1 {
+			can_pins_b: can_b {
 				rx_tx {
 					rx = <STM32_PIN_PD0 (STM32_PINMUX_ALT_FUNC_0 | STM32_PUPDR_PULL_UP)>;
 					tx = <STM32_PIN_PD1 (STM32_PINMUX_ALT_FUNC_0 | STM32_PUPDR_NO_PULL)>;

--- a/dts/arm/st/stm32f1-pinctrl.dtsi
+++ b/dts/arm/st/stm32f1-pinctrl.dtsi
@@ -9,31 +9,31 @@
 / {
 	soc {
 		pinctrl: pin-controller@40010800 {
-			usart1_pins_a: usart1@0 {
+			usart1_pins_a: usart1_a {
 				rx_tx {
 					rx = <STM32_PIN_PA10 STM32_PIN_USART_RX>;
 					tx = <STM32_PIN_PA9 STM32_PIN_USART_TX>;
 				};
 			};
-			usart2_pins_a: usart2@0 {
+			usart2_pins_a: usart2_a {
 				rx_tx {
 					rx = <STM32_PIN_PA3 STM32_PIN_USART_RX>;
 					tx = <STM32_PIN_PA2 STM32_PIN_USART_TX>;
 				};
 			};
-			usart2_pins_b: usart2@1 {
+			usart2_pins_b: usart2_b {
 				rx_tx {
 					rx = <STM32_PIN_PD6 STM32_PIN_USART_RX>;
 					tx = <STM32_PIN_PD5 STM32_PIN_USART_TX>;
 				};
 			};
-			usart3_pins_a: usart3@0 {
+			usart3_pins_a: usart3_a {
 				rx_tx {
 					rx = <STM32_PIN_PB11 STM32_PIN_USART_RX>;
 					tx = <STM32_PIN_PB10 STM32_PIN_USART_TX>;
 				};
 			};
-			uart4_pins_a: uart4@0 {
+			uart4_pins_a: uart4_a {
 				rx_tx {
 					rx = <STM32_PIN_PC11 STM32_PIN_USART_RX>;
 					tx = <STM32_PIN_PC10 STM32_PIN_USART_TX>;

--- a/dts/arm/st/stm32f2-pinctrl.dtsi
+++ b/dts/arm/st/stm32f2-pinctrl.dtsi
@@ -9,37 +9,37 @@
 / {
 	soc {
 		pinctrl: pin-controller@40020000 {
-			usart1_pins_a: usart1@0 {
+			usart1_pins_a: usart1_a {
 				rx_tx {
 					rx = <STM32_PIN_PB7 (STM32_PINMUX_ALT_FUNC_7 | STM32_PUPDR_NO_PULL)>;
 					tx = <STM32_PIN_PB6 (STM32_PINMUX_ALT_FUNC_7 | STM32_PUSHPULL_NOPULL)>;
 				};
 			};
-			usart1_pins_b: usart1@1 {
+			usart1_pins_b: usart1_b {
 				rx_tx {
 					rx = <STM32_PIN_PA10 (STM32_PINMUX_ALT_FUNC_7 | STM32_PUPDR_NO_PULL)>;
 					tx = <STM32_PIN_PA9 (STM32_PINMUX_ALT_FUNC_7 | STM32_PUSHPULL_NOPULL)>;
 				};
 			};
-			usart2_pins_a: usart2@0 {
+			usart2_pins_a: usart2_a {
 				rx_tx {
 					rx = <STM32_PIN_PA3 (STM32_PINMUX_ALT_FUNC_7 | STM32_PUPDR_NO_PULL)>;
 					tx = <STM32_PIN_PA2 (STM32_PINMUX_ALT_FUNC_7 | STM32_PUSHPULL_NOPULL)>;
 				};
 			};
-			usart2_pins_b: usart2@1 {
+			usart2_pins_b: usart2_b {
 				rx_tx {
 					rx = <STM32_PIN_PD5 (STM32_PINMUX_ALT_FUNC_7 | STM32_PUPDR_NO_PULL)>;
 					tx = <STM32_PIN_PD6 (STM32_PINMUX_ALT_FUNC_7 | STM32_PUSHPULL_NOPULL)>;
 				};
 			};
-			usart3_pins_a: usart3@0 {
+			usart3_pins_a: usart3_a {
 				rx_tx {
 					rx = <STM32_PIN_PB11 (STM32_PINMUX_ALT_FUNC_7 | STM32_PUPDR_NO_PULL)>;
 					tx = <STM32_PIN_PB10 (STM32_PINMUX_ALT_FUNC_7 | STM32_PUSHPULL_NOPULL)>;
 				};
 			};
-			usart3_pins_b: usart3@1 {
+			usart3_pins_b: usart3_b {
 				rx_tx {
 					rx = <STM32_PIN_PD9 (STM32_PINMUX_ALT_FUNC_7 | STM32_PUPDR_NO_PULL)>;
 					tx = <STM32_PIN_PD8 (STM32_PINMUX_ALT_FUNC_7 | STM32_PUSHPULL_NOPULL)>;

--- a/dts/arm/st/stm32f3-pinctrl.dtsi
+++ b/dts/arm/st/stm32f3-pinctrl.dtsi
@@ -9,61 +9,61 @@
 / {
 	soc {
 		pinctrl: pin-controller@48000000 {
-			usart1_pins_a: usart1@0 {
+			usart1_pins_a: usart1_a {
 				rx_tx {
 					rx = <STM32_PIN_PB6 (STM32_PINMUX_ALT_FUNC_7 | STM32_PUPDR_NO_PULL)>;
 					tx = <STM32_PIN_PB7 (STM32_PINMUX_ALT_FUNC_7 | STM32_PUSHPULL_NOPULL)>;
 				};
 			};
-			usart1_pins_b: usart1@1 {
+			usart1_pins_b: usart1_b {
 				rx_tx {
 					rx = <STM32_PIN_PA10 (STM32_PINMUX_ALT_FUNC_7 | STM32_PUPDR_NO_PULL)>;
 					tx = <STM32_PIN_PA9 (STM32_PINMUX_ALT_FUNC_7 | STM32_PUSHPULL_NOPULL)>;
 				};
 			};
-			usart1_pins_c: usart1@2 {
+			usart1_pins_c: usart1_c {
 				rx_tx {
 					rx = <STM32_PIN_PG10 (STM32_PINMUX_ALT_FUNC_7 | STM32_PUPDR_NO_PULL)>;
 					tx = <STM32_PIN_PB6 (STM32_PINMUX_ALT_FUNC_7 | STM32_PUSHPULL_NOPULL)>;
 				};
 			};
-			usart1_pins_d: usart1@3 {
+			usart1_pins_d: usart1_d {
 				rx_tx {
 					rx = <STM32_PIN_PC5 (STM32_PINMUX_ALT_FUNC_7 | STM32_PUPDR_NO_PULL)>;
 					tx = <STM32_PIN_PC4 (STM32_PINMUX_ALT_FUNC_7 | STM32_PUSHPULL_NOPULL)>;
 				};
 			};
-			usart2_pins_a: usart2@0 {
+			usart2_pins_a: usart2_a {
 				rx_tx {
 					rx = <STM32_PIN_PA3 (STM32_PINMUX_ALT_FUNC_7 | STM32_PUPDR_NO_PULL)>;
 					tx = <STM32_PIN_PA2 (STM32_PINMUX_ALT_FUNC_7 | STM32_PUSHPULL_NOPULL)>;
 				};
 			};
-			usart2_pins_b: usart2@1 {
+			usart2_pins_b: usart2_b {
 				rx_tx {
 					rx = <STM32_PIN_PA15 (STM32_PINMUX_ALT_FUNC_7 | STM32_PUPDR_NO_PULL)>;
 					tx = <STM32_PIN_PA2 (STM32_PINMUX_ALT_FUNC_7 | STM32_PUSHPULL_NOPULL)>;
 				};
 			};
-			usart2_pins_c: usart2@2 {
+			usart2_pins_c: usart2_c {
 				rx_tx {
 					rx = <STM32_PIN_PD6 (STM32_PINMUX_ALT_FUNC_7 | STM32_PUPDR_NO_PULL)>;
 					tx = <STM32_PIN_PA2 (STM32_PINMUX_ALT_FUNC_7 | STM32_PUSHPULL_NOPULL)>;
 				};
 			};
-			usart2_pins_d: usart2@3 {
+			usart2_pins_d: usart2_d {
 				rx_tx {
 					rx = <STM32_PIN_PD6 (STM32_PINMUX_ALT_FUNC_7 | STM32_PUPDR_NO_PULL)>;
 					tx = <STM32_PIN_PD5 (STM32_PINMUX_ALT_FUNC_7 | STM32_PUSHPULL_NOPULL)>;
 				};
 			};
-			usart3_pins_a: usart3@0 {
+			usart3_pins_a: usart3_a {
 				rx_tx {
 					rx = <STM32_PIN_PB11 (STM32_PINMUX_ALT_FUNC_7 | STM32_PUPDR_NO_PULL)>;
 					tx = <STM32_PIN_PB10 (STM32_PINMUX_ALT_FUNC_7 | STM32_PUSHPULL_NOPULL)>;
 				};
 			};
-			usart3_pins_b: usart3@1 {
+			usart3_pins_b: usart3_b {
 				rx_tx {
 					rx = <STM32_PIN_PD9 (STM32_PINMUX_ALT_FUNC_7 | STM32_PUPDR_NO_PULL)>;
 					tx = <STM32_PIN_PD8 (STM32_PINMUX_ALT_FUNC_7 | STM32_PUSHPULL_NOPULL)>;

--- a/dts/arm/st/stm32f4-pinctrl.dtsi
+++ b/dts/arm/st/stm32f4-pinctrl.dtsi
@@ -9,43 +9,43 @@
 / {
 	soc {
 		pinctrl: pin-controller@40020000 {
-			usart1_pins_a: usart1@0 {
+			usart1_pins_a: usart1_a {
 				rx_tx {
 					rx = <STM32_PIN_PB7 (STM32_PINMUX_ALT_FUNC_7 | STM32_PUPDR_NO_PULL)>;
 					tx = <STM32_PIN_PB6 (STM32_PINMUX_ALT_FUNC_7 | STM32_PUSHPULL_NOPULL)>;
 				};
 			};
-			usart1_pins_b: usart1@1 {
+			usart1_pins_b: usart1_b {
 				rx_tx {
 					rx = <STM32_PIN_PA10 (STM32_PINMUX_ALT_FUNC_7 | STM32_PUPDR_NO_PULL)>;
 					tx = <STM32_PIN_PA9 (STM32_PINMUX_ALT_FUNC_7 | STM32_PUSHPULL_NOPULL)>;
 				};
 			};
-			usart1_pins_c: usart1@2 {
+			usart1_pins_c: usart1_c {
 				rx_tx {
 					rx = <STM32_PIN_PG10 (STM32_PINMUX_ALT_FUNC_7 | STM32_PUPDR_NO_PULL)>;
 					tx = <STM32_PIN_PB6 (STM32_PINMUX_ALT_FUNC_7 | STM32_PUSHPULL_NOPULL)>;
 				};
 			};
-			usart2_pins_a: usart2@0 {
+			usart2_pins_a: usart2_a {
 				rx_tx {
 					rx = <STM32_PIN_PA3 (STM32_PINMUX_ALT_FUNC_7 | STM32_PUPDR_NO_PULL)>;
 					tx = <STM32_PIN_PA2 (STM32_PINMUX_ALT_FUNC_7 | STM32_PUSHPULL_NOPULL)>;
 				};
 			};
-			usart3_pins_a: usart3@0 {
+			usart3_pins_a: usart3_a {
 				rx_tx {
 					rx = <STM32_PIN_PB11 (STM32_PINMUX_ALT_FUNC_7 | STM32_PUPDR_NO_PULL)>;
 					tx = <STM32_PIN_PB10 (STM32_PINMUX_ALT_FUNC_7 | STM32_PUSHPULL_NOPULL)>;
 				};
 			};
-			usart3_pins_b: usart3@1 {
+			usart3_pins_b: usart3_b {
 				rx_tx {
 					rx = <STM32_PIN_PD9 (STM32_PINMUX_ALT_FUNC_7 | STM32_PUPDR_NO_PULL)>;
 					tx = <STM32_PIN_PD8 (STM32_PINMUX_ALT_FUNC_7 | STM32_PUSHPULL_NOPULL)>;
 				};
 			};
-			usart6_pins_a: usart6@0 {
+			usart6_pins_a: usart6_a {
 				rx_tx {
 					rx = <STM32_PIN_PC7 (STM32_PINMUX_ALT_FUNC_8 | STM32_PUPDR_NO_PULL)>;
 					tx = <STM32_PIN_PC6 (STM32_PINMUX_ALT_FUNC_8 | STM32_PUSHPULL_NOPULL)>;

--- a/dts/arm/st/stm32f405-pinctrl.dtsi
+++ b/dts/arm/st/stm32f405-pinctrl.dtsi
@@ -9,25 +9,25 @@
 / {
 	soc {
 		pinctrl: pin-controller@40020000 {
-			usart3_pins_a: usart3@0 {
+			usart3_pins_a: usart3_a {
 				rx_tx {
 					rx = <STM32_PIN_PB11 (STM32_PINMUX_ALT_FUNC_7 | STM32_PUSHPULL_PULLUP)>;
 					tx = <STM32_PIN_PB10 (STM32_PINMUX_ALT_FUNC_7 | STM32_PUSHPULL_PULLUP)>;
 				};
 			};
-			usart3_pins_b: usart3@1 {
+			usart3_pins_b: usart3_b {
 				rx_tx {
 					rx = <STM32_PIN_PD9 (STM32_PINMUX_ALT_FUNC_7 | STM32_PUSHPULL_PULLUP)>;
 					tx = <STM32_PIN_PD8 (STM32_PINMUX_ALT_FUNC_7 | STM32_PUSHPULL_PULLUP)>;
 				};
 			};
-			usart6_pins_a: usart6@0 {
+			usart6_pins_a: usart6_a {
 				rx_tx {
 					rx = <STM32_PIN_PG14 (STM32_PINMUX_ALT_FUNC_7 | STM32_PUSHPULL_PULLUP)>;
 					tx = <STM32_PIN_PG9 (STM32_PINMUX_ALT_FUNC_7 | STM32_PUSHPULL_PULLUP)>;
 				};
 			};
-			usart6_pins_b: usart6@1 {
+			usart6_pins_b: usart6_b {
 				rx_tx {
 					rx = <STM32_PIN_PC7 (STM32_PINMUX_ALT_FUNC_7 | STM32_PUSHPULL_PULLUP)>;
 					tx = <STM32_PIN_PC6 (STM32_PINMUX_ALT_FUNC_7 | STM32_PUSHPULL_PULLUP)>;

--- a/dts/arm/st/stm32f412-pinctrl.dtsi
+++ b/dts/arm/st/stm32f412-pinctrl.dtsi
@@ -9,26 +9,26 @@
 / {
 	soc {
 		pinctrl: pin-controller@40020000 {
-			usart3_pins_a: usart3@0 {
+			usart3_pins_a: usart3_a {
 				rx_tx {
 					rx = <STM32_PIN_PB11 (STM32_PINMUX_ALT_FUNC_7 | STM32_PUSHPULL_PULLUP)>;
 					tx = <STM32_PIN_PB10 (STM32_PINMUX_ALT_FUNC_7 | STM32_PUSHPULL_PULLUP)>;
 				};
 			};
-			usart3_pins_b: usart3@1 {
+			usart3_pins_b: usart3_b {
 				rx_tx {
 					rx = <STM32_PIN_PD9 (STM32_PINMUX_ALT_FUNC_7 | STM32_PUSHPULL_PULLUP)>;
 					tx = <STM32_PIN_PD8 (STM32_PINMUX_ALT_FUNC_7 | STM32_PUSHPULL_PULLUP)>;
 				};
 			};
 
-			usart2_pins_a: usart2@0 {
+			usart2_pins_a: usart2_a {
 				rx_tx {
 					rx = <STM32_PIN_PA3 (STM32_PINMUX_ALT_FUNC_7 | STM32_PUSHPULL_PULLUP)>;
 					tx = <STM32_PIN_PA2 (STM32_PINMUX_ALT_FUNC_7 | STM32_PUSHPULL_PULLUP)>;
 				};
 			};
-			usart2_pins_b: usart2@1 {
+			usart2_pins_b: usart2_b {
 				rx_tx {
 					rx = <STM32_PIN_PD6 (STM32_PINMUX_ALT_FUNC_7 | STM32_PUSHPULL_PULLUP)>;
 					tx = <STM32_PIN_PD5 (STM32_PINMUX_ALT_FUNC_7 | STM32_PUSHPULL_PULLUP)>;

--- a/dts/arm/st/stm32f413-pinctrl.dtsi
+++ b/dts/arm/st/stm32f413-pinctrl.dtsi
@@ -9,13 +9,13 @@
 / {
 	soc {
 		pinctrl: pin-controller@40020000 {
-			usart3_pins_a: usart3@0 {
+			usart3_pins_a: usart3_a {
 				rx_tx {
 					rx = <STM32_PIN_PB11 (STM32_PINMUX_ALT_FUNC_7 | STM32_PUSHPULL_PULLUP)>;
 					tx = <STM32_PIN_PB10 (STM32_PINMUX_ALT_FUNC_7 | STM32_PUSHPULL_PULLUP)>;
 				};
 			};
-			usart3_pins_b: usart3@1 {
+			usart3_pins_b: usart3_b {
 				rx_tx {
 					rx = <STM32_PIN_PD9 (STM32_PINMUX_ALT_FUNC_7 | STM32_PUSHPULL_PULLUP)>;
 					tx = <STM32_PIN_PD8 (STM32_PINMUX_ALT_FUNC_7 | STM32_PUSHPULL_PULLUP)>;

--- a/dts/arm/st/stm32f7-pinctrl.dtsi
+++ b/dts/arm/st/stm32f7-pinctrl.dtsi
@@ -9,91 +9,91 @@
 / {
 	soc {
 		pinctrl: pin-controller@40020000 {
-			usart1_pins_a: usart1@0 {
+			usart1_pins_a: usart1_a {
 				rx_tx {
 					rx = <STM32_PIN_PB7 (STM32_PINMUX_ALT_FUNC_7 | STM32_PUPDR_NO_PULL)>;
 					tx = <STM32_PIN_PB6 (STM32_PINMUX_ALT_FUNC_7 | STM32_PUSHPULL_NOPULL)>;
 				};
 			};
-			usart1_pins_b: usart1@1 {
+			usart1_pins_b: usart1_b {
 				rx_tx {
 					rx = <STM32_PIN_PA10 (STM32_PINMUX_ALT_FUNC_7 | STM32_PUPDR_NO_PULL)>;
 					tx = <STM32_PIN_PA9 (STM32_PINMUX_ALT_FUNC_7 | STM32_PUSHPULL_NOPULL)>;
 				};
 			};
-			usart2_pins_a: usart2@0 {
+			usart2_pins_a: usart2_a {
 				rx_tx {
 					rx = <STM32_PIN_PA3 (STM32_PINMUX_ALT_FUNC_7 | STM32_PUPDR_NO_PULL)>;
 					tx = <STM32_PIN_PA2 (STM32_PINMUX_ALT_FUNC_7 | STM32_PUSHPULL_NOPULL)>;
 				};
 			};
-			usart2_pins_b: usart2@1 {
+			usart2_pins_b: usart2_b {
 				rx_tx {
 					rx = <STM32_PIN_PD6 (STM32_PINMUX_ALT_FUNC_7 | STM32_PUPDR_NO_PULL)>;
 					tx = <STM32_PIN_PD5 (STM32_PINMUX_ALT_FUNC_7 | STM32_PUSHPULL_NOPULL)>;
 				};
 			};
-			usart3_pins_a: usart3@0 {
+			usart3_pins_a: usart3_a {
 				rx_tx {
 					rx = <STM32_PIN_PB11 (STM32_PINMUX_ALT_FUNC_7 | STM32_PUPDR_NO_PULL)>;
 					tx = <STM32_PIN_PB10 (STM32_PINMUX_ALT_FUNC_7 | STM32_PUSHPULL_NOPULL)>;
 				};
 			};
-			usart3_pins_b: usart3@1 {
+			usart3_pins_b: usart3_b {
 				rx_tx {
 					rx = <STM32_PIN_PD9 (STM32_PINMUX_ALT_FUNC_7 | STM32_PUPDR_NO_PULL)>;
 					tx = <STM32_PIN_PD8 (STM32_PINMUX_ALT_FUNC_7 | STM32_PUSHPULL_NOPULL)>;
 				};
 			};
-			usart3_pins_c: usart3@2 {
+			usart3_pins_c: usart3_c {
 				rx_tx {
 					rx = <STM32_PIN_PC11 (STM32_PINMUX_ALT_FUNC_7 | STM32_PUPDR_NO_PULL)>;
 					tx = <STM32_PIN_PC10 (STM32_PINMUX_ALT_FUNC_7 | STM32_PUSHPULL_NOPULL)>;
 				};
 			};
-			uart4_pins_a: uart4@0 {
+			uart4_pins_a: uart4_a {
 				rx_tx {
 					rx = <STM32_PIN_PA1 (STM32_PINMUX_ALT_FUNC_8 | STM32_PUPDR_NO_PULL)>;
 					tx = <STM32_PIN_PA0 (STM32_PINMUX_ALT_FUNC_8 | STM32_PUSHPULL_NOPULL)>;
 				};
 			};
-			uart4_pins_b: uart4@1 {
+			uart4_pins_b: uart4_b {
 				rx_tx {
 					rx = <STM32_PIN_PC11 (STM32_PINMUX_ALT_FUNC_8 | STM32_PUPDR_NO_PULL)>;
 					tx = <STM32_PIN_PC10 (STM32_PINMUX_ALT_FUNC_8 | STM32_PUSHPULL_NOPULL)>;
 				};
 			};
-			uart5_pins_a: uart5@0 {
+			uart5_pins_a: uart5_a {
 				rx_tx {
 					rx = <STM32_PIN_PD2 (STM32_PINMUX_ALT_FUNC_8 | STM32_PUPDR_NO_PULL)>;
 					tx = <STM32_PIN_PC12 (STM32_PINMUX_ALT_FUNC_8 | STM32_PUSHPULL_NOPULL)>;
 				};
 			};
-			usart6_pins_a: usart6@0 {
+			usart6_pins_a: usart6_a {
 				rx_tx {
 					rx = <STM32_PIN_PC7 (STM32_PINMUX_ALT_FUNC_8 | STM32_PUPDR_NO_PULL)>;
 					tx = <STM32_PIN_PC6 (STM32_PINMUX_ALT_FUNC_8 | STM32_PUSHPULL_NOPULL)>;
 				};
 			};
-			usart6_pins_b: usart6@1 {
+			usart6_pins_b: usart6_b {
 				rx_tx {
 					rx = <STM32_PIN_PG9 (STM32_PINMUX_ALT_FUNC_8 | STM32_PUPDR_NO_PULL)>;
 					tx = <STM32_PIN_PG14 (STM32_PINMUX_ALT_FUNC_8 | STM32_PUSHPULL_NOPULL)>;
 				};
 			};
-			uart7_pins_a: uart7@0 {
+			uart7_pins_a: uart7_a {
 				rx_tx {
 					rx = <STM32_PIN_PE7 (STM32_PINMUX_ALT_FUNC_8 | STM32_PUPDR_NO_PULL)>;
 					tx = <STM32_PIN_PE8 (STM32_PINMUX_ALT_FUNC_8 | STM32_PUSHPULL_NOPULL)>;
 				};
 			};
-			uart7_pins_b: uart7@1 {
+			uart7_pins_b: uart7_b {
 				rx_tx {
 					rx = <STM32_PIN_PF6 (STM32_PINMUX_ALT_FUNC_8 | STM32_PUPDR_NO_PULL)>;
 					tx = <STM32_PIN_PF7 (STM32_PINMUX_ALT_FUNC_8 | STM32_PUSHPULL_NOPULL)>;
 				};
 			};
-			uart8_pins_a: uart8@0 {
+			uart8_pins_a: uart8_a {
 				rx_tx {
 					rx = <STM32_PIN_PE0 (STM32_PINMUX_ALT_FUNC_8 | STM32_PUPDR_NO_PULL)>;
 					tx = <STM32_PIN_PE1 (STM32_PINMUX_ALT_FUNC_8 | STM32_PUSHPULL_NOPULL)>;

--- a/dts/arm/st/stm32l0-pinctrl.dtsi
+++ b/dts/arm/st/stm32l0-pinctrl.dtsi
@@ -9,19 +9,19 @@
 / {
 	soc {
 		pinctrl: pin-controller@50000000 {
-			usart1_pins_a: usart1@0 {
+			usart1_pins_a: usart1_a {
 				rx_tx {
 					rx = <STM32_PIN_PB7 (STM32_PINMUX_ALT_FUNC_0 | STM32_PUPDR_NO_PULL)>;
 					tx = <STM32_PIN_PB6 (STM32_PINMUX_ALT_FUNC_0 | STM32_PUSHPULL_NOPULL)>;
 				};
 			};
-			usart2_pins_a: usart2@0 {
+			usart2_pins_a: usart2_a {
 				rx_tx {
 					rx = <STM32_PIN_PA3 (STM32_PINMUX_ALT_FUNC_4 | STM32_PUPDR_NO_PULL)>;
 					tx = <STM32_PIN_PA2 (STM32_PINMUX_ALT_FUNC_4 | STM32_PUSHPULL_NOPULL)>;
 				};
 			};
-			lpuart1_pins_a: lpuart1@0 {
+			lpuart1_pins_a: lpuart1_a {
 				rx_tx {
 					rx = <STM32_PIN_PA3 (STM32_PINMUX_ALT_FUNC_6 | STM32_PUPDR_NO_PULL)>;
 					tx = <STM32_PIN_PA2 (STM32_PINMUX_ALT_FUNC_6 | STM32_PUSHPULL_NOPULL)>;

--- a/dts/arm/st/stm32l4-pinctrl.dtsi
+++ b/dts/arm/st/stm32l4-pinctrl.dtsi
@@ -9,55 +9,55 @@
 / {
 	soc {
 		pinctrl: pin-controller@48000000 {
-			usart1_pins_a: usart1@0 {
+			usart1_pins_a: usart1_a {
 				rx_tx {
 					rx = <STM32_PIN_PB7 (STM32_PINMUX_ALT_FUNC_7 | STM32_PUPDR_NO_PULL)>;
 					tx = <STM32_PIN_PB6 (STM32_PINMUX_ALT_FUNC_7 | STM32_PUSHPULL_NOPULL)>;
 				};
 			};
-			usart1_pins_b: usart1@1 {
+			usart1_pins_b: usart1_b {
 				rx_tx {
 					rx = <STM32_PIN_PA10 (STM32_PINMUX_ALT_FUNC_7 | STM32_PUPDR_NO_PULL)>;
 					tx = <STM32_PIN_PA9 (STM32_PINMUX_ALT_FUNC_7 | STM32_PUSHPULL_NOPULL)>;
 				};
 			};
-			usart1_pins_c: usart1@2 {
+			usart1_pins_c: usart1_c {
 				rx_tx {
 					rx = <STM32_PIN_PG10 (STM32_PINMUX_ALT_FUNC_7 | STM32_PUPDR_NO_PULL)>;
 					tx = <STM32_PIN_PB6 (STM32_PINMUX_ALT_FUNC_7 | STM32_PUSHPULL_NOPULL)>;
 				};
 			};
-			usart2_pins_a: usart2@0 {
+			usart2_pins_a: usart2_a {
 				rx_tx {
 					rx = <STM32_PIN_PA3 (STM32_PINMUX_ALT_FUNC_7 | STM32_PUPDR_NO_PULL)>;
 					tx = <STM32_PIN_PA2 (STM32_PINMUX_ALT_FUNC_7 | STM32_PUSHPULL_NOPULL)>;
 				};
 			};
-			usart2_pins_b: usart2@1 {
+			usart2_pins_b: usart2_b {
 				rx_tx {
 					rx = <STM32_PIN_PA15 (STM32_PINMUX_ALT_FUNC_7 | STM32_PUPDR_NO_PULL)>;
 					tx = <STM32_PIN_PA2 (STM32_PINMUX_ALT_FUNC_7 | STM32_PUSHPULL_NOPULL)>;
 				};
 			};
-			usart2_pins_c: usart2@2 {
+			usart2_pins_c: usart2_c {
 				rx_tx {
 					rx = <STM32_PIN_PD6 (STM32_PINMUX_ALT_FUNC_7 | STM32_PUPDR_NO_PULL)>;
 					tx = <STM32_PIN_PA2 (STM32_PINMUX_ALT_FUNC_7 | STM32_PUSHPULL_NOPULL)>;
 				};
 			};
-			usart2_pins_d: usart2@3 {
+			usart2_pins_d: usart2_d {
 				rx_tx {
 					rx = <STM32_PIN_PD6 (STM32_PINMUX_ALT_FUNC_7 | STM32_PUPDR_NO_PULL)>;
 					tx = <STM32_PIN_PD5 (STM32_PINMUX_ALT_FUNC_7 | STM32_PUSHPULL_NOPULL)>;
 				};
 			};
-			usart3_pins_a: usart3@0 {
+			usart3_pins_a: usart3_a {
 				rx_tx {
 					rx = <STM32_PIN_PB11 (STM32_PINMUX_ALT_FUNC_7 | STM32_PUPDR_NO_PULL)>;
 					tx = <STM32_PIN_PB10 (STM32_PINMUX_ALT_FUNC_7 | STM32_PUSHPULL_NOPULL)>;
 				};
 			};
-			can_pins_a: can@0 {
+			can_pins_a: can_a {
 				rx_tx {
 					rx = <STM32_PIN_PA11 (STM32_PINMUX_ALT_FUNC_9 | STM32_PUPDR_PULL_UP)>;
 					tx = <STM32_PIN_PA12 (STM32_PINMUX_ALT_FUNC_9 | STM32_PUSHPULL_NOPULL)>;


### PR DESCRIPTION
This change aims at fixing 'unit_address_vs_reg' warning in
stm32 *-pinctrl.dtsi files.
This warning pops up when a node name is made up with an address
(node_name@xx) but does not contain a reg property.
This case was encountered for led nodes for instance,
where a reg property has no meaning.
Fix this by changing node_name@xx to a node_name_xx string which removes the
guilty '@xx' syntax but preserves node_name uniqueness.

Signed-off-by: Erwan Gouriou <erwan.gouriou@linaro.org>