### PR TITLE
Bluetooth: controller: Fix advertising random delay resolution calc

### DIFF
--- a/subsys/bluetooth/controller/ll_sw/ctrl.c
+++ b/subsys/bluetooth/controller/ll_sw/ctrl.c
@@ -3911,7 +3911,6 @@ static inline u32_t isr_close_adv(void)
 						    (void *)&random_delay,
 						    sizeof(random_delay));
 			random_delay %= 10000;
-			random_delay += 1;
 
 			/* Call to ticker_update can fail under the race
 			 * condition where in the Adv role is being stopped but
@@ -3923,7 +3922,7 @@ static inline u32_t isr_close_adv(void)
 				ticker_update(RADIO_TICKER_INSTANCE_ID_RADIO,
 					RADIO_TICKER_USER_ID_WORKER,
 					RADIO_TICKER_ID_ADV,
-					HAL_TICKER_US_TO_TICKS(random_delay),
+					HAL_TICKER_US_TO_TICKS(random_delay)+1,
 					0, 0, 0, 0, 0, ticker_update_adv_assert,
 					(void *)__LINE__);
 			LL_ASSERT((ticker_status == TICKER_STATUS_SUCCESS) ||


### PR DESCRIPTION
In commit d5836195d7f7 ("Bluetooth: controller: Increase advertising
random delay resolution"), the resolution of random_delay was
increased from 8-bit to 16-bit.  Due to this switch the result
of HAL_TICKER_US_TO_TICKS() can now be a 0, which causes the following
crash:
***** Kernel OOPS! *****
Current thread ID = 0x200043f0
Faulting instruction address = 0x17914
Fatal fault in ISR! Spinning...

Let's make sure we don't pass a 0 to ticker_update() by increasing
the result of HAL_TICKER_US_TO_TICKS() by 1.

Signed-off-by: Michael Scott <mike@foundries.io>