### PR TITLE
arch: arm: re-program MPU stack guard upon userspace enter

### DIFF
--- a/arch/arm/core/userspace.S
+++ b/arch/arm/core/userspace.S
@@ -40,6 +40,15 @@ SECTION_FUNC(TEXT,_arm_userspace_enter)
     /* move user_entry to lr */
     mov lr, r0
 
+#if defined (CONFIG_MPU_STACK_GUARD)
+    /* Re-program MPU to guard the privileged stack. */
+    push {r1,r2,r3,lr}
+    ldr r0, =_kernel
+    ldr r0, [r0, #_kernel_offset_to_current]
+    bl configure_mpu_stack_guard
+    pop {r1,r2,r3,lr}
+#endif
+
     /* set stack to priviliged stack */
     ldr r0, =_kernel
     ldr r0, [r0, #_kernel_offset_to_current]


### PR DESCRIPTION
Because before entering userspace, the MPU stack guard is
configured to guard the default (i.e. afterwards, the "user")
thread stack, as the privileged stack has not yet been set. Upon
entering userspace the MPU stack guard needs to be re-programmed
to the privileged stack, otherwise, there is a risk that the
first system call might be serviced without privileged stack
protection, if it occurs before any context-switch. This commit
fixes this issue, by calling configure_mpu_stack_guard(..) upon
userspace entering.

Signed-off-by: Ioannis Glaropoulos <Ioannis.Glaropoulos@nordicsemi.no>