### PR TITLE
net: wifi: shell: Fix connect command SSID parameter

### DIFF
--- a/subsys/net/l2/wifi/wifi_shell.c
+++ b/subsys/net/l2/wifi/wifi_shell.c
@@ -149,22 +149,15 @@ static int cmd_wifi_connect(const struct shell *shell, size_t argc,
 	struct net_if *iface = net_if_get_default();
 	static struct wifi_connect_req_params cnx_params;
 	char *endptr;
-	int idx = 3;
+	int idx = 2;
 
 	if (shell_help_requested(shell) || argc < 3) {
 		shell_help_print(shell, NULL, 0);
 		return -ENOEXEC;
 	}
 
-	cnx_params.ssid_length = strtol(argv[2], &endptr, 10);
-	if (*endptr != '\0' || cnx_params.ssid_length <= 2) {
-		shell_help_print(shell, NULL, 0);
-		return -ENOEXEC;
-	}
-
-	cnx_params.ssid = &argv[1][1];
-
-	argv[1][cnx_params.ssid_length + 1] = '\0';
+	cnx_params.ssid = argv[1];
+	cnx_params.ssid_length = strlen(argv[1]);
 
 	if ((idx < argc) && (strlen(argv[idx]) <= 2)) {
 		cnx_params.channel = strtol(argv[idx], &endptr, 10);
@@ -266,7 +259,7 @@ static int cmd_wifi_scan(const struct shell *shell, size_t argc, char *argv[])
 SHELL_CREATE_STATIC_SUBCMD_SET(wifi_commands)
 {
 	SHELL_CMD(connect, NULL,
-		  "\"<SSID>\"\n<SSID length>\n<channel number (optional), "
+		  "\"<SSID>\"\n<channel number (optional), "
 		  "0 means all>\n"
 		  "<PSK (optional: valid only for secured SSIDs)>",
 		  cmd_wifi_connect),


### PR DESCRIPTION
The new shell subsystem takes care of removing quote ('"') from
command arguments and produces a standard string.
So now the SSID string starts at &argv[1][0] (instead of &argv[1][1]).
Fix this.

In the same time, remove SSID length parameter which can be find with
strlen().

Signed-off-by: lpoulain <lpoulain@lpoulain-ThinkPad-T470p>