### PR TITLE
dts: Fix warning related to invalid alias name

### DIFF
--- a/boards/arm/hexiwear_k64/hexiwear_k64.dts
+++ b/boards/arm/hexiwear_k64/hexiwear_k64.dts
@@ -34,7 +34,7 @@
 		pwm-led0 = &green_pwm_led;
 		red-pwm-led = &red_pwm_led;
 		green-pwm-led = &green_pwm_led;
-		blue_pwm-led = &blue_pwm_led;
+		blue-pwm-led = &blue_pwm_led;
 	};
 
 	chosen {

--- a/boards/nios2/qemu_nios2/qemu_nios2.dts
+++ b/boards/nios2/qemu_nios2/qemu_nios2.dts
@@ -7,8 +7,8 @@
 	compatible = "qemu,nios2";
 
 	aliases {
-		uart_0 = &jtag_uart;
-		uart_1 = &ns16550_uart;
+		uart-0 = &jtag_uart;
+		uart-1 = &ns16550_uart;
 	};
 
 	chosen {


### PR DESCRIPTION
Aliases are not suppose to use '_', so replace with '-'.

Signed-off-by: Kumar Gala <kumar.gala@linaro.org>