### PR TITLE
dts: yaml: remove unused id field

### DIFF
--- a/dts/bindings/display/solomon,ssd1306fb-i2c.yaml
+++ b/dts/bindings/display/solomon,ssd1306fb-i2c.yaml
@@ -5,7 +5,6 @@
 #
 ---
 title: SSD1306 128x64 Dot Matrix Display Controller
-id: solomon,ssd1306fb-i2c
 version: 0.1
 
 description: >

--- a/dts/bindings/display/solomon,ssd1673fb.yaml
+++ b/dts/bindings/display/solomon,ssd1673fb.yaml
@@ -5,7 +5,6 @@
 #
 ---
 title: SSD1673 250x150 EPD Display Controller
-id: solomon,ssd1673fb-spi
 version: 0.1
 
 description: >

--- a/dts/bindings/sensor/meas,ms5837.yaml
+++ b/dts/bindings/sensor/meas,ms5837.yaml
@@ -5,7 +5,6 @@
 #
 ---
 title: TE Connectivity digital pressure sensor MS5837
-id: meas,ms5837
 version: 0.1
 
 description: >

--- a/dts/bindings/sensor/st,lis2mdl-magn.yaml
+++ b/dts/bindings/sensor/st,lis2mdl-magn.yaml
@@ -5,7 +5,6 @@
 #
 ---
 title: STMicroelectronics MEMS sensors LIS2MDL
-id: st,lis2mdl-magn
 version: 0.1
 
 description: >

--- a/dts/bindings/sensor/st,lsm303dlhc-accel.yaml
+++ b/dts/bindings/sensor/st,lsm303dlhc-accel.yaml
@@ -5,7 +5,6 @@
 #
 ---
 title: STMicroelectronics MEMS sensors LSM303DLHC
-id: st,lsm303dlhc-accel
 version: 0.1
 
 description: >

--- a/dts/bindings/sensor/st,lsm303dlhc-magn.yaml
+++ b/dts/bindings/sensor/st,lsm303dlhc-magn.yaml
@@ -5,7 +5,6 @@
 #
 ---
 title: STMicroelectronics MEMS sensors LSM303DLHC
-id: st,lsm303dlhc-magn
 version: 0.1
 
 description: >

--- a/dts/bindings/watchdog/intel,qmsi-watchdog.yaml
+++ b/dts/bindings/watchdog/intel,qmsi-watchdog.yaml
@@ -5,7 +5,6 @@
 #
 ---
 title: QMSI watchdog driver
-id: intel,qmsi-watchdog
 version: 0.1
 
 description: >


### PR DESCRIPTION
Some new yaml bindings that got committed added back in the 'id:' field
which we have removed.  Remove it from those dts binding files.

Signed-off-by: Kumar Gala <kumar.gala@linaro.org>