### PR TITLE
Support kconfig root convention

### DIFF
--- a/cmake/kconfig.cmake
+++ b/cmake/kconfig.cmake
@@ -4,7 +4,14 @@ file(MAKE_DIRECTORY ${PROJECT_BINARY_DIR}/kconfig/include/generated)
 file(MAKE_DIRECTORY ${PROJECT_BINARY_DIR}/kconfig/include/config)
 file(MAKE_DIRECTORY ${PROJECT_BINARY_DIR}/include/generated)
 
-set_ifndef(KCONFIG_ROOT ${ZEPHYR_BASE}/Kconfig)
+if(KCONFIG_ROOT)
+  # KCONFIG_ROOT has either been specified as a CMake variable or is
+  # already in the CMakeCache.txt. This has precedence.
+elseif(EXISTS   ${APPLICATION_SOURCE_DIR}/Kconfig)
+  set(KCONFIG_ROOT ${APPLICATION_SOURCE_DIR}/Kconfig)
+else()
+  set(KCONFIG_ROOT ${ZEPHYR_BASE}/Kconfig)
+endif()
 
 set(BOARD_DEFCONFIG ${BOARD_DIR}/${BOARD}_defconfig)
 set(DOTCONFIG       ${PROJECT_BINARY_DIR}/.config)

--- a/doc/application/application.rst
+++ b/doc/application/application.rst
@@ -853,8 +853,9 @@ Make sure to follow these steps in order.
 
    More details are available below in :ref:`application_dt`.
 
-#. If your application has its own kernel configuration options, add a
-   line setting the location of the Kconfig file that defines them.
+#. If your application has its own kernel configuration options,
+   create a :file:`Kconfig` file in the same directory as your
+   application's :file:`CMakeLists.txt`.
 
    An (unlikely) advanced use case would be if your application has its own
    unique configuration **options** that are set differently depending on the
@@ -862,13 +863,6 @@ Make sure to follow these steps in order.
 
    If you just want to set application specific **values** for existing Zephyr
    configuration options, refer to the :makevar:`CONF_FILE` description above.
-
-   For example, if you have a file named :file:`Kconfig` in the same directory
-   as your application's :file:`CMakeLists.txt`, add the following line:
-
-   .. code-block:: cmake
-
-      set(KCONFIG_ROOT ${CMAKE_CURRENT_SOURCE_DIR}/Kconfig)
 
    Structure your :file:`Kconfig` file like this:
 
@@ -883,6 +877,11 @@ Make sure to follow these steps in order.
 
        See the :ref:`kconfig_extensions` section in the
        :ref:`board_porting_guide` for more information.
+
+   The :file:`Kconfig` file is automatically detected when placed in
+   the application directory, but it is also possible for it to be
+   found elsewhere if the CMake variable :makevar:`KCONFIG_ROOT` is
+   set with an absolute path.
 
 #. Now include the mandatory boilerplate that integrates the
    application with the Zephyr build system on a new line, **after any

--- a/samples/drivers/CAN/CMakeLists.txt
+++ b/samples/drivers/CAN/CMakeLists.txt
@@ -1,6 +1,5 @@
 cmake_minimum_required(VERSION 3.8.2)
 
-set(KCONFIG_ROOT ${CMAKE_CURRENT_SOURCE_DIR}/Kconfig)
 
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
 project(NONE)

--- a/samples/net/echo_client/CMakeLists.txt
+++ b/samples/net/echo_client/CMakeLists.txt
@@ -1,5 +1,4 @@
 cmake_minimum_required(VERSION 3.8.2)
-set(KCONFIG_ROOT ${CMAKE_CURRENT_SOURCE_DIR}/Kconfig)
 
 macro(set_conf_file)
   if(EXISTS ${APPLICATION_SOURCE_DIR}/prj_${BOARD}.conf)

--- a/samples/net/echo_server/CMakeLists.txt
+++ b/samples/net/echo_server/CMakeLists.txt
@@ -1,5 +1,4 @@
 cmake_minimum_required(VERSION 3.8.2)
-set(KCONFIG_ROOT ${CMAKE_CURRENT_SOURCE_DIR}/Kconfig)
 
 macro(set_conf_file)
   if(EXISTS ${APPLICATION_SOURCE_DIR}/prj_${BOARD}.conf)

--- a/samples/net/gptp/CMakeLists.txt
+++ b/samples/net/gptp/CMakeLists.txt
@@ -1,5 +1,4 @@
 cmake_minimum_required(VERSION 3.8.2)
-set(KCONFIG_ROOT ${CMAKE_CURRENT_SOURCE_DIR}/Kconfig)
 
 macro(set_conf_file)
   if(EXISTS ${APPLICATION_SOURCE_DIR}/prj_${BOARD}.conf)

--- a/samples/net/lldp/CMakeLists.txt
+++ b/samples/net/lldp/CMakeLists.txt
@@ -1,5 +1,4 @@
 cmake_minimum_required(VERSION 3.8.2)
-set(KCONFIG_ROOT ${CMAKE_CURRENT_SOURCE_DIR}/Kconfig)
 
 macro(set_conf_file)
   if(EXISTS ${APPLICATION_SOURCE_DIR}/prj_${BOARD}.conf)

