### PR TITLE
Make dts required for sensor drivers

### DIFF
--- a/drivers/sensor/adt7420/Kconfig
+++ b/drivers/sensor/adt7420/Kconfig
@@ -7,40 +7,12 @@
 
 menuconfig ADT7420
 	bool "ADT7420 Temperature Sensor"
-	depends on I2C
+	depends on I2C && HAS_DTS_I2C
 	help
 	  Enable the driver for Analog Devices ADT7420 High-Accuracy
 	  16-bit Digital I2C Temperature Sensors.
 
 if ADT7420
-
-if !HAS_DTS_I2C
-
-config ADT7420_NAME
-	string "Driver name"
-	default "ADT7420"
-	help
-	  Device name with which the ADT7420 sensor is identified.
-
-config ADT7420_I2C_ADDR
-	hex "I2C address for ADT7420"
-	default 0x48
-	help
-	  I2C address of the ADT7420 sensor.
-
-	  0x48: A0 connected GND and A1 connected to GND.
-	  0x49: A0 connected VDD and A1 connected to GND.
-	  0x4A: A0 connected GND and A1 connected to VDD.
-	  0x4B: A0 connected VDD and A1 connected to VDD.
-
-config ADT7420_I2C_MASTER_DEV_NAME
-	string "I2C master where ADT7420 is connected"
-	default "I2C_0"
-	help
-	  Specify the device name of the I2C master device to which the
-	  ADT7420 chip is connected.
-
-endif # !HAS_DTS_I2C
 
 config ADT7420_TEMP_HYST
 	int "Temperature hysteresis in °C"

--- a/drivers/sensor/adt7420/Kconfig
+++ b/drivers/sensor/adt7420/Kconfig
@@ -7,7 +7,7 @@
 
 menuconfig ADT7420
 	bool "ADT7420 Temperature Sensor"
-	depends on I2C && HAS_DTS_I2C
+	depends on I2C && HAS_DTS_I2C && HAS_DTS_GPIO
 	help
 	  Enable the driver for Analog Devices ADT7420 High-Accuracy
 	  16-bit Digital I2C Temperature Sensors.
@@ -54,26 +54,6 @@ endchoice
 
 config ADT7420_TRIGGER
 	bool
-
-if !HAS_DTS_GPIO
-
-config ADT7420_GPIO_DEV_NAME
-	string "GPIO device"
-	default "GPIO_0"
-	depends on ADT7420_TRIGGER
-	help
-	  The GPIO device's name where the ADT7420 interrupt (alert) pin is
-	  connected.
-
-config ADT7420_GPIO_PIN_NUM
-	int "Interrupt GPIO pin number"
-	default 0
-	depends on ADT7420_TRIGGER
-	help
-	  The GPIO pin number receiving the interrupt signal from the
-	  ADT7420 sensor.
-
-endif # !HAS_DTS_GPIO
 
 config ADT7420_THREAD_PRIORITY
 	int "Thread priority"

--- a/drivers/sensor/adxl372/Kconfig
+++ b/drivers/sensor/adxl372/Kconfig
@@ -7,7 +7,7 @@
 
 menuconfig ADXL372
 	bool "ADXL372 Three Axis High-g I2C/SPI accelerometer"
-	depends on (I2C && HAS_DTS_I2C) || SPI
+	depends on (I2C && HAS_DTS_I2C) || (SPI && HAS_DTS_SPI)
 	help
 	  Enable driver for ADXL372 Three-Axis Digital Accelerometers.
 
@@ -27,62 +27,6 @@ config ADXL372_SPI
 	bool "SPI Interface"
 
 endchoice
