### PR TITLE
CODEOWNERS: Update list to add `scripts/coccinelle/` directory

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -194,6 +194,7 @@ samples/net/sockets/                     @jukkar @tbursztyka @pfalcon
 samples/sensor/                          @bogdan-davidoaia
 samples/subsys/usb                       @jfischer-phytec-iot @finikorg
 scripts/coccicheck                       @himanshujha199640 @JuliaLawall
+scripts/coccinelle/                      @himanshujha199640 @JuliaLawall
 scripts/expr_parser.py                   @andrewboie @nashif
 scripts/sanity_chk/                      @andrewboie @nashif
 scripts/sanitycheck                      @andrewboie @nashif


### PR DESCRIPTION
Add missing directory `scripts/coccinelle/` to the maintainer
list of Coccinelle Infrastructure, which was assigned
recently in commit d88421db37d6d22ee03021c4c55774c6d8a964ae

This directory is used to add new coccinelle scripts.

Signed-off-by: Julia Lawall <julia.lawall@lip6.fr>
Signed-off-by: Himanshu Jha <himanshujha199640@gmail.com>
Cc @JuliaLawall @nashif 