### PR TITLE
subsys: shell: removing redundant assert

### DIFF
--- a/subsys/shell/shell.c
+++ b/subsys/shell/shell.c
@@ -148,7 +148,6 @@ static void cmd_get(const struct shell_cmd_entry *command, size_t lvl,
 		    struct shell_static_entry *d_entry)
 {
 	assert(entry != NULL);
-	assert(command != NULL);
 	assert(d_entry != NULL);
 
 	if (lvl == SHELL_CMD_ROOT_LVL) {


### PR DESCRIPTION
Removing assert that was crashing shell in allowed scenario.
For example the Tab button is pressed when command buffer is empty.

Update: This assert will always happen whenever the Tab button is pressed. It is because function `cmd_get` is called as long as there are no more commands available - assert condition.

Signed-off-by: Jakub Rzeszutko <jakub.rzeszutko@nordicsemi.no>