### PR TITLE
Bluetooth: Fix security level checking with LE SC and no-bonding

### DIFF
--- a/subsys/bluetooth/host/hci_core.c
+++ b/subsys/bluetooth/host/hci_core.c
@@ -2672,7 +2672,7 @@ static void update_sec_level(struct bt_conn *conn)
 	}
 
 	if (conn->le.keys && (conn->le.keys->flags & BT_KEYS_AUTHENTICATED)) {
-		if (conn->le.keys->keys & BT_KEYS_LTK_P256) {
+		if (conn->le.keys->flags & BT_KEYS_SC) {
 			conn->sec_level = BT_SECURITY_FIPS;
 		} else {
 			conn->sec_level = BT_SECURITY_HIGH;

--- a/subsys/bluetooth/host/keys.h
+++ b/subsys/bluetooth/host/keys.h
@@ -24,6 +24,7 @@ enum {
 	BT_KEYS_DEBUG           = BIT(1),
 	BT_KEYS_ID_PENDING_ADD  = BIT(2),
 	BT_KEYS_ID_PENDING_DEL  = BIT(3),
+	BT_KEYS_SC              = BIT(4),
 };
 
 struct bt_ltk {

--- a/subsys/bluetooth/host/smp.c
+++ b/subsys/bluetooth/host/smp.c
@@ -4454,15 +4454,20 @@ void bt_smp_update_keys(struct bt_conn *conn)
 	 * exclusive with legacy pairing. Other keys are added on keys
 	 * distribution.
 	 */
-	if (atomic_test_bit(smp->flags, SMP_FLAG_SC) &&
-	    atomic_test_bit(smp->flags, SMP_FLAG_BOND)) {
-		bt_keys_add_type(conn->le.keys, BT_KEYS_LTK_P256);
-		memcpy(conn->le.keys->ltk.val, smp->tk,
-		       sizeof(conn->le.keys->ltk.val));
-		(void)memset(conn->le.keys->ltk.rand, 0,
-			     sizeof(conn->le.keys->ltk.rand));
-		(void)memset(conn->le.keys->ltk.ediv, 0,
-			     sizeof(conn->le.keys->ltk.ediv));
+	if (atomic_test_bit(smp->flags, SMP_FLAG_SC)) {
+		conn->le.keys->flags |= BT_KEYS_SC;
+
+		if (atomic_test_bit(smp->flags, SMP_FLAG_BOND)) {
+			bt_keys_add_type(conn->le.keys, BT_KEYS_LTK_P256);
+			memcpy(conn->le.keys->ltk.val, smp->tk,
+			       sizeof(conn->le.keys->ltk.val));
+			(void)memset(conn->le.keys->ltk.rand, 0,
+				     sizeof(conn->le.keys->ltk.rand));
+			(void)memset(conn->le.keys->ltk.ediv, 0,
+				     sizeof(conn->le.keys->ltk.ediv));
+		}
+	} else {
+		conn->le.keys->flags &= ~BT_KEYS_SC;
 	}
 }
 


### PR DESCRIPTION
This was affecting SM/MAS/SCPK/BV-01-C qualification test case.

Signed-off-by: Szymon Janc <szymon.janc@codecoup.pl>