### PR TITLE
doc: add ability to only generate kernel documentation

### DIFF
--- a/doc/CMakeLists.txt
+++ b/doc/CMakeLists.txt
@@ -36,16 +36,12 @@ else()
   separate_arguments(SPHINXOPTS)
 endif()
 
+# SPHINX_OUTPUT_DIR is used to specify exactly where HTML (or other
+# outputs) are placed, so no /html, /latex, /pdf suffixes are needed.
+# Build target is to use SPHINX_OUTPUT_DIR as-is if defined, else
+# use SPHINX_OUTPUT_DEFAULT_DIR to construct a path.
 if(NOT DEFINED SPHINX_OUTPUT_DIR)
-  set(SPHINX_OUTPUT_DIR_HTML ${CMAKE_CURRENT_BINARY_DIR}/html)
-  set(SPHINX_OUTPUT_DIR_LATEX ${CMAKE_CURRENT_BINARY_DIR}/latex)
-  set(SPHINX_OUTPUT_DIR_PDF ${CMAKE_CURRENT_BINARY_DIR}/pdf)
-else()
-  # SPHINX_OUTPUT_DIR is used to specify exactly where HTML (or other
-  # outputs) are placed, so no /html, /latex, /pdf suffixes are needed.
-  set(SPHINX_OUTPUT_DIR_HTML ${SPHINX_OUTPUT_DIR})
-  set(SPHINX_OUTPUT_DIR_LATEX ${SPHINX_OUTPUT_DIR})
-  set(SPHINX_OUTPUT_DIR_PDF ${SPHINX_OUTPUT_DIR})
+  set(SPHINX_OUTPUT_DEFAULT_DIR ${CMAKE_CURRENT_BINARY_DIR})
 endif()
 
 if(NOT DEFINED DOC_TAG)
@@ -53,8 +49,7 @@ if(NOT DEFINED DOC_TAG)
 endif()
 
 # Internal variables.
-set(ALLSPHINXOPTS  -d ${CMAKE_CURRENT_BINARY_DIR}/doctrees ${SPHINXOPTS})
-if("-q" IN_LIST ALLSPHINXOPTS)
+if("-q" IN_LIST SPHINXOPTS)
   set(SPHINX_USES_TERMINAL )
 else()
   set(SPHINX_USES_TERMINAL USES_TERMINAL)
@@ -65,66 +60,67 @@ set(I18NSPHINXOPTS  ${SPHINXOPTS})
 
 set(DOXYFILE_IN ${CMAKE_CURRENT_LIST_DIR}/zephyr.doxyfile.in)
 set(DOXYFILE_OUT ${CMAKE_CURRENT_BINARY_DIR}/zephyr.doxyfile)
-set(RST_OUT ${CMAKE_CURRENT_BINARY_DIR}/rst)
 set(DOC_LOG ${CMAKE_CURRENT_BINARY_DIR}/doc.log)
 set(DOXY_LOG ${CMAKE_CURRENT_BINARY_DIR}/doxy.log)
 set(SPHINX_LOG ${CMAKE_CURRENT_BINARY_DIR}/sphinx.log)
 set(DOC_WARN ${CMAKE_CURRENT_BINARY_DIR}/doc.warnings)
-set(CONTENT_OUTPUTS ${CMAKE_CURRENT_BINARY_DIR}/extracted-content.txt)
 
 configure_file(${DOXYFILE_IN} ${DOXYFILE_OUT} @ONLY)
 
-# This command is used to copy all documentation source files into the build
-# directory,
 #
-# We need to make copies because Sphinx requires a single
-# documentation root directory, but Zephyr's documentation is
-# scattered around the tree in samples/, boards/, and doc/. Putting
-# them into a single rooted tree in the build directory is a
-# workaround for this limitation.
-set(EXTRACT_CONTENT_COMMAND
-  ${CMAKE_COMMAND} -E env
-  ${PYTHON_EXECUTABLE} scripts/extract_content.py
-  # Ignore any files in the output directory.
-  --ignore ${CMAKE_CURRENT_BINARY_DIR}
-  # Copy all files in doc to the rst folder.
-  "*:doc:${RST_OUT}"
-  # We want to copy the .rst files in samples/ and boards/ to the rst
-  # folder, and also the doc folder inside rst.
+# Macro to generate target for document content
+#
+# Note: this is a macro because variables set by this
+#       are being used in constructing other targets.
+#
+macro(construct_content_target scope)
+  # This command is used to copy all documentation source files into the build
+  # directory,
   #
-  # Some files refer to items in samples/ and boards/ relative to
-  # their actual position in the Zephyr tree. For example, in
-  # subsystems/sensor.rst:
-  #
-  # .. literalinclude:: ../../samples/sensor/mcp9808/src/main.c
-  #
-  # The additional copy is a hackaround so these references work.
-  "*.rst:samples:${RST_OUT}" "*.rst:boards:${RST_OUT}"
-  "*.rst:samples:${RST_OUT}/doc" "*.rst:boards:${RST_OUT}/doc")
+  # We need to make copies because Sphinx requires a single
+  # documentation root directory, but Zephyr's documentation is
+  # scattered around the tree in samples/, boards/, and doc/. Putting
+  # them into a single rooted tree in the build directory is a
+  # workaround for this limitation.
+  set(EXTRACT_CONTENT_COMMAND
+    ${CMAKE_COMMAND} -E env
+    ${PYTHON_EXECUTABLE} scripts/extract_content.py
+    # Ignore any files in the output directory.
+    --ignore ${CMAKE_CURRENT_BINARY_DIR}
+    # Copy all files in doc to the rst folder.
+    "*:doc:${RST_OUT}"
+    # We want to copy the .rst files in samples/ and boards/ to the rst
+    # folder, and also the doc folder inside rst.
+    #
+    # Some files refer to items in samples/ and boards/ relative to
+    # their actual position in the Zephyr tree. For example, in
+    # subsystems/sensor.rst:
+    #
+    # .. literalinclude:: ../../samples/sensor/mcp9808/src/main.c
+    #
+    # The additional copy is a hackaround so these references work.
+    "*.rst:samples:${RST_OUT}" "*.rst:boards:${RST_OUT}"
+    "*.rst:samples:${RST_OUT}/doc" "*.rst:boards:${RST_OUT}/doc")
 
