### PR TITLE
Bluetooth: controller: Fix default Tx buffers

### DIFF
--- a/subsys/bluetooth/controller/Kconfig
+++ b/subsys/bluetooth/controller/Kconfig
@@ -91,7 +91,7 @@ config BT_CTLR_RX_BUFFERS
 config BT_CTLR_TX_BUFFERS
 	int "Number of Tx buffers"
 	default 7 if BT_HCI_RAW
-	default 2
+	default 3
 	range 1 19
 	help
 	  Set the number of Tx PDUs to be queued for transmission in the


### PR DESCRIPTION
Fix the default Tx buffers to 3. While the first Tx-ed
buffer generates the HCI Number of Completed Packets Event,
the controller needs to have 2 additional Tx buffers queued
so that the second Tx PDU has the More Data (MD) bit set so
as to have the connection event to continue to transmit any
additional Tx buffers that the Host will enqueue in the same
connection event.

Signed-off-by: Vinayak Kariappa Chettimada <vich@nordicsemi.no>