### PR TITLE
cmake: west: Take the 'kernel' name out of the .bin/.hex file

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1324,6 +1324,10 @@ else()
     )
 endif()
 
+# Set overridable variables used by cmake/flash/CMakeLists.txt
+set_ifndef(HEX_FILE   ${PROJECT_BINARY_DIR}/${KERNEL_HEX_NAME})
+set_ifndef(BIN_FILE   ${PROJECT_BINARY_DIR}/${KERNEL_BIN_NAME})
+
 add_subdirectory(cmake/flash)
 
 add_subdirectory(cmake/usage)

--- a/cmake/flash/CMakeLists.txt
+++ b/cmake/flash/CMakeLists.txt
@@ -29,10 +29,11 @@ if(RUNNERS)
     CACHE STRING "Board definition directory" FORCE)
   set(ZEPHYR_RUNNER_CONFIG_KERNEL_ELF "${PROJECT_BINARY_DIR}/${KERNEL_ELF_NAME}"
     CACHE STRING "Path to kernel image in ELF format" FORCE)
-  set(ZEPHYR_RUNNER_CONFIG_KERNEL_HEX "${PROJECT_BINARY_DIR}/${KERNEL_HEX_NAME}"
-    CACHE STRING "Path to kernel image in Intel Hex format" FORCE)
-  set(ZEPHYR_RUNNER_CONFIG_KERNEL_BIN "${PROJECT_BINARY_DIR}/${KERNEL_BIN_NAME}"
-    CACHE STRING "Path to kernel image as raw binary" FORCE)
+  set(ZEPHYR_RUNNER_CONFIG_HEX_FILE   "${HEX_FILE}"
+    CACHE STRING "Path to hex file" FORCE)
+  set(ZEPHYR_RUNNER_CONFIG_BIN_FILE   "${BIN_FILE}"
+    CACHE STRING "Path to binary file" FORCE)
+
   # Not always applicable, but so often needed that they're provided
   # by default: (TODO: clean this up)
   if(DEFINED CMAKE_GDB)

--- a/scripts/meta/west/commands/run_common.py
+++ b/scripts/meta/west/commands/run_common.py
@@ -76,10 +76,10 @@ def add_parser_common(parser_adder, command):
                        help='Zephyr board directory')
     group.add_argument('--kernel-elf',
                        help='Path to kernel binary in .elf format')
-    group.add_argument('--kernel-hex',
-                       help='Path to kernel binary in .hex format')
-    group.add_argument('--kernel-bin',
-                       help='Path to kernel binary in .bin format')
+    group.add_argument('--hex-file',
+                       help='Path to hex file')
+    group.add_argument('--bin-file',
+                       help='Path to binary file')
     group.add_argument('--gdb',
                        help='Path to GDB, if applicable')
     group.add_argument('--openocd',
@@ -109,14 +109,14 @@ def cached_runner_config(build_dir, cache):
     '''Parse the RunnerConfig from a build directory and CMake Cache.'''
     board_dir = cache['ZEPHYR_RUNNER_CONFIG_BOARD_DIR']
     kernel_elf = cache['ZEPHYR_RUNNER_CONFIG_KERNEL_ELF']
-    kernel_hex = cache['ZEPHYR_RUNNER_CONFIG_KERNEL_HEX']
-    kernel_bin = cache['ZEPHYR_RUNNER_CONFIG_KERNEL_BIN']
+    hex_file   = cache['ZEPHYR_RUNNER_CONFIG_HEX_FILE']
+    bin_file   = cache['ZEPHYR_RUNNER_CONFIG_BIN_FILE']
     gdb = cache.get('ZEPHYR_RUNNER_CONFIG_GDB')
     openocd = cache.get('ZEPHYR_RUNNER_CONFIG_OPENOCD')
     openocd_search = cache.get('ZEPHYR_RUNNER_CONFIG_OPENOCD_SEARCH')
 
     return RunnerConfig(build_dir, board_dir,
-                        kernel_elf, kernel_hex, kernel_bin,
+                        kernel_elf, hex_file, bin_file,
                         gdb=gdb, openocd=openocd,
                         openocd_search=openocd_search)
 

--- a/scripts/meta/west/runners/bossac.py
+++ b/scripts/meta/west/runners/bossac.py
@@ -48,7 +48,7 @@ class BossacBinaryRunner(ZephyrBinaryRunner):
                     'ospeed', '1200', 'cs8', '-cstopb', 'ignpar', 'eol', '255',
                     'eof', '255']
         cmd_flash = [self.bossac, '-p', self.port, '-R', '-e', '-w', '-v',
-                     '-b', self.cfg.kernel_bin]
+                     '-b', self.cfg.bin_file]
 
         self.check_call(cmd_stty)
         self.check_call(cmd_flash)

