### PR TITLE
subsys: logging: Fix build when LOG_BACKEND_RTT_MODE_DROP=n

### DIFF
--- a/subsys/logging/log_backend_rtt.c
+++ b/subsys/logging/log_backend_rtt.c
@@ -10,9 +10,10 @@
 #include <logging/log_output.h>
 #include <rtt/SEGGER_RTT.h>
 
+#define DROP_MAX 99
+
 #if CONFIG_LOG_BACKEND_RTT_MODE_DROP
 
-#define DROP_MAX 99
 #define DROP_MSG "\nmessages dropped:    \r"
 #define DROP_MSG_LEN (sizeof(DROP_MSG) - 1)
 


### PR DESCRIPTION
When `LOG_BACKEND_RTT_MODE_DROP=n` DROP_MAX is not defined.
This commit ensures all related RTT_MODE_DROP functions and
variables are removed when the mode is not supported.

Signed-off-by: Olivier Martin <olivier.martin@proglove.de>