-
-if !HAS_DTS_SPI
-
-config ADXL372_DEV_NAME
-	string "ADXL372 device name"
-	depends on ADXL372_SPI
-	default "ADXL372"
-
-config ADXL372_SPI_DEV_NAME
-	string "SPI device where ADXL372 is connected"
-	depends on ADXL372_SPI
-	default "SPI_0"
-	help
-	  Specify the device name of the SPI device to which ADXL372 is
-	  connected.
-
-config ADXL372_SPI_DEV_SLAVE
-	int "SPI Slave Select where ADXL372 is connected"
-	depends on ADXL372_SPI
-	default 2
-	help
-	  Specify the slave select pin of the SPI to which ADXL372 is
-	  connected.
-
-config ADXL372_SPI_GPIO_CS
-	bool "ADXL372 SPI CS through a GPIO pin"
-	depends on ADXL372_SPI
-	help
-	  This option is useful if one needs to manage SPI CS through a GPIO
-	  pin to by-pass the SPI controller's CS logic.
-
-config ADXL372_SPI_BUS_FREQ
-	int "ADXL372 SPI bus speed in Hz"
-	range 10000 10000000
-	default 8000000
-	help
-	  This is the maximum supported SPI bus frequency. The chip supports a
-	  frequency up to 10MHz.
-
-config ADXL372_SPI_GPIO_CS_DRV_NAME
-	string "GPIO driver's name to use to drive SPI CS through"
-	default "GPIO_0"
-	depends on ADXL372_SPI_GPIO_CS
-	help
-	  This option is mandatory to set which GPIO controller to use in order
-	  to actually emulate the SPI CS.
-
-config ADXL372_SPI_GPIO_CS_PIN
-	int "GPIO PIN to use to drive SPI CS through"
-	default 0
-	depends on ADXL372_SPI_GPIO_CS
-	help
-	  This option is mandatory to set which GPIO pin to use in order
-	  to actually emulate the SPI CS.
-
-endif # !HAS_DTS_SPI
 
 choice
 	prompt "Operating mode"

--- a/drivers/sensor/adxl372/Kconfig
+++ b/drivers/sensor/adxl372/Kconfig
@@ -206,26 +206,6 @@ endchoice
 config ADXL372_TRIGGER
 	bool
 
-if !HAS_DTS_GPIO
-
-config ADXL372_GPIO_DEV_NAME
-	string "GPIO device"
-	default "GPIO_0"
-	depends on ADXL372_TRIGGER
-	help
-	  The GPIO device's name where the ADXL372 interrupt 1 or 2 pin is
-	  connected.
-
-config ADXL372_GPIO_PIN_NUM
-	int "Interrupt GPIO pin number"
-	default 0
-	depends on ADXL372_TRIGGER
-	help
-	  The GPIO pin number receiving the interrupt signal from the
-	  ADXL372 sensor.
-
-endif # !HAS_DTS_GPIO
-
 config ADXL372_THREAD_PRIORITY
 	int "Thread priority"
 	depends on ADXL372_TRIGGER_OWN_THREAD && ADXL372_TRIGGER

--- a/drivers/sensor/adxl372/Kconfig
+++ b/drivers/sensor/adxl372/Kconfig
@@ -7,7 +7,7 @@
 
 menuconfig ADXL372
 	bool "ADXL372 Three Axis High-g I2C/SPI accelerometer"
-	depends on I2C || SPI
+	depends on (I2C && HAS_DTS_I2C) || SPI
 	help
 	  Enable driver for ADXL372 Three-Axis Digital Accelerometers.
 
@@ -27,33 +27,6 @@ config ADXL372_SPI
 	bool "SPI Interface"
 
 endchoice
-
-if !HAS_DTS_I2C
-
-config ADXL372_DEV_NAME
-	string "ADXL372 device name"
-	depends on ADXL372_I2C
-	default "ADXL372"
-
-config ADXL372_I2C_ADDR
-	hex "I2C address for ADXL372"
-	depends on ADXL372_I2C
-	default 0x1D
-	help
-	  I2C address of the ADXL372 sensor.
-
-	  0x1D: if MISO is pulled low
-	  0x53: if MISO is pulled high
-
-config ADXL372_I2C_MASTER_DEV_NAME
-	string "I2C master where ADXL372 is connected"
-	depends on ADXL372_I2C
-	default "I2C_0"
-	help
-	  Specify the device name of the I2C master device to which the
-	  ADXL372 chip is connected.
-
-endif # !HAS_DTS_I2C
 
 if !HAS_DTS_SPI
 

