### PR TITLE
native_posix: Add support for CONFIG_REBOOT

### DIFF
--- a/arch/posix/core/cpuhalt.c
+++ b/arch/posix/core/cpuhalt.c
@@ -7,14 +7,17 @@
 /**
  * @file  CPU power management code for POSIX
  *
- * This module provides an implementation of the architecture-specific
+ * This module provides:
+ *
+ * An implementation of the architecture-specific
  * k_cpu_idle() primitive required by the kernel idle loop component.
  * It can be called within an implementation of _sys_power_save_idle(),
  * which is provided for the kernel by the platform.
  *
- * The module also provides an implementation of k_cpu_atomic_idle(), which
+ * An implementation of k_cpu_atomic_idle(), which
  * atomically re-enables interrupts and enters low power mode.
  *
+ * A weak stub for sys_arch_reboot(), which does nothing
  */
 
 #include "posix_core.h"
@@ -59,9 +62,23 @@ void k_cpu_idle(void)
  *
  * @return N/A
  */
-
 void k_cpu_atomic_idle(unsigned int key)
 {
 	z_sys_trace_idle();
 	posix_atomic_halt_cpu(key);
 }
+
+#if defined(CONFIG_REBOOT)
+/**
+ *
+ * @brief Stub for sys_arch_reboot
+ *
+ * Does nothing
+ *
+ * @return N/A
+ */
+void __weak sys_arch_reboot(int type)
+{
+	ARG_UNUSED(type);
+}
+#endif /* CONFIG_REBOOT */

--- a/drivers/timer/native_posix_timer.c
+++ b/drivers/timer/native_posix_timer.c
@@ -133,3 +133,19 @@ void k_busy_wait(u32_t usec_to_wait)
 	}
 }
 #endif
+
+#if defined(CONFIG_SYSTEM_CLOCK_DISABLE)
+/**
+ *
+ * @brief Stop announcing sys ticks into the kernel
+ *
+ * Disable the system ticks generation
+ *
+ * @return N/A
+ */
+void sys_clock_disable(void)
+{
+	irq_disable(TIMER_TICK_IRQ);
+	hwtimer_set_silent_ticks(INT64_MAX);
+}
+#endif /* CONFIG_SYSTEM_CLOCK_DISABLE */


### PR DESCRIPTION
##### Description of Change
To allow apps to compile with ```CONFIG_REBOOT```, add a weak stub for ```sys_arch_reboot()``` which does nothing in the POSIX arch. POSIX boards may choose to provide a more sensible implementation if relevant.
+
In the native_posix timer driver: Add support for ```CONFIG_SYSTEM_CLOCK_DISABLE```.

Fixes #10240

##### Checklist
- [x] PR description included and stakeholders cc'd
- [x] `sanitycheck` passes

##### Release Notes
Notes: native_posix: added support for CONFIG_REBOOT
