### PR TITLE
driver: ethernet: e1000: Use correct return for device init()

### DIFF
--- a/drivers/ethernet/eth_e1000.c
+++ b/drivers/ethernet/eth_e1000.c
@@ -165,10 +165,10 @@ int e1000_probe(struct device *device)
 
 		pci_show(&dev->pci);
 
-		found = true;
+		return 0;
 	}
 
-	return found;
+	return -ENODEV;
 }
 
 static struct device DEVICE_NAME_GET(eth_e1000);


### PR DESCRIPTION
In case of successful detection, return 0. Otherwise, return -ENODEV
error.

Signed-off-by: Paul Sokolovsky <paul.sokolovsky@linaro.org>