### PR TITLE
boards: nrf52840_pca10056: Fix SPI pin assignment conflicts

### DIFF
--- a/boards/arm/nrf52840_pca10056/nrf52840_pca10056.dts
+++ b/boards/arm/nrf52840_pca10056/nrf52840_pca10056.dts
@@ -150,16 +150,16 @@
 
 &spi2 {
 	status = "ok";
-	sck-pin = <43>;
-	mosi-pin = <44>;
-	miso-pin = <45>;
+	sck-pin = <37>;
+	mosi-pin = <38>;
+	miso-pin = <39>;
 };
 
 &spi3 {
 	status = "ok";
-	sck-pin = <42>;
-	mosi-pin = <41>;
-	miso-pin = <20>;
+	sck-pin = <41>;
+	mosi-pin = <42>;
+	miso-pin = <43>;
 };
 
 &flash0 {


### PR DESCRIPTION
Removed pin 20 which by default is connected to QSPI memory.
Removed conflict with default pin assignment for UART 1.

Signed-off-by: Filip Kubicz <filip.kubicz@nordicsemi.no>