### PR TITLE
drivers: entropy nRF5x: hide the driver on non-nRF boards

### DIFF
--- a/drivers/entropy/Kconfig.nrf5
+++ b/drivers/entropy/Kconfig.nrf5
@@ -8,6 +8,7 @@
 menuconfig ENTROPY_NRF5_RNG
 	bool "nRF5 RNG driver"
 	depends on ENTROPY_GENERATOR
+	depends on SOC_COMPATIBLE_NRF
 	select ENTROPY_HAS_DRIVER
 	help
 	  This option enables the RNG peripheral, which is a random number


### PR DESCRIPTION
The nRF5x entropy driver does not depends on SOC_FAMILY_NRF is therefore
visible and selectable non-nRF5x SoCs. Fix that.

Signed-off-by: Aurelien Jarno <aurelien@aurel32.net>