### PR TITLE
net/ieee802154: Remove unnecessary __packed keyword on API struct

### DIFF
--- a/include/net/ieee802154_radio.h
+++ b/include/net/ieee802154_radio.h
@@ -107,7 +107,7 @@ struct ieee802154_radio_api {
 		       void (*done_cb)(struct device *dev,
 				       s16_t max_ed));
 #endif /* CONFIG_NET_L2_OPENTHREAD */
-} __packed;
+};
 
 #define IEEE802154_AR_FLAG_SET (0x20)
 


### PR DESCRIPTION
It is useless first, and for some reason now generate a bug on kw41z.

Fixes #11301

Signed-off-by: Tomasz Bursztyka <tomasz.bursztyka@linux.intel.com>