### PR TITLE
boards: olimexino_stm32: Conform to default configuration guidelines

### DIFF
--- a/boards/arm/olimexino_stm32/olimexino_stm32.dts
+++ b/boards/arm/olimexino_stm32/olimexino_stm32.dts
@@ -43,6 +43,10 @@
 	};
 };
 
+uext_i2c: &i2c2 {};
+uext_spi: &spi1 {};
+uext_serial: &usart1 {};
+
 &usart1 {
 	current-speed = <115200>;
 	pinctrl-0 = <&usart1_pins_a>;


### PR DESCRIPTION
Update olimexino_stm32 configuration to match with default
configuration guidelines:

- Configure available connectors

Signed-off-by: Yannis Damigos <giannis.damigos@gmail.com>