### PR TITLE
drivers: modem: WNCM14A2A select UART_INTERRUPT_DRIVEN

### DIFF
--- a/drivers/modem/Kconfig
+++ b/drivers/modem/Kconfig
@@ -41,7 +41,8 @@ config MODEM_SHELL
 
 config MODEM_WNCM14A2A
 	bool "Enable Wistron LTE-M modem driver"
-	depends on UART_INTERRUPT_DRIVEN
+	depends on SERIAL_SUPPORT_INTERRUPT
+	select UART_INTERRUPT_DRIVEN
 	select MODEM_RECEIVER
 	select NET_OFFLOAD
 	select UART_MCUX_2 if BOARD_FRDM_K64F


### PR DESCRIPTION
Modem driver for WNCM14A2A was erroneously  leaving the
selection of UART_INTERRUPT_DRIVEN up to CONSOLE_HANDLER.
Now, with the move to the new SHELL backend, this is no
longer happening.

Let's select it from the modem driver, instead of depending
on it.

Signed-off-by: Michael Scott <mike@foundries.io>