--- a/scripts/meta/west/runners/core.py
+++ b/scripts/meta/west/runners/core.py
@@ -191,8 +191,8 @@ class RunnerConfig:
     This class's __slots__ contains exactly the configuration variables.
     '''
 
-    __slots__ = ['build_dir', 'board_dir', 'kernel_elf', 'kernel_hex',
-                 'kernel_bin', 'gdb', 'openocd', 'openocd_search']
+    __slots__ = ['build_dir', 'board_dir', 'kernel_elf', 'hex_file',
+                 'bin_file', 'gdb', 'openocd', 'openocd_search']
 
     # TODO: revisit whether we can get rid of some of these.  Having
     # tool-specific configuration options here is a layering
@@ -200,7 +200,7 @@ class RunnerConfig:
     # store the locations of tools (like gdb and openocd) that are
     # needed by multiple ZephyrBinaryRunner subclasses.
     def __init__(self, build_dir, board_dir,
-                 kernel_elf, kernel_hex, kernel_bin,
+                 kernel_elf, hex_file, bin_file,
                  gdb=None, openocd=None, openocd_search=None):
         self.build_dir = build_dir
         '''Zephyr application build directory'''
@@ -211,11 +211,11 @@ class RunnerConfig:
         self.kernel_elf = kernel_elf
         '''Path to kernel binary in .elf format'''
 
-        self.kernel_hex = kernel_hex
-        '''Path to kernel binary in .hex format'''
+        self.hex_file = hex_file
+        '''Path to hex file'''
 
-        self.kernel_bin = kernel_bin
-        '''Path to kernel binary in .bin format'''
+        self.bin_file = bin_file
+        '''Path to bin file'''
 
         self.gdb = gdb
         ''''Path to GDB compatible with the target, may be None.'''

--- a/scripts/meta/west/runners/dfu.py
+++ b/scripts/meta/west/runners/dfu.py
@@ -69,7 +69,7 @@ class DfuUtilBinaryRunner(ZephyrBinaryRunner):
     @classmethod
     def create(cls, cfg, args):
         if args.img is None:
-            args.img = cfg.kernel_bin
+            args.img = cfg.bin_file
 
         if args.dfuse:
             args.dt_flash = True  # --dfuse implies --dt-flash.

--- a/scripts/meta/west/runners/jlink.py
+++ b/scripts/meta/west/runners/jlink.py
@@ -23,7 +23,7 @@ class JLinkBinaryRunner(ZephyrBinaryRunner):
                  gdbserver='JLinkGDBServer', gdb_port=DEFAULT_JLINK_GDB_PORT,
                  tui=False):
         super(JLinkBinaryRunner, self).__init__(cfg)
-        self.bin_name = cfg.kernel_bin
+        self.bin_name = cfg.bin_file
         self.elf_name = cfg.kernel_elf
         self.gdb_cmd = [cfg.gdb] if cfg.gdb else None
         self.device = device

--- a/scripts/meta/west/runners/nios2.py
+++ b/scripts/meta/west/runners/nios2.py
@@ -19,7 +19,7 @@ class Nios2BinaryRunner(ZephyrBinaryRunner):
 
     def __init__(self, cfg, quartus_py=None, cpu_sof=None, tui=False):
         super(Nios2BinaryRunner, self).__init__(cfg)
-        self.hex_name = cfg.kernel_hex
+        self.hex_name = cfg.hex_file
         self.elf_name = cfg.kernel_elf
         self.cpu_sof = cpu_sof
         self.quartus_py = quartus_py

--- a/scripts/meta/west/runners/nrfjprog.py
+++ b/scripts/meta/west/runners/nrfjprog.py
@@ -15,7 +15,7 @@ class NrfJprogBinaryRunner(ZephyrBinaryRunner):
 
     def __init__(self, cfg, family, softreset, snr, erase=False):
         super(NrfJprogBinaryRunner, self).__init__(cfg)
-        self.hex_ = cfg.kernel_hex
+        self.hex_ = cfg.hex_file
         self.family = family
         self.softreset = softreset
         self.snr = snr

--- a/scripts/meta/west/runners/pyocd.py
+++ b/scripts/meta/west/runners/pyocd.py
@@ -30,7 +30,7 @@ class PyOcdBinaryRunner(ZephyrBinaryRunner):
         self.gdbserver = gdbserver
         self.gdb_port = gdb_port
         self.tui_args = ['-tui'] if tui else []
-        self.bin_name = cfg.kernel_bin
+        self.bin_name = cfg.bin_file
         self.elf_name = cfg.kernel_elf
 
         board_args = []


### PR DESCRIPTION
Rename variables to make west more agnostic, and therefore potentially
more flexible, to what it is flashing.

This is a small step towards solving #7868 and other similar
issues. Essentially, sometimes, for instance when a bootloader is
used, or a dual-core platform is used, we need to flash multiple
images/application's, not just the 'kernel'.

To prepare 'west' for this future feature we make it agnostic to what
kind of hex/bin file it is flashing by taking the 'kernel' name out of
the variables. This allows the hex file to contain not just the
kernel, but also a bootloader, or a second image.

Signed-off-by: Sebastian Bøe <sebastian.boe@nordicsemi.no>