### PR TITLE
sanitycheck: remove unused platforms keyword

### DIFF
--- a/doc/subsystems/test/sanitycheck.rst
+++ b/doc/subsystems/test/sanitycheck.rst
@@ -289,7 +289,6 @@ related to the sample and what is being demonstrated:
         sample:
           name: hello world
           description: Hello World sample, the simplest Zephyr application
-          platforms: all
         tests:
           test:
             build_only: true

--- a/samples/basic/userspace/shared_mem/sample.yaml
+++ b/samples/basic/userspace/shared_mem/sample.yaml
@@ -2,7 +2,6 @@ sample:
   description: userspace memory domain protection
     example application
   name: protected memory
-  platforms: all
 common:
     tags: userspace
     harness: console

--- a/samples/drivers/led_lp3943/sample.yaml
+++ b/samples/drivers/led_lp3943/sample.yaml
@@ -1,7 +1,6 @@
 sample:
   description: Demonstration of the LP3943 LED driver
   name: LP3943 sample
-  platforms: all
 tests:
   test:
     platform_whitelist: 96b_neonkey

--- a/samples/drivers/led_lpd8806/sample.yaml
+++ b/samples/drivers/led_lpd8806/sample.yaml
@@ -1,7 +1,6 @@
 sample:
   description: Demonstration of the lpd880x LED driver
   name: LPD880x sample
-  platforms: all
 tests:
   test:
     platform_whitelist: 96b_carbon

--- a/samples/drivers/led_pca9633/sample.yaml
+++ b/samples/drivers/led_pca9633/sample.yaml
@@ -1,7 +1,6 @@
 sample:
   description: Demonstration of the PCA9633 LED driver
   name: PCA9633 sample
-  platforms: all
 tests:
   test:
     platform_whitelist: stm32373c_eval

--- a/samples/drivers/led_ws2812/sample.yaml
+++ b/samples/drivers/led_ws2812/sample.yaml
@@ -1,7 +1,6 @@
 sample:
   description: Demonstration of the WS2812 LED driver
   name: WS2812 sample
-  platforms: all
 tests:
   test:
     platform_whitelist: 96b_carbon bbc_microbit

--- a/samples/hello_world/sample.yaml
+++ b/samples/hello_world/sample.yaml
@@ -2,7 +2,6 @@ sample:
   description: Hello World sample, the simplest Zephyr
     application
   name: hello world
-  platforms: all
 common:
     tags: introduction
     harness: console

--- a/samples/net/rpl_node/sample.yaml
+++ b/samples/net/rpl_node/sample.yaml
@@ -6,7 +6,6 @@ sample:
     to be run in real device. This cannot be run in
     QEMU.
   name: RPL node demo application
-  platforms: all
 tests:
   test:
     platform_whitelist: quark_se_c1000_devboard nrf52840_pca10056

--- a/samples/sensor/ccs811/sample.yaml
+++ b/samples/sensor/ccs811/sample.yaml
@@ -1,7 +1,6 @@
 sample:
   description: Demonstration of the CCS811 Digital Gas Sensor driver
   name: CCS811 sample
-  platforms: all
 tests:
   test:
     harness: sensor

--- a/scripts/sanity_chk/sanitycheck-tc-schema.yaml
+++ b/scripts/sanity_chk/sanitycheck-tc-schema.yaml
@@ -106,9 +106,6 @@ mapping:
       "description":
         type: str
         required: no
-      "platforms":
-        type: str
-        required: no
   # The list of testcases -- IDK why this is a sequence of
   # maps maps, shall just be a sequence of maps
   # maybe it is just an artifact?


### PR DESCRIPTION
This keyword had no effect and was being copied over to many samples
errornously.

Signed-off-by: Anas Nashif <anas.nashif@intel.com>