### PR TITLE
clock_control: nRF5x: Workaround Errata [192] LFRC frequency offs

### DIFF
--- a/drivers/clock_control/nrf5_power_clock.c
+++ b/drivers/clock_control/nrf5_power_clock.c
@@ -312,6 +312,14 @@ static void _power_clock_isr(void *arg)
 		 */
 		NRF_CLOCK->INTENCLR = CLOCK_INTENCLR_HFCLKSTARTED_Msk;
 
+#if defined(CONFIG_SOC_SERIES_NRF52X)
+		/* NOTE: Errata [192] CLOCK: LFRC frequency offset after
+		 * calibration.
+		 * Calibration start, workaround.
+		 */
+		*(volatile u32_t *)0x40000C34 = 0x00000002;
+#endif /* CONFIG_SOC_SERIES_NRF52X */
+
 		/* Start Calibration */
 		NRF_CLOCK->TASKS_CAL = 1;
 	}
@@ -324,6 +332,14 @@ static void _power_clock_isr(void *arg)
 
 	if (done) {
 		int err;
+
+#if defined(CONFIG_SOC_SERIES_NRF52X)
+		/* NOTE: Errata [192] CLOCK: LFRC frequency offset after
+		 * calibration.
+		 * Calibration done, workaround.
+		 */
+		*(volatile u32_t *)0x40000C34 = 0x00000000;
+#endif /* CONFIG_SOC_SERIES_NRF52X */
 
 		NRF_CLOCK->EVENTS_DONE = 0;
 


### PR DESCRIPTION
Workaround the Errata [192] CLOCK: LFRC frequency offset
after calibration.

Signed-off-by: Vinayak Kariappa Chettimada <vich@nordicsemi.no>