### PR TITLE
samples, tests: Use semi-accurate project names

### DIFF
--- a/doc/application/application.rst
+++ b/doc/application/application.rst
@@ -119,7 +119,7 @@ Follow these steps to create a new application directory. (Refer to
       # Boilerplate code, which pulls in the Zephyr build system.
       cmake_minimum_required(VERSION 3.8.2)
       include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
-      project(NONE)
+      project(my_zephyr_app)
 
       # Add your source file to the "app" target. This must come after
       # the boilerplate code, which defines the target.
@@ -733,7 +733,7 @@ Create a Debugger Configuration
 
    - In the Main tab:
 
-     - Project: NONE@build
+     - Project: my_zephyr_app@build
      - C/C++ Application: :file:`zephyr/zephyr.elf`
 
    - In the Debugger tab:
@@ -910,7 +910,7 @@ Make sure to follow these steps in order.
    .. code-block:: cmake
 
       include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
-      project(NONE)
+      project(my_zephyr_app)
 
 #. Now add any application source files to the 'app' target
    library, each on their own line, like so:
@@ -926,7 +926,7 @@ Below is a simple example :file:`CMakeList.txt`:
    set(BOARD qemu_x86)
 
    include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
-   project(NONE)
+   project(my_zephyr_app)
 
    target_sources(app PRIVATE src/main.c)
 

--- a/samples/application_development/external_lib/CMakeLists.txt
+++ b/samples/application_development/external_lib/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.8.2)
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
-project(NONE)
+project(external_lib)
 
 target_sources(app PRIVATE src/main.c)
 

--- a/samples/application_development/out_of_tree_board/CMakeLists.txt
+++ b/samples/application_development/out_of_tree_board/CMakeLists.txt
@@ -9,6 +9,6 @@ set(BOARD_ROOT ${CMAKE_CURRENT_LIST_DIR})
 set(BOARD nrf52840_pca10056)
 
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
-project(NONE)
+project(out_of_tree_board)
 
 target_sources(app PRIVATE src/main.c)

--- a/samples/basic/blink_led/CMakeLists.txt
+++ b/samples/basic/blink_led/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 3.8.2)
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
-project(NONE)
+project(blink_led)
 
 target_sources(app PRIVATE src/main.c)

--- a/samples/basic/blinky/CMakeLists.txt
+++ b/samples/basic/blinky/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 3.8.2)
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
-project(NONE)
+project(blinky)
 
 target_sources(app PRIVATE src/main.c)

--- a/samples/basic/button/CMakeLists.txt
+++ b/samples/basic/button/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 3.8.2)
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
-project(NONE)
+project(button)
 
 target_sources(app PRIVATE src/main.c)

--- a/samples/basic/disco/CMakeLists.txt
+++ b/samples/basic/disco/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 3.8.2)
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
-project(NONE)
+project(disco)
 
 target_sources(app PRIVATE src/main.c)

--- a/samples/basic/fade_led/CMakeLists.txt
+++ b/samples/basic/fade_led/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 3.8.2)
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
-project(NONE)
+project(fade_led)
 
 target_sources(app PRIVATE src/main.c)

--- a/samples/basic/rgb_led/CMakeLists.txt
+++ b/samples/basic/rgb_led/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 3.8.2)
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
-project(NONE)
+project(rgb_led)
 
 target_sources(app PRIVATE src/main.c)

--- a/samples/basic/servo_motor/CMakeLists.txt
+++ b/samples/basic/servo_motor/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 3.8.2)
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
-project(NONE)
+project(servo_motor)
 
 target_sources(app PRIVATE src/main.c)

--- a/samples/basic/threads/CMakeLists.txt
+++ b/samples/basic/threads/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 3.8.2)
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
-project(NONE)
+project(threads)
 
 target_sources(app PRIVATE src/main.c)

