### PR TITLE
subsys: shell: removing Console dependencies from Shell UART backend

### DIFF
--- a/boards/arm/nrf52840_pca10056/nrf52840_pca10056.dts
+++ b/boards/arm/nrf52840_pca10056/nrf52840_pca10056.dts
@@ -71,6 +71,7 @@
 		sw1 = &button1;
 		sw2 = &button2;
 		sw3 = &button3;
+		config-shell-serial = &uart0;
 	};
 };
 

--- a/subsys/shell/shell_uart.c
+++ b/subsys/shell/shell_uart.c
@@ -26,7 +26,7 @@ static int init(const struct shell_transport *transport,
 {
 	struct shell_uart *sh_uart = (struct shell_uart *)transport->ctx;
 
-	sh_uart->dev = device_get_binding(CONFIG_UART_CONSOLE_ON_DEV_NAME);
+	sh_uart->dev = device_get_binding(CONFIG_SHELL_SERIAL_LABEL);
 	sh_uart->handler = evt_handler;
 	sh_uart->context = context;
 


### PR DESCRIPTION
This PR fixes #10191.

@aescolar @pfalcon @jukkar : This is my fix proposal to get rid of Console dependencies from shell uart backend. Once you will agree with this approach I will add necessary aliases for all boards.

Signed-off-by: Jakub Rzeszutko <jakub.rzeszutko@nordicsemi.no>