### PR TITLE
cmake: Add quotes to handle missing ZEPHYR_TOOLCHAIN_VARIANT variable

### DIFF
--- a/cmake/toolchain.cmake
+++ b/cmake/toolchain.cmake
@@ -34,7 +34,7 @@ if(NOT ZEPHYR_TOOLCHAIN_VARIANT)
 endif()
 
 # Until we completely deprecate it
-if(${ZEPHYR_TOOLCHAIN_VARIANT} STREQUAL "gccarmemb")
+if("${ZEPHYR_TOOLCHAIN_VARIANT}" STREQUAL "gccarmemb")
   message(WARNING "gccarmemb is deprecated, please use gnuarmemb instead")
   set(ZEPHYR_TOOLCHAIN_VARIANT "gnuarmemb")
 endif()


### PR DESCRIPTION
If this environment variable is missing, the user gets a rather confusing
cmake error message about  "STREQUAL" "gccarmemb" from the lines below it.

This explicit check makes it more obvious what is missing.