### PR TITLE
cmake: Support custom out-of-tree toolchains

### DIFF
--- a/cmake/toolchain.cmake
+++ b/cmake/toolchain.cmake
@@ -8,6 +8,16 @@ set(CMAKE_FIND_ROOT_PATH_MODE_LIBRARY ONLY)
 set(CMAKE_FIND_ROOT_PATH_MODE_INCLUDE ONLY)
 set(CMAKE_FIND_ROOT_PATH_MODE_PACKAGE ONLY)
 
+if(NOT TOOLCHAIN_ROOT)
+  if(DEFINED ENV{TOOLCHAIN_ROOT})
+    # Support for out-of-tree toolchain
+    set(TOOLCHAIN_ROOT $ENV{TOOLCHAIN_ROOT})
+  else()
+    # Default toolchain cmake file
+    set(TOOLCHAIN_ROOT ${ZEPHYR_BASE})
+  endif()
+endif()
+
 # Don't inherit compiler flags from the environment
 foreach(var CFLAGS CXXFLAGS)
   if(DEFINED ENV{${var}})
@@ -39,6 +49,10 @@ if("${ZEPHYR_TOOLCHAIN_VARIANT}" STREQUAL "gccarmemb")
   set(ZEPHYR_TOOLCHAIN_VARIANT "gnuarmemb")
 endif()
 
+
+set(TOOLCHAIN_ROOT ${TOOLCHAIN_ROOT} CACHE STRING "Zephyr toolchain root")
+assert(TOOLCHAIN_ROOT "Zephyr toolchain root path invalid: please set the TOOLCHAIN_ROOT-variable")
+
 set(ZEPHYR_TOOLCHAIN_VARIANT ${ZEPHYR_TOOLCHAIN_VARIANT} CACHE STRING "Zephyr toolchain variant")
 assert(ZEPHYR_TOOLCHAIN_VARIANT "Zephyr toolchain variant invalid: please set the ZEPHYR_TOOLCHAIN_VARIANT-variable")
 
@@ -49,7 +63,7 @@ endif()
 
 # Configure the toolchain based on what SDK/toolchain is in use.
 if(NOT (COMPILER STREQUAL "host-gcc"))
-  include(${ZEPHYR_BASE}/cmake/toolchain/${ZEPHYR_TOOLCHAIN_VARIANT}.cmake)
+  include(${TOOLCHAIN_ROOT}/cmake/toolchain/${ZEPHYR_TOOLCHAIN_VARIANT}.cmake)
 endif()
 
 # Configure the toolchain based on what toolchain technology is used

--- a/doc/getting_started/getting_started.rst
+++ b/doc/getting_started/getting_started.rst
@@ -263,6 +263,26 @@ Make sure to unset the ZEPHYR_SDK_INSTALL_DIR if you don't use the SDK's host
 tools. See `Building without the Zephyr SDK`_ and `Set Up the Development
 Environment`_ for more details.
 
+Using Custom Cmake Toolchains
+=============================
+
+To use a custom toolchain defined in an external cmake file, export the
+following environment variables:
+
+   .. code-block:: console
+
+      export ZEPHYR_TOOLCHAIN_VARIANT=<toolchain name>
+      export TOOLCHAIN_ROOT=<path to toolchain>
+
+or set them as cmake variables:
+
+  .. code-block:: console
+
+      cmake -DZEPHYR_TOOLCHAIN_VARIANT=... -DTOOLCHAIN_ROOT=...
+
+Zephyr will then include the toolchain cmake file located in:
+``<path to toolchain>/cmake/toolchain/<toolchain name>.cmake``
+
 Running a Sample Application in QEMU
 ====================================
 


### PR DESCRIPTION
Add a new optional TOOLCHAIN_ROOT cmake and environment variable to
specify an alternative location for toolchain cmake files.

When set, Zephyr will look for a toolchain cmake file located in:
${TOOLCHAIN_ROOT}/cmake/toolchain/${ZEPHYR_TOOLCHAIN_VARIANT}.cmake

Signed-off-by: François Delawarde <fnde@oticon.com>