### PR TITLE
dts: x86: Fix dts warnings when building up_squared

### DIFF
--- a/boards/x86/up_squared/up_squared.dts
+++ b/boards/x86/up_squared/up_squared.dts
@@ -130,7 +130,7 @@
 			status = "ok";
 		};
 
-		i2c6: i2c@91528000 {
+		i2c6: i2c@9158000 {
 			compatible = "snps,designware-i2c";
 			clock-frequency = <I2C_BITRATE_STANDARD>;
 			#address-cells = <1>;

--- a/dts/x86/apollo_lake.dtsi
+++ b/dts/x86/apollo_lake.dtsi
@@ -44,7 +44,7 @@
 		compatible = "simple-bus";
 		ranges;
 
-		gpio: gpio@0 {
+		gpio: gpio@d0c50000 {
 			compatible = "intel,apl-gpio";
 			reg = <0xd0c50000 0x1000>,
 			      <0xd0c40000 0x1000>,


### PR DESCRIPTION
Fix the following dts warnings:

up_squared.dts_compiled: Warning (simple_bus_reg): /soc/gpio@0:
	simple-bus unit address format error, expected "d0c50000"
up_squared.dts_compiled: Warning (simple_bus_reg): /soc/i2c@91528000:
	simple-bus unit address format error, expected "9158000"

Signed-off-by: Kumar Gala <kumar.gala@linaro.org>