### PR TITLE
genrest/menuconfig: Fix crash for promptless choices

### DIFF
--- a/doc/scripts/genrest.py
+++ b/doc/scripts/genrest.py
@@ -356,7 +356,14 @@ def kconfig_definition_rst(sc):
             if node is node.kconfig.top_node:
                 break
 
-            path = arrow + node.prompt[0] + path
+            # Promptless choices can show up as parents, e.g. when people
+            # define choices in multiple locations to add symbols. Use
+            # standard_sc_expr_str() to show them. That way they show up as
+            # '<choice (name if any)>'.
+            path = arrow + \
+                   (node.prompt[0] if node.prompt else
+                    kconfiglib.standard_sc_expr_str(node.item)) + \
+                   path
 
         return "(top menu)" + path
 

--- a/scripts/kconfig/kconfiglib.py
+++ b/scripts/kconfig/kconfiglib.py
@@ -488,7 +488,7 @@ If my_fn() returns "n", this will result in
 
     config FOO
         ...
-	depends on n
+        depends on n
 
 Warning
 *******
@@ -754,10 +754,9 @@ class Kconfig(object):
         "_include_path",
         "_filestack",
         "_line",
-        "_saved_line",
         "_tokens",
         "_tokens_i",
-        "_has_tokens",
+        "_reuse_tokens",
     )
 
     #
@@ -931,9 +930,10 @@ class Kconfig(object):
         self.kconfig_filenames = [filename]
         self.env_vars = set()
 
-        # These implement a single line of "unget" for the parser
-        self._saved_line = None
-        self._has_tokens = False
+        # Used to avoid retokenizing lines when we discover that they're not
+        # part of the construct currently being parsed. This is kinda like an
+        # unget operation.
+        self._reuse_tokens = False
 
         # Keeps track of the location in the parent Kconfig files. Kconfig
         # files usually source other Kconfig files. See _enter_file().
@@ -1038,7 +1038,7 @@ class Kconfig(object):
 
         replace (default: True):
           True if all existing user values should be cleared before loading the
-          .config.
+          .config. Pass False to merge configurations.
         """
         # Disable the warning about assigning to symbols without prompts. This
         # is normal and expected within a .config file.
@@ -1499,8 +1499,9 @@ class Kconfig(object):
     def node_iter(self, unique_syms=False):
         """
         Returns a generator for iterating through all MenuNode's in the Kconfig
-        tree. The iteration is done in Kconfig definition order (the children
-        of a node are visited before the next node is visited).
+        tree. The iteration is done in Kconfig definition order (each node is
+        visited before its children, and the children of a node are visited
+        before the next node).
 
         The Kconfig.top_node menu node is skipped. It contains an implicit menu
         that holds the top-level items.
@@ -1777,19 +1778,19 @@ class Kconfig(object):
         # Fetches and tokenizes the next line from the current Kconfig file.
         # Returns False at EOF and True otherwise.
 
-        # _saved_line provides a single line of "unget", currently only used
-        # for help texts.
-        #
-        # This also works as expected if _saved_line is "", indicating EOF:
-        # "" is falsy, and readline() returns "" over and over at EOF.
-        if self._saved_line:
-            self._line = self._saved_line
-            self._saved_line = None
-        else:
-            self._line = self._file.readline()
-            if not self._line:
-                return False
-            self._linenr += 1
+        # We might already have tokens from parsing a line and discovering that
+        # it's part of a different construct
+        if self._reuse_tokens:
+            self._reuse_tokens = False
+            self._tokens_i = -1
+            return True
+
+        # Note: readline() returns '' over and over at EOF, which we rely on
+        # for help texts at the end of files (see _line_after_help())
+        self._line = self._file.readline()
+        if not self._line:
+            return False
+        self._linenr += 1
 
         # Handle line joining
         while self._line.endswith("\\\n"):
@@ -1800,6 +1801,26 @@ class Kconfig(object):
         self._tokens_i = -1  # Token index (minus one)
 
         return True
+
+    def _line_after_help(self, line):
+        # Tokenizes the line after a help text. This case is special in that
+        # the line has already been fetched (to discover that it isn't part of
+        # the help text).
+        #
+        # An earlier version used a _saved_line variable instead that was
+        # checked in _next_line(). This special-casing gets rid of it and makes
+        # _reuse_tokens alone sufficient to handle unget.
+
+        if line:
+            # Handle line joining
+            while line.endswith("\\\n"):
+                line = line[:-2] + self._file.readline()
+                self._linenr += 1
+
+            self._line = line
+
+            self._tokens = self._tokenize(line)
+            self._reuse_tokens = True
 
 
     #
