### PR TITLE
drivers: samples: out-of-order logging include cleanup

### DIFF
--- a/drivers/gpio/gpio_shell.c
+++ b/drivers/gpio/gpio_shell.c
@@ -12,10 +12,9 @@
 #include <gpio.h>
 #include <stdlib.h>
 #include <ctype.h>
-#include <logging/log.h>
 
 #define LOG_LEVEL CONFIG_LOG_DEFAULT_LEVEL
-
+#include <logging/log.h>
 LOG_MODULE_REGISTER(gpio_shell);
 
 struct args_index {

--- a/drivers/modem/modem_receiver.c
+++ b/drivers/modem/modem_receiver.c
@@ -15,10 +15,9 @@
 #include <init.h>
 #include <uart.h>
 
-#include <logging/log.h>
-#define LOG_DOMAIN mdm_receiver
 #define LOG_LEVEL CONFIG_LOG_MODEM_LEVEL
-LOG_MODULE_REGISTER(LOG_DOMAIN);
+#include <logging/log.h>
+LOG_MODULE_REGISTER(mdm_receiver);
 
 #include <drivers/modem/modem_receiver.h>
 

--- a/drivers/pci/pci_shell.c
+++ b/drivers/pci/pci_shell.c
@@ -10,11 +10,10 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <ctype.h>
-#include <logging/log.h>
 #include <pci/pci.h>
 
 #define LOG_LEVEL CONFIG_LOG_DEFAULT_LEVEL
-
+#include <logging/log.h>
 LOG_MODULE_REGISTER(lspci_shell);
 
 static void list_devices(const struct shell *shell,

--- a/drivers/sensor/adxl362/adxl362.c
+++ b/drivers/sensor/adxl362/adxl362.c
@@ -14,11 +14,11 @@
 #include <misc/byteorder.h>
 #include <misc/__assert.h>
 #include <spi.h>
-#include <logging/log.h>
 
 #include "adxl362.h"
 
 #define LOG_LEVEL CONFIG_SENSOR_LOG_LEVEL
+#include <logging/log.h>
 LOG_MODULE_REGISTER(ADXL362);
 
 static struct adxl362_data adxl362_data;

--- a/drivers/sensor/adxl372/adxl372.c
+++ b/drivers/sensor/adxl372/adxl372.c
@@ -14,11 +14,11 @@
 #include <stdlib.h>
 #include <spi.h>
 #include <i2c.h>
-#include <logging/log.h>
 
 #include "adxl372.h"
 
 #define LOG_LEVEL CONFIG_SENSOR_LOG_LEVEL
+#include <logging/log.h>
 LOG_MODULE_REGISTER(ADXL372);
 
 static int adxl372_bus_access(struct device *dev, u8_t reg,

--- a/drivers/sensor/ak8975/ak8975.c
+++ b/drivers/sensor/ak8975/ak8975.c
@@ -11,11 +11,11 @@
 #include <misc/__assert.h>
 #include <misc/byteorder.h>
 #include <misc/util.h>
-#include <logging/log.h>
 
 #include "ak8975.h"
 
 #define LOG_LEVEL CONFIG_SENSOR_LOG_LEVEL
+#include <logging/log.h>
 LOG_MODULE_REGISTER(AK8975);
 
 static int ak8975_sample_fetch(struct device *dev, enum sensor_channel chan)

--- a/drivers/sensor/amg88xx/amg88xx.c
+++ b/drivers/sensor/amg88xx/amg88xx.c
@@ -13,11 +13,11 @@
 #include <kernel.h>
 #include <sensor.h>
 #include <misc/__assert.h>
-#include <logging/log.h>
 
 #include "amg88xx.h"
 
 #define LOG_LEVEL CONFIG_SENSOR_LOG_LEVEL
+#include <logging/log.h>
 LOG_MODULE_REGISTER(AMG88XX);
 
 static int amg88xx_sample_fetch(struct device *dev, enum sensor_channel chan)

--- a/drivers/sensor/apds9960/apds9960.c
+++ b/drivers/sensor/apds9960/apds9960.c
@@ -17,11 +17,11 @@
 #include <init.h>
 #include <kernel.h>
 #include <string.h>
-#include <logging/log.h>
 
 #include "apds9960.h"
 
 #define LOG_LEVEL CONFIG_SENSOR_LOG_LEVEL
+#include <logging/log.h>
 LOG_MODULE_REGISTER(APDS9960);
 
 static void apds9960_gpio_callback(struct device *dev,

--- a/drivers/sensor/bma280/bma280.c
+++ b/drivers/sensor/bma280/bma280.c
@@ -8,11 +8,11 @@
 #include <init.h>
 #include <sensor.h>
 #include <misc/__assert.h>
-#include <logging/log.h>
 
 #include "bma280.h"
 
 #define LOG_LEVEL CONFIG_SENSOR_LOG_LEVEL
+#include <logging/log.h>
 LOG_MODULE_REGISTER(BMA280);
 
 static int bma280_sample_fetch(struct device *dev, enum sensor_channel chan)

--- a/drivers/sensor/bmc150_magn/bmc150_magn.c
+++ b/drivers/sensor/bmc150_magn/bmc150_magn.c
@@ -17,11 +17,11 @@
 #include <misc/__assert.h>
 
 #include <gpio.h>
-#include <logging/log.h>
 
 #include "bmc150_magn.h"
 
 #define LOG_LEVEL CONFIG_SENSOR_LOG_LEVEL
+#include <logging/log.h>
 LOG_MODULE_REGISTER(BMC150_MAGN);
 
 static const struct {

--- a/drivers/sensor/bme280/bme280.c
+++ b/drivers/sensor/bme280/bme280.c
@@ -19,11 +19,11 @@
 #elif defined CONFIG_BME280_DEV_TYPE_SPI
 #include <spi.h>
 #endif
-#include <logging/log.h>
 
 #include "bme280.h"
 
 #define LOG_LEVEL CONFIG_SENSOR_LOG_LEVEL
+#include <logging/log.h>
 LOG_MODULE_REGISTER(BME280);
 
 static int bm280_reg_read(struct bme280_data *data,

--- a/drivers/sensor/bmg160/bmg160.c
+++ b/drivers/sensor/bmg160/bmg160.c
@@ -12,11 +12,11 @@
 #include <sensor.h>
 #include <misc/byteorder.h>
 #include <kernel.h>
-#include <logging/log.h>
 
 #include "bmg160.h"
 
 #define LOG_LEVEL CONFIG_SENSOR_LOG_LEVEL
+#include <logging/log.h>
 LOG_MODULE_REGISTER(BMG160);
 
 struct bmg160_device_data bmg160_data;

--- a/drivers/sensor/bmi160/bmi160.c
+++ b/drivers/sensor/bmi160/bmi160.c
@@ -13,11 +13,11 @@
 #include <misc/byteorder.h>
 #include <kernel.h>
 #include <misc/__assert.h>
-#include <logging/log.h>
 
 #include "bmi160.h"
 
 #define LOG_LEVEL CONFIG_SENSOR_LOG_LEVEL
+#include <logging/log.h>
 LOG_MODULE_REGISTER(BMI160);
 
 struct bmi160_device_data bmi160_data;

--- a/drivers/sensor/bmm150/bmm150.c
+++ b/drivers/sensor/bmm150/bmm150.c
@@ -6,10 +6,10 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <logging/log.h>
 #include "bmm150.h"
 
 #define LOG_LEVEL CONFIG_SENSOR_LOG_LEVEL
+#include <logging/log.h>
 LOG_MODULE_REGISTER(BMM150);
 
 static const struct {

--- a/drivers/sensor/ccs811/ccs811.c
+++ b/drivers/sensor/ccs811/ccs811.c
@@ -12,11 +12,11 @@
 #include <misc/util.h>
 #include <sensor.h>
 #include <misc/__assert.h>
-#include <logging/log.h>
 
 #include "ccs811.h"
 
 #define LOG_LEVEL CONFIG_SENSOR_LOG_LEVEL
+#include <logging/log.h>
 LOG_MODULE_REGISTER(CCS811);
 
 static int ccs811_sample_fetch(struct device *dev, enum sensor_channel chan)

--- a/drivers/sensor/dht/dht.c
+++ b/drivers/sensor/dht/dht.c
@@ -11,11 +11,11 @@
 #include <sensor.h>
 #include <string.h>
 #include <zephyr.h>
-#include <logging/log.h>
 
 #include "dht.h"
 
 #define LOG_LEVEL CONFIG_SENSOR_LOG_LEVEL
+#include <logging/log.h>
 LOG_MODULE_REGISTER(DHT);
 
 /**

--- a/drivers/sensor/fxas21002/fxas21002.c
+++ b/drivers/sensor/fxas21002/fxas21002.c
@@ -7,9 +7,9 @@
 #include "fxas21002.h"
 #include <misc/util.h>
 #include <misc/__assert.h>
-#include <logging/log.h>
 
 #define LOG_LEVEL CONFIG_SENSOR_LOG_LEVEL
+#include <logging/log.h>
 LOG_MODULE_REGISTER(FXAS21002);
 
 /* Sample period in microseconds, indexed by output data rate encoding (DR) */

--- a/drivers/sensor/fxas21002/fxas21002_trigger.c
+++ b/drivers/sensor/fxas21002/fxas21002_trigger.c
@@ -4,8 +4,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <logging/log.h>
-
 #include "fxas21002.h"
 
 #define LOG_LEVEL CONFIG_SENSOR_LOG_LEVEL

--- a/drivers/sensor/fxos8700/fxos8700.c
+++ b/drivers/sensor/fxos8700/fxos8700.c
@@ -8,10 +8,10 @@
 #include "fxos8700.h"
 #include <misc/util.h>
 #include <misc/__assert.h>
-#include <logging/log.h>
 #include <stdlib.h>
 
 #define LOG_LEVEL CONFIG_SENSOR_LOG_LEVEL
+#include <logging/log.h>
 LOG_MODULE_REGISTER(FXOS8700);
 
 int fxos8700_set_odr(struct device *dev, const struct sensor_value *val)

--- a/drivers/sensor/hdc1008/hdc1008.c
+++ b/drivers/sensor/hdc1008/hdc1008.c
@@ -11,11 +11,11 @@
 #include <sensor.h>
 #include <misc/util.h>
 #include <misc/__assert.h>
-#include <logging/log.h>
 
 #include "hdc1008.h"
 
 #define LOG_LEVEL CONFIG_SENSOR_LOG_LEVEL
+#include <logging/log.h>
 LOG_MODULE_REGISTER(HDC1008);
 
 static void hdc1008_gpio_callback(struct device *dev,

--- a/drivers/sensor/hmc5883l/hmc5883l.c
+++ b/drivers/sensor/hmc5883l/hmc5883l.c
@@ -10,11 +10,11 @@
 #include <misc/byteorder.h>
 #include <sensor.h>
 #include <string.h>
-#include <logging/log.h>
 
 #include "hmc5883l.h"
 
 #define LOG_LEVEL CONFIG_SENSOR_LOG_LEVEL
+#include <logging/log.h>
 LOG_MODULE_REGISTER(HMC5883L);
 
 static void hmc5883l_convert(struct sensor_value *val, s16_t raw_val,

--- a/drivers/sensor/hp206c/hp206c.c
+++ b/drivers/sensor/hp206c/hp206c.c
@@ -14,12 +14,11 @@
 #include <misc/byteorder.h>
 #include <kernel.h>
 #include <gpio.h>
-#include <logging/log.h>
 
 #include "hp206c.h"
 
-
 #define LOG_LEVEL CONFIG_SENSOR_LOG_LEVEL
+#include <logging/log.h>
 LOG_MODULE_REGISTER(HP206C);
 
 static inline int hp206c_bus_config(struct device *dev)

--- a/drivers/sensor/hts221/hts221.c
+++ b/drivers/sensor/hts221/hts221.c
@@ -10,11 +10,11 @@
 #include <misc/byteorder.h>
 #include <sensor.h>
 #include <string.h>
-#include <logging/log.h>
 
 #include "hts221.h"
 
 #define LOG_LEVEL CONFIG_SENSOR_LEVEL
+#include <logging/log.h>
 LOG_MODULE_REGISTER(HTS221);
 
 static int hts221_channel_get(struct device *dev,

--- a/drivers/sensor/isl29035/isl29035.c
+++ b/drivers/sensor/isl29035/isl29035.c
@@ -11,11 +11,11 @@
 #include <i2c.h>
 #include <sensor.h>
 #include <misc/__assert.h>
-#include <logging/log.h>
 
 #include "isl29035.h"
 
 #define LOG_LEVEL CONFIG_SENSOR_LOG_LEVEL
+#include <logging/log.h>
 LOG_MODULE_REGISTER(ISL29035);
 
 static int isl29035_sample_fetch(struct device *dev, enum sensor_channel chan)

--- a/drivers/sensor/lis2dh/lis2dh.c
+++ b/drivers/sensor/lis2dh/lis2dh.c
@@ -8,9 +8,9 @@
 #include <init.h>
 #include <misc/byteorder.h>
 #include <misc/__assert.h>
-#include <logging/log.h>
 
 #define LOG_LEVEL CONFIG_SENSOR_LOG_LEVEL
+#include <logging/log.h>
 LOG_MODULE_REGISTER(lis2dh);
 #include "lis2dh.h"
 

--- a/drivers/sensor/lis3dh/lis3dh.c
+++ b/drivers/sensor/lis3dh/lis3dh.c
@@ -8,11 +8,11 @@
 #include <init.h>
 #include <sensor.h>
 #include <misc/__assert.h>
-#include <logging/log.h>
 
 #include "lis3dh.h"
 
 #define LOG_LEVEL CONFIG_SENSOR_LOG_LEVEL
+#include <logging/log.h>
 LOG_MODULE_REGISTER(LIS3DH);
 
 static void lis3dh_convert(struct sensor_value *val, s64_t raw_val)

--- a/drivers/sensor/lis3dh/lis3dh_trigger.c
+++ b/drivers/sensor/lis3dh/lis3dh_trigger.c
@@ -9,7 +9,6 @@
 #include <misc/util.h>
 #include <kernel.h>
 #include <sensor.h>
-#include <logging/log.h>
 
 #include "lis3dh.h"
 

--- a/drivers/sensor/lis3mdl/lis3mdl.c
+++ b/drivers/sensor/lis3mdl/lis3mdl.c
@@ -10,11 +10,11 @@
 #include <misc/byteorder.h>
 #include <sensor.h>
 #include <string.h>
-#include <logging/log.h>
 
 #include "lis3mdl.h"
 
 #define LOG_LEVEL CONFIG_SENSOR_LOG_LEVEL
+#include <logging/log.h>
 LOG_MODULE_REGISTER(LIS3MDL);
 
 static void lis3mdl_convert(struct sensor_value *val, s16_t raw_val,

--- a/drivers/sensor/lps22hb/lps22hb.c
+++ b/drivers/sensor/lps22hb/lps22hb.c
@@ -12,11 +12,11 @@
 #include <init.h>
 #include <misc/byteorder.h>
 #include <misc/__assert.h>
-#include <logging/log.h>
 
 #include "lps22hb.h"
 
 #define LOG_LEVEL CONFIG_SENSOR_LOG_LEVEL
+#include <logging/log.h>
 LOG_MODULE_REGISTER(LPS22HB);
 
 static inline int lps22hb_set_odr_raw(struct device *dev, u8_t odr)

--- a/drivers/sensor/lps25hb/lps25hb.c
+++ b/drivers/sensor/lps25hb/lps25hb.c
@@ -12,11 +12,11 @@
 #include <init.h>
 #include <misc/byteorder.h>
 #include <misc/__assert.h>
-#include <logging/log.h>
 
 #include "lps25hb.h"
 
 #define LOG_LEVEL CONFIG_SENSOR_LOG_LEVEL
+#include <logging/log.h>
 LOG_MODULE_REGISTER(LPS25HB);
 
 static inline int lps25hb_power_ctrl(struct device *dev, u8_t value)

--- a/drivers/sensor/lsm6ds0/lsm6ds0.c
+++ b/drivers/sensor/lsm6ds0/lsm6ds0.c
@@ -14,11 +14,11 @@
 #include <init.h>
 #include <misc/byteorder.h>
 #include <misc/__assert.h>
-#include <logging/log.h>
 
 #include "lsm6ds0.h"
 
 #define LOG_LEVEL CONFIG_SENSOR_LOG_LEVEL
+#include <logging/log.h>
 LOG_MODULE_REGISTER(LSM6DS0);
 
 static inline int lsm6ds0_reboot(struct device *dev)

--- a/drivers/sensor/lsm6dsl/lsm6dsl.c
+++ b/drivers/sensor/lsm6dsl/lsm6dsl.c
@@ -15,11 +15,11 @@
 #include <string.h>
 #include <misc/byteorder.h>
 #include <misc/__assert.h>
-#include <logging/log.h>
 
 #include "lsm6dsl.h"
 
 #define LOG_LEVEL CONFIG_SENSOR_LOG_LEVEL
+#include <logging/log.h>
 LOG_MODULE_REGISTER(LSM6DSL);
 
 static const u16_t lsm6dsl_odr_map[] = {0, 12, 26, 52, 104, 208, 416, 833,

--- a/drivers/sensor/lsm6dsl/lsm6dsl_i2c.c
+++ b/drivers/sensor/lsm6dsl/lsm6dsl_i2c.c
@@ -9,13 +9,13 @@
 
 #include <string.h>
 #include <i2c.h>
-#include <logging/log.h>
 
 #include "lsm6dsl.h"
 
 static u16_t lsm6dsl_i2c_slave_addr = CONFIG_LSM6DSL_I2C_ADDR;
 
 #define LOG_LEVEL CONFIG_SENSOR_LOG_LEVEL
+#include <logging/log.h>
 LOG_MODULE_DECLARE(LSM6DSL);
 
 static int lsm6dsl_i2c_read_data(struct lsm6dsl_data *data, u8_t reg_addr,

--- a/drivers/sensor/lsm6dsl/lsm6dsl_shub.c
+++ b/drivers/sensor/lsm6dsl/lsm6dsl_shub.c
@@ -10,11 +10,11 @@
 #include <misc/util.h>
 #include <kernel.h>
 #include <sensor.h>
-#include <logging/log.h>
 
 #include "lsm6dsl.h"
 
 #define LOG_LEVEL CONFIG_SENSOR_LOG_LEVEL
+#include <logging/log.h>
 LOG_MODULE_DECLARE(LSM6DSL);
 
 #define LSM6DSL_EMBEDDED_SLV0_ADDR       0x02

--- a/drivers/sensor/lsm6dsl/lsm6dsl_spi.c
+++ b/drivers/sensor/lsm6dsl/lsm6dsl_spi.c
@@ -10,11 +10,11 @@
 #include <string.h>
 #include <spi.h>
 #include "lsm6dsl.h"
-#include <logging/log.h>
 
 #define LSM6DSL_SPI_READ		(1 << 7)
 
 #define LOG_LEVEL CONFIG_SENSOR_LOG_LEVEL
+#include <logging/log.h>
 LOG_MODULE_DECLARE(LSM6DSL);
 
 #if defined(CONFIG_LSM6DSL_SPI_GPIO_CS)

--- a/drivers/sensor/lsm9ds0_gyro/lsm9ds0_gyro.c
+++ b/drivers/sensor/lsm9ds0_gyro/lsm9ds0_gyro.c
@@ -14,11 +14,11 @@
 #include <misc/__assert.h>
 
 #include <gpio.h>
-#include <logging/log.h>
 
 #include "lsm9ds0_gyro.h"
 
 #define LOG_LEVEL CONFIG_SENSOR_LOG_LEVEL
+#include <logging/log.h>
 LOG_MODULE_REGISTER(LSM9DS0_GYRO);
 
 static inline int lsm9ds0_gyro_power_ctrl(struct device *dev, int power,

--- a/drivers/sensor/lsm9ds0_mfd/lsm9ds0_mfd.c
+++ b/drivers/sensor/lsm9ds0_mfd/lsm9ds0_mfd.c
@@ -15,11 +15,11 @@
 #include <i2c.h>
 #include <misc/byteorder.h>
 #include <gpio.h>
-#include <logging/log.h>
 
 #include "lsm9ds0_mfd.h"
 
 #define LOG_LEVEL CONFIG_SENSOR_LOG_LEVEL
+#include <logging/log.h>
 LOG_MODULE_REGISTER(LSM9DS0_MFD);
 
 static inline int lsm9ds0_mfd_reboot_memory(struct device *dev)

--- a/drivers/sensor/max30101/max30101.c
+++ b/drivers/sensor/max30101/max30101.c
@@ -4,11 +4,10 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <logging/log.h>
-
 #include "max30101.h"
 
 #define LOG_LEVEL CONFIG_SENSOR_LOG_LEVEL
+#include <logging/log.h>
 LOG_MODULE_REGISTER(MAX30101);
 
 static int max30101_sample_fetch(struct device *dev, enum sensor_channel chan)

--- a/drivers/sensor/max44009/max44009.c
+++ b/drivers/sensor/max44009/max44009.c
@@ -8,11 +8,11 @@
 #include <i2c.h>
 #include <sensor.h>
 #include <misc/__assert.h>
-#include <logging/log.h>
 
 #include "max44009.h"
 
 #define LOG_LEVEL CONFIG_SENSOR_LOG_LEVEL
+#include <logging/log.h>
 LOG_MODULE_REGISTER(MAX44009);
 
 static int max44009_reg_read(struct max44009_data *drv_data, u8_t reg,

--- a/drivers/sensor/mcp9808/mcp9808.c
+++ b/drivers/sensor/mcp9808/mcp9808.c
@@ -13,11 +13,11 @@
 #include <init.h>
 #include <misc/byteorder.h>
 #include <misc/__assert.h>
-#include <logging/log.h>
 
 #include "mcp9808.h"
 
 #define LOG_LEVEL CONFIG_SENSOR_LOG_LEVEL
+#include <logging/log.h>
 LOG_MODULE_REGISTER(MCP9808);
 
 int mcp9808_reg_read(struct mcp9808_data *data, u8_t reg, u16_t *val)

--- a/drivers/sensor/mpu6050/mpu6050.c
+++ b/drivers/sensor/mpu6050/mpu6050.c
@@ -8,11 +8,11 @@
 #include <init.h>
 #include <misc/byteorder.h>
 #include <sensor.h>
-#include <logging/log.h>
 
 #include "mpu6050.h"
 
 #define LOG_LEVEL CONFIG_SENSOR_LOG_LEVEL
+#include <logging/log.h>
 LOG_MODULE_REGISTER(MPU6050);
 
 /* see "Accelerometer Measurements" section from register map description */

--- a/drivers/sensor/nrf5/temp_nrf5.c
+++ b/drivers/sensor/nrf5/temp_nrf5.c
@@ -7,9 +7,9 @@
 #include <device.h>
 #include <sensor.h>
 #include <clock_control.h>
-#include <logging/log.h>
 
 #define LOG_LEVEL CONFIG_SENSOR_LOG_LEVEL
+#include <logging/log.h>
 LOG_MODULE_REGISTER(TEMPNRF5);
 
 #include "nrf.h"

--- a/drivers/sensor/pms7003/pms7003.c
+++ b/drivers/sensor/pms7003/pms7003.c
@@ -18,9 +18,9 @@
 #include <stdlib.h>
 #include <string.h>
 #include <uart.h>
-#include <logging/log.h>
 
 #define LOG_LEVEL CONFIG_SENSOR_LOG_LEVEL
+#include <logging/log.h>
 LOG_MODULE_REGISTER(PMS7003);
 
 /* wait serial output with 1000ms timeout */

--- a/drivers/sensor/sht3xd/sht3xd.c
+++ b/drivers/sensor/sht3xd/sht3xd.c
@@ -9,11 +9,11 @@
 #include <kernel.h>
 #include <sensor.h>
 #include <misc/__assert.h>
-#include <logging/log.h>
 
 #include "sht3xd.h"
 
 #define LOG_LEVEL CONFIG_SENSOR_LOG_LEVEL
+#include <logging/log.h>
 LOG_MODULE_REGISTER(SHT3XD);
 
 /*

--- a/drivers/sensor/sx9500/sx9500.c
+++ b/drivers/sensor/sx9500/sx9500.c
@@ -14,11 +14,11 @@
 #include <init.h>
 #include <gpio.h>
 #include <misc/__assert.h>
-#include <logging/log.h>
 
 #include "sx9500.h"
 
 #define LOG_LEVEL CONFIG_SENSOR_LOG_LEVEL
+#include <logging/log.h>
 LOG_MODULE_REGISTER(SX9500);
 
 static u8_t sx9500_reg_defaults[] = {

--- a/drivers/sensor/th02/th02.c
+++ b/drivers/sensor/th02/th02.c
@@ -11,11 +11,11 @@
 #include <misc/util.h>
 #include <sensor.h>
 #include <misc/__assert.h>
-#include <logging/log.h>
 
 #include "th02.h"
 
 #define LOG_LEVEL CONFIG_SENSOR_LOG_LEVEL
+#include <logging/log.h>
 LOG_MODULE_REGISTER(TH02);
 
 static u8_t read8(struct device *dev, u8_t d)

--- a/drivers/sensor/tmp007/tmp007.c
+++ b/drivers/sensor/tmp007/tmp007.c
@@ -12,11 +12,11 @@
 #include <kernel.h>
 #include <sensor.h>
 #include <misc/__assert.h>
-#include <logging/log.h>
 
 #include "tmp007.h"
 
 #define LOG_LEVEL CONFIG_SENSOR_LOG_LEVEL
+#include <logging/log.h>
 LOG_MODULE_REGISTER(TMP007);
 
 int tmp007_reg_read(struct tmp007_data *drv_data, u8_t reg, u16_t *val)

--- a/drivers/sensor/tmp112/tmp112.c
+++ b/drivers/sensor/tmp112/tmp112.c
@@ -11,9 +11,9 @@
 #include <kernel.h>
 #include <sensor.h>
 #include <misc/__assert.h>
-#include <logging/log.h>
 
 #define LOG_LEVEL CONFIG_SENSOR_LOG_LEVEL
+#include <logging/log.h>
 LOG_MODULE_REGISTER(TMP112);
 
 #define TMP112_I2C_ADDRESS		CONFIG_TMP112_I2C_ADDR

--- a/drivers/sensor/vl53l0x/vl53l0x.c
+++ b/drivers/sensor/vl53l0x/vl53l0x.c
@@ -16,12 +16,12 @@
 #include <misc/__assert.h>
 #include <zephyr/types.h>
 #include <device.h>
-#include <logging/log.h>
 
 #include "vl53l0x_api.h"
 #include "vl53l0x_platform.h"
 
 #define LOG_LEVEL CONFIG_SENSOR_LOG_LEVEL
+#include <logging/log.h>
 LOG_MODULE_REGISTER(VL53L0X);
 
 /* All the values used in this driver are coming from ST datasheet and examples.

--- a/drivers/sensor/vl53l0x/vl53l0x_platform.c
+++ b/drivers/sensor/vl53l0x/vl53l0x_platform.c
@@ -15,9 +15,9 @@
 #include <device.h>
 #include <init.h>
 #include <i2c.h>
-#include <logging/log.h>
 
 #define LOG_LEVEL CONFIG_SENSOR_LOG_LEVEL
+#include <logging/log.h>
 LOG_MODULE_DECLARE(VL53L0X);
 
 VL53L0X_Error VL53L0X_WriteMulti(VL53L0X_DEV Dev, uint8_t index, uint8_t *pdata,

--- a/samples/bluetooth/ipsp/src/main.c
+++ b/samples/bluetooth/ipsp/src/main.c
@@ -6,9 +6,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <logging/log.h>
-
 #define LOG_LEVEL CONFIG_LOG_DEFAULT_LEVEL
+#include <logging/log.h>
 LOG_MODULE_REGISTER(ipsp);
 
 /* Preventing log module registration in net_core.h */


### PR DESCRIPTION
LOG_LEVEL must be defined prior to including logging/log.h
otherwise CONFIG_LOG_DEFAULT_LEVEL will be used instead.

Due to the out of order include of logging/log.h these
drivers and the 1 sample are actually using the setting
defined by CONFIG_LOG_DEFAULT_LEVEL.

Let's fix this.

NOTE: A static code analysis script should updated to check
for this issue and run on incoming PRs to avoid this in the
future.

Signed-off-by: Michael Scott <mike@foundries.io>