### PR TITLE
Misc xtensa fixups

### DIFF
--- a/arch/xtensa/core/xt_zephyr.S
+++ b/arch/xtensa/core/xt_zephyr.S
@@ -259,7 +259,7 @@ _zxt_timer_int:
 .L_xt_timer_int_catchup:
 #ifdef CONFIG_SYS_CLOCK_EXISTS
 
-#if CONFIG_XTENSA_INTERNAL_TIMER || (CONFIG_XTENSA_TIMER_IRQ < 0)
+#if USE_INTERNAL_TIMER || (EXTERNAL_TIMER_IRQ < 0)
 	/* Update the timer comparator for the next tick. */
 #ifdef XT_CLOCK_FREQ
 	movi a2, XT_TICK_DIVISOR  /* a2 = comparator increment          */
@@ -271,7 +271,7 @@ _zxt_timer_int:
 	add a4, a3, a2            /* a4 = new comparator value          */
 	wsr a4, XT_CCOMPARE       /* update comp. and clear interrupt   */
 	esync
-#endif /* CONFIG_XTENSA_INTERNAL_TIMER || (CONFIG_XTENSA_TIMER_IRQ < 0) */
+#endif /* USE_INTERNAL_TIMER || (EXTERNAL_TIMER_IRQ < 0) */
 
 
 #ifdef __XTENSA_CALL0_ABI__
@@ -292,13 +292,13 @@ _zxt_timer_int:
 	callx4   a7
 #endif
 
-#if CONFIG_XTENSA_INTERNAL_TIMER || (CONFIG_XTENSA_TIMER_IRQ < 0)
+#if USE_INTERNAL_TIMER || (EXTERNAL_TIMER_IRQ < 0)
 	/* Check if we need to process more ticks to catch up. */
 	esync          /* ensure comparator update complete  */
 	rsr a4, CCOUNT /* a4 = cycle count                   */
 	sub a4, a4, a3 /* diff = ccount - old comparator     */
 	blt a2, a4, .L_xt_timer_int_catchup  /* repeat while diff > divisor */
-#endif /* CONFIG_XTENSA_INTERNAL_TIMER || (CONFIG_XTENSA_TIMER_IRQ < 0) */
+#endif /* USE_INTERNAL_TIMER || (EXTERNAL_TIMER_IRQ < 0) */
 
 #endif
 
@@ -320,7 +320,7 @@ _zxt_tick_timer_init:
 
 	ENTRY(48)
 #ifdef CONFIG_SYS_CLOCK_EXISTS
-#if CONFIG_XTENSA_INTERNAL_TIMER || (CONFIG_XTENSA_TIMER_IRQ < 0)
+#if USE_INTERNAL_TIMER || (EXTERNAL_TIMER_IRQ < 0)
 
 	/* Set up the periodic tick timer (assume enough time to complete
 	 * init).
@@ -348,7 +348,7 @@ _zxt_tick_timer_init:
 #endif
 
 #endif
-#endif /* CONFIG_XTENSA_INTERNAL_TIMER || (CONFIG_XTENSA_TIMER_IRQ < 0) */
+#endif /* USE_INTERNAL_TIMER || (EXTERNAL_TIMER_IRQ < 0) */
 	RET(48)
 
 /*

--- a/arch/xtensa/core/xtensa-asm2.c
+++ b/arch/xtensa/core/xtensa-asm2.c
@@ -135,9 +135,10 @@ static void dump_stack(int *stack)
 #define DEF_INT_C_HANDLER(l)				\
 void *xtensa_int##l##_c(void *interrupted_stack)	\
 {							   \
-	int irqs, m;					   \
+	u32_t irqs, intenable, m;			   \
 	__asm__ volatile("rsr.interrupt %0" : "=r"(irqs)); \
-							   \
+	__asm__ volatile("rsr.intenable %0" : "=r"(intenable)); \
+	irqs &= intenable;					\
 	while ((m = _xtensa_handle_one_int##l(irqs))) {		\
 		irqs ^= m;					\
 		__asm__ volatile("wsr.intclear %0" : : "r"(m)); \

--- a/arch/xtensa/include/xtensa_timer.h
+++ b/arch/xtensa/include/xtensa_timer.h
@@ -31,7 +31,10 @@
 
 #include    "xtensa_rtos.h"     /* in case this wasn't included directly */
 
-#if CONFIG_XTENSA_INTERNAL_TIMER || (CONFIG_XTENSA_TIMER_IRQ < 0)
+#define USE_INTERNAL_TIMER 1
+#define EXTERNAL_TIMER_IRQ -1
+
+#if USE_INTERNAL_TIMER || (EXTERNAL_TIMER_IRQ < 0)
 /*
  * Select timer to use for periodic tick, and determine its interrupt number
  * and priority. User may specify a timer by defining XT_TIMER_INDEX with -D,
@@ -79,14 +82,14 @@
 #error "The timer selected by XT_TIMER_INDEX does not exist in this core."
 #endif
 #else /* Case of an external timer which is not emulated by internal timer */
