### PR TITLE
subsys: logging: native_posix: Fixed output buffer size

### DIFF
--- a/subsys/logging/log_backend_native_posix.c
+++ b/subsys/logging/log_backend_native_posix.c
@@ -54,7 +54,7 @@ int char_out(u8_t *data, size_t length, void *ctx)
 	return length;
 }
 
-LOG_OUTPUT_DEFINE(log_output, char_out, buf, 1);
+LOG_OUTPUT_DEFINE(log_output, char_out, buf, sizeof(buf));
 
 static void put(const struct log_backend *const backend,
 		struct log_msg *msg)


### PR DESCRIPTION
`LOG_OUTPUT_DEFINE()` accepts buffer size as a last parameter.

Signed-off-by: Olivier Martin <olivier.martin@proglove.de>