### PR TITLE
Shell unify commands ret val

### DIFF
--- a/doc/subsystems/shell/shell.rst
+++ b/doc/subsystems/shell/shell.rst
@@ -228,8 +228,10 @@ checks for valid arguments count.
 		 *
 		 * Each of these actions can be deactivated in Kconfig.
 		 */
-		if (!shell_cmd_precheck(shell, (argc <= 2), NULL, 0) {
-			return 0;
+		int err = shell_cmd_precheck(shell, (argc <= 2), NULL, 0);
+
+		if (err) {
+			return err;
 		}
 
 		shell_fprintf(shell, SHELL_NORMAL,
@@ -271,6 +273,7 @@ in command handler.
 	static int cmd_with_options(const struct shell *shell, size_t argc,
 			            char **argv)
 	{
+		int err;
 		/* Dummy options showing options usage */
 		static const struct shell_getopt_option opt[] = {
 			SHELL_OPT(
@@ -288,9 +291,10 @@ in command handler.
 		/* If command will be called with -h or --help option
 		 * all declared options will be listed in the help message
 		 */
-		if (!shell_cmd_precheck(shell, (argc <= 2), opt,
-					  sizeof(opt)/sizeof(opt[1]))) {
-			return 0;
+		err = shell_cmd_precheck(shell, (argc <= 2), opt,
+					 sizeof(opt)/sizeof(opt[1]));
+		if (err) {
+			return err;
 		}
 
 		/* checking if command was called with test option */

--- a/drivers/flash/flash_shell.c
+++ b/drivers/flash/flash_shell.c
@@ -228,17 +228,21 @@ SHELL_CREATE_STATIC_SUBCMD_SET(flash_cmds) {
 
 static int cmd_flash(const struct shell *shell, size_t argc, char **argv)
 {
+	int err;
+
 	if (argc == 1) {
 		shell_help_print(shell, NULL, 0);
-		return 0;
+		/* shell_cmd_precheck returns 1 when help is printed */
+		return 1;
 	}
 
-	if (!shell_cmd_precheck(shell, (argc == 2), NULL, 0)) {
-		return 0;
+	err = shell_cmd_precheck(shell, (argc == 2), NULL, 0);
+	if (err) {
+		return err;
 	}
 
 	error(shell, "%s:%s%s", argv[0], "unknown parameter: ", argv[1]);
-	return -ENOEXEC;
+	return -EINVAL;
 }
 
 SHELL_CMD_REGISTER(flash, &flash_cmds, "Flash shell commands",

--- a/include/shell/shell.h
+++ b/include/shell/shell.h
@@ -572,12 +572,14 @@ int shell_prompt_change(const struct shell *shell, char *prompt);
  * @param[in] opt	  Pointer to the optional option array.
  * @param[in] opt_len	  Option array size.
  *
- * @return True if check passed, false otherwise or help was requested.
+ * @return 0		  if check passed
+ * @return 1		  if help was requested
+ * @return -EINVAL	  if wrong argument count
  */
-bool shell_cmd_precheck(const struct shell *shell,
-			bool arg_cnt_ok,
-			const struct shell_getopt_option *opt,
-			size_t opt_len);
+int shell_cmd_precheck(const struct shell *shell,
+		       bool arg_cnt_ok,
+		       const struct shell_getopt_option *opt,
+		       size_t opt_len);
 
 /**
  * @internal @brief This function shall not be used directly, it is required by

--- a/samples/drivers/flash_shell/src/main.c
+++ b/samples/drivers/flash_shell/src/main.c
@@ -239,12 +239,14 @@ static int cmd_flash(const struct shell *shell, size_t argc, char **argv)
 
 
 static int cmd_write_block_size(const struct shell *shell, size_t argc,
-					 char **argv)
+				char **argv)
 {
-	int err;
+	ARG_UNUSED(argv);
 
-	if (!shell_cmd_precheck(shell, argc == 1, NULL, 0)) {
-		return 0;
+	int err = shell_cmd_precheck(shell, (argc == 1), NULL, 0);
+
+	if (err) {
+		return err;
 	}
 
 	err = check_flash_device(shell);
@@ -258,11 +260,12 @@ static int cmd_write_block_size(const struct shell *shell, size_t argc,
 
 static int cmd_read(const struct shell *shell, size_t argc, char **argv)
 {
-	unsigned long int offset, len;
-	int err;
 
-	if (!shell_cmd_precheck(shell, argc == 3, NULL, 0)) {
-		return 0;
+	int err = shell_cmd_precheck(shell, (argc == 3), NULL, 0);
+	unsigned long int offset, len;
+
+	if (err) {
+		goto exit;
 	}
 
 	err = check_flash_device(shell);
@@ -284,11 +287,11 @@ exit:
 
 static int cmd_erase(const struct shell *shell, size_t argc, char **argv)
 {
+	int err = shell_cmd_precheck(shell, (argc == 3), NULL, 0);
 	unsigned long int offset, size;
-	int err;
 
-	if (!shell_cmd_precheck(shell, argc == 3, NULL, 0)) {
-		return 0 ;
+	if (err) {
+		goto exit;
 	}
 
 	err = check_flash_device(shell);
@@ -309,12 +312,12 @@ exit:
 
 static int cmd_write(const struct shell *shell, size_t argc, char **argv)
 {
+	int err = shell_cmd_precheck(shell, (argc > 2), NULL, 0);
 	unsigned long int i, offset;
 	u8_t buf[ARGC_MAX];
-	int err = 0;
 
-	if (!shell_cmd_precheck(shell, argc > 2, NULL, 0)) {
-		return 0;
+	if (err) {
+		goto exit;
 	}
 
 	err = check_flash_device(shell);
@@ -361,11 +364,13 @@ exit:
 #ifdef CONFIG_FLASH_PAGE_LAYOUT
 static int cmd_page_count(const struct shell *shell, size_t argc, char **argv)
 {
-	size_t page_count;
-	int err;
+	ARG_UNUSED(argv);
 
-	if (!shell_cmd_precheck(shell, argc == 1, NULL, 0)) {
-		return 0;
+	int err = shell_cmd_precheck(shell, (argc == 1), NULL, 0);
+	size_t page_count;
+
+	if (err) {
+		return err;
 	}
 
 	err = check_flash_device(shell);
@@ -404,12 +409,12 @@ static bool page_layout_cb(const struct flash_pages_info *info, void *datav)
 
 static int cmd_page_layout(const struct shell *shell, size_t argc, char **argv)
 {
+	int err = shell_cmd_precheck(shell, (argc <= 3), NULL, 0);
 	unsigned long int start_page, end_page;
 	struct page_layout_data data;
-	int err = 0;
 
-	if (!shell_cmd_precheck(shell, argc <= 3, NULL, 0)) {
-		return 0 ;
+	if (err) {
+		return err;
 	}
 
 	err = check_flash_device(shell);
@@ -458,13 +463,15 @@ static int cmd_page_read(const struct shell *shell, size_t argc, char **argv)
 	struct flash_pages_info info;
 	int ret;
 
-	ret = check_flash_device(shell);
+
+	ret = shell_cmd_precheck(shell, (argc == 3) || (argc == 4), NULL, 0);
 	if (ret) {
 		return ret;
 	}
 
-	if (!shell_cmd_precheck(shell, (argc == 3) || (argc == 4), NULL, 0)) {
-		return 0;
+	ret = check_flash_device(shell);
+	if (ret) {
+		return ret;
 	}
 
 	if (argc == 3) {
@@ -505,8 +512,9 @@ static int cmd_page_erase(const struct shell *shell, size_t argc, char **argv)
 		return ret;
 	}
 
-	if (!shell_cmd_precheck(shell, (argc == 2) || (argc == 3), NULL, 0)) {
-		return 0;
+	ret = shell_cmd_precheck(shell, (argc == 2) || (argc == 3), NULL, 0);
+	if (ret) {
+		return ret;
 	}
 
 	if (parse_ul(argv[1], &page)) {
@@ -555,8 +563,9 @@ static int cmd_page_write(const struct shell *shell, size_t argc, char **argv)
 		return ret;
 	}
 
-	if (!shell_cmd_precheck(shell, (argc > 2), NULL, 0)) {
-		return 0;
+	ret = shell_cmd_precheck(shell, (argc > 2), NULL, 0);
+	if (ret) {
+		return ret;
 	}
 
 	if (argc < 2 || parse_ul(argv[1], &page) || parse_ul(argv[2], &off)) {
@@ -592,9 +601,11 @@ static int cmd_set_dev(const struct shell *shell, size_t argc, char **argv)
 {
 	struct device *dev;
 	const char *name;
+	int ret;
 
-	if (!shell_cmd_precheck(shell, (argc == 2), NULL, 0)) {
-		return 0;
+	ret = shell_cmd_precheck(shell, (argc = 2), NULL, 0);
+	if (ret) {
+		return ret;
 	}
 
 	name = argv[1];

--- a/samples/mpu/mpu_test/src/main.c
+++ b/samples/mpu/mpu_test/src/main.c
@@ -159,6 +159,7 @@ static int cmd_mtest(const struct shell *shell, size_t argc, char *argv[])
 {
 	u32_t *mem;
 	u32_t val;
+	int err;
 
 	if (argc > 3) {
 		PR_ERROR(shell, "mtest accepts 1 (Read) or 2 (Write)"
@@ -166,8 +167,9 @@ static int cmd_mtest(const struct shell *shell, size_t argc, char *argv[])
 		return -EINVAL;
 	}
 
-	if (!shell_cmd_precheck(shell, (argc >= 2) && (argc <= 3), NULL, 0)) {
-		return 0;
+	err = shell_cmd_precheck(shell, (argc >= 2) && (argc <= 3), NULL, 0);
+	if (err) {
+		return err;
 	}
 
 	val = (u32_t)strtol(argv[1], NULL, 16);

--- a/samples/subsys/shell/shell_module/src/main.c
+++ b/samples/subsys/shell/shell_module/src/main.c
@@ -29,8 +29,12 @@ K_TIMER_DEFINE(log_timer, timer_expired_handler, NULL);
 static int cmd_log_test_start(const struct shell *shell, size_t argc,
 			      char **argv, u32_t period)
 {
-	if (!shell_cmd_precheck(shell, argc == 1, NULL, 0)) {
-		return 0;
+	ARG_UNUSED(argv);
+
+	int err = shell_cmd_precheck(shell, argc == 1, NULL, 0);
+
+	if (err) {
+		return err;
 	}
 
 	k_timer_start(&log_timer, period, period);
@@ -58,8 +62,10 @@ static int cmd_log_test_stop(const struct shell *shell, size_t argc,
 	ARG_UNUSED(argc);
 	ARG_UNUSED(argv);
 
-	if (!shell_cmd_precheck(shell, argc == 1, NULL, 0)) {
-		return 0;
+	int err = shell_cmd_precheck(shell, argc == 1, NULL, 0);
+
+	if (err) {
+		return err;
 	}
 
 	k_timer_stop(&log_timer);
@@ -127,7 +133,6 @@ SHELL_CREATE_STATIC_SUBCMD_SET(sub_demo)
 	SHELL_CMD(ping, NULL, "Ping command.", cmd_demo_ping),
 	SHELL_SUBCMD_SET_END /* Array terminated. */
 };
-
 SHELL_CMD_REGISTER(demo, &sub_demo, "Demo commands", NULL);
 
 SHELL_CMD_REGISTER(version, NULL, "Show kernel version", cmd_version);

--- a/subsys/bluetooth/shell/bredr.c
+++ b/subsys/bluetooth/shell/bredr.c
@@ -50,6 +50,7 @@ static int cmd_auth_pincode(const struct shell *shell,
 {
 	struct bt_conn *conn;
 	u8_t max = 16;
+	int err;
 
 	if (default_conn) {
 		conn = default_conn;
@@ -64,8 +65,9 @@ static int cmd_auth_pincode(const struct shell *shell,
 		return 0;
 	}
 
-	if (!shell_cmd_precheck(shell, argc == 2, NULL, 0)) {
-		return 0;
+	err = shell_cmd_precheck(shell, (argc == 2), NULL, 0);
+	if (err) {
+		return err;
 	}
 
 	if (strlen(argv[1]) > max) {
@@ -87,8 +89,9 @@ static int cmd_connect(const struct shell *shell, size_t argc, char *argv[])
 	bt_addr_t addr;
 	int err;
 
-	if (!shell_cmd_precheck(shell, argc == 2, NULL, 0)) {
-		return 0;
+	err = shell_cmd_precheck(shell, (argc == 2), NULL, 0);
+	if (err) {
+		return err;
 	}
 
 	err = str2bt_addr(argv[1], &addr);
@@ -176,9 +179,11 @@ static void br_discovery_complete(struct bt_br_discovery_result *results,
 static int cmd_discovery(const struct shell *shell, size_t argc, char *argv[])
 {
 	const char *action;
+	int err;
 
-	if (!shell_cmd_precheck(shell, argc >= 2, NULL, 0)) {
-		return 0;
+	err = shell_cmd_precheck(shell, (argc >= 2), NULL, 0);
+	if (err) {
+		return err;
 	}
 
 	action = argv[1];
@@ -276,8 +281,10 @@ static struct bt_l2cap_server br_server = {
 static int cmd_l2cap_register(const struct shell *shell,
 			      size_t argc, char *argv[])
 {
-	if (!shell_cmd_precheck(shell, argc == 2, NULL, 0)) {
-		return 0;
+	int err = shell_cmd_precheck(shell, (argc == 2), NULL, 0);
+
+	if (err) {
+		return err;
 	}
 
 	if (br_server.psm) {
@@ -304,8 +311,9 @@ static int cmd_discoverable(const struct shell *shell,
 	int err;
 	const char *action;
 
-	if (!shell_cmd_precheck(shell, argc == 2, NULL, 0)) {
-		return 0;
+	err = shell_cmd_precheck(shell, (argc == 2), NULL, 0);
+	if (err) {
+		return err;
 	}
 
 	action = argv[1];
@@ -336,8 +344,9 @@ static int cmd_connectable(const struct shell *shell,
 	int err;
 	const char *action;
 
-	if (!shell_cmd_precheck(shell, argc == 2, NULL, 0)) {
-		return 0;
+	err = shell_cmd_precheck(shell, (argc == 2), NULL, 0);
+	if (err) {
+		return err;
 	}
 
 	action = argv[1];
@@ -513,7 +522,7 @@ static struct bt_sdp_discover_params discov;
 static int cmd_sdp_find_record(const struct shell *shell,
 			       size_t argc, char *argv[])
 {
-	int err = 0, res;
+	int err, res;
 	const char *action;
 
 	if (!default_conn) {
@@ -521,8 +530,9 @@ static int cmd_sdp_find_record(const struct shell *shell,
 		return 0;
 	}
 
-	if (!shell_cmd_precheck(shell, argc == 2, NULL, 0)) {
-		return 0;
+	err = shell_cmd_precheck(shell, (argc == 2), NULL, 0);
+	if (err) {
+		return err;
 	}
 
 	action = argv[1];
@@ -574,13 +584,17 @@ SHELL_CREATE_STATIC_SUBCMD_SET(br_cmds) {
 
 static int cmd_br(const struct shell *shell, size_t argc, char **argv)
 {
+	int err;
+
 	if (argc == 1) {
 		shell_help_print(shell, NULL, 0);
-		return 0;
+		/* shell_cmd_precheck returns 1 when help is printed */
+		return 1;
 	}
 
-	if (!shell_cmd_precheck(shell, (argc == 2), NULL, 0)) {
-		return 0;
+	err = shell_cmd_precheck(shell, (argc == 2), NULL, 0);
+	if (err) {
+		return err;
 	}
 
 	error(shell, "%s unknown parameter: %s", argv[0], argv[1]);

--- a/subsys/bluetooth/shell/bt.c
+++ b/subsys/bluetooth/shell/bt.c
@@ -365,8 +365,9 @@ static int cmd_hci_cmd(const struct shell *shell, size_t argc, char *argv[])
 	struct net_buf *buf = NULL, *rsp;
 	int err;
 
-	if (!shell_cmd_precheck(shell, (argc == 3), NULL, 0)) {
-		return 0;
+	err = shell_cmd_precheck(shell, (argc == 3), NULL, 0);
+	if (err) {
+		return err;
 	}
 
 	ogf = strtoul(argv[1], NULL, 16);
@@ -517,7 +518,8 @@ static int cmd_id_select(const struct shell *shell, size_t argc, char *argv[])
 
 	if (argc < 2) {
 		shell_help_print(shell, NULL, 0);
-		return 0;
+		/* shell_cmd_precheck returns 1 when help is printed */
+		return 1;
 	}
 
 	id = strtol(argv[1], NULL, 10);
@@ -604,9 +606,11 @@ static int cmd_scan(const struct shell *shell, size_t argc, char *argv[])
 {
 	const char *action;
 	int dups = -1;
+	int err;
 
-	if (!shell_cmd_precheck(shell, (argc >= 2), NULL, 0)) {
-		return 0;
+	err = shell_cmd_precheck(shell, (argc >= 2), NULL, 0);
+	if (err) {
+		return err;
 	}
 
 	/* Parse duplicate filtering data */
@@ -619,7 +623,8 @@ static int cmd_scan(const struct shell *shell, size_t argc, char *argv[])
 			dups = BT_HCI_LE_SCAN_FILTER_DUP_ENABLE;
 		} else {
 			shell_help_print(shell, NULL, 0);
-			return 0;
+			/* shell_cmd_precheck returns 1 when help is printed */
+			return 1;
 		}
 	}
 
@@ -632,6 +637,8 @@ static int cmd_scan(const struct shell *shell, size_t argc, char *argv[])
 		return cmd_passive_scan_on(shell, dups);
 	} else {
 		shell_help_print(shell, NULL, 0);
+		/* shell_cmd_precheck returns 1 when help is printed */
+		return 1;
 	}
 
 	return 0;
@@ -648,8 +655,9 @@ static int cmd_advertise(const struct shell *shell, size_t argc, char *argv[])
 	size_t ad_len, scan_rsp_len;
 	int err;
 
-	if (!shell_cmd_precheck(shell, (argc >= 2), NULL, 0)) {
-		return 0;
+	err = shell_cmd_precheck(shell, (argc >= 2), NULL, 0);
+	if (err) {
+		return err;
 	}
 
 	if (!strcmp(argv[1], "off")) {
@@ -723,7 +731,8 @@ static int cmd_connect_le(const struct shell *shell, size_t argc, char *argv[])
 
 	if (argc < 3) {
 		shell_help_print(shell, NULL, 0);
-		return 0;
+		/* shell_cmd_precheck returns 1 when help is printed */
+		return 1;
 	}
 
 	err = str2bt_addr_le(argv[1], argv[2], &addr);
@@ -760,7 +769,8 @@ static int cmd_disconnect(const struct shell *shell, size_t argc, char *argv[])
 
 		if (argc < 3) {
 			shell_help_print(shell, NULL, 0);
-			return 0;
+			/* shell_cmd_precheck returns 1 when help is printed */
+			return 1;
 		}
 
 		err = str2bt_addr_le(argv[1], argv[2], &addr);
@@ -796,7 +806,8 @@ static int cmd_auto_conn(const struct shell *shell, size_t argc, char *argv[])
 
 	if (argc < 3) {
 		shell_help_print(shell, NULL, 0);
-		return 0;
+		/* shell_cmd_precheck returns 1 when help is printed */
+		return 1;
 	}
 
 	err = str2bt_addr_le(argv[1], argv[2], &addr);
@@ -813,6 +824,8 @@ static int cmd_auto_conn(const struct shell *shell, size_t argc, char *argv[])
 		return bt_le_set_auto_conn(&addr, NULL);
 	} else {
 		shell_help_print(shell, NULL, 0);
+		/* shell_cmd_precheck returns 1 when help is printed */
+		return 1;
 	}
 
 	return 0;
@@ -826,8 +839,9 @@ static int cmd_directed_adv(const struct shell *shell,
 	struct bt_conn *conn;
 	struct bt_le_adv_param *param = BT_LE_ADV_CONN_DIR;
 
-	if (!shell_cmd_precheck(shell, (argc >= 2), NULL, 0)) {
-		return 0;
+	err = shell_cmd_precheck(shell, (argc >= 2), NULL, 0);
+	if (err) {
+		return err;
 	}
 
 	err = str2bt_addr_le(argv[1], argv[2], &addr);
@@ -841,7 +855,8 @@ static int cmd_directed_adv(const struct shell *shell,
 			param = BT_LE_ADV_CONN_DIR_LOW_DUTY;
 		} else {
 			shell_help_print(shell, NULL, 0);
-			return 0;
+			/* shell_cmd_precheck returns 1 when help is printed */
+			return 1;
 		}
 	}
 
@@ -865,8 +880,9 @@ static int cmd_select(const struct shell *shell, size_t argc, char *argv[])
 	bt_addr_le_t addr;
 	int err;
 
-	if (!shell_cmd_precheck(shell, argc == 3, NULL, 0)) {
-		return 0;
+	err = shell_cmd_precheck(shell, (argc == 3), NULL, 0);
+	if (err) {
+		return err;
 	}
 
 	err = str2bt_addr_le(argv[1], argv[2], &addr);
@@ -896,8 +912,9 @@ static int cmd_conn_update(const struct shell *shell,
 	struct bt_le_conn_param param;
 	int err;
 
-	if (!shell_cmd_precheck(shell, argc == 5, NULL, 0)) {
-		return 0;
+	err = shell_cmd_precheck(shell, (argc == 5), NULL, 0);
+	if (err) {
+		return err;
 	}
 
 	param.interval_min = strtoul(argv[1], NULL, 16);
@@ -990,8 +1007,9 @@ static int cmd_chan_map(const struct shell *shell, size_t argc, char *argv[])
 	u8_t chan_map[5];
 	int err;
 
-	if (!shell_cmd_precheck(shell, argc == 2, NULL, 0)) {
-		return 0;
+	err = shell_cmd_precheck(shell, (argc == 2), NULL, 0);
+	if (err) {
+		return err;
 	}
 
 	err = hexstr2array(argv[1], chan_map, 5);
@@ -1021,8 +1039,9 @@ static int cmd_security(const struct shell *shell, size_t argc, char *argv[])
 		return -ENOEXEC;
 	}
 
-	if (!shell_cmd_precheck(shell, argc == 2, NULL, 0)) {
-		return 0;
+	err = shell_cmd_precheck(shell, (argc == 2), NULL, 0);
+	if (err) {
+		return err;
 	}
 
 	sec = *argv[1] - '0';
@@ -1038,9 +1057,11 @@ static int cmd_security(const struct shell *shell, size_t argc, char *argv[])
 static int cmd_bondable(const struct shell *shell, size_t argc, char *argv[])
 {
 	const char *bondable;
+	int err;
 
-	if (!shell_cmd_precheck(shell, argc == 2, NULL, 0)) {
-		return 0;
+	err = shell_cmd_precheck(shell, (argc == 2), NULL, 0);
+	if (err) {
+		return err;
 	}
 
 	bondable = argv[1];
@@ -1050,6 +1071,8 @@ static int cmd_bondable(const struct shell *shell, size_t argc, char *argv[])
 		bt_set_bondable(false);
 	} else {
 		shell_help_print(shell, NULL, 0);
+		/* shell_cmd_precheck returns 1 when help is printed */
+		return 1;
 	}
 
 	return 0;
@@ -1227,8 +1250,10 @@ static struct bt_conn_auth_cb auth_cb_all = {
 
 static int cmd_auth(const struct shell *shell, size_t argc, char *argv[])
 {
-	if (!shell_cmd_precheck(shell, argc == 2, NULL, 0)) {
-		return 0;
+	int err = shell_cmd_precheck(shell, (argc == 2), NULL, 0);
+
+	if (err) {
+		return err;
 	}
 
 	if (!strcmp(argv[1], "all")) {
@@ -1245,6 +1270,8 @@ static int cmd_auth(const struct shell *shell, size_t argc, char *argv[])
 		bt_conn_auth_cb_register(NULL);
 	} else {
 		shell_help_print(shell, NULL, 0);
+		/* shell_cmd_precheck returns 1 when help is printed */
+		return 1;
 	}
 
 	return 0;
@@ -1328,6 +1355,7 @@ static int cmd_fixed_passkey(const struct shell *shell,
 static int cmd_auth_passkey(const struct shell *shell,
 			    size_t argc, char *argv[])
 {
+	int err;
 	unsigned int passkey;
 
 	if (!default_conn) {
@@ -1335,14 +1363,15 @@ static int cmd_auth_passkey(const struct shell *shell,
 		return -ENOEXEC;
 	}
 
-	if (!shell_cmd_precheck(shell, argc == 2, NULL, 0)) {
-		return 0;
+	err = shell_cmd_precheck(shell, (argc == 2), NULL, 0);
+	if (err) {
+		return err;
 	}
 
 	passkey = atoi(argv[1]);
 	if (passkey > 999999) {
 		print(shell, "Passkey should be between 0-999999");
-		return -ENOEXEC;
+		return -EINVAL;
 	}
 
 	bt_conn_auth_passkey_entry(default_conn, passkey);
@@ -1418,18 +1447,22 @@ SHELL_CREATE_STATIC_SUBCMD_SET(bt_cmds) {
 
 static int cmd_bt(const struct shell *shell, size_t argc, char **argv)
 {
+	int err;
+
 	if (argc == 1) {
 		shell_help_print(shell, NULL, 0);
-		return 0;
+		/* shell_cmd_precheck returns 1 when help is printed */
+		return 1;
 	}
 
-	if (!shell_cmd_precheck(shell, (argc == 2), NULL, 0)) {
-		return 0;
+	err = shell_cmd_precheck(shell, (argc == 2), NULL, 0);
+	if (err) {
+		return err;
 	}
 
 	error(shell, "%s unknown parameter: %s", argv[0], argv[1]);
 
-	return -ENOEXEC;
+	return -EINVAL;
 }
 
 SHELL_CMD_REGISTER(bt, &bt_cmds, "Bluetooth shell commands", cmd_bt);

--- a/subsys/bluetooth/shell/gatt.c
+++ b/subsys/bluetooth/shell/gatt.c
@@ -225,8 +225,9 @@ static int cmd_read(const struct shell *shell, size_t argc, char *argv[])
 
 	read_params.func = read_func;
 
-	if (!shell_cmd_precheck(shell, (argc >= 2), NULL, 0)) {
-		return 0;
+	err = shell_cmd_precheck(shell, (argc >= 2), NULL, 0);
+	if (err) {
+		return err;
 	}
 
 	read_params.handle_count = 1;
@@ -257,14 +258,15 @@ static int cmd_mread(const struct shell *shell, size_t argc, char *argv[])
 		return -ENOEXEC;
 	}
 
-	if (!shell_cmd_precheck(shell, (argc >= 3), NULL, 0)) {
-		return 0;
+	err = shell_cmd_precheck(shell, (argc >= 3), NULL, 0);
+	if (err) {
+		return err;
 	}
 
-	if (argc - 1 >  ARRAY_SIZE(h)) {
+	if ((argc - 1) >  ARRAY_SIZE(h)) {
 		print(shell, "Enter max %lu handle items to read",
 		      ARRAY_SIZE(h));
-		return -ENOEXEC;
+		return -EINVAL;
 	}
 
 	for (i = 0; i < argc - 1; i++) {
@@ -311,8 +313,9 @@ static int cmd_write(const struct shell *shell, size_t argc, char *argv[])
 	}
 
 
-	if (!shell_cmd_precheck(shell, (argc >= 4), NULL, 0)) {
-		return 0;
+	err = shell_cmd_precheck(shell, (argc >= 4), NULL, 0);
+	if (err) {
+		return err;
 	}
 
 	handle = strtoul(argv[1], NULL, 16);
@@ -353,7 +356,7 @@ static int cmd_write_without_rsp(const struct shell *shell,
 {
 	u16_t handle;
 	u16_t repeat;
-	int err = 0;
+	int err;
 	u16_t len;
 	bool sign;
 
@@ -362,8 +365,9 @@ static int cmd_write_without_rsp(const struct shell *shell,
 		return -ENOEXEC;
 	}
 
-	if (!shell_cmd_precheck(shell, (argc >= 3), NULL, 0)) {
-		return 0;
+	err = shell_cmd_precheck(shell, (argc >= 3), NULL, 0);
+	if (err) {
+		return err;
 	}
 
 	sign = !strcmp(argv[0], "signed-write");
@@ -435,8 +439,8 @@ static int cmd_subscribe(const struct shell *shell, size_t argc, char *argv[])
 		return -ENOEXEC;
 	}
 
-	if (!shell_cmd_precheck(shell, (argc >= 3), NULL, 0)) {
-		return 0;
+	err = shell_cmd_precheck(shell, (argc >= 3), NULL, 0); {
+		return err;
 	}
 
 	subscribe_params.ccc_handle = strtoul(argv[1], NULL, 16);
@@ -814,18 +818,22 @@ SHELL_CREATE_STATIC_SUBCMD_SET(gatt_cmds) {
 
 static int cmd_gatt(const struct shell *shell, size_t argc, char **argv)
 {
+	int err;
+
 	if (argc == 1) {
 		shell_help_print(shell, NULL, 0);
-		return 0;
+		/* shell_cmd_precheck returns 1 when help is printed */
+		return 1;
 	}
 
-	if (!shell_cmd_precheck(shell, (argc == 2), NULL, 0)) {
-		return 0;
+	err = shell_cmd_precheck(shell, (argc == 2), NULL, 0);
+	if (err) {
+		return err;
 	}
 
 	error(shell, "%s unknown parameter: %s", argv[0], argv[1]);
 
-	return -ENOEXEC;
+	return -EINVAL;
 }
 
 SHELL_CMD_REGISTER(gatt, &gatt_cmds, "Bluetooth GATT shell commands", cmd_gatt);

--- a/subsys/bluetooth/shell/l2cap.c
+++ b/subsys/bluetooth/shell/l2cap.c
@@ -165,9 +165,11 @@ static struct bt_l2cap_server server = {
 
 static int cmd_register(const struct shell *shell, size_t argc, char *argv[])
 {
+	int err;
 
-	if (!shell_cmd_precheck(shell, argc >= 2, NULL, 0)) {
-		return 0;
+	err = shell_cmd_precheck(shell, (argc >= 2), NULL, 0);
+	if (err) {
+		return err;
 	}
 
 	if (server.psm) {
@@ -203,8 +205,9 @@ static int cmd_connect(const struct shell *shell, size_t argc, char *argv[])
 		return -ENOEXEC;
 	}
 
-	if (!shell_cmd_precheck(shell, argc == 2, NULL, 0)) {
-		return 0;
+	err = shell_cmd_precheck(shell, (argc == 2), NULL, 0);
+	if (err) {
+		return err;
 	}
 
 	if (l2ch_chan.ch.chan.conn) {
@@ -316,13 +319,17 @@ SHELL_CREATE_STATIC_SUBCMD_SET(l2cap_cmds) {
 
 static int cmd_l2cap(const struct shell *shell, size_t argc, char **argv)
 {
+	int err;
+
 	if (argc == 1) {
 		shell_help_print(shell, NULL, 0);
-		return 0;
+		/* shell_cmd_precheck returns 1 when help is printed */
+		return 1;
 	}
 
-	if (!shell_cmd_precheck(shell, (argc == 2), NULL, 0)) {
-		return 0;
+	err = shell_cmd_precheck(shell, (argc == 2), NULL, 0);
+	if (err) {
+		return err;
 	}
 
 	error(shell, "%s unknown parameter: %s", argv[0], argv[1]);

--- a/subsys/bluetooth/shell/rfcomm.c
+++ b/subsys/bluetooth/shell/rfcomm.c
@@ -181,8 +181,9 @@ static int cmd_connect(const struct shell *shell, size_t argc, char *argv[])
 		return -ENOEXEC;
 	}
 
-	if (!shell_cmd_precheck(shell, argc == 2, NULL, 0)) {
-		return 0;
+	err = shell_cmd_precheck(shell, (argc == 2), NULL, 0);
+	if (err) {
+		return err;
 	}
 
 	channel = strtoul(argv[1], NULL, 16);
@@ -250,13 +251,17 @@ SHELL_CREATE_STATIC_SUBCMD_SET(rfcomm_cmds) {
 
 static int cmd_rfcomm(const struct shell *shell, size_t argc, char **argv)
 {
+	int err;
+
 	if (argc == 1) {
 		shell_help_print(shell, NULL, 0);
-		return 0;
+		/* shell_cmd_precheck returns 1 when help is printed */
+		return 1;
 	}
 
-	if (!shell_cmd_precheck(shell, (argc == 2), NULL, 0)) {
-		return 0;
+	err = shell_cmd_precheck(shell, (argc == 2), NULL, 0);
+	if (err) {
+		return err;
 	}
 
 	error(shell, "%s unknown parameter: %s", argv[0], argv[1]);

--- a/subsys/bluetooth/shell/ticker.c
+++ b/subsys/bluetooth/shell/ticker.c
@@ -133,13 +133,17 @@ SHELL_CREATE_STATIC_SUBCMD_SET(ticker_cmds) {
 
 static int cmd_ticker(const struct shell *shell, size_t argc, char **argv)
 {
+	int err;
+
 	if (argc == 1) {
 		shell_help_print(shell, NULL, 0);
-		return 0;
+		/* shell_cmd_precheck returns 1 when help is printed */
+		return 1;
 	}
 
-	if (!shell_cmd_precheck(shell, (argc == 2), NULL, 0)) {
-		return 0;
+	err = shell_cmd_precheck(shell, (argc == 2), NULL, 0);
+	if (err) {
+		return err;
 	}
 
 	error(shell, "%s:%s%s", argv[0], "unknown parameter: ", argv[1]);

--- a/subsys/fs/shell.c
+++ b/subsys/fs/shell.c
@@ -93,13 +93,13 @@ static int cmd_cd(const struct shell *shell, size_t argc, char **argv)
 
 	err = fs_stat(path, &entry);
 	if (err) {
-		shell_fprintf(shell, SHELL_ERROR, "%s doesn't exist\r\n", path);
+		shell_fprintf(shell, SHELL_ERROR, "%s doesn't exist\n", path);
 		return -ENOEXEC;
 	}
 
 	if (entry.type != FS_DIR_ENTRY_DIR) {
 		shell_fprintf(shell, SHELL_ERROR,
-				"%s is not a directory\r\n", path);
+				"%s is not a directory\n", path);
 		return -ENOEXEC;
 	}
 
@@ -123,7 +123,7 @@ static int cmd_ls(const struct shell *shell, size_t argc, char **argv)
 	err = fs_opendir(&dir, path);
 	if (err) {
 		shell_fprintf(shell, SHELL_ERROR,
-			      "Unable to open %s (err %d)\r\n", path, err);
+			      "Unable to open %s (err %d)\n", path, err);
 		return -ENOEXEC;
 	}
 
@@ -133,7 +133,7 @@ static int cmd_ls(const struct shell *shell, size_t argc, char **argv)
 		err = fs_readdir(&dir, &entry);
 		if (err) {
 			shell_fprintf(shell, SHELL_ERROR,
-				      "Unable to read directory\r\n");
+				      "Unable to read directory\n");
 			break;
 		}
 
@@ -142,7 +142,7 @@ static int cmd_ls(const struct shell *shell, size_t argc, char **argv)
 			break;
 		}
 
-		shell_fprintf(shell, SHELL_NORMAL, "%s%s\r\n",
+		shell_fprintf(shell, SHELL_NORMAL, "%s%s\n",
 			      entry.name,
 			      (entry.type == FS_DIR_ENTRY_DIR) ? "/" : "");
 	}
@@ -154,7 +154,7 @@ static int cmd_ls(const struct shell *shell, size_t argc, char **argv)
 
 static int cmd_pwd(const struct shell *shell, size_t argc, char **argv)
 {
-	shell_fprintf(shell, SHELL_NORMAL, "%s\r\n", cwd);
+	shell_fprintf(shell, SHELL_NORMAL, "%s\n", cwd);
 
 	return 0;
 }
@@ -166,8 +166,9 @@ static int cmd_trunc(const struct shell *shell, size_t argc, char **argv)
 	int length;
 	int err;
 
-	if (!shell_cmd_precheck(shell, (argc >= 2), NULL, 0)) {
-		return 0;
+	err = hell_cmd_precheck(shell, (argc >= 2), NULL, 0);
+	if (err) {
+		return err;
 	}
 
 	if (argv[1][0] == '/') {
@@ -190,14 +191,14 @@ static int cmd_trunc(const struct shell *shell, size_t argc, char **argv)
 	err = fs_open(&file, path);
 	if (err) {
 		shell_fprintf(shell, SHELL_ERROR,
-			      "Failed to open %s (%d)\r\n", path, err);
+			      "Failed to open %s (%d)\n", path, err);
 		return -ENOEXEC;;
 	}
 
 	err = fs_truncate(&file, length);
 	if (err) {
 		shell_fprintf(shell, SHELL_ERROR,
-			      "Failed to truncate %s (%d)\r\n", path, err);
+			      "Failed to truncate %s (%d)\n", path, err);
 		err = -ENOEXEC;
 	}
 
@@ -211,8 +212,9 @@ static int cmd_mkdir(const struct shell *shell, size_t argc, char **argv)
 	int err;
 	char path[MAX_PATH_LEN];
 
-	if (!shell_cmd_precheck(shell, (argc == 2), NULL, 0)) {
-		return 0;
+	err = shell_cmd_precheck(shell, (argc == 2), NULL, 0);
+	if (err) {
+		return err;
 	}
 
 	create_abs_path(argv[1], path, sizeof(path));
@@ -220,7 +222,7 @@ static int cmd_mkdir(const struct shell *shell, size_t argc, char **argv)
 	err = fs_mkdir(path);
 	if (err) {
 		shell_fprintf(shell, SHELL_ERROR,
-				"Error creating dir[%d]\r\n", err);
+				"Error creating dir[%d]\n", err);
 		err = -ENOEXEC;
 	}
 
@@ -232,8 +234,9 @@ static int cmd_rm(const struct shell *shell, size_t argc, char **argv)
 	int err;
 	char path[MAX_PATH_LEN];
 
-	if (!shell_cmd_precheck(shell, (argc == 2), NULL, 0)) {
-		return 0;
+	err = shell_cmd_precheck(shell, (argc == 2), NULL, 0);
+	if (err) {
+		return err;
 	}
 
 	create_abs_path(argv[1], path, sizeof(path));
@@ -241,7 +244,7 @@ static int cmd_rm(const struct shell *shell, size_t argc, char **argv)
 	err = fs_unlink(path);
 	if (err) {
 		shell_fprintf(shell, SHELL_ERROR,
-				"Failed to remove %s (%d)\r\n", path, err);
+				"Failed to remove %s (%d)\n", path, err);
 		err = -ENOEXEC;
 	}
 
@@ -257,8 +260,9 @@ static int cmd_read(const struct shell *shell, size_t argc, char **argv)
 	off_t offset;
 	int err;
 
-	if (!shell_cmd_precheck(shell, (argc >= 2), NULL, 0)) {
-		return 0;
+	err = shell_cmd_precheck(shell, (argc >= 2), NULL, 0);
+	if (err) {
+		return err;
 	}
 
 	create_abs_path(argv[1], path, sizeof(path));
@@ -281,22 +285,22 @@ static int cmd_read(const struct shell *shell, size_t argc, char **argv)
 	err = fs_stat(path, &dirent);
 	if (err) {
 		shell_fprintf(shell, SHELL_ERROR,
-			      "Failed to obtain file %s (err: %d)\r\n",
+			      "Failed to obtain file %s (err: %d)\n",
 			      path, err);
 		return -ENOEXEC;
 	}
 
 	if (dirent.type != FS_DIR_ENTRY_FILE) {
-		shell_fprintf(shell, SHELL_ERROR, "Note a file %s\r\n",
+		shell_fprintf(shell, SHELL_ERROR, "Note a file %s\n",
 				path);
 		return -ENOEXEC;
 	}
 
-	shell_fprintf(shell, SHELL_NORMAL, "File size: %zd\r\n", dirent.size);
+	shell_fprintf(shell, SHELL_NORMAL, "File size: %zd\n", dirent.size);
 
 	err = fs_open(&file, path);
 	if (err) {
-		shell_fprintf(shell, SHELL_ERROR, "Failed to open %s (%d)\r\n",
+		shell_fprintf(shell, SHELL_ERROR, "Failed to open %s (%d)\n",
 				path, err);
 		return -ENOEXEC;
 	}
@@ -331,7 +335,7 @@ static int cmd_read(const struct shell *shell, size_t argc, char **argv)
 			       buf[i] > 127 ? '.' : buf[i]);
 		}
 
-		shell_fprintf(shell, SHELL_NORMAL, "\r\n");
+		shell_fprintf(shell, SHELL_NORMAL, "\n");
 
 		offset += read;
 		count -= read;
@@ -352,8 +356,9 @@ static int cmd_write(const struct shell *shell, size_t argc, char **argv)
 	off_t offset = -1;
 	int err;
 
-	if (!shell_cmd_precheck(shell, (argc >= 3), NULL, 0)) {
-		return 0;
+	err = shell_cmd_precheck(shell, (argc >= 3), NULL, 0);
+	if (err) {
+		return err;
 	}
 
 	create_abs_path(argv[1], path, sizeof(path));
@@ -361,7 +366,7 @@ static int cmd_write(const struct shell *shell, size_t argc, char **argv)
 	if (!strcmp(argv[2], "-o")) {
 		if (argc < 4) {
 			shell_fprintf(shell, SHELL_ERROR,
-					"Missing argument\r\n");
+					"Missing argument\n");
 			return -ENOEXEC;
 		}
 
@@ -374,7 +379,7 @@ static int cmd_write(const struct shell *shell, size_t argc, char **argv)
 
 	err = fs_open(&file, path);
 	if (err) {
-		shell_fprintf(shell, SHELL_ERROR, "Failed to open %s (%d)\r\n",
+		shell_fprintf(shell, SHELL_ERROR, "Failed to open %s (%d)\n",
 				path, err);
 		return -ENOEXEC;
 	}
@@ -386,7 +391,7 @@ static int cmd_write(const struct shell *shell, size_t argc, char **argv)
 	}
 	if (err) {
 		shell_fprintf(shell, SHELL_ERROR,
-				"Failed to seek %s (%d)\r\n", path, err);
+				"Failed to seek %s (%d)\n", path, err);
 		fs_close(&file);
 		return -ENOEXEC;
 	}
@@ -399,7 +404,7 @@ static int cmd_write(const struct shell *shell, size_t argc, char **argv)
 			err = fs_write(&file, buf, buf_len);
 			if (err < 0) {
 				shell_fprintf(shell, SHELL_ERROR,
-					      "Failed to write %s (%d)\r\n",
+					      "Failed to write %s (%d)\n",
 					      path, err);
 				fs_close(&file);
 				return -ENOEXEC;
@@ -434,14 +439,15 @@ static int cmd_mount_fat(const struct shell *shell, size_t argc, char **argv)
 	char *mntpt;
 	int res;
 
-	if (!shell_cmd_precheck(shell, (argc == 2), NULL, 0)) {
-		return 0;
+	res = shell_cmd_precheck(shell, (argc == 2), NULL, 0);
+	if (res) {
+		return res;
 	}
 
 	mntpt = mntpt_prepare(argv[1]);
 	if (!mntpt) {
 		shell_fprintf(shell, SHELL_ERROR,
-			"Failed to allocate  buffer for mount point\r\n");
+			"Failed to allocate  buffer for mount point\n");
 		return -ENOEXEC;
 	}
 
@@ -449,11 +455,11 @@ static int cmd_mount_fat(const struct shell *shell, size_t argc, char **argv)
 	res = fs_mount(&fatfs_mnt);
 	if (res != 0) {
 		shell_fprintf(shell, SHELL_ERROR,
-			      "Error mounting fat fs.Error Code [%d]\r\n", res);
+			      "Error mounting fat fs.Error Code [%d]\n", res);
 		return -ENOEXEC;
 	}
 
-	shell_fprintf(shell, SHELL_NORMAL, "Successfully mounted fat fs:%s\r\n",
+	shell_fprintf(shell, SHELL_NORMAL, "Successfully mounted fat fs:%s\n",
 			fatfs_mnt.mnt_point);
 
 	return 0;
@@ -467,14 +473,15 @@ static int cmd_mount_nffs(const struct shell *shell, size_t argc, char **argv)
 	char *mntpt;
 	int res;
 
-	if (!shell_cmd_precheck(shell, (argc == 2), NULL, 0)) {
-		return 0;
+	res = shell_cmd_precheck(shell, (argc == 2), NULL, 0);
+	if (res) {
+		return res;
 	}
 
 	mntpt = mntpt_prepare(argv[1]);
 	if (!mntpt) {
 		shell_fprintf(shell, SHELL_ERROR,
-			"Failed to allocate  buffer for mount point\r\n");
+			"Failed to allocate  buffer for mount point\n");
 		return -ENOEXEC;
 	}
 
@@ -489,12 +496,12 @@ static int cmd_mount_nffs(const struct shell *shell, size_t argc, char **argv)
 	res = fs_mount(&nffs_mnt);
 	if (res != 0) {
 		shell_fprintf(shell, SHELL_ERROR,
-			      "Error mounting fat fs.Error Code [%d]\r\n", res);
+			      "Error mounting fat fs.Error Code [%d]\n", res);
 		return -ENOEXEC;
 	}
 
 	shell_fprintf(shell, SHELL_NORMAL,
-		      "Successfully mounted fs:%s\r\n", nffs_mnt.mnt_point);
+		      "Successfully mounted fs:%s\n", nffs_mnt.mnt_point);
 
 	return 0;
 }

--- a/subsys/logging/log_cmds.c
+++ b/subsys/logging/log_cmds.c
@@ -228,9 +228,10 @@ static int log_enable(const struct shell *shell,
 		      char **argv)
 {
 	int severity_level;
+	int err = shell_cmd_precheck(shell, (argc > 1), NULL, 0);
 
-	if (!shell_cmd_precheck(shell, (argc > 1), NULL, 0)) {
-		return 0;
+	if (err) {
+		return err;
 	}
 
 	severity_level = severity_level_get(argv[1]);
@@ -267,8 +268,10 @@ static int log_disable(const struct shell *shell,
 		       size_t argc,
 		       char **argv)
 {
-	if (!shell_cmd_precheck(shell, (argc > 1), NULL, 0)) {
-		return 0;
+	int err = shell_cmd_precheck(shell, (argc > 1), NULL, 0);
+
+	if (err) {
+		return err;
 	}
 
 	filters_set(shell, backend, argc - 1, &argv[1], LOG_LEVEL_NONE);
@@ -372,9 +375,10 @@ static int cmd_log_backends_list(const struct shell *shell,
 				 size_t argc, char **argv)
 {
 	int backend_count;
+	int err = shell_cmd_precheck(shell, (argc == 1), NULL, 0);
 
-	if (!shell_cmd_precheck(shell, (argc == 1), NULL, 0)) {
-		return 0;
+	if (err) {
+		return err;
 	}
 
 	backend_count = log_backend_count_get();

--- a/subsys/shell/shell.c
+++ b/subsys/shell/shell.c
@@ -1700,29 +1700,29 @@ int shell_prompt_change(const struct shell *shell, char *prompt)
 	return -1;
 }
 
-bool shell_cmd_precheck(const struct shell *shell,
-			bool arg_cnt_ok,
-			const struct shell_getopt_option *opt,
-			size_t opt_len)
+int shell_cmd_precheck(const struct shell *shell,
+		       bool arg_cnt_ok,
+		       const struct shell_getopt_option *opt,
+		       size_t opt_len)
 {
 	if (shell_help_requested(shell)) {
 		shell_help_print(shell, opt, opt_len);
-		return false;
+		return 1; /* help printed */
 	}
 
 	if (!arg_cnt_ok) {
 		shell_fprintf(shell, SHELL_ERROR,
-			      "%s: wrong parameter count\r\n",
+			      "%s: wrong parameter count\n",
 			      shell->ctx->active_cmd.syntax);
 
-		if (IS_ENABLED(SHELL_HELP_ON_WRONG_ARGUMENT_COUNT)) {
+		if (IS_ENABLED(CONFIG_SHELL_HELP_ON_WRONG_ARGUMENT_COUNT)) {
 			shell_help_print(shell, opt, opt_len);
 		}
 
-		return false;
+		return -EINVAL;
 	}
 
-	return true;
+	return 0;
 }
 
 int shell_execute_cmd(const struct shell *shell, const char *cmd)

--- a/subsys/shell/shell_cmds.c
+++ b/subsys/shell/shell_cmds.c
@@ -9,7 +9,7 @@
 #include "shell_vt100.h"
 
 #define SHELL_HELP_CLEAR		"Clear screen."
-#define SHELL_HELP_BACKSPACE_MODE	"Toggle backspace key mode.\r\n" \
+#define SHELL_HELP_BACKSPACE_MODE	"Toggle backspace key mode.\n" \
 	"Some terminals are not sending separate escape code for"	 \
 	"backspace and delete button. Hence backspace is not working as" \
 	"expected. This command can force shell to interpret delete"	 \
@@ -182,156 +182,195 @@ static int terminal_size_get(const struct shell *shell)
 
 static int cmd_clear(const struct shell *shell, size_t argc, char **argv)
 {
-	(void)argv;
+	ARG_UNUSED(argv);
 
-	if ((argc == 2) && (shell_help_requested(shell))) {
-		shell_help_print(shell, NULL, 0);
-		return 0;
+	int ret = shell_cmd_precheck(shell, (argc == 1), NULL, 0);
+
+	if (ret) {
+		return ret;
 	}
+
 	SHELL_VT100_CMD(shell, SHELL_VT100_CURSORHOME);
 	SHELL_VT100_CMD(shell, SHELL_VT100_CLEARSCREEN);
+
 	return 0;
 }
 
 static int cmd_shell(const struct shell *shell, size_t argc, char **argv)
 {
-	(void)argv;
+	int ret = shell_cmd_precheck(shell, (argc == 2), NULL, 0);
 
-	if ((argc == 1) || ((argc == 2) && shell_help_requested(shell))) {
-		shell_help_print(shell, NULL, 0);
-		return 0;
+	if (ret) {
+		return ret;
 	}
 
-	shell_fprintf(shell, SHELL_ERROR, SHELL_MSG_SPECIFY_SUBCOMMAND);
-	return 0;
-}
+	shell_fprintf(shell, SHELL_ERROR, "%s:%s%s\n", argv[0],
+		      SHELL_MSG_UNKNOWN_PARAMETER, argv[1]);
 
-static int cmd_bacskpace_mode(const struct shell *shell, size_t argc,
-			       char **argv)
-{
-	(void)shell_cmd_precheck(shell, (argc == 2), NULL, 0);
-	return 0;
+	return -EINVAL;
 }
 
 static int cmd_bacskpace_mode_backspace(const struct shell *shell, size_t argc,
-					 char **argv)
+					char **argv)
 {
-	if (!shell_cmd_precheck(shell, (argc == 1), NULL, 0)) {
-		return 0;
+	ARG_UNUSED(argv);
+
+	int ret = shell_cmd_precheck(shell, (argc == 1), NULL, 0);
+
+	if (ret == 0) {
+		shell->ctx->internal.flags.mode_delete = 0;
 	}
 
-	shell->ctx->internal.flags.mode_delete = 0;
-	return 0;
+	return ret;
 }
 
 static int cmd_bacskpace_mode_delete(const struct shell *shell, size_t argc,
 				      char **argv)
 {
-	if (!shell_cmd_precheck(shell, (argc == 1), NULL, 0)) {
-		return 0;
+	ARG_UNUSED(argv);
+
+	int ret = shell_cmd_precheck(shell, (argc == 1), NULL, 0);
+
+	if (ret == 0) {
+		shell->ctx->internal.flags.mode_delete = 1;
 	}
 
-	shell->ctx->internal.flags.mode_delete = 1;
-	return 0;
+	return ret;
+}
+
+static int cmd_bacskpace_mode(const struct shell *shell, size_t argc,
+			      char **argv)
+{
+	int ret = shell_cmd_precheck(shell, (argc == 2), NULL, 0);
+
+	if (ret) {
+		return ret;
+	}
+
+	shell_fprintf(shell, SHELL_ERROR, "%s:%s%s\n", argv[0],
+		      SHELL_MSG_UNKNOWN_PARAMETER, argv[1]);
+
+	return -EINVAL;
 }
 
 static int cmd_colors_off(const struct shell *shell, size_t argc, char **argv)
 {
-	if (!shell_cmd_precheck(shell, (argc == 1), NULL, 0)) {
-		return 0;
+	ARG_UNUSED(argv);
+
+	int ret = shell_cmd_precheck(shell, (argc == 1), NULL, 0);
+
+	if (ret == 0) {
+		shell->ctx->internal.flags.use_colors = 0;
 	}
 
-	shell->ctx->internal.flags.use_colors = 0;
-	return 0;
+	return ret;
 }
 
 static int cmd_colors_on(const struct shell *shell, size_t argc, char **argv)
 {
-	if (!shell_cmd_precheck(shell, (argc == 1), NULL, 0)) {
-		return 0;
+	ARG_UNUSED(argv);
+
+	int ret = shell_cmd_precheck(shell, (argc == 1), NULL, 0);
+
+	if (ret == 0) {
+		shell->ctx->internal.flags.use_colors = 1;
 	}
-	shell->ctx->internal.flags.use_colors = 1;
-	return 0;
+
+	return ret;
 }
 
 static int cmd_colors(const struct shell *shell, size_t argc, char **argv)
 {
-	if (argc == 1) {
-		shell_help_print(shell, NULL, 0);
-		return 0;
+	int ret = shell_cmd_precheck(shell, (argc == 2), NULL, 0);
+
+	if (ret) {
+		return ret;
 	}
 
-	if (!shell_cmd_precheck(shell, (argc == 2), NULL, 0)) {
-		return 0;
-	}
-
-	shell_fprintf(shell, SHELL_ERROR, "%s:%s%s\r\n", argv[0],
+	shell_fprintf(shell, SHELL_ERROR, "%s:%s%s\n", argv[0],
 		      SHELL_MSG_UNKNOWN_PARAMETER, argv[1]);
-	return -ENOEXEC;
-}
 
-static int cmd_echo(const struct shell *shell, size_t argc, char **argv)
-{
-	if (!shell_cmd_precheck(shell, (argc <= 2), NULL, 0)) {
-		return 0;
-	}
-
-	if (argc == 2) {
-		shell_fprintf(shell, SHELL_ERROR, "%s:%s%s\r\n", argv[0],
-			      SHELL_MSG_UNKNOWN_PARAMETER, argv[1]);
-		return -ENOEXEC;
-	}
-
-	shell_fprintf(shell, SHELL_NORMAL, "Echo status: %s\r\n",
-		      flag_echo_is_set(shell) ? "on" : "off");
-	return 0;
+	return -EINVAL;
 }
 
 static int cmd_echo_off(const struct shell *shell, size_t argc, char **argv)
 {
-	if (!shell_cmd_precheck(shell, (argc == 1), NULL, 0)) {
-		return 0;
+	ARG_UNUSED(argv);
+
+	int ret = shell_cmd_precheck(shell, (argc == 1), NULL, 0);
+
+	if (ret == 0) {
+		shell->ctx->internal.flags.echo = 0;
 	}
 
-	shell->ctx->internal.flags.echo = 0;
-	return 0;
+	return ret;
 }
 
 static int cmd_echo_on(const struct shell *shell, size_t argc, char **argv)
 {
-	if (!shell_cmd_precheck(shell, (argc == 1), NULL, 0)) {
-		return 0;
+	ARG_UNUSED(argv);
+
+	int ret = shell_cmd_precheck(shell, (argc == 1), NULL, 0);
+
+	if (ret == 0) {
+		shell->ctx->internal.flags.echo = 1;
 	}
 
-	shell->ctx->internal.flags.echo = 1;
+	return ret;
+}
+
+static int cmd_echo(const struct shell *shell, size_t argc, char **argv)
+{
+	int ret = shell_cmd_precheck(shell, (argc <= 2), NULL, 0);
+
+	if (ret) {
+		return ret;
+	}
+
+	if (argc == 2) {
+		shell_fprintf(shell, SHELL_ERROR, "%s:%s%s\n", argv[0],
+			      SHELL_MSG_UNKNOWN_PARAMETER, argv[1]);
+		return -EINVAL;
+	}
+
+	shell_fprintf(shell, SHELL_NORMAL, "Echo status: %s\n",
+		      flag_echo_is_set(shell) ? "on" : "off");
+
 	return 0;
 }
 
 static int cmd_help(const struct shell *shell, size_t argc, char **argv)
 {
-	shell_fprintf(shell, SHELL_NORMAL, "Please press the <Tab> button to "
-					   "see all available commands.\r\n"
-					   "You can also use the <Tab> button "
-					   "to prompt or auto-complete all "
-					   "commands or its subcommands.\r\n"
-					   "You can try to call commands "
-					   "with <-h> or <--help> parameter to "
-					   "get know what they are doing.\r\n");
+	ARG_UNUSED(argc);
+	ARG_UNUSED(argv);
+
+	shell_fprintf(shell, SHELL_NORMAL,
+		"Please press the <Tab> button to see all available commands.\n"
+		"You can also use the <Tab> button to prompt or auto-complete"
+		"all commands or its subcommands.\n"
+		"You can try to call commands with <-h> or <--help> parameter"
+		" for more information.\n");
+
 	return 0;
 }
 
 static int cmd_history(const struct shell *shell, size_t argc, char **argv)
 {
+	ARG_UNUSED(argv);
+
 	size_t i = 0;
 	size_t len;
+	int ret;
 
 	if (!IS_ENABLED(CONFIG_SHELL_HISTORY)) {
-		shell_fprintf(shell, SHELL_ERROR, "Command not supported.\r\n");
+		shell_fprintf(shell, SHELL_ERROR, "Command not supported.\n");
 		return -ENOEXEC;
 	}
 
-	if (!shell_cmd_precheck(shell, (argc == 1), NULL, 0)) {
-		return 0;
+	ret = shell_cmd_precheck(shell, (argc == 1), NULL, 0);
+
+	if (ret) {
+		return ret;
 	}
 
 	while (1) {
@@ -339,7 +378,7 @@ static int cmd_history(const struct shell *shell, size_t argc, char **argv)
 				  shell->ctx->temp_buff, &len);
 
 		if (len) {
-			shell_fprintf(shell, SHELL_NORMAL, "[%3d] %s\r\n",
+			shell_fprintf(shell, SHELL_NORMAL, "[%3d] %s\n",
 				      i++, shell->ctx->temp_buff);
 
 		} else {
@@ -348,70 +387,82 @@ static int cmd_history(const struct shell *shell, size_t argc, char **argv)
 	}
 
 	shell->ctx->temp_buff[0] = '\0';
-	return 0;
-}
 
-static int cmd_shell_stats(const struct shell *shell, size_t argc, char **argv)
-{
-	if (argc == 1) {
-		shell_help_print(shell, NULL, 0);
-		return 0;
-	}
-
-	if (argc == 2) {
-		shell_fprintf(shell, SHELL_ERROR, "%s:%s%s\r\n", argv[0],
-			      SHELL_MSG_UNKNOWN_PARAMETER, argv[1]);
-		return -ENOEXEC;
-	}
-
-	(void)shell_cmd_precheck(shell, (argc <= 2), NULL, 0);
 	return 0;
 }
 
 static int cmd_shell_stats_show(const struct shell *shell, size_t argc,
 				char **argv)
 {
+	ARG_UNUSED(argv);
+
 	if (!IS_ENABLED(CONFIG_SHELL_STATS)) {
-		shell_fprintf(shell, SHELL_ERROR, "Command not supported.\r\n");
+		shell_fprintf(shell, SHELL_ERROR, "Command not supported.\n");
 		return -ENOEXEC;
 	}
 
-	if (!shell_cmd_precheck(shell, (argc == 1), NULL, 0)) {
-		return 0;
+	int ret = shell_cmd_precheck(shell, (argc == 1), NULL, 0);
+
+	if (ret == 0) {
+		shell_fprintf(shell, SHELL_NORMAL, "Lost logs: %u\n",
+			      shell->stats->log_lost_cnt);
 	}
 
-	shell_fprintf(shell, SHELL_NORMAL, "Lost logs: %u\r\n",
-		      shell->stats->log_lost_cnt);
-	return 0;
+	return ret;
 }
 
 static int cmd_shell_stats_reset(const struct shell *shell,
 				 size_t argc, char **argv)
 {
+	ARG_UNUSED(argv);
+
 	if (!IS_ENABLED(CONFIG_SHELL_STATS)) {
-		shell_fprintf(shell, SHELL_ERROR, "Command not supported.\r\n");
+		shell_fprintf(shell, SHELL_ERROR, "Command not supported.\n");
 		return -ENOEXEC;
 	}
 
-	if (!shell_cmd_precheck(shell, (argc == 1), NULL, 0)) {
-		return 0;
+	int ret = shell_cmd_precheck(shell, (argc == 1), NULL, 0);
+
+	if (ret == 0) {
+		shell->stats->log_lost_cnt = 0;
 	}
 
-	shell->stats->log_lost_cnt = 0;
-	return 0;
+	return ret;
+}
+
+static int cmd_shell_stats(const struct shell *shell, size_t argc, char **argv)
+{
+	ARG_UNUSED(argc);
+
+	if (shell_help_requested(shell)) {
+		shell_help_print(shell, NULL, 0);
+		return 1;
+	} else if (argc == 1) {
+		shell_help_print(shell, NULL, 0);
+	} else {
+		shell_fprintf(shell, SHELL_ERROR, "%s:%s%s\n", argv[0],
+			      SHELL_MSG_UNKNOWN_PARAMETER, argv[1]);
+	}
+
+	return -EINVAL;
 }
 
 static int cmd_resize_default(const struct shell *shell,
 			      size_t argc, char **argv)
 {
-	if (!shell_cmd_precheck(shell, (argc == 1), NULL, 0)) {
-		return 0;
+	ARG_UNUSED(argv);
+
+	int ret = shell_cmd_precheck(shell, (argc == 1), NULL, 0);
+
+	if (ret == 0) {
+		SHELL_VT100_CMD(shell, SHELL_VT100_SETCOL_80);
+		shell->ctx->vt100_ctx.cons.terminal_wid =
+						   SHELL_DEFAULT_TERMINAL_WIDTH;
+		shell->ctx->vt100_ctx.cons.terminal_hei =
+						  SHELL_DEFAULT_TERMINAL_HEIGHT;
 	}
 
-	SHELL_VT100_CMD(shell, SHELL_VT100_SETCOL_80);
-	shell->ctx->vt100_ctx.cons.terminal_wid = SHELL_DEFAULT_TERMINAL_WIDTH;
-	shell->ctx->vt100_ctx.cons.terminal_hei = SHELL_DEFAULT_TERMINAL_HEIGHT;
-	return 0;
+	return ret;
 }
 
 static int cmd_resize(const struct shell *shell, size_t argc, char **argv)
@@ -419,18 +470,19 @@ static int cmd_resize(const struct shell *shell, size_t argc, char **argv)
 	int err;
 
 	if (!IS_ENABLED(CONFIG_SHELL_CMDS_RESIZE)) {
-		shell_fprintf(shell, SHELL_ERROR, "Command not supported.\r\n");
+		shell_fprintf(shell, SHELL_ERROR, "Command not supported.\n");
 		return -ENOEXEC;
 	}
 
-	if (!shell_cmd_precheck(shell, (argc <= 2), NULL, 0)) {
-		return 0;
+	err = shell_cmd_precheck(shell, (argc <= 2), NULL, 0);
+	if (err) {
+		return err;
 	}
 
 	if (argc != 1) {
-		shell_fprintf(shell, SHELL_ERROR, "%s:%s%s\r\n", argv[0],
+		shell_fprintf(shell, SHELL_ERROR, "%s:%s%s\n", argv[0],
 			      SHELL_MSG_UNKNOWN_PARAMETER, argv[1]);
-		return -ENOEXEC;
+		return -EINVAL;
 	}
 
 	err = terminal_size_get(shell);
@@ -441,8 +493,10 @@ static int cmd_resize(const struct shell *shell, size_t argc, char **argv)
 				SHELL_DEFAULT_TERMINAL_HEIGHT;
 		shell_fprintf(shell, SHELL_WARNING,
 			      "No response from the terminal, assumed 80x24 "
-			      "screen size\r\n");
+			      "screen size\n");
+		return -ENOEXEC;
 	}
+
 	return 0;
 }
 

--- a/tests/bluetooth/shell/src/main.c
+++ b/tests/bluetooth/shell/src/main.c
@@ -39,8 +39,10 @@ static bool hrs_simulate;
 static int cmd_hrs_simulate(const struct shell *shell,
 			    size_t argc, char *argv[])
 {
-	if (!shell_cmd_precheck(shell, (argc == 2), NULL, 0)) {
-		return 0;
+	int err = shell_cmd_precheck(shell, (argc == 2), NULL, 0);
+
+	if (err) {
+		return err;
 	}
 
 	if (!strcmp(argv[1], "on")) {
@@ -81,13 +83,16 @@ SHELL_CREATE_STATIC_SUBCMD_SET(hrs_cmds) {
 
 static int cmd_hrs(const struct shell *shell, size_t argc, char **argv)
 {
+	int err = shell_cmd_precheck(shell, (argc == 2), NULL, 0);
+
 	if (argc == 1) {
 		shell_help_print(shell, NULL, 0);
-		return 0;
+		/* shell_cmd_precheck returns 1 when help is printed */
+		return 1;
 	}
 
-	if (!shell_cmd_precheck(shell, (argc == 2), NULL, 0)) {
-		return 0;
+	if (err) {
+		return err;
 	}
 
 	error(shell, "%s unknown parameter: %s", argv[0], argv[1]);


### PR DESCRIPTION
This PR is first step to implement CI tests shell module.
I have unified usage of a function shell_cmd_precheck, now it returns error messge, not only true/false.

Return values have now follwoing meaning:
-  0		          if check passed
- 1                      if help was requested
-  -EINVAL	  if wrong argument count