### PR TITLE
soc: sam4s: added missing devices in sam4s range

### DIFF
--- a/boards/arm/sam4s_xplained/sam4s_xplained.dts
+++ b/boards/arm/sam4s_xplained/sam4s_xplained.dts
@@ -5,7 +5,7 @@
 
 /dts-v1/;
 
-#include <atmel/sam4s.dtsi>
+#include <atmel/sam4s16c.dtsi>
 
 / {
 	model = "Atmel SAM4S Xplained Board with an Atmel SAM4S16C SoC";

--- a/dts/arm/atmel/sam4s.dtsi
+++ b/dts/arm/atmel/sam4s.dtsi
@@ -22,13 +22,11 @@
 	sram0: memory@20100000 {
 		device_type = "memory";
 		compatible = "mmio-sram";
-		reg = <0x20100000 0x20000>;
 	};
 
 	flash0: flash@400000 {
 		compatible = "soc-nv-flash";
 		label = "FLASH_0";
-		reg = <0x00400000 0x100000>;
 	};
 
 	soc {

--- a/dts/arm/atmel/sam4s16b.dtsi
+++ b/dts/arm/atmel/sam4s16b.dtsi
@@ -1,0 +1,18 @@
+/*
+ * Copyright (c) 2018 Vincent van der Locht
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <mem.h>
+#include <atmel/sam4s.dtsi>
+
+/ {
+	flash0: flash@400000 {
+		reg = <0x00400000 DT_SIZE_K(1024)>;
+	};
+
+	sram0: memory@20100000 {
+		reg = <0x20100000 DT_SIZE_K(128)>;
+	};
+};

--- a/dts/arm/atmel/sam4s16c.dtsi
+++ b/dts/arm/atmel/sam4s16c.dtsi
@@ -1,0 +1,18 @@
+/*
+ * Copyright (c) 2018 Vincent van der Locht
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <mem.h>
+#include <atmel/sam4s.dtsi>
+
+/ {
+	flash0: flash@400000 {
+		reg = <0x00400000 DT_SIZE_K(1024)>;
+	};
+
+	sram0: memory@20100000 {
+		reg = <0x20100000 DT_SIZE_K(128)>;
+	};
+};

--- a/dts/arm/atmel/sam4s2a.dtsi
+++ b/dts/arm/atmel/sam4s2a.dtsi
@@ -1,0 +1,18 @@
+/*
+ * Copyright (c) 2018 Vincent van der Locht
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <mem.h>
+#include <atmel/sam4s.dtsi>
+
+/ {
+	flash0: flash@400000 {
+		reg = <0x00400000 DT_SIZE_K(128)>;
+	};
+
+	sram0: memory@20100000 {
+		reg = <0x20100000 DT_SIZE_K(64)>;
+	};
+};

--- a/dts/arm/atmel/sam4s2b.dtsi
+++ b/dts/arm/atmel/sam4s2b.dtsi
@@ -1,0 +1,18 @@
+/*
+ * Copyright (c) 2018 Vincent van der Locht
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <mem.h>
+#include <atmel/sam4s.dtsi>
+
+/ {
+	flash0: flash@400000 {
+		reg = <0x00400000 DT_SIZE_K(128)>;
+	};
+
+	sram0: memory@20100000 {
+		reg = <0x20100000 DT_SIZE_K(64)>;
+	};
+};

--- a/dts/arm/atmel/sam4s2c.dtsi
+++ b/dts/arm/atmel/sam4s2c.dtsi
@@ -1,0 +1,18 @@
+/*
+ * Copyright (c) 2018 Vincent van der Locht
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <mem.h>
+#include <atmel/sam4s.dtsi>
+
+/ {
+	flash0: flash@400000 {
+		reg = <0x00400000 DT_SIZE_K(128)>;
+	};
+
+	sram0: memory@20100000 {
+		reg = <0x20100000 DT_SIZE_K(64)>;
+	};
+};

--- a/dts/arm/atmel/sam4s4a.dtsi
+++ b/dts/arm/atmel/sam4s4a.dtsi
@@ -1,0 +1,18 @@
+/*
+ * Copyright (c) 2018 Vincent van der Locht
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <mem.h>
+#include <atmel/sam4s.dtsi>
+
+/ {
+	flash0: flash@400000 {
+		reg = <0x00400000 DT_SIZE_K(256)>;
+	};
+
+	sram0: memory@20100000 {
+		reg = <0x20100000 DT_SIZE_K(64)>;
+	};
+};

--- a/dts/arm/atmel/sam4s4b.dtsi
+++ b/dts/arm/atmel/sam4s4b.dtsi
@@ -1,0 +1,18 @@
+/*
+ * Copyright (c) 2018 Vincent van der Locht
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <mem.h>
+#include <atmel/sam4s.dtsi>
+
+/ {
+	flash0: flash@400000 {
+		reg = <0x00400000 DT_SIZE_K(356)>;
+	};
+
+	sram0: memory@20100000 {
+		reg = <0x20100000 DT_SIZE_K(64)>;
+	};
+};

--- a/dts/arm/atmel/sam4s4c.dtsi
+++ b/dts/arm/atmel/sam4s4c.dtsi
@@ -1,0 +1,18 @@
+/*
+ * Copyright (c) 2018 Vincent van der Locht
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <mem.h>
+#include <atmel/sam4s.dtsi>
+
+/ {
+	flash0: flash@400000 {
+		reg = <0x00400000 DT_SIZE_K(256)>;
+	};
+
+	sram0: memory@20100000 {
+		reg = <0x20100000 DT_SIZE_K(64)>;
+	};
+};

--- a/dts/arm/atmel/sam4s8b.dtsi
+++ b/dts/arm/atmel/sam4s8b.dtsi
@@ -1,0 +1,18 @@
+/*
+ * Copyright (c) 2018 Vincent van der Locht
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <mem.h>
+#include <atmel/sam4s.dtsi>
+
+/ {
+	flash0: flash@400000 {
+		reg = <0x00400000 DT_SIZE_K(512)>;
+	};
+
+	sram0: memory@20100000 {
+		reg = <0x20100000 DT_SIZE_K(128)>;
+	};
+};

--- a/dts/arm/atmel/sam4s8c.dtsi
+++ b/dts/arm/atmel/sam4s8c.dtsi
@@ -1,0 +1,18 @@
+/*
+ * Copyright (c) 2018 Vincent van der Locht
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <mem.h>
+#include <atmel/sam4s.dtsi>
+
+/ {
+	flash0: flash@400000 {
+		reg = <0x00400000 DT_SIZE_K(512)>;
+	};
+
+	sram0: memory@20100000 {
+		reg = <0x20100000 DT_SIZE_K(128)>;
+	};
+};

--- a/soc/arm/atmel_sam/sam4s/Kconfig.defconfig.series
+++ b/soc/arm/atmel_sam/sam4s/Kconfig.defconfig.series
@@ -1,6 +1,7 @@
 # Kconfig - Atmel SAM4S MCU series configuration options
 #
 # Copyright (c) 2017 Justin Watson
+# Copyright (c) 2018 Vincent van der Locht
 #
 # SPDX-License-Identifier: Apache-2.0
 #
@@ -14,6 +15,15 @@ config SOC_SERIES
 config SOC_PART_NUMBER
 	string
 	default "sam4s16c" if SOC_PART_NUMBER_SAM4S16C
+	default "sam4s16b" if SOC_PART_NUMBER_SAM4S16B
+	default "sam4s8c" if SOC_PART_NUMBER_SAM4S8C
+	default "sam4s8b" if SOC_PART_NUMBER_SAM4S8B
+	default "sam4s4c" if SOC_PART_NUMBER_SAM4S4C
+	default "sam4s4b" if SOC_PART_NUMBER_SAM4S4B
+	default "sam4s4a" if SOC_PART_NUMBER_SAM4S4A
+	default "sam4s2c" if SOC_PART_NUMBER_SAM4S2C
+	default "sam4s2b" if SOC_PART_NUMBER_SAM4S2B
+	default "sam4s2a" if SOC_PART_NUMBER_SAM4S2A
 
 #
 # SAM4S family has total 35 peripherals capable of

--- a/soc/arm/atmel_sam/sam4s/Kconfig.series
+++ b/soc/arm/atmel_sam/sam4s/Kconfig.series
@@ -1,6 +1,7 @@
 # Kconfig - Atmel SAM4S MCU series
 #
 # Copyright (c) 2017 Justin Watson
+# Copyright (c) 2018 Vincent van der Locht
 #
 # SPDX-License-Identifier: Apache-2.0
 #
@@ -14,4 +15,5 @@ config SOC_SERIES_SAM4S
 	select ASF
 	help
 	  Enable support for Atmel SAM4S Cortex-M4 microcontrollers.
-	  Part No.: SAM4S16C
+	  Part No.: SAM4S16C, SAM4S16B, SAM4S8C, SAM4S8B,
+	  SAM4S4C, SAM4S4B, SAM4S4A, SAM4S2C, SAM4S2B, SAM4S2A

--- a/soc/arm/atmel_sam/sam4s/Kconfig.soc
+++ b/soc/arm/atmel_sam/sam4s/Kconfig.soc
@@ -1,6 +1,7 @@
 # Kconfig - Atmel SAM4S MCU series
 #
 # Copyright (c) 2017 Justin Watson
+# Copyright (c) 2018 Vincent van der Locht
 #
 # SPDX-License-Identifier: Apache-2.0
 #
@@ -11,6 +12,37 @@ choice
 
 	config SOC_PART_NUMBER_SAM4S16C
 		bool "SAM4S16C"
+
+	config SOC_PART_NUMBER_SAM4S16C
+		bool "SAM4S16C"
+
+	config SOC_PART_NUMBER_SAM4S16B
+		bool "SAM4S16B"
+
+	config SOC_PART_NUMBER_SAM4S8C
+		bool "SAM4S8C"
+
+	config SOC_PART_NUMBER_SAM4S8B
+		bool "SAM4S8B"
+
+	config SOC_PART_NUMBER_SAM4S4C
+		bool "SAM4S4C"
+
+	config SOC_PART_NUMBER_SAM4S4B
+		bool "SAM4S4B"
+
+	config SOC_PART_NUMBER_SAM4S4A
+		bool "SAM4S4A"
+
+	config SOC_PART_NUMBER_SAM4S2C
+		bool "SAM4S2C"
+
+	config SOC_PART_NUMBER_SAM4S2B
+		bool "SAM4S2B"
+
+	config SOC_PART_NUMBER_SAM4S2A
+		bool "SAM4S2A"
+
 endchoice
 
 if SOC_SERIES_SAM4S

--- a/soc/arm/atmel_sam/sam4s/soc.h
+++ b/soc/arm/atmel_sam/sam4s/soc.h
@@ -1,4 +1,5 @@
 /*
+ * Copyright (c) 2018 Vincent van der Locht
  * Copyright (c) 2017 Justin Watson
  * Copyright (c) 2016 Intel Corporation.
  * Copyright (c) 2013-2015 Wind River Systems, Inc.
@@ -21,6 +22,24 @@
 
 #if defined(CONFIG_SOC_PART_NUMBER_SAM4S16C)
 #include <sam4s16c.h>
+#elif defined(CONFIG_SOC_PART_NUMBER_SAM4S16B)
+#include <sam4s16b.h>
+#elif defined(CONFIG_SOC_PART_NUMBER_SAM4S8C)
+#include <sam4s8c.h>
+#elif defined(CONFIG_SOC_PART_NUMBER_SAM4S18B)
+#include <sam4s8b.h>
+#elif defined(CONFIG_SOC_PART_NUMBER_SAM4S4C)
+#include <sam4s4c.h>
+#elif defined(CONFIG_SOC_PART_NUMBER_SAM4S4B)
+#include <sam4s4b.h>
+#elif defined(CONFIG_SOC_PART_NUMBER_SAM4S4A)
+#include <sam4s4a.h>
+#elif defined(CONFIG_SOC_PART_NUMBER_SAM4S2C)
+#include <sam4s2c.h>
+#elif defined(CONFIG_SOC_PART_NUMBER_SAM4S2B)
+#include <sam4s2b.h>
+#elif defined(CONFIG_SOC_PART_NUMBER_SAM4S2A)
+#include <sam4s2a.h>
 #else
 #error Library does not support the specified device.
 #endif


### PR DESCRIPTION
added sam4s16b, sam4s8c, sam4s8b, sam4s4c, sam4s4b,
sam4s4a, sam4s2c, sam4s2b and sam4s2a.
Used the same order as in the data sheet and code structure
equal to same70. Updated the sam4s_xplained board to match
the altered .dtsi location of the specific SoC.

Signed-off-by: Vincent van der Locht <vincent@vlotech.nl>