### PR TITLE
subsys: shell: manual `*` parsing

### DIFF
--- a/subsys/shell/shell.c
+++ b/subsys/shell/shell.c
@@ -1533,11 +1533,23 @@ static void help_item_print(const struct shell *shell, const char *item_name,
 		return;
 	}
 
-	/* print option name */
-	shell_fprintf(shell, SHELL_NORMAL, "%s%-*s%s:",
-		      tabulator,
-		      item_name_width, item_name,
-		      tabulator);
+	if (!IS_ENABLED(CONFIG_NEWLIB_LIBC) && !IS_ENABLED(CONFIG_ARCH_POSIX)) {
+		/* print option name */
+		shell_fprintf(shell, SHELL_NORMAL, "%s%-*s%s:",
+			      tabulator,
+			      item_name_width, item_name,
+			      tabulator);
+	} else {
+		u16_t tmp = item_name_width - strlen(item_name);
+		char space = ' ';
+
+		shell_fprintf(shell, SHELL_NORMAL, "%s%s", tabulator,
+			      item_name);
+		for (u16_t i = 0; i < tmp; i++) {
+			shell_write(shell, &space, 1);
+		}
+		shell_fprintf(shell, SHELL_NORMAL, "%s:", tabulator);
+	}
 
 	if (item_help == NULL) {
 		cursor_next_line_move(shell);


### PR DESCRIPTION
This PR fixes: #10195.
Function _vprintk when used cannot parse '*' what as a result
causes dereferencing bad pointer.

This change is replacement for: #10299

Signed-off-by: Jakub Rzeszutko <jakub.rzeszutko@nordicsemi.no>