### PR TITLE
[DNM] Memory Protection features in ARMv8-M

### DIFF
--- a/arch/Kconfig
+++ b/arch/Kconfig
@@ -385,6 +385,12 @@ config MPU_REQUIRES_POWER_OF_TWO_ALIGNMENT
 	  This option is enabled when the MPU requires a power of two alignment
 	  and size for MPU regions.
 
+config MPU_REQUIRES_NON_OVERLAPPING_REGIONS
+	bool
+	# Omit prompt to signify "hidden" option
+	help
+	  This option is enabled when the MPU requires the active (i.e. enabled)
+	  MPU regions to be non-overlapping with each other.
 
 menu "Floating Point Options"
 depends on CPU_HAS_FPU

--- a/arch/arm/core/cortex_m/mpu/Kconfig
+++ b/arch/arm/core/cortex_m/mpu/Kconfig
@@ -12,10 +12,13 @@ config ARM_MPU
 	select THREAD_STACK_INFO
 	select ARCH_HAS_EXECUTABLE_PAGE_BIT
 	select MPU_REQUIRES_POWER_OF_TWO_ALIGNMENT if !(CPU_HAS_NXP_MPU || ARMV8_M_BASELINE || ARMV8_M_MAINLINE)
+	select MPU_REQUIRES_NON_OVERLAPPING_REGIONS if CPU_HAS_ARM_MPU && (ARMV8_M_BASELINE || ARMV8_M_MAINLINE)
 	help
 	  MCU implements Memory Protection Unit.
 	  Note that NXP MPU as well as ARMv8-M MPU does not require MPU regions
 	  to have power-of-two alignment for base address and region size.
+	  In addition to the above, ARMv8-M MPU requires the active MPU regions
+	  be non-overlapping.
 
 config MPU_STACK_GUARD
 	bool "Thread Stack Guards"

--- a/arch/arm/core/cortex_m/mpu/arm_core_mpu.c
+++ b/arch/arm/core/cortex_m/mpu/arm_core_mpu.c
@@ -15,6 +15,20 @@
 #include <logging/log.h>
 LOG_MODULE_REGISTER(mpu);
 
+#if defined(CONFIG_MPU_REQUIRES_NON_OVERLAPPING_REGIONS)
+#if defined(CONFIG_MPU_STACK_GUARD) || defined(CONFIG_USERSPACE)
+/*
+ * @brief Reset Kernel SRAM region access permissions at context-switch.
+ */
+void configure_mpu_kernel_ram_region_reset(void)
+{
+	arm_core_mpu_disable();
+	arm_core_mpu_kernel_ram_region_reset();
+	arm_core_mpu_enable();
+}
+#endif /* CONFIG_MPU_STACK_GUARD || CONFIG_USERSPACE */
+#endif
+
 #if defined(CONFIG_MPU_STACK_GUARD)
 /*
  * @brief Configure MPU stack guard

--- a/arch/arm/core/cortex_m/mpu/arm_core_mpu.c
+++ b/arch/arm/core/cortex_m/mpu/arm_core_mpu.c
@@ -49,7 +49,12 @@ void configure_mpu_stack_guard(struct k_thread *thread)
 	u32_t guard_start = thread->stack_info.start;
 #endif
 
+#if !defined(CONFIG_MPU_REQUIRES_NON_OVERLAPPING_REGIONS)
+	/* Determining the proper partitioning requires MPU to be enabled.
+	 * The underlying driver shall disable MPU before re-programming it.
+	 */
 	arm_core_mpu_disable();
+#endif /* CONFIG_MPU_REQUIRES_NON_OVERLAPPING_REGIONS */
 	arm_core_mpu_configure(THREAD_STACK_GUARD_REGION, guard_start,
 			       guard_size);
 	arm_core_mpu_enable();
@@ -68,7 +73,12 @@ void configure_mpu_stack_guard(struct k_thread *thread)
 void configure_mpu_user_context(struct k_thread *thread)
 {
 	LOG_DBG("configure user thread %p's context", thread);
+#if !defined(CONFIG_MPU_REQUIRES_NON_OVERLAPPING_REGIONS)
+	/* Determining the proper partitioning requires MPU to be enabled.
+	 * The underlying driver shall disable MPU before re-programming it.
+	 */
 	arm_core_mpu_disable();
+#endif /* CONFIG_MPU_REQUIRES_NON_OVERLAPPING_REGIONS */
 	arm_core_mpu_configure_user_context(thread);
 	arm_core_mpu_enable();
 }

