### PR TITLE
logging: Fix RTT backend being enabled with shell RTT

### DIFF
--- a/subsys/logging/Kconfig
+++ b/subsys/logging/Kconfig
@@ -297,7 +297,7 @@ config LOG_BACKEND_UART
 config LOG_BACKEND_RTT
 	bool "Enable Segger J-Link RTT backend"
 	depends on USE_SEGGER_RTT
-	default y
+	default y if !SHELL_BACKEND_RTT
 	help
 	  When enabled, backend will use RTT for logging. This backend works on a per
 	  message basis. Only a whole message (terminated with a carriage return: '\r')


### PR DESCRIPTION
If USE_SEGGER_RTT option was enabled then LOG_BACKEND_RTT was
enabled by default. In case shell RTT was also used then both
write to RTT. Updated Kconfig to prevent such situation.

Signed-off-by: Krzysztof Chruscinski <krzysztof.chruscinski@nordicsemi.no>