### PR TITLE
logging in headers + LOG_MODULE_REGISTER/DECLARE refactoring

### DIFF
--- a/arch/arc/core/mpu/arc_core_mpu.c
+++ b/arch/arc/core/mpu/arc_core_mpu.c
@@ -9,10 +9,9 @@
 #include <kernel.h>
 #include <soc.h>
 #include <arch/arc/v2/mpu/arc_core_mpu.h>
-
-#define LOG_LEVEL CONFIG_MPU_LOG_LEVEL
 #include <logging/log.h>
-LOG_MODULE_REGISTER(mpu);
+
+LOG_MODULE_REGISTER(mpu, CONFIG_MPU_LOG_LEVEL);
 
 /*
  * @brief Configure MPU for the thread

--- a/arch/arc/core/mpu/arc_mpu.c
+++ b/arch/arc/core/mpu/arc_mpu.c
@@ -12,10 +12,9 @@
 #include <arch/arc/v2/mpu/arc_mpu.h>
 #include <arch/arc/v2/mpu/arc_core_mpu.h>
 #include <linker/linker-defs.h>
-
-#define LOG_LEVEL CONFIG_MPU_LOG_LEVEL
 #include <logging/log.h>
-LOG_MODULE_DECLARE(mpu);
+
+LOG_MODULE_DECLARE(mpu, CONFIG_MPU_LOG_LEVEL);
 
 #define AUX_MPU_RDB_VALID_MASK (0x1)
 #define AUX_MPU_EN_ENABLE   (0x40000000)

--- a/arch/arm/core/cortex_m/mpu/arm_core_mpu.c
+++ b/arch/arm/core/cortex_m/mpu/arm_core_mpu.c
@@ -10,10 +10,9 @@
 #include <soc.h>
 #include <arch/arm/cortex_m/cmsis.h>
 #include <arch/arm/cortex_m/mpu/arm_core_mpu.h>
-
-#define LOG_LEVEL CONFIG_MPU_LOG_LEVEL
 #include <logging/log.h>
-LOG_MODULE_REGISTER(mpu);
+
+LOG_MODULE_REGISTER(mpu, CONFIG_MPU_LOG_LEVEL);
 
 #if defined(CONFIG_MPU_STACK_GUARD)
 /*

--- a/arch/arm/core/cortex_m/mpu/arm_mpu.c
+++ b/arch/arm/core/cortex_m/mpu/arm_mpu.c
@@ -12,10 +12,9 @@
 #include <arch/arm/cortex_m/mpu/arm_mpu.h>
 #include <arch/arm/cortex_m/mpu/arm_core_mpu.h>
 #include <linker/linker-defs.h>
-
-#define LOG_LEVEL CONFIG_MPU_LOG_LEVEL
 #include <logging/log.h>
-LOG_MODULE_DECLARE(mpu);
+
+LOG_MODULE_DECLARE(mpu, CONFIG_MPU_LOG_LEVEL);
 
 #if defined(CONFIG_CPU_CORTEX_M0PLUS) || \
 	defined(CONFIG_CPU_CORTEX_M3) || \

--- a/arch/arm/core/cortex_m/mpu/nxp_mpu.c
+++ b/arch/arm/core/cortex_m/mpu/nxp_mpu.c
@@ -12,10 +12,9 @@
 #include <arch/arm/cortex_m/mpu/nxp_mpu.h>
 #include <misc/__assert.h>
 #include <linker/linker-defs.h>
-
-#define LOG_LEVEL CONFIG_MPU_LOG_LEVEL
 #include <logging/log.h>
-LOG_MODULE_DECLARE(mpu);
+
+LOG_MODULE_DECLARE(mpu, CONFIG_MPU_LOG_LEVEL);
 
 /* NXP MPU Enabled state */
 static u8_t nxp_mpu_enabled;

--- a/doc/subsystems/logging/logger.rst
+++ b/doc/subsystems/logging/logger.rst
@@ -150,23 +150,45 @@ Logging in a module
 In order to use logger in the module, a unique name of a module must be
 specified and module must be registered with the logger core using
 :c:macro:`LOG_MODULE_REGISTER`. Optionally, a compile time log level for the
-module can be specified as well.
+module can be specified as the second parameter. Default log level
+(:option:`CONFIG_LOG_DEFAULT_LEVEL`) is used if custom log level is not
+provided.
 
 .. code-block:: c
 
-   #define LOG_LEVEL CONFIG_FOO_LOG_LEVEL /* From foo module Kconfig */
    #include <logging/log.h>
-   LOG_MODULE_REGISTER(foo); /* One per given log_module_name */
+   LOG_MODULE_REGISTER(foo, CONFIG_FOO_LOG_LEVEL);
 
 If the module consists of multiple files, then ``LOG_MODULE_REGISTER()`` should
 appear in exactly one of them. Each other file should use
 :c:macro:`LOG_MODULE_DECLARE` to declare its membership in the module.
+Optionally, a compile time log level for the module can be specified as
+the second parameter. Default log level (:option:`CONFIG_LOG_DEFAULT_LEVEL`)
+is used if custom log level is not provided.
 
 .. code-block:: c
 
-   #define LOG_LEVEL CONFIG_FOO_LOG_LEVEL /* From foo module Kconfig */
    #include <logging/log.h>
-   LOG_MODULE_DECLARE(foo); /* In all files comprising the module but one */
+   /* In all files comprising the module but one */
+   LOG_MODULE_DECLARE(foo, CONFIG_FOO_LOG_LEVEL);
+
+In order to use logger API in a function implemented in a header file
+:c:macro:`LOG_MODULE_DECLARE` macro must be used in the function body
+before logger API is called. Optionally, a compile time log level for the module
+can be specified as the second parameter. Default log level
+(:option:`CONFIG_LOG_DEFAULT_LEVEL`) is used if custom log level is not
+provided.
+
+.. code-block:: c
+
+   #include <logging/log.h>
+
+   static inline void foo(void)
+   {
+   	LOG_MODULE_DECLARE(foo, CONFIG_FOO_LOG_LEVEL);
+
+   	LOG_INF("foo");
+   }
 
 Dedicated Kconfig template (:file:`subsys/logging/Kconfig.template.log_config`)
 can be used to create local log level configuration.
@@ -216,12 +238,27 @@ In order to use instance level filtering following steps must be performed:
 Note that when logger is disabled logger instance and pointer to that instance
 are not created.
 
-- logger can be used in function
+In order to use the instance logging API in a source file, a compile-time log
+level must be set using :c:macro:`LOG_LEVEL_SET`.
 
 .. code-block:: c
 
+   LOG_LEVEL_SET(CONFIG_FOO_LOG_LEVEL);
+
    void foo_init(foo_object *f)
    {
+   	LOG_INST_INF(f->log, "Initialized.");
+   }
+
+In order to use the instance logging API in a header file, a compile-time log
+level must be set using :c:macro:`LOG_LEVEL_SET`.
+
+.. code-block:: c
+
+   static inline void foo_init(foo_object *f)
+   {
+   	LOG_LEVEL_SET(CONFIG_FOO_LOG_LEVEL);
+
    	LOG_INST_INF(f->log, "Initialized.");
    }
 

--- a/drivers/adc/adc_dw.c
+++ b/drivers/adc/adc_dw.c
@@ -15,14 +15,13 @@
 #include <soc.h>
 #include <adc.h>
 #include <arch/cpu.h>
+#include <logging/log.h>
 
 #define ADC_CONTEXT_USES_KERNEL_TIMER
 #include "adc_context.h"
 #include "adc_dw.h"
 
-#define LOG_LEVEL CONFIG_ADC_LOG_LEVEL
-#include <logging/log.h>
-LOG_MODULE_REGISTER(adc_dw);
+LOG_MODULE_REGISTER(adc_dw, CONFIG_ADC_LOG_LEVEL);
 
 #define ADC_CLOCK_GATE      (1 << 31)
 #define ADC_DEEP_POWER_DOWN  0x01

--- a/drivers/adc/adc_intel_quark_d2000.c
+++ b/drivers/adc/adc_intel_quark_d2000.c
@@ -13,10 +13,9 @@
 #include <soc.h>
 #include <adc.h>
 #include <arch/cpu.h>
-
-#define LOG_LEVEL CONFIG_ADC_LOG_LEVEL
 #include <logging/log.h>
-LOG_MODULE_REGISTER(adc_intel_quark_d2000);
+
+LOG_MODULE_REGISTER(adc_intel_quark_d2000, CONFIG_ADC_LOG_LEVEL);
 
 #define ADC_CONTEXT_USES_KERNEL_TIMER
 #include "adc_context.h"

--- a/drivers/adc/adc_mcux_adc16.c
+++ b/drivers/adc/adc_mcux_adc16.c
@@ -7,10 +7,9 @@
 #include <errno.h>
 #include <adc.h>
 #include <fsl_adc16.h>
-
-#define LOG_LEVEL CONFIG_ADC_LOG_LEVEL
 #include <logging/log.h>
-LOG_MODULE_REGISTER(adc_mcux_adc16);
+
+LOG_MODULE_REGISTER(adc_mcux_adc16, CONFIG_ADC_LOG_LEVEL);
 
 #define ADC_CONTEXT_USES_KERNEL_TIMER
 #include "adc_context.h"

--- a/drivers/adc/adc_nrfx_adc.c
+++ b/drivers/adc/adc_nrfx_adc.c
@@ -7,10 +7,9 @@
 #define ADC_CONTEXT_USES_KERNEL_TIMER
 #include "adc_context.h"
 #include <nrfx_adc.h>
-
-#define LOG_LEVEL CONFIG_ADC_LOG_LEVEL
 #include <logging/log.h>
