### PR TITLE
sensor: lis2mdl: Handle return value of i2c_burst_read

### DIFF
--- a/drivers/sensor/lis2mdl/lis2mdl_trigger.c
+++ b/drivers/sensor/lis2mdl/lis2mdl_trigger.c
@@ -39,9 +39,12 @@ int lis2mdl_trigger_set(struct device *dev,
 		lis2mdl->handler_drdy = handler;
 		if (handler) {
 			/* fetch raw data sample: re-trigger lost interrupt */
-			i2c_burst_read(lis2mdl->i2c, lis2mdl->i2c_addr,
-				       LIS2MDL_OUT_REG,
-				       raw, sizeof(raw));
+			if (i2c_burst_read(lis2mdl->i2c, lis2mdl->i2c_addr,
+					   LIS2MDL_OUT_REG, raw,
+					   sizeof(raw)) < 0) {
+				LOG_ERR("Failed to fetch raw data sample.");
+				return -EIO;
+			}
 			return lis2mdl_enable_int(dev, 1);
 		} else {
 			return lis2mdl_enable_int(dev, 0);


### PR DESCRIPTION
i2c_burst_read can fail during read/write procedure. Therefore,
add a sanity check for its return value.

Fixes #11101
Coverity-CID: 189505

Signed-off-by: Himanshu Jha <himanshujha199640@gmail.com>