### PR TITLE
boards: reel_board: fix DTS compatible string

### DIFF
--- a/boards/arm/reel_board/reel_board.dts
+++ b/boards/arm/reel_board/reel_board.dts
@@ -10,7 +10,7 @@
 
 / {
 	model = "reel board";
-	compatible = "nordic,pca10056-dk", "nordic,nrf52840-qiaa",
+	compatible = "phytec,reel_board", "nordic,nrf52840-qiaa",
 		     "nordic,nrf52840";
 
 	chosen {


### PR DESCRIPTION
Fix the compatible string for the PHYTEC reel_board.

Signed-off-by: Henrik Brix Andersen <henrik@brixandersen.dk>