### PR TITLE
shell: fix shell_log_backend dependency

### DIFF
--- a/subsys/shell/CMakeLists.txt
+++ b/subsys/shell/CMakeLists.txt
@@ -30,7 +30,7 @@ zephyr_sources_ifdef(
 )
 
 zephyr_sources_ifdef(
-  CONFIG_LOG
+  CONFIG_SHELL_LOG_BACKEND
   shell_log_backend.c
 )
 

--- a/subsys/shell/Kconfig
+++ b/subsys/shell/Kconfig
@@ -170,6 +170,11 @@ config SHELL_CMDS_RESIZE
 	  must be called to ensure correct text display on the terminal screen.
 	  Resize command can be turned off to safe code memory (~0,5k).
 
+config SHELL_LOG_BACKEND
+	bool
+	default y if LOG
+	default n if !LOG
+
 endif #SHELL
 endmenu
 


### PR DESCRIPTION
Fixed case when shell_log_backend.c was included even though
shell was disabled.

Signed-off-by: Krzysztof Chruscinski <krzysztof.chruscinski@nordicsemi.no>