### PR TITLE
drivers: nrf: Fix nrf uarte fifo_fill function.

### DIFF
--- a/drivers/serial/uart_nrfx_uarte.c
+++ b/drivers/serial/uart_nrfx_uarte.c
@@ -275,6 +275,9 @@ static int uarte_nrfx_fifo_fill(struct device *dev,
 	struct uarte_nrfx_data *data = get_dev_data(dev);
 	const struct uarte_nrfx_config *config = get_dev_config(dev);
 
+	if (!nrf_uarte_event_check(uarte, NRF_UARTE_EVENT_ENDTX)) {
+		return 0;
+	}
 
 	if (len > config->tx_buff_size) {
 		len = config->tx_buff_size;


### PR DESCRIPTION
Calling fifo_fill function from uart_nrfx_uarte in the same
interrupt more than once, would break previous transmission.

Following fix adds checking if previous data was sent, and
if not, returns 0.