### PR TITLE
net: lwm2m: fix compile warning related to Logger changes

### DIFF
--- a/subsys/net/lib/lwm2m/lwm2m_engine.c
+++ b/subsys/net/lib/lwm2m/lwm2m_engine.c
@@ -196,7 +196,6 @@ char *lwm2m_sprint_ip_addr(const struct sockaddr *addr)
 	return NULL;
 }
 
-#if LOG_LEVEL >= LOG_LEVEL_DBG
 static u8_t to_hex_digit(u8_t digit)
 {
 	if (digit >= 10) {
@@ -230,7 +229,6 @@ static char *sprint_token(const u8_t *token, u8_t tkl)
 
 	return buf;
 }
-#endif
 
 /* block-wise transfer functions */
 


### PR DESCRIPTION
When DBG level for CONFIG_LWM2M_LOG_LEVEL is disabled, a compiler warning
is generated:
In file included from include/logging/log.h:11:0,
                 from subsys/net/lib/lwm2m/lwm2m_engine.c:28:
subsys/net/lib/lwm2m/lwm2m_engine.c: In function ‘engine_add_observer’:
subsys/net/lib/lwm2m/lwm2m_engine.c:558:3: warning: implicit
declaration of function ‘sprint_token’
[-Wimplicit-function-declaration]
   sprint_token(token, tkl), lwm2m_sprint_ip_addr(addr));
   ^

Let's remove the #if guards around sprint_token() and let
the Linker remove it when not needed.

Signed-off-by: Michael Scott <mike@foundries.io>