### PR TITLE
drivers: serial: uart_cmsdk_apb: Fix interrupt-driven operation

### DIFF
--- a/samples/subsys/console/echo/src/main.c
+++ b/samples/subsys/console/echo/src/main.c
@@ -6,11 +6,15 @@
 #include <zephyr.h>
 #include <console.h>
 
+static const char prompt[] = "Start typing characters to see them echoed back\n";
+
 void main(void)
 {
 	console_init();
 
-	printk("Start typing characters to see them echoed back\n");
+	printk("You should see another line with instructions below. If not,\n");
+	printk("the (interrupt-driven) console device doesn't work as expected:\n");
+	console_write(NULL, prompt, sizeof(prompt) - 1);
 
 	while (1) {
 		u8_t c = console_getchar();


### PR DESCRIPTION
1. There's an expectations that TX ready (i.e. TX buffer space
available) interrupt is a level interrupt, i.e. always active
while there's TX buffer space available. In particular, there's
an expectation that after uart_irq_tx_enable(), the TX interrupt
will immediately fire (assuming free TX buffer space is available).
But CMSDK UART interrupt appears to be edge interrupt, firing only
on buffer state change. So, after irq_tx_enable(), we need to
"bootstrap" interrupt processing by calling user-defined ISR
manually (the ISR will see that TX ready to accept a new char,
will write it there, then we'll get interrupt once TX buffer is
ready again).

2. Interrupts should be acknowledges only after user ISR is called,
because the ISR will check the status of interrupts.

3. Update stale comments.

Signed-off-by: Paul Sokolovsky <paul.sokolovsky@linaro.org>