### PR TITLE
Bluetooth: L2CAP: Process received packets on system wq

### DIFF
--- a/drivers/bluetooth/hci/h4.c
+++ b/drivers/bluetooth/hci/h4.c
@@ -16,6 +16,7 @@
 #include <uart.h>
 #include <misc/util.h>
 #include <misc/byteorder.h>
+#include <misc/stack.h>
 #include <string.h>
 
 #include <bluetooth/bluetooth.h>
@@ -129,6 +130,9 @@ static inline void get_evt_hdr(void)
 			rx.discardable = true;
 			break;
 #endif
+		case BT_HCI_EVT_DISCONN_COMPLETE:
+			STACK_ANALYZE("rx stack", rx_thread_stack);
+			break;
 		}
 	}
 

--- a/include/bluetooth/l2cap.h
+++ b/include/bluetooth/l2cap.h
@@ -78,6 +78,8 @@ struct bt_l2cap_chan {
 	bt_l2cap_chan_destroy_t		destroy;
 	/* Response Timeout eXpired (RTX) timer */
 	struct k_delayed_work		rtx_work;
+	struct k_work			rx_work;
+	struct k_fifo			rx_queue;
 #if defined(CONFIG_BT_L2CAP_DYNAMIC_CHANNEL)
 	bt_l2cap_chan_state_t		state;
 	/** Remote PSM to be connected */


### PR DESCRIPTION
This avoid processing packets for upper layers in the RX thread which
should potentially avoid growing its stack even bigger since protocols
on top of L2CAP would be using the system wq stack.