### PR TITLE
Bluetooth: ATT: Assert if request is invalid

### DIFF
--- a/subsys/bluetooth/host/att.c
+++ b/subsys/bluetooth/host/att.c
@@ -262,6 +262,10 @@ static inline bool att_is_connected(struct bt_att *att)
 
 static int att_send_req(struct bt_att *att, struct bt_att_req *req)
 {
+	__ASSERT_NO_MSG(req);
+	__ASSERT_NO_MSG(req->func);
+	__ASSERT_NO_MSG(!att->req);
+
 	BT_DBG("req %p", req);
 
 	att->req = req;


### PR DESCRIPTION
Consider invalid if the request pointer is NULL or the callback is NULL
or there is a request ongoing. This conditions would likely lead to a
crash and most likely there is some other bug involved like for example
the application queueing the same request multiple times.

Signed-off-by: Luiz Augusto von Dentz <luiz.von.dentz@intel.com>