### PR TITLE
ext: lib: crypto: mbedtls: fix mbedtls_snprintf glue in platform.h

### DIFF
--- a/ext/lib/crypto/mbedtls/include/mbedtls/platform.h
+++ b/ext/lib/crypto/mbedtls/include/mbedtls/platform.h
@@ -223,7 +223,7 @@ int mbedtls_platform_set_snprintf( int (*snprintf_func)( char * s, size_t n,
 #if defined(MBEDTLS_PLATFORM_SNPRINTF_MACRO)
 #define mbedtls_snprintf   MBEDTLS_PLATFORM_SNPRINTF_MACRO
 #else
-#define mbedtls_snprintf   MBEDTLS_PLATFORM_STD_SNPRINTF
+#define mbedtls_snprintf   snprintf
 #endif /* MBEDTLS_PLATFORM_SNPRINTF_MACRO */
 #endif /* MBEDTLS_PLATFORM_SNPRINTF_ALT */
 


### PR DESCRIPTION
Fixes https://github.com/zephyrproject-rtos/zephyr/issues/10990. I am unfamiliar with this bit of code, see related issue for more information.