### PR TITLE
xtensa: intel_s1000: turn on XTENSA_ASM2

### DIFF
--- a/arch/xtensa/Kconfig
+++ b/arch/xtensa/Kconfig
@@ -89,4 +89,11 @@ config XTENSA_USE_CORE_CRT1
 	  SoC or boards might define their own __start by setting this setting
 	  to false.
 
+config XTENSA_KERNEL_CPU_PTR_SR
+	string
+	default "MISC0"
+	help
+	  Specify which special register to store the pointer to
+	  _kernel.cpus[] for the current CPU.
+
 endmenu

--- a/arch/xtensa/core/xtensa-asm2-util.S
+++ b/arch/xtensa/core/xtensa-asm2-util.S
@@ -236,7 +236,7 @@ _switch_restore_pc:
  */
 .align 4
 _handle_excint:
-	EXCINT_HANDLER MISC0, ___cpu_t_nested_OFFSET, ___cpu_t_irq_stack_OFFSET
+	EXCINT_HANDLER CONFIG_XTENSA_KERNEL_CPU_PTR_SR, ___cpu_t_nested_OFFSET, ___cpu_t_irq_stack_OFFSET
 
 /* Define the actual vectors for the hardware-defined levels with
  * DEF_EXCINT.  These load a C handler address and jump to our handler

--- a/boards/xtensa/intel_s1000_crb/board.cmake
+++ b/boards/xtensa/intel_s1000_crb/board.cmake
@@ -7,3 +7,7 @@ board_finalize_runner_args(intel_s1000
   "--ocd-jtag-instr=dsp0_gdb.txt"
   "--gdb-flash-file=load_elf.txt"
 )
+
+if(NOT "${ZEPHYR_TOOLCHAIN_VARIANT}" STREQUAL "xcc")
+  message(FATAL_ERROR "ZEPHYR_TOOLCHAIN_VARIANT != xcc. This requires xcc to build!")
+endif()

--- a/drivers/audio/tlv320dac310x.c
+++ b/drivers/audio/tlv320dac310x.c
@@ -138,7 +138,8 @@ static int codec_set_property(struct device *dev,
 {
 	/* individual channel control not currently supported */
 	if (channel != AUDIO_CHANNEL_ALL) {
-		LOG_ERR("channel %u invalid. must be AUDIO_CHANNEL_ALL");
+		LOG_ERR("channel %u invalid. must be AUDIO_CHANNEL_ALL",
+			channel);
 		return -EINVAL;
 	}
 

--- a/dts/xtensa/intel_s1000.dtsi
+++ b/dts/xtensa/intel_s1000.dtsi
@@ -27,7 +27,7 @@
 
 	};
 
