### PR TITLE
Bluetooth: Allow to configure background scan window and interval

### DIFF
--- a/subsys/bluetooth/host/Kconfig
+++ b/subsys/bluetooth/host/Kconfig
@@ -389,6 +389,17 @@ endif # BT_GAP_PERIPHERAL_PREF_PARAMS
 
 endif # BT_CONN
 
+if BT_OBSERVER
+config BT_BACKGROUND_SCAN_INTERVAL
+	int "Scan interval used for background scanning in 0.625 ms units"
+	default 2048
+	range 4 16384
+config BT_BACKGROUND_SCAN_WINDOW
+	int "Scan window used for background scanning in 0.625 ms units"
+	default 18
+	range 4 16384
+endif # BT_OBSERVER
+
 config BT_SCAN_WITH_IDENTITY
 	bool "Perform active scanning using local identity address"
 	depends on !BT_PRIVACY && (BT_CENTRAL || BT_OBSERVER)

--- a/subsys/bluetooth/host/hci_core.c
+++ b/subsys/bluetooth/host/hci_core.c
@@ -3175,8 +3175,8 @@ int bt_le_scan_update(bool fast_scan)
 			interval = BT_GAP_SCAN_FAST_INTERVAL;
 			window = BT_GAP_SCAN_FAST_WINDOW;
 		} else {
-			interval = BT_GAP_SCAN_SLOW_INTERVAL_1;
-			window = BT_GAP_SCAN_SLOW_WINDOW_1;
+			interval = CONFIG_BT_BACKGROUND_SCAN_INTERVAL;
+			window = CONFIG_BT_BACKGROUND_SCAN_WINDOW;
 		}
 
 		return start_le_scan(BT_HCI_LE_SCAN_PASSIVE, interval, window);


### PR DESCRIPTION
Applications may require different scan windows and interval depending
on expected re-connection time or peer devices advertising parameters.
Default to GAP recommended slow values.

Signed-off-by: Szymon Janc <szymon.janc@codecoup.pl>