### PR TITLE
arch: high-level Kconfig symbol structure for Trusted Execution

### DIFF
--- a/arch/Kconfig
+++ b/arch/Kconfig
@@ -72,6 +72,35 @@ config BIG_ENDIAN
          is used to select linker script OUTPUT_FORMAT and command
          line option for gen_isr_tables.py.
 
+if ARCH_HAS_TRUSTED_EXECUTION
+
+config TRUSTED_EXECUTION_SECURE
+	bool "Trusted Execution: Secure firmware image"
+	help
+	  Select this option to enable building a Secure firmware
+	  image for a platform that supports Trusted Execution. A
+	  Secure firmware image will execute in Secure state. It may
+	  allow the CPU to execute in Non-Secure (Normal) state.
+	  Therefore, a Secure firmware image shall be able to
+	  configure security attributions of CPU resources (memory
+	  areas, peripherals, interrupts, etc.) as well as to handle
+	  faults, related to security violations. It may optionally
+	  allow certain functions to be called from the Non-Secure
+	  (Normal) domain.
+
+config TRUSTED_EXECUTION_NONSECURE
+	depends on !TRUSTED_EXECUTION_SECURE
+	bool "Trusted Execution: Non-Secure firmware image"
+	help
+	  Select this option to enable building a Non-Secure
+	  firmware image for a platform that supports Trusted
+	  Execution. A Non-Secure firmware image will execute
+	  in Non-Secure (Normal) state. Therefore, it shall not
+	  access CPU resources (memory areas, peripherals,
+	  interrupts etc.) belonging to the Secure domain.
+
+endif # ARCH_HAS_TRUSTED_EXECUTION
+
 config HW_STACK_PROTECTION
 	bool "Hardware Stack Protection"
 	depends on ARCH_HAS_STACK_PROTECTION
@@ -228,6 +257,9 @@ endmenu
 #
 # Architecture Capabilities
 #
+config ARCH_HAS_TRUSTED_EXECUTION
+	bool
+
 config ARCH_HAS_STACK_PROTECTION
 	bool
 
@@ -314,6 +346,13 @@ config BOOTLOADER_CONTEXT_RESTORE_SUPPORTED
 
 # End hidden CPU family configs
 #
+
+config CPU_HAS_TEE
+	bool
+	help
+	  This option is enabled when the CPU has support for Trusted
+	  Execution Environment (e.g. when it has a security attribution
+	  unit).
 
 config CPU_HAS_FPU
 	bool

--- a/arch/arm/core/Kconfig
+++ b/arch/arm/core/Kconfig
@@ -20,6 +20,7 @@ config CPU_CORTEX_M
 	select HAS_CMSIS
 	select HAS_FLASH_LOAD_OFFSET
 	select HAS_DTS
+	select ARCH_HAS_TRUSTED_EXECUTION if ARM_TRUSTZONE_M
 	select ARCH_HAS_STACK_PROTECTION if ARM_MPU || CPU_CORTEX_M_HAS_SPLIM
 	select ARCH_HAS_USERSPACE if ARM_MPU
 	help
@@ -57,6 +58,7 @@ config ARM_STACK_PROTECTION
 config ARM_SECURE_FIRMWARE
 	bool
 	depends on ARMV8_M_SE
+	default y if TRUSTED_EXECUTION_SECURE
 	help
 	  This option indicates that we are building a Zephyr image that
 	  is intended to execute in Secure state. The option is only
@@ -78,6 +80,7 @@ config ARM_NONSECURE_FIRMWARE
 	bool
 	depends on !ARM_SECURE_FIRMWARE
 	depends on ARMV8_M_SE
+	default y if TRUSTED_EXECUTION_NONSECURE
 	help
 	  This option indicates that we are building a Zephyr image that
 	  is intended to execute in Non-Secure state. Execution of this
@@ -163,4 +166,8 @@ source "arch/arm/core/cortex_m/Kconfig"
 
 if CPU_HAS_MPU
 source "arch/arm/core/cortex_m/mpu/Kconfig"
+endif
+
+if CPU_HAS_TEE
+source "arch/arm/core/cortex_m/tz/Kconfig"
 endif

--- a/arch/arm/core/cortex_m/Kconfig
+++ b/arch/arm/core/cortex_m/Kconfig
@@ -50,6 +50,7 @@ config CPU_CORTEX_M23
 	select CPU_CORTEX_M
 	# Omit prompt to signify "hidden" option
 	select ARMV8_M_BASELINE
+	select ARMV8_M_SE if CPU_HAS_TEE
 	help
 	  This option signifies the use of a Cortex-M23 CPU
 
@@ -58,6 +59,7 @@ config CPU_CORTEX_M33
 	select CPU_CORTEX_M
 	# Omit prompt to signify "hidden" option
 	select ARMV8_M_MAINLINE
+	select ARMV8_M_SE if CPU_HAS_TEE
 	select ARMV7_M_ARMV8_M_FP if CPU_HAS_FPU
 	help
 	  This option signifies the use of a Cortex-M33 CPU

--- a/arch/arm/core/cortex_m/tz/Kconfig
+++ b/arch/arm/core/cortex_m/tz/Kconfig
@@ -5,8 +5,9 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-
-config ARM_SAU
-	bool "ARM Security Attribution Unit"
+config ARM_TRUSTZONE_M
+	bool "ARM TrustZone-M support"
+	depends on CPU_HAS_TEE
+	depends on ARMV8_M_SE
 	help
-	  MCU implements the ARM Security Attribution Unit (SAU).
+	  Platform has support for ARM TrustZone-M.

--- a/soc/arm/Kconfig
+++ b/soc/arm/Kconfig
@@ -13,3 +13,10 @@ config CPU_HAS_NXP_MPU
 	help
 	  This option is enabled when the CPU has a Memory Protection Unit (MPU)
 	  in NXP flavour.
+
+config CPU_HAS_ARM_SAU
+	bool
+	# Omit prompt to signify "hidden" option
+	select CPU_HAS_TEE
+	help
+	  MCU implements the ARM Security Attribution Unit (SAU).


### PR DESCRIPTION
This commit contributes a Kconfig symbol hierarchy which allows
the user to build Zephyr Secure and Non-Secure images on ARMv8-M
MCUs with support for Trusted Execution. However, the high-level
configuration structure is generic, thus, can be potentially
used for any platform that supports Trusted Execution.

Signed-off-by: Ioannis Glaropoulos <Ioannis.Glaropoulos@nordicsemi.no>

This PR addresses #6374.
It does not add any code; only the Konfig hierarchy for the user to enable trusted execution builds.