### PR TITLE
cmake: Move MDK-defines from 'soc' to the MDK build script

### DIFF
--- a/ext/hal/nordic/CMakeLists.txt
+++ b/ext/hal/nordic/CMakeLists.txt
@@ -11,6 +11,12 @@ if(CONFIG_HAS_NRFX)
   zephyr_include_directories(nrfx/mdk)
   zephyr_include_directories(.)
 
+  # Define MDK defines globally
+  zephyr_compile_definitions_ifdef(CONFIG_SOC_SERIES_NRF51X NRF51)
+  zephyr_compile_definitions_ifdef(CONFIG_SOC_NRF52810      NRF52810_XXAA)
+  zephyr_compile_definitions_ifdef(CONFIG_SOC_NRF52832      NRF52832_XXAA)
+  zephyr_compile_definitions_ifdef(CONFIG_SOC_NRF52840      NRF52840_XXAA)
+
   zephyr_sources_ifdef(CONFIG_SOC_SERIES_NRF51X nrfx/mdk/system_nrf51.c)
   zephyr_sources_ifdef(CONFIG_SOC_NRF52810      nrfx/mdk/system_nrf52810.c)
   zephyr_sources_ifdef(CONFIG_SOC_NRF52832      nrfx/mdk/system_nrf52.c)

--- a/soc/arm/nordic_nrf/nrf51/CMakeLists.txt
+++ b/soc/arm/nordic_nrf/nrf51/CMakeLists.txt
@@ -1,6 +1,7 @@
+# NB: The define 'NRF51822' is deprecated. 'NRF51' should be used in
+# it's place.
 zephyr_compile_definitions_ifdef(
   CONFIG_SOC_SERIES_NRF51X
-  NRF51
   NRF51822
   )
 

--- a/soc/arm/nordic_nrf/nrf51/CMakeLists.txt
+++ b/soc/arm/nordic_nrf/nrf51/CMakeLists.txt
@@ -1,10 +1,3 @@
-# NB: The define 'NRF51822' is deprecated. 'NRF51' should be used in
-# it's place.
-zephyr_compile_definitions_ifdef(
-  CONFIG_SOC_SERIES_NRF51X
-  NRF51822
-  )
-
 zephyr_sources(
   soc.c
   )

--- a/soc/arm/nordic_nrf/nrf52/CMakeLists.txt
+++ b/soc/arm/nordic_nrf/nrf52/CMakeLists.txt
@@ -1,7 +1,3 @@
-zephyr_compile_definitions_ifdef(CONFIG_SOC_NRF52810 NRF52810_XXAA)
-zephyr_compile_definitions_ifdef(CONFIG_SOC_NRF52832 NRF52832_XXAA)
-zephyr_compile_definitions_ifdef(CONFIG_SOC_NRF52840 NRF52840_XXAA)
-
 zephyr_sources(
   power.c
   soc.c


### PR DESCRIPTION
The build script ext/hal/nordic/CMakeLists.txt manages the MDK
dependency. The MDK is not aware of Zephyr and uses it's own defines
to indicate what HW we are building for.

This PR moves these MDK-specific defines out of the 'soc' build
scripts and into the MDK build script where they belong.

It also drops support for a define that is unused in-tree and believed to have been
added by accident.

Signed-off-by: Sebastian Bøe <sebastian.boe@nordicsemi.no>