### PR TITLE
samples: buttons: Add GPIO_INT_EDGE to button configuration

### DIFF
--- a/samples/basic/button/src/main.c
+++ b/samples/basic/button/src/main.c
@@ -30,7 +30,7 @@
 
 /* change to use another GPIO pin interrupt config */
 #ifdef SW0_GPIO_FLAGS
-#define EDGE    SW0_GPIO_FLAGS
+#define EDGE    (SW0_GPIO_FLAGS | GPIO_INT_EDGE)
 #else
 /*
  * If SW0_GPIO_FLAGS not defined used default EDGE value.


### PR DESCRIPTION
Add GPIO_INT_EDGE triggering for the button push for boards where
the dts generates a SW0_GPIO_FLAGS.

Signed-off-by: David Leach <david.leach@nxp.com>