### PR TITLE
sanitycheck: support requirements on env variables

### DIFF
--- a/boards/posix/nrf52_bsim/nrf52_bsim.yaml
+++ b/boards/posix/nrf52_bsim/nrf52_bsim.yaml
@@ -2,6 +2,8 @@ identifier: nrf52_bsim
 name: NRF52 BabbleSim board
 type: native
 arch: posix
+env:
+  - BSIM_OUT_PATH
 toolchain:
   - zephyr
 testing:

--- a/scripts/sanity_chk/sanitycheck-platform-schema.yaml
+++ b/scripts/sanity_chk/sanitycheck-platform-schema.yaml
@@ -28,6 +28,11 @@ mapping:
     seq:
       -
         type: str
+  "env":
+    type: seq
+    seq:
+      -
+        type: str
   "ram":
     type: int
   "flash":

--- a/scripts/sanitycheck
+++ b/scripts/sanitycheck
@@ -1150,7 +1150,9 @@ class MakeGenerator:
 # XXX Be sure to update __doc__ if you change any of this!!
 
 platform_valid_keys = {"qemu_support": {"type": "bool", "default": False},
-                       "supported_toolchains": {"type": "list", "default": []}}
+                       "supported_toolchains": {"type": "list", "default": []},
+                       "env": {"type": "list", "default": []}
+                       }
 
 testcase_valid_keys = {"tags": {"type": "set", "required": False},
                        "type": {"type": "str", "default": "integration"},
@@ -1343,6 +1345,11 @@ class Platform:
         self.type = data.get('type', "na")
         self.simulation = data.get('simulation', "na")
         self.supported_toolchains = data.get("toolchain", [])
+        self.env = data.get("env", [])
+        self.env_satisfied = True
+        for env in self.env:
+            if os.environ.get(env, None) == None:
+                self.env_satisfied = False
         self.defconfig = None
         pass
 
@@ -1817,7 +1824,8 @@ class TestSuite:
                     if tc.toolchain_whitelist and toolchain not in tc.toolchain_whitelist:
                         continue
 
-                    if (tc.tc_filter and (plat.default or all_plats or platform_filter)
+                    if (plat.env_satisfied and tc.tc_filter
+                            and (plat.default or all_plats or platform_filter)
                             and (toolchain in plat.supported_toolchains or options.force_toolchain)):
                         args = tc.extra_args[:]
                         args.append("BOARD={}".format(plat.name))
@@ -1928,7 +1936,13 @@ class TestSuite:
                         discards[instance] = "Not in testcase toolchain whitelist"
                         continue
 
-                    if not options.force_toolchain and toolchain and toolchain not in plat.supported_toolchains and tc.type != 'unit':
+                    if not plat.env_satisfied:
+                        discards[instance] = "Environment ({}) not satisfied".format(", ".join(plat.env))
+                        continue
+
+                    if not options.force_toolchain \
+                        and toolchain and (toolchain not in plat.supported_toolchains) \
+                        and tc.type != 'unit':
                         discards[instance] = "Not supported by the toolchain"
                         continue
 


### PR DESCRIPTION
Some boards depend on environment variables so we want to make sure we do
not attempt to build boards requiring additional setup.

Add the section below into the board YAML file, sanitycheck will check the
environment and will only run tests on that board if the variables are
defined.

```
env:
 - VAR1
 - VAR2
```