### PR TITLE
util: Add GENMASK helper macro definition

### DIFF
--- a/drivers/dma/dma_stm32f4x.c
+++ b/drivers/dma/dma_stm32f4x.c
@@ -13,6 +13,7 @@
 #include <init.h>
 #include <stdio.h>
 #include <string.h>
+#include <misc/util.h>
 
 #define LOG_LEVEL CONFIG_DMA_LOG_LEVEL
 #include <logging/log.h>
@@ -87,9 +88,6 @@ struct dma_stm32_config {
 
 /* Maximum data sent in single transfer (Bytes) */
 #define DMA_STM32_MAX_DATA_ITEMS		0xffff
-
-#define BITS_PER_LONG		32
-#define GENMASK(h, l) (((~0UL) << (l)) & (~0UL >> (BITS_PER_LONG - 1 - (h))))
 
 #define DMA_STM32_1_BASE	0x40026000
 #define DMA_STM32_2_BASE	0x40026400

--- a/drivers/sensor/adxl372/adxl372.h
+++ b/drivers/sensor/adxl372/adxl372.h
@@ -12,8 +12,7 @@
 #include <gpio.h>
 #include <spi.h>
 #include <i2c.h>
-
-#define GENMASK(h, l) (((~0UL) - (1UL << (l)) + 1) & (~0UL >> (31 - (h))))
+#include <misc/util.h>
 
 /*
  * ADXL372 registers definition

--- a/include/misc/util.h
+++ b/include/misc/util.h
@@ -27,6 +27,17 @@
 #define POINTER_TO_INT(x)  ((s32_t) (x))
 #define INT_TO_POINTER(x)  ((void *) (x))
 
+#if !(defined (__CHAR_BIT__) && defined (__SIZEOF_LONG__))
+#	error Missing required predefined macros for BITS_PER_LONG calculation
+#endif
+
+#define BITS_PER_LONG	(__CHAR_BIT__ * __SIZEOF_LONG__)
+/* Create a contiguous bitmask starting at bit position @l and ending at
+ * position @h.
+ */
+#define GENMASK(h, l) \
+	(((~0UL) - (1UL << (l)) + 1) & (~0UL >> (BITS_PER_LONG - 1 - (h))))
+
 /* Evaluates to 0 if cond is true-ish; compile error otherwise */
 #define ZERO_OR_COMPILE_ERROR(cond) ((int) sizeof(char[1 - 2 * !(cond)]) - 1)
 


### PR DESCRIPTION
Macro is used to create contiguous bitmask between the
arguments passed to the macro.

`BITS_PER_LONG` is computed as the multiplication of predefined
macros `__CHAR_BIT__` and `__SIZEOF_LONG__`.

Both gcc and clang support these predefined macros.

With this change, replace the redundant defintions of
GENMASK with the new generic macro available.

Fixes #10843

Signed-off-by: Himanshu Jha <himanshujha199640@gmail.com>

Cc @ulfalizer 

```
himanshu@himanshu-Vostro-3559:~$ uname -a
Linux himanshu-Vostro-3559 4.15.0-38-generic #41-Ubuntu SMP Wed Oct 10 10:59:38 UTC 2018 x86_64 x86_64 x86_64 GNU/Linux

himanshu@himanshu-Vostro-3559:~$ clang -dM -E -x c /dev/null | grep -w '__SIZEOF_LONG__\|__CHAR_BIT__'
#define __CHAR_BIT__ 8
#define __SIZEOF_LONG__ 8

himanshu@himanshu-Vostro-3559:~$ gcc -dM -E -x c /dev/null | grep -w '__SIZEOF_LONG__\|__CHAR_BIT__'
#define __CHAR_BIT__ 8
#define __SIZEOF_LONG__ 8
```