### PR TITLE
IPv6 MLDv2: Remove incorrect length assigment

### DIFF
--- a/subsys/net/ip/ipv6_mld.c
+++ b/subsys/net/ip/ipv6_mld.c
@@ -125,7 +125,6 @@ static int send_mldv2_raw(struct net_if *iface, struct net_buf *frags)
 
 #define ROUTER_ALERT_LEN 8
 
-	pkt->frags->len = NET_IPV6ICMPH_LEN + ROUTER_ALERT_LEN;
 	net_pkt_set_iface(pkt, iface);
 
 	/* Insert the actual multicast record(s) here */


### PR DESCRIPTION
This assignment sets the packet length two bytes short, causing later code to overwrite the reserved and record count fields.

## Packet with original code:
![malformed_packet](https://user-images.githubusercontent.com/229360/47352137-9e6c6d80-d6b9-11e8-97f3-1cd414d76fc8.png)

## Packet with patched code:
![wellformed_packet](https://user-images.githubusercontent.com/229360/47352149-a4624e80-d6b9-11e8-92b1-7d9223d803db.png)

Caveat: I haven't completely wrapped my head around the code after this change, which also uses the local `ROUTER_ALERT_LEN` define. Maybe more modifications are required. Please review carefully.
