### PR TITLE
boards: atmel: Enable gpio in board.yaml

### DIFF
--- a/boards/arm/sam4s_xplained/sam4s_xplained.yaml
+++ b/boards/arm/sam4s_xplained/sam4s_xplained.yaml
@@ -5,3 +5,5 @@ arch: arm
 toolchain:
   - zephyr
   - gnuarmemb
+supported:
+  - gpio

--- a/boards/arm/sam_e70_xplained/sam_e70_xplained.yaml
+++ b/boards/arm/sam_e70_xplained/sam_e70_xplained.yaml
@@ -8,3 +8,4 @@ toolchain:
 supported:
   - netif:eth
   - adc
+  - gpio


### PR DESCRIPTION
List gpio as a support feature of the sam4s_xplained & sam_e70_xplained
boards.

Signed-off-by: Kumar Gala <kumar.gala@linaro.org>