### PR TITLE
e1000 fixes

### DIFF
--- a/drivers/ethernet/eth_e1000.c
+++ b/drivers/ethernet/eth_e1000.c
@@ -212,6 +212,8 @@ static void e1000_init(struct net_if *iface)
 	memcpy(dev->mac, &ral, 4);
 	memcpy(dev->mac + 4, &rah, 2);
 
+	ethernet_init(iface);
+
 	net_if_set_link_addr(iface, dev->mac, sizeof(dev->mac),
 				NET_LINK_ETHERNET);
 

--- a/drivers/ethernet/eth_e1000.c
+++ b/drivers/ethernet/eth_e1000.c
@@ -223,7 +223,7 @@ static void e1000_init(struct net_if *iface)
 
 	iow32(dev, CTRL, CTRL_SLU); /* Set link up */
 
-	iow32(dev, RCTL, RCTL_EN);
+	iow32(dev, RCTL, RCTL_EN | RCTL_MPE);
 
 	dev_dbg("done");
 }

--- a/drivers/ethernet/eth_e1000.c
+++ b/drivers/ethernet/eth_e1000.c
@@ -202,8 +202,6 @@ static void e1000_init(struct net_if *iface)
 	iow32(dev, RDH, 0);
 	iow32(dev, RDT, 1);
 
-	iow32(dev, RCTL, RCTL_EN);
-
 	iow32(dev, IMS, IMS_RXO);
 
 	ral = ior32(dev, RAL);
@@ -217,13 +215,15 @@ static void e1000_init(struct net_if *iface)
 	net_if_set_link_addr(iface, dev->mac, sizeof(dev->mac),
 				NET_LINK_ETHERNET);
 
-	iow32(dev, CTRL, CTRL_SLU); /* Set link up */
-
 	IRQ_CONNECT(CONFIG_ETH_E1000_IRQ, CONFIG_ETH_E1000_IRQ_PRIORITY,
 			e1000_isr, DEVICE_GET(eth_e1000),
 			CONFIG_ETH_E1000_IRQ_FLAGS);
 
 	irq_enable(CONFIG_ETH_E1000_IRQ);
+
+	iow32(dev, CTRL, CTRL_SLU); /* Set link up */
+
+	iow32(dev, RCTL, RCTL_EN);
 
 	dev_dbg("done");
 }

--- a/drivers/ethernet/eth_e1000_priv.h
+++ b/drivers/ethernet/eth_e1000_priv.h
@@ -22,6 +22,8 @@ extern "C" {
 
 #define IMS_RXO		(1 << 6) /* Receiver FIFO Overrun */
 
+#define RCTL_MPE	(1 << 4) /* Multicast Promiscuous Enabled */
+
 #define TDESC_EOP	     (1) /* End Of Packet */
 #define TDESC_RS	(1 << 3) /* Report Status */
 

--- a/drivers/ethernet/eth_e1000_priv.h
+++ b/drivers/ethernet/eth_e1000_priv.h
@@ -90,14 +90,14 @@ static const char *e1000_reg_to_string(enum e1000_reg_t r)
 	__attribute__((unused));
 
 #define iow32(_dev, _reg, _val) do {					\
-	dev_dbg("iow32 %s 0x%08x", e1000_reg_to_string(_reg), _val); 	\
+	LOG_DBG("iow32 %s 0x%08x", e1000_reg_to_string(_reg), _val); 	\
 	sys_write32(_val, (_dev)->pci.addr + _reg);			\
 } while (0)
 
 #define ior32(_dev, _reg)						\
 ({									\
 	u32_t val = sys_read32((_dev)->pci.addr + (_reg));		\
-	dev_dbg("ior32 %s 0x%08x", e1000_reg_to_string(_reg), val); 	\
+	LOG_DBG("ior32 %s 0x%08x", e1000_reg_to_string(_reg), val); 	\
 	val;								\
 })
 


### PR DESCRIPTION
drivers: eth: e1000: Don't print function names twice
drivers: eth: e1000: Call ethernet_init() on init
