### PR TITLE
Fixed install command for python requirements

### DIFF
--- a/doc/getting_started/getting_started.rst
+++ b/doc/getting_started/getting_started.rst
@@ -45,7 +45,7 @@ Next, install additional Python packages required by Zephyr in a shell or
 .. code-block:: console
 
    # Linux
-   pip3 install --user -r zephyr/scripts/requirements.txt
+   pip3 install -r --user zephyr/scripts/requirements.txt
 
    # macOS and Windows
    pip3 install -r zephyr/scripts/requirements.txt

--- a/doc/getting_started/installation_linux.rst
+++ b/doc/getting_started/installation_linux.rst
@@ -99,6 +99,12 @@ On Arch:
    sudo pacman -S git cmake ninja gperf ccache dfu-util dtc wget \
        python-pip python-setuptools python-wheel xz file make
 
+On Arch, you also need the following packages to flash a board from the AUR. The install differs, depending on the tool you use to access the AUR.
+
+.. code-block:: console
+   python-pykwalify
+   pyocd
+
 CMake version 3.8.2 or higher is required. Check what version you have using
 ``cmake --version``; if you have an older version, check the backports or
 install a more recent version manually. For example, to install version


### PR DESCRIPTION
The second patch added additional packaged which are needed on Arch Linux, but not available within the normal repo. As it is needed to install them with yaourt or an equivalent tool, I just named the packages.