### PR TITLE
dts: yaml: remove unused id field

### DIFF
--- a/dts/bindings/arc/arc,dccm.yaml
+++ b/dts/bindings/arc/arc,dccm.yaml
@@ -5,7 +5,6 @@
 #
 ---
 title: ARC DCCM
-id: arc,dccm
 version: 0.1
 
 description: >

--- a/dts/bindings/arc/arc,iccm.yaml
+++ b/dts/bindings/arc/arc,iccm.yaml
@@ -5,7 +5,6 @@
 #
 ---
 title: ARC ICCM
-id: arc,iccm
 version: 0.1
 
 description: >

--- a/dts/bindings/arm/atmel,sam0-sercom.yaml
+++ b/dts/bindings/arm/atmel,sam0-sercom.yaml
@@ -1,6 +1,5 @@
 ---
 title: Atmel SERCOM binding
-id: atmel,sam0-sercom
 version: 0.1
 
 description: >

--- a/dts/bindings/arm/nxp,kinetis-sim.yaml
+++ b/dts/bindings/arm/nxp,kinetis-sim.yaml
@@ -5,7 +5,6 @@
 #
 ---
 title: Kinetis System Integration Module (SIM)
-id: nxp,kinetis-sim
 version: 0.1
 
 description: >

--- a/dts/bindings/arm/nxp,lpc-mailbox.yaml
+++ b/dts/bindings/arm/nxp,lpc-mailbox.yaml
@@ -5,7 +5,6 @@
 #
 ---
 title: LPC MAILBOX
-id: nxp,lpc-mailbox
 version: 0.1
 
 description: >

--- a/dts/bindings/arm/st,stm32-ccm.yaml
+++ b/dts/bindings/arm/st,stm32-ccm.yaml
@@ -1,7 +1,6 @@
 ---
 # SPDX-License-Identifier: Apache-2.0
 title: STM32 CCM
-id: st,stm32-ccm
 version: 0.1
 
 description: >

--- a/dts/bindings/audio/ti,tlv320dac.yaml
+++ b/dts/bindings/audio/ti,tlv320dac.yaml
@@ -5,7 +5,6 @@
 #
 ---
 title: Texas Instruments TLV320DAC Audio DAC
-id: ti,tlv320dac
 version: 0.1
 
 description: >

--- a/dts/bindings/bluetooth/st,spbtle-rf.yaml
+++ b/dts/bindings/bluetooth/st,spbtle-rf.yaml
@@ -5,7 +5,6 @@
 #
 ---
 title: STMicroelectronics SPBTLE-RF bluetooth module
-id: st,spbtle-rf
 version: 0.1
 
 description: >

--- a/dts/bindings/bluetooth/zephyr,bt-hci-spi.yaml
+++ b/dts/bindings/bluetooth/zephyr,bt-hci-spi.yaml
@@ -5,7 +5,6 @@
 #
 ---
 title: Bluetooth module based on Zephyr's Bluetooth HCI SPI driver
-id: zephyr,bt-hci-spi
 version: 0.1
 
 description: >

--- a/dts/bindings/can/can-device.yaml
+++ b/dts/bindings/can/can-device.yaml
@@ -5,7 +5,6 @@
 #
 ---
 title: CAN Device Base Structure
-id: can-device
 version: 0.1
 
 description: >

--- a/dts/bindings/can/can.yaml
+++ b/dts/bindings/can/can.yaml
@@ -1,6 +1,5 @@
 ---
 title: CAN Base Structure
-id: can
 version: 0.1
 
 description: >

--- a/dts/bindings/can/st,stm32-can.yaml
+++ b/dts/bindings/can/st,stm32-can.yaml
@@ -1,6 +1,5 @@
 ---
 title: STM32 CAN
-id: st,stm32-can
 version: 0.1
 
 description: >

--- a/dts/bindings/clock/nxp,imx-ccm.yaml
+++ b/dts/bindings/clock/nxp,imx-ccm.yaml
@@ -5,7 +5,6 @@
 #
 ---
 title: i.MX Clock Controller Module (CCM)
-id: nxp,imx-ccm
 version: 0.1
 
 description: >

--- a/dts/bindings/clock/st,stm32-rcc.yaml
+++ b/dts/bindings/clock/st,stm32-rcc.yaml
@@ -1,6 +1,5 @@
 ---
 title: STM32 RCC
-id: st,stm32-rcc
 version: 0.1
 
 description: >

--- a/dts/bindings/crypto/arm,cryptocell-310.yaml
+++ b/dts/bindings/crypto/arm,cryptocell-310.yaml
@@ -5,7 +5,6 @@
 #
 ---
 title: ARM TrustZone CryptoCell 310
-id: arm,cryptocell-310
 version: 0.1
 
 description: >

--- a/dts/bindings/crypto/nordic,nrf-cc310.yaml
+++ b/dts/bindings/crypto/nordic,nrf-cc310.yaml
@@ -5,7 +5,6 @@
 #
 ---
 title: Nordic Control Interface for ARM TrustZone CryptoCell 310
-id: nordic,nrf-cc310
 version: 0.1
 
 description: >

--- a/dts/bindings/ethernet/intel,e1000.yaml
+++ b/dts/bindings/ethernet/intel,e1000.yaml
@@ -4,7 +4,6 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 title: Intel E1000 Ethernet controller
-id: intel,e1000
 version: 0.1
 
 description: >

--- a/dts/bindings/flash_controller/atmel,sam0-nvmctrl.yaml
+++ b/dts/bindings/flash_controller/atmel,sam0-nvmctrl.yaml
@@ -1,6 +1,5 @@
 ---
 title: Atmel SAM0 Non-Volatile Memory Controller
-id: atmel,sam0-nvmctrl
 version: 0.1
 
 description: >

--- a/dts/bindings/flash_controller/cypress,psoc6-flash-controller.yaml
+++ b/dts/bindings/flash_controller/cypress,psoc6-flash-controller.yaml
@@ -5,7 +5,6 @@
 #
 ---
 title: Cypress Flash Controller
-id: cypress,psoc6-flash-controller
 version: 0.1
 
 description: >

--- a/dts/bindings/flash_controller/flash-controller.yaml
+++ b/dts/bindings/flash_controller/flash-controller.yaml
@@ -1,6 +1,5 @@
 ---
 title: flash controller Base Structure
-id: soc-nv-flash-controller
 version: 0.1
 
 description: >

--- a/dts/bindings/flash_controller/nordic,nrf51-flash-controller.yaml
+++ b/dts/bindings/flash_controller/nordic,nrf51-flash-controller.yaml
@@ -1,6 +1,5 @@
 ---
 title: Nordic NVMC
-id: nordic,nrf51-flash-controller
 version: 0.1
 
 description: >

