### PR TITLE
tests: fatal: fix condition for NXP MPU

### DIFF
--- a/tests/kernel/fatal/src/main.c
+++ b/tests/kernel/fatal/src/main.c
@@ -248,7 +248,7 @@ void test_fatal(void)
 			(k_thread_entry_t)stack_thread2,
 			NULL, NULL, NULL, K_PRIO_PREEMPT(PRIORITY), 0,
 			K_NO_WAIT);
-#ifdef CPU_HAS_NXP_MPU
+#ifdef CONFIG_CPU_HAS_NXP_MPU
 	/* FIXME: See #7706 */
 	zassert_true(crash_reason == _NANO_ERR_STACK_CHK_FAIL ||
 		     crash_reason == _NANO_ERR_HW_EXCEPTION, NULL);


### PR DESCRIPTION
Fixed condition and wrong Kconfig name, shoud be CONFIG_CPU_HAS_NXP_MPU
instead of only CPU_HAS_NXP_MPU.

Signed-off-by: Anas Nashif <anas.nashif@intel.com>