### PR TITLE
arm: Placing the functions which holds __ramfunc into '.ramfunc'

### DIFF
--- a/arch/Kconfig
+++ b/arch/Kconfig
@@ -339,6 +339,9 @@ config ARCH_HAS_EXECUTABLE_PAGE_BIT
 config ARCH_HAS_NOCACHE_MEMORY_SUPPORT
 	bool
 
+config ARCH_HAS_RAMFUNC_SUPPORT
+	bool
+
 #
 # Other architecture related options
 #

--- a/arch/arm/core/Kconfig
+++ b/arch/arm/core/Kconfig
@@ -23,6 +23,7 @@ config CPU_CORTEX_M
 	select ARCH_HAS_STACK_PROTECTION if ARM_MPU || CPU_CORTEX_M_HAS_SPLIM
 	select ARCH_HAS_USERSPACE if ARM_MPU
 	select ARCH_HAS_NOCACHE_MEMORY_SUPPORT if ARM_MPU && CPU_HAS_ARM_MPU && CPU_CORTEX_M7
+	select ARCH_HAS_RAMFUNC_SUPPORT
 	select SWAP_NONATOMIC
 	help
 	  This option signifies the use of a CPU of the Cortex-M family.

--- a/arch/arm/core/cortex_m/mpu/arm_core_mpu.c
+++ b/arch/arm/core/cortex_m/mpu/arm_core_mpu.c
@@ -77,8 +77,15 @@ void _arch_configure_static_mpu_regions(void)
 		.start = (u32_t)&_nocache_ram_start,
 		.size = (u32_t)&_nocache_ram_size,
 		.attr = K_MEM_PARTITION_P_RW_U_NA_NOCACHE,
-		}
+		},
 #endif /* CONFIG_NOCACHE_MEMORY */
+#if defined(CONFIG_RAM_FUNCTION)
+		{
+		.start = (u32_t)&_ramfunc_ram_start,
+		.size = (u32_t)&_ramfunc_ram_start - (u32_t)&_ramfunc_ram_end,
+		.attr = K_MEM_PARTITION_P_RX_U_RX,
+		}
+#endif /* CONFIG_RAM_FUNCTION */
 	};
 
 	/* Configure the static MPU regions within firmware SRAM boundaries.

--- a/arch/arm/core/cortex_m/mpu/arm_core_mpu.c
+++ b/arch/arm/core/cortex_m/mpu/arm_core_mpu.c
@@ -79,13 +79,13 @@ void _arch_configure_static_mpu_regions(void)
 		.attr = K_MEM_PARTITION_P_RW_U_NA_NOCACHE,
 		},
 #endif /* CONFIG_NOCACHE_MEMORY */
-#if defined(CONFIG_RAM_FUNCTION)
+#if defined(CONFIG_ARCH_HAS_RAMFUNC_SUPPORT)
 		{
 		.start = (u32_t)&_ramfunc_ram_start,
 		.size = (u32_t)&_ramfunc_ram_size,
 		.attr = K_MEM_PARTITION_P_RX_U_RX,
 		}
-#endif /* CONFIG_RAM_FUNCTION */
+#endif /* CONFIG_ARCH_HAS_RAMFUNC_SUPPORT */
 	};
 
 	/* Configure the static MPU regions within firmware SRAM boundaries.

--- a/arch/arm/core/cortex_m/mpu/arm_core_mpu.c
+++ b/arch/arm/core/cortex_m/mpu/arm_core_mpu.c
@@ -82,7 +82,7 @@ void _arch_configure_static_mpu_regions(void)
 #if defined(CONFIG_RAM_FUNCTION)
 		{
 		.start = (u32_t)&_ramfunc_ram_start,
-		.size = (u32_t)&_ramfunc_ram_start - (u32_t)&_ramfunc_ram_end,
+		.size = (u32_t)&_ramfunc_ram_size,
 		.attr = K_MEM_PARTITION_P_RX_U_RX,
 		}
 #endif /* CONFIG_RAM_FUNCTION */

--- a/include/arch/arm/cortex_m/scripts/linker.ld
+++ b/include/arch/arm/cortex_m/scripts/linker.ld
@@ -368,7 +368,7 @@ SECTIONS
 	_nocache_ram_size = _nocache_ram_end - _nocache_ram_start;
 #endif /* CONFIG_NOCACHE_MEMORY */
 
-#if defined(CONFIG_RAM_FUNCTION)
+#if defined(CONFIG_ARCH_HAS_RAMFUNC_SUPPORT)
 	SECTION_DATA_PROLOGUE(.ramfunc,,)
 	{
 		MPU_ALIGN(_ramfunc_ram_size);
@@ -380,7 +380,7 @@ SECTIONS
 	} GROUP_DATA_LINK_IN(RAMABLE_REGION, ROMABLE_REGION)
 	_ramfunc_ram_size = _ramfunc_ram_end - _ramfunc_ram_start;
 	_ramfunc_rom_start = LOADADDR(.ramfunc);
