### PR TITLE
coccinelle: irq_lock.cocci: Update script

### DIFF
--- a/scripts/coccinelle/irq_lock.cocci
+++ b/scripts/coccinelle/irq_lock.cocci
@@ -1,47 +1,45 @@
+/// Use unsigned int as the return value for irq_lock()
+///
+// Confidence: High
 // Copyright (c) 2017 Intel Corporation
 //
 // SPDX-License-Identifier: Apache-2.0
 
-@find@
+virtual patch
+
+@find depends on !(file in "ext")@
 type T;
-position p;
 identifier i;
+typedef uint32_t,u32_t;
 @@
 
-T@p i = irq_lock();
-
-@script:python raise_error@
-t << find.T;
-@@
-if t in ["uint32_t", "unsigned int", "u32_t"]:
-   cocci.include_match(False)
-
-@replacement@
-type find.T;
-position find.p;
-@@
-- T@p
+(
+ uint32_t i = irq_lock();
+|
+ unsigned int i = irq_lock();
+|
+ u32_t i = irq_lock();
+|
+- T
 + unsigned int
+  i = irq_lock();
+)
 
-@find2@
+@find2 depends on !(file in "ext") exists@
 type T;
-position p;
 identifier i;
 @@
 
-T@p i;
-...
-i = irq_lock();
-
-@script:python raise_error2@
-t << find2.T;
-@@
-if t in ["uint32_t", "unsigned int", "u32_t"]:
-   cocci.include_match(False)
-
-@replacement2@
-type find2.T;
-identifier find2.i;
-@@
--  T i;
-+  unsigned int i;
+(
+ uint32_t i;
+|
+ unsigned int i;
+|
+ u32_t i;
+|
+- T
++ unsigned int
+  i;
+  ...
+  i = irq_lock();
+)


### PR DESCRIPTION
* Provide a single liner description at top using `///`
  comments. This one liner is displayed when using `--verbose`
  mode of coccicheck.

* Specify Condidence level property adhering to coccinelle.rst
  section "Proposing new semantic patches".

* Add virtual patch rule to handle the patch case when coccicheck
  is supplied with `--mode=patch` option.

* Add `depends on !(file in "ext")` to ignore reports from `ext/`
  directory.

* Simplify rule to use disjunctions and use "exists" to match any
  available control path.

Suggested-by: Julia Lawall <julia.lawall@lip6.fr>
Signed-off-by: Himanshu Jha <himanshujha199640@gmail.com>

@ceolin @nashif @pfalcon @galak @carlescufi 

I have completely suppressed coccinelle rules to avoid throwing
reports using `depends on !(file in "ext")` for `ext/` as suggested
in some other thread of discussion.

None of my coccinelle PRs had any review or approval since the last
9-10 days. Please let me know what to do and some of them don't even
have a assigned reviewer.

Another question: How do I send the bulk changes based on say this
current `irq_lock` violation script touching various subsystems ?

Am I allowed to change CODEOWNERS file to add myself and Julia
as the maintainer of coccinelle infrastructure just to get notified of changes
and review them ?

Anyway, there are some more scripts that I have in my mind and soon
after pushing those I shall share a public doc in devel list where the community
can throw their ideas to frame new coccinelle scripts.