### PR TITLE
samples: console: echo: Be sure to print (both) CR LF in messages

### DIFF
--- a/samples/subsys/console/echo/src/main.c
+++ b/samples/subsys/console/echo/src/main.c
@@ -6,7 +6,7 @@
 #include <zephyr.h>
 #include <console.h>
 
-static const char prompt[] = "Start typing characters to see them echoed back\n";
+static const char prompt[] = "Start typing characters to see them echoed back\r\n";
 
 void main(void)
 {


### PR DESCRIPTION
As it stands now, the console effectively works in raw mode, so all
messages should end with "\r\n". This was missed previously, because
the sample was run in QEMU, on top of POSIX cooked console. Running
on real hardware showed this issue.

Signed-off-by: Paul Sokolovsky <paul.sokolovsky@linaro.org>