### PR TITLE
lib: POSIX: Add check for deadlock in pthread_join

### DIFF
--- a/lib/posix/pthread.c
+++ b/lib/posix/pthread.c
@@ -381,6 +381,10 @@ int pthread_join(pthread_t thread, void **status)
 		return ESRCH;
 	}
 
+	if (pthread == pthread_self()) {
+		return EDEADLK;
+	}
+
 	pthread_mutex_lock(&pthread->state_lock);
 
 	if (pthread->state == PTHREAD_JOINABLE) {

--- a/tests/posix/pthread_join/src/main.c
+++ b/tests/posix/pthread_join/src/main.c
@@ -117,6 +117,9 @@ void test_pthread_join(void)
 
 	/* Test PASS if all threads have exited before main exit */
 	zassert_equal(exit_count, N_THR, "pthread join test failed");
+
+	/* Test for deadlock */
+	zassert_equal(pthread_join(pthread_self(), &retval), EDEADLK, NULL);
 }
 
 void test_main(void)


### PR DESCRIPTION
Calling pthread_join() with current thread would lead
to deadlock. Adding check for it and to return
appropriate error code.

Also updated the test case to verify the scenario.

Part of: #9993 
Signed-off-by: Spoorthi K <spoorthi.k@intel.com>