### PR TITLE
boards: Cleanup gpio flags in device tree (fixes button example)

### DIFF
--- a/boards/arm/96b_argonkey/96b_argonkey.dts
+++ b/boards/arm/96b_argonkey/96b_argonkey.dts
@@ -20,11 +20,11 @@
 	leds {
 		compatible = "gpio-leds";
 		green_led_0: led@0 {
-			gpios = <&gpioc 13 GPIO_INT_ACTIVE_HIGH>;
+			gpios = <&gpioc 13 0>;
 			label = "USR0 LED";
 		};
 		green_led_1: led@1 {
-			gpios = <&gpiob 2 GPIO_INT_ACTIVE_HIGH>;
+			gpios = <&gpiob 2 0>;
 			label = "USR1 LED";
 		};
 	};

--- a/boards/arm/96b_argonkey/96b_argonkey.dts
+++ b/boards/arm/96b_argonkey/96b_argonkey.dts
@@ -33,7 +33,8 @@
 		compatible = "gpio-keys";
 		user_button: button {
 			label = "User";
-			gpios = <&gpioa 2 GPIO_INT_ACTIVE_LOW>;
+			gpios = <&gpioa 2 (GPIO_INT_ACTIVE_LOW |
+					   GPIO_INT_EDGE)>;
 		};
 	};
 

--- a/boards/arm/96b_carbon/96b_carbon.dts
+++ b/boards/arm/96b_carbon/96b_carbon.dts
@@ -20,15 +20,15 @@
 	leds {
 		compatible = "gpio-leds";
 		green_led_1: led_1 {
-			gpios = <&gpiod 2 GPIO_INT_ACTIVE_HIGH>;
+			gpios = <&gpiod 2 0>;
 			label = "USR1 LED";
 		};
 		green_led_2: led_2 {
-			gpios = <&gpioa 15 GPIO_INT_ACTIVE_HIGH>;
+			gpios = <&gpioa 15 0>;
 			label = "USR2 LED";
 		};
 		bt_blue_led: led_3 {
-			gpios = <&gpioa 15 GPIO_INT_ACTIVE_HIGH>;
+			gpios = <&gpioa 15 0>;
 			label = "BT LED";
 		};
 	};

--- a/boards/arm/96b_carbon/96b_carbon.dts
+++ b/boards/arm/96b_carbon/96b_carbon.dts
@@ -37,7 +37,8 @@
 		compatible = "gpio-keys";
 		user_button: button {
 			label = "User";
-			gpios = <&gpiob 2 GPIO_INT_ACTIVE_LOW>;
+			gpios = <&gpiob 2 (GPIO_INT_ACTIVE_LOW |
+					   GPIO_INT_EDGE)>;
 		};
 	};
 

--- a/boards/arm/96b_neonkey/96b_neonkey.dts
+++ b/boards/arm/96b_neonkey/96b_neonkey.dts
@@ -20,19 +20,19 @@
 	leds {
 		compatible = "gpio-leds";
 		green_led_0: led_0 {
-			gpios = <&gpiob 12 GPIO_INT_ACTIVE_HIGH>;
+			gpios = <&gpiob 12 0>;
 			label = "USR0 LED";
 		};
 		green_led_1: led_1 {
-			gpios = <&gpiob 13 GPIO_INT_ACTIVE_HIGH>;
+			gpios = <&gpiob 13 0>;
 			label = "USR1 LED";
 		};
 		green_led_2: led_2 {
-			gpios = <&gpiob 14 GPIO_INT_ACTIVE_HIGH>;
+			gpios = <&gpiob 14 0>;
 			label = "USR2 LED";
 		};
 		green_led_3: led_3 {
-			gpios = <&gpiob 15 GPIO_INT_ACTIVE_HIGH>;
+			gpios = <&gpiob 15 0>;
 			label = "USR3 LED";
 		};
 	};

--- a/boards/arm/96b_neonkey/96b_neonkey.dts
+++ b/boards/arm/96b_neonkey/96b_neonkey.dts
@@ -41,7 +41,8 @@
 		compatible = "gpio-keys";
 		user_button: button@0 {
 			label = "User";
-			gpios = <&gpiob 2 GPIO_INT_ACTIVE_LOW>;
+			gpios = <&gpiob 2 (GPIO_INT_ACTIVE_LOW |
+					   GPIO_INT_EDGE)>;
 		};
 	};
 

--- a/boards/arm/colibri_imx7d_m4/colibri_imx7d_m4.dts
+++ b/boards/arm/colibri_imx7d_m4/colibri_imx7d_m4.dts
@@ -33,7 +33,7 @@
 	leds {
 		compatible = "gpio-leds";
 		green_led: led@0 {
-			gpios = <&gpio1 2 GPIO_INT_ACTIVE_LOW>;
+			gpios = <&gpio1 2 0>;
 			label = "User LED1";
 		};
 	};

--- a/boards/arm/colibri_imx7d_m4/colibri_imx7d_m4.dts
+++ b/boards/arm/colibri_imx7d_m4/colibri_imx7d_m4.dts
@@ -41,7 +41,8 @@
 	gpio_keys {
 		compatible = "gpio-keys";
 		user_switch_1: user_sw_1 {
-			gpios = <&gpio2 26 GPIO_INT_ACTIVE_LOW>;
+			gpios = <&gpio2 26 (GPIO_INT_ACTIVE_LOW |
+					    GPIO_INT_EDGE)>;
 			label = "User SW1";
 		};
 	};

--- a/boards/arm/disco_l475_iot1/disco_l475_iot1.dts
+++ b/boards/arm/disco_l475_iot1/disco_l475_iot1.dts
@@ -20,11 +20,11 @@
 	leds {
 		compatible = "gpio-leds";
 		green_led_1: led_1 {
-			gpios = <&gpioa 5 GPIO_INT_ACTIVE_HIGH>;
+			gpios = <&gpioa 5 0>;
 			label = "User LD1";
 		};
 		green_led_2: led_2 {
-			gpios = <&gpiob 14 GPIO_INT_ACTIVE_HIGH>;
+			gpios = <&gpiob 14 0>;
 			label = "User LD2";
 		};
 	};

--- a/boards/arm/disco_l475_iot1/disco_l475_iot1.dts
+++ b/boards/arm/disco_l475_iot1/disco_l475_iot1.dts
@@ -33,7 +33,8 @@
 		compatible = "gpio-keys";
 		user_button: button@0 {
 			label = "User";
-			gpios = <&gpioc 13 GPIO_INT_ACTIVE_LOW>;
+			gpios = <&gpioc 13 (GPIO_INT_ACTIVE_LOW |
+					    GPIO_INT_EDGE)>;
 		};
 	};
 

--- a/boards/arm/frdm_k64f/frdm_k64f.dts
+++ b/boards/arm/frdm_k64f/frdm_k64f.dts
@@ -65,11 +65,13 @@
 		compatible = "gpio-keys";
 		user_button_2: button@0 {
 			label = "User SW2";
-			gpios = <&gpioc 6 GPIO_INT_ACTIVE_LOW>;
+			gpios = <&gpioc 6 (GPIO_INT_ACTIVE_LOW |
+					   GPIO_INT_EDGE)>;
 		};
 		user_button_3: button@1 {
 			label = "User SW3";
-			gpios = <&gpioa 4 GPIO_INT_ACTIVE_LOW>;
+			gpios = <&gpioa 4 (GPIO_INT_ACTIVE_LOW |
+					   GPIO_INT_EDGE)>;
 		};
 	};
 };

--- a/boards/arm/frdm_kl25z/frdm_kl25z.dts
+++ b/boards/arm/frdm_kl25z/frdm_kl25z.dts
@@ -49,11 +49,13 @@
 		compatible = "gpio-keys";
 		user_button_0: button@0 {
 			label = "User SW0";
-			gpios = <&gpioa 16 GPIO_INT_ACTIVE_LOW>;
+			gpios = <&gpioa 16 (GPIO_INT_ACTIVE_LOW |
+					    GPIO_INT_EDGE)>;
 		};
 		user_button_1: button@1 {
 			label = "User SW1";
-			gpios = <&gpioa 17 GPIO_INT_ACTIVE_LOW>;
+			gpios = <&gpioa 17 (GPIO_INT_ACTIVE_LOW |
+					    GPIO_INT_EDGE)>;
 		};
 	};
 };

--- a/boards/arm/frdm_kw41z/frdm_kw41z.dts
+++ b/boards/arm/frdm_kw41z/frdm_kw41z.dts
@@ -51,11 +51,13 @@
 		compatible = "gpio-keys";
 		user_button_3: button@0 {
 			label = "User SW3";
-			gpios = <&gpioc 4 GPIO_INT_ACTIVE_LOW>;
+			gpios = <&gpioc 4 (GPIO_INT_ACTIVE_LOW |
+					   GPIO_INT_EDGE)>;
 		};
 		user_button_4: button@1 {
 			label = "User SW4";
-			gpios = <&gpioc 5 GPIO_INT_ACTIVE_LOW>;
+			gpios = <&gpioc 5 (GPIO_INT_ACTIVE_LOW |
+					   GPIO_INT_EDGE)>;
 		};
 	};
 };

--- a/boards/arm/mimxrt1050_evk/mimxrt1050_evk.dts
+++ b/boards/arm/mimxrt1050_evk/mimxrt1050_evk.dts
@@ -58,7 +58,8 @@
 		compatible = "gpio-keys";
 		user_button: button@0 {
 			label = "User SW8";
-			gpios = <&gpio5 0 GPIO_INT_ACTIVE_LOW>;
+			gpios = <&gpio5 0 (GPIO_INT_ACTIVE_LOW |
+					   GPIO_INT_EDGE)>;
 		};
 	};
 };

