### PR TITLE
dts: arm: st: f3: Fix the unit-address for gpiof

### DIFF
--- a/dts/arm/st/f3/stm32f3.dtsi
+++ b/dts/arm/st/f3/stm32f3.dtsi
@@ -93,7 +93,7 @@
 				label = "GPIOD";
 			};
 
-			gpiof: gpio@480014000 {
+			gpiof: gpio@48001400 {
 				compatible = "st,stm32-gpio";
 				gpio-controller;
 				#gpio-cells = <2>;


### PR DESCRIPTION
Removed the extra zero from the unit-address for gpiof.

Signed-off-by: Galen Seitz <galens@seitzassoc.com>