### PR TITLE
[DNM] Arch out-of-tree

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -550,12 +550,16 @@ gen_kobj(KOBJ_INCLUDE_PATH)
 # Generate offsets.c.obj from offsets.c
 # Generate offsets.h     from offsets.c.obj
 
-set(OFFSETS_C_PATH ${ZEPHYR_BASE}/arch/${ARCH}/core/offsets/offsets.c)
-set(OFFSETS_O_PATH ${CMAKE_CURRENT_BINARY_DIR}/CMakeFiles/offsets.dir/arch/${ARCH}/core/offsets/offsets.c.obj)
+set(OFFSETS_C_PATH arch/${ARCH}/core/offsets/offsets.c)
 set(OFFSETS_H_PATH ${PROJECT_BINARY_DIR}/include/generated/offsets.h)
 
-add_library(          offsets STATIC ${OFFSETS_C_PATH})
-target_link_libraries(offsets zephyr_interface)
+add_library(          offsets OBJECT ${OFFSETS_C_PATH})
+# target_link_libraries for librareis of type OBJECT is not supported in CMake until 3.12.3. Until then the
+# include directories, compile options and compile definitions are transefered using the the following 3 lines.
+target_include_directories(offsets PRIVATE $<TARGET_PROPERTY:zephyr_interface,INTERFACE_INCLUDE_DIRECTORIES>)
+target_compile_options(offsets PRIVATE $<TARGET_PROPERTY:zephyr_interface,INTERFACE_COMPILE_OPTIONS>)
+target_compile_definitions(offsets PRIVATE $<TARGET_PROPERTY:zephyr_interface,INTERFACE_COMPILE_DEFINITIONS>)
+
 add_dependencies(     offsets
   syscall_list_h_target
   syscall_macros_h_target
@@ -566,7 +570,7 @@ add_dependencies(     offsets
 add_custom_command(
   OUTPUT ${OFFSETS_H_PATH}
   COMMAND ${PYTHON_EXECUTABLE} ${ZEPHYR_BASE}/scripts/gen_offset_header.py
-  -i ${OFFSETS_O_PATH}
+  -i $<TARGET_OBJECTS:offsets>
   -o ${OFFSETS_H_PATH}
   DEPENDS offsets
 )
@@ -797,7 +801,7 @@ set(zephyr_lnk
   ${ZEPHYR_LIBS_PROPERTY}
   ${LINKERFLAGPREFIX},--no-whole-archive
   kernel
-  ${OFFSETS_O_PATH}
+  $<TARGET_OBJECTS:offsets>
   ${LIB_INCLUDE_DIR}
   -L${PROJECT_BINARY_DIR}
   ${TOOLCHAIN_LIBS}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -49,7 +49,7 @@ zephyr_library_named(zephyr)
 
 zephyr_include_directories(
   kernel/include
-  arch/${ARCH}/include
+  ${ARCH_DIR}/${ARCH}/include
   ${SOC_DIR}/${ARCH}/${SOC_PATH}
   ${SOC_DIR}/${ARCH}/${SOC_PATH}/include
   ${SOC_DIR}/${ARCH}/${SOC_FAMILY}/include
@@ -550,7 +550,7 @@ gen_kobj(KOBJ_INCLUDE_PATH)
 # Generate offsets.c.obj from offsets.c
 # Generate offsets.h     from offsets.c.obj
 
-set(OFFSETS_C_PATH arch/${ARCH}/core/offsets/offsets.c)
+set(OFFSETS_C_PATH ${ARCH_DIR}/${ARCH}/core/offsets/offsets.c)
 set(OFFSETS_H_PATH ${PROJECT_BINARY_DIR}/include/generated/offsets.h)
 
 add_library(          offsets OBJECT ${OFFSETS_C_PATH})

--- a/arch/CMakeLists.txt
+++ b/arch/CMakeLists.txt
@@ -1,4 +1,4 @@
 add_definitions(-D__ZEPHYR_SUPERVISOR__)
 
 add_subdirectory(common)
-add_subdirectory(${ARCH})
+add_subdirectory(${ARCH_DIR}/${ARCH} arch/${ARCH})

--- a/arch/Kconfig
+++ b/arch/Kconfig
@@ -12,7 +12,7 @@
 # overriden (by defining symbols in multiple locations)
 
 # Note: $ARCH might be a glob pattern
-source "arch/$(ARCH)/Kconfig"
+source "$(ARCH_DIR)/$(ARCH)/Kconfig"
 
 choice
 	prompt "Architecture"

--- a/cmake/app/boilerplate.cmake
+++ b/cmake/app/boilerplate.cmake
@@ -202,6 +202,12 @@ else()
   set(SOC_DIR ${SOC_ROOT}/soc)
 endif()
 
+if(NOT ARCH_ROOT)
+  set(ARCH_DIR ${ZEPHYR_BASE}/arch)
+else()
+  set(ARCH_DIR ${ARCH_ROOT}/arch)
+endif()
+
 # Use BOARD to search for a '_defconfig' file.
 # e.g. zephyr/boards/arm/96b_carbon_nrf51/96b_carbon_nrf51_defconfig.
 # When found, use that path to infer the ARCH we are building for.

--- a/cmake/kconfig.cmake
+++ b/cmake/kconfig.cmake
@@ -29,6 +29,7 @@ set(ENV{KCONFIG_CONFIG}     ${DOTCONFIG})
 set(ENV{ARCH}      ${ARCH})
 set(ENV{BOARD_DIR} ${BOARD_DIR})
 set(ENV{SOC_DIR}   ${SOC_DIR})
+set(ENV{ARCH_DIR}   ${ARCH_DIR})
 
 add_custom_target(
   menuconfig
@@ -39,6 +40,7 @@ add_custom_target(
   ARCH=$ENV{ARCH}
   BOARD_DIR=$ENV{BOARD_DIR}
   SOC_DIR=$ENV{SOC_DIR}
+  ARCH_DIR=$ENV{ARCH_DIR}
   ${PYTHON_EXECUTABLE} ${ZEPHYR_BASE}/scripts/kconfig/menuconfig.py ${KCONFIG_ROOT}
   WORKING_DIRECTORY ${PROJECT_BINARY_DIR}/kconfig
   USES_TERMINAL


### PR DESCRIPTION
(This is based on-top of PR #11309, and should not be merged)
Proposal for the support of having a processor architecture out-of-tree.
It includes moving files from the two following locations:
${ZEPHYR_BASE}/arch/
${ZEPHYR_BASE/include/arch
into an out-of-tree path with the same tree structure

This is done by supplying the optional argument ARCH_ROOT, in the same way it is done with BOARD_ROOT and SOC_ROOT.