### PR TITLE
sensor: isl29035: Unchecked return value

### DIFF
--- a/drivers/sensor/isl29035/isl29035_trigger.c
+++ b/drivers/sensor/isl29035/isl29035_trigger.c
@@ -84,8 +84,11 @@ static void isl29035_thread_cb(struct device *dev)
 	u8_t val;
 
 	/* clear interrupt */
-	i2c_reg_read_byte(drv_data->i2c, ISL29035_I2C_ADDRESS,
-			  ISL29035_COMMAND_I_REG, &val);
+	if (i2c_reg_read_byte(drv_data->i2c, ISL29035_I2C_ADDRESS,
+			      ISL29035_COMMAND_I_REG, &val) < 0) {
+		LOG_ERR("isl29035: Error reading command register");
+		return;
+	}
 
 	if (drv_data->th_handler != NULL) {
 		drv_data->th_handler(dev, &drv_data->th_trigger);


### PR DESCRIPTION
Check the return value of i2c_reg_read_byte() and return
if unable to read the register
Coverity-CID: 188740

Fixes #10585

Signed-off-by: Satya Bhattacharya <satyacube@gmail.com>