### PR TITLE
scripts/dts: extract_dts_includes: fix alias creation for subnodes

### DIFF
--- a/scripts/dts/extract_dts_includes.py
+++ b/scripts/dts/extract_dts_includes.py
@@ -347,8 +347,13 @@ def extract_property(node_compat, yaml, node_address, prop, prop_val, names,
             # Generate alias definition if parent has any alias
             if parent_address in aliases:
                 for i in aliases[parent_address]:
-                    node_alias = i + '_' + def_label
-                    aliases[node_address].append(node_alias)
+                    # Build an alias name that respects device tree specs
+                    node_name = node_compat + '-' + node_address.split('@')[-1]
+                    node_strip = node_name.replace('@','-').replace(',','-')
+                    node_alias = i + '-' + node_strip
+                    if node_alias not in aliases[node_address]:
+                        # Need to generate alias name for this node:
+                        aliases[node_address].append(node_alias)
 
             # Use parent label to generate label
             parent_label = get_node_label(


### PR DESCRIPTION
Heuristic for populating an alias string for a subnode
of an alias node was wrong as there was no check if
alias already existed and string created was not in line
with device tree specfication (allowed chars: [0-9],[a-z], '-').

Fix these two points.

Signed-off-by: Erwan Gouriou <erwan.gouriou@linaro.org>