### PR TITLE
net: sockets: Unblock threads waiting on recv on socket close

### DIFF
--- a/subsys/net/lib/sockets/sockets.c
+++ b/subsys/net/lib/sockets/sockets.c
@@ -51,6 +51,9 @@ static void zsock_flush_queue(struct net_context *ctx)
 			net_pkt_unref(p);
 		}
 	}
+
+	/* Some threads might be waiting on recv, cancel the wait */
+	k_fifo_cancel_wait(&ctx->recv_q);
 }
 
 int _impl_zsock_socket(int family, int type, int proto)


### PR DESCRIPTION
This commit fixes the issue that if a thread is waiting on recv for data and the user closes the socket, the waiting thread is not unblocked.

Signed-off-by: Léonard Bise <leonard.bise@gmail.com>