### PR TITLE
Build: Build offsets lib as OBJECT instead of STATIC. Use cmake to ge…

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -550,12 +550,16 @@ gen_kobj(KOBJ_INCLUDE_PATH)
 # Generate offsets.c.obj from offsets.c
 # Generate offsets.h     from offsets.c.obj
 
-set(OFFSETS_C_PATH ${ZEPHYR_BASE}/arch/${ARCH}/core/offsets/offsets.c)
-set(OFFSETS_O_PATH ${CMAKE_CURRENT_BINARY_DIR}/CMakeFiles/offsets.dir/arch/${ARCH}/core/offsets/offsets.c.obj)
+set(OFFSETS_C_PATH arch/${ARCH}/core/offsets/offsets.c)
 set(OFFSETS_H_PATH ${PROJECT_BINARY_DIR}/include/generated/offsets.h)
 
-add_library(          offsets STATIC ${OFFSETS_C_PATH})
-target_link_libraries(offsets zephyr_interface)
+add_library(          offsets OBJECT ${OFFSETS_C_PATH})
+# target_link_libraries for librareis of type OBJECT is not supported in CMake until 3.12.3. Until then the
+# include directories, compile options and compile definitions are transefered using the the following 3 lines.
+target_include_directories(offsets PRIVATE $<TARGET_PROPERTY:zephyr_interface,INTERFACE_INCLUDE_DIRECTORIES>)
+target_compile_options(offsets PRIVATE $<TARGET_PROPERTY:zephyr_interface,INTERFACE_COMPILE_OPTIONS>)
+target_compile_definitions(offsets PRIVATE $<TARGET_PROPERTY:zephyr_interface,INTERFACE_COMPILE_DEFINITIONS>)
+
 add_dependencies(     offsets
   syscall_list_h_target
   syscall_macros_h_target
@@ -566,7 +570,7 @@ add_dependencies(     offsets
 add_custom_command(
   OUTPUT ${OFFSETS_H_PATH}
   COMMAND ${PYTHON_EXECUTABLE} ${ZEPHYR_BASE}/scripts/gen_offset_header.py
-  -i ${OFFSETS_O_PATH}
+  -i $<TARGET_OBJECTS:offsets>
   -o ${OFFSETS_H_PATH}
   DEPENDS offsets
 )
@@ -797,7 +801,7 @@ set(zephyr_lnk
   ${ZEPHYR_LIBS_PROPERTY}
   ${LINKERFLAGPREFIX},--no-whole-archive
   kernel
-  ${OFFSETS_O_PATH}
+  $<TARGET_OBJECTS:offsets>
   ${LIB_INCLUDE_DIR}
   -L${PROJECT_BINARY_DIR}
   ${TOOLCHAIN_LIBS}


### PR DESCRIPTION
Build offsets lib as OBJECT instead of STATIC. Use cmake to get generated path of lib instead of predefined absolute path. This is needed to eventually be able to have an architecture-out-of-tree build. The path "OFFSETS_O_PATH" is not generated for sources out-of-tree and therefore must be replaced by the cmake generator $<TARGET_OBJECTS:offsets>. 

The following lines are needed while we are using a Cmake version < 3.12.3:
+target_include_directories(.....
+target_compile_options(...
+target_compile_definitions(....
This is due to the cmake feature "Linking Object Libraries" not supported until 3.12: https://cmake.org/cmake/help/v3.12/command/target_link_libraries.html#linking-object-libraries

Signed-off-by: Klaus Petersen <klauspetersen@gmail.com>