### PR TITLE
First pass at removing/reducing use of board.h

### DIFF
--- a/arch/arc/include/vector_table.h
+++ b/arch/arc/include/vector_table.h
@@ -29,7 +29,6 @@ extern "C" {
 
 #ifdef _ASMLANGUAGE
 
-#include <board.h>
 #include <toolchain.h>
 #include <linker/sections.h>
 

--- a/arch/arm/core/cortex_m/reset.S
+++ b/arch/arm/core/cortex_m/reset.S
@@ -11,7 +11,6 @@
  * Reset handler that prepares the system for running C code.
  */
 
-#include <board.h>
 #include <toolchain.h>
 #include <linker/sections.h>
 #include <arch/cpu.h>

--- a/arch/arm/core/cortex_m/vector_table.S
+++ b/arch/arm/core/cortex_m/vector_table.S
@@ -16,7 +16,6 @@
  * rest should not be triggered until the kernel is ready to handle them.
  */
 
-#include <board.h>
 #include <toolchain.h>
 #include <linker/sections.h>
 #include "vector_table.h"

--- a/arch/arm/core/cortex_m/vector_table.h
+++ b/arch/arm/core/cortex_m/vector_table.h
@@ -27,7 +27,6 @@ extern "C" {
 
 #ifdef _ASMLANGUAGE
 
-#include <board.h>
 #include <toolchain.h>
 #include <linker/sections.h>
 #include <misc/util.h>

--- a/arch/arm/core/irq_relay.S
+++ b/arch/arm/core/irq_relay.S
@@ -21,7 +21,6 @@
  * Note: Currently support mcuboot only.
  * */
 
-#include <board.h>
 #include <toolchain.h>
 #include <linker/sections.h>
 

--- a/boards/arm/efm32hg_slstk3400a/board.c
+++ b/boards/arm/efm32hg_slstk3400a/board.c
@@ -5,7 +5,7 @@
  */
 
 #include <init.h>
-#include <board.h>
+#include "board.h"
 #include <gpio.h>
 #include <misc/printk.h>
 

--- a/boards/arm/efm32wg_stk3800/board.c
+++ b/boards/arm/efm32wg_stk3800/board.c
@@ -5,7 +5,7 @@
  */
 
 #include <init.h>
-#include <board.h>
+#include "board.h"
 #include <gpio.h>
 #include <misc/printk.h>
 

--- a/boards/arm/efr32_slwstk6061a/board.c
+++ b/boards/arm/efr32_slwstk6061a/board.c
@@ -5,7 +5,7 @@
  */
 
 #include <init.h>
-#include <board.h>
+#include "board.h"
 #include <gpio.h>
 #include <misc/printk.h>
 

--- a/boards/arm/nrf52840_pca10059/board.c
+++ b/boards/arm/nrf52840_pca10059/board.c
@@ -5,7 +5,6 @@
  */
 
 #include <init.h>
-#include <board.h>
 #include <nrf_power.h>
 
 static int board_nrf52840_pca10059_init(struct device *dev)

--- a/boards/arm/nrf52_pca20020/board.c
+++ b/boards/arm/nrf52_pca20020/board.c
@@ -5,7 +5,6 @@
  */
 
 #include <init.h>
-#include <board.h>
 #include <gpio.h>
 #include <misc/printk.h>
 

--- a/boards/arm/reel_board/board.c
+++ b/boards/arm/reel_board/board.c
@@ -5,7 +5,7 @@
  */
 
 #include <init.h>
-#include <board.h>
+#include "board.h"
 #include <soc.h>
 
 static int board_reel_board_init(struct device *dev)

--- a/boards/riscv32/hifive1/clock.c
+++ b/boards/riscv32/hifive1/clock.c
@@ -6,7 +6,6 @@
  */
 
 #include <init.h>
-#include <board.h>
 #include "prci.h"
 
 /* Selects the 16MHz oscilator on the HiFive1 board, which provides a clock

--- a/boards/riscv32/hifive1/pinmux.c
+++ b/boards/riscv32/hifive1/pinmux.c
@@ -6,7 +6,7 @@
 
 #include <init.h>
 #include <pinmux.h>
-#include <board.h>
+#include <soc.h>
 
 static int hifive1_pinmux_init(struct device *dev)
 {

--- a/boards/x86/arduino_101/pinmux.c
+++ b/boards/x86/arduino_101/pinmux.c
@@ -6,7 +6,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 #include <kernel.h>
-#include <board.h>
+#include "board.h"
 #include <device.h>
 #include <init.h>
 #include <pinmux.h>

--- a/boards/x86/galileo/pinmux.c
+++ b/boards/x86/galileo/pinmux.c
@@ -7,7 +7,7 @@
  */
 
 #include <kernel.h>
-#include <board.h>
+#include "board.h"
 #include <device.h>
 #include <init.h>
 

--- a/boards/x86/quark_d2000_crb/pinmux.c
+++ b/boards/x86/quark_d2000_crb/pinmux.c
@@ -14,7 +14,7 @@
  */
 
 #include <kernel.h>
-#include <board.h>
+#include <soc.h>
 #include <device.h>
 #include <init.h>
 #include <pinmux.h>

--- a/boards/x86/quark_se_c1000_devboard/pinmux.c
+++ b/boards/x86/quark_se_c1000_devboard/pinmux.c
@@ -7,7 +7,7 @@
  */
 
 #include <kernel.h>
-#include <board.h>
+#include "board.h"
 #include <device.h>
 #include <init.h>
 #include <pinmux.h>

--- a/boards/x86/tinytile/pinmux.c
+++ b/boards/x86/tinytile/pinmux.c
@@ -6,7 +6,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 #include <kernel.h>
-#include <board.h>
+#include "board.h"
 #include <device.h>
 #include <init.h>
 #include <pinmux.h>

--- a/ext/hal/nxp/mcux/devices/LPC54114/gcc/startup_LPC54114_cm4.S
+++ b/ext/hal/nxp/mcux/devices/LPC54114/gcc/startup_LPC54114_cm4.S
@@ -45,7 +45,6 @@
 /* Version: GCC for ARM Embedded Processors                                  */
 /*****************************************************************************/
 
-#include <board.h>
 #include <toolchain.h>
 #include <linker/sections.h>
 #include <arch/cpu.h>

--- a/include/arch/xtensa/xtensa_irq.h
+++ b/include/arch/xtensa/xtensa_irq.h
@@ -8,7 +8,6 @@
 
 #include <xtensa_api.h>
 #include <xtensa/xtruntime.h>
-#include <board.h>
 
 #define CONFIG_GEN_IRQ_START_VECTOR 0
 

--- a/samples/basic/blink_led/src/main.c
+++ b/samples/basic/blink_led/src/main.c
@@ -14,7 +14,6 @@
 #include <misc/printk.h>
 #include <device.h>
 #include <pwm.h>
-#include <board.h>
 
 #if defined(CONFIG_SOC_STM32F401XE) || defined(CONFIG_SOC_STM32F412ZG) || \
 	defined(CONFIG_SOC_STM32F413XH) || defined(CONFIG_SOC_STM32L476XG) || \
@@ -31,6 +30,7 @@
 #define PWM_DRIVER CONFIG_PWM_NRF5_SW_0_DEV_NAME
 #define PWM_CHANNEL LED0_GPIO_PIN
 #elif defined(CONFIG_BOARD_HEXIWEAR_K64)
+#include <board.h>
 #define PWM_DRIVER	GREEN_PWM_NAME
 #define PWM_CHANNEL	GREEN_PWM_CHANNEL
 #elif defined(CONFIG_BOARD_COLIBRI_IMX7D_M4)

--- a/samples/basic/button/src/main.c
+++ b/samples/basic/button/src/main.c
@@ -5,7 +5,6 @@
  */
 
 #include <zephyr.h>
-#include <board.h>
 #include <device.h>
 #include <gpio.h>
 #include <misc/util.h>

--- a/samples/basic/fade_led/src/main.c
+++ b/samples/basic/fade_led/src/main.c
@@ -14,7 +14,6 @@
 #include <misc/printk.h>
 #include <device.h>
 #include <pwm.h>
-#include <board.h>
 
 #if defined(CONFIG_SOC_STM32F401XE) || defined(CONFIG_SOC_STM32L476XG)
 #define PWM_DRIVER CONFIG_PWM_STM32_2_DEV_NAME
@@ -26,10 +25,10 @@
 #define PWM_DRIVER CONFIG_PWM_QMSI_DEV_NAME
 #define PWM_CHANNEL 0
 #elif defined(CONFIG_SOC_FAMILY_NRF)
-#include <board.h>
 #define PWM_DRIVER CONFIG_PWM_NRF5_SW_0_DEV_NAME
 #define PWM_CHANNEL LED0_GPIO_PIN
 #elif defined(CONFIG_BOARD_HEXIWEAR_K64)
+#include <board.h>
 #define PWM_DRIVER	GREEN_PWM_NAME
 #define PWM_CHANNEL	GREEN_PWM_CHANNEL
 #elif defined(CONFIG_SOC_ESP32)

--- a/samples/basic/rgb_led/src/main.c
+++ b/samples/basic/rgb_led/src/main.c
@@ -14,7 +14,6 @@
 #include <misc/printk.h>
 #include <device.h>
 #include <pwm.h>
-#include <board.h>
 
 #if defined(CONFIG_SOC_QUARK_SE_C1000)
 #define PWM_DEV0	CONFIG_PWM_QMSI_DEV_NAME
@@ -24,6 +23,7 @@
 #define PWM_DEV2	CONFIG_PWM_QMSI_DEV_NAME
 #define PWM_CH2		2
 #elif defined(CONFIG_BOARD_HEXIWEAR_K64)
+#include <board.h>
 #define PWM_DEV0	RED_PWM_NAME
 #define PWM_CH0		RED_PWM_CHANNEL
 #define PWM_DEV1	GREEN_PWM_NAME

--- a/samples/basic/threads/src/main.c
+++ b/samples/basic/threads/src/main.c
@@ -9,7 +9,6 @@
 #include <gpio.h>
 #include <misc/printk.h>
 #include <misc/__assert.h>
-#include <board.h>
 #include <string.h>
 
 /* size of stack area used by each thread */

--- a/samples/boards/96b_argonkey/src/main.c
+++ b/samples/boards/96b_argonkey/src/main.c
@@ -7,12 +7,13 @@
 #include <zephyr.h>
 #include <misc/printk.h>
 
-#include <board.h>
 #include <gpio.h>
 #include <led.h>
 #include <i2c.h>
 #include <spi.h>
 #include <sensor.h>
+
+#include <stdio.h>
 
 /* #define ARGONKEY_TEST_LOG 1 */
 

--- a/samples/boards/microbit/display/src/main.c
+++ b/samples/boards/microbit/display/src/main.c
@@ -6,7 +6,6 @@
 
 #include <zephyr.h>
 #include <misc/printk.h>
-#include <board.h>
 #include <gpio.h>
 #include <device.h>
 

--- a/samples/boards/microbit/pong/src/ble.c
+++ b/samples/boards/microbit/pong/src/ble.c
@@ -6,7 +6,6 @@
 
 #include <zephyr.h>
 #include <misc/printk.h>
-#include <board.h>
 #include <gpio.h>
 #include <device.h>
 #include <string.h>

--- a/samples/boards/nrf52/mesh/onoff-app/src/main.c
+++ b/samples/boards/nrf52/mesh/onoff-app/src/main.c
@@ -49,8 +49,6 @@
 #include <bluetooth/mesh.h>
 #include <stdio.h>
 
-#include <board.h>
-
 /* Model Operation Codes */
 #define BT_MESH_MODEL_OP_GEN_ONOFF_GET		BT_MESH_MODEL_OP_2(0x82, 0x01)
 #define BT_MESH_MODEL_OP_GEN_ONOFF_SET		BT_MESH_MODEL_OP_2(0x82, 0x02)

--- a/samples/boards/nrf52/mesh/onoff_level_lighting_vnd_app/src/main.c
+++ b/samples/boards/nrf52/mesh/onoff_level_lighting_vnd_app/src/main.c
@@ -5,7 +5,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <board.h>
 #include <gpio.h>
 
 #include "ble_mesh.h"

--- a/samples/boards/nrf52/mesh/onoff_level_lighting_vnd_app/src/mesh/device_composition.c
+++ b/samples/boards/nrf52/mesh/onoff_level_lighting_vnd_app/src/mesh/device_composition.c
@@ -5,7 +5,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <board.h>
 #include <gpio.h>
 
 #include "common.h"

--- a/samples/boards/nrf52/mesh/onoff_level_lighting_vnd_app/src/mesh/publisher.c
+++ b/samples/boards/nrf52/mesh/onoff_level_lighting_vnd_app/src/mesh/publisher.c
@@ -5,7 +5,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <board.h>
 #include <gpio.h>
 
 #include "common.h"

--- a/samples/boards/nrf52/mesh/onoff_level_lighting_vnd_app/src/mesh/state_binding.c
+++ b/samples/boards/nrf52/mesh/onoff_level_lighting_vnd_app/src/mesh/state_binding.c
@@ -5,7 +5,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <board.h>
 #include <gpio.h>
 
 #include "common.h"

--- a/samples/boards/nrf52/mesh/onoff_level_lighting_vnd_app/src/mesh/transition.c
+++ b/samples/boards/nrf52/mesh/onoff_level_lighting_vnd_app/src/mesh/transition.c
@@ -5,7 +5,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <board.h>
 #include <gpio.h>
 
 #include "common.h"

--- a/samples/boards/nrf52/power_mgr/src/test.h
+++ b/samples/boards/nrf52/power_mgr/src/test.h
@@ -9,7 +9,7 @@
 #include <soc_power.h>
 #include <misc/printk.h>
 #include <string.h>
-#include <board.h>
+#include <soc.h>
 #include <device.h>
 #include <gpio.h>
 

--- a/samples/net/irc_bot/src/irc-bot.c
+++ b/samples/net/irc_bot/src/irc-bot.c
@@ -8,7 +8,6 @@
 #define LOG_MODULE_NAME net_irc_bot
 #define NET_LOG_LEVEL LOG_LEVEL_DBG
 
-#include <board.h>
 #include <random/rand32.h>
 #include <errno.h>
 #include <gpio.h>

--- a/samples/net/leds_demo/src/leds-demo.c
+++ b/samples/net/leds_demo/src/leds-demo.c
@@ -10,7 +10,6 @@
 #include <errno.h>
 
 #include <zephyr.h>
-#include <board.h>
 
 #include <misc/byteorder.h>
 #include <net/net_core.h>

--- a/samples/net/lwm2m_client/src/lwm2m-client.c
+++ b/samples/net/lwm2m_client/src/lwm2m-client.c
@@ -11,7 +11,6 @@
 #include <logging/log.h>
 LOG_MODULE_REGISTER(LOG_MODULE_NAME);
 
-#include <board.h>
 #include <zephyr.h>
 #include <gpio.h>
 #include <net/lwm2m.h>

--- a/samples/net/nats/src/main.c
+++ b/samples/net/nats/src/main.c
@@ -7,7 +7,6 @@
 #define LOG_MODULE_NAME net_nats_app_main
 #define NET_LOG_LEVEL LOG_LEVEL_DBG
 
-#include <board.h>
 #include <gpio.h>
 #include <net/net_context.h>
 #include <net/net_core.h>

--- a/samples/net/rpl_node/src/main.c
+++ b/samples/net/rpl_node/src/main.c
@@ -9,7 +9,6 @@
 
 #include <zephyr.h>
 #include <errno.h>
-#include <board.h>
 
 #include <misc/byteorder.h>
 #include <net/net_core.h>

--- a/samples/nfc/nfc_hello/src/main.c
+++ b/samples/nfc/nfc_hello/src/main.c
@@ -8,7 +8,6 @@
 #include <stdio.h>
 #include <zephyr/types.h>
 #include <string.h>
-#include <board.h>
 #include <uart.h>
 #include <misc/byteorder.h>
 

--- a/samples/subsys/nvs/src/main.c
+++ b/samples/subsys/nvs/src/main.c
@@ -40,7 +40,6 @@
 
 #include <zephyr.h>
 #include <misc/reboot.h>
-#include <board.h>
 #include <device.h>
 #include <string.h>
 #include <nvs/nvs.h>

--- a/samples/subsys/power/power_mgr/src/main.c
+++ b/samples/subsys/power/power_mgr/src/main.c
@@ -9,7 +9,6 @@
 #include <soc_power.h>
 #include <misc/printk.h>
 #include <string.h>
-#include <board.h>
 #include <device.h>
 #include <gpio.h>
 

--- a/samples/subsys/usb/hid-mouse/src/main.c
+++ b/samples/subsys/usb/hid-mouse/src/main.c
@@ -4,7 +4,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 #include <zephyr.h>
-#include <board.h>
 #include <device.h>
 #include <gpio.h>
 

--- a/soc/arm/ti_lm3s6965/reboot.S
+++ b/soc/arm/ti_lm3s6965/reboot.S
@@ -4,7 +4,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <board.h>
 #include <toolchain.h>
 #include <linker/sections.h>
 #include <arch/cpu.h>

--- a/soc/x86/intel_quark/quark_se/soc_config.c
+++ b/soc/x86/intel_quark/quark_se/soc_config.c
@@ -9,7 +9,6 @@
 #include <device.h>
 #include <init.h>
 
-#include "board.h"
 #include <kernel.h>
 #include <arch/cpu.h>
 

--- a/soc/xtensa/intel_s1000/soc.c
+++ b/soc/xtensa/intel_s1000/soc.c
@@ -7,7 +7,6 @@
 #include <device.h>
 #include <xtensa_api.h>
 #include <xtensa/xtruntime.h>
-#include <board.h>
 #include <irq_nextlevel.h>
 #include <xtensa/hal.h>
 #include <init.h>

--- a/subsys/dfu/boot/mcuboot.c
+++ b/subsys/dfu/boot/mcuboot.c
@@ -15,7 +15,6 @@
 
 #include <misc/__assert.h>
 #include <misc/byteorder.h>
-#include <board.h>
 #include <dfu/mcuboot.h>
 
 /*

--- a/subsys/dfu/img_util/flash_img.c
+++ b/subsys/dfu/img_util/flash_img.c
@@ -16,7 +16,6 @@ LOG_MODULE_REGISTER(LOG_MODULE_NAME);
 #include <string.h>
 #include <errno.h>
 #include <flash.h>
-#include <board.h>
 #include <dfu/flash_img.h>
 #include <inttypes.h>
 

--- a/subsys/net/l2/bluetooth/bluetooth.c
+++ b/subsys/net/l2/bluetooth/bluetooth.c
@@ -13,7 +13,6 @@
 #include <string.h>
 #include <errno.h>
 
-#include <board.h>
 #include <device.h>
 #include <init.h>
 

--- a/subsys/usb/usb_device.c
+++ b/subsys/usb/usb_device.c
@@ -61,7 +61,6 @@
 #include <misc/util.h>
 #include <misc/__assert.h>
 #include <init.h>
-#include <board.h>
 #if defined(USB_VUSB_EN_GPIO)
 #include <gpio.h>
 #endif

--- a/tests/drivers/i2c/i2c_slave_api/common/i2c_virtual.c
+++ b/tests/drivers/i2c/i2c_slave_api/common/i2c_virtual.c
@@ -8,7 +8,6 @@
 #include <clock_control.h>
 #include <misc/util.h>
 #include <kernel.h>
-#include <board.h>
 #include <errno.h>
 #include <i2c.h>
 

--- a/tests/kernel/context/src/main.c
+++ b/tests/kernel/context/src/main.c
@@ -27,11 +27,11 @@
 #include <sys_clock.h>
 
 /*
- * Include board.h from platform to get IRQ number.
+ * Include soc.h from platform to get IRQ number.
  * NOTE: Cortex-M does not need IRQ numbers
  */
-#if !defined(CONFIG_CPU_CORTEX_M)
-#include <board.h>
+#if !defined(CONFIG_CPU_CORTEX_M) && !defined(CONFIG_XTENSA)
+#include <soc.h>
 #endif
 
 #define THREAD_STACKSIZE    (512 + CONFIG_TEST_EXTRA_STACKSIZE)


### PR DESCRIPTION
Most inclusions of board.h aren't need or should be soc.h.  This is the first pass at removing/reducing the usage.  (also split up so CI might pass).