### PR TITLE
logging: Added support for 15 arguments in log message

### DIFF
--- a/include/logging/log_core.h
+++ b/include/logging/log_core.h
@@ -171,10 +171,28 @@ extern "C" {
 /******************************************************************************/
 /****************** Internal macros for log frontend **************************/
 /******************************************************************************/
+/**@brief Second stage for _LOG_NARGS_POSTFIX */
+#define _LOG_NARGS_POSTFIX_IMPL(				\
+	_ignored,						\
+	_0, _1, _2, _3, _4, _5, _6, _7, _8, _9, _10,		\
+	_11, _12, _13, _14, N, ...) N
+
+/**@brief Macro to get the postfix for further log message processing.
+ *
+ * Logs with more than 3 arguments are processed in a generic way.
+ *
+ * param[in]    ...     List of arguments
+ *
+ * @retval  Postfix, number of arguments or _LONG when more than 3 arguments.
+ */
+#define _LOG_NARGS_POSTFIX(...) \
+	_LOG_NARGS_POSTFIX_IMPL(__VA_ARGS__, LONG, LONG, LONG, LONG, LONG, \
+			LONG, LONG, LONG, LONG, LONG, LONG, LONG, 3, 2, 1, 0, ~)
+
 #define _LOG_INTERNAL_X(N, ...)  UTIL_CAT(_LOG_INTERNAL_, N)(__VA_ARGS__)
 
 #define __LOG_INTERNAL(_src_level, ...)			 \
