### PR TITLE
shell: fix possible hanging reason when history feature is used

### DIFF
--- a/subsys/shell/shell.c
+++ b/subsys/shell/shell.c
@@ -690,8 +690,7 @@ static void shell_tab_handle(const struct shell *shell)
 #define SHELL_ASCII_MAX_CHAR (127u)
 static inline int ascii_filter(const char data)
 {
-	return (u8_t) data > SHELL_ASCII_MAX_CHAR ?
-			-EINVAL : 0;
+	return (u8_t) data > SHELL_ASCII_MAX_CHAR ? -EINVAL : 0;
 }
 
 static void metakeys_handle(const struct shell *shell, char data)

--- a/subsys/shell/shell_uart.c
+++ b/subsys/shell/shell_uart.c
@@ -73,7 +73,9 @@ static int read(const struct shell_transport *transport,
 		void *data, size_t length, size_t *cnt)
 {
 	struct shell_uart *sh_uart = (struct shell_uart *)transport->ctx;
+	u32_t key;
 
+	key = irq_lock();
 	if (sh_uart->rx_cnt) {
 		memcpy(data, sh_uart->rx, 1);
 		sh_uart->rx_cnt = 0;
@@ -81,6 +83,7 @@ static int read(const struct shell_transport *transport,
 	} else {
 		*cnt = 0;
 	}
+	irq_unlock(key);
 
 	return 0;
 }


### PR DESCRIPTION
Fixing shell hanging reason.


Signed-off-by: Jakub Rzeszutko <jakub.rzeszutko@nordicsemi.no>