### PR TITLE
drivers: usb_dc_sam: kill a coverity warning

### DIFF
--- a/drivers/usb/device/usb_dc_sam.c
+++ b/drivers/usb/device/usb_dc_sam.c
@@ -658,7 +658,7 @@ int usb_dc_ep_flush(u8_t ep)
 int usb_dc_ep_write(u8_t ep, const u8_t *data, u32_t data_len, u32_t *ret_bytes)
 {
 	u8_t ep_idx = EP_ADDR2IDX(ep);
-	u32_t packet_len = min(data_len, usb_dc_ep_mps(ep));
+	u32_t packet_len;
 
 	if (ep_idx >= DT_USBHS_NUM_BIDIR_EP) {
 		LOG_ERR("wrong endpoint index/address");
@@ -681,6 +681,7 @@ int usb_dc_ep_write(u8_t ep, const u8_t *data, u32_t data_len, u32_t *ret_bytes)
 	}
 
 	/* Write the data to the FIFO */
+	packet_len = min(data_len, dev_data.ep_data[ep_idx].mps);
 	for (int i = 0; i < packet_len; i++) {
 		usb_dc_ep_fifo_put(ep_idx, data[i]);
 	}


### PR DESCRIPTION
Coverity complains that packet_len can get assigned a negative value if
usb_dc_ep_mps() returns an error. This is correct, however it only
happens if the endpoint address is invalid, and in that case the value
is not used as the endpoint address is also validated in
usb_dc_ep_write().

Fix the issue by moving the assignment after the endpoint address
validation and by accessing the value directly instead of getting it
through usb_dc_ep_mps().

Fixes #11481

Signed-off-by: Aurelien Jarno <aurelien@aurel32.net>