### PR TITLE
nrf52_bsim: Fix possible NULL pointer dereference

### DIFF
--- a/boards/posix/nrf52_bsim/bstests_entry.c
+++ b/boards/posix/nrf52_bsim/bstests_entry.c
@@ -167,9 +167,13 @@ void bst_post_init(void)
 void bst_tick(bs_time_t time)
 {
 
-	if (current_test && current_test->test_tick_f) {
+	if (current_test == NULL) {
+		return;
+	}
+
+	if (current_test->test_tick_f) {
 		current_test->test_tick_f(time);
-	} else {
+	} else if (current_test->test_id) {
 		bs_trace_error_line("the test id %s doesn't have a tick handler"
 				    " (how come did we arrive here?)\n",
 				    current_test->test_id);


### PR DESCRIPTION
Fixed a very unlikely NULL pointer dereference, which could occur
in an error condition, triggered if the test/fake HW timer model
was enabled but there was no registered handler for that timer tick.

The de-reference was in the error message printout.

Fixes #10778

Signed-off-by: Alberto Escolar Piedras <alpi@oticon.com>