### PR TITLE
gitignore: Ignore any sanity-out* or build* dir

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,8 +7,7 @@
 *.swp
 *.swo
 *~
-build
-build-*
+build*
 cscope.*
 .dir
 
@@ -30,7 +29,7 @@ doc/boards
 doc/samples
 doc/latex
 doc/themes/zephyr-docs-theme
-sanity-out/
+sanity-out*
 scripts/grub
 doc/reference/kconfig/*.rst
 doc/doc.warnings


### PR DESCRIPTION
Tweak the wildcard matching for any build or sanity-out dir

Signed-off-by: Kumar Gala <kumar.gala@linaro.org>