### PR TITLE
Log backend autoinit

### DIFF
--- a/doc/subsystems/logging/logger.rst
+++ b/doc/subsystems/logging/logger.rst
@@ -427,8 +427,8 @@ Example message formatted using :cpp:func:`log_output_msg_process`.
    }
 
 Logger backends are registered to the logger using
-:c:macro:`LOG_BACKEND_DEFINE` macro. The macro creates an instance in the dedicated
-memory section. Backends can be dynamically enabled
+:c:macro:`LOG_BACKEND_DEFINE` macro. The macro creates an instance in the
+dedicated memory section. Backends can be dynamically enabled
 (:cpp:func:`log_backend_enable`) and disabled.
 
 Limitations

--- a/include/logging/log_backend.h
+++ b/include/logging/log_backend.h
@@ -49,6 +49,7 @@ struct log_backend {
 	const struct log_backend_api *api;
 	struct log_backend_control_block *cb;
 	const char *name;
+	bool autostart;
 };
 
 extern const struct log_backend __log_backends_start[0];
@@ -57,10 +58,12 @@ extern const struct log_backend __log_backends_end[0];
 /**
  * @brief Macro for creating a logger backend instance.
  *
- * @param _name  Name of the backend instance.
- * @param _api   Logger backend API.
+ * @param _name		Name of the backend instance.
+ * @param _api		Logger backend API.
+ * @param _autostart	If true backend is initialized and activated together
+ *			with the logger subsystem.
  */
-#define LOG_BACKEND_DEFINE(_name, _api)					       \
+#define LOG_BACKEND_DEFINE(_name, _api, _autostart)			       \
 	static struct log_backend_control_block UTIL_CAT(backend_cb_, _name) = \
 	{								       \
 		.active = false,					       \
@@ -71,7 +74,8 @@ extern const struct log_backend __log_backends_end[0];
 	{								       \
 		.api = &_api,						       \
 		.cb = &UTIL_CAT(backend_cb_, _name),			       \
-		.name = STRINGIFY(_name)				       \
+		.name = STRINGIFY(_name),				       \
+		.autostart = _autostart					       \
 	}
 
 

--- a/include/shell/shell_log_backend.h
+++ b/include/shell/shell_log_backend.h
@@ -56,7 +56,7 @@ int shell_log_backend_output_func(u8_t *data, size_t length, void *ctx);
  */
 #if CONFIG_LOG
 #define SHELL_LOG_BACKEND_DEFINE(_name, _buf, _size)			     \
-	LOG_BACKEND_DEFINE(_name##_backend, log_backend_shell_api);	     \
+	LOG_BACKEND_DEFINE(_name##_backend, log_backend_shell_api, false);   \
 	K_FIFO_DEFINE(_name##_fifo);					     \
 	LOG_OUTPUT_DEFINE(_name##_log_output, shell_log_backend_output_func, \
 			  _buf, _size);					     \

--- a/subsys/logging/log_backend_native_posix.c
+++ b/subsys/logging/log_backend_native_posix.c
@@ -89,4 +89,6 @@ const struct log_backend_api log_backend_native_posix_api = {
 	.panic = panic,
 };
 
-LOG_BACKEND_DEFINE(log_backend_native_posix, log_backend_native_posix_api);
+LOG_BACKEND_DEFINE(log_backend_native_posix,
+		   log_backend_native_posix_api,
+		   true);

--- a/subsys/logging/log_backend_uart.c
+++ b/subsys/logging/log_backend_uart.c
@@ -68,4 +68,4 @@ const struct log_backend_api log_backend_uart_api = {
 	.init = log_backend_uart_init,
 };
 
-LOG_BACKEND_DEFINE(log_backend_uart, log_backend_uart_api);
+LOG_BACKEND_DEFINE(log_backend_uart, log_backend_uart_api, true);

--- a/subsys/logging/log_core.c
+++ b/subsys/logging/log_core.c
@@ -271,12 +271,14 @@ void log_init(void)
 		log_backend_id_set(backend,
 				   i + LOG_FILTER_FIRST_BACKEND_SLOT_IDX);
 
-		backend_filter_init(backend);
-		if (backend->api->init) {
-			backend->api->init();
-		}
+		if (backend->autostart) {
+			backend_filter_init(backend);
+			if (backend->api->init) {
+				backend->api->init();
+			}
 
-		log_backend_activate(backend, NULL);
+			log_backend_activate(backend, NULL);
+		}
 	}
 }
 

--- a/subsys/logging/log_core.c
+++ b/subsys/logging/log_core.c
@@ -34,6 +34,7 @@ static u8_t __noinit __aligned(sizeof(u32_t))
 static struct log_list_t list;
 static atomic_t initialized;
 static bool panic_mode;
+static bool backend_attached;
 static atomic_t buffered_cnt;
 static k_tid_t proc_tid;
 
@@ -278,6 +279,7 @@ void log_init(void)
 			}
 
 			log_backend_activate(backend, NULL);
+			backend_attached = true;
 		}
 	}
 }
@@ -375,6 +377,9 @@ bool log_process(bool bypass)
 {
 	struct log_msg *msg;
 
+	if (!backend_attached) {
+		return false;
+	}
 	unsigned int key = irq_lock();
 
 	msg = log_list_head_get(&list);
@@ -477,6 +482,7 @@ void log_backend_enable(struct log_backend const *const backend,
 {
 	backend_filter_set(backend, level);
 	log_backend_activate(backend, ctx);
+	backend_attached = true;
 }
 
 void log_backend_disable(struct log_backend const *const backend)

--- a/tests/subsys/logging/log_core/src/log_core_test.c
+++ b/tests/subsys/logging/log_core/src/log_core_test.c
@@ -101,10 +101,10 @@ const struct log_backend_api log_backend_test_api = {
 	.panic = panic,
 };
 
-LOG_BACKEND_DEFINE(backend1, log_backend_test_api);
+LOG_BACKEND_DEFINE(backend1, log_backend_test_api, true);
 struct backend_cb backend1_cb;
 
-LOG_BACKEND_DEFINE(backend2, log_backend_test_api);
+LOG_BACKEND_DEFINE(backend2, log_backend_test_api, true);
 struct backend_cb backend2_cb;
 
 static u32_t stamp;


### PR DESCRIPTION
https://github.com/zephyrproject-rtos/zephyr/commit/6162caf787a8d54c72a8eeb348364d093e9758b7 introduced all logger backends enabling during logger initialization. Then new shell as a log backend got added and it was also automatically initialized during logger subsystem initialization. It was done before shell was initialized. As the outcome, log processing before shell init resulted in fault.

Extended LOG_BACKEND_DEFINE with autostart flag. Only backends with autostart=true (uart, native_posix) are enabled with the logger. Shell log backend is explicitly enabled when shell is initialized.

Additionally, in second commit, added a mechanism which prevents log processing when no backends are enabled. Without that mechanism when logger backend was initialized after logger some log from startup could be lost.

Fixes #10369 