### PR TITLE
 boards: Introduce frdm_kw41z ble controller shield

### DIFF
--- a/boards/arm/frdm_k64f/frdm_k64f.dts
+++ b/boards/arm/frdm_k64f/frdm_k64f.dts
@@ -40,9 +40,6 @@
 		zephyr,sram = &sram0;
 		zephyr,flash = &flash0;
 		zephyr,console = &uart0;
-#ifdef CONFIG_BT
-		zephyr,bt-uart = &uart3;
-#endif
 		zephyr,uart-pipe = &uart0;
 	};
 
@@ -74,6 +71,8 @@
 		};
 	};
 };
+
+arduino_serial: &uart3 {};
 
 &adc0 {
 	status = "ok";
@@ -137,13 +136,6 @@
 		status = "ok";
 	};
 #endif
-};
-#endif
-
-#ifdef CONFIG_BT
-&uart3 {
-	status = "ok";
-	current-speed = <115200>;
 };
 #endif
 

--- a/boards/arm/mimxrt1050_evk/mimxrt1050_evk.dts
+++ b/boards/arm/mimxrt1050_evk/mimxrt1050_evk.dts
@@ -35,9 +35,6 @@
 #endif
 		zephyr,sram = &dtcm0;
 		zephyr,console = &uart1;
-#ifdef CONFIG_BT
-		zephyr,bt-uart = &uart3;
-#endif
 	};
 
 	sdram0: memory@80000000 {
@@ -62,6 +59,8 @@
 		};
 	};
 };
+
+arduino_serial: &uart3 {};
 
 &flexspi0 {
 	hyperflash0: hyperflash@0 {
@@ -89,13 +88,6 @@
 	status = "ok";
 	current-speed = <115200>;
 };
-
-#ifdef CONFIG_BT
-&uart3 {
-	status = "ok";
-	current-speed = <115200>;
-};
-#endif
 
 &spi3 {
 	status = "ok";

--- a/boards/shields/frdm_kw41z/Kconfig.shield
+++ b/boards/shields/frdm_kw41z/Kconfig.shield
@@ -1,0 +1,8 @@
+#
+# Copyright (c) 2018, NXP
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+
+config SHIELD_FRDM_KW41Z
+	bool "frdm_kw41z"

--- a/boards/shields/frdm_kw41z/doc/frdm_kw41z.rst
+++ b/boards/shields/frdm_kw41z/doc/frdm_kw41z.rst
@@ -1,0 +1,64 @@
+.. _frdm_kw41z_shield:
+
+NXP FRDM-KW41Z
+##############
+
+Overview
+********
+
+The FRDM-KW41Z is a development kit enabled by the Kinetis |reg| W series
+KW41Z/31Z/21Z (KW41Z) family built on ARM |reg| Cortex |reg|-M0+ processor with
+integrated 2.4 GHz transceiver supporting Bluetooth |reg| Smart/Bluetooth
+|reg| Low Energy
+(BLE) v4.2, Generic FSK, IEEE |reg| 802.15.4 and Thread.
+
+The FRDM-KW41Z can be used as a standalone board or as an Arduino shield. This
+document covers usage as a shield; see :ref:`frdm_kw41z` for usage as a
+standalone board.
+
+Bluetooth Controller
+********************
+
+To use the FRDM-KW41Z as a Bluetooth low energy controller shield with a serial
+host controller interface (HCI):
+
+#. Download the MCUXpresso SDK for FRDM-KW41Z from the `MCUXpresso SDK Builder
+   Website`_.
+
+#. Open the MCUXpresso IDE or IAR project in
+   :file:`boards/frdmkw41z/wireless_examples/bluetooth/hci_black_box/bm`
+
+#. Open :file:`source/common/app_preinclude.h` and add the following line:
+
+.. code-block:: console
+
+	#define gSerialMgrRxBufSize_c 64
+
+#. Build the project to generate a binary :file:`hci_black_box_frdmkw41z.bin`.
+
+#. Connect the FRDM-KW41Z board to your computer with a USB cable. A USB mass
+   storage device should enumerate.
+
+#. Program the binary to flash by copying it to the USB mass storage device.
+
+#. Remove the USB cable to power down the board.
+
+#. Configure the jumpers J30 and J31 such that:
+   - J30 pin 1 is attached to J31 pin 2
+   - J30 pin 2 is attached to J31 pin 1
+   The jumpers should be parallel to the Arduino headers. This configuration
+   routes the UART RX and TX signals to the Arduino header, rather than to the
+   OpenSDA circuit.
+
+#. Attach the FRDM-KW41Z to the Arduino header on your selected main board,
+   such as :ref:`mimxrt1050_evk` or :ref:`frdm_k64f`.
+
+#. Set CONFIG_SHIELD_FRDM_KW41Z=y in your Zephyr bluetooth application.
+
+References
+**********
+
+.. target-notes::
+
+.. _MCUXpresso SDK Builder Website:
+   https://mcuxpresso.nxp.com

--- a/boards/shields/frdm_kw41z/frdm_kw41z.overlay
+++ b/boards/shields/frdm_kw41z/frdm_kw41z.overlay
@@ -1,0 +1,16 @@
+/*
+ * Copyright (c) 2018, NXP
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/ {
+	chosen {
+		zephyr,bt-uart = &arduino_serial;
+	};
+};
+
+&arduino_serial {
+	status = "ok";
+	current-speed = <115200>;
+};

--- a/samples/bluetooth/peripheral_hr/overlay-shield_frdm_kw41z.conf
+++ b/samples/bluetooth/peripheral_hr/overlay-shield_frdm_kw41z.conf
@@ -1,0 +1,7 @@
+#
+# Copyright (c) 2018, NXP
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+
+CONFIG_SHIELD_FRDM_KW41Z=y

--- a/samples/bluetooth/peripheral_hr/sample.yaml
+++ b/samples/bluetooth/peripheral_hr/sample.yaml
@@ -6,3 +6,8 @@ tests:
     harness: bluetooth
     platform_whitelist: qemu_cortex_m3 qemu_x86
     tags: bluetooth
+  test.overlay-shield_frdm_kw41z:
+    harness: bluetooth
+    extra_args: OVERLAY_CONFIG=overlay-shield_frdm_kw41z.conf
+    platform_whitelist: mimxrt1050_evk frdm_k64f
+    tags: bluetooth


### PR DESCRIPTION
The frdm_kw41z can be used as a standalone board or as an arduino
shield. Zephyr already supports the standalone configuration, this
change introduces support the arduino shield configuration.

In the arduino configuration, the frdm_kw41z operates as a ble
controller over serial hci. It can be attached to another board, such as
the frdm_k64f or mimxrt1050_evk, which runs the ble host.