### PR TITLE
drivers: uart_stm32: fix ORE hogging the CPU

### DIFF
--- a/drivers/serial/uart_stm32.c
+++ b/drivers/serial/uart_stm32.c
@@ -36,6 +36,11 @@ static int uart_stm32_poll_in(struct device *dev, unsigned char *c)
 {
 	USART_TypeDef *UartInstance = UART_STRUCT(dev);
 
+	/* Clear overrun error flag */
+	if (LL_USART_IsActiveFlag_ORE(UartInstance)) {
+		LL_USART_ClearFlag_ORE(UartInstance);
+	}
+
 	if (!LL_USART_IsActiveFlag_RXNE(UartInstance)) {
 		return -1;
 	}
@@ -107,6 +112,12 @@ static int uart_stm32_fifo_read(struct device *dev, u8_t *rx_data,
 
 		/* Receive a character (8bit , parity none) */
 		rx_data[num_rx++] = LL_USART_ReceiveData8(UartInstance);
+
+		/* Clear overrun error flag */
+		if (LL_USART_IsActiveFlag_ORE(UartInstance)) {
+			LL_USART_ClearFlag_ORE(UartInstance);
+		}
+
 	}
 	return num_rx;
 }


### PR DESCRIPTION
If data is received before an IRQ handler was set and enabled,
hardware sets the ORE flag. Once set, the IRQ routine starts
hogging the CPU until ORE is cleared. This change will clear
the flag when user code attempts to drain incoming data.

Fixes #10413