### PR TITLE
Shell autocreate shell instance

### DIFF
--- a/doc/subsystems/shell/shell.rst
+++ b/doc/subsystems/shell/shell.rst
@@ -416,36 +416,16 @@ The shell module supports the following meta keys:
 Usage
 *****
 
-Use the :c:macro:`SHELL_DEFINE` macro to create an instance of the shell.
-Pass expected `shell_flag` parameter to this macro.  Otherwise, the shell
-might not move the terminal cursor to a new line correctly.
-
-.. list-table:: Available shell flags
-   :widths: 10 30
-   :header-rows: 1
-
-   * - Flag
-     - Action
-   * - SHELL_FLAG_CRLF_DEFAULT
-     - Shell does not add LF or CR characters to an output string.
-   * - SHELL_FLAG_OLF_CRLF
-     - The shell parses an output string and it adds a CR character before each
-       found LF character.
+To create a new shell instance user needs to activate requested
+backend using `menuconfig`.
 
 The following code shows a simple use case of this library:
 
 .. code-block:: c
 
-	/* Defining shell backend */
-	SHELL_UART_DEFINE(shell_transport_uart);
-
-	/* Creating shell instance */
-	SHELL_DEFINE(uart_shell, "uart:~$ ", &shell_transport_uart, 10,
-		     SHELL_FLAG_OLF_CRLF);
-
 	void main(void)
 	{
-		(void)shell_init(&uart_shell, NULL, true, true, LOG_LEVEL_INF);
+
 	}
 
 	static int cmd_demo_ping(const struct shell *shell, size_t argc,

--- a/samples/drivers/flash_shell/src/main.c
+++ b/samples/drivers/flash_shell/src/main.c
@@ -19,10 +19,6 @@
 
 LOG_MODULE_REGISTER(app);
 
-SHELL_UART_DEFINE(shell_transport_uart);
-SHELL_DEFINE(uart_shell, "uart:~$ ", &shell_transport_uart, 10,
-	     SHELL_FLAG_OLF_CRLF);
-
 #define PR_SHELL(shell, fmt, ...)				\
 	shell_fprintf(shell, SHELL_NORMAL, fmt, ##__VA_ARGS__)
 #define PR_ERROR(shell, fmt, ...)				\
@@ -629,8 +625,6 @@ void main(void)
 		printk("Run set_device <name> to specify one "
 		       "before using other commands.\n");
 	}
-
-	(void)shell_init(&uart_shell, NULL, true, true, LOG_LEVEL_INF);
 }
 
 

--- a/samples/subsys/shell/shell_module/src/main.c
+++ b/samples/subsys/shell/shell_module/src/main.c
@@ -14,10 +14,6 @@
 
 LOG_MODULE_REGISTER(app);
 
-SHELL_UART_DEFINE(shell_transport_uart);
-SHELL_DEFINE(uart_shell, "uart:~$ ", &shell_transport_uart, 10,
-	     SHELL_FLAG_OLF_CRLF);
-
 extern void foo(void);
 
 void timer_expired_handler(struct k_timer *timer)
@@ -139,5 +135,5 @@ SHELL_CMD_REGISTER(version, NULL, "Show kernel version", cmd_version);
 
 void main(void)
 {
-	(void)shell_init(&uart_shell, NULL, true, true, LOG_LEVEL_INF);
+
 }

--- a/subsys/shell/shell_uart.c
+++ b/subsys/shell/shell_uart.c
@@ -6,6 +6,11 @@
 
 #include <shell/shell_uart.h>
 #include <uart.h>
+#include <init.h>
+
+SHELL_UART_DEFINE(shell_transport_uart);
+SHELL_DEFINE(uart_shell, "uart:~$ ", &shell_transport_uart, 10,
+	     SHELL_FLAG_OLF_CRLF);
 
 static void timer_handler(struct k_timer *timer)
 {
@@ -87,3 +92,11 @@ const struct shell_transport_api shell_uart_transport_api = {
 	.write = write,
 	.read = read
 };
+
+static int enable_shell_uart(struct device *arg)
+{
+	ARG_UNUSED(arg);
+	shell_init(&uart_shell, NULL, true, true, LOG_LEVEL_INF);
+	return 0;
+}
+SYS_INIT(enable_shell_uart, POST_KERNEL, 0);

--- a/tests/bluetooth/shell/src/main.c
+++ b/tests/bluetooth/shell/src/main.c
@@ -33,10 +33,6 @@
 
 #define DEVICE_NAME CONFIG_BT_DEVICE_NAME
 
-SHELL_UART_DEFINE(shell_transport_uart);
-SHELL_DEFINE(uart_shell, "uart:~$ ", &shell_transport_uart, 10,
-	     SHELL_FLAG_CRLF_DEFAULT);
-
 #if defined(CONFIG_BT_CONN)
 static bool hrs_simulate;
 
@@ -104,11 +100,9 @@ SHELL_CMD_REGISTER(hrs, &hrs_cmds, "Heart Rate Service shell commands",
 
 void main(void)
 {
-	(void)shell_init(&uart_shell, NULL, true, true, LOG_LEVEL_INF);
-
-	print(&uart_shell, "Type \"help\" for supported commands.");
-	print(&uart_shell, "Before any Bluetooth commands you must `bt init`"
-	      " to initialize the stack.");
+	printk("Type \"help\" for supported commands.");
+	printk("Before any Bluetooth commands you must `bt init` to initialize"
+	       " the stack.\n");
 
 	while (1) {
 		k_sleep(MSEC_PER_SEC);


### PR DESCRIPTION
With this PR user will not have to bother creating shell backend. All that is required from the user is to enable particular shell backend in the Kconfig file. For each enabled backend shell instance will be created automatically.

Next step is to add console backend to the shell. Once this will be in place it will be enough to activate shell commands to start default shell instance: console.

Fixes #10480 