### PR TITLE
drivers: flash: w25q: Make spi_flash_wb_write/read support multiple pages

### DIFF
--- a/drivers/flash/Kconfig.w25qxxdv
+++ b/drivers/flash/Kconfig.w25qxxdv
@@ -82,4 +82,12 @@ config SPI_FLASH_W25QXXDV_DEVICE_ID
 	  This is the device ID of the flash chip to use, which is 0x00ef4015 for
           the W25QXXDV
 
+config SPI_FLASH_W25QXXDV_PAGE_PROGRAM_SIZE
+	int "Page Program Size in bytes"
+	default 256
+	help
+	  This is the maximum size of a page program operation. Writing data
+	  over this page boundary will split the write operation into two
+	  pages.
+
 endif # SPI_FLASH_W25QXXDV


### PR DESCRIPTION
Until now `spi_flash_wb_write/read` functions were only supporting buffers that fit into a W25Q page (even if they were not checking the offset was page aligned).

This change allows these functions to read/write across multiple W25Q page.
This change is required as the caller of these functions are not aware of flash page size.

Signed-off-by: Olivier Martin olivier.martin@proglove.de
Signed-off-by: Johannes Hutter johannes@proglove.de
Signed-off-by: Michael Wendland michael@proglove.de