### PR TITLE
nrf52_bsim: Codestyle fix

### DIFF
--- a/boards/posix/nrf52_bsim/bstests.h
+++ b/boards/posix/nrf52_bsim/bstests.h
@@ -66,7 +66,7 @@ typedef void (*bst_test_fake_ddriver_postkernel_t)(void);
  */
 typedef void (*bst_test_main_t)(void);
 
-typedef struct {
+struct bst_test_instance {
 	char *test_id;
 	char *test_descr;
 	bst_test_args_t                    test_args_f;
@@ -78,20 +78,21 @@ typedef struct {
 	bst_test_fake_ddriver_prekernel_t  test_fake_ddriver_prekernel_f;
 	bst_test_fake_ddriver_postkernel_t test_fake_ddriver_postkernel_f;
 	bst_test_main_t                    test_main_f;
-} bst_test_instance_t;
+};
 
 #define BSTEST_END_MARKER \
 {NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL}
 
-typedef struct test_list_entry_t {
-	bst_test_instance_t         *test_instance;
-	struct test_list_entry_t    *next;
-} bst_test_list_t;
+struct bst_test_list {
+	struct bst_test_instance  *test_instance;
+	struct bst_test_list    *next;
+};
 
-typedef bst_test_list_t *(*bst_test_install_t)(bst_test_list_t *test_tail);
+typedef struct bst_test_list *(*bst_test_install_t)(struct bst_test_list
+							*test_tail);
 
-bst_test_list_t *bst_add_tests(bst_test_list_t *tests,
-		const bst_test_instance_t *test_def);
+struct bst_test_list *bst_add_tests(struct bst_test_list *tests,
+				    const struct bst_test_instance *test_def);
 void bst_set_testapp_mode(char *test_id);
 void bst_pass_args(int argc, char **argv);
 void bst_pre_init(void);
@@ -102,7 +103,7 @@ bool bst_irq_sniffer(int irq_number);
 uint8_t bst_delete(void);
 
 /* These return codes need to fit in a uint8_t (0..255), where 0 = successful */
-typedef enum {Passed = 0, In_progress = 1, Failed = 2} bst_result_t;
+enum bst_result_t {Passed = 0, In_progress = 1, Failed = 2};
 
 void bst_print_testslist(void);
 

--- a/boards/posix/nrf52_bsim/bstests_entry.c
+++ b/boards/posix/nrf52_bsim/bstests_entry.c
@@ -17,19 +17,19 @@
  * {the HW model return code} will be 0 unless it fails or it is
  * configured illegally
  */
-bst_result_t bst_result;
+enum bst_result_t bst_result;
 
-static bst_test_instance_t *current_test;
-static bst_test_list_t *test_list_top;
+static struct bst_test_instance *current_test;
+static struct bst_test_list *test_list_top;
 
 __attribute__((weak)) bst_test_install_t test_installers[] = { NULL };
 
-bst_test_list_t *bst_add_tests(bst_test_list_t *tests,
-				const bst_test_instance_t *test_def)
+struct bst_test_list *bst_add_tests(struct bst_test_list *tests,
+				const struct bst_test_instance *test_def)
 {
 	int idx = 0;
-	bst_test_list_t *tail = tests;
-	bst_test_list_t *head = tests;
+	struct bst_test_list *tail = tests;
+	struct bst_test_list *head = tests;
 
 	if (tail) {
 		/* First we 'run to end' */
@@ -38,28 +38,29 @@ bst_test_list_t *bst_add_tests(bst_test_list_t *tests,
 		}
 	} else {
 		if (test_def[idx].test_id != NULL) {
-			head = malloc(sizeof(bst_test_list_t));
+			head = malloc(sizeof(struct bst_test_list));
 			head->next = NULL;
-			head->test_instance = (bst_test_instance_t *)
+			head->test_instance = (struct bst_test_instance *)
 						&test_def[idx++];
 			tail = head;
 		}
 	}
 
 	while (test_def[idx].test_id != NULL) {
-		tail->next = malloc(sizeof(bst_test_list_t));
+		tail->next = malloc(sizeof(struct bst_test_list));
 		tail = tail->next;
-		tail->test_instance = (bst_test_instance_t *)&test_def[idx++];
+		tail->test_instance = (struct bst_test_instance *)
+					&test_def[idx++];
 		tail->next = NULL;
 	}
 
 	return head;
 }
 
-static bst_test_instance_t *bst_test_find(bst_test_list_t *tests,
+static struct bst_test_instance *bst_test_find(struct bst_test_list *tests,
 					  char *test_id)
 {
-	bst_test_list_t *top = tests;
+	struct bst_test_list *top = tests;
 
 	while (top != NULL) {
 		if (!strcmp(top->test_instance->test_id, test_id)) {
@@ -97,7 +98,7 @@ void bst_install_tests(void)
  */
 void bst_print_testslist(void)
 {
-	bst_test_list_t *top;
+	struct bst_test_list *top;
 
 	/* Install tests */
 	bst_install_tests();
@@ -228,7 +229,7 @@ uint8_t bst_delete(void)
 	}
 
 	while (test_list_top) {
-		bst_test_list_t *tmp = test_list_top->next;
+		struct bst_test_list *tmp = test_list_top->next;
 
 		free(test_list_top);
 		test_list_top = tmp;


### PR DESCRIPTION
This is the fix for the style issue you (@jhedberg) mentioned in #10688.
I split it into its own PR so that it can be merged soon (as that other PR will probably take a while), as it affects testcases being built which use this hooks.

------------
This is only a codestyle fix with no functional implications.
A few structures typedefs are removed. The structures are not in
use yet outside of the board code.

Signed-off-by: Alberto Escolar Piedras <alpi@oticon.com>

