### PR TITLE
samples: mesh: nrf52: improvement in transition type reassignment & other optimization

### DIFF
--- a/samples/boards/nrf52/mesh/onoff_level_lighting_vnd_app/src/mesh/device_composition.c
+++ b/samples/boards/nrf52/mesh/onoff_level_lighting_vnd_app/src/mesh/device_composition.c
@@ -185,10 +185,6 @@ static bool gen_onoff_setunack(struct bt_mesh_model *model,
 		return false;
 	}
 
-	bound_states_transition_type_reassignment(ONOFF);
-	state->transition->tt = tt;
-	state->transition->delay = delay;
-
 	*ptr_counter = 0;
 	k_timer_stop(ptr_timer);
 
@@ -197,9 +193,8 @@ static bool gen_onoff_setunack(struct bt_mesh_model *model,
 	state->last_msg_timestamp = now;
 	state->target_onoff = onoff;
 
-	state->transition->counter = 0;
 	if (state->target_onoff != state->onoff) {
-		onoff_tt_values(state);
+		onoff_tt_values(state, tt, delay);
 	} else {
 		return true;
 	}
@@ -357,14 +352,6 @@ static bool gen_level_setunack(struct bt_mesh_model *model,
 		return false;
 	}
 
-	if (bt_mesh_model_elem(model)->addr == elements[0].addr) {
-		bound_states_transition_type_reassignment(LEVEL);
-	} else if (bt_mesh_model_elem(model)->addr == elements[1].addr) {
-		bound_states_transition_type_reassignment(LEVEL_TEMP);
-	}
-	state->transition->tt = tt;
-	state->transition->delay = delay;
-
 	*ptr_counter = 0;
 	k_timer_stop(ptr_timer);
 
@@ -373,9 +360,8 @@ static bool gen_level_setunack(struct bt_mesh_model *model,
 	state->last_msg_timestamp = now;
 	state->target_level = level;
 
-	state->transition->counter = 0;
 	if (state->target_level != state->level) {
-		level_tt_values(state);
+		level_tt_values(state, tt, delay);
 	} else {
 		return true;
 	}
@@ -459,14 +445,6 @@ static bool gen_delta_setunack(struct bt_mesh_model *model,
 		return false;
 	}
 
-	if (bt_mesh_model_elem(model)->addr == elements[0].addr) {
-		bound_states_transition_type_reassignment(LEVEL);
-	} else if (bt_mesh_model_elem(model)->addr == elements[1].addr) {
-		bound_states_transition_type_reassignment(LEVEL_TEMP);
-	}
-	state->transition->tt = tt;
-	state->transition->delay = delay;
-
 	*ptr_counter = 0;
 	k_timer_stop(ptr_timer);
 
@@ -483,9 +461,8 @@ static bool gen_delta_setunack(struct bt_mesh_model *model,
 
 	state->target_level = tmp32;
 
-	state->transition->counter = 0;
 	if (state->target_level != state->level) {
-		level_tt_values(state);
+		level_tt_values(state, tt, delay);
 	} else {
 		return true;
 	}
@@ -562,14 +539,6 @@ static bool gen_move_setunack(struct bt_mesh_model *model,
 		return false;
 	}
 
-	if (bt_mesh_model_elem(model)->addr == elements[0].addr) {
-		bound_states_transition_type_reassignment(LEVEL);
-	} else if (bt_mesh_model_elem(model)->addr == elements[1].addr) {
-		bound_states_transition_type_reassignment(LEVEL_TEMP);
-	}
-	state->transition->tt = tt;
-	state->transition->delay = delay;
-
 	*ptr_counter = 0;
 	k_timer_stop(ptr_timer);
 
@@ -587,9 +556,8 @@ static bool gen_move_setunack(struct bt_mesh_model *model,
 
 	state->target_level = tmp32;
 
-	state->transition->counter = 0;
 	if (state->target_level != state->level) {
-		level_tt_values(state);
+		level_tt_values(state, tt, delay);
 	} else {
 		if (delta == 0) {
 			goto jump;
@@ -959,10 +927,6 @@ static bool light_lightness_setunack(struct bt_mesh_model *model,
 		return false;
 	}
 
-	bound_states_transition_type_reassignment(ACTUAL);
-	state->transition->tt = tt;
-	state->transition->delay = delay;
-
 	*ptr_counter = 0;
 	k_timer_stop(ptr_timer);
 
@@ -978,9 +942,8 @@ static bool light_lightness_setunack(struct bt_mesh_model *model,
 
 	state->target_actual = actual;
 
-	state->transition->counter = 0;
 	if (state->target_actual != state->actual) {
-		light_lightness_actual_tt_values(state);
+		light_lightness_actual_tt_values(state, tt, delay);
 	} else {
 		return true;
 	}
@@ -1093,10 +1056,6 @@ static bool light_lightness_linear_setunack(struct bt_mesh_model *model,
 		return false;
 	}
 
-	bound_states_transition_type_reassignment(LINEAR);
-	state->transition->tt = tt;
-	state->transition->delay = delay;
-
 	*ptr_counter = 0;
 	k_timer_stop(ptr_timer);
 
@@ -1105,9 +1064,8 @@ static bool light_lightness_linear_setunack(struct bt_mesh_model *model,
 	state->last_msg_timestamp = now;
 	state->target_linear = linear;
 
-	state->transition->counter = 0;
 	if (state->target_linear != state->linear) {
-		light_lightness_linear_tt_values(state);
+		light_lightness_linear_tt_values(state, tt, delay);
 	} else {
 		return true;
 	}
@@ -1448,10 +1406,6 @@ static bool light_ctl_setunack(struct bt_mesh_model *model,
 		return false;
 	}
 
-	bound_states_transition_type_reassignment(CTL);
-	state->transition->tt = tt;
-	state->transition->delay = delay;
-
 	*ptr_counter = 0;
 	k_timer_stop(ptr_timer);
 
@@ -1469,11 +1423,10 @@ static bool light_ctl_setunack(struct bt_mesh_model *model,
 	state->target_temp = temp;
 	state->target_delta_uv = delta_uv;
 
-	state->transition->counter = 0;
 	if (state->target_lightness != state->lightness ||
 	    state->target_temp != state->temp ||
 	    state->target_delta_uv != state->delta_uv) {
-		light_ctl_tt_values(state);
+		light_ctl_tt_values(state, tt, delay);
 	} else {
 		return true;
 	}
@@ -1828,10 +1781,6 @@ static bool light_ctl_temp_setunack(struct bt_mesh_model *model,
 		return false;
 	}
 
-	bound_states_transition_type_reassignment(CTL_TEMP);
-	state->transition->tt = tt;
-	state->transition->delay = delay;
-
 	*ptr_counter = 0;
 	k_timer_stop(ptr_timer);
 
@@ -1848,10 +1797,9 @@ static bool light_ctl_temp_setunack(struct bt_mesh_model *model,
 	state->target_temp = temp;
 	state->target_delta_uv = delta_uv;
 
-	state->transition->counter = 0;
 	if (state->target_temp != state->temp ||
 	    state->target_delta_uv != state->delta_uv) {
-		light_ctl_temp_tt_values(state);
+		light_ctl_temp_tt_values(state, tt, delay);
 	} else {
 		return true;
 	}

--- a/samples/boards/nrf52/mesh/onoff_level_lighting_vnd_app/src/mesh/transition.c
+++ b/samples/boards/nrf52/mesh/onoff_level_lighting_vnd_app/src/mesh/transition.c
@@ -61,7 +61,7 @@ void calculate_rt(struct transition *transition)
 
 /* Function to calculate Remaining Time (End) */
 
-void bound_states_transition_type_reassignment(u8_t type)
+static void bound_states_transition_type_reassignment(u8_t type)
 {
 	switch (type) {
 	case ONOFF:
@@ -115,8 +115,12 @@ static void tt_values_calculator(struct transition *transition)
 	ptr_counter = &transition->counter;
 }
 
-void onoff_tt_values(struct generic_onoff_state *state)
+void onoff_tt_values(struct generic_onoff_state *state, u8_t tt, u8_t delay)
 {
+	bound_states_transition_type_reassignment(ONOFF);
+	state->transition->tt = tt;
+	state->transition->delay = delay;
+
 	tt_values_calculator(state->transition);
 
 	if (state->transition->counter == 0) {
@@ -129,9 +133,17 @@ void onoff_tt_values(struct generic_onoff_state *state)
 	}
 }
 
-void level_tt_values(struct generic_level_state *state)
+void level_tt_values(struct generic_level_state *state, u8_t tt, u8_t delay)
 {
 	u32_t counter;
+
+	if (state == &gen_level_srv_root_user_data) {
+		bound_states_transition_type_reassignment(LEVEL);
+	} else if (state == &gen_level_srv_s0_user_data) {
+		bound_states_transition_type_reassignment(LEVEL_TEMP);
+	}
+	state->transition->tt = tt;
+	state->transition->delay = delay;
 
 	tt_values_calculator(state->transition);
 
@@ -154,9 +166,14 @@ void level_tt_values(struct generic_level_state *state)
 			   counter);
 }
 
-void light_lightness_actual_tt_values(struct light_lightness_state *state)
+void light_lightness_actual_tt_values(struct light_lightness_state *state,
+				      u8_t tt, u8_t delay)
 {
 	u32_t counter;
+
+	bound_states_transition_type_reassignment(ACTUAL);
+	state->transition->tt = tt;
+	state->transition->delay = delay;
 
 	tt_values_calculator(state->transition);
 
@@ -176,9 +193,14 @@ void light_lightness_actual_tt_values(struct light_lightness_state *state)
 		 counter);
 }
 
-void light_lightness_linear_tt_values(struct light_lightness_state *state)
+void light_lightness_linear_tt_values(struct light_lightness_state *state,
+				      u8_t tt, u8_t delay)
 {
 	u32_t counter;
+
+	bound_states_transition_type_reassignment(LINEAR);
+	state->transition->tt = tt;
+	state->transition->delay = delay;
 
 	tt_values_calculator(state->transition);
 
@@ -198,9 +220,13 @@ void light_lightness_linear_tt_values(struct light_lightness_state *state)
 		 counter);
 }
 
-void light_ctl_tt_values(struct light_ctl_state *state)
+void light_ctl_tt_values(struct light_ctl_state *state, u8_t tt, u8_t delay)
 {
 	u32_t counter;
+
+	bound_states_transition_type_reassignment(CTL);
+	state->transition->tt = tt;
+	state->transition->delay = delay;
 
 	tt_values_calculator(state->transition);
 
@@ -228,9 +254,14 @@ void light_ctl_tt_values(struct light_ctl_state *state)
 		 counter);
 }
 
-void light_ctl_temp_tt_values(struct light_ctl_state *state)
+void light_ctl_temp_tt_values(struct light_ctl_state *state,
+			      u8_t tt, u8_t delay)
 {
 	u32_t counter;
+
+	bound_states_transition_type_reassignment(CTL_TEMP);
+	state->transition->tt = tt;
+	state->transition->delay = delay;
 
 	tt_values_calculator(state->transition);
 

--- a/samples/boards/nrf52/mesh/onoff_level_lighting_vnd_app/src/mesh/transition.c
+++ b/samples/boards/nrf52/mesh/onoff_level_lighting_vnd_app/src/mesh/transition.c
@@ -18,7 +18,6 @@ u32_t *ptr_counter;
 struct k_timer *ptr_timer = &dummy_timer;
 
 struct transition lightness_transition, temp_transition;
-static struct k_timer lightness_timer, temp_timer;
 
 /* Function to calculate Remaining Time (Start) */
 
@@ -612,7 +611,7 @@ K_TIMER_DEFINE(dummy_timer, NULL, NULL);
 /* Messages handlers (Start) */
 void onoff_handler(struct generic_onoff_state *state)
 {
-	ptr_timer = &lightness_timer;
+	ptr_timer = &state->transition->timer;
 	state->transition->just_started = true;
 
 	k_timer_init(ptr_timer, onoff_tt_handler, NULL);
@@ -624,7 +623,7 @@ void onoff_handler(struct generic_onoff_state *state)
 
 void level_lightness_handler(struct generic_level_state *state)
 {
-	ptr_timer = &lightness_timer;
+	ptr_timer = &state->transition->timer;
 	state->transition->just_started = true;
 
 	k_timer_init(ptr_timer, level_lightness_tt_handler, NULL);
@@ -636,7 +635,7 @@ void level_lightness_handler(struct generic_level_state *state)
 
 void level_temp_handler(struct generic_level_state *state)
 {
-	ptr_timer = &temp_timer;
+	ptr_timer = &state->transition->timer;
 	state->transition->just_started = true;
 
 	k_timer_init(ptr_timer, level_temp_tt_handler, NULL);
@@ -648,7 +647,7 @@ void level_temp_handler(struct generic_level_state *state)
 
 void light_lightness_actual_handler(struct light_lightness_state *state)
 {
-	ptr_timer = &lightness_timer;
+	ptr_timer = &state->transition->timer;
 	state->transition->just_started = true;
 
 	k_timer_init(ptr_timer, light_lightness_actual_tt_handler, NULL);
@@ -660,7 +659,7 @@ void light_lightness_actual_handler(struct light_lightness_state *state)
 
 void light_lightness_linear_handler(struct light_lightness_state *state)
 {
-	ptr_timer = &lightness_timer;
+	ptr_timer = &state->transition->timer;
 	state->transition->just_started = true;
 
 	k_timer_init(ptr_timer, light_lightness_linear_tt_handler, NULL);
@@ -672,7 +671,7 @@ void light_lightness_linear_handler(struct light_lightness_state *state)
 
 void light_ctl_handler(struct light_ctl_state *state)
 {
-	ptr_timer = &lightness_timer;
+	ptr_timer = &state->transition->timer;
 	state->transition->just_started = true;
 
 	k_timer_init(ptr_timer, light_ctl_tt_handler, NULL);
@@ -684,7 +683,7 @@ void light_ctl_handler(struct light_ctl_state *state)
 
 void light_ctl_temp_handler(struct light_ctl_state *state)
 {
-	ptr_timer = &temp_timer;
+	ptr_timer = &state->transition->timer;
 	state->transition->just_started = true;
 
 	k_timer_init(ptr_timer, light_ctl_temp_tt_handler, NULL);

--- a/samples/boards/nrf52/mesh/onoff_level_lighting_vnd_app/src/mesh/transition.h
+++ b/samples/boards/nrf52/mesh/onoff_level_lighting_vnd_app/src/mesh/transition.h
@@ -43,14 +43,16 @@ extern struct k_timer dummy_timer;
 
 void calculate_rt(struct transition *transition);
 
-void bound_states_transition_type_reassignment(u8_t type);
 
-void onoff_tt_values(struct generic_onoff_state *state);
-void level_tt_values(struct generic_level_state *state);
-void light_lightness_actual_tt_values(struct light_lightness_state *state);
-void light_lightness_linear_tt_values(struct light_lightness_state *state);
-void light_ctl_tt_values(struct light_ctl_state *state);
-void light_ctl_temp_tt_values(struct light_ctl_state *state);
+void onoff_tt_values(struct generic_onoff_state *state, u8_t tt, u8_t delay);
+void level_tt_values(struct generic_level_state *state, u8_t tt, u8_t delay);
+void light_lightness_actual_tt_values(struct light_lightness_state *state,
+				      u8_t tt, u8_t delay);
+void light_lightness_linear_tt_values(struct light_lightness_state *state,
+				      u8_t tt, u8_t delay);
+void light_ctl_tt_values(struct light_ctl_state *state, u8_t tt, u8_t delay);
+void light_ctl_temp_tt_values(struct light_ctl_state *state,
+			      u8_t tt, u8_t delay);
 
 void onoff_handler(struct generic_onoff_state *state);
 void level_lightness_handler(struct generic_level_state *state);

--- a/samples/boards/nrf52/mesh/onoff_level_lighting_vnd_app/src/mesh/transition.h
+++ b/samples/boards/nrf52/mesh/onoff_level_lighting_vnd_app/src/mesh/transition.h
@@ -29,6 +29,8 @@ struct transition {
 	u32_t counter;
 	u32_t total_duration;
 	s64_t start_timestamp;
+
+	struct k_timer timer;
 };
 
 extern u8_t transition_type, default_tt;


### PR DESCRIPTION
In this commit, struct k_timer timer_lightness & struct k_timer
timer_temp picked & merged into struct transition lightness_transition
& struct transition temp_transition resp.

Simplifies message handler for Servers & transition type reassignment.

Signed-off-by: Vikrant More <vikrant8051@gmail.com>