### PR TITLE
power: Add API's to lock/unlock System PM states

### DIFF
--- a/subsys/power/CMakeLists.txt
+++ b/subsys/power/CMakeLists.txt
@@ -2,4 +2,5 @@ zephyr_sources(
   power.c
   device.c
   )
+zephyr_sources_ifdef(CONFIG_PM_CONTROL_STATE_LOCK pm_ctrl.c)
 add_subdirectory(policy)

--- a/subsys/power/Kconfig
+++ b/subsys/power/Kconfig
@@ -4,6 +4,14 @@ menu "OS Power Management"
 
 source "subsys/power/policy/Kconfig"
 
+config PM_CONTROL_STATE_LOCK
+	bool "Enable PM state locking capability"
+	help
+	  Enable OS Power Management state locking capability
+	  if any application wants to temporarily disable certain
+	  System Low Power states while doing any critical work
+	  or needs quick response from hardware resources.
+
 config PM_CONTROL_OS_DEBUG
 	bool "Enable OS Power Management debug hooks"
 	help

--- a/subsys/power/pm_ctrl.c
+++ b/subsys/power/pm_ctrl.c
@@ -1,0 +1,79 @@
+/*
+ * Copyright (c) 2018 Intel Corporation.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <zephyr.h>
+#include <string.h>
+#include <soc.h>
+#include <device.h>
+#include <atomic.h>
+#include "policy/pm_policy.h"
+
+#define LOG_LEVEL CONFIG_PM_LOG_LEVEL /* From power module Kconfig */
+#include <logging/log.h>
+LOG_MODULE_DECLARE(power);
+
+struct pm_ctrl_info {
+	int pm_state;
+	atomic_t count;
+};
+
+static struct pm_ctrl_info pm_ctrl[] = {
+	{SYS_PM_LOW_POWER_STATE, ATOMIC_INIT(0)},
+	{SYS_PM_DEEP_SLEEP, ATOMIC_INIT(0)},
+};
+
+void sys_pm_ctrl_disable_state(int state)
+{
+	if (state == SYS_PM_LOW_POWER_STATE) {
+		__ASSERT(pm_ctrl[0].count < UINT_MAX,
+				"Low Power state count overflowed\n");
+		atomic_inc(&pm_ctrl[0].count);
+	} else if (state == SYS_PM_DEEP_SLEEP) {
+		__ASSERT(pm_ctrl[1].count < UINT_MAX,
+				"Deep Sleep state count overflowed\n");
+		atomic_inc(&pm_ctrl[1].count);
+	} else {
+		LOG_WRN("\nInvalid PM state");
+	}
+}
+
+void sys_pm_ctrl_enable_state(int state)
+{
+	if (state == SYS_PM_LOW_POWER_STATE) {
+		__ASSERT(pm_ctrl[0].count > 0,
+				"Low Power state count underflowed\n");
+		atomic_dec(&pm_ctrl[0].count);
+	} else if (state == SYS_PM_DEEP_SLEEP) {
+		__ASSERT(pm_ctrl[1].count > 0,
+				"Deep Sleep state count underflowed\n");
+		atomic_dec(&pm_ctrl[1].count);
+	} else {
+		LOG_WRN("\nInvalid PM state");
+	}
+}
+
+bool sys_pm_ctrl_is_state_enabled(int state)
+{
+	bool enabled = true;
+
+	switch (state) {
+	case SYS_PM_LOW_POWER_STATE:
+		if (pm_ctrl[0].count) {
+			enabled = false;
+		}
+		break;
+	case SYS_PM_DEEP_SLEEP:
+		if (pm_ctrl[1].count) {
+			enabled = false;
+		}
+		break;
+	default:
+		LOG_WRN("\nInvalid PM state");
+		enabled = false;
+	}
+
+	return enabled;
+}

--- a/subsys/power/policy/pm_policy.h
+++ b/subsys/power/policy/pm_policy.h
@@ -62,6 +62,27 @@ extern void sys_pm_notify_lps_exit(enum power_states state);
  */
 extern void sys_pm_dump_debug_info(void);
 
+/**
+ * @brief Disable system PM state
+ *
+ * Disable system Low power states like LPS or Deep Sleep states.
+ */
+extern void sys_pm_ctrl_disable_state(int state);
+
+/**
+ * @brief Enable system PM state
+ *
+ * Enable system Low power states like LPS or Deep Sleep states.
+ */
+extern void sys_pm_ctrl_enable_state(int state);
+
+/**
+ * @brief Get enable status of a PM state
+ *
+ * Get enable status of a system PM state.
+ */
+extern bool sys_pm_ctrl_is_state_enabled(int state);
+
 #ifdef __cplusplus
 }
 #endif

--- a/subsys/power/power.c
+++ b/subsys/power/power.c
@@ -71,6 +71,15 @@ int _sys_soc_suspend(s32_t ticks)
 
 	sys_state = sys_pm_policy_next_state(ticks, &pm_state);
 
+#ifdef CONFIG_PM_CONTROL_STATE_LOCK
+	/* Check if PM state is locked */
+	if ((sys_state != SYS_PM_NOT_HANDLED) &&
+			!sys_pm_ctrl_is_state_enabled(sys_state)) {
+		LOG_DBG("PM state locked %d\n", sys_state);
+		return SYS_PM_NOT_HANDLED;
+	}
+#endif
+
 	switch (sys_state) {
 	case SYS_PM_LOW_POWER_STATE:
 		sys_pm_notify_lps_entry(pm_state);


### PR DESCRIPTION
Add API's to lock/unlock System PM states so that an
an application can block/unblock system from entering
certain Low Power states.

Signed-off-by: Ramakrishna Pallala <ramakrishna.pallala@intel.com>