### PR TITLE
boards: arm: fix openocd.cfg for nucleo_l476rg

### DIFF
--- a/boards/arm/nucleo_l476rg/support/openocd.cfg
+++ b/boards/arm/nucleo_l476rg/support/openocd.cfg
@@ -1,4 +1,4 @@
-source [find board/st_nucleo_l476rg.cfg]
+source [find board/st_nucleo_l4.cfg]
 
 $_TARGETNAME configure -event gdb-attach {
 	echo "Debugger attaching: halting execution"


### PR DESCRIPTION
Other ST boards have their openocd.cfg support file updated,
but Nucleo L476RG was still looking for board/st_nucleo_l476rg.cfg
and fails with Zephyr SDK 0.9.5.

Signed-off-by: Kiril Zyapkov <k.zyapkov@allterco.com>