--- a/dts/bindings/flash_controller/nordic,nrf52-flash-controller.yaml
+++ b/dts/bindings/flash_controller/nordic,nrf52-flash-controller.yaml
@@ -1,6 +1,5 @@
 ---
 title: Nordic NVMC
-id: nordic,nrf52-flash-controller
 version: 0.1
 
 description: >

--- a/dts/bindings/flash_controller/nxp,kinetis-ftfa.yaml
+++ b/dts/bindings/flash_controller/nxp,kinetis-ftfa.yaml
@@ -1,6 +1,5 @@
 ---
 title: NXP Kinetis Flash Memory Module (FTFA)
-id: nxp,kinetis-ftfa
 version: 0.1
 
 description: >

--- a/dts/bindings/flash_controller/nxp,kinetis-ftfe.yaml
+++ b/dts/bindings/flash_controller/nxp,kinetis-ftfe.yaml
@@ -1,6 +1,5 @@
 ---
 title: NXP Kinetis Flash Memory Module (FTFE)
-id: nxp,kinetis-ftfe
 version: 0.1
 
 description: >

--- a/dts/bindings/flash_controller/nxp,kinetis-ftfl.yaml
+++ b/dts/bindings/flash_controller/nxp,kinetis-ftfl.yaml
@@ -1,6 +1,5 @@
 ---
 title: NXP Kinetis Flash Memory Module (FTFL)
-id: nxp,kinetis-ftfl
 version: 0.1
 
 description: >

--- a/dts/bindings/flash_controller/st,stm32f0-flash-controller.yaml
+++ b/dts/bindings/flash_controller/st,stm32f0-flash-controller.yaml
@@ -1,6 +1,5 @@
 ---
 title: STM32 F0 Flash Controller
-id: st,stm32f0-flash-controller
 version: 0.1
 
 description: >

--- a/dts/bindings/flash_controller/st,stm32f2-flash-controller.yaml
+++ b/dts/bindings/flash_controller/st,stm32f2-flash-controller.yaml
@@ -1,6 +1,5 @@
 ---
 title: STM32 F2 Flash Controller
-id: st,stm32f2-flash-controller
 version: 0.1
 
 description: >

--- a/dts/bindings/flash_controller/st,stm32f3-flash-controller.yaml
+++ b/dts/bindings/flash_controller/st,stm32f3-flash-controller.yaml
@@ -1,6 +1,5 @@
 ---
 title: STM32 F3 Flash Controller
-id: st,stm32f3-flash-controller
 version: 0.1
 
 description: >

--- a/dts/bindings/flash_controller/st,stm32f4-flash-controller.yaml
+++ b/dts/bindings/flash_controller/st,stm32f4-flash-controller.yaml
@@ -1,6 +1,5 @@
 ---
 title: STM32 F4 Flash Controller
-id: st,stm32f4-flash-controller
 version: 0.1
 
 description: >

--- a/dts/bindings/flash_controller/st,stm32l4-flash-controller.yaml
+++ b/dts/bindings/flash_controller/st,stm32l4-flash-controller.yaml
@@ -1,6 +1,5 @@
 ---
 title: STM32 L4 Flash Controller
-id: st,stm32l4-flash-controller
 version: 0.1
 
 description: >

--- a/dts/bindings/gpio/arm,cmsdk-gpio.yaml
+++ b/dts/bindings/gpio/arm,cmsdk-gpio.yaml
@@ -1,6 +1,5 @@
 ---
 title: ARM CMSDK GPIO
-id: arm,cmsdk-gpio
 version: 0.1
 
 description: >

--- a/dts/bindings/gpio/atmel,sam-gpio.yaml
+++ b/dts/bindings/gpio/atmel,sam-gpio.yaml
@@ -1,6 +1,5 @@
 ---
 title: Atmel SAM GPIO PORT driver
-id: atmel,sam-gpio
 version: 0.1
 
 description: >

--- a/dts/bindings/gpio/atmel,sam0-gpio.yaml
+++ b/dts/bindings/gpio/atmel,sam0-gpio.yaml
@@ -1,6 +1,5 @@
 ---
 title: Atmel SAM0 GPIO PORT driver
-id: atmel,sam0-gpio
 version: 0.1
 
 description: >

--- a/dts/bindings/gpio/gpio-keys.yaml
+++ b/dts/bindings/gpio/gpio-keys.yaml
@@ -5,7 +5,6 @@
 #
 ---
 title: GPIO KEYS
-id: gpio-keys
 version: 0.1
 
 description: >

--- a/dts/bindings/gpio/gpio-leds.yaml
+++ b/dts/bindings/gpio/gpio-leds.yaml
@@ -5,7 +5,6 @@
 #
 ---
 title: GPIO LED
-id: gpio-leds
 version: 0.1
 
 description: >

--- a/dts/bindings/gpio/intel,apl-gpio.yaml
+++ b/dts/bindings/gpio/intel,apl-gpio.yaml
@@ -5,7 +5,6 @@
 #
 ---
 title: Intel Apollo Lake GPIO controller
-id: intel,apl-gpio
 version: 0.1
 
 description: >

--- a/dts/bindings/gpio/intel,qmsi-gpio.yaml
+++ b/dts/bindings/gpio/intel,qmsi-gpio.yaml
@@ -5,7 +5,6 @@
 #
 ---
 title: Intel QMSI GPIO
-id: intel,qmsi-gpio
 version: 0.1
 
 description: >

--- a/dts/bindings/gpio/intel,qmsi-ss-gpio.yaml
+++ b/dts/bindings/gpio/intel,qmsi-ss-gpio.yaml
@@ -5,7 +5,6 @@
 #
 ---
 title: Intel QMSI SS GPIO
-id: intel,qmsi-ss-gpio
 version: 0.1
 
 description: >

--- a/dts/bindings/gpio/nordic,nrf-gpio.yaml
+++ b/dts/bindings/gpio/nordic,nrf-gpio.yaml
@@ -5,7 +5,6 @@
 #
 ---
 title: NRF5 GPIO
-id: nordic,nrf-gpio
 version: 0.1
 
 description: >

--- a/dts/bindings/gpio/nordic,nrf-gpiote.yaml
+++ b/dts/bindings/gpio/nordic,nrf-gpiote.yaml
@@ -5,7 +5,6 @@
 #
 ---
 title: NRF5 GPIOTE
-id: nordic,nrf-gpiote
 version: 0.1
 
 description: >

--- a/dts/bindings/gpio/nxp,imx-gpio.yaml
+++ b/dts/bindings/gpio/nxp,imx-gpio.yaml
@@ -5,7 +5,6 @@
 #
 ---
 title: i.MX GPIO
-id: nxp,imx-gpio
 version: 0.1
 
 description: >

--- a/dts/bindings/gpio/nxp,kinetis-gpio.yaml
+++ b/dts/bindings/gpio/nxp,kinetis-gpio.yaml
@@ -1,6 +1,5 @@
 ---
 title: Kinetis GPIO
