### PR TITLE
logging: Add mechanism for logging in headers

### DIFF
--- a/doc/subsystems/logging/logger.rst
+++ b/doc/subsystems/logging/logger.rst
@@ -159,6 +159,26 @@ appear in exactly one of them. Each other file should use
    #include <logging/log.h>
    LOG_MODULE_DECLARE(foo); /* In all files comprising the module but one */
 
+In order to use the logger in the header file,
+:c:macro:`LOG_MODULE_DECLARE_IN_HEADER` must be used. Additionally, macro must
+be preceded by definition of LOG_IN_HEADER and LOG_LEVEL. Both defines must be
+undefined at the bottom of the file.
+
+.. code-block:: c
+
+   #include <logging/log.h>
+   #define LOG_LEVEL CONFIG_FOO_LOG_LEVEL /* From foo module Kconfig */
+   #define LOG_IN_HEADER 1
+   LOG_MODULE_DECLARE_IN_HEADER();
+
+   static inline void foo(void)
+   {
+   	LOG_DBG("foo");
+   }
+
+   #undef LOG_IN_HEADER
+   #undef LOG_LEVEL
+
 Dedicated Kconfig template (:file:`subsys/logging/Kconfig.template.log_config`)
 can be used to create local log level configuration.
 

--- a/include/logging/log.h
+++ b/include/logging/log.h
@@ -330,7 +330,15 @@ int log_printk(const char *fmt, va_list ap);
 		()						\
 		)
 
-#define _LOG_MODULE_DECLARE(_name, _level)				     \
+#define _LOG_RUNTIME_MODULE_IN_HEADER_DECLARE(_name)			\
+	_LOG_EVAL(							\
+		CONFIG_LOG_RUNTIME_FILTERING,				\
+		(; extern struct log_source_dynamic_data		\
+			LOG_ITEM_DYNAMIC_DATA(LOG_MODULE_NAME);),	\
+		()							\
+		)
+
+#define _LOG_MODULE_DECLARE(_name)					     \
 	extern const struct log_source_const_data LOG_ITEM_CONST_DATA(_name) \
 	_LOG_RUNTIME_MODULE_DECLARE(_name);				     \
 	static inline const struct log_source_const_data *		     \
@@ -338,6 +346,11 @@ int log_printk(const char *fmt, va_list ap);
 	{								     \
 		return &LOG_ITEM_CONST_DATA(_name);			     \
 	}
+
+#define _LOG_MODULE_IN_HEADER_DECLARE()					\
+	extern const struct log_source_const_data			\
+				LOG_ITEM_CONST_DATA(LOG_MODULE_NAME)	\
+	_LOG_RUNTIME_MODULE_IN_HEADER_DECLARE(LOG_MODULE_NAME)
 
 /**
  * @brief Macro for declaring a log module (not registering it).
@@ -356,12 +369,32 @@ int log_printk(const char *fmt, va_list ap);
  *       this macro has no effect.
  * @see LOG_MODULE_REGISTER
  */
-#define LOG_MODULE_DECLARE(log_module_name)				\
-	_LOG_EVAL(							\
-		_LOG_LEVEL(),						\
-		(_LOG_MODULE_DECLARE(log_module_name, _LOG_LEVEL())),	\
-		()							\
-		)							\
+#define LOG_MODULE_DECLARE(log_module_name)			\
+	_LOG_EVAL(						\
+		_LOG_LEVEL(),					\
+		(_LOG_MODULE_DECLARE(log_module_name)),		\
+		()						\
+		)						\
+
+
+/**
+ * @brief Macro for declaring a log module (not registering it) in the header.
+ *
+ * @note In order to use logging in a header, macro must be preceded by
+ * definition of LOG_IN_HEADER (\#define LOG_IN_HEADER 1). LOG_IN_HEADER must be
+ * undefined at the end of the header (\#undef LOG_IN_HEADER).
+ *
+ * @note The module's state is declared in the header only if LOG_LEVEL for the
+ *       current source file is non-zero or it is not defined and
+ *       CONFIG_LOG_DEFAULT_LOG_LEVEL is non-zero.  In other cases,
+ *       this macro has no effect.
+ * @see LOG_MODULE_REGISTER
+ */
+#define LOG_MODULE_IN_HEADER_DECLARE()				\
+		_LOG_LEVEL(),					\
+		(_LOG_MODULE_IN_HEADER_DECLARE()),		\
+		()						\
+		)						\
 
 /**
  * @}

--- a/include/logging/log_core.h
+++ b/include/logging/log_core.h
@@ -47,8 +47,8 @@ extern "C" {
 /**
  * @brief Macro for conditional code generation if provided log level allows.
  *
- * Macro behaves similarly to standard #if #else #endif clause. The difference is
- * that it is evaluated when used and not when header file is included.
+ * Macro behaves similarly to standard #if #else #endif clause. The difference
+ * is that it is evaluated when used and not when header file is included.
  *
  * @param _eval_level Evaluated level. If level evaluates to one of existing log
  *		      log level (1-4) then macro evaluates to _iftrue.
@@ -95,22 +95,50 @@ extern "C" {
  * @def LOG_CURRENT_MODULE_ID
  * @brief Macro for getting ID of current module.
  */
