### PR TITLE
Renode sanity check

### DIFF
--- a/boards/riscv32/m2gl025_miv/board.cmake
+++ b/boards/riscv32/m2gl025_miv/board.cmake
@@ -1,0 +1,2 @@
+set(EMU_PLATFORM renode)
+set(RENODE_SCRIPT ${CMAKE_CURRENT_LIST_DIR}/support/m2gl025_miv.resc)

--- a/boards/riscv32/m2gl025_miv/m2gl025_miv.yaml
+++ b/boards/riscv32/m2gl025_miv/m2gl025_miv.yaml
@@ -5,6 +5,7 @@ arch: riscv32
 toolchain:
   - zephyr
 ram: 64
+simulation: renode
 testing:
   ignore_tags:
     - net

--- a/boards/riscv32/m2gl025_miv/support/m2gl025_miv.resc
+++ b/boards/riscv32/m2gl025_miv/support/m2gl025_miv.resc
@@ -1,0 +1,16 @@
+:name: Mi-V
+:description: This script is prepared to run Zephyr on a Mi-V RISC-V board.
+
+$name?="Mi-V"
+
+using sysbus
+mach create $name
+machine LoadPlatformDescription @platforms/boards/miv-board.repl
+
+showAnalyzer uart
+
+macro reset
+"""
+    sysbus LoadELF $bin
+"""
+runMacro $reset

--- a/cmake/emu/renode.cmake
+++ b/cmake/emu/renode.cmake
@@ -1,0 +1,18 @@
+find_program(
+  RENODE
+  renode
+  )
+
+set(RENODE_FLAGS
+  --disable-xwt
+  --pid-file renode.pid
+  )
+
+add_custom_target(run
+  COMMAND
+  ${RENODE}
+  ${RENODE_FLAGS}
+  -e '$$bin=@${APPLICATION_BINARY_DIR}/zephyr/${KERNEL_ELF_NAME}\; include @${RENODE_SCRIPT}\; s'
+  WORKING_DIRECTORY ${APPLICATION_BINARY_DIR}
+  USES_TERMINAL
+  )

--- a/scripts/sanitycheck
+++ b/scripts/sanitycheck
@@ -311,6 +311,7 @@ class Handler:
         self.metrics["rom_size"] = 0
 
         self.binary = None
+        self.pid_fn = None
         self.call_make_run = False
 
         self.name = instance.name
@@ -343,6 +344,16 @@ class BinaryHandler(Handler):
         super().__init__(instance)
 
         self.valgrind = False
+
+    def try_kill_process_by_pid(self):
+        if self.pid_fn != None:
+            pid = int(open(self.pid_fn).read())
+            os.unlink(self.pid_fn)
+            self.pid_fn = None  # clear so we don't try to kill the binary twice
+            try:
+                os.kill(pid, signal.SIGTERM)
+            except ProcessLookupError:
+                pass
 
     def _output_reader(self, proc, harness):
         log_out_fp = open(self.log, "wt")
@@ -383,6 +394,7 @@ class BinaryHandler(Handler):
             t.start()
             t.join(self.timeout)
             if t.is_alive():
+                self.try_kill_process_by_pid()
                 proc.terminate()
                 out_state = "timeout"
                 t.join()
@@ -395,6 +407,8 @@ class BinaryHandler(Handler):
         if options.enable_coverage:
             returncode = subprocess.call(["GCOV_PREFIX=" + self.outdir,
                 "gcov", self.sourcedir, "-b", "-s", self.outdir], shell=True)
+
+        self.try_kill_process_by_pid()
 
         # FIME: This is needed when killing the simulator, the console is
         # garbled and needs to be reset. Did not find a better way to do that.
@@ -486,7 +500,6 @@ class DeviceHandler(Handler):
                     harness.tests[c] = "BLOCK"
 
         self.instance.results = harness.tests
-
         if harness.state:
             self.set_state(harness.state, {})
         else:
@@ -1013,6 +1026,10 @@ class MakeGenerator:
             handler.binary = os.path.join(outdir, "testbinary")
         elif type == "device":
             handler = DeviceHandler(instance)
+        elif type == "renode":
+            handler = BinaryHandler(instance)
+            handler.pid_fn = os.path.join(instance.outdir, "renode.pid")
+            handler.call_make_run = True
 
         if options.enable_coverage:
             args += ["EXTRA_LDFLAGS=--coverage"]
@@ -1066,6 +1083,9 @@ class MakeGenerator:
         elif ti.platform.simulation == "nsim" and do_run:
             if find_executable("nsimdrv"):
                 type = "nsim"
+        elif ti.platform.simulation == "renode" and do_run:
+            if find_executable("renode"):
+                type = "renode"
         elif options.device_testing and (not ti.build_only) and (not options.build_only):
             type = "device"
 


### PR DESCRIPTION
This pull requests adds Renode support for sanitycheck.

The tests on Renode are enabled for `m2gl025_miv` platform.

To run tests on Renode, you need to have it installed from a package.
Please download Renode from [the GitHub repository](https://github.com/renode/renode) and follow the [build instructions](https://renode.readthedocs.io/en/latest/advanced/building_from_sources.html).

To start tests, run `./scripts/sanitycheck --platform m2gl025_miv -v`

It is still work in progress. Renode hangs on failed tests, we need to solve closing the framework on timeout.

We are very interested in knowing if this approach (via cmake files and console analysis) is right and how should we move forward with enabling more platforms.