### PR TITLE
Bluetooth: Change l2cap accept callback return error

### DIFF
--- a/include/bluetooth/l2cap.h
+++ b/include/bluetooth/l2cap.h
@@ -249,7 +249,7 @@ struct bt_l2cap_server {
 	 *  Possible return values:
 	 *  -ENOMEM if no available space for new channel.
 	 *  -EACCES if application did not authorize the connection.
-	 *  -EKEYREJECTED if encryption key size is too short.
+	 *  -EPERM if encryption key size is too short.
 	 */
 	int (*accept)(struct bt_conn *conn, struct bt_l2cap_chan **chan);
 

--- a/subsys/bluetooth/host/l2cap.c
+++ b/subsys/bluetooth/host/l2cap.c
@@ -730,7 +730,7 @@ static u16_t le_err_to_result(int err)
 		return BT_L2CAP_LE_ERR_NO_RESOURCES;
 	case -EACCES:
 		return BT_L2CAP_LE_ERR_AUTHORIZATION;
-	case -EKEYREJECTED:
+	case -EPERM:
 		return BT_L2CAP_LE_ERR_KEY_SIZE;
 	default:
 		return BT_L2CAP_LE_ERR_UNACCEPT_PARAMS;

--- a/subsys/bluetooth/shell/l2cap.c
+++ b/subsys/bluetooth/shell/l2cap.c
@@ -175,7 +175,7 @@ static int l2cap_accept_policy(struct bt_conn *conn)
 		u8_t enc_key_size = bt_conn_enc_key_size(conn);
 
 		if (enc_key_size && enc_key_size < BT_ENC_KEY_SIZE_MAX) {
-			return -EKEYREJECTED;
+			return -EPERM;
 		}
 	} else if (l2cap_policy == L2CAP_POLICY_WHITELIST) {
 		for (i = 0; i < ARRAY_SIZE(l2cap_whitelist); i++) {


### PR DESCRIPTION
This changes EKEYREJECTED to EPERM due to newlib dependencies
errors.

Relates to #10879

Signed-off-by: Mariusz Skamra <mariusz.skamra@codecoup.pl>