### PR TITLE
shell: Fix invalid assert

### DIFF
--- a/subsys/shell/shell.c
+++ b/subsys/shell/shell.c
@@ -148,7 +148,6 @@ static void cmd_get(const struct shell_cmd_entry *command, size_t lvl,
 		    struct shell_static_entry *d_entry)
 {
 	assert(entry != NULL);
-	assert(command != NULL);
 	assert(d_entry != NULL);
 
 	if (lvl == SHELL_CMD_ROOT_LVL) {


### PR DESCRIPTION
It is valid to pass NULL as command to cmd_get, in fact this seems to
always happens when using tab to complete.

Signed-off-by: Luiz Augusto von Dentz <luiz.von.dentz@intel.com>