### PR TITLE
Bluetooth: shell/gatt: Fix unreachable code

### DIFF
--- a/subsys/bluetooth/shell/gatt.c
+++ b/subsys/bluetooth/shell/gatt.c
@@ -439,7 +439,8 @@ static int cmd_subscribe(const struct shell *shell, size_t argc, char *argv[])
 		return -ENOEXEC;
 	}
 
-	err = shell_cmd_precheck(shell, (argc >= 3), NULL, 0); {
+	err = shell_cmd_precheck(shell, (argc >= 3), NULL, 0);
+	if (err) {
 		return err;
 	}
 


### PR DESCRIPTION
The code had somehow gotten corrupt (yet in a way that it compiles) so
that an intended if-branch was missing.

Signed-off-by: Johan Hedberg <johan.hedberg@intel.com>