### PR TITLE
move modem configurtion to overlay for nrf52840_mdk & nrf52840_pca10056

### DIFF
--- a/boards/arm/nrf52840_mdk/nrf52840_mdk.dts
+++ b/boards/arm/nrf52840_mdk/nrf52840_mdk.dts
@@ -77,30 +77,6 @@
 	cts-pin = <7>;
 };
 
-#ifdef CONFIG_UART_1_NRF_UARTE
-&uart1 {
-	current-speed = <115200>;
-	status = "ok";
-	tx-pin = <16>;
-	rx-pin = <15>;
-	rts-pin = <14>;
-	cts-pin = <17>;
-
-#ifdef CONFIG_MODEM_WNCM14A2A
-	wncm14a2a {
-		compatible = "wnc,m14a2a";
-		label = "wncm14a2a";
-		mdm-boot-mode-sel-gpios = <&gpio1 2 0>;
-		mdm-power-gpios = <&gpio1 3 0>;
-		mdm-keep-awake-gpios = <&gpio1 7 0>;
-		mdm-reset-gpios = <&gpio1 10 0>;
-		mdm-shld-trans-ena-gpios = <&gpio1 11 0>;
-		status = "ok";
-	};
-#endif
-};
-#endif
-
 &i2c0 {
 	status = "ok";
 	sda-pin = <26>;

--- a/boards/arm/nrf52840_pca10056/nrf52840_pca10056.dts
+++ b/boards/arm/nrf52840_pca10056/nrf52840_pca10056.dts
@@ -98,30 +98,6 @@
 	cts-pin = <7>;
 };
 
-#ifdef CONFIG_UART_1_NRF_UARTE
-&uart1 {
-	current-speed = <115200>;
-	status = "ok";
-	tx-pin = <46>;
-	rx-pin = <45>;
-	rts-pin = <44>;
-	cts-pin = <47>;
-
-#ifdef CONFIG_MODEM_WNCM14A2A
-	wncm14a2a {
-		compatible = "wnc,m14a2a";
-		label = "wncm14a2a";
-		mdm-boot-mode-sel-gpios = <&gpio1 2 0>;
-		mdm-power-gpios = <&gpio1 3 0>;
-		mdm-keep-awake-gpios = <&gpio1 7 0>;
-		mdm-reset-gpios = <&gpio1 10 0>;
-		mdm-shld-trans-ena-gpios = <&gpio1 11 0>;
-		status = "ok";
-	};
-#endif
-};
-#endif
-
 &i2c0 {
 	status = "ok";
 	sda-pin = <26>;

--- a/samples/net/lwm2m_client/nrf52840_mdk.overlay
+++ b/samples/net/lwm2m_client/nrf52840_mdk.overlay
@@ -1,0 +1,25 @@
+/*
+ * Copyright (c) 2018 Linaro Limited
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+&uart1 {
+	current-speed = <115200>;
+	status = "ok";
+	tx-pin = <16>;
+	rx-pin = <15>;
+	rts-pin = <14>;
+	cts-pin = <17>;
+
+	wncm14a2a {
+		compatible = "wnc,m14a2a";
+		label = "wncm14a2a";
+		mdm-boot-mode-sel-gpios = <&gpio1 2 0>;
+		mdm-power-gpios = <&gpio1 3 0>;
+		mdm-keep-awake-gpios = <&gpio1 7 0>;
+		mdm-reset-gpios = <&gpio1 10 0>;
+		mdm-shld-trans-ena-gpios = <&gpio1 11 0>;
+		status = "ok";
+	};
+};

--- a/samples/net/lwm2m_client/nrf52840_pca10056.overlay
+++ b/samples/net/lwm2m_client/nrf52840_pca10056.overlay
@@ -1,0 +1,25 @@
+/*
+ * Copyright (c) 2018 Linaro Limited
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+&uart1 {
+	current-speed = <115200>;
+	status = "ok";
+	tx-pin = <46>;
+	rx-pin = <45>;
+	rts-pin = <44>;
+	cts-pin = <47>;
+
+	wncm14a2a {
+		compatible = "wnc,m14a2a";
+		label = "wncm14a2a";
+		mdm-boot-mode-sel-gpios = <&gpio1 2 0>;
+		mdm-power-gpios = <&gpio1 3 0>;
+		mdm-keep-awake-gpios = <&gpio1 7 0>;
+		mdm-reset-gpios = <&gpio1 10 0>;
+		mdm-shld-trans-ena-gpios = <&gpio1 11 0>;
+		status = "ok";
+	};
+};


### PR DESCRIPTION
The wncm14a2a modem is an add-on/shield and not part of the boards and should be maintained and configured outside of the board.

This needs to be moved to a shield, see #10965.
