### PR TITLE
cmake: Enforce that the DTC is at least 1.4.6

### DIFF
--- a/cmake/host-tools.cmake
+++ b/cmake/host-tools.cmake
@@ -12,6 +12,23 @@ if(${DTC} STREQUAL DTC-NOTFOUND)
   message(FATAL_ERROR "Unable to find dtc")
 endif()
 
+# Parse the 'dtc --version' and make sure it is at least MIN_DTC_VERSION
+set(MIN_DTC_VERSION 1.4.6)
+execute_process(
+  COMMAND
+  ${DTC} --version
+  OUTPUT_VARIABLE dtc_version_output
+  )
+string(REGEX MATCH "Version: DTC ([0-9]+\.[0-9]+.[0-9]+).*" out_var ${dtc_version_output})
+if(${CMAKE_MATCH_1} VERSION_LESS ${MIN_DTC_VERSION})
+  assert(0 "The detected dtc version is unsupported.                                 \n\
+	  The version was found to be ${CMAKE_MATCH_1}                                   \n\
+	  But the minimum supported version is ${MIN_DTC_VERSION}                        \n\
+	  See https://docs.zephyrproject.org/latest/getting_started/getting_started.html \n\
+	  for how to use the SDK's dtc alongside a custom toolchain."
+	)
+endif()
+
 find_program(
   GPERF
   gperf


### PR DESCRIPTION
The Zephyr SDK distributes a device-tree-compiler with version
"1.4.6-dirty". As of recently, we have started using flags that are
only present in recent versions of dtc. Like the flag "-E
unit_address_vs_reg".

Users that are opting out of using the Zephyr SDK's host tools are
reporting obscure error messages.

To avoid this we use an appropriate error message when the detected
version is unsupported.

Signed-off-by: Sebastian Bøe <sebastian.boe@nordicsemi.no>