### PR TITLE
tests: bluetooth/tester: Fix having unique log domains

### DIFF
--- a/tests/bluetooth/tester/src/bttester.c
+++ b/tests/bluetooth/tester/src/bttester.c
@@ -16,6 +16,10 @@
 #include <misc/byteorder.h>
 #include <console/uart_pipe.h>
 
+#include <logging/log.h>
+#define LOG_MODULE_NAME bttester
+LOG_MODULE_REGISTER(LOG_MODULE_NAME);
+
 #include "bttester.h"
 
 #define STACKSIZE 2048

--- a/tests/bluetooth/tester/src/bttester.h
+++ b/tests/bluetooth/tester/src/bttester.h
@@ -24,10 +24,6 @@
 #define BTP_STATUS_UNKNOWN_CMD	0x02
 #define BTP_STATUS_NOT_READY	0x03
 
-#include <logging/log.h>
-#define LOG_MODULE_NAME bttester
-LOG_MODULE_REGISTER(LOG_MODULE_NAME);
-
 struct btp_hdr {
 	u8_t  service;
 	u8_t  opcode;

--- a/tests/bluetooth/tester/src/gap.c
+++ b/tests/bluetooth/tester/src/gap.c
@@ -17,6 +17,10 @@
 #include <misc/byteorder.h>
 #include <net/buf.h>
 
+#include <logging/log.h>
+#define LOG_MODULE_NAME bttester_gap
+LOG_MODULE_REGISTER(LOG_MODULE_NAME);
+
 #include "bttester.h"
 
 #define CONTROLLER_INDEX 0

--- a/tests/bluetooth/tester/src/gatt.c
+++ b/tests/bluetooth/tester/src/gatt.c
@@ -20,6 +20,10 @@
 #include <misc/printk.h>
 #include <net/buf.h>
 
+#include <logging/log.h>
+#define LOG_MODULE_NAME bttester_gatt
+LOG_MODULE_REGISTER(LOG_MODULE_NAME);
+
 #include "bttester.h"
 
 #define CONTROLLER_INDEX 0

--- a/tests/bluetooth/tester/src/l2cap.c
+++ b/tests/bluetooth/tester/src/l2cap.c
@@ -11,6 +11,11 @@
 #include <errno.h>
 #include <bluetooth/l2cap.h>
 #include <misc/byteorder.h>
+
+#include <logging/log.h>
+#define LOG_MODULE_NAME bttester_l2cap
+LOG_MODULE_REGISTER(LOG_MODULE_NAME);
+
 #include "bttester.h"
 
 #define CONTROLLER_INDEX 0

--- a/tests/bluetooth/tester/src/main.c
+++ b/tests/bluetooth/tester/src/main.c
@@ -10,6 +10,10 @@
 #include <zephyr/types.h>
 #include <toolchain.h>
 
+#include <logging/log.h>
+#define LOG_MODULE_NAME bttester_main
+LOG_MODULE_REGISTER(LOG_MODULE_NAME);
+
 #include "bttester.h"
 
 void main(void)

--- a/tests/bluetooth/tester/src/mesh.c
+++ b/tests/bluetooth/tester/src/mesh.c
@@ -12,6 +12,11 @@
 #include <bluetooth/mesh.h>
 #include <bluetooth/testing.h>
 #include <misc/byteorder.h>
+
+#include <logging/log.h>
+#define LOG_MODULE_NAME bttester_mesh
+LOG_MODULE_REGISTER(LOG_MODULE_NAME);
+
 #include "bttester.h"
 
 #define CONTROLLER_INDEX 0


### PR DESCRIPTION
Each c-file must have unique log domains or building will fail at the
linker stage.

Signed-off-by: Johan Hedberg <johan.hedberg@intel.com>