### PR TITLE
doc: fix misspellings in doxygen comments

### DIFF
--- a/include/display/cfb.h
+++ b/include/display/cfb.h
@@ -60,7 +60,7 @@ struct cfb_font {
  *
  * @param _name   Name of the font entry.
  * @param _width  Width of the font in pixels
- * @param _height Heigth of the font in pixels.
+ * @param _height Height of the font in pixels.
  * @param _caps   Font capabilities.
  * @param _data   Raw data of the font.
  * @param _fc     Character mapped to first font element.

--- a/include/drivers/system_timer.h
+++ b/include/drivers/system_timer.h
@@ -61,7 +61,7 @@ extern int z_clock_device_ctrl(struct device *device,
  * Note that ticks can also be passed the special value K_FOREVER,
  * indicating that no future timer interrupts are expected or required
  * and that the system is permitted to enter an indefinite sleep even
- * if this could cause rolloever of the internal counter (i.e. the
+ * if this could cause rollover of the internal counter (i.e. the
  * system uptime counter is allowed to be wrong, see
  * k_enable_sys_clock_always_on().
  *
@@ -92,7 +92,7 @@ extern void z_clock_set_timeout(s32_t ticks, bool idle);
  * @brief Timer idle exit notification
  *
  * This notifies the timer driver that the system is exiting the idle
- * and allows it to do whatever bookeeping is needed to restore timer
+ * and allows it to do whatever bookkeeping is needed to restore timer
  * operation and compute elapsed ticks.
  *
  * @note Legacy timer drivers also use this opportunity to call back

--- a/include/net/net_ip.h
+++ b/include/net/net_ip.h
@@ -703,12 +703,12 @@ static inline bool net_is_ipv6_addr_mcast_site(const struct in6_addr *addr)
 }
 
 /**
- * @brief Check if the IPv6 address is an organisation scope multicast
+ * @brief Check if the IPv6 address is an organization scope multicast
  * address (FFx8::).
  *
  * @param addr IPv6 address.
  *
- * @return True if the address is an organisation scope multicast address,
+ * @return True if the address is an organization scope multicast address,
  * false otherwise.
  */
 static inline bool net_is_ipv6_addr_mcast_org(const struct in6_addr *addr)


### PR DESCRIPTION
Scan and fix misspellings in header files in /include missed during
regular reviews.

Signed-off-by: David B. Kinder <david.b.kinder@intel.com>