### PR TITLE
drivers: i2c: i2c_nrfx_twi: Add return -EBUSY when I2C bus is busy

### DIFF
--- a/drivers/i2c/i2c_nrfx_twi.c
+++ b/drivers/i2c/i2c_nrfx_twi.c
@@ -53,7 +53,11 @@ static int i2c_nrfx_twi_transfer(struct device *dev, struct i2c_msg *msgs,
 					       (msgs[i].flags & I2C_MSG_STOP) ?
 					       0 : NRFX_TWI_FLAG_TX_NO_STOP);
 		if (res != NRFX_SUCCESS) {
-			return -EIO;
+			if (res == NRFX_ERROR_BUSY) {
+				return -EBUSY;
+			} else {
+				return -EIO;
+			}
 		}
 
 		k_sem_take(&(get_dev_data(dev)->sync), K_FOREVER);

--- a/drivers/i2c/i2c_nrfx_twim.c
+++ b/drivers/i2c/i2c_nrfx_twim.c
@@ -54,7 +54,11 @@ static int i2c_nrfx_twim_transfer(struct device *dev, struct i2c_msg *msgs,
 					       (msgs[i].flags & I2C_MSG_STOP) ?
 					       0 : NRFX_TWIM_FLAG_TX_NO_STOP);
 		if (res != NRFX_SUCCESS) {
-			return -EIO;
+			if (res == NRFX_ERROR_BUSY) {
+				return -EBUSY;
+			} else {
+				return -EIO;
+			}
 		}
 
 		k_sem_take(&(get_dev_data(dev)->sync), K_FOREVER);


### PR DESCRIPTION
Return -EBUSY instead of -EIO when trying to access 
the I2C bus while it is currently used

Signed-off-by: Aurelien Vouaillat <aurelien.vouaillat@proglove.de>