### PR TITLE
linker: warn about orphan sections

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -287,6 +287,13 @@ zephyr_ld_options(
   ${LINKERFLAGPREFIX},--build-id=none
   )
 
+# Funny thing is if this is set to =error, some architectures will
+# skip this flag even though the compiler flag check passes
+# (e.g. ARC and Xtensa). So keep it at =warn, for now.
+zephyr_ld_options(
+  ${LINKERFLAGPREFIX},--orphan-handling=warn
+  )
+
 if(CONFIG_HAVE_CUSTOM_LINKER_SCRIPT)
   set(LINKER_SCRIPT ${APPLICATION_SOURCE_DIR}/${CONFIG_CUSTOM_LINKER_SCRIPT})
   if(NOT EXISTS ${LINKER_SCRIPT})

--- a/include/arch/arc/v2/linker.ld
+++ b/include/arch/arc/v2/linker.ld
@@ -73,6 +73,9 @@ MEMORY {
 }
 
 SECTIONS {
+
+#include <linker/rel-sections.ld>
+
 	GROUP_START(ROMABLE_REGION)
 
 	SECTION_PROLOGUE(_TEXT_SECTION_NAME,,ALIGN(1024)) {
@@ -283,4 +286,7 @@ SECTIONS {
 #ifdef CONFIG_GEN_ISR_TABLES
 #include <linker/intlist.ld>
 #endif
+
+#include <linker/debug-sections.ld>
+
 	}

--- a/include/arch/arc/v2/linker.ld
+++ b/include/arch/arc/v2/linker.ld
@@ -107,6 +107,10 @@ SECTIONS {
 		*(".rodata.*")
 		*(.gnu.linkonce.r.*)
 
+#ifdef CONFIG_SOC_RODATA_LD
+#include <soc-rodata.ld>
+#endif
+
 #ifdef CONFIG_CUSTOM_RODATA_LD
 /* Located in project source directory */
 #include <custom-rodata.ld>
@@ -228,6 +232,10 @@ SECTIONS {
 		 KERNEL_INPUT_SECTION(".noinit.*")
 		 *(".kernel_noinit.*")
 
+#ifdef CONFIG_SOC_NOINIT_LD
+#include <soc-noinit.ld>
+#endif
+
 	} GROUP_LINK_IN(RAMABLE_REGION)
 
 	SECTION_DATA_PROLOGUE(_DATA_SECTION_NAME,,) {
@@ -237,6 +245,10 @@ SECTIONS {
 		KERNEL_INPUT_SECTION(.data)
 		KERNEL_INPUT_SECTION(".data.*")
 		*(".kernel.*")
+
+#ifdef CONFIG_SOC_RWDATA_LD
+#include <soc-rwdata.ld>
+#endif
 
 #ifdef CONFIG_CUSTOM_RWDATA_LD
 /* Located in project source directory */

--- a/include/arch/arm/cortex_m/scripts/linker.ld
+++ b/include/arch/arm/cortex_m/scripts/linker.ld
@@ -163,6 +163,10 @@ SECTIONS
 	*(".rodata.*")
 	*(.gnu.linkonce.r.*)
 
+#ifdef CONFIG_SOC_RODATA_LD
+#include <soc-rodata.ld>
+#endif
+
 #ifdef CONFIG_CUSTOM_RODATA_LD
 /* Located in project source directory */
 #include <custom-rodata.ld>
@@ -330,6 +334,10 @@ SECTIONS
         KERNEL_INPUT_SECTION(".noinit.*")
 	*(".kernel_noinit.*")
 
+#ifdef CONFIG_SOC_NOINIT_LD
+#include <soc-noinit.ld>
+#endif
+
         } GROUP_LINK_IN(RAMABLE_REGION)
 
     SECTION_DATA_PROLOGUE(_DATA_SECTION_NAME,,)
@@ -338,6 +346,10 @@ SECTIONS
 	KERNEL_INPUT_SECTION(.data)
 	KERNEL_INPUT_SECTION(".data.*")
 	*(".kernel.*")
+
+#ifdef CONFIG_SOC_RWDATA_LD
+#include <soc-rwdata.ld>
+#endif
 
 #ifdef CONFIG_CUSTOM_RWDATA_LD
 /* Located in project source directory */

--- a/include/arch/arm/cortex_m/scripts/linker.ld
+++ b/include/arch/arm/cortex_m/scripts/linker.ld
@@ -87,6 +87,23 @@ ENTRY(CONFIG_KERNEL_ENTRY)
 
 SECTIONS
     {
+
+#include <linker/rel-sections.ld>
+
+    /*
+     * .plt and .iplt are here according to 'arm-zephyr-elf-ld --verbose',
+     * before text section.
+     */
+    SECTION_PROLOGUE(.plt,,)
+	{
+	*(.plt)
+	}
+
+    SECTION_PROLOGUE(.iplt,,)
+	{
+	*(.iplt)
+	}
+
     GROUP_START(ROMABLE_REGION)
 
 	_image_rom_start = ROM_ADDR;
@@ -132,6 +149,12 @@ SECTIONS
 	*(.text)
 	*(".text.*")
 	*(.gnu.linkonce.t.*)
+
+	/*
+	 * These are here according to 'arm-zephyr-elf-ld --verbose',
+	 * after .gnu.linkonce.t.*
+	 */
+	*(.glue_7t) *(.glue_7) *(.vfp11_veneer) *(.v4_bx)
 
 #include <linker/priv_stacks-text.ld>
 #include <linker/kobject-text.ld>
@@ -218,6 +241,18 @@ SECTIONS
     KEEP(*(TI_CCFG))
     } > FLASH_CCFG
 #endif
+
+    /*
+     * These are here according to 'arm-zephyr-elf-ld --verbose',
+     * before data section.
+     */
+    SECTION_PROLOGUE(.got,,)
+	{
+	*(.got.plt)
+	*(.igot.plt)
+	*(.got)
+	*(.igot)
+	}
 
     GROUP_START(RAMABLE_REGION)
 
@@ -318,6 +353,8 @@ SECTIONS
 	KERNEL_INPUT_SECTION(".bss.*")
 	KERNEL_INPUT_SECTION(COMMON)
 	*(".kernel_bss.*")
+
+#include <linker/priv_stacks-noinit.ld>
 
         /*
          * As memory is cleared in words only, it is simpler to ensure the BSS
@@ -426,5 +463,13 @@ SECTIONS
 #ifdef CONFIG_GEN_ISR_TABLES
 #include <linker/intlist.ld>
 #endif
+
+#include <linker/debug-sections.ld>
+
+    SECTION_PROLOGUE(.ARM.attributes, 0,)
+	{
+	KEEP(*(.ARM.attributes))
+	KEEP(*(.gnu.attributes))
+	}
 
     }

--- a/include/arch/arm/cortex_m/scripts/linker.ld
+++ b/include/arch/arm/cortex_m/scripts/linker.ld
@@ -114,6 +114,8 @@ SECTIONS
 
 	KEEP(*(IRQ_VECTOR_TABLE))
 
+	KEEP(*(.vectors))
+
 	KEEP(*(.openocd_dbg))
 	KEEP(*(".openocd_dbg.*"))
 

--- a/include/arch/nios2/linker.ld
+++ b/include/arch/nios2/linker.ld
@@ -82,6 +82,23 @@ ENTRY(CONFIG_KERNEL_ENTRY)
 
 SECTIONS
     {
+
+#include <linker/rel-sections.ld>
+
+    /*
+     * .plt and .iplt are here according to
+     * 'nios2-zephyr-elf-ld --verbose', before text section.
+     */
+    SECTION_PROLOGUE(.plt,,)
+        {
+        *(.plt)
+        }
+
+    SECTION_PROLOGUE(.iplt,,)
+        {
+        *(.iplt)
+        }
+
     GROUP_START(ROMABLE_REGION)
     _image_rom_start = _ROM_ADDR;
 
@@ -260,6 +277,8 @@ SECTIONS
 #ifdef CONFIG_GEN_ISR_TABLES
 #include <linker/intlist.ld>
 #endif
+
+#include <linker/debug-sections.ld>
 
     }
 

--- a/include/arch/nios2/linker.ld
+++ b/include/arch/nios2/linker.ld
@@ -128,6 +128,10 @@ SECTIONS
         *(".rodata.*")
         *(.gnu.linkonce.r.*)
 
+#ifdef CONFIG_SOC_RODATA_LD
+#include <soc-rodata.ld>
+#endif
+
 #ifdef CONFIG_CUSTOM_RODATA_LD
 /* Located in project source directory */
 #include <custom-rodata.ld>
@@ -173,6 +177,10 @@ SECTIONS
 #endif
         *(.data)
         *(".data.*")
+
+#ifdef CONFIG_SOC_RWDATA_LD
+#include <soc-rwdata.ld>
+#endif
 
 #ifdef CONFIG_CUSTOM_RWDATA_LD
 /* Located in project source directory */
@@ -231,6 +239,11 @@ SECTIONS
          */
         *(.noinit)
         *(".noinit.*")
+
+#ifdef CONFIG_SOC_NOINIT_LD
+#include <soc-noinit.ld>
+#endif
+
         } GROUP_LINK_IN(RAMABLE_REGION)
 
     /* Define linker symbols */

--- a/include/arch/posix/linker.ld
+++ b/include/arch/posix/linker.ld
@@ -21,15 +21,42 @@
 #include <linker/linker-defs.h>
 #include <linker/linker-tool.h>
 
+SECTIONS
+ {
+	SECTION_PROLOGUE(.note.ABI-tag,,)
+	{
+	*(.note.ABI-tag)
+	}
+
+ } INSERT AFTER .interp;
 
 SECTIONS
  {
+
+#include <linker/rel-sections.ld>
 
 #include <linker/common-rom.ld>
 
 #include <linker/common-ram.ld>
 
+	SECTION_PROLOGUE(_NOINIT_SECTION_NAME, (NOLOAD OPTIONAL),)
+	{
+	/*
+	 * This section is used for non-initialized objects that
+	 * will not be cleared during the boot process.
+	 */
+	KERNEL_INPUT_SECTION(.noinit)
+	KERNEL_INPUT_SECTION(".noinit.*")
+	*(".kernel_noinit.*")
+	}
+
 #include <arch/posix/native_tasks.ld>
+
+	/* Related to transactional memory */
+	SECTION_PROLOGUE(.tm_clone_table,,)
+	{
+	*(.tm_clone_table)
+	}
 
  __data_ram_end = .;
 

--- a/include/arch/riscv32/common/linker.ld
+++ b/include/arch/riscv32/common/linker.ld
@@ -96,6 +96,11 @@ SECTIONS
 		 *(.rodata)
 		 *(".rodata.*")
 		 *(.gnu.linkonce.r.*)
+
+#ifdef CONFIG_SOC_RODATA_LD
+#include <soc-rodata.ld>
+#endif
+
 	} GROUP_LINK_IN(ROMABLE_REGION)
 
     _image_rom_end = .;
@@ -116,6 +121,10 @@ SECTIONS
 
 		 *(.sdata .sdata.* .gnu.linkonce.s.*)
 		 *(.sdata2 .sdata2.* .gnu.linkonce.s2.*)
+
+#ifdef CONFIG_SOC_RWDATA_LD
+#include <soc-rwdata.ld>
+#endif
 
 	}  GROUP_DATA_LINK_IN(RAMABLE_REGION, ROMABLE_REGION)
 
@@ -151,6 +160,11 @@ SECTIONS
 		 */
 		 *(.noinit)
 		 *(".noinit.*")
+
+#ifdef CONFIG_SOC_NOINIT_LD
+#include <soc-noinit.ld>
+#endif
+
 	} GROUP_LINK_IN(RAMABLE_REGION)
 
      _image_ram_end = .;

