### PR TITLE
scripts: extract: globals.py: Fix node name parsing

### DIFF
--- a/scripts/dts/extract/globals.py
+++ b/scripts/dts/extract/globals.py
@@ -165,8 +165,8 @@ def get_node_label(node_compat, node_address):
         def_label += '_' + \
                 convert_string_to_label(node_address.split('@')[-1])
     else:
-        def_label += convert_string_to_label(node_address)
-
+        def_label += '_' + \
+                convert_string_to_label(node_address.split('/')[-1])
     return def_label
 
 def find_parent_prop(node_address, prop):


### PR DESCRIPTION
The node name parsing for the _LABEL #define does not parse the unique
node portion in the same fashion between @<unit_address> and _< number >.
This change normalizes the two modes.

Signed-off-by: David Leach <david.leach@nxp.com>