### PR TITLE
usb: usb_dc_nrfx: Remove dead code

### DIFF
--- a/drivers/usb/device/usb_dc_nrfx.c
+++ b/drivers/usb/device/usb_dc_nrfx.c
@@ -1085,10 +1085,9 @@ int usb_dc_detach(void)
 	if (ret) {
 		return ret;
 	}
+
 	nrf5_power_usb_power_int_enable(false);
-	if (ret) {
-		return ret;
-	}
+
 	ctx->attached = false;
 	return ret;
 }


### PR DESCRIPTION
Fix deadcode warning.

Signed-off-by: Andrei Emeltchenko <andrei.emeltchenko@intel.com>