### PR TITLE
Docs build fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,7 +7,7 @@
 *.swp
 *.swo
 *~
-build*
+build*/
 cscope.*
 .dir
 

--- a/doc/CMakeLists.txt
+++ b/doc/CMakeLists.txt
@@ -68,8 +68,75 @@ set(DOC_LOG ${CMAKE_CURRENT_BINARY_DIR}/doc.log)
 set(DOXY_LOG ${CMAKE_CURRENT_BINARY_DIR}/doxy.log)
 set(SPHINX_LOG ${CMAKE_CURRENT_BINARY_DIR}/sphinx.log)
 set(DOC_WARN ${CMAKE_CURRENT_BINARY_DIR}/doc.warnings)
+set(CONTENT_OUTPUTS ${CMAKE_CURRENT_BINARY_DIR}/extracted-content.txt)
 
 configure_file(${DOXYFILE_IN} ${DOXYFILE_OUT} @ONLY)
+
+# This command is used to copy all documentation source files into the
+# build directory. Sphinx requires a single documentation root, but
+# Zephyr's documentation is scattered around the tree in samples/,
+# boards/, and doc/, so we need to copy those files into a single
+# place in the build directory.
+set(EXTRACT_CONTENT_COMMAND
+  ${CMAKE_COMMAND} -E env
+  ${PYTHON_EXECUTABLE} scripts/extract_content.py
+  # Save the outputs for processing by this list file.
+  --outputs ${CONTENT_OUTPUTS}
+  # Ignore any files in the output directory.
+  --ignore ${CMAKE_CURRENT_BINARY_DIR}
+  # Copy all files in doc to the rst folder.
+  "*:doc:${RST_OUT}"
+  # Copy the .rst files in samples/ and boards/ to the rst folder, and
+  # also the doc folder inside rst.
+  #
+  # Some files refer to items in samples/ and boards/ relative to
+  # their actual position in the Zephyr tree. For example, in
+  # subsystems/sensor.rst:
+  #
+  # .. literalinclude:: ../../samples/sensor/mcp9808/src/main.c
+  #
+  # We make an additional copy as a hackaround so these references
+  # work.
+  "*.rst:samples:${RST_OUT}" "*.rst:boards:${RST_OUT}"
+  "*.rst:samples:${RST_OUT}/doc" "*.rst:boards:${RST_OUT}/doc")
+
+# Run the content extraction command at configure time in order to
+# produce lists of input and output files, which are respectively its
+# dependencies and outputs. This also causes the content files
+# to be copied for the first time.
+execute_process(
+  COMMAND ${EXTRACT_CONTENT_COMMAND}
+  WORKING_DIRECTORY ${CMAKE_CURRENT_LIST_DIR}
+  RESULT_VARIABLE RET)
+
+if (NOT RET EQUAL 0)
+  message(FATAL_ERROR "Cannot prepare documentation content extraction")
+endif()
+
+# Load the outputs listing from extract_content.py. This is a file
+# where each pair of lines is a source file in the Zephyr tree and a
+# destination file in the build directory.
+file(STRINGS ${CONTENT_OUTPUTS} EXTRACT_CONTENT_RAW)
+
+# Build up a list of output files for later use in target/command
+# DEPENDS. Make sure each output file gets updated if the
+# corresponding input file changes.
+set(EXTRACT_CONTENT_OUTPUTS)
+while(EXTRACT_CONTENT_RAW)
+  list(GET EXTRACT_CONTENT_RAW 0 SRC)
+  list(GET EXTRACT_CONTENT_RAW 1 DST)
+
+  add_custom_command(
+    COMMAND ${CMAKE_COMMAND} -E copy ${SRC} ${DST}
+    DEPENDS ${SRC}
+    OUTPUT ${DST}
+    )
+
+  list(REMOVE_AT EXTRACT_CONTENT_RAW 0 1)
+  list(APPEND EXTRACT_CONTENT_OUTPUTS ${DST})
+endwhile()
+
+add_custom_target(content DEPENDS ${EXTRACT_CONTENT_OUTPUTS})
 
 set(ARGS ${DOXYFILE_OUT})
 
