### PR TITLE
net: Remove s_addr/s6_addr defines from in_addr/in6_addr

### DIFF
--- a/include/net/net_ip.h
+++ b/include/net/net_ip.h
@@ -79,27 +79,20 @@ enum net_sock_type {
 /** IPv6 address structure */
 struct in6_addr {
 	union {
-		u8_t		u6_addr8[16];
-		u16_t		u6_addr16[8]; /* In big endian */
-		u32_t		u6_addr32[4]; /* In big endian */
-	} in6_u;
-#define s6_addr			in6_u.u6_addr8
-#define s6_addr16		in6_u.u6_addr16
-#define s6_addr32		in6_u.u6_addr32
+		u8_t s6_addr[16];
+		u16_t s6_addr16[8]; /* In big endian */
+		u32_t s6_addr32[4]; /* In big endian */
+	};
 };
 
 /** IPv4 address */
 struct in_addr {
 	union {
-		u8_t		u4_addr8[4];
-		u16_t		u4_addr16[2]; /* In big endian */
-		u32_t		u4_addr32[1]; /* In big endian */
-	} in4_u;
-#define s4_addr			in4_u.u4_addr8
-#define s4_addr16		in4_u.u4_addr16
-#define s4_addr32		in4_u.u4_addr32
-
-#define s_addr			s4_addr32[0]
+		u8_t s4_addr[4];
+		u16_t s4_addr16[2]; /* In big endian */
+		u32_t s4_addr32[1]; /* In big endian */
+		u32_t s_addr; /* In big endian, for POSIX compatibility. */
+	};
 };
 
 typedef unsigned short int sa_family_t;


### PR DESCRIPTION
Replace #defines for `s_addr`/`s6_addr` etc. in `in_addr`/`in6_addr` structures
within `net_ip.h` with fixed fileds. This prevents intrusive behaviour of
`net_ip.h`, that expands every occurence of `s_addr`/`s6_addr` with it's own
define, even in other, non-related structures.

Fixes #10242

Signed-off-by: Robert Lubos <robert.lubos@nordicsemi.no>