### PR TITLE
subsys: console/tty: Refactor to introduce POSIX-like read/write API

### DIFF
--- a/include/console.h
+++ b/include/console.h
@@ -23,9 +23,11 @@ struct tty_serial {
 	u16_t rx_get, rx_put;
 	s32_t rx_timeout;
 
+	struct k_sem tx_sem;
 	u8_t *tx_ringbuf;
 	u32_t tx_ringbuf_sz;
 	u16_t tx_get, tx_put;
+	s32_t tx_timeout;
 };
 
 /**
@@ -60,6 +62,20 @@ void tty_init(struct tty_serial *tty, struct device *uart_dev,
 static inline void tty_set_rx_timeout(struct tty_serial *tty, s32_t timeout)
 {
 	tty->rx_timeout = timeout;
+}
+
+/**
+ * @brief Set transmit timeout for tty device.
+ *
+ * Set timeout for putchar() operation, for a case when output buffer is full.
+ * Default timeout after device initialization is K_FOREVER.
+ *
+ * @param tty tty device structure
+ * @param timeout timeout in milliseconds, or K_FOREVER, or K_NO_WAIT
+ */
+static inline void tty_set_tx_timeout(struct tty_serial *tty, s32_t timeout)
+{
+	tty->tx_timeout = timeout;
 }
 
 /**

--- a/include/console.h
+++ b/include/console.h
@@ -21,6 +21,7 @@ struct tty_serial {
 	u8_t *rx_ringbuf;
 	u32_t rx_ringbuf_sz;
 	u16_t rx_get, rx_put;
+	s32_t rx_timeout;
 
 	u8_t *tx_ringbuf;
 	u32_t tx_ringbuf_sz;
@@ -47,13 +48,28 @@ void tty_init(struct tty_serial *tty, struct device *uart_dev,
 	      u8_t *rxbuf, u16_t rxbuf_sz,
 	      u8_t *txbuf, u16_t txbuf_sz);
 
+/**
+ * @brief Set receive timeout for tty device.
+ *
+ * Set timeout for getchar() operation. Default timeout after
+ * device initialization is K_FOREVER.
+ *
+ * @param tty tty device structure
+ * @param timeout timeout in milliseconds, or K_FOREVER, or K_NO_WAIT
+ */
+static inline void tty_set_rx_timeout(struct tty_serial *tty, s32_t timeout)
+{
+	tty->rx_timeout = timeout;
+}
 
 /**
  * @brief Input a character from a tty device.
  *
  * @param tty tty device structure
+ * @return >=0, an input character
+ *         <0, an error (e.g. -EAGAIN if timeout expired)
  */
-u8_t tty_getchar(struct tty_serial *tty);
+int tty_getchar(struct tty_serial *tty);
 
 /**
  * @brief Output a character from to tty device.

--- a/subsys/console/getchar.c
+++ b/subsys/console/getchar.c
@@ -13,15 +13,36 @@ static struct tty_serial console_serial;
 static u8_t console_rxbuf[CONFIG_CONSOLE_GETCHAR_BUFSIZE];
 static u8_t console_txbuf[CONFIG_CONSOLE_PUTCHAR_BUFSIZE];
 
-int console_putchar(char c)
+ssize_t console_write(void *dummy, const void *buf, size_t size)
 {
-	return tty_putchar(&console_serial, (u8_t)c);
+	ARG_UNUSED(dummy);
+
+	return tty_write(&console_serial, buf, size);
 }
 
-u8_t console_getchar(void)
+ssize_t console_read(void *dummy, void *buf, size_t size)
 {
-	/* Console works in blocking mode, so we don't expect an error here */
-	return (u8_t)tty_getchar(&console_serial);
+	ARG_UNUSED(dummy);
+
+	return tty_read(&console_serial, buf, size);
+}
+
+int console_putchar(char c)
+{
+	return tty_write(&console_serial, &c, 1);
+}
+
+int console_getchar(void)
+{
+	u8_t c;
+	int res;
+
+	res = tty_read(&console_serial, &c, 1);
+	if (res < 0) {
+		return res;
+	}
+
+	return c;
 }
 
 void console_init(void)

--- a/subsys/console/getchar.c
+++ b/subsys/console/getchar.c
@@ -20,7 +20,8 @@ int console_putchar(char c)
 
 u8_t console_getchar(void)
 {
-	return tty_getchar(&console_serial);
+	/* Console works in blocking mode, so we don't expect an error here */
+	return (u8_t)tty_getchar(&console_serial);
 }
 
 void console_init(void)


### PR DESCRIPTION
* Allow to specify receive/transmit timeouts.
* Switch to API based on POSIX-like read()/write() functions.

(The underlying implementation stays the same for now, subject to follow-up refactors.)