### PR TITLE
soc: silabs_exx32: Simplify Kconfig options

### DIFF
--- a/soc/arm/silabs_exx32/Kconfig
+++ b/soc/arm/silabs_exx32/Kconfig
@@ -19,11 +19,6 @@ source "soc/arm/silabs_exx32/*/Kconfig.soc"
 
 config SOC_PART_NUMBER
 	string
-	default SOC_PART_NUMBER_EXX32_EFM32WG if SOC_SERIES_EFM32WG
-	default SOC_PART_NUMBER_EXX32_EFR32FG1P if SOC_SERIES_EFR32FG1P
-	default SOC_PART_NUMBER_EXX32_EFM32HG if SOC_SERIES_EFM32HG
-	default SOC_PART_NUMBER_EXX32_EFR32MG12P if SOC_SERIES_EFR32MG12P
-	default SOC_PART_NUMBER_EXX32_EFM32PG12B if SOC_SERIES_EFM32PG12B
 	help
 	  This string holds the full part number of the SoC. It is a hidden option
 	  that you should not set directly. The part number selection choice defines

--- a/soc/arm/silabs_exx32/efm32hg/Kconfig.defconfig.efm32hg
+++ b/soc/arm/silabs_exx32/efm32hg/Kconfig.defconfig.efm32hg
@@ -6,11 +6,7 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 
-if SOC_EFM32HG
-
-config SOC
-	string
-	default "efm32hg"
+if SOC_SERIES_EFM32HG
 
 config GPIO
 	default y
@@ -36,4 +32,4 @@ config SOC_FLASH_GECKO
 
 endif # FLASH
 
-endif # SOC_EFM32HG
+endif # SOC_SERIES_EFM32HG

--- a/soc/arm/silabs_exx32/efm32hg/Kconfig.defconfig.series
+++ b/soc/arm/silabs_exx32/efm32hg/Kconfig.defconfig.series
@@ -11,11 +11,14 @@ if SOC_SERIES_EFM32HG
 config SOC_SERIES
 	default "efm32hg"
 
+config SOC_PART_NUMBER
+	default "EFM32HG322F64" if SOC_PART_NUMBER_EFM32HG322F64
+
 config NUM_IRQS
 	int
 	# must be >= the highest interrupt number used
 	default 20
 
-source "soc/arm/silabs_exx32/efm32hg/Kconfig.defconfig.e*"
+source "soc/arm/silabs_exx32/efm32hg/Kconfig.defconfig.efm32hg"
 
 endif # SOC_SERIES_EFM32HG

--- a/soc/arm/silabs_exx32/efm32hg/Kconfig.series
+++ b/soc/arm/silabs_exx32/efm32hg/Kconfig.series
@@ -12,5 +12,7 @@ config SOC_SERIES_EFM32HG
 	select SOC_FAMILY_EXX32
 	select SYS_POWER_LOW_POWER_STATE_SUPPORTED
 	select CPU_HAS_SYSTICK
+	select HAS_SILABS_GECKO
+	select HAS_CMU
 	help
 	  Enable support for EFM32 Happy Gecko MCU series

--- a/soc/arm/silabs_exx32/efm32hg/Kconfig.soc
+++ b/soc/arm/silabs_exx32/efm32hg/Kconfig.soc
@@ -1,32 +1,13 @@
-# Kconfig - EFM32HG MCU line
+# Kconfig - EFM32HG (Happy Gecko) MCU line
 #
 # Copyright (c) 2018 Marcio Montenegro
 #
 # SPDX-License-Identifier: Apache-2.0
 #
 
-choice
-prompt "EFM32 Happy Gecko MCU Selection"
-depends on SOC_SERIES_EFM32HG
-
-config SOC_EFM32HG
-	bool "SOC_EFM32HG"
-	select HAS_SILABS_GECKO
-	select HAS_CMU
-
-endchoice
-
 if SOC_SERIES_EFM32HG
 
 config SOC_PART_NUMBER_EFM32HG322F64
 	bool
-
-config SOC_PART_NUMBER_EXX32_EFM32HG
-	string
-	default "EFM32HG322F64" if SOC_PART_NUMBER_EFM32HG322F64
-	help
-	  This string holds the full part number of the SoC. It is a hidden option
-	  that you should not set directly. The part number selection choice defines
-	  the default value for this string.
 
 endif # SOC_SERIES_EFM32HG

--- a/soc/arm/silabs_exx32/efm32pg12b/Kconfig.defconfig.efm32pg12b
+++ b/soc/arm/silabs_exx32/efm32pg12b/Kconfig.defconfig.efm32pg12b
@@ -6,11 +6,7 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 
-if SOC_EFM32PG12B
-
-config SOC
-	string
-	default "efm32pg12b"
+if SOC_SERIES_EFM32PG12B
 
 config GPIO
 	default y
