### PR TITLE
cmake: Don't remember misnamed boards

### DIFF
--- a/cmake/app/boilerplate.cmake
+++ b/cmake/app/boilerplate.cmake
@@ -193,7 +193,12 @@ foreach(root ${BOARD_ROOT})
   endif()
 endforeach()
 
-assert_with_usage(BOARD_DIR "No board named '${BOARD}' found")
+if(NOT BOARD_DIR)
+  message("No board named '${BOARD}' found")
+  print_usage()
+  unset(CACHED_BOARD CACHE)
+  message(FATAL_ERROR "Invalid usage")
+endif()
 
 get_filename_component(BOARD_ARCH_DIR ${BOARD_DIR} DIRECTORY)
 get_filename_component(BOARD_FAMILY   ${BOARD_DIR} NAME     )

--- a/cmake/extensions.cmake
+++ b/cmake/extensions.cmake
@@ -1099,14 +1099,7 @@ macro(assert_exists var)
   endif()
 endmacro()
 
-# Usage:
-#   assert_with_usage(BOARD_DIR "No board named '${BOARD}' found")
-#
-# will print an error message, show usage, and then end executioon
-# with a FATAL_ERROR if the test fails.
-macro(assert_with_usage test comment)
-  if(NOT ${test})
-    message(${comment})
+function(print_usage)
     message("see usage:")
 	string(REPLACE ";" " " BOARD_ROOT_SPACE_SEPARATED "${BOARD_ROOT}")
     execute_process(
@@ -1115,9 +1108,7 @@ macro(assert_with_usage test comment)
       -DBOARD_ROOT_SPACE_SEPARATED=${BOARD_ROOT_SPACE_SEPARATED}
       -P ${ZEPHYR_BASE}/cmake/usage/usage.cmake
       )
-    message(FATAL_ERROR "Invalid usage")
-  endif()
-endmacro()
+endfunction()
 
 # 3.5. File system management
 function(check_if_directory_is_writeable dir ok)


### PR DESCRIPTION
CMake prints a helpful error message with all the boards supported
when a board name has been misspelled. But CMake also
remembers (caches) the corrupted board name and refuses to change it
until the board directory has been cleared.

CMake is rightly hesitant to change the board, as other cached
variables depend on what the board is. But it is safe to change the
board just after it has been selected, because we verify it's
correctness before using it to calculate other variables.

So to support the use-case of changing a misspelled board
name (without clearing the build directory) we unset the cached board
when it is invalid.

Also; change the now unused (in-tree) macro 'assert_with_usage' to
'print_usage'.

Signed-off-by: Sebastian Bøe <sebastian.boe@nordicsemi.no>