### PR TITLE
ci: use latest docker image

### DIFF
--- a/.shippable.yml
+++ b/.shippable.yml
@@ -27,7 +27,7 @@ build:
         - ${SHIPPABLE_BUILD_DIR}/ccache
     pre_ci_boot:
         image_name: zephyrprojectrtos/ci
-        image_tag: v0.4-rc12
+        image_tag: v0.4-rc14
         pull: true
         options: "-e HOME=/home/buildslave --privileged=true --tty --net=bridge --user buildslave"
 


### PR DESCRIPTION
- Has cmake 3.8.2 that matches min. required version
- Has west pre-installed
- Uses latest python dependencies from scripts/requirements.txt
- remove ISSM toolchain
- added scancode-toolkit for scanning licenses and copyrights.

Signed-off-by: Anas Nashif <anas.nashif@intel.com>