### PR TITLE
ext: lib: mgmt: mcumgr: update to latest master

### DIFF
--- a/ext/lib/mgmt/mcumgr/cmd/img_mgmt/src/img_mgmt.c
+++ b/ext/lib/mgmt/mcumgr/cmd/img_mgmt/src/img_mgmt.c
@@ -232,6 +232,11 @@ img_mgmt_erase(struct mgmt_ctxt *ctxt)
     CborError err;
     int rc;
 
+    if (img_mgmt_slot_in_use(1)) {
+        /* No free slot. */
+        return MGMT_ERR_EBADSTATE;
+    }
+
     rc = img_mgmt_impl_erase_slot();
 
     err = 0;


### PR DESCRIPTION
This patch introduce version which fixes following bug:

It was possible to erase slot 1 while it stores confirmed image
while ongoing test run - this is unwanted behavior which allow
to even brick remote device accidentally.
This patch add check for such case of test run etc.
This also aligns condition required for erase command
execution to similar as upload command requires.

Origin: mcumgr
License: Apache 2.0
URL: https://github.com/apache/mynewt-mcumgr
Commit: 91a76b95b1b81aba06e30ee168e5ee5975cdfe93
Purpose: Bug Fix
Maintained-by: External

Signed-off-by: Andrzej Puzdrowski andrzej.puzdrowski@nordicsemi.no