--- a/arch/arm/core/cortex_m/mpu/arm_mpu.c
+++ b/arch/arm/core/cortex_m/mpu/arm_mpu.c
@@ -142,6 +142,29 @@ static inline u32_t _get_region_index_by_type(u32_t type)
 }
 
 /**
+ * This internal function programs the MPU region of the given type,
+ * base address, and size.
+ */
+static void _mpu_configure_by_type(u8_t type, u32_t base, u32_t size)
+{
+	struct arm_mpu_region region_conf;
+
+	LOG_DBG("Region info: 0x%x 0x%x", base, size);
+	u32_t region_index = _get_region_index_by_type(type);
+
+	if (_get_region_attr_by_type(&region_conf.attr, type, base, size)) {
+		return;
+	}
+	region_conf.base = base;
+
+	if (region_index >= _get_num_regions()) {
+		return;
+	}
+
+	_region_init(region_index, &region_conf);
+}
+
+/**
  * This internal function disables a given MPU region.
  */
 static inline void _disable_region(u32_t r_index)
@@ -169,21 +192,7 @@ static inline void _disable_region(u32_t r_index)
  */
 void arm_core_mpu_configure(u8_t type, u32_t base, u32_t size)
 {
-	struct arm_mpu_region region_conf;
-
-	LOG_DBG("Region info: 0x%x 0x%x", base, size);
-	u32_t region_index = _get_region_index_by_type(type);
-
-	if (_get_region_attr_by_type(&region_conf.attr, type, base, size)) {
-		return;
-	}
-	region_conf.base = base;
-
-	if (region_index >= _get_num_regions()) {
-		return;
-	}
-
-	_region_init(region_index, &region_conf);
+	_mpu_configure_by_type(type, base, size);
 }
 
 #if defined(CONFIG_USERSPACE)

--- a/arch/arm/core/cortex_m/mpu/arm_mpu.c
+++ b/arch/arm/core/cortex_m/mpu/arm_mpu.c
@@ -366,8 +366,17 @@ void arm_core_mpu_kernel_ram_region_reset(void)
 void arm_core_mpu_configure_user_context(struct k_thread *thread)
 {
 	if (!thread->arch.priv_stack_start) {
+		/* If this is a supervisor thread,
+		 * disable thread stack MPU region.
+		 */
+#if !defined(CONFIG_MPU_REQUIRES_NON_OVERLAPPING_REGIONS)
+		/* For ARMv8-M MPU with requirement for non-overlapping regions
+		 * Kernel SRAM access permissions are reset in context-switch,
+		 * so this region has already been disabled.
+		 */
 		_disable_region(_get_region_index_by_type(
 			THREAD_STACK_REGION));
+#endif
 		return;
 	}
 

--- a/arch/arm/core/cortex_m/mpu/arm_mpu.c
+++ b/arch/arm/core/cortex_m/mpu/arm_mpu.c
@@ -553,6 +553,12 @@ static int arm_mpu_init(struct device *arg)
 	_mpu_configure_by_type(KERNEL_BKGND_REGION,
 		(u32_t)&__kernel_ram_start,
 		(u32_t)&__kernel_ram_end - (u32_t)&__kernel_ram_start);
+#if defined(CONFIG_APP_SHARED_MEM)
+	/* Set access permissions for Application shared memory at init. */
+	_mpu_configure_by_type(APP_SHARED_MEM_BKGND_REGION,
+		(u32_t)&_app_smem_start,
+		(u32_t)&_app_smem_end - (u32_t)&_app_smem_start);
+#endif /* CONFIG_APP_SHARED_MEM */
 #endif /* CONFIG_MPU_REQUIRES_NON_OVERLAPPING_REGIONS */
 
 	arm_core_mpu_enable();

--- a/arch/arm/core/cortex_m/mpu/arm_mpu.c
+++ b/arch/arm/core/cortex_m/mpu/arm_mpu.c
@@ -166,6 +166,8 @@ static void _mpu_configure_by_type(u8_t type, u32_t base, u32_t size)
 
 /**
  * This internal function disables a given MPU region.
+ *
+ * @param r_index MPU region index
  */
 static inline void _disable_region(u32_t r_index)
 {
@@ -182,6 +184,23 @@ static inline void _disable_region(u32_t r_index)
 	/* Disable region */
 	ARM_MPU_ClrRegion(r_index);
 }
+
+#if defined(CONFIG_MPU_REQUIRES_NON_OVERLAPPING_REGIONS)
+/**
+ * This internal function disables the MPU region of the given type
+ *
+ * @param   type    MPU region type
+ */
+static void _disable_region_by_type(u8_t type)
+{
+	LOG_DBG("disable region type ox%x", type);
+	u32_t region_index = _get_region_index_by_type(type);
+	if (region_index >= _get_num_regions()) {
+		return;
+	}
+	_disable_region(region_index);
+}
+#endif /* CONFIG_MPU_REQUIRES_NON_OVERLAPPING_REGIONS */
 
 /**
  * @brief configure the base address and size for an MPU region

--- a/arch/arm/core/cortex_m/mpu/arm_mpu.c
+++ b/arch/arm/core/cortex_m/mpu/arm_mpu.c
@@ -200,6 +200,32 @@ static void _disable_region_by_type(u8_t type)
 	}
 	_disable_region(region_index);
 }
+
+#if defined(CONFIG_USERSPACE) || defined(CONFIG_MPU_STACK_GUARD)
+/**
+ * This internal function determines the background region
+ * type corresponding to the requested MPU region type.
+ */
+static inline int _get_background_region_type(u8_t type)
+{
+	switch (type) {
+#if defined(CONFIG_USERSPACE)
+	case THREAD_STACK_REGION:
+		return KERNEL_BKGND_THREAD_STACK_REGION;
+#endif
+#if defined(CONFIG_MPU_STACK_GUARD)
+	case THREAD_STACK_GUARD_REGION:
+		return KERNEL_BKGND_STACK_GUARD_REGION;
+#endif
+	default:
+		__ASSERT(0,
+			"Failed to get background type for region type %u\n",
+			type);
+		return -EINVAL;
+	}
+}
+
+#endif /* CONFIG_USERSPACE || CONFIG_MPU_STACK_GUARD */
 #endif /* CONFIG_MPU_REQUIRES_NON_OVERLAPPING_REGIONS */
 
 /**

--- a/arch/arm/core/cortex_m/mpu/arm_mpu.c
+++ b/arch/arm/core/cortex_m/mpu/arm_mpu.c
@@ -364,18 +364,10 @@ static int arm_mpu_init(struct device *arg)
 	}
 
 #if defined(CONFIG_APPLICATION_MEMORY)
-	u32_t index, size;
-	struct arm_mpu_region region_conf;
-
 	/* configure app data portion */
-	index = _get_region_index_by_type(THREAD_APP_DATA_REGION);
-	size = (u32_t)&__app_ram_end - (u32_t)&__app_ram_start;
-	_get_region_attr_by_type(&region_conf.attr, THREAD_APP_DATA_REGION,
-			(u32_t)&__app_ram_start, size);
-	region_conf.base = (u32_t)&__app_ram_start;
-	if (size > 0) {
-		_region_init(index, &region_conf);
-	}
+	_mpu_configure_by_type(THREAD_APP_DATA_REGION,
+		(u32_t)&__app_ram_start,
+		(u32_t)&__app_ram_end - (u32_t)&__app_ram_start);
 #endif
 
 	arm_core_mpu_enable();

--- a/arch/arm/core/cortex_m/mpu/arm_mpu_v8_internal.h
+++ b/arch/arm/core/cortex_m/mpu/arm_mpu_v8_internal.h
@@ -56,9 +56,6 @@ static void _region_init(u32_t index, const struct arm_mpu_region *region_conf)
 			region_conf->attr.mair_idx, region_conf->attr.r_limit);
 }
 
