### PR TITLE
subsys: bluetooth: controller: Remove timestamp from HCI

### DIFF
--- a/subsys/bluetooth/controller/hci/hci.c
+++ b/subsys/bluetooth/controller/hci/hci.c
@@ -1805,10 +1805,8 @@ static void vs_read_build_info(struct net_buf *buf, struct net_buf **evt)
 {
 	struct bt_hci_rp_vs_read_build_info *rp;
 
-#define BUILD_TIMESTAMP " " __DATE__ " " __TIME__
-
 #define HCI_VS_BUILD_INFO "Zephyr OS v" \
-	KERNEL_VERSION_STRING BUILD_TIMESTAMP CONFIG_BT_CTLR_HCI_VS_BUILD_INFO
+	KERNEL_VERSION_STRING CONFIG_BT_CTLR_HCI_VS_BUILD_INFO
 
 	const char build_info[] = HCI_VS_BUILD_INFO;
 


### PR DESCRIPTION
In order to avoid the build system complications that come from
including a timestamp, remove it by default from the version string in
HCI Vendor Extensions. Users can still include a unique identifier, be
it timestamp or not, using the CONFIG_BT_CTLR_HCI_VS_BUILD_INFO Kconfig
option.

Signed-off-by: Carles Cufi <carles.cufi@nordicsemi.no>