### PR TITLE
stm32: Update openocd.cfg to support JLink debug adapter

### DIFF
--- a/boards/arm/nucleo_f070rb/board.cmake
+++ b/boards/arm/nucleo_f070rb/board.cmake
@@ -1,8 +1,2 @@
-set_ifndef(STLINK_FW stlink)
-
-if(STLINK_FW STREQUAL jlink)
-  board_runner_args(jlink "--device=stm32f070rb" "--speed=4000")
-  include(${ZEPHYR_BASE}/boards/common/jlink.board.cmake)
-elseif(STLINK_FW STREQUAL stlink)
-  include($ENV{ZEPHYR_BASE}/boards/common/openocd.board.cmake)
-endif()
+board_runner_args(openocd)
+include(${ZEPHYR_BASE}/boards/common/openocd.board.cmake)

--- a/boards/arm/nucleo_f070rb/support/openocd.cfg
+++ b/boards/arm/nucleo_f070rb/support/openocd.cfg
@@ -1,4 +1,19 @@
-source [find board/st_nucleo_f0.cfg]
+if {[info exists env(OPENOCD_INTERFACE)]} {
+	set INTERFACE $env(OPENOCD_INTERFACE)
+	set TRANSPORT_SWD "swd"
+} else {
+	# By default connect over ST-LINK/V2-1 in-circuit debugger
+	set INTERFACE "stlink-v2-1"
+	set TRANSPORT_SWD "hla_swd"
+}
+
+source [find interface/$INTERFACE.cfg]
+
+transport select $TRANSPORT_SWD
+
+source [find target/stm32f0x.cfg]
+
+reset_config srst_only
 
 $_TARGETNAME configure -event gdb-attach {
 	echo "Debugger attaching: halting execution"

--- a/boards/arm/nucleo_f207zg/board.cmake
+++ b/boards/arm/nucleo_f207zg/board.cmake
@@ -1,1 +1,2 @@
+board_runner_args(openocd)
 include(${ZEPHYR_BASE}/boards/common/openocd.board.cmake)

--- a/boards/arm/nucleo_f207zg/support/openocd.cfg
+++ b/boards/arm/nucleo_f207zg/support/openocd.cfg
@@ -1,13 +1,27 @@
-source [find interface/stlink-v2-1.cfg]
+if {[info exists env(OPENOCD_INTERFACE)]} {
+	set INTERFACE $env(OPENOCD_INTERFACE)
+	set TRANSPORT_SWD "swd"
+} else {
+	# By default connect over ST-LINK/V2-1 in-circuit debugger
+	set INTERFACE "stlink-v2-1"
+	set TRANSPORT_SWD "hla_swd"
+}
+
+source [find interface/$INTERFACE.cfg]
+
+transport select $TRANSPORT_SWD
+
 source [find target/stm32f2x.cfg]
 
+reset_config srst_only
+
 $_TARGETNAME configure -event gdb-attach {
-        echo "Debugger attaching: halting execution"
-        reset halt
-        gdb_breakpoint_override hard
+	echo "Debugger attaching: halting execution"
+	reset halt
+	gdb_breakpoint_override hard
 }
 
 $_TARGETNAME configure -event gdb-detach {
-        echo "Debugger detaching: resuming execution"
-        resume
+	echo "Debugger detaching: resuming execution"
+	resume
 }

--- a/doc/tools/stlink-v21.rst
+++ b/doc/tools/stlink-v21.rst
@@ -59,15 +59,17 @@ Host Tools and Firmware
 Download and install the `Segger J-Link Software and Documentation Pack`_ to
 get the J-Link GDB server for your host computer.
 
+To make OpenOCD use the J-Link tools, open a new terminal and use::
+
+    export OPENOCD_INTERFACE=jlink
+
+before flashing and debugging.
+
 Flashing
 ========
 
-Use the CMake ``flash`` target with the argument ``STLINK_FW=jlink`` to
-build your Zephyr application.
-
   .. zephyr-app-commands::
      :zephyr-app: samples/hello_world
-     :gen-args: -DSTLINK_FW=jlink
      :goals: flash
 
 Debugging
@@ -79,7 +81,6 @@ program your Zephyr application to flash. It will leave you at a GDB prompt.
 
   .. zephyr-app-commands::
      :zephyr-app: samples/hello_world
-     :gen-args: -DSTLINK_FW=jlink
      :goals: debug
 
 Console


### PR DESCRIPTION
Commit af05ff6c introduct a way flashing and debuging using JLink tool,
that's using one more param '-DSTLINK_FW' when using CMake generates
the build system.

And the previous way can't change the debug tool unless you clean all
CMake files and regenerated. This patch using a environment variable
to select which debug tool we used, so you can select another tool
at anytimes, just change the envrionment variable.

Signed-off-by: qianfan Zhao <qianfanguijin@163.com>