### PR TITLE
kernel: Fix problem introduced in 92ea2f9

### DIFF
--- a/kernel/include/syscall_handler.h
+++ b/kernel/include/syscall_handler.h
@@ -351,9 +351,9 @@ bool z_syscall_verify_msg(bool expr, const char *fmt, ...)
 #define Z_SYSCALL_MEMORY_ARRAY(ptr, nmemb, size, write) \
 	({ \
 		u32_t product; \
-		Z_SYSCALL_VERIFY_MSG(__builtin_umul_overflow((u32_t)(nmemb), \
+		Z_SYSCALL_VERIFY_MSG(!__builtin_umul_overflow((u32_t)(nmemb), \
 							      (u32_t)(size), \
-							      &product) == 0,\
+							      &product), \
 				     "%ux%u array is too large", \
 				     (u32_t)(nmemb), (u32_t)(size)) ||  \
 			Z_SYSCALL_MEMORY(ptr, product, write); \

--- a/kernel/poll.c
+++ b/kernel/poll.c
@@ -259,9 +259,9 @@ Z_SYSCALL_HANDLER(k_poll, events, num_events, timeout)
 		goto out;
 	}
 	if (Z_SYSCALL_VERIFY_MSG(
-		__builtin_umul_overflow(num_events,
+		!__builtin_umul_overflow(num_events,
 					sizeof(struct k_poll_event),
-					&bounds) == 0,
+					&bounds),
 					"num_events too large")) {
 		ret = -EINVAL;
 		goto out;

--- a/kernel/thread.c
+++ b/kernel/thread.c
@@ -463,9 +463,9 @@ Z_SYSCALL_HANDLER(k_thread_create,
 	 * size and not allocated in addition to the stack size
 	 */
 	guard_size = (u32_t)K_THREAD_STACK_BUFFER(stack) - (u32_t)stack;
-	Z_OOPS(Z_SYSCALL_VERIFY_MSG(__builtin_uadd_overflow(guard_size,
+	Z_OOPS(Z_SYSCALL_VERIFY_MSG(!__builtin_uadd_overflow(guard_size,
 							     stack_size,
-							     &total_size) == 0,
+							     &total_size),
 				    "stack size overflow (%u+%u)", stack_size,
 				    guard_size));
 #else


### PR DESCRIPTION
The builtin function __builtin_umul_overflow returns a boolean and
should not checked as an integer.

Signed-off-by: Flavio Ceolin <flavio.ceolin@intel.com>