### PR TITLE
Arch arm mpu declare mpu config as const

### DIFF
--- a/arch/arm/core/cortex_m/mpu/arm_mpu_v7_internal.h
+++ b/arch/arm/core/cortex_m/mpu/arm_mpu_v7_internal.h
@@ -23,7 +23,7 @@ static void _mpu_init(void)
  * Note:
  *   The caller must provide a valid region index.
  */
-static void _region_init(u32_t index, struct arm_mpu_region *region_conf)
+static void _region_init(u32_t index, const struct arm_mpu_region *region_conf)
 {
 	/* Select the region you want to access */
 	MPU->RNR = index;

--- a/arch/arm/core/cortex_m/mpu/arm_mpu_v8_internal.h
+++ b/arch/arm/core/cortex_m/mpu/arm_mpu_v8_internal.h
@@ -35,7 +35,7 @@ static void _mpu_init(void)
  * Note:
  *   The caller must provide a valid region index.
  */
-static void _region_init(u32_t index, struct arm_mpu_region *region_conf)
+static void _region_init(u32_t index, const struct arm_mpu_region *region_conf)
 {
 	ARM_MPU_SetRegion(
 		/* RNR */

--- a/include/arch/arm/cortex_m/mpu/arm_mpu.h
+++ b/include/arch/arm/cortex_m/mpu/arm_mpu.h
@@ -36,7 +36,7 @@ struct arm_mpu_config {
 	/* Number of regions */
 	u32_t num_regions;
 	/* Regions */
-	struct arm_mpu_region *mpu_regions;
+	const struct arm_mpu_region *mpu_regions;
 };
 
 #define MPU_REGION_ENTRY(_name, _base, _attr) \
@@ -54,6 +54,6 @@ struct arm_mpu_config {
  * for Thread Stack, Stack Guards, etc.) are programmed during runtime, thus,
  * not kept here.
  */
-extern struct arm_mpu_config mpu_config;
+extern const struct arm_mpu_config mpu_config;
 
 #endif /* ZEPHYR_INCLUDE_ARCH_ARM_CORTEX_M_MPU_ARM_MPU_H_ */

--- a/include/arch/arm/cortex_m/mpu/nxp_mpu.h
+++ b/include/arch/arm/cortex_m/mpu/nxp_mpu.h
@@ -151,7 +151,14 @@ struct nxp_mpu_config {
 	u32_t sram_region;
 };
 
-/* Reference to the MPU configuration */
+/* Reference to the MPU configuration.
+ *
+ * This struct is defined and populated for each SoC (in the SoC definition),
+ * and holds the build-time configuration information for the fixed MPU
+ * regions enabled during kernel initialization. Dynamic MPU regions (e.g.
+ * for Thread Stack, Stack Guards, etc.) are programmed during runtime, thus,
+ * not kept here.
+ */
 extern struct nxp_mpu_config mpu_config;
 
 #endif /* ZEPHYR_INCLUDE_ARCH_ARM_CORTEX_M_MPU_NXP_MPU_H_ */

--- a/include/arch/arm/cortex_m/mpu/nxp_mpu.h
+++ b/include/arch/arm/cortex_m/mpu/nxp_mpu.h
@@ -146,7 +146,7 @@ struct nxp_mpu_config {
 	/* Number of regions */
 	u32_t num_regions;
 	/* Regions */
-	struct nxp_mpu_region *mpu_regions;
+	const struct nxp_mpu_region *mpu_regions;
 	/* SRAM Region */
 	u32_t sram_region;
 };
@@ -159,6 +159,6 @@ struct nxp_mpu_config {
  * for Thread Stack, Stack Guards, etc.) are programmed during runtime, thus,
  * not kept here.
  */
-extern struct nxp_mpu_config mpu_config;
+extern const struct nxp_mpu_config mpu_config;
 
 #endif /* ZEPHYR_INCLUDE_ARCH_ARM_CORTEX_M_MPU_NXP_MPU_H_ */

--- a/soc/arm/arm/beetle/arm_mpu_regions.c
+++ b/soc/arm/arm/beetle/arm_mpu_regions.c
@@ -7,7 +7,7 @@
 #include <soc.h>
 #include <arch/arm/cortex_m/mpu/arm_mpu.h>
 
-static struct arm_mpu_region mpu_regions[] = {
+static const struct arm_mpu_region mpu_regions[] = {
 	/* Region 0 */
 	MPU_REGION_ENTRY("FLASH_0",
 			 CONFIG_FLASH_BASE_ADDRESS,
@@ -18,7 +18,7 @@ static struct arm_mpu_region mpu_regions[] = {
 			 REGION_RAM_ATTR(REGION_128K)),
 };
 
-struct arm_mpu_config mpu_config = {
+const struct arm_mpu_config mpu_config = {
 	.num_regions = ARRAY_SIZE(mpu_regions),
 	.mpu_regions = mpu_regions,
 };

--- a/soc/arm/arm/mps2/arm_mpu_regions.c
+++ b/soc/arm/arm/mps2/arm_mpu_regions.c
@@ -9,7 +9,7 @@
 #include <soc.h>
 #include <arch/arm/cortex_m/mpu/arm_mpu.h>
 
-static struct arm_mpu_region mpu_regions[] = {
+static const struct arm_mpu_region mpu_regions[] = {
 	/* Region 0 */
 	MPU_REGION_ENTRY("FLASH_0",
 			 CONFIG_FLASH_BASE_ADDRESS,
@@ -20,7 +20,7 @@ static struct arm_mpu_region mpu_regions[] = {
 			 REGION_RAM_ATTR(REGION_2M))
 };
 
-struct arm_mpu_config mpu_config = {
+const struct arm_mpu_config mpu_config = {
 	.num_regions = ARRAY_SIZE(mpu_regions),
 	.mpu_regions = mpu_regions,
 };

--- a/soc/arm/atmel_sam/common/arm_mpu_regions.c
+++ b/soc/arm/atmel_sam/common/arm_mpu_regions.c
@@ -9,7 +9,7 @@
 
 #include "arm_mpu_mem_cfg.h"
 
-static struct arm_mpu_region mpu_regions[] = {
+static const struct arm_mpu_region mpu_regions[] = {
 	/* Region 0 */
 	MPU_REGION_ENTRY("FLASH_0",
 			 CONFIG_FLASH_BASE_ADDRESS,
@@ -26,7 +26,7 @@ static struct arm_mpu_region mpu_regions[] = {
 #endif
 };
 
-struct arm_mpu_config mpu_config = {
+const struct arm_mpu_config mpu_config = {
 	.num_regions = ARRAY_SIZE(mpu_regions),
 	.mpu_regions = mpu_regions,
 };

--- a/soc/arm/nordic_nrf/nrf52/mpu_regions.c
+++ b/soc/arm/nordic_nrf/nrf52/mpu_regions.c
@@ -13,7 +13,7 @@
 #define PERIPH_BASE	0x40000000
 #define M4_PPB_BASE	0xE0000000
 
-static struct arm_mpu_region mpu_regions[] = {
+static const struct arm_mpu_region mpu_regions[] = {
 	/* Region 0 */
 	MPU_REGION_ENTRY("FLASH_0",
 			 CONFIG_FLASH_BASE_ADDRESS,
@@ -35,7 +35,7 @@ static struct arm_mpu_region mpu_regions[] = {
 #endif /* REGION_SRAM_1_SIZE */
 };
 
-struct arm_mpu_config mpu_config = {
+const struct arm_mpu_config mpu_config = {
 	.num_regions = ARRAY_SIZE(mpu_regions),
 	.mpu_regions = mpu_regions,
 };

--- a/soc/arm/nxp_imx/rt/arm_mpu_regions.c
+++ b/soc/arm/nxp_imx/rt/arm_mpu_regions.c
@@ -12,7 +12,7 @@
 #define PERIPH_BASE	0x40000000
 #define PPB_BASE	0xE0000000
 
-static struct arm_mpu_region mpu_regions[] = {
+static const struct arm_mpu_region mpu_regions[] = {
 	/* Region 0 */
 	MPU_REGION_ENTRY("FLASH_0",
 			 CONFIG_FLASH_BASE_ADDRESS,
@@ -23,7 +23,7 @@ static struct arm_mpu_region mpu_regions[] = {
 			 REGION_RAM_ATTR(REGION_SRAM_0_SIZE)),
 };
 
-struct arm_mpu_config mpu_config = {
+const struct arm_mpu_config mpu_config = {
 	.num_regions = ARRAY_SIZE(mpu_regions),
 	.mpu_regions = mpu_regions,
 };

--- a/soc/arm/nxp_kinetis/k6x/nxp_mpu_regions.c
+++ b/soc/arm/nxp_kinetis/k6x/nxp_mpu_regions.c
@@ -6,7 +6,7 @@
 #include <soc.h>
 #include <arch/arm/cortex_m/mpu/nxp_mpu.h>
 
-static struct nxp_mpu_region mpu_regions[] = {
+static const struct nxp_mpu_region mpu_regions[] = {
 	/* Region 0 */
 	MPU_REGION_ENTRY("DEBUGGER_0",
 			 0,
@@ -48,7 +48,7 @@ static struct nxp_mpu_region mpu_regions[] = {
 			 REGION_RAM_ATTR),
 };
 
-struct nxp_mpu_config mpu_config = {
+const struct nxp_mpu_config mpu_config = {
 	.num_regions = ARRAY_SIZE(mpu_regions),
 	.mpu_regions = mpu_regions,
 	.sram_region = 4,

--- a/soc/arm/st_stm32/common/arm_mpu_regions.c
+++ b/soc/arm/st_stm32/common/arm_mpu_regions.c
@@ -12,7 +12,7 @@
 /* SoC Private Peripheral Bus */
 #define PPB_BASE  0xE0000000
 
-static struct arm_mpu_region mpu_regions[] = {
+static const struct arm_mpu_region mpu_regions[] = {
 	/* Region 0 */
 	MPU_REGION_ENTRY("FLASH_0",
 			 CONFIG_FLASH_BASE_ADDRESS,
@@ -27,7 +27,7 @@ static struct arm_mpu_region mpu_regions[] = {
 			 REGION_RAM_ATTR(REGION_SRAM_1_SIZE)),
 };
 
-struct arm_mpu_config mpu_config = {
+const struct arm_mpu_config mpu_config = {
 	.num_regions = ARRAY_SIZE(mpu_regions),
 	.mpu_regions = mpu_regions,
 };


### PR DESCRIPTION
Define and declare mpu configuration structures as const.
Trivial.

Fixing #10320 
