### PR TITLE
Bluetooth: controller: Add min & max interval support in CPR

### DIFF
--- a/subsys/bluetooth/controller/hci/hci.c
+++ b/subsys/bluetooth/controller/hci/hci.c
@@ -1117,18 +1117,21 @@ static void le_conn_update(struct net_buf *buf, struct net_buf **evt)
 {
 	struct hci_cp_le_conn_update *cmd = (void *)buf->data;
 	u16_t supervision_timeout;
+	u16_t conn_interval_min;
 	u16_t conn_interval_max;
 	u16_t conn_latency;
 	u32_t status;
 	u16_t handle;
 
 	handle = sys_le16_to_cpu(cmd->handle);
+	conn_interval_min = sys_le16_to_cpu(cmd->conn_interval_min);
 	conn_interval_max = sys_le16_to_cpu(cmd->conn_interval_max);
 	conn_latency = sys_le16_to_cpu(cmd->conn_latency);
 	supervision_timeout = sys_le16_to_cpu(cmd->supervision_timeout);
 
-	status = ll_conn_update(handle, 0, 0, conn_interval_max,
-				conn_latency, supervision_timeout);
+	status = ll_conn_update(handle, 0, 0, conn_interval_min,
+				conn_interval_max, conn_latency,
+				supervision_timeout);
 
 	*evt = cmd_status(status);
 }
@@ -1138,6 +1141,7 @@ static void le_conn_param_req_reply(struct net_buf *buf, struct net_buf **evt)
 {
 	struct bt_hci_cp_le_conn_param_req_reply *cmd = (void *)buf->data;
 	struct bt_hci_rp_le_conn_param_req_reply *rp;
+	u16_t interval_min;
 	u16_t interval_max;
 	u16_t latency;
 	u16_t timeout;
@@ -1145,12 +1149,13 @@ static void le_conn_param_req_reply(struct net_buf *buf, struct net_buf **evt)
 	u16_t handle;
 
 	handle = sys_le16_to_cpu(cmd->handle);
+	interval_min = sys_le16_to_cpu(cmd->interval_min);
 	interval_max = sys_le16_to_cpu(cmd->interval_max);
 	latency = sys_le16_to_cpu(cmd->latency);
 	timeout = sys_le16_to_cpu(cmd->timeout);
 
-	status = ll_conn_update(handle, 2, 0, interval_max, latency,
-				timeout);
+	status = ll_conn_update(handle, 2, 0, interval_min, interval_max,
+				latency, timeout);
 
 	rp = cmd_complete(evt, sizeof(*rp));
 	rp->status = status;
@@ -1166,7 +1171,7 @@ static void le_conn_param_req_neg_reply(struct net_buf *buf,
 	u16_t handle;
 
 	handle = sys_le16_to_cpu(cmd->handle);
-	status = ll_conn_update(handle, 2, cmd->reason, 0, 0, 0);
+	status = ll_conn_update(handle, 2, cmd->reason, 0, 0, 0, 0);
 
 	rp = cmd_complete(evt, sizeof(*rp));
 	rp->status = status;
@@ -2818,7 +2823,7 @@ static void le_conn_param_req(struct pdu_data *pdu_data, u16_t handle,
 	if (!(event_mask & BT_EVT_MASK_LE_META_EVENT) ||
 	    !(le_event_mask & BT_EVT_MASK_LE_CONN_PARAM_REQ)) {
 		/* event masked, reject the conn param req */
-		ll_conn_update(handle, 2, BT_HCI_ERR_UNSUPP_REMOTE_FEATURE,
+		ll_conn_update(handle, 2, BT_HCI_ERR_UNSUPP_REMOTE_FEATURE, 0,
 			       0, 0, 0);
 
 		return;

--- a/subsys/bluetooth/controller/include/ll.h
+++ b/subsys/bluetooth/controller/include/ll.h
@@ -55,9 +55,8 @@ u32_t ll_create_connection(u16_t scan_interval, u16_t scan_window,
 			   u16_t interval, u16_t latency,
 			   u16_t timeout);
 u32_t ll_connect_disable(void **node_rx);
-u32_t ll_conn_update(u16_t handle, u8_t cmd, u8_t status,
-		     u16_t interval, u16_t latency,
-		     u16_t timeout);
+u32_t ll_conn_update(u16_t handle, u8_t cmd, u8_t status, u16_t interval_min,
+		     u16_t interval_max, u16_t latency, u16_t timeout);
 u32_t ll_chm_update(u8_t *chm);
 u32_t ll_chm_get(u16_t handle, u8_t *chm);
 u32_t ll_enc_req_send(u16_t handle, u8_t *rand, u8_t *ediv,

--- a/subsys/bluetooth/controller/ll_sw/ctrl.c
+++ b/subsys/bluetooth/controller/ll_sw/ctrl.c
@@ -10731,8 +10731,8 @@ u32_t ll_connect_disable(void **node_rx)
 	return status;
 }
 
-u32_t ll_conn_update(u16_t handle, u8_t cmd, u8_t status, u16_t interval,
-		     u16_t latency, u16_t timeout)
+u32_t ll_conn_update(u16_t handle, u8_t cmd, u8_t status, u16_t interval_min,
+		     u16_t interval_max, u16_t latency, u16_t timeout)
 {
 	struct connection *conn;
 
@@ -10765,7 +10765,7 @@ u32_t ll_conn_update(u16_t handle, u8_t cmd, u8_t status, u16_t interval,
 
 		conn->llcp.conn_upd.win_size = 1;
 		conn->llcp.conn_upd.win_offset_us = 0;
-		conn->llcp.conn_upd.interval = interval;
+		conn->llcp.conn_upd.interval = interval_max;
 		conn->llcp.conn_upd.latency = latency;
 		conn->llcp.conn_upd.timeout = timeout;
 		/* conn->llcp.conn_upd.instant     = 0; */
@@ -10796,8 +10796,8 @@ u32_t ll_conn_update(u16_t handle, u8_t cmd, u8_t status, u16_t interval,
 			}
 
 			conn->llcp_conn_param.status = 0;
-			conn->llcp_conn_param.interval_min = interval;
-			conn->llcp_conn_param.interval_max = interval;
+			conn->llcp_conn_param.interval_min = interval_min;
+			conn->llcp_conn_param.interval_max = interval_max;
 			conn->llcp_conn_param.latency = latency;
 			conn->llcp_conn_param.timeout = timeout;
 			conn->llcp_conn_param.state = cmd;


### PR DESCRIPTION
Add support for exchanging both minimum and maximum
connection interval values in Connection Parameter Request
Procedure implementation.

Signed-off-by: Vinayak Kariappa Chettimada <vich@nordicsemi.no>