### PR TITLE
usb: console: Notify user about incorrect configuration

### DIFF
--- a/samples/subsys/usb/console/src/main.c
+++ b/samples/subsys/usb/console/src/main.c
@@ -6,9 +6,20 @@
 
 #include <zephyr.h>
 #include <misc/printk.h>
+#include <misc/util.h>
+#include <string.h>
 
 void main(void)
 {
+	if (strlen(CONFIG_UART_CONSOLE_ON_DEV_NAME) !=
+	    strlen(CONFIG_CDC_ACM_PORT_NAME) ||
+	    strncmp(CONFIG_UART_CONSOLE_ON_DEV_NAME, CONFIG_CDC_ACM_PORT_NAME,
+		    strlen(CONFIG_UART_CONSOLE_ON_DEV_NAME))) {
+		printk("Error: Console device name is not USB ACM\n");
+
+		return;
+	}
+
 	while (1) {
 		printk("Hello World! %s\n", CONFIG_ARCH);
 		k_sleep(K_SECONDS(1));


### PR DESCRIPTION
Since setting USB console port name is moved to DTS users have
problems enabling it. Notify user that the console is not set.

Fixes #10693

Signed-off-by: Andrei Emeltchenko <andrei.emeltchenko@intel.com>