### PR TITLE
sanitycheck: Support legacy variant 'gccarmemb'

### DIFF
--- a/scripts/sanitycheck
+++ b/scripts/sanitycheck
@@ -1705,6 +1705,9 @@ class TestSuite:
         toolchain = os.environ.get("ZEPHYR_TOOLCHAIN_VARIANT", None) or \
                     os.environ.get("ZEPHYR_GCC_VARIANT", None)
 
+        if toolchain == "gccarmemb":
+            # Remove this translation when gccarmemb is no longer supported.
+            toolchain = "gnuarmemb"
 
         try:
             if not toolchain:


### PR DESCRIPTION
CMake will translate from the toolchain variant 'gccarmemb' to
'gnuarmemb', but sanitycheck does not. This causes inconsistent and
therefore confusing behaviour between CMake and sanitycheck.

Until gccarmemb is dropped support for, do the same translation with
sanitycheck.

Signed-off-by: Sebastian Bøe <sebastian.boe@nordicsemi.no>