### PR TITLE
samples: sockets: Set correct log module name in echo_server

### DIFF
--- a/samples/net/sockets/echo_server/src/tcp.c
+++ b/samples/net/sockets/echo_server/src/tcp.c
@@ -7,7 +7,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#define LOG_MODULE_NAME net_echo_client_tcp
+#define LOG_MODULE_NAME net_echo_server_tcp
 #define NET_LOG_LEVEL LOG_LEVEL_DBG
 
 #include <zephyr.h>

--- a/samples/net/sockets/echo_server/src/udp.c
+++ b/samples/net/sockets/echo_server/src/udp.c
@@ -7,7 +7,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#define LOG_MODULE_NAME net_echo_client_udp
+#define LOG_MODULE_NAME net_echo_server_udp
 #define NET_LOG_LEVEL LOG_LEVEL_DBG
 
 #include <zephyr.h>


### PR DESCRIPTION
Minor issue spotted: `echo_server` used incorrect `net_echo_client_*` names for logger, making logs confusing.

Signed-off-by: Robert Lubos <robert.lubos@nordicsemi.no>