### PR TITLE
Driver: Serial STM32: Fix how uart_irq_is_pending() works

### DIFF
--- a/drivers/serial/uart_stm32.c
+++ b/drivers/serial/uart_stm32.c
@@ -209,8 +209,8 @@ static int uart_stm32_irq_is_pending(struct device *dev)
 
 	return ((LL_USART_IsActiveFlag_RXNE(UartInstance) &&
 		 LL_USART_IsEnabledIT_RXNE(UartInstance)) ||
-		(LL_USART_IsActiveFlag_TXE(UartInstance) &&
-		 LL_USART_IsEnabledIT_TXE(UartInstance)));
+		(LL_USART_IsActiveFlag_TC(UartInstance) &&
+		 LL_USART_IsEnabledIT_TC(UartInstance)));
 }
 
 static int uart_stm32_irq_update(struct device *dev)


### PR DESCRIPTION
uart_stm32_irq_tx_enable/disable() functions use TC IRQ.
But uart_stm32_irq_tx_ready() function use TXE IRQ.
So uart_stm32_irq_tx_ready() function alway return 0, because TXE flag is never enabled by uart_stm32_irq_tx_enable.
