### PR TITLE
storage: flash_map: Make flash_map as extern

### DIFF
--- a/subsys/storage/flash_map/flash_map.c
+++ b/subsys/storage/flash_map/flash_map.c
@@ -40,7 +40,7 @@ static const struct driver_map_entry  flash_drivers_map[] = {
 #endif
 };
 
-const struct flash_area *flash_map;
+extern const struct flash_area *flash_map;
 extern const int flash_map_entries;
 static struct device *flash_dev[ARRAY_SIZE(flash_drivers_map)];
 


### PR DESCRIPTION
flash_map should be made extern in flash_map.c since it is defined
in flash_map_default.c. Not having flash_map as extern will result
in build errors.

Signed-off-by: Rajavardhan Gundi <rajavardhan.gundi@intel.com>