### PR TITLE
Select HAS_DTS_I2C in drivers instead of boards

### DIFF
--- a/boards/arc/arduino_101_sss/Kconfig.board
+++ b/boards/arc/arduino_101_sss/Kconfig.board
@@ -2,4 +2,3 @@
 config BOARD_ARDUINO_101_SSS
 	bool "Arduino 101 Sensor Sub System"
 	depends on SOC_QUARK_SE_C1000_SS
-	select HAS_DTS_I2C

--- a/boards/arc/em_starterkit/Kconfig.board
+++ b/boards/arc/em_starterkit/Kconfig.board
@@ -7,7 +7,6 @@
 config BOARD_EM_STARTERKIT
 	bool "ARC EM Starter Kit"
 	depends on SOC_EMSK
-	select HAS_DTS_I2C
 	select HAS_DTS_SPI
 	select HAS_DTS
 	help

--- a/boards/arc/quark_se_c1000_ss_devboard/Kconfig.board
+++ b/boards/arc/quark_se_c1000_ss_devboard/Kconfig.board
@@ -2,4 +2,3 @@
 config BOARD_QUARK_SE_C1000_DEVBOARD_SS
 	bool "Quark SE C1000 - Sensor Sub System"
 	depends on SOC_QUARK_SE_C1000_SS
-	select HAS_DTS_I2C

--- a/boards/arm/warp7_m4/Kconfig.board
+++ b/boards/arm/warp7_m4/Kconfig.board
@@ -9,7 +9,6 @@ config BOARD_WARP7_M4
 	bool "WaRP7 iMX7 Solo"
 	depends on SOC_SERIES_IMX7_M4
 	select SOC_PART_NUMBER_MCIMX7S3DVK08SA
-	select HAS_DTS_I2C
 	select HAS_DTS_I2C_DEVICE
 	select HAS_DTS_GPIO
 	select HAS_DTS_GPIO_DEVICE

--- a/boards/x86/arduino_101/Kconfig.board
+++ b/boards/x86/arduino_101/Kconfig.board
@@ -3,4 +3,3 @@ config BOARD_ARDUINO_101
 	bool "Arduino 101 Board"
 	depends on SOC_SERIES_QUARK_SE
 	select HAS_DTS
-	select HAS_DTS_I2C

--- a/boards/x86/galileo/Kconfig.board
+++ b/boards/x86/galileo/Kconfig.board
@@ -3,7 +3,6 @@ config BOARD_GALILEO
 	bool "Galileo Gen2"
 	depends on SOC_SERIES_QUARK_X1000
 	select HAS_DTS
-	select HAS_DTS_I2C
 	help
 	  The Intel Galileo Gen 2 development board is a microcontroller board
 	  based on the Intel Quark SoC X1000 application processor, a 32-bit

--- a/boards/x86/quark_d2000_crb/Kconfig.board
+++ b/boards/x86/quark_d2000_crb/Kconfig.board
@@ -3,4 +3,3 @@ config BOARD_QUARK_D2000_CRB
 	bool "Intel Quark D2000 CRB"
 	depends on SOC_SERIES_QUARK_D2000
 	select HAS_DTS
-	select HAS_DTS_I2C

--- a/boards/x86/quark_se_c1000_devboard/Kconfig.board
+++ b/boards/x86/quark_se_c1000_devboard/Kconfig.board
@@ -3,4 +3,3 @@ config BOARD_QUARK_SE_C1000_DEVBOARD
 	bool "Quark SE C1000 Devboard"
 	depends on SOC_SERIES_QUARK_SE
 	select HAS_DTS
-	select HAS_DTS_I2C

--- a/boards/x86/tinytile/Kconfig.board
+++ b/boards/x86/tinytile/Kconfig.board
@@ -3,4 +3,3 @@ config BOARD_TINYTILE
 	bool "TinyTILE"
 	depends on SOC_SERIES_QUARK_SE
 	select HAS_DTS
-	select HAS_DTS_I2C

--- a/boards/x86/up_squared/Kconfig.board
+++ b/boards/x86/up_squared/Kconfig.board
@@ -8,4 +8,3 @@ config BOARD_UP_SQUARED
 	bool "UP Squared"
 	depends on SOC_APOLLO_LAKE
 	select HAS_DTS
-	select HAS_DTS_I2C

--- a/boards/xtensa/intel_s1000_crb/Kconfig.board
+++ b/boards/xtensa/intel_s1000_crb/Kconfig.board
@@ -7,4 +7,3 @@ config  BOARD_INTEL_S1000_CRB
 	bool "Xtensa on Intel_S1000"
 	depends on SOC_INTEL_S1000
 	select HAS_DTS
-	select HAS_DTS_I2C

--- a/drivers/i2c/Kconfig.dw
+++ b/drivers/i2c/Kconfig.dw
@@ -6,6 +6,7 @@
 
 menuconfig I2C_DW
 	bool "Design Ware I2C support"
+	select HAS_DTS_I2C
 	help
 	  Enable Design Ware I2C support on the selected board
 

--- a/drivers/i2c/Kconfig.qmsi
+++ b/drivers/i2c/Kconfig.qmsi
@@ -7,6 +7,7 @@
 menuconfig I2C_QMSI
 	bool "QMSI I2C driver"
 	depends on QMSI
+	select HAS_DTS_I2C
 	help
 	  This option enable the QMSI I2C driver.
 
@@ -39,6 +40,7 @@ endif # I2C_QMSI
 menuconfig I2C_QMSI_SS
 	bool "QMSI I2C driver for the Sensor Subsystem"
 	depends on QMSI
+	select HAS_DTS_I2C
 	help
 	  This option enable the Sensor QMSI I2C driver.
 


### PR DESCRIPTION
Clean up inconsistencies in where we select HAS_DTS_I2C.