### PR TITLE
Check invalid fields in ARP header

### DIFF
--- a/subsys/net/l2/ethernet/arp.c
+++ b/subsys/net/l2/ethernet/arp.c
@@ -562,6 +562,19 @@ fail:
 	return NULL;
 }
 
+static bool arp_hdr_check(struct net_arp_hdr *arp_hdr)
+{
+	if (ntohs(arp_hdr->hwtype) != NET_ARP_HTYPE_ETH ||
+	    ntohs(arp_hdr->protocol) != NET_ETH_PTYPE_IP ||
+	    arp_hdr->hwlen != sizeof(struct net_eth_addr) ||
+	    arp_hdr->protolen != NET_ARP_IPV4_PTYPE_SIZE) {
+		NET_DBG("Invalid ARP header");
+		return false;
+	}
+
+	return true;
+}
+
 enum net_verdict net_arp_input(struct net_pkt *pkt)
 {
 	struct net_arp_hdr *arp_hdr;
@@ -578,12 +591,7 @@ enum net_verdict net_arp_input(struct net_pkt *pkt)
 	}
 
 	arp_hdr = NET_ARP_HDR(pkt);
-
-	if (ntohs(arp_hdr->hwtype) != NET_ARP_HTYPE_ETH) {
-		return NET_DROP;
-	}
-
-	if (ntohs(arp_hdr->protocol) != NET_ETH_PTYPE_IP) {
+	if (!arp_hdr_check(arp_hdr)) {
 		return NET_DROP;
 	}
 

--- a/subsys/net/l2/ethernet/arp.h
+++ b/subsys/net/l2/ethernet/arp.h
@@ -38,6 +38,7 @@ struct net_arp_hdr {
 }  __packed;
 
 #define NET_ARP_HTYPE_ETH 1
+#define NET_ARP_IPV4_PTYPE_SIZE 4
 
 #define NET_ARP_REQUEST 1
 #define NET_ARP_REPLY   2


### PR DESCRIPTION
If ARP header contains invalid fields then drop the packet.

Fixes #11257
Fixes #11254
Fixes #11253
Fixes #11248

