### PR TITLE
coccinelle: Add script to remove unnecessary return variable

### DIFF
--- a/drivers/flash/flash_gecko.c
+++ b/drivers/flash/flash_gecko.c
@@ -109,7 +109,6 @@ static int flash_gecko_erase(struct device *dev, off_t offset, size_t size)
 static int flash_gecko_write_protection(struct device *dev, bool enable)
 {
 	struct flash_gecko_data *const dev_data = DEV_DATA(dev);
-	int ret = 0;
 
 	k_sem_take(&dev_data->mutex, K_FOREVER);
 
@@ -123,7 +122,7 @@ static int flash_gecko_write_protection(struct device *dev, bool enable)
 
 	k_sem_give(&dev_data->mutex);
 
-	return ret;
+	return 0;
 }
 
 /* Note:

--- a/drivers/sensor/vl53l0x/vl53l0x_platform.c
+++ b/drivers/sensor/vl53l0x/vl53l0x_platform.c
@@ -190,9 +190,7 @@ VL53L0X_Error  VL53L0X_RdDWord(VL53L0X_DEV Dev, uint8_t index, uint32_t *data)
 
 VL53L0X_Error VL53L0X_PollingDelay(VL53L0X_DEV Dev)
 {
-	VL53L0X_Error status = VL53L0X_ERROR_NONE;
-
 	k_sleep(2);
-	return status;
+	return VL53L0X_ERROR_NONE;
 }
 

--- a/samples/net/ws_echo_server/src/ws.c
+++ b/samples/net/ws_echo_server/src/ws.c
@@ -266,14 +266,12 @@ out:
 static int ws_works(struct http_ctx *ctx,
 		    const struct sockaddr *dst)
 {
-	int ret = 0;
-
 	NET_INFO("WS url called");
 
 	append_and_send_data(ctx, dst, false, "connection");
 	append_and_send_data(ctx, dst, true, " established.");
 
-	return ret;
+	return 0;
 }
 
 static void ws_connected(struct http_ctx *ctx,

--- a/scripts/coccinelle/returnvar.cocci
+++ b/scripts/coccinelle/returnvar.cocci
@@ -1,0 +1,67 @@
+///
+/// Remove unneeded variable used to store return value.
+///
+// Confidence: Moderate
+// Copyright: (C) 2012 Peter Senna Tschudin, INRIA/LIP6.  GPLv2.
+// URL: http://coccinelle.lip6.fr/
+// Comments: Comments on code can be deleted if near code that is removed.
+//           "when strict" can be removed to get more hits, but adds false
+//           positives
+
+virtual patch
+virtual report
+virtual context
+virtual org
+
+@depends on patch && !(file in "ext")@
+type T;
+constant C;
+identifier ret;
+@@
+- T ret = C;
+... when != ret
+    when strict
+return
+- ret
++ C
+;
+
+@depends on context && !(file in "ext")@
+type T;
+constant C;
+identifier ret;
+@@
+* T ret = C;
+... when != ret
+    when strict
+* return ret;
+
+@r1 depends on (report || org) && !(file in "ext")@
+type T;
+constant C;
+identifier ret;
+position p1, p2;
+@@
+T ret@p1 = C;
+... when != ret
+    when strict
+return ret@p2;
+
+@script:python depends on report@
+p1 << r1.p1;
+p2 << r1.p2;
+C << r1.C;
+ret << r1.ret;
+@@
+coccilib.report.print_report(p1[0], "Unneeded variable: \"" + ret +
+			     "\". Return \"" + C + "\" on line "
+			     + p2[0].line)
+
+@script:python depends on org@
+p1 << r1.p1;
+p2 << r1.p2;
+C << r1.C;
+ret << r1.ret;
+@@
+cocci.print_main("unneeded \"" + ret + "\" variable", p1)
+cocci.print_sec("return " + C + " here", p2)

--- a/subsys/net/l2/openthread/openthread.c
+++ b/subsys/net/l2/openthread/openthread.c
@@ -232,7 +232,6 @@ static enum net_verdict openthread_recv(struct net_if *iface,
 enum net_verdict openthread_send(struct net_if *iface, struct net_pkt *pkt)
 {
 	struct openthread_context *ot_context = net_if_l2_data(iface);
-	enum net_verdict ret = NET_OK;
 	otMessage *message;
 	struct net_buf *frag;
 
@@ -265,7 +264,7 @@ enum net_verdict openthread_send(struct net_if *iface, struct net_pkt *pkt)
 exit:
 	net_pkt_unref(pkt);
 
-	return ret;
+	return NET_OK;
 }
 
 static u16_t openthread_reserve(struct net_if *iface, void *arg)

--- a/subsys/net/lib/lwm2m/ipso_light_control.c
+++ b/subsys/net/lib/lwm2m/ipso_light_control.c
@@ -177,8 +177,6 @@ static struct lwm2m_engine_obj_inst *light_control_create(u16_t obj_inst_id)
 
 static int ipso_light_control_init(struct device *dev)
 {
-	int ret = 0;
-
 	/* Set default values */
 	(void)memset(inst, 0, sizeof(*inst) * MAX_INSTANCE_COUNT);
 	(void)memset(res, 0, sizeof(struct lwm2m_engine_res_inst) *
@@ -191,7 +189,7 @@ static int ipso_light_control_init(struct device *dev)
 	light_control.create_cb = light_control_create;
 	lwm2m_register_obj(&light_control);
 
-	return ret;
+	return 0;
 }
 
 SYS_INIT(ipso_light_control_init, APPLICATION,

--- a/subsys/net/lib/lwm2m/ipso_temp_sensor.c
+++ b/subsys/net/lib/lwm2m/ipso_temp_sensor.c
@@ -202,8 +202,6 @@ static struct lwm2m_engine_obj_inst *temp_sensor_create(u16_t obj_inst_id)
 
 static int ipso_temp_sensor_init(struct device *dev)
 {
-	int ret = 0;
-
 	/* Set default values */
 	(void)memset(inst, 0, sizeof(*inst) * MAX_INSTANCE_COUNT);
 	(void)memset(res, 0, sizeof(struct lwm2m_engine_res_inst) *
@@ -216,7 +214,7 @@ static int ipso_temp_sensor_init(struct device *dev)
 	temp_sensor.create_cb = temp_sensor_create;
 	lwm2m_register_obj(&temp_sensor);
 
-	return ret;
+	return 0;
 }
 
 SYS_INIT(ipso_temp_sensor_init, APPLICATION,

--- a/tests/crypto/tinycrypt/src/ecc_dh.c
+++ b/tests/crypto/tinycrypt/src/ecc_dh.c
@@ -400,7 +400,6 @@ int montecarlo_ecdh(int num_tests, bool verbose)
 	uint8_t public2[2 * NUM_ECC_BYTES] = { 0 };
 	uint8_t secret1[NUM_ECC_BYTES] = { 0 };
 	uint8_t secret2[NUM_ECC_BYTES] = { 0 };
-	unsigned int result = TC_PASS;
 
 	const struct uECC_Curve_t *curve = uECC_secp256r1();
 
@@ -444,7 +443,7 @@ int montecarlo_ecdh(int num_tests, bool verbose)
 	}
 
 	TC_PRINT("\n");
-	return result;
+	return TC_PASS;
 }
 
 void test_ecc_dh(void)

--- a/tests/net/mgmt/src/mgmt.c
+++ b/tests/net/mgmt/src/mgmt.c
@@ -143,8 +143,6 @@ static void receiver_cb(struct net_mgmt_event_callback *cb,
 
 static int sending_event(u32_t times, bool receiver, bool info)
 {
-	int ret = TC_PASS;
-
 	TC_PRINT("- Sending event %u times, %s a receiver, %s info\n",
 		 times, receiver ? "with" : "without",
 		 info ? "with" : "without");
@@ -172,7 +170,7 @@ static int sending_event(u32_t times, bool receiver, bool info)
 		rx_event = rx_calls = 0;
 	}
 
-	return ret;
+	return TC_PASS;
 }
 
 static int test_sending_event(u32_t times, bool receiver)
@@ -243,8 +241,6 @@ static void initialize_event_tests(void)
 
 static int test_core_event(u32_t event, bool (*func)(void))
 {
-	int ret = TC_PASS;
-
 	TC_PRINT("- Triggering core event: 0x%08X\n", event);
 
 	net_mgmt_init_event_callback(&rx_cb, receiver_cb, event);
@@ -261,7 +257,7 @@ static int test_core_event(u32_t event, bool (*func)(void))
 	net_mgmt_del_event_callback(&rx_cb);
 	rx_event = rx_calls = 0;
 
-	return ret;
+	return TC_PASS;
 }
 
 static bool _iface_ip6_add(void)


### PR DESCRIPTION
This script helps to remove bogus intermediate local variable
 used in functions to store return value and instead return
 directly while saving few bits of memory.
    
