### PR TITLE
Avoid nested C/C++ comments

### DIFF
--- a/arch/arm/include/kernel_arch_thread.h
+++ b/arch/arm/include/kernel_arch_thread.h
@@ -30,13 +30,13 @@ struct _caller_saved {
 	 *
 	 * For Cortex-A, this may be:
 	 *
-	 * u32_t a1;    // r0
-	 * u32_t a2;    // r1
-	 * u32_t a3;    // r2
-	 * u32_t a4;    // r3
-	 * u32_t ip;    // r12
-	 * u32_t lr;    // r14
-	 * u32_t pc;    // r15
+	 * u32_t a1;       r0
+	 * u32_t a2;       r1
+	 * u32_t a3;       r2
+	 * u32_t a4;       r3
+	 * u32_t ip;       r12
+	 * u32_t lr;       r14
+	 * u32_t pc;       r15
 	 * u32_t xpsr;
 	 */
 };

--- a/arch/xtensa/core/startup/memerror-vector.S
+++ b/arch/xtensa/core/startup/memerror-vector.S
@@ -26,15 +26,15 @@
 #include <xtensa/coreasm.h>
 #include <xtensa/corebits.h>
 
-// This file just contains this one symbol, used by the reset code.
-// It is here rather than in reset-vector.S because we want the symbol
-// to be external, so resolution is delayed until link time.
-//
-// To define your own value to override this default, redefine the
-// symbol _MemErrorHandler to the desired value, e.g. -
-//
-//    xt-xcc test.c -g -o test -Wl,--defsym=_MemErrorHandler=0x08080808
-//
+/* This file just contains this one symbol, used by the reset code.
+ * It is here rather than in reset-vector.S because we want the symbol
+ * to be external, so resolution is delayed until link time.
+ *
+ * To define your own value to override this default, redefine the
+ * symbol _MemErrorHandler to the desired value, e.g. -
+ *
+ *    xt-xcc test.c -g -o test -Wl,--defsym=_MemErrorHandler=0x08080808
+ */
 
 	.global	_MemErrorHandler
 	.weak   _MemErrorHandler

--- a/arch/xtensa/core/startup/memerror-vector.S
+++ b/arch/xtensa/core/startup/memerror-vector.S
@@ -1,7 +1,5 @@
 /* memerror-vector.S  --  Memory Error Exception Vector and Handler */
 
-/* $Id: //depot/rel/Foxhill/dot.5/Xtensa/OS/xtos/memerror-vector.S#1 $ */
-
 /*
  * Copyright (c) 2006-2013 Tensilica Inc.
  *

--- a/drivers/pci/pci.c
+++ b/drivers/pci/pci.c
@@ -41,8 +41,10 @@
  * pci_bus_scan_init();
  *
  * while (pci_bus_scan(&info)) {
- *      // do something with "info" which holds a valid result, i.e. some
- *      // device information matching the PCI class PCI_CLASS_COMM_CTLR
+ *      ...
+ *      do something with "info" which holds a valid result, i.e. some
+ *      device information matching the PCI class PCI_CLASS_COMM_CTLR
+ *      ...
  * }
  *
  * INTERNALS

--- a/subsys/mgmt/smp.c
+++ b/subsys/mgmt/smp.c
@@ -83,7 +83,7 @@ zephyr_smp_trim_front(void *buf, size_t len, void *arg)
  *
  *     struct net_buf *frag;
  *     struct net_buf *rsp;
- *     // [...]
+ *     ...
  *     while (rsp != NULL) {
  *         frag = zephyr_smp_split_frag(&rsp, zst, get_mtu());
  *         if (frag == NULL) {


### PR DESCRIPTION
This patch cleans up nested C++ comments within C comments and fixes #10270. In order to find (most of) the locations where this happens, the following command was used:
`egrep -R '(/\*|\*[[:space:]]).*//' arch/ boards/ drivers/ dts/ include/ kernel/ lib/ misc/ soc/ subsys/ tests/ | egrep -v 'https?://'`

After applying the below patches, there are 145 locations that contain an http:// or https:// URL, and one false positive hexadecimal UDP packet that contains // in the commented out ASCII output in tests/net/utils/src/main.c. There are more matches in ./ext, but that directory was excluded.