### PR TITLE
scripts/dts: extract_dts_includes: fix multi-compat bus parent

### DIFF
--- a/scripts/dts/extract_dts_includes.py
+++ b/scripts/dts/extract_dts_includes.py
@@ -327,8 +327,8 @@ def extract_property(node_compat, yaml, node_address, prop, prop_val, names):
 
             #check parent has matching child bus value
             try:
-                parent_yaml = \
-                    yaml[reduced[parent_address]['props']['compatible']]
+                parent_compat = get_compat(parent_address)
+                parent_yaml = yaml[parent_compat]
                 parent_bus = parent_yaml['child']['bus']
             except (KeyError, TypeError) as e:
                 raise Exception(str(node_address) + " defines parent " +


### PR DESCRIPTION
Case when bus parent has more than one compatible was not treated
correctly. Use get_compat() method which returns first compat
in case several compats are available

Fixes #11121

Signed-off-by: Erwan Gouriou <erwan.gouriou@linaro.org>