--- a/boards/arm/mimxrt1060_evk/mimxrt1060_evk.dts
+++ b/boards/arm/mimxrt1060_evk/mimxrt1060_evk.dts
@@ -44,7 +44,7 @@
 	leds {
 		compatible = "gpio-leds";
 		green_led: led-1 {
-			gpios = <&gpio1 9 GPIO_INT_ACTIVE_LOW>;
+			gpios = <&gpio1 9 0>;
 			label = "User LD1";
 		};
 	};

--- a/boards/arm/mimxrt1060_evk/mimxrt1060_evk.dts
+++ b/boards/arm/mimxrt1060_evk/mimxrt1060_evk.dts
@@ -53,7 +53,8 @@
 		compatible = "gpio-keys";
 		user_button: button-1 {
 			label = "User SW8";
-			gpios = <&gpio5 0 GPIO_INT_ACTIVE_LOW>;
+			gpios = <&gpio5 0 (GPIO_INT_ACTIVE_LOW |
+					   GPIO_INT_EDGE)>;
 		};
 	};
 };

--- a/boards/arm/nrf51_pca10028/nrf51_pca10028.dts
+++ b/boards/arm/nrf51_pca10028/nrf51_pca10028.dts
@@ -24,19 +24,19 @@
 	leds {
 		compatible = "gpio-leds";
 		led0: led@0 {
-			gpios = <&gpio0 21 GPIO_INT_ACTIVE_LOW>;
+			gpios = <&gpio0 21 0>;
 			label = "Green LED 0";
 		};
 		led1: led@1 {
-			gpios = <&gpio0 22 GPIO_INT_ACTIVE_LOW>;
+			gpios = <&gpio0 22 0>;
 			label = "Green LED 1";
 		};
 		led2: led@2 {
-			gpios = <&gpio0 23 GPIO_INT_ACTIVE_LOW>;
+			gpios = <&gpio0 23 0>;
 			label = "Green LED 2";
 		};
 		led3: led@3 {
-			gpios = <&gpio0 24 GPIO_INT_ACTIVE_LOW>;
+			gpios = <&gpio0 24 0>;
 			label = "Green LED 3";
 		};
 	};

--- a/boards/arm/nrf51_pca10028/nrf51_pca10028.dts
+++ b/boards/arm/nrf51_pca10028/nrf51_pca10028.dts
@@ -44,19 +44,27 @@
 	buttons {
 		compatible = "gpio-keys";
 		button0: button@0 {
-			gpios = <&gpio0 17 GPIO_PUD_PULL_UP>;
+			gpios = <&gpio0 17 (GPIO_PUD_PULL_UP |
+					    GPIO_INT_ACTIVE_LOW |
+					    GPIO_INT_EDGE)>;
 			label = "Push button switch 0";
 		};
 		button1: button@1 {
-			gpios = <&gpio0 18 GPIO_PUD_PULL_UP>;
+			gpios = <&gpio0 18 (GPIO_PUD_PULL_UP |
+					    GPIO_INT_ACTIVE_LOW |
+					    GPIO_INT_EDGE)>;
 			label = "Push button switch 1";
 		};
 		button2: button@2 {
-			gpios = <&gpio0 19 GPIO_PUD_PULL_UP>;
+			gpios = <&gpio0 19 (GPIO_PUD_PULL_UP |
+					    GPIO_INT_ACTIVE_LOW |
+					    GPIO_INT_EDGE)>;
 			label = "Push button switch 2";
 		};
 		button3: button@3 {
-			gpios = <&gpio0 20 GPIO_PUD_PULL_UP>;
+			gpios = <&gpio0 20 (GPIO_PUD_PULL_UP |
+					    GPIO_INT_ACTIVE_LOW |
+					    GPIO_INT_EDGE)>;
 			label = "Push button switch 3";
 		};
 	};

--- a/boards/arm/nrf52810_pca10040/nrf52810_pca10040.dts
+++ b/boards/arm/nrf52810_pca10040/nrf52810_pca10040.dts
@@ -26,19 +26,19 @@
 	leds {
 		compatible = "gpio-leds";
 		led0: led@0 {
-			gpios = <&gpio0 17 GPIO_INT_ACTIVE_LOW>;
+			gpios = <&gpio0 17 0>;
 			label = "Green LED 0";
 		};
 		led1: led@1 {
-			gpios = <&gpio0 18 GPIO_INT_ACTIVE_LOW>;
+			gpios = <&gpio0 18 0>;
 			label = "Green LED 1";
 		};
 		led2: led@2 {
-			gpios = <&gpio0 19 GPIO_INT_ACTIVE_LOW>;
+			gpios = <&gpio0 19 0>;
 			label = "Green LED 2";
 		};
 		led3: led@3 {
-			gpios = <&gpio0 20 GPIO_INT_ACTIVE_LOW>;
+			gpios = <&gpio0 20 0>;
 			label = "Green LED 3";
 		};
 	};

--- a/boards/arm/nrf52810_pca10040/nrf52810_pca10040.dts
+++ b/boards/arm/nrf52810_pca10040/nrf52810_pca10040.dts
@@ -47,19 +47,27 @@
 		compatible = "gpio-keys";
 		button0: button@0 {
 			label = "Push button switch 0";
-			gpios = <&gpio0 13 GPIO_PUD_PULL_UP>;
+			gpios = <&gpio0 13 (GPIO_PUD_PULL_UP |
+					    GPIO_INT_ACTIVE_LOW |
+					    GPIO_INT_EDGE)>;
 		};
 		button1: button@1 {
 			label = "Push button switch 1";
-			gpios = <&gpio0 14 GPIO_PUD_PULL_UP>;
+			gpios = <&gpio0 14 (GPIO_PUD_PULL_UP |
+					    GPIO_INT_ACTIVE_LOW |
+					    GPIO_INT_EDGE)>;
 		};
 		button2: button@2 {
 			label = "Push button switch 2";
-			gpios = <&gpio0 15 GPIO_PUD_PULL_UP>;
+			gpios = <&gpio0 15 (GPIO_PUD_PULL_UP |
+					    GPIO_INT_ACTIVE_LOW |
+					    GPIO_INT_EDGE)>;
 		};
 		button3: button@3 {
 			label = "Push button switch 3";
-			gpios = <&gpio0 16 GPIO_PUD_PULL_UP>;
+			gpios = <&gpio0 16 (GPIO_PUD_PULL_UP |
+					    GPIO_INT_ACTIVE_LOW |
+					    GPIO_INT_EDGE)>;
 		};
 	};
 

--- a/boards/arm/nrf52840_pca10056/nrf52840_pca10056.dts
+++ b/boards/arm/nrf52840_pca10056/nrf52840_pca10056.dts
@@ -24,19 +24,19 @@
 	leds {
 		compatible = "gpio-leds";
 		led0: led@0 {
-			gpios = <&gpio0 13 GPIO_INT_ACTIVE_LOW>;
+			gpios = <&gpio0 13 0>;
 			label = "Green LED 0";
 		};
 		led1: led@1 {
-			gpios = <&gpio0 14 GPIO_INT_ACTIVE_LOW>;
+			gpios = <&gpio0 14 0>;
 			label = "Green LED 1";
 		};
 		led2: led@2 {
-			gpios = <&gpio0 15 GPIO_INT_ACTIVE_LOW>;
+			gpios = <&gpio0 15 0>;
 			label = "Green LED 2";
 		};
 		led3: led@3 {
-			gpios = <&gpio0 16 GPIO_INT_ACTIVE_LOW>;
+			gpios = <&gpio0 16 0>;
 			label = "Green LED 3";
 		};
 	};

--- a/boards/arm/nrf52840_pca10056/nrf52840_pca10056.dts
+++ b/boards/arm/nrf52840_pca10056/nrf52840_pca10056.dts
@@ -44,19 +44,27 @@
 	buttons {
 		compatible = "gpio-keys";
 		button0: button@0 {
-			gpios = <&gpio0 11 GPIO_PUD_PULL_UP>;
+			gpios = <&gpio0 11 (GPIO_PUD_PULL_UP |
+					    GPIO_INT_ACTIVE_LOW |
+					    GPIO_INT_EDGE)>;
 			label = "Push button switch 0";
 		};
 		button1: button@1 {
-			gpios = <&gpio0 12 GPIO_PUD_PULL_UP>;
+			gpios = <&gpio0 12 (GPIO_PUD_PULL_UP |
+					    GPIO_INT_ACTIVE_LOW |
+					    GPIO_INT_EDGE)>;
 			label = "Push button switch 1";
 		};
 		button2: button@2 {
-			gpios = <&gpio0 24 GPIO_PUD_PULL_UP>;
+			gpios = <&gpio0 24 (GPIO_PUD_PULL_UP |
+					    GPIO_INT_ACTIVE_LOW |
+					    GPIO_INT_EDGE)>;
 			label = "Push button switch 2";
 		};
 		button3: button@3 {
-			gpios = <&gpio0 25 GPIO_PUD_PULL_UP>;
+			gpios = <&gpio0 25 (GPIO_PUD_PULL_UP |
+					    GPIO_INT_ACTIVE_LOW |
+					    GPIO_INT_EDGE)>;
 			label = "Push button switch 3";
 		};
 	};

