### PR TITLE
doc: fix doxygen BUILD_ASSERT error

### DIFF
--- a/doc/zephyr.doxyfile.in
+++ b/doc/zephyr.doxyfile.in
@@ -1984,6 +1984,7 @@ PREDEFINED             = "CONFIG_SYS_CLOCK_EXISTS=y" \
                          "DEVICE_DEFINE()=" \
                          "DEVICE_AND_API_INIT()=" \
                          "BUILD_ASSERT_MSG()=" \
+                         "BUILD_ASSERT()=" \
                          "__deprecated=" \
                          "__packed=" \
                          "__aligned(x)=" \


### PR DESCRIPTION
PR #10216 hit a doxygen/breathe known issue that is worked around by
adding an entry to the doxygen configuration to treat BUILD_ASSERT() as
a predefined macro.

Signed-off-by: David B. Kinder <david.b.kinder@intel.com>