### PR TITLE
scripts: inline code generation with cogeno (and edts)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -492,6 +492,17 @@ if(EXISTS ${CMAKE_BINARY_DIR}/zephyr_modules.txt)
   set(ZEPHYR_CURRENT_MODULE_DIR)
 endif()
 
+# Add all generated zephyr sources in the same context as the zephyr library
+# is created.
+# Note: Assure all sub directories that might invoke source file generation
+#       are processed before.
+# The ZEPHYR_GENERATED_SOURCE_FILES property is for generated files of the
+# zepyhr library that can be added on the first build run. For files that are
+# dependent on a previous build run see GENERATED_KERNEL_SOURCE_FILES below.
+get_property(zephyr_generated_sources GLOBAL PROPERTY ZEPHYR_GENERATED_SOURCE_FILES)
+set_source_files_properties(${zephyr_generated_sources} PROPERTIES GENERATED 1)
+target_sources(zephyr PRIVATE ${zephyr_generated_sources})
+
 set(syscall_list_h ${CMAKE_CURRENT_BINARY_DIR}/include/generated/syscall_list.h)
 set(syscalls_json  ${CMAKE_CURRENT_BINARY_DIR}/misc/generated/syscalls.json)
 

--- a/cmake/cogeno.cmake
+++ b/cmake/cogeno.cmake
@@ -1,0 +1,317 @@
+# Copyright (c) 2018..2020 Bobby Noelte.
+# SPDX-License-Identifier: Apache-2.0
+
+# utilities
+function(cogeno_unique_target_name_from_filename filename target_name)
+    get_filename_component(basename ${filename} NAME)
+    string(REPLACE "." "_" x ${basename})
+    string(REPLACE "@" "_" x ${x})
+
+    string(MD5 unique_chars ${filename})
+
+    set(${target_name} cogeno_${x}_${unique_chars} PARENT_SCOPE)
+endfunction()
+
+# 1st priority: cogeno as a Zephyr module
+if(ZEPHYR_MODULES)
+    foreach(module ${ZEPHYR_MODULES})
+        set(full_path ${module}/cogeno/cogeno.py)
+        if(EXISTS ${full_path})
+            set(COGENO_BASE "${module}" CACHE INTERNAL "cogeno base directory")
+            set(COGENO_PY ${full_path})
+            break()
+        endif()
+    endforeach()
+endif()
+
+# 2nd priority: cogeno installed side by side to Zephyr
+# (but not as a Zephyr module)
+if(NOT EXISTS "${COGENO_PY}")
+    FILE(GLOB modules LIST_DIRECTORIES true "${ZEPHYR_BASE}/../*")
+    foreach(module ${modules})
+        set(full_path ${module}/cogeno/cogeno.py)
+        if(EXISTS ${full_path})
+            set(COGENO_BASE "${module}" CACHE INTERNAL "cogeno base directory")
+            set(COGENO_PY ${full_path})
+            break()
+        endif()
+    endforeach()
+endif()
+
+# 3rd prioritity: get cogeno from the git repository
+# (this is a work around as long as cogeno is not installed as one of above.)
+if(NOT EXISTS "${COGENO_PY}")
+    find_package(Git)
+    if(NOT GIT_FOUND)
+        message(FATAL_ERROR "git not found!")
+    endif()
+    execute_process(
+        COMMAND             ${GIT_EXECUTABLE} clone https://gitlab.com/b0661/cogeno.git --recursive
+        WORKING_DIRECTORY   "${ZEPHYR_BASE}/.."
+        OUTPUT_VARIABLE     git_output)
+    message(STATUS "${git_output}")
+    set(module "${ZEPHYR_BASE}/../cogeno")
+    if (EXISTS ${module})
+        execute_process(
+            COMMAND             ${GIT_EXECUTABLE} checkout master
+            WORKING_DIRECTORY   "${module}"
+            OUTPUT_VARIABLE     git_output)
+        message(STATUS "${git_output}")
+        set(full_path ${module}/cogeno/cogeno.py)
+        if(EXISTS ${full_path})
+            set(COGENO_BASE "${module}" CACHE INTERNAL "cogeno base directory")
+            set(COGENO_PY ${full_path})
+        endif()
+    endif()
+endif()
+
+# We also need a Python interpreter for cogeno
+if(EXISTS "${COGENO_PY}")
+    if(${CMAKE_VERSION} VERSION_LESS "3.12")
+        set(Python_ADDITIONAL_VERSIONS 3.7 3.6 3.5)
+        find_package(PythonInterp)
+
+        set(Python3_Interpreter_FOUND ${PYTHONINTERP_FOUND})
+        set(Python3_EXECUTABLE ${PYTHON_EXECUTABLE})
+        set(Python3_VERSION ${PYTHON_VERSION_STRING})
+    else()
+        # CMake >= 3.12
+        find_package(Python3 COMPONENTS Interpreter)
+    endif()
+
+    if(NOT ${Python3_Interpreter_FOUND})
+        message(FATAL_ERROR "Python 3 not found")
+    endif()
+
+    set(COGENO_EXECUTABLE "${Python3_EXECUTABLE}")
+    set(COGENO_EXECUTABLE_OPTION "${COGENO_PY}")
+endif()
+
+# 4th priority: cogeno installed on host
+if(NOT EXISTS "${COGENO_PY}")
+    find_program(COGENO_PY cogeno)
+
+    if(EXISTS "${COGENO_PY}")
+        set(COGENO_EXECUTABLE "${COGENO_PY}")
+        # We do not need the Python 3 interpreter
+        set(COGENO_EXECUTABLE_OPTION)
+    endif()
+endif()
+
+if(NOT EXISTS "${COGENO_PY}")
+    message(FATAL_ERROR "Cogeno not found - '${COGENO_PY}'.")
+endif()
+
+message(STATUS "Found cogeno: '${COGENO_PY}'.")
+
+# Get all the files that make up cogeno for dependency reasons.
+file(GLOB_RECURSE COGENO_SOURCES LIST_DIRECTORIES false
+      ${COGENO_BASE}/cogeno/*.py
+      ${COGENO_BASE}/cogeno/*.yaml
+      ${COGENO_BASE}/cogeno/*.c
+      ${COGENO_BASE}/cogeno/*.jinja2)
+
+function(target_sources_cogeno
+    target          # The CMake target that depends on the generated file
+    )
+
+    # defines
+    if(NOT COGENO_CONFIG)
+        set(COGENO_DEFINES
+            "\"BOARD=${BOARD}\""
+            "\"GENERATED_DTS_BOARD_H=${GENERATED_DTS_BOARD_H}\""
+            "\"GENERATED_DTS_BOARD_CONF=${GENERATED_DTS_BOARD_CONF}\"")
+    endif()
+    set(options)
+    set(oneValueArgs)
+    set(multiValueArgs COGENO_DEFINES DEPENDS)
+    cmake_parse_arguments(COGENO "${options}" "${oneValueArgs}"
+                          "${multiValueArgs}" ${ARGN})
+    # prepend -D to all defines
+    string(REGEX REPLACE "([^;]+)" "-D;\\1"
+           cogeno_opt_defines "${COGENO_COGENO_DEFINES}")
+
+    # --config
+    if(COGENO_CMAKECACHE)
+        set(cogeno_opt_cmakecache "--cmakecache" "${COGENO_CMAKECACHE}")
+    else()
+        set(cogeno_opt_cmakecache "--cmakecache" "${CMAKE_BINARY_DIR}/CMakeCache.txt")
+    endif()
+
+    # --config
+    if(COGENO_CONFIG)
+        set(cogeno_opt_config "--config" "${COGENO_CONFIG}")
+    else()
+        set(cogeno_opt_config "--config" "${PROJECT_BINARY_DIR}/.config")
+    endif()
+
+    # --dts
+    # --bindings
+    # --edts
+    if(COGENO_DTS)
+        set(cogeno_opt_dts "--dts" "${COGENO_DTS}")
+    else()
+        set(cogeno_opt_dts "--dts" "${PROJECT_BINARY_DIR}/${BOARD}.dts.pre.tmp")
+    endif()
+    if(COGENO_BINDINGS)
+        set(cogeno_opt_bindings "--bindings" ${COGENO_BINDINGS})
+    else()
+        string (REPLACE "?" ";" cogeno_opt_bindings "${DTS_ROOT_BINDINGS}")
+        set(cogeno_opt_bindings "--bindings"  ${cogeno_opt_bindings})
+    endif()
+    if(COGENO_EDTS)
+        set(cogeno_opt_edts "--edts" "${COGENO_EDTS}")
+    else()
+        set(cogeno_opt_edts "--edts" "${CMAKE_BINARY_DIR}/edts.json")
+    endif()
+
+    # --modules
+    if(COGENO_MODULES)
+        set(cogeno_opt_modules "--modules" ${COGENO_MODULES})
+    else()
+        if(EXISTS "${APPLICATION_SOURCE_DIR}/templates")
+           list(APPEND COGENO_MODULES "${APPLICATION_SOURCE_DIR}/templates")
+        endif()
+        if(EXISTS "${PROJECT_SOURCE_DIR}/templates")
+            list(APPEND COGENO_MODULES "${PROJECT_SOURCE_DIR}/templates")
+        endif()
+        if(COGENO_MODULES)
+            set(cogeno_opt_modules "--modules" ${COGENO_MODULES})
+        else()
+            set(cogeno_opt_modules)
+        endif()
+    endif()
+
+    # --templates
+    if(COGENO_TEMPLATES)
+        set(cogeno_opt_templates "--templates" ${COGENO_TEMPLATES})
+    else()
+        if(EXISTS "${APPLICATION_SOURCE_DIR}/templates")
+            list(APPEND COGENO_TEMPLATES "${APPLICATION_SOURCE_DIR}/templates")
+        endif()
+        if(EXISTS "${PROJECT_SOURCE_DIR}/templates")
+            list(APPEND COGENO_TEMPLATES "${PROJECT_SOURCE_DIR}/templates")
+        endif()
+        if(COGENO_TEMPLATES)
+            set(cogeno_opt_templates "--templates" ${COGENO_TEMPLATES})
+        else()
+            set(cogeno_opt_templates)
+        endif()
+    endif()
+
+    message(STATUS "Will generate for target ${target}")
+    # Generated file must be generated to the current binary directory.
+    # Otherwise this would trigger CMake issue #14633:
+    # https://gitlab.kitware.com/cmake/cmake/issues/14633
+    foreach(arg ${COGENO_UNPARSED_ARGUMENTS})
+        if(IS_ABSOLUTE ${arg})
+            set(template_file ${arg})
+            get_filename_component(generated_file_name ${arg} NAME)
+            set(generated_file ${CMAKE_CURRENT_BINARY_DIR}/${generated_file_name})
+        else()
+            set(template_file ${CMAKE_CURRENT_SOURCE_DIR}/${arg})
+            set(generated_file ${CMAKE_CURRENT_BINARY_DIR}/${arg})
+        endif()
+        get_filename_component(template_dir ${template_file} DIRECTORY)
+        get_filename_component(generated_dir ${generated_file} DIRECTORY)
+
+        if(IS_DIRECTORY ${template_file})
+            message(FATAL_ERROR "target_sources_cogeno() was called on a directory")
+        endif()
+
+        # Generate file from template
+        message(STATUS " from '${template_file}'")
+        message(STATUS " to   '${generated_file}'")
+        add_custom_command(
+            COMMENT "cogeno ${generated_file}"
+            OUTPUT ${generated_file}
+            MAIN_DEPENDENCY ${template_file}
+            DEPENDS
+            DEPENDS
+            ${COGENO_DEPENDS}
+            ${COGENO_SOURCES}
+            COMMAND
+            ${COGENO_EXECUTABLE}
+            ${COGENO_EXECUTABLE_OPTION}
+            --input "${template_file}"
+            --output "${generated_file}"
+            --log "${CMAKE_BINARY_DIR}${CMAKE_FILES_DIRECTORY}/cogeno.log"
+            --lock "${CMAKE_BINARY_DIR}${CMAKE_FILES_DIRECTORY}/cogeno.lock"
+            ${cogeno_opt_defines}
+            -D "\"APPLICATION_SOURCE_DIR=${APPLICATION_SOURCE_DIR}\""
+            -D "\"APPLICATION_BINARY_DIR=${APPLICATION_BINARY_DIR}\""
+            -D "\"PROJECT_NAME=${PROJECT_NAME}\""
+            -D "\"PROJECT_SOURCE_DIR=${PROJECT_SOURCE_DIR}\""
+            -D "\"PROJECT_BINARY_DIR=${PROJECT_BINARY_DIR}\""
+            -D "\"CMAKE_SOURCE_DIR=${CMAKE_SOURCE_DIR}\""
+            -D "\"CMAKE_BINARY_DIR=${CMAKE_BINARY_DIR}\""
+            -D "\"CMAKE_CURRENT_SOURCE_DIR=${CMAKE_CURRENT_SOURCE_DIR}\""
+            -D "\"CMAKE_CURRENT_BINARY_DIR=${CMAKE_CURRENT_BINARY_DIR}\""
+            -D "\"CMAKE_CURRENT_LIST_DIR=${CMAKE_CURRENT_LIST_DIR}\""
+            -D "\"CMAKE_FILES_DIRECTORY=${CMAKE_FILES_DIRECTORY}\""
+            -D "\"CMAKE_PROJECT_NAME=${CMAKE_PROJECT_NAME}\""
+            -D "\"CMAKE_SYSTEM=${CMAKE_SYSTEM}\""
+            -D "\"CMAKE_SYSTEM_NAME=${CMAKE_SYSTEM_NAME}\""
+            -D "\"CMAKE_SYSTEM_VERSION=${CMAKE_SYSTEM_VERSION}\""
+            -D "\"CMAKE_SYSTEM_PROCESSOR=${CMAKE_SYSTEM_PROCESSOR}\""
+            -D "\"CMAKE_C_COMPILER=${CMAKE_C_COMPILER}\""
+            -D "\"CMAKE_CXX_COMPILER=${CMAKE_CXX_COMPILER}\""
+            -D "\"CMAKE_COMPILER_IS_GNUCC=${CMAKE_COMPILER_IS_GNUCC}\""
+            -D "\"CMAKE_COMPILER_IS_GNUCXX=${CMAKE_COMPILER_IS_GNUCXX}\""
+            ${cogeno_opt_cmakecache}
+            ${cogeno_opt_config}
+            ${cogeno_opt_dts}
+            ${cogeno_opt_bindings}
+            ${cogeno_opt_edts}
+            ${cogeno_opt_modules}
+            ${cogeno_opt_templates}
+            WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
+        )
+
+        set_source_files_properties(${generated_file} PROPERTIES GENERATED 1)
+        if("${target}" STREQUAL "zephyr")
+          # Zephyr is special
+          cogeno_unique_target_name_from_filename(${generated_file} generated_target_name)
+          add_custom_target(${generated_target_name} DEPENDS ${generated_file})
+          add_dependencies(zephyr ${generated_target_name})
+          # Remember all the files that are generated for zephyr.
+          # target_sources(zephyr PRIVATE ${ZEPHYR_GENERATED_SOURCE_FILES})
+          # is executed in the top level Zephyr CMakeFile.txt context.
+          set_property(GLOBAL APPEND PROPERTY ZEPHYR_GENERATED_SOURCE_FILES ${generated_file})
+          # Add template directory to include path to allow includes with
+          # relative path in generated file to work
+          zephyr_include_directories(${template_dir})
+          # Add directory of generated file to include path to allow includes
+          # of generated header file with relative path.
+          zephyr_include_directories(${generated_dir})
+        else()
+          target_sources(${target} PRIVATE ${generated_file})
+          # Add template directory to include path to allow includes with
+          # relative path in generated file to work
+          target_include_directories(${target} PRIVATE ${template_dir})
+          # Add directory of generated file to include path to allow includes
+          # of generated header file with relative path.
+          target_include_directories(${target} PRIVATE ${generated_dir})
+        endif()
+    endforeach()
+endfunction()
+
+function(zephyr_sources_cogeno)
+    target_sources_cogeno(zephyr ${ARGN})
+endfunction()
+
+function(zephyr_sources_cogeno_ifdef feature_toggle)
+    if(${${feature_toggle}})
+        zephyr_sources_cogeno(${ARGN})
+    endif()
+endfunction()
+
+function(zephyr_library_sources_cogeno)
+    target_sources_cogeno(${ZEPHYR_CURRENT_LIBRARY} ${ARGN})
+endfunction()
+
+function(zephyr_library_sources_cogeno_ifdef feature_toggle)
+    if(${${feature_toggle}})
+        zephyr_library_sources_cogeno(${ARGN})
+    endif()
+endfunction()

--- a/cmake/extensions.cmake
+++ b/cmake/extensions.cmake
@@ -584,6 +584,13 @@ function(generate_inc_file_for_target
   generate_inc_file_for_gen_target(${target} ${source_file} ${generated_file} ${generated_target_name} ${ARGN})
 endfunction()
 
+# Code generation using cogeno provides:
+# - zephyr_sources_cogeno
+# - zephyr_sources_cogeno_ifdef
+# - zephyr_library_sources_cogeno
+# - zephyr_library_sources_cogeno_ifdef
+include(${ZEPHYR_BASE}/cmake/cogeno.cmake)
+
 # 1.4. board_*
 #
 # This section is for extensions which control Zephyr's board runners

--- a/doc/guides/cogeno.rst
+++ b/doc/guides/cogeno.rst
@@ -1,0 +1,207 @@
+..
+    Copyright (c) 2018..2020 Bobby Noelte
+    SPDX-License-Identifier: Apache-2.0
+
+.. _cogeno:
+
+Inline code generation
+######################
+
+For some repetitive or parameterized coding tasks, it's convenient to
+use a code generating tool to build code fragments, instead of writing
+(or editing) that source code by hand.
+
+Cogeno, the inline code generation tool, processes Python or Jinja2 "snippets"
+inlined in your source files. It can also access CMake build
+parameters and device tree information to generate source code automatically
+tailored and tuned to a specific project configuration.
+
+Cogeno can be used, for example, to generate source code that creates
+and fills data structures, adapts programming logic, creates
+configuration-specific code fragments, and more.
+
+About cogeno
+************
+
+Cogeno uses script snippets that are inlined in a source file as code generators.
+
+The inlined script snippets can contain any `Python 3 <https://www.python.org>`_
+or `Jinja2 <http://jinja.pocoo.org/>`_ code, they are regular scripts.
+
+All Python snippets in a source file and all Python snippets of
+included template files are treated as a python script with a common set of
+global Python variables. Global data created in one snippet can be used in
+another snippet that is processed later on. This feature could be used, for
+example, to customize included template files.
+
+Jinja2 snippets provide a - compared to Python - simplified script language.
+
+An inlined script snippet can always access the cogeno module. The cogeno
+module encapsulates and provides all the functions to retrieve information
+(options, device tree properties, CMake variables, config properties) and to
+output the generated code.
+
+Cogeno transforms files in a very simple way: it finds snippets of script code
+embedded in them, executes the script code, and places its output combined with
+the original file into the generated file. The original file can contain
+whatever text you like around the script code. It will usually be source code.
+
+For example, if you run this file through cogeno:
+
+::
+
+    /* This is my C file. */
+    ...
+    /**
+     * @code{.cogeno.py}
+     * fnames = ['DoSomething', 'DoAnotherThing', 'DoLastThing']
+     * for fn in fnames:
+     *     cogeno.outl(f'void {fn}();')
+     * @endcode{.cogeno.py}
+     */
+    /** @code{.cogeno.ins}@endcode */
+    ...
+
+it will come out like this:
+
+::
+
+    /* This is my C file. */
+    ...
+    /**
+     * @code{.cogeno.py}
+     * fnames = ['DoSomething', 'DoAnotherThing', 'DoLastThing']
+     * for fn in fnames:
+     *     cogeno.outl(f'void {fn}();')
+     * @endcode{.cogeno.py}
+     */
+    void DoSomething();
+    void DoAnotherThing();
+    void DoLastThing();
+    /** @code{.cogeno.ins}@endcode */
+    ...
+
+Lines with ``@code{.cogeno.py}`` or ``@code{.cogeno.ins}@endcode`` are marker lines.
+The lines between ``@code{.cogeno.py}`` and ``@endcode{.cogeno.py}`` are the
+generator Python code. The lines between ``@endcode{.cogeno.py}`` and
+``@code{.cogeno.ins}@endcode`` are the output from the generator.
+
+When cogeno runs, it discards the last generated Python output, executes the
+generator Python code, and writes its generated output into the file. All text
+lines outside of the special markers are passed through unchanged.
+
+The cogeno marker lines can contain any text in addition to the marker tokens.
+This makes it possible to hide the generator Python code from the source file.
+
+In the sample above, the entire chunk of Python code is a C comment, so the
+Python code can be left in place while the file is treated as C code.
+
+Cogeno is developed in its own `repository on GitLab <https://gitlab.com/b0661/cogeno>`_.
+
+Cogeno's documentation is available:
+
+- online at `Read the Docs <https://cogeno.readthedocs.io/en/latest/index.html>`_.
+- in the `repository on GitLab <https://gitlab.com/b0661/cogeno>`_.
+
+About cogeno modules
+********************
+
+Cogeno includes several modules to support specific code generation tasks.
+
+* Ccode module
+
+  The ccode module supports code generation for the C language. E.g. one of the
+  function allows to generate C defines from the content of the Extended
+  Device Tree Specification (EDTS) database.
+
+* CMake module
+
+  The cmake module provides access to CMake variables and the CMake cache.
+
+* Extended device tree specification module
+
+  The edts module provides access to the device tree specification data of
+  a project that is stored in the Extended Device Tree Specification (EDTS)
+  database.
+
+  The EDTS database may be loaded from a json file, stored to a json file or
+  extracted from the DTS files and the bindings yaml files of the project. The
+  EDTS database is automatically available to cogeno scripts. It can also be
+  used as a standalone tool.
+
+* Zephyr module
+
+  The Zephyr module provides functions to generate device driver instantiations.
+
+ ::
+
+    /* This file uses modules. */
+    ...
+    /**
+     * @code{.cogeno.py}
+     * cogeno.import_module('zephyr')
+     * zephyr.device_declare_single(device_config, driver_name, device_init,
+     *                              device_pm_control, device_level,
+     *                              device_prio, device_api, device_info)
+     * @endcode{.cogeno.py}
+     */
+    /** @code{.cogeno.ins}@endcode */
+    ...
+
+About cogeno templates
+**********************
+
+Code generation templates provide sophisticated code generation functions.
+
+Templates are simply text files. They may be hierarchical organized.
+There is always one top level template. All the other templates have
+to be included to gain access to the template's functions and variables.
+
+A template file usually contains normal text and templating commands
+intermixed. A bound sequence of templating commands is called a script
+snippet. As a special case a template file may be a script snippet
+as a whole.
+
+ ::
+
+    /* This file uses templates. */
+    ...
+    /**
+     * @code{.cogeno.py}
+     * template_in_var = 1
+     * cogeno.out_include('templates/template_tmpl.c')
+     * if template_out_var not None:
+     *     cogeno.outl("int x = %s;" % template_out_var)
+     * @endcode{.cogeno.py}
+     */
+    /** @code{.cogeno.ins}@endcode */
+    ...
+
+
+Inlince code generation in the build process
+********************************************
+
+Inline code generation has to be invoked as part of the build process.
+
+In Zephyr the processing of source files is controlled by the CMake extension functions:
+``zephyr_sources_cogeno(..)`` or ``zephyr_library_sources_cogeno(..)``. The generated
+source files are added to the Zephyr sources. During build the source files are
+processed by cogeno and the generated source files are written to the CMake
+binary directory. Zephyr uses `CMake <https://cmake.org/>`_ as the tool to manage building
+the project. A file that contains inline code generation has to be added to the project
+by one of the following commands in a :file:`CMakeList.txt` file:
+
+.. function:: zephyr_sources_cogeno(file [COGENO_DEFINES defines..] [DEPENDS target.. file..])
+
+.. function:: zephyr_sources_cogeno_ifdef(ifguard file [COGENO_DEFINES defines..] [DEPENDS target.. file..])
+
+.. function:: zephyr_library_sources_cogeno(file [COGENO_DEFINES defines..] [DEPENDS target.. file..])
+
+.. function:: zephyr_library_sources_cogeno_ifdef(ifguard file [COGENO_DEFINES defines..] [DEPENDS target.. file..])
+
+The arguments given by the ``COGENO_DEFINES`` keyword have to be of the form
+``define_name=define_value``. The arguments become globals in the python
+snippets and can be accessed by ``define_name``.
+
+Dependencies given by the ``DEPENDS`` key word are added to the dependencies
+of the generated file.

--- a/doc/guides/index.rst
+++ b/doc/guides/index.rst
@@ -15,6 +15,7 @@ User and Developer Guides
    documentation/index
    coccinelle.rst
    code-relocation.rst
+   cogeno.rst
    crypto/index
    debugging/index
    device_mgmt/index


### PR DESCRIPTION
# Overview

Extend Zephyr build system by inline code generation ([cogeno](https://cogeno.readthedocs.io/en/latest/)) with Python snippets in source files. As most information for drivers is taken from the device tree an extended device tree database (edts) is added to allow easy retrieval with Python.

The PR is the sucessor to PR #6762. It includes all of #6762 and the relevant commits from #9876.

The PR is completely self contained. Besides the changes to the CMake build system to allow [cogeno](https://cogeno.readthedocs.io/en/latest/) to be used as a script there are no other changes to the current code base.

# Motivation for or Use Case

The prime motivation is to be able to configure drivers on build time by the information from the device tree in a standardized way. Therefor there must be means to easily generate structured  data from device tree information at build time.

The EDTS database directly extracts the device tree information from the compiled DTS data. Inline code generation with Python snippets by cogeno is used to get this information and generate structured data to be compiled.

# Design Details

Python snippets that are inlined in a source file are used as generators. The tool to scan the source file for the Python snippets and process them is [cogeno](https://cogeno.readthedocs.io/en/latest/). [Cogeno](https://cogeno.readthedocs.io/en/latest/) is itself written in Python. [Cogeno](https://cogeno.readthedocs.io/en/latest/) used [Cog](https://nedbatchelder.com/code/cog/index.html) as it's starting point and has extended and rewritten it to provide specific generator functions.

The processing of source files is controlled by two CMake extension functions: zephyr_sources_cogeno(..) and zephyr_sources_cogeno_ifdef(..). During CMake configuration the source files are processed by cogeno and the generated source files are written to the CMake binary directory. The generated source files are added to the Zephyr sources.

The inlined Python snippets can contain any Python code, they are regular Python scripts. All Python snippets in a source file and all Python snippets of included template files are treated as a python script with a common set of global Python variables. Global data created in one snippet can be used in another snippet that is processed later on. This feature is e.g. used to customize included template files.

An inlined Python snippet can always access the [cogeno](https://cogeno.readthedocs.io/en/latest/) module. The [cogeno](https://cogeno.readthedocs.io/en/latest/) module encapsulates and provides all the functions to retrieve information (options, device tree properties, CMake variables, config properties) and to put out the generated code.

# Test Strategy

A working proof of concept for driver instantiation is #10888 (Edit: Has to be updated).

For the EDTS database the sanity check script from #9876 is used with some adaptations.

# PR History

This PR is the sucessor of several PRs:

  - #5799 'extract_dts_includes.py script'
    - This PR is the source of codegen and the extended DTS database. Codegen was added to be able to generate device data structures for pin controllers at build time from DTS data. The EDTS database was added to provide a more consistent access to device tree info. To enable easier review PRs #6762 (codegen) and #6761 (EDTS database/ DTS extraction) were split out. #5799 was also used as a test platform to prove the viability of inline code generation using a very complex driver - the pin controller driver for STM32F0. To have an easy review of the simpler prove of concept drivers also #9163 (Device instantiation) was split out.
  - #6761 '[WIP] scripts: extract_dts_includes.py: enhance'
    - This PR described a way to extract DTS info to the EDTS database using the extract_dts_includes.py script. It was superseded by #9876 which still uses the extract_dts_includes.py script but improved the API of the extended DTS database that holds the DTS info after extraction.
  - #6762 'scripts: add Zephyr inline code generation with Python'
    - This PR contained the inline code generation tool codegen. In the beginning codegen used the DTS info extraction from #6761. Later on it used the sucessor #9876.
  - #9163 'drivers: use codegen for device instantiation'
    - As already descrived in this PR the easy instantiation of drivers using inline code generation was shown. It's pendant that fits to this PR is #10888.
  - #9876 'script/dts: Generate Extended Device Tree database'
    - This PR as the sucessor to #6761 enhanced the EDTS database API and internal structure.
  - #10885 - 2018: ''
    - In this PR the codegen tool (#6762) and the extended DTS database (#9876, #6761) is re-integrated. The additions/ improvements that were done in #9876 are also re-integrated. With the current PR the extraction of DTS info was made independent from the extract_dts_includes.py script to make this PR a self contained change that does not effect the current code base. The EDTS database now includes an internal DTS extraction function that extracts directly from the compiled DTS file.
  - #10885 - NOW: ''
    - Codegen transfered to [cogeno](https://cogeno.readthedocs.io/en/latest/), a standalone tool with it's own repository.  


Signed-off-by: Bobby Noelte <b0661n0e17e@gmail.com>