### PR TITLE
lib: posix: fix error code returns

### DIFF
--- a/lib/posix/pthread.c
+++ b/lib/posix/pthread.c
@@ -296,8 +296,14 @@ int pthread_attr_init(pthread_attr_t *attr)
 int pthread_getschedparam(pthread_t pthread, int *policy,
 			  struct sched_param *param)
 {
-	k_tid_t thread = (k_tid_t)pthread;
-	u32_t  priority = k_thread_priority_get(thread);
+	struct posix_thread *thread = (struct posix_thread *) pthread;
+	u32_t priority;
+
+	if (thread == NULL || thread->state == PTHREAD_TERMINATED) {
+		return ESRCH;
+	}
+
+	priority = k_thread_priority_get((k_tid_t) thread);
 
 	param->priority = zephyr_to_posix_priority(priority, policy);
 	return 0;

--- a/lib/posix/pthread.c
+++ b/lib/posix/pthread.c
@@ -143,9 +143,12 @@ int pthread_create(pthread_t *newthread, const pthread_attr_t *attr,
 	 * pointer and stack size. So even though POSIX 1003.1 spec accepts
 	 * attrib as NULL but zephyr needs it initialized with valid stack.
 	 */
-	if (!attr || !attr->initialized || !attr->stack || !attr->stacksize ||
-		(pthread_num >= CONFIG_MAX_PTHREAD_COUNT)) {
+	if (!attr || !attr->initialized || !attr->stack || !attr->stacksize) {
 		return EINVAL;
+	}
+
+	if (pthread_num >= CONFIG_MAX_PTHREAD_COUNT) {
+		return EAGAIN;
 	}
 
 	prio = posix_to_zephyr_priority(attr->priority, attr->schedpolicy);

--- a/lib/posix/pthread.c
+++ b/lib/posix/pthread.c
@@ -86,12 +86,9 @@ int pthread_attr_setschedparam(pthread_attr_t *attr,
 {
 	int priority = schedparam->priority;
 
-	if (!attr || !attr->initialized) {
+	if (!attr || !attr->initialized ||
+	    (is_posix_prio_valid(priority, attr->schedpolicy) == false)) {
 		return EINVAL;
-	}
-
-	if (is_posix_prio_valid(priority, attr->schedpolicy) == false) {
-		return ENOTSUP;
 	}
 
 	attr->priority = priority;


### PR DESCRIPTION
Added or fixed appropriate returns of error
codes wherever possible in pthread.c file.

Part of fix for #9993

Signed-off-by: Niranjhana N <niranjhana.n@intel.com>