### PR TITLE
logger: rtt backend don't let starve others in blocking mode

### DIFF
--- a/subsys/logging/log_backend_rtt.c
+++ b/subsys/logging/log_backend_rtt.c
@@ -224,7 +224,9 @@ static void panic(struct log_backend const *const backend)
 static void log_backend_rtt_flush(void)
 {
 	while (SEGGER_RTT_HasDataUp(CONFIG_LOG_BACKEND_RTT_BUFFER)) {
-		/* pass */
+		if (!panic_mode) {
+			k_yield();
+		}
 	}
 }
 


### PR DESCRIPTION
When a RTT logger backend is configured to blocks, allow other threads
to continue during waiting for data to be transferred to host.

Signed-off-by: Pavel Kral <pavel.kral@omsquare.com>