### PR TITLE
usb: device: fix the log level of a debug message

### DIFF
--- a/subsys/usb/usb_device.c
+++ b/subsys/usb/usb_device.c
@@ -1463,7 +1463,7 @@ static int composite_setup_ep_cb(void)
 	for (size_t i = 0; i < size; i++) {
 		ep_data = __usb_data_start[i].endpoint;
 		for (u8_t n = 0; n < __usb_data_start[i].num_endpoints; n++) {
-			USB_ERR("set cb, ep: 0x%x\n", ep_data[n].ep_addr);
+			USB_DBG("set cb, ep: 0x%x", ep_data[n].ep_addr);
 			if (usb_dc_ep_set_callback(ep_data[n].ep_addr,
 						   ep_data[n].ep_cb)) {
 				return -1;


### PR DESCRIPTION
When using composite devices, an error is printed during the
initialization:

| [00:00:00.000,000] <err> usb_device: set cb, ep: 0x81
|
| [00:00:00.000,000] <err> usb_device: set cb, ep: 0x1
|
| [00:00:00.000,000] <err> usb_device: set cb, ep: 0x82
|
| [00:00:00.000,000] <err> usb_device: set cb, ep: 0x2

This is actually not an error, but rather a debug message. In addition
it should not contain a new line as it is automatically added by the
logger subsystem.

Signed-off-by: Aurelien Jarno <aurelien@aurel32.net>