### PR TITLE
isr_wrapper: Use 'bx' instead of 'b' to jump to _IntExit

### DIFF
--- a/arch/arm/core/isr_wrapper.S
+++ b/arch/arm/core/isr_wrapper.S
@@ -132,5 +132,8 @@ _idle_state_cleared:
 #error Unknown ARM architecture
 #endif /* CONFIG_ARMV6_M_ARMV8_M_BASELINE */
 
-	/* exception return is done in _IntExit() */
-	b _IntExit
+	/* Use 'bx' instead of 'b' because 'bx' can jump further, and use
+	 * 'bx' instead of 'blx' because exception return is done in
+	 * _IntExit() */
+	ldr r0, =_IntExit
+	bx r0


### PR DESCRIPTION
'b' can't jump very far on Cortex-M0 and will cause linker issues when
isr_wrapper and _IntExit are placed far away from each other.

To resolve this we use the 'bx' instruction, as it can jump much
further. Using 'bx' is not dangerous because we are jumping to thumb
mode code.

This fixes #11167 

Signed-off-by: Sebastian Bøe <sebastian.boe@nordicsemi.no>