### PR TITLE
drivers: modem: wncm14a2a: fix void ptr math warning

### DIFF
--- a/drivers/modem/wncm14a2a.c
+++ b/drivers/modem/wncm14a2a.c
@@ -1810,7 +1810,7 @@ static inline u8_t *wncm14a2a_get_mac(struct device *dev)
 	ctx->mac_addr[1] = 0x10;
 
 	UNALIGNED_PUT(sys_cpu_to_be32(sys_rand32_get()),
-		      (u32_t *) ((void *)ctx->mac_addr+2));
+		      (u32_t *)(ctx->mac_addr + 2));
 
 	return ctx->mac_addr;
 }


### PR DESCRIPTION
I have no idea what I was thinking when I wrote this.
But, it's an easy fix to remove the void * entirely.

Signed-off-by: Michael Scott <mike@foundries.io>