### PR TITLE
coccinelle: ignore_return.cocci: Update script

### DIFF
--- a/scripts/coccinelle/ignore_return.cocci
+++ b/scripts/coccinelle/ignore_return.cocci
@@ -1,11 +1,19 @@
+/// Cast void to memset to ignore its return value
+///
+//# The return of memset is never checked and therefore cast
+//# it to void to explicitly ignore while adhering to MISRA-C.
+//
+// Confidence: High
 // Copyright (c) 2017 Intel Corporation
 //
-// SPDX-License-Identifier: Apache-2.0//
+// SPDX-License-Identifier: Apache-2.0
 
-@@
+virtual patch
+
+@depends on patch && !(file in "ext")@
 expression e1,e2,e3;
 @@
 
-- memset(e1,e2,e3);
-+ (void)memset(e1,e2,e3);
++ (void)
+memset(e1,e2,e3);
 


### PR DESCRIPTION
* Provide a single liner description at top using `///`
  comments. This one liner is displayed when using `--verbose`
  mode of coccicheck.

* Specify Condidence level property adhering to coccinelle.rst
  section "Proposing new semantic patches".

* Add virtual patch rule to handle the patch case when coccicheck
  is supplied with `--mode=patch` option.

* Add `depends on !(file in "ext")` to ignore reports from `ext/`
  directory.

* Simplify patch rule to reduce effort in reconstruction since
  logically we are only *adding* void cast.

Signed-off-by: Himanshu Jha <himanshujha199640@gmail.com>