### PR TITLE
I2S subsystem fixes & enhancements

### DIFF
--- a/boards/posix/nrf52_bsim/k_busy_wait.c
+++ b/boards/posix/nrf52_bsim/k_busy_wait.c
@@ -14,9 +14,9 @@
  * Will block this thread (and therefore the whole zephyr) during usec_to_wait
  *
  * Note that interrupts may be received in the meanwhile and that therefore this
- * thread may loose context
+ * thread may lose context
  */
-void k_busy_wait(u32_t usec_to_wait)
+void z_arch_busy_wait(u32_t usec_to_wait)
 {
 	bs_time_t time_end = tm_get_hw_time() + usec_to_wait;
 

--- a/drivers/i2s/i2s_handlers.c
+++ b/drivers/i2s/i2s_handlers.c
@@ -30,7 +30,7 @@ Z_SYSCALL_HANDLER(i2s_buf_read, dev, buf, size)
 		copy_success = z_user_to_copy((void *)buf, mem_block,
 					      data_size);
 
-		k_mem_slab_free(rx_cfg->mem_slab, mem_block);
+		k_mem_slab_free(rx_cfg->mem_slab, &mem_block);
 		Z_OOPS(copy_success);
 		Z_OOPS(z_user_to_copy((void *)size, &data_size,
 				      sizeof(data_size)));
@@ -62,7 +62,7 @@ Z_SYSCALL_HANDLER(i2s_buf_write, dev, buf, size)
 
 	ret = z_user_from_copy(mem_block, (void *)buf, size);
 	if (ret) {
-		k_mem_slab_free(tx_cfg->mem_slab, mem_block);
+		k_mem_slab_free(tx_cfg->mem_slab, &mem_block);
 		Z_OOPS(ret);
 	}
 

--- a/drivers/i2s/i2s_sam_ssc.c
+++ b/drivers/i2s/i2s_sam_ssc.c
@@ -106,8 +106,8 @@ struct i2s_sam_dev_data {
 #define MODULO_INC(val, max) { val = (++val < max) ? val : 0; }
 
 static struct device *get_dev_from_dma_channel(u32_t dma_channel);
-static void dma_rx_callback(struct device *, u32_t, int);
-static void dma_tx_callback(struct device *, u32_t, int);
+static void dma_rx_callback(void *, u32_t, int);
+static void dma_tx_callback(void *, u32_t, int);
 static void rx_stream_disable(struct stream *, Ssc *const, struct device *);
 static void tx_stream_disable(struct stream *, Ssc *const, struct device *);
 
@@ -188,7 +188,7 @@ static int start_dma(struct device *dev_dma, u32_t channel,
 }
 
 /* This function is executed in the interrupt context */
-static void dma_rx_callback(struct device *dev_dma, u32_t channel, int status)
+static void dma_rx_callback(void *callback_arg, u32_t channel, int status)
 {
 	struct device *dev = get_dev_from_dma_channel(channel);
 	const struct i2s_sam_dev_cfg *const dev_cfg = DEV_CFG(dev);
@@ -197,6 +197,7 @@ static void dma_rx_callback(struct device *dev_dma, u32_t channel, int status)
 	struct stream *stream = &dev_data->rx;
 	int ret;
 
+	ARG_UNUSED(callback_arg);
 	__ASSERT_NO_MSG(stream->mem_block != NULL);
 
 	/* Stop reception if there was an error */
@@ -246,7 +247,7 @@ rx_disable:
 }
 
 /* This function is executed in the interrupt context */
-static void dma_tx_callback(struct device *dev_dma, u32_t channel, int status)
+static void dma_tx_callback(void *callback_arg, u32_t channel, int status)
 {
 	struct device *dev = get_dev_from_dma_channel(channel);
 	const struct i2s_sam_dev_cfg *const dev_cfg = DEV_CFG(dev);
@@ -256,6 +257,7 @@ static void dma_tx_callback(struct device *dev_dma, u32_t channel, int status)
 	size_t mem_block_size;
 	int ret;
 
+	ARG_UNUSED(callback_arg);
 	__ASSERT_NO_MSG(stream->mem_block != NULL);
 
 	/* All block data sent */

--- a/drivers/timer/native_posix_timer.c
+++ b/drivers/timer/native_posix_timer.c
@@ -125,7 +125,7 @@ int z_clock_driver_init(struct device *device)
  * Note that interrupts may be received in the meanwhile and that therefore this
  * thread may loose context
  */
-void k_busy_wait(u32_t usec_to_wait)
+void z_arch_busy_wait(u32_t usec_to_wait)
 {
 	u64_t time_end = hwm_get_time() + usec_to_wait;
 

--- a/include/i2s.h
+++ b/include/i2s.h
@@ -346,8 +346,11 @@ struct i2s_driver_api {
  * @retval 0 If successful.
  * @retval -EINVAL Invalid argument.
  */
-static inline int i2s_configure(struct device *dev, enum i2s_dir dir,
-				struct i2s_config *cfg)
+__syscall int i2s_configure(struct device *dev, enum i2s_dir dir,
+			    struct i2s_config *cfg);
+
+static inline int _impl_i2s_configure(struct device *dev, enum i2s_dir dir,
+				      struct i2s_config *cfg)
 {
 	const struct i2s_driver_api *api = dev->driver_api;
 

--- a/include/kernel.h
+++ b/include/kernel.h
@@ -800,7 +800,7 @@ __syscall s32_t k_sleep(s32_t duration);
  *
  * @return N/A
  */
-extern void k_busy_wait(u32_t usec_to_wait);
+__syscall void k_busy_wait(u32_t usec_to_wait);
 
 /**
  * @brief Yield the current thread.

--- a/kernel/include/kernel_internal.h
+++ b/kernel/include/kernel_internal.h
@@ -227,6 +227,10 @@ extern u32_t z_early_boot_rand32_get(void);
 extern int z_stack_adjust_initialized;
 #endif
 
+#if defined(CONFIG_ARCH_HAS_CUSTOM_BUSY_WAIT)
+extern void z_arch_busy_wait(u32_t usec_to_wait);
+#endif
+
 #ifdef __cplusplus
 }
 #endif

--- a/kernel/mem_slab.c
+++ b/kernel/mem_slab.c
@@ -62,6 +62,7 @@ static int init_mem_slab_module(struct device *dev)
 	     slab++) {
 		create_free_list(slab);
 		SYS_TRACING_OBJ_INIT(k_mem_slab, slab);
+		_k_object_init(slab);
 	}
 	return 0;
 }

--- a/scripts/gen_kobject_list.py
+++ b/scripts/gen_kobject_list.py
@@ -18,6 +18,7 @@ from elf_helper import ElfHelper, kobject_to_enum
 
 kobjects = {
     "k_alert": None,
+    "k_mem_slab": None,
     "k_msgq": None,
     "k_mutex": None,
     "k_pipe": None,

--- a/soc/posix/inf_clock/posix_board_if.h
+++ b/soc/posix/inf_clock/posix_board_if.h
@@ -25,10 +25,6 @@ void posix_irq_handler(void);
 void posix_exit(int exit_code);
 u64_t posix_get_hw_cycle(void);
 
-#if defined(CONFIG_ARCH_HAS_CUSTOM_BUSY_WAIT)
-void k_busy_wait(u32_t usec_to_wait);
-#endif
-
 #ifdef __cplusplus
 }
 #endif


### PR DESCRIPTION
- expose k_busy_wait() so user mode can access it(needed for a test case)
- track k_mem_slabs as kernel objects, even though there is no user facing API. This will allow the user to assign a k_mem_slab that it has been granted permission on to i2s_configure()
- expose i2s_configure() to user mode since we can now verify the k_mem_slab provided
- fix incorrect use of k_mem_slab_free() in the i2s_buf_read/write system call handlers
- fix a build warning in the i2s_sam_ssc driver

I've been testing on sam_e70_xplained. A forthcoming commit will run all the tests in test/drivers/i2s/i2s_api in user mode, but I'm working through some issues that seem to be timing related, including #11383 