### PR TITLE
 Fix: Remove garbage leaked from developer workspace

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,11 +34,11 @@ scripts/grub
 doc/reference/kconfig/*.rst
 doc/doc.warnings
 tags
-.project
-.cproject
-.xxproject
+.*project
+.settings
 .envrc
 .vscode
+hide-defaults-note
 
 # Tag files
 GPATH


### PR DESCRIPTION
In a429104 a hide-defaults-note file was introduced by mistake in Zephyr's root folder. This file should not have been commited => remove it
+
add that file and a few more to `.gitignore` to prevent this in the future.