--- a/include/arch/riscv32/common/linker.ld
+++ b/include/arch/riscv32/common/linker.ld
@@ -46,6 +46,22 @@ ENTRY(CONFIG_KERNEL_ENTRY)
 SECTIONS
     {
 
+#include <linker/rel-sections.ld>
+
+    /*
+     * The .plt and .iplt are here according to
+     * 'riscv32-zephyr-elf-ld --verbose', before text section.
+     */
+    SECTION_PROLOGUE(.plt,,)
+	{
+		*(.plt)
+	}
+
+    SECTION_PROLOGUE(.iplt,,)
+	{
+		*(.iplt)
+	}
+
     GROUP_START(ROM)
     _image_rom_start = .;
 
@@ -175,4 +191,7 @@ SECTIONS
 #endif
 
      GROUP_END(RAMABLE_REGION)
+
+#include <linker/debug-sections.ld>
+
 }

--- a/include/arch/riscv32/pulpino/linker.ld
+++ b/include/arch/riscv32/pulpino/linker.ld
@@ -90,6 +90,11 @@ SECTIONS
 		*(.rodata)
 		*(".rodata.*")
 		*(.gnu.linkonce.r.*)
+
+#ifdef CONFIG_SOC_RODATA_LD
+#include <soc-rodata.ld>
+#endif
+
 	} GROUP_LINK_IN(RAMABLE_REGION)
 
     _image_ram_start = .;
