### PR TITLE
samples: mesh: nrf52: minor improvements

### DIFF
--- a/samples/boards/nrf52/mesh/onoff_level_lighting_vnd_app/src/mesh/device_composition.c
+++ b/samples/boards/nrf52/mesh/onoff_level_lighting_vnd_app/src/mesh/device_composition.c
@@ -96,9 +96,6 @@ struct generic_level_state gen_level_srv_s0_user_data = {
 };
 /* Definitions of models user data (End) */
 
-u8_t get_msg, last_get_msg;
-bool is_light_lightness_actual_state_published;
-bool is_light_ctl_state_published;
 static struct bt_mesh_elem elements[];
 
 /* message handlers (Start) */
@@ -898,8 +895,6 @@ void light_lightness_publisher(struct bt_mesh_model *model)
 		err = bt_mesh_model_publish(model);
 		if (err) {
 			printk("bt_mesh_model_publish err %d\n", err);
-		} else {
-			is_light_lightness_actual_state_published = true;
 		}
 	}
 }

--- a/samples/boards/nrf52/mesh/onoff_level_lighting_vnd_app/src/mesh/device_composition.h
+++ b/samples/boards/nrf52/mesh/onoff_level_lighting_vnd_app/src/mesh/device_composition.h
@@ -26,34 +26,6 @@
 #define CANNOT_SET_RANGE_MIN		0x01
 #define CANNOT_SET_RANGE_MAX		0x02
 
-enum lightness {
-	ONPOWERUP = 0x01,
-	ONOFF,
-	LEVEL,
-	DELTA_LEVEL,
-	ACTUAL,
-	LINEAR,
-	CTL,
-	IGNORE
-};
-
-enum temperature {
-	ONOFF_TEMP = 0x01,
-	LEVEL_TEMP,
-	CTL_TEMP,
-	IGNORE_TEMP
-};
-
-enum target_values {
-	ONOFF_TARGET = 0x01,
-	LEVEL_LIGHT_TARGET,
-	LIGHT_ACTUAL_TARGET,
-	LIGHT_LINEAR_TARGET,
-	LIGHT_CTL_TARGET,
-	LEVEL_TEMP_TARGET,
-	LIGHT_CTL_TEMP_TARGET
-};
-
 struct generic_onoff_state {
 	u8_t onoff;
 	u8_t target_onoff;

--- a/samples/boards/nrf52/mesh/onoff_level_lighting_vnd_app/src/mesh/state_binding.c
+++ b/samples/boards/nrf52/mesh/onoff_level_lighting_vnd_app/src/mesh/state_binding.c
@@ -11,6 +11,7 @@
 #include "common.h"
 #include "ble_mesh.h"
 #include "device_composition.h"
+#include "state_binding.h"
 #include "transition.h"
 
 #define MINDIFF 2.25e-308
@@ -256,7 +257,7 @@ void calculate_lightness_target_values(u8_t type)
 	set_light_ctl_temp_target_value = true;
 
 	switch (type) {
-	case ONOFF_TARGET:
+	case ONOFF:
 		if (gen_onoff_srv_root_user_data.target_onoff == 0) {
 			tmp16 = 0;
 		} else {
@@ -264,19 +265,19 @@ void calculate_lightness_target_values(u8_t type)
 		}
 
 		break;
-	case LEVEL_LIGHT_TARGET:
+	case LEVEL:
 		tmp16 = gen_level_srv_root_user_data.target_level + 32768;
 		break;
-	case LIGHT_ACTUAL_TARGET:
+	case ACTUAL:
 		tmp16 = light_lightness_srv_user_data.target_actual;
 		break;
-	case LIGHT_LINEAR_TARGET:
+	case LINEAR:
 		tmp16 = (u16_t) 65535 *
 			sqrt(((float)
 			      light_lightness_srv_user_data.target_linear /
 			      65535));
 		break;
-	case LIGHT_CTL_TARGET:
+	case CTL:
 		set_light_ctl_temp_target_value = false;
 
 		tmp16 = light_ctl_srv_user_data.target_lightness;
@@ -322,11 +323,11 @@ void calculate_temp_target_values(u8_t type)
 	set_light_ctl_delta_uv_target_value = true;
 
 	switch (type) {
-	case LEVEL_TEMP_TARGET:
+	case LEVEL_TEMP:
 		light_ctl_srv_user_data.target_temp =
 			level_to_light_ctl_temp(gen_level_srv_s0_user_data.target_level);
 		break;
-	case LIGHT_CTL_TEMP_TARGET:
+	case CTL_TEMP:
 		set_light_ctl_delta_uv_target_value = false;
 
 		gen_level_srv_s0_user_data.target_level = (s16_t)

--- a/samples/boards/nrf52/mesh/onoff_level_lighting_vnd_app/src/mesh/state_binding.h
+++ b/samples/boards/nrf52/mesh/onoff_level_lighting_vnd_app/src/mesh/state_binding.h
@@ -8,6 +8,22 @@
 #ifndef _STATE_BINDING_H
 #define _STATE_BINDING_H
 
+enum state_binding {
+	ONPOWERUP = 0x01,
+	ONOFF,
+	LEVEL,
+	DELTA_LEVEL,
+	ACTUAL,
+	LINEAR,
+	CTL,
+	IGNORE,
+
+	ONOFF_TEMP,
+	LEVEL_TEMP,
+	CTL_TEMP,
+	IGNORE_TEMP
+};
+
 void state_binding(u8_t lightness, u8_t temperature);
 void calculate_lightness_target_values(u8_t type);
 void calculate_temp_target_values(u8_t type);

--- a/samples/boards/nrf52/mesh/onoff_level_lighting_vnd_app/src/mesh/transition.c
+++ b/samples/boards/nrf52/mesh/onoff_level_lighting_vnd_app/src/mesh/transition.c
@@ -106,7 +106,7 @@ void onoff_tt_values(struct generic_onoff_state *state)
 		state->transition->quo_tt = state->transition->total_duration /
 						state->transition->counter;
 
-		calculate_lightness_target_values(ONOFF_TARGET);
+		calculate_lightness_target_values(ONOFF);
 	}
 }
 
@@ -132,9 +132,9 @@ void level_tt_values(struct generic_level_state *state)
 						counter;
 
 		if (state == &gen_level_srv_root_user_data) {
-			calculate_lightness_target_values(LEVEL_LIGHT_TARGET);
+			calculate_lightness_target_values(LEVEL);
 		} else if (state == &gen_level_srv_s0_user_data) {
-			calculate_temp_target_values(LEVEL_TEMP_TARGET);
+			calculate_temp_target_values(LEVEL_TEMP);
 		}
 	}
 
