### PR TITLE
ext/hal: stm32cube: fix exti declaration in STM32F7/STM32L4

### DIFF
--- a/ext/hal/st/stm32cube/stm32f7xx/README
+++ b/ext/hal/st/stm32cube/stm32f7xx/README
@@ -48,6 +48,7 @@ Patch List:
      drivers/include/stm32f7xx_ll_spi.h
     ST Bug tracker ID: 13359
 
+
    *Add correct shifting to I2SR field in PLLI2SCFGR register
      The I2SR field should be shifted by RCC_PLLI2SCFGR_PLLI2SR_Pos when the PLLI2SCFGR register
      is read or written.
@@ -65,3 +66,11 @@ Patch List:
      CMakeLists.txt
      drivers/include/stm32f7xx_hal_conf.h
      drivers/src/Legacy/stm32f7_hal_can.c
+
+   *Fix LL_EXTI_LINE_18 and LL_EXTI_LINE_20 declarations
+     LL_EXTI_LINE_18 and LL_EXTI_LINE_20 are declared in stm32f7xx_hal_pcd.h
+     and in stm32f7xx_ll_exti.h which generates warnings. Set #ifndef
+     in stm32f7xx_ll_exti.h around declarations.
+    Impacted files:
+     drivers/include/stm32f7xx_ll_exti.h
+    ST Bug tracker ID: 55274

--- a/ext/hal/st/stm32cube/stm32f7xx/drivers/include/stm32f7xx_ll_exti.h
+++ b/ext/hal/st/stm32cube/stm32f7xx/drivers/include/stm32f7xx_ll_exti.h
@@ -121,11 +121,15 @@ typedef struct
 #endif
 #define LL_EXTI_LINE_17                EXTI_IMR_IM17          /*!< Extended line 17 */
 #if defined(EXTI_IMR_IM18)
+#ifndef LL_EXTI_LINE_18
 #define LL_EXTI_LINE_18                EXTI_IMR_IM18          /*!< Extended line 18 */
+#endif
 #endif
 #define LL_EXTI_LINE_19                EXTI_IMR_IM19          /*!< Extended line 19 */
 #if defined(EXTI_IMR_IM20)
+#ifndef LL_EXTI_LINE_20
 #define LL_EXTI_LINE_20                EXTI_IMR_IM20          /*!< Extended line 20 */
+#endif
 #endif
 #if defined(EXTI_IMR_IM21)
 #define LL_EXTI_LINE_21                EXTI_IMR_IM21          /*!< Extended line 21 */

--- a/ext/hal/st/stm32cube/stm32l4xx/README
+++ b/ext/hal/st/stm32cube/stm32l4xx/README
@@ -54,3 +54,12 @@ Patch List:
      CMakeLists.txt
      drivers/include/stm32l4xx_hal_conf.h
      drivers/src/Legacy/stm32l4_hal_can.c
+
+
+   *Fix LL_EXTI_LINE_18 and LL_EXTI_LINE_20 declarations
+     LL_EXTI_LINE_18 and LL_EXTI_LINE_20 are declared in stm32l4xx_hal_pcd.h
+     and in stm32l4xx_ll_exti.h which generates warnings. Set #ifndef
+     in stm32l4xx_ll_exti.h around declarations.
+    Impacted files:
+     drivers/include/stm32l4xx_ll_exti.h
+    ST Bug tracker ID: 55275

--- a/ext/hal/st/stm32cube/stm32l4xx/drivers/include/stm32l4xx_ll_exti.h
+++ b/ext/hal/st/stm32cube/stm32l4xx/drivers/include/stm32l4xx_ll_exti.h
@@ -124,11 +124,15 @@ typedef struct
 #endif
 #define LL_EXTI_LINE_17                EXTI_IMR1_IM17          /*!< Extended line 17 */
 #if defined(EXTI_IMR1_IM18)
+#ifndef LL_EXTI_LINE_18
 #define LL_EXTI_LINE_18                EXTI_IMR1_IM18          /*!< Extended line 18 */
+#endif
 #endif
 #define LL_EXTI_LINE_19                EXTI_IMR1_IM19          /*!< Extended line 19 */
 #if defined(EXTI_IMR1_IM20)
+#ifndef LL_EXTI_LINE_20
 #define LL_EXTI_LINE_20                EXTI_IMR1_IM20          /*!< Extended line 20 */
+#endif
 #endif
 #if defined(EXTI_IMR1_IM21)
 #define LL_EXTI_LINE_21                EXTI_IMR1_IM21          /*!< Extended line 21 */


### PR DESCRIPTION
LL_EXTI_LINE_18 and LL_EXTI_LINE_20 are declared in stm32f7/l4xx_hal_pcd.h
and in stm32f7/l4xx_ll_exti.h which generates warnings.
Set #ifndef in stm32f7/l4xx_ll_exti.h around declarations.
