### PR TITLE
tests: benchmark: time measurement for  pending queue operations

### DIFF
--- a/tests/kernel/pipe/pipe_api/src/main.c
+++ b/tests/kernel/pipe/pipe_api/src/main.c
@@ -13,7 +13,6 @@
 
 #include <ztest.h>
 extern void test_pipe_thread2thread(void);
-
 extern void test_pipe_put_fail(void);
 extern void test_pipe_get_fail(void);
 extern void test_pipe_block_put(void);
@@ -24,6 +23,7 @@ extern void test_half_pipe_block_put_sema(void);
 extern void test_pipe_alloc(void);
 extern void test_pipe_reader_wait(void);
 extern void test_pipe_block_writer_wait(void);
+extern void test_bench(void);
 #ifdef CONFIG_USERSPACE
 extern void test_pipe_user_thread2thread(void);
 extern void test_pipe_user_put_fail(void);
@@ -75,6 +75,7 @@ void test_main(void)
 			 ztest_unit_test(test_half_pipe_get_put),
 			 ztest_unit_test(test_pipe_alloc),
 			 ztest_unit_test(test_pipe_reader_wait),
-			 ztest_unit_test(test_pipe_block_writer_wait));
+			 ztest_unit_test(test_pipe_block_writer_wait),
+			 ztest_unit_test(test_bench));
 	ztest_run_test_suite(pipe_api);
 }

--- a/tests/kernel/pipe/pipe_api/src/test_pipe_bench.c
+++ b/tests/kernel/pipe/pipe_api/src/test_pipe_bench.c
@@ -1,0 +1,121 @@
+/*
+ * Copyright (c) 2016 Intel Corporation
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <ztest.h>
+#include <kernel_structs.h>
+#include <ksched.h>
+#include <wait_q.h>
+
+#if CONFIG_X86
+#define TIMING_INFO_PRE_READ()
+#define TIMING_INFO_OS_GET_TIME() (_tsc_read())
+#elif CONFIG_ARM
+#define TIMING_INFO_PRE_READ()
+#define TIMING_INFO_OS_GET_TIME()      (k_cycle_get_32())
+#endif
+
+#define STACK_SIZE      1024
+#define PIPE_LEN 16
+K_PIPE_DEFINE(kpipe4, PIPE_LEN, 4);
+K_THREAD_STACK_DEFINE(tstack4, STACK_SIZE);
+K_THREAD_STACK_DEFINE(tstack5, STACK_SIZE);
+K_THREAD_STACK_DEFINE(tstack6, STACK_SIZE);
+K_THREAD_STACK_DEFINE(tstack7, STACK_SIZE);
+__kernel struct k_thread tdata4;
+__kernel struct k_thread tdata5;
+__kernel struct k_thread tdata6;
+__kernel struct k_thread tdata7;
+
+
+static void thread_handler(void *p1, void *p2, void *p3)
+{
+	while (1) {
+		k_yield();
+	}
+}
+
+void test_bench(void)
+{
+	struct k_thread *thread;
+
+	k_tid_t tid1 = k_thread_create(&tdata4, tstack4, STACK_SIZE,
+					thread_handler, NULL, NULL, NULL,
+					K_PRIO_PREEMPT(1), 0, 0);
+
+	k_tid_t tid2 = k_thread_create(&tdata5, tstack5, STACK_SIZE,
+					thread_handler, NULL, NULL, NULL,
+					K_PRIO_PREEMPT(2), 0, 0);
+
+	k_tid_t tid3 = k_thread_create(&tdata6, tstack6, STACK_SIZE,
+					thread_handler, NULL, NULL, NULL,
+					K_PRIO_PREEMPT(3), 0, 0);
+
+	k_tid_t tid4 = k_thread_create(&tdata7, tstack7, STACK_SIZE,
+					thread_handler, &kpipe4, NULL, NULL,
+					K_PRIO_PREEMPT(4), 0, 0);
+
+	k_sleep(10);
+
+	TIMING_INFO_PRE_READ();
+	u32_t pre_pend_time1 = TIMING_INFO_OS_GET_TIME();
+
+	_pend_thread((struct k_thread *) tid1,
+			&kpipe4.wait_q.writers, K_NO_WAIT);
+
+	TIMING_INFO_PRE_READ();
+	u32_t post_pend_time1 = TIMING_INFO_OS_GET_TIME();
+	u32_t time_for_pend1 = (post_pend_time1 - pre_pend_time1);
+
+	TIMING_INFO_PRE_READ();
+	u32_t pre_pend_time2 = TIMING_INFO_OS_GET_TIME();
+
+	_pend_thread((struct k_thread *) tid2,
+			&kpipe4.wait_q.writers, K_NO_WAIT);
+
+	TIMING_INFO_PRE_READ();
+	u32_t post_pend_time2 = TIMING_INFO_OS_GET_TIME();
+	u32_t time_for_pend2 = (post_pend_time2 - pre_pend_time2);
+
+	TIMING_INFO_PRE_READ();
+	u32_t pre_pend_time3 = TIMING_INFO_OS_GET_TIME();
+
+	_pend_thread((struct k_thread *) tid3,
+			&kpipe4.wait_q.writers, K_NO_WAIT);
+
+	TIMING_INFO_PRE_READ();
+	u32_t post_pend_time3 = TIMING_INFO_OS_GET_TIME();
+	u32_t time_for_pend3 = (post_pend_time3 - pre_pend_time3);
+
+	TIMING_INFO_PRE_READ();
+	u32_t pre_pend_time4 = TIMING_INFO_OS_GET_TIME();
+
+	_pend_thread((struct k_thread *) tid4,
+			&kpipe4.wait_q.writers, K_NO_WAIT);
+
+	TIMING_INFO_PRE_READ();
+	u32_t post_pend_time4 = TIMING_INFO_OS_GET_TIME();
+	u32_t time_for_pend4 = (post_pend_time4 - pre_pend_time4);
+
+	printk("time spent during pending for thread1  %d\n", time_for_pend1);
+	printk("time spent during pending for thread2  %d\n", time_for_pend2);
+	printk("time spent during pending for thread3  %d\n", time_for_pend3);
+	printk("time spent during pending for thread4  %d\n", time_for_pend4);
+
+	while ((thread = _waitq_head(&kpipe4.wait_q.writers)) != NULL) {
+		TIMING_INFO_PRE_READ();
+		u32_t pre_unpend_time = TIMING_INFO_OS_GET_TIME();
+
+		_unpend_thread(thread);
+
+		TIMING_INFO_PRE_READ();
+		u32_t post_unpend_time = TIMING_INFO_OS_GET_TIME();
+
+		u32_t time_for_unpend = post_unpend_time - pre_unpend_time;
+
+		printk("time spent during unpend of thread %d\n",
+							time_for_unpend);
+	}
+}


### PR DESCRIPTION
Measurement of  latency during the pend and unpend operation
with pending queue while  WAITQ_SCALABLE Configuration enabled.
Operations should happen in constant time to meet the O(1)
time complexity.

Signed-off-by: Ajay Kishore <ajay.kishore@intel.com>