### PR TITLE
Bluetooth: gatt: gatt_discover_next with inclusive handle range

### DIFF
--- a/subsys/bluetooth/host/gatt.c
+++ b/subsys/bluetooth/host/gatt.c
@@ -1170,10 +1170,12 @@ static void gatt_discover_next(struct bt_conn *conn, u16_t last_handle,
 	params->start_handle = last_handle;
 	if (params->start_handle < UINT16_MAX) {
 		params->start_handle++;
+	} else {
+		goto done;
 	}
 
 	/* Stop if over the range or the requests */
-	if (params->start_handle >= params->end_handle) {
+	if (params->start_handle > params->end_handle) {
 		goto done;
 	}
 


### PR DESCRIPTION
This fix ensures that the handle range used for next GATT discovery is
always inclusive. Previously, the discovery procedure could not be
started with equal value of start and end handle.

Fixes:  #10119

Signed-off-by: Kamil Piszczek <Kamil.Piszczek@nordicsemi.no>