### PR TITLE
usb: add SoF event

### DIFF
--- a/drivers/usb/device/usb_dc_nrfx.c
+++ b/drivers/usb/device/usb_dc_nrfx.c
@@ -979,6 +979,9 @@ static void usbd_event_handler(nrfx_usbd_evt_t const *const p_event)
 		usbd_status_code_update(USB_DC_RESET);
 		break;
 	case NRFX_USBD_EVT_SOF:
+#ifdef CONFIG_USB_DEVICE_SOF
+		usbd_status_code_update(USB_DC_SOF);
+#endif
 		break;
 
 	case NRFX_USBD_EVT_EPTRANSFER:

--- a/include/drivers/usb/usb_dc.h
+++ b/include/drivers/usb/usb_dc.h
@@ -59,6 +59,8 @@ enum usb_dc_status_code {
 	USB_DC_SET_HALT,
 	/** Clear Feature ENDPOINT_HALT received */
 	USB_DC_CLEAR_HALT,
+	/** Start of Frame received */
+	USB_DC_SOF,
 	/** Initial USB connection status */
 	USB_DC_UNKNOWN
 };

--- a/samples/subsys/usb/hid/src/main.c
+++ b/samples/subsys/usb/hid/src/main.c
@@ -108,6 +108,8 @@ static void status_cb(enum usb_dc_status_code status, const u8_t *param)
 	case USB_DC_CONFIGURED:
 		in_ready_cb();
 		break;
+	case USB_DC_SOF:
+		break;
 	default:
 		LOG_DBG("status %u unhandled", status);
 		break;

--- a/subsys/usb/Kconfig
+++ b/subsys/usb/Kconfig
@@ -61,6 +61,9 @@ config USB_COMPOSITE_BUFFER_SIZE
 	default 256 if USB_DEVICE_NETWORK_RNDIS
 	default 64
 
+config USB_DEVICE_SOF
+	bool "Enable Start of Frame processing in events"
+
 config USB_DEVICE_BOS
 	bool "Enable USB Binary Device Object Store (BOS)"
 

--- a/subsys/usb/class/bluetooth.c
+++ b/subsys/usb/class/bluetooth.c
@@ -231,6 +231,8 @@ static void bluetooth_status_cb(enum usb_dc_status_code status,
 	case USB_DC_RESUME:
 		LOG_DBG("USB device resumed");
 		break;
+	case USB_DC_SOF:
+		break;
 	case USB_DC_UNKNOWN:
 	default:
 		LOG_DBG("USB unknown state");

--- a/subsys/usb/class/cdc_acm.c
+++ b/subsys/usb/class/cdc_acm.c
@@ -425,6 +425,8 @@ static void cdc_acm_dev_status_cb(enum usb_dc_status_code status,
 	case USB_DC_RESUME:
 		LOG_DBG("USB device resumed");
 		break;
+	case USB_DC_SOF:
+		break;
 	case USB_DC_UNKNOWN:
 	default:
 		LOG_DBG("USB unknown state");

--- a/subsys/usb/class/hid/core.c
+++ b/subsys/usb/class/hid/core.c
@@ -122,6 +122,8 @@ static void hid_status_cb(enum usb_dc_status_code status, const u8_t *param)
 		case USB_DC_RESUME:
 			LOG_DBG("USB device resumed");
 			break;
+		case USB_DC_SOF:
+			break;
 		case USB_DC_UNKNOWN:
 		default:
 			LOG_DBG("USB unknown state");

--- a/subsys/usb/class/mass_storage.c
+++ b/subsys/usb/class/mass_storage.c
@@ -832,6 +832,8 @@ static void mass_storage_status_cb(enum usb_dc_status_code status,
 	case USB_DC_INTERFACE:
 		LOG_DBG("USB interface selected");
 		break;
+	case USB_DC_SOF:
+		break;
 	case USB_DC_UNKNOWN:
 	default:
 		LOG_DBG("USB unknown state");

--- a/subsys/usb/class/netusb/function_ecm.c
+++ b/subsys/usb/class/netusb/function_ecm.c
@@ -388,6 +388,9 @@ static void ecm_status_cb(enum usb_dc_status_code status, const u8_t *param)
 		LOG_DBG("USB unhandlded state: %d", status);
 		break;
 
+	case USB_DC_SOF:
+		break;
+
 	case USB_DC_UNKNOWN:
 	default:
 		LOG_DBG("USB unknown state: %d", status);

--- a/subsys/usb/class/netusb/function_eem.c
+++ b/subsys/usb/class/netusb/function_eem.c
@@ -262,6 +262,9 @@ static void eem_status_cb(enum usb_dc_status_code status, const u8_t *param)
 		LOG_DBG("USB unhandlded state: %d", status);
 		break;
 
+	case USB_DC_SOF:
+		break;
+
 	case USB_DC_UNKNOWN:
 	default:
 		LOG_DBG("USB unknown state: %d", status);

--- a/subsys/usb/class/netusb/function_rndis.c
+++ b/subsys/usb/class/netusb/function_rndis.c
@@ -1310,6 +1310,9 @@ static void rndis_status_cb(enum usb_dc_status_code status, const u8_t *param)
 		LOG_DBG("USB unhandlded state: %d", status);
 		break;
 
+	case USB_DC_SOF:
+		break;
+
 	case USB_DC_UNKNOWN:
 	default:
 		LOG_DBG("USB unknown state %d", status);

--- a/subsys/usb/class/usb_dfu.c
+++ b/subsys/usb/class/usb_dfu.c
@@ -583,6 +583,8 @@ static void dfu_status_cb(enum usb_dc_status_code status, const u8_t *param)
 	case USB_DC_RESUME:
 		LOG_DBG("USB device resumed");
 		break;
+	case USB_DC_SOF:
+		break;
 	case USB_DC_UNKNOWN:
 	default:
 		LOG_DBG("USB unknown state");


### PR DESCRIPTION
Start of Frame events can now be accessed from USB classes.
This will be useful when implementing idle rate functionality.

Signed-off-by: Marcin Szymczyk <Marcin.Szymczyk@nordicsemi.no>