--- a/boards/arm/nrf52840_pca10059/nrf52840_pca10059.dts
+++ b/boards/arm/nrf52840_pca10059/nrf52840_pca10059.dts
@@ -45,7 +45,9 @@
 	buttons {
 		compatible = "gpio-keys";
 		button0: button@0 {
-			gpios = <&gpio1 6 GPIO_PUD_PULL_UP>;
+			gpios = <&gpio1 6 (GPIO_PUD_PULL_UP |
+					   GPIO_INT_ACTIVE_LOW |
+					   GPIO_INT_EDGE)>;
 			label = "Push button switch 0";
 		};
 	};

--- a/boards/arm/nrf52840_pca10059/nrf52840_pca10059.dts
+++ b/boards/arm/nrf52840_pca10059/nrf52840_pca10059.dts
@@ -25,19 +25,19 @@
 	leds {
 		compatible = "gpio-leds";
 		led0_green: led@0 {
-			gpios = <&gpio0 6 GPIO_INT_ACTIVE_LOW>;
+			gpios = <&gpio0 6 0>;
 			label = "Green LED 0";
 		};
 		led1_red: led@1 {
-			gpios = <&gpio0 8 GPIO_INT_ACTIVE_LOW>;
+			gpios = <&gpio0 8 0>;
 			label = "Red LED 1";
 		};
 		led1_green: led@2 {
-			gpios = <&gpio1 9 GPIO_INT_ACTIVE_LOW>;
+			gpios = <&gpio1 9 0>;
 			label = "Green LED 1";
 		};
 		led1_blue: led@3 {
-			gpios = <&gpio0 12 GPIO_INT_ACTIVE_LOW>;
+			gpios = <&gpio0 12 0>;
 			label = "Blue LED 1";
 		};
 	};

--- a/boards/arm/nrf52_pca10040/nrf52_pca10040.dts
+++ b/boards/arm/nrf52_pca10040/nrf52_pca10040.dts
@@ -45,19 +45,27 @@
 	buttons {
 		compatible = "gpio-keys";
 		button0: button@0 {
-			gpios = <&gpio0 13 GPIO_PUD_PULL_UP>;
+			gpios = <&gpio0 13 (GPIO_PUD_PULL_UP |
+					    GPIO_INT_ACTIVE_LOW |
+					    GPIO_INT_EDGE)>;
 			label = "Push button switch 0";
 		};
 		button1: button@1 {
-			gpios = <&gpio0 14 GPIO_PUD_PULL_UP>;
+			gpios = <&gpio0 14 (GPIO_PUD_PULL_UP |
+					    GPIO_INT_ACTIVE_LOW |
+					    GPIO_INT_EDGE)>;
 			label = "Push button switch 1";
 		};
 		button2: button@2 {
-			gpios = <&gpio0 15 GPIO_PUD_PULL_UP>;
+			gpios = <&gpio0 15 (GPIO_PUD_PULL_UP |
+					    GPIO_INT_ACTIVE_LOW |
+					    GPIO_INT_EDGE)>;
 			label = "Push button switch 2";
 		};
 		button3: button@3 {
-			gpios = <&gpio0 16 GPIO_PUD_PULL_UP>;
+			gpios = <&gpio0 16 (GPIO_PUD_PULL_UP |
+					    GPIO_INT_ACTIVE_LOW |
+					    GPIO_INT_EDGE)>;
 			label = "Push button switch 3";
 		};
 	};

--- a/boards/arm/nrf52_pca10040/nrf52_pca10040.dts
+++ b/boards/arm/nrf52_pca10040/nrf52_pca10040.dts
@@ -25,19 +25,19 @@
 	leds {
 		compatible = "gpio-leds";
 		led0: led@0 {
-			gpios = <&gpio0 17 GPIO_INT_ACTIVE_LOW>;
+			gpios = <&gpio0 17 0>;
 			label = "Green LED 0";
 		};
 		led1: led@1 {
-			gpios = <&gpio0 18 GPIO_INT_ACTIVE_LOW>;
+			gpios = <&gpio0 18 0>;
 			label = "Green LED 1";
 		};
 		led2: led@2 {
-			gpios = <&gpio0 19 GPIO_INT_ACTIVE_LOW>;
+			gpios = <&gpio0 19 0>;
 			label = "Green LED 2";
 		};
 		led3: led@3 {
-			gpios = <&gpio0 20 GPIO_INT_ACTIVE_LOW>;
+			gpios = <&gpio0 20 0>;
 			label = "Green LED 3";
 		};
 	};

--- a/boards/arm/nucleo_f030r8/nucleo_f030r8.dts
+++ b/boards/arm/nucleo_f030r8/nucleo_f030r8.dts
@@ -20,7 +20,7 @@
 	leds {
 		compatible = "gpio-leds";
 		green_led_2: led_2 {
-			gpios = <&gpioa 5 GPIO_INT_ACTIVE_HIGH>;
+			gpios = <&gpioa 5 0>;
 			label = "User LD2";
 		};
 	};

--- a/boards/arm/nucleo_f030r8/nucleo_f030r8.dts
+++ b/boards/arm/nucleo_f030r8/nucleo_f030r8.dts
@@ -29,7 +29,8 @@
 		compatible = "gpio-keys";
 		user_button: button {
 			label = "User";
-			gpios = <&gpioc 13 GPIO_INT_ACTIVE_LOW>;
+			gpios = <&gpioc 13 (GPIO_INT_ACTIVE_LOW |
+					    GPIO_INT_EDGE)>;
 		};
 	};
 

--- a/boards/arm/nucleo_f070rb/nucleo_f070rb.dts
+++ b/boards/arm/nucleo_f070rb/nucleo_f070rb.dts
@@ -20,7 +20,7 @@
 	leds {
 		compatible = "gpio-leds";
 		green_led_2: led_2 {
-			gpios = <&gpioa 5 GPIO_INT_ACTIVE_HIGH>;
+			gpios = <&gpioa 5 0>;
 			label = "User LD2";
 		};
 	};

--- a/boards/arm/nucleo_f070rb/nucleo_f070rb.dts
+++ b/boards/arm/nucleo_f070rb/nucleo_f070rb.dts
@@ -29,7 +29,8 @@
 		compatible = "gpio-keys";
 		user_button: button {
 			label = "User";
-			gpios = <&gpioc 13 GPIO_INT_ACTIVE_LOW>;
+			gpios = <&gpioc 13 (GPIO_INT_ACTIVE_LOW |
+					    GPIO_INT_EDGE)>;
 		};
 	};
 

--- a/boards/arm/nucleo_f091rc/nucleo_f091rc.dts
+++ b/boards/arm/nucleo_f091rc/nucleo_f091rc.dts
@@ -20,7 +20,7 @@
 	leds {
 		compatible = "gpio-leds";
 		green_led_2: led_2 {
-			gpios = <&gpioa 5 GPIO_INT_ACTIVE_HIGH>;
+			gpios = <&gpioa 5 0>;
 			label = "User LD2";
 		};
 	};

--- a/boards/arm/nucleo_f091rc/nucleo_f091rc.dts
+++ b/boards/arm/nucleo_f091rc/nucleo_f091rc.dts
@@ -29,7 +29,8 @@
 		compatible = "gpio-keys";
 		user_button: button {
 			label = "User";
-			gpios = <&gpioc 13 GPIO_INT_ACTIVE_LOW>;
+			gpios = <&gpioc 13 (GPIO_INT_ACTIVE_LOW |
+					    GPIO_INT_EDGE)>;
 		};
 	};
 

--- a/boards/arm/nucleo_f103rb/nucleo_f103rb.dts
+++ b/boards/arm/nucleo_f103rb/nucleo_f103rb.dts
@@ -20,7 +20,7 @@
 	leds {
 		compatible = "gpio-leds";
 		green_led_2: led_2 {
-			gpios = <&gpioa 5 GPIO_INT_ACTIVE_HIGH>;
+			gpios = <&gpioa 5 0>;
 			label = "User LD2";
 		};
 	};

--- a/boards/arm/nucleo_f103rb/nucleo_f103rb.dts
+++ b/boards/arm/nucleo_f103rb/nucleo_f103rb.dts
@@ -29,7 +29,8 @@
 		compatible = "gpio-keys";
 		user_button: button {
 			label = "User";
-			gpios = <&gpioc 13 GPIO_INT_ACTIVE_LOW>;
+			gpios = <&gpioc 13 (GPIO_INT_ACTIVE_LOW |
+					    GPIO_INT_EDGE)>;
 		};
 	};
 

--- a/boards/arm/nucleo_f207zg/nucleo_f207zg.dts
+++ b/boards/arm/nucleo_f207zg/nucleo_f207zg.dts
@@ -20,15 +20,15 @@
 	leds {
 		compatible = "gpio-leds";
 		green_led_1: led_1 {
-			gpios = <&gpiob 0 GPIO_INT_ACTIVE_HIGH>;
+			gpios = <&gpiob 0 0>;
 			label = "User LD1";
 		};
 		blue_led_1: led_2 {
-			gpios = <&gpiob 7 GPIO_INT_ACTIVE_HIGH>;
+			gpios = <&gpiob 7 0>;
 			label = "User LD2";
 		};
 		red_led_1: led_3 {
-			gpios = <&gpiob 14 GPIO_INT_ACTIVE_HIGH>;
+			gpios = <&gpiob 14 0>;
 			label = "User LD3";
 		};
 	};

