### PR TITLE
mgmt: Add function to unregister GATT service

### DIFF
--- a/include/mgmt/smp_bt.h
+++ b/include/mgmt/smp_bt.h
@@ -25,6 +25,13 @@ extern "C" {
  */
 int smp_bt_register(void);
 
+/**
+ * @brief Unregisters the SMP Bluetooth service.
+ *
+ * @return 0 on success; negative error code on failure.
+ */
+int smp_bt_unregister(void);
+
 #ifdef __cplusplus
 }
 #endif

--- a/subsys/mgmt/smp_bt.c
+++ b/subsys/mgmt/smp_bt.c
@@ -176,6 +176,11 @@ int smp_bt_register(void)
 	return bt_gatt_service_register(&smp_bt_svc);
 }
 
+int smp_bt_unregister(void)
+{
+	return bt_gatt_service_unregister(&smp_bt_svc);
+}
+
 static int smp_bt_init(struct device *dev)
 {
 	ARG_UNUSED(dev);


### PR DESCRIPTION
This adds a possibility to unregister SMP service. Using this function,
device can disable Firmware Update functionality, if not needed.

Signed-off-by: Mariusz Skamra <mariusz.skamra@codecoup.pl>