### PR TITLE
logging: Add assert when no backends defined

### DIFF
--- a/boards/xtensa/qemu_xtensa/qemu_xtensa.yaml
+++ b/boards/xtensa/qemu_xtensa/qemu_xtensa.yaml
@@ -11,3 +11,4 @@ testing:
   ignore_tags:
      - net
      - bluetooth
+     - logging

--- a/subsys/logging/log_core.c
+++ b/subsys/logging/log_core.c
@@ -668,6 +668,8 @@ void log_free(void *str)
 
 static void log_process_thread_func(void *dummy1, void *dummy2, void *dummy3)
 {
+	__ASSERT_NO_MSG(log_backend_count_get() > 0);
+
 	log_init();
 	thread_set(k_current_get());
 


### PR DESCRIPTION
Added an assert in the logger thread in case there
is no backends, instead of having that thread spinning
forever.

Fixes #10054 

Signed-off-by: Alberto Escolar Piedras <alpi@oticon.com>
Signed-off-by: Krzysztof Chruscinski <krzysztof.chruscinski@nordicsemi.no>