### PR TITLE
dts/arm/st: Add missing properties to stm32f2 fash controller node

### DIFF
--- a/dts/arm/st/stm32f2.dtsi
+++ b/dts/arm/st/stm32f2.dtsi
@@ -30,6 +30,11 @@
 
 	soc {
 		flash-controller@40023c00 {
+			compatible = "st,stm32f2-flash-controller";
+			label = "FLASH_CTRL";
+			reg = <0x40023c00 0x400>;
+			interrupts = <4 0>;
+
 			#address-cells = <1>;
 			#size-cells = <1>;
 

--- a/dts/bindings/flash_controller/st,stm32f2-flash-controller.yaml
+++ b/dts/bindings/flash_controller/st,stm32f2-flash-controller.yaml
@@ -1,0 +1,16 @@
+---
+title: STM32 F2 Flash Controller
+id: st,stm32f2-flash-controller
+version: 0.1
+
+description: >
+    This binding gives a base representation of the STM32 F2 Flash Controller
+
+inherits:
+    !include flash-controller.yaml
+
+properties:
+    compatible:
+      constraint: "st,stm32f2-flash-controller"
+
+...


### PR DESCRIPTION
Flash controller-node for stm32f2 based SoCs was missing basic
properties such as compatible, labeln reg and interrupts.
Fix this and add matching yaml binding file;

Fixes #10057

Signed-off-by: Erwan Gouriou <erwan.gouriou@linaro.org>