### PR TITLE
arch: ARM: set -mabi and -march in linker flags

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -162,6 +162,10 @@ zephyr_compile_options(
 )
 endif()
 
+zephyr_ld_options(
+  ${TOOLCHAIN_LD_FLAGS}
+)
+
 if(NOT CONFIG_NATIVE_APPLICATION)
 zephyr_ld_options(
   -nostdlib

--- a/arch/arm/CMakeLists.txt
+++ b/arch/arm/CMakeLists.txt
@@ -17,4 +17,9 @@ zephyr_compile_options(
   ${ARCH_FLAG}
   )
 
+zephyr_ld_options(
+  -mabi=aapcs
+  ${ARCH_FLAG}
+  )
+
 add_subdirectory(core)

--- a/cmake/compiler/gcc.cmake
+++ b/cmake/compiler/gcc.cmake
@@ -82,15 +82,22 @@ else()
       -mthumb
       -mcpu=${GCC_M_CPU}
       )
+    list(APPEND TOOLCHAIN_LD_FLAGS
+      -mthumb
+      -mcpu=${GCC_M_CPU}
+      )
 
     include(${ZEPHYR_BASE}/cmake/fpu-for-gcc-m-cpu.cmake)
 
     if(CONFIG_FLOAT)
       list(APPEND TOOLCHAIN_C_FLAGS -mfpu=${FPU_FOR_${GCC_M_CPU}})
+      list(APPEND TOOLCHAIN_LD_FLAGS -mfpu=${FPU_FOR_${GCC_M_CPU}})
       if    (CONFIG_FP_SOFTABI)
         list(APPEND TOOLCHAIN_C_FLAGS -mfloat-abi=softfp)
+        list(APPEND TOOLCHAIN_LD_FLAGS -mfloat-abi=softfp)
       elseif(CONFIG_FP_HARDABI)
         list(APPEND TOOLCHAIN_C_FLAGS -mfloat-abi=hard)
+        list(APPEND TOOLCHAIN_LD_FLAGS -mfloat-abi=hard)
       endif()
     endif()
   elseif("${ARCH}" STREQUAL "arc")


### PR DESCRIPTION
Some toolchains are built with multilib enabled in order to provide
multiple versions of the same library, optimized for different ABI
or architecture. They require the -march= and -mabi= options to be
passed at link time. This is important for example when linking with
newlib.

Signed-off-by: Aurelien Jarno <aurelien@aurel32.net>