### PR TITLE
drivers: timers: systick: Enforce a barrier in _timer_cycle_get_32.

### DIFF
--- a/drivers/timer/cortex_m_systick.c
+++ b/drivers/timer/cortex_m_systick.c
@@ -41,6 +41,7 @@ static u32_t elapsed(void)
 	do {
 		val = SysTick->VAL & COUNTER_MAX;
 		ctrl_cache |= SysTick->CTRL;
+		__ISB();
 	} while (SysTick->VAL > val);
 
 	ov = (ctrl_cache & SysTick_CTRL_COUNTFLAG_Msk) ? last_load : 0;


### PR DESCRIPTION
This fix was missed out in the timer rework. 
This patch was taken from 36365e38ba3f2cfb810235e4b1b2f7145c813cfd
and re applied.

The code assumes that when the systick counter hits zero,
the timer interrupt will be taken before the loop can
read the LOAD/VAL registers, but this is not architecturally
guaranteed, and so the code can see a post-reload SysTick->VAL
and a pre-reload clock_accumulated_count, which causes it to
return an incorrectly small cycle count. By adding a ISB we
overcome this issue.

Signed-off-by: Adithya Baglody <adithya.nagaraj.baglody@intel.com>