### PR TITLE
samples: USB mass storage sample.yaml cleanup

### DIFF
--- a/samples/subsys/usb/mass/overlay-flash-disk.conf
+++ b/samples/subsys/usb/mass/overlay-flash-disk.conf
@@ -1,0 +1,4 @@
+# config to disk access over SPI flash
+CONFIG_DISK_ACCESS_FLASH=y
+CONFIG_MASS_STORAGE_DISK_NAME="NAND"
+CONFIG_SPI=y

--- a/samples/subsys/usb/mass/overlay-ram-disk.conf
+++ b/samples/subsys/usb/mass/overlay-ram-disk.conf
@@ -1,0 +1,3 @@
+# config to disk access over RAM
+CONFIG_DISK_ACCESS_RAM=y
+CONFIG_MASS_STORAGE_DISK_NAME="RAM"

--- a/samples/subsys/usb/mass/prj.conf
+++ b/samples/subsys/usb/mass/prj.conf
@@ -14,12 +14,3 @@ CONFIG_USB_MASS_STORAGE_LOG_LEVEL_ERR=y
 # If the target's code needs to do file operations, enable target's
 # FAT FS code. (Without this only the host can access the fs contents)
 #CONFIG_FILE_SYSTEM=y
-
-#SPI flash related configs
-CONFIG_DISK_ACCESS_FLASH=y
-CONFIG_MASS_STORAGE_DISK_NAME="NAND"
-CONFIG_SPI=y
-
-#Want RAM DISK instead ? comment the whole flash block and uncomment
-#CONFIG_DISK_ACCESS_RAM=y
-#CONFIG_MASS_STORAGE_DISK_NAME="RAM"

--- a/samples/subsys/usb/mass/sample.yaml
+++ b/samples/subsys/usb/mass/sample.yaml
@@ -1,6 +1,25 @@
 sample:
   name: Mass Storage
 tests:
-  test:
+  test_mass_flash:
+    extra_args: OVERLAY_CONFIG="overlay-flash-disk.conf"
+    extra_configs:
+        - CONFIG_LOG_DEFAULT_LEVEL=3
     platform_whitelist: arduino_101
     tags: msd usb
+    harness: console
+    harness_config:
+      type: one_line
+      regex:
+        - "The device is put in USB mass storage mode."
+  test_mass_ram:
+    extra_args: OVERLAY_CONFIG="overlay-ram-disk.conf"
+    extra_configs:
+        - CONFIG_LOG_DEFAULT_LEVEL=3
+    platform_whitelist: frdm_k64f quark_se_c1000_devboard
+    tags: msd usb
+    harness: console
+    harness_config:
+      type: one_line
+      regex:
+        - "The device is put in USB mass storage mode."


### PR DESCRIPTION
Add console harness support for USB mass storage test.
Also, using overlay config for DISK_ACCESS configuration
and accessing the different config file with different
method.


Signed-off-by: Ajay Kishore <ajay.kishore@intel.com>