-#define XT_TIMER_INTNUM         CONFIG_XTENSA_TIMER_IRQ
-#endif /* CONFIG_XTENSA_INTERNAL_TIMER || (CONFIG_XTENSA_TIMER_IRQ < 0) */
+#define XT_TIMER_INTNUM         EXTERNAL_TIMER_IRQ
+#endif /* USE_INTERNAL_TIMER || (EXTERNAL_TIMER_IRQ < 0) */
 
-#if CONFIG_XTENSA_INTERNAL_TIMER
+#if USE_INTERNAL_TIMER
 #define XT_TIMER_INTPRI         XCHAL_INT_LEVEL(XT_TIMER_INTNUM)
 #else
-#define XT_TIMER_INTPRI         CONFIG_XTENSA_TIMER_IRQ_PRIORITY
-#endif /* CONFIG_XTENSA_INTERNAL_TIMER */
+#define XT_TIMER_INTPRI         EXTERNAL_TIMER_IRQ_PRIORITY
+#endif /* USE_INTERNAL_TIMER */
 
 #if XT_TIMER_INTPRI > XCHAL_EXCM_LEVEL
 #error "The timer interrupt cannot be high priority (use medium or low)."
@@ -141,7 +144,7 @@
 #define XT_TICK_DIVISOR     (XT_CLOCK_FREQ / XT_TICK_PER_SEC)
 #endif
 
-#if CONFIG_XTENSA_INTERNAL_TIMER || (CONFIG_XTENSA_TIMER_IRQ < 0)
+#if USE_INTERNAL_TIMER || (EXTERNAL_TIMER_IRQ < 0)
 #ifndef __ASSEMBLER__
 extern unsigned int _xt_tick_divisor;
 extern void _xt_tick_divisor_init(void);

--- a/drivers/timer/xtensa_sys_timer.c
+++ b/drivers/timer/xtensa_sys_timer.c
@@ -57,6 +57,17 @@ static void ccompare_isr(void *arg)
 	z_clock_announce(dticks);
 }
 
+/* The legacy Xtensa platform code handles the timer interrupt via a
+ * special path and must find it via this name.  Remove once ASM2 is
+ * pervasive.
+ */
+#ifndef CONFIG_XTENSA_ASM2
+void _timer_int_handler(void *arg)
+{
+	return ccompare_isr(arg);
+}
+#endif
+
 int z_clock_driver_init(struct device *device)
 {
 	IRQ_CONNECT(TIMER_IRQ, 0, ccompare_isr, 0, 0);

--- a/misc/printk.c
+++ b/misc/printk.c
@@ -40,9 +40,12 @@ static void _printk_hex_ulong(out_func_t out, void *ctx,
  * @brief Default character output routine that does nothing
  * @param c Character to swallow
  *
+ * Note this is defined as a weak symbol, allowing architecture code
+ * to override it where possible to enable very early logging.
+ *
  * @return 0
  */
-static int _nop_char_out(int c)
+ __attribute__((weak)) int z_arch_printk_char_out(int c)
 {
 	ARG_UNUSED(c);
 
@@ -50,7 +53,7 @@ static int _nop_char_out(int c)
 	return 0;
 }
 
-static int (*_char_out)(int) = _nop_char_out;
+int (*_char_out)(int) = z_arch_printk_char_out;
 
 /**
  * @brief Install the character output routine for printk

--- a/soc/xtensa/esp32/soc.c
+++ b/soc/xtensa/esp32/soc.c
@@ -74,3 +74,13 @@ void __attribute__((section(".iram1"))) __start(void)
 
 	CODE_UNREACHABLE;
 }
+
+/* Boot-time static default printk handler, possibly to be overriden later. */
+int z_arch_printk_char_out(int c)
+{
+	if (c == '\n') {
+		esp32_rom_uart_tx_one_char('\r');
+	}
+	esp32_rom_uart_tx_one_char(c);
+	return 0;
+}

--- a/subsys/debug/Kconfig
+++ b/subsys/debug/Kconfig
@@ -104,7 +104,6 @@ config STACK_SENTINEL
 
 config PRINTK
 	bool "Send printk() to console"
-	depends on CONSOLE_HAS_DRIVER
 	default y
 	help
 	  This option directs printk() debugging output to the supported


### PR DESCRIPTION
Fixes for issues discovered on ESP-32/S1000 after the merge of the new xtensa timer driver.

Note this also includes a patch cribbed from the x86_64 PR which enables a statically-linked printk handler for very early debugging (the crash on ESP-32 was actually due to an interrupt dispatch goof, and the timer initialization happens well before the UART arrives for printk).