### PR TITLE
bluetooth: host: Rename bt_conn_get_id and make it public.

### DIFF
--- a/include/bluetooth/conn.h
+++ b/include/bluetooth/conn.h
@@ -100,6 +100,18 @@ struct bt_conn *bt_conn_lookup_addr_le(u8_t id, const bt_addr_le_t *peer);
  */
 const bt_addr_le_t *bt_conn_get_dst(const struct bt_conn *conn);
 
+/** @brief Get array index of a connection
+ *
+ *  This function is used to map bt_conn to index of an array of
+ *  connections. The array has CONFIG_BT_MAX_CONN elements.
+ *
+ *  @param conn Connection object.
+ *
+ *  @return Index of the connection object.
+ *  The range of the returned value is 0..CONFIG_BT_MAX_CONN-1
+ */
+u8_t bt_conn_index(struct bt_conn *conn);
+
 /** Connection Type */
 enum {
 	/** LE Connection Type */

--- a/subsys/bluetooth/host/conn.c
+++ b/subsys/bluetooth/host/conn.c
@@ -2249,9 +2249,12 @@ int bt_conn_auth_pairing_confirm(struct bt_conn *conn)
 }
 #endif /* CONFIG_BT_SMP || CONFIG_BT_BREDR */
 
-u8_t bt_conn_get_id(struct bt_conn *conn)
+u8_t bt_conn_index(struct bt_conn *conn)
 {
-	return conn - conns;
+	u8_t index = conn - conns;
+
+	__ASSERT(index < CONFIG_BT_MAX_CONN, "Invalid bt_conn pointer");
+	return index;
 }
 
 struct bt_conn *bt_conn_lookup_id(u8_t id)

--- a/subsys/bluetooth/host/conn_internal.h
+++ b/subsys/bluetooth/host/conn_internal.h
@@ -181,7 +181,6 @@ int bt_conn_addr_le_cmp(const struct bt_conn *conn, const bt_addr_le_t *peer);
  * e.g. as the handle since that's assigned to us by the controller.
  */
 #define BT_CONN_ID_INVALID 0xff
-u8_t bt_conn_get_id(struct bt_conn *conn);
 struct bt_conn *bt_conn_lookup_id(u8_t id);
 
 /* Look up a connection state. For BT_ADDR_LE_ANY, returns the first connection

--- a/subsys/bluetooth/host/gatt.c
+++ b/subsys/bluetooth/host/gatt.c
@@ -19,6 +19,7 @@
 
 #include <bluetooth/hci.h>
 #include <bluetooth/bluetooth.h>
+#include <bluetooth/conn.h>
 #include <bluetooth/uuid.h>
 #include <bluetooth/gatt.h>
 #include <bluetooth/hci_driver.h>
@@ -289,12 +290,12 @@ static struct gatt_ccc_store {
 
 static bool gatt_ccc_conn_is_queued(struct bt_conn *conn)
 {
-	return (conn == gatt_ccc_store.conn_list[bt_conn_get_id(conn)]);
+	return (conn == gatt_ccc_store.conn_list[bt_conn_index(conn)]);
 }
 
 static void gatt_ccc_conn_unqueue(struct bt_conn *conn)
 {
-	u8_t index = bt_conn_get_id(conn);
+	u8_t index = bt_conn_index(conn);
 
 	if (gatt_ccc_store.conn_list[index] != NULL) {
 		bt_conn_unref(gatt_ccc_store.conn_list[index]);
@@ -727,7 +728,7 @@ ssize_t bt_gatt_attr_write_ccc(struct bt_conn *conn,
 			/* Store the connection with the same index it has in
 			 * the conns array
 			 */
-			gatt_ccc_store.conn_list[bt_conn_get_id(conn)] =
+			gatt_ccc_store.conn_list[bt_conn_index(conn)] =
 				bt_conn_ref(conn);
 			k_delayed_work_submit(&gatt_ccc_store.work,
 					      CCC_STORE_DELAY);

--- a/subsys/bluetooth/host/hci_core.c
+++ b/subsys/bluetooth/host/hci_core.c
@@ -503,7 +503,7 @@ static void hci_acl(struct net_buf *buf)
 		return;
 	}
 
-	acl(buf)->id = bt_conn_get_id(conn);
+	acl(buf)->id = bt_conn_index(conn);
 
 	bt_conn_recv(conn, buf, flags);
 	bt_conn_unref(conn);


### PR DESCRIPTION
There is not an easy way to relate an application's user_data to a
connection. One way is to save a pointer to bt_conn in the
application's user_data array upon connection establishment.
Each connection related callback function will have to loop for all
user_data and compare the saved pointer to the passed bt_conn
pointer. This is inefficient if there are many callback activations
during the connection.

This change makes the internal bt_conn mapping function accessible to
applications in conn.h. The function name is changed to
bt_conn_get_index to clearly indicate that the function returns an
index of an array.

This new pull request is based on reviewer's comments in the rejected
pull request #11581

Signed-off-by: Kim Sekkelund <ksek@oticon.com>