-id: nxp,kinetis-gpio
 version: 0.1
 
 description: >

--- a/dts/bindings/gpio/pulp,pulpino-gpio.yaml
+++ b/dts/bindings/gpio/pulp,pulpino-gpio.yaml
@@ -5,7 +5,6 @@
 #
 ---
 title: PULPINO GPIO Controller
-id: pulp,pulpino-gpio
 version: 0.1
 
 description: >

--- a/dts/bindings/gpio/semtech,sx1509b-gpio.yaml
+++ b/dts/bindings/gpio/semtech,sx1509b-gpio.yaml
@@ -5,7 +5,6 @@
 #
 ---
 title: Semtech SX1509B I2C GPIO
-id: semtech,sx1509b
 version: 0.1
 
 description: >

--- a/dts/bindings/gpio/sifive,gpio0.yaml
+++ b/dts/bindings/gpio/sifive,gpio0.yaml
@@ -5,7 +5,6 @@
 #
 ---
 title: SiFive GPIO
-id: sifive,gpio0
 version: 0.1
 
 description: >

--- a/dts/bindings/gpio/silabs,efm32-gpio-port.yaml
+++ b/dts/bindings/gpio/silabs,efm32-gpio-port.yaml
@@ -1,6 +1,5 @@
 ---
 title: EFM32 GPIO
-id: silabs,efm32-gpio-port
 version: 0.1
 
 description: >

--- a/dts/bindings/gpio/silabs,efm32-gpio.yaml
+++ b/dts/bindings/gpio/silabs,efm32-gpio.yaml
@@ -1,6 +1,5 @@
 ---
 title: EFM32 GPIO
-id: silabs,efm32-gpio
 version: 0.1
 
 description: >

--- a/dts/bindings/gpio/silabs,efr32xg1-gpio-port.yaml
+++ b/dts/bindings/gpio/silabs,efr32xg1-gpio-port.yaml
@@ -1,6 +1,5 @@
 ---
 title: EFR32XG1 GPIO
-id: silabs,efr32xg1-gpio-port
 version: 0.1
 
 description: >

--- a/dts/bindings/gpio/silabs,efr32xg1-gpio.yaml
+++ b/dts/bindings/gpio/silabs,efr32xg1-gpio.yaml
@@ -1,6 +1,5 @@
 ---
 title: EFR32XG1 GPIO
-id: silabs,efr32xg1-gpio
 version: 0.1
 
 description: >

--- a/dts/bindings/gpio/snps,designware-gpio.yaml
+++ b/dts/bindings/gpio/snps,designware-gpio.yaml
@@ -5,7 +5,6 @@
 #
 ---
 title: Synopsys Designware GPIO controller
-id: snps,designware-gpio
 version: 0.1
 
 description: >

--- a/dts/bindings/gpio/st,stm32-gpio.yaml
+++ b/dts/bindings/gpio/st,stm32-gpio.yaml
@@ -5,7 +5,6 @@
 #
 ---
 title: STM32 GPIO
-id: st,stm32-gpio
 version: 0.1
 
 description: >

--- a/dts/bindings/i2c/arm,versatile-i2c.yaml
+++ b/dts/bindings/i2c/arm,versatile-i2c.yaml
@@ -5,7 +5,6 @@
 #
 ---
 title: ARM SBCon two-wire serial bus interface
-id: arm,versatile-i2c
 version: 0.1
 
 description: >

--- a/dts/bindings/i2c/atmel,sam-i2c-twi.yaml
+++ b/dts/bindings/i2c/atmel,sam-i2c-twi.yaml
@@ -5,7 +5,6 @@
 #
 ---
 title: Atmel SAM Family I2C (TWI) node
-id: atmel,sam-i2c-twi
 version: 0.1
 
 description: >

--- a/dts/bindings/i2c/atmel,sam-i2c-twihs.yaml
+++ b/dts/bindings/i2c/atmel,sam-i2c-twihs.yaml
@@ -5,7 +5,6 @@
 #
 ---
 title: Atmel SAM Family I2C (TWIHS) node
-id: atmel,sam-i2c-twihs
 version: 0.1
 
 description: >

--- a/dts/bindings/i2c/fsl,imx7d-i2c.yaml
+++ b/dts/bindings/i2c/fsl,imx7d-i2c.yaml
@@ -5,7 +5,6 @@
 #
 ---
 title: i.MX I2C Controller
-id: fsl,imx7d-i2c
 version: 0.1
 
 description: >

--- a/dts/bindings/i2c/i2c-device.yaml
+++ b/dts/bindings/i2c/i2c-device.yaml
@@ -5,7 +5,6 @@
 #
 ---
 title: I2C Device Base Structure
-id: i2c-device
 version: 0.1
 
 description: >

--- a/dts/bindings/i2c/i2c.yaml
+++ b/dts/bindings/i2c/i2c.yaml
@@ -5,7 +5,6 @@
 #
 ---
 title: I2C Base Structure
-id: i2c
 version: 0.1
 
 description: >

--- a/dts/bindings/i2c/intel,qmsi-i2c.yaml
+++ b/dts/bindings/i2c/intel,qmsi-i2c.yaml
@@ -5,7 +5,6 @@
 #
 ---
 title: Intel QMSI i2c
-id: intel,qmsi-i2c
 version: 0.1
 
 description: >

--- a/dts/bindings/i2c/intel,qmsi-ss-i2c.yaml
+++ b/dts/bindings/i2c/intel,qmsi-ss-i2c.yaml
@@ -5,7 +5,6 @@
 #
 ---
 title: Intel QMSI SS i2c
-id: intel,qmsi-ss-i2c
 version: 0.1
 
 description: >

--- a/dts/bindings/i2c/nordic,nrf-i2c.yaml
+++ b/dts/bindings/i2c/nordic,nrf-i2c.yaml
@@ -6,7 +6,6 @@
 #
 ---
 title: Nordic nRF Family I2C Master node
-id: nordic,nrf-i2c
 version: 0.1
 
 description: >

--- a/dts/bindings/i2c/nxp,kinetis-i2c.yaml
+++ b/dts/bindings/i2c/nxp,kinetis-i2c.yaml
@@ -5,7 +5,6 @@
 #
 ---
 title: Kinetis I2C Controller
-id: nxp,kinetis-i2c
 version: 0.1
 
 description: >

--- a/dts/bindings/i2c/snps,designware-i2c.yaml
+++ b/dts/bindings/i2c/snps,designware-i2c.yaml
@@ -5,7 +5,6 @@
 #
 ---
 title: Synopys DesignWare I2C controller
-id: snps,designware-i2c
 version: 0.1
 
 description: >

