### PR TITLE
fix bme280 temperature format and clarify preferred sensor_value representation

### DIFF
--- a/include/sensor.h
+++ b/include/sensor.h
@@ -39,11 +39,19 @@ extern "C" {
  *     -0.5: val1 =  0, val2 = -500000
  *     -1.0: val1 = -1, val2 =  0
  *     -1.5: val1 = -1, val2 = -500000
+ *
+ * Denormalized representations should be avoided:
+ *
+ *      0.5: val1 =  1, val2 = -500000
+ *     -1.5: val1 = -2, val2 =  500000
  */
 struct sensor_value {
 	/** Integer part of the value. */
 	s32_t val1;
-	/** Fractional part of the value (in one-millionth parts). */
+	/**
+	 * Fractional part of the value (in one-millionth parts). This
+	 * must have the same sign as #val1 unless #val1 is zero.
+	 */
 	s32_t val2;
 };
 

--- a/samples/sensor/bme280/src/main.c
+++ b/samples/sensor/bme280/src/main.c
@@ -8,6 +8,7 @@
 #include <device.h>
 #include <sensor.h>
 #include <stdio.h>
+#include <stdlib.h>
 
 void main(void)
 {
@@ -23,9 +24,17 @@ void main(void)
 		sensor_channel_get(dev, SENSOR_CHAN_PRESS, &press);
 		sensor_channel_get(dev, SENSOR_CHAN_HUMIDITY, &humidity);
 
-		printf("temp: %d.%06d; press: %d.%06d; humidity: %d.%06d\n",
-		      temp.val1, temp.val2, press.val1, press.val2,
-		      humidity.val1, humidity.val2);
+		const char *temp_sign = "";
+
+		/* signed value = val1 + (val2 / 1000000) */
+		if ((temp.val1 < 0) || (temp.val2 < 0)) {
+			temp_sign = "-";
+			temp.val1 = abs(temp.val1);
+			temp.val2 = abs(temp.val2);
+		}
+		printf("temp: %s%d.%06d; press: %d.%06d; humidity: %d.%06d\n",
+		       temp_sign, temp.val1, temp.val2, press.val1, press.val2,
+		       humidity.val1, humidity.val2);
 
 		k_sleep(1000);
 	}


### PR DESCRIPTION
AFAICT #6144 left open the possibility of denormalized `sensor_value` instances.  Since those weren't given as examples, I'm presuming they aren't desired.  Of the uses surveyed in #5692 only bmi160 handles denormalized values.  The first patch updates the documentation say "don't do that".  Wording can be modified, or this can be dropped, depending on intent.

The second patch fixes the handling of negative temperatures in the bme280 sample so you get `-2.250000` instead of `-2.-250000`, under the assumption the values aren't denormalized (which they won't be given the way the values are calculated).