### PR TITLE
net: if: Move link address assert check to net_if_up()

### DIFF
--- a/subsys/net/ip/net_if.c
+++ b/subsys/net/ip/net_if.c
@@ -246,11 +246,6 @@ static inline void init_iface(struct net_if *iface)
 	if (!net_if_is_ip_offloaded(iface)) {
 		NET_ASSERT(api->send);
 	}
-
-	/* In many places it's assumed that link address was set with
-	 * net_if_set_link_addr(). Better check that now.
-	 */
-	NET_ASSERT(net_if_get_link_addr(iface)->addr != NULL);
 }
 
 enum net_verdict net_if_send_data(struct net_if *iface, struct net_pkt *pkt)
@@ -2763,6 +2758,11 @@ int net_if_up(struct net_if *iface)
 	}
 
 done:
+	/* In many places it's assumed that link address was set with
+	 * net_if_set_link_addr(). Better check that now.
+	 */
+	NET_ASSERT(net_if_get_link_addr(iface)->addr != NULL);
+
 	atomic_set_bit(iface->if_dev->flags, NET_IF_UP);
 
 #if defined(CONFIG_NET_IPV6_DAD)


### PR DESCRIPTION
For Bluetooth, the link address is set only after the Bluetooth
connection is established. Because of this, place the link address
check to net_if_up() because at that point the link address should
be set properly.

Signed-off-by: Jukka Rissanen <jukka.rissanen@linux.intel.com>