### PR TITLE
boards: qemu_x86: remove deprecated qemu options

### DIFF
--- a/boards/x86/qemu_x86/board.cmake
+++ b/boards/x86/qemu_x86/board.cmake
@@ -14,9 +14,7 @@ set(QEMU_FLAGS_${ARCH}
   -vga none
   -display none
   -net none
-  -clock dynticks
   -no-acpi
-  -balloon none
   -machine type=pc-0.14
   )
 


### PR DESCRIPTION
Options "-clock dynticks" and  "-balloon none" are deprecated and
produce warning in recent Qemu versions, so remove them.

Signed-off-by: Anas Nashif <anas.nashif@intel.com>