### PR TITLE
tests: Bluetooth: shell: Whitelist nrf52840_pca10056

### DIFF
--- a/tests/bluetooth/shell/testcase.yaml
+++ b/tests/bluetooth/shell/testcase.yaml
@@ -3,6 +3,7 @@ tests:
     extra_configs:
       - CONFIG_NATIVE_UART_0_ON_STDINOUT=y
     platform_whitelist: qemu_cortex_m3 qemu_x86 arduino_101 native_posix
+                        nrf52840_pca10056
     platform_exclude: nrf52810_pca10040
     tags: bluetooth
     harness: keyboard


### PR DESCRIPTION
In order to fully cover the platform that supports most of the optional
features in the specification, whitelist the nRF52840 DK.

Signed-off-by: Carles Cufi <carles.cufi@nordicsemi.no>