### PR TITLE
shell: Fix typo

### DIFF
--- a/subsys/fs/shell.c
+++ b/subsys/fs/shell.c
@@ -166,7 +166,7 @@ static int cmd_trunc(const struct shell *shell, size_t argc, char **argv)
 	int length;
 	int err;
 
-	err = hell_cmd_precheck(shell, (argc >= 2), NULL, 0);
+	err = shell_cmd_precheck(shell, (argc >= 2), NULL, 0);
 	if (err) {
 		return err;
 	}


### PR DESCRIPTION
Fixed a typo in the shell subsystem.