### PR TITLE
Bluetooth: controller: Increase advertising random delay resolution

### DIFF
--- a/subsys/bluetooth/controller/ll_sw/ctrl.c
+++ b/subsys/bluetooth/controller/ll_sw/ctrl.c
@@ -3905,12 +3905,12 @@ static inline u32_t isr_close_adv(void)
 		if ((_radio.state == STATE_CLOSE) &&
 		    (!_radio.advertiser.is_hdcd)) {
 			u32_t ticker_status;
-			u8_t random_delay;
+			u16_t random_delay;
 
 			entropy_nrf_get_entropy_isr(_radio.entropy,
-						    &random_delay,
+						    (void *)&random_delay,
 						    sizeof(random_delay));
-			random_delay %= 10;
+			random_delay %= 10000;
 			random_delay += 1;
 
 			/* Call to ticker_update can fail under the race
@@ -3923,8 +3923,7 @@ static inline u32_t isr_close_adv(void)
 				ticker_update(RADIO_TICKER_INSTANCE_ID_RADIO,
 					RADIO_TICKER_USER_ID_WORKER,
 					RADIO_TICKER_ID_ADV,
-					HAL_TICKER_US_TO_TICKS(random_delay *
-							       1000),
+					HAL_TICKER_US_TO_TICKS(random_delay),
 					0, 0, 0, 0, 0, ticker_update_adv_assert,
 					(void *)__LINE__);
 			LL_ASSERT((ticker_status == TICKER_STATUS_SUCCESS) ||


### PR DESCRIPTION
Increase the resolution of advertising random delay from
1 ms unit to 1 us units. The controller scheduling will
floor it to nearest 32KHz clock unit on nRF5 series.

Signed-off-by: Vinayak Kariappa Chettimada <vich@nordicsemi.no>