### PR TITLE
samples: reel_board: Change a DTS-derived label to the alias one

### DIFF
--- a/samples/boards/reel_board/mesh_badge/src/reel_board.c
+++ b/samples/boards/reel_board/mesh_badge/src/reel_board.c
@@ -408,7 +408,7 @@ static int configure_button(void)
 {
 	static struct gpio_callback button_cb;
 
-	gpio = device_get_binding(GPIO_KEYS_BUTTON_0_GPIO_CONTROLLER);
+	gpio = device_get_binding(SW0_GPIO_CONTROLLER);
 	if (!gpio) {
 		return -ENODEV;
 	}


### PR DESCRIPTION
Change the label GPIO_KEYS_BUTTON_0_GPIO_CONTROLLER that is generated
for the DT node directly to the corresponding one generated through
the "sw0" alias (i.e. SW0_GPIO_CONTROLLER) to make it consistent with
other DT related labels used in this code (SW0_* and LED?_*).

Pulled out from #11180 as [suggested](https://github.com/zephyrproject-rtos/zephyr/pull/11180#issuecomment-437062471) there.