### PR TITLE
drivers: gpio: shell: rectify gpio get error msg

### DIFF
--- a/drivers/gpio/gpio_shell.c
+++ b/drivers/gpio/gpio_shell.c
@@ -93,7 +93,7 @@ static int cmd_gpio_get(const struct shell *shell,
 		index = (uint8_t)atoi(argv[args_indx.index]);
 	} else {
 		shell_fprintf(shell, SHELL_ERROR,
-			      "Wrong parameters for set\n");
+			      "Wrong parameters for get\n");
 		return 0;
 	}
 


### PR DESCRIPTION
Previous the error for get was:
- Wrong parameters for set
Now:
- Wrong parameters for get

Signed-off-by: Sean Nyekjaer <sean.nyekjaer@prevas.dk>