### PR TITLE
Bluetooth: controller: Fix enable and disable of scan state

### DIFF
--- a/subsys/bluetooth/controller/ll_sw/ctrl.c
+++ b/subsys/bluetooth/controller/ll_sw/ctrl.c
@@ -10504,9 +10504,13 @@ u32_t radio_scan_enable(u8_t type, u8_t init_addr_type, u8_t *init_addr,
 	return 0;
 }
 
-u32_t radio_scan_disable(void)
+u32_t radio_scan_disable(bool scanner)
 {
 	u32_t status;
+
+	if (scanner && _radio.scanner.conn) {
+		return BT_HCI_ERR_CMD_DISALLOWED;
+	}
 
 	status = role_disable(RADIO_TICKER_ID_SCAN,
 			      RADIO_TICKER_ID_SCAN_STOP);
@@ -10518,7 +10522,7 @@ u32_t radio_scan_disable(void)
 		}
 	}
 
-	return status ? BT_HCI_ERR_CMD_DISALLOWED : 0;
+	return _radio.scanner.is_enabled ? BT_HCI_ERR_CMD_DISALLOWED : 0;
 }
 
 u32_t ll_scan_is_enabled(void)
@@ -10709,7 +10713,7 @@ u32_t ll_connect_disable(void **node_rx)
 		return BT_HCI_ERR_CMD_DISALLOWED;
 	}
 
-	status = radio_scan_disable();
+	status = radio_scan_disable(false);
 	if (!status) {
 		struct connection *conn = _radio.scanner.conn;
 		struct radio_pdu_node_rx *rx;

--- a/subsys/bluetooth/controller/ll_sw/ctrl.h
+++ b/subsys/bluetooth/controller/ll_sw/ctrl.h
@@ -356,7 +356,7 @@ u32_t radio_adv_filter_pol_get(void);
 u32_t radio_scan_enable(u8_t type, u8_t init_addr_type, u8_t *init_addr,
 			u16_t interval, u16_t window, u8_t filter_policy,
 			u8_t rpa_gen, u8_t rl_idx);
-u32_t radio_scan_disable(void);
+u32_t radio_scan_disable(bool scanner);
 u32_t ll_scan_is_enabled(void);
 u32_t radio_scan_filter_pol_get(void);
 

--- a/subsys/bluetooth/controller/ll_sw/ll_scan.c
+++ b/subsys/bluetooth/controller/ll_sw/ll_scan.c
@@ -59,12 +59,22 @@ u32_t ll_scan_params_set(u8_t type, u16_t interval, u16_t window,
 
 u32_t ll_scan_enable(u8_t enable)
 {
+	u8_t rpa_gen = 0;
 	u32_t status;
-	u8_t  rpa_gen = 0;
+	u32_t scan;
 
 	if (!enable) {
-		return radio_scan_disable();
-	} else if (ll_scan_is_enabled()) {
+		return radio_scan_disable(true);
+	}
+
+	scan = ll_scan_is_enabled();
+
+	/* Initiator and scanning are not supported */
+	if (scan & BIT(2)) {
+	       return BT_HCI_ERR_CMD_DISALLOWED;
+	}
+
+	if (scan) {
 		/* Duplicate filtering is processed in the HCI layer */
 		return 0;
 	}


### PR DESCRIPTION
Updated controller implementation to disallow disabling
initiator state using scan disable. But allow disabling an
already disabled scan state. Also, disallow enabling scan
state while in initiator state.

Signed-off-by: Szymon Janc <szymon.janc@codecoup.pl>
Signed-off-by: Vinayak Kariappa Chettimada <vich@nordicsemi.no>