### PR TITLE
drivers: gpio: Select HAS_DTS_GPIO in various drivers

### DIFF
--- a/drivers/gpio/Kconfig.dw
+++ b/drivers/gpio/Kconfig.dw
@@ -9,6 +9,7 @@
 menuconfig GPIO_DW
 	bool "Designware GPIO"
 	depends on GPIO
+	select HAS_DTS_GPIO
 	help
 	  Enable driver for Designware GPIO
 

--- a/drivers/gpio/Kconfig.imx
+++ b/drivers/gpio/Kconfig.imx
@@ -8,6 +8,7 @@
 menuconfig GPIO_IMX
 	bool "IMX GPIO driver"
 	depends on GPIO && HAS_IMX_GPIO
+	select HAS_DTS_GPIO
 	help
 	  Enable the IMX GPIO driver.
 

--- a/drivers/gpio/Kconfig.mcux_igpio
+++ b/drivers/gpio/Kconfig.mcux_igpio
@@ -8,6 +8,7 @@
 menuconfig GPIO_MCUX_IGPIO
 	bool "MCUX IGPIO driver"
 	depends on GPIO && HAS_MCUX_IGPIO
+	select HAS_DTS_GPIO
 	help
 	  Enable the MCUX IGPIO driver.
 

--- a/drivers/gpio/Kconfig.qmsi
+++ b/drivers/gpio/Kconfig.qmsi
@@ -9,6 +9,7 @@
 menuconfig GPIO_QMSI
 	bool "QMSI GPIO driver"
 	depends on GPIO && QMSI
+	select HAS_DTS_GPIO
 	help
 	  Enable the GPIO driver found on Intel Microcontroller
 	  boards, using the QMSI library.
@@ -16,6 +17,7 @@ menuconfig GPIO_QMSI
 menuconfig GPIO_QMSI_SS
 	bool "QMSI GPIO SS driver"
 	depends on GPIO && QMSI && ARC
+	select HAS_DTS_GPIO
 	help
 	  Enable the GPIO driver found on Intel Microcontroller
 	  boards, on the sensor subsystem, using the QMSI library.

--- a/drivers/gpio/Kconfig.sam
+++ b/drivers/gpio/Kconfig.sam
@@ -6,5 +6,6 @@
 menuconfig GPIO_SAM
 	bool "Atmel SAM GPIO (PORT) driver"
 	depends on GPIO && SOC_FAMILY_SAM
+	select HAS_DTS_GPIO
 	help
 	  Enable support for the Atmel SAM 'PORT' GPIO controllers.

--- a/drivers/gpio/Kconfig.sam0
+++ b/drivers/gpio/Kconfig.sam0
@@ -6,5 +6,6 @@
 menuconfig GPIO_SAM0
 	bool "Atmel SAM0 GPIO (PORT) driver"
 	depends on GPIO && SOC_FAMILY_SAM0
+	select HAS_DTS_GPIO
 	help
 	  Enable support for the Atmel SAM0 'PORT' GPIO controllers.

--- a/drivers/gpio/Kconfig.sx1509b
+++ b/drivers/gpio/Kconfig.sx1509b
@@ -9,6 +9,7 @@
 menuconfig GPIO_SX1509B
 	bool "SX1509B I2C GPIO chip"
 	depends on GPIO && I2C
+	select HAS_DTS_GPIO
 	help
 	  Enable driver for SX1509B I2C GPIO chip.
 


### PR DESCRIPTION
Selects HAS_DTS_GPIO in various gpio drivers that already support dts,
similar to how we select HAS_DTS_SPI in spi drivers and HAS_DTS_I2C in
i2c drivers.

Signed-off-by: Maureen Helm <maureen.helm@nxp.com>