### PR TITLE
script: dts: Fix alias generation for reg property.

### DIFF
--- a/scripts/dts/extract/reg.py
+++ b/scripts/dts/extract/reg.py
@@ -94,10 +94,10 @@ class DTReg(DTDirective):
             if node_address in aliases:
                 for i in aliases[node_address]:
                     alias_label = convert_string_to_label(i)
-                    alias_addr = [alias_label] + l_addr
-                    alias_size = [alias_label] + l_size
-                    prop_alias['_'.join(alias_addr)] = '_'.join(l_base + l_addr)
-                    prop_alias['_'.join(alias_size)] = '_'.join(l_base + l_size)
+                    alias_addr = [alias_label] + l_addr + l_idx
+                    alias_size = [alias_label] + l_size + l_idx
+                    prop_alias['_'.join(alias_addr)] = '_'.join(l_base + l_addr + l_idx)
+                    prop_alias['_'.join(alias_size)] = '_'.join(l_base + l_size + l_idx)
 
             insert_defs(node_address, prop_def, prop_alias)
 


### PR DESCRIPTION
In case of having more than one reg, aliases would not generate
properly. Number of register at the end of define was missing.

Current situation:
```
/* gpio@50000000 */
#define NORDIC_NRF_GPIO_50000000_BASE_ADDRESS_0		0x50000000
#define NORDIC_NRF_GPIO_50000000_BASE_ADDRESS_1		0x50000500
#define NORDIC_NRF_GPIO_50000000_LABEL			"GPIO_0"
#define NORDIC_NRF_GPIO_50000000_SIZE_0			512
#define NORDIC_NRF_GPIO_50000000_SIZE_1			768
#define NRF_GPIO_0_BASE_ADDRESS				NORDIC_NRF_GPIO_50000000_BASE_ADDRESS
#define NRF_GPIO_0_LABEL				NORDIC_NRF_GPIO_50000000_LABEL
#define NRF_GPIO_0_SIZE					NORDIC_NRF_GPIO_50000000_SIZE
```
After fix:
```
/* gpio@50000000 */
#define NORDIC_NRF_GPIO_50000000_BASE_ADDRESS_0		0x50000000
#define NORDIC_NRF_GPIO_50000000_BASE_ADDRESS_1		0x50000500
#define NORDIC_NRF_GPIO_50000000_LABEL			"GPIO_0"
#define NORDIC_NRF_GPIO_50000000_SIZE_0			512
#define NORDIC_NRF_GPIO_50000000_SIZE_1			768
#define NRF_GPIO_0_BASE_ADDRESS_0			NORDIC_NRF_GPIO_50000000_BASE_ADDRESS_0
#define NRF_GPIO_0_BASE_ADDRESS_1			NORDIC_NRF_GPIO_50000000_BASE_ADDRESS_1
#define NRF_GPIO_0_LABEL				NORDIC_NRF_GPIO_50000000_LABEL
#define NRF_GPIO_0_SIZE_0				NORDIC_NRF_GPIO_50000000_SIZE_0
#define NRF_GPIO_0_SIZE_1				NORDIC_NRF_GPIO_50000000_SIZE_1
```