### PR TITLE
flash: make flash shell generic

### DIFF
--- a/drivers/flash/CMakeLists.txt
+++ b/drivers/flash/CMakeLists.txt
@@ -35,4 +35,6 @@ zephyr_library_sources_ifdef(CONFIG_SOC_FLASH_STM32
 	)
 endif()
 
+zephyr_library_sources_ifdef(CONFIG_FLASH_SHELL flash_shell.c)
+
 zephyr_include_directories_ifdef(CONFIG_SOC_FLASH_NRF_RADIO_SYNC ${ZEPHYR_BASE}/subsys/bluetooth)

--- a/drivers/flash/Kconfig
+++ b/drivers/flash/Kconfig
@@ -31,6 +31,13 @@ module = FLASH
 module-str = flash
 source "subsys/logging/Kconfig.template.log_config"
 
+config FLASH_SHELL
+	bool "Enable Flash shell"
+	depends on FLASH_HAS_PAGE_LAYOUT
+	help
+	  Enable the flash shell with flash related commands such as test,
+	  write, read and erase.
+
 config FLASH_PAGE_LAYOUT
 	bool "API for retrieving the layout of pages"
 	depends on FLASH_HAS_PAGE_LAYOUT

--- a/drivers/flash/flash_shell.c
+++ b/drivers/flash/flash_shell.c
@@ -1,19 +1,11 @@
-/** @file
- * @brief Bluetooth Controller and flash co-operation
- *
- */
-
 /*
  * Copyright (c) 2017 Nordic Semiconductor ASA
+ * Copyright (c) 2018 Intel Corporation
  *
  * SPDX-License-Identifier: Apache-2.0
  */
 
 #include <zephyr.h>
-
-#include <bluetooth/hci.h>
-#include <bluetooth/bluetooth.h>
-#include <bluetooth/conn.h>
 
 #include <shell/shell.h>
 
@@ -22,7 +14,14 @@
 #include "flash.h"
 #include <soc.h>
 
-#include "bt.h"
+extern const struct shell *ctx_shell;
+
+#define print(_sh, _ft, ...) \
+	shell_fprintf(_sh ? _sh : ctx_shell, SHELL_NORMAL, _ft "\r\n", \
+		      ##__VA_ARGS__)
+#define error(_sh, _ft, ...) \
+	shell_fprintf(_sh ? _sh : ctx_shell, SHELL_ERROR, _ft "\r\n", \
+		      ##__VA_ARGS__)
 
 #define FLASH_SHELL_MODULE "flash"
 #define BUF_ARRAY_CNT 16
@@ -39,7 +38,7 @@ static int cmd_erase(const struct shell *shell, size_t argc, char *argv[])
 
 	flash_dev = device_get_binding(FLASH_DEV_NAME);
 	if (!flash_dev) {
-		error(shell, "Nordic nRF5 flash driver was not found!");
+		error(shell, "Flash driver was not found!");
 		return -ENODEV;
 	}
 
@@ -79,7 +78,7 @@ static int cmd_write(const struct shell *shell, size_t argc, char *argv[])
 
 	flash_dev = device_get_binding(FLASH_DEV_NAME);
 	if (!flash_dev) {
-		error(shell, "Nordic nRF5 flash driver was not found!");
+		error(shell, "Flash driver was not found!");
 		return -ENODEV;
 	}
 
@@ -131,7 +130,7 @@ static int cmd_read(const struct shell *shell, size_t argc, char *argv[])
 
 	flash_dev = device_get_binding(FLASH_DEV_NAME);
 	if (!flash_dev) {
-		error(shell, "Nordic nRF5 flash driver was not found!");
+		error(shell, "Flash driver was not found!");
 		return -ENODEV;
 	}
 
@@ -171,7 +170,7 @@ static int cmd_test(const struct shell *shell, size_t argc, char *argv[])
 
 	flash_dev = device_get_binding(FLASH_DEV_NAME);
 	if (!flash_dev) {
-		error(shell, "Nordic nRF5 flash driver was not found!");
+		error(shell, "Flash driver was not found!");
 		return -ENODEV;
 	}
 
@@ -242,5 +241,5 @@ static int cmd_flash(const struct shell *shell, size_t argc, char **argv)
 	return -ENOEXEC;
 }
 
-SHELL_CMD_REGISTER(flash, &flash_cmds, "Bluetooth flash shell commands",
+SHELL_CMD_REGISTER(flash, &flash_cmds, "Flash shell commands",
 		   cmd_flash);

--- a/subsys/bluetooth/shell/CMakeLists.txt
+++ b/subsys/bluetooth/shell/CMakeLists.txt
@@ -23,7 +23,3 @@ zephyr_library_sources_ifdef(
   ll.c
   ticker.c
   )
-zephyr_library_sources_ifdef(
-  CONFIG_SOC_FLASH_NRF
-  flash.c
-  )

--- a/subsys/bluetooth/shell/Kconfig
+++ b/subsys/bluetooth/shell/Kconfig
@@ -10,6 +10,7 @@ config BT_SHELL
 	bool "Enable Bluetooth shell"
 	select SERIAL
 	select SHELL
+	select FLASH_SHELL
 	help
 	  Activate shell module that provides Bluetooth commands to the
 	  console.


### PR DESCRIPTION
This shell command was tied to bluetooth and the bluetooth shell and
also had messages all related to nordic ICs.
Make it generic and put it under drivers/flash/ so it can be included by
anyone and independently of bluetooth.

Signed-off-by: Anas Nashif <anas.nashif@intel.com>