--- a/drivers/sensor/apds9960/Kconfig
+++ b/drivers/sensor/apds9960/Kconfig
@@ -7,28 +7,11 @@
 
 menuconfig APDS9960
 	bool "APDS9960 Sensor"
-	depends on I2C
+	depends on I2C && HAS_DTS_I2C
 	help
 	  Enable driver for APDS9960 sensors.
 
 if APDS9960
-
-if !HAS_DTS_I2C
-
-config  APDS9960_I2C_DEV_NAME
-	string "I2C Master"
-	default "I2C_0"
-	help
-	  The device name of the I2C master device to which the APDS9960
-	  chip is connected.
-
-config APDS9960_DRV_NAME
-	string "Driver name"
-	default "APDS9960"
-	help
-	  Device name with which the APDS9960 is identified.
-
-endif # !HAS_DTS_I2C
 
 if !HAS_DTS_GPIO
 

--- a/drivers/sensor/apds9960/Kconfig
+++ b/drivers/sensor/apds9960/Kconfig
@@ -7,28 +7,11 @@
 
 menuconfig APDS9960
 	bool "APDS9960 Sensor"
-	depends on I2C && HAS_DTS_I2C
+	depends on I2C && HAS_DTS_I2C && HAS_DTS_GPIO
 	help
 	  Enable driver for APDS9960 sensors.
 
 if APDS9960
-
-if !HAS_DTS_GPIO
-
-config APDS9960_GPIO_DEV_NAME
-	string "GPIO device"
-	default "GPIO_0"
-	help
-	  The GPIO device's name where the APDS9960 interrupt pin is connected.
-
-config APDS9960_GPIO_PIN_NUM
-	int "Interrupt GPIO pin number"
-	default 0
-	help
-	  The GPIO pin number receiving the interrupt signal from the
-	  APDS9960 sensor.
-
-endif # !HAS_DTS_GPIO
 
 choice
 	prompt "Trigger mode"

--- a/drivers/sensor/ccs811/Kconfig
+++ b/drivers/sensor/ccs811/Kconfig
@@ -8,37 +8,11 @@
 
 menuconfig CCS811
 	bool "CCS811 Digital Gas Sensor"
-	depends on I2C
+	depends on I2C && HAS_DTS_I2C
 	help
 	  Enable driver for CCS811 Gas sensors.
 
 if CCS811
-
-if !HAS_DTS_I2C
-
-config CCS811_NAME
-	string "Driver name"
-	default "CCS811"
-	help
-	  Device name with which the CCS811 sensor is identified.
-
-config CCS811_I2C_ADDR
-	hex "I2C address for CCS811 Sensor"
-	range 0x5a 0x5b
-	default "0x5b"
-	help
-	  I2C address of the CCS811 sensor.
-	  0x5a: I2C_ADDR connected to GND.
-	  0x5b: I2C_ADDR connected to VDD.
-
-config CCS811_I2C_MASTER_DEV_NAME
-	string "I2C master where CCS811 is connected"
-	default "I2C_1"
-	help
-	  Specify the device name of the I2C master device to which the
-	  CCS811 chip is connected.
-
-endif
 
 config CCS811_GPIO_DEV_NAME
 	string "GPIO device"

--- a/drivers/sensor/fxas21002/Kconfig
+++ b/drivers/sensor/fxas21002/Kconfig
@@ -7,31 +7,11 @@
 
 menuconfig FXAS21002
 	bool "FXAS21002 gyroscope driver"
-	depends on I2C
+	depends on I2C && HAS_DTS_I2C
 	help
 	  Enable driver for the FXAS21002 gyroscope
 
 if FXAS21002
-
-if !HAS_DTS_I2C
-
-config FXAS21002_NAME
-	string "Device name"
-	default "FXAS21002"
-
-config FXAS21002_I2C_NAME
-	string "I2C device name"
-	default I2C_0_NAME
-
-config FXAS21002_I2C_ADDRESS
-	hex "I2C address"
-	range 0x20 0x21
-	default 0x20
-	help
-	  The I2C slave address can be configured by the SA0 input pin. This
-	  option should usually be set by the board defconfig.
-
-endif # !HAS_DTS_I2C
 
 config FXAS21002_WHOAMI
 	hex "WHOAMI value"

