### PR TITLE
doc: bluetooth: Add existing qualification listings

### DIFF
--- a/doc/subsystems/bluetooth/qualification.rst
+++ b/doc/subsystems/bluetooth/qualification.rst
@@ -15,3 +15,41 @@ the following documents:
    l2cap-pics.rst
    sm-pics.rst
    rfcomm-pics.rst
+
+Qualification Listings
+**********************
+
+The Zephyr BLE stack has obtained qualification listings for both the Host
+and the Controller.
+See the tables below for a list of qualification listings
+
+Host qualifications
+-------------------
+
+.. list-table::
+   :header-rows: 1
+
+   * - Zephyr version
+     - Link
+     - Qualifying Company
+
+   * - 1.13
+     - `QDID 119517 <https://launchstudio.bluetooth.com/ListingDetails/70189>`__
+     - Nordic
+
+Controller qualifications
+-------------------------
+
+.. list-table::
+   :header-rows: 1
+
+   * - Zephyr version
+     - Link
+     - Qualifying Company
+     - Compatible Hardware
+
+   * - 1.9 to 1.13
+     - `QDID 101395 <https://launchstudio.bluetooth.com/ListingDetails/25166>`__
+     - Nordic
+     - nRF52x
+


### PR DESCRIPTION
List the currently available Bluetooth Qualification Listings for the
Zephyr Host and Controller.

Signed-off-by: Carles Cufi <carles.cufi@nordicsemi.no>