### PR TITLE
boards: cc3220sf: Fix compatibility issue with gnuarmemb

### DIFF
--- a/drivers/wifi/simplelink/CMakeLists.txt
+++ b/drivers/wifi/simplelink/CMakeLists.txt
@@ -4,7 +4,6 @@ if(CONFIG_WIFI_SIMPLELINK)
     $ENV{ZEPHYR_BASE}/ext/hal/ti/simplelink/kernel/zephyr/dpl
     $ENV{ZEPHYR_BASE}/ext/hal/ti/simplelink/source
     $ENV{ZEPHYR_BASE}/ext/hal/ti/simplelink/source/ti/drivers/net/wifi/porting
-    $ENV{ZEPHYR_BASE}/ext/hal/ti/simplelink/source/ti/drivers/net/wifi/bsd
     )
   zephyr_sources(
     simplelink_support.c


### PR DESCRIPTION
The cc3220sf_launchxl board is AFAICT not compatible with the
toolchain variant 'gnuarmemb'. To avoid triggering CI failures we
remove this compatibility declaration from the metadata.

Signed-off-by: Sebastian Bøe <sebastian.boe@nordicsemi.no>