### PR TITLE
boards: reel_board: add links to the PHYTEC reel board procuct page

### DIFF
--- a/boards/arm/reel_board/doc/reel_board.rst
+++ b/boards/arm/reel_board/doc/reel_board.rst
@@ -6,7 +6,7 @@ reel board
 Overview
 ********
 
-reel board is a evaluation board based on the Nordic Semiconductor
+`reel board`_ is a evaluation board based on the Nordic Semiconductor
 nRF52840 SoC. The board was developed by PHYTEC Messtechnik GmbH in
 cooperation with Zephyr Project for the Hackathon - "Get Connected".
 The board has a built-in debug adapter based on the DAPLink interface
@@ -428,6 +428,9 @@ References
 **********
 
 .. target-notes::
+
+.. _reel board:
+   https://www.phytec.de/reelboard/
 
 .. _DAPLink reel board Firmware:
    https://github.com/jfischer-phytec-iot/DAPLink/tree/reel-board


### PR DESCRIPTION
Add a link to the reel board product page at PHYTEC to help people in
locating schematics, etc.

Signed-off-by: Henrik Brix Andersen <henrik@brixandersen.dk>