### PR TITLE
include/logging: Avoid subtraction on void pointers

### DIFF
--- a/include/logging/log_core.h
+++ b/include/logging/log_core.h
@@ -335,7 +335,7 @@ static inline u8_t log_compiled_level_get(u32_t source_id)
 static inline u32_t log_const_source_id(
 				const struct log_source_const_data *data)
 {
-	return ((void *)data - (void *)__log_const_start)/
+	return ((char *)data - (char *)__log_const_start)/
 			sizeof(struct log_source_const_data);
 }
 
@@ -377,7 +377,7 @@ static inline u32_t *log_dynamic_filters_get(u32_t source_id)
  */
 static inline u32_t log_dynamic_source_id(struct log_source_dynamic_data *data)
 {
-	return ((void *)data - (void *)__log_dynamic_start)/
+	return ((char *)data - (char *)__log_dynamic_start)/
 			sizeof(struct log_source_dynamic_data);
 }
 


### PR DESCRIPTION
Avoid subtraction on void pointers.
void* pointer arithmetic is not allowed by C standard and also C++.
If you include "logging/log.h" into a C++ application it fails to
build.

Signed-off-by: Yannis Damigos <giannis.damigos@gmail.com>