### PR TITLE
Bluetooth: Define log level at bluetooth subsystem level

### DIFF
--- a/subsys/bluetooth/Kconfig
+++ b/subsys/bluetooth/Kconfig
@@ -15,6 +15,10 @@ config BT
 
 if BT
 
+module = BT
+module-str = bt
+source "subsys/logging/Kconfig.template.log_config"
+
 choice
 	prompt "Bluetooth Stack Selection"
 	default BT_HCI

--- a/subsys/bluetooth/common/log.h
+++ b/subsys/bluetooth/common/log.h
@@ -29,7 +29,7 @@ extern "C" {
 #if BT_DBG_ENABLED
 #define LOG_LEVEL LOG_LEVEL_DBG
 #else
-#define LOG_LEVEL CONFIG_LOG_DEFAULT_LEVEL
+#define LOG_LEVEL CONFIG_BT_LOG_LEVEL
 #endif
 
 #include <logging/log.h>


### PR DESCRIPTION
This commit defines a default log level at bluetooth subsystem level when module log level is not defined.

Prior to this change, the bluetooth subsystem would use the firmware default log level. A firmware engineer might want to define a different a log level for bluetooth subsystem as the rest of the firmware.

Signed-off-by: Olivier Martin <olivier.martin@proglove.de>