### PR TITLE
tracing: don't include kernel_structs.h from tracing_sysview.h

### DIFF
--- a/subsys/debug/tracing/include/tracing_sysview.h
+++ b/subsys/debug/tracing/include/tracing_sysview.h
@@ -6,7 +6,6 @@
 #ifndef _TRACE_SYSVIEW_H
 #define _TRACE_SYSVIEW_H
 #include <kernel.h>
-#include <kernel_structs.h>
 #include <init.h>
 
 #include <systemview/SEGGER_SYSVIEW.h>


### PR DESCRIPTION
Remove a private unused include from the sysview tracing header which is causing build errors when used in bluetooth's smp.c.