### PR TITLE
net: pkt: Print debug prints in one line

### DIFF
--- a/subsys/net/ip/net_pkt.c
+++ b/subsys/net/ip/net_pkt.c
@@ -389,10 +389,9 @@ struct net_buf *net_pkt_get_reserve_data(struct net_buf_pool *pool,
 
 	net_pkt_alloc_add(frag, false, caller, line);
 
-	NET_DBG("%s (%s) [%d] frag %p reserve %u",
+	NET_DBG("%s (%s) [%d] frag %p reserve %u ref %d (%s():%d)",
 		pool2str(pool), get_name(pool), get_frees(pool),
-		frag, reserve_head);
-	NET_DBG("  ref %d (%s():%d)", frag->ref, caller, line);
+		frag, reserve_head, frag->ref, caller, line);
 #endif
 
 	return frag;
@@ -782,11 +781,10 @@ void net_pkt_unref(struct net_pkt *pkt)
 
 	frag = pkt->frags;
 	while (frag) {
-		NET_DBG("%s (%s) [%d] frag %p",
+		NET_DBG("%s (%s) [%d] frag %p ref %d frags %p (%s():%d)",
 			pool2str(net_buf_pool_get(frag->pool_id)),
 			get_name(net_buf_pool_get(frag->pool_id)),
-			get_frees(net_buf_pool_get(frag->pool_id)), frag);
-		NET_DBG("  ref %d frags %p (%s():%d)",
+			get_frees(net_buf_pool_get(frag->pool_id)), frag,
 			frag->ref - 1, frag->frags, caller, line);
 
 		if (!frag->ref) {
@@ -2193,14 +2191,14 @@ struct net_pkt *net_pkt_clone(struct net_pkt *pkt, s32_t timeout)
 void net_pkt_init(void)
 {
 #if CONFIG_NET_PKT_LOG_LEVEL >= LOG_LEVEL_DBG
-	NET_DBG("Allocating %u RX (%zu bytes), %u TX (%zu bytes), ",
+	NET_DBG("Allocating %u RX (%zu bytes), %u TX (%zu bytes), "
+		"%d RX data (%u bytes) and %d TX data (%u bytes) buffers",
 		k_mem_slab_num_free_get(&rx_pkts),
 		(size_t)(k_mem_slab_num_free_get(&rx_pkts) *
 			 sizeof(struct net_pkt)),
 		k_mem_slab_num_free_get(&tx_pkts),
 		(size_t)(k_mem_slab_num_free_get(&tx_pkts) *
-			 sizeof(struct net_pkt)));
-	NET_DBG("  %d RX data (%u bytes) and %d TX data (%u bytes) buffers",
+			 sizeof(struct net_pkt)),
 		get_frees(&rx_bufs), get_size(&rx_bufs),
 		get_frees(&tx_bufs), get_size(&tx_bufs));
 #endif


### PR DESCRIPTION
In earlier commit 15e7e3ea4 ("net: ip: Split debug prints into
smaller pieces"), the net_pkt debug prints were split to two
lines because of the argument count limitation in logging system.
As the logging subsystem increased the limit count in
commit 62d011549a ("logging: Support for up to 15 arguments in log
message") we can restore the original version as it is easier
to read.

Signed-off-by: Jukka Rissanen <jukka.rissanen@linux.intel.com>