### PR TITLE
Ignore GNU Globals tag files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,3 +43,8 @@ tags
 
 # Disables the warning about the changed behavior for Kconfig defaults
 hide-defaults-note
+
+# Tag files
+GPATH
+GRTAGS
+GTAGS


### PR DESCRIPTION
GNU Global creates a few files at the root dir.  Ignore them all.