### PR TITLE
net: Make Kconfig template variables prettier

### DIFF
--- a/drivers/ethernet/Kconfig
+++ b/drivers/ethernet/Kconfig
@@ -9,10 +9,10 @@
 menu "Ethernet Drivers"
 
 if NET_L2_ETHERNET
-module=ETHERNET
-module-dep=LOG
-module-str=Log level for Ethernet driver
-module-help=Sets log level for Ethernet Device Drivers.
+module = ETHERNET
+module-dep = LOG
+module-str = Log level for Ethernet driver
+module-help = Sets log level for Ethernet Device Drivers.
 source "subsys/net/Kconfig.template.log_config.net"
 endif # NET_L2_ETHERNET
 

--- a/drivers/ieee802154/Kconfig
+++ b/drivers/ieee802154/Kconfig
@@ -16,10 +16,10 @@ menuconfig IEEE802154
 if IEEE802154
 
 if NET_L2_IEEE802154
-module=IEEE802154
-module-dep=LOG
-module-str=Log level for IEEE 802.15.4 driver
-module-help=Sets log level for IEEE 802.15.4 Device Drivers.
+module = IEEE802154
+module-dep = LOG
+module-str = Log level for IEEE 802.15.4 driver
+module-help = Sets log level for IEEE 802.15.4 Device Drivers.
 source "subsys/net/Kconfig.template.log_config.net"
 endif # NET_L2_IEEE802154
 

--- a/drivers/net/Kconfig
+++ b/drivers/net/Kconfig
@@ -56,10 +56,10 @@ config	SLIP_MTU
 	  data into net_buf's. The actual SLIP connection
 	  does not use this value.
 
-module=SLIP
-module-dep=LOG
-module-str=Log level for slip driver
-module-help=Sets log level for slip driver.
+module = SLIP
+module-dep = LOG
+module-str = Log level for slip driver
+module-help = Sets log level for slip driver.
 source "subsys/net/Kconfig.template.log_config.net"
 
 config	SLIP_STATISTICS
@@ -95,10 +95,10 @@ menuconfig NET_LOOPBACK
 
 if NET_LOOPBACK
 
-module=NET_LOOPBACK
-module-dep=LOG
-module-str=Log level for network loopback driver
-module-help=Sets log level for network loopback driver.
+module = NET_LOOPBACK
+module-dep = LOG
+module-str = Log level for network loopback driver
+module-help = Sets log level for network loopback driver.
 source "subsys/net/Kconfig.template.log_config.net"
 
 endif

--- a/subsys/net/Kconfig
+++ b/subsys/net/Kconfig
@@ -33,10 +33,10 @@ config NET_BUF_LOG
 
 if NET_BUF_LOG
 
-module=NET_BUF
-module-dep=LOG
-module-str=Log level for network buffer handling
-module-help=Sets log level for network buffers.
+module = NET_BUF
+module-dep = LOG
+module-str = Log level for network buffer handling
+module-help = Sets log level for network buffers.
 source "subsys/net/Kconfig.template.log_config.net"
 
 config NET_BUF_WARN_ALLOC_INTERVAL

--- a/subsys/net/lib/app/Kconfig
+++ b/subsys/net/lib/app/Kconfig
@@ -17,10 +17,10 @@ menuconfig NET_APP
 
 if NET_APP
 
-module=NET_APP
-module-dep=NET_LOG
-module-str=Log level for net_app library
-module-help=Enables net app library to output debug messages.
+module = NET_APP
+module-dep = NET_LOG
+module-str = Log level for net_app library
+module-help = Enables net app library to output debug messages.
 source "subsys/net/Kconfig.template.log_config.net"
 
 config NET_APP_SERVER

--- a/subsys/net/lib/coap/Kconfig
+++ b/subsys/net/lib/coap/Kconfig
@@ -63,9 +63,9 @@ config COAP_INIT_ACK_TIMEOUT_MS
 	  This value is used as a base value to retry pending CoAP packets.
 
 if COAP
-module=COAP
-module-dep=NET_LOG
-module-str=Log level for CoAP
-module-help=Enables CoAP debug messages.
+module = COAP
+module-dep = NET_LOG
+module-str = Log level for CoAP
+module-help = Enables CoAP debug messages.
 source "subsys/net/Kconfig.template.log_config.net"
 endif # COAP

--- a/subsys/net/lib/config/Kconfig
+++ b/subsys/net/lib/config/Kconfig
@@ -55,10 +55,10 @@ config NET_CONFIG_NEED_IPV4
 	  This option makes sure the network application is initialized properly
 	  in order to use IPv4.
 
-module=NET_CONFIG
-module-dep=NET_LOG
-module-str=Log level for network config library
-module-help=Enables net config library to output debug messages.
+module = NET_CONFIG
+module-dep = NET_LOG
+module-str = Log level for network config library
+module-help = Enables net config library to output debug messages.
 source "subsys/net/Kconfig.template.log_config.net"
 
 menuconfig NET_CONFIG_SETTINGS

--- a/subsys/net/lib/dns/Kconfig
+++ b/subsys/net/lib/dns/Kconfig
@@ -108,10 +108,10 @@ config DNS_NUM_CONCUR_QUERIES
 	  This defines how many concurrent DNS queries can be generated using
 	  same DNS context. Normally 1 is a good default value.
 
-module=DNS_RESOLVER
-module-dep=NET_LOG
-module-str=Log level for DNS resolver
-module-help=Enables DNS resolver code to output debug messages.
+module = DNS_RESOLVER
+module-dep = NET_LOG
+module-str = Log level for DNS resolver
+module-help = Enables DNS resolver code to output debug messages.
 source "subsys/net/Kconfig.template.log_config.net"
 
 endif # DNS_RESOLVER