@@ -2427,12 +2448,7 @@ class Kconfig(object):
         # Returns the final menu node in the block (or 'prev' if the block is
         # empty). This allows chaining.
 
-        # We might already have tokens from parsing a line to check if it's a
-        # property and discovering it isn't. self._has_tokens functions as a
-        # kind of "unget".
-        while self._has_tokens or self._next_line():
-            self._has_tokens = False
-
+        while self._next_line():
             t0 = self._next_token()
             if t0 is None:
                 continue
@@ -2514,9 +2530,6 @@ class Kconfig(object):
                 node = MenuNode()
                 node.item = node.prompt = None
                 node.parent = parent
-                node.filename = self._filename
-                node.linenr = self._linenr
-
                 node.dep = self._expect_expr_and_eol()
 
                 self._parse_block(_T_ENDIF, node, node)
@@ -2781,8 +2794,7 @@ class Kconfig(object):
 
             else:
                 # Reuse the tokens for the non-property line later
-                self._has_tokens = True
-                self._tokens_i = -1
+                self._reuse_tokens = True
                 return
 
     def _set_type(self, node, new_type):
@@ -2844,7 +2856,7 @@ class Kconfig(object):
                        " has 'help' but empty help text")
 
             node.help = ""
-            self._saved_line = line  # "Unget" the line
+            self._line_after_help(line)
             return
 
         # The help text goes on till the first non-empty line with less indent
@@ -2871,7 +2883,7 @@ class Kconfig(object):
         self._linenr += len(help_lines)
 
         node.help = "\n".join(help_lines).rstrip() + "\n"
-        self._saved_line = line  # "Unget" the line
+        self._line_after_help(line)
 
     def _parse_expr(self, transform_m):
         # Parses an expression from the tokens in Kconfig._tokens using a
@@ -2931,8 +2943,7 @@ class Kconfig(object):
         if isinstance(token, Symbol):
             # Plain symbol or relation
 
-            next_token = self._peek_token()
-            if next_token not in _RELATIONS:
+            if self._peek_token() not in _RELATIONS:
                 # Plain symbol
 
                 # For conditional expressions ('depends on <expr>',
@@ -3757,27 +3768,27 @@ class Symbol(object):
                 # (implies)
 
                 for default, cond in self.defaults:
-                    cond_val = expr_value(cond)
-                    if cond_val:
-                        val = min(expr_value(default), cond_val)
+                    dep_val = expr_value(cond)
+                    if dep_val:
+                        val = min(expr_value(default), dep_val)
                         if val:
                             self._write_to_conf = True
                         break
 
                 # Weak reverse dependencies are only considered if our
                 # direct dependencies are met
-                weak_rev_dep_val = expr_value(self.weak_rev_dep)
-                if weak_rev_dep_val and expr_value(self.direct_dep):
-                    val = max(weak_rev_dep_val, val)
+                dep_val = expr_value(self.weak_rev_dep)
+                if dep_val and expr_value(self.direct_dep):
+                    val = max(dep_val, val)
                     self._write_to_conf = True
 
             # Reverse (select-related) dependencies take precedence
-            rev_dep_val = expr_value(self.rev_dep)
-            if rev_dep_val:
-                if expr_value(self.direct_dep) < rev_dep_val:
+            dep_val = expr_value(self.rev_dep)
+            if dep_val:
+                if expr_value(self.direct_dep) < dep_val:
                     self._warn_select_unsatisfied_deps()
 
-                val = max(rev_dep_val, val)
+                val = max(dep_val, val)
                 self._write_to_conf = True
 
             # m is promoted to y for (1) bool symbols and (2) symbols with a
@@ -4280,8 +4291,7 @@ class Choice(object):
 
     name:
       The name of the choice, e.g. "FOO" for 'choice FOO', or None if the
-      Choice has no name. I can't remember ever seeing named choices in
-      practice, but the C tools support them too.
+      Choice has no name.
 
     type:
       The type of the choice. One of BOOL, TRISTATE, UNKNOWN. UNKNOWN is for
@@ -4368,17 +4378,14 @@ class Choice(object):
     syms:
       List of symbols contained in the choice.
 
