### PR TITLE
boards: arm: nucleo_f746zg: Highlight possible pin conflict

### DIFF
--- a/boards/arm/nucleo_f746zg/nucleo_f746zg.dts
+++ b/boards/arm/nucleo_f746zg/nucleo_f746zg.dts
@@ -86,5 +86,9 @@ arduino_spi: &spi1 {};
 };
 
 &spi1 {
+	/*
+	 * WARNING: The pin PA7 will conflict on selection of SPI_1 and
+	 *          ETH_STM32_HAL. See pinmux.c for further details.
+	 */
 	status = "ok";
 };

--- a/boards/arm/nucleo_f746zg/pinmux.c
+++ b/boards/arm/nucleo_f746zg/pinmux.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018 Adam Palmer
+ * Copyright (c) 2018 AJ Palmer
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -12,7 +12,13 @@
 
 #include <pinmux/stm32/pinmux_stm32.h>
 
-/* NUCLEO-F746ZG pin configurations  */
+/* NUCLEO-F746ZG pin configurations
+ *
+ * WARNING: The pin PA7 will conflict on selection of SPI_1 and ETH_STM32_HAL.
+ *          If you require both peripherals, and you do not need Arduino Uno v3
+ *          comaptability, the pin PB5 (also on ST Zio connector) can be used
+ *          for the SPI_1 MOSI signal.
+ */
 static const struct pin_config pinconf[] = {
 #ifdef CONFIG_UART_2
 	{ STM32_PIN_PD5, STM32F7_PINMUX_FUNC_PD5_USART2_TX },


### PR DESCRIPTION
Updated .dts and pinmux.c to highlight pin conflict on PA7 if ETH and
SPI_1 are selected together without modification.

Signed-off-by: AJ Palmer <ajpcode@hotmail.com>