### PR TITLE
Bluetooth: controller: Extra master SCA Kconfig option

### DIFF
--- a/subsys/bluetooth/controller/Kconfig
+++ b/subsys/bluetooth/controller/Kconfig
@@ -343,6 +343,15 @@ config BT_CTLR_PHY_CODED
 
 endif # BT_CTLR_PHY
 
+config BT_CTLR_MASTER_SCA_EXTRA
+	int "Master SCA Compensation PPM"
+	depends on BT_PERIPHERAL
+	range 0 500
+	default 0
+	help
+	  Compensate for masters with incorrect SCA, communicated at connection
+	  establishment, by adding an extra jitter value to window widening.
+
 config BT_CTLR_WORKER_PRIO
 	int "Radio and Ticker's Worker IRQ priority"
 	range 0 3 if SOC_SERIES_NRF51X

--- a/subsys/bluetooth/controller/ll_sw/ctrl.c
+++ b/subsys/bluetooth/controller/ll_sw/ctrl.c
@@ -47,6 +47,12 @@
 #define LOG_MODULE_NAME bt_ctlr_llsw_ctrl
 #include "common/log.h"
 
+#if defined(CONFIG_BT_CTLR_MASTER_SCA_EXTRA)
+#define CLOCK_ACCURACY_EXTRA CONFIG_BT_CTLR_MASTER_SCA_EXTRA
+#else
+#define CLOCK_ACCURACY_EXTRA 0
+#endif /* CONFIG_BT_CTLR_MASTER_SCA_EXTRA */
+
 #if defined(CONFIG_BT_CTLR_CONN_RSSI)
 #define RADIO_RSSI_SAMPLE_COUNT	10
 #define RADIO_RSSI_THRESHOLD	4
@@ -1109,7 +1115,7 @@ static inline u32_t isr_rx_adv(u8_t devmatch_ok, u8_t devmatch_id,
 		/* calculate the window widening */
 		conn->slave.sca = pdu_adv->connect_ind.sca;
 		conn->slave.window_widening_periodic_us =
-			(((gc_lookup_ppm[_radio.sca] +
+			(((gc_lookup_ppm[_radio.sca] + CLOCK_ACCURACY_EXTRA +
 			   gc_lookup_ppm[conn->slave.sca]) *
 			  conn_interval_us) + (1000000 - 1)) / 1000000;
 		conn->slave.window_widening_max_us =
@@ -6837,6 +6843,7 @@ static inline u32_t event_conn_upd_prep(struct connection *conn,
 
 			conn->slave.window_widening_periodic_us =
 				(((gc_lookup_ppm[_radio.sca] +
+				   CLOCK_ACCURACY_EXTRA +
 				   gc_lookup_ppm[conn->slave.sca]) *
 				  conn_interval_us) + (1000000 - 1)) / 1000000;
 			conn->slave.window_widening_max_us =


### PR DESCRIPTION
Added Kconfig option to use an extra master SCA PPM value as
compensation in slave's window widening with masters that
communicate incorrect master SCA at the time of connection
establishment.

Signed-off-by: Vinayak Kariappa Chettimada <vich@nordicsemi.no>