### PR TITLE
sanitycheck: make nrf51_pca10028 the default for cortex-m0

### DIFF
--- a/boards/arm/bbc_microbit/bbc_microbit.yaml
+++ b/boards/arm/bbc_microbit/bbc_microbit.yaml
@@ -7,7 +7,6 @@ toolchain:
   - gnuarmemb
 ram: 16
 testing:
-  default: true
   ignore_tags:
     - net
 supported:

--- a/boards/arm/nrf51_pca10028/nrf51_pca10028.yaml
+++ b/boards/arm/nrf51_pca10028/nrf51_pca10028.yaml
@@ -10,3 +10,7 @@ supported:
   - adc
   - ble
   - nvs
+testing:
+  default: true
+  ignore_tags:
+    - net


### PR DESCRIPTION
This board has more coverage and more ram, so lets make it the default
for testing cortex-m0.

Signed-off-by: Anas Nashif <anas.nashif@intel.com>