### PR TITLE
doc: Fix pip3 install command

### DIFF
--- a/doc/getting_started/getting_started.rst
+++ b/doc/getting_started/getting_started.rst
@@ -45,7 +45,7 @@ Next, install additional Python packages required by Zephyr in a shell or
 .. code-block:: console
 
    # Linux
-   pip3 install -r --user zephyr/scripts/requirements.txt
+   pip3 install --user -r zephyr/scripts/requirements.txt
 
    # macOS and Windows
    pip3 install -r zephyr/scripts/requirements.txt


### PR DESCRIPTION
The getting started guide says to run:

pip3 install -r --user zephyr/scripts/requirements.txt

but this is broken. It should be:

pip3 install --user -r zephyr/scripts/requirements.txt

This fixes #10817 and is a regression from:
0d811b9aee6

Signed-off-by: Sebastian Bøe <sebastian.boe@nordicsemi.no>