### PR TITLE
kernel: Fix compilation errors when CONFIG_TIMESLICING=n

### DIFF
--- a/kernel/include/ksched.h
+++ b/kernel/include/ksched.h
@@ -47,7 +47,10 @@ void *_get_next_switch_handle(void *interrupted);
 struct k_thread *_find_first_thread_to_unpend(_wait_q_t *wait_q,
 					      struct k_thread *from);
 void idle(void *a, void *b, void *c);
+
+#ifdef CONFIG_TIMESLICING
 void z_reset_timeslice(void);
+#endif
 
 /* find which one is the next thread to run */
 /* must be called with interrupts locked */
@@ -223,7 +226,8 @@ static inline void _ready_thread(struct k_thread *thread)
 		_add_thread_to_ready_q(thread);
 	}
 
-#if defined(CONFIG_TICKLESS_KERNEL) && !defined(CONFIG_SMP)
+#if defined(CONFIG_TICKLESS_KERNEL) && !defined(CONFIG_SMP) && \
+    defined(CONFIG_TIMESLICING)
 	z_reset_timeslice();
 #endif
 

--- a/tests/benchmarks/footprint/src/main.c
+++ b/tests/benchmarks/footprint/src/main.c
@@ -133,7 +133,9 @@ static pfunc func_array[] = {
 	(pfunc)k_thread_priority_set,
 	(pfunc)k_thread_suspend,
 	(pfunc)k_thread_resume,
+#ifdef CONFIG_TIMESLICING
 	(pfunc)k_sched_time_slice_set,
+#endif
 	(pfunc)k_is_in_isr,
 	(pfunc)k_thread_custom_data_set,
 	(pfunc)k_thread_custom_data_get,


### PR DESCRIPTION
Add ifdef guard to the z_reset_timeslice() to fix compilation
errors when CONFIG_TIMESLICING is disabled.

Signed-off-by: Daniel Leung <daniel.leung@intel.com>