--- a/drivers/sensor/fxas21002/Kconfig
+++ b/drivers/sensor/fxas21002/Kconfig
@@ -7,7 +7,7 @@
 
 menuconfig FXAS21002
 	bool "FXAS21002 gyroscope driver"
-	depends on I2C && HAS_DTS_I2C
+	depends on I2C && HAS_DTS_I2C && HAS_DTS_GPIO
 	help
 	  Enable driver for the FXAS21002 gyroscope
 
@@ -69,16 +69,6 @@ config FXAS21002_TRIGGER
 	bool
 
 if FXAS21002_TRIGGER
-
-if !HAS_DTS_GPIO
-
-config FXAS21002_GPIO_NAME
-	string "GPIO device name"
-
-config FXAS21002_GPIO_PIN
-	int "GPIO pin"
-
-endif
 
 config FXAS21002_DRDY_INT1
 	bool "Data ready interrupt to INT1 pin"

--- a/drivers/sensor/fxos8700/Kconfig
+++ b/drivers/sensor/fxos8700/Kconfig
@@ -7,7 +7,7 @@
 
 menuconfig FXOS8700
 	bool "FXOS8700 accelerometer/magnetometer driver"
-	depends on I2C && HAS_DTS_I2C
+	depends on I2C && HAS_DTS_I2C && HAS_DTS_GPIO
 	help
 	  Enable driver for the FXOS8700 accelerometer/magnetometer
 
@@ -79,18 +79,6 @@ endchoice
 
 config FXOS8700_TRIGGER
 	bool
-
-if !HAS_DTS_GPIO
-
-config FXOS8700_GPIO_NAME
-	string "GPIO device name"
-	depends on FXOS8700_TRIGGER
-
-config FXOS8700_GPIO_PIN
-	int "GPIO pin"
-	depends on FXOS8700_TRIGGER
-
-endif
 
 config FXOS8700_DRDY_INT1
 	bool "Data ready interrupt to INT1 pin"

--- a/drivers/sensor/fxos8700/Kconfig
+++ b/drivers/sensor/fxos8700/Kconfig
@@ -7,31 +7,11 @@
 
 menuconfig FXOS8700
 	bool "FXOS8700 accelerometer/magnetometer driver"
-	depends on I2C
+	depends on I2C && HAS_DTS_I2C
 	help
 	  Enable driver for the FXOS8700 accelerometer/magnetometer
 
 if FXOS8700
-
-if !HAS_DTS_I2C
-
-config FXOS8700_NAME
-	string "Device name"
-	default "FXOS8700"
-
-config FXOS8700_I2C_NAME
-	string "I2C device name"
-	default I2C_0_NAME
-
-config FXOS8700_I2C_ADDRESS
-	hex "I2C address"
-	range 0x1c 0x1f
-	default 0x1d
-	help
-	  The I2C slave address can be configured by the SA0 and SA1 input
-	  pins. This option should usually be set by the board defconfig.
-
-endif # !HAS_DTS_I2C
 
 config FXOS8700_WHOAMI
 	hex "WHOAMI value"

--- a/drivers/sensor/hdc1008/Kconfig
+++ b/drivers/sensor/hdc1008/Kconfig
@@ -8,37 +8,11 @@
 
 menuconfig HDC1008
 	bool "HDC1008 Temperature and Humidity Sensor"
-	depends on I2C && GPIO
+	depends on I2C && HAS_DTS_I2C && GPIO
 	help
 	  Enable driver for HDC1008 temperature and humidity sensors.
 
 if HDC1008
-
-if !HAS_DTS_I2C
-
-config HDC1008_NAME
-	string "Driver name"
-	default "HDC1008"
-	help
-	  Device name with which the HDC1008 sensor is identified.
-
-config HDC1008_I2C_ADDR
-	hex "I2C Address for HDC1008"
-	default "0x40"
-	help
-	  0x40: A0 connected GND and A1 connected to GND.
-	  0x41: A0 connected VDD and A1 connected to GND.
-	  0x42: A0 connected GND and A1 connected to VDD.
-	  0x43: A0 connected VDD and A1 connected to VDD.
-
-config HDC1008_I2C_MASTER_DEV_NAME
-	string "I2C master where HDC1008 is connected"
-	default "I2C_0"
-	help
-	  Specify the device name of the I2C master device to which the
-	  HDC1008 chip is connected.
-
-endif # !HAS_DTS_I2C
 
 if !HAS_DTS_GPIO
 

