### PR TITLE
subsys: usb_device: Fix removal of board.h

### DIFF
--- a/subsys/usb/usb_device.c
+++ b/subsys/usb/usb_device.c
@@ -61,6 +61,7 @@
 #include <misc/util.h>
 #include <misc/__assert.h>
 #include <init.h>
+#include <board.h>
 #if defined(USB_VUSB_EN_GPIO)
 #include <gpio.h>
 #endif


### PR DESCRIPTION
Restore including board.h to get USB_VUSB_EN_GPIO and associate defines
if the board.h sets them.  This should move to device tree in the
future.

Signed-off-by: Kumar Gala <kumar.gala@linaro.org>