### PR TITLE
openocd.board.cmake: Fix flash load address

### DIFF
--- a/boards/common/openocd.board.cmake
+++ b/boards/common/openocd.board.cmake
@@ -11,14 +11,11 @@ else()
   set_ifndef(OPENOCD_FLASH "flash write_image erase")
 endif()
 
-# zephyr.bin, or something else?
-set_ifndef(OPENOCD_IMAGE "${PROJECT_BINARY_DIR}/${KERNEL_BIN_NAME}")
+# zephyr.elf, or something else?
+set_ifndef(OPENOCD_IMAGE "${PROJECT_BINARY_DIR}/${KERNEL_ELF_NAME}")
 
-# CONFIG_FLASH_BASE_ADDRESS, or something else?
-set_ifndef(OPENOCD_ADDRESS "${CONFIG_FLASH_BASE_ADDRESS}")
-
-set(OPENOCD_CMD_LOAD_DEFAULT "${OPENOCD_FLASH} ${OPENOCD_IMAGE} ${OPENOCD_ADDRESS}")
-set(OPENOCD_CMD_VERIFY_DEFAULT "verify_image ${OPENOCD_IMAGE} ${OPENOCD_ADDRESS}")
+set(OPENOCD_CMD_LOAD_DEFAULT "${OPENOCD_FLASH} ${OPENOCD_IMAGE}")
+set(OPENOCD_CMD_VERIFY_DEFAULT "verify_image ${OPENOCD_IMAGE}")
 
 board_finalize_runner_args(openocd
   --cmd-load "${OPENOCD_CMD_LOAD_DEFAULT}"


### PR DESCRIPTION
'make flash' always erase the flash banks from sector 0, and flashing
the Zephyr.bin file to base address of flash even if there has a
bootloader placed on the first sector.

Users maybe want placed Zephyr to another location instead of sector
0 by adding 'zephyr,code-partition' in dts. But the openocd scripts
doesn't deal with that currently.

Fix this issue, flash Zephyr.bin to address:
CONFIG_FLASH_BASE_ADDRESS + CONFIG_FLASH_LOAD_OFFSET.

Signed-off-by: qianfan Zhao <qianfanguijin@163.com>