### PR TITLE
Add support for stm32f4xx GPTP

### DIFF
--- a/drivers/ethernet/Kconfig.stm32_hal
+++ b/drivers/ethernet/Kconfig.stm32_hal
@@ -79,5 +79,14 @@ config ETH_STM32_HAL_MAC5
 	  This is the byte 5 of the MAC address.
 endif
 
+config PTP_CLOCK_STM32
+	bool "STM32 PTP clock driver support"
+	default y
+	depends on PTP_CLOCK && NET_PKT_TIMESTAMP
+	help
+	  Enable STM32 PTP clock support.
+
+
+
 endif # ETH_STM32_HAL
 

--- a/drivers/ethernet/eth_stm32_hal.c
+++ b/drivers/ethernet/eth_stm32_hal.c
@@ -156,7 +156,7 @@ static int eth_tx(struct net_if *iface, struct net_pkt *pkt)
                 }
         }
         else{
-                LOG_ERR("HAL_ETH_TransmitFrame failed");
+		LOG_ERR("HAL_ETH_TransmitFrame failed");
 		res = -EIO;
 		goto error;
         }
@@ -199,7 +199,7 @@ static struct net_pkt *eth_rx(struct device *dev)
 	u8_t *dma_buffer;
 	int i;
 #if defined(CONFIG_PTP_CLOCK_STM32)
-        ETH_PTP_TIMESTAM time_stamp;
+	ETH_PTP_TIMESTAM time_stamp;
 #endif
 
 	__ASSERT_NO_MSG(dev != NULL);
@@ -473,9 +473,9 @@ static void eth_iface_init(struct net_if *iface)
 #if defined(CONFIG_PTP_CLOCK_STM32)
 	HAL_ETH_DMATxDescListInit(heth, dma_tx_desc_tab,
 				  &dma_tx_buffer[0][0], ETH_TXBUFNB, true);
-        ETH_PTPStart(heth, ETH_PTP_FineUpdate); 
+	ETH_PTPStart(heth, ETH_PTP_FineUpdate); 
 #else