-add_custom_target(
-  content
-  # Copy all files in doc/ to the rst folder
-  COMMAND ${EXTRACT_CONTENT_COMMAND}
-  WORKING_DIRECTORY ${CMAKE_CURRENT_LIST_DIR}
-)
+  add_custom_target(
+    ${TGT_NAME_CONTENT}
+    # Copy all files in doc/ to the rst folder
+    COMMAND ${EXTRACT_CONTENT_COMMAND}
+    WORKING_DIRECTORY ${CMAKE_CURRENT_LIST_DIR}
+  )
+endmacro()
 
-set(ARGS ${DOXYFILE_OUT})
+set(DOXY_ARGS ${DOXYFILE_OUT})
 
 add_custom_target(
   doxy
   COMMAND ${CMAKE_COMMAND}
     -DCOMMAND=${DOXYGEN_EXECUTABLE}
-    -DARGS="${ARGS}"
+    -DARGS="${DOXY_ARGS}"
     -DOUTPUT_FILE=${DOXY_LOG}
     -DERROR_FILE=${DOXY_LOG}
     -DWORKING_DIRECTORY=${CMAKE_CURRENT_LIST_DIR}
     -P ${ZEPHYR_BASE}/cmake/util/execute_process.cmake
-)
-
-add_custom_target(
-  pristine
-  COMMAND ${CMAKE_COMMAND} -P ${ZEPHYR_BASE}/cmake/pristine.cmake
 )
 
 if(WIN32)
@@ -133,150 +129,263 @@ else()
   set(SEP :)
 endif()
 
-add_custom_target(
-  kconfig
-  COMMAND ${CMAKE_COMMAND} -E make_directory ${RST_OUT}/doc/reference/kconfig
-  COMMAND ${CMAKE_COMMAND} -E env
-  PYTHONPATH="${ZEPHYR_BASE}/scripts/kconfig${SEP}$ENV{PYTHONPATH}"
-  srctree=${ZEPHYR_BASE}
-  KERNELVERSION=${KERNELVERSION}
-  BOARD_DIR=boards/*/*/
-  ARCH=*
-  SOC_DIR=soc/
-  SRCARCH=x86
-  KCONFIG_TURBO_MODE=${KCONFIG_TURBO_MODE}
-  ${PYTHON_EXECUTABLE} scripts/genrest.py Kconfig ${RST_OUT}/doc/reference/kconfig/
-  WORKING_DIRECTORY ${CMAKE_CURRENT_LIST_DIR}
-)
+#
+# Function to generate target for kconfig RST files
+#
+function(construct_kconfig_target scope)
+  if(TARGET ${TGT_NAME_KCONFIG})
+    return()
+  endif()
+
+  add_custom_target(
+    ${TGT_NAME_KCONFIG}
+    COMMAND ${CMAKE_COMMAND} -E make_directory ${RST_OUT}/doc/reference/kconfig
+    COMMAND ${CMAKE_COMMAND} -E env
+    PYTHONPATH="${ZEPHYR_BASE}/scripts/kconfig${SEP}$ENV{PYTHONPATH}"
+    srctree=${ZEPHYR_BASE}
+    KERNELVERSION=${KERNELVERSION}
+    BOARD_DIR=boards/*/*/
+    ARCH=*
+    SOC_DIR=soc/
+    SRCARCH=x86
+    KCONFIG_TURBO_MODE=${KCONFIG_TURBO_MODE}
+    ${PYTHON_EXECUTABLE} scripts/genrest.py Kconfig ${RST_OUT}/doc/reference/kconfig/
+    WORKING_DIRECTORY ${CMAKE_CURRENT_LIST_DIR}
+  )
+endfunction()
 
 set(KI_SCRIPT ${ZEPHYR_BASE}/scripts/filter-known-issues.py)
+set(KI_CONFIG_DIR ${ZEPHYR_BASE}/.known-issues/doc)
 set(FIX_TEX_SCRIPT ${ZEPHYR_BASE}/doc/scripts/fix_tex.py)
-set(CONFIG_DIR ${ZEPHYR_BASE}/.known-issues/doc)
 
 #
-# HTML section
+# Function to generate a target with HTML output
 #
-set(SPHINX_BUILD_HTML_COMMAND
-  ${CMAKE_COMMAND} -E env
-  ZEPHYR_BUILD=${CMAKE_CURRENT_BINARY_DIR}
-  ${SPHINXBUILD} -w ${SPHINX_LOG} -N -t ${DOC_TAG} -b html ${ALLSPHINXOPTS} ${RST_OUT}/doc ${SPHINX_OUTPUT_DIR_HTML})
+function(construct_html_target scope)
+  if(DEFINED SPHINX_OUTPUT_DIR)
+    # SPHINX_OUTPUT_DIR is used to specify exactly where HTML (or other
+    # outputs) are placed, so no /html, /latex, /pdf suffixes are needed.
+    set(SPHINX_OUTPUT_DIR_HTML ${SPHINX_OUTPUT_DIR})
+  else()
+    if("${scope}" STREQUAL "")
+      set(SPHINX_OUTPUT_DIR_HTML ${SPHINX_OUTPUT_DEFAULT_DIR}/html)
+    else()
+      set(SPHINX_OUTPUT_DIR_HTML ${SPHINX_OUTPUT_DEFAULT_DIR}/${scope}_html)
+    endif()
+  endif()
 
-# The sphinx-html target is provided as a convenience for incremental
-# re-builds of content files without regenerating the entire docs
-# pipeline. It can be significantly faster than re-running the full
-# HTML build, but it has no idea if Doxygen, Kconfig, etc. need to be
-# regenerated. Use with caution.
-add_custom_target(
-  sphinx-html
-  COMMAND ${SPHINX_BUILD_HTML_COMMAND}
-  DEPENDS ${EXTRACT_CONTENT_OUTPUTS}
-  COMMENT "Just re-generating HTML (USE WITH CAUTION)"
-  USES_TERMINAL
-)
+  set(TGT_NAME_HTML "${scope}html")
+  set(TGT_NAME_HTML_DOCS "${TGT_NAME_HTML}docs")
 
