### PR TITLE
soc: arm: nordic: provide custom busy_wait implementations

### DIFF
--- a/soc/arm/nordic_nrf/nrf51/Kconfig.defconfig.series
+++ b/soc/arm/nordic_nrf/nrf51/Kconfig.defconfig.series
@@ -20,6 +20,9 @@ config SYS_CLOCK_HW_CYCLES_PER_SEC
 config SYS_POWER_MANAGEMENT
 	default y
 
+config ARCH_HAS_CUSTOM_BUSY_WAIT
+	default y
+
 config NUM_IRQS
 	int
 	default 26

--- a/soc/arm/nordic_nrf/nrf51/soc.c
+++ b/soc/arm/nordic_nrf/nrf51/soc.c
@@ -15,6 +15,8 @@
 
 #include <kernel.h>
 #include <init.h>
+#include <nrfx.h>
+#include <soc/nrfx_coredep.h>
 
 #ifdef CONFIG_RUNTIME_NMI
 extern void _NmiInit(void);
@@ -46,6 +48,18 @@ static int nordicsemi_nrf51_init(struct device *arg)
 	irq_unlock(key);
 
 	return 0;
+}
+
+#define DELAY_CALL_OVERHEAD_US 2
+
+void z_arch_busy_wait(u32_t time_us)
+{
+	if (time_us <= DELAY_CALL_OVERHEAD_US) {
+		return;
+	}
+
+	time_us -= DELAY_CALL_OVERHEAD_US;
+	nrfx_coredep_delay_us(time_us);
 }
 
 SYS_INIT(nordicsemi_nrf51_init, PRE_KERNEL_1, 0);

--- a/soc/arm/nordic_nrf/nrf52/Kconfig.defconfig.series
+++ b/soc/arm/nordic_nrf/nrf52/Kconfig.defconfig.series
@@ -16,6 +16,9 @@ config SYS_CLOCK_HW_CYCLES_PER_SEC
 	int
 	default 32768
 
+config ARCH_HAS_CUSTOM_BUSY_WAIT
+	default y
+
 config SYS_POWER_MANAGEMENT
 	default y
 

--- a/soc/arm/nordic_nrf/nrf52/soc.c
+++ b/soc/arm/nordic_nrf/nrf52/soc.c
@@ -15,6 +15,8 @@
 #include <kernel.h>
 #include <init.h>
 #include <cortex_m/exc.h>
+#include <nrfx.h>
+#include <soc/nrfx_coredep.h>
 
 #ifdef CONFIG_RUNTIME_NMI
 extern void _NmiInit(void);
@@ -69,6 +71,11 @@ static int nordicsemi_nrf52_init(struct device *arg)
 	irq_unlock(key);
 
 	return 0;
+}
+
+void z_arch_busy_wait(u32_t time_us)
+{
+	nrfx_coredep_delay_us(time_us);
 }
 
 SYS_INIT(nordicsemi_nrf52_init, PRE_KERNEL_1, 0);


### PR DESCRIPTION
Implementation taken from Nordic nrfx version 1.3.1 soc/nrfx_coredep.h,
modified to remove material from other series and to conform to Zephyr
coding standards.

Note that unlike standard k_busy_wait this is susceptible to
longer-than-intended delays due to the impact of interrupt handling.

Fixes #11626

Signed-off-by: Peter A. Bigot <pab@pabigot.com>