### PR TITLE
boards: atsamd20_xpro: Add led/button info to DTS

### DIFF
--- a/boards/arm/atsamd20_xpro/atsamd20_xpro.dts
+++ b/boards/arm/atsamd20_xpro/atsamd20_xpro.dts
@@ -11,10 +11,31 @@
 	model = "SAM D20 Xplained Pro";
 	compatible = "atsamd20,xpro", "atmel,samd20j18", "atmel,samd20";
 
+	aliases {
+		led0 = &yellow_led;
+		sw0 = &user_button;
+	};
+
 	chosen {
 		zephyr,console = &sercom3;
 		zephyr,sram = &sram0;
 		zephyr,flash = &flash0;
+	};
+
+	leds {
+		compatible = "gpio-leds";
+		yellow_led: led_0 {
+			gpios = <&porta 14 0>;
+			label = "LED0";
+		};
+	};
+
+	buttons {
+		compatible = "gpio-keys";
+		user_button: button_0 {
+			gpios = <&porta 15 (GPIO_PUD_PULL_UP | GPIO_INT_ACTIVE_LOW)>;
+			label = "SW0";
+		};
 	};
 };
 


### PR DESCRIPTION
Add on-board LED and button definitions to the Atmel SAM D20 Xplained Pro (atsamd20_xpro) device tree.