### PR TITLE
net: ipv6: Add Destination Options Header support

### DIFF
--- a/subsys/net/ip/ipv6.c
+++ b/subsys/net/ip/ipv6.c
@@ -540,6 +540,22 @@ enum net_verdict net_ipv6_process_pkt(struct net_pkt *pkt)
 			 */
 			goto drop;
 
+		case NET_IPV6_NEXTHDR_DESTO:
+			frag = net_frag_read_u8(frag, offset, &offset,
+						(u8_t *)&length);
+			if (!frag) {
+				goto drop;
+			}
+			length = length * 8 + 8;
+			total_len += length;
+
+			ext_bitmap |= NET_IPV6_NEXTHDR_DESTO;
+
+			frag = handle_ext_hdr_options(pkt, frag, real_len,
+						      length, offset, &offset,
+						      &verdict);
+			break;
+
 		case NET_IPV6_NEXTHDR_HBHO:
 			if (ext_bitmap & NET_IPV6_EXT_HDR_BITMAP_HBHO) {
 				NET_ERR("Dropping packet with multiple HBHO");

--- a/subsys/net/ip/ipv6_fragment.c
+++ b/subsys/net/ip/ipv6_fragment.c
@@ -99,6 +99,7 @@ int net_ipv6_find_last_ext_hdr(struct net_pkt *pkt, u16_t *next_hdr_idx,
 			break;
 
 		case NET_IPV6_NEXTHDR_HBHO:
+		case NET_IPV6_NEXTHDR_DESTO:
 			length = 0;
 			frag = net_frag_read_u8(frag, offset, &offset,
 						(u8_t *)&length);


### PR DESCRIPTION
This patch adds support for IPv6 Destination Options Header

Signed-off-by: Ruslan Mstoi <ruslan.mstoi@intel.com>