### PR TITLE
net: if: Assert that link layer addr was set by driver

### DIFF
--- a/subsys/net/ip/net_if.c
+++ b/subsys/net/ip/net_if.c
@@ -246,6 +246,11 @@ static inline void init_iface(struct net_if *iface)
 	if (!net_if_is_ip_offloaded(iface)) {
 		NET_ASSERT(api->send);
 	}
+
+	/* In many places it's assumed that link address was set with
+	 * net_if_set_link_addr(). Better check that now.
+	 */
+	NET_ASSERT(net_if_get_link_addr(iface)->addr != NULL);
 }
 
 enum net_verdict net_if_send_data(struct net_if *iface, struct net_pkt *pkt)


### PR DESCRIPTION
There's a lot of code which assumes net_if_get_link_addr(iface)->addr
Forgetting to set it leads to deferred, spectacular crashes. It's
impractical to assert it on every usage. So, instead let's assert
it after call to driver->init(), as that is supposed to set it.

Signed-off-by: Paul Sokolovsky <paul.sokolovsky@linaro.org>