### PR TITLE
doc: kconfig: Explain the '<type> <prompt>' shorthand

### DIFF
--- a/doc/porting/board_porting.rst
+++ b/doc/porting/board_porting.rst
@@ -178,11 +178,13 @@ Here are some examples of visible and invisible symbols:
     	default FOO
 
     config VISIBLE_1
-    	bool "Enable stuff"
-
-    config VISIBLE_2
     	string
     	prompt "Foo value"
+
+    config VISIBLE_2
+    	# Shorthand for giving a type and a prompt at the same time. This is
+    	# the preferred style in Zephyr.
+    	bool "Enable stuff"
 
 
 Configuring visible Kconfig symbols


### PR DESCRIPTION
The board porting guide assumed that people were already familiar with
the Kconfig `bool "foo"` shorthand for giving a symbol's type and prompt
at the same time. I got an email pointing out that it isn't obvious.

Explain the shorthand, and also mention that it's the preferred style in
Zephyr.