### PR TITLE
Kconfig: BT: Give the LL selection option a name

### DIFF
--- a/subsys/bluetooth/controller/Kconfig
+++ b/subsys/bluetooth/controller/Kconfig
@@ -14,7 +14,7 @@ config BT_CTLR
 
 if BT_CTLR
 
-choice
+choice BT_LL_CHOICE
 	prompt "Bluetooth Link Layer Selection"
 	default BT_LL_SW
 	help


### PR DESCRIPTION
There is an unnamed choice for the BT link layer selection.

Giving the choice a name would allow multiple declarations of the
option and the ability to select out-of-tree LL's.

From the Kconfig documentation:

> If no [symbol] is associated with a choice, then you can not have multiple
> definitions of that choice. If a [symbol] is associated to the choice,
> then you may define the same choice (i.e. with the same entries) in another
> place.

Signed-off-by: Sebastian Bøe <sebastian.boe@nordicsemi.no>