### PR TITLE
Add thread name and floating point context to openocd offsets

### DIFF
--- a/samples/synchronization/sample.yaml
+++ b/samples/synchronization/sample.yaml
@@ -12,3 +12,14 @@ tests:
       regex:
         - "threadA: Hello World from (.*)!"
         - "threadB: Hello World from (.*)!"
+  sample.synchronization.openocd:
+    tags: kernel synchronization
+    extra_configs:
+      - CONFIG_OPENOCD_SUPPORT=y
+    arch_exclude: posix xtensa
+    harness: console
+    harness_config:
+      type: multi_line
+      regex:
+        - "thread_a: Hello World from (.*)!"
+        - "thread_b: Hello World from (.*)!"

--- a/subsys/debug/Kconfig
+++ b/subsys/debug/Kconfig
@@ -183,6 +183,7 @@ config EXCEPTION_STACK_TRACE
 config OPENOCD_SUPPORT
 	bool "OpenOCD support [EXPERIMENTAL]"
 	select THREAD_MONITOR
+	select THREAD_NAME
 	help
 	  This option exports an array of offsets to kernel structs, used by
 	  OpenOCD to determine the state of running threads.  (This option

--- a/subsys/debug/openocd.c
+++ b/subsys/debug/openocd.c
@@ -17,6 +17,7 @@ enum {
 	OPENOCD_OFFSET_T_USER_OPTIONS,
 	OPENOCD_OFFSET_T_PRIO,
 	OPENOCD_OFFSET_T_STACK_PTR,
+	OPENOCD_OFFSET_T_NAME,
 };
 
 /* Forward-compatibility notes: 1) Increment OPENOCD_OFFSET_VERSION element
@@ -27,7 +28,7 @@ enum {
 __attribute__((used, section(".openocd_dbg")))
 size_t _kernel_openocd_offsets[] = {
 	/* Version 0 starts */
-	[OPENOCD_OFFSET_VERSION] = 0,
+	[OPENOCD_OFFSET_VERSION] = 1,
 	[OPENOCD_OFFSET_K_CURR_THREAD] = offsetof(struct _kernel, current),
 	[OPENOCD_OFFSET_K_THREADS] = offsetof(struct _kernel, threads),
 	[OPENOCD_OFFSET_T_ENTRY] = offsetof(struct k_thread, entry),
@@ -60,6 +61,8 @@ size_t _kernel_openocd_offsets[] = {
 	[OPENOCD_OFFSET_T_STACK_PTR] = 0xffffffff,
 #endif
 	/* Version 0 ends */
+
+	[OPENOCD_OFFSET_T_NAME] = offsetof(struct k_thread, name),
 };
 
 __attribute__((used, section(".openocd_dbg")))

--- a/subsys/debug/openocd.c
+++ b/subsys/debug/openocd.c
@@ -6,6 +6,8 @@
 
 #include <kernel_structs.h>
 
+#define OPENOCD_UNIMPLEMENTED	0xffffffff
+
 #if defined(CONFIG_OPENOCD_SUPPORT) && defined(CONFIG_THREAD_MONITOR)
 enum {
 	OPENOCD_OFFSET_VERSION,
@@ -18,6 +20,9 @@ enum {
 	OPENOCD_OFFSET_T_PRIO,
 	OPENOCD_OFFSET_T_STACK_PTR,
 	OPENOCD_OFFSET_T_NAME,
+	OPENOCD_OFFSET_T_ARCH,
+	OPENOCD_OFFSET_T_PREEMPT_FLOAT,
+	OPENOCD_OFFSET_T_COOP_FLOAT,
 };
 
 /* Forward-compatibility notes: 1) Increment OPENOCD_OFFSET_VERSION element
@@ -53,16 +58,29 @@ size_t _kernel_openocd_offsets[] = {
 	[OPENOCD_OFFSET_T_STACK_PTR] = offsetof(struct k_thread,
 						callee_saved.sp),
 #else
-	/* Use 0xffffffff as a special value so that OpenOCD knows that
-	 * obtaining the stack pointer is not possible on this particular
-	 * architecture.
+	/* Use a special value so that OpenOCD knows that obtaining the stack
+	 * pointer is not possible on this particular architecture.
 	 */
 #warning Please define OPENOCD_OFFSET_T_STACK_PTR for this architecture
-	[OPENOCD_OFFSET_T_STACK_PTR] = 0xffffffff,
+	[OPENOCD_OFFSET_T_STACK_PTR] = OPENOCD_UNIMPLEMENTED,
 #endif
 	/* Version 0 ends */
 
 	[OPENOCD_OFFSET_T_NAME] = offsetof(struct k_thread, name),
+	[OPENOCD_OFFSET_T_ARCH] = offsetof(struct k_thread, arch),
+#if defined(CONFIG_FLOAT) && defined(CONFIG_ARM)
+	[OPENOCD_OFFSET_T_PREEMPT_FLOAT] = offsetof(struct _thread_arch,
+						    preempt_float),
+	[OPENOCD_OFFSET_T_COOP_FLOAT] = OPENOCD_UNIMPLEMENTED,
+#elif defined(CONFIG_FLOAT) && defined(CONFIG_X86)
+	[OPENOCD_OFFSET_T_PREEMPT_FLOAT] = offsetof(struct _thread_arch,
+						    preempFloatReg),
+	[OPENOCD_OFFSET_T_COOP_FLOAT] = offsetof(struct _thread_arch,
+						 coopFloatReg),
+#else
+	[OPENOCD_OFFSET_T_PREEMPT_FLOAT] = OPENOCD_UNIMPLEMENTED,
+	[OPENOCD_OFFSET_T_COOP_FLOAT] = OPENOCD_UNIMPLEMENTED,
+#endif
 };
 
 __attribute__((used, section(".openocd_dbg")))


### PR DESCRIPTION
Adds the thread name and floating point context to the openocd offsets array so openocd and pyocd can access them.