### PR TITLE
doc: shell: rtt: Add documentation for RTT shell backend

### DIFF
--- a/doc/subsystems/shell/shell.rst
+++ b/doc/subsystems/shell/shell.rst
@@ -31,8 +31,30 @@ The module can be connected to any transport for command input and output.
 At this point, the following transport layers are implemented:
 
 * UART
+* Segger RTT
 
 See the :ref:`shell_api` documentation for more information.
+
+Connecting to Segger RTT via TCP (on macOS, for example)
+=================
+
+On macOS JLinkRTTClient won't let you enter input. Instead, please use following procedure:
+* Open up a first Terminal window and enter:
+
+.. code-block:: none
+
+    JLinkRTTLogger -Device NRF52840_XXAA -RTTChannel 1 -if SWD -Speed 4000 ~/rtt.log
+
+(change device if required)
+
+* Open up a second Terminal window and enter:
+
+.. code-block:: none
+
+    nc localhost 19021
+
+* Now you should have a network connection to RTT which will let you enter input to the shell.
+
 
 Commands
 ********

--- a/include/shell/shell_rtt.h
+++ b/include/shell/shell_rtt.h
@@ -1,0 +1,38 @@
+/*
+ * Copyright (c) 2018 Makaio GmbH
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef SHELL_RTT_H__
+#define SHELL_RTT_H__
+
+#include <shell/shell.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+extern const struct shell_transport_api shell_rtt_transport_api;
+
+struct shell_rtt {
+	struct device *dev;
+	shell_transport_handler_t handler;
+	struct k_timer timer;
+	void *context;
+	u8_t rx[5];
+	size_t rx_cnt;
+};
+
+#define SHELL_RTT_DEFINE(_name)					\
+	static struct shell_rtt _name##_shell_rtt;			\
+	struct shell_transport _name = {				\
+		.api = &shell_rtt_transport_api,			\
+		.ctx = (struct shell_rtt *)&_name##_shell_rtt		\
+	}
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* SHELL_RTT_H__ */

--- a/subsys/shell/CMakeLists.txt
+++ b/subsys/shell/CMakeLists.txt
@@ -24,6 +24,11 @@ zephyr_sources_ifdef(
   )
 
 zephyr_sources_ifdef(
+  CONFIG_SHELL_BACKEND_RTT
+  shell_rtt.c
+)
+
+zephyr_sources_ifdef(
   CONFIG_SHELL_CMDS
   shell_cmds.c
 )

--- a/subsys/shell/Kconfig.backends
+++ b/subsys/shell/Kconfig.backends
@@ -21,5 +21,12 @@ config SHELL_BACKEND_SERIAL
 	help
 	  Enable serial backends.
 
+config SHELL_BACKEND_RTT
+	bool "Enable RTT backend."
+	select RTT_CONSOLE
+	help
+	  Enable RTT backend.
+
+
 endif # SHELL_BACKENDS
 

--- a/subsys/shell/shell_rtt.c
+++ b/subsys/shell/shell_rtt.c
@@ -1,0 +1,120 @@
+/*
+ * Copyright (c) 2018 Makaio GmbH
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <shell/shell_rtt.h>
+#include <init.h>
+#include <rtt/SEGGER_RTT.h>
+
+SHELL_RTT_DEFINE(shell_transport_rtt);
+SHELL_DEFINE(rtt_shell, "rtt:~$ ", &shell_transport_rtt, 10,
+	     SHELL_FLAG_OLF_CRLF);
+
+
+static struct k_thread rtt_rx_thread;
+static K_THREAD_STACK_DEFINE(rtt_rx_stack, 1024);
+
+static void shell_rtt_rx_process(struct shell_rtt *sh_rtt)
+{
+	unsigned int count;
+	while (true)
+	{
+		SEGGER_RTT_LOCK();
+		count = SEGGER_RTT_ReadNoLock(0, sh_rtt->rx, sizeof(sh_rtt->rx));
+
+		if(count > 0)
+		{
+			sh_rtt->rx_cnt = 1;
+			sh_rtt->handler(SHELL_TRANSPORT_EVT_RX_RDY, sh_rtt->context);
+		}
+		SEGGER_RTT_UNLOCK();
+		k_sleep(K_MSEC(10));
+	}
+}
+
+
+static int init(const struct shell_transport *transport,
+		const void *config,
+		shell_transport_handler_t evt_handler,
+		void *context)
+{
+
+	struct shell_rtt *sh_rtt = (struct shell_rtt *)transport->ctx;
+
+    sh_rtt->dev = device_get_binding(CONFIG_UART_CONSOLE_ON_DEV_NAME);
+    sh_rtt->handler = evt_handler;
+    sh_rtt->context = context;
+
+
+	k_thread_create(&rtt_rx_thread, rtt_rx_stack,
+					K_THREAD_STACK_SIZEOF(rtt_rx_stack),
+					(k_thread_entry_t)shell_rtt_rx_process,
+					sh_rtt, NULL, NULL, K_PRIO_COOP(8), 0, K_NO_WAIT);
+
+	return 0;
+}
+
+static int uninit(const struct shell_transport *transport)
+{
+	return 0;
+}
+
+static int enable(const struct shell_transport *transport, bool blocking)
+{
+	return 0;
+}
+
+static int write(const struct shell_transport *transport,
+		 const void *data, size_t length, size_t *cnt)
+{
+	struct shell_rtt *sh_rtt = (struct shell_rtt *)transport->ctx;
+	const u8_t *data8 = (const u8_t *)data;
+
+	SEGGER_RTT_WriteNoLock(0, data8, length);
+	*cnt = length;
+
+    sh_rtt->handler(SHELL_TRANSPORT_EVT_TX_RDY, sh_rtt->context);
+	return 0;
+}
+
+static int read(const struct shell_transport *transport,
+		void *data, size_t length, size_t *cnt)
+{
+	struct shell_rtt *sh_rtt = (struct shell_rtt *)transport->ctx;
+
+	if (sh_rtt->rx_cnt) {
+		memcpy(data, sh_rtt->rx, 1);
+        sh_rtt->rx_cnt = 0;
+		*cnt = 1;
+	} else {
+		*cnt = 0;
+	}
+
+	return 0;
+}
+
+const struct shell_transport_api shell_rtt_transport_api = {
+	.init = init,
+	.uninit = uninit,
+	.enable = enable,
+	.write = write,
+	.read = read
+};
+
+static int enable_shell_rtt(struct device *arg)
+{
+	ARG_UNUSED(arg);
+
+	shell_init(&rtt_shell, NULL, false, false, LOG_LEVEL_INF);
+
+	return 0;
+}
+
+/* Function is used for testing purposes */
+const struct shell *shell_backend_rtt_get_ptr(void)
+{
+	return &rtt_shell;
+}
+SYS_INIT(enable_shell_rtt, POST_KERNEL, 0);


### PR DESCRIPTION
This adds documentation about the RTT shell backend introduced in #10709 