### PR TITLE
dts: bindings: cleanup soc-nv-flash binding

### DIFF
--- a/dts/bindings/mtd/soc-nv-flash.yaml
+++ b/dts/bindings/mtd/soc-nv-flash.yaml
@@ -33,7 +33,4 @@ properties:
      category: optional
      label: alignment
 
-base_label: FLASH
-use-property-label: yes
-
 ...


### PR DESCRIPTION
Remove setting of base_label and use-property-label from soc-nv-flash
binding file.  We don't really need to set either of these properties
in the binding and it just goes to make things more complicated than
they need to be.

Signed-off-by: Kumar Gala <kumar.gala@linaro.org>