### PR TITLE
logging: reorder designated initializers in __LOG macro

### DIFF
--- a/include/logging/log_core.h
+++ b/include/logging/log_core.h
@@ -239,8 +239,8 @@ extern "C" {
 		    (_level <= LOG_RUNTIME_FILTER(_filter))) {		    \
 			struct log_msg_ids src_level = {		    \
 				.level = _level,			    \
-				.source_id = _id,			    \
-				.domain_id = CONFIG_LOG_DOMAIN_ID	    \
+				.domain_id = CONFIG_LOG_DOMAIN_ID,	    \
+				.source_id = _id			    \
 			};						    \
 			__LOG_INTERNAL(src_level, _LOG_STR(__VA_ARGS__));   \
 		} else if (0) {						    \


### PR DESCRIPTION
As C++ does not support designated initializers, including this file in a c++ file caused a compilation error.

I tested it with an application using mqtt and ethernet.

Signed-off-by: Alexander Polleti <metapsycholo@gmail.com>