### PR TITLE
scripts: dts: extract: Fix handling of reg prop being a list of lists

### DIFF
--- a/scripts/dts/extract/reg.py
+++ b/scripts/dts/extract/reg.py
@@ -49,6 +49,13 @@ class DTReg(DTDirective):
 
         index = 0
         props = list(reg)
+
+        # Newer versions of dtc might have the reg propertly look like
+        # reg = <1 2>, <3 4>;
+        # So we need to flatten the list in that case
+        if isinstance(props[0], list):
+            props = [item for sublist in props for item in sublist]
+
         while props:
             prop_def = {}
             prop_alias = {}


### PR DESCRIPTION
Before dtc 1.4.7 we'd get something like the following for an reg
property:

reg = <1 2 3 4>;

After dtc 1.4.7 we get:

reg = <1 2>, <3 4>;

We should handle both cases in the extract reg handling code.  So if
we see a list of lists, we flatten it to a single list to normalize
the property.

Signed-off-by: Kumar Gala <kumar.gala@linaro.org>