### PR TITLE
lib: fdtable: Assign data structures to proper sections

### DIFF
--- a/lib/fdtable.c
+++ b/lib/fdtable.c
@@ -29,7 +29,7 @@ struct fd_entry {
 #define FD_OBJ_STDERR (void *)0x12
 
 #ifdef CONFIG_POSIX_API
-static struct fd_op_vtable stdinout_fd_op_vtable;
+static const struct fd_op_vtable stdinout_fd_op_vtable;
 #endif
 
 static struct fd_entry fdtable[CONFIG_POSIX_MAX_FDS] = {
@@ -218,7 +218,7 @@ static int stdinout_ioctl_vmeth(void *obj, unsigned int request, ...)
 }
 
 
-static struct fd_op_vtable stdinout_fd_op_vtable = {
+static const struct fd_op_vtable stdinout_fd_op_vtable = {
 	.read = stdinout_read_vmeth,
 	.write = stdinout_write_vmeth,
 	.ioctl = stdinout_ioctl_vmeth,

--- a/lib/fdtable.c
+++ b/lib/fdtable.c
@@ -32,7 +32,7 @@ struct fd_entry {
 static const struct fd_op_vtable stdinout_fd_op_vtable;
 #endif
 
-static struct fd_entry fdtable[CONFIG_POSIX_MAX_FDS] = {
+__kernel static struct fd_entry fdtable[CONFIG_POSIX_MAX_FDS] = {
 #ifdef CONFIG_POSIX_API
 	/*
 	 * Predefine entries for stdin/stdout/stderr. Object pointer

--- a/subsys/net/lib/sockets/sockets.c
+++ b/subsys/net/lib/sockets/sockets.c
@@ -23,7 +23,7 @@
 #define SET_ERRNO(x) \
 	{ int _err = x; if (_err < 0) { errno = -_err; return -1; } }
 
-static struct fd_op_vtable sock_fd_op_vtable;
+static const struct fd_op_vtable sock_fd_op_vtable;
 
 static void zsock_received_cb(struct net_context *ctx, struct net_pkt *pkt,
 			      int status, void *user_data);
@@ -895,7 +895,7 @@ static int sock_ioctl_vmeth(void *obj, unsigned int request, ...)
 	}
 }
 
-static struct fd_op_vtable sock_fd_op_vtable = {
+static const struct fd_op_vtable sock_fd_op_vtable = {
 	.read = sock_read_vmeth,
 	.write = sock_write_vmeth,
 	.ioctl = sock_ioctl_vmeth,


### PR DESCRIPTION
lib: fdtable: FD method tables should be const. 

lib: fdtable: File descriptor table should reside in kernel memory 
