### PR TITLE
board: stm32_min_dev: Add PWM support

### DIFF
--- a/boards/arm/stm32_min_dev/Kconfig.defconfig
+++ b/boards/arm/stm32_min_dev/Kconfig.defconfig
@@ -24,4 +24,11 @@ config I2C_1
 
 endif # I2C
 
+if PWM
+
+config PWM_STM32_1
+	default y
+
+endif # PWM
+
 endif # BOARD_STM32_MIN_DEV

--- a/boards/arm/stm32_min_dev/doc/stm32_min_dev.rst
+++ b/boards/arm/stm32_min_dev/doc/stm32_min_dev.rst
@@ -93,6 +93,8 @@ The stm32_min_dev board configuration supports the following hardware features:
 +-----------+------------+----------------------+
 | I2C       | on-chip    | i2c                  |
 +-----------+------------+----------------------+
+| PWM       | on-chip    | pwm                  |
++-----------+------------+----------------------+
 
 Other hardware features are not supported by the Zephyr kernel.
 

--- a/boards/arm/stm32_min_dev/pinmux.c
+++ b/boards/arm/stm32_min_dev/pinmux.c
@@ -30,6 +30,9 @@ static const struct pin_config pinconf[] = {
 	{STM32_PIN_PB6, STM32F1_PINMUX_FUNC_PB6_I2C1_SCL},
 	{STM32_PIN_PB7, STM32F1_PINMUX_FUNC_PB7_I2C1_SDA},
 #endif /* CONFIG_I2C_1 */
+#ifdef CONFIG_PWM_STM32_1
+	{STM32_PIN_PA8, STM32F1_PINMUX_FUNC_PA8_PWM1_CH1},
+#endif /* CONFIG_PWM_STM32_1 */
 };
 
 static int pinmux_stm32_init(struct device *port)

--- a/boards/arm/stm32_min_dev/stm32_min_dev.dts
+++ b/boards/arm/stm32_min_dev/stm32_min_dev.dts
@@ -53,3 +53,11 @@
 	status = "ok";
 	clock-frequency = <I2C_BITRATE_FAST>;
 };
+
+&timers1 {
+	status = "ok";
+
+	pwm {
+		status = "ok";
+	};
+};

--- a/boards/arm/stm32_min_dev/stm32_min_dev.yaml
+++ b/boards/arm/stm32_min_dev/stm32_min_dev.yaml
@@ -8,3 +8,4 @@ toolchain:
 ram: 20
 supported:
   - i2c
+  - pwm


### PR DESCRIPTION
Add support PWM 1 to stm32_min_dev board

Signed-off-by: Harry Jiang <explora26@gmail.com>