--- a/boards/arm/nucleo_f207zg/nucleo_f207zg.dts
+++ b/boards/arm/nucleo_f207zg/nucleo_f207zg.dts
@@ -37,7 +37,8 @@
 		compatible = "gpio-keys";
 		user_button: button {
 			label = "User";
-			gpios = <&gpioc 13 GPIO_INT_ACTIVE_LOW>;
+			gpios = <&gpioc 13 (GPIO_INT_ACTIVE_LOW |
+					    GPIO_INT_EDGE)>;
 		};
 	};
 

--- a/boards/arm/nucleo_f334r8/nucleo_f334r8.dts
+++ b/boards/arm/nucleo_f334r8/nucleo_f334r8.dts
@@ -20,7 +20,7 @@
 	leds {
 		compatible = "gpio-leds";
 		green_led_2: led_2 {
-			gpios = <&gpioa 5 GPIO_INT_ACTIVE_HIGH>;
+			gpios = <&gpioa 5 0>;
 			label = "User LD2";
 		};
 	};

--- a/boards/arm/nucleo_f334r8/nucleo_f334r8.dts
+++ b/boards/arm/nucleo_f334r8/nucleo_f334r8.dts
@@ -29,7 +29,8 @@
 		compatible = "gpio-keys";
 		user_button: button {
 			label = "User";
-			gpios = <&gpioc 13 GPIO_INT_ACTIVE_LOW>;
+			gpios = <&gpioc 13 (GPIO_INT_ACTIVE_LOW |
+					    GPIO_INT_EDGE)>;
 		};
 	};
 

--- a/boards/arm/nucleo_f401re/nucleo_f401re.dts
+++ b/boards/arm/nucleo_f401re/nucleo_f401re.dts
@@ -20,7 +20,7 @@
 	leds {
 		compatible = "gpio-leds";
 		green_led_2: led_2 {
-			gpios = <&gpioa 5 GPIO_INT_ACTIVE_HIGH>;
+			gpios = <&gpioa 5 0>;
 			label = "User LD2";
 		};
 	};

--- a/boards/arm/nucleo_f401re/nucleo_f401re.dts
+++ b/boards/arm/nucleo_f401re/nucleo_f401re.dts
@@ -29,7 +29,8 @@
 		compatible = "gpio-keys";
 		user_button: button {
 			label = "User";
-			gpios = <&gpioc 13 GPIO_INT_ACTIVE_LOW>;
+			gpios = <&gpioc 13 (GPIO_INT_ACTIVE_LOW |
+					    GPIO_INT_EDGE)>;
 		};
 	};
 

--- a/boards/arm/nucleo_f411re/nucleo_f411re.dts
+++ b/boards/arm/nucleo_f411re/nucleo_f411re.dts
@@ -20,7 +20,7 @@
 	leds {
 		compatible = "gpio-leds";
 		green_led_2: led_2 {
-			gpios = <&gpioa 5 GPIO_INT_ACTIVE_HIGH>;
+			gpios = <&gpioa 5 0>;
 			label = "User LD2";
 		};
 	};

--- a/boards/arm/nucleo_f411re/nucleo_f411re.dts
+++ b/boards/arm/nucleo_f411re/nucleo_f411re.dts
@@ -29,7 +29,8 @@
 		compatible = "gpio-keys";
 		user_button: button {
 			label = "User";
-			gpios = <&gpioc 13 GPIO_INT_ACTIVE_LOW>;
+			gpios = <&gpioc 13 (GPIO_INT_ACTIVE_LOW |
+					    GPIO_INT_EDGE)>;
 		};
 	};
 

--- a/boards/arm/nucleo_f412zg/nucleo_f412zg.dts
+++ b/boards/arm/nucleo_f412zg/nucleo_f412zg.dts
@@ -20,15 +20,15 @@
 	leds {
 		compatible = "gpio-leds";
 		green_led_1: led_1 {
-			gpios = <&gpiob 0 GPIO_INT_ACTIVE_HIGH>;
+			gpios = <&gpiob 0 0>;
 			label = "User LD1";
 		};
 		blue_led_1: led_2 {
-			gpios = <&gpiob 7 GPIO_INT_ACTIVE_HIGH>;
+			gpios = <&gpiob 7 0>;
 			label = "User LD2";
 		};
 		red_led_1: led_3 {
-			gpios = <&gpiob 14 GPIO_INT_ACTIVE_HIGH>;
+			gpios = <&gpiob 14 0>;
 			label = "User LD3";
 		};
 	};

--- a/boards/arm/nucleo_f412zg/nucleo_f412zg.dts
+++ b/boards/arm/nucleo_f412zg/nucleo_f412zg.dts
@@ -37,7 +37,8 @@
 		compatible = "gpio-keys";
 		user_button: button {
 			label = "User";
-			gpios = <&gpioc 13 GPIO_INT_ACTIVE_LOW>;
+			gpios = <&gpioc 13 (GPIO_INT_ACTIVE_LOW |
+					    GPIO_INT_EDGE)>;
 		};
 	};
 

--- a/boards/arm/nucleo_f413zh/nucleo_f413zh.dts
+++ b/boards/arm/nucleo_f413zh/nucleo_f413zh.dts
@@ -20,15 +20,15 @@
 	leds {
 		compatible = "gpio-leds";
 		green_led_1: led_1 {
-			gpios = <&gpiob 0 GPIO_INT_ACTIVE_HIGH>;
+			gpios = <&gpiob 0 0>;
 			label = "User LD1";
 		};
 		blue_led_1: led_2 {
-			gpios = <&gpiob 7 GPIO_INT_ACTIVE_HIGH>;
+			gpios = <&gpiob 7 0>;
 			label = "User LD2";
 		};
 		red_led_1: led_3 {
-			gpios = <&gpiob 14 GPIO_INT_ACTIVE_HIGH>;
+			gpios = <&gpiob 14 0>;
 			label = "User LD3";
 		};
 	};

--- a/boards/arm/nucleo_f413zh/nucleo_f413zh.dts
+++ b/boards/arm/nucleo_f413zh/nucleo_f413zh.dts
@@ -37,7 +37,8 @@
 		compatible = "gpio-keys";
 		user_button: button {
 			label = "User";
-			gpios = <&gpioc 13 GPIO_INT_ACTIVE_LOW>;
+			gpios = <&gpioc 13 (GPIO_INT_ACTIVE_LOW |
+					    GPIO_INT_EDGE)>;
 		};
 	};
 

--- a/boards/arm/nucleo_f429zi/nucleo_f429zi.dts
+++ b/boards/arm/nucleo_f429zi/nucleo_f429zi.dts
@@ -38,7 +38,8 @@
 		compatible = "gpio-keys";
 		user_button: button {
 			label = "User";
-			gpios = <&gpioc 13 GPIO_INT_ACTIVE_LOW>;
+			gpios = <&gpioc 13 (GPIO_INT_ACTIVE_LOW |
+					    GPIO_INT_EDGE)>;
 		};
 	};
 

--- a/boards/arm/nucleo_f429zi/nucleo_f429zi.dts
+++ b/boards/arm/nucleo_f429zi/nucleo_f429zi.dts
@@ -21,15 +21,15 @@
 	leds {
 		compatible = "gpio-leds";
 		green_led_1: led_1 {
-			gpios = <&gpiob 0 GPIO_INT_ACTIVE_HIGH>;
+			gpios = <&gpiob 0 0>;
 			label = "User LD1";
 		};
 		blue_led_1: led_2 {
-			gpios = <&gpiob 7 GPIO_INT_ACTIVE_HIGH>;
+			gpios = <&gpiob 7 0>;
 			label = "User LD2";
 		};
 		red_led_1: led_3 {
-			gpios = <&gpiob 14 GPIO_INT_ACTIVE_HIGH>;
+			gpios = <&gpiob 14 0>;
 			label = "User LD3";
 		};
 	};

--- a/boards/arm/nucleo_f446re/nucleo_f446re.dts
+++ b/boards/arm/nucleo_f446re/nucleo_f446re.dts
@@ -20,7 +20,7 @@
 	leds {
 		compatible = "gpio-leds";
 		green_led_2: led_2 {
-			gpios = <&gpioa 5 GPIO_INT_ACTIVE_HIGH>;
+			gpios = <&gpioa 5 0>;
 			label = "User LD2";
 		};
 	};

--- a/boards/arm/nucleo_f446re/nucleo_f446re.dts
+++ b/boards/arm/nucleo_f446re/nucleo_f446re.dts
@@ -29,7 +29,8 @@
 		compatible = "gpio-keys";
 		user_button: button {
 			label = "User";
-			gpios = <&gpioc 13 GPIO_INT_ACTIVE_LOW>;
+			gpios = <&gpioc 13 (GPIO_INT_ACTIVE_LOW |
+					    GPIO_INT_EDGE)>;
 		};
 	};
 

--- a/boards/arm/nucleo_l053r8/nucleo_l053r8.dts
+++ b/boards/arm/nucleo_l053r8/nucleo_l053r8.dts
@@ -20,7 +20,7 @@
 	leds {
 		compatible = "gpio-leds";
 		green_led_2: led_2 {
-			gpios = <&gpioa 5 GPIO_INT_ACTIVE_HIGH>;
+			gpios = <&gpioa 5 0>;
 			label = "User LD2";
 		};
 	};

