### PR TITLE
Bluetooth: host: Avoid using out-of-scope pointer

### DIFF
--- a/subsys/bluetooth/host/conn.c
+++ b/subsys/bluetooth/host/conn.c
@@ -238,14 +238,16 @@ static void conn_le_update_timeout(struct k_work *work)
 					 conn->le.interval_max,
 					 conn->le.latency,
 					 conn->le.timeout);
+
+		send_conn_le_param_update(conn, param);
 	} else {
 		param = BT_LE_CONN_PARAM(CONFIG_BT_PERIPHERAL_PREF_MIN_INT,
 					 CONFIG_BT_PERIPHERAL_PREF_MAX_INT,
 					 CONFIG_BT_PERIPHERAL_PREF_SLAVE_LATENCY,
 					 CONFIG_BT_PERIPHERAL_PREF_TIMEOUT);
-	}
 
-	send_conn_le_param_update(conn, param);
+		send_conn_le_param_update(conn, param);
+	}
 #else
 	/* update only if application set own params */
 	if (atomic_test_and_clear_bit(conn->flags, BT_CONN_SLAVE_PARAM_SET)) {


### PR DESCRIPTION
Mkae sure that variable pointed by params is valid when passing it
as function argument.

Fixes #10587

Signed-off-by: Szymon Janc <szymon.janc@codecoup.pl>