-#if defined(CONFIG_USERSPACE) || defined(CONFIG_MPU_STACK_GUARD) || \
-	defined(CONFIG_APPLICATION_MEMORY)
-
 /**
  * This internal function returns the MPU region, in which a
  * buffer, specified by its start address and size, lies. If
@@ -124,6 +121,9 @@ static inline void _get_mpu_ram_region_attr(arm_mpu_region_attr_t *p_attr,
 	p_attr->mair_idx = MPU_MAIR_INDEX_SRAM;
 	p_attr->r_limit = REGION_LIMIT_ADDR(base, size);
 }
+
+#if defined(CONFIG_USERSPACE) || defined(CONFIG_MPU_STACK_GUARD) || \
+	defined(CONFIG_APPLICATION_MEMORY)
 
 /**
  * This internal function is utilized by the MPU driver to combine a given

--- a/arch/arm/core/cortex_m/mpu/arm_mpu_v8_internal.h
+++ b/arch/arm/core/cortex_m/mpu/arm_mpu_v8_internal.h
@@ -79,6 +79,38 @@ static inline int _get_region_index(u32_t start, u32_t size)
 	return -EINVAL;
 }
 
+/* Get the base address of a configured MPU region
+ *
+ * @param r_index the index number of the MPU region
+ */
+static inline u32_t _get_region_base_addr(u32_t r_index)
+{
+	MPU->RNR = r_index;
+	return MPU->RBAR & MPU_RBAR_BASE_Msk;
+}
+
+/* Get the end address of a configured MPU region
+ *
+ * @param r_index the index number of the MPU region
+ */
+static inline u32_t _get_region_end_addr(u32_t r_index)
+{
+	MPU->RNR = r_index;
+	return (MPU->RLAR & MPU_RLAR_LIMIT_Msk) | (~MPU_RLAR_LIMIT_Msk);
+}
+
+/* Set (i.e. modify) the end address of an MPU region
+ *
+ * @param r_index the index number of the MPU region
+ * @param addr    the address to be set as the end address
+ */
+static inline void _set_region_end_addr(u32_t r_index, u32_t addr)
+{
+	MPU->RNR = r_index;
+	MPU->RLAR = (MPU->RLAR & (~(MPU_RLAR_LIMIT_Msk))) |
+		((addr) & MPU_RLAR_LIMIT_Msk);
+}
+
 /**
  * This internal function allocates default RAM cache-ability, share-ability,
  * and execution allowance attributes along with the requested access

--- a/arch/arm/core/swap_helper.S
+++ b/arch/arm/core/swap_helper.S
@@ -182,6 +182,15 @@ _thread_irq_disabled:
     vldmia r0, {s16-s31}
 #endif
 
+#ifdef CONFIG_MPU_REQUIRES_NON_OVERLAPPING_REGIONS
+#if defined(CONFIG_MPU_STACK_GUARD) || defined(CONFIG_USERSPACE)
+	/* r2 contains k_thread */
+    push {r2, lr}
+    blx configure_mpu_kernel_ram_region_reset
+    pop {r2, lr}
+#endif /* CONFIG_MPU_STACK_GUARD || USERSPACE */
+#endif
+
 #ifdef CONFIG_MPU_STACK_GUARD
     /* r2 contains k_thread */
     add r0, r2, #0

