### PR TITLE
Bluetooth: host: Clear CCC when clearing all keys

### DIFF
--- a/subsys/bluetooth/host/keys.c
+++ b/subsys/bluetooth/host/keys.c
@@ -23,6 +23,7 @@
 #include "common/log.h"
 
 #include "common/rpa.h"
+#include "gatt_internal.h"
 #include "hci_core.h"
 #include "smp.h"
 #include "settings.h"
@@ -229,6 +230,10 @@ static void keys_clear_id(struct bt_keys *keys, void *data)
 	u8_t *id = data;
 
 	if (*id == keys->id) {
+		if (IS_ENABLED(CONFIG_BT_SETTINGS)) {
+			bt_gatt_clear_ccc(*id, &keys->addr);
+		}
+
 		bt_keys_clear(keys);
 	}
 }


### PR DESCRIPTION
CCC settings were not removed when unpairing all keys.
It means CCC settings were still present in flash and were
loading at bluetooth initialization time.

Loading these orphan CCC settings would fill `bt_gatt_ccc_cfg`
configurations and would prevent to add new CCC when pairing
with a new device.

Signed-off-by: Olivier Martin <olivier.martin@proglove.de>