### PR TITLE
native_posix doc: Remove possible macOS support note

### DIFF
--- a/boards/posix/native_posix/doc/board.rst
+++ b/boards/posix/native_posix/doc/board.rst
@@ -25,8 +25,8 @@ See `Peripherals`_ for more information.
 Host system dependencies
 ========================
 
-This port is designed to run in POSIX compatible operating systems.
-It has only been tested on Linux, but should also be compatible with macOS.
+This port is designed to run in POSIX compatible operating systems,
+but it has only been tested on Linux.
 
 .. note::
 


### PR DESCRIPTION
native_posix is, from some reports, known to not compile
on macOS. Therefore let's better remove the line that says
that in principle it should, to avoid missleading users.

Signed-off-by: Alberto Escolar Piedras <alpi@oticon.com>