### PR TITLE
logging: fix net/lib/app compile where CONFIG_LOG=n

### DIFF
--- a/include/logging/log.h
+++ b/include/logging/log.h
@@ -253,7 +253,11 @@ extern "C" {
  *
  * return Number of bytes written.
  */
+#if defined(CONFIG_LOG)
 int log_printk(const char *fmt, va_list ap);
+#else
+#define log_printk(...) { ; }
+#endif
 
 /** @brief Copy transient string to a buffer from internal, logger pool.
  *
@@ -267,7 +271,11 @@ int log_printk(const char *fmt, va_list ap);
  *	   allocated. String may be truncated if input string does not fit in
  *	   a buffer from the pool (see CONFIG_LOG_STRDUP_MAX_STRING).
  */
+#if defined(CONFIG_LOG)
 char *log_strdup(const char *str);
+#else
+#define log_strdup(...) ""
+#endif
 
 #define __DYNAMIC_MODULE_REGISTER(_name)\
 	struct log_source_dynamic_data LOG_ITEM_DYNAMIC_DATA(_name)	\


### PR DESCRIPTION
If CONFIG_LOG=n and subsys/net/lib/app is included in the build,
the following linker error is presented to the user:
libzephyr.a(net_app.c.obj): In function `_net_app_sprint_ipaddr':
/home/scottml/fio/zmp-osf/zephyr/subsys/net/lib/app/net_app.c:112: undefined reference to `log_strdup'
/home/scottml/fio/zmp-osf/zephyr/subsys/net/lib/app/net_app.c:122: undefined reference to `log_strdup'
collect2: error: ld returned 1 exit status

Let's fix that.

Signed-off-by: Michael Scott <mike@foundries.io>