### PR TITLE
dts/extract/globals.py: Add function to get list of compats

### DIFF
--- a/scripts/dts/extract/globals.py
+++ b/scripts/dts/extract/globals.py
@@ -75,6 +75,21 @@ def get_aliases(root):
         if reduced[k].get('alt_name', None) is not None:
             aliases[k].append(reduced[k]['alt_name'])
 
+def get_node_compats(node_address):
+    compat = None
+
+    try:
+        if 'props' in reduced[node_address].keys():
+            compat = reduced[node_address]['props'].get('compatible')
+
+        if not isinstance(compat, list):
+            compat = [compat, ]
+
+    except:
+        pass
+
+    return compat
+
 def get_compat(node_address):
     compat = None
 


### PR DESCRIPTION
Add a function that given a node address we get a list of compats back
instead of just the first.  This is in prep for eDTS support.

Signed-off-by: Kumar Gala <kumar.gala@linaro.org>