### PR TITLE
dts: Remove ifdef CONFIG_FS_FLASH_STORAGE_PARTITION from dts files

### DIFF
--- a/boards/arm/adafruit_feather_m0_basic_proto/adafruit_feather_m0_basic_proto.dts
+++ b/boards/arm/adafruit_feather_m0_basic_proto/adafruit_feather_m0_basic_proto.dts
@@ -72,13 +72,10 @@
 		 * The final 16 KiB is reserved for the application
 		 * and is used by NFFS if enabled.
 		 */
-
-#if defined(CONFIG_FS_FLASH_STORAGE_PARTITION)
 		storage_partition: partition@3c000 {
 			label = "storage";
 			reg = <0x0003c000 0x00004000>;
 		};
-#endif
 	};
 };
 

--- a/boards/arm/adafruit_trinket_m0/adafruit_trinket_m0.dts
+++ b/boards/arm/adafruit_trinket_m0/adafruit_trinket_m0.dts
@@ -87,13 +87,10 @@
 		 * The final 16 KiB is reserved for the application
 		 * and is used by NFFS if enabled.
 		 */
-
-#if defined(CONFIG_FS_FLASH_STORAGE_PARTITION)
 		storage_partition: partition@3c000 {
 			label = "storage";
 			reg = <0x0003c000 0x00004000>;
 		};
-#endif
 	};
 };
 

--- a/boards/arm/arduino_zero/arduino_zero.dts
+++ b/boards/arm/arduino_zero/arduino_zero.dts
@@ -75,13 +75,10 @@
 		 * The final 16 KiB is reserved for the application
 		 * and is used by NFFS if enabled.
 		 */
-
-#if defined(CONFIG_FS_FLASH_STORAGE_PARTITION)
 		storage_partition: partition@3c000 {
 			label = "storage";
 			reg = <0x0003c000 0x00004000>;
 		};
-#endif
 	};
 };
 

--- a/boards/arm/atsamd20_xpro/atsamd20_xpro.dts
+++ b/boards/arm/atsamd20_xpro/atsamd20_xpro.dts
@@ -72,12 +72,9 @@
 		 * The final 16 KiB is reserved for the application
 		 * and is used by NFFS if enabled.
 		 */
-
-#if defined(CONFIG_FS_FLASH_MAP_STORAGE)
 		storage_partition: partition@3c000 {
 			label = "storage";
 			reg = <0x0003c000 0x00004000>;
 		};
-#endif
 	};
 };

--- a/boards/arm/bbc_microbit/bbc_microbit.dts
+++ b/boards/arm/bbc_microbit/bbc_microbit.dts
@@ -94,12 +94,9 @@
 			label = "image-scratch";
 			reg = <0x0003c000 0x2000>;
 		};
-
-#if defined(CONFIG_FS_FLASH_STORAGE_PARTITION)
 		storage_partition: partition@3e000 {
 			label = "storage";
 			reg = <0x0003e000 0x00002000>;
 		};
-#endif
 	};
 };

--- a/boards/arm/frdm_k64f/frdm_k64f.dts
+++ b/boards/arm/frdm_k64f/frdm_k64f.dts
@@ -145,12 +145,10 @@ arduino_serial: &uart3 {};
 		 * 0x0001ffff (sectors 16-31) is reserved for use
 		 * by the application.
 		 */
-#if defined(CONFIG_FS_FLASH_STORAGE_PARTITION)
-		 storage_partition: partition@1e000 {
+		storage_partition: partition@1e000 {
 			label = "storage";
 			reg = <0x0001e000 0x00002000>;
 		};
-#endif
 
 		slot0_partition: partition@20000 {
 			label = "image-0";

--- a/boards/arm/nrf51_pca10028/nrf51_pca10028.dts
+++ b/boards/arm/nrf51_pca10028/nrf51_pca10028.dts
@@ -145,12 +145,9 @@
 			label = "image-scratch";
 			reg = <0x0003c000 0x2000>;
 		};
-
-#if defined(CONFIG_FS_FLASH_STORAGE_PARTITION)
 		storage_partition: partition@3e000 {
 			label = "storage";
 			reg = <0x0003e000 0x00002000>;
 		};
-#endif
 	};
 };

