### PR TITLE
shell: fix history feature

### DIFF
--- a/include/shell/shell.h
+++ b/include/shell/shell.h
@@ -288,6 +288,7 @@ struct shell_flags {
 	u32_t processing  :1; /*!< Shell is executing process function.*/
 	u32_t tx_rdy      :1;
 	u32_t mode_delete :1; /*!< Operation mode of backspace key */
+	u32_t history_exit:1; /*!< Request to exit history mode */
 };
 
 BUILD_ASSERT_MSG((sizeof(struct shell_flags) == sizeof(u32_t)),

--- a/subsys/shell/shell_history.c
+++ b/subsys/shell/shell_history.c
@@ -57,7 +57,7 @@ bool shell_history_get(struct shell_history *history, bool up,
 	}
 
 	*len = 0;
-	return up;
+	return false;
 }
 
 static void add_to_head(struct shell_history *history,


### PR DESCRIPTION
When user was typing a new command and next pressed an up arrow shell has displayed previously executed command. Next it was not possible to display currently edited command using a down arrow.

Fixes #10766.

Signed-off-by: Jakub Rzeszutko <jakub.rzeszutko@nordicsemi.no>