@@ -46,4 +42,4 @@ config SOC_FLASH_GECKO
 
 endif # FLASH
 
-endif # SOC_EFM32
+endif # SOC_SERIES_EFM32PG12B

--- a/soc/arm/silabs_exx32/efm32pg12b/Kconfig.defconfig.series
+++ b/soc/arm/silabs_exx32/efm32pg12b/Kconfig.defconfig.series
@@ -11,12 +11,14 @@ if SOC_SERIES_EFM32PG12B
 config SOC_SERIES
 	default "efm32pg12b"
 
+config SOC_PART_NUMBER
+	default "EFM32PG12B500F1024GL125" if SOC_PART_NUMBER_EFM32PG12B500F1024GL125
+
 config NUM_IRQS
 	int
 	# must be >= the highest interrupt number used
 	default 50
 
-source "soc/arm/silabs_exx32/efm32pg12b/Kconfig.defconfig.e*"
+source "soc/arm/silabs_exx32/efm32pg12b/Kconfig.defconfig.efm32pg12b"
 
 endif # SOC_SERIES_EFM32PG12B
-

--- a/soc/arm/silabs_exx32/efm32pg12b/Kconfig.series
+++ b/soc/arm/silabs_exx32/efm32pg12b/Kconfig.series
@@ -13,5 +13,7 @@ config SOC_SERIES_EFM32PG12B
 	select SOC_FAMILY_EXX32
 	select SYS_POWER_LOW_POWER_STATE_SUPPORTED
 	select CPU_HAS_SYSTICK
+	select HAS_CMU
+	select SOC_GECKO_EMU
 	help
 	  Enable support for EFM32 PearlGecko MCU series

--- a/soc/arm/silabs_exx32/efm32pg12b/Kconfig.soc
+++ b/soc/arm/silabs_exx32/efm32pg12b/Kconfig.soc
@@ -1,32 +1,13 @@
-# Kconfig - EFM32PG12B MCU line
+# Kconfig - EFM32PG12B (Pearl Gecko) MCU line
 #
 # Copyright (c) 2018 Christian Taedcke
 #
 # SPDX-License-Identifier: Apache-2.0
 #
 
-choice
-prompt "EFM32 Pearl Gecko MCU Selection"
-depends on SOC_SERIES_EFM32PG12B
-
-config SOC_EFM32PG12B
-	bool "SOC_EFM32PG12B"
-	select HAS_CMU
-	select SOC_GECKO_EMU
-
-endchoice
-
 if SOC_SERIES_EFM32PG12B
 
 config SOC_PART_NUMBER_EFM32PG12B500F1024GL125
 	bool
-
-config SOC_PART_NUMBER_EXX32_EFM32PG12B
-	string
-	default "EFM32PG12B500F1024GL125" if SOC_PART_NUMBER_EFM32PG12B500F1024GL125
-	help
-	  This string holds the full part number of the SoC. It is a hidden option
-	  that you should not set directly. The part number selection choice defines
-	  the default value for this string.
 
 endif # SOC_SERIES_EFM32PG12B

--- a/soc/arm/silabs_exx32/efm32wg/Kconfig.defconfig.efm32wg
+++ b/soc/arm/silabs_exx32/efm32wg/Kconfig.defconfig.efm32wg
@@ -6,11 +6,7 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 
-if SOC_EFM32WG
-
-config SOC
-	string
-	default "efm32wg"
+if SOC_SERIES_EFM32WG
 
 config GPIO
 	default y
@@ -36,4 +32,4 @@ config SOC_FLASH_GECKO
 
 endif # FLASH
 
-endif # SOC_EFM32
+endif # SOC_SERIES_EFM32WG

--- a/soc/arm/silabs_exx32/efm32wg/Kconfig.defconfig.series
+++ b/soc/arm/silabs_exx32/efm32wg/Kconfig.defconfig.series
@@ -11,11 +11,14 @@ if SOC_SERIES_EFM32WG
 config SOC_SERIES
 	default "efm32wg"
 
+config SOC_PART_NUMBER
+	default "EFM32WG990F256" if SOC_PART_NUMBER_EFM32WG990F256
+
 config NUM_IRQS
 	int
 	# must be >= the highest interrupt number used
 	default 39
 
-source "soc/arm/silabs_exx32/efm32wg/Kconfig.defconfig.e*"
+source "soc/arm/silabs_exx32/efm32wg/Kconfig.defconfig.efm32wg"
 
 endif # SOC_SERIES_EFM32WG