--- a/drivers/sensor/hdc1008/Kconfig
+++ b/drivers/sensor/hdc1008/Kconfig
@@ -8,28 +8,6 @@
 
 menuconfig HDC1008
 	bool "HDC1008 Temperature and Humidity Sensor"
-	depends on I2C && HAS_DTS_I2C && GPIO
+	depends on I2C && HAS_DTS_I2C && GPIO && HAS_DTS_GPIO
 	help
 	  Enable driver for HDC1008 temperature and humidity sensors.
-
-if HDC1008
-
-if !HAS_DTS_GPIO
-
-config HDC1008_GPIO_DEV_NAME
-	string "GPIO device"
-	default "GPIO_0"
-	help
-	  The device name of the GPIO device to which the HDC1008 data-ready
-	  pin is connected.
-
-config HDC1008_GPIO_PIN_NUM
-	int "Interrupt GPIO pin number"
-	default 0
-	help
-	  The number of the GPIO on which the data-ready signal from the HDC1008
-	  chip will be received.
-
-endif # !HAS_DTS_GPIO
-
-endif # HDC1008

--- a/drivers/sensor/hts221/Kconfig
+++ b/drivers/sensor/hts221/Kconfig
@@ -6,28 +6,11 @@
 
 menuconfig HTS221
 	bool "HTS221 temperature and humidity sensor"
-	depends on I2C
+	depends on I2C && HAS_DTS_I2C
 	help
 	  Enable driver for HTS221 I2C-based temperature and humidity sensor.
 
 if HTS221
-
-if !HAS_DTS_I2C
-
-config HTS221_NAME
-	string "Driver name"
-	default "HTS221"
-	help
-	  Device name with which the HTS221 sensor is identified.
-
-config HTS221_I2C_MASTER_DEV_NAME
-	string "I2C master where HTS221 is connected"
-	default "I2C_0"
-	help
-	  Specify the device name of the I2C master device to which HTS221 is
-	  connected.
-
-endif
 
 choice HTS221_TRIGGER_MODE
 	prompt "Trigger mode"

--- a/drivers/sensor/lis3mdl/Kconfig
+++ b/drivers/sensor/lis3mdl/Kconfig
@@ -6,36 +6,11 @@
 
 menuconfig LIS3MDL
 	bool "LIS3MDL magnetometer"
-	depends on I2C
+	depends on I2C && HAS_DTS_I2C
 	help
 	  Enable driver for LIS3MDL I2C-based magnetometer.
 
 if LIS3MDL
-
-if !HAS_DTS_I2C
-
-config LIS3MDL_NAME
-	string "Driver name"
-	default "LIS3MDL"
-	help
-	  Device name with which the LIS3MDL sensor is identified.
-
-config LIS3MDL_I2C_ADDR
-	hex "I2C address"
-	default 0x1C
-	help
-	  I2C address of the LIS3MDL sensor.
-	  Use 0x1C if the SA1 pin is pulled to GND or 0x1E if the SA1 pin
-	  is pulled to VDD.
-
-config LIS3MDL_I2C_MASTER_DEV_NAME
-	string "I2C master where LIS3MDL is connected"
-	default "I2C_0"
-	help
-	  Specify the device name of the I2C master device to which LIS3MDL is
-	  connected.
-
-endif
 
 choice LIS3MDL_TRIGGER_MODE
 	prompt "Trigger mode"

--- a/drivers/sensor/lps22hb/Kconfig
+++ b/drivers/sensor/lps22hb/Kconfig
@@ -6,38 +6,12 @@
 
 menuconfig LPS22HB
 	bool "LPS22HB pressure and temperature"
-	depends on I2C
+	depends on I2C && HAS_DTS_I2C
 	help
 	  Enable driver for LPS22HB I2C-based pressure and temperature
 	  sensor.
 
 if LPS22HB
