### PR TITLE
net: gptp: Experimental Grand Master support

### DIFF
--- a/include/net/gptp.h
+++ b/include/net/gptp.h
@@ -32,6 +32,7 @@ extern "C" {
 #define GPTP_OFFSET_SCALED_LOG_VAR_UNKNOWN 0x436A
 
 #define GPTP_PRIORITY1_NON_GM_CAPABLE      255
+#define GPTP_PRIORITY1_GM_CAPABLE          248
 #define GPTP_PRIORITY2_DEFAULT             248
 
 /**
@@ -208,6 +209,25 @@ struct gptp_phase_dis_cb {
 };
 
 /**
+ * @brief ClockSourceTime.invoke function parameters
+ *
+ * Parameters passed by ClockSourceTime.invoke function.
+ */
+struct gptp_clk_src_time_invoke_params {
+	/** Frequency change on the last Time Base Indicator Change. */
+	double last_gm_freq_change;
+
+	/** The time this function is invoked. */
+	struct net_ptp_extended_time src_time;
+
+	/** Phase change on the last Time Base Indicator Change. */
+	struct gptp_scaled_ns last_gm_phase_change;
+
+	/** Time Base - changed only if Phase or Frequency changes. */
+	u16_t time_base_indicator;
+};
+
+/**
  * @brief Register a phase discontinuity callback.
  *
  * @param phase_dis Caller specified handler for the callback.
@@ -277,6 +297,14 @@ void gptp_foreach_port(gptp_port_cb_t cb, void *user_data);
  * @return Pointer to domain or NULL if not found.
  */
 struct gptp_domain *gptp_get_domain(void);
+
+/**
+ * @brief This interface is used by the ClockSource entity to provide time to
+ *        the ClockMaster entity of a time-aware system.
+ *
+ * @param arg Current state and parameters of the ClockSource entity.
+ */
+void gptp_clk_src_time_invoke(struct gptp_clk_src_time_invoke_params *arg);
 
 #ifdef __cplusplus
 }

