### PR TITLE
drivers: rtt: fix no return statement in rtt_init

### DIFF
--- a/ext/debug/segger/rtt/SEGGER_RTT_zephyr.c
+++ b/ext/debug/segger/rtt/SEGGER_RTT_zephyr.c
@@ -26,6 +26,8 @@ static int rtt_init(struct device *unused)
 	ARG_UNUSED(unused);
 
 	SEGGER_RTT_Init();
+
+	return 0;
 }
 
 SYS_INIT(rtt_init, PRE_KERNEL_1, CONFIG_KERNEL_INIT_PRIORITY_OBJECTS);


### PR DESCRIPTION
Add missing return statement to rtt_init function.

Signed-off-by: Pavel Kral <pavel.kral@omsquare.com>