-
-if !HAS_DTS_I2C
-
-config LPS22HB_DEV_NAME
-	string "Device name"
-	default "LPS22HB"
-	help
-	  Device name used for LPS22HB sensor identification.
-
-config LPS22HB_I2C_ADDR
-	hex "I2C address"
-	default 0x5D
-	range 0x5C 0x5D
-	help
-	  I2C address of the LPS22HB sensor.
-	  Use 0x5C if the SA0 pin is pulled to GND or 0x5D if the SA0
-	  pin is pulled to VDD.
-
-config LPS22HB_I2C_MASTER_DEV_NAME
-	string "I2C master where LPS22HB is connected"
-	default I2C_0_NAME
-	help
-	  Specify the device name of the I2C master device to which
-	  LPS22HB is connected.
-
-endif
 
 menu "Attributes"
 

--- a/drivers/sensor/lps25hb/Kconfig
+++ b/drivers/sensor/lps25hb/Kconfig
@@ -6,37 +6,12 @@
 
 menuconfig LPS25HB
 	bool "LPS25HB pressure and temperature"
-	depends on I2C
+	depends on I2C && HAS_DTS_I2C
 	help
 	  Enable driver for LPS25HB I2C-based pressure and temperature
 	  sensor.
 
 if LPS25HB
-
-if !HAS_DTS_I2C
-
-config LPS25HB_DEV_NAME
-	string "Device name"
-	default "lps25hb"
-	help
-	  Device name with which the LPS25HB sensor is identified.
-
-config LPS25HB_I2C_ADDR
-	hex "I2C address"
-	default "0x5C"
-	help
-	  I2C address of the LPS25HB sensor.
-	  Use 0x5C if the SA0 pin is pulled to GND or 0x5D if the SA0
-	  pin is pulled to VDD.
-
-config LPS25HB_I2C_MASTER_DEV_NAME
-	string "I2C master where LPS25HB is connected"
-	default "I2C_0"
-	help
-	  Specify the device name of the I2C master device to which
-	  LPS25HB is connected.
-
-endif
 
 menu "Attributes"
 

--- a/drivers/sensor/lsm6ds0/Kconfig
+++ b/drivers/sensor/lsm6ds0/Kconfig
@@ -9,35 +9,12 @@
 
 menuconfig LSM6DS0
 	bool "LSM6DS0 I2C accelerometer and gyroscope Chip"
-	depends on I2C
+	depends on I2C && HAS_DTS_I2C
 	help
 	  Enable driver for LSM6DS0 I2C-based accelerometer and gyroscope
 	  sensor.
 
 if LSM6DS0
-
-if !HAS_DTS_I2C
-
-config LSM6DS0_DEV_NAME
-	string "LSM6DS0 device name"
-	default "lsm6ds0"
-
-config LSM6DS0_I2C_ADDR
-	hex "LSM6DS0 I2C address"
-	default 0x6B
-	help
-	  I2C address of the LSM6DS0 sensor.
-	  Use 0x6A if the SA0 pin is pulled to GND or 0x6B if the SA0 pin
-	  is pulled to VCC.
-
-config LSM6DS0_I2C_MASTER_DEV_NAME
-	string "I2C master where LSM6DS0 chip is connected"
-	default "I2C_0"
-	help
-	  Specify the device name of the I2C master device to which LSM6DS0 is
-	  connected.
-
-endif
 
 config LSM6DS0_ACCEL_ENABLE_X_AXIS
 	bool "Enable accelerometer X axis"

--- a/drivers/sensor/lsm6dsl/Kconfig
+++ b/drivers/sensor/lsm6dsl/Kconfig
@@ -54,24 +54,6 @@ endchoice
 config LSM6DSL_TRIGGER
 	bool
 
