### PR TITLE
tests: intel_s1000: Change flash offset from 0x10000 to 0x3F0000

### DIFF
--- a/tests/boards/intel_s1000_crb/src/spi_flash.c
+++ b/tests/boards/intel_s1000_crb/src/spi_flash.c
@@ -11,7 +11,7 @@
 #include <logging/log.h>
 LOG_MODULE_REGISTER(test_flash);
 
-#define FLASH_TEST_REGION_OFFSET 0x10000
+#define FLASH_TEST_REGION_OFFSET 0x3F0000
 #define FLASH_SECTOR_SIZE        0x10000
 #define TEST_DATA_BYTE_0         0x4f
 #define TEST_DATA_BYTE_1         0x4a


### PR DESCRIPTION
Use the last sector of 4MB flash to run the flash API tests.

Fixes #11462.

Signed-off-by: Rajavardhan Gundi <rajavardhan.gundi@intel.com>