### PR TITLE
Fix handling of coverage in sanitycheck

### DIFF
--- a/scripts/sanitycheck
+++ b/scripts/sanitycheck
@@ -1015,7 +1015,7 @@ class MakeGenerator:
             handler = DeviceHandler(instance)
 
         if options.enable_coverage:
-            args += ["COVERAGE=1", "EXTRA_LDFLAGS=--coverage"]
+            args += ["EXTRA_LDFLAGS=--coverage"]
             args += ["CONFIG_COVERAGE=y"]
 
         if type == 'qemu':
@@ -1839,7 +1839,7 @@ class TestSuite:
                         # each other since they all try to build them
                         # simultaneously
 
-                        if plat.type == "native" and options.enable_coverage:
+                        if options.enable_coverage:
                             args.append("CONFIG_COVERAGE=y")
 
                         o = os.path.join(self.outdir, plat.name, tc.path)
@@ -2553,13 +2553,10 @@ def parse_arguments():
     )
 
     parser.add_argument("--enable-coverage", action="store_true",
-                        help="Enable code coverage when building unit tests and"
-                        " when targeting the native_posix board")
+                        help="Enable code coverage using gcov.")
 
     parser.add_argument("-C", "--coverage", action="store_true",
-                        help="Generate coverage report for unit tests, and"
-                        " tests and samples run in native_posix. Implies"
-                        " --enable_coverage")
+                        help="Generate coverage reports. Implies --enable_coverage")
 
     return parser.parse_args()
 

--- a/scripts/sanitycheck
+++ b/scripts/sanitycheck
@@ -1016,7 +1016,6 @@ class MakeGenerator:
 
         if options.enable_coverage:
             args += ["EXTRA_LDFLAGS=--coverage"]
-            args += ["CONFIG_COVERAGE=y"]
 
         if type == 'qemu':
             args.append("QEMU_PIPE=%s" % handler.get_fifo())
@@ -1042,9 +1041,12 @@ class MakeGenerator:
             by execute() will be keyed by its .name field.
         """
         args = ti.test.extra_args[:]
-        if len(ti.test.extra_configs) > 0:
+        if len(ti.test.extra_configs) > 0 or options.coverage:
             args.append("OVERLAY_CONFIG=%s" %
                         os.path.join(ti.outdir, "overlay.conf"))
+
+        if ti.test.type == "unit" and options.enable_coverage:
+            args.append("COVERAGE=1")
 
         args.append("BOARD={}".format(ti.platform.name))
         args.extend(extra_args)
@@ -1541,14 +1543,18 @@ class TestInstance:
         self.results = {}
 
     def create_overlay(self):
+        file = os.path.join(self.outdir, "overlay.conf")
+        os.makedirs(self.outdir, exist_ok=True)
+        f = open(file, "w")
+        content = ""
+
         if len(self.test.extra_configs) > 0:
-            file = os.path.join(self.outdir, "overlay.conf")
-            os.makedirs(self.outdir, exist_ok=True)
-            f = open(file, "w")
-            content = ""
             content = "\n".join(self.test.extra_configs)
-            f.write(content)
-            f.close()
+        if options.enable_coverage:
+            content = content + "\nCONFIG_COVERAGE=y"
+
+        f.write(content)
+        f.close()
 
     def calculate_sizes(self):
         """Get the RAM/ROM sizes of a test case.
@@ -1838,9 +1844,6 @@ class TestSuite:
                         # need a way to avoid different Make processes from clobbering
                         # each other since they all try to build them
                         # simultaneously
-
-                        if options.enable_coverage:
-                            args.append("CONFIG_COVERAGE=y")
 
                         o = os.path.join(self.outdir, plat.name, tc.path)
                         dlist[tc, plat, tc.name.split("/")[-1]] = os.path.join(o, "zephyr", ".config")
@@ -2668,7 +2671,7 @@ def generate_coverage(outdir, ignores):
                          "--output-file", ztestfile,
                          "--rc", "lcov_branch_coverage=1"], stdout=coveragelog)
 
-        if os.path.getsize(ztestfile) > 0:
+        if os.path.exists(ztestfile) and os.path.getsize(ztestfile) > 0:
             subprocess.call(["lcov", "--remove", ztestfile,
                              os.path.join(ZEPHYR_BASE, "tests/ztest/test/*"),
                              "--output-file", ztestfile,

--- a/scripts/sanitycheck
+++ b/scripts/sanitycheck
@@ -2946,7 +2946,7 @@ def main():
 
     if options.coverage:
         info("Generating coverage files...")
-        generate_coverage(options.outdir, ["tests/*", "samples/*"])
+        generate_coverage(options.outdir, ["*generated*", "tests/*", "samples/*"])
 
     duration = time.time() - start_time
     info("%s%d of %d%s tests passed with %s%d%s warnings in %d seconds" %


### PR DESCRIPTION
Do no force CONFIG_CONFIG throuh CMake, use overlays instead.