### PR TITLE
doc: Linux installation: Add gcc and gcc_mulitlib for Ubuntu

### DIFF
--- a/doc/getting_started/installation_linux.rst
+++ b/doc/getting_started/installation_linux.rst
@@ -74,7 +74,8 @@ On Ubuntu:
 
    sudo apt-get install --no-install-recommends git cmake ninja-build gperf \
      ccache dfu-util device-tree-compiler wget \
-     python3-pip python3-setuptools python3-wheel xz-utils file make
+     python3-pip python3-setuptools python3-wheel xz-utils file make gcc \
+     gcc-multilib
 
 On Fedora:
 


### PR DESCRIPTION
In 0d811b9aee6a6410f73fdfb4d4072d4d16b05a52 the gcc-mulitlib package
was removed from the Ubuntu list of packages to install.
Seems this may be creating some confusion for some developers (see
comments in #10243)
Let's add it back.

Signed-off-by: Alberto Escolar Piedras <alpi@oticon.com>