### PR TITLE
samples: userspace: remove unwanted check

### DIFF
--- a/samples/basic/userspace/shared_mem/src/enc.c
+++ b/samples/basic/userspace/shared_mem/src/enc.c
@@ -107,7 +107,7 @@ int calc_rev_wheel(BYTE *wheel, BYTE *backpath)
 	int i;
 
 	for (i = 0; i < WHEEL_SIZE; i++) {
-		if (wheel[i] >= WHEEL_SIZE || wheel[i] < 0) {
+		if (wheel[i] >= WHEEL_SIZE) {
 			return -1;
 		}
 		backpath[wheel[i]] = i;


### PR DESCRIPTION
No need to check if array elements are less than 0 as they are of type unsigned char.

Fixes #10573 

Signed-off-by: Niranjhana N <niranjhana.n@intel.com>