### PR TITLE
ext: hal: nordic: Update nrfx to version 1.3.1

### DIFF
--- a/ext/hal/nordic/nrfx/README
+++ b/ext/hal/nordic/nrfx/README
@@ -2,10 +2,10 @@ nrfx
 ####
 
 Origin:
-   https://github.com/NordicSemiconductor/nrfx/tree/v1.3.0
+   https://github.com/NordicSemiconductor/nrfx/tree/v1.3.1
 
 Status:
-   v1.3.0
+   v1.3.1
 
 Purpose:
    With added proper shims adapting it to Zephyr's APIs, nrfx will provide
@@ -28,7 +28,7 @@ URL:
    https://github.com/NordicSemiconductor/nrfx
 
 commit:
-   67710e47c7313cc56a15748e485079831ee6a3af
+   d4ebe15f58de1442e3eed93b40d13930e7785903
 
 Maintained-by:
    External
@@ -37,4 +37,4 @@ License:
    BSD-3-Clause
 
 License Link:
-   https://github.com/NordicSemiconductor/nrfx/blob/v1.3.0/LICENSE
+   https://github.com/NordicSemiconductor/nrfx/blob/v1.3.1/LICENSE

--- a/ext/hal/nordic/nrfx/drivers/include/nrfx_nfct.h
+++ b/ext/hal/nordic/nrfx/drivers/include/nrfx_nfct.h
@@ -318,7 +318,7 @@ void nrfx_nfct_autocolres_enable(void);
 void nrfx_nfct_autocolres_disable(void);
 
 
-void nrfx_nfct_irq_handler();
+void nrfx_nfct_irq_handler(void);
 
 
 /** @} */

--- a/ext/hal/nordic/nrfx/drivers/include/nrfx_usbd.h
+++ b/ext/hal/nordic/nrfx/drivers/include/nrfx_usbd.h
@@ -149,25 +149,27 @@ typedef enum
 } nrfx_usbd_event_type_t;
 
 /**
- * @brief Possible endpoint error codes.
+ * @brief Endpoint status codes.
  *
- * Error codes that may be returned with @ref NRFX_USBD_EVT_EPTRANSFER.
+ * Status codes that may be returned by @ref nrfx_usbd_ep_status_get or, except for
+ * @ref NRFX_USBD_EP_BUSY, reported together with @ref NRFX_USBD_EVT_EPTRANSFER.
  */
 typedef enum
 {
-    NRFX_USBD_EP_OK,       /**< No error */
+    NRFX_USBD_EP_OK,       /**< No error occured. */
     NRFX_USBD_EP_WAITING,  /**< Data received, no buffer prepared already - waiting for configured transfer. */
     NRFX_USBD_EP_OVERLOAD, /**< Received number of bytes cannot fit given buffer.
-                           *   This error would also be returned when next_transfer function has been defined
-                           *   but currently received data cannot fit completely in current buffer.
-                           *   No data split from single endpoint transmission is supported.
-                           *
-                           *   When this error is reported - data is left inside endpoint buffer.
-                           *   Clear endpoint or prepare new buffer and read it.
-                           */
+                            *   This error would also be returned when next_transfer function has been defined
+                            *   but currently received data cannot fit completely in current buffer.
+                            *   No data split from single endpoint transmission is supported.
+                            *
+                            *   When this error is reported - data is left inside endpoint buffer.
+                            *   Clear endpoint or prepare new buffer and read it.
+                            */
     NRFX_USBD_EP_ABORTED,  /**< EP0 transfer can be aborted when new setup comes.
-                           *   Any other transfer can be aborted by USB reset or driver stopping.
-                           */
+                            *   Any other transfer can be aborted by USB reset or driver stopping.
+                            */
+    NRFX_USBD_EP_BUSY,     /**< A transfer is in progress. */
 } nrfx_usbd_ep_status_t;
 
 /**
@@ -702,12 +704,11 @@ void * nrfx_usbd_feeder_buffer_get(void);
  * @param[in]  ep     Endpoint number.
  * @param[out] p_size Information about the current/last transfer size.
  *
- * @retval NRFX_SUCCESS         Transfer already finished.
- * @retval NRFX_ERROR_BUSY      Ongoing transfer.
- * @retval NRFX_ERROR_DATA_SIZE Too much of data received that cannot fit into buffer and cannot be splited into chunks.
- *                             This may happen if buffer size is not a multiplication of endpoint buffer size.
+ * @return Endpoint status.
+ *
+ * @sa nrfx_usbd_ep_status_t
  */
