### PR TITLE
ci: Fix potential CI CMake failure

### DIFF
--- a/.shippable.yml
+++ b/.shippable.yml
@@ -77,7 +77,8 @@ build:
            echo "Dumping the capability database in case we are affected by #9992"
            cat $HOME/.cache/zephyr/ToolchainCapabilityDatabase.cmake
          fi;
-      - rm -rf ccache $HOME/.cache/zephyr
+      - rm -rf ccache
+      - rm $HOME/.cache/zephyr/*
       - mkdir -p shippable/testresults
       - mkdir -p shippable/codecoverage
       - source zephyr-env.sh
@@ -102,7 +103,8 @@ build:
             cp ./scripts/sanity_chk/last_sanity.xml shippable/testresults/;
           fi;
     on_success:
-      - rm -rf ccache $HOME/.cache/zephyr
+      - rm -rf ccache
+      - rm $HOME/.cache/zephyr/*
       - mkdir -p shippable/testresults
       - mkdir -p shippable/codecoverage
       - source zephyr-env.sh


### PR DESCRIPTION
When CMake appends text to a file, and the directory to the file does
not exist, it first creates the directory and then the file. Equivalent to this:

mkdir -p $path && echo "foo" > $path/file.txt

If the directory is deleted in the interim of the directory being
created and the file being written a CMake and CI failure will occur.

To safeguard against this potential failure we avoid deleting the
directory in CI.

Signed-off-by: Sebastian Bøe <sebastian.boe@nordicsemi.no>