### PR TITLE
Bluetooth: host: Improve error feedback on invalid input

### DIFF
--- a/subsys/bluetooth/host/hci_core.c
+++ b/subsys/bluetooth/host/hci_core.c
@@ -4734,6 +4734,7 @@ static int set_ad(u16_t hci_op, const struct bt_ad *ad, size_t ad_len)
 				len = 31 - (set_data->len + 2);
 				if (type != BT_DATA_NAME_COMPLETE || !len) {
 					net_buf_unref(buf);
+					BT_ERR("Too big advertising data");
 					return -EINVAL;
 				}
 				type = BT_DATA_NAME_SHORTENED;


### PR DESCRIPTION
Improve the error feedback when calling bt_le_adv_start and inputting
too much data in the advertisement.

Error feedback before:

Bluetooth initialized
Advertising failed to start (err -22)

Error feedback after:

Bluetooth initialized
[bt] [ERR] set_ad: Advertising data does not fit in buffer
Advertising failed to start (err -22)

Signed-off-by: Sebastian Bøe <sebastian.boe@nordicsemi.no>