### PR TITLE
subsys: usb: Change the buffer fragmentation for IN transfers.

### DIFF
--- a/subsys/usb/usb_device.c
+++ b/subsys/usb/usb_device.c
@@ -234,7 +234,7 @@ static bool usb_handle_request(struct usb_setup_packet *setup,
  */
 static void usb_data_to_host(void)
 {
-	u32_t chunk = min(MAX_PACKET_SIZE0, usb_dev.data_buf_residue);
+	u32_t chunk = usb_dev.data_buf_residue;
 
 	/*Always EP0 for control*/
 	usb_dc_ep_write(0x80, usb_dev.data_buf, chunk, &chunk);


### PR DESCRIPTION
USB controller was performing the fragmentation by itself and the driver
was not aware if current chunk is the last one if data size is equal to
maximum chunk size. Some hardware controllers (i.e. in nRF52840) handle
the status stage by hardware which must be triggered after the last data
chunk.
Currently, the whole remaining data is passed to the driver, and the
driver decides whether to fragment the data internally, or send only
the chunk and report back to the stack.

Signed-off-by: Paweł Zadrożniak <pawel.zadrozniak@nordicsemi.no>