### PR TITLE
samples: net: zperf: Remove task_profiler as it is not used

### DIFF
--- a/samples/net/zperf/CMakeLists.txt
+++ b/samples/net/zperf/CMakeLists.txt
@@ -26,5 +26,4 @@ target_sources(app PRIVATE
 
 target_include_directories(app PRIVATE
   $ENV{ZEPHYR_BASE}/subsys/net/ip
-  $ENV{ZEPHYR_BASE}/samples/task_profiler/profiler/src
   )


### PR DESCRIPTION
The task_profiler is not needed nor used by zperf so remove
it from CMakefile.

Fixes #11051

Signed-off-by: Jukka Rissanen <jukka.rissanen@linux.intel.com>