--- a/boards/arm/nrf52810_pca10040/nrf52810_pca10040.dts
+++ b/boards/arm/nrf52810_pca10040/nrf52810_pca10040.dts
@@ -134,12 +134,9 @@
 			label = "image-scratch";
 			reg = <0x00026000 0x3000>;
 		};
-
-#if defined(CONFIG_FS_FLASH_STORAGE_PARTITION)
 		storage_partition: partition@29000 {
 			label = "storage";
 			reg = <0x00029000 0x00007000>;
 		};
-#endif
 	};
 };

--- a/boards/arm/nrf52832_mdk/nrf52832_mdk.dts
+++ b/boards/arm/nrf52832_mdk/nrf52832_mdk.dts
@@ -113,12 +113,9 @@
 			label = "image-scratch";
 			reg = <0x00070000 0xa000>;
 		};
-
-#if defined(CONFIG_FS_FLASH_STORAGE_PARTITION)
 		storage_partition: partition@7a000 {
 			label = "storage";
 			reg = <0x0007a000 0x00006000>;
 		};
-#endif
 	};
 };

--- a/boards/arm/nrf52840_mdk/nrf52840_mdk.dts
+++ b/boards/arm/nrf52840_mdk/nrf52840_mdk.dts
@@ -139,13 +139,10 @@
 			label = "image-scratch";
 			reg = <0x000de000 0x0001e000>;
 		};
-
-#if defined(CONFIG_FS_FLASH_STORAGE_PARTITION)
 		storage_partition: partition@fc000 {
 			label = "storage";
 			reg = <0x000fc000 0x00004000>;
 		};
-#endif
 	};
 };
 

--- a/boards/arm/nrf52840_pca10056/nrf52840_pca10056.dts
+++ b/boards/arm/nrf52840_pca10056/nrf52840_pca10056.dts
@@ -188,13 +188,10 @@
 			label = "image-scratch";
 			reg = <0x000de000 0x0001e000>;
 		};
-
-#if defined(CONFIG_FS_FLASH_STORAGE_PARTITION)
 		storage_partition: partition@fc000 {
 			label = "storage";
 			reg = <0x000fc000 0x00004000>;
 		};
-#endif
 	};
 };
 

--- a/boards/arm/nrf52840_pca10059/nrf52840_pca10059.dts
+++ b/boards/arm/nrf52840_pca10059/nrf52840_pca10059.dts
@@ -140,13 +140,10 @@
 			label = "image-scratch";
 			reg = <0x000c1000 0x0001f000>;
 		};
-
-#if defined(CONFIG_FS_FLASH_STORAGE_PARTITION)
 		storage_partition: partition@fa000 {
 			label = "storage";
 			reg = <0x000fa000 0x00004000>;
 		};
-#endif
 	};
 };
 

--- a/boards/arm/nrf52_adafruit_feather/nrf52_adafruit_feather.dts
+++ b/boards/arm/nrf52_adafruit_feather/nrf52_adafruit_feather.dts
@@ -96,12 +96,9 @@
 			label = "image-scratch";
 			reg = <0x00070000 0xa000>;
 		};
-
-#if defined(CONFIG_FS_FLASH_STORAGE_PARTITION)
 		storage_partition: partition@7a000 {
 			label = "storage";
 			reg = <0x0007a000 0x00006000>;
 		};
-#endif
 	};
 };

--- a/boards/arm/nrf52_blenano2/nrf52_blenano2.dts
+++ b/boards/arm/nrf52_blenano2/nrf52_blenano2.dts
@@ -82,12 +82,9 @@
 			label = "image-scratch";
 			reg = <0x00070000 0xD000>;
 		};
-
-#if defined(CONFIG_FS_FLASH_STORAGE_PARTITION)
 		storage_partition: partition@7D000 {
 			label = "storage";
 			reg = <0x0007D000 0x00004000>;
 		};
-#endif
 	};
 };

--- a/boards/arm/nrf52_pca10040/nrf52_pca10040.dts
+++ b/boards/arm/nrf52_pca10040/nrf52_pca10040.dts
@@ -154,12 +154,9 @@
 			label = "image-scratch";
 			reg = <0x00070000 0xa000>;
 		};
