### PR TITLE
logging: Add compile time error on 64 bit platforms

### DIFF
--- a/include/logging/log_core.h
+++ b/include/logging/log_core.h
@@ -15,6 +15,10 @@
 extern "C" {
 #endif
 
+#if UINTPTR_MAX == 0xFFFFFFFFFFFFFFFFUL
+#error "Logger does not support 64 bit architecture."
+#endif
+
 #if !CONFIG_LOG
 #define CONFIG_LOG_DEFAULT_LEVEL 0
 #define CONFIG_LOG_DOMAIN_ID 0


### PR DESCRIPTION
Logger is designed with assumption that address fit in 32 bits.
Added explicit compilation error on 64 bit platforms.

Signed-off-by: Krzysztof Chruscinski <krzysztof.chruscinski@nordicsemi.no>