### PR TITLE
boards: yaml: Use corrrect toolchain name

### DIFF
--- a/boards/arm/efm32hg_slstk3400a/efm32hg_slstk3400a.yaml
+++ b/boards/arm/efm32hg_slstk3400a/efm32hg_slstk3400a.yaml
@@ -6,7 +6,7 @@ ram: 8
 flash: 64
 toolchain:
   - zephyr
-  - gccarmemb
+  - gnuarmemb
 supported:
   - gpio
 testing:

--- a/boards/arm/nucleo_l4r5zi/nucleo_l4r5zi.yaml
+++ b/boards/arm/nucleo_l4r5zi/nucleo_l4r5zi.yaml
@@ -4,7 +4,7 @@ type: mcu
 arch: arm
 toolchain:
   - zephyr
-  - gccarmemb
+  - gnuarmemb
 supported:
   - pwm
   - spi


### PR DESCRIPTION
Use the name 'gnuarmemb' instead of 'gccarmemb' when declaring
toolchain compatibility.

Signed-off-by: Sebastian Bøe <sebastian.boe@nordicsemi.no>