--- a/include/net/gptp.h
+++ b/include/net/gptp.h
@@ -27,8 +27,6 @@
 extern "C" {
 #endif
 
-#define GPTP_CLOCK_ACCURACY_UNKNOWN        0xFE
-
 #define GPTP_OFFSET_SCALED_LOG_VAR_UNKNOWN 0x436A
 
 #define GPTP_PRIORITY1_NON_GM_CAPABLE      255

--- a/include/net/ptp_time.h
+++ b/include/net/ptp_time.h
@@ -63,6 +63,54 @@ struct net_ptp_time {
 #endif
 
 /**
+ * @brief Precision Time Protocol Extended Timestamp format.
+ *
+ * This structure represents an extended timestamp according
+ * to the Precision Time Protocol standard.
+ *
+ * Seconds are encoded as 48 bits unsigned integer.
+ * Fractional nanoseconds are encoded as 48 bits, their unit
+ * is 2*(-16) ns.
+ */
+struct net_ptp_extended_time {
+	/** Seconds encoded on 48 bits. */
+	union {
+		struct {
+#if __BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__
+			u32_t low;
+			u16_t high;
+			u16_t unused;
+#elif __BYTE_ORDER__ == __ORDER_BIG_ENDIAN__
+			u16_t unused;
+			u16_t high;
+			u32_t low;
+#else
+#error "Unknown byte order"
+#endif
+		} _sec;
+		u64_t second;
+	};
+
+	/** Fractional nanoseconds on 48 bits. */
+	union {
+		struct {
+#if __BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__
+			u32_t low;
+			u16_t high;
+			u16_t unused;
+#elif __BYTE_ORDER__ == __ORDER_BIG_ENDIAN__
+			u16_t unused;
+			u16_t high;
+			u32_t low;
+#else
+#error "Unknown byte order"
+#endif
+		} _fns;
+		u64_t fract_nsecond;
+	};
+} __packed;
+
+/**
  * @}
  */
 

--- a/subsys/net/ip/net_shell.c
+++ b/subsys/net/ip/net_shell.c
@@ -2078,9 +2078,6 @@ static void gptp_print_port_info(int port)
 	       port_state->pss_send.last_follow_up_correction_field);
 	printk("\tUpstream Tx Time of the last recv PortSyncSync   "
 	       ": %llu\n", port_state->pss_send.last_upstream_tx_time);
-	printk("\tSync Receipt Timeout Time of last recv PSS       "
-	       ": %llu\n",
-	       port_state->pss_send.last_sync_receipt_timeout_time);
 	printf("\tRate Ratio of the last received PortSyncSync     "
 	       ": %f\n",
 	       port_state->pss_send.last_rate_ratio);

--- a/subsys/net/l2/ethernet/gptp/Kconfig
+++ b/subsys/net/l2/ethernet/gptp/Kconfig
@@ -21,6 +21,22 @@ config NET_DEBUG_GPTP
 	help
 	  Enable logs for the gPTP stack.
 
+config NET_GPTP_GM_CAPABLE
+	bool "Enable IEEE 802.1AS GrandMaster Capability"
+	help
+	  Enable to mark the whole system as Grand Master Capable.
+
+config NET_GPTP_PROBE_CLOCK_SOURCE_ON_DEMAND
+	bool "Probe clock source on demand"
+	depends on NET_GPTP_GM_CAPABLE
+	default y
+	help
+	  This option is helpful if the driver does not fully support the
+	  ClockSourceTime.invoke function. If this is enabled, the clock
+	  source is probed when it is actually needed instead of being
+	  updated on each tick.
+	  See IEEE 802.1AS-2011, chapter 9.2 for more details.
+
 config NET_GPTP_NUM_PORTS
 	int "Number of gPTP ports"
 	default 1

--- a/subsys/net/l2/ethernet/gptp/Kconfig
+++ b/subsys/net/l2/ethernet/gptp/Kconfig
@@ -37,6 +37,77 @@ config NET_GPTP_PROBE_CLOCK_SOURCE_ON_DEMAND
 	  updated on each tick.
 	  See IEEE 802.1AS-2011, chapter 9.2 for more details.
 
+choice
+	prompt "gPTP Clock Accuracy"
+	depends on NET_GPTP
+	default NET_GPTP_CLOCK_ACCURACY_UNKNOWN
+	help
+	  Specify the accuracy of the clock. This setting should reflect
+	  the actual capabilities of the hardware.
+	  See 7.6.2.5 of IEEE 1588-2008 for more info.
+
+	config NET_GPTP_CLOCK_ACCURACY_UNKNOWN
+		bool "Unknown"
+	config NET_GPTP_CLOCK_ACCURACY_25NS
+		bool "25ns"
+	config NET_GPTP_CLOCK_ACCURACY_100NS
+		bool "100ns"
+	config NET_GPTP_CLOCK_ACCURACY_250NS
+		bool "250ns"
+	config NET_GPTP_CLOCK_ACCURACY_1US
+		bool "1us"
+	config NET_GPTP_CLOCK_ACCURACY_2_5US
+		bool "2.5us"
+	config NET_GPTP_CLOCK_ACCURACY_10US
+		bool "10us"
+	config NET_GPTP_CLOCK_ACCURACY_25US
+		bool "25us"
+	config NET_GPTP_CLOCK_ACCURACY_100US
+		bool "100us"
+	config NET_GPTP_CLOCK_ACCURACY_250US
+		bool "250us"
+	config NET_GPTP_CLOCK_ACCURACY_1MS
+		bool "1ms"
+	config NET_GPTP_CLOCK_ACCURACY_2_5MS
+		bool "1.5ms"
+	config NET_GPTP_CLOCK_ACCURACY_10MS
+		bool "10ms"
+	config NET_GPTP_CLOCK_ACCURACY_25MS
+		bool "25ms"
+	config NET_GPTP_CLOCK_ACCURACY_100MS
+		bool "100ms"
+	config NET_GPTP_CLOCK_ACCURACY_250MS
+		bool "250ms"
+	config NET_GPTP_CLOCK_ACCURACY_1S
+		bool "1s"
+	config NET_GPTP_CLOCK_ACCURACY_10S
+		bool "10s"
+	config NET_GPTP_CLOCK_ACCURACY_GT_10S
+		bool "> 10s"
+endchoice
+
+config NET_GPTP_CLOCK_ACCURACY
+	hex
+	default 0x20 if NET_GPTP_CLOCK_ACCURACY_25NS
+	default 0x21 if NET_GPTP_CLOCK_ACCURACY_100NS
+	default 0x22 if NET_GPTP_CLOCK_ACCURACY_250NS
+	default 0x23 if NET_GPTP_CLOCK_ACCURACY_1US
+	default 0x24 if NET_GPTP_CLOCK_ACCURACY_2_5US
+	default 0x25 if NET_GPTP_CLOCK_ACCURACY_10US
+	default 0x26 if NET_GPTP_CLOCK_ACCURACY_25US
+	default 0x27 if NET_GPTP_CLOCK_ACCURACY_100US
+	default 0x28 if NET_GPTP_CLOCK_ACCURACY_250US
+	default 0x29 if NET_GPTP_CLOCK_ACCURACY_1MS
+	default 0x2a if NET_GPTP_CLOCK_ACCURACY_2_5MS
+	default 0x2b if NET_GPTP_CLOCK_ACCURACY_10MS
+	default 0x2c if NET_GPTP_CLOCK_ACCURACY_25MS
+	default 0x2d if NET_GPTP_CLOCK_ACCURACY_100MS
+	default 0x2e if NET_GPTP_CLOCK_ACCURACY_250MS
+	default 0x2f if NET_GPTP_CLOCK_ACCURACY_1S
+	default 0x30 if NET_GPTP_CLOCK_ACCURACY_10S
+	default 0x31 if NET_GPTP_CLOCK_ACCURACY_GT_10S
+	default 0xfe
+
 config NET_GPTP_NUM_PORTS
 	int "Number of gPTP ports"
 	default 1

--- a/subsys/net/l2/ethernet/gptp/gptp.c
+++ b/subsys/net/l2/ethernet/gptp/gptp.c
@@ -374,14 +374,19 @@ static void gptp_init_clock_ds(void)
 	/* Compute the clock identity from the first port MAC address. */
 	gptp_compute_clock_identity(GPTP_PORT_START);
 
-	/* XXX GrandMaster capability is not supported. */
-	default_ds->gm_capable = false;
-	default_ds->clk_quality.clock_class = GPTP_CLASS_SLAVE_ONLY;
+	default_ds->gm_capable = IS_ENABLED(CONFIG_NET_GPTP_GM_CAPABLE);
+	default_ds->clk_quality.clock_class = GPTP_CLASS_OTHER;
 	default_ds->clk_quality.clock_accuracy =
 		GPTP_CLOCK_ACCURACY_UNKNOWN;
 	default_ds->clk_quality.offset_scaled_log_var =
 		GPTP_OFFSET_SCALED_LOG_VAR_UNKNOWN;
-	default_ds->priority1 = GPTP_PRIORITY1_NON_GM_CAPABLE;
+
+	if (default_ds->gm_capable) {
+		default_ds->priority1 = GPTP_PRIORITY1_GM_CAPABLE;
+	} else {
+		default_ds->priority1 = GPTP_PRIORITY1_NON_GM_CAPABLE;
+	}
+
 	default_ds->priority2 = GPTP_PRIORITY2_DEFAULT;
 
 	default_ds->cur_utc_offset = 37; /* Current leap seconds TAI - UTC */
@@ -427,6 +432,8 @@ static void gptp_init_clock_ds(void)
 	global_ds->sys_flags.all = default_ds->flags.all;
 	global_ds->sys_current_utc_offset = default_ds->cur_utc_offset;
 	global_ds->sys_time_source = default_ds->time_source;
+	global_ds->clk_master_sync_itv =
+		NSEC_PER_SEC * GPTP_POW2(CONFIG_NET_GPTP_INIT_LOG_SYNC_ITV);
 }
 
 static void gptp_init_port_ds(int port)

