### PR TITLE
soc: Kconfig: Add BPROT and MPU to list of supported HW.

### DIFF
--- a/soc/arm/nordic_nrf/Kconfig.peripherals
+++ b/soc/arm/nordic_nrf/Kconfig.peripherals
@@ -11,6 +11,9 @@ config HAS_HW_NRF_ACL
 config HAS_HW_NRF_ADC
 	bool
 
+config HAS_HW_NRF_BPROT
+	bool
+
 config HAS_HW_NRF_CC310
 	bool
 
@@ -57,6 +60,9 @@ config HAS_HW_NRF_I2S
 	bool
 
 config HAS_HW_NRF_LPCOMP
+	bool
+
+config HAS_HW_NRF_MPU
 	bool
 
 config HAS_HW_NRF_MWU

--- a/soc/arm/nordic_nrf/nrf51/Kconfig.soc
+++ b/soc/arm/nordic_nrf/nrf51/Kconfig.soc
@@ -17,6 +17,7 @@ config SOC_NRF51822_QFAA
 	select HAS_HW_NRF_GPIO0
 	select HAS_HW_NRF_GPIOTE
 	select HAS_HW_NRF_LPCOMP
+	select HAS_HW_NRF_MPU
 	select HAS_HW_NRF_QDEC
 	select HAS_HW_NRF_PPI
 	select HAS_HW_NRF_RNG
@@ -42,6 +43,7 @@ config SOC_NRF51822_QFAB
 	select HAS_HW_NRF_GPIO0
 	select HAS_HW_NRF_GPIOTE
 	select HAS_HW_NRF_LPCOMP
+	select HAS_HW_NRF_MPU
 	select HAS_HW_NRF_QDEC
 	select HAS_HW_NRF_PPI
 	select HAS_HW_NRF_RNG
@@ -67,6 +69,7 @@ config SOC_NRF51822_QFAC
 	select HAS_HW_NRF_GPIO0
 	select HAS_HW_NRF_GPIOTE
 	select HAS_HW_NRF_LPCOMP
+	select HAS_HW_NRF_MPU
 	select HAS_HW_NRF_QDEC
 	select HAS_HW_NRF_PPI
 	select HAS_HW_NRF_RNG

--- a/soc/arm/nordic_nrf/nrf52/Kconfig.soc
+++ b/soc/arm/nordic_nrf/nrf52/Kconfig.soc
@@ -8,6 +8,7 @@
 config SOC_NRF52810
 	depends on SOC_SERIES_NRF52X
 	bool
+	select HAS_HW_NRF_BPROT
 	select HAS_HW_NRF_CCM
 	select HAS_HW_NRF_CLOCK
 	select HAS_HW_NRF_COMP
@@ -47,6 +48,7 @@ config SOC_NRF52832
 	bool
 	select SOC_COMPATIBLE_NRF52832
 	select CPU_HAS_FPU
+	select HAS_HW_NRF_BPROT
 	select HAS_HW_NRF_CCM
 	select HAS_HW_NRF_CLOCK
 	select HAS_HW_NRF_COMP


### PR DESCRIPTION
soc: Kconfig: Add BPROT and MPU to list of supported HW.
Add configuration values for HAS_HW_NRF_BPROT and HAS_HW_NRF_MPU.
Select these configurations where applicable.

Signed-off-by: Håkon Øye Amundsen <haakon.amundsen@nordicsemi.no>