### PR TITLE
Linker: Add ".ARM.extab" section in linker script for Cortex-M

### DIFF
--- a/include/arch/arm/cortex_m/scripts/linker.ld
+++ b/include/arch/arm/cortex_m/scripts/linker.ld
@@ -163,6 +163,16 @@ SECTIONS
 
 	_image_text_end = .;
 
+#if defined (CONFIG_CPLUSPLUS)
+	SECTION_PROLOGUE(.ARM.extab,,)
+	{
+	/*
+	 * .ARM.extab section containing exception unwinding information.
+	 */
+	*(.ARM.extab* .gnu.linkonce.armextab.*)
+	} GROUP_LINK_IN(ROMABLE_REGION)
+#endif
+
 	SECTION_PROLOGUE(.ARM.exidx,,)
 	{
 	/*


### PR DESCRIPTION
When using C++ exceptions in a Cortex-M, the linker return a warning:
warning: orphan section ".ARM.extab"
.ARM.extab section containing exception unwinding information.
This section is missing in the linker script for Cortex-M.
