### PR TITLE
shell: Fix reference to nonexistent Kconfig symbol

### DIFF
--- a/subsys/shell/shell.c
+++ b/subsys/shell/shell.c
@@ -1392,7 +1392,7 @@ int shell_start(const struct shell *shell)
 		return err;
 	}
 
-	if (IS_ENABLED(CONFIG_SHELL_VT100_COLORS_ENABLED)) {
+	if (IS_ENABLED(CONFIG_SHELL_VT100_COLORS)) {
 		vt100_color_set(shell, SHELL_NORMAL);
 	}
 


### PR DESCRIPTION
The code referenced CONFIG_SHELL_VT100_COLORS_ENABLED which does not
exist.  Its mostly likely that CONFIG_SHELL_VT100_COLORS was meant
to be tested instead.

Signed-off-by: Kumar Gala <kumar.gala@linaro.org>