### PR TITLE
tests: interrupt: disable riscv32

### DIFF
--- a/tests/kernel/interrupt/testcase.yaml
+++ b/tests/kernel/interrupt/testcase.yaml
@@ -1,4 +1,4 @@
 tests:
   arch.interrupt:
-    arch_exclude: nios2
+    arch_exclude: nios2 riscv32
     tags: interrupt


### PR DESCRIPTION
This is a new test and we have riscv32 failing on that all of the
sudden. Disabling while we look into it and identify if that is a
testcase issue or not.

Signed-off-by: Anas Nashif <anas.nashif@intel.com>