### PR TITLE
Fix secure sockets after FD table introduction

### DIFF
--- a/subsys/net/lib/sockets/sockets_tls.c
+++ b/subsys/net/lib/sockets/sockets_tls.c
@@ -1742,11 +1742,13 @@ int ztls_getsockopt(int sock, int level, int optname,
 	}
 
 	if (!context || !context->tls) {
-		return -EBADF;
+		errno = EBADF;
+		return -1;
 	}
 
 	if (!optval || !optlen) {
-		return -EINVAL;
+		errno = EINVAL;
+		return -1;
 	}
 
 	switch (optname) {
@@ -1787,7 +1789,8 @@ int ztls_setsockopt(int sock, int level, int optname,
 	}
 
 	if (!context || !context->tls) {
-		return -EBADF;
+		errno = EBADF;
+		return -1;
 	}
 
 	switch (optname) {


### PR DESCRIPTION
This PR fixes secure sockets implementation by removing invalid typecasts between socket descriptor and `net_context`. Note, that this PR does not add full support for POSIX APIs for secure sockets (like read/write), it's just a bugfix.

With FD table introduction, net_context can no longer be reached by typecasting socket descriptor to `net_context`, and vice versa. Instead, file descriptor API have to be used to reach the `net_context`.

As reverse conversion is not possible (`net_context` -> file descriptor), we need to provide file descriptor to functions that call `zsock_*` API (i.e. mbedTLS bio functions).

Additionally, second commit fixes a bug with `getsockopt`/`setsockopt` reuturn values, spotted during rework.