### PR TITLE
kernel: sched: Fix compiler warning in sched.c

### DIFF
--- a/kernel/sched.c
+++ b/kernel/sched.c
@@ -445,7 +445,8 @@ void _reschedule(u32_t key)
 	}
 
 #ifdef CONFIG_SMP
-	return _Swap(key);
+	(void)_Swap(key);
+	return;
 #else
 	if (_get_next_ready_thread() != _current) {
 		(void)_Swap(key);


### PR DESCRIPTION
Ignore return value of _Swap() as it is not
used anywhere.

Fixes: #10803 

Signed-off-by: Spoorthi K <spoorthi.k@intel.com>