### PR TITLE
dts: intel_s1000: update SRAM size to 4MB

### DIFF
--- a/dts/xtensa/intel_s1000.dtsi
+++ b/dts/xtensa/intel_s1000.dtsi
@@ -30,7 +30,7 @@
 	sram0: memory@be000000 {
 		device_type = "memory";
 		compatible = "mmio-sram";
-		reg = <0xbe000000 0x300000>;
+		reg = <0xbe000000 0x400000>;
 	};
 
 	soc {


### PR DESCRIPTION
Intel S1000 has 4MB of internal memory while it was defined as 3MB in DTS.