### PR TITLE
drivers: serial: nrf: remove obsolete PIN Kconfig definitions

### DIFF
--- a/drivers/serial/Kconfig.nrfx
+++ b/drivers/serial/Kconfig.nrfx
@@ -99,36 +99,6 @@ config UART_1_NRF_FLOW_CONTROL
 	  Enable flow control. If selected, additionally two pins, RTS and CTS
 	  have to be configured.
 
-config UART_1_NRF_TX_PIN
-	int "TX Pin Number"
-	range 0 47 if SOC_NRF52840_QIAA
-	range 0 31
-	help
-	  The GPIO pin to use for TX.
-
-config UART_1_NRF_RX_PIN
-	int "RX Pin Number"
-	range 0 47 if SOC_NRF52840_QIAA
-	range 0 31
-	help
-	  The GPIO pin to use for RX.
-
-config UART_1_NRF_CTS_PIN
-	int "CTS Pin Number"
-	range 0 47 if SOC_NRF52840_QIAA
-	range 0 31
-	depends on UART_1_NRF_FLOW_CONTROL
-	help
-	  The GPIO pin to use for CTS.
-
-config UART_1_NRF_RTS_PIN
-	int "RTS Pin Number"
-	range 0 47 if SOC_NRF52840_QIAA
-	range 0 31
-	depends on UART_1_NRF_FLOW_CONTROL
-	help
-	  The GPIO pin to use for RTS.
-
 config UART_1_NRF_TX_BUFFER_SIZE
 	int "Size of RAM buffer"
 	range 1 65535


### PR DESCRIPTION
This commit removes the Kconfig symbol definitions
that signify the UARTE_1 pins. The symbols are
already removed for UARTE_0 in #9694.

Signed-off-by: Ioannis Glaropoulos <Ioannis.Glaropoulos@nordicsemi.no>