### PR TITLE
net: buf: Fix debug level setting

### DIFF
--- a/subsys/net/Kconfig
+++ b/subsys/net/Kconfig
@@ -33,9 +33,10 @@ config NET_BUF_LOG
 
 module = NET_BUF
 module-dep = LOG
+module-def = LOG_LEVEL_WRN
 module-str = Log level for network buffer handling
 module-help = Sets log level for network buffers.
-source "subsys/net/Kconfig.template.log_config.net"
+source "subsys/net/Kconfig.template.log_config.default.net"
 
 if NET_BUF_LOG
 

--- a/subsys/net/buf.c
+++ b/subsys/net/buf.c
@@ -6,6 +6,12 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+#define LOG_MODULE_NAME net_buf
+#define LOG_LEVEL CONFIG_NET_BUF_LOG_LEVEL
+
+#include <logging/log.h>
+LOG_MODULE_REGISTER(LOG_MODULE_NAME);
+
 #include <stdio.h>
 #include <errno.h>
 #include <stddef.h>
@@ -15,12 +21,6 @@
 #include <net/buf.h>
 
 #if defined(CONFIG_NET_BUF_LOG)
-#define LOG_MODULE_NAME net_buf
-#define NET_LOG_LEVEL CONFIG_NET_BUF_LOG_LEVEL
-
-#include <logging/log.h>
-LOG_MODULE_REGISTER();
-
 #define NET_BUF_DBG(fmt, ...) LOG_DBG("(%p) " fmt, k_current_get(), \
 				      ##__VA_ARGS__)
 #define NET_BUF_ERR(fmt, ...) LOG_ERR(fmt, ##__VA_ARGS__)


### PR DESCRIPTION
Some of the net_buf related tests failed if they enabled
CONFIG_NET_BUF_LOG setting.

Signed-off-by: Jukka Rissanen <jukka.rissanen@linux.intel.com>