-add_custom_target(
-  html
-  COMMAND ${SPHINX_BUILD_HTML_COMMAND}
-  # Merge the Doxygen and Sphinx logs into a single file
-  COMMAND ${CMAKE_COMMAND} -P ${ZEPHYR_BASE}/cmake/util/fmerge.cmake ${DOC_LOG} ${DOXY_LOG} ${SPHINX_LOG}
-  COMMAND ${PYTHON_EXECUTABLE} ${KI_SCRIPT} --config-dir ${CONFIG_DIR} --errors ${DOC_WARN} --warnings ${DOC_WARN} ${DOC_LOG}
-  WORKING_DIRECTORY ${CMAKE_CURRENT_LIST_DIR}
-  COMMENT "Generating HTML documentation"
-  ${SPHINX_USES_TERMINAL}
-)
+  set(SPHINX_BUILD_HTML_COMMAND
+    ${CMAKE_COMMAND} -E env
+    ZEPHYR_BUILD=${CMAKE_CURRENT_BINARY_DIR}
+    ${SPHINXBUILD} -w ${SPHINX_LOG} -N -t ${DOC_TAG} -b html ${SCOPE_TAG}
+    -d ${CACHE_DIR} ${SPHINXOPTS} ${RST_OUT}/doc ${SPHINX_OUTPUT_DIR_HTML})
 
-#
-# LaTEX section
-#
-set(SPHINX_BUILD_LATEX_COMMAND
-  ${CMAKE_COMMAND} -E env
-  ZEPHYR_BUILD=${CMAKE_CURRENT_BINARY_DIR}
-  ${SPHINXBUILD} -w ${SPHINX_LOG} -N -t ${DOC_TAG} -b latex -t svgconvert ${ALLSPHINXOPTS} ${RST_OUT}/doc ${SPHINX_OUTPUT_DIR_LATEX})
+  # Add a custom target (e.g. html) to invoke sphinx-build
+  add_custom_target(
+    ${TGT_NAME_HTML}
+    COMMAND ${SPHINX_BUILD_HTML_COMMAND}
+    # Merge the Doxygen and Sphinx logs into a single file
+    COMMAND ${CMAKE_COMMAND} -P ${ZEPHYR_BASE}/cmake/util/fmerge.cmake ${DOC_LOG} ${DOXY_LOG} ${SPHINX_LOG}
+    COMMAND ${PYTHON_EXECUTABLE} ${KI_SCRIPT} --config-dir ${KI_CONFIG_DIR} --errors ${DOC_WARN} --warnings ${DOC_WARN} ${DOC_LOG}
+    WORKING_DIRECTORY ${CMAKE_CURRENT_LIST_DIR}
+    COMMENT "Generating HTML documentation"
+    ${SPHINX_USES_TERMINAL}
+  )
 
-# The sphinx-latex target works similarly to sphinx-html, and carries
-# the same warnings.
-add_custom_target(
-  sphinx-latex
-  COMMAND ${SPHINX_BUILD_LATEX_COMMAND}
-  DEPENDS ${EXTRACT_CONTENT_OUTPUTS}
-  COMMENT "Just re-generating LaTeX (USE WITH CAUTION)"
-  USES_TERMINAL
-)
+  add_dependencies(${TGT_NAME_HTML} doxy ${TGT_NAME_CONTENT} ${TGT_NAME_KCONFIG})
 
-add_custom_command(
-  OUTPUT ${SPHINX_OUTPUT_DIR_LATEX}/zephyr.tex
-  COMMAND ${SPHINX_BUILD_LATEX_COMMAND}
-  # Merge the Doxygen and Sphinx logs into a single file
-  COMMAND ${CMAKE_COMMAND} -P ${ZEPHYR_BASE}/cmake/util/fmerge.cmake ${DOC_LOG} ${DOXY_LOG} ${SPHINX_LOG}
-  COMMAND ${PYTHON_EXECUTABLE} ${KI_SCRIPT} --config-dir ${CONFIG_DIR} --errors ${DOC_WARN} --warnings ${DOC_WARN} ${DOC_LOG}
-  COMMAND ${PYTHON_EXECUTABLE} ${FIX_TEX_SCRIPT} ${SPHINX_OUTPUT_DIR_LATEX}/zephyr.tex
-  WORKING_DIRECTORY ${CMAKE_CURRENT_LIST_DIR}
-  COMMENT "Generating LaTeX documentation"
-  ${SPHINX_USES_TERMINAL}
-)
-
-add_custom_target(
-  latex
-  DEPENDS ${SPHINX_OUTPUT_DIR_LATEX}/zephyr.tex
-)
+  # Final build target (e.g. htmldocs):
+  # Having an extra target allows steps to be added
+  # between Sphinx and final target by adding
+  # dependencies in between.
+  add_custom_target(
+    ${TGT_NAME_HTML_DOCS}
+    DEPENDS ${TGT_NAME_HTML}
+  )
+endfunction()
 
 #
-# PDF section
+# Function to generate a target with LaTeX and PDF output
 #
-if(NOT ${LATEXMK} STREQUAL LATEXMK-NOTFOUND)
+function(construct_latex_pdf_target scope)
+  if(DEFINED SPHINX_OUTPUT_DIR)
+    # SPHINX_OUTPUT_DIR is used to specify exactly where HTML (or other
+    # outputs) are placed, so no /html, /latex, /pdf suffixes are needed.
+    set(SPHINX_OUTPUT_DIR_LATEX ${SPHINX_OUTPUT_DIR})
+  else()
+    if("${scope}" STREQUAL "")
+      set(SPHINX_OUTPUT_DIR_LATEX ${SPHINX_OUTPUT_DEFAULT_DIR}/latex)
+    else()
+      set(SPHINX_OUTPUT_DIR_LATEX ${SPHINX_OUTPUT_DEFAULT_DIR}/${scope}_latex)
+    endif()
+  endif()
 
-add_custom_command(
-  OUTPUT ${SPHINX_OUTPUT_DIR_LATEX}/zephyr.pdf
-  DEPENDS latexdocs ${SPHINX_OUTPUT_DIR_LATEX}/zephyr.tex
-  COMMAND ${CMAKE_COMMAND} -E env
-  LATEXOPTS="-halt-on-error -no-shell-escape"
-  ${LATEXMK} -quiet -pdf -dvi- -ps-
-  WORKING_DIRECTORY ${SPHINX_OUTPUT_DIR_LATEX}
-  COMMENT "Generating PDF documentation"
-)
+  if("${scope}" STREQUAL "")
+    set(LATEXPDF_FILESTEM "zephyr")
+  else()
+    set(LATEXPDF_FILESTEM "${scope}")
+  endif()
 
