### PR TITLE
arch: arm: linker: Move priv.noinit to the end of the RAM.

### DIFF
--- a/include/arch/arm/cortex_m/scripts/linker.ld
+++ b/include/arch/arm/cortex_m/scripts/linker.ld
@@ -371,7 +371,6 @@ SECTIONS
         KERNEL_INPUT_SECTION(".noinit.*")
 	*(".kernel_noinit.*")
 
-#include <linker/priv_stacks-noinit.ld>
 
 #ifdef CONFIG_SOC_NOINIT_LD
 #include <soc-noinit.ld>
@@ -402,6 +401,8 @@ SECTIONS
 #include <linker/common-ram.ld>
 #include <linker/priv_stacks.ld>
 #include <linker/kobject.ld>
+
+#include <linker/priv_stacks-noinit.ld>
 
     __data_ram_end = .;
 

--- a/include/linker/priv_stacks-noinit.ld
+++ b/include/linker/priv_stacks-noinit.ld
@@ -4,4 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-	*(".priv_stacks.noinit")
+     SECTION_DATA_PROLOGUE(_PRIVILEGE_NONINIT_SECTION_NAME,,)
+        {
+        *(".priv_stacks.noinit")
+        } GROUP_DATA_LINK_IN(RAMABLE_REGION, ROMABLE_REGION)


### PR DESCRIPTION
This ensures that the data locations remain consistent between
different stages of the build.

Signed-off-by: Adithya Baglody <adithya.nagaraj.baglody@intel.com>