### PR TITLE
samples: wifi: Enable sample on disco_l475_iot1

### DIFF
--- a/samples/net/wifi/sample.yaml
+++ b/samples/net/wifi/sample.yaml
@@ -6,4 +6,4 @@ sample:
   name: WiFi sample app
 tests:
   test:
-    platform_whitelist: quark_se_c1000_devboard cc3220sf_launchxl
+    platform_whitelist: quark_se_c1000_devboard cc3220sf_launchxl disco_l475_iot1


### PR DESCRIPTION
The disco_l475_iot1 has the Inventek eS-WiFi, so lets enable the sample
on the board.  (This also gets us something that will build test the
eS-Wifi driver as part of sanitycheck).

Signed-off-by: Kumar Gala <kumar.gala@linaro.org>