### PR TITLE
Bluetooth: Fix incorrectly reporting connection as failure

### DIFF
--- a/subsys/bluetooth/host/hci_core.c
+++ b/subsys/bluetooth/host/hci_core.c
@@ -876,6 +876,7 @@ static void le_enh_conn_complete(struct bt_hci_evt_le_enh_conn_complete *evt)
 	conn->le.latency = sys_le16_to_cpu(evt->latency);
 	conn->le.timeout = sys_le16_to_cpu(evt->supv_timeout);
 	conn->role = evt->role;
+	conn->err = 0;
 
 	/*
 	 * Use connection address (instead of identity address) as initiator
@@ -1613,6 +1614,7 @@ static void conn_complete(struct net_buf *buf)
 	}
 
 	conn->handle = handle;
+	conn->err = 0;
 	conn->encrypt = evt->encr_enabled;
 	update_sec_level_br(conn);
 	bt_conn_set_state(conn, BT_CONN_CONNECTED);


### PR DESCRIPTION
Auto connect code reuses bt_conn object and connection code was assuming
object was cleared which resulted in invalid code being provided to
application. Fix that by explicitly setting error code to 0 on
successful connection.

Signed-off-by: Szymon Janc <szymon.janc@codecoup.pl>