### PR TITLE
Bluetooth: shell: Cleanups

### DIFF
--- a/subsys/bluetooth/shell/Kconfig
+++ b/subsys/bluetooth/shell/Kconfig
@@ -8,7 +8,6 @@
 
 config BT_SHELL
 	bool "Enable Bluetooth shell"
-	select SERIAL
 	select SHELL
 	select FLASH_SHELL
 	help

--- a/subsys/bluetooth/shell/bredr.c
+++ b/subsys/bluetooth/shell/bredr.c
@@ -50,7 +50,6 @@ static int cmd_auth_pincode(const struct shell *shell,
 {
 	struct bt_conn *conn;
 	u8_t max = 16;
-	int err;
 
 	if (default_conn) {
 		conn = default_conn;
@@ -63,11 +62,6 @@ static int cmd_auth_pincode(const struct shell *shell,
 	if (!conn) {
 		shell_print(shell, "Not connected");
 		return 0;
-	}
-
-	err = shell_cmd_precheck(shell, (argc == 2), NULL, 0);
-	if (err) {
-		return err;
 	}
 
 	if (strlen(argv[1]) > max) {
@@ -88,11 +82,6 @@ static int cmd_connect(const struct shell *shell, size_t argc, char *argv[])
 	struct bt_conn *conn;
 	bt_addr_t addr;
 	int err;
-
-	err = shell_cmd_precheck(shell, (argc == 2), NULL, 0);
-	if (err) {
-		return err;
-	}
 
 	err = str2bt_addr(argv[1], &addr);
 	if (err) {
@@ -179,12 +168,6 @@ static void br_discovery_complete(struct bt_br_discovery_result *results,
 static int cmd_discovery(const struct shell *shell, size_t argc, char *argv[])
 {
 	const char *action;
-	int err;
-
-	err = shell_cmd_precheck(shell, (argc >= 2), NULL, 0);
-	if (err) {
-		return err;
-	}
 
 	action = argv[1];
 	if (!strcmp(action, "on")) {
@@ -282,12 +265,6 @@ static struct bt_l2cap_server br_server = {
 static int cmd_l2cap_register(const struct shell *shell,
 			      size_t argc, char *argv[])
 {
-	int err = shell_cmd_precheck(shell, (argc == 2), NULL, 0);
-
-	if (err) {
-		return err;
-	}
-
 	if (br_server.psm) {
 		shell_print(shell, "Already registered");
 		return 0;
@@ -311,11 +288,6 @@ static int cmd_discoverable(const struct shell *shell,
 {
 	int err;
 	const char *action;
-
-	err = shell_cmd_precheck(shell, (argc == 2), NULL, 0);
-	if (err) {
-		return err;
-	}
 
 	action = argv[1];
 
@@ -344,11 +316,6 @@ static int cmd_connectable(const struct shell *shell,
 {
 	int err;
 	const char *action;
-
-	err = shell_cmd_precheck(shell, (argc == 2), NULL, 0);
-	if (err) {
-		return err;
-	}
 
 	action = argv[1];
 
@@ -532,17 +499,12 @@ static struct bt_sdp_discover_params discov;
 static int cmd_sdp_find_record(const struct shell *shell,
 			       size_t argc, char *argv[])
 {
-	int err, res;
+	int res;
 	const char *action;
 
 	if (!default_conn) {
 		shell_print(shell, "Not connected");
 		return 0;
-	}
-
-	err = shell_cmd_precheck(shell, (argc == 2), NULL, 0);
-	if (err) {
-		return err;
 	}
 
 	action = argv[1];
@@ -554,14 +516,6 @@ static int cmd_sdp_find_record(const struct shell *shell,
 	} else {
 		shell_help_print(shell, NULL, 0);
 		return 0;
-	}
-
-	if (err) {
-		shell_error(shell, "SDP UUID to resolve not valid (err %d)",
-			    err);
-		shell_print(shell,
-			    "Supported UUID are \'HFPAG\' \'A2SRC\' only");
-		return -ENOEXEC;
 	}
 
 	shell_print(shell, "SDP UUID \'%s\' gets applied", action);
@@ -581,32 +535,25 @@ static int cmd_sdp_find_record(const struct shell *shell,
 #define HELP_ADDR_LE "<address: XX:XX:XX:XX:XX:XX> <type: (public|random)>"
 
 SHELL_CREATE_STATIC_SUBCMD_SET(br_cmds) {
-	SHELL_CMD(auth-pincode, NULL, "<pincode>", cmd_auth_pincode),
-	SHELL_CMD(connect, NULL, "<address>", cmd_connect),
-	SHELL_CMD(discovery, NULL,
-		  "<value: on, off> [length: 1-48] [mode: limited]",
-		  cmd_discovery),
-	SHELL_CMD(iscan, NULL, "<value: on, off>", cmd_discoverable),
-	SHELL_CMD(l2cap-register, NULL, "<psm>", cmd_l2cap_register),
-	SHELL_CMD(oob, NULL, NULL, cmd_oob),
-	SHELL_CMD(pscan, NULL, "value: on, off", cmd_connectable),
-	SHELL_CMD(sdp-find, NULL, "<HFPAG>", cmd_sdp_find_record),
+	SHELL_CMD_ARG(auth-pincode, NULL, "<pincode>", cmd_auth_pincode, 2, 0),
+	SHELL_CMD_ARG(connect, NULL, "<address>", cmd_connect, 2, 0),
+	SHELL_CMD_ARG(discovery, NULL,
+		      "<value: on, off> [length: 1-48] [mode: limited]",
+		      cmd_discovery, 2, 2),
+	SHELL_CMD_ARG(iscan, NULL, "<value: on, off>", cmd_discoverable, 2, 0),
+	SHELL_CMD_ARG(l2cap-register, NULL, "<psm>", cmd_l2cap_register, 2, 0),
+	SHELL_CMD_ARG(oob, NULL, NULL, cmd_oob, 1, 0),
+	SHELL_CMD_ARG(pscan, NULL, "<value: on, off>", cmd_connectable, 2, 0),
+	SHELL_CMD_ARG(sdp-find, NULL, "<HFPAG>", cmd_sdp_find_record, 2, 0),
 	SHELL_SUBCMD_SET_END
 };
 
 static int cmd_br(const struct shell *shell, size_t argc, char **argv)
 {
-	int err;
-
 	if (argc == 1) {
 		shell_help_print(shell, NULL, 0);
 		/* shell_cmd_precheck returns 1 when help is printed */
 		return 1;
-	}
-
-	err = shell_cmd_precheck(shell, (argc == 2), NULL, 0);
-	if (err) {
-		return err;
 	}
 
 	shell_error(shell, "%s unknown parameter: %s", argv[0], argv[1]);
@@ -614,4 +561,5 @@ static int cmd_br(const struct shell *shell, size_t argc, char **argv)
 	return -ENOEXEC;
 }
 
-SHELL_CMD_REGISTER(br, &br_cmds, "Bluetooth BR/EDR shell commands", cmd_br);
+SHELL_CMD_ARG_REGISTER(br, &br_cmds, "Bluetooth BR/EDR shell commands", cmd_br,
+		       1, 1);

--- a/subsys/bluetooth/shell/bredr.c
+++ b/subsys/bluetooth/shell/bredr.c
@@ -61,7 +61,7 @@ static int cmd_auth_pincode(const struct shell *shell,
 	}
 
 	if (!conn) {
-		print(shell, "Not connected\n");
+		shell_print(shell, "Not connected");
 		return 0;
 	}
 
@@ -71,12 +71,12 @@ static int cmd_auth_pincode(const struct shell *shell,
 	}
 
 	if (strlen(argv[1]) > max) {
-		print(shell, "PIN code value invalid - enter max %u digits\n",
-		      max);
+		shell_print(shell, "PIN code value invalid - enter max %u "
+			    "digits", max);
 		return 0;
 	}
 
-	print(shell, "PIN code \"%s\" applied\n", argv[1]);
+	shell_print(shell, "PIN code \"%s\" applied", argv[1]);
 
 	bt_conn_auth_pincode_entry(conn, argv[1]);
 
@@ -96,16 +96,16 @@ static int cmd_connect(const struct shell *shell, size_t argc, char *argv[])
 
 	err = str2bt_addr(argv[1], &addr);
 	if (err) {
-		print(shell, "Invalid peer address (err %d)\n", err);
+		shell_print(shell, "Invalid peer address (err %d)", err);
 		return -ENOEXEC;
 	}
 
 	conn = bt_conn_create_br(&addr, BT_BR_CONN_PARAM_DEFAULT);
 	if (!conn) {
-		print(shell, "Connection failed\n");
+		shell_print(shell, "Connection failed");
 	} else {
 
-		print(shell, "Connection pending\n");
+		shell_print(shell, "Connection pending");
 
 		/* unref connection obj in advance as app user */
 		bt_conn_unref(conn);
@@ -158,7 +158,7 @@ static void br_device_found(const bt_addr_t *addr, s8_t rssi,
 
 	bt_addr_to_str(addr, br_addr, sizeof(br_addr));
 
-	print(NULL, "[DEVICE]: %s, RSSI %i %s\n", br_addr, rssi, name);
+	shell_print(ctx_shell, "[DEVICE]: %s, RSSI %i %s", br_addr, rssi, name);
 }
 
 static struct bt_br_discovery_result br_discovery_results[5];
@@ -168,7 +168,7 @@ static void br_discovery_complete(struct bt_br_discovery_result *results,
 {
 	size_t i;
 
-	print(NULL, "BR/EDR discovery complete\n");
+	shell_print(ctx_shell, "BR/EDR discovery complete");
 
 	for (i = 0; i < count; i++) {
 		br_device_found(&results[i].addr, results[i].rssi,
@@ -204,18 +204,18 @@ static int cmd_discovery(const struct shell *shell, size_t argc, char *argv[])
 		if (bt_br_discovery_start(&param, br_discovery_results,
 					  ARRAY_SIZE(br_discovery_results),
 					  br_discovery_complete) < 0) {
-			print(shell, "Failed to start discovery\n");
+			shell_print(shell, "Failed to start discovery");
 			return 0;
 		}
 
-		print(shell, "Discovery started\n");
+		shell_print(shell, "Discovery started");
 	} else if (!strcmp(action, "off")) {
 		if (bt_br_discovery_stop()) {
-			print(shell, "Failed to stop discovery\n");
+			shell_print(shell, "Failed to stop discovery");
 			return 0;
 		}
 
-		print(shell, "Discovery stopped\n");
+		shell_print(shell, "Discovery stopped");
 	} else {
 		shell_help_print(shell, NULL, 0);
 	}
@@ -225,24 +225,25 @@ static int cmd_discovery(const struct shell *shell, size_t argc, char *argv[])
 
 static int l2cap_recv(struct bt_l2cap_chan *chan, struct net_buf *buf)
 {
-	print(NULL, "Incoming data channel %p len %u\n", chan, buf->len);
+	shell_print(ctx_shell, "Incoming data channel %p len %u", chan,
+		    buf->len);
 
 	return 0;
 }
 
 static void l2cap_connected(struct bt_l2cap_chan *chan)
 {
-	print(NULL, "Channel %p connected\n", chan);
+	shell_print(ctx_shell, "Channel %p connected", chan);
 }
 
 static void l2cap_disconnected(struct bt_l2cap_chan *chan)
 {
-	print(NULL, "Channel %p disconnected\n", chan);
+	shell_print(ctx_shell, "Channel %p disconnected", chan);
 }
 
 static struct net_buf *l2cap_alloc_buf(struct bt_l2cap_chan *chan)
 {
-	print(NULL, "Channel %p requires buffer\n", chan);
+	shell_print(ctx_shell, "Channel %p requires buffer", chan);
 
 	return net_buf_alloc(&data_pool, K_FOREVER);
 }
@@ -262,10 +263,10 @@ static struct bt_l2cap_br_chan l2cap_chan = {
 
 static int l2cap_accept(struct bt_conn *conn, struct bt_l2cap_chan **chan)
 {
-	print(NULL, "Incoming BR/EDR conn %p\n", conn);
+	shell_print(ctx_shell, "Incoming BR/EDR conn %p", conn);
 
 	if (l2cap_chan.chan.conn) {
-		error(NULL, "No channels available");
+		shell_error(ctx_shell, "No channels available");
 		return -ENOMEM;
 	}
 
@@ -288,18 +289,18 @@ static int cmd_l2cap_register(const struct shell *shell,
 	}
 
 	if (br_server.psm) {
-		print(shell, "Already registered\n");
+		shell_print(shell, "Already registered");
 		return 0;
 	}
 
 	br_server.psm = strtoul(argv[1], NULL, 16);
 
 	if (bt_l2cap_br_server_register(&br_server) < 0) {
-		error(shell, "Unable to register psm\n");
+		shell_error(shell, "Unable to register psm");
 		br_server.psm = 0;
 		return -ENOEXEC;
 	} else {
-		print(shell, "L2CAP psm %u registered\n", br_server.psm);
+		shell_print(shell, "L2CAP psm %u registered", br_server.psm);
 	}
 
 	return 0;
@@ -328,11 +329,11 @@ static int cmd_discoverable(const struct shell *shell,
 	}
 
 	if (err) {
-		print(shell, "BR/EDR set/reset discoverable failed (err %d)\n",
-		      err);
+		shell_print(shell, "BR/EDR set/reset discoverable failed "
+			    "(err %d)", err);
 		return -ENOEXEC;
 	} else {
-		print(shell, "BR/EDR set/reset discoverable done\n");
+		shell_print(shell, "BR/EDR set/reset discoverable done");
 	}
 
 	return 0;
@@ -361,11 +362,11 @@ static int cmd_connectable(const struct shell *shell,
 	}
 
 	if (err) {
-		print(shell, "BR/EDR set/rest connectable failed (err %d)\n",
-		      err);
+		shell_print(shell, "BR/EDR set/rest connectable failed "
+			    "(err %d)", err);
 		return -ENOEXEC;
 	} else {
-		print(shell, "BR/EDR set/reset connectable done\n");
+		shell_print(shell, "BR/EDR set/reset connectable done");
 	}
 
 	return 0;
@@ -379,14 +380,14 @@ static int cmd_oob(const struct shell *shell, size_t argc, char *argv[])
 
 	err = bt_br_oob_get_local(&oob);
 	if (err) {
-		print(shell, "BR/EDR OOB data failed\n");
+		shell_print(shell, "BR/EDR OOB data failed");
 		return -ENOEXEC;
 	}
 
 	bt_addr_to_str(&oob.addr, addr, sizeof(addr));
 
-	print(shell, "BR/EDR OOB data:\n");
-	print(shell, "  addr %s\n", addr);
+	shell_print(shell, "BR/EDR OOB data:");
+	shell_print(shell, "  addr %s", addr);
 	return 0;
 }
 
@@ -401,9 +402,10 @@ static u8_t sdp_hfp_ag_user(struct bt_conn *conn,
 	conn_addr_str(conn, addr, sizeof(addr));
 
 	if (result) {
-		print(NULL, "SDP HFPAG data@%p (len %u) hint %u from remote %s"
-		      "\n", result->resp_buf, result->resp_buf->len,
-		      result->next_record_hint, addr);
+		shell_print(ctx_shell, "SDP HFPAG data@%p (len %u) hint %u from"
+			    " remote %s", result->resp_buf,
+			    result->resp_buf->len, result->next_record_hint,
+			    addr);
 
 		/*
 		 * Focus to get BT_SDP_ATTR_PROTO_DESC_LIST attribute item to
@@ -412,20 +414,21 @@ static u8_t sdp_hfp_ag_user(struct bt_conn *conn,
 		res = bt_sdp_get_proto_param(result->resp_buf,
 					     BT_SDP_PROTO_RFCOMM, &param);
 		if (res < 0) {
-			error(NULL, "Error getting Server CN, err %d\n", res);
+			shell_error(ctx_shell, "Error getting Server CN, "
+				    "err %d", res);
 			goto done;
 		}
-		print(NULL, "HFPAG Server CN param 0x%04x\n", param);
+		shell_print(ctx_shell, "HFPAG Server CN param 0x%04x", param);
 
 		res = bt_sdp_get_profile_version(result->resp_buf,
 						 BT_SDP_HANDSFREE_SVCLASS,
 						 &version);
 		if (res < 0) {
-			error(NULL, "Error getting profile version, err %d\n",
-			      res);
+			shell_error(ctx_shell, "Error getting profile version, "
+				    "err %d", res);
 			goto done;
 		}
-		print(NULL, "HFP version param 0x%04x\n", version);
+		shell_print(ctx_shell, "HFP version param 0x%04x", version);
 
 		/*
 		 * Focus to get BT_SDP_ATTR_SUPPORTED_FEATURES attribute item to
@@ -433,14 +436,15 @@ static u8_t sdp_hfp_ag_user(struct bt_conn *conn,
 		 */
 		res = bt_sdp_get_features(result->resp_buf, &features);
 		if (res < 0) {
-			error(NULL, "Error getting HFPAG Features, err %d\n",
-			      res);
+			shell_error(ctx_shell, "Error getting HFPAG Features, "
+				    "err %d", res);
 			goto done;
 		}
-		print(NULL, "HFPAG Supported Features param 0x%04x\n",
+		shell_print(ctx_shell, "HFPAG Supported Features param 0x%04x",
 		      features);
 	} else {
-		print(NULL, "No SDP HFPAG data from remote %s\n", addr);
+		shell_print(ctx_shell, "No SDP HFPAG data from remote %s",
+			    addr);
 	}
 done:
 	return BT_SDP_DISCOVER_UUID_CONTINUE;
@@ -457,9 +461,10 @@ static u8_t sdp_a2src_user(struct bt_conn *conn,
 	conn_addr_str(conn, addr, sizeof(addr));
 
 	if (result) {
-		print(NULL, "SDP A2SRC data@%p (len %u) hint %u from remote %s"
-		      "\n", result->resp_buf, result->resp_buf->len,
-		      result->next_record_hint, addr);
+		shell_print(ctx_shell, "SDP A2SRC data@%p (len %u) hint %u from"
+			    " remote %s", result->resp_buf,
+			    result->resp_buf->len, result->next_record_hint,
+			    addr);
 
 		/*
 		 * Focus to get BT_SDP_ATTR_PROTO_DESC_LIST attribute item to
@@ -468,11 +473,13 @@ static u8_t sdp_a2src_user(struct bt_conn *conn,
 		res = bt_sdp_get_proto_param(result->resp_buf,
 					     BT_SDP_PROTO_L2CAP, &param);
 		if (res < 0) {
-			error(NULL, "A2SRC PSM Number not found, err %d\n",
-			      res);
+			shell_error(ctx_shell, "A2SRC PSM Number not found, "
+				    "err %d", res);
 			goto done;
 		}
-		print(NULL, "A2SRC Server PSM Number param 0x%04x\n", param);
+
+		shell_print(ctx_shell, "A2SRC Server PSM Number param 0x%04x",
+			    param);
 
 		/*
 		 * Focus to get BT_SDP_ATTR_PROFILE_DESC_LIST attribute item to
@@ -482,10 +489,11 @@ static u8_t sdp_a2src_user(struct bt_conn *conn,
 						 BT_SDP_ADVANCED_AUDIO_SVCLASS,
 						 &version);
 		if (res < 0) {
-			error(NULL, "A2SRC version not found, err %d\n", res);
+			shell_error(ctx_shell, "A2SRC version not found, "
+				    "err %d", res);
 			goto done;
 		}
-		print(NULL, "A2SRC version param 0x%04x\n", version);
+		shell_print(ctx_shell, "A2SRC version param 0x%04x", version);
 
 		/*
 		 * Focus to get BT_SDP_ATTR_SUPPORTED_FEATURES attribute item to
@@ -493,13 +501,15 @@ static u8_t sdp_a2src_user(struct bt_conn *conn,
 		 */
 		res = bt_sdp_get_features(result->resp_buf, &features);
 		if (res < 0) {
-			error(NULL, "A2SRC Features not found, err %d\n", res);
+			shell_error(ctx_shell, "A2SRC Features not found, "
+				    "err %d", res);
 			goto done;
 		}
-		print(NULL, "A2SRC Supported Features param 0x%04x\n",
+		shell_print(ctx_shell, "A2SRC Supported Features param 0x%04x",
 		      features);
 	} else {
-		print(NULL, "No SDP A2SRC data from remote %s\n", addr);
+		shell_print(ctx_shell, "No SDP A2SRC data from remote %s",
+			    addr);
 	}
 done:
 	return BT_SDP_DISCOVER_UUID_CONTINUE;
@@ -526,7 +536,7 @@ static int cmd_sdp_find_record(const struct shell *shell,
 	const char *action;
 
 	if (!default_conn) {
-		print(shell, "Not connected\n");
+		shell_print(shell, "Not connected");
 		return 0;
 	}
 
@@ -547,19 +557,21 @@ static int cmd_sdp_find_record(const struct shell *shell,
 	}
 
 	if (err) {
-		error(shell, "SDP UUID to resolve not valid (err %d)\n", err);
-		print(shell, "Supported UUID are \'HFPAG\' \'A2SRC\' only\n");
+		shell_error(shell, "SDP UUID to resolve not valid (err %d)",
+			    err);
+		shell_print(shell,
+			    "Supported UUID are \'HFPAG\' \'A2SRC\' only");
 		return -ENOEXEC;
 	}
 
-	print(shell, "SDP UUID \'%s\' gets applied\n", action);
+	shell_print(shell, "SDP UUID \'%s\' gets applied", action);
 
 	res = bt_sdp_discover(default_conn, &discov);
 	if (res) {
-		error(shell, "SDP discovery failed: result %d\n", res);
+		shell_error(shell, "SDP discovery failed: result %d", res);
 		return -ENOEXEC;
 	} else {
-		print(shell, "SDP discovery started\n");
+		shell_print(shell, "SDP discovery started");
 	}
 
 	return 0;
@@ -597,7 +609,7 @@ static int cmd_br(const struct shell *shell, size_t argc, char **argv)
 		return err;
 	}
 
-	error(shell, "%s unknown parameter: %s", argv[0], argv[1]);
+	shell_error(shell, "%s unknown parameter: %s", argv[0], argv[1]);
 
 	return -ENOEXEC;
 }

--- a/subsys/bluetooth/shell/bt.c
+++ b/subsys/bluetooth/shell/bt.c
@@ -73,7 +73,7 @@ static void device_found(const bt_addr_le_t *addr, s8_t rssi, u8_t evtype,
 	bt_data_parse(buf, data_cb, name);
 
 	bt_addr_le_to_str(addr, le_addr, sizeof(le_addr));
-	print(NULL, "[DEVICE]: %s, AD evt type %u, RSSI %i %s",
+	shell_print(ctx_shell, "[DEVICE]: %s, AD evt type %u, RSSI %i %s",
 	      le_addr, evtype, rssi, name);
 }
 
@@ -139,12 +139,12 @@ static void connected(struct bt_conn *conn, u8_t err)
 	conn_addr_str(conn, addr, sizeof(addr));
 
 	if (err) {
-		error(NULL, "Failed to connect to %s (%u)", addr,
+		shell_error(ctx_shell, "Failed to connect to %s (%u)", addr,
 			     err);
 		goto done;
 	}
 
-	print(NULL, "Connected: %s", addr);
+	shell_print(ctx_shell, "Connected: %s", addr);
 
 	if (!default_conn) {
 		default_conn = bt_conn_ref(conn);
@@ -163,7 +163,7 @@ static void disconnected(struct bt_conn *conn, u8_t reason)
 	char addr[BT_ADDR_LE_STR_LEN];
 
 	conn_addr_str(conn, addr, sizeof(addr));
-	print(NULL, "Disconnected: %s (reason %u)", addr, reason);
+	shell_print(ctx_shell, "Disconnected: %s (reason %u)", addr, reason);
 
 	if (default_conn == conn) {
 		bt_conn_unref(default_conn);
@@ -173,9 +173,9 @@ static void disconnected(struct bt_conn *conn, u8_t reason)
 
 static bool le_param_req(struct bt_conn *conn, struct bt_le_conn_param *param)
 {
-	print(NULL, "LE conn  param req: int (0x%04x, 0x%04x) lat %d "
-		     "to %d", param->interval_min, param->interval_max,
-		     param->latency, param->timeout);
+	shell_print(ctx_shell, "LE conn  param req: int (0x%04x, 0x%04x) lat %d"
+		    " to %d", param->interval_min, param->interval_max,
+		    param->latency, param->timeout);
 
 	return true;
 }
@@ -183,7 +183,7 @@ static bool le_param_req(struct bt_conn *conn, struct bt_le_conn_param *param)
 static void le_param_updated(struct bt_conn *conn, u16_t interval,
 			     u16_t latency, u16_t timeout)
 {
-	print(NULL, "LE conn param updated: int 0x%04x lat %d "
+	shell_print(ctx_shell, "LE conn param updated: int 0x%04x lat %d "
 		     "to %d", interval, latency, timeout);
 }
 
@@ -197,7 +197,7 @@ static void identity_resolved(struct bt_conn *conn, const bt_addr_le_t *rpa,
 	bt_addr_le_to_str(identity, addr_identity, sizeof(addr_identity));
 	bt_addr_le_to_str(rpa, addr_rpa, sizeof(addr_rpa));
 
-	print(NULL, "Identity resolved %s -> %s", addr_rpa,
+	shell_print(ctx_shell, "Identity resolved %s -> %s", addr_rpa,
 	      addr_identity);
 }
 #endif
@@ -208,7 +208,7 @@ static void security_changed(struct bt_conn *conn, bt_security_t level)
 	char addr[BT_ADDR_LE_STR_LEN];
 
 	conn_addr_str(conn, addr, sizeof(addr));
-	print(NULL, "Security changed: %s level %u", addr, level);
+	shell_print(ctx_shell, "Security changed: %s level %u", addr, level);
 }
 #endif
 
@@ -298,11 +298,11 @@ static int str2bt_addr_le(const char *str, const char *type, bt_addr_le_t *addr)
 static void bt_ready(int err)
 {
 	if (err) {
-		error(NULL, "Bluetooth init failed (err %d)", err);
+		shell_error(ctx_shell, "Bluetooth init failed (err %d)", err);
 		return;
 	}
 
-	print(NULL, "Bluetooth initialized");
+	shell_print(ctx_shell, "Bluetooth initialized");
 
 	if (IS_ENABLED(CONFIG_SETTINGS)) {
 		settings_load();
@@ -321,7 +321,7 @@ static int cmd_init(const struct shell *shell, size_t argc, char *argv[])
 
 	err = bt_enable(bt_ready);
 	if (err) {
-		error(shell, "Bluetooth init failed (err %d)", err);
+		shell_error(shell, "Bluetooth init failed (err %d)", err);
 	}
 
 	ctx_shell = shell;
@@ -336,23 +336,23 @@ void hexdump(const struct shell *shell, const u8_t *data, size_t len)
 
 	while (len--) {
 		if (n % 16 == 0) {
-			print(shell, "%08X ", n);
+			shell_print(shell, "%08X ", n);
 		}
 
-		print(shell, "%02X ", *data++);
+		shell_print(shell, "%02X ", *data++);
 
 		n++;
 		if (n % 8 == 0) {
 			if (n % 16 == 0) {
-				print(shell, "");
+				shell_print(shell, "");
 			} else {
-				print(shell, " ");
+				shell_print(shell, " ");
 			}
 		}
 	}
 
 	if (n % 16) {
-		print(shell, "");
+		shell_print(shell, "");
 	}
 }
 #endif /* CONFIG_BT_HCI || CONFIG_BT_L2CAP_DYNAMIC_CHANNEL */
@@ -385,7 +385,7 @@ static int cmd_hci_cmd(const struct shell *shell, size_t argc, char *argv[])
 
 	err = bt_hci_cmd_send_sync(BT_OP(ogf, ocf), buf, &rsp);
 	if (err) {
-		error(shell, "HCI command failed (err %d)", err);
+		shell_error(shell, "HCI command failed (err %d)", err);
 		return err;
 	} else {
 		hexdump(shell, rsp->data, rsp->len);
@@ -401,12 +401,13 @@ static int cmd_name(const struct shell *shell, size_t argc, char *argv[])
 	int err;
 
 	if (argc < 2) {
-		print(shell, "Bluetooth Local Name: %s", bt_get_name());
+		shell_print(shell, "Bluetooth Local Name: %s", bt_get_name());
 	}
 
 	err = bt_set_name(argv[1]);
 	if (err) {
-		error(shell, "Unable to set name %s (err %d)", argv[1], err);
+		shell_error(shell, "Unable to set name %s (err %d)", argv[1],
+			    err);
 		return err;
 	}
 
@@ -422,7 +423,7 @@ static int cmd_id_create(const struct shell *shell, size_t argc, char *argv[])
 	if (argc > 1) {
 		err = str2bt_addr_le(argv[1], "random", &addr);
 		if (err) {
-			error(shell, "Invalid address");
+			shell_error(shell, "Invalid address");
 		}
 	} else {
 		bt_addr_le_copy(&addr, BT_ADDR_LE_ANY);
@@ -430,11 +431,11 @@ static int cmd_id_create(const struct shell *shell, size_t argc, char *argv[])
 
 	err = bt_id_create(&addr, NULL);
 	if (err < 0) {
-		error(shell, "Creating new ID failed (err %d)", err);
+		shell_error(shell, "Creating new ID failed (err %d)", err);
 	}
 
 	bt_addr_le_to_str(&addr, addr_str, sizeof(addr_str));
-	print(shell, "New identity (%d) created: %s", err, addr_str);
+	shell_print(shell, "New identity (%d) created: %s", err, addr_str);
 
 	return 0;
 }
@@ -447,7 +448,7 @@ static int cmd_id_reset(const struct shell *shell, size_t argc, char *argv[])
 	int err;
 
 	if (argc < 2) {
-		error(shell, "Identity identifier not specified");
+		shell_error(shell, "Identity identifier not specified");
 		return -ENOEXEC;
 	}
 
@@ -456,7 +457,7 @@ static int cmd_id_reset(const struct shell *shell, size_t argc, char *argv[])
 	if (argc > 2) {
 		err = str2bt_addr_le(argv[2], "random", &addr);
 		if (err) {
-			print(shell, "Invalid address");
+			shell_print(shell, "Invalid address");
 			return err;
 		}
 	} else {
@@ -465,12 +466,12 @@ static int cmd_id_reset(const struct shell *shell, size_t argc, char *argv[])
 
 	err = bt_id_reset(id, &addr, NULL);
 	if (err < 0) {
-		print(shell, "Resetting ID %u failed (err %d)", id, err);
+		shell_print(shell, "Resetting ID %u failed (err %d)", id, err);
 		return err;
 	}
 
 	bt_addr_le_to_str(&addr, addr_str, sizeof(addr_str));
-	print(shell, "Identity %u reset: %s", id, addr_str);
+	shell_print(shell, "Identity %u reset: %s", id, addr_str);
 
 	return 0;
 }
@@ -481,7 +482,7 @@ static int cmd_id_delete(const struct shell *shell, size_t argc, char *argv[])
 	int err;
 
 	if (argc < 2) {
-		error(shell, "Identity identifier not specified");
+		shell_error(shell, "Identity identifier not specified");
 		return -ENOEXEC;
 	}
 
@@ -489,11 +490,11 @@ static int cmd_id_delete(const struct shell *shell, size_t argc, char *argv[])
 
 	err = bt_id_delete(id);
 	if (err < 0) {
-		error(shell, "Deleting ID %u failed (err %d)", id, err);
+		shell_error(shell, "Deleting ID %u failed (err %d)", id, err);
 		return err;
 	}
 
-	print(shell, "Identity %u deleted", id);
+	shell_print(shell, "Identity %u deleted", id);
 
 	return 0;
 }
@@ -509,7 +510,7 @@ static int cmd_id_show(const struct shell *shell, size_t argc, char *argv[])
 		char addr_str[BT_ADDR_LE_STR_LEN];
 
 		bt_addr_le_to_str(&addrs[i], addr_str, sizeof(addr_str));
-		print(shell, "%s%zu: %s", i == selected_id ? "*" : " ", i,
+		shell_print(shell, "%s%zu: %s", i == selected_id ? "*" : " ", i,
 		      addr_str);
 	}
 
@@ -533,12 +534,12 @@ static int cmd_id_select(const struct shell *shell, size_t argc, char *argv[])
 
 	bt_id_get(addrs, &count);
 	if (count <= id) {
-		error(shell, "Invalid identity");
+		shell_error(shell, "Invalid identity");
 		return -ENOEXEC;
 	}
 
 	bt_addr_le_to_str(&addrs[id], addr_str, sizeof(addr_str));
-	print(shell, "Selected identity: %s", addr_str);
+	shell_print(shell, "Selected identity: %s", addr_str);
 	selected_id = id;
 
 	return 0;
@@ -559,11 +560,11 @@ static int cmd_active_scan_on(const struct shell *shell, int dups)
 
 	err = bt_le_scan_start(&param, device_found);
 	if (err) {
-		error(shell, "Bluetooth set active scan failed "
+		shell_error(shell, "Bluetooth set active scan failed "
 		      "(err %d)", err);
 		return err;
 	} else {
-		print(shell, "Bluetooth active scan enabled");
+		shell_print(shell, "Bluetooth active scan enabled");
 	}
 
 	return 0;
@@ -584,11 +585,11 @@ static int cmd_passive_scan_on(const struct shell *shell, int dups)
 
 	err = bt_le_scan_start(&param, device_found);
 	if (err) {
-		error(shell, "Bluetooth set passive scan failed "
+		shell_error(shell, "Bluetooth set passive scan failed "
 			    "(err %d)", err);
 		return err;
 	} else {
-		print(shell, "Bluetooth passive scan enabled");
+		shell_print(shell, "Bluetooth passive scan enabled");
 	}
 
 	return 0;
@@ -600,10 +601,10 @@ static int cmd_scan_off(const struct shell *shell)
 
 	err = bt_le_scan_stop();
 	if (err) {
-		error(shell, "Stopping scanning failed (err %d)", err);
+		shell_error(shell, "Stopping scanning failed (err %d)", err);
 		return err;
 	} else {
-		print(shell, "Scan successfully stopped");
+		shell_print(shell, "Scan successfully stopped");
 	}
 
 	return 0;
@@ -669,10 +670,10 @@ static int cmd_advertise(const struct shell *shell, size_t argc, char *argv[])
 
 	if (!strcmp(argv[1], "off")) {
 		if (bt_le_adv_stop() < 0) {
-			error(shell, "Failed to stop advertising");
+			shell_error(shell, "Failed to stop advertising");
 			return -ENOEXEC;
 		} else {
-			print(shell, "Advertising stopped");
+			shell_print(shell, "Advertising stopped");
 		}
 
 		return 0;
@@ -713,11 +714,11 @@ static int cmd_advertise(const struct shell *shell, size_t argc, char *argv[])
 
 	err = bt_le_adv_start(&param, ad, ad_len, NULL, 0);
 	if (err < 0) {
-		error(shell, "Failed to start advertising (err %d)",
+		shell_error(shell, "Failed to start advertising (err %d)",
 			    err);
 		return err;
 	} else {
-		print(shell, "Advertising started");
+		shell_print(shell, "Advertising started");
 	}
 
 	return 0;
@@ -742,18 +743,18 @@ static int cmd_connect_le(const struct shell *shell, size_t argc, char *argv[])
 
 	err = str2bt_addr_le(argv[1], argv[2], &addr);
 	if (err) {
-		error(shell, "Invalid peer address (err %d)", err);
+		shell_error(shell, "Invalid peer address (err %d)", err);
 		return err;
 	}
 
 	conn = bt_conn_create_le(&addr, BT_LE_CONN_PARAM_DEFAULT);
 
 	if (!conn) {
-		error(shell, "Connection failed");
+		shell_error(shell, "Connection failed");
 		return -ENOEXEC;
 	} else {
 
-		print(shell, "Connection pending");
+		shell_print(shell, "Connection pending");
 
 		/* unref connection obj in advance as app user */
 		bt_conn_unref(conn);
@@ -780,7 +781,7 @@ static int cmd_disconnect(const struct shell *shell, size_t argc, char *argv[])
 
 		err = str2bt_addr_le(argv[1], argv[2], &addr);
 		if (err) {
-			error(shell, "Invalid peer address (err %d)",
+			shell_error(shell, "Invalid peer address (err %d)",
 				    err);
 			return err;
 		}
@@ -789,13 +790,13 @@ static int cmd_disconnect(const struct shell *shell, size_t argc, char *argv[])
 	}
 
 	if (!conn) {
-		error(shell, "Not connected");
+		shell_error(shell, "Not connected");
 		return -ENOEXEC;
 	}
 
 	err = bt_conn_disconnect(conn, BT_HCI_ERR_REMOTE_USER_TERM_CONN);
 	if (err) {
-		error(shell, "Disconnection failed (err %d)", err);
+		shell_error(shell, "Disconnection failed (err %d)", err);
 		return err;
 	}
 
@@ -817,7 +818,7 @@ static int cmd_auto_conn(const struct shell *shell, size_t argc, char *argv[])
 
 	err = str2bt_addr_le(argv[1], argv[2], &addr);
 	if (err) {
-		error(shell, "Invalid peer address (err %d)", err);
+		shell_error(shell, "Invalid peer address (err %d)", err);
 		return err;
 	}
 
@@ -851,7 +852,7 @@ static int cmd_directed_adv(const struct shell *shell,
 
 	err = str2bt_addr_le(argv[1], argv[2], &addr);
 	if (err) {
-		error(shell, "Invalid peer address (err %d)", err);
+		shell_error(shell, "Invalid peer address (err %d)", err);
 		return err;
 	}
 
@@ -870,10 +871,10 @@ static int cmd_directed_adv(const struct shell *shell,
 connect:
 	conn = bt_conn_create_slave_le(&addr, param);
 	if (!conn) {
-		error(shell, "Failed to start directed advertising");
+		shell_error(shell, "Failed to start directed advertising");
 		return -ENOEXEC;
 	} else {
-		print(shell, "Started directed advertising");
+		shell_print(shell, "Started directed advertising");
 
 		/* unref connection obj in advance as app user */
 		bt_conn_unref(conn);
@@ -895,13 +896,13 @@ static int cmd_select(const struct shell *shell, size_t argc, char *argv[])
 
 	err = str2bt_addr_le(argv[1], argv[2], &addr);
 	if (err) {
-		error(shell, "Invalid peer address (err %d)", err);
+		shell_error(shell, "Invalid peer address (err %d)", err);
 		return err;
 	}
 
 	conn = bt_conn_lookup_addr_le(BT_ID_DEFAULT, &addr);
 	if (!conn) {
-		error(shell, "No matching connection found");
+		shell_error(shell, "No matching connection found");
 		return -ENOEXEC;
 	}
 
@@ -932,9 +933,9 @@ static int cmd_conn_update(const struct shell *shell,
 
 	err = bt_conn_le_param_update(default_conn, &param);
 	if (err) {
-		error(shell, "conn update failed (err %d).", err);
+		shell_error(shell, "conn update failed (err %d).", err);
 	} else {
-		print(shell, "conn update initiated.");
+		shell_print(shell, "conn update initiated.");
 	}
 
 	return err;
@@ -948,14 +949,14 @@ static int cmd_oob(const struct shell *shell, size_t argc, char *argv[])
 
 	err = bt_le_oob_get_local(selected_id, &oob);
 	if (err) {
-		error(shell, "OOB data failed");
+		shell_error(shell, "OOB data failed");
 		return err;
 	}
 
 	bt_addr_le_to_str(&oob.addr, addr, sizeof(addr));
 
-	print(shell, "OOB data:");
-	print(shell, "  addr %s", addr);
+	shell_print(shell, "OOB data:");
+	shell_print(shell, "  addr %s", addr);
 
 	return 0;
 }
@@ -966,18 +967,18 @@ static int cmd_clear(const struct shell *shell, size_t argc, char *argv[])
 	int err;
 
 	if (argc < 2) {
-		error(shell, "Specify remote address or \"all\"");
+		shell_error(shell, "Specify remote address or \"all\"");
 		return -ENOEXEC;
 	}
 
 	if (strcmp(argv[1], "all") == 0) {
 		err = bt_unpair(selected_id, NULL);
 		if (err) {
-			error(shell, "Failed to clear pairings (err %d)",
+			shell_error(shell, "Failed to clear pairings (err %d)",
 			      err);
 			return err;
 		} else {
-			print(shell, "Pairings successfully cleared");
+			shell_print(shell, "Pairings successfully cleared");
 		}
 
 		return 0;
@@ -988,7 +989,7 @@ static int cmd_clear(const struct shell *shell, size_t argc, char *argv[])
 		addr.type = BT_ADDR_LE_PUBLIC;
 		err = str2bt_addr(argv[1], &addr.a);
 #else
-		print(shell, "Both address and address type needed");
+		shell_print(shell, "Both address and address type needed");
 		return -ENOEXEC;
 #endif
 	} else {
@@ -996,15 +997,15 @@ static int cmd_clear(const struct shell *shell, size_t argc, char *argv[])
 	}
 
 	if (err) {
-		print(shell, "Invalid address");
+		shell_print(shell, "Invalid address");
 		return err;
 	}
 
 	err = bt_unpair(selected_id, &addr);
 	if (err) {
-		error(shell, "Failed to clear pairing (err %d)", err);
+		shell_error(shell, "Failed to clear pairing (err %d)", err);
 	} else {
-		print(shell, "Pairing successfully cleared");
+		shell_print(shell, "Pairing successfully cleared");
 	}
 
 	return err;
@@ -1022,15 +1023,15 @@ static int cmd_chan_map(const struct shell *shell, size_t argc, char *argv[])
 
 	err = hexstr2array(argv[1], chan_map, 5);
 	if (err) {
-		error(shell, "Invalid channel map");
+		shell_error(shell, "Invalid channel map");
 		return -ENOEXEC;
 	}
 
 	err = bt_le_set_chan_map(chan_map);
 	if (err) {
-		error(shell, "Failed to set channel map (err %d)", err);
+		shell_error(shell, "Failed to set channel map (err %d)", err);
 	} else {
-		print(shell, "Channel map set");
+		shell_print(shell, "Channel map set");
 	}
 
 	return err;
@@ -1043,7 +1044,7 @@ static int cmd_security(const struct shell *shell, size_t argc, char *argv[])
 	int err, sec;
 
 	if (!default_conn) {
-		error(shell, "Not connected");
+		shell_error(shell, "Not connected");
 		return -ENOEXEC;
 	}
 
@@ -1056,7 +1057,7 @@ static int cmd_security(const struct shell *shell, size_t argc, char *argv[])
 
 	err = bt_conn_security(default_conn, sec);
 	if (err) {
-		error(shell, "Setting security failed (err %d)", err);
+		shell_error(shell, "Setting security failed (err %d)", err);
 	}
 
 	return err;
@@ -1095,7 +1096,7 @@ static void auth_passkey_display(struct bt_conn *conn, unsigned int passkey)
 
 	snprintk(passkey_str, 7, "%06u", passkey);
 
-	print(NULL, "Passkey for %s: %s", addr, passkey_str);
+	shell_print(ctx_shell, "Passkey for %s: %s", addr, passkey_str);
 }
 
 static void auth_passkey_confirm(struct bt_conn *conn, unsigned int passkey)
@@ -1107,7 +1108,7 @@ static void auth_passkey_confirm(struct bt_conn *conn, unsigned int passkey)
 
 	snprintk(passkey_str, 7, "%06u", passkey);
 
-	print(NULL, "Confirm passkey for %s: %s", addr, passkey_str);
+	shell_print(ctx_shell, "Confirm passkey for %s: %s", addr, passkey_str);
 }
 
 static void auth_passkey_entry(struct bt_conn *conn)
@@ -1116,7 +1117,7 @@ static void auth_passkey_entry(struct bt_conn *conn)
 
 	bt_addr_le_to_str(bt_conn_get_dst(conn), addr, sizeof(addr));
 
-	print(NULL, "Enter passkey for %s", addr);
+	shell_print(ctx_shell, "Enter passkey for %s", addr);
 }
 
 static void auth_cancel(struct bt_conn *conn)
@@ -1125,7 +1126,7 @@ static void auth_cancel(struct bt_conn *conn)
 
 	conn_addr_str(conn, addr, sizeof(addr));
 
-	print(NULL, "Pairing cancelled: %s", addr);
+	shell_print(ctx_shell, "Pairing cancelled: %s", addr);
 
 	/* clear connection reference for sec mode 3 pairing */
 	if (pairing_conn) {
@@ -1140,7 +1141,7 @@ static void auth_pairing_confirm(struct bt_conn *conn)
 
 	bt_addr_le_to_str(bt_conn_get_dst(conn), addr, sizeof(addr));
 
-	print(NULL, "Confirm pairing for %s", addr);
+	shell_print(ctx_shell, "Confirm pairing for %s", addr);
 }
 
 static void auth_pairing_complete(struct bt_conn *conn, bool bonded)
@@ -1149,7 +1150,8 @@ static void auth_pairing_complete(struct bt_conn *conn, bool bonded)
 
 	bt_addr_le_to_str(bt_conn_get_dst(conn), addr, sizeof(addr));
 
-	print(NULL, "%s with %s", bonded ? "Bonded" : "Paired",  addr);
+	shell_print(ctx_shell, "%s with %s", bonded ? "Bonded" : "Paired",
+		    addr);
 }
 
 static void auth_pairing_failed(struct bt_conn *conn)
@@ -1158,7 +1160,7 @@ static void auth_pairing_failed(struct bt_conn *conn)
 
 	bt_addr_le_to_str(bt_conn_get_dst(conn), addr, sizeof(addr));
 
-	print(NULL, "Pairing failed with %s", addr);
+	shell_print(ctx_shell, "Pairing failed with %s", addr);
 }
 
 #if defined(CONFIG_BT_BREDR)
@@ -1178,10 +1180,10 @@ static void auth_pincode_entry(struct bt_conn *conn, bool highsec)
 	bt_addr_to_str(info.br.dst, addr, sizeof(addr));
 
 	if (highsec) {
-		print(NULL, "Enter 16 digits wide PIN code for %s",
-		      addr);
+		shell_print(ctx_shell, "Enter 16 digits wide PIN code for %s",
+			    addr);
 	} else {
-		print(NULL, "Enter PIN code for %s", addr);
+		shell_print(ctx_shell, "Enter PIN code for %s", addr);
 	}
 
 	/*
@@ -1299,7 +1301,7 @@ static int cmd_auth_cancel(const struct shell *shell,
 	}
 
 	if (!conn) {
-		print(shell, "Not connected");
+		shell_print(shell, "Not connected");
 		return -ENOEXEC;
 	}
 
@@ -1312,7 +1314,7 @@ static int cmd_auth_passkey_confirm(const struct shell *shell,
 				    size_t argc, char *argv[])
 {
 	if (!default_conn) {
-		print(shell, "Not connected");
+		shell_print(shell, "Not connected");
 		return -ENOEXEC;
 	}
 
@@ -1324,7 +1326,7 @@ static int cmd_auth_pairing_confirm(const struct shell *shell,
 				    size_t argc, char *argv[])
 {
 	if (!default_conn) {
-		print(shell, "Not connected");
+		shell_print(shell, "Not connected");
 		return -ENOEXEC;
 	}
 
@@ -1341,19 +1343,20 @@ static int cmd_fixed_passkey(const struct shell *shell,
 
 	if (argc < 2) {
 		bt_passkey_set(BT_PASSKEY_INVALID);
-		print(shell, "Fixed passkey cleared");
+		shell_print(shell, "Fixed passkey cleared");
 		return 0;
 	}
 
 	passkey = atoi(argv[1]);
 	if (passkey > 999999) {
-		print(shell, "Passkey should be between 0-999999");
+		shell_print(shell, "Passkey should be between 0-999999");
 		return -ENOEXEC;
 	}
 
 	err = bt_passkey_set(passkey);
 	if (err) {
-		print(shell, "Setting fixed passkey failed (err %d)", err);
+		shell_print(shell, "Setting fixed passkey failed (err %d)",
+			    err);
 	}
 
 	return err;
@@ -1367,7 +1370,7 @@ static int cmd_auth_passkey(const struct shell *shell,
 	unsigned int passkey;
 
 	if (!default_conn) {
-		print(shell, "Not connected");
+		shell_print(shell, "Not connected");
 		return -ENOEXEC;
 	}
 
@@ -1378,7 +1381,7 @@ static int cmd_auth_passkey(const struct shell *shell,
 
 	passkey = atoi(argv[1]);
 	if (passkey > 999999) {
-		print(shell, "Passkey should be between 0-999999");
+		shell_print(shell, "Passkey should be between 0-999999");
 		return -EINVAL;
 	}
 
@@ -1468,7 +1471,7 @@ static int cmd_bt(const struct shell *shell, size_t argc, char **argv)
 		return err;
 	}
 
-	error(shell, "%s unknown parameter: %s", argv[0], argv[1]);
+	shell_error(shell, "%s unknown parameter: %s", argv[0], argv[1]);
 
 	return -EINVAL;
 }

--- a/subsys/bluetooth/shell/bt.c
+++ b/subsys/bluetooth/shell/bt.c
@@ -365,11 +365,6 @@ static int cmd_hci_cmd(const struct shell *shell, size_t argc, char *argv[])
 	struct net_buf *buf = NULL, *rsp;
 	int err;
 
-	err = shell_cmd_precheck(shell, (argc == 3), NULL, 0);
-	if (err) {
-		return err;
-	}
-
 	ogf = strtoul(argv[1], NULL, 16);
 	ocf = strtoul(argv[2], NULL, 16);
 
@@ -524,12 +519,6 @@ static int cmd_id_select(const struct shell *shell, size_t argc, char *argv[])
 	size_t count = CONFIG_BT_ID_MAX;
 	u8_t id;
 
-	if (argc < 2) {
-		shell_help_print(shell, NULL, 0);
-		/* shell_cmd_precheck returns 1 when help is printed */
-		return 1;
-	}
-
 	id = strtol(argv[1], NULL, 10);
 
 	bt_id_get(addrs, &count);
@@ -614,12 +603,6 @@ static int cmd_scan(const struct shell *shell, size_t argc, char *argv[])
 {
 	const char *action;
 	int dups = -1;
-	int err;
-
-	err = shell_cmd_precheck(shell, (argc >= 2), NULL, 0);
-	if (err) {
-		return err;
-	}
 
 	/* Parse duplicate filtering data */
 	if (argc >= 3) {
@@ -662,11 +645,6 @@ static int cmd_advertise(const struct shell *shell, size_t argc, char *argv[])
 	const struct bt_data *ad;
 	size_t ad_len;
 	int err;
-
-	err = shell_cmd_precheck(shell, (argc >= 2), NULL, 0);
-	if (err) {
-		return err;
-	}
 
 	if (!strcmp(argv[1], "off")) {
 		if (bt_le_adv_stop() < 0) {
@@ -734,12 +712,6 @@ static int cmd_connect_le(const struct shell *shell, size_t argc, char *argv[])
 	int err;
 	bt_addr_le_t addr;
 	struct bt_conn *conn;
-
-	if (argc < 3) {
-		shell_help_print(shell, NULL, 0);
-		/* shell_cmd_precheck returns 1 when help is printed */
-		return 1;
-	}
 
 	err = str2bt_addr_le(argv[1], argv[2], &addr);
 	if (err) {
@@ -810,12 +782,6 @@ static int cmd_auto_conn(const struct shell *shell, size_t argc, char *argv[])
 	bt_addr_le_t addr;
 	int err;
 
-	if (argc < 3) {
-		shell_help_print(shell, NULL, 0);
-		/* shell_cmd_precheck returns 1 when help is printed */
-		return 1;
-	}
-
 	err = str2bt_addr_le(argv[1], argv[2], &addr);
 	if (err) {
 		shell_error(shell, "Invalid peer address (err %d)", err);
@@ -844,11 +810,6 @@ static int cmd_directed_adv(const struct shell *shell,
 	bt_addr_le_t addr;
 	struct bt_conn *conn;
 	struct bt_le_adv_param *param = BT_LE_ADV_CONN_DIR;
-
-	err = shell_cmd_precheck(shell, (argc >= 2), NULL, 0);
-	if (err) {
-		return err;
-	}
 
 	err = str2bt_addr_le(argv[1], argv[2], &addr);
 	if (err) {
@@ -889,11 +850,6 @@ static int cmd_select(const struct shell *shell, size_t argc, char *argv[])
 	bt_addr_le_t addr;
 	int err;
 
-	err = shell_cmd_precheck(shell, (argc == 3), NULL, 0);
-	if (err) {
-		return err;
-	}
-
 	err = str2bt_addr_le(argv[1], argv[2], &addr);
 	if (err) {
 		shell_error(shell, "Invalid peer address (err %d)", err);
@@ -920,11 +876,6 @@ static int cmd_conn_update(const struct shell *shell,
 {
 	struct bt_le_conn_param param;
 	int err;
-
-	err = shell_cmd_precheck(shell, (argc == 5), NULL, 0);
-	if (err) {
-		return err;
-	}
 
 	param.interval_min = strtoul(argv[1], NULL, 16);
 	param.interval_max = strtoul(argv[2], NULL, 16);
@@ -1016,11 +967,6 @@ static int cmd_chan_map(const struct shell *shell, size_t argc, char *argv[])
 	u8_t chan_map[5] = {};
 	int err;
 
-	err = shell_cmd_precheck(shell, (argc == 2), NULL, 0);
-	if (err) {
-		return err;
-	}
-
 	err = hexstr2array(argv[1], chan_map, 5);
 	if (err) {
 		shell_error(shell, "Invalid channel map");
@@ -1048,11 +994,6 @@ static int cmd_security(const struct shell *shell, size_t argc, char *argv[])
 		return -ENOEXEC;
 	}
 
-	err = shell_cmd_precheck(shell, (argc == 2), NULL, 0);
-	if (err) {
-		return err;
-	}
-
 	sec = *argv[1] - '0';
 
 	err = bt_conn_security(default_conn, sec);
@@ -1066,12 +1007,6 @@ static int cmd_security(const struct shell *shell, size_t argc, char *argv[])
 static int cmd_bondable(const struct shell *shell, size_t argc, char *argv[])
 {
 	const char *bondable;
-	int err;
-
-	err = shell_cmd_precheck(shell, (argc == 2), NULL, 0);
-	if (err) {
-		return err;
-	}
 
 	bondable = argv[1];
 	if (!strcmp(bondable, "on")) {
@@ -1260,12 +1195,6 @@ static struct bt_conn_auth_cb auth_cb_all = {
 
 static int cmd_auth(const struct shell *shell, size_t argc, char *argv[])
 {
-	int err = shell_cmd_precheck(shell, (argc == 2), NULL, 0);
-
-	if (err) {
-		return err;
-	}
-
 	if (!strcmp(argv[1], "all")) {
 		bt_conn_auth_cb_register(&auth_cb_all);
 	} else if (!strcmp(argv[1], "input")) {
@@ -1366,17 +1295,11 @@ static int cmd_fixed_passkey(const struct shell *shell,
 static int cmd_auth_passkey(const struct shell *shell,
 			    size_t argc, char *argv[])
 {
-	int err;
 	unsigned int passkey;
 
 	if (!default_conn) {
 		shell_print(shell, "Not connected");
 		return -ENOEXEC;
-	}
-
-	err = shell_cmd_precheck(shell, (argc == 2), NULL, 0);
-	if (err) {
-		return err;
 	}
 
 	passkey = atoi(argv[1]);
@@ -1395,80 +1318,80 @@ static int cmd_auth_passkey(const struct shell *shell,
 #define HELP_ADDR_LE "<address: XX:XX:XX:XX:XX:XX> <type: (public|random)>"
 
 SHELL_CREATE_STATIC_SUBCMD_SET(bt_cmds) {
-	SHELL_CMD(init, NULL, HELP_ADDR_LE, cmd_init),
+	SHELL_CMD_ARG(init, NULL, HELP_ADDR_LE, cmd_init, 1, 0),
 #if defined(CONFIG_BT_HCI)
-	SHELL_CMD(hci-cmd, NULL, "<ogf> <ocf> [data]", cmd_hci_cmd),
+	SHELL_CMD_ARG(hci-cmd, NULL, "<ogf> <ocf> [data]", cmd_hci_cmd, 3, 1),
 #endif
-	SHELL_CMD(id-create, NULL, "[addr]", cmd_id_create),
-	SHELL_CMD(id-reset, NULL, "<id> [addr]", cmd_id_reset),
-	SHELL_CMD(id-delete, NULL, "<id>", cmd_id_delete),
-	SHELL_CMD(id-show, NULL, HELP_NONE, cmd_id_show),
-	SHELL_CMD(id-select, NULL, "<id>", cmd_id_select),
-	SHELL_CMD(name, NULL, "[name]", cmd_name),
-	SHELL_CMD(scan, NULL,
-		  "<value: on, passive, off> <dup filter: dups, nodups>",
-		  cmd_scan),
-	SHELL_CMD(advertise, NULL,
-		  "<type: off, on, scan, nconn> <mode: discov, non_discov>",
-		  cmd_advertise),
+	SHELL_CMD_ARG(id-create, NULL, "[addr]", cmd_id_create, 1, 1),
+	SHELL_CMD_ARG(id-reset, NULL, "<id> [addr]", cmd_id_reset, 2, 1),
+	SHELL_CMD_ARG(id-delete, NULL, "<id>", cmd_id_delete, 2, 0),
+	SHELL_CMD_ARG(id-show, NULL, HELP_NONE, cmd_id_show, 1, 0),
+	SHELL_CMD_ARG(id-select, NULL, "<id>", cmd_id_select, 2, 0),
+	SHELL_CMD_ARG(name, NULL, "[name]", cmd_name, 1, 1),
+	SHELL_CMD_ARG(scan, NULL,
+		      "<value: on, passive, off> <dup filter: dups, nodups>",
+		      cmd_scan, 3, 0),
+	SHELL_CMD_ARG(advertise, NULL,
+		      "<type: off, on, scan, nconn> <mode: discov, non_discov>",
+		      cmd_advertise, 3, 0),
 #if defined(CONFIG_BT_CONN)
-	SHELL_CMD(connect, NULL, HELP_ADDR_LE, cmd_connect_le),
-	SHELL_CMD(disconnect, NULL, HELP_NONE, cmd_disconnect),
-	SHELL_CMD(auto-conn, NULL, HELP_ADDR_LE, cmd_auto_conn),
-	SHELL_CMD(directed-adv, NULL, HELP_ADDR_LE " [mode: low]",
-		  cmd_directed_adv),
-	SHELL_CMD(select, NULL, HELP_ADDR_LE, cmd_select),
-	SHELL_CMD(conn-update, NULL, "<min> <max> <latency> <timeout>",
-		  cmd_conn_update),
-	SHELL_CMD(oob, NULL, NULL, cmd_oob),
-	SHELL_CMD(clear, NULL, NULL, cmd_clear),
-	SHELL_CMD(channel-map, NULL, "<channel-map: XX:XX:XX:XX:XX> (36-0)",
-		  cmd_chan_map),
+	SHELL_CMD_ARG(connect, NULL, HELP_ADDR_LE, cmd_connect_le, 3, 0),
+	SHELL_CMD_ARG(disconnect, NULL, HELP_NONE, cmd_disconnect, 1, 0),
+	SHELL_CMD_ARG(auto-conn, NULL, HELP_ADDR_LE, cmd_auto_conn, 3, 0),
+	SHELL_CMD_ARG(directed-adv, NULL, HELP_ADDR_LE " [mode: low]",
+		      cmd_directed_adv, 1, 1),
+	SHELL_CMD_ARG(select, NULL, HELP_ADDR_LE, cmd_select, 3, 0),
+	SHELL_CMD_ARG(conn-update, NULL, "<min> <max> <latency> <timeout>",
+		      cmd_conn_update, 5, 0),
+	SHELL_CMD_ARG(oob, NULL, NULL, cmd_oob, 1, 0),
+	SHELL_CMD_ARG(clear, NULL, NULL, cmd_clear, 1, 0),
+	SHELL_CMD_ARG(channel-map, NULL, "<channel-map: XX:XX:XX:XX:XX> (36-0)",
+		      cmd_chan_map, 2, 1),
 #if defined(CONFIG_BT_SMP) || defined(CONFIG_BT_BREDR)
-	SHELL_CMD(security, NULL, "<security level: 0, 1, 2, 3>", cmd_security),
-	SHELL_CMD(bondable, NULL, "<bondable: on, off>", cmd_bondable),
-	SHELL_CMD(auth, NULL,
-		  "<auth method: all, input, display, yesno, confirm, none>",
-		  cmd_auth),
-	SHELL_CMD(auth-cancel, NULL, HELP_NONE, cmd_auth_cancel),
-	SHELL_CMD(auth-passkey, NULL, "<passkey>", cmd_auth_passkey),
-	SHELL_CMD(auth-passkey-confirm, NULL, HELP_NONE,
-		  cmd_auth_passkey_confirm),
-	SHELL_CMD(auth-pairing-confirm, NULL, HELP_NONE,
-		  cmd_auth_pairing_confirm),
+	SHELL_CMD_ARG(security, NULL, "<security level: 0, 1, 2, 3>",
+		      cmd_security, 2, 0),
+	SHELL_CMD_ARG(bondable, NULL, "<bondable: on, off>", cmd_bondable,
+		      2, 0),
+	SHELL_CMD_ARG(auth, NULL,
+		      "<method: all, input, display, yesno, confirm, none>",
+		      cmd_auth, 2, 0),
+	SHELL_CMD_ARG(auth-cancel, NULL, HELP_NONE, cmd_auth_cancel, 1, 0),
+	SHELL_CMD_ARG(auth-passkey, NULL, "<passkey>", cmd_auth_passkey, 2, 0),
+	SHELL_CMD_ARG(auth-passkey-confirm, NULL, HELP_NONE,
+		      cmd_auth_passkey_confirm, 1, 0),
+	SHELL_CMD_ARG(auth-pairing-confirm, NULL, HELP_NONE,
+		      cmd_auth_pairing_confirm, 1, 0),
 #if defined(CONFIG_BT_FIXED_PASSKEY)
-	SHELL_CMD(fixed-passkey, NULL, "[passkey]", cmd_fixed_passkey),
+	SHELL_CMD_ARG(fixed-passkey, NULL, "[passkey]", cmd_fixed_passkey,
+		      1, 1),
 #endif
 #endif /* CONFIG_BT_SMP || CONFIG_BT_BREDR) */
 #endif /* CONFIG_BT_CONN */
 #if defined(CONFIG_BT_CTLR_ADV_EXT)
-	SHELL_CMD(advx, NULL, "<on off> [coded] [anon] [txp]", cmd_advx),
-	SHELL_CMD(scanx, NULL, "<on passive off> [coded]", cmd_scanx),
+	SHELL_CMD_ARG(advx, NULL, "<on off> [coded] [anon] [txp]", cmd_advx,
+		      2, 3),
+	SHELL_CMD_ARG(scanx, NULL, "<on passive off> [coded]", cmd_scanx,
+		      2, 1),
 #endif /* CONFIG_BT_CTLR_ADV_EXT */
 #if defined(CONFIG_BT_LL_SW)
-	SHELL_CMD(ll-addr, NULL, "<random|public>", cmd_ll_addr_get),
+	SHELL_CMD_ARG(ll-addr, NULL, "<random|public>", cmd_ll_addr_get, 2, 0),
 #endif
 #if defined(CONFIG_BT_CTLR_DTM)
-	SHELL_CMD(test_tx, NULL, "<chan> <len> <type> <phy>", cmd_test_tx),
-	SHELL_CMD(test_rx, NULL, "<chan> <phy> <mod_idx>", cmd_test_rx),
-	SHELL_CMD(test_end, NULL, HELP_NONE, cmd_test_end),
+	SHELL_CMD_ARG(test_tx, NULL, "<chan> <len> <type> <phy>", cmd_test_tx,
+		      5, 0),
+	SHELL_CMD_ARG(test_rx, NULL, "<chan> <phy> <mod_idx>", cmd_test_rx,
+		      4, 0),
+	SHELL_CMD_ARG(test_end, NULL, HELP_NONE, cmd_test_end, 1, 0),
 #endif /* CONFIG_BT_CTLR_ADV_EXT */
 	SHELL_SUBCMD_SET_END
 };
 
 static int cmd_bt(const struct shell *shell, size_t argc, char **argv)
 {
-	int err;
-
 	if (argc == 1) {
 		shell_help_print(shell, NULL, 0);
 		/* shell_cmd_precheck returns 1 when help is printed */
 		return 1;
-	}
-
-	err = shell_cmd_precheck(shell, (argc == 2), NULL, 0);
-	if (err) {
-		return err;
 	}
 
 	shell_error(shell, "%s unknown parameter: %s", argv[0], argv[1]);
@@ -1476,4 +1399,4 @@ static int cmd_bt(const struct shell *shell, size_t argc, char **argv)
 	return -EINVAL;
 }
 
-SHELL_CMD_REGISTER(bt, &bt_cmds, "Bluetooth shell commands", cmd_bt);
+SHELL_CMD_ARG_REGISTER(bt, &bt_cmds, "Bluetooth shell commands", cmd_bt, 1, 1);

--- a/subsys/bluetooth/shell/bt.h
+++ b/subsys/bluetooth/shell/bt.h
@@ -14,14 +14,6 @@
 #define __BT_H
 
 extern const struct shell *ctx_shell;
-
-#define print(_sh, _ft, ...) \
-	shell_fprintf(_sh ? _sh : ctx_shell, SHELL_NORMAL, _ft "\r\n", \
-		      ##__VA_ARGS__)
-#define error(_sh, _ft, ...) \
-	shell_fprintf(_sh ? _sh : ctx_shell, SHELL_ERROR, _ft "\r\n", \
-		      ##__VA_ARGS__)
-
 extern struct bt_conn *default_conn;
 
 int str2bt_addr(const char *str, bt_addr_t *addr);

--- a/subsys/bluetooth/shell/gatt.c
+++ b/subsys/bluetooth/shell/gatt.c
@@ -31,7 +31,8 @@
 static void exchange_func(struct bt_conn *conn, u8_t err,
 			  struct bt_gatt_exchange_params *params)
 {
-	print(NULL, "Exchange %s", err == 0 ? "successful" : "failed");
+	shell_print(ctx_shell, "Exchange %s", err == 0 ? "successful" :
+		    "failed");
 }
 
 static struct bt_gatt_exchange_params exchange_params;
@@ -42,7 +43,7 @@ static int cmd_exchange_mtu(const struct shell *shell,
 	int err;
 
 	if (!default_conn) {
-		print(shell, "Not connected");
+		shell_print(shell, "Not connected");
 		return -ENOEXEC;
 	}
 
@@ -50,9 +51,9 @@ static int cmd_exchange_mtu(const struct shell *shell,
 
 	err = bt_gatt_exchange_mtu(default_conn, &exchange_params);
 	if (err) {
-		print(shell, "Exchange failed (err %d)", err);
+		shell_print(shell, "Exchange failed (err %d)", err);
 	} else {
-		print(shell, "Exchange pending");
+		shell_print(shell, "Exchange pending");
 	}
 
 	return err;
@@ -63,41 +64,41 @@ static struct bt_uuid_16 uuid = BT_UUID_INIT_16(0);
 
 static void print_chrc_props(const struct shell *shell, u8_t properties)
 {
-	print(shell, "Properties: ");
+	shell_print(shell, "Properties: ");
 
 	if (properties & BT_GATT_CHRC_BROADCAST) {
-		print(shell, "[bcast]");
+		shell_print(shell, "[bcast]");
 	}
 
 	if (properties & BT_GATT_CHRC_READ) {
-		print(shell, "[read]");
+		shell_print(shell, "[read]");
 	}
 
 	if (properties & BT_GATT_CHRC_WRITE) {
-		print(shell, "[write]");
+		shell_print(shell, "[write]");
 	}
 
 	if (properties & BT_GATT_CHRC_WRITE_WITHOUT_RESP) {
-		print(shell, "[write w/w rsp]");
+		shell_print(shell, "[write w/w rsp]");
 	}
 
 	if (properties & BT_GATT_CHRC_NOTIFY) {
-		print(shell, "[notify]");
+		shell_print(shell, "[notify]");
 	}
 
 	if (properties & BT_GATT_CHRC_INDICATE) {
-		print(shell, "[indicate]");
+		shell_print(shell, "[indicate]");
 	}
 
 	if (properties & BT_GATT_CHRC_AUTH) {
-		print(shell, "[auth]");
+		shell_print(shell, "[auth]");
 	}
 
 	if (properties & BT_GATT_CHRC_EXT_PROP) {
-		print(shell, "[ext prop]");
+		shell_print(shell, "[ext prop]");
 	}
 
-	print(shell, "");
+	shell_print(shell, "");
 }
 
 static u8_t discover_func(struct bt_conn *conn,
@@ -110,7 +111,7 @@ static u8_t discover_func(struct bt_conn *conn,
 	char str[37];
 
 	if (!attr) {
-		print(NULL, "Discover complete");
+		shell_print(ctx_shell, "Discover complete");
 		(void)memset(params, 0, sizeof(*params));
 		return BT_GATT_ITER_STOP;
 	}
@@ -120,28 +121,29 @@ static u8_t discover_func(struct bt_conn *conn,
 	case BT_GATT_DISCOVER_PRIMARY:
 		gatt_service = attr->user_data;
 		bt_uuid_to_str(gatt_service->uuid, str, sizeof(str));
-		print(NULL, "Service %s found: start handle %x, "
-		      "end_handle %x", str, attr->handle,
-		      gatt_service->end_handle);
+		shell_print(ctx_shell, "Service %s found: start handle %x, "
+			    "end_handle %x", str, attr->handle,
+			    gatt_service->end_handle);
 		break;
 	case BT_GATT_DISCOVER_CHARACTERISTIC:
 		gatt_chrc = attr->user_data;
 		bt_uuid_to_str(gatt_chrc->uuid, str, sizeof(str));
-		print(NULL, "Characteristic %s found: handle %x", str,
-		      attr->handle);
+		shell_print(ctx_shell, "Characteristic %s found: handle %x",
+			    str, attr->handle);
 		print_chrc_props(ctx_shell, gatt_chrc->properties);
 		break;
 	case BT_GATT_DISCOVER_INCLUDE:
 		gatt_include = attr->user_data;
 		bt_uuid_to_str(gatt_include->uuid, str, sizeof(str));
-		print(NULL, "Include %s found: handle %x, start %x, "
-		      "end %x", str, attr->handle, gatt_include->start_handle,
-		       gatt_include->end_handle);
+		shell_print(ctx_shell, "Include %s found: handle %x, start %x, "
+			    "end %x", str, attr->handle,
+			    gatt_include->start_handle,
+			    gatt_include->end_handle);
 		break;
 	default:
 		bt_uuid_to_str(attr->uuid, str, sizeof(str));
-		print(NULL, "Descriptor %s found: handle %x", str,
-		      attr->handle);
+		shell_print(ctx_shell, "Descriptor %s found: handle %x", str,
+			    attr->handle);
 		break;
 	}
 
@@ -153,7 +155,7 @@ static int cmd_discover(const struct shell *shell, size_t argc, char *argv[])
 	int err;
 
 	if (!default_conn) {
-		error(shell, "Not connected");
+		shell_error(shell, "Not connected");
 		return -ENOEXEC;
 	}
 
@@ -190,9 +192,9 @@ static int cmd_discover(const struct shell *shell, size_t argc, char *argv[])
 
 	err = bt_gatt_discover(default_conn, &discover_params);
 	if (err) {
-		error(shell, "Discover failed (err %d)", err);
+		shell_error(shell, "Discover failed (err %d)", err);
 	} else {
-		print(shell, "Discover pending");
+		shell_print(shell, "Discover pending");
 	}
 
 	return err;
@@ -204,7 +206,7 @@ static u8_t read_func(struct bt_conn *conn, u8_t err,
 			 struct bt_gatt_read_params *params,
 			 const void *data, u16_t length)
 {
-	print(NULL, "Read complete: err %u length %u", err, length);
+	shell_print(ctx_shell, "Read complete: err %u length %u", err, length);
 
 	if (!data) {
 		(void)memset(params, 0, sizeof(*params));
@@ -219,7 +221,7 @@ static int cmd_read(const struct shell *shell, size_t argc, char *argv[])
 	int err;
 
 	if (!default_conn) {
-		error(shell, "Not connected");
+		shell_error(shell, "Not connected");
 		return -ENOEXEC;
 	}
 
@@ -240,9 +242,9 @@ static int cmd_read(const struct shell *shell, size_t argc, char *argv[])
 
 	err = bt_gatt_read(default_conn, &read_params);
 	if (err) {
-		error(shell, "Read failed (err %d)", err);
+		shell_error(shell, "Read failed (err %d)", err);
 	} else {
-		print(shell, "Read pending");
+		shell_print(shell, "Read pending");
 	}
 
 	return err;
@@ -254,7 +256,7 @@ static int cmd_mread(const struct shell *shell, size_t argc, char *argv[])
 	int i, err;
 
 	if (!default_conn) {
-		error(shell, "Not connected");
+		shell_error(shell, "Not connected");
 		return -ENOEXEC;
 	}
 
@@ -264,8 +266,8 @@ static int cmd_mread(const struct shell *shell, size_t argc, char *argv[])
 	}
 
 	if ((argc - 1) >  ARRAY_SIZE(h)) {
-		print(shell, "Enter max %lu handle items to read",
-		      ARRAY_SIZE(h));
+		shell_print(shell, "Enter max %lu handle items to read",
+			    ARRAY_SIZE(h));
 		return -EINVAL;
 	}
 
@@ -279,8 +281,8 @@ static int cmd_mread(const struct shell *shell, size_t argc, char *argv[])
 
 	err = bt_gatt_read(default_conn, &read_params);
 	if (err) {
-		error(shell, "GATT multiple read request failed (err %d)",
-		      err);
+		shell_error(shell, "GATT multiple read request failed (err %d)",
+			    err);
 	}
 
 	return err;
@@ -292,7 +294,7 @@ static u8_t gatt_write_buf[CHAR_SIZE_MAX];
 static void write_func(struct bt_conn *conn, u8_t err,
 		       struct bt_gatt_write_params *params)
 {
-	print(NULL, "Write complete: err %u", err);
+	shell_print(ctx_shell, "Write complete: err %u", err);
 
 	(void)memset(&write_params, 0, sizeof(write_params));
 }
@@ -303,12 +305,12 @@ static int cmd_write(const struct shell *shell, size_t argc, char *argv[])
 	u16_t handle, offset;
 
 	if (!default_conn) {
-		error(shell, "Not connected");
+		shell_error(shell, "Not connected");
 		return -ENOEXEC;
 	}
 
 	if (write_params.func) {
-		error(shell, "Write ongoing");
+		shell_error(shell, "Write ongoing");
 		return -ENOEXEC;
 	}
 
@@ -343,9 +345,9 @@ static int cmd_write(const struct shell *shell, size_t argc, char *argv[])
 
 	err = bt_gatt_write(default_conn, &write_params);
 	if (err) {
-		error(shell, "Write failed (err %d)", err);
+		shell_error(shell, "Write failed (err %d)", err);
 	} else {
-		print(shell, "Write pending");
+		shell_print(shell, "Write pending");
 	}
 
 	return err;
@@ -361,7 +363,7 @@ static int cmd_write_without_rsp(const struct shell *shell,
 	bool sign;
 
 	if (!default_conn) {
-		error(shell, "Not connected");
+		shell_error(shell, "Not connected");
 		return -ENOEXEC;
 	}
 
@@ -403,7 +405,7 @@ static int cmd_write_without_rsp(const struct shell *shell,
 		}
 	}
 
-	print(shell, "Write Complete (err %d)", err);
+	shell_print(shell, "Write Complete (err %d)", err);
 	return err;
 }
 
@@ -414,12 +416,12 @@ static u8_t notify_func(struct bt_conn *conn,
 			const void *data, u16_t length)
 {
 	if (!data) {
-		print(NULL, "Unsubscribed");
+		shell_print(ctx_shell, "Unsubscribed");
 		params->value_handle = 0;
 		return BT_GATT_ITER_STOP;
 	}
 
-	print(NULL, "Notification: data %p length %u", data, length);
+	shell_print(ctx_shell, "Notification: data %p length %u", data, length);
 
 	return BT_GATT_ITER_CONTINUE;
 }
@@ -429,13 +431,13 @@ static int cmd_subscribe(const struct shell *shell, size_t argc, char *argv[])
 	int err;
 
 	if (subscribe_params.value_handle) {
-		error(shell, "Cannot subscribe: subscription to %x already "
-		      "exists", subscribe_params.value_handle);
+		shell_error(shell, "Cannot subscribe: subscription to %x "
+			    "already exists", subscribe_params.value_handle);
 		return -ENOEXEC;
 	}
 
 	if (!default_conn) {
-		error(shell, "Not connected");
+		shell_error(shell, "Not connected");
 		return -ENOEXEC;
 	}
 
@@ -455,9 +457,9 @@ static int cmd_subscribe(const struct shell *shell, size_t argc, char *argv[])
 
 	err = bt_gatt_subscribe(default_conn, &subscribe_params);
 	if (err) {
-		error(shell, "Subscribe failed (err %d)", err);
+		shell_error(shell, "Subscribe failed (err %d)", err);
 	} else {
-		print(shell, "Subscribed");
+		shell_print(shell, "Subscribed");
 	}
 
 	return err;
@@ -469,20 +471,20 @@ static int cmd_unsubscribe(const struct shell *shell,
 	int err;
 
 	if (!default_conn) {
-		error(shell, "Not connected");
+		shell_error(shell, "Not connected");
 		return -ENOEXEC;
 	}
 
 	if (!subscribe_params.value_handle) {
-		error(shell, "No subscription found");
+		shell_error(shell, "No subscription found");
 		return -ENOEXEC;
 	}
 
 	err = bt_gatt_unsubscribe(default_conn, &subscribe_params);
 	if (err) {
-		error(shell, "Unsubscribe failed (err %d)", err);
+		shell_error(shell, "Unsubscribe failed (err %d)", err);
 	} else {
-		print(shell, "Unsubscribe success");
+		shell_print(shell, "Unsubscribe success");
 	}
 
 	return err;
@@ -493,7 +495,7 @@ static u8_t print_attr(const struct bt_gatt_attr *attr, void *user_data)
 {
 	const struct shell *shell = user_data;
 
-	print(shell, "attr %p handle 0x%04x uuid %s perm 0x%02x",
+	shell_print(shell, "attr %p handle 0x%04x uuid %s perm 0x%02x",
 	      attr, attr->handle, bt_uuid_str(attr->uuid), attr->perm);
 
 	return BT_GATT_ITER_CONTINUE;
@@ -542,7 +544,7 @@ static ssize_t write_vnd1(struct bt_conn *conn, const struct bt_gatt_attr *attr,
 			  u8_t flags)
 {
 	if (echo_enabled) {
-		print(NULL, "Echo attr len %u", len);
+		shell_print(ctx_shell, "Echo attr len %u", len);
 		bt_gatt_notify(conn, attr, buf, len);
 	}
 
@@ -653,7 +655,7 @@ static int cmd_register_test_svc(const struct shell *shell,
 	bt_gatt_service_register(&vnd_svc);
 	bt_gatt_service_register(&vnd1_svc);
 
-	print(shell, "Registering test vendor services");
+	shell_print(shell, "Registering test vendor services");
 	return 0;
 }
 
@@ -663,7 +665,7 @@ static int cmd_unregister_test_svc(const struct shell *shell,
 	bt_gatt_service_unregister(&vnd_svc);
 	bt_gatt_service_unregister(&vnd1_svc);
 
-	print(shell, "Unregistering test vendor services");
+	shell_print(shell, "Unregistering test vendor services");
 	return 0;
 }
 
@@ -744,7 +746,7 @@ static int cmd_metrics(const struct shell *shell, size_t argc, char *argv[])
 	int err = 0;
 
 	if (argc < 2) {
-		print(shell, "Write: count= %u, len= %u, rate= %u bps.",
+		shell_print(shell, "Write: count= %u, len= %u, rate= %u bps.",
 		       write_count, write_len, write_rate);
 
 		return -ENOEXEC;
@@ -754,22 +756,22 @@ static int cmd_metrics(const struct shell *shell, size_t argc, char *argv[])
 		static bool registered;
 
 		if (!registered) {
-			print(shell, "Registering GATT metrics test "
+			shell_print(shell, "Registering GATT metrics test "
 			      "Service.");
 			err = bt_gatt_service_register(&met_svc);
 			registered = true;
 		}
 	} else if (!strcmp(argv[1], "off")) {
-		print(shell, "Unregistering GATT metrics test Service.");
+		shell_print(shell, "Unregistering GATT metrics test Service.");
 		err = bt_gatt_service_unregister(&met_svc);
 	} else {
-		error(shell, "Incorrect value: %s", argv[1]);
+		shell_error(shell, "Incorrect value: %s", argv[1]);
 		shell_help_print(shell, NULL, 0);
 		return -ENOEXEC;
 	}
 
 	if (!err) {
-		print(shell, "GATT write cmd metrics %s.", argv[1]);
+		shell_print(shell, "GATT write cmd metrics %s.", argv[1]);
 	}
 
 	return err;
@@ -832,7 +834,7 @@ static int cmd_gatt(const struct shell *shell, size_t argc, char **argv)
 		return err;
 	}
 
-	error(shell, "%s unknown parameter: %s", argv[0], argv[1]);
+	shell_error(shell, "%s unknown parameter: %s", argv[0], argv[1]);
 
 	return -EINVAL;
 }

--- a/subsys/bluetooth/shell/gatt.c
+++ b/subsys/bluetooth/shell/gatt.c
@@ -226,12 +226,6 @@ static int cmd_read(const struct shell *shell, size_t argc, char *argv[])
 	}
 
 	read_params.func = read_func;
-
-	err = shell_cmd_precheck(shell, (argc >= 2), NULL, 0);
-	if (err) {
-		return err;
-	}
-
 	read_params.handle_count = 1;
 	read_params.single.handle = strtoul(argv[1], NULL, 16);
 	read_params.single.offset = 0;
@@ -258,11 +252,6 @@ static int cmd_mread(const struct shell *shell, size_t argc, char *argv[])
 	if (!default_conn) {
 		shell_error(shell, "Not connected");
 		return -ENOEXEC;
-	}
-
-	err = shell_cmd_precheck(shell, (argc >= 3), NULL, 0);
-	if (err) {
-		return err;
 	}
 
 	if ((argc - 1) >  ARRAY_SIZE(h)) {
@@ -315,11 +304,6 @@ static int cmd_write(const struct shell *shell, size_t argc, char *argv[])
 	}
 
 
-	err = shell_cmd_precheck(shell, (argc >= 4), NULL, 0);
-	if (err) {
-		return err;
-	}
-
 	handle = strtoul(argv[1], NULL, 16);
 	offset = strtoul(argv[2], NULL, 16);
 
@@ -365,11 +349,6 @@ static int cmd_write_without_rsp(const struct shell *shell,
 	if (!default_conn) {
 		shell_error(shell, "Not connected");
 		return -ENOEXEC;
-	}
-
-	err = shell_cmd_precheck(shell, (argc >= 3), NULL, 0);
-	if (err) {
-		return err;
 	}
 
 	sign = !strcmp(argv[0], "signed-write");
@@ -439,11 +418,6 @@ static int cmd_subscribe(const struct shell *shell, size_t argc, char *argv[])
 	if (!default_conn) {
 		shell_error(shell, "Not connected");
 		return -ENOEXEC;
-	}
-
-	err = shell_cmd_precheck(shell, (argc >= 3), NULL, 0);
-	if (err) {
-		return err;
 	}
 
 	subscribe_params.ccc_handle = strtoul(argv[1], NULL, 16);
@@ -781,57 +755,50 @@ static int cmd_metrics(const struct shell *shell, size_t argc, char *argv[])
 
 SHELL_CREATE_STATIC_SUBCMD_SET(gatt_cmds) {
 #if defined(CONFIG_BT_GATT_CLIENT)
-	SHELL_CMD(discover-characteristic, NULL,
-		  "[UUID] [start handle] [end handle]", cmd_discover),
-	SHELL_CMD(discover-descriptor, NULL,
-		  "[UUID] [start handle] [end handle]", cmd_discover),
-	SHELL_CMD(discover-include, NULL,
-		  "[UUID] [start handle] [end handle]", cmd_discover),
-	SHELL_CMD(discover-primary, NULL,
-		  "[UUID] [start handle] [end handle]", cmd_discover),
-	SHELL_CMD(discover-secondary, NULL,
-		  "[UUID] [start handle] [end handle]", cmd_discover),
-	SHELL_CMD(exchange-mtu, NULL, HELP_NONE, cmd_exchange_mtu),
-	SHELL_CMD(read, NULL, "<handle> [offset]", cmd_read),
-	SHELL_CMD(read-multiple, NULL, "<handle 1> <handle 2> ...",
-		  cmd_mread),
-	SHELL_CMD(signed-write, NULL, "<handle> <data> [length] [repeat]",
-		  cmd_write_without_rsp),
-	SHELL_CMD(subscribe, NULL, "<CCC handle> <value handle> [ind]",
-		  cmd_subscribe),
-	SHELL_CMD(write, NULL, "<handle> <offset> <data> [length]",
-		  cmd_write),
-	SHELL_CMD(write-without-response, NULL,
-		  "<handle> <data> [length] [repeat]",
-		  cmd_write_without_rsp),
-	SHELL_CMD(unsubscribe, NULL, HELP_NONE, cmd_unsubscribe),
+	SHELL_CMD_ARG(discover-characteristic, NULL,
+		      "[UUID] [start handle] [end handle]", cmd_discover, 1, 3),
+	SHELL_CMD_ARG(discover-descriptor, NULL,
+		      "[UUID] [start handle] [end handle]", cmd_discover, 1, 3),
+	SHELL_CMD_ARG(discover-include, NULL,
+		      "[UUID] [start handle] [end handle]", cmd_discover, 1, 3),
+	SHELL_CMD_ARG(discover-primary, NULL,
+		      "[UUID] [start handle] [end handle]", cmd_discover, 1, 3),
+	SHELL_CMD_ARG(discover-secondary, NULL,
+		      "[UUID] [start handle] [end handle]", cmd_discover, 1, 3),
+	SHELL_CMD_ARG(exchange-mtu, NULL, HELP_NONE, cmd_exchange_mtu, 1, 0),
+	SHELL_CMD_ARG(read, NULL, "<handle> [offset]", cmd_read, 2, 1),
+	SHELL_CMD_ARG(read-multiple, NULL, "<handle 1> <handle 2> ...",
+		      cmd_mread, 2, -1),
+	SHELL_CMD_ARG(signed-write, NULL, "<handle> <data> [length] [repeat]",
+		      cmd_write_without_rsp, 3, 2),
+	SHELL_CMD_ARG(subscribe, NULL, "<CCC handle> <value handle> [ind]",
+		      cmd_subscribe, 3, 1),
+	SHELL_CMD_ARG(write, NULL, "<handle> <offset> <data> [length]",
+		      cmd_write, 4, 1),
+	SHELL_CMD_ARG(write-without-response, NULL,
+		      "<handle> <data> [length] [repeat]",
+		      cmd_write_without_rsp, 3, 2),
+	SHELL_CMD_ARG(unsubscribe, NULL, HELP_NONE, cmd_unsubscribe, 1, 0),
 #endif /* CONFIG_BT_GATT_CLIENT */
-	SHELL_CMD(metrics, NULL,
-		  "register vendr char and measure rx [value on, off]",
-		  cmd_metrics),
-	SHELL_CMD(register, NULL,
-		  "register pre-predefined test service",
-		  cmd_register_test_svc),
-	SHELL_CMD(show-db, NULL, HELP_NONE, cmd_show_db),
-	SHELL_CMD(unregister, NULL,
-		  "unregister pre-predefined test service",
-		  cmd_unregister_test_svc),
+	SHELL_CMD_ARG(metrics, NULL,
+		      "register vendr char and measure rx <value: on, off>",
+		      cmd_metrics, 2, 0),
+	SHELL_CMD_ARG(register, NULL,
+		      "register pre-predefined test service",
+		      cmd_register_test_svc, 1, 0),
+	SHELL_CMD_ARG(show-db, NULL, HELP_NONE, cmd_show_db, 1, 0),
+	SHELL_CMD_ARG(unregister, NULL,
+		      "unregister pre-predefined test service",
+		      cmd_unregister_test_svc, 1, 0),
 	SHELL_SUBCMD_SET_END
 };
 
 static int cmd_gatt(const struct shell *shell, size_t argc, char **argv)
 {
-	int err;
-
 	if (argc == 1) {
 		shell_help_print(shell, NULL, 0);
 		/* shell_cmd_precheck returns 1 when help is printed */
 		return 1;
-	}
-
-	err = shell_cmd_precheck(shell, (argc == 2), NULL, 0);
-	if (err) {
-		return err;
 	}
 
 	shell_error(shell, "%s unknown parameter: %s", argv[0], argv[1]);
@@ -839,4 +806,5 @@ static int cmd_gatt(const struct shell *shell, size_t argc, char **argv)
 	return -EINVAL;
 }
 
-SHELL_CMD_REGISTER(gatt, &gatt_cmds, "Bluetooth GATT shell commands", cmd_gatt);
+SHELL_CMD_ARG_REGISTER(gatt, &gatt_cmds, "Bluetooth GATT shell commands",
+		       cmd_gatt, 1, 1);

--- a/subsys/bluetooth/shell/l2cap.c
+++ b/subsys/bluetooth/shell/l2cap.c
@@ -218,13 +218,7 @@ static struct bt_l2cap_server server = {
 
 static int cmd_register(const struct shell *shell, size_t argc, char *argv[])
 {
-	int err;
 	const char *policy;
-
-	err = shell_cmd_precheck(shell, (argc >= 2), NULL, 0);
-	if (err) {
-		return err;
-	}
 
 	if (server.psm) {
 		shell_error(shell, "Already registered");
@@ -271,11 +265,6 @@ static int cmd_connect(const struct shell *shell, size_t argc, char *argv[])
 	if (!default_conn) {
 		shell_error(shell, "Not connected");
 		return -ENOEXEC;
-	}
-
-	err = shell_cmd_precheck(shell, (argc == 2), NULL, 0);
-	if (err) {
-		return err;
 	}
 
 	if (l2ch_chan.ch.chan.conn) {
@@ -407,36 +396,29 @@ static int cmd_whitelist_remove(const struct shell *shell, size_t argc, char *ar
 #define HELP_NONE "[none]"
 
 SHELL_CREATE_STATIC_SUBCMD_SET(whitelist_cmds) {
-	SHELL_CMD(add, NULL, HELP_NONE, cmd_whitelist_add),
-	SHELL_CMD(remove, NULL, HELP_NONE, cmd_whitelist_remove),
+	SHELL_CMD_ARG(add, NULL, HELP_NONE, cmd_whitelist_add, 1, 0),
+	SHELL_CMD_ARG(remove, NULL, HELP_NONE, cmd_whitelist_remove, 1, 0),
 	SHELL_SUBCMD_SET_END
 };
 
 SHELL_CREATE_STATIC_SUBCMD_SET(l2cap_cmds) {
-	SHELL_CMD(connect, NULL, "<psm>", cmd_connect),
-	SHELL_CMD(disconnect, NULL, HELP_NONE, cmd_disconnect),
-	SHELL_CMD(metrics, NULL, "<value on, off>", cmd_metrics),
-	SHELL_CMD(recv, NULL, "[delay (in miliseconds)", cmd_recv),
-	SHELL_CMD(register, NULL, "<psm> [sec_level] "
-		  "[policy: whitelist, 16byte_key]", cmd_register),
-	SHELL_CMD(send, NULL, "<number of packets>", cmd_send),
-	SHELL_CMD(whitelist, &whitelist_cmds, HELP_NONE, NULL),
+	SHELL_CMD_ARG(connect, NULL, "<psm>", cmd_connect, 1, 0),
+	SHELL_CMD_ARG(disconnect, NULL, HELP_NONE, cmd_disconnect, 1, 0),
+	SHELL_CMD_ARG(metrics, NULL, "<value on, off>", cmd_metrics, 2, 0),
+	SHELL_CMD_ARG(recv, NULL, "[delay (in miliseconds)", cmd_recv, 1, 1),
+	SHELL_CMD_ARG(register, NULL, "<psm> [sec_level] "
+		      "[policy: whitelist, 16byte_key]", cmd_register, 2, 2),
+	SHELL_CMD_ARG(send, NULL, "<number of packets>", cmd_send, 2, 0),
+	SHELL_CMD_ARG(whitelist, &whitelist_cmds, HELP_NONE, NULL, 1, 0),
 	SHELL_SUBCMD_SET_END
 };
 
 static int cmd_l2cap(const struct shell *shell, size_t argc, char **argv)
 {
-	int err;
-
 	if (argc == 1) {
 		shell_help_print(shell, NULL, 0);
 		/* shell_cmd_precheck returns 1 when help is printed */
 		return 1;
-	}
-
-	err = shell_cmd_precheck(shell, (argc == 2), NULL, 0);
-	if (err) {
-		return err;
 	}
 
 	shell_error(shell, "%s unknown parameter: %s", argv[0], argv[1]);
@@ -444,6 +426,6 @@ static int cmd_l2cap(const struct shell *shell, size_t argc, char **argv)
 	return -ENOEXEC;
 }
 
-SHELL_CMD_REGISTER(l2cap, &l2cap_cmds, "Bluetooth L2CAP shell commands",
-		   cmd_l2cap);
+SHELL_CMD_ARG_REGISTER(l2cap, &l2cap_cmds, "Bluetooth L2CAP shell commands",
+		       cmd_l2cap, 1, 1);
 

--- a/subsys/bluetooth/shell/l2cap.c
+++ b/subsys/bluetooth/shell/l2cap.c
@@ -85,7 +85,7 @@ static void l2cap_recv_cb(struct k_work *work)
 	struct net_buf *buf;
 
 	while ((buf = net_buf_get(&l2cap_recv_fifo, K_NO_WAIT))) {
-		print(ctx_shell, "Confirming reception");
+		shell_print(ctx_shell, "Confirming reception");
 		bt_l2cap_chan_recv_complete(&c->ch.chan, buf);
 	}
 }
@@ -94,7 +94,8 @@ static int l2cap_recv(struct bt_l2cap_chan *chan, struct net_buf *buf)
 {
 	struct l2ch *l2ch = L2CH_CHAN(chan);
 
-	print(ctx_shell, "Incoming data channel %p len %u", chan, buf->len);
+	shell_print(ctx_shell, "Incoming data channel %p len %u", chan,
+		    buf->len);
 
 	if (buf->len) {
 		hexdump(ctx_shell, buf->data, buf->len);
@@ -103,8 +104,8 @@ static int l2cap_recv(struct bt_l2cap_chan *chan, struct net_buf *buf)
 	if (l2cap_recv_delay) {
 		/* Submit work only if queue is empty */
 		if (k_fifo_is_empty(&l2cap_recv_fifo)) {
-			print(ctx_shell, "Delaying response in %u ms...",
-			      l2cap_recv_delay);
+			shell_print(ctx_shell, "Delaying response in %u ms...",
+				    l2cap_recv_delay);
 			k_delayed_work_submit(&l2ch->recv_work,
 					      l2cap_recv_delay);
 		}
@@ -121,19 +122,19 @@ static void l2cap_connected(struct bt_l2cap_chan *chan)
 
 	k_delayed_work_init(&c->recv_work, l2cap_recv_cb);
 
-	print(ctx_shell, "Channel %p connected", chan);
+	shell_print(ctx_shell, "Channel %p connected", chan);
 }
 
 static void l2cap_disconnected(struct bt_l2cap_chan *chan)
 {
-	print(ctx_shell, "Channel %p disconnected", chan);
+	shell_print(ctx_shell, "Channel %p disconnected", chan);
 }
 
 static struct net_buf *l2cap_alloc_buf(struct bt_l2cap_chan *chan)
 {
 	/* print if metrics is disabled */
 	if (chan->ops->recv != l2cap_recv_metrics) {
-		print(ctx_shell, "Channel %p requires buffer", chan);
+		shell_print(ctx_shell, "Channel %p requires buffer", chan);
 	}
 
 	return net_buf_alloc(&data_rx_pool, K_FOREVER);
@@ -194,7 +195,7 @@ static int l2cap_accept(struct bt_conn *conn, struct bt_l2cap_chan **chan)
 {
 	int err;
 
-	print(ctx_shell, "Incoming conn %p", conn);
+	shell_print(ctx_shell, "Incoming conn %p", conn);
 
 	err = l2cap_accept_policy(conn);
 	if (err < 0) {
@@ -202,7 +203,7 @@ static int l2cap_accept(struct bt_conn *conn, struct bt_l2cap_chan **chan)
 	}
 
 	if (l2ch_chan.ch.chan.conn) {
-		print(ctx_shell, "No channels available");
+		shell_print(ctx_shell, "No channels available");
 		return -ENOMEM;
 	}
 
@@ -226,7 +227,7 @@ static int cmd_register(const struct shell *shell, size_t argc, char *argv[])
 	}
 
 	if (server.psm) {
-		error(shell, "Already registered");
+		shell_error(shell, "Already registered");
 		return -ENOEXEC;
 	}
 
@@ -249,14 +250,14 @@ static int cmd_register(const struct shell *shell, size_t argc, char *argv[])
 	}
 
 	if (bt_l2cap_server_register(&server) < 0) {
-		error(shell, "Unable to register psm");
+		shell_error(shell, "Unable to register psm");
 		server.psm = 0;
 		return -ENOEXEC;
 	} else {
 		bt_conn_cb_register(&l2cap_conn_callbacks);
 
-		print(shell, "L2CAP psm %u sec_level %u registered",
-		      server.psm, server.sec_level);
+		shell_print(shell, "L2CAP psm %u sec_level %u registered",
+			    server.psm, server.sec_level);
 	}
 
 	return 0;
@@ -268,7 +269,7 @@ static int cmd_connect(const struct shell *shell, size_t argc, char *argv[])
 	int err;
 
 	if (!default_conn) {
-		error(shell, "Not connected");
+		shell_error(shell, "Not connected");
 		return -ENOEXEC;
 	}
 
@@ -278,7 +279,7 @@ static int cmd_connect(const struct shell *shell, size_t argc, char *argv[])
 	}
 
 	if (l2ch_chan.ch.chan.conn) {
-		error(shell, "Channel already in use");
+		shell_error(shell, "Channel already in use");
 		return -ENOEXEC;
 	}
 
@@ -286,10 +287,10 @@ static int cmd_connect(const struct shell *shell, size_t argc, char *argv[])
 
 	err = bt_l2cap_chan_connect(default_conn, &l2ch_chan.ch.chan, psm);
 	if (err < 0) {
-		error(shell, "Unable to connect to psm %u (err %u)", psm,
-		      err);
+		shell_error(shell, "Unable to connect to psm %u (err %u)", psm,
+			    err);
 	} else {
-		print(shell, "L2CAP connection pending");
+		shell_print(shell, "L2CAP connection pending");
 	}
 
 	return err;
@@ -301,7 +302,7 @@ static int cmd_disconnect(const struct shell *shell, size_t argc, char *argv[])
 
 	err = bt_l2cap_chan_disconnect(&l2ch_chan.ch.chan);
 	if (err) {
-		print(shell, "Unable to disconnect: %u", -err);
+		shell_print(shell, "Unable to disconnect: %u", -err);
 	}
 
 	return err;
@@ -326,7 +327,7 @@ static int cmd_send(const struct shell *shell, size_t argc, char *argv[])
 		net_buf_add_mem(buf, buf_data, len);
 		ret = bt_l2cap_chan_send(&l2ch_chan.ch.chan, buf);
 		if (ret < 0) {
-			print(shell, "Unable to send: %d", -ret);
+			shell_print(shell, "Unable to send: %d", -ret);
 			net_buf_unref(buf);
 			return -ENOEXEC;
 		}
@@ -340,8 +341,8 @@ static int cmd_recv(const struct shell *shell, size_t argc, char *argv[])
 	if (argc > 1) {
 		l2cap_recv_delay = strtoul(argv[1], NULL, 10);
 	} else {
-		print(shell, "l2cap receive delay: %u ms",
-			     l2cap_recv_delay);
+		shell_print(shell, "l2cap receive delay: %u ms",
+			    l2cap_recv_delay);
 	}
 
 	return 0;
@@ -352,7 +353,7 @@ static int cmd_metrics(const struct shell *shell, size_t argc, char *argv[])
 	const char *action;
 
 	if (argc < 2) {
-		print(shell, "l2cap rate: %u bps.", l2cap_rate);
+		shell_print(shell, "l2cap rate: %u bps.", l2cap_rate);
 
 		return 0;
 	}
@@ -368,7 +369,7 @@ static int cmd_metrics(const struct shell *shell, size_t argc, char *argv[])
 		return 0;
 	}
 
-	print(shell, "l2cap metrics %s.", action);
+	shell_print(shell, "l2cap metrics %s.", action);
 	return 0;
 }
 
@@ -377,7 +378,7 @@ static int cmd_whitelist_add(const struct shell *shell, size_t argc, char *argv[
 	int i;
 
 	if (!default_conn) {
-		error(shell, "Not connected\n");
+		shell_error(shell, "Not connected");
 		return 0;
 	}
 
@@ -394,7 +395,7 @@ static int cmd_whitelist_add(const struct shell *shell, size_t argc, char *argv[
 static int cmd_whitelist_remove(const struct shell *shell, size_t argc, char *argv[])
 {
 	if (!default_conn) {
-		error(shell, "Not connected\n");
+		shell_error(shell, "Not connected");
 		return 0;
 	}
 
@@ -438,7 +439,7 @@ static int cmd_l2cap(const struct shell *shell, size_t argc, char **argv)
 		return err;
 	}
 
-	error(shell, "%s unknown parameter: %s", argv[0], argv[1]);
+	shell_error(shell, "%s unknown parameter: %s", argv[0], argv[1]);
 
 	return -ENOEXEC;
 }

--- a/subsys/bluetooth/shell/ll.c
+++ b/subsys/bluetooth/shell/ll.c
@@ -46,7 +46,7 @@ int cmd_ll_addr_get(const struct shell *shell, size_t argc, char *argv[])
 	(void)ll_addr_get(addr_type, addr.val);
 	bt_addr_to_str(&addr, str_addr, sizeof(str_addr));
 
-	print(shell, "Current %s address: %s\n", str_type, str_addr);
+	shell_print(shell, "Current %s address: %s\n", str_type, str_addr);
 
 	return 0;
 }
@@ -73,7 +73,7 @@ int cmd_test_tx(const struct shell *shell, size_t  argc, char *argv[])
 		return -EINVAL;
 	}
 
-	print(shell, "test_tx...");
+	shell_print(shell, "test_tx...");
 
 	return 0;
 }
@@ -96,7 +96,7 @@ int cmd_test_rx(const struct shell *shell, size_t  argc, char *argv[])
 		return -EINVAL;
 	}
 
-	print(shell, "test_rx...");
+	shell_print(shell, "test_rx...");
 
 	return 0;
 }
@@ -111,7 +111,7 @@ int cmd_test_end(const struct shell *shell, size_t  argc, char *argv[])
 		return -EINVAL;
 	}
 
-	print(shell, "num_rx= %u.", num_rx);
+	shell_print(shell, "num_rx= %u.", num_rx);
 
 	return 0;
 }
@@ -191,7 +191,7 @@ int cmd_advx(const struct shell *shell, size_t argc, char *argv[])
 		}
 	}
 
-	print(shell, "adv param set...");
+	shell_print(shell, "adv param set...");
 	err = ll_adv_params_set(0x00, evt_prop, ADV_INTERVAL, ADV_TYPE,
 				OWN_ADDR_TYPE, PEER_ADDR_TYPE, PEER_ADDR,
 				ADV_CHAN_MAP, FILTER_POLICY, ADV_TX_PWR,
@@ -202,14 +202,14 @@ int cmd_advx(const struct shell *shell, size_t argc, char *argv[])
 	}
 
 disable:
-	print(shell, "adv enable (%u)...", enable);
+	shell_print(shell, "adv enable (%u)...", enable);
 	err = ll_adv_enable(enable);
 	if (err) {
 		goto exit;
 	}
 
 exit:
-	print(shell, "done (err= %d).", err);
+	shell_print(shell, "done (err= %d).", err);
 
 	return 0;
 }
@@ -250,7 +250,7 @@ int cmd_scanx(const struct shell *shell, size_t  argc, char *argv[])
 		}
 	}
 
-	print(shell, "scan param set...");
+	shell_print(shell, "scan param set...");
 	err = ll_scan_params_set(type, SCAN_INTERVAL, SCAN_WINDOW,
 				 SCAN_OWN_ADDR_TYPE, SCAN_FILTER_POLICY);
 	if (err) {
@@ -258,14 +258,14 @@ int cmd_scanx(const struct shell *shell, size_t  argc, char *argv[])
 	}
 
 disable:
-	print(shell, "scan enable (%u)...", enable);
+	shell_print(shell, "scan enable (%u)...", enable);
 	err = ll_scan_enable(enable);
 	if (err) {
 		goto exit;
 	}
 
 exit:
-	print(shell, "done (err= %d).", err);
+	shell_print(shell, "done (err= %d).", err);
 
 	return err;
 }

--- a/subsys/bluetooth/shell/rfcomm.c
+++ b/subsys/bluetooth/shell/rfcomm.c
@@ -178,11 +178,6 @@ static int cmd_connect(const struct shell *shell, size_t argc, char *argv[])
 		return -ENOEXEC;
 	}
 
-	err = shell_cmd_precheck(shell, (argc == 2), NULL, 0);
-	if (err) {
-		return err;
-	}
-
 	channel = strtoul(argv[1], NULL, 16);
 
 	err = bt_rfcomm_dlc_connect(default_conn, &rfcomm_dlc, channel);
@@ -239,26 +234,19 @@ static int cmd_disconnect(const struct shell *shell, size_t argc, char *argv[])
 #define HELP_ADDR_LE "<address: XX:XX:XX:XX:XX:XX> <type: (public|random)>"
 
 SHELL_CREATE_STATIC_SUBCMD_SET(rfcomm_cmds) {
-	SHELL_CMD(register, NULL, "<channel>", cmd_register),
-	SHELL_CMD(connect, NULL, "<channel>", cmd_connect),
-	SHELL_CMD(disconnect, NULL, HELP_NONE, cmd_disconnect),
-	SHELL_CMD(send, NULL, "<number of packets>", cmd_send),
+	SHELL_CMD_ARG(register, NULL, "<channel>", cmd_register, 2, 0),
+	SHELL_CMD_ARG(connect, NULL, "<channel>", cmd_connect, 2, 0),
+	SHELL_CMD_ARG(disconnect, NULL, HELP_NONE, cmd_disconnect, 1, 0),
+	SHELL_CMD_ARG(send, NULL, "<number of packets>", cmd_send, 2, 0),
 	SHELL_SUBCMD_SET_END
 };
 
 static int cmd_rfcomm(const struct shell *shell, size_t argc, char **argv)
 {
-	int err;
-
 	if (argc == 1) {
 		shell_help_print(shell, NULL, 0);
 		/* shell_cmd_precheck returns 1 when help is printed */
 		return 1;
-	}
-
-	err = shell_cmd_precheck(shell, (argc == 2), NULL, 0);
-	if (err) {
-		return err;
 	}
 
 	shell_error(shell, "%s unknown parameter: %s", argv[0], argv[1]);
@@ -266,6 +254,6 @@ static int cmd_rfcomm(const struct shell *shell, size_t argc, char **argv)
 	return -ENOEXEC;
 }
 
-SHELL_CMD_REGISTER(rfcomm, &rfcomm_cmds, "Bluetooth RFCOMM shell commands",
-		   cmd_rfcomm);
+SHELL_CMD_ARG_REGISTER(rfcomm, &rfcomm_cmds, "Bluetooth RFCOMM shell commands",
+		       cmd_rfcomm, 1, 1);
 

--- a/subsys/bluetooth/shell/ticker.c
+++ b/subsys/bluetooth/shell/ticker.c
@@ -128,28 +128,21 @@ int cmd_ticker_info(const struct shell *shell, size_t argc, char *argv[])
 #define HELP_NONE "[none]"
 
 SHELL_CREATE_STATIC_SUBCMD_SET(ticker_cmds) {
-	SHELL_CMD(info, NULL, HELP_NONE, cmd_ticker_info),
+	SHELL_CMD_ARG(info, NULL, HELP_NONE, cmd_ticker_info, 1, 0),
 	SHELL_SUBCMD_SET_END
 };
 
 static int cmd_ticker(const struct shell *shell, size_t argc, char **argv)
 {
-	int err;
-
 	if (argc == 1) {
 		shell_help_print(shell, NULL, 0);
 		/* shell_cmd_precheck returns 1 when help is printed */
 		return 1;
 	}
 
-	err = shell_cmd_precheck(shell, (argc == 2), NULL, 0);
-	if (err) {
-		return err;
-	}
-
 	shell_error(shell, "%s:%s%s", argv[0], "unknown parameter: ", argv[1]);
 	return -ENOEXEC;
 }
 
-SHELL_CMD_REGISTER(ticker, &ticker_cmds, "Bluetooth Ticker shell commands",
-		   cmd_ticker);
+SHELL_CMD_ARG_REGISTER(ticker, &ticker_cmds, "Bluetooth Ticker shell commands",
+		       cmd_ticker, 1, 1);

--- a/subsys/bluetooth/shell/ticker.c
+++ b/subsys/bluetooth/shell/ticker.c
@@ -74,8 +74,8 @@ int cmd_ticker_info(const struct shell *shell, size_t argc, char *argv[])
 
 		if ((err_cb != TICKER_STATUS_SUCCESS) ||
 		    (ticker_id == TICKER_NULL)) {
-			print(shell, "Query done (0x%02x, err= %u).", ticker_id,
-			       err);
+			shell_print(shell, "Query done (0x%02x, err= %u).",
+				    ticker_id, err);
 
 			break;
 		}
@@ -83,7 +83,8 @@ int cmd_ticker_info(const struct shell *shell, size_t argc, char *argv[])
 		if (ticks_current != ticks_previous) {
 			retry--;
 			if (!retry) {
-				print(shell, "Retry again, tickers too busy now.");
+				shell_print(shell, "Retry again, tickers too "
+					    "busy now.");
 
 				return -EAGAIN;
 			}
@@ -91,8 +92,8 @@ int cmd_ticker_info(const struct shell *shell, size_t argc, char *argv[])
 			if (tickers_count) {
 				tickers_count = 0;
 
-				print(shell, "Query reset, %u retries remaining.",
-				       retry);
+				shell_print(shell, "Query reset, %u retries "
+					    "remaining.", retry);
 			}
 		}
 
@@ -102,24 +103,24 @@ int cmd_ticker_info(const struct shell *shell, size_t argc, char *argv[])
 
 	} while (tickers_count < TICKERS_MAX);
 
-	print(shell, "Tickers: %u.", tickers_count);
-	print(shell, "Tick: %u (%uus).", ticks_current,
+	shell_print(shell, "Tickers: %u.", tickers_count);
+	shell_print(shell, "Tick: %u (%uus).", ticks_current,
 	       HAL_TICKER_TICKS_TO_US(ticks_current));
 
 	if (!tickers_count) {
 		return 0;
 	}
 
-	print(shell, "---------------------");
-	print(shell, " id   offset   offset");
-	print(shell, "      (tick)     (us)");
-	print(shell, "---------------------");
+	shell_print(shell, "---------------------");
+	shell_print(shell, " id   offset   offset");
+	shell_print(shell, "      (tick)     (us)");
+	shell_print(shell, "---------------------");
 	for (i = 0; i < tickers_count; i++) {
-		print(shell, "%03u %08u %08u", tickers[i].id,
+		shell_print(shell, "%03u %08u %08u", tickers[i].id,
 		       tickers[i].ticks_to_expire,
 		       HAL_TICKER_TICKS_TO_US(tickers[i].ticks_to_expire));
 	}
-	print(shell, "---------------------");
+	shell_print(shell, "---------------------");
 
 	return 0;
 }
@@ -146,7 +147,7 @@ static int cmd_ticker(const struct shell *shell, size_t argc, char **argv)
 		return err;
 	}
 
-	error(shell, "%s:%s%s", argv[0], "unknown parameter: ", argv[1]);
+	shell_error(shell, "%s:%s%s", argv[0], "unknown parameter: ", argv[1]);
 	return -ENOEXEC;
 }
 

--- a/tests/bluetooth/shell/src/main.c
+++ b/tests/bluetooth/shell/src/main.c
@@ -22,14 +22,8 @@
 #include <zephyr.h>
 
 #include <shell/shell.h>
-#include <shell/shell_uart.h>
 
 #include <gatt/hrs.h>
-
-#define print(_sh, _ft, ...) \
-	shell_fprintf(_sh, SHELL_NORMAL, _ft "\r\n", ##__VA_ARGS__)
-#define error(_sh, _ft, ...) \
-	shell_fprintf(_sh, SHELL_ERROR, _ft "\r\n", ##__VA_ARGS__)
 
 #define DEVICE_NAME CONFIG_BT_DEVICE_NAME
 
@@ -49,18 +43,18 @@ static int cmd_hrs_simulate(const struct shell *shell,
 		static bool hrs_registered;
 
 		if (!hrs_registered) {
-			print(shell, "Registering HRS Service");
+			shell_print(shell, "Registering HRS Service");
 			hrs_init(0x01);
 			hrs_registered = true;
 		}
 
-		print(shell, "Start HRS simulation");
+		shell_print(shell, "Start HRS simulation");
 		hrs_simulate = true;
 	} else if (!strcmp(argv[1], "off")) {
-		print(shell, "Stop HRS simulation");
+		shell_print(shell, "Stop HRS simulation");
 		hrs_simulate = false;
 	} else {
-		print(shell, "Incorrect value: %s", argv[1]);
+		shell_print(shell, "Incorrect value: %s", argv[1]);
 		shell_help_print(shell, NULL, 0);
 		return -ENOEXEC;
 	}
@@ -95,7 +89,7 @@ static int cmd_hrs(const struct shell *shell, size_t argc, char **argv)
 		return err;
 	}
 
-	error(shell, "%s unknown parameter: %s", argv[0], argv[1]);
+	shell_error(shell, "%s unknown parameter: %s", argv[0], argv[1]);
 
 	return -ENOEXEC;
 }


### PR DESCRIPTION
Cleanup the code that is not longer used and make use of new API introduced to handle arguments and printing messages.