### PR TITLE
dts: nordic: remove unnecessary inclusions

### DIFF
--- a/dts/arm/nordic/nrf51822_qfaa.dtsi
+++ b/dts/arm/nordic/nrf51822_qfaa.dtsi
@@ -4,7 +4,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <mem.h>
 #include <nordic/nrf51822.dtsi>
 
 / {

--- a/dts/arm/nordic/nrf51822_qfab.dtsi
+++ b/dts/arm/nordic/nrf51822_qfab.dtsi
@@ -4,7 +4,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <mem.h>
 #include <nordic/nrf51822.dtsi>
 
 / {

--- a/dts/arm/nordic/nrf51822_qfac.dtsi
+++ b/dts/arm/nordic/nrf51822_qfac.dtsi
@@ -4,7 +4,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <mem.h>
 #include <nordic/nrf51822.dtsi>
 
 / {

--- a/dts/arm/nordic/nrf52810_qfaa.dtsi
+++ b/dts/arm/nordic/nrf52810_qfaa.dtsi
@@ -4,7 +4,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <mem.h>
 #include <nordic/nrf52810.dtsi>
 
 / {

--- a/dts/arm/nordic/nrf52832_ciaa.dtsi
+++ b/dts/arm/nordic/nrf52832_ciaa.dtsi
@@ -4,7 +4,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <mem.h>
 #include <nordic/nrf52832.dtsi>
 
 / {

--- a/dts/arm/nordic/nrf52832_qfaa.dtsi
+++ b/dts/arm/nordic/nrf52832_qfaa.dtsi
@@ -4,7 +4,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <mem.h>
 #include <nordic/nrf52832.dtsi>
 
 / {

--- a/dts/arm/nordic/nrf52832_qfab.dtsi
+++ b/dts/arm/nordic/nrf52832_qfab.dtsi
@@ -4,7 +4,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <mem.h>
 #include <nordic/nrf52832.dtsi>
 
 / {

--- a/dts/arm/nordic/nrf52840_qiaa.dtsi
+++ b/dts/arm/nordic/nrf52840_qiaa.dtsi
@@ -4,7 +4,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <mem.h>
 #include <nordic/nrf52840.dtsi>
 
 / {


### PR DESCRIPTION
This commit removes the un-necessary inclusions of mem.h
from dts/arm/nordic/nrf5x_xxxx .dtsi headers. mem.h does
not exist any more.

Signed-off-by: Ioannis Glaropoulos <Ioannis.Glaropoulos@nordicsemi.no>