--- a/boards/arm/nucleo_l053r8/nucleo_l053r8.dts
+++ b/boards/arm/nucleo_l053r8/nucleo_l053r8.dts
@@ -29,7 +29,8 @@
 		compatible = "gpio-keys";
 		user_button: button {
 			label = "User";
-			gpios = <&gpioc 13 GPIO_INT_ACTIVE_LOW>;
+			gpios = <&gpioc 13 (GPIO_INT_ACTIVE_LOW |
+					    GPIO_INT_EDGE)>;
 		};
 	};
 

--- a/boards/arm/nucleo_l073rz/nucleo_l073rz.dts
+++ b/boards/arm/nucleo_l073rz/nucleo_l073rz.dts
@@ -20,7 +20,7 @@
 	leds {
 		compatible = "gpio-leds";
 		green_led_2: led_2 {
-			gpios = <&gpioa 5 GPIO_INT_ACTIVE_HIGH>;
+			gpios = <&gpioa 5 0>;
 			label = "User LD2";
 		};
 	};

--- a/boards/arm/nucleo_l073rz/nucleo_l073rz.dts
+++ b/boards/arm/nucleo_l073rz/nucleo_l073rz.dts
@@ -29,7 +29,8 @@
 		compatible = "gpio-keys";
 		user_button: button {
 			label = "User";
-			gpios = <&gpioc 13 GPIO_INT_ACTIVE_LOW>;
+			gpios = <&gpioc 13 (GPIO_INT_ACTIVE_LOW |
+					    GPIO_INT_EDGE)>;
 		};
 	};
 

--- a/boards/arm/nucleo_l432kc/nucleo_l432kc.dts
+++ b/boards/arm/nucleo_l432kc/nucleo_l432kc.dts
@@ -20,7 +20,8 @@
 	leds {
 		compatible = "gpio-leds";
 		green_led: led@0 {
-			gpios = <&gpiob 3 GPIO_INT_ACTIVE_HIGH>;
+			gpios = <&gpiob 3 (GPIO_INT_ACTIVE_HIGH |
+					   GPIO_INT_EDGE)>;
 			label = "User LD3";
 		};
 	};

--- a/boards/arm/nucleo_l476rg/nucleo_l476rg.dts
+++ b/boards/arm/nucleo_l476rg/nucleo_l476rg.dts
@@ -20,7 +20,7 @@
 	leds {
 		compatible = "gpio-leds";
 		green_led_2: led_2 {
-			gpios = <&gpioa 5 GPIO_INT_ACTIVE_HIGH>;
+			gpios = <&gpioa 5 0>;
 			label = "User LD2";
 		};
 	};

--- a/boards/arm/nucleo_l476rg/nucleo_l476rg.dts
+++ b/boards/arm/nucleo_l476rg/nucleo_l476rg.dts
@@ -29,7 +29,8 @@
 		compatible = "gpio-keys";
 		user_button: button {
 			label = "User";
-			gpios = <&gpioc 13 GPIO_INT_ACTIVE_LOW>;
+			gpios = <&gpioc 13 (GPIO_INT_ACTIVE_LOW |
+					    GPIO_INT_EDGE)>;
 		};
 	};
 

--- a/boards/arm/olimex_stm32_e407/olimex_stm32_e407.dts
+++ b/boards/arm/olimex_stm32_e407/olimex_stm32_e407.dts
@@ -21,7 +21,7 @@
 	leds {
 		compatible = "gpio-leds";
 		green_led_1: led_1 {
-			gpios = <&gpioc 13 GPIO_INT_ACTIVE_HIGH>;
+			gpios = <&gpioc 13 0>;
 			label = "LED1";
 		};
 	};

--- a/boards/arm/olimex_stm32_e407/olimex_stm32_e407.dts
+++ b/boards/arm/olimex_stm32_e407/olimex_stm32_e407.dts
@@ -30,7 +30,8 @@
 		compatible = "gpio-keys";
 		user_button: button {
 			label = "Key";
-			gpios = <&gpioa 0 GPIO_INT_ACTIVE_LOW>;
+			gpios = <&gpioa 0 (GPIO_INT_ACTIVE_LOW |
+					   GPIO_INT_EDGE)>;
 		};
 	};
 

--- a/boards/arm/olimex_stm32_h407/olimex_stm32_h407.dts
+++ b/boards/arm/olimex_stm32_h407/olimex_stm32_h407.dts
@@ -21,7 +21,7 @@
 	leds {
 		compatible = "gpio-leds";
 		green_led_2: led_2 {
-			gpios = <&gpioa 0 GPIO_INT_ACTIVE_HIGH>;
+			gpios = <&gpioa 0 0>;
 			label = "User LD2";
 		};
 	};

--- a/boards/arm/olimex_stm32_h407/olimex_stm32_h407.dts
+++ b/boards/arm/olimex_stm32_h407/olimex_stm32_h407.dts
@@ -30,7 +30,8 @@
 		compatible = "gpio-keys";
 		user_button: button {
 			label = "User";
-			gpios = <&gpioc 13 GPIO_INT_ACTIVE_LOW>;
+			gpios = <&gpioc 13 (GPIO_INT_ACTIVE_LOW |
+					    GPIO_INT_EDGE)>;
 		};
 	};
 

--- a/boards/arm/olimex_stm32_p405/olimex_stm32_p405.dts
+++ b/boards/arm/olimex_stm32_p405/olimex_stm32_p405.dts
@@ -30,7 +30,8 @@
 		compatible = "gpio-keys";
 		user_button: button {
 			label = "Key";
-			gpios = <&gpioa 0 GPIO_INT_ACTIVE_LOW>;
+			gpios = <&gpioa 0 (GPIO_INT_ACTIVE_LOW |
+					   GPIO_INT_EDGE)>;
 		};
 	};
 

--- a/boards/arm/olimex_stm32_p405/olimex_stm32_p405.dts
+++ b/boards/arm/olimex_stm32_p405/olimex_stm32_p405.dts
@@ -21,7 +21,7 @@
 	leds {
 		compatible = "gpio-leds";
 		green_led_1: led_1 {
-			gpios = <&gpioc 12 GPIO_INT_ACTIVE_HIGH>;
+			gpios = <&gpioc 12 0>;
 			label = "LED1";
 		};
 	};

--- a/boards/arm/olimexino_stm32/olimexino_stm32.dts
+++ b/boards/arm/olimexino_stm32/olimexino_stm32.dts
@@ -33,7 +33,8 @@
 		compatible = "gpio-keys";
 		user_button: button {
 			label = "Key";
-			gpios = <&gpioc 9 GPIO_INT_ACTIVE_LOW>;
+			gpios = <&gpioc 9 (GPIO_INT_ACTIVE_LOW |
+					   GPIO_INT_EDGE)>;
 		};
 	};
 

--- a/boards/arm/olimexino_stm32/olimexino_stm32.dts
+++ b/boards/arm/olimexino_stm32/olimexino_stm32.dts
@@ -20,11 +20,11 @@
 	leds {
 		compatible = "gpio-leds";
 		green_led_1: led_1 {
-			gpios = <&gpioa 5 GPIO_INT_ACTIVE_HIGH>;
+			gpios = <&gpioa 5 0>;
 			label = "LED1";
 		};
 		yellow_led_2: led_2 {
-			gpios = <&gpioa 1 GPIO_INT_ACTIVE_HIGH>;
+			gpios = <&gpioa 1 0>;
 			label = "LED2";
 		};
 	};

--- a/boards/arm/reel_board/reel_board.dts
+++ b/boards/arm/reel_board/reel_board.dts
@@ -45,7 +45,9 @@
 	gpio_keys {
 		compatible = "gpio-keys";
 		user_button: button@0 {
-			gpios = <&gpio0 7 GPIO_PUD_PULL_UP>;
+			gpios = <&gpio0 7 (GPIO_PUD_PULL_UP |
+					   GPIO_INT_ACTIVE_LOW |
+					   GPIO_INT_EDGE)>;
 			label = "User Button";
 		};
 	};

--- a/boards/arm/stm3210c_eval/stm3210c_eval.dts
+++ b/boards/arm/stm3210c_eval/stm3210c_eval.dts
@@ -29,7 +29,8 @@
 		compatible = "gpio-keys";
 		user_button: button {
 			label = "User";
-			gpios = <&gpiob 9 GPIO_INT_ACTIVE_LOW>;
+			gpios = <&gpiob 9 (GPIO_INT_ACTIVE_LOW |
+					   GPIO_INT_EDGE)>;
 		};
 	};
 

--- a/boards/arm/stm3210c_eval/stm3210c_eval.dts
+++ b/boards/arm/stm3210c_eval/stm3210c_eval.dts
@@ -20,7 +20,7 @@
 	leds {
 		compatible = "gpio-leds";
 		green_led_2: led_2 {
-			gpios = <&gpiod 13 GPIO_INT_ACTIVE_HIGH>;
+			gpios = <&gpiod 13 0>;
 			label = "User LD2";
 		};
 	};

--- a/boards/arm/stm32373c_eval/stm32373c_eval.dts
+++ b/boards/arm/stm32373c_eval/stm32373c_eval.dts
@@ -29,7 +29,8 @@
 		compatible = "gpio-keys";
 		user_button: button {
 			label = "Key";
-			gpios = <&gpioa 2 GPIO_INT_ACTIVE_LOW>;
+			gpios = <&gpioa 2 (GPIO_INT_ACTIVE_LOW |
+					   GPIO_INT_EDGE)>;
 		};
 	};
 

