### PR TITLE
boards: x86: Convert boards to use device tree for LEDs & Buttons

### DIFF
--- a/boards/x86/arduino_101/arduino_101.dts
+++ b/boards/x86/arduino_101/arduino_101.dts
@@ -12,6 +12,7 @@
 	compatible = "arduino,101","intel,quark";
 
 	aliases {
+		led0 = &led0;
 		uart-0 = &uart0;
 		uart-1 = &uart1;
 	};
@@ -27,6 +28,14 @@
 		zephyr,bt-uart = &uart0;
 		zephyr,uart-pipe = &uart1;
 		zephyr,bt-mon-uart = &uart1;
+	};
+
+	leds {
+		compatible = "gpio-leds";
+		led0: led_0 {
+			gpios = <&gpio0 8 0>;
+			label = "LED";
+		};
 	};
 };
 

--- a/boards/x86/arduino_101/board.h
+++ b/boards/x86/arduino_101/board.h
@@ -9,9 +9,6 @@
 
 #include <soc.h>
 
-#define LED0_GPIO_PORT  CONFIG_GPIO_QMSI_0_NAME
-#define LED0_GPIO_PIN   8
-
 #if defined(CONFIG_USB)
 /* GPIO driver name */
 #define USB_GPIO_DRV_NAME	CONFIG_GPIO_QMSI_0_NAME

--- a/boards/x86/quark_d2000_crb/board.h
+++ b/boards/x86/quark_d2000_crb/board.h
@@ -9,13 +9,4 @@
 
 #include <soc.h>
 
-
-/* Push button switch 0 */
-#define SW0_GPIO_PIN	2
-#define SW0_GPIO_NAME	CONFIG_GPIO_QMSI_0_NAME
-
-/* Onboard LED */
-#define LED0_GPIO_PORT	CONFIG_GPIO_QMSI_0_NAME
-#define LED0_GPIO_PIN	24
-
 #endif /* __INC_BOARD_H */

--- a/boards/x86/quark_d2000_crb/quark_d2000_crb.dts
+++ b/boards/x86/quark_d2000_crb/quark_d2000_crb.dts
@@ -12,6 +12,8 @@
 	compatible = "intel,quark-d2000-crb", "intel,quark-d2000";
 
 	aliases {
+		led0 = &led0;
+		sw0 = &button0;
 		uart-0 = &uart0;
 		uart-1 = &uart1;
 	};
@@ -20,6 +22,23 @@
 		zephyr,sram = &sram0;
 		zephyr,flash = &flash0;
 		zephyr,console = &uart0;
+	};
+
+	leds {
+		compatible = "gpio-leds";
+		led0: led_0 {
+			gpios = <&gpio 24 0>;
+			label = "LED";
+		};
+	};
+
+	buttons {
+		compatible = "gpio-keys";
+		button0: button_0 {
+			/* gpio flags need validation */
+			gpios = <&gpio 2 GPIO_INT_ACTIVE_LOW>;
+			label = "Push button switch 0";
+		};
 	};
 };
 

--- a/boards/x86/quark_se_c1000_devboard/board.h
+++ b/boards/x86/quark_se_c1000_devboard/board.h
@@ -9,18 +9,6 @@
 
 #include <soc.h>
 
-/* Push button switch 0 */
-#define SW0_GPIO_PIN	4
-#define SW0_GPIO_NAME	CONFIG_GPIO_QMSI_1_NAME
-
-/* Push button switch 1 */
-#define SW1_GPIO_PIN	5
-#define SW1_GPIO_NAME	CONFIG_GPIO_QMSI_0_NAME
-
-/* Onboard LED */
-#define LED0_GPIO_PORT  CONFIG_GPIO_QMSI_0_NAME
-#define LED0_GPIO_PIN   25
-
 #if defined(CONFIG_IEEE802154_CC2520)
 
 /* GPIO numbers where the TI cc2520 chip is connected to */

--- a/boards/x86/quark_se_c1000_devboard/quark_se_c1000_devboard.dts
+++ b/boards/x86/quark_se_c1000_devboard/quark_se_c1000_devboard.dts
@@ -12,6 +12,9 @@
 	compatible = "intel,quark_se_c1000_devboard", "intel,quark_se_c1000";
 
 	aliases {
+		led0 = &led0;
+		sw0 = &button0;
+		sw1 = &button1;
 		uart-0 = &uart0;
 		uart-1 = &uart1;
 	};
@@ -27,6 +30,29 @@
 		zephyr,bt-uart = &uart0;
 		zephyr,uart-pipe = &uart1;
 		zephyr,bt-mon-uart = &uart1;
+	};
+
+	leds {
+		compatible = "gpio-leds";
+		led0: led_0 {
+			gpios = <&gpio0 25 0>;
+			label = "LED";
+		};
+	};
+
+	buttons {
+		/* Push button switch 0 KEY1 */
+		compatible = "gpio-keys";
+		button0: button_0 {
+			/* gpio flags need validation */
+			gpios = <&gpio1 4 GPIO_INT_ACTIVE_LOW>;
+			label = "Push button switch 0";
+		};
+		button1: button_1 {
+			/* gpio flags need validation */
+			gpios = <&gpio0 5 GPIO_INT_ACTIVE_LOW>;
+			label = "Push button switch 1";
+		};
 	};
 };
 

--- a/boards/x86/tinytile/board.h
+++ b/boards/x86/tinytile/board.h
@@ -9,11 +9,6 @@
 
 #include <soc.h>
 
-#if CONFIG_GPIO
-#define LED0_GPIO_PORT  CONFIG_GPIO_QMSI_0_NAME
-#define LED0_GPIO_PIN   8
-#endif
-
 #if defined(CONFIG_USB)
 /* GPIO driver name */
 #define USB_GPIO_DRV_NAME	CONFIG_GPIO_QMSI_0_NAME

--- a/boards/x86/tinytile/tinytile.dts
+++ b/boards/x86/tinytile/tinytile.dts
@@ -12,6 +12,7 @@
 	compatible = "intel,tinytile", "intel,quark_se_c100";
 
 	aliases {
+		led0 = &led0;
 		uart-0 = &uart0;
 		uart-1 = &uart1;
 	};
@@ -27,6 +28,14 @@
 		zephyr,bt-uart = &uart0;
 		zephyr,uart-pipe = &uart1;
 		zephyr,bt-mon-uart = &uart1;
+	};
+
+	leds {
+		compatible = "gpio-leds";
+		led0: led_0 {
+			gpios = <&gpio0 8 0>;
+			label = "LED";
+		};
 	};
 };
 

--- a/dts/x86/intel_curie.dtsi
+++ b/dts/x86/intel_curie.dtsi
@@ -6,6 +6,7 @@
 
 #include "skeleton.dtsi"
 #include <dt-bindings/interrupt-controller/intel-ioapic.h>
+#include <dt-bindings/gpio/gpio.h>
 #include <dt-bindings/i2c/i2c.h>
 
 / {

--- a/dts/x86/intel_quark_d2000.dtsi
+++ b/dts/x86/intel_quark_d2000.dtsi
@@ -6,6 +6,7 @@
 
 #include "skeleton.dtsi"
 #include <dt-bindings/interrupt-controller/intel-mvic.h>
+#include <dt-bindings/gpio/gpio.h>
 #include <dt-bindings/i2c/i2c.h>
 
 / {


### PR DESCRIPTION
Convert over x86 based boards to use device tree instead of board.h to
describe buttons & LEDs.  There are a few boards that the button gpio
flags need validation.

Signed-off-by: Kumar Gala <kumar.gala@linaro.org>