### PR TITLE
POSIX ARCH tickless test fixes

### DIFF
--- a/tests/kernel/sched/schedule_api/src/test_sched_timeslice_reset.c
+++ b/tests/kernel/sched/schedule_api/src/test_sched_timeslice_reset.c
@@ -53,7 +53,11 @@ static void thread_tslice(void *p1, void *p2, void *p3)
 	 */
 	while (k_uptime_get_32() - t32 < BUSY_MS) {
 #if defined(CONFIG_ARCH_POSIX)
-		posix_halt_cpu(); /*sleep until next irq*/
+		/*
+		 * In the posix arch, a busy loop takes no time, so let's make
+		 * it take some
+		 */
+		k_busy_wait(50);
 #else
 		;
 #endif

--- a/tests/kernel/sleep/src/main.c
+++ b/tests/kernel/sleep/src/main.c
@@ -73,7 +73,7 @@ static void align_to_tick_boundary(void)
 	while (k_uptime_get_32() == tick) {
 		/* Busy wait to align to tick boundary */
 #if defined(CONFIG_ARCH_POSIX)
-		posix_halt_cpu();
+		k_busy_wait(50);
 #endif
 	}
 

--- a/tests/kernel/tickless/tickless_concept/src/main.c
+++ b/tests/kernel/tickless/tickless_concept/src/main.c
@@ -33,7 +33,7 @@ static struct k_thread tdata[NUM_THREAD];
 	do {				       \
 		u32_t t = k_uptime_get_32();   \
 		while (t == k_uptime_get_32()) \
-			posix_halt_cpu();      \
+			k_busy_wait(50);       \
 	} while (0)
 #else
 #define ALIGN_MS_BOUNDARY()		       \


### PR DESCRIPTION
In the POSIX architecture, with the inf_clock "SOC", time does
not pass while the CPU is running. Tests that require time to pass
while busy waiting should call k_busy_wait() or in some other way
set the CPU to idle. These tests were setting the CPU to idle while
waiting for the next time slice. This is ok if the system tick
(timer) is active and awaking the CPU every system tick period.
But when configured in tickless mode that is not the case, and the
CPU was set to sleep for an indefinite amount of time.
This fixes it by using k_busy_wait(a few microseconds) inside
those busy wait loops instead.

Related to #10556