--- a/boards/arm/stm32373c_eval/stm32373c_eval.dts
+++ b/boards/arm/stm32373c_eval/stm32373c_eval.dts
@@ -20,7 +20,7 @@
 	leds {
 		compatible = "gpio-leds";
 		green_led_2: led_2 {
-			gpios = <&gpioc 1 GPIO_INT_ACTIVE_HIGH>;
+			gpios = <&gpioc 1 0>;
 			label = "User LD2";
 		};
 	};

--- a/boards/arm/stm32_min_dev/stm32_min_dev.dts
+++ b/boards/arm/stm32_min_dev/stm32_min_dev.dts
@@ -20,7 +20,8 @@
 	leds {
 		compatible = "gpio-leds";
 		led: led {
-			gpios = <&gpiob 12 GPIO_INT_ACTIVE_HIGH>;
+			gpios = <&gpiob 12 (GPIO_INT_ACTIVE_HIGH |
+					    GPIO_INT_EDGE)>;
 			label = "LD";
 		};
 	};

--- a/boards/arm/stm32f072_eval/stm32f072_eval.dts
+++ b/boards/arm/stm32f072_eval/stm32f072_eval.dts
@@ -21,19 +21,19 @@
 	leds {
 		compatible = "gpio-leds";
 		green_led_1: led_1 {
-			gpios = <&gpiod 8 GPIO_INT_ACTIVE_HIGH>;
+			gpios = <&gpiod 8 0>;
 			label = "User LD1";
 		};
 		orange_led_2: led_2 {
-			gpios = <&gpiod 9 GPIO_INT_ACTIVE_HIGH>;
+			gpios = <&gpiod 9 0>;
 			label = "User LD2";
 		};
 		red_led_3: led_3 {
-			gpios = <&gpiod 10 GPIO_INT_ACTIVE_HIGH>;
+			gpios = <&gpiod 10 0>;
 			label = "User LD3";
 		};
 		blue_led_4: led_4 {
-			gpios = <&gpiod 11 GPIO_INT_ACTIVE_HIGH>;
+			gpios = <&gpiod 11 0>;
 			label = "User LD4";
 		};
 	};

--- a/boards/arm/stm32f072_eval/stm32f072_eval.dts
+++ b/boards/arm/stm32f072_eval/stm32f072_eval.dts
@@ -42,27 +42,33 @@
 		compatible = "gpio-keys";
 		tamper: tamper_button {
 			label = "tamper button";
-			gpios = <&gpioc 13 GPIO_INT_ACTIVE_LOW>;
+			gpios = <&gpioc 13 (GPIO_INT_ACTIVE_LOW |
+					    GPIO_INT_EDGE)>;
 		};
 		joy_sel: joystick_selection {
 			label = "joystick selection";
-			gpios = <&gpioa 0 GPIO_INT_ACTIVE_LOW>;
+			gpios = <&gpioa 0 (GPIO_INT_ACTIVE_LOW |
+					   GPIO_INT_EDGE)>;
 		};
 		joy_down: joystick_down {
 			label = "joystick down";
-			gpios = <&gpiof 10 GPIO_INT_ACTIVE_LOW>;
+			gpios = <&gpiof 10 (GPIO_INT_ACTIVE_LOW |
+					    GPIO_INT_EDGE)>;
 		};
 		joy_up: joystick_up {
 			label = "joystick up";
-			gpios = <&gpiof 9 GPIO_INT_ACTIVE_LOW>;
+			gpios = <&gpiof 9 (GPIO_INT_ACTIVE_LOW |
+					   GPIO_INT_EDGE)>;
 		};
 		joy_left: joystick_left {
 			label = "joystick left";
-			gpios = <&gpiof 2 GPIO_INT_ACTIVE_LOW>;
+			gpios = <&gpiof 2 (GPIO_INT_ACTIVE_LOW |
+					   GPIO_INT_EDGE)>;
 		};
 		joy_right: joystick_right {
 			label = "joystick right";
-			gpios = <&gpioe 3 GPIO_INT_ACTIVE_LOW>;
+			gpios = <&gpioe 3 (GPIO_INT_ACTIVE_LOW |
+					   GPIO_INT_EDGE)>;
 		};
 	};
 

--- a/boards/arm/stm32f072b_disco/stm32f072b_disco.dts
+++ b/boards/arm/stm32f072b_disco/stm32f072b_disco.dts
@@ -41,7 +41,8 @@
 		compatible = "gpio-keys";
 		user_button: button {
 			label = "User";
-			gpios = <&gpioa 0 GPIO_INT_ACTIVE_LOW>;
+			gpios = <&gpioa 0 (GPIO_INT_ACTIVE_LOW |
+					   GPIO_INT_EDGE)>;
 		};
 	};
 

--- a/boards/arm/stm32f072b_disco/stm32f072b_disco.dts
+++ b/boards/arm/stm32f072b_disco/stm32f072b_disco.dts
@@ -20,19 +20,19 @@
 	leds {
 		compatible = "gpio-leds";
 		red_up_led_3: led_3 {
-			gpios = <&gpioc 6 GPIO_INT_ACTIVE_HIGH>;
+			gpios = <&gpioc 6 0>;
 			label = "User LD3";
 		};
 		yellow_left_4: led_4 {
-			gpios = <&gpioc 8 GPIO_INT_ACTIVE_HIGH>;
+			gpios = <&gpioc 8 0>;
 			label = "User LD4";
 		};
 		green_right_led_5: led_5 {
-			gpios = <&gpioc 9 GPIO_INT_ACTIVE_HIGH>;
+			gpios = <&gpioc 9 0>;
 			label = "User LD5";
 		};
 		blue_low_led_6: led_6 {
-			gpios = <&gpioc 7 GPIO_INT_ACTIVE_HIGH>;
+			gpios = <&gpioc 7 0>;
 			label = "User LD6";
 		};
 	};

--- a/boards/arm/stm32f0_disco/stm32f0_disco.dts
+++ b/boards/arm/stm32f0_disco/stm32f0_disco.dts
@@ -20,11 +20,11 @@
 	leds {
 		compatible = "gpio-leds";
 		green_led_3: led_3 {
-			gpios = <&gpioc 9 GPIO_INT_ACTIVE_HIGH>;
+			gpios = <&gpioc 9 0>;
 			label = "User LD3";
 		};
 		blue_led_4: led_4 {
-			gpios = <&gpioc 8 GPIO_INT_ACTIVE_HIGH>;
+			gpios = <&gpioc 8 0>;
 			label = "User LD4";
 		};
 	};

--- a/boards/arm/stm32f0_disco/stm32f0_disco.dts
+++ b/boards/arm/stm32f0_disco/stm32f0_disco.dts
@@ -33,7 +33,8 @@
 		compatible = "gpio-keys";
 		user_button: button {
 			label = "Key";
-			gpios = <&gpioa 0 GPIO_INT_ACTIVE_LOW>;
+			gpios = <&gpioa 0 (GPIO_INT_ACTIVE_LOW |
+					   GPIO_INT_EDGE)>;
 		};
 	};
 

--- a/boards/arm/stm32f3_disco/stm32f3_disco.dts
+++ b/boards/arm/stm32f3_disco/stm32f3_disco.dts
@@ -57,7 +57,8 @@
 		compatible = "gpio-keys";
 		user_button: button {
 			label = "User";
-			gpios = <&gpioa 0 GPIO_INT_ACTIVE_LOW>;
+			gpios = <&gpioa 0 (GPIO_INT_ACTIVE_LOW |
+					   GPIO_INT_EDGE)>;
 		};
 	};
 

--- a/boards/arm/stm32f3_disco/stm32f3_disco.dts
+++ b/boards/arm/stm32f3_disco/stm32f3_disco.dts
@@ -20,35 +20,35 @@
 	leds {
 		compatible = "gpio-leds";
 		red_led_3: led_3 {
-			gpios = <&gpioe 9 GPIO_INT_ACTIVE_HIGH>;
+			gpios = <&gpioe 9 0>;
 			label = "User LD3";
 		};
 		blue_led_4: led_4 {
-			gpios = <&gpioe 8 GPIO_INT_ACTIVE_HIGH>;
+			gpios = <&gpioe 8 0>;
 			label = "User LD4";
 		};
 		orange_led_5: led_5 {
-			gpios = <&gpioe 10 GPIO_INT_ACTIVE_HIGH>;
+			gpios = <&gpioe 10 0>;
 			label = "User LD5";
 		};
 		green_led_6: led_6 {
-			gpios = <&gpioe 15 GPIO_INT_ACTIVE_HIGH>;
+			gpios = <&gpioe 15 0>;
 			label = "User LD6";
 		};
 		green_led_7: led_7 {
-			gpios = <&gpiod 11 GPIO_INT_ACTIVE_HIGH>;
+			gpios = <&gpiod 11 0>;
 			label = "User LD7";
 		};
 		orange_led_8: led_8 {
-			gpios = <&gpioe 14 GPIO_INT_ACTIVE_HIGH>;
+			gpios = <&gpioe 14 0>;
 			label = "User LD8";
 		};
 		blue_led_9: led_9 {
-			gpios = <&gpioe 12 GPIO_INT_ACTIVE_HIGH>;
+			gpios = <&gpioe 12 0>;
 			label = "User LD9";
 		};
 		red_led_10: led_10 {
-			gpios = <&gpioe 13 GPIO_INT_ACTIVE_HIGH>;
+			gpios = <&gpioe 13 0>;
 			label = "User LD10";
 		};
 	};