--- a/dts/bindings/i2c/st,stm32-i2c-v1.yaml
+++ b/dts/bindings/i2c/st,stm32-i2c-v1.yaml
@@ -5,7 +5,6 @@
 #
 ---
 title: STM32 I2C V1
-id: st,stm32-i2c-v1
 version: 0.1
 
 description: >

--- a/dts/bindings/i2c/st,stm32-i2c-v2.yaml
+++ b/dts/bindings/i2c/st,stm32-i2c-v2.yaml
@@ -5,7 +5,6 @@
 #
 ---
 title: STM32 I2C V2
-id: st,stm32-i2c-v2
 version: 0.1
 
 description: >

--- a/dts/bindings/i2c/ti,cc32xx-i2c.yaml
+++ b/dts/bindings/i2c/ti,cc32xx-i2c.yaml
@@ -1,6 +1,5 @@
 ---
 title: CC32XX I2C
-id: ti,cc32xx-i2c
 
 description: >
     This binding gives a base representation of the TI CC32XX I2C controller

--- a/dts/bindings/ieee802154/nxp,mcr20a.yaml
+++ b/dts/bindings/ieee802154/nxp,mcr20a.yaml
@@ -5,7 +5,6 @@
 #
 ---
 title: NXP MCR20A 802.15.4 Wireless Transceiver
-id: nxp,mcr20a
 version: 0.1
 
 description: >

--- a/dts/bindings/iio/adc/adc.yaml
+++ b/dts/bindings/iio/adc/adc.yaml
@@ -5,7 +5,6 @@
 #
 ---
 title: ADC Base Structure
-id: adc
 version: 0.1
 
 description: >

--- a/dts/bindings/iio/adc/atmel,sam-afec.yaml
+++ b/dts/bindings/iio/adc/atmel,sam-afec.yaml
@@ -1,6 +1,5 @@
 ---
 title: Atmel SAM Family AFEC
-id: atmel,sam-afec
 version: 0.1
 
 description: >

--- a/dts/bindings/iio/adc/intel,quark-d2000-adc.yaml
+++ b/dts/bindings/iio/adc/intel,quark-d2000-adc.yaml
@@ -5,7 +5,6 @@
 #
 ---
 title: Intel Quark D2000 ADC
-id: intel,quark-d2000-adc
 version: 0.1
 
 description: >

--- a/dts/bindings/iio/adc/nordic,nrf-adc.yaml
+++ b/dts/bindings/iio/adc/nordic,nrf-adc.yaml
@@ -5,7 +5,6 @@
 #
 ---
 title: Nordic Semiconductor nRF Family ADC
-id: nordic,nrf-adc
 version: 0.1
 
 description: >

--- a/dts/bindings/iio/adc/nordic,nrf-saadc.yaml
+++ b/dts/bindings/iio/adc/nordic,nrf-saadc.yaml
@@ -5,7 +5,6 @@
 #
 ---
 title: Nordic Semiconductor nRF Family SAADC
-id: nordic,nrf-saadc
 version: 0.1
 
 description: >

--- a/dts/bindings/iio/adc/nxp,kinetis-adc16.yaml
+++ b/dts/bindings/iio/adc/nxp,kinetis-adc16.yaml
@@ -5,7 +5,6 @@
 #
 ---
 title: Kinetis ADC16
-id: nxp,kinetis-adc16
 version: 0.1
 
 description: >

--- a/dts/bindings/iio/adc/snps,dw-adc.yaml
+++ b/dts/bindings/iio/adc/snps,dw-adc.yaml
@@ -5,7 +5,6 @@
 #
 ---
 title: DesignWare ADC
-id: snps,dw-adc
 version: 0.1
 
 description: >

--- a/dts/bindings/interrupt-controller/arm,v6m-nvic.yaml
+++ b/dts/bindings/interrupt-controller/arm,v6m-nvic.yaml
@@ -1,6 +1,5 @@
 ---
 title: ARMv6-M NVIC Interrupt Controller
-id: arm,v6m-nvic
 version: 0.1
 
 description: >

--- a/dts/bindings/interrupt-controller/arm,v7m-nvic.yaml
+++ b/dts/bindings/interrupt-controller/arm,v7m-nvic.yaml
@@ -1,6 +1,5 @@
 ---
 title: ARMv7-M NVIC Interrupt Controller
-id: arm,v7m-nvic
 version: 0.1
 
 description: >

--- a/dts/bindings/interrupt-controller/arm,v8m-nvic.yaml
+++ b/dts/bindings/interrupt-controller/arm,v8m-nvic.yaml
@@ -1,6 +1,5 @@
 ---
 title: ARMv8-M NVIC Interrupt Controller
-id: arm,v8m-nvic
 version: 0.1
 
 description: >

--- a/dts/bindings/interrupt-controller/pulpino,event-unit.yaml
+++ b/dts/bindings/interrupt-controller/pulpino,event-unit.yaml
@@ -5,7 +5,6 @@
 #
 ---
 title: PULPINO Event Unit
-id: pulp,pulpino-event-unit
 version: 0.1
 
 description: >

--- a/dts/bindings/interrupt-controller/riscv,plic0.yaml
+++ b/dts/bindings/interrupt-controller/riscv,plic0.yaml
@@ -5,7 +5,6 @@
 #
 ---
 title: RISC-V PLIC
-id: riscv,plic0
 version: 0.1
 
 description: >

--- a/dts/bindings/interrupt-controller/snps,arcv2-intc.yaml
+++ b/dts/bindings/interrupt-controller/snps,arcv2-intc.yaml
@@ -5,7 +5,6 @@
 #
 ---
 title: ARCV2 Interrupt Controller
-id: snps,arcv2-intc
 version: 0.1
 
 description: >

--- a/dts/bindings/led/nxp,pca9633.yaml
+++ b/dts/bindings/led/nxp,pca9633.yaml
@@ -1,6 +1,5 @@
 ---
 title: NXP PCA9633 LED Driver
-id: nxp,pca9633
 version: 0.1
 
 description: NXP PCA9633 LED binding

--- a/dts/bindings/led/ti,lp3943.yaml
+++ b/dts/bindings/led/ti,lp3943.yaml
@@ -1,6 +1,5 @@
 ---
 title: TI LP3943 LED Driver
-id: ti,lp3943
 version: 0.1
 
 description: TI LP3943 LED binding

--- a/dts/bindings/led/ti,lp5562.yaml
+++ b/dts/bindings/led/ti,lp5562.yaml
@@ -1,6 +1,5 @@
 ---
 title: TI LP5562 LED Driver
-id: ti,lp5562
 version: 0.1
 
 description: TI LP5562 LED binding

--- a/dts/bindings/led_strip/apa,apa-102.yaml
+++ b/dts/bindings/led_strip/apa,apa-102.yaml
@@ -1,6 +1,5 @@
 ---
 title: APA102 SPI LED strip
-id: apa,apa102
 version: 0.1
 
 description: APA102 SPI LED strip binding

