### PR TITLE
[RFC] Add PF_CAN protocol for socket CAN

### DIFF
--- a/include/net/net_context.h
+++ b/include/net/net_context.h
@@ -27,6 +27,8 @@
 #include <net/net_if.h>
 #include <net/net_stats.h>
 
+#include <net/socket_can.h>
+
 #ifdef __cplusplus
 extern "C" {
 #endif
@@ -287,7 +289,7 @@ struct net_context {
 	u8_t iface;
 
 	/** Flags for the context */
-	u8_t flags;
+	u16_t flags;
 };
 
 static inline bool net_context_is_used(struct net_context *context)
@@ -354,6 +356,11 @@ static inline sa_family_t net_context_get_family(struct net_context *context)
 		return AF_INET6;
 	}
 
+	if (IS_ENABLED(CONFIG_SOCKET_CAN) &&
+	    (context->flags & CAN_CONTEXT_FAMILY)) {
+		return AF_CAN;
+	}
+
 	return AF_INET;
 }
 
@@ -373,6 +380,12 @@ static inline void net_context_set_family(struct net_context *context,
 
 	if (family == AF_INET6) {
 		context->flags |= NET_CONTEXT_FAMILY;
+		return;
+	}
+
+	if (IS_ENABLED(CONFIG_SOCKET_CAN) &&
+	    (family == AF_CAN)) {
+		context->flags |= CAN_CONTEXT_FAMILY;
 		return;
 	}
 
@@ -398,6 +411,11 @@ enum net_sock_type net_context_get_type(struct net_context *context)
 		return SOCK_STREAM;
 	}
 
+	if (IS_ENABLED(CONFIG_SOCKET_CAN) &&
+	    (context->flags & CAN_CONTEXT_FAMILY)) {
+		return SOCK_RAW;
+	}
+
 	return SOCK_DGRAM;
 }
 
@@ -417,6 +435,12 @@ static inline void net_context_set_type(struct net_context *context,
 
 	if (type == SOCK_STREAM) {
 		context->flags |= NET_CONTEXT_TYPE;
+		return;
+	}
+
+	if (IS_ENABLED(CONFIG_SOCKET_CAN) &&
+	    (type == SOCK_RAW)) {
+		context->flags |= CAN_CONTEXT_TYPE;
 		return;
 	}
 
@@ -442,6 +466,11 @@ enum net_ip_protocol net_context_get_ip_proto(struct net_context *context)
 		return IPPROTO_TCP;
 	}
 
+	if (IS_ENABLED(CONFIG_SOCKET_CAN) &&
+	    (context->flags & CAN_CONTEXT_PROTO)) {
+		return CAN_RAW;
+	}
+
 	return IPPROTO_UDP;
 }
 
