### PR TITLE
Add support to generate PWM info from DT/PWM LEDs

### DIFF
--- a/boards/arm/hexiwear_k64/board.h
+++ b/boards/arm/hexiwear_k64/board.h
@@ -9,17 +9,4 @@
 
 #include <soc.h>
 
-#ifdef CONFIG_PWM_3
-
-#define RED_PWM_NAME		CONFIG_FTM_3_NAME
-#define RED_PWM_CHANNEL		4
-
-#define GREEN_PWM_NAME		CONFIG_FTM_3_NAME
-#define GREEN_PWM_CHANNEL	0
-
-#define BLUE_PWM_NAME		CONFIG_FTM_3_NAME
-#define BLUE_PWM_CHANNEL	5
-
-#endif /* CONFIG_PWM_3 */
-
 #endif /* __INC_BOARD_H */

--- a/boards/arm/hexiwear_k64/hexiwear_k64.dts
+++ b/boards/arm/hexiwear_k64/hexiwear_k64.dts
@@ -31,6 +31,10 @@
 		led0 = &green_led;
 		led1 = &blue_led;
 		led2 = &red_led;
+		pwm-led0 = &green_pwm_led;
+		red-pwm-led = &red_pwm_led;
+		green-pwm-led = &green_pwm_led;
+		blue_pwm-led = &blue_pwm_led;
 	};
 
 	chosen {
@@ -55,6 +59,20 @@
 		blue_led: led_2 {
 			gpios = <&gpioc 9 0>;
 			label = "User LD3";
+		};
+	};
+
+	pwmleds {
+		compatible = "pwm-leds";
+
+		red_pwm_led: red_pwm_led {
+			pwms = <&pwm3 4 15625000>;
+		};
+		green_pwm_led: green_pwm_led {
+			pwms = <&pwm3 0 15625000>;
+		};
+		blue_pwm_led: blue_pwm_led {
+			pwms = <&pwm3 5 15625000>;
 		};
 	};
 };

--- a/dts/arm/nxp/nxp_k6x.dtsi
+++ b/dts/arm/nxp/nxp_k6x.dtsi
@@ -337,8 +337,8 @@
 			reg = <0x40038000 0x98>;
 			interrupts = <42 0>;
 			label = "PWM_0";
-			/* channel information needed - fixme */
 			status = "disabled";
