### PR TITLE
kconfig: cmake: Support for images without gaps.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1242,22 +1242,27 @@ list_append_ifdef(CONFIG_CHECK_LINK_MAP
   COMMAND ${PYTHON_EXECUTABLE} ${ZEPHYR_BASE}/scripts/check_link_map.py ${KERNEL_MAP_NAME}
   )
 
+if(NOT CONFIG_BUILD_NO_GAP_FILL)
+  # Use ';' as separator to get proper space in resulting command.
+  set(GAP_FILL "--gap-fill;0xff")
+endif()
+
 list_append_ifdef(
   CONFIG_BUILD_OUTPUT_HEX
   post_build_commands
-  COMMAND ${CMAKE_OBJCOPY} -S -Oihex --gap-fill 0xFF  -R .comment -R COMMON -R .eh_frame  ${KERNEL_ELF_NAME}    ${KERNEL_HEX_NAME}
+  COMMAND ${CMAKE_OBJCOPY} -S -Oihex ${GAP_FILL}  -R .comment -R COMMON -R .eh_frame  ${KERNEL_ELF_NAME}    ${KERNEL_HEX_NAME}
   )
 
 list_append_ifdef(
   CONFIG_BUILD_OUTPUT_BIN
   post_build_commands
-  COMMAND ${CMAKE_OBJCOPY} -S -Obinary --gap-fill 0xFF -R .comment -R COMMON -R .eh_frame  ${KERNEL_ELF_NAME}    ${KERNEL_BIN_NAME}
+  COMMAND ${CMAKE_OBJCOPY} -S -Obinary ${GAP_FILL} -R .comment -R COMMON -R .eh_frame  ${KERNEL_ELF_NAME}    ${KERNEL_BIN_NAME}
   )
 
 list_append_ifdef(
   CONFIG_BUILD_OUTPUT_S19
   post_build_commands
-  COMMAND ${CMAKE_OBJCOPY} --gap-fill 0xFF --srec-len 1 --output-target=srec ${KERNEL_ELF_NAME} ${KERNEL_S19_NAME}
+  COMMAND ${CMAKE_OBJCOPY} ${GAP_FILL} --srec-len 1 --output-target=srec ${KERNEL_ELF_NAME} ${KERNEL_S19_NAME}
   )
 
 list_append_ifdef(

--- a/Kconfig.zephyr
+++ b/Kconfig.zephyr
@@ -289,6 +289,10 @@ config BUILD_OUTPUT_S19
 	  Build a binary in S19 format. This will build a zephyr.s19 file need
 	  by some platforms.
 
+config BUILD_NO_GAP_FILL
+	bool "Don't fill gaps in generated hex/bin/s19 files."
+	depends on BUILD_OUTPUT_HEX || BUILD_OUTPUT_BIN || BUILD_OUTPUT_S19
+
 config BUILD_OUTPUT_STRIPPED
 	bool "Build a stripped binary"
 	help


### PR DESCRIPTION
Defines a Kconfig variable which allows the user to specify
that any generated hex/bin/s19 file should not have filled gaps.

This is done to support building in a multi image context,
where several image files will be merged together.

Signed-off-by: Håkon Øye Amundsen <haakon.amundsen@nordicsemi.no>