### PR TITLE
bluetooth: host: conn: Add const attribute to addr in bt_le_set_auto_…

### DIFF
--- a/include/bluetooth/conn.h
+++ b/include/bluetooth/conn.h
@@ -209,7 +209,7 @@ struct bt_conn *bt_conn_create_le(const bt_addr_le_t *peer,
  *
  *  @return Zero on success or error code otherwise.
  */
-int bt_le_set_auto_conn(bt_addr_le_t *addr,
+int bt_le_set_auto_conn(const bt_addr_le_t *addr,
 			const struct bt_le_conn_param *param);
 
 /** @brief Initiate directed advertising to a remote device

--- a/subsys/bluetooth/host/conn.c
+++ b/subsys/bluetooth/host/conn.c
@@ -1933,7 +1933,7 @@ struct bt_conn *bt_conn_create_le(const bt_addr_le_t *peer,
 	return conn;
 }
 
-int bt_le_set_auto_conn(bt_addr_le_t *addr,
+int bt_le_set_auto_conn(const bt_addr_le_t *addr,
 			const struct bt_le_conn_param *param)
 {
 	struct bt_conn *conn;


### PR DESCRIPTION
…conn

This commit adds missed const modifier for addr pointer for
bt_le_set_auto_conn function

Signed-off-by: Radoslaw Koppel <radoslaw.koppel@nordicsemi.no>