### PR TITLE
Various XCC fixes to compile warnings

### DIFF
--- a/drivers/dma/dma_cavs.c
+++ b/drivers/dma/dma_cavs.c
@@ -12,7 +12,7 @@
 #include <device.h>
 #include <init.h>
 #include <dma.h>
-
+#include <soc.h>
 #include "dma_cavs.h"
 
 #define LOG_LEVEL CONFIG_DMA_LOG_LEVEL

--- a/drivers/interrupt_controller/dw_ictl.c
+++ b/drivers/interrupt_controller/dw_ictl.c
@@ -14,6 +14,7 @@
 #include <device.h>
 #include <irq_nextlevel.h>
 #include "dw_ictl.h"
+#include <soc.h>
 
 static ALWAYS_INLINE void dw_ictl_dispatch_child_isrs(u32_t intr_status,
 						      u32_t isr_base_offset)

--- a/drivers/timer/sys_clock_init.c
+++ b/drivers/timer/sys_clock_init.c
@@ -16,9 +16,6 @@
 #include <init.h>
 #include <drivers/system_timer.h>
 
-SYS_DEVICE_DEFINE("sys_clock", z_clock_driver_init, z_clock_device_ctrl,
-		PRE_KERNEL_2, CONFIG_SYSTEM_CLOCK_INIT_PRIORITY);
-
 /* Weak-linked noop defaults for optional driver interfaces: */
 
 int __weak z_clock_driver_init(struct device *device)
@@ -35,3 +32,6 @@ int __weak z_clock_device_ctrl(struct device *device,
 void __weak z_clock_set_timeout(s32_t ticks, bool idle)
 {
 }
+
+SYS_DEVICE_DEFINE("sys_clock", z_clock_driver_init, z_clock_device_ctrl,
+		PRE_KERNEL_2, CONFIG_SYSTEM_CLOCK_INIT_PRIORITY);

--- a/include/toolchain/xcc.h
+++ b/include/toolchain/xcc.h
@@ -36,7 +36,8 @@
 
 #endif /* __GCC_LINKER_CMD__ */
 
-#define __builtin_unreachable() __ASSERT(0, "Unreachable code")
+#define __builtin_unreachable() do { __ASSERT(0, "Unreachable code"); } \
+	while (true)
 
 /* TODO: XCC doesn't define the below macros which are useful for checking
  * overflows. This needs to be fixed.


### PR DESCRIPTION
- __builtin_unreachable needs to be a loop
- include soc.h
- use weak function after declaration