### PR TITLE
logging: fix out of bounds write in log_strdup

### DIFF
--- a/subsys/logging/log_core.c
+++ b/subsys/logging/log_core.c
@@ -21,7 +21,7 @@
 	(CONFIG_LOG_STRDUP_MAX_STRING + 1) /* additional byte for termination */
 
 #define LOG_STRBUF_BUF_SIZE \
-	ROUND_UP(LOG_STRBUF_STR_SIZE + 1, sizeof(u32_t))
+	ROUND_UP(LOG_STRBUF_STR_SIZE + sizeof(u32_t), sizeof(u32_t))
 
 #define LOG_STRDUP_POOL_BUFFER_SIZE \
 	(LOG_STRBUF_BUF_SIZE * CONFIG_LOG_STRDUP_BUF_COUNT)


### PR DESCRIPTION
log_strdup writes out of bounds of a strdup slab.
e.g: CONFIG_LOG_STRDUP_MAX_STRING=46 and
     LOG_STRBUF_STR_SIZE=47 then in the line L:529
sdupl[LOG_STRBUF_STR_SIZE - 1] = '\0';
writes out of bounds because the available buffer space
is only 44 bytes (rounded up to 48 bytes and minus 4 bytes
for the allocated flag).
