### PR TITLE
Log panic in fault handlers

### DIFF
--- a/arch/arc/core/fatal.c
+++ b/arch/arc/core/fatal.c
@@ -17,6 +17,7 @@
 #include <toolchain.h>
 #include <arch/cpu.h>
 #include <misc/printk.h>
+#include <logging/log_ctrl.h>
 
 /**
  *
@@ -35,6 +36,8 @@
  */
 void _NanoFatalErrorHandler(unsigned int reason, const NANO_ESF *pEsf)
 {
+	LOG_PANIC();
+
 	switch (reason) {
 	case _NANO_ERR_HW_EXCEPTION:
 		break;
@@ -83,6 +86,7 @@ void _NanoFatalErrorHandler(unsigned int reason, const NANO_ESF *pEsf)
 
 FUNC_NORETURN void _arch_syscall_oops(void *ssf_ptr)
 {
+	LOG_PANIC();
 	_SysFatalErrorHandler(_NANO_ERR_KERNEL_OOPS, ssf_ptr);
 	CODE_UNREACHABLE;
 }

--- a/arch/arc/core/fault.c
+++ b/arch/arc/core/fault.c
@@ -19,6 +19,7 @@
 #include <kernel_structs.h>
 #include <misc/printk.h>
 #include <exc_handle.h>
+#include <logging/log_ctrl.h>
 
 #ifdef CONFIG_USERSPACE
 Z_EXC_DECLARE(z_arch_user_string_nlen);
@@ -41,6 +42,8 @@ void _Fault(NANO_ESF *esf)
 	u32_t vector, code, parameter;
 	u32_t exc_addr = _arc_v2_aux_reg_read(_ARC_V2_EFA);
 	u32_t ecr = _arc_v2_aux_reg_read(_ARC_V2_ECR);
+
+	LOG_PANIC();
 
 #ifdef CONFIG_USERSPACE
 	for (int i = 0; i < ARRAY_SIZE(exceptions); i++) {

--- a/arch/arm/core/fatal.c
+++ b/arch/arm/core/fatal.c
@@ -18,7 +18,7 @@
 #include <kernel.h>
 #include <kernel_structs.h>
 #include <misc/printk.h>
-
+#include <logging/log_ctrl.h>
 
 /**
  *
@@ -47,6 +47,8 @@
 void _NanoFatalErrorHandler(unsigned int reason,
 					  const NANO_ESF *pEsf)
 {
+	LOG_PANIC();
+
 	switch (reason) {
 	case _NANO_ERR_HW_EXCEPTION:
 		printk("***** Hardware exception *****\n");
@@ -97,6 +99,8 @@ FUNC_NORETURN void _arch_syscall_oops(void *ssf_ptr)
 {
 	u32_t *ssf_contents = ssf_ptr;
 	NANO_ESF oops_esf = { 0 };
+
+	LOG_PANIC();
 
 	oops_esf.pc = ssf_contents[3];
 

--- a/arch/arm/core/fault.c
+++ b/arch/arm/core/fault.c
@@ -18,6 +18,7 @@
 #include <kernel_structs.h>
 #include <inttypes.h>
 #include <exc_handle.h>
+#include <logging/log_ctrl.h>
 
 #ifdef CONFIG_PRINTK
 #include <misc/printk.h>
@@ -669,6 +670,8 @@ void _Fault(NANO_ESF *esf, u32_t exc_return)
 {
 	u32_t reason;
 	int fault = SCB->ICSR & SCB_ICSR_VECTACTIVE_Msk;
+
+	LOG_PANIC();
 
 #if defined(CONFIG_ARM_SECURE_FIRMWARE)
 	if ((exc_return & EXC_RETURN_INDICATOR_PREFIX) !=

--- a/arch/nios2/core/fatal.c
+++ b/arch/nios2/core/fatal.c
@@ -9,6 +9,7 @@
 #include <kernel_structs.h>
 #include <misc/printk.h>
 #include <inttypes.h>
+#include <logging/log_ctrl.h>
 
 const NANO_ESF _default_esf = {
 	0xdeadbaad,
@@ -50,6 +51,8 @@ const NANO_ESF _default_esf = {
 FUNC_NORETURN void _NanoFatalErrorHandler(unsigned int reason,
 					  const NANO_ESF *esf)
 {
+	LOG_PANIC();
+
 #ifdef CONFIG_PRINTK
 	switch (reason) {
 	case _NANO_ERR_CPU_EXCEPTION:

--- a/arch/posix/core/fatal.c
+++ b/arch/posix/core/fatal.c
@@ -10,6 +10,7 @@
 #include <kernel_structs.h>
 #include <misc/printk.h>
 #include <inttypes.h>
+#include <logging/log_ctrl.h>
 #include "posix_soc_if.h"
 
 const NANO_ESF _default_esf = {
@@ -34,6 +35,8 @@ const NANO_ESF _default_esf = {
 FUNC_NORETURN void _NanoFatalErrorHandler(unsigned int reason,
 		const NANO_ESF *esf)
 {
+	LOG_PANIC();
+
 #ifdef CONFIG_PRINTK
 	switch (reason) {
 	case _NANO_ERR_CPU_EXCEPTION:

--- a/arch/riscv32/core/fatal.c
+++ b/arch/riscv32/core/fatal.c
@@ -8,6 +8,7 @@
 #include <kernel_structs.h>
 #include <inttypes.h>
 #include <misc/printk.h>
+#include <logging/log_ctrl.h>
 
 const NANO_ESF _default_esf = {
 	0xdeadbaad,
@@ -60,6 +61,8 @@ const NANO_ESF _default_esf = {
 FUNC_NORETURN void _NanoFatalErrorHandler(unsigned int reason,
 					  const NANO_ESF *esf)
 {
+	LOG_PANIC();
+
 	switch (reason) {
 	case _NANO_ERR_CPU_EXCEPTION:
 	case _NANO_ERR_SPURIOUS_INT:
@@ -134,6 +137,8 @@ FUNC_NORETURN __weak void _SysFatalErrorHandler(unsigned int reason,
 						const NANO_ESF *esf)
 {
 	ARG_UNUSED(esf);
+
+	LOG_PANIC();
 
 #if !defined(CONFIG_SIMPLE_FATAL_ERROR_HANDLER)
 #ifdef CONFIG_STACK_SENTINEL

--- a/arch/x86/core/fatal.c
+++ b/arch/x86/core/fatal.c
@@ -22,6 +22,7 @@
 #include <exception.h>
 #include <inttypes.h>
 #include <exc_handle.h>
+#include <logging/log_ctrl.h>
 
 __weak void _debug_fatal_hook(const NANO_ESF *esf) { ARG_UNUSED(esf); }
 
@@ -83,6 +84,8 @@ static void unwind_stack(u32_t base_ptr)
 FUNC_NORETURN void _NanoFatalErrorHandler(unsigned int reason,
 					  const NANO_ESF *pEsf)
 {
+	LOG_PANIC();
+
 	_debug_fatal_hook(pEsf);
 
 #ifdef CONFIG_PRINTK

--- a/arch/x86/core/sys_fatal_error_handler.c
+++ b/arch/x86/core/sys_fatal_error_handler.c
@@ -17,6 +17,7 @@
 #include <linker/sections.h>
 #include <kernel_structs.h>
 #include <misc/printk.h>
+#include <logging/log_ctrl.h>
 
 /**
  *
@@ -42,6 +43,8 @@ FUNC_NORETURN __weak void _SysFatalErrorHandler(unsigned int reason,
 					 const NANO_ESF *pEsf)
 {
 	ARG_UNUSED(pEsf);
+
+	LOG_PANIC();
 
 #if !defined(CONFIG_SIMPLE_FATAL_ERROR_HANDLER)
 #ifdef CONFIG_STACK_SENTINEL

--- a/arch/xtensa/core/fatal.c
+++ b/arch/xtensa/core/fatal.c
@@ -10,6 +10,7 @@
 #include <kernel_arch_data.h>
 #include <misc/printk.h>
 #include <xtensa/specreg.h>
+#include <logging/log_ctrl.h>
 
 #ifdef XT_SIMULATOR
 #include <xtensa/simcall.h>
@@ -51,6 +52,8 @@ const NANO_ESF _default_esf = {
 XTENSA_ERR_NORET void _NanoFatalErrorHandler(unsigned int reason,
 					     const NANO_ESF *pEsf)
 {
+	LOG_PANIC();
+
 	switch (reason) {
 	case _NANO_ERR_HW_EXCEPTION:
 	case _NANO_ERR_RESERVED_IRQ:

--- a/include/logging/log_ctrl.h
+++ b/include/logging/log_ctrl.h
@@ -64,9 +64,11 @@ void log_thread_set(k_tid_t process_tid);
 int log_set_timestamp_func(timestamp_get_t timestamp_getter, u32_t freq);
 
 /**
- * @brief Switch logger subsystem to panic mode.
+ * @brief Switch the logger subsystem to the panic mode.
  *
- * @details On panic logger subsystem informs all backends about panic mode.
+ * Returns immediately if the logger is already in the panic mode.
+ *
+ * @details On panic the logger subsystem informs all backends about panic mode.
  *          Backends must switch to blocking mode or halt. All pending logs
  *          are flushed after switching to panic mode. In panic mode, all log
  *          messages must be processed in the context of the call.

--- a/subsys/logging/log_core.c
+++ b/subsys/logging/log_core.c
@@ -299,6 +299,10 @@ void log_panic(void)
 {
 	struct log_backend const *backend;
 
+	if (panic_mode) {
+		return;
+	}
+
 	for (int i = 0; i < log_backend_count_get(); i++) {
 		backend = log_backend_get(i);
 


### PR DESCRIPTION
As suggested by @aescolar stripped down version of #10049 with LOG_PANIC() added to fault handlers. Keeping printk messages there (see discussion: https://github.com/zephyrproject-rtos/zephyr/pull/10049#discussion_r218707834)