### PR TITLE
Arch arm reorg mpu region types

### DIFF
--- a/include/arch/arm/cortex_m/mpu/arm_core_mpu_dev.h
+++ b/include/arch/arm/cortex_m/mpu/arm_core_mpu_dev.h
@@ -31,9 +31,6 @@ extern "C" {
  */
 /* Thread Stack Region Intent Type */
 enum {
-#ifdef CONFIG_USERSPACE
-	THREAD_STACK_REGION,
-#endif
 #ifdef CONFIG_APPLICATION_MEMORY
 	THREAD_APP_DATA_REGION,
 #endif
@@ -41,6 +38,7 @@ enum {
 	THREAD_STACK_GUARD_REGION,
 #endif
 #ifdef CONFIG_USERSPACE
+	THREAD_STACK_REGION,
 	THREAD_DOMAIN_PARTITION_REGION,
 #endif
 	THREAD_MPU_REGION_LAST

--- a/include/arch/arm/cortex_m/mpu/arm_core_mpu_dev.h
+++ b/include/arch/arm/cortex_m/mpu/arm_core_mpu_dev.h
@@ -14,20 +14,22 @@ extern "C" {
 
 /*
  * The defines below represent the region types. The MPU driver is responsible
- * to allocate the region accordingly to the type and set the correct
+ * for allocating the region according to the type and for setting the correct
  * attributes.
  *
  * Each MPU is different and has a different set of attributes, hence instead
- * of having the attributes at this level the arm_mpu_core defines the intent
+ * of having the attributes at this level, the arm_mpu_core defines the intent
  * types.
+ *
  * An intent type (i.e. THREAD_STACK_GUARD) can correspond to a different set
- * of operations and attributes for each MPU and it is responsibility of the
- * MPU driver to select the correct ones.
+ * of operations and attributes for each MPU and it is the responsibility of
+ * the MPU driver to select the correct ones.
  *
  * The intent based configuration can't fail hence at this level no error
  * is returned by the configuration functions.
  * If one of the operations corresponding to an intent fails the error has to
- * be managed inside the MPU driver and not escalated.
+ * be managed inside the MPU driver and to not be escalated.
+ *
  */
 /* Thread Stack Region Intent Type */
 enum {

--- a/include/kernel.h
+++ b/include/kernel.h
@@ -4802,7 +4802,7 @@ struct k_mem_partition {
 #endif	/* CONFIG_USERSPACE */
 };
 
-/* memory domian
+/* memory domain
  * Note: Always declare this structure with __kernel prefix
  */
 struct k_mem_domain {


### PR DESCRIPTION

This PR includes
- several improvements of the MPU region types documentation
- a grouping of USERSPACE-related types in a single #ifdef guard.

It does not introduce behavioral changes.