### PR TITLE
boards: 96b_argonkey: Kconfig.board: Fix ArgonKey board building

### DIFF
--- a/boards/arm/96b_argonkey/Kconfig.board
+++ b/boards/arm/96b_argonkey/Kconfig.board
@@ -7,4 +7,4 @@
 config BOARD_96B_ARGONKEY
 	bool "96Boards Argonkey"
 	depends on SOC_STM32F412CG
-	select HAS_DTS_SPI_PINS
+	select HAS_DTS_GPIO_DEVICE


### PR DESCRIPTION
Argonkey board building has been recently broken by a LSM6DSL sensor
driver fix (see commit: a013ce3bf07ace679eb5a4d2e62c3be2d7891d05).

The board configuration file must now enable HAS_DTS_GPIO_DEVICE macro
instead of HAS_DTS_SPI_DEVICE.

Signed-off-by: Armando Visconti <armando.visconti@st.com>