### PR TITLE
linker: Fixup warning associated with .ARC.attributes section

### DIFF
--- a/include/arch/arc/v2/linker.ld
+++ b/include/arch/arc/v2/linker.ld
@@ -289,4 +289,11 @@ SECTIONS {
 
 #include <linker/debug-sections.ld>
 
+
+    SECTION_PROLOGUE(.ARC.attributes, 0,)
+	{
+	KEEP(*(.ARC.attributes))
+	KEEP(*(.gnu.attributes))
+	}
+
 	}


### PR DESCRIPTION
With newer linker for ARC we can possibly get a warning like:

   real-ld: warning: orphan section `.ARC.attributes' from `(foo.o)'
   being placed in section `.ARC.attributes'.

Fixes #11060

Signed-off-by: Kumar Gala <kumar.gala@linaro.org>