### PR TITLE
[RFC] drivers/spi: implement a composite event for async callback

### DIFF
--- a/drivers/spi/spi_dw.c
+++ b/drivers/spi/spi_dw.c
@@ -330,7 +330,7 @@ static int transceive(struct device *dev,
 		      const struct spi_buf_set *tx_bufs,
 		      const struct spi_buf_set *rx_bufs,
 		      bool asynchronous,
-		      struct k_poll_signal *signal)
+		      struct spi_async_event *signal)
 {
 	const struct spi_dw_config *info = dev->config->config_info;
 	struct spi_dw_data *spi = dev->driver_data;
@@ -443,7 +443,7 @@ static int spi_dw_transceive_async(struct device *dev,
 				   const struct spi_config *config,
 				   const struct spi_buf_set *tx_bufs,
 				   const struct spi_buf_set *rx_bufs,
-				   struct k_poll_signal *async)
+				   struct spi_async_event *async)
 {
 	LOG_DBG("%p, %p, %p, %p", dev, tx_bufs, rx_bufs, async);
 

--- a/drivers/spi/spi_intel.c
+++ b/drivers/spi/spi_intel.c
@@ -179,7 +179,7 @@ static int transceive(struct device *dev,
 		      const struct spi_buf_set *tx_bufs,
 		      const struct spi_buf_set *rx_bufs,
 		      bool asynchronous,
-		      struct k_poll_signal *signal)
+		      struct spi_async_event *signal)
 {
 	struct spi_intel_data *spi = dev->driver_data;
 	int ret;
@@ -229,7 +229,7 @@ static int spi_intel_transceive_async(struct device *dev,
 				      const struct spi_config *config,
 				      const struct spi_buf_set *tx_bufs,
 				      const struct spi_buf_set *rx_bufs,
-				      struct k_poll_signal *async)
+				      struct spi_async_event *async)
 {
 	LOG_DBG("%p, %p, %p, %p", dev, tx_bufs, rx_bufs, async);
 

--- a/drivers/spi/spi_ll_stm32.c
+++ b/drivers/spi/spi_ll_stm32.c
@@ -362,7 +362,7 @@ static int transceive(struct device *dev,
 		      const struct spi_config *config,
 		      const struct spi_buf_set *tx_bufs,
 		      const struct spi_buf_set *rx_bufs,
-		      bool asynchronous, struct k_poll_signal *signal)
+		      bool asynchronous, struct spi_async_event *signal)
 {
 	const struct spi_stm32_config *cfg = DEV_CFG(dev);
 	struct spi_stm32_data *data = DEV_DATA(dev);
@@ -444,7 +444,7 @@ static int spi_stm32_transceive_async(struct device *dev,
 				      const struct spi_config *config,
 				      const struct spi_buf_set *tx_bufs,
 				      const struct spi_buf_set *rx_bufs,
-				      struct k_poll_signal *async)
+				      struct spi_async_event *async)
 {
 	return transceive(dev, config, tx_bufs, rx_bufs, true, async);
 }

--- a/drivers/spi/spi_mcux_dspi.c
+++ b/drivers/spi/spi_mcux_dspi.c
@@ -193,7 +193,7 @@ static int transceive(struct device *dev,
 		      const struct spi_buf_set *tx_bufs,
 		      const struct spi_buf_set *rx_bufs,
 		      bool asynchronous,
-		      struct k_poll_signal *signal)
+		      struct spi_async_event *signal)
 {
 	struct spi_mcux_data *data = dev->driver_data;
 	int ret;
@@ -231,7 +231,7 @@ static int spi_mcux_transceive_async(struct device *dev,
 				     const struct spi_config *spi_cfg,
 				     const struct spi_buf_set *tx_bufs,
 				     const struct spi_buf_set *rx_bufs,
-				     struct k_poll_signal *async)
+				     struct spi_async_event *async)
 {
 	return transceive(dev, spi_cfg, tx_bufs, rx_bufs, true, async);
 }

--- a/drivers/spi/spi_mcux_lpspi.c
+++ b/drivers/spi/spi_mcux_lpspi.c
@@ -197,7 +197,7 @@ static int transceive(struct device *dev,
 		      const struct spi_buf_set *tx_bufs,
 		      const struct spi_buf_set *rx_bufs,
 		      bool asynchronous,
-		      struct k_poll_signal *signal)
+		      struct spi_async_event *signal)
 {
 	struct spi_mcux_data *data = dev->driver_data;
 	int ret;
@@ -235,7 +235,7 @@ static int spi_mcux_transceive_async(struct device *dev,
 				     const struct spi_config *spi_cfg,
 				     const struct spi_buf_set *tx_bufs,
 				     const struct spi_buf_set *rx_bufs,
-				     struct k_poll_signal *async)
+				     struct spi_async_event *async)
 {
 	return transceive(dev, spi_cfg, tx_bufs, rx_bufs, true, async);
 }