@@ -105,6 +110,10 @@ SECTIONS
 
 		 *(.sdata .sdata.* .gnu.linkonce.s.*)
 		 *(.sdata2 .sdata2.* .gnu.linkonce.s2.*)
+
+#ifdef CONFIG_SOC_RWDATA_LD
+#include <soc-rwdata.ld>
+#endif
 
 	}  GROUP_LINK_IN(RAMABLE_REGION)
 
@@ -136,6 +145,11 @@ SECTIONS
 		 */
 		 *(.noinit)
 		 *(".noinit.*")
+
+#ifdef CONFIG_SOC_NOINIT_LD
+#include <soc-noinit.ld>
+#endif
+
 	} GROUP_LINK_IN(RAMABLE_REGION)
 
      _image_ram_end = .;

--- a/include/arch/riscv32/pulpino/linker.ld
+++ b/include/arch/riscv32/pulpino/linker.ld
@@ -41,6 +41,23 @@ ENTRY(CONFIG_KERNEL_ENTRY)
 
 SECTIONS
     {
+
+#include <linker/rel-sections.ld>
+
+    /*
+     * .plt and .iplt are here according to
+     * 'riscv32-zephyr-elf-ld --verbose', before text section.
+     */
+    SECTION_PROLOGUE(.plt,,)
+	{
+		*(.plt)
+	}
+
+    SECTION_PROLOGUE(.iplt,,)
+	{
+		*(.iplt)
+	}
+
     GROUP_START(INSTRRAM)
 
     SECTION_PROLOGUE(_VECTOR_SECTION_NAME,,)
@@ -71,6 +88,7 @@ SECTIONS
 		*(.text)
 		*(".text.*")
 		*(.gnu.linkonce.t.*)
+		*(.eh_frame)
 	} GROUP_LINK_IN(INSTRRAM)
 
     _image_text_end = .;
@@ -160,4 +178,7 @@ SECTIONS
 #endif
 
      GROUP_END(RAMABLE_REGION)
+
+#include <linker/debug-sections.ld>
+
 }

--- a/include/arch/x86/linker.ld
+++ b/include/arch/x86/linker.ld
@@ -66,6 +66,9 @@ ENTRY(CONFIG_KERNEL_ENTRY)
 /* SECTIONS definitions */
 SECTIONS
 	{
+
+#include <linker/rel-sections.ld>
+
 	GROUP_START(ROMABLE_REGION)
 #ifdef CONFIG_REALMODE
 	/* 16-bit sections */
@@ -377,6 +380,8 @@ SECTIONS
 /* Located in project source directory */
 #include <custom-sections.ld>
 #endif
+
+#include <linker/debug-sections.ld>
 
 	}
 

--- a/include/arch/x86/linker.ld
+++ b/include/arch/x86/linker.ld
@@ -132,6 +132,10 @@ SECTIONS
 #endif
 #endif
 
+#ifdef CONFIG_SOC_RODATA_LD
+#include <soc-rodata.ld>
+#endif
+
 #ifdef CONFIG_CUSTOM_RODATA_LD
 /* Located in project source directory */
 #include <custom-rodata.ld>
@@ -244,6 +248,10 @@ SECTIONS
 	KERNEL_INPUT_SECTION(".noinit.*")
 	*(".kernel_noinit.*")
 
+#ifdef CONFIG_SOC_NOINIT_LD
+#include <soc-noinit.ld>
+#endif
+
 	MMU_PAGE_ALIGN
 
 	} GROUP_DATA_LINK_IN(RAMABLE_REGION, RAMABLE_REGION)
@@ -256,6 +264,10 @@ SECTIONS
 	KERNEL_INPUT_SECTION(.data)
 	KERNEL_INPUT_SECTION(".data.*")
 	*(".kernel.*")
+
+#ifdef CONFIG_SOC_RWDATA_LD
+#include <soc-rwdata.ld>
+#endif
 
 #ifdef CONFIG_CUSTOM_RWDATA_LD
 /* Located in project source directory */

