### PR TITLE
drivers: usb: nordic: Fix max packet size handling

### DIFF
--- a/drivers/usb/device/usb_dc_nrfx.c
+++ b/drivers/usb/device/usb_dc_nrfx.c
@@ -1192,6 +1192,13 @@ int usb_dc_ep_configure(const struct usb_dc_ep_cfg_data *const ep_cfg)
 	ep_ctx->cfg.type = ep_cfg->ep_type;
 	ep_ctx->cfg.max_sz = ep_cfg->ep_mps;
 
+	if ((ep_cfg->ep_mps & (ep_cfg->ep_mps - 1)) != 0) {
+		LOG_ERR("EP max packet size must be a power of 2.");
+		return -EINVAL;
+	}
+	nrfx_usbd_ep_max_packet_size_set(ep_addr_to_nrfx(ep_cfg->ep_addr),
+					 ep_cfg->ep_mps);
+
 	return 0;
 }
 


### PR DESCRIPTION
This commit fixes the issue with non-default max packet size (<64).
The max packet size value was not passed to low-level driver
in norfic hal (nrfx_usbd) causing 64-byte being send regardless of
configured endpoint size. Size mismatch results in communication
error on Linux hosts.

Signed-off-by: Paweł Zadrożniak <pawel.zadrozniak@nordicsemi.no>