### PR TITLE
dts: atmel: samd: Fix reg address for NVM flash controller

### DIFF
--- a/dts/arm/atmel/samd.dtsi
+++ b/dts/arm/atmel/samd.dtsi
@@ -29,7 +29,7 @@
 		nvmctrl: nvmctrl@41004000  {
 			compatible = "atmel,sam0-nvmctrl";
 			label = "FLASH_CTRL";
-			reg = <0x40022000 0x22>;
+			reg = <0x41004000 0x22>;
 			interrupts = <5 0>;
 
 			#address-cells = <1>;


### PR DESCRIPTION
dtc was producing this warning when we build on SAMD SoCs:
	Warning (simple_bus_reg): /soc/nvmctrl@41004000:
	simple-bus unit address format error, expected "40022000"

The reg addr isn't used by the flash_sam0.c driver so we wouldn't notice
this issue.  Looking at the atmel HAL we see:

#define NVMCTRL           ((Nvmctrl  *)0x41004000UL) 

So that provides confirmation of what the reg addr should be.

Signed-off-by: Kumar Gala <kumar.gala@linaro.org>