### PR TITLE
subsys: bluetooth: host: Remove ATT Req from the list after processing

### DIFF
--- a/subsys/bluetooth/host/att.c
+++ b/subsys/bluetooth/host/att.c
@@ -322,6 +322,13 @@ static u8_t att_handle_rsp(struct bt_att *att, void *pdu, u16_t len, u8_t err)
 	func = att->req->func;
 	att->req->func = NULL;
 
+	/*
+	 * Remove the ATT Req from the list.
+	 * It has to be removed before it reaches the callback since the
+	 * application may reuse the ATT req.
+	 */
+	sys_slist_find_and_remove(&att->reqs, &att->req->node);
+
 	func(att->chan.chan.conn, err, pdu, len, att->req);
 
 	/* Don't destroy if callback had reused the request */


### PR DESCRIPTION
The ATT Request node must be removed from the list after the request has been freed by `att_handle_rsp()`.

By not removing the ATT Req from the list, it will be processed again the ATT Req node in the function `att_process()`. As the ATT Req buffer and callback have been freed and set to `NULL`, it will go into an undefined behaviour.

Signed-off-by: Olivier Martin <olivier.martin@proglove.de>