### PR TITLE
tests: sched: schedule_api: Increase the minimum ram needed.

### DIFF
--- a/tests/kernel/sched/schedule_api/testcase.yaml
+++ b/tests/kernel/sched/schedule_api/testcase.yaml
@@ -1,6 +1,6 @@
 tests:
   kernel.sched:
-    min_ram: 20
+    min_ram: 32
     tags: kernel threads sched
   kernel.sched.native_posix:
     extra_args: CONF_FILE=prj_native_posix.conf


### PR DESCRIPTION
This test was failing on nrf52810_pca10040 due to lack of RAM.
It was a side effect of increasing the privilege stack size.

Signed-off-by: Adithya Baglody <adithya.nagaraj.baglody@intel.com>