### PR TITLE
Enable instruction and data caches on SAM E70

### DIFF
--- a/soc/arm/atmel_sam/same70/soc.c
+++ b/soc/arm/atmel_sam/same70/soc.c
@@ -229,6 +229,18 @@ static int atmel_same70_init(struct device *arg)
 
 	SCB_EnableICache();
 
+/*
+ * The Atmel SAM GMAC Ethernet driver is using a scatter-gather technique
+ * to exchange data with the Ethernet driver. This requires the use use of
+ * a non-cached memory area. This is currently not supported on Zephyr, so
+ * do not enable the cache in that case.
+ */
+#ifndef CONFIG_ETH_SAM_GMAC
+	if (!(SCB->CCR & SCB_CCR_DC_Msk)) {
+		SCB_EnableDCache();
+	}
+#endif
+
 	/* Clear all faults */
 	_ClearFaults();
 

--- a/soc/arm/atmel_sam/same70/soc.c
+++ b/soc/arm/atmel_sam/same70/soc.c
@@ -227,6 +227,8 @@ static int atmel_same70_init(struct device *arg)
 
 	key = irq_lock();
 
+	SCB_EnableICache();
+
 	/* Clear all faults */
 	_ClearFaults();
 


### PR DESCRIPTION
This patchset enables the instruction and data cache on the Atmel SAM E70 SoC. This has already been tried in the past, but caused issues, and had to be reverted. The issues have been fixed in PR #11194. 

The SAM GMAC Ethernet driver requires non-cached memory. Support for it is being discussed in PR#11199. In the meantime, do not enable the data cache if the SAM GMAC Ethernet driver is enabled.

Fixes #11069.