### PR TITLE
shell: fix assert in wildcard plugin

### DIFF
--- a/subsys/shell/shell_wildcard.c
+++ b/subsys/shell/shell_wildcard.c
@@ -14,7 +14,7 @@ static void subcmd_get(const struct shell_cmd_entry *cmd,
 		       struct shell_static_entry *d_entry)
 {
 	__ASSERT_NO_MSG(entry != NULL);
-	__ASSERT_NO_MSG(st_entry != NULL);
+	__ASSERT_NO_MSG(d_entry != NULL);
 
 	if (cmd == NULL) {
 		*entry = NULL;


### PR DESCRIPTION
Fixing a variable name in assert check in a function subcmd_get.

Signed-off-by: Jakub Rzeszutko <jakub.rzeszutko@nordicsemi.no>