### PR TITLE
scripts: coccicheck: Improve continuous run operation

### DIFF
--- a/doc/application/coccinelle.rst
+++ b/doc/application/coccinelle.rst
@@ -235,6 +235,8 @@ sub-directories of ``scripts/coccinelle/``.
 
 The cocci script should have the following properties:
 
+* The script **must** have ``report`` mode.
+
 * The first few lines should state the purpose of the script
   using ``///`` comments . Usually, this message would be used as the
   commit log when proposing a patch based on the script.
@@ -512,9 +514,11 @@ illustrated below:
 Coccinelle Mailing List
 ***********************
 
-Interested developers can subscribe coccinelle mailing list via:
-        https://systeme.lip6.fr/mailman/listinfo/cocci
+Subscribe to the coccinelle mailing list:
+
+* https://systeme.lip6.fr/mailman/listinfo/cocci
 
 Archives:
-        https://lore.kernel.org/cocci/
-        https://systeme.lip6.fr/pipermail/cocci/
+
+* https://lore.kernel.org/cocci/
+* https://systeme.lip6.fr/pipermail/cocci/

--- a/scripts/coccicheck
+++ b/scripts/coccicheck
@@ -143,9 +143,20 @@ coccinelle () {
 	    echo "Consider adding vitrual rules to the script."
 	    exit 1
     elif [[ $VIRTUAL != *"$MODE"* ]]; then
-	    echo "Invalid mode \"$MODE\" supplied."
-	    echo "Available modes for \"$COCCI\" are: `echo $VIRTUAL`"
-	    exit 1
+	    echo "Invalid mode \"$MODE\" supplied!"
+	    echo "Available modes for \"`basename $COCCI`\" are: "$VIRTUAL""
+
+	    if [[ $VIRTUAL == *report* ]]; then
+		    MODE=report
+	    elif [[ $VIRTUAL == *context* ]]; then
+		    MODE=context
+	    elif [[ $VIRTUAL == *patch* ]]; then
+		    MODE=patch
+	    else
+		    MODE=org
+	    fi
+	    echo "Using random availble mode: \"$MODE\""
+	    echo ''
     fi
 
     if [ $VERBOSE -ne 0 ] ; then
@@ -201,6 +212,7 @@ coccinelle () {
 	run_cmd_parmap $SPATCH -D $MODE   $FLAGS --cocci-file $COCCI $OPT $OPTIONS || exit 1
     fi
 
+    MODE=report
 }
 
 if [ "$DEBUG_FILE" != "/dev/null" -a "$DEBUG_FILE" != "" ]; then
@@ -215,6 +227,8 @@ fi
 if [ "$COCCI" = "" ] ; then
     for f in `find $ZEPHYR_BASE/scripts/coccinelle/ -name '*.cocci' -type f | sort`; do
 	coccinelle $f
+	echo '-------------------------------------------------------------------------'
+	echo ''
     done
 else
     coccinelle $COCCI


### PR DESCRIPTION
The current implementation of continuous run operation using
command `./scripts/coccicheck` i.e., without specifying any options,
`coccicheck` default runs in `report` mode with all available
coccinelle scripts present at `scripts/coccinelle/`.

Not all scripts have report mode implemented in them, which
leads to failure of coccicheck.

With this new implementation we choose whatever available mode
is present in coccinelle script and pass it to MODE variable
without stopping continuous coverage.

And perhaps if there are plans to add `coccicheck` as a sanity
checker in future to the Zephyr automated CI, then certainly we
want the warnings/errors produced by scripts to be less verbose
to the users.

Therefore, in this new implementation we prioritise the modes as:

1. report
2. context
3. patch
and lastly falling to
4. org

Lastly, in order to differentiate between outputs of various
coccinelle scripts being run, `x------x` separator has been used
to make reports mode readable.

Signed-off-by: Himanshu Jha <himanshujha199640@gmail.com>

Cc @JuliaLawall @nashif 

Sample run with some statistics:
```
himanshu@himanshu-Vostro-3559:~/zephyr$ time ./scripts/coccicheck --verbose=1
You have not explicitly specified the mode to use. Using default "report" mode.
Available modes are the following: patch, report, context, org
You can specify the mode with "./scripts/coccicheck --mode=<mode>"
Note however that some modes are not implemented by some semantic patches.

Please check for false positives in the output before submitting a patch.
When using "patch" mode, carefully review the patch before submitting it.

Processing array_size.cocci
with option(s) " --no-includes --include-headers"

Message example to submit a patch:
 Use ARRAY_SIZE instead of dividing sizeof array with sizeof an element

 The semantic patch that makes this report is available
 in scripts/coccinelle/array_size.cocci.

 More information about semantic patching is available at
 http://coccinelle.lip6.fr/

Semantic patch information:
 This makes an effort to find cases where ARRAY_SIZE can be used such as
 where there is a division of sizeof the array by the sizeof its first
 element or by any indexed element or the element type. It replaces the
 division of the two sizeofs by ARRAY_SIZE.

Running (4 in parallel): /usr/local/bin/spatch -D report --no-show-diff --very-quiet --cocci-file /home/himanshu/zephyr/scripts/coccinelle/array_size.cocci --no-includes --include-headers --dir /home/himanshu/zephyr --jobs 4 --chunksize 1
X-------------------------------------------------------------------------X

Processing deref_null.cocci
with option(s) ""

Message example to submit a patch:

 A variable is dereferenced under a NULL test.
 Even though it is known to be NULL.

 The semantic patch that makes this report is available
 in scripts/coccinelle/deref_null.cocci.

 More information about semantic patching is available at
 http://coccinelle.lip6.fr/

Running (4 in parallel): /usr/local/bin/spatch -D report --no-show-diff --very-quiet --cocci-file /home/himanshu/zephyr/scripts/coccinelle/deref_null.cocci --dir /home/himanshu/zephyr --jobs 4 --chunksize 1
X-------------------------------------------------------------------------X

Invalid mode "report" supplied!
Available modes for "ignore_return.cocci" are: patch
Using random availble mode: "patch"

Processing ignore_return.cocci
with option(s) ""

Message example to submit a patch:
 Cast void to memset to ignore its return value

 The semantic patch that makes this change is available
 in scripts/coccinelle/ignore_return.cocci.

 More information about semantic patching is available at
 http://coccinelle.lip6.fr/

Semantic patch information:
 The return of memset is never checked and therefore cast
 it to void to explicitly ignore while adhering to MISRA-C.

Running (4 in parallel): /usr/local/bin/spatch -D patch --no-show-diff --very-quiet --cocci-file /home/himanshu/zephyr/scripts/coccinelle/ignore_return.cocci --dir /home/himanshu/zephyr --jobs 4 --chunksize 1
X-------------------------------------------------------------------------X

Invalid mode "report" supplied!
Available modes for "irq_lock.cocci" are: patch
Using random availble mode: "patch"

Processing irq_lock.cocci
with option(s) ""

Message example to submit a patch:
 Use unsigned int as the return value for irq_lock()

 The semantic patch that makes this change is available
 in scripts/coccinelle/irq_lock.cocci.

 More information about semantic patching is available at
 http://coccinelle.lip6.fr/

Running (4 in parallel): /usr/local/bin/spatch -D patch --no-show-diff --very-quiet --cocci-file /home/himanshu/zephyr/scripts/coccinelle/irq_lock.cocci --dir /home/himanshu/zephyr --jobs 4 --chunksize 1
X-------------------------------------------------------------------------X

Processing mini_lock.cocci
with option(s) ""

Message example to submit a patch:
 Find missing unlocks.  This semantic match considers the specific case
 where the unlock is missing from an if branch, and there is a lock
 before the if and an unlock after the if.  False positives are due to
 cases where the if branch represents a case where the function is
 supposed to exit with the lock held, or where there is some preceding
 function call that releases the lock.

 The semantic patch that makes this report is available
 in scripts/coccinelle/mini_lock.cocci.

 More information about semantic patching is available at
 http://coccinelle.lip6.fr/

Running (4 in parallel): /usr/local/bin/spatch -D report --no-show-diff --very-quiet --cocci-file /home/himanshu/zephyr/scripts/coccinelle/mini_lock.cocci --dir /home/himanshu/zephyr --jobs 4 --chunksize 1
/home/himanshu/zephyr/subsys/bluetooth/host/rfcomm.c:519:2-8: preceding lock on line 516
X-------------------------------------------------------------------------X

Processing noderef.cocci
with option(s) " --no-includes --include-headers"

Message example to submit a patch:
 sizeof when applied to a pointer typed expression gives the size of
 the pointer

 The semantic patch that makes this report is available
 in scripts/coccinelle/noderef.cocci.

 More information about semantic patching is available at
 http://coccinelle.lip6.fr/

Running (4 in parallel): /usr/local/bin/spatch -D report --no-show-diff --very-quiet --cocci-file /home/himanshu/zephyr/scripts/coccinelle/noderef.cocci --no-includes --include-headers --dir /home/himanshu/zephyr --jobs 4 --chunksize 1
/home/himanshu/zephyr/subsys/bluetooth/controller/util/mem.c:79:23-29: ERROR: application of sizeof to pointer
X-------------------------------------------------------------------------X

Processing semicolon.cocci
with option(s) " --no-includes --include-headers"

Message example to submit a patch:

 Remove unneeded semicolon.

 The semantic patch that makes this report is available
 in scripts/coccinelle/semicolon.cocci.

 More information about semantic patching is available at
 http://coccinelle.lip6.fr/

Running (4 in parallel): /usr/local/bin/spatch -D report --no-show-diff --very-quiet --cocci-file /home/himanshu/zephyr/scripts/coccinelle/semicolon.cocci --no-includes --include-headers --dir /home/himanshu/zephyr --jobs 4 --chunksize 1
/home/himanshu/zephyr/lib/libc/minimal/source/string/string.c:253:3-4: Unneeded semicolon
/home/himanshu/zephyr/lib/libc/minimal/source/string/string.c:299:2-3: Unneeded semicolon
/home/himanshu/zephyr/samples/boards/bbc_microbit/pong/src/main.c:215:2-3: Unneeded semicolon
/home/himanshu/zephyr/subsys/bluetooth/host/hci_core.c:2019:3-4: Unneeded semicolon
/home/himanshu/zephyr/subsys/bluetooth/host/hci_core.c:2240:3-4: Unneeded semicolon
/home/himanshu/zephyr/subsys/bluetooth/shell/bredr.c:118:3-4: Unneeded semicolon
/home/himanshu/zephyr/tests/drivers/i2c/i2c_slave_api/common/i2c_virtual.c:203:2-3: Unneeded semicolon
/home/himanshu/zephyr/samples/net/wpan_serial/src/main.c:634:2-3: Unneeded semicolon
/home/himanshu/zephyr/samples/boards/up_squared/gpio_counter/src/main.c:127:2-3: Unneeded semicolon
/home/himanshu/zephyr/subsys/bluetooth/host/l2cap_br.c:620:2-3: Unneeded semicolon
/home/himanshu/zephyr/tests/drivers/watchdog/wdt_basic_api/src/test_wdt.c:201:2-3: Unneeded semicolon
/home/himanshu/zephyr/tests/drivers/watchdog/wdt_basic_api/src/test_wdt.c:262:2-3: Unneeded semicolon
/home/himanshu/zephyr/tests/drivers/watchdog/wdt_basic_api/src/test_wdt.c:154:2-3: Unneeded semicolon
/home/himanshu/zephyr/samples/drivers/watchdog/src/main.c:74:2-3: Unneeded semicolon
/home/himanshu/zephyr/subsys/net/ip/icmpv6.c:157:42-43: Unneeded semicolon
/home/himanshu/zephyr/subsys/net/ip/icmpv6.c:191:45-46: Unneeded semicolon
/home/himanshu/zephyr/subsys/bluetooth/host/smp.c:3785:2-3: Unneeded semicolon
/home/himanshu/zephyr/subsys/bluetooth/host/smp.c:3791:2-3: Unneeded semicolon
X-------------------------------------------------------------------------X

Processing unsigned_lesser_than_zero.cocci
with option(s) ""

Message example to submit a patch:
 Unsigned expressions cannot be lesser than zero. Presence of
 comparisons 'unsigned (<|<=) 0' often indicates a bug,
 usually wrong type of variable.

 The semantic patch that makes this report is available
 in scripts/coccinelle/unsigned_lesser_than_zero.cocci.

 More information about semantic patching is available at
 http://coccinelle.lip6.fr/

Running (4 in parallel): /usr/local/bin/spatch -D report --no-show-diff --very-quiet --cocci-file /home/himanshu/zephyr/scripts/coccinelle/unsigned_lesser_than_zero.cocci --dir /home/himanshu/zephyr --jobs 4 --chunksize 1
/home/himanshu/zephyr/drivers/spi/spi_sam0.c:231:5-8: WARNING: Unsigned expression compared with zero.
/home/himanshu/zephyr/subsys/net/lib/lwm2m/lwm2m_obj_device.c:172:5-16: WARNING: Unsigned expression compared with zero.
/home/himanshu/zephyr/subsys/net/lib/mqtt/mqtt_pkt.c:638:5-10: WARNING: Unsigned expression compared with zero.
/home/himanshu/zephyr/subsys/net/lib/mqtt/mqtt_pkt.c:793:5-13: WARNING: Unsigned expression compared with zero.
/home/himanshu/zephyr/lib/posix/mqueue.c:71:45-53: WARNING: Unsigned expression compared with zero.
/home/himanshu/zephyr/lib/posix/mqueue.c:72:10-18: WARNING: Unsigned expression compared with zero.
/home/himanshu/zephyr/drivers/flash/soc_flash_nios2_qspi.c:90:7-23: WARNING: Unsigned expression compared with zero.
/home/himanshu/zephyr/drivers/flash/soc_flash_nios2_qspi.c:283:6-22: WARNING: Unsigned expression compared with zero.
/home/himanshu/zephyr/drivers/spi/spi_sam.c:223:5-8: WARNING: Unsigned expression compared with zero.
X-------------------------------------------------------------------------X

Invalid mode "report" supplied!
Available modes for "unsigned_shift.cocci" are: patch
Using random availble mode: "patch"

Processing unsigned_shift.cocci
with option(s) ""

Message example to submit a patch:
 Use BIT() helper macro instead of hardcoding using bitshifting

 The semantic patch that makes this change is available
 in scripts/coccinelle/unsigned_shift.cocci.

 More information about semantic patching is available at
 http://coccinelle.lip6.fr/

Running (4 in parallel): /usr/local/bin/spatch -D patch --no-show-diff --very-quiet --cocci-file /home/himanshu/zephyr/scripts/coccinelle/unsigned_shift.cocci --dir /home/himanshu/zephyr --jobs 4 --chunksize 1
X-------------------------------------------------------------------------X


real	9m40.874s
user	36m58.083s
sys	0m15.343s

himanshu@himanshu-Vostro-3559:~/zephyr$ find scripts/coccinelle/ -name "*.cocci" | wc -l
9

himanshu@himanshu-Vostro-3559:~/zephyr$ lscpu 
Architecture:        x86_64
CPU op-mode(s):      32-bit, 64-bit
Byte Order:          Little Endian
CPU(s):              4
On-line CPU(s) list: 0-3
Thread(s) per core:  2
Core(s) per socket:  2
Socket(s):           1
NUMA node(s):        1
Vendor ID:           GenuineIntel
CPU family:          6
Model:               78
Model name:          Intel(R) Core(TM) i5-6200U CPU @ 2.30GHz
Stepping:            3
CPU MHz:             1191.070
CPU max MHz:         2800.0000
CPU min MHz:         400.0000
BogoMIPS:            4800.00
Virtualization:      VT-x
L1d cache:           32K
L1i cache:           32K
L2 cache:            256K
L3 cache:            3072K
NUMA node0 CPU(s):   0-3
```
