### PR TITLE
logger: Add a Segger RTT backend

### DIFF
--- a/doc/tools/nordic_segger.rst
+++ b/doc/tools/nordic_segger.rst
@@ -167,6 +167,7 @@ To use RTT, you will first need to enable it by adding the following lines in yo
 .. code-block:: text
 
    CONFIG_HAS_SEGGER_RTT=y
+   CONFIG_USE_SEGGER_RTT=y
    CONFIG_RTT_CONSOLE=y
 
 If you get no RTT output you might need to disable other consoles which conflict

--- a/drivers/console/Kconfig
+++ b/drivers/console/Kconfig
@@ -117,7 +117,7 @@ config RAM_CONSOLE_BUFFER_SIZE
 
 config RTT_CONSOLE
 	bool "Use RTT console"
-	depends on HAS_SEGGER_RTT
+	depends on USE_SEGGER_RTT
 	select CONSOLE_HAS_DRIVER
 	help
 	  Emit console messages to a RAM buffer that is then read by the

--- a/drivers/console/rtt_console.c
+++ b/drivers/console/rtt_console.c
@@ -82,8 +82,6 @@ static int rtt_console_init(struct device *d)
 {
 	ARG_UNUSED(d);
 
-	SEGGER_RTT_Init();
-
 	__printk_hook_install(rtt_console_out);
 	__stdout_hook_install(rtt_console_out);
 

--- a/drivers/console/rtt_console.c
+++ b/drivers/console/rtt_console.c
@@ -36,15 +36,14 @@ static void wait(void)
 
 static int rtt_console_out(int character)
 {
-	unsigned int key;
 	char c = (char)character;
 	unsigned int cnt;
 	int max_cnt = CONFIG_RTT_TX_RETRY_CNT;
 
 	do {
-		key = irq_lock();
+		SEGGER_RTT_LOCK();
 		cnt = SEGGER_RTT_WriteNoLock(0, &c, 1);
-		irq_unlock(key);
+		SEGGER_RTT_UNLOCK();
 
 		/* There are two possible reasons for not writing any data to
 		 * RTT:

--- a/ext/debug/CMakeLists.txt
+++ b/ext/debug/CMakeLists.txt
@@ -1,1 +1,1 @@
-add_subdirectory_ifdef(CONFIG_RTT_CONSOLE segger)
+add_subdirectory(segger)

--- a/ext/debug/segger/CMakeLists.txt
+++ b/ext/debug/segger/CMakeLists.txt
@@ -1,4 +1,7 @@
 
 zephyr_include_directories_ifdef(CONFIG_HAS_SEGGER_RTT .)
-zephyr_sources_ifdef(CONFIG_HAS_SEGGER_RTT rtt/SEGGER_RTT.c)
+zephyr_sources_ifdef(CONFIG_HAS_SEGGER_RTT
+	rtt/SEGGER_RTT.c
+	rtt/SEGGER_RTT_zephyr.c
+	)
 zephyr_sources_ifdef(CONFIG_SEGGER_SYSTEMVIEW systemview/SEGGER_SYSVIEW.c)

--- a/ext/debug/segger/CMakeLists.txt
+++ b/ext/debug/segger/CMakeLists.txt
@@ -1,6 +1,6 @@
 
-zephyr_include_directories_ifdef(CONFIG_HAS_SEGGER_RTT .)
-zephyr_sources_ifdef(CONFIG_HAS_SEGGER_RTT
+zephyr_include_directories_ifdef(CONFIG_USE_SEGGER_RTT .)
+zephyr_sources_ifdef(CONFIG_USE_SEGGER_RTT
 	rtt/SEGGER_RTT.c
 	rtt/SEGGER_RTT_zephyr.c
 	)

--- a/ext/debug/segger/CMakeLists.txt
+++ b/ext/debug/segger/CMakeLists.txt
@@ -1,4 +1,4 @@
 
-zephyr_include_directories(.)
-zephyr_sources_ifdef(CONFIG_RTT_CONSOLE rtt/SEGGER_RTT.c)
+zephyr_include_directories_ifdef(CONFIG_HAS_SEGGER_RTT .)
+zephyr_sources_ifdef(CONFIG_HAS_SEGGER_RTT rtt/SEGGER_RTT.c)
 zephyr_sources_ifdef(CONFIG_SEGGER_SYSTEMVIEW systemview/SEGGER_SYSVIEW.c)

--- a/ext/debug/segger/Kconfig
+++ b/ext/debug/segger/Kconfig
@@ -7,7 +7,16 @@
 config HAS_SEGGER_RTT
 	bool
 
-if HAS_SEGGER_RTT
+config USE_SEGGER_RTT
+    bool "Enable SEGGER RTT libraries."
+    depends on HAS_SEGGER_RTT
+    default n
+    help
+        Enable Segger J-Link RTT libraries for platforms that support it.
+        Selection of this option enable use of RTT for various subsytems.
+        Note that by enabling this option, RTT buffers consumes more RAM.
+
+if USE_SEGGER_RTT
 
 config SEGGER_SYSTEMVIEW
 	bool "Segger SystemView support"

--- a/ext/debug/segger/Kconfig
+++ b/ext/debug/segger/Kconfig
@@ -13,8 +13,8 @@ config USE_SEGGER_RTT
     default n
     help
         Enable Segger J-Link RTT libraries for platforms that support it.
-        Selection of this option enable use of RTT for various subsytems.
-        Note that by enabling this option, RTT buffers consumes more RAM.
+        Selection of this option enables use of RTT for various subsytems.
+        Note that by enabling this option, RTT buffers consume more RAM.
 
 if USE_SEGGER_RTT
 

--- a/ext/debug/segger/Kconfig
+++ b/ext/debug/segger/Kconfig
@@ -8,13 +8,13 @@ config HAS_SEGGER_RTT
 	bool
 
 config USE_SEGGER_RTT
-    bool "Enable SEGGER RTT libraries."
-    depends on HAS_SEGGER_RTT
-    default n
-    help
-        Enable Segger J-Link RTT libraries for platforms that support it.
-        Selection of this option enables use of RTT for various subsytems.
-        Note that by enabling this option, RTT buffers consume more RAM.
+	bool "Enable SEGGER RTT libraries."
+	depends on HAS_SEGGER_RTT
+	default n
+	help
+	  Enable Segger J-Link RTT libraries for platforms that support it.
+	  Selection of this option enables use of RTT for various subsytems.
+	  Note that by enabling this option, RTT buffers consume more RAM.
 
 if USE_SEGGER_RTT
 

--- a/ext/debug/segger/rtt/SEGGER_RTT_Conf.h
+++ b/ext/debug/segger/rtt/SEGGER_RTT_Conf.h
@@ -138,7 +138,12 @@ else
 *       Rowley CrossStudio and GCC
 */
 #if (defined __SES_ARM) || (defined __CROSSWORKS_ARM) || (defined __GNUC__)
-  #ifdef __ARM_ARCH_6M__
+  #ifdef __ZEPHYR__
+    #include <kernel.h>
+    extern struct k_mutex rtt_term_mutex;
+    #define SEGGER_RTT_LOCK() k_mutex_lock(&rtt_term_mutex, K_FOREVER);
+    #define SEGGER_RTT_UNLOCK() k_mutex_unlock(&rtt_term_mutex);
+  #elif __ARM_ARCH_6M__
     #define SEGGER_RTT_LOCK()   {                                                                   \
                                     unsigned int LockState;                                         \
                                   __asm volatile ("mrs   %0, primask  \n\t"                         \

--- a/ext/debug/segger/rtt/SEGGER_RTT_zephyr.c
+++ b/ext/debug/segger/rtt/SEGGER_RTT_zephyr.c
@@ -5,6 +5,8 @@
  */
 
 #include <kernel.h>
+#include <init.h>
+#include "SEGGER_RTT.h"
 
 /*
  * Common mutex for locking access to terminal buffer.
@@ -18,3 +20,12 @@
  */
 
 K_MUTEX_DEFINE(rtt_term_mutex);
+
+static int rtt_init(struct device *unused)
+{
+	ARG_UNUSED(unused);
+
+	SEGGER_RTT_Init();
+}
+
+SYS_INIT(rtt_init, PRE_KERNEL_1, CONFIG_KERNEL_INIT_PRIORITY_OBJECTS);

--- a/ext/debug/segger/rtt/SEGGER_RTT_zephyr.c
+++ b/ext/debug/segger/rtt/SEGGER_RTT_zephyr.c
@@ -1,0 +1,20 @@
+/*
+ * Copyright (c) 2018 omSquare s.r.o.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <kernel.h>
+
+/*
+ * Common mutex for locking access to terminal buffer.
+ * Note that SEGGER uses same lock macros for both SEGGER_RTT_Write and
+ * SEGGER_RTT_Read functions. Because of this we are not able generally
+ * separate up and down access using two mutexes until SEGGER library fix
+ * this.
+ *
+ * If sharing access cause performance problems, consider using another
+ * non terminal buffers.
+ */
+
+K_MUTEX_DEFINE(rtt_term_mutex);

--- a/subsys/logging/CMakeLists.txt
+++ b/subsys/logging/CMakeLists.txt
@@ -23,3 +23,8 @@ zephyr_sources_ifdef(
   CONFIG_LOG_BACKEND_NATIVE_POSIX
   log_backend_native_posix.c
   )
+
+zephyr_sources_ifdef(
+  CONFIG_LOG_BACKEND_RTT
+  log_backend_rtt.c
+)

--- a/subsys/logging/Kconfig
+++ b/subsys/logging/Kconfig
@@ -288,6 +288,66 @@ config LOG_BACKEND_UART
 	help
 	  When enabled backend is using UART to output logs.
 
+config LOG_BACKEND_RTT
+	bool "Enable Segger J-Link RTT backend"
+	depends on HAS_SEGGER_RTT
+	default y
+	help
+	  When enabled backend will use RTT for logging. This backend works on per
+	  message basis. Only whole message (terminated with carrier return '\r')
+	  is transferred to up-buffer at once depending on available space and
+	  selected mode.
+	  In panic mode backend always blocks and waits until there will be space
+	  in up-buffer for a message and message is transferred to host.
+
+if LOG_BACKEND_RTT
+
+choice
+    prompt "Logger behaviour"
+    default LOG_BACKEND_RTT_MODE_BLOCK
+
+config LOG_BACKEND_RTT_MODE_DROP
+	bool "Drop message that does not fits in up-buffer."
+	help
+	    If there is not enough space in up-buffer for a message, drop it.
+	    Number of dropped messages will be logged.
+	    Increase up-buffer size helps to reduce dropping of messages
+
+config LOG_BACKEND_RTT_MODE_BLOCK
+    bool "Block until message is transferred to host."
+    help
+        Waits until there will be enough space in the up-buffer for a message
+        and until the message is completely transferred to the host.
+
+endchoice
+
+config LOG_BACKEND_RTT_MESSAGE_SIZE
+	int "Size of internal buffer for storing messages."
+	range 32 256
+	default 128
+	help
+	    This option defines maximum message size transferable to up-buffer.
+
+config LOG_BACKEND_RTT_BUFFER
+	int "Buffer number used for logger output."
+	range 0 SEGGER_RTT_MAX_NUM_UP_BUFFERS
+	default 0
+	help
+	  Select index of up-buffer used for logger output, by default is uses
+	  terminal up-buffer and its settings.
+
+if LOG_BACKEND_RTT_BUFFER > 0
+
+config LOG_BACKEND_RTT_BUFFER_SIZE
+	int "Size of reserved up-buffer for logger output."
+	default 1024
+	help
+	  Specify reserved size of up-buffer used for logger output.
+
+endif # LOG_BACKEND_RTT_BUFFER
+endif # LOG_BACKEND_RTT
+
+
 config LOG_BACKEND_NATIVE_POSIX
 	bool "Enable native backend"
 	depends on ARCH_POSIX
@@ -297,14 +357,14 @@ config LOG_BACKEND_NATIVE_POSIX
 
 config LOG_BACKEND_SHOW_COLOR
 	bool "Enable colors in the backend"
-	depends on LOG_BACKEND_UART || LOG_BACKEND_NATIVE_POSIX
+	depends on LOG_BACKEND_UART || LOG_BACKEND_NATIVE_POSIX || LOG_BACKEND_RTT
 	default y
 	help
-	  When enabled UART backend prints errors in red and warning in yellow.
+	  When enabled selected backend prints errors in red and warning in yellow.
 
 config LOG_BACKEND_FORMAT_TIMESTAMP
 	bool "Enable timestamp formatting in the backend"
-	depends on LOG_BACKEND_UART || LOG_BACKEND_NATIVE_POSIX
+	depends on LOG_BACKEND_UART || LOG_BACKEND_NATIVE_POSIX || LOG_BACKEND_RTT
 	default y
 	help
 	  When enabled timestamp is formatted to hh:mm:ss:ms,us.

--- a/subsys/logging/Kconfig
+++ b/subsys/logging/Kconfig
@@ -307,11 +307,11 @@ choice
     default LOG_BACKEND_RTT_MODE_BLOCK
 
 config LOG_BACKEND_RTT_MODE_DROP
-	bool "Drop message that does not fits in up-buffer."
+	bool "Drop messages that do not fit in up-buffer."
 	help
 	    If there is not enough space in up-buffer for a message, drop it.
 	    Number of dropped messages will be logged.
-	    Increase up-buffer size helps to reduce dropping of messages
+	    Increase up-buffer size helps to reduce dropping of messages.
 
 config LOG_BACKEND_RTT_MODE_BLOCK
     bool "Block until message is transferred to host."

--- a/subsys/logging/Kconfig
+++ b/subsys/logging/Kconfig
@@ -303,21 +303,21 @@ config LOG_BACKEND_RTT
 if LOG_BACKEND_RTT
 
 choice
-    prompt "Logger behaviour"
-    default LOG_BACKEND_RTT_MODE_BLOCK
+	prompt "Logger behaviour"
+	default LOG_BACKEND_RTT_MODE_BLOCK
 
 config LOG_BACKEND_RTT_MODE_DROP
 	bool "Drop messages that do not fit in up-buffer."
 	help
-	    If there is not enough space in up-buffer for a message, drop it.
-	    Number of dropped messages will be logged.
-	    Increase up-buffer size helps to reduce dropping of messages.
+	  If there is not enough space in up-buffer for a message, drop it.
+	  Number of dropped messages will be logged.
+	  Increase up-buffer size helps to reduce dropping of messages.
 
 config LOG_BACKEND_RTT_MODE_BLOCK
-    bool "Block until message is transferred to host."
-    help
-        Waits until there is enough space in the up-buffer for a message
-        and until the message is completely transferred to the host.
+	bool "Block until message is transferred to host."
+	help
+	  Waits until there is enough space in the up-buffer for a message
+	  and until the message is completely transferred to the host.
 
 endchoice
 
@@ -326,7 +326,7 @@ config LOG_BACKEND_RTT_MESSAGE_SIZE
 	range 32 256
 	default 128
 	help
-	    This option defines maximum message size transferable to up-buffer.
+	  This option defines maximum message size transferable to up-buffer.
 
 config LOG_BACKEND_RTT_BUFFER
 	int "Buffer number used for logger output."

--- a/subsys/logging/Kconfig
+++ b/subsys/logging/Kconfig
@@ -293,11 +293,11 @@ config LOG_BACKEND_RTT
 	depends on USE_SEGGER_RTT
 	default y
 	help
-	  When enabled backend will use RTT for logging. This backend works on per
-	  message basis. Only whole message (terminated with carrier return '\r')
+	  When enabled, backend will use RTT for logging. This backend works on a per
+	  message basis. Only a whole message (terminated with a carriage return: '\r')
 	  is transferred to up-buffer at once depending on available space and
 	  selected mode.
-	  In panic mode backend always blocks and waits until there will be space
+	  In panic mode backend always blocks and waits until there is space
 	  in up-buffer for a message and message is transferred to host.
 
 if LOG_BACKEND_RTT
@@ -316,7 +316,7 @@ config LOG_BACKEND_RTT_MODE_DROP
 config LOG_BACKEND_RTT_MODE_BLOCK
     bool "Block until message is transferred to host."
     help
-        Waits until there will be enough space in the up-buffer for a message
+        Waits until there is enough space in the up-buffer for a message
         and until the message is completely transferred to the host.
 
 endchoice
@@ -333,7 +333,7 @@ config LOG_BACKEND_RTT_BUFFER
 	range 0 SEGGER_RTT_MAX_NUM_UP_BUFFERS
 	default 0
 	help
-	  Select index of up-buffer used for logger output, by default is uses
+	  Select index of up-buffer used for logger output, by default it uses
 	  terminal up-buffer and its settings.
 
 if LOG_BACKEND_RTT_BUFFER > 0

--- a/subsys/logging/Kconfig
+++ b/subsys/logging/Kconfig
@@ -290,7 +290,7 @@ config LOG_BACKEND_UART
 
 config LOG_BACKEND_RTT
 	bool "Enable Segger J-Link RTT backend"
-	depends on HAS_SEGGER_RTT
+	depends on USE_SEGGER_RTT
 	default y
 	help
 	  When enabled backend will use RTT for logging. This backend works on per

--- a/subsys/logging/log_backend_rtt.c
+++ b/subsys/logging/log_backend_rtt.c
@@ -12,7 +12,8 @@
 
 #if CONFIG_LOG_BACKEND_RTT_MODE_DROP
 
-#define DROP_MSG "\nmessages dropped: 99 \r"
+#define DROP_MAX 99
+#define DROP_MSG "\nmessages dropped:    \r"
 #define DROP_MSG_LEN (sizeof(DROP_MSG) - 1)
 
 #else
@@ -109,7 +110,7 @@ static int log_backend_rtt_write_drop(void)
 	}
 
 	if (drop_warn) {
-		int cnt = min(drop_cnt, 99);
+		int cnt = min(drop_cnt, DROP_MAX);
 
 		if (cnt < 10) {
 			line_buf[DROP_MSG_LEN - 2] = ' ';

--- a/subsys/logging/log_backend_rtt.c
+++ b/subsys/logging/log_backend_rtt.c
@@ -1,0 +1,202 @@
+/*
+ * Copyright (c) 2018 omSquare s.r.o.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <logging/log_backend.h>
+#include <logging/log_core.h>
+#include <logging/log_msg.h>
+#include <logging/log_output.h>
+#include <rtt/SEGGER_RTT.h>
+
+
+#if CONFIG_LOG_BACKEND_RTT_MODE_DROP
+
+#define DROP_MESSAGE "\nmessages dropped: 99 \r"
+#define DROP_MESSAGE_LEN (sizeof(DROP_MESSAGE) - 1)
+static const char *drop_msg = DROP_MESSAGE;
+static int drop_cnt = 0;
+static int drop_warn = 0;
+
+#else
+
+#define DROP_MESSAGE_LEN 0
+
+#endif /* CONFIG_LOG_BACKEND_RTT_MODE_DROP */
+
+#if CONFIG_LOG_BACKEND_RTT_BUFFER > 0
+static u8_t rtt_buf[CONFIG_LOG_BACKEND_RTT_BUFFER_SIZE];
+#endif /* CONFIG_LOG_BACKEND_RTT_BUFFER > 0 */
+
+static u8_t line_buf[CONFIG_LOG_BACKEND_RTT_MESSAGE_SIZE + DROP_MESSAGE_LEN];
+static u8_t *line_pos;
+static u8_t char_buf;
+static int panic_mode;
+
+static int msg_out(u8_t *data, size_t length, void *ctx);
+
+static int line_out(u8_t data);
+
+static void log_backend_rtt_flush(void);
+
+static int log_backend_rtt_write(void);
+
+static int log_backend_rtt_panic(u8_t *data, size_t length);
+
+static int msg_out(u8_t *data, size_t length, void *ctx)
+{
+	(void) ctx;
+	u8_t *pos;
+
+	if (panic_mode) {
+		return log_backend_rtt_panic(data, length);
+	}
+
+	for (pos = data; pos < data + length; pos++) {
+		if (line_out(*pos)) {
+			break;
+		}
+	}
+
+	return (int) (pos - data);
+}
+
+static int line_out(u8_t data)
+{
+	if (data == '\r') {
+		if (log_backend_rtt_write()) {
+			return 1;
+		}
+		line_pos = line_buf;
+		return 0;
+	}
+
+	if (line_pos < line_buf + sizeof(line_buf) - 1) {
+		*line_pos++ = data;
+	}
+
+	/* not enough space in line buffer, we have to wait for EOL */
+	return 0;
+}
+
+#if CONFIG_LOG_BACKEND_RTT_MODE_DROP
+
+static int log_backend_rtt_write(void)
+{
+	*line_pos = '\r';
+
+	if (drop_cnt > 0 && !drop_warn) {
+		memmove(line_buf + DROP_MESSAGE_LEN, line_buf,
+			line_pos - line_buf);
+		memcpy(line_buf, drop_msg, DROP_MESSAGE_LEN);
+		line_pos += DROP_MESSAGE_LEN;
+		drop_warn = 1;
+	}
+
+	if (drop_warn) {
+		int cnt = min(drop_cnt, 99);
+		if (cnt < 10) {
+			line_buf[DROP_MESSAGE_LEN - 2] = ' ';
+			line_buf[DROP_MESSAGE_LEN - 3] = (u8_t) ('0' + cnt);
+			line_buf[DROP_MESSAGE_LEN - 4] = ' ';
+		} else {
+			line_buf[DROP_MESSAGE_LEN - 2] = (u8_t) ('0' + cnt % 10);
+			line_buf[DROP_MESSAGE_LEN - 3] = (u8_t) ('0' + cnt / 10);
+			line_buf[DROP_MESSAGE_LEN - 4] = '>';
+		}
+	}
+
+	int ret = SEGGER_RTT_WriteSkipNoLock(CONFIG_LOG_BACKEND_RTT_BUFFER,
+					     line_buf, line_pos - line_buf + 1);
+
+	if (!ret) {
+		drop_cnt++;
+		return 0;
+	}
+
+	drop_cnt = 0;
+	drop_warn = 0;
+	return 0;
+}
+
+#elif CONFIG_LOG_BACKEND_RTT_MODE_BLOCK
+
+static int log_backend_rtt_write(void)
+{
+	*line_pos = '\r';
+	if (SEGGER_RTT_WriteSkipNoLock(CONFIG_LOG_BACKEND_RTT_BUFFER, line_buf,
+				       line_pos - line_buf + 1)) {
+		log_backend_rtt_flush();
+		return 0;
+	}
+	return 1;
+}
+
+#endif
+
+static int log_backend_rtt_panic(u8_t *data, size_t length)
+{
+	unsigned int written;
+
+	written = SEGGER_RTT_WriteNoLock(CONFIG_LOG_BACKEND_RTT_BUFFER, data,
+					 length);
+	log_backend_rtt_flush();
+	return written;
+}
+
+
+LOG_OUTPUT_DEFINE(log_output, msg_out, &char_buf, 1);
+
+static void put(const struct log_backend *const backend,
+		struct log_msg *msg)
+{
+	log_msg_get(msg);
+
+	u32_t flags = LOG_OUTPUT_FLAG_LEVEL | LOG_OUTPUT_FLAG_TIMESTAMP;
+
+	if (IS_ENABLED(CONFIG_LOG_BACKEND_SHOW_COLOR)) {
+		flags |= LOG_OUTPUT_FLAG_COLORS;
+	}
+
+	if (IS_ENABLED(CONFIG_LOG_BACKEND_FORMAT_TIMESTAMP)) {
+		flags |= LOG_OUTPUT_FLAG_FORMAT_TIMESTAMP;
+	}
+
+	log_output_msg_process(&log_output, msg, flags);
+
+	log_msg_put(msg);
+
+}
+
+static void log_backend_rtt_init(void)
+{
+	SEGGER_RTT_Init();
+#if CONFIG_LOG_BACKEND_RTT_BUFFER > 0
+	SEGGER_RTT_ConfigUpBuffer(CONFIG_LOG_BACKEND_RTT_BUFFER, "Logger",
+				  rtt_buf, sizeof(rtt_buf),
+				  SEGGER_RTT_MODE_NO_BLOCK_SKIP);
+#endif
+	panic_mode = 0;
+	line_pos = line_buf;
+}
+
+static void panic(struct log_backend const *const backend)
+{
+	panic_mode = 1;
+}
+
+static void log_backend_rtt_flush(void)
+{
+	while (SEGGER_RTT_HasDataUp(CONFIG_LOG_BACKEND_RTT_BUFFER)) {
+		/* pass */
+	}
+}
+
+const struct log_backend_api log_backend_rtt_api = {
+	.put = put,
+	.panic = panic,
+	.init = log_backend_rtt_init,
+};
+
+LOG_BACKEND_DEFINE(log_backend_rtt, log_backend_rtt_api, true);

--- a/subsys/logging/log_backend_rtt.c
+++ b/subsys/logging/log_backend_rtt.c
@@ -83,7 +83,7 @@ static int line_out(u8_t data)
 		if (log_backend_rtt_write()) {
 			return 1;
 		}
-		line_pos = line_buf;
+		line_pos = drop_cnt > 0 ? line_buf + DROP_MSG_LEN : line_buf;
 		return 0;
 	}
 

--- a/subsys/logging/log_backend_rtt.c
+++ b/subsys/logging/log_backend_rtt.c
@@ -13,15 +13,15 @@
 
 #if CONFIG_LOG_BACKEND_RTT_MODE_DROP
 
-#define DROP_MESSAGE "\nmessages dropped: 99 \r"
-#define DROP_MESSAGE_LEN (sizeof(DROP_MESSAGE) - 1)
-static const char *drop_msg = DROP_MESSAGE;
-static int drop_cnt = 0;
-static int drop_warn = 0;
+#define DROP_MSG "\nmessages dropped: 99 \r"
+#define DROP_MSG_LEN (sizeof(DROP_MSG) - 1)
+static const char *drop_msg = DROP_MSG;
+static int drop_cnt;
+static int drop_warn;
 
 #else
 
-#define DROP_MESSAGE_LEN 0
+#define DROP_MSG_LEN 0
 
 #endif /* CONFIG_LOG_BACKEND_RTT_MODE_DROP */
 
@@ -38,7 +38,7 @@ static u8_t rtt_buf[CONFIG_LOG_BACKEND_RTT_BUFFER_SIZE];
 
 #endif /* CONFIG_LOG_BACKEND_RTT_BUFFER > 0 */
 
-static u8_t line_buf[CONFIG_LOG_BACKEND_RTT_MESSAGE_SIZE + DROP_MESSAGE_LEN];
+static u8_t line_buf[CONFIG_LOG_BACKEND_RTT_MESSAGE_SIZE + DROP_MSG_LEN];
 static u8_t *line_pos;
 static u8_t char_buf;
 static int panic_mode;
@@ -96,23 +96,24 @@ static int log_backend_rtt_write(void)
 	*line_pos = '\r';
 
 	if (drop_cnt > 0 && !drop_warn) {
-		memmove(line_buf + DROP_MESSAGE_LEN, line_buf,
+		memmove(line_buf + DROP_MSG_LEN, line_buf,
 			line_pos - line_buf);
-		memcpy(line_buf, drop_msg, DROP_MESSAGE_LEN);
-		line_pos += DROP_MESSAGE_LEN;
+		memcpy(line_buf, drop_msg, DROP_MSG_LEN);
+		line_pos += DROP_MSG_LEN;
 		drop_warn = 1;
 	}
 
 	if (drop_warn) {
 		int cnt = min(drop_cnt, 99);
+
 		if (cnt < 10) {
-			line_buf[DROP_MESSAGE_LEN - 2] = ' ';
-			line_buf[DROP_MESSAGE_LEN - 3] = (u8_t) ('0' + cnt);
-			line_buf[DROP_MESSAGE_LEN - 4] = ' ';
+			line_buf[DROP_MSG_LEN - 2] = ' ';
+			line_buf[DROP_MSG_LEN - 3] = (u8_t) ('0' + cnt);
+			line_buf[DROP_MSG_LEN - 4] = ' ';
 		} else {
-			line_buf[DROP_MESSAGE_LEN - 2] = (u8_t) ('0' + cnt % 10);
-			line_buf[DROP_MESSAGE_LEN - 3] = (u8_t) ('0' + cnt / 10);
-			line_buf[DROP_MESSAGE_LEN - 4] = '>';
+			line_buf[DROP_MSG_LEN - 2] = (u8_t) ('0' + cnt % 10);
+			line_buf[DROP_MSG_LEN - 3] = (u8_t) ('0' + cnt / 10);
+			line_buf[DROP_MSG_LEN - 4] = '>';
 		}
 	}
 

--- a/subsys/logging/log_backend_rtt.c
+++ b/subsys/logging/log_backend_rtt.c
@@ -208,8 +208,6 @@ static void log_backend_rtt_cfg(void)
 
 static void log_backend_rtt_init(void)
 {
-	SEGGER_RTT_Init();
-
 	if (CONFIG_LOG_BACKEND_RTT_BUFFER > 0) {
 		log_backend_rtt_cfg();
 	}


### PR DESCRIPTION
Add logger backend that uses Segger RTT for message output. Several
options are provided allowing configuration of up-buffer and logger
behaviour.

Signed-off-by: Pavel Kral <pavel.kral@omsquare.com>