-      Gotcha: If a symbol depends on the previous symbol within a choice so
-      that an implicit menu is created, it won't be a choice symbol, and won't
-      be included in 'syms'. There are real-world examples of this, and it was
-      a PITA to support in older versions of Kconfiglib that didn't implement
-      the menu structure.
+      Obscure gotcha: If a symbol depends on the previous symbol within a
+      choice so that an implicit menu is created, it won't be a choice symbol,
+      and won't be included in 'syms'.
 
     nodes:
       A list of MenuNodes for this choice. In practice, the list will probably
       always contain a single MenuNode, but it is possible to give a choice a
-      name and define it in multiple locations (I've never even seen a named
-      choice though).
+      name and define it in multiple locations.
 
     defaults:
       List of (symbol, cond) tuples for the choice's 'defaults' properties. For
@@ -4858,7 +4865,7 @@ class MenuNode(object):
         "defaults",
         "selects",
         "implies",
-        "ranges"
+        "ranges",
     )
 
     def __init__(self):
@@ -5154,29 +5161,27 @@ def expr_value(expr):
         # kconfig in 31847b67 (kconfig: allow use of relations other than
         # (in)equality).
 
-        oper, op1, op2 = expr
+        rel, v1, v2 = expr
 
         # If both operands are strings...
-        if op1.orig_type is STRING and op2.orig_type is STRING:
+        if v1.orig_type is STRING and v2.orig_type is STRING:
             # ...then compare them lexicographically
-            comp = _strcmp(op1.str_value, op2.str_value)
+            comp = _strcmp(v1.str_value, v2.str_value)
         else:
             # Otherwise, try to compare them as numbers
             try:
-                comp = _sym_to_num(op1) - _sym_to_num(op2)
+                comp = _sym_to_num(v1) - _sym_to_num(v2)
             except ValueError:
                 # Fall back on a lexicographic comparison if the operands don't
                 # parse as numbers
-                comp = _strcmp(op1.str_value, op2.str_value)
+                comp = _strcmp(v1.str_value, v2.str_value)
 
-        if   oper is EQUAL:         res = comp == 0
-        elif oper is UNEQUAL:       res = comp != 0
-        elif oper is LESS:          res = comp < 0
-        elif oper is LESS_EQUAL:    res = comp <= 0
-        elif oper is GREATER:       res = comp > 0
-        elif oper is GREATER_EQUAL: res = comp >= 0
-
-        return 2*res
+        if rel is EQUAL:         return 2*(comp == 0)
+        if rel is UNEQUAL:       return 2*(comp != 0)
+        if rel is LESS:          return 2*(comp < 0)
+        if rel is LESS_EQUAL:    return 2*(comp <= 0)
+        if rel is GREATER:       return 2*(comp > 0)
+        if rel is GREATER_EQUAL: return 2*(comp >= 0)
 
     _internal_error("Internal error while evaluating expression: "
                     "unknown operation {}.".format(expr[0]))
@@ -5972,8 +5977,8 @@ def _shell_fn(kconf, _, command):
                         command, "\n".join(stderr.splitlines())),
                     kconf._filename, kconf._linenr)
 
-    # Manual universal newlines with splitlines() (to prevent e.g. stray \r's
-    # in command output on Windows), trailing newline removal, and
+    # Universal newlines with splitlines() (to prevent e.g. stray \r's in
+    # command output on Windows), trailing newline removal, and
     # newline-to-space conversion.
     #
     # On Python 3 versions before 3.6, it's not possible to specify the


### PR DESCRIPTION
Update menuconfig (and Kconfiglib, just to sync) to upstream revision
256e5b3e38e92 to get the fix below in, for an issue in an external
project. Also update genrest.py with a similar fix (the genrest issue
was what originally prompted it).

    menuconfig: Improve/fix promptless choice handling

    The code assumed that all parent (interface) menus always have a
    prompt, which is false for items in promptless choices. This led to
    a crash e.g. when viewing the symbol information for a symbol within
    a promptless choice.

    Promptless choices with children can show up "legitimately" when
    people define choices in multiple locations to add symbols, though
    this is broken in the C tools.

    Use standard_sc_expr_str(node.item) instead of the non-existing
    prompt for promptless choices. That way they show up as
    '<choice (name if any>)>', which is consistent with how they're
    shown elsewhere.

    This commit also changes how choice names are displayed in
    show-name/show-all mode, to the standard_sc_expr_str() format.

Signed-off-by: Ulf Magnusson <Ulf.Magnusson@nordicsemi.no>