### PR TITLE
driver: wifi: eswifi: Fix how we get SPI bus

### DIFF
--- a/drivers/wifi/eswifi/eswifi_bus_spi.c
+++ b/drivers/wifi/eswifi/eswifi_bus_spi.c
@@ -209,22 +209,23 @@ int eswifi_spi_init(struct eswifi_dev *eswifi)
 	}
 
 	/* SPI DATA READY PIN */
-	spi->dr.dev = device_get_binding(ESWIFI0_DATA_GPIOS_CONTROLLER);
+	spi->dr.dev = device_get_binding(
+			DT_INVENTEK_ESWIFI_ESWIFI0_DATA_GPIOS_CONTROLLER);
 	if (!spi->dr.dev) {
 		LOG_ERR("Failed to initialize GPIO driver: %s",
-			    ESWIFI0_DATA_GPIOS_CONTROLLER);
+			    DT_INVENTEK_ESWIFI_ESWIFI0_DATA_GPIOS_CONTROLLER);
 		return -ENODEV;
 	}
-	spi->dr.pin = ESWIFI0_DATA_GPIOS_PIN;
+	spi->dr.pin = DT_INVENTEK_ESWIFI_ESWIFI0_DATA_GPIOS_PIN;
 	gpio_pin_configure(spi->dr.dev, spi->dr.pin, GPIO_DIR_IN);
 
 
 	/* SPI CONFIG/CS */
-	spi->spi_cfg.frequency = ESWIFI0_SPI_MAX_FREQUENCY;
+	spi->spi_cfg.frequency = DT_INVENTEK_ESWIFI_ESWIFI0_SPI_MAX_FREQUENCY;
 	spi->spi_cfg.operation = (SPI_OP_MODE_MASTER | SPI_TRANSFER_MSB |
 				  SPI_WORD_SET(16) | SPI_LINES_SINGLE |
 				  SPI_HOLD_ON_CS | SPI_LOCK_ON);
-	spi->spi_cfg.slave = ESWIFI0_BASE_ADDRESS;
+	spi->spi_cfg.slave = DT_INVENTEK_ESWIFI_ESWIFI0_BASE_ADDRESS;
 	spi->spi_cs.gpio_dev = device_get_binding(DT_ESWIFI0_CS_GPIOS_CONTROLLER);
 	spi->spi_cs.gpio_pin = DT_ESWIFI0_CS_GPIOS_PIN;
 	spi->spi_cs.delay = 1000;

--- a/drivers/wifi/eswifi/eswifi_bus_spi.c
+++ b/drivers/wifi/eswifi/eswifi_bus_spi.c
@@ -202,7 +202,7 @@ int eswifi_spi_init(struct eswifi_dev *eswifi)
 	struct eswifi_spi_data *spi = &eswifi_spi0; /* Static instance */
 
 	/* SPI DEV */
-	spi->spi_dev = device_get_binding("SPI_3");
+	spi->spi_dev = device_get_binding(DT_INVENTEK_ESWIFI_ESWIFI0_BUS_NAME);
 	if (!spi->spi_dev) {
 		LOG_ERR("Failed to initialize SPI driver");
 		return -ENODEV;

--- a/drivers/wifi/eswifi/eswifi_core.c
+++ b/drivers/wifi/eswifi/eswifi_core.c
@@ -461,21 +461,23 @@ static int eswifi_init(struct device *dev)
 	eswifi->bus = &eswifi_bus_ops_spi;
 	eswifi->bus->init(eswifi);
 
-	eswifi->resetn.dev = device_get_binding(ESWIFI0_RESETN_GPIOS_CONTROLLER);
+	eswifi->resetn.dev = device_get_binding(
+			DT_INVENTEK_ESWIFI_ESWIFI0_RESETN_GPIOS_CONTROLLER);
 	if (!eswifi->resetn.dev) {
 		LOG_ERR("Failed to initialize GPIO driver: %s",
-			    ESWIFI0_RESETN_GPIOS_CONTROLLER);
+			    DT_INVENTEK_ESWIFI_ESWIFI0_RESETN_GPIOS_CONTROLLER);
 	}
-	eswifi->resetn.pin = ESWIFI0_RESETN_GPIOS_PIN;
+	eswifi->resetn.pin = DT_INVENTEK_ESWIFI_ESWIFI0_RESETN_GPIOS_PIN;
 	gpio_pin_configure(eswifi->resetn.dev, eswifi->resetn.pin,
 			   GPIO_DIR_OUT);
 
-	eswifi->wakeup.dev = device_get_binding(ESWIFI0_WAKEUP_GPIOS_CONTROLLER);
+	eswifi->wakeup.dev = device_get_binding(
+			DT_INVENTEK_ESWIFI_ESWIFI0_WAKEUP_GPIOS_CONTROLLER);
 	if (!eswifi->wakeup.dev) {
 		LOG_ERR("Failed to initialize GPIO driver: %s",
-			    ESWIFI0_WAKEUP_GPIOS_CONTROLLER);
+			    DT_INVENTEK_ESWIFI_ESWIFI0_WAKEUP_GPIOS_CONTROLLER);
 	}
-	eswifi->wakeup.pin = ESWIFI0_WAKEUP_GPIOS_PIN;
+	eswifi->wakeup.pin = DT_INVENTEK_ESWIFI_ESWIFI0_WAKEUP_GPIOS_PIN;
 	gpio_pin_configure(eswifi->wakeup.dev, eswifi->wakeup.pin,
 			   GPIO_DIR_OUT);
 	gpio_pin_write(eswifi->wakeup.dev, eswifi->wakeup.pin, 1);


### PR DESCRIPTION
We were hard coding the SPI bus name to "SPI_3".  Instead we should use
ESWIFI0_BUS_NAME as its generated from the device tree.

Signed-off-by: Kumar Gala <kumar.gala@linaro.org>