### PR TITLE
build: do not rename elf file, copy it

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1216,7 +1216,7 @@ list_append_ifdef(
 list_append_ifdef(
   CONFIG_BUILD_OUTPUT_EXE
   post_build_commands
-  COMMAND ${CMAKE_COMMAND} -E rename ${KERNEL_ELF_NAME}    ${KERNEL_EXE_NAME}
+  COMMAND ${CMAKE_COMMAND} -E copy ${KERNEL_ELF_NAME}    ${KERNEL_EXE_NAME}
   )
 
 add_custom_command(


### PR DESCRIPTION
We break dependency if we rename the zephyr.elf file, we should keep it
as it is an essential dependency in the build system. Instead, copy the
file.

Fixes #10639

Signed-off-by: Anas Nashif <anas.nashif@intel.com>