### PR TITLE
Remove semaphore from sntp_client application

### DIFF
--- a/samples/net/sntp_client/src/main.c
+++ b/samples/net/sntp_client/src/main.c
@@ -10,8 +10,6 @@
 
 #define SNTP_PORT 123
 
-struct k_sem sem;
-
 void resp_callback(struct sntp_ctx *ctx,
 		   int status,
 		   u64_t epoch_time,
@@ -20,16 +18,12 @@ void resp_callback(struct sntp_ctx *ctx,
 	printk("time: %lld\n", epoch_time);
 	printk("status: %d\n", status);
 	printk("user_data: %p\n", user_data);
-
-	k_sem_give(&sem);
 }
 
 void main(void)
 {
 	struct sntp_ctx ctx;
 	int rv;
-
-	k_sem_init(&sem, 0, 1);
 
 	/* ipv4 */
 	rv = sntp_init(&ctx,
@@ -38,16 +32,15 @@ void main(void)
 		       K_FOREVER);
 	if (rv < 0) {
 		printk("Failed to init sntp ctx: %d\n", rv);
-		return;
+		goto end;
 	}
 
 	rv = sntp_request(&ctx, K_FOREVER, resp_callback, NULL);
 	if (rv < 0) {
 		printk("Failed to send sntp request: %d\n", rv);
-		return;
+		goto end;
 	}
 
-	k_sem_take(&sem, K_FOREVER);
 	sntp_close(&ctx);
 
 	/* ipv6 */
@@ -57,15 +50,15 @@ void main(void)
 		       K_NO_WAIT);
 	if (rv < 0) {
 		printk("Failed to initi sntp ctx: %d\n", rv);
-		return;
+		goto end;
 	}
 
 	rv = sntp_request(&ctx, K_NO_WAIT, resp_callback, NULL);
 	if (rv < 0) {
 		printk("Failed to send sntp request: %d\n", rv);
-		return;
+		goto end;
 	}
 
-	k_sem_take(&sem, K_FOREVER);
+end:
 	sntp_close(&ctx);
 }


### PR DESCRIPTION
Issue found using Coccinelle. Semaphore is not required at all in this application.

Fixes #11150
