### PR TITLE
Permanently fix a dtc warning

### DIFF
--- a/boards/arm/96b_neonkey/96b_neonkey.dts
+++ b/boards/arm/96b_neonkey/96b_neonkey.dts
@@ -39,7 +39,7 @@
 
 	gpio_keys {
 		compatible = "gpio-keys";
-		user_button: button@0 {
+		user_button: button_0 {
 			label = "User";
 			gpios = <&gpiob 2 GPIO_INT_ACTIVE_LOW>;
 		};

--- a/boards/arm/disco_l475_iot1/disco_l475_iot1.dts
+++ b/boards/arm/disco_l475_iot1/disco_l475_iot1.dts
@@ -31,7 +31,7 @@
 
 	gpio_keys {
 		compatible = "gpio-keys";
-		user_button: button@0 {
+		user_button: button_0 {
 			label = "User";
 			gpios = <&gpioc 13 GPIO_INT_ACTIVE_LOW>;
 		};

--- a/boards/arm/frdm_k64f/frdm_k64f.dts
+++ b/boards/arm/frdm_k64f/frdm_k64f.dts
@@ -63,11 +63,11 @@
 
 	gpio_keys {
 		compatible = "gpio-keys";
-		user_button_2: button@0 {
+		user_button_2: button_0 {
 			label = "User SW2";
 			gpios = <&gpioc 6 GPIO_INT_ACTIVE_LOW>;
 		};
-		user_button_3: button@1 {
+		user_button_3: button_1 {
 			label = "User SW3";
 			gpios = <&gpioa 4 GPIO_INT_ACTIVE_LOW>;
 		};

--- a/boards/arm/frdm_kl25z/frdm_kl25z.dts
+++ b/boards/arm/frdm_kl25z/frdm_kl25z.dts
@@ -47,11 +47,11 @@
 
 	gpio_keys {
 		compatible = "gpio-keys";
-		user_button_0: button@0 {
+		user_button_0: button_0 {
 			label = "User SW0";
 			gpios = <&gpioa 16 GPIO_INT_ACTIVE_LOW>;
 		};
-		user_button_1: button@1 {
+		user_button_1: button_1 {
 			label = "User SW1";
 			gpios = <&gpioa 17 GPIO_INT_ACTIVE_LOW>;
 		};

--- a/boards/arm/frdm_kw41z/frdm_kw41z.dts
+++ b/boards/arm/frdm_kw41z/frdm_kw41z.dts
@@ -49,11 +49,11 @@
 
 	gpio_keys {
 		compatible = "gpio-keys";
-		user_button_3: button@0 {
+		user_button_3: button_0 {
 			label = "User SW3";
 			gpios = <&gpioc 4 GPIO_INT_ACTIVE_LOW>;
 		};
-		user_button_4: button@1 {
+		user_button_4: button_1 {
 			label = "User SW4";
 			gpios = <&gpioc 5 GPIO_INT_ACTIVE_LOW>;
 		};

--- a/boards/arm/mimxrt1050_evk/mimxrt1050_evk.dts
+++ b/boards/arm/mimxrt1050_evk/mimxrt1050_evk.dts
@@ -56,7 +56,7 @@
 
 	gpio_keys {
 		compatible = "gpio-keys";
-		user_button: button@0 {
+		user_button: button_0 {
 			label = "User SW8";
 			gpios = <&gpio5 0 GPIO_INT_ACTIVE_LOW>;
 		};

--- a/boards/arm/nrf51_pca10028/nrf51_pca10028.dts
+++ b/boards/arm/nrf51_pca10028/nrf51_pca10028.dts
@@ -43,19 +43,19 @@
 
 	buttons {
 		compatible = "gpio-keys";
-		button0: button@0 {
+		button0: button_0 {
 			gpios = <&gpio0 17 GPIO_PUD_PULL_UP>;
 			label = "Push button switch 0";
 		};
-		button1: button@1 {
+		button1: button_1 {
 			gpios = <&gpio0 18 GPIO_PUD_PULL_UP>;
 			label = "Push button switch 1";
 		};
-		button2: button@2 {
+		button2: button_2 {
 			gpios = <&gpio0 19 GPIO_PUD_PULL_UP>;
 			label = "Push button switch 2";
 		};
-		button3: button@3 {
+		button3: button_3 {
 			gpios = <&gpio0 20 GPIO_PUD_PULL_UP>;
 			label = "Push button switch 3";
 		};

--- a/boards/arm/nrf52810_pca10040/nrf52810_pca10040.dts
+++ b/boards/arm/nrf52810_pca10040/nrf52810_pca10040.dts
@@ -45,19 +45,19 @@
 
 	gpio_keys {
 		compatible = "gpio-keys";
-		button0: button@0 {
+		button0: button_0 {
 			label = "Push button switch 0";
 			gpios = <&gpio0 13 GPIO_PUD_PULL_UP>;
 		};
-		button1: button@1 {
+		button1: button_1 {
 			label = "Push button switch 1";
 			gpios = <&gpio0 14 GPIO_PUD_PULL_UP>;
 		};
-		button2: button@2 {
+		button2: button_2 {
 			label = "Push button switch 2";
 			gpios = <&gpio0 15 GPIO_PUD_PULL_UP>;
 		};
-		button3: button@3 {
+		button3: button_3 {
 			label = "Push button switch 3";
 			gpios = <&gpio0 16 GPIO_PUD_PULL_UP>;
 		};

--- a/boards/arm/nrf52840_pca10059/nrf52840_pca10059.dts
+++ b/boards/arm/nrf52840_pca10059/nrf52840_pca10059.dts
@@ -44,7 +44,7 @@
 
 	buttons {
 		compatible = "gpio-keys";
-		button0: button@0 {
+		button0: button_0 {
 			gpios = <&gpio1 6 GPIO_PUD_PULL_UP>;
 			label = "Push button switch 0";
 		};

--- a/boards/arm/nrf52_pca10040/nrf52_pca10040.dts
+++ b/boards/arm/nrf52_pca10040/nrf52_pca10040.dts
@@ -44,19 +44,19 @@
 
 	buttons {
 		compatible = "gpio-keys";
-		button0: button@0 {
+		button0: button_0 {
 			gpios = <&gpio0 13 GPIO_PUD_PULL_UP>;
 			label = "Push button switch 0";
 		};
-		button1: button@1 {
+		button1: button_1 {
 			gpios = <&gpio0 14 GPIO_PUD_PULL_UP>;
 			label = "Push button switch 1";
 		};
-		button2: button@2 {
+		button2: button_2 {
 			gpios = <&gpio0 15 GPIO_PUD_PULL_UP>;
 			label = "Push button switch 2";
 		};
-		button3: button@3 {
+		button3: button_3 {
 			gpios = <&gpio0 16 GPIO_PUD_PULL_UP>;
 			label = "Push button switch 3";
 		};

--- a/boards/arm/reel_board/reel_board.dts
+++ b/boards/arm/reel_board/reel_board.dts
@@ -44,7 +44,7 @@
 
 	gpio_keys {
 		compatible = "gpio-keys";
-		user_button: button@0 {
+		user_button: button_0 {
 			gpios = <&gpio0 7 GPIO_PUD_PULL_UP>;
 			label = "User Button";
 		};

--- a/boards/arm/usb_kw24d512/usb_kw24d512.dts
+++ b/boards/arm/usb_kw24d512/usb_kw24d512.dts
@@ -45,7 +45,7 @@
 
 	gpio_keys {
 		compatible = "gpio-keys";
-		user_button_1: button@0 {
+		user_button_1: button_0 {
 			label = "User SW1";
 			gpios = <&gpioc 4 GPIO_INT_ACTIVE_LOW>;
 		};

--- a/cmake/dts.cmake
+++ b/cmake/dts.cmake
@@ -111,8 +111,8 @@ if(CONFIG_HAS_DTS)
     -O dts
     -o ${BOARD}.dts_compiled
     -b 0
-	${EXTRA_DTC_FLAGS} # User settable
     -E unit_address_vs_reg
+    ${EXTRA_DTC_FLAGS} # User settable
     ${BOARD}.dts.pre.tmp
     WORKING_DIRECTORY ${PROJECT_BINARY_DIR}
     RESULT_VARIABLE ret

--- a/cmake/dts.cmake
+++ b/cmake/dts.cmake
@@ -111,6 +111,8 @@ if(CONFIG_HAS_DTS)
     -O dts
     -o ${BOARD}.dts_compiled
     -b 0
+	${EXTRA_DTC_FLAGS} # User settable
+    -E unit_address_vs_reg
     ${BOARD}.dts.pre.tmp
     WORKING_DIRECTORY ${PROJECT_BINARY_DIR}
     RESULT_VARIABLE ret


### PR DESCRIPTION
Permanently fix the 'unit_address_vs_reg' warning by;

1. fixing the remaining offenders
2. turning the warning into an error
3. Allowing users to enable/disable DTC warnings (in case out-of-tree DTS should not be modified).