### PR TITLE
drivers: ethernet: native: Fix compile issue in RedHat 7

### DIFF
--- a/drivers/ethernet/CMakeLists.txt
+++ b/drivers/ethernet/CMakeLists.txt
@@ -8,7 +8,14 @@ zephyr_sources_ifdef(CONFIG_ETH_DW		eth_dw.c)
 zephyr_sources_ifdef(CONFIG_ETH_ENC28J60	eth_enc28j60.c)
 zephyr_sources_ifdef(CONFIG_ETH_MCUX		eth_mcux.c)
 zephyr_sources_ifdef(CONFIG_ETH_STM32_HAL	eth_stm32_hal.c)
-zephyr_sources_ifdef(CONFIG_ETH_NATIVE_POSIX
-	eth_native_posix.c
-	eth_native_posix_adapt.c
-	)
+
+if(CONFIG_ETH_NATIVE_POSIX)
+	zephyr_library()
+	zephyr_library_include_directories(${ZEPHYR_BASE}/subsys/net/l2)
+	zephyr_library_compile_definitions(NO_POSIX_CHEATS)
+	zephyr_library_compile_definitions(_BSD_SOURCE)
+	zephyr_library_sources(
+		eth_native_posix.c
+		eth_native_posix_adapt.c
+		)
+endif()

--- a/drivers/ethernet/eth_native_posix_adapt.c
+++ b/drivers/ethernet/eth_native_posix_adapt.c
@@ -24,6 +24,7 @@
 #include <fcntl.h>
 #include <sys/ioctl.h>
 #include <sys/socket.h>
+#include <sys/select.h>
 #include <net/if.h>
 #include <time.h>
 #include "posix_trace.h"


### PR DESCRIPTION
Fix 2 compile issues in RedHat/CentOS 7 for the native
ethernet driver due to an oldish glibc, which does not include
by default the needed structures.
+
Separate the native ethernet driver into its own library,
and set NO_POSIX_CHEATS for it, in case the Zephyr POSIX
library would eventually add support for any of the host functions
used in this driver.

Signed-off-by: Alberto Escolar Piedras <alpi@oticon.com>