### PR TITLE
Bluetooth: Mesh: Enforce proper compilation

### DIFF
--- a/subsys/bluetooth/host/mesh/prov.c
+++ b/subsys/bluetooth/host/mesh/prov.c
@@ -1078,7 +1078,7 @@ static void prov_data(const u8_t *data)
 	/* After PB-GATT provisioning we should start advertising
 	 * using Node Identity.
 	 */
-	if (identity_enable) {
+	if (IS_ENABLED(CONFIG_BT_MESH_GATT_PROXY) && identity_enable) {
 		bt_mesh_proxy_identity_enable();
 	}
 }


### PR DESCRIPTION
The current method relies heavily on the linker/compiler to
do the correct operation. Which is to eliminate the code that will
never get called. This posses a problem if the build even changes
by a smallest fraction.
The current patch will enforce proper inclusion of the code at the
pre-processing stage. Thereby not relying on the compiler/linker to
do the right thing.

Signed-off-by: Adithya Baglody <adithya.nagaraj.baglody@intel.com>