### PR TITLE
SPI driver behaviour alignement 

### DIFF
--- a/drivers/spi/spi_mcux_dspi.c
+++ b/drivers/spi/spi_mcux_dspi.c
@@ -128,6 +128,11 @@ static int spi_mcux_configure(struct device *dev,
 	u32_t clock_freq;
 	u32_t word_size;
 
+	if (spi_context_configured(&data->ctx, spi_cfg)) {
+		/* This configuration is already in use */
+		return 0;
+	}
+
 	DSPI_MasterGetDefaultConfig(&master_config);
 
 	if (spi_cfg->slave > FSL_FEATURE_DSPI_CHIP_SELECT_COUNT) {

--- a/drivers/spi/spi_mcux_lpspi.c
+++ b/drivers/spi/spi_mcux_lpspi.c
@@ -131,6 +131,11 @@ static int spi_mcux_configure(struct device *dev,
 	u32_t clock_freq;
 	u32_t word_size;
 
+	if (spi_context_configured(&data->ctx, spi_cfg)) {
+		/* This configuration is already in use */
+		return 0;
+	}
+
 	LPSPI_MasterGetDefaultConfig(&master_config);
 
 	if (spi_cfg->slave > CHIP_SELECT_COUNT) {

--- a/drivers/spi/spi_sam.c
+++ b/drivers/spi/spi_sam.c
@@ -51,9 +51,14 @@ static int spi_sam_configure(struct device *dev,
 			     const struct spi_config *config)
 {
 	const struct spi_sam_config *cfg = dev->config->config_info;
+	struct spi_sam_data *data = dev->driver_data;
 	Spi *regs = cfg->regs;
 	u32_t spi_mr = 0, spi_csr = 0;
 	int div;
+
+	if (spi_context_configured(&data->ctx, config)) {
+		return 0;
+	}
 
 	if (SPI_OP_MODE_GET(config->operation) != SPI_OP_MODE_MASTER) {
 		/* Slave mode is not implemented. */
@@ -95,6 +100,10 @@ static int spi_sam_configure(struct device *dev,
 	regs->SPI_MR = spi_mr;
 	regs->SPI_CSR[config->slave] = spi_csr;
 	regs->SPI_CR = SPI_CR_SPIEN; /* Enable SPI */
+
+	spi_context_cs_configure(&data->ctx);
+
+	data->ctx.config = config;
 
 	return 0;
 }
@@ -363,8 +372,6 @@ static int spi_sam_transceive(struct device *dev,
 		goto done;
 	}
 
-	data->ctx.config = config;
-	spi_context_cs_configure(&data->ctx);
 	spi_context_cs_control(&data->ctx, true);
 
 	/* This driver special cases the common send only, receive
@@ -477,4 +484,3 @@ SPI_SAM_DEVICE_INIT(0);
 #if DT_SPI_1_BASE_ADDRESS
 SPI_SAM_DEVICE_INIT(1);
 #endif
-


### PR DESCRIPTION
Not sure why sam/sam0 drivers where not implementing the async mode (since it's just using k_poll_signal object to signal the caller).