### PR TITLE
include: posix: Add minimum stack size macro

### DIFF
--- a/include/posix/pthread.h
+++ b/include/posix/pthread.h
@@ -48,6 +48,8 @@ struct posix_thread {
 	pthread_cond_t state_cond;
 };
 
+#define PTHREAD_STACK_MIN 256
+
 /* Pthread detach/joinable */
 #define PTHREAD_CREATE_JOINABLE     0
 #define PTHREAD_CREATE_DETACHED     1

--- a/lib/posix/pthread.c
+++ b/lib/posix/pthread.c
@@ -108,6 +108,10 @@ int pthread_attr_setstack(pthread_attr_t *attr, void *stackaddr,
 	}
 
 	attr->stack = stackaddr;
+
+	if (stacksize < PTHREAD_STACK_MIN)
+		return EINVAL;
+
 	attr->stacksize = stacksize;
 	return 0;
 }


### PR DESCRIPTION
Add PTHREAD_STACK_MIN macro and check for EINVAL error code.

Signed-off-by: Punit Vara <punit.vara@intel.com>