### PR TITLE
ext: debug: segger: Add missing # for else in SEGGER config header

### DIFF
--- a/ext/debug/segger/rtt/SEGGER_RTT_Conf.h
+++ b/ext/debug/segger/rtt/SEGGER_RTT_Conf.h
@@ -105,7 +105,7 @@ Revision: $Rev: 9599 $
 */
 #if defined(CONFIG_SEGGER_RTT_MEMCPY_USE_BYTELOOP)
 #define SEGGER_RTT_MEMCPY_USE_BYTELOOP              1 // 1: Use a simple byte-loop
-else
+#else
 #define SEGGER_RTT_MEMCPY_USE_BYTELOOP              0 // 0: Use memcpy/SEGGER_RTT_MEMCPY
 #endif
 //


### PR DESCRIPTION
This commit fixes #10685

Signed-off-by: Sigvart M. Hovland <sigvart.hovland@nordicsemi.no>