### PR TITLE
cmake: Align the DT build logs with Kconfig

### DIFF
--- a/cmake/dts.cmake
+++ b/cmake/dts.cmake
@@ -55,8 +55,6 @@ foreach(board_root ${BOARD_ROOT})
   endforeach()
 endforeach()
 
-message(STATUS "Generating zephyr/include/generated/generated_dts_board.h")
-
 if(CONFIG_HAS_DTS)
 
   if(DTC_OVERLAY_FILE)
@@ -68,10 +66,19 @@ if(CONFIG_HAS_DTS)
       )
   endif()
 
+  set(i 0)
   unset(DTC_INCLUDE_FLAG_FOR_DTS)
   foreach(dts_file ${dts_files})
     list(APPEND DTC_INCLUDE_FLAG_FOR_DTS
          -include ${dts_file})
+
+	if(i EQUAL 0)
+	  message(STATUS "Loading ${dts_file} as base")
+	else()
+	  message(STATUS "Overlaying ${dts_file}")
+	endif()
+
+	math(EXPR i "${i}+1")
   endforeach()
 
   # TODO: Cut down on CMake configuration time by avoiding


### PR DESCRIPTION
Align how DT and Kconfig print log output.

For instance, Kconfig does not state which header file it generates,
so we remove this from DT.

Also, Kconfig states which sources it uses, which is useful to know
when there is a build failure, so we align with Kconfig by printing
the DT source and overlay files.

Signed-off-by: Sebastian Bøe <sebastian.boe@nordicsemi.no>