### PR TITLE
board: stm32_min_dev: Add I2C support

### DIFF
--- a/boards/arm/stm32_min_dev/Kconfig.defconfig
+++ b/boards/arm/stm32_min_dev/Kconfig.defconfig
@@ -17,4 +17,11 @@ config UART_STM32_PORT_1
 
 endif # UART_CONSOLE
 
+if I2C
+
+config I2C_1
+	default y
+
+endif # I2C
+
 endif # BOARD_STM32_MIN_DEV

--- a/boards/arm/stm32_min_dev/doc/stm32_min_dev.rst
+++ b/boards/arm/stm32_min_dev/doc/stm32_min_dev.rst
@@ -91,6 +91,8 @@ The stm32_min_dev board configuration supports the following hardware features:
 +-----------+------------+----------------------+
 | GPIO      | on-chip    | gpio                 |
 +-----------+------------+----------------------+
+| I2C       | on-chip    | i2c                  |
++-----------+------------+----------------------+
 
 Other hardware features are not supported by the Zephyr kernel.
 

--- a/boards/arm/stm32_min_dev/pinmux.c
+++ b/boards/arm/stm32_min_dev/pinmux.c
@@ -26,6 +26,10 @@ static const struct pin_config pinconf[] = {
 	{STM32_PIN_PB10, STM32F1_PINMUX_FUNC_PB10_USART3_TX},
 	{STM32_PIN_PB11, STM32F1_PINMUX_FUNC_PB11_USART3_RX},
 #endif	/* CONFIG_UART_STM32_PORT_3 */
+#ifdef CONFIG_I2C_1
+	{STM32_PIN_PB6, STM32F1_PINMUX_FUNC_PB6_I2C1_SCL},
+	{STM32_PIN_PB7, STM32F1_PINMUX_FUNC_PB7_I2C1_SDA},
+#endif /* CONFIG_I2C_1 */
 };
 
 static int pinmux_stm32_init(struct device *port)

--- a/boards/arm/stm32_min_dev/stm32_min_dev.dts
+++ b/boards/arm/stm32_min_dev/stm32_min_dev.dts
@@ -48,3 +48,8 @@
 	pinctrl-0 = <&usart3_pins_a>;
 	pinctrl-names = "default";
 };
+
+&i2c1 {
+	status = "ok";
+	clock-frequency = <I2C_BITRATE_FAST>;
+};

--- a/boards/arm/stm32_min_dev/stm32_min_dev.yaml
+++ b/boards/arm/stm32_min_dev/stm32_min_dev.yaml
@@ -6,3 +6,5 @@ toolchain:
   - zephyr
   - gnuarmemb
 ram: 20
+supported:
+  - i2c


### PR DESCRIPTION
This commit adds I2C support to stm32_min_dev, verified with BME280

Signed-off-by: Harry Jiang <explora26@gmail.com>