### PR TITLE
Bluetooth: Add API to iterate through existing bonds

### DIFF
--- a/include/bluetooth/bluetooth.h
+++ b/include/bluetooth/bluetooth.h
@@ -688,6 +688,22 @@ int bt_br_set_connectable(bool enable);
   */
 int bt_unpair(u8_t id, const bt_addr_le_t *addr);
 
+/** Information about a bond with a remote device. */
+struct bt_bond_info {
+	/** Address of the remote device. */
+	bt_addr_le_t addr;
+};
+
+/** Iterate through all existing bonds.
+  *
+  * @param id         Local identity (mostly just BT_ID_DEFAULT).
+  * @param func       Function to call for each bond.
+  * @param user_data  Data to pass to the callback function.
+  */
+void bt_foreach_bond(u8_t id, void (*func)(const struct bt_bond_info *info,
+					   void *user_data),
+		     void *user_data);
+
 /**
  * @}
  */

--- a/subsys/bluetooth/host/keys.c
+++ b/subsys/bluetooth/host/keys.c
@@ -56,6 +56,24 @@ struct bt_keys *bt_keys_get_addr(u8_t id, const bt_addr_le_t *addr)
 	return NULL;
 }
 
+void bt_foreach_bond(u8_t id, void (*func)(const struct bt_bond_info *info,
+					   void *user_data),
+		     void *user_data)
+{
+	int i;
+
+	for (i = 0; i < ARRAY_SIZE(key_pool); i++) {
+		struct bt_keys *keys = &key_pool[i];
+
+		if (keys->keys && keys->id == id) {
+			struct bt_bond_info info;
+
+			bt_addr_le_copy(&info.addr, &keys->addr);
+			func(&info, user_data);
+		}
+	}
+}
+
 void bt_keys_foreach(int type, void (*func)(struct bt_keys *keys, void *data),
 		     void *data)
 {


### PR DESCRIPTION
So far the stack hasn't provided any way for the application to access
the existing bonds. This patch adds such an API.

Fixes #10122

Signed-off-by: Johan Hedberg <johan.hedberg@intel.com>