### PR TITLE
net: promisc: Flush the promisc queue properly

### DIFF
--- a/subsys/net/ip/promiscuous.c
+++ b/subsys/net/ip/promiscuous.c
@@ -70,7 +70,7 @@ int net_promisc_mode_off(struct net_if *iface)
 		net_if_unset_promisc(iface);
 
 		prev = atomic_dec(&enabled);
-		if (!prev) {
+		if (prev == 1) {
 			atomic_clear(&enabled);
 
 			flush_queue();


### PR DESCRIPTION
Flush the promiscuous queue after all the clients have turned
off promiscuous mode. This makes sure that we do not leave any
RX packets hanging on the queue and waste memory.

Signed-off-by: Jukka Rissanen <jukka.rissanen@linux.intel.com>