--- a/include/linker/debug-sections.ld
+++ b/include/linker/debug-sections.ld
@@ -1,0 +1,40 @@
+	/* following sections are obtained via 'ld --verbose' */
+
+	/* Stabs debugging sections. */
+	SECTION_PROLOGUE(.stab, 0,)            { *(.stab) }
+	SECTION_PROLOGUE(.stabstr, 0,)         { *(.stabstr) }
+	SECTION_PROLOGUE(.stab.excl, 0,)       { *(.stab.excl) }
+	SECTION_PROLOGUE(.stab.exclstr, 0,)    { *(.stab.exclstr) }
+	SECTION_PROLOGUE(.stab.index, 0,)      { *(.stab.index) }
+	SECTION_PROLOGUE(.stab.indexstr, 0,)   { *(.stab.indexstr) }
+	SECTION_PROLOGUE(.comment, 0,)         { *(.comment) }
+	/* DWARF debug sections.
+	   Symbols in the DWARF debugging sections are relative to the beginning
+	   of the section so we begin them at 0. */
+	/* DWARF 1 */
+	SECTION_PROLOGUE(.debug, 0,)           { *(.debug) }
+	SECTION_PROLOGUE(.line, 0,)            { *(.line) }
+	/* GNU DWARF 1 extensions */
+	SECTION_PROLOGUE(.debug_srcinfo, 0,)   { *(.debug_srcinfo) }
+	SECTION_PROLOGUE(.debug_sfnames, 0,)   { *(.debug_sfnames) }
+	/* DWARF 1.1 and DWARF 2 */
+	SECTION_PROLOGUE(.debug_aranges, 0,)   { *(.debug_aranges) }
+	SECTION_PROLOGUE(.debug_pubnames, 0,)  { *(.debug_pubnames) }
+	/* DWARF 2 */
+	SECTION_PROLOGUE(.debug_info, 0,)      { *(.debug_info .gnu.linkonce.wi.*) }
+	SECTION_PROLOGUE(.debug_abbrev, 0,)    { *(.debug_abbrev) }
+	SECTION_PROLOGUE(.debug_line, 0,)      { *(.debug_line .debug_line.* .debug_line_end ) }
+	SECTION_PROLOGUE(.debug_frame, 0,)     { *(.debug_frame) }
+	SECTION_PROLOGUE(.debug_str, 0,)       { *(.debug_str) }
+	SECTION_PROLOGUE(.debug_loc, 0,)       { *(.debug_loc) }
+	SECTION_PROLOGUE(.debug_macinfo, 0,)   { *(.debug_macinfo) }
+	/* SGI/MIPS DWARF 2 extensions */
+	SECTION_PROLOGUE(.debug_weaknames, 0,) { *(.debug_weaknames) }
+	SECTION_PROLOGUE(.debug_funcnames, 0,) { *(.debug_funcnames) }
+	SECTION_PROLOGUE(.debug_typenames, 0,) { *(.debug_typenames) }
+	SECTION_PROLOGUE(.debug_varnames, 0,)  { *(.debug_varnames) }
+	/* DWARF 3 */
+	SECTION_PROLOGUE(.debug_pubtypes, 0,)  { *(.debug_pubtypes) }
+	SECTION_PROLOGUE(.debug_ranges, 0,)    { *(.debug_ranges) }
+	/* DWARF Extension. */
+	SECTION_PROLOGUE(.debug_macro, 0,)     { *(.debug_macro) }

--- a/include/linker/priv_stacks-noinit.ld
+++ b/include/linker/priv_stacks-noinit.ld
@@ -1,0 +1,7 @@
+/*
+ * Copyright (c) 2017 Linaro Limited.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+	*(".priv_stacks.noinit")

--- a/include/linker/rel-sections.ld
+++ b/include/linker/rel-sections.ld
@@ -1,0 +1,124 @@
+	/*
+	 * .rel.* are for relocation.
+	 * These are being produced by compiler/linker.
+	 * Specify these here so they are not considered orphan sections.
+	 *
+	 * Obtained via
+	 * '$(ARCH)-zephyr-elf-ld --verbose'
+	 */
+
+#if !defined(CONFIG_RISCV32) && !defined(CONFIG_XTENSA)
+	SECTION_PROLOGUE(.rel.dyn,,)
+	{
+	*(.rel.init)
+	*(.rel.text .rel.text.* .rel.text_start.* .rel.gnu.linkonce.t.*)
+	*(.rel.fini)
+	*(.rel.rodata .rel.rodata.* .rel.gnu.linkonce.r.*)
+	*(.rel.data.rel.ro .rel.data.rel.ro.* .rel.gnu.linkonce.d.rel.ro.*)
+	*(.rel.data .rel.data.* .rel.gnu.linkonce.d.*)
+	*(.rel.tdata .rel.tdata.* .rel.gnu.linkonce.td.*)
+	*(.rel.tbss .rel.tbss.* .rel.gnu.linkonce.tb.*)
+
+#if defined(CONFIG_ARCH_POSIX)
+	*(.rel.preinit_array)
+	*(.rel.init_array)
+	*(.rel.fini_array)
+#endif
+
+	*(.rel.ctors)
+	*(.rel.dtors)
+	*(.rel.got)
+	*(.rel.bss .rel.bss.* .rel.gnu.linkonce.b.*)
+
+#if defined(CONFIG_ARM) || defined(CONFIG_NIOS2)
+	PROVIDE_HIDDEN (__rel_iplt_start = .);
+	*(.rel.iplt)
+	PROVIDE_HIDDEN (__rel_iplt_end = .);
+#endif
+
+	/* These are related to sections defined by Zephyr */
+	*(.rel.kernel .rel.kernel.*)
+	*(.rel.init_PRE_KERNEL*)
+	*(.rel.init_POST_KERNEL*)
+	*(.rel.init_APPLICATION*)
+
+#if defined(CONFIG_ARCH_POSIX)
+	*(.rel.native_PRE_BOOT*)
+	*(.rel.native_FIRST_SLEEP*)
+	*(.rel.native_ON_EXIT*)
+#endif
+
+	*(.rel.devconfig.*)
+	*(.rel._k_alert.*)
+	*(.rel._k_mem_pool.*)
+	*(.rel._k_timer.*)
+	*(.rel._static_thread_data.*)
+
+#if defined(CONFIG_X86)
+	*(.rel.ifunc)
+	*(.rel.mmulist)
+	*(.rel.tss)
+#endif
+	}
+#endif /* !defined(CONFIG_RISCV32) */
+
+#if defined(CONFIG_ARM) || defined(CONFIG_NIOS2) || defined(CONFIG_RISCV32)
+	SECTION_PROLOGUE(.rela.dyn,,)
+	{
+	*(.rela.init)
+	*(.rela.text .rela.text.* .rela.gnu.linkonce.t.*)
+	*(.rela.fini)
+	*(.rela.rodata .rela.rodata.* .rela.gnu.linkonce.r.*)
+	*(.rela.data .rela.data.* .rela.gnu.linkonce.d.*)
+	*(.rela.tdata .rela.tdata.* .rela.gnu.linkonce.td.*)
+	*(.rela.tbss .rela.tbss.* .rela.gnu.linkonce.tb.*)
+	*(.rela.ctors)
+	*(.rela.dtors)
+	*(.rela.got)
+	*(.rela.bss .rela.bss.* .rela.gnu.linkonce.b.*)
+
+#if defined(CONFIG_ARM) || defined(CONFIG_NIOS2)
+	PROVIDE_HIDDEN (__rela_iplt_start = .);
+	*(.rela.iplt)
+	PROVIDE_HIDDEN (__rela_iplt_end = .);
+#endif
+
+	/* These are related to sections defined by Zephyr */
+	*(.rela.kernel .rel.kernel.*)
+	*(.rela.init_PRE_KERNEL*)
+	*(.rela.init_POST_KERNEL*)
+	*(.rela.init_APPLICATION*)
+	*(.rela._k_alert.*)
+	*(.rela._k_mem_pool.*)
+	*(.rela._k_timer.*)
+	*(.rela._static_thread_data.*)
+
+#if defined(CONFIG_RISCV32)
+	*(.rela.devconfig.*)
+	*(.rela.exception.*)
+	*(.rela.gnu.linkonce.sw_isr_table)
+	*(.rela.sdata.*)
+#endif
+
+	}
+#endif
+
+#if !defined(CONFIG_RISCV32) && !defined(CONFIG_XTENSA)
+	SECTION_PROLOGUE(.rel.plt,,)
+	{
+	*(.rel.plt)
+
+#if defined(CONFIG_X86)
+	PROVIDE_HIDDEN (__rel_iplt_start = .);
+	*(.rel.iplt)
+	PROVIDE_HIDDEN (__rel_iplt_end = .);
+#endif
+	}
+#endif /* !defined(CONFIG_RISCV32) */
+
+#if defined(CONFIG_ARM) || defined(CONFIG_NIOS2) || defined(CONFIG_RISCV32)
+	SECTION_PROLOGUE(.rela.plt,,)
+	{
+	*(.rela.plt)
+	}
+#endif

