### PR TITLE
dts/bindings: Remove id field from inventek,eswifi

### DIFF
--- a/dts/bindings/wifi/inventek,eswifi.yaml
+++ b/dts/bindings/wifi/inventek,eswifi.yaml
@@ -5,7 +5,6 @@
 #
 ---
 title: Inventek eS-WiFi WiFi module
-id: inventek,eswifi
 version: 0.1
 
 description: >


### PR DESCRIPTION
inventek,eswifi.yaml had the old id field that we have removed.  Remove
it so we stop getting a warning about it.

Signed-off-by: Kumar Gala <kumar.gala@linaro.org>