### PR TITLE
samples: Add explicit zephyr_include_directories to get <board.h>

### DIFF
--- a/samples/bluetooth/mesh_demo/CMakeLists.txt
+++ b/samples/bluetooth/mesh_demo/CMakeLists.txt
@@ -6,6 +6,8 @@ project(mesh_demo)
 
 target_sources(app PRIVATE src/main.c)
 target_sources_ifdef(CONFIG_BOARD_BBC_MICROBIT app PRIVATE src/microbit.c)
+zephyr_include_directories_ifdef(CONFIG_BOARD_BBC_MICROBIT
+				 $ENV{ZEPHYR_BASE}/boards/arm/bbc_microbit)
 
 if(NODE_ADDR)
   zephyr_compile_definitions(NODE_ADDR=${NODE_ADDR})

--- a/samples/boards/bbc_microbit/pong/CMakeLists.txt
+++ b/samples/boards/bbc_microbit/pong/CMakeLists.txt
@@ -5,3 +5,4 @@ project(pong)
 
 FILE(GLOB app_sources src/*.c)
 target_sources(app PRIVATE ${app_sources})
+zephyr_include_directories($ENV{ZEPHYR_BASE}/boards/arm/bbc_microbit)

--- a/samples/boards/bbc_microbit/sound/CMakeLists.txt
+++ b/samples/boards/bbc_microbit/sound/CMakeLists.txt
@@ -5,3 +5,4 @@ project(sound)
 
 FILE(GLOB app_sources src/*.c)
 target_sources(app PRIVATE ${app_sources})
+zephyr_include_directories($ENV{ZEPHYR_BASE}/boards/arm/bbc_microbit)

--- a/samples/boards/up_squared/gpio_counter/CMakeLists.txt
+++ b/samples/boards/up_squared/gpio_counter/CMakeLists.txt
@@ -4,3 +4,4 @@ include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
 project(gpio_counter)
 
 target_sources(app PRIVATE src/main.c)
+zephyr_include_directories($ENV{ZEPHYR_BASE}/boards/x86/up_squared)


### PR DESCRIPTION
There are a small handful of samples that still utilize <board.h>
include, to minimize the use of <board.h> to these specific cases and
allow us to remove adding the board dir to the top level include search
path, we explicitly in each sample add the specific board dir it needs.

For the microbit cases these could be replaced by DTS support in the
future when the pwm_nrf5_sw supports DTS.

Signed-off-by: Kumar Gala <kumar.gala@linaro.org>