### PR TITLE
cmake: Set PYTHON_EXECUTABLE env var with kconfig

### DIFF
--- a/cmake/kconfig.cmake
+++ b/cmake/kconfig.cmake
@@ -23,6 +23,7 @@ endif()
 set(ENV{srctree}            ${ZEPHYR_BASE})
 set(ENV{KERNELVERSION}      ${KERNELVERSION})
 set(ENV{KCONFIG_CONFIG}     ${DOTCONFIG})
+set(ENV{PYTHON_EXECUTABLE} ${PYTHON_EXECUTABLE})
 
 # Set environment variables so that Kconfig can prune Kconfig source
 # files for other architectures
@@ -33,6 +34,7 @@ set(ENV{SOC_DIR}   ${SOC_DIR})
 add_custom_target(
   menuconfig
   ${CMAKE_COMMAND} -E env
+  PYTHON_EXECUTABLE=${PYTHON_EXECUTABLE}
   srctree=${ZEPHYR_BASE}
   KERNELVERSION=${KERNELVERSION}
   KCONFIG_CONFIG=${DOTCONFIG}


### PR DESCRIPTION
In order to be able to invoke Python from Kconfig files,
set the path to the Python executable (which can be python,
python3, py -3, etc) as an environment variable so that
Kconfig shell invocations can use it like:

```
config MY_OPTION
       string "My option string"
       default "$(shell,$(PYTHON_EXECUTABLE) \
	          $(ZEPHYR_BASE)\scripts\script.py)"
```

Signed-off-by: Carles Cufi <carles.cufi@nordicsemi.no>