--- a/dts/bindings/memory-controllers/nxp,imx-semc.yaml
+++ b/dts/bindings/memory-controllers/nxp,imx-semc.yaml
@@ -5,7 +5,6 @@
 #
 ---
 title: NXP SEMC
-id: nxp,imx-semc
 version: 0.1
 
 description: >

--- a/dts/bindings/modem/wnc,m14a2a.yaml
+++ b/dts/bindings/modem/wnc,m14a2a.yaml
@@ -5,7 +5,6 @@
 #
 ---
 title: WNC-M14A2A LTE-M Modem
-id: wnc,m14a2a
 version: 0.1
 
 description: >

--- a/dts/bindings/mtd/partition.yaml
+++ b/dts/bindings/mtd/partition.yaml
@@ -1,6 +1,5 @@
 ---
 title: Flash Partitions
-id: fixed-partition
 version: 0.1
 
 description: >

--- a/dts/bindings/mtd/soc-nv-flash.yaml
+++ b/dts/bindings/mtd/soc-nv-flash.yaml
@@ -1,6 +1,5 @@
 ---
 title: Flash base node description
-id: soc-nv-flash
 version: 0.1
 
 description: >

--- a/dts/bindings/pinctrl/atmel,sam0-pinmux.yaml
+++ b/dts/bindings/pinctrl/atmel,sam0-pinmux.yaml
@@ -1,6 +1,5 @@
 ---
 title: Atmel SAM0 PINMUX
-id: atmel,sam0-pinmux
 version: 0.1
 
 description: >

--- a/dts/bindings/pinctrl/nxp,kinetis-pinmux.yaml
+++ b/dts/bindings/pinctrl/nxp,kinetis-pinmux.yaml
@@ -1,6 +1,5 @@
 ---
 title: Kinetis Pinmux
-id: nxp,kinetis-pinmux
 version: 0.1
 
 description: >

--- a/dts/bindings/pinctrl/st,stm32-pinmux.yaml
+++ b/dts/bindings/pinctrl/st,stm32-pinmux.yaml
@@ -1,6 +1,5 @@
 ---
 title: STM32 PINMUX
-id: st,stm32-pinmux
 version: 0.1
 
 description: >

--- a/dts/bindings/pwm/fsl,imx7d-pwm.yaml
+++ b/dts/bindings/pwm/fsl,imx7d-pwm.yaml
@@ -5,7 +5,6 @@
 #
 ---
 title: i.MX7D PWM
-id: fsl,imx7d-pwm
 version: 0.1
 
 description: >

--- a/dts/bindings/pwm/nxp,kinetis-ftm.yaml
+++ b/dts/bindings/pwm/nxp,kinetis-ftm.yaml
@@ -5,7 +5,6 @@
 #
 ---
 title: Kinetis FTM
-id: nxp,kinetis-ftm
 version: 0.1
 
 description: >

--- a/dts/bindings/pwm/pwm.yaml
+++ b/dts/bindings/pwm/pwm.yaml
@@ -5,7 +5,6 @@
 #
 ---
 title: PWM Base Structure
-id: pwm
 version: 0.1
 
 description: >

--- a/dts/bindings/pwm/sifive,pwm0.yaml
+++ b/dts/bindings/pwm/sifive,pwm0.yaml
@@ -5,7 +5,6 @@
 #
 ---
 title: SiFive PWM
-id: sifive,pwm0
 version: 0.1
 
 description: >

--- a/dts/bindings/pwm/st,stm32-pwm.yaml
+++ b/dts/bindings/pwm/st,stm32-pwm.yaml
@@ -1,6 +1,5 @@
 ---
 title: STM32 PWM
-id: st,stm32-pwm
 version: 0.1
 
 description: >

--- a/dts/bindings/rtc/intel,qmsi-rtc.yaml
+++ b/dts/bindings/rtc/intel,qmsi-rtc.yaml
@@ -5,7 +5,6 @@
 #
 ---
 title: Intel QMSI RTC
-id: intel,qmsi-rtc
 version: 0.1
 
 description: >

--- a/dts/bindings/rtc/nxp,kinetis-rtc.yaml
+++ b/dts/bindings/rtc/nxp,kinetis-rtc.yaml
@@ -5,7 +5,6 @@
 #
 ---
 title: Kinetis RTC
-id: nxp,kinetis-rtc
 version: 0.1
 
 description: >

--- a/dts/bindings/rtc/rtc.yaml
+++ b/dts/bindings/rtc/rtc.yaml
@@ -5,7 +5,6 @@
 #
 ---
 title: RTC Base Structure
-id: rtc
 version: 0.1
 
 description: >

--- a/dts/bindings/rtc/st,stm32-rtc.yaml
+++ b/dts/bindings/rtc/st,stm32-rtc.yaml
@@ -5,7 +5,6 @@
 #
 ---
 title: STM32 RTC
-id: st,stm32-rtc
 version: 0.1
 
 description: >

--- a/dts/bindings/sensor/adi,adt7420.yaml
+++ b/dts/bindings/sensor/adi,adt7420.yaml
@@ -5,7 +5,6 @@
 #
 ---
 title: ADT7420 16-Bit Digital I2C Temperature Sensor
-id: adi,adt7420
 version: 0.1
 
 description: >

--- a/dts/bindings/sensor/ams,ccs811.yaml
+++ b/dts/bindings/sensor/ams,ccs811.yaml
@@ -5,7 +5,6 @@
 #
 ---
 title: AMS (Austria Mikro Systeme) Digital Air Quality Sensor CCS811
-id: ams,ccs811
 version: 0.1
 
 description: >

--- a/dts/bindings/sensor/avago,apds9960.yaml
+++ b/dts/bindings/sensor/avago,apds9960.yaml
@@ -5,7 +5,6 @@
 #
 ---
 title: APDS9960 Digital Proximity, Ambient Light, RGB and Gesture Sensor
-id: avago,apds9960
 version: 0.1
 
 description: >

--- a/dts/bindings/sensor/max,max30101.yaml
+++ b/dts/bindings/sensor/max,max30101.yaml
@@ -5,7 +5,6 @@
 #
 ---
 title: MAX30101 heart rate sensor
-id: nxp,max30101
 version: 0.1
 
 description: >

--- a/dts/bindings/sensor/nxp,fxas21002.yaml
+++ b/dts/bindings/sensor/nxp,fxas21002.yaml
@@ -5,7 +5,6 @@
 #
 ---
 title: FXAS21002 3-axis gyroscope
-id: nxp,fxas21002
 version: 0.1
 
 description: >

--- a/dts/bindings/sensor/nxp,fxos8700.yaml
+++ b/dts/bindings/sensor/nxp,fxos8700.yaml
@@ -5,7 +5,6 @@
 #
 ---
 title: FXOS8700 6-axis accelerometer/magnetometer
