### PR TITLE
coccinelle: Suppress reports/warnings for `ext/`

### DIFF
--- a/scripts/coccinelle/array_size.cocci
+++ b/scripts/coccinelle/array_size.cocci
@@ -24,7 +24,7 @@ virtual report
 //  For context mode
 //----------------------------------------------------------
 
-@depends on i&&context@
+@depends on i&&context && !(file in "ext")@
 type T;
 T[] E;
 @@
@@ -40,7 +40,7 @@ T[] E;
 //  For patch mode
 //----------------------------------------------------------
 
-@depends on i&&patch@
+@depends on i&&patch && !(file in "ext")@
 type T;
 T[] E;
 @@
@@ -59,7 +59,7 @@ T[] E;
 //  For org and report mode
 //----------------------------------------------------------
 
-@r depends on (org || report)@
+@r depends on (org || report) && !(file in "ext")@
 type T;
 T[] E;
 position p;

--- a/scripts/coccinelle/deref_null.cocci
+++ b/scripts/coccinelle/deref_null.cocci
@@ -16,7 +16,7 @@ virtual report
 
 // The following two rules are separate, because both can match a single
 // expression in different ways
-@pr1 expression@
+@pr1 depends on !(file in "ext")@
 expression E;
 identifier f;
 position p1;
@@ -24,7 +24,7 @@ position p1;
 
  (E != NULL && ...) ? <+...E->f@p1...+> : ...
 
-@pr2 expression@
+@pr2 depends on !(file in "ext")@
 expression E;
 identifier f;
 position p2;
@@ -38,7 +38,7 @@ position p2;
  sizeof(<+...E->f@p2...+>)
 )
 
-@ifm@
+@ifm depends on !(file in "ext")@
 expression *E;
 statement S1,S2;
 position p1;
@@ -48,7 +48,7 @@ if@p1 ((E == NULL && ...) || ...) S1 else S2
 
 // For org and report modes
 
-@r depends on !context && (org || report) exists@
+@r depends on !context && (org || report) && !(file in "ext") exists@
 expression subE <= ifm.E;
 expression *ifm.E;
 expression E1,E2;
@@ -169,7 +169,7 @@ cocci.print_main(msg_safe,p)
 
 // For context mode
 
-@depends on context && !org && !report exists@
+@depends on context && !org && !report && !(file in "ext") exists@
 expression subE <= ifm.E;
 expression *ifm.E;
 expression E1,E2;
@@ -212,7 +212,7 @@ else S3
 // The following three rules are duplicates of ifm, pr1 and pr2 respectively.
 // It is need because the previous rule as already made a "change".
 
-@pr11 depends on context && !org && !report expression@
+@pr11 depends on context && !org && !report && !(file in "ext") && pr1@
 expression E;
 identifier f;
 position p1;
@@ -220,7 +220,7 @@ position p1;
 
  (E != NULL && ...) ? <+...E->f@p1...+> : ...
 
-@pr12 depends on context && !org && !report expression@
+@pr12 depends on context && !org && !report && pr2@
 expression E;
 identifier f;
 position p2;
@@ -234,7 +234,7 @@ position p2;
  sizeof(<+...E->f@p2...+>)
 )
 
-@ifm1 depends on context && !org && !report@
+@ifm1 depends on context && !org && !report && !(file in "ext") && ifm@
 expression *E;
 statement S1,S2;
 position p1;

--- a/scripts/coccinelle/noderef.cocci
+++ b/scripts/coccinelle/noderef.cocci
@@ -13,7 +13,7 @@ virtual report
 virtual context
 virtual patch
 
-@depends on patch@
+@depends on patch && !(file in "ext")@
 expression *x;
 expression f;
 expression i;
@@ -47,7 +47,7 @@ f(...,i*sizeof(
    ),...,(T)(x),...)
 )
 
-@r depends on !patch@
+@r depends on !patch && !(file in "ext")@
 expression *x;
 expression f;
 expression i;

--- a/scripts/coccinelle/semicolon.cocci
+++ b/scripts/coccinelle/semicolon.cocci
@@ -12,7 +12,7 @@ virtual report
 virtual context
 virtual org
 
-@r_default@
+@r_default depends on !(file in "ext")@
 position p;
 @@
 switch (...)
@@ -20,7 +20,7 @@ switch (...)
 default: ...;@p
 }
 
-@r_case@
+@r_case depends on !(file in "ext")@
 position p;
 @@
 (
@@ -43,7 +43,7 @@ case ...:;@p
 }
 )
 
-@r1@
+@r1 depends on !(file in "ext")@
 statement S;
 position p1;
 position p != {r_default.p, r_case.p};


### PR DESCRIPTION
The following addition `depends on !(file in "ext")` allows
to exclude `ext/` warnings reported by coccinelle scripts.

Signed-off-by: Himanshu Jha <himanshujha199640@gmail.com>