### PR TITLE
include: posix: unistd: Fix prototypes and dependency

### DIFF
--- a/include/posix/time.h
+++ b/include/posix/time.h
@@ -27,8 +27,8 @@ struct timeval {
 
 #include <kernel.h>
 #include <errno.h>
-#include "sys/types.h"
-#include "signal.h"
+#include <sys/types.h>
+#include <signal.h>
 
 #ifndef CLOCK_REALTIME
 #define CLOCK_REALTIME 0

--- a/include/posix/time.h
+++ b/include/posix/time.h
@@ -28,7 +28,7 @@ struct timeval {
 #include <kernel.h>
 #include <errno.h>
 #include <sys/types.h>
-#include <signal.h>
+#include <posix/signal.h>
 
 #ifndef CLOCK_REALTIME
 #define CLOCK_REALTIME 0

--- a/include/posix/unistd.h
+++ b/include/posix/unistd.h
@@ -13,7 +13,7 @@ extern "C" {
 #include "sys/types.h"
 #include "sys/stat.h"
 
-#ifdef CONFIG_POSIX_FS
+#ifdef CONFIG_POSIX_API
 #include <fs.h>
 
 typedef unsigned int mode_t;
@@ -21,9 +21,9 @@ typedef unsigned int mode_t;
 /* File related operations */
 extern int open(const char *name, int flags);
 extern int close(int file);
-extern ssize_t write(int file, char *buffer, unsigned int count);
-extern ssize_t read(int file, char *buffer, unsigned int count);
-extern int lseek(int file, int offset, int whence);
+extern ssize_t write(int file, const void *buffer, size_t count);
+extern ssize_t read(int file, void *buffer, size_t count);
+extern off_t lseek(int file, off_t offset, int whence);
 
 /* File System related operations */
 extern int rename(const char *old, const char *newp);

--- a/lib/posix/fs.c
+++ b/lib/posix/fs.c
@@ -151,7 +151,7 @@ int close(int fd)
  *
  * See IEEE 1003.1
  */
-ssize_t write(int fd, char *buffer, unsigned int count)
+ssize_t write(int fd, const void *buffer, size_t count)
 {
 	ssize_t rc;
 	struct fs_file_t *ptr = NULL;
@@ -175,7 +175,7 @@ ssize_t write(int fd, char *buffer, unsigned int count)
  *
  * See IEEE 1003.1
  */
-ssize_t read(int fd, char *buffer, unsigned int count)
+ssize_t read(int fd, void *buffer, size_t count)
 {
 	ssize_t rc;
 	struct fs_file_t *ptr = NULL;
@@ -199,7 +199,7 @@ ssize_t read(int fd, char *buffer, unsigned int count)
  *
  * See IEEE 1003.1
  */
-int lseek(int fd, int offset, int whence)
+off_t lseek(int fd, off_t offset, int whence)
 {
 	int rc;
 	struct fs_file_t *ptr = NULL;

--- a/tests/posix/fs/src/test_fs_file.c
+++ b/tests/posix/fs/src/test_fs_file.c
@@ -32,30 +32,30 @@ static int test_file_open(void)
 
 int test_file_write(void)
 {
-	int brw;
-	int res;
+	ssize_t brw;
+	off_t res;
 
 	TC_PRINT("\nWrite tests:\n");
 
 	res = lseek(file, 0, SEEK_SET);
-	if (res) {
-		TC_PRINT("lseek failed [%d]\n", res);
+	if (res != 0) {
+		TC_PRINT("lseek failed [%d]\n", (int)res);
 		close(file);
-		return res;
+		return TC_FAIL;
 	}
 
 	TC_PRINT("Data written:\"%s\"\n\n", test_str);
 
 	brw = write(file, (char *)test_str, strlen(test_str));
 	if (brw < 0) {
-		TC_PRINT("Failed writing to file [%d]\n", brw);
+		TC_PRINT("Failed writing to file [%d]\n", (int)brw);
 		close(file);
-		return brw;
+		return TC_FAIL;
 	}
 
 	if (brw < strlen(test_str)) {
 		TC_PRINT("Unable to complete write. Volume full.\n");
-		TC_PRINT("Number of bytes written: [%d]\n", brw);
+		TC_PRINT("Number of bytes written: [%d]\n", (int)brw);
 		close(file);
 		return TC_FAIL;
 	}
@@ -67,25 +67,25 @@ int test_file_write(void)
 
 static int test_file_read(void)
 {
-	int brw;
-	int res;
+	ssize_t brw;
+	off_t res;
 	char read_buff[80];
 	size_t sz = strlen(test_str);
 
 	TC_PRINT("\nRead tests:\n");
 
 	res = lseek(file, 0, SEEK_SET);
-	if (res) {
-		TC_PRINT("lseek failed [%d]\n", res);
+	if (res != 0) {
+		TC_PRINT("lseek failed [%d]\n", (int)res);
 		close(file);
-		return res;
+		return TC_FAIL;
 	}
 
 	brw = read(file, read_buff, sz);
 	if (brw < 0) {
-		TC_PRINT("Failed reading file [%d]\n", brw);
+		TC_PRINT("Failed reading file [%d]\n", (int)brw);
 		close(file);
-		return brw;
+		return TC_FAIL;
 	}
 
 	read_buff[brw] = 0;


### PR DESCRIPTION
For read/write/lseek, use size_t and off_t types, as mandated by
POSIX:
http://pubs.opengroup.org/onlinepubs/9699919799/basedefs/unistd.h.html

Also, prototypes of unistd.h functions should not depend on
CONFIG_POSIX_FS, as (many) of them deal with generic I/O, not with
files in filesystem per se.

Signed-off-by: Paul Sokolovsky <paul.sokolovsky@linaro.org>