### PR TITLE
logging: Fix lost printk output when no newline

### DIFF
--- a/subsys/logging/log_output.c
+++ b/subsys/logging/log_output.c
@@ -359,17 +359,25 @@ static void raw_string_print(struct log_msg *msg,
 
 	size_t offset = 0;
 	size_t length;
+	bool eol = false;
 
 	do {
 		length = log_output->size;
 		/* Sting is stored in a hexdump message. */
 		log_msg_hexdump_data_get(msg, log_output->buf, &length, offset);
 		log_output->control_block->offset = length;
+
+		if (length) {
+			eol = (log_output->buf[length - 1] == '\n');
+		}
+
 		log_output_flush(log_output);
 		offset += length;
 	} while (length > 0);
 
-	print_formatted(log_output, "\r");
+	if (eol) {
+		print_formatted(log_output, "\r");
+	}
 }
 
 static int prefix_print(struct log_msg *msg,


### PR DESCRIPTION
Log_output module was always postfixing printk strings
with '\r'. If printk message did not ended with '\n'
it lead to last printk message being overwritten.

Fixed by adding '\r' only when string was ended by '\n'.

Fixes #11495,

Note that output will not look nice if consecutive printks (without '\n' in between) will
be interleaved with log messages. 

Example:
```
printk("abcd")
printk("1234\n");
```

Expected output:
```
abcd1234
[12232132] <DBG> .....
```

Possible output
```
abcd[12321321] <DBG> ...
1234
```

In order to fix that log_output would need to hold a state to know that there is incompleted printk and log message must be prepended with new line. I wouldn't like to add it unless there are people seriously annoyed by that.

Signed-off-by: Krzysztof Chruscinski <krzysztof.chruscinski@nordicsemi.no>