### PR TITLE
usb: Make USB_VBUS_GPIO a Kconfig option

### DIFF
--- a/boards/x86/arduino_101/Kconfig.defconfig
+++ b/boards/x86/arduino_101/Kconfig.defconfig
@@ -57,4 +57,17 @@ endif # SPI_FLASH_W25QXXDV
 
 endif # FLASH && SPI
 
+if USB_DEVICE_STACK
+
+config USB_VBUS_GPIO
+	def_bool y
+
+config USB_VBUS_GPIO_DEV_NAME
+	default "GPIO_0"
+
+config USB_VBUS_GPIO_PIN_NUM
+        default 28
+
+endif # USB_DEVICE_STACK
+
 endif # BOARD_ARDUINO_101

--- a/boards/x86/arduino_101/board.h
+++ b/boards/x86/arduino_101/board.h
@@ -9,11 +9,4 @@
 
 #include <soc.h>
 
-#if defined(CONFIG_USB)
-/* GPIO driver name */
-#define USB_GPIO_DRV_NAME	CONFIG_GPIO_QMSI_0_NAME
-/* GPIO pin for enabling VBUS */
-#define USB_VUSB_EN_GPIO	28
-#endif
-
 #endif /* __INC_BOARD_H */

--- a/boards/x86/quark_se_c1000_devboard/Kconfig.defconfig
+++ b/boards/x86/quark_se_c1000_devboard/Kconfig.defconfig
@@ -39,4 +39,17 @@ config IEEE802154_CC2520_GPIO_1_NAME
 
 endif # IEEE802154_CC2520
 
+if USB_DEVICE_STACK
+
+config USB_VBUS_GPIO
+	def_bool y
+
+config USB_VBUS_GPIO_DEV_NAME
+	default "GPIO_0"
+
+config USB_VBUS_GPIO_PIN_NUM
+        default 28
+
+endif # USB_DEVICE_STACK
+
 endif # BOARD_QUARK_SE_C1000_DEVBOARD

--- a/boards/x86/quark_se_c1000_devboard/board.h
+++ b/boards/x86/quark_se_c1000_devboard/board.h
@@ -21,11 +21,4 @@
 
 #endif /* CONFIG_IEEE802154_CC2520 */
 
-#if defined(CONFIG_USB)
-/* GPIO driver name */
-#define USB_GPIO_DRV_NAME	CONFIG_GPIO_QMSI_0_NAME
-/* GPIO pin for enabling VBUS */
-#define USB_VUSB_EN_GPIO	28
-#endif
-
 #endif /* __BOARD_H__ */

--- a/boards/x86/tinytile/Kconfig.defconfig
+++ b/boards/x86/tinytile/Kconfig.defconfig
@@ -18,6 +18,15 @@ config USB_DW
 config USB_DEVICE_STACK
 	def_bool y
 
+config USB_VBUS_GPIO
+	def_bool y
+
+config USB_VBUS_GPIO_DEV_NAME
+	default "GPIO_0"
+
+config USB_VBUS_GPIO_PIN_NUM
+        default 28
+
 if USB_UART_CONSOLE
 
 config UART_INTERRUPT_DRIVEN

--- a/boards/x86/tinytile/board.h
+++ b/boards/x86/tinytile/board.h
@@ -9,11 +9,4 @@
 
 #include <soc.h>
 
-#if defined(CONFIG_USB)
-/* GPIO driver name */
-#define USB_GPIO_DRV_NAME	CONFIG_GPIO_QMSI_0_NAME
-/* GPIO pin for enabling VBUS */
-#define USB_VUSB_EN_GPIO	28
-#endif
-
 #endif /* __INC_BOARD_H */

--- a/subsys/usb/Kconfig
+++ b/subsys/usb/Kconfig
@@ -66,6 +66,30 @@ config USB_DEVICE_BOS
 config USB_DEVICE_OS_DESC
 	bool "Enable MS OS Descriptors support"
 
+menuconfig USB_VBUS_GPIO
+	bool "Control VBUS via GPIO pin"
+	depends on GPIO
+	help
+	  The USB VBUS signal is connected via a GPIO pin.
+
+if USB_VBUS_GPIO
+
+config USB_VBUS_GPIO_DEV_NAME
+	string "GPIO Device"
+	default "GPIO_0"
+	help
+	  The device name of the GPIO device to which the USB_VBUS_EN signal is
+	  connected.
+
+config USB_VBUS_GPIO_PIN_NUM
+	int "GPIO pin number"
+	default 0
+	help
+	  The number of the GPIO pin to which the USB_VBUS_EN signal is
+	  connected.
+
+endif # USB_VBUS_GPIO
+
 source "subsys/usb/class/Kconfig"
 
 endif # USB_DEVICE_STACK

--- a/subsys/usb/usb_device.c
+++ b/subsys/usb/usb_device.c
@@ -61,8 +61,7 @@
 #include <misc/util.h>
 #include <misc/__assert.h>
 #include <init.h>
-#include <board.h>
-#if defined(USB_VUSB_EN_GPIO)
+#if defined(CONFIG_USB_VBUS_GPIO)
 #include <gpio.h>
 #endif
 #include <usb/usb_device.h>
@@ -894,22 +893,26 @@ static void usb_register_status_callback(usb_dc_status_callback cb)
  */
 static int usb_vbus_set(bool on)
 {
-#if defined(USB_VUSB_EN_GPIO)
+#if defined(CONFIG_USB_VBUS_GPIO)
 	int ret = 0;
-	struct device *gpio_dev = device_get_binding(USB_GPIO_DRV_NAME);
+	struct device *gpio_dev;
+
+	gpio_dev = device_get_binding(CONFIG_USB_VBUS_GPIO_DEV_NAME);
 
 	if (!gpio_dev) {
 		LOG_DBG("USB requires GPIO. Cannot find %s!",
-			USB_GPIO_DRV_NAME);
+			CONFIG_USB_VBUS_GPIO_DEV_NAME);
 		return -ENODEV;
 	}
 
 	/* Enable USB IO */
-	ret = gpio_pin_configure(gpio_dev, USB_VUSB_EN_GPIO, GPIO_DIR_OUT);
+	ret = gpio_pin_configure(gpio_dev, CONFIG_USB_VBUS_GPIO_PIN_NUM,
+				 GPIO_DIR_OUT);
 	if (ret)
 		return ret;
 
-	ret = gpio_pin_write(gpio_dev, USB_VUSB_EN_GPIO, on == true ? 1 : 0);
+	ret = gpio_pin_write(gpio_dev, CONFIG_USB_VBUS_GPIO_PIN_NUM,
+			     on == true ? 1 : 0);
 	if (ret)
 		return ret;
 #endif


### PR DESCRIPTION
Previously we had a set of magic #define's in board.h that would both
enable and set the GPIO controller & pin if a given board used a GPIO
for USB VBUS.  Now we make it a proper Kconfig set of options that
specify if the feature is needed, the GPIO controller device name, and
pin number.  In the future this should move to devicetree.

Updated the related boards that used this feature to set the Kconfig
options in the Kconfig.defconfig

Signed-off-by: Kumar Gala <kumar.gala@linaro.org>