### PR TITLE
riscv32: linker: Keep vectors section in ROMABLE_REGION

### DIFF
--- a/include/arch/riscv32/common/linker.ld
+++ b/include/arch/riscv32/common/linker.ld
@@ -62,18 +62,15 @@ SECTIONS
 		*(.iplt)
 	}
 
-    GROUP_START(ROM)
+    GROUP_START(ROMABLE_REGION)
+
     _image_rom_start = .;
 
     SECTION_PROLOGUE(_VECTOR_SECTION_NAME,,)
     {
 		. = ALIGN(4);
 		KEEP(*(.vectors.*))
-    } GROUP_LINK_IN(ROM)
-
-    GROUP_END(ROM)
-
-    GROUP_START(ROMABLE_REGION)
+    } GROUP_LINK_IN(ROMABLE_REGION)
 
     SECTION_PROLOGUE(_RESET_SECTION_NAME,,)
     {


### PR DESCRIPTION
For non XIP based RISC-V devices, vectors section needs to be placed
in RAM rather than in ROM. This would require us to place the section
under ROMABLE_REGION alias instead of the hardcoded ROM region.

Signed-off-by: Manivannan Sadhasivam <manivannanece23@gmail.com>