### PR TITLE
logging: Add option to suppress level and timestamp printing in log_output

### DIFF
--- a/include/logging/log_output.h
+++ b/include/logging/log_output.h
@@ -22,10 +22,13 @@ extern "C" {
 /** @brief Flag forcing ANSI escape code colors, red (errors), yellow
  *         (warnings).
  */
-#define LOG_OUTPUT_FLAG_COLORS                  (1 << 0)
+#define LOG_OUTPUT_FLAG_COLORS			(1 << 0)
 
 /** @brief Flag forcing timestamp formatting. */
-#define LOG_OUTPUT_FLAG_FORMAT_TIMESTAMP        (1 << 1)
+#define LOG_OUTPUT_FLAG_FORMAT_TIMESTAMP	(1 << 1)
+
+/** @brief Flag forcing severity level prefix. */
+#define LOG_OUTPUT_FLAG_LEVEL			(1 << 2)
 
 /**
  * @brief Prototype of the function processing output data.

--- a/include/logging/log_output.h
+++ b/include/logging/log_output.h
@@ -22,13 +22,16 @@ extern "C" {
 /** @brief Flag forcing ANSI escape code colors, red (errors), yellow
  *         (warnings).
  */
-#define LOG_OUTPUT_FLAG_COLORS			(1 << 0)
+#define LOG_OUTPUT_FLAG_COLORS			BIT(0)
+
+/** @brief Flag forcing timestamp */
+#define LOG_OUTPUT_FLAG_TIMESTAMP		BIT(1)
 
 /** @brief Flag forcing timestamp formatting. */
-#define LOG_OUTPUT_FLAG_FORMAT_TIMESTAMP	(1 << 1)
+#define LOG_OUTPUT_FLAG_FORMAT_TIMESTAMP	BIT(2)
 
 /** @brief Flag forcing severity level prefix. */
-#define LOG_OUTPUT_FLAG_LEVEL			(1 << 2)
+#define LOG_OUTPUT_FLAG_LEVEL			BIT(3)
 
 /**
  * @brief Prototype of the function processing output data.

--- a/subsys/logging/log_backend_native_posix.c
+++ b/subsys/logging/log_backend_native_posix.c
@@ -61,7 +61,7 @@ static void put(const struct log_backend *const backend,
 {
 	log_msg_get(msg);
 
-	u32_t flags = LOG_OUTPUT_FLAG_LEVEL;
+	u32_t flags = LOG_OUTPUT_FLAG_LEVEL | LOG_OUTPUT_FLAG_TIMESTAMP;
 
 	if (IS_ENABLED(CONFIG_LOG_BACKEND_SHOW_COLOR)) {
 		if (posix_trace_over_tty(0)) {

--- a/subsys/logging/log_backend_native_posix.c
+++ b/subsys/logging/log_backend_native_posix.c
@@ -61,7 +61,7 @@ static void put(const struct log_backend *const backend,
 {
 	log_msg_get(msg);
 
-	u32_t flags = 0;
+	u32_t flags = LOG_OUTPUT_FLAG_LEVEL;
 
 	if (IS_ENABLED(CONFIG_LOG_BACKEND_SHOW_COLOR)) {
 		if (posix_trace_over_tty(0)) {

--- a/subsys/logging/log_backend_uart.c
+++ b/subsys/logging/log_backend_uart.c
@@ -32,7 +32,7 @@ static void put(const struct log_backend *const backend,
 {
 	log_msg_get(msg);
 
-	u32_t flags = LOG_OUTPUT_FLAG_LEVEL;
+	u32_t flags = LOG_OUTPUT_FLAG_LEVEL | LOG_OUTPUT_FLAG_TIMESTAMP;
 
 	if (IS_ENABLED(CONFIG_LOG_BACKEND_SHOW_COLOR)) {
 		flags |= LOG_OUTPUT_FLAG_COLORS;

--- a/subsys/logging/log_backend_uart.c
+++ b/subsys/logging/log_backend_uart.c
@@ -32,7 +32,7 @@ static void put(const struct log_backend *const backend,
 {
 	log_msg_get(msg);
 
-	u32_t flags = 0;
+	u32_t flags = LOG_OUTPUT_FLAG_LEVEL;
 
 	if (IS_ENABLED(CONFIG_LOG_BACKEND_SHOW_COLOR)) {
 		flags |= LOG_OUTPUT_FLAG_COLORS;

--- a/subsys/logging/log_output.c
+++ b/subsys/logging/log_output.c
@@ -166,14 +166,21 @@ static void color_postfix(struct log_msg *msg,
 
 
 static int ids_print(struct log_msg *msg,
-		     const struct log_output *log_output)
+		     const struct log_output *log_output, bool level_on)
 {
 	u32_t domain_id = log_msg_domain_id_get(msg);
 	u32_t source_id = log_msg_source_id_get(msg);
 	u32_t level = log_msg_level_get(msg);
+	int total = 0;
 
-	return print_formatted(log_output, "<%s> %s: ", severity[level],
-		     log_source_name_get(domain_id, source_id));
+	if (level_on) {
+		total += print_formatted(log_output, "<%s> ", severity[level]);
+	}
+
+	total += print_formatted(log_output, "%s: ",
+				log_source_name_get(domain_id, source_id));
+
+	return total;
 }
 
 static void newline_print(const struct log_output *ctx)
@@ -359,10 +366,11 @@ static int prefix_print(struct log_msg *msg,
 	if (!log_msg_is_raw_string(msg)) {
 		bool stamp_format = flags & LOG_OUTPUT_FLAG_FORMAT_TIMESTAMP;
 		bool colors_on = flags & LOG_OUTPUT_FLAG_COLORS;
+		bool level_on = flags & LOG_OUTPUT_FLAG_LEVEL;
 
 		length += timestamp_print(msg, log_output, stamp_format);
 		color_prefix(msg, log_output, colors_on);
-		length += ids_print(msg, log_output);
+		length += ids_print(msg, log_output, level_on);
 	}
 
 	return length;

--- a/subsys/logging/log_output.c
+++ b/subsys/logging/log_output.c
@@ -364,11 +364,18 @@ static int prefix_print(struct log_msg *msg,
 	int length = 0;
 
 	if (!log_msg_is_raw_string(msg)) {
-		bool stamp_format = flags & LOG_OUTPUT_FLAG_FORMAT_TIMESTAMP;
+		bool stamp = flags & LOG_OUTPUT_FLAG_TIMESTAMP;
 		bool colors_on = flags & LOG_OUTPUT_FLAG_COLORS;
 		bool level_on = flags & LOG_OUTPUT_FLAG_LEVEL;
 
-		length += timestamp_print(msg, log_output, stamp_format);
+		if (stamp) {
+			bool stamp_format =
+				flags & LOG_OUTPUT_FLAG_FORMAT_TIMESTAMP;
+
+			length += timestamp_print(msg, log_output,
+						  stamp_format);
+		}
+
 		color_prefix(msg, log_output, colors_on);
 		length += ids_print(msg, log_output, level_on);
 	}

--- a/subsys/shell/shell_log_backend.c
+++ b/subsys/shell/shell_log_backend.c
@@ -74,7 +74,9 @@ void shell_log_backend_disable(const struct shell_log_backend *backend)
 static void msg_process(const struct log_output *log_output,
 			struct log_msg *msg)
 {
-	u32_t flags = LOG_OUTPUT_FLAG_LEVEL | LOG_OUTPUT_FLAG_FORMAT_TIMESTAMP;
+	u32_t flags = LOG_OUTPUT_FLAG_LEVEL |
+		      LOG_OUTPUT_FLAG_TIMESTAMP |
+		      LOG_OUTPUT_FLAG_FORMAT_TIMESTAMP;
 
 	if (IS_ENABLED(CONFIG_SHELL_VT100_COLORS)) {
 		flags |= LOG_OUTPUT_FLAG_COLORS;

--- a/subsys/shell/shell_log_backend.c
+++ b/subsys/shell/shell_log_backend.c
@@ -74,14 +74,10 @@ void shell_log_backend_disable(const struct shell_log_backend *backend)
 static void msg_process(const struct log_output *log_output,
 			struct log_msg *msg)
 {
-	u32_t flags = 0;
+	u32_t flags = LOG_OUTPUT_FLAG_LEVEL | LOG_OUTPUT_FLAG_FORMAT_TIMESTAMP;
 
-	if (IS_ENABLED(CONFIG_SHELL)) {
+	if (IS_ENABLED(CONFIG_SHELL_VT100_COLORS)) {
 		flags |= LOG_OUTPUT_FLAG_COLORS;
-	}
-
-	if (IS_ENABLED(CONFIG_SHELL)) {
-		flags |= LOG_OUTPUT_FLAG_FORMAT_TIMESTAMP;
 	}
 
 	log_output_msg_process(log_output, msg, flags);


### PR DESCRIPTION
Added flags in log_output module to add severity level and timestamp when message is
formatted to string. Updated existing backends.

Requested by @jhedberg for bluetooth backend he is working on. Same as other log_output flags this flag is also positive (flag must be set to get severity level). Because of that existing backends had to be updated.

Signed-off-by: Krzysztof Chruscinski <krzysztof.chruscinski@nordicsemi.no>