### PR TITLE
cmake: Do not abort even if git describe failed

### DIFF
--- a/cmake/app/boilerplate.cmake
+++ b/cmake/app/boilerplate.cmake
@@ -263,11 +263,12 @@ if(GIT_FOUND)
     WORKING_DIRECTORY ${ZEPHYR_BASE}
     OUTPUT_VARIABLE BUILD_VERSION
     OUTPUT_STRIP_TRAILING_WHITESPACE
+    ERROR_STRIP_TRAILING_WHITESPACE
     ERROR_VARIABLE stderr
     RESULT_VARIABLE return_code
     )
   if(return_code)
-    message(FATAL_ERROR "${stderr}")
+    message(STATUS "git describe failed: ${stderr}; ${KERNEL_VERSION_STRING} will be used instead")
   elseif(CMAKE_VERBOSE_MAKEFILE)
     message(STATUS "git describe stderr: ${stderr}")
   endif()


### PR DESCRIPTION
The commit 1b80f00f56fb66ae7b03d3a95389b85380b2a2a3 made git describe
failure as fatal.  But a failure can happens when no tag is in a
repository.  And such a repository might exist for a internal build
system or some test environments.

Zephyr's build system is capable building without a commit hash.

This commit makes it non-fatal again and inform users that the build
system is failed to execute "git describe" but continues building with
KERNEL_VERSION_STRING.