### PR TITLE
drivers: eth: Free packet after sending it

### DIFF
--- a/drivers/ethernet/eth_e1000.c
+++ b/drivers/ethernet/eth_e1000.c
@@ -90,7 +90,7 @@ static int e1000_send(struct net_if *iface, struct net_pkt *pkt)
 
 	int err = e1000_tx(dev, dev->txb, len);
 
-	if (err) {
+	if (!err) {
 		net_pkt_unref(pkt);
 	}
 


### PR DESCRIPTION
The error check was wrong, if we could send the packet then
we free it. If sending fails, then let the caller to decide
what to do with the packet.

Signed-off-by: Jukka Rissanen <jukka.rissanen@linux.intel.com>