@@ -87,20 +154,6 @@ add_custom_target(
 add_custom_target(
   pristine
   COMMAND ${CMAKE_COMMAND} -P ${ZEPHYR_BASE}/cmake/pristine.cmake
-)
-
-add_custom_target(
-  content
-  # Copy all files in doc/ to the rst folder
-  COMMAND ${CMAKE_COMMAND} -E env
-  ${PYTHON_EXECUTABLE} scripts/extract_content.py --ignore ${CMAKE_CURRENT_BINARY_DIR} -a ${RST_OUT} doc
-  # Copy the .rst files in samples/ and boards/ to the rst folder
-  COMMAND ${CMAKE_COMMAND} -E env
-  ${PYTHON_EXECUTABLE} scripts/extract_content.py --ignore ${CMAKE_CURRENT_BINARY_DIR} ${RST_OUT} samples boards
-  # Copy the .rst files in samples/ and boards/ to the doc folder inside rst
-  COMMAND ${CMAKE_COMMAND} -E env
-  ${PYTHON_EXECUTABLE} scripts/extract_content.py --ignore ${CMAKE_CURRENT_BINARY_DIR} ${RST_OUT}/doc samples boards
-  WORKING_DIRECTORY ${CMAKE_CURRENT_LIST_DIR}
 )
 
 if(WIN32)

--- a/doc/CMakeLists.txt
+++ b/doc/CMakeLists.txt
@@ -186,31 +186,62 @@ set(CONFIG_DIR ${ZEPHYR_BASE}/.known-issues/doc)
 #
 # HTML section
 #
+set(SPHINX_BUILD_HTML_COMMAND
+  ${CMAKE_COMMAND} -E env
+  ZEPHYR_BUILD=${CMAKE_CURRENT_BINARY_DIR}
+  ${SPHINXBUILD} -w ${SPHINX_LOG} -N -t ${DOC_TAG} -b html ${ALLSPHINXOPTS} ${RST_OUT}/doc ${SPHINX_OUTPUT_DIR_HTML})
+
+# The sphinx-html target is provided as a convenience for incremental
+# re-builds of content files without regenerating the entire docs
+# pipeline. It can be significantly faster than re-running the full
+# HTML build, but it has no idea if Doxygen, Kconfig, etc. need to be
+# regenerated. Use with caution.
+add_custom_target(
+  sphinx-html
+  COMMAND ${SPHINX_BUILD_HTML_COMMAND}
+  DEPENDS ${EXTRACT_CONTENT_OUTPUTS}
+  COMMENT "Just re-generating HTML (USE WITH CAUTION)"
+  USES_TERMINAL
+)
+
 add_custom_target(
   html
-  COMMAND ${CMAKE_COMMAND} -E env
-  ZEPHYR_BUILD=${CMAKE_CURRENT_BINARY_DIR}
-  ${SPHINXBUILD} -w ${SPHINX_LOG} -N -t ${DOC_TAG} -b html ${ALLSPHINXOPTS} ${RST_OUT}/doc ${SPHINX_OUTPUT_DIR_HTML}
+  COMMAND ${SPHINX_BUILD_HTML_COMMAND}
   # Merge the Doxygen and Sphinx logs into a single file
   COMMAND ${CMAKE_COMMAND} -P ${ZEPHYR_BASE}/cmake/util/fmerge.cmake ${DOC_LOG} ${DOXY_LOG} ${SPHINX_LOG}
   COMMAND ${PYTHON_EXECUTABLE} ${KI_SCRIPT} --config-dir ${CONFIG_DIR} --errors ${DOC_WARN} --warnings ${DOC_WARN} ${DOC_LOG}
   WORKING_DIRECTORY ${CMAKE_CURRENT_LIST_DIR}
+  COMMENT "Generating HTML documentation"
   ${SPHINX_USES_TERMINAL}
 )
 
 #
 # LaTEX section
 #
+set(SPHINX_BUILD_LATEX_COMMAND
+  ${CMAKE_COMMAND} -E env
+  ZEPHYR_BUILD=${CMAKE_CURRENT_BINARY_DIR}
+  ${SPHINXBUILD} -w ${SPHINX_LOG} -N -t ${DOC_TAG} -b latex -t svgconvert ${ALLSPHINXOPTS} ${RST_OUT}/doc ${SPHINX_OUTPUT_DIR_LATEX})
+
+# The sphinx-latex target works similarly to sphinx-html, and carries
+# the same warnings.
+add_custom_target(
+  sphinx-latex
+  COMMAND ${SPHINX_BUILD_LATEX_COMMAND}
+  DEPENDS ${EXTRACT_CONTENT_OUTPUTS}
+  COMMENT "Just re-generating LaTeX (USE WITH CAUTION)"
+  USES_TERMINAL
+)
+
 add_custom_command(
   OUTPUT ${SPHINX_OUTPUT_DIR_LATEX}/zephyr.tex
-  COMMAND ${CMAKE_COMMAND} -E env
-  ZEPHYR_BUILD=${CMAKE_CURRENT_BINARY_DIR}
-  ${SPHINXBUILD} -w ${SPHINX_LOG} -N -t ${DOC_TAG} -b latex -t svgconvert ${ALLSPHINXOPTS} ${RST_OUT}/doc ${SPHINX_OUTPUT_DIR_LATEX}
+  COMMAND ${SPHINX_BUILD_LATEX_COMMAND}
   # Merge the Doxygen and Sphinx logs into a single file
   COMMAND ${CMAKE_COMMAND} -P ${ZEPHYR_BASE}/cmake/util/fmerge.cmake ${DOC_LOG} ${DOXY_LOG} ${SPHINX_LOG}
   COMMAND ${PYTHON_EXECUTABLE} ${KI_SCRIPT} --config-dir ${CONFIG_DIR} --errors ${DOC_WARN} --warnings ${DOC_WARN} ${DOC_LOG}
   COMMAND ${PYTHON_EXECUTABLE} ${FIX_TEX_SCRIPT} ${SPHINX_OUTPUT_DIR_LATEX}/zephyr.tex
   WORKING_DIRECTORY ${CMAKE_CURRENT_LIST_DIR}
+  COMMENT "Generating LaTeX documentation"
   ${SPHINX_USES_TERMINAL}
 )
 
@@ -231,6 +262,7 @@ add_custom_command(
   LATEXOPTS="-halt-on-error -no-shell-escape"
   ${LATEXMK} -quiet -pdf -dvi- -ps-
   WORKING_DIRECTORY ${SPHINX_OUTPUT_DIR_LATEX}
+  COMMENT "Generating PDF documentation"
 )
 
 if(NOT DEFINED SPHINX_OUTPUT_DIR)

--- a/doc/CMakeLists.txt
+++ b/doc/CMakeLists.txt
@@ -93,16 +93,13 @@ add_custom_target(
   content
   # Copy all files in doc/ to the rst folder
   COMMAND ${CMAKE_COMMAND} -E env
-  ZEPHYR_BUILD=${CMAKE_CURRENT_BINARY_DIR}
-  ${PYTHON_EXECUTABLE} scripts/extract_content.py -a ${RST_OUT} doc
+  ${PYTHON_EXECUTABLE} scripts/extract_content.py --ignore ${CMAKE_CURRENT_BINARY_DIR} -a ${RST_OUT} doc
   # Copy the .rst files in samples/ and boards/ to the rst folder
   COMMAND ${CMAKE_COMMAND} -E env
-  ZEPHYR_BUILD=${CMAKE_CURRENT_BINARY_DIR}
-  ${PYTHON_EXECUTABLE} scripts/extract_content.py ${RST_OUT} samples boards
+  ${PYTHON_EXECUTABLE} scripts/extract_content.py --ignore ${CMAKE_CURRENT_BINARY_DIR} ${RST_OUT} samples boards
   # Copy the .rst files in samples/ and boards/ to the doc folder inside rst
   COMMAND ${CMAKE_COMMAND} -E env
-  ZEPHYR_BUILD=${CMAKE_CURRENT_BINARY_DIR}
-  ${PYTHON_EXECUTABLE} scripts/extract_content.py ${RST_OUT}/doc samples boards
+  ${PYTHON_EXECUTABLE} scripts/extract_content.py --ignore ${CMAKE_CURRENT_BINARY_DIR} ${RST_OUT}/doc samples boards
   WORKING_DIRECTORY ${CMAKE_CURRENT_LIST_DIR}
 )
 

--- a/doc/CMakeLists.txt
+++ b/doc/CMakeLists.txt
@@ -41,6 +41,8 @@ if(NOT DEFINED SPHINX_OUTPUT_DIR)
   set(SPHINX_OUTPUT_DIR_LATEX ${CMAKE_CURRENT_BINARY_DIR}/latex)
   set(SPHINX_OUTPUT_DIR_PDF ${CMAKE_CURRENT_BINARY_DIR}/pdf)
 else()
+  # SPHINX_OUTPUT_DIR is used to specify exactly where HTML (or other
+  # outputs) are placed, so no /html, /latex, /pdf suffixes are needed.
   set(SPHINX_OUTPUT_DIR_HTML ${SPHINX_OUTPUT_DIR})
   set(SPHINX_OUTPUT_DIR_LATEX ${SPHINX_OUTPUT_DIR})
   set(SPHINX_OUTPUT_DIR_PDF ${SPHINX_OUTPUT_DIR})

--- a/doc/README.rst
+++ b/doc/README.rst
@@ -117,6 +117,10 @@ the PDF file is available at ``doc/_build/pdf/zephyr.pdf``.
 If you want to build the documentation from scratch just delete the contents
 of the build folder and run ``cmake`` and then ``ninja`` again.
 
+.. note::
+
+   If you add or remove a file from the documentation, you need to re-run CMake.
+
 On Unix platforms a convenience :file:`Makefile` at the root folder
 of the Zephyr repository can be used to build the documentation directly from
 there:

--- a/doc/scripts/extract_content.py
+++ b/doc/scripts/extract_content.py
@@ -9,7 +9,6 @@
 # to fix the website and external links
 
 import argparse
-import errno
 import filecmp
 import fnmatch
 import os
@@ -18,7 +17,7 @@ import shutil
 import sys
 
 # directives to parse for included files
-DIRECTIVES = ["figure","include","image","literalinclude"]
+DIRECTIVES = ["figure", "include", "image", "literalinclude"]
 
 if "ZEPHYR_BASE" not in os.environ:
     sys.stderr.write("$ZEPHYR_BASE environment variable undefined.\n")
@@ -30,6 +29,7 @@ if "ZEPHYR_BUILD" in os.environ:
 else:
     ZEPHYR_BUILD = None
 
+
 def copy_if_different(src, dst):
     # Copies 'src' as 'dst', but only if dst does not exist or if itx contents
     # differ from src.This avoids unnecessary # timestamp updates, which
@@ -38,19 +38,21 @@ def copy_if_different(src, dst):
         return
     shutil.copyfile(src, dst)
 
+
 def get_files(all, dest, dir):
     matches = []
-    for root, dirnames, filenames in os.walk('%s/%s' %(ZEPHYR_BASE, dir)):
+    for root, dirnames, filenames in os.walk('%s/%s' % (ZEPHYR_BASE, dir)):
         if ZEPHYR_BUILD:
-            if os.path.normpath(root).startswith(os.path.normpath(ZEPHYR_BUILD)):
+            if os.path.normpath(root).startswith(
+                    os.path.normpath(ZEPHYR_BUILD)):
                 # Build folder, skip it
                 continue
 
         for filename in fnmatch.filter(filenames, '*' if all else '*.rst'):
             matches.append(os.path.join(root, filename))
     for file in matches:
-        frel = file.replace(ZEPHYR_BASE,"").strip("/")
-        dir=os.path.dirname(frel)
+        frel = file.replace(ZEPHYR_BASE, "").strip("/")
+        dir = os.path.dirname(frel)
         if not os.path.exists(os.path.join(dest, dir)):
             os.makedirs(os.path.join(dest, dir))
 
@@ -67,7 +69,7 @@ def get_files(all, dest, dir):
 
             content = [x.strip() for x in content]
             directives = "|".join(DIRECTIVES)
-            pattern = re.compile("\s*\.\.\s+(%s)::\s+(.*)" %directives)
+            pattern = re.compile("\s*\.\.\s+(%s)::\s+(.*)" % directives)
             for l in content:
                 m = pattern.match(l)
                 if m:
@@ -82,7 +84,8 @@ def get_files(all, dest, dir):
                         copy_if_different(src, dst)
 
                     except FileNotFoundError:
-                        sys.stderr.write("File not found: %s\n  reference by %s\n" % (inf, file))
+                        print("File not found:", inf, "\n  referenced by:",
+                              file, file=sys.stderr)
 
         except UnicodeDecodeError as e:
             sys.stderr.write(
@@ -97,16 +100,16 @@ def get_files(all, dest, dir):
 
         f.close()
 
+
 def main():
+    parser = argparse.ArgumentParser(
+        description='''Recursively copy .rst files from the origin folder(s) to
+        the destination folder, plus files referenced in those .rst files by a
+        configurable list of directives: {}.'''.format(DIRECTIVES))
 
-    parser = argparse.ArgumentParser(description='Recursively copy .rst files '
-                                     'from the origin folder(s) to the '
-                                     'destination folder, plus files referenced '
-                                     'in those .rst files by a configurable '
-                                     'list of directives: {}.'.format(DIRECTIVES))
-
-    parser.add_argument('-a', '--all', action='store_true', help='Copy all files '
-                        '(recursively) in the specified source folder(s).')
+    parser.add_argument('-a', '--all', action='store_true',
+                        help='''Copy all files (recursively) in the specified
+                        source folder(s).''')
     parser.add_argument('dest', nargs=1)
     parser.add_argument('src', nargs='+')
     args = parser.parse_args()
@@ -115,6 +118,7 @@ def main():
 
     for d in args.src:
         get_files(args.all, dest, d)
+
 
 if __name__ == "__main__":
     main()

--- a/doc/scripts/extract_content.py
+++ b/doc/scripts/extract_content.py
@@ -1,12 +1,17 @@
 #!/usr/bin/env python3
 #
+# Copyright (c) 2018, Foundries.io Ltd
 # Copyright (c) 2018, Nordic Semiconductor ASA
 # Copyright (c) 2017, Intel Corporation
 #
 # SPDX-License-Identifier: Apache-2.0
 
-# Very quick script to move docs from different places into the doc directory
-# to fix the website and external links
+# Internal script used by the documentation's build system to create
+# the "final" docs tree which is then compiled by Sphinx.
+#
+# This works around the fact that Sphinx needs a single documentation
+# root directory, while Zephyr's documentation files are spread around
+# the tree.
 
 import argparse
 import filecmp
@@ -19,16 +24,6 @@ import sys
 # directives to parse for included files
 DIRECTIVES = ["figure", "include", "image", "literalinclude"]
 
-if "ZEPHYR_BASE" not in os.environ:
-    sys.stderr.write("$ZEPHYR_BASE environment variable undefined.\n")
-    exit(1)
-ZEPHYR_BASE = os.environ["ZEPHYR_BASE"]
-
-if "ZEPHYR_BUILD" in os.environ:
-    ZEPHYR_BUILD = os.environ["ZEPHYR_BUILD"]
-else:
-    ZEPHYR_BUILD = None
-
 
 def copy_if_different(src, dst):
     # Copies 'src' as 'dst', but only if dst does not exist or if itx contents
@@ -39,32 +34,32 @@ def copy_if_different(src, dst):
     shutil.copyfile(src, dst)
 
 
-def get_files(all, dest, dir):
+def get_files(zephyr_base, src, dest, fnfilter, ignore):
     matches = []
-    for root, dirnames, filenames in os.walk('%s/%s' % (ZEPHYR_BASE, dir)):
-        if ZEPHYR_BUILD:
-            if os.path.normpath(root).startswith(
-                    os.path.normpath(ZEPHYR_BUILD)):
-                # Build folder, skip it
-                continue
-
-        for filename in fnmatch.filter(filenames, '*' if all else '*.rst'):
+    for root, dirnames, filenames in os.walk('%s/%s' % (zephyr_base, src)):
+        # Append any matching files.
+        for filename in fnmatch.filter(filenames, fnfilter):
             matches.append(os.path.join(root, filename))
-    for file in matches:
-        frel = file.replace(ZEPHYR_BASE, "").strip("/")
+
+        # Limit the rest of the walk to subdirectories that aren't ignored.
+        dirnames[:] = [d for d in dirnames if not
+                       os.path.join(root, d).startswith(ignore)]
+
+    for src_file in matches:
+        frel = src_file.replace(zephyr_base, "").strip("/")
         dir = os.path.dirname(frel)
         if not os.path.exists(os.path.join(dest, dir)):
             os.makedirs(os.path.join(dest, dir))
 
-        copy_if_different(file, os.path.join(dest, frel))
+        copy_if_different(src_file, os.path.join(dest, frel))
 
         # Inspect only .rst files for directives referencing other files
         # we'll need to copy (as configured in the DIRECTIVES variable)
-        if not fnmatch.fnmatch(file, "*.rst"):
+        if not fnmatch.fnmatch(src_file, "*.rst"):
             continue
 
         try:
-            with open(file, encoding="utf-8") as f:
+            with open(src_file, encoding="utf-8") as f:
                 content = f.readlines()
 
             content = [x.strip() for x in content]
@@ -78,14 +73,14 @@ def get_files(all, dest, dir):
                     if not os.path.exists(os.path.join(dest, dir, ind)):
                         os.makedirs(os.path.join(dest, dir, ind))
 
-                    src = os.path.join(ZEPHYR_BASE, dir, inf)
+                    src = os.path.join(zephyr_base, dir, inf)
                     dst = os.path.join(dest, dir, inf)
                     try:
                         copy_if_different(src, dst)
 
                     except FileNotFoundError:
                         print("File not found:", inf, "\n  referenced by:",
-                              file, file=sys.stderr)
+                              src_file, file=sys.stderr)
 
         except UnicodeDecodeError as e:
             sys.stderr.write(
@@ -93,7 +88,7 @@ def get_files(all, dest, dir):
                 "  Context: {}\n"
                 "  Problematic data: {}\n"
                 "  Reason: {}\n".format(
-                    e.encoding, file,
+                    e.encoding, src_file,
                     e.object[max(e.start - 40, 0):e.end + 40],
                     e.object[e.start:e.end],
                     e.reason))
@@ -105,19 +100,36 @@ def main():
     parser = argparse.ArgumentParser(
         description='''Recursively copy .rst files from the origin folder(s) to
         the destination folder, plus files referenced in those .rst files by a
-        configurable list of directives: {}.'''.format(DIRECTIVES))
+        configurable list of directives: {}. The ZEPHYR_BASE environment
+        variable is used to determine source directories to copy files
+        from.'''.format(DIRECTIVES))
 
     parser.add_argument('-a', '--all', action='store_true',
                         help='''Copy all files (recursively) in the specified
                         source folder(s).''')
+    parser.add_argument('--ignore', action='append',
+                        help='''Source directories to ignore when copying
+                        files. This may be given multiple times.''')
     parser.add_argument('dest', nargs=1)
     parser.add_argument('src', nargs='+')
     args = parser.parse_args()
 
+    if "ZEPHYR_BASE" not in os.environ:
+        sys.exit("ZEPHYR_BASE environment variable undefined.")
+    zephyr_base = os.environ["ZEPHYR_BASE"]
+
     dest = args.dest[0]
+    if not args.ignore:
+        ignore = ()
+    else:
+        ignore = tuple(os.path.normpath(ign) for ign in args.ignore)
+    if args.all:
+        fnfilter = '*'
+    else:
+        fnfilter = '*.rst'
 
     for d in args.src:
-        get_files(args.all, dest, d)
+        get_files(zephyr_base, d, dest, fnfilter, ignore)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
The documentation build works well for non-incremental, CI builds, but has some issues which matter more to the developer's edit/build workflow.

- its content extraction script (extract_content.py) is unnecessarily coarse-grained, considering every single source .rst file instead of just letting the build system copy updated ones after configure time
- extract_content.py doesn't track its source dependencies properly when copying .rst/etc into the build directory, so updated .rst sources don't trigger rebuilds
- its handling of SPHINX_OUTPUT_DIR doesn't look right
- running sphinx-build without `-j` leaves huge opportunities for parallelism on the table
- there's no way for developers to *just* run sphinx-build to update e.g. the HTML if they know what they are doing

This PR addresses these issues. A fresh documentation build is 75% faster on my system. Additionally, careful use of the targets which just re-run sphinx-build allows rebuilding the HTML docs in under 10 seconds.

There's a lot of room for further improvement (in particular, adding logic to only re-run Doxygen and regenerate Kconfig docs when truly necessary), but this felt like a good enough place to start (and makes docs editing feel a lot better from my perspective).