-#endif /* CONFIG_RAM_FUNCTION */
+#endif /* CONFIG_ARCH_HAS_RAMFUNC_SUPPORT */
 
 #if defined(CONFIG_APP_SHARED_MEM)
 #define APP_SHARED_ALIGN . = ALIGN(_region_min_align);

--- a/include/arch/arm/cortex_m/scripts/linker.ld
+++ b/include/arch/arm/cortex_m/scripts/linker.ld
@@ -368,6 +368,20 @@ SECTIONS
 	_nocache_ram_size = _nocache_ram_end - _nocache_ram_start;
 #endif /* CONFIG_NOCACHE_MEMORY */
 
+#if defined(CONFIG_RAM_FUNCTION)
+	SECTION_DATA_PROLOGUE(.ramfunc,,)
+	{
+		MPU_ALIGN(_ramfunc_ram_size);
+		_ramfunc_ram_start = .;
+		*(.ramfunc)
+		*(".ramfunc.*")
+		MPU_ALIGN(_ramfunc_ram_size);
+		_ramfunc_ram_end = .;
+	} GROUP_DATA_LINK_IN(RAMABLE_REGION, ROMABLE_REGION)
+	_ramfunc_ram_size = _ramfunc_ram_end - _ramfunc_ram_start;
+	_ramfunc_rom_start = LOADADDR(.ramfunc);
+#endif /* CONFIG_RAM_FUNCTION */
+
 #if defined(CONFIG_APP_SHARED_MEM)
 #define APP_SHARED_ALIGN . = ALIGN(_region_min_align);
 #define SMEM_PARTITION_ALIGN MPU_ALIGN

--- a/include/linker/linker-defs.h
+++ b/include/linker/linker-defs.h
@@ -247,6 +247,7 @@ extern char _nocache_ram_size[];
  */
 extern char _ramfunc_ram_start[];
 extern char _ramfunc_ram_end[];
+extern char _ramfunc_ram_size[];
 extern char _ramfunc_rom_start[];
 
 #endif /* ! _ASMLANGUAGE */

--- a/include/linker/linker-defs.h
+++ b/include/linker/linker-defs.h
@@ -239,6 +239,16 @@ extern char _nocache_ram_end[];
 extern char _nocache_ram_size[];
 #endif /* CONFIG_NOCACHE_MEMORY */
 
+/* Memory owned by the kernel. Start and end will be aligned for memory
+ * management/protection hardware for the target architecture.
+ *
+ * All the functions with '__ramfunc' keyword will be placed into this
+ * sections.
+ */
+extern char _ramfunc_ram_start[];
+extern char _ramfunc_ram_end[];
+extern char _ramfunc_rom_start[];
+
 #endif /* ! _ASMLANGUAGE */
 
 #endif /* ZEPHYR_INCLUDE_LINKER_LINKER_DEFS_H_ */

--- a/include/linker/linker-defs.h
+++ b/include/linker/linker-defs.h
@@ -243,12 +243,14 @@ extern char _nocache_ram_size[];
  * management/protection hardware for the target architecture.
  *
  * All the functions with '__ramfunc' keyword will be placed into this
- * sections.
+ * section, stored in RAM instead of FLASH.
  */
+#ifdef CONFIG_ARCH_HAS_RAMFUNC_SUPPORT
 extern char _ramfunc_ram_start[];
 extern char _ramfunc_ram_end[];
 extern char _ramfunc_ram_size[];
 extern char _ramfunc_rom_start[];
+#endif /* CONFIG_ARCH_HAS_RAMFUNC_SUPPORT */
 
 #endif /* ! _ASMLANGUAGE */
 

