### PR TITLE
gpio: remove unused GPIO_INT_CLOCK_SYNC flag

### DIFF
--- a/drivers/gpio/gpio_cc2650.c
+++ b/drivers/gpio/gpio_cc2650.c
@@ -139,11 +139,6 @@ static int gpio_cc2650_config_pin(int pin, int flags)
 			iocfg_config |= CC2650_IOC_NEG_AND_POS_EDGE_DET;
 		}
 
-		if (flags & GPIO_INT_CLOCK_SYNC) {
-			/* Don't commit changes */
-			return -ENOTSUP;
-		}
-
 		if (flags & GPIO_INT_DEBOUNCE) {
 			iocfg_config |= CC2650_IOC_HYSTERESIS_ENABLED;
 		} else {

--- a/include/dt-bindings/gpio/gpio.h
+++ b/include/dt-bindings/gpio/gpio.h
@@ -40,9 +40,6 @@
 /** GPIO pin trigger on level high or rising edge. */
 #define GPIO_INT_ACTIVE_HIGH	(1 << 2)
 
-/** GPIO pin trigger to be synchronized to clock pulses. */
-#define GPIO_INT_CLOCK_SYNC     (1 << 3)
-
 /** Enable GPIO pin debounce. */
 #define GPIO_INT_DEBOUNCE       (1 << 4)
 


### PR DESCRIPTION
GPIO_INT_CLOCK_SYNC wasn't implemented by anything, so remove it.

Signed-off-by: Kumar Gala <kumar.gala@linaro.org>