### PR TITLE
boards: arm: nrf52840_pca10059: update dts and overlay

### DIFF
--- a/boards/arm/nrf52840_pca10059/Kconfig
+++ b/boards/arm/nrf52840_pca10059/Kconfig
@@ -11,4 +11,11 @@ config BOARD_ENABLE_DCDC
         select SOC_DCDC_NRF52X
         default y
 
+config BOARD_HAS_NRF5_BOOTLOADER
+	bool "Board has nRF5 bootloader"
+	default y
+	help
+	 If selected, applications are linked so that they can be loaded by
+	 Nordic nRF5 bootloader.
+
 endif # BOARD_NRF52840_PCA10059

--- a/boards/arm/nrf52840_pca10059/Kconfig.defconfig
+++ b/boards/arm/nrf52840_pca10059/Kconfig.defconfig
@@ -9,6 +9,16 @@ if BOARD_NRF52840_PCA10059
 config BOARD
 	default "nrf52840_pca10059"
 
+if BOARD_HAS_NRF5_BOOTLOADER && !BOOTLOADER_MCUBOOT
+
+# Link the application after Nordic MBR.
+# When flashing MCUBoot, leave unchanged to link it in its correct partition.
+
+config TEXT_SECTION_OFFSET
+	default 0x1000
+
+endif # BOARD_HAS_NRF5_BOOTLOADER && !BOOTLOADER_MCUBOOT
+
 if ADC
 
 config ADC_0

--- a/boards/arm/nrf52840_pca10059/fstab-debugger.dts
+++ b/boards/arm/nrf52840_pca10059/fstab-debugger.dts
@@ -1,0 +1,40 @@
+/*
+ * Copyright (c) 2019 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/* Flash partition table without support for Nordic nRF5 bootloader */
+
+&flash0 {
+	partitions {
+		compatible = "fixed-partitions";
+		#address-cells = <1>;
+		#size-cells = <1>;
+
+		/* The size of this partition ensures MCUBoot can be built
+		 * with an RTT console, CDC ACM support, and w/o optimizations
+		 */
+		boot_partition: partition@0 {
+			label = "mcuboot";
+			reg = <0x000000000 0x0000f000>;
+		};
+
+		slot0_partition: partition@f000 {
+			label = "image-0";
+			reg = <0x0000f000 0x000069000>;
+		};
+		slot1_partition: partition@78000 {
+			label = "image-1";
+			reg = <0x00078000 0x000069000>;
+		};
+		scratch_partition: partition@e1000 {
+			label = "image-scratch";
+			reg = <0x000e1000 0x0001b000>;
+		};
+		storage_partition: partition@fc000 {
+			label = "storage";
+			reg = <0x000fc000 0x00004000>;
+		};
+	};
+};

--- a/boards/arm/nrf52840_pca10059/fstab-stock.dts
+++ b/boards/arm/nrf52840_pca10059/fstab-stock.dts
@@ -1,0 +1,47 @@
+/*
+ * Copyright (c) 2019 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/* Flash partition table compatible with Nordic nRF5 bootloader */
+
+&flash0 {
+	partitions {
+		compatible = "fixed-partitions";
+		#address-cells = <1>;
+		#size-cells = <1>;
+
+		/* MCUboot placed after Nordic MBR.
+		 * The size of this partition ensures MCUBoot can be built
+		 * with an RTT console, CDC ACM support, and w/o optimizations.
+		 */
+		boot_partition: partition@1000 {
+			label = "mcuboot";
+			reg = <0x00001000 0x000f000>;
+		};
+
+		slot0_partition: partition@10000 {
+			label = "image-0";
+			reg = <0x00010000 0x00005e000>;
+		};
+		slot1_partition: partition@6d000 {
+			label = "image-1";
+			reg = <0x006e000 0x00005e000>;
+		};
+		storage_partition: partition@cc000 {
+			label = "storage";
+			reg = <0x000cc000 0x00004000>;
+		};
+		scratch_partition: partition@d0000 {
+			label = "image-scratch";
+			reg = <0x000d0000 0x00010000>;
+		};
+
+		/* Nordic nRF5 bootloader <0xe0000 0x1c000>
+		 *
+		 * In addition, the last and second last flash pages
+		 * are used by the nRF5 bootloader and MBR to store settings.
+		 */
+	};
+};

--- a/boards/arm/nrf52840_pca10059/nrf52840_pca10059.dts
+++ b/boards/arm/nrf52840_pca10059/nrf52840_pca10059.dts
@@ -115,38 +115,12 @@
 	miso-pin = <45>;
 };
 
-&flash0 {
-	/*
-	 * For more information, see:
-	 * http://docs.zephyrproject.org/latest/devices/dts/flash_partitions.html
-	 */
-	partitions {
-		compatible = "fixed-partitions";
-		#address-cells = <1>;
-		#size-cells = <1>;
-
-		boot_partition: partition@e0000 {
-			label = "mcuboot";
-			reg = <0x0000e0000 0x0001a000>;
-		};
-		slot0_partition: partition@1000 {
-			label = "image-0";
-			reg = <0x00001000 0x000060000>;
-		};
-		slot1_partition: partition@61000 {
-			label = "image-1";
-			reg = <0x0061000 0x000060000>;
-		};
-		scratch_partition: partition@c1000 {
-			label = "image-scratch";
-			reg = <0x000c1000 0x0001f000>;
-		};
-		storage_partition: partition@fa000 {
-			label = "storage";
-			reg = <0x000fa000 0x00004000>;
-		};
-	};
-};
+/* Include flash partition table.
+ * Two partition tables are available:
+ * fstab-stock		-compatible with Nordic nRF5 bootloader, default
+ * fstab-debugger	-to use an external debugger, w/o the nRF5 bootloader
+ */
+#include "fstab-stock.dts"
 
 &usbd {
 	compatible = "nordic,nrf-usbd";


### PR DESCRIPTION
Update the flash partitions and add a couple of dts files to support several boot scenarios.

Add support for using Nordic nRF5 bootloader to:
- flash a Zephyr application
- flash a MCUboot image as an application
- ~~migrate to MCUboot (already present)~~

This will require some documentation :) trying to sum it up:

There is a new option under "Board options" to mark that Nordic nRF5 bootloader is present. If that entry is checked, then applications are linked to be loaded by the stock bootloader and can be programmed using `nrfutil`.

~~If the "MCUboot bootloader support" under "Boot options" is also checked, then a new option will appear to select whether MCUboot is linked as an application or not.~~

MCUboot can be programmed as an application via `nrfutil` and chain-loaded by the nRF5 bootloader too, like a normal Zephyr application.

~~Otherwise,  MCUboot is linked to replace the stock bootloader and applications are linked somewhere else. MCUboot can be programmed as a bootloader package via nrfutil. Keep in mind that bootloader updates need to be signed to be accepted by the stock bootloader, thus this option is only inteded for development purposes when an external debugger is available.~~

CC @carlescufi @nvlsianpu 