+			#pwm-cells = <2>;
 		};
 
 		pwm1: pwm@40039000{
@@ -346,8 +346,8 @@
 			reg = <0x40039000 0x98>;
 			interrupts = <43 0>;
 			label = "PWM_1";
-			/* channel information needed - fixme */
 			status = "disabled";
+			#pwm-cells = <2>;
 		};
 
 		pwm2: pwm@4003a000{
@@ -355,8 +355,8 @@
 			reg = <0x4003a000 0x98>;
 			interrupts = <44 0>;
 			label = "PWM_2";
-			/* channel information needed - fixme */
 			status = "disabled";
+			#pwm-cells = <2>;
 		};
 
 		pwm3: pwm@400b9000{
@@ -364,8 +364,8 @@
 			reg = <0x400b9000 0x98>;
 			interrupts = <71 0>;
 			label = "PWM_3";
-			/* channel information needed - fixme */
 			status = "disabled";
+			#pwm-cells = <2>;
 		};
 
 		adc0: adc@4003b000{

--- a/dts/arm/nxp/nxp_kw2xd.dtsi
+++ b/dts/arm/nxp/nxp_kw2xd.dtsi
@@ -287,8 +287,8 @@
 			reg = <0x40038000 0x98>;
 			interrupts = <42 0>;
 			label = "PWM_0";
-			/* channel information needed - fixme */
 			status = "disabled";
+			#pwm-cells = <2>;
 		};
 
 		pwm1: pwm@40039000{
@@ -296,8 +296,8 @@
 			reg = <0x40039000 0x98>;
 			interrupts = <43 0>;
 			label = "PWM_1";
-			/* channel information needed - fixme */
 			status = "disabled";
+			#pwm-cells = <2>;
 		};
 
 		pwm2: pwm@4003a000{
@@ -305,8 +305,8 @@
 			reg = <0x4003a000 0x98>;
 			interrupts = <44 0>;
 			label = "PWM_2";
-			/* channel information needed - fixme */
 			status = "disabled";
+			#pwm-cells = <2>;
 		};
 
 		adc0: adc@4003b000{

--- a/dts/bindings/led/pwm-leds.yaml
+++ b/dts/bindings/led/pwm-leds.yaml
@@ -1,0 +1,32 @@
+#
+# Copyright (c) 2018, Linaro Limited
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+---
+title: PWM LED
+version: 0.1
+
+description: >
+    This is a representation of the PWM GPIO nodes
+
+properties:
+    compatible:
+      type: string
+      category: required
+      description: compatible strings
+      constraint: "pwm-leds"
+      generation: define
+
+    pwms:
+      type: compound
+      category: required
+      generation: define
+
+    label:
+      type: string
+      category: required
+      description: Human readable string describing the device (used by Zephyr for API name)
+      generation: define
+
+...

--- a/dts/bindings/pwm/nxp,kinetis-ftm.yaml
+++ b/dts/bindings/pwm/nxp,kinetis-ftm.yaml
@@ -28,4 +28,9 @@ properties:
       category: required
       description: required interrupts
       generation: define
+
+"#cells":
+  - channel
+# period in terms of nanoseconds
+  - period
 ...

--- a/samples/basic/blink_led/src/main.c
+++ b/samples/basic/blink_led/src/main.c
@@ -29,16 +29,16 @@
 #elif defined(CONFIG_SOC_FAMILY_NRF)
 #define PWM_DRIVER CONFIG_PWM_NRF5_SW_0_DEV_NAME
 #define PWM_CHANNEL LED0_GPIO_PIN
-#elif defined(CONFIG_BOARD_HEXIWEAR_K64)
-#include <board.h>
-#define PWM_DRIVER	GREEN_PWM_NAME
-#define PWM_CHANNEL	GREEN_PWM_CHANNEL
 #elif defined(CONFIG_BOARD_COLIBRI_IMX7D_M4)
 #define PWM_DRIVER	PWM_1_LABEL
 #define PWM_CHANNEL	0
 #elif defined(CONFIG_SOC_FAMILY_NRF)
 #define PWM_DRIVER	CONFIG_PWM_NRF5_SW_0_DEV_NAME
 #define PWM_CHANNEL	LED0_GPIO_PIN
+#elif defined(PWM_LED0_PWM_CONTROLLER) && defined(PWM_LED0_PWM_CHANNEL)
+/* get the defines from dt (based on alias 'pwm-led0') */
+#define PWM_DRIVER	PWM_LED0_PWM_CONTROLLER
+#define PWM_CHANNEL	PWM_LED0_PWM_CHANNEL
 #else
 #error "Choose supported PWM driver"
 #endif

--- a/samples/basic/fade_led/src/main.c
+++ b/samples/basic/fade_led/src/main.c
@@ -27,13 +27,13 @@
 #elif defined(CONFIG_SOC_FAMILY_NRF)
 #define PWM_DRIVER CONFIG_PWM_NRF5_SW_0_DEV_NAME
 #define PWM_CHANNEL LED0_GPIO_PIN
-#elif defined(CONFIG_BOARD_HEXIWEAR_K64)
-#include <board.h>
-#define PWM_DRIVER	GREEN_PWM_NAME
-#define PWM_CHANNEL	GREEN_PWM_CHANNEL
 #elif defined(CONFIG_SOC_ESP32)
 #define PWM_DRIVER CONFIG_PWM_LED_ESP32_DEV_NAME_0
 #define PWM_CHANNEL	21
+#elif defined(PWM_LED0_PWM_CONTROLLER) && defined(PWM_LED0_PWM_CHANNEL)
+/* get the defines from dt (based on alias 'pwm-led0') */
+#define PWM_DRIVER	PWM_LED0_PWM_CONTROLLER
+#define PWM_CHANNEL	PWM_LED0_PWM_CHANNEL
 #else
 #error "Choose supported PWM driver"
 #endif

--- a/samples/basic/rgb_led/src/main.c
+++ b/samples/basic/rgb_led/src/main.c
@@ -22,14 +22,21 @@
 #define PWM_CH1		1
 #define PWM_DEV2	CONFIG_PWM_QMSI_DEV_NAME
 #define PWM_CH2		2
-#elif defined(CONFIG_BOARD_HEXIWEAR_K64)
-#include <board.h>
-#define PWM_DEV0	RED_PWM_NAME
-#define PWM_CH0		RED_PWM_CHANNEL
-#define PWM_DEV1	GREEN_PWM_NAME
-#define PWM_CH1		GREEN_PWM_CHANNEL
-#define PWM_DEV2	BLUE_PWM_NAME
-#define PWM_CH2		BLUE_PWM_CHANNEL
+#elif defined(RED_PWM_LED_PWM_CONTROLLER) && \
+      defined(RED_PWM_LED_PWM_CHANNEL) && \
+      defined(GREEN_PWM_LED_PWM_CONTROLLER) && \
+      defined(GREEN_PWM_LED_PWM_CHANNEL) && \
+      defined(BLUE_PWM_LED_PWM_CONTROLLER) && \
+      defined(BLUE_PWM_LED_PWM_CHANNEL)
+/* Get the defines from dt (based on aliases 'red-pwm-led', 'green-pwm-led' &
+ * 'blue-pwm-led')
+ */
+#define PWM_DEV0	RED_PWM_LED_PWM_CONTROLLER
+#define PWM_CH0		RED_PWM_LED_PWM_CHANNEL
+#define PWM_DEV1	GREEN_PWM_LED_PWM_CONTROLLER
+#define PWM_CH1		GREEN_PWM_LED_PWM_CHANNEL
+#define PWM_DEV2	BLUE_PWM_LED_PWM_CONTROLLER
+#define PWM_CH2		BLUE_PWM_LED_PWM_CHANNEL
 #else
 #error "Choose supported board or add new board for the application"
 #endif

--- a/scripts/dts/extract_dts_includes.py
+++ b/scripts/dts/extract_dts_includes.py
@@ -387,7 +387,9 @@ def extract_property(node_compat, yaml, node_address, prop, prop_val, names):
         pinctrl.extract(node_address, yaml, prop, def_label)
     elif 'clocks' in prop:
         clocks.extract(node_address, yaml, prop, def_label)
-    elif 'gpios' in prop:
+    elif 'pwms' in prop or 'gpios' in prop:
+        # drop the 's' from the prop
+        generic = prop[:-1]
         try:
             prop_values = list(reduced[node_address]['props'].get(prop))
         except:
@@ -400,9 +402,9 @@ def extract_property(node_compat, yaml, node_address, prop, prop_val, names):
             prop_values = [item for sublist in prop_values for item in sublist]
 
         extract_controller(node_address, yaml, prop, prop_values, 0,
-                           def_label, 'gpio')
+                           def_label, generic)
         extract_cells(node_address, yaml, prop, prop_values,
-                      names, 0, def_label, 'gpio')
+                      names, 0, def_label, generic)
     else:
         default.extract(node_address, yaml, prop, prop_val['type'], def_label)
 


### PR DESCRIPTION
Added a series of patches to enable generation of pwm info based on device tree.  Also added for use of this based on pwm-leds on the hexiwear_k64.