### PR TITLE
subsys: debug: tracing: Fix thread tracing

### DIFF
--- a/arch/arm/core/swap_helper.S
+++ b/arch/arm/core/swap_helper.S
@@ -46,7 +46,7 @@ SECTION_FUNC(TEXT, __pendsv)
 #ifdef CONFIG_TRACING
     /* Register the context switch */
     push {lr}
-    bl z_sys_trace_thread_switched_in
+    bl z_sys_trace_thread_switched_out
 #if defined(CONFIG_ARMV6_M_ARMV8_M_BASELINE)
     pop {r0}
     mov lr, r0
@@ -254,6 +254,18 @@ _thread_irq_disabled:
 #endif /* CONFIG_ARMV6_M_ARMV8_M_BASELINE */
     ldm sp!,{r0-r3} /* Load back regs ro to r4 */
 #endif /* CONFIG_EXECUTION_BENCHMARKING */
+
+#ifdef CONFIG_TRACING
+    /* Register the context switch */
+    push {lr}
+    bl z_sys_trace_thread_switched_in
+#if defined(CONFIG_ARMV6_M_ARMV8_M_BASELINE)
+    pop {r0}
+    mov lr, r0
+#else
+    pop {lr}
+#endif /* CONFIG_ARMV6_M_ARMV8_M_BASELINE */
+#endif /* CONFIG_TRACING */
 
     /* exc return */
     bx lr

--- a/arch/arm/include/kernel_arch_func.h
+++ b/arch/arm/include/kernel_arch_func.h
@@ -55,7 +55,13 @@ _arch_switch_to_main_thread(struct k_thread *main_thread,
 #endif
 	start_of_main_stack = (void *)STACK_ROUND_DOWN(start_of_main_stack);
 
+#ifdef CONFIG_TRACING
+	z_sys_trace_thread_switched_out();
+#endif
 	_current = main_thread;
+#ifdef CONFIG_TRACING
+	z_sys_trace_thread_switched_in();
+#endif
 
 	/* the ready queue cache already contains the main thread */
 

--- a/include/tracing.h
+++ b/include/tracing.h
@@ -23,6 +23,7 @@ void z_sys_trace_idle(void);
 void z_sys_trace_isr_enter(void);
 void z_sys_trace_isr_exit_to_scheduler(void);
 void z_sys_trace_thread_switched_in(void);
+void z_sys_trace_thread_switched_out(void);
 #endif
 
 #ifdef CONFIG_SEGGER_SYSTEMVIEW
@@ -121,6 +122,8 @@ void z_sys_trace_thread_switched_in(void);
 #define z_sys_trace_isr_exit_to_scheduler()
 
 #define z_sys_trace_thread_switched_in()
+
+#define z_sys_trace_thread_switched_out()
 
 #endif
 #endif

--- a/kernel/include/kswap.h
+++ b/kernel/include/kswap.h
@@ -90,12 +90,16 @@ static inline int _Swap(unsigned int key)
 	int ret;
 	_check_stack_sentinel();
 
+#ifndef CONFIG_ARM
 #ifdef CONFIG_TRACING
 	sys_trace_thread_switched_out();
 #endif
+#endif
 	ret = __swap(key);
+#ifndef CONFIG_ARM
 #ifdef CONFIG_TRACING
 	sys_trace_thread_switched_in();
+#endif
 #endif
 
 	return ret;

--- a/kernel/init.c
+++ b/kernel/init.c
@@ -279,6 +279,15 @@ static void prepare_multithreading(struct k_thread *dummy_thread)
 #ifdef CONFIG_ARCH_HAS_CUSTOM_SWAP_TO_MAIN
 	ARG_UNUSED(dummy_thread);
 #else
+
+#ifdef CONFIG_TRACING
+	sys_trace_thread_switched_out();
+#endif
+	_current = dummy_thread;
+#ifdef CONFIG_TRACING
+	sys_trace_thread_switched_in();
+#endif
+
 	/*
 	 * Initialize the current execution thread to permit a level of
 	 * debugging output if an exception should happen during kernel
@@ -286,9 +295,6 @@ static void prepare_multithreading(struct k_thread *dummy_thread)
 	 * fields of the dummy thread beyond those needed to identify it as a
 	 * dummy thread.
 	 */
-
-	_current = dummy_thread;
-
 	dummy_thread->base.user_options = K_ESSENTIAL;
 	dummy_thread->base.thread_state = _THREAD_DUMMY;
 #ifdef CONFIG_THREAD_STACK_INFO

--- a/kernel/sched.c
+++ b/kernel/sched.c
@@ -508,12 +508,24 @@ void *_get_next_switch_handle(void *interrupted)
 		if (_current != th) {
 			reset_time_slice();
 			_current_cpu->swap_ok = 0;
+#ifdef CONFIG_TRACING
+			sys_trace_thread_switched_out();
+#endif
 			_current = th;
+#ifdef CONFIG_TRACING
+			sys_trace_thread_switched_in();
+#endif
 		}
 	}
 
 #else
+#ifdef CONFIG_TRACING
+	sys_trace_thread_switched_out();
+#endif
 	_current = _get_next_ready_thread();
+#ifdef CONFIG_TRACING
+	sys_trace_thread_switched_in();
+#endif
 #endif
 
 	_check_stack_sentinel();

--- a/subsys/debug/tracing/sysview.c
+++ b/subsys/debug/tracing/sysview.c
@@ -39,6 +39,11 @@ void z_sys_trace_thread_switched_in(void)
 	sys_trace_thread_switched_in();
 }
 
+void z_sys_trace_thread_switched_out(void)
+{
+	sys_trace_thread_switched_out();
+}
+
 static void send_task_list_cb(void)
 {
 	struct k_thread *thread;


### PR DESCRIPTION
Change to fix [issue](https://github.com/zephyrproject-rtos/zephyr/issues/10870) connected with thread execution tracing. It fixes tracing with sys_thread_switched_in() and sys_thread_switched_out() - checked that after change thread which is switching out is thread which recently switched in (before it wasn't working properly). Change affects ARM architecture.