### PR TITLE
boards: intel_s1000_crb: fix build error

### DIFF
--- a/drivers/dma/dma_cavs.c
+++ b/drivers/dma/dma_cavs.c
@@ -12,6 +12,7 @@
 #include <device.h>
 #include <init.h>
 #include <dma.h>
+#include <soc.h>
 
 #include "dma_cavs.h"
 

--- a/drivers/interrupt_controller/dw_ictl.c
+++ b/drivers/interrupt_controller/dw_ictl.c
@@ -14,6 +14,7 @@
 #include <device.h>
 #include <irq_nextlevel.h>
 #include "dw_ictl.h"
+#include <soc.h>
 
 static ALWAYS_INLINE void dw_ictl_dispatch_child_isrs(u32_t intr_status,
 						      u32_t isr_base_offset)

--- a/soc/xtensa/intel_s1000/Kconfig.defconfig
+++ b/soc/xtensa/intel_s1000/Kconfig.defconfig
@@ -13,7 +13,7 @@ config IRQ_OFFLOAD_INTNUM
 	default 0
 
 config XTENSA_ASM2
-	def_bool y
+	def_bool n
 
 # S1000 does not have MISC0.
 # Since EXCSAVE2 is unused by Zephyr, use it instead.


### PR DESCRIPTION
patch add the soc.h to dma_cavs and dw_ictl.c
drivers to fix build error.

XTENSA_ASM2 is disabled by default to fix system crash

Signed-off-by: Savinay Dharmappa <savinay.dharmappa@intel.com>