### PR TITLE
arch: sam: Enable SEGGER RTT on all sam0 and same70 SoCs

### DIFF
--- a/soc/arm/atmel_sam/Kconfig
+++ b/soc/arm/atmel_sam/Kconfig
@@ -6,6 +6,7 @@
 config SOC_FAMILY_SAM
 	bool
 	# omit prompt to signify a "hidden" option
+	select HAS_SEGGER_RTT
 
 if SOC_FAMILY_SAM
 


### PR DESCRIPTION
All chip from Atmel's sam series can support SEGGER RTT.

Signed-off-by: qianfan Zhao <qianfanguijin@163.com>