### PR TITLE
net: shell: Return -ETIMEDOUT if ping target timeout

### DIFF
--- a/subsys/net/ip/net_shell.c
+++ b/subsys/net/ip/net_shell.c
@@ -3286,6 +3286,8 @@ wait_reply:
 		PR_INFO("Ping timeout\n");
 		_remove_ipv6_ping_handler();
 		_remove_ipv4_ping_handler();
+
+		return -ETIMEDOUT;
 	}
 
 	return 0;


### PR DESCRIPTION
The previous code return 0 even if ping target failed(timeout),
that's can't detect if the target is alived from shell_execute_cmd.

Signed-off-by: qianfan Zhao <qianfanguijin@163.com>