### PR TITLE
Bluetooth: Controller: Use a different flag for speed optimization

### DIFF
--- a/subsys/bluetooth/controller/CMakeLists.txt
+++ b/subsys/bluetooth/controller/CMakeLists.txt
@@ -62,7 +62,7 @@ zephyr_library_include_directories(
 
 zephyr_library_compile_options_ifdef(
   CONFIG_BT_CTLR_FAST_ENC
-  -Ofast
+  ${OPTIMIZE_FOR_SPEED_FLAG}
   )
 
 zephyr_library_link_libraries(subsys__bluetooth)


### PR DESCRIPTION
The bluetooth controller has been using the flag '-Ofast' to keep
within a real-time limit. There are two problems with this; firstly,
when a project should be optimized for size it is standard to use -O2,
not -Ofast.

Secondly, optimization flags have been deemed to be non-portable, so
instead of directly using "-Ofast" we should use the intent-macro
OPTIMIZE_FOR_SPEED_FLAG to ensure toolchain portability.

Changing from -Ofast to -O2 is expected to make the controller run
slower, so testing must be done to ensure we are still within the
real-time limit.

Signed-off-by: Sebastian Bøe <sebastian.boe@nordicsemi.no>