### PR TITLE
samples: mesh: nrf52: coding style & feature improvements

### DIFF
--- a/samples/boards/nrf52/mesh/onoff_level_lighting_vnd_app/src/mesh/state_binding.c
+++ b/samples/boards/nrf52/mesh/onoff_level_lighting_vnd_app/src/mesh/state_binding.c
@@ -260,7 +260,11 @@ void calculate_lightness_target_values(u8_t type)
 		if (gen_onoff_srv_root_user_data.target_onoff == 0) {
 			tmp16 = 0;
 		} else {
-			tmp16 = light_lightness_srv_user_data.last;
+			if (light_lightness_srv_user_data.def == 0) {
+				tmp16 = light_lightness_srv_user_data.last;
+			} else {
+				tmp16 = light_lightness_srv_user_data.def;
+			}
 		}
 
 		break;
@@ -348,3 +352,4 @@ void calculate_temp_target_values(u8_t type)
 			light_ctl_srv_user_data.delta_uv;
 	}
 }
+

--- a/samples/boards/nrf52/mesh/onoff_level_lighting_vnd_app/src/mesh/transition.c
+++ b/samples/boards/nrf52/mesh/onoff_level_lighting_vnd_app/src/mesh/transition.c
@@ -130,6 +130,11 @@ void onoff_tt_values(struct generic_onoff_state *state, u8_t tt, u8_t delay)
 						state->transition->counter;
 
 		calculate_lightness_target_values(ONOFF);
+
+		light_lightness_srv_user_data.tt_delta_actual =
+			((float) (light_lightness_srv_user_data.actual -
+				  light_lightness_srv_user_data.target_actual) /
+			 state->transition->counter);
 	}
 }
 
@@ -302,9 +307,6 @@ static void onoff_work_handler(struct k_work *work)
 
 			if (state->target_onoff == STATE_ON) {
 				state->onoff = STATE_ON;
-
-				state_binding(ONOFF, IGNORE_TEMP);
-				update_light_state();
 			}
 		}
 
@@ -313,12 +315,20 @@ static void onoff_work_handler(struct k_work *work)
 
 	if (state->transition->counter != 0) {
 		state->transition->counter--;
+
+		light_lightness_srv_user_data.actual -=
+			light_lightness_srv_user_data.tt_delta_actual;
+
+		state_binding(ACTUAL, IGNORE_TEMP);
+		update_light_state();
 	}
 
 	if (state->transition->counter == 0) {
 		state->onoff = state->target_onoff;
+		light_lightness_srv_user_data.actual =
+			light_lightness_srv_user_data.target_actual;
 
-		state_binding(ONOFF, IGNORE_TEMP);
+		state_binding(ACTUAL, IGNORE_TEMP);
 		update_light_state();
 
 		k_timer_stop(ptr_timer);
@@ -724,5 +734,6 @@ void light_ctl_temp_handler(struct light_ctl_state *state)
 		      K_MSEC(state->transition->quo_tt));
 }
 /* Messages handlers (End) */
+
 
 


### PR DESCRIPTION
Create independent function handlers for prime Servers. This
would not initiate state binding if current state is equal to
Client requested state.

Now if Gen. OnOff state set by client as '1' with some
transition time then value of Lightness will not jump to default
or last value instantly instead it would gradually increase during
that transition period.

Signed-off-by: Vikrant More vikrant8051@gmail.com