### PR TITLE
shell: Add initial log level for rtt and uart backends

### DIFF
--- a/subsys/shell/Kconfig.backends
+++ b/subsys/shell/Kconfig.backends
@@ -22,14 +22,14 @@ config SHELL_BACKEND_SERIAL
 	help
 	  Enable serial backends.
 
+if SHELL_BACKEND_SERIAL
+
 # Internal config to enable UART interrupts if supported.
 config SHELL_BACKEND_SERIAL_FORCE_INTERRUPTS
 	bool
 	default y
 	depends on SERIAL_SUPPORT_INTERRUPT
 	imply UART_INTERRUPT_DRIVEN
-
-if SHELL_BACKEND_SERIAL
 
 config SHELL_BACKEND_SERIAL_TX_RING_BUFFER_SIZE
 	int "Set TX ring buffer size"
@@ -56,13 +56,84 @@ config SHELL_BACKEND_SERIAL_RX_POLL_PERIOD
 	help
 	  Determines how often UART is polled for RX byte.
 
+choice
+	prompt "Initial log level limit"
+	default SHELL_BACKEND_SERIAL_LOG_LEVEL_DEFAULT
+
+config SHELL_BACKEND_SERIAL_LOG_LEVEL_DEFAULT
+	bool "System limit (LOG_MAX_LEVEL)"
+
+config SHELL_BACKEND_SERIAL_LOG_LEVEL_DBG
+	bool "Debug"
+
+config SHELL_BACKEND_SERIAL_LOG_LEVEL_INF
+	bool "Info"
+
+config SHELL_BACKEND_SERIAL_LOG_LEVEL_WRN
+	bool "Warning"
+
+config SHELL_BACKEND_SERIAL_LOG_LEVEL_ERR
+	bool "Error"
+
+config SHELL_BACKEND_SERIAL_LOG_LEVEL_NONE
+	bool "None"
+
+endchoice
+
+config SHELL_BACKEND_SERIAL_LOG_LEVEL
+	int
+	default 0 if SHELL_BACKEND_SERIAL_LOG_LEVEL_NONE
+	default 1 if SHELL_BACKEND_SERIAL_LOG_LEVEL_ERR
+	default 2 if SHELL_BACKEND_SERIAL_LOG_LEVEL_WRN
+	default 3 if SHELL_BACKEND_SERIAL_LOG_LEVEL_INF
+	default 4 if SHELL_BACKEND_SERIAL_LOG_LEVEL_DBG
+	default 5 if SHELL_BACKEND_SERIAL_LOG_LEVEL_DEFAULT
+
 endif #SHELL_BACKEND_SERIAL
 
 config SHELL_BACKEND_RTT
 	bool "Enable RTT backend."
+	select USE_SEGGER_RTT
 	select RTT_CONSOLE
 	help
 	  Enable RTT backend.
+
+if SHELL_BACKEND_RTT
+
+choice
+	prompt "Initial log level limit"
+	default SHELL_BACKEND_RTT_LOG_LEVEL_DEFAULT
+
+config SHELL_BACKEND_RTT_LOG_LEVEL_DEFAULT
+	bool "System limit (LOG_MAX_LEVEL)"
+
+config SHELL_BACKEND_RTT_LOG_LEVEL_DBG
+	bool "Debug"
+
+config SHELL_BACKEND_RTT_LOG_LEVEL_INF
+	bool "Info"
+
+config SHELL_BACKEND_RTT_LOG_LEVEL_WRN
+	bool "Warning"
+
+config SHELL_BACKEND_RTT_LOG_LEVEL_ERR
+	bool "Error"
+
+config SHELL_BACKEND_RTT_LOG_LEVEL_NONE
+	bool "None"
+
+endchoice
+
+config SHELL_BACKEND_RTT_LOG_LEVEL
+	int
+	default 0 if SHELL_BACKEND_RTT_LOG_LEVEL_NONE
+	default 1 if SHELL_BACKEND_RTT_LOG_LEVEL_ERR
+	default 2 if SHELL_BACKEND_RTT_LOG_LEVEL_WRN
+	default 3 if SHELL_BACKEND_RTT_LOG_LEVEL_INF
+	default 4 if SHELL_BACKEND_RTT_LOG_LEVEL_DBG
+	default 5 if SHELL_BACKEND_RTT_LOG_LEVEL_DEFAULT
+
+endif #SHELL_BACKEND_RTT
 
 config SHELL_BACKEND_DUMMY
 	bool "Enable dummy backend."

--- a/subsys/shell/shell_rtt.c
+++ b/subsys/shell/shell_rtt.c
@@ -25,7 +25,8 @@ static void shell_rtt_rx_process(struct shell_rtt *sh_rtt)
 
 		if (count > 0) {
 			sh_rtt->rx_cnt = count;
-			sh_rtt->handler(SHELL_TRANSPORT_EVT_RX_RDY, sh_rtt->context);
+			sh_rtt->handler(SHELL_TRANSPORT_EVT_RX_RDY,
+					sh_rtt->context);
 		}
 
 		k_sleep(K_MSEC(10));
@@ -102,8 +103,11 @@ const struct shell_transport_api shell_rtt_transport_api = {
 static int enable_shell_rtt(struct device *arg)
 {
 	ARG_UNUSED(arg);
+	bool log_backend = CONFIG_SHELL_BACKEND_RTT_LOG_LEVEL > 0;
+	u32_t level = (CONFIG_SHELL_BACKEND_RTT_LOG_LEVEL > LOG_LEVEL_DBG) ?
+		      CONFIG_LOG_MAX_LEVEL : CONFIG_SHELL_BACKEND_RTT_LOG_LEVEL;
 
-	shell_init(&rtt_shell, NULL, false, false, LOG_LEVEL_INF);
+	shell_init(&rtt_shell, NULL, true, log_backend, level);
 
 	return 0;
 }

--- a/subsys/shell/shell_uart.c
+++ b/subsys/shell/shell_uart.c
@@ -218,7 +218,13 @@ static int enable_shell_uart(struct device *arg)
 	ARG_UNUSED(arg);
 	struct device *dev =
 			device_get_binding(CONFIG_UART_CONSOLE_ON_DEV_NAME);
-	shell_init(&uart_shell, dev, true, true, LOG_LEVEL_INF);
+	bool log_backend = CONFIG_SHELL_BACKEND_SERIAL_LOG_LEVEL > 0;
+	u32_t level =
+		(CONFIG_SHELL_BACKEND_SERIAL_LOG_LEVEL > LOG_LEVEL_DBG) ?
+		CONFIG_LOG_MAX_LEVEL : CONFIG_SHELL_BACKEND_SERIAL_LOG_LEVEL;
+
+	shell_init(&uart_shell, dev, true, log_backend, level);
+
 	return 0;
 }
 SYS_INIT(enable_shell_uart, POST_KERNEL, 0);


### PR DESCRIPTION
RTT and uart shell backends were started with fixed
log limit set to INF. Configuration has been moved
to Kconfig allowing certain level or default LOG_MAX_LEVEL.

Fixes #11417.

Signed-off-by: Krzysztof Chruscinski <krzysztof.chruscinski@nordicsemi.no>