### PR TITLE
dts: Cleanup warnings associated with cpu node

### DIFF
--- a/boards/arm/mps2_an385/mps2_an385.dts
+++ b/boards/arm/mps2_an385/mps2_an385.dts
@@ -15,6 +15,9 @@
 	};
 
 	cpus {
+		#address-cells = <1>;
+		#size-cells = <0>;
+
 		cpu@0 {
 			compatible = "arm,cortex-m3";
 			reg = <0>;

--- a/boards/arm/v2m_beetle/v2m_beetle.dts
+++ b/boards/arm/v2m_beetle/v2m_beetle.dts
@@ -15,6 +15,9 @@
 	};
 
 	cpus {
+		#address-cells = <1>;
+		#size-cells = <0>;
+
 		cpu@0 {
 			compatible = "arm,cortex-m3";
 			reg = <0>;

--- a/dts/arm/silabs/efm32wg.dtsi
+++ b/dts/arm/silabs/efm32wg.dtsi
@@ -2,6 +2,9 @@
 
 / {
 	cpus {
+		#address-cells = <1>;
+		#size-cells = <0>;
+
 		cpu@0 {
 			compatible = "arm,cortex-m4f";
 			reg = <0>;

--- a/dts/arm/silabs/efr32fg1p.dtsi
+++ b/dts/arm/silabs/efr32fg1p.dtsi
@@ -2,6 +2,9 @@
 
 / {
 	cpus {
+		#address-cells = <1>;
+		#size-cells = <0>;
+
 		cpu@0 {
 			compatible = "arm,cortex-m4f";
 			reg = <0>;

--- a/dts/arm/ti/msp432p4xx.dtsi
+++ b/dts/arm/ti/msp432p4xx.dtsi
@@ -2,6 +2,9 @@
 
 / {
 	cpus {
+		#address-cells = <1>;
+		#size-cells = <0>;
+
 		cpu@0 {
 			compatible = "arm,cortex-m4f";
 			reg = <0>;


### PR DESCRIPTION
When we fixed the missing reg property in the cpu node, we forgot to
add #address-cells & #size-cells for the node.

This fix the following warnings we get:
	Warning (reg_format): "reg" property in /cpus/cpu@0 has invalid
	length (4 bytes) (#address-cells == 2, #size-cells == 1)

Signed-off-by: Kumar Gala <kumar.gala@linaro.org>