### PR TITLE
boards: lpcxpresso54114_m0: fix pinmux.c

### DIFF
--- a/boards/arm/lpcxpresso54114_m0/pinmux.c
+++ b/boards/arm/lpcxpresso54114_m0/pinmux.c
@@ -5,9 +5,9 @@
 
 #include <init.h>
 #include <pinmux.h>
-#include <pin_mux.h>
 #include <fsl_common.h>
-#include <fsl_lpc_iocon.h>
+#include <fsl_iocon.h>
+#include <soc.h>
 
 static int lpcxpresso_54114_pinmux_init(struct device *dev)
 {


### PR DESCRIPTION
Some of the headers referenced in the pinmux.c file don't exist.  Match
the includes that the lpcxpresso54114_m4 pinmux.c file uses.

Signed-off-by: Kumar Gala <kumar.gala@linaro.org>