### PR TITLE
Fix USB_UART_CONSOLE option with shell and logs

### DIFF
--- a/drivers/console/Kconfig
+++ b/drivers/console/Kconfig
@@ -81,8 +81,7 @@ config UART_CONSOLE_MCUMGR
 
 config USB_UART_CONSOLE
 	bool "Use USB port for console outputs"
-	depends on SERIAL
-	select CONSOLE_HAS_DRIVER
+	select UART_CONSOLE
 	select USB_CDC_ACM
 	help
 	  Enable this option to use the USB UART for console output. The output

--- a/subsys/usb/class/Kconfig
+++ b/subsys/usb/class/Kconfig
@@ -10,6 +10,8 @@ if USB_DEVICE_STACK
 
 config USB_CDC_ACM
 	bool "USB CDC ACM Device Class Driver"
+	select SERIAL_HAS_DRIVER
+	select SERIAL_SUPPORT_INTERRUPT
 	help
 	  USB CDC ACM device class driver
 

--- a/subsys/usb/class/cdc_acm.c
+++ b/subsys/usb/class/cdc_acm.c
@@ -414,6 +414,7 @@ static void cdc_acm_dev_status_cb(enum usb_dc_status_code status,
 		LOG_DBG("USB device connected");
 		break;
 	case USB_DC_CONFIGURED:
+		dev_data->tx_ready = 1;
 		LOG_DBG("USB device configured");
 		break;
 	case USB_DC_DISCONNECTED:
@@ -624,6 +625,9 @@ static void cdc_acm_irq_tx_enable(struct device *dev)
 	struct cdc_acm_dev_data_t * const dev_data = DEV_DATA(dev);
 
 	dev_data->tx_irq_ena = 1U;
+	if (dev_data->tx_ready) {
+		dev_data->cb(dev_data->cb_data);
+	}
 }
 
 /**
@@ -652,7 +656,6 @@ static int cdc_acm_irq_tx_ready(struct device *dev)
 	struct cdc_acm_dev_data_t * const dev_data = DEV_DATA(dev);
 
 	if (dev_data->tx_ready) {
-		dev_data->tx_ready = 0U;
 		return 1;
 	}
 
@@ -671,6 +674,9 @@ static void cdc_acm_irq_rx_enable(struct device *dev)
 	struct cdc_acm_dev_data_t * const dev_data = DEV_DATA(dev);
 
 	dev_data->rx_irq_ena = 1U;
+	if (dev_data->rx_ready) {
+		dev_data->cb(dev_data->cb_data);
+	}
 }
 
 /**
@@ -699,7 +705,6 @@ static int cdc_acm_irq_rx_ready(struct device *dev)
 	struct cdc_acm_dev_data_t * const dev_data = DEV_DATA(dev);
 
 	if (dev_data->rx_ready) {
-		dev_data->rx_ready = 0U;
 		return 1;
 	}
 


### PR DESCRIPTION
This patch series fixes the USB_UART_CONSOLE option providing _USB port for console outputs_ so that it can be used for shell and logs. It has been tested on NRF52840 dongle and SAM E70 Xplained. It is especially interesting on the NRF52840 dongle as there is no easy access to the serial port.