### PR TITLE
dts: Add proper handling for boolean properties

### DIFF
--- a/scripts/dts/extract/default.py
+++ b/scripts/dts/extract/default.py
@@ -21,12 +21,20 @@ class DTDefault(DTDirective):
     # @param node_address Address of node owning the clockxxx definition.
     # @param yaml YAML definition for the owning node.
     # @param prop property name
+    # @param prop type (string, boolean, etc)
     # @param def_label Define label string of node owning the directive.
     #
-    def extract(self, node_address, yaml, prop, def_label):
+    def extract(self, node_address, yaml, prop, prop_type, def_label):
         prop_def = {}
         prop_alias = {}
-        prop_values = reduced[node_address]['props'][prop]
+
+        if prop_type == 'boolean':
+            if prop in reduced[node_address]['props'].keys():
+                prop_values = 1
+            else:
+                prop_values = 0
+        else:
+            prop_values = reduced[node_address]['props'][prop]
 
         if isinstance(prop_values, list):
             for i, prop_value in enumerate(prop_values):

--- a/scripts/dts/extract/flash.py
+++ b/scripts/dts/extract/flash.py
@@ -72,7 +72,7 @@ class DTFlash(DTDirective):
         flash_props = ["label", "write-block-size", "erase-block-size"]
         for prop in flash_props:
             if prop in self._flash_node['props']:
-                default.extract(node_address, None, prop, def_label)
+                default.extract(node_address, None, prop, None, def_label)
         insert_defs(node_address, load_defs, {})
 
         #for address in reduced:

--- a/scripts/dts/extract_dts_includes.py
+++ b/scripts/dts/extract_dts_includes.py
@@ -387,7 +387,7 @@ def extract_property(node_compat, yaml, node_address, prop, prop_val, names,
         extract_cells(node_address, yaml, prop, prop_values,
                       names, 0, def_label, 'gpio')
     else:
-        default.extract(node_address, yaml, prop, def_label)
+        default.extract(node_address, yaml, prop, prop_val['type'], def_label)
 
 
 def extract_node_include_info(reduced, root_node_address, sub_node_address,
@@ -420,6 +420,7 @@ def extract_node_include_info(reduced, root_node_address, sub_node_address,
                             reduced, root_node_address, c, yaml, v)
             if 'generation' in v:
 
+                match = False
                 for c in node['props'].keys():
                     if c.endswith("-names"):
                         pass
@@ -444,7 +445,15 @@ def extract_node_include_info(reduced, root_node_address, sub_node_address,
                         extract_property(
                             node_compat, yaml, sub_node_address, c, v, names,
                             label_override)
+                        match = True
 
+                # Handle the case that we have a boolean property, but its not
+                # in the dts
+                if not match:
+                    if v['type'] == "boolean":
+                        extract_property(
+                            node_compat, yaml, sub_node_address, k, v, None,
+                            label_override)
 
 def dict_merge(dct, merge_dct):
     # from https://gist.github.com/angstwad/bf22d1822c38a92ec0a9


### PR DESCRIPTION
We've never handled boolean properties well, if we had a boolean that
existed we'd generate a define of 'True' and if the boolean didn't exist
than nothing would be generated.  So there was no easy way to tell that
the boolean wasn't defined.

Now if we mark a property as boolean in the yaml, we will generate a
define for it regardless if it exists or not.  If it exists we'll
set the value to 1, and if it doesn't to 0.

Fixes #8376

Signed-off-by: Kumar Gala <kumar.gala@linaro.org>