### PR TITLE
shell: parsing output LF character

### DIFF
--- a/doc/subsystems/shell/shell.rst
+++ b/doc/subsystems/shell/shell.rst
@@ -182,13 +182,13 @@ Simple command handler implementation:
 		ARG_UNUSED(argv);
 
 		shell_fprintf(shell, SHELL_NORMAL,
-			      "Print simple text.\r\n");
+			      "Print simple text.\n");
 
 		shell_fprintf(shell, SHELL_WARNING,
-			      "Print warning text.\r\n");
+			      "Print warning text.\n");
 
 		shell_fprintf(shell, SHELL_ERROR,
-			      "Print error text.\r\n");
+			      "Print error text.\n");
 
 		return 0;
 	}
@@ -234,7 +234,7 @@ checks for valid arguments count.
 
 		shell_fprintf(shell, SHELL_NORMAL,
 			      "Command called with no -h or --help option."
-			      "\r\n");
+			      "\n");
 		return 0;
 	}
 
@@ -249,7 +249,7 @@ checks for valid arguments count.
 		} else {
 			shell_fprintf(shell, SHELL_NORMAL,
 			      "Command called with no -h or --help option."
-			      "\r\n");
+			      "\n");
 		}
 
 		return 0;
@@ -296,19 +296,19 @@ in command handler.
 		/* checking if command was called with test option */
 		if (!strcmp(argv[1], "-t") || !strcmp(argv[1], "--test")) {
 		    shell_fprintf(shell, SHELL_NORMAL, "Command called with -t"
-				  " or --test option.\r\n");
+				  " or --test option.\n");
 		    return 0;
 		}
 
 		/* checking if command was called with dummy option */
 		if (!strcmp(argv[1], "-d") || !strcmp(argv[1], "--dummy")) {
 		    shell_fprintf(shell, SHELL_NORMAL, "Command called with -d"
-				  " or --dummy option.\r\n");
+				  " or --dummy option.\n");
 		    return 0;
 		}
 
 		shell_fprintf(shell, SHELL_WARNING,
-			      "Command called with no valid option.\r\n");
+			      "Command called with no valid option.\n");
 		return 0;
 	}
 
@@ -334,17 +334,16 @@ commands or the parent commands, depending on how you index ``argv``.
 		 * can be found using argv[-1].
 		 */
 		shell_fprintf(shell, SHELL_NORMAL,
-			      "This command has a parent command: %s\r\n",
+			      "This command has a parent command: %s\n",
 			      argv[-1]);
 
 		/* Print this command syntax */
 		shell_fprintf(shell, SHELL_NORMAL,
-			      "This command syntax is: %s\r\n",
+			      "This command syntax is: %s\n",
 			      argv[0]);
 
 		/* Print first argument */
 		shell_fprintf(shell, SHELL_NORMAL,
-			      "This command has an argument: %s\r\n",
 			      argv[1]);
 
 		return 0;
@@ -418,6 +417,20 @@ Usage
 *****
 
 Use the :c:macro:`SHELL_DEFINE` macro to create an instance of the shell.
+Pass expected `shell_flag` parameter to this macro.  Otherwise, the shell
+might not move the terminal cursor to a new line correctly.
+
+.. list-table:: Available shell flags
+   :widths: 10 30
+   :header-rows: 1
+
+   * - Flag
+     - Action
+   * - SHELL_FLAG_CRLF_DEFAULT
+     - Shell does not add LF or CR characters to an output string.
+   * - SHELL_FLAG_OLF_CRLF
+     - The shell parses an output string and it adds a CR character before each
+       found LF character.
 
 The following code shows a simple use case of this library:
 
@@ -427,7 +440,8 @@ The following code shows a simple use case of this library:
 	SHELL_UART_DEFINE(shell_transport_uart);
 
 	/* Creating shell instance */
-	SHELL_DEFINE(uart_shell, "uart:~$ ", &shell_transport_uart, 10);
+	SHELL_DEFINE(uart_shell, "uart:~$ ", &shell_transport_uart, 10,
+		     SHELL_FLAG_OLF_CRLF);
 
 	void main(void)
 	{
@@ -440,7 +454,7 @@ The following code shows a simple use case of this library:
 		ARG_UNUSED(argc);
 		ARG_UNUSED(argv);
 
-		shell_fprintf(shell, SHELL_NORMAL, "pong\r\n");
+		shell_fprintf(shell, SHELL_NORMAL, "pong\n");
 		return 0;
 	}
 
@@ -449,10 +463,10 @@ The following code shows a simple use case of this library:
 	{
 		int cnt;
 
-		shell_fprintf(shell, SHELL_NORMAL, "argc = %d\r\n", argc);
+		shell_fprintf(shell, SHELL_NORMAL, "argc = %d\n", argc);
 		for (cnt = 0; cnt < argc; cnt++) {
 			shell_fprintf(shell, SHELL_NORMAL,
-					"  argv[%d] = %s\r\n", cnt, argv[cnt]);
+					"  argv[%d] = %s\n", cnt, argv[cnt]);
 		}
 		return 0;
 	}

--- a/include/shell/shell_fprintf.h
+++ b/include/shell/shell_fprintf.h
@@ -34,7 +34,6 @@ struct shell_fprintf {
 	struct shell_fprintf_control_block *ctrl_blk;
 };
 
