### PR TITLE
Bluetooth: host: Fallback to L2CAP for CPUP if rejected by master on LL

### DIFF
--- a/subsys/bluetooth/host/conn.c
+++ b/subsys/bluetooth/host/conn.c
@@ -202,9 +202,20 @@ static int send_conn_le_param_update(struct bt_conn *conn,
 	 * it; or if local role is master then use LE connection update.
 	 */
 	if ((BT_FEAT_LE_CONN_PARAM_REQ_PROC(bt_dev.le.features) &&
-	     BT_FEAT_LE_CONN_PARAM_REQ_PROC(conn->le.features)) ||
-	    (conn->role == BT_HCI_ROLE_MASTER)) {
-		return bt_conn_le_conn_update(conn, param);
+	     BT_FEAT_LE_CONN_PARAM_REQ_PROC(conn->le.features) &&
+	     !atomic_test_bit(conn->flags, BT_CONN_SLAVE_PARAM_L2CAP)) ||
+	     (conn->role == BT_HCI_ROLE_MASTER)) {
+		int rc;
+
+		rc = bt_conn_le_conn_update(conn, param);
+
+		/* store those in case of fallback to L2CAP */
+		if (rc == 0) {
+			conn->le.pending_latency = param->latency;
+			conn->le.pending_timeout = param->timeout;
+		}
+
+		return rc;
 	}
 
 	/* If remote master does not support LL Connection Parameters Request
@@ -237,8 +248,8 @@ static void conn_le_update_timeout(struct k_work *work)
 	if (atomic_test_and_clear_bit(conn->flags, BT_CONN_SLAVE_PARAM_SET)) {
 		param = BT_LE_CONN_PARAM(conn->le.interval_min,
 					 conn->le.interval_max,
-					 conn->le.latency,
-					 conn->le.timeout);
+					 conn->le.pending_latency,
+					 conn->le.pending_timeout);
 
 		send_conn_le_param_update(conn, param);
 	} else {
@@ -1814,13 +1825,11 @@ int bt_conn_le_param_update(struct bt_conn *conn,
 			return send_conn_le_param_update(conn, param);
 		}
 
-		/* store new conn params to be used by update timer
-		 * TODO this overwrites current latency and timeout
-		 */
+		/* store new conn params to be used by update timer */
 		conn->le.interval_min = param->interval_min;
 		conn->le.interval_max = param->interval_max;
-		conn->le.latency = param->latency;
-		conn->le.timeout = param->timeout;
+		conn->le.pending_latency = param->latency;
+		conn->le.pending_timeout = param->timeout;
 		atomic_set_bit(conn->flags, BT_CONN_SLAVE_PARAM_SET);
 	}
 

--- a/subsys/bluetooth/host/conn_internal.h
+++ b/subsys/bluetooth/host/conn_internal.h
@@ -29,6 +29,7 @@ enum {
 	BT_CONN_AUTO_DATA_LEN,          /* Auto data len change in progress */
 	BT_CONN_SLAVE_PARAM_UPDATE,	/* If slave param update timer fired */
 	BT_CONN_SLAVE_PARAM_SET,	/* If slave param were set from app */
+	BT_CONN_SLAVE_PARAM_L2CAP,	/* If should force L2CAP for CPUP */
 
 	/* Total number of flags - must be at the end of the enum */
 	BT_CONN_NUM_FLAGS,
@@ -46,6 +47,8 @@ struct bt_conn_le {
 
 	u16_t			latency;
 	u16_t			timeout;
+	u16_t			pending_latency;
+	u16_t			pending_timeout;
 
 	u8_t			features[8];
 


### PR DESCRIPTION
Fallback to L2CAP Connection Parameters Update Request if LL Connection
Update Request was rejected by remote device that has this marked as
supported in features. This can happen if procedure is supported only
by remote controller, but not enabled by host. This is connection
parameters update with iOS devices.

Signed-off-by: Szymon Janc <szymon.janc@codecoup.pl>