### PR TITLE
doc: usermode: Add missing "called" in _k_object_init() description

### DIFF
--- a/doc/kernel/usermode/kernelobjects.rst
+++ b/doc/kernel/usermode/kernelobjects.rst
@@ -220,7 +220,7 @@ Some objects will be implicitly initialized at boot:
   is run by the kernel early in the boot process.
 
 If a kernel object is initialized with a private static initializer, the
-object must have :c:func:`_k_object_init()` on it at some point by a supervisor
+object must have :c:func:`_k_object_init()` called on it at some point by a supervisor
 thread, otherwise the kernel will consider the object uninitialized if accessed
 by a user thread. This is very uncommon, typically only for kernel objects that
 are embedded within some larger struct and initialized statically.


### PR DESCRIPTION
The phrase "object must have _k_object_init() on it at some point"
visibly misses "called".

Signed-off-by: Paul Sokolovsky <paul.sokolovsky@linaro.org>