### PR TITLE
boards: mimxrt1050_evk: Enable pyocd runner

### DIFF
--- a/boards/arm/mimxrt1050_evk/board.cmake
+++ b/boards/arm/mimxrt1050_evk/board.cmake
@@ -4,5 +4,18 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 
+set_ifndef(OPENSDA_FW jlink)
+
+if(OPENSDA_FW STREQUAL jlink)
+  set_ifndef(BOARD_DEBUG_RUNNER jlink)
+  set_ifndef(BOARD_FLASH_RUNNER jlink)
+elseif(OPENSDA_FW STREQUAL daplink)
+  set_ifndef(BOARD_DEBUG_RUNNER pyocd)
+  set_ifndef(BOARD_FLASH_RUNNER pyocd)
+endif()
+
+board_runner_args(pyocd "--target=mimxrt1050_hyperflash")
 board_runner_args(jlink "--device=MCIMXRT1052")
+
+include(${ZEPHYR_BASE}/boards/common/pyocd.board.cmake)
 include(${ZEPHYR_BASE}/boards/common/jlink.board.cmake)


### PR DESCRIPTION
Adds support for debugging and flashing the mimxrt1050_evk board via
pyocd. Support for this board has not yet been merged in upstream pyocd,
therefore the default in zephyr is left as jlink.

Signed-off-by: Maureen Helm <maureen.helm@nxp.com>