### PR TITLE
gitlint: do not start with subsys:

### DIFF
--- a/.gitlint
+++ b/.gitlint
@@ -22,7 +22,7 @@ min-line-count=1
 max-line-count=200
 
 [title-starts-with-subsystem]
-regex = ^(([^:]+):)(\s([^:]+):)*\s(.+)$
+regex = ^(?!subsys:)(([^:]+):)(\s([^:]+):)*\s(.+)$
 
 [title-must-not-contain-word]
 # Comma-separated list of words that should not occur in the title. Matching is case

--- a/scripts/gitlint/zephyr_commit_rules.py
+++ b/scripts/gitlint/zephyr_commit_rules.py
@@ -93,7 +93,7 @@ class TitleStartsWithSubsystem(LineRule):
     def validate(self, title, _commit):
         regex = self.options['regex'].value
         pattern = re.compile(regex, re.UNICODE)
-        violation_message = "Title does not follow [subsystem]: [subject]"
+        violation_message = "Title does not follow [subsystem]: [subject] (and should not start with literal subsys:)"
         if not pattern.search(title):
             return [RuleViolation(self.id, violation_message, title)]
 


### PR DESCRIPTION
Commit messages should not start with literal "subsys:", instead, spell
out the actual subsystem name.

Signed-off-by: Anas Nashif <anas.nashif@intel.com>