--- a/samples/net/sockets/echo_client/CMakeLists.txt
+++ b/samples/net/sockets/echo_client/CMakeLists.txt
@@ -1,5 +1,4 @@
 cmake_minimum_required(VERSION 3.8.2)
-set(KCONFIG_ROOT ${CMAKE_CURRENT_SOURCE_DIR}/Kconfig)
 
 macro(set_conf_file)
   if(EXISTS                 ${APPLICATION_SOURCE_DIR}/boards/${BOARD}.conf)

--- a/samples/net/sockets/echo_server/CMakeLists.txt
+++ b/samples/net/sockets/echo_server/CMakeLists.txt
@@ -1,5 +1,4 @@
 cmake_minimum_required(VERSION 3.8.2)
-set(KCONFIG_ROOT ${CMAKE_CURRENT_SOURCE_DIR}/Kconfig)
 
 macro(set_conf_file)
   if(EXISTS                 ${APPLICATION_SOURCE_DIR}/boards/${BOARD}.conf)

--- a/samples/net/stats/CMakeLists.txt
+++ b/samples/net/stats/CMakeLists.txt
@@ -1,5 +1,4 @@
 cmake_minimum_required(VERSION 3.8.2)
-set(KCONFIG_ROOT ${CMAKE_CURRENT_SOURCE_DIR}/Kconfig)
 
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
 project(NONE)

--- a/samples/net/traffic_class/CMakeLists.txt
+++ b/samples/net/traffic_class/CMakeLists.txt
@@ -1,5 +1,4 @@
 cmake_minimum_required(VERSION 3.8.2)
-set(KCONFIG_ROOT ${CMAKE_CURRENT_SOURCE_DIR}/Kconfig)
 
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
 project(NONE)

--- a/samples/net/vlan/CMakeLists.txt
+++ b/samples/net/vlan/CMakeLists.txt
@@ -1,5 +1,4 @@
 cmake_minimum_required(VERSION 3.8.2)
-set(KCONFIG_ROOT ${CMAKE_CURRENT_SOURCE_DIR}/Kconfig)
 
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
 project(NONE)

--- a/samples/net/wifi/CMakeLists.txt
+++ b/samples/net/wifi/CMakeLists.txt
@@ -1,5 +1,4 @@
 cmake_minimum_required(VERSION 3.8.2)
-set(KCONFIG_ROOT ${CMAKE_CURRENT_SOURCE_DIR}/Kconfig)
 
 macro(set_conf_file)
   if(EXISTS         ${APPLICATION_SOURCE_DIR}/prj_${BOARD}.conf)

--- a/samples/subsys/logging/logger/CMakeLists.txt
+++ b/samples/subsys/logging/logger/CMakeLists.txt
@@ -1,6 +1,5 @@
 cmake_minimum_required(VERSION 3.8.2)
 
-set(KCONFIG_ROOT ${CMAKE_CURRENT_SOURCE_DIR}/Kconfig)
 
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
 project(NONE)

--- a/tests/benchmarks/object_footprint/CMakeLists.txt
+++ b/tests/benchmarks/object_footprint/CMakeLists.txt
@@ -1,5 +1,4 @@
 cmake_minimum_required(VERSION 3.8.2)
-set(KCONFIG_ROOT ${CMAKE_CURRENT_SOURCE_DIR}/Kconfig)
 
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
 project(NONE)

--- a/tests/drivers/i2c/i2c_slave_api/CMakeLists.txt
+++ b/tests/drivers/i2c/i2c_slave_api/CMakeLists.txt
@@ -1,5 +1,4 @@
 cmake_minimum_required(VERSION 3.8.2)
-set(KCONFIG_ROOT ${CMAKE_CURRENT_SOURCE_DIR}/Kconfig)
 
 macro(set_conf_file)
   if(EXISTS               ${APPLICATION_SOURCE_DIR}/boards/${BOARD}.conf)

--- a/tests/drivers/spi/spi_loopback/CMakeLists.txt
+++ b/tests/drivers/spi/spi_loopback/CMakeLists.txt
@@ -1,5 +1,4 @@
 cmake_minimum_required(VERSION 3.8.2)
-set(KCONFIG_ROOT ${CMAKE_CURRENT_SOURCE_DIR}/Kconfig)
 
 macro(set_conf_file)
   if(EXISTS         ${APPLICATION_SOURCE_DIR}/prj_${BOARD}.conf)

--- a/tests/kernel/arm_irq_vector_table/CMakeLists.txt
+++ b/tests/kernel/arm_irq_vector_table/CMakeLists.txt
@@ -1,5 +1,4 @@
 cmake_minimum_required(VERSION 3.8.2)
-set(KCONFIG_ROOT ${CMAKE_CURRENT_SOURCE_DIR}/Kconfig)
 
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
 project(NONE)


### PR DESCRIPTION
Automatically detect the Kconfig file in it's conventional placement
${APPLICATION_SOURCE_DIR}/Kconfig and set KCONFIG_ROOT accordingly.

'Convention over configuration' is an imporant principle for
minimizing metadata and keeping things consistent. We use this
principle for instance with the file prj.conf.

This commit applies this principle to also re-direct KCONFIG_ROOT.

This feature is backwards-compatible with existing applications that may or may not set KCONFIG_ROOT.