### PR TITLE
kernel: remove deprecated k_thread_cancel

### DIFF
--- a/include/kernel.h
+++ b/include/kernel.h
@@ -854,21 +854,6 @@ __syscall void k_wakeup(k_tid_t thread);
 __syscall k_tid_t k_current_get(void);
 
 /**
- * @brief Cancel thread performing a delayed start.
- *
- * This routine prevents @a thread from executing if it has not yet started
- * execution. The thread must be re-spawned before it will execute.
- *
- * @param thread ID of thread to cancel.
- *
- * @retval 0 Thread spawning canceled.
- * @retval -EINVAL Thread has already started executing.
- *
- * @deprecated This API is deprecated.  Use k_thread_abort().
- */
-__deprecated __syscall int k_thread_cancel(k_tid_t thread);
-
-/**
  * @brief Abort a thread.
  *
  * This routine permanently stops execution of @a thread. The thread is taken

--- a/kernel/thread.c
+++ b/kernel/thread.c
@@ -514,32 +514,6 @@ Z_SYSCALL_HANDLER(k_thread_create,
 #endif /* CONFIG_USERSPACE */
 #endif /* CONFIG_MULTITHREADING */
 
-/* LCOV_EXCL_START */
-int _impl_k_thread_cancel(k_tid_t tid)
-{
-	struct k_thread *thread = tid;
-
-	unsigned int key = irq_lock();
-
-	if (_has_thread_started(thread) ||
-	    !_is_thread_timeout_active(thread)) {
-		irq_unlock(key);
-		return -EINVAL;
-	}
-
-	(void)_abort_thread_timeout(thread);
-	_thread_monitor_exit(thread);
-
-	irq_unlock(key);
-
-	return 0;
-}
-
-#ifdef CONFIG_USERSPACE
-Z_SYSCALL_HANDLER1_SIMPLE(k_thread_cancel, K_OBJ_THREAD, struct k_thread *);
-#endif
-/* LCOV_EXCL_STOP */
-
 void _k_thread_single_suspend(struct k_thread *thread)
 {
 	if (_is_thread_ready(thread)) {


### PR DESCRIPTION
Remove deprecated function k_thread_cancel. We now use k_thread_abort.

Signed-off-by: Anas Nashif <anas.nashif@intel.com>