### PR TITLE
drivers: modem: migrate modem shell to new shell API

### DIFF
--- a/drivers/modem/Kconfig
+++ b/drivers/modem/Kconfig
@@ -34,7 +34,7 @@ config MODEM_RECEIVER_MAX_CONTEXTS
 
 config MODEM_SHELL
 	bool "Enable modem shell utilities"
-	select CONSOLE_SHELL
+	select SHELL
 	help
 	  Activate shell module that provides modem utilities like
 	  sending a command to the modem UART.


### PR DESCRIPTION
Convert modem-shell to use the new shell API.

Signed-off-by: Michael Scott <mike@foundries.io>