### PR TITLE
coccinelle: Add script to remove redundant semicolon

### DIFF
--- a/drivers/display/ssd1673.c
+++ b/drivers/display/ssd1673.c
@@ -94,7 +94,7 @@ static inline void ssd1673_busy_wait(struct ssd1673_data *driver)
 	while (val) {
 		k_busy_wait(SSD1673_BUSY_DELAY);
 		gpio_pin_read(driver->busy, CONFIG_SSD1673_BUSY_PIN, &val);
-	};
+	}
 }
 
 static inline int ssd1673_set_ram_param(struct ssd1673_data *driver,

--- a/drivers/i2c/i2c_atmel_sam3.c
+++ b/drivers/i2c/i2c_atmel_sam3.c
@@ -237,7 +237,7 @@ static inline void sr_bits_set_wait(struct device *dev, u32_t bits)
 
 	while (!(cfg->regs->TWI_SR & bits)) {
 		/* loop till <bits> are set */
-	};
+	}
 }
 
 /* Clear the status registers from previous transfers */

--- a/drivers/i2c/i2c_ll_stm32.c
+++ b/drivers/i2c/i2c_ll_stm32.c
@@ -140,7 +140,7 @@ static int i2c_stm32_transfer(struct device *dev, struct i2c_msg *msg,
 
 		current++;
 		num_msgs--;
-	};
+	}
 #if defined(CONFIG_I2C_STM32_V1)
 	LL_I2C_Disable(i2c);
 #endif

--- a/drivers/i2c/i2c_ll_stm32_v1.c
+++ b/drivers/i2c/i2c_ll_stm32_v1.c
@@ -359,7 +359,7 @@ s32_t stm32_i2c_msg_write(struct device *dev, struct i2c_msg *msg,
 
 				return -EIO;
 			}
-		};
+		}
 		LL_I2C_TransmitData8(i2c, *buf);
 		buf++;
 		len--;

--- a/drivers/sensor/adxl372/adxl372_trigger.c
+++ b/drivers/sensor/adxl372/adxl372_trigger.c
@@ -122,7 +122,7 @@ int adxl372_trigger_set(struct device *dev,
 		int_en = int_mask;
 	} else {
 		int_en = 0;
-	};
+	}
 
 	ret = adxl372_reg_write_mask(dev, ADXL372_INT1_MAP, int_mask, int_en);
 

--- a/drivers/sensor/lis3mdl/lis3mdl.c
+++ b/drivers/sensor/lis3mdl/lis3mdl.c
@@ -81,7 +81,7 @@ int lis3mdl_sample_fetch(struct device *dev, enum sensor_channel chan)
 			   (u8_t *)(buf + 3), 2) < 0) {
 		LOG_DBG("Failed to fetch temperature sample.");
 		return -EIO;
-	};
+	}
 
 	drv_data->x_sample = sys_le16_to_cpu(buf[0]);
 	drv_data->y_sample = sys_le16_to_cpu(buf[1]);

--- a/drivers/sensor/qdec_nrfx/qdec_nrfx.c
+++ b/drivers/sensor/qdec_nrfx/qdec_nrfx.c
@@ -158,7 +158,7 @@ static void qdec_nrfx_event_handler(nrfx_qdec_event_t event)
 	default:
 		SYS_LOG_ERR("unhandled event (0x%x)", event.type);
 		break;
-	};
+	}
 }
 
 static void qdec_nrfx_gpio_ctrl(bool enable)

--- a/drivers/serial/uart_sam.c
+++ b/drivers/serial/uart_sam.c
@@ -127,7 +127,7 @@ static int uart_sam_init(struct device *dev)
 			      SOC_ATMEL_SAM_MCK_FREQ_HZ);
 	if (retval != 0) {
 		return retval;
-	};
+	}
 
 	/* Enable receiver and transmitter */
 	uart->UART_CR = UART_CR_RXEN | UART_CR_TXEN;
@@ -200,7 +200,7 @@ static int baudrate_set(Uart *const uart, u32_t baudrate,
 
 	if (divisor > 0xFFFF) {
 		return -EINVAL;
-	};
+	}
 
 	uart->UART_BRGR = UART_BRGR_CD(divisor);
 

--- a/drivers/serial/usart_sam.c
+++ b/drivers/serial/usart_sam.c
@@ -112,7 +112,7 @@ static int usart_sam_init(struct device *dev)
 			      SOC_ATMEL_SAM_MCK_FREQ_HZ);
 	if (retval != 0) {
 		return retval;
-	};
+	}
 
 	/* Enable receiver and transmitter */
 	usart->US_CR = US_CR_RXEN | US_CR_TXEN;
@@ -186,7 +186,7 @@ static int baudrate_set(Usart *const usart, u32_t baudrate,
 
 	if (divisor > 0xFFFF) {
 		return -EINVAL;
-	};
+	}
 
 	usart->US_BRGR = US_BRGR_CD(divisor);
 

--- a/scripts/coccinelle/semicolon.cocci
+++ b/scripts/coccinelle/semicolon.cocci
@@ -1,0 +1,83 @@
+///
+/// Remove unneeded semicolon.
+///
+// Confidence: Moderate
+// Copyright: (C) 2012 Peter Senna Tschudin, INRIA/LIP6.  GPLv2.
+// URL: http://coccinelle.lip6.fr/
+// Comments: Some false positives on empty default cases in switch statements.
+// Options: --no-includes --include-headers
+
+virtual patch
+virtual report
+virtual context
+virtual org
+
+@r_default@
+position p;
+@@
+switch (...)
+{
+default: ...;@p
+}
+
+@r_case@
+position p;
+@@
+(
+switch (...)
+{
+case ...:;@p
+}
+|
+switch (...)
+{
+case ...:...
+case ...:;@p
+}
+|
+switch (...)
+{
+case ...:...
+case ...:
+case ...:;@p
+}
+)
+
+@r1@
+statement S;
+position p1;
+position p != {r_default.p, r_case.p};
+identifier label;
+@@
+(
+label:;
+|
+S@p1;@p
+)
+
+@script:python@
+p << r1.p;
+p1 << r1.p1;
+@@
+if p[0].line != p1[0].line_end:
+	cocci.include_match(False)
+
+@depends on patch@
+position r1.p;
+@@
+-;@p
+
+@script:python depends on report@
+p << r1.p;
+@@
+coccilib.report.print_report(p[0],"Unneeded semicolon")
+
+@depends on context@
+position r1.p;
+@@
+*;@p
+
+@script:python depends on org@
+p << r1.p;
+@@
+cocci.print_main("Unneeded semicolon",p)


### PR DESCRIPTION
This script allowes to remove the redundant semicolon from
`if`, `switch`, `while`, `for` statements.

Signed-off-by: Himanshu Jha <himanshujha199640@gmail.com>