-if !HAS_DTS_GPIO
-
-config LSM6DSL_GPIO_DEV_NAME
-	string "GPIO device"
-	depends on LSM6DSL_TRIGGER
-	help
-	  The device name of the GPIO device to which the LSM6DSL interrupt pin
-	  is connected.
-
-config LSM6DSL_GPIO_PIN_NUM
-	int "Interrupt GPIO pin number"
-	depends on LSM6DSL_TRIGGER
-	help
-	  The number of the GPIO on which the interrupt signal from the LSM6DSL
-	  chip will be received.
-
-endif # HAS_DTS_GPIO
-
 config LSM6DSL_THREAD_PRIORITY
 	int "Thread priority"
 	depends on LSM6DSL_TRIGGER_OWN_THREAD

--- a/drivers/sensor/lsm6dsl/Kconfig
+++ b/drivers/sensor/lsm6dsl/Kconfig
@@ -9,7 +9,7 @@
 
 menuconfig LSM6DSL
 	bool "LSM6DSL I2C/SPI accelerometer and gyroscope Chip"
-	depends on (I2C && HAS_DTS_I2C) || SPI
+	depends on (I2C && HAS_DTS_I2C) || (SPI && HAS_DTS_SPI)
 	help
 	  Enable driver for LSM6DSL accelerometer and gyroscope
 	  sensor.
@@ -30,61 +30,6 @@ config LSM6DSL_SPI
 	bool "SPI Interface"
 
 endchoice
-
-config LSM6DSL_DEV_NAME
-	string "LSM6DSL device name"
-	depends on LSM6DSL_SPI
-	default "LSM6DSL"
-
-if !HAS_DTS_SPI
-
-config LSM6DSL_SPI_SELECT_SLAVE
-	hex "LSM6DSL SPI slave select pin"
-	depends on LSM6DSL_SPI
-	default 1
-	help
-	  LSM6DSL SPI chip select pin (active low).
-
-config LSM6DSL_SPI_BUS_FREQ
-	int "LSM6DSL SPI bus speed in Hz"
-	default 8000000
-	depends on LSM6DSL_SPI
-	help
-	  This is the maximum supported SPI bus frequency. The chip supports a
-	  frequency up to 10MHz.
-
-config LSM6DSL_SPI_MASTER_DEV_NAME
-	string "SPI master name where LSM6DSL chip is connected"
-	depends on LSM6DSL_SPI
-	default "SPI_2"
-	help
-	  Specify the device name of the spi master device to which LSM6DSL is
-	  connected.
-
-config LSM6DSL_SPI_GPIO_CS
-	bool "LSM6DSL SPI CS through a GPIO pin"
-	depends on LSM6DSL_SPI
-	help
-	  This option is useful if one needs to manage SPI CS through a GPIO
-	  pin to by-pass the SPI controller's CS logic.
-
-config LSM6DSL_SPI_GPIO_CS_DRV_NAME
-	string "GPIO driver's name to use to drive SPI CS through"
-	default ""
-	depends on LSM6DSL_SPI_GPIO_CS
-	help
-	  This option is mandatory to set which GPIO controller to use in order
-	  to actually emulate the SPI CS.
-
-config LSM6DSL_SPI_GPIO_CS_PIN
-	int "GPIO PIN to use to drive SPI CS through"
-	default 0
-	depends on LSM6DSL_SPI_GPIO_CS
-	help
-	  This option is mandatory to set which GPIO pin to use in order
-	  to actually emulate the SPI CS.
-
-endif # !HAS_DTS_SPI
 
 choice LSM6DSL_TRIGGER_MODE
 	prompt "Trigger mode"

--- a/drivers/sensor/lsm6dsl/Kconfig
+++ b/drivers/sensor/lsm6dsl/Kconfig
@@ -9,7 +9,7 @@
 
 menuconfig LSM6DSL
 	bool "LSM6DSL I2C/SPI accelerometer and gyroscope Chip"
-	depends on I2C || SPI
+	depends on (I2C && HAS_DTS_I2C) || SPI
 	help
 	  Enable driver for LSM6DSL accelerometer and gyroscope
 	  sensor.
@@ -33,30 +33,8 @@ endchoice
 
 config LSM6DSL_DEV_NAME
 	string "LSM6DSL device name"
-	depends on (LSM6DSL_I2C && !HAS_DTS_I2C) || LSM6DSL_SPI
+	depends on LSM6DSL_SPI
 	default "LSM6DSL"
