### PR TITLE
CODEOWNERS: Add @avisconti as maintainer

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -34,6 +34,7 @@ boards/arc/arduino_101_sss/              @nashif
 boards/arc/em_starterkit/                @vonhust
 boards/arc/quark_se_c1000_ss_devboard/   @nashif
 boards/arm/                              @MaureenHelm @galak
+boards/arm/96b_argonkey/                 @avisconti
 boards/arm/96b_carbon/                   @rsalveti @idlethread
 boards/arm/96b_nitrogen/                 @idlethread
 boards/arm/96b_neonkey/                  @Mani-Sadhasivam
@@ -94,12 +95,17 @@ drivers/flash/                           @nashif
 drivers/flash/*stm32*                    @superna9999
 drivers/gpio/*stm32*                     @rsalveti @idlethread
 drivers/gpio/gpio_pulpino.c              @kgugala @pgielda @nategraff-sifive
+drivers/i2s/i2s_ll_stm32*                @avisconti
 drivers/ieee802154/                      @jukkar @tbursztyka
 drivers/interrupt_controller/            @andrewboie
 drivers/led/                             @Mani-Sadhasivam
 drivers/led_strip/                       @mbolivar
 drivers/pinmux/stm32/                    @rsalveti @idlethread
 drivers/sensor/                          @bogdan-davidoaia @MaureenHelm
+drivers/sensor/hts*/                     @avisconti
+drivers/sensor/lis*/                     @avisconti
+drivers/sensor/lps*/                     @avisconti
+drivers/sensor/lsm*/                     @avisconti
 drivers/serial/uart_altera_jtag_hal.c    @ramakrishnapallala
 drivers/serial/uart_riscv_qemu.c         @kgugala @pgielda @nategraff-sifive
 drivers/net/slip.c                       @jukkar @tbursztyka


### PR DESCRIPTION
Add @avisconti as maintainer for following stuff:

- ArgonKey board
- STM32 I2S driver
- ST motion sensor drivers

Signed-off-by: Armando Visconti <armando.visconti@st.com>