### PR TITLE
dts: ieee802154: cc1200: Add DTS support

### DIFF
--- a/drivers/ieee802154/Kconfig.cc1200
+++ b/drivers/ieee802154/Kconfig.cc1200
@@ -14,47 +14,11 @@ config IEEE802154_CC1200_DRV_NAME
 	help
 	  This option sets the driver name
 
-config IEEE802154_CC1200_SPI_DRV_NAME
-	string "SPI driver's name to use to access CC1200"
-	help
-	  This option is mandatory to set which SPI controller to use in order
-	  to actually control the CC1200 chip.
-
-config IEEE802154_CC1200_SPI_FREQ
-	int "SPI system frequency"
-	default 0
-	help
-	  This option sets the SPI controller's frequency. Beware this value
-	  depends on the SPI controller being used and also on the system
-	  clock.
-
-config IEEE802154_CC1200_SPI_SLAVE
-	int "SPI slave linked to CC1200"
-	default 0
-	help
-	  This option sets the SPI slave number SPI controller has to switch
-	  to when dealing with CC1200 chip.
-
 config IEEE802154_CC1200_GPIO_SPI_CS
 	bool "Manage SPI CS through a GPIO pin"
 	help
 	  This option is useful if one needs to manage SPI CS through a GPIO
 	  pin to by-pass the SPI controller's CS logic.
-
-config IEEE802154_CC1200_GPIO_SPI_CS_DRV_NAME
-	string "GPIO driver's name to use to drive SPI CS through"
-	depends on IEEE802154_CC1200_GPIO_SPI_CS
-	help
-	  This option is mandatory to set which GPIO controller to use in order
-	  to actually emulate the SPI CS.
-
-config IEEE802154_CC1200_GPIO_SPI_CS_PIN
-	int "GPIO PIN to use to drive SPI CS through"
-	default 0
-	depends on IEEE802154_CC1200_GPIO_SPI_CS
-	help
-	  This option is mandatory to set which GPIO pin to use in order
-	  to actually emulate the SPI CS.
 
 config IEEE802154_CC1200_RX_STACK_SIZE
 	int "Driver's internal RX thread stack size"

--- a/drivers/ieee802154/ieee802154_cc1200.c
+++ b/drivers/ieee802154/ieee802154_cc1200.c
@@ -744,8 +744,7 @@ static int configure_spi(struct device *dev)
 {
 	struct cc1200_context *cc1200 = dev->driver_data;
 
-	cc1200->spi = device_get_binding(
-			CONFIG_IEEE802154_CC1200_SPI_DRV_NAME);
+	cc1200->spi = device_get_binding(DT_IEEE802154_CC1200_SPI_DRV_NAME);
 	if (!cc1200->spi) {
 		LOG_ERR("Unable to get SPI device");
 		return -ENODEV;
@@ -753,25 +752,25 @@ static int configure_spi(struct device *dev)
 
 	if (IS_ENABLED(CONFIG_IEEE802154_CC1200_GPIO_SPI_CS)) {
 		cs_ctrl.gpio_dev = device_get_binding(
-			CONFIG_IEEE802154_CC1200_GPIO_SPI_CS_DRV_NAME);
+			DT_IEEE802154_CC1200_GPIO_SPI_CS_DRV_NAME);
 		if (!cs_ctrl.gpio_dev) {
 			LOG_ERR("Unable to get GPIO SPI CS device");
 			return -ENODEV;
 		}
 
-		cs_ctrl.gpio_pin = CONFIG_IEEE802154_CC1200_GPIO_SPI_CS_PIN;
+		cs_ctrl.gpio_pin = DT_IEEE802154_CC1200_GPIO_SPI_CS_PIN;
 		cs_ctrl.delay = 0;
 
 		cc1200->spi_cfg.cs = &cs_ctrl;
 
 		LOG_DBG("SPI GPIO CS configured on %s:%u",
-			    CONFIG_IEEE802154_CC1200_GPIO_SPI_CS_DRV_NAME,
-			    CONFIG_IEEE802154_CC1200_GPIO_SPI_CS_PIN);
+			    DT_IEEE802154_CC1200_GPIO_SPI_CS_DRV_NAME,
+			    DT_IEEE802154_CC1200_GPIO_SPI_CS_PIN);
 	}
 
 	cc1200->spi_cfg.operation = SPI_WORD_SET(8);
-	cc1200->spi_cfg.frequency = CONFIG_IEEE802154_CC1200_SPI_FREQ;
-	cc1200->spi_cfg.slave = CONFIG_IEEE802154_CC1200_SPI_SLAVE;
+	cc1200->spi_cfg.frequency = DT_IEEE802154_CC1200_SPI_FREQ;
+	cc1200->spi_cfg.slave = DT_IEEE802154_CC1200_SPI_SLAVE;
 
 	return 0;
 }

--- a/dts/bindings/ieee802154/ti,cc1200.yaml
+++ b/dts/bindings/ieee802154/ti,cc1200.yaml
@@ -1,0 +1,23 @@
+#
+# Copyright (c) 2018, Linaro Limited
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+---
+title: CC1200 802.15.4 Wireless Transceiver
+version: 0.1
+
+description: >
+    This is a representation of the CC1200 wireless transceiver.
+
+inherits:
+    !include spi-device.yaml
+
+properties:
+    compatible:
+      type: string
+      category: required
+      description: compatible strings
+      constraint: "ti,cc1200"
+
+...


### PR DESCRIPTION
Add a dts binding file for the cc1200 and move the Kconfig options for
SPI and GPIOs to DTS for the CC1200 driver.

Signed-off-by: Kumar Gala <kumar.gala@linaro.org>