### PR TITLE
lib: posix: Return errno code

### DIFF
--- a/lib/posix/semaphore.c
+++ b/lib/posix/semaphore.c
@@ -35,7 +35,13 @@ int sem_destroy(sem_t *semaphore)
  */
 int sem_getvalue(sem_t *semaphore, int *value)
 {
+	if (semaphore == NULL) {
+		errno = EINVAL;
+		return -1;
+	}
+
 	*value = (int) k_sem_count_get(semaphore);
+
 	return 0;
 }
 /**


### PR DESCRIPTION
Return EINVAL errno when argument doesn't refer to
valid semaphore.

partly fixes #9993

Signed-off-by: Punit Vara <punit.vara@intel.com>