### PR TITLE
linker: intel_s1000: Remove limits on code and data sections

### DIFF
--- a/soc/xtensa/intel_s1000/linker.ld
+++ b/soc/xtensa/intel_s1000/linker.ld
@@ -23,8 +23,8 @@ OUTPUT_ARCH(xtensa)
 #include <linker/linker-defs.h>
 #include <linker/linker-tool.h>
 
-#define RAMABLE_REGION data :data_phdr
-#define ROMABLE_REGION text :text_phdr
+#define RAMABLE_REGION ram :ram_phdr
+#define ROMABLE_REGION ram :ram_phdr
 
 MEMORY
 {
@@ -97,20 +97,14 @@ MEMORY
   vector_double_text :
        	org = XCHAL_DOUBLEEXC_VECTOR_PADDR_SRAM,
         len = MEM_VECT_TEXT_SIZE
-  text :
-       	org = TEXT_BASE,
-        len = TEXT_SIZE,
+  ram :
+	org = RAM_BASE,
+	len = RAM_SIZE
 #ifdef CONFIG_GEN_ISR_TABLES
   IDT_LIST :
-        org = TEXT_BASE + TEXT_SIZE,
-        len = IDT_SIZE,
+	org = IDT_BASE,
+	len = IDT_SIZE
 #endif
-  data :
-       	org = TEXT_BASE + TEXT_SIZE + IDT_SIZE,
-        len = DATA_SIZE
-  bss_data :
-        org = TEXT_BASE + TEXT_SIZE + IDT_SIZE + DATA_SIZE,
-        len = BSS_DATA_SIZE
 }
 
 PHDRS
@@ -138,9 +132,7 @@ PHDRS
   vector_user_text_phdr PT_LOAD;
   vector_double_lit_phdr PT_LOAD;
   vector_double_text_phdr PT_LOAD;
-  text_phdr PT_LOAD;
-  data_phdr PT_LOAD;
-  bss_data_phdr PT_LOAD;
+  ram_phdr PT_LOAD;
 }
 _rom_store_table = 0;
 PROVIDE(_memmap_vecbase_reset = XCHAL_VECBASE_RESET_PADDR_SRAM);
@@ -323,14 +315,14 @@ SECTIONS
     *(.gnu.version)
     _text_end = ABSOLUTE(.);
     _etext = .;
-  } >text :text_phdr
+  } >ram :ram_phdr
 #include <linker/common-rom.ld>
 
   .noinit :  ALIGN(4)
   {
     *(.noinit)
     *(.noinit.*)
-  } >data :data_phdr
+  } >ram :ram_phdr
   .rodata : ALIGN(4)
   {
     _rodata_start = ABSOLUTE(.);
@@ -365,7 +357,7 @@ SECTIONS
     LONG(_bss_end)
     _bss_table_end = ABSOLUTE(.);
     _rodata_end = ABSOLUTE(.);
-  } >data :data_phdr
+  } >ram :ram_phdr
   .data : ALIGN(4)
   {
     _data_start = ABSOLUTE(.);
@@ -384,7 +376,7 @@ SECTIONS
     . = ALIGN(4096);
     *(.gna_model)
     _data_end = ABSOLUTE(.);
-  } >data :data_phdr
+  } >ram :ram_phdr
   .lit4 : ALIGN(4)
   {
     _lit4_start = ABSOLUTE(.);
@@ -392,7 +384,7 @@ SECTIONS
     *(.lit4.*)
     *(.gnu.linkonce.lit4.*)
     _lit4_end = ABSOLUTE(.);
-  } >data :data_phdr
+  } >ram :ram_phdr
 #include <linker/common-ram.ld>
 
   .bss (NOLOAD) : ALIGN(8)
@@ -414,7 +406,7 @@ SECTIONS
     *(COMMON)
     . = ALIGN (8);
     _bss_end = ABSOLUTE(.);
-  } >bss_data :bss_data_phdr
+  } >ram :ram_phdr
 
   /* stack */
   _end = ALIGN(8);

--- a/soc/xtensa/intel_s1000/memory.h
+++ b/soc/xtensa/intel_s1000/memory.h
@@ -43,17 +43,19 @@
 #define MEM_ERROR_TEXT_SIZE			0x180
 #define MEM_ERROR_LIT_SIZE			0x8
 
-/* text and data share the same L2 HP SRAM on Intel S1000 */
-#define TEXT_BASE				(DT_L2_SRAM_BASE + L2_VECTOR_SIZE)
-#define TEXT_SIZE				0x16000
+/* text and data share the same L2 HP SRAM on Intel S1000.
+ * So, they lie next to each other.
+ */
+#define RAM_BASE			(DT_L2_SRAM_BASE + L2_VECTOR_SIZE)
+#define RAM_SIZE			(DT_L2_SRAM_SIZE - L2_VECTOR_SIZE)
+
+/* Location for the intList section which is later used to construct the
+ * Interrupt Descriptor Table (IDT). This is a bogus address as this
+ * section will be stripped off in the final image.
+ */
+#define IDT_BASE				0xFFFFF7FF
 
 /* size of the Interrupt Descriptor Table (IDT) */
 #define IDT_SIZE				0x2000
-
-/* initialized data */
-#define DATA_SIZE				0x10000
-
-/* bss data */
-#define BSS_DATA_SIZE				0x8000
 
 #endif /* __INC_MEMORY_H */


### PR DESCRIPTION
All text, data and bss sections are all mapped to the same physical
memory (SRAM). This patch removes the individual section limits
and defines a common limit for the sum of text, data and bss sections.
This would make it more flexible for application developers.

Fixes #11268.

Signed-off-by: Rajavardhan Gundi <rajavardhan.gundi@intel.com>