### PR TITLE
dts: bindings: remove setting use-prop-label in st,stm32-ccm

### DIFF
--- a/dts/bindings/arm/st,stm32-ccm.yaml
+++ b/dts/bindings/arm/st,stm32-ccm.yaml
@@ -20,6 +20,5 @@ properties:
       category: required
 
 base_label: CCM
-use-property-label: yes
 
 ...


### PR DESCRIPTION
We set 'use-prop-label' incorrectly in the st,stm32-ccm binding file.
This property is meant to generate names based on there being a label
property set in the node.  For st,stm32-ccm nodes we don't ever set
labels and the binding file doesn't specify a label.  So remove setting
'use-prop-label'.

Signed-off-by: Kumar Gala <kumar.gala@linaro.org>