### PR TITLE
[RFC] sensor: API: Extend sensor API to allow NMEA sentence as sensor value

### DIFF
--- a/include/sensor.h
+++ b/include/sensor.h
@@ -39,12 +39,24 @@ extern "C" {
  *     -0.5: val1 =  0, val2 = -500000
  *     -1.0: val1 = -1, val2 =  0
  *     -1.5: val1 = -1, val2 = -500000
+ *
+ * Alternatively, the sensor readout may be a string pointer, str.
+ * str_len holds the length of the string pointed to by str.
  */
 struct sensor_value {
-	/** Integer part of the value. */
-	s32_t val1;
-	/** Fractional part of the value (in one-millionth parts). */
-	s32_t val2;
+	union {
+		/** Integer part of the value. */
+		s32_t val1;
+		/** Pointer to string. */
+		char *str;
+	};
+
+	union {
+		/** Fractional part of the value (in one-millionth parts). */
+		s32_t val2;
+		/** Length of the string. */
+		u32_t str_len;
+	};
 };
 
 /**
@@ -142,6 +154,9 @@ enum sensor_channel {
 	SENSOR_CHAN_VOLTAGE,
 	/** Current, in amps **/
 	SENSOR_CHAN_CURRENT,
+
+	/** NMEA sentence */
+	SENSOR_CHAN_NMEA_SENTENCE,
 
 	/** All channels. */
 	SENSOR_CHAN_ALL,


### PR DESCRIPTION
Hi,

this pull request is intended to discuss whether strings could be allowed as sensor values in the sensor API. Currently, sensor values are expected to be a number, with an integer and fractional part. Some sensors, such as GPS sensors, output data as strings with an array of information. In certain use-cases, it would be beneficial for the application to receive the strings directly instead of parsing them and output as numbers on multiple sensor channels and then reassemble to strings again on the application side.

--- 

This commit adds a new channel for NMEA sentences and extends
sensor_value type to allow a string to be fetched from a sensor.
NMEA sentences are ASCII strings typically used by GPS receivers.

Signed-off-by: Jan Tore Guggedal <jantore.guggedal@nordicsemi.no>