### PR TITLE
scripts: add colorama to requirements.txt

### DIFF
--- a/scripts/requirements.txt
+++ b/scripts/requirements.txt
@@ -15,3 +15,4 @@ pyserial
 pykwalify
 # "win32" is used for 64-bit Windows as well
 windows-curses; sys_platform == "win32"
+colorama


### PR DESCRIPTION
This got missed in the latest west code import.

Fixes #10241 
Fixes #10231 

