### PR TITLE
drivers: soc_flash_nios2_qspi: fix logging formatting

### DIFF
--- a/drivers/flash/soc_flash_nios2_qspi.c
+++ b/drivers/flash/soc_flash_nios2_qspi.c
@@ -79,7 +79,7 @@ static int flash_nios2_qspi_erase(struct device *dev, off_t offset, size_t len)
 	if (((offset + len) > qspi_dev->data_end) ||
 			(0 != (erase_offset &
 			       (NIOS2_WRITE_BLOCK_SIZE - 1)))) {
-		LOG_ERR("erase failed at offset %ld\n", offset);
+		LOG_ERR("erase failed at offset %ld", (long)offset);
 		rc = -EINVAL;
 		goto qspi_erase_err;
 	}
@@ -138,7 +138,7 @@ static int flash_nios2_qspi_erase(struct device *dev, off_t offset, size_t len)
 
 		if ((flag_status & FLAG_STATUS_ERASE_ERROR) ||
 				(flag_status & FLAG_STATUS_PROTECTION_ERROR)) {
-			LOG_ERR("erase failed, Flag Status Reg:%x\n",
+			LOG_ERR("erase failed, Flag Status Reg:%x",
 								flag_status);
 			rc = -EIO;
 			goto qspi_erase_err;
@@ -237,7 +237,7 @@ static int flash_nios2_qspi_write_block(struct device *dev, int block_offset,
 
 		if ((flag_status & FLAG_STATUS_PROGRAM_ERROR) ||
 			(flag_status & FLAG_STATUS_PROTECTION_ERROR)) {
-			LOG_ERR("write failed, Flag Status Reg:%x\n",
+			LOG_ERR("write failed, Flag Status Reg:%x",
 								flag_status);
 			rc = -EIO; /* sector might be protected */
 			goto qspi_write_block_err;
@@ -272,7 +272,7 @@ static int flash_nios2_qspi_write(struct device *dev, off_t offset,
 	if ((data == NULL) || ((offset + len) > qspi_dev->data_end) ||
 			(0 != (write_offset &
 			       (NIOS2_WRITE_BLOCK_SIZE - 1)))) {
-		LOG_ERR("write failed at offset %ld\n", offset);
+		LOG_ERR("write failed at offset %ld", (long)offset);
 		rc = -EINVAL;
 		goto qspi_write_err;
 	}
@@ -337,7 +337,7 @@ static int flash_nios2_qspi_read(struct device *dev, off_t offset,
 	 */
 	if ((data == NULL) || ((offset + len) > qspi_dev->data_end) ||
 			(0 != (read_offset & (NIOS2_WRITE_BLOCK_SIZE - 1)))) {
-		LOG_ERR("read failed at offset %ld\n", offset);
+		LOG_ERR("read failed at offset %ld", (long)offset);
 		rc = -EINVAL;
 		goto qspi_read_err;
 	}
@@ -418,7 +418,7 @@ static int flash_nios2_qspi_write_protection(struct device *dev, bool enable)
 	}
 
 	if (timeout <= 0) {
-		LOG_ERR("locking failed, status-reg 0x%x\n", status);
+		LOG_ERR("locking failed, status-reg 0x%x", status);
 		rc = -EIO;
 	}
 


### PR DESCRIPTION
Fix formatting in logging messages. Remove newline.

Signed-off-by: Anas Nashif <anas.nashif@intel.com>