### PR TITLE
Drop ARP requests based on specific scenarios

### DIFF
--- a/subsys/net/ip/icmpv4.c
+++ b/subsys/net/ip/icmpv4.c
@@ -112,6 +112,14 @@ static inline enum net_verdict icmpv4_handle_echo_request(struct net_pkt *pkt)
 	net_ipaddr_copy(&NET_IPV4_HDR(pkt)->src,
 			net_if_ipv4_select_src_addr(net_pkt_iface(pkt),
 						    &addr));
+	/* If interface can not select src address based on dst addr
+	 * and src address is unspecified, drop the echo request.
+	 */
+	if (net_ipv4_is_addr_unspecified(&NET_IPV4_HDR(pkt)->src)) {
+		NET_DBG("DROP: src addr is unspecified");
+		return NET_DROP;
+	}
+
 	net_ipaddr_copy(&NET_IPV4_HDR(pkt)->dst, &addr);
 
 	icmp_hdr.type = NET_ICMPV4_ECHO_REPLY;

--- a/subsys/net/ip/ipv4.c
+++ b/subsys/net/ip/ipv4.c
@@ -122,7 +122,13 @@ enum net_verdict net_ipv4_process_pkt(struct net_pkt *pkt)
 		goto drop;
 	}
 
+	if (net_ipv4_is_addr_mcast(&hdr->src)) {
+		NET_DBG("DROP: src addr is mcast");
+		goto drop;
+	}
+
 	if (net_ipv4_is_addr_bcast(net_pkt_iface(pkt), &hdr->src)) {
+		NET_DBG("DROP: src addr is bcast");
 		goto drop;
 	}
 

--- a/subsys/net/ip/net_context.c
+++ b/subsys/net/ip/net_context.c
@@ -642,6 +642,11 @@ struct net_pkt *net_context_create_ipv4(struct net_context *context,
 	    || net_ipv4_is_addr_mcast(src)) {
 		src = net_if_ipv4_select_src_addr(net_pkt_iface(pkt),
 						  (struct in_addr *)dst);
+		/* If src address is still unspecified, do not create pkt */
+		if (net_ipv4_is_addr_unspecified(src)) {
+			NET_DBG("DROP: src addr is unspecified");
+			return NULL;
+		}
 	}
 
 	return net_ipv4_create(pkt,

--- a/subsys/net/l2/ethernet/arp.c
+++ b/subsys/net/l2/ethernet/arp.c
@@ -567,8 +567,9 @@ static bool arp_hdr_check(struct net_arp_hdr *arp_hdr)
 	if (ntohs(arp_hdr->hwtype) != NET_ARP_HTYPE_ETH ||
 	    ntohs(arp_hdr->protocol) != NET_ETH_PTYPE_IP ||
 	    arp_hdr->hwlen != sizeof(struct net_eth_addr) ||
-	    arp_hdr->protolen != NET_ARP_IPV4_PTYPE_SIZE) {
-		NET_DBG("Invalid ARP header");
+	    arp_hdr->protolen != NET_ARP_IPV4_PTYPE_SIZE ||
+	    net_ipv4_is_addr_loopback(&arp_hdr->src_ipaddr)) {
+		NET_DBG("DROP: Invalid ARP header");
 		return false;
 	}
 

--- a/subsys/net/l2/ethernet/ethernet.c
+++ b/subsys/net/l2/ethernet/ethernet.c
@@ -455,23 +455,25 @@ static enum net_verdict ethernet_send(struct net_if *iface,
 				net_pkt_unref(pkt);
 
 				pkt = arp_pkt;
+				/* For ARP message, we do not touch the packet
+				 * further but will send it as it is because the
+				 * arp.c has prepared the packet already.
+				 */
+				ptype = htons(NET_ETH_PTYPE_ARP);
 			} else {
 				NET_DBG("Found ARP entry, sending pkt %p to "
 					"iface %p",
 					pkt, iface);
+				ptype = htons(NET_ETH_PTYPE_IP);
 			}
+		} else {
+			ptype = htons(NET_ETH_PTYPE_ARP);
 		}
 
 		net_pkt_lladdr_src(pkt)->addr = (u8_t *)&NET_ETH_HDR(pkt)->src;
 		net_pkt_lladdr_src(pkt)->len = sizeof(struct net_eth_addr);
 		net_pkt_lladdr_dst(pkt)->addr = (u8_t *)&NET_ETH_HDR(pkt)->dst;
 		net_pkt_lladdr_dst(pkt)->len = sizeof(struct net_eth_addr);
-
-		/* For ARP message, we do not touch the packet further but will
-		 * send it as it is because the arp.c has prepared the packet
-		 * already.
-		 */
-		ptype = htons(NET_ETH_PTYPE_ARP);
 
 		goto send_frame;
 	}


### PR DESCRIPTION
This PR handles special ARP requests. Based on specific scenarios ARP requests will be dropped silently.
Silently discard ARP request if Ethernet address is broadcast and Source IP address is Multicast  adress.
REFERENCES:
    RFC 826: page 4
    RFC 1122: section 3.3.6 {Silently discard link-layer-only b'cast dg's}
    RFC 1812: section 3.3.2, page 34

Networking stack sometimes try to find source address based on destination address. If interface could not find best match then it returns unspecified address (0.0.0.0). Host should not send these packets.

Drop  ARP request with sender IP address set to localhost.

Fixes #11329.
Fixes #11489