### PR TITLE
net: sockets: zsock_close: Be sure to free file descriptor

### DIFF
--- a/subsys/net/lib/sockets/sockets.c
+++ b/subsys/net/lib/sockets/sockets.c
@@ -139,6 +139,8 @@ int _impl_zsock_close(int sock)
 		return -1;
 	}
 
+	z_free_fd(sock);
+
 	return zsock_close_ctx(ctx);
 }
 


### PR DESCRIPTION
File descriptor I freed automagically when using POSIX subsystem's
close() function, but any subsys-adhoc functions like zsock_close()
should do that explicitly.

Signed-off-by: Paul Sokolovsky <paul.sokolovsky@linaro.org>