--- a/soc/arm/silabs_exx32/efm32wg/Kconfig.series
+++ b/soc/arm/silabs_exx32/efm32wg/Kconfig.series
@@ -12,5 +12,7 @@ config SOC_SERIES_EFM32WG
 	select SOC_FAMILY_EXX32
 	select SYS_POWER_LOW_POWER_STATE_SUPPORTED
 	select CPU_HAS_SYSTICK
+	select HAS_SILABS_GECKO
+	select HAS_CMU
 	help
 	  Enable support for EFM32 WonderGecko MCU series

--- a/soc/arm/silabs_exx32/efm32wg/Kconfig.soc
+++ b/soc/arm/silabs_exx32/efm32wg/Kconfig.soc
@@ -1,33 +1,13 @@
-# Kconfig - EFM32WG MCU line
+# Kconfig - EFM32WG (Wonder Gecko) MCU line
 #
 # Copyright (c) 2017 Christian Taedcke
 #
 # SPDX-License-Identifier: Apache-2.0
 #
 
-choice
-prompt "EFM32 Wonder Gecko MCU Selection"
-depends on SOC_SERIES_EFM32WG
-
-config SOC_EFM32WG
-	bool "SOC_EFM32WG"
-	select HAS_SILABS_GECKO
-	select HAS_CMU
-	select CPU_HAS_FPU
-
-endchoice
-
 if SOC_SERIES_EFM32WG
 
 config SOC_PART_NUMBER_EFM32WG990F256
 	bool
-
-config SOC_PART_NUMBER_EXX32_EFM32WG
-	string
-	default "EFM32WG990F256" if SOC_PART_NUMBER_EFM32WG990F256
-	help
-	  This string holds the full part number of the SoC. It is a hidden option
-	  that you should not set directly. The part number selection choice defines
-	  the default value for this string.
 
 endif # SOC_SERIES_EFM32WG

--- a/soc/arm/silabs_exx32/efr32fg1p/Kconfig.defconfig.efr32fg1p
+++ b/soc/arm/silabs_exx32/efr32fg1p/Kconfig.defconfig.efr32fg1p
@@ -6,11 +6,7 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 
-if SOC_EFR32FG1P
-
-config SOC
-	string
-	default "efr32fg1p"
+if SOC_SERIES_EFR32FG1P
 
 config GPIO
 	default y
@@ -36,4 +32,4 @@ config SOC_FLASH_GECKO
 
 endif # FLASH
 
-endif # SOC_EFR32FG1P
+endif # SOC_SERIES_EFR32FG1P

--- a/soc/arm/silabs_exx32/efr32fg1p/Kconfig.defconfig.series
+++ b/soc/arm/silabs_exx32/efr32fg1p/Kconfig.defconfig.series
@@ -11,11 +11,14 @@ if SOC_SERIES_EFR32FG1P
 config SOC_SERIES
 	default "efr32fg1p"
 
+config SOC_PART_NUMBER
+	default "EFR32FG1P133F256GM48" if SOC_PART_NUMBER_EFR32FG1P133F256GM48
+
 config NUM_IRQS
 	int
 	# must be >= the highest interrupt number used
 	default 33
 
-source "soc/arm/silabs_exx32/efr32fg1p/Kconfig.defconfig.e*"
+source "soc/arm/silabs_exx32/efr32fg1p/Kconfig.defconfig.efr32fg1p"
 
 endif # SOC_SERIES_EFR32FG1P

--- a/soc/arm/silabs_exx32/efr32fg1p/Kconfig.series
+++ b/soc/arm/silabs_exx32/efr32fg1p/Kconfig.series
@@ -8,6 +8,7 @@
 config SOC_SERIES_EFR32FG1P
 	bool "EFR32FG1P Series MCU"
 	select HAS_SILABS_GECKO
+	select HAS_CMU
 	select CPU_CORTEX_M4
 	select CPU_HAS_FPU
 	select SOC_FAMILY_EXX32

--- a/soc/arm/silabs_exx32/efr32fg1p/Kconfig.soc
+++ b/soc/arm/silabs_exx32/efr32fg1p/Kconfig.soc
@@ -1,31 +1,13 @@
-# Kconfig - EFR32FG1P MCU line
+# Kconfig - EFR32FG1P (Flex Gecko) MCU line
 #
 # Copyright (c) 2018 Christian Taedcke
 #
 # SPDX-License-Identifier: Apache-2.0
 #
 
-choice
-prompt "EFR32FG1P Flex Gecko MCU Selection"
-depends on SOC_SERIES_EFR32FG1P
-
-config SOC_EFR32FG1P
-	bool "SOC_EFR32FG1P"
-	select HAS_CMU
-
-endchoice
-
 if SOC_SERIES_EFR32FG1P
 
 config SOC_PART_NUMBER_EFR32FG1P133F256GM48
 	bool
