### PR TITLE
driver: refactor the arcv2 timer0 driver

### DIFF
--- a/drivers/timer/Kconfig
+++ b/drivers/timer/Kconfig
@@ -117,6 +117,7 @@ config ARCV2_TIMER
 	bool "ARC Timer"
 	default y
 	depends on ARC
+	select TICKLESS_CAPABLE
 	help
 	  This module implements a kernel device driver for the ARCv2 processor timer 0
 	  and provides the standard "system clock driver" interfaces.

--- a/drivers/timer/arcv2_timer0.c
+++ b/drivers/timer/arcv2_timer0.c
@@ -39,7 +39,6 @@ static u32_t last_load;
 
 static u32_t cycle_count;
 
-static volatile u32_t ctrl_cache; /* overflow bit clears on read! */
 
 /**
  *
@@ -109,14 +108,14 @@ static ALWAYS_INLINE void timer0_limit_register_set(u32_t count)
 
 static u32_t elapsed(void)
 {
-	u32_t val, ov;
+	u32_t val, ov, ctrl;
 
 	do {
 		val =  timer0_count_register_get();
-		ctrl_cache = timer0_control_register_get();
+		ctrl = timer0_control_register_get();
 	} while (timer0_count_register_get() < val);
 
-	ov = (ctrl_cache & _ARC_V2_TMR_CTRL_IP) ? last_load : 0;
+	ov = (ctrl & _ARC_V2_TMR_CTRL_IP) ? last_load : 0;
 	return val + ov;
 }
 

--- a/drivers/timer/arcv2_timer0.c
+++ b/drivers/timer/arcv2_timer0.c
@@ -131,7 +131,7 @@ static u32_t elapsed(void)
  *
  * @return N/A
  */
-void _timer_int_handler(void *unused)
+static void _timer_int_handler(void *unused)
 {
 	ARG_UNUSED(unused);
 	u32_t dticks;
@@ -152,7 +152,7 @@ void _timer_int_handler(void *unused)
  * @brief Initialize and enable the system clock
  *
  * This routine is used to program the ARCv2 timer to deliver interrupts at the
- * rate specified via the 'sys_clock_us_per_tick' global variable.
+ * rate specified via the CYC_PER_TICK.
  *
  * @return 0
  */
@@ -182,9 +182,8 @@ int z_clock_driver_init(struct device *device)
 void z_clock_set_timeout(s32_t ticks, bool idle)
 {
 	/* If the kernel allows us to miss tick announcements in idle,
-	 * then shut off
-	 * the counter. (Note: we can assume if idle==true that
-	 * interrupts are already disabled)
+	 * then shut off the counter. (Note: we can assume if idle==true
+	 * that interrupts are already disabled)
 	 */
 	if (IS_ENABLED(CONFIG_TICKLESS_IDLE) && idle && ticks == K_FOREVER) {
 		timer0_control_register_set(0);
@@ -217,8 +216,6 @@ void z_clock_set_timeout(s32_t ticks, bool idle)
 #endif
 }
 
-
-
 u32_t z_clock_elapsed(void)
 {
 	if (!TICKLESS) {
@@ -240,7 +237,6 @@ u32_t _timer_cycle_get_32(void)
 	k_spin_unlock(&lock, key);
 	return ret;
 }
-
 
 /**
  *

--- a/drivers/timer/arcv2_timer0.c
+++ b/drivers/timer/arcv2_timer0.c
@@ -31,8 +31,7 @@
 #define MAX_TICKS ((COUNTER_MAX / CYC_PER_TICK) - 1)
 #define MAX_CYCLES (MAX_TICKS * CYC_PER_TICK)
 
-#define TICKLESS (IS_ENABLED(CONFIG_TICKLESS_KERNEL) &&			\
-		  !IS_ENABLED(CONFIG_QEMU_TICKLESS_WORKAROUND))
+#define TICKLESS (IS_ENABLED(CONFIG_TICKLESS_KERNEL))
 
 static struct k_spinlock lock;
 
@@ -193,7 +192,7 @@ void z_clock_set_timeout(s32_t ticks, bool idle)
 		return;
 	}
 
-#if defined(CONFIG_TICKLESS_KERNEL) && !defined(CONFIG_QEMU_TICKLESS_WORKAROUND)
+#if defined(CONFIG_TICKLESS_KERNEL)
 	u32_t delay;
 
 	ticks = min(MAX_TICKS, max(ticks - 1, 0));
@@ -263,5 +262,5 @@ void sys_clock_disable(void)
 
 	/* disable interrupt in the interrupt controller */
 
-	irq_disable(ARCV2_TIMER0_INT_LVL);
+	irq_disable(IRQ_TIMER0);
 }

--- a/soc/arc/snps_emsk/soc.h
+++ b/soc/arc/snps_emsk/soc.h
@@ -42,12 +42,6 @@
 #include <misc/util.h>
 #include <random/rand32.h>
 
-#define ARCV2_TIMER0_INT_LVL			IRQ_TIMER0
-#define ARCV2_TIMER0_INT_PRI			0
-
-#define ARCV2_TIMER1_INT_LVL			IRQ_TIMER1
-#define ARCV2_TIMER1_INT_PRI			1
-
 #define INT_ENABLE_ARC				~(0x00000001 << 8)
 #define INT_ENABLE_ARC_BIT_POS			(8)
 

--- a/soc/arc/snps_nsim/soc.h
+++ b/soc/arc/snps_nsim/soc.h
@@ -27,12 +27,6 @@
 #include <misc/util.h>
 #include <random/rand32.h>
 
-#define ARCV2_TIMER0_INT_LVL			IRQ_TIMER0
-#define ARCV2_TIMER0_INT_PRI			0
-
-#define ARCV2_TIMER1_INT_LVL			IRQ_TIMER1
-#define ARCV2_TIMER1_INT_PRI			1
-
 #define INT_ENABLE_ARC				~(0x00000001 << 8)
 #define INT_ENABLE_ARC_BIT_POS			(8)
 


### PR DESCRIPTION
refactor the arcv2 timer0 driver according to
the latest changes in sys clock dirver

The new dirver refers the implementation of cortex-m sys tick driver

Verified by the test/kernel on nsim_sem

Fixes #10747
Fixes #11129

Signed-off-by: Wayne Ren <wei.ren@synopsys.com>