### PR TITLE
arch: arm: Minor style and typo fixes in inline comments

### DIFF
--- a/arch/arm/core/thread.c
+++ b/arch/arm/core/thread.c
@@ -125,7 +125,7 @@ FUNC_NORETURN void _arch_user_mode_enter(k_thread_entry_t user_entry,
 	_current->arch.priv_stack_size =
 		(u32_t)CONFIG_PRIVILEGED_STACK_SIZE;
 
-	/* FIXME: Need a general API for aligning stacks so thet the initial
+	/* FIXME: Need a general API for aligning stacks so that the initial
 	 * user thread stack pointer doesn't overshoot the granularity of MPU
 	 * regions, that works for ARM/NXP/QEMU.
 	 */

--- a/include/arch/arm/arch.h
+++ b/include/arch/arm/arch.h
@@ -10,7 +10,7 @@
  *
  * This header contains the ARM specific kernel interface.  It is
  * included by the kernel interface architecture-abstraction header
- * (include/arc/cpu.h)
+ * (include/arm/cpu.h)
  */
 
 #ifndef ZEPHYR_INCLUDE_ARCH_ARM_ARCH_H_
@@ -54,11 +54,11 @@ extern "C" {
 /**
  * @brief Declare a minimum MPU guard alignment and size
  *
- * This specifies the minimum MPU guard alignment/size for the MPU.  This
+ * This specifies the minimum MPU guard alignment/size for the MPU. This
  * will be used to denote the guard section of the stack, if it exists.
  *
  * One key note is that this guard results in extra bytes being added to
- * the stack.  APIs which give the stack ptr and stack size will take this
+ * the stack. APIs which give the stack ptr and stack size will take this
  * guard size into account.
  *
  * Stack is allocated, but initial stack pointer is at the end
@@ -121,7 +121,7 @@ extern "C" {
 		1 << (31 - __builtin_clz(x)))
 
 /**
- * @brief Declare a toplevel thread stack memory region
+ * @brief Declare a top level thread stack memory region
  *
  * This declares a region of memory suitable for use as a thread's stack.
  *
@@ -169,7 +169,7 @@ extern "C" {
 #endif
 
 /**
- * @brief Declare a toplevel array of thread stack memory regions
+ * @brief Declare a top level array of thread stack memory regions
  *
  * Create an array of equally sized stacks. See K_THREAD_STACK_DEFINE
  * definition for additional details and constraints.

--- a/kernel/thread.c
+++ b/kernel/thread.c
@@ -562,7 +562,7 @@ void _k_thread_single_abort(struct k_thread *thread)
 	sys_trace_thread_abort(thread);
 
 #ifdef CONFIG_USERSPACE
-	/* Clear initailized state so that this thread object may be re-used
+	/* Clear initialized state so that this thread object may be re-used
 	 * and triggers errors if API calls are made on it from user threads
 	 */
 	_k_object_uninit(thread->stack_obj);


### PR DESCRIPTION
Several style and typo fixes in inline comments of arm kernel
files and thread.c.

Signed-off-by: Ioannis Glaropoulos <Ioannis.Glaropoulos@nordicsemi.no>