### PR TITLE
revert: print a note about the changed 'default' behavior

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,9 +41,6 @@ tags
 .envrc
 .vscode
 
-# Disables the warning about the changed behavior for Kconfig defaults
-hide-defaults-note
-
 # Tag files
 GPATH
 GRTAGS

--- a/cmake/app/boilerplate.cmake
+++ b/cmake/app/boilerplate.cmake
@@ -339,20 +339,3 @@ foreach(boilerplate_lib ${ZEPHYR_INTERFACE_LIBS_PROPERTY})
     ${boilerplate_lib}
     )
 endforeach()
-
-
-if(NOT EXISTS ${ZEPHYR_BASE}/hide-defaults-note)
-    message(STATUS "\n\
-*******************************\n\
-*** NOTE TO KCONFIG AUTHORS ***\n\
-*******************************\n\
-\n\
-The behavior of Kconfig 'default' properties in Zephyr has changed. The \n\
-earliest default with a satisfied condition is now used, instead of the \n\
-last one. This is standard Kconfig behavior.\n\
-\n\
-See http://docs.zephyrproject.org/latest/porting/board_porting.html#old-zephyr-kconfig-behavior-for-defaults.\n\
-\n\
-To get rid of this note, create a file called 'hide-defaults-note' in the \n\
-Zephyr root directory. An empty file is fine.")
-endif()


### PR DESCRIPTION
The deprecation warning has existed for 1 release and 3 months, giving
users plenty of time to be warned.

This reverts commit 9c93e8e87bede05801b08a43f05e50d43a810d47.

Signed-off-by: Sebastian Bøe <sebastian.boe@nordicsemi.no>