### PR TITLE
doc: filter expected dup decl warnings

### DIFF
--- a/.known-issues/doc/networking.conf
+++ b/.known-issues/doc/networking.conf
@@ -64,3 +64,7 @@
 ^(?P<filename>([\-:\\/\w\.])+[/\\]doc[/\\]api[/\\]networking.rst):(?P<lineno>[0-9]+): WARNING: Invalid definition: Expected end of definition. \[error at [0-9]+]
 ^.*net_stats_tc.[a-z]+
 ^[- \t]*\^
+#
+# stray duplicate definition warnings
+#
+^(?P<filename>([\-:\\/\w\.])+[/\\]doc[/\\]api[/\\]networking.rst):(?P<lineno>[0-9]+): WARNING: Duplicate declaration.


### PR DESCRIPTION
The API documentation for networking.rst can throw a doxygen warning
depending on the versions of sphinx/breathe being used.

Fixes: #11111

Signed-off-by: David B. Kinder <david.b.kinder@intel.com>