-        HAL_ETH_DMATxDescListInit(heth, dma_tx_desc_tab,
+	HAL_ETH_DMATxDescListInit(heth, dma_tx_desc_tab,
 	        		  &dma_tx_buffer[0][0], ETH_TXBUFNB, false);
 #endif
 
@@ -605,58 +605,58 @@ static int ptp_clock_stm32_set(struct device *dev, struct net_ptp_time *tm)
 
 static int ptp_clock_stm32_get(struct device *dev, struct net_ptp_time *tm)
 {
-        struct ptp_eth_stm32_hal_dev_data *ptp_dev_data = dev->driver_data;
-        struct eth_stm32_hal_dev_data *dev_data = ptp_dev_data->eth_dev_data;
-        ETH_HandleTypeDef *heth;
+	struct ptp_eth_stm32_hal_dev_data *ptp_dev_data = dev->driver_data;
+	struct eth_stm32_hal_dev_data *dev_data = ptp_dev_data->eth_dev_data;
+	ETH_HandleTypeDef *heth;
 
-        heth = &dev_data->heth;
+	heth = &dev_data->heth;
 
-        tm->nanosecond = ETH_PTPSubSecond2NanoSecond(ETH_GetPTPRegister(heth, ETH_PTPTSLR));
-        tm->second = ETH_GetPTPRegister(heth, ETH_PTPTSHR);
+	tm->nanosecond = ETH_PTPSubSecond2NanoSecond(ETH_GetPTPRegister(heth, ETH_PTPTSLR));
+	tm->second = ETH_GetPTPRegister(heth, ETH_PTPTSHR);
 
 	return 0;
 }
 
 static int ptp_clock_stm32_adjust(struct device *dev, int increment)
 {
-        uint32_t Sign;
-        uint32_t SecondValue;
-        uint32_t NanoSecondValue;
-        uint32_t SubSecondValue;
-        uint32_t addend;
-        struct ptp_eth_stm32_hal_dev_data *ptp_dev_data = dev->driver_data;
-        struct eth_stm32_hal_dev_data *dev_data = ptp_dev_data->eth_dev_data;
-        ETH_HandleTypeDef *heth;
+	uint32_t Sign;
+	uint32_t SecondValue;
+	uint32_t NanoSecondValue;
+	uint32_t SubSecondValue;
+	uint32_t addend;
+	struct ptp_eth_stm32_hal_dev_data *ptp_dev_data = dev->driver_data;
+	struct eth_stm32_hal_dev_data *dev_data = ptp_dev_data->eth_dev_data;
+	ETH_HandleTypeDef *heth;
 
-        heth = &dev_data->heth;
+	heth = &dev_data->heth;
 
-        if ((increment <= -NSEC_PER_SEC) || (increment >= NSEC_PER_SEC)) {
+	if ((increment <= -NSEC_PER_SEC) || (increment >= NSEC_PER_SEC)) {
 		return -EINVAL;
-        }
+	}
 
-        if (increment < 0) {
-                Sign = ETH_PTP_NegativeTime;
-                SecondValue = 0;
-                NanoSecondValue = -increment;
-        } else {
-                Sign = ETH_PTP_PositiveTime;
-                SecondValue = 0;
-                NanoSecondValue = increment;
-        }
+	if (increment < 0) {
+	        Sign = ETH_PTP_NegativeTime;
+	        SecondValue = 0;
+	        NanoSecondValue = -increment;
+	} else {
+	        Sign = ETH_PTP_PositiveTime;
+	        SecondValue = 0;
+	        NanoSecondValue = increment;
+	}
 
-        SubSecondValue = ETH_PTPNanoSecond2SubSecond(NanoSecondValue);
- 
-        addend = ETH_GetPTPRegister(heth, ETH_PTPTSAR);
+	SubSecondValue = ETH_PTPNanoSecond2SubSecond(NanoSecondValue);
 
-        while(ETH_GetPTPFlagStatus(heth, ETH_PTP_FLAG_TSSTU) == SET);
-        while(ETH_GetPTPFlagStatus(heth, ETH_PTP_FLAG_TSSTI) == SET);
+	addend = ETH_GetPTPRegister(heth, ETH_PTPTSAR);
 
-        ETH_SetPTPTimeStampUpdate(heth, Sign, SecondValue, SubSecondValue);
-        ETH_EnablePTPTimeStampUpdate(heth);
-        while(ETH_GetPTPFlagStatus(heth, ETH_PTP_FLAG_TSSTU) == SET);      
+	while(ETH_GetPTPFlagStatus(heth, ETH_PTP_FLAG_TSSTU) == SET);
+	while(ETH_GetPTPFlagStatus(heth, ETH_PTP_FLAG_TSSTI) == SET);
+
+	ETH_SetPTPTimeStampUpdate(heth, Sign, SecondValue, SubSecondValue);
+	ETH_EnablePTPTimeStampUpdate(heth);
+	while(ETH_GetPTPFlagStatus(heth, ETH_PTP_FLAG_TSSTU) == SET);      
         
         ETH_SetPTPTimeStampAddend(heth, addend);
-        ETH_EnablePTPTimeStampAddend(heth);
+	ETH_EnablePTPTimeStampAddend(heth);
        
 	return 0;
 }

--- a/drivers/ethernet/eth_stm32_hal.c
+++ b/drivers/ethernet/eth_stm32_hal.c
@@ -211,11 +211,11 @@ static struct net_pkt *eth_rx(struct device *dev)
 	heth = &dev_data->heth;
 
 #if defined(CONFIG_PTP_CLOCK_STM32)
-        if (HAL_ETH_PtpGetReceivedFrame_IT(heth, &time_stamp) != HAL_OK) {
+	if (HAL_ETH_PtpGetReceivedFrame_IT(heth, &time_stamp) != HAL_OK) {
 		return NULL;
-        }
+	}
 #else
-        if (HAL_ETH_GetReceivedFrame_IT(heth) != HAL_OK) {
+	if (HAL_ETH_GetReceivedFrame_IT(heth) != HAL_OK) {
 		return NULL;
 	}
 #endif
@@ -504,7 +504,7 @@ static enum ethernet_hw_caps eth_stm32_hal_get_capabilities(struct device *dev)
 #if defined(CONFIG_PTP_CLOCK_STM32)
 	        | ETHERNET_PTP
 #endif
-                ;
+		;
 }
 
 #if defined(CONFIG_PTP_CLOCK_STM32)
@@ -654,8 +654,8 @@ static int ptp_clock_stm32_adjust(struct device *dev, int increment)
 	ETH_SetPTPTimeStampUpdate(heth, Sign, SecondValue, SubSecondValue);
 	ETH_EnablePTPTimeStampUpdate(heth);
 	while(ETH_GetPTPFlagStatus(heth, ETH_PTP_FLAG_TSSTU) == SET);      
-        
-        ETH_SetPTPTimeStampAddend(heth, addend);
+
+	ETH_SetPTPTimeStampAddend(heth, addend);
 	ETH_EnablePTPTimeStampAddend(heth);
        
 	return 0;

--- a/drivers/ethernet/eth_stm32_hal_priv.h
+++ b/drivers/ethernet/eth_stm32_hal_priv.h
@@ -16,6 +16,10 @@
 #define ETH_RX_BUF_SIZE	ETH_MAX_PACKET_SIZE /* buffer size for receive */
 #define ETH_TX_BUF_SIZE	ETH_MAX_PACKET_SIZE /* buffer size for transmit */
 
+/*Definition of zhe ptp */
+#define ETH_STM32_PTP_ADDEND    0x4C19EF00
+#define ETH_STM32_PTP_INCREMENT 43
+
 /* Device constant configuration parameters */
 struct eth_stm32_hal_dev_cfg {
 	void (*config_func)(void);
@@ -32,6 +36,9 @@ struct eth_stm32_hal_dev_data {
 	ETH_HandleTypeDef heth;
 	/* clock device */
 	struct device *clock;
+#if defined(CONFIG_PTP_CLOCK_STM32)
+	struct device *ptp_clock;
+#endif
 	struct k_mutex tx_mutex;
 	struct k_sem rx_int_sem;
 	K_THREAD_STACK_MEMBER(rx_thread_stack,


### PR DESCRIPTION
add gptp support at stm32f4xx eth driver.
the PR is experimental, It has some problems. I hope you can review the code and give some Suggestions for improvement.
there are some limitations
Experiment with one master and one slave, the error time is always 4ms.
set TSSARFE of ETH_PTPTSCR register to time stamp snapshot for all received frames enable，because if not set this , can not get the timestamp when receive.
Adjusting clock frequency is not working.
Previous message can view in PR #10126