### PR TITLE
logging: Make log_strdup() parameter const

### DIFF
--- a/include/logging/log.h
+++ b/include/logging/log.h
@@ -267,7 +267,7 @@ int log_printk(const char *fmt, va_list ap);
  *	   allocated. String may be truncated if input string does not fit in
  *	   a buffer from the pool (see CONFIG_LOG_STRDUP_MAX_STRING).
  */
-char *log_strdup(char *str);
+char *log_strdup(const char *str);
 
 #define __DYNAMIC_MODULE_REGISTER(_name)\
 	struct log_source_dynamic_data LOG_ITEM_DYNAMIC_DATA(_name)	\

--- a/subsys/logging/log_core.c
+++ b/subsys/logging/log_core.c
@@ -500,7 +500,7 @@ u32_t log_filter_get(struct log_backend const *const backend,
 	}
 }
 
-char *log_strdup(char *str)
+char *log_strdup(const char *str)
 {
 	u32_t *dupl;
 	char *sdupl;


### PR DESCRIPTION
The string parameter needs to be const as otherwise calling this
function using a const string pointer will lead to a warning.
Besides the function does not modify the parameter so should be
const anyway.

Signed-off-by: Jukka Rissanen <jukka.rissanen@linux.intel.com>