### PR TITLE
tests: posix: Bugfix unitialized array in posix_pthread_execution

### DIFF
--- a/tests/posix/common/src/pthread.c
+++ b/tests/posix/common/src/pthread.c
@@ -225,7 +225,7 @@ void test_posix_pthread_execution(void)
 {
 	int i, ret, min_prio, max_prio;
 	int dstate, policy;
-	pthread_attr_t attr[N_THR_E];
+	pthread_attr_t attr[N_THR_E] = {};
 	struct sched_param schedparam, getschedparam;
 	pthread_t newthread[N_THR_E];
 	int schedpolicy = SCHED_FIFO;


### PR DESCRIPTION
Initialize an otherwise unitialized array which was causing random
failures in tests/posix/common.

Fixes #10508

Signed-off-by: Alberto Escolar Piedras <alpi@oticon.com>