### PR TITLE
kernel: Always set clock expiry with sync with timeout module

### DIFF
--- a/kernel/include/timeout_q.h
+++ b/kernel/include/timeout_q.h
@@ -48,6 +48,8 @@ static inline int _abort_thread_timeout(struct k_thread *thread)
 
 s32_t _get_next_timeout_expiry(void);
 
+void z_set_timeout_expiry(s32_t ticks, bool idle);
+
 s32_t z_timeout_remaining(struct _timeout *timeout);
 
 #else
@@ -57,6 +59,7 @@ s32_t z_timeout_remaining(struct _timeout *timeout);
 #define _add_thread_timeout(th, to) do {} while (0 && (void *)to && (void *)th)
 #define _abort_thread_timeout(t) (0)
 #define _get_next_timeout_expiry() (K_FOREVER)
+#define z_set_timeout_expiry(t, i) do {} while (0)
 
 #endif
 

--- a/kernel/sched.c
+++ b/kernel/sched.c
@@ -219,17 +219,13 @@ static int slice_max_prio;
  */
 static void reset_time_slice(void)
 {
-	int to = _get_next_timeout_expiry();
-
 	/* Add the elapsed time since the last announced tick to the
 	 * slice count, as we'll see those "expired" ticks arrive in a
 	 * FUTURE z_time_slice() call.
 	 */
 	_current_cpu->slice_ticks = slice_time + z_clock_elapsed();
 
-	if (to == K_FOREVER || slice_time < to) {
-		z_clock_set_timeout(slice_time, false);
-	}
+	z_set_timeout_expiry(slice_time, false);
 }
 
 void k_sched_time_slice_set(s32_t duration_in_ms, int prio)

--- a/kernel/timeout.c
+++ b/kernel/timeout.c
@@ -85,7 +85,9 @@ void _add_timeout(struct _timeout *to, _timeout_func_t fn, s32_t ticks)
 			sys_dlist_append(&timeout_list, &to->node);
 		}
 
-		z_clock_set_timeout(_get_next_timeout_expiry(), false);
+		if (to == first()) {
+			z_clock_set_timeout(_get_next_timeout_expiry(), false);
+		}
 	}
 }
 
@@ -180,6 +182,17 @@ s32_t _get_next_timeout_expiry(void)
 	}
 #endif
 	return ret;
+}
+
+void z_set_timeout_expiry(s32_t ticks, bool idle)
+{
+	LOCKED(&timeout_lock) {
+		int next = _get_next_timeout_expiry();
+
+		if ((next == K_FOREVER) || (ticks < next)) {
+			z_clock_set_timeout(ticks, idle);
+		}
+	}
 }
 
 int k_enable_sys_clock_always_on(void)


### PR DESCRIPTION
System must not set the clock expiry via backdoor as it may
effect in unbound time drift of all scheduled timeouts.

Fixes: #11502

Signed-off-by: Pawel Dunaj <pawel.dunaj@nordicsemi.no>