### PR TITLE
linker: use wildcards in rel-sections.ld

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -287,12 +287,21 @@ zephyr_ld_options(
   ${LINKERFLAGPREFIX},--build-id=none
   )
 
-# Funny thing is if this is set to =error, some architectures will
-# skip this flag even though the compiler flag check passes
-# (e.g. ARC and Xtensa). So keep it at =warn, for now.
-zephyr_ld_options(
-  ${LINKERFLAGPREFIX},--orphan-handling=warn
-  )
+if(NOT CONFIG_NATIVE_APPLICATION)
+  # Funny thing is if this is set to =error, some architectures will
+  # skip this flag even though the compiler flag check passes
+  # (e.g. ARC and Xtensa). So keep it at =warn, for now.
+  #
+  # Skip this for native application as Zephyr only provides
+  # additions to the host toolchain linker script. The relocation
+  # sections (.rel*) requires us to override those provided
+  # by host toolchain. As we can't account for all possible
+  # combination of compiler and linker on all machines used
+  # for development, it is better to turn this off.
+  zephyr_ld_options(
+    ${LINKERFLAGPREFIX},--orphan-handling=warn
+    )
+endif()
 
 if(CONFIG_HAVE_CUSTOM_LINKER_SCRIPT)
   set(LINKER_SCRIPT ${APPLICATION_SOURCE_DIR}/${CONFIG_CUSTOM_LINKER_SCRIPT})

--- a/include/arch/posix/linker.ld
+++ b/include/arch/posix/linker.ld
@@ -21,42 +21,15 @@
 #include <linker/linker-defs.h>
 #include <linker/linker-tool.h>
 
