### PR TITLE
soc: xtensa: intel_s1000: fix fatal exception.

### DIFF
--- a/soc/xtensa/intel_s1000/Kconfig.defconfig
+++ b/soc/xtensa/intel_s1000/Kconfig.defconfig
@@ -13,7 +13,7 @@ config IRQ_OFFLOAD_INTNUM
 	default 0
 
 config XTENSA_ASM2
-	def_bool y
+	def_bool n
 
 # S1000 does not have MISC0.
 # Since EXCSAVE2 is unused by Zephyr, use it instead.


### PR DESCRIPTION
disable XTENSA_ASM2 Config to fix fatal exection
on intel_s1000.

Signed-off-by: Savinay Dharmappa <savinay.dharmappa@intel.com>