### PR TITLE
dts/bindings: document use of value 'base_label'

### DIFF
--- a/dts/bindings/device_node.yaml.template
+++ b/dts/bindings/device_node.yaml.template
@@ -69,4 +69,9 @@ properties:
 # of _GPIOS_
 
 # "type" attribute is currenty not used.
+
+base_label: LABEL
+# This will use 'LABEL' instead of the device generated name when we produce
+# #define's for the node
+
 ...


### PR DESCRIPTION
'base_label' is not documented.  Update device_node.yaml.template to
fix this.

Signed-off-by: Kumar Gala <kumar.gala@linaro.org>