### PR TITLE
Docs: don't copy files twice

### DIFF
--- a/doc/CMakeLists.txt
+++ b/doc/CMakeLists.txt
@@ -74,22 +74,33 @@ set(CONTENT_OUTPUTS ${CMAKE_CURRENT_BINARY_DIR}/extracted-content.txt)
 
 configure_file(${DOXYFILE_IN} ${DOXYFILE_OUT} @ONLY)
 
-# This command is used to copy all documentation source files into the
-# build directory. Sphinx requires a single documentation root, but
-# Zephyr's documentation is scattered around the tree in samples/,
-# boards/, and doc/, so we need to copy those files into a single
-# place in the build directory.
+# This command is used to find all documentation source files so they
+# can be copied into the build directory, and the copies can be
+# properly tracked by CMake as built files.
+#
+# We need to make copies because Sphinx requires a single
+# documentation root directory, but Zephyr's documentation is
+# scattered around the tree in samples/, boards/, and doc/. Putting
+# them into a single rooted tree in the build directory is a
+# workaround for this limitation.
+#
+# This command does NOT cause the content files to be copied; we leave
+# that up to an add_custom_command() below. (Ninja will copy them during
+# the first build regardless of if they exist already or not, so
+# --just-outputs means the copy only happens once. The build system
+# has to know about the relationship between sources and copies to
+# track dependencies properly, for the "clean" target, etc.)
 set(EXTRACT_CONTENT_COMMAND
   ${CMAKE_COMMAND} -E env
   ${PYTHON_EXECUTABLE} scripts/extract_content.py
-  # Save the outputs for processing by this list file.
-  --outputs ${CONTENT_OUTPUTS}
+  # Just save the outputs for processing by this list file.
+  --outputs ${CONTENT_OUTPUTS} --just-outputs
   # Ignore any files in the output directory.
   --ignore ${CMAKE_CURRENT_BINARY_DIR}
   # Copy all files in doc to the rst folder.
   "*:doc:${RST_OUT}"
-  # Copy the .rst files in samples/ and boards/ to the rst folder, and
-  # also the doc folder inside rst.
+  # We want to copy the .rst files in samples/ and boards/ to the rst
+  # folder, and also the doc folder inside rst.
   #
   # Some files refer to items in samples/ and boards/ relative to
   # their actual position in the Zephyr tree. For example, in
@@ -97,15 +108,13 @@ set(EXTRACT_CONTENT_COMMAND
   #
   # .. literalinclude:: ../../samples/sensor/mcp9808/src/main.c
   #
-  # We make an additional copy as a hackaround so these references
-  # work.
+  # The additional copy is a hackaround so these references work.
   "*.rst:samples:${RST_OUT}" "*.rst:boards:${RST_OUT}"
   "*.rst:samples:${RST_OUT}/doc" "*.rst:boards:${RST_OUT}/doc")
 
 # Run the content extraction command at configure time in order to
 # produce lists of input and output files, which are respectively its
-# dependencies and outputs. This also causes the content files
-# to be copied for the first time.
+# dependencies and outputs.
 execute_process(
   COMMAND ${EXTRACT_CONTENT_COMMAND}
   WORKING_DIRECTORY ${CMAKE_CURRENT_LIST_DIR}

--- a/doc/README.rst
+++ b/doc/README.rst
@@ -109,6 +109,17 @@ folder, here are the commands to generate the html content locally:
    # To generate PDF output, run ninja on the generated build system:
    ninja pdfdocs
 
+.. warning::
+
+   The documentation build system creates copies in the build
+   directory of every .rst file used to generate the documentation,
+   along with dependencies referenced by those .rst files.
+
+   This means that Sphinx warnings and errors refer to the **copies**,
+   and **not the version-controlled original files in Zephyr**. Be
+   careful to make sure you don't accidentally edit the copy of the
+   file in an error message, as these changes will not be saved.
+
 Depending on your development system, it will take up to 15 minutes to
 collect and generate the HTML content.  When done, you can view the HTML
 output with your browser started at ``doc/_build/html/index.html`` and

--- a/doc/scripts/extract_content.py
+++ b/doc/scripts/extract_content.py
@@ -162,6 +162,9 @@ def main():
 
     parser.add_argument('--outputs',
                         help='If given, save input/output files to this path')
+    parser.add_argument('--just-outputs', action='store_true',
+                        help='''Skip extraction and just list outputs.
+                        Cannot be given without --outputs.''')
     parser.add_argument('--ignore', action='append',
                         help='''Source directories to ignore when copying
                         files. This may be given multiple times.''')
@@ -182,11 +185,15 @@ def main():
     else:
         ignore = tuple(path.normpath(ign) for ign in args.ignore)
 
+    if args.just_outputs and not args.outputs:
+        sys.exit('--just-outputs cannot be given without --outputs')
+
     content_config = [cfg.split(':', 2) for cfg in args.content_config]
     outputs = set()
     for fnfilter, source, dest in content_config:
         content = find_content(zephyr_base, source, dest, fnfilter, ignore)
-        extract_content(content)
+        if not args.just_outputs:
+            extract_content(content)
         outputs |= set(content.outputs)
     if args.outputs:
         with open(args.outputs, 'w') as f:


### PR DESCRIPTION
@carlescufi reported that recent changes to the documentation build system were resulting in files being copied twice (once by extract_content.py, and again by the ninja targets for each copy). Avoid this.

Reading the ninja docs, it looks like it tracks the actual commands used to build a file in .ninja_log, and will rebuild if the command line changed regardless of mtime. In a clean build, there is no log, so it seems ninja is forced to run the copy command.

Tack on a warning in the doc readme about editing the copies in the build directory.