### PR TITLE
net: dhcpv4: net_dhcpv4_stop() removing address during renew

### DIFF
--- a/subsys/net/ip/dhcpv4.c
+++ b/subsys/net/ip/dhcpv4.c
@@ -1107,6 +1107,7 @@ void net_dhcpv4_stop(struct net_if *iface)
 	case NET_DHCPV4_DISABLED:
 		break;
 
+	case NET_DHCPV4_RENEWING:
 	case NET_DHCPV4_BOUND:
 		if (!net_if_ipv4_addr_rm(iface,
 					 &iface->config.dhcpv4.requested_ip)) {
@@ -1117,7 +1118,6 @@ void net_dhcpv4_stop(struct net_if *iface)
 	case NET_DHCPV4_INIT:
 	case NET_DHCPV4_SELECTING:
 	case NET_DHCPV4_REQUESTING:
-	case NET_DHCPV4_RENEWING:
 	case NET_DHCPV4_REBINDING:
 		iface->config.dhcpv4.state = NET_DHCPV4_DISABLED;
 		NET_DBG("state=%s",


### PR DESCRIPTION
Should net_dhcpv4_stop be called when the interface is
in NET_DHCPV4_RENEWING state, than then address is not removed.
By also deleting the address in the renewing state means the status is 
always equal to the moment before _start is called. 

Signed-off-by: Vincent van der Locht <vincent@vlotech.nl>