-id: nxp,fxos8700
 version: 0.1
 
 description: >

--- a/dts/bindings/sensor/nxp,mma8451q.yaml
+++ b/dts/bindings/sensor/nxp,mma8451q.yaml
@@ -5,7 +5,6 @@
 #
 ---
 title: MMA8451Q 3-axis Accelerometer
-id: nxp,mma8451q
 version: 0.1
 
 description: >

--- a/dts/bindings/sensor/st,hts221.yaml
+++ b/dts/bindings/sensor/st,hts221.yaml
@@ -5,7 +5,6 @@
 #
 ---
 title: STMicroelectronics MEMS sensors HTS221
-id: st,hts221
 version: 0.1
 
 description: >

--- a/dts/bindings/sensor/st,lis3mdl-magn.yaml
+++ b/dts/bindings/sensor/st,lis3mdl-magn.yaml
@@ -5,7 +5,6 @@
 #
 ---
 title: STMicroelectronics MEMS sensors LIS3MDL
-id: st,lis3mdl-magn
 version: 0.1
 
 description: >

--- a/dts/bindings/sensor/st,lps22hb-press.yaml
+++ b/dts/bindings/sensor/st,lps22hb-press.yaml
@@ -5,7 +5,6 @@
 #
 ---
 title: STMicroelectronics MEMS sensors LPS22HB
-id: st,lps22hb-press
 version: 0.1
 
 description: >

--- a/dts/bindings/sensor/st,lps25hb-press.yaml
+++ b/dts/bindings/sensor/st,lps25hb-press.yaml
@@ -5,7 +5,6 @@
 #
 ---
 title: STMicroelectronics MEMS sensors LPS25HB
-id: st,lps25hb-press
 version: 0.1
 
 description: >

--- a/dts/bindings/sensor/st,lsm6ds0.yaml
+++ b/dts/bindings/sensor/st,lsm6ds0.yaml
@@ -5,7 +5,6 @@
 #
 ---
 title: STMicroelectronics MEMS sensors LSM6DS0
-id: st,lsm6ds0
 version: 0.1
 
 description: >

--- a/dts/bindings/sensor/st,lsm6dsl-spi.yaml
+++ b/dts/bindings/sensor/st,lsm6dsl-spi.yaml
@@ -5,7 +5,6 @@
 #
 ---
 title: STMicroelectronics MEMS sensors LSM6DSL SPI
-id: st,lsm6dsl-spi
 version: 0.1
 
 description: >

--- a/dts/bindings/sensor/st,lsm6dsl.yaml
+++ b/dts/bindings/sensor/st,lsm6dsl.yaml
@@ -5,7 +5,6 @@
 #
 ---
 title: STMicroelectronics MEMS sensors LSM6DSL
-id: st,lsm6dsl
 version: 0.1
 
 description: >

--- a/dts/bindings/sensor/st,vl53l0x.yaml
+++ b/dts/bindings/sensor/st,vl53l0x.yaml
@@ -5,7 +5,6 @@
 #
 ---
 title: STMicroelectronics MEMS sensors VL53L0X
-id: st,vl53l0x
 version: 0.1
 
 description: >

--- a/dts/bindings/sensor/ti,hdc1008.yaml
+++ b/dts/bindings/sensor/ti,hdc1008.yaml
@@ -5,7 +5,6 @@
 #
 ---
 title: HDC1008 Temperature and Humidity Sensor
-id: ti,hdc1008
 version: 0.1
 
 description: >

--- a/dts/bindings/serial/altera,jtag-uart.yaml
+++ b/dts/bindings/serial/altera,jtag-uart.yaml
@@ -1,6 +1,5 @@
 ---
 title: Altera JTAG UART
-id: altera,jtag-uart
 version: 0.1
 
 description: >

--- a/dts/bindings/serial/arm,cmsdk-uart.yaml
+++ b/dts/bindings/serial/arm,cmsdk-uart.yaml
@@ -1,6 +1,5 @@
 ---
 title: ARM CMSDK UART
-id: arm,cmsdk-uart
 version: 0.1
 
 description: >

--- a/dts/bindings/serial/atmel,sam-uart.yaml
+++ b/dts/bindings/serial/atmel,sam-uart.yaml
@@ -1,6 +1,5 @@
 ---
 title: SAM Family UART
-id: atmel,sam-uart
 version: 0.1
 
 description: >

--- a/dts/bindings/serial/atmel,sam-usart.yaml
+++ b/dts/bindings/serial/atmel,sam-usart.yaml
@@ -1,6 +1,5 @@
 ---
 title: Atmel SAM Family USART
-id: atmel,sam-usart
 version: 0.1
 
 description: >

--- a/dts/bindings/serial/atmel,sam0-uart.yaml
+++ b/dts/bindings/serial/atmel,sam0-uart.yaml
@@ -1,6 +1,5 @@
 ---
 title: Atmel SAM0 SERCOM UART driver
-id: atmel,sam0-uart
 version: 0.1
 
 description: >

--- a/dts/bindings/serial/cypress,psoc6-uart.yaml
+++ b/dts/bindings/serial/cypress,psoc6-uart.yaml
@@ -5,7 +5,6 @@
 #
 ---
 title: CYPRESS UART
-id: cypress,psoc6-uart
 version: 0.1
 
 description: >

--- a/dts/bindings/serial/intel,qmsi-uart.yaml
+++ b/dts/bindings/serial/intel,qmsi-uart.yaml
@@ -5,7 +5,6 @@
 #
 ---
 title: Intel QMSI Uart
-id: intel,qmsi-uart
 version: 0.1
 
 description: >

--- a/dts/bindings/serial/nordic,nrf-uart.yaml
+++ b/dts/bindings/serial/nordic,nrf-uart.yaml
@@ -1,6 +1,5 @@
 ---
 title: Nordic UART
-id: nordic,nrf-uart
 version: 0.1
 
 description: >

--- a/dts/bindings/serial/nordic,nrf-uarte.yaml
+++ b/dts/bindings/serial/nordic,nrf-uarte.yaml
@@ -1,6 +1,5 @@
 ---
 title: Nordic UARTE
-id: nordic,nrf-uarte
 version: 0.1
 
 description: >

--- a/dts/bindings/serial/ns16550.yaml
+++ b/dts/bindings/serial/ns16550.yaml
@@ -1,6 +1,5 @@
 ---
 title: ns16550
-id: ns16550
 version: 0.1
 
 description: >

--- a/dts/bindings/serial/nxp,imx-uart.yaml
+++ b/dts/bindings/serial/nxp,imx-uart.yaml
@@ -5,7 +5,6 @@
 #
 ---
 title: iMX Uart
-id: nxp,imx-uart
 version: 0.1
 
 description: >

