### PR TITLE
dts: Fix warnings associated with reg/unit-address not matching

### DIFF
--- a/dts/arc/emsk.dtsi
+++ b/dts/arc/emsk.dtsi
@@ -106,7 +106,7 @@
 
 		gpio0: gpio@f0002000 {
 			compatible = "snps,designware-gpio";
-			reg = <0xF0002000 0xc>;
+			reg = <0xf0002000 0xc>;
 			bits = <32>;
 			label = "GPIO_0";
 			interrupts = <DT_GPIO0_INTNO 1>;
@@ -116,9 +116,9 @@
 			#gpio-cells = <2>;
 		};
 
-		gpio1: gpio@f000200C {
+		gpio1: gpio@f000200c {
 			compatible = "snps,designware-gpio";
-			reg = <0xF000200C 0xc>;
+			reg = <0xf000200c 0xc>;
 			bits = <9>;
 			label = "GPIO_1";
 			interrupts = <DT_GPIO1_INTNO 1>;

--- a/dts/arm/atmel/sam3x.dtsi
+++ b/dts/arm/atmel/sam3x.dtsi
@@ -32,19 +32,19 @@
 	};
 
 	soc {
-		wdog: watchdog@400E1A50 {
+		wdog: watchdog@400e1a50 {
 			compatible = "atmel,sam-watchdog";
-			reg = <0x400E1A50 0xc>;
+			reg = <0x400e1a50 0xc>;
 			interrupts = <4 0>;
 			peripheral-id = <4>;
 			label = "WATCHDOG_0";
 			status = "disabled";
 		};
 
-		i2c0: i2c@4008C000 {
+		i2c0: i2c@4008c000 {
 			compatible = "atmel,sam-i2c-twi";
 			clock-frequency = <I2C_BITRATE_STANDARD>;
-			reg = <0x4008C000 0x128>;
+			reg = <0x4008c000 0x128>;
 			interrupts = <22 0>;
 			peripheral-id = <22>;
 			label = "I2C_0";
@@ -61,9 +61,9 @@
 			status = "disabled";
 		};
 
-		uart0: uart@400E0800 {
+		uart0: uart@400e0800 {
 			compatible = "atmel,sam-uart";
-			reg = <0x400E0800 0x124>;
+			reg = <0x400e0800 0x124>;
 			interrupts = <8 1>;
 			peripheral-id = <8>;
 			status = "disabled";
@@ -79,27 +79,27 @@
 			label = "USART_0";
 		};
 
-		usart1: usart@4009C000 {
+		usart1: usart@4009c000 {
 			compatible = "atmel,sam-usart";
-			reg = <0x4009C000 0x130>;
+			reg = <0x4009c000 0x130>;
 			interrupts = <18 0>;
 			peripheral-id = <18>;
 			status = "disabled";
 			label = "USART_1";
 		};
 
-		usart2: usart@400A0000 {
+		usart2: usart@400a0000 {
 			compatible = "atmel,sam-usart";
-			reg = <0x400A0000 0x130>;
+			reg = <0x400a0000 0x130>;
 			interrupts = <19 0>;
 			peripheral-id = <19>;
 			status = "disabled";
 			label = "USART_2";
 		};
 
-		usart3: usart@400A4000 {
+		usart3: usart@400a4000 {
 			compatible = "atmel,sam-usart";
-			reg = <0x400A4000 0x130>;
+			reg = <0x400a4000 0x130>;
 			interrupts = <20 0>;
 			peripheral-id = <20>;
 			status = "disabled";

--- a/dts/arm/atmel/sam4s.dtsi
+++ b/dts/arm/atmel/sam4s.dtsi
@@ -31,9 +31,9 @@
 	};
 
 	soc {
-		wdog: watchdog@400E1450 {
+		wdog: watchdog@400e1450 {
 			compatible = "atmel,sam-watchdog";
-			reg = <0x400E1450 0xc>;
+			reg = <0x400e1450 0xc>;
 			interrupts = <4 0>;
 			peripheral-id = <4>;
 			label = "WATCHDOG_0";
@@ -49,28 +49,28 @@
 			status = "disabled";
 		};
 
-		i2c1: i2c@4001C000 {
+		i2c1: i2c@4001c000 {
 			compatible = "atmel,sam-i2c-twi";
 			clock-frequency = <I2C_BITRATE_STANDARD>;
-			reg = <0x4001C000 0x128>;
+			reg = <0x4001c000 0x128>;
 			interrupts = <20 0>;
 			peripheral-id = <20>;
 			label = "I2C_1";
 			status = "disabled";
 		};
 
-		uart0: uart@400E0600 {
+		uart0: uart@400e0600 {
 			compatible = "atmel,sam-uart";
-			reg = <0x400E0600 0x200>;
+			reg = <0x400e0600 0x200>;
 			interrupts = <8 1>;
 			peripheral-id = <8>;
 			status = "disabled";
 			label = "UART_0";
 		};
 
-		uart1: uart@400E0800 {
+		uart1: uart@400e0800 {
 			compatible = "atmel,sam-uart";
-			reg = <0x400E0800 0x200>;
+			reg = <0x400e0800 0x200>;
 			interrupts = <9 1>;
 			peripheral-id = <9>;
 			status = "disabled";
@@ -95,9 +95,9 @@
 			label = "USART_1";
 		};
 
-		porta: gpio@400E0E00 {
+		porta: gpio@400e0e00 {
 			compatible = "atmel,sam-gpio";
-			reg = <0x400E0E00 0x190>;
+			reg = <0x400e0e00 0x190>;
 			interrupts = <11 1>;
 			peripheral-id = <11>;
 			label = "PORTA";
@@ -105,9 +105,9 @@
 			#gpio-cells = <2>;
 		};
 
-		portb: gpio@400E1000 {
+		portb: gpio@400e1000 {
 			compatible = "atmel,sam-gpio";
-			reg = <0x400E1000 0x190>;
+			reg = <0x400e1000 0x190>;
 			interrupts = <12 1>;
 			peripheral-id = <12>;
 			label = "PORTB";
@@ -115,9 +115,9 @@
 			#gpio-cells = <2>;
 		};
 
-		portc: gpio@400E1200 {
+		portc: gpio@400e1200 {
 			compatible = "atmel,sam-gpio";
-			reg = <0x400E1200 0x190>;
+			reg = <0x400e1200 0x190>;
 			interrupts = <13 1>;
 			peripheral-id = <13>;
 			label = "PORTC";

--- a/dts/arm/atmel/samd.dtsi
+++ b/dts/arm/atmel/samd.dtsi
@@ -102,9 +102,9 @@
 			label = "SERCOM4";
 		};
 
-		sercom5: sercom@42001C00 {
+		sercom5: sercom@42001c00 {
 			compatible = "atmel,sam0-sercom";
-			reg = <0x42001C00 0x40>;
+			reg = <0x42001c00 0x40>;
 			interrupts = <14 0>;
 			status = "disabled";
 			label = "SERCOM5";

--- a/dts/arm/atmel/same70.dtsi
+++ b/dts/arm/atmel/same70.dtsi
@@ -32,9 +32,9 @@
 	};
 
 	soc {
-		wdog: watchdog@400E1850 {
+		wdog: watchdog@400e1850 {
 			compatible = "atmel,sam-watchdog";
-			reg = <0x400E1850 0xc>;
+			reg = <0x400e1850 0xc>;
 			interrupts = <4 0>;
 			peripheral-id = <4>;
 			label = "WATCHDOG_0";
@@ -53,12 +53,12 @@
 			status = "disabled";
 		};
 
-		i2c1: i2c@4001C000 {
+		i2c1: i2c@4001c000 {
 			compatible = "atmel,sam-i2c-twihs";
 			clock-frequency = <I2C_BITRATE_STANDARD>;
 			#address-cells = <1>;
 			#size-cells = <0>;
-			reg = <0x4001C000 0x12B>;
+			reg = <0x4001c000 0x12B>;
 			interrupts = <20 0>;
 			peripheral-id = <20>;
 			label = "I2C_1";
@@ -99,45 +99,45 @@
 			status = "disabled";
 		};
 
-		uart0: uart@400E0800 {
+		uart0: uart@400e0800 {
 			compatible = "atmel,sam-uart";
-			reg = <0x400E0800 0x100>;
+			reg = <0x400e0800 0x100>;
 			interrupts = <7 1>;
 			peripheral-id = <7>;
 			status = "disabled";
 			label = "UART_0";
 		};
 
-		uart1: uart@400E0A00 {
+		uart1: uart@400e0a00 {
 			compatible = "atmel,sam-uart";
-			reg = <0x400E0A00 0x100>;
+			reg = <0x400e0a00 0x100>;
 			interrupts = <8 1>;
 			peripheral-id = <8>;
 			status = "disabled";
 			label = "UART_1";
 		};
 
-		uart2: uart@400E1A00 {
+		uart2: uart@400e1a00 {
 			compatible = "atmel,sam-uart";
-			reg = <0x400E1A00 0x100>;
+			reg = <0x400e1a00 0x100>;
 			interrupts = <44 1>;
 			peripheral-id = <44>;
 			status = "disabled";
 			label = "UART_2";
 		};
 
-		uart3: uart@400E1C00 {
+		uart3: uart@400e1c00 {
 			compatible = "atmel,sam-uart";
-			reg = <0x400E1C00 0x100>;
+			reg = <0x400e1c00 0x100>;
 			interrupts = <45 1>;
 			peripheral-id = <45>;
 			status = "disabled";
 			label = "UART_3";
 		};
 
-		uart4: uart@400E1E00 {
+		uart4: uart@400e1e00 {
 			compatible = "atmel,sam-uart";
-			reg = <0x400E1E00 0x100>;
+			reg = <0x400e1e00 0x100>;
 			interrupts = <46 1>;
 			peripheral-id = <46>;
 			status = "disabled";
@@ -162,18 +162,18 @@
 			label = "USART_1";
 		};
 
-		usart2: usart@4002C000 {
+		usart2: usart@4002c000 {
 			compatible = "atmel,sam-usart";
-			reg = <0x4002C000 0x100>;
+			reg = <0x4002c000 0x100>;
 			interrupts = <15 0>;
 			peripheral-id = <15>;
 			status = "disabled";
 			label = "USART_2";
 		};
 
-		adc0: adc@4003C000 {
+		adc0: adc@4003c000 {
 			compatible = "atmel,sam-afec";
-			reg = <0x4003C000 0x100>;
+			reg = <0x4003c000 0x100>;
 			interrupts = <29 0>;
 			peripheral-id = <29>;
 			status = "disabled";
@@ -189,9 +189,9 @@
 			label = "ADC_1";
 		};
 
-		porta: gpio@400E0E00 {
+		porta: gpio@400e0e00 {
 			compatible = "atmel,sam-gpio";
-			reg = <0x400E0E00 0x190>;
+			reg = <0x400e0e00 0x190>;
 			interrupts = <10 1>;
 			peripheral-id = <10>;
 			label = "PORTA";
@@ -199,9 +199,9 @@
 			#gpio-cells = <2>;
 		};
 
-		portb: gpio@400E1000 {
+		portb: gpio@400e1000 {
 			compatible = "atmel,sam-gpio";
-			reg = <0x400E1000 0x190>;
+			reg = <0x400e1000 0x190>;
 			interrupts = <11 1>;
 			peripheral-id = <11>;
 			label = "PORTB";
@@ -209,9 +209,9 @@
 			#gpio-cells = <2>;
 		};
 
-		portc: gpio@400E1200 {
+		portc: gpio@400e1200 {
 			compatible = "atmel,sam-gpio";
-			reg = <0x400E1200 0x190>;
+			reg = <0x400e1200 0x190>;
 			interrupts = <12 1>;
 			peripheral-id = <12>;
 			label = "PORTC";
@@ -219,9 +219,9 @@
 			#gpio-cells = <2>;
 		};
 
-		portd: gpio@400E1400 {
+		portd: gpio@400e1400 {
 			compatible = "atmel,sam-gpio";
-			reg = <0x400E1400 0x190>;
+			reg = <0x400e1400 0x190>;
 			interrupts = <16 1>;
 			peripheral-id = <16>;
 			label = "PORTD";
@@ -229,9 +229,9 @@
 			#gpio-cells = <2>;
 		};
 
-		porte: gpio@400E1600 {
+		porte: gpio@400e1600 {
 			compatible = "atmel,sam-gpio";
-			reg = <0x400E1600 0x190>;
+			reg = <0x400e1600 0x190>;
 			interrupts = <17 1>;
 			peripheral-id = <17>;
 			label = "PORTE";

--- a/dts/arm/nordic/nrf52840.dtsi
+++ b/dts/arm/nordic/nrf52840.dtsi
@@ -151,11 +151,11 @@
 			label = "SPI_2";
 		};
 
-		spi3: spi@4002B000 {
+		spi3: spi@4002b000 {
 			compatible = "nordic,nrf-spi";
 			#address-cells = <1>;
 			#size-cells = <0>;
-			reg = <0x4002B000 0x1000>;
+			reg = <0x4002b000 0x1000>;
 			interrupts = <47 1>;
 			status = "disabled";
 			label = "SPI_3";

--- a/dts/arm/nxp/nxp_imx6sx_m4.dtsi
+++ b/dts/arm/nxp/nxp_imx6sx_m4.dtsi
@@ -27,10 +27,10 @@
 		};
 	};
 
-	tcml:memory@1FFF8000 {
+	tcml:memory@1fff8000 {
 		device_type = "memory";
 		compatible = "nxp,imx-code-bus";
-		reg = <0x1FFF8000 0x00008000>;
+		reg = <0x1fff8000 0x00008000>;
 		label = "TCML";
 	};
 
@@ -41,10 +41,10 @@
 		label = "TCMU";
 	};
 
-	ocram_s:memory@208F8000 {
+	ocram_s:memory@208f8000 {
 		device_type = "memory";
 		compatible = "nxp,imx-sys-bus";
-		reg = <0x208F8000 0x00004000>;
+		reg = <0x208f8000 0x00004000>;
 		label = "OCRAM_S";
 	};
 
@@ -84,9 +84,9 @@
 			status = "disabled";
 		};
 
-		uart2:uart@421E8000 {
+		uart2:uart@421e8000 {
 			compatible = "nxp,imx-uart";
-			reg = <0x421E8000 0x00004000>;
+			reg = <0x421e8000 0x00004000>;
 			interrupts = <27 0>;
 			rdc = <(RDC_DOMAIN_PERM(A9_DOMAIN_ID,\
 					       RDC_DOMAIN_PERM_RW)|\
@@ -96,9 +96,9 @@
 			status = "disabled";
 		};
 
-		uart3:uart@421EC000 {
+		uart3:uart@421ec000 {
 			compatible = "nxp,imx-uart";
-			reg = <0x421EC000 0x00004000>;
+			reg = <0x421ec000 0x00004000>;
 			interrupts = <28 0>;
 			rdc = <(RDC_DOMAIN_PERM(A9_DOMAIN_ID,\
 					       RDC_DOMAIN_PERM_RW)|\
@@ -108,9 +108,9 @@
 			status = "disabled";
 		};
 
-		uart4:uart@421F0000 {
+		uart4:uart@421f0000 {
 			compatible = "nxp,imx-uart";
-			reg = <0x421F0000 0x00004000>;
+			reg = <0x421f0000 0x00004000>;
 			interrupts = <29 0>;
 			rdc = <(RDC_DOMAIN_PERM(A9_DOMAIN_ID,\
 					       RDC_DOMAIN_PERM_RW)|\
@@ -120,9 +120,9 @@
 			status = "disabled";
 		};
 
-		uart5:uart@421F4000 {
+		uart5:uart@421f4000 {
 			compatible = "nxp,imx-uart";
-			reg = <0x421F4000 0x00004000>;
+			reg = <0x421f4000 0x00004000>;
 			interrupts = <30 0>;
 			rdc = <(RDC_DOMAIN_PERM(A9_DOMAIN_ID,\
 					       RDC_DOMAIN_PERM_RW)|\
@@ -132,9 +132,9 @@
 			status = "disabled";
 		};
 
-		uart6:uart@422A0000 {
+		uart6:uart@422a0000 {
 			compatible = "nxp,imx-uart";
-			reg = <0x422A0000 0x00004000>;
+			reg = <0x422a0000 0x00004000>;
 			interrupts = <17 0>;
 			rdc = <(RDC_DOMAIN_PERM(A9_DOMAIN_ID,\
 					       RDC_DOMAIN_PERM_RW)|\
@@ -144,9 +144,9 @@
 			status = "disabled";
 		};
 
-		gpio1:gpio@4209C000 {
+		gpio1:gpio@4209c000 {
 			compatible = "nxp,imx-gpio";
-			reg = <0x4209C000 0x4000>;
+			reg = <0x4209c000 0x4000>;
 			interrupts = <66 0>, <67 0>;
 			rdc = <(RDC_DOMAIN_PERM(A9_DOMAIN_ID,\
 					       RDC_DOMAIN_PERM_RW)|\
@@ -158,9 +158,9 @@
 			status = "disabled";
 		};
 
-		gpio2:gpio@420A0000 {
+		gpio2:gpio@420a0000 {
 			compatible = "nxp,imx-gpio";
-			reg = <0x420A0000 0x4000>;
+			reg = <0x420a0000 0x4000>;
 			interrupts = <68 0>, <69 0>;
 			rdc = <(RDC_DOMAIN_PERM(A9_DOMAIN_ID,\
 					       RDC_DOMAIN_PERM_RW)|\
@@ -172,9 +172,9 @@
 			status = "disabled";
 		};
 
-		gpio3:gpio@420A4000 {
+		gpio3:gpio@420a4000 {
 			compatible = "nxp,imx-gpio";
-			reg = <0x420A4000 0x4000>;
+			reg = <0x420a4000 0x4000>;
 			interrupts = <70 0>, <71 0>;
 			rdc = <(RDC_DOMAIN_PERM(A9_DOMAIN_ID,\
 					       RDC_DOMAIN_PERM_RW)|\
@@ -186,9 +186,9 @@
 			status = "disabled";
 		};
 
-		gpio4:gpio@420A8000 {
+		gpio4:gpio@420a8000 {
 			compatible = "nxp,imx-gpio";
-			reg = <0x420A8000 0x4000>;
+			reg = <0x420a8000 0x4000>;
 			interrupts = <72 0>, <73 0>;
 			rdc = <(RDC_DOMAIN_PERM(A9_DOMAIN_ID,\
 					       RDC_DOMAIN_PERM_RW)|\
@@ -200,9 +200,9 @@
 			status = "disabled";
 		};
 
-		gpio5:gpio@420AC000 {
+		gpio5:gpio@420ac000 {
 			compatible = "nxp,imx-gpio";
-			reg = <0x420AC000 0x4000>;
+			reg = <0x420ac000 0x4000>;
 			interrupts = <74 0>, <74 0>;
 			rdc = <(RDC_DOMAIN_PERM(A9_DOMAIN_ID,\
 					       RDC_DOMAIN_PERM_RW)|\
@@ -214,9 +214,9 @@
 			status = "disabled";
 		};
 
-		gpio6:gpio@420B0000 {
+		gpio6:gpio@420b0000 {
 			compatible = "nxp,imx-gpio";
-			reg = <0x420B0000 0x4000>;
+			reg = <0x420b0000 0x4000>;
 			interrupts = <76 0>, <77 0>;
 			rdc = <(RDC_DOMAIN_PERM(A9_DOMAIN_ID,\
 					       RDC_DOMAIN_PERM_RW)|\
@@ -228,9 +228,9 @@
 			status = "disabled";
 		};
 
-		gpio7:gpio@420B4000 {
+		gpio7:gpio@420b4000 {
 			compatible = "nxp,imx-gpio";
-			reg = <0x420B4000 0x4000>;
+			reg = <0x420b4000 0x4000>;
 			interrupts = <78 0>, <79 0>;
 			rdc = <(RDC_DOMAIN_PERM(A9_DOMAIN_ID,\
 					       RDC_DOMAIN_PERM_RW)|\

--- a/dts/arm/nxp/nxp_imx7d_m4.dtsi
+++ b/dts/arm/nxp/nxp_imx7d_m4.dtsi
@@ -212,9 +212,9 @@
 			status = "disabled";
 		};
 
-		uart4: uart@30A60000 {
+		uart4: uart@30a60000 {
 			compatible = "nxp,imx-uart";
-			reg = <0x30A60000 0x10000>;
+			reg = <0x30a60000 0x10000>;
 			interrupts = <29 3>;
 			rdc = <(RDC_DOMAIN_PERM(A7_DOMAIN_ID,\
 					       RDC_DOMAIN_PERM_RW)|\
@@ -224,9 +224,9 @@
 			status = "disabled";
 		};
 
-		uart5: uart@30A70000 {
+		uart5: uart@30a70000 {
 			compatible = "nxp,imx-uart";
-			reg = <0x30A70000 0x10000>;
+			reg = <0x30a70000 0x10000>;
 			interrupts = <30 3>;
 			rdc = <(RDC_DOMAIN_PERM(A7_DOMAIN_ID,\
 					       RDC_DOMAIN_PERM_RW)|\
@@ -236,9 +236,9 @@
 			status = "disabled";
 		};
 
-		uart6: uart@30A80000 {
+		uart6: uart@30a80000 {
 			compatible = "nxp,imx-uart";
-			reg = <0x30A80000 0x10000>;
+			reg = <0x30a80000 0x10000>;
 			interrupts = <16 3>;
 			rdc = <(RDC_DOMAIN_PERM(A7_DOMAIN_ID,\
 					       RDC_DOMAIN_PERM_RW)|\
@@ -248,9 +248,9 @@
 			status = "disabled";
 		};
 
-		uart7: uart@30A90000 {
+		uart7: uart@30a90000 {
 			compatible = "nxp,imx-uart";
-			reg = <0x30A90000 0x10000>;
+			reg = <0x30a90000 0x10000>;
 			interrupts = <126 3>;
 			rdc = <(RDC_DOMAIN_PERM(A7_DOMAIN_ID,\
 					       RDC_DOMAIN_PERM_RW)|\
@@ -260,12 +260,12 @@
 			status = "disabled";
 		};
 
-		i2c1: i2c@30A20000 {
+		i2c1: i2c@30a20000 {
 			compatible = "fsl,imx7d-i2c";
 			clock-frequency = <I2C_BITRATE_STANDARD>;
 			#address-cells = <1>;
 			#size-cells = <0>;
-			reg = <0x30A20000 0x10000>;
+			reg = <0x30a20000 0x10000>;
 			interrupts = <35 0>;
 			rdc = <(RDC_DOMAIN_PERM(A7_DOMAIN_ID,\
 					       RDC_DOMAIN_PERM_RW)|\
@@ -275,12 +275,12 @@
 			status = "disabled";
 		};
 
-		i2c2: i2c@30A30000 {
+		i2c2: i2c@30a30000 {
 			compatible = "fsl,imx7d-i2c";
 			clock-frequency = <I2C_BITRATE_STANDARD>;
 			#address-cells = <1>;
 			#size-cells = <0>;
-			reg = <0x30A30000 0x10000>;
+			reg = <0x30a30000 0x10000>;
 			interrupts = <36 0>;
 			rdc = <(RDC_DOMAIN_PERM(A7_DOMAIN_ID,\
 					       RDC_DOMAIN_PERM_RW)|\
@@ -290,12 +290,12 @@
 			status = "disabled";
 		};
 
-		i2c3: i2c@30A40000 {
+		i2c3: i2c@30a40000 {
 			compatible = "fsl,imx7d-i2c";
 			clock-frequency = <I2C_BITRATE_STANDARD>;
 			#address-cells = <1>;
 			#size-cells = <0>;
-			reg = <0x30A40000 0x10000>;
+			reg = <0x30a40000 0x10000>;
 			interrupts = <37 0>;
 			rdc = <(RDC_DOMAIN_PERM(A7_DOMAIN_ID,\
 					       RDC_DOMAIN_PERM_RW)|\
@@ -305,12 +305,12 @@
 			status = "disabled";
 		};
 
-		i2c4: i2c@30A50000 {
+		i2c4: i2c@30a50000 {
 			compatible = "fsl,imx7d-i2c";
 			clock-frequency = <I2C_BITRATE_STANDARD>;
 			#address-cells = <1>;
 			#size-cells = <0>;
-			reg = <0x30A50000 0x10000>;
+			reg = <0x30a50000 0x10000>;
 			interrupts = <38 0>;
 			rdc = <(RDC_DOMAIN_PERM(A7_DOMAIN_ID,\
 					       RDC_DOMAIN_PERM_RW)|\

--- a/dts/arm/nxp/nxp_k6x.dtsi
+++ b/dts/arm/nxp/nxp_k6x.dtsi
@@ -394,9 +394,9 @@
 			label = "USBD";
 		};
 
-		eth: ethernet@400C0004 {
+		eth: ethernet@400c0004 {
 			compatible = "nxp,kinetis-ethernet";
-			reg = <0x400C0004 0x620>;
+			reg = <0x400c0004 0x620>;
 			interrupts = <83 0>, <84 0>, <85 0>;
 			interrupts-names = "TX", "RX", "ERR_MISC";
 			status = "disabled";

--- a/dts/arm/nxp/nxp_kl25z.dtsi
+++ b/dts/arm/nxp/nxp_kl25z.dtsi
@@ -78,9 +78,9 @@
 			#clock-cells = <3>;
 		};
 
-		uart0: uart@4006A000 {
+		uart0: uart@4006a000 {
 			compatible = "nxp,kinetis-lpsci";
-			reg = <0x4006A000 0xc>;
+			reg = <0x4006a000 0xc>;
 			interrupts = <12 0>;
 			clocks = <&sim KINETIS_SIM_CORESYS_CLK 0x1034 10>;
 			label = "UART_0";

--- a/dts/arm/nxp/nxp_lpc54xxx.dtsi
+++ b/dts/arm/nxp/nxp_lpc54xxx.dtsi
@@ -58,7 +58,7 @@
 
 		gpio0: gpio@0 {
 			compatible = "nxp,kinetis-gpio";
-			reg = <0x4008C000 0x2488>;
+			reg = <0x4008c000 0x2488>;
 			interrupts = <2 2>;
 			label = "GPIO_0";
 			gpio-controller;
@@ -74,9 +74,9 @@
 			#gpio-cells = <2>;
 		};
 
-		mailbox0:mailbox@4008B000 {
+		mailbox0:mailbox@4008b000 {
 			compatible = "nxp,lpc-mailbox";
-			reg = <0x4008B000 0xEC>;
+			reg = <0x4008b000 0xEC>;
 			interrupts = <31 0>;
 			label = "MAILBOX_0";
 			status = "disabled";

--- a/dts/arm/silabs/efr32mg.dtsi
+++ b/dts/arm/silabs/efr32mg.dtsi
@@ -62,40 +62,40 @@
 			label = "USART_2";
 		};
 
-		usart3: usart@40010C00 { /* USART3 */
+		usart3: usart@40010c00 { /* USART3 */
 			compatible = "silabs,gecko-usart";
-			reg = <0x40010C00 0x400>;
+			reg = <0x40010c00 0x400>;
 			interrupts = <43 0>, <44 0>;
 			interrupt-names = "rx", "tx";
 			status = "disabled";
 			label = "USART_3";
 		};
 
-		leuart0: leuart@4004A000 { /* LEUART0 */
+		leuart0: leuart@4004a000 { /* LEUART0 */
 			compatible = "silabs,gecko-leuart";
-			reg = <0x4004A000 0x400>;
+			reg = <0x4004a000 0x400>;
 			interrupts = <22 0>;
 			status = "disabled";
 			label = "LEUART_0";
 		};
 
-		i2c0: i2c@4000C000 {
+		i2c0: i2c@4000c000 {
 			compatible = "silabs,gecko-i2c";
 			clock-frequency = <I2C_BITRATE_STANDARD>;
 			#address-cells = <1>;
 			#size-cells = <0>;
-			reg = <0x4000C000 0x400>;
+			reg = <0x4000c000 0x400>;
 			interrupts = <17 0>;
 			label = "I2C_0";
 			status = "disabled";
 		};
 
-		i2c1: i2c@4000C400 {
+		i2c1: i2c@4000c400 {
 			compatible = "silabs,gecko-i2c";
 			clock-frequency = <I2C_BITRATE_STANDARD>;
 			#address-cells = <1>;
 			#size-cells = <0>;
-			reg = <0x4000C400 0x400>;
+			reg = <0x4000c400 0x400>;
 			interrupts = <42 0>;
 			label = "I2C_1";
 			status = "disabled";

--- a/dts/arm/st/f1/stm32f103Xe.dtsi
+++ b/dts/arm/st/f1/stm32f103Xe.dtsi
@@ -74,11 +74,11 @@
 			};
 		};
 
-		spi3: spi@40003C00 {
+		spi3: spi@40003c00 {
 			compatible = "st,stm32-spi";
 			#address-cells = <1>;
 			#size-cells = <0>;
-			reg = <0x40003C00 0x400>;
+			reg = <0X40003c00 0x400>;
 			clocks = <&rcc STM32_CLOCK_BUS_APB1 0x00008000>;
 			interrupts = <51 5>;
 			status = "disabled";

--- a/dts/arm/st/f3/stm32f302.dtsi
+++ b/dts/arm/st/f3/stm32f302.dtsi
@@ -45,11 +45,11 @@
 			label = "SPI_2";
 		};
 
-		spi3: spi@40003C00 {
+		spi3: spi@40003c00 {
 			compatible = "st,stm32-spi-fifo";
 			#address-cells = <1>;
 			#size-cells = <0>;
-			reg = <0x40003C00 0x400>;
+			reg = <0X40003c00 0x400>;
 			clocks = <&rcc STM32_CLOCK_BUS_APB1 0x00008000>;
 			interrupts = <51 5>;
 			status = "disabled";

--- a/dts/arm/st/f3/stm32f373.dtsi
+++ b/dts/arm/st/f3/stm32f373.dtsi
@@ -43,11 +43,11 @@
 			label = "SPI_2";
 		};
 
-		spi3: spi@40003C00 {
+		spi3: spi@40003c00 {
 			compatible = "st,stm32-spi-fifo";
 			#address-cells = <1>;
 			#size-cells = <0>;
-			reg = <0x40003C00 0x400>;
+			reg = <0x40003c00 0x400>;
 			clocks = <&rcc STM32_CLOCK_BUS_APB1 0x00008000>;
 			interrupts = <51 5>;
 			status = "disabled";

--- a/dts/arm/st/f4/stm32f4.dtsi
+++ b/dts/arm/st/f4/stm32f4.dtsi
@@ -168,12 +168,12 @@
 			label= "I2C_2";
 		};
 
-		i2c3: i2c@40005C00 {
+		i2c3: i2c@40005c00 {
 			compatible = "st,stm32-i2c-v1";
 			clock-frequency = <I2C_BITRATE_STANDARD>;
 			#address-cells = <1>;
 			#size-cells = <0>;
-			reg = <0x40005C00 0x400>;
+			reg = <0x40005c00 0x400>;
 			clocks = <&rcc STM32_CLOCK_BUS_APB1 0x00800000>;
 			interrupts = <72 0>, <73 0>;
 			interrupt-names = "event", "error";

--- a/dts/arm/st/f4/stm32f401.dtsi
+++ b/dts/arm/st/f4/stm32f401.dtsi
@@ -19,11 +19,11 @@
 			label = "SPI_2";
 		};
 
-		spi3: spi@40003C00 {
+		spi3: spi@40003c00 {
 			compatible = "st,stm32-spi";
 			#address-cells = <1>;
 			#size-cells = <0>;
-			reg = <0x40003C00 0x400>;
+			reg = <0x40003c00 0x400>;
 			clocks = <&rcc STM32_CLOCK_BUS_APB1 0x00008000>;
 			interrupts = <51 5>;
 			status = "disabled";
@@ -39,9 +39,9 @@
 			label = "I2S_2";
 		};
 
-		i2s3: i2s@40003C00 {
+		i2s3: i2s@40003c00 {
 			compatible = "st,stm32-i2s";
-			reg = <0x40003C00 0x400>;
+			reg = <0x40003c00 0x400>;
 			clocks = <&rcc STM32_CLOCK_BUS_APB1 0x00008000>;
 			interrupts = <51 5>;
 			status = "disabled";

--- a/dts/arm/st/f7/stm32f7.dtsi
+++ b/dts/arm/st/f7/stm32f7.dtsi
@@ -193,9 +193,9 @@
 			label = "UART_7";
 		};
 
-		uart8: serial@40007C00 {
+		uart8: serial@40007c00 {
 			compatible = "st,stm32-uart";
-			reg = <0x40007C00 0x400>;
+			reg = <0x40007c00 0x400>;
 			clocks = <&rcc STM32_CLOCK_BUS_APB1 0x80000000>;
 			interrupts = <83 0>;
 			status = "disabled";
@@ -228,12 +228,12 @@
 			label = "I2C_2";
 		};
 
-		i2c3: i2c@40005C00 {
+		i2c3: i2c@40005c00 {
 			compatible = "st,stm32-i2c-v2";
 			clock-frequency = <I2C_BITRATE_STANDARD>;
 			#address-cells = <1>;
 			#size-cells = <0>;
-			reg = <0x40005C00 0x400>;
+			reg = <0x40005c00 0x400>;
 			clocks = <&rcc STM32_CLOCK_BUS_APB1 0x00800000>;
 			interrupts = <72 0>, <73 0>;
 			interrupt-names = "event", "error";
@@ -263,11 +263,11 @@
 			label = "SPI_2";
 		};
 
-		spi3: spi@40003C00 {
+		spi3: spi@40003c00 {
 			compatible = "st,stm32-spi";
 			#address-cells = <1>;
 			#size-cells = <0>;
-			reg = <0x40003C00 0x400>;
+			reg = <0x40003c00 0x400>;
 			clocks = <&rcc STM32_CLOCK_BUS_APB1 0x00008000>;
 			interrupts = <51 5>;
 			status = "disabled";

--- a/dts/arm/st/l4/stm32l4.dtsi
+++ b/dts/arm/st/l4/stm32l4.dtsi
@@ -147,12 +147,12 @@
 			label= "I2C_1";
 		};
 
-		i2c3: i2c@40005C00 {
+		i2c3: i2c@40005c00 {
 			compatible = "st,stm32-i2c-v2";
 			clock-frequency = <I2C_BITRATE_STANDARD>;
 			#address-cells = <1>;
 			#size-cells = <0>;
-			reg = <0x40005C00 0x400>;
+			reg = <0x40005c00 0x400>;
 			clocks = <&rcc STM32_CLOCK_BUS_APB1 0x00800000>;
 			interrupts = <72 0>, <73 0>;
 			interrupt-names = "event", "error";

--- a/dts/arm/st/l4/stm32l475.dtsi
+++ b/dts/arm/st/l4/stm32l475.dtsi
@@ -78,11 +78,11 @@
 			label= "I2C_2";
 		};
 
-		spi3: spi@40003C00 {
+		spi3: spi@40003c00 {
 			compatible = "st,stm32-spi-fifo";
 			#address-cells = <1>;
 			#size-cells = <0>;
-			reg = <0x40003C00 0x400>;
+			reg = <0x40003c00 0x400>;
 			clocks = <&rcc STM32_CLOCK_BUS_APB1 0x00008000>;
 			interrupts = <51 5>;
 			status = "disabled";

--- a/dts/arm/st/l4/stm32l4r5.dtsi
+++ b/dts/arm/st/l4/stm32l4r5.dtsi
@@ -88,11 +88,11 @@
 			label= "I2C_4";
 		};
 
-		spi3: spi@40003C00 {
+		spi3: spi@40003c00 {
 			compatible = "st,stm32-spi-fifo";
 			#address-cells = <1>;
 			#size-cells = <0>;
-			reg = <0x40003C00 0x400>;
+			reg = <0x40003c00 0x400>;
 			interrupts = <51 5>;
 			status = "disabled";
 			label = "SPI_3";

--- a/dts/arm/ti/cc32xx.dtsi
+++ b/dts/arm/ti/cc32xx.dtsi
@@ -39,17 +39,17 @@
 	};
 
 	soc {
-		uart0: uart@4000C000 {
+		uart0: uart@4000c000 {
 			compatible = "ti,cc32xx-uart";
-			reg = <0x4000C000 0x4c>;
+			reg = <0x4000c000 0x4c>;
 			interrupts = <EXP_UARTA0 3>;
 			status = "disabled";
 			label = "UART_0";
 		};
 
-		uart1: uart@4000D000 {
+		uart1: uart@4000d000 {
 			compatible = "ti,cc32xx-uart";
-			reg = <0x4000D000 0x4c>;
+			reg = <0x4000d000 0x4c>;
 			interrupts = <EXP_UARTA1 3>;
 			status = "disabled";
 			label = "UART_1";

--- a/dts/arm/ti/lm3s6965.dtsi
+++ b/dts/arm/ti/lm3s6965.dtsi
@@ -24,25 +24,25 @@
 	};
 
 	soc {
-		uart0: uart@4000C000 {
+		uart0: uart@4000c000 {
 			compatible = "ti,stellaris-uart";
-			reg = <0x4000C000 0x4c>;
+			reg = <0x4000c000 0x4c>;
 			interrupts = <5 3>;
 			status = "disabled";
 			label = "UART_0";
 		};
 
-		uart1: uart@4000D000 {
+		uart1: uart@4000d000 {
 			compatible = "ti,stellaris-uart";
-			reg = <0x4000D000 0x4c>;
+			reg = <0x4000d000 0x4c>;
 			interrupts = <6 3>;
 			status = "disabled";
 			label = "UART_1";
 		};
 
-		uart2: uart@4000E000 {
+		uart2: uart@4000e000 {
 			compatible = "ti,stellaris-uart";
-			reg = <0x4000E000 0x4c>;
+			reg = <0x4000e000 0x4c>;
 			interrupts = <33 3>;
 			status = "disabled";
 			label = "UART_2";


### PR DESCRIPTION
Newer DTC now warns about mismatch between the reg and unit-address.
Most of these cases are due to case not matching, so fix thoses so
everything is lowercase.

Signed-off-by: Kumar Gala <kumar.gala@linaro.org>