### PR TITLE
kernel: Fix type of Z_EXC_HANDLE

### DIFF
--- a/include/exc_handle.h
+++ b/include/exc_handle.h
@@ -35,11 +35,11 @@ struct z_exc_handle {
 };
 
 #define Z_EXC_HANDLE(name) \
-	{ &name ## _fault_start, &name ## _fault_end, &name ## _fixup }
+	{ name ## _fault_start, name ## _fault_end, name ## _fixup }
 
-#define Z_EXC_DECLARE(name) \
-	extern void (*name ## _fault_start)(void); \
-	extern void (*name ## _fault_end)(void); \
-	extern void (*name ## _fixup)(void)
+#define Z_EXC_DECLARE(name)          \
+	void name ## _fault_start(void); \
+	void name ## _fault_end(void);   \
+	void name ## _fixup(void)
 
 #endif /* ZEPHYR_INCLUDE_EXC_HANDLE_H_ */


### PR DESCRIPTION
The type of Z_EXC_HANDLE was incorrectly declared, this was causing
the compiler to make incorrect inferences about what could be in
exc_handle and caused a bug in fault.c.

To get more specific ...

An exception handler consists of three void pointers, or function
pointers. The function pointers point to functions. An example of one
such function is 'z_arch_user_string_nlen_fault_start' From
userspace.S.

The correct way of initalizing a function pointer from a function
declared in another source file looks like this:

void external_defined_function(void);

{
   void * internal_initialized_function_ptr = external_defined_function;
}

But EXC_HANDLER is not doing this. Instead it does this:

extern void (*external_defined_function)(void);

{
  void * internal_initialized_function_ptr = &external_defined_function;
}

The declaration here is wrong. It declares that externally, there is
stored a function pointer somewhere. Which is not true. There does not
exist a function pointer anywhere. But this doesn't matter, because we
don't actually de-reference the function pointer to find the address
of the function, but instead we take the address of the function
pointer.

Taking the address of the function pointer to find the address of a
function is wrong, one should de-reference function pointers to find
function addresses. Luckily, these two bugs have been cancelling each
other out, until recently.

This patch corrects the type used.

Signed-off-by: Sebastian Bøe <sebastian.boe@nordicsemi.no>