### PR TITLE
Bluetooth: Add basic documentation for address types

### DIFF
--- a/include/bluetooth/hci.h
+++ b/include/bluetooth/hci.h
@@ -30,10 +30,12 @@ extern "C" {
 #define BT_HCI_OWN_ADDR_RPA_OR_PUBLIC  0x02
 #define BT_HCI_OWN_ADDR_RPA_OR_RANDOM  0x03
 
+/** Bluetooth Device Address */
 typedef struct {
 	u8_t  val[6];
 } bt_addr_t;
 
+/** Bluetooth LE Device Address */
 typedef struct {
 	u8_t      type;
 	bt_addr_t a;


### PR DESCRIPTION
The Bluetooth address types were not documented, causing warnings from
Doxygen.

Fixes #3524

Signed-off-by: Johan Hedberg <johan.hedberg@intel.com>