### PR TITLE
Bluetooth: Fix autoconnect if cancelled pending connection

### DIFF
--- a/subsys/bluetooth/host/conn.c
+++ b/subsys/bluetooth/host/conn.c
@@ -223,10 +223,11 @@ static void conn_le_update_timeout(struct k_work *work)
 
 	if (IS_ENABLED(CONFIG_BT_CENTRAL) &&
 	    conn->role == BT_CONN_ROLE_MASTER) {
-		if (conn->state == BT_CONN_CONNECT) {
-			bt_conn_disconnect(conn,
-					   BT_HCI_ERR_REMOTE_USER_TERM_CONN);
-		}
+		/* we don't call bt_conn_disconnect as it would also clear
+		 * auto connect flag if it was set, instead just cancel
+		 * connection directly
+		 */
+		bt_hci_cmd_send(BT_HCI_OP_LE_CREATE_CONN_CANCEL, NULL);
 		return;
 	}
 

--- a/subsys/bluetooth/host/hci_core.c
+++ b/subsys/bluetooth/host/hci_core.c
@@ -829,13 +829,12 @@ static void le_enh_conn_complete(struct bt_hci_evt_le_enh_conn_complete *evt)
 
 		bt_conn_set_state(conn, BT_CONN_DISCONNECTED);
 
-		/* Drop the reference got by lookup call in CONNECT state.
-		 * We are now in DISCONNECTED state since no successful LE
-		 * link been made.
-		 */
-		bt_conn_unref(conn);
+		/* check if device is market for auto connect */
+		if (atomic_test_bit(conn->flags, BT_CONN_AUTO_CONNECT)) {
+			bt_conn_set_state(conn, BT_CONN_CONNECT_SCAN);
+		}
 
-		return;
+		goto done;
 	}
 
 	bt_addr_le_copy(&id_addr, &evt->peer_addr);


### PR DESCRIPTION
bt_conn_disconnect removes device from autoconnect list and thus
should not be called from le_conn_update when timeouting pending
connection. Also auto connect flag needs to be check on connection
failure to make sure scan is restarted.

Signed-off-by: Szymon Janc <szymon.janc@codecoup.pl>