### PR TITLE
kconfig: Don't set the deprecated env var KCONFIG_AUTOHEADER

### DIFF
--- a/cmake/kconfig.cmake
+++ b/cmake/kconfig.cmake
@@ -23,7 +23,6 @@ endif()
 set(ENV{srctree}            ${ZEPHYR_BASE})
 set(ENV{KERNELVERSION}      ${PROJECT_VERSION})
 set(ENV{KCONFIG_CONFIG}     ${DOTCONFIG})
-set(ENV{KCONFIG_AUTOHEADER} ${AUTOCONF_H})
 
 # Set environment variables so that Kconfig can prune Kconfig source
 # files for other architectures

--- a/cmake/kconfig.cmake
+++ b/cmake/kconfig.cmake
@@ -146,8 +146,8 @@ execute_process(
   ${PYTHON_EXECUTABLE}
   ${ZEPHYR_BASE}/scripts/kconfig/kconfig.py
   ${KCONFIG_ROOT}
-  ${PROJECT_BINARY_DIR}/.config
-  ${PROJECT_BINARY_DIR}/include/generated/autoconf.h
+  ${DOTCONFIG}
+  ${AUTOCONF_H}
   ${merge_fragments}
   WORKING_DIRECTORY ${APPLICATION_SOURCE_DIR}
   # The working directory is set to the app dir such that the user


### PR DESCRIPTION
KCONFIG_AUTOHEADER is an environment variable that was used by the C
Kconfig tools to determine where the autconf.h file is. After the
migration to python this environment variable became unused.

This patch removes the deprecated env var.

Also, some minor refactoring has been done.