### PR TITLE
logging: refactor log_filter_set to set existing log level

### DIFF
--- a/include/logging/log_ctrl.h
+++ b/include/logging/log_ctrl.h
@@ -134,15 +134,18 @@ u32_t log_filter_get(struct log_backend const *const backend,
 /**
  * @brief Set filter on given source for the provided backend.
  *
- * @param backend	Backend instance.
+ * @param backend	Backend instance. NULL for all backends.
  * @param domain_id	ID of the domain.
  * @param src_id	Source (module or instance) ID.
  * @param level		Severity level.
+ *
+ * @return Actual level set which may be limited by compiled level. If filter
+ *	   was set for all backends then maximal level that was set is returned.
  */
-void log_filter_set(struct log_backend const *const backend,
-		    u32_t domain_id,
-		    u32_t src_id,
-		    u32_t level);
+u32_t log_filter_set(struct log_backend const *const backend,
+		     u32_t domain_id,
+		     u32_t src_id,
+		     u32_t level);
 
 /**
  *

--- a/subsys/logging/log_cmds.c
+++ b/subsys/logging/log_cmds.c
@@ -158,22 +158,6 @@ static int module_id_get(const char *name)
 	return -1;
 }
 
-static u32_t module_filter_set(const struct log_backend *backend,
-			       int module_id, u32_t level)
-{
-	u32_t compiled_lvl;
-
-	compiled_lvl = log_filter_get(backend, CONFIG_LOG_DOMAIN_ID,
-				      module_id, false);
-	if (level > compiled_lvl) {
-		level = compiled_lvl;
-	}
-
-	log_filter_set(backend, CONFIG_LOG_DOMAIN_ID, module_id, level);
-
-	return level;
-}
-
 static void filters_set(const struct shell *shell,
 			const struct log_backend *backend,
 			size_t argc, char **argv, u32_t level)
@@ -190,7 +174,9 @@ static void filters_set(const struct shell *shell,
 	for (i = 0; i < cnt; i++) {
 		id = all ? i : module_id_get(argv[i]);
 		if (id >= 0) {
-			u32_t set_lvl = module_filter_set(backend, id, level);
+			u32_t set_lvl = log_filter_set(backend,
+						       CONFIG_LOG_DOMAIN_ID,
+						       id, level);
 
 			if (set_lvl != level) {
 				const char *name;

--- a/subsys/logging/log_core.c
+++ b/subsys/logging/log_core.c
@@ -446,10 +446,10 @@ static u32_t max_filter_get(u32_t filters)
 	return max_filter;
 }
 
-void log_filter_set(struct log_backend const *const backend,
-		    u32_t domain_id,
-		    u32_t src_id,
-		    u32_t level)
+u32_t log_filter_set(struct log_backend const *const backend,
+		     u32_t domain_id,
+		     u32_t src_id,
+		     u32_t level)
 {
 	assert(src_id < log_sources_count());
 
@@ -460,13 +460,23 @@ void log_filter_set(struct log_backend const *const backend,
 
 		if (backend == NULL) {
 			struct log_backend const *backend;
+			u32_t max = 0;
+			u32_t current;
 
 			for (int i = 0; i < log_backend_count_get(); i++) {
 				backend = log_backend_get(i);
-				log_filter_set(backend, domain_id,
-					       src_id, level);
+				current = log_filter_set(backend, domain_id,
+							 src_id, level);
+				max = max(current, max);
 			}
+
+			level = max;
 		} else {
+			u32_t max = log_filter_get(backend, domain_id,
+						   src_id, false);
+
+			level = min(level, max);
+
 			LOG_FILTER_SLOT_SET(filters,
 					    log_backend_id_get(backend),
 					    level);
@@ -481,6 +491,8 @@ void log_filter_set(struct log_backend const *const backend,
 					    new_aggr_filter);
 		}
 	}
+
+	return level;
 }
 
 static void backend_filter_set(struct log_backend const *const backend,


### PR DESCRIPTION
Modified log_filter_set function to limit level if requested
level is not compiled in. Additionally, extended function to
return actually set level. Removed redundant code from log_cmds.

Change fixes shell log backend initialization which was setting
log levels without taking into account compiled in limits
(like `log enable` command was doing).

Signed-off-by: Krzysztof Chruscinski <krzysztof.chruscinski@nordicsemi.no>