### PR TITLE
drivers/spi: stm32: fix warning in SYS_LOG_ERR macro

### DIFF
--- a/drivers/spi/spi_ll_stm32.c
+++ b/drivers/spi/spi_ll_stm32.c
@@ -54,7 +54,7 @@ static int spi_stm32_get_err(SPI_TypeDef *spi)
 
 	if (sr & SPI_STM32_ERR_MSK) {
 		SYS_LOG_ERR("%s: err=%d", __func__,
-			    sr & SPI_STM32_ERR_MSK);
+			    sr & (u32_t)SPI_STM32_ERR_MSK);
 
 		/* OVR error must be explicitly cleared */
 		if (LL_SPI_IsActiveFlag_OVR(spi)) {


### PR DESCRIPTION
Following log subsystem rework, a warning poped-up in SYS_LOG_ERR
in spi_stm32_get_err macro.

Fixes #10380

Signed-off-by: Erwan Gouriou <erwan.gouriou@linaro.org>