### PR TITLE
net: wifi: Allow mgmt interface to compile if not offloaded

### DIFF
--- a/include/net/net_if.h
+++ b/include/net/net_if.h
@@ -545,6 +545,13 @@ static inline struct net_offload *net_if_offload(struct net_if *iface)
 {
 	return iface->if_dev->offload;
 }
+#else
+static inline bool net_if_is_ip_offloaded(struct net_if *iface)
+{
+	ARG_UNUSED(iface);
+
+	return false;
+}
 #endif
 
 /**

--- a/include/net/wifi_mgmt.h
+++ b/include/net/wifi_mgmt.h
@@ -92,8 +92,6 @@ struct wifi_status {
 	int status;
 };
 
-#ifdef CONFIG_WIFI_OFFLOAD
-
 #include <net/net_if.h>
 
 typedef void (*scan_result_cb_t)(struct net_if *iface, int status,
@@ -117,6 +115,8 @@ struct net_wifi_mgmt_offload {
 		       struct wifi_connect_req_params *params);
 	int (*disconnect)(struct device *dev);
 };
+
+#ifdef CONFIG_WIFI_OFFLOAD
 
 void wifi_mgmt_raise_connect_result_event(struct net_if *iface, int status);
 void wifi_mgmt_raise_disconnect_result_event(struct net_if *iface, int status);


### PR DESCRIPTION
Even if we do not have wifi network offloading enabled, allow the
application to be compiled just fine. This allows easier
testing of the application even if the board does not support
wifi offloading.

Signed-off-by: Jukka Rissanen <jukka.rissanen@linux.intel.com>