### PR TITLE
shell: fix shell thread name

### DIFF
--- a/include/shell/shell.h
+++ b/include/shell/shell.h
@@ -435,6 +435,7 @@ struct shell {
 
 	LOG_INSTANCE_PTR_DECLARE(log);
 
+	const char *thread_name;
 	struct k_thread *thread;
 	k_thread_stack_t *stack;
 };
@@ -474,6 +475,7 @@ struct shell {
 		.stats = SHELL_STATS_PTR(_name),			     \
 		.log_backend = SHELL_LOG_BACKEND_PTR(_name),		     \
 		LOG_INSTANCE_PTR_INIT(log, shell, _name)		     \
+		.thread_name = STRINGIFY(_name),			     \
 		.thread = &_name##_thread,				     \
 		.stack = _name##_stack					     \
 	}

--- a/subsys/shell/shell.c
+++ b/subsys/shell/shell.c
@@ -1334,7 +1334,7 @@ int shell_init(const struct shell *shell, const void *transport_config,
 			      (void *)init_log_level,
 			      CONFIG_SHELL_THREAD_PRIO, 0, K_NO_WAIT);
 
-	k_thread_name_set(tid, "shell");
+	k_thread_name_set(tid, shell->thread_name);
 
 	return 0;
 }

--- a/subsys/shell/shell_dummy.c
+++ b/subsys/shell/shell_dummy.c
@@ -8,7 +8,7 @@
 #include <init.h>
 
 SHELL_DUMMY_DEFINE(shell_transport_dummy);
-SHELL_DEFINE(dummy_shell, "~$ ", &shell_transport_dummy, 10,
+SHELL_DEFINE(shell_dummy, "~$ ", &shell_transport_dummy, 10,
 	     SHELL_FLAG_OLF_CRLF);
 
 static int init(const struct shell_transport *transport,
@@ -90,12 +90,12 @@ const struct shell_transport_api shell_dummy_transport_api = {
 static int enable_shell_dummy(struct device *arg)
 {
 	ARG_UNUSED(arg);
-	shell_init(&dummy_shell, NULL, true, true, LOG_LEVEL_INF);
+	shell_init(&shell_dummy, NULL, true, true, LOG_LEVEL_INF);
 	return 0;
 }
 SYS_INIT(enable_shell_dummy, POST_KERNEL, 0);
 
 const struct shell *shell_backend_dummy_get_ptr(void)
 {
-	return &dummy_shell;
+	return &shell_dummy;
 }

--- a/subsys/shell/shell_rtt.c
+++ b/subsys/shell/shell_rtt.c
@@ -10,7 +10,7 @@
 #include <logging/sys_log.h>
 
 SHELL_RTT_DEFINE(shell_transport_rtt);
-SHELL_DEFINE(rtt_shell, "rtt:~$ ", &shell_transport_rtt, 10,
+SHELL_DEFINE(shell_rtt, "rtt:~$ ", &shell_transport_rtt, 10,
 	     SHELL_FLAG_OLF_CRLF);
 
 static struct k_thread rtt_rx_thread;
@@ -107,7 +107,7 @@ static int enable_shell_rtt(struct device *arg)
 	u32_t level = (CONFIG_SHELL_BACKEND_RTT_LOG_LEVEL > LOG_LEVEL_DBG) ?
 		      CONFIG_LOG_MAX_LEVEL : CONFIG_SHELL_BACKEND_RTT_LOG_LEVEL;
 
-	shell_init(&rtt_shell, NULL, true, log_backend, level);
+	shell_init(&shell_rtt, NULL, true, log_backend, level);
 
 	return 0;
 }
@@ -115,6 +115,6 @@ static int enable_shell_rtt(struct device *arg)
 /* Function is used for testing purposes */
 const struct shell *shell_backend_rtt_get_ptr(void)
 {
-	return &rtt_shell;
+	return &shell_rtt;
 }
 SYS_INIT(enable_shell_rtt, POST_KERNEL, 0);

--- a/subsys/shell/shell_uart.c
+++ b/subsys/shell/shell_uart.c
@@ -21,7 +21,7 @@ LOG_MODULE_REGISTER(shell_uart);
 SHELL_UART_DEFINE(shell_transport_uart,
 		  CONFIG_SHELL_BACKEND_SERIAL_TX_RING_BUFFER_SIZE,
 		  CONFIG_SHELL_BACKEND_SERIAL_RX_RING_BUFFER_SIZE);
-SHELL_DEFINE(uart_shell, "uart:~$ ", &shell_transport_uart, 10,
+SHELL_DEFINE(shell_uart, "uart:~$ ", &shell_transport_uart, 10,
 	     SHELL_FLAG_OLF_CRLF);
 
 #ifdef CONFIG_UART_INTERRUPT_DRIVEN
@@ -235,7 +235,7 @@ static int enable_shell_uart(struct device *arg)
 		(CONFIG_SHELL_BACKEND_SERIAL_LOG_LEVEL > LOG_LEVEL_DBG) ?
 		CONFIG_LOG_MAX_LEVEL : CONFIG_SHELL_BACKEND_SERIAL_LOG_LEVEL;
 
-	shell_init(&uart_shell, dev, true, log_backend, level);
+	shell_init(&shell_uart, dev, true, log_backend, level);
 
 	return 0;
 }
@@ -243,5 +243,5 @@ SYS_INIT(enable_shell_uart, POST_KERNEL, 0);
 
 const struct shell *shell_backend_uart_get_ptr(void)
 {
-	return &uart_shell;
+	return &shell_uart;
 }


### PR DESCRIPTION
Each shell thread will have unique name.
Previously thread name "shell" has been created for each shell
backend.

Signed-off-by: Jakub Rzeszutko <jakub.rzeszutko@nordicsemi.no>