### PR TITLE
userspace: move KOBJECT_TEXT_AREA and PRIV_STACKS_TEXT_AREA  to Kconfig

### DIFF
--- a/arch/Kconfig
+++ b/arch/Kconfig
@@ -95,6 +95,22 @@ config PRIVILEGED_STACK_SIZE
 	  this region will be inaccessible from user mode.  During system calls,
 	  this region will be utilized by the system call.
 
+config PRIVILEGED_STACK_TEXT_AREA
+	int "Privileged stacks text area"
+	default 256 if (DEBUG || STACK_CANARIES)
+	default 128
+	depends on ARCH_HAS_USERSPACE
+	help
+	  Stack text area size for privileged stacks.
+
+config KOBJECT_TEXT_AREA
+	int "Size if kobject text area"
+	default 256 if (!SIZE_OPTIMIZATIONS || STACK_CANARIES || ARC)
+	default 128
+	depends on ARCH_HAS_USERSPACE
+	help
+	  Size of kernel object text area. Used in linker script.
+
 config STACK_GROWS_UP
 	bool "Stack grows towards higher memory addresses"
 	help

--- a/include/arch/arc/v2/linker.ld
+++ b/include/arch/arc/v2/linker.ld
@@ -21,8 +21,6 @@
 #include <linker/linker-defs.h>
 #include <linker/linker-tool.h>
 
-#define KOBJECT_TEXT_AREA 256
-
 /* physical address of RAM */
 #ifdef CONFIG_HARVARD
 	#define ROMABLE_REGION ICCM

--- a/include/linker/kobject-text.ld
+++ b/include/linker/kobject-text.ld
@@ -1,11 +1,3 @@
-#ifndef KOBJECT_TEXT_AREA
-#if ! defined(CONFIG_SIZE_OPTIMIZATIONS) || defined(CONFIG_STACK_CANARIES)
-#define KOBJECT_TEXT_AREA	256
-#else
-#define KOBJECT_TEXT_AREA	128
-#endif
-#endif
-
 #ifdef CONFIG_USERSPACE
 	/* We need to reserve room for the gperf generated hash functions.
 	 * Fortunately, unlike the data tables, the size of the code is
@@ -26,6 +18,6 @@
 	PROVIDE(_k_object_wordlist_foreach = .);
 #endif
 #endif
-	. += KOBJECT_TEXT_AREA - (_kobject_text_area_end - _kobject_text_area_start);
+	. += CONFIG_KOBJECT_TEXT_AREA - (_kobject_text_area_end - _kobject_text_area_start);
 #endif /* CONFIG_USERSPACE */
 

--- a/include/linker/priv_stacks-text.ld
+++ b/include/linker/priv_stacks-text.ld
@@ -3,14 +3,6 @@
  *
  * SPDX-License-Identifier: Apache-2.0
  */
-#ifndef PRIV_STACKS_TEXT_AREA
-#if defined(CONFIG_DEBUG) || defined(CONFIG_STACK_CANARIES)
-#define PRIV_STACKS_TEXT_AREA	256
-#else
-#define PRIV_STACKS_TEXT_AREA	128
-#endif
-#endif
-
 #ifdef CONFIG_USERSPACE
 	/* We need to reserve room for the gperf generated hash functions.
 	 * Fortunately, unlike the data tables, the size of the code is
@@ -25,6 +17,6 @@
 #ifndef LINKER_PASS2
 	PROVIDE(_k_priv_stack_find = .);
 #endif
-	. += PRIV_STACKS_TEXT_AREA - (_priv_stacks_text_area_end - _priv_stacks_text_area_start);
+	. += CONFIG_PRIVILEGED_STACK_TEXT_AREA - (_priv_stacks_text_area_end - _priv_stacks_text_area_start);
 #endif /* CONFIG_USERSPACE */
 


### PR DESCRIPTION
Instead of hardcoding in linker script, use a Kconfig and deal with
dependencies in Kconfig instead of directly in the linker file.

Signed-off-by: Anas Nashif <anas.nashif@intel.com>