### PR TITLE
dt: Fix DTC warning

### DIFF
--- a/boards/arm/96b_argonkey/96b_argonkey.dts
+++ b/boards/arm/96b_argonkey/96b_argonkey.dts
@@ -19,11 +19,11 @@
 
 	leds {
 		compatible = "gpio-leds";
-		green_led_0: led@0 {
+		green_led_0: led_0 {
 			gpios = <&gpioc 13 GPIO_INT_ACTIVE_HIGH>;
 			label = "USR0 LED";
 		};
-		green_led_1: led@1 {
+		green_led_1: led_1 {
 			gpios = <&gpiob 2 GPIO_INT_ACTIVE_HIGH>;
 			label = "USR1 LED";
 		};

--- a/boards/arm/colibri_imx7d_m4/colibri_imx7d_m4.dts
+++ b/boards/arm/colibri_imx7d_m4/colibri_imx7d_m4.dts
@@ -32,7 +32,7 @@
 
 	leds {
 		compatible = "gpio-leds";
-		green_led: led@0 {
+		green_led: led_0 {
 			gpios = <&gpio1 2 GPIO_INT_ACTIVE_LOW>;
 			label = "User LED1";
 		};

--- a/boards/arm/frdm_k64f/frdm_k64f.dts
+++ b/boards/arm/frdm_k64f/frdm_k64f.dts
@@ -47,15 +47,15 @@
 
 	leds {
 		compatible = "gpio-leds";
-		red_led: led@0 {
+		red_led: led_0 {
 			gpios = <&gpiob 22 0>;
 			label = "User LD1";
 		};
-		green_led: led@1 {
+		green_led: led_1 {
 			gpios = <&gpioe 26 0>;
 			label = "User LD2";
 		};
-		blue_led: led@2 {
+		blue_led: led_2 {
 			gpios = <&gpiob 21 0>;
 			label = "User LD3";
 		};

--- a/boards/arm/frdm_kl25z/frdm_kl25z.dts
+++ b/boards/arm/frdm_kl25z/frdm_kl25z.dts
@@ -31,15 +31,15 @@
 
 	leds {
 		compatible = "gpio-leds";
-		red_led: led@0 {
+		red_led: led_0 {
 			gpios = <&gpiob 18 0>;
 			label = "User LD1";
 		};
-		green_led: led@1 {
+		green_led: led_1 {
 			gpios = <&gpiob 19 0>;
 			label = "User LD2";
 		};
-		blue_led: led@2 {
+		blue_led: led_2 {
 			gpios = <&gpiod 1 0>;
 			label = "User LD3";
 		};

--- a/boards/arm/frdm_kw41z/frdm_kw41z.dts
+++ b/boards/arm/frdm_kw41z/frdm_kw41z.dts
@@ -33,15 +33,15 @@
 
 	leds {
 		compatible = "gpio-leds";
-		red_led: led@0 {
+		red_led: led_0 {
 			gpios = <&gpioc 1 0>;
 			label = "User LD1";
 		};
-		green_led: led@1 {
+		green_led: led_1 {
 			gpios = <&gpioa 19 0>;
 			label = "User LD2";
 		};
-		blue_led: led@2 {
+		blue_led: led_2 {
 			gpios = <&gpioa 18 0>;
 			label = "User LD3";
 		};

--- a/boards/arm/hexiwear_k64/hexiwear_k64.dts
+++ b/boards/arm/hexiwear_k64/hexiwear_k64.dts
@@ -44,15 +44,15 @@
 
 	leds {
 		compatible = "gpio-leds";
-		red_led: led@0 {
+		red_led: led_0 {
 			gpios = <&gpioc 8 0>;
 			label = "User LD1";
 		};
-		green_led: led@1 {
+		green_led: led_1 {
 			gpios = <&gpiod 0 0>;
 			label = "User LD2";
 		};
-		blue_led: led@2 {
+		blue_led: led_2 {
 			gpios = <&gpioc 9 0>;
 			label = "User LD3";
 		};

--- a/boards/arm/lpcxpresso54114_m0/lpcxpresso54114_m0.dts
+++ b/boards/arm/lpcxpresso54114_m0/lpcxpresso54114_m0.dts
@@ -28,15 +28,15 @@
 
 	leds {
 		compatible = "gpio-leds";
-		red_led: led@0 {
+		red_led: led_0 {
 			gpios = <&gpio0 29 0>;
 			label = "User LD1";
 		};
-		green_led: led@1 {
+		green_led: led_1 {
 			gpios = <&gpio1 10 0>;
 			label = "User LD2";
 		};
-		blue_led: led@2 {
+		blue_led: led_2 {
 			gpios = <&gpio1 9 0>;
 			label = "User LD3";
 		};

--- a/boards/arm/lpcxpresso54114_m4/lpcxpresso54114_m4.dts
+++ b/boards/arm/lpcxpresso54114_m4/lpcxpresso54114_m4.dts
@@ -28,15 +28,15 @@
 
 	leds {
 		compatible = "gpio-leds";
-		red_led: led@0 {
+		red_led: led_0 {
 			gpios = <&gpio0 29 0>;
 			label = "User LD1";
 		};
-		green_led: led@1 {
+		green_led: led_1 {
 			gpios = <&gpio1 10 0>;
 			label = "User LD2";
 		};
-		blue_led: led@2 {
+		blue_led: led_2 {
 			gpios = <&gpio1 9 0>;
 			label = "User LD3";
 		};

--- a/boards/arm/mimxrt1050_evk/mimxrt1050_evk.dts
+++ b/boards/arm/mimxrt1050_evk/mimxrt1050_evk.dts
@@ -48,7 +48,7 @@
 
 	leds {
 		compatible = "gpio-leds";
-		green_led: led@0 {
+		green_led: led_0 {
 			gpios = <&gpio1 9 0>;
 			label = "User LD1";
 		};

--- a/boards/arm/nrf51_pca10028/nrf51_pca10028.dts
+++ b/boards/arm/nrf51_pca10028/nrf51_pca10028.dts
@@ -23,19 +23,19 @@
 
 	leds {
 		compatible = "gpio-leds";
-		led0: led@0 {
+		led0: led_0 {
 			gpios = <&gpio0 21 GPIO_INT_ACTIVE_LOW>;
 			label = "Green LED 0";
 		};
-		led1: led@1 {
+		led1: led_1 {
 			gpios = <&gpio0 22 GPIO_INT_ACTIVE_LOW>;
 			label = "Green LED 1";
 		};
-		led2: led@2 {
+		led2: led_2 {
 			gpios = <&gpio0 23 GPIO_INT_ACTIVE_LOW>;
 			label = "Green LED 2";
 		};
-		led3: led@3 {
+		led3: led_3 {
 			gpios = <&gpio0 24 GPIO_INT_ACTIVE_LOW>;
 			label = "Green LED 3";
 		};

--- a/boards/arm/nrf52810_pca10040/nrf52810_pca10040.dts
+++ b/boards/arm/nrf52810_pca10040/nrf52810_pca10040.dts
@@ -25,19 +25,19 @@
 
 	leds {
 		compatible = "gpio-leds";
-		led0: led@0 {
+		led0: led_0 {
 			gpios = <&gpio0 17 GPIO_INT_ACTIVE_LOW>;
 			label = "Green LED 0";
 		};
-		led1: led@1 {
+		led1: led_1 {
 			gpios = <&gpio0 18 GPIO_INT_ACTIVE_LOW>;
 			label = "Green LED 1";
 		};
-		led2: led@2 {
+		led2: led_2 {
 			gpios = <&gpio0 19 GPIO_INT_ACTIVE_LOW>;
 			label = "Green LED 2";
 		};
-		led3: led@3 {
+		led3: led_3 {
 			gpios = <&gpio0 20 GPIO_INT_ACTIVE_LOW>;
 			label = "Green LED 3";
 		};

--- a/boards/arm/nrf52840_pca10056/nrf52840_pca10056.dts
+++ b/boards/arm/nrf52840_pca10056/nrf52840_pca10056.dts
@@ -23,19 +23,19 @@
 
 	leds {
 		compatible = "gpio-leds";
-		led0: led@0 {
+		led0: led_0 {
 			gpios = <&gpio0 13 GPIO_INT_ACTIVE_LOW>;
 			label = "Green LED 0";
 		};
-		led1: led@1 {
+		led1: led_1 {
 			gpios = <&gpio0 14 GPIO_INT_ACTIVE_LOW>;
 			label = "Green LED 1";
 		};
-		led2: led@2 {
+		led2: led_2 {
 			gpios = <&gpio0 15 GPIO_INT_ACTIVE_LOW>;
 			label = "Green LED 2";
 		};
-		led3: led@3 {
+		led3: led_3 {
 			gpios = <&gpio0 16 GPIO_INT_ACTIVE_LOW>;
 			label = "Green LED 3";
 		};
@@ -43,19 +43,19 @@
 
 	buttons {
 		compatible = "gpio-keys";
-		button0: button@0 {
+		button0: button_0 {
 			gpios = <&gpio0 11 GPIO_PUD_PULL_UP>;
 			label = "Push button switch 0";
 		};
-		button1: button@1 {
+		button1: button_1 {
 			gpios = <&gpio0 12 GPIO_PUD_PULL_UP>;
 			label = "Push button switch 1";
 		};
-		button2: button@2 {
+		button2: button_2 {
 			gpios = <&gpio0 24 GPIO_PUD_PULL_UP>;
 			label = "Push button switch 2";
 		};
-		button3: button@3 {
+		button3: button_3 {
 			gpios = <&gpio0 25 GPIO_PUD_PULL_UP>;
 			label = "Push button switch 3";
 		};

--- a/boards/arm/nrf52840_pca10059/nrf52840_pca10059.dts
+++ b/boards/arm/nrf52840_pca10059/nrf52840_pca10059.dts
@@ -24,19 +24,19 @@
 
 	leds {
 		compatible = "gpio-leds";
-		led0_green: led@0 {
+		led0_green: led_0 {
 			gpios = <&gpio0 6 GPIO_INT_ACTIVE_LOW>;
 			label = "Green LED 0";
 		};
-		led1_red: led@1 {
+		led1_red: led_1 {
 			gpios = <&gpio0 8 GPIO_INT_ACTIVE_LOW>;
 			label = "Red LED 1";
 		};
-		led1_green: led@2 {
+		led1_green: led_2 {
 			gpios = <&gpio1 9 GPIO_INT_ACTIVE_LOW>;
 			label = "Green LED 1";
 		};
-		led1_blue: led@3 {
+		led1_blue: led_3 {
 			gpios = <&gpio0 12 GPIO_INT_ACTIVE_LOW>;
 			label = "Blue LED 1";
 		};

--- a/boards/arm/nrf52_pca10040/nrf52_pca10040.dts
+++ b/boards/arm/nrf52_pca10040/nrf52_pca10040.dts
@@ -24,19 +24,19 @@
 
 	leds {
 		compatible = "gpio-leds";
-		led0: led@0 {
+		led0: led_0 {
 			gpios = <&gpio0 17 GPIO_INT_ACTIVE_LOW>;
 			label = "Green LED 0";
 		};
-		led1: led@1 {
+		led1: led_1 {
 			gpios = <&gpio0 18 GPIO_INT_ACTIVE_LOW>;
 			label = "Green LED 1";
 		};
-		led2: led@2 {
+		led2: led_2 {
 			gpios = <&gpio0 19 GPIO_INT_ACTIVE_LOW>;
 			label = "Green LED 2";
 		};
-		led3: led@3 {
+		led3: led_3 {
 			gpios = <&gpio0 20 GPIO_INT_ACTIVE_LOW>;
 			label = "Green LED 3";
 		};

--- a/boards/arm/nucleo_l432kc/nucleo_l432kc.dts
+++ b/boards/arm/nucleo_l432kc/nucleo_l432kc.dts
@@ -19,7 +19,7 @@
 
 	leds {
 		compatible = "gpio-leds";
-		green_led: led@0 {
+		green_led: led_0 {
 			gpios = <&gpiob 3 GPIO_INT_ACTIVE_HIGH>;
 			label = "User LD3";
 		};

--- a/boards/arm/reel_board/reel_board.dts
+++ b/boards/arm/reel_board/reel_board.dts
@@ -24,19 +24,19 @@
 
 	leds {
 		compatible = "gpio-leds";
-		yellow_led: led@0 {
+		yellow_led: led_0 {
 			gpios = <&gpio0 13 0>;
 			label = "User D13";
 		};
-		red_led: led@1 {
+		red_led: led_1 {
 			gpios = <&gpio0 11 0>;
 			label = "User D3 red";
 		};
-		green_led: led@2 {
+		green_led: led_2 {
 			gpios = <&gpio0 12 0>;
 			label = "User D3 green";
 		};
-		blue_led: led@3 {
+		blue_led: led_3 {
 			gpios = <&gpio1 9 0>;
 			label = "User D3 blue";
 		};

--- a/boards/arm/udoo_neo_full_m4/udoo_neo_full_m4.dts
+++ b/boards/arm/udoo_neo_full_m4/udoo_neo_full_m4.dts
@@ -46,7 +46,7 @@
 
 	leds {
 		compatible = "gpio-leds";
-		red_led: led@0 {
+		red_led: led_0 {
 			gpios = <&gpio4 6 0>;
 			label = "User LD1";
 		};

--- a/boards/arm/usb_kw24d512/usb_kw24d512.dts
+++ b/boards/arm/usb_kw24d512/usb_kw24d512.dts
@@ -33,11 +33,11 @@
 
 	leds {
 		compatible = "gpio-leds";
-		led_0: led@0 {
+		led_0: led_0 {
 			gpios = <&gpiod 4 0>;
 			label = "User LD1";
 		};
-		led_1: led@1 {
+		led_1: led_1 {
 			gpios = <&gpiod 5 0>;
 			label = "User LD2";
 		};


### PR DESCRIPTION
DTC is triggering the warning: "Node has a unit name, but no reg
property".

Signed-off-by: Sebastian Bøe <sebastian.boe@nordicsemi.no>