### PR TITLE
samples: blinky: cleanup to use just DT and remove board.h

### DIFF
--- a/samples/basic/blinky/src/main.c
+++ b/samples/basic/blinky/src/main.c
@@ -5,18 +5,10 @@
  */
 
 #include <zephyr.h>
-#include <board.h>
 #include <device.h>
 #include <gpio.h>
 
-/* Change this if you have an LED connected to a custom port */
-#ifndef LED0_GPIO_CONTROLLER
-#define LED0_GPIO_CONTROLLER 	LED0_GPIO_PORT
-#endif
-
 #define LED_PORT LED0_GPIO_CONTROLLER
-
-/* Change this if you have an LED connected to a custom pin */
 #define LED	LED0_GPIO_PIN
 
 /* 1000 msec = 1 sec */


### PR DESCRIPTION
Now that we set LED info in the device tree for all boards we don't need
to special case handle in the name/led pin (it comes from DT).  We can
also remove include board.h.

Signed-off-by: Kumar Gala <kumar.gala@linaro.org>