### PR TITLE
drivers: serial: uart_cmsdk_apb: Ack IRQs before callback to avoid races

### DIFF
--- a/drivers/serial/uart_cmsdk_apb.c
+++ b/drivers/serial/uart_cmsdk_apb.c
@@ -426,13 +426,13 @@ void uart_cmsdk_apb_isr(void *arg)
 	volatile struct uart_cmsdk_apb *uart = UART_STRUCT(dev);
 	struct uart_cmsdk_apb_dev_data *data = DEV_DATA(dev);
 
+	/* Clear pending interrupts */
+	uart->intclear = UART_RX_IN | UART_TX_IN;
+
 	/* Verify if the callback has been registered */
 	if (data->irq_cb) {
 		data->irq_cb(data->irq_cb_data);
 	}
-
-	/* Clear pending interrupts */
-	uart->intclear = UART_RX_IN | UART_TX_IN;
 }
 
 #endif /* CONFIG_UART_INTERRUPT_DRIVEN */


### PR DESCRIPTION
This effectively reverts part of earlier 49bb1637566a3 which moved
interrupt acknowledgement until after return from the user callback.
This was done confusing the flow of this driver with how some other
drivers do it, where pending interrupt status is checked by
uart_irq_rx_ready()/uart_irq_tx_ready(), which should be called by
the callback. But the uart_cmsdk_apb driver actually uses different
hardware register in these functions. And acking IRQs after user
callback can lead to race condition and losing an IRQ, and the
simple fix in this case is just move acknowledgement to where it
was before.

Signed-off-by: Paul Sokolovsky <paul.sokolovsky@linaro.org>