### PR TITLE
C++: Fix vtable with libstdc++

### DIFF
--- a/subsys/cpp/cpp_vtable.cpp
+++ b/subsys/cpp/cpp_vtable.cpp
@@ -14,6 +14,7 @@
  * @brief basic virtual tables required for classes to build
  *
  */
+#if !defined(CONFIG_LIB_CPLUSPLUS)
 
 namespace __cxxabiv1 {
 	class __class_type_info {
@@ -25,3 +26,4 @@ namespace __cxxabiv1 {
 	void __class_type_info::dummy() { }  // causes the vtable to get created here
 	void __si_class_type_info::dummy() { }  // causes the vtable to get created here
 };
+#endif // !defined(CONFIG_LIB_CPLUSPLUS)


### PR DESCRIPTION
When linking with C++ standard library (libstdc++), __cxxabiv1::__class_type_info is already defined inside.
If user code contains virtual classes, __cxxabiv1::__class_type_info is defined twice.