### PR TITLE
arch: common: Fixed compile error with multi interrupt.

### DIFF
--- a/arch/common/gen_isr_tables.py
+++ b/arch/common/gen_isr_tables.py
@@ -196,7 +196,7 @@ def main():
 
             debug(str(list_2nd_lvl_offsets))
 
-            if syms["CONFIG_3RD_LEVEL_INTERRUPTS"]:
+            if "CONFIG_3RD_LEVEL_INTERRUPTS" in syms:
                 if "CONFIG_NUM_3RD_LEVEL_AGGREGATORS" in syms:
                     num_aggregators = syms["CONFIG_NUM_3RD_LEVEL_AGGREGATORS"]
                     list_3rd_lvl_offsets = []


### PR DESCRIPTION
When enable 2-level interrupt with CONFIG_MULTI_LEVEL_INTERRUPTS
and CONFIG_2ND_LEVEL_INTERRUPTS, it will cause below issue:

  [ 97%] Generating isr_tables.c
    File "zephyr/arch/common/gen_isr_tables.py", line 199
       if syms["CONFIG_3RD_LEVEL_INTERRUPTS"]:
                                            ^
   TabError: inconsistent use of tabs and spaces in indentation
   *** [zephyr/isr_tables.c] Error 1

Signed-off-by: Dong Xiang <dong.xiang@unisoc.com>