### PR TITLE
scripts: dts: extract: Fix handling of prop being a list of lists

### DIFF
--- a/scripts/dts/extract_dts_includes.py
+++ b/scripts/dts/extract_dts_includes.py
@@ -393,6 +393,12 @@ def extract_property(node_compat, yaml, node_address, prop, prop_val, names):
         except:
             prop_values = reduced[node_address]['props'].get(prop)
 
+        # Newer versions of dtc might have the property look like
+        # cs-gpios = <0x05 0x0d 0x00>, < 0x06 0x00 0x00>;
+        # So we need to flatten the list in that case
+        if isinstance(prop_values[0], list):
+            prop_values = [item for sublist in prop_values for item in sublist]
+
         extract_controller(node_address, yaml, prop, prop_values, 0,
                            def_label, 'gpio')
         extract_cells(node_address, yaml, prop, prop_values,


### PR DESCRIPTION
Before dtc 1.4.7 we'd get something like the following for an gpios
property:

reg = <1 2 3 4>;

After dtc 1.4.7 we get:

cs-gpios = <0x05 0x0d 0x00>, < 0x06 0x00 0x00>;

We should handle both cases in the extract reg handling code.  So if
we see a list of lists, we flatten it to a single list to normalize
the property.

Signed-off-by: Kumar Gala <kumar.gala@linaro.org>