### PR TITLE
linker: riscv: Disable creating ROM domain by config option.

### DIFF
--- a/include/arch/riscv32/common/linker.ld
+++ b/include/arch/riscv32/common/linker.ld
@@ -35,7 +35,9 @@
 
 MEMORY
 {
+#ifdef CONFIG_XIP
     ROM (rx)  : ORIGIN = CONFIG_RISCV_ROM_BASE_ADDR, LENGTH = CONFIG_RISCV_ROM_SIZE
+#endif
     RAM (rwx) : ORIGIN = CONFIG_RISCV_RAM_BASE_ADDR, LENGTH = RISCV_RAM_SIZE
     /* Used by and documented in include/linker/intlist.ld */
     IDT_LIST  (wx)      : ORIGIN = 0xFFFFF7FF, LENGTH = 2K
@@ -62,18 +64,14 @@ SECTIONS
 		*(.iplt)
 	}
 
-    GROUP_START(ROM)
+    GROUP_START(ROMABLE_REGION)
     _image_rom_start = .;
 
     SECTION_PROLOGUE(_VECTOR_SECTION_NAME,,)
     {
 		. = ALIGN(4);
 		KEEP(*(.vectors.*))
-    } GROUP_LINK_IN(ROM)
-
-    GROUP_END(ROM)
-
-    GROUP_START(ROMABLE_REGION)
+    } GROUP_LINK_IN(ROMABLE_REGION)
 
     SECTION_PROLOGUE(_RESET_SECTION_NAME,,)
     {


### PR DESCRIPTION
Patch is useful for RISCV platforms which can not provide ROM memory.
Switching CONFIG_XIP to "n" disables allocating ROM region.

Signed-off-by: Vitaly Gaiduk <vitaly.gaiduk@cloudbear.ru>