### PR TITLE
L2 rework

### DIFF
--- a/drivers/ethernet/eth_e1000.c
+++ b/drivers/ethernet/eth_e1000.c
@@ -82,19 +82,12 @@ static int e1000_tx(struct e1000_dev *dev, void *data, size_t data_len)
 	return (dev->tx.sta & TDESC_STA_DD) ? 0 : -EIO;
 }
 
-static int e1000_send(struct net_if *iface, struct net_pkt *pkt)
+static int e1000_send(struct device *device, struct net_pkt *pkt)
 {
-	struct e1000_dev *dev = net_if_get_device(iface)->driver_data;
-
+	struct e1000_dev *dev = device->driver_data;
 	size_t len = e1000_linearize(pkt, dev->txb, sizeof(dev->txb));
 
-	int err = e1000_tx(dev, dev->txb, len);
-
-	if (!err) {
-		net_pkt_unref(pkt);
-	}
-
-	return err;
+	return e1000_tx(dev, dev->txb, len);
 }
 
 static struct net_pkt *e1000_rx(struct e1000_dev *dev)
@@ -235,8 +228,8 @@ static struct e1000_dev e1000_dev = {
 
 static const struct ethernet_api e1000_api = {
 	.iface_api.init		= e1000_init,
-	.iface_api.send		= e1000_send,
 	.get_capabilities	= e1000_caps,
+	.send			= e1000_send,
 };
 
 NET_DEVICE_INIT(eth_e1000,

--- a/drivers/ethernet/eth_enc28j60.c
+++ b/drivers/ethernet/eth_enc28j60.c
@@ -405,9 +405,8 @@ static void eth_enc28j60_init_phy(struct device *dev)
 	}
 }
 
-static int eth_enc28j60_tx(struct net_if *iface, struct net_pkt *pkt)
+static int eth_enc28j60_tx(struct device *dev, struct net_pkt *pkt)
 {
-	struct device *dev = net_if_get_device(iface);
 	struct eth_enc28j60_runtime *context = dev->driver_data;
 	u16_t len = net_pkt_ll_reserve(pkt) + net_pkt_get_len(pkt);
 	u16_t tx_bufaddr = ENC28J60_TXSTART;
@@ -486,8 +485,6 @@ static int eth_enc28j60_tx(struct net_if *iface, struct net_pkt *pkt)
 		LOG_ERR("TX failed!");
 		return -EIO;
 	}
-
-	net_pkt_unref(pkt);
 
 	LOG_DBG("Tx successful");
 
@@ -672,9 +669,9 @@ static void eth_enc28j60_iface_init(struct net_if *iface)
 
 static const struct ethernet_api api_funcs = {
 	.iface_api.init		= eth_enc28j60_iface_init,
-	.iface_api.send		= eth_enc28j60_tx,
 
 	.get_capabilities	= eth_enc28j60_get_capabilities,
+	.send			= eth_enc28j60_tx,
 };
 
 static int eth_enc28j60_init(struct device *dev)

--- a/drivers/ethernet/eth_native_posix.c
+++ b/drivers/ethernet/eth_native_posix.c
@@ -107,11 +107,6 @@ static struct k_thread rx_thread_data;
 /* TODO: support multiple interfaces */
 static struct eth_context eth_context_data;
 
