### PR TITLE
net: llmnr_responder: Check return value of net_udp_get_hdr

### DIFF
--- a/subsys/net/lib/dns/llmnr_responder.c
+++ b/subsys/net/lib/dns/llmnr_responder.c
@@ -92,6 +92,10 @@ static void create_ipv4_dst_addr(struct net_pkt *pkt,
 	struct net_udp_hdr *udp_hdr, hdr;
 
 	udp_hdr = net_udp_get_hdr(pkt, &hdr);
+	if (!udp_hdr) {
+		NET_ERR("could not get UDP header");
+		return;
+	}
 
 	addr->sin_family = AF_INET;
 	addr->sin_port = udp_hdr->src_port;


### PR DESCRIPTION
net_udp_get_hdr() function returns NULL on failure. Therefore
handle its return value to avoid potential NULL dereference.

Fixes #11485
Coverity-CID: 189738

Signed-off-by: Himanshu Jha <himanshujha199640@gmail.com>