@@ -143,10 +143,10 @@ config MDNS_RESPONDER_INIT_PRIO
 	  Note that if NET_CONFIG_AUTO_INIT is enabled, then this value
 	  should be bigger than its value.
 
-module=MDNS_RESPONDER
-module-dep=NET_LOG
-module-str=Log level for mDNS responder
-module-help=Enables mDNS responder code to output debug messages.
+module = MDNS_RESPONDER
+module-dep = NET_LOG
+module-str = Log level for mDNS responder
+module-help = Enables mDNS responder code to output debug messages.
 source "subsys/net/Kconfig.template.log_config.net"
 
 config MDNS_RESOLVER_ADDITIONAL_BUF_CTR
@@ -188,10 +188,10 @@ config LLMNR_RESPONDER_INIT_PRIO
 	  Note that if NET_CONFIG_AUTO_INIT is enabled, then this value
 	  should be bigger than its value.
 
-module=LLMNR_RESPONDER
-module-dep=NET_LOG
-module-str=Log level for LLMNR responder
-module-help=Enables LLMNR responder code to output debug messages.
+module = LLMNR_RESPONDER
+module-dep = NET_LOG
+module-str = Log level for LLMNR responder
+module-help = Enables LLMNR responder code to output debug messages.
 source "subsys/net/Kconfig.template.log_config.net"
 
 config LLMNR_RESOLVER_ADDITIONAL_BUF_CTR

--- a/subsys/net/lib/http/Kconfig
+++ b/subsys/net/lib/http/Kconfig
@@ -67,10 +67,10 @@ config HTTP_CLIENT_NETWORK_TIMEOUT
 	  Default network activity timeout in seconds.  This setting is used
 	  for TCP connection timeout.
 
-module=HTTP
-module-dep=NET_LOG
-module-str=Log level for HTTP
-module-help=Enables routing engine debug messages.
+module = HTTP
+module-dep = NET_LOG
+module-str = Log level for HTTP
+module-help = Enables routing engine debug messages.
 source "subsys/net/Kconfig.template.log_config.net"
 
 config  NET_DEBUG_HTTP_CONN

--- a/subsys/net/lib/lwm2m/Kconfig
+++ b/subsys/net/lib/lwm2m/Kconfig
@@ -14,9 +14,9 @@ menuconfig LWM2M
 
 if LWM2M
 
-module=LWM2M
-module-dep=LOG
-module-str=Log level for LWM2M library
+module = LWM2M
+module-dep = LOG
+module-str = Log level for LWM2M library
 source "subsys/net/Kconfig.template.log_config.net"
 
 config LWM2M_ENGINE_STACK_SIZE

--- a/subsys/net/lib/sntp/Kconfig
+++ b/subsys/net/lib/sntp/Kconfig
@@ -12,10 +12,10 @@ menuconfig SNTP
 
 if SNTP
 
-module=SNTP
-module-dep=NET_LOG
-module-str=Log level for SNTP
-module-help=Enable debug message of SNTP client library.
+module = SNTP
+module-dep = NET_LOG
+module-str = Log level for SNTP
+module-help = Enable debug message of SNTP client library.
 source "subsys/net/Kconfig.template.log_config.net"
 
 endif # SNTP

--- a/subsys/net/lib/sockets/Kconfig
+++ b/subsys/net/lib/sockets/Kconfig
@@ -96,10 +96,10 @@ config NET_SOCKETS_OFFLOAD
 	  See NET_OFFLOAD for a more deeply integrated approach which offloads
 	  from the net_context() API within the Zephyr IP stack.
 
-module=NET_SOCKETS
-module-dep=NET_LOG
-module-str=Log level for BSD sockets compatible API calls
-module-help=Enables logging for sockets code.
+module = NET_SOCKETS
+module-dep = NET_LOG
+module-str = Log level for BSD sockets compatible API calls
+module-help = Enables logging for sockets code.
 source "subsys/net/Kconfig.template.log_config.net"
 
 endif # NET_SOCKETS

--- a/subsys/net/lib/websocket/Kconfig
+++ b/subsys/net/lib/websocket/Kconfig
@@ -13,10 +13,10 @@ menuconfig WEBSOCKET
 
 if WEBSOCKET
 
-module=WEBSOCKET
-module-dep=NET_LOG
-module-str=Log level for weboscket library
-module-help=Enables websocket library to output debug messages.
+module = WEBSOCKET
+module-dep = NET_LOG
+module-str = Log level for weboscket library
+module-help = Enables websocket library to output debug messages.
 source "subsys/net/Kconfig.template.log_config.net"
 
 endif # WEBSOCKET

--- a/subsys/usb/class/netusb/Kconfig
+++ b/subsys/usb/class/netusb/Kconfig
@@ -87,9 +87,9 @@ endif # USB_DEVICE_NETWORK_RNDIS
 
 if USB_DEVICE_NETWORK
 
-module=USB_DEVICE_NETWORK
-module-dep=LOG
-module-str=USR Device Network log level
+module = USB_DEVICE_NETWORK
+module-dep = LOG
+module-str = USB Device Network log level
 source "subsys/net/Kconfig.template.log_config.net"
 
 endif # USB_DEVICE_NETWORK


### PR DESCRIPTION
Adding spaces around "=" when definining Kconfig template so
that is more consistent with overall style of these template
variables.

Signed-off-by: Jukka Rissanen <jukka.rissanen@linux.intel.com>