### PR TITLE
drivers: sensor: Fix missing case break in fxos8700 driver

### DIFF
--- a/drivers/sensor/fxos8700/fxos8700.c
+++ b/drivers/sensor/fxos8700/fxos8700.c
@@ -401,6 +401,7 @@ static int fxos8700_init(struct device *dev)
 				    data->whoami);
 			return -EIO;
 		}
+		break;
 	case WHOAMI_ID_FXOS8700:
 		LOG_DBG("Device ID 0x%x", data->whoami);
 		break;


### PR DESCRIPTION
Fixes a missing case break in the fxos8700 sensor driver, caught by
Coverity.

Coverity-CID: 189517

Signed-off-by: Maureen Helm <maureen.helm@nxp.com>

Fixes #11089