### PR TITLE
drivers: dma: stm32f4: Fix typo introduced when removing board.h

### DIFF
--- a/drivers/dma/dma_stm32f4x.c
+++ b/drivers/dma/dma_stm32f4x.c
@@ -11,6 +11,7 @@
 #include <errno.h>
 #include <init.h>
 #include <stdio.h>
+#include <soc.h>
 #include <string.h>
 #include <misc/util.h>
 


### PR DESCRIPTION
Following commit removed board.h but forgot to add soc.h:

  "drivers: Remove board.h include"

Signed-off-by: Armando Visconti <armando.visconti@st.com>