### PR TITLE
Added optional ETH phy thread for STM32 for link check

### DIFF
--- a/drivers/ethernet/Kconfig.stm32_hal
+++ b/drivers/ethernet/Kconfig.stm32_hal
@@ -48,6 +48,27 @@ config ETH_STM32_HAL_PHY_ADDRESS
 	help
 	  The phy address to use.
 
+config ETH_STM32_HAL_PHY_THREAD
+	bool "PHY polling thread for link status detection"
+	depends on ETH_STM32_HAL
+	default y
+	help
+	  Run a separate thread which polls the link status 
+
+config ETH_STM32_HAL_PHY_THREAD_STACK_SIZE
+	int "PHY thread stack size"
+	depends on ETH_STM32_HAL_PHY_THREAD
+	default 512
+	help
+	  PHY thread stack size
+
+config ETH_STM32_HAL_PHY_THREAD_PRIO
+	int "PHY thread priority"
+	depends on ETH_STM32_HAL_PHY_THREAD
+	default 3
+	help
+	  PHY thread priority
+
 config ETH_STM32_HAL_RANDOM_MAC
 	bool "Random MAC address"
 	depends on ETH_STM32_HAL && ENTROPY_GENERATOR

--- a/drivers/ethernet/eth_stm32_hal_priv.h
+++ b/drivers/ethernet/eth_stm32_hal_priv.h
@@ -37,6 +37,11 @@ struct eth_stm32_hal_dev_data {
 	K_THREAD_STACK_MEMBER(rx_thread_stack,
 		CONFIG_ETH_STM32_HAL_RX_THREAD_STACK_SIZE);
 	struct k_thread rx_thread;
+#if defined(CONFIG_ETH_STM32_HAL_PHY_THREAD)
+	K_THREAD_STACK_MEMBER(phy_thread_stack,
+		CONFIG_ETH_STM32_HAL_PHY_THREAD_STACK_SIZE);
+	struct k_thread phy_thread;
+#endif
 };
 
 #define DEV_CFG(dev) \

--- a/ext/hal/st/stm32cube/stm32f1xx/drivers/include/stm32f1xx_hal_eth.h
+++ b/ext/hal/st/stm32cube/stm32f1xx/drivers/include/stm32f1xx_hal_eth.h
@@ -2040,6 +2040,8 @@ void HAL_ETH_MspDeInit(ETH_HandleTypeDef *heth);
 HAL_StatusTypeDef HAL_ETH_DMATxDescListInit(ETH_HandleTypeDef *heth, ETH_DMADescTypeDef *DMATxDescTab, uint8_t *TxBuff, uint32_t TxBuffCount);
 HAL_StatusTypeDef HAL_ETH_DMARxDescListInit(ETH_HandleTypeDef *heth, ETH_DMADescTypeDef *DMARxDescTab, uint8_t *RxBuff, uint32_t RxBuffCount);
 
+HAL_StatusTypeDef HAL_ETH_CheckAutoNegotiation(ETH_HandleTypeDef *heth);
+
 /**
   * @}
   */

--- a/ext/hal/st/stm32cube/stm32f2xx/drivers/include/stm32f2xx_hal_eth.h
+++ b/ext/hal/st/stm32cube/stm32f2xx/drivers/include/stm32f2xx_hal_eth.h
@@ -2111,6 +2111,8 @@ void HAL_ETH_MspDeInit(ETH_HandleTypeDef *heth);
 HAL_StatusTypeDef HAL_ETH_DMATxDescListInit(ETH_HandleTypeDef *heth, ETH_DMADescTypeDef *DMATxDescTab, uint8_t* TxBuff, uint32_t TxBuffCount);
 HAL_StatusTypeDef HAL_ETH_DMARxDescListInit(ETH_HandleTypeDef *heth, ETH_DMADescTypeDef *DMARxDescTab, uint8_t *RxBuff, uint32_t RxBuffCount);
 
+HAL_StatusTypeDef HAL_ETH_CheckAutoNegotiation(ETH_HandleTypeDef *heth);
+
 /**
   * @}
   */

