### PR TITLE
i2c: support const correctness for write operations

### DIFF
--- a/include/i2c.h
+++ b/include/i2c.h
@@ -358,12 +358,12 @@ static inline int _impl_i2c_slave_driver_unregister(struct device *dev)
  * @retval 0 If successful.
  * @retval -EIO General input / output error.
  */
-static inline int i2c_write(struct device *dev, u8_t *buf,
+static inline int i2c_write(struct device *dev, const u8_t *buf,
 			    u32_t num_bytes, u16_t addr)
 {
 	struct i2c_msg msg;
 
-	msg.buf = buf;
+	msg.buf = (u8_t *)buf;
 	msg.len = num_bytes;
 	msg.flags = I2C_MSG_WRITE | I2C_MSG_STOP;
 
@@ -444,7 +444,7 @@ static inline int i2c_burst_read(struct device *dev, u16_t dev_addr,
  * @retval -EIO General input / output error.
  */
 static inline int i2c_burst_write(struct device *dev, u16_t dev_addr,
-				  u8_t start_addr, u8_t *buf,
+				  u8_t start_addr, const u8_t *buf,
 				  u32_t num_bytes)
 {
 	struct i2c_msg msg[2];
@@ -453,7 +453,7 @@ static inline int i2c_burst_write(struct device *dev, u16_t dev_addr,
 	msg[0].len = 1;
 	msg[0].flags = I2C_MSG_WRITE;
 
-	msg[1].buf = buf;
+	msg[1].buf = (u8_t *)buf;
 	msg[1].len = num_bytes;
 	msg[1].flags = I2C_MSG_WRITE | I2C_MSG_STOP;
 
@@ -588,7 +588,7 @@ static inline int i2c_burst_read16(struct device *dev, u16_t dev_addr,
  * @retval Negative errno code if failure.
  */
 static inline int i2c_burst_write16(struct device *dev, u16_t dev_addr,
-				    u16_t start_addr, u8_t *buf,
+				    u16_t start_addr, const u8_t *buf,
 				    u32_t num_bytes)
 {
 	u8_t addr_buffer[2];
@@ -600,7 +600,7 @@ static inline int i2c_burst_write16(struct device *dev, u16_t dev_addr,
 	msg[0].len = 2;
 	msg[0].flags = I2C_MSG_WRITE;
 
-	msg[1].buf = buf;
+	msg[1].buf = (u8_t *)buf;
 	msg[1].len = num_bytes;
 	msg[1].flags = I2C_MSG_WRITE | I2C_MSG_STOP;
 
@@ -701,13 +701,13 @@ static inline int i2c_reg_update16(struct device *dev, u16_t dev_addr,
  * @retval Negative errno code if failure.
  */
 static inline int i2c_burst_read_addr(struct device *dev, u16_t dev_addr,
-				      u8_t *start_addr,
+				      const u8_t *start_addr,
 				      const u8_t addr_size,
 				      u8_t *buf, u32_t num_bytes)
 {
 	struct i2c_msg msg[2];
 
-	msg[0].buf = start_addr;
+	msg[0].buf = (u8_t *)start_addr;
 	msg[0].len = addr_size;
 	msg[0].flags = I2C_MSG_WRITE;
 
@@ -736,17 +736,17 @@ static inline int i2c_burst_read_addr(struct device *dev, u16_t dev_addr,
  * @retval Negative errno code if failure.
  */
 static inline int i2c_burst_write_addr(struct device *dev, u16_t dev_addr,
-				       u8_t *start_addr,
+				       const u8_t *start_addr,
 				       const u8_t addr_size,
-				       u8_t *buf, u32_t num_bytes)
+				       const u8_t *buf, u32_t num_bytes)
 {
 	struct i2c_msg msg[2];
 
-	msg[0].buf = start_addr;
+	msg[0].buf = (u8_t *)start_addr;
 	msg[0].len = addr_size;
 	msg[0].flags = I2C_MSG_WRITE;
 
-	msg[1].buf = buf;
+	msg[1].buf = (u8_t *)buf;
 	msg[1].len = num_bytes;
 	msg[1].flags = I2C_MSG_WRITE | I2C_MSG_STOP;
 
@@ -772,8 +772,8 @@ static inline int i2c_burst_write_addr(struct device *dev, u16_t dev_addr,
  */
 static inline int i2c_reg_read_addr(struct device *dev,
 				    u16_t dev_addr,
-				    u8_t *reg_addr,
-				    const u8_t addr_size,
+				    const u8_t *reg_addr,
+				    u8_t addr_size,
 				    u8_t *value)
 {
 	return i2c_burst_read_addr(dev, dev_addr, reg_addr,
@@ -799,7 +799,7 @@ static inline int i2c_reg_read_addr(struct device *dev,
  */
 static inline int i2c_reg_write_addr(struct device *dev,
 				     u16_t dev_addr,
-				     u8_t *reg_addr,
+				     const u8_t *reg_addr,
 				     const u8_t addr_size,
 				     u8_t value)
 {
@@ -827,7 +827,7 @@ static inline int i2c_reg_write_addr(struct device *dev,
  */
 static inline int i2c_reg_update_addr(struct device *dev,
 				      u16_t dev_addr,
-				      u8_t *reg_addr,
+				      const u8_t *reg_addr,
 				      u8_t addr_size,
 				      u8_t mask,
 				      u8_t value)


### PR DESCRIPTION
Material that is being written to the device, as well as blocks of
octets used to specify the operation, are never written to by the I2C
infrastructure.  Applications should be permitted to store these objects
in immutable memory.

Update the API to add const qualifiers to object pointer arguments where
the corresponding address is used in an I2C write operation.

Signed-off-by: Peter A. Bigot <pab@pabigot.com>