### PR TITLE
samples: flash_shell: Replace incorrect assignment to boolean expression

### DIFF
--- a/samples/drivers/flash_shell/src/main.c
+++ b/samples/drivers/flash_shell/src/main.c
@@ -603,7 +603,7 @@ static int cmd_set_dev(const struct shell *shell, size_t argc, char **argv)
 	const char *name;
 	int ret;
 
-	ret = shell_cmd_precheck(shell, (argc = 2), NULL, 0);
+	ret = shell_cmd_precheck(shell, (argc == 2), NULL, 0);
 	if (ret) {
 		return ret;
 	}


### PR DESCRIPTION
`shell_cmd_precheck()` function has the second argument as boolean
and currently we pass assignment expression instead of boolean
expression. Therefore, fix the expression by passing `argc == 2`
as the boolean argument.

Fixes #11099
Coverity-CID: 189507

Signed-off-by: Himanshu Jha <himanshujha199640@gmail.com>

@jarz-nordic Could you please confirm once that the fix is correct ?