--- a/ext/hal/st/stm32cube/stm32f2xx/drivers/src/stm32f2xx_hal_eth.c
+++ b/ext/hal/st/stm32cube/stm32f2xx/drivers/src/stm32f2xx_hal_eth.c
@@ -173,10 +173,11 @@ static void ETH_Delay(uint32_t mdelay);
   */
 HAL_StatusTypeDef HAL_ETH_Init(ETH_HandleTypeDef *heth)
 {
-  uint32_t tmpreg1 = 0U, phyreg = 0U;
+  uint32_t tmpreg1 = 0U;
   uint32_t hclk = 60000000U;
   uint32_t tickstart = 0U;
   uint32_t err = ETH_SUCCESS;
+  //HAL_StatusTypeDef res;
 
   /* Check the ETH peripheral state */
   if(heth == NULL)
@@ -284,6 +285,36 @@ HAL_StatusTypeDef HAL_ETH_Init(ETH_HandleTypeDef *heth)
   /* Delay to assure PHY reset */
   HAL_Delay(PHY_RESET_DELAY);
 
+  /* CheckAutoNegotiation has a timeout on the link detect, which slows the boot process  with several seconds */
+  //if((res = HAL_ETH_CheckAutoNegotiation(heth)) != HAL_OK)
+  {
+	  /* In case of write timeout */
+	  err = ETH_ERROR;
+  }
+
+  /* Config MAC and DMA */
+  ETH_MACDMAConfig(heth, err);
+
+  /* Set ETH HAL State to Ready */
+  heth->State = HAL_ETH_STATE_READY;
+
+  /* Return function status */
+  return HAL_TIMEOUT; //res;
+
+}
+
+HAL_StatusTypeDef HAL_ETH_CheckAutoNegotiation(ETH_HandleTypeDef *heth)
+{
+  uint32_t phyreg = 0U;
+  uint32_t tickstart = 0U;
+  uint32_t err = ETH_SUCCESS;
+
+  /* Check the ETH peripheral state */
+  if(heth == NULL)
+  {
+    return HAL_ERROR;
+  }
+
   if((heth->Init).AutoNegotiation != ETH_AUTONEGOTIATION_DISABLE)
   {
     /* Get tick */
@@ -297,18 +328,8 @@ HAL_StatusTypeDef HAL_ETH_Init(ETH_HandleTypeDef *heth)
       /* Check for the Timeout */
       if((HAL_GetTick() - tickstart ) > ETH_TIMEOUT_LINKED_STATE)
       {
-        /* In case of write timeout */
-        err = ETH_ERROR;
-
-        /* Config MAC and DMA */
-        ETH_MACDMAConfig(heth, err);
-
-        heth->State= HAL_ETH_STATE_READY;
-
-        /* Process Unlocked */
-        __HAL_UNLOCK(heth);
-
-        return HAL_TIMEOUT;
+  		/* No link detected so don't change PHY settings */
+  		return HAL_TIMEOUT;
       }
     } while (((phyreg & PHY_LINKED_STATUS) != PHY_LINKED_STATUS));
 
@@ -340,18 +361,8 @@ HAL_StatusTypeDef HAL_ETH_Init(ETH_HandleTypeDef *heth)
       /* Check for the Timeout */
       if((HAL_GetTick() - tickstart ) > ETH_TIMEOUT_AUTONEGO_COMPLETED)
       {
-        /* In case of write timeout */
-        err = ETH_ERROR;
-
-        /* Config MAC and DMA */
-        ETH_MACDMAConfig(heth, err);
-
-        heth->State= HAL_ETH_STATE_READY;
-
-        /* Process Unlocked */
-        __HAL_UNLOCK(heth);
-
-        return HAL_TIMEOUT;
+  		/* No link setup negotiated so don't change PHY settings */
+  		return HAL_TIMEOUT;
       }
 
     } while (((phyreg & PHY_AUTONEGO_COMPLETE) != PHY_AUTONEGO_COMPLETE));

--- a/ext/hal/st/stm32cube/stm32f4xx/drivers/include/stm32f4xx_hal_eth.h
+++ b/ext/hal/st/stm32cube/stm32f4xx/drivers/include/stm32f4xx_hal_eth.h
@@ -2108,6 +2108,8 @@ void HAL_ETH_MspDeInit(ETH_HandleTypeDef *heth);
 HAL_StatusTypeDef HAL_ETH_DMATxDescListInit(ETH_HandleTypeDef *heth, ETH_DMADescTypeDef *DMATxDescTab, uint8_t* TxBuff, uint32_t TxBuffCount);
 HAL_StatusTypeDef HAL_ETH_DMARxDescListInit(ETH_HandleTypeDef *heth, ETH_DMADescTypeDef *DMARxDescTab, uint8_t *RxBuff, uint32_t RxBuffCount);
 
