### PR TITLE
CODEOWNERS: maintainer updates

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -17,9 +17,9 @@ soc/arm/ti_simplelink/cc32xx             @GAnthony
 soc/arm/ti_simplelink/msp432p4xx         @Mani-Sadhasivam
 arch/nios2/                              @andrewboie @ramakrishnapallala
 arch/posix/                              @aescolar
-arch/riscv32/                            @fractalclone @kgugala @pgielda
+arch/riscv32/                            @kgugala @pgielda @nategraff-sifive
 soc/posix/                               @aescolar
-soc/riscv32/                             @fractalclone @kgugala @pgielda
+soc/riscv32/                             @kgugala @pgielda @nategraff-sifive
 arch/x86/                                @andrewboie @ramakrishnapallala
 arch/x86/core/                           @andrewboie
 arch/x86/core/crt0.S                     @ramakrishnapallala @nashif
@@ -65,7 +65,7 @@ boards/arm/stm32f3_disco/                @ydamigos
 boards/nios2/                            @ramakrishnapallala
 boards/nios2/altera_max10/               @ramakrishnapallala
 boards/posix/                            @aescolar
-boards/riscv32/                          @fractalclone @kgugala @pgielda
+boards/riscv32/                          @kgugala @pgielda @nategraff-sifive
 boards/x86/                              @andrewboie @nashif
 boards/x86/arduino_101/                  @nashif
 boards/x86/galileo/                      @nashif
@@ -92,7 +92,7 @@ drivers/ethernet/                        @jukkar @tbursztyka @pfalcon
 drivers/flash/                           @nashif
 drivers/flash/*stm32*                    @superna9999
 drivers/gpio/*stm32*                     @rsalveti @idlethread
-drivers/gpio/gpio_pulpino.c              @fractalclone @kgugala @pgielda
+drivers/gpio/gpio_pulpino.c              @kgugala @pgielda @nategraff-sifive
 drivers/ieee802154/                      @jukkar @tbursztyka
 drivers/interrupt_controller/            @andrewboie
 drivers/led/                             @Mani-Sadhasivam
@@ -100,13 +100,13 @@ drivers/led_strip/                       @mbolivar
 drivers/pinmux/stm32/                    @rsalveti @idlethread
 drivers/sensor/                          @bogdan-davidoaia @MaureenHelm
 drivers/serial/uart_altera_jtag_hal.c    @ramakrishnapallala
-drivers/serial/uart_riscv_qemu.c         @fractalclone @kgugala @pgielda
+drivers/serial/uart_riscv_qemu.c         @kgugala @pgielda @nategraff-sifive
 drivers/net/slip.c                       @jukkar @tbursztyka
 drivers/spi/                             @tbursztyka
 drivers/spi/spi_ll_stm32.*               @superna9999
 drivers/timer/altera_avalon_timer_hal.c  @ramakrishnapallala
-drivers/timer/pulpino_timer.c            @fractalclone @kgugala @pgielda
-drivers/timer/riscv_machine_timer.c      @fractalclone @kgugala @pgielda
+drivers/timer/pulpino_timer.c            @nategraff-sifive @kgugala @pgielda
+drivers/timer/riscv_machine_timer.c      @nategraff-sifive @kgugala @pgielda
 drivers/usb/                             @jfischer-phytec-iot @finikorg
 drivers/usb/device/usb_dc_stm32.c        @ydamigos @loicpoulain
 drivers/i2c/i2c_ll_stm32*                @ldts @ydamigos
@@ -130,7 +130,7 @@ include/arch/arm/cortex_m/irq.h          @andrewboie
 include/arch/nios2/                      @andrewboie
 include/arch/nios2/arch.h                @andrewboie
 include/arch/posix/                      @aescolar
-include/arch/riscv32                     @fractalclone @kgugala @pgielda
+include/arch/riscv32                     @nategraff-sifive @kgugala @pgielda
 include/arch/x86/                        @andrewboie @ramakrishnapallala
 include/arch/x86/arch.h                  @andrewboie
 include/arch/xtensa/                     @andrewboie
@@ -213,13 +213,13 @@ subsys/shell/                            @jarz-nordic @nordic-krch
 subsys/*/*native_posix*/                 @aescolar
 subsys/usb/                              @jfischer-phytec-iot @finikorg
 tests/boards/native_posix/               @aescolar
-tests/bluetooth/                         @sjanc @jhedberg @Vudentz @tarunkum
+tests/bluetooth/                         @sjanc @jhedberg @Vudentz
 tests/posix/                             @nniranjhana
 tests/crypto/                            @lpereira @pswarnak
 tests/crypto/mbedtls/                    @nashif @lpereira
 tests/drivers/spi/                       @tbursztyka
 tests/kernel/                            @andrewboie @andyross @spoorthik @pswarnak @nniranjhana
-tests/net/                               @jukkar @tbursztyka @tarunkum @pfalcon
+tests/net/                               @jukkar @tbursztyka @pfalcon
 tests/net/buf/                           @jukkar @jhedberg @tbursztyka @pfalcon
 tests/net/lib/                           @jukkar @tbursztyka @pfalcon
 tests/net/lib/http_header_fields/        @jukkar @tbursztyka


### PR DESCRIPTION
- Updated maintainers for riscv32: Added @nategraff-sifive
- Removed @tarunkum who is not working on the project anymore

Signed-off-by: Anas Nashif <anas.nashif@intel.com>