--- a/samples/basic/userspace/shared_mem/CMakeLists.txt
+++ b/samples/basic/userspace/shared_mem/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.8.2)
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
-project(NONE)
+project(shared_mem)
 
 FILE(GLOB app_sources src/*.c)
 target_sources(app PRIVATE ${app_sources})

--- a/samples/bluetooth/beacon/CMakeLists.txt
+++ b/samples/bluetooth/beacon/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 3.8.2)
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
-project(NONE)
+project(beacon)
 
 target_sources(app PRIVATE src/main.c)

--- a/samples/bluetooth/central/CMakeLists.txt
+++ b/samples/bluetooth/central/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.8.2)
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
-project(NONE)
+project(central)
 
 target_sources(app PRIVATE
   src/main.c

--- a/samples/bluetooth/central_hr/CMakeLists.txt
+++ b/samples/bluetooth/central_hr/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.8.2)
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
-project(NONE)
+project(central_hr)
 
 FILE(GLOB app_sources src/*.c)
 target_sources(app PRIVATE ${app_sources})

--- a/samples/bluetooth/eddystone/CMakeLists.txt
+++ b/samples/bluetooth/eddystone/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.8.2)
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
-project(NONE)
+project(eddystone)
 
 target_sources(app PRIVATE
   src/main.c

--- a/samples/bluetooth/handsfree/CMakeLists.txt
+++ b/samples/bluetooth/handsfree/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.8.2)
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
-project(NONE)
+project(handsfree)
 
 FILE(GLOB app_sources src/*.c)
 target_sources(app PRIVATE ${app_sources})

--- a/samples/bluetooth/hci_spi/CMakeLists.txt
+++ b/samples/bluetooth/hci_spi/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.8.2)
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
-project(NONE)
+project(hci_spi)
 
 FILE(GLOB app_sources src/*.c)
 target_sources(app PRIVATE ${app_sources})

--- a/samples/bluetooth/hci_uart/CMakeLists.txt
+++ b/samples/bluetooth/hci_uart/CMakeLists.txt
@@ -6,6 +6,6 @@ else()
 endif()
 
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
-project(NONE)
+project(hci_uart)
 
 target_sources(app PRIVATE src/main.c)

--- a/samples/bluetooth/hci_usb/CMakeLists.txt
+++ b/samples/bluetooth/hci_usb/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 3.8.2)
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
-project(NONE)
+project(hci_usb)
 
 target_sources(app PRIVATE src/main.c)

--- a/samples/bluetooth/ibeacon/CMakeLists.txt
+++ b/samples/bluetooth/ibeacon/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.8.2)
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
-project(NONE)
+project(ibeacon)
 
 target_sources(app PRIVATE src/main.c)
 

--- a/samples/bluetooth/ipsp/CMakeLists.txt
+++ b/samples/bluetooth/ipsp/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.8.2)
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
-project(NONE)
+project(ipsp)
 
 target_sources(app PRIVATE
   src/main.c

--- a/samples/bluetooth/mesh/CMakeLists.txt
+++ b/samples/bluetooth/mesh/CMakeLists.txt
@@ -2,7 +2,7 @@ cmake_minimum_required(VERSION 3.8.2)
 set(QEMU_EXTRA_FLAGS -s)
 
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
-project(NONE)
+project(mesh)
 
 target_sources(app PRIVATE src/main.c)
 target_sources_ifdef(CONFIG_BOARD_BBC_MICROBIT app PRIVATE src/microbit.c)

--- a/samples/bluetooth/mesh_demo/CMakeLists.txt
+++ b/samples/bluetooth/mesh_demo/CMakeLists.txt
@@ -2,7 +2,7 @@ cmake_minimum_required(VERSION 3.8.2)
 set(QEMU_EXTRA_FLAGS -s)
 
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
-project(NONE)
+project(mesh_demo)
 
 target_sources(app PRIVATE src/main.c)
 target_sources_ifdef(CONFIG_BOARD_BBC_MICROBIT app PRIVATE src/microbit.c)

--- a/samples/bluetooth/peripheral/CMakeLists.txt
+++ b/samples/bluetooth/peripheral/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.8.2)
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
-project(NONE)
+project(peripheral)
 
 target_sources(app PRIVATE
   src/main.c

--- a/samples/bluetooth/peripheral_csc/CMakeLists.txt
+++ b/samples/bluetooth/peripheral_csc/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.8.2)
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
-project(NONE)
+project(peripheral_csc)
 
 FILE(GLOB app_sources src/*.c)
 target_sources(app PRIVATE

--- a/samples/bluetooth/peripheral_dis/CMakeLists.txt
+++ b/samples/bluetooth/peripheral_dis/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.8.2)
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
-project(NONE)
+project(peripheral_dis)
 
 FILE(GLOB app_sources src/*.c)
 target_sources(app PRIVATE

--- a/samples/bluetooth/peripheral_esp/CMakeLists.txt
+++ b/samples/bluetooth/peripheral_esp/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.8.2)
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
-project(NONE)
+project(peripheral_esp)
 
 target_sources(app PRIVATE
   src/main.c

--- a/samples/bluetooth/peripheral_hids/CMakeLists.txt
+++ b/samples/bluetooth/peripheral_hids/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.8.2)
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
-project(NONE)
+project(peripheral_hids)
 
 FILE(GLOB app_sources src/*.c)
 target_sources(app PRIVATE

--- a/samples/bluetooth/peripheral_hr/CMakeLists.txt
+++ b/samples/bluetooth/peripheral_hr/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.8.2)
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
-project(NONE)
+project(peripheral_hr)
 
 FILE(GLOB app_sources src/*.c)
 target_sources(app PRIVATE

--- a/samples/bluetooth/peripheral_sc_only/CMakeLists.txt
+++ b/samples/bluetooth/peripheral_sc_only/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.8.2)
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
-project(NONE)
+project(peripheral_sc_only)
 
 target_sources(app PRIVATE
   src/main.c

--- a/samples/bluetooth/scan_adv/CMakeLists.txt
+++ b/samples/bluetooth/scan_adv/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.8.2)
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
-project(NONE)
+project(scan_adv)
 
 FILE(GLOB app_sources src/*.c)
 target_sources(app PRIVATE ${app_sources})

--- a/samples/boards/96b_argonkey/CMakeLists.txt
+++ b/samples/boards/96b_argonkey/CMakeLists.txt
@@ -5,6 +5,6 @@ cmake_minimum_required(VERSION 3.8.2)
 #
 
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
-project(NONE)
+project(96b_argonkey)
 
 target_sources(app PRIVATE src/main.c)

--- a/samples/boards/altera_max10/pio/CMakeLists.txt
+++ b/samples/boards/altera_max10/pio/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 3.8.2)
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
-project(NONE)
+project(pio)
 
 target_sources(app PRIVATE src/main.c)

--- a/samples/boards/arduino_101/environmental_sensing/ap/CMakeLists.txt
+++ b/samples/boards/arduino_101/environmental_sensing/ap/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.8.2)
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
-project(NONE)
+project(environmental_sensing_ap)
 
 target_include_directories(app PRIVATE $ENV{ZEPHYR_BASE}/drivers)
 target_sources(app PRIVATE src/main.c)

--- a/samples/boards/arduino_101/environmental_sensing/sensor/CMakeLists.txt
+++ b/samples/boards/arduino_101/environmental_sensing/sensor/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.8.2)
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
-project(NONE)
+project(environmental_sensing_sensor)
 
 target_include_directories(app PRIVATE $ENV{ZEPHYR_BASE}/drivers)
 target_sources(app PRIVATE src/main.c)

--- a/samples/boards/microbit/display/CMakeLists.txt
+++ b/samples/boards/microbit/display/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.8.2)
 
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
-project(NONE)
+project(display)
 
 FILE(GLOB app_sources src/*.c)
 target_sources(app PRIVATE ${app_sources})

--- a/samples/boards/microbit/pong/CMakeLists.txt
+++ b/samples/boards/microbit/pong/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.8.2)
 
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
-project(NONE)
+project(pong)
 
 FILE(GLOB app_sources src/*.c)
 target_sources(app PRIVATE ${app_sources})

--- a/samples/boards/microbit/sound/CMakeLists.txt
+++ b/samples/boards/microbit/sound/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.8.2)
 
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
-project(NONE)
+project(sound)
 
 FILE(GLOB app_sources src/*.c)
 target_sources(app PRIVATE ${app_sources})

--- a/samples/boards/nrf52/mesh/onoff-app/CMakeLists.txt
+++ b/samples/boards/nrf52/mesh/onoff-app/CMakeLists.txt
@@ -2,6 +2,6 @@ cmake_minimum_required(VERSION 3.8.2)
 set(QEMU_EXTRA_FLAGS -s)
 
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
-project(NONE)
+project(onoff-app)
 
 target_sources(app PRIVATE src/main.c)

--- a/samples/boards/nrf52/mesh/onoff_level_lighting_vnd_app/CMakeLists.txt
+++ b/samples/boards/nrf52/mesh/onoff_level_lighting_vnd_app/CMakeLists.txt
@@ -2,7 +2,7 @@ cmake_minimum_required(VERSION 3.8.2)
 set(QEMU_EXTRA_FLAGS -s)
 
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
-project(NONE)
+project(onoff_level_lighting_vnd_app)
 
 target_link_libraries(app PUBLIC subsys__bluetooth)
 

--- a/samples/boards/nrf52/power_mgr/CMakeLists.txt
+++ b/samples/boards/nrf52/power_mgr/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.8.2)
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
-project(NONE)
+project(nrf52_power_mgr)
 
 FILE(GLOB app_sources src/*.c)
 target_sources(app PRIVATE ${app_sources})

--- a/samples/boards/olimex_stm32_e407/ccm/CMakeLists.txt
+++ b/samples/boards/olimex_stm32_e407/ccm/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 3.8.2)
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
-project(NONE)
+project(ccm)
 
 target_sources(app PRIVATE src/main.c)

--- a/samples/boards/quark_se_c1000/power_mgr/CMakeLists.txt
+++ b/samples/boards/quark_se_c1000/power_mgr/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 3.8.2)
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
-project(NONE)
+project(quark_se_c1000_power_mgr)
 
 target_sources(app PRIVATE src/main.c)

--- a/samples/boards/reel_board/mesh_badge/CMakeLists.txt
+++ b/samples/boards/reel_board/mesh_badge/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 3.8.2)
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
-project(NONE)
+project(mesh_badge)
 
 target_sources(app PRIVATE src/main.c src/mesh.c src/${BOARD}.c)

--- a/samples/boards/up_squared/gpio_counter/CMakeLists.txt
+++ b/samples/boards/up_squared/gpio_counter/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.8.2)
 
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
-project(NONE)
+project(gpio_counter)
 
 target_sources(app PRIVATE src/main.c)

--- a/samples/cpp_synchronization/CMakeLists.txt
+++ b/samples/cpp_synchronization/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 3.8.2)
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
-project(NONE)
+project(cpp_synchronization)
 
 target_sources(app PRIVATE src/main.cpp)

--- a/samples/display/cfb/CMakeLists.txt
+++ b/samples/display/cfb/CMakeLists.txt
@@ -11,7 +11,7 @@ macro(set_conf_file)
 endmacro()
 
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
-project(NONE)
+project(cfb)
 
 FILE(GLOB app_sources src/*.c)
 target_sources(app PRIVATE ${app_sources})

--- a/samples/display/grove_display/CMakeLists.txt
+++ b/samples/display/grove_display/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.8.2)
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
-project(NONE)
+project(grove_display)
 
 FILE(GLOB app_sources src/*.c)
 target_sources(app PRIVATE ${app_sources})

--- a/samples/display/ili9340/CMakeLists.txt
+++ b/samples/display/ili9340/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.8.2)
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
-project(NONE)
+project(ili9340)
 
 FILE(GLOB app_sources src/*.c)
 target_sources(app PRIVATE ${app_sources})

--- a/samples/drivers/CAN/CMakeLists.txt
+++ b/samples/drivers/CAN/CMakeLists.txt
@@ -2,6 +2,6 @@ cmake_minimum_required(VERSION 3.8.2)
 
 
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
-project(NONE)
+project(CAN)
 
 target_sources(app PRIVATE src/main.c)

--- a/samples/drivers/crypto/CMakeLists.txt
+++ b/samples/drivers/crypto/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.8.2)
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
-project(NONE)
+project(crypto)
 
 FILE(GLOB app_sources src/*.c)
 target_sources(app PRIVATE ${app_sources})

--- a/samples/drivers/current_sensing/CMakeLists.txt
+++ b/samples/drivers/current_sensing/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.8.2)
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
-project(NONE)
+project(current_sensing)
 
 FILE(GLOB app_sources src/*.c)
 target_sources(app PRIVATE ${app_sources})

--- a/samples/drivers/entropy/CMakeLists.txt
+++ b/samples/drivers/entropy/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.8.2)
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
-project(NONE)
+project(entropy)
 
 FILE(GLOB app_sources src/*.c)
 target_sources(app PRIVATE ${app_sources})

--- a/samples/drivers/flash_shell/CMakeLists.txt
+++ b/samples/drivers/flash_shell/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.8.2)
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
-project(NONE)
+project(flash_shell)
 
 FILE(GLOB app_sources src/*.c)
 target_sources(app PRIVATE ${app_sources})

--- a/samples/drivers/gpio/CMakeLists.txt
+++ b/samples/drivers/gpio/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.8.2)
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
-project(NONE)
+project(gpio)
 
 FILE(GLOB app_sources src/*.c)
 target_sources(app PRIVATE ${app_sources})

--- a/samples/drivers/i2c_fujitsu_fram/CMakeLists.txt
+++ b/samples/drivers/i2c_fujitsu_fram/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.8.2)
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
-project(NONE)
+project(i2c_fujitsu_fram)
 
 FILE(GLOB app_sources src/*.c)
 target_sources(app PRIVATE ${app_sources})

--- a/samples/drivers/lcd_hd44780/CMakeLists.txt
+++ b/samples/drivers/lcd_hd44780/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.8.2)
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
-project(NONE)
+project(lcd_hd44780)
 
 FILE(GLOB app_sources src/*.c)
 target_sources(app PRIVATE ${app_sources})

--- a/samples/drivers/led_apa102c/CMakeLists.txt
+++ b/samples/drivers/led_apa102c/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.8.2)
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
-project(NONE)
+project(led_apa102c)
 
 FILE(GLOB app_sources src/*.c)
 target_sources(app PRIVATE ${app_sources})

--- a/samples/drivers/led_lp3943/CMakeLists.txt
+++ b/samples/drivers/led_lp3943/CMakeLists.txt
@@ -8,7 +8,7 @@ macro(set_conf_file)
 endmacro()
 
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
-project(NONE)
+project(led_lp3943)
 
 FILE(GLOB app_sources src/*.c)
 target_sources(app PRIVATE ${app_sources})

--- a/samples/drivers/led_lp5562/CMakeLists.txt
+++ b/samples/drivers/led_lp5562/CMakeLists.txt
@@ -8,7 +8,7 @@ macro(set_conf_file)
 endmacro()
 
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
-project(NONE)
+project(led_lp5562)
 
 FILE(GLOB app_sources src/*.c)
 target_sources(app PRIVATE ${app_sources})

--- a/samples/drivers/led_lpd8806/CMakeLists.txt
+++ b/samples/drivers/led_lpd8806/CMakeLists.txt
@@ -8,7 +8,7 @@ macro(set_conf_file)
 endmacro()
 
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
-project(NONE)
+project(led_lpd8806)
 
 FILE(GLOB app_sources src/*.c)
 target_sources(app PRIVATE ${app_sources})

--- a/samples/drivers/led_pca9633/CMakeLists.txt
+++ b/samples/drivers/led_pca9633/CMakeLists.txt
@@ -8,7 +8,7 @@ macro(set_conf_file)
 endmacro()
 
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
-project(NONE)
+project(led_pca9633)
 
 FILE(GLOB app_sources src/*.c)
 target_sources(app PRIVATE ${app_sources})

--- a/samples/drivers/led_ws2812/CMakeLists.txt
+++ b/samples/drivers/led_ws2812/CMakeLists.txt
@@ -8,7 +8,7 @@ macro(set_conf_file)
 endmacro()
 
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
-project(NONE)
+project(led_ws2812)
 
 FILE(GLOB app_sources src/*.c)
 target_sources(app PRIVATE ${app_sources})

--- a/samples/drivers/random/CMakeLists.txt
+++ b/samples/drivers/random/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.8.2)
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
-project(NONE)
+project(random)
 
 FILE(GLOB app_sources src/*.c)
 target_sources(app PRIVATE ${app_sources})

--- a/samples/drivers/rtc/CMakeLists.txt
+++ b/samples/drivers/rtc/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.8.2)
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
-project(NONE)
+project(rtc)
 
 FILE(GLOB app_sources src/*.c)
 target_sources(app PRIVATE ${app_sources})

--- a/samples/drivers/soc_flash_nrf/CMakeLists.txt
+++ b/samples/drivers/soc_flash_nrf/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.8.2)
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
-project(NONE)
+project(soc_flash_nrf)
 
 FILE(GLOB app_sources src/*.c)
 target_sources(app PRIVATE ${app_sources})

--- a/samples/drivers/spi_flash/CMakeLists.txt
+++ b/samples/drivers/spi_flash/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.8.2)
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
-project(NONE)
+project(spi_flash)
 
 FILE(GLOB app_sources src/*.c)
 target_sources(app PRIVATE ${app_sources})

--- a/samples/drivers/spi_fujitsu_fram/CMakeLists.txt
+++ b/samples/drivers/spi_fujitsu_fram/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.8.2)
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
-project(NONE)
+project(spi_fujitsu_fram)
 
 FILE(GLOB app_sources src/*.c)
 target_sources(app PRIVATE ${app_sources})

--- a/samples/drivers/watchdog/CMakeLists.txt
+++ b/samples/drivers/watchdog/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.8.2)
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
-project(NONE)
+project(watchdog)
 
 if(CONFIG_IWDG_STM32)
 target_sources(app PRIVATE src/iwdg_main.c)

--- a/samples/hello_world/CMakeLists.txt
+++ b/samples/hello_world/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.8.2)
 
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
-project(NONE)
+project(hello_world)
 
 target_sources(app PRIVATE src/main.c)

--- a/samples/mpu/mem_domain_apis_test/CMakeLists.txt
+++ b/samples/mpu/mem_domain_apis_test/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.8.2)
 
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
-project(NONE)
+project(mem_domain_apis_test)
 
 FILE(GLOB app_sources src/*.c)
 target_sources(app PRIVATE ${app_sources})

--- a/samples/mpu/mpu_stack_guard_test/CMakeLists.txt
+++ b/samples/mpu/mpu_stack_guard_test/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.8.2)
 
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
-project(NONE)
+project(mpu_stack_guard_test)
 
 FILE(GLOB app_sources src/*.c)
 target_sources(app PRIVATE ${app_sources})

--- a/samples/mpu/mpu_test/CMakeLists.txt
+++ b/samples/mpu/mpu_test/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.8.2)
 
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
-project(NONE)
+project(mpu_test)
 
 FILE(GLOB app_sources src/*.c)
 target_sources(app PRIVATE ${app_sources})

--- a/samples/net/coap_client/CMakeLists.txt
+++ b/samples/net/coap_client/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.8.2)
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
-project(NONE)
+project(coap_client)
 
 FILE(GLOB app_sources src/*.c)
 target_sources(app PRIVATE ${app_sources})

--- a/samples/net/coap_server/CMakeLists.txt
+++ b/samples/net/coap_server/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.8.2)
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
-project(NONE)
+project(coap_server)
 
 FILE(GLOB app_sources src/*.c)
 target_sources(app PRIVATE ${app_sources})

--- a/samples/net/dhcpv4_client/CMakeLists.txt
+++ b/samples/net/dhcpv4_client/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.8.2)
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
-project(NONE)
+project(dhcpv4_client)
 
 FILE(GLOB app_sources src/*.c)
 target_sources(app PRIVATE ${app_sources})

--- a/samples/net/dns_resolve/CMakeLists.txt
+++ b/samples/net/dns_resolve/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.8.2)
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
-project(NONE)
+project(dns_resolve)
 
 FILE(GLOB app_sources src/*.c)
 target_sources(app PRIVATE ${app_sources})

--- a/samples/net/echo_client/CMakeLists.txt
+++ b/samples/net/echo_client/CMakeLists.txt
@@ -12,7 +12,7 @@ macro(set_conf_file)
 endmacro()
 
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
-project(NONE)
+project(echo_client)
 
 target_sources(                     app PRIVATE src/echo-client.c)
 target_sources_ifdef(CONFIG_NET_UDP app PRIVATE src/udp.c)

--- a/samples/net/echo_server/CMakeLists.txt
+++ b/samples/net/echo_server/CMakeLists.txt
@@ -12,7 +12,7 @@ macro(set_conf_file)
 endmacro()
 
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
-project(NONE)
+project(echo_server)
 
 target_sources(                     app PRIVATE src/echo-server.c)
 target_sources_ifdef(CONFIG_NET_UDP app PRIVATE src/udp.c)

--- a/samples/net/eth_native_posix/CMakeLists.txt
+++ b/samples/net/eth_native_posix/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.8.2)
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
-project(NONE)
+project(eth_native_posix)
 
 target_sources(app PRIVATE src/main.c)
 

--- a/samples/net/gptp/CMakeLists.txt
+++ b/samples/net/gptp/CMakeLists.txt
@@ -12,6 +12,6 @@ macro(set_conf_file)
 endmacro()
 
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
-project(NONE)
+project(gptp)
 
 target_sources(app PRIVATE src/main.c)

--- a/samples/net/http_client/CMakeLists.txt
+++ b/samples/net/http_client/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.8.2)
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
-project(NONE)
+project(http_client)
 
 FILE(GLOB app_sources src/*.c)
 target_sources(app PRIVATE ${app_sources})

--- a/samples/net/http_server/CMakeLists.txt
+++ b/samples/net/http_server/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.8.2)
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
-project(NONE)
+project(http_server)
 
 FILE(GLOB app_sources src/*.c)
 target_sources(app PRIVATE ${app_sources})

--- a/samples/net/ipv4_autoconf/CMakeLists.txt
+++ b/samples/net/ipv4_autoconf/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.8.2)
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
-project(NONE)
+project(ipv4_autoconf)
 
 FILE(GLOB app_sources src/*.c)
 target_sources(app PRIVATE ${app_sources})

--- a/samples/net/irc_bot/CMakeLists.txt
+++ b/samples/net/irc_bot/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.8.2)
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
-project(NONE)
+project(irc_bot)
 
 FILE(GLOB app_sources src/*.c)
 target_sources(app PRIVATE ${app_sources})

--- a/samples/net/leds_demo/CMakeLists.txt
+++ b/samples/net/leds_demo/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.8.2)
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
-project(NONE)
+project(leds_demo)
 
 target_include_directories(app PRIVATE $ENV{ZEPHYR_BASE}/subsys/net/ip)
 target_sources(app PRIVATE src/leds-demo.c)

--- a/samples/net/lldp/CMakeLists.txt
+++ b/samples/net/lldp/CMakeLists.txt
@@ -12,6 +12,6 @@ macro(set_conf_file)
 endmacro()
 
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
-project(NONE)
+project(lldp)
 
 target_sources(app PRIVATE src/main.c)

--- a/samples/net/lwm2m_client/CMakeLists.txt
+++ b/samples/net/lwm2m_client/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.8.2)
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
-project(NONE)
+project(lwm2m_client)
 
 FILE(GLOB app_sources src/*.c)
 target_sources(app PRIVATE ${app_sources})

--- a/samples/net/mdns_responder/CMakeLists.txt
+++ b/samples/net/mdns_responder/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.8.2)
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
-project(NONE)
+project(mdns_responder)
 
 FILE(GLOB app_sources src/*.c)
 target_sources(app PRIVATE ${app_sources})

--- a/samples/net/mqtt_publisher/CMakeLists.txt
+++ b/samples/net/mqtt_publisher/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.8.2)
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
-project(NONE)
+project(mqtt_publisher)
 
 FILE(GLOB app_sources src/*.c)
 target_sources(app PRIVATE ${app_sources})

--- a/samples/net/nats/CMakeLists.txt
+++ b/samples/net/nats/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.8.2)
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
-project(NONE)
+project(nats)
 
 FILE(GLOB app_sources src/*.c)
 target_sources(app PRIVATE ${app_sources})

--- a/samples/net/promiscuous_mode/CMakeLists.txt
+++ b/samples/net/promiscuous_mode/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 3.8.2)
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
-project(NONE)
+project(promiscuous_mode)
 
 target_sources(app PRIVATE src/main.c)

--- a/samples/net/rpl-mesh-qemu/node/CMakeLists.txt
+++ b/samples/net/rpl-mesh-qemu/node/CMakeLists.txt
@@ -5,6 +5,6 @@ set(CONF_FILE prj_qemu.conf)
 set(QEMU_PIPE_STACK 1)
 
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
-project(NONE)
+project(rpl_mesh_qemu_node)
 
 target_sources(app PRIVATE src/main.c)

--- a/samples/net/rpl-mesh-qemu/root/CMakeLists.txt
+++ b/samples/net/rpl-mesh-qemu/root/CMakeLists.txt
@@ -5,7 +5,7 @@ set(CONF_FILE prj_qemu.conf)
 set(QEMU_PIPE_STACK 1)
 
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
-project(NONE)
+project(rpl_mesh_qemu_root)
 
 target_include_directories(app PRIVATE $ENV{ZEPHYR_BASE}/subsys/net/ip)
 

--- a/samples/net/rpl_border_router/CMakeLists.txt
+++ b/samples/net/rpl_border_router/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.8.2)
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
-project(NONE)
+project(rpl_border_router)
 
 FILE(GLOB app_sources src/*.c)
 target_sources(app PRIVATE ${app_sources})

--- a/samples/net/rpl_node/CMakeLists.txt
+++ b/samples/net/rpl_node/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.8.2)
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
-project(NONE)
+project(rpl_node)
 
 target_sources(app PRIVATE src/main.c)
 

--- a/samples/net/sntp_client/CMakeLists.txt
+++ b/samples/net/sntp_client/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.8.2)
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
-project(NONE)
+project(sntp_client)
 
 FILE(GLOB app_sources src/*.c)
 target_sources(app PRIVATE ${app_sources})

--- a/samples/net/sockets/big_http_download/CMakeLists.txt
+++ b/samples/net/sockets/big_http_download/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.8.2)
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
-project(NONE)
+project(big_http_download)
 
 FILE(GLOB app_sources src/*.c)
 target_sources(app PRIVATE ${app_sources})

--- a/samples/net/sockets/dumb_http_server/CMakeLists.txt
+++ b/samples/net/sockets/dumb_http_server/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.8.2)
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
-project(NONE)
+project(dumb_http_server)
 
 FILE(GLOB app_sources src/*.c)
 target_sources(app PRIVATE ${app_sources})

--- a/samples/net/sockets/echo/CMakeLists.txt
+++ b/samples/net/sockets/echo/CMakeLists.txt
@@ -11,7 +11,7 @@ macro(set_conf_file)
 endmacro()
 
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
-project(NONE)
+project(sockets_echo)
 
 FILE(GLOB app_sources src/*.c)
 target_sources(app PRIVATE ${app_sources})

--- a/samples/net/sockets/echo_async/CMakeLists.txt
+++ b/samples/net/sockets/echo_async/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.8.2)
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
-project(NONE)
+project(sockets_echo_async)
 
 FILE(GLOB app_sources src/*.c)
 target_sources(app PRIVATE ${app_sources})

--- a/samples/net/sockets/echo_client/CMakeLists.txt
+++ b/samples/net/sockets/echo_client/CMakeLists.txt
@@ -9,7 +9,7 @@ macro(set_conf_file)
 endmacro()
 
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
-project(NONE)
+project(sockets_echo_client)
 
 target_sources(                     app PRIVATE src/echo-client.c)
 target_sources_ifdef(CONFIG_NET_UDP app PRIVATE src/udp.c)

--- a/samples/net/sockets/echo_server/CMakeLists.txt
+++ b/samples/net/sockets/echo_server/CMakeLists.txt
@@ -9,7 +9,7 @@ macro(set_conf_file)
 endmacro()
 
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
-project(NONE)
+project(sockets_echo_server)
 
 target_sources(                     app PRIVATE src/echo-server.c)
 target_sources_ifdef(CONFIG_NET_UDP app PRIVATE src/udp.c)

--- a/samples/net/sockets/http_get/CMakeLists.txt
+++ b/samples/net/sockets/http_get/CMakeLists.txt
@@ -11,7 +11,7 @@ macro(set_conf_file)
 endmacro()
 
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
-project(NONE)
+project(http_get)
 
 FILE(GLOB app_sources src/*.c)
 target_sources(app PRIVATE ${app_sources})

--- a/samples/net/stats/CMakeLists.txt
+++ b/samples/net/stats/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.8.2)
 
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
-project(NONE)
+project(stats)
 
 target_sources(app PRIVATE src/main.c)
 

--- a/samples/net/telnet/CMakeLists.txt
+++ b/samples/net/telnet/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.8.2)
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
-project(NONE)
+project(telnet)
 
 FILE(GLOB app_sources src/*.c)
 target_sources(app PRIVATE ${app_sources})

--- a/samples/net/throughput_server/CMakeLists.txt
+++ b/samples/net/throughput_server/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.8.2)
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
-project(NONE)
+project(throughput_server)
 
 target_sources(                     app PRIVATE src/server.c)
 target_sources_ifdef(CONFIG_NET_UDP app PRIVATE src/udp.c)

--- a/samples/net/traffic_class/CMakeLists.txt
+++ b/samples/net/traffic_class/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.8.2)
 
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
-project(NONE)
+project(traffic_class)
 
 target_sources(app PRIVATE src/main.c)
 

--- a/samples/net/vlan/CMakeLists.txt
+++ b/samples/net/vlan/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.8.2)
 
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
-project(NONE)
+project(vlan)
 
 target_sources(app PRIVATE src/main.c)
 

--- a/samples/net/wifi/CMakeLists.txt
+++ b/samples/net/wifi/CMakeLists.txt
@@ -11,7 +11,7 @@ macro(set_conf_file)
 endmacro()
 
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
-project(NONE)
+project(wifi)
 
 FILE(GLOB app_sources src/*.c)
 target_sources(app PRIVATE ${app_sources})

--- a/samples/net/wpan_serial/CMakeLists.txt
+++ b/samples/net/wpan_serial/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.8.2)
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
-project(NONE)
+project(wpan_serial)
 
 target_include_directories(app PRIVATE $ENV{ZEPHYR_BASE}/subsys/net/ip)
 

--- a/samples/net/wpanusb/CMakeLists.txt
+++ b/samples/net/wpanusb/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.8.2)
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
-project(NONE)
+project(wpanusb)
 
 target_include_directories(app PRIVATE $ENV{ZEPHYR_BASE}/subsys/net/ip)
 

--- a/samples/net/ws_console/CMakeLists.txt
+++ b/samples/net/ws_console/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.8.2)
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
-project(NONE)
+project(ws_console)
 
 FILE(GLOB app_sources src/*.c)
 target_sources(app PRIVATE ${app_sources})

--- a/samples/net/ws_echo_server/CMakeLists.txt
+++ b/samples/net/ws_echo_server/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.8.2)
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
-project(NONE)
+project(ws_echo_server)
 
 FILE(GLOB app_sources src/*.c)
 target_sources(app PRIVATE ${app_sources})

--- a/samples/net/zperf/CMakeLists.txt
+++ b/samples/net/zperf/CMakeLists.txt
@@ -12,7 +12,7 @@ macro(set_conf_file)
 endmacro()
 
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
-project(NONE)
+project(zperf)
 
 target_sources(app PRIVATE
   src/shell_utils.c

--- a/samples/nfc/nfc_hello/CMakeLists.txt
+++ b/samples/nfc/nfc_hello/CMakeLists.txt
@@ -2,7 +2,7 @@ cmake_minimum_required(VERSION 3.8.2)
 list(APPEND QEMU_EXTRA_FLAGS -serial tcp:localhost:8888)
 
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
-project(NONE)
+project(nfc_hello)
 
 FILE(GLOB app_sources src/*.c)
 target_sources(app PRIVATE ${app_sources})

--- a/samples/philosophers/CMakeLists.txt
+++ b/samples/philosophers/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 3.8.2)
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
-project(NONE)
+project(philosophers)
 
 target_sources(app PRIVATE src/main.c)

--- a/samples/sensor/adt7420/CMakeLists.txt
+++ b/samples/sensor/adt7420/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.8.2)
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
-project(NONE)
+project(adt7420)
 
 FILE(GLOB app_sources src/*.c)
 target_sources(app PRIVATE ${app_sources})

--- a/samples/sensor/adxl372/CMakeLists.txt
+++ b/samples/sensor/adxl372/CMakeLists.txt
@@ -5,7 +5,7 @@
 #
 cmake_minimum_required(VERSION 3.8.2)
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
-project(NONE)
+project(adxl372)
 
 FILE(GLOB app_sources src/*.c)
 target_sources(app PRIVATE ${app_sources})

--- a/samples/sensor/amg88xx/CMakeLists.txt
+++ b/samples/sensor/amg88xx/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.8.2)
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
-project(NONE)
+project(amg88xx)
 
 FILE(GLOB app_sources src/*.c)
 target_sources(app PRIVATE ${app_sources})

--- a/samples/sensor/apds9960/CMakeLists.txt
+++ b/samples/sensor/apds9960/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.8.2)
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
-project(NONE)
+project(apds9960)
 
 FILE(GLOB app_sources src/*.c)
 target_sources(app PRIVATE ${app_sources})

--- a/samples/sensor/bme280/CMakeLists.txt
+++ b/samples/sensor/bme280/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.8.2)
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
-project(NONE)
+project(bme280)
 
 FILE(GLOB app_sources src/*.c)
 target_sources(app PRIVATE ${app_sources})

--- a/samples/sensor/bmg160/CMakeLists.txt
+++ b/samples/sensor/bmg160/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.8.2)
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
-project(NONE)
+project(bmg160)
 
 FILE(GLOB app_sources src/*.c)
 target_sources(app PRIVATE ${app_sources})

--- a/samples/sensor/bmi160/CMakeLists.txt
+++ b/samples/sensor/bmi160/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.8.2)
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
-project(NONE)
+project(bmi160)
 
 FILE(GLOB app_sources src/*.c)
 target_sources(app PRIVATE ${app_sources})

--- a/samples/sensor/bmm150/CMakeLists.txt
+++ b/samples/sensor/bmm150/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.8.2)
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
-project(NONE)
+project(bmm150)
 
 FILE(GLOB app_sources src/*.c)
 target_sources(app PRIVATE ${app_sources})

--- a/samples/sensor/ccs811/CMakeLists.txt
+++ b/samples/sensor/ccs811/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.8.2)
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
-project(NONE)
+project(ccs811)
 
 FILE(GLOB app_sources src/*.c)
 target_sources(app PRIVATE ${app_sources})

--- a/samples/sensor/fxas21002/CMakeLists.txt
+++ b/samples/sensor/fxas21002/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.8.2)
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
-project(NONE)
+project(fxas21002)
 
 FILE(GLOB app_sources src/*.c)
 target_sources(app PRIVATE ${app_sources})

--- a/samples/sensor/fxos8700/CMakeLists.txt
+++ b/samples/sensor/fxos8700/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.8.2)
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
-project(NONE)
+project(fxos8700)
 
 FILE(GLOB app_sources src/*.c)
 target_sources(app PRIVATE ${app_sources})

--- a/samples/sensor/grove_light/CMakeLists.txt
+++ b/samples/sensor/grove_light/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.8.2)
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
-project(NONE)
+project(grove_light)
 
 FILE(GLOB app_sources src/*.c)
 target_sources(app PRIVATE ${app_sources})

--- a/samples/sensor/grove_temperature/CMakeLists.txt
+++ b/samples/sensor/grove_temperature/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.8.2)
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
-project(NONE)
+project(grove_temperature)
 
 FILE(GLOB app_sources src/*.c)
 target_sources(app PRIVATE ${app_sources})

--- a/samples/sensor/hts221/CMakeLists.txt
+++ b/samples/sensor/hts221/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.8.2)
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
-project(NONE)
+project(hts221)
 
 FILE(GLOB app_sources src/*.c)
 target_sources(app PRIVATE ${app_sources})

--- a/samples/sensor/lsm303dlhc/CMakeLists.txt
+++ b/samples/sensor/lsm303dlhc/CMakeLists.txt
@@ -6,7 +6,7 @@
 
 cmake_minimum_required(VERSION 3.8.2)
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
-project(NONE)
+project(lsm303dlhc)
 
 FILE(GLOB app_sources src/*.c)
 target_sources(app PRIVATE ${app_sources})

--- a/samples/sensor/magn_polling/CMakeLists.txt
+++ b/samples/sensor/magn_polling/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.8.2)
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
-project(NONE)
+project(magn_polling)
 
 FILE(GLOB app_sources src/*.c)
 target_sources(app PRIVATE ${app_sources})

--- a/samples/sensor/max30101/CMakeLists.txt
+++ b/samples/sensor/max30101/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.8.2)
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
-project(NONE)
+project(max30101)
 
 FILE(GLOB app_sources src/*.c)
 target_sources(app PRIVATE ${app_sources})

--- a/samples/sensor/max44009/CMakeLists.txt
+++ b/samples/sensor/max44009/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.8.2)
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
-project(NONE)
+project(max44009)
 
 FILE(GLOB app_sources src/*.c)
 target_sources(app PRIVATE ${app_sources})

--- a/samples/sensor/mcp9808/CMakeLists.txt
+++ b/samples/sensor/mcp9808/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.8.2)
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
-project(NONE)
+project(mcp9808)
 
 FILE(GLOB app_sources src/*.c)
 target_sources(app PRIVATE ${app_sources})

--- a/samples/sensor/ms5837/CMakeLists.txt
+++ b/samples/sensor/ms5837/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.8.2)
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
-project(NONE)
+project(ms5837)
 
 FILE(GLOB app_sources src/*.c)
 target_sources(app PRIVATE ${app_sources})

--- a/samples/sensor/sx9500/CMakeLists.txt
+++ b/samples/sensor/sx9500/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.8.2)
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
-project(NONE)
+project(sx9500)
 
 FILE(GLOB app_sources src/*.c)
 target_sources(app PRIVATE ${app_sources})

--- a/samples/sensor/th02/CMakeLists.txt
+++ b/samples/sensor/th02/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.8.2)
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
-project(NONE)
+project(th02)
 
 FILE(GLOB app_sources src/*.c)
 target_sources(app PRIVATE ${app_sources})

--- a/samples/sensor/thermometer/CMakeLists.txt
+++ b/samples/sensor/thermometer/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.8.2)
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
-project(NONE)
+project(thermometer)
 
 FILE(GLOB app_sources src/*.c)
 target_sources(app PRIVATE ${app_sources})

--- a/samples/sensor/tmp112/CMakeLists.txt
+++ b/samples/sensor/tmp112/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.8.2)
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
-project(NONE)
+project(tmp112)
 
 FILE(GLOB app_sources src/*.c)
 target_sources(app PRIVATE ${app_sources})

--- a/samples/sensor/vl53l0x/CMakeLists.txt
+++ b/samples/sensor/vl53l0x/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.8.2)
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
-project(NONE)
+project(vl53l0x)
 
 FILE(GLOB app_sources src/*.c)
 target_sources(app PRIVATE ${app_sources})

--- a/samples/shields/x_nucleo_iks01a1/CMakeLists.txt
+++ b/samples/shields/x_nucleo_iks01a1/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.8.2)
 
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
-project(NONE)
+project(x_nucleo_iks01a1)
 
 FILE(GLOB app_sources src/*.c)
 target_sources(app PRIVATE ${app_sources})

--- a/samples/subsys/console/echo/CMakeLists.txt
+++ b/samples/subsys/console/echo/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 3.8.2)
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
-project(NONE)
+project(echo)
 
 target_sources(app PRIVATE src/main.c)

--- a/samples/subsys/console/getchar/CMakeLists.txt
+++ b/samples/subsys/console/getchar/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 3.8.2)
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
-project(NONE)
+project(getchar)
 
 target_sources(app PRIVATE src/main.c)

--- a/samples/subsys/console/getline/CMakeLists.txt
+++ b/samples/subsys/console/getline/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 3.8.2)
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
-project(NONE)
+project(getline)
 
 target_sources(app PRIVATE src/main.c)

--- a/samples/subsys/ipc/ipm_mailbox/ap/CMakeLists.txt
+++ b/samples/subsys/ipc/ipm_mailbox/ap/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.8.2)
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
-project(NONE)
+project(ipm_mailbox_ap)
 
 target_include_directories(app PRIVATE $ENV{ZEPHYR_BASE}/drivers)
 target_sources(app PRIVATE src/hello.c)

--- a/samples/subsys/ipc/ipm_mailbox/sensor/CMakeLists.txt
+++ b/samples/subsys/ipc/ipm_mailbox/sensor/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.8.2)
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
-project(NONE)
+project(ipm_mailbox_sensor)
 
 target_include_directories(app PRIVATE $ENV{ZEPHYR_BASE}/drivers)
 target_sources(app PRIVATE src/hello.c)

--- a/samples/subsys/ipc/ipm_mcux/CMakeLists.txt
+++ b/samples/subsys/ipc/ipm_mcux/CMakeLists.txt
@@ -18,7 +18,7 @@ ExternalProject_Add(
   # NB: Do we need to pass on more CMake variables?
 )
 
-project(NONE)
+project(ipm_mcux)
 
 target_sources(app PRIVATE src/main_master.c)
 add_dependencies(core_m0_inc_target ipm_mcux_remote)

--- a/samples/subsys/ipc/ipm_mcux/remote/CMakeLists.txt
+++ b/samples/subsys/ipc/ipm_mcux/remote/CMakeLists.txt
@@ -6,6 +6,6 @@ cmake_minimum_required(VERSION 3.8.2)
 set(BOARD lpcxpresso54114_m0)
 
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
-project(NONE)
+project(ipm_mcux_remote)
 
 target_sources(app PRIVATE src/main_remote.c)

--- a/samples/subsys/ipc/openamp/CMakeLists.txt
+++ b/samples/subsys/ipc/openamp/CMakeLists.txt
@@ -6,7 +6,7 @@ cmake_minimum_required(VERSION 3.8.2)
 set(BOARD lpcxpresso54114_m4)
 
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
-project(NONE)
+project(openamp)
 
 enable_language(C ASM)
 

--- a/samples/subsys/ipc/openamp/remote/CMakeLists.txt
+++ b/samples/subsys/ipc/openamp/remote/CMakeLists.txt
@@ -8,7 +8,7 @@ set(BOARD lpcxpresso54114_m0)
 set(PLATFORM_DIR "${CMAKE_CURRENT_SOURCE_DIR}/../platform")
 
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
-project(NONE)
+project(openamp_remote)
 
 target_sources(app PRIVATE src/main_remote.c
 	       ${PLATFORM_DIR}/platform.c

--- a/samples/subsys/logging/logger/CMakeLists.txt
+++ b/samples/subsys/logging/logger/CMakeLists.txt
@@ -2,7 +2,7 @@ cmake_minimum_required(VERSION 3.8.2)
 
 
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
-project(NONE)
+project(logger)
 
 FILE(GLOB app_sources src/*.c)
 target_sources(app PRIVATE ${app_sources})

--- a/samples/subsys/mgmt/mcumgr/smp_svr/CMakeLists.txt
+++ b/samples/subsys/mgmt/mcumgr/smp_svr/CMakeLists.txt
@@ -10,7 +10,7 @@ cmake_minimum_required(VERSION 3.8.2)
 
 # Standard Zephyr application boilerplate.
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
-project(NONE)
+project(smp_svr)
 
 target_sources(app PRIVATE
     src/main.c

--- a/samples/subsys/nvs/CMakeLists.txt
+++ b/samples/subsys/nvs/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.8.2)
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
-project(NONE)
+project(nvs)
 
 
 target_sources(app PRIVATE src/main.c)

--- a/samples/subsys/power/power_mgr/CMakeLists.txt
+++ b/samples/subsys/power/power_mgr/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.8.2)
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
-project(NONE)
+project(power_mgr)
 
 FILE(GLOB app_sources src/*.c)
 target_sources(app PRIVATE ${app_sources})

--- a/samples/subsys/shell/shell_module/CMakeLists.txt
+++ b/samples/subsys/shell/shell_module/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.8.2)
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
-project(NONE)
+project(shell_module)
 
 FILE(GLOB app_sources src/*.c)
 target_sources(app PRIVATE ${app_sources})

--- a/samples/subsys/usb/cdc_acm/CMakeLists.txt
+++ b/samples/subsys/usb/cdc_acm/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.8.2)
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
-project(NONE)
+project(cdc_acm)
 
 FILE(GLOB app_sources src/*.c)
 target_sources(app PRIVATE ${app_sources})

--- a/samples/subsys/usb/console/CMakeLists.txt
+++ b/samples/subsys/usb/console/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.8.2)
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
-project(NONE)
+project(console)
 
 FILE(GLOB app_sources src/*.c)
 target_sources(app PRIVATE ${app_sources})

--- a/samples/subsys/usb/dfu/CMakeLists.txt
+++ b/samples/subsys/usb/dfu/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.8.2)
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
-project(NONE)
+project(dfu)
 
 FILE(GLOB app_sources src/*.c)
 target_sources(app PRIVATE ${app_sources})

--- a/samples/subsys/usb/hid-mouse/CMakeLists.txt
+++ b/samples/subsys/usb/hid-mouse/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.8.2)
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
-project(NONE)
+project(hid-mouse)
 
 FILE(GLOB app_sources src/*.c)
 target_sources(app PRIVATE ${app_sources})

--- a/samples/subsys/usb/hid/CMakeLists.txt
+++ b/samples/subsys/usb/hid/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.8.2)
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
-project(NONE)
+project(hid)
 
 FILE(GLOB app_sources src/*.c)
 target_sources(app PRIVATE ${app_sources})

--- a/samples/subsys/usb/mass/CMakeLists.txt
+++ b/samples/subsys/usb/mass/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.8.2)
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
-project(NONE)
+project(mass)
 
 FILE(GLOB app_sources src/*.c)
 target_sources(app PRIVATE ${app_sources})

--- a/samples/subsys/usb/testusb/CMakeLists.txt
+++ b/samples/subsys/usb/testusb/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.8.2)
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
-project(NONE)
+project(testusb)
 
 FILE(GLOB app_sources src/*.c)
 target_sources(app PRIVATE ${app_sources})

--- a/samples/subsys/usb/webusb/CMakeLists.txt
+++ b/samples/subsys/usb/webusb/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.8.2)
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
-project(NONE)
+project(webusb)
 
 FILE(GLOB app_sources src/*.c)
 target_sources(app PRIVATE ${app_sources})

--- a/samples/synchronization/CMakeLists.txt
+++ b/samples/synchronization/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.8.2)
 
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
-project(NONE)
+project(synchronization)
 
 target_sources(app PRIVATE src/main.c)

--- a/samples/testing/integration/CMakeLists.txt
+++ b/samples/testing/integration/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.8.2)
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
-project(NONE)
+project(integration)
 
 FILE(GLOB app_sources src/*.c)
 target_sources(app PRIVATE ${app_sources})

--- a/samples/xtensa_asm2/CMakeLists.txt
+++ b/samples/xtensa_asm2/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.8.2)
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
-project(NONE)
+project(xtensa_asm2)
 
 enable_language(ASM)
 

--- a/tests/application_development/cpp/CMakeLists.txt
+++ b/tests/application_development/cpp/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.8.2)
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
-project(NONE)
+project(cpp)
 
 FILE(GLOB app_sources src/*.cpp)
 target_sources(app PRIVATE ${app_sources})

--- a/tests/application_development/gen_inc_file/CMakeLists.txt
+++ b/tests/application_development/gen_inc_file/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.8.2)
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
-project(NONE)
+project(gen_inc_file)
 
 FILE(GLOB app_sources src/*.c)
 target_sources(app PRIVATE ${app_sources})

--- a/tests/benchmarks/app_kernel/CMakeLists.txt
+++ b/tests/benchmarks/app_kernel/CMakeLists.txt
@@ -4,7 +4,7 @@ if(BOARD STREQUAL "minnowboard")
 endif()
 
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
-project(NONE)
+project(app_kernel)
 
 FILE(GLOB app_sources src/*.c)
 target_sources(app PRIVATE ${app_sources})

--- a/tests/benchmarks/boot_time/CMakeLists.txt
+++ b/tests/benchmarks/boot_time/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.8.2)
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
-project(NONE)
+project(boot_time)
 
 FILE(GLOB app_sources src/*.c)
 target_sources(app PRIVATE ${app_sources})

--- a/tests/benchmarks/footprint/CMakeLists.txt
+++ b/tests/benchmarks/footprint/CMakeLists.txt
@@ -14,7 +14,7 @@ macro(set_conf_file)
 endmacro()
 
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
-project(NONE)
+project(footprint)
 
 FILE(GLOB app_sources src/*.c)
 target_sources(app PRIVATE ${app_sources})

--- a/tests/benchmarks/latency_measure/CMakeLists.txt
+++ b/tests/benchmarks/latency_measure/CMakeLists.txt
@@ -10,7 +10,7 @@ else()
 endif()
 
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
-project(NONE)
+project(latency_measure)
 
 FILE(GLOB app_sources src/*.c)
 target_sources(app PRIVATE ${app_sources})

--- a/tests/benchmarks/object_footprint/CMakeLists.txt
+++ b/tests/benchmarks/object_footprint/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.8.2)
 
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
-project(NONE)
+project(object_footprint)
 
 FILE(GLOB app_sources src/*.c)
 target_sources(app PRIVATE ${app_sources})

--- a/tests/benchmarks/sys_kernel/CMakeLists.txt
+++ b/tests/benchmarks/sys_kernel/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.8.2)
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
-project(NONE)
+project(sys_kernel)
 
 FILE(GLOB app_sources src/*.c)
 target_sources(app PRIVATE ${app_sources})

--- a/tests/benchmarks/timing_info/CMakeLists.txt
+++ b/tests/benchmarks/timing_info/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.8.2)
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
-project(NONE)
+project(timing_info)
 
 FILE(GLOB app_sources src/[^u]*.c)
 target_sources(app PRIVATE ${app_sources})

--- a/tests/bluetooth/bluetooth/CMakeLists.txt
+++ b/tests/bluetooth/bluetooth/CMakeLists.txt
@@ -2,6 +2,6 @@ cmake_minimum_required(VERSION 3.8.2)
 set(NO_QEMU_SERIAL_BT_SERVER 1)
 
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
-project(NONE)
+project(bluetooth)
 
 target_sources(app PRIVATE src/bluetooth.c)

--- a/tests/bluetooth/init/CMakeLists.txt
+++ b/tests/bluetooth/init/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.8.2)
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
-project(NONE)
+project(bluetooth_init)
 
 FILE(GLOB app_sources src/*.c)
 target_sources(app PRIVATE ${app_sources})

--- a/tests/bluetooth/mesh/CMakeLists.txt
+++ b/tests/bluetooth/mesh/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.8.2)
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
-project(NONE)
+project(mesh)
 
 zephyr_library_include_directories($ENV{ZEPHYR_BASE}/samples/bluetooth)
 target_sources(app PRIVATE src/main.c)

--- a/tests/bluetooth/mesh_shell/CMakeLists.txt
+++ b/tests/bluetooth/mesh_shell/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.8.2)
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
-project(NONE)
+project(mesh_shell)
 
 FILE(GLOB app_sources src/*.c)
 target_sources(app PRIVATE ${app_sources})

--- a/tests/bluetooth/shell/CMakeLists.txt
+++ b/tests/bluetooth/shell/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.8.2)
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
-project(NONE)
+project(bluetooth_shell)
 
 zephyr_library_include_directories($ENV{ZEPHYR_BASE}/samples/bluetooth)
 

--- a/tests/bluetooth/tester/CMakeLists.txt
+++ b/tests/bluetooth/tester/CMakeLists.txt
@@ -8,7 +8,7 @@ endif()
 LIST(APPEND QEMU_EXTRA_FLAGS -serial unix:/tmp/bt-stack-tester)
 
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
-project(NONE)
+project(tester)
 
 zephyr_library_include_directories($ENV{ZEPHYR_BASE}/samples/bluetooth)
 target_sources(app PRIVATE

--- a/tests/boards/altera_max10/i2c_master/CMakeLists.txt
+++ b/tests/boards/altera_max10/i2c_master/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.8.2)
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
-project(NONE)
+project(i2c_master)
 
 FILE(GLOB app_sources src/*.c)
 target_sources(app PRIVATE ${app_sources})

--- a/tests/boards/altera_max10/msgdma/CMakeLists.txt
+++ b/tests/boards/altera_max10/msgdma/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.8.2)
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
-project(NONE)
+project(msgdma)
 
 FILE(GLOB app_sources src/*.c)
 target_sources(app PRIVATE ${app_sources})

--- a/tests/boards/altera_max10/qspi/CMakeLists.txt
+++ b/tests/boards/altera_max10/qspi/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.8.2)
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
-project(NONE)
+project(qspi)
 
 FILE(GLOB app_sources src/*.c)
 target_sources(app PRIVATE ${app_sources})

--- a/tests/boards/altera_max10/sysid/CMakeLists.txt
+++ b/tests/boards/altera_max10/sysid/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.8.2)
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
-project(NONE)
+project(sysid)
 
 FILE(GLOB app_sources src/*.c)
 target_sources(app PRIVATE ${app_sources})

--- a/tests/boards/intel_s1000_crb/CMakeLists.txt
+++ b/tests/boards/intel_s1000_crb/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.8.2)
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
-project(NONE)
+project(intel_s1000_crb)
 
 if(CONFIG_I2C)
 target_sources(app PRIVATE src/i2c_test.c)

--- a/tests/boards/native_posix/native_tasks/CMakeLists.txt
+++ b/tests/boards/native_posix/native_tasks/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.8.2)
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
-project(NONE)
+project(native_tasks)
 
 FILE(GLOB app_sources src/*.c)
 target_sources(app PRIVATE ${app_sources})

--- a/tests/boards/native_posix/rtc/CMakeLists.txt
+++ b/tests/boards/native_posix/rtc/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.8.2)
 
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
-project(NONE)
+project(rtc)
 
 target_sources(app PRIVATE src/main.c)

--- a/tests/booting/stub/CMakeLists.txt
+++ b/tests/booting/stub/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 3.8.2)
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
-project(NONE)
+project(stub)
 
 target_sources(app PRIVATE src/main.c)

--- a/tests/cmsis_rtos_v1/CMakeLists.txt
+++ b/tests/cmsis_rtos_v1/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.8.2)
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
-project(NONE)
+project(cmsis_rtos_v1)
 
 target_include_directories(app PRIVATE $ENV{ZEPHYR_BASE}/include/cmsis_rtos_v1)
 FILE(GLOB app_sources src/*.c)

--- a/tests/crypto/mbedtls/CMakeLists.txt
+++ b/tests/crypto/mbedtls/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.8.2)
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
-project(NONE)
+project(mbedtls)
 
 FILE(GLOB app_sources src/*.c)
 target_sources(app PRIVATE ${app_sources})

--- a/tests/crypto/rand32/CMakeLists.txt
+++ b/tests/crypto/rand32/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.8.2)
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
-project(NONE)
+project(rand32)
 
 zephyr_include_directories(app PRIVATE $ENV{ZEPHYR_BASE}/kernel/include/)
 

--- a/tests/crypto/tinycrypt/CMakeLists.txt
+++ b/tests/crypto/tinycrypt/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.8.2)
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
-project(NONE)
+project(tinycrypt)
 
 FILE(GLOB app_sources src/*.c)
 target_sources(app PRIVATE ${app_sources})

--- a/tests/crypto/tinycrypt_hmac_prng/CMakeLists.txt
+++ b/tests/crypto/tinycrypt_hmac_prng/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.8.2)
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
-project(NONE)
+project(tinycrypt_hmac_prng)
 
 FILE(GLOB app_sources src/*.c)
 target_sources(app PRIVATE ${app_sources})

--- a/tests/drivers/adc/adc_api/CMakeLists.txt
+++ b/tests/drivers/adc/adc_api/CMakeLists.txt
@@ -8,7 +8,7 @@ macro(set_conf_file)
 endmacro()
 
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
-project(NONE)
+project(adc_api)
 
 FILE(GLOB app_sources src/*.c)
 target_sources(app PRIVATE ${app_sources})

--- a/tests/drivers/aio/api/CMakeLists.txt
+++ b/tests/drivers/aio/api/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.8.2)
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
-project(NONE)
+project(aio_api)
 
 FILE(GLOB app_sources src/*.c)
 target_sources(app PRIVATE ${app_sources})

--- a/tests/drivers/aio/app/CMakeLists.txt
+++ b/tests/drivers/aio/app/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.8.2)
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
-project(NONE)
+project(aio_app)
 
 FILE(GLOB app_sources src/*.c)
 target_sources(app PRIVATE ${app_sources})

--- a/tests/drivers/aon_counter/aon_api/CMakeLists.txt
+++ b/tests/drivers/aon_counter/aon_api/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.8.2)
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
-project(NONE)
+project(aon_api)
 
 FILE(GLOB app_sources src/*.c)
 target_sources(app PRIVATE ${app_sources})

--- a/tests/drivers/build_all/CMakeLists.txt
+++ b/tests/drivers/build_all/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.8.2)
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
-project(NONE)
+project(build_all)
 
 FILE(GLOB app_sources src/*.c)
 target_sources(app PRIVATE ${app_sources})

--- a/tests/drivers/dma/chan_blen_transfer/CMakeLists.txt
+++ b/tests/drivers/dma/chan_blen_transfer/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.8.2)
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
-project(NONE)
+project(chan_blen_transfer)
 
 FILE(GLOB app_sources src/*.c)
 target_sources(app PRIVATE ${app_sources})

--- a/tests/drivers/dma/loop_transfer/CMakeLists.txt
+++ b/tests/drivers/dma/loop_transfer/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.8.2)
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
-project(NONE)
+project(loop_transfer)
 
 FILE(GLOB app_sources src/*.c)
 target_sources(app PRIVATE ${app_sources})

--- a/tests/drivers/entropy/api/CMakeLists.txt
+++ b/tests/drivers/entropy/api/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.8.2)
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
-project(NONE)
+project(entropy_api)
 
 FILE(GLOB app_sources src/*.c)
 target_sources(app PRIVATE ${app_sources})

--- a/tests/drivers/gpio/gpio_basic_api/CMakeLists.txt
+++ b/tests/drivers/gpio/gpio_basic_api/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.8.2)
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
-project(NONE)
+project(gpio_basic_api)
 
 FILE(GLOB app_sources src/*.c)
 target_sources(app PRIVATE ${app_sources})

--- a/tests/drivers/i2c/i2c_api/CMakeLists.txt
+++ b/tests/drivers/i2c/i2c_api/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.8.2)
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
-project(NONE)
+project(i2c_api)
 
 FILE(GLOB app_sources src/*.c)
 target_sources(app PRIVATE ${app_sources})

--- a/tests/drivers/i2c/i2c_slave_api/CMakeLists.txt
+++ b/tests/drivers/i2c/i2c_slave_api/CMakeLists.txt
@@ -9,7 +9,7 @@ macro(set_conf_file)
 endmacro()
 
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
-project(NONE)
+project(i2c_slave_api)
 
 add_subdirectory(common)
 

--- a/tests/drivers/i2s/i2s_api/CMakeLists.txt
+++ b/tests/drivers/i2s/i2s_api/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.8.2)
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
-project(NONE)
+project(i2s_api)
 
 FILE(GLOB app_sources src/*.c)
 target_sources(app PRIVATE ${app_sources})

--- a/tests/drivers/i2s/i2s_speed/CMakeLists.txt
+++ b/tests/drivers/i2s/i2s_speed/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.8.2)
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
-project(NONE)
+project(i2s_speed)
 
 FILE(GLOB app_sources src/*.c)
 target_sources(app PRIVATE ${app_sources})

--- a/tests/drivers/ipm/CMakeLists.txt
+++ b/tests/drivers/ipm/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.8.2)
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
-project(NONE)
+project(ipm)
 
 FILE(GLOB app_sources src/*.c)
 target_sources(app PRIVATE ${app_sources})

--- a/tests/drivers/pci_enum/CMakeLists.txt
+++ b/tests/drivers/pci_enum/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.8.2)
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
-project(NONE)
+project(pci_enum)
 
 FILE(GLOB app_sources src/*.c)
 target_sources(app PRIVATE ${app_sources})

--- a/tests/drivers/pinmux/pinmux_basic_api/CMakeLists.txt
+++ b/tests/drivers/pinmux/pinmux_basic_api/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.8.2)
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
-project(NONE)
+project(pinmux_basic_api)
 
 FILE(GLOB app_sources src/*.c)
 target_sources(app PRIVATE ${app_sources})

--- a/tests/drivers/pwm/pwm_api/CMakeLists.txt
+++ b/tests/drivers/pwm/pwm_api/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.8.2)
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
-project(NONE)
+project(pwm_api)
 
 FILE(GLOB app_sources src/*.c)
 target_sources(app PRIVATE ${app_sources})

--- a/tests/drivers/rtc/rtc_basic_api/CMakeLists.txt
+++ b/tests/drivers/rtc/rtc_basic_api/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.8.2)
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
-project(NONE)
+project(rtc_basic_api)
 
 FILE(GLOB app_sources src/*.c)
 target_sources(app PRIVATE ${app_sources})

--- a/tests/drivers/spi/spi_loopback/CMakeLists.txt
+++ b/tests/drivers/spi/spi_loopback/CMakeLists.txt
@@ -11,7 +11,7 @@ macro(set_conf_file)
 endmacro()
 
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
-project(NONE)
+project(spi_loopback)
 
 FILE(GLOB app_sources src/*.c)
 target_sources(app PRIVATE ${app_sources})

--- a/tests/drivers/uart/uart_basic_api/CMakeLists.txt
+++ b/tests/drivers/uart/uart_basic_api/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.8.2)
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
-project(NONE)
+project(uart_basic_api)
 
 target_sources(app PRIVATE
     src/main.c

--- a/tests/drivers/watchdog/wdt_basic_api/CMakeLists.txt
+++ b/tests/drivers/watchdog/wdt_basic_api/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.8.2)
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
-project(NONE)
+project(wdt_basic_api)
 
 FILE(GLOB app_sources src/*.c)
 target_sources(app PRIVATE ${app_sources})

--- a/tests/kernel/alert/alert_api/CMakeLists.txt
+++ b/tests/kernel/alert/alert_api/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.8.2)
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
-project(NONE)
+project(alert_api)
 
 FILE(GLOB app_sources src/*.c)
 target_sources(app PRIVATE ${app_sources})

--- a/tests/kernel/arm_irq_vector_table/CMakeLists.txt
+++ b/tests/kernel/arm_irq_vector_table/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.8.2)
 
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
-project(NONE)
+project(arm_irq_vector_table)
 
 FILE(GLOB app_sources src/*.c)
 target_sources(app PRIVATE ${app_sources})

--- a/tests/kernel/arm_runtime_nmi/CMakeLists.txt
+++ b/tests/kernel/arm_runtime_nmi/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.8.2)
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
-project(NONE)
+project(arm_runtime_nmi)
 
 FILE(GLOB app_sources src/*.c)
 target_sources(app PRIVATE ${app_sources})

--- a/tests/kernel/boot_page_table/CMakeLists.txt
+++ b/tests/kernel/boot_page_table/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.8.2)
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
-project(NONE)
+project(boot_page_table)
 
 FILE(GLOB app_sources src/*.c)
 target_sources(app PRIVATE ${app_sources})

--- a/tests/kernel/common/CMakeLists.txt
+++ b/tests/kernel/common/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.8.2)
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
-project(NONE)
+project(kernel_common)
 
 if(NOT CONFIG_ARM)
 target_sources(app PRIVATE

--- a/tests/kernel/context/CMakeLists.txt
+++ b/tests/kernel/context/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.8.2)
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
-project(NONE)
+project(kernel_context)
 
 FILE(GLOB app_sources src/*.c)
 target_sources(app PRIVATE ${app_sources})

--- a/tests/kernel/critical/CMakeLists.txt
+++ b/tests/kernel/critical/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.8.2)
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
-project(NONE)
+project(critical)
 
 FILE(GLOB app_sources src/*.c)
 target_sources(app PRIVATE ${app_sources})

--- a/tests/kernel/device/CMakeLists.txt
+++ b/tests/kernel/device/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.8.2)
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
-project(NONE)
+project(device)
 
 FILE(GLOB app_sources src/*.c)
 target_sources(app PRIVATE ${app_sources})

--- a/tests/kernel/early_sleep/CMakeLists.txt
+++ b/tests/kernel/early_sleep/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.8.2)
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
-project(NONE)
+project(early_sleep)
 
 FILE(GLOB app_sources src/*.c)
 target_sources(app PRIVATE ${app_sources})

--- a/tests/kernel/errno/CMakeLists.txt
+++ b/tests/kernel/errno/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.8.2)
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
-project(NONE)
+project(errno)
 
 FILE(GLOB app_sources src/*.c)
 target_sources(app PRIVATE ${app_sources})

--- a/tests/kernel/fatal/CMakeLists.txt
+++ b/tests/kernel/fatal/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.8.2)
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
-project(NONE)
+project(fatal)
 
 FILE(GLOB app_sources src/*.c)
 target_sources(app PRIVATE ${app_sources})

--- a/tests/kernel/fifo/fifo_api/CMakeLists.txt
+++ b/tests/kernel/fifo/fifo_api/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.8.2)
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
-project(NONE)
+project(fifo_api)
 
 FILE(GLOB app_sources src/*.c)
 target_sources(app PRIVATE ${app_sources})

--- a/tests/kernel/fifo/fifo_timeout/CMakeLists.txt
+++ b/tests/kernel/fifo/fifo_timeout/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.8.2)
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
-project(NONE)
+project(fifo_timeout)
 
 FILE(GLOB app_sources src/*.c)
 target_sources(app PRIVATE ${app_sources})

--- a/tests/kernel/fifo/fifo_usage/CMakeLists.txt
+++ b/tests/kernel/fifo/fifo_usage/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.8.2)
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
-project(NONE)
+project(fifo_usage)
 
 FILE(GLOB app_sources src/*.c)
 target_sources(app PRIVATE ${app_sources})

--- a/tests/kernel/fp_sharing/CMakeLists.txt
+++ b/tests/kernel/fp_sharing/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.8.2)
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
-project(NONE)
+project(fp_sharing)
 
 # Some boards are significantly slower than others resulting in the test
 # output being in the range of every few seconds to every few minutes. To

--- a/tests/kernel/gen_isr_table/CMakeLists.txt
+++ b/tests/kernel/gen_isr_table/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.8.2)
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
-project(NONE)
+project(gen_isr_table)
 
 FILE(GLOB app_sources src/*.c)
 target_sources(app PRIVATE ${app_sources})

--- a/tests/kernel/init/CMakeLists.txt
+++ b/tests/kernel/init/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.8.2)
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
-project(NONE)
+project(kernel_init)
 
 FILE(GLOB app_sources src/*.c)
 target_sources(app PRIVATE ${app_sources})

--- a/tests/kernel/interrupt/CMakeLists.txt
+++ b/tests/kernel/interrupt/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.8.2)
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
-project(NONE)
+project(interrupt)
 
 FILE(GLOB app_sources src/*.c)
 target_sources(app PRIVATE ${app_sources})

--- a/tests/kernel/irq_offload/CMakeLists.txt
+++ b/tests/kernel/irq_offload/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.8.2)
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
-project(NONE)
+project(irq_offload)
 
 FILE(GLOB app_sources src/*.c)
 target_sources(app PRIVATE ${app_sources})

--- a/tests/kernel/lifo/lifo_api/CMakeLists.txt
+++ b/tests/kernel/lifo/lifo_api/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.8.2)
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
-project(NONE)
+project(lifo_api)
 
 FILE(GLOB app_sources src/*.c)
 target_sources(app PRIVATE ${app_sources})

--- a/tests/kernel/lifo/lifo_usage/CMakeLists.txt
+++ b/tests/kernel/lifo/lifo_usage/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.8.2)
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
-project(NONE)
+project(lifo_usage)
 
 FILE(GLOB app_sources src/*.c)
 target_sources(app PRIVATE ${app_sources})

--- a/tests/kernel/mbox/mbox_api/CMakeLists.txt
+++ b/tests/kernel/mbox/mbox_api/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.8.2)
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
-project(NONE)
+project(mbox_api)
 
 FILE(GLOB app_sources src/*.c)
 target_sources(app PRIVATE ${app_sources})

--- a/tests/kernel/mbox/mbox_usage/CMakeLists.txt
+++ b/tests/kernel/mbox/mbox_usage/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.8.2)
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
-project(NONE)
+project(mbox_usage)
 
 FILE(GLOB app_sources src/*.c)
 target_sources(app PRIVATE ${app_sources})

--- a/tests/kernel/mem_heap/mheap_api_concept/CMakeLists.txt
+++ b/tests/kernel/mem_heap/mheap_api_concept/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.8.2)
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
-project(NONE)
+project(mheap_api_concept)
 
 FILE(GLOB app_sources src/*.c)
 target_sources(app PRIVATE ${app_sources})

--- a/tests/kernel/mem_pool/mem_pool/CMakeLists.txt
+++ b/tests/kernel/mem_pool/mem_pool/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.8.2)
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
-project(NONE)
+project(mem_pool)
 
 FILE(GLOB app_sources src/*.c)
 target_sources(app PRIVATE ${app_sources})

--- a/tests/kernel/mem_pool/mem_pool_api/CMakeLists.txt
+++ b/tests/kernel/mem_pool/mem_pool_api/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.8.2)
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
-project(NONE)
+project(mem_pool_api)
 
 FILE(GLOB app_sources src/*.c)
 target_sources(app PRIVATE ${app_sources})

--- a/tests/kernel/mem_pool/mem_pool_concept/CMakeLists.txt
+++ b/tests/kernel/mem_pool/mem_pool_concept/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.8.2)
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
-project(NONE)
+project(mem_pool_concept)
 
 FILE(GLOB app_sources src/*.c)
 target_sources(app PRIVATE ${app_sources})

--- a/tests/kernel/mem_pool/mem_pool_threadsafe/CMakeLists.txt
+++ b/tests/kernel/mem_pool/mem_pool_threadsafe/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.8.2)
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
-project(NONE)
+project(mem_pool_threadsafe)
 
 FILE(GLOB app_sources src/*.c)
 target_sources(app PRIVATE ${app_sources})

--- a/tests/kernel/mem_pool/sys_mem_pool/CMakeLists.txt
+++ b/tests/kernel/mem_pool/sys_mem_pool/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.8.2)
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
-project(NONE)
+project(sys_mem_pool)
 
 FILE(GLOB app_sources src/*.c)
 target_sources(app PRIVATE ${app_sources})

--- a/tests/kernel/mem_protect/app_memory/CMakeLists.txt
+++ b/tests/kernel/mem_protect/app_memory/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.8.2)
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
-project(NONE)
+project(app_memory)
 
 FILE(GLOB app_sources src/*.c)
 target_sources(app PRIVATE ${app_sources})

--- a/tests/kernel/mem_protect/mem_protect/CMakeLists.txt
+++ b/tests/kernel/mem_protect/mem_protect/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.8.2)
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
-project(NONE)
+project(mem_protect)
 
 FILE(GLOB app_sources src/*.c)
 target_sources(app PRIVATE ${app_sources})

--- a/tests/kernel/mem_protect/obj_validation/CMakeLists.txt
+++ b/tests/kernel/mem_protect/obj_validation/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.8.2)
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
-project(NONE)
+project(obj_validation)
 
 FILE(GLOB app_sources src/*.c)
 target_sources(app PRIVATE ${app_sources})

--- a/tests/kernel/mem_protect/protection/CMakeLists.txt
+++ b/tests/kernel/mem_protect/protection/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.8.2)
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
-project(NONE)
+project(protection)
 
 FILE(GLOB app_sources src/*.c)
 target_sources(app PRIVATE ${app_sources})

--- a/tests/kernel/mem_protect/stack_random/CMakeLists.txt
+++ b/tests/kernel/mem_protect/stack_random/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.8.2)
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
-project(NONE)
+project(stack_random)
 
 FILE(GLOB app_sources src/*.c)
 target_sources(app PRIVATE ${app_sources})

--- a/tests/kernel/mem_protect/stackprot/CMakeLists.txt
+++ b/tests/kernel/mem_protect/stackprot/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.8.2)
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
-project(NONE)
+project(stackprot)
 
 FILE(GLOB app_sources src/*.c)
 target_sources(app PRIVATE ${app_sources})

--- a/tests/kernel/mem_protect/syscalls/CMakeLists.txt
+++ b/tests/kernel/mem_protect/syscalls/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.8.2)
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
-project(NONE)
+project(syscalls)
 
 FILE(GLOB app_sources src/*.c)
 target_sources(app PRIVATE ${app_sources})

--- a/tests/kernel/mem_protect/userspace/CMakeLists.txt
+++ b/tests/kernel/mem_protect/userspace/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.8.2)
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
-project(NONE)
+project(userspace)
 
 FILE(GLOB app_sources src/*.c)
 target_sources(app PRIVATE ${app_sources})

--- a/tests/kernel/mem_protect/x86_mmu_api/CMakeLists.txt
+++ b/tests/kernel/mem_protect/x86_mmu_api/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.8.2)
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
-project(NONE)
+project(x86_mmu_api)
 
 file(GLOB source_for_app src/*.c)
 

--- a/tests/kernel/mem_slab/mslab/CMakeLists.txt
+++ b/tests/kernel/mem_slab/mslab/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.8.2)
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
-project(NONE)
+project(mslab)
 
 FILE(GLOB app_sources src/*.c)
 target_sources(app PRIVATE ${app_sources})

--- a/tests/kernel/mem_slab/mslab_api/CMakeLists.txt
+++ b/tests/kernel/mem_slab/mslab_api/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.8.2)
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
-project(NONE)
+project(mslab_api)
 
 FILE(GLOB app_sources src/*.c)
 target_sources(app PRIVATE ${app_sources})

--- a/tests/kernel/mem_slab/mslab_concept/CMakeLists.txt
+++ b/tests/kernel/mem_slab/mslab_concept/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.8.2)
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
-project(NONE)
+project(mslab_concept)
 
 FILE(GLOB app_sources src/*.c)
 target_sources(app PRIVATE ${app_sources})

--- a/tests/kernel/mem_slab/mslab_threadsafe/CMakeLists.txt
+++ b/tests/kernel/mem_slab/mslab_threadsafe/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.8.2)
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
-project(NONE)
+project(mslab_threadsafe)
 
 FILE(GLOB app_sources src/*.c)
 target_sources(app PRIVATE ${app_sources})

--- a/tests/kernel/mp/CMakeLists.txt
+++ b/tests/kernel/mp/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 3.8.2)
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
-project(NONE)
+project(mp)
 
 target_sources(app PRIVATE src/main.c)

--- a/tests/kernel/msgq/msgq_api/CMakeLists.txt
+++ b/tests/kernel/msgq/msgq_api/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.8.2)
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
-project(NONE)
+project(msgq_api)
 
 FILE(GLOB app_sources src/*.c)
 target_sources(app PRIVATE ${app_sources})

--- a/tests/kernel/mutex/mutex/CMakeLists.txt
+++ b/tests/kernel/mutex/mutex/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.8.2)
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
-project(NONE)
+project(mutex)
 
 FILE(GLOB app_sources src/*.c)
 target_sources(app PRIVATE ${app_sources})

--- a/tests/kernel/mutex/mutex_api/CMakeLists.txt
+++ b/tests/kernel/mutex/mutex_api/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.8.2)
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
-project(NONE)
+project(mutex_api)
 
 FILE(GLOB app_sources src/*.c)
 target_sources(app PRIVATE ${app_sources})

--- a/tests/kernel/obj_tracing/CMakeLists.txt
+++ b/tests/kernel/obj_tracing/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.8.2)
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
-project(NONE)
+project(obj_tracing)
 
 FILE(GLOB app_sources src/*.c)
 target_sources(app PRIVATE ${app_sources})

--- a/tests/kernel/pending/CMakeLists.txt
+++ b/tests/kernel/pending/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.8.2)
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
-project(NONE)
+project(pending)
 
 FILE(GLOB app_sources src/*.c)
 target_sources(app PRIVATE ${app_sources})

--- a/tests/kernel/pipe/pipe/CMakeLists.txt
+++ b/tests/kernel/pipe/pipe/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.8.2)
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
-project(NONE)
+project(pipe)
 
 FILE(GLOB app_sources src/*.c)
 target_sources(app PRIVATE ${app_sources})

--- a/tests/kernel/pipe/pipe_api/CMakeLists.txt
+++ b/tests/kernel/pipe/pipe_api/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.8.2)
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
-project(NONE)
+project(pipe_api)
 
 FILE(GLOB app_sources src/*.c)
 target_sources(app PRIVATE ${app_sources})

--- a/tests/kernel/poll/CMakeLists.txt
+++ b/tests/kernel/poll/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.8.2)
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
-project(NONE)
+project(poll)
 
 FILE(GLOB app_sources src/*.c)
 target_sources(app PRIVATE ${app_sources})

--- a/tests/kernel/profiling/profiling_api/CMakeLists.txt
+++ b/tests/kernel/profiling/profiling_api/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.8.2)
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
-project(NONE)
+project(profiling_api)
 
 FILE(GLOB app_sources src/*.c)
 target_sources(app PRIVATE ${app_sources})

--- a/tests/kernel/queue/CMakeLists.txt
+++ b/tests/kernel/queue/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.8.2)
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
-project(NONE)
+project(queue)
 
 FILE(GLOB app_sources src/*.c)
 target_sources(app PRIVATE ${app_sources})

--- a/tests/kernel/sched/deadline/CMakeLists.txt
+++ b/tests/kernel/sched/deadline/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.8.2)
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
-project(NONE)
+project(deadline)
 
 FILE(GLOB app_sources src/*.c)
 target_sources(app PRIVATE ${app_sources})

--- a/tests/kernel/sched/preempt/CMakeLists.txt
+++ b/tests/kernel/sched/preempt/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.8.2)
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
-project(NONE)
+project(preempt)
 
 FILE(GLOB app_sources src/*.c)
 target_sources(app PRIVATE ${app_sources})

--- a/tests/kernel/sched/schedule_api/CMakeLists.txt
+++ b/tests/kernel/sched/schedule_api/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.8.2)
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
-project(NONE)
+project(schedule_api)
 
 FILE(GLOB app_sources src/*.c)
 target_sources(app PRIVATE ${app_sources})

--- a/tests/kernel/semaphore/sema_api/CMakeLists.txt
+++ b/tests/kernel/semaphore/sema_api/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.8.2)
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
-project(NONE)
+project(sema_api)
 
 FILE(GLOB app_sources src/*.c)
 target_sources(app PRIVATE ${app_sources})

--- a/tests/kernel/semaphore/semaphore/CMakeLists.txt
+++ b/tests/kernel/semaphore/semaphore/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.8.2)
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
-project(NONE)
+project(semaphore)
 
 FILE(GLOB app_sources src/*.c)
 target_sources(app PRIVATE ${app_sources})

--- a/tests/kernel/sleep/CMakeLists.txt
+++ b/tests/kernel/sleep/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.8.2)
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
-project(NONE)
+project(sleep)
 
 FILE(GLOB app_sources src/*.c)
 target_sources(app PRIVATE ${app_sources})

--- a/tests/kernel/smp/CMakeLists.txt
+++ b/tests/kernel/smp/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 3.8.2)
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
-project(NONE)
+project(smp)
 
 target_sources(app PRIVATE src/main.c)

--- a/tests/kernel/spinlock/CMakeLists.txt
+++ b/tests/kernel/spinlock/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 3.8.2)
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
-project(NONE)
+project(spinlock)
 
 target_sources(app PRIVATE src/main.c)

--- a/tests/kernel/stack/stack_api/CMakeLists.txt
+++ b/tests/kernel/stack/stack_api/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.8.2)
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
-project(NONE)
+project(stack_api)
 
 FILE(GLOB app_sources src/*.c)
 target_sources(app PRIVATE ${app_sources})

--- a/tests/kernel/stack/stack_usage/CMakeLists.txt
+++ b/tests/kernel/stack/stack_usage/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.8.2)
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
-project(NONE)
+project(stack_usage)
 
 FILE(GLOB app_sources src/*.c)
 target_sources(app PRIVATE ${app_sources})

--- a/tests/kernel/static_idt/CMakeLists.txt
+++ b/tests/kernel/static_idt/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.8.2)
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
-project(NONE)
+project(static_idt)
 
 enable_language(C ASM)
 

--- a/tests/kernel/threads/dynamic_thread/CMakeLists.txt
+++ b/tests/kernel/threads/dynamic_thread/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.8.2)
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
-project(NONE)
+project(dynamic_thread)
 
 FILE(GLOB app_sources src/*.c)
 target_sources(app PRIVATE ${app_sources})

--- a/tests/kernel/threads/no-multithreading/CMakeLists.txt
+++ b/tests/kernel/threads/no-multithreading/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.8.2)
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
-project(NONE)
+project(no-multithreading)
 
 FILE(GLOB app_sources src/*.c)
 target_sources(app PRIVATE ${app_sources})

--- a/tests/kernel/threads/thread_apis/CMakeLists.txt
+++ b/tests/kernel/threads/thread_apis/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.8.2)
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
-project(NONE)
+project(thread_apis)
 
 FILE(GLOB app_sources src/*.c)
 target_sources(app PRIVATE ${app_sources})

--- a/tests/kernel/threads/thread_init/CMakeLists.txt
+++ b/tests/kernel/threads/thread_init/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.8.2)
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
-project(NONE)
+project(thread_init)
 
 FILE(GLOB app_sources src/*.c)
 target_sources(app PRIVATE ${app_sources})

--- a/tests/kernel/tickless/tickless/CMakeLists.txt
+++ b/tests/kernel/tickless/tickless/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.8.2)
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
-project(NONE)
+project(tickless)
 
 target_sources(app PRIVATE src/main.c)
 target_sources_ifdef(CONFIG_ARM app PRIVATE src/timestamps.c)

--- a/tests/kernel/tickless/tickless_concept/CMakeLists.txt
+++ b/tests/kernel/tickless/tickless_concept/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.8.2)
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
-project(NONE)
+project(tickless_concept)
 
 FILE(GLOB app_sources src/*.c)
 target_sources(app PRIVATE ${app_sources})

--- a/tests/kernel/timer/timer_api/CMakeLists.txt
+++ b/tests/kernel/timer/timer_api/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.8.2)
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
-project(NONE)
+project(timer_api)
 
 FILE(GLOB app_sources src/*.c)
 target_sources(app PRIVATE ${app_sources})

--- a/tests/kernel/timer/timer_monotonic/CMakeLists.txt
+++ b/tests/kernel/timer/timer_monotonic/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.8.2)
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
-project(NONE)
+project(timer_monotonic)
 
 FILE(GLOB app_sources src/*.c)
 target_sources(app PRIVATE ${app_sources})

--- a/tests/kernel/workq/work_queue/CMakeLists.txt
+++ b/tests/kernel/workq/work_queue/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.8.2)
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
-project(NONE)
+project(work_queue)
 
 FILE(GLOB app_sources src/*.c)
 target_sources(app PRIVATE ${app_sources})

--- a/tests/kernel/workq/work_queue_api/CMakeLists.txt
+++ b/tests/kernel/workq/work_queue_api/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.8.2)
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
-project(NONE)
+project(work_queue_api)
 
 FILE(GLOB app_sources src/*.c)
 target_sources(app PRIVATE ${app_sources})

--- a/tests/kernel/xip/CMakeLists.txt
+++ b/tests/kernel/xip/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.8.2)
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
-project(NONE)
+project(xip)
 
 FILE(GLOB app_sources src/*.c)
 target_sources(app PRIVATE ${app_sources})

--- a/tests/lib/base64/CMakeLists.txt
+++ b/tests/lib/base64/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.8.2)
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
-project(NONE)
+project(base64)
 
 FILE(GLOB app_sources src/*.c)
 target_sources(app PRIVATE ${app_sources})

--- a/tests/lib/c_lib/CMakeLists.txt
+++ b/tests/lib/c_lib/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.8.2)
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
-project(NONE)
+project(c_lib)
 
 FILE(GLOB app_sources src/*.c)
 target_sources(app PRIVATE ${app_sources})

--- a/tests/lib/json/CMakeLists.txt
+++ b/tests/lib/json/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.8.2)
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
-project(NONE)
+project(json)
 
 FILE(GLOB app_sources src/*.c)
 target_sources(app PRIVATE ${app_sources})

--- a/tests/lib/mem_alloc/CMakeLists.txt
+++ b/tests/lib/mem_alloc/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.8.2)
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
-project(NONE)
+project(mem_alloc)
 
 FILE(GLOB app_sources src/*.c)
 target_sources(app PRIVATE ${app_sources})

--- a/tests/lib/rbtree/CMakeLists.txt
+++ b/tests/lib/rbtree/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 3.8.2)
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
-project(NONE)
+project(rbtree)
 
 target_sources(app PRIVATE src/main.c)

--- a/tests/lib/ringbuffer/CMakeLists.txt
+++ b/tests/lib/ringbuffer/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.8.2)
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
-project(NONE)
+project(ringbuffer)
 
 FILE(GLOB app_sources src/*.c)
 target_sources(app PRIVATE ${app_sources})

--- a/tests/lib/sprintf/CMakeLists.txt
+++ b/tests/lib/sprintf/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.8.2)
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
-project(NONE)
+project(sprintf)
 
 FILE(GLOB app_sources src/*.c)
 target_sources(app PRIVATE ${app_sources})

--- a/tests/misc/test_build/CMakeLists.txt
+++ b/tests/misc/test_build/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.8.2)
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
-project(NONE)
+project(test_build)
 
 FILE(GLOB app_sources src/*.c)
 target_sources(app PRIVATE ${app_sources})

--- a/tests/net/6lo/CMakeLists.txt
+++ b/tests/net/6lo/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.8.2)
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
-project(NONE)
+project(6lo)
 
 target_include_directories(app PRIVATE $ENV{ZEPHYR_BASE}/subsys/net/ip)
 FILE(GLOB app_sources src/*.c)

--- a/tests/net/all/CMakeLists.txt
+++ b/tests/net/all/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.8.2)
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
-project(NONE)
+project(all)
 
 FILE(GLOB app_sources src/*.c)
 target_sources(app PRIVATE ${app_sources})

--- a/tests/net/app/CMakeLists.txt
+++ b/tests/net/app/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.8.2)
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
-project(NONE)
+project(net_app)
 
 FILE(GLOB app_sources src/*.c)
 target_sources(app PRIVATE ${app_sources})

--- a/tests/net/arp/CMakeLists.txt
+++ b/tests/net/arp/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.8.2)
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
-project(NONE)
+project(arp)
 
 target_include_directories(
   app

--- a/tests/net/buf/CMakeLists.txt
+++ b/tests/net/buf/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.8.2)
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
-project(NONE)
+project(buf)
 
 target_include_directories(app PRIVATE $ENV{ZEPHYR_BASE}/subsys/net/ip)
 FILE(GLOB app_sources src/*.c)

--- a/tests/net/checksum_offload/CMakeLists.txt
+++ b/tests/net/checksum_offload/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.8.2)
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
-project(NONE)
+project(checksum_offload)
 
 target_include_directories(app PRIVATE $ENV{ZEPHYR_BASE}/subsys/net/ip)
 FILE(GLOB app_sources src/*.c)

--- a/tests/net/context/CMakeLists.txt
+++ b/tests/net/context/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.8.2)
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
-project(NONE)
+project(net_context)
 
 target_include_directories(app PRIVATE $ENV{ZEPHYR_BASE}/subsys/net/ip)
 FILE(GLOB app_sources src/*.c)

--- a/tests/net/dhcpv4/CMakeLists.txt
+++ b/tests/net/dhcpv4/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.8.2)
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
-project(NONE)
+project(dhcpv4)
 
 target_include_directories(app PRIVATE $ENV{ZEPHYR_BASE}/subsys/net/ip)
 FILE(GLOB app_sources src/*.c)

--- a/tests/net/ethernet_mgmt/CMakeLists.txt
+++ b/tests/net/ethernet_mgmt/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.8.2)
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
-project(NONE)
+project(ethernet_mgmt)
 
 FILE(GLOB app_sources src/*.c)
 target_sources(app PRIVATE ${app_sources})

--- a/tests/net/icmpv6/CMakeLists.txt
+++ b/tests/net/icmpv6/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.8.2)
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
-project(NONE)
+project(icmpv6)
 
 target_include_directories(app PRIVATE $ENV{ZEPHYR_BASE}/subsys/net/ip)
 FILE(GLOB app_sources src/*.c)

--- a/tests/net/ieee802154/crypto/CMakeLists.txt
+++ b/tests/net/ieee802154/crypto/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.8.2)
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
-project(NONE)
+project(crypto)
 
 target_include_directories(
   app

--- a/tests/net/ieee802154/fragment/CMakeLists.txt
+++ b/tests/net/ieee802154/fragment/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.8.2)
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
-project(NONE)
+project(fragment)
 
 target_include_directories(
   app

--- a/tests/net/ieee802154/l2/CMakeLists.txt
+++ b/tests/net/ieee802154/l2/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.8.2)
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
-project(NONE)
+project(l2)
 
 target_include_directories(
   app

--- a/tests/net/iface/CMakeLists.txt
+++ b/tests/net/iface/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.8.2)
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
-project(NONE)
+project(iface)
 
 target_include_directories(app PRIVATE $ENV{ZEPHYR_BASE}/subsys/net/ip)
 FILE(GLOB app_sources src/*.c)

--- a/tests/net/ip-addr/CMakeLists.txt
+++ b/tests/net/ip-addr/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.8.2)
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
-project(NONE)
+project(ip-addr)
 
 target_include_directories(app PRIVATE $ENV{ZEPHYR_BASE}/subsys/net/ip)
 FILE(GLOB app_sources src/*.c)

--- a/tests/net/ipv6/CMakeLists.txt
+++ b/tests/net/ipv6/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.8.2)
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
-project(NONE)
+project(ipv6)
 
 target_include_directories(app PRIVATE $ENV{ZEPHYR_BASE}/subsys/net/ip)
 FILE(GLOB app_sources src/*.c)

--- a/tests/net/ipv6_fragment/CMakeLists.txt
+++ b/tests/net/ipv6_fragment/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.8.2)
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
-project(NONE)
+project(ipv6_fragment)
 
 target_include_directories(app PRIVATE $ENV{ZEPHYR_BASE}/subsys/net/ip)
 FILE(GLOB app_sources src/*.c)

--- a/tests/net/lib/coap/CMakeLists.txt
+++ b/tests/net/lib/coap/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.8.2)
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
-project(NONE)
+project(coap)
 
 FILE(GLOB app_sources src/*.c)
 target_sources(app PRIVATE ${app_sources})

--- a/tests/net/lib/dns_packet/CMakeLists.txt
+++ b/tests/net/lib/dns_packet/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.8.2)
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
-project(NONE)
+project(dns_packet)
 
 FILE(GLOB app_sources src/*.c)
 target_sources(app PRIVATE ${app_sources})

--- a/tests/net/lib/dns_resolve/CMakeLists.txt
+++ b/tests/net/lib/dns_resolve/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.8.2)
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
-project(NONE)
+project(dns_resolve)
 
 target_include_directories(app PRIVATE $ENV{ZEPHYR_BASE}/subsys/net/ip)
 FILE(GLOB app_sources src/*.c)

--- a/tests/net/lib/http_header_fields/CMakeLists.txt
+++ b/tests/net/lib/http_header_fields/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.8.2)
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
-project(NONE)
+project(http_header_fields)
 
 target_include_directories(app PRIVATE $ENV{ZEPHYR_BASE}/subsys/net/ip)
 FILE(GLOB app_sources src/*.c)

--- a/tests/net/lib/mqtt_packet/CMakeLists.txt
+++ b/tests/net/lib/mqtt_packet/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.8.2)
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
-project(NONE)
+project(mqtt_packet)
 
 target_include_directories(app PRIVATE
 	$ENV{ZEPHYR_BASE}/subsys/net/ip

--- a/tests/net/lib/mqtt_publisher/CMakeLists.txt
+++ b/tests/net/lib/mqtt_publisher/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.8.2)
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
-project(NONE)
+project(mqtt_publisher)
 
 target_include_directories(app PRIVATE
 	$ENV{ZEPHYR_BASE}/subsys/net/ip

--- a/tests/net/lib/mqtt_subscriber/CMakeLists.txt
+++ b/tests/net/lib/mqtt_subscriber/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.8.2)
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
-project(NONE)
+project(mqtt_subscriber)
 
 target_include_directories(app PRIVATE
 	$ENV{ZEPHYR_BASE}/subsys/net/ip

--- a/tests/net/lib/tls_credentials/CMakeLists.txt
+++ b/tests/net/lib/tls_credentials/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.8.2)
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
-project(NONE)
+project(tls_credentials)
 
 target_include_directories(app PRIVATE $ENV{ZEPHYR_BASE}/subsys/net/lib/tls_credentials)
 FILE(GLOB app_sources src/*.c)

--- a/tests/net/mgmt/CMakeLists.txt
+++ b/tests/net/mgmt/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.8.2)
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
-project(NONE)
+project(mgmt)
 
 target_include_directories(app PRIVATE $ENV{ZEPHYR_BASE}/subsys/net/ip)
 FILE(GLOB app_sources src/*.c)

--- a/tests/net/mld/CMakeLists.txt
+++ b/tests/net/mld/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.8.2)
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
-project(NONE)
+project(mld)
 
 target_include_directories(app PRIVATE $ENV{ZEPHYR_BASE}/subsys/net/ip)
 FILE(GLOB app_sources src/*.c)

--- a/tests/net/neighbor/CMakeLists.txt
+++ b/tests/net/neighbor/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.8.2)
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
-project(NONE)
+project(neighbor)
 
 target_include_directories(app PRIVATE $ENV{ZEPHYR_BASE}/subsys/net/ip)
 FILE(GLOB app_sources src/*.c)

--- a/tests/net/net_pkt/CMakeLists.txt
+++ b/tests/net/net_pkt/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.8.2)
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
-project(NONE)
+project(net_pkt)
 
 target_include_directories(app PRIVATE $ENV{ZEPHYR_BASE}/subsys/net/ip)
 FILE(GLOB app_sources src/*.c)

--- a/tests/net/promiscuous/CMakeLists.txt
+++ b/tests/net/promiscuous/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.8.2)
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
-project(NONE)
+project(promiscuous)
 
 target_include_directories(app PRIVATE $ENV{ZEPHYR_BASE}/subsys/net/ip)
 FILE(GLOB app_sources src/*.c)

--- a/tests/net/ptp/clock/CMakeLists.txt
+++ b/tests/net/ptp/clock/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.8.2)
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
-project(NONE)
+project(clock)
 
 target_include_directories(app PRIVATE $ENV{ZEPHYR_BASE}/subsys/net/ip)
 FILE(GLOB app_sources src/*.c)

--- a/tests/net/route/CMakeLists.txt
+++ b/tests/net/route/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.8.2)
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
-project(NONE)
+project(route)
 
 target_include_directories(app PRIVATE $ENV{ZEPHYR_BASE}/subsys/net/ip)
 FILE(GLOB app_sources src/*.c)

--- a/tests/net/rpl/CMakeLists.txt
+++ b/tests/net/rpl/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.8.2)
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
-project(NONE)
+project(rpl)
 
 target_include_directories(app PRIVATE $ENV{ZEPHYR_BASE}/subsys/net/ip)
 FILE(GLOB app_sources src/*.c)

--- a/tests/net/socket/getaddrinfo/CMakeLists.txt
+++ b/tests/net/socket/getaddrinfo/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.8.2)
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
-project(NONE)
+project(getaddrinfo)
 
 FILE(GLOB app_sources src/*.c)
 target_sources(app PRIVATE ${app_sources})

--- a/tests/net/socket/tcp/CMakeLists.txt
+++ b/tests/net/socket/tcp/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.8.2)
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
-project(NONE)
+project(socket_tcp)
 
 target_include_directories(app PRIVATE $ENV{ZEPHYR_BASE}/subsys/net/ip)
 FILE(GLOB app_sources src/*.c)

--- a/tests/net/socket/udp/CMakeLists.txt
+++ b/tests/net/socket/udp/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.8.2)
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
-project(NONE)
+project(socket_udp)
 
 target_include_directories(app PRIVATE $ENV{ZEPHYR_BASE}/subsys/net/ip)
 FILE(GLOB app_sources src/*.c)

--- a/tests/net/tcp/CMakeLists.txt
+++ b/tests/net/tcp/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.8.2)
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
-project(NONE)
+project(tcp)
 
 target_include_directories(app PRIVATE $ENV{ZEPHYR_BASE}/subsys/net/ip)
 FILE(GLOB app_sources src/*.c)

--- a/tests/net/traffic_class/CMakeLists.txt
+++ b/tests/net/traffic_class/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.8.2)
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
-project(NONE)
+project(traffic_class)
 
 target_include_directories(app PRIVATE $ENV{ZEPHYR_BASE}/subsys/net/ip)
 FILE(GLOB app_sources src/*.c)

--- a/tests/net/trickle/CMakeLists.txt
+++ b/tests/net/trickle/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.8.2)
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
-project(NONE)
+project(trickle)
 
 target_include_directories(app PRIVATE $ENV{ZEPHYR_BASE}/subsys/net/ip)
 FILE(GLOB app_sources src/*.c)

--- a/tests/net/tx_timestamp/CMakeLists.txt
+++ b/tests/net/tx_timestamp/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.8.2)
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
-project(NONE)
+project(tx_timestamp)
 
 target_include_directories(app PRIVATE $ENV{ZEPHYR_BASE}/subsys/net/ip)
 FILE(GLOB app_sources src/*.c)

--- a/tests/net/udp/CMakeLists.txt
+++ b/tests/net/udp/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.8.2)
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
-project(NONE)
+project(udp)
 
 target_include_directories(app PRIVATE $ENV{ZEPHYR_BASE}/subsys/net/ip)
 FILE(GLOB app_sources src/*.c)

--- a/tests/net/utils/CMakeLists.txt
+++ b/tests/net/utils/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.8.2)
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
-project(NONE)
+project(utils)
 
 target_include_directories(app PRIVATE $ENV{ZEPHYR_BASE}/subsys/net/ip)
 FILE(GLOB app_sources src/*.c)

--- a/tests/net/vlan/CMakeLists.txt
+++ b/tests/net/vlan/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.8.2)
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
-project(NONE)
+project(vlan)
 
 target_include_directories(app PRIVATE $ENV{ZEPHYR_BASE}/subsys/net/ip)
 FILE(GLOB app_sources src/*.c)

--- a/tests/net/websocket/CMakeLists.txt
+++ b/tests/net/websocket/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.8.2)
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
-project(NONE)
+project(websocket)
 
 target_include_directories(app PRIVATE $ENV{ZEPHYR_BASE}/subsys/net/ip)
 FILE(GLOB app_sources src/*.c)

--- a/tests/posix/common/CMakeLists.txt
+++ b/tests/posix/common/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.8.2)
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
-project(NONE)
+project(posix_common)
 
 target_include_directories(app PRIVATE $ENV{ZEPHYR_BASE}/include/posix)
 FILE(GLOB app_sources src/*.c)

--- a/tests/posix/fs/CMakeLists.txt
+++ b/tests/posix/fs/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.8.2)
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
-project(NONE)
+project(fs)
 
 target_include_directories(app PRIVATE $ENV{ZEPHYR_BASE}/include/)
 

--- a/tests/power/multicore/arc/CMakeLists.txt
+++ b/tests/power/multicore/arc/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.8.2)
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
-project(NONE)
+project(arc)
 
 target_include_directories(app PRIVATE $ENV{ZEPHYR_BASE}/drivers)
 FILE(GLOB app_sources src/*.c)

--- a/tests/power/multicore/lmt/CMakeLists.txt
+++ b/tests/power/multicore/lmt/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.8.2)
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
-project(NONE)
+project(lmt)
 
 target_include_directories(app PRIVATE $ENV{ZEPHYR_BASE}/drivers)
 FILE(GLOB app_sources src/*.c)

--- a/tests/power/power_states/CMakeLists.txt
+++ b/tests/power/power_states/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.8.2)
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
-project(NONE)
+project(power_states)
 
 FILE(GLOB app_sources src/*.c)
 target_sources(app PRIVATE ${app_sources})

--- a/tests/shell/CMakeLists.txt
+++ b/tests/shell/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.8.2)
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
-project(NONE)
+project(shell)
 
 FILE(GLOB app_sources src/*.c)
 target_sources(app PRIVATE ${app_sources})

--- a/tests/subsys/dfu/img_util/CMakeLists.txt
+++ b/tests/subsys/dfu/img_util/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.8.2)
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
-project(NONE)
+project(img_util)
 
 FILE(GLOB app_sources src/*.c)
 target_sources(app PRIVATE ${app_sources})

--- a/tests/subsys/dfu/mcuboot/CMakeLists.txt
+++ b/tests/subsys/dfu/mcuboot/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.8.2)
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
-project(NONE)
+project(mcuboot)
 
 FILE(GLOB app_sources src/*.c)
 target_sources(app PRIVATE ${app_sources})

--- a/tests/subsys/fs/fat_fs_api/CMakeLists.txt
+++ b/tests/subsys/fs/fat_fs_api/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.8.2)
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
-project(NONE)
+project(fat_fs_api)
 
 FILE(GLOB app_sources src/*.c)
 target_sources(app PRIVATE ${app_sources})

--- a/tests/subsys/fs/fat_fs_dual_drive/CMakeLists.txt
+++ b/tests/subsys/fs/fat_fs_dual_drive/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.8.2)
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
-project(NONE)
+project(fat_fs_dual_drive)
 
 FILE(GLOB app_sources src/*.c)
 target_sources(app PRIVATE ${app_sources})

--- a/tests/subsys/fs/fcb/CMakeLists.txt
+++ b/tests/subsys/fs/fcb/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.8.2)
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
-project(NONE)
+project(fs_fcb)
 
 FILE(GLOB app_sources src/*.c)
 target_sources(app PRIVATE ${app_sources})

--- a/tests/subsys/fs/multi-fs/CMakeLists.txt
+++ b/tests/subsys/fs/multi-fs/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.8.2)
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
-project(NONE)
+project(multi-fs)
 
 zephyr_compile_definitions(
   -DTEST_FLASH_OFFSET=0

--- a/tests/subsys/fs/nffs_fs_api/basic/CMakeLists.txt
+++ b/tests/subsys/fs/nffs_fs_api/basic/CMakeLists.txt
@@ -8,7 +8,7 @@ elseif(BOARD STREQUAL nrf52840_pca10056)
 endif()
 
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
-project(NONE)
+project(basic)
 
 if(BOARD STREQUAL qemu_x86)
     zephyr_compile_definitions(

--- a/tests/subsys/fs/nffs_fs_api/cache/CMakeLists.txt
+++ b/tests/subsys/fs/nffs_fs_api/cache/CMakeLists.txt
@@ -8,7 +8,7 @@ elseif(BOARD STREQUAL nrf52840_pca10056)
 endif()
 
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
-project(NONE)
+project(cache)
 
 if(BOARD STREQUAL qemu_x86)
     zephyr_compile_definitions(

--- a/tests/subsys/fs/nffs_fs_api/large/CMakeLists.txt
+++ b/tests/subsys/fs/nffs_fs_api/large/CMakeLists.txt
@@ -8,7 +8,7 @@ elseif(BOARD STREQUAL nrf52840_pca10056)
 endif()
 
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
-project(NONE)
+project(large)
 
 if(BOARD STREQUAL qemu_x86)
     zephyr_compile_definitions(

--- a/tests/subsys/fs/nffs_fs_api/performance/CMakeLists.txt
+++ b/tests/subsys/fs/nffs_fs_api/performance/CMakeLists.txt
@@ -8,7 +8,7 @@ elseif(BOARD STREQUAL nrf52840_pca10056)
 endif()
 
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
-project(NONE)
+project(performance)
 
 if(BOARD STREQUAL qemu_x86)
     zephyr_compile_definitions(

--- a/tests/subsys/logging/log_core/CMakeLists.txt
+++ b/tests/subsys/logging/log_core/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.8.2)
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
-project(NONE)
+project(log_core)
 
 FILE(GLOB app_sources src/*.c)
 target_sources(app PRIVATE ${app_sources})

--- a/tests/subsys/logging/log_list/CMakeLists.txt
+++ b/tests/subsys/logging/log_list/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.8.2)
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
-project(NONE)
+project(log_list)
 
 FILE(GLOB app_sources src/*.c)
 target_sources(app PRIVATE ${app_sources})

--- a/tests/subsys/logging/log_msg/CMakeLists.txt
+++ b/tests/subsys/logging/log_msg/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.8.2)
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
-project(NONE)
+project(log_msg)
 
 FILE(GLOB app_sources src/*.c)
 target_sources(app PRIVATE ${app_sources})

--- a/tests/subsys/logging/logger-hook/CMakeLists.txt
+++ b/tests/subsys/logging/logger-hook/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.8.2)
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
-project(NONE)
+project(logger-hook)
 
 FILE(GLOB app_sources src/*.c)
 target_sources(app PRIVATE ${app_sources})

--- a/tests/subsys/settings/fcb/CMakeLists.txt
+++ b/tests/subsys/settings/fcb/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.8.2)
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
-project(NONE)
+project(settings_fcb)
 
 FILE(GLOB app_sources src/*.c ../src/*c)
 target_sources(app PRIVATE ${app_sources})

--- a/tests/subsys/settings/fcb_init/CMakeLists.txt
+++ b/tests/subsys/settings/fcb_init/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.8.2)
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
-project(NONE)
+project(fcb_init)
 
 FILE(GLOB app_sources src/*.c)
 target_sources(app PRIVATE ${app_sources})

--- a/tests/subsys/settings/nffs/CMakeLists.txt
+++ b/tests/subsys/settings/nffs/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.8.2)
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
-project(NONE)
+project(nffs)
 
 FILE(GLOB app_sources src/*.c ../src/*c)
 target_sources(app PRIVATE ${app_sources})

--- a/tests/subsys/storage/flash_map/CMakeLists.txt
+++ b/tests/subsys/storage/flash_map/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.8.2)
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
-project(NONE)
+project(flash_map)
 
 FILE(GLOB app_sources src/*.c)
 target_sources(app PRIVATE ${app_sources})

--- a/tests/subsys/usb/bos/CMakeLists.txt
+++ b/tests/subsys/usb/bos/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.8.2)
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
-project(NONE)
+project(bos)
 
 FILE(GLOB app_sources src/*.c)
 target_sources(app PRIVATE ${app_sources})

--- a/tests/subsys/usb/os_desc/CMakeLists.txt
+++ b/tests/subsys/usb/os_desc/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.8.2)
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
-project(NONE)
+project(os_desc)
 
 zephyr_library_include_directories(
 	${ZEPHYR_BASE}/subsys/usb/

--- a/tests/unit/bluetooth/at/CMakeLists.txt
+++ b/tests/unit/bluetooth/at/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.8.2)
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
-project(NONE)
+project(at)
 
 FILE(GLOB app_sources src/*.c)
 target_sources(app PRIVATE ${app_sources})

--- a/tests/unit/lib/crc/CMakeLists.txt
+++ b/tests/unit/lib/crc/CMakeLists.txt
@@ -1,3 +1,3 @@
-project(none)
+project(crc)
 include($ENV{ZEPHYR_BASE}/tests/unit/unittest.cmake)
 

--- a/tests/ztest/test/base/CMakeLists.txt
+++ b/tests/ztest/test/base/CMakeLists.txt
@@ -3,10 +3,10 @@ if(BOARD STREQUAL unit_testing)
   list(APPEND SOURCES src/main.c)
 
   include($ENV{ZEPHYR_BASE}/tests/unit/unittest.cmake)
-  project(none)
+  project(base)
 else()
   include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
-  project(NONE)
+  project(base)
 
   FILE(GLOB app_sources src/*.c)
   target_sources(app PRIVATE ${app_sources})

--- a/tests/ztest/test/mock/CMakeLists.txt
+++ b/tests/ztest/test/mock/CMakeLists.txt
@@ -3,10 +3,10 @@ if(BOARD STREQUAL unit_testing)
   list(APPEND SOURCES src/main.c)
 
   include($ENV{ZEPHYR_BASE}/tests/unit/unittest.cmake)
-  project(none)
+  project(mock)
 else()
   include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
-  project(NONE)
+  project(mock)
 
   FILE(GLOB app_sources src/*.c)
   target_sources(app PRIVATE ${app_sources})


### PR DESCRIPTION
When using an IDE (e.g. Eclipse, Qt Creator), the project name gets
displayed. This greatly simplifies the navigation between projects when
having many of them open at the same time. Naming every project "NONE"
defeats this functionality.

This patch tries to use sensible project names while not duplicating
too much of what is already represented in the path.

Signed-off-by: Reto Schneider <code@reto-schneider.ch>