### PR TITLE
subsys: settings: Invalidate entry with the same key in FCB

### DIFF
--- a/include/settings/settings.h
+++ b/include/settings/settings.h
@@ -26,7 +26,7 @@ extern "C" {
 #define SETTINGS_MAX_VAL_LEN	256
 #define SETTINGS_NAME_SEPARATOR	"/"
 
-/* pleace for settings additions:
+/* place for settings additions:
  * up to 7 separators, '=', '\0'
  */
 #define SETTINGS_EXTRA_LEN ((SETTINGS_MAX_DIR_DEPTH - 1) + 2)

--- a/tests/subsys/settings/fcb_init/src/settings_test_fcb_init.c
+++ b/tests/subsys/settings/fcb_init/src/settings_test_fcb_init.c
@@ -83,7 +83,7 @@ void test_init_setup(void)
 	settings_subsys_init();
 
 	err = settings_register(&c1_settings);
-	zassert_true(err == 0, "can't regsister the settings handler");
+	zassert_true(err == 0, "can't register the settings handler");
 
 	err = settings_load();
 	zassert_true(err == 0, "can't load settings");
@@ -100,8 +100,7 @@ void test_init_setup(void)
 void test_main(void)
 {
 	/* Bellow call is not used as a test setup intentionally.    */
-	/* It causes device reboota at the first device run after it */
-	/* was flashed. */
+	/* It causes device reboot a first time after it was flashed. */
 	test_init_setup();
 
 	ztest_test_suite(test_initialization,


### PR DESCRIPTION
Without this PR, entries with the same key name are present in FCB setting partition as many time as they have been written.
All these duplicated keys are loaded at the initialisation of the settings subsystem. The consumer of these settings will be notified for each of these key.

It could lead to issues in the caller logic.

See my comment to see how it affects Zephyr bluetooth stack: https://github.com/zephyrproject-rtos/zephyr/issues/11409#issuecomment-440630063

With this change, support for deleting settings should be easier to implement properly. Today, to delete a key, users use `settings_save_one("mykey", NULL)`. Rather than deleting the key it creates a new key with the NULL value.

Signed-off-by: Olivier Martin <olivier.martin@proglove.de>