### PR TITLE
drivers: wdog: Update CMSDK Wdog driver

### DIFF
--- a/drivers/watchdog/wdog_cmsdk_apb.c
+++ b/drivers/watchdog/wdog_cmsdk_apb.c
@@ -64,9 +64,9 @@ struct device *wdog_r;
 
 /* watchdog reload value in sec */
 static unsigned int reload_s = CMSDK_APB_WDOG_RELOAD;
-static unsigned int mode;
+static u8_t flags;
 
-static void (*user_cb)(struct device *dev);
+static void (*user_cb)(struct device *dev, int channel_id);
 
 static void wdog_cmsdk_apb_unlock(struct device *dev)
 {
@@ -77,14 +77,17 @@ static void wdog_cmsdk_apb_unlock(struct device *dev)
 	wdog->lock = CMSDK_APB_WDOG_UNLOCK_VALUE;
 }
 
-static void wdog_cmsdk_apb_enable(struct device *dev)
+static int wdog_cmsdk_apb_setup(struct device *dev, u8_t options)
 {
 	volatile struct wdog_cmsdk_apb *wdog = WDOG_STRUCT;
 
 	ARG_UNUSED(dev);
+	ARG_UNUSED(options);
 
 	/* Start the watchdog counter with INTEN bit */
 	wdog->ctrl = (CMSDK_APB_WDOG_CTRL_RESEN | CMSDK_APB_WDOG_CTRL_INTEN);
+
+	return 0;
 }
 
 static int wdog_cmsdk_apb_disable(struct device *dev)
@@ -99,55 +102,46 @@ static int wdog_cmsdk_apb_disable(struct device *dev)
 	return 0;
 }
 
-static int wdog_cmsdk_apb_set_config(struct device *dev,
-				     struct wdt_config *config)
+static int wdog_cmsdk_apb_install_timeout(struct device *dev,
+					  const struct wdt_timeout_cfg *config)
 {
 	volatile struct wdog_cmsdk_apb *wdog = WDOG_STRUCT;
 
 	ARG_UNUSED(dev);
 
 	/* Reload value */
-	reload_s = config->timeout * CONFIG_SYS_CLOCK_HW_CYCLES_PER_SEC;
-	mode = config->mode;
+	reload_s = config->window.max * CONFIG_SYS_CLOCK_HW_CYCLES_PER_SEC;
+	flags = config->flags;
 
 	wdog->load = reload_s;
 
 	/* Configure only the callback */
-	user_cb = config->interrupt_fn;
+	user_cb = config->callback;
 
 	return 0;
 }
 
-static void wdog_cmsdk_apb_get_config(struct device *dev,
-				      struct wdt_config *config)
-{
-	ARG_UNUSED(dev);
-
-	/* Return stored configuration */
-	config->timeout = reload_s / CONFIG_SYS_CLOCK_HW_CYCLES_PER_SEC;
-	config->mode = mode;
-	config->interrupt_fn = user_cb;
-}
-
-static void wdog_cmsdk_apb_reload(struct device *dev)
+static int wdog_cmsdk_apb_feed(struct device *dev, int channel_id)
 {
 	volatile struct wdog_cmsdk_apb *wdog = WDOG_STRUCT;
 
 	ARG_UNUSED(dev);
+	ARG_UNUSED(channel_id);
 
 	/* Clear the interrupt */
 	wdog->intclr = CMSDK_APB_WDOG_INTCLR;
 
 	/* Reload */
 	wdog->load = reload_s;
+
+	return 0;
 }
 
 static const struct wdt_driver_api wdog_cmsdk_apb_api = {
-	.enable = wdog_cmsdk_apb_enable,
+	.setup = wdog_cmsdk_apb_setup,
 	.disable = wdog_cmsdk_apb_disable,
-	.get_config = wdog_cmsdk_apb_get_config,
-	.set_config = wdog_cmsdk_apb_set_config,
-	.reload = wdog_cmsdk_apb_reload,
+	.install_timeout = wdog_cmsdk_apb_install_timeout,
+	.feed = wdog_cmsdk_apb_feed,
 };
 
 #ifdef CONFIG_RUNTIME_NMI
@@ -172,7 +166,7 @@ static void wdog_cmsdk_apb_isr(void)
 		sys_reboot(0);
 	} else {
 		if (user_cb != NULL) {
-			user_cb(wdog_r);
+			user_cb(wdog_r, 0);
 		}
 	}
 }


### PR DESCRIPTION
The commit 0c2ef4ea3dbff2a7746dddd49df6fb0842209382 "drivers:
watchdog: Watchdog API redesign" introduced an API redesign for the
watchdog drivers compliant with Zephyr.

This patch updated the CMSDK Watchdog driver to be compliant with the
new API.

Signed-off-by: Vincenzo Frascino <vincenzo.frascino@linaro.org>