### PR TITLE
boards: cy8ckit_062_wifi_bt_m{0,4}: Add OpenOCD support for flashing

### DIFF
--- a/boards/arm/cy8ckit_062_wifi_bt_m0/board.cmake
+++ b/boards/arm/cy8ckit_062_wifi_bt_m0/board.cmake
@@ -4,6 +4,7 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 
+include(${ZEPHYR_BASE}/boards/common/openocd.board.cmake)
 include(${ZEPHYR_BASE}/boards/common/jlink.board.cmake)
 
 set(CY8C6247BZI_D54)

--- a/boards/arm/cy8ckit_062_wifi_bt_m0/support/openocd.cfg
+++ b/boards/arm/cy8ckit_062_wifi_bt_m0/support/openocd.cfg
@@ -1,0 +1,17 @@
+#
+# Copyright (c) 2018 Linaro Limited.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+if {[info exists env(OPENOCD_INTERFACE)]} {
+        set INTERFACE $env(OPENOCD_INTERFACE)
+} else {
+        # By default connect over Debug USB port
+        set INTERFACE "cmsis-dap"
+}
+
+source [find interface/$INTERFACE.cfg]
+
+transport select swd
+
+source [find target/psoc6.cfg]

--- a/boards/arm/cy8ckit_062_wifi_bt_m4/board.cmake
+++ b/boards/arm/cy8ckit_062_wifi_bt_m4/board.cmake
@@ -4,4 +4,5 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 
+include(${ZEPHYR_BASE}/boards/common/openocd.board.cmake)
 include(${ZEPHYR_BASE}/boards/common/jlink.board.cmake)

--- a/boards/arm/cy8ckit_062_wifi_bt_m4/support/openocd.cfg
+++ b/boards/arm/cy8ckit_062_wifi_bt_m4/support/openocd.cfg
@@ -1,0 +1,17 @@
+#
+# Copyright (c) 2018 Linaro Limited.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+if {[info exists env(OPENOCD_INTERFACE)]} {
+        set INTERFACE $env(OPENOCD_INTERFACE)
+} else {
+        # By default connect over Debug USB port
+        set INTERFACE "cmsis-dap"
+}
+
+source [find interface/$INTERFACE.cfg]
+
+transport select swd
+
+source [find target/psoc6.cfg]


### PR DESCRIPTION
The 0.9.5 SDK has support for the Cypress PSoC6 family.  Add ablilty to
flash with openocd.  I've only tested flashing hello_world on the m0.

Signed-off-by: Kumar Gala <kumar.gala@linaro.org>