### PR TITLE
net: tls: Do not assume PSK id is NULL terminated

### DIFF
--- a/subsys/net/lib/sockets/sockets_tls.c
+++ b/subsys/net/lib/sockets/sockets_tls.c
@@ -635,7 +635,7 @@ static int tls_set_psk(struct tls_context *tls,
 	int err = mbedtls_ssl_conf_psk(&tls->config,
 				       psk->buf, psk->len,
 				       (const unsigned char *)psk_id->buf,
-				       psk_id->len - 1);
+				       psk_id->len);
 	if (err != 0) {
 		return -EINVAL;
 	}


### PR DESCRIPTION
Current TLS socket implementation assumed that PSK ID stored in manager is NULL terminated. It's actually better to store only the string content, as the string length is stored as well. This approach is less confusing, when a user is not operating on C strings but on a non-NULL terminated byte array.

No samples are affected with the change, as there are no samples using PSK atuhentication yet (it's added in reworked MQTT sample pending on PR).

Signed-off-by: Robert Lubos <robert.lubos@nordicsemi.no>