### PR TITLE
scripts: extract_dts_includes: Read files as utf-8

### DIFF
--- a/scripts/dts/extract_dts_includes.py
+++ b/scripts/dts/extract_dts_includes.py
@@ -62,14 +62,14 @@ class Bindings(yaml.Loader):
         yaml_list = {}
         file_load_list = set()
         for file in cls._files:
-            for line in open(file, 'r'):
+            for line in open(file, 'r', encoding='utf-8'):
                 if re.search('^\s+constraint:*', line):
                     c = line.split(':')[1].strip()
                     c = c.strip('"')
                     if c in s:
                         if file not in file_load_list:
                             file_load_list.add(file)
-                            with open(file, 'r') as yf:
+                            with open(file, 'r', encoding='utf-8') as yf:
                                 cls._included = []
                                 yaml_list[c] = yaml.load(yf, cls)
         return yaml_list
@@ -122,7 +122,7 @@ class Bindings(yaml.Loader):
                       format(filename), filepaths)
                 raise yaml.constructor.ConstructorError
             filepaths = files
-        with open(filepaths[0], 'r') as f:
+        with open(filepaths[0], 'r', encoding='utf-8') as f:
             return yaml.load(f, Bindings)
 
 
@@ -615,7 +615,7 @@ def output_include_lines(fd, fixups):
                 fd.write(
                     "/* Following definitions fixup the generated include */\n")
                 try:
-                    with open(fixup, "r") as fixup_fd:
+                    with open(fixup, "r", encoding="utf-8") as fixup_fd:
                         for line in fixup_fd.readlines():
                             fd.write(line)
                         fd.write("\n")
@@ -633,7 +633,7 @@ def generate_include_file(inc_file, fixups):
 
 
 def load_and_parse_dts(dts_file):
-    with open(dts_file, "r") as fd:
+    with open(dts_file, "r", encoding="utf-8") as fd:
         dts = parse_file(fd)
 
     return dts


### PR DESCRIPTION
Python's open() by default using "system character encoding", which
may vary from system to system (e.g. LOCALE=C aka "ascii" on bare-OS
systems, something on Windows, etc.). But Zephyr files are utf-8, so
read them as such, by explicitly specifying encoding.

This is similar to changes earlier done to another script in 94620bd.

Signed-off-by: Paul Sokolovsky <paul.sokolovsky@linaro.org>