### PR TITLE
 tests: i2c_slave_api: Add missing testcase.yaml

### DIFF
--- a/boards/arm/nucleo_f091rc/nucleo_f091rc.yaml
+++ b/boards/arm/nucleo_f091rc/nucleo_f091rc.yaml
@@ -7,3 +7,5 @@ toolchain:
   - gnuarmemb
 ram: 32
 flash: 256
+supported:
+  - i2c

--- a/tests/drivers/i2c/i2c_slave_api/testcase.yaml
+++ b/tests/drivers/i2c/i2c_slave_api/testcase.yaml
@@ -1,0 +1,5 @@
+tests:
+  peripheral.i2c_slave:
+    depends_on: i2c
+    tags: drivers i2c
+    platform_whitelist: nucleo_f091rc stm32f072b_disco


### PR DESCRIPTION
The i2c_slave_api test was missing a testcase.yaml and therefore not
getting built by CI.