### PR TITLE
ci: do not build docs in main CI job

### DIFF
--- a/scripts/ci/run_ci.sh
+++ b/scripts/ci/run_ci.sh
@@ -128,10 +128,11 @@ function get_tests_to_run() {
 }
 
 if [ ! -z "${BSIM_OUT_PATH}" ]; then
+	# Build BT Simulator
+	build_btsim
+
 	# Run BLE tests in simulator on the 1st CI instance:
 	if [ "$MATRIX" = "1" ]; then
-		# Build BT Simulator
-		build_btsim
 		run_bsim_bt_tests
 	fi
 else

--- a/scripts/ci/run_ci.sh
+++ b/scripts/ci/run_ci.sh
@@ -54,6 +54,7 @@ while getopts ":pm:b:r:M:" opt; do
 done
 
 DOC_MATRIX=${MATRIX_BUILDS}
+
 if [ -z "$BRANCH" ]; then
 	echo "No base branch given"
 	exit
@@ -135,12 +136,6 @@ if [ ! -z "${BSIM_OUT_PATH}" ]; then
 	fi
 else
 	echo "Skipping BT simulator tests"
-fi
-
-# Build Docs on matrix 5 in a pull request
-if [ "${MATRIX}" = "${DOC_MATRIX}" -a -n "${PULL_REQUEST}" ]; then
-	build_docs
-	./scripts/ci/check-compliance.py --commits ${COMMIT_RANGE} || true;
 fi
 
 # In a pull-request see if we have changed any tests or board definitions


### PR DESCRIPTION
Building docs and running various checks is now being done in another CI
job that runs in parallel and reports directly to the PR.

Signed-off-by: Anas Nashif <anas.nashif@intel.com>