--- a/subsys/net/l2/ethernet/gptp/gptp.c
+++ b/subsys/net/l2/ethernet/gptp/gptp.c
@@ -377,7 +377,7 @@ static void gptp_init_clock_ds(void)
 	default_ds->gm_capable = IS_ENABLED(CONFIG_NET_GPTP_GM_CAPABLE);
 	default_ds->clk_quality.clock_class = GPTP_CLASS_OTHER;
 	default_ds->clk_quality.clock_accuracy =
-		GPTP_CLOCK_ACCURACY_UNKNOWN;
+		CONFIG_NET_GPTP_CLOCK_ACCURACY;
 	default_ds->clk_quality.offset_scaled_log_var =
 		GPTP_OFFSET_SCALED_LOG_VAR_UNKNOWN;
 

--- a/subsys/net/l2/ethernet/gptp/gptp_data_set.h
+++ b/subsys/net/l2/ethernet/gptp/gptp_data_set.h
@@ -164,6 +164,24 @@ struct gptp_path_trace {
  * variable declared in gptp_port_ds.
  */
 struct gptp_global_ds {
+	/** Mean time interval between messages providing time-sync info. */
+	u64_t clk_master_sync_itv;
+
+	/** Value if current time. */
+	u64_t sync_receipt_local_time;
+
+	/** Fractional frequency offset of the Clock Source entity. */
+	double clk_src_freq_offset;
+
+	/** Last Grand Master Frequency Change. */
+	double clk_src_last_gm_freq_change;
+
+	/** Ratio of the frequency of the ClockSource to the LocalClock. */
+	double gm_rate_ratio;
+
+	/** Last Grand Master Frequency Change. */
+	double last_gm_freq_change;
+
 	/** The synchronized time computed by the ClockSlave entity. */
 	struct net_ptp_extended_time sync_receipt_time;
 
@@ -179,42 +197,6 @@ struct gptp_global_ds {
 	/** System current flags. */
 	struct gptp_flags sys_flags;
 
-	/** Mean time interval between messages providing time-sync info. */
-	u64_t clk_master_sync_itv;
-
-	/** Value if current time. */
-	u64_t sync_receipt_local_time;
-
-	/** Time provided by the ClockSource entity minus the sync time. */
-	s64_t clk_src_phase_offset;
-
-	/** Fractional frequency offset of the Clock Source entity. */
-	double clk_src_freq_offset;
-
-	/** Last Grand Master Frequency Change. */
-	double clk_src_last_gm_freq_change;
-
-	/** Ratio of the frequency of the ClockSource to the LocalClock. */
-	double gm_rate_ratio;
-
-	/** Last Grand Master Frequency Change. */
-	double last_gm_freq_change;
-
-	/** Time source. */
-	enum gptp_time_source time_source;
-
-	/** System time source. */
-	enum gptp_time_source sys_time_source;
-
-	/** Selected port Roles. */
-	enum gptp_port_state selected_role[CONFIG_NET_GPTP_NUM_PORTS + 1];
-
-	/** Reselect port bit array. */
-	u32_t reselect_array;
-
-	/** Selected port bit array. */
-	u32_t selected_array;
-
 	/** Path trace to be sent in announce message. */
 	struct gptp_path_trace path_trace;
 
@@ -223,6 +205,24 @@ struct gptp_global_ds {
 
 	/** Previous Grand Master priority vector. */
 	struct gptp_priority_vector last_gm_priority;
+
+	/** Value of current_time when the last invoke call was received. */
+	struct gptp_uscaled_ns local_time;
+
+	/** Time maintained by the ClockMaster entity. */
+	struct net_ptp_extended_time master_time;
+
+	/** Time provided by the ClockSource entity minus the sync time. */
+	struct gptp_scaled_ns clk_src_phase_offset;
+
+	/** Grand Master Time Base Indicator. */
+	u16_t gm_time_base_indicator;
+
+	/** Reselect port bit array. */
+	u32_t reselect_array;
+
+	/** Selected port bit array. */
+	u32_t selected_array;
 
 	/** Steps removed from selected master. */
 	u16_t master_steps_removed;
@@ -239,8 +239,14 @@ struct gptp_global_ds {
 	/** Previous Time Base Indicator. */
 	u16_t clk_src_time_base_indicator_prev;
 
-	/** Grand Master Time Base Indicator. */
-	u16_t gm_time_base_indicator;
+	/** Time source. */
+	enum gptp_time_source time_source;
+
+	/** System time source. */
+	enum gptp_time_source sys_time_source;
+
+	/** Selected port Roles. */
+	enum gptp_port_state selected_role[CONFIG_NET_GPTP_NUM_PORTS + 1];
 
 	/** A Grand Master is present in the domain. */
 	bool gm_present;

--- a/subsys/net/l2/ethernet/gptp/gptp_data_set.h
+++ b/subsys/net/l2/ethernet/gptp/gptp_data_set.h
@@ -165,7 +165,7 @@ struct gptp_path_trace {
  */
 struct gptp_global_ds {
 	/** The synchronized time computed by the ClockSlave entity. */
-	struct net_ptp_time sync_receipt_time;
+	struct net_ptp_extended_time sync_receipt_time;
 
 	/** Last Grand Master Phase Change. */
 	struct gptp_scaled_ns clk_src_last_gm_phase_change;

--- a/subsys/net/l2/ethernet/gptp/gptp_mi.c
+++ b/subsys/net/l2/ethernet/gptp/gptp_mi.c
@@ -634,11 +634,11 @@ static void gptp_mi_clk_slave_sync_compute(void)
 	sync_receipt_time += port_ds->delay_asymmetry;
 
 	global_ds->sync_receipt_time.second = sync_receipt_time / NSEC_PER_SEC;
-	global_ds->sync_receipt_time.nanosecond =
-		sync_receipt_time % NSEC_PER_SEC;
+	global_ds->sync_receipt_time.fract_nsecond =
+		(sync_receipt_time % NSEC_PER_SEC) * GPTP_POW2(16);
 	global_ds->sync_receipt_time.second += pss->precise_orig_ts.second;
-	global_ds->sync_receipt_time.nanosecond +=
-		pss->precise_orig_ts.nanosecond;
+	global_ds->sync_receipt_time.fract_nsecond +=
+		pss->precise_orig_ts.nanosecond * GPTP_POW2(16);
 
 	global_ds->sync_receipt_local_time = port_ds->delay_asymmetry;
 	global_ds->sync_receipt_local_time /= pss->rate_ratio;
@@ -681,7 +681,8 @@ static void gptp_update_local_port_clock(void)
 
 	second_diff = global_ds->sync_receipt_time.second -
 		(global_ds->sync_receipt_local_time / NSEC_PER_SEC);
-	nanosecond_diff = global_ds->sync_receipt_time.nanosecond -
+	nanosecond_diff =
+		(global_ds->sync_receipt_time.fract_nsecond / GPTP_POW2(16)) -
 		(global_ds->sync_receipt_local_time % NSEC_PER_SEC);
 
 	clk = net_eth_get_ptp_clock(GPTP_PORT_IFACE(port));

--- a/subsys/net/l2/ethernet/gptp/gptp_mi.c
+++ b/subsys/net/l2/ethernet/gptp/gptp_mi.c
@@ -501,8 +501,7 @@ static void gptp_mi_pss_send_state_machine(int port)
 						&port_ds->half_sync_itv);
 
 		/* Start 0.5 * syncInterval timeout timer. */
-		k_timer_start(&state->half_sync_itv_timer,
-			      duration, duration);
+		k_timer_start(&state->half_sync_itv_timer, duration, 0);
 
 		gptp_mi_pss_send_md_sync_send(port);
 

--- a/subsys/net/l2/ethernet/gptp/gptp_mi.c
+++ b/subsys/net/l2/ethernet/gptp/gptp_mi.c
@@ -168,10 +168,10 @@ static void gptp_mi_init_port_announce_rcv_sm(int port)
 
 static void gptp_mi_init_clock_master_sync_rcv_sm(void)
 {
-	struct gptp_clk_master_sync_state *cms_rcv;
+	struct gptp_clk_master_sync_rcv_state *cms_rcv;
 
 	cms_rcv = &GPTP_STATE()->clk_master_sync_receive;
-	(void)memset(cms_rcv, 0, sizeof(struct gptp_clk_master_sync_state));
+	(void)memset(cms_rcv, 0, sizeof(struct gptp_clk_master_sync_rcv_state));
 	cms_rcv->state = GPTP_CMS_RCV_INITIALIZING;
 }
 
@@ -773,7 +773,7 @@ static void gptp_mi_clk_slave_sync_state_machine(void)
 
 static void gptp_mi_clk_master_sync_rcv_state_machine(void)
 {
-	struct gptp_clk_master_sync_state *state;
+	struct gptp_clk_master_sync_rcv_state *state;
 
 	state = &GPTP_STATE()->clk_master_sync_receive;
 	switch (state->state) {

--- a/subsys/net/l2/ethernet/gptp/gptp_mi.c
+++ b/subsys/net/l2/ethernet/gptp/gptp_mi.c
@@ -540,8 +540,7 @@ static void gptp_mi_pss_send_state_machine(int port)
 			k_timer_stop(&state->send_sync_receipt_timeout_timer);
 			state->send_sync_receipt_timeout_timer_expired = false;
 
-			duration = (state->last_sync_receipt_timeout_time -
-				    gptp_get_current_time_nanosecond(port)) /
+			duration = port_ds->sync_receipt_timeout_time_itv /
 				(NSEC_PER_USEC * USEC_PER_MSEC);
 
 			k_timer_start(&state->send_sync_receipt_timeout_timer,

--- a/subsys/net/l2/ethernet/gptp/gptp_state.h
+++ b/subsys/net/l2/ethernet/gptp/gptp_state.h
@@ -114,6 +114,18 @@ enum gptp_pa_transmit_states {
 	GPTP_PA_TRANSMIT_POST_IDLE,
 } __packed;
 
+/* ClockMasterSyncOffset states. */
+enum gptp_cms_offset_states {
+	GPTP_CMS_OFFSET_INITIALIZING,
+	GPTP_CMS_OFFSET_INDICATION,
+} __packed;
+
+/* ClockMasterSyncSend states. */
+enum gptp_cms_snd_states {
+	GPTP_CMS_SND_INITIALIZING,
+	GPTP_CMS_SND_INDICATION,
+} __packed;
+
 /* ClockMasterSyncReceive states. */
 enum gptp_cms_rcv_states {
 	GPTP_CMS_RCV_INITIALIZING,
@@ -374,8 +386,35 @@ struct gptp_clk_slave_sync_state {
 	bool rcvd_local_clk_tick;
 };
 
+/* ClockMasterSyncOffset state machine variables. */
+struct gptp_clk_master_sync_offset_state {
+	/** Current state of the state machine. */
+	enum gptp_cms_offset_states state;
+
+	/** Notifies the state machine when Sync Receipt Time is received. */
+	bool rcvd_sync_receipt_time;
+};
+
+/* ClockMasterSyncSend state machine variables. */
+struct gptp_clk_master_sync_snd_state {
+	/** Time when synchronization info will be sent. */
+	struct gptp_uscaled_ns sync_send_time;
+
+	/** PortSyncSync structure transmitted by the state machine. */
+	struct gptp_mi_port_sync_sync pss_snd;
+
+	/** Current state of the state machine. */
+	enum gptp_cms_snd_states state;
+};
+
 /* ClockMasterSyncReceive state machine variables. */
 struct gptp_clk_master_sync_rcv_state {
+	/** The received ClockSourceTime.invoke parameters. Note that the
+	 * standard defines this as a pointer, but storing the struct here is
+	 * more convenient
+	 */
+	struct gptp_clk_src_time_invoke_params rcvd_clk_src_req;
+
 	/** Current state of the state machine */
 	enum gptp_cms_rcv_states state;
 
@@ -439,6 +478,12 @@ struct gptp_states {
 
 	/** PortRoleSelection state machine variables. */
 	struct gptp_port_role_selection_state pr_sel;
+
+	/** ClockMasterSyncOffset state machine variables. */
+	struct gptp_clk_master_sync_offset_state clk_master_sync_offset;
+
+	/** ClockMasterSyncSend state machine variables. */
+	struct gptp_clk_master_sync_snd_state clk_master_sync_send;
 
 	/** ClockMasterSyncReceive state machine variables. */
 	struct gptp_clk_master_sync_rcv_state clk_master_sync_receive;

--- a/subsys/net/l2/ethernet/gptp/gptp_state.h
+++ b/subsys/net/l2/ethernet/gptp/gptp_state.h
@@ -374,8 +374,8 @@ struct gptp_clk_slave_sync_state {
 	bool rcvd_local_clk_tick;
 };
 
-/* ClockMasterSync state machine variables. */
-struct gptp_clk_master_sync_state {
+/* ClockMasterSyncReceive state machine variables. */
+struct gptp_clk_master_sync_rcv_state {
 	/** Current state of the state machine */
 	enum gptp_cms_rcv_states state;
 
@@ -441,7 +441,7 @@ struct gptp_states {
 	struct gptp_port_role_selection_state pr_sel;
 
 	/** ClockMasterSyncReceive state machine variables. */
-	struct gptp_clk_master_sync_state clk_master_sync_receive;
+	struct gptp_clk_master_sync_rcv_state clk_master_sync_receive;
 };
 
 /**

--- a/subsys/net/l2/ethernet/gptp/gptp_state.h
+++ b/subsys/net/l2/ethernet/gptp/gptp_state.h
@@ -30,7 +30,7 @@ enum gptp_pdelay_req_states {
 	GPTP_PDELAY_REQ_WAIT_RESP,
 	GPTP_PDELAY_REQ_WAIT_FOLLOW_UP,
 	GPTP_PDELAY_REQ_WAIT_ITV_TIMER,
-};
+} __packed;
 
 /* Path Delay Response states. */
 enum gptp_pdelay_resp_states {
@@ -38,27 +38,27 @@ enum gptp_pdelay_resp_states {
 	GPTP_PDELAY_RESP_INITIAL_WAIT_REQ,
 	GPTP_PDELAY_RESP_WAIT_REQ,
 	GPTP_PDELAY_RESP_WAIT_TSTAMP,
-};
+} __packed;
 
 /* SyncReceive states. */
 enum gptp_sync_rcv_states {
 	GPTP_SYNC_RCV_DISCARD,
 	GPTP_SYNC_RCV_WAIT_SYNC,
 	GPTP_SYNC_RCV_WAIT_FOLLOW_UP,
-};
+} __packed;
 
 /* SyncSend states. */
 enum gptp_sync_send_states {
 	GPTP_SYNC_SEND_INITIALIZING,
 	GPTP_SYNC_SEND_SEND_SYNC,
 	GPTP_SYNC_SEND_SEND_FUP,
-};
+} __packed;
 
 /* PortSyncSyncReceive states. */
 enum gptp_pss_rcv_states {
 	GPTP_PSS_RCV_DISCARD,
 	GPTP_PSS_RCV_RECEIVED_SYNC,
-};
+} __packed;
 
 /* PortSyncSyncSend states. */
 enum gptp_pss_send_states {
@@ -66,25 +66,25 @@ enum gptp_pss_send_states {
 	GPTP_PSS_SEND_SYNC_RECEIPT_TIMEOUT,
 	GPTP_PSS_SEND_SEND_MD_SYNC,
 	GPTP_PSS_SEND_SET_SYNC_RECEIPT_TIMEOUT,
-};
+} __packed;
 
 /* SiteSyncSyncReceive states. */
 enum gptp_site_sync_sync_states {
 	GPTP_SSS_INITIALIZING,
 	GPTP_SSS_RECEIVING_SYNC,
-};
+} __packed;
 
 /* ClockSlaveSync states. */
 enum gptp_clk_slave_sync_states {
 	GPTP_CLK_SLAVE_SYNC_INITIALIZING,
 	GPTP_CLK_SLAVE_SYNC_SEND_SYNC_IND,
-};
+} __packed;
 
 /* PortAnnounceReceive states. */
 enum gptp_pa_rcv_states {
 	GPTP_PA_RCV_DISCARD,
 	GPTP_PA_RCV_RECEIVE,
-};
+} __packed;
 
 /* PortAnnounceInformation states. */
 enum gptp_pa_info_states {
@@ -98,13 +98,13 @@ enum gptp_pa_info_states {
 	GPTP_PA_INFO_SUPERIOR_MASTER_PORT,
 	GPTP_PA_INFO_REPEATED_MASTER_PORT,
 	GPTP_PA_INFO_INFERIOR_MASTER_OR_OTHER_PORT,
-};
+} __packed;
 
 /* PortRoleSelection states. */
 enum gptp_pr_selection_states {
 	GPTP_PR_SELECTION_INIT_BRIDGE,
 	GPTP_PR_SELECTION_ROLE_SELECTION,
-};
+} __packed;
 
 /* PortAnnounceTransmit states. */
 enum gptp_pa_transmit_states {
@@ -112,14 +112,14 @@ enum gptp_pa_transmit_states {
 	GPTP_PA_TRANSMIT_PERIODIC,
 	GPTP_PA_TRANSMIT_IDLE,
 	GPTP_PA_TRANSMIT_POST_IDLE,
-};
+} __packed;
 
 /* ClockMasterSyncReceive states. */
 enum gptp_cms_rcv_states {
 	GPTP_CMS_RCV_INITIALIZING,
 	GPTP_CMS_RCV_WAITING,
 	GPTP_CMS_RCV_SOURCE_TIME,
-};
+} __packed;
 
 /* Info_is enumeration2. */
 enum gptp_info_is {
@@ -127,7 +127,7 @@ enum gptp_info_is {
 	GPTP_INFO_IS_MINE,
 	GPTP_INFO_IS_AGED,
 	GPTP_INFO_IS_DISABLED,
-};
+} __packed;
 
 enum gptp_time_source {
 	GPTP_TS_ATOMIC_CLOCK        = 0x10,
@@ -138,7 +138,7 @@ enum gptp_time_source {
 	GPTP_TS_HAND_SET            = 0x60,
 	GPTP_TS_OTHER               = 0x90,
 	GPTP_TS_INTERNAL_OSCILLATOR = 0xA0,
-};
+} __packed;
 
 /**
  * @brief gPTP time-synchronization spanning tree priority vector
@@ -181,9 +181,6 @@ struct gptp_pdelay_req_state {
 	/** Pointer to the Path Delay Request to be transmitted. */
 	struct net_pkt *tx_pdelay_req_ptr;
 
-	/** Current state of the state machine. */
-	enum gptp_pdelay_req_states state;
-
 	/** Path Delay Response messages received. */
 	u32_t rcvd_pdelay_resp;
 
@@ -192,6 +189,9 @@ struct gptp_pdelay_req_state {
 
 	/** Number of lost Path Delay Responses. */
 	u16_t lost_responses;
+
+	/** Current state of the state machine. */
+	enum gptp_pdelay_req_states state;
 
 	/** Timer expired, a new Path Delay Request needs to be sent. */
 	bool pdelay_timer_expired;
@@ -451,9 +451,6 @@ struct gptp_port_states {
 	/** PathDelayRequest state machine variables. */
 	struct gptp_pdelay_req_state pdelay_req;
 
-	/** PathDelayResponse state machine variables. */
-	struct gptp_pdelay_resp_state pdelay_resp;
-
 	/** SyncReceive state machine variables. */
 	struct gptp_sync_rcv_state sync_rcv;
 
@@ -466,14 +463,17 @@ struct gptp_port_states {
 	/** PortSyncSync Send state machine variables. */
 	struct gptp_pss_send_state pss_send;
 
-	/** PortAnnounceReceive state machine variables. */
-	struct gptp_port_announce_receive_state pa_rcv;
-
 	/** PortAnnounceInformation state machine variables. */
 	struct gptp_port_announce_information_state pa_info;
 
 	/** PortAnnounceTransmit state machine variables. */
 	struct gptp_port_announce_transmit_state pa_transmit;
+
+	/** PathDelayResponse state machine variables. */
+	struct gptp_pdelay_resp_state pdelay_resp;
+
+	/** PortAnnounceReceive state machine variables. */
+	struct gptp_port_announce_receive_state pa_rcv;
 };
 
 /**

--- a/subsys/net/l2/ethernet/gptp/gptp_state.h
+++ b/subsys/net/l2/ethernet/gptp/gptp_state.h
@@ -315,9 +315,6 @@ struct gptp_pss_send_state {
 	/** Upstream Tx Time of the last received PortSyncSync. */
 	u64_t last_upstream_tx_time;
 
-	/** Sync Receipt Timeout Time of the last received PortSyncSync. */
-	u64_t last_sync_receipt_timeout_time;
-
 	/** PortSyncSync structure received from the SiteSyncSync. */
 	struct gptp_mi_port_sync_sync *pss_sync_ptr;
 

--- a/subsys/net/l2/ethernet/gptp/gptp_user_api.c
+++ b/subsys/net/l2/ethernet/gptp/gptp_user_api.c
@@ -81,3 +81,15 @@ char *gptp_sprint_clock_id(const u8_t *clk_id, char *output, size_t output_len)
 {
 	return net_sprint_ll_addr_buf(clk_id, 8, output, output_len);
 }
+
+void gptp_clk_src_time_invoke(struct gptp_clk_src_time_invoke_params *arg)
+{
+	struct gptp_clk_master_sync_rcv_state *state;
+
+	state = &GPTP_STATE()->clk_master_sync_receive;
+
+	memcpy(&state->rcvd_clk_src_req, arg,
+	       sizeof(struct gptp_clk_src_time_invoke_params));
+
+	state->rcvd_clock_source_req = true;
+}


### PR DESCRIPTION
So far, the gPTP support in Zephyr only covered the Slave side. Zephyr could synchronize its clock to other devices but there was no way to for example sync clocks between two devices running Zephyr. This PR adds that possibility.
It is marked as experimental because the whole gPTP support still is.

What is added is basically what one of the commits says: GMCAP-1, GMCAP-2, and GMCAP-3  from 802.1AS-2011 are either implemented from scratch or finished. Additionally there are some commits with bug-fixes that were found along the way and are needed for the Grand Master role to work.

Fully working test setup, on which the GM support was tested:
`SAM e70 Xplained <-> regular Ethernet switch <-> SAM e70 Xplained`

The switch in between is useful to be able to also connect a third party host to it for sniffing (e.g. with ptpTrackHound), but it also makes the connections and bring up much easier, because sam gmac does not yet support link re-negotiation (it only negotiates link during boot), so it makes sense to have a device that is always on on the other side.

Some notes and known limitations:
* The correction field is always set to 0 in the Sync Follow Up packets - this mimics the behavior of OpenAvnu (a Linux gPTP client). There is a TODO left in the code which indicates that the filed should be properly calculated in order be fully compliant.
* OpenAvnu accepts Zephyr as GM but refuses to sync its clock - this could also be the case with some other gPTP-enabled devices.
* The clock accuracy can be chosen through KConfig - generally the chosen setting should reflect the capabilities of the HW, but this option is also useful for testing, as the device with the best accuracy is chosen as GM
* There is a `gptp_clock_source_time_invoke` callback added. According to the standard it should be called every time the clock updates its value but an `ON_DEMAND` functionality was added to probe the clock from current master when it is actually needed, as it doesn't always make sense to update it continuously in the ptp clock driver.
