### PR TITLE
usb: logs: Use original logger functions

### DIFF
--- a/drivers/usb/device/usb_dc_dw.c
+++ b/drivers/usb/device/usb_dc_dw.c
@@ -148,7 +148,7 @@ static int usb_dw_reset(void)
 	while (!(USB_DW->grstctl & USB_DW_GRSTCTL_AHB_IDLE)) {
 		usb_dw_udelay(1);
 		if (++cnt > USB_DW_CORE_RST_TIMEOUT_US) {
-			USB_ERR("USB reset HANG! AHB Idle GRSTCTL=0x%08x",
+			LOG_ERR("USB reset HANG! AHB Idle GRSTCTL=0x%08x",
 				USB_DW->grstctl);
 			return -EIO;
 		}
@@ -400,7 +400,7 @@ static int usb_dw_tx(u8_t ep, const u8_t *const data,
 
 	avail_space *= 4;
 	if (!avail_space) {
-		USB_ERR("USB IN EP%d no space available, DTXFSTS %x", ep_idx,
+		LOG_ERR("USB IN EP%d no space available, DTXFSTS %x", ep_idx,
 			USB_DW->in_ep_reg[ep_idx].dtxfsts);
 		irq_unlock(key);
 		return -EAGAIN;
@@ -809,7 +809,7 @@ int usb_dc_ep_check_cap(const struct usb_dc_ep_cfg_data * const cfg)
 		cfg->ep_type);
 
 	if ((cfg->ep_type == USB_DC_EP_CONTROL) && ep_idx) {
-		USB_ERR("invalid endpoint configuration");
+		LOG_ERR("invalid endpoint configuration");
 		return -1;
 	}
 
@@ -1026,7 +1026,7 @@ int usb_dc_ep_flush(const u8_t ep)
 	cnt = 0;
 	do {
 		if (++cnt > USB_DW_CORE_RST_TIMEOUT_US) {
-			USB_ERR("USB TX FIFO flush HANG!");
+			LOG_ERR("USB TX FIFO flush HANG!");
 			return -EIO;
 		}
 		usb_dw_udelay(1);
@@ -1073,25 +1073,25 @@ int usb_dc_ep_read_wait(u8_t ep, u8_t *data, u32_t max_data_len,
 	u32_t i, j, data_len, bytes_to_copy;
 
 	if (!usb_dw_ctrl.attached && !usb_dw_ep_is_valid(ep)) {
-		USB_ERR("No valid endpoint");
+		LOG_ERR("No valid endpoint");
 		return -EINVAL;
 	}
 
 	/* Check if OUT ep */
 	if (USB_DW_EP_ADDR2DIR(ep) != USB_EP_DIR_OUT) {
-		USB_ERR("Wrong endpoint direction");
+		LOG_ERR("Wrong endpoint direction");
 		return -EINVAL;
 	}
 
 	/* Allow to read 0 bytes */
 	if (!data && max_data_len) {
-		USB_ERR("Wrong arguments");
+		LOG_ERR("Wrong arguments");
 		return -EINVAL;
 	}
 
 	/* Check if ep enabled */
 	if (!usb_dw_ep_is_enabled(ep)) {
-		USB_ERR("Not enabled endpoint");
+		LOG_ERR("Not enabled endpoint");
 		return -EINVAL;
 	}
 
@@ -1109,7 +1109,7 @@ int usb_dc_ep_read_wait(u8_t ep, u8_t *data, u32_t max_data_len,
 
 
 	if (data_len > max_data_len) {
-		USB_ERR("Not enough room to copy all the rcvd data!");
+		LOG_ERR("Not enough room to copy all the rcvd data!");
 		bytes_to_copy = max_data_len;
 	} else {
 		bytes_to_copy = data_len;
@@ -1147,13 +1147,13 @@ int usb_dc_ep_read_continue(u8_t ep)
 	u8_t ep_idx = USB_DW_EP_ADDR2IDX(ep);
 
 	if (!usb_dw_ctrl.attached && !usb_dw_ep_is_valid(ep)) {
-		USB_ERR("No valid endpoint");
+		LOG_ERR("No valid endpoint");
 		return -EINVAL;
 	}
 
 	/* Check if OUT ep */
 	if (USB_DW_EP_ADDR2DIR(ep) != USB_EP_DIR_OUT) {
-		USB_ERR("Wrong endpoint direction");
+		LOG_ERR("Wrong endpoint direction");
 		return -EINVAL;
 	}
 

--- a/drivers/usb/device/usb_dc_dw.c
+++ b/drivers/usb/device/usb_dc_dw.c
@@ -436,7 +436,7 @@ static int usb_dw_tx(u8_t ep, const u8_t *const data,
 
 		/* Check if transfer len is too big */
 		if (data_len > max_xfer_size) {
-			USB_WRN("USB IN EP%d len too big (%d->%d)", ep_idx,
+			LOG_WRN("USB IN EP%d len too big (%d->%d)", ep_idx,
 				data_len, max_xfer_size);
 			data_len = max_xfer_size;
 		}
@@ -451,7 +451,7 @@ static int usb_dw_tx(u8_t ep, const u8_t *const data,
 		pkt_cnt = (data_len + ep_mps - 1) / ep_mps;
 
 		if (pkt_cnt > max_pkt_cnt) {
-			USB_WRN("USB IN EP%d pkt count too big (%d->%d)",
+			LOG_WRN("USB IN EP%d pkt count too big (%d->%d)",
 				ep_idx, pkt_cnt, pkt_cnt);
 			pkt_cnt = max_pkt_cnt;
 			data_len = pkt_cnt * ep_mps;
@@ -814,19 +814,19 @@ int usb_dc_ep_check_cap(const struct usb_dc_ep_cfg_data * const cfg)
 	}
 
 	if (cfg->ep_mps > DW_USB_MAX_PACKET_SIZE) {
-		USB_WRN("unsupported packet size");
+		LOG_WRN("unsupported packet size");
 		return -1;
 	}
 
 	if ((USB_DW_EP_ADDR2DIR(cfg->ep_addr) == USB_EP_DIR_OUT) &&
 	    (ep_idx >= DW_USB_OUT_EP_NUM)) {
-		USB_WRN("OUT endpoint address out of range");
+		LOG_WRN("OUT endpoint address out of range");
 		return -1;
 	}
 
 	if ((USB_DW_EP_ADDR2DIR(cfg->ep_addr) == USB_EP_DIR_IN) &&
 	    (ep_idx >= DW_USB_IN_EP_NUM)) {
-		USB_WRN("IN endpoint address out of range");
+		LOG_WRN("IN endpoint address out of range");
 		return -1;
 	}
 

--- a/drivers/usb/device/usb_dc_dw.c
+++ b/drivers/usb/device/usb_dc_dw.c
@@ -75,28 +75,28 @@ static void usb_dw_reg_dump(void)
 {
 	u8_t i;
 
-	USB_DBG("USB registers:  GOTGCTL : 0x%x  GOTGINT : 0x%x  GAHBCFG : "
+	LOG_DBG("USB registers:  GOTGCTL : 0x%x  GOTGINT : 0x%x  GAHBCFG : "
 		"0x%x", USB_DW->gotgctl, USB_DW->gotgint, USB_DW->gahbcfg);
-	USB_DBG("  GUSBCFG : 0x%x  GINTSTS : 0x%x  GINTMSK : 0x%x",
+	LOG_DBG("  GUSBCFG : 0x%x  GINTSTS : 0x%x  GINTMSK : 0x%x",
 		USB_DW->gusbcfg, USB_DW->gintsts, USB_DW->gintmsk);
-	USB_DBG("  DCFG    : 0x%x  DCTL    : 0x%x  DSTS    : 0x%x",
+	LOG_DBG("  DCFG    : 0x%x  DCTL    : 0x%x  DSTS    : 0x%x",
 		USB_DW->dcfg, USB_DW->dctl, USB_DW->dsts);
-	USB_DBG("  DIEPMSK : 0x%x  DOEPMSK : 0x%x  DAINT   : 0x%x",
+	LOG_DBG("  DIEPMSK : 0x%x  DOEPMSK : 0x%x  DAINT   : 0x%x",
 		USB_DW->diepmsk, USB_DW->doepmsk, USB_DW->daint);
-	USB_DBG("  DAINTMSK: 0x%x  GHWCFG1 : 0x%x  GHWCFG2 : 0x%x",
+	LOG_DBG("  DAINTMSK: 0x%x  GHWCFG1 : 0x%x  GHWCFG2 : 0x%x",
 		USB_DW->daintmsk, USB_DW->ghwcfg1, USB_DW->ghwcfg2);
-	USB_DBG("  GHWCFG3 : 0x%x  GHWCFG4 : 0x%x",
+	LOG_DBG("  GHWCFG3 : 0x%x  GHWCFG4 : 0x%x",
 		USB_DW->ghwcfg3, USB_DW->ghwcfg4);
 
 	for (i = 0; i < USB_DW_OUT_EP_NUM; i++) {
-		USB_DBG("\n  EP %d registers:    DIEPCTL : 0x%x    DIEPINT : "
+		LOG_DBG("\n  EP %d registers:    DIEPCTL : 0x%x    DIEPINT : "
 			"0x%x", i, USB_DW->in_ep_reg[i].diepctl,
 			USB_DW->in_ep_reg[i].diepint);
-		USB_DBG("    DIEPTSIZ: 0x%x    DIEPDMA : 0x%x    DOEPCTL : "
+		LOG_DBG("    DIEPTSIZ: 0x%x    DIEPDMA : 0x%x    DOEPCTL : "
 			"0x%x", USB_DW->in_ep_reg[i].dieptsiz,
 			USB_DW->in_ep_reg[i].diepdma,
 			USB_DW->out_ep_reg[i].doepctl);
-		USB_DBG("    DOEPINT : 0x%x    DOEPTSIZ: 0x%x    DOEPDMA : "
+		LOG_DBG("    DOEPINT : 0x%x    DOEPTSIZ: 0x%x    DOEPDMA : "
 			"0x%x", USB_DW->out_ep_reg[i].doepint,
 			USB_DW->out_ep_reg[i].doeptsiz,
 			USB_DW->out_ep_reg[i].doepdma);
@@ -159,7 +159,7 @@ static int usb_dw_reset(void)
 	USB_DW->grstctl |= USB_DW_GRSTCTL_C_SFT_RST;
 	do {
 		if (++cnt > USB_DW_CORE_RST_TIMEOUT_US) {
-			USB_DBG("USB reset HANG! Soft Reset GRSTCTL=0x%08x",
+			LOG_DBG("USB reset HANG! Soft Reset GRSTCTL=0x%08x",
 				USB_DW->grstctl);
 			return -EIO;
 		}
@@ -277,7 +277,7 @@ static int usb_dw_ep_set(u8_t ep,
 	volatile u32_t *p_depctl;
 	u8_t ep_idx = USB_DW_EP_ADDR2IDX(ep);
 
-	USB_DBG("%s ep %x, mps %d, type %d", __func__, ep, ep_mps, ep_type);
+	LOG_DBG("%s ep %x, mps %d, type %d", __func__, ep, ep_mps, ep_type);
 
 	if (USB_DW_EP_ADDR2DIR(ep) == USB_EP_DIR_OUT) {
 		p_depctl = &USB_DW->out_ep_reg[ep_idx].doepctl;
@@ -374,7 +374,7 @@ static void usb_dw_prep_rx(const u8_t ep, u8_t setup)
 	}
 	USB_DW->out_ep_reg[ep_idx].doepctl |= USB_DW_DEPCTL_EP_ENA;
 
-	USB_DBG("USB OUT EP%d armed", ep_idx);
+	LOG_DBG("USB OUT EP%d armed", ep_idx);
 }
 
 static int usb_dw_tx(u8_t ep, const u8_t *const data,
@@ -494,7 +494,7 @@ static int usb_dw_tx(u8_t ep, const u8_t *const data,
 	}
 	irq_unlock(key);
 
-	USB_DBG("USB IN EP%d write %u bytes", ep_idx, data_len);
+	LOG_DBG("USB IN EP%d write %u bytes", ep_idx, data_len);
 
 	return data_len;
 }
@@ -547,7 +547,7 @@ static int usb_dw_init(void)
 
 static void usb_dw_handle_reset(void)
 {
-	USB_DBG("USB RESET event");
+	LOG_DBG("USB RESET event");
 
 	/* Inform upper layers */
 	if (usb_dw_ctrl.status_cb) {
@@ -570,7 +570,7 @@ static void usb_dw_handle_enum_done(void)
 	speed = (USB_DW->dsts & ~USB_DW_DSTS_ENUM_SPD_MASK) >>
 	    USB_DW_DSTS_ENUM_SPD_OFFSET;
 
-	USB_DBG("USB ENUM DONE event, %s speed detected",
+	LOG_DBG("USB ENUM DONE event, %s speed detected",
 		speed == USB_DW_DSTS_ENUM_LS ? "Low" : "Full");
 
 	/* Inform upper layers */
@@ -589,7 +589,7 @@ static void usb_dw_isr_handler(void)
 	/*  Read interrupt status */
 	while ((int_status = (USB_DW->gintsts & USB_DW->gintmsk))) {
 
-		USB_DBG("USB GINTSTS 0x%x", int_status);
+		LOG_DBG("USB GINTSTS 0x%x", int_status);
 
 		if (int_status & USB_DW_GINTSTS_USB_RST) {
 			/* Clear interrupt. */
@@ -636,7 +636,7 @@ static void usb_dw_isr_handler(void)
 			xfer_size = (grxstsp & USB_DW_GRXSTSR_PKT_CNT_MASK) >>
 			    USB_DW_GRXSTSR_PKT_CNT_OFFSET;
 
-			USB_DBG("USB OUT EP%d: RX_FLVL status %d, size %d",
+			LOG_DBG("USB OUT EP%d: RX_FLVL status %d, size %d",
 				ep_idx, status, xfer_size);
 			usb_dw_ctrl.out_ep_ctrl[ep_idx].data_len = xfer_size;
 			ep_cb = usb_dw_ctrl.out_ep_ctrl[ep_idx].cb;
@@ -678,7 +678,7 @@ static void usb_dw_isr_handler(void)
 					USB_DW->in_ep_reg[ep_idx].diepint =
 					    ep_int_status;
 
-					USB_DBG("USB IN EP%d interrupt "
+					LOG_DBG("USB IN EP%d interrupt "
 						"status: 0x%x", ep_idx,
 						ep_int_status);
 
@@ -718,7 +718,7 @@ static void usb_dw_isr_handler(void)
 					USB_DW->out_ep_reg[ep_idx].doepint =
 					    ep_int_status;
 
-					USB_DBG("USB OUT EP%d interrupt "
+					LOG_DBG("USB OUT EP%d interrupt "
 						"status: 0x%x\n", ep_idx,
 						ep_int_status);
 				}
@@ -805,7 +805,7 @@ int usb_dc_ep_check_cap(const struct usb_dc_ep_cfg_data * const cfg)
 {
 	u8_t ep_idx = USB_DW_EP_ADDR2IDX(cfg->ep_addr);
 
-	USB_DBG("ep %x, mps %d, type %d", cfg->ep_addr, cfg->ep_mps,
+	LOG_DBG("ep %x, mps %d, type %d", cfg->ep_addr, cfg->ep_mps,
 		cfg->ep_type);
 
 	if ((cfg->ep_type == USB_DC_EP_CONTROL) && ep_idx) {
@@ -1115,7 +1115,7 @@ int usb_dc_ep_read_wait(u8_t ep, u8_t *data, u32_t max_data_len,
 		bytes_to_copy = data_len;
 	}
 
-	USB_DBG("Read EP%d, req %d, read %d bytes", ep, max_data_len,
+	LOG_DBG("Read EP%d, req %d, read %d bytes", ep, max_data_len,
 		bytes_to_copy);
 
 	/* Data in the FIFOs is always stored per 32-bit words */

--- a/drivers/usb/device/usb_dc_kinetis.c
+++ b/drivers/usb/device/usb_dc_kinetis.c
@@ -272,12 +272,12 @@ int usb_dc_ep_check_cap(const struct usb_dc_ep_cfg_data * const cfg)
 	u8_t ep_idx = EP_ADDR2IDX(cfg->ep_addr);
 
 	if ((cfg->ep_type == USB_DC_EP_CONTROL) && ep_idx) {
-		USB_ERR("invalid endpoint configuration");
+		LOG_ERR("invalid endpoint configuration");
 		return -1;
 	}
 
 	if (ep_idx > NUM_OF_EP_MAX) {
-		USB_ERR("endpoint index/address out of range");
+		LOG_ERR("endpoint index/address out of range");
 		return -1;
 	}
 
@@ -305,7 +305,7 @@ int usb_dc_ep_configure(const struct usb_dc_ep_cfg_data * const cfg)
 	struct usb_ep_ctrl_data *ep_ctrl = &dev_data.ep_ctrl[ep_idx];
 
 	if (ep_idx > (NUM_OF_EP_MAX - 1)) {
-		USB_ERR("Wrong endpoint index/address");
+		LOG_ERR("Wrong endpoint index/address");
 		return -EINVAL;
 	}
 
@@ -335,7 +335,7 @@ int usb_dc_ep_configure(const struct usb_dc_ep_cfg_data * const cfg)
 	if (k_mem_pool_alloc(&ep_buf_pool, block, cfg->ep_mps * 2, 10) == 0) {
 		(void)memset(block->data, 0, cfg->ep_mps * 2);
 	} else {
-		USB_ERR("Memory allocation time-out");
+		LOG_ERR("Memory allocation time-out");
 		return -ENOMEM;
 	}
 
@@ -392,7 +392,7 @@ int usb_dc_ep_set_stall(const u8_t ep)
 	u8_t bd_idx;
 
 	if (ep_idx > (NUM_OF_EP_MAX - 1)) {
-		USB_ERR("Wrong endpoint index/address");
+		LOG_ERR("Wrong endpoint index/address");
 		return -EINVAL;
 	}
 
@@ -419,7 +419,7 @@ int usb_dc_ep_clear_stall(const u8_t ep)
 	u8_t bd_idx;
 
 	if (ep_idx > (NUM_OF_EP_MAX - 1)) {
-		USB_ERR("Wrong endpoint index/address");
+		LOG_ERR("Wrong endpoint index/address");
 		return -EINVAL;
 	}
 
@@ -454,7 +454,7 @@ int usb_dc_ep_is_stalled(const u8_t ep, u8_t *const stalled)
 	u8_t ep_idx = EP_ADDR2IDX(ep);
 
 	if (ep_idx > (NUM_OF_EP_MAX - 1)) {
-		USB_ERR("Wrong endpoint index/address");
+		LOG_ERR("Wrong endpoint index/address");
 		return -EINVAL;
 	}
 
@@ -492,7 +492,7 @@ int usb_dc_ep_enable(const u8_t ep)
 	u8_t ep_idx = EP_ADDR2IDX(ep);
 
 	if (ep_idx > (NUM_OF_EP_MAX - 1)) {
-		USB_ERR("Wrong endpoint index/address");
+		LOG_ERR("Wrong endpoint index/address");
 		return -EINVAL;
 	}
 
@@ -530,7 +530,7 @@ int usb_dc_ep_disable(const u8_t ep)
 	u8_t ep_idx = EP_ADDR2IDX(ep);
 
 	if (ep_idx > (NUM_OF_EP_MAX - 1)) {
-		USB_ERR("Wrong endpoint index/address");
+		LOG_ERR("Wrong endpoint index/address");
 		return -EINVAL;
 	}
 
@@ -552,7 +552,7 @@ int usb_dc_ep_flush(const u8_t ep)
 	u8_t ep_idx = EP_ADDR2IDX(ep);
 
 	if (ep_idx > (NUM_OF_EP_MAX - 1)) {
-		USB_ERR("Wrong endpoint index/address");
+		LOG_ERR("Wrong endpoint index/address");
 		return -EINVAL;
 	}
 
@@ -571,12 +571,12 @@ int usb_dc_ep_write(const u8_t ep, const u8_t *const data,
 	u32_t len_to_send = data_len;
 
 	if (ep_idx > (NUM_OF_EP_MAX - 1)) {
-		USB_ERR("Wrong endpoint index/address");
+		LOG_ERR("Wrong endpoint index/address");
 		return -EINVAL;
 	}
 
 	if (EP_ADDR2DIR(ep) != USB_EP_DIR_IN) {
-		USB_ERR("Wrong endpoint direction");
+		LOG_ERR("Wrong endpoint direction");
 		return -EINVAL;
 	}
 
@@ -633,12 +633,12 @@ int usb_dc_ep_read_wait(u8_t ep, u8_t *data, u32_t max_data_len,
 	u32_t data_len;
 
 	if (ep_idx > (NUM_OF_EP_MAX - 1)) {
-		USB_ERR("Wrong endpoint index/address");
+		LOG_ERR("Wrong endpoint index/address");
 		return -EINVAL;
 	}
 
 	if (EP_ADDR2DIR(ep) != USB_EP_DIR_OUT) {
-		USB_ERR("Wrong endpoint direction");
+		LOG_ERR("Wrong endpoint direction");
 		return -EINVAL;
 	}
 
@@ -649,12 +649,12 @@ int usb_dc_ep_read_wait(u8_t ep, u8_t *data, u32_t max_data_len,
 
 	/* Allow to read 0 bytes */
 	if (!data && max_data_len) {
-		USB_ERR("Wrong arguments");
+		LOG_ERR("Wrong arguments");
 		return -EINVAL;
 	}
 
 	while (bdt[bd_idx].get.own) {
-		USB_ERR("Endpoint is occupied by the controller");
+		LOG_ERR("Endpoint is occupied by the controller");
 		return -EBUSY;
 	}
 
@@ -699,12 +699,12 @@ int usb_dc_ep_read_continue(u8_t ep)
 	u8_t bd_idx = get_bdt_idx(ep, dev_data.ep_ctrl[ep_idx].status.out_odd);
 
 	if (ep_idx > (NUM_OF_EP_MAX - 1)) {
-		USB_ERR("Wrong endpoint index/address");
+		LOG_ERR("Wrong endpoint index/address");
 		return -EINVAL;
 	}
 
 	if (EP_ADDR2DIR(ep) != USB_EP_DIR_OUT) {
-		USB_ERR("Wrong endpoint direction");
+		LOG_ERR("Wrong endpoint direction");
 		return -EINVAL;
 	}
 
@@ -965,7 +965,7 @@ static void usb_kinetis_thread_main(void *arg1, void *unused1, void *unused2)
 				}
 				break;
 			default:
-				USB_ERR("unknown msg");
+				LOG_ERR("unknown msg");
 				break;
 			}
 		} else if (dev_data.status_cb) {
@@ -983,7 +983,7 @@ static void usb_kinetis_thread_main(void *arg1, void *unused1, void *unused2)
 				dev_data.status_cb(USB_DC_RESUME, NULL);
 				break;
 			default:
-				USB_ERR("unknown msg");
+				LOG_ERR("unknown msg");
 				break;
 			}
 		}

--- a/drivers/usb/device/usb_dc_kinetis.c
+++ b/drivers/usb/device/usb_dc_kinetis.c
@@ -283,12 +283,12 @@ int usb_dc_ep_check_cap(const struct usb_dc_ep_cfg_data * const cfg)
 
 	if (ep_idx & BIT(0)) {
 		if (EP_ADDR2DIR(cfg->ep_addr) != USB_EP_DIR_IN) {
-			USB_INF("pre-selected as IN endpoint");
+			LOG_INF("pre-selected as IN endpoint");
 			return -1;
 		}
 	} else {
 		if (EP_ADDR2DIR(cfg->ep_addr) != USB_EP_DIR_OUT) {
-			USB_INF("pre-selected as OUT endpoint");
+			LOG_INF("pre-selected as OUT endpoint");
 			return -1;
 		}
 	}
@@ -340,9 +340,9 @@ int usb_dc_ep_configure(const struct usb_dc_ep_cfg_data * const cfg)
 	}
 
 	bdt[idx_even].buf_addr = (u32_t)block->data;
-	USB_INF("idx_even %x", (u32_t)block->data);
+	LOG_INF("idx_even %x", (u32_t)block->data);
 	bdt[idx_odd].buf_addr = (u32_t)((u8_t *)block->data + cfg->ep_mps);
-	USB_INF("idx_odd %x", (u32_t)((u8_t *)block->data + cfg->ep_mps));
+	LOG_INF("idx_odd %x", (u32_t)((u8_t *)block->data + cfg->ep_mps));
 
 	if (cfg->ep_addr & USB_EP_DIR_IN) {
 		dev_data.ep_ctrl[ep_idx].mps_in = cfg->ep_mps;
@@ -518,7 +518,7 @@ int usb_dc_ep_enable(const u8_t ep)
 		dev_data.ep_ctrl[ep_idx].status.in_enabled = true;
 	}
 
-	USB_INF("ep 0x%x, ep_idx %d", ep, ep_idx);
+	LOG_INF("ep 0x%x, ep_idx %d", ep, ep_idx);
 
 	return 0;
 }
@@ -534,7 +534,7 @@ int usb_dc_ep_disable(const u8_t ep)
 		return -EINVAL;
 	}
 
-	USB_INF("ep %x, idx %d", ep_idx, ep);
+	LOG_INF("ep %x, idx %d", ep_idx, ep);
 
 	bdt[idx_even].bd_fields = 0;
 	bdt[idx_odd].bd_fields = 0;

--- a/drivers/usb/device/usb_dc_kinetis.c
+++ b/drivers/usb/device/usb_dc_kinetis.c
@@ -182,7 +182,7 @@ static int kinetis_usb_init(void)
 
 	irq_enable(CONFIG_USBD_KINETIS_IRQ);
 
-	USB_DBG("");
+	LOG_DBG("");
 
 	return 0;
 }
@@ -215,7 +215,7 @@ int usb_dc_reset(void)
 		       USB_INTEN_STALLEN_MASK |
 		       USB_INTEN_ERROREN_MASK);
 
-	USB_DBG("");
+	LOG_DBG("");
 
 	return 0;
 }
@@ -235,7 +235,7 @@ int usb_dc_attach(void)
 	usb_dc_reset();
 
 	dev_data.attached = 1;
-	USB_DBG("attached");
+	LOG_DBG("attached");
 
 	/* non-OTG device mode, enable DP Pullup */
 	USB0->CONTROL = USB_CONTROL_DPPULLUPNONOTG_MASK;
@@ -245,7 +245,7 @@ int usb_dc_attach(void)
 
 int usb_dc_detach(void)
 {
-	USB_DBG("");
+	LOG_DBG("");
 	/* disable USB and DP Pullup */
 	USB0->CTL  &= ~USB_CTL_USBENSOFEN_MASK;
 	USB0->CONTROL &= ~USB_CONTROL_DPPULLUPNONOTG_MASK;
@@ -255,7 +255,7 @@ int usb_dc_detach(void)
 
 int usb_dc_set_address(const u8_t addr)
 {
-	USB_DBG("");
+	LOG_DBG("");
 	/*
 	 * The device stack tries to set the address before
 	 * sending the ACK with ZLP, which is totally stupid,
@@ -315,7 +315,7 @@ int usb_dc_ep_configure(const struct usb_dc_ep_cfg_data * const cfg)
 		return -EBUSY;
 	}
 
-	USB_DBG("ep %x, mps %d, type %d", cfg->ep_addr, cfg->ep_mps,
+	LOG_DBG("ep %x, mps %d, type %d", cfg->ep_addr, cfg->ep_mps,
 		cfg->ep_type);
 
 	if (EP_ADDR2DIR(cfg->ep_addr) == USB_EP_DIR_OUT) {
@@ -358,7 +358,7 @@ int usb_dc_ep_configure(const struct usb_dc_ep_cfg_data * const cfg)
 
 	switch (cfg->ep_type) {
 	case USB_DC_EP_CONTROL:
-		USB_DBG("configure control endpoint");
+		LOG_DBG("configure control endpoint");
 		USB0->ENDPOINT[ep_idx].ENDPT |= (USB_ENDPT_EPHSHK_MASK |
 						 USB_ENDPT_EPRXEN_MASK |
 						 USB_ENDPT_EPTXEN_MASK);
@@ -396,7 +396,7 @@ int usb_dc_ep_set_stall(const u8_t ep)
 		return -EINVAL;
 	}
 
-	USB_DBG("ep %x, idx %d", ep, ep_idx);
+	LOG_DBG("ep %x, idx %d", ep, ep_idx);
 
 	if (EP_ADDR2DIR(ep) == USB_EP_DIR_OUT) {
 		dev_data.ep_ctrl[ep_idx].status.out_stalled = 1;
@@ -423,7 +423,7 @@ int usb_dc_ep_clear_stall(const u8_t ep)
 		return -EINVAL;
 	}
 
-	USB_DBG("ep %x, idx %d", ep, ep_idx);
+	LOG_DBG("ep %x, idx %d", ep, ep_idx);
 	USB0->ENDPOINT[ep_idx].ENDPT &= ~USB_ENDPT_EPSTALL_MASK;
 
 	if (EP_ADDR2DIR(ep) == USB_EP_DIR_OUT) {
@@ -458,7 +458,7 @@ int usb_dc_ep_is_stalled(const u8_t ep, u8_t *const stalled)
 		return -EINVAL;
 	}
 
-	USB_DBG("ep %x, idx %d", ep_idx, ep);
+	LOG_DBG("ep %x, idx %d", ep_idx, ep);
 	if (!stalled) {
 		return -EINVAL;
 	}
@@ -556,7 +556,7 @@ int usb_dc_ep_flush(const u8_t ep)
 		return -EINVAL;
 	}
 
-	USB_DBG("ep %x, idx %d", ep_idx, ep);
+	LOG_DBG("ep %x, idx %d", ep_idx, ep);
 
 	return 0;
 }
@@ -586,11 +586,11 @@ int usb_dc_ep_write(const u8_t ep, const u8_t *const data,
 	}
 
 	while (bdt[bd_idx].get.own) {
-		USB_DBG("ep 0x%x is busy", ep);
+		LOG_DBG("ep 0x%x is busy", ep);
 		k_yield();
 	}
 
-	USB_DBG("bd idx %x bufp %p odd %d", bd_idx, bufp, odd);
+	LOG_DBG("bd idx %x bufp %p odd %d", bd_idx, bufp, odd);
 
 	if (data_len > dev_data.ep_ctrl[ep_idx].mps_in) {
 		len_to_send = dev_data.ep_ctrl[ep_idx].mps_in;
@@ -614,7 +614,7 @@ int usb_dc_ep_write(const u8_t ep, const u8_t *const data,
 	/* Toggle next Data1 */
 	dev_data.ep_ctrl[ep_idx].status.in_data1 ^= 1;
 
-	USB_DBG("ep 0x%x write %d bytes from %d", ep, len_to_send, data_len);
+	LOG_DBG("ep 0x%x write %d bytes from %d", ep, len_to_send, data_len);
 
 	if (ret_bytes) {
 		*ret_bytes = len_to_send;
@@ -682,7 +682,7 @@ int usb_dc_ep_read_wait(u8_t ep, u8_t *data, u32_t max_data_len,
 		}
 	}
 
-	USB_DBG("Read idx %d, req %d, read %d bytes", bd_idx, max_data_len,
+	LOG_DBG("Read idx %d, req %d, read %d bytes", bd_idx, max_data_len,
 		data_len);
 
 	if (read_bytes) {
@@ -734,7 +734,7 @@ int usb_dc_ep_read_continue(u8_t ep)
 		USB0->CTL &= ~USB_CTL_TXSUSPENDTOKENBUSY_MASK;
 	}
 
-	USB_DBG("idx next %x", bd_idx);
+	LOG_DBG("idx next %x", bd_idx);
 
 	return 0;
 }
@@ -759,7 +759,7 @@ int usb_dc_ep_read(const u8_t ep, u8_t *const data,
 		return -EINVAL;
 	}
 
-	USB_DBG("");
+	LOG_DBG("");
 
 	return 0;
 }
@@ -777,7 +777,7 @@ int usb_dc_ep_set_callback(const u8_t ep, const usb_dc_ep_callback cb)
 	} else {
 		dev_data.ep_ctrl[ep_idx].cb_out = cb;
 	}
-	USB_DBG("ep_idx %x", ep_idx);
+	LOG_DBG("ep_idx %x", ep_idx);
 
 	return 0;
 }
@@ -785,7 +785,7 @@ int usb_dc_ep_set_callback(const u8_t ep, const usb_dc_ep_callback cb)
 int usb_dc_set_status_callback(const usb_dc_status_callback cb)
 {
 	dev_data.status_cb = cb;
-	USB_DBG("");
+	LOG_DBG("");
 
 	return 0;
 }

--- a/drivers/usb/device/usb_dc_kinetis.c
+++ b/drivers/usb/device/usb_dc_kinetis.c
@@ -223,7 +223,7 @@ int usb_dc_reset(void)
 int usb_dc_attach(void)
 {
 	if (dev_data.attached) {
-		USB_WRN("already attached");
+		LOG_WRN("already attached");
 	}
 
 	kinetis_usb_init();
@@ -311,7 +311,7 @@ int usb_dc_ep_configure(const struct usb_dc_ep_cfg_data * const cfg)
 
 	if (ep_idx && (dev_data.ep_ctrl[ep_idx].status.in_enabled ||
 	    dev_data.ep_ctrl[ep_idx].status.out_enabled)) {
-		USB_WRN("endpoint already configured");
+		LOG_WRN("endpoint already configured");
 		return -EBUSY;
 	}
 
@@ -472,10 +472,10 @@ int usb_dc_ep_is_stalled(const u8_t ep, u8_t *const stalled)
 
 	u8_t bd_idx = get_bdt_idx(ep,
 			dev_data.ep_ctrl[ep_idx].status.in_odd);
-	USB_WRN("active bd ctrl: %x", bdt[bd_idx].set.bd_ctrl);
+	LOG_WRN("active bd ctrl: %x", bdt[bd_idx].set.bd_ctrl);
 	bd_idx = get_bdt_idx(ep,
 			~dev_data.ep_ctrl[ep_idx].status.in_odd);
-	USB_WRN("next bd ctrl: %x", bdt[bd_idx].set.bd_ctrl);
+	LOG_WRN("next bd ctrl: %x", bdt[bd_idx].set.bd_ctrl);
 
 	return 0;
 }
@@ -498,7 +498,7 @@ int usb_dc_ep_enable(const u8_t ep)
 
 	if (ep_idx && (dev_data.ep_ctrl[ep_idx].status.in_enabled ||
 	    dev_data.ep_ctrl[ep_idx].status.out_enabled)) {
-		USB_WRN("endpoint 0x%x already enabled", ep);
+		LOG_WRN("endpoint 0x%x already enabled", ep);
 		return -EBUSY;
 	}
 
@@ -581,7 +581,7 @@ int usb_dc_ep_write(const u8_t ep, const u8_t *const data,
 	}
 
 	if (dev_data.ep_ctrl[ep_idx].status.in_stalled) {
-		USB_WRN("endpoint is stalled");
+		LOG_WRN("endpoint is stalled");
 		return -EBUSY;
 	}
 
@@ -643,7 +643,7 @@ int usb_dc_ep_read_wait(u8_t ep, u8_t *data, u32_t max_data_len,
 	}
 
 	if (dev_data.ep_ctrl[ep_idx].status.out_stalled) {
-		USB_WRN("endpoint is stalled");
+		LOG_WRN("endpoint is stalled");
 		return -EBUSY;
 	}
 
@@ -672,7 +672,7 @@ int usb_dc_ep_read_wait(u8_t ep, u8_t *data, u32_t max_data_len,
 	}
 
 	if (data_len > max_data_len) {
-		USB_WRN("Not enough room to copy all the data!");
+		LOG_WRN("Not enough room to copy all the data!");
 		data_len = max_data_len;
 	}
 
@@ -710,7 +710,7 @@ int usb_dc_ep_read_continue(u8_t ep)
 
 	if (bdt[bd_idx].get.own) {
 		/* May occur when usb_transfer initializes the OUT transfer */
-		USB_WRN("Current buffer is claimed by the controller");
+		LOG_WRN("Current buffer is claimed by the controller");
 		return 0;
 	}
 

--- a/drivers/usb/device/usb_dc_sam0.c
+++ b/drivers/usb/device/usb_dc_sam0.c
@@ -265,12 +265,12 @@ int usb_dc_ep_check_cap(const struct usb_dc_ep_cfg_data * const cfg)
 	u8_t ep_idx = cfg->ep_addr & ~USB_EP_DIR_MASK;
 
 	if ((cfg->ep_type == USB_DC_EP_CONTROL) && ep_idx) {
-		USB_ERR("invalid endpoint configuration");
+		LOG_ERR("invalid endpoint configuration");
 		return -1;
 	}
 
 	if (ep_idx > CONFIG_USB_DC_SAM0_NUM_BIDIR_ENDPOINTS) {
-		USB_ERR("endpoint index/address too high");
+		LOG_ERR("endpoint index/address too high");
 		return -1;
 	}
 

--- a/drivers/usb/device/usb_dc_stm32.c
+++ b/drivers/usb/device/usb_dc_stm32.c
@@ -298,7 +298,7 @@ static u32_t usb_dc_stm32_get_maximum_speed(void)
 	} else if (!strncmp(CONFIG_USB_MAXIMUM_SPEED, "low-speed", 9)) {
 		speed = USB_OTG_SPEED_LOW;
 	} else {
-		USB_DBG("Unsupported maximum speed defined in device tree. "
+		LOG_DBG("Unsupported maximum speed defined in device tree. "
 			"USB controller will default to its maximum HW "
 			"capability");
 	}
@@ -342,14 +342,14 @@ static int usb_dc_stm32_init(void)
 
 #endif /* USB */
 
-	USB_DBG("HAL_PCD_Init");
+	LOG_DBG("HAL_PCD_Init");
 	status = HAL_PCD_Init(&usb_dc_stm32_state.pcd);
 	if (status != HAL_OK) {
 		USB_ERR("PCD_Init failed, %d", (int)status);
 		return -EIO;
 	}
 
-	USB_DBG("HAL_PCD_Start");
+	LOG_DBG("HAL_PCD_Start");
 	status = HAL_PCD_Start(&usb_dc_stm32_state.pcd);
 	if (status != HAL_OK) {
 		USB_ERR("PCD_Start failed, %d", (int)status);
@@ -390,7 +390,7 @@ int usb_dc_attach(void)
 {
 	int ret;
 
-	USB_DBG("");
+	LOG_DBG("");
 
 	/*
 	 * For STM32F0 series SoCs on QFN28 and TSSOP20 packages enable PIN
@@ -438,7 +438,7 @@ int usb_dc_ep_set_callback(const u8_t ep, const usb_dc_ep_callback cb)
 {
 	struct usb_dc_stm32_ep_state *ep_state = usb_dc_stm32_get_ep_state(ep);
 
-	USB_DBG("ep 0x%02x", ep);
+	LOG_DBG("ep 0x%02x", ep);
 
 	if (!ep_state) {
 		return -EINVAL;
@@ -451,7 +451,7 @@ int usb_dc_ep_set_callback(const u8_t ep, const usb_dc_ep_callback cb)
 
 int usb_dc_set_status_callback(const usb_dc_status_callback cb)
 {
-	USB_DBG("");
+	LOG_DBG("");
 
 	usb_dc_stm32_state.status_cb = cb;
 
@@ -462,7 +462,7 @@ int usb_dc_set_address(const u8_t addr)
 {
 	HAL_StatusTypeDef status;
 
-	USB_DBG("addr %u (0x%02x)", addr, addr);
+	LOG_DBG("addr %u (0x%02x)", addr, addr);
 
 	status = HAL_PCD_SetAddress(&usb_dc_stm32_state.pcd, addr);
 	if (status != HAL_OK) {
@@ -478,7 +478,7 @@ int usb_dc_ep_start_read(u8_t ep, u8_t *data, u32_t max_data_len)
 {
 	HAL_StatusTypeDef status;
 
-	USB_DBG("ep 0x%02x, len %u", ep, max_data_len);
+	LOG_DBG("ep 0x%02x, len %u", ep, max_data_len);
 
 	/* we flush EP0_IN by doing a 0 length receive on it */
 	if (!EP_IS_OUT(ep) && (ep != EP0_IN || max_data_len)) {
@@ -518,7 +518,7 @@ int usb_dc_ep_check_cap(const struct usb_dc_ep_cfg_data * const cfg)
 {
 	u8_t ep_idx = EP_IDX(cfg->ep_addr);
 
-	USB_DBG("ep %x, mps %d, type %d", cfg->ep_addr, cfg->ep_mps,
+	LOG_DBG("ep %x, mps %d, type %d", cfg->ep_addr, cfg->ep_mps,
 		cfg->ep_type);
 
 	if ((cfg->ep_type == USB_DC_EP_CONTROL) && ep_idx) {
@@ -539,7 +539,7 @@ int usb_dc_ep_configure(const struct usb_dc_ep_cfg_data * const ep_cfg)
 	u8_t ep = ep_cfg->ep_addr;
 	struct usb_dc_stm32_ep_state *ep_state = usb_dc_stm32_get_ep_state(ep);
 
-	USB_DBG("ep 0x%02x, ep_mps %u, ep_type %u", ep_cfg->ep_addr,
+	LOG_DBG("ep 0x%02x, ep_mps %u, ep_type %u", ep_cfg->ep_addr,
 		ep_cfg->ep_mps, ep_cfg->ep_type);
 
 	if (!ep_state) {
@@ -582,7 +582,7 @@ int usb_dc_ep_set_stall(const u8_t ep)
 	struct usb_dc_stm32_ep_state *ep_state = usb_dc_stm32_get_ep_state(ep);
 	HAL_StatusTypeDef status;
 
-	USB_DBG("ep 0x%02x", ep);
+	LOG_DBG("ep 0x%02x", ep);
 
 	if (!ep_state) {
 		return -EINVAL;
@@ -605,7 +605,7 @@ int usb_dc_ep_clear_stall(const u8_t ep)
 	struct usb_dc_stm32_ep_state *ep_state = usb_dc_stm32_get_ep_state(ep);
 	HAL_StatusTypeDef status;
 
-	USB_DBG("ep 0x%02x", ep);
+	LOG_DBG("ep 0x%02x", ep);
 
 	if (!ep_state) {
 		return -EINVAL;
@@ -628,7 +628,7 @@ int usb_dc_ep_is_stalled(const u8_t ep, u8_t *const stalled)
 {
 	struct usb_dc_stm32_ep_state *ep_state = usb_dc_stm32_get_ep_state(ep);
 
-	USB_DBG("ep 0x%02x", ep);
+	LOG_DBG("ep 0x%02x", ep);
 
 	if (!ep_state) {
 		return -EINVAL;
@@ -644,13 +644,13 @@ int usb_dc_ep_enable(const u8_t ep)
 	struct usb_dc_stm32_ep_state *ep_state = usb_dc_stm32_get_ep_state(ep);
 	HAL_StatusTypeDef status;
 
-	USB_DBG("ep 0x%02x", ep);
+	LOG_DBG("ep 0x%02x", ep);
 
 	if (!ep_state) {
 		return -EINVAL;
 	}
 
-	USB_DBG("HAL_PCD_EP_Open(0x%02x, %u, %u)", ep, ep_state->ep_mps,
+	LOG_DBG("HAL_PCD_EP_Open(0x%02x, %u, %u)", ep, ep_state->ep_mps,
 		ep_state->ep_type);
 
 	status = HAL_PCD_EP_Open(&usb_dc_stm32_state.pcd, ep,
@@ -675,7 +675,7 @@ int usb_dc_ep_disable(const u8_t ep)
 	struct usb_dc_stm32_ep_state *ep_state = usb_dc_stm32_get_ep_state(ep);
 	HAL_StatusTypeDef status;
 
-	USB_DBG("ep 0x%02x", ep);
+	LOG_DBG("ep 0x%02x", ep);
 
 	if (!ep_state) {
 		return -EINVAL;
@@ -699,7 +699,7 @@ int usb_dc_ep_write(const u8_t ep, const u8_t *const data,
 	u32_t len = data_len;
 	int ret = 0;
 
-	USB_DBG("ep 0x%02x, len %u", ep, data_len);
+	LOG_DBG("ep 0x%02x, len %u", ep, data_len);
 
 	if (!EP_IS_IN(ep)) {
 		USB_ERR("invalid ep 0x%02x", ep);
@@ -753,7 +753,7 @@ int usb_dc_ep_read_wait(u8_t ep, u8_t *data, u32_t max_data_len,
 	struct usb_dc_stm32_ep_state *ep_state = usb_dc_stm32_get_ep_state(ep);
 	u32_t read_count = ep_state->read_count;
 
-	USB_DBG("ep 0x%02x, %u bytes, %u+%u, %p", ep, max_data_len,
+	LOG_DBG("ep 0x%02x, %u bytes, %u+%u, %p", ep, max_data_len,
 		ep_state->read_offset, read_count, data);
 
 	if (!EP_IS_OUT(ep)) { /* check if OUT ep */
@@ -828,7 +828,7 @@ int usb_dc_ep_mps(const u8_t ep)
 
 void HAL_PCD_ResetCallback(PCD_HandleTypeDef *hpcd)
 {
-	USB_DBG("");
+	LOG_DBG("");
 
 	HAL_PCD_EP_Open(&usb_dc_stm32_state.pcd, EP0_IN, EP0_MPS, EP_TYPE_CTRL);
 	HAL_PCD_EP_Open(&usb_dc_stm32_state.pcd, EP0_OUT, EP0_MPS,
@@ -841,7 +841,7 @@ void HAL_PCD_ResetCallback(PCD_HandleTypeDef *hpcd)
 
 void HAL_PCD_ConnectCallback(PCD_HandleTypeDef *hpcd)
 {
-	USB_DBG("");
+	LOG_DBG("");
 
 	if (usb_dc_stm32_state.status_cb) {
 		usb_dc_stm32_state.status_cb(USB_DC_CONNECTED, NULL);
@@ -850,7 +850,7 @@ void HAL_PCD_ConnectCallback(PCD_HandleTypeDef *hpcd)
 
 void HAL_PCD_DisconnectCallback(PCD_HandleTypeDef *hpcd)
 {
-	USB_DBG("");
+	LOG_DBG("");
 
 	if (usb_dc_stm32_state.status_cb) {
 		usb_dc_stm32_state.status_cb(USB_DC_DISCONNECTED, NULL);
@@ -859,7 +859,7 @@ void HAL_PCD_DisconnectCallback(PCD_HandleTypeDef *hpcd)
 
 void HAL_PCD_SuspendCallback(PCD_HandleTypeDef *hpcd)
 {
-	USB_DBG("");
+	LOG_DBG("");
 
 	if (usb_dc_stm32_state.status_cb) {
 		usb_dc_stm32_state.status_cb(USB_DC_SUSPEND, NULL);
@@ -868,7 +868,7 @@ void HAL_PCD_SuspendCallback(PCD_HandleTypeDef *hpcd)
 
 void HAL_PCD_ResumeCallback(PCD_HandleTypeDef *hpcd)
 {
-	USB_DBG("");
+	LOG_DBG("");
 
 	if (usb_dc_stm32_state.status_cb) {
 		usb_dc_stm32_state.status_cb(USB_DC_RESUME, NULL);
@@ -880,7 +880,7 @@ void HAL_PCD_SetupStageCallback(PCD_HandleTypeDef *hpcd)
 	struct usb_setup_packet *setup = (void *)usb_dc_stm32_state.pcd.Setup;
 	struct usb_dc_stm32_ep_state *ep_state;
 
-	USB_DBG("");
+	LOG_DBG("");
 
 	ep_state = usb_dc_stm32_get_ep_state(EP0_OUT); /* can't fail for ep0 */
 	ep_state->read_count = SETUP_SIZE;
@@ -907,7 +907,7 @@ void HAL_PCD_DataOutStageCallback(PCD_HandleTypeDef *hpcd, u8_t epnum)
 	u8_t ep = ep_idx | USB_EP_DIR_OUT;
 	struct usb_dc_stm32_ep_state *ep_state = usb_dc_stm32_get_ep_state(ep);
 
-	USB_DBG("epnum 0x%02x, rx_count %u", epnum,
+	LOG_DBG("epnum 0x%02x, rx_count %u", epnum,
 		HAL_PCD_EP_GetRxCount(&usb_dc_stm32_state.pcd, epnum));
 
 	/* Transaction complete, data is now stored in the buffer and ready
@@ -927,7 +927,7 @@ void HAL_PCD_DataInStageCallback(PCD_HandleTypeDef *hpcd, u8_t epnum)
 	u8_t ep = ep_idx | USB_EP_DIR_IN;
 	struct usb_dc_stm32_ep_state *ep_state = usb_dc_stm32_get_ep_state(ep);
 
-	USB_DBG("epnum 0x%02x", epnum);
+	LOG_DBG("epnum 0x%02x", epnum);
 
 	k_sem_give(&ep_state->write_sem);
 

--- a/drivers/usb/device/usb_dc_stm32.c
+++ b/drivers/usb/device/usb_dc_stm32.c
@@ -233,7 +233,7 @@ static int usb_dc_stm32_clock_enable(void)
 	if (LL_APB2_GRP1_IsEnabledClock(LL_APB2_GRP1_PERIPH_SYSCFG)) {
 		LL_SYSCFG_VREFINT_EnableHSI48();
 	} else {
-		USB_ERR("System Configuration Controller clock is "
+		LOG_ERR("System Configuration Controller clock is "
 			"disabled. Unable to enable VREFINT which "
 			"is required by HSI48.");
 	}
@@ -249,7 +249,7 @@ static int usb_dc_stm32_clock_enable(void)
 	if (LL_RCC_PLL_IsReady()) {
 		LL_RCC_SetUSBClockSource(LL_RCC_USB_CLKSOURCE_PLL);
 	} else {
-		USB_ERR("Unable to set USB clock source to PLL.");
+		LOG_ERR("Unable to set USB clock source to PLL.");
 	}
 #endif /* RCC_HSI48_SUPPORT / LL_RCC_USB_CLKSOURCE_NONE */
 
@@ -345,14 +345,14 @@ static int usb_dc_stm32_init(void)
 	LOG_DBG("HAL_PCD_Init");
 	status = HAL_PCD_Init(&usb_dc_stm32_state.pcd);
 	if (status != HAL_OK) {
-		USB_ERR("PCD_Init failed, %d", (int)status);
+		LOG_ERR("PCD_Init failed, %d", (int)status);
 		return -EIO;
 	}
 
 	LOG_DBG("HAL_PCD_Start");
 	status = HAL_PCD_Start(&usb_dc_stm32_state.pcd);
 	if (status != HAL_OK) {
-		USB_ERR("PCD_Start failed, %d", (int)status);
+		LOG_ERR("PCD_Start failed, %d", (int)status);
 		return -EIO;
 	}
 
@@ -400,7 +400,7 @@ int usb_dc_attach(void)
 	if (LL_APB1_GRP2_IsEnabledClock(LL_APB1_GRP2_PERIPH_SYSCFG)) {
 		LL_SYSCFG_EnablePinRemap();
 	} else {
-		USB_ERR("System Configuration Controller clock is "
+		LOG_ERR("System Configuration Controller clock is "
 			"disable. Unable to enable pin remapping."
 	}
 #endif
@@ -466,7 +466,7 @@ int usb_dc_set_address(const u8_t addr)
 
 	status = HAL_PCD_SetAddress(&usb_dc_stm32_state.pcd, addr);
 	if (status != HAL_OK) {
-		USB_ERR("HAL_PCD_SetAddress failed(0x%02x), %d", addr,
+		LOG_ERR("HAL_PCD_SetAddress failed(0x%02x), %d", addr,
 			(int)status);
 		return -EIO;
 	}
@@ -482,7 +482,7 @@ int usb_dc_ep_start_read(u8_t ep, u8_t *data, u32_t max_data_len)
 
 	/* we flush EP0_IN by doing a 0 length receive on it */
 	if (!EP_IS_OUT(ep) && (ep != EP0_IN || max_data_len)) {
-		USB_ERR("invalid ep 0x%02x", ep);
+		LOG_ERR("invalid ep 0x%02x", ep);
 		return -EINVAL;
 	}
 
@@ -494,7 +494,7 @@ int usb_dc_ep_start_read(u8_t ep, u8_t *data, u32_t max_data_len)
 				    usb_dc_stm32_state.ep_buf[EP_IDX(ep)],
 				    max_data_len);
 	if (status != HAL_OK) {
-		USB_ERR("HAL_PCD_EP_Receive failed(0x%02x), %d", ep,
+		LOG_ERR("HAL_PCD_EP_Receive failed(0x%02x), %d", ep,
 			(int)status);
 		return -EIO;
 	}
@@ -505,7 +505,7 @@ int usb_dc_ep_start_read(u8_t ep, u8_t *data, u32_t max_data_len)
 int usb_dc_ep_get_read_count(u8_t ep, u32_t *read_bytes)
 {
 	if (!EP_IS_OUT(ep)) {
-		USB_ERR("invalid ep 0x%02x", ep);
+		LOG_ERR("invalid ep 0x%02x", ep);
 		return -EINVAL;
 	}
 
@@ -522,12 +522,12 @@ int usb_dc_ep_check_cap(const struct usb_dc_ep_cfg_data * const cfg)
 		cfg->ep_type);
 
 	if ((cfg->ep_type == USB_DC_EP_CONTROL) && ep_idx) {
-		USB_ERR("invalid endpoint configuration");
+		LOG_ERR("invalid endpoint configuration");
 		return -1;
 	}
 
 	if (ep_idx > CONFIG_USB_NUM_BIDIR_ENDPOINTS) {
-		USB_ERR("endpoint index/address out of range");
+		LOG_ERR("endpoint index/address out of range");
 		return -1;
 	}
 
@@ -590,7 +590,7 @@ int usb_dc_ep_set_stall(const u8_t ep)
 
 	status = HAL_PCD_EP_SetStall(&usb_dc_stm32_state.pcd, ep);
 	if (status != HAL_OK) {
-		USB_ERR("HAL_PCD_EP_SetStall failed(0x%02x), %d", ep,
+		LOG_ERR("HAL_PCD_EP_SetStall failed(0x%02x), %d", ep,
 			(int)status);
 		return -EIO;
 	}
@@ -613,7 +613,7 @@ int usb_dc_ep_clear_stall(const u8_t ep)
 
 	status = HAL_PCD_EP_ClrStall(&usb_dc_stm32_state.pcd, ep);
 	if (status != HAL_OK) {
-		USB_ERR("HAL_PCD_EP_ClrStall failed(0x%02x), %d", ep,
+		LOG_ERR("HAL_PCD_EP_ClrStall failed(0x%02x), %d", ep,
 			(int)status);
 		return -EIO;
 	}
@@ -656,7 +656,7 @@ int usb_dc_ep_enable(const u8_t ep)
 	status = HAL_PCD_EP_Open(&usb_dc_stm32_state.pcd, ep,
 				 ep_state->ep_mps, ep_state->ep_type);
 	if (status != HAL_OK) {
-		USB_ERR("HAL_PCD_EP_Open failed(0x%02x), %d", ep,
+		LOG_ERR("HAL_PCD_EP_Open failed(0x%02x), %d", ep,
 			(int)status);
 		return -EIO;
 	}
@@ -683,7 +683,7 @@ int usb_dc_ep_disable(const u8_t ep)
 
 	status = HAL_PCD_EP_Close(&usb_dc_stm32_state.pcd, ep);
 	if (status != HAL_OK) {
-		USB_ERR("HAL_PCD_EP_Close failed(0x%02x), %d", ep,
+		LOG_ERR("HAL_PCD_EP_Close failed(0x%02x), %d", ep,
 			(int)status);
 		return -EIO;
 	}
@@ -702,13 +702,13 @@ int usb_dc_ep_write(const u8_t ep, const u8_t *const data,
 	LOG_DBG("ep 0x%02x, len %u", ep, data_len);
 
 	if (!EP_IS_IN(ep)) {
-		USB_ERR("invalid ep 0x%02x", ep);
+		LOG_ERR("invalid ep 0x%02x", ep);
 		return -EINVAL;
 	}
 
 	ret = k_sem_take(&ep_state->write_sem, K_NO_WAIT);
 	if (ret) {
-		USB_ERR("Unable to write ep 0x%02x (%d)", ep, ret);
+		LOG_ERR("Unable to write ep 0x%02x (%d)", ep, ret);
 		return ret;
 	}
 
@@ -723,7 +723,7 @@ int usb_dc_ep_write(const u8_t ep, const u8_t *const data,
 	status = HAL_PCD_EP_Transmit(&usb_dc_stm32_state.pcd, ep,
 				     (void *)data, len);
 	if (status != HAL_OK) {
-		USB_ERR("HAL_PCD_EP_Transmit failed(0x%02x), %d", ep,
+		LOG_ERR("HAL_PCD_EP_Transmit failed(0x%02x), %d", ep,
 			(int)status);
 		k_sem_give(&ep_state->write_sem);
 		ret = -EIO;
@@ -757,7 +757,7 @@ int usb_dc_ep_read_wait(u8_t ep, u8_t *data, u32_t max_data_len,
 		ep_state->read_offset, read_count, data);
 
 	if (!EP_IS_OUT(ep)) { /* check if OUT ep */
-		USB_ERR("Wrong endpoint direction: 0x%02x", ep);
+		LOG_ERR("Wrong endpoint direction: 0x%02x", ep);
 		return -EINVAL;
 	}
 
@@ -772,7 +772,7 @@ int usb_dc_ep_read_wait(u8_t ep, u8_t *data, u32_t max_data_len,
 		ep_state->read_count -= read_count;
 		ep_state->read_offset += read_count;
 	} else if (max_data_len) {
-		USB_ERR("Wrong arguments");
+		LOG_ERR("Wrong arguments");
 	}
 
 	if (read_bytes) {
@@ -787,7 +787,7 @@ int usb_dc_ep_read_continue(u8_t ep)
 	struct usb_dc_stm32_ep_state *ep_state = usb_dc_stm32_get_ep_state(ep);
 
 	if (!EP_IS_OUT(ep)) { /* Check if OUT ep */
-		USB_ERR("Not valid endpoint: %02x", ep);
+		LOG_ERR("Not valid endpoint: %02x", ep);
 		return -EINVAL;
 	}
 

--- a/include/usb/usb_device.h
+++ b/include/usb/usb_device.h
@@ -44,13 +44,6 @@
 extern "C" {
 #endif
 
-#if defined(CONFIG_LOG_FUNCTION_NAME)
-#define USB_DBG(fmt, ...) LOG_DBG("(%p): " fmt, k_current_get(), \
-				##__VA_ARGS__)
-#else
-#define USB_DBG(fmt, ...) LOG_DBG("(%p): %s: " fmt, k_current_get(), \
-				  __func__, ##__VA_ARGS__)
-#endif /* CONFIG_LOG_FUNCTION_NAME */
 #define USB_ERR(fmt, ...) LOG_ERR(fmt, ##__VA_ARGS__)
 #define USB_WRN(fmt, ...) LOG_WRN(fmt, ##__VA_ARGS__)
 #define USB_INF(fmt, ...) LOG_INF(fmt, ##__VA_ARGS__)

--- a/include/usb/usb_device.h
+++ b/include/usb/usb_device.h
@@ -44,7 +44,6 @@
 extern "C" {
 #endif
 
-#define USB_ERR(fmt, ...) LOG_ERR(fmt, ##__VA_ARGS__)
 #define USB_WRN(fmt, ...) LOG_WRN(fmt, ##__VA_ARGS__)
 #define USB_INF(fmt, ...) LOG_INF(fmt, ##__VA_ARGS__)
 

--- a/include/usb/usb_device.h
+++ b/include/usb/usb_device.h
@@ -44,8 +44,6 @@
 extern "C" {
 #endif
 
-#define USB_WRN(fmt, ...) LOG_WRN(fmt, ##__VA_ARGS__)
-
 /*
  * These macros should be used to place the USB descriptors
  * in predetermined order in the RAM.

--- a/include/usb/usb_device.h
+++ b/include/usb/usb_device.h
@@ -45,7 +45,6 @@ extern "C" {
 #endif
 
 #define USB_WRN(fmt, ...) LOG_WRN(fmt, ##__VA_ARGS__)
-#define USB_INF(fmt, ...) LOG_INF(fmt, ##__VA_ARGS__)
 
 /*
  * These macros should be used to place the USB descriptors

--- a/include/usb/usb_device.h
+++ b/include/usb/usb_device.h
@@ -44,8 +44,13 @@
 extern "C" {
 #endif
 
+#if defined(CONFIG_LOG_FUNCTION_NAME)
+#define USB_DBG(fmt, ...) LOG_DBG("(%p): " fmt, k_current_get(), \
+				##__VA_ARGS__)
+#else
 #define USB_DBG(fmt, ...) LOG_DBG("(%p): %s: " fmt, k_current_get(), \
 				  __func__, ##__VA_ARGS__)
+#endif /* CONFIG_LOG_FUNCTION_NAME */
 #define USB_ERR(fmt, ...) LOG_ERR(fmt, ##__VA_ARGS__)
 #define USB_WRN(fmt, ...) LOG_WRN(fmt, ##__VA_ARGS__)
 #define USB_INF(fmt, ...) LOG_INF(fmt, ##__VA_ARGS__)

--- a/samples/net/wpanusb/src/wpanusb.c
+++ b/samples/net/wpanusb/src/wpanusb.c
@@ -264,14 +264,14 @@ static int set_pan_id(void *data, int len)
 
 static int start(void)
 {
-	USB_INF("Start IEEE 802.15.4 device");
+	LOG_INF("Start IEEE 802.15.4 device");
 
 	return radio_api->start(ieee802154_dev);
 }
 
 static int stop(void)
 {
-	USB_INF("Stop IEEE 802.15.4 device");
+	LOG_INF("Stop IEEE 802.15.4 device");
 
 	return radio_api->stop(ieee802154_dev);
 }
@@ -498,7 +498,7 @@ void main(void)
 {
 	wpanusb_start(&__dev);
 
-	USB_INF("Start");
+	LOG_INF("Start");
 
 	ieee802154_dev = device_get_binding(CONFIG_NET_CONFIG_IEEE802154_DEV_NAME);
 	if (!ieee802154_dev) {

--- a/samples/net/wpanusb/src/wpanusb.c
+++ b/samples/net/wpanusb/src/wpanusb.c
@@ -290,7 +290,7 @@ static int tx(struct net_pkt *pkt)
 	} while (ret && retries--);
 
 	if (ret) {
-		USB_ERR("Error sending data, seq %u", seq);
+		LOG_ERR("Error sending data, seq %u", seq);
 		/* Send seq = 0 for unsuccessful send */
 		seq = 0;
 	}
@@ -380,7 +380,7 @@ static void tx_thread(void)
 			set_pan_id(buf->data, buf->len);
 			break;
 		default:
-			USB_ERR("%x: Not handled for now", cmd);
+			LOG_ERR("%x: Not handled for now", cmd);
 			break;
 		}
 
@@ -419,14 +419,14 @@ static int wpanusb_init(struct device *dev)
 	/* Initialize the USB driver with the right configuration */
 	ret = usb_set_config(&wpanusb_config);
 	if (ret < 0) {
-		USB_ERR("Failed to configure USB");
+		LOG_ERR("Failed to configure USB");
 		return ret;
 	}
 
 	/* Enable USB driver */
 	ret = usb_enable(&wpanusb_config);
 	if (ret < 0) {
-		USB_ERR("Failed to enable USB");
+		LOG_ERR("Failed to enable USB");
 		return ret;
 	}
 
@@ -502,7 +502,7 @@ void main(void)
 
 	ieee802154_dev = device_get_binding(CONFIG_NET_CONFIG_IEEE802154_DEV_NAME);
 	if (!ieee802154_dev) {
-		USB_ERR("Cannot get IEEE802.15.4 device");
+		LOG_ERR("Cannot get IEEE802.15.4 device");
 		return;
 	}
 

--- a/samples/net/wpanusb/src/wpanusb.c
+++ b/samples/net/wpanusb/src/wpanusb.c
@@ -148,29 +148,29 @@ static void wpanusb_status_cb(enum usb_dc_status_code status, const u8_t *param)
 	/* Check the USB status and do needed action if required */
 	switch (status) {
 	case USB_DC_ERROR:
-		USB_DBG("USB device error");
+		LOG_DBG("USB device error");
 		break;
 	case USB_DC_RESET:
-		USB_DBG("USB device reset detected");
+		LOG_DBG("USB device reset detected");
 		break;
 	case USB_DC_CONNECTED:
-		USB_DBG("USB device connected");
+		LOG_DBG("USB device connected");
 		break;
 	case USB_DC_CONFIGURED:
-		USB_DBG("USB device configured");
+		LOG_DBG("USB device configured");
 		break;
 	case USB_DC_DISCONNECTED:
-		USB_DBG("USB device disconnected");
+		LOG_DBG("USB device disconnected");
 		break;
 	case USB_DC_SUSPEND:
-		USB_DBG("USB device suspended");
+		LOG_DBG("USB device suspended");
 		break;
 	case USB_DC_RESUME:
-		USB_DBG("USB device resumed");
+		LOG_DBG("USB device resumed");
 		break;
 	case USB_DC_UNKNOWN:
 	default:
-		USB_DBG("USB unknown state");
+		LOG_DBG("USB unknown state");
 		break;
 		}
 }
@@ -196,7 +196,7 @@ static int set_channel(void *data, int len)
 {
 	struct set_channel *req = data;
 
-	USB_DBG("page %u channel %u", req->page, req->channel);
+	LOG_DBG("page %u channel %u", req->page, req->channel);
 
 	return radio_api->set_channel(ieee802154_dev, req->channel);
 }
@@ -205,7 +205,7 @@ static int set_ieee_addr(void *data, int len)
 {
 	struct set_ieee_addr *req = data;
 
-	USB_DBG("len %u", len);
+	LOG_DBG("len %u", len);
 
 	if (IEEE802154_HW_FILTER &
 	    radio_api->get_capabilities(ieee802154_dev)) {
@@ -225,7 +225,7 @@ static int set_short_addr(void *data, int len)
 {
 	struct set_short_addr *req = data;
 
-	USB_DBG("len %u", len);
+	LOG_DBG("len %u", len);
 
 
 	if (IEEE802154_HW_FILTER &
@@ -246,7 +246,7 @@ static int set_pan_id(void *data, int len)
 {
 	struct set_pan_id *req = data;
 
-	USB_DBG("len %u", len);
+	LOG_DBG("len %u", len);
 
 	if (IEEE802154_HW_FILTER &
 	    radio_api->get_capabilities(ieee802154_dev)) {
@@ -283,7 +283,7 @@ static int tx(struct net_pkt *pkt)
 	int retries = 3;
 	int ret;
 
-	USB_DBG("len %d seq %u", buf->len, seq);
+	LOG_DBG("len %d seq %u", buf->len, seq);
 
 	do {
 		ret = radio_api->tx(ieee802154_dev, pkt, buf);
@@ -332,7 +332,7 @@ static int wpanusb_vendor_handler(struct usb_setup_packet *setup,
 
 	memcpy(net_buf_add(buf, *len), *data, *len);
 
-	USB_DBG("len %u seq %u", *len, setup->wIndex);
+	LOG_DBG("len %u seq %u", *len, setup->wIndex);
 
 	k_fifo_put(&tx_queue, pkt);
 
@@ -341,7 +341,7 @@ static int wpanusb_vendor_handler(struct usb_setup_packet *setup,
 
 static void tx_thread(void)
 {
-	USB_DBG("Tx thread started");
+	LOG_DBG("Tx thread started");
 
 	while (1) {
 		u8_t cmd;
@@ -356,7 +356,7 @@ static void tx_thread(void)
 
 		switch (cmd) {
 		case RESET:
-			USB_DBG("Reset device");
+			LOG_DBG("Reset device");
 			break;
 		case TX:
 			tx(pkt);
@@ -411,7 +411,7 @@ static int wpanusb_init(struct device *dev)
 	struct wpanusb_dev_data_t * const dev_data = DEV_DATA(dev);
 	int ret;
 
-	USB_DBG("");
+	LOG_DBG("");
 
 	wpanusb_config.interface.payload_data = dev_data->interface_data;
 	wpanusb_dev = dev;
@@ -471,7 +471,7 @@ int net_recv_data(struct net_if *iface, struct net_pkt *pkt)
 {
 	struct net_buf *frag;
 
-	USB_DBG("Got data, pkt %p, len %d", pkt, net_pkt_get_len(pkt));
+	LOG_DBG("Got data, pkt %p, len %d", pkt, net_pkt_get_len(pkt));
 
 	frag = net_buf_frag_last(pkt->frags);
 
@@ -516,5 +516,5 @@ void main(void)
 
 	/* TODO: Initialize more */
 
-	USB_DBG("radio_api %p initialized", radio_api);
+	LOG_DBG("radio_api %p initialized", radio_api);
 }

--- a/samples/subsys/usb/hid/src/main.c
+++ b/samples/subsys/usb/hid/src/main.c
@@ -59,7 +59,7 @@ static const u8_t hid_report_desc[] = {
 static int debug_cb(struct usb_setup_packet *setup, s32_t *len,
 		    u8_t **data)
 {
-	USB_DBG("Debug callback");
+	LOG_DBG("Debug callback");
 
 	return -ENOTSUP;
 }
@@ -67,7 +67,7 @@ static int debug_cb(struct usb_setup_packet *setup, s32_t *len,
 static int set_idle_cb(struct usb_setup_packet *setup, s32_t *len,
 		       u8_t **data)
 {
-	USB_DBG("Set Idle callback");
+	LOG_DBG("Set Idle callback");
 
 	/* TODO: Do something */
 
@@ -77,7 +77,7 @@ static int set_idle_cb(struct usb_setup_packet *setup, s32_t *len,
 static int get_report_cb(struct usb_setup_packet *setup, s32_t *len,
 			 u8_t **data)
 {
-	USB_DBG("Get report callback");
+	LOG_DBG("Get report callback");
 
 	/* TODO: Do something */
 
@@ -91,7 +91,7 @@ static void send_report(struct k_work *work)
 
 	ret = hid_int_ep_write(report_1, sizeof(report_1), &wrote);
 
-	USB_DBG("Wrote %d bytes with ret %d", wrote, ret);
+	LOG_DBG("Wrote %d bytes with ret %d", wrote, ret);
 
 	/* Increment reported data */
 	report_1[1]++;
@@ -109,7 +109,7 @@ static void status_cb(enum usb_dc_status_code status, const u8_t *param)
 		in_ready_cb();
 		break;
 	default:
-		USB_DBG("status %u unhandled", status);
+		LOG_DBG("status %u unhandled", status);
 		break;
 	}
 }
@@ -127,7 +127,7 @@ static const struct hid_ops ops = {
 
 void main(void)
 {
-	USB_DBG("Starting application");
+	LOG_DBG("Starting application");
 
 	k_delayed_work_init(&delayed_report_send, send_report);
 

--- a/subsys/usb/bos.c
+++ b/subsys/usb/bos.c
@@ -55,7 +55,7 @@ void usb_bos_register_cap(struct usb_bos_platform_descriptor *desc)
 int usb_handle_bos(struct usb_setup_packet *setup,
 		   s32_t *len, u8_t **data)
 {
-	USB_DBG("wValue 0x%x", setup->wValue);
+	LOG_DBG("wValue 0x%x", setup->wValue);
 
 	if (GET_DESC_TYPE(setup->wValue) == DESCRIPTOR_TYPE_BOS) {
 		*data = (u8_t *)usb_bos_get_header();

--- a/subsys/usb/class/bluetooth.c
+++ b/subsys/usb/class/bluetooth.c
@@ -129,7 +129,7 @@ static struct usb_ep_cfg_data bluetooth_ep_data[] = {
 
 static void hci_rx_thread(void)
 {
-	USB_DBG("Start USB Bluetooth thread");
+	LOG_DBG("Start USB Bluetooth thread");
 
 	while (true) {
 		struct net_buf *buf;
@@ -205,35 +205,35 @@ static void bluetooth_status_cb(enum usb_dc_status_code status,
 	/* Check the USB status and do needed action if required */
 	switch (status) {
 	case USB_DC_ERROR:
-		USB_DBG("USB device error");
+		LOG_DBG("USB device error");
 		break;
 	case USB_DC_RESET:
-		USB_DBG("USB device reset detected");
+		LOG_DBG("USB device reset detected");
 		break;
 	case USB_DC_CONNECTED:
-		USB_DBG("USB device connected");
+		LOG_DBG("USB device connected");
 		break;
 	case USB_DC_CONFIGURED:
-		USB_DBG("USB device configured");
+		LOG_DBG("USB device configured");
 		/* Start reading */
 		acl_read_cb(bluetooth_ep_data[HCI_OUT_EP_IDX].ep_addr, 0, NULL);
 		break;
 	case USB_DC_DISCONNECTED:
-		USB_DBG("USB device disconnected");
+		LOG_DBG("USB device disconnected");
 		/* Cancel any transfer */
 		usb_cancel_transfer(bluetooth_ep_data[HCI_INT_EP_IDX].ep_addr);
 		usb_cancel_transfer(bluetooth_ep_data[HCI_IN_EP_IDX].ep_addr);
 		usb_cancel_transfer(bluetooth_ep_data[HCI_OUT_EP_IDX].ep_addr);
 		break;
 	case USB_DC_SUSPEND:
-		USB_DBG("USB device suspended");
+		LOG_DBG("USB device suspended");
 		break;
 	case USB_DC_RESUME:
-		USB_DBG("USB device resumed");
+		LOG_DBG("USB device resumed");
 		break;
 	case USB_DC_UNKNOWN:
 	default:
-		USB_DBG("USB unknown state");
+		LOG_DBG("USB unknown state");
 		break;
 	}
 }
@@ -243,7 +243,7 @@ static int bluetooth_class_handler(struct usb_setup_packet *setup,
 {
 	struct net_buf *buf;
 
-	USB_DBG("len %u", *len);
+	LOG_DBG("len %u", *len);
 
 	if (!*len || *len > CMD_BUF_SIZE) {
 		USB_ERR("Incorrect length: %d\n", *len);
@@ -290,7 +290,7 @@ static int bluetooth_init(struct device *dev)
 {
 	int ret;
 
-	USB_DBG("Initialization");
+	LOG_DBG("Initialization");
 
 	ret = bt_enable_raw(&rx_queue);
 	if (ret) {

--- a/subsys/usb/class/bluetooth.c
+++ b/subsys/usb/class/bluetooth.c
@@ -150,7 +150,7 @@ static void hci_rx_thread(void)
 				USB_TRANS_WRITE);
 			break;
 		default:
-			USB_ERR("Unknown type %u", bt_buf_get_type(buf));
+			LOG_ERR("Unknown type %u", bt_buf_get_type(buf));
 			break;
 		}
 
@@ -166,7 +166,7 @@ static void hci_tx_thread(void)
 		buf = net_buf_get(&tx_queue, K_FOREVER);
 
 		if (bt_send(buf)) {
-			USB_ERR("Error sending to driver");
+			LOG_ERR("Error sending to driver");
 			net_buf_unref(buf);
 		}
 	}
@@ -189,7 +189,7 @@ static void acl_read_cb(u8_t ep, int size, void *priv)
 
 	buf = net_buf_alloc(&acl_tx_pool, K_NO_WAIT);
 	if (!buf) {
-		USB_ERR("Cannot get free buffer\n");
+		LOG_ERR("Cannot get free buffer\n");
 		return;
 	}
 	net_buf_reserve(buf, CONFIG_BT_HCI_RESERVE);
@@ -246,13 +246,13 @@ static int bluetooth_class_handler(struct usb_setup_packet *setup,
 	LOG_DBG("len %u", *len);
 
 	if (!*len || *len > CMD_BUF_SIZE) {
-		USB_ERR("Incorrect length: %d\n", *len);
+		LOG_ERR("Incorrect length: %d\n", *len);
 		return -EINVAL;
 	}
 
 	buf = net_buf_alloc(&tx_pool, K_NO_WAIT);
 	if (!buf) {
-		USB_ERR("Cannot get free buffer\n");
+		LOG_ERR("Cannot get free buffer\n");
 		return -ENOMEM;
 	}
 
@@ -294,7 +294,7 @@ static int bluetooth_init(struct device *dev)
 
 	ret = bt_enable_raw(&rx_queue);
 	if (ret) {
-		USB_ERR("Failed to open Bluetooth raw channel: %d", ret);
+		LOG_ERR("Failed to open Bluetooth raw channel: %d", ret);
 		return ret;
 	}
 
@@ -305,14 +305,14 @@ static int bluetooth_init(struct device *dev)
 	/* Initialize the USB driver with the right configuration */
 	ret = usb_set_config(&bluetooth_config);
 	if (ret < 0) {
-		USB_ERR("Failed to config USB");
+		LOG_ERR("Failed to config USB");
 		return ret;
 	}
 
 	/* Enable USB driver */
 	ret = usb_enable(&bluetooth_config);
 	if (ret < 0) {
-		USB_ERR("Failed to enable USB");
+		LOG_ERR("Failed to enable USB");
 		return ret;
 	}
 #endif

--- a/subsys/usb/class/cdc_acm.c
+++ b/subsys/usb/class/cdc_acm.c
@@ -258,7 +258,7 @@ int cdc_acm_class_handle_req(struct usb_setup_packet *pSetup,
 	case SET_LINE_CODING:
 		memcpy(&dev_data->line_coding,
 		       *data, sizeof(dev_data->line_coding));
-		USB_DBG("\nCDC_SET_LINE_CODING %d %d %d %d",
+		LOG_DBG("\nCDC_SET_LINE_CODING %d %d %d %d",
 			sys_le32_to_cpu(dev_data->line_coding.dwDTERate),
 			dev_data->line_coding.bCharFormat,
 			dev_data->line_coding.bParityType,
@@ -267,14 +267,14 @@ int cdc_acm_class_handle_req(struct usb_setup_packet *pSetup,
 
 	case SET_CONTROL_LINE_STATE:
 		dev_data->line_state = (u8_t)sys_le16_to_cpu(pSetup->wValue);
-		USB_DBG("CDC_SET_CONTROL_LINE_STATE 0x%x",
+		LOG_DBG("CDC_SET_CONTROL_LINE_STATE 0x%x",
 			dev_data->line_state);
 		break;
 
 	case GET_LINE_CODING:
 		*data = (u8_t *)(&dev_data->line_coding);
 		*len = sizeof(dev_data->line_coding);
-		USB_DBG("\nCDC_GET_LINE_CODING %d %d %d %d",
+		LOG_DBG("\nCDC_GET_LINE_CODING %d %d %d %d",
 			sys_le32_to_cpu(dev_data->line_coding.dwDTERate),
 			dev_data->line_coding.bCharFormat,
 			dev_data->line_coding.bParityType,
@@ -282,7 +282,7 @@ int cdc_acm_class_handle_req(struct usb_setup_packet *pSetup,
 		break;
 
 	default:
-		USB_DBG("CDC ACM request 0x%x, value 0x%x",
+		LOG_DBG("CDC ACM request 0x%x, value 0x%x",
 			pSetup->bRequest, pSetup->wValue);
 		return -EINVAL;
 	}
@@ -382,7 +382,7 @@ static void cdc_acm_int_in(u8_t ep, enum usb_dc_ep_cb_status_code ep_status)
 	ARG_UNUSED(ep_status);
 
 	dev_data->notification_sent = 1;
-	USB_DBG("CDC_IntIN EP[%x]\r", ep);
+	LOG_DBG("CDC_IntIN EP[%x]\r", ep);
 }
 
 /**
@@ -405,29 +405,29 @@ static void cdc_acm_dev_status_cb(enum usb_dc_status_code status,
 	/* Check the USB status and do needed action if required */
 	switch (status) {
 	case USB_DC_ERROR:
-		USB_DBG("USB device error");
+		LOG_DBG("USB device error");
 		break;
 	case USB_DC_RESET:
-		USB_DBG("USB device reset detected");
+		LOG_DBG("USB device reset detected");
 		break;
 	case USB_DC_CONNECTED:
-		USB_DBG("USB device connected");
+		LOG_DBG("USB device connected");
 		break;
 	case USB_DC_CONFIGURED:
-		USB_DBG("USB device configured");
+		LOG_DBG("USB device configured");
 		break;
 	case USB_DC_DISCONNECTED:
-		USB_DBG("USB device disconnected");
+		LOG_DBG("USB device disconnected");
 		break;
 	case USB_DC_SUSPEND:
-		USB_DBG("USB device suspended");
+		LOG_DBG("USB device suspended");
 		break;
 	case USB_DC_RESUME:
-		USB_DBG("USB device resumed");
+		LOG_DBG("USB device resumed");
 		break;
 	case USB_DC_UNKNOWN:
 	default:
-		USB_DBG("USB unknown state");
+		LOG_DBG("USB unknown state");
 		break;
 	}
 }
@@ -791,7 +791,7 @@ static int cdc_acm_send_notification(struct device *dev, u16_t serial_state)
 		k_busy_wait(1);
 
 		if (++cnt > CDC_CONTROL_SERIAL_STATE_TIMEOUT_US) {
-			USB_DBG("CDC ACM notification timeout!");
+			LOG_DBG("CDC ACM notification timeout!");
 			return -EIO;
 		}
 	}

--- a/subsys/usb/class/cdc_acm.c
+++ b/subsys/usb/class/cdc_acm.c
@@ -351,7 +351,7 @@ static void cdc_acm_bulk_out(u8_t ep,
 			if (((buf_head + 1) % CDC_ACM_BUFFER_SIZE) ==
 			    dev_data->rx_buf_tail) {
 				/* FIFO full, discard data */
-				USB_ERR("CDC buffer full!");
+				LOG_ERR("CDC buffer full!");
 			} else {
 				dev_data->rx_buf[buf_head] = tmp_buf[j];
 				buf_head = (buf_head + 1) % CDC_ACM_BUFFER_SIZE;
@@ -514,14 +514,14 @@ static int cdc_acm_init(struct device *dev)
 	/* Initialize the USB driver with the right configuration */
 	ret = usb_set_config(&cdc_acm_config);
 	if (ret < 0) {
-		USB_ERR("Failed to config USB");
+		LOG_ERR("Failed to config USB");
 		return ret;
 	}
 
 	/* Enable USB driver */
 	ret = usb_enable(&cdc_acm_config);
 	if (ret < 0) {
-		USB_ERR("Failed to enable USB");
+		LOG_ERR("Failed to enable USB");
 		return ret;
 	}
 #endif

--- a/subsys/usb/class/hid/core.c
+++ b/subsys/usb/class/hid/core.c
@@ -195,7 +195,7 @@ static int hid_custom_handle_req(struct usb_setup_packet *setup,
 			 * already tell it the right descriptor size.
 			 * So truncated wLength if it doesn't match. */
 			if (*len != hid_device.report_size) {
-				USB_WRN("len %d doesn't match "
+				LOG_WRN("len %d doesn't match "
 					"Report Descriptor size", *len);
 				*len = min(*len, hid_device.report_size);
 			}

--- a/subsys/usb/class/hid/core.c
+++ b/subsys/usb/class/hid/core.c
@@ -102,29 +102,29 @@ static void hid_status_cb(enum usb_dc_status_code status, const u8_t *param)
 	} else {
 		switch (status) {
 		case USB_DC_ERROR:
-			USB_DBG("USB device error");
+			LOG_DBG("USB device error");
 			break;
 		case USB_DC_RESET:
-			USB_DBG("USB device reset detected");
+			LOG_DBG("USB device reset detected");
 			break;
 		case USB_DC_CONNECTED:
-			USB_DBG("USB device connected");
+			LOG_DBG("USB device connected");
 			break;
 		case USB_DC_CONFIGURED:
-			USB_DBG("USB device configured");
+			LOG_DBG("USB device configured");
 			break;
 		case USB_DC_DISCONNECTED:
-			USB_DBG("USB device disconnected");
+			LOG_DBG("USB device disconnected");
 			break;
 		case USB_DC_SUSPEND:
-			USB_DBG("USB device suspended");
+			LOG_DBG("USB device suspended");
 			break;
 		case USB_DC_RESUME:
-			USB_DBG("USB device resumed");
+			LOG_DBG("USB device resumed");
 			break;
 		case USB_DC_UNKNOWN:
 		default:
-			USB_DBG("USB unknown state");
+			LOG_DBG("USB unknown state");
 			break;
 		}
 	}
@@ -133,13 +133,13 @@ static void hid_status_cb(enum usb_dc_status_code status, const u8_t *param)
 static int hid_class_handle_req(struct usb_setup_packet *setup,
 				s32_t *len, u8_t **data)
 {
-	USB_DBG("Class request: bRequest 0x%x bmRequestType 0x%x len %d",
+	LOG_DBG("Class request: bRequest 0x%x bmRequestType 0x%x len %d",
 		setup->bRequest, setup->bmRequestType, *len);
 
 	if (REQTYPE_GET_DIR(setup->bmRequestType) == REQTYPE_DIR_TO_HOST) {
 		switch (setup->bRequest) {
 		case HID_GET_REPORT:
-			USB_DBG("Get Report");
+			LOG_DBG("Get Report");
 			if (hid_device.ops->get_report) {
 				return hid_device.ops->get_report(setup, len,
 								  data);
@@ -155,7 +155,7 @@ static int hid_class_handle_req(struct usb_setup_packet *setup,
 	} else {
 		switch (setup->bRequest) {
 		case HID_SET_IDLE:
-			USB_DBG("Set Idle");
+			LOG_DBG("Set Idle");
 			if (hid_device.ops->set_idle) {
 				return hid_device.ops->set_idle(setup, len,
 								data);
@@ -179,7 +179,7 @@ static int hid_class_handle_req(struct usb_setup_packet *setup,
 static int hid_custom_handle_req(struct usb_setup_packet *setup,
 				 s32_t *len, u8_t **data)
 {
-	USB_DBG("Standard request: bRequest 0x%x bmRequestType 0x%x len %d",
+	LOG_DBG("Standard request: bRequest 0x%x bmRequestType 0x%x len %d",
 		setup->bRequest, setup->bmRequestType, *len);
 
 	if (REQTYPE_GET_DIR(setup->bmRequestType) == REQTYPE_DIR_TO_HOST &&
@@ -188,7 +188,7 @@ static int hid_custom_handle_req(struct usb_setup_packet *setup,
 					setup->bRequest == REQ_GET_DESCRIPTOR) {
 		switch (setup->wValue) {
 		case 0x2200:
-			USB_DBG("Return Report Descriptor");
+			LOG_DBG("Return Report Descriptor");
 
 			/* Some buggy system may be pass a larger wLength when
 			 * it try read HID report descriptor, although we had
@@ -272,7 +272,7 @@ static u8_t interface_data[CONFIG_USB_HID_MAX_PAYLOAD_SIZE];
 
 int usb_hid_init(void)
 {
-	USB_DBG("Iinitializing HID Device");
+	LOG_DBG("Iinitializing HID Device");
 
 	/*
 	 * Modify Report Descriptor Size

--- a/subsys/usb/class/hid/core.c
+++ b/subsys/usb/class/hid/core.c
@@ -144,12 +144,12 @@ static int hid_class_handle_req(struct usb_setup_packet *setup,
 				return hid_device.ops->get_report(setup, len,
 								  data);
 			} else {
-				USB_ERR("Mandatory request not supported");
+				LOG_ERR("Mandatory request not supported");
 				return -EINVAL;
 			}
 			break;
 		default:
-			USB_ERR("Unhandled request 0x%x", setup->bRequest);
+			LOG_ERR("Unhandled request 0x%x", setup->bRequest);
 			break;
 		}
 	} else {
@@ -163,12 +163,12 @@ static int hid_class_handle_req(struct usb_setup_packet *setup,
 			break;
 		case HID_SET_REPORT:
 			if (hid_device.ops->set_report == NULL) {
-				USB_ERR("set_report not implemented");
+				LOG_ERR("set_report not implemented");
 				return -EINVAL;
 			}
 			return hid_device.ops->set_report(setup, len, data);
 		default:
-			USB_ERR("Unhandled request 0x%x", setup->bRequest);
+			LOG_ERR("Unhandled request 0x%x", setup->bRequest);
 			break;
 		}
 	}
@@ -288,14 +288,14 @@ int usb_hid_init(void)
 	/* Initialize the USB driver with the right configuration */
 	ret = usb_set_config(&hid_config);
 	if (ret < 0) {
-		USB_ERR("Failed to config USB");
+		LOG_ERR("Failed to config USB");
 		return ret;
 	}
 
 	/* Enable USB driver */
 	ret = usb_enable(&hid_config);
 	if (ret < 0) {
-		USB_ERR("Failed to enable USB");
+		LOG_ERR("Failed to enable USB");
 		return ret;
 	}
 #endif

--- a/subsys/usb/class/loopback.c
+++ b/subsys/usb/class/loopback.c
@@ -77,7 +77,7 @@ static void loopback_out_cb(u8_t ep, enum usb_dc_ep_cb_status_code ep_status)
 	u32_t bytes_to_read;
 
 	usb_read(ep, NULL, 0, &bytes_to_read);
-	USB_DBG("ep 0x%x, bytes to read %d ", ep, bytes_to_read);
+	LOG_DBG("ep 0x%x, bytes to read %d ", ep, bytes_to_read);
 	usb_read(ep, loopback_buf, bytes_to_read, NULL);
 }
 
@@ -85,7 +85,7 @@ static void loopback_in_cb(u8_t ep,
 				enum usb_dc_ep_cb_status_code ep_status)
 {
 	if (usb_write(ep, loopback_buf, CONFIG_LOOPBACK_BULK_EP_MPS, NULL)) {
-		USB_DBG("ep 0x%x", ep);
+		LOG_DBG("ep 0x%x", ep);
 	}
 }
 
@@ -108,13 +108,13 @@ static void loopback_status_cb(enum usb_dc_status_code status,
 	switch (status) {
 	case USB_DC_CONFIGURED:
 		loopback_in_cb(ep_cfg[LOOPBACK_IN_EP_IDX].ep_addr, 0);
-		USB_DBG("USB device configured");
+		LOG_DBG("USB device configured");
 		break;
 	case USB_DC_SET_HALT:
-		USB_DBG("Set Feature ENDPOINT_HALT");
+		LOG_DBG("Set Feature ENDPOINT_HALT");
 		break;
 	case USB_DC_CLEAR_HALT:
-		USB_DBG("Clear Feature ENDPOINT_HALT");
+		LOG_DBG("Clear Feature ENDPOINT_HALT");
 		if (*param == ep_cfg[LOOPBACK_IN_EP_IDX].ep_addr) {
 			loopback_in_cb(ep_cfg[LOOPBACK_IN_EP_IDX].ep_addr, 0);
 		}
@@ -128,7 +128,7 @@ static void loopback_status_cb(enum usb_dc_status_code status,
 static int loopback_vendor_handler(struct usb_setup_packet *setup,
 				   s32_t *len, u8_t **data)
 {
-	USB_DBG("Class request: bRequest 0x%x bmRequestType 0x%x len %d",
+	LOG_DBG("Class request: bRequest 0x%x bmRequestType 0x%x len %d",
 		setup->bRequest, setup->bmRequestType, *len);
 
 	if (REQTYPE_GET_RECIP(setup->bmRequestType) != REQTYPE_RECIP_DEVICE) {
@@ -137,7 +137,7 @@ static int loopback_vendor_handler(struct usb_setup_packet *setup,
 
 	if (REQTYPE_GET_DIR(setup->bmRequestType) == REQTYPE_DIR_TO_DEVICE &&
 	    setup->bRequest == 0x5b) {
-		USB_DBG("Host-to-Device, data %p", *data);
+		LOG_DBG("Host-to-Device, data %p", *data);
 		return 0;
 	}
 
@@ -149,7 +149,7 @@ static int loopback_vendor_handler(struct usb_setup_packet *setup,
 
 		*data = loopback_buf;
 		*len = setup->wLength;
-		USB_DBG("Device-to-Host, wLength %d, data %p",
+		LOG_DBG("Device-to-Host, wLength %d, data %p",
 			setup->wLength, *data);
 		return 0;
 	}
@@ -205,7 +205,7 @@ static int loopback_init(struct device *dev)
 	}
 	/* usb.rst enable USB controller end */
 #endif
-	USB_DBG("");
+	LOG_DBG("");
 
 	return 0;
 }

--- a/subsys/usb/class/loopback.c
+++ b/subsys/usb/class/loopback.c
@@ -192,7 +192,7 @@ static int loopback_init(struct device *dev)
 	/* usb.rst configure USB controller start */
 	ret = usb_set_config(&loopback_config);
 	if (ret < 0) {
-		USB_ERR("Failed to config USB");
+		LOG_ERR("Failed to config USB");
 		return ret;
 	}
 	/* usb.rst configure USB controller end */
@@ -200,7 +200,7 @@ static int loopback_init(struct device *dev)
 	/* usb.rst enable USB controller start */
 	ret = usb_enable(&loopback_config);
 	if (ret < 0) {
-		USB_ERR("Failed to enable USB");
+		LOG_ERR("Failed to enable USB");
 		return ret;
 	}
 	/* usb.rst enable USB controller end */

--- a/subsys/usb/class/mass_storage.c
+++ b/subsys/usb/class/mass_storage.c
@@ -244,7 +244,7 @@ static int mass_storage_class_handle_req(struct usb_setup_packet *pSetup,
 		break;
 
 	default:
-		USB_WRN("Unknown request 0x%x, value 0x%x",
+		LOG_WRN("Unknown request 0x%x, value 0x%x",
 			pSetup->bRequest, pSetup->wValue);
 		return -EINVAL;
 	}
@@ -256,10 +256,10 @@ static void testUnitReady(void)
 {
 	if (cbw.DataLength != 0) {
 		if ((cbw.Flags & 0x80) != 0) {
-			USB_WRN("Stall IN endpoint");
+			LOG_WRN("Stall IN endpoint");
 			usb_ep_set_stall(mass_ep_data[MSD_IN_EP_IDX].ep_addr);
 		} else {
-			USB_WRN("Stall OUT endpoint");
+			LOG_WRN("Stall OUT endpoint");
 			usb_ep_set_stall(mass_ep_data[MSD_OUT_EP_IDX].ep_addr);
 		}
 	}
@@ -435,7 +435,7 @@ static bool infoTransfer(void)
 	length = n * BLOCK_SIZE;
 
 	if (!cbw.DataLength) {              /* host requests no data*/
-		USB_WRN("Zero length in CBW");
+		LOG_WRN("Zero length in CBW");
 		csw.Status = CSW_FAILED;
 		sendCSW();
 		return false;
@@ -443,10 +443,10 @@ static bool infoTransfer(void)
 
 	if (cbw.DataLength != length) {
 		if ((cbw.Flags & 0x80) != 0) {
-			USB_WRN("Stall IN endpoint");
+			LOG_WRN("Stall IN endpoint");
 			usb_ep_set_stall(mass_ep_data[MSD_IN_EP_IDX].ep_addr);
 		} else {
-			USB_WRN("Stall OUT endpoint");
+			LOG_WRN("Stall OUT endpoint");
 			usb_ep_set_stall(mass_ep_data[MSD_OUT_EP_IDX].ep_addr);
 		}
 
@@ -481,7 +481,7 @@ static void CBWDecode(u8_t *buf, u16_t size)
 	csw.DataResidue = cbw.DataLength;
 
 	if ((cbw.CBLength <  1) || (cbw.CBLength > 16) || (cbw.LUN != 0)) {
-		USB_WRN("cbw.CBLength %d", cbw.CBLength);
+		LOG_WRN("cbw.CBLength %d", cbw.CBLength);
 		fail();
 	} else {
 		switch (cbw.CB[0]) {
@@ -519,7 +519,7 @@ static void CBWDecode(u8_t *buf, u16_t size)
 				} else {
 					usb_ep_set_stall(
 					  mass_ep_data[MSD_OUT_EP_IDX].ep_addr);
-					USB_WRN("Stall OUT endpoint");
+					LOG_WRN("Stall OUT endpoint");
 					csw.Status = CSW_ERROR;
 					sendCSW();
 				}
@@ -534,7 +534,7 @@ static void CBWDecode(u8_t *buf, u16_t size)
 				} else {
 					usb_ep_set_stall(
 					  mass_ep_data[MSD_IN_EP_IDX].ep_addr);
-					USB_WRN("Stall IN endpoint");
+					LOG_WRN("Stall IN endpoint");
 					csw.Status = CSW_ERROR;
 					sendCSW();
 				}
@@ -554,7 +554,7 @@ static void CBWDecode(u8_t *buf, u16_t size)
 				} else {
 					usb_ep_set_stall(
 					  mass_ep_data[MSD_IN_EP_IDX].ep_addr);
-					USB_WRN("Stall IN endpoint");
+					LOG_WRN("Stall IN endpoint");
 					csw.Status = CSW_ERROR;
 					sendCSW();
 				}
@@ -566,7 +566,7 @@ static void CBWDecode(u8_t *buf, u16_t size)
 			sendCSW();
 			break;
 		default:
-			USB_WRN(">> default CB[0] %x", cbw.CB[0]);
+			LOG_WRN(">> default CB[0] %x", cbw.CB[0]);
 			fail();
 			break;
 		}		/*switch(cbw.CB[0])*/
@@ -582,7 +582,7 @@ static void memoryVerify(u8_t *buf, u16_t size)
 		size = memory_size - addr;
 		stage = ERROR;
 		usb_ep_set_stall(mass_ep_data[MSD_OUT_EP_IDX].ep_addr);
-		USB_WRN("Stall OUT endpoint");
+		LOG_WRN("Stall OUT endpoint");
 	}
 
 	/* beginning of a new block -> load a whole block in RAM */
@@ -620,7 +620,7 @@ static void memoryWrite(u8_t *buf, u16_t size)
 		size = memory_size - addr;
 		stage = ERROR;
 		usb_ep_set_stall(mass_ep_data[MSD_OUT_EP_IDX].ep_addr);
-		USB_WRN("Stall OUT endpoint");
+		LOG_WRN("Stall OUT endpoint");
 	}
 
 	/* we fill an array in RAM of 1 block before writing it in memory */
@@ -689,7 +689,7 @@ static void mass_storage_bulk_out(u8_t ep,
 
 	/*an error has occurred: stall endpoint and send CSW*/
 	default:
-		USB_WRN("Stall OUT endpoint, stage: %d", stage);
+		LOG_WRN("Stall OUT endpoint, stage: %d", stage);
 		usb_ep_set_stall(ep);
 		csw.Status = CSW_ERROR;
 		sendCSW();
@@ -766,7 +766,7 @@ static void mass_storage_bulk_in(u8_t ep,
 
 	/*an error has occurred*/
 	default:
-		USB_WRN("Stall IN endpoint, stage: %d", stage);
+		LOG_WRN("Stall IN endpoint, stage: %d", stage);
 		usb_ep_set_stall(mass_ep_data[MSD_IN_EP_IDX].ep_addr);
 		sendCSW();
 		break;

--- a/subsys/usb/class/mass_storage.c
+++ b/subsys/usb/class/mass_storage.c
@@ -918,9 +918,9 @@ static int mass_storage_init(struct device *dev)
 	}
 
 
-	USB_INF("Sect Count %d", block_count);
+	LOG_INF("Sect Count %d", block_count);
 	memory_size = block_count * BLOCK_SIZE;
-	USB_INF("Memory Size %d", memory_size);
+	LOG_INF("Memory Size %d", memory_size);
 
 	msd_state_machine_reset();
 	msd_init();

--- a/subsys/usb/class/netusb/function_ecm.c
+++ b/subsys/usb/class/netusb/function_ecm.c
@@ -206,7 +206,7 @@ static int ecm_class_handler(struct usb_setup_packet *setup, s32_t *len,
 	}
 
 	if (setup->bmRequestType != USB_CDC_ECM_REQ_TYPE) {
-		USB_WRN("Unhandled req_type 0x%x", setup->bmRequestType);
+		LOG_WRN("Unhandled req_type 0x%x", setup->bmRequestType);
 		return 0;
 	}
 

--- a/subsys/usb/class/netusb/function_ecm.c
+++ b/subsys/usb/class/netusb/function_ecm.c
@@ -279,7 +279,7 @@ static int ecm_send(struct net_pkt *pkt)
 	ret = usb_transfer_sync(ecm_ep_data[ECM_IN_EP_IDX].ep_addr,
 				tx_buf, b_idx, USB_TRANS_WRITE);
 	if (ret != b_idx) {
-		USB_ERR("Transfer failure");
+		LOG_ERR("Transfer failure");
 		return -EINVAL;
 	}
 
@@ -309,13 +309,13 @@ static void ecm_read_cb(u8_t ep, int size, void *priv)
 
 	pkt = net_pkt_get_reserve_rx(0, K_FOREVER);
 	if (!pkt) {
-		USB_ERR("no memory for network packet\n");
+		LOG_ERR("no memory for network packet\n");
 		goto done;
 	}
 
 	frag = net_pkt_get_frag(pkt, K_FOREVER);
 	if (!frag) {
-		USB_ERR("no memory for network packet\n");
+		LOG_ERR("no memory for network packet\n");
 		net_pkt_unref(pkt);
 		goto done;
 	}
@@ -323,7 +323,7 @@ static void ecm_read_cb(u8_t ep, int size, void *priv)
 	net_pkt_frag_insert(pkt, frag);
 
 	if (!net_pkt_append_all(pkt, size, rx_buf, K_FOREVER)) {
-		USB_ERR("no memory for network packet\n");
+		LOG_ERR("no memory for network packet\n");
 		net_pkt_unref(pkt);
 		goto done;
 	}

--- a/subsys/usb/class/netusb/function_ecm.c
+++ b/subsys/usb/class/netusb/function_ecm.c
@@ -212,7 +212,7 @@ static int ecm_class_handler(struct usb_setup_packet *setup, s32_t *len,
 
 	switch (setup->bRequest) {
 	case USB_CDC_SET_ETH_PKT_FILTER:
-		USB_DBG("intf 0x%x filter 0x%x", setup->wIndex, setup->wValue);
+		LOG_DBG("intf 0x%x filter 0x%x", setup->wIndex, setup->wValue);
 		break;
 	default:
 		break;
@@ -223,7 +223,7 @@ static int ecm_class_handler(struct usb_setup_packet *setup, s32_t *len,
 
 static void ecm_int_in(u8_t ep, enum usb_dc_ep_cb_status_code ep_status)
 {
-	USB_DBG("EP 0x%x status %d", ep, ep_status);
+	LOG_DBG("EP 0x%x status %d", ep, ep_status);
 }
 
 /* Retrieve expected pkt size from ethernet/ip header */
@@ -247,7 +247,7 @@ static size_t ecm_eth_size(void *ecm_pkt, size_t len)
 		ip_len = ntohs(((struct net_ipv6_hdr *)ip_data)->len);
 		break;
 	default:
-		USB_DBG("Unknown hdr type 0x%04x", hdr->type);
+		LOG_DBG("Unknown hdr type 0x%04x", hdr->type);
 		return 0;
 	}
 
@@ -355,7 +355,7 @@ static struct netusb_function ecm_function = {
 
 static inline void ecm_status_interface(const u8_t *iface)
 {
-	USB_DBG("iface %u", *iface);
+	LOG_DBG("iface %u", *iface);
 
 	/* First interface is CDC Comm interface */
 	if (*iface != ecm_get_first_iface_number() + 1) {
@@ -370,12 +370,12 @@ static void ecm_status_cb(enum usb_dc_status_code status, const u8_t *param)
 	/* Check the USB status and do needed action if required */
 	switch (status) {
 	case USB_DC_DISCONNECTED:
-		USB_DBG("USB device disconnected");
+		LOG_DBG("USB device disconnected");
 		netusb_disable();
 		break;
 
 	case USB_DC_INTERFACE:
-		USB_DBG("USB interface selected");
+		LOG_DBG("USB interface selected");
 		ecm_status_interface(param);
 		break;
 
@@ -385,12 +385,12 @@ static void ecm_status_cb(enum usb_dc_status_code status, const u8_t *param)
 	case USB_DC_CONFIGURED:
 	case USB_DC_SUSPEND:
 	case USB_DC_RESUME:
-		USB_DBG("USB unhandlded state: %d", status);
+		LOG_DBG("USB unhandlded state: %d", status);
 		break;
 
 	case USB_DC_UNKNOWN:
 	default:
-		USB_DBG("USB unknown state: %d", status);
+		LOG_DBG("USB unknown state: %d", status);
 		break;
 	}
 }

--- a/subsys/usb/class/netusb/function_eem.c
+++ b/subsys/usb/class/netusb/function_eem.c
@@ -169,11 +169,11 @@ static void eem_read_cb(u8_t ep, int size, void *priv)
 			goto done;
 		}
 
-		USB_DBG("hdr 0x%x, eem_size %d, size %d",
+		LOG_DBG("hdr 0x%x, eem_size %d, size %d",
 			eem_hdr, eem_size, size);
 
 		if (!size || !eem_size) {
-			USB_DBG("no payload");
+			LOG_DBG("no payload");
 			break;
 		}
 
@@ -230,7 +230,7 @@ static struct netusb_function eem_function = {
 
 static inline void eem_status_interface(const u8_t *iface)
 {
-	USB_DBG("");
+	LOG_DBG("");
 
 	if (*iface != eem_get_first_iface_number()) {
 		return;
@@ -244,12 +244,12 @@ static void eem_status_cb(enum usb_dc_status_code status, const u8_t *param)
 	/* Check the USB status and do needed action if required */
 	switch (status) {
 	case USB_DC_DISCONNECTED:
-		USB_DBG("USB device disconnected");
+		LOG_DBG("USB device disconnected");
 		netusb_disable();
 		break;
 
 	case USB_DC_INTERFACE:
-		USB_DBG("USB interface selected");
+		LOG_DBG("USB interface selected");
 		eem_status_interface(param);
 		break;
 
@@ -259,12 +259,12 @@ static void eem_status_cb(enum usb_dc_status_code status, const u8_t *param)
 	case USB_DC_CONFIGURED:
 	case USB_DC_SUSPEND:
 	case USB_DC_RESUME:
-		USB_DBG("USB unhandlded state: %d", status);
+		LOG_DBG("USB unhandlded state: %d", status);
 		break;
 
 	case USB_DC_UNKNOWN:
 	default:
-		USB_DBG("USB unknown state: %d", status);
+		LOG_DBG("USB unknown state: %d", status);
 		break;
 	}
 }

--- a/subsys/usb/class/netusb/function_eem.c
+++ b/subsys/usb/class/netusb/function_eem.c
@@ -132,7 +132,7 @@ static int eem_send(struct net_pkt *pkt)
 				tx_buf, b_idx,
 				USB_TRANS_WRITE);
 	if (ret != b_idx) {
-		USB_ERR("Transfer failure");
+		LOG_ERR("Transfer failure");
 		return -EIO;
 	}
 
@@ -157,7 +157,7 @@ static void eem_read_cb(u8_t ep, int size, void *priv)
 
 		if (eem_size + sizeof(u16_t) > size) {
 			/* eem pkt greater than transferred data */
-			USB_ERR("pkt size error");
+			LOG_ERR("pkt size error");
 			break;
 		}
 
@@ -179,13 +179,13 @@ static void eem_read_cb(u8_t ep, int size, void *priv)
 
 		pkt = net_pkt_get_reserve_rx(0, K_FOREVER);
 		if (!pkt) {
-			USB_ERR("Unable to alloc pkt\n");
+			LOG_ERR("Unable to alloc pkt\n");
 			break;
 		}
 
 		frag = net_pkt_get_frag(pkt, K_FOREVER);
 		if (!frag) {
-			USB_ERR("Unable to alloc fragment");
+			LOG_ERR("Unable to alloc fragment");
 			net_pkt_unref(pkt);
 			break;
 		}
@@ -194,7 +194,7 @@ static void eem_read_cb(u8_t ep, int size, void *priv)
 
 		/* copy payload and discard 32-bit sentinel */
 		if (!net_pkt_append_all(pkt, eem_size - 4, ptr, K_FOREVER)) {
-			USB_ERR("Unable to append pkt\n");
+			LOG_ERR("Unable to append pkt\n");
 			net_pkt_unref(pkt);
 			break;
 		}

--- a/subsys/usb/class/netusb/function_rndis.c
+++ b/subsys/usb/class/netusb/function_rndis.c
@@ -1032,7 +1032,7 @@ static int rndis_class_handler(struct usb_setup_packet *setup, s32_t *len,
 
 static void cmd_thread(void)
 {
-	USB_INF("Command thread started");
+	LOG_INF("Command thread started");
 
 	while (true) {
 		struct net_buf *buf;

--- a/subsys/usb/class/netusb/function_rndis.c
+++ b/subsys/usb/class/netusb/function_rndis.c
@@ -345,7 +345,7 @@ static void rndis_bulk_out(u8_t ep, enum usb_dc_ep_cb_status_code ep_status)
 	LOG_DBG("EP 0x%x status %d len %u", ep, ep_status, len);
 
 	if (len > CONFIG_RNDIS_BULK_EP_MPS) {
-		USB_WRN("Limit read len %u to MPS %u", len,
+		LOG_WRN("Limit read len %u to MPS %u", len,
 			CONFIG_RNDIS_BULK_EP_MPS);
 		len = CONFIG_RNDIS_BULK_EP_MPS;
 	}
@@ -368,7 +368,7 @@ static void rndis_bulk_out(u8_t ep, enum usb_dc_ep_cb_status_code ep_status)
 
 	/* Handle skip bytes */
 	if (rndis.skip_bytes) {
-		USB_WRN("Skip %u bytes out of remaining %d bytes",
+		LOG_WRN("Skip %u bytes out of remaining %d bytes",
 			len, rndis.skip_bytes);
 
 		rndis.skip_bytes -= len;
@@ -489,7 +489,7 @@ static void rndis_notify(struct k_work *work)
 
 	/* Decrement notify_count here */
 	if (atomic_dec(&rndis.notify_count) != 1) {
-		USB_WRN("Queue next notification, count %u",
+		LOG_WRN("Queue next notification, count %u",
 			atomic_get(&rndis.notify_count));
 
 		k_delayed_work_submit(&notify_work, K_NO_WAIT);
@@ -517,7 +517,7 @@ static void rndis_queue_rsp(struct net_buf *rsp)
 			net_buf_unref(buf);
 		}
 #endif
-		USB_WRN("Transmit response queue is not empty");
+		LOG_WRN("Transmit response queue is not empty");
 	}
 
 	LOG_DBG("Queued response pkt %p", rsp);
@@ -534,7 +534,7 @@ static void rndis_notify_rsp(void)
 
 	/* Keep track of number of notifies */
 	if (atomic_inc(&rndis.notify_count) != 0) {
-		USB_WRN("Unhandled notify: count %u",
+		LOG_WRN("Unhandled notify: count %u",
 			atomic_get(&rndis.notify_count));
 
 		return;
@@ -728,7 +728,7 @@ static int rndis_query_handle(u8_t *data, u32_t len)
 		net_buf_add_le32(buf, drv_version);
 		break;
 	default:
-		USB_WRN("Unhandled query for Object ID 0x%x", object_id);
+		LOG_WRN("Unhandled query for Object ID 0x%x", object_id);
 		break;
 	}
 
@@ -910,7 +910,7 @@ static int handle_encapsulated_cmd(u8_t *data, u32_t len)
 	net_hexdump("CMD >", data, len);
 
 	if (len != msg->len) {
-		USB_WRN("Total len is different then command len %u %u",
+		LOG_WRN("Total len is different then command len %u %u",
 			len, msg->len);
 		/* TODO: need actions? */
 	}
@@ -1023,7 +1023,7 @@ static int rndis_class_handler(struct usb_setup_packet *setup, s32_t *len,
 		handle_encapsulated_rsp(data, len);
 	} else {
 		*len = 0; /* FIXME! */
-		USB_WRN("Unknown USB packet req 0x%x type 0x%x",
+		LOG_WRN("Unknown USB packet req 0x%x type 0x%x",
 			setup->bRequest, setup->bmRequestType);
 	}
 

--- a/subsys/usb/class/netusb/netusb.c
+++ b/subsys/usb/class/netusb/netusb.c
@@ -147,7 +147,7 @@ int try_write(u8_t ep, u8_t *data, u16_t len)
 			 * error from the controller, try only several times.
 			 */
 			if (tries--) {
-				USB_WRN("Error: EAGAIN. Another try");
+				LOG_WRN("Error: EAGAIN. Another try");
 				continue;
 			}
 
@@ -157,7 +157,7 @@ int try_write(u8_t ep, u8_t *data, u16_t len)
 			break;
 		/* TODO: Handle other error codes */
 		default:
-			USB_WRN("Error writing to ep 0x%x ret %d", ep, ret);
+			LOG_WRN("Error writing to ep 0x%x ret %d", ep, ret);
 			return ret;
 		}
 
@@ -168,7 +168,7 @@ int try_write(u8_t ep, u8_t *data, u16_t len)
 #endif
 
 		if (len) {
-			USB_WRN("Remaining bytes %d wrote %d", len, wrote);
+			LOG_WRN("Remaining bytes %d wrote %d", len, wrote);
 		}
 	}
 

--- a/subsys/usb/class/netusb/netusb.c
+++ b/subsys/usb/class/netusb/netusb.c
@@ -40,7 +40,7 @@ static int netusb_send(struct net_if *iface, struct net_pkt *pkt)
 {
 	int ret;
 
-	USB_DBG("Send pkt, len %u", net_pkt_get_len(pkt));
+	LOG_DBG("Send pkt, len %u", net_pkt_get_len(pkt));
 
 	if (!netusb_enabled()) {
 		USB_ERR("interface disabled");
@@ -58,7 +58,7 @@ static int netusb_send(struct net_if *iface, struct net_pkt *pkt)
 
 void netusb_recv(struct net_pkt *pkt)
 {
-	USB_DBG("Recv pkt, len %u", net_pkt_get_len(pkt));
+	LOG_DBG("Recv pkt, len %u", net_pkt_get_len(pkt));
 
 	if (net_recv_data(netusb.iface, pkt) < 0) {
 		USB_ERR("Packet %p dropped by NET stack", pkt);
@@ -68,7 +68,7 @@ void netusb_recv(struct net_pkt *pkt)
 
 static int netusb_connect_media(void)
 {
-	USB_DBG("");
+	LOG_DBG("");
 
 	if (!netusb_enabled()) {
 		USB_ERR("interface disabled");
@@ -84,7 +84,7 @@ static int netusb_connect_media(void)
 
 static int netusb_disconnect_media(void)
 {
-	USB_DBG("");
+	LOG_DBG("");
 
 	if (!netusb_enabled()) {
 		USB_ERR("interface disabled");
@@ -100,7 +100,7 @@ static int netusb_disconnect_media(void)
 
 void netusb_enable(const struct netusb_function *func)
 {
-	USB_DBG("");
+	LOG_DBG("");
 
 	netusb.func = func;
 
@@ -110,7 +110,7 @@ void netusb_enable(const struct netusb_function *func)
 
 void netusb_disable(void)
 {
-	USB_DBG("");
+	LOG_DBG("");
 
 	if (!netusb_enabled()) {
 		return;
@@ -164,7 +164,7 @@ int try_write(u8_t ep, u8_t *data, u16_t len)
 		len -= wrote;
 		data += wrote;
 #if VERBOSE_DEBUG
-		USB_DBG("Wrote %u bytes, remaining %u", wrote, len);
+		LOG_DBG("Wrote %u bytes, remaining %u", wrote, len);
 #endif
 
 		if (len) {
@@ -179,7 +179,7 @@ static void netusb_init(struct net_if *iface)
 {
 	static u8_t mac[6] = { 0x00, 0x00, 0x5E, 0x00, 0x53, 0x00 };
 
-	USB_DBG("netusb device initialization");
+	LOG_DBG("netusb device initialization");
 
 	netusb.iface = iface;
 
@@ -199,7 +199,7 @@ static void netusb_init(struct net_if *iface)
 		struct usb_cfg_data *cfg = &(__usb_data_start[i]);
 		int ret;
 
-		USB_DBG("Registering function %u", i);
+		LOG_DBG("Registering function %u", i);
 
 		cfg->interface.payload_data = interface_data;
 		cfg->usb_device_description = usb_get_device_descriptor();

--- a/subsys/usb/class/netusb/netusb.c
+++ b/subsys/usb/class/netusb/netusb.c
@@ -43,7 +43,7 @@ static int netusb_send(struct net_if *iface, struct net_pkt *pkt)
 	LOG_DBG("Send pkt, len %u", net_pkt_get_len(pkt));
 
 	if (!netusb_enabled()) {
-		USB_ERR("interface disabled");
+		LOG_ERR("interface disabled");
 		return -ENODEV;
 	}
 
@@ -61,7 +61,7 @@ void netusb_recv(struct net_pkt *pkt)
 	LOG_DBG("Recv pkt, len %u", net_pkt_get_len(pkt));
 
 	if (net_recv_data(netusb.iface, pkt) < 0) {
-		USB_ERR("Packet %p dropped by NET stack", pkt);
+		LOG_ERR("Packet %p dropped by NET stack", pkt);
 		net_pkt_unref(pkt);
 	}
 }
@@ -71,7 +71,7 @@ static int netusb_connect_media(void)
 	LOG_DBG("");
 
 	if (!netusb_enabled()) {
-		USB_ERR("interface disabled");
+		LOG_ERR("interface disabled");
 		return -ENODEV;
 	}
 
@@ -87,7 +87,7 @@ static int netusb_disconnect_media(void)
 	LOG_DBG("");
 
 	if (!netusb_enabled()) {
-		USB_ERR("interface disabled");
+		LOG_ERR("interface disabled");
 		return -ENODEV;
 	}
 
@@ -206,13 +206,13 @@ static void netusb_init(struct net_if *iface)
 
 		ret = usb_set_config(cfg);
 		if (ret < 0) {
-			USB_ERR("Failed to configure USB device");
+			LOG_ERR("Failed to configure USB device");
 			return;
 		}
 
 		ret = usb_enable(cfg);
 		if (ret < 0) {
-			USB_ERR("Failed to enable USB");
+			LOG_ERR("Failed to enable USB");
 			return;
 		}
 	}

--- a/subsys/usb/class/netusb/netusb.c
+++ b/subsys/usb/class/netusb/netusb.c
@@ -218,7 +218,7 @@ static void netusb_init(struct net_if *iface)
 	}
 #endif /* CONFIG_USB_COMPOSITE_DEVICE */
 
-	USB_INF("netusb initialized");
+	LOG_INF("netusb initialized");
 }
 
 static const struct ethernet_api netusb_api_funcs = {

--- a/subsys/usb/class/usb_dfu.c
+++ b/subsys/usb/class/usb_dfu.c
@@ -539,7 +539,7 @@ static int dfu_class_handle_req(struct usb_setup_packet *pSetup,
 		}
 		break;
 	default:
-		USB_WRN("DFU UNKNOWN STATE: %d", pSetup->bRequest);
+		LOG_WRN("DFU UNKNOWN STATE: %d", pSetup->bRequest);
 		return -EINVAL;
 	}
 
@@ -628,7 +628,7 @@ static int dfu_custom_handle_req(struct usb_setup_packet *pSetup,
 					FLASH_AREA_IMAGE_1_SIZE;
 				break;
 			default:
-				USB_WRN("Invalid DFU alternate setting");
+				LOG_WRN("Invalid DFU alternate setting");
 				return -ENOTSUP;
 			}
 			dfu_data.alt_setting = pSetup->wValue;

--- a/subsys/usb/class/usb_dfu.c
+++ b/subsys/usb/class/usb_dfu.c
@@ -329,7 +329,7 @@ static void dfu_flash_write(u8_t *data, size_t len)
 	}
 
 	if (flash_img_buffered_write(&dfu_data.ctx, data, len, flush)) {
-		USB_ERR("flash write error");
+		LOG_ERR("flash write error");
 		dfu_data.state = dfuERROR;
 		dfu_data.status = errWRITE;
 	} else if (!len) {
@@ -426,7 +426,7 @@ static int dfu_class_handle_req(struct usb_setup_packet *pSetup,
 						+ FLASH_AREA_IMAGE_1_OFFSET) {
 				dfu_data.status = errWRITE;
 				dfu_data.state = dfuERROR;
-				USB_ERR("This area can not be overwritten");
+				LOG_ERR("This area can not be overwritten");
 				break;
 			}
 
@@ -439,7 +439,7 @@ static int dfu_class_handle_req(struct usb_setup_packet *pSetup,
 			dfu_flash_write(*data, pSetup->wLength);
 			break;
 		default:
-			USB_ERR("DFU_DNLOAD wrong state %d", dfu_data.state);
+			LOG_ERR("DFU_DNLOAD wrong state %d", dfu_data.state);
 			dfu_data.state = dfuERROR;
 			dfu_data.status = errUNKNOWN;
 			dfu_reset_counters();
@@ -507,7 +507,7 @@ static int dfu_class_handle_req(struct usb_setup_packet *pSetup,
 
 			break;
 		default:
-			USB_ERR("DFU_UPLOAD wrong state %d", dfu_data.state);
+			LOG_ERR("DFU_UPLOAD wrong state %d", dfu_data.state);
 			dfu_data.state = dfuERROR;
 			dfu_data.status = errUNKNOWN;
 			dfu_reset_counters();
@@ -534,7 +534,7 @@ static int dfu_class_handle_req(struct usb_setup_packet *pSetup,
 		/* Set the DFU mode descriptors to be used after reset */
 		dfu_config.usb_device_description = (u8_t *) &dfu_mode_desc;
 		if (usb_set_config(&dfu_config) != 0) {
-			USB_ERR("usb_set_config failed in DFU_DETACH");
+			LOG_ERR("usb_set_config failed in DFU_DETACH");
 			return -EIO;
 		}
 		break;
@@ -685,7 +685,7 @@ static int usb_dfu_init(struct device *dev)
 
 	dfu_data.flash_dev = device_get_binding(FLASH_DEV_NAME);
 	if (!dfu_data.flash_dev) {
-		USB_ERR("Flash device not found\n");
+		LOG_ERR("Flash device not found\n");
 		return -ENODEV;
 	}
 
@@ -696,14 +696,14 @@ static int usb_dfu_init(struct device *dev)
 	/* Initialize the USB driver with the right configuration */
 	ret = usb_set_config(&dfu_config);
 	if (ret < 0) {
-		USB_ERR("Failed to config USB");
+		LOG_ERR("Failed to config USB");
 		return ret;
 	}
 
 	/* Enable USB driver */
 	ret = usb_enable(&dfu_config);
 	if (ret < 0) {
-		USB_ERR("Failed to enable USB");
+		LOG_ERR("Failed to enable USB");
 		return ret;
 	}
 #endif

--- a/subsys/usb/class/usb_dfu.c
+++ b/subsys/usb/class/usb_dfu.c
@@ -333,7 +333,7 @@ static void dfu_flash_write(u8_t *data, size_t len)
 		dfu_data.state = dfuERROR;
 		dfu_data.status = errWRITE;
 	} else if (!len) {
-		USB_DBG("flash write done");
+		LOG_DBG("flash write done");
 		dfu_data.state = dfuMANIFEST_SYNC;
 		dfu_reset_counters();
 		if (boot_request_upgrade(false)) {
@@ -344,7 +344,7 @@ static void dfu_flash_write(u8_t *data, size_t len)
 		dfu_data.state = dfuDNLOAD_IDLE;
 	}
 
-	USB_DBG("bytes written 0x%x", flash_img_bytes_written(&dfu_data.ctx));
+	LOG_DBG("bytes written 0x%x", flash_img_bytes_written(&dfu_data.ctx));
 }
 
 
@@ -365,7 +365,7 @@ static int dfu_class_handle_req(struct usb_setup_packet *pSetup,
 
 	switch (pSetup->bRequest) {
 	case DFU_GETSTATUS:
-		USB_DBG("DFU_GETSTATUS: status %d, state %d",
+		LOG_DBG("DFU_GETSTATUS: status %d, state %d",
 			dfu_data.status, dfu_data.state);
 
 		if (dfu_data.state == dfuMANIFEST_SYNC) {
@@ -382,13 +382,13 @@ static int dfu_class_handle_req(struct usb_setup_packet *pSetup,
 		break;
 
 	case DFU_GETSTATE:
-		USB_DBG("DFU_GETSTATE");
+		LOG_DBG("DFU_GETSTATE");
 		(*data)[0] = dfu_data.state;
 		*data_len = 1;
 		break;
 
 	case DFU_ABORT:
-		USB_DBG("DFU_ABORT");
+		LOG_DBG("DFU_ABORT");
 
 		if (dfu_check_app_state()) {
 			return -EINVAL;
@@ -400,7 +400,7 @@ static int dfu_class_handle_req(struct usb_setup_packet *pSetup,
 		break;
 
 	case DFU_CLRSTATUS:
-		USB_DBG("DFU_CLRSTATUS");
+		LOG_DBG("DFU_CLRSTATUS");
 
 		if (dfu_check_app_state()) {
 			return -EINVAL;
@@ -411,7 +411,7 @@ static int dfu_class_handle_req(struct usb_setup_packet *pSetup,
 		break;
 
 	case DFU_DNLOAD:
-		USB_DBG("DFU_DNLOAD block %d, len %d, state %d",
+		LOG_DBG("DFU_DNLOAD block %d, len %d, state %d",
 			pSetup->wValue, pSetup->wLength, dfu_data.state);
 
 		if (dfu_check_app_state()) {
@@ -420,7 +420,7 @@ static int dfu_class_handle_req(struct usb_setup_packet *pSetup,
 
 		switch (dfu_data.state) {
 		case dfuIDLE:
-			USB_DBG("DFU_DNLOAD start");
+			LOG_DBG("DFU_DNLOAD start");
 			dfu_reset_counters();
 			if (dfu_data.flash_addr != CONFIG_FLASH_BASE_ADDRESS
 						+ FLASH_AREA_IMAGE_1_OFFSET) {
@@ -447,7 +447,7 @@ static int dfu_class_handle_req(struct usb_setup_packet *pSetup,
 		}
 		break;
 	case DFU_UPLOAD:
-		USB_DBG("DFU_UPLOAD block %d, len %d, state %d",
+		LOG_DBG("DFU_UPLOAD block %d, len %d, state %d",
 			pSetup->wValue, pSetup->wLength, dfu_data.state);
 
 		if (dfu_check_app_state()) {
@@ -457,11 +457,11 @@ static int dfu_class_handle_req(struct usb_setup_packet *pSetup,
 		switch (dfu_data.state) {
 		case dfuIDLE:
 			dfu_reset_counters();
-			USB_DBG("DFU_UPLOAD start");
+			LOG_DBG("DFU_UPLOAD start");
 		case dfuUPLOAD_IDLE:
 			if (!pSetup->wLength ||
 			    dfu_data.block_nr != pSetup->wValue) {
-				USB_DBG("DFU_UPLOAD block %d, expected %d, "
+				LOG_DBG("DFU_UPLOAD block %d, expected %d, "
 					"len %d", pSetup->wValue,
 					dfu_data.block_nr, pSetup->wLength);
 				dfu_data.state = dfuERROR;
@@ -515,7 +515,7 @@ static int dfu_class_handle_req(struct usb_setup_packet *pSetup,
 		}
 		break;
 	case DFU_DETACH:
-		USB_DBG("DFU_DETACH timeout %d, state %d",
+		LOG_DBG("DFU_DETACH timeout %d, state %d",
 			pSetup->wValue, dfu_data.state);
 
 		if (dfu_data.state != appIDLE) {
@@ -560,32 +560,32 @@ static void dfu_status_cb(enum usb_dc_status_code status, const u8_t *param)
 	/* Check the USB status and do needed action if required */
 	switch (status) {
 	case USB_DC_ERROR:
-		USB_DBG("USB device error");
+		LOG_DBG("USB device error");
 		break;
 	case USB_DC_RESET:
-		USB_DBG("USB device reset detected, state %d", dfu_data.state);
+		LOG_DBG("USB device reset detected, state %d", dfu_data.state);
 		if (dfu_data.state == appDETACH) {
 			dfu_data.state = dfuIDLE;
 		}
 		break;
 	case USB_DC_CONNECTED:
-		USB_DBG("USB device connected");
+		LOG_DBG("USB device connected");
 		break;
 	case USB_DC_CONFIGURED:
-		USB_DBG("USB device configured");
+		LOG_DBG("USB device configured");
 		break;
 	case USB_DC_DISCONNECTED:
-		USB_DBG("USB device disconnected");
+		LOG_DBG("USB device disconnected");
 		break;
 	case USB_DC_SUSPEND:
-		USB_DBG("USB device supended");
+		LOG_DBG("USB device supended");
 		break;
 	case USB_DC_RESUME:
-		USB_DBG("USB device resumed");
+		LOG_DBG("USB device resumed");
 		break;
 	case USB_DC_UNKNOWN:
 	default:
-		USB_DBG("USB unknown state");
+		LOG_DBG("USB unknown state");
 		break;
 	}
 }
@@ -610,7 +610,7 @@ static int dfu_custom_handle_req(struct usb_setup_packet *pSetup,
 	if (REQTYPE_GET_RECIP(pSetup->bmRequestType) ==
 	    REQTYPE_RECIP_INTERFACE) {
 		if (pSetup->bRequest == REQ_SET_INTERFACE) {
-			USB_DBG("DFU alternate setting %d", pSetup->wValue);
+			LOG_DBG("DFU alternate setting %d", pSetup->wValue);
 
 			switch (pSetup->wValue) {
 			case 0:

--- a/subsys/usb/os_desc.c
+++ b/subsys/usb/os_desc.c
@@ -18,7 +18,7 @@ static struct usb_os_descriptor *os_desc;
 int usb_handle_os_desc(struct usb_setup_packet *setup,
 		       s32_t *len, u8_t **data)
 {
-	USB_DBG("wValue 0x%x", setup->wValue);
+	LOG_DBG("wValue 0x%x", setup->wValue);
 
 	if (!os_desc) {
 		return -ENOTSUP;
@@ -26,7 +26,7 @@ int usb_handle_os_desc(struct usb_setup_packet *setup,
 
 	if (GET_DESC_TYPE(setup->wValue) == DESC_STRING &&
 	    GET_DESC_INDEX(setup->wValue) == USB_OSDESC_STRING_DESC_INDEX) {
-		USB_DBG("MS OS Descriptor string read");
+		LOG_DBG("MS OS Descriptor string read");
 		*data = os_desc->string;
 		*len = os_desc->string_len;
 
@@ -39,7 +39,7 @@ int usb_handle_os_desc(struct usb_setup_packet *setup,
 int usb_handle_os_desc_feature(struct usb_setup_packet *setup,
 			       s32_t *len, u8_t **data)
 {
-	USB_DBG("bRequest 0x%x", setup->bRequest);
+	LOG_DBG("bRequest 0x%x", setup->bRequest);
 
 	if (!os_desc) {
 		return -ENOTSUP;
@@ -48,7 +48,7 @@ int usb_handle_os_desc_feature(struct usb_setup_packet *setup,
 	if (setup->bRequest == os_desc->vendor_code) {
 		switch (setup->wIndex) {
 		case USB_OSDESC_EXTENDED_COMPAT_ID:
-			USB_DBG("Handle Compat ID");
+			LOG_DBG("Handle Compat ID");
 			*data = os_desc->compat_id;
 			*len = os_desc->compat_id_len;
 

--- a/subsys/usb/usb_descriptor.c
+++ b/subsys/usb/usb_descriptor.c
@@ -164,11 +164,11 @@ static void ascii7_to_utf16le(void *descriptor)
 	int ascii_idx_max = USB_BSTRING_ASCII_IDX_MAX(str_descr->bLength);
 	u8_t *buf = (u8_t *)&str_descr->bString;
 
-	USB_DBG("idx_max %d, ascii_idx_max %d, buf %x",
+	LOG_DBG("idx_max %d, ascii_idx_max %d, buf %x",
 		idx_max, ascii_idx_max, (u32_t)buf);
 
 	for (int i = idx_max; i >= 0; i -= 2) {
-		USB_DBG("char %c : %x, idx %d -> %d",
+		LOG_DBG("char %c : %x, idx %d -> %d",
 			buf[ascii_idx_max],
 			buf[ascii_idx_max],
 			ascii_idx_max, i);
@@ -260,7 +260,7 @@ static int usb_validate_ep_cfg_data(struct usb_ep_descriptor * const ep_descr,
 				} else {
 					*requested_ep |= (1 << idx);
 				}
-				USB_DBG("endpoint 0x%x", ep_data[i].ep_addr);
+				LOG_DBG("endpoint 0x%x", ep_data[i].ep_addr);
 				return 0;
 			}
 		}
@@ -345,16 +345,16 @@ static int usb_fix_descriptor(struct usb_desc_header *head)
 		switch (head->bDescriptorType) {
 		case USB_CONFIGURATION_DESC:
 			cfg_descr = (struct usb_cfg_descriptor *)head;
-			USB_DBG("Configuration descriptor %p", head);
+			LOG_DBG("Configuration descriptor %p", head);
 			break;
 		case USB_ASSOCIATION_DESC:
-			USB_DBG("Association descriptor %p", head);
+			LOG_DBG("Association descriptor %p", head);
 			break;
 		case USB_INTERFACE_DESC:
 			if_descr = (struct usb_if_descriptor *)head;
-			USB_DBG("Interface descriptor %p", head);
+			LOG_DBG("Interface descriptor %p", head);
 			if (if_descr->bAlternateSetting) {
-				USB_DBG("Skip alternate interface");
+				LOG_DBG("Skip alternate interface");
 				break;
 			}
 
@@ -375,7 +375,7 @@ static int usb_fix_descriptor(struct usb_desc_header *head)
 			numof_ifaces++;
 			break;
 		case USB_ENDPOINT_DESC:
-			USB_DBG("Endpoint descriptor %p", head);
+			LOG_DBG("Endpoint descriptor %p", head);
 			ep_descr = (struct usb_ep_descriptor *)head;
 			if (usb_validate_ep_cfg_data(ep_descr,
 						     cfg_data,
@@ -407,7 +407,7 @@ static int usb_fix_descriptor(struct usb_desc_header *head)
 					return -1;
 				}
 
-				USB_DBG("Now the wTotalLength is %d",
+				LOG_DBG("Now the wTotalLength is %d",
 					(u8_t *)head - (u8_t *)cfg_descr);
 				cfg_descr->wTotalLength =
 					sys_cpu_to_le16((u8_t *)head -
@@ -427,7 +427,7 @@ static int usb_fix_descriptor(struct usb_desc_header *head)
 	}
 
 	if ((head + 1) != __usb_descriptor_end) {
-		USB_DBG("try to fix next descriptor at %p", head + 1);
+		LOG_DBG("try to fix next descriptor at %p", head + 1);
 		return usb_fix_descriptor(head + 1);
 	}
 
@@ -437,8 +437,8 @@ static int usb_fix_descriptor(struct usb_desc_header *head)
 
 u8_t *usb_get_device_descriptor(void)
 {
-	USB_DBG("__usb_descriptor_start %p", __usb_descriptor_start);
-	USB_DBG("__usb_descriptor_end %p", __usb_descriptor_end);
+	LOG_DBG("__usb_descriptor_start %p", __usb_descriptor_start);
+	LOG_DBG("__usb_descriptor_end %p", __usb_descriptor_end);
 
 	if (usb_fix_descriptor(__usb_descriptor_start)) {
 		USB_ERR("Failed to fixup USB descriptor");

--- a/subsys/usb/usb_descriptor.c
+++ b/subsys/usb/usb_descriptor.c
@@ -313,7 +313,7 @@ usb_fix_ascii_sn_string_descriptor(struct usb_sn_descriptor *sn)
 	default_sn_len = strlen(CONFIG_USB_DEVICE_SN);
 
 	if (runtime_sn_len != default_sn_len) {
-		USB_ERR("the new SN descriptor doesn't has the same "
+		LOG_ERR("the new SN descriptor doesn't has the same "
 			"length as CONFIG_USB_DEVICE_SN");
 		return;
 	}
@@ -361,7 +361,7 @@ static int usb_fix_descriptor(struct usb_desc_header *head)
 			if (if_descr->bInterfaceNumber == 0) {
 				cfg_data = usb_get_cfg_data(if_descr);
 				if (!cfg_data) {
-					USB_ERR("There is no usb_cfg_data "
+					LOG_ERR("There is no usb_cfg_data "
 						"for %p", head);
 					return -1;
 				}
@@ -380,7 +380,7 @@ static int usb_fix_descriptor(struct usb_desc_header *head)
 			if (usb_validate_ep_cfg_data(ep_descr,
 						     cfg_data,
 						     &requested_ep)) {
-				USB_ERR("Failed to validate endpoints");
+				LOG_ERR("Failed to validate endpoints");
 				return -1;
 			}
 
@@ -403,7 +403,7 @@ static int usb_fix_descriptor(struct usb_desc_header *head)
 				ascii7_to_utf16le(head);
 			} else {
 				if (!cfg_descr) {
-					USB_ERR("Incomplete device descriptor");
+					LOG_ERR("Incomplete device descriptor");
 					return -1;
 				}
 
@@ -441,7 +441,7 @@ u8_t *usb_get_device_descriptor(void)
 	LOG_DBG("__usb_descriptor_end %p", __usb_descriptor_end);
 
 	if (usb_fix_descriptor(__usb_descriptor_start)) {
-		USB_ERR("Failed to fixup USB descriptor");
+		LOG_ERR("Failed to fixup USB descriptor");
 		return NULL;
 	}
 

--- a/subsys/usb/usb_device.c
+++ b/subsys/usb/usb_device.c
@@ -1233,7 +1233,7 @@ void usb_transfer_ep_callback(u8_t ep, enum usb_dc_ep_cb_status_code status)
 				usb_dc_ep_read_wait(ep, &data, 1, &bytes);
 			} while (bytes);
 
-			USB_ERR("RX data lost, no transfer");
+			LOG_ERR("RX data lost, no transfer");
 		}
 		return;
 	}
@@ -1265,7 +1265,7 @@ int usb_transfer(u8_t ep, u8_t *data, size_t dlen, unsigned int flags,
 	}
 
 	if (!trans) {
-		USB_ERR("no transfer slot available");
+		LOG_ERR("no transfer slot available");
 		ret = -ENOMEM;
 		goto done;
 	}
@@ -1492,7 +1492,7 @@ static int usb_composite_init(struct device *dev)
 	/* register device descriptor */
 	device_descriptor = usb_get_device_descriptor();
 	if (!device_descriptor) {
-		USB_ERR("Failed to configure USB device stack");
+		LOG_ERR("Failed to configure USB device stack");
 		return -1;
 	}
 

--- a/subsys/usb/usb_device.c
+++ b/subsys/usb/usb_device.c
@@ -751,7 +751,7 @@ static bool usb_handle_std_endpoint_req(struct usb_setup_packet *setup,
 	case REQ_CLEAR_FEATURE:
 		if (setup->wValue == FEA_ENDPOINT_HALT) {
 			/* clear HALT by unstalling */
-			USB_INF("... EP clear halt %x", ep);
+			LOG_INF("... EP clear halt %x", ep);
 			usb_dc_ep_clear_stall(ep);
 			if (usb_dev.status_callback) {
 				usb_dev.status_callback(USB_DC_CLEAR_HALT, &ep);
@@ -764,7 +764,7 @@ static bool usb_handle_std_endpoint_req(struct usb_setup_packet *setup,
 	case REQ_SET_FEATURE:
 		if (setup->wValue == FEA_ENDPOINT_HALT) {
 			/* set HALT by stalling */
-			USB_INF("--- EP SET halt %x", ep);
+			LOG_INF("--- EP SET halt %x", ep);
 			usb_dc_ep_set_stall(ep);
 			if (usb_dev.status_callback) {
 				usb_dev.status_callback(USB_DC_SET_HALT, &ep);

--- a/subsys/usb/usb_device.c
+++ b/subsys/usb/usb_device.c
@@ -174,10 +174,10 @@ static struct usb_dev_priv {
  */
 static void usb_print_setup(struct usb_setup_packet *setup)
 {
-	/* avoid compiler warning if USB_DBG is not defined */
+	/* avoid compiler warning if LOG_DBG is not defined */
 	ARG_UNUSED(setup);
 
-	USB_DBG("Setup: %x %x %x %x %x",
+	LOG_DBG("Setup: %x %x %x %x %x",
 		setup->bmRequestType,
 		setup->bRequest,
 		setup->wValue,
@@ -205,20 +205,20 @@ static bool usb_handle_request(struct usb_setup_packet *setup,
 	u32_t type = REQTYPE_GET_TYPE(setup->bmRequestType);
 	usb_request_handler handler = usb_dev.req_handlers[type];
 
-	USB_DBG("** %d **", type);
+	LOG_DBG("** %d **", type);
 
 	if (type >= MAX_NUM_REQ_HANDLERS) {
-		USB_DBG("Error Incorrect iType %d", type);
+		LOG_DBG("Error Incorrect iType %d", type);
 		return false;
 	}
 
 	if (handler == NULL) {
-		USB_DBG("No handler for reqtype %d", type);
+		LOG_DBG("No handler for reqtype %d", type);
 		return false;
 	}
 
 	if ((*handler)(setup, len, data) < 0) {
-		USB_DBG("Handler Error %d", type);
+		LOG_DBG("Handler Error %d", type);
 		usb_print_setup(setup);
 		return false;
 	}
@@ -256,7 +256,7 @@ static void usb_handle_control_transfer(u8_t ep,
 	u32_t type = 0;
 	struct usb_setup_packet *setup = &usb_dev.setup;
 
-	USB_DBG("ep %x, status %x", ep, ep_status);
+	LOG_DBG("ep %x, status %x", ep, ep_status);
 
 	if (ep == USB_CONTROL_OUT_EP0 && ep_status == USB_DC_EP_SETUP) {
 		/*
@@ -265,7 +265,7 @@ static void usb_handle_control_transfer(u8_t ep,
 		 */
 		if (usb_dc_ep_read(ep,
 				   (u8_t *)setup, sizeof(*setup), NULL) < 0) {
-			USB_DBG("Read Setup Packet failed");
+			LOG_DBG("Read Setup Packet failed");
 			usb_dc_ep_set_stall(USB_CONTROL_IN_EP0);
 			return;
 		}
@@ -274,7 +274,7 @@ static void usb_handle_control_transfer(u8_t ep,
 		type = REQTYPE_GET_TYPE(setup->bmRequestType);
 		usb_dev.data_buf = usb_dev.data_store[type];
 		if (!usb_dev.data_buf) {
-			USB_DBG("buffer not available");
+			LOG_DBG("buffer not available");
 			usb_dc_ep_set_stall(USB_CONTROL_OUT_EP0);
 			usb_dc_ep_set_stall(USB_CONTROL_IN_EP0);
 			return;
@@ -293,7 +293,7 @@ static void usb_handle_control_transfer(u8_t ep,
 		if (!usb_handle_request(setup,
 					&usb_dev.data_buf_len,
 					&usb_dev.data_buf)) {
-			USB_DBG("usb_handle_request failed");
+			LOG_DBG("usb_handle_request failed");
 			usb_dc_ep_set_stall(USB_CONTROL_IN_EP0);
 			return;
 		}
@@ -309,7 +309,7 @@ static void usb_handle_control_transfer(u8_t ep,
 			/* absorb zero-length status message */
 			if (usb_dc_ep_read(USB_CONTROL_OUT_EP0,
 					   usb_dev.data_buf, 0, &chunk) < 0) {
-				USB_DBG("Read DATA Packet failed");
+				LOG_DBG("Read DATA Packet failed");
 				usb_dc_ep_set_stall(USB_CONTROL_IN_EP0);
 			}
 			return;
@@ -318,7 +318,7 @@ static void usb_handle_control_transfer(u8_t ep,
 		if (usb_dc_ep_read(USB_CONTROL_OUT_EP0,
 				   usb_dev.data_buf,
 				   usb_dev.data_buf_residue, &chunk) < 0) {
-			USB_DBG("Read DATA Packet failed");
+			LOG_DBG("Read DATA Packet failed");
 			usb_dc_ep_set_stall(USB_CONTROL_IN_EP0);
 			usb_dc_ep_set_stall(USB_CONTROL_OUT_EP0);
 			return;
@@ -333,13 +333,13 @@ static void usb_handle_control_transfer(u8_t ep,
 			if (!usb_handle_request(setup,
 						&usb_dev.data_buf_len,
 						&usb_dev.data_buf)) {
-				USB_DBG("usb_handle_request1 failed");
+				LOG_DBG("usb_handle_request1 failed");
 				usb_dc_ep_set_stall(USB_CONTROL_IN_EP0);
 				return;
 			}
 
 			/*Send status to host*/
-			USB_DBG(">> usb_data_to_host(2)");
+			LOG_DBG(">> usb_data_to_host(2)");
 			usb_data_to_host();
 		}
 	} else if (ep == USB_CONTROL_IN_EP0) {
@@ -451,7 +451,7 @@ static bool usb_get_descriptor(u16_t type_index, u16_t lang_id,
 		}
 	} else {
 		/* nothing found */
-		USB_DBG("Desc %x not found!", type_index);
+		LOG_DBG("Desc %x not found!", type_index);
 	}
 	return found;
 }
@@ -476,7 +476,7 @@ static bool usb_set_configuration(u8_t config_index, u8_t alt_setting)
 
 	if (config_index == 0) {
 		/* unconfigure device */
-		USB_DBG("Device not configured - invalid configuration "
+		LOG_DBG("Device not configured - invalid configuration "
 			"offset");
 		return true;
 	}
@@ -548,7 +548,7 @@ static bool usb_set_interface(u8_t iface, u8_t alt_setting)
 	u8_t cur_alt_setting = 0xFF;
 	struct usb_dc_ep_cfg_data ep_cfg;
 
-	USB_DBG("iface %u alt_setting %u", iface, alt_setting);
+	LOG_DBG("iface %u alt_setting %u", iface, alt_setting);
 
 	while (p[DESC_bLength] != 0) {
 		switch (p[DESC_bDescriptorType]) {
@@ -573,7 +573,7 @@ static bool usb_set_interface(u8_t iface, u8_t alt_setting)
 			usb_dc_ep_configure(&ep_cfg);
 			usb_dc_ep_enable(ep_cfg.ep_addr);
 
-			USB_DBG("Found: ep_addr 0x%x", ep_cfg.ep_addr);
+			LOG_DBG("Found: ep_addr 0x%x", ep_cfg.ep_addr);
 			break;
 		default:
 			break;
@@ -581,7 +581,7 @@ static bool usb_set_interface(u8_t iface, u8_t alt_setting)
 
 		/* skip to next descriptor */
 		p += p[DESC_bLength];
-		USB_DBG("p %p", p);
+		LOG_DBG("p %p", p);
 	}
 
 	if (usb_dev.status_callback) {
@@ -608,7 +608,7 @@ static bool usb_handle_std_device_req(struct usb_setup_packet *setup,
 
 	switch (setup->bRequest) {
 	case REQ_GET_STATUS:
-		USB_DBG("REQ_GET_STATUS");
+		LOG_DBG("REQ_GET_STATUS");
 		/* bit 0: self-powered */
 		/* bit 1: remote wakeup = not supported */
 		data[0] = 0;
@@ -617,28 +617,28 @@ static bool usb_handle_std_device_req(struct usb_setup_packet *setup,
 		break;
 
 	case REQ_SET_ADDRESS:
-		USB_DBG("REQ_SET_ADDRESS, addr 0x%x", setup->wValue);
+		LOG_DBG("REQ_SET_ADDRESS, addr 0x%x", setup->wValue);
 		usb_dc_set_address(setup->wValue);
 		break;
 
 	case REQ_GET_DESCRIPTOR:
-		USB_DBG("REQ_GET_DESCRIPTOR");
+		LOG_DBG("REQ_GET_DESCRIPTOR");
 		ret = usb_get_descriptor(setup->wValue,
 		    setup->wIndex, len, data_buf);
 		break;
 
 	case REQ_GET_CONFIGURATION:
-		USB_DBG("REQ_GET_CONFIGURATION");
+		LOG_DBG("REQ_GET_CONFIGURATION");
 		/* indicate if we are configured */
 		data[0] = usb_dev.configuration;
 		*len = 1;
 		break;
 
 	case REQ_SET_CONFIGURATION:
-		USB_DBG("REQ_SET_CONFIGURATION, conf 0x%x",
+		LOG_DBG("REQ_SET_CONFIGURATION, conf 0x%x",
 			    setup->wValue & 0xFF);
 		if (!usb_set_configuration(setup->wValue & 0xFF, 0)) {
-			USB_DBG("USB Set Configuration failed");
+			LOG_DBG("USB Set Configuration failed");
 			ret = false;
 		} else {
 			/* configuration successful,
@@ -649,10 +649,10 @@ static bool usb_handle_std_device_req(struct usb_setup_packet *setup,
 		break;
 
 	case REQ_CLEAR_FEATURE:
-		USB_DBG("REQ_CLEAR_FEATURE");
+		LOG_DBG("REQ_CLEAR_FEATURE");
 		break;
 	case REQ_SET_FEATURE:
-		USB_DBG("REQ_SET_FEATURE");
+		LOG_DBG("REQ_SET_FEATURE");
 
 		if (setup->wValue == FEA_REMOTE_WAKEUP) {
 			/* put DEVICE_REMOTE_WAKEUP code here */
@@ -665,12 +665,12 @@ static bool usb_handle_std_device_req(struct usb_setup_packet *setup,
 		break;
 
 	case REQ_SET_DESCRIPTOR:
-		USB_DBG("Device req %x not implemented", setup->bRequest);
+		LOG_DBG("Device req %x not implemented", setup->bRequest);
 		ret = false;
 		break;
 
 	default:
-		USB_DBG("Illegal device req %x", setup->bRequest);
+		LOG_DBG("Illegal device req %x", setup->bRequest);
 		ret = false;
 		break;
 	}
@@ -712,13 +712,13 @@ static bool usb_handle_std_interface_req(struct usb_setup_packet *setup,
 		break;
 
 	case REQ_SET_INTERFACE:
-		USB_DBG("REQ_SET_INTERFACE");
+		LOG_DBG("REQ_SET_INTERFACE");
 		usb_set_interface(setup->wIndex, setup->wValue);
 		*len = 0;
 		break;
 
 	default:
-		USB_DBG("Illegal interface req %d", setup->bRequest);
+		LOG_DBG("Illegal interface req %d", setup->bRequest);
 		return false;
 	}
 
@@ -775,11 +775,11 @@ static bool usb_handle_std_endpoint_req(struct usb_setup_packet *setup,
 		return false;
 
 	case REQ_SYNCH_FRAME:
-		USB_DBG("EP req %d not implemented", setup->bRequest);
+		LOG_DBG("EP req %d not implemented", setup->bRequest);
 		return false;
 
 	default:
-		USB_DBG("Illegal EP req %d", setup->bRequest);
+		LOG_DBG("Illegal EP req %d", setup->bRequest);
 		return false;
 	}
 
@@ -839,7 +839,7 @@ static int usb_handle_standard_request(struct usb_setup_packet *setup,
 static int usb_handle_vendor_request(struct usb_setup_packet *setup,
 				     s32_t *len, u8_t **data_buf)
 {
-	USB_DBG("");
+	LOG_DBG("");
 
 	if (usb_os_desc_enabled()) {
 		if (!usb_handle_os_desc_feature(setup, len, data_buf)) {
@@ -899,7 +899,7 @@ static int usb_vbus_set(bool on)
 	struct device *gpio_dev = device_get_binding(USB_GPIO_DRV_NAME);
 
 	if (!gpio_dev) {
-		USB_DBG("USB requires GPIO. Cannot find %s!",
+		LOG_DBG("USB requires GPIO. Cannot find %s!",
 			USB_GPIO_DRV_NAME);
 		return -ENODEV;
 	}
@@ -1199,7 +1199,7 @@ done:
 			return;
 		}
 
-		USB_DBG("transfer done, ep=%02x, status=%d, size=%u",
+		LOG_DBG("transfer done, ep=%02x, status=%d, size=%u",
 			trans->ep, trans->status, trans->tsize);
 
 		trans->cb = NULL;
@@ -1253,7 +1253,7 @@ int usb_transfer(u8_t ep, u8_t *data, size_t dlen, unsigned int flags,
 	struct usb_transfer_data *trans = NULL;
 	int i, key, ret = 0;
 
-	USB_DBG("transfer start, ep=%02x, data=%p, dlen=%d", ep, data, dlen);
+	LOG_DBG("transfer start, ep=%02x, data=%p, dlen=%d", ep, data, dlen);
 
 	key = irq_lock();
 
@@ -1393,7 +1393,7 @@ static int class_handler(struct usb_setup_packet *pSetup,
 	const struct usb_if_descriptor *if_descr;
 	struct usb_interface_cfg_data *iface;
 
-	USB_DBG("bRequest 0x%x, wIndex 0x%x", pSetup->bRequest, pSetup->wIndex);
+	LOG_DBG("bRequest 0x%x, wIndex 0x%x", pSetup->bRequest, pSetup->wIndex);
 
 	for (size_t i = 0; i < size; i++) {
 		iface = &(__usb_data_start[i].interface);
@@ -1414,7 +1414,7 @@ static int custom_handler(struct usb_setup_packet *pSetup,
 	const struct usb_if_descriptor *if_descr;
 	struct usb_interface_cfg_data *iface;
 
-	USB_DBG("bRequest 0x%x, wIndex 0x%x", pSetup->bRequest, pSetup->wIndex);
+	LOG_DBG("bRequest 0x%x, wIndex 0x%x", pSetup->bRequest, pSetup->wIndex);
 
 	for (size_t i = 0; i < size; i++) {
 		iface = &(__usb_data_start[i].interface);
@@ -1435,7 +1435,7 @@ static int vendor_handler(struct usb_setup_packet *pSetup,
 	const struct usb_if_descriptor *if_descr;
 	struct usb_interface_cfg_data *iface;
 
-	USB_DBG("bRequest 0x%x, wIndex 0x%x", pSetup->bRequest, pSetup->wIndex);
+	LOG_DBG("bRequest 0x%x, wIndex 0x%x", pSetup->bRequest, pSetup->wIndex);
 
 	if (usb_os_desc_enabled()) {
 		if (!usb_handle_os_desc_feature(pSetup, len, data)) {
@@ -1464,7 +1464,7 @@ static int composite_setup_ep_cb(void)
 	for (size_t i = 0; i < size; i++) {
 		ep_data = __usb_data_start[i].endpoint;
 		for (u8_t n = 0; n < __usb_data_start[i].num_endpoints; n++) {
-			USB_DBG("set cb, ep: 0x%x", ep_data[n].ep_addr);
+			LOG_DBG("set cb, ep: 0x%x", ep_data[n].ep_addr);
 			if (usb_dc_ep_set_callback(ep_data[n].ep_addr,
 						   ep_data[n].ep_cb)) {
 				return -1;


### PR DESCRIPTION
When CONFIG_LOG_FUNCTION_NAME is defined to not add name again.

Signed-off-by: Andrei Emeltchenko <andrei.emeltchenko@intel.com>