### PR TITLE
subsys: logging: Add CR/LF handling flags

### DIFF
--- a/include/logging/log_output.h
+++ b/include/logging/log_output.h
@@ -33,6 +33,12 @@ extern "C" {
 /** @brief Flag forcing severity level prefix. */
 #define LOG_OUTPUT_FLAG_LEVEL			BIT(3)
 
+/** @brief Flag preventing the logger from adding CR and LF characters. */
+#define LOG_OUTPUT_FLAG_CRLF_NONE		BIT(4)
+
+/** @brief Flag forcing a single LF character for line breaks. */
+#define LOG_OUTPUT_FLAG_CRLF_LFONLY		BIT(5)
+
 /**
  * @brief Prototype of the function processing output data.
  *


### PR DESCRIPTION
Add 2 new flags to control the output of newlines by the logger output
module. By default the logger adds both CR and LF, and with these 2 new
flags it is now possible to request LF only or no newlines at all.

Signed-off-by: Carles Cufi <carles.cufi@nordicsemi.no>