### PR TITLE
Remove __deprecated tag to one RPL function

### DIFF
--- a/subsys/net/ip/rpl.h
+++ b/subsys/net/ip/rpl.h
@@ -1058,7 +1058,7 @@ void net_rpl_init(void);
 #define net_rpl_init(...)
 #define net_rpl_global_repair(...)
 #define net_rpl_update_header(...) 0
-__deprecated static inline struct net_if *net_rpl_get_interface(void)
+static inline struct net_if *net_rpl_get_interface(void)
 {
 	return NULL;
 }


### PR DESCRIPTION
net_rpl_get_interface() function which returns always NULL is defined if NET_RPL is not enabled. so remove deprecated tag to this particular function. Otherwise it will cause unnecessary compilation warnings.

