### PR TITLE
Shell fix cr or lf as line delimiter

### DIFF
--- a/doc/subsystems/shell/shell.rst
+++ b/doc/subsystems/shell/shell.rst
@@ -425,8 +425,6 @@ Usage
 *****
 
 Use the :c:macro:`SHELL_DEFINE` macro to create an instance of the shell.
-Pass the expected newline character to this macro: either ``\r`` or ``\n``,
-otherwise the shell will not respond correctly to the :kbd:`Enter` key.
 
 The following code shows a simple use case of this library:
 
@@ -436,7 +434,7 @@ The following code shows a simple use case of this library:
 	SHELL_UART_DEFINE(shell_transport_uart);
 
 	/* Creating shell instance */
-	SHELL_DEFINE(uart_shell, "uart:~$ ", &shell_transport_uart, '\r', 10);
+	SHELL_DEFINE(uart_shell, "uart:~$ ", &shell_transport_uart, 10);
 
 	void main(void)
 	{

--- a/include/shell/shell.h
+++ b/include/shell/shell.h
@@ -365,9 +365,6 @@ struct shell {
 
 	LOG_INSTANCE_PTR_DECLARE(log);
 
-	/*!< New line character, only allowed values: \\n and \\r.*/
-	const char newline_char;
-
 	struct k_thread *thread;
 	k_thread_stack_t *stack;
 };
@@ -378,12 +375,10 @@ struct shell {
  * @param[in] _name             Instance name.
  * @param[in] _prompt           Shell prompt string.
  * @param[in] transport_iface   Pointer to the transport interface.
- * @param[in] newline_ch        New line character - only allowed values are
- *				'\\n' or '\\r'.
  * @param[in] log_queue_size    Logger processing queue size.
  */
 #define SHELL_DEFINE(_name, _prompt, transport_iface,			     \
-		  newline_ch, log_queue_size)				     \
+		     log_queue_size)					     \
 	static const struct shell _name;				     \
 	static struct shell_ctx UTIL_CAT(_name, _ctx);			     \
 	static char _name##prompt[CONFIG_SHELL_PROMPT_LENGTH + 1] = _prompt; \
@@ -407,7 +402,6 @@ struct shell {
 		.stats = SHELL_STATS_PTR(_name),			     \
 		.log_backend = SHELL_LOG_BACKEND_PTR(_name),		     \
 		LOG_INSTANCE_PTR_INIT(log, shell, _name)		     \
-		.newline_char = newline_ch,				     \
 		.thread = &_name##_thread,				     \
 		.stack = _name##_stack					     \
 	}

--- a/samples/subsys/shell/shell_module/src/main.c
+++ b/samples/subsys/shell/shell_module/src/main.c
@@ -15,7 +15,7 @@
 LOG_MODULE_REGISTER(app);
 
 SHELL_UART_DEFINE(shell_transport_uart);
-SHELL_DEFINE(uart_shell, "uart:~$ ", &shell_transport_uart, '\r', 10);
+SHELL_DEFINE(uart_shell, "uart:~$ ", &shell_transport_uart, 10);
 
 extern void foo(void);
 

--- a/subsys/shell/shell.c
+++ b/subsys/shell/shell.c
@@ -759,8 +759,7 @@ static void shell_state_collect(const struct shell *shell)
 
 		switch (shell->ctx->receive_state) {
 		case SHELL_RECEIVE_DEFAULT:
-			if (data == shell->newline_char) {
-
+			if ((data == '\r') || (data == '\n')) {
 				if (!shell->ctx->cmd_buff_len) {
 					history_mode_exit(shell);
 					cursor_next_line_move(shell);
@@ -1150,8 +1149,6 @@ static int shell_instance_init(const struct shell *shell, const void *p_config,
 {
 	__ASSERT_NO_MSG(shell);
 	__ASSERT_NO_MSG(shell->ctx && shell->iface && shell->prompt);
-	__ASSERT_NO_MSG((shell->newline_char == '\n') ||
-			(shell->newline_char == '\r'));
 
 	int err;
 

--- a/tests/bluetooth/shell/src/main.c
+++ b/tests/bluetooth/shell/src/main.c
@@ -29,7 +29,7 @@
 #define DEVICE_NAME CONFIG_BT_DEVICE_NAME
 
 SHELL_UART_DEFINE(shell_transport_uart);
-SHELL_DEFINE(uart_shell, "uart:~$ ", &shell_transport_uart, '\r', 10);
+SHELL_DEFINE(uart_shell, "uart:~$ ", &shell_transport_uart, 10);
 
 #if defined(CONFIG_BT_CONN)
 static bool hrs_simulate;


### PR DESCRIPTION
Shell macro `SHELL_DEFINE` no longer needs new_line character as an input parameter. Shell accepts both: `\r` and `\n` as a as line delimiter.

Fixes: #10207.