### PR TITLE
arch: arm: ensure shared mem and app sram MPU regions don't overlap

### DIFF
--- a/include/arch/arm/cortex_m/scripts/linker.ld
+++ b/include/arch/arm/cortex_m/scripts/linker.ld
@@ -299,8 +299,10 @@ SECTIONS
 		_image_ram_start = .;
 		_app_smem_start = .;
 		APP_SMEM_SECTION()
+		/* 32-byte align end of app shared area to make MPU friendly */
+		. = ALIGN(_app_data_align);
 		_app_smem_end = .;
-		. = ALIGN(4);
+
 	} GROUP_DATA_LINK_IN(RAMABLE_REGION, ROMABLE_REGION)
 #endif  /* CONFIG_MPU_REQUIRES_POWER_OF_TWO_ALIGNMENT */
 


### PR DESCRIPTION
This commit contributes a patch to the Arm Cortex-M linker
script, which guarantees that the linker sections for shared
memory and the application memory will have sufficient padding
in between, so that the latter will start from an address that
is 32-byte aligned. This is required for ensuring that the MPU
regions defined using the start and end addresses of the two
sections will not overlap.

Signed-off-by: Ioannis Glaropoulos <Ioannis.Glaropoulos@nordicsemi.no>