### PR TITLE
drivers: interrupt_controller: fix cmake file

### DIFF
--- a/drivers/interrupt_controller/CMakeLists.txt
+++ b/drivers/interrupt_controller/CMakeLists.txt
@@ -1,7 +1,7 @@
 zephyr_sources_ifdef(CONFIG_ARCV2_INTERRUPT_UNIT    arcv2_irq_unit.c)
 zephyr_sources_ifdef(CONFIG_IOAPIC                  ioapic_intr.c)
 zephyr_sources_ifdef(CONFIG_LOAPIC                  loapic_intr.c system_apic.c)
-zephyr_sources_ifdef(CONFIG_LOAPIC_SPURIOUS_VECTOR  loapic_spurious.c)
+zephyr_sources_ifdef(CONFIG_LOAPIC_SPURIOUS_VECTOR  loapic_spurious.S)
 zephyr_sources_ifdef(CONFIG_MVIC                    mvic.c)
 zephyr_sources_ifdef(CONFIG_PIC_DISABLE             i8259.c)
 zephyr_sources_ifdef(CONFIG_PLIC                    plic.c)


### PR DESCRIPTION
We were trying to build a file that does not exist, should include .S
file instead of .c

Signed-off-by: Anas Nashif <anas.nashif@intel.com>