### PR TITLE
xcc: fix warning about unsupported compiler/linker flags on no standard defines/libraryes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -165,8 +165,6 @@ endif()
 
 if(NOT CONFIG_NATIVE_APPLICATION)
 zephyr_ld_options(
-  -nostartfiles
-  -nodefaultlibs
   -nostdlib
   -static
   -no-pie
@@ -748,7 +746,7 @@ function(construct_add_custom_command_for_linker_pass linker_output_name output_
     COMMAND ${CMAKE_C_COMPILER}
     -x assembler-with-cpp
     ${NOSTDINC_F}
-    -undef
+    ${NOSYSDEF_CFLAG}
     -MD -MF ${linker_cmd_file_name}.dep -MT ${BASE_NAME}/${linker_cmd_file_name}
     ${ZEPHYR_INCLUDES}
     ${LINKER_SCRIPT_DEFINES}

--- a/cmake/compiler/gcc.cmake
+++ b/cmake/compiler/gcc.cmake
@@ -53,6 +53,12 @@ find_program(CMAKE_CXX_COMPILER ${cplusplus_compiler} PATH ${TOOLCHAIN_HOME} NO_
 
 set(NOSTDINC "")
 
+# Note that NOSYSDEF_CFLAG may be an empty string, and
+# set_ifndef() does not work with empty string.
+if(NOT DEFINED NOSYSDEF_CFLAG)
+  set(NOSYSDEF_CFLAG -undef)
+endif()
+
 foreach(file_name include include-fixed)
   execute_process(
     COMMAND ${CMAKE_C_COMPILER} --print-file-name=${file_name}

--- a/cmake/compiler/llvm.cmake
+++ b/cmake/compiler/llvm.cmake
@@ -3,6 +3,12 @@
 
 set(NOSTDINC "")
 
+# Note that NOSYSDEF_CFLAG may be an empty string, and
+# set_ifndef() does not work with empty string.
+if(NOT DEFINED NOSYSDEF_CFLAG)
+  set(NOSYSDEF_CFLAG -undef)
+endif()
+
 foreach(file_name include include-fixed)
   execute_process(
     COMMAND ${CMAKE_C_COMPILER} --print-file-name=${file_name}
@@ -19,4 +25,3 @@ endforeach()
 
 set(CMAKE_REQUIRED_FLAGS -nostartfiles -nostdlib ${isystem_include_flags} -Wl,--unresolved-symbols=ignore-in-object-files)
 string(REPLACE ";" " " CMAKE_REQUIRED_FLAGS "${CMAKE_REQUIRED_FLAGS}")
-

--- a/cmake/dts.cmake
+++ b/cmake/dts.cmake
@@ -92,7 +92,8 @@ if(CONFIG_HAS_DTS)
     -include ${AUTOCONF_H}
     ${DTC_INCLUDE_FLAG_FOR_DTS}  # include the DTS source and overlays
     -I${ZEPHYR_BASE}/dts/common
-    -undef -D__DTS__
+    ${NOSYSDEF_CFLAG}
+    -D__DTS__
     -P
     -E ${ZEPHYR_BASE}/misc/empty_file.c
     -o ${BOARD}.dts.pre.tmp

--- a/cmake/toolchain/xcc.cmake
+++ b/cmake/toolchain/xcc.cmake
@@ -15,4 +15,12 @@ set(OPTIMIZE_FOR_DEBUG_FLAG "-O0")
 set(CC xcc)
 set(C++ xc++)
 
+set(NOSYSDEF_CFLAG "")
+
 list(APPEND TOOLCHAIN_C_FLAGS -fms-extensions)
+
+# xcc doesn't have this, so we need to define it here.
+# This is the same as in the xcc toolchain spec files.
+list(APPEND TOOLCHAIN_C_FLAGS
+  -D__SIZEOF_LONG__=4
+  )

--- a/soc/xtensa/intel_s1000/soc.c
+++ b/soc/xtensa/intel_s1000/soc.c
@@ -11,6 +11,8 @@
 #include <xtensa/hal.h>
 #include <init.h>
 
+#include "soc.h"
+
 #define LOG_LEVEL CONFIG_SOC_LOG_LEVEL
 #include <logging/log.h>
 LOG_MODULE_REGISTER(soc);


### PR DESCRIPTION
XCC does not support the GCC flags to not include standard include files and libraries (e.g. -undef, -nodefaultlibs). So make these into parameters and XCC compiler configuration can override them.