### PR TITLE
cmake: openamp: Fix OpenAMP sample

### DIFF
--- a/samples/subsys/ipc/ipm_mcux/CMakeLists.txt
+++ b/samples/subsys/ipc/ipm_mcux/CMakeLists.txt
@@ -7,6 +7,11 @@ set(BOARD lpcxpresso54114_m4)
 
 
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
+
+if(NOT ("${BOARD}" STREQUAL "lpcxpresso54114_m4"))
+  message(FATAL_ERROR "${BOARD} was specified, but this sample only supports lpcxpresso54114_m4")
+endif()
+
 include(ExternalProject)
 
 ExternalProject_Add(
@@ -14,8 +19,6 @@ ExternalProject_Add(
   SOURCE_DIR ${APPLICATION_SOURCE_DIR}/remote
   INSTALL_COMMAND ""      # This particular build system has no install command
   BUILD_BYPRODUCTS "${CMAKE_CURRENT_BINARY_DIR}/ipm_mcux_remote-prefix/src/ipm_mcux_remote-build/zephyr/zephyr.bin"
-  CMAKE_CACHE_ARGS -DBOARD:STRING=${BOARD}
-  # NB: Do we need to pass on more CMake variables?
 )
 
 project(ipm_mcux)

--- a/samples/subsys/ipc/ipm_mcux/remote/CMakeLists.txt
+++ b/samples/subsys/ipc/ipm_mcux/remote/CMakeLists.txt
@@ -8,4 +8,8 @@ set(BOARD lpcxpresso54114_m0)
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
 project(ipm_mcux_remote)
 
+if(NOT ("${BOARD}" STREQUAL "lpcxpresso54114_m0"))
+  message(FATAL_ERROR "${BOARD} was specified, but this sample only supports lpcxpresso54114_m0")
+endif()
+
 target_sources(app PRIVATE src/main_remote.c)

--- a/samples/subsys/ipc/openamp/CMakeLists.txt
+++ b/samples/subsys/ipc/openamp/CMakeLists.txt
@@ -8,6 +8,10 @@ set(BOARD lpcxpresso54114_m4)
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
 project(openamp)
 
+if(NOT ("${BOARD}" STREQUAL "lpcxpresso54114_m4"))
+  message(FATAL_ERROR "${BOARD} was specified, but this sample only supports lpcxpresso54114_m4")
+endif()
+
 enable_language(C ASM)
 
 # Location of external dependencies:
@@ -25,7 +29,6 @@ ExternalProject_Add(
   SOURCE_DIR ${APPLICATION_SOURCE_DIR}/remote
   INSTALL_COMMAND ""      # This particular build system has no install command
   BUILD_BYPRODUCTS "${CMAKE_CURRENT_BINARY_DIR}/openamp_remote-prefix/src/openamp_remote-build/zephyr/zephyr.bin"
-  CMAKE_CACHE_ARGS -DBOARD:STRING=${BOARD}
   # NB: Do we need to pass on more CMake variables?
 )
 add_dependencies(core_m0_inc_target openamp_remote)

--- a/samples/subsys/ipc/openamp/remote/CMakeLists.txt
+++ b/samples/subsys/ipc/openamp/remote/CMakeLists.txt
@@ -10,6 +10,10 @@ set(PLATFORM_DIR "${CMAKE_CURRENT_SOURCE_DIR}/../platform")
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
 project(openamp_remote)
 
+if(NOT ("${BOARD}" STREQUAL "lpcxpresso54114_m0"))
+  message(FATAL_ERROR "${BOARD} was specified, but this sample only supports lpcxpresso54114_m0")
+endif()
+
 target_sources(app PRIVATE src/main_remote.c
 	       ${PLATFORM_DIR}/platform.c
 	       ${PLATFORM_DIR}/resource_table.c


### PR DESCRIPTION
Stop specifying that the OpenAMP 'remote' app should use the same
board as the root app.

Also, add assertions to make sure that the user does not try to
override the board's that are specified in the app build scripts.

This fixes #10345

Signed-off-by: Sebastian Bøe <sebastian.boe@nordicsemi.no>