### PR TITLE
net: log: Max debug level was forced too high

### DIFF
--- a/subsys/net/ip/Kconfig.debug
+++ b/subsys/net/ip/Kconfig.debug
@@ -26,7 +26,7 @@ module-dep = NET_LOG
 module-def = LOG_LEVEL_DBG
 module-str = Max network stack logging level
 module-help = Max log level. This overrides individual networking log levels.
-source "subsys/net/Kconfig.template.log_config.net"
+source "subsys/net/Kconfig.template.log_config.default.net"
 
 module = NET_CORE
 module-dep = NET_LOG


### PR DESCRIPTION
Wrong Kconfig template was used for max debug level which caused
the max level to be the default level (ERROR). This prevented
all debug prints from showing.

Signed-off-by: Jukka Rissanen <jukka.rissanen@linux.intel.com>