-
-if !HAS_DTS_I2C
-
-config LSM6DSL_I2C_ADDR
-	hex "LSM6DSL I2C address"
-	depends on LSM6DSL_I2C
-	default 0x6A
-	range 0x6A 0x6B
-	help
-	  I2C address of the LSM6DSL sensor.
-	  Use 0x6A if the SA0 pin is pulled to GND or 0x6B if the SA0 pin
-	  is pulled to VCC.
-
-config LSM6DSL_I2C_MASTER_DEV_NAME
-	string "I2C master name where LSM6DSL chip is connected"
-	depends on LSM6DSL_I2C
-	default "I2C_2"
-	help
-	  Specify the device name of the I2C master device to which LSM6DSL is
-	  connected.
-
-endif #HAS_DTS_I2C
 
 if !HAS_DTS_SPI
 

--- a/drivers/sensor/max30101/Kconfig
+++ b/drivers/sensor/max30101/Kconfig
@@ -7,21 +7,9 @@
 
 menuconfig MAX30101
 	bool "MAX30101 Pulse Oximeter and Heart Rate Sensor"
-	depends on I2C
+	depends on I2C && HAS_DTS_I2C
 
 if MAX30101
-
-if !HAS_DTS_I2C
-
-config MAX30101_NAME
-	string "Driver name"
-	default "MAX30101"
-
-config MAX30101_I2C_NAME
-	string "I2C device name"
-	default "I2C_0"
-
-endif # !HAS_DTS_I2C
 
 config MAX30101_SMP_AVE
 	int "Sample averaging"

--- a/drivers/sensor/mma8451q/Kconfig
+++ b/drivers/sensor/mma8451q/Kconfig
@@ -7,30 +7,11 @@
 
 menuconfig MMA8451Q
 	bool "MMA8451Q Accelerometer driver"
-	depends on I2C
+	depends on I2C && HAS_DTS_I2C
 	help
 	  Enable driver for MMA8451Q Accelerometer.
 
 if MMA8451Q
-
-if !HAS_DTS_I2C
-
-config MMA8451Q_NAME
-	string "Device name"
-	default "MMA8451Q"
-
-config MMA8451Q_I2C_NAME
-	string "I2C device name"
-	default I2C_0_NAME
-
-config MMA8451Q_I2C_ADDRESS
-	hex "I2C address for MMA8451Q Sensor"
-	default 0x1D
-	help
-	  I2C address of the MMA8451Q sensor.
-	  0x1D: I2C_ADDR
-
-endif # !HAS_DTS_I2C
 
 config MMA8451Q_WHOAMI
 	hex "WHOAMI value"

--- a/drivers/sensor/vl53l0x/Kconfig
+++ b/drivers/sensor/vl53l0x/Kconfig
@@ -8,35 +8,12 @@
 
 menuconfig VL53L0X
 	bool "VL53L0X time of flight sensor"
-	depends on I2C
+	depends on I2C && HAS_DTS_I2C
 	select HAS_STLIB
 	help
 	  Enable driver for VL53L0X I2C-based time of flight sensor.
 
 if VL53L0X
-
-if !HAS_DTS_I2C
-
-config VL53L0X_NAME
-	string "Driver name"
-	default "VL53L0X"
-	help
-	  Device name with which the VL53L0X sensor is identified.
-
-config VL53L0X_I2C_ADDR
-	hex "Vl53l0x I2C address"
-	default 0x29
-	help
-	  address of the i2c used for the vl53l0x sensor
-
-config VL53L0X_I2C_MASTER_DEV_NAME
-	string "I2C master where VL53L0X is connected"
-	default "I2C_0"
-	help
-	  Specify the device name of the I2C master device to which VL53L0X is
-	  connected.
-
-endif
 
 config VL53L0X_XSHUT_CONTROL_ENABLE
 	bool "Enable XSHUT pin control"


### PR DESCRIPTION
I'm looking at starting to convert older sensor drivers to dts. Rather than continuing to propagate all this `if !HAS_DTS` stuff, I'd like to see if we can just remove it instead. Most boards and i2c/spi drivers support dts now, at least in arm.