--- a/drivers/spi/spi_nrfx_spi.c
+++ b/drivers/spi/spi_nrfx_spi.c
@@ -204,7 +204,7 @@ static int spi_nrfx_transceive_async(struct device *dev,
 				     const struct spi_config *spi_cfg,
 				     const struct spi_buf_set *tx_bufs,
 				     const struct spi_buf_set *rx_bufs,
-				     struct k_poll_signal *async)
+				     struct spi_async_event *async)
 {
 	spi_context_lock(&get_dev_data(dev)->ctx, true, async);
 	return transceive(dev, spi_cfg, tx_bufs, rx_bufs);

--- a/drivers/spi/spi_nrfx_spim.c
+++ b/drivers/spi/spi_nrfx_spim.c
@@ -233,7 +233,7 @@ static int spi_nrfx_transceive_async(struct device *dev,
 				     const struct spi_config *spi_cfg,
 				     const struct spi_buf_set *tx_bufs,
 				     const struct spi_buf_set *rx_bufs,
-				     struct k_poll_signal *async)
+				     struct spi_async_event *async)
 {
 	spi_context_lock(&get_dev_data(dev)->ctx, true, async);
 	return transceive(dev, spi_cfg, tx_bufs, rx_bufs);

--- a/drivers/spi/spi_nrfx_spis.c
+++ b/drivers/spi/spi_nrfx_spis.c
@@ -187,7 +187,7 @@ static int spi_nrfx_transceive_async(struct device *dev,
 				     const struct spi_config *spi_cfg,
 				     const struct spi_buf_set *tx_bufs,
 				     const struct spi_buf_set *rx_bufs,
-				     struct k_poll_signal *async)
+				     struct spi_async_event *async)
 {
 	spi_context_lock(&get_dev_data(dev)->ctx, true, async);
 	return transceive(dev, spi_cfg, tx_bufs, rx_bufs);

--- a/drivers/spi/spi_sam.c
+++ b/drivers/spi/spi_sam.c
@@ -412,7 +412,7 @@ static int spi_sam_transceive_async(struct device *dev,
 				     const struct spi_config *config,
 				     const struct spi_buf_set *tx_bufs,
 				     const struct spi_buf_set *rx_bufs,
-				     struct k_poll_signal *async)
+				     struct spi_async_event *async)
 {
 	struct spi_sam_data *data = dev->driver_data;
 

--- a/drivers/spi/spi_sam0.c
+++ b/drivers/spi/spi_sam0.c
@@ -419,7 +419,7 @@ static int spi_sam0_transceive_async(struct device *dev,
 				     const struct spi_config *config,
 				     const struct spi_buf_set *tx_bufs,
 				     const struct spi_buf_set *rx_bufs,
-				     struct k_poll_signal *async)
+				     struct spi_async_event *async)
 {
 	struct spi_sam0_data *data = dev->driver_data;
 

--- a/tests/drivers/spi/spi_loopback/src/spi.c
+++ b/tests/drivers/spi/spi_loopback/src/spi.c
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2017 Intel Corporation.
+ * Copyright (c) 2018 Vincent van der Locht
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -320,6 +321,10 @@ static struct k_poll_event async_evt =
 static K_SEM_DEFINE(caller, 0, 1);
 K_THREAD_STACK_DEFINE(spi_async_stack, STACK_SIZE);
 static int result = 1;
+static struct spi_async_event async_event = {
+		.type = SPI_ASYNC_EVENT_TYPE_SIGNAL,
+		.signal = &async_sig,
+};
 
 static void spi_async_call_cb(struct k_poll_event *async_evt,
 			      struct k_sem *caller_sem,
@@ -368,7 +373,7 @@ static int spi_async_call(struct device *dev, struct spi_config *spi_conf)
 
 	LOG_INF("Start");
 
-	ret = spi_transceive_async(dev, spi_conf, &tx, &rx, &async_sig);
+	ret = spi_transceive_async(dev, spi_conf, &tx, &rx, &async_event);
 	if (ret == -ENOTSUP) {
 		LOG_DBG("Not supported");
 		return 0;


### PR DESCRIPTION
For not all applications the poll_signal interface is a practical solution to tell upper layers an asynchronous transfer is completed.
To allow different types of synchronization, a composite interface is made. Allowing semaphore (give), mutex (unlock), alert (send) and poll (signal) to be used depending on the application one of the given methods can be used.  

An additional method could be added, which is a callback function with the device as argument. This is not added to this composite interface yet. 

In case this is seen as a practical way of handling asynchronous callbacks, it could be extended to a generic implementation for all I/O drivers. 

Signed-off-by: Vincent van der Locht <vincent@vlotech.nl>