### PR TITLE
logging: Fix LOG_LEVEL dependency on log.h include

### DIFF
--- a/include/logging/log.h
+++ b/include/logging/log.h
@@ -270,14 +270,16 @@ int log_printk(const char *fmt, va_list ap);
 char *log_strdup(const char *str);
 
 /* Macro expects that optionally on second argument local log level is provided.
- * If provided it is returned, otherwise default log level is returned.
+ * If provided it is returned, otherwise default log level is returned or
+ * LOG_LEVEL, if it was locally defined.
  */
-#if defined(LOG_LEVEL) && defined(CONFIG_LOG)
-#define _LOG_LEVEL_RESOLVE(...) \
-	__LOG_ARG_2(__VA_ARGS__, LOG_LEVEL)
+#if !defined(CONFIG_LOG)
+#define _LOG_LEVEL_RESOLVE(...) LOG_LEVEL_NONE
 #else
 #define _LOG_LEVEL_RESOLVE(...) \
-	__LOG_ARG_2(__VA_ARGS__, CONFIG_LOG_DEFAULT_LEVEL)
+	_LOG_EVAL(LOG_LEVEL, \
+		  (__LOG_ARG_2(__VA_ARGS__, LOG_LEVEL)), \
+		  (__LOG_ARG_2(__VA_ARGS__, CONFIG_LOG_DEFAULT_LEVEL)))
 #endif
 
 /* Return first argument */


### PR DESCRIPTION
Refactoring of LOG_MODULE_REGISTER (commit 88648699) introduced
regression: fixed ordering of LOG_LEVEL definition and log.h
include.

PR fixes 2 issues:
- ordering of LOG_LEVEL and log.h include (@mike-scott, Fixes #11352 can be closed, imo)
- compilation failure when log is disabled. That was probably unnoticed so far but was regression no.2

Change is to resolve LOG_LEVEL in place where LOG_MODULE_REGISTER is used (`_LOG_EVAL` macro) and not where log.h is included (traditional `#ifdef ...`). Only `CONFIG_LOG` is resolved with `#if ...` because it is coming from kconfig while LOG_LEVEL comes from source file.

Signed-off-by: Krzysztof Chruscinski <krzysztof.chruscinski@nordicsemi.no>