### PR TITLE
subsys: shell: Print help message only if command doesn't available

### DIFF
--- a/subsys/shell/shell.c
+++ b/subsys/shell/shell.c
@@ -956,9 +956,10 @@ static int exec_cmd(const struct shell *shell, size_t argc, char **argv)
 		} else {
 			shell_fprintf(shell, SHELL_ERROR,
 				      SHELL_MSG_SPECIFY_SUBCOMMAND);
-			ret_val = -ENOEXEC;
-			goto clear;
 		}
+
+		ret_val = -ENOEXEC;
+		goto clear;
 	}
 
 	if (shell->ctx->active_cmd.args) {


### PR DESCRIPTION
Fixes: #11250

Signed-off-by: qianfan Zhao <qianfanguijin@163.com>