### PR TITLE
Bluetooth: controller: Refactor adv random delay resolution fix

### DIFF
--- a/subsys/bluetooth/controller/ll_sw/ctrl.c
+++ b/subsys/bluetooth/controller/ll_sw/ctrl.c
@@ -3910,7 +3910,9 @@ static inline u32_t isr_close_adv(void)
 			entropy_nrf_get_entropy_isr(_radio.entropy,
 						    (void *)&random_delay,
 						    sizeof(random_delay));
-			random_delay %= 10000;
+
+			random_delay %= HAL_TICKER_US_TO_TICKS(10000);
+			random_delay += 1;
 
 			/* Call to ticker_update can fail under the race
 			 * condition where in the Adv role is being stopped but
@@ -3921,8 +3923,7 @@ static inline u32_t isr_close_adv(void)
 			ticker_status =
 				ticker_update(RADIO_TICKER_INSTANCE_ID_RADIO,
 					RADIO_TICKER_USER_ID_WORKER,
-					RADIO_TICKER_ID_ADV,
-					HAL_TICKER_US_TO_TICKS(random_delay)+1,
+					RADIO_TICKER_ID_ADV, random_delay,
 					0, 0, 0, 0, 0, ticker_update_adv_assert,
 					(void *)__LINE__);
 			LL_ASSERT((ticker_status == TICKER_STATUS_SUCCESS) ||


### PR DESCRIPTION
Refactored the fix in the commit 685da0235446 ("Bluetooth:
controller: Fix advertising random delay resolution calc")
to apply modulo in tick units before adding a tick.

Signed-off-by: Vinayak Kariappa Chettimada <vich@nordicsemi.no>