### PR TITLE
drivers: sensor: lsm6dsl: Fix missing LSM6DSL_DEV_NAME in Kconfig

### DIFF
--- a/drivers/sensor/lsm6dsl/Kconfig
+++ b/drivers/sensor/lsm6dsl/Kconfig
@@ -16,6 +16,10 @@ menuconfig LSM6DSL
 
 if LSM6DSL
 
+config LSM6DSL_DEV_NAME
+	string "LSM6DSL device name"
+	default "LSM6DSL"
+
 choice LSM6DSL_BUS_TYPE
 	prompt "Interface to AP"
 	help


### PR DESCRIPTION
LSM6DSL_DEV_NAME definition was deleted by mistake, but it is
necessary to correctly build this sensor driver.

Signed-off-by: Armando Visconti <armando.visconti@st.com>