### PR TITLE
Bluetooth: host: Fix trivial comment mismatch

### DIFF
--- a/subsys/bluetooth/host/smp.c
+++ b/subsys/bluetooth/host/smp.c
@@ -4434,7 +4434,7 @@ int bt_passkey_set(unsigned int passkey)
 	fixed_passkey = passkey;
 	return 0;
 }
-#endif /* CONFIG_SMP_FIXED_PASSKEY */
+#endif /* CONFIG_BT_FIXED_PASSKEY */
 
 void bt_smp_update_keys(struct bt_conn *conn)
 {


### PR DESCRIPTION
The endif comment block is for CONFIG_BT_FIXED_PASSKEY not
CONFIG_SMP_FIXED_PASSKEY.  Fix the comment to match.

Signed-off-by: Kumar Gala <kumar.gala@linaro.org>