### PR TITLE
drivers: eth: e1000: Remove unused variable

### DIFF
--- a/drivers/ethernet/eth_e1000.c
+++ b/drivers/ethernet/eth_e1000.c
@@ -153,7 +153,6 @@ static void e1000_isr(struct device *device)
 int e1000_probe(struct device *device)
 {
 	struct e1000_dev *dev = device->driver_data;
-	bool found = false;
 
 	pci_bus_scan_init();
 


### PR DESCRIPTION
The probe function had unused variable which caused compile warning.

Signed-off-by: Jukka Rissanen <jukka.rissanen@linux.intel.com>