### PR TITLE
doc: usb: Move generated api to the right place

### DIFF
--- a/doc/api/api.rst
+++ b/doc/api/api.rst
@@ -28,3 +28,4 @@ The Zephyr APIs are used the same way on all SoCs and boards.
    misc_api
    logger_api
    shell_api
+   usb_api

--- a/doc/api/usb_api.rst
+++ b/doc/api/usb_api.rst
@@ -1,0 +1,21 @@
+.. _usb_api:
+
+USB subsystem API
+#################
+
+.. contents::
+   :depth: 2
+   :local:
+   :backlinks: top
+
+USB Device Controller API
+*************************
+
+.. doxygengroup:: _usb_device_controller_api
+   :project: Zephyr
+
+USB Device Core Layer API
+*************************
+
+.. doxygengroup:: _usb_device_core_api
+   :project: Zephyr

--- a/doc/subsystems/usb/usb.rst
+++ b/doc/subsystems/usb/usb.rst
@@ -31,13 +31,6 @@ to deal directly with the hardware. All device controller drivers should
 implement the APIs described in file usb_dc.h. This allows the integration of
 new USB device controllers to be done without changing the upper layers.
 
-.. _usb_device_controller_api:
-
-USB Device Controller API
-=========================
-.. doxygengroup:: _usb_device_controller_api
-   :project: Zephyr
-
 USB device core layer
 *********************
 
@@ -54,11 +47,6 @@ functionalities:
      customer applications. The APIs are described in the usb_device.h file.
    * Uses the APIs provided by the device controller drivers to interact with
      the USB device controller.
-
-USB Device Core Layer API
-=========================
-.. doxygengroup:: _usb_device_core_api
-   :project: Zephyr
 
 USB device class drivers
 ************************
@@ -326,4 +314,13 @@ USB transaction(s), depending endpoint max packet size. The class driver does
 not have to implement endpoint callback and should set this callback to the
 generic usb_transfer_ep_callback.
 
+Further reading
+***************
 
+More information on the stack and its usage can be found in the following
+subsections:
+
+.. toctree::
+   :maxdepth: 2
+
+   ../../api/usb_api.rst

--- a/doc/subsystems/usb/usb.rst
+++ b/doc/subsystems/usb/usb.rst
@@ -3,10 +3,10 @@
 USB device stack
 ################
 
-The USB device stack is split into three layers:
-   * `USB device controller drivers`_ (hardware dependent)
-   * `USB device core layer`_ (hardware independent)
-   * `USB device class drivers`_ (hardware independent)
+.. contents::
+   :depth: 2
+   :local:
+   :backlinks: top
 
 USB Vendor and Product identifiers
 **********************************


### PR DESCRIPTION
Move USB API to the right place.

Signed-off-by: Andrei Emeltchenko <andrei.emeltchenko@intel.com>