### PR TITLE
bluetooth: config: Fix bluetooth config dependencies

### DIFF
--- a/samples/bluetooth/hci_uart/src/main.c
+++ b/samples/bluetooth/hci_uart/src/main.c
@@ -38,7 +38,7 @@ static struct k_thread tx_thread_data;
 NET_BUF_POOL_DEFINE(cmd_tx_pool, CONFIG_BT_HCI_CMD_COUNT, CMD_BUF_SIZE,
 		    BT_BUF_USER_DATA_MIN, NULL);
 
-#if defined(CONFIG_BT_CTLR)
+#if defined(CONFIG_BT_CTLR_TX_BUFFER_SIZE)
 #define BT_L2CAP_MTU (CONFIG_BT_CTLR_TX_BUFFER_SIZE - BT_L2CAP_HDR_SIZE)
 #else
 #define BT_L2CAP_MTU 65 /* 64-byte public key + opcode */

--- a/subsys/bluetooth/common/dummy.c
+++ b/subsys/bluetooth/common/dummy.c
@@ -11,12 +11,14 @@
 
 #include <zephyr.h>
 
+#if defined(CONFIG_BT_HCI_HOST)
 /* The Bluetooth subsystem requires the Tx thread to execute at higher priority
  * than the Rx thread as the Tx thread needs to process the acknowledgements
  * before new Rx data is processed. This is a necessity to correctly detect
  * transaction violations in ATT and SMP protocols.
  */
 BUILD_ASSERT(CONFIG_BT_HCI_TX_PRIO < CONFIG_BT_RX_PRIO);
+#endif
 
 #if defined(CONFIG_BT_CTLR)
 /* The Bluetooth Controller's priority receive thread priority shall be higher


### PR DESCRIPTION
Fix bluetooth config dependencies where the definitions depend on other
definitions.
BT_RX_PRIO is not always defined in a controller only build.
BT_CTLR_TX_BUFFER_SIZE does not depend on BT_CTLR, but BT_LL_SW.

Signed-off-by: Joakim Andersson <joakim.andersson@nordicsemi.no>