### PR TITLE
cmake: openamp: Fixed a bug where the wrong BOARD was set

### DIFF
--- a/samples/subsys/ipc/ipm_mcux/CMakeLists.txt
+++ b/samples/subsys/ipc/ipm_mcux/CMakeLists.txt
@@ -14,6 +14,8 @@ ExternalProject_Add(
   SOURCE_DIR ${APPLICATION_SOURCE_DIR}/remote
   INSTALL_COMMAND ""      # This particular build system has no install command
   BUILD_BYPRODUCTS "${CMAKE_CURRENT_BINARY_DIR}/ipm_mcux_remote-prefix/src/ipm_mcux_remote-build/zephyr/zephyr.bin"
+  CMAKE_CACHE_ARGS -DBOARD:STRING=${BOARD}
+  # NB: Do we need to pass on more CMake variables?
 )
 
 project(NONE)

--- a/samples/subsys/ipc/openamp/CMakeLists.txt
+++ b/samples/subsys/ipc/openamp/CMakeLists.txt
@@ -25,6 +25,8 @@ ExternalProject_Add(
   SOURCE_DIR ${APPLICATION_SOURCE_DIR}/remote
   INSTALL_COMMAND ""      # This particular build system has no install command
   BUILD_BYPRODUCTS "${CMAKE_CURRENT_BINARY_DIR}/openamp_remote-prefix/src/openamp_remote-build/zephyr/zephyr.bin"
+  CMAKE_CACHE_ARGS -DBOARD:STRING=${BOARD}
+  # NB: Do we need to pass on more CMake variables?
 )
 add_dependencies(core_m0_inc_target openamp_remote)
 


### PR DESCRIPTION
Fixed a bug in the OpenAMP sample's recursive build scripts, where it
would pass on the wrong board to it's second CMake invocation.

This fixes #10345

Fixed the same bug in ipm_mcux.

Signed-off-by: Sebastian Bøe <sebastian.boe@nordicsemi.no>