### PR TITLE
Spi api fix

### DIFF
--- a/tests/boards/intel_s1000_crb/src/spi_flash.c
+++ b/tests/boards/intel_s1000_crb/src/spi_flash.c
@@ -51,13 +51,13 @@ void test_flash(void)
 
 	LOG_INF("   Attempted to write %x %x\n", buf[0], buf[1]);
 	if (flash_write(flash_dev, FLASH_TEST_REGION_OFFSET, buf,
-	    TEST_DATA_LEN) != TEST_DATA_LEN) {
+	    TEST_DATA_LEN) != 0) {
 		LOG_ERR("   Flash write failed!\n");
 		return;
 	}
 
 	if (flash_read(flash_dev, FLASH_TEST_REGION_OFFSET, buf,
-	    TEST_DATA_LEN) != TEST_DATA_LEN) {
+	    TEST_DATA_LEN) != 0) {
 		LOG_ERR("   Flash read failed!\n");
 		return;
 	}


### PR DESCRIPTION
drivers: flash: spi_nor: Correct the return values for R/W

Fixed the return values for read and write APIs for spin_nor.c which were not inline with what the corresponding interfaces were meant to return.

Signed-off-by: Rajavardhan Gundi <rajavardhan.gundi@intel.com>
