### PR TITLE
Remove asserts that break LF clock on nRF5

### DIFF
--- a/drivers/clock_control/nrf5_power_clock.c
+++ b/drivers/clock_control/nrf5_power_clock.c
@@ -326,8 +326,6 @@ static void _power_clock_isr(void *arg)
 
 	if (lf) {
 		NRF_CLOCK->EVENTS_LFCLKSTARTED = 0;
-
-		__ASSERT_NO_MSG(0);
 	}
 
 	if (done) {
@@ -345,7 +343,7 @@ static void _power_clock_isr(void *arg)
 
 		/* Calibration done, stop 16M Xtal. */
 		err = _m16src_stop(dev, NULL);
-		__ASSERT_NO_MSG(!err);
+		__ASSERT_NO_MSG(!err || err == -EBUSY);
 
 		/* Start timer for next calibration. */
 		NRF_CLOCK->TASKS_CTSTART = 1;


### PR DESCRIPTION
There are two asserts in the ISR for clock events on the nRF5 that
appear to be accidental.

The first assert fails if there are any LF clock started events, which
there will be when starting up the RC oscillator with calibration.

The second assert fails when we decrement the refcount on the HF
oscillator after finishing a calibration. There will typically be
users left of the HF oscillator, so _m16src_stop() doesn't actually
stop it and thus doesn't return 0.

This code typically works fine because it's not built with asserts
enabled by default. Can be reproduced on a BBC microbit with the
default config plus CONFIG_ASSERT=y.
