### PR TITLE
logging: init strdup mem_slab with aligned buffer size

### DIFF
--- a/subsys/logging/log_core.c
+++ b/subsys/logging/log_core.c
@@ -257,7 +257,7 @@ void log_init(void)
 	}
 
 	k_mem_slab_init(&log_strdup_pool, log_strdup_pool_buf,
-			CONFIG_LOG_STRDUP_MAX_STRING,
+			LOG_STRBUF_BUF_SIZE,
 			CONFIG_LOG_STRDUP_BUF_COUNT);
 
 	/* Set default timestamp. */


### PR DESCRIPTION
We are using a non-32-bit aligned value as the block size
when initializing the strdup mem_slab for Logger.

When the non-aligned pointer is being freed, it's converted
to a u32_t and this generates the following:
***** USAGE FAULT *****
  Unaligned memory access

Let's use the aligned buffer size as the block size instead.

Signed-off-by: Michael Scott <mike@foundries.io>