### PR TITLE
dts: stm32f334: Delete usb node

### DIFF
--- a/dts/arm/st/f3/stm32f334.dtsi
+++ b/dts/arm/st/f3/stm32f334.dtsi
@@ -24,3 +24,5 @@
 		};
 	};
 };
+
+/delete-node/ &usb;


### PR DESCRIPTION
STM32F334 SoCs don't include USB controller,
so delete USB node for theses SoCs in DT.

Signed-off-by: Yannis Damigos <giannis.damigos@gmail.com>