--- a/include/toolchain/gcc.h
+++ b/include/toolchain/gcc.h
@@ -115,15 +115,18 @@ do {                                                                    \
 
 #define __in_section_unique(seg) ___in_section(seg, __FILE__, __COUNTER__)
 
-#ifdef CONFIG_RAM_FUNCTION
-/* Using this places a function into RAM instead of FLASH.
- * Make sure '__ramfunc' are defined only when CONFIG_RAM_FUNCTION,
- * so the compiler can report error if used '__ramfunc' but hadn't
- * enable CONFIG_RAM_FUNCTION in Kconfig.
+/* When using XIP, using '__ramfunc' places a function into RAM instead
+ * of FLASH. Make sure '__ramfunc' is defined only when
+ * CONFIG_ARCH_HAS_RAMFUNC_SUPPORT is defined, so that the compiler can
+ * report an error if '__ramfunc' is used but the architecture does not
+ * support it.
  */
+#if !defined(CONFIG_XIP)
+#define __ramfunc
+#elif defined(CONFIG_ARCH_HAS_RAMFUNC_SUPPORT)
 #define __ramfunc	__attribute__((noinline))			\
 			__attribute__((long_call, section(".ramfunc")))
-#endif
+#endif /* !CONFIG_XIP */
 
 #ifndef __packed
 #define __packed        __attribute__((__packed__))

--- a/include/toolchain/gcc.h
+++ b/include/toolchain/gcc.h
@@ -115,6 +115,16 @@ do {                                                                    \
 
 #define __in_section_unique(seg) ___in_section(seg, __FILE__, __COUNTER__)
 
+#ifdef CONFIG_RAM_FUNCTION
+/* Using this places a function into RAM instead of FLASH.
+ * Make sure '__ramfunc' are defined only when CONFIG_RAM_FUNCTION,
+ * so the compiler can report error if used '__ramfunc' but hadn't
+ * enable CONFIG_RAM_FUNCTION in Kconfig.
+ */
+#define __ramfunc	__attribute__((noinline))			\
+			__attribute__((long_call, section(".ramfunc")))
+#endif
+
 #ifndef __packed
 #define __packed        __attribute__((__packed__))
 #endif

--- a/kernel/Kconfig
+++ b/kernel/Kconfig
@@ -207,13 +207,6 @@ config ERRNO
 	  symbol. The C library must access the per-thread errno via the
 	  _get_errno() symbol.
 
-config RAM_FUNCTION
-	bool "Enable __ramfunc support"
-	help
-	  Using '__ramfunc' places a function into RAM instead of Flash.
-	  Code that for example reprograms flash at runtime can't execute
-	  from flash, in that case must placing code into RAM.
-
 choice SCHED_ALGORITHM
 	prompt "Scheduler priority queue algorithm"
 	default SCHED_DUMB

--- a/kernel/Kconfig
+++ b/kernel/Kconfig
@@ -207,6 +207,13 @@ config ERRNO
 	  symbol. The C library must access the per-thread errno via the
 	  _get_errno() symbol.
 
+config RAM_FUNCTION
+	bool "Enable __ramfunc support"
+	help
+	  Using '__ramfunc' places a function into RAM instead of Flash.
+	  Code that for example reprograms flash at runtime can't execute
+	  from flash, in that case must placing code into RAM.
+
 choice SCHED_ALGORITHM
 	prompt "Scheduler priority queue algorithm"
 	default SCHED_DUMB

--- a/kernel/init.c
+++ b/kernel/init.c
@@ -173,6 +173,10 @@ void _data_copy(void)
 {
 	(void)memcpy(&__data_ram_start, &__data_rom_start,
 		 ((u32_t) &__data_ram_end - (u32_t) &__data_ram_start));
+#ifdef CONFIG_RAM_FUNCTION
+	(void)memcpy(&_ramfunc_ram_start, &_ramfunc_rom_start,
+		 ((u32_t) &_ramfunc_ram_end - (u32_t) &_ramfunc_ram_start));
+#endif
 #ifdef DT_CCM_BASE_ADDRESS
 	(void)memcpy(&__ccm_data_start, &__ccm_data_rom_start,
 		 ((u32_t) &__ccm_data_end - (u32_t) &__ccm_data_start));

--- a/kernel/init.c
+++ b/kernel/init.c
@@ -173,10 +173,10 @@ void _data_copy(void)
 {
 	(void)memcpy(&__data_ram_start, &__data_rom_start,
 		 ((u32_t) &__data_ram_end - (u32_t) &__data_ram_start));
-#ifdef CONFIG_RAM_FUNCTION
+#ifdef CONFIG_ARCH_HAS_RAMFUNC_SUPPORT
 	(void)memcpy(&_ramfunc_ram_start, &_ramfunc_rom_start,
 		 ((u32_t) &_ramfunc_ram_size));
-#endif
+#endif /* CONFIG_ARCH_HAS_RAMFUNC_SUPPORT */
 #ifdef DT_CCM_BASE_ADDRESS
 	(void)memcpy(&__ccm_data_start, &__ccm_data_rom_start,
 		 ((u32_t) &__ccm_data_end - (u32_t) &__ccm_data_start));

--- a/kernel/init.c
+++ b/kernel/init.c
@@ -175,7 +175,7 @@ void _data_copy(void)
 		 ((u32_t) &__data_ram_end - (u32_t) &__data_ram_start));
 #ifdef CONFIG_RAM_FUNCTION
 	(void)memcpy(&_ramfunc_ram_start, &_ramfunc_rom_start,
-		 ((u32_t) &_ramfunc_ram_end - (u32_t) &_ramfunc_ram_start));
+		 ((u32_t) &_ramfunc_ram_size));
 #endif
 #ifdef DT_CCM_BASE_ADDRESS
 	(void)memcpy(&__ccm_data_start, &__ccm_data_rom_start,


### PR DESCRIPTION
__ramfunc is an intrinsis of IAR, using this places a function in RAM
instead of Flash. Code that for example reprograms flash at runtime
can't execute from flash, in that case must placing code into RAM.

This commit create a new section named '.ramfunc' in link scripts,
all functions has __ramfunc keyword saved in thats sections and
will load from flash to sram after the system booted.

Fixes: #10253

Signed-off-by: qianfan Zhao <qianfanguijin@163.com>