### PR TITLE
drivers: i2c: Parse 10-bit addressing flag in mcux driver

### DIFF
--- a/drivers/i2c/i2c_mcux.c
+++ b/drivers/i2c/i2c_mcux.c
@@ -102,6 +102,9 @@ static int i2c_mcux_transfer(struct device *dev, struct i2c_msg *msgs,
 
 	/* Iterate over all the messages */
 	for (int i = 0; i < num_msgs; i++) {
+		if (I2C_MSG_ADDR_10_BITS & msgs->flags) {
+			return -ENOTSUP;
+		}
 
 		/* Initialize the transfer descriptor */
 		transfer.flags = i2c_mcux_convert_flags(msgs->flags);


### PR DESCRIPTION
Parses the new message-level flag for 10-bit addressing in the mcux i2c
driver.

Signed-off-by: Maureen Helm <maureen.helm@nxp.com>