-	sram0: memory@0xbe000000 {
+	sram0: memory@be000000 {
 		device_type = "memory";
 		compatible = "mmio-sram";
 		reg = <0xbe000000 0x300000>;

--- a/include/toolchain/xcc.h
+++ b/include/toolchain/xcc.h
@@ -43,5 +43,7 @@
  */
 #define __builtin_add_overflow(a, b, output)	({ *output = (a) + (b); 0; })
 #define __builtin_mul_overflow(a, b, output)	({ *output = (a) * (b); 0; })
+#define __builtin_umul_overflow(a, b, output)	({ *output = (a) * (b); 0; })
+#define __builtin_umulll_overflow(a, b, output)	({ *output = (a) * (b); 0; })
 
 #endif

--- a/soc/xtensa/intel_s1000/Kconfig.defconfig
+++ b/soc/xtensa/intel_s1000/Kconfig.defconfig
@@ -12,4 +12,12 @@ config SOC
 config IRQ_OFFLOAD_INTNUM
 	default 0
 
+config XTENSA_ASM2
+	def_bool y
+
+# S1000 does not have MISC0.
+# Since EXCSAVE2 is unused by Zephyr, use it instead.
+config XTENSA_KERNEL_CPU_PTR_SR
+	default "EXCSAVE2"
+
 endif

--- a/soc/xtensa/intel_s1000/include/_soc_inthandlers.h
+++ b/soc/xtensa/intel_s1000/include/_soc_inthandlers.h
@@ -1,0 +1,257 @@
+/*
+ * THIS FILE WAS AUTOMATICALLY GENERATED.  DO NOT EDIT.
+ *
+ * Functions here are designed to produce efficient code to
+ * search an Xtensa bitmask of interrupts, inspecting only those bits
+ * declared to be associated with a given interrupt level.  Each
+ * dispatcher will handle exactly one flagged interrupt, in numerical
+ * order (low bits first) and will return a mask of that bit that can
+ * then be cleared by the calling code.  Unrecognized bits for the
+ * level will invoke an error handler.
+ */
+
+#include <xtensa/config/core-isa.h>
+#include <sw_isr_table.h>
+
+#if !defined(XCHAL_INT0_LEVEL) || XCHAL_INT0_LEVEL != 1
+#error core-isa.h interrupt level does not match dispatcher!
+#endif
+#if !defined(XCHAL_INT1_LEVEL) || XCHAL_INT1_LEVEL != 1
+#error core-isa.h interrupt level does not match dispatcher!
+#endif
+#if !defined(XCHAL_INT2_LEVEL) || XCHAL_INT2_LEVEL != 1
+#error core-isa.h interrupt level does not match dispatcher!
+#endif
+#if !defined(XCHAL_INT3_LEVEL) || XCHAL_INT3_LEVEL != 1
+#error core-isa.h interrupt level does not match dispatcher!
+#endif
+#if !defined(XCHAL_INT4_LEVEL) || XCHAL_INT4_LEVEL != 2
+#error core-isa.h interrupt level does not match dispatcher!
+#endif
+#if !defined(XCHAL_INT5_LEVEL) || XCHAL_INT5_LEVEL != 2
+#error core-isa.h interrupt level does not match dispatcher!
+#endif
+#if !defined(XCHAL_INT6_LEVEL) || XCHAL_INT6_LEVEL != 2
+#error core-isa.h interrupt level does not match dispatcher!
+#endif
+#if !defined(XCHAL_INT7_LEVEL) || XCHAL_INT7_LEVEL != 2
+#error core-isa.h interrupt level does not match dispatcher!
+#endif
+#if !defined(XCHAL_INT8_LEVEL) || XCHAL_INT8_LEVEL != 3
+#error core-isa.h interrupt level does not match dispatcher!
+#endif
+#if !defined(XCHAL_INT9_LEVEL) || XCHAL_INT9_LEVEL != 3
+#error core-isa.h interrupt level does not match dispatcher!
+#endif
+#if !defined(XCHAL_INT10_LEVEL) || XCHAL_INT10_LEVEL != 3
+#error core-isa.h interrupt level does not match dispatcher!
+#endif
+#if !defined(XCHAL_INT11_LEVEL) || XCHAL_INT11_LEVEL != 3
+#error core-isa.h interrupt level does not match dispatcher!
+#endif
+#if !defined(XCHAL_INT12_LEVEL) || XCHAL_INT12_LEVEL != 4
+#error core-isa.h interrupt level does not match dispatcher!
+#endif
+#if !defined(XCHAL_INT13_LEVEL) || XCHAL_INT13_LEVEL != 4
+#error core-isa.h interrupt level does not match dispatcher!
+#endif
+#if !defined(XCHAL_INT14_LEVEL) || XCHAL_INT14_LEVEL != 4
+#error core-isa.h interrupt level does not match dispatcher!
+#endif
+#if !defined(XCHAL_INT15_LEVEL) || XCHAL_INT15_LEVEL != 5
+#error core-isa.h interrupt level does not match dispatcher!
+#endif
+#if !defined(XCHAL_INT16_LEVEL) || XCHAL_INT16_LEVEL != 5
+#error core-isa.h interrupt level does not match dispatcher!
+#endif
+#if !defined(XCHAL_INT17_LEVEL) || XCHAL_INT17_LEVEL != 5
+#error core-isa.h interrupt level does not match dispatcher!
+#endif
+#if !defined(XCHAL_INT18_LEVEL) || XCHAL_INT18_LEVEL != 5
+#error core-isa.h interrupt level does not match dispatcher!
+#endif
+#if !defined(XCHAL_INT19_LEVEL) || XCHAL_INT19_LEVEL != 5
+#error core-isa.h interrupt level does not match dispatcher!
+#endif
+#if !defined(XCHAL_INT20_LEVEL) || XCHAL_INT20_LEVEL != 7
+#error core-isa.h interrupt level does not match dispatcher!
+#endif
+
+static inline int _xtensa_handle_one_int1(unsigned int mask)
+{
+	if (mask & 0x3) {
+		if (mask & (1 << 0)) {
+			struct _isr_table_entry *e = &_sw_isr_table[0];
+
+			e->isr(e->arg);
+			return 1 << 0;
+		}
+		if (mask & (1 << 1)) {
+			struct _isr_table_entry *e = &_sw_isr_table[1];
+
+			e->isr(e->arg);
+			return 1 << 1;
+		}
+	} else {
+		if (mask & (1 << 2)) {
+			struct _isr_table_entry *e = &_sw_isr_table[2];
+
+			e->isr(e->arg);
+			return 1 << 2;
+		}
+		if (mask & (1 << 3)) {
+			struct _isr_table_entry *e = &_sw_isr_table[3];
+
+			e->isr(e->arg);
+			return 1 << 3;
+		}
+	}
+	return 0;
+}
+
+static inline int _xtensa_handle_one_int2(unsigned int mask)
+{
+	if (mask & 0x30) {
+		if (mask & (1 << 4)) {
+			struct _isr_table_entry *e = &_sw_isr_table[4];
+
+			e->isr(e->arg);
+			return 1 << 4;
+		}
+		if (mask & (1 << 5)) {
+			struct _isr_table_entry *e = &_sw_isr_table[5];
+
+			e->isr(e->arg);
+			return 1 << 5;
+		}
+	} else {
+		if (mask & (1 << 6)) {
+			struct _isr_table_entry *e = &_sw_isr_table[6];
+
+			e->isr(e->arg);
+			return 1 << 6;
+		}
+		if (mask & (1 << 7)) {
+			struct _isr_table_entry *e = &_sw_isr_table[7];
+
+			e->isr(e->arg);
+			return 1 << 7;
+		}
+	}
+	return 0;
+}
+
+static inline int _xtensa_handle_one_int3(unsigned int mask)
+{
+	if (mask & 0x300) {
+		if (mask & (1 << 8)) {
+			struct _isr_table_entry *e = &_sw_isr_table[8];
+
+			e->isr(e->arg);
+			return 1 << 8;
+		}
+		if (mask & (1 << 9)) {
+			struct _isr_table_entry *e = &_sw_isr_table[9];
+
+			e->isr(e->arg);
+			return 1 << 9;
+		}
+	} else {
+		if (mask & (1 << 10)) {
+			struct _isr_table_entry *e = &_sw_isr_table[10];
+
+			e->isr(e->arg);
+			return 1 << 10;
+		}
+		if (mask & (1 << 11)) {
+			struct _isr_table_entry *e = &_sw_isr_table[11];
+
+			e->isr(e->arg);
+			return 1 << 11;
+		}
+	}
+	return 0;
+}
+
+static inline int _xtensa_handle_one_int4(unsigned int mask)
+{
+	if (mask & (1 << 12)) {
+		struct _isr_table_entry *e = &_sw_isr_table[12];
+
+		e->isr(e->arg);
+		return 1 << 12;
+	}
+	if (mask & (1 << 13)) {
+		struct _isr_table_entry *e = &_sw_isr_table[13];
+
+		e->isr(e->arg);
+		return 1 << 13;
+	}
+	if (mask & (1 << 14)) {
+		struct _isr_table_entry *e = &_sw_isr_table[14];
+
+		e->isr(e->arg);
+		return 1 << 14;
+	}
+	return 0;
+}
+
+static inline int _xtensa_handle_one_int5(unsigned int mask)
+{
+	if (mask & 0x18000) {
+		if (mask & (1 << 15)) {
+			struct _isr_table_entry *e = &_sw_isr_table[15];
+
+			e->isr(e->arg);
+			return 1 << 15;
+		}
+		if (mask & (1 << 16)) {
+			struct _isr_table_entry *e = &_sw_isr_table[16];
+
+			e->isr(e->arg);
+			return 1 << 16;
+		}
+	} else {
+		if (mask & (1 << 17)) {
+			struct _isr_table_entry *e = &_sw_isr_table[17];
+
+			e->isr(e->arg);
+			return 1 << 17;
+		}
+		if (mask & (1 << 18)) {
+			struct _isr_table_entry *e = &_sw_isr_table[18];
+
+			e->isr(e->arg);
+			return 1 << 18;
+		}
+		if (mask & (1 << 19)) {
+			struct _isr_table_entry *e = &_sw_isr_table[19];
+
+			e->isr(e->arg);
+			return 1 << 19;
+		}
+	}
+	return 0;
+}
+
+static inline int _xtensa_handle_one_int7(unsigned int mask)
+{
+	if (mask & (1 << 20)) {
+		struct _isr_table_entry *e = &_sw_isr_table[20];
+
+		e->isr(e->arg);
+		return 1 << 20;
+	}
+	return 0;
+}
+
+static inline int _xtensa_handle_one_int0(unsigned int mask)
+{
+	return 0;
+}
+
+static inline int _xtensa_handle_one_int6(unsigned int mask)
+{
+	return 0;
+}
+

--- a/soc/xtensa/intel_s1000/linker.ld
+++ b/soc/xtensa/intel_s1000/linker.ld
@@ -312,6 +312,7 @@ SECTIONS
     _text_start = ABSOLUTE(.);
     *(.entry.text)
     *(.init.literal)
+    *(.iram0.text)
     KEEP(*(.init))
     *(.literal .text .literal.* .text.* .stub .gnu.warning .gnu.linkonce.literal.* .gnu.linkonce.t.*.literal .gnu.linkonce.t.*)
     *(.fini.literal)


### PR DESCRIPTION
This adds the necessary bits to support ASM2 with XCC for Intel S1000 SoC. With ASM2 enabled, xcc is now required to build for Intel S1000 SoC.

This also fixes some trivial compilation errors/warnings.
