### PR TITLE
cmake: Fix 'run' command of native_posix

### DIFF
--- a/cmake/emu/native.cmake
+++ b/cmake/emu/native.cmake
@@ -1,6 +1,7 @@
 add_custom_target(run
   COMMAND
   ${APPLICATION_BINARY_DIR}/zephyr/${KERNEL_EXE_NAME}
+  DEPENDS ${logical_target_for_zephyr_elf}
   WORKING_DIRECTORY ${APPLICATION_BINARY_DIR}
   USES_TERMINAL
   )


### PR DESCRIPTION
The 'run' target was missing it's dependency on the executable and
thereby behaving incorrectly.

This fixes #10639 .

Signed-off-by: Sebastian Bøe <sebastian.boe@nordicsemi.no>