### PR TITLE
samples: net: wifi: Fix README, to account for new shell regression

### DIFF
--- a/samples/net/wifi/README.rst
+++ b/samples/net/wifi/README.rst
@@ -30,10 +30,9 @@ Sample console interaction
 
 .. code-block:: console
 
-   shell> select wifi
-   wifi> scan
+   shell> wifi scan
    Scan requested
-   wifi>
+   shell>
    Num  | SSID                             (len) | Chan | RSSI | Sec
    1    | kapoueh!                         8     | 1    | -93  | WPA/WPA2
    2    | mooooooh                         8     | 6    | -89  | WPA/WPA2
@@ -42,8 +41,8 @@ Sample console interaction
    ----------
    Scan request done
 
-   wifi> connect "gksu" 4 SecretStuff
+   shell> wifi connect "gksu" 4 SecretStuff
    Connection requested
-   wifi>
+   shell>
    Connected
-   wifi>
+   shell>


### PR DESCRIPTION
This updates documentation to account for the new shell which
does not support 'select' for command context anymore.

Note: Currently, I see an ugly "uart:~$" prompt, but I didn't want to put that in the README,
as I expect that would change depending on the console backend.
So, still showing the "shell>" prompt in the README.
What's most important is to show that 'wifi' now has to proceed every wifi command.
