### PR TITLE
Bluetooth: controller: Add support for setting public address

### DIFF
--- a/include/bluetooth/controller.h
+++ b/include/bluetooth/controller.h
@@ -1,0 +1,39 @@
+/** @file
+ *  @brief Bluetooth subsystem controller APIs.
+ */
+
+/*
+ * Copyright (c) 2018 Codecoup
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+#ifndef ZEPHYR_INCLUDE_BLUETOOTH_CONTROLLER_H_
+#define ZEPHYR_INCLUDE_BLUETOOTH_CONTROLLER_H_
+
+/**
+ * @brief Bluetooth Controller
+ * @defgroup bt_ctrl Bluetooth Controller
+ * @ingroup bluetooth
+ * @{
+ */
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/** @brief Set public address for controller
+ *
+ *  Should be called before bt_enable().
+ *
+ *  @param addr Public address
+ */
+void bt_ctlr_set_public_addr(const u8_t *addr);
+
+#ifdef __cplusplus
+}
+#endif
+/**
+ * @}
+ */
+
+#endif /* ZEPHYR_INCLUDE_BLUETOOTH_CONTROLLER_H_ */

--- a/subsys/bluetooth/controller/ll_sw/ll_addr.c
+++ b/subsys/bluetooth/controller/ll_sw/ll_addr.c
@@ -9,6 +9,7 @@
 
 #include <zephyr/types.h>
 #include <bluetooth/hci.h>
+#include <bluetooth/controller.h>
 #include <misc/slist.h>
 
 #include "util/util.h"
@@ -54,4 +55,9 @@ u32_t ll_addr_set(u8_t addr_type, u8_t const *const bdaddr)
 	}
 
 	return 0;
+}
+
+void bt_ctlr_set_public_addr(const u8_t *addr)
+{
+    (void)memcpy(pub_addr, addr, sizeof(pub_addr));
 }


### PR DESCRIPTION
This allows to provide public address for controller without using
VS HCI command from host. Useful for controller only builds or
combined builds that are not using VS HCI commands

Signed-off-by: Szymon Janc <szymon.janc@codecoup.pl>