### PR TITLE
kconfiglib/menuconfig: Various improvements

### DIFF
--- a/scripts/kconfig/menuconfig.py
+++ b/scripts/kconfig/menuconfig.py
@@ -1000,7 +1000,8 @@ def _prefer_toggle(item):
            (isinstance(item, Choice) and len(item.assignable) > 1)
 
 def _enter_menu(menu):
-    # Makes 'menu' the currently displayed menu. "Menu" here includes choices.
+    # Makes 'menu' the currently displayed menu. "Menu" here includes choices
+    # and symbols defined with the 'menuconfig' keyword.
 
     global _cur_menu
     global _shown
@@ -2795,10 +2796,10 @@ def _node_str(node):
                     s += " ({})".format(node_.prompt[0])
 
     # Print "--->" next to nodes that have menus that can potentially be
-    # entered. Add "(empty)" if the menu is empty. We don't allow those to be
+    # entered. Print "----" if the menu is empty. We don't allow those to be
     # entered.
     if node.is_menuconfig:
-        s += "  --->" if _shown_nodes(node) else "  ---> (empty)"
+        s += "  --->" if _shown_nodes(node) else "  ----"
 
     return s
 


### PR DESCRIPTION
Update Kconfiglib and menuconfig to upstream revision e47d7eff1012e, to
add some small fixes/improvements/changes:

 - Raise errors for extra trailing tokens anywhere. They were silently
   ignored in some places:

     * `end{if,menu,choice} <extra tokens>`

     * `{default,select,...} FOO <extra tokens>`  (though e.g.
       `default FOO if` raised an error)

 - Rephrase the warning when selecting a choice symbol to make it
   clearer that select never has any effect on choice symbols.

 - Display empty menus with `----` instead of `---> (empty)`. This
   matches the C tools. It might be less confusing for symbols defined
   with `menuconfig`, which is where you most often get empty menus
   (when the symbol is n).

 - Speed up parsing performance