-SECTIONS
- {
-	SECTION_PROLOGUE(.note.ABI-tag,,)
-	{
-	*(.note.ABI-tag)
-	}
-
- } INSERT AFTER .interp;
 
 SECTIONS
  {
-
-#include <linker/rel-sections.ld>
 
 #include <linker/common-rom.ld>
 
 #include <linker/common-ram.ld>
 
-	SECTION_PROLOGUE(_NOINIT_SECTION_NAME, (NOLOAD OPTIONAL),)
-	{
-	/*
-	 * This section is used for non-initialized objects that
-	 * will not be cleared during the boot process.
-	 */
-	KERNEL_INPUT_SECTION(.noinit)
-	KERNEL_INPUT_SECTION(".noinit.*")
-	*(".kernel_noinit.*")
-	}
-
 #include <arch/posix/native_tasks.ld>
-
-	/* Related to transactional memory */
-	SECTION_PROLOGUE(.tm_clone_table,,)
-	{
-	*(.tm_clone_table)
-	}
 
  __data_ram_end = .;
 

--- a/include/linker/rel-sections.ld
+++ b/include/linker/rel-sections.ld
@@ -2,142 +2,32 @@
 	 * .rel.* are for relocation.
 	 * These are being produced by compiler/linker.
 	 * Specify these here so they are not considered orphan sections.
-	 *
-	 * Obtained via
-	 * '$(ARCH)-zephyr-elf-ld --verbose'
 	 */
 
-#if !defined(CONFIG_RISCV32) && !defined(CONFIG_XTENSA)
-	SECTION_PROLOGUE(.rel.dyn,,)
-	{
-	*(.rel.init)
-	*(.rel.text .rel.text.* .rel.text_start.* .rel.gnu.linkonce.t.*)
-	*(.rel.fini)
-	*(.rel.rodata .rel.rodata.* .rel.gnu.linkonce.r.*)
-	*(.rel.data.rel.ro .rel.data.rel.ro.* .rel.gnu.linkonce.d.rel.ro.*)
-	*(.rel.data .rel.data.* .rel.gnu.linkonce.d.*)
-	*(.rel.tdata .rel.tdata.* .rel.gnu.linkonce.td.*)
-	*(.rel.tbss .rel.tbss.* .rel.gnu.linkonce.tb.*)
-
-#if defined(CONFIG_ARCH_POSIX)
-	*(.rel.preinit_array)
-	*(.rel.init_array)
-	*(.rel.fini_array)
-#endif
-
-	*(.rel.ctors)
-	*(.rel.dtors)
-	*(.rel.got)
-	*(.rel.bss .rel.bss.* .rel.gnu.linkonce.b.*)
-
-#if defined(CONFIG_ARM) || defined(CONFIG_NIOS2)
-	PROVIDE_HIDDEN (__rel_iplt_start = .);
-	*(.rel.iplt)
-	PROVIDE_HIDDEN (__rel_iplt_end = .);
-#endif
-
-	/* These are related to sections defined by Zephyr */
-	*(.rel.kernel .rel.kernel.*)
-	*(.rel.init_PRE_KERNEL*)
-	*(.rel.init_POST_KERNEL*)
-	*(.rel.init_APPLICATION*)
-
-#if defined(CONFIG_ARCH_POSIX)
-	*(.rel.native_PRE_BOOT*)
-	*(.rel.native_FIRST_SLEEP*)
-	*(.rel.native_ON_EXIT*)
-#endif
-
-	*(.rel.devconfig.*)
-
-	*(.rel._k_*)
-
-	*(.rel._bt_settings.*)
-
-	*(.rel.log_*)
-
-	*(.rel._net_buf_pool.*)
-	*(.rel.net_*)
-
-	*(.rel._static_thread_data.*)
-
-	*(.rel.usb.*)
-
-#if defined(CONFIG_X86)
-	*(.rel.ifunc)
-	*(.rel.mmulist)
-	*(.rel.tss)
-#endif
-	}
-#endif /* !defined(CONFIG_RISCV32) */
-
-#if defined(CONFIG_ARM) || defined(CONFIG_NIOS2) || defined(CONFIG_RISCV32)
-	SECTION_PROLOGUE(.rela.dyn,,)
-	{
-	*(.rela.init)
-	*(.rela.text .rela.text.* .rela.gnu.linkonce.t.*)
-	*(.rela.fini)
-	*(.rela.rodata .rela.rodata.* .rela.gnu.linkonce.r.*)
-	*(.rela.data .rela.data.* .rela.gnu.linkonce.d.*)
-	*(.rela.tdata .rela.tdata.* .rela.gnu.linkonce.td.*)
-	*(.rela.tbss .rela.tbss.* .rela.gnu.linkonce.tb.*)
-	*(.rela.ctors)
-	*(.rela.dtors)
-	*(.rela.got)
-	*(.rela.bss .rela.bss.* .rela.gnu.linkonce.b.*)
-
-#if defined(CONFIG_ARM) || defined(CONFIG_NIOS2)
-	PROVIDE_HIDDEN (__rela_iplt_start = .);
-	*(.rela.iplt)
-	PROVIDE_HIDDEN (__rela_iplt_end = .);
-#endif
-
-	/* These are related to sections defined by Zephyr */
-	*(.rela.kernel .rel.kernel.*)
-	*(.rela.init_PRE_KERNEL*)
-	*(.rela.init_POST_KERNEL*)
-	*(.rela.init_APPLICATION*)
-
-	*(.rela.devconfig.*)
-
-	*(.rela._k_*)
-
-	*(.rela._bt_settings.*)
-
-	*(.rela.log_*)
-
-	*(.rela._net_buf_pool.*)
-	*(.rela.net_*)
-
-	*(.rela._static_thread_data.*)
-
-	*(.rela.usb.*)
-
-#if defined(CONFIG_RISCV32)
-	*(.rela.exception.*)
-	*(.rela.gnu.linkonce.sw_isr_table)
-	*(.rela.sdata.*)
-#endif
-
-	}
-#endif
-
-#if !defined(CONFIG_RISCV32) && !defined(CONFIG_XTENSA)
 	SECTION_PROLOGUE(.rel.plt,,)
 	{
 	*(.rel.plt)
 
-#if defined(CONFIG_X86)
 	PROVIDE_HIDDEN (__rel_iplt_start = .);
 	*(.rel.iplt)
 	PROVIDE_HIDDEN (__rel_iplt_end = .);
-#endif
 	}
-#endif /* !defined(CONFIG_RISCV32) */
 
-#if defined(CONFIG_ARM) || defined(CONFIG_NIOS2) || defined(CONFIG_RISCV32)
 	SECTION_PROLOGUE(.rela.plt,,)
 	{
 	*(.rela.plt)
+
+	PROVIDE_HIDDEN (__rela_iplt_start = .);
+	*(.rela.iplt)
+	PROVIDE_HIDDEN (__rela_iplt_end = .);
 	}
-#endif
+
+	SECTION_PROLOGUE(.rel.dyn,,)
+	{
+	*(.rel.*)
+	}
+
+	SECTION_PROLOGUE(.rela.dyn,,)
+	{
+	*(.rela.*)
+	}


### PR DESCRIPTION
Update rel-sections.ld to use wildcards instead of
spelling out those sections one by one.

Fixes #10493

Signed-off-by: Daniel Leung <daniel.leung@intel.com>