-
-#if defined(CONFIG_FS_FLASH_STORAGE_PARTITION)
 		storage_partition: partition@7a000 {
 			label = "storage";
 			reg = <0x0007a000 0x00006000>;
 		};
-#endif
 	};
 };

--- a/boards/arm/nrf52_pca20020/nrf52_pca20020.dts
+++ b/boards/arm/nrf52_pca20020/nrf52_pca20020.dts
@@ -151,12 +151,9 @@
 		 * by the application. If enabled, partition for NFFS
 		 * will be created in this area.
 		 */
-
-#if defined(CONFIG_FS_FLASH_STORAGE_PARTITION)
 		storage_partition: partition@7a000 {
 			label = "storage";
 			reg = <0x0007a000 0x00006000>;
 		};
-#endif
 	};
 };

--- a/boards/arm/nrf52_sparkfun/nrf52_sparkfun.dts
+++ b/boards/arm/nrf52_sparkfun/nrf52_sparkfun.dts
@@ -85,12 +85,9 @@
 			label = "image-scratch";
 			reg = <0x00070000 0xa000>;
 		};
-
-#if defined(CONFIG_FS_FLASH_STORAGE_PARTITION)
 		storage_partition: partition@7a000 {
 			label = "storage";
 			reg = <0x0007a000 0x00006000>;
 		};
-#endif
 	};
 };

--- a/boards/arm/nucleo_l432kc/nucleo_l432kc.dts
+++ b/boards/arm/nucleo_l432kc/nucleo_l432kc.dts
@@ -72,7 +72,6 @@
 		#address-cells = <1>;
 		#size-cells = <1>;
 
-#if defined(CONFIG_FS_FLASH_STORAGE_PARTITION)
 		/*
 		 * Reserve the final 16 KiB for the application.
 		 */
@@ -80,6 +79,5 @@
 			label = "storage";
 			reg = <0x0003c000 0x00004000>;
 		};
-#endif
 	};
 };

--- a/boards/arm/nucleo_l4r5zi/nucleo_l4r5zi.dts
+++ b/boards/arm/nucleo_l4r5zi/nucleo_l4r5zi.dts
@@ -105,12 +105,10 @@ arduino_serial: &usart3 {};
 		#address-cells = <1>;
 		#size-cells = <1>;
 
-#if defined(CONFIG_FS_FLASH_STORAGE_PARTITION)
 		/* Reserve last 16KiB for property storage */
 		storage_partition: partition@1FB000 {
 			label = "storage";
 			reg = <0x001FB000 0x00004000>;
 		};
-#endif
 	};
 };

--- a/boards/arm/reel_board/reel_board.dts
+++ b/boards/arm/reel_board/reel_board.dts
@@ -154,12 +154,10 @@
 			reg = <0x000de000 0x0001e000>;
 		};
 
-#if defined(CONFIG_FS_FLASH_STORAGE_PARTITION)
 		storage_partition: partition@fc000 {
 			label = "storage";
 			reg = <0x000fc000 0x00004000>;
 		};
-#endif
 	};
 };
 

--- a/samples/application_development/out_of_tree_board/boards/arm/nrf52840_pca10056/nrf52840_pca10056.dts
+++ b/samples/application_development/out_of_tree_board/boards/arm/nrf52840_pca10056/nrf52840_pca10056.dts
@@ -67,13 +67,10 @@
 			label = "image-scratch";
 			reg = <0x000de000 0x0001e000>;
 		};
-
-#if defined(CONFIG_FS_FLASH_STORAGE_PARTITION)
 		storage_partition: partition@fc000 {
 			label = "storage";
 			reg = <0x000fc000 0x00004000>;
 		};
-#endif
 	};
 };
 


### PR DESCRIPTION
Remove the ifdef related to CONFIG_FS_FLASH_STORAGE_PARTITION.  There
shouldn't be any harm in always having the partition around as we'll
just generate the defines related to and most applications will ignore
them.

Helps get one step closer to have DTS not depend on Kconfig.

Signed-off-by: Kumar Gala <kumar.gala@linaro.org>