### PR TITLE
subsys: logger: fix merge error

### DIFF
--- a/subsys/logging/CMakeLists.txt
+++ b/subsys/logging/CMakeLists.txt
@@ -18,3 +18,8 @@ zephyr_sources_ifdef(
   CONFIG_LOG_CMDS
   log_cmds.c
   )
+
+zephyr_sources_ifdef(
+  CONFIG_LOG_BACKEND_NATIVE_POSIX
+  log_backend_native_posix.c
+  )


### PR DESCRIPTION
Fix merge error introduced in:
ba01a3952f2180d51c514dd08ff07b1cb7d5e180
(as part of #9362)
which deleted the native_posix backend for the logger.

Signed-off-by: Alberto Escolar Piedras <alpi@oticon.com>

Partially f ixes #10164
Needed by #10163