--- a/include/linker/sections.h
+++ b/include/linker/sections.h
@@ -53,9 +53,9 @@
 #define KINETIS_FLASH_CONFIG  kinetis_flash_config
 #define TI_CCFG	.ti_ccfg
 
-#define _CCM_DATA_SECTION_NAME		ccm_data
-#define _CCM_BSS_SECTION_NAME		ccm_bss
-#define _CCM_NOINIT_SECTION_NAME	ccm_noinit
+#define _CCM_DATA_SECTION_NAME		.ccm_data
+#define _CCM_BSS_SECTION_NAME		.ccm_bss
+#define _CCM_NOINIT_SECTION_NAME	.ccm_noinit
 
 #endif
 

--- a/soc/Kconfig
+++ b/soc/Kconfig
@@ -11,3 +11,39 @@ osource "$(SOC_DIR)/$(ARCH)/Kconfig"
 osource "$(SOC_DIR)/$(ARCH)/*/Kconfig"
 
 endmenu
+
+#
+# SOC_*_LD: SoC specific Linker script additions
+#
+config SOC_NOINIT_LD
+	bool
+	depends on (ARC || ARM || X86 || NIOS2 || RISCV32)
+	help
+	  Include an SoC specific linker script fragment named soc-noinit.ld
+	  for inserting additional data and linker directives into
+	  the noinit section.
+
+	  This only has effect if the SoC uses the common linker script
+	  under include/arch/.
+
+config SOC_RODATA_LD
+	bool
+	depends on (ARC || ARM || X86 || NIOS2 || RISCV32)
+	help
+	  Include an SoC specific linker script fragment named soc-rodata.ld
+	  for inserting additional data and linker directives into
+	  the rodata section.
+
+	  This only has effect if the SoC uses the common linker script
+	  under include/arch/.
+
+config SOC_RWDATA_LD
+	bool
+	depends on (ARC || ARM || X86 || NIOS2 || RISCV32)
+	help
+	  Include an SoC specific linker script fragment named soc-rwdata.ld
+	  for inserting additional data and linker directives into
+	  the data section.
+
+	  This only has effect if the SoC uses the common linker script
+	  under include/arch/.

--- a/soc/arm/cypress/psoc6/Kconfig.series
+++ b/soc/arm/cypress/psoc6/Kconfig.series
@@ -11,5 +11,7 @@ config SOC_SERIES_PSOC62
 	select SYS_POWER_LOW_POWER_STATE_SUPPORTED
 	select CPU_HAS_SYSTICK
 	select HAS_CYPRESS_DRIVERS
+	select SOC_NOINIT_LD
+	select SOC_RWDATA_LD
 	help
 	  Enable support for Cypress PSoC6 MCU series

--- a/soc/arm/cypress/psoc6/soc-noinit.ld
+++ b/soc/arm/cypress/psoc6/soc-noinit.ld
@@ -1,0 +1,16 @@
+	/*
+	 * Extracted from:
+	 * ext/hal/cypress/.../devices/psoc6/linker/gcc/cy8c6xx6_cm0plus.ld
+	 *
+	 * Size of sections are calculated in the startup scripts,
+	 * so they don't have to be specified here.
+	 */
+
+	. = ALIGN(8);
+	KEEP(*(.ram_vectors))
+
+	. = ALIGN(4);
+	KEEP(*(.heap))
+
+	. = ALIGN(4);
+	KEEP(*(.stack))

--- a/soc/arm/cypress/psoc6/soc-rwdata.ld
+++ b/soc/arm/cypress/psoc6/soc-rwdata.ld
@@ -1,0 +1,6 @@
+	/*
+	 * Extracted from:
+	 * ext/hal/cypress/.../devices/psoc6/linker/gcc/cy8c6xx6_cm0plus.ld
+	 */
+
+	KEEP(*(.cy_ramfunc))

