### PR TITLE
Fix for interrupt hooks

### DIFF
--- a/arch/arm/core/isr_wrapper.S
+++ b/arch/arm/core/isr_wrapper.S
@@ -119,6 +119,10 @@ _idle_state_cleared:
 #endif
 	blx r3		/* call ISR */
 
+#ifdef CONFIG_TRACING
+	bl z_sys_trace_isr_exit
+#endif
+
 #if defined(CONFIG_ARMV6_M_ARMV8_M_BASELINE)
 	pop {r3}
 	mov lr, r3

--- a/include/arch/arm/cortex_m/irq.h
+++ b/include/arch/arm/cortex_m/irq.h
@@ -117,16 +117,16 @@ extern void _arch_isr_direct_header(void);
 extern void _IntExit(void);
 
 #ifdef CONFIG_TRACING
-extern void z_sys_trace_isr_exit_to_scheduler(void);
+extern void z_sys_trace_isr_exit(void);
 #endif
 
 static inline void _arch_isr_direct_footer(int maybe_swap)
 {
-	if (maybe_swap) {
 
 #ifdef CONFIG_TRACING
-		z_sys_trace_isr_exit_to_scheduler();
+	z_sys_trace_isr_exit();
 #endif
+	if (maybe_swap) {
 		_IntExit();
 	}
 }

--- a/include/tracing.h
+++ b/include/tracing.h
@@ -21,6 +21,7 @@
 #if CONFIG_TRACING
 void z_sys_trace_idle(void);
 void z_sys_trace_isr_enter(void);
+void z_sys_trace_isr_exit(void);
 void z_sys_trace_isr_exit_to_scheduler(void);
 void z_sys_trace_thread_switched_in(void);
 void z_sys_trace_thread_switched_out(void);
@@ -114,10 +115,11 @@ void z_sys_trace_thread_switched_out(void);
 #define sys_trace_end_call(id)
 
 
-
 #define z_sys_trace_idle()
 
 #define z_sys_trace_isr_enter()
+
+#define z_sys_trace_isr_exit()
 
 #define z_sys_trace_isr_exit_to_scheduler()
 

--- a/subsys/debug/tracing/sysview.c
+++ b/subsys/debug/tracing/sysview.c
@@ -29,6 +29,11 @@ void z_sys_trace_isr_enter(void)
 	sys_trace_isr_enter();
 }
 
+void z_sys_trace_isr_exit(void)
+{
+	sys_trace_isr_exit();
+}
+
 void z_sys_trace_isr_exit_to_scheduler(void)
 {
 	sys_trace_isr_exit_to_scheduler();


### PR DESCRIPTION
Currently there is no ISR exit tracing in arm/core/isr_wrapper.S - change fixes the issue.