### PR TITLE
samples: mesh: nrf52: to solve pending issues after merging PR:9997 

### DIFF
--- a/samples/boards/nrf52/mesh/onoff_level_lighting_vnd_app/src/main.c
+++ b/samples/boards/nrf52/mesh/onoff_level_lighting_vnd_app/src/main.c
@@ -171,51 +171,6 @@ K_TIMER_DEFINE(save_lightness_temp_last_state_timer,
 
 static void no_transition_work_handler(struct k_work *work)
 {
-	u16_t publisher;
-
-	/* publisher values is based on enum get_messages
-	 * which is defined in device_configuration.h
-	 */
-	publisher = (get_msg << 8) | last_get_msg;
-
-	switch (publisher) {
-	case PUB_ONOFF_1:
-	case PUB_ONOFF_2:
-	case PUB_ONOFF_3:
-		gen_onoff_publisher(&root_models[2]);
-		break;
-	case PUB_LEVEL_1:
-	case PUB_LEVEL_2:
-	case PUB_LEVEL_3:
-		gen_level_publisher(&root_models[4]);
-		break;
-	case PUB_LIGHT_ACTUAL_1:
-	case PUB_LIGHT_ACTUAL_2:
-		light_lightness_publisher(&root_models[11]);
-		break;
-	case PUB_LIGHT_LINEAR_1:
-	case PUB_LIGHT_LINEAR_2:
-		light_lightness_linear_publisher(&root_models[11]);
-		break;
-	case PUB_LIGHT_CTL_1:
-	case PUB_LIGHT_CTL_2:
-		light_ctl_publisher(&root_models[14]);
-		break;
-	}
-
-	if (!is_light_lightness_actual_state_published) {
-		light_lightness_publisher(&root_models[11]);
-	}
-
-	if (!is_light_ctl_state_published) {
-		light_ctl_publisher(&root_models[14]);
-	}
-
-	last_get_msg = NULL_GET;
-	get_msg = NULL_GET;
-	is_light_lightness_actual_state_published = false;
-	is_light_ctl_state_published = false;
-
 	/* If Lightness & Temperature values remains stable for
 	 * 10 Seconds then & then only get stored on SoC flash.
 	 */

--- a/samples/boards/nrf52/mesh/onoff_level_lighting_vnd_app/src/mesh/device_composition.h
+++ b/samples/boards/nrf52/mesh/onoff_level_lighting_vnd_app/src/mesh/device_composition.h
@@ -26,30 +26,6 @@
 #define CANNOT_SET_RANGE_MIN		0x01
 #define CANNOT_SET_RANGE_MAX		0x02
 
-enum get_messages {
-	NULL_GET = 0x00,
-	ONOFF_GET,
-	LEVEL_GET,
-	LIGHT_LIGHTNESS_ACTUAL_GET,
-	LIGHT_LIGHTNESS_LINEAR_GET,
-	LIGHT_CTL_GET
-};
-
-enum status {
-	PUB_ONOFF_1 = 0x0301,
-	PUB_ONOFF_2 = 0x0401,
-	PUB_ONOFF_3 = 0x0501,
-	PUB_LEVEL_1 = 0x0302,
-	PUB_LEVEL_2 = 0x0402,
-	PUB_LEVEL_3 = 0x0502,
-	PUB_LIGHT_ACTUAL_1 = 0x0403,
-	PUB_LIGHT_ACTUAL_2 = 0x0503,
-	PUB_LIGHT_LINEAR_1 = 0x0304,
-	PUB_LIGHT_LINEAR_2 = 0x0504,
-	PUB_LIGHT_CTL_1 = 0x0305,
-	PUB_LIGHT_CTL_2 = 0x0405
-};
-
 enum lightness {
 	ONPOWERUP = 0x01,
 	ONOFF,
@@ -193,14 +169,11 @@ extern struct bt_mesh_model s0_models[];
 
 extern const struct bt_mesh_comp comp;
 
-extern u8_t get_msg, last_get_msg;
-extern bool is_light_lightness_actual_state_published;
-extern bool is_light_ctl_state_published;
-
 void gen_onoff_publisher(struct bt_mesh_model *model);
 void gen_level_publisher(struct bt_mesh_model *model);
 void light_lightness_publisher(struct bt_mesh_model *model);
 void light_lightness_linear_publisher(struct bt_mesh_model *model);
 void light_ctl_publisher(struct bt_mesh_model *model);
+void light_ctl_temp_publisher(struct bt_mesh_model *model);
 
 #endif


### PR DESCRIPTION
https://github.com/zephyrproject-rtos/zephyr/pull/9997

If user aggresively vary the state then previous mechanism
failed to publish status of other bounded states since it
has to publish multiple things back to back.
This PR repair the things.

Signed-off-by: Vikrant More <vikrant8051@gmail.com>