### PR TITLE
tests: kernel: Enhance test to validate set thread name to current thread

### DIFF
--- a/tests/kernel/threads/thread_apis/src/main.c
+++ b/tests/kernel/threads/thread_apis/src/main.c
@@ -115,6 +115,14 @@ void test_thread_name_get_set(void)
 	int ret;
 	const char *thread_name;
 
+	/* Set and get current thread's name */
+	k_thread_name_set(NULL, "parent_thread");
+	thread_name = k_thread_name_get(k_current_get());
+
+	ret = strcmp(thread_name, "parent_thread");
+	zassert_equal(ret, 0, "parent thread name does not match");
+
+	/* Set and get child thread's name */
 	k_tid_t tid = k_thread_create(&tdata_name, tstack_name, STACK_SIZE,
 				      (k_thread_entry_t)thread_name_entry,
 				      NULL, NULL, NULL,
@@ -127,7 +135,7 @@ void test_thread_name_get_set(void)
 	thread_name = k_thread_name_get(tid);
 
 	ret = strcmp(thread_name, "customdata");
-	zassert_equal(ret, 0, "thread name does not match");
+	zassert_equal(ret, 0, "child thread name does not match");
 
 	/* cleanup environment */
 	k_thread_abort(tid);


### PR DESCRIPTION
Enhance test to validate a scenario where k_thread_name_set()
    with NULL as thread ID should set thread name to current
    thread.

This improves code coverage of thread.c

Signed-off-by: Spoorthi K <spoorthi.k@intel.com>