### PR TITLE
A few more WiFi shell and sample fixes

### DIFF
--- a/samples/net/wifi/src/wifi_test.c
+++ b/samples/net/wifi/src/wifi_test.c
@@ -48,5 +48,5 @@ struct winc1500_gpio_configuration *winc1500_configure_gpios(void)
 
 void main(void)
 {
-	k_sleep(K_FOREVER);
+
 }

--- a/subsys/net/l2/wifi/wifi_shell.c
+++ b/subsys/net/l2/wifi/wifi_shell.c
@@ -162,9 +162,7 @@ static int cmd_wifi_connect(const struct shell *shell, size_t argc,
 		return -ENOEXEC;
 	}
 
-	cnx_params.ssid = &argv[1][1];
-
-	argv[1][cnx_params.ssid_length + 1] = '\0';
+	cnx_params.ssid = argv[1];
 
 	if ((idx < argc) && (strlen(argv[idx]) <= 2)) {
 		cnx_params.channel = strtol(argv[idx], &endptr, 10);


### PR DESCRIPTION
Previously, the wifi shell needed to remove the quotes from the
SSID parameter, passed in by the underlying shell.

The new shell is now able to parse quoted strings as arguments,
so this adjustment can be removed.

Otherwise, it results in a failure to connect to an AP, as the first
character of the SSID name is stripped off.

Also, the wifi sample was asserting in k_sleep when tested with CONFIG_ASSERT=y.
So, the call to k_sleep(K_FOREVER) is removed.