### PR TITLE
CODEOWNERS: Assing maintainer for all native_posix backends

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -200,6 +200,7 @@ subsys/net/lib/lwm2m/                    @mike-scott
 subsys/net/lib/mqtt/                     @jukkar @tbursztyka
 subsys/net/lib/coap/                     @rveerama1
 subsys/net/lib/sockets/                  @jukkar @tbursztyka @pfalcon
+subsys/*/*native_posix*/                 @aescolar
 subsys/usb/                              @jfischer-phytec-iot @finikorg
 tests/boards/native_posix/               @aescolar
 tests/bluetooth/                         @sjanc @jhedberg @Vudentz @tarunkum


### PR DESCRIPTION
Assign aescolar as maintainer for all native_posix subsys
backends/components/modules

Signed-off-by: Alberto Escolar Piedras <alpi@oticon.com>