### PR TITLE
doc: bluetooth: clarify where to find the btmgmt binary

### DIFF
--- a/doc/subsystems/bluetooth/devel.rst
+++ b/doc/subsystems/bluetooth/devel.rst
@@ -133,7 +133,7 @@ Zephyr-based controller:
 
    .. code-block:: console
 
-      sudo btmgmt --index 0
+      sudo tools/btmgmt --index 0
       [hci0]# auto-power
       [hci0]# find -l
 


### PR DESCRIPTION
Prepend the btmgmt call with the tools/ subdirectory to line up with
the other BlueZ tool calls in the examples.

Signed-off-by: Henrik Brix Andersen <henrik@brixandersen.dk>