### PR TITLE
net: arp: Add support for receiving gratuitous ARP request

### DIFF
--- a/subsys/net/l2/ethernet/Kconfig
+++ b/subsys/net/l2/ethernet/Kconfig
@@ -54,6 +54,19 @@ config NET_ARP_TABLE_SIZE
 	help
 	  Each entry in the ARP table consumes 22 bytes of memory.
 
+config NET_ARP_GRATUITOUS
+	bool "Support gratuitous ARP requests/replies."
+	depends on NET_ARP
+	default y
+	help
+	  Gratuitous in this case means a ARP request or reply that is not
+	  normally needed according to the ARP specification but could be used
+	  in some cases. A gratuitous ARP request is a ARP request packet where
+	  the source and destination IP are both set to the IP of the machine
+	  issuing the packet and the destination MAC is the broadcast address
+	  ff:ff:ff:ff:ff:ff. Ordinarily, no reply packet will occur.
+	  A gratuitous ARP reply is a reply to which no request has been made.
+
 if NET_ARP
 module = NET_ARP
 module-dep = NET_LOG


### PR DESCRIPTION
If we receive a valid gratuitous ARP request, then update ARP
cache accordingly. This feature is optional and by default
it is enabled, but can be turned off if needed.

Signed-off-by: Jukka Rissanen <jukka.rissanen@linux.intel.com>