--- a/boards/arm/stm32f411e_disco/stm32f411e_disco.dts
+++ b/boards/arm/stm32f411e_disco/stm32f411e_disco.dts
@@ -41,7 +41,8 @@
 		compatible = "gpio-keys";
 		user_button: button {
 			label = "User";
-			gpios = <&gpioa 0 GPIO_INT_ACTIVE_LOW>;
+			gpios = <&gpioa 0 (GPIO_INT_ACTIVE_LOW |
+					   GPIO_INT_EDGE)>;
 		};
 	};
 

--- a/boards/arm/stm32f411e_disco/stm32f411e_disco.dts
+++ b/boards/arm/stm32f411e_disco/stm32f411e_disco.dts
@@ -20,19 +20,19 @@
 	leds {
 		compatible = "gpio-leds";
 		orange_led_3: led_3 {
-			gpios = <&gpiod 13 GPIO_INT_ACTIVE_HIGH>;
+			gpios = <&gpiod 13 0>;
 			label = "User LD3";
 		};
 		green_led_4: led_4 {
-			gpios = <&gpiod 12 GPIO_INT_ACTIVE_HIGH>;
+			gpios = <&gpiod 12 0>;
 			label = "User LD4";
 		};
 		red_led_5: led_5 {
-			gpios = <&gpiod 14 GPIO_INT_ACTIVE_HIGH>;
+			gpios = <&gpiod 14 0>;
 			label = "User LD5";
 		};
 		blue_led_6: led_6 {
-			gpios = <&gpiod 15 GPIO_INT_ACTIVE_HIGH>;
+			gpios = <&gpiod 15 0>;
 			label = "User LD6";
 		};
 	};

--- a/boards/arm/stm32f412g_disco/stm32f412g_disco.dts
+++ b/boards/arm/stm32f412g_disco/stm32f412g_disco.dts
@@ -20,19 +20,19 @@
 	leds {
 		compatible = "gpio-leds";
 		green_led_1: led_1 {
-			gpios = <&gpioe 0 GPIO_INT_ACTIVE_HIGH>;
+			gpios = <&gpioe 0 0>;
 			label = "User LD1";
 		};
 		orange_led_2: led_2 {
-			gpios = <&gpioe 1 GPIO_INT_ACTIVE_HIGH>;
+			gpios = <&gpioe 1 0>;
 			label = "User LD2";
 		};
 		red_led_3: led_3 {
-			gpios = <&gpioe 2 GPIO_INT_ACTIVE_HIGH>;
+			gpios = <&gpioe 2 0>;
 			label = "User LD3";
 		};
 		blue_led_4: led_4 {
-			gpios = <&gpioe 4 GPIO_INT_ACTIVE_HIGH>;
+			gpios = <&gpioe 4 0>;
 			label = "User LD4";
 		};
 	};

--- a/boards/arm/stm32f412g_disco/stm32f412g_disco.dts
+++ b/boards/arm/stm32f412g_disco/stm32f412g_disco.dts
@@ -41,23 +41,28 @@
 		compatible = "gpio-keys";
 		joy_sel: joystick_selection {
 			label = "joystick selection";
-			gpios = <&gpioa 0 GPIO_INT_ACTIVE_LOW>;
+			gpios = <&gpioa 0 (GPIO_INT_ACTIVE_LOW |
+					   GPIO_INT_EDGE)>;
 		};
 		joy_down: joystick_down {
 			label = "joystick down";
-			gpios = <&gpiog 1 GPIO_INT_ACTIVE_LOW>;
+			gpios = <&gpiog 1 (GPIO_INT_ACTIVE_LOW |
+					   GPIO_INT_EDGE)>;
 		};
 		joy_up: joystick_up {
 			label = "joystick up";
-			gpios = <&gpiog 0 GPIO_INT_ACTIVE_LOW>;
+			gpios = <&gpiog 0 (GPIO_INT_ACTIVE_LOW |
+					   GPIO_INT_EDGE)>;
 		};
 		joy_left: joystick_left {
 			label = "joystick left";
-			gpios = <&gpiof 15 GPIO_INT_ACTIVE_LOW>;
+			gpios = <&gpiof 15 (GPIO_INT_ACTIVE_LOW |
+					    GPIO_INT_EDGE)>;
 		};
 		joy_right: joystick_right {
 			label = "joystick right";
-			gpios = <&gpiof 14 GPIO_INT_ACTIVE_LOW>;
+			gpios = <&gpiof 14 (GPIO_INT_ACTIVE_LOW |
+					    GPIO_INT_EDGE)>;
 		};
 	};
 

--- a/boards/arm/stm32f429i_disc1/stm32f429i_disc1.dts
+++ b/boards/arm/stm32f429i_disc1/stm32f429i_disc1.dts
@@ -33,7 +33,8 @@
 		compatible = "gpio-keys";
 		user_button: button {
 			label = "User";
-			gpios = <&gpioa 0 GPIO_INT_ACTIVE_LOW>;
+			gpios = <&gpioa 0 (GPIO_INT_ACTIVE_LOW |
+					   GPIO_INT_EDGE)>;
 		};
 	};
 

--- a/boards/arm/stm32f429i_disc1/stm32f429i_disc1.dts
+++ b/boards/arm/stm32f429i_disc1/stm32f429i_disc1.dts
@@ -20,11 +20,11 @@
 	leds {
 		compatible = "gpio-leds";
 		orange_led_3: led_3 {
-			gpios = <&gpiog 13 GPIO_INT_ACTIVE_HIGH>;
+			gpios = <&gpiog 13 0>;
 			label = "User LD3";
 		};
 		green_led_4: led_4 {
-			gpios = <&gpiog 14 GPIO_INT_ACTIVE_HIGH>;
+			gpios = <&gpiog 14 0>;
 			label = "User LD4";
 		};
 	};

--- a/boards/arm/stm32f469i_disco/stm32f469i_disco.dts
+++ b/boards/arm/stm32f469i_disco/stm32f469i_disco.dts
@@ -20,19 +20,19 @@
 	leds {
 		compatible = "gpio-leds";
 		green_led_1: led_1 {
-			gpios = <&gpiog 6 GPIO_INT_ACTIVE_HIGH>;
+			gpios = <&gpiog 6 0>;
 			label = "User LD1";
 		};
 		orange_led_2: led_2 {
-			gpios = <&gpiod 4 GPIO_INT_ACTIVE_HIGH>;
+			gpios = <&gpiod 4 0>;
 			label = "User LD2";
 		};
 		red_led_3: led_3 {
-			gpios = <&gpiod 5 GPIO_INT_ACTIVE_HIGH>;
+			gpios = <&gpiod 5 0>;
 			label = "User LD3";
 		};
 		blue_led_4: led_4 {
-			gpios = <&gpiok 3 GPIO_INT_ACTIVE_HIGH>;
+			gpios = <&gpiok 3 0>;
 			label = "User LD4";
 		};
 	};

--- a/boards/arm/stm32f469i_disco/stm32f469i_disco.dts
+++ b/boards/arm/stm32f469i_disco/stm32f469i_disco.dts
@@ -41,7 +41,8 @@
 		compatible = "gpio-keys";
 		user_button: button {
 			label = "User";
-			gpios = <&gpioa 0 GPIO_INT_ACTIVE_LOW>;
+			gpios = <&gpioa 0 (GPIO_INT_ACTIVE_LOW |
+					   GPIO_INT_EDGE)>;
 		};
 	};
 

--- a/boards/arm/stm32f4_disco/stm32f4_disco.dts
+++ b/boards/arm/stm32f4_disco/stm32f4_disco.dts
@@ -41,7 +41,8 @@
 		compatible = "gpio-keys";
 		user_button: button {
 			label = "Key";
-			gpios = <&gpioa 0 GPIO_INT_ACTIVE_LOW>;
+			gpios = <&gpioa 0 (GPIO_INT_ACTIVE_LOW |
+					   GPIO_INT_EDGE)>;
 		};
 	};
 

--- a/boards/arm/stm32f4_disco/stm32f4_disco.dts
+++ b/boards/arm/stm32f4_disco/stm32f4_disco.dts
@@ -20,19 +20,19 @@
 	leds {
 		compatible = "gpio-leds";
 		orange_led_3: led_3 {
-			gpios = <&gpiod 13 GPIO_INT_ACTIVE_HIGH>;
+			gpios = <&gpiod 13 0>;
 			label = "User LD3";
 		};
 		green_led_4: led_4 {
-			gpios = <&gpiod 12 GPIO_INT_ACTIVE_HIGH>;
+			gpios = <&gpiod 12 0>;
 			label = "User LD4";
 		};
 		red_led_5: led_5 {
-			gpios = <&gpiod 14 GPIO_INT_ACTIVE_HIGH>;
+			gpios = <&gpiod 14 0>;
 			label = "User LD5";
 		};
 		blue_led_6: led_6 {
-			gpios = <&gpiod 15 GPIO_INT_ACTIVE_HIGH>;
+			gpios = <&gpiod 15 0>;
 			label = "User LD6";
 		};
 	};

--- a/boards/arm/stm32f723e_disco/stm32f723e_disco.dts
+++ b/boards/arm/stm32f723e_disco/stm32f723e_disco.dts
@@ -37,7 +37,8 @@
 		compatible = "gpio-keys";
 		user_button: button {
 			label = "User";
-			gpios = <&gpioa 0 GPIO_INT_ACTIVE_HIGH>;
+			gpios = <&gpioa 0 (GPIO_INT_ACTIVE_HIGH |
+					   GPIO_INT_EDGE)>;
 		};
 	};
 

