### PR TITLE
boards: atsamd20_xpro: fix tx pin number for sercom3

### DIFF
--- a/boards/arm/atsamd20_xpro/atsamd20_xpro.dts
+++ b/boards/arm/atsamd20_xpro/atsamd20_xpro.dts
@@ -51,7 +51,7 @@
 	compatible = "atmel,sam0-uart";
 	current-speed = <115200>;
 	rxpo = <3>;
-	txpo = <2>;
+	txpo = <1>;
 };
 
 &sercom4 {


### PR DESCRIPTION
Not pretty to change the PAD name from 2 to 1 as the correct
is PAD2 but for the SAMD20 the register value is 1.

Fixes: 6d08958ad5 ("drivers: uart_sam0: move sercom pad info to dts")
Signed-off-by: Sean Nyekjaer <sean.nyekjaer@prevas.dk>