### PR TITLE
subsys: logging: backend: Declare the local functions as 'static'

### DIFF
--- a/subsys/logging/log_backend_native_posix.c
+++ b/subsys/logging/log_backend_native_posix.c
@@ -45,7 +45,7 @@ static void preprint_char(int c)
 
 static u8_t buf[_STDOUT_BUF_SIZE];
 
-int char_out(u8_t *data, size_t length, void *ctx)
+static int char_out(u8_t *data, size_t length, void *ctx)
 {
 	for (size_t i = 0; i < length; i++) {
 		preprint_char(data[i]);

--- a/subsys/logging/log_backend_uart.c
+++ b/subsys/logging/log_backend_uart.c
@@ -12,7 +12,7 @@
 #include <uart.h>
 #include <assert.h>
 
-int char_out(u8_t *data, size_t length, void *ctx)
+static int char_out(u8_t *data, size_t length, void *ctx)
 {
 	struct device *dev = (struct device *)ctx;
 
@@ -48,7 +48,7 @@ static void put(const struct log_backend *const backend,
 
 }
 
-void log_backend_uart_init(void)
+static void log_backend_uart_init(void)
 {
 	struct device *dev;
 


### PR DESCRIPTION
After the recent change in `struct log_backend_api` (ie: add of `init` function), init function can be marked as `static` as it is only used in the scope of the file.

Signed-off-by: Olivier Martin <olivier.martin@proglove.de>