### PR TITLE
soc: same70: don't switch main clock if already did

### DIFF
--- a/soc/arm/atmel_sam/same70/soc.c
+++ b/soc/arm/atmel_sam/same70/soc.c
@@ -71,7 +71,7 @@ static ALWAYS_INLINE void clock_init(void)
 	 * by a previous program i.e. bootloader
 	 */
 
-	if (PMC->PMC_SR & PMC_SR_MOSCRCS) {
+	if (!(PMC->CKGR_MOR & CKGR_MOR_MOSCSEL_Msk)) {
 		/* Start the external crystal oscillator */
 		PMC->CKGR_MOR =   CKGR_MOR_KEY_PASSWD
 				/* We select maximum setup time.
@@ -100,17 +100,17 @@ static ALWAYS_INLINE void clock_init(void)
 		while (!(PMC->PMC_SR & PMC_SR_MOSCSELS)) {
 			;
 		}
+	}
 
-		/* Turn off RC OSC, not used any longer, to save power */
-		PMC->CKGR_MOR =   CKGR_MOR_KEY_PASSWD
-				| CKGR_MOR_MOSCSEL
-				| CKGR_MOR_MOSCXTST(0xFFu)
-				| CKGR_MOR_MOSCXTEN;
+	/* Turn off RC OSC, not used any longer, to save power */
+	PMC->CKGR_MOR =   CKGR_MOR_KEY_PASSWD
+			| CKGR_MOR_MOSCSEL
+			| CKGR_MOR_MOSCXTST(0xFFu)
+			| CKGR_MOR_MOSCXTEN;
 
-		/* Wait for RC OSC to be turned off */
-		while (PMC->PMC_SR & PMC_SR_MOSCRCS) {
-			;
-		}
+	/* Wait for RC OSC to be turned off */
+	while (PMC->PMC_SR & PMC_SR_MOSCRCS) {
+		;
 	}
 
 #ifdef CONFIG_SOC_ATMEL_SAME70_WAIT_MODE


### PR DESCRIPTION
Don't switch clock to external clock again if the bootloader already did.

The system will hang on if already switched main clock to external clock in bootloader (and I hadn't find sometings on the same70's datasheet about this issue).

Commit 1d8e7a5 is the first version try to solve this issue, but the commit check PMC_SR_MOSCRCS flag, that can't detect wether switched to extranel clock or not.