### PR TITLE
usb: device: fix wrong direction in usb_transfer_ep_callback

### DIFF
--- a/subsys/usb/usb_device.c
+++ b/subsys/usb/usb_device.c
@@ -1218,7 +1218,7 @@ void usb_transfer_ep_callback(u8_t ep, enum usb_dc_ep_cb_status_code status)
 	}
 
 	if (!trans) {
-		if (status == USB_DC_EP_DATA_IN) {
+		if (status == USB_DC_EP_DATA_OUT) {
 			u32_t bytes;
 			/* In the unlikely case we receive data while no
 			 * transfer is ongoing, we have to consume the data


### PR DESCRIPTION
In case no transfer is ongoing, the usb_transfer_ep_callback consumes
the received data. This is however associated with the wrong test. USB i
host centric, so data reception on the device is signaled by
USB_DC_EP_DATA_OUT and not USB_DC_EP_DATA_IN.

Signed-off-by: Aurelien Jarno <aurelien@aurel32.net>