### PR TITLE
coccinelle: Add script to check legal usage of sizeof expression

### DIFF
--- a/scripts/coccinelle/noderef.cocci
+++ b/scripts/coccinelle/noderef.cocci
@@ -1,0 +1,81 @@
+/// sizeof when applied to a pointer typed expression gives the size of
+/// the pointer
+///
+// Confidence: High
+// Copyright: (C) 2012 Julia Lawall, INRIA/LIP6.  GPLv2.
+// Copyright: (C) 2012 Gilles Muller, INRIA/LiP6.  GPLv2.
+// URL: http://coccinelle.lip6.fr/
+// Comments:
+// Options: --no-includes --include-headers
+
+virtual org
+virtual report
+virtual context
+virtual patch
+
+@depends on patch@
+expression *x;
+expression f;
+expression i;
+type T;
+@@
+
+(
+x = <+... sizeof(
+- x
++ *x
+   ) ...+>
+|
+f(...,(T)(x),...,sizeof(
+- x
++ *x
+   ),...)
+|
+f(...,sizeof(
+- x
++ *x
+   ),...,(T)(x),...)
+|
+f(...,(T)(x),...,i*sizeof(
+- x
++ *x
+   ),...)
+|
+f(...,i*sizeof(
+- x
++ *x
+   ),...,(T)(x),...)
+)
+
+@r depends on !patch@
+expression *x;
+expression f;
+expression i;
+position p;
+type T;
+@@
+
+(
+*x = <+... sizeof@p(x) ...+>
+|
+*f(...,(T)(x),...,sizeof@p(x),...)
+|
+*f(...,sizeof@p(x),...,(T)(x),...)
+|
+*f(...,(T)(x),...,i*sizeof@p(x),...)
+|
+*f(...,i*sizeof@p(x),...,(T)(x),...)
+)
+
+@script:python depends on org@
+p << r.p;
+@@
+
+cocci.print_main("application of sizeof to pointer",p)
+
+@script:python depends on report@
+p << r.p;
+@@
+
+msg = "ERROR: application of sizeof to pointer"
+coccilib.report.print_report(p[0],msg)


### PR DESCRIPTION
sizeof when applied to a pointer typed expression gives the size of
the pointer and not the size of the object associated with the pointer
expression leading to errors.

This scripts checks for inconsistencies where sizeof is incorrectly
used, especially while calculating size of memory to be allocated in
memory allocating functions.

Eg:

-	memset(pStr, 0, sizeof(pStr));
+	memset(pStr, 0, sizeof(*pStr));

Signed-off-by: Himanshu Jha <himanshujha199640@gmail.com>

One possible report found using this script was:
https://github.com/zephyrproject-rtos/zephyr/blob/master/subsys/bluetooth/controller/util/mem.c#L79
But it is a false postive.