### PR TITLE
boards: arm: nrf: Fix dts avoid_unnecessary_addr_size warn

### DIFF
--- a/boards/arm/nrf51_pca10028/nrf51_pca10028.dts
+++ b/boards/arm/nrf51_pca10028/nrf51_pca10028.dts
@@ -43,8 +43,6 @@
 
 	buttons {
 		compatible = "gpio-keys";
-		#address-cells = <1>;
-		#size-cells = <0>;
 		button0: button@0 {
 			gpios = <&gpio0 17 GPIO_PUD_PULL_UP>;
 			label = "Push button switch 0";

--- a/boards/arm/nrf52840_pca10056/nrf52840_pca10056.dts
+++ b/boards/arm/nrf52840_pca10056/nrf52840_pca10056.dts
@@ -43,8 +43,6 @@
 
 	buttons {
 		compatible = "gpio-keys";
-		#address-cells = <1>;
-		#size-cells = <0>;
 		button0: button@0 {
 			gpios = <&gpio0 11 GPIO_PUD_PULL_UP>;
 			label = "Push button switch 0";

--- a/boards/arm/nrf52840_pca10059/nrf52840_pca10059.dts
+++ b/boards/arm/nrf52840_pca10059/nrf52840_pca10059.dts
@@ -44,8 +44,6 @@
 
 	buttons {
 		compatible = "gpio-keys";
-		#address-cells = <1>;
-		#size-cells = <0>;
 		button0: button@0 {
 			gpios = <&gpio1 6 GPIO_PUD_PULL_UP>;
 			label = "Push button switch 0";

--- a/boards/arm/nrf52_pca10040/nrf52_pca10040.dts
+++ b/boards/arm/nrf52_pca10040/nrf52_pca10040.dts
@@ -44,8 +44,6 @@
 
 	buttons {
 		compatible = "gpio-keys";
-		#address-cells = <1>;
-		#size-cells = <0>;
 		button0: button@0 {
 			gpios = <&gpio0 13 GPIO_PUD_PULL_UP>;
 			label = "Push button switch 0";


### PR DESCRIPTION
We get the following warning when building nrf52810_pca10040:

	Warning (avoid_unnecessary_addr_size): unnecessary
	#address-cells/#size-cells without "ranges" or child
	"reg" property in /buttons

Remove #address-cells/#size-cells since they aren't needed for gpio_keys

Signed-off-by: Kumar Gala <kumar.gala@linaro.org>