### PR TITLE
subsys: bluetooth: host: Notify outstanding request before destroying all ATT reqs

### DIFF
--- a/subsys/bluetooth/host/att.c
+++ b/subsys/bluetooth/host/att.c
@@ -2002,6 +2002,9 @@ static void att_reset(struct bt_att *att)
 		k_sem_give(&att->tx_sem);
 	}
 
+	/* Notify outstanding request */
+	att_handle_rsp(att, NULL, 0, BT_ATT_ERR_UNLIKELY);
+
 	/* Notify pending requests */
 	SYS_SLIST_FOR_EACH_CONTAINER_SAFE(&att->reqs, req, tmp, node) {
 		if (req->func) {
@@ -2014,12 +2017,8 @@ static void att_reset(struct bt_att *att)
 	/* Reset list */
 	sys_slist_init(&att->reqs);
 
-	if (!att->req) {
-		return;
-	}
-
-	/* Notify outstanding request */
-	att_handle_rsp(att, NULL, 0, BT_ATT_ERR_UNLIKELY);
+	/* Remove active ATT req that has been freed */
+	att->req = NULL;
 }
 
 static void att_timeout(struct k_work *work)


### PR DESCRIPTION
`att_reset()` destroys all ATT reqs (using `att_req_destroy`) and empty the ATT req queue.

Calling `att_handle_rsp()` after the loop will use an invalid ATT req (all the ATT reqs have been `memset(0)`) - so the notified ATT req function called [here](https://github.com/zephyrproject-rtos/zephyr/blob/master/subsys/bluetooth/host/att.c#L325) is `NULL`.

This change move the outstanding req notification before destroying all ATT reqs.

Signed-off-by: Olivier Martin <olivier.martin@proglove.de>