### PR TITLE
rtc: rtc_mcux: Fix build issue with logging change

### DIFF
--- a/drivers/rtc/rtc_mcux.c
+++ b/drivers/rtc/rtc_mcux.c
@@ -6,7 +6,7 @@
 
 #define LOG_LEVEL CONFIG_RTC_LOG_LEVEL
 #include <logging/log.h>
-LOG_DOMAIN_REGISTER(rtc_mcux);
+LOG_MODULE_REGISTER(rtc_mcux);
 
 #include <errno.h>
 #include <device.h>


### PR DESCRIPTION
When the driver was changed to use the new logging subsystem, it used
LOG_DOMAIN_REGISTER should have been LOG_MODULE_REGISTER.

Signed-off-by: Kumar Gala <kumar.gala@linaro.org>