### PR TITLE
Bluetooth: Allow to configure LE Create Connection timeout

### DIFF
--- a/subsys/bluetooth/host/Kconfig
+++ b/subsys/bluetooth/host/Kconfig
@@ -387,6 +387,10 @@ config BT_PERIPHERAL_PREF_TIMEOUT
 	  where Conn_Interval_Max is given in milliseconds.
 endif # BT_GAP_PERIPHERAL_PREF_PARAMS
 
+config BT_CREATE_CONN_TIMEOUT
+        int "Timeout for pending LE Create Connection command in seconds"
+        default 3
+        range 1 65535
 endif # BT_CONN
 
 if BT_OBSERVER

--- a/subsys/bluetooth/host/conn.c
+++ b/subsys/bluetooth/host/conn.c
@@ -57,7 +57,7 @@ NET_BUF_POOL_FIXED_DEFINE(frag_pool, CONFIG_BT_L2CAP_TX_FRAG_COUNT, FRAG_SIZE,
 #endif /* CONFIG_BT_L2CAP_TX_FRAG_COUNT > 0 */
 
 /* How long until we cancel HCI_LE_Create_Connection */
-#define CONN_TIMEOUT	K_SECONDS(3)
+#define CONN_TIMEOUT	K_SECONDS(CONFIG_BT_CREATE_CONN_TIMEOUT)
 
 #if defined(CONFIG_BT_SMP) || defined(CONFIG_BT_BREDR)
 const struct bt_conn_auth_cb *bt_auth;


### PR DESCRIPTION
Depending on perhiperal advertising interval 3 seconds might not be
enough and would result in cancelling pending connection. Make this
Kconfig configurable and let application to decide.

Signed-off-by: Szymon Janc <szymon.janc@codecoup.pl>