--- a/include/arch/arm/cortex_m/mpu/arm_core_mpu.h
+++ b/include/arch/arm/cortex_m/mpu/arm_core_mpu.h
@@ -20,6 +20,21 @@
 extern "C" {
 #endif
 
+#if defined(CONFIG_MPU_REQUIRES_NON_OVERLAPPING_REGIONS)
+/**
+ * @brief Reset the access permissions of the entire kernel SRAM region
+ *
+ * This function will reset the access permissions of the kernel RAM region.
+ * It does this by re-programming the MPU region that covers the entire kernel
+ * SRAM (i.e. KERNEL_BKGND_REGION). In addition, it clears any MPU regions
+ * related to memory protection features (e.g. THREAD_STACK, STACK_GUARD, etc.)
+ * and their respective background ram regions. The function intends to be used
+ * during context switch, for MPU architectures that do not allow overlapping
+ * active MPU regions.
+ */
+void configure_mpu_kernel_ram_region_reset(void);
+#endif
+
 #if defined(CONFIG_MPU_STACK_GUARD)
 /**
  * @brief Configure MPU stack guard

--- a/include/arch/arm/cortex_m/mpu/arm_core_mpu_dev.h
+++ b/include/arch/arm/cortex_m/mpu/arm_core_mpu_dev.h
@@ -132,6 +132,11 @@ void arm_core_mpu_disable(void);
 void arm_core_mpu_configure(u8_t type, u32_t base, u32_t size);
 
 /**
+ * @brief reset access permissions for the entire kernel SRAM region
+ */
+void arm_core_mpu_kernel_ram_region_reset(void);
+
+/**
  * @brief configure MPU regions for the memory partitions of the memory domain
  *
  * @param   mem_domain    memory domain that thread belongs to

--- a/include/linker/linker-defs.h
+++ b/include/linker/linker-defs.h
@@ -172,9 +172,14 @@ GDATA(__data_num_words)
 
 #include <zephyr/types.h>
 /*
- * The following are externs symbols from the linker. This enables
+ * Memory owned by the kernel, to be used as shared memory between threads.
+ *
+ * The following are extern symbols from the linker. This enables
  * the dynamic k_mem_domain and k_mem_partition creation and alignment
  * to the section produced in the linker.
+
+ * The policy for this memory will be to initially configure all of it as
+ * kernel / supervisor thread accessible.
  */
 extern char _app_smem_start[];
 extern char _app_smem_end[];
@@ -194,7 +199,7 @@ extern char __app_ram_size[];
 #endif
 
 /* Memory owned by the kernel. Start and end will be aligned for memory
- * management/protection hardware for the target architecture..
+ * management/protection hardware for the target architecture.
  *
  * Consists of all kernel-side globals, all kernel objects, all thread stacks,
  * and all currently unused RAM.  If CONFIG_APPLICATION_MEMORY is not enabled,


### PR DESCRIPTION
Pushing this as an "almost complete" work.
Goal:  support User-mode, Application Memory, Shared App Memory and Priv Stack Guards in ARMv8-M

Changes modularized into small patches; several commits are just refactoring.
I recommend to review commit-by-commit.

Things to do after this PR is reviewed and merged:
Document or enforce the proper use of APP Shared Memory in ARMv8-M builds

**Update**:
**All userspace-related Zephyr tests are passing, except for tests/kernel/mem_protect/mem_protect; which partially fails, because it defines mem_domains in kernel area (expected)**

Fixed comments by @agross-linaro 