### PR TITLE
add issue and pr templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,36 @@
+---
+name: Bug report
+about: Create a report to help us improve Zephyr
+
+---
+
+**Describe the bug**
+A clear and concise description of what the bug is.
+What have you tried to diagnose or workaround this issue?
+
+**To Reproduce**
+Steps to reproduce the behavior:
+1. mkdir build; cd build
+2. cmake -DBOARD=board\_xyz
+3. make
+4. See error
+
+**Expected behavior**
+A clear and concise description of what you expected to happen.
+
+**Impact**
+What impact does this issue have on your progress (e.g., annoyance, showstopper)
+
+**Screenshots or console output**
+If applicable, add a screenshot (drag-and-drop an image), or console logs
+(cut-and-paste text and put a code fence (\`\`\`) before and after, to help
+explain the issue.
+
+**Environment (please complete the following information):**
+ - OS: (e.g. Linux, MacOS, Windows)
+ - Toolchain (e.g Zephyr SDK, ...)
+ - Commit SHA or Version used
+
+
+**Additional context**
+Add any other context about the problem here.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,17 @@
+---
+name: Feature request
+about: Suggest an idea for this project
+
+---
+
+**Is your feature request related to a problem? Please describe.**
+A clear and concise description of what the problem is.
+
+**Describe the solution you'd like**
+A clear and concise description of what you want to happen.
+
+**Describe alternatives you've considered**
+A clear and concise description of any alternative solutions or features you've considered.
+
+**Additional context**
+Add any other context or graphics (drag-and-drop an image) about the feature request here.


### PR DESCRIPTION
Add issue and PR templates per community guidelines of Github

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `sanitycheck` passes
- [ ] relevant documentation is changed or added


<!-- Used to describe release notes for future release versions. -->

Notes: Added issue and pull request templates.