### PR TITLE
dts: stm32f4: Fix clock settings for usart1

### DIFF
--- a/dts/arm/st/f4/stm32f4.dtsi
+++ b/dts/arm/st/f4/stm32f4.dtsi
@@ -118,7 +118,7 @@
 		usart1: serial@40011000 {
 			compatible = "st,stm32-usart", "st,stm32-uart";
 			reg = <0x40011000 0x400>;
-			clocks = <&rcc STM32_CLOCK_BUS_APB2 0x00004000>;
+			clocks = <&rcc STM32_CLOCK_BUS_APB2 0x00000010>;
 			interrupts = <37 0>;
 			status = "disabled";
 			label = "UART_1";


### PR DESCRIPTION
Clock mask was not set correctly for usart1 in stm32f4.dtsi

Fixes #11339

Signed-off-by: Erwan Gouriou <erwan.gouriou@linaro.org>