### PR TITLE
dts: Fix builds of arc EMSK & NSIM SoCs

### DIFF
--- a/soc/arc/snps_emsk/dts_fixup.h
+++ b/soc/arc/snps_emsk/dts_fixup.h
@@ -4,8 +4,8 @@
 #define DT_DCCM_BASE_ADDRESS       DT_ARC_DCCM_80000000_BASE_ADDRESS
 #define DT_DCCM_SIZE               (DT_ARC_DCCM_80000000_SIZE >> 10)
 
-#define DT_ICCM_BASE_ADDRESS       ARC_ICCM_0_BASE_ADDRESS
-#define DT_ICCM_SIZE               (ARC_ICCM_0_SIZE >> 10)
+#define DT_ICCM_BASE_ADDRESS       DT_ARC_ICCM_0_BASE_ADDRESS
+#define DT_ICCM_SIZE               (DT_ARC_ICCM_0_SIZE >> 10)
 
 /*
  * UART configuration

--- a/soc/arc/snps_nsim/dts_fixup.h
+++ b/soc/arc/snps_nsim/dts_fixup.h
@@ -4,7 +4,7 @@
 #define DT_DCCM_BASE_ADDRESS       DT_ARC_DCCM_80000000_BASE_ADDRESS
 #define DT_DCCM_SIZE               (DT_ARC_DCCM_80000000_SIZE >> 10)
 
-#define DT_ICCM_BASE_ADDRESS       ARC_ICCM_0_BASE_ADDRESS
-#define DT_ICCM_SIZE               (ARC_ICCM_0_SIZE >> 10)
+#define DT_ICCM_BASE_ADDRESS       DT_ARC_ICCM_0_BASE_ADDRESS
+#define DT_ICCM_SIZE               (DT_ARC_ICCM_0_SIZE >> 10)
 
 /* End of SoC Level DTS fixup file */


### PR DESCRIPTION
With the DT_ prefix change we missed adding prefixes in dts_fixup.h
on snps_emsk & snps_nsim for ARC_ICCM_0_BASE_ADDRESS and
ARC_ICCM_0_SIZE.

Signed-off-by: Kumar Gala <kumar.gala@linaro.org>