### PR TITLE
net: if: net_if_set_link_addr: Mention lifetime for address buffer

### DIFF
--- a/include/net/net_if.h
+++ b/include/net/net_if.h
@@ -600,7 +600,8 @@ void net_if_start_rs(struct net_if *iface);
  * @brief Set a network interface's link address
  *
  * @param iface Pointer to a network interface structure
- * @param addr a pointer to a u8_t buffer representing the address
+ * @param addr A pointer to a u8_t buffer representing the address. The buffer
+ *             must remain valid throughout interface lifetime.
  * @param len length of the address buffer
  * @param type network bearer type of this link address
  *


### PR DESCRIPTION
This function just stores the buffer pointer passed, so explicitly
mention that the buffer must remain valid while netif itself is
valid. For example, it can't be stored on stack.

Signed-off-by: Paul Sokolovsky <paul.sokolovsky@linaro.org>