@@ -158,7 +158,7 @@ void light_lightness_actual_tt_values(struct light_lightness_state *state)
 		state->transition->quo_tt = state->transition->total_duration /
 						counter;
 
-		calculate_lightness_target_values(LIGHT_ACTUAL_TARGET);
+		calculate_lightness_target_values(ACTUAL);
 	}
 
 	state->tt_delta_actual =
@@ -182,7 +182,7 @@ void light_lightness_linear_tt_values(struct light_lightness_state *state)
 		state->transition->quo_tt = state->transition->total_duration /
 						counter;
 
-		calculate_lightness_target_values(LIGHT_LINEAR_TARGET);
+		calculate_lightness_target_values(LINEAR);
 	}
 
 	state->tt_delta_linear =
@@ -207,7 +207,7 @@ void light_ctl_tt_values(struct light_ctl_state *state)
 		state->transition->quo_tt = state->transition->total_duration /
 						counter;
 
-		calculate_lightness_target_values(LIGHT_CTL_TARGET);
+		calculate_lightness_target_values(CTL);
 	}
 
 	state->tt_delta_lightness =
@@ -240,7 +240,7 @@ void light_ctl_temp_tt_values(struct light_ctl_state *state)
 		state->transition->quo_tt = state->transition->total_duration /
 						counter;
 
-		calculate_temp_target_values(LIGHT_CTL_TEMP_TARGET);
+		calculate_temp_target_values(CTL_TEMP);
 	}
 
 	state->tt_delta_temp = ((float) (state->temp - state->target_temp) /

--- a/samples/boards/nrf52/mesh/onoff_level_lighting_vnd_app/src/storage.h
+++ b/samples/boards/nrf52/mesh/onoff_level_lighting_vnd_app/src/storage.h
@@ -8,7 +8,7 @@
 #ifndef _STORAGE_H
 #define _STORAGE_H
 
-enum app_variables_id {
+enum ps_variables_id {
 	RESET_COUNTER = 0x01,
 	GEN_DEF_TRANS_TIME_STATE,
 	GEN_ONPOWERUP_STATE,


### PR DESCRIPTION
1. Redefined & relocate enums to improve code readability.
2.  Defined common publisher i.e. gen_level_publisher() for
    all three gen. level related message handlers.
3. With this commit, some prime Servers would unsolicitedly
    publishes their states values if there is no transition is in progress.