-	_LOG_INTERNAL_X(NUM_VA_ARGS_LESS_1(__VA_ARGS__), \
+	_LOG_INTERNAL_X(_LOG_NARGS_POSTFIX(__VA_ARGS__), \
 			_src_level, __VA_ARGS__)
 
 #define _LOG_INTERNAL_0(_src_level, _str) \
@@ -198,27 +216,6 @@ extern "C" {
 		u32_t args[] = {__LOG_ARGUMENTS(__VA_ARGS__)};	 \
 		log_n(_str, args, ARRAY_SIZE(args), _src_level); \
 	} while (false)
-
-#define _LOG_INTERNAL_4(_src_level, _str, ...) \
-		_LOG_INTERNAL_LONG(_src_level, _str, __VA_ARGS__)
-
-#define _LOG_INTERNAL_5(_src_level, _str, ...) \
-		_LOG_INTERNAL_LONG(_src_level, _str, __VA_ARGS__)
-
-#define _LOG_INTERNAL_6(_src_level, _str, ...) \
-		_LOG_INTERNAL_LONG(_src_level, _str, __VA_ARGS__)
-
-#define _LOG_INTERNAL_7(_src_level, _str, ...) \
-		_LOG_INTERNAL_LONG(_src_level, _str, __VA_ARGS__)
-
-#define _LOG_INTERNAL_8(_src_level, _str, ...) \
-		_LOG_INTERNAL_LONG(_src_level, _str, __VA_ARGS__)
-
-#define _LOG_INTERNAL_9(_src_level, _str, ...) \
-		_LOG_INTERNAL_LONG(_src_level, _str, __VA_ARGS__)
-
-#define _LOG_INTERNAL_10(_src_level, _str, ...) \
-		_LOG_INTERNAL_LONG(_src_level, _str, __VA_ARGS__)
 
 #define _LOG_LEVEL_CHECK(_level, _check_level, _default_level) \
 	(_level <= _LOG_RESOLVED_LEVEL(_check_level, _default_level))

--- a/subsys/logging/log_output.c
+++ b/subsys/logging/log_output.c
@@ -43,7 +43,8 @@ static u32_t timestamp_div;
 typedef int (*out_func_t)(int c, void *ctx);
 
 extern int _prf(int (*func)(), void *dest, char *format, va_list vargs);
-extern void _vprintk(out_func_t out, void *log_output, const char *fmt, va_list ap);
+extern void _vprintk(out_func_t out, void *log_output,
+		     const char *fmt, va_list ap);
 
 static int out_func(int c, void *ctx)
 {
@@ -203,94 +204,83 @@ static void std_print(struct log_msg *msg,
 		      const struct log_output *log_output)
 {
 	const char *str = log_msg_str_get(msg);
+	u32_t nargs = log_msg_nargs_get(msg);
+	u32_t *args = alloca(sizeof(u32_t)*nargs);
+	int i;
+
+	for (i = 0; i < nargs; i++) {
+		args[i] = log_msg_arg_get(msg, i);
+	}
 
 	switch (log_msg_nargs_get(msg)) {
 	case 0:
 		print_formatted(log_output, str);
 		break;
 	case 1:
-		print_formatted(log_output, str, log_msg_arg_get(msg, 0));
+		print_formatted(log_output, str, args[0]);
 		break;
 	case 2:
-		print_formatted(log_output, str,
-		      log_msg_arg_get(msg, 0),
-		      log_msg_arg_get(msg, 1));
+		print_formatted(log_output, str, args[0], args[1]);
 		break;
 	case 3:
-		print_formatted(log_output, str,
-		      log_msg_arg_get(msg, 0),
-		      log_msg_arg_get(msg, 1),
-		      log_msg_arg_get(msg, 2));
+		print_formatted(log_output, str, args[0], args[1], args[2]);
 		break;
 	case 4:
-		print_formatted(log_output, str,
-		      log_msg_arg_get(msg, 0),
-		      log_msg_arg_get(msg, 1),
-		      log_msg_arg_get(msg, 2),
-		      log_msg_arg_get(msg, 3));
+		print_formatted(log_output, str, args[0], args[1], args[2],
+				args[3]);
 		break;
 	case 5:
-		print_formatted(log_output, str,
-		      log_msg_arg_get(msg, 0),
-		      log_msg_arg_get(msg, 1),
-		      log_msg_arg_get(msg, 2),
-		      log_msg_arg_get(msg, 3),
-		      log_msg_arg_get(msg, 4));
+		print_formatted(log_output, str, args[0], args[1], args[2],
+				args[3], args[4]);
 		break;
 	case 6:
-		print_formatted(log_output, str,
-		      log_msg_arg_get(msg, 0),
-		      log_msg_arg_get(msg, 1),
-		      log_msg_arg_get(msg, 2),
-		      log_msg_arg_get(msg, 3),
-		      log_msg_arg_get(msg, 4),
-		      log_msg_arg_get(msg, 5));
+		print_formatted(log_output, str, args[0], args[1], args[2],
+				args[3], args[4], args[5]);
 		break;
 	case 7:
-		print_formatted(log_output, str,
-		      log_msg_arg_get(msg, 0),
-		      log_msg_arg_get(msg, 1),
-		      log_msg_arg_get(msg, 2),
-		      log_msg_arg_get(msg, 3),
-		      log_msg_arg_get(msg, 4),
-		      log_msg_arg_get(msg, 5),
-		      log_msg_arg_get(msg, 6));
+		print_formatted(log_output, str, args[0], args[1], args[2],
+				args[3], args[4], args[5], args[6]);
 		break;
 	case 8:
-		print_formatted(log_output, str,
-		      log_msg_arg_get(msg, 0),
-		      log_msg_arg_get(msg, 1),
-		      log_msg_arg_get(msg, 2),
-		      log_msg_arg_get(msg, 3),
-		      log_msg_arg_get(msg, 4),
-		      log_msg_arg_get(msg, 5),
-		      log_msg_arg_get(msg, 6),
-		      log_msg_arg_get(msg, 7));
+		print_formatted(log_output, str, args[0], args[1], args[2],
+				args[3], args[4], args[5], args[6], args[7]);
 		break;
 	case 9:
-		print_formatted(log_output, str,
-		      log_msg_arg_get(msg, 0),
-		      log_msg_arg_get(msg, 1),
-		      log_msg_arg_get(msg, 2),
-		      log_msg_arg_get(msg, 3),
-		      log_msg_arg_get(msg, 4),
-		      log_msg_arg_get(msg, 5),
-		      log_msg_arg_get(msg, 6),
-		      log_msg_arg_get(msg, 7),
-		      log_msg_arg_get(msg, 8));
+		print_formatted(log_output, str, args[0], args[1], args[2],
+				args[3], args[4], args[5], args[6],  args[7],
+				args[8]);
 		break;
 	case 10:
-		print_formatted(log_output, str,
-		      log_msg_arg_get(msg, 0),
-		      log_msg_arg_get(msg, 1),
-		      log_msg_arg_get(msg, 2),
-		      log_msg_arg_get(msg, 3),
-		      log_msg_arg_get(msg, 4),
-		      log_msg_arg_get(msg, 5),
-		      log_msg_arg_get(msg, 6),
-		      log_msg_arg_get(msg, 7),
-		      log_msg_arg_get(msg, 8),
-		      log_msg_arg_get(msg, 9));
+		print_formatted(log_output, str, args[0], args[1], args[2],
+				args[3], args[4], args[5], args[6],  args[7],
+				args[8], args[9]);
+		break;
+	case 11:
+		print_formatted(log_output, str, args[0], args[1], args[2],
+				args[3], args[4], args[5], args[6],  args[7],
+				args[8], args[9], args[10]);
+		break;
+	case 12:
+		print_formatted(log_output, str, args[0], args[1], args[2],
+				args[3], args[4], args[5], args[6],  args[7],
+				args[8], args[9], args[10], args[11]);
+		break;
+	case 13:
+		print_formatted(log_output, str, args[0], args[1], args[2],
+				args[3], args[4], args[5], args[6],  args[7],
+				args[8], args[9], args[10], args[11], args[12]);
+		break;
+	case 14:
+		print_formatted(log_output, str, args[0], args[1], args[2],
+				args[3], args[4], args[5], args[6],  args[7],
+				args[8], args[9], args[10], args[11], args[12],
+				args[13]);
+		break;
+	case 15:
+		print_formatted(log_output, str, args[0], args[1], args[2],
+				args[3], args[4], args[5], args[6],  args[7],
+				args[8], args[9], args[10], args[11], args[12],
+				args[13], args[14]);
 		break;
 	default:
 		/* Unsupported number of arguments. */


### PR DESCRIPTION
Extended supported number of arguments in log message. Support for messages
consisting of more than 2 chunks had to be added. So far messages could
consist of one chunk (up to 3 args) or two chunks (2 args in first chunk and
7 in second chunk). Once 2+ chunks support is added number of arguments is
techinically limited to 15 (4 bit field). log_core and log_output extended
to suppor 10 arguments.

Signed-off-by: Krzysztof Chruscinski <krzysztof.chruscinski@nordicsemi.no>