--- a/boards/arm/stm32f723e_disco/stm32f723e_disco.dts
+++ b/boards/arm/stm32f723e_disco/stm32f723e_disco.dts
@@ -20,15 +20,15 @@
 	leds {
 		compatible = "gpio-leds";
 		blue_led: led_1 {
-			gpios = <&gpioa 5 GPIO_INT_ACTIVE_HIGH>;
+			gpios = <&gpioa 5 0>;
 			label = "User LD1";
 		};
 		red_led: led_2 {
-			gpios = <&gpioa 7 GPIO_INT_ACTIVE_HIGH>;
+			gpios = <&gpioa 7 0>;
 			label = "User LD5";
 		};
 		green_led: led_3 {
-			gpios = <&gpiob 1 GPIO_INT_ACTIVE_HIGH>;
+			gpios = <&gpiob 1 0>;
 			label = "User LD6";
 		};
 	};

--- a/boards/arm/stm32f746g_disco/stm32f746g_disco.dts
+++ b/boards/arm/stm32f746g_disco/stm32f746g_disco.dts
@@ -29,7 +29,8 @@
 		compatible = "gpio-keys";
 		user_button: button {
 			label = "User";
-			gpios = <&gpioi 11 GPIO_INT_ACTIVE_HIGH>;
+			gpios = <&gpioi 11 (GPIO_INT_ACTIVE_HIGH |
+					    GPIO_INT_EDGE)>;
 		};
 	};
 

--- a/boards/arm/stm32f746g_disco/stm32f746g_disco.dts
+++ b/boards/arm/stm32f746g_disco/stm32f746g_disco.dts
@@ -20,7 +20,7 @@
 	leds {
 		compatible = "gpio-leds";
 		green_led_1: led_1 {
-			gpios = <&gpioi 1 GPIO_INT_ACTIVE_HIGH>;
+			gpios = <&gpioi 1 0>;
 			label = "User LD1";
 		};
 	};

--- a/boards/arm/stm32f769i_disco/stm32f769i_disco.dts
+++ b/boards/arm/stm32f769i_disco/stm32f769i_disco.dts
@@ -41,7 +41,8 @@
 		compatible = "gpio-keys";
 		user_button: button {
 			label = "User";
-			gpios = <&gpioa 0 GPIO_INT_ACTIVE_HIGH>;
+			gpios = <&gpioa 0 (GPIO_INT_ACTIVE_HIGH |
+					   GPIO_INT_EDGE)>;
 		};
 	};
 

--- a/boards/arm/stm32f769i_disco/stm32f769i_disco.dts
+++ b/boards/arm/stm32f769i_disco/stm32f769i_disco.dts
@@ -20,19 +20,19 @@
 	leds {
 		compatible = "gpio-leds";
 		red_led_1:led_1 {
-			gpios = <&gpioj 13 GPIO_INT_ACTIVE_HIGH>;
+			gpios = <&gpioj 13 0>;
 			label = "User LD1";
 		};
 		green_led_2:led_2 {
-			gpios = <&gpioj 5 GPIO_INT_ACTIVE_HIGH>;
+			gpios = <&gpioj 5 0>;
 			label = "User LD2";
 		};
 		green_led_3:led_3 {
-			gpios = <&gpioa 12 GPIO_INT_ACTIVE_HIGH>;
+			gpios = <&gpioa 12 0>;
 			label = "User LD3";
 		};
 		red_led_4:led_4 {
-			gpios = <&gpiod 4 GPIO_INT_ACTIVE_HIGH>;
+			gpios = <&gpiod 4 0>;
 			label = "User LD4";
 		};
 	};

--- a/boards/arm/stm32l476g_disco/stm32l476g_disco.dts
+++ b/boards/arm/stm32l476g_disco/stm32l476g_disco.dts
@@ -37,23 +37,28 @@
 		compatible = "gpio-keys";
 		joy_center: joystick_center {
 			label = "joystick center";
-			gpios = <&gpioa 0 GPIO_INT_ACTIVE_LOW>;
+			gpios = <&gpioa 0 (GPIO_INT_ACTIVE_LOW |
+					   GPIO_INT_EDGE)>;
 		};
 		joy_down: joystick_down {
 			label = "joystick down";
-			gpios = <&gpioa 5 GPIO_INT_ACTIVE_LOW>;
+			gpios = <&gpioa 5 (GPIO_INT_ACTIVE_LOW |
+					   GPIO_INT_EDGE)>;
 		};
 		joy_up: joystick_up {
 			label = "joystick up";
-			gpios = <&gpioa 3 GPIO_INT_ACTIVE_LOW>;
+			gpios = <&gpioa 3 (GPIO_INT_ACTIVE_LOW |
+					   GPIO_INT_EDGE)>;
 		};
 		joy_left: joystick_left {
 			label = "joystick left";
-			gpios = <&gpioa 1 GPIO_INT_ACTIVE_LOW>;
+			gpios = <&gpioa 1 (GPIO_INT_ACTIVE_LOW |
+					   GPIO_INT_EDGE)>;
 		};
 		joy_right: joystick_right {
 			label = "joystick right";
-			gpios = <&gpioa 2 GPIO_INT_ACTIVE_LOW>;
+			gpios = <&gpioa 2 (GPIO_INT_ACTIVE_LOW |
+					   GPIO_INT_EDGE)>;
 		};
 	};
 

--- a/boards/arm/stm32l476g_disco/stm32l476g_disco.dts
+++ b/boards/arm/stm32l476g_disco/stm32l476g_disco.dts
@@ -24,11 +24,11 @@
 	leds {
 		compatible = "gpio-leds";
 		green_led_4: led_4 {
-			gpios = <&gpiob 2 GPIO_INT_ACTIVE_HIGH>;
+			gpios = <&gpiob 2 0>;
 			label = "User LD4";
 		};
 		green_led_5: led_5 {
-			gpios = <&gpioe 8 GPIO_INT_ACTIVE_HIGH>;
+			gpios = <&gpioe 8 0>;
 			label = "User LD5";
 		};
 	};

--- a/boards/arm/stm32l496g_disco/stm32l496g_disco.dts
+++ b/boards/arm/stm32l496g_disco/stm32l496g_disco.dts
@@ -20,7 +20,7 @@
 	leds {
 		compatible = "gpio-leds";
 		green_led_2: led_2 {
-			gpios = <&gpiob 13 GPIO_INT_ACTIVE_HIGH>;
+			gpios = <&gpiob 13 0>;
 			label = "User LD2";
 		};
 	};

--- a/boards/arm/stm32l496g_disco/stm32l496g_disco.dts
+++ b/boards/arm/stm32l496g_disco/stm32l496g_disco.dts
@@ -29,23 +29,28 @@
 		compatible = "gpio-keys";
 		joy_sel: joystick_select {
 			label = "joystick select";
-			gpios = <&gpioc 13 GPIO_INT_ACTIVE_LOW>;
+			gpios = <&gpioc 13 (GPIO_INT_ACTIVE_LOW |
+					    GPIO_INT_EDGE)>;
 		};
 		joy_down: joystick_down {
 			label = "joystick down";
-			gpios = <&gpioi 10 GPIO_INT_ACTIVE_LOW>;
+			gpios = <&gpioi 10 (GPIO_INT_ACTIVE_LOW |
+					    GPIO_INT_EDGE)>;
 		};
 		joy_up: joystick_up {
 			label = "joystick up";
-			gpios = <&gpioi 8 GPIO_INT_ACTIVE_LOW>;
+			gpios = <&gpioi 8 (GPIO_INT_ACTIVE_LOW |
+					   GPIO_INT_EDGE)>;
 		};
 		joy_left: joystick_left {
 			label = "joystick left";
-			gpios = <&gpioi 9 GPIO_INT_ACTIVE_LOW>;
+			gpios = <&gpioi 9 (GPIO_INT_ACTIVE_LOW |
+					   GPIO_INT_EDGE)>;
 		};
 		joy_right: joystick_right {
 			label = "joystick right";
-			gpios = <&gpiof 11 GPIO_INT_ACTIVE_LOW>;
+			gpios = <&gpiof 11 (GPIO_INT_ACTIVE_LOW |
+					    GPIO_INT_EDGE)>;
 		};
 	};
 

--- a/boards/arm/usb_kw24d512/usb_kw24d512.dts
+++ b/boards/arm/usb_kw24d512/usb_kw24d512.dts
@@ -47,7 +47,8 @@
 		compatible = "gpio-keys";
 		user_button_1: button@0 {
 			label = "User SW1";
-			gpios = <&gpioc 4 GPIO_INT_ACTIVE_LOW>;
+			gpios = <&gpioc 4 (GPIO_INT_ACTIVE_LOW |
+					   GPIO_INT_EDGE)>;
 		};
 	};
 };

--- a/boards/arm/warp7_m4/warp7_m4.dts
+++ b/boards/arm/warp7_m4/warp7_m4.dts
@@ -31,7 +31,8 @@
 	gpio_keys {
 		compatible = "gpio-keys";
 		user_switch_1: user_sw_1 {
-			gpios = <&gpio7 1 GPIO_INT_ACTIVE_LOW>;
+			gpios = <&gpio7 1 (GPIO_INT_ACTIVE_LOW |
+					   GPIO_INT_EDGE)>;
 			label = "User SW1";
 		};
 	};


### PR DESCRIPTION
Cleanup the gpio flags in board DTS files:
* Remove setting of GPIO_INT_ACTIVE_HIGH for LEDs
* Set proper flags for buttons