### PR TITLE
arm: beetle: Fix UART1 IRQ number

### DIFF
--- a/boards/arm/v2m_beetle/v2m_beetle.dts
+++ b/boards/arm/v2m_beetle/v2m_beetle.dts
@@ -63,7 +63,7 @@
 		uart1: uart@40005000 {
 			compatible = "arm,cmsdk-uart";
 			reg = <0x40005000 0x1000>;
-			interrupts = <1 3>;
+			interrupts = <2 3>;
 			current-speed = <115200>;
 			label = "UART_1";
 		};


### PR DESCRIPTION
The commit de78ecd "arm: beetle: Use device tree for IRQs" introduces
a regression related to UART1 IRQ.

On arm beetle the UART1 has IRQ number 2.

This patch restores the functionality modifying the arm beetle device
tree file.

Signed-off-by: Vincenzo Frascino <vincenzo.frascino@linaro.org>