### PR TITLE
samples: reel_board: mesh_badge: automatically disconnect

### DIFF
--- a/samples/boards/reel_board/mesh_badge/src/main.c
+++ b/samples/boards/reel_board/mesh_badge/src/main.c
@@ -72,6 +72,8 @@ static ssize_t write_name(struct bt_conn *conn, const struct bt_gatt_attr *attr,
 	mesh_set_name(name, first_name_len(name));
 	board_refresh_display();
 
+	bt_conn_disconnect(conn, BT_HCI_ERR_REMOTE_USER_TERM_CONN);
+
 	return len;
 }
 


### PR DESCRIPTION
Automatically disconnect the GATT client after setting the name. This
will automatically start the mesh, which is most likely what the user
wants to do.

Signed-off-by: Henrik Brix Andersen <henrik@brixandersen.dk>