### PR TITLE
drivers: flash: spi_nor: Manage SPI CS with GPIO

### DIFF
--- a/drivers/flash/Kconfig.nor
+++ b/drivers/flash/Kconfig.nor
@@ -73,4 +73,33 @@ config SPI_NOR_BLOCK_ERASE_SIZE
 	default 4 if SPI_NOR_BLOCK_ERASE_64K
 	help
 	This option specifies block size of SPI flash
+
+config SPI_NOR_GPIO_SPI_CS
+	bool "Manage SPI CS through a GPIO pin"
+	help
+	This option is useful if one needs to manage SPI CS through a GPIO
+	pin to by-pass the SPI controller's CS logic.
+
+config SPI_NOR_GPIO_SPI_CS_DRV_NAME
+	string "GPIO driver's name to use to drive SPI CS through"
+	depends on SPI_NOR_GPIO_SPI_CS
+	help
+	This option is mandatory to set which GPIO controller to use in order
+	to actually emulate the SPI CS.
+
+config SPI_NOR_GPIO_SPI_CS_PIN
+	int "GPIO PIN to use to drive SPI CS through"
+	default 0
+	depends on SPI_NOR_GPIO_SPI_CS
+	help
+	This option is mandatory to set which GPIO pin to use in order
+	to actually emulate the SPI CS.
+
+config SPI_NOR_GPIO_SPI_CS_WAIT_DELAY
+	int "Delay time in us"
+	default 0
+		depends on SPI_NOR_GPIO_SPI_CS
+	help
+	This is the wait delay (in us) to allow for CS switching to take effect
+
 endif # SPI_NOR


### PR DESCRIPTION
Added the way to manage SPI NOR with a GPIO Pin. Inspired from
the existing W25QXXDV SPI FLASH driver.

Tested on a custom board with Cypress S25FL164K NOR flash.
Unfortunately I cannot post any code related to this board, and so my tests.