### PR TITLE
Remove errno defines not used (introduced for bluetooth l2cap)

### DIFF
--- a/lib/libc/minimal/include/errno.h
+++ b/lib/libc/minimal/include/errno.h
@@ -126,12 +126,6 @@ extern "C" {
 #define ETIME 79   /* STREAMS timeout occurred */
 #define ENOMSG 80  /* Unexpected message type */
 
-/* specific encryption errno values */
-#define ENOKEY 126       /* Required key not available */
-#define EKEYEXPIRED 127  /* Required key not available */
-#define EKEYREVOKED 128  /* Key has been revoked */
-#define EKEYREJECTED 129 /* Key was rejected by service */
-
 #define EILSEQ 138 /* Illegal byte sequence */
 
 #ifdef __cplusplus


### PR DESCRIPTION
The error codes for key management where put into errno.h, however if we
build with newlib these defines are visibile (since we get errno.h from
newlib's headers).  Move these defines to l2cap as its the user of them.

Fixes: #10878

Signed-off-by: Kumar Gala <kumar.gala@linaro.org>