### PR TITLE
Minor CI scripting fix

### DIFF
--- a/.shippable.yml
+++ b/.shippable.yml
@@ -35,9 +35,9 @@ build:
       - export CCACHE_DIR=${SHIPPABLE_BUILD_DIR}/ccache/.ccache
       - >
         if [ "$IS_PULL_REQUEST" = "true" ]; then
-          ./scripts/ci/run_ci.sh -b master -r origin -m ${MATRIX_BUILD} -M ${MATRIX_BUILDS} -p;
+          ./scripts/ci/run_ci.sh -b master -r origin -m ${MATRIX_BUILD} -M ${MATRIX_BUILDS} -B ${BSIM_BT_TEST_RESULTS_FILE} -p;
         else
-          ./scripts/ci/run_ci.sh -b master -r origin -m ${MATRIX_BUILD} -M ${MATRIX_BUILDS};
+          ./scripts/ci/run_ci.sh -b master -r origin -m ${MATRIX_BUILD} -M ${MATRIX_BUILDS} -B ${BSIM_BT_TEST_RESULTS_FILE};
         fi;
       - ccache -s
     on_failure:

--- a/scripts/ci/run_ci.sh
+++ b/scripts/ci/run_ci.sh
@@ -25,7 +25,7 @@ SANITYCHECK="${ZEPHYR_BASE}/scripts/sanitycheck"
 MATRIX_BUILDS=1
 MATRIX=1
 
-while getopts ":pm:b:r:M:" opt; do
+while getopts ":pm:b:B:r:M:" opt; do
   case $opt in
     p)
       echo "Testing a Pull Request." >&2
@@ -42,6 +42,10 @@ while getopts ":pm:b:r:M:" opt; do
     b)
       echo "Base Branch: $OPTARG" >&2
       BRANCH=$OPTARG
+      ;;
+    B)
+      echo "bsim BT tests xml results file: $OPTARG" >&2
+      BSIM_BT_TEST_RESULTS_FILE=$OPTARG
       ;;
     r)
       echo "Remote: $OPTARG" >&2

--- a/tests/bluetooth/bsim_bt/compile.sh
+++ b/tests/bluetooth/bsim_bt/compile.sh
@@ -32,11 +32,16 @@ function compile(){
 
   echo "Building $EXE_NAME"
 
-  [ -d "${WORK_DIR}/${APP}" ] && rm ${WORK_DIR}/${APP} -rf
-  mkdir -p ${WORK_DIR}/${APP} && cd ${WORK_DIR}/${APP}
-  cmake -GNinja -DBOARD_ROOT=${BOARD_ROOT} -DBOARD=${BOARD} \
-        -DCONF_FILE=${CONF_FILE} ${CMAKE_ARGS} ${APP_ROOT}/${APP} \
-      &> cmake.out || { cat cmake.out && return 0; }
+  #Set INCR_BUILD when calling to only do an incremental build
+  if [ ! -v INCR_BUILD ] || [ ! -d "${WORK_DIR}/${APP}" ]; then
+      [ -d "${WORK_DIR}/${APP}" ] && rm ${WORK_DIR}/${APP} -rf
+      mkdir -p ${WORK_DIR}/${APP} && cd ${WORK_DIR}/${APP}
+      cmake -GNinja -DBOARD_ROOT=${BOARD_ROOT} -DBOARD=${BOARD} \
+            -DCONF_FILE=${CONF_FILE} ${CMAKE_ARGS} ${APP_ROOT}/${APP} \
+	  &> cmake.out || { cat cmake.out && return 0; }
+  else
+      cd ${WORK_DIR}/${APP}
+  fi
   ninja ${NINJA_ARGS} &> ninja.out || { cat ninja.out && return 0; }
   cp ${WORK_DIR}/${APP}/zephyr/zephyr.exe ${EXE_NAME}
 


### PR DESCRIPTION
Following this comment: https://github.com/zephyrproject-rtos/zephyr/pull/10688#discussion_r233108608
Add in run_ci.sh an option which was missing (was just inherited from command line)

As a freeby, add an option in compile.sh to do only an incremental build (for those who want to reuse this script locally)
