### PR TITLE
boards: arm: 96b_argonkey.yaml: Add i2c/spi/gpio to the supported list

### DIFF
--- a/boards/arm/96b_argonkey/96b_argonkey.yaml
+++ b/boards/arm/96b_argonkey/96b_argonkey.yaml
@@ -6,4 +6,7 @@ toolchain:
   - zephyr
   - gnuarmemb
 supported:
+  - gpio
+  - i2c
   - rtc
+  - spi


### PR DESCRIPTION
Add i2c/spi/gpio to the supported list to enable the CI to correctly
run the 96b_argonkey board sample.

Signed-off-by: Armando Visconti <armando.visconti@st.com>