### PR TITLE
lib: cmsis_rtos_v1: do null check before use

### DIFF
--- a/lib/cmsis_rtos_v1/cmsis_thread.c
+++ b/lib/cmsis_rtos_v1/cmsis_thread.c
@@ -45,12 +45,12 @@ osThreadId osThreadCreate(const osThreadDef_t *thread_def, void *arg)
 	k_thread_stack_t
 	   (*stk_ptr)[K_THREAD_STACK_LEN(CONFIG_CMSIS_THREAD_MAX_STACK_SIZE)];
 
-	__ASSERT(thread_def->stacksize <= CONFIG_CMSIS_THREAD_MAX_STACK_SIZE,
-		 "invalid stack size\n");
-
 	if ((thread_def == NULL) || (thread_def->instances == 0)) {
 		return NULL;
 	}
+
+	__ASSERT(thread_def->stacksize <= CONFIG_CMSIS_THREAD_MAX_STACK_SIZE,
+		 "invalid stack size\n");
 
 	if (_is_in_isr()) {
 		return NULL;


### PR DESCRIPTION
Moving a `thread_def` null check to top before
using the structure's elements.

Fixes #10092 

Signed-off-by: Niranjhana N <niranjhana.n@intel.com>