### PR TITLE
drivers: i2c: enable logging for drivers loading i2c-priv.h

### DIFF
--- a/drivers/i2c/i2c_imx.c
+++ b/drivers/i2c/i2c_imx.c
@@ -9,6 +9,10 @@
 #include <soc.h>
 #include <i2c_imx.h>
 #include <misc/util.h>
+
+#include <logging/log.h>
+LOG_MODULE_REGISTER(i2c_imx);
+
 #include "i2c-priv.h"
 
 #define DEV_CFG(dev) \

--- a/drivers/i2c/i2c_mcux.c
+++ b/drivers/i2c/i2c_mcux.c
@@ -10,6 +10,10 @@
 #include <fsl_i2c.h>
 #include <fsl_clock.h>
 #include <misc/util.h>
+
+#include <logging/log.h>
+LOG_MODULE_REGISTER(i2c_mcux);
+
 #include "i2c-priv.h"
 
 #define DEV_CFG(dev) \

--- a/drivers/i2c/i2c_qmsi.c
+++ b/drivers/i2c/i2c_qmsi.c
@@ -16,6 +16,8 @@
 #include "clk.h"
 #include "soc.h"
 
+#include <logging/log.h>
+LOG_MODULE_REGISTER(i2c_qmsi);
 #include "i2c-priv.h"
 
 /* Convenient macros to get the controller instance and the driver data. */

--- a/drivers/i2c/i2c_qmsi_ss.c
+++ b/drivers/i2c/i2c_qmsi_ss.c
@@ -13,6 +13,8 @@
 #include "qm_ss_isr.h"
 #include "ss_clk.h"
 
+#include <logging/log.h>
+LOG_MODULE_REGISTER(i2c_qmsi_ss);
 #include "i2c-priv.h"
 
 /* Convenient macros to get the controller instance and the driver data. */


### PR DESCRIPTION
i2c-priv.h is currently doing some logging and is included in various
i2c drivers, make sure the logger is enabled for those drivers.

Signed-off-by: Anas Nashif <anas.nashif@intel.com>