### PR TITLE
scripts/dts/extract: reg.py: Flatten reg instead of props

### DIFF
--- a/scripts/dts/extract/reg.py
+++ b/scripts/dts/extract/reg.py
@@ -45,8 +45,8 @@ class DTReg(DTDirective):
         # Newer versions of dtc might have the reg propertly look like
         # reg = <1 2>, <3 4>;
         # So we need to flatten the list in that case
-        if isinstance(props[0], list):
-            props = [item for sublist in props for item in sublist]
+        if isinstance(reg[0], list):
+            reg = [item for sublist in reg for item in sublist]
 
         (nr_address_cells, nr_size_cells) = get_addr_size_cells(node_address)
 


### PR DESCRIPTION
Flatten reg instead of props


Signed-off-by: Erwan Gouriou <erwan.gouriou@linaro.org>