### PR TITLE
boards: arm: Remove CONFIG_MCUMGR_SMP_UART from dts files

### DIFF
--- a/boards/arm/nrf51_pca10028/nrf51_pca10028.dts
+++ b/boards/arm/nrf51_pca10028/nrf51_pca10028.dts
@@ -14,9 +14,7 @@
 
 	chosen {
 		zephyr,console = &uart0;
-#ifdef CONFIG_MCUMGR_SMP_UART
 		zephyr,uart-mcumgr = &uart0;
-#endif
 		zephyr,sram = &sram0;
 		zephyr,flash = &flash0;
 	};

--- a/boards/arm/nrf52810_pca10040/nrf52810_pca10040.dts
+++ b/boards/arm/nrf52810_pca10040/nrf52810_pca10040.dts
@@ -16,9 +16,7 @@
 
 	chosen {
 		zephyr,console = &uart0;
-#ifdef CONFIG_MCUMGR_SMP_UART
 		zephyr,uart-mcumgr = &uart0;
-#endif
 		zephyr,sram = &sram0;
 		zephyr,flash = &flash0;
 	};

--- a/boards/arm/nrf52832_mdk/nrf52832_mdk.dts
+++ b/boards/arm/nrf52832_mdk/nrf52832_mdk.dts
@@ -15,9 +15,7 @@
 
 	chosen {
 		zephyr,console = &uart0;
-#ifdef CONFIG_MCUMGR_SMP_UART
 		zephyr,uart-mcumgr = &uart0;
-#endif
 		zephyr,sram = &sram0;
 		zephyr,flash = &flash0;
 	};

--- a/boards/arm/nrf52840_mdk/nrf52840_mdk.dts
+++ b/boards/arm/nrf52840_mdk/nrf52840_mdk.dts
@@ -14,9 +14,7 @@
 
 	chosen {
 		zephyr,console = &uart0;
-#ifdef CONFIG_MCUMGR_SMP_UART
 		zephyr,uart-mcumgr = &uart0;
-#endif
 		zephyr,sram = &sram0;
 		zephyr,flash = &flash0;
 	};

--- a/boards/arm/nrf52840_pca10056/nrf52840_pca10056.dts
+++ b/boards/arm/nrf52840_pca10056/nrf52840_pca10056.dts
@@ -14,9 +14,7 @@
 
 	chosen {
 		zephyr,console = &uart0;
-#ifdef CONFIG_MCUMGR_SMP_UART
 		zephyr,uart-mcumgr = &uart0;
-#endif
 		zephyr,sram = &sram0;
 		zephyr,flash = &flash0;
 	};

--- a/boards/arm/nrf52840_pca10059/nrf52840_pca10059.dts
+++ b/boards/arm/nrf52840_pca10059/nrf52840_pca10059.dts
@@ -15,9 +15,7 @@
 
 	chosen {
 		zephyr,console = &uart0;
-#ifdef CONFIG_MCUMGR_SMP_UART
 		zephyr,uart-mcumgr = &uart0;
-#endif
 		zephyr,sram = &sram0;
 		zephyr,flash = &flash0;
 	};

--- a/boards/arm/nrf52_adafruit_feather/nrf52_adafruit_feather.dts
+++ b/boards/arm/nrf52_adafruit_feather/nrf52_adafruit_feather.dts
@@ -15,9 +15,7 @@
 
 	chosen {
 		zephyr,console = &uart0;
-#ifdef CONFIG_MCUMGR_SMP_UART
 		zephyr,uart-mcumgr = &uart0;
-#endif
 		zephyr,sram = &sram0;
 		zephyr,flash = &flash0;
 	};

--- a/boards/arm/nrf52_pca10040/nrf52_pca10040.dts
+++ b/boards/arm/nrf52_pca10040/nrf52_pca10040.dts
@@ -15,9 +15,7 @@
 
 	chosen {
 		zephyr,console = &uart0;
-#ifdef CONFIG_MCUMGR_SMP_UART
 		zephyr,uart-mcumgr = &uart0;
-#endif
 		zephyr,sram = &sram0;
 		zephyr,flash = &flash0;
 	};

--- a/boards/arm/reel_board/reel_board.dts
+++ b/boards/arm/reel_board/reel_board.dts
@@ -15,9 +15,7 @@
 
 	chosen {
 		zephyr,console = &uart0;
-#ifdef CONFIG_MCUMGR_SMP_UART
 		zephyr,uart-mcumgr = &uart0;
-#endif
 		zephyr,sram = &sram0;
 		zephyr,flash = &flash0;
 	};


### PR DESCRIPTION
In an effort to reduce the number of CONFIG_ defines in dts files, we
can remove CONFIG_MCUMGR_SMP_UART and just always set
'zephyr,uart-mcumgr' as there is no harm to always having this set for
those board dts files that define the property.

Signed-off-by: Kumar Gala <kumar.gala@linaro.org>