### PR TITLE
uncrustify: Add a rule to remove space inside function argument

### DIFF
--- a/.uncrustify.cfg
+++ b/.uncrustify.cfg
@@ -50,6 +50,7 @@ sp_after_comma      = add
 sp_func_def_paren   = remove    # "int foo (){" vs "int foo(){"
 sp_func_call_paren  = remove    # "foo (" vs "foo("
 sp_func_proto_paren = remove    # "int foo ();" vs "int foo();"
+sp_inside_fparen    = remove    # "func( arg )" vs "func(arg)"
 sp_else_brace       = add       # ignore/add/remove/force
 sp_before_ptr_star  = add       # ignore/add/remove/force
 sp_after_ptr_star   = remove    # ignore/add/remove/force


### PR DESCRIPTION
Our code base doesn't have spaces both after the opening parenthesis
and the closing parenthesis.  "func( arg )" vs "func(arg)".

This patch adds the rule to remove the spaces.