-if(NOT DEFINED SPHINX_OUTPUT_DIR)
-# Although latexmk allows specifying output directory,
-# makeindex fails if one is specified.
-# Hence the need of this to copy the PDF file over.
-add_custom_command(
-  OUTPUT ${SPHINX_OUTPUT_DIR_PDF}/zephyr.pdf
-  COMMAND ${CMAKE_COMMAND} -E make_directory ${SPHINX_OUTPUT_DIR_PDF}
-  COMMAND ${CMAKE_COMMAND} -E copy ${SPHINX_OUTPUT_DIR_LATEX}/zephyr.pdf ${SPHINX_OUTPUT_DIR_PDF}/zephyr.pdf
-  DEPENDS ${SPHINX_OUTPUT_DIR_LATEX}/zephyr.pdf
-)
-endif()
+  set(TGT_NAME_LATEX "${scope}latex")
+  set(TGT_NAME_LATEX_DOCS "${TGT_NAME_LATEX}docs")
 
-add_custom_target(
-  pdf
-  DEPENDS ${SPHINX_OUTPUT_DIR_PDF}/zephyr.pdf
-)
+  set(SPHINX_BUILD_LATEX_COMMAND
+    ${CMAKE_COMMAND} -E env
+    ZEPHYR_BUILD=${CMAKE_CURRENT_BINARY_DIR}
+    ${SPHINXBUILD} -w ${SPHINX_LOG} -N -t ${DOC_TAG} -b latex -t svgconvert ${SCOPE_TAG}
+    -d ${CACHE_DIR} ${SPHINXOPTS} ${RST_OUT}/doc ${SPHINX_OUTPUT_DIR_LATEX})
 
-endif()
+  add_custom_command(
+    OUTPUT ${SPHINX_OUTPUT_DIR_LATEX}/${LATEXPDF_FILESTEM}.tex
+    COMMAND ${SPHINX_BUILD_LATEX_COMMAND}
+    # Merge the Doxygen and Sphinx logs into a single file
+    COMMAND ${CMAKE_COMMAND} -P ${ZEPHYR_BASE}/cmake/util/fmerge.cmake ${DOC_LOG} ${DOXY_LOG} ${SPHINX_LOG}
+    COMMAND ${PYTHON_EXECUTABLE} ${KI_SCRIPT} --config-dir ${KI_CONFIG_DIR} --errors ${DOC_WARN} --warnings ${DOC_WARN} ${DOC_LOG}
+    COMMAND ${PYTHON_EXECUTABLE} ${FIX_TEX_SCRIPT} ${SPHINX_OUTPUT_DIR_LATEX}/${LATEXPDF_FILESTEM}.tex
+    WORKING_DIRECTORY ${CMAKE_CURRENT_LIST_DIR}
+    COMMENT "Generating LaTeX documentation"
+    ${SPHINX_USES_TERMINAL}
+  )
+
+  add_custom_target(
+    ${TGT_NAME_LATEX}
+    DEPENDS ${SPHINX_OUTPUT_DIR_LATEX}/${LATEXPDF_FILESTEM}.tex
+  )
+
+  add_dependencies(${TGT_NAME_LATEX} doxy ${TGT_NAME_CONTENT} ${TGT_NAME_KCONFIG})
+
+  # Final build target (e.g. htmldocs):
+  # Having an extra target allows steps to be added
+  # between Sphinx and final target by adding
+  # dependencies in between.
+  add_custom_target(
+    ${TGT_NAME_LATEX_DOCS}
+    DEPENDS ${TGT_NAME_LATEX}
+  )
+
+  if(NOT ${LATEXMK} STREQUAL LATEXMK-NOTFOUND)
+    if(DEFINED SPHINX_OUTPUT_DIR)
+      # SPHINX_OUTPUT_DIR is used to specify exactly where HTML (or other
+      # outputs) are placed, so no /html, /latex, /pdf suffixes are needed.
+      set(SPHINX_OUTPUT_DIR_PDF ${SPHINX_OUTPUT_DIR})
+    else()
+      set(SPHINX_OUTPUT_DIR_PDF ${SPHINX_OUTPUT_DEFAULT_DIR}/pdf)
+    endif()
+
+    set(TGT_NAME_PDF "${scope}pdf")
+    set(TGT_NAME_PDF_DOCS "${TGT_NAME_PDF}docs")
+
+    add_custom_command(
+      OUTPUT ${SPHINX_OUTPUT_DIR_LATEX}/${LATEXPDF_FILESTEM}.pdf
+      DEPENDS ${TGT_NAME_LATEX_DOCS} ${SPHINX_OUTPUT_DIR_LATEX}/${LATEXPDF_FILESTEM}.tex
+      COMMAND ${CMAKE_COMMAND} -E env
+      LATEXOPTS="-halt-on-error -no-shell-escape"
+      ${LATEXMK} -quiet -pdf -dvi- -ps-
+      WORKING_DIRECTORY ${SPHINX_OUTPUT_DIR_LATEX}
+    )
+
+    # Although latexmk allows specifying output directory,
+    # makeindex fails if one is specified.
+    # Hence the need of this to copy the PDF file over.
+    add_custom_command(
+      OUTPUT ${SPHINX_OUTPUT_DIR_PDF}/${LATEXPDF_FILESTEM}.pdf
+      COMMAND ${CMAKE_COMMAND} -E make_directory ${SPHINX_OUTPUT_DIR_PDF}
+      COMMAND ${CMAKE_COMMAND} -E copy ${SPHINX_OUTPUT_DIR_LATEX}/${LATEXPDF_FILESTEM}.pdf ${SPHINX_OUTPUT_DIR_PDF}/${LATEXPDF_FILESTEM}.pdf
+      DEPENDS ${SPHINX_OUTPUT_DIR_LATEX}/${LATEXPDF_FILESTEM}.pdf
+    )
+
+    add_custom_target(
+      ${TGT_NAME_PDF}
+      DEPENDS ${SPHINX_OUTPUT_DIR_PDF}/${LATEXPDF_FILESTEM}.pdf
+    )
+
+    add_custom_target(
+      ${TGT_NAME_PDF_DOCS}
+      DEPENDS ${TGT_NAME_PDF}
+    )
+  endif()
+
+endfunction()
 
 #
-# Dependencies and final targets
+# Function the necessary build targets for a certain output_format/scope
+# combinations.
 #
-add_dependencies(html content doxy kconfig)
+# Param: output_format: format to be generated (e.g. html or latexpdf).
+#
+# Param: scope: document scope to be generated (e.g. kernel).
+#
+# Param: has_custom_content_tgt:
+#            FALSE: if use the default generated target;
+#            TRUE:  if special steps are needed to generate content.
+#                   A target named "${scope}content" will need to be defined manually.
+#
+# Param: has_custom_kconfig_tgt:
+#            FALSE: if use the default generated target;
+#            TRUE:  if special steps are needed to generate kconfig RST files.
+#                   A target named "${scope}kconfig" will need to be defined manually.
+#
+function(construct_target output_format scope has_custom_content_tgt has_custom_kconfig_tgt)
+  # Directory for RST files and supporing content
+  if("${scope}" STREQUAL "")
+    set(RST_OUT ${CMAKE_CURRENT_BINARY_DIR}/rst)
+  else()
+    set(RST_OUT ${CMAKE_CURRENT_BINARY_DIR}/${scope}_rst)
+  endif()
 
