### PR TITLE
driver: spi_dw: Add EEPROM Mode support

### DIFF
--- a/drivers/spi/Kconfig.dw
+++ b/drivers/spi/Kconfig.dw
@@ -30,6 +30,13 @@ config SPI_DW_FIFO_DEPTH
 	  SSI_RX_FIFO_DEPTH of the DesignWare Synchronous
 	  Serial Interface. Depth ranges from 2-256.
 
+config SPI_DW_ENABLE_EEPROM_MODE
+	bool "enable eeprom mode"
+	default n
+	help
+	  Enable internal EEPROM MODE.
+
+
 if SPI_0
 
 config SPI_DW_PORT_0_INTERRUPT_SINGLE_LINE

--- a/drivers/spi/spi_dw.h
+++ b/drivers/spi/spi_dw.h
@@ -109,7 +109,13 @@ struct spi_dw_data {
 #define DW_SPI_CTRLR0_SLV_OE_BIT	(10)
 #define DW_SPI_CTRLR0_SLV_OE		BIT(DW_SPI_CTRLR0_SLV_OE_BIT)
 
+#ifdef CONFIG_SOC_INTEL_S1000
+#define DW_SPI_CTRLR0_TMOD_SHIFT	(10)
+#else
 #define DW_SPI_CTRLR0_TMOD_SHIFT	(8)
+#endif
+
+
 #define DW_SPI_CTRLR0_TMOD_TX_RX	(0)
 #define DW_SPI_CTRLR0_TMOD_TX		(1 << DW_SPI_CTRLR0_TMOD_SHIFT)
 #define DW_SPI_CTRLR0_TMOD_RX		(2 << DW_SPI_CTRLR0_TMOD_SHIFT)
@@ -119,7 +125,7 @@ struct spi_dw_data {
 #define DW_SPI_CTRLR0_DFS_16(__bpw)	((__bpw) - 1)
 #define DW_SPI_CTRLR0_DFS_32(__bpw)	(((__bpw) - 1) << 16)
 
-#ifdef CONFIG_ARC
+#if defined(CONFIG_ARC) || defined(CONFIG_SOC_INTEL_S1000)
 #define DW_SPI_CTRLR0_DFS		DW_SPI_CTRLR0_DFS_16
 #else
 #define DW_SPI_CTRLR0_DFS		DW_SPI_CTRLR0_DFS_32


### PR DESCRIPTION
This PR is to discuss better way to enable the EEPROM support SPI_DW driver. I had pushed similar patch where I had received review comments. I could address only one among them. I am having issue distinguishing the Between EEPROM and TX and RX mode has both will have rx and tx buff filled. Hence I have used config. 