### PR TITLE
arch: add big endian support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -765,6 +765,7 @@ if(CONFIG_GEN_ISR_TABLES)
     --output-source isr_tables.c
     --kernel $<TARGET_FILE:zephyr_prebuilt>
     --intlist isrList.bin
+    $<$<BOOL:${CONFIG_BIG_ENDIAN}>:--big-endian>
     $<$<BOOL:${CMAKE_VERBOSE_MAKEFILE}>:--debug>
     ${GEN_ISR_TABLE_EXTRA_ARG}
     DEPENDS zephyr_prebuilt

--- a/arch/Kconfig
+++ b/arch/Kconfig
@@ -61,6 +61,17 @@ module = MPU
 module-str = mpu
 source "subsys/logging/Kconfig.template.log_config"
 
+config BIG_ENDIAN
+       bool
+       help
+         This option tells the build system that the target system is
+         big-endian.  Little-endian architecture is the default and
+         should leave this option unselected.  This option is selected
+         by arch/$ARCH/Kconfig, soc/**/Kconfig, or boards/**/Kconfig
+         and the user should generally avoid modifying it.  The option
+         is used to select linker script OUTPUT_FORMAT and command
+         line option for gen_isr_tables.py.
+
 config HW_STACK_PROTECTION
 	bool "Hardware Stack Protection"
 	depends on ARCH_HAS_STACK_PROTECTION

--- a/include/linker/linker-tool-gcc.h
+++ b/include/linker/linker-tool-gcc.h
@@ -16,7 +16,12 @@
 #define ZEPHYR_INCLUDE_LINKER_LINKER_TOOL_GCC_H_
 
 #if defined(CONFIG_ARM)
-	OUTPUT_FORMAT("elf32-littlearm", "elf32-bigarm", "elf32-littlearm")
+#if defined(CONFIG_BIG_ENDIAN)
+#define OUTPUT_FORMAT_ "elf32-bigarm"
+#else
+#define OUTPUT_FORMAT_ "elf32-littlearm"
+#endif
+	OUTPUT_FORMAT(OUTPUT_FORMAT_)
 #elif defined(CONFIG_ARC)
 	OUTPUT_FORMAT("elf32-littlearc", "elf32-bigarc", "elf32-littlearc")
 #elif defined(CONFIG_X86)


### PR DESCRIPTION
This patch adds Big Endian architecture support.  Even if a compiler
generating big endian object files is used, our linker script, or
include/linker/linker-tool-gcc.h to be precise, has default output
format as little endian.

This patch adds a hidden config CONFIG_BIG_ENDIAN, which should be set
by big endian architectures or a SoC's, and adds an condition to
switch OUTPUT_FORMAT in our linker.cmd.

Signed-off-by: Yasushi SHOJI <y-shoji@ispace-inc.com>