### PR TITLE
Kconfig: Remove redundant $(ZEPHYR_BASE) from 'source's

### DIFF
--- a/doc/application/application-kconfig.include
+++ b/doc/application/application-kconfig.include
@@ -2,4 +2,10 @@ mainmenu "Your Application Name"
 
 # Your application configuration options go here
 
-source "$(ZEPHYR_BASE)/Kconfig.zephyr"
+# Sources Kconfig.zephyr in the Zephyr root directory.
+#
+# Note: All 'source' statements work relative to the Zephyr root directory (due
+# to the $srctree environment variable being set to $ZEPHYR_BASE). If you want
+# to 'source' relative to the current Kconfig file instead, use 'rsource' (or a
+# path relative to the Zephyr root).
+source "Kconfig.zephyr"

--- a/samples/drivers/CAN/Kconfig
+++ b/samples/drivers/CAN/Kconfig
@@ -46,4 +46,4 @@ config LOOPBACK_MODE
 	  This allows testing without a second board.
 
 
-source "$(ZEPHYR_BASE)/Kconfig.zephyr"
+source "Kconfig.zephyr"

--- a/samples/net/echo_client/Kconfig
+++ b/samples/net/echo_client/Kconfig
@@ -46,4 +46,4 @@ config NET_SAMPLE_IFACE3_VLAN_TAG
 	  Set VLAN (virtual LAN) tag (id) that is used in the sample
 	  application.
 
-source "$(ZEPHYR_BASE)/Kconfig.zephyr"
+source "Kconfig.zephyr"

--- a/samples/net/echo_server/Kconfig
+++ b/samples/net/echo_server/Kconfig
@@ -46,4 +46,4 @@ config NET_SAMPLE_IFACE3_VLAN_TAG
 	  Set VLAN (virtual LAN) tag (id) that is used in the sample
 	  application.
 
-source "$(ZEPHYR_BASE)/Kconfig.zephyr"
+source "Kconfig.zephyr"

--- a/samples/net/gptp/Kconfig
+++ b/samples/net/gptp/Kconfig
@@ -58,4 +58,4 @@ config NET_SAMPLE_IFACE3_VLAN_TAG
 endif
 
 
-source "$(ZEPHYR_BASE)/Kconfig.zephyr"
+source "Kconfig.zephyr"

--- a/samples/net/lldp/Kconfig
+++ b/samples/net/lldp/Kconfig
@@ -10,7 +10,7 @@
 
 mainmenu "LLDP sample application"
 
-source "$(ZEPHYR_BASE)/Kconfig.zephyr"
+source "Kconfig.zephyr"
 
 if NET_LLDP
 

--- a/samples/net/sockets/echo_client/Kconfig
+++ b/samples/net/sockets/echo_client/Kconfig
@@ -46,4 +46,4 @@ config NET_SAMPLE_IFACE3_VLAN_TAG
 	  Set VLAN (virtual LAN) tag (id) that is used in the sample
 	  application.
 
-source "$(ZEPHYR_BASE)/Kconfig.zephyr"
+source "Kconfig.zephyr"

--- a/samples/net/sockets/echo_server/Kconfig
+++ b/samples/net/sockets/echo_server/Kconfig
@@ -46,4 +46,4 @@ config NET_SAMPLE_IFACE3_VLAN_TAG
 	  Set VLAN (virtual LAN) tag (id) that is used in the sample
 	  application.
 
-source "$(ZEPHYR_BASE)/Kconfig.zephyr"
+source "Kconfig.zephyr"

--- a/samples/net/stats/Kconfig
+++ b/samples/net/stats/Kconfig
@@ -17,4 +17,4 @@ config SAMPLE_PERIOD
 	  Print statistics after every n. seconds
 
 
-source "$(ZEPHYR_BASE)/Kconfig.zephyr"
+source "Kconfig.zephyr"

--- a/samples/net/traffic_class/Kconfig
+++ b/samples/net/traffic_class/Kconfig
@@ -45,4 +45,4 @@ config SAMPLE_PEER_IPV4_ADDR_2
 	  The value depends on your network setup.
 
 
-source "$(ZEPHYR_BASE)/Kconfig.zephyr"
+source "Kconfig.zephyr"

--- a/samples/net/vlan/Kconfig
+++ b/samples/net/vlan/Kconfig
@@ -35,4 +35,4 @@ config SAMPLE_IPV4_ADDR_2
 	  The value depends on your network setup.
 
 
-source "$(ZEPHYR_BASE)/Kconfig.zephyr"
+source "Kconfig.zephyr"

--- a/samples/net/wifi/Kconfig
+++ b/samples/net/wifi/Kconfig
@@ -17,4 +17,4 @@ config WINC1500_GPIO_RESET_N
 endif # WIFI_WINC1500
 
 
-source "$(ZEPHYR_BASE)/Kconfig.zephyr"
+source "Kconfig.zephyr"

--- a/samples/subsys/logging/logger/Kconfig
+++ b/samples/subsys/logging/logger/Kconfig
@@ -15,4 +15,4 @@ source "subsys/logging/Kconfig.template.log_config"
 
 endmenu
 
-source "$(ZEPHYR_BASE)/Kconfig.zephyr"
+source "Kconfig.zephyr"

--- a/tests/benchmarks/object_footprint/Kconfig
+++ b/tests/benchmarks/object_footprint/Kconfig
@@ -1,6 +1,6 @@
 mainmenu "Zephyr Object Sizes"
 
-source "$(ZEPHYR_BASE)/Kconfig.zephyr"
+source "Kconfig.zephyr"
 
 config OBJECTS_PRINTK
 	bool "use printk"

--- a/tests/drivers/i2c/i2c_slave_api/Kconfig
+++ b/tests/drivers/i2c/i2c_slave_api/Kconfig
@@ -1,5 +1,5 @@
 mainmenu "I2C Slave API Test"
 
-source "$(ZEPHYR_BASE)/Kconfig.zephyr"
+source "Kconfig.zephyr"
 
-source "$(ZEPHYR_BASE)/tests/drivers/i2c/i2c_slave_api/common/Kconfig"
+source "tests/drivers/i2c/i2c_slave_api/common/Kconfig"

--- a/tests/drivers/spi/spi_loopback/Kconfig
+++ b/tests/drivers/spi/spi_loopback/Kconfig
@@ -1,6 +1,6 @@
 mainmenu "SPI Loopback Test"
 
-source "$(ZEPHYR_BASE)/Kconfig.zephyr"
+source "Kconfig.zephyr"
 
 config SPI_LOOPBACK_DRV_NAME
 	string "SPI device name to use for test"

--- a/tests/kernel/arm_irq_vector_table/Kconfig
+++ b/tests/kernel/arm_irq_vector_table/Kconfig
@@ -2,4 +2,4 @@ config NUM_IRQS
 	int "Number of IRQs for this test, made overridable in the .conf file"
 	default 3
 
-source "$(ZEPHYR_BASE)/Kconfig.zephyr"
+source "Kconfig.zephyr"


### PR DESCRIPTION
The `$srctree` environment variable gives the path relative to which
`(o)source` statements work (the current directory is used if `$srctree`
is unset). It is set to `$ZEPHYR_BASE` in `cmake/kconfig.cmake`, so there's
no need to qualify the source of `Kconfig.zephyr` in sample Kconfig files
(or in external projects).

All `source`s in Zephyr assume that the Zephyr root directory is used as
the srctree as well, and would break otherwise.

Remove the `$(ZEPHYR_BASE)`s to make it clearer that all `source`
statements work relative to the Zephyr root. There was some user
confusion on IRC.

Also explain how things work in the documentation.