### PR TITLE
arch: increase priv stack with built-in stack-overflow checking

### DIFF
--- a/arch/Kconfig
+++ b/arch/Kconfig
@@ -134,7 +134,7 @@ config USERSPACE
 
 config PRIVILEGED_STACK_SIZE
 	int "Size of privileged stack"
-	default 512 if MPU_STACK_GUARD
+	default 512 if MPU_STACK_GUARD || BUILTIN_STACK_GUARD
 	default 384 if ARC
 	default 256
 	depends on ARCH_HAS_USERSPACE


### PR DESCRIPTION
This commit increases the privilege stack size to 512 bytes,
when building with support for built-in stack-overflow checking.
This is in alignment with #10729, which increases the privilege
stack size when MPU-based stack guarding is enabled.

Signed-off-by: Ioannis Glaropoulos <Ioannis.Glaropoulos@nordicsemi.no>

@nashif @agross-linaro The patch is analogous to #10729, and applicable for ARMv8-M MCUs that have built-in support for stack-overflow checking.