### PR TITLE
dts: Update sifive PWM device tree binding/nodes for #pwm-cells

### DIFF
--- a/dts/bindings/pwm/sifive,pwm0.yaml
+++ b/dts/bindings/pwm/sifive,pwm0.yaml
@@ -33,4 +33,8 @@ properties:
       description: required interrupts
       generation: define
 
+"#cells":
+  - channel
+# period in terms of nanoseconds
+  - period
 ...

--- a/dts/riscv32/riscv32-fe310.dtsi
+++ b/dts/riscv32/riscv32-fe310.dtsi
@@ -115,6 +115,7 @@
 			reg = <0x10015000 0x1000>;
 			reg-names = "control";
 			status = "disabled";
+			#pwm-cells = <2>;
 		};
 		pwm1: pwm@10025000 {
 			compatible = "sifive,pwm0";
@@ -123,6 +124,7 @@
 			reg = <0x10025000 0x1000>;
 			reg-names = "control";
 			status = "disabled";
+			#pwm-cells = <2>;
 		};
 		pwm2: pwm@10035000 {
 			compatible = "sifive,pwm0";
@@ -131,6 +133,7 @@
 			reg = <0x10035000 0x1000>;
 			reg-names = "control";
 			status = "disabled";
+			#pwm-cells = <2>;
 		};
 		modeselect: rom@1000 {
 			compatible = "sifive,modeselect0";


### PR DESCRIPTION
Add #pwm-cells to the sifive PWM binding and dts files.  This is to
support have a pwms clients work properly.

Signed-off-by: Kumar Gala <kumar.gala@linaro.org>