@@ -461,6 +490,12 @@ static inline void net_context_set_ip_proto(struct net_context *context,
 
 	if (ip_proto == IPPROTO_TCP) {
 		context->flags |= NET_CONTEXT_PROTO;
+		return;
+	}
+
+	if (IS_ENABLED(CONFIG_SOCKET_CAN) &&
+	    (ip_proto == CAN_RAW)) {
+		context->flags |= CAN_CONTEXT_PROTO;
 		return;
 	}
 

--- a/include/net/net_ip.h
+++ b/include/net/net_ip.h
@@ -40,11 +40,13 @@ extern "C" {
 #define PF_UNSPEC	0	/* Unspecified.  */
 #define PF_INET		2	/* IP protocol family.  */
 #define PF_INET6	10	/* IP version 6.  */
+#define PF_CAN		13	/* CAN protocol family */
 
 /** Address families.  */
 #define AF_UNSPEC	PF_UNSPEC
 #define AF_INET		PF_INET
 #define AF_INET6	PF_INET6
+#define AF_CAN		PF_CAN	/* CAN address family */
 
 /** Protocol numbers from IANA */
 enum net_ip_protocol {
@@ -52,6 +54,7 @@ enum net_ip_protocol {
 	IPPROTO_TCP = 6,
 	IPPROTO_UDP = 17,
 	IPPROTO_ICMPV6 = 58,
+	CAN_RAW = 252,
 };
 
 /* Protocol numbers for TLS protocols */
@@ -67,6 +70,7 @@ enum net_ip_protocol_secure {
 enum net_sock_type {
 	SOCK_STREAM = 1,
 	SOCK_DGRAM,
+	SOCK_RAW,
 };
 
 #define ntohs(x) sys_be16_to_cpu(x)

--- a/include/net/net_l2.h
+++ b/include/net/net_l2.h
@@ -103,6 +103,12 @@ NET_L2_DECLARE_PUBLIC(BLUETOOTH_L2);
 NET_L2_DECLARE_PUBLIC(OPENTHREAD_L2);
 #endif /* CONFIG_NET_L2_OPENTHREAD */
 
+#ifdef CONFIG_NET_L2_CAN
+#define CAN_L2  CAN
+#define CAN_L2_CTX_TYPE  void*
+NET_L2_DECLARE_PUBLIC(CAN_L2);
+#endif /* CONFIG_NET_L2_CAN */
+
 #define NET_L2_INIT(_name, _recv_fn, _send_fn, _reserve_fn, _enable_fn, \
 		    _get_flags_fn)					\
 	const struct net_l2 (NET_L2_GET_NAME(_name)) __used		\

--- a/include/net/socket.h
+++ b/include/net/socket.h
@@ -52,6 +52,10 @@ struct zsock_pollfd {
  */
 #define SOL_TLS 282
 
+/* Protocl level of CAN */
+#define SOL_CAN_BASE 100
+#define SOL_CAN_RAW (SOL_CAN_BASE + CAN_RAW)
+
 /* Socket options for TLS */
 
 /* Socket option to select TLS credentials to use. It accepts and returns an
@@ -93,6 +97,16 @@ struct zsock_pollfd {
  * 0 - client,
  * 1 - server.
  */
+
+/* Socket optaions for CAN */
+
+/* Get ifindex for corresponding socket*/
+#define SOCKET_CAN_GET_IF_INDEX 6
+/* Confifgure CAN controller operation mode defined in can.h */
+#define SOCKET_CAN_SET_MODE 7
+/* Configure CAN filter for acceptance filtering */
+#define SOCKET_CAN_SET_FILTER 8
+
 #define TLS_DTLS_ROLE 6
 
 struct zsock_addrinfo {

--- a/include/net/socket_can.h
+++ b/include/net/socket_can.h
@@ -1,0 +1,158 @@
+/*
+ * Copyright (c) 2018 Intel Corporation.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef _SOCKET_CAN_H_
+#define _SOCKET_CAN_H_
+
+#include <device.h>
+#include <net/net_ip.h>
+#include <can.h>
+#include <zephyr/types.h>
+
+/** Max length of socket packet */
+#define CAN_NET_MTU (72)
+
+/**  Protocol family of socket can connection */
+#define CAN_CONTEXT_FAMILY BIT(8)
+
+/**  Context type of socket can connection */
+#define CAN_CONTEXT_TYPE BIT(9)
+
+/**  Context proto for socket can connection */
+#define CAN_CONTEXT_PROTO BIT(10)
+
+/**
+ * @brief socket addr structure for AF_CAN protocol
+ *
+ * Socket address structure for AF_CAN protocol family
+ *
+ */
+struct sockaddr_can {
+	/** protocol family for socket can */
+	sa_family_t can_family;
+	/** net_if interface associated with socket */
+	u8_t can_ifindex;
+};
+
+/**
+ * @brief check matched CAN filter for incoming CAN message.
+ *
+ * This routine matches id with configured filters id and return true or false.
+ * *
+ * @param dev       Pointer to the device structure for the driver instance.
+ * @param pkt       incoming net_pkt
+ *
+ * @retval 1 if filter matched otherwise 0.
+ */
+typedef int (*socket_can_check_filter_matched_t)(struct device *dev,
+						 struct net_pkt *pkt);
+
+/**
+ * @brief configure filter for accpetance filter.
+ *
+ * This routine configure can filter and register rx callback.
+ * *
+ * @param dev       Pointer to the device structure for the driver instance.
+ * @param filter    can_filter structure
+ *
+ * @retval return < 0 in case of error and 0 for success.
+ */
+typedef int (*socket_can_config_filter_t)(struct device *dev,
+					  struct can_filter *filter);
+
+int socket_can_get_opt(struct net_context *context, int optname,
+		       void *optval, socklen_t *optlen);
+int socket_can_set_opt(struct net_context *context, int optname,
+		       const void *optval, socklen_t optlen);
+
+
+
+/**
+ * @brief socket can driver api structure
+ * Socket CAN driver apis for iface interface functions and ioctl call.
+ *
+ */
+struct socket_can_driver_api_t {
+	/** iface interface for socket apis to send and init function*/
+	struct net_if_api iface_api;
+	/** check matching filter for loopback messages */
+	socket_can_check_filter_matched_t check_matched_filter;
+	/** configure filter with rx callback */
+	socket_can_config_filter_t config_filter;
+};
+
+/**
+ * @brief socket can context structure
+ *
+ * socket can driver specific structure.
+ *
+ */
+struct socket_can_context {
+	/** id of CAN instance */
+	u32_t id;
+	/** iface interface reference structure*/
+	struct net_if *iface;
+	/** can device structure reference */
+	struct device *can_dev;
+};
+
+/**
+ * @brief socket can mode structure
+ *
+ * This structure will be passed via setSocketOpt and configure can controller
+ * operation mode as well as baud rate
+ */
+struct socket_can_mode {
+	enum can_mode op_mode;
+	u32_t baud_rate;
+};
+
+__syscall int socket_can_check_filter_matched(struct device *dev,
+					      struct net_pkt *pkt);
+
+static inline int _impl_socket_can_check_filter_matched(struct device *dev,
+							struct net_pkt *pkt)
+{
+	const struct socket_can_driver_api_t *api = NULL;
+	int result = 0;
+
+	if (pkt == NULL) {
+		goto err;
+	}
+
+	api = dev->driver_api;
+	if (api && api->check_matched_filter) {
+		result = api->check_matched_filter(dev, pkt);
+	}
+err:
+	return result;
+}
+
+__syscall int socket_can_config_filter(struct device *dev,
+				       struct can_filter *filter);
+
+static inline int _impl_socket_can_config_filter(struct device *dev,
+						 struct can_filter *filter)
+{
+	const struct socket_can_driver_api_t *api = NULL;
+	int res = 0;
+
+	if (filter == NULL) {
+		res = -EBADF;
+		goto err;
+	}
+
+	api = dev->driver_api;
+	if (api && api->config_filter) {
+		res = api->config_filter(dev, filter);
+	}
+err:
+	return res;
+}
+
+#include <syscalls/socket_can.h>
+
+#endif /*_SOCKET_CAN_H_ */

--- a/subsys/net/ip/CMakeLists.txt
+++ b/subsys/net/ip/CMakeLists.txt
@@ -31,6 +31,7 @@ zephyr_library_sources_ifdef(CONFIG_NET_TCP          connection.c tcp.c)
 zephyr_library_sources_ifdef(CONFIG_NET_TRICKLE      trickle.c)
 zephyr_library_sources_ifdef(CONFIG_NET_UDP          connection.c udp.c)
 zephyr_library_sources_ifdef(CONFIG_NET_PROMISCUOUS_MODE promiscuous.c)
+zephyr_library_sources_ifdef(CONFIG_SOCKET_CAN       connection.c)
 
 if(CONFIG_NET_SHELL)
 zephyr_library_include_directories(. ${ZEPHYR_BASE}/subsys/net/l2)

--- a/subsys/net/ip/connection.h
+++ b/subsys/net/ip/connection.h
@@ -21,6 +21,8 @@
 #include <net/net_ip.h>
 #include <net/net_pkt.h>
 
+#include <can.h>
+
 #ifdef __cplusplus
 extern "C" {
 #endif
@@ -163,6 +165,17 @@ typedef void (*net_conn_foreach_cb_t)(struct net_conn *conn, void *user_data);
 void net_conn_foreach(net_conn_foreach_cb_t cb, void *user_data);
 
 void net_conn_init(void);
+
+#if defined(CONFIG_SOCKET_CAN)
+/**
+ * @brief Trigger connection callback for sending a can packet and loopback.
+ *
+ * @param pkt Pointer to net_pkt structure
+ * @param loopback boolean for loopback transmission
+ * @return net_verdict NET_OK is callback triggered else NET_DROP.
+ */
+enum net_verdict can_conn_input(struct net_pkt *pkt, bool loopback);
+#endif
 
 #ifdef __cplusplus
 }

--- a/subsys/net/ip/utils.c
+++ b/subsys/net/ip/utils.c
@@ -43,6 +43,10 @@ const char *net_proto2str(enum net_ip_protocol proto)
 		return "UDP";
 	case IPPROTO_ICMPV6:
 		return "ICMPv6";
+#if defined(CONFIG_SOCKET_CAN)
+	case CAN_RAW:
+		return "CAN_RAW";
+#endif
 	default:
 		break;
 	}

--- a/subsys/net/l2/CMakeLists.txt
+++ b/subsys/net/l2/CMakeLists.txt
@@ -21,3 +21,7 @@ endif()
 if(CONFIG_NET_L2_WIFI_MGMT OR CONFIG_NET_L2_WIFI_SHELL)
   add_subdirectory(wifi)
 endif()
+
+if(CONFIG_NET_L2_CAN)
+  add_subdirectory(can)
+endif()

--- a/subsys/net/l2/Kconfig
+++ b/subsys/net/l2/Kconfig
@@ -98,4 +98,10 @@ config NET_L2_WIFI_SHELL
 	  This can be used for controlling WiFi through the console via
 	  exposing a shell module named "wifi".
 
+config NET_L2_CAN
+	bool "Enable L2 layer for CAN"
+	default y if SOCKET_CAN
+	depends on SOCKET_CAN
+	help
+		Add support l2 layer for CAN.
 endmenu

--- a/subsys/net/l2/can/CMakeLists.txt
+++ b/subsys/net/l2/can/CMakeLists.txt
@@ -1,0 +1,4 @@
+zephyr_library()
+zephyr_library_include_directories(. ${ZEPHYR_BASE}/subsys/net/ip)
+
+zephyr_library_sources_ifdef(CONFIG_NET_L2_CAN can_l2.c)

--- a/subsys/net/l2/can/can_l2.c
+++ b/subsys/net/l2/can/can_l2.c
@@ -1,0 +1,40 @@
+/*
+ * Copyright (c) 2016 Intel Corporation
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <device.h>
+#include <misc/printk.h>
+#include <kernel.h>
+#include <net/net_ip.h>
+#include <net/net_if.h>
+#include <net/buf.h>
+#include <net/net_pkt.h>
+#include <net/net_context.h>
+#include <net/net_l2.h>
+#include <zephyr.h>
+#include <device.h>
+
+enum net_verdict can_l2_recv(struct net_if *iface,
+			     struct net_pkt *pkt)
+{
+	return NET_CONTINUE;
+}
+
+enum net_verdict can_l2_send(struct net_if *iface,
+			     struct net_pkt *pkt)
+{
+	net_if_queue_tx(iface, pkt);
+
+	return NET_OK;
+}
+
+u16_t can_l2_reserve(struct net_if *iface, void *unused)
+{
+	ARG_UNUSED(iface);
+	ARG_UNUSED(unused);
+
+	return 0;
+}
+

--- a/subsys/net/lib/sockets/CMakeLists.txt
+++ b/subsys/net/lib/sockets/CMakeLists.txt
@@ -6,3 +6,4 @@ zephyr_sources(
 
 zephyr_sources_ifdef(CONFIG_NET_SOCKETS_SOCKOPT_TLS sockets_tls.c)
 zephyr_sources_ifdef(CONFIG_NET_SOCKETS_OFFLOAD     socket_offload.c)
+zephyr_sources_ifdef(CONFIG_SOCKET_CAN     socket_can.c)

--- a/subsys/net/lib/sockets/Kconfig
+++ b/subsys/net/lib/sockets/Kconfig
@@ -96,6 +96,13 @@ config NET_SOCKETS_OFFLOAD
 	  See NET_OFFLOAD for a more deeply integrated approach which offloads
 	  from the net_context() API within the Zephyr IP stack.
 
+config SOCKET_CAN
+	bool "Enable socket can for CAN_RAW type sockets"
+	default n
+	depends on CAN
+	help
+	  "Enable socket can"
+
 module = NET_SOCKETS
 module-dep = NET_LOG
 module-str = Log level for BSD sockets compatible API calls

--- a/subsys/net/lib/sockets/socket_can.c
+++ b/subsys/net/lib/sockets/socket_can.c
@@ -1,0 +1,237 @@
+/*
+ * Copyright (c) 2018 Intel Corporation.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#define LOG_MODULE_NAME net_sock_can
+
+#define NET_LOG_LEVEL CONFIG_NET_SOCKETS_LOG_LEVEL
+
+#include <net/net_context.h>
+#include <net/socket_can.h>
+#include <device.h>
+#include <misc/printk.h>
+#include <kernel.h>
+#include <net/net_ip.h>
+#include <net/net_if.h>
+#include <net/buf.h>
+#include <net/net_pkt.h>
+#include <net/net_l2.h>
+#include <zephyr.h>
+#include <can.h>
+#include <net/socket.h>
+
+int socket_can_get_opt(struct net_context *context, int optname,
+		       void *optval, socklen_t *optlen)
+{
+	int ret = 0;
+	struct device *dev;
+	struct net_if *iface;
+	struct socket_can_context *sock_ctx;
+
+	if (!context) {
+		ret = -EBADF;
+		goto err;
+	}
+
+	if (!optval || !optlen) {
+		ret = -EINVAL;
+		goto err;
+	}
+
+	iface = net_context_get_iface(context);
+	if (iface == NULL) {
+		ret = -EBADF;
+		goto err;
+	}
+
+	dev = net_if_get_device(iface);
+	if (dev == NULL) {
+		ret = -EBADF;
+		goto err;
+	}
+
+	sock_ctx = dev->driver_data;
+
+	switch (optname) {
+	case SOCKET_CAN_GET_IF_INDEX:
+		*((u8_t *)optval) = net_if_get_by_iface(sock_ctx->iface);
+		*optlen = sizeof(u8_t);
+		break;
+	default:
+		ret = ENOPROTOOPT;
+	}
+
+err:
+	return ret;
+
+}
+
+int socket_can_set_opt(struct net_context *context, int optname,
+		       const void *optval, socklen_t optlen)
+{
+	int ret = 0;
+	struct device *dev;
+	struct can_filter *filter;
+	struct socket_can_mode *mode;
+	struct device *can_dev;
+	struct net_if *iface;
+	struct socket_can_context *sock_ctx;
+	const struct socket_can_driver_api_t *api;
+
+	ARG_UNUSED(optlen);
+
+	if (!context) {
+		ret = -EBADF;
+		goto err;
+	}
+
+	if (!optval) {
+		ret = -EINVAL;
+		goto err;
+	}
+
+	iface = net_context_get_iface(context);
+	if (iface == NULL) {
+		ret = -EBADF;
+		goto err;
+	}
+
+	dev = net_if_get_device(iface);
+	if (dev == NULL) {
+		ret = -EBADF;
+		goto err;
+	}
+
+	sock_ctx = dev->driver_data;
+	if (sock_ctx == NULL) {
+		ret = -EBADF;
+		goto err;
+	}
+
+	can_dev = sock_ctx->can_dev;
+
+	if (can_dev == NULL) {
+		ret = -EBADF;
+		goto err;
+	}
+
+	switch (optname) {
+	case SOCKET_CAN_SET_FILTER:
+		filter = (struct can_filter *)optval;
+		api = dev->driver_api;
+		if (api == NULL) {
+			ret = -EBADF;
+			goto err;
+		}
+		if (api->config_filter) {
+			ret = api->config_filter(dev, filter);
+		} else {
+			ret = -ENOPROTOOPT;
+			goto err;
+		}
+		break;
+	case SOCKET_CAN_SET_MODE:
+		mode = (struct socket_can_mode *)optval;
+		ret = can_configure(can_dev,
+				    mode->op_mode, mode->baud_rate);
+		break;
+	default:
+		ret = -ENOPROTOOPT;
+	}
+
+err:
+	return ret;
+
+}
+
+void socket_can_iface_init(struct net_if *iface)
+{
+	struct device *dev = net_if_get_device(iface);
+	struct socket_can_context *context = dev->driver_data;
+
+	context->iface = iface;
+}
+
+static void socket_can_tx_callback(u32_t flags)
+{
+	NET_DBG("TX CALLBACK OCCURRED flags = %x", flags);
+	if (flags != CAN_TX_OK) {
+		NET_DBG("SOCKET_CAN_TRANSMISSION FAILED ERR = %d", flags);
+	}
+}
+
+int socket_can_iface_send(struct net_if *iface, struct net_pkt *pkt)
+{
+	int ret = CAN_TX_ERR;
+	struct device *dev;
+	struct socket_can_context *context;
+	struct device *can_dev;
+	struct net_buf *buf;
+	struct can_msg *msg;
+
+	if (pkt == NULL) {
+		goto err;
+	}
+	dev = net_if_get_device(iface);
+	if (dev == NULL) {
+		goto err;
+	}
+	context = dev->driver_data;
+	if (context == NULL) {
+		goto err;
+	}
+	can_dev = context->can_dev;
+
+	buf = pkt->frags;
+	if ((buf == NULL) || (buf->data == NULL)) {
+		goto err;
+	}
+	msg = (struct can_msg *)(buf->data);
+
+	ret = can_send(can_dev, msg, K_FOREVER, socket_can_tx_callback);
+err:
+	return ret;
+}
+
+bool socket_can_check_matched_id_filter(struct net_pkt *pkt)
+{
+	struct net_if *iface = NULL;
+	struct net_context *ctx = NULL;
+	struct device *dev = NULL;
+	const struct socket_can_driver_api_t *api = NULL;
+	bool result = false;
+
+	if (pkt == NULL) {
+		goto err;
+	}
+
+	ctx = net_pkt_context(pkt);
+	if (ctx == NULL) {
+		goto err;
+	}
+
+	iface = net_context_get_iface(ctx);
+	if (iface == NULL) {
+		goto err;
+	}
+
+	dev = net_if_get_device(iface);
+	if (dev == NULL) {
+		goto err;
+	}
+
+	api = dev->driver_api;
+	if (api == NULL) {
+		goto err;
+	}
+
+	if (api->check_matched_filter) {
+		result = api->check_matched_filter(dev, pkt);
+	}
+
+err:
+	return result;
+}
+


### PR DESCRIPTION
This patch adds support for PF_CAN protocol and CAN_RAW type sockets, also it adds common APIs for socket can driver and header file.
