### PR TITLE
dts: Update i.MX PWM device tree binding/nodes for #pwm-cells

### DIFF
--- a/dts/arm/nxp/nxp_imx7d_m4.dtsi
+++ b/dts/arm/nxp/nxp_imx7d_m4.dtsi
@@ -331,6 +331,7 @@
 					       RDC_DOMAIN_PERM_RW))>;
 			label = "PWM_1";
 			status = "disabled";
+			#pwm-cells = <2>;
 		};
 
 		pwm2: pwm@30670000 {
@@ -344,6 +345,7 @@
 					       RDC_DOMAIN_PERM_RW))>;
 			label = "PWM_2";
 			status = "disabled";
+			#pwm-cells = <2>;
 		};
 
 		pwm3: pwm@30680000 {
@@ -357,6 +359,7 @@
 					       RDC_DOMAIN_PERM_RW))>;
 			label = "PWM_3";
 			status = "disabled";
+			#pwm-cells = <2>;
 		};
 
 		pwm4: pwm@30690000 {
@@ -370,6 +373,7 @@
 					       RDC_DOMAIN_PERM_RW))>;
 			label = "PWM_4";
 			status = "disabled";
+			#pwm-cells = <2>;
 		};
 	};
 };

--- a/dts/bindings/pwm/fsl,imx7d-pwm.yaml
+++ b/dts/bindings/pwm/fsl,imx7d-pwm.yaml
@@ -41,4 +41,8 @@ properties:
      description: Set the RDC permission for this peripheral
      generation: define
 
+"#cells":
+  - channel
+# period in terms of nanoseconds
+  - period
 ...


### PR DESCRIPTION
Add #pwm-cells to the i.MX PWM binding and dts files.  This is to
support have a pwms clients work properly.

Signed-off-by: Kumar Gala <kumar.gala@linaro.org>