### PR TITLE
dts: scan application dir for files included by dts

### DIFF
--- a/cmake/dts.cmake
+++ b/cmake/dts.cmake
@@ -13,6 +13,7 @@ set(GENERATED_DTS_BOARD_CONF ${PROJECT_BINARY_DIR}/include/generated/generated_d
 set_ifndef(DTS_SOURCE ${BOARD_DIR}/${BOARD}.dts)
 set_ifndef(DTS_COMMON_OVERLAYS ${ZEPHYR_BASE}/dts/common/common.dts)
 set_ifndef(DTS_APP_BINDINGS ${APPLICATION_SOURCE_DIR}/dts/bindings)
+set_ifndef(DTS_APP_INCLUDE ${APPLICATION_SOURCE_DIR}/dts)
 
 set(dts_files
   ${DTS_SOURCE}
@@ -87,6 +88,7 @@ if(CONFIG_HAS_DTS)
     COMMAND ${CMAKE_C_COMPILER}
     -x assembler-with-cpp
     -nostdinc
+    -isystem ${DTS_APP_INCLUDE}
     -isystem ${ZEPHYR_BASE}/include
     -isystem ${ZEPHYR_BASE}/dts/${ARCH}
     -isystem ${ZEPHYR_BASE}/dts


### PR DESCRIPTION
In addition to zephyr/include and zephyr/dts also scan
the dts directory within the application source directory
for files included by the DTS.

Allows to have application specific DTS includes. This
is especially useful for out of tree drivers.

Signed-off-by: Bobby Noelte <b0661n0e17e@gmail.com>