### PR TITLE
subsys: bluetooth: shell: bt: Add command to show LL address

### DIFF
--- a/subsys/bluetooth/shell/bt.c
+++ b/subsys/bluetooth/shell/bt.c
@@ -6,6 +6,7 @@
 
 /*
  * Copyright (c) 2017 Intel Corporation
+ * Copyright (c) 2018 Nordic Semiconductor ASA
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -1404,6 +1405,9 @@ SHELL_CREATE_STATIC_SUBCMD_SET(bt_cmds) {
 	SHELL_CMD(advx, NULL, "<on off> [coded] [anon] [txp]", cmd_advx),
 	SHELL_CMD(scanx, NULL, "<on passive off> [coded]", cmd_scanx),
 #endif /* CONFIG_BT_CTLR_ADV_EXT */
+#if defined(CONFIG_BT_LL_SW)
+	SHELL_CMD(ll-addr, NULL, "<random|public>", cmd_ll_addr_get),
+#endif
 #if defined(CONFIG_BT_CTLR_DTM)
 	SHELL_CMD(test_tx, NULL, "<chan> <len> <type> <phy>", cmd_test_tx),
 	SHELL_CMD(test_rx, NULL, "<chan> <phy> <mod_idx>", cmd_test_rx),

--- a/subsys/bluetooth/shell/ll.c
+++ b/subsys/bluetooth/shell/ll.c
@@ -23,6 +23,34 @@
 
 #include "bt.h"
 
+int cmd_ll_addr_get(const struct shell *shell, size_t argc, char *argv[])
+{
+	u8_t addr_type;
+	const char *str_type;
+	bt_addr_t addr;
+	char str_addr[BT_ADDR_STR_LEN];
+
+	if (argc < 2) {
+		return -EINVAL;
+	}
+
+	str_type = argv[1];
+	if (!strcmp(str_type, "random")) {
+		addr_type = 1;
+	} else if (!strcmp(str_type, "public")) {
+		addr_type = 0;
+	} else {
+		return -EINVAL;
+	}
+
+	(void)ll_addr_get(addr_type, addr.val);
+	bt_addr_to_str(&addr, str_addr, sizeof(str_addr));
+
+	print(shell, "Current %s address: %s\n", str_type, str_addr);
+
+	return 0;
+}
+
 #if defined(CONFIG_BT_CTLR_DTM)
 #include "../controller/ll_sw/ll_test.h"
 

--- a/subsys/bluetooth/shell/ll.h
+++ b/subsys/bluetooth/shell/ll.h
@@ -13,6 +13,8 @@
 #ifndef __LL_H
 #define __LL_H
 
+int cmd_ll_addr_get(const struct shell *shell, size_t argc, char *argv[]);
+
 int cmd_advx(const struct shell *shell, size_t  argc, char *argv[]);
 int cmd_scanx(const struct shell *shell, size_t  argc, char *argv[]);
 


### PR DESCRIPTION
This commit implements command in the shell to show current
link layer address.

Signed-off-by: Radoslaw Koppel <radoslaw.koppel@nordicsemi.no>