### PR TITLE
arch: arm: fix K_MEM_PARTITION_IS_WRITABLE definition

### DIFF
--- a/include/arch/arm/cortex_m/mpu/arm_mpu.h
+++ b/include/arch/arm/cortex_m/mpu/arm_mpu.h
@@ -21,40 +21,6 @@
 #error "Unsupported ARM CPU"
 #endif
 
-#ifdef CONFIG_USERSPACE
-#ifndef _ASMLANGUAGE
-/* Read-Write access permission attributes */
-#define K_MEM_PARTITION_P_NA_U_NA	(NO_ACCESS_Msk | NOT_EXEC)
-#define K_MEM_PARTITION_P_RW_U_RW	(P_RW_U_RW_Msk | NOT_EXEC)
-#define K_MEM_PARTITION_P_RW_U_RO	(P_RW_U_RO_Msk | NOT_EXEC)
-#define K_MEM_PARTITION_P_RW_U_NA	(P_RW_U_NA_Msk | NOT_EXEC)
-#define K_MEM_PARTITION_P_RO_U_RO	(P_RO_U_RO_Msk | NOT_EXEC)
-#define K_MEM_PARTITION_P_RO_U_NA	(P_RO_U_NA_Msk | NOT_EXEC)
-
-/* Execution-allowed attributes */
-#define K_MEM_PARTITION_P_RWX_U_RWX	(P_RW_U_RW_Msk)
-#define K_MEM_PARTITION_P_RWX_U_RX	(P_RW_U_RO_Msk)
-#define K_MEM_PARTITION_P_RX_U_RX	(P_RO_U_RO_Msk)
-
-#define K_MEM_PARTITION_IS_WRITABLE(attr) \
-	({ \
-		int __is_writable__; \
-		switch (attr) { \
-		case P_RW_U_RW: \
-		case P_RW_U_RO: \
-		case P_RW_U_NA: \
-			__is_writable__ = 1; \
-			break; \
-		default: \
-			__is_writable__ = 0; \
-		} \
-		__is_writable__; \
-	})
-#define K_MEM_PARTITION_IS_EXECUTABLE(attr) \
-	(!((attr) & (NOT_EXEC)))
-#endif /* _ASMLANGUAGE */
-#endif /* USERSPACE */
-
 /* Region definition data structure */
 struct arm_mpu_region {
 	/* Region Base Address */

--- a/include/arch/arm/cortex_m/mpu/arm_mpu_v7m.h
+++ b/include/arch/arm/cortex_m/mpu/arm_mpu_v7m.h
@@ -128,3 +128,38 @@ struct arm_mpu_region_attr {
 };
 
 typedef struct arm_mpu_region_attr arm_mpu_region_attr_t;
+
+#ifdef CONFIG_USERSPACE
+#ifndef _ASMLANGUAGE
+/* Read-Write access permission attributes */
+#define K_MEM_PARTITION_P_NA_U_NA	(NO_ACCESS_Msk | NOT_EXEC)
+#define K_MEM_PARTITION_P_RW_U_RW	(P_RW_U_RW_Msk | NOT_EXEC)
+#define K_MEM_PARTITION_P_RW_U_RO	(P_RW_U_RO_Msk | NOT_EXEC)
+#define K_MEM_PARTITION_P_RW_U_NA	(P_RW_U_NA_Msk | NOT_EXEC)
+#define K_MEM_PARTITION_P_RO_U_RO	(P_RO_U_RO_Msk | NOT_EXEC)
+#define K_MEM_PARTITION_P_RO_U_NA	(P_RO_U_NA_Msk | NOT_EXEC)
+
+/* Execution-allowed attributes */
+#define K_MEM_PARTITION_P_RWX_U_RWX	(P_RW_U_RW_Msk)
+#define K_MEM_PARTITION_P_RWX_U_RX	(P_RW_U_RO_Msk)
+#define K_MEM_PARTITION_P_RX_U_RX	(P_RO_U_RO_Msk)
+
+#define K_MEM_PARTITION_IS_WRITABLE(attr) \
+	({ \
+		int __is_writable__; \
+		switch (attr) { \
+		case P_RW_U_RW: \
+		case P_RW_U_RO: \
+		case P_RW_U_NA: \
+			__is_writable__ = 1; \
+			break; \
+		default: \
+			__is_writable__ = 0; \
+		} \
+		__is_writable__; \
+	})
+
+#define K_MEM_PARTITION_IS_EXECUTABLE(attr) \
+	(!((attr) & (NOT_EXEC)))
+#endif /* _ASMLANGUAGE */
+#endif /* USERSPACE */

--- a/include/arch/arm/cortex_m/mpu/arm_mpu_v8m.h
+++ b/include/arch/arm/cortex_m/mpu/arm_mpu_v8m.h
@@ -138,3 +138,34 @@ struct arm_mpu_region_attr {
 };
 
  typedef struct arm_mpu_region_attr arm_mpu_region_attr_t;
+
+#ifdef CONFIG_USERSPACE
+#ifndef _ASMLANGUAGE
+/* Read-Write access permission attributes */
+#define K_MEM_PARTITION_P_RW_U_RW	(P_RW_U_RW_Msk | NOT_EXEC)
+#define K_MEM_PARTITION_P_RW_U_NA	(P_RW_U_NA_Msk | NOT_EXEC)
+#define K_MEM_PARTITION_P_RO_U_RO	(P_RO_U_RO_Msk | NOT_EXEC)
+#define K_MEM_PARTITION_P_RO_U_NA	(P_RO_U_NA_Msk | NOT_EXEC)
+
+/* Execution-allowed attributes */
+#define K_MEM_PARTITION_P_RWX_U_RWX	(P_RW_U_RW_Msk)
+#define K_MEM_PARTITION_P_RX_U_RX	(P_RO_U_RO_Msk)
+
+#define K_MEM_PARTITION_IS_WRITABLE(attr) \
+	({ \
+		int __is_writable__; \
+		switch (attr) { \
+		case P_RW_U_RW: \
+		case P_RW_U_NA: \
+			__is_writable__ = 1; \
+			break; \
+		default: \
+			__is_writable__ = 0; \
+		} \
+		__is_writable__; \
+	})
+
+#define K_MEM_PARTITION_IS_EXECUTABLE(attr) \
+	(!((attr) & (NOT_EXEC)))
+#endif /* _ASMLANGUAGE */
+#endif /* USERSPACE */

--- a/samples/mpu/mem_domain_apis_test/src/main.c
+++ b/samples/mpu/mem_domain_apis_test/src/main.c
@@ -36,7 +36,10 @@ u8_t __aligned(4096) app1_buf[4096];
 
 K_MEM_PARTITION_DEFINE(app0_parts0, app0_buf, sizeof(app0_buf),
 		       K_MEM_PARTITION_P_RW_U_RW);
-#ifdef CONFIG_X86
+#if defined(CONFIG_X86) || \
+	((defined(CONFIG_ARMV8_M_BASELINE) || \
+		defined(CONFIG_ARMV8_M_MAINLINE)) \
+		&& defined(CONFIG_CPU_HAS_ARM_MPU))
 K_MEM_PARTITION_DEFINE(app0_parts1, app1_buf, sizeof(app1_buf),
 		       K_MEM_PARTITION_P_RO_U_RO);
 #else
@@ -51,7 +54,10 @@ struct k_mem_partition *app0_parts[] = {
 
 K_MEM_PARTITION_DEFINE(app1_parts0, app1_buf, sizeof(app1_buf),
 		       K_MEM_PARTITION_P_RW_U_RW);
-#ifdef CONFIG_X86
+#if defined(CONFIG_X86) || \
+	((defined(CONFIG_ARMV8_M_BASELINE) || \
+		defined(CONFIG_ARMV8_M_MAINLINE)) \
+		&& defined(CONFIG_CPU_HAS_ARM_MPU))
 K_MEM_PARTITION_DEFINE(app1_parts1, app0_buf, sizeof(app0_buf),
 		       K_MEM_PARTITION_P_RO_U_RO);
 #else

--- a/tests/kernel/mem_protect/mem_protect/src/mem_domain.c
+++ b/tests/kernel/mem_protect/mem_protect/src/mem_domain.c
@@ -35,7 +35,10 @@ K_MEM_PARTITION_DEFINE(mem_domain_memory_partition,
 		       sizeof(mem_domain_buf),
 		       K_MEM_PARTITION_P_RW_U_RW);
 
-#ifdef CONFIG_X86
+#if defined(CONFIG_X86) || \
+	((defined(CONFIG_ARMV8_M_BASELINE) || \
+		defined(CONFIG_ARMV8_M_MAINLINE)) \
+		&& defined(CONFIG_CPU_HAS_ARM_MPU))
 K_MEM_PARTITION_DEFINE(mem_domain_memory_partition1,
 		       mem_domain_buf1,
 		       sizeof(mem_domain_buf1),


### PR DESCRIPTION
In ARMv8-M MPU it is not possible to have the following access
permissions: Privileged RW / Unprivileged RO. So we define
K_MEM_PARTITION_IS_WRITABLE macro separately for v8M and v7M MPU
architectures (in the separate include files).

The commit does not change the behavior for ARMv6-M and ARMv7-M. It only corrects the implementation for ARMv8-M.

Signed-off-by: Ioannis Glaropoulos <Ioannis.Glaropoulos@nordicsemi.no>