### PR TITLE
kernel/timeout: Fix race with clock timeout setting

### DIFF
--- a/kernel/sched.c
+++ b/kernel/sched.c
@@ -206,6 +206,17 @@ static struct k_thread *next_up(void)
 static int slice_time;
 static int slice_max_prio;
 
+/* Subtle note on locking here: in theory we're subject to a race
+ * where _get_next_timeout_expiry() returns a value that changes
+ * between the return and the z_clock_set_timeout() of the adjusted
+ * time: another context can add a new timeout that should expire
+ * sooner, and we'll miss it.  But that's OK, because (1) we're inside
+ * the scheduler lock, so cannot be interrupted on uniprocessor
+ * systems, and (2) it's an interrupt time for our local CPU -- in
+ * SMP, it's safe to miss a timeout as long as another CPU (i.e. the
+ * one we're racing against) is available to wake up at the
+ * appropriate time.
+ */
 static void reset_time_slice(void)
 {
 	int to = _get_next_timeout_expiry();

--- a/kernel/timeout.c
+++ b/kernel/timeout.c
@@ -84,9 +84,9 @@ void _add_timeout(struct _timeout *to, _timeout_func_t fn, s32_t ticks)
 		if (t == NULL) {
 			sys_dlist_append(&timeout_list, &to->node);
 		}
-	}
 
-	z_clock_set_timeout(_get_next_timeout_expiry(), false);
+		z_clock_set_timeout(_get_next_timeout_expiry(), false);
+	}
 }
 
 int _abort_timeout(struct _timeout *to)
@@ -158,9 +158,9 @@ void z_clock_announce(s32_t ticks)
 	LOCKED(&timeout_lock) {
 		curr_tick += announce_remaining;
 		announce_remaining = 0;
-	}
 
-	z_clock_set_timeout(_get_next_timeout_expiry(), false);
+		z_clock_set_timeout(_get_next_timeout_expiry(), false);
+	}
 }
 
 s32_t _get_next_timeout_expiry(void)


### PR DESCRIPTION
The call to z_clock_set_timeout() was being made outside the timeout
lock, which can race against other contexts setting sooner-expiring
timeouts.

Also add a long comment to one spot (timeslicing) where this call is
made outside the timeout spinlock (inside the scheduler lock) and why
this is OK.

Signed-off-by: Andy Ross <andrew.j.ross@intel.com>