### PR TITLE
usb: Fix unaligned access

### DIFF
--- a/subsys/usb/class/hid/core.c
+++ b/subsys/usb/class/hid/core.c
@@ -89,10 +89,10 @@ static struct hid_device_info {
 	const struct hid_ops *ops;
 } hid_device;
 
-static void usb_set_hid_report_size(u16_t report_desc_size)
+static void usb_set_hid_report_size(u16_t size)
 {
-	UNALIGNED_PUT(sys_cpu_to_le16(report_desc_size),
-		&(hid_cfg.if0_hid.subdesc[0].wDescriptorLength));
+	sys_put_le16(size,
+		     (u8_t *)&(hid_cfg.if0_hid.subdesc[0].wDescriptorLength));
 }
 
 static void hid_status_cb(enum usb_dc_status_code status, const u8_t *param)

--- a/subsys/usb/usb_descriptor.c
+++ b/subsys/usb/usb_descriptor.c
@@ -409,9 +409,8 @@ static int usb_fix_descriptor(struct usb_desc_header *head)
 
 				LOG_DBG("Now the wTotalLength is %d",
 					(u8_t *)head - (u8_t *)cfg_descr);
-				cfg_descr->wTotalLength =
-					sys_cpu_to_le16((u8_t *)head -
-							(u8_t *)cfg_descr);
+				sys_put_le16((u8_t *)head - (u8_t *)cfg_descr,
+					     (u8_t *)&cfg_descr->wTotalLength);
 				cfg_descr->bNumInterfaces = numof_ifaces;
 			}
 


### PR DESCRIPTION
Use sys_put_le16() for unaligned access, this is refactored work of
PR #8495
PR #11432

Signed-off-by: Andrei Emeltchenko <andrei.emeltchenko@intel.com>