-nrfx_err_t nrfx_usbd_ep_status_get(nrfx_usbd_ep_t ep, size_t * p_size);
+nrfx_usbd_ep_status_t nrfx_usbd_ep_status_get(nrfx_usbd_ep_t ep, size_t * p_size);
 
 /**
  * @brief Get number of received bytes.

--- a/ext/hal/nordic/nrfx/drivers/src/nrfx_nfct.c
+++ b/ext/hal/nordic/nrfx/drivers/src/nrfx_nfct.c
@@ -380,7 +380,7 @@ static void nrfx_nfct_field_poll(void)
 
 static void nrfx_nfct_field_timer_handler(nrf_timer_event_t event_type, void * p_context)
 {
-    UNUSED_PARAMETER(p_context);
+    (void)p_context;
 
     if (event_type != NRF_TIMER_EVENT_COMPARE0)
     {
@@ -463,7 +463,7 @@ nrfx_err_t nrfx_nfct_init(nrfx_nfct_config_t const * p_config)
     m_nrf52840.eng_bc = nrfx_nfct_type_52840_final_check();
 #endif // NRF52840_XXAA
 
-    memcpy(&m_nfct_cb.config, p_config, sizeof(nrfx_nfct_config_t));
+    m_nfct_cb.config = *p_config;
     nrfx_nfct_hw_init_setup();
 
 #ifdef USE_TIMER_WORKAROUND
@@ -572,7 +572,7 @@ nrfx_err_t nrfx_nfct_tx(nrfx_nfct_data_desc_t const * p_tx_data,
     nrfx_nfct_rxtx_int_enable(NRFX_NFCT_TX_INT_MASK);
     nrf_nfct_task_trigger(NRF_NFCT_TASK_STARTTX);
 
-    NRF_LOG_INFO("Tx start");
+    NRFX_LOG_INFO("Tx start");
     return NRFX_SUCCESS;
 }
 

--- a/ext/hal/nordic/nrfx/drivers/src/nrfx_usbd.c
+++ b/ext/hal/nordic/nrfx/drivers/src/nrfx_usbd.c
@@ -1579,7 +1579,8 @@ void nrfx_usbd_irq_handler(void)
                 *((volatile uint32_t *)(NRF_USBD_BASE + 0x800)) = 0x7A9;
                 *((volatile uint32_t *)(NRF_USBD_BASE + 0x804)) = uii;
                 rb = (uint8_t)*((volatile uint32_t *)(NRF_USBD_BASE + 0x804));
-            NRFX_USBD_LOG_PROTO1_FIX_PRINTF("   uii: 0x%.2x (0x%.2x)", uii, rb);
+                NRFX_USBD_LOG_PROTO1_FIX_PRINTF("   uii: 0x%.2x (0x%.2x)", uii, rb);
+                (void)rb;
             }
 
             *((volatile uint32_t *)(NRF_USBD_BASE + 0x800)) = 0x7AD;
@@ -1591,7 +1592,8 @@ void nrfx_usbd_irq_handler(void)
                 *((volatile uint32_t *)(NRF_USBD_BASE + 0x800)) = 0x7AA;
                 *((volatile uint32_t *)(NRF_USBD_BASE + 0x804)) = uoi;
                 rb = (uint8_t)*((volatile uint32_t *)(NRF_USBD_BASE + 0x804));
-            NRFX_USBD_LOG_PROTO1_FIX_PRINTF("   uoi: 0x%.2u (0x%.2x)", uoi, rb);
+                NRFX_USBD_LOG_PROTO1_FIX_PRINTF("   uoi: 0x%.2u (0x%.2x)", uoi, rb);
+                (void)rb;
             }
 
             *((volatile uint32_t *)(NRF_USBD_BASE + 0x800)) = 0x7AE;
@@ -1610,7 +1612,8 @@ void nrfx_usbd_irq_handler(void)
                 *((volatile uint32_t *)(NRF_USBD_BASE + 0x800)) = 0x7AB;
                 *((volatile uint32_t *)(NRF_USBD_BASE + 0x804)) = usbi;
                 rb = (uint8_t)*((volatile uint32_t *)(NRF_USBD_BASE + 0x804));
-            NRFX_USBD_LOG_PROTO1_FIX_PRINTF("   usbi: 0x%.2u (0x%.2x)", usbi, rb);
+                NRFX_USBD_LOG_PROTO1_FIX_PRINTF("   usbi: 0x%.2u (0x%.2x)", usbi, rb);
+                (void)rb;
             }
 
             if (0 != (m_simulated_dataepstatus &
@@ -1797,7 +1800,7 @@ void nrfx_usbd_enable(void)
 
     if (nrfx_usbd_errata_187())
     {
-        CRITICAL_REGION_ENTER();
+        NRFX_CRITICAL_SECTION_ENTER();
         if (*((volatile uint32_t *)(0x4006EC00)) == 0x00000000)
         {
             *((volatile uint32_t *)(0x4006EC00)) = 0x00009375;
@@ -1808,7 +1811,7 @@ void nrfx_usbd_enable(void)
         {
             *((volatile uint32_t *)(0x4006ED14)) = 0x00000000;
         }
-        CRITICAL_REGION_EXIT();
+        NRFX_CRITICAL_SECTION_EXIT();
     }
 }
 
@@ -2228,14 +2231,14 @@ void * nrfx_usbd_feeder_buffer_get(void)
     return m_tx_buffer;
 }
 
-nrfx_err_t nrfx_usbd_ep_status_get(nrfx_usbd_ep_t ep, size_t * p_size)
+nrfx_usbd_ep_status_t nrfx_usbd_ep_status_get(nrfx_usbd_ep_t ep, size_t * p_size)
 {
-    nrfx_err_t ret;
+    nrfx_usbd_ep_status_t ret;
 
     usbd_ep_state_t const * p_state = ep_state_access(ep);
     NRFX_CRITICAL_SECTION_ENTER();
     *p_size = p_state->transfer_cnt;
-    ret = (p_state->handler.consumer == NULL) ? p_state->status : NRFX_ERROR_BUSY;
+    ret = (p_state->handler.consumer == NULL) ? p_state->status : NRFX_USBD_EP_BUSY;
     NRFX_CRITICAL_SECTION_EXIT();
     return ret;
 }


### PR DESCRIPTION
Updates nrfx to the recently released version that corrects a few
imperfections in NFCT and USBD drivers.

Origin: nrfx
License: BSD 3-Clause
URL: https://github.com/NordicSemiconductor/nrfx/tree/v1.3.1
commit: d4ebe15f58de1442e3eed93b40d13930e7785903
Purpose: Provide peripheral drivers for Nordic SoCs
Maintained-by: External

Signed-off-by: Andrzej Głąbek <andrzej.glabek@nordicsemi.no>