### PR TITLE
net: Fix assert on net_if_api send for NET_OFFLOAD drivers

### DIFF
--- a/subsys/net/ip/net_if.c
+++ b/subsys/net/ip/net_if.c
@@ -236,11 +236,16 @@ static inline void init_iface(struct net_if *iface)
 {
 	const struct net_if_api *api = net_if_get_device(iface)->driver_api;
 
-	NET_ASSERT(api && api->init && api->send);
+	NET_ASSERT(api && api->init);
 
 	NET_DBG("On iface %p", iface);
 
 	api->init(iface);
+
+	/* Test for api->send only when ip is *not* offloaded: */
+	if (!net_if_is_ip_offloaded(iface)) {
+		NET_ASSERT(api->send);
+	}
 }
 
 enum net_verdict net_if_send_data(struct net_if *iface, struct net_pkt *pkt)


### PR DESCRIPTION
Recently, the wifi net offload driver has been asserting
as init_iface() was checking for api->send != NULL, even in
the case of NET_OFFLOAD

This patch suggests a fix to handle the NET_OFFLOAD case.

Signed-off-by: Gil Pitney <gil.pitney@linaro.org>