### PR TITLE
GPIO fixes around callbacks and interrupt flag handling

### DIFF
--- a/drivers/gpio/gpio_atmel_sam3.c
+++ b/drivers/gpio/gpio_atmel_sam3.c
@@ -202,9 +202,7 @@ static int gpio_sam3_manage_callback(struct device *dev,
 {
 	struct gpio_sam3_runtime *context = dev->driver_data;
 
-	_gpio_manage_callback(&context->cb, callback, set);
-
-	return 0;
+	return _gpio_manage_callback(&context->cb, callback, set);
 }
 
 static int gpio_sam3_enable_callback(struct device *dev,

--- a/drivers/gpio/gpio_cc2650.c
+++ b/drivers/gpio/gpio_cc2650.c
@@ -297,8 +297,7 @@ static int gpio_cc2650_manage_callback(struct device *port,
 {
 	struct gpio_cc2650_data *data = port->driver_data;
 
-	_gpio_manage_callback(&data->callbacks, callback, set);
-	return 0;
+	return _gpio_manage_callback(&data->callbacks, callback, set);
 }
 
 static int gpio_cc2650_enable_callback(struct device *port,

--- a/drivers/gpio/gpio_cc32xx.c
+++ b/drivers/gpio/gpio_cc32xx.c
@@ -129,9 +129,7 @@ static int gpio_cc32xx_manage_callback(struct device *dev,
 {
 	struct gpio_cc32xx_data *data = DEV_DATA(dev);
 
-	_gpio_manage_callback(&data->callbacks, callback, set);
-
-	return 0;
+	return _gpio_manage_callback(&data->callbacks, callback, set);
 }
 
 

--- a/drivers/gpio/gpio_cmsdk_ahb.c
+++ b/drivers/gpio/gpio_cmsdk_ahb.c
@@ -217,9 +217,7 @@ static int gpio_cmsdk_ahb_manage_callback(struct device *dev,
 {
 	struct gpio_cmsdk_ahb_dev_data *data = dev->driver_data;
 
-	_gpio_manage_callback(&data->gpio_cb, callback, set);
-
-	return 0;
+	return _gpio_manage_callback(&data->gpio_cb, callback, set);
 }
 
 static int gpio_cmsdk_ahb_enable_callback(struct device *dev,

--- a/drivers/gpio/gpio_dw.c
+++ b/drivers/gpio/gpio_dw.c
@@ -291,9 +291,7 @@ static inline int gpio_dw_manage_callback(struct device *port,
 {
 	struct gpio_dw_runtime *context = port->driver_data;
 
-	_gpio_manage_callback(&context->callbacks, callback, set);
-
-	return 0;
+	return _gpio_manage_callback(&context->callbacks, callback, set);
 }
 
 static inline int gpio_dw_enable_callback(struct device *port, int access_op,

--- a/drivers/gpio/gpio_esp32.c
+++ b/drivers/gpio/gpio_esp32.c
@@ -210,9 +210,7 @@ static int gpio_esp32_manage_callback(struct device *dev,
 {
 	struct gpio_esp32_data *data = dev->driver_data;
 
-	_gpio_manage_callback(&data->cb, callback, set);
-
-	return 0;
+	return _gpio_manage_callback(&data->cb, callback, set);
 }
 
 static int gpio_esp32_enable_callback(struct device *dev,

--- a/drivers/gpio/gpio_gecko.c
+++ b/drivers/gpio/gpio_gecko.c
@@ -200,9 +200,7 @@ static int gpio_gecko_manage_callback(struct device *dev,
 {
 	struct gpio_gecko_data *data = dev->driver_data;
 
-	_gpio_manage_callback(&data->callbacks, callback, set);
-
-	return 0;
+	return _gpio_manage_callback(&data->callbacks, callback, set);
 }
 
 static int gpio_gecko_enable_callback(struct device *dev,

--- a/drivers/gpio/gpio_handlers.c
+++ b/drivers/gpio/gpio_handlers.c
@@ -29,20 +29,17 @@ Z_SYSCALL_HANDLER(gpio_read, port, access_op, pin, value)
 
 Z_SYSCALL_HANDLER(gpio_enable_callback, port, access_op, pin)
 {
-	Z_OOPS(Z_SYSCALL_DRIVER_GPIO(port, enable_callback));
 	return _impl_gpio_enable_callback((struct device *)port, access_op,
 					  pin);
 }
 
 Z_SYSCALL_HANDLER(gpio_disable_callback, port, access_op, pin)
 {
-	Z_OOPS(Z_SYSCALL_DRIVER_GPIO(port, disable_callback));
 	return _impl_gpio_disable_callback((struct device *)port, access_op,
 					   pin);
 }
 
 Z_SYSCALL_HANDLER(gpio_get_pending_int, port)
 {
-	Z_OOPS(Z_SYSCALL_DRIVER_GPIO(port, get_pending_int));
 	return _impl_gpio_get_pending_int((struct device *)port);
 }

--- a/drivers/gpio/gpio_imx.c
+++ b/drivers/gpio/gpio_imx.c
@@ -109,9 +109,7 @@ static int imx_gpio_manage_callback(struct device *dev,
 {
 	struct imx_gpio_data *data = dev->driver_data;
 
-	_gpio_manage_callback(&data->callbacks, callback, set);
-
-	return 0;
+	return _gpio_manage_callback(&data->callbacks, callback, set);
 }
 
 static int imx_gpio_enable_callback(struct device *dev,

--- a/drivers/gpio/gpio_intel_apl.c
+++ b/drivers/gpio/gpio_intel_apl.c
@@ -338,9 +338,7 @@ static int gpio_intel_apl_manage_callback(struct device *dev,
 {
 	struct gpio_intel_apl_data *data = dev->driver_data;
 
-	_gpio_manage_callback(&data->cb, callback, set);
-
-	return 0;
+	return _gpio_manage_callback(&data->cb, callback, set);
 }
 
 static int gpio_intel_apl_enable_callback(struct device *dev,

--- a/drivers/gpio/gpio_mcux.c
+++ b/drivers/gpio/gpio_mcux.c
@@ -45,7 +45,7 @@ static int gpio_mcux_configure(struct device *dev,
 
 	/* Check if GPIO port supports interrupts */
 	if ((flags & GPIO_INT) && ((config->flags & GPIO_INT) == 0)) {
-		return -EINVAL;
+		return -ENOTSUP;
 	}
 
 	/* The flags contain options that require touching registers in the

--- a/drivers/gpio/gpio_mcux.c
+++ b/drivers/gpio/gpio_mcux.c
@@ -174,9 +174,7 @@ static int gpio_mcux_manage_callback(struct device *dev,
 {
 	struct gpio_mcux_data *data = dev->driver_data;
 
-	_gpio_manage_callback(&data->callbacks, callback, set);
-
-	return 0;
+	return _gpio_manage_callback(&data->callbacks, callback, set);
 }
 
 static int gpio_mcux_enable_callback(struct device *dev,
@@ -412,4 +410,3 @@ static int gpio_mcux_porte_init(struct device *dev)
 #endif
 }
 #endif /* CONFIG_GPIO_MCUX_PORTE */
-

--- a/drivers/gpio/gpio_mcux_igpio.c
+++ b/drivers/gpio/gpio_mcux_igpio.c
@@ -107,9 +107,7 @@ static int mcux_igpio_manage_callback(struct device *dev,
 {
 	struct mcux_igpio_data *data = dev->driver_data;
 
-	_gpio_manage_callback(&data->callbacks, callback, set);
-
-	return 0;
+	return _gpio_manage_callback(&data->callbacks, callback, set);
 }
 
 static int mcux_igpio_enable_callback(struct device *dev,

--- a/drivers/gpio/gpio_mcux_lpc.c
+++ b/drivers/gpio/gpio_mcux_lpc.c
@@ -48,10 +48,12 @@ static int gpio_mcux_lpc_configure(struct device *dev,
 	if ((flags & GPIO_INT) && (flags & GPIO_DIR_OUT)) {
 		return -EINVAL;
 	}
+
 	/* Check if GPIO port supports interrupts */
 	if (flags & GPIO_INT) {
-		return -EINVAL;
+		return -ENOTSUP;
 	}
+
 	/* supports access by pin now,you can add access by port when needed */
 	if (access_op == GPIO_ACCESS_BY_PIN) {
 		/* input-0,output-1 */

--- a/drivers/gpio/gpio_mmio32.c
+++ b/drivers/gpio/gpio_mmio32.c
@@ -35,6 +35,10 @@ static int gpio_mmio32_config(struct device *dev, int access_op,
 	struct gpio_mmio32_context *context = dev->driver_data;
 	const struct gpio_mmio32_config *config = context->config;
 
+	if (flags & GPIO_INT) {
+		return -ENOTSUP;
+	}
+
 	if (access_op != GPIO_ACCESS_BY_PIN) {
 		return -ENOTSUP;
 	}

--- a/drivers/gpio/gpio_nrfx.c
+++ b/drivers/gpio/gpio_nrfx.c
@@ -255,8 +255,8 @@ static int gpio_nrfx_manage_callback(struct device *port,
 				     struct gpio_callback *callback,
 				     bool set)
 {
-	_gpio_manage_callback(&get_port_data(port)->callbacks, callback, set);
-	return 0;
+	return _gpio_manage_callback(&get_port_data(port)->callbacks,
+				     callback, set);
 }
 
 static int gpio_nrfx_pin_manage_callback(struct device *port,

--- a/drivers/gpio/gpio_pcal9535a.c
+++ b/drivers/gpio/gpio_pcal9535a.c
@@ -358,6 +358,10 @@ static int gpio_pcal9535a_config(struct device *dev, int access_op,
 	u16_t i2c_addr = config->i2c_slave_addr;
 #endif
 
+	if (flags & GPIO_INT) {
+		return -ENOTSUP;
+	}
+
 	if (!_has_i2c_master(dev)) {
 		return -EINVAL;
 	}
@@ -488,44 +492,10 @@ done:
 	return ret;
 }
 
-static int gpio_pcal9535a_manage_callback(struct device *dev,
-					  struct gpio_callback *callback,
-					  bool set)
-{
-	ARG_UNUSED(dev);
-	ARG_UNUSED(callback);
-	ARG_UNUSED(set);
-
-	return -ENOTSUP;
-}
-
-static int gpio_pcal9535a_enable_callback(struct device *dev,
-					  int access_op, u32_t pin)
-{
-	ARG_UNUSED(dev);
-	ARG_UNUSED(access_op);
-	ARG_UNUSED(pin);
-
-	return -ENOTSUP;
-}
-
-static int gpio_pcal9535a_disable_callback(struct device *dev,
-					   int access_op, u32_t pin)
-{
-	ARG_UNUSED(dev);
-	ARG_UNUSED(access_op);
-	ARG_UNUSED(pin);
-
-	return -ENOTSUP;
-}
-
 static const struct gpio_driver_api gpio_pcal9535a_drv_api_funcs = {
 	.config = gpio_pcal9535a_config,
 	.write = gpio_pcal9535a_write,
 	.read = gpio_pcal9535a_read,
-	.manage_callback = gpio_pcal9535a_manage_callback,
-	.enable_callback = gpio_pcal9535a_enable_callback,
-	.disable_callback = gpio_pcal9535a_disable_callback,
 };
 
 /**

--- a/drivers/gpio/gpio_pulpino.c
+++ b/drivers/gpio/gpio_pulpino.c
@@ -193,9 +193,7 @@ static int gpio_pulpino_manage_callback(struct device *dev,
 {
 	struct gpio_pulpino_data *data = DEV_GPIO_DATA(dev);
 
-	_gpio_manage_callback(&data->cb, callback, set);
-
-	return 0;
+	return _gpio_manage_callback(&data->cb, callback, set);
 }
 
 static int gpio_pulpino_enable_callback(struct device *dev,

--- a/drivers/gpio/gpio_qmsi.c
+++ b/drivers/gpio/gpio_qmsi.c
@@ -298,9 +298,7 @@ static inline int gpio_qmsi_manage_callback(struct device *port,
 {
 	struct gpio_qmsi_runtime *context = port->driver_data;
 
-	_gpio_manage_callback(&context->callbacks, callback, set);
-
-	return 0;
+	return _gpio_manage_callback(&context->callbacks, callback, set);
 }
 
 static inline int gpio_qmsi_enable_callback(struct device *port,

--- a/drivers/gpio/gpio_qmsi_ss.c
+++ b/drivers/gpio/gpio_qmsi_ss.c
@@ -290,9 +290,7 @@ static inline int ss_gpio_qmsi_manage_callback(struct device *port,
 {
 	struct ss_gpio_qmsi_runtime *context = port->driver_data;
 
-	_gpio_manage_callback(&context->callbacks, callback, set);
-
-	return 0;
+	return _gpio_manage_callback(&context->callbacks, callback, set);
 }
 
 static inline int ss_gpio_qmsi_enable_callback(struct device *port,

--- a/drivers/gpio/gpio_sam.c
+++ b/drivers/gpio/gpio_sam.c
@@ -202,9 +202,7 @@ static int gpio_sam_manage_callback(struct device *port,
 {
 	struct gpio_sam_runtime *context = port->driver_data;
 
-	_gpio_manage_callback(&context->cb, callback, set);
-
-	return 0;
+	return _gpio_manage_callback(&context->cb, callback, set);
 }
 
 static int gpio_sam_enable_callback(struct device *port,

--- a/drivers/gpio/gpio_sch.c
+++ b/drivers/gpio/gpio_sch.c
@@ -235,7 +235,9 @@ static int gpio_sch_manage_callback(struct device *dev,
 {
 	struct gpio_sch_data *gpio = dev->driver_data;
 
-	_gpio_manage_callback(&gpio->callbacks, callback, set);
+	if (_gpio_manage_callback(&gpio->callbacks, callback, set)) {
+		return -EINVAL;
+	}
 
 	_gpio_sch_manage_callback(dev);
 

--- a/drivers/gpio/gpio_sifive.c
+++ b/drivers/gpio/gpio_sifive.c
@@ -274,9 +274,7 @@ static int gpio_sifive_manage_callback(struct device *dev,
 {
 	struct gpio_sifive_data *data = DEV_GPIO_DATA(dev);
 
-	_gpio_manage_callback(&data->cb, callback, set);
-
-	return 0;
+	return _gpio_manage_callback(&data->cb, callback, set);
 }
 
 static int gpio_sifive_enable_callback(struct device *dev,

--- a/drivers/gpio/gpio_stm32.c
+++ b/drivers/gpio/gpio_stm32.c
@@ -127,9 +127,7 @@ static int gpio_stm32_manage_callback(struct device *dev,
 {
 	struct gpio_stm32_data *data = dev->driver_data;
 
-	_gpio_manage_callback(&data->cb, callback, set);
-
-	return 0;
+	return _gpio_manage_callback(&data->cb, callback, set);
 }
 
 static int gpio_stm32_enable_callback(struct device *dev,

--- a/drivers/gpio/gpio_utils.h
+++ b/drivers/gpio/gpio_utils.h
@@ -18,19 +18,29 @@
  * @param callbacks A pointer to the original list of callbacks (can be NULL)
  * @param callback A pointer of the callback to insert or remove from the list
  * @param set A boolean indicating insertion or removal of the callback
+ *
+ * @return 0 on success, negative errno otherwise.
  */
-static inline void _gpio_manage_callback(sys_slist_t *callbacks,
-					 struct gpio_callback *callback,
-					 bool set)
+static inline int _gpio_manage_callback(sys_slist_t *callbacks,
+					struct gpio_callback *callback,
+					bool set)
 {
 	__ASSERT(callback, "No callback!");
 	__ASSERT(callback->handler, "No callback handler!");
 
+	if (!sys_slist_is_empty(callbacks)) {
+		if (!sys_slist_find_and_remove(callbacks, &callback->node)) {
+			if (!set) {
+				return -EINVAL;
+			}
+		}
+	}
+
 	if (set) {
 		sys_slist_prepend(callbacks, &callback->node);
-	} else {
-		sys_slist_find_and_remove(callbacks, &callback->node);
 	}
+
+	return 0;
 }
 
 /**

--- a/include/gpio.h
+++ b/include/gpio.h
@@ -169,6 +169,10 @@ static inline int _impl_gpio_enable_callback(struct device *port,
 	const struct gpio_driver_api *api =
 		(const struct gpio_driver_api *)port->driver_api;
 
+	if (!api->enable_callback) {
+		return -ENOTSUP;
+	}
+
 	return api->enable_callback(port, access_op, pin);
 }
 
@@ -180,6 +184,10 @@ static inline int _impl_gpio_disable_callback(struct device *port,
 {
 	const struct gpio_driver_api *api =
 		(const struct gpio_driver_api *)port->driver_api;
+
+	if (!api->disable_callback) {
+		return -ENOTSUP;
+	}
 
 	return api->disable_callback(port, access_op, pin);
 }
@@ -260,7 +268,9 @@ static inline int gpio_add_callback(struct device *port,
 	const struct gpio_driver_api *api =
 		(const struct gpio_driver_api *)port->driver_api;
 
-	__ASSERT(callback, "Callback pointer should not be NULL");
+	if (!api->manage_callback) {
+		return -ENOTSUP;
+	}
 
 	return api->manage_callback(port, callback, true);
 }
@@ -280,7 +290,9 @@ static inline int gpio_remove_callback(struct device *port,
 	const struct gpio_driver_api *api =
 		(const struct gpio_driver_api *)port->driver_api;
 
-	__ASSERT(callback, "Callback pointer should not be NULL");
+	if (!api->manage_callback) {
+		return -ENOTSUP;
+	}
 
 	return api->manage_callback(port, callback, false);
 }
@@ -405,9 +417,13 @@ __syscall int gpio_get_pending_int(struct device *dev);
  */
 static inline int _impl_gpio_get_pending_int(struct device *dev)
 {
-	struct gpio_driver_api *api;
+	const struct gpio_driver_api *api =
+		(const struct gpio_driver_api *)dev->driver_api;
 
-	api = (struct gpio_driver_api *)dev->driver_api;
+	if (!api->get_pending_int) {
+		return -ENOTSUP;
+	}
+
 	return api->get_pending_int(dev);
 }
 


### PR DESCRIPTION
Notice that some driver should not have landed there as they do not follow basic code style rules ({} on one-liners for instance, etc..), but I will no touch that. 