### PR TITLE
Bluetooth: host: Increase ECC thread stack

### DIFF
--- a/subsys/bluetooth/host/hci_ecc.c
+++ b/subsys/bluetooth/host/hci_ecc.c
@@ -36,7 +36,7 @@
 #endif
 
 static struct k_thread ecc_thread_data;
-static K_THREAD_STACK_DEFINE(ecc_thread_stack, 1024);
+static K_THREAD_STACK_DEFINE(ecc_thread_stack, 1100);
 
 /* based on Core Specification 4.2 Vol 3. Part H 2.3.5.6.1 */
 static const u32_t debug_private_key[8] = {


### PR DESCRIPTION
Logging subsystem could take few extra bytes when enabled.
ECC thread stack has been unconditionally increased to support it.
    
During my test, I noticed a usage of 1052 bytes when logging subsystem is enabled.

Signed-off-by: Olivier Martin <olivier.martin@proglove.de>