### PR TITLE
CODEOWNERS: Add for drivers/wifi/ same reviewers as for drivers/ethernet

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,5 +1,8 @@
 # CODEOWNERS for autoreview assigning in github
 
+# Order is important; the last matching pattern takes the most
+# precedence.
+
 # Do not use wildcard on all source yet
 # *                                        @galak @nashif
 
@@ -117,6 +120,7 @@ drivers/timer/riscv_machine_timer.c      @nategraff-sifive @kgugala @pgielda
 drivers/usb/                             @jfischer-phytec-iot @finikorg
 drivers/usb/device/usb_dc_stm32.c        @ydamigos @loicpoulain
 drivers/i2c/i2c_ll_stm32*                @ldts @ydamigos
+drivers/wifi/                            @jukkar @tbursztyka @pfalcon
 drivers/wifi/eswifi                      @loicpoulain
 dts/arm/st/                              @erwango
 dts/arm/nordic/                          @ioannisg @carlescufi


### PR DESCRIPTION
drivers/wifi/ is closely related to the (IP) network stack, so
shouldn't be left without owners, so use the same as for Ethernet.

Also, extend, don't replace reviewers for drivers/wifi/eswifi based
on the above change and CODEOWNERS processing order.

Also, add a reminder about this processing order at the top of file.

Signed-off-by: Paul Sokolovsky <paul.sokolovsky@linaro.org>