--- a/dts/bindings/serial/nxp,kinetis-lpsci.yaml
+++ b/dts/bindings/serial/nxp,kinetis-lpsci.yaml
@@ -1,6 +1,5 @@
 ---
 title: Kinetis LPSCI UART
-id: nxp,kinetis-lpsci
 version: 0.1
 
 description: >

--- a/dts/bindings/serial/nxp,kinetis-lpuart.yaml
+++ b/dts/bindings/serial/nxp,kinetis-lpuart.yaml
@@ -1,6 +1,5 @@
 ---
 title: Kinetis LPUART
-id: nxp,kinetis-lpuart
 version: 0.1
 
 description: >

--- a/dts/bindings/serial/nxp,kinetis-uart.yaml
+++ b/dts/bindings/serial/nxp,kinetis-uart.yaml
@@ -1,6 +1,5 @@
 ---
 title: Kinetis UART
-id: nxp,kinetis-uart
 version: 0.1
 
 description: >

--- a/dts/bindings/serial/nxp,lpc-usart.yaml
+++ b/dts/bindings/serial/nxp,lpc-usart.yaml
@@ -5,7 +5,6 @@
 #
 ---
 title: LPC USART
-id: nxp,lpc-usart
 version: 0.1
 
 description: >

--- a/dts/bindings/serial/riscv,qemu-uart.yaml
+++ b/dts/bindings/serial/riscv,qemu-uart.yaml
@@ -1,6 +1,5 @@
 ---
 title: RISCV QEMU UART
-id: riscv,qemu-uart
 version: 0.1
 
 description: >

--- a/dts/bindings/serial/sifive,uart0.yaml
+++ b/dts/bindings/serial/sifive,uart0.yaml
@@ -5,7 +5,6 @@
 #
 ---
 title: SIFIVE UART
-id: sifive,uart0
 version: 0.1
 
 description: >

--- a/dts/bindings/serial/silabs,efm32-uart.yaml
+++ b/dts/bindings/serial/silabs,efm32-uart.yaml
@@ -1,6 +1,5 @@
 ---
 title: EFM32 UART
-id: silabs,efm32-uart
 version: 0.1
 
 description: >

--- a/dts/bindings/serial/silabs,efm32-usart.yaml
+++ b/dts/bindings/serial/silabs,efm32-usart.yaml
@@ -1,6 +1,5 @@
 ---
 title: EFM32 USART
-id: silabs,efm32-usart
 version: 0.1
 
 description: >

--- a/dts/bindings/serial/st,stm32-lpuart.yaml
+++ b/dts/bindings/serial/st,stm32-lpuart.yaml
@@ -1,6 +1,5 @@
 ---
 title: STM32 LPUART
-id: st,stm32-lpuart
 version: 0.1
 
 description: >

--- a/dts/bindings/serial/st,stm32-uart.yaml
+++ b/dts/bindings/serial/st,stm32-uart.yaml
@@ -1,6 +1,5 @@
 ---
 title: STM32 UART
-id: st,stm32-uart
 version: 0.1
 
 description: >

--- a/dts/bindings/serial/st,stm32-usart.yaml
+++ b/dts/bindings/serial/st,stm32-usart.yaml
@@ -1,6 +1,5 @@
 ---
 title: STM32 USART
-id: st,stm32-usart
 version: 0.1
 
 description: >

--- a/dts/bindings/serial/ti,cc32xx-uart.yaml
+++ b/dts/bindings/serial/ti,cc32xx-uart.yaml
@@ -1,6 +1,5 @@
 ---
 title: TI CC32XX Uart
-id: ti,cc32xx-uart
 version: 0.1
 
 description: >

--- a/dts/bindings/serial/ti,msp432p4xx-uart.yaml
+++ b/dts/bindings/serial/ti,msp432p4xx-uart.yaml
@@ -1,6 +1,5 @@
 ---
 title: TI MSP432P4XX UART
-id: ti,msp432p4xx-uart
 version: 0.1
 
 description: >

--- a/dts/bindings/serial/ti,stellaris-uart.yaml
+++ b/dts/bindings/serial/ti,stellaris-uart.yaml
@@ -1,6 +1,5 @@
 ---
 title: TI Stellaris UART
-id: ti,stellaris-uart
 version: 0.1
 
 description: >

--- a/dts/bindings/serial/uart-device.yaml
+++ b/dts/bindings/serial/uart-device.yaml
@@ -5,7 +5,6 @@
 #
 ---
 title: UART Device Base Structure
-id: uart-device
 version: 0.1
 
 description: >

--- a/dts/bindings/serial/uart.yaml
+++ b/dts/bindings/serial/uart.yaml
@@ -1,6 +1,5 @@
 ---
 title: Uart Base Structure
-id: uart
 version: 0.1
 
 description: >

--- a/dts/bindings/slave/i2c,eeprom.yaml
+++ b/dts/bindings/slave/i2c,eeprom.yaml
@@ -5,7 +5,6 @@
 #
 ---
 title: Virtual I2C slave eeprom
-id: i2c,eeprom
 version: 0.1
 
 description: >

--- a/dts/bindings/spi/atmel,sam-spi.yaml
+++ b/dts/bindings/spi/atmel,sam-spi.yaml
@@ -5,7 +5,6 @@
 #
 ---
 title: Atmel SAM SPI driver
-id: atmel,sam-spi
 version: 0.1
 
 description: >

--- a/dts/bindings/spi/atmel,sam0-spi.yaml
+++ b/dts/bindings/spi/atmel,sam0-spi.yaml
@@ -5,7 +5,6 @@
 #
 ---
 title: Atmel SAM0 SERCOM SPI driver
-id: atmel,sam0-spi
 version: 0.1
 
 description: >

--- a/dts/bindings/spi/nordic,nrf-spi.yaml
+++ b/dts/bindings/spi/nordic,nrf-spi.yaml
@@ -5,7 +5,6 @@
 #
 ---
 title: Nordic nRF Family SPI Master node
-id: nordic,nrf-spi
 version: 0.1
 
 description: >

--- a/dts/bindings/spi/nxp,imx-flexspi.yaml
+++ b/dts/bindings/spi/nxp,imx-flexspi.yaml
@@ -5,7 +5,6 @@
 #
 ---
 title: NXP FlexSPI
-id: nxp,imx-flexspi
 version: 0.1
 
 description: >

--- a/dts/bindings/spi/nxp,imx-lpspi.yaml
+++ b/dts/bindings/spi/nxp,imx-lpspi.yaml
@@ -5,7 +5,6 @@
 #
 ---
 title: NXP LPSPI
-id: nxp,imx-lpspi
 version: 0.1
 
 description: >

--- a/dts/bindings/spi/nxp,kinetis-dspi.yaml
+++ b/dts/bindings/spi/nxp,kinetis-dspi.yaml
@@ -5,7 +5,6 @@
 #
 ---
 title: NXP DSPI
