### PR TITLE
arch: increase rivileged stack with mpu stack guard

### DIFF
--- a/arch/Kconfig
+++ b/arch/Kconfig
@@ -105,6 +105,7 @@ config USERSPACE
 
 config PRIVILEGED_STACK_SIZE
 	int "Size of privileged stack"
+	default 512 if MPU_STACK_GUARD
 	default 384 if ARC
 	default 256
 	depends on ARCH_HAS_USERSPACE


### PR DESCRIPTION
After commit 3fb6ea21 the stack is not enough and a few tests have been
failing.

Fixes #10632

Signed-off-by: Anas Nashif <anas.nashif@intel.com>