### PR TITLE
kernel: mem_domain: minor typo fixes

### DIFF
--- a/doc/kernel/usermode/usermode_sharedmem.rst
+++ b/doc/kernel/usermode/usermode_sharedmem.rst
@@ -27,11 +27,11 @@ partitions available to a thread.  Specifically processors with MPU's
 cannot support the same number of partitions as a MMU.
 
 This specific implementation adds a wrapper to simplify the programmers
-task of using the app_memmory subsystem through the use of macros and
-a python script to generate the linker script.  The linker script provides
+task of using the app_memory subsystem through the use of macros and
+a python script to generate the linker script. The linker script provides
 the proper alignment for processors requiring power of two boundaries.
 Without the wrapper, a developer is required to implement custom
-linker scripts for each processor the project.
+linker scripts for each processor in the project.
 
 The general usage is as follows. Define CONFIG_APP_SHARED_MEM=y in the
 proj.conf file in the project folder.  Include app_memory/app_memdomain.h

--- a/kernel/mem_domain.c
+++ b/kernel/mem_domain.c
@@ -118,7 +118,9 @@ void k_mem_domain_destroy(struct k_mem_domain *domain)
 
 	key = irq_lock();
 
-	/* Handle architecture specifc destroy only if it is the current thread*/
+	/* Handle architecture-specific destroy
+	 * only if it is the current thread.
+	 */
 	if (_current->mem_domain_info.mem_domain == domain) {
 		_arch_mem_domain_destroy(domain);
 	}
@@ -191,7 +193,9 @@ void k_mem_domain_remove_partition(struct k_mem_domain *domain,
 	/* Assert if not found */
 	__ASSERT(p_idx < max_partitions, "");
 
-	/* Handle architecture specifc remove only if it is the current thread*/
+	/* Handle architecture-specific remove
+	 * only if it is the current thread.
+	 */
 	if (_current->mem_domain_info.mem_domain == domain) {
 		_arch_mem_domain_partition_remove(domain, p_idx);
 	}


### PR DESCRIPTION
Testing the TRIVIAL PR feature. 

Fixing a few minor typo fixes in kernel/mem_domain.c
and the respective documentation section.

Signed-off-by: Ioannis Glaropoulos <Ioannis.Glaropoulos@nordicsemi.no>