### PR TITLE
net: ipv4: Clarify basic IPv4 packet drop logging

### DIFF
--- a/subsys/net/ip/ipv4.c
+++ b/subsys/net/ip/ipv4.c
@@ -118,7 +118,8 @@ enum net_verdict net_ipv4_process_pkt(struct net_pkt *pkt)
 	enum net_verdict verdict = NET_DROP;
 
 	if (real_len < pkt_len) {
-		NET_DBG("IPv4 packet size %d pkt len %d", pkt_len, real_len);
+		NET_DBG("DROP: pkt len per hdr %d != pkt real len %d",
+			pkt_len, real_len);
 		goto drop;
 	} else if (real_len > pkt_len) {
 		net_pkt_pull(pkt, pkt_len, real_len - pkt_len);


### PR DESCRIPTION
1. Clarify message telling that the actual packet length fed by the
driver differs from what specified in IPv4 header, and that leads to
drop.
2. Debug log any dropped packets in general.

These changes come from the experience of developing a networking
driver, where figuring out why packets get dropped may require
quite a head-scratching.

Signed-off-by: Paul Sokolovsky <paul.sokolovsky@linaro.org>