### PR TITLE
arch: arm: API to allow Non-Secure FPU Access

### DIFF
--- a/arch/arm/core/cortex_m/tz/arm_core_tz.c
+++ b/arch/arm/core/cortex_m/tz/arm_core_tz.c
@@ -108,6 +108,14 @@ void tz_nonsecure_system_reset_req_block(int block)
 		| aircr_payload;
 }
 
+#if defined(CONFIG_ARMV7_M_ARMV8_M_FP)
+void tz_nonsecure_fpu_access_enable(void)
+{
+	SCB->NSACR |=
+		(1UL << SCB_NSACR_CP10_Pos) | (1UL << SCB_NSACR_CP11_Pos);
+}
+#endif /* CONFIG_ARMV7_M_ARMV8_M_FP */
+
 void tz_sau_configure(int enable, int allns)
 {
 	if (enable) {

--- a/arch/arm/include/cortex_m/tz.h
+++ b/arch/arm/include/cortex_m/tz.h
@@ -167,6 +167,23 @@ void tz_nonsecure_exception_prio_config(int secure_boost);
  */
 void tz_nbanked_exception_target_state_set(int secure_state);
 
+#if defined(CONFIG_ARMV7_M_ARMV8_M_FP)
+/**
+ * @brief Allow Non-Secure firmware to access the FPU
+ *
+ * Function allows the Non-Secure firmware to access the Floating Point Unit.
+ *
+ * Relevant for ARMv8-M MCUs supporting the Floating Point Extension.
+ *
+ * Note:
+ *
+ * This function shall only be called from Secure state.
+ *
+ * @return N/A
+ */
+void tz_nonsecure_fpu_access_enable(void);
+#endif /* CONFIG_ARMV7_M_ARMV8_M_FP */
+
 /**
  *
  * @brief Configure SAU


### PR DESCRIPTION
This commit introduces and implements an internal ARM
TrustZone-M API to allow the Non-Secure firmware to use
the Floating Point Unit (FPU).

Signed-off-by: Ioannis Glaropoulos <Ioannis.Glaropoulos@nordicsemi.no>