### PR TITLE
samples: blinky: Remove platform whitelist

### DIFF
--- a/samples/basic/blinky/sample.yaml
+++ b/samples/basic/blinky/sample.yaml
@@ -2,6 +2,5 @@ sample:
   name: Blinky Sample
 tests:
   test:
-    platform_whitelist: arduino_101
     tags: samples
     depends_on: gpio


### PR DESCRIPTION
Removes the platform whitelist so we test this sample on more than just
the arduino_101 board.

Signed-off-by: Maureen Helm <maureen.helm@nxp.com>