-static struct eth_context *get_context(struct net_if *iface)
-{
-	return net_if_get_device(iface)->driver_data;
-}
-
 #if defined(CONFIG_NET_GPTP)
 static bool need_timestamping(struct gptp_hdr *hdr)
 {
@@ -205,9 +200,9 @@ static void update_gptp(struct net_if *iface, struct net_pkt *pkt,
 #define update_gptp(iface, pkt, send)
 #endif /* CONFIG_NET_GPTP */
 
-static int eth_send(struct net_if *iface, struct net_pkt *pkt)
+static int eth_send(struct device *dev, struct net_pkt *pkt)
 {
-	struct eth_context *ctx = get_context(iface);
+	struct eth_context *ctx = dev->driver_data;
 	struct net_buf *frag;
 	int count = 0;
 	int ret;
@@ -225,29 +220,27 @@ static int eth_send(struct net_if *iface, struct net_pkt *pkt)
 		frag = frag->frags;
 	}
 
-	eth_stats_update_bytes_tx(iface, count);
-	eth_stats_update_pkts_tx(iface);
+	eth_stats_update_bytes_tx(net_pkt_iface(pkt), count);
+	eth_stats_update_pkts_tx(net_pkt_iface(pkt));
 
 	if (IS_ENABLED(CONFIG_NET_STATISTICS_ETHERNET)) {
 		if (net_eth_is_addr_broadcast(
 			    &((struct net_eth_hdr *)NET_ETH_HDR(pkt))->dst)) {
-			eth_stats_update_broadcast_tx(iface);
+			eth_stats_update_broadcast_tx(net_pkt_iface(pkt));
 		} else if (net_eth_is_addr_multicast(
 				   &((struct net_eth_hdr *)
 						NET_ETH_HDR(pkt))->dst)) {
-			eth_stats_update_multicast_tx(iface);
+			eth_stats_update_multicast_tx(net_pkt_iface(pkt));
 		}
 	}
 
-	update_gptp(iface, pkt, true);
+	update_gptp(net_pkt_iface(pkt), pkt, true);
 
 	LOG_DBG("Send pkt %p len %d", pkt, count);
 
 	ret = eth_write_data(ctx->dev_fd, ctx->send, count);
 	if (ret < 0) {
 		LOG_DBG("Cannot send pkt %p (%d)", pkt, ret);
-	} else {
-		net_pkt_unref(pkt);
 	}
 
 	return ret < 0 ? ret : 0;
@@ -565,12 +558,12 @@ static int eth_stop_device(struct device *dev)
 
 static const struct ethernet_api eth_if_api = {
 	.iface_api.init = eth_iface_init,
-	.iface_api.send = eth_send,
 
 	.get_capabilities = eth_posix_native_get_capabilities,
 	.set_config = set_config,
 	.start = eth_start_device,
 	.stop = eth_stop_device,
+	.send = eth_send,
 
 #if defined(CONFIG_NET_VLAN)
 	.vlan_setup = vlan_setup,

--- a/drivers/ethernet/eth_stm32_hal.c
+++ b/drivers/ethernet/eth_stm32_hal.c
@@ -54,10 +54,9 @@ static inline void disable_mcast_filter(ETH_HandleTypeDef *heth)
 	heth->Instance->MACFFR = tmp;
 }
 
-static int eth_tx(struct net_if *iface, struct net_pkt *pkt)
+static int eth_tx(struct device *dev, struct net_pkt *pkt)
 {
-	struct device *dev;
-	struct eth_stm32_hal_dev_data *dev_data;
+	struct eth_stm32_hal_dev_data *dev_data = DEV_DATA(dev);
 	ETH_HandleTypeDef *heth;
 	u8_t *dma_buffer;
 	int res;
@@ -65,13 +64,8 @@ static int eth_tx(struct net_if *iface, struct net_pkt *pkt)
 	u16_t total_len;
 	__IO ETH_DMADescTypeDef *dma_tx_desc;
 
-	__ASSERT_NO_MSG(iface != NULL);
 	__ASSERT_NO_MSG(pkt != NULL);
 	__ASSERT_NO_MSG(pkt->frags != NULL);
-
-	dev = net_if_get_device(iface);
-	dev_data = DEV_DATA(dev);
-
 	__ASSERT_NO_MSG(dev != NULL);
 	__ASSERT_NO_MSG(dev_data != NULL);
 
@@ -121,8 +115,6 @@ static int eth_tx(struct net_if *iface, struct net_pkt *pkt)
 		res = -EIO;
 		goto error;
 	}
-
-	net_pkt_unref(pkt);
 
 	res = 0;
 error:
@@ -387,9 +379,9 @@ static enum ethernet_hw_caps eth_stm32_hal_get_capabilities(struct device *dev)
 
 static const struct ethernet_api eth_api = {
 	.iface_api.init = eth_iface_init,
-	.iface_api.send = eth_tx,
 
 	.get_capabilities = eth_stm32_hal_get_capabilities,
+	.send = eth_tx,
 };
 
 static struct device DEVICE_NAME_GET(eth0_stm32_hal);

--- a/drivers/ieee802154/ieee802154_cc1200.c
+++ b/drivers/ieee802154/ieee802154_cc1200.c
@@ -833,7 +833,6 @@ static struct cc1200_context cc1200_context_data;
 
 static struct ieee802154_radio_api cc1200_radio_api = {
 	.iface_api.init	= cc1200_iface_init,
-	.iface_api.send	= ieee802154_radio_send,
 
 	.get_capabilities	= cc1200_get_capabilities,
 	.cca			= cc1200_cca,

--- a/drivers/ieee802154/ieee802154_cc2520.c
+++ b/drivers/ieee802154/ieee802154_cc2520.c
@@ -1072,7 +1072,6 @@ static struct cc2520_context cc2520_context_data;
 
 static struct ieee802154_radio_api cc2520_radio_api = {
 	.iface_api.init	= cc2520_iface_init,
-	.iface_api.send	= ieee802154_radio_send,
 
 	.get_capabilities	= cc2520_get_capabilities,
 	.cca			= cc2520_cca,

--- a/drivers/ieee802154/ieee802154_kw41z.c
+++ b/drivers/ieee802154/ieee802154_kw41z.c
@@ -1008,7 +1008,6 @@ static void kw41z_iface_init(struct net_if *iface)
 
 static struct ieee802154_radio_api kw41z_radio_api = {
 	.iface_api.init	= kw41z_iface_init,
-	.iface_api.send	= ieee802154_radio_send,
 
 	.get_capabilities	= kw41z_get_capabilities,
 	.cca			= kw41z_cca,

--- a/drivers/ieee802154/ieee802154_mcr20a.c
+++ b/drivers/ieee802154/ieee802154_mcr20a.c
@@ -1462,7 +1462,6 @@ static struct mcr20a_context mcr20a_context_data;
 
 static struct ieee802154_radio_api mcr20a_radio_api = {
 	.iface_api.init	= mcr20a_iface_init,
-	.iface_api.send	= ieee802154_radio_send,
 
 	.get_capabilities	= mcr20a_get_capabilities,
 	.cca			= mcr20a_cca,

--- a/drivers/ieee802154/ieee802154_nrf5.c
+++ b/drivers/ieee802154/ieee802154_nrf5.c
@@ -424,7 +424,6 @@ static const struct nrf5_802154_config nrf5_radio_cfg = {
 
 static struct ieee802154_radio_api nrf5_radio_api = {
 	.iface_api.init = nrf5_iface_init,
-	.iface_api.send = ieee802154_radio_send,
 
 	.get_capabilities = nrf5_get_capabilities,
 	.cca = nrf5_cca,

--- a/drivers/ieee802154/ieee802154_uart_pipe.c
+++ b/drivers/ieee802154/ieee802154_uart_pipe.c
@@ -370,7 +370,6 @@ static struct upipe_context upipe_context_data;
 
 static struct ieee802154_radio_api upipe_radio_api = {
 	.iface_api.init		= upipe_iface_init,
-	.iface_api.send		= ieee802154_radio_send,
 
 	.get_capabilities	= upipe_get_capabilities,
 	.cca			= upipe_cca,

--- a/drivers/modem/wncm14a2a.c
+++ b/drivers/modem/wncm14a2a.c
@@ -1821,7 +1821,6 @@ static void offload_iface_init(struct net_if *iface)
 
 static struct net_if_api api_funcs = {
 	.init	= offload_iface_init,
-	.send	= NULL,
 };
 
 NET_DEVICE_OFFLOAD_INIT(modem_wncm14a2a, "MODEM_WNCM14A2A",

--- a/drivers/wifi/eswifi/eswifi_core.c
+++ b/drivers/wifi/eswifi/eswifi_core.c
@@ -493,7 +493,6 @@ static int eswifi_init(struct device *dev)
 
 static const struct net_wifi_mgmt_offload eswifi_offload_api = {
 	.iface_api.init = eswifi_iface_init,
-	.iface_api.send = NULL,
 	.scan		= eswifi_mgmt_scan,
 	.connect	= eswifi_mgmt_connect,
 	.disconnect	= eswifi_mgmt_disconnect,

--- a/include/net/dummy.h
+++ b/include/net/dummy.h
@@ -1,0 +1,44 @@
+/*
+ * Copyright (c) 2018 Intel Corporation.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+
+#ifndef ZEPHYR_INCLUDE_NET_DUMMY_H_
+#define ZEPHYR_INCLUDE_NET_DUMMY_H_
+
+#include <net/net_if.h>
+#include <net/net_pkt.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @brief Dummy L2/driver support functions
+ * @defgroup dummy Dummy L2/driver Support Functions
+ * @ingroup networking
+ * @{
+ */
+
+struct dummy_api {
+	/**
+	 * The net_if_api must be placed in first position in this
+	 * struct so that we are compatible with network interface API.
+	 */
+	struct net_if_api iface_api;
+
+	/** Send a network packet */
+	int (*send)(struct device *dev, struct net_pkt *pkt);
+};
+
+#ifdef __cplusplus
+}
+#endif
+
+/**
+ * @}
+ */
+
+#endif /* ZEPHYR_INCLUDE_NET_DUMMY_H_ */

--- a/include/net/ethernet.h
+++ b/include/net/ethernet.h
@@ -218,6 +218,9 @@ struct ethernet_api {
 	/** Return ptp_clock device that is tied to this ethernet device */
 	struct device *(*get_ptp_clock)(struct device *dev);
 #endif /* CONFIG_PTP_CLOCK */
+
+	/** Send a network packet */
+	int (*send)(struct device *dev, struct net_pkt *pkt);
 };
 
 struct net_eth_hdr {
@@ -535,23 +538,7 @@ static inline bool net_eth_get_vlan_status(struct net_if *iface)
 }
 #endif /* CONFIG_NET_VLAN */
 
-/**
- * @brief Fill ethernet header in network packet.
- *
- * @param ctx Ethernet context
- * @param pkt Network packet
- * @param ptype Upper level protocol type (in network byte order)
- * @param src Source ethernet address
- * @param dst Destination ethernet address
- *
- * @return Pointer to newly inserted net_buf where header is found,
- *         NULL otherwise.
- */
-struct net_buf *net_eth_fill_header(struct ethernet_context *ctx,
-				    struct net_pkt *pkt,
-				    u32_t ptype,
-				    u8_t *src,
-				    u8_t *dst);
+int net_eth_send(struct net_if *iface, struct net_pkt *pkt);
 
 /**
  * @brief Inform ethernet L2 driver that ethernet carrier is detected.

--- a/include/net/ethernet.h
+++ b/include/net/ethernet.h
@@ -538,8 +538,6 @@ static inline bool net_eth_get_vlan_status(struct net_if *iface)
 }
 #endif /* CONFIG_NET_VLAN */
 
-int net_eth_send(struct net_if *iface, struct net_pkt *pkt);
-
 /**
  * @brief Inform ethernet L2 driver that ethernet carrier is detected.
  * This happens when cable is connected.

--- a/include/net/ethernet.h
+++ b/include/net/ethernet.h
@@ -544,13 +544,14 @@ static inline bool net_eth_get_vlan_status(struct net_if *iface)
  * @param src Source ethernet address
  * @param dst Destination ethernet address
  *
- * @return Pointer to ethernet header struct inside net_buf.
+ * @return Pointer to newly inserted net_buf where header is found,
+ *         NULL otherwise.
  */
-struct net_eth_hdr *net_eth_fill_header(struct ethernet_context *ctx,
-					struct net_pkt *pkt,
-					u32_t ptype,
-					u8_t *src,
-					u8_t *dst);
+struct net_buf *net_eth_fill_header(struct ethernet_context *ctx,
+				    struct net_pkt *pkt,
+				    u32_t ptype,
+				    u8_t *src,
+				    u8_t *dst);
 
 /**
  * @brief Inform ethernet L2 driver that ethernet carrier is detected.

--- a/include/net/ieee802154_radio.h
+++ b/include/net/ieee802154_radio.h
@@ -129,20 +129,6 @@ static inline bool ieee802154_is_ar_flag_set(struct net_pkt *pkt)
 #ifndef CONFIG_IEEE802154_RAW_MODE
 
 /**
- * @brief Radio driver sending function that hw drivers should use
- *
- * @details This function should be used to fill in struct net_if's send
- * pointer.
- *
- * @param iface A valid pointer on a network interface to send from
- * @param pkt A valid pointer on a packet to send
- *
- * @return 0 on success, negative value otherwise
- */
-extern int ieee802154_radio_send(struct net_if *iface,
-				 struct net_pkt *pkt);
-
-/**
  * @brief Radio driver ACK handling function that hw drivers should use
  *
  * @details ACK handling requires fast handling and thus such function
@@ -164,12 +150,6 @@ extern enum net_verdict ieee802154_radio_handle_ack(struct net_if *iface,
 void ieee802154_init(struct net_if *iface);
 
 #else /* CONFIG_IEEE802154_RAW_MODE */
-
-static inline int ieee802154_radio_send(struct net_if *iface,
-					struct net_pkt *pkt)
-{
-	return 0;
-}
 
 static inline enum net_verdict ieee802154_radio_handle_ack(struct net_if *iface,
 							   struct net_pkt *pkt)

--- a/include/net/net_if.h
+++ b/include/net/net_if.h
@@ -1808,7 +1808,6 @@ bool net_if_is_promisc(struct net_if *iface);
 
 struct net_if_api {
 	void (*init)(struct net_if *iface);
-	int (*send)(struct net_if *iface, struct net_pkt *pkt);
 };
 
 #if defined(CONFIG_NET_DHCPV4)

--- a/include/net/net_l2.h
+++ b/include/net/net_l2.h
@@ -49,8 +49,9 @@ struct net_l2 {
 	 * This function is used by net core to push a packet to lower layer
 	 * (interface's L2), which in turn might work on the packet relevantly.
 	 * (adding proper header etc...)
+	 * Returns a negative error code, or the number of bytes sent otherwise.
 	 */
-	enum net_verdict (*send)(struct net_if *iface, struct net_pkt *pkt);
+	int (*send)(struct net_if *iface, struct net_pkt *pkt);
 
 	/**
 	 * This function is used to get the amount of bytes the net core should

--- a/include/net/net_pkt.h
+++ b/include/net/net_pkt.h
@@ -670,6 +670,13 @@ static inline void net_pkt_set_ipv4_auto(struct net_pkt *pkt,
 {
 	pkt->ipv4_auto_arp_msg = is_auto_arp_msg;
 }
+#else
+static inline bool net_pkt_ipv4_auto(struct net_pkt *pkt)
+{
+	return false;
+}
+
+#define net_pkt_set_ipv4_auto(...)
 #endif
 
 #define NET_IPV6_HDR(pkt) ((struct net_ipv6_hdr *)net_pkt_ip_data(pkt))

--- a/include/net/net_pkt.h
+++ b/include/net/net_pkt.h
@@ -118,10 +118,18 @@ struct net_pkt {
 				 * packet before EOF
 				 * Used only if defined(CONFIG_NET_TCP)
 				 */
-	u8_t pkt_queued: 1;	/* For outgoing packet: is this packet queued
-				 * to be sent but has not reached the driver
-				 * yet. Used only if defined(CONFIG_NET_TCP)
-				 */
+	union {
+		u8_t pkt_queued: 1; /* For outgoing packet: is this packet
+				     * queued to be sent but has not reached
+				     * the driver yet.
+				     * Used only if defined(CONFIG_NET_TCP)
+				     */
+		u8_t gptp_pkt: 1; /* For outgoing packet: is this packet
+				   * a GPTP packet.
+				   * Used only if defined (CONFIG_NET_GPTP)
+				   */
+	};
+
 	u8_t forwarding : 1;	/* Are we forwarding this pkt
 				 * Used only if defined(CONFIG_NET_ROUTE)
 				 */
@@ -257,6 +265,16 @@ static inline u8_t net_pkt_family(struct net_pkt *pkt)
 static inline void net_pkt_set_family(struct net_pkt *pkt, u8_t family)
 {
 	pkt->family = family;
+}
+
+static inline bool net_pkt_is_gptp(struct net_pkt *pkt)
+{
+	return !!(pkt->gptp_pkt);
+}
+
+static inline void net_pkt_set_gptp(struct net_pkt *pkt, bool is_gptp)
+{
+	pkt->gptp_pkt = is_gptp;
 }
 
 static inline u8_t net_pkt_ip_hdr_len(struct net_pkt *pkt)

--- a/subsys/net/ip/net_if.c
+++ b/subsys/net/ip/net_if.c
@@ -164,7 +164,8 @@ static bool net_if_tx(struct net_if *iface, struct net_pkt *pkt)
 	context_token = net_pkt_token(pkt);
 
 	if (atomic_test_bit(iface->if_dev->flags, NET_IF_UP)) {
-		if (IS_ENABLED(CONFIG_NET_TCP)) {
+		if (IS_ENABLED(CONFIG_NET_TCP) &&
+		    net_pkt_family(pkt) != AF_UNSPEC) {
 			net_pkt_set_sent(pkt, true);
 			net_pkt_set_queued(pkt, false);
 		}
@@ -177,7 +178,8 @@ static bool net_if_tx(struct net_if *iface, struct net_pkt *pkt)
 	}
 
 	if (status < 0) {
-		if (IS_ENABLED(CONFIG_NET_TCP)) {
+		if (IS_ENABLED(CONFIG_NET_TCP)
+		    && net_pkt_family(pkt) != AF_UNSPEC) {
 			net_pkt_set_sent(pkt, false);
 		}
 

--- a/subsys/net/ip/net_if.c
+++ b/subsys/net/ip/net_if.c
@@ -240,11 +240,6 @@ static inline void init_iface(struct net_if *iface)
 	NET_DBG("On iface %p", iface);
 
 	api->init(iface);
-
-	/* Test for api->send only when ip is *not* offloaded: */
-	if (!net_if_is_ip_offloaded(iface)) {
-		NET_ASSERT(api->send);
-	}
 }
 
 enum net_verdict net_if_send_data(struct net_if *iface, struct net_pkt *pkt)

--- a/subsys/net/l2/ethernet/arp.c
+++ b/subsys/net/l2/ethernet/arp.c
@@ -470,9 +470,7 @@ static void arp_update(struct net_if *iface,
 	/* Inserting entry into the table */
 	sys_slist_prepend(&arp_table, &entry->node);
 
-	if (net_if_send_data(iface, pkt) == NET_DROP) {
-		net_pkt_unref(pkt);
-	}
+	net_if_queue_tx(iface, pkt);
 }
 
 static inline struct net_pkt *arp_prepare_reply(struct net_if *iface,

--- a/subsys/net/l2/ethernet/arp.h
+++ b/subsys/net/l2/ethernet/arp.h
@@ -71,7 +71,8 @@ void net_arp_init(void);
  */
 
 #else /* CONFIG_NET_ARP */
-
+#define net_arp_prepare(_kt, _u1, _u2) _kt
+#define net_arp_input(_ptt) NET_OK
 #define net_arp_clear_cache(...)
 #define net_arp_init(...)
 

--- a/subsys/net/l2/ethernet/ethernet.c
+++ b/subsys/net/l2/ethernet/ethernet.c
@@ -492,6 +492,8 @@ static int ethernet_send(struct net_if *iface, struct net_pkt *pkt)
 	} else if (IS_ENABLED(CONFIG_NET_IPV6) &&
 		   net_pkt_family(pkt) == AF_INET6) {
 		ptype = htons(NET_ETH_PTYPE_IPV6);
+	} else if (IS_ENABLED(CONFIG_NET_GPTP) && net_pkt_is_gptp(pkt)) {
+		ptype = htons(NET_ETH_PTYPE_PTP);
 	} else if (IS_ENABLED(CONFIG_NET_ARP)) {
 		/* Unktown type: Unqueued pkt is an ARP reply.
 		 */

--- a/subsys/net/l2/ethernet/ethernet.c
+++ b/subsys/net/l2/ethernet/ethernet.c
@@ -464,15 +464,7 @@ static struct net_buf *ethernet_fill_header(struct ethernet_context *ctx,
 	return hdr_frag;
 }
 
-static enum net_verdict ethernet_send(struct net_if *iface,
-				      struct net_pkt *pkt)
-{
-	net_if_queue_tx(iface, pkt);
-
-	return NET_OK;
-}
-
-int net_eth_send(struct net_if *iface, struct net_pkt *pkt)
+static int ethernet_send(struct net_if *iface, struct net_pkt *pkt)
 {
 	const struct ethernet_api *api = net_if_get_device(iface)->driver_api;
 	struct ethernet_context *ctx = net_if_l2_data(iface);
@@ -538,6 +530,7 @@ int net_eth_send(struct net_if *iface, struct net_pkt *pkt)
 
 	ret = api->send(net_if_get_device(iface), pkt);
 	if (!ret) {
+		ret = net_pkt_get_len(pkt);
 		net_pkt_unref(pkt);
 	}
 

--- a/subsys/net/l2/ieee802154/ieee802154_mgmt.c
+++ b/subsys/net/l2/ieee802154/ieee802154_mgmt.c
@@ -20,6 +20,7 @@
 #include "ieee802154_mgmt_priv.h"
 #include "ieee802154_security.h"
 #include "ieee802154_utils.h"
+#include "ieee802154_radio_utils.h"
 
 enum net_verdict ieee802154_handle_beacon(struct net_if *iface,
 					  struct ieee802154_mpdu *mpdu,
@@ -138,7 +139,7 @@ static int ieee802154_scan(u32_t mgmt_request, struct net_if *iface,
 			net_pkt_ref(pkt);
 			net_pkt_frag_ref(pkt->frags);
 
-			ret = ieee802154_radio_send(iface, pkt);
+			ret = ieee802154_radio_send(iface, pkt, pkt->frags);
 			if (ret) {
 				NET_DBG("Could not send Beacon Request (%d)",
 					ret);

--- a/subsys/net/l2/ieee802154/ieee802154_radio_aloha.c
+++ b/subsys/net/l2/ieee802154/ieee802154_radio_aloha.c
@@ -16,9 +16,9 @@
 #include "ieee802154_utils.h"
 #include "ieee802154_radio_utils.h"
 
-static inline int aloha_tx_fragment(struct net_if *iface,
-				    struct net_pkt *pkt,
-				    struct net_buf *frag)
+static inline int aloha_radio_send(struct net_if *iface,
+				   struct net_pkt *pkt,
+				   struct net_buf *frag)
 {
 	u8_t retries = CONFIG_NET_L2_IEEE802154_RADIO_TX_RETRIES;
 	struct ieee802154_context *ctx = net_if_l2_data(iface);
@@ -42,13 +42,6 @@ static inline int aloha_tx_fragment(struct net_if *iface,
 	}
 
 	return ret;
-}
-
-static int aloha_radio_send(struct net_if *iface, struct net_pkt *pkt)
-{
-	NET_DBG("pkt %p (frags %p)", pkt, pkt->frags);
-
-	return tx_packet_fragments(iface, pkt, aloha_tx_fragment);
 }
 
 static enum net_verdict aloha_radio_handle_ack(struct net_if *iface,

--- a/subsys/net/l2/ieee802154/ieee802154_radio_csma_ca.c
+++ b/subsys/net/l2/ieee802154/ieee802154_radio_csma_ca.c
@@ -19,9 +19,9 @@
 #include "ieee802154_utils.h"
 #include "ieee802154_radio_utils.h"
 
-static inline int csma_ca_tx_fragment(struct net_if *iface,
-				      struct net_pkt *pkt,
-				      struct net_buf *frag)
+static inline int csma_ca_radio_send(struct net_if *iface,
+				     struct net_pkt *pkt,
+				     struct net_buf *frag)
 {
 	const u8_t max_bo = CONFIG_NET_L2_IEEE802154_RADIO_CSMA_CA_MAX_BO;
 	const u8_t max_be = CONFIG_NET_L2_IEEE802154_RADIO_CSMA_CA_MAX_BE;
@@ -69,13 +69,6 @@ loop:
 	}
 
 	return ret;
-}
-
-static int csma_ca_radio_send(struct net_if *iface, struct net_pkt *pkt)
-{
-	NET_DBG("pkt %p (frags %p)", pkt, pkt->frags);
-
-	return tx_packet_fragments(iface, pkt, csma_ca_tx_fragment);
 }
 
 static enum net_verdict csma_ca_radio_handle_ack(struct net_if *iface,

--- a/subsys/net/l2/openthread/openthread.c
+++ b/subsys/net/l2/openthread/openthread.c
@@ -229,11 +229,12 @@ static enum net_verdict openthread_recv(struct net_if *iface,
 	return NET_OK;
 }
 
-enum net_verdict openthread_send(struct net_if *iface, struct net_pkt *pkt)
+int openthread_send(struct net_if *iface, struct net_pkt *pkt)
 {
 	struct openthread_context *ot_context = net_if_l2_data(iface);
-	otMessage *message;
+	int len = net_pkt_get_len(pkt);
 	struct net_buf *frag;
+	otMessage *message;
 
 	NET_DBG("Sending Ip6 packet to ot stack");
 
@@ -264,7 +265,7 @@ enum net_verdict openthread_send(struct net_if *iface, struct net_pkt *pkt)
 exit:
 	net_pkt_unref(pkt);
 
-	return NET_OK;
+	return len;
 }
 
 static u16_t openthread_reserve(struct net_if *iface, void *arg)
@@ -343,17 +344,6 @@ static int openthread_init(struct net_if *iface)
 void ieee802154_init(struct net_if *iface)
 {
 	openthread_init(iface);
-}
-
-int ieee802154_radio_send(struct net_if *iface, struct net_pkt *pkt)
-{
-	ARG_UNUSED(iface);
-	ARG_UNUSED(pkt);
-
-	/* Shouldn't be here */
-	__ASSERT(false, "OpenThread L2 should never reach here");
-
-	return -EIO;
 }
 
 static enum net_l2_flags openthread_flags(struct net_if *iface)

--- a/subsys/usb/class/netusb/netusb.c
+++ b/subsys/usb/class/netusb/netusb.c
@@ -36,9 +36,11 @@ static struct __netusb {
 static u8_t interface_data[300];
 #endif
 
-static int netusb_send(struct net_if *iface, struct net_pkt *pkt)
+static int netusb_send(struct device *dev, struct net_pkt *pkt)
 {
 	int ret;
+
+	ARG_UNUSED(dev);
 
 	LOG_DBG("Send pkt, len %u", net_pkt_get_len(pkt));
 
@@ -52,7 +54,6 @@ static int netusb_send(struct net_if *iface, struct net_pkt *pkt)
 		return ret;
 	}
 
-	net_pkt_unref(pkt);
 	return 0;
 }
 
@@ -222,11 +223,10 @@ static void netusb_init(struct net_if *iface)
 }
 
 static const struct ethernet_api netusb_api_funcs = {
-	.iface_api = {
-		.init = netusb_init,
-		.send = netusb_send,
-	},
+	.iface_api.init = netusb_init,
+
 	.get_capabilities = NULL,
+	.send = netusb_send,
 };
 
 static int netusb_init_dev(struct device *dev)

--- a/tests/net/6lo/src/main.c
+++ b/tests/net/6lo/src/main.c
@@ -23,6 +23,7 @@
 #include <net/net_core.h>
 #include <net/net_pkt.h>
 #include <net/net_ip.h>
+#include <net/dummy.h>
 
 #include <tc_util.h>
 
@@ -201,14 +202,13 @@ static void net_6lo_iface_init(struct net_if *iface)
 	net_if_set_link_addr(iface, src_mac, 8, NET_LINK_IEEE802154);
 }
 
-static int tester_send(struct net_if *iface, struct net_pkt *pkt)
+static int tester_send(struct device *dev, struct net_pkt *pkt)
 {
-	net_pkt_unref(pkt);
-	return NET_OK;
+	return 0;
 }
 
-static struct net_if_api net_6lo_if_api = {
-	.init = net_6lo_iface_init,
+static struct dummy_api net_6lo_if_api = {
+	.iface_api.init = net_6lo_iface_init,
 	.send = tester_send,
 };
 

--- a/tests/net/all/src/main.c
+++ b/tests/net/all/src/main.c
@@ -17,6 +17,7 @@
 
 #include <net/net_if.h>
 #include <net/net_pkt.h>
+#include <net/dummy.h>
 
 static struct offload_context {
 	void *none;
@@ -24,8 +25,8 @@ static struct offload_context {
 	.none = NULL
 };
 
-static struct net_if_api offload_if_api = {
-	.init = NULL,
+static struct dummy_api offload_if_api = {
+	.iface_api.init = NULL,
 	.send = NULL,
 };
 

--- a/tests/net/checksum_offload/src/main.c
+++ b/tests/net/checksum_offload/src/main.c
@@ -106,9 +106,9 @@ static void eth_iface_init(struct net_if *iface)
 	ethernet_init(iface);
 }
 
-static int eth_tx_offloading_disabled(struct net_if *iface, struct net_pkt *pkt)
+static int eth_tx_offloading_disabled(struct device *dev, struct net_pkt *pkt)
 {
-	struct eth_context *context = net_if_get_device(iface)->driver_data;
+	struct eth_context *context = dev->driver_data;
 
 	zassert_equal_ptr(&eth_context_offloading_disabled, context,
 			  "Context pointers do not match (%p vs %p)",
@@ -165,8 +165,11 @@ static int eth_tx_offloading_disabled(struct net_if *iface, struct net_pkt *pkt)
 		pkt->frags->len += net_pkt_ll_reserve(pkt);
 		net_pkt_set_ll_reserve(pkt, 0);
 
+		net_pkt_ref(pkt);
+
 		if (net_recv_data(net_pkt_iface(pkt), pkt) < 0) {
 			test_failed = true;
+			net_pkt_unref(pkt);
 			zassert_true(false, "Packet %p receive failed\n", pkt);
 		}
 
@@ -185,14 +188,12 @@ static int eth_tx_offloading_disabled(struct net_if *iface, struct net_pkt *pkt)
 		k_sem_give(&wait_data);
 	}
 
-	net_pkt_unref(pkt);
-
 	return 0;
 }
 
-static int eth_tx_offloading_enabled(struct net_if *iface, struct net_pkt *pkt)
+static int eth_tx_offloading_enabled(struct device *dev, struct net_pkt *pkt)
 {
-	struct eth_context *context = net_if_get_device(iface)->driver_data;
+	struct eth_context *context = dev->driver_data;
 
 	zassert_equal_ptr(&eth_context_offloading_enabled, context,
 			  "Context pointers do not match (%p vs %p)",
@@ -215,8 +216,6 @@ static int eth_tx_offloading_enabled(struct net_if *iface, struct net_pkt *pkt)
 		k_sem_give(&wait_data);
 	}
 
-	net_pkt_unref(pkt);
-
 	return 0;
 }
 
@@ -233,16 +232,16 @@ static enum ethernet_hw_caps eth_offloading_disabled(struct device *dev)
 
 static struct ethernet_api api_funcs_offloading_disabled = {
 	.iface_api.init = eth_iface_init,
-	.iface_api.send = eth_tx_offloading_disabled,
 
 	.get_capabilities = eth_offloading_disabled,
+	.send = eth_tx_offloading_disabled,
 };
 
 static struct ethernet_api api_funcs_offloading_enabled = {
 	.iface_api.init = eth_iface_init,
-	.iface_api.send = eth_tx_offloading_enabled,
 
 	.get_capabilities = eth_offloading_enabled,
+	.send = eth_tx_offloading_enabled,
 };
 
 static void generate_mac(u8_t *mac_addr)
@@ -768,6 +767,8 @@ static void rx_chksum_offload_disabled_test_v6(void)
 			       NULL);
 	zassert_equal(ret, 0, "Recv UDP failed (%d)\n", ret);
 
+	start_receiving = false;
+
 	ret = net_context_sendto(pkt, (struct sockaddr *)&dst_addr6,
 				 sizeof(struct sockaddr_in6),
 				 NULL, 0, NULL, NULL);
@@ -830,6 +831,8 @@ static void rx_chksum_offload_disabled_test_v4(void)
 	ret = net_context_recv(udp_v4_ctx_1, recv_cb_offload_disabled, 0,
 			       NULL);
 	zassert_equal(ret, 0, "Recv UDP failed (%d)\n", ret);
+
+	start_receiving = false;
 
 	ret = net_context_sendto(pkt, (struct sockaddr *)&dst_addr4,
 				 sizeof(struct sockaddr_in),

--- a/tests/net/context/src/main.c
+++ b/tests/net/context/src/main.c
@@ -21,6 +21,7 @@
 #include <tc_util.h>
 
 #include <net/ethernet.h>
+#include <net/dummy.h>
 #include <net/buf.h>
 #include <net/net_ip.h>
 #include <net/net_if.h>
@@ -968,7 +969,7 @@ static void net_context_iface_init(struct net_if *iface)
 			     NET_LINK_ETHERNET);
 }
 
-static int tester_send(struct net_if *iface, struct net_pkt *pkt)
+static int tester_send(struct device *dev, struct net_pkt *pkt)
 {
 	struct net_udp_hdr hdr, *udp_hdr;
 
@@ -1019,10 +1020,15 @@ static int tester_send(struct net_if *iface, struct net_pkt *pkt)
 		udp_hdr->dst_port = port;
 		net_udp_set_hdr(pkt, udp_hdr);
 
-		if (net_recv_data(iface, pkt) < 0) {
+		if (net_recv_data(net_pkt_iface(pkt), pkt) < 0) {
 			TC_ERROR("Data receive failed.");
 			goto out;
 		}
+
+		/* L2 or net_if will unref the pkt, but we are pushing it
+		 * to rx path, so let's reference it or it will be freed.
+		 */
+		net_pkt_ref(pkt);
 
 		timeout_token = 0;
 
@@ -1030,8 +1036,6 @@ static int tester_send(struct net_if *iface, struct net_pkt *pkt)
 	}
 
 out:
-	net_pkt_unref(pkt);
-
 	if (data_failure) {
 		test_failed = true;
 	}
@@ -1041,8 +1045,8 @@ out:
 
 struct net_context_test net_context_data;
 
-static struct net_if_api net_context_if_api = {
-	.init = net_context_iface_init,
+static struct dummy_api net_context_if_api = {
+	.iface_api.init = net_context_iface_init,
 	.send = tester_send,
 };
 

--- a/tests/net/ethernet_mgmt/src/main.c
+++ b/tests/net/ethernet_mgmt/src/main.c
@@ -53,12 +53,11 @@ static void eth_fake_iface_init(struct net_if *iface)
 	ethernet_init(iface);
 }
 
-static int eth_fake_send(struct net_if *iface,
+static int eth_fake_send(struct device *dev,
 			 struct net_pkt *pkt)
 {
-	ARG_UNUSED(iface);
-
-	net_pkt_unref(pkt);
+	ARG_UNUSED(dev);
+	ARG_UNUSED(pkt);
 
 	return 0;
 }
@@ -266,11 +265,11 @@ static int eth_fake_get_config(struct device *dev,
 
 static struct ethernet_api eth_fake_api_funcs = {
 	.iface_api.init = eth_fake_iface_init,
-	.iface_api.send = eth_fake_send,
 
 	.get_capabilities = eth_fake_get_capabilities,
 	.set_config = eth_fake_set_config,
 	.get_config = eth_fake_get_config,
+	.send = eth_fake_send,
 };
 
 static int eth_fake_init(struct device *dev)

--- a/tests/net/ieee802154/fragment/src/main.c
+++ b/tests/net/ieee802154/fragment/src/main.c
@@ -23,6 +23,7 @@
 #include <net/net_core.h>
 #include <net/net_pkt.h>
 #include <net/net_ip.h>
+#include <net/dummy.h>
 
 #include <tc_util.h>
 
@@ -158,14 +159,13 @@ static void net_fragment_iface_init(struct net_if *iface)
 	net_if_set_link_addr(iface, mac, 8, NET_LINK_IEEE802154);
 }
 
-static int tester_send(struct net_if *iface, struct net_pkt *pkt)
+static int tester_send(struct device *dev, struct net_pkt *pkt)
 {
-	net_pkt_unref(pkt);
-	return NET_OK;
+	return 0;
 }
 
-static struct net_if_api net_fragment_if_api = {
-	.init = net_fragment_iface_init,
+static struct dummy_api net_fragment_if_api = {
+	.iface_api.init = net_fragment_iface_init,
 	.send = tester_send,
 };
 

--- a/tests/net/iface/src/main.c
+++ b/tests/net/iface/src/main.c
@@ -20,6 +20,7 @@
 #include <ztest.h>
 
 #include <net/ethernet.h>
+#include <net/dummy.h>
 #include <net/buf.h>
 #include <net/net_ip.h>
 #include <net/net_if.h>
@@ -104,7 +105,7 @@ static void net_iface_init(struct net_if *iface)
 			     NET_LINK_ETHERNET);
 }
 
-static int sender_iface(struct net_if *iface, struct net_pkt *pkt)
+static int sender_iface(struct device *dev, struct net_pkt *pkt)
 {
 	if (!pkt->frags) {
 		DBG("No data to send!\n");
@@ -112,26 +113,18 @@ static int sender_iface(struct net_if *iface, struct net_pkt *pkt)
 	}
 
 	if (test_started) {
-		struct net_if_test *data =
-			net_if_get_device(iface)->driver_data;
+		struct net_if_test *data = dev->driver_data;
 
-		DBG("Sending at iface %d %p\n", net_if_get_by_iface(iface),
-		    iface);
+		DBG("Sending at iface %d %p\n",
+		    net_if_get_by_iface(net_pkt_iface(pkt)),
+		    net_pkt_iface(pkt));
 
-		if (net_pkt_iface(pkt) != iface) {
-			DBG("Invalid interface %p, expecting %p\n",
-				 net_pkt_iface(pkt), iface);
-			test_failed = true;
-		}
-
-		if (net_if_get_by_iface(iface) != data->idx) {
+		if (net_if_get_by_iface(net_pkt_iface(pkt)) != data->idx) {
 			DBG("Invalid interface %d index, expecting %d\n",
-				 data->idx, net_if_get_by_iface(iface));
+			    data->idx, net_if_get_by_iface(net_pkt_iface(pkt)));
 			test_failed = true;
 		}
 	}
-
-	net_pkt_unref(pkt);
 
 	k_sem_give(&wait_data);
 
@@ -142,8 +135,8 @@ struct net_if_test net_iface1_data;
 struct net_if_test net_iface2_data;
 struct net_if_test net_iface3_data;
 
-static struct net_if_api net_iface_api = {
-	.init = net_iface_init,
+static struct dummy_api net_iface_api = {
+	.iface_api.init = net_iface_init,
 	.send = sender_iface,
 };
 
@@ -208,12 +201,11 @@ static void eth_fake_iface_init(struct net_if *iface)
 	ethernet_init(iface);
 }
 
-static int eth_fake_send(struct net_if *iface,
+static int eth_fake_send(struct device *dev,
 			 struct net_pkt *pkt)
 {
-	ARG_UNUSED(iface);
-
-	net_pkt_unref(pkt);
+	ARG_UNUSED(dev);
+	ARG_UNUSED(pkt);
 
 	return 0;
 }
@@ -248,10 +240,10 @@ static int eth_fake_set_config(struct device *dev,
 
 static struct ethernet_api eth_fake_api_funcs = {
 	.iface_api.init = eth_fake_iface_init,
-	.iface_api.send = eth_fake_send,
 
 	.get_capabilities = eth_fake_get_capabilities,
 	.set_config = eth_fake_set_config,
+	.send = eth_fake_send,
 };
 
 static int eth_fake_init(struct device *dev)

--- a/tests/net/ip-addr/src/main.c
+++ b/tests/net/ip-addr/src/main.c
@@ -22,6 +22,7 @@
 #include <net/net_core.h>
 #include <net/net_pkt.h>
 #include <net/net_ip.h>
+#include <net/dummy.h>
 
 #define NET_LOG_ENABLED 1
 #include "net_private.h"
@@ -136,16 +137,15 @@ static void net_test_iface_init(struct net_if *iface)
 	net_if_set_link_addr(iface, mac, 6, NET_LINK_ETHERNET);
 }
 
-static int tester_send(struct net_if *iface, struct net_pkt *pkt)
+static int tester_send(struct device *dev, struct net_pkt *pkt)
 {
-	net_pkt_unref(pkt);
 	return 0;
 }
 
 struct net_test_context net_test_context_data;
 
-static struct net_if_api net_test_if_api = {
-	.init = net_test_iface_init,
+static struct dummy_api net_test_if_api = {
+	.iface_api.init = net_test_iface_init,
 	.send = tester_send,
 };
 

--- a/tests/net/lib/dns_resolve/src/main.c
+++ b/tests/net/lib/dns_resolve/src/main.c
@@ -17,6 +17,7 @@
 #include <ztest.h>
 
 #include <net/ethernet.h>
+#include <net/dummy.h>
 #include <net/buf.h>
 #include <net/net_ip.h>
 #include <net/net_if.h>
@@ -122,7 +123,7 @@ static inline int get_slot_by_id(struct dns_resolve_context *ctx,
 	return -1;
 }
 
-static int sender_iface(struct net_if *iface, struct net_pkt *pkt)
+static int sender_iface(struct device *dev, struct net_pkt *pkt)
 {
 	if (!pkt->frags) {
 		DBG("No data to send!\n");
@@ -130,23 +131,13 @@ static int sender_iface(struct net_if *iface, struct net_pkt *pkt)
 	}
 
 	if (!timeout_query) {
-		struct net_if_test *data =
-			net_if_get_device(iface)->driver_data;
+		struct net_if_test *data = dev->driver_data;
 		struct dns_resolve_context *ctx;
 		int slot;
 
-		DBG("Sending at iface %d %p\n", net_if_get_by_iface(iface),
-		    iface);
-
-		if (net_pkt_iface(pkt) != iface) {
-			DBG("Invalid interface %p, expecting %p\n",
-				 net_pkt_iface(pkt), iface);
-			test_failed = true;
-		}
-
-		if (net_if_get_by_iface(iface) != data->idx) {
+		if (net_if_get_by_iface(net_pkt_iface(pkt)) != data->idx) {
 			DBG("Invalid interface %d index, expecting %d\n",
-				 data->idx, net_if_get_by_iface(iface));
+			    data->idx, net_if_get_by_iface(net_pkt_iface(pkt)));
 			test_failed = true;
 		}
 
@@ -178,15 +169,13 @@ static int sender_iface(struct net_if *iface, struct net_pkt *pkt)
 	}
 
 out:
-	net_pkt_unref(pkt);
-
 	return 0;
 }
 
 struct net_if_test net_iface1_data;
 
-static struct net_if_api net_iface_api = {
-	.init = net_iface_init,
+static struct dummy_api net_iface_api = {
+	.iface_api.init = net_iface_init,
 	.send = sender_iface,
 };
 

--- a/tests/net/mgmt/src/mgmt.c
+++ b/tests/net/mgmt/src/mgmt.c
@@ -13,6 +13,7 @@
 #include <toolchain.h>
 #include <linker/sections.h>
 
+#include <net/dummy.h>
 #include <net/net_mgmt.h>
 #include <net/net_pkt.h>
 #include <ztest.h>
@@ -73,15 +74,13 @@ static void fake_iface_init(struct net_if *iface)
 	net_if_set_link_addr(iface, mac, 8, NET_LINK_DUMMY);
 }
 
-static int fake_iface_send(struct net_if *iface, struct net_pkt *pkt)
+static int fake_iface_send(struct device *dev, struct net_pkt *pkt)
 {
-	net_pkt_unref(pkt);
-
-	return NET_OK;
+	return 0;
 }
 
-static struct net_if_api fake_iface_api = {
-	.init = fake_iface_init,
+static struct dummy_api fake_iface_api = {
+	.iface_api.init = fake_iface_init,
 	.send = fake_iface_send,
 };
 

--- a/tests/net/mld/src/main.c
+++ b/tests/net/mld/src/main.c
@@ -23,6 +23,7 @@
 #include <net/net_ip.h>
 #include <net/net_core.h>
 #include <net/ethernet.h>
+#include <net/dummy.h>
 #include <net/net_mgmt.h>
 #include <net/net_event.h>
 
@@ -97,7 +98,7 @@ static void net_test_iface_init(struct net_if *iface)
 
 #define NET_ICMP_HDR(pkt) ((struct net_icmp_hdr *)net_pkt_icmp_data(pkt))
 
-static int tester_send(struct net_if *iface, struct net_pkt *pkt)
+static int tester_send(struct device *dev, struct net_pkt *pkt)
 {
 	struct net_icmp_hdr *icmp = NET_ICMP_HDR(pkt);
 
@@ -117,15 +118,13 @@ static int tester_send(struct net_if *iface, struct net_pkt *pkt)
 		k_sem_give(&wait_data);
 	}
 
-	net_pkt_unref(pkt);
-
 	return 0;
 }
 
 struct net_test_mld net_test_data;
 
-static struct net_if_api net_test_if_api = {
-	.init = net_test_iface_init,
+static struct dummy_api net_test_if_api = {
+	.iface_api.init = net_test_iface_init,
 	.send = tester_send,
 };
 

--- a/tests/net/promiscuous/src/main.c
+++ b/tests/net/promiscuous/src/main.c
@@ -86,12 +86,11 @@ static void eth_fake_iface_init(struct net_if *iface)
 	ethernet_init(iface);
 }
 
-static int eth_fake_send(struct net_if *iface,
+static int eth_fake_send(struct device *dev,
 			 struct net_pkt *pkt)
 {
-	ARG_UNUSED(iface);
-
-	net_pkt_unref(pkt);
+	ARG_UNUSED(dev);
+	ARG_UNUSED(pkt);
 
 	return 0;
 }
@@ -126,10 +125,10 @@ static int eth_fake_set_config(struct device *dev,
 
 static struct ethernet_api eth_fake_api_funcs = {
 	.iface_api.init = eth_fake_iface_init,
-	.iface_api.send = eth_fake_send,
 
 	.get_capabilities = eth_fake_get_capabilities,
 	.set_config = eth_fake_set_config,
+	.send = eth_fake_send,
 };
 
 static int eth_fake_init(struct device *dev)

--- a/tests/net/ptp/clock/src/main.c
+++ b/tests/net/ptp/clock/src/main.c
@@ -91,9 +91,9 @@ static void eth_iface_init(struct net_if *iface)
 	ethernet_init(iface);
 }
 
-static int eth_tx(struct net_if *iface, struct net_pkt *pkt)
+static int eth_tx(struct device *dev, struct net_pkt *pkt)
 {
-	struct eth_context *context = net_if_get_device(iface)->driver_data;
+	struct eth_context *context = dev->driver_data;
 
 	if (&eth_context_1 != context && &eth_context_2 != context) {
 		zassert_true(false, "Context pointers do not match\n");
@@ -105,11 +105,9 @@ static int eth_tx(struct net_if *iface, struct net_pkt *pkt)
 	}
 
 	if (test_started) {
-
 		k_sem_give(&wait_data);
 	}
 
-	net_pkt_unref(pkt);
 
 	return 0;
 }
@@ -128,10 +126,10 @@ static struct device *eth_get_ptp_clock(struct device *dev)
 
 static struct ethernet_api api_funcs = {
 	.iface_api.init = eth_iface_init,
-	.iface_api.send = eth_tx,
 
 	.get_capabilities = eth_capabilities,
 	.get_ptp_clock = eth_get_ptp_clock,
+	.send = eth_tx,
 };
 
 static void generate_mac(u8_t *mac_addr)

--- a/tests/net/route/src/main.c
+++ b/tests/net/route/src/main.c
@@ -21,6 +21,7 @@
 #include <tc_util.h>
 
 #include <net/ethernet.h>
+#include <net/dummy.h>
 #include <net/buf.h>
 #include <net/net_ip.h>
 #include <net/net_if.h>
@@ -124,7 +125,7 @@ static void net_route_iface_init(struct net_if *iface)
 			     NET_LINK_ETHERNET);
 }
 
-static int tester_send(struct net_if *iface, struct net_pkt *pkt)
+static int tester_send(struct device *dev, struct net_pkt *pkt)
 {
 	if (!pkt->frags) {
 		TC_ERROR("No data to send!\n");
@@ -136,7 +137,9 @@ static int tester_send(struct net_if *iface, struct net_pkt *pkt)
 
 	if (feed_data) {
 		DBG("Received at iface %p and feeding it into iface %p\n",
-		    iface, recipient);
+		    net_pkt_iface(pkt), recipient);
+
+		net_pkt_ref(pkt);
 
 		if (net_recv_data(recipient, pkt) < 0) {
 			TC_ERROR("Data receive failed.");
@@ -144,27 +147,23 @@ static int tester_send(struct net_if *iface, struct net_pkt *pkt)
 			test_failed = true;
 		}
 
-		k_sem_give(&wait_data);
-
-		return 0;
+		goto out;
 	}
 
 	DBG("pkt %p to be sent len %lu\n", pkt, net_pkt_get_len(pkt));
-
-	net_pkt_unref(pkt);
 
 	if (data_failure) {
 		test_failed = true;
 	}
 
 	msg_sending = 0;
-
+out:
 	k_sem_give(&wait_data);
 
 	return 0;
 }
 
-static int tester_send_peer(struct net_if *iface, struct net_pkt *pkt)
+static int tester_send_peer(struct device *dev, struct net_pkt *pkt)
 {
 	if (!pkt->frags) {
 		TC_ERROR("No data to send!\n");
@@ -176,29 +175,26 @@ static int tester_send_peer(struct net_if *iface, struct net_pkt *pkt)
 
 	if (feed_data) {
 		DBG("Received at iface %p and feeding it into iface %p\n",
-		    iface, recipient);
+		    net_pkt_iface(pkt), recipient);
 
+		net_pkt_ref(pkt);
 		if (net_recv_data(recipient, pkt) < 0) {
 			TC_ERROR("Data receive failed.");
 			net_pkt_unref(pkt);
 			test_failed = true;
 		}
 
-		k_sem_give(&wait_data);
-
-		return 0;
+		goto out;
 	}
 
 	DBG("pkt %p to be sent len %lu\n", pkt, net_pkt_get_len(pkt));
-
-	net_pkt_unref(pkt);
 
 	if (data_failure) {
 		test_failed = true;
 	}
 
 	msg_sending = 0;
-
+out:
 	k_sem_give(&wait_data);
 
 	return 0;
@@ -207,13 +203,13 @@ static int tester_send_peer(struct net_if *iface, struct net_pkt *pkt)
 struct net_route_test net_route_data;
 struct net_route_test net_route_data_peer;
 
-static struct net_if_api net_route_if_api = {
-	.init = net_route_iface_init,
+static struct dummy_api net_route_if_api = {
+	.iface_api.init = net_route_iface_init,
 	.send = tester_send,
 };
 
-static struct net_if_api net_route_if_api_peer = {
-	.init = net_route_iface_init,
+static struct dummy_api net_route_if_api_peer = {
+	.iface_api.init = net_route_iface_init,
 	.send = tester_send_peer,
 };
 

--- a/tests/net/tcp/src/main.c
+++ b/tests/net/tcp/src/main.c
@@ -24,6 +24,7 @@
 #include <net/net_pkt.h>
 #include <net/net_ip.h>
 #include <net/tcp.h>
+#include <net/dummy.h>
 
 #include <tc_util.h>
 
@@ -95,8 +96,9 @@ static void net_tcp_iface_init(struct net_if *iface)
 	return;
 }
 
-static void v6_send_syn_ack(struct net_if *iface, struct net_pkt *req)
+static void v6_send_syn_ack(struct net_pkt *req)
 {
+	struct net_if *iface = net_pkt_iface(req);
 	struct net_pkt *rsp = NULL;
 	int ret;
 
@@ -138,7 +140,7 @@ static void v6_send_syn_ack(struct net_if *iface, struct net_pkt *req)
 
 static int send_status = -EINVAL;
 
-static int tester_send(struct net_if *iface, struct net_pkt *pkt)
+static int tester_send(struct device *dev, struct net_pkt *pkt)
 {
 	if (!pkt->frags) {
 		DBG("No data to send!\n");
@@ -147,17 +149,15 @@ static int tester_send(struct net_if *iface, struct net_pkt *pkt)
 	if (syn_v6_sent && net_pkt_family(pkt) == AF_INET6) {
 		DBG("v6 SYN was sent successfully\n");
 		syn_v6_sent = false;
-		v6_send_syn_ack(iface, pkt);
+		v6_send_syn_ack(pkt);
 	}
-
-	net_pkt_unref(pkt);
 
 	send_status = 0;
 
 	return 0;
 }
 
-static int tester_send_peer(struct net_if *iface, struct net_pkt *pkt)
+static int tester_send_peer(struct device *dev, struct net_pkt *pkt)
 {
 	if (!pkt->frags) {
 		DBG("No data to send!\n");
@@ -165,8 +165,6 @@ static int tester_send_peer(struct net_if *iface, struct net_pkt *pkt)
 	}
 
 	DBG("Peer data was sent successfully\n");
-
-	net_pkt_unref(pkt);
 
 	return 0;
 }
@@ -1308,13 +1306,13 @@ static bool test_create_v6_data_packet(void)
 struct net_tcp_context net_tcp_context_data;
 struct net_tcp_context net_tcp_context_data_peer;
 
-static struct net_if_api net_tcp_if_api = {
-	.init = net_tcp_iface_init,
+static struct dummy_api net_tcp_if_api = {
+	.iface_api.init = net_tcp_iface_init,
 	.send = tester_send,
 };
 
-static struct net_if_api net_tcp_if_api_peer = {
-	.init = net_tcp_iface_init,
+static struct dummy_api net_tcp_if_api_peer = {
+	.iface_api.init = net_tcp_iface_init,
 	.send = tester_send_peer,
 };
 
@@ -1660,7 +1658,7 @@ static bool test_init(void)
 {
 	struct net_if *iface = net_if_get_default();
 	struct net_if_addr *ifaddr;
-	const struct net_if_api *api;
+	const struct dummy_api *api;
 
 	if (!iface) {
 		TC_ERROR("Interface is NULL\n");

--- a/tests/net/tx_timestamp/src/main.c
+++ b/tests/net/tx_timestamp/src/main.c
@@ -23,6 +23,7 @@
 #include <net/net_ip.h>
 #include <net/net_pkt.h>
 #include <net/ethernet.h>
+#include <net/dummy.h>
 #include <net/net_l2.h>
 
 #include "ipv6.h"
@@ -94,7 +95,7 @@ static void eth_iface_init(struct net_if *iface)
 	ethernet_init(iface);
 }
 
-static int eth_tx(struct net_if *iface, struct net_pkt *pkt)
+static int eth_tx(struct device *dev, struct net_pkt *pkt)
 {
 	if (!pkt->frags) {
 		DBG("No data to send!\n");
@@ -112,7 +113,6 @@ static int eth_tx(struct net_if *iface, struct net_pkt *pkt)
 		}
 	}
 
-	net_pkt_unref(pkt);
 	test_started = false;
 
 	return 0;
@@ -125,9 +125,9 @@ static enum ethernet_hw_caps eth_get_capabilities(struct device *dev)
 
 static struct ethernet_api api_funcs = {
 	.iface_api.init = eth_iface_init,
-	.iface_api.send = eth_tx,
 
 	.get_capabilities = eth_get_capabilities,
+	.send = eth_tx,
 };
 
 static void generate_mac(u8_t *mac_addr)

--- a/tests/net/udp/src/main.c
+++ b/tests/net/udp/src/main.c
@@ -25,6 +25,7 @@
 #include <net/net_pkt.h>
 #include <net/net_ip.h>
 #include <net/ethernet.h>
+#include <net/dummy.h>
 #include <net/udp.h>
 
 #include <ztest.h>
@@ -87,7 +88,7 @@ static void net_udp_iface_init(struct net_if *iface)
 
 static int send_status = -EINVAL;
 
-static int tester_send(struct net_if *iface, struct net_pkt *pkt)
+static int tester_send(struct device *dev, struct net_pkt *pkt)
 {
 	if (!pkt->frags) {
 		DBG("No data to send!\n");
@@ -95,8 +96,6 @@ static int tester_send(struct net_if *iface, struct net_pkt *pkt)
 	}
 
 	DBG("Data was sent successfully\n");
-
-	net_pkt_unref(pkt);
 
 	send_status = 0;
 
@@ -123,8 +122,8 @@ static inline struct in_addr *if_get_addr(struct net_if *iface)
 
 struct net_udp_context net_udp_context_data;
 
-static struct net_if_api net_udp_if_api = {
-	.init = net_udp_iface_init,
+static struct dummy_api net_udp_if_api = {
+	.iface_api.init = net_udp_iface_init,
 	.send = tester_send,
 };
 

--- a/tests/net/vlan/src/main.c
+++ b/tests/net/vlan/src/main.c
@@ -20,6 +20,7 @@
 #include <ztest.h>
 
 #include <net/ethernet.h>
+#include <net/dummy.h>
 #include <net/buf.h>
 #include <net/net_ip.h>
 #include <net/ethernet_vlan.h>
@@ -102,9 +103,9 @@ static void eth_vlan_iface_init(struct net_if *iface)
 	ethernet_init(iface);
 }
 
-static int eth_tx(struct net_if *iface, struct net_pkt *pkt)
+static int eth_tx(struct device *dev, struct net_pkt *pkt)
 {
-	struct eth_context *context = net_if_get_device(iface)->driver_data;
+	struct eth_context *context = dev->driver_data;
 
 	zassert_equal_ptr(&eth_vlan_context, context,
 			  "Context pointers do not match (%p vs %p)",
@@ -132,8 +133,6 @@ static int eth_tx(struct net_if *iface, struct net_pkt *pkt)
 		k_sem_give(&wait_data);
 	}
 
-	net_pkt_unref(pkt);
-
 	return 0;
 }
 
@@ -144,9 +143,9 @@ static enum ethernet_hw_caps eth_capabilities(struct device *dev)
 
 static struct ethernet_api api_funcs = {
 	.iface_api.init = eth_vlan_iface_init,
-	.iface_api.send = eth_tx,
 
 	.get_capabilities = eth_capabilities,
+	.send = eth_tx,
 };
 
 static void generate_mac(u8_t *mac_addr)
@@ -229,18 +228,16 @@ static void net_iface_init(struct net_if *iface)
 			     NET_LINK_ETHERNET);
 }
 
-static int sender_iface(struct net_if *iface, struct net_pkt *pkt)
+static int sender_iface(struct device *dev, struct net_pkt *pkt)
 {
-	net_pkt_unref(pkt);
-
 	return 0;
 }
 
 struct net_if_test net_iface1_data;
 struct net_if_test net_iface2_data;
 
-static struct net_if_api net_iface_api = {
-	.init = net_iface_init,
+static struct dummy_api net_iface_api = {
+	.iface_api.init = net_iface_init,
 	.send = sender_iface,
 };
 


### PR DESCRIPTION
Changing the way packet are sent: instead of going like net_if_send_data -> l2 send -> net_if tx queue -> net_if_tx -> driver send
it will be now:
net_if_send _data -> net_if tx queue -> net_if_tx ->  l2 send ->  driver send

This will enable removing ll reserve from l2 as well as doing interesting optimization in L2 side.

- Now L2 is responsible for unrefing the packet on success. (net_if still keeps that responsibility in case of error) so drivers do not have to care about it.

- l2 send does not return a verdict, but a int: 0+ (lenght of sent packet) on succes, negative errno otherwise.

- driver API have to provide their own send/tx function, relatively to their respective L2. There is no more the net_if_api send function. That will permit l2 to have whatever signature they need for that function (15.4 has done so for quite a while, but it was thus a hack).

@tgorochowik Could you check if the sam gmac driver still works fine? It's a bit different in there, as it queues tx pkt. I hope I did not break it.
@Vudentz It was relatively simple in bt L2 to do the change, but I could not test it. I believe it's fine though.


All of this is part of the preliminary work to revise net_pkt buffer management totally.