-add_custom_target(
-  htmldocs
-)
-add_dependencies(htmldocs html)
+  # Common targets used across multiple targets
+  set(TGT_NAME_CONTENT "${scope}content")
+  set(TGT_NAME_KCONFIG "${scope}kconfig")
 
-add_dependencies(latex content doxy kconfig)
+  #
+  # If a cached environment is built with one output format and used
+  # subsequently for another output format (e.g. HTML then LaTeX),
+  # the cached environment may be corrupted (e.g. app.env.found_docs
+  # is different between builds even though nothing has changed).
+  # This behvaior is not observed if the cached environment is being
+  # used multiple time with the same format (with or without changes
+  # to RST files). As a precaution, have different cached
+  # environments for each output format.
+  #
+  if("${scope}" STREQUAL "")
+    set(CACHE_DIR ${CMAKE_CURRENT_BINARY_DIR}/doctrees.${output_format})
+  else()
+    set(CACHE_DIR ${CMAKE_CURRENT_BINARY_DIR}/doctrees.${scope}.${output_format})
+  endif()
 
-add_custom_target(
-  latexdocs
-)
-add_dependencies(latexdocs latex)
+  # Set tag for Sphinx
+  if("${scope}" STREQUAL "")
+    set(SCOPE_TAG "")
+  else()
+    set(SCOPE_TAG "-t" "${scope}")
+  endif()
 
-if(NOT ${LATEXMK} STREQUAL LATEXMK-NOTFOUND)
+  # Custom content generation target?
+  # Use the generic one if not.
+  if(NOT ${has_custom_content_tgt})
+    if(NOT TARGET ${TGT_NAME_CONTENT})
+      construct_content_target("${scope}")
+    endif()
+  endif()
 
-add_custom_target(
-  pdfdocs
-  DEPENDS latexdocs pdf
-)
-add_dependencies(pdfdocs pdf)
+  # Custom kconfig RST generation target?
+  # Use the generic one if not.
+  if(NOT ${has_custom_kconfig_tgt})
+    construct_kconfig_target("${scope}")
+  endif()
 
-endif()
+  if("${output_format}" STREQUAL "html")
+    construct_html_target("${scope}")
+  elseif("${output_format}" STREQUAL "latexpdf")
+    construct_latex_pdf_target("${scope}")
+  else()
+    message(FATAL_ERROR "output_format '${output_format}' not recognized")
+  endif()
+endfunction()
+
+# HTML, LaTeX and PDF targets for whole document
+construct_target("html" "" FALSE FALSE)
+construct_target("latexpdf" "" FALSE FALSE)

--- a/doc/CMakeLists.txt
+++ b/doc/CMakeLists.txt
@@ -137,6 +137,18 @@ function(construct_kconfig_target scope)
     return()
   endif()
 
+  if("${scope}" STREQUAL "kernel")
+    set(SRC "${ZEPHYR_BASE}/doc/scopes/kernel.kconfig")
+
+    # A particular scope may use the whole kconfig tree
+    # if a custom one is not found
+    if(NOT EXISTS ${SRC})
+      set(SRC "Kconfig")
+    endif()
+  else()
+    set(SRC "Kconfig")
+  endif()
+
   add_custom_target(
     ${TGT_NAME_KCONFIG}
     COMMAND ${CMAKE_COMMAND} -E make_directory ${RST_OUT}/doc/reference/kconfig
@@ -149,7 +161,7 @@ function(construct_kconfig_target scope)
     SOC_DIR=soc/
     SRCARCH=x86
     KCONFIG_TURBO_MODE=${KCONFIG_TURBO_MODE}
-    ${PYTHON_EXECUTABLE} scripts/genrest.py Kconfig ${RST_OUT}/doc/reference/kconfig/
+    ${PYTHON_EXECUTABLE} scripts/genrest.py ${SRC} ${RST_OUT}/doc/reference/kconfig/
     WORKING_DIRECTORY ${CMAKE_CURRENT_LIST_DIR}
   )
 endfunction()
@@ -389,3 +401,7 @@ endfunction()
 # HTML, LaTeX and PDF targets for whole document
 construct_target("html" "" FALSE FALSE)
 construct_target("latexpdf" "" FALSE FALSE)
+
+# HTML, LaTeX and PDF targets for kernel only document
+construct_target("html" "kernel" FALSE FALSE)
+construct_target("latexpdf" "kernel" FALSE FALSE)

--- a/doc/CMakeLists.txt
+++ b/doc/CMakeLists.txt
@@ -278,6 +278,15 @@ function(construct_latex_pdf_target scope)
     DEPENDS ${TGT_NAME_LATEX}
   )
 
+  # On Windows system, this needs to be double-quoted.
+  # On other systems, double-quote makes this passed as one quoted string
+  # and being treated as one command argument. So use single quotes.
+  if(WIN32)
+    set(LATEXOPTS "-halt-on-error -no-shell-escape")
+  else()
+    set(LATEXOPTS '-halt-on-error -no-shell-escape')
+  endif()
+
   if(NOT ${LATEXMK} STREQUAL LATEXMK-NOTFOUND)
     if(DEFINED SPHINX_OUTPUT_DIR)
       # SPHINX_OUTPUT_DIR is used to specify exactly where HTML (or other
@@ -294,7 +303,7 @@ function(construct_latex_pdf_target scope)
       OUTPUT ${SPHINX_OUTPUT_DIR_LATEX}/${LATEXPDF_FILESTEM}.pdf
       DEPENDS ${TGT_NAME_LATEX_DOCS} ${SPHINX_OUTPUT_DIR_LATEX}/${LATEXPDF_FILESTEM}.tex
       COMMAND ${CMAKE_COMMAND} -E env
-      LATEXOPTS="-halt-on-error -no-shell-escape"
+      LATEXOPTS=${LATEXOPTS}
       ${LATEXMK} -quiet -pdf -dvi- -ps-
       WORKING_DIRECTORY ${SPHINX_OUTPUT_DIR_LATEX}
     )

