### PR TITLE
net: Rename net_is_xxx...() functions to net_xxx_is...()

### DIFF
--- a/include/net/net_ip.h
+++ b/include/net/net_ip.h
@@ -336,7 +336,7 @@ struct net_tcp_hdr {
  *
  * @return True if address is a loopback address, False otherwise.
  */
-static inline bool net_is_ipv6_addr_loopback(struct in6_addr *addr)
+static inline bool net_ipv6_is_addr_loopback(struct in6_addr *addr)
 {
 	return UNALIGNED_GET(&addr->s6_addr32[0]) == 0 &&
 		UNALIGNED_GET(&addr->s6_addr32[1]) == 0 &&
@@ -351,7 +351,7 @@ static inline bool net_is_ipv6_addr_loopback(struct in6_addr *addr)
  *
  * @return True if address is multicast address, False otherwise.
  */
-static inline bool net_is_ipv6_addr_mcast(const struct in6_addr *addr)
+static inline bool net_ipv6_is_addr_mcast(const struct in6_addr *addr)
 {
 	return addr->s6_addr[0] == 0xFF;
 }
@@ -369,7 +369,7 @@ extern struct net_if_addr *net_if_ipv6_addr_lookup(const struct in6_addr *addr,
  *
  * @return True if address was found, False otherwise.
  */
-static inline bool net_is_my_ipv6_addr(struct in6_addr *addr)
+static inline bool net_ipv6_is_my_addr(struct in6_addr *addr)
 {
 	return net_if_ipv6_addr_lookup(addr, NULL) != NULL;
 }
@@ -385,7 +385,7 @@ extern struct net_if_mcast_addr *net_if_ipv6_maddr_lookup(
  *
  * @return True if address was found, False otherwise.
  */
-static inline bool net_is_my_ipv6_maddr(struct in6_addr *maddr)
+static inline bool net_ipv6_is_my_maddr(struct in6_addr *maddr)
 {
 	return net_if_ipv6_maddr_lookup(maddr, NULL) != NULL;
 }
@@ -399,7 +399,7 @@ static inline bool net_is_my_ipv6_maddr(struct in6_addr *maddr)
  *
  * @return True if IPv6 prefixes are the same, False otherwise.
  */
-static inline bool net_is_ipv6_prefix(const u8_t *addr1,
+static inline bool net_ipv6_is_prefix(const u8_t *addr1,
 				      const u8_t *addr2,
 				      u8_t length)
 {
@@ -436,7 +436,7 @@ static inline bool net_is_ipv6_prefix(const u8_t *addr1,
  *
  * @return True if address is a loopback address, False otherwise.
  */
-static inline bool net_is_ipv4_addr_loopback(struct in_addr *addr)
+static inline bool net_ipv4_is_addr_loopback(struct in_addr *addr)
 {
 	return addr->s4_addr[0] == 127;
 }
@@ -448,7 +448,7 @@ static inline bool net_is_ipv4_addr_loopback(struct in_addr *addr)
  *
  *  @return True if the address is unspecified, false otherwise.
  */
-static inline bool net_is_ipv4_addr_unspecified(const struct in_addr *addr)
+static inline bool net_ipv4_is_addr_unspecified(const struct in_addr *addr)
 {
 	return UNALIGNED_GET(&addr->s_addr) == 0;
 }
@@ -460,7 +460,7 @@ static inline bool net_is_ipv4_addr_unspecified(const struct in_addr *addr)
  *
  * @return True if address is multicast address, False otherwise.
  */
-static inline bool net_is_ipv4_addr_mcast(const struct in_addr *addr)
+static inline bool net_ipv4_is_addr_mcast(const struct in_addr *addr)
 {
 	return (ntohl(UNALIGNED_GET(&addr->s_addr)) & 0xE0000000) == 0xE0000000;
 }
@@ -472,7 +472,7 @@ static inline bool net_is_ipv4_addr_mcast(const struct in_addr *addr)
  *
  * @return True if it is, false otherwise.
  */
-static inline bool net_is_ipv4_ll_addr(const struct in_addr *addr)
+static inline bool net_ipv4_is_ll_addr(const struct in_addr *addr)
 {
 	return (ntohl(UNALIGNED_GET(&addr->s_addr)) & 0xA9FE0000) == 0xA9FE0000;
 }
@@ -524,7 +524,7 @@ static inline bool net_ipv6_addr_cmp(const struct in6_addr *addr1,
  *
  * @return True if it is, false otherwise.
  */
-static inline bool net_is_ipv6_ll_addr(const struct in6_addr *addr)
+static inline bool net_ipv6_is_ll_addr(const struct in6_addr *addr)
 {
 	return UNALIGNED_GET(&addr->s6_addr16[0]) == htons(0xFE80);
 }
@@ -580,7 +580,7 @@ extern bool net_if_ipv4_is_addr_bcast(struct net_if *iface,
  *
  * @return True if address is a broadcast address, false otherwise.
  */
-static inline bool net_is_ipv4_addr_bcast(struct net_if *iface,
+static inline bool net_ipv4_is_addr_bcast(struct net_if *iface,
 					  const struct in_addr *addr)
 {
 	if (net_ipv4_addr_cmp(addr, net_ipv4_broadcast_address())) {
@@ -602,13 +602,13 @@ extern struct net_if_addr *net_if_ipv4_addr_lookup(const struct in_addr *addr,
  * @return True if IPv4 address is found in one of the network interfaces,
  * False otherwise.
  */
-static inline bool net_is_my_ipv4_addr(const struct in_addr *addr)
+static inline bool net_ipv4_is_my_addr(const struct in_addr *addr)
 {
 	bool ret;
 
 	ret = net_if_ipv4_addr_lookup(addr, NULL) != NULL;
 	if (!ret) {
-		ret = net_is_ipv4_addr_bcast(NULL, addr);
+		ret = net_ipv4_is_addr_bcast(NULL, addr);
 	}
 
 	return ret;
@@ -621,7 +621,7 @@ static inline bool net_is_my_ipv4_addr(const struct in_addr *addr)
  *
  *  @return True if the address is unspecified, false otherwise.
  */
-static inline bool net_is_ipv6_addr_unspecified(const struct in6_addr *addr)
+static inline bool net_ipv6_is_addr_unspecified(const struct in6_addr *addr)
 {
 	return UNALIGNED_GET(&addr->s6_addr32[0]) == 0 &&
 		UNALIGNED_GET(&addr->s6_addr32[1]) == 0 &&
@@ -637,7 +637,7 @@ static inline bool net_is_ipv6_addr_unspecified(const struct in6_addr *addr)
  *
  *  @return True if the address is solicited node address, false otherwise.
  */
-static inline bool net_is_ipv6_addr_solicited_node(const struct in6_addr *addr)
+static inline bool net_ipv6_is_addr_solicited_node(const struct in6_addr *addr)
 {
 	return UNALIGNED_GET(&addr->s6_addr32[0]) == htonl(0xff020000) &&
 		UNALIGNED_GET(&addr->s6_addr32[1]) == 0x00000000 &&
@@ -656,7 +656,7 @@ static inline bool net_is_ipv6_addr_solicited_node(const struct in6_addr *addr)
  * @return True if the address is in given scope multicast address,
  * false otherwise.
  */
-static inline bool net_is_ipv6_addr_mcast_scope(const struct in6_addr *addr,
+static inline bool net_ipv6_is_addr_mcast_scope(const struct in6_addr *addr,
 						int scope)
 {
 	return (addr->s6_addr[0] == 0xff) && (addr->s6_addr[1] == scope);
@@ -669,9 +669,9 @@ static inline bool net_is_ipv6_addr_mcast_scope(const struct in6_addr *addr,
  *
  * @return True if the address is global multicast address, false otherwise.
 */
-static inline bool net_is_ipv6_addr_mcast_global(const struct in6_addr *addr)
+static inline bool net_ipv6_is_addr_mcast_global(const struct in6_addr *addr)
 {
-	return net_is_ipv6_addr_mcast_scope(addr, 0x0e);
+	return net_ipv6_is_addr_mcast_scope(addr, 0x0e);
 }
 
 /**
@@ -683,9 +683,9 @@ static inline bool net_is_ipv6_addr_mcast_global(const struct in6_addr *addr)
  * @return True if the address is a interface scope multicast address,
  * false otherwise.
  */
-static inline bool net_is_ipv6_addr_mcast_iface(const struct in6_addr *addr)
+static inline bool net_ipv6_is_addr_mcast_iface(const struct in6_addr *addr)
 {
-	return net_is_ipv6_addr_mcast_scope(addr, 0x01);
+	return net_ipv6_is_addr_mcast_scope(addr, 0x01);
 }
 
 /**
@@ -697,9 +697,9 @@ static inline bool net_is_ipv6_addr_mcast_iface(const struct in6_addr *addr)
  * @return True if the address is a site scope multicast address,
  * false otherwise.
  */
-static inline bool net_is_ipv6_addr_mcast_site(const struct in6_addr *addr)
+static inline bool net_ipv6_is_addr_mcast_site(const struct in6_addr *addr)
 {
-	return net_is_ipv6_addr_mcast_scope(addr, 0x05);
+	return net_ipv6_is_addr_mcast_scope(addr, 0x05);
 }
 
 /**
@@ -711,9 +711,9 @@ static inline bool net_is_ipv6_addr_mcast_site(const struct in6_addr *addr)
  * @return True if the address is an organisation scope multicast address,
  * false otherwise.
  */
-static inline bool net_is_ipv6_addr_mcast_org(const struct in6_addr *addr)
+static inline bool net_ipv6_is_addr_mcast_org(const struct in6_addr *addr)
 {
-	return net_is_ipv6_addr_mcast_scope(addr, 0x08);
+	return net_ipv6_is_addr_mcast_scope(addr, 0x08);
 }
 
 /**
@@ -726,7 +726,7 @@ static inline bool net_is_ipv6_addr_mcast_org(const struct in6_addr *addr)
  * @return True if the IPv6 multicast address belongs to given multicast
  * group, false otherwise.
  */
-static inline bool net_is_ipv6_addr_mcast_group(const struct in6_addr *addr,
+static inline bool net_ipv6_is_addr_mcast_group(const struct in6_addr *addr,
 						const struct in6_addr *group)
 {
 	return UNALIGNED_GET(&addr->s6_addr16[1]) == group->s6_addr16[1] &&

--- a/samples/net/nats/src/main.c
+++ b/samples/net/nats/src/main.c
@@ -142,7 +142,7 @@ static void initialize_network(void)
 	NET_INFO("Waiting for DHCP ...");
 	do {
 		k_sleep(K_SECONDS(1));
-	} while (net_is_ipv4_addr_unspecified(&iface->dhcpv4.requested_ip));
+	} while (net_ipv4_is_addr_unspecified(&iface->dhcpv4.requested_ip));
 
 	NET_INFO("Done!");
 
@@ -150,7 +150,7 @@ static void initialize_network(void)
 	NET_INFO("Waiting for IP assginment ...");
 	do {
 		k_sleep(K_SECONDS(1));
-	} while (!net_is_my_ipv4_addr(&iface->dhcpv4.requested_ip));
+	} while (!net_ipv4_is_my_addr(&iface->dhcpv4.requested_ip));
 
 	NET_INFO("Done!");
 #else

--- a/samples/net/zperf/src/zperf_shell.c
+++ b/samples/net/zperf/src/zperf_shell.c
@@ -849,13 +849,13 @@ static int shell_cmd_upload2(const struct shell *shell, size_t argc,
 	}
 
 	if (family == AF_INET6) {
-		if (net_is_ipv6_addr_unspecified(&in6_addr_my.sin6_addr)) {
+		if (net_ipv6_is_addr_unspecified(&in6_addr_my.sin6_addr)) {
 			shell_fprintf(shell, SHELL_WARNING,
 				      "Invalid local IPv6 address.\n");
 			return -ENOEXEC;
 		}
 
-		if (net_is_ipv6_addr_unspecified(&in6_addr_dst.sin6_addr)) {
+		if (net_ipv6_is_addr_unspecified(&in6_addr_dst.sin6_addr)) {
 			shell_fprintf(shell, SHELL_WARNING,
 				      "Invalid destination IPv6 address.\n");
 			return -ENOEXEC;
@@ -865,13 +865,13 @@ static int shell_cmd_upload2(const struct shell *shell, size_t argc,
 			      "Connecting to %s\n",
 			      net_sprint_ipv6_addr(&in6_addr_dst.sin6_addr));
 	} else {
-		if (net_is_ipv4_addr_unspecified(&in4_addr_my.sin_addr)) {
+		if (net_ipv4_is_addr_unspecified(&in4_addr_my.sin_addr)) {
 			shell_fprintf(shell, SHELL_WARNING,
 				      "Invalid local IPv4 address.\n");
 			return -ENOEXEC;
 		}
 
-		if (net_is_ipv4_addr_unspecified(&in4_addr_dst.sin_addr)) {
+		if (net_ipv4_is_addr_unspecified(&in4_addr_dst.sin_addr)) {
 			shell_fprintf(shell, SHELL_WARNING,
 				      "Invalid destination IPv4 address.\n");
 			return -ENOEXEC;

--- a/subsys/net/ip/6lo.c
+++ b/subsys/net/ip/6lo.c
@@ -288,7 +288,7 @@ static inline u8_t compress_sa(struct net_ipv6_hdr *ipv6,
 			       struct net_buf *frag,
 			       u8_t offset)
 {
-	if (net_is_ipv6_addr_unspecified(&ipv6->src)) {
+	if (net_ipv6_is_addr_unspecified(&ipv6->src)) {
 		NET_DBG("SAM_00, SAC_1 unspecified src address");
 
 		/* Unspecified IPv6 src address */
@@ -299,7 +299,7 @@ static inline u8_t compress_sa(struct net_ipv6_hdr *ipv6,
 	}
 
 	/* If address is link-local prefix and padded with zeros */
-	if (net_is_ipv6_ll_addr(&ipv6->src) &&
+	if (net_ipv6_is_ll_addr(&ipv6->src) &&
 	    net_6lo_ll_prefix_padded_with_zeros(&ipv6->src)) {
 
 		NET_DBG("SAC_0 src is ll_addr and padded with zeros");
@@ -446,12 +446,12 @@ static inline u8_t compress_da(struct net_ipv6_hdr *ipv6,
 			       u8_t offset)
 {
 	/* If destination address is multicast */
-	if (net_is_ipv6_addr_mcast(&ipv6->dst)) {
+	if (net_ipv6_is_addr_mcast(&ipv6->dst)) {
 		return compress_da_mcast(ipv6, pkt, frag, offset);
 	}
 
 	/* If address is link-local prefix and padded with zeros */
-	if (net_is_ipv6_ll_addr(&ipv6->dst) &&
+	if (net_ipv6_is_ll_addr(&ipv6->dst) &&
 	    net_6lo_ll_prefix_padded_with_zeros(&ipv6->dst)) {
 
 		NET_DBG("Dst is ll_addr and padded with zeros");

--- a/subsys/net/ip/connection.c
+++ b/subsys/net/ip/connection.c
@@ -580,7 +580,7 @@ int net_conn_register(enum net_ip_protocol proto,
 				memcpy(&conns[i].remote_addr, remote_addr,
 				       sizeof(struct sockaddr_in6));
 
-				if (net_is_ipv6_addr_unspecified(
+				if (net_ipv6_is_addr_unspecified(
 					    &net_sin6(remote_addr)->
 							sin6_addr)) {
 					rank |= NET_RANK_REMOTE_UNSPEC_ADDR;
@@ -617,7 +617,7 @@ int net_conn_register(enum net_ip_protocol proto,
 				memcpy(&conns[i].local_addr, local_addr,
 				       sizeof(struct sockaddr_in6));
 
-				if (net_is_ipv6_addr_unspecified(
+				if (net_ipv6_is_addr_unspecified(
 					    &net_sin6(local_addr)->
 							sin6_addr)) {
 					rank |= NET_RANK_LOCAL_UNSPEC_ADDR;
@@ -721,7 +721,7 @@ static bool check_addr(struct net_pkt *pkt,
 			addr6 = &NET_IPV6_HDR(pkt)->dst;
 		}
 
-		if (!net_is_ipv6_addr_unspecified(
+		if (!net_ipv6_is_addr_unspecified(
 			    &net_sin6(addr)->sin6_addr)) {
 			if (!net_ipv6_addr_cmp(&net_sin6(addr)->sin6_addr,
 					       addr6)) {
@@ -781,14 +781,14 @@ static bool is_invalid_packet(struct net_pkt *pkt,
 	switch (NET_IPV6_HDR(pkt)->vtc & 0xf0) {
 #if defined(CONFIG_NET_IPV6)
 	case 0x60:
-		if (net_is_my_ipv6_addr(&NET_IPV6_HDR(pkt)->src)) {
+		if (net_ipv6_is_my_addr(&NET_IPV6_HDR(pkt)->src)) {
 			my_src_addr = true;
 		}
 		break;
 #endif
 #if defined(CONFIG_NET_IPV4)
 	case 0x40:
-		if (net_is_my_ipv4_addr(&NET_IPV4_HDR(pkt)->src)) {
+		if (net_ipv4_is_my_addr(&NET_IPV4_HDR(pkt)->src)) {
 			my_src_addr = true;
 		}
 		break;
@@ -1004,13 +1004,13 @@ enum net_verdict net_conn_input(enum net_ip_protocol proto, struct net_pkt *pkt)
 	 * we do not send ICMP error as that makes no sense.
 	 */
 	if (net_pkt_family(pkt) == AF_INET6 &&
-	    net_is_ipv6_addr_mcast(&NET_IPV6_HDR(pkt)->dst)) {
+	    net_ipv6_is_addr_mcast(&NET_IPV6_HDR(pkt)->dst)) {
 		;
 	} else
 #endif
 #if defined(CONFIG_NET_IPV4)
 	if (net_pkt_family(pkt) == AF_INET &&
-	    net_is_ipv4_addr_mcast(&NET_IPV4_HDR(pkt)->dst)) {
+	    net_ipv4_is_addr_mcast(&NET_IPV4_HDR(pkt)->dst)) {
 		;
 	} else
 #endif

--- a/subsys/net/ip/icmpv4.c
+++ b/subsys/net/ip/icmpv4.c
@@ -345,7 +345,7 @@ enum net_verdict net_icmpv4_input(struct net_pkt *pkt)
 		goto drop;
 	}
 
-	if (net_is_ipv4_addr_bcast(net_pkt_iface(pkt),
+	if (net_ipv4_is_addr_bcast(net_pkt_iface(pkt),
 				   &NET_IPV4_HDR(pkt)->dst)) {
 		if (!IS_ENABLED(CONFIG_NET_ICMPV4_ACCEPT_BROADCAST) ||
 		    icmp_hdr.type != NET_ICMPV4_ECHO_REQUEST) {

--- a/subsys/net/ip/icmpv6.c
+++ b/subsys/net/ip/icmpv6.c
@@ -334,7 +334,7 @@ static enum net_verdict handle_echo_request(struct net_pkt *orig)
 	NET_IPV6_HDR(pkt)->flow = 0;
 	NET_IPV6_HDR(pkt)->hop_limit = net_if_ipv6_get_hop_limit(iface);
 
-	if (net_is_ipv6_addr_mcast(&NET_IPV6_HDR(pkt)->dst)) {
+	if (net_ipv6_is_addr_mcast(&NET_IPV6_HDR(pkt)->dst)) {
 		net_ipaddr_copy(&NET_IPV6_HDR(pkt)->dst,
 				&NET_IPV6_HDR(orig)->src);
 
@@ -480,7 +480,7 @@ int net_icmpv6_send_error(struct net_pkt *orig, u8_t type, u8_t code,
 			     sizeof(struct net_icmp_hdr));
 	}
 
-	if (net_is_ipv6_addr_mcast(&NET_IPV6_HDR(orig)->dst)) {
+	if (net_ipv6_is_addr_mcast(&NET_IPV6_HDR(orig)->dst)) {
 		net_ipaddr_copy(&NET_IPV6_HDR(pkt)->dst,
 				&NET_IPV6_HDR(orig)->src);
 

--- a/subsys/net/ip/ipv4.c
+++ b/subsys/net/ip/ipv4.c
@@ -122,7 +122,7 @@ enum net_verdict net_ipv4_process_pkt(struct net_pkt *pkt)
 		goto drop;
 	}
 
-	if (net_is_ipv4_addr_bcast(net_pkt_iface(pkt), &hdr->src)) {
+	if (net_ipv4_is_addr_bcast(net_pkt_iface(pkt), &hdr->src)) {
 		goto drop;
 	}
 
@@ -133,8 +133,8 @@ enum net_verdict net_ipv4_process_pkt(struct net_pkt *pkt)
 	net_pkt_set_ip_hdr_len(pkt, sizeof(struct net_ipv4_hdr));
 	net_pkt_set_ipv4_ttl(pkt, NET_IPV4_HDR(pkt)->ttl);
 
-	if (!net_is_my_ipv4_addr(&hdr->dst) &&
-	    !net_is_ipv4_addr_mcast(&hdr->dst)) {
+	if (!net_ipv4_is_my_addr(&hdr->dst) &&
+	    !net_ipv4_is_addr_mcast(&hdr->dst)) {
 		if (IS_ENABLED(CONFIG_NET_DHCPV4) &&
 		    hdr->proto == IPPROTO_UDP &&
 		    net_ipv4_addr_cmp(&hdr->dst,
@@ -157,7 +157,7 @@ enum net_verdict net_ipv4_process_pkt(struct net_pkt *pkt)
 		verdict = net_icmpv4_input(pkt);
 		break;
 	case IPPROTO_TCP:
-		if (net_is_ipv4_addr_bcast(net_pkt_iface(pkt), &hdr->dst)) {
+		if (net_ipv4_is_addr_bcast(net_pkt_iface(pkt), &hdr->dst)) {
 			goto drop;
 		}
 

--- a/subsys/net/ip/ipv6.c
+++ b/subsys/net/ip/ipv6.c
@@ -192,7 +192,7 @@ static inline struct net_pkt *check_unknown_option(struct net_pkt *pkt,
 	case 0x40:
 		return NULL;
 	case 0xc0:
-		if (net_is_ipv6_addr_mcast(&NET_IPV6_HDR(pkt)->dst)) {
+		if (net_ipv6_is_addr_mcast(&NET_IPV6_HDR(pkt)->dst)) {
 			return NULL;
 		}
 		/* passthrough */
@@ -372,8 +372,8 @@ static enum net_verdict route_ipv6_packet(struct net_pkt *pkt,
 		int ret;
 
 		if (IS_ENABLED(CONFIG_NET_ROUTING) &&
-		    (net_is_ipv6_ll_addr(&hdr->src) ||
-		     net_is_ipv6_ll_addr(&hdr->dst))) {
+		    (net_ipv6_is_ll_addr(&hdr->src) ||
+		     net_ipv6_is_ll_addr(&hdr->dst))) {
 			/* RFC 4291 ch 2.5.6 */
 			no_route_info(pkt, &hdr->src, &hdr->dst);
 			goto drop;
@@ -445,28 +445,28 @@ enum net_verdict net_ipv6_process_pkt(struct net_pkt *pkt, bool is_loopback)
 		log_strdup(net_sprint_ipv6_addr(&hdr->src)),
 		log_strdup(net_sprint_ipv6_addr(&hdr->dst)));
 
-	if (!is_loopback && (net_is_ipv6_addr_loopback(&hdr->dst) ||
-			     net_is_ipv6_addr_loopback(&hdr->src))) {
+	if (!is_loopback && (net_ipv6_is_addr_loopback(&hdr->dst) ||
+			     net_ipv6_is_addr_loopback(&hdr->src))) {
 		NET_DBG("Dropping ::1 packet");
 		net_stats_update_ipv6_drop(net_pkt_iface(pkt));
 		goto drop;
 	}
 
-	if (net_is_ipv6_addr_mcast(&hdr->src) ||
-	    net_is_ipv6_addr_mcast_scope(&hdr->dst, 0)) {
+	if (net_ipv6_is_addr_mcast(&hdr->src) ||
+	    net_ipv6_is_addr_mcast_scope(&hdr->dst, 0)) {
 		NET_DBG("Dropping multicast packet");
 		net_stats_update_ipv6_drop(net_pkt_iface(pkt));
 		goto drop;
 	}
 
 	if (!is_loopback) {
-		bool is_empty_group = net_is_ipv6_addr_mcast_group(
+		bool is_empty_group = net_ipv6_is_addr_mcast_group(
 			&hdr->dst, net_ipv6_unspecified_address());
 
-		if (net_is_ipv6_addr_mcast_iface(&hdr->dst) ||
+		if (net_ipv6_is_addr_mcast_iface(&hdr->dst) ||
 		    (is_empty_group &&
-		     (net_is_ipv6_addr_mcast_site(&hdr->dst) ||
-		      net_is_ipv6_addr_mcast_org(&hdr->dst)))) {
+		     (net_ipv6_is_addr_mcast_site(&hdr->dst) ||
+		      net_ipv6_is_addr_mcast_org(&hdr->dst)))) {
 			NET_DBG("Dropping invalid scope multicast packet");
 			net_stats_update_ipv6_drop(net_pkt_iface(pkt));
 			goto drop;
@@ -479,9 +479,9 @@ enum net_verdict net_ipv6_process_pkt(struct net_pkt *pkt, bool is_loopback)
 	net_pkt_set_ip_hdr_len(pkt, sizeof(struct net_ipv6_hdr));
 	net_pkt_set_ipv6_hop_limit(pkt, NET_IPV6_HDR(pkt)->hop_limit);
 
-	if (!net_is_my_ipv6_addr(&hdr->dst) &&
-	    !net_is_my_ipv6_maddr(&hdr->dst) &&
-	    !net_is_ipv6_addr_mcast(&hdr->dst)) {
+	if (!net_ipv6_is_my_addr(&hdr->dst) &&
+	    !net_ipv6_is_my_maddr(&hdr->dst) &&
+	    !net_ipv6_is_addr_mcast(&hdr->dst)) {
 #if defined(CONFIG_NET_ROUTE)
 		enum net_verdict verdict;
 
@@ -502,8 +502,8 @@ enum net_verdict net_ipv6_process_pkt(struct net_pkt *pkt, bool is_loopback)
 	 * boundary, then drop the packet. RFC 4291 ch 2.5.6
 	 */
 	if (IS_ENABLED(CONFIG_NET_ROUTING) &&
-	    net_is_ipv6_ll_addr(&hdr->src) &&
-	    !net_is_ipv6_addr_mcast(&hdr->dst) &&
+	    net_ipv6_is_ll_addr(&hdr->src) &&
+	    !net_ipv6_is_addr_mcast(&hdr->dst) &&
 	    !net_if_ipv6_addr_lookup_by_iface(net_pkt_iface(pkt),
 					      &hdr->dst)) {
 		no_route_info(pkt, &hdr->src, &hdr->dst);

--- a/subsys/net/ip/net_context.c
+++ b/subsys/net/ip/net_context.c
@@ -418,7 +418,7 @@ int net_context_bind(struct net_context *context, const struct sockaddr *addr,
 			return -EINVAL;
 		}
 
-		if (net_is_ipv6_addr_mcast(&addr6->sin6_addr)) {
+		if (net_ipv6_is_addr_mcast(&addr6->sin6_addr)) {
 			struct net_if_mcast_addr *maddr;
 
 			maddr = net_if_ipv6_maddr_lookup(&addr6->sin6_addr,
@@ -429,7 +429,7 @@ int net_context_bind(struct net_context *context, const struct sockaddr *addr,
 
 			ptr = &maddr->address.in6_addr;
 
-		} else if (net_is_ipv6_addr_unspecified(&addr6->sin6_addr)) {
+		} else if (net_ipv6_is_addr_unspecified(&addr6->sin6_addr)) {
 			iface = net_if_ipv6_select_src_iface(
 				&net_sin6(&context->remote)->sin6_addr);
 
@@ -507,7 +507,7 @@ int net_context_bind(struct net_context *context, const struct sockaddr *addr,
 			return -EINVAL;
 		}
 
-		if (net_is_ipv4_addr_mcast(&addr4->sin_addr)) {
+		if (net_ipv4_is_addr_mcast(&addr4->sin_addr)) {
 			struct net_if_mcast_addr *maddr;
 
 			maddr = net_if_ipv4_maddr_lookup(&addr4->sin_addr,
@@ -638,8 +638,8 @@ struct net_pkt *net_context_create_ipv4(struct net_context *context,
 		src = ((struct sockaddr_in_ptr *)&context->local)->sin_addr;
 	}
 
-	if (net_is_ipv4_addr_unspecified(src)
-	    || net_is_ipv4_addr_mcast(src)) {
+	if (net_ipv4_is_addr_unspecified(src)
+	    || net_ipv4_is_addr_mcast(src)) {
 		src = net_if_ipv4_select_src_addr(net_pkt_iface(pkt),
 						  (struct in_addr *)dst);
 	}
@@ -664,8 +664,8 @@ struct net_pkt *net_context_create_ipv6(struct net_context *context,
 		src = ((struct sockaddr_in6_ptr *)&context->local)->sin6_addr;
 	}
 
-	if (net_is_ipv6_addr_unspecified(src)
-	    || net_is_ipv6_addr_mcast(src)) {
+	if (net_ipv6_is_addr_unspecified(src)
+	    || net_ipv6_is_addr_mcast(src)) {
 		src = net_if_ipv6_select_src_addr(net_pkt_iface(pkt),
 						  (struct in6_addr *)dst);
 	}
@@ -733,7 +733,7 @@ int net_context_connect(struct net_context *context,
 		}
 
 		if (net_context_get_ip_proto(context) == IPPROTO_TCP &&
-		    net_is_ipv6_addr_mcast(&addr6->sin6_addr)) {
+		    net_ipv6_is_addr_mcast(&addr6->sin6_addr)) {
 			return -EADDRNOTAVAIL;
 		}
 
@@ -743,7 +743,7 @@ int net_context_connect(struct net_context *context,
 		addr6->sin6_port = net_sin6(addr)->sin6_port;
 		addr6->sin6_family = AF_INET6;
 
-		if (!net_is_ipv6_addr_unspecified(&addr6->sin6_addr)) {
+		if (!net_ipv6_is_addr_unspecified(&addr6->sin6_addr)) {
 			context->flags |= NET_CONTEXT_REMOTE_ADDR_SET;
 		} else {
 			context->flags &= ~NET_CONTEXT_REMOTE_ADDR_SET;
@@ -978,7 +978,7 @@ static int sendto(struct net_pkt *pkt,
 			return -EINVAL;
 		}
 
-		if (net_is_ipv6_addr_unspecified(&addr6->sin6_addr)) {
+		if (net_ipv6_is_addr_unspecified(&addr6->sin6_addr)) {
 			return -EDESTADDRREQ;
 		}
 	} else

--- a/subsys/net/ip/net_core.c
+++ b/subsys/net/ip/net_core.c
@@ -174,8 +174,8 @@ static inline int check_ip_addr(struct net_pkt *pkt)
 		/* If the destination address is our own, then route it
 		 * back to us.
 		 */
-		if (net_is_ipv6_addr_loopback(&NET_IPV6_HDR(pkt)->dst) ||
-		    net_is_my_ipv6_addr(&NET_IPV6_HDR(pkt)->dst)) {
+		if (net_ipv6_is_addr_loopback(&NET_IPV6_HDR(pkt)->dst) ||
+		    net_ipv6_is_my_addr(&NET_IPV6_HDR(pkt)->dst)) {
 			struct in6_addr addr;
 
 			/* Swap the addresses so that in receiving side
@@ -192,7 +192,7 @@ static inline int check_ip_addr(struct net_pkt *pkt)
 		/* The source check must be done after the destination check
 		 * as having src ::1 is perfectly ok if dst is ::1 too.
 		 */
-		if (net_is_ipv6_addr_loopback(&NET_IPV6_HDR(pkt)->src)) {
+		if (net_ipv6_is_addr_loopback(&NET_IPV6_HDR(pkt)->src)) {
 			NET_DBG("IPv6 loopback src address");
 			return -EADDRNOTAVAIL;
 		}
@@ -210,10 +210,10 @@ static inline int check_ip_addr(struct net_pkt *pkt)
 		/* If the destination address is our own, then route it
 		 * back to us.
 		 */
-		if (net_is_ipv4_addr_loopback(&NET_IPV4_HDR(pkt)->dst) ||
-		    (net_is_ipv4_addr_bcast(net_pkt_iface(pkt),
+		if (net_ipv4_is_addr_loopback(&NET_IPV4_HDR(pkt)->dst) ||
+		    (net_ipv4_is_addr_bcast(net_pkt_iface(pkt),
 				     &NET_IPV4_HDR(pkt)->dst) == false &&
-		     net_is_my_ipv4_addr(&NET_IPV4_HDR(pkt)->dst))) {
+		     net_ipv4_is_my_addr(&NET_IPV4_HDR(pkt)->dst))) {
 			struct in_addr addr;
 
 			/* Swap the addresses so that in receiving side
@@ -231,7 +231,7 @@ static inline int check_ip_addr(struct net_pkt *pkt)
 		 * as having src 127.0.0.0/8 is perfectly ok if dst is in
 		 * localhost subnet too.
 		 */
-		if (net_is_ipv4_addr_loopback(&NET_IPV4_HDR(pkt)->src)) {
+		if (net_ipv4_is_addr_loopback(&NET_IPV4_HDR(pkt)->src)) {
 			NET_DBG("IPv4 loopback src address");
 			return -EADDRNOTAVAIL;
 		}

--- a/subsys/net/ip/net_if.c
+++ b/subsys/net/ip/net_if.c
@@ -723,7 +723,7 @@ struct net_if_addr *net_if_ipv6_addr_lookup(const struct in6_addr *addr,
 				continue;
 			}
 
-			if (net_is_ipv6_prefix(
+			if (net_ipv6_is_prefix(
 				    addr->s6_addr,
 				    ipv6->unicast[i].address.in6_addr.s6_addr,
 				    128)) {
@@ -756,7 +756,7 @@ struct net_if_addr *net_if_ipv6_addr_lookup_by_iface(struct net_if *iface,
 			continue;
 		}
 
-		if (net_is_ipv6_prefix(
+		if (net_ipv6_is_prefix(
 			    addr->s6_addr,
 			    ipv6->unicast[i].address.in6_addr.s6_addr,
 			    128)) {
@@ -986,7 +986,7 @@ static inline struct in6_addr *check_global_addr(struct net_if *iface)
 			continue;
 		}
 
-		if (!net_is_ipv6_ll_addr(&ipv6->unicast[i].address.in6_addr)) {
+		if (!net_ipv6_is_ll_addr(&ipv6->unicast[i].address.in6_addr)) {
 			return &ipv6->unicast[i].address.in6_addr;
 		}
 	}
@@ -1134,7 +1134,7 @@ struct net_if_mcast_addr *net_if_ipv6_maddr_add(struct net_if *iface,
 		return NULL;
 	}
 
-	if (!net_is_ipv6_addr_mcast(addr)) {
+	if (!net_ipv6_is_addr_mcast(addr)) {
 		NET_DBG("Address %s is not a multicast address.",
 			log_strdup(net_sprint_ipv6_addr(addr)));
 		return NULL;
@@ -1215,7 +1215,7 @@ struct net_if_mcast_addr *net_if_ipv6_maddr_lookup(const struct in6_addr *maddr,
 				continue;
 			}
 
-			if (net_is_ipv6_prefix(
+			if (net_ipv6_is_prefix(
 				    maddr->s6_addr,
 				    ipv6->mcast[i].address.in6_addr.s6_addr,
 				    128)) {
@@ -1275,7 +1275,7 @@ static void remove_prefix_addresses(struct net_if *iface,
 			continue;
 		}
 
-		if (net_is_ipv6_prefix(
+		if (net_ipv6_is_prefix(
 				addr->s6_addr,
 				ipv6->unicast[i].address.in6_addr.s6_addr,
 				len)) {
@@ -1567,7 +1567,7 @@ struct net_if_ipv6_prefix *net_if_ipv6_prefix_get(struct net_if *iface,
 			continue;
 		}
 
-		if (net_is_ipv6_prefix(ipv6->prefix[i].prefix.s6_addr,
+		if (net_ipv6_is_prefix(ipv6->prefix[i].prefix.s6_addr,
 				       addr->s6_addr,
 				       ipv6->prefix[i].len)) {
 			if (!prefix || prefix->len > ipv6->prefix[i].len) {
@@ -1595,7 +1595,7 @@ struct net_if_ipv6_prefix *net_if_ipv6_prefix_lookup(struct net_if *iface,
 			continue;
 		}
 
-		if (net_is_ipv6_prefix(ipv6->prefix[i].prefix.s6_addr,
+		if (net_ipv6_is_prefix(ipv6->prefix[i].prefix.s6_addr,
 				       addr->s6_addr, len)) {
 			return &ipv6->prefix[i];
 		}
@@ -1622,7 +1622,7 @@ bool net_if_ipv6_addr_onlink(struct net_if **iface, struct in6_addr *addr)
 
 		for (i = 0; i < NET_IF_MAX_IPV6_PREFIX; i++) {
 			if (ipv6->prefix[i].is_used &&
-			    net_is_ipv6_prefix(ipv6->prefix[i].prefix.s6_addr,
+			    net_ipv6_is_prefix(ipv6->prefix[i].prefix.s6_addr,
 					       addr->s6_addr,
 					       ipv6->prefix[i].len)) {
 				if (iface) {
@@ -1825,7 +1825,7 @@ struct in6_addr *net_if_ipv6_get_ll(struct net_if *iface,
 			continue;
 		}
 
-		if (net_is_ipv6_ll_addr(&ipv6->unicast[i].address.in6_addr)) {
+		if (net_ipv6_is_ll_addr(&ipv6->unicast[i].address.in6_addr)) {
 			return &ipv6->unicast[i].address.in6_addr;
 		}
 	}
@@ -1888,7 +1888,7 @@ static inline bool is_proper_ipv6_address(struct net_if_addr *addr)
 {
 	if (addr->is_used && addr->addr_state == NET_ADDR_PREFERRED &&
 	    addr->address.family == AF_INET6 &&
-	    !net_is_ipv6_ll_addr(&addr->address.in6_addr)) {
+	    !net_ipv6_is_ll_addr(&addr->address.in6_addr)) {
 		return true;
 	}
 
@@ -1930,7 +1930,7 @@ const struct in6_addr *net_if_ipv6_select_src_addr(struct net_if *dst_iface,
 	u8_t best_match = 0;
 	struct net_if *iface;
 
-	if (!net_is_ipv6_ll_addr(dst) && !net_is_ipv6_addr_mcast(dst)) {
+	if (!net_ipv6_is_ll_addr(dst) && !net_ipv6_is_addr_mcast(dst)) {
 
 		for (iface = __net_if_start;
 		     !dst_iface && iface != __net_if_end;
@@ -2221,7 +2221,7 @@ static inline bool is_proper_ipv4_address(struct net_if_addr *addr)
 {
 	if (addr->is_used && addr->addr_state == NET_ADDR_PREFERRED &&
 	    addr->address.family == AF_INET &&
-	    !net_is_ipv4_ll_addr(&addr->address.in_addr)) {
+	    !net_ipv4_is_ll_addr(&addr->address.in_addr)) {
 		return true;
 	}
 
@@ -2274,7 +2274,7 @@ struct in_addr *net_if_ipv4_get_ll(struct net_if *iface,
 			continue;
 		}
 
-		if (net_is_ipv4_ll_addr(&ipv4->unicast[i].address.in_addr)) {
+		if (net_ipv4_is_ll_addr(&ipv4->unicast[i].address.in_addr)) {
 			return &ipv4->unicast[i].address.in_addr;
 		}
 	}
@@ -2289,7 +2289,7 @@ const struct in_addr *net_if_ipv4_select_src_addr(struct net_if *dst_iface,
 	u8_t best_match = 0;
 	struct net_if *iface;
 
-	if (!net_is_ipv4_ll_addr(dst) && !net_is_ipv4_addr_mcast(dst)) {
+	if (!net_ipv4_is_ll_addr(dst) && !net_ipv4_is_addr_mcast(dst)) {
 
 		for (iface = __net_if_start;
 		     !dst_iface && iface != __net_if_end;
@@ -2525,7 +2525,7 @@ struct net_if_mcast_addr *net_if_ipv4_maddr_add(struct net_if *iface,
 		return NULL;
 	}
 
-	if (!net_is_ipv4_addr_mcast(addr)) {
+	if (!net_ipv4_is_addr_mcast(addr)) {
 		NET_DBG("Address %s is not a multicast address.",
 			log_strdup(net_sprint_ipv4_addr(addr)));
 		return NULL;

--- a/subsys/net/ip/route.c
+++ b/subsys/net/ip/route.c
@@ -273,7 +273,7 @@ struct net_route_entry *net_route_lookup(struct net_if *iface,
 		route = net_route_data(nbr);
 
 		if (route->prefix_len >= longest_match &&
-		    net_is_ipv6_prefix((u8_t *)dst,
+		    net_ipv6_is_prefix((u8_t *)dst,
 				       (u8_t *)&route->addr,
 				       route->prefix_len)) {
 			found = route;

--- a/subsys/net/ip/rpl.c
+++ b/subsys/net/ip/rpl.c
@@ -825,7 +825,7 @@ static enum net_verdict handle_dis(struct net_pkt *pkt)
 			continue;
 		}
 
-		if (net_is_ipv6_addr_mcast(&NET_IPV6_HDR(pkt)->dst)) {
+		if (net_ipv6_is_addr_mcast(&NET_IPV6_HDR(pkt)->dst)) {
 			net_rpl_dio_reset_timer(instance);
 		} else {
 			net_rpl_dio_send(net_pkt_iface(pkt),
@@ -1232,7 +1232,7 @@ static void check_prefix(struct net_if *iface,
 
 	if (last_prefix && new_prefix &&
 	    last_prefix->length == new_prefix->length &&
-	    net_is_ipv6_prefix(last_prefix->prefix.s6_addr,
+	    net_ipv6_is_prefix(last_prefix->prefix.s6_addr,
 			       new_prefix->prefix.s6_addr,
 			       new_prefix->length) &&
 	    last_prefix->flags == new_prefix->flags) {
@@ -2215,7 +2215,7 @@ static void send_mcast_dao(struct net_rpl_instance *instance)
 		   &instance->iface->config.ip.ipv6->mcast[i].address.in6_addr;
 
 		if (instance->iface->config.ip.ipv6->mcast[i].is_used &&
-		    net_is_ipv6_addr_mcast_global(addr)) {
+		    net_ipv6_is_addr_mcast_global(addr)) {
 
 			net_rpl_dao_send(instance->iface,
 				       instance->current_dag->preferred_parent,
@@ -3404,7 +3404,7 @@ static enum net_verdict handle_dao(struct net_pkt *pkt)
 		}
 	}
 
-	learned_from = net_is_ipv6_addr_mcast(dao_sender) ?
+	learned_from = net_ipv6_is_addr_mcast(dao_sender) ?
 		NET_RPL_ROUTE_MULTICAST_DAO :
 		NET_RPL_ROUTE_UNICAST_DAO;
 
@@ -3490,7 +3490,7 @@ static enum net_verdict handle_dao(struct net_pkt *pkt)
 		log_strdup(net_sprint_ipv6_addr(&addr)), target_len);
 
 #if NET_RPL_MULTICAST
-	if (net_is_ipv6_addr_mcast_global(&addr)) {
+	if (net_ipv6_is_addr_mcast_global(&addr)) {
 		struct net_route_entry_mcast *mcast_group;
 
 		mcast_group = net_route_mcast_add(net_pkt_iface(pkt), &addr);
@@ -4246,7 +4246,7 @@ int net_rpl_insert_header(struct net_pkt *pkt)
 {
 #if defined(CONFIG_NET_RPL_INSERT_HBH_OPTION)
 	if (rpl_default_instance &&
-	    !net_is_ipv6_addr_mcast(&NET_IPV6_HDR(pkt)->dst)) {
+	    !net_ipv6_is_addr_mcast(&NET_IPV6_HDR(pkt)->dst)) {
 		return net_rpl_update_header_empty(pkt);
 	}
 #endif

--- a/subsys/net/l2/ethernet/arp.c
+++ b/subsys/net/l2/ethernet/arp.c
@@ -383,7 +383,7 @@ struct net_pkt *net_arp_prepare(struct net_pkt *pkt,
 
 		if (ipv4) {
 			addr = &ipv4->gw;
-			if (net_is_ipv4_addr_unspecified(addr)) {
+			if (net_ipv4_is_addr_unspecified(addr)) {
 				NET_ERR("Gateway not set for iface %p",
 					net_pkt_iface(pkt));
 
@@ -640,7 +640,7 @@ enum net_verdict net_arp_input(struct net_pkt *pkt)
 		break;
 
 	case NET_ARP_REPLY:
-		if (net_is_my_ipv4_addr(&arp_hdr->dst_ipaddr)) {
+		if (net_ipv4_is_my_addr(&arp_hdr->dst_ipaddr)) {
 			arp_update(net_pkt_iface(pkt),
 				   &arp_hdr->src_ipaddr,
 				   &arp_hdr->src_hwaddr,

--- a/subsys/net/l2/ethernet/ethernet.c
+++ b/subsys/net/l2/ethernet/ethernet.c
@@ -242,7 +242,7 @@ static inline bool check_if_dst_is_broadcast_or_mcast(struct net_if *iface,
 {
 	struct net_eth_hdr *hdr = NET_ETH_HDR(pkt);
 
-	if (net_is_ipv4_addr_bcast(iface, &NET_IPV4_HDR(pkt)->dst)) {
+	if (net_ipv4_is_addr_bcast(iface, &NET_IPV4_HDR(pkt)->dst)) {
 		/* Broadcast address */
 		net_pkt_lladdr_dst(pkt)->addr = (u8_t *)broadcast_eth_addr.addr;
 		net_pkt_lladdr_dst(pkt)->len = sizeof(struct net_eth_addr);
@@ -503,7 +503,7 @@ static enum net_verdict ethernet_send(struct net_if *iface,
 	if (!net_pkt_lladdr_dst(pkt)->addr) {
 #if defined(CONFIG_NET_IPV6)
 		if (net_pkt_family(pkt) == AF_INET6 &&
-		    net_is_ipv6_addr_mcast(&NET_IPV6_HDR(pkt)->dst)) {
+		    net_ipv6_is_addr_mcast(&NET_IPV6_HDR(pkt)->dst)) {
 			struct net_eth_addr *dst = &NET_ETH_HDR(pkt)->dst;
 
 			memcpy(dst, (u8_t *)multicast_eth_addr.addr,

--- a/subsys/net/l2/ieee802154/ieee802154_frame.c
+++ b/subsys/net/l2/ieee802154/ieee802154_frame.c
@@ -421,8 +421,8 @@ u16_t ieee802154_compute_header_size(struct net_if *iface,
 
 	/** if dst is NULL, we'll consider it as a brodcast header */
 	if (!dst ||
-	    net_is_ipv6_addr_mcast(dst) ||
-	    net_is_ipv6_addr_unspecified(dst)) {
+	    net_ipv6_is_addr_mcast(dst) ||
+	    net_ipv6_is_addr_unspecified(dst)) {
 		NET_DBG("Broadcast destination");
 		/* 4 dst pan/addr + 8 src addr */
 		hdr_len += IEEE802154_PAN_ID_LENGTH +

--- a/subsys/net/lib/app/client.c
+++ b/subsys/net/lib/app/client.c
@@ -386,7 +386,7 @@ int net_app_init_client(struct net_app_ctx *ctx,
 		/* local_port is used if the IP address isn't specified */
 #if defined(CONFIG_NET_IPV4)
 		if (client_addr->sa_family == AF_INET) {
-			empty_addr = net_is_ipv4_addr_unspecified(
+			empty_addr = net_ipv4_is_addr_unspecified(
 					&net_sin(client_addr)->sin_addr);
 			local_port = net_sin(client_addr)->sin_port;
 		}
@@ -394,7 +394,7 @@ int net_app_init_client(struct net_app_ctx *ctx,
 
 #if defined(CONFIG_NET_IPV6)
 		if (client_addr->sa_family == AF_INET6) {
-			empty_addr = net_is_ipv6_addr_unspecified(
+			empty_addr = net_ipv6_is_addr_unspecified(
 					&net_sin6(client_addr)->sin6_addr);
 			local_port = net_sin6(client_addr)->sin6_port;
 		}
@@ -638,7 +638,7 @@ static void check_local_address(struct net_app_ctx *ctx,
 		struct in6_addr *raddr;
 
 		laddr = &net_sin6(&ctx->ipv6.local)->sin6_addr;
-		if (!net_is_ipv6_addr_unspecified(laddr)) {
+		if (!net_ipv6_is_addr_unspecified(laddr)) {
 			return;
 		}
 
@@ -660,7 +660,7 @@ static void check_local_address(struct net_app_ctx *ctx,
 		struct net_if *iface;
 
 		laddr = &net_sin(&ctx->ipv4.local)->sin_addr;
-		if (!net_is_ipv4_addr_unspecified(laddr)) {
+		if (!net_ipv4_is_addr_unspecified(laddr)) {
 			return;
 		}
 

--- a/subsys/net/lib/coap/coap.c
+++ b/subsys/net/lib/coap/coap.c
@@ -485,7 +485,7 @@ static inline bool is_addr_unspecified(const struct sockaddr *addr)
 	}
 
 	if (addr->sa_family == AF_INET6) {
-		return net_is_ipv6_addr_unspecified(
+		return net_ipv6_is_addr_unspecified(
 			&(net_sin6(addr)->sin6_addr));
 	} else if (addr->sa_family == AF_INET) {
 		return net_sin(addr)->sin_addr.s4_addr32[0] == 0;

--- a/subsys/net/lib/coap_sock/coap_sock.c
+++ b/subsys/net/lib/coap_sock/coap_sock.c
@@ -1106,7 +1106,7 @@ static inline bool is_addr_unspecified(const struct sockaddr *addr)
 	}
 
 	if (addr->sa_family == AF_INET6) {
-		return net_is_ipv6_addr_unspecified(
+		return net_ipv6_is_addr_unspecified(
 			&(net_sin6(addr)->sin6_addr));
 	} else if (addr->sa_family == AF_INET) {
 		return net_sin(addr)->sin_addr.s4_addr32[0] == 0;

--- a/subsys/net/lib/dns/llmnr_responder.c
+++ b/subsys/net/lib/dns/llmnr_responder.c
@@ -271,7 +271,7 @@ static const u8_t *get_ipv4_src(struct net_if *iface, struct in_addr *dst)
 	const struct in_addr *addr;
 
 	addr = net_if_ipv4_select_src_addr(iface, dst);
-	if (!addr || net_is_ipv4_addr_unspecified(addr)) {
+	if (!addr || net_ipv4_is_addr_unspecified(addr)) {
 		return NULL;
 	}
 
@@ -285,7 +285,7 @@ static const u8_t *get_ipv6_src(struct net_if *iface, struct in6_addr *dst)
 	const struct in6_addr *addr;
 
 	addr = net_if_ipv6_select_src_addr(iface, dst);
-	if (!addr || net_is_ipv6_addr_unspecified(addr)) {
+	if (!addr || net_ipv6_is_addr_unspecified(addr)) {
 		return NULL;
 	}
 

--- a/subsys/net/lib/dns/resolve.c
+++ b/subsys/net/lib/dns/resolve.c
@@ -82,7 +82,7 @@ static struct dns_resolve_context dns_default_ctx;
 static bool server_is_mdns(sa_family_t family, struct sockaddr *addr)
 {
 	if (family == AF_INET) {
-		if (net_is_ipv4_addr_mcast(&net_sin(addr)->sin_addr) &&
+		if (net_ipv4_is_addr_mcast(&net_sin(addr)->sin_addr) &&
 		    net_sin(addr)->sin_addr.s4_addr[3] == 251) {
 			return true;
 		}
@@ -91,7 +91,7 @@ static bool server_is_mdns(sa_family_t family, struct sockaddr *addr)
 	}
 
 	if (family == AF_INET6) {
-		if (net_is_ipv6_addr_mcast(&net_sin6(addr)->sin6_addr) &&
+		if (net_ipv6_is_addr_mcast(&net_sin6(addr)->sin6_addr) &&
 		    net_sin6(addr)->sin6_addr.s6_addr[15] == 0xfb) {
 			return true;
 		}
@@ -105,7 +105,7 @@ static bool server_is_mdns(sa_family_t family, struct sockaddr *addr)
 static bool server_is_llmnr(sa_family_t family, struct sockaddr *addr)
 {
 	if (family == AF_INET) {
-		if (net_is_ipv4_addr_mcast(&net_sin(addr)->sin_addr) &&
+		if (net_ipv4_is_addr_mcast(&net_sin(addr)->sin_addr) &&
 		    net_sin(addr)->sin_addr.s4_addr[3] == 252) {
 			return true;
 		}
@@ -114,7 +114,7 @@ static bool server_is_llmnr(sa_family_t family, struct sockaddr *addr)
 	}
 
 	if (family == AF_INET6) {
-		if (net_is_ipv6_addr_mcast(&net_sin6(addr)->sin6_addr) &&
+		if (net_ipv6_is_addr_mcast(&net_sin6(addr)->sin6_addr) &&
 		    net_sin6(addr)->sin6_addr.s6_addr[15] == 0x03) {
 			return true;
 		}

--- a/tests/net/ip-addr/src/main.c
+++ b/tests/net/ip-addr/src/main.c
@@ -224,11 +224,11 @@ static void test_ipv6_addresses(void)
 	int i;
 
 	/**TESTPOINT: Check if the IPv6 address is a loopback address*/
-	zassert_true(net_is_ipv6_addr_loopback(&loopback),
+	zassert_true(net_ipv6_is_addr_loopback(&loopback),
 		     "IPv6 loopback address check failed.");
 
 	/**TESTPOINT: Check if the IPv6 address is a multicast address*/
-	zassert_true(net_is_ipv6_addr_mcast(&mcast),
+	zassert_true(net_ipv6_is_addr_mcast(&mcast),
 		     "IPv6 multicast address check failed.");
 
 	ifaddr1 = net_if_ipv6_addr_add(net_if_get_default(),
@@ -245,27 +245,27 @@ static void test_ipv6_addresses(void)
 			  "IPv6 interface address mismatch");
 
 	/**TESTPOINT: Check if the IPv6 address is a loopback address*/
-	zassert_false(net_is_my_ipv6_addr(&loopback),
+	zassert_false(net_ipv6_is_my_addr(&loopback),
 		      "My IPv6 loopback address check failed");
 
 	/**TESTPOINT: Check IPv6 address*/
-	zassert_true(net_is_my_ipv6_addr(&addr6),
+	zassert_true(net_ipv6_is_my_addr(&addr6),
 		     "My IPv6 address check failed");
 
 	/**TESTPOINTS: Check IPv6 prefix*/
-	zassert_true(net_is_ipv6_prefix((u8_t *)&addr6_pref1,
+	zassert_true(net_ipv6_is_prefix((u8_t *)&addr6_pref1,
 					(u8_t *)&addr6_pref2, 64),
 		     "Same IPv6 prefix test failed");
 
-	zassert_false(net_is_ipv6_prefix((u8_t *)&addr6_pref1,
+	zassert_false(net_ipv6_is_prefix((u8_t *)&addr6_pref1,
 					 (u8_t *)&addr6_pref3, 64),
 		      "Different IPv6 prefix test failed");
 
-	zassert_false(net_is_ipv6_prefix((u8_t *)&addr6_pref1,
+	zassert_false(net_ipv6_is_prefix((u8_t *)&addr6_pref1,
 					 (u8_t *)&addr6_pref2, 128),
 		      "Different full IPv6 prefix test failed");
 
-	zassert_false(net_is_ipv6_prefix((u8_t *)&addr6_pref1,
+	zassert_false(net_ipv6_is_prefix((u8_t *)&addr6_pref1,
 					 (u8_t *)&addr6_pref3, 255),
 		      "Too long prefix test failed");
 
@@ -388,7 +388,7 @@ static void test_ipv4_addresses(void)
 				       0);
 	zassert_not_null(ifaddr1, "IPv4 interface address add failed");
 
-	zassert_true(net_is_my_ipv4_addr(&addr4),
+	zassert_true(net_ipv4_is_my_addr(&addr4),
 		     "My IPv4 address check failed");
 
 	ifaddr1 = net_if_ipv4_addr_add(net_if_get_default(),
@@ -397,10 +397,10 @@ static void test_ipv4_addresses(void)
 				       0);
 	zassert_not_null(ifaddr1, "IPv4 interface address add failed");
 
-	zassert_true(net_is_my_ipv4_addr(&lladdr4),
+	zassert_true(net_ipv4_is_my_addr(&lladdr4),
 		     "My IPv4 address check failed");
 
-	zassert_false(net_is_my_ipv4_addr(&loopback4),
+	zassert_false(net_ipv4_is_my_addr(&loopback4),
 		      "My IPv4 loopback address check failed");
 
 	/* Two tests for IPv4, first with interface given, then when
@@ -466,13 +466,13 @@ static void test_ipv4_addresses(void)
 	zassert_true(net_ipv4_addr_mask_cmp(iface, &match_addr),
 		     "IPv4 match failed");
 
-	zassert_true(net_is_ipv4_addr_mcast(&maddr4a),
+	zassert_true(net_ipv4_is_addr_mcast(&maddr4a),
 		     "IPv4 multicast address");
 
-	zassert_true(net_is_ipv4_addr_mcast(&maddr4b),
+	zassert_true(net_ipv4_is_addr_mcast(&maddr4b),
 		     "IPv4 multicast address");
 
-	zassert_false(net_is_ipv4_addr_mcast(&addr4), "IPv4 address");
+	zassert_false(net_ipv4_is_addr_mcast(&addr4), "IPv4 address");
 
 	ifmaddr1 = net_if_ipv4_maddr_add(net_if_get_default(), &maddr4a);
 	zassert_not_null(ifmaddr1, "IPv4 multicast address add failed");
@@ -511,27 +511,27 @@ static void test_ipv4_addresses(void)
 	ifmaddr1 = net_if_ipv4_maddr_lookup(&maddr4b, &iface1);
 	zassert_is_null(ifmaddr1, "IPv4 multicast address lookup succeed");
 
-	ret = net_is_ipv4_addr_bcast(iface, &bcast_addr1);
+	ret = net_ipv4_is_addr_bcast(iface, &bcast_addr1);
 	zassert_true(ret, "IPv4 address 1 is not broadcast address");
 
-	ret = net_is_ipv4_addr_bcast(iface, &bcast_addr2);
+	ret = net_ipv4_is_addr_bcast(iface, &bcast_addr2);
 	zassert_false(ret, "IPv4 address 2 is broadcast address");
 
-	ret = net_is_ipv4_addr_bcast(iface, &bcast_addr4);
+	ret = net_ipv4_is_addr_bcast(iface, &bcast_addr4);
 	zassert_false(ret, "IPv4 address 4 is broadcast address");
 
-	ret = net_is_ipv4_addr_bcast(iface, &maddr4b);
+	ret = net_ipv4_is_addr_bcast(iface, &maddr4b);
 	zassert_false(ret, "IPv4 address is broadcast address");
 
-	ret = net_is_ipv4_addr_bcast(iface, &bcast_addr5);
+	ret = net_ipv4_is_addr_bcast(iface, &bcast_addr5);
 	zassert_true(ret, "IPv4 address 5 is not broadcast address");
 
 	net_if_ipv4_set_netmask(iface, &netmask2);
 
-	ret = net_is_ipv4_addr_bcast(iface, &bcast_addr2);
+	ret = net_ipv4_is_addr_bcast(iface, &bcast_addr2);
 	zassert_false(ret, "IPv4 address 2 is broadcast address");
 
-	ret = net_is_ipv4_addr_bcast(iface, &bcast_addr3);
+	ret = net_ipv4_is_addr_bcast(iface, &bcast_addr3);
 	zassert_true(ret, "IPv4 address 3 is not broadcast address");
 }
 

--- a/tests/net/ipv6/src/main.c
+++ b/tests/net/ipv6/src/main.c
@@ -347,36 +347,36 @@ static void test_cmp_prefix(void)
 	struct in6_addr prefix2 = { { { 0x20, 0x01, 0x0d, 0xb8, 0, 0, 0, 0,
 					0, 0, 0, 0, 0, 0, 0, 0x2 } } };
 
-	st = net_is_ipv6_prefix((u8_t *)&prefix1, (u8_t *)&prefix2, 64);
+	st = net_ipv6_is_prefix((u8_t *)&prefix1, (u8_t *)&prefix2, 64);
 	zassert_true(st, "Prefix /64  compare failed");
 
-	st = net_is_ipv6_prefix((u8_t *)&prefix1, (u8_t *)&prefix2, 65);
+	st = net_ipv6_is_prefix((u8_t *)&prefix1, (u8_t *)&prefix2, 65);
 	zassert_true(st, "Prefix /65 compare failed");
 
 	/* Set one extra bit in the other prefix for testing /65 */
 	prefix1.s6_addr[8] = 0x80;
 
-	st = net_is_ipv6_prefix((u8_t *)&prefix1, (u8_t *)&prefix2, 65);
+	st = net_ipv6_is_prefix((u8_t *)&prefix1, (u8_t *)&prefix2, 65);
 	zassert_false(st, "Prefix /65 compare should have failed");
 
 	/* Set two bits in prefix2, it is now /66 */
 	prefix2.s6_addr[8] = 0xc0;
 
-	st = net_is_ipv6_prefix((u8_t *)&prefix1, (u8_t *)&prefix2, 65);
+	st = net_ipv6_is_prefix((u8_t *)&prefix1, (u8_t *)&prefix2, 65);
 	zassert_true(st, "Prefix /65 compare failed");
 
 	/* Set all remaining bits in prefix2, it is now /128 */
 	(void)memset(&prefix2.s6_addr[8], 0xff, 8);
 
-	st = net_is_ipv6_prefix((u8_t *)&prefix1, (u8_t *)&prefix2, 65);
+	st = net_ipv6_is_prefix((u8_t *)&prefix1, (u8_t *)&prefix2, 65);
 	zassert_true(st, "Prefix /65 compare failed");
 
 	/* Comparing /64 should be still ok */
-	st = net_is_ipv6_prefix((u8_t *)&prefix1, (u8_t *)&prefix2, 64);
+	st = net_ipv6_is_prefix((u8_t *)&prefix1, (u8_t *)&prefix2, 64);
 	zassert_true(st, "Prefix /64 compare failed");
 
 	/* But comparing /66 should should fail */
-	st = net_is_ipv6_prefix((u8_t *)&prefix1, (u8_t *)&prefix2, 66);
+	st = net_ipv6_is_prefix((u8_t *)&prefix1, (u8_t *)&prefix2, 66);
 	zassert_false(st, "Prefix /66 compare should have failed");
 
 }


### PR DESCRIPTION
Unify the function naming for various network checking functions.

For example:
     net_is_ipv6_addr_loopback() -> net_ipv6_is_addr_loopback()
     net_is_my_ipv6_maddr() -> net_ipv6_is_my_maddr()
etc.

Signed-off-by: Jukka Rissanen <jukka.rissanen@linux.intel.com>