### PR TITLE
tests: net: Fix possible null dereference in net_pkt tests

### DIFF
--- a/tests/net/net_pkt/src/main.c
+++ b/tests/net/net_pkt/src/main.c
@@ -441,8 +441,9 @@ static void test_pkt_read_append(void)
 	tfrag = tfrag->frags;
 	off = tfrag->len;
 	tfrag = net_frag_read(tfrag, off + 10, &tpos, 10, data);
-	if (!tfrag ||
-	    memcmp(sample_data + off + 10, data, 10)) {
+	zassert_not_null(tfrag, "Fail offset read");
+
+	if (memcmp(sample_data + off + 10, data, 10)) {
 		printk("Failed to read from offset %d, frag length %d "
 		       "read length %d\n",
 		       tfrag->len + 10, tfrag->len, 10);


### PR DESCRIPTION
It might be that the test might access null pointer in some cases.
In practice this is not possible as the test is using pre-defined
data when running the test.

Fixes #10777

Signed-off-by: Jukka Rissanen <jukka.rissanen@linux.intel.com>