### PR TITLE
net: sockets: Add getaddrinfo and freeaddrinfo to socket offloading

### DIFF
--- a/drivers/wifi/simplelink/simplelink_sockets.c
+++ b/drivers/wifi/simplelink/simplelink_sockets.c
@@ -506,6 +506,24 @@ exit:
 	return _SlDrvSetErrno(retval);
 }
 
+static int simplelink_getaddrinfo(const char *node, const char *service,
+				  const struct addrinfo *hints,
+				  struct addrinfo **res)
+{
+	ARG_UNUSED(node);
+	ARG_UNUSED(service);
+	ARG_UNUSED(hints);
+	ARG_UNUSED(res);
+
+	errno = ENOTSUP;
+	return EAI_SYSTEM;
+}
+
+static void simplelink_freeaddrinfo(struct addrinfo *res)
+{
+	ARG_UNUSED(res);
+}
+
 const struct socket_offload simplelink_ops = {
 	.socket = simplelink_socket,
 	.close = simplelink_close,
@@ -520,4 +538,6 @@ const struct socket_offload simplelink_ops = {
 	.recvfrom = simplelink_recvfrom,
 	.send = simplelink_send,
 	.sendto = simplelink_sendto,
+	.getaddrinfo = simplelink_getaddrinfo,
+	.freeaddrinfo = simplelink_freeaddrinfo,
 };

--- a/include/net/socket.h
+++ b/include/net/socket.h
@@ -318,7 +318,33 @@ static inline int setsockopt(int sock, int level, int optname,
 #endif
 }
 
+static inline int getaddrinfo(const char *host, const char *service,
+			      const struct zsock_addrinfo *hints,
+			      struct zsock_addrinfo **res)
+{
+	return zsock_getaddrinfo(host, service, hints, res);
+}
+
+static inline void freeaddrinfo(struct zsock_addrinfo *ai)
+{
+	free(ai);
+}
+
+#define addrinfo zsock_addrinfo
+
 #else
+
+struct addrinfo {
+	int ai_flags;
+	int ai_family;
+	int ai_socktype;
+	int ai_protocol;
+	socklen_t ai_addrlen;
+	struct sockaddr *ai_addr;
+	char *ai_canonname;
+	struct addrinfo *ai_next;
+};
+
 #include <net/socket_offload.h>
 #endif /* !defined(CONFIG_NET_SOCKETS_OFFLOAD) */
 
@@ -340,24 +366,12 @@ static inline int inet_pton(sa_family_t family, const char *src, void *dst)
 	return zsock_inet_pton(family, src, dst);
 }
 
-static inline int getaddrinfo(const char *host, const char *service,
-			      const struct zsock_addrinfo *hints,
-			      struct zsock_addrinfo **res)
-{
-	return zsock_getaddrinfo(host, service, hints, res);
-}
-
-static inline void freeaddrinfo(struct zsock_addrinfo *ai)
-{
-	free(ai);
-}
-
-#define addrinfo zsock_addrinfo
 #define EAI_BADFLAGS DNS_EAI_BADFLAGS
 #define EAI_NONAME DNS_EAI_NONAME
 #define EAI_AGAIN DNS_EAI_AGAIN
 #define EAI_FAIL DNS_EAI_FAIL
 #define EAI_NODATA DNS_EAI_NODATA
+#define EAI_SYSTEM DNS_EAI_SYSTEM
 #endif /* defined(CONFIG_NET_SOCKETS_POSIX_NAMES) */
 
 #ifdef __cplusplus

--- a/include/net/socket_offload.h
+++ b/include/net/socket_offload.h
@@ -140,6 +140,24 @@ static inline ssize_t sendto(int sock, const void *buf,
 	return socket_ops->sendto(sock, buf, len, flags, to, tolen);
 }
 
+static inline int getaddrinfo(const char *node, const char *service,
+			      const struct addrinfo *hints,
+			      struct addrinfo **res)
+{
+	__ASSERT_NO_MSG(socket_ops);
+	__ASSERT_NO_MSG(socket_ops->getaddrinfo);
+
+	return socket_ops->getaddrinfo(node, service, hints, res);
+}
+
+static inline void freeaddrinfo(struct addrinfo *res)
+{
+	__ASSERT_NO_MSG(socket_ops);
+	__ASSERT_NO_MSG(socket_ops->freeaddrinfo);
+
+	return socket_ops->freeaddrinfo(res);
+}
+
 #ifdef __cplusplus
 }
 #endif

--- a/include/net/socket_offload_ops.h
+++ b/include/net/socket_offload_ops.h
@@ -45,6 +45,10 @@ struct socket_offload {
 	ssize_t (*send)(int sock, const void *buf, size_t len, int flags);
 	ssize_t (*sendto)(int sock, const void *buf, size_t len, int flags,
 			  const struct sockaddr *to, socklen_t tolen);
+	int (*getaddrinfo)(const char *node, const char *service,
+			   const struct addrinfo *hints,
+			   struct addrinfo **res);
+	void (*freeaddrinfo)(struct addrinfo *res);
 };
 
 extern void socket_offload_register(const struct socket_offload *ops);


### PR DESCRIPTION
Adds `getaddrinfo` and `freeaddrinfo` to the offloaded API.

In our solution we offload DNS calls as well, hence we need to have possibility to call offloaded functions.

@GAnthony Please let me know how do you find this proposal in terms of your solution. I've allowed myself to stub new functions in your offloaded calls, let me know if you're fine with that, or should I remove the stubs.

Signed-off-by: Joakim Andre Tønnesen <joakim.tonnesen@nordicsemi.no>
Signed-off-by: Robert Lubos <robert.lubos@nordicsemi.no>