-#define LOG_CURRENT_MODULE_ID()						\
+
+#define LOG_CURRENT_MODULE_ID_DEFINE()					\
+	_LOG_EVAL(							\
+	  _LOG_LEVEL(),							\
+	  (log_const_source_id(&LOG_ITEM_CONST_DATA(LOG_MODULE_NAME))),	\
+	  (0)								\
+	)
+
+#define LOG_CURRENT_MODULE_ID_FUNC()					\
 	_LOG_EVAL(							\
 	  _LOG_LEVEL(),							\
 	  (log_const_source_id(__log_current_const_data_get())),	\
 	  (0)								\
 	)
 
+#define LOG_CURRENT_MODULE_ID() \
+	_LOG_EVAL(\
+	  IS_ENABLED(LOG_IN_HEADER),\
+	  (LOG_CURRENT_MODULE_ID_DEFINE()),\
+	  (LOG_CURRENT_MODULE_ID_FUNC())\
+	)
 /**
  * @def LOG_CURRENT_DYNAMIC_DATA_ADDR
  * @brief Macro for getting address of dynamic structure of current module.
  */
-#define LOG_CURRENT_DYNAMIC_DATA_ADDR()			\
+#define LOG_CURRENT_DYNAMIC_DATA_ADDR_DEFINE()		\
+	_LOG_EVAL(					\
+	  _LOG_LEVEL(),					\
+	  (&LOG_ITEM_DYNAMIC_DATA(LOG_MODULE_NAME)),	\
+	  ((struct log_source_dynamic_data *)0)		\
+	)
+
+#define LOG_CURRENT_DYNAMIC_DATA_ADDR_FUNC()		\
 	_LOG_EVAL(					\
 	  _LOG_LEVEL(),					\
 	  (__log_current_dynamic_data_get()),		\
 	  ((struct log_source_dynamic_data *)0)		\
+	)
+
+#define LOG_CURRENT_DYNAMIC_DATA_ADDR() \
+	_LOG_EVAL(\
+	  IS_ENABLED(LOG_IN_HEADER),\
+	  (LOG_CURRENT_DYNAMIC_DATA_ADDR_DEFINE()),\
+	  (LOG_CURRENT_DYNAMIC_DATA_ADDR_FUNC())\
 	)
 
 /** @brief Macro for getting ID of the element of the section.

--- a/samples/subsys/logging/logger/src/main.c
+++ b/samples/subsys/logging/logger/src/main.c
@@ -77,6 +77,7 @@ static void module_logging_showcase(void)
 {
 	printk("Module logging showcase.\n");
 
+	sample_module_inline_func();
 	sample_module_func();
 
 	if (IS_ENABLED(CONFIG_LOG_RUNTIME_FILTERING)) {
@@ -87,6 +88,7 @@ static void module_logging_showcase(void)
 			       log_source_id_get(sample_module_name_get()),
 			       LOG_LEVEL_NONE);
 
+		sample_module_inline_func();
 		sample_module_func();
 
 		printk("Function called again but with logging disabled.\n");

--- a/samples/subsys/logging/logger/src/sample_module.c
+++ b/samples/subsys/logging/logger/src/sample_module.c
@@ -6,13 +6,13 @@
 #include <zephyr.h>
 #include <logging/log.h>
 
-#define LOG_MODULE_NAME sample_module
+#define MODULE_NAME sample_module
 #define LOG_LEVEL CONFIG_SAMPLE_MODULE_LOG_LEVEL
-LOG_MODULE_REGISTER(LOG_MODULE_NAME);
+LOG_MODULE_REGISTER(MODULE_NAME);
 
 const char *sample_module_name_get(void)
 {
-	return STRINGIFY(LOG_MODULE_NAME);
+	return STRINGIFY(MODULE_NAME);
 }
 
 void sample_module_func(void)

--- a/samples/subsys/logging/logger/src/sample_module.h
+++ b/samples/subsys/logging/logger/src/sample_module.h
@@ -10,8 +10,23 @@
 extern "C" {
 #endif
 
+#include <logging/log.h>
+
+#define LOG_MODULE_NAME sample_module
+#define LOG_LEVEL CONFIG_SAMPLE_MODULE_LOG_LEVEL
+#define LOG_IN_HEADER 1
+LOG_MODULE_IN_HEADER_DECLARE();
+
 const char *sample_module_name_get(void);
 void sample_module_func(void);
+
+static inline void sample_module_inline_func(void)
+{
+	LOG_INF("inline logging");
+}
+
+#undef LOG_IN_HEADER /* Undef to indicate end of logging in the header. */
+#undef LOG_LEVEL
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
Extended logger to enable logging in inline functions in headers.

Mechanism is not super friendly but i don't see better one while keeping nice LOG_MODULE_REGISTER(name) macro. I assume we consider using logger in the headers less common than in source file thus we favor user friendliness of registeration/declaration in source file. 

See https://github.com/nordic-krch/zephyr/blob/34c940ca4a4dba45834cf1825123096d5ba09851/samples/subsys/logging/logger/src/sample_module.h for example usage.

Signed-off-by: Krzysztof Chruscinski <krzysztof.chruscinski@nordicsemi.no>