### PR TITLE
drivers: modem: wncm14a2a: remove socket_reading logic

### DIFF
--- a/drivers/modem/wncm14a2a.c
+++ b/drivers/modem/wncm14a2a.c
@@ -946,8 +946,13 @@ static void on_cmd_sockdataind(struct net_buf **buf, u16_t len)
 		snprintk(sendbuf, sizeof(sendbuf), "AT@SOCKREAD=%d,%d",
 			 sock->socket_id, left_bytes);
 
-		/* We still have a lock from hitting this cmd trigger,
-		 * so don't hold one when we send the new command
+		/* We entered this trigger due to an unsolicited modem response.
+		 * When we send the AT@SOCKREAD command it won't generate an
+		 * "OK" response directly.  The modem will respond with
+		 * "@SOCKREAD ..." and the data requested and then "OK" or
+		 * "ERROR".  Let's not wait here by passing in a timeout to
+		 * send_at_cmd().  Instead, when the resulting response is
+		 * received, we trigger on_cmd_sockread() to handle it.
 		 */
 		send_at_cmd(sock, sendbuf, K_NO_WAIT);
 	}


### PR DESCRIPTION
Remove overly complicated logic to skip incoming data if we were
still waiting on a previous set of data to be read.

This fixes a bug where an error during data receive could end up
with the modem ignoring all incoming data.

Signed-off-by: Michael Scott <mike@foundries.io>