### PR TITLE
c++: kconfig: EXCEPTIONS needs to depend on NEWLIB_LIBC

### DIFF
--- a/subsys/cpp/Kconfig
+++ b/subsys/cpp/Kconfig
@@ -55,6 +55,7 @@ config LIB_CPLUSPLUS
 
 config EXCEPTIONS
 	depends on CPLUSPLUS
+	depends on NEWLIB_LIBC
 	select LIB_CPLUSPLUS
 	bool "Enable C++ exceptions support"
 	help


### PR DESCRIPTION
C++ exception support needs to use the newlib C library in order to get
the abort function. C++ exceptions also do not work with the simple
malloc/free implementation provided by the Zephyr minimal C library.

Signed-off-by: Aurelien Jarno <aurelien@aurel32.net>