### PR TITLE
lib: posix: Select Newlib libc

### DIFF
--- a/include/posix/sys/types.h
+++ b/include/posix/sys/types.h
@@ -20,7 +20,7 @@ extern "C" {
 typedef unsigned long useconds_t;
 
 /* time related attributes */
-#ifndef CONFIG_NEWLIB_LIBC
+#if !defined(CONFIG_NEWLIB_LIBC) || defined(CONFIG_ARCH_POSIX)
 typedef u32_t clockid_t;
 #endif /*CONFIG_NEWLIB_LIBC */
 typedef unsigned long timer_t;

--- a/include/posix/time.h
+++ b/include/posix/time.h
@@ -14,11 +14,18 @@ struct timespec {
 	signed int  tv_sec;
 	signed int  tv_nsec;
 };
+#define __timespec_defined
 
+/*
+ * riscv32 toolchain's sys/types.h defines struct itimerspec without any
+ * define guard, so little we can do except testing it like this.
+ */
+#ifndef CONFIG_RISCV32
 struct itimerspec {
 	struct timespec it_interval;  /* Timer interval */
 	struct timespec it_value;     /* Timer expiration */
 };
+#endif
 
 struct timeval {
 	signed int  tv_sec;

--- a/lib/posix/Kconfig
+++ b/lib/posix/Kconfig
@@ -6,6 +6,8 @@
 
 config POSIX_API
 	bool "POSIX APIs"
+	# decent libc is part of POSIX
+	select NEWLIB_LIBC
 	help
 	  Enable mostly-standards-compliant implementations of
 	  various POSIX (IEEE 1003.1) APIs.


### PR DESCRIPTION
POSIX standard includes also requirements for C library, so we can't
really talk about "real POSIX" without a more or less well-developed
library like Newlib.

If there are real usecases for doing it otherwise (and that would be
using only some sub-API of POSIX, and not other), we can revisit and
optimize that later. But currently, we have a single master switch,
CONFIG_POSIX_API, and without consistent configuration, it's very
to elaborate foundations of POSIX support.

Signed-off-by: Paul Sokolovsky <paul.sokolovsky@linaro.org>