### PR TITLE
samples: usb: mass: enable CONFIG_DISK_ACCESS_RAM

### DIFF
--- a/samples/subsys/usb/mass/prj.conf
+++ b/samples/subsys/usb/mass/prj.conf
@@ -11,6 +11,8 @@ CONFIG_USB_MASS_STORAGE=y
 CONFIG_USB_DEVICE_LOG_LEVEL_ERR=y
 CONFIG_USB_MASS_STORAGE_LOG_LEVEL_ERR=y
 
+CONFIG_DISK_ACCESS_RAM=y
+
 # If the target's code needs to do file operations, enable target's
 # FAT FS code. (Without this only the host can access the fs contents)
 #CONFIG_FILE_SYSTEM=y


### PR DESCRIPTION
The USB mass storage example uses the disk interface, but does not
select a RAM or a flash backend device, causing the following error:
    
[00:00:00.000,000] <err> usb_msc.mass_storage_init: Storage init ERROR
!!!! - Aborting USB init
    
Fix that by enabling the RAM one with CONFIG_DISK_ACCESS_RAM to match
the documentation.

Signed-off-by: Aurelien Jarno aurelien@aurel32.net