### PR TITLE
Bluetooth: Mesh: Increase scan window from 10ms to 30ms

### DIFF
--- a/subsys/bluetooth/host/mesh/adv.c
+++ b/subsys/bluetooth/host/mesh/adv.c
@@ -34,8 +34,8 @@
 #define ADV_SCAN_UNIT(_ms) ((_ms) * 8 / 5)
 
 /* Window and Interval are equal for continuous scanning */
-#define MESH_SCAN_INTERVAL_MS 10
-#define MESH_SCAN_WINDOW_MS   10
+#define MESH_SCAN_INTERVAL_MS 30
+#define MESH_SCAN_WINDOW_MS   30
 #define MESH_SCAN_INTERVAL    ADV_SCAN_UNIT(MESH_SCAN_INTERVAL_MS)
 #define MESH_SCAN_WINDOW      ADV_SCAN_UNIT(MESH_SCAN_WINDOW_MS)
 


### PR DESCRIPTION
Experiments have shown that the probability of missing advertising
packets is significantly lower with 30ms scan window compared to 10ms
scan window. This is especially the case with advertisers using a 20ms
advertising interval, which in turn is perhaps the most common one
since it's the smallest allowed by the Bluetooth 5.0 specification.

Signed-off-by: Johan Hedberg <johan.hedberg@intel.com>