### PR TITLE
Shell handler returns int value

### DIFF
--- a/doc/subsystems/shell/shell.rst
+++ b/doc/subsystems/shell/shell.rst
@@ -182,7 +182,7 @@ Simple command handler implementation:
 
 .. code-block:: c
 
-	static void cmd_handler(const struct shell *shell, size_t argc,
+	static int cmd_handler(const struct shell *shell, size_t argc,
 				char **argv)
 	{
 		ARG_UNUSED(argc);
@@ -196,6 +196,8 @@ Simple command handler implementation:
 
 		shell_fprintf(shell, SHELL_ERROR,
 			      "Print error text.\r\n");
+
+		return 0;
 	}
 
 .. warning::
@@ -222,8 +224,8 @@ checks for valid arguments count.
 
 .. code-block:: c
 
-	static void cmd_dummy_1(const struct shell *shell, size_t argc,
-				char **argv)
+	static int cmd_dummy_1(const struct shell *shell, size_t argc,
+			       char **argv)
 	{
 		ARG_UNUSED(argv);
 
@@ -234,28 +236,30 @@ checks for valid arguments count.
 		 * Each of these actions can be deactivated in Kconfig.
 		 */
 		if (!shell_cmd_precheck(shell, (argc <= 2), NULL, 0) {
-			return;
+			return 0;
 		}
 
 		shell_fprintf(shell, SHELL_NORMAL,
 			      "Command called with no -h or --help option."
 			      "\r\n");
+		return 0;
 	}
 
-	static void cmd_dummy_2(const struct shell *shell, size_t argc,
-				char **argv)
+	static int cmd_dummy_2(const struct shell *shell, size_t argc,
+			       char **argv)
 	{
 		ARG_UNUSED(argc);
 		ARG_UNUSED(argv);
 
 		if (hell_help_requested(shell) {
 			shell_help_print(shell, NULL, 0);
-			return;
-		}
-
-		shell_fprintf(shell, SHELL_NORMAL,
+		} else {
+			shell_fprintf(shell, SHELL_NORMAL,
 			      "Command called with no -h or --help option."
 			      "\r\n");
+		}
+
+		return 0;
 	}
 
 Command options
@@ -271,8 +275,8 @@ in command handler.
 
 .. code-block:: c
 
-	static void cmd_with_options(const struct shell *shell, size_t argc,
-				     char **argv)
+	static int cmd_with_options(const struct shell *shell, size_t argc,
+			            char **argv)
 	{
 		/* Dummy options showing options usage */
 		static const struct shell_getopt_option opt[] = {
@@ -293,25 +297,26 @@ in command handler.
 		 */
 		if (!shell_cmd_precheck(shell, (argc <= 2), opt,
 					  sizeof(opt)/sizeof(opt[1]))) {
-			return;
+			return 0;
 		}
 
 		/* checking if command was called with test option */
 		if (!strcmp(argv[1], "-t") || !strcmp(argv[1], "--test")) {
 		    shell_fprintf(shell, SHELL_NORMAL, "Command called with -t"
 				  " or --test option.\r\n");
-		    return;
+		    return 0;
 		}
 
 		/* checking if command was called with dummy option */
 		if (!strcmp(argv[1], "-d") || !strcmp(argv[1], "--dummy")) {
 		    shell_fprintf(shell, SHELL_NORMAL, "Command called with -d"
 				  " or --dummy option.\r\n");
-		    return;
+		    return 0;
 		}
 
 		shell_fprintf(shell, SHELL_WARNING,
 			      "Command called with no valid option.\r\n");
+		return 0;
 	}
 
 Parent commands
@@ -327,8 +332,8 @@ commands or the parent commands, depending on how you index ``argv``.
 
 .. code-block:: c
 
-	static void cmd_handler(const struct shell *shell, size_t argc,
-					char **argv)
+	static int cmd_handler(const struct shell *shell, size_t argc,
+			       char **argv)
 	{
 		ARG_UNUSED(argc);
 
@@ -348,6 +353,8 @@ commands or the parent commands, depending on how you index ``argv``.
 		shell_fprintf(shell, SHELL_NORMAL,
 			      "This command has an argument: %s\r\n",
 			      argv[1]);
+
+		return 0;
 	}
 
 Built-in commands
@@ -436,17 +443,18 @@ The following code shows a simple use case of this library:
 		(void)shell_init(&uart_shell, NULL, true, true, LOG_LEVEL_INF);
 	}
 
-	static void cmd_demo_ping(const struct shell *shell, size_t argc,
-				  char **argv)
+	static int cmd_demo_ping(const struct shell *shell, size_t argc,
+				 char **argv)
 	{
 		ARG_UNUSED(argc);
 		ARG_UNUSED(argv);
 
 		shell_fprintf(shell, SHELL_NORMAL, "pong\r\n");
+		return 0;
 	}
 
-	static void cmd_demo_params(const struct shell *shell, size_t argc,
-				    char **argv)
+	static int cmd_demo_params(const struct shell *shell, size_t argc,
+				   char **argv)
 	{
 		int cnt;
 
@@ -455,6 +463,7 @@ The following code shows a simple use case of this library:
 			shell_fprintf(shell, SHELL_NORMAL,
 					"  argv[%d] = %s\r\n", cnt, argv[cnt]);
 		}
+		return 0;
 	}
 
 	/* Creating subcommands (level 1 command) array for command "demo".

--- a/include/shell/shell.h
+++ b/include/shell/shell.h
@@ -585,6 +585,20 @@ bool shell_cmd_precheck(const struct shell *shell,
 void shell_print_stream(const void *user_ctx, const char *data,
 			size_t data_len);
 
+/** @brief Execute command.
+ *
+ * Pass command line to shell to execute.
+ *
+ * Note: This by no means makes any of the commands a stable interface, so
+ * this function should only be used for debugging/diagnostic.
+ *
+ * @param[in] shell	Pointer to the shell instance.
+ * @param[in] cmd	Command to be executed.
+ *
+ * @returns Result of the execution
+ */
+int shell_execute_cmd(const struct shell *shell, const char *cmd);
+
 /**
  * @}
  */

--- a/include/shell/shell.h
+++ b/include/shell/shell.h
@@ -74,8 +74,8 @@ struct shell;
 /**
  * @brief Shell command handler prototype.
  */
-typedef void (*shell_cmd_handler)(const struct shell *shell,
-				  size_t argc, char **argv);
+typedef int (*shell_cmd_handler)(const struct shell *shell,
+				 size_t argc, char **argv);
 
 /*
  * @brief Shell static command descriptor.

--- a/samples/subsys/shell/shell_module/src/main.c
+++ b/samples/subsys/shell/shell_module/src/main.c
@@ -29,41 +29,46 @@ void timer_expired_handler(struct k_timer *timer)
 
 K_TIMER_DEFINE(log_timer, timer_expired_handler, NULL);
 
-static void cmd_log_test_start(const struct shell *shell, size_t argc,
-			       char **argv, u32_t period)
+static int cmd_log_test_start(const struct shell *shell, size_t argc,
+			      char **argv, u32_t period)
 {
 	if (!shell_cmd_precheck(shell, argc == 1, NULL, 0)) {
-		return;
+		return 0;
 	}
 
 	k_timer_start(&log_timer, period, period);
 	shell_fprintf(shell, SHELL_NORMAL, "Log test started\r\n");
+	return 0;
 }
 
-static void cmd_log_test_start_demo(const struct shell *shell, size_t argc,
-				    char **argv)
+static int cmd_log_test_start_demo(const struct shell *shell, size_t argc,
+				   char **argv)
 {
 	cmd_log_test_start(shell, argc, argv, 200);
+	return 0;
 }
 
-static void cmd_log_test_start_flood(const struct shell *shell, size_t argc,
-				     char **argv)
+static int cmd_log_test_start_flood(const struct shell *shell, size_t argc,
+				    char **argv)
 {
 	cmd_log_test_start(shell, argc, argv, 10);
+	return 0;
 }
 
-static void cmd_log_test_stop(const struct shell *shell, size_t argc,
-			      char **argv)
+static int cmd_log_test_stop(const struct shell *shell, size_t argc,
+			     char **argv)
 {
 	ARG_UNUSED(argc);
 	ARG_UNUSED(argv);
 
 	if (!shell_cmd_precheck(shell, argc == 1, NULL, 0)) {
-		return;
+		return 0;
 	}
 
 	k_timer_stop(&log_timer);
 	shell_fprintf(shell, SHELL_NORMAL, "Log test stopped\r\n");
+
+	return 0;
 }
 SHELL_CREATE_STATIC_SUBCMD_SET(sub_log_test_start)
 {
@@ -86,15 +91,17 @@ SHELL_CREATE_STATIC_SUBCMD_SET(sub_log_test)
 
 SHELL_CMD_REGISTER(log_test, &sub_log_test, "Log test", NULL);
 
-static void cmd_demo_ping(const struct shell *shell, size_t argc, char **argv)
+static int cmd_demo_ping(const struct shell *shell, size_t argc, char **argv)
 {
 	ARG_UNUSED(argc);
 	ARG_UNUSED(argv);
 
 	shell_fprintf(shell, SHELL_NORMAL, "pong\r\n");
+
+	return 0;
 }
 
-static void cmd_demo_params(const struct shell *shell, size_t argc, char **argv)
+static int cmd_demo_params(const struct shell *shell, size_t argc, char **argv)
 {
 	int cnt;
 
@@ -103,15 +110,17 @@ static void cmd_demo_params(const struct shell *shell, size_t argc, char **argv)
 		shell_fprintf(shell, SHELL_NORMAL,
 				"  argv[%d] = %s\r\n", cnt, argv[cnt]);
 	}
+	return 0;
 }
 
-static void cmd_version(const struct shell *shell, size_t argc, char **argv)
+static int cmd_version(const struct shell *shell, size_t argc, char **argv)
 {
 	ARG_UNUSED(argc);
 	ARG_UNUSED(argv);
 
 	shell_fprintf(shell, SHELL_NORMAL,
 		      "Zephyr version %s\r\n", KERNEL_VERSION_STRING);
+	return 0;
 }
 
 SHELL_CREATE_STATIC_SUBCMD_SET(sub_demo)

--- a/subsys/shell/modules/kernel_service.c
+++ b/subsys/shell/modules/kernel_service.c
@@ -13,7 +13,7 @@
 #include <misc/stack.h>
 #include <string.h>
 
-static void cmd_kernel_version(const struct shell *shell,
+static int cmd_kernel_version(const struct shell *shell,
 			      size_t argc, char **argv)
 {
 	u32_t version = sys_kernel_version_get();
@@ -25,19 +25,21 @@ static void cmd_kernel_version(const struct shell *shell,
 		      SYS_KERNEL_VER_MAJOR(version),
 		      SYS_KERNEL_VER_MINOR(version),
 		      SYS_KERNEL_VER_PATCHLEVEL(version));
+	return 0;
 }
 
-static void cmd_kernel_uptime(const struct shell *shell,
-			      size_t argc, char **argv)
+static int cmd_kernel_uptime(const struct shell *shell,
+			     size_t argc, char **argv)
 {
 	ARG_UNUSED(argc);
 	ARG_UNUSED(argv);
 
 	shell_fprintf(shell, SHELL_NORMAL, "Uptime: %u ms\r\n",
 			k_uptime_get_32());
+	return 0;
 }
 
-static void cmd_kernel_cycles(const struct shell *shell,
+static int cmd_kernel_cycles(const struct shell *shell,
 			      size_t argc, char **argv)
 {
 	ARG_UNUSED(argc);
@@ -45,6 +47,7 @@ static void cmd_kernel_cycles(const struct shell *shell,
 
 	shell_fprintf(shell, SHELL_NORMAL, "cycles: %u hw cycles\r\n",
 			k_cycle_get_32());
+	return 0;
 }
 
 #if defined(CONFIG_INIT_STACKS) && defined(CONFIG_THREAD_MONITOR) \
@@ -78,7 +81,7 @@ static void shell_tdata_dump(const struct k_thread *thread, void *user_data)
 
 }
 
-static void cmd_kernel_threads(const struct shell *shell,
+static int cmd_kernel_threads(const struct shell *shell,
 			      size_t argc, char **argv)
 {
 	ARG_UNUSED(argc);
@@ -86,6 +89,7 @@ static void cmd_kernel_threads(const struct shell *shell,
 
 	shell_fprintf(shell, SHELL_NORMAL, "Threads:\r\n");
 	k_thread_foreach(shell_tdata_dump, (void *)shell);
+	return 0;
 }
 
 static void shell_stack_dump(const struct k_thread *thread, void *user_data)
@@ -108,30 +112,33 @@ static void shell_stack_dump(const struct k_thread *thread, void *user_data)
 		      size, unused, size - unused, size, pcnt);
 }
 
-static void cmd_kernel_stacks(const struct shell *shell,
-			      size_t argc, char **argv)
+static int cmd_kernel_stacks(const struct shell *shell,
+			     size_t argc, char **argv)
 {
 	ARG_UNUSED(argc);
 	ARG_UNUSED(argv);
 	k_thread_foreach(shell_stack_dump, (void *)shell);
+	return 0;
 }
 #endif
 
 #if defined(CONFIG_REBOOT)
-static void cmd_kernel_reboot_warm(const struct shell *shell,
-				   size_t argc, char **argv)
+static int cmd_kernel_reboot_warm(const struct shell *shell,
+				  size_t argc, char **argv)
 {
 	ARG_UNUSED(argc);
 	ARG_UNUSED(argv);
 	sys_reboot(SYS_REBOOT_WARM);
+	return 0;
 }
 
-static void cmd_kernel_reboot_cold(const struct shell *shell,
-				   size_t argc, char **argv)
+static int cmd_kernel_reboot_cold(const struct shell *shell,
+				  size_t argc, char **argv)
 {
 	ARG_UNUSED(argc);
 	ARG_UNUSED(argv);
 	sys_reboot(SYS_REBOOT_COLD);
+	return 0;
 }
 
 SHELL_CREATE_STATIC_SUBCMD_SET(sub_kernel_reboot)

--- a/subsys/shell/shell.c
+++ b/subsys/shell/shell.c
@@ -1708,3 +1708,21 @@ bool shell_cmd_precheck(const struct shell *shell,
 
 	return true;
 }
+
+int shell_execute_cmd(const struct shell *shell, const char *cmd)
+{
+	u16_t cmd_len = shell_strlen(cmd);
+
+	if ((cmd == NULL) || (shell == NULL)) {
+		return -ENOEXEC;
+	}
+
+	if (cmd_len > (CONFIG_SHELL_CMD_BUFF_SIZE - 1)) {
+		return -ENOEXEC;
+	}
+
+	strcpy(shell->ctx->cmd_buff, cmd);
+	shell->ctx->cmd_buff_len = cmd_len;
+
+	return shell_execute(shell);
+}

--- a/subsys/shell/shell_cmds.c
+++ b/subsys/shell/shell_cmds.c
@@ -177,127 +177,137 @@ static int terminal_size_get(const struct shell *shell)
 	}
 
 	cursor_restore(shell);
-
 	return ret_val;
 }
 
-static void cmd_clear(const struct shell *shell, size_t argc, char **argv)
+static int cmd_clear(const struct shell *shell, size_t argc, char **argv)
 {
 	(void)argv;
 
 	if ((argc == 2) && (shell_help_requested(shell))) {
 		shell_help_print(shell, NULL, 0);
-		return;
+		return 0;
 	}
 	SHELL_VT100_CMD(shell, SHELL_VT100_CURSORHOME);
 	SHELL_VT100_CMD(shell, SHELL_VT100_CLEARSCREEN);
+	return 0;
 }
 
-static void cmd_shell(const struct shell *shell, size_t argc, char **argv)
+static int cmd_shell(const struct shell *shell, size_t argc, char **argv)
 {
 	(void)argv;
 
 	if ((argc == 1) || ((argc == 2) && shell_help_requested(shell))) {
 		shell_help_print(shell, NULL, 0);
-		return;
+		return 0;
 	}
 
 	shell_fprintf(shell, SHELL_ERROR, SHELL_MSG_SPECIFY_SUBCOMMAND);
+	return 0;
 }
 
-static void cmd_bacskpace_mode(const struct shell *shell, size_t argc,
+static int cmd_bacskpace_mode(const struct shell *shell, size_t argc,
 			       char **argv)
 {
 	(void)shell_cmd_precheck(shell, (argc == 2), NULL, 0);
+	return 0;
 }
 
-static void cmd_bacskpace_mode_backspace(const struct shell *shell, size_t argc,
+static int cmd_bacskpace_mode_backspace(const struct shell *shell, size_t argc,
 					 char **argv)
 {
 	if (!shell_cmd_precheck(shell, (argc == 1), NULL, 0)) {
-		return;
+		return 0;
 	}
 
 	shell->ctx->internal.flags.mode_delete = 0;
+	return 0;
 }
 
-static void cmd_bacskpace_mode_delete(const struct shell *shell, size_t argc,
+static int cmd_bacskpace_mode_delete(const struct shell *shell, size_t argc,
 				      char **argv)
 {
 	if (!shell_cmd_precheck(shell, (argc == 1), NULL, 0)) {
-		return;
+		return 0;
 	}
 
 	shell->ctx->internal.flags.mode_delete = 1;
+	return 0;
 }
 
-static void cmd_colors_off(const struct shell *shell, size_t argc, char **argv)
+static int cmd_colors_off(const struct shell *shell, size_t argc, char **argv)
 {
 	if (!shell_cmd_precheck(shell, (argc == 1), NULL, 0)) {
-		return;
+		return 0;
 	}
 
 	shell->ctx->internal.flags.use_colors = 0;
+	return 0;
 }
 
-static void cmd_colors_on(const struct shell *shell, size_t argc, char **argv)
+static int cmd_colors_on(const struct shell *shell, size_t argc, char **argv)
 {
 	if (!shell_cmd_precheck(shell, (argc == 1), NULL, 0)) {
-		return;
+		return 0;
 	}
 	shell->ctx->internal.flags.use_colors = 1;
+	return 0;
 }
 
-static void cmd_colors(const struct shell *shell, size_t argc, char **argv)
+static int cmd_colors(const struct shell *shell, size_t argc, char **argv)
 {
 	if (argc == 1) {
 		shell_help_print(shell, NULL, 0);
-		return;
+		return 0;
 	}
 
 	if (!shell_cmd_precheck(shell, (argc == 2), NULL, 0)) {
-		return;
+		return 0;
 	}
 
 	shell_fprintf(shell, SHELL_ERROR, "%s:%s%s\r\n", argv[0],
 		      SHELL_MSG_UNKNOWN_PARAMETER, argv[1]);
+	return -ENOEXEC;
 }
 
-static void cmd_echo(const struct shell *shell, size_t argc, char **argv)
+static int cmd_echo(const struct shell *shell, size_t argc, char **argv)
 {
 	if (!shell_cmd_precheck(shell, (argc <= 2), NULL, 0)) {
-		return;
+		return 0;
 	}
 
 	if (argc == 2) {
 		shell_fprintf(shell, SHELL_ERROR, "%s:%s%s\r\n", argv[0],
 			      SHELL_MSG_UNKNOWN_PARAMETER, argv[1]);
-		return;
+		return -ENOEXEC;
 	}
 
 	shell_fprintf(shell, SHELL_NORMAL, "Echo status: %s\r\n",
 		      flag_echo_is_set(shell) ? "on" : "off");
+	return 0;
 }
 
-static void cmd_echo_off(const struct shell *shell, size_t argc, char **argv)
+static int cmd_echo_off(const struct shell *shell, size_t argc, char **argv)
 {
 	if (!shell_cmd_precheck(shell, (argc == 1), NULL, 0)) {
-		return;
+		return 0;
 	}
 
 	shell->ctx->internal.flags.echo = 0;
+	return 0;
 }
 
-static void cmd_echo_on(const struct shell *shell, size_t argc, char **argv)
+static int cmd_echo_on(const struct shell *shell, size_t argc, char **argv)
 {
 	if (!shell_cmd_precheck(shell, (argc == 1), NULL, 0)) {
-		return;
+		return 0;
 	}
 
 	shell->ctx->internal.flags.echo = 1;
+	return 0;
 }
 
-static void cmd_help(const struct shell *shell, size_t argc, char **argv)
+static int cmd_help(const struct shell *shell, size_t argc, char **argv)
 {
 	shell_fprintf(shell, SHELL_NORMAL, "Please press the <Tab> button to "
 					   "see all available commands.\r\n"
@@ -307,21 +317,21 @@ static void cmd_help(const struct shell *shell, size_t argc, char **argv)
 					   "You can try to call commands "
 					   "with <-h> or <--help> parameter to "
 					   "get know what they are doing.\r\n");
-
+	return 0;
 }
 
-static void cmd_history(const struct shell *shell, size_t argc, char **argv)
+static int cmd_history(const struct shell *shell, size_t argc, char **argv)
 {
 	size_t i = 0;
 	size_t len;
 
 	if (!IS_ENABLED(CONFIG_SHELL_HISTORY)) {
 		shell_fprintf(shell, SHELL_ERROR, "Command not supported.\r\n");
-		return;
+		return -ENOEXEC;
 	}
 
 	if (!shell_cmd_precheck(shell, (argc == 1), NULL, 0)) {
-		return;
+		return 0;
 	}
 
 	while (1) {
@@ -338,84 +348,89 @@ static void cmd_history(const struct shell *shell, size_t argc, char **argv)
 	}
 
 	shell->ctx->temp_buff[0] = '\0';
+	return 0;
 }
 
-static void cmd_shell_stats(const struct shell *shell, size_t argc, char **argv)
+static int cmd_shell_stats(const struct shell *shell, size_t argc, char **argv)
 {
 	if (argc == 1) {
 		shell_help_print(shell, NULL, 0);
-		return;
+		return 0;
 	}
 
 	if (argc == 2) {
 		shell_fprintf(shell, SHELL_ERROR, "%s:%s%s\r\n", argv[0],
 			      SHELL_MSG_UNKNOWN_PARAMETER, argv[1]);
-		return;
+		return -ENOEXEC;
 	}
 
 	(void)shell_cmd_precheck(shell, (argc <= 2), NULL, 0);
+	return 0;
 }
 
-static void cmd_shell_stats_show(const struct shell *shell, size_t argc,
-			       char **argv)
+static int cmd_shell_stats_show(const struct shell *shell, size_t argc,
+				char **argv)
 {
 	if (!IS_ENABLED(CONFIG_SHELL_STATS)) {
 		shell_fprintf(shell, SHELL_ERROR, "Command not supported.\r\n");
-		return;
+		return -ENOEXEC;
 	}
 
 	if (!shell_cmd_precheck(shell, (argc == 1), NULL, 0)) {
-		return;
+		return 0;
 	}
 
 	shell_fprintf(shell, SHELL_NORMAL, "Lost logs: %u\r\n",
 		      shell->stats->log_lost_cnt);
+	return 0;
 }
 
-static void cmd_shell_stats_reset(const struct shell *shell,
-				size_t argc, char **argv)
+static int cmd_shell_stats_reset(const struct shell *shell,
+				 size_t argc, char **argv)
 {
 	if (!IS_ENABLED(CONFIG_SHELL_STATS)) {
 		shell_fprintf(shell, SHELL_ERROR, "Command not supported.\r\n");
-		return;
+		return -ENOEXEC;
 	}
 
 	if (!shell_cmd_precheck(shell, (argc == 1), NULL, 0)) {
-		return;
+		return 0;
 	}
 
 	shell->stats->log_lost_cnt = 0;
+	return 0;
 }
 
-static void cmd_resize_default(const struct shell *shell,
-				     size_t argc, char **argv)
+static int cmd_resize_default(const struct shell *shell,
+			      size_t argc, char **argv)
 {
 	if (!shell_cmd_precheck(shell, (argc == 1), NULL, 0)) {
-		return;
+		return 0;
 	}
 
 	SHELL_VT100_CMD(shell, SHELL_VT100_SETCOL_80);
 	shell->ctx->vt100_ctx.cons.terminal_wid = SHELL_DEFAULT_TERMINAL_WIDTH;
 	shell->ctx->vt100_ctx.cons.terminal_hei = SHELL_DEFAULT_TERMINAL_HEIGHT;
+	return 0;
 }
 
-static void cmd_resize(const struct shell *shell, size_t argc, char **argv)
+static int cmd_resize(const struct shell *shell, size_t argc, char **argv)
 {
 	int err;
 
 	if (!IS_ENABLED(CONFIG_SHELL_CMDS_RESIZE)) {
 		shell_fprintf(shell, SHELL_ERROR, "Command not supported.\r\n");
-		return;
+		return -ENOEXEC;
 	}
 
 	if (!shell_cmd_precheck(shell, (argc <= 2), NULL, 0)) {
-		return;
+		return 0;
 	}
 
 	if (argc != 1) {
 		shell_fprintf(shell, SHELL_ERROR, "%s:%s%s\r\n", argv[0],
 			      SHELL_MSG_UNKNOWN_PARAMETER, argv[1]);
-		return;
+		return -ENOEXEC;
 	}
 
 	err = terminal_size_get(shell);
@@ -428,6 +443,7 @@ static void cmd_resize(const struct shell *shell, size_t argc, char **argv)
 			      "No response from the terminal, assumed 80x24 "
 			      "screen size\r\n");
 	}
+	return 0;
 }
 
 /* Warning!

--- a/tests/bluetooth/shell/src/main.c
+++ b/tests/bluetooth/shell/src/main.c
@@ -34,11 +34,11 @@ SHELL_DEFINE(uart_shell, "uart:~$ ", &shell_transport_uart, '\r', 10);
 #if defined(CONFIG_BT_CONN)
 static bool hrs_simulate;
 
-static void cmd_hrs_simulate(const struct shell *shell,
-			     size_t argc, char *argv[])
+static int cmd_hrs_simulate(const struct shell *shell,
+			    size_t argc, char *argv[])
 {
 	if (!shell_cmd_precheck(shell, (argc == 2), NULL, 0)) {
-		return;
+		return 0;
 	}
 
 	if (!strcmp(argv[1], "on")) {
@@ -58,8 +58,10 @@ static void cmd_hrs_simulate(const struct shell *shell,
 	} else {
 		printk("Incorrect value: %s\n", argv[1]);
 		shell_help_print(shell, NULL, 0);
-		return;
+		return -ENOEXEC;
 	}
+
+	return 0;
 }
 #endif /* CONFIG_BT_CONN */
 
@@ -75,19 +77,21 @@ SHELL_CREATE_STATIC_SUBCMD_SET(hrs_cmds) {
 	SHELL_SUBCMD_SET_END
 };
 
-static void cmd_hrs(const struct shell *shell, size_t argc, char **argv)
+static int cmd_hrs(const struct shell *shell, size_t argc, char **argv)
 {
 	if (argc == 1) {
 		shell_help_print(shell, NULL, 0);
-		return;
+		return 0;
 	}
 
 	if (!shell_cmd_precheck(shell, (argc == 2), NULL, 0)) {
-		return;
+		return 0;
 	}
 
 	shell_fprintf(shell, SHELL_ERROR, "%s:%s%s\r\n", argv[0],
 		      "unknown parameter: ", argv[1]);
+
+	return -ENOEXEC;
 }
 
 SHELL_CMD_REGISTER(hrs, &hrs_cmds, "Heart Rate Service shell commands",


### PR DESCRIPTION
Shell handler can now return an int value. This gives an opportunity to check if command has been executed successfully. It will allow to write tests for modules using shell commands. 

This change is needed to make new shell backward compatible with legacy shell.