### PR TITLE
dts: riscv: pulpino: Fix warning for itim unit address

### DIFF
--- a/dts/riscv32/pulpino.dtsi
+++ b/dts/riscv32/pulpino.dtsi
@@ -25,7 +25,7 @@
 		compatible = "pulp,pulpino-soc", "simple-bus";
 		ranges;
 
-		itim: itim@8000000 {
+		itim: itim@0 {
 			compatible = "pulp,pulpino0itim";
 			reg = <0x0 0x8000>;
 		};


### PR DESCRIPTION
dtc produces the following warning:

Warning (simple_bus_reg): /soc/itim@8000000: simple-bus unit address
format error, expected "0"

We had the wrong unit address in the dtsi file, should be 0.

Signed-off-by: Kumar Gala <kumar.gala@linaro.org>