### PR TITLE
arch: arm: sam0: enable SEGGER RTT on Atmel sam0 SoCs

### DIFF
--- a/soc/arm/atmel_sam0/Kconfig
+++ b/soc/arm/atmel_sam0/Kconfig
@@ -5,6 +5,7 @@
 
 config SOC_FAMILY_SAM0
 	bool
+	select HAS_SEGGER_RTT
 
 if SOC_FAMILY_SAM0
 


### PR DESCRIPTION
Atmel sam0 series SoCs support SEGGER RTT and this patch enables it in Kconfig.