### PR TITLE
shell: enable UART backend without interrupts

### DIFF
--- a/include/shell/shell_uart.h
+++ b/include/shell/shell_uart.h
@@ -26,7 +26,7 @@ struct shell_uart_ctrl_blk {
 	bool blocking;
 };
 
-#ifdef CONFIG_UART_INTERRUPT_DRIVEN
+#ifdef CONFIG_SHELL_BACKEND_SERIAL_INTERRUPT_DRIVEN
 #define UART_SHELL_TX_RINGBUF_DECLARE(_name, _size) \
 	RING_BUF_DECLARE(_name##_tx_ringbuf, _size)
 
@@ -39,13 +39,13 @@ struct shell_uart_ctrl_blk {
 
 #define UART_SHELL_RX_TIMER_PTR(_name) NULL
 
-#else /* CONFIG_UART_INTERRUPT_DRIVEN */
+#else /* CONFIG_SHELL_BACKEND_SERIAL_INTERRUPT_DRIVEN */
 #define UART_SHELL_TX_RINGBUF_DECLARE(_name, _size) /* Empty */
 #define UART_SHELL_TX_BUF_DECLARE(_name) /* Empty */
 #define UART_SHELL_RX_TIMER_DECLARE(_name) static struct k_timer _name##_timer
 #define UART_SHELL_TX_RINGBUF_PTR(_name) NULL
 #define UART_SHELL_RX_TIMER_PTR(_name) (&_name##_timer)
-#endif /* CONFIG_UART_INTERRUPT_DRIVEN */
+#endif /* CONFIG_SHELL_BACKEND_SERIAL_INTERRUPT_DRIVEN */
 
 /** @brief Shell UART transport instance structure. */
 struct shell_uart {

--- a/subsys/shell/Kconfig.backends
+++ b/subsys/shell/Kconfig.backends
@@ -25,16 +25,15 @@ config SHELL_BACKEND_SERIAL
 if SHELL_BACKEND_SERIAL
 
 # Internal config to enable UART interrupts if supported.
-config SHELL_BACKEND_SERIAL_FORCE_INTERRUPTS
-	bool
-	default y
+config SHELL_BACKEND_SERIAL_INTERRUPT_DRIVEN
+	bool "Interrupt driven"
+	default y if UART_INTERRUPT_DRIVEN
 	depends on SERIAL_SUPPORT_INTERRUPT
-	imply UART_INTERRUPT_DRIVEN
 
 config SHELL_BACKEND_SERIAL_TX_RING_BUFFER_SIZE
 	int "Set TX ring buffer size"
 	default 8
-	depends on UART_INTERRUPT_DRIVEN
+	depends on SHELL_BACKEND_SERIAL_INTERRUPT_DRIVEN
 	help
 	  If UART is utilizing DMA transfers then increasing ring buffer size
 	  increases transfers length and reduces number of interrupts.
@@ -52,7 +51,7 @@ config SHELL_BACKEND_SERIAL_RX_RING_BUFFER_SIZE
 config SHELL_BACKEND_SERIAL_RX_POLL_PERIOD
 	int "RX polling period (in milliseconds)"
 	default 10
-	depends on !UART_INTERRUPT_DRIVEN
+	depends on !SHELL_BACKEND_SERIAL_INTERRUPT_DRIVEN
 	help
 	  Determines how often UART is polled for RX byte.
 


### PR DESCRIPTION
Currently shell UART backend is interrupt driven if UART driver
is interrupt driven. That can be limitation if one instance
wants to use interrupts but shell UART should not.

Added option to shell uart to be able to control use of
interrupts. By default interrupts are enabled if driver
supports it.

Signed-off-by: Krzysztof Chruscinski <krzysztof.chruscinski@nordicsemi.no>