### PR TITLE
drivers: serial: Update more DTS-derived labels with DT_ prefix

### DIFF
--- a/drivers/serial/uart_msp432p4xx.c
+++ b/drivers/serial/uart_msp432p4xx.c
@@ -144,11 +144,11 @@ static int uart_msp432p4xx_init(struct device *dev)
 	MAP_UART_enableModule((unsigned long)config->base);
 
 #ifdef CONFIG_UART_INTERRUPT_DRIVEN
-	IRQ_CONNECT(TI_MSP432P4XX_UART_40001000_IRQ_0,
-			TI_MSP432P4XX_UART_40001000_IRQ_0_PRIORITY,
+	IRQ_CONNECT(DT_TI_MSP432P4XX_UART_40001000_IRQ_0,
+			DT_TI_MSP432P4XX_UART_40001000_IRQ_0_PRIORITY,
 			uart_msp432p4xx_isr, DEVICE_GET(uart_msp432p4xx_0),
 			0);
-	irq_enable(TI_MSP432P4XX_UART_40001000_IRQ_0);
+	irq_enable(DT_TI_MSP432P4XX_UART_40001000_IRQ_0);
 
 #endif
 	return 0;


### PR DESCRIPTION
This is a follow-up to commit b3ca789ef25627bcf7b02ec2aa7fa900fba37227.
Apparently, another driver needed to be updated but this was not caught
up in CI builds at that time.

Signed-off-by: Andrzej Głąbek <andrzej.glabek@nordicsemi.no>

Fixes #11532.