### PR TITLE
subsys: logging: Fix invalid memory access

### DIFF
--- a/subsys/logging/log_msg.c
+++ b/subsys/logging/log_msg.c
@@ -167,7 +167,9 @@ static struct log_msg *msg_alloc(u32_t nargs)
 
 		if (!cont) {
 			msg_free(msg);
+			return NULL;
 		}
+
 		*next = cont;
 		cont->next = NULL;
 		next = &cont->next;


### PR DESCRIPTION
Coverity-CID: 189512

Signed-off-by: Flavio Ceolin <flavio.ceolin@intel.com>