### PR TITLE
net: coap: Fix Coap coap_option_value_to_int and coap_append_option_int

### DIFF
--- a/subsys/net/lib/coap/coap.c
+++ b/subsys/net/lib/coap/coap.c
@@ -705,7 +705,7 @@ unsigned int coap_option_value_to_int(const struct coap_option *option)
 		return (option->value[2] << 0) | (option->value[1] << 8) |
 			(option->value[0] << 16);
 	case 4:
-		return (option->value[2] << 0) | (option->value[2] << 8) |
+		return (option->value[3] << 0) | (option->value[2] << 8) |
 			(option->value[1] << 16) | (option->value[0] << 24);
 	default:
 		return 0;
@@ -1060,8 +1060,8 @@ int coap_append_option_int(struct coap_packet *cpkt, u16_t code,
 		sys_put_be16(val, data);
 		len = 2;
 	} else if (val < 0xFFFFFF) {
-		sys_put_be16(val, data);
-		data[2] = val >> 16;
+		sys_put_be16(val, &data[1]);
+		data[0] = val >> 16;
 		len = 3;
 	} else {
 		sys_put_be32(val, data);


### PR DESCRIPTION
In coap_option_value_to_int function, when coap option length is 4,
option->value[3] should be shifted by 0 rather than option->value[2].
This doesn't affect the behavior of function but needs to be fixed.

In coap_append_option_int function, when the value is between 0xffff
and 0xffffff(when option length is 3), bit shift operation is wrong.
For example, if the value is 0xABCDEF, by sys_put_be16(val, data)
data[0]=0xCD, data[1]=0xEF, by val >> 16, data[2]=0xAB. So the result
becomes 0xCDEFAB not 0xABCDEF. So, to sys_put_be16 function hand
&data[1] over instead of handing data over and val >> 16 needs to be
set to data[0], not data[2].

Signed-off-by: Taehwa Kang <hegrecomm@gmail.com>