### PR TITLE
doc: addition of a code of conduct

### DIFF
--- a/CODE_OF_CONDUCT.rst
+++ b/CODE_OF_CONDUCT.rst
@@ -1,0 +1,76 @@
+Contributor Covenant Code of Conduct
+####################################
+
+Our Pledge
+**********
+
+In the interest of fostering an open and welcoming environment, we as
+contributors and maintainers pledge to making participation in our
+project and our community a harassment-free experience for everyone,
+regardless of age, body size, disability, ethnicity, gender identity and
+expression, level of experience, nationality, personal appearance, race,
+religion, or sexual identity and orientation.
+
+Also refer to our
+`Zephyr project community guidelines
+<https://www.zephyrproject.org/developers/how-to-contribute/#community-guidelines>`__
+
+Our Standards
+*************
+
+Examples of behavior that contribute to creating a positive environment include:
+
+* Using welcoming and inclusive language
+* Being respectful of differing viewpoints and experiences
+* Gracefully accepting constructive criticism
+* Focusing on what is best for the community
+* Showing empathy towards other community members
+
+Examples of unacceptable behavior by participants include:
+
+* The use of sexualized language or imagery and unwelcome sexual attention
+  or advances
+* Trolling, insulting/derogatory comments, and personal or political attacks
+* Public or private harassment
+* Publishing others' private information, such as a physical or
+  electronic address, without explicit permission
+* Other conduct which could reasonably be considered inappropriate in a
+  professional setting
+
+Our Responsibilities
+********************
+
+Project maintainers are responsible for clarifying the standards of
+acceptable behavior and are expected to take appropriate and fair
+corrective action in response to any instances of unacceptable behavior.
+
+Project maintainers have the right and responsibility to remove, edit,
+or reject comments, commits, code, wiki edits, issues, and other
+contributions that are not aligned to this Code of Conduct, or to ban
+temporarily or permanently any contributor for other behaviors that they
+deem inappropriate, threatening, offensive, or harmful.
+
+Scope
+*****
+
+This Code of Conduct applies both within project spaces and in public
+spaces when an individual is representing the project or its community.
+Examples of representing a project or community include using an
+official project e-mail address, posting via an official social media
+account, or acting as an appointed representative at an online or
+offline event. Representation of a project may be further defined and
+clarified by project maintainers and `project governing bodies
+<https://www.zephyrproject.org/about/organization/>`__
+
+Reporting
+*********
+
+We strive to maintain a respectful and professional environment in the Zephyr
+Community. If you experience or witness Code of Conduct violations and wish to
+report the incident please contact us at info@zephyrproject.org.  
+
+Attribution
+***********
+
+This Code of Conduct is adapted from the `Contributor
+Covenant version 1.4 <http://contributor-covenant.org/version/1/4/>`__

--- a/CODE_OF_CONDUCT.rst
+++ b/CODE_OF_CONDUCT.rst
@@ -62,15 +62,25 @@ offline event. Representation of a project may be further defined and
 clarified by project maintainers and `project governing bodies
 <https://www.zephyrproject.org/about/organization/>`__
 
-Reporting
-*********
+## Enforcement
 
-We strive to maintain a respectful and professional environment in the Zephyr
-Community. If you experience or witness Code of Conduct violations and wish to
-report the incident please contact us at report@zephyrproject.org.
+Instances of abusive, harassing, or otherwise unacceptable behavior may be
+reported by contacting the project team at [INSERT EMAIL ADDRESS]. All
+complaints will be reviewed and investigated and will result in a response that
+is deemed necessary and appropriate to the circumstances. The project team is
+obligated to maintain confidentiality with regard to the reporter of an incident.
+Further details of specific enforcement policies may be posted separately.
 
-Attribution
-***********
+Project maintainers who do not follow or enforce the Code of Conduct in good
+faith may face temporary or permanent repercussions as determined by other
+members of the project's leadership.
 
-This Code of Conduct is adapted from the `Contributor
-Covenant version 1.4 <http://contributor-covenant.org/version/1/4/>`__
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage], version 1.4,
+available at https://www.contributor-covenant.org/version/1/4/code-of-conduct.html
+
+[homepage]: https://www.contributor-covenant.org
+
+For answers to common questions about this code of conduct, see
+https://www.contributor-covenant.org/faq

--- a/CODE_OF_CONDUCT.rst
+++ b/CODE_OF_CONDUCT.rst
@@ -67,7 +67,7 @@ Reporting
 
 We strive to maintain a respectful and professional environment in the Zephyr
 Community. If you experience or witness Code of Conduct violations and wish to
-report the incident please contact us at info@zephyrproject.org.  
+report the incident please contact us at report@zephyrproject.org.
 
 Attribution
 ***********

--- a/CODE_OF_CONDUCT.rst
+++ b/CODE_OF_CONDUCT.rst
@@ -65,11 +65,13 @@ clarified by project maintainers and `project governing bodies
 ## Enforcement
 
 Instances of abusive, harassing, or otherwise unacceptable behavior may be
-reported by contacting the project team at [INSERT EMAIL ADDRESS]. All
-complaints will be reviewed and investigated and will result in a response that
-is deemed necessary and appropriate to the circumstances. The project team is
-obligated to maintain confidentiality with regard to the reporter of an incident.
-Further details of specific enforcement policies may be posted separately.
+reported by contacting the project team at conduct@zephyrproject.org.
+Reports will be received by Kate Stewart (Linux Foundation) and Amy Occhialino
+(Intel). All complaints will be reviewed and investigated and will result in
+a response that is deemed necessary and appropriate to the circumstances.
+The project team is obligated to maintain confidentiality with regard to
+the reporter of an incident. Further details of specific enforcement
+policies may be posted separately.
 
 Project maintainers who do not follow or enforce the Code of Conduct in good
 faith may face temporary or permanent repercussions as determined by other


### PR DESCRIPTION
This change adds a Code of Conduct based on
https://www.contributor-covenant.org/. Additional reporting and
enforcement guidelines will be added at a later date.

Signed-off-by: Thea Aldrich <aldrich.thea@gmail.com>