### PR TITLE
Bluetooth: host: Don't restart scan if connection is pending

### DIFF
--- a/subsys/bluetooth/host/hci_core.c
+++ b/subsys/bluetooth/host/hci_core.c
@@ -3182,6 +3182,13 @@ int bt_le_scan_update(bool fast_scan)
 		u16_t interval, window;
 		struct bt_conn *conn;
 
+		/* don't restart scan if we have pending connection */
+		conn = bt_conn_lookup_state_le(NULL, BT_CONN_CONNECT);
+		if (conn) {
+			bt_conn_unref(conn);
+			return 0;
+		}
+
 		conn = bt_conn_lookup_state_le(NULL, BT_CONN_CONNECT_SCAN);
 		if (!conn) {
 			return 0;


### PR DESCRIPTION
With multiple devices on auto-connect list it is possible that while
having pending connection to device A, device B disconnects. In that
case host should not try to start scan (currently controller doesn't
support concurrent scanning and initiating).

Signed-off-by: Szymon Janc <szymon.janc@codecoup.pl>