### PR TITLE
libc: newlib: libc-hooks: Consistently use const void* as arg to write

### DIFF
--- a/include/misc/libc-hooks.h
+++ b/include/misc/libc-hooks.h
@@ -25,7 +25,7 @@
 
 __syscall int _zephyr_read(char *buf, int nbytes);
 
-__syscall int _zephyr_write(char *buf, int nbytes);
+__syscall int _zephyr_write(const void *buf, int nbytes);
 
 #else
 /* Minimal libc */

--- a/lib/libc/newlib/libc-hooks.c
+++ b/lib/libc/newlib/libc-hooks.c
@@ -100,8 +100,9 @@ Z_SYSCALL_HANDLER(_zephyr_read, buf, nbytes)
 }
 #endif
 
-int _impl__zephyr_write(char *buf, int nbytes)
+int _impl__zephyr_write(const void *buffer, int nbytes)
 {
+	const char *buf = buffer;
 	int i;
 
 	for (i = 0; i < nbytes; i++) {
@@ -117,7 +118,7 @@ int _impl__zephyr_write(char *buf, int nbytes)
 Z_SYSCALL_HANDLER(_zephyr_write, buf, nbytes)
 {
 	Z_OOPS(Z_SYSCALL_MEMORY_READ(buf, nbytes));
-	return _impl__zephyr_write((char *)buf, nbytes);
+	return _impl__zephyr_write((const void *)buf, nbytes);
 }
 #endif
 
@@ -130,7 +131,7 @@ int _read(int fd, char *buf, int nbytes)
 }
 FUNC_ALIAS(_read, read, int);
 
-int _write(int fd, char *buf, int nbytes)
+int _write(int fd, const void *buf, int nbytes)
 {
 	ARG_UNUSED(fd);
 
@@ -156,7 +157,7 @@ int _lseek(int file, int ptr, int dir)
 }
 FUNC_ALIAS(_lseek, lseek, int);
 #else
-extern ssize_t write(int file, char *buffer, unsigned int count);
+extern ssize_t write(int file, const char *buffer, size_t count);
 #define _write	write
 #endif
 


### PR DESCRIPTION
write() function is not supposed to change buffer passed to it, so
propagate const pointer param to all write-like functions used/defined
in this file.

Signed-off-by: Paul Sokolovsky <paul.sokolovsky@linaro.org>