### PR TITLE
board/argonkey/dts: Configure i2c3 at 400KHz

### DIFF
--- a/boards/arm/96b_argonkey/96b_argonkey.dts
+++ b/boards/arm/96b_argonkey/96b_argonkey.dts
@@ -102,7 +102,7 @@
 
 &i2c3 {
 	status = "ok";
-	clock-frequency = <I2C_BITRATE_STANDARD>;
+	clock-frequency = <I2C_BITRATE_FAST>;
 
 	lp3943@60 {
 		compatible = "ti,lp3943";


### PR DESCRIPTION
As explained in issue #8915 the STM32F4xx SoC family I2C
does not work well in Standard mode (100KHz). So let's
configure i2c3 in Fast mode (400KHz).

Signed-off-by: Armando Visconti <armando.visconti@st.com>