### PR TITLE
boards: arm: nrf52810_pca10040: Fix dts avoid_unnecessary_addr_size warn

### DIFF
--- a/boards/arm/nrf52810_pca10040/nrf52810_pca10040.dts
+++ b/boards/arm/nrf52810_pca10040/nrf52810_pca10040.dts
@@ -45,8 +45,6 @@
 
 	gpio_keys {
 		compatible = "gpio-keys";
-		#address-cells = <1>;
-		#size-cells = <0>;
 		button0: button@0 {
 			label = "Push button switch 0";
 			gpios = <&gpio0 13 GPIO_PUD_PULL_UP>;


### PR DESCRIPTION
We get the following warning when building nrf52810_pca10040:

	Warning (avoid_unnecessary_addr_size): unnecessary
	#address-cells/#size-cells without "ranges" or child
	"reg" property in /gpio_keys

Remove #address-cells/#size-cells since they aren't needed for gpio_keys

Signed-off-by: Kumar Gala <kumar.gala@linaro.org>