### PR TITLE
scripts/dts/extract: Change compat define prefix

### DIFF
--- a/scripts/dts/extract/compatible.py
+++ b/scripts/dts/extract/compatible.py
@@ -38,7 +38,7 @@ class DTCompatible(DTDirective):
         for i, comp in enumerate(compatible):
             # Generate #define's
             compat_label = convert_string_to_label(str(comp))
-            compat_defs = 'CONFIG_DT_COMPAT_' + compat_label
+            compat_defs = 'DT_COMPAT_' + compat_label
             load_defs = {
                 compat_defs: "",
             }

--- a/scripts/dts/extract/globals.py
+++ b/scripts/dts/extract/globals.py
@@ -139,7 +139,7 @@ def get_phandles(root, name, handles):
 def insert_defs(node_address, new_defs, new_aliases):
 
     for key in new_defs.keys():
-        if key.startswith('CONFIG_DT_COMPAT_'):
+        if key.startswith('DT_COMPAT_'):
             node_address = 'Compatibles'
 
     if node_address in defs:


### PR DESCRIPTION
Drop CONFIG_ and just use DT_ prefix for compatiable generated defines.

Signed-off-by: Kumar Gala <kumar.gala@linaro.org>