### PR TITLE
tests: kernel: test force suspend of device

### DIFF
--- a/tests/kernel/device/src/main.c
+++ b/tests/kernel/device/src/main.c
@@ -115,7 +115,7 @@ static void build_suspend_device_list(void)
 void test_dummy_device_pm(void)
 {
 	struct device *dev;
-	int busy;
+	int busy, ret;
 
 	dev = device_get_binding(DUMMY_PORT_2);
 	zassert_false((dev == NULL), NULL);
@@ -124,7 +124,9 @@ void test_dummy_device_pm(void)
 	zassert_true((busy == 0), NULL);
 
 	/* Set device state to DEVICE_PM_ACTIVE_STATE */
-	device_set_power_state(dev, DEVICE_PM_ACTIVE_STATE);
+	ret = device_set_power_state(dev, DEVICE_PM_ACTIVE_STATE);
+	zassert_true((ret == 0), "Unable to set active state to device");
+
 	device_busy_set(dev);
 
 	busy = device_any_busy_check();
@@ -137,6 +139,10 @@ void test_dummy_device_pm(void)
 
 	busy = device_busy_check(dev);
 	zassert_true((busy == 0), NULL);
+
+	/* Set device state to DEVICE_PM_FORCE_SUSPEND_STATE */
+	ret = device_set_power_state(dev, DEVICE_PM_FORCE_SUSPEND_STATE);
+	zassert_true((ret == 0), "Unable to force suspend device");
 
 	build_suspend_device_list();
 }


### PR DESCRIPTION
Add test for the force suspend of device by setting the appropriate flag to `device_set_power_state` API.

Adds the check for #10445 

Signed-off-by: Niranjhana N <niranjhana.n@intel.com>