### PR TITLE
coccinelle: unsigned_shift.cocci: Update script

### DIFF
--- a/scripts/coccinelle/unsigned_shift.cocci
+++ b/scripts/coccinelle/unsigned_shift.cocci
@@ -1,10 +1,15 @@
+/// Use BIT() helper macro instead of hardcoding using bitshifting
+///
+// Confidence: High
 // Copyright (c) 2017 Intel Corporation
 //
 // SPDX-License-Identifier: Apache-2.0
 
-@@
-constant A;
+virtual patch
+
+@depends on patch && !(file in "ext")@
+expression A;
 @@
 
-- 1 << A
+- (1 << A)
 + BIT(A)


### PR DESCRIPTION
* Use `expression` metavariable instead of `constant` to catch
  missing cases such as:
```
diff -u -p a/subsys/net/ip/rpl.c b/subsys/net/ip/rpl.c
--- a/subsys/net/ip/rpl.c
+++ b/subsys/net/ip/rpl.c
@@ -686,7 +686,7 @@ static void new_dio_interval(struct net_
 {
 	u32_t time;

-	time = 1 << instance->dio_interval_current;
+	time = BIT(instance->dio_interval_current);
```
* Provide a single liner description at top using `///`
  comments. This one liner is displayed when using `--verbose`
  mode of coccicheck.

* Specify Condidence level property adhering to coccinelle.rst
  section "Proposing new semantic patches".

* Add virtual patch rule to handle the patch case when coccicheck
  is supplied with `--mode=patch` option.

* Edit patch rule to remove redundant parentheses in the output.

* Add `depends on !(file in "ext")` to ignore reports from `ext/`
  directory.

Signed-off-by: Himanshu Jha <himanshujha199640@gmail.com>