### PR TITLE
Set name of all system threads (for debugging)

### DIFF
--- a/kernel/system_work_q.c
+++ b/kernel/system_work_q.c
@@ -26,6 +26,7 @@ static int k_sys_work_q_init(struct device *dev)
 		       sys_work_q_stack,
 		       K_THREAD_STACK_SIZEOF(sys_work_q_stack),
 		       CONFIG_SYSTEM_WORKQUEUE_PRIORITY);
+	k_thread_name_set(&k_sys_work_q.thread, "sysworkq");
 
 	return 0;
 }

--- a/subsys/net/ip/net_if.c
+++ b/subsys/net/ip/net_if.c
@@ -2957,6 +2957,7 @@ void net_if_init(void)
 			K_THREAD_STACK_SIZEOF(tx_ts_stack),
 			(k_thread_entry_t)net_tx_ts_thread,
 			NULL, NULL, NULL, K_PRIO_COOP(1), 0, 0);
+	k_thread_name_set(&tx_thread_ts, "tx_tstamp");
 #endif /* CONFIG_NET_PKT_TIMESTAMP */
 
 #if defined(CONFIG_NET_VLAN)

--- a/subsys/net/ip/net_mgmt.c
+++ b/subsys/net/ip/net_mgmt.c
@@ -381,6 +381,7 @@ void net_mgmt_event_init(void)
 			K_THREAD_STACK_SIZEOF(mgmt_stack),
 			(k_thread_entry_t)mgmt_thread, NULL, NULL, NULL,
 			K_PRIO_COOP(CONFIG_NET_MGMT_EVENT_THREAD_PRIO), 0, 0);
+	k_thread_name_set(&mgmt_thread_data, "net_mgmt");
 
 	NET_DBG("Net MGMT initialized: queue of %u entries, stack size of %u",
 		CONFIG_NET_MGMT_EVENT_QUEUE_SIZE,

--- a/subsys/net/ip/net_tc.c
+++ b/subsys/net/ip/net_tc.c
@@ -257,6 +257,7 @@ void net_tc_tx_init(void)
 			       tx_stack[i],
 			       K_THREAD_STACK_SIZEOF(tx_stack[i]),
 			       K_PRIO_COOP(thread_priority));
+		k_thread_name_set(&tx_classes[i].work_q.thread, "tx_workq");
 	}
 }
 
@@ -295,5 +296,6 @@ void net_tc_rx_init(void)
 			       rx_stack[i],
 			       K_THREAD_STACK_SIZEOF(rx_stack[i]),
 			       K_PRIO_COOP(thread_priority));
+		k_thread_name_set(&rx_classes[i].work_q.thread, "rx_workq");
 	}
 }

--- a/subsys/net/l2/ethernet/gptp/gptp.c
+++ b/subsys/net/l2/ethernet/gptp/gptp.c
@@ -900,6 +900,7 @@ static void init_ports(void)
 			      K_THREAD_STACK_SIZEOF(gptp_stack),
 			      (k_thread_entry_t)gptp_thread,
 			      NULL, NULL, NULL, K_PRIO_COOP(5), 0, 0);
+	k_thread_name_set(&gptp_thread_data, "gptp");
 }
 
 #if defined(CONFIG_NET_GPTP_VLAN)

--- a/subsys/net/l2/openthread/openthread.c
+++ b/subsys/net/l2/openthread/openthread.c
@@ -336,6 +336,7 @@ static int openthread_init(struct net_if *iface)
 				 openthread_process,
 				 ot_context, NULL, NULL,
 				 OT_PRIORITY, 0, K_NO_WAIT);
+	k_thread_name_set(&ot_thread_data, "openthread");
 
 	return 0;
 }

--- a/subsys/net/lib/lwm2m/lwm2m_engine.c
+++ b/subsys/net/lib/lwm2m/lwm2m_engine.c
@@ -4043,6 +4043,8 @@ static int lwm2m_engine_init(struct device *dev)
 			/* Lowest priority cooperative thread */
 			K_PRIO_COOP(CONFIG_NUM_COOP_PRIORITIES - 1),
 			0, K_NO_WAIT);
+	k_thread_name_set(&engine_thread_data, "lwm2m");
+
 	LOG_DBG("LWM2M engine thread started");
 	return 0;
 }


### PR DESCRIPTION
~~~

net: Set names for threads used by the network stack

Previously, these either used generic names like "workqueue" (so,
it wasn't possible to distiguish tx and rx workqueues) or didn't
set for net management thread. Here's an example of thread dump
in a typical system (using stack_analyze() call):

rx_workq (real size 4092):	unused 3696	usage 396 / 4092 (9 %)
tx_workq (real size 4092):	unused 3692	usage 400 / 4092 (9 %)
net_mgmt (real size 4092):	unused 3772	usage 320 / 4092 (7 %)
sysworkq (real size 4092):	unused 3512	usage 580 / 4092 (14 %)
idle (real size 252):	unused 64	usage 188 / 252 (74 %)
main (real size 4732):	unused 3672	usage 1060 / 4732 (22 %)

Signed-off-by: Paul Sokolovsky <paul.sokolovsky@linaro.org>
~~~