### PR TITLE
boards: dts: Fix dtc led warning in stm32 board dts files

### DIFF
--- a/boards/arm/96b_carbon/96b_carbon.dts
+++ b/boards/arm/96b_carbon/96b_carbon.dts
@@ -19,15 +19,15 @@
 
 	leds {
 		compatible = "gpio-leds";
-		green_led_1: led@0 {
+		green_led_1: led_1 {
 			gpios = <&gpiod 2 GPIO_INT_ACTIVE_HIGH>;
 			label = "USR1 LED";
 		};
-		green_led_2: led@1 {
+		green_led_2: led_2 {
 			gpios = <&gpioa 15 GPIO_INT_ACTIVE_HIGH>;
 			label = "USR2 LED";
 		};
-		bt_blue_led: led@2 {
+		bt_blue_led: led_3 {
 			gpios = <&gpioa 15 GPIO_INT_ACTIVE_HIGH>;
 			label = "BT LED";
 		};

--- a/boards/arm/96b_neonkey/96b_neonkey.dts
+++ b/boards/arm/96b_neonkey/96b_neonkey.dts
@@ -19,19 +19,19 @@
 
 	leds {
 		compatible = "gpio-leds";
-		green_led_0: led@0 {
+		green_led_0: led_0 {
 			gpios = <&gpiob 12 GPIO_INT_ACTIVE_HIGH>;
 			label = "USR0 LED";
 		};
-		green_led_1: led@1 {
+		green_led_1: led_1 {
 			gpios = <&gpiob 13 GPIO_INT_ACTIVE_HIGH>;
 			label = "USR1 LED";
 		};
-		green_led_2: led@2 {
+		green_led_2: led_2 {
 			gpios = <&gpiob 14 GPIO_INT_ACTIVE_HIGH>;
 			label = "USR2 LED";
 		};
-		green_led_3: led@3 {
+		green_led_3: led_3 {
 			gpios = <&gpiob 15 GPIO_INT_ACTIVE_HIGH>;
 			label = "USR3 LED";
 		};

--- a/boards/arm/disco_l475_iot1/disco_l475_iot1.dts
+++ b/boards/arm/disco_l475_iot1/disco_l475_iot1.dts
@@ -19,11 +19,11 @@
 
 	leds {
 		compatible = "gpio-leds";
-		green_led_1: led@0 {
+		green_led_1: led_1 {
 			gpios = <&gpioa 5 GPIO_INT_ACTIVE_HIGH>;
 			label = "User LD1";
 		};
-		green_led_2: led@1 {
+		green_led_2: led_2 {
 			gpios = <&gpiob 14 GPIO_INT_ACTIVE_HIGH>;
 			label = "User LD2";
 		};

--- a/boards/arm/nucleo_f030r8/nucleo_f030r8.dts
+++ b/boards/arm/nucleo_f030r8/nucleo_f030r8.dts
@@ -19,7 +19,7 @@
 
 	leds {
 		compatible = "gpio-leds";
-		green_led_2: led@0 {
+		green_led_2: led_2 {
 			gpios = <&gpioa 5 GPIO_INT_ACTIVE_HIGH>;
 			label = "User LD2";
 		};

--- a/boards/arm/nucleo_f070rb/nucleo_f070rb.dts
+++ b/boards/arm/nucleo_f070rb/nucleo_f070rb.dts
@@ -19,7 +19,7 @@
 
 	leds {
 		compatible = "gpio-leds";
-		green_led_2: led@0 {
+		green_led_2: led_2 {
 			gpios = <&gpioa 5 GPIO_INT_ACTIVE_HIGH>;
 			label = "User LD2";
 		};

--- a/boards/arm/nucleo_f091rc/nucleo_f091rc.dts
+++ b/boards/arm/nucleo_f091rc/nucleo_f091rc.dts
@@ -19,7 +19,7 @@
 
 	leds {
 		compatible = "gpio-leds";
-		green_led_2: led@0 {
+		green_led_2: led_2 {
 			gpios = <&gpioa 5 GPIO_INT_ACTIVE_HIGH>;
 			label = "User LD2";
 		};

--- a/boards/arm/nucleo_f103rb/nucleo_f103rb.dts
+++ b/boards/arm/nucleo_f103rb/nucleo_f103rb.dts
@@ -19,7 +19,7 @@
 
 	leds {
 		compatible = "gpio-leds";
-		green_led_2: led@0 {
+		green_led_2: led_2 {
 			gpios = <&gpioa 5 GPIO_INT_ACTIVE_HIGH>;
 			label = "User LD2";
 		};

--- a/boards/arm/nucleo_f207zg/nucleo_f207zg.dts
+++ b/boards/arm/nucleo_f207zg/nucleo_f207zg.dts
@@ -19,15 +19,15 @@
 
 	leds {
 		compatible = "gpio-leds";
-		green_led_1: led@0 {
+		green_led_1: led_1 {
 			gpios = <&gpiob 0 GPIO_INT_ACTIVE_HIGH>;
 			label = "User LD1";
 		};
-		blue_led_1: led@1 {
+		blue_led_1: led_2 {
 			gpios = <&gpiob 7 GPIO_INT_ACTIVE_HIGH>;
 			label = "User LD2";
 		};
-		red_led_1: led@2 {
+		red_led_1: led_3 {
 			gpios = <&gpiob 14 GPIO_INT_ACTIVE_HIGH>;
 			label = "User LD3";
 		};
@@ -59,4 +59,3 @@
 &usbotg_fs {
 	status = "ok";
 };
-

--- a/boards/arm/nucleo_f334r8/nucleo_f334r8.dts
+++ b/boards/arm/nucleo_f334r8/nucleo_f334r8.dts
@@ -19,7 +19,7 @@
 
 	leds {
 		compatible = "gpio-leds";
-		green_led_2: led@0 {
+		green_led_2: led_2 {
 			gpios = <&gpioa 5 GPIO_INT_ACTIVE_HIGH>;
 			label = "User LD2";
 		};

--- a/boards/arm/nucleo_f401re/nucleo_f401re.dts
+++ b/boards/arm/nucleo_f401re/nucleo_f401re.dts
@@ -19,7 +19,7 @@
 
 	leds {
 		compatible = "gpio-leds";
-		green_led_2: led@0 {
+		green_led_2: led_2 {
 			gpios = <&gpioa 5 GPIO_INT_ACTIVE_HIGH>;
 			label = "User LD2";
 		};

--- a/boards/arm/nucleo_f411re/nucleo_f411re.dts
+++ b/boards/arm/nucleo_f411re/nucleo_f411re.dts
@@ -19,7 +19,7 @@
 
 	leds {
 		compatible = "gpio-leds";
-		green_led_2: led@0 {
+		green_led_2: led_2 {
 			gpios = <&gpioa 5 GPIO_INT_ACTIVE_HIGH>;
 			label = "User LD2";
 		};

--- a/boards/arm/nucleo_f412zg/nucleo_f412zg.dts
+++ b/boards/arm/nucleo_f412zg/nucleo_f412zg.dts
@@ -19,15 +19,15 @@
 
 	leds {
 		compatible = "gpio-leds";
-		green_led_1: led@0 {
+		green_led_1: led_1 {
 			gpios = <&gpiob 0 GPIO_INT_ACTIVE_HIGH>;
 			label = "User LD1";
 		};
-		blue_led_1: led@1 {
+		blue_led_1: led_2 {
 			gpios = <&gpiob 7 GPIO_INT_ACTIVE_HIGH>;
 			label = "User LD2";
 		};
-		red_led_1: led@2 {
+		red_led_1: led_3 {
 			gpios = <&gpiob 14 GPIO_INT_ACTIVE_HIGH>;
 			label = "User LD3";
 		};

--- a/boards/arm/nucleo_f413zh/nucleo_f413zh.dts
+++ b/boards/arm/nucleo_f413zh/nucleo_f413zh.dts
@@ -19,15 +19,15 @@
 
 	leds {
 		compatible = "gpio-leds";
-		green_led_1: led@0 {
+		green_led_1: led_1 {
 			gpios = <&gpiob 0 GPIO_INT_ACTIVE_HIGH>;
 			label = "User LD1";
 		};
-		blue_led_1: led@1 {
+		blue_led_1: led_2 {
 			gpios = <&gpiob 7 GPIO_INT_ACTIVE_HIGH>;
 			label = "User LD2";
 		};
-		red_led_1: led@2 {
+		red_led_1: led_3 {
 			gpios = <&gpiob 14 GPIO_INT_ACTIVE_HIGH>;
 			label = "User LD3";
 		};

--- a/boards/arm/nucleo_f429zi/nucleo_f429zi.dts
+++ b/boards/arm/nucleo_f429zi/nucleo_f429zi.dts
@@ -20,15 +20,15 @@
 
 	leds {
 		compatible = "gpio-leds";
-		green_led_1: led@0 {
+		green_led_1: led_1 {
 			gpios = <&gpiob 0 GPIO_INT_ACTIVE_HIGH>;
 			label = "User LD1";
 		};
-		blue_led_1: led@1 {
+		blue_led_1: led_2 {
 			gpios = <&gpiob 7 GPIO_INT_ACTIVE_HIGH>;
 			label = "User LD2";
 		};
-		red_led_1: led@2 {
+		red_led_1: led_3 {
 			gpios = <&gpiob 14 GPIO_INT_ACTIVE_HIGH>;
 			label = "User LD3";
 		};

--- a/boards/arm/nucleo_f446re/nucleo_f446re.dts
+++ b/boards/arm/nucleo_f446re/nucleo_f446re.dts
@@ -19,7 +19,7 @@
 
 	leds {
 		compatible = "gpio-leds";
-		green_led_2: led@0 {
+		green_led_2: led_2 {
 			gpios = <&gpioa 5 GPIO_INT_ACTIVE_HIGH>;
 			label = "User LD2";
 		};

--- a/boards/arm/nucleo_l053r8/nucleo_l053r8.dts
+++ b/boards/arm/nucleo_l053r8/nucleo_l053r8.dts
@@ -19,7 +19,7 @@
 
 	leds {
 		compatible = "gpio-leds";
-		green_led_2: led@0 {
+		green_led_2: led_2 {
 			gpios = <&gpioa 5 GPIO_INT_ACTIVE_HIGH>;
 			label = "User LD2";
 		};

--- a/boards/arm/nucleo_l073rz/nucleo_l073rz.dts
+++ b/boards/arm/nucleo_l073rz/nucleo_l073rz.dts
@@ -19,7 +19,7 @@
 
 	leds {
 		compatible = "gpio-leds";
-		green_led_2: led@0 {
+		green_led_2: led_2 {
 			gpios = <&gpioa 5 GPIO_INT_ACTIVE_HIGH>;
 			label = "User LD2";
 		};

--- a/boards/arm/nucleo_l476rg/nucleo_l476rg.dts
+++ b/boards/arm/nucleo_l476rg/nucleo_l476rg.dts
@@ -19,7 +19,7 @@
 
 	leds {
 		compatible = "gpio-leds";
-		green_led_2: led@0 {
+		green_led_2: led_2 {
 			gpios = <&gpioa 5 GPIO_INT_ACTIVE_HIGH>;
 			label = "User LD2";
 		};

--- a/boards/arm/olimex_stm32_e407/olimex_stm32_e407.dts
+++ b/boards/arm/olimex_stm32_e407/olimex_stm32_e407.dts
@@ -20,7 +20,7 @@
 
 	leds {
 		compatible = "gpio-leds";
-		green_led_1: led@0 {
+		green_led_1: led_1 {
 			gpios = <&gpioc 13 GPIO_INT_ACTIVE_HIGH>;
 			label = "LED1";
 		};

--- a/boards/arm/olimex_stm32_h407/olimex_stm32_h407.dts
+++ b/boards/arm/olimex_stm32_h407/olimex_stm32_h407.dts
@@ -20,7 +20,7 @@
 
 	leds {
 		compatible = "gpio-leds";
-		green_led_2: led@0 {
+		green_led_2: led_2 {
 			gpios = <&gpioa 0 GPIO_INT_ACTIVE_HIGH>;
 			label = "User LD2";
 		};

--- a/boards/arm/olimex_stm32_p405/olimex_stm32_p405.dts
+++ b/boards/arm/olimex_stm32_p405/olimex_stm32_p405.dts
@@ -20,7 +20,7 @@
 
 	leds {
 		compatible = "gpio-leds";
-		green_led_1: led@0 {
+		green_led_1: led_1 {
 			gpios = <&gpioc 12 GPIO_INT_ACTIVE_HIGH>;
 			label = "LED1";
 		};

--- a/boards/arm/olimexino_stm32/olimexino_stm32.dts
+++ b/boards/arm/olimexino_stm32/olimexino_stm32.dts
@@ -19,11 +19,11 @@
 
 	leds {
 		compatible = "gpio-leds";
-		green_led_1: led@0 {
+		green_led_1: led_1 {
 			gpios = <&gpioa 5 GPIO_INT_ACTIVE_HIGH>;
 			label = "LED1";
 		};
-		yellow_led_2: led@1 {
+		yellow_led_2: led_2 {
 			gpios = <&gpioa 1 GPIO_INT_ACTIVE_HIGH>;
 			label = "LED2";
 		};

--- a/boards/arm/stm3210c_eval/stm3210c_eval.dts
+++ b/boards/arm/stm3210c_eval/stm3210c_eval.dts
@@ -19,7 +19,7 @@
 
 	leds {
 		compatible = "gpio-leds";
-		green_led_2: led@0 {
+		green_led_2: led_2 {
 			gpios = <&gpiod 13 GPIO_INT_ACTIVE_HIGH>;
 			label = "User LD2";
 		};

--- a/boards/arm/stm32373c_eval/stm32373c_eval.dts
+++ b/boards/arm/stm32373c_eval/stm32373c_eval.dts
@@ -19,7 +19,7 @@
 
 	leds {
 		compatible = "gpio-leds";
-		green_led_2: led@0 {
+		green_led_2: led_2 {
 			gpios = <&gpioc 1 GPIO_INT_ACTIVE_HIGH>;
 			label = "User LD2";
 		};

--- a/boards/arm/stm32_min_dev/stm32_min_dev.dts
+++ b/boards/arm/stm32_min_dev/stm32_min_dev.dts
@@ -19,7 +19,7 @@
 
 	leds {
 		compatible = "gpio-leds";
-		led: led@0 {
+		led: led {
 			gpios = <&gpiob 12 GPIO_INT_ACTIVE_HIGH>;
 			label = "LD";
 		};

--- a/boards/arm/stm32f072_eval/stm32f072_eval.dts
+++ b/boards/arm/stm32f072_eval/stm32f072_eval.dts
@@ -20,19 +20,19 @@
 
 	leds {
 		compatible = "gpio-leds";
-		green_led_1: led@0 {
+		green_led_1: led_1 {
 			gpios = <&gpiod 8 GPIO_INT_ACTIVE_HIGH>;
 			label = "User LD1";
 		};
-		orange_led_2: led@1 {
+		orange_led_2: led_2 {
 			gpios = <&gpiod 9 GPIO_INT_ACTIVE_HIGH>;
 			label = "User LD2";
 		};
-		red_led_3: led@2 {
+		red_led_3: led_3 {
 			gpios = <&gpiod 10 GPIO_INT_ACTIVE_HIGH>;
 			label = "User LD3";
 		};
-		blue_led_4: led@3 {
+		blue_led_4: led_4 {
 			gpios = <&gpiod 11 GPIO_INT_ACTIVE_HIGH>;
 			label = "User LD4";
 		};

--- a/boards/arm/stm32f072b_disco/stm32f072b_disco.dts
+++ b/boards/arm/stm32f072b_disco/stm32f072b_disco.dts
@@ -19,19 +19,19 @@
 
 	leds {
 		compatible = "gpio-leds";
-		red_up_led_3: led@0 {
+		red_up_led_3: led_3 {
 			gpios = <&gpioc 6 GPIO_INT_ACTIVE_HIGH>;
 			label = "User LD3";
 		};
-		yellow_left_4: led@1 {
+		yellow_left_4: led_4 {
 			gpios = <&gpioc 8 GPIO_INT_ACTIVE_HIGH>;
 			label = "User LD4";
 		};
-		green_right_led_5: led@2 {
+		green_right_led_5: led_5 {
 			gpios = <&gpioc 9 GPIO_INT_ACTIVE_HIGH>;
 			label = "User LD5";
 		};
-		blue_low_led_6: led@3 {
+		blue_low_led_6: led_6 {
 			gpios = <&gpioc 7 GPIO_INT_ACTIVE_HIGH>;
 			label = "User LD6";
 		};

--- a/boards/arm/stm32f0_disco/stm32f0_disco.dts
+++ b/boards/arm/stm32f0_disco/stm32f0_disco.dts
@@ -19,11 +19,11 @@
 
 	leds {
 		compatible = "gpio-leds";
-		green_led_3: led@0 {
+		green_led_3: led_3 {
 			gpios = <&gpioc 9 GPIO_INT_ACTIVE_HIGH>;
 			label = "User LD3";
 		};
-		blue_led_4: led@1 {
+		blue_led_4: led_4 {
 			gpios = <&gpioc 8 GPIO_INT_ACTIVE_HIGH>;
 			label = "User LD4";
 		};

--- a/boards/arm/stm32f3_disco/stm32f3_disco.dts
+++ b/boards/arm/stm32f3_disco/stm32f3_disco.dts
@@ -19,35 +19,35 @@
 
 	leds {
 		compatible = "gpio-leds";
-		red_led_3: led@0 {
+		red_led_3: led_3 {
 			gpios = <&gpioe 9 GPIO_INT_ACTIVE_HIGH>;
 			label = "User LD3";
 		};
-		blue_led_4: led@1 {
+		blue_led_4: led_4 {
 			gpios = <&gpioe 8 GPIO_INT_ACTIVE_HIGH>;
 			label = "User LD4";
 		};
-		orange_led_5: led@2 {
+		orange_led_5: led_5 {
 			gpios = <&gpioe 10 GPIO_INT_ACTIVE_HIGH>;
 			label = "User LD5";
 		};
-		green_led_6: led@3 {
+		green_led_6: led_6 {
 			gpios = <&gpioe 15 GPIO_INT_ACTIVE_HIGH>;
 			label = "User LD6";
 		};
-		green_led_7: led@4 {
+		green_led_7: led_7 {
 			gpios = <&gpiod 11 GPIO_INT_ACTIVE_HIGH>;
 			label = "User LD7";
 		};
-		orange_led_8: led@5 {
+		orange_led_8: led_8 {
 			gpios = <&gpioe 14 GPIO_INT_ACTIVE_HIGH>;
 			label = "User LD8";
 		};
-		blue_led_9: led@6 {
+		blue_led_9: led_9 {
 			gpios = <&gpioe 12 GPIO_INT_ACTIVE_HIGH>;
 			label = "User LD9";
 		};
-		red_led_10: led@7 {
+		red_led_10: led_10 {
 			gpios = <&gpioe 13 GPIO_INT_ACTIVE_HIGH>;
 			label = "User LD10";
 		};

--- a/boards/arm/stm32f411e_disco/stm32f411e_disco.dts
+++ b/boards/arm/stm32f411e_disco/stm32f411e_disco.dts
@@ -19,19 +19,19 @@
 
 	leds {
 		compatible = "gpio-leds";
-		orange_led_3: led@0 {
+		orange_led_3: led_3 {
 			gpios = <&gpiod 13 GPIO_INT_ACTIVE_HIGH>;
 			label = "User LD3";
 		};
-		green_led_4: led@1 {
+		green_led_4: led_4 {
 			gpios = <&gpiod 12 GPIO_INT_ACTIVE_HIGH>;
 			label = "User LD4";
 		};
-		red_led_5: led@2 {
+		red_led_5: led_5 {
 			gpios = <&gpiod 14 GPIO_INT_ACTIVE_HIGH>;
 			label = "User LD5";
 		};
-		blue_led_6: led@3 {
+		blue_led_6: led_6 {
 			gpios = <&gpiod 15 GPIO_INT_ACTIVE_HIGH>;
 			label = "User LD6";
 		};

--- a/boards/arm/stm32f412g_disco/stm32f412g_disco.dts
+++ b/boards/arm/stm32f412g_disco/stm32f412g_disco.dts
@@ -19,19 +19,19 @@
 
 	leds {
 		compatible = "gpio-leds";
-		green_led_1: led@0 {
+		green_led_1: led_1 {
 			gpios = <&gpioe 0 GPIO_INT_ACTIVE_HIGH>;
 			label = "User LD1";
 		};
-		orange_led_2: led@1 {
+		orange_led_2: led_2 {
 			gpios = <&gpioe 1 GPIO_INT_ACTIVE_HIGH>;
 			label = "User LD2";
 		};
-		red_led_3: led@2 {
+		red_led_3: led_3 {
 			gpios = <&gpioe 2 GPIO_INT_ACTIVE_HIGH>;
 			label = "User LD3";
 		};
-		blue_led_4: led@3 {
+		blue_led_4: led_4 {
 			gpios = <&gpioe 4 GPIO_INT_ACTIVE_HIGH>;
 			label = "User LD4";
 		};

--- a/boards/arm/stm32f429i_disc1/stm32f429i_disc1.dts
+++ b/boards/arm/stm32f429i_disc1/stm32f429i_disc1.dts
@@ -19,11 +19,11 @@
 
 	leds {
 		compatible = "gpio-leds";
-		orange_led_3: led@0 {
+		orange_led_3: led_3 {
 			gpios = <&gpiog 13 GPIO_INT_ACTIVE_HIGH>;
 			label = "User LD3";
 		};
-		green_led_4: led@1 {
+		green_led_4: led_4 {
 			gpios = <&gpiog 14 GPIO_INT_ACTIVE_HIGH>;
 			label = "User LD4";
 		};

--- a/boards/arm/stm32f469i_disco/stm32f469i_disco.dts
+++ b/boards/arm/stm32f469i_disco/stm32f469i_disco.dts
@@ -19,19 +19,19 @@
 
 	leds {
 		compatible = "gpio-leds";
-		green_led_1: led@0 {
+		green_led_1: led_1 {
 			gpios = <&gpiog 6 GPIO_INT_ACTIVE_HIGH>;
 			label = "User LD1";
 		};
-		orange_led_2: led@1 {
+		orange_led_2: led_2 {
 			gpios = <&gpiod 4 GPIO_INT_ACTIVE_HIGH>;
 			label = "User LD2";
 		};
-		red_led_3: led@2 {
+		red_led_3: led_3 {
 			gpios = <&gpiod 5 GPIO_INT_ACTIVE_HIGH>;
 			label = "User LD3";
 		};
-		blue_led_4: led@3 {
+		blue_led_4: led_4 {
 			gpios = <&gpiok 3 GPIO_INT_ACTIVE_HIGH>;
 			label = "User LD4";
 		};

--- a/boards/arm/stm32f4_disco/stm32f4_disco.dts
+++ b/boards/arm/stm32f4_disco/stm32f4_disco.dts
@@ -19,19 +19,19 @@
 
 	leds {
 		compatible = "gpio-leds";
-		orange_led_3: led@0 {
+		orange_led_3: led_3 {
 			gpios = <&gpiod 13 GPIO_INT_ACTIVE_HIGH>;
 			label = "User LD3";
 		};
-		green_led_4: led@1 {
+		green_led_4: led_4 {
 			gpios = <&gpiod 12 GPIO_INT_ACTIVE_HIGH>;
 			label = "User LD4";
 		};
-		red_led_5: led@2 {
+		red_led_5: led_5 {
 			gpios = <&gpiod 14 GPIO_INT_ACTIVE_HIGH>;
 			label = "User LD5";
 		};
-		blue_led_6: led@3 {
+		blue_led_6: led_6 {
 			gpios = <&gpiod 15 GPIO_INT_ACTIVE_HIGH>;
 			label = "User LD6";
 		};

--- a/boards/arm/stm32f723e_disco/stm32f723e_disco.dts
+++ b/boards/arm/stm32f723e_disco/stm32f723e_disco.dts
@@ -19,15 +19,15 @@
 
 	leds {
 		compatible = "gpio-leds";
-		blue_led: led@0 {
+		blue_led: led_1 {
 			gpios = <&gpioa 5 GPIO_INT_ACTIVE_HIGH>;
 			label = "User LD1";
 		};
-		red_led: led@1 {
+		red_led: led_2 {
 			gpios = <&gpioa 7 GPIO_INT_ACTIVE_HIGH>;
 			label = "User LD5";
 		};
-		green_led: led@2 {
+		green_led: led_3 {
 			gpios = <&gpiob 1 GPIO_INT_ACTIVE_HIGH>;
 			label = "User LD6";
 		};

--- a/boards/arm/stm32f746g_disco/stm32f746g_disco.dts
+++ b/boards/arm/stm32f746g_disco/stm32f746g_disco.dts
@@ -19,7 +19,7 @@
 
 	leds {
 		compatible = "gpio-leds";
-		green_led_1: led@0 {
+		green_led_1: led_1 {
 			gpios = <&gpioi 1 GPIO_INT_ACTIVE_HIGH>;
 			label = "User LD1";
 		};

--- a/boards/arm/stm32f769i_disco/stm32f769i_disco.dts
+++ b/boards/arm/stm32f769i_disco/stm32f769i_disco.dts
@@ -19,19 +19,19 @@
 
 	leds {
 		compatible = "gpio-leds";
-		red_led_1:led@0 {
+		red_led_1:led_1 {
 			gpios = <&gpioj 13 GPIO_INT_ACTIVE_HIGH>;
 			label = "User LD1";
 		};
-		green_led_2:led@1 {
+		green_led_2:led_2 {
 			gpios = <&gpioj 5 GPIO_INT_ACTIVE_HIGH>;
 			label = "User LD2";
 		};
-		green_led_3:led@2 {
+		green_led_3:led_3 {
 			gpios = <&gpioa 12 GPIO_INT_ACTIVE_HIGH>;
 			label = "User LD3";
 		};
-		red_led_4:led@3 {
+		red_led_4:led_4 {
 			gpios = <&gpiod 4 GPIO_INT_ACTIVE_HIGH>;
 			label = "User LD4";
 		};

--- a/boards/arm/stm32l476g_disco/stm32l476g_disco.dts
+++ b/boards/arm/stm32l476g_disco/stm32l476g_disco.dts
@@ -23,11 +23,11 @@
 
 	leds {
 		compatible = "gpio-leds";
-		green_led_4: led@0 {
+		green_led_4: led_4 {
 			gpios = <&gpiob 2 GPIO_INT_ACTIVE_HIGH>;
 			label = "User LD4";
 		};
-		green_led_5: led@1 {
+		green_led_5: led_5 {
 			gpios = <&gpioe 8 GPIO_INT_ACTIVE_HIGH>;
 			label = "User LD5";
 		};

--- a/boards/arm/stm32l496g_disco/stm32l496g_disco.dts
+++ b/boards/arm/stm32l496g_disco/stm32l496g_disco.dts
@@ -19,7 +19,7 @@
 
 	leds {
 		compatible = "gpio-leds";
-		green_led_2: led@0 {
+		green_led_2: led_2 {
 			gpios = <&gpiob 13 GPIO_INT_ACTIVE_HIGH>;
 			label = "User LD2";
 		};


### PR DESCRIPTION
This change aims at fixing 'unit_address_vs_reg' warning in
STM32 based boards.
This warning pops up when a node name is made up with an address
(node_name@xx) but does not contain a reg property.
This case was encountered for led nodes for instance,
where a reg property has no meaning.
Fix this by changing node_name@xx to node_name_xx which removes the
 guilty '@xx' syntax but preserves node_name uniqueness.

Signed-off-by: Erwan Gouriou <erwan.gouriou@linaro.org>