### PR TITLE
dts/arm/st: f4: gpioh node is defined twice for stm32f405

### DIFF
--- a/dts/arm/st/f4/stm32f405.dtsi
+++ b/dts/arm/st/f4/stm32f405.dtsi
@@ -30,15 +30,6 @@
 				label = "GPIOG";
 			};
 
-			gpioh: gpio@40021c00 {
-				compatible = "st,stm32-gpio";
-				gpio-controller;
-				#gpio-cells = <2>;
-				reg = <0x40021c00 0x400>;
-				clocks = <&rcc STM32_CLOCK_BUS_AHB1 0x00000040>;
-				label = "GPIOH";
-			};
-
 			gpioi: gpio@40022000 {
 				compatible = "st,stm32-gpio";
 				gpio-controller;


### PR DESCRIPTION
Remove duplicated gpioh node in stm32f405.dtsi,
as already defined in stm32f4.dtsi.


Signed-off-by: Erwan Gouriou <erwan.gouriou@linaro.org>