### PR TITLE
Posix tickless fixes

### DIFF
--- a/tests/kernel/common/src/clock.c
+++ b/tests/kernel/common/src/clock.c
@@ -11,7 +11,7 @@
 	do {				       \
 		u32_t t = k_uptime_get_32();   \
 		while (t == k_uptime_get_32()) \
-			posix_halt_cpu();      \
+			k_busy_wait(50);       \
 	} while (0)
 #else
 #define ALIGN_MS_BOUNDARY		       \
@@ -42,7 +42,7 @@ void test_clock_uptime(void)
 	t64 = k_uptime_get();
 	while (k_uptime_get() < (t64 + 5))
 #if defined(CONFIG_ARCH_POSIX)
-		posix_halt_cpu();
+		k_busy_wait(50);
 #else
 		;
 #endif
@@ -51,7 +51,7 @@ void test_clock_uptime(void)
 	t32 = k_uptime_get_32();
 	while (k_uptime_get_32() < (t32 + 5))
 #if defined(CONFIG_ARCH_POSIX)
-		posix_halt_cpu();
+		k_busy_wait(50);
 #else
 		;
 #endif
@@ -66,7 +66,7 @@ void test_clock_uptime(void)
 	/* Note: this will stall if the systick period < 5ms */
 	while (k_uptime_delta(&d64) < 5)
 #if defined(CONFIG_ARCH_POSIX)
-		posix_halt_cpu();
+		k_busy_wait(50);
 #else
 		;
 #endif
@@ -76,7 +76,7 @@ void test_clock_uptime(void)
 	/* Note: this will stall if the systick period < 5ms */
 	while (k_uptime_delta_32(&d64) < 5)
 #if defined(CONFIG_ARCH_POSIX)
-		posix_halt_cpu();
+		k_busy_wait(50);
 #else
 		;
 #endif
@@ -103,7 +103,7 @@ void test_clock_cycle(void)
 	while (k_cycle_get_32() > c32 &&
 	       k_cycle_get_32() < (c32 + sys_clock_hw_cycles_per_tick()))
 #if defined(CONFIG_ARCH_POSIX)
-		posix_halt_cpu();
+		k_busy_wait(50);
 #else
 		;
 #endif
@@ -114,7 +114,7 @@ void test_clock_cycle(void)
 	t32 = k_uptime_get_32();
 	while (t32 == k_uptime_get_32())
 #if defined(CONFIG_ARCH_POSIX)
-		posix_halt_cpu();
+		k_busy_wait(50);
 #else
 		;
 #endif

--- a/tests/kernel/common/src/timeout_order.c
+++ b/tests/kernel/common/src/timeout_order.c
@@ -67,7 +67,7 @@ void test_timeout_order(void)
 	/* sync on tick */
 	while (uptime == k_uptime_get_32())
 #if defined(CONFIG_ARCH_POSIX)
-		posix_halt_cpu();
+		k_busy_wait(50);
 #else
 		;
 #endif

--- a/tests/kernel/context/src/main.c
+++ b/tests/kernel/context/src/main.c
@@ -244,7 +244,7 @@ static void _test_kernel_cpu_idle(int atomic)
 	tms = k_uptime_get_32();
 	while (tms == k_uptime_get_32()) {
 #if defined(CONFIG_ARCH_POSIX)
-		posix_halt_cpu(); /*Sleep until next IRQ*/
+		k_busy_wait(50);
 #endif
 	}
 

--- a/tests/kernel/sched/preempt/src/main.c
+++ b/tests/kernel/sched/preempt/src/main.c
@@ -123,7 +123,7 @@ void wakeup_src_thread(int id)
 		 * executes in 0 time: it always waits for the code to finish
 		 * and it letting the cpu sleep before letting time pass)
 		 */
-		posix_halt_cpu();
+		k_busy_wait(50);
 #endif
 	}
 

--- a/tests/kernel/sched/schedule_api/src/test_sched_timeslice_reset.c
+++ b/tests/kernel/sched/schedule_api/src/test_sched_timeslice_reset.c
@@ -108,7 +108,7 @@ void test_slice_reset(void)
 		t32 = k_uptime_get_32();
 		while (k_uptime_get_32() - t32 < HALF_SLICE_SIZE) {
 #if defined(CONFIG_ARCH_POSIX)
-			posix_halt_cpu(); /*sleep until next irq*/
+			k_busy_wait(50);
 #else
 			;
 #endif

--- a/tests/kernel/sched/schedule_api/src/test_slice_scheduling.c
+++ b/tests/kernel/sched/schedule_api/src/test_slice_scheduling.c
@@ -58,7 +58,7 @@ static void thread_tslice(void *p1, void *p2, void *p3)
 		 */
 		while (k_uptime_get_32() - t32 < BUSY_MS) {
 #if defined(CONFIG_ARCH_POSIX)
-			posix_halt_cpu(); /*sleep until next irq*/
+			k_busy_wait(50);
 #else
 			;
 #endif
@@ -114,7 +114,7 @@ void test_slice_scheduling(void)
 		t32 = k_uptime_get_32();
 		while (k_uptime_get_32() - t32 < BUSY_MS) {
 #if defined(CONFIG_ARCH_POSIX)
-			posix_halt_cpu(); /*sleep until next irq*/
+			k_busy_wait(50);
 #else
 			;
 #endif

--- a/tests/kernel/tickless/tickless_concept/src/main.c
+++ b/tests/kernel/tickless/tickless_concept/src/main.c
@@ -63,7 +63,7 @@ static void thread_tslice(void *p1, void *p2, void *p3)
 	/*keep the current thread busy for more than one slice*/
 	while (k_uptime_get_32() - t32 < SLEEP_TICKLESS)
 #if defined(CONFIG_ARCH_POSIX)
-		posix_halt_cpu();
+		k_busy_wait(50);
 #else
 		;
 #endif


### PR DESCRIPTION
In the POSIX architecture, with the inf_clock "SOC", time does
not pass while the CPU is running. Tests that require time to pass
while busy waiting should call k_busy_wait() or in some other way
set the CPU to idle. This test was setting the CPU to idle while
waiting for the next time slice. This is ok if the system tick
(timer) is active and awaking the CPU every system tick period.
But when configured in tickless mode that is not the case, and the
CPU was set to sleep for an indefinite amount of time.
This commit fixes it by using k_busy_wait(a few microseconds) inside
that busy wait loop instead.

-----

Fixes the current CI issue in #10556