### PR TITLE
drivers: dma: stm32f4: Fix typo introduced with new logger

### DIFF
--- a/drivers/dma/dma_stm32f4x.c
+++ b/drivers/dma/dma_stm32f4x.c
@@ -381,7 +381,7 @@ static int dma_stm32_config(struct device *dev, u32_t id,
 	}
 
 	if ((MEMORY_TO_MEMORY == stream->direction) && (!ddata->mem2mem)) {
-		SYS_LOG_ERR("DMA error: Memcopy not supported for device %s",
+		LOG_ERR("DMA error: Memcopy not supported for device %s",
 				dev->config->name);
 		return -EINVAL;
 	}


### PR DESCRIPTION
Compilation of this driver was broken by commit 07ff2d5
as reported in issue #10453. This commit is fixing it.

Fixes #10453

Signed-off-by: Armando Visconti <armando.visconti@st.com>