### PR TITLE
dts: stm32f302: Delete spi1 node from STM32F302X8

### DIFF
--- a/dts/arm/st/f3/stm32f302X8.dtsi
+++ b/dts/arm/st/f3/stm32f302X8.dtsi
@@ -20,3 +20,5 @@
 		};
 	};
 };
+
+/delete-node/ &spi1;


### PR DESCRIPTION
STM32F302X8 SoCs don't support SPI1 port,
so delete SPI1 node for these SoCs in DT.

Signed-off-by: Yannis Damigos <giannis.damigos@gmail.com>