--- a/doc/README.rst
+++ b/doc/README.rst
@@ -152,6 +152,12 @@ folder, here are the commands to generate the html content locally:
    # To generate PDF output, run ninja on the generated build system:
    ninja pdfdocs
 
+   # To generate HTML output for documentation related to core Kernel
+   ninja kernelhtmldocs
+
+   # To generate PDF output for documentation related to core Kernel
+   ninja kernelpdfdocs
+
 .. warning::
 
    The documentation build system creates copies in the build

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -64,6 +64,7 @@ extensions = [
     'zephyr.application',
     'zephyr.html_redirects',
     'only.eager_only',
+    'zephyr.doc_scope',
     'zephyr.link-roles'
 ]
 
@@ -416,6 +417,8 @@ linkcheck_timeout = 30
 linkcheck_workers = 10
 # linkcheck_ignore = [r'https://jira\.zephyrproject\.org/']
 linkcheck_anchors = False
+
+zephyr_doc_scope = None
 
 def setup(app):
    app.add_stylesheet("zephyr-custom.css")

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -59,6 +59,7 @@ except CalledProcessError as e:
 # ones.
 extensions = [
     'breathe', 'sphinx.ext.todo',
+    'sphinx.ext.ifconfig',
     'sphinx.ext.extlinks',
     'sphinx.ext.autodoc',
     'zephyr.application',
@@ -282,7 +283,10 @@ sourcelink_suffix = '.txt'
 #html_search_scorer = 'scorer.js'
 
 # Output file base name for HTML help builder.
-htmlhelp_basename = 'zephyrdoc'
+if tags.has("kernel"):
+    htmlhelp_basename = 'zephyrkerneldoc'
+else:
+    htmlhelp_basename = 'zephyrdoc'
 
 
 # Custom added feature to allow redirecting old URLs
@@ -310,10 +314,16 @@ latex_elements = {
 # Grouping the document tree into LaTeX files. List of tuples
 # (source start file, target name, title,
 #  author, documentclass [howto, manual, or own class]).
-latex_documents = [
-  (master_doc, 'zephyr.tex', u'Zephyr Project Documentation',
-   u'many', 'manual'),
-]
+if tags.has("kernel"):
+    latex_documents = [
+      (master_doc, 'kernel.tex', u'Zephyr Project Kernel Documentation',
+       u'many', 'manual'),
+    ]
+else:
+    latex_documents = [
+      (master_doc, 'zephyr.tex', u'Zephyr Project Documentation',
+       u'many', 'manual'),
+    ]
 
 # The name of an image file (relative to this directory) to place at the top of
 # the title page.
@@ -339,10 +349,16 @@ latex_documents = [
 
 # One entry per manual page. List of tuples
 # (source start file, name, description, authors, manual section).
-man_pages = [
-    (master_doc, 'zephyr', u'Zephyr Project Documentation',
-     [author], 1)
-]
+if tags.has("kernel"):
+    man_pages = [
+        (master_doc, 'kernel', u'Zephyr Project Kernel Documentation',
+         [author], 1)
+    ]
+else:
+    man_pages = [
+        (master_doc, 'zephyr', u'Zephyr Project Documentation',
+         [author], 1)
+    ]
 
 # If true, show URL addresses after external links.
 #man_show_urls = False
@@ -353,11 +369,18 @@ man_pages = [
 # Grouping the document tree into Texinfo files. List of tuples
 # (source start file, target name, title, author,
 #  dir menu entry, description, category)
-texinfo_documents = [
-  (master_doc, 'zephyr', u'Zephyr Project Documentation',
-   author, 'Zephyr', 'One line description of project.',
-   'Miscellaneous'),
-]
+if tags.has("kernel"):
+    texinfo_documents = [
+      (master_doc, 'kernel', u'Zephyr Project Kernel Documentation',
+       author, 'Zephyr', 'One line description of project.',
+       'Miscellaneous'),
+    ]
+else:
+    texinfo_documents = [
+      (master_doc, 'zephyr', u'Zephyr Project Documentation',
+       author, 'Zephyr', 'One line description of project.',
+       'Miscellaneous'),
+    ]
 
 # Documents to append as an appendix to all manuals.
 #texinfo_appendices = []
@@ -419,6 +442,8 @@ linkcheck_workers = 10
 linkcheck_anchors = False
 
 zephyr_doc_scope = None
+if tags.has("kernel"):
+    zephyr_doc_scope = "kernel"
 
 def setup(app):
    app.add_stylesheet("zephyr-custom.css")

--- a/doc/extensions/zephyr/doc_scope.py
+++ b/doc/extensions/zephyr/doc_scope.py
@@ -1,0 +1,257 @@
+# Copyright (c) 2019, Intel Corporation
+#
+# SPDX-License-Identifier: Apache-2.0
+
+import ast
+import fnmatch
+import os
+
+import docutils
+import sphinx
+
+docs_to_include = set()
+docs_to_remove = set()
+external_links = {}
+fp_patterns = []
+
+if "ZEPHYR_BASE" not in os.environ:
+    sys.stderr.write("$ZEPHYR_BASE environment variable undefined.\n")
+    exit(1)
+ZEPHYR_BASE = os.environ["ZEPHYR_BASE"]
+
+#
+# This reads in the file path patterns from doc/scopes/${scope}.patterns
+# Each line in the file contains one pattern which is used to match
+# against the relative path of document files from Sphinx using fnmatch().
+#
+# The pattern is relative to document source directory.
+# For example, to match "doc/_build/rst/doc/kernel/kernel.rst",
+# the pattern is "kernel/kernel.rst" since "doc/_build/rst/doc"
+# is the root of document source directory.
+#
+# If the pattern has a file extension that is defined in Sphinx
+# configuration 'source_suffix', the file extension will be removed
+# from the pattern as Sphinx removes them also before storing the paths.
+#
+# Note that fnmatch() performs path normalization before matching
+# which allows the patterns in the file to be Unix style path.
+# The normalization will transform the pattern into one suitable
+# for the operating system.
+#
+# For example, doc/scopes/kernel.patterns:
+#
+#     index.rst
+#     api/api.rst
+#     api/kernel_api.rst
+#     application/index.rst
+#     kernel/*
+#     reference/kconfig/*
+#
+def _get_file_path_patterns(app, scope):
+    global fp_patterns
+
+    filepath = os.path.join(ZEPHYR_BASE, "doc", "scopes", scope + ".patterns")
+    with open(filepath) as f:
+        for line in f:
+            # Normalize path so it works cross-platform
+            path = os.path.normcase(line.strip())
+
+            # Skip empty lines
+            if not path:
+                continue
+
+            # Strip file extensions
+            for suffix in app.config.source_suffix:
+                idx = path.endswith(suffix)
+                if idx > 0:
+                    path = path[:-len(suffix)]
+                    break
+
+            if path:
+                fp_patterns.append(path)
+
+    if not fp_patterns:
+        raise Exception("No usable pattern defined in {}!".format(filepath))
+
+
+#
+# This reads in the reference (:ref:) to external URL mapping
+# from doc/scopes/${scope}.extlinks if this file exists.
+#
+# The content of the file is a Python dictionary, and will be parsed
+# as literal. Each item must have two strings, "name" and "url".
+# The "name" is the text which will be put in the output document
+# replacing the :ref:<...> text. The "url" will be used to generate
+# the necessary hyperlink in the output.
+#
+# When generating a subset of document, some RST files are no longer
+# included in the build. The references (:ref:) to labels within
+# these files can no longer be resolved. External links are needed
+# to point them to the online documentation to avoid broken references.
+#
+# For example, doc/scopes/kernel.extlinks
+#
+#    {
+#        'application':
+#            {
+#                'name': 'Application Development Primer',
+#                'url' : 'https://docs.zephyrproject.org/latest/application/application.html'
+#            },
+#        'glossary':
+#            {
+#                'name': 'Glossary',
+#                'url' : 'https://docs.zephyrproject.org/latest/glossary.html#glossary'
+#            },
+#        'zephyr_licensing':
+#            {
+#                'name': 'Licensing of Zephyr Project components',
+#                'url' : 'https://docs.zephyrproject.org/latest/LICENSING.html'
+#            },
+#        'zephyr_release_notes':
+#            {
+#                'name': 'Release Notes',
+#                'url' : 'https://docs.zephyrproject.org/latest/release-notes.html'
+#            }
+#    }
+#
+def _get_external_links(app, scope):
+    global external_links
+
+    filepath = os.path.join(ZEPHYR_BASE, "doc", "scopes", scope + ".extlinks")
+
+    if os.path.isfile(filepath):
+        with open(os.path.join(filepath)) as f:
+            external_links = ast.literal_eval(f.read())
+
+
+def _init(app, scope):
+    _get_file_path_patterns(app, scope)
+    _get_external_links(app, scope)
+
+
+#
+# This filters the list of document found by Sphinx using
+# the file path patterns. Sphinx then only processes
+# the files in the filtered list. This also populates
+# a list of removed files which will be used to filter
+# the TOC trees in later build stage.
+#
+def builder_inited(app):
+    global docs_to_include
+    global docs_to_remove
+    global fp_patterns
+
+    # Only manipulate documents list if scope is specified
+    scope = app.config.zephyr_doc_scope
+    if scope is None:
+        return
+
+    _init(app, scope)
+
+    # Trim the document list according to file path patterns
+    for pattern in fp_patterns:
+        docs_to_include.update(fnmatch.filter(app.env.found_docs, pattern))
+
+    docs_to_remove = app.env.found_docs.copy()
+    docs_to_remove.difference_update(docs_to_include)
+
+    app.env.found_docs.intersection_update(docs_to_include)
+
+
+#
+# After Sphinx figures out what files to be added,
+# which changes, and what to remove, we need to update
+# those lists with our patterns.
+#
+# Note this is also called on first run, since technically
+# the environment is "out-dated".
+#
+def env_get_outdated(app, env, added, changed, removed):
+    global docs_to_remove
+
+    # Only manipulate documents list if scope is specified
+    scope = app.config.zephyr_doc_scope
+    if scope is None:
+        return []
+
+    added.difference_update(docs_to_remove)
+    changed.difference_update(docs_to_remove)
+    removed.update(docs_to_remove)
+
+    return []
+
+
+#
+# For each parsed document, goes through the TOC tree (.. toctree::)
+# and removes the entries that are out of scope.
+#
+def doctree_read(app, doctree):
+    global docs_to_remove
+
+    # Only process files if scope is specified
+    scope = app.config.zephyr_doc_scope
+    if scope is None:
+        return
+
+    # Traverse the TOC nodes and removes any entries and
+    # references to out-of-scope documents
+    for toctreenode in doctree.traverse(sphinx.addnodes.toctree):
+        to_remove = []
+
+        for e in toctreenode['entries']:
+            ref = str(e[1])
+            if ref in docs_to_remove:
+                to_remove.append(e)
+
+        if to_remove:
+            for e in to_remove:
+                toctreenode['entries'].remove(e)
+                toctreenode['includefiles'].remove(e[1])
+
+
+#
+# Sphinx calls this when a docutil node has unresolved
+# references. This function replaces these references
+# with external links.
+#
+def missing_reference(app, env, node, contnode):
+    global external_links
+
+    # Only process missing refs if scope is specified
+    scope = app.config.zephyr_doc_scope
+    if scope is None:
+        return
+
+    # External link list is empty of does not exist
+    if not external_links:
+        return
+
+    # References (:ref:) that are in out-of-scope documents
+    # need to be replaced with links to online document
+    if node['reftype'] == 'ref':
+        tgt = node['reftarget']
+        if tgt in external_links:
+            newnode = docutils.nodes.reference(
+                          external_links[tgt]['name'],
+                          external_links[tgt]['name'],
+                          refuri = external_links[tgt]['url'],
+                          internal = False)
+
+            return newnode
+
+    return None
+
+
+def setup(app):
+    app.add_config_value('zephyr_doc_scope', None, 'env')
+
+    app.connect('builder-inited', builder_inited)
+    app.connect('env-get-outdated', env_get_outdated)
+    app.connect('doctree-read', doctree_read)
+    app.connect('missing-reference', missing_reference)
+
+    return {
+        'version': '1.0',
+        'parallel_read_safe': True,
+        'parallel_write_safe': True
+    }

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -1,8 +1,15 @@
 ..
     Zephyr Project documentation master file
 
-Zephyr Project Documentation
-############################
+.. ifconfig:: not zephyr_doc_scope
+
+   Zephyr Project Documentation
+   ############################
+
+.. ifconfig:: zephyr_doc_scope == "kernel"
+
+   Zephyr Project Kernel Documentation
+   ###################################
 
 .. only:: release
 
@@ -30,69 +37,71 @@ licensing, as described in :ref:`Zephyr_Licensing`.
 .. _GitHub repo: https://github.com/zephyrproject-rtos/zephyr
 
 
-.. raw:: html
+.. ifconfig:: not zephyr_doc_scope
 
-   <ul class="grid">
-       <li class="grid-item">
-	   <a href="introduction/introducing_zephyr.html">
-	       <img alt="" src="_static/images/kite.png"/>
-	       <h2>Introduction</h2>
-	   </a>
-	   <p>Introducing the Zephyr Project: the overview, architecture, features and licensing</p>
-       </li>
-       <li class="grid-item">
-	   <a href="getting_started/getting_started.html">
-	       <img alt="" src=""/>
-	       <h2>Getting Started Guide</h2>
-	   </a>
-	   <p>Follow this guide to set up a Zephyr development environment on your
-	       system, and then build and run a sample application.</p>
-       </li>
-       <li class="grid-item">
-	   <a href="contribute/index.html">
-	       <img alt="" src=""/>
-	       <h2>Contribution Guidelines</h2>
-	   </a>
-	   <p>As an open-source project, we welcome and encourage the community
-           to submit patches directly to the project.</p>
-       </li>
-       <li class="grid-item">
-	   <a href="samples/samples.html">
-	       <img alt="" src=""/>
-	       <h2>Samples and Demos</h2>
-	   </a>
-	   <p>A list of samples and demos that can run on a variety of boards supported
-	       by Zephyr</p>
-       </li>
-       <li class="grid-item">
-	   <a href="kernel/kernel.html">
-	       <img alt="" src=""/>
-	       <h2>Kernel Services</h2>
-	   </a>
-	   <p>General introduction of the Zephyr kernel’s key capabilities and services.</p>
-       </li>
-       <li class="grid-item">
-	   <a href="security/security.html">
-	       <img alt="" src=""/>
-	       <h2>Security</h2>
-	   </a>
-	   <p>Requirements, processes, and developer guidelines for ensuring security is addressed within the Zephyr project.</p>
-       </li>
-       <li class="grid-item">
-	   <a href="boards/boards.html">
-	       <img alt="" src=""/>
-	       <h2>Supported Boards</h2>
-	   </a>
-	   <p>List if supported boards and platforms.</p>
-       </li>
-       <li class="grid-item">
-	   <a href="tools/index.html">
-	       <img alt="" src=""/>
-	       <h2>Tools</h2>
-	   </a>
-	   <p>List of Tools used for development.</p>
-       </li>
-   </ul>
+   .. raw:: html
+
+      <ul class="grid">
+          <li class="grid-item">
+              <a href="introduction/introducing_zephyr.html">
+                  <img alt="" src="_static/images/kite.png"/>
+                  <h2>Introduction</h2>
+              </a>
+              <p>Introducing the Zephyr Project: the overview, architecture, features and licensing</p>
+          </li>
+          <li class="grid-item">
+              <a href="getting_started/getting_started.html">
+                  <img alt="" src=""/>
+                  <h2>Getting Started Guide</h2>
+              </a>
+              <p>Follow this guide to set up a Zephyr development environment on your
+                  system, and then build and run a sample application.</p>
+          </li>
+          <li class="grid-item">
+              <a href="contribute/index.html">
+                  <img alt="" src=""/>
+                  <h2>Contribution Guidelines</h2>
+              </a>
+              <p>As an open-source project, we welcome and encourage the community
+                  to submit patches directly to the project.</p>
+          </li>
+          <li class="grid-item">
+              <a href="samples/samples.html">
+                  <img alt="" src=""/>
+                  <h2>Samples and Demos</h2>
+              </a>
+              <p>A list of samples and demos that can run on a variety of boards supported
+                  by Zephyr</p>
+          </li>
+          <li class="grid-item">
+              <a href="kernel/kernel.html">
+                  <img alt="" src=""/>
+                  <h2>Kernel Services</h2>
+              </a>
+              <p>General introduction of the Zephyr kernel’s key capabilities and services.</p>
+          </li>
+          <li class="grid-item">
+              <a href="security/security.html">
+                  <img alt="" src=""/>
+                  <h2>Security</h2>
+              </a>
+              <p>Requirements, processes, and developer guidelines for ensuring security is addressed within the Zephyr project.</p>
+          </li>
+          <li class="grid-item">
+              <a href="boards/boards.html">
+                  <img alt="" src=""/>
+                  <h2>Supported Boards</h2>
+              </a>
+              <p>List if supported boards and platforms.</p>
+          </li>
+          <li class="grid-item">
+              <a href="tools/index.html">
+                  <img alt="" src=""/>
+                  <h2>Tools</h2>
+              </a>
+              <p>List of Tools used for development.</p>
+          </li>
+      </ul>
 
 .. only:: html
 

--- a/doc/scopes/kernel.extlinks
+++ b/doc/scopes/kernel.extlinks
@@ -1,0 +1,22 @@
+{
+    'application':
+        {
+            'name': 'Application Development Primer',
+            'url' : 'https://docs.zephyrproject.org/latest/application/application.html'
+        },
+    'glossary':
+        {
+            'name': 'Glossary',
+            'url' : 'https://docs.zephyrproject.org/latest/glossary.html#glossary'
+        },
+    'zephyr_licensing':
+        {
+            'name': 'Licensing of Zephyr Project components',
+            'url' : 'https://docs.zephyrproject.org/latest/LICENSING.html'
+        },
+    'zephyr_release_notes':
+        {
+            'name': 'Release Notes',
+            'url' : 'https://docs.zephyrproject.org/latest/release-notes.html'
+        }
+}

--- a/doc/scopes/kernel.kconfig
+++ b/doc/scopes/kernel.kconfig
@@ -1,0 +1,18 @@
+#
+# kernel.kconfig
+#
+# including only the kconfig options needed for
+# kernel documentation
+#
+
+mainmenu "Zephyr Kernel Configuration"
+
+source "arch/Kconfig"
+
+source "kernel/Kconfig"
+
+# need for
+#   CONFIG_MULTI_LEVEL_INTERRUPTS
+#   CONFIG_2ND_LEVEL_INTERRUPTS
+#   CONFIG_3RD_LEVEL_INTERRUPTS
+source "drivers/interrupt_controller/Kconfig.multilevel"

--- a/doc/scopes/kernel.patterns
+++ b/doc/scopes/kernel.patterns
@@ -1,0 +1,7 @@
+index.rst
+api/index.rst
+api/kernel_api.rst
+application/index.rst
+kernel/*
+reference/index.rst
+reference/kconfig/*


### PR DESCRIPTION
This adds a few targets to generate core kernel documentation
(including the Kernel Primer and API).

Relates to #6782

Signed-off-by: Daniel Leung <daniel.leung@intel.com>