### PR TITLE
cmake: Add build system target for west attach command

### DIFF
--- a/cmake/flash/CMakeLists.txt
+++ b/cmake/flash/CMakeLists.txt
@@ -67,9 +67,9 @@ if(BOARD_DEBUG_RUNNER)
     "Default runner for debugging" FORCE)
 endif()
 
-# Generate the flash, debug, debugserver targets within the build
+# Generate the flash, debug, debugserver, attach targets within the build
 # system itself.
-foreach(target flash debug debugserver)
+foreach(target flash debug debugserver attach)
   if(target STREQUAL flash)
     set(comment "Flashing ${BOARD}")
   elseif(target STREQUAL debug)
@@ -81,6 +81,8 @@ foreach(target flash debug debugserver)
       # emulation platforms, so we don't add one here
       continue()
     endif()
+  elseif(target STREQUAL attach)
+    set(comment "Debugging ${BOARD}")
   endif()
 
   # We pass --skip-rebuild here because the DEPENDS value ensures the


### PR DESCRIPTION
Adds a build system target for the west attach command, which starts a
debugging session without programming the flash.

Signed-off-by: Maureen Helm <maureen.helm@nxp.com>