--- a/soc/xtensa/D_108mini/linker.ld
+++ b/soc/xtensa/D_108mini/linker.ld
@@ -178,6 +178,8 @@ PROVIDE(_memmap_cacheattr_reset = _memmap_cacheattr_wb_trapnull);
 SECTIONS
 {
 
+#include <linker/rel-sections.ld>
+
   .dram1.rodata : ALIGN(4)
   {
     _dram1_rodata_start = ABSOLUTE(.);
@@ -563,6 +565,7 @@ SECTIONS
   } >sram0_seg :sram0_bss_phdr
   __stack = 0x64000000;
   _heap_sentry = 0x64000000;
+  .comment  0 :  { *(.comment) }
   .debug  0 :  { *(.debug) }
   .line  0 :  { *(.line) }
   .debug_srcinfo  0 :  { *(.debug_srcinfo) }
@@ -580,6 +583,8 @@ SECTIONS
   .debug_funcnames  0 :  { *(.debug_funcnames) }
   .debug_typenames  0 :  { *(.debug_typenames) }
   .debug_varnames  0 :  { *(.debug_varnames) }
+  .debug_ranges  0 :  { *(.debug_ranges) }
+  .xtensa.info  0 :  { *(.xtensa.info) }
   .xt.insn 0 :
   {
     KEEP (*(.xt.insn))

--- a/soc/xtensa/D_212GP/linker.ld
+++ b/soc/xtensa/D_212GP/linker.ld
@@ -178,6 +178,8 @@ PROVIDE(_memmap_cacheattr_reset = _memmap_cacheattr_wb_trapnull);
 SECTIONS
 {
 
+#include <linker/rel-sections.ld>
+
   .dport0.rodata : ALIGN(4)
   {
     _dport0_rodata_start = ABSOLUTE(.);
@@ -569,6 +571,7 @@ SECTIONS
   } >sram19_seg :sram19_bss_phdr
   __stack = 0x64000000;
   _heap_sentry = 0x64000000;
+  .comment  0 :  { *(.comment) }
   .debug  0 :  { *(.debug) }
   .line  0 :  { *(.line) }
   .debug_srcinfo  0 :  { *(.debug_srcinfo) }
@@ -586,6 +589,8 @@ SECTIONS
   .debug_funcnames  0 :  { *(.debug_funcnames) }
   .debug_typenames  0 :  { *(.debug_typenames) }
   .debug_varnames  0 :  { *(.debug_varnames) }
+  .debug_ranges  0 :  { *(.debug_ranges) }
+  .xtensa.info  0 :  { *(.xtensa.info) }
   .xt.insn 0 :
   {
     KEEP (*(.xt.insn))

--- a/soc/xtensa/D_233L/linker.ld
+++ b/soc/xtensa/D_233L/linker.ld
@@ -159,6 +159,8 @@ PROVIDE(_memmap_cacheattr_reset = _memmap_cacheattr_wb_trapnull);
 SECTIONS
 {
 
+#include <linker/rel-sections.ld>
+
   .WindowVectors.text : ALIGN(4)
   {
     _WindowVectors_text_start = ABSOLUTE(.);
@@ -470,6 +472,7 @@ SECTIONS
     _memmap_seg_srom1_end = ALIGN(0x8);
     _image_rom_end = ABSOLUTE(.);
   } >srom1_seg :srom1_phdr
+  .comment  0 :  { *(.comment) }
   .debug  0 :  { *(.debug) }
   .line  0 :  { *(.line) }
   .debug_srcinfo  0 :  { *(.debug_srcinfo) }
@@ -487,6 +490,8 @@ SECTIONS
   .debug_funcnames  0 :  { *(.debug_funcnames) }
   .debug_typenames  0 :  { *(.debug_typenames) }
   .debug_varnames  0 :  { *(.debug_varnames) }
+  .debug_ranges  0 :  { *(.debug_ranges) }
+  .xtensa.info  0 :  { *(.xtensa.info) }
   .xt.insn 0 :
   {
     KEEP (*(.xt.insn))

--- a/soc/xtensa/XRC_D2PM_5swIrq/linker.ld
+++ b/soc/xtensa/XRC_D2PM_5swIrq/linker.ld
@@ -178,6 +178,8 @@ PROVIDE(_memmap_cacheattr_reset = _memmap_cacheattr_wb_trapnull);
 SECTIONS
 {
 
+#include <linker/rel-sections.ld>
+
   .ResetVector.text : ALIGN(4)
   {
     _image_rom_start = ABSOLUTE(.);
@@ -573,6 +575,7 @@ SECTIONS
   } >sram19_seg :sram19_bss_phdr
   PROVIDE(__stack = 0x64000000);
   _heap_sentry = 0x64000000;
+  .comment  0 :  { *(.comment) }
   .debug  0 :  { *(.debug) }
   .line  0 :  { *(.line) }
   .debug_srcinfo  0 :  { *(.debug_srcinfo) }
@@ -590,6 +593,8 @@ SECTIONS
   .debug_funcnames  0 :  { *(.debug_funcnames) }
   .debug_typenames  0 :  { *(.debug_typenames) }
   .debug_varnames  0 :  { *(.debug_varnames) }
+  .debug_ranges  0 :  { *(.debug_ranges) }
+  .xtensa.info  0 :  { *(.xtensa.info) }
   .xt.insn 0 :
   {
     KEEP (*(.xt.insn))

--- a/soc/xtensa/XRC_FUSION_AON_ALL_LM/linker.ld
+++ b/soc/xtensa/XRC_FUSION_AON_ALL_LM/linker.ld
@@ -120,6 +120,8 @@ PROVIDE(_memmap_cacheattr_reset = _memmap_cacheattr_wb_trapnull);
 SECTIONS
 {
 
+#include <linker/rel-sections.ld>
+
   .dram0.rodata : ALIGN(4)
   {
     _dram0_rodata_start = ABSOLUTE(.);
@@ -402,6 +404,7 @@ SECTIONS
 
   PROVIDE(__stack = 0x64000000);
   _heap_sentry = 0x64000000;
+  .comment  0 :  { *(.comment) }
   .debug  0 :  { *(.debug) }
   .line  0 :  { *(.line) }
   .debug_srcinfo  0 :  { *(.debug_srcinfo) }
@@ -419,6 +422,8 @@ SECTIONS
   .debug_funcnames  0 :  { *(.debug_funcnames) }
   .debug_typenames  0 :  { *(.debug_typenames) }
   .debug_varnames  0 :  { *(.debug_varnames) }
+  .debug_ranges  0 :  { *(.debug_ranges) }
+  .xtensa.info  0 :  { *(.xtensa.info) }
   .xt.insn 0 :
   {
     KEEP (*(.xt.insn))

--- a/soc/xtensa/esp32/linker.ld
+++ b/soc/xtensa/esp32/linker.ld
@@ -64,6 +64,9 @@ PROVIDE(_memmap_reset_vector = 0x40000400);
 
 SECTIONS
 {
+
+#include <linker/rel-sections.ld>
+
   /* RTC fast memory holds RTC wake stub code,
      including from any source file named rtc_wake_stub*.c
   */
@@ -241,4 +244,12 @@ SECTIONS
 #ifdef CONFIG_GEN_ISR_TABLES
 #include <linker/intlist.ld>
 #endif
+
+#include <linker/debug-sections.ld>
+
+  SECTION_PROLOGUE(.xtensa.info, 0,)
+  {
+    *(.xtensa.info)
+  }
+
 }

--- a/soc/xtensa/hifi2_std/linker.ld
+++ b/soc/xtensa/hifi2_std/linker.ld
@@ -178,6 +178,8 @@ PROVIDE(_memmap_cacheattr_reset = _memmap_cacheattr_wb_trapnull);
 SECTIONS
 {
 
+#include <linker/rel-sections.ld>
+
   .dram1.rodata : ALIGN(4)
   {
     _dram1_rodata_start = ABSOLUTE(.);
@@ -573,6 +575,7 @@ SECTIONS
   } >sram19_seg :sram19_bss_phdr
   PROVIDE(__stack = 0x64000000);
   _heap_sentry = 0x64000000;
+  .comment  0 :  { *(.comment) }
   .debug  0 :  { *(.debug) }
   .line  0 :  { *(.line) }
   .debug_srcinfo  0 :  { *(.debug_srcinfo) }
@@ -590,6 +593,8 @@ SECTIONS
   .debug_funcnames  0 :  { *(.debug_funcnames) }
   .debug_typenames  0 :  { *(.debug_typenames) }
   .debug_varnames  0 :  { *(.debug_varnames) }
+  .debug_ranges  0 :  { *(.debug_ranges) }
+  .xtensa.info  0 :  { *(.xtensa.info) }
   .xt.insn 0 :
   {
     KEEP (*(.xt.insn))

--- a/soc/xtensa/hifi3_bd5/linker.ld
+++ b/soc/xtensa/hifi3_bd5/linker.ld
@@ -118,6 +118,8 @@ PROVIDE(_memmap_cacheattr_reset = _memmap_cacheattr_wb_trapnull);
 SECTIONS
 {
 
+#include <linker/rel-sections.ld>
+
   .ResetVector.text : ALIGN(4)
   {
     _image_rom_start = ABSOLUTE(.);
@@ -349,6 +351,7 @@ SECTIONS
   } >sram9_seg :sram9_bss_phdr
   __stack = 0x64000000;
   _heap_sentry = 0x64000000;
+  .comment  0 :  { *(.comment) }
   .debug  0 :  { *(.debug) }
   .line  0 :  { *(.line) }
   .debug_srcinfo  0 :  { *(.debug_srcinfo) }
@@ -366,6 +369,8 @@ SECTIONS
   .debug_funcnames  0 :  { *(.debug_funcnames) }
   .debug_typenames  0 :  { *(.debug_typenames) }
   .debug_varnames  0 :  { *(.debug_varnames) }
+  .debug_ranges  0 :  { *(.debug_ranges) }
+  .xtensa.info  0 :  { *(.xtensa.info) }
   .xt.insn 0 :
   {
     KEEP (*(.xt.insn))

--- a/soc/xtensa/hifi3_bd5_call0/linker.ld
+++ b/soc/xtensa/hifi3_bd5_call0/linker.ld
@@ -118,6 +118,8 @@ PROVIDE(_memmap_cacheattr_reset = _memmap_cacheattr_wb_trapnull);
 SECTIONS
 {
 
+#include <linker/rel-sections.ld>
+
   .ResetVector.text : ALIGN(4)
   {
     _image_rom_start = ABSOLUTE(.);
@@ -349,6 +351,7 @@ SECTIONS
   } >sram9_seg :sram9_bss_phdr
   __stack = 0x64000000;
   _heap_sentry = 0x64000000;
+  .comment  0 :  { *(.comment) }
   .debug  0 :  { *(.debug) }
   .line  0 :  { *(.line) }
   .debug_srcinfo  0 :  { *(.debug_srcinfo) }
@@ -366,6 +369,8 @@ SECTIONS
   .debug_funcnames  0 :  { *(.debug_funcnames) }
   .debug_typenames  0 :  { *(.debug_typenames) }
   .debug_varnames  0 :  { *(.debug_varnames) }
+  .debug_ranges  0 :  { *(.debug_ranges) }
+  .xtensa.info  0 :  { *(.xtensa.info) }
   .xt.insn 0 :
   {
     KEEP (*(.xt.insn))

--- a/soc/xtensa/hifi4_bd7/linker.ld
+++ b/soc/xtensa/hifi4_bd7/linker.ld
@@ -133,6 +133,8 @@ PROVIDE(_memmap_cacheattr_reset = _memmap_cacheattr_wb_trapnull);
 SECTIONS
 {
 
+#include <linker/rel-sections.ld>
+
   .ResetVector.text : ALIGN(4)
   {
     _image_rom_start = ABSOLUTE(.);
@@ -396,6 +398,7 @@ SECTIONS
   } >sram13_seg :sram13_bss_phdr
   __stack = 0x60400000;
   _heap_sentry = 0x60400000;
+  .comment  0 :  { *(.comment) }
   .debug  0 :  { *(.debug) }
   .line  0 :  { *(.line) }
   .debug_srcinfo  0 :  { *(.debug_srcinfo) }
@@ -413,6 +416,8 @@ SECTIONS
   .debug_funcnames  0 :  { *(.debug_funcnames) }
   .debug_typenames  0 :  { *(.debug_typenames) }
   .debug_varnames  0 :  { *(.debug_varnames) }
+  .debug_ranges  0 :  { *(.debug_ranges) }
+  .xtensa.info  0 :  { *(.xtensa.info) }
   .xt.insn 0 :
   {
     KEEP (*(.xt.insn))

--- a/soc/xtensa/hifi_mini/linker.ld
+++ b/soc/xtensa/hifi_mini/linker.ld
@@ -105,6 +105,8 @@ PROVIDE(_memmap_cacheattr_reset = _memmap_cacheattr_wb_trapnull);
 SECTIONS
 {
 
+#include <linker/rel-sections.ld>
+
   .dram0.rodata : ALIGN(4)
   {
     _dram0_rodata_start = ABSOLUTE(.);
@@ -321,6 +323,7 @@ SECTIONS
     _etext = .;
   } >iram0_7_seg :iram0_7_phdr
   _image_text_end = .;
+  .comment  0 :  { *(.comment) }
   .debug  0 :  { *(.debug) }
   .line  0 :  { *(.line) }
   .debug_srcinfo  0 :  { *(.debug_srcinfo) }
@@ -338,6 +341,8 @@ SECTIONS
   .debug_funcnames  0 :  { *(.debug_funcnames) }
   .debug_typenames  0 :  { *(.debug_typenames) }
   .debug_varnames  0 :  { *(.debug_varnames) }
+  .debug_ranges  0 :  { *(.debug_ranges) }
+  .xtensa.info  0 :  { *(.xtensa.info) }
   .xt.insn 0 :
   {
     KEEP (*(.xt.insn))

--- a/soc/xtensa/hifi_mini_4swIrq/linker.ld
+++ b/soc/xtensa/hifi_mini_4swIrq/linker.ld
@@ -105,6 +105,8 @@ PROVIDE(_memmap_cacheattr_reset = _memmap_cacheattr_wb_trapnull);
 SECTIONS
 {
 
+#include <linker/rel-sections.ld>
+
   .dram0.rodata : ALIGN(4)
   {
     _dram0_rodata_start = ABSOLUTE(.);
@@ -321,6 +323,7 @@ SECTIONS
     _etext = .;
   } >iram0_7_seg :iram0_7_phdr
   _image_text_end = .;
+  .comment  0 :  { *(.comment) }
   .debug  0 :  { *(.debug) }
   .line  0 :  { *(.line) }
   .debug_srcinfo  0 :  { *(.debug_srcinfo) }
@@ -338,6 +341,8 @@ SECTIONS
   .debug_funcnames  0 :  { *(.debug_funcnames) }
   .debug_typenames  0 :  { *(.debug_typenames) }
   .debug_varnames  0 :  { *(.debug_varnames) }
+  .debug_ranges  0 :  { *(.debug_ranges) }
+  .xtensa.info  0 :  { *(.xtensa.info) }
   .xt.insn 0 :
   {
     KEEP (*(.xt.insn))

--- a/soc/xtensa/intel_s1000/linker.ld
+++ b/soc/xtensa/intel_s1000/linker.ld
@@ -167,6 +167,9 @@ _memmap_cacheattr_intel_s1000 = 0xf2ff4242;
 PROVIDE(_memmap_cacheattr_reset = _memmap_cacheattr_intel_s1000);
 SECTIONS
 {
+
+#include <linker/rel-sections.ld>
+
   .ResetVector.text : ALIGN(4)
   {
     _ResetVector_text_start = ABSOLUTE(.);
@@ -415,6 +418,7 @@ SECTIONS
   _end = ALIGN(8);
   PROVIDE(end = ALIGN(8));
   __stack = L2_SRAM_BASE + L2_SRAM_SIZE;
+  .comment  0 :  { *(.comment) }
   .debug 0 : { *(.debug) }
   .line 0 : { *(.line) }
   .debug_srcinfo 0 : { *(.debug_srcinfo) }
@@ -432,6 +436,8 @@ SECTIONS
   .debug_funcnames 0 : { *(.debug_funcnames) }
   .debug_typenames 0 : { *(.debug_typenames) }
   .debug_varnames 0 : { *(.debug_varnames) }
+  .debug_ranges  0 :  { *(.debug_ranges) }
+  .xtensa.info  0 :  { *(.xtensa.info) }
   .xt.insn 0 :
   {
     KEEP (*(.xt.insn))

--- a/soc/xtensa/sample_controller/linker.ld
+++ b/soc/xtensa/sample_controller/linker.ld
@@ -178,6 +178,8 @@ PROVIDE(_memmap_cacheattr_reset = _memmap_cacheattr_wb_trapnull);
 SECTIONS
 {
 
+#include <linker/rel-sections.ld>
+
   .dram1.rodata : ALIGN(4)
   {
     _dram1_rodata_start = ABSOLUTE(.);
@@ -563,6 +565,7 @@ SECTIONS
   } >sram0_seg :sram0_bss_phdr
   __stack = 0x64000000;
   _heap_sentry = 0x64000000;
+  .comment  0 :  { *(.comment) }
   .debug  0 :  { *(.debug) }
   .line  0 :  { *(.line) }
   .debug_srcinfo  0 :  { *(.debug_srcinfo) }
@@ -580,6 +583,8 @@ SECTIONS
   .debug_funcnames  0 :  { *(.debug_funcnames) }
   .debug_typenames  0 :  { *(.debug_typenames) }
   .debug_varnames  0 :  { *(.debug_varnames) }
+  .debug_ranges  0 :  { *(.debug_ranges) }
+  .xtensa.info  0 :  { *(.xtensa.info) }
   .xt.insn 0 :
   {
     KEEP (*(.xt.insn))

--- a/tests/drivers/watchdog/wdt_basic_api/src/test_wdt.c
+++ b/tests/drivers/watchdog/wdt_basic_api/src/test_wdt.c
@@ -86,17 +86,17 @@ static struct wdt_timeout_cfg m_cfg_wdt1;
 /* m_state indicates state of particular test. Used to check whether testcase
  * should go to reset state or check other values after reset.
  */
-volatile uint32_t m_state __attribute__((section("app_noinit")));
+volatile uint32_t m_state __attribute__((section(".noinit.test_wdt")));
 
 /* m_testcase_index is incremented after each test to make test possible
  * switch to next testcase.
  */
-volatile uint32_t m_testcase_index __attribute__((section("app_noinit")));
+volatile uint32_t m_testcase_index __attribute__((section(".noinit.test_wdt")));
 
 /* m_testvalue contains value set in interrupt callback to point whether
  * first or second interrupt was fired.
  */
-volatile uint32_t m_testvalue __attribute__((section("app_noinit")));
+volatile uint32_t m_testvalue __attribute__((section(".noinit.test_wdt")));
 
 static void wdt_int_cb0(struct device *wdt_dev, int channel_id)
 {


### PR DESCRIPTION
This adds a linker flag and necessary changes to linker scripts so that linker will warn about orphan sections.

Relates to #5534