### PR TITLE
Bluetooth: samples/peripheral_sc_only: Improve logging

### DIFF
--- a/samples/bluetooth/peripheral_sc_only/prj.conf
+++ b/samples/bluetooth/peripheral_sc_only/prj.conf
@@ -1,4 +1,9 @@
+# Uncomment the following two options to get thread stack usage logs
+#CONFIG_INIT_STACKS=y
+#CONFIG_THREAD_STACK_INFO=y
+
 CONFIG_BT=y
+CONFIG_BT_DEBUG_LOG=y
 CONFIG_BT_PERIPHERAL=y
 CONFIG_BT_SMP=y
 CONFIG_BT_SMP_SC_ONLY=y

--- a/samples/bluetooth/peripheral_sc_only/src/main.c
+++ b/samples/bluetooth/peripheral_sc_only/src/main.c
@@ -97,10 +97,23 @@ static void auth_cancel(struct bt_conn *conn)
 	printk("Pairing cancelled: %s\n", addr);
 }
 
+static void pairing_complete(struct bt_conn *conn, bool bonded)
+{
+	printk("Pairing Complete\n");
+}
+
+static void pairing_failed(struct bt_conn *conn)
+{
+	printk("Pairing Failed. Disconnecting.\n");
+	bt_conn_disconnect(conn, BT_HCI_ERR_AUTHENTICATION_FAIL);
+}
+
 static struct bt_conn_auth_cb auth_cb_display = {
 	.passkey_display = auth_passkey_display,
 	.passkey_entry = NULL,
 	.cancel = auth_cancel,
+	.pairing_complete = pairing_complete,
+	.pairing_failed = pairing_failed,
 };
 
 void main(void)


### PR DESCRIPTION
The periphreal_sc_only sample app wasn't very clearly logging
information about pairing failures and could give the false
impression that everything work when it doesn't. Enable some more
logging Kconfig features and take advantage of the pairing complete &
failed callbacks to give more information to the user.

Signed-off-by: Johan Hedberg <johan.hedberg@intel.com>