### PR TITLE
CODEOWNERS: Assign maintainer of Coccinelle Infrastructure

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -76,6 +76,7 @@ boards/xtensa/                           @andrewboie @ramakrishnapallala
 cmake/                                   @nashif @SebastianBoe
 /CMakeLists.txt                          @nashif @SebastianBoe
 doc/                                     @dbkinder
+doc/application/coccinelle.rst           @himanshujha199640 @JuliaLawall
 doc/CMakeLists.txt                       @carlescufi
 doc/scripts/                             @carlescufi
 doc/subsystems/bluetooth/                @sjanc @jhedberg @Vudentz
@@ -192,6 +193,7 @@ samples/net/coap_server/                 @rveerama1
 samples/net/sockets/                     @jukkar @tbursztyka @pfalcon
 samples/sensor/                          @bogdan-davidoaia
 samples/subsys/usb                       @jfischer-phytec-iot @finikorg
+scripts/coccicheck                       @himanshujha199640 @JuliaLawall
 scripts/expr_parser.py                   @andrewboie @nashif
 scripts/sanity_chk/                      @andrewboie @nashif
 scripts/sanitycheck                      @andrewboie @nashif


### PR DESCRIPTION
Add myself and Julia Lawall as the maintainer of Coccinelle
Infrastructure.

Signed-off-by: Julia Lawall <julia.lawall@lip6.fr>
Signed-off-by: Himanshu Jha <himanshujha199640@gmail.com>
Cc @JuliaLawall @nashif 