### PR TITLE
power: Move application level API's to public header

### DIFF
--- a/include/power.h
+++ b/include/power.h
@@ -111,6 +111,40 @@ void _sys_soc_resume(void);
  */
 extern int _sys_soc_suspend(s32_t ticks);
 
+#ifdef CONFIG_PM_CONTROL_OS_DEBUG
+/**
+ * @brief Dump Low Power states related debug info
+ *
+ * Dump Low Power states debug info like LPS entry count and residencies.
+ */
+extern void sys_pm_dump_debug_info(void);
+
+#endif /* CONFIG_PM_CONTROL_OS_DEBUG */
+
+#ifdef CONFIG_PM_CONTROL_STATE_LOCK
+/**
+ * @brief Disable system PM state
+ *
+ * Disable system Low power states like LPS or Deep Sleep states.
+ */
+extern void sys_pm_ctrl_disable_state(int state);
+
+/**
+ * @brief Enable system PM state
+ *
+ * Enable system Low power states like LPS or Deep Sleep states.
+ */
+extern void sys_pm_ctrl_enable_state(int state);
+
+/**
+ * @brief Get enable status of a PM state
+ *
+ * Get enable status of a system PM state.
+ */
+extern bool sys_pm_ctrl_is_state_enabled(int state);
+
+#endif /* CONFIG_PM_CONTROL_STATE_LOCK */
+
 /**
  * @}
  */

--- a/subsys/power/policy/pm_policy.h
+++ b/subsys/power/policy/pm_policy.h
@@ -55,34 +55,6 @@ extern void sys_pm_notify_lps_entry(enum power_states state);
  */
 extern void sys_pm_notify_lps_exit(enum power_states state);
 
-/**
- * @brief Dump Low Power states related debug info
- *
- * Dump Low Power states debug info like LPS entry count and residencies.
- */
-extern void sys_pm_dump_debug_info(void);
-
-/**
- * @brief Disable system PM state
- *
- * Disable system Low power states like LPS or Deep Sleep states.
- */
-extern void sys_pm_ctrl_disable_state(int state);
-
-/**
- * @brief Enable system PM state
- *
- * Enable system Low power states like LPS or Deep Sleep states.
- */
-extern void sys_pm_ctrl_enable_state(int state);
-
-/**
- * @brief Get enable status of a PM state
- *
- * Get enable status of a system PM state.
- */
-extern bool sys_pm_ctrl_is_state_enabled(int state);
-
 #ifdef __cplusplus
 }
 #endif


### PR DESCRIPTION
Move the API's used by applications to include/power.h file.

Signed-off-by: Ramakrishna Pallala <ramakrishna.pallala@intel.com>