### PR TITLE
drivers: sensors: adxl372: Add missing dts bindings

### DIFF
--- a/dts/bindings/sensor/adi,adxl372.yaml
+++ b/dts/bindings/sensor/adi,adxl372.yaml
@@ -1,0 +1,25 @@
+#
+# Copyright (c) 2018 Analog Devices Inc.
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+---
+title: ADXL372 Three Axis High-g I2C/SPI accelerometer
+version: 0.1
+
+description: >
+    This is a representation of the ADXL372 Three Axis High-g I2C/SPI accelerometer
+
+inherits:
+    !include i2c-device.yaml
+
+properties:
+    compatible:
+      constraint: "adi,adxl372"
+
+    int1-gpios:
+      type: compound
+      category: optional
+      generation: define, use-prop-name
+
+...


### PR DESCRIPTION
This patch adds the required dts/bindings/sensor/adi,adxl372.yaml file.

Signed-off-by: Michael Hennerich <michael.hennerich@analog.com>