### PR TITLE
dts/bindings: Remove id field from atmel,sam-watchdog

### DIFF
--- a/dts/bindings/watchdog/atmel,sam-watchdog.yaml
+++ b/dts/bindings/watchdog/atmel,sam-watchdog.yaml
@@ -5,7 +5,6 @@
 #
 ---
 title: Atmel SAM watchdog driver
-id: atmel,sam-watchdog
 version: 0.1
 
 description: >


### PR DESCRIPTION
atmel,sam-watchdog..yaml had the old id field that we have removed.
Remove it so we stop getting a warning about it.

Signed-off-by: Kumar Gala <kumar.gala@linaro.org>