### PR TITLE
doc: [DNM] check CI is catching doc build errors

### DIFF
--- a/doc/not-included.rst
+++ b/doc/not-included.rst
@@ -1,0 +1,12 @@
+Generate a warning from sphinx because this doc is not included in any
+toctree command.  Check that doc warnings are caught by the CI system.
+
+Throw in an indentation problem too:
+
+* item one
+
+  * item one-a
+   * item one-b
+ * item one-c
+
+* item two


### PR DESCRIPTION
DO NOT MERGE - a quick check that the CI system is catching docbuild
errors... I have a suspicion maybe not?

Signed-off-by: David B. Kinder <david.b.kinder@intel.com>