### PR TITLE
Bluetooth: Mesh: AES-CCM: Fix output MIC with additional data

### DIFF
--- a/subsys/bluetooth/host/mesh/crypto.c
+++ b/subsys/bluetooth/host/mesh/crypto.c
@@ -267,7 +267,7 @@ static int bt_mesh_ccm_decrypt(const u8_t key[16], u8_t nonce[13],
 			}
 		}
 
-		for (i = 0; i < aad_len; i++, j++) {
+		for (; i < aad_len; i++, j++) {
 			pmsg[i] = Xn[i] ^ aad[j];
 		}
 
@@ -431,7 +431,7 @@ static int bt_mesh_ccm_encrypt(const u8_t key[16], u8_t nonce[13],
 			}
 		}
 
-		for (i = 0; i < aad_len; i++, j++) {
+		for (; i < aad_len; i++, j++) {
 			pmsg[i] = Xn[i] ^ aad[j];
 		}
 


### PR DESCRIPTION
In case of providing additional authentication data, the bt_mesh_ccm_encrypt function doesn't produce correct MIC values according to RFC3610. This fix was verified using the test vectors that comply with the required MIC sizes.
Signed-off-by: Reham Tarek <reham.tarek@si-vision.com>