### PR TITLE
doc: add CODE_OF_CONDUCT doc

### DIFF
--- a/CODE_OF_CONDUCT.rst
+++ b/CODE_OF_CONDUCT.rst
@@ -1,0 +1,103 @@
+Contributor Covenant Code of Conduct
+####################################
+
+Our Pledge
+**********
+
+In the interest of fostering an open and welcoming environment, we as
+contributors and maintainers pledge to making participation in our
+project and our community a harassment-free experience for everyone,
+regardless of age, body size, disability, ethnicity, gender identity and
+expression, level of experience, nationality, personal appearance, race,
+religion, or sexual identity and orientation.
+
+Also refer to our
+`Zephyr project community guidelines
+<https://www.zephyrproject.org/developers/how-to-contribute/#community-guidelines>`__.
+
+Our Standards
+*************
+
+Examples of behavior that contributes to creating a positive environment include:
+
+* Using welcoming and inclusive language
+* Being respectful of differing viewpoints and experiences
+* Gracefully accepting constructive criticism
+* Focusing on what is best for the community
+* Showing empathy towards other community members
+
+Examples of unacceptable behavior by participants include:
+
+* The use of sexualized language or imagery and unwelcome sexual attention
+  or advances
+* Trolling, insulting/derogatory comments, and personal or political attacks
+* Public or private harassment
+* Publishing others' private information, such as a physical or
+  electronic address, without explicit permission
+* Other conduct which could reasonably be considered inappropriate in a
+  professional setting
+
+Our Responsibilities
+********************
+
+Project maintainers are responsible for clarifying the standards of
+acceptable behavior and are expected to take appropriate and fair
+corrective action in response to any instances of unacceptable behavior.
+
+Project maintainers have the right and responsibility to remove, edit,
+or reject comments, commits, code, wiki edits, issues, and other
+contributions that are not aligned to this Code of Conduct, or to ban
+temporarily or permanently any contributor for other behaviors that they
+deem inappropriate, threatening, offensive, or harmful.
+
+Scope
+*****
+
+This Code of Conduct applies both within project spaces and in public
+spaces when an individual is representing the project or its community.
+Examples of representing a project or community include using an
+official project e-mail address, posting via an official social media
+account, or acting as an appointed representative at an online or
+offline event. Representation of a project may be further defined and
+clarified by project maintainers and `project governing bodies
+<https://www.zephyrproject.org/about/organization/>`__.
+
+Enforcement
+***********
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may
+be reported by contacting the project team at info@zephyrproject.org.
+The project team will review and investigate all complaints, and will
+respond in a way that it deems appropriate to the circumstances. The
+project team is obligated to maintain confidentiality with regard to the
+reporter of an incident. Further details of specific enforcement
+policies may be posted separately.
+
+Project maintainers who do not follow or enforce the Code of Conduct in
+good faith may face temporary or permanent repercussions as determined
+by other members of the project's leadership and our Technical Steering
+Committee.
+
+Guideline Violations - Three Strikes Method
+===========================================
+
+We need a fair way to deal with people who are making our community an
+unpleasant place.
+
+- **First occurrence**:
+  Public reminder that the behavior is inappropriate according to our
+  guidelines.
+
+- **Second occurrence**:
+  Private message warning that any additional violations will
+  result in removal from the community.
+
+- **Third occurrence**:
+  Depending on the violation, may include account deletion or banning.
+
+
+Attribution
+***********
+
+This Code of Conduct is adapted from the `Contributor
+Covenant version 1.4 <http://contributor-covenant.org/version/1/4/>`__.


### PR DESCRIPTION
GitHub provides a template for Code of Conduct material based on
material from https://www.contributor-covenant.org/

Signed-off-by: David B. Kinder <david.b.kinder@intel.com>