### PR TITLE
c++: convert implicit conversion to explicit ones in header files

### DIFF
--- a/include/dma.h
+++ b/include/dma.h
@@ -195,7 +195,8 @@ struct dma_driver_api {
 static inline int dma_config(struct device *dev, u32_t channel,
 			     struct dma_config *config)
 {
-	const struct dma_driver_api *api = dev->driver_api;
+	const struct dma_driver_api *api =
+		(const struct dma_driver_api *)dev->driver_api;
 
 	return api->config(dev, channel, config);
 }
@@ -216,7 +217,8 @@ static inline int dma_config(struct device *dev, u32_t channel,
 static inline int dma_reload(struct device *dev, u32_t channel,
 		u32_t src, u32_t dst, size_t size)
 {
-	const struct dma_driver_api *api = dev->driver_api;
+	const struct dma_driver_api *api =
+		(const struct dma_driver_api *)dev->driver_api;
 
 	return api->reload(dev, channel, src, dst, size);
 }
@@ -239,7 +241,8 @@ __syscall int dma_start(struct device *dev, u32_t channel);
 
 static inline int _impl_dma_start(struct device *dev, u32_t channel)
 {
-	const struct dma_driver_api *api = dev->driver_api;
+	const struct dma_driver_api *api =
+		(const struct dma_driver_api *)dev->driver_api;
 
 	return api->start(dev, channel);
 }
@@ -261,7 +264,8 @@ __syscall int dma_stop(struct device *dev, u32_t channel);
 
 static inline int _impl_dma_stop(struct device *dev, u32_t channel)
 {
-	const struct dma_driver_api *api = dev->driver_api;
+	const struct dma_driver_api *api =
+		(const struct dma_driver_api *)dev->driver_api;
 
 	return api->stop(dev, channel);
 }

--- a/include/logging/log_core.h
+++ b/include/logging/log_core.h
@@ -253,7 +253,7 @@ extern "C" {
 
 #define _LOG(_level, ...)			       \
 	__LOG(_level,				       \
-	      LOG_CURRENT_MODULE_ID(),		       \
+	      (u16_t)LOG_CURRENT_MODULE_ID(),	       \
 	      LOG_CURRENT_DYNAMIC_DATA_ADDR(),	       \
 	      __VA_ARGS__)
 

--- a/include/net/net_context.h
+++ b/include/net/net_context.h
@@ -314,8 +314,9 @@ enum net_context_state net_context_get_state(struct net_context *context)
 {
 	NET_ASSERT(context);
 
-	return (context->flags >> NET_CONTEXT_STATE_SHIFT) &
-		NET_CONTEXT_STATE_MASK;
+	return (enum net_context_state)
+		((context->flags >> NET_CONTEXT_STATE_SHIFT) &
+		NET_CONTEXT_STATE_MASK);
 }
 
 /**

--- a/include/net/net_ip.h
+++ b/include/net/net_ip.h
@@ -1119,7 +1119,7 @@ static inline enum net_priority net_vlan2priority(u8_t priority)
 		return NET_PRIORITY_BE;
 	}
 
-	return vlan2priority[priority];
+	return (enum net_priority)vlan2priority[priority];
 }
 
 /**


### PR DESCRIPTION
c++ does not allow implicit conversions and setting -fpermissive just causes a huge load of warnings to appear and hides real errors.

This commit converts those implicit conversions to c-style explicit conversions.

Signed-off-by: Alexander Polleti <metapsycholo@gmail.com>