-
 /**
  * @brief Macro for defining shell_fprintf instance.
  *

--- a/samples/subsys/shell/shell_module/src/main.c
+++ b/samples/subsys/shell/shell_module/src/main.c
@@ -15,7 +15,8 @@
 LOG_MODULE_REGISTER(app);
 
 SHELL_UART_DEFINE(shell_transport_uart);
-SHELL_DEFINE(uart_shell, "uart:~$ ", &shell_transport_uart, 10);
+SHELL_DEFINE(uart_shell, "uart:~$ ", &shell_transport_uart, 10,
+	     SHELL_FLAG_OLF_CRLF);
 
 extern void foo(void);
 
@@ -37,7 +38,7 @@ static int cmd_log_test_start(const struct shell *shell, size_t argc,
 	}
 
 	k_timer_start(&log_timer, period, period);
-	shell_fprintf(shell, SHELL_NORMAL, "Log test started\r\n");
+	shell_fprintf(shell, SHELL_NORMAL, "Log test started\n");
 	return 0;
 }
 
@@ -66,7 +67,7 @@ static int cmd_log_test_stop(const struct shell *shell, size_t argc,
 	}
 
 	k_timer_stop(&log_timer);
-	shell_fprintf(shell, SHELL_NORMAL, "Log test stopped\r\n");
+	shell_fprintf(shell, SHELL_NORMAL, "Log test stopped\n");
 
 	return 0;
 }
@@ -96,7 +97,7 @@ static int cmd_demo_ping(const struct shell *shell, size_t argc, char **argv)
 	ARG_UNUSED(argc);
 	ARG_UNUSED(argv);
 
-	shell_fprintf(shell, SHELL_NORMAL, "pong\r\n");
+	shell_fprintf(shell, SHELL_NORMAL, "pong\n");
 
 	return 0;
 }
@@ -105,10 +106,10 @@ static int cmd_demo_params(const struct shell *shell, size_t argc, char **argv)
 {
 	int cnt;
 
-	shell_fprintf(shell, SHELL_NORMAL, "argc = %d\r\n", argc);
+	shell_fprintf(shell, SHELL_NORMAL, "argc = %d\n", argc);
 	for (cnt = 0; cnt < argc; cnt++) {
 		shell_fprintf(shell, SHELL_NORMAL,
-				"  argv[%d] = %s\r\n", cnt, argv[cnt]);
+				"  argv[%d] = %s\n", cnt, argv[cnt]);
 	}
 	return 0;
 }
@@ -119,7 +120,7 @@ static int cmd_version(const struct shell *shell, size_t argc, char **argv)
 	ARG_UNUSED(argv);
 
 	shell_fprintf(shell, SHELL_NORMAL,
-		      "Zephyr version %s\r\n", KERNEL_VERSION_STRING);
+		      "Zephyr version %s\n", KERNEL_VERSION_STRING);
 	return 0;
 }
 

--- a/subsys/shell/shell.c
+++ b/subsys/shell/shell.c
@@ -1154,6 +1154,8 @@ static int shell_instance_init(const struct shell *shell, const void *p_config,
 {
 	__ASSERT_NO_MSG(shell);
 	__ASSERT_NO_MSG(shell->ctx && shell->iface && shell->prompt);
+	__ASSERT_NO_MSG((shell->shell_flag == SHELL_FLAG_CRLF_DEFAULT)	||
+			(shell->shell_flag == SHELL_FLAG_OLF_CRLF));
 
 	int err;
 

--- a/subsys/shell/shell_fprintf.c
+++ b/subsys/shell/shell_fprintf.c
@@ -5,6 +5,7 @@
  */
 
 #include <shell/shell_fprintf.h>
+#include <shell/shell.h>
 
 #ifdef CONFIG_NEWLIB_LIBC
 typedef int (*out_func_t)(int c, void *ctx);
@@ -16,8 +17,14 @@ extern int _prf(int (*func)(), void *dest, char *format, va_list vargs);
 static int out_func(int c, void *ctx)
 {
 	const struct shell_fprintf *sh_fprintf;
+	const struct shell *shell;
 
 	sh_fprintf = (const struct shell_fprintf *)ctx;
+	shell = (const struct shell *)sh_fprintf->user_ctx;
+
+	if ((shell->shell_flag == SHELL_FLAG_OLF_CRLF) && (c == '\n')) {
+		(void)out_func('\r', ctx);
+	}
 
 	sh_fprintf->buffer[sh_fprintf->ctrl_blk->buffer_cnt] = (u8_t)c;
 	sh_fprintf->ctrl_blk->buffer_cnt++;

--- a/tests/bluetooth/shell/src/main.c
+++ b/tests/bluetooth/shell/src/main.c
@@ -34,7 +34,8 @@
 #define DEVICE_NAME CONFIG_BT_DEVICE_NAME
 
 SHELL_UART_DEFINE(shell_transport_uart);
-SHELL_DEFINE(uart_shell, "uart:~$ ", &shell_transport_uart, 10);
+SHELL_DEFINE(uart_shell, "uart:~$ ", &shell_transport_uart, 10,
+	     SHELL_FLAG_CRLF_DEFAULT);
 
 #if defined(CONFIG_BT_CONN)
 static bool hrs_simulate;


### PR DESCRIPTION
Some terminals literally interprets shell output data. Hence to print message in new line shell needs to send `\r\n` each time. To minimize flash usage user can now  send `\n` as a line delimiter and shell will automatically add missing `\r` character.

Signed-off-by: Jakub Rzeszutko <jakub.rzeszutko@nordicsemi.no>