-id: nxp,kinetis-dspi
 version: 0.1
 
 description: >

--- a/dts/bindings/spi/sifive,spi0.yaml
+++ b/dts/bindings/spi/sifive,spi0.yaml
@@ -5,7 +5,6 @@
 #
 ---
 title: Sifive SPI driver
-id: sifive,spi0
 version: 0.1
 
 description: >

--- a/dts/bindings/spi/snps,designware-spi.yaml
+++ b/dts/bindings/spi/snps,designware-spi.yaml
@@ -5,7 +5,6 @@
 #
 ---
 title: Synopsys Designware SPI Controller
-id: snps,designware-spi
 version: 0.1
 
 description: >

--- a/dts/bindings/spi/spi-device.yaml
+++ b/dts/bindings/spi/spi-device.yaml
@@ -5,7 +5,6 @@
 #
 ---
 title: SPI Device Base Structure
-id: spi-device
 version: 0.1
 
 description: >

--- a/dts/bindings/spi/spi.yaml
+++ b/dts/bindings/spi/spi.yaml
@@ -5,7 +5,6 @@
 #
 ---
 title: SPI Base Structure
-id: spi
 version: 0.1
 
 description: >

--- a/dts/bindings/spi/st,stm32-spi-fifo.yaml
+++ b/dts/bindings/spi/st,stm32-spi-fifo.yaml
@@ -5,7 +5,6 @@
 #
 ---
 title: STM32 SPI FIFO
-id: st,stm32-spi-fifo
 version: 0.1
 
 description: >

--- a/dts/bindings/spi/st,stm32-spi.yaml
+++ b/dts/bindings/spi/st,stm32-spi.yaml
@@ -5,7 +5,6 @@
 #
 ---
 title: STM32 SPI
-id: st,stm32-spi
 version: 0.1
 
 description: >

--- a/dts/bindings/timer/arm,cmsdk-dtimer.yaml
+++ b/dts/bindings/timer/arm,cmsdk-dtimer.yaml
@@ -1,6 +1,5 @@
 ---
 title: ARM CMSDK DUALTIMER
-id: arm,cmsdk-dtimer
 version: 0.1
 
 description: >

--- a/dts/bindings/timer/arm,cmsdk-timer.yaml
+++ b/dts/bindings/timer/arm,cmsdk-timer.yaml
@@ -1,6 +1,5 @@
 ---
 title: ARM CMSDK TIMER
-id: arm,cmsdk-timer
 version: 0.1
 
 description: >

--- a/dts/bindings/timer/st,stm32-timers.yaml
+++ b/dts/bindings/timer/st,stm32-timers.yaml
@@ -1,6 +1,5 @@
 ---
 title: STM32 TIMERS
-id: st,stm32-timers
 version: 0.1
 
 description: >

--- a/dts/bindings/usb/atmel,sam0-usb.yaml
+++ b/dts/bindings/usb/atmel,sam0-usb.yaml
@@ -1,6 +1,5 @@
 ---
 title: Atmel SAM0 USB device
-id: atmel,sam0-usb
 version: 0.1
 
 description: >

--- a/dts/bindings/usb/nordic,nrf-usbd.yaml
+++ b/dts/bindings/usb/nordic,nrf-usbd.yaml
@@ -5,7 +5,6 @@
 #
 ---
 title: Nordic nRF52 USBD
-id: nordic,nrf-usbd
 version: 0.1
 
 description: >

--- a/dts/bindings/usb/nxp,kinetis-usbd.yaml
+++ b/dts/bindings/usb/nxp,kinetis-usbd.yaml
@@ -5,7 +5,6 @@
 #
 ---
 title: NXP Kinetis USBD
-id: nxp,kinetis-usbd
 version: 0.1
 
 description: >

--- a/dts/bindings/usb/st,stm32-otgfs.yaml
+++ b/dts/bindings/usb/st,stm32-otgfs.yaml
@@ -5,7 +5,6 @@
 #
 ---
 title: STM32 OTGFS
-id: st,stm32-otgfs
 version: 0.1
 
 description: >

--- a/dts/bindings/usb/st,stm32-otghs.yaml
+++ b/dts/bindings/usb/st,stm32-otghs.yaml
@@ -5,7 +5,6 @@
 #
 ---
 title: STM32 OTGHS
-id: st,stm32-otghs
 version: 0.1
 
 description: >

--- a/dts/bindings/usb/st,stm32-usb.yaml
+++ b/dts/bindings/usb/st,stm32-usb.yaml
@@ -5,7 +5,6 @@
 #
 ---
 title: STM32 USB
-id: st,stm32-usb
 version: 0.1
 
 description: >

--- a/dts/bindings/usb/usb-ep.yaml
+++ b/dts/bindings/usb/usb-ep.yaml
@@ -5,7 +5,6 @@
 #
 ---
 title: USB Endpoints' properties
-id: USB-EP
 version: 0.1
 
 description: >

--- a/dts/bindings/usb/usb.yaml
+++ b/dts/bindings/usb/usb.yaml
@@ -5,7 +5,6 @@
 #
 ---
 title: USB Base Structure
-id: USB
 version: 0.1
 
 description: >

--- a/dts/bindings/watchdog/arm,cmsdk-watchdog.yaml
+++ b/dts/bindings/watchdog/arm,cmsdk-watchdog.yaml
@@ -1,6 +1,5 @@
 ---
 title: ARM CMSDK WATCHDOG
-id: arm,cmsdk-watchdog
 version: 0.1
 
 description: >

--- a/dts/bindings/watchdog/atmel,sam0-watchdog.yaml
+++ b/dts/bindings/watchdog/atmel,sam0-watchdog.yaml
@@ -1,6 +1,5 @@
 ---
 title: Atmel SAM0 watchdog driver
-id: atmel,sam0-watchdog
 version: 0.1
 
 description: >

--- a/dts/bindings/watchdog/nordic,nrf-watchdog.yaml
+++ b/dts/bindings/watchdog/nordic,nrf-watchdog.yaml
@@ -5,7 +5,6 @@
 #
 ---
 title: Nordic Semiconductor NRF watchdog driver
-id: nordic,nrf-watchdog
 version: 0.1
 
 description: >

--- a/dts/bindings/watchdog/nxp,kinetis-wdog.yaml
+++ b/dts/bindings/watchdog/nxp,kinetis-wdog.yaml
@@ -5,7 +5,6 @@
 #
 ---
 title: NXP Kinetis watchdog driver
-id: nxp,kinetis-wdog
 version: 0.1
 
 description: >


### PR DESCRIPTION
The 'id' field was never used and tended to just have the compat of the
node.  Lets remove it and removed some code in extract_dts_includes.py
related to it.  Added a warning if 'id' is set in a yaml so we can
remove it going forward.

Signed-off-by: Kumar Gala <kumar.gala@linaro.org>