### PR TITLE
net: sockets: Add missing POLLERR definition

### DIFF
--- a/include/net/socket.h
+++ b/include/net/socket.h
@@ -324,6 +324,7 @@ static inline int setsockopt(int sock, int level, int optname,
 
 #define POLLIN ZSOCK_POLLIN
 #define POLLOUT ZSOCK_POLLOUT
+#define POLLERR ZSOCK_POLLERR
 
 #define MSG_PEEK ZSOCK_MSG_PEEK
 #define MSG_DONTWAIT ZSOCK_MSG_DONTWAIT


### PR DESCRIPTION
`ZSOCK_POLLERR` was missing it's posix name, so this commit adds one.

Signed-off-by: Robert Lubos <robert.lubos@nordicsemi.no>