### PR TITLE
CODEOWNERS: assign maintainer for include/arch/posix

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -127,6 +127,7 @@ include/arch/arm/                        @MaureenHelm @galak
 include/arch/arm/cortex_m/irq.h          @andrewboie
 include/arch/nios2/                      @andrewboie
 include/arch/nios2/arch.h                @andrewboie
+include/arch/posix/                      @aescolar
 include/arch/riscv32                     @fractalclone @kgugala @pgielda
 include/arch/x86/                        @andrewboie @ramakrishnapallala
 include/arch/x86/arch.h                  @andrewboie


### PR DESCRIPTION
include/arch/posix was orphan. Assign aescolar as maintainer for it.

Signed-off-by: Alberto Escolar Piedras <alpi@oticon.com>