### PR TITLE
boards: PCA10056: add board.c for nRF52840 PCA10056

### DIFF
--- a/soc/arm/nordic_nrf/nrf52/Kconfig.soc
+++ b/soc/arm/nordic_nrf/nrf52/Kconfig.soc
@@ -222,3 +222,31 @@ config NRF_ENABLE_ICACHE
 	bool "Enable the instruction cache (I-Cache)"
 	depends on SOC_NRF52832 || SOC_NRF52840
 	default y
+
+if SOC_NRF52840
+    choice
+    prompt "REG0 output voltage"
+
+    comment "Only applied to a fresh/erased SoC"
+
+    config NRF52840_REG0_1V8
+        bool "1.8V"
+
+    config NRF52840_REG0_2V1
+        bool "2.1V"
+
+    config NRF52840_REG0_2V4
+        bool "2.4V"
+
+    config NRF52840_REG0_2V7
+        bool "2.7V"
+
+    config NRF52840_REG0_3V0
+        bool "3.0V"
+
+    config NRF52840_REG0_3V3
+        bool "3.3V"
+
+    endchoice
+
+endif # SOC_NRF52840

--- a/soc/arm/nordic_nrf/nrf52/soc.c
+++ b/soc/arm/nordic_nrf/nrf52/soc.c
@@ -38,9 +38,28 @@ extern void _NmiInit(void);
 #include <nrf.h>
 #include <hal/nrf_power.h>
 
+/**
+ * @brief REG0 voltage definitions for nRF52840
+ */
+#if defined(CONFIG_NRF52840_REG0_1V8)
+#define NRF52840_REG0_VOUT	UICR_REGOUT0_VOUT_1V8
+#elif defined(CONFIG_NRF52840_REG0_2V1)
+#define NRF52840_REG0_VOUT	UICR_REGOUT0_VOUT_2V1
+#elif defined(CONFIG_NRF52840_REG0_2V4)
+#define NRF52840_REG0_VOUT	UICR_REGOUT0_VOUT_2V4
+#elif defined(CONFIG_NRF52840_REG0_2V7)
+#define NRF52840_REG0_VOUT	UICR_REGOUT0_VOUT_2V7
+#elif defined(CONFIG_NRF52840_REG0_3V0)
+#define NRF52840_REG0_VOUT	UICR_REGOUT0_VOUT_3V0
+#elif defined(CONFIG_NRF52840_REG0_3V3)
+#define NRF52840_REG0_VOUT	UICR_REGOUT0_VOUT_3V3
+#endif
+
 #define LOG_LEVEL CONFIG_SOC_LOG_LEVEL
 #include <logging/log.h>
 LOG_MODULE_REGISTER(soc);
+
+static void nordicsemi_nrf52840_reg0_voltage_set(void);
 
 static int nordicsemi_nrf52_init(struct device *arg)
 {
@@ -55,6 +74,10 @@ static int nordicsemi_nrf52_init(struct device *arg)
 #ifdef CONFIG_NRF_ENABLE_ICACHE
 	/* Enable the instruction cache */
 	NRF_NVMC->ICACHECNF = NVMC_ICACHECNF_CACHEEN_Msk;
+#endif
+
+#if defined(NRF_POWER_REG0_VOLT)
+	nordicsemi_nrf52840_reg0_voltage_set();
 #endif
 
 #if defined(CONFIG_SOC_DCDC_NRF52X)
@@ -76,6 +99,39 @@ static int nordicsemi_nrf52_init(struct device *arg)
 void z_arch_busy_wait(u32_t time_us)
 {
 	nrfx_coredep_delay_us(time_us);
+}
+
+/**
+ * @brief Sets REG0 output voltage for nRF52840
+ *
+ * @note  REG0 output voltage will only be set for reseted boards
+ * 		  as function checks if current voltage is DEFAULT
+ * 		  (factory default)
+ *
+ */
+static void nordicsemi_nrf52840_reg0_voltage_set(void)
+{
+	if ((nrf_power_mainregstatus_get() == NRF_POWER_MAINREGSTATUS_HIGH) &&
+		((NRF_UICR->REGOUT0 & UICR_REGOUT0_VOUT_Msk) ==
+		 (UICR_REGOUT0_VOUT_DEFAULT << UICR_REGOUT0_VOUT_Pos))) {
+
+		NRF_NVMC->CONFIG = NVMC_CONFIG_WEN_Wen << NVMC_CONFIG_WEN_Pos;
+		while (NRF_NVMC->READY == NVMC_READY_READY_Busy) {
+			;
+		}
+
+		NRF_UICR->REGOUT0 =
+				(NRF_UICR->REGOUT0 & ~((uint32_t)UICR_REGOUT0_VOUT_Msk)) |
+				(NRF52840_REG0_VOUT << UICR_REGOUT0_VOUT_Pos);
+
+		NRF_NVMC->CONFIG = NVMC_CONFIG_WEN_Ren << NVMC_CONFIG_WEN_Pos;
+		while (NRF_NVMC->READY == NVMC_READY_READY_Busy) {
+			;
+		}
+
+		/* a reset is required for changes to take effect */
+		NVIC_SystemReset();
+	}
 }
 
 SYS_INIT(nordicsemi_nrf52_init, PRE_KERNEL_1, 0);


### PR DESCRIPTION
Add board.c for nRF52840 PCA10056 to enable changes to regulator voltage

Current status:
Voltage set fixed to 3.3V, can be changed in board.c (current line 31)

Background:
If nRF52840 is fed by high-voltage input the low-voltage output will be 1.8V by default but then SWD won't work (because of the different voltage lvl)
I've added this because we don't actually use a PCA10056 but our own board which comes close to it - except that we only use high-voltage input. It won't harm to include it here (in PCA10056) as a reference for everyone to adopt, as I guess that PCA10056 will be the most commonly used starting point for anyone working with nRF52840.

ToDo: 
Maybe implement the selectable voltage levels in config