-
-config SOC_PART_NUMBER_EXX32_EFR32FG1P
-	string
-	default "EFR32FG1P133F256GM48" if SOC_PART_NUMBER_EFR32FG1P133F256GM48
-	help
-	  This string holds the full part number of the SoC. It is a hidden option
-	  that you should not set directly. The part number selection choice defines
-	  the default value for this string.
 
 endif # SOC_SERIES_EFR32FG1P

--- a/soc/arm/silabs_exx32/efr32mg12p/Kconfig.defconfig.efr32mg12p
+++ b/soc/arm/silabs_exx32/efr32mg12p/Kconfig.defconfig.efr32mg12p
@@ -6,11 +6,7 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 
-if SOC_EFR32MG12P
-
-config SOC
-	string
-	default "efr32mg12p"
+if SOC_SERIES_EFR32MG12P
 
 config GPIO
 	default y
@@ -46,4 +42,4 @@ config SOC_FLASH_GECKO
 
 endif # FLASH
 
-endif # SOC_EFR32MG12P
+endif # SOC_SERIES_EFR32MG12P

--- a/soc/arm/silabs_exx32/efr32mg12p/Kconfig.defconfig.series
+++ b/soc/arm/silabs_exx32/efr32mg12p/Kconfig.defconfig.series
@@ -11,11 +11,14 @@ if SOC_SERIES_EFR32MG12P
 config SOC_SERIES
 	default "efr32mg12p"
 
+config SOC_PART_NUMBER
+	default "EFR32MG12P332F1024GL125" if SOC_PART_NUMBER_EFR32MG12P332F1024GL125
+
 config NUM_IRQS
 	int
 	# must be >= the highest interrupt number used
 	default 49
 
-gsource "soc/arm/silabs_exx32/efr32mg12p/Kconfig.defconfig.e*"
+source "soc/arm/silabs_exx32/efr32mg12p/Kconfig.defconfig.efr32mg12p"
 
 endif # SOC_SERIES_EFR32MG12P

--- a/soc/arm/silabs_exx32/efr32mg12p/Kconfig.series
+++ b/soc/arm/silabs_exx32/efr32mg12p/Kconfig.series
@@ -12,5 +12,8 @@ config SOC_SERIES_EFR32MG12P
 	select SOC_FAMILY_EXX32
 	select SYS_POWER_LOW_POWER_STATE_SUPPORTED
 	select CPU_HAS_SYSTICK
+	select HAS_SILABS_GECKO
+	select HAS_CMU
+	select SOC_GECKO_EMU
 	help
 	  Enable support for EFR32 Mighty Gecko MCU series

--- a/soc/arm/silabs_exx32/efr32mg12p/Kconfig.soc
+++ b/soc/arm/silabs_exx32/efr32mg12p/Kconfig.soc
@@ -1,33 +1,13 @@
-# Kconfig - EFR32MG12P MCU line
+# Kconfig - EFR32MG12P (Mighty Gecko) MCU line
 #
 # Copyright (c) 2018 Diego Sueiro
 #
 # SPDX-License-Identifier: Apache-2.0
 #
 
-choice
-prompt "EFR32 Mighty Gecko MCU Selection"
-depends on SOC_SERIES_EFR32MG12P
-
-config SOC_EFR32MG12P
-	bool "SOC_EFR32MG12P"
-	select HAS_SILABS_GECKO
-	select HAS_CMU
-	select SOC_GECKO_EMU
-
-endchoice
-
 if SOC_SERIES_EFR32MG12P
 
 config SOC_PART_NUMBER_EFR32MG12P332F1024GL125
 	bool
-
-config SOC_PART_NUMBER_EXX32_EFR32MG12P
-	string
-	default "EFR32MG12P332F1024GL125" if SOC_PART_NUMBER_EFR32MG12P332F1024GL125
-	help
-	  This string holds the full part number of the SoC. It is a hidden option
-	  that you should not set directly. The part number selection choice defines
-	  the default value for this string.
 
 endif # SOC_SERIES_EFR32MG12P


### PR DESCRIPTION
At the moment the Kconfig options for all SiLabs series define only one part number which is used on the evaluation board we support. I would like to add remaining part numbers (for efr32fg1p series). This PR is a first step, it cleans up and simplifies Kconfig options related to handling of SoC series, part numbers.

The change is possible since all SiLabs SoCs within a single family have a very uniform structure. The old implementation was likely based on a vendor whose SoC series are not that uniform, e.g. Nordic nrf52. The SiLabs SoCs in this regard are more similar to Atmel SAM SoCs.