### PR TITLE
Fixes usb/console sample for nrf52840

### DIFF
--- a/dts/arm/nordic/nrf52840.dtsi
+++ b/dts/arm/nordic/nrf52840.dtsi
@@ -193,6 +193,11 @@
 			label = "USBD";
 		};
 
+		usb_cdc: virtualcom {
+			compatible = "nordic,nrf-usbd";
+			label = "CDC_ACM";
+		};
+
 		wdt: watchdog@40010000 {
 			compatible = "nordic,nrf-watchdog";
 			reg = <0x40010000 0x1000>;

--- a/samples/subsys/usb/console/nrf52840_pca10056.overlay
+++ b/samples/subsys/usb/console/nrf52840_pca10056.overlay
@@ -1,0 +1,10 @@
+/*
+ * Copyright (c) 2018 Intel Corporation
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+/ {
+        chosen {
+                zephyr,console = &usb_cdc;
+        };
+};


### PR DESCRIPTION
Adds the virtualcom device to the SoC and adds an overlay to set the
console device name appropriately for the sample.