-LOG_MODULE_REGISTER(adc_mcux_adc16);
+
+LOG_MODULE_REGISTER(adc_mcux_adc16, CONFIG_ADC_LOG_LEVEL);
 
 struct driver_data {
 	struct adc_context ctx;

--- a/drivers/adc/adc_nrfx_saadc.c
+++ b/drivers/adc/adc_nrfx_saadc.c
@@ -7,10 +7,9 @@
 #define ADC_CONTEXT_USES_KERNEL_TIMER
 #include "adc_context.h"
 #include <hal/nrf_saadc.h>
-
-#define LOG_LEVEL CONFIG_ADC_LOG_LEVEL
 #include <logging/log.h>
-LOG_MODULE_REGISTER(adc_nrfx_saadc);
+
+LOG_MODULE_REGISTER(adc_nrfx_saadc, CONFIG_ADC_LOG_LEVEL);
 
 struct driver_data {
 	struct adc_context ctx;

--- a/drivers/adc/adc_sam_afec.c
+++ b/drivers/adc/adc_sam_afec.c
@@ -19,13 +19,12 @@
 #include <init.h>
 #include <soc.h>
 #include <adc.h>
+#include <logging/log.h>
 
 #define ADC_CONTEXT_USES_KERNEL_TIMER
 #include "adc_context.h"
 
-#define LOG_LEVEL CONFIG_ADC_LOG_LEVEL
-#include <logging/log.h>
-LOG_MODULE_REGISTER(adc_sam_afec);
+LOG_MODULE_REGISTER(adc_sam_afec, CONFIG_ADC_LOG_LEVEL);
 
 #define NUM_CHANNELS 12
 

--- a/drivers/adc/adc_ti_adc108s102.c
+++ b/drivers/adc/adc_ti_adc108s102.c
@@ -12,11 +12,10 @@
 #include <misc/util.h>
 #include <string.h>
 #include <init.h>
-
-#include "adc_ti_adc108s102.h"
-#define LOG_LEVEL CONFIG_ADC_LOG_LEVEL
 #include <logging/log.h>
-LOG_MODULE_REGISTER(adc_ti_adc108s102);
+#include "adc_ti_adc108s102.h"
+
+LOG_MODULE_REGISTER(adc_ti_adc108s102, CONFIG_ADC_LOG_LEVEL);
 
 static inline int _ti_adc108s102_sampling(struct device *dev)
 {

--- a/drivers/audio/tlv320dac310x.c
+++ b/drivers/audio/tlv320dac310x.c
@@ -10,13 +10,11 @@
 
 #include <device.h>
 #include <i2c.h>
-
 #include <audio/codec.h>
+#include <logging/log.h>
 #include "tlv320dac310x.h"
 
-#define LOG_LEVEL CONFIG_AUDIO_CODEC_LOG_LEVEL
-#include <logging/log.h>
-LOG_MODULE_REGISTER(tlv320dac310x);
+LOG_MODULE_REGISTER(tlv320dac310x, CONFIG_AUDIO_CODEC_LOG_LEVEL);
 
 #define CODEC_OUTPUT_VOLUME_MAX		0
 #define CODEC_OUTPUT_VOLUME_MIN		(-78 * 2)

--- a/drivers/can/stm32_can.c
+++ b/drivers/can/stm32_can.c
@@ -13,10 +13,9 @@
 #include <errno.h>
 #include <stdbool.h>
 #include "stm32_can.h"
-
-#define LOG_LEVEL CONFIG_CAN_LOG_LEVEL
 #include <logging/log.h>
-LOG_MODULE_REGISTER(stm32_can);
+
+LOG_MODULE_REGISTER(stm32_can, CONFIG_CAN_LOG_LEVEL);
 
 static void can_stm32_signal_tx_complete(struct can_mailbox *mb)
 {

--- a/drivers/clock_control/clock_control_mcux_ccm.c
+++ b/drivers/clock_control/clock_control_mcux_ccm.c
@@ -8,10 +8,9 @@
 #include <clock_control.h>
 #include <dt-bindings/clock/imx_ccm.h>
 #include <fsl_clock.h>
-
-#define LOG_LEVEL CONFIG_CLOCK_CONTROL_LOG_LEVEL
 #include <logging/log.h>
-LOG_MODULE_REGISTER(clock_control);
+
+LOG_MODULE_REGISTER(clock_control, CONFIG_CLOCK_CONTROL_LOG_LEVEL);
 
 static const clock_name_t lpspi_clocks[] = {
 	kCLOCK_Usb1PllPfd1Clk,

--- a/drivers/clock_control/quark_se_clock_control.c
+++ b/drivers/clock_control/quark_se_clock_control.c
@@ -18,10 +18,9 @@
 
 #include <clock_control.h>
 #include <clock_control/quark_se_clock_control.h>
-
-#define LOG_LEVEL CONFIG_CLOCK_CONTROL_LOG_LEVEL
 #include <logging/log.h>
-LOG_MODULE_REGISTER(clock_control);
+
+LOG_MODULE_REGISTER(clock_control, CONFIG_CLOCK_CONTROL_LOG_LEVEL);
 
 #ifdef CONFIG_ARC
 #define WRITE(__data, __base_address)		\

--- a/drivers/console/telnet_console.c
+++ b/drivers/console/telnet_console.c
@@ -16,15 +16,14 @@
  * RFC 854 - https://tools.ietf.org/html/rfc854
  */
 
-#define LOG_LEVEL CONFIG_TELNET_CONSOLE_LOG_LEVEL
-#define LOG_DOMAIN net_telnet
 #include <logging/log.h>
-LOG_MODULE_REGISTER(LOG_DOMAIN);
+LOG_MODULE_REGISTER(net_telnet, CONFIG_TELNET_CONSOLE_LOG_LEVEL);
 
+/* This prevents log module registration in net_core.h */
+#define LOG_LEVEL	0
 #include <zephyr.h>
 #include <init.h>
 #include <misc/printk.h>
-
 #include <console/console.h>
 #include <net/buf.h>
 #include <net/net_pkt.h>
@@ -32,6 +31,7 @@ LOG_MODULE_REGISTER(LOG_DOMAIN);
 #include <net/net_context.h>
 
 #include "telnet_protocol.h"
+
 
 /* Various definitions mapping the telnet service configuration options */
 #define TELNET_PORT             CONFIG_TELNET_CONSOLE_PORT

--- a/drivers/console/websocket_console.c
+++ b/drivers/console/websocket_console.c
@@ -13,10 +13,8 @@
  * a websocket connection.
  */
 
-#define LOG_LEVEL CONFIG_WEBSOCKET_CONSOLE_LOG_LEVEL
-#define LOG_DOMAIN ws_console
-#include <logging/log.h>
-LOG_MODULE_REGISTER(LOG_DOMAIN);
+#define LOG_MODULE_NAME ws_console
+#define NET_LOG_LEVEL CONFIG_WEBSOCKET_CONSOLE_LOG_LEVEL
 
 #include <zephyr.h>
 #include <init.h>
@@ -26,6 +24,7 @@ LOG_MODULE_REGISTER(LOG_DOMAIN);
 #include <net/buf.h>
 #include <net/net_pkt.h>
 #include <net/websocket_console.h>
+#include <logging/log.h>
 
 #define NVT_NUL 0
 #define NVT_LF  10

--- a/drivers/crypto/crypto_ataes132a.c
+++ b/drivers/crypto/crypto_ataes132a.c
@@ -11,6 +11,7 @@
 #include <i2c.h>
 #include <assert.h>
 #include <crypto/cipher.h>
+#include <logging/log.h>
 
 #include "crypto_ataes132a_priv.h"
 
@@ -21,9 +22,7 @@
 /* ATAES132A can store up to 16 different crypto keys */
 #define CRYPTO_MAX_SESSION 16
 
-#define LOG_LEVEL CONFIG_CRYPTO_LOG_LEVEL
-#include <logging/log.h>
-LOG_MODULE_REGISTER(ataes132a);
+LOG_MODULE_REGISTER(ataes132a, CONFIG_CRYPTO_LOG_LEVEL);
 
 static struct ataes132a_driver_state ataes132a_state[CRYPTO_MAX_SESSION];
 

--- a/drivers/crypto/crypto_mtls_shim.c
+++ b/drivers/crypto/crypto_mtls_shim.c
@@ -22,12 +22,11 @@
 
 #include <mbedtls/ccm.h>
 #include <mbedtls/aes.h>
+#include <logging/log.h>
 
 #define MTLS_SUPPORT (CAP_RAW_KEY | CAP_SEPARATE_IO_BUFS | CAP_SYNC_OPS)
 
-#define LOG_LEVEL CONFIG_CRYPTO_LOG_LEVEL
-#include <logging/log.h>
-LOG_MODULE_REGISTER(mbedtls);
+LOG_MODULE_REGISTER(mbedtls, CONFIG_CRYPTO_LOG_LEVEL);
 
 struct mtls_shim_session {
 	mbedtls_ccm_context mtls;

--- a/drivers/crypto/crypto_tc_shim.c
+++ b/drivers/crypto/crypto_tc_shim.c
@@ -16,10 +16,9 @@
 #include <string.h>
 #include <crypto/cipher.h>
 #include "crypto_tc_shim_priv.h"
-
-#define LOG_LEVEL CONFIG_CRYPTO_LOG_LEVEL
 #include <logging/log.h>
-LOG_MODULE_REGISTER(tinycrypt);
+
+LOG_MODULE_REGISTER(tinycrypt, CONFIG_CRYPTO_LOG_LEVEL);
 
 #define CRYPTO_MAX_SESSION CONFIG_CRYPTO_TINYCRYPT_SHIM_MAX_SESSION
 

--- a/drivers/display/display_ili9340.c
+++ b/drivers/display/display_ili9340.c
@@ -6,15 +6,13 @@
 
 #include "display_ili9340.h"
 #include <display.h>
-
-#define LOG_LEVEL CONFIG_DISPLAY_LOG_LEVEL
-#include <logging/log.h>
-LOG_MODULE_REGISTER(display_ili9340);
-
 #include <gpio.h>
 #include <misc/byteorder.h>
 #include <spi.h>
 #include <string.h>
+#include <logging/log.h>
+
+LOG_MODULE_REGISTER(display_ili9340, CONFIG_DISPLAY_LOG_LEVEL);
 
 struct ili9340_data {
 	struct device *reset_gpio;

--- a/drivers/dma/dma_cavs.c
+++ b/drivers/dma/dma_cavs.c
@@ -12,12 +12,10 @@
 #include <device.h>
 #include <init.h>
 #include <dma.h>
-
+#include <logging/log.h>
 #include "dma_cavs.h"
 
-#define LOG_LEVEL CONFIG_DMA_LOG_LEVEL
-#include <logging/log.h>
-LOG_MODULE_REGISTER(dma_cavs)
+LOG_MODULE_REGISTER(dma_cavs, CONFIG_DMA_LOG_LEVEL);
 
 #define BYTE				(1)
 #define WORD				(2)

--- a/drivers/dma/dma_nios2_msgdma.c
+++ b/drivers/dma/dma_nios2_msgdma.c
@@ -14,10 +14,9 @@
 #include "altera_msgdma_csr_regs.h"
 #include "altera_msgdma_descriptor_regs.h"
 #include "altera_msgdma.h"
-
-#define LOG_LEVEL CONFIG_DMA_LOG_LEVEL
 #include <logging/log.h>
-LOG_MODULE_REGISTER(dma_nios2)
+
+LOG_MODULE_REGISTER(dma_nios2, CONFIG_DMA_LOG_LEVEL);
 
 /* Device configuration parameters */
 struct nios2_msgdma_dev_cfg {

--- a/drivers/dma/dma_sam_xdmac.c
+++ b/drivers/dma/dma_sam_xdmac.c
@@ -15,11 +15,10 @@
 #include <string.h>
 #include <soc.h>
 #include <dma.h>
+#include <logging/log.h>
 #include "dma_sam_xdmac.h"
 
-#define LOG_LEVEL CONFIG_DMA_LOG_LEVEL
-#include <logging/log.h>
-LOG_MODULE_REGISTER(dma_sam_xdmac)
+LOG_MODULE_REGISTER(dma_sam_xdmac, CONFIG_DMA_LOG_LEVEL);
 
 #define XDMAC_INT_ERR (XDMAC_CIE_RBIE | XDMAC_CIE_WBIE | XDMAC_CIE_ROIE)
 #define DMA_CHANNELS_NO  XDMACCHID_NUMBER

--- a/drivers/dma/dma_stm32f4x.c
+++ b/drivers/dma/dma_stm32f4x.c
@@ -13,10 +13,9 @@
 #include <stdio.h>
 #include <string.h>
 #include <misc/util.h>
-
-#define LOG_LEVEL CONFIG_DMA_LOG_LEVEL
 #include <logging/log.h>
-LOG_MODULE_REGISTER(dma_stm32f4x)
+
+LOG_MODULE_REGISTER(dma_stm32f4x, CONFIG_DMA_LOG_LEVEL);
 
 #include <clock_control/stm32_clock_control.h>
 

--- a/drivers/ethernet/eth_dw.c
+++ b/drivers/ethernet/eth_dw.c
@@ -3,12 +3,6 @@
  *
  * SPDX-License-Identifier: Apache-2.0
  */
-#define LOG_MODULE_NAME eth_dw
-#define LOG_LEVEL CONFIG_ETHERNET_LOG_LEVEL
-
-#include <logging/log.h>
-LOG_MODULE_REGISTER(LOG_MODULE_NAME);
-
 #include <soc.h>
 #include <device.h>
 #include <errno.h>
@@ -22,12 +16,15 @@ LOG_MODULE_REGISTER(LOG_MODULE_NAME);
 #include <string.h>
 #include <sys_io.h>
 #include <net/ethernet.h>
+#include <logging/log.h>
 
 #include "eth_dw_priv.h"
 
 #ifdef CONFIG_SHARED_IRQ
 #include <shared_irq.h>
 #endif
+
+LOG_MODULE_REGISTER(eth_dw, CONFIG_ETHERNET_LOG_LEVEL);
 
 #define TX_BUSY_LOOP_SPINS 20
 

--- a/drivers/ethernet/eth_e1000.c
+++ b/drivers/ethernet/eth_e1000.c
@@ -3,16 +3,13 @@
  *
  * SPDX-License-Identifier: Apache-2.0
  */
-
-#define LOG_MODULE_NAME eth_e1000
-#define LOG_LEVEL CONFIG_ETHERNET_LOG_LEVEL
-#include <logging/log.h>
-LOG_MODULE_REGISTER(LOG_MODULE_NAME);
-
 #include <zephyr.h>
 #include <net/ethernet.h>
 #include <pci/pci.h>
+#include <logging/log.h>
 #include "eth_e1000_priv.h"
+
+LOG_MODULE_REGISTER(eth_e1000, CONFIG_ETHERNET_LOG_LEVEL);
 
 #define dev_dbg(fmt, args...) LOG_DBG("%s() " fmt, __func__, ## args)
 #define dev_err(fmt, args...) LOG_ERR("%s() " "Error: " fmt, __func__, ## args)

--- a/drivers/ethernet/eth_enc28j60.c
+++ b/drivers/ethernet/eth_enc28j60.c
@@ -4,12 +4,11 @@
  *
  * SPDX-License-Identifier: Apache-2.0
  */
-
-#define LOG_MODULE_NAME eth_enc28j60
-#define LOG_LEVEL CONFIG_ETHERNET_LOG_LEVEL
-
 #include <logging/log.h>
-LOG_MODULE_REGISTER(LOG_MODULE_NAME);
+LOG_MODULE_REGISTER(eth_enc28j60, CONFIG_ETHERNET_LOG_LEVEL);
+
+/* This prevents log module registration in net_core.h */
+#define LOG_LEVEL	0
 
 #include <zephyr.h>
 #include <device.h>
@@ -22,6 +21,7 @@ LOG_MODULE_REGISTER(LOG_MODULE_NAME);
 #include <net/ethernet.h>
 
 #include "eth_enc28j60_priv.h"
+
 
 #define D10D24S 11
 

--- a/drivers/ethernet/eth_mcux.c
+++ b/drivers/ethernet/eth_mcux.c
@@ -13,11 +13,11 @@
  * error behaviour.
  */
 
-#define LOG_MODULE_NAME eth_mcux
-#define LOG_LEVEL CONFIG_ETHERNET_LOG_LEVEL
-
+LOG_MODULE_REGISTER(eth_mcux, CONFIG_ETHERNET_LOG_LEVEL);
 #include <logging/log.h>
-LOG_MODULE_REGISTER(LOG_MODULE_NAME);
+
+/* This prevents log module registration in net_core.h */
+#define LOG_LEVEL	0
 
 #include <device.h>
 #include <misc/util.h>

--- a/drivers/ethernet/eth_native_posix.c
+++ b/drivers/ethernet/eth_native_posix.c
@@ -12,10 +12,7 @@
  */
 
 #define LOG_MODULE_NAME eth_posix
-#define LOG_LEVEL CONFIG_ETHERNET_LOG_LEVEL
-
-#include <logging/log.h>
-LOG_MODULE_REGISTER(LOG_MODULE_NAME);
+#define NET_LOG_LEVEL CONFIG_ETHERNET_LOG_LEVEL
 
 #include <stdio.h>
 

--- a/drivers/ethernet/eth_native_posix_adapt.c
+++ b/drivers/ethernet/eth_native_posix_adapt.c
@@ -11,6 +11,12 @@
  * because there is naming conflicts between host and zephyr network stacks.
  */
 
+#include <logging/log.h>
+LOG_MODULE_REGISTER(eth_posix_adapt, CONFIG_ETHERNET_LOG_LEVEL);
+
+/* This prevents log module registration in net_core.h */
+#define LOG_LEVEL	0
+
 /* Host include files */
 #include <stdio.h>
 #include <stdlib.h>
@@ -34,12 +40,6 @@
 /* Zephyr include files. Be very careful here and only include minimum
  * things needed.
  */
-#define LOG_MODULE_NAME eth_posix_adapt
-#define LOG_LEVEL CONFIG_ETHERNET_LOG_LEVEL
-
-#include <logging/log.h>
-LOG_MODULE_REGISTER(LOG_MODULE_NAME);
-
 #include <zephyr/types.h>
 #include <sys_clock.h>
 
@@ -48,6 +48,7 @@ LOG_MODULE_REGISTER(LOG_MODULE_NAME);
 #endif
 
 #include "eth_native_posix_priv.h"
+
 
 /* Note that we cannot create the TUN/TAP device from the setup script
  * as we need to get a file descriptor to communicate with the interface.

--- a/drivers/ethernet/eth_sam_gmac.c
+++ b/drivers/ethernet/eth_sam_gmac.c
@@ -19,13 +19,6 @@
  * - no support for devices with DCache enabled due to missing non-cacheable
  *   RAM regions in Zephyr.
  */
-
-#define LOG_MODULE_NAME eth_sam
-#define LOG_LEVEL CONFIG_ETHERNET_LOG_LEVEL
-
-#include <logging/log.h>
-LOG_MODULE_REGISTER(LOG_MODULE_NAME);
-
 #include <kernel.h>
 #include <device.h>
 #include <misc/__assert.h>
@@ -37,6 +30,7 @@ LOG_MODULE_REGISTER(LOG_MODULE_NAME);
 #include <net/ethernet.h>
 #include <i2c.h>
 #include <soc.h>
+#include <logging/log.h>
 #include "phy_sam_gmac.h"
 #include "eth_sam_gmac_priv.h"
 
@@ -44,6 +38,8 @@ LOG_MODULE_REGISTER(LOG_MODULE_NAME);
 #include <ptp_clock.h>
 #include <net/gptp.h>
 #endif
+
+LOG_MODULE_REGISTER(eth_sam, CONFIG_ETHERNET_LOG_LEVEL);
 
 /*
  * Verify Kconfig configuration

--- a/drivers/ethernet/eth_stm32_hal.c
+++ b/drivers/ethernet/eth_stm32_hal.c
@@ -2,13 +2,6 @@
  * Copyright (c) 2017 Erwin Rol <erwin@erwinrol.com>
  * SPDX-License-Identifier: Apache-2.0
  */
-
-#define LOG_MODULE_NAME eth_stm32_hal
-#define LOG_LEVEL CONFIG_ETHERNET_LOG_LEVEL
-
-#include <logging/log.h>
-LOG_MODULE_REGISTER(LOG_MODULE_NAME);
-
 #include <kernel.h>
 #include <device.h>
 #include <misc/__assert.h>
@@ -22,8 +15,11 @@ LOG_MODULE_REGISTER(LOG_MODULE_NAME);
 #include <misc/printk.h>
 #include <clock_control.h>
 #include <clock_control/stm32_clock_control.h>
+#include <logging/log.h>
 
 #include "eth_stm32_hal_priv.h"
+
+LOG_MODULE_REGISTER(eth_stm32_hal, CONFIG_ETHERNET_LOG_LEVEL);
 
 static ETH_DMADescTypeDef dma_rx_desc_tab[ETH_RXBUFNB] __aligned(4);
 static ETH_DMADescTypeDef dma_tx_desc_tab[ETH_TXBUFNB] __aligned(4);

--- a/drivers/ethernet/phy_sam_gmac.c
+++ b/drivers/ethernet/phy_sam_gmac.c
@@ -10,13 +10,10 @@
 #include <errno.h>
 #include <kernel.h>
 #include <net/mii.h>
+#include <logging/log.h>
 #include "phy_sam_gmac.h"
 
-#define LOG_MODULE_NAME eth_sam_phy
-#define LOG_LEVEL CONFIG_ETHERNET_LOG_LEVEL
-
-#include <logging/log.h>
-LOG_MODULE_REGISTER(LOG_MODULE_NAME);
+LOG_MODULE_REGISTER(eth_sam_phy, CONFIG_ETHERNET_LOG_LEVEL);
 
 /* Maximum time to establish a link through auto-negotiation for
  * 10BASE-T, 100BASE-TX is 3.7s, to add an extra margin the timeout

--- a/drivers/flash/flash_sam0.c
+++ b/drivers/flash/flash_sam0.c
@@ -3,18 +3,15 @@
  *
  * SPDX-License-Identifier: Apache-2.0
  */
-
-#define LOG_LEVEL CONFIG_FLASH_LOG_LEVEL
-#include <logging/log.h>
-LOG_MODULE_REGISTER(flash_sam0);
-
 #include <device.h>
 #include <flash.h>
 #include <init.h>
 #include <kernel.h>
 #include <soc.h>
 #include <string.h>
+#include <logging/log.h>
 
+LOG_MODULE_REGISTER(flash_sam0, CONFIG_FLASH_LOG_LEVEL);
 /*
  * Zephyr and the SAM0 series use different and conflicting names for
  * the erasable units and programmable units:

--- a/drivers/flash/flash_stm32f0x.c
+++ b/drivers/flash/flash_stm32f0x.c
@@ -3,20 +3,16 @@
  *
  * SPDX-License-Identifier: Apache-2.0
  */
-
-#define LOG_DOMAIN flash_stm32f0
-#define LOG_LEVEL CONFIG_FLASH_LOG_LEVEL
-#include <logging/log.h>
-LOG_MODULE_REGISTER(LOG_DOMAIN);
-
 #include <kernel.h>
 #include <device.h>
 #include <string.h>
 #include <flash.h>
 #include <init.h>
 #include <soc.h>
-
+#include <logging/log.h>
 #include "flash_stm32.h"
+
+LOG_MODULE_REGISTER(flash_stm32f0, CONFIG_FLASH_LOG_LEVEL);
 
 /* offset and len must be aligned on 2 for write
  * positive and not beyond end of flash

--- a/drivers/flash/flash_stm32l4x.c
+++ b/drivers/flash/flash_stm32l4x.c
@@ -4,20 +4,17 @@
  *
  * SPDX-License-Identifier: Apache-2.0
  */
-
-#define LOG_DOMAIN flash_stm32l4
-#define LOG_LEVEL CONFIG_FLASH_LOG_LEVEL
-#include <logging/log.h>
-LOG_MODULE_REGISTER(LOG_DOMAIN);
-
 #include <kernel.h>
 #include <device.h>
 #include <string.h>
 #include <flash.h>
 #include <init.h>
 #include <soc.h>
+#include <logging/log.h>
 
 #include "flash_stm32.h"
+
+LOG_MODULE_REGISTER(flash_stm32l4, CONFIG_FLASH_LOG_LEVEL);
 
 #if !defined (STM32L4R5xx) && !defined (STM32L4R7xx) && !defined (STM32L4R9xx) && !defined (STM32L4S5xx) && !defined (STM32L4S7xx) && !defined (STM32L4S9xx)
 #define STM32L4X_PAGE_SHIFT	11

--- a/drivers/flash/soc_flash_nios2_qspi.c
+++ b/drivers/flash/soc_flash_nios2_qspi.c
@@ -17,13 +17,12 @@
 #include <init.h>
 #include <soc.h>
 #include <misc/util.h>
+#include <logging/log.h>
 #include "flash_priv.h"
 #include "altera_generic_quad_spi_controller2_regs.h"
 #include "altera_generic_quad_spi_controller2.h"
 
-#define LOG_LEVEL CONFIG_FLASH_LOG_LEVEL
-#include <logging/log.h>
-LOG_MODULE_REGISTER(flash_nios2_qspi);
+LOG_MODULE_REGISTER(flash_nios2_qspi, CONFIG_FLASH_LOG_LEVEL);
 
 /*
  * Remove the following macros once the Altera HAL

--- a/drivers/gpio/gpio_pcal9535a.c
+++ b/drivers/gpio/gpio_pcal9535a.c
@@ -16,12 +16,11 @@
 #include <misc/util.h>
 #include <gpio.h>
 #include <i2c.h>
+#include <logging/log.h>
 
 #include "gpio_pcal9535a.h"
 
-#define LOG_LEVEL CONFIG_GPIO_LOG_LEVEL
-#include <logging/log.h>
-LOG_MODULE_REGISTER(gpio_pcal9535a);
+LOG_MODULE_REGISTER(gpio_pcal9535a, CONFIG_GPIO_LOG_LEVEL);
 
 /* Register definitions */
 #define REG_INPUT_PORT0			0x00

--- a/drivers/gpio/gpio_sch.c
+++ b/drivers/gpio/gpio_sch.c
@@ -13,13 +13,12 @@
 #include <init.h>
 #include <sys_io.h>
 #include <misc/util.h>
+#include <logging/log.h>
 
 #include "gpio_sch.h"
 #include "gpio_utils.h"
 
-#define LOG_LEVEL CONFIG_GPIO_LOG_LEVEL
-#include <logging/log.h>
-LOG_MODULE_REGISTER(gpio_sch)
+LOG_MODULE_REGISTER(gpio_sch, CONFIG_GPIO_LOG_LEVEL);
 
 /* Define GPIO_SCH_LEGACY_IO_PORTS_ACCESS
  * inside soc.h if the GPIO controller

--- a/drivers/i2c/i2c_atmel_sam3.c
+++ b/drivers/i2c/i2c_atmel_sam3.c
@@ -33,10 +33,9 @@
 #include <sys_clock.h>
 
 #include <misc/util.h>
-
-#define LOG_LEVEL CONFIG_I2C_LOG_LEVEL
 #include <logging/log.h>
-LOG_MODULE_REGISTER(i2c_atmel_sam3)
+
+LOG_MODULE_REGISTER(i2c_atmel_sam3, CONFIG_I2C_LOG_LEVEL);
 
 #define TWI_IRQ_PDC \
 	(TWI_SR_ENDRX | TWI_SR_ENDTX | TWI_SR_RXBUFF | TWI_SR_TXBUFE)

--- a/drivers/i2c/i2c_cc32xx.c
+++ b/drivers/i2c/i2c_cc32xx.c
@@ -17,10 +17,9 @@
 #include <driverlib/rom.h>
 #include <driverlib/rom_map.h>
 #include <driverlib/i2c.h>
-
-#define LOG_LEVEL CONFIG_I2C_LOG_LEVEL
 #include <logging/log.h>
-LOG_MODULE_REGISTER(i2c_cc32xx)
+
+LOG_MODULE_REGISTER(i2c_cc32xx, CONFIG_I2C_LOG_LEVEL);
 
 #include "i2c-priv.h"
 

--- a/drivers/i2c/i2c_dw.c
+++ b/drivers/i2c/i2c_dw.c
@@ -21,6 +21,7 @@
 #include <sys_io.h>
 
 #include <misc/util.h>
+#include <logging/log.h>
 
 #ifdef CONFIG_SHARED_IRQ
 #include <shared_irq.h>
@@ -32,9 +33,7 @@
 
 #include "i2c_dw.h"
 #include "i2c_dw_registers.h"
-#define LOG_LEVEL CONFIG_I2C_LOG_LEVEL
-#include <logging/log.h>
-LOG_MODULE_REGISTER(i2c_dw);
+LOG_MODULE_REGISTER(i2c_dw, CONFIG_I2C_LOG_LEVEL);
 
 #include "i2c-priv.h"
 

--- a/drivers/i2c/i2c_gecko.c
+++ b/drivers/i2c/i2c_gecko.c
@@ -12,9 +12,8 @@
 #include <em_gpio.h>
 #include <soc.h>
 
-#define LOG_LEVEL CONFIG_I2C_LOG_LEVEL
 #include <logging/log.h>
-LOG_MODULE_REGISTER(i2c_gecko)
+LOG_MODULE_REGISTER(i2c_gecko, CONFIG_I2C_LOG_LEVEL);
 
 #include "i2c-priv.h"
 

--- a/drivers/i2c/i2c_imx.c
+++ b/drivers/i2c/i2c_imx.c
@@ -9,9 +9,9 @@
 #include <soc.h>
 #include <i2c_imx.h>
 #include <misc/util.h>
-
 #include <logging/log.h>
-LOG_MODULE_REGISTER(i2c_imx);
+
+LOG_MODULE_REGISTER(i2c_imx, CONFIG_I2C_LOG_LEVEL);
 
 #include "i2c-priv.h"
 

--- a/drivers/i2c/i2c_ll_stm32.c
+++ b/drivers/i2c/i2c_ll_stm32.c
@@ -13,10 +13,9 @@
 #include <errno.h>
 #include <i2c.h>
 #include "i2c_ll_stm32.h"
-
-#define LOG_LEVEL CONFIG_I2C_LOG_LEVEL
 #include <logging/log.h>
-LOG_MODULE_REGISTER(i2c_ll_stm32);
+
+LOG_MODULE_REGISTER(i2c_ll_stm32, CONFIG_I2C_LOG_LEVEL);
 
 #include "i2c-priv.h"
 

--- a/drivers/i2c/i2c_ll_stm32_v1.c
+++ b/drivers/i2c/i2c_ll_stm32_v1.c
@@ -16,10 +16,9 @@
 #include <errno.h>
 #include <i2c.h>
 #include "i2c_ll_stm32.h"
-
-#define LOG_LEVEL CONFIG_I2C_LOG_LEVEL
 #include <logging/log.h>
-LOG_MODULE_REGISTER(i2c_ll_stm32_v1);
+
+LOG_MODULE_REGISTER(i2c_ll_stm32_v1, CONFIG_I2C_LOG_LEVEL);
 
 #define I2C_REQUEST_WRITE	0x00
 #define I2C_REQUEST_READ	0x01

--- a/drivers/i2c/i2c_ll_stm32_v2.c
+++ b/drivers/i2c/i2c_ll_stm32_v2.c
@@ -16,10 +16,9 @@
 #include <errno.h>
 #include <i2c.h>
 #include "i2c_ll_stm32.h"
-
-#define LOG_LEVEL CONFIG_I2C_LOG_LEVEL
 #include <logging/log.h>
-LOG_MODULE_REGISTER(i2c_ll_stm32_v2);
+
+LOG_MODULE_REGISTER(i2c_ll_stm32_v2, CONFIG_I2C_LOG_LEVEL);
 
 #include "i2c-priv.h"
 

--- a/drivers/i2c/i2c_mcux.c
+++ b/drivers/i2c/i2c_mcux.c
@@ -10,9 +10,9 @@
 #include <fsl_i2c.h>
 #include <fsl_clock.h>
 #include <misc/util.h>
-
 #include <logging/log.h>
-LOG_MODULE_REGISTER(i2c_mcux);
+
+LOG_MODULE_REGISTER(i2c_mcux, CONFIG_I2C_LOG_LEVEL);
 
 #include "i2c-priv.h"
 

--- a/drivers/i2c/i2c_nios2.c
+++ b/drivers/i2c/i2c_nios2.c
@@ -10,10 +10,9 @@
 #include <misc/util.h>
 #include <altera_common.h>
 #include "altera_avalon_i2c.h"
-
-#define LOG_LEVEL CONFIG_I2C_LOG_LEVEL
 #include <logging/log.h>
-LOG_MODULE_REGISTER(i2c_nios2);
+
+LOG_MODULE_REGISTER(i2c_nios2, CONFIG_I2C_LOG_LEVEL);
 
 #define NIOS2_I2C_TIMEOUT_USEC		1000
 

--- a/drivers/i2c/i2c_nrfx_twi.c
+++ b/drivers/i2c/i2c_nrfx_twi.c
@@ -7,10 +7,9 @@
 
 #include <i2c.h>
 #include <nrfx_twi.h>
-
-#define LOG_LEVEL CONFIG_I2C_LOG_LEVEL
 #include <logging/log.h>
-LOG_MODULE_REGISTER(i2c_nrfx_twi);
+
+LOG_MODULE_REGISTER(i2c_nrfx_twi, CONFIG_I2C_LOG_LEVEL);
 
 struct i2c_nrfx_twi_data {
 	struct k_sem sync;

--- a/drivers/i2c/i2c_nrfx_twim.c
+++ b/drivers/i2c/i2c_nrfx_twim.c
@@ -7,11 +7,9 @@
 
 #include <i2c.h>
 #include <nrfx_twim.h>
-
-#define LOG_DOMAIN "i2c_nrfx_twim"
-#define LOG_LEVEL CONFIG_I2C_LOG_LEVEL
 #include <logging/log.h>
-LOG_MODULE_REGISTER(i2c_nrfx_twim);
+
+LOG_MODULE_REGISTER(i2c_nrfx_twim, CONFIG_I2C_LOG_LEVEL);
 
 struct i2c_nrfx_twim_data {
 	struct k_sem sync;

--- a/drivers/i2c/i2c_qmsi.c
+++ b/drivers/i2c/i2c_qmsi.c
@@ -10,14 +10,15 @@
 #include <i2c.h>
 #include <ioapic.h>
 #include <power.h>
+#include <logging/log.h>
 
 #include "qm_i2c.h"
 #include "qm_isr.h"
 #include "clk.h"
 #include "soc.h"
 
-#include <logging/log.h>
-LOG_MODULE_REGISTER(i2c_qmsi);
+LOG_MODULE_REGISTER(i2c_qmsi, CONFIG_I2C_LOG_LEVEL);
+
 #include "i2c-priv.h"
 
 /* Convenient macros to get the controller instance and the driver data. */

--- a/drivers/i2c/i2c_qmsi_ss.c
+++ b/drivers/i2c/i2c_qmsi_ss.c
@@ -8,13 +8,14 @@
 #include <device.h>
 #include <i2c.h>
 #include <soc.h>
+#include <logging/log.h>
 
 #include "qm_ss_i2c.h"
 #include "qm_ss_isr.h"
 #include "ss_clk.h"
 
-#include <logging/log.h>
-LOG_MODULE_REGISTER(i2c_qmsi_ss);
+LOG_MODULE_REGISTER(i2c_qmsi_ss, CONFIG_I2C_LOG_LEVEL);
+
 #include "i2c-priv.h"
 
 /* Convenient macros to get the controller instance and the driver data. */

--- a/drivers/i2c/i2c_sam_twi.c
+++ b/drivers/i2c/i2c_sam_twi.c
@@ -20,10 +20,9 @@
 #include <init.h>
 #include <soc.h>
 #include <i2c.h>
-
-#define LOG_LEVEL CONFIG_I2C_LOG_LEVEL
 #include <logging/log.h>
-LOG_MODULE_REGISTER(i2c_sam_twi)
+
+LOG_MODULE_REGISTER(i2c_sam_twi, CONFIG_I2C_LOG_LEVEL);
 
 #include "i2c-priv.h"
 

--- a/drivers/i2c/i2c_sam_twihs.c
+++ b/drivers/i2c/i2c_sam_twihs.c
@@ -18,10 +18,9 @@
 #include <init.h>
 #include <soc.h>
 #include <i2c.h>
-
-#define LOG_LEVEL CONFIG_I2C_LOG_LEVEL
 #include <logging/log.h>
-LOG_MODULE_REGISTER(i2c_sam_twihs)
+
+LOG_MODULE_REGISTER(i2c_sam_twihs, CONFIG_I2C_LOG_LEVEL);
 
 #include "i2c-priv.h"
 

--- a/drivers/i2c/slave/eeprom_slave.c
+++ b/drivers/i2c/slave/eeprom_slave.c
@@ -10,10 +10,9 @@
 #include <i2c.h>
 #include <string.h>
 #include <drivers/i2c/slave/eeprom.h>
-
-#define LOG_LEVEL CONFIG_I2C_LOG_LEVEL
 #include <logging/log.h>
-LOG_MODULE_REGISTER(i2c_slave)
+
+LOG_MODULE_REGISTER(i2c_slave, CONFIG_I2C_LOG_LEVEL);
 
 struct i2c_eeprom_slave_data {
 	struct device *i2c_controller;

--- a/drivers/i2s/i2s_cavs.c
+++ b/drivers/i2s/i2s_cavs.c
@@ -21,12 +21,10 @@
 #include <dma.h>
 #include <i2s.h>
 #include <soc.h>
+#include <logging/log.h>
 #include "i2s_cavs.h"
 
-#define LOG_DOMAIN dev_i2s_cavs
-#define LOG_LEVEL CONFIG_I2S_LOG_LEVEL
-#include <logging/log.h>
-LOG_MODULE_REGISTER(LOG_DOMAIN);
+LOG_MODULE_REGISTER(dev_i2s_cavs, CONFIG_I2S_LOG_LEVEL);
 
 #ifdef CONFIG_DCACHE_WRITEBACK
 #define DCACHE_INVALIDATE(addr, size) \

--- a/drivers/i2s/i2s_sam_ssc.c
+++ b/drivers/i2s/i2s_sam_ssc.c
@@ -26,11 +26,9 @@
 #include <dma.h>
 #include <i2s.h>
 #include <soc.h>
-
-#define LOG_DOMAIN dev_i2s_sam_ssc
-#define LOG_LEVEL CONFIG_I2S_LOG_LEVEL
 #include <logging/log.h>
-LOG_MODULE_REGISTER(LOG_DOMAIN);
+
+LOG_MODULE_REGISTER(dev_i2s_sam_ssc, CONFIG_I2S_LOG_LEVEL);
 
 /* FIXME change to
  * #if __DCACHE_PRESENT == 1

--- a/drivers/ieee802154/ieee802154_cc1200.c
+++ b/drivers/ieee802154/ieee802154_cc1200.c
@@ -6,12 +6,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#define LOG_MODULE_NAME ieee802154_cc1200
-#define LOG_LEVEL CONFIG_IEEE802154_LOG_LEVEL
-
-#include <logging/log.h>
-LOG_MODULE_REGISTER(LOG_MODULE_NAME);
-
 #include <errno.h>
 
 #include <kernel.h>
@@ -30,6 +24,9 @@ LOG_MODULE_REGISTER(LOG_MODULE_NAME);
 #include <gpio.h>
 
 #include <net/ieee802154_radio.h>
+#include <logging/log.h>
+
+LOG_MODULE_REGISTER(ieee802154_cc1200, CONFIG_IEEE802154_LOG_LEVEL);
 
 #include "ieee802154_cc1200.h"
 #include "ieee802154_cc1200_rf.h"

--- a/drivers/ieee802154/ieee802154_cc2520.c
+++ b/drivers/ieee802154/ieee802154_cc2520.c
@@ -6,11 +6,11 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#define LOG_MODULE_NAME ieee802154_cc2520
-#define LOG_LEVEL CONFIG_IEEE802154_LOG_LEVEL
-
 #include <logging/log.h>
-LOG_MODULE_REGISTER(LOG_MODULE_NAME);
+LOG_MODULE_REGISTER(ieee802154_cc2520, CONFIG_IEEE802154_LOG_LEVEL);
+
+/* This prevents log module registration in net_core.h */
+#define LOG_LEVEL	0
 
 #include <errno.h>
 
@@ -38,6 +38,7 @@ LOG_MODULE_REGISTER(LOG_MODULE_NAME);
 #include <net/ieee802154_radio.h>
 
 #include "ieee802154_cc2520.h"
+
 
 /**
  * Content is split as follows:

--- a/drivers/ieee802154/ieee802154_kw41z.c
+++ b/drivers/ieee802154/ieee802154_kw41z.c
@@ -5,12 +5,11 @@
  *
  * SPDX-License-Identifier: Apache-2.0
  */
-
-#define LOG_MODULE_NAME ieee802154_kw41z
-#define LOG_LEVEL CONFIG_IEEE802154_LOG_LEVEL
-
+LOG_MODULE_REGISTER(ieee802154_kw41z, CONFIG_IEEE802154_LOG_LEVEL);
 #include <logging/log.h>
-LOG_MODULE_REGISTER(LOG_MODULE_NAME);
+
+/* This prevents log module registration in net_core.h */
+#define LOG_LEVEL	0
 
 #include <zephyr.h>
 #include <kernel.h>

--- a/drivers/ieee802154/ieee802154_mcr20a.c
+++ b/drivers/ieee802154/ieee802154_mcr20a.c
@@ -5,12 +5,11 @@
  *
  * SPDX-License-Identifier: Apache-2.0
  */
-
-#define LOG_MODULE_NAME ieee802154_mcr20a
-#define LOG_LEVEL CONFIG_IEEE802154_LOG_LEVEL
-
 #include <logging/log.h>
-LOG_MODULE_REGISTER(LOG_MODULE_NAME);
+LOG_MODULE_REGISTER(ieee802154_mcr20a, CONFIG_IEEE802154_LOG_LEVEL);
+
+/* This prevents log module registration in net_core.h */
+#define LOG_LEVEL	0
 
 #include <errno.h>
 
@@ -32,6 +31,7 @@ LOG_MODULE_REGISTER(LOG_MODULE_NAME);
 
 #include "ieee802154_mcr20a.h"
 #include "MCR20Overwrites.h"
+
 
 /*
  * max. TX duraton = (PR + SFD + FLI + PDU + FCS)

--- a/drivers/ieee802154/ieee802154_nrf5.c
+++ b/drivers/ieee802154/ieee802154_nrf5.c
@@ -6,12 +6,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#define LOG_MODULE_NAME ieee802154_nrf5
-#define LOG_LEVEL CONFIG_IEEE802154_LOG_LEVEL
-
-#include <logging/log.h>
-LOG_MODULE_REGISTER(LOG_MODULE_NAME);
-
 #include <errno.h>
 
 #include <kernel.h>
@@ -34,10 +28,13 @@ LOG_MODULE_REGISTER(LOG_MODULE_NAME);
 #include <net/ieee802154_radio.h>
 #include <drivers/clock_control/nrf5_clock_control.h>
 #include <clock_control.h>
+#include <logging/log.h>
 
 #include "nrf52840.h"
 #include "ieee802154_nrf5.h"
 #include "nrf_drv_radio802154.h"
+
+LOG_MODULE_REGISTER(ieee802154_nrf5, CONFIG_IEEE802154_LOG_LEVEL);
 
 struct nrf5_802154_config {
 	void (*irq_config_func)(struct device *dev);

--- a/drivers/ieee802154/ieee802154_uart_pipe.c
+++ b/drivers/ieee802154/ieee802154_uart_pipe.c
@@ -3,13 +3,6 @@
  *
  * SPDX-License-Identifier: Apache-2.0
  */
-
-#define LOG_MODULE_NAME ieee802154_uart_pipe
-#define LOG_LEVEL CONFIG_IEEE802154_LOG_LEVEL
-
-#include <logging/log.h>
-LOG_MODULE_REGISTER(LOG_MODULE_NAME);
-
 #include <errno.h>
 
 #include <kernel.h>
@@ -19,11 +12,14 @@ LOG_MODULE_REGISTER(LOG_MODULE_NAME);
 #include <init.h>
 #include <net/net_if.h>
 #include <net/net_pkt.h>
+#include <logging/log.h>
 
 #include <console/uart_pipe.h>
 #include <net/ieee802154_radio.h>
 
 #include "ieee802154_uart_pipe.h"
+
+LOG_MODULE_REGISTER(ieee802154_uart_pipe, CONFIG_IEEE802154_LOG_LEVEL);
 
 #define PAN_ID_OFFSET           3 /* Pan Id offset */
 #define DEST_ADDR_OFFSET        5 /* Destination offset address*/

--- a/drivers/led/lp3943.c
+++ b/drivers/led/lp3943.c
@@ -21,10 +21,9 @@
 #include <led.h>
 #include <misc/util.h>
 #include <zephyr.h>
-
-#define LOG_LEVEL CONFIG_LED_LOG_LEVEL
 #include <logging/log.h>
-LOG_MODULE_REGISTER(lp3943);
+
+LOG_MODULE_REGISTER(lp3943, CONFIG_LED_LOG_LEVEL);
 
 #include "led_context.h"
 

--- a/drivers/led/lp5562.c
+++ b/drivers/led/lp5562.c
@@ -32,10 +32,9 @@
 #include <led.h>
 #include <device.h>
 #include <zephyr.h>
-
-#define LOG_LEVEL CONFIG_LED_LOG_LEVEL
 #include <logging/log.h>
-LOG_MODULE_REGISTER(lp5562);
+
+LOG_MODULE_REGISTER(lp5562, CONFIG_LED_LOG_LEVEL);
 
 #include "led_context.h"
 

--- a/drivers/led/pca9633.c
+++ b/drivers/led/pca9633.c
@@ -13,10 +13,9 @@
 #include <led.h>
 #include <misc/util.h>
 #include <zephyr.h>
-
-#define LOG_LEVEL CONFIG_LED_LOG_LEVEL
 #include <logging/log.h>
-LOG_MODULE_REGISTER(pca9633);
+
+LOG_MODULE_REGISTER(pca9633, CONFIG_LED_LOG_LEVEL);
 
 #include "led_context.h"
 

--- a/drivers/led_strip/lpd880x.c
+++ b/drivers/led_strip/lpd880x.c
@@ -8,15 +8,13 @@
 
 #include <errno.h>
 #include <string.h>
-
-#define LOG_LEVEL CONFIG_LED_STRIP_LOG_LEVEL
-#include <logging/log.h>
-LOG_MODULE_REGISTER(lpd880x);
-
 #include <zephyr.h>
 #include <device.h>
 #include <spi.h>
 #include <misc/util.h>
+#include <logging/log.h>
+
+LOG_MODULE_REGISTER(lpd880x, CONFIG_LED_STRIP_LOG_LEVEL);
 
 /*
  * LPD880X SPI master configuration:

--- a/drivers/led_strip/ws2812.c
+++ b/drivers/led_strip/ws2812.c
@@ -7,15 +7,13 @@
 #include <led_strip.h>
 
 #include <string.h>
-
-#define LOG_LEVEL CONFIG_LED_STRIP_LOG_LEVEL
-#include <logging/log.h>
-LOG_MODULE_REGISTER(ws2812);
-
 #include <zephyr.h>
 #include <device.h>
 #include <spi.h>
 #include <misc/util.h>
+#include <logging/log.h>
+
+LOG_MODULE_REGISTER(ws2812, CONFIG_LED_STRIP_LOG_LEVEL);
 
 /*
  * WS2812-ish SPI master configuration:

--- a/drivers/led_strip/ws2812b_sw.c
+++ b/drivers/led_strip/ws2812b_sw.c
@@ -7,16 +7,14 @@
 #include <led_strip.h>
 
 #include <string.h>
-
-#define LOG_LEVEL CONFIG_LED_STRIP_LOG_LEVEL
-#include <logging/log.h>
-LOG_MODULE_REGISTER(ws2812b_sw);
-
 #include <zephyr.h>
 #include <soc.h>
 #include <gpio.h>
 #include <device.h>
 #include <clock_control.h>
+#include <logging/log.h>
+
+LOG_MODULE_REGISTER(ws2812b_sw, CONFIG_LED_STRIP_LOG_LEVEL);
 
 #define BLOCKING ((void *)1)
 

--- a/drivers/modem/wncm14a2a.c
+++ b/drivers/modem/wncm14a2a.c
@@ -3,12 +3,6 @@
  *
  * SPDX-License-Identifier: Apache-2.0
  */
-
-#define LOG_DOMAIN modem_wncm14a2a
-#define LOG_LEVEL CONFIG_MODEM_LOG_LEVEL
-#include <logging/log.h>
-LOG_MODULE_REGISTER(LOG_DOMAIN);
-
 #include <zephyr/types.h>
 #include <stddef.h>
 #include <stdlib.h>
@@ -18,6 +12,7 @@ LOG_MODULE_REGISTER(LOG_DOMAIN);
 #include <gpio.h>
 #include <device.h>
 #include <init.h>
+#include <logging/log.h>
 
 #include <net/net_context.h>
 #include <net/net_if.h>
@@ -31,6 +26,8 @@ LOG_MODULE_REGISTER(LOG_DOMAIN);
 #endif
 
 #include <drivers/modem/modem_receiver.h>
+
+LOG_MODULE_REGISTER(modem_wncm14a2a, CONFIG_MODEM_LOG_LEVEL);
 
 /* Uncomment the #define below to enable a hexdump of all incoming
  * data from the modem receiver

--- a/drivers/net/loopback.c
+++ b/drivers/net/loopback.c
@@ -10,17 +10,13 @@
  *
  * Network loopback interface implementation.
  */
-
-#define LOG_MODULE_NAME netlo
-#define LOG_LEVEL CONFIG_NET_LOOPBACK_LOG_LEVEL
-
-#include <logging/log.h>
-LOG_MODULE_REGISTER(LOG_MODULE_NAME);
-
 #include <net/net_pkt.h>
 #include <net/buf.h>
 #include <net/net_ip.h>
 #include <net/net_if.h>
+#include <logging/log.h>
+
+LOG_MODULE_REGISTER(netlo, CONFIG_NET_LOOPBACK_LOG_LEVEL);
 
 int loopback_dev_init(struct device *dev)
 {

--- a/drivers/net/slip.c
+++ b/drivers/net/slip.c
@@ -10,13 +10,6 @@
  * SLIP driver using uart_pipe. This is meant for network connectivity between
  * host and qemu. The host will need to run tunslip process.
  */
-
-#define LOG_MODULE_NAME slip
-#define LOG_LEVEL CONFIG_SLIP_LOG_LEVEL
-
-#include <logging/log.h>
-LOG_MODULE_REGISTER(LOG_MODULE_NAME);
-
 #include <stdio.h>
 
 #include <kernel.h>
@@ -33,6 +26,9 @@ LOG_MODULE_REGISTER(LOG_MODULE_NAME);
 #include <net/lldp.h>
 #include <console/uart_pipe.h>
 #include <net/ethernet.h>
+#include <logging/log.h>
+
+LOG_MODULE_REGISTER(slip, CONFIG_SLIP_LOG_LEVEL);
 
 #define SLIP_END     0300
 #define SLIP_ESC     0333

--- a/drivers/pwm/pwm_imx.c
+++ b/drivers/pwm/pwm_imx.c
@@ -8,10 +8,9 @@
 #include <pwm.h>
 #include <soc.h>
 #include <device_imx.h>
-
-#define LOG_LEVEL CONFIG_PWM_LOG_LEVEL
 #include <logging/log.h>
-LOG_MODULE_REGISTER(pwm_imx);
+
+LOG_MODULE_REGISTER(pwm_imx, CONFIG_PWM_LOG_LEVEL);
 
 #define PWM_PWMSR_FIFOAV_4WORDS	0x4
 

--- a/drivers/pwm/pwm_mcux_ftm.c
+++ b/drivers/pwm/pwm_mcux_ftm.c
@@ -9,10 +9,9 @@
 #include <soc.h>
 #include <fsl_ftm.h>
 #include <fsl_clock.h>
-
-#define LOG_LEVEL CONFIG_PWM_LOG_LEVEL
 #include <logging/log.h>
-LOG_MODULE_REGISTER(pwm_mcux_ftm);
+
+LOG_MODULE_REGISTER(pwm_mcux_ftm, CONFIG_PWM_LOG_LEVEL);
 
 #define MAX_CHANNELS ARRAY_SIZE(FTM0->CONTROLS)
 

--- a/drivers/pwm/pwm_nrf5_sw.c
+++ b/drivers/pwm/pwm_nrf5_sw.c
@@ -7,10 +7,9 @@
 #include <soc.h>
 
 #include "pwm.h"
-
-#define LOG_LEVEL CONFIG_PWM_LOG_LEVEL
 #include <logging/log.h>
-LOG_MODULE_REGISTER(pwm_nrf5_sw);
+
+LOG_MODULE_REGISTER(pwm_nrf5_sw, CONFIG_PWM_LOG_LEVEL);
 
 struct pwm_config {
 	NRF_TIMER_Type *timer;

--- a/drivers/pwm/pwm_nrfx.c
+++ b/drivers/pwm/pwm_nrfx.c
@@ -5,10 +5,9 @@
  */
 #include <nrfx_pwm.h>
 #include <pwm.h>
-
-#define LOG_LEVEL CONFIG_PWM_LOG_LEVEL
 #include <logging/log.h>
-LOG_MODULE_REGISTER(pwm_nrfx);
+
+LOG_MODULE_REGISTER(pwm_nrfx, CONFIG_PWM_LOG_LEVEL);
 
 #define PWM_NRFX_CH_VALUE_NORMAL        (1UL << 15)
 #define PWM_NRFX_CH_VALUE_INVERTED      (0)

--- a/drivers/sensor/bmc150_magn/bmc150_magn.c
+++ b/drivers/sensor/bmc150_magn/bmc150_magn.c
@@ -21,8 +21,7 @@
 
 #include "bmc150_magn.h"
 
-#define LOG_LEVEL CONFIG_SENSOR_LOG_LEVEL
-LOG_MODULE_REGISTER(BMC150_MAGN)
+LOG_MODULE_REGISTER(BMC150_MAGN, CONFIG_SENSOR_LOG_LEVEL);
 
 static const struct {
 	int freq;

--- a/drivers/spi/spi_dw.c
+++ b/drivers/spi/spi_dw.c
@@ -5,11 +5,6 @@
  *
  * SPDX-License-Identifier: Apache-2.0
  */
-#define LOG_DOMAIN "SPI DW"
-#define LOG_LEVEL CONFIG_SPI_LOG_LEVEL
-#include <logging/log.h>
-LOG_MODULE_REGISTER(spi_dw);
-
 #if (CONFIG_SPI_LOG_LEVEL == 4)
 #define DBG_COUNTER_INIT()	\
 	u32_t __cnt = 0
@@ -35,12 +30,15 @@ LOG_MODULE_REGISTER(spi_dw);
 #include <sys_io.h>
 #include <clock_control.h>
 #include <misc/util.h>
+#include <logging/log.h>
 
 #ifdef CONFIG_IOAPIC
 #include <drivers/ioapic.h>
 #endif
 
 #include <spi.h>
+
+LOG_MODULE_REGISTER(spi_dw, CONFIG_SPI_LOG_LEVEL);
 
 #include "spi_dw.h"
 #include "spi_context.h"

--- a/drivers/spi/spi_intel.c
+++ b/drivers/spi/spi_intel.c
@@ -5,30 +5,26 @@
  *
  * SPDX-License-Identifier: Apache-2.0
  */
-
-#define LOG_DOMAIN "SPI Intel"
-#define LOG_LEVEL CONFIG_SPI_LOG_LEVEL
-#include <logging/log.h>
-LOG_MODULE_REGISTER(spi_intel);
-
 #include <errno.h>
 
 #include <kernel.h>
 #include <arch/cpu.h>
-
 #include <misc/__assert.h>
 #include <soc.h>
 #include <init.h>
-
 #include <sys_io.h>
 #include <power.h>
+#include <logging/log.h>
 
 #include <spi.h>
-#include "spi_intel.h"
 
 #ifdef CONFIG_IOAPIC
 #include <drivers/ioapic.h>
 #endif
+
+LOG_MODULE_REGISTER(spi_intel, CONFIG_SPI_LOG_LEVEL);
+
+#include "spi_intel.h"
 
 static void completed(struct device *dev, u32_t error)
 {

--- a/drivers/spi/spi_ll_stm32.c
+++ b/drivers/spi/spi_ll_stm32.c
@@ -3,11 +3,6 @@
  *
  * SPDX-License-Identifier: Apache-2.0
  */
-
-#define LOG_LEVEL CONFIG_SPI_LOG_LEVEL
-#include <logging/log.h>
-LOG_MODULE_REGISTER(spi_ll_stm32);
-
 #include <misc/util.h>
 #include <kernel.h>
 #include <soc.h>
@@ -17,6 +12,9 @@ LOG_MODULE_REGISTER(spi_ll_stm32);
 
 #include <clock_control/stm32_clock_control.h>
 #include <clock_control.h>
+#include <logging/log.h>
+
+LOG_MODULE_REGISTER(spi_ll_stm32, CONFIG_SPI_LOG_LEVEL);
 
 #include "spi_ll_stm32.h"
 

--- a/drivers/spi/spi_mcux_dspi.c
+++ b/drivers/spi/spi_mcux_dspi.c
@@ -9,10 +9,9 @@
 #include <spi.h>
 #include <clock_control.h>
 #include <fsl_dspi.h>
-
-#define LOG_LEVEL CONFIG_SPI_LOG_LEVEL
 #include <logging/log.h>
-LOG_MODULE_REGISTER(spi_mcux_dspi);
+
+LOG_MODULE_REGISTER(spi_mcux_dspi, CONFIG_SPI_LOG_LEVEL);
 
 #include "spi_context.h"
 

--- a/drivers/spi/spi_mcux_lpspi.c
+++ b/drivers/spi/spi_mcux_lpspi.c
@@ -8,10 +8,9 @@
 #include <spi.h>
 #include <clock_control.h>
 #include <fsl_lpspi.h>
-
-#define LOG_LEVEL CONFIG_SPI_LOG_LEVEL
 #include <logging/log.h>
-LOG_MODULE_REGISTER(spi_mcux_lpspi);
+
+LOG_MODULE_REGISTER(spi_mcux_lpspi, CONFIG_SPI_LOG_LEVEL);
 
 #include "spi_context.h"
 

--- a/drivers/spi/spi_nrfx_spi.c
+++ b/drivers/spi/spi_nrfx_spi.c
@@ -6,11 +6,9 @@
 
 #include <spi.h>
 #include <nrfx_spi.h>
-
-#define LOG_DOMAIN "spi_nrfx_spi"
-#define LOG_LEVEL CONFIG_SPI_LOG_LEVEL
 #include <logging/log.h>
-LOG_MODULE_REGISTER(spi_nrfx_spi);
+
+LOG_MODULE_REGISTER(spi_nrfx_spi, CONFIG_SPI_LOG_LEVEL);
 
 #include "spi_context.h"
 

--- a/drivers/spi/spi_nrfx_spim.c
+++ b/drivers/spi/spi_nrfx_spim.c
@@ -7,11 +7,9 @@
 #include <spi.h>
 #include <nrfx_spim.h>
 #include <string.h>
-
-#define LOG_DOMAIN "spi_nrfx_spim"
-#define LOG_LEVEL CONFIG_SPI_LOG_LEVEL
 #include <logging/log.h>
-LOG_MODULE_REGISTER(spi_nrfx_spim);
+
+LOG_MODULE_REGISTER(spi_nrfx_spim, CONFIG_SPI_LOG_LEVEL);
 
 #include "spi_context.h"
 

--- a/drivers/spi/spi_nrfx_spis.c
+++ b/drivers/spi/spi_nrfx_spis.c
@@ -6,11 +6,9 @@
 
 #include <spi.h>
 #include <nrfx_spis.h>
-
-#define LOG_DOMAIN "spi_nrfx_spis"
-#define LOG_LEVEL CONFIG_SPI_LOG_LEVEL
 #include <logging/log.h>
-LOG_MODULE_REGISTER(spi_nrfx_spis);
+
+LOG_MODULE_REGISTER(spi_nrfx_spis, CONFIG_SPI_LOG_LEVEL);
 
 #include "spi_context.h"
 

--- a/drivers/spi/spi_sam.c
+++ b/drivers/spi/spi_sam.c
@@ -4,17 +4,16 @@
  *
  * SPDX-License-Identifier: Apache-2.0
  */
-
-#define LOG_LEVEL CONFIG_SPI_LOG_LEVEL
-#include <logging/log.h>
-LOG_MODULE_REGISTER(spi_sam);
-
-#include "spi_context.h"
 #include <errno.h>
 #include <device.h>
 #include <spi.h>
 #include <soc.h>
 #include <board.h>
+#include <logging/log.h>
+
+LOG_MODULE_REGISTER(spi_sam, CONFIG_SPI_LOG_LEVEL);
+
+#include "spi_context.h"
 
 #define SAM_SPI_CHIP_SELECT_COUNT			4
 

--- a/drivers/spi/spi_sam0.c
+++ b/drivers/spi/spi_sam0.c
@@ -3,17 +3,16 @@
  *
  * SPDX-License-Identifier: Apache-2.0
  */
-
-#define LOG_LEVEL CONFIG_SPI_LOG_LEVEL
-#include <logging/log.h>
-LOG_MODULE_REGISTER(spi_sam0);
-
-#include "spi_context.h"
 #include <errno.h>
 #include <device.h>
 #include <spi.h>
 #include <soc.h>
 #include <board.h>
+#include <logging/log.h>
+
+LOG_MODULE_REGISTER(spi_sam0, CONFIG_SPI_LOG_LEVEL);
+
+#include "spi_context.h"
 
 /* Device constant configuration parameters */
 struct spi_sam0_config {

--- a/drivers/usb/device/usb_dc_dw.c
+++ b/drivers/usb/device/usb_dc_dw.c
@@ -20,13 +20,12 @@
 #include <usb/usb_device.h>
 #include "usb_dw_registers.h"
 #include <soc.h>
+#include <logging/log.h>
 #ifdef CONFIG_QMSI
 #include "clk.h"
 #endif
 
-#define LOG_LEVEL CONFIG_USB_DRIVER_LOG_LEVEL
-#include <logging/log.h>
-LOG_MODULE_REGISTER(usb_dc_dw);
+LOG_MODULE_REGISTER(usb_dc_dw, CONFIG_USB_DRIVER_LOG_LEVEL);
 
 /* convert from endpoint address to hardware endpoint index */
 #define USB_DW_EP_ADDR2IDX(ep)  ((ep) & ~USB_EP_DIR_MASK)

--- a/drivers/usb/device/usb_dc_kinetis.c
+++ b/drivers/usb/device/usb_dc_kinetis.c
@@ -13,10 +13,9 @@
 #include <misc/byteorder.h>
 #include <usb/usb_device.h>
 #include <device.h>
-
-#define LOG_LEVEL CONFIG_USB_DRIVER_LOG_LEVEL
 #include <logging/log.h>
-LOG_MODULE_REGISTER(usb_dc_kinetis);
+
+LOG_MODULE_REGISTER(usb_dc_kinetis, CONFIG_USB_DRIVER_LOG_LEVEL);
 
 #define NUM_OF_EP_MAX		CONFIG_USBD_KINETIS_NUM_BIDIR_EP
 

--- a/drivers/usb/device/usb_dc_sam0.c
+++ b/drivers/usb/device/usb_dc_sam0.c
@@ -3,14 +3,12 @@
  *
  * SPDX-License-Identifier: Apache-2.0
  */
-
-#define LOG_LEVEL CONFIG_USB_DRIVER_LOG_LEVEL
-#include <logging/log.h>
-LOG_MODULE_REGISTER(usb_dc_sam0);
-
 #include <usb/usb_device.h>
 #include <soc.h>
 #include <string.h>
+#include <logging/log.h>
+
+LOG_MODULE_REGISTER(usb_dc_sam0, CONFIG_USB_DRIVER_LOG_LEVEL);
 
 #define NVM_USB_PAD_TRANSN_POS 45
 #define NVM_USB_PAD_TRANSN_SIZE 5

--- a/drivers/usb/device/usb_dc_stm32.c
+++ b/drivers/usb/device/usb_dc_stm32.c
@@ -50,10 +50,9 @@
 #include <clock_control/stm32_clock_control.h>
 #include <misc/util.h>
 #include <gpio.h>
-
-#define LOG_LEVEL CONFIG_USB_DRIVER_LOG_LEVEL
 #include <logging/log.h>
-LOG_MODULE_REGISTER(usb_dc_stm32);
+
+LOG_MODULE_REGISTER(usb_dc_stm32, CONFIG_USB_DRIVER_LOG_LEVEL);
 
 #if defined(CONFIG_USB_BASE_ADDRESS) && defined(CONFIG_USB_HS_BASE_ADDRES)
 #error "Only one interface should be enabled at a time, OTG FS or OTG HS"

--- a/drivers/watchdog/wdt_mcux_wdog.c
+++ b/drivers/watchdog/wdt_mcux_wdog.c
@@ -8,10 +8,9 @@
 #include <watchdog.h>
 #include <clock_control.h>
 #include <fsl_wdog.h>
-
-#define LOG_LEVEL CONFIG_WDT_LOG_LEVEL
 #include <logging/log.h>
-LOG_MODULE_REGISTER(wdt_mcux_wdog)
+
+LOG_MODULE_REGISTER(wdt_mcux_wdog, CONFIG_WDT_LOG_LEVEL);
 
 #define MIN_TIMEOUT 4
 

--- a/drivers/watchdog/wdt_nrfx.c
+++ b/drivers/watchdog/wdt_nrfx.c
@@ -6,10 +6,9 @@
 
 #include <nrfx_wdt.h>
 #include <watchdog.h>
-
-#define LOG_LEVEL CONFIG_WDT_LOG_LEVEL
 #include <logging/log.h>
-LOG_MODULE_REGISTER(wdt_nrfx);
+
+LOG_MODULE_REGISTER(wdt_nrfx, CONFIG_WDT_LOG_LEVEL);
 
 DEVICE_DECLARE(wdt_nrfx);
 

--- a/drivers/watchdog/wdt_sam.c
+++ b/drivers/watchdog/wdt_sam.c
@@ -17,10 +17,9 @@
 
 #include <watchdog.h>
 #include <soc.h>
-
-#define LOG_LEVEL CONFIG_WDT_LOG_LEVEL
 #include <logging/log.h>
-LOG_MODULE_REGISTER(wdt_sam);
+
+LOG_MODULE_REGISTER(wdt_sam, CONFIG_WDT_LOG_LEVEL);
 
 /* Device constant configuration parameters */
 struct wdt_sam_dev_cfg {

--- a/drivers/wifi/simplelink/simplelink.c
+++ b/drivers/wifi/simplelink/simplelink.c
@@ -3,9 +3,11 @@
  *
  * SPDX-License-Identifier: Apache-2.0
  */
-
 #include "simplelink_log.h"
-LOG_MODULE_REGISTER(LOG_MODULE_NAME);
+LOG_MODULE_REGISTER(LOG_MODULE_NAME, LOG_LEVEL);
+
+/* This prevents log module registration in net_core.h */
+#define LOG_LEVEL	0
 
 #include <zephyr.h>
 #include <kernel.h>

--- a/drivers/wifi/simplelink/simplelink_sockets.c
+++ b/drivers/wifi/simplelink/simplelink_sockets.c
@@ -5,7 +5,7 @@
  */
 
 #include "simplelink_log.h"
-LOG_MODULE_DECLARE(LOG_MODULE_NAME);
+LOG_MODULE_DECLARE(LOG_MODULE_NAME, LOG_LEVEL);
 
 #include <stdlib.h>
 #include <limits.h>

--- a/drivers/wifi/simplelink/simplelink_support.c
+++ b/drivers/wifi/simplelink/simplelink_support.c
@@ -9,7 +9,7 @@
 #include <string.h>
 
 #include "simplelink_log.h"
-LOG_MODULE_DECLARE(LOG_MODULE_NAME);
+LOG_MODULE_DECLARE(LOG_MODULE_NAME, LOG_LEVEL);
 
 #include <zephyr.h>
 #include <stdint.h>

--- a/drivers/wifi/winc1500/wifi_winc1500.c
+++ b/drivers/wifi/winc1500/wifi_winc1500.c
@@ -7,9 +7,6 @@
 #define LOG_MODULE_NAME wifi_winc1500
 #define LOG_LEVEL CONFIG_WIFI_LOG_LEVEL
 
-#include <logging/log.h>
-LOG_MODULE_REGISTER(LOG_MODULE_NAME);
-
 #include <zephyr.h>
 #include <kernel.h>
 #include <device.h>
@@ -23,6 +20,9 @@ LOG_MODULE_REGISTER(LOG_MODULE_NAME);
 #include <net/wifi_mgmt.h>
 
 #include <misc/printk.h>
+#include <logging/log.h>
+
+LOG_MODULE_REGISTER(wifi_winc1500, CONFIG_WIFI_LOG_LEVEL);
 
 /* We do not need <socket/include/socket.h>
  * It seems there is a bug in ASF side: if OS is already defining sockaddr

--- a/drivers/wifi/winc1500/wifi_winc1500_nm_bus_wrapper.c
+++ b/drivers/wifi/winc1500/wifi_winc1500_nm_bus_wrapper.c
@@ -3,16 +3,12 @@
  *
  * SPDX-License-Identifier: Apache-2.0
  */
-
-#define LOG_LEVEL CONFIG_WIFI_LOG_LEVEL
-#include <logging/log.h>
-LOG_MODULE_REGISTER(winc1500);
-
 #include <stdio.h>
 #include <stdint.h>
 
 #include <device.h>
 #include <spi.h>
+#include <logging/log.h>
 
 #include "wifi_winc1500_nm_bsp_internal.h"
 
@@ -21,6 +17,8 @@ LOG_MODULE_REGISTER(winc1500);
 #include <bus_wrapper/include/nm_bus_wrapper.h>
 
 #include "wifi_winc1500_config.h"
+
+LOG_MODULE_DECLARE(winc1500, CONFIG_WIFI_LOG_LEVEL);
 
 #define NM_BUS_MAX_TRX_SZ	256
 

--- a/include/logging/log.h
+++ b/include/logging/log.h
@@ -269,38 +269,41 @@ int log_printk(const char *fmt, va_list ap);
  */
 char *log_strdup(const char *str);
 
-#define __DYNAMIC_MODULE_REGISTER(_name)\
-	struct log_source_dynamic_data LOG_ITEM_DYNAMIC_DATA(_name)	\
-	__attribute__ ((section("." STRINGIFY(				\
-				     LOG_ITEM_DYNAMIC_DATA(_name))))	\
-				     )					\
-	__attribute__((used));						\
-	static inline const struct log_source_dynamic_data  *		\
-				__log_current_dynamic_data_get(void)	\
-	{								\
-		return &LOG_ITEM_DYNAMIC_DATA(_name);			\
-	}
+/* Macro expects that optionally on second argument local log level is provided.
+ * If provided it is returned, otherwise default log level is returned.
+ */
+#define _LOG_LEVEL_RESOLVE(...) \
+	__LOG_ARG_2(__VA_ARGS__, CONFIG_LOG_DEFAULT_LEVEL)
 
-#define _LOG_RUNTIME_MODULE_REGISTER(_name)				\
-	_LOG_EVAL(							\
-		CONFIG_LOG_RUNTIME_FILTERING,				\
-		(; __DYNAMIC_MODULE_REGISTER(_name)),			\
-		()							\
-	)
+/* Return first argument */
+#define _LOG_ARG1(arg1, ...) arg1
 
-#define _LOG_MODULE_REGISTER(_name, _level)				     \
+
+#define _LOG_MODULE_CONST_DATA_CREATE(_name, _level)			     \
 	const struct log_source_const_data LOG_ITEM_CONST_DATA(_name)	     \
 	__attribute__ ((section("." STRINGIFY(LOG_ITEM_CONST_DATA(_name))))) \
 	__attribute__((used)) = {					     \
 		.name = STRINGIFY(_name),				     \
 		.level = _level						     \
-	}								     \
-	_LOG_RUNTIME_MODULE_REGISTER(_name);				     \
-	static inline const struct log_source_const_data *		     \
-				__log_current_const_data_get(void)	     \
-	{								     \
-		return &LOG_ITEM_CONST_DATA(_name);			     \
 	}
+
+#define _LOG_MODULE_DYNAMIC_DATA_CREATE(_name)				\
+	struct log_source_dynamic_data LOG_ITEM_DYNAMIC_DATA(_name)	\
+	__attribute__ ((section("." STRINGIFY(				\
+				     LOG_ITEM_DYNAMIC_DATA(_name))))	\
+				     )					\
+	__attribute__((used))
+
+#define _LOG_MODULE_DYNAMIC_DATA_COND_CREATE(_name)		\
+	_LOG_EVAL(						\
+		IS_ENABLED(CONFIG_LOG_RUNTIME_FILTERING),	\
+		(_LOG_MODULE_DYNAMIC_DATA_CREATE(_name);),	\
+		()						\
+		)
+
+#define _LOG_MODULE_DATA_CREATE(_name, _level)			\
+	_LOG_MODULE_CONST_DATA_CREATE(_name, _level);		\
+	_LOG_MODULE_DYNAMIC_DATA_COND_CREATE(_name)
 
 /**
  * @brief Create module-specific state and register the module with Logger.
@@ -313,7 +316,19 @@ char *log_strdup(const char *str);
  * - The module consists of more than one file, and another file
  *   invokes this macro. (LOG_MODULE_DECLARE() should be used instead
  *   in all of the module's other files.)
- * - Instance logging is used and there is no need to create module entry.
+ * - Instance logging is used and there is no need to create module entry. In
+ *   that case LOG_LEVEL_SET() should be used to set log level used within the
+ *   file.
+ *
+ * Macro accepts one or two parameters:
+ * - module name
+ * - optional log level. If not provided then default log level is used in
+ *  the file.
+ *
+ * Example usage:
+ * - LOG_MODULE_REGISTER(foo, CONFIG_FOO_LOG_LEVEL)
+ * - LOG_MODULE_REGISTER(foo)
+ *
  *
  * @note The module's state is defined, and the module is registered,
  *       only if LOG_LEVEL for the current source file is non-zero or
@@ -321,36 +336,16 @@ char *log_strdup(const char *str);
  *       In other cases, this macro has no effect.
  * @see LOG_MODULE_DECLARE
  */
-#define LOG_MODULE_REGISTER(log_module_name)				\
+
+
+#define LOG_MODULE_REGISTER(...)					\
 	_LOG_EVAL(							\
-		_LOG_LEVEL(),						\
-		(_LOG_MODULE_REGISTER(log_module_name, _LOG_LEVEL())),	\
+		_LOG_LEVEL_RESOLVE(__VA_ARGS__),			\
+		(_LOG_MODULE_DATA_CREATE(_LOG_ARG1(__VA_ARGS__),	\
+				      _LOG_LEVEL_RESOLVE(__VA_ARGS__))),\
 		()/*Empty*/						\
-	)
-
-#define __DYNAMIC_MODULE_DECLARE(_name)					   \
-	extern struct log_source_dynamic_data LOG_ITEM_DYNAMIC_DATA(_name);\
-	static inline struct log_source_dynamic_data *			   \
-				__log_current_dynamic_data_get(void)	   \
-	{								   \
-		return &LOG_ITEM_DYNAMIC_DATA(_name);			   \
-	}
-
-#define _LOG_RUNTIME_MODULE_DECLARE(_name)			\
-	_LOG_EVAL(						\
-		CONFIG_LOG_RUNTIME_FILTERING,			\
-		(; __DYNAMIC_MODULE_DECLARE(_name)),		\
-		()						\
-		)
-
-#define _LOG_MODULE_DECLARE(_name, _level)				     \
-	extern const struct log_source_const_data LOG_ITEM_CONST_DATA(_name) \
-	_LOG_RUNTIME_MODULE_DECLARE(_name);				     \
-	static inline const struct log_source_const_data *		     \
-				__log_current_const_data_get(void)	     \
-	{								     \
-		return &LOG_ITEM_CONST_DATA(_name);			     \
-	}
+	)								\
+	LOG_MODULE_DECLARE(__VA_ARGS__)
 
 /**
  * @brief Macro for declaring a log module (not registering it).
@@ -363,18 +358,50 @@ char *log_strdup(const char *str);
  * declare that same state. (Otherwise, LOG_INF() etc. will not be
  * able to refer to module-specific state variables.)
  *
+ * Macro accepts one or two parameters:
+ * - module name
+ * - optional log level. If not provided then default log level is used in
+ *  the file.
+ *
+ * Example usage:
+ * - LOG_MODULE_DECLARE(foo, CONFIG_FOO_LOG_LEVEL)
+ * - LOG_MODULE_DECLARE(foo)
+ *
  * @note The module's state is declared only if LOG_LEVEL for the
  *       current source file is non-zero or it is not defined and
  *       CONFIG_LOG_DEFAULT_LOG_LEVEL is non-zero.  In other cases,
  *       this macro has no effect.
  * @see LOG_MODULE_REGISTER
  */
-#define LOG_MODULE_DECLARE(log_module_name)				\
-	_LOG_EVAL(							\
-		_LOG_LEVEL(),						\
-		(_LOG_MODULE_DECLARE(log_module_name, _LOG_LEVEL())),	\
-		()							\
-		)							\
+#define LOG_MODULE_DECLARE(...)						      \
+	extern const struct log_source_const_data			      \
+			LOG_ITEM_CONST_DATA(_LOG_ARG1(__VA_ARGS__));	      \
+	extern struct log_source_dynamic_data				      \
+			LOG_ITEM_DYNAMIC_DATA(_LOG_ARG1(__VA_ARGS__));	      \
+									      \
+	static const struct log_source_const_data *			      \
+		__log_current_const_data __attribute__((unused)) =	      \
+			_LOG_LEVEL_RESOLVE(__VA_ARGS__) ?		      \
+			&LOG_ITEM_CONST_DATA(_LOG_ARG1(__VA_ARGS__)) : NULL;  \
+									      \
+	static struct log_source_dynamic_data *				      \
+		__log_current_dynamic_data __attribute__((unused)) =	      \
+			(_LOG_LEVEL_RESOLVE(__VA_ARGS__) &&		      \
+			IS_ENABLED(CONFIG_LOG_RUNTIME_FILTERING)) ?	      \
+			&LOG_ITEM_DYNAMIC_DATA(_LOG_ARG1(__VA_ARGS__)) : NULL;\
+									      \
+	static const u32_t __log_level __attribute__((unused)) =	      \
+					_LOG_LEVEL_RESOLVE(__VA_ARGS__)
+
+/**
+ * @brief Macro for setting log level in the file or function where instance
+ * logging API is used.
+ *
+ * @param level Level used in file or in function.
+ *
+ */
+#define LOG_LEVEL_SET(level) \
+	static const u32_t __log_level __attribute__((unused)) = level
 
 /**
  * @}

--- a/include/logging/log_core.h
+++ b/include/logging/log_core.h
@@ -51,8 +51,8 @@ extern "C" {
 /**
  * @brief Macro for conditional code generation if provided log level allows.
  *
- * Macro behaves similarly to standard #if #else #endif clause. The difference is
- * that it is evaluated when used and not when header file is included.
+ * Macro behaves similarly to standard #if #else #endif clause. The difference
+ * is that it is evaluated when used and not when header file is included.
  *
  * @param _eval_level Evaluated level. If level evaluates to one of existing log
  *		      log level (1-4) then macro evaluates to _iftrue.
@@ -108,44 +108,39 @@ extern "C" {
  *
  *  @param _addr Address of the element.
  */
-#define LOG_CONST_ID_GET(_addr)						       \
-	_LOG_EVAL(							       \
-	  _LOG_LEVEL(),							       \
-	  (log_const_source_id((const struct log_source_const_data *)_addr)),  \
-	  (0)								       \
+#define LOG_CONST_ID_GET(_addr) \
+	_LOG_EVAL(\
+	  CONFIG_LOG,\
+	  (__log_level ? \
+	  log_const_source_id((const struct log_source_const_data *)_addr) : \
+	  0),\
+	  (0)\
 	)
 
 /**
  * @def LOG_CURRENT_MODULE_ID
  * @brief Macro for getting ID of current module.
  */
-#define LOG_CURRENT_MODULE_ID()						\
-	_LOG_EVAL(							\
-	  _LOG_LEVEL(),							\
-	  (log_const_source_id(__log_current_const_data_get())),	\
-	  (0)								\
-	)
+#define LOG_CURRENT_MODULE_ID() (__log_level ? \
+	log_const_source_id(__log_current_const_data) : 0)
 
 /**
  * @def LOG_CURRENT_DYNAMIC_DATA_ADDR
  * @brief Macro for getting address of dynamic structure of current module.
  */
-#define LOG_CURRENT_DYNAMIC_DATA_ADDR()			\
-	_LOG_EVAL(					\
-	  _LOG_LEVEL(),					\
-	  (__log_current_dynamic_data_get()),		\
-	  ((struct log_source_dynamic_data *)0)		\
-	)
+#define LOG_CURRENT_DYNAMIC_DATA_ADDR()	(__log_level ? \
+	__log_current_dynamic_data : (struct log_source_dynamic_data *)0)
 
 /** @brief Macro for getting ID of the element of the section.
  *
  *  @param _addr Address of the element.
  */
-#define LOG_DYNAMIC_ID_GET(_addr)					     \
-	_LOG_EVAL(							     \
-	  _LOG_LEVEL(),							     \
-	  (log_dynamic_source_id((struct log_source_dynamic_data *)_addr)),  \
-	  (0)								     \
+#define LOG_DYNAMIC_ID_GET(_addr) \
+	_LOG_EVAL(\
+	  CONFIG_LOG,\
+	  (__log_level ? \
+	  log_dynamic_source_id((struct log_source_dynamic_data *)_addr) : 0),\
+	  (0)\
 	)
 
 /**
@@ -229,7 +224,7 @@ extern "C" {
 	_LOG_LEVEL_CHECK(_level, CONFIG_LOG_OVERRIDE_LEVEL, LOG_LEVEL_NONE) \
 	||								    \
 	(!IS_ENABLED(CONFIG_LOG_OVERRIDE_LEVEL) &&			    \
-	_LOG_LEVEL_CHECK(_level, LOG_LEVEL, CONFIG_LOG_DEFAULT_LEVEL) &&    \
+	(_level <= __log_level) &&					    \
 	(_level <= CONFIG_LOG_MAX_LEVEL)				    \
 	)								    \
 	))

--- a/include/net/net_core.h
+++ b/include/net/net_core.h
@@ -51,7 +51,7 @@ extern "C" {
 #if defined(NET_LOG_LEVEL)
 #include <logging/log.h>
 
-LOG_MODULE_REGISTER(LOG_MODULE_NAME);
+LOG_MODULE_REGISTER(LOG_MODULE_NAME, LOG_LEVEL);
 #endif /* NET_LOG_LEVEL */
 
 #if defined(CONFIG_LOG_FUNCTION_NAME)

--- a/kernel/init.c
+++ b/kernel/init.c
@@ -33,11 +33,11 @@
 #include <logging/log_ctrl.h>
 #include <tracing.h>
 #include <stdbool.h>
+#include <logging/log.h>
 
 #define IDLE_THREAD_NAME	"idle"
-#define LOG_LEVEL CONFIG_KERNEL_LOG_LEVEL
-#include <logging/log.h>
-LOG_MODULE_REGISTER(kernel);
+
+LOG_MODULE_REGISTER(kernel, CONFIG_KERNEL_LOG_LEVEL);
 
 /* boot banner items */
 #if defined(CONFIG_BOOT_DELAY) && CONFIG_BOOT_DELAY > 0

--- a/kernel/userspace.c
+++ b/kernel/userspace.c
@@ -16,10 +16,9 @@
 #include <syscall_handler.h>
 #include <device.h>
 #include <init.h>
-
-#define LOG_LEVEL CONFIG_KERNEL_LOG_LEVEL
 #include <logging/log.h>
-LOG_MODULE_DECLARE(kernel);
+
+LOG_MODULE_DECLARE(kernel, CONFIG_KERNEL_LOG_LEVEL);
 
 #if defined(CONFIG_NETWORKING) && defined (CONFIG_DYNAMIC_OBJECTS)
 /* Used by auto-generated obj_size_get() switch body, as we need to

--- a/lib/libc/minimal/source/stdlib/malloc.c
+++ b/lib/libc/minimal/source/stdlib/malloc.c
@@ -10,10 +10,9 @@
 #include <errno.h>
 #include <misc/mempool.h>
 #include <string.h>
-
-#define LOG_LEVEL CONFIG_KERNEL_LOG_LEVEL
 #include <logging/log.h>
-LOG_MODULE_DECLARE(os);
+
+LOG_MODULE_DECLARE(os, CONFIG_KERNEL_LOG_LEVEL);
 
 #if (CONFIG_MINIMAL_LIBC_MALLOC_ARENA_SIZE > 0)
 K_MUTEX_DEFINE(malloc_mutex);

--- a/samples/display/ili9340/src/main.c
+++ b/samples/display/ili9340/src/main.c
@@ -9,9 +9,8 @@
 #include <stdio.h>
 #include <string.h>
 #include <zephyr.h>
-
-#define LOG_LEVEL CONFIG_LOG_DEFAULT_LEVEL
 #include <logging/log.h>
+
 LOG_MODULE_REGISTER(main);
 
 /* This example will update each 500ms one of the LCD corners

--- a/samples/drivers/crypto/src/main.c
+++ b/samples/drivers/crypto/src/main.c
@@ -12,10 +12,9 @@
 #include <zephyr.h>
 #include <string.h>
 #include <crypto/cipher.h>
-
-#define LOG_LEVEL CONFIG_CRYPTO_LOG_LEVEL
 #include <logging/log.h>
-LOG_MODULE_REGISTER(main);
+
+LOG_MODULE_REGISTER(main, CONFIG_CRYPTO_LOG_LEVEL);
 
 #ifdef CONFIG_CRYPTO_TINYCRYPT_SHIM
 #define CRYPTO_DRV_NAME CONFIG_CRYPTO_TINYCRYPT_SHIM_DRV_NAME

--- a/samples/drivers/led_lp3943/src/main.c
+++ b/samples/drivers/led_lp3943/src/main.c
@@ -9,10 +9,9 @@
 #include <led.h>
 #include <misc/util.h>
 #include <zephyr.h>
-
-#define LOG_LEVEL CONFIG_LOG_DEFAULT_LEVEL
 #include <logging/log.h>
-LOG_MODULE_REGISTER(log)
+
+LOG_MODULE_REGISTER(app);
 
 #define LED_DEV_NAME CONFIG_LP3943_DEV_NAME
 #define NUM_LEDS 16

--- a/samples/drivers/led_lp5562/src/main.c
+++ b/samples/drivers/led_lp5562/src/main.c
@@ -9,10 +9,9 @@
 #include <led.h>
 #include <misc/util.h>
 #include <zephyr.h>
-
-#define LOG_LEVEL 4
 #include <logging/log.h>
-LOG_MODULE_REGISTER(main);
+
+LOG_MODULE_REGISTER(main, LOG_LEVEL_DBG);
 
 #define LED_DEV_NAME CONFIG_LP5562_DEV_NAME
 #define NUM_LEDS 4

--- a/samples/drivers/led_lpd8806/src/main.c
+++ b/samples/drivers/led_lpd8806/src/main.c
@@ -6,16 +6,14 @@
 
 #include <errno.h>
 #include <string.h>
-
-#define LOG_LEVEL CONFIG_LOG_DEFAULT_LEVEL
 #include <logging/log.h>
-LOG_MODULE_REGISTER(main);
-
 #include <zephyr.h>
 #include <led_strip.h>
 #include <device.h>
 #include <spi.h>
 #include <misc/util.h>
+
+LOG_MODULE_REGISTER(main);
 
 /*
  * Number of RGB LEDs in the LED strip, adjust as needed.

--- a/samples/drivers/led_pca9633/src/main.c
+++ b/samples/drivers/led_pca9633/src/main.c
@@ -9,9 +9,8 @@
 #include <led.h>
 #include <misc/util.h>
 #include <zephyr.h>
-
-#define LOG_LEVEL CONFIG_LOG_DEFAULT_LEVEL
 #include <logging/log.h>
+
 LOG_MODULE_REGISTER(main);
 
 #define LED_DEV_NAME CONFIG_PCA9633_DEV_NAME

--- a/samples/drivers/led_ws2812/src/main.c
+++ b/samples/drivers/led_ws2812/src/main.c
@@ -7,16 +7,14 @@
 
 #include <errno.h>
 #include <string.h>
-
-#define LOG_LEVEL 4
 #include <logging/log.h>
-LOG_MODULE_REGISTER(main);
-
 #include <zephyr.h>
 #include <led_strip.h>
 #include <device.h>
 #include <spi.h>
 #include <misc/util.h>
+
+LOG_MODULE_REGISTER(main, LOG_LEVEL_DBG);
 
 /*
  * Number of RGB LEDs in the LED strip, adjust as needed.

--- a/samples/net/lwm2m_client/src/lwm2m-client.c
+++ b/samples/net/lwm2m_client/src/lwm2m-client.c
@@ -5,15 +5,12 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#define LOG_MODULE_NAME net_lwm2m_client_app
-#define LOG_LEVEL LOG_LEVEL_DBG
-
 #include <logging/log.h>
-LOG_MODULE_REGISTER(LOG_MODULE_NAME);
-
 #include <zephyr.h>
 #include <gpio.h>
 #include <net/lwm2m.h>
+
+LOG_MODULE_REGISTER(net_lwm2m_client_app, LOG_LEVEL_DBG);
 
 #define APP_BANNER "Run LWM2M client"
 

--- a/samples/subsys/logging/logger/src/ext_log_system_adapter.c
+++ b/samples/subsys/logging/logger/src/ext_log_system_adapter.c
@@ -6,8 +6,6 @@
 
 #include "ext_log_system_adapter.h"
 #include "ext_log_system.h"
-
-#define LOG_MODULE_NAME ext_log_system
 #include <logging/log.h>
 
 LOG_MODULE_REGISTER(ext_log_system);

--- a/samples/subsys/logging/logger/src/main.c
+++ b/samples/subsys/logging/logger/src/main.c
@@ -81,6 +81,7 @@ static void module_logging_showcase(void)
 	printk("Module logging showcase.\n");
 
 	sample_module_func();
+	inline_func();
 
 	if (IS_ENABLED(CONFIG_LOG_RUNTIME_FILTERING)) {
 		printk("Disabling logging in the %s module\n",
@@ -111,7 +112,9 @@ static void instance_logging_showcase(void)
 {
 	printk("Instance level logging showcase.\n");
 
+	sample_instance_inline_call(&inst1);
 	sample_instance_call(&inst1);
+	sample_instance_inline_call(&inst2);
 	sample_instance_call(&inst2);
 
 	if (IS_ENABLED(CONFIG_LOG_RUNTIME_FILTERING)) {
@@ -121,7 +124,9 @@ static void instance_logging_showcase(void)
 		log_filter_set(NULL, 0,
 			       log_source_id_get(INST1_NAME), LOG_LEVEL_WRN);
 
+		sample_instance_inline_call(&inst1);
 		sample_instance_call(&inst1);
+		sample_instance_inline_call(&inst2);
 		sample_instance_call(&inst2);
 
 		printk("Disabling logging on both instances.\n");
@@ -134,7 +139,9 @@ static void instance_logging_showcase(void)
 			       log_source_id_get(INST2_NAME),
 			       LOG_LEVEL_NONE);
 
+		sample_instance_inline_call(&inst1);
 		sample_instance_call(&inst1);
+		sample_instance_inline_call(&inst2);
 		sample_instance_call(&inst2);
 
 		printk("Function call on both instances with logging disabled.\n");

--- a/samples/subsys/logging/logger/src/sample_instance.c
+++ b/samples/subsys/logging/logger/src/sample_instance.c
@@ -11,6 +11,8 @@
  */
 #include <logging/log.h>
 
+LOG_LEVEL_SET(LOG_LEVEL_INF);
+
 void sample_instance_call(struct sample_instance *inst)
 {
 	u8_t data[4] = { 1, 2, 3, 4 };

--- a/samples/subsys/logging/logger/src/sample_instance.h
+++ b/samples/subsys/logging/logger/src/sample_instance.h
@@ -8,6 +8,7 @@
 
 #include <kernel.h>
 #include <logging/log_instance.h>
+#include <logging/log.h>
 
 #define SAMPLE_INSTANCE_NAME sample_instance
 
@@ -16,12 +17,19 @@ struct sample_instance {
 	u32_t cnt;
 };
 
-#define SAMPLE_INSTANCE_DEFINE(_name)					\
-	LOG_INSTANCE_REGISTER(SAMPLE_INSTANCE_NAME, _name, 3);		\
-	struct sample_instance _name = {				\
-		LOG_INSTANCE_PTR_INIT(log, SAMPLE_INSTANCE_NAME, _name)	\
+#define SAMPLE_INSTANCE_DEFINE(_name)					   \
+	LOG_INSTANCE_REGISTER(SAMPLE_INSTANCE_NAME, _name, LOG_LEVEL_INF); \
+	struct sample_instance _name = {				   \
+		LOG_INSTANCE_PTR_INIT(log, SAMPLE_INSTANCE_NAME, _name)	   \
 	}
 
 void sample_instance_call(struct sample_instance *inst);
+
+static inline void sample_instance_inline_call(struct sample_instance *inst)
+{
+	LOG_LEVEL_SET(LOG_LEVEL_INF);
+
+	LOG_INST_INF(inst->log, "Inline call.");
+}
 
 #endif /*SAMPLE_INSTANCE_H*/

--- a/samples/subsys/logging/logger/src/sample_module.c
+++ b/samples/subsys/logging/logger/src/sample_module.c
@@ -5,14 +5,13 @@
  */
 #include <zephyr.h>
 #include <logging/log.h>
+#include "sample_module.h"
 
-#define LOG_MODULE_NAME sample_module
-#define LOG_LEVEL CONFIG_SAMPLE_MODULE_LOG_LEVEL
-LOG_MODULE_REGISTER(LOG_MODULE_NAME);
+LOG_MODULE_REGISTER(MODULE_NAME, CONFIG_SAMPLE_MODULE_LOG_LEVEL);
 
 const char *sample_module_name_get(void)
 {
-	return STRINGIFY(LOG_MODULE_NAME);
+	return STRINGIFY(MODULE_NAME);
 }
 
 void sample_module_func(void)

--- a/samples/subsys/logging/logger/src/sample_module.h
+++ b/samples/subsys/logging/logger/src/sample_module.h
@@ -9,9 +9,19 @@
 #ifdef __cplusplus
 extern "C" {
 #endif
+#include <logging/log.h>
+
+#define MODULE_NAME sample_module
 
 const char *sample_module_name_get(void);
 void sample_module_func(void);
+
+static inline void inline_func(void)
+{
+	LOG_MODULE_DECLARE(MODULE_NAME, CONFIG_SAMPLE_MODULE_LOG_LEVEL);
+
+	LOG_INF("Inline function.");
+}
 
 #ifdef __cplusplus
 }

--- a/samples/subsys/usb/hid/src/main.c
+++ b/samples/subsys/usb/hid/src/main.c
@@ -10,8 +10,7 @@
 #include <usb/usb_device.h>
 #include <usb/class/usb_hid.h>
 
-#define LOG_LEVEL LOG_LEVEL_DBG
-LOG_MODULE_REGISTER(main)
+LOG_MODULE_REGISTER(main, LOG_LEVEL_DBG)
 
 #define REPORT_ID_1	0x01
 #define REPORT_ID_2	0x02

--- a/samples/subsys/usb/webusb/src/main.c
+++ b/samples/subsys/usb/webusb/src/main.c
@@ -12,22 +12,20 @@
  * data is echoed back to the WebUSB based application running in
  * the browser at host.
  */
-
-#define LOG_LEVEL CONFIG_LOG_DEFAULT_LEVEL
-#include <logging/log.h>
-LOG_MODULE_REGISTER(main);
-
 #include <stdio.h>
 #include <string.h>
 #include <device.h>
 #include <uart.h>
 #include <zephyr.h>
+#include <logging/log.h>
 #include <misc/byteorder.h>
 #include <usb/usb_common.h>
 #include <usb/usb_device.h>
 #include <usb/bos.h>
 
 #include "webusb_serial.h"
+
+LOG_MODULE_REGISTER(main);
 
 /* Predefined response to control commands related to MS OS 2.0 descriptors */
 static const u8_t msos2_descriptor[] = {

--- a/samples/subsys/usb/webusb/src/webusb_serial.c
+++ b/samples/subsys/usb/webusb/src/webusb_serial.c
@@ -38,7 +38,6 @@
  * to support the WebUSB.
  */
 
-#define LOG_LEVEL CONFIG_LOG_DEFAULT_LEVEL
 #include <logging/log.h>
 LOG_MODULE_DECLARE(main);
 

--- a/soc/arm/nordic_nrf/nrf51/soc.c
+++ b/soc/arm/nordic_nrf/nrf51/soc.c
@@ -24,9 +24,9 @@ extern void _NmiInit(void);
 #endif
 
 #include <system_nrf51.h>
-#define LOG_LEVEL CONFIG_SOC_LOG_LEVEL
 #include <logging/log.h>
-LOG_MODULE_REGISTER(soc);
+
+LOG_MODULE_REGISTER(soc, CONFIG_SOC_LOG_LEVEL);
 
 static int nordicsemi_nrf51_init(struct device *arg)
 {

--- a/soc/arm/nordic_nrf/nrf52/power.c
+++ b/soc/arm/nordic_nrf/nrf52/power.c
@@ -6,10 +6,9 @@
 #include <zephyr.h>
 #include <soc_power.h>
 #include <nrf_power.h>
-
-#define LOG_LEVEL CONFIG_SOC_LOG_LEVEL
 #include <logging/log.h>
-LOG_MODULE_DECLARE(soc);
+
+LOG_MODULE_DECLARE(soc, CONFIG_SOC_LOG_LEVEL);
 
 #if defined(CONFIG_SYS_POWER_DEEP_SLEEP)
 /* System_OFF is deepest Power state available, On exiting from this

--- a/soc/arm/nordic_nrf/nrf52/soc.c
+++ b/soc/arm/nordic_nrf/nrf52/soc.c
@@ -35,10 +35,9 @@ extern void _NmiInit(void);
 
 #include <nrf.h>
 #include <hal/nrf_power.h>
-
-#define LOG_LEVEL CONFIG_SOC_LOG_LEVEL
 #include <logging/log.h>
-LOG_MODULE_REGISTER(soc);
+
+LOG_MODULE_REGISTER(soc, CONFIG_SOC_LOG_LEVEL);
 
 static int nordicsemi_nrf52_init(struct device *arg)
 {

--- a/soc/x86/intel_quark/quark_se/soc.c
+++ b/soc/x86/intel_quark/quark_se/soc.c
@@ -22,10 +22,9 @@
 #include <init.h>
 #include "shared_mem.h"
 #include <mmustructs.h>
-
-#define LOG_LEVEL CONFIG_SOC_LOG_LEVEL
 #include <logging/log.h>
-LOG_MODULE_REGISTER(soc);
+
+LOG_MODULE_REGISTER(soc, CONFIG_SOC_LOG_LEVEL);
 
 #ifdef CONFIG_X86_MMU
 /* loapic */

--- a/soc/xtensa/intel_s1000/soc.c
+++ b/soc/xtensa/intel_s1000/soc.c
@@ -12,10 +12,9 @@
 #include <init.h>
 
 #include "soc.h"
-
-#define LOG_LEVEL CONFIG_SOC_LOG_LEVEL
 #include <logging/log.h>
-LOG_MODULE_REGISTER(soc);
+
+LOG_MODULE_REGISTER(soc, CONFIG_SOC_LOG_LEVEL);
 
 static u32_t ref_clk_freq;
 

--- a/subsys/bluetooth/host/l2cap.c
+++ b/subsys/bluetooth/host/l2cap.c
@@ -219,6 +219,11 @@ void bt_l2cap_chan_set_state_debug(struct bt_l2cap_chan *chan,
 	chan->state = state;
 }
 #else
+const char *bt_l2cap_chan_state_str(bt_l2cap_chan_state_t state)
+{
+	return NULL;
+}
+
 void bt_l2cap_chan_set_state(struct bt_l2cap_chan *chan,
 			     bt_l2cap_chan_state_t state)
 {

--- a/subsys/dfu/img_util/flash_img.c
+++ b/subsys/dfu/img_util/flash_img.c
@@ -5,11 +5,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#define LOG_MODULE_NAME fota_flash_block
-#define LOG_LEVEL CONFIG_IMG_MANAGER_LOG_LEVEL
-#include <logging/log.h>
-LOG_MODULE_REGISTER(LOG_MODULE_NAME);
-
 #include <zephyr/types.h>
 #include <stddef.h>
 #include <stdio.h>
@@ -18,6 +13,9 @@ LOG_MODULE_REGISTER(LOG_MODULE_NAME);
 #include <flash.h>
 #include <dfu/flash_img.h>
 #include <inttypes.h>
+#include <logging/log.h>
+
+LOG_MODULE_REGISTER(fota_flash_block, CONFIG_IMG_MANAGER_LOG_LEVEL);
 
 BUILD_ASSERT_MSG((CONFIG_IMG_BLOCK_BUF_SIZE % FLASH_WRITE_BLOCK_SIZE == 0),
 		 "CONFIG_IMG_BLOCK_BUF_SIZE is not a multiple of "

--- a/subsys/fs/nvs/nvs.c
+++ b/subsys/fs/nvs/nvs.c
@@ -12,10 +12,9 @@
 #include <nvs/nvs.h>
 #include <crc8.h>
 #include "nvs_priv.h"
-
-#define LOG_LEVEL CONFIG_NVS_LOG_LEVEL
 #include <logging/log.h>
-LOG_MODULE_REGISTER(fs_nvs);
+
+LOG_MODULE_REGISTER(fs_nvs, CONFIG_NVS_LOG_LEVEL);
 
 
 /* basic routines */

--- a/subsys/net/buf.c
+++ b/subsys/net/buf.c
@@ -6,12 +6,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#define LOG_MODULE_NAME net_buf
-#define LOG_LEVEL CONFIG_NET_BUF_LOG_LEVEL
-
-#include <logging/log.h>
-LOG_MODULE_REGISTER(LOG_MODULE_NAME);
-
 #include <stdio.h>
 #include <errno.h>
 #include <stddef.h>
@@ -21,6 +15,10 @@ LOG_MODULE_REGISTER(LOG_MODULE_NAME);
 #include <net/buf.h>
 
 #if defined(CONFIG_NET_BUF_LOG)
+
+#include <logging/log.h>
+LOG_MODULE_REGISTER(net_buf, CONFIG_NET_BUF_LOG_LEVEL);
+
 #define NET_BUF_DBG(fmt, ...) LOG_DBG("(%p) " fmt, k_current_get(), \
 				      ##__VA_ARGS__)
 #define NET_BUF_ERR(fmt, ...) LOG_ERR(fmt, ##__VA_ARGS__)

--- a/subsys/net/ip/ipv4_autoconf.c
+++ b/subsys/net/ip/ipv4_autoconf.c
@@ -10,7 +10,7 @@
  */
 
 #define LOG_MODULE_NAME net_ipv4_autoconf
-#define NET_LOG_LEVEL CONFIG_NET_IPV4_AUTOCONF_LOG_LEVEL
+#define NET_LOG_LEVEL CONFIG_NET_IPV4_AUTO_LOG_LEVEL
 
 #include "net_private.h"
 #include <errno.h>

--- a/subsys/net/lib/lwm2m/ipso_light_control.c
+++ b/subsys/net/lib/lwm2m/ipso_light_control.c
@@ -9,19 +9,15 @@
  * https://github.com/IPSO-Alliance/pub/blob/master/docs/IPSO-Smart-Objects.pdf
  * Section: "16. IPSO Object: Light Control"
  */
-
-#define LOG_MODULE_NAME net_ipso_light_control
-#define LOG_LEVEL CONFIG_LWM2M_LOG_LEVEL
-
-#include <logging/log.h>
-LOG_MODULE_REGISTER(LOG_MODULE_NAME);
-
 #include <stdint.h>
 #include <init.h>
+#include <logging/log.h>
 #include <net/lwm2m.h>
 
 #include "lwm2m_object.h"
 #include "lwm2m_engine.h"
+
+LOG_MODULE_REGISTER(net_ipso_light_control, CONFIG_LWM2M_LOG_LEVEL);
 
 /* Server resource IDs */
 #define LIGHT_ON_OFF_ID				5850

--- a/subsys/net/lib/lwm2m/ipso_temp_sensor.c
+++ b/subsys/net/lib/lwm2m/ipso_temp_sensor.c
@@ -9,19 +9,15 @@
  * https://github.com/IPSO-Alliance/pub/blob/master/docs/IPSO-Smart-Objects.pdf
  * Section: "10. IPSO Object: Temperature"
  */
-
-#define LOG_MODULE_NAME net_ipso_temp_sensor
-#define LOG_LEVEL CONFIG_LWM2M_LOG_LEVEL
-
-#include <logging/log.h>
-LOG_MODULE_REGISTER(LOG_MODULE_NAME);
-
 #include <stdint.h>
 #include <init.h>
+#include <logging/log.h>
 #include <net/lwm2m.h>
 
 #include "lwm2m_object.h"
 #include "lwm2m_engine.h"
+
+LOG_MODULE_REGISTER(net_ipso_temp_sensor, CONFIG_LWM2M_LOG_LEVEL);
 
 /* Server resource IDs */
 #define TEMP_SENSOR_VALUE_ID			5700

--- a/subsys/net/lib/lwm2m/lwm2m_engine.c
+++ b/subsys/net/lib/lwm2m/lwm2m_engine.c
@@ -22,12 +22,6 @@
  * - Handle Resource ObjLink type
  */
 
-#define LOG_MODULE_NAME net_lwm2m_engine
-#define LOG_LEVEL CONFIG_LWM2M_LOG_LEVEL
-
-#include <logging/log.h>
-LOG_MODULE_REGISTER(LOG_MODULE_NAME);
-
 #include <zephyr/types.h>
 #include <stddef.h>
 #include <stdlib.h>
@@ -37,6 +31,7 @@ LOG_MODULE_REGISTER(LOG_MODULE_NAME);
 #include <errno.h>
 #include <init.h>
 #include <misc/printk.h>
+#include <logging/log.h>
 #include <net/net_app.h>
 #include <net/net_ip.h>
 #include <net/net_pkt.h>
@@ -54,6 +49,8 @@ LOG_MODULE_REGISTER(LOG_MODULE_NAME);
 #ifdef CONFIG_LWM2M_RD_CLIENT_SUPPORT
 #include "lwm2m_rd_client.h"
 #endif
+
+LOG_MODULE_REGISTER(net_lwm2m_engine, CONFIG_LWM2M_LOG_LEVEL);
 
 #define ENGINE_UPDATE_INTERVAL K_MSEC(500)
 

--- a/subsys/net/lib/lwm2m/lwm2m_obj_device.c
+++ b/subsys/net/lib/lwm2m/lwm2m_obj_device.c
@@ -9,19 +9,15 @@
  * - Implement UTC_OFFSET & TIMEZONE
  * - Configurable CURRENT_TIME notification delay
  */
-
-#define LOG_MODULE_NAME net_lwm2m_obj_device
-#define LOG_LEVEL CONFIG_LWM2M_LOG_LEVEL
-
-#include <logging/log.h>
-LOG_MODULE_REGISTER(LOG_MODULE_NAME);
-
 #include <string.h>
 #include <stdio.h>
 #include <init.h>
+#include <logging/log.h>
 
 #include "lwm2m_object.h"
 #include "lwm2m_engine.h"
+
+LOG_MODULE_REGISTER(net_lwm2m_obj_device, CONFIG_LWM2M_LOG_LEVEL);
 
 /* Device resource IDs */
 #define DEVICE_MANUFACTURER_ID			0

--- a/subsys/net/lib/lwm2m/lwm2m_obj_firmware.c
+++ b/subsys/net/lib/lwm2m/lwm2m_obj_firmware.c
@@ -3,19 +3,15 @@
  *
  * SPDX-License-Identifier: Apache-2.0
  */
-
-#define LOG_MODULE_NAME net_lwm2m_obj_firmware
-#define LOG_LEVEL CONFIG_LWM2M_LOG_LEVEL
-
-#include <logging/log.h>
-LOG_MODULE_REGISTER(LOG_MODULE_NAME);
-
 #include <net/coap.h>
 #include <string.h>
 #include <init.h>
+#include <logging/log.h>
 
 #include "lwm2m_object.h"
 #include "lwm2m_engine.h"
+
+LOG_MODULE_REGISTER(net_lwm2m_obj_firmware, CONFIG_LWM2M_LOG_LEVEL);
 
 /* Firmware resource IDs */
 #define FIRMWARE_PACKAGE_ID			0

--- a/subsys/net/lib/lwm2m/lwm2m_obj_firmware_pull.c
+++ b/subsys/net/lib/lwm2m/lwm2m_obj_firmware_pull.c
@@ -3,16 +3,10 @@
  *
  * SPDX-License-Identifier: Apache-2.0
  */
-
-#define LOG_MODULE_NAME net_lwm2m_obj_firmware_pull
-#define LOG_LEVEL CONFIG_LWM2M_LOG_LEVEL
-
-#include <logging/log.h>
-LOG_MODULE_REGISTER(LOG_MODULE_NAME);
-
 #include <ctype.h>
 #include <stdio.h>
 #include <string.h>
+#include <logging/log.h>
 #include <net/coap.h>
 #include <net/net_app.h>
 #include <net/net_core.h>
@@ -22,6 +16,8 @@ LOG_MODULE_REGISTER(LOG_MODULE_NAME);
 
 #include "lwm2m_object.h"
 #include "lwm2m_engine.h"
+
+LOG_MODULE_REGISTER(net_lwm2m_obj_firmware_pull, CONFIG_LWM2M_LOG_LEVEL);
 
 #define URI_LEN		255
 

--- a/subsys/net/lib/lwm2m/lwm2m_obj_security.c
+++ b/subsys/net/lib/lwm2m/lwm2m_obj_security.c
@@ -3,18 +3,14 @@
  *
  * SPDX-License-Identifier: Apache-2.0
  */
-
-#define LOG_MODULE_NAME net_lwm2m_obj_security
-#define LOG_LEVEL CONFIG_LWM2M_LOG_LEVEL
-
-#include <logging/log.h>
-LOG_MODULE_REGISTER(LOG_MODULE_NAME);
-
 #include <stdint.h>
 #include <init.h>
+#include <logging/log.h>
 
 #include "lwm2m_object.h"
 #include "lwm2m_engine.h"
+
+LOG_MODULE_REGISTER(net_lwm2m_obj_security, CONFIG_LWM2M_LOG_LEVEL);
 
 /* Security resource IDs */
 #define SECURITY_SERVER_URI_ID			0

--- a/subsys/net/lib/lwm2m/lwm2m_obj_server.c
+++ b/subsys/net/lib/lwm2m/lwm2m_obj_server.c
@@ -3,15 +3,9 @@
  *
  * SPDX-License-Identifier: Apache-2.0
  */
-
-#define LOG_MODULE_NAME net_lwm2m_obj_server
-#define LOG_LEVEL CONFIG_LWM2M_LOG_LEVEL
-
-#include <logging/log.h>
-LOG_MODULE_REGISTER(LOG_MODULE_NAME);
-
 #include <stdint.h>
 #include <init.h>
+#include <logging/log.h>
 #include <net/lwm2m.h>
 
 #include "lwm2m_object.h"
@@ -19,6 +13,8 @@ LOG_MODULE_REGISTER(LOG_MODULE_NAME);
 #ifdef CONFIG_LWM2M_RD_CLIENT_SUPPORT
 #include "lwm2m_rd_client.h"
 #endif
+
+LOG_MODULE_REGISTER(net_lwm2m_obj_server, CONFIG_LWM2M_LOG_LEVEL);
 
 /* Server resource IDs */
 #define SERVER_SHORT_SERVER_ID		0

--- a/subsys/net/lib/lwm2m/lwm2m_rd_client.c
+++ b/subsys/net/lib/lwm2m/lwm2m_rd_client.c
@@ -41,19 +41,13 @@
  *         Niclas Finne <nfi@sics.se>
  *         Joel Hoglund <joel@sics.se>
  */
-
-#define LOG_MODULE_NAME net_lwm2m_rd_client
-#define LOG_LEVEL CONFIG_LWM2M_LOG_LEVEL
-
-#include <logging/log.h>
-LOG_MODULE_REGISTER(LOG_MODULE_NAME);
-
 #include <zephyr/types.h>
 #include <stddef.h>
 #include <stdio.h>
 #include <string.h>
 #include <errno.h>
 #include <init.h>
+#include <logging/log.h>
 #include <misc/printk.h>
 #include <net/net_pkt.h>
 #include <net/coap.h>
@@ -61,6 +55,8 @@ LOG_MODULE_REGISTER(LOG_MODULE_NAME);
 
 #include "lwm2m_object.h"
 #include "lwm2m_engine.h"
+
+LOG_MODULE_REGISTER(net_lwm2m_rd_client, CONFIG_LWM2M_LOG_LEVEL);
 
 #define LWM2M_RD_CLIENT_URI "rd"
 

--- a/subsys/net/lib/lwm2m/lwm2m_rw_json.c
+++ b/subsys/net/lib/lwm2m/lwm2m_rw_json.c
@@ -56,23 +56,19 @@
  * - Replace magic #'s with defines
  * - Research using Zephyr JSON lib for json_next_token()
  */
-
-#define LOG_MODULE_NAME net_lwm2m_json
-#define LOG_LEVEL CONFIG_LWM2M_LOG_LEVEL
-
-#include <logging/log.h>
-LOG_MODULE_REGISTER(LOG_MODULE_NAME);
-
 #include <stdio.h>
 #include <stddef.h>
 #include <stdint.h>
 #include <inttypes.h>
 #include <ctype.h>
+#include <logging/log.h>
 
 #include "lwm2m_object.h"
 #include "lwm2m_rw_json.h"
 #include "lwm2m_rw_plain_text.h"
 #include "lwm2m_engine.h"
+
+LOG_MODULE_REGISTER(net_lwm2m_json, CONFIG_LWM2M_LOG_LEVEL);
 
 #define T_NONE		0
 #define T_STRING_B	1

--- a/subsys/net/lib/lwm2m/lwm2m_rw_oma_tlv.c
+++ b/subsys/net/lib/lwm2m/lwm2m_rw_oma_tlv.c
@@ -56,19 +56,15 @@
  * - Var / parameter type cleanup
  * - Replace magic #'s with defines
  */
-
-#define LOG_MODULE_NAME net_lwm2m_oma_tlv
-#define LOG_LEVEL CONFIG_LWM2M_LOG_LEVEL
-
-#include <logging/log.h>
-LOG_MODULE_REGISTER(LOG_MODULE_NAME);
-
 #include <string.h>
 #include <stdint.h>
 #include <misc/byteorder.h>
+#include <logging/log.h>
 
 #include "lwm2m_rw_oma_tlv.h"
 #include "lwm2m_engine.h"
+
+LOG_MODULE_REGISTER(net_lwm2m_oma_tlv, CONFIG_LWM2M_LOG_LEVEL);
 
 enum {
 	OMA_TLV_TYPE_OBJECT_INSTANCE   = 0,

--- a/subsys/net/lib/lwm2m/lwm2m_rw_plain_text.c
+++ b/subsys/net/lib/lwm2m/lwm2m_rw_plain_text.c
@@ -55,22 +55,18 @@
  * - Type cleanups
  * - Cleanup integer parsing
  */
-
-#define LOG_MODULE_NAME net_lwm2m_plain_text
-#define LOG_LEVEL CONFIG_LWM2M_LOG_LEVEL
-
-#include <logging/log.h>
-LOG_MODULE_REGISTER(LOG_MODULE_NAME);
-
 #include <stdarg.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
 #include <ctype.h>
+#include <logging/log.h>
 
 #include "lwm2m_object.h"
 #include "lwm2m_rw_plain_text.h"
 #include "lwm2m_engine.h"
+
+LOG_MODULE_REGISTER(net_lwm2m_plain_text, CONFIG_LWM2M_LOG_LEVEL);
 
 /* some temporary buffer space for format conversions */
 static char pt_buffer[42]; /* can handle float64 format */

--- a/subsys/net/lib/openthread/platform/alarm.c
+++ b/subsys/net/lib/openthread/platform/alarm.c
@@ -3,16 +3,10 @@
  *
  * SPDX-License-Identifier: Apache-2.0
  */
-
-#define LOG_MODULE_NAME net_openthread_alarm
-#define LOG_LEVEL CONFIG_OPENTHREAD_LOG_LEVEL
-
-#include <logging/log.h>
-LOG_MODULE_REGISTER(LOG_MODULE_NAME);
-
 #include <kernel.h>
 #include <string.h>
 #include <inttypes.h>
+#include <logging/log.h>
 
 #include <openthread/platform/alarm-milli.h>
 #include <platform.h>
@@ -20,6 +14,8 @@ LOG_MODULE_REGISTER(LOG_MODULE_NAME);
 #include <stdio.h>
 
 #include "platform-zephyr.h"
+
+LOG_MODULE_REGISTER(net_openthread_alarm, CONFIG_OPENTHREAD_LOG_LEVEL);
 
 static bool timer_fired;
 

--- a/subsys/net/lib/openthread/platform/logging.c
+++ b/subsys/net/lib/openthread/platform/logging.c
@@ -7,13 +7,11 @@
 #include <kernel.h>
 #include <stdarg.h>
 #include <stdio.h>
+#include <logging/log.h>
 
 #include <openthread/platform/logging.h>
 
-#define LOG_MODULE_NAME net_openthread
-#define LOG_LEVEL LOG_LEVEL_DBG
-#include <logging/log.h>
-LOG_MODULE_REGISTER(LOG_MODULE_NAME);
+LOG_MODULE_REGISTER(net_openthread, LOG_LEVEL_DBG);
 
 #include "platform-zephyr.h"
 

--- a/subsys/net/lib/openthread/platform/radio.c
+++ b/subsys/net/lib/openthread/platform/radio.c
@@ -10,13 +10,6 @@
  *   for radio communication.
  *
  */
-
-#define LOG_LEVEL CONFIG_OPENTHREAD_LOG_LEVEL
-#define LOG_MODULE_NAME net_otPlat_radio
-
-#include <logging/log.h>
-LOG_MODULE_REGISTER(LOG_MODULE_NAME);
-
 #include <stdbool.h>
 #include <stddef.h>
 #include <stdint.h>
@@ -27,6 +20,7 @@ LOG_MODULE_REGISTER(LOG_MODULE_NAME);
 #include <net/ieee802154_radio.h>
 #include <net/net_pkt.h>
 #include <misc/__assert.h>
+#include <logging/log.h>
 
 #include <openthread/platform/radio.h>
 #include <openthread/platform/diag.h>
@@ -35,6 +29,8 @@ LOG_MODULE_REGISTER(LOG_MODULE_NAME);
 #include <openthread/types.h>
 
 #include "platform-zephyr.h"
+
+LOG_MODULE_REGISTER(net_otPlat_radio, CONFIG_OPENTHREAD_LOG_LEVEL);
 
 #define FCS_SIZE 2
 

--- a/subsys/power/Kconfig
+++ b/subsys/power/Kconfig
@@ -8,6 +8,10 @@ config PM_CONTROL_OS_DEBUG
 	bool "Enable OS Power Management debug hooks"
 	help
 	  Enable OS Power Management debugging hooks.
+	  
+module = PM
+module-str = Power Management
+source "subsys/logging/Kconfig.template.log_config"
 
 endmenu
 endif # PM_CONTROL_OS

--- a/subsys/power/device.c
+++ b/subsys/power/device.c
@@ -10,10 +10,9 @@
 #include <soc.h>
 #include <device.h>
 #include "policy/pm_policy.h"
-
-#define LOG_LEVEL CONFIG_PM_LOG_LEVEL /* From power module Kconfig */
 #include <logging/log.h>
-LOG_MODULE_DECLARE(power);
+
+LOG_MODULE_DECLARE(power, CONFIG_PM_LOG_LEVEL);
 
 /*
  * FIXME: Remove the conditional inclusion of

--- a/subsys/power/policy/policy_dummy.c
+++ b/subsys/power/policy/policy_dummy.c
@@ -8,10 +8,9 @@
 #include <kernel.h>
 #include <soc.h>
 #include "pm_policy.h"
-
-#define LOG_LEVEL CONFIG_PM_LOG_LEVEL /* From power module Kconfig */
 #include <logging/log.h>
-LOG_MODULE_DECLARE(power);
+
+LOG_MODULE_DECLARE(power, CONFIG_PM_LOG_LEVEL);
 
 #if !(defined(CONFIG_SYS_POWER_STATE_CPU_LPS_SUPPORTED) || \
 		defined(CONFIG_SYS_POWER_STATE_CPU_LPS_1_SUPPORTED) || \

--- a/subsys/power/policy/policy_residency.c
+++ b/subsys/power/policy/policy_residency.c
@@ -8,10 +8,9 @@
 #include <kernel.h>
 #include <soc.h>
 #include "pm_policy.h"
-
-#define LOG_LEVEL CONFIG_PM_LOG_LEVEL /* From power module Kconfig */
 #include <logging/log.h>
-LOG_MODULE_DECLARE(power);
+
+LOG_MODULE_DECLARE(power, CONFIG_PM_LOG_LEVEL);
 
 #define SECS_TO_TICKS		CONFIG_SYS_CLOCK_TICKS_PER_SEC
 

--- a/subsys/power/power.c
+++ b/subsys/power/power.c
@@ -10,10 +10,9 @@
 #include <string.h>
 #include <soc.h>
 #include "policy/pm_policy.h"
-
-#define LOG_LEVEL CONFIG_PM_LOG_LEVEL /* From power module Kconfig */
 #include <logging/log.h>
-LOG_MODULE_REGISTER(power);
+
+LOG_MODULE_REGISTER(power, CONFIG_PM_LOG_LEVEL);
 
 static int post_ops_done = 1;
 static enum power_states pm_state;

--- a/subsys/usb/bos.c
+++ b/subsys/usb/bos.c
@@ -3,17 +3,15 @@
  *
  * SPDX-License-Identifier: Apache-2.0
  */
-
-#define LOG_LEVEL CONFIG_USB_DEVICE_LOG_LEVEL
-#include <logging/log.h>
-LOG_MODULE_REGISTER(usb_bos)
-
 #include <zephyr.h>
+#include <logging/log.h>
 
 #include <usb/usb_device.h>
 #include <usb/usb_common.h>
 
 #include <usb/bos.h>
+
+LOG_MODULE_REGISTER(usb_bos, CONFIG_USB_DEVICE_LOG_LEVEL);
 
 extern const u8_t __usb_bos_desc_start[];
 extern const u8_t __usb_bos_desc_end[];

--- a/subsys/usb/class/bluetooth.c
+++ b/subsys/usb/class/bluetooth.c
@@ -18,10 +18,9 @@
 #include <bluetooth/buf.h>
 #include <bluetooth/hci_raw.h>
 #include <bluetooth/l2cap.h>
-
-#define LOG_LEVEL CONFIG_USB_DEVICE_LOG_LEVEL
 #include <logging/log.h>
-LOG_MODULE_REGISTER(usb_bluetooth)
+
+LOG_MODULE_REGISTER(usb_bluetooth, CONFIG_USB_DEVICE_LOG_LEVEL);
 
 #if !defined(CONFIG_USB_COMPOSITE_DEVICE)
 static u8_t interface_data[64];

--- a/subsys/usb/class/cdc_acm.c
+++ b/subsys/usb/class/cdc_acm.c
@@ -42,6 +42,7 @@
 #include <uart.h>
 #include <string.h>
 #include <misc/byteorder.h>
+#include <logging/log.h>
 #include <usb/class/usb_cdc.h>
 #include <usb/usb_device.h>
 #include <usb/usb_common.h>
@@ -53,9 +54,7 @@
 
 /* definitions */
 
-#define LOG_LEVEL CONFIG_USB_CDC_ACM_LOG_LEVEL
-#include <logging/log.h>
-LOG_MODULE_REGISTER(usb_cdc_acm)
+LOG_MODULE_REGISTER(usb_cdc_acm, CONFIG_USB_CDC_ACM_LOG_LEVEL);
 
 #define DEV_DATA(dev)						\
 	((struct cdc_acm_dev_data_t * const)(dev)->driver_data)

--- a/subsys/usb/class/hid/core.c
+++ b/subsys/usb/class/hid/core.c
@@ -5,17 +5,15 @@
  *
  * SPDX-License-Identifier: Apache-2.0
  */
-
-#define LOG_LEVEL CONFIG_USB_DEVICE_LOG_LEVEL
-#include <logging/log.h>
-LOG_MODULE_REGISTER(usb_hid)
-
 #include <misc/byteorder.h>
+#include <logging/log.h>
 #include <usb_device.h>
 #include <usb_common.h>
 
 #include <usb_descriptor.h>
 #include <class/usb_hid.h>
+
+LOG_MODULE_REGISTER(usb_hid, CONFIG_USB_DEVICE_LOG_LEVEL);
 
 #define HID_INT_IN_EP_ADDR				0x81
 #define HID_INT_OUT_EP_ADDR				0x01

--- a/subsys/usb/class/loopback.c
+++ b/subsys/usb/class/loopback.c
@@ -9,13 +9,12 @@
 #include <init.h>
 
 #include <misc/byteorder.h>
+#include <logging/log.h>
 #include <usb/usb_device.h>
 #include <usb/usb_common.h>
 #include <usb_descriptor.h>
 
-#define LOG_LEVEL CONFIG_USB_DEVICE_LOG_LEVEL
-#include <logging/log.h>
-LOG_MODULE_REGISTER(usb_loopback)
+LOG_MODULE_REGISTER(usb_loopback, CONFIG_USB_DEVICE_LOG_LEVEL);
 
 #define LOOPBACK_OUT_EP_ADDR		0x01
 #define LOOPBACK_IN_EP_ADDR		0x81

--- a/subsys/usb/class/mass_storage.c
+++ b/subsys/usb/class/mass_storage.c
@@ -39,14 +39,13 @@
 #include <misc/byteorder.h>
 #include <misc/__assert.h>
 #include <disk_access.h>
+#include <logging/log.h>
 #include <usb/class/usb_msc.h>
 #include <usb/usb_device.h>
 #include <usb/usb_common.h>
 #include <usb_descriptor.h>
 
-#define LOG_LEVEL CONFIG_USB_MASS_STORAGE_LOG_LEVEL
-#include <logging/log.h>
-LOG_MODULE_REGISTER(usb_msc)
+LOG_MODULE_REGISTER(usb_msc, CONFIG_USB_MASS_STORAGE_LOG_LEVEL);
 
 /* max USB packet size */
 #define MAX_PACKET	CONFIG_MASS_STORAGE_BULK_EP_MPS

--- a/subsys/usb/class/netusb/function_ecm.c
+++ b/subsys/usb/class/netusb/function_ecm.c
@@ -4,15 +4,14 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#define LOG_LEVEL CONFIG_USB_DEVICE_NETWORK_DEBUG_LEVEL
 #include <logging/log.h>
-LOG_MODULE_REGISTER(usb_ecm)
+LOG_MODULE_REGISTER(usb_ecm, CONFIG_USB_DEVICE_NETWORK_LOG_LEVEL);
 
 /* Enable verbose debug printing extra hexdumps */
 #define VERBOSE_DEBUG	0
 
-/* This enables basic hexdumps */
-#define NET_LOG_ENABLED	0
+/* This prevents log module registration in net_core.h */
+#define LOG_LEVEL	0
 #include <net_private.h>
 
 #include <zephyr.h>
@@ -26,6 +25,7 @@ LOG_MODULE_REGISTER(usb_ecm)
 #include <usb_descriptor.h>
 #include <class/usb_cdc.h>
 #include "netusb.h"
+
 
 #define USB_CDC_ECM_REQ_TYPE		0x21
 #define USB_CDC_SET_ETH_PKT_FILTER	0x43

--- a/subsys/usb/class/netusb/function_eem.c
+++ b/subsys/usb/class/netusb/function_eem.c
@@ -3,11 +3,11 @@
  *
  * SPDX-License-Identifier: Apache-2.0
  */
-
-#define LOG_LEVEL CONFIG_USB_DEVICE_NETWORK_DEBUG_LEVEL
 #include <logging/log.h>
-LOG_MODULE_REGISTER(usb_eem)
+LOG_MODULE_REGISTER(usb_eem, CONFIG_USB_DEVICE_NETWORK_DEBUG_LEVEL);
 
+/* This prevents log module registration in net_core.h */
+#define LOG_LEVEL	0
 #include <net_private.h>
 #include <zephyr.h>
 #include <usb_device.h>
@@ -18,6 +18,7 @@ LOG_MODULE_REGISTER(usb_eem)
 #include <usb_descriptor.h>
 #include <class/usb_cdc.h>
 #include "netusb.h"
+
 
 static u8_t tx_buf[NETUSB_MTU], rx_buf[NETUSB_MTU];
 

--- a/subsys/usb/class/netusb/function_rndis.c
+++ b/subsys/usb/class/netusb/function_rndis.c
@@ -4,15 +4,13 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#define LOG_LEVEL CONFIG_USB_DEVICE_NETWORK_DEBUG_LEVEL
 #include <logging/log.h>
-LOG_MODULE_REGISTER(usb_rndis)
-
+LOG_MODULE_REGISTER(usb_rndis, CONFIG_USB_DEVICE_NETWORK_LOG_LEVEL);
 /* Enable verbose debug printing extra hexdumps */
 #define VERBOSE_DEBUG	0
 
-/* This enables basic hexdumps */
-#define NET_LOG_ENABLED	0
+/* This prevents log module registration in net_core.h */
+#define LOG_LEVEL 0
 #include <net_private.h>
 
 #include <zephyr.h>
@@ -30,6 +28,7 @@ LOG_MODULE_REGISTER(usb_rndis)
 
 #include "netusb.h"
 #include "function_rndis.h"
+
 
 /* RNDIS handling */
 #define CFG_RNDIS_TX_BUF_COUNT	5

--- a/subsys/usb/class/netusb/netusb.c
+++ b/subsys/usb/class/netusb/netusb.c
@@ -6,15 +6,14 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#define LOG_LEVEL CONFIG_USB_DEVICE_NETWORK_LOG_LEVEL
 #include <logging/log.h>
-LOG_MODULE_REGISTER(usb_net)
+LOG_MODULE_REGISTER(usb_net, CONFIG_USB_DEVICE_NETWORK_LOG_LEVEL);
 
 /* Enable verbose debug printing extra hexdumps */
 #define VERBOSE_DEBUG	0
 
-/* This enables basic hexdumps */
-#define NET_LOG_ENABLED	0
+/* This prevents log module registration in net_core.h */
+#define LOG_LEVEL	0
 #include <net_private.h>
 
 #include <init.h>

--- a/subsys/usb/class/usb_dfu.c
+++ b/subsys/usb/class/usb_dfu.c
@@ -46,14 +46,13 @@
 #include <dfu/mcuboot.h>
 #include <dfu/flash_img.h>
 #include <misc/byteorder.h>
+#include <logging/log.h>
 #include <usb/usb_device.h>
 #include <usb/usb_common.h>
 #include <usb/class/usb_dfu.h>
 #include <usb_descriptor.h>
 
-#define LOG_LEVEL CONFIG_USB_DEVICE_LOG_LEVEL
-#include <logging/log.h>
-LOG_MODULE_REGISTER(usb_dfu)
+LOG_MODULE_REGISTER(usb_dfu, CONFIG_USB_DEVICE_LOG_LEVEL);
 
 #define NUMOF_ALTERNATE_SETTINGS	2
 

--- a/subsys/usb/os_desc.c
+++ b/subsys/usb/os_desc.c
@@ -3,15 +3,13 @@
  *
  * SPDX-License-Identifier: Apache-2.0
  */
-
-#define LOG_LEVEL CONFIG_USB_DEVICE_LOG_LEVEL
-#include <logging/log.h>
-LOG_MODULE_REGISTER(usb_os_desc)
-
 #include <zephyr.h>
+#include <logging/log.h>
 
 #include <usb/usb_device.h>
 #include <os_desc.h>
+
+LOG_MODULE_REGISTER(usb_os_desc, CONFIG_USB_DEVICE_LOG_LEVEL);
 
 static struct usb_os_descriptor *os_desc;
 

--- a/subsys/usb/usb_descriptor.c
+++ b/subsys/usb/usb_descriptor.c
@@ -10,14 +10,13 @@
 #include <string.h>
 #include <misc/byteorder.h>
 #include <misc/__assert.h>
+#include <logging/log.h>
 #include <usb/usbstruct.h>
 #include <usb/usb_device.h>
 #include <usb/usb_common.h>
 #include "usb_descriptor.h"
 
-#define LOG_LEVEL CONFIG_USB_DEVICE_LOG_LEVEL
-#include <logging/log.h>
-LOG_MODULE_REGISTER(usb_descriptor);
+LOG_MODULE_REGISTER(usb_descriptor, CONFIG_USB_DEVICE_LOG_LEVEL);
 
 /*
  * The last index of the initializer_string without null character is:

--- a/subsys/usb/usb_device.c
+++ b/subsys/usb/usb_device.c
@@ -61,6 +61,7 @@
 #include <misc/util.h>
 #include <misc/__assert.h>
 #include <init.h>
+#include <logging/log.h>
 #if defined(USB_VUSB_EN_GPIO)
 #include <gpio.h>
 #endif
@@ -69,9 +70,7 @@
 #include <usb/usb_common.h>
 #include <usb_descriptor.h>
 
-#define LOG_LEVEL CONFIG_USB_DEVICE_LOG_LEVEL
-#include <logging/log.h>
-LOG_MODULE_REGISTER(usb_device)
+LOG_MODULE_REGISTER(usb_device, CONFIG_USB_DEVICE_LOG_LEVEL);
 
 #include <usb/bos.h>
 #include <os_desc.h>

--- a/tests/boards/intel_s1000_crb/src/main.c
+++ b/tests/boards/intel_s1000_crb/src/main.c
@@ -6,8 +6,8 @@
 
 #include <zephyr.h>
 #include <misc/printk.h>
-#define LOG_LEVEL CONFIG_LOG_DEFAULT_LEVEL
 #include <logging/log.h>
+
 LOG_MODULE_REGISTER(main);
 
 /* This semaphore is used to serialize the UART prints dumped by various

--- a/tests/boards/intel_s1000_crb/src/test_hid.c
+++ b/tests/boards/intel_s1000_crb/src/test_hid.c
@@ -3,15 +3,13 @@
  *
  * SPDX-License-Identifier: Apache-2.0
  */
-
-#define LOG_LEVEL CONFIG_LOG_DEFAULT_LEVEL
-#include <logging/log.h>
-LOG_MODULE_DECLARE(main);
-
 #include <zephyr.h>
+#include <logging/log.h>
 
 #include <usb/usb_device.h>
 #include <usb/class/usb_hid.h>
+
+LOG_MODULE_DECLARE(main);
 
 #define REPORT_ID_1	0x01
 #define REPORT_ID_2	0x02

--- a/tests/drivers/i2c/i2c_slave_api/common/i2c_virtual.c
+++ b/tests/drivers/i2c/i2c_slave_api/common/i2c_virtual.c
@@ -10,10 +10,9 @@
 #include <kernel.h>
 #include <errno.h>
 #include <i2c.h>
-
-#define LOG_LEVEL CONFIG_I2C_LOG_LEVEL
 #include <logging/log.h>
-LOG_MODULE_DECLARE(main);
+
+LOG_MODULE_DECLARE(main, CONFIG_I2C_LOG_LEVEL);
 
 #define DEV_DATA(dev) ((struct i2c_virtual_data * const)(dev)->driver_data)
 

--- a/tests/drivers/i2c/i2c_slave_api/src/main.c
+++ b/tests/drivers/i2c/i2c_slave_api/src/main.c
@@ -6,9 +6,8 @@
 
 #include <errno.h>
 #include <string.h>
-
-#define LOG_LEVEL CONFIG_LOG_DEFAULT_LEVEL
 #include <logging/log.h>
+
 LOG_MODULE_REGISTER(main);
 
 #include <zephyr.h>

--- a/tests/drivers/spi/spi_loopback/src/spi.c
+++ b/tests/drivers/spi/spi_loopback/src/spi.c
@@ -4,7 +4,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#define LOG_LEVEL CONFIG_LOG_DEFAULT_LEVEL
 #include <logging/log.h>
 LOG_MODULE_REGISTER(main);
 

--- a/tests/lib/ringbuffer/src/main.c
+++ b/tests/lib/ringbuffer/src/main.c
@@ -17,8 +17,8 @@
 #include <ztest.h>
 #include <irq_offload.h>
 #include <ring_buffer.h>
-
 #include <logging/log.h>
+
 LOG_MODULE_REGISTER(test);
 
 /**

--- a/tests/subsys/logging/log_core/src/test_module.c
+++ b/tests/subsys/logging/log_core/src/test_module.c
@@ -11,6 +11,7 @@
  */
 
 #include <logging/log.h>
+
 LOG_MODULE_DECLARE(test);
 
 void test_func(void)

--- a/tests/subsys/logging/log_core/src/test_module.h
+++ b/tests/subsys/logging/log_core/src/test_module.h
@@ -1,0 +1,21 @@
+/*
+ * Copyright (c) 2018 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef TEST_MODULE_H
+#define TEST_MODULE_H
+
+#include <logging/log.h>
+
+void test_func(void);
+
+static inline void test_inline_func(void)
+{
+	LOG_MODULE_DECLARE(test);
+
+	LOG_ERR("inline");
+}
+
+#endif /* TEST_MODULE_H */


### PR DESCRIPTION
Module handling macros has been refactored to take log level as a parameter. Under the hood static variables with log level and pointers to static and dynamic structures are created.
Solution is cleaner now:
- registration `LOG_MODULE_REGISTER(foo, CONFIG_FOO_LOG_LEVEL)`
- referencing `LOG_MODULE_DECLARE(foo, CONFIG_FOO_LOG_LEVEL)`

`LOG_MODULE_DECLARE` can also be used in functions for creating local reference to a module.

Example of logging in static inline function:

```
static inline void foo(void)
{
   LOG_MODULE_DECLARE(foo, CONFIG_FOO_LOG_LEVEL)
   LOG_INF("foo");
}
```

Added macro LOG_LEVEL_SET() intended to be used in modules which are using instance logging API. Macro sets compilation log level for that file or function (if used in static inline function).