### PR TITLE
Remove dead code associated w/nonexistent Kconfig symbols

### DIFF
--- a/drivers/adc/adc_dw.h
+++ b/drivers/adc/adc_dw.h
@@ -197,10 +197,6 @@ struct adc_info {
 	u32_t channels;
 	u32_t channel_id;
 
-#ifdef CONFIG_ADC_DW_REPETITIVE
-	/**Current reception buffer index*/
-	u8_t  index[BUFS_NUM];
-#endif
 	/**Sequence entries' array*/
 	const struct adc_sequence *entries;
 	/**State of execution of the driver*/
@@ -210,9 +206,6 @@ struct adc_info {
 #ifdef CONFIG_ADC_DW_CALIBRATION
 	/**Calibration value*/
 	u8_t calibration_value;
-#endif
-#ifdef CONFIG_ADC_DW_DUMMY_CONVERSION
-	u8_t dummy_conversion;
 #endif
 
 };

--- a/ext/hal/qmsi/CMakeLists.txt
+++ b/ext/hal/qmsi/CMakeLists.txt
@@ -51,8 +51,6 @@ if(CONFIG_QMSI_BUILTIN)
   endif()
 endif()
 
-zephyr_library_sources_ifdef(CONFIG_ADC_QMSI             drivers/adc/qm_adc.c)
-zephyr_library_sources_ifdef(CONFIG_ADC_QMSI_SS          drivers/adc/qm_ss_adc.c)
 zephyr_library_sources_ifdef(CONFIG_AIO_COMPARATOR_QMSI  drivers/comparator/qm_comparator.c)
 zephyr_library_sources_ifdef(CONFIG_AON_COUNTER_QMSI     drivers/aon_counters/qm_aon_counters.c)
 zephyr_library_sources_ifdef(CONFIG_DMA_QMSI             drivers/dma/qm_dma.c)


### PR DESCRIPTION
Cleanup a few places that we have dead code associated with Kconfig symbols that do not exist.