### PR TITLE
doc: Remove quotes from Windows env var

### DIFF
--- a/doc/getting_started/toolchain_3rd_party_x_compilers.rst
+++ b/doc/getting_started/toolchain_3rd_party_x_compilers.rst
@@ -35,7 +35,7 @@ GNU ARM Embedded
 
       # Windows in cmd.exe
       set ZEPHYR_TOOLCHAIN_VARIANT=gnuarmemb
-      set GNUARMEMB_TOOLCHAIN_PATH="C:\gnu_arm_embedded"
+      set GNUARMEMB_TOOLCHAIN_PATH=C:\gnu_arm_embedded
 
 Intel ISSM
 **********


### PR DESCRIPTION
Windows requires that there are no quotes around environment variables,
remove the ones in the documentation.

@jimschm 

Fixes #10882