### PR TITLE
soc: arm: mps2: remove un-necessary Kconfig option selection

### DIFF
--- a/soc/arm/arm/mps2/Kconfig.soc
+++ b/soc/arm/arm/mps2/Kconfig.soc
@@ -12,6 +12,5 @@ config SOC_MPS2_AN385
 	bool "ARM Cortex-M3 SMM on V2M-MPS2 (Application Note AN385)"
 	select CPU_CORTEX_M3
 	select CPU_HAS_ARM_MPU
-	select MPU_REQUIRES_POWER_OF_TWO_ALIGNMENT
 
 endchoice


### PR DESCRIPTION
Remove the selection of MPU_REQUIRES_POWER_OF_TWO_ALIGNMENT
in SOC_MPS2_AN3385, as this is selected automatically by
ARM_MPU option (for ARMv7-M MCUs).

Signed-off-by: Ioannis Glaropoulos <Ioannis.Glaropoulos@nordicsemi.no>