### PR TITLE
Bluetooth: host: always set address via HCI before scanning

### DIFF
--- a/subsys/bluetooth/host/hci_core.c
+++ b/subsys/bluetooth/host/hci_core.c
@@ -3095,6 +3095,8 @@ static int start_le_scan(u8_t scan_type, u16_t interval, u16_t window)
 			}
 
 			set_param.addr_type = BT_ADDR_LE_RANDOM;
+		} else if (set_param.addr_type == BT_ADDR_LE_RANDOM) {
+			set_random_address(&bt_dev.id_addr[0].a);
 		}
 	}
 


### PR DESCRIPTION
The address of the device is also set via HCI interface when passive
scanning is used. As a result, LL does not filter out directed
advertising packets that are targeted at this device.

Fixes #10208 