### PR TITLE
lib/cmsis_rtos_v1: Use k_is_in_isr instead of _is_in_isr

### DIFF
--- a/lib/cmsis_rtos_v1/cmsis_kernel.c
+++ b/lib/cmsis_rtos_v1/cmsis_kernel.c
@@ -31,10 +31,10 @@ osStatus osKernelInitialize(void)
  */
 osStatus osKernelStart(void)
 {
-	 if (_is_in_isr()) {
-		 return osErrorISR;
-	 }
-	 return osOK;
+	if (k_is_in_isr()) {
+		return osErrorISR;
+	}
+	return osOK;
 }
 
 /**

--- a/lib/cmsis_rtos_v1/cmsis_mailq.c
+++ b/lib/cmsis_rtos_v1/cmsis_mailq.c
@@ -16,7 +16,7 @@ osMailQId osMailCreate(const osMailQDef_t *queue_def, osThreadId thread_id)
 		return NULL;
 	}
 
-	if (_is_in_isr()) {
+	if (k_is_in_isr()) {
 		return NULL;
 	}
 

--- a/lib/cmsis_rtos_v1/cmsis_mempool.c
+++ b/lib/cmsis_rtos_v1/cmsis_mempool.c
@@ -14,7 +14,7 @@
  */
 osPoolId osPoolCreate(const osPoolDef_t *pool_def)
 {
-	if (_is_in_isr()) {
+	if (k_is_in_isr()) {
 		return NULL;
 	}
 

--- a/lib/cmsis_rtos_v1/cmsis_msgq.c
+++ b/lib/cmsis_rtos_v1/cmsis_msgq.c
@@ -17,7 +17,7 @@ osMessageQId osMessageCreate(const osMessageQDef_t *queue_def,
 		return NULL;
 	}
 
-	if (_is_in_isr()) {
+	if (k_is_in_isr()) {
 		return NULL;
 	}
 

--- a/lib/cmsis_rtos_v1/cmsis_mutex.c
+++ b/lib/cmsis_rtos_v1/cmsis_mutex.c
@@ -21,7 +21,7 @@ osMutexId osMutexCreate(const osMutexDef_t *mutex_def)
 		return NULL;
 	}
 
-	if (_is_in_isr()) {
+	if (k_is_in_isr()) {
 		return NULL;
 	}
 
@@ -48,7 +48,7 @@ osStatus osMutexWait(osMutexId mutex_id, uint32_t timeout)
 		return osErrorParameter;
 	}
 
-	if (_is_in_isr()) {
+	if (k_is_in_isr()) {
 		return osErrorISR;
 	}
 
@@ -80,7 +80,7 @@ osStatus osMutexRelease(osMutexId mutex_id)
 		return osErrorParameter;
 	}
 
-	if (_is_in_isr()) {
+	if (k_is_in_isr()) {
 		return osErrorISR;
 	}
 
@@ -105,7 +105,7 @@ osStatus osMutexDelete(osMutexId mutex_id)
 		return osErrorParameter;
 	}
 
-	if (_is_in_isr()) {
+	if (k_is_in_isr()) {
 		return osErrorISR;
 	}
 

--- a/lib/cmsis_rtos_v1/cmsis_semaphore.c
+++ b/lib/cmsis_rtos_v1/cmsis_semaphore.c
@@ -22,7 +22,7 @@ osSemaphoreId osSemaphoreCreate(const osSemaphoreDef_t *semaphore_def,
 		return NULL;
 	}
 
-	if (_is_in_isr()) {
+	if (k_is_in_isr()) {
 		return NULL;
 	}
 
@@ -50,7 +50,7 @@ int32_t osSemaphoreWait(osSemaphoreId semaphore_id, uint32_t timeout)
 		return -1;
 	}
 
-	if (_is_in_isr()) {
+	if (k_is_in_isr()) {
 		return -1;
 	}
 
@@ -105,7 +105,7 @@ osStatus osSemaphoreDelete(osSemaphoreId semaphore_id)
 		return osErrorParameter;
 	}
 
-	if (_is_in_isr()) {
+	if (k_is_in_isr()) {
 		return osErrorISR;
 	}
 

--- a/lib/cmsis_rtos_v1/cmsis_signal.c
+++ b/lib/cmsis_rtos_v1/cmsis_signal.c
@@ -48,7 +48,7 @@ int32_t osSignalClear(osThreadId thread_id, int32_t signals)
 {
 	int sig, key;
 
-	if (_is_in_isr() || (thread_id == NULL) || (!signals) ||
+	if (k_is_in_isr() || (thread_id == NULL) || (!signals) ||
 		(signals & 0x80000000) || (signals > MAX_VALID_SIGNAL_VAL)) {
 		return 0x80000000;
 	}
@@ -76,7 +76,7 @@ osEvent osSignalWait(int32_t signals, uint32_t millisec)
 	u32_t time_delta_ms, timeout = millisec;
 	u64_t time_stamp_start, hwclk_cycles_delta, time_delta_ns;
 
-	if (_is_in_isr()) {
+	if (k_is_in_isr()) {
 		evt.status = osErrorISR;
 		return evt;
 	}

--- a/lib/cmsis_rtos_v1/cmsis_thread.c
+++ b/lib/cmsis_rtos_v1/cmsis_thread.c
@@ -59,7 +59,7 @@ osThreadId osThreadCreate(const osThreadDef_t *thread_def, void *arg)
 	__ASSERT(thread_def->stacksize <= CONFIG_CMSIS_THREAD_MAX_STACK_SIZE,
 		 "invalid stack size\n");
 
-	if (_is_in_isr()) {
+	if (k_is_in_isr()) {
 		return NULL;
 	}
 
@@ -96,7 +96,7 @@ osThreadId osThreadCreate(const osThreadDef_t *thread_def, void *arg)
  */
 osThreadId osThreadGetId(void)
 {
-	if (_is_in_isr()) {
+	if (k_is_in_isr()) {
 		return NULL;
 	}
 
@@ -111,7 +111,7 @@ osPriority osThreadGetPriority(osThreadId thread_id)
 	k_tid_t thread = (k_tid_t)thread_id;
 	u32_t priority;
 
-	if ((thread_id == NULL) || (_is_in_isr())) {
+	if ((thread_id == NULL) || (k_is_in_isr())) {
 		return osPriorityError;
 	}
 
@@ -128,7 +128,7 @@ osStatus osThreadSetPriority(osThreadId thread_id, osPriority priority)
 		return osErrorParameter;
 	}
 
-	if (_is_in_isr()) {
+	if (k_is_in_isr()) {
 		return osErrorISR;
 	}
 
@@ -155,7 +155,7 @@ osStatus osThreadTerminate(osThreadId thread_id)
 		return osErrorParameter;
 	}
 
-	if (_is_in_isr()) {
+	if (k_is_in_isr()) {
 		return osErrorISR;
 	}
 
@@ -172,7 +172,7 @@ osStatus osThreadTerminate(osThreadId thread_id)
  */
 osStatus osThreadYield(void)
 {
-	if (_is_in_isr()) {
+	if (k_is_in_isr()) {
 		return osErrorISR;
 	}
 

--- a/lib/cmsis_rtos_v1/cmsis_timer.c
+++ b/lib/cmsis_rtos_v1/cmsis_timer.c
@@ -74,7 +74,7 @@ osStatus osTimerStart(osTimerId timer_id, uint32_t millisec)
 		return osErrorParameter;
 	}
 
-	if (_is_in_isr()) {
+	if (k_is_in_isr()) {
 		return osErrorISR;
 	}
 
@@ -99,7 +99,7 @@ osStatus osTimerStop(osTimerId timer_id)
 		return osErrorParameter;
 	}
 
-	if (_is_in_isr()) {
+	if (k_is_in_isr()) {
 		return osErrorISR;
 	}
 
@@ -123,7 +123,7 @@ osStatus osTimerDelete(osTimerId timer_id)
 		return osErrorParameter;
 	}
 
-	if (_is_in_isr()) {
+	if (k_is_in_isr()) {
 		return osErrorISR;
 	}
 

--- a/lib/cmsis_rtos_v1/cmsis_wait.c
+++ b/lib/cmsis_rtos_v1/cmsis_wait.c
@@ -12,7 +12,7 @@
  */
 osStatus osDelay(uint32_t delay_ms)
 {
-	if (_is_in_isr()) {
+	if (k_is_in_isr()) {
 		return osErrorISR;
 	}
 

--- a/tests/cmsis_rtos_v1/src/signal.c
+++ b/tests/cmsis_rtos_v1/src/signal.c
@@ -167,7 +167,7 @@ static void offload_function(void *param)
 	int signals;
 
 	/* Make sure we're in IRQ context */
-	zassert_true(_is_in_isr(), "Not in IRQ context!");
+	zassert_true(k_is_in_isr(), "Not in IRQ context!");
 
 	signals = osSignalSet((osThreadId)tid, ISR_SIGNAL);
 	zassert_not_equal(signals, 0x80000000, "signal set failed in ISR");


### PR DESCRIPTION
Use the kernel API k_is_in_isr() instead of the internal
_is_in_isr() function.

Signed-off-by: Rajavardhan Gundi <rajavardhan.gundi@intel.com>