### PR TITLE
doc: boards: pca10059: add bootloader documentation

### DIFF
--- a/boards/arm/nrf52840_pca10059/doc/nrf52840_pca10059.rst
+++ b/boards/arm/nrf52840_pca10059/doc/nrf52840_pca10059.rst
@@ -109,21 +109,89 @@ Programming and Debugging
 *************************
 
 Applications for the ``nrf52840_pca10059`` board configuration can be
-built in the usual way (see :ref:`build_an_application` for more details);
-however, an external debugger IC is necessary to program the device,
-and the standard debugging targets are not currently available.
+built in the usual way (see :ref:`build_an_application` for more details).
+There are two ways to program the board, with the DFU tool or with an external
+debugger chip.
 
-Flashing
-========
+Flashing with a device firmware update (DFU)
+============================================
 
-Flashing Zephyr onto the ``nrf52840_pca10059`` board requires an external
-J-Link programmer. The programmer is attached to the SWD header on the back
-side of the board.
+The board is factory-programmed with Nordic's bootloader from Nordic's nRF5 SDK.
+This section covers the steps required to program the board with a Zephyr
+application using Nordic's DFU tool nrfutil.
+
+Follow the instructions on `nrfutil GitHub`_ to install the necessary software.
+
+Compile a Zephyr application as usual,
+here is an example for the :ref:`blinky-sample` application.
+
+.. zephyr-app-commands::
+   :zephyr-app: samples/basic/blinky
+   :board: nrf52840_pca10059
+   :goals: build
+
+Create an application package, using nrfutil::
+
+	nrfutil pkg generate --hw-version 52 --sd-req=0x00 \
+		--application zephyr.hex --application-version 1 pkg.zip
+
+Flash it onto the board::
+
+	nrfutil dfu usb_serial -pkg pkg.zip -p /dev/ttyACM0
+
+Observe the green LED on the board blinking.
+
+For more information on these steps visit: `Nordic Semiconductor USB DFU`_ and
+`nrfutil GitHub`_ pages.
+
+Chainloading the MCUBoot bootloader
+===================================
+
+It is possible to use the nRF5 bootloader alongside MCUBoot. To do so,
+program the board with MCUBoot as a Zephyr application, following
+the steps above. Then, prepare to compile an application with MCUBoot support.
+
+Select :option: `CONFIG_BOOTLOADER_MCUBOOT`, under "Boot options" and set
+:option: `CONFIG_TEXT_SECTION_OFFSET` under "Build and Link features",
+"Linker options" to 0x200 to ensure the code is offset to account for MCUboot
+firwmare image metadata.
+
+Sign the resulting firmware image using the imgtool utility as follows::
+
+	imgtool sign -S 0x5e000 --key mcuboot/root-rsa-2048.pem \
+		--header-size 0x200 --align 8 --version 3.0 firmware.bin signed.bin
+
+Enter MCUboot serial recovery mode by inserting the device into the USB port
+while holding BUTTON1 down. Keep in mind that resetting the device using the
+RESET button will always enter Nordic nRF5 bootloader's DFU mode.
+
+Finally, perform a firmware update using mcumgr as follows::
+
+	mcumgr --conntype=serial --connstring='dev=/dev/ttyACM0,baud=115200' \
+		image upload -e signed.bin
+
+and reset the device::
+
+	mcumgr --conntype=serial --connstring='dev=/dev/ttyACM0,baud=115200' reset
+
+For more information about these steps refer to: `MCUboot`_ and
+`mcumgr`_.
+
+Flashing with an external JLink programmer
+===========================================
+
+Flashing Zephyr onto the ``nrf52840_pca10059`` with an external J-Link
+programmer requires an SWD header to be attached on the back side of the board.
 
 Follow the instructions in the :ref:`nordic_segger` page to install
 and configure all the necessary software. Further information can be
-found in :ref:`nordic_segger_flashing`. Then build and flash
-applications as usual (see :ref:`build_an_application` and
+found in :ref:`nordic_segger_flashing`.
+
+Locate the DTS file for the board under: boards/arm/nrf52840_pca10059.
+This file requires a small modification to use a different partition table.
+Edit the include directive to include "fstab-segger" instead of "fstab-stock".
+
+Then build and flash applications as usual (see :ref:`build_an_application` and
 :ref:`application_run` for more details).
 
 Here is an example for the :ref:`blinky-sample` application.
@@ -151,8 +219,8 @@ the board are working properly with Zephyr:
 
 * :ref:`blinky-sample`
 
-You can build and program the examples to make sure Zephyr is running correctly on
-your board. The button and LED definitions can be found in :file:`boards/arm/nrf52840_pca10059/board.h`.
+You can build and program the examples to make sure Zephyr is running correctly
+on your board.
 
 
 References
@@ -163,4 +231,7 @@ References
 .. _nRF52840 Dongle website: https://www.nordicsemi.com/eng/Products/nRF52840-Dongle
 .. _Nordic Semiconductor Infocenter: http://infocenter.nordicsemi.com/
 .. _J-Link Software and documentation pack: https://www.segger.com/jlink-software.html
-
+.. _Nordic Semiconductor USB DFU: https://infocenter.nordicsemi.com/index.jsp?topic=%2Fcom.nordic.infocenter.sdk5.v15.2.0%2Fsdk_app_serial_dfu_bootloader.html
+.. _nrfutil GitHub: https://github.com/NordicSemiconductor/pc-nrfutil
+.. _MCUboot: https://github.com/runtimeco/mcuboot/blob/master/docs/readme-zephyr.md
+.. _mcumgr: https://github.com/apache/mynewt-mcumgr-cli


### PR DESCRIPTION
~~Add documentation on how to migrate from the factory programmed bootloader to MCUboot.~~

Document how to program the nrf52840_pca10059 board without an external debugger.