### PR TITLE
Bluetooth: GATT: Fix not handling duplicated CCC storage

### DIFF
--- a/subsys/bluetooth/host/gatt.c
+++ b/subsys/bluetooth/host/gatt.c
@@ -2627,13 +2627,16 @@ static u8_t ccc_load(const struct bt_gatt_attr *attr, void *user_data)
 	BT_DBG("Restoring CCC: handle 0x%04x value 0x%04x", load->entry->handle,
 	       load->entry->value);
 
-	cfg = ccc_find_cfg(ccc, BT_ADDR_LE_ANY);
+	cfg = ccc_find_cfg(ccc, &load->addr);
 	if (!cfg) {
-		BT_DBG("Unable to restore CCC: no cfg left");
-		goto next;
+		cfg = ccc_find_cfg(ccc, BT_ADDR_LE_ANY);
+		if (!cfg) {
+			BT_DBG("Unable to restore CCC: no cfg left");
+			goto next;
+		}
+		bt_addr_le_copy(&cfg->peer, &load->addr);
 	}
 
-	bt_addr_le_copy(&cfg->peer, &load->addr);
 	cfg->value = load->entry->value;
 
 next:


### PR DESCRIPTION
Some backends may actually contain the same key multiple times so the
code needs to check if there is already a ccc_cfg for an address before
attempting to use one that is unallocated.

Fixes #11409

Signed-off-by: Luiz Augusto von Dentz <luiz.von.dentz@intel.com>