+HAL_StatusTypeDef HAL_ETH_CheckAutoNegotiation(ETH_HandleTypeDef *heth);
+
 /**
   * @}
   */

--- a/ext/hal/st/stm32cube/stm32f4xx/drivers/src/stm32f4xx_hal_eth.c
+++ b/ext/hal/st/stm32cube/stm32f4xx/drivers/src/stm32f4xx_hal_eth.c
@@ -177,10 +177,11 @@ static void ETH_Delay(uint32_t mdelay);
   */
 HAL_StatusTypeDef HAL_ETH_Init(ETH_HandleTypeDef *heth)
 {
-  uint32_t tmpreg1 = 0U, phyreg = 0U;
+  uint32_t tmpreg1 = 0U;
   uint32_t hclk = 60000000U;
   uint32_t tickstart = 0U;
   uint32_t err = ETH_SUCCESS;
+  //HAL_StatusTypeDef res;
 
   /* Check the ETH peripheral state */
   if(heth == NULL)
@@ -293,142 +294,152 @@ HAL_StatusTypeDef HAL_ETH_Init(ETH_HandleTypeDef *heth)
   /* Delay to assure PHY reset */
   HAL_Delay(PHY_RESET_DELAY);
 
+  /* CheckAutoNegotiation has a timeout on the link detect, which slows the boot process  with several seconds */
+  //if((res = HAL_ETH_CheckAutoNegotiation(heth)) != HAL_OK)
+  {
+	  /* In case of write timeout */
+	  err = ETH_ERROR;
+  }
+
+  /* Config MAC and DMA */
+  ETH_MACDMAConfig(heth, err);
+
+  /* Set ETH HAL State to Ready */
+  heth->State = HAL_ETH_STATE_READY;
+
+  /* Return function status */
+  return HAL_TIMEOUT; //res;
+
+}
+
+HAL_StatusTypeDef HAL_ETH_CheckAutoNegotiation(ETH_HandleTypeDef *heth)
+{
+  uint32_t phyreg = 0U;
+  uint32_t tickstart = 0U;
+  uint32_t err = ETH_SUCCESS;
+
+  /* Check the ETH peripheral state */
+  if(heth == NULL)
+  {
+	return HAL_ERROR;
+  }
+
   if((heth->Init).AutoNegotiation != ETH_AUTONEGOTIATION_DISABLE)
   {
-    /* Get tick */
-    tickstart = HAL_GetTick();
+	/* Get tick */
+	tickstart = HAL_GetTick();
 
-    /* We wait for linked status */
-    do
-    {
-      HAL_ETH_ReadPHYRegister(heth, PHY_BSR, &phyreg);
+	/* We wait for linked status */
+	do
+	{
+	  HAL_ETH_ReadPHYRegister(heth, PHY_BSR, &phyreg);
 
-      /* Check for the Timeout */
-      if((HAL_GetTick() - tickstart ) > ETH_TIMEOUT_LINKED_STATE)
-      {
-        /* In case of write timeout */
-        err = ETH_ERROR;
-
-        /* Config MAC and DMA */
-        ETH_MACDMAConfig(heth, err);
-
-        heth->State= HAL_ETH_STATE_READY;
-
-        /* Process Unlocked */
-        __HAL_UNLOCK(heth);
-
-        return HAL_TIMEOUT;
-      }
-    } while (((phyreg & PHY_LINKED_STATUS) != PHY_LINKED_STATUS));
+	  /* Check for the Timeout */
+	  if((HAL_GetTick() - tickstart ) > ETH_TIMEOUT_LINKED_STATE)
+	  {
+		/* No link detected so don't change PHY settings */
+		return HAL_TIMEOUT;
+	  }
+	} while (((phyreg & PHY_LINKED_STATUS) != PHY_LINKED_STATUS));
 
 
-    /* Enable Auto-Negotiation */
-    if((HAL_ETH_WritePHYRegister(heth, PHY_BCR, PHY_AUTONEGOTIATION)) != HAL_OK)
-    {
-      /* In case of write timeout */
-      err = ETH_ERROR;
+	/* Enable Auto-Negotiation */
+	if((HAL_ETH_WritePHYRegister(heth, PHY_BCR, PHY_AUTONEGOTIATION)) != HAL_OK)
+	{
+	  /* In case of write timeout */
+	  err = ETH_ERROR;
 
-      /* Config MAC and DMA */
-      ETH_MACDMAConfig(heth, err);
+	  /* Config MAC and DMA */
+	  ETH_MACDMAConfig(heth, err);
 
-      /* Set the ETH peripheral state to READY */
-      heth->State = HAL_ETH_STATE_READY;
+	  /* Set the ETH peripheral state to READY */
+	  heth->State = HAL_ETH_STATE_READY;
 
-      /* Return HAL_ERROR */
-      return HAL_ERROR;
-    }
+	  /* Return HAL_ERROR */
+	  return HAL_ERROR;
+	}
 
-    /* Get tick */
-    tickstart = HAL_GetTick();
+	/* Get tick */
+	tickstart = HAL_GetTick();
 
-    /* Wait until the auto-negotiation will be completed */
-    do
-    {
-      HAL_ETH_ReadPHYRegister(heth, PHY_BSR, &phyreg);
+	/* Wait until the auto-negotiation will be completed */
+	do
+	{
+	  HAL_ETH_ReadPHYRegister(heth, PHY_BSR, &phyreg);
 
-      /* Check for the Timeout */
-      if((HAL_GetTick() - tickstart ) > ETH_TIMEOUT_AUTONEGO_COMPLETED)
-      {
-        /* In case of write timeout */
-        err = ETH_ERROR;
+	  /* Check for the Timeout */
+	  if((HAL_GetTick() - tickstart ) > ETH_TIMEOUT_AUTONEGO_COMPLETED)
+	  {
+		/* No link setup negotiated so don't change PHY settings */
+		return HAL_TIMEOUT;
+	  }
 
-        /* Config MAC and DMA */
-        ETH_MACDMAConfig(heth, err);
+	} while (((phyreg & PHY_AUTONEGO_COMPLETE) != PHY_AUTONEGO_COMPLETE));
 
-        heth->State= HAL_ETH_STATE_READY;
+	/* Read the result of the auto-negotiation */
+	if((HAL_ETH_ReadPHYRegister(heth, PHY_SR, &phyreg)) != HAL_OK)
+	{
+	  /* In case of write timeout */
+	  err = ETH_ERROR;
 
-        /* Process Unlocked */
-        __HAL_UNLOCK(heth);
+	  /* Config MAC and DMA */
+	  ETH_MACDMAConfig(heth, err);
 
-        return HAL_TIMEOUT;
-      }
+	  /* Set the ETH peripheral state to READY */
+	  heth->State = HAL_ETH_STATE_READY;
 
-    } while (((phyreg & PHY_AUTONEGO_COMPLETE) != PHY_AUTONEGO_COMPLETE));
+	  /* Return HAL_ERROR */
+	  return HAL_ERROR;
+	}
 
-    /* Read the result of the auto-negotiation */
-    if((HAL_ETH_ReadPHYRegister(heth, PHY_SR, &phyreg)) != HAL_OK)
-    {
-      /* In case of write timeout */
-      err = ETH_ERROR;
-
-      /* Config MAC and DMA */
-      ETH_MACDMAConfig(heth, err);
-
-      /* Set the ETH peripheral state to READY */
-      heth->State = HAL_ETH_STATE_READY;
-
-      /* Return HAL_ERROR */
-      return HAL_ERROR;
-    }
-
-    /* Configure the MAC with the Duplex Mode fixed by the auto-negotiation process */
-    if((phyreg & PHY_DUPLEX_STATUS) != (uint32_t)RESET)
-    {
-      /* Set Ethernet duplex mode to Full-duplex following the auto-negotiation */
-      (heth->Init).DuplexMode = ETH_MODE_FULLDUPLEX;
-    }
-    else
-    {
-      /* Set Ethernet duplex mode to Half-duplex following the auto-negotiation */
-      (heth->Init).DuplexMode = ETH_MODE_HALFDUPLEX;
-    }
-    /* Configure the MAC with the speed fixed by the auto-negotiation process */
-    if((phyreg & PHY_SPEED_STATUS) == PHY_SPEED_STATUS)
-    {
-      /* Set Ethernet speed to 10M following the auto-negotiation */
-      (heth->Init).Speed = ETH_SPEED_10M;
-    }
-    else
-    {
-      /* Set Ethernet speed to 100M following the auto-negotiation */
-      (heth->Init).Speed = ETH_SPEED_100M;
-    }
+	/* Configure the MAC with the Duplex Mode fixed by the auto-negotiation process */
+	if((phyreg & PHY_DUPLEX_STATUS) != (uint32_t)RESET)
+	{
+	  /* Set Ethernet duplex mode to Full-duplex following the auto-negotiation */
+	  (heth->Init).DuplexMode = ETH_MODE_FULLDUPLEX;
+	}
+	else
+	{
+	  /* Set Ethernet duplex mode to Half-duplex following the auto-negotiation */
+	  (heth->Init).DuplexMode = ETH_MODE_HALFDUPLEX;
+	}
+	/* Configure the MAC with the speed fixed by the auto-negotiation process */
+	if((phyreg & PHY_SPEED_STATUS) == PHY_SPEED_STATUS)
+	{
+	  /* Set Ethernet speed to 10M following the auto-negotiation */
+	  (heth->Init).Speed = ETH_SPEED_10M;
+	}
+	else
+	{
+	  /* Set Ethernet speed to 100M following the auto-negotiation */
+	  (heth->Init).Speed = ETH_SPEED_100M;
+	}
   }
   else /* AutoNegotiation Disable */
   {
-    /* Check parameters */
-    assert_param(IS_ETH_SPEED(heth->Init.Speed));
-    assert_param(IS_ETH_DUPLEX_MODE(heth->Init.DuplexMode));
+	/* Check parameters */
+	assert_param(IS_ETH_SPEED(heth->Init.Speed));
+	assert_param(IS_ETH_DUPLEX_MODE(heth->Init.DuplexMode));
 
-    /* Set MAC Speed and Duplex Mode */
-    if(HAL_ETH_WritePHYRegister(heth, PHY_BCR, ((uint16_t)((heth->Init).DuplexMode >> 3U) |
-                                                (uint16_t)((heth->Init).Speed >> 1U))) != HAL_OK)
-    {
-      /* In case of write timeout */
-      err = ETH_ERROR;
+	/* Set MAC Speed and Duplex Mode */
+	if(HAL_ETH_WritePHYRegister(heth, PHY_BCR, ((uint16_t)((heth->Init).DuplexMode >> 3U) |
+												(uint16_t)((heth->Init).Speed >> 1U))) != HAL_OK)
+	{
+	  /* In case of write timeout */
+	  err = ETH_ERROR;
 
-      /* Config MAC and DMA */
-      ETH_MACDMAConfig(heth, err);
+	  /* Config MAC and DMA */
+	  ETH_MACDMAConfig(heth, err);
 
-      /* Set the ETH peripheral state to READY */
-      heth->State = HAL_ETH_STATE_READY;
+	  /* Set the ETH peripheral state to READY */
+	  heth->State = HAL_ETH_STATE_READY;
 
-      /* Return HAL_ERROR */
-      return HAL_ERROR;
-    }
+	  /* Return HAL_ERROR */
+	  return HAL_ERROR;
+	}
 
-    /* Delay to assure PHY configuration */
-    HAL_Delay(PHY_CONFIG_DELAY);
+	/* Delay to assure PHY configuration */
+	HAL_Delay(PHY_CONFIG_DELAY);
   }
 
   /* Config MAC and DMA */

--- a/ext/hal/st/stm32cube/stm32f7xx/drivers/include/stm32f7xx_hal_eth.h
+++ b/ext/hal/st/stm32cube/stm32f7xx/drivers/include/stm32f7xx_hal_eth.h
@@ -2112,6 +2112,8 @@ void HAL_ETH_MspDeInit(ETH_HandleTypeDef *heth);
 HAL_StatusTypeDef HAL_ETH_DMATxDescListInit(ETH_HandleTypeDef *heth, ETH_DMADescTypeDef *DMATxDescTab, uint8_t* TxBuff, uint32_t TxBuffCount);
 HAL_StatusTypeDef HAL_ETH_DMARxDescListInit(ETH_HandleTypeDef *heth, ETH_DMADescTypeDef *DMARxDescTab, uint8_t *RxBuff, uint32_t RxBuffCount);
 
+HAL_StatusTypeDef HAL_ETH_CheckAutoNegotiation(ETH_HandleTypeDef *heth);
+
 /**
   * @}
   */

--- a/ext/hal/st/stm32cube/stm32f7xx/drivers/src/stm32f7xx_hal_eth.c
+++ b/ext/hal/st/stm32cube/stm32f7xx/drivers/src/stm32f7xx_hal_eth.c
@@ -171,10 +171,11 @@ static void ETH_FlushTransmitFIFO(ETH_HandleTypeDef *heth);
   */
 HAL_StatusTypeDef HAL_ETH_Init(ETH_HandleTypeDef *heth)
 {
-  uint32_t tempreg = 0, phyreg = 0;
+  uint32_t tempreg = 0;
   uint32_t hclk = 60000000;
   uint32_t tickstart = 0;
   uint32_t err = ETH_SUCCESS;
+  //HAL_StatusTypeDef res;
 
   /* Check the ETH peripheral state */
   if(heth == NULL)
@@ -288,6 +289,37 @@ HAL_StatusTypeDef HAL_ETH_Init(ETH_HandleTypeDef *heth)
   /* Delay to assure PHY reset */
   HAL_Delay(PHY_RESET_DELAY);
 
+  /* CheckAutoNegotiation has a timeout on the link detect, which slows the boot process  with several seconds */
+  //if((res = HAL_ETH_CheckAutoNegotiation(heth)) != HAL_OK)
+  {
+	  /* In case of write timeout */
+	  err = ETH_ERROR;
+  }
+
+  /* Config MAC and DMA */
+  ETH_MACDMAConfig(heth, err);
+
+  /* Set ETH HAL State to Ready */
+  heth->State = HAL_ETH_STATE_READY;
+
+  /* Return function status */
+  return HAL_TIMEOUT; //res;
+
+}
+
+HAL_StatusTypeDef HAL_ETH_CheckAutoNegotiation(ETH_HandleTypeDef *heth)
+{
+  uint32_t phyreg = 0U;
+  uint32_t tickstart = 0U;
+  uint32_t err = ETH_SUCCESS;
+
+  /* Check the ETH peripheral state */
+  if(heth == NULL)
+  {
+    return HAL_ERROR;
+  }
+
+
   if((heth->Init).AutoNegotiation != ETH_AUTONEGOTIATION_DISABLE)
   {
     /* Get tick */
@@ -301,18 +333,8 @@ HAL_StatusTypeDef HAL_ETH_Init(ETH_HandleTypeDef *heth)
       /* Check for the Timeout */
       if((HAL_GetTick() - tickstart ) > ETH_TIMEOUT_LINKED_STATE)
       {
-        /* In case of write timeout */
-        err = ETH_ERROR;
-
-        /* Config MAC and DMA */
-        ETH_MACDMAConfig(heth, err);
-
-        heth->State= HAL_ETH_STATE_READY;
-
-        /* Process Unlocked */
-        __HAL_UNLOCK(heth);
-
-        return HAL_TIMEOUT;
+  		/* No link detected so don't change PHY settings */
+  		return HAL_TIMEOUT;
       }
     } while (((phyreg & PHY_LINKED_STATUS) != PHY_LINKED_STATUS));
 
@@ -344,18 +366,8 @@ HAL_StatusTypeDef HAL_ETH_Init(ETH_HandleTypeDef *heth)
       /* Check for the Timeout */
       if((HAL_GetTick() - tickstart ) > ETH_TIMEOUT_AUTONEGO_COMPLETED)
       {
-        /* In case of write timeout */
-        err = ETH_ERROR;
-
-        /* Config MAC and DMA */
-        ETH_MACDMAConfig(heth, err);
-
-        heth->State= HAL_ETH_STATE_READY;
-
-        /* Process Unlocked */
-        __HAL_UNLOCK(heth);
-
-        return HAL_TIMEOUT;
+  		/* No link setup negotiated so don't change PHY settings */
+  		return HAL_TIMEOUT;
       }
 
     } while (((phyreg & PHY_AUTONEGO_COMPLETE) != PHY_AUTONEGO_COMPLETE));


### PR DESCRIPTION
The ethernet driver of stm32 (low level driver) does not generate link information (cable attached or not). To allow applications to react on the link detect, an additional thread is added which poll the link status at a low rate. 
This can be switched on/off through the menuconfig.

Signed-off-by: Vincent van der Locht <vincent@vlotech.nl>
