### PR TITLE
cmake: Abort early if Python3 is not found

### DIFF
--- a/cmake/app/boilerplate.cmake
+++ b/cmake/app/boilerplate.cmake
@@ -96,7 +96,10 @@ set_property(DIRECTORY APPEND PROPERTY CMAKE_CONFIGURE_DEPENDS ${AUTOCONF_H})
 
 include(${ZEPHYR_BASE}/cmake/extensions.cmake)
 
-find_package(PythonInterp 3.4)
+find_package(
+  PythonInterp 3.4
+  REQUIRED
+  )
 
 include(${ZEPHYR_BASE}/cmake/ccache.cmake)
 


### PR DESCRIPTION
When Python3 is not found the build system will warn the user and then
continue. Python3 is required and continuing can only confuse the user
with new off-topic error messages.

This patch denotes Python3 as required to resolve this.

Signed-off-by: Sebastian Bøe <sebastian.boe@nordicsemi.no>