### PR TITLE
logger: fix missing macro in RTT backend, when blocking mode is selected

### DIFF
--- a/subsys/logging/log_backend_rtt.c
+++ b/subsys/logging/log_backend_rtt.c
@@ -10,9 +10,10 @@
 #include <logging/log_output.h>
 #include <rtt/SEGGER_RTT.h>
 
+#define DROP_MAX 99
+
 #if CONFIG_LOG_BACKEND_RTT_MODE_DROP
 
-#define DROP_MAX 99
 #define DROP_MSG "\nmessages dropped:    \r"
 #define DROP_MSG_LEN (sizeof(DROP_MSG) - 1)
 


### PR DESCRIPTION
This simple patch fix compiler error when RTT blocking mode is selected.

Signed-off-by: Pavel Kral <pavel.kral@omsquare.com>