### PR TITLE
drivers: ethernet: native: fix compile error when glibc >= 2.20

### DIFF
--- a/drivers/ethernet/CMakeLists.txt
+++ b/drivers/ethernet/CMakeLists.txt
@@ -14,6 +14,7 @@ if(CONFIG_ETH_NATIVE_POSIX)
 	zephyr_library_include_directories(${ZEPHYR_BASE}/subsys/net/l2)
 	zephyr_library_compile_definitions(NO_POSIX_CHEATS)
 	zephyr_library_compile_definitions(_BSD_SOURCE)
+	zephyr_library_compile_definitions(_DEFAULT_SOURCE)
 	zephyr_library_sources(
 		eth_native_posix.c
 		eth_native_posix_adapt.c

--- a/drivers/ethernet/eth_native_posix_adapt.c
+++ b/drivers/ethernet/eth_native_posix_adapt.c
@@ -11,8 +11,6 @@
  * because there is naming conflicts between host and zephyr network stacks.
  */
 
-#define _DEFAULT_SOURCE
-
 /* Host include files */
 #include <stdio.h>
 #include <stdlib.h>


### PR DESCRIPTION
Starting with glibc 2.20, there is warning when _BSD_SOURCE is defined
but not _DEFAULT_SOURCE (in /usr/include/features.h around line 184).
Sanitycheck turns this warning into error. So define _DEFAULT_SOURCE
at build time for native.

Signed-off-by: Daniel Leung <daniel.leung@intel.com>