### PR TITLE
tests: test dynamic IRQ APIs

### DIFF
--- a/tests/kernel/gen_isr_table/prj.conf
+++ b/tests/kernel/gen_isr_table/prj.conf
@@ -1,2 +1,2 @@
 CONFIG_TEST=y
-# Nothing needed
+CONFIG_DYNAMIC_INTERRUPTS=y


### PR DESCRIPTION
The gen_isr_table test now tries to install two dynamic
IRQ handlers.

RISCV32 has a workaround due to limited number of SW
triggerable interrupts that can be configured.

Signed-off-by: Andrew Boie <andrew.p.boie@intel.com>