### PR TITLE
lib: posix: fix a wrong type in mqueue.c

### DIFF
--- a/lib/posix/mqueue.c
+++ b/lib/posix/mqueue.c
@@ -51,7 +51,7 @@ mqd_t mq_open(const char *name, int oflags, ...)
 	va_list va;
 	mode_t mode;
 	mq_attr *attrs = NULL;
-	u32_t msg_size = 0U, max_msgs = 0U;
+	long msg_size = 0U, max_msgs = 0U;
 	mqueue_object *msg_queue;
 	mqueue_desc *msg_queue_desc = NULL, *mqd = (mqueue_desc *)(-1);
 	char *mq_desc_ptr, *mq_obj_ptr, *mq_buf_ptr, *mq_name_ptr;


### PR DESCRIPTION
`mq_maxmsg` and `mq_msgsize` are defined to be of type `long` in [POSIX standard](http://man7.org/linux/man-pages/man3/mq_getattr.3.html#DESCRIPTION). So use `long` for variables that hold its value in `mq_open()`.

Fixes #11133 

Signed-off-by: Niranjhana N <niranjhana.n@intel.com>