### PR TITLE
Rework shell help

### DIFF
--- a/doc/subsystems/shell/shell.rst
+++ b/doc/subsystems/shell/shell.rst
@@ -289,7 +289,7 @@ checks for valid arguments count.
 		ARG_UNUSED(argv);
 
 		if (shell_help_requested(shell) {
-			shell_help_print(shell, NULL, 0);
+			shell_help_print(shell);
 		} else {
 			shell_fprintf(shell, SHELL_NORMAL,
 			      "Command called with no -h or --help option."

--- a/drivers/flash/flash_shell.c
+++ b/drivers/flash/flash_shell.c
@@ -231,12 +231,12 @@ static int cmd_flash(const struct shell *shell, size_t argc, char **argv)
 	int err;
 
 	if (argc == 1) {
-		shell_help_print(shell, NULL, 0);
+		shell_help_print(shell);
 		/* shell_cmd_precheck returns 1 when help is printed */
 		return 1;
 	}
 
-	err = shell_cmd_precheck(shell, (argc == 2), NULL, 0);
+	err = shell_cmd_precheck(shell, argc == 2);
 	if (err) {
 		return err;
 	}

--- a/drivers/flash/flash_shell.c
+++ b/drivers/flash/flash_shell.c
@@ -216,8 +216,6 @@ static int cmd_test(const struct shell *shell, size_t argc, char *argv[])
 	return 0;
 }
 
-#define HELP_NONE "[none]"
-
 SHELL_CREATE_STATIC_SUBCMD_SET(flash_cmds) {
 	SHELL_CMD(erase, NULL, "<page address> <size>", cmd_erase),
 	SHELL_CMD(read, NULL, "<address> <Dword count>", cmd_read),
@@ -228,22 +226,9 @@ SHELL_CREATE_STATIC_SUBCMD_SET(flash_cmds) {
 
 static int cmd_flash(const struct shell *shell, size_t argc, char **argv)
 {
-	int err;
-
-	if (argc == 1) {
-		shell_help_print(shell);
-		/* shell_cmd_precheck returns 1 when help is printed */
-		return 1;
-	}
-
-	err = shell_cmd_precheck(shell, argc == 2);
-	if (err) {
-		return err;
-	}
-
-	error(shell, "%s:%s%s", argv[0], "unknown parameter: ", argv[1]);
+	error(shell, "%s:unknown parameter: %s", argv[0], argv[1]);
 	return -EINVAL;
 }
 
-SHELL_CMD_REGISTER(flash, &flash_cmds, "Flash shell commands",
-		   cmd_flash);
+SHELL_CMD_ARG_REGISTER(flash, &flash_cmds, "Flash shell commands",
+		       cmd_flash, 2, 0);

--- a/drivers/pci/pci_shell.c
+++ b/drivers/pci/pci_shell.c
@@ -45,7 +45,7 @@ static int cmd_lspci(const struct shell *shell, size_t argc, char **argv)
 	};
 
 	if (shell_help_requested(shell)) {
-		shell_help_print(shell, NULL, 0);
+		shell_help_print(shell);
 		return 1;
 	}
 

--- a/drivers/pci/pci_shell.c
+++ b/drivers/pci/pci_shell.c
@@ -44,11 +44,6 @@ static int cmd_lspci(const struct shell *shell, size_t argc, char **argv)
 		.bar = PCI_BAR_ANY,
 	};
 
-	if (shell_help_requested(shell)) {
-		shell_help_print(shell);
-		return 1;
-	}
-
 	pci_bus_scan_init();
 
 	while (pci_bus_scan(&info)) {

--- a/include/shell/shell.h
+++ b/include/shell/shell.h
@@ -342,7 +342,6 @@ struct shell_stats {
  */
 struct shell_flags {
 	u32_t insert_mode :1; /*!< Controls insert mode for text introduction.*/
-	u32_t show_help   :1; /*!< Shows help if -h or --help option present.*/
 	u32_t use_colors  :1; /*!< Controls colored syntax.*/
 	u32_t echo        :1; /*!< Controls shell echo.*/
 	u32_t processing  :1; /*!< Shell is executing process function.*/
@@ -614,18 +613,6 @@ void shell_fprintf(const struct shell *shell, enum shell_vt100_color color,
  * @param[in] shell Pointer to the shell instance.
  */
 void shell_process(const struct shell *shell);
-
-/**
- * @brief Informs that a command has been called with -h or --help option.
- *
- * @param[in] shell Pointer to the shell instance.
- *
- * @return True if help has been requested.
- */
-static inline bool shell_help_requested(const struct shell *shell)
-{
-	return shell->ctx->internal.flags.show_help;
-}
 
 /**
  * @brief Prints the current command help.

--- a/include/shell/shell.h
+++ b/include/shell/shell.h
@@ -640,7 +640,7 @@ int shell_prompt_change(const struct shell *shell, char *prompt);
  *
  * @param[in] shell      Pointer to the shell instance.
  */
-void shell_help_print(const struct shell *shell);
+void shell_help(const struct shell *shell);
 
 /** @brief Execute command.
  *

--- a/include/shell/shell.h
+++ b/include/shell/shell.h
@@ -616,28 +616,6 @@ void shell_fprintf(const struct shell *shell, enum shell_vt100_color color,
 void shell_process(const struct shell *shell);
 
 /**
- * @brief Option descriptor.
- */
-struct shell_getopt_option {
-	const char *optname; /*!< Option long name.*/
-	const char *optname_short; /*!< Option short name.*/
-	const char *optname_help; /*!< Option help string.*/
-};
-
-/**
- * @brief Option structure initializer.
- *
- * @param[in] _optname    Option name long.
- * @param[in] _shortname  Option name short.
- * @param[in] _help       Option help string.
- */
-#define SHELL_OPT(_optname, _shortname, _help) {	\
-	.optname = _optname,				\
-	.optname_short = _shortname,			\
-	.optname_help = _help,				\
-	}
-
-/**
  * @brief Informs that a command has been called with -h or --help option.
  *
  * @param[in] shell Pointer to the shell instance.
@@ -652,15 +630,12 @@ static inline bool shell_help_requested(const struct shell *shell)
 /**
  * @brief Prints the current command help.
  *
- * Function will print a help string with: the currently entered command, its
- * options,and subcommands (if they exist).
+ * Function will print a help string with the currently entered command and
+ * its subcommands (if exist).
  *
  * @param[in] shell      Pointer to the shell instance.
- * @param[in] opt        Pointer to the optional option array.
- * @param[in] opt_len    Option array size.
  */
-void shell_help_print(const struct shell *shell,
-		      const struct shell_getopt_option *opt, size_t opt_len);
+void shell_help_print(const struct shell *shell);
 
 /**
  * @brief Change displayed shell prompt.
@@ -680,17 +655,13 @@ int shell_prompt_change(const struct shell *shell, char *prompt);
  *
  * @param[in] shell	  Pointer to the shell instance.
  * @param[in] arg_cnt_ok  Flag indicating valid number of arguments.
- * @param[in] opt	  Pointer to the optional option array.
- * @param[in] opt_len	  Option array size.
  *
  * @return 0		  if check passed
  * @return 1		  if help was requested
  * @return -EINVAL	  if wrong argument count
  */
 int shell_cmd_precheck(const struct shell *shell,
-		       bool arg_cnt_ok,
-		       const struct shell_getopt_option *opt,
-		       size_t opt_len);
+		       bool arg_cnt_ok);
 
 /**
  * @internal @brief This function shall not be used directly, it is required by

--- a/include/shell/shell.h
+++ b/include/shell/shell.h
@@ -119,14 +119,14 @@ struct shell_static_entry {
  */
 #define SHELL_CMD_ARG_REGISTER(syntax, subcmd, help, handler,		   \
 			       mandatory, optional)			   \
-	static const struct shell_static_entry UTIL_CAT(shell_, syntax) =  \
+	static const struct shell_static_entry UTIL_CAT(_shell_, syntax) = \
 	SHELL_CMD_ARG(syntax, subcmd, help, handler, mandatory, optional); \
 	static const struct shell_cmd_entry UTIL_CAT(shell_cmd_, syntax)   \
 	__attribute__ ((section("."					   \
 			STRINGIFY(UTIL_CAT(shell_root_cmd_, syntax)))))	   \
 	__attribute__((used)) = {					   \
 		.is_dynamic = false,					   \
-		.u.entry = &UTIL_CAT(shell_, syntax)			   \
+		.u.entry = &UTIL_CAT(_shell_, syntax)			   \
 	}
 
 /**
@@ -141,14 +141,14 @@ struct shell_static_entry {
  * @param[in] handler Pointer to a function handler.
  */
 #define SHELL_CMD_REGISTER(syntax, subcmd, help, handler) \
-	static const struct shell_static_entry UTIL_CAT(shell_, syntax) =  \
+	static const struct shell_static_entry UTIL_CAT(_shell_, syntax) = \
 	SHELL_CMD(syntax, subcmd, help, handler);			   \
 	static const struct shell_cmd_entry UTIL_CAT(shell_cmd_, syntax)   \
 	__attribute__ ((section("."					   \
 			STRINGIFY(UTIL_CAT(shell_root_cmd_, syntax)))))	   \
 	__attribute__((used)) = {					   \
 		.is_dynamic = false,					   \
-		.u.entry = &UTIL_CAT(shell_, syntax)			   \
+		.u.entry = &UTIL_CAT(_shell_, syntax)			   \
 	}
 
 /**
@@ -440,6 +440,8 @@ struct shell {
 	k_thread_stack_t *stack;
 };
 
+extern void shell_print_stream(const void *user_ctx, const char *data,
+			       size_t data_len);
 /**
  * @brief Macro for defining a shell instance.
  *
@@ -615,16 +617,6 @@ void shell_fprintf(const struct shell *shell, enum shell_vt100_color color,
 void shell_process(const struct shell *shell);
 
 /**
- * @brief Prints the current command help.
- *
- * Function will print a help string with the currently entered command and
- * its subcommands (if exist).
- *
- * @param[in] shell      Pointer to the shell instance.
- */
-void shell_help_print(const struct shell *shell);
-
-/**
  * @brief Change displayed shell prompt.
  *
  * @param[in] shell	Pointer to the shell instance.
@@ -636,30 +628,14 @@ void shell_help_print(const struct shell *shell);
 int shell_prompt_change(const struct shell *shell, char *prompt);
 
 /**
- * @brief Prints help if requested and prints error message on wrong argument
- *	  count.
- *	  Optionally, printing help on wrong argument count can be enabled.
+ * @brief Prints the current command help.
  *
- * @param[in] shell	  Pointer to the shell instance.
- * @param[in] arg_cnt_ok  Flag indicating valid number of arguments.
+ * Function will print a help string with: the currently entered command
+ * and subcommands (if they exist).
  *
- * @return 0		  if check passed
- * @return 1		  if help was requested
- * @return -EINVAL	  if wrong argument count
+ * @param[in] shell      Pointer to the shell instance.
  */
-int shell_cmd_precheck(const struct shell *shell,
-		       bool arg_cnt_ok);
-
-/**
- * @internal @brief This function shall not be used directly, it is required by
- *		    the fprintf module.
- *
- * @param[in] p_user_ctx    Pointer to the context for the shell instance.
- * @param[in] p_data        Pointer to the data buffer.
- * @param[in] data_len      Data buffer size.
- */
-void shell_print_stream(const void *user_ctx, const char *data,
-			size_t data_len);
+void shell_help_print(const struct shell *shell);
 
 /** @brief Execute command.
  *

--- a/include/shell/shell.h
+++ b/include/shell/shell.h
@@ -105,10 +105,12 @@ struct shell_static_entry {
 };
 
 /**
- * @brief Macro for defining and adding a root command (level 0) with
- * arguments.
+ * @brief Macro for defining and adding a root command (level 0) with required
+ * number of arguments.
  *
- * @note Each root command shall have unique syntax.
+ * @note Each root command shall have unique syntax. If a command will be called
+ * with wrong number of arguments shell will print an error message and command
+ * handler will not be called.
  *
  * @param[in] syntax  Command syntax (for example: history).
  * @param[in] subcmd  Pointer to a subcommands array.
@@ -184,7 +186,10 @@ struct shell_static_entry {
 	}
 
 /**
- * @brief Initializes a shell command with arguments
+ * @brief Initializes a shell command with arguments.
+ *
+ * @note If a command will be called with wrong number of arguments shell will
+ * print an error message and command handler will not be called.
  *
  * @param[in] _syntax  Command syntax (for example: history).
  * @param[in] _subcmd  Pointer to a subcommands array.

--- a/include/shell/shell_fprintf.h
+++ b/include/shell/shell_fprintf.h
@@ -76,7 +76,6 @@ void shell_fprintf_fmt(const struct shell_fprintf *sh_fprintf,
  */
 void shell_fprintf_buffer_flush(const struct shell_fprintf *sh_fprintf);
 
-
 #ifdef __cplusplus
 }
 #endif

--- a/samples/drivers/flash_shell/src/main.c
+++ b/samples/drivers/flash_shell/src/main.c
@@ -233,7 +233,7 @@ static int cmd_flash(const struct shell *shell, size_t argc, char **argv)
 	ARG_UNUSED(argc);
 	ARG_UNUSED(argv);
 
-	shell_help_print(shell, NULL, 0);
+	shell_help_print(shell);
 	return 0;
 }
 
@@ -243,7 +243,7 @@ static int cmd_write_block_size(const struct shell *shell, size_t argc,
 {
 	ARG_UNUSED(argv);
 
-	int err = shell_cmd_precheck(shell, (argc == 1), NULL, 0);
+	int err = shell_cmd_precheck(shell, argc == 1);
 
 	if (err) {
 		return err;
@@ -261,7 +261,7 @@ static int cmd_write_block_size(const struct shell *shell, size_t argc,
 static int cmd_read(const struct shell *shell, size_t argc, char **argv)
 {
 
-	int err = shell_cmd_precheck(shell, (argc == 3), NULL, 0);
+	int err = shell_cmd_precheck(shell, argc == 3);
 	unsigned long int offset, len;
 
 	if (err) {
@@ -287,7 +287,7 @@ exit:
 
 static int cmd_erase(const struct shell *shell, size_t argc, char **argv)
 {
-	int err = shell_cmd_precheck(shell, (argc == 3), NULL, 0);
+	int err = shell_cmd_precheck(shell, argc == 3);
 	unsigned long int offset, size;
 
 	if (err) {
@@ -312,7 +312,7 @@ exit:
 
 static int cmd_write(const struct shell *shell, size_t argc, char **argv)
 {
-	int err = shell_cmd_precheck(shell, (argc > 2), NULL, 0);
+	int err = shell_cmd_precheck(shell, argc > 2);
 	unsigned long int i, offset;
 	u8_t buf[ARGC_MAX];
 
@@ -366,7 +366,7 @@ static int cmd_page_count(const struct shell *shell, size_t argc, char **argv)
 {
 	ARG_UNUSED(argv);
 
-	int err = shell_cmd_precheck(shell, (argc == 1), NULL, 0);
+	int err = shell_cmd_precheck(shell, argc == 1);
 	size_t page_count;
 
 	if (err) {
@@ -409,7 +409,7 @@ static bool page_layout_cb(const struct flash_pages_info *info, void *datav)
 
 static int cmd_page_layout(const struct shell *shell, size_t argc, char **argv)
 {
-	int err = shell_cmd_precheck(shell, (argc <= 3), NULL, 0);
+	int err = shell_cmd_precheck(shell, argc <= 3);
 	unsigned long int start_page, end_page;
 	struct page_layout_data data;
 
@@ -464,7 +464,7 @@ static int cmd_page_read(const struct shell *shell, size_t argc, char **argv)
 	int ret;
 
 
-	ret = shell_cmd_precheck(shell, (argc == 3) || (argc == 4), NULL, 0);
+	ret = shell_cmd_precheck(shell, argc == 3 || argc == 4);
 	if (ret) {
 		return ret;
 	}
@@ -512,7 +512,7 @@ static int cmd_page_erase(const struct shell *shell, size_t argc, char **argv)
 		return ret;
 	}
 
-	ret = shell_cmd_precheck(shell, (argc == 2) || (argc == 3), NULL, 0);
+	ret = shell_cmd_precheck(shell, argc == 2 || argc == 3);
 	if (ret) {
 		return ret;
 	}
@@ -563,7 +563,7 @@ static int cmd_page_write(const struct shell *shell, size_t argc, char **argv)
 		return ret;
 	}
 
-	ret = shell_cmd_precheck(shell, (argc > 2), NULL, 0);
+	ret = shell_cmd_precheck(shell, argc > 2);
 	if (ret) {
 		return ret;
 	}
@@ -603,7 +603,7 @@ static int cmd_set_dev(const struct shell *shell, size_t argc, char **argv)
 	const char *name;
 	int ret;
 
-	ret = shell_cmd_precheck(shell, (argc == 2), NULL, 0);
+	ret = shell_cmd_precheck(shell, argc == 2);
 	if (ret) {
 		return ret;
 	}

--- a/samples/drivers/flash_shell/src/main.c
+++ b/samples/drivers/flash_shell/src/main.c
@@ -3,7 +3,6 @@
  *
  * SPDX-License-Identifier: Apache-2.0
  */
-
 #include <stdlib.h>
 #include <string.h>
 
@@ -241,15 +240,11 @@ static int cmd_flash(const struct shell *shell, size_t argc, char **argv)
 static int cmd_write_block_size(const struct shell *shell, size_t argc,
 				char **argv)
 {
+	ARG_UNUSED(argc);
 	ARG_UNUSED(argv);
 
-	int err = shell_cmd_precheck(shell, argc == 1);
+	int err = check_flash_device(shell);
 
-	if (err) {
-		return err;
-	}
-
-	err = check_flash_device(shell);
 	if (!err) {
 		PR_SHELL(shell, "%d\n",
 			 flash_get_write_block_size(flash_device));
@@ -260,15 +255,9 @@ static int cmd_write_block_size(const struct shell *shell, size_t argc,
 
 static int cmd_read(const struct shell *shell, size_t argc, char **argv)
 {
-
-	int err = shell_cmd_precheck(shell, argc == 3);
+	int err = check_flash_device(shell);
 	unsigned long int offset, len;
 
-	if (err) {
-		goto exit;
-	}
-
-	err = check_flash_device(shell);
 	if (err) {
 		goto exit;
 	}
@@ -287,14 +276,10 @@ exit:
 
 static int cmd_erase(const struct shell *shell, size_t argc, char **argv)
 {
-	int err = shell_cmd_precheck(shell, argc == 3);
-	unsigned long int offset, size;
+	int err = check_flash_device(shell);
+	unsigned long int offset;
+	unsigned long int size;
 
-	if (err) {
-		goto exit;
-	}
-
-	err = check_flash_device(shell);
 	if (err) {
 		goto exit;
 	}
@@ -312,15 +297,11 @@ exit:
 
 static int cmd_write(const struct shell *shell, size_t argc, char **argv)
 {
-	int err = shell_cmd_precheck(shell, argc > 2);
 	unsigned long int i, offset;
 	u8_t buf[ARGC_MAX];
 
-	if (err) {
-		goto exit;
-	}
+	int err = check_flash_device(shell);
 
-	err = check_flash_device(shell);
 	if (err) {
 		goto exit;
 	}
@@ -365,15 +346,11 @@ exit:
 static int cmd_page_count(const struct shell *shell, size_t argc, char **argv)
 {
 	ARG_UNUSED(argv);
+	ARG_UNUSED(argc);
 
-	int err = shell_cmd_precheck(shell, argc == 1);
+	int err = check_flash_device(shell);
 	size_t page_count;
 
-	if (err) {
-		return err;
-	}
-
-	err = check_flash_device(shell);
 	if (!err) {
 		page_count = flash_get_page_count(flash_device);
 		PR_SHELL(shell, "Flash device contains %lu pages.\n",
@@ -409,15 +386,11 @@ static bool page_layout_cb(const struct flash_pages_info *info, void *datav)
 
 static int cmd_page_layout(const struct shell *shell, size_t argc, char **argv)
 {
-	int err = shell_cmd_precheck(shell, argc <= 3);
 	unsigned long int start_page, end_page;
 	struct page_layout_data data;
 
-	if (err) {
-		return err;
-	}
+	int err = check_flash_device(shell);
 
-	err = check_flash_device(shell);
 	if (err) {
 		goto bail;
 	}
@@ -463,12 +436,6 @@ static int cmd_page_read(const struct shell *shell, size_t argc, char **argv)
 	struct flash_pages_info info;
 	int ret;
 
-
-	ret = shell_cmd_precheck(shell, argc == 3 || argc == 4);
-	if (ret) {
-		return ret;
-	}
-
 	ret = check_flash_device(shell);
 	if (ret) {
 		return ret;
@@ -508,11 +475,6 @@ static int cmd_page_erase(const struct shell *shell, size_t argc, char **argv)
 	int ret;
 
 	ret = check_flash_device(shell);
-	if (ret) {
-		return ret;
-	}
-
-	ret = shell_cmd_precheck(shell, argc == 2 || argc == 3);
 	if (ret) {
 		return ret;
 	}
@@ -563,15 +525,11 @@ static int cmd_page_write(const struct shell *shell, size_t argc, char **argv)
 		return ret;
 	}
 
-	ret = shell_cmd_precheck(shell, argc > 2);
-	if (ret) {
-		return ret;
-	}
-
-	if (argc < 2 || parse_ul(argv[1], &page) || parse_ul(argv[2], &off)) {
+	if (parse_ul(argv[1], &page) || parse_ul(argv[2], &off)) {
 		ret = -EINVAL;
 		goto bail;
 	}
+
 	argc -= 3;
 	argv += 3;
 	for (i = 0; i < argc; i++) {
@@ -601,12 +559,6 @@ static int cmd_set_dev(const struct shell *shell, size_t argc, char **argv)
 {
 	struct device *dev;
 	const char *name;
-	int ret;
-
-	ret = shell_cmd_precheck(shell, argc == 2);
-	if (ret) {
-		return ret;
-	}
 
 	name = argv[1];
 
@@ -642,19 +594,21 @@ void main(void)
 SHELL_CREATE_STATIC_SUBCMD_SET(sub_flash)
 {
 	/* Alphabetically sorted to ensure correct Tab autocompletion. */
-	SHELL_CMD(erase,		NULL,	ERASE_HELP,	cmd_erase),
+	SHELL_CMD_ARG(erase,	NULL,	ERASE_HELP,	cmd_erase, 3, 0),
 #ifdef CONFIG_FLASH_PAGE_LAYOUT
-	SHELL_CMD(page_count,	NULL,	PAGE_COUNT_HELP,   cmd_page_count),
-	SHELL_CMD(page_errase,	NULL,	PAGE_ERASE_HELP,   cmd_page_erase),
-	SHELL_CMD(page_layout,	NULL,	PAGE_LAYOUT_HELP,  cmd_page_layout),
-	SHELL_CMD(page_read,	NULL,	PAGE_READ_HELP,	   cmd_page_read),
-	SHELL_CMD(page_write,	NULL,	PAGE_WRITE_HELP,   cmd_page_write),
+	SHELL_CMD_ARG(page_count,  NULL, PAGE_COUNT_HELP, cmd_page_count, 1, 0),
+	SHELL_CMD_ARG(page_erase, NULL, PAGE_ERASE_HELP, cmd_page_erase, 2, 1),
+	SHELL_CMD_ARG(page_layout, NULL, PAGE_LAYOUT_HELP,
+		      cmd_page_layout, 1, 2),
+	SHELL_CMD_ARG(page_read,   NULL, PAGE_READ_HELP,  cmd_page_read, 3, 1),
+	SHELL_CMD_ARG(page_write,  NULL, PAGE_WRITE_HELP,
+		      cmd_page_write, 3, 255),
 #endif
-	SHELL_CMD(read,			NULL,	READ_HELP,	cmd_read),
-	SHELL_CMD(set_device,		NULL,	SET_DEV_HELP,	cmd_set_dev),
-	SHELL_CMD(write,		NULL,	WRITE_HELP,	cmd_write),
-	SHELL_CMD(write_block_size,	NULL,	WRITE_BLOCK_SIZE_HELP,
-							cmd_write_block_size),
+	SHELL_CMD_ARG(read,		NULL,	READ_HELP,	cmd_read, 3, 0),
+	SHELL_CMD_ARG(set_device, NULL, SET_DEV_HELP, cmd_set_dev, 2, 0),
+	SHELL_CMD_ARG(write,	  NULL,	WRITE_HELP,	cmd_write, 3, 255),
+	SHELL_CMD_ARG(write_block_size,	NULL,	WRITE_BLOCK_SIZE_HELP,
+						    cmd_write_block_size, 1, 0),
 	SHELL_SUBCMD_SET_END /* Array terminated. */
 };
 

--- a/samples/drivers/flash_shell/src/main.c
+++ b/samples/drivers/flash_shell/src/main.c
@@ -232,7 +232,7 @@ static int cmd_flash(const struct shell *shell, size_t argc, char **argv)
 	ARG_UNUSED(argc);
 	ARG_UNUSED(argv);
 
-	shell_help_print(shell);
+	shell_help(shell);
 	return 0;
 }
 

--- a/samples/mpu/mpu_test/src/main.c
+++ b/samples/mpu/mpu_test/src/main.c
@@ -34,11 +34,6 @@ static int cmd_read(const struct shell *shell, size_t argc, char *argv[])
 
 	u32_t *p_mem = (u32_t *) RESERVED_MEM_MAP;
 
-	if (shell_help_requested(shell)) {
-		shell_help_print(shell);
-		return 0;
-	}
-
 	/* Reads from an address that is reserved in the memory map */
 	PR_SHELL(shell, "The value is: %d\n", *p_mem);
 
@@ -54,11 +49,6 @@ static int cmd_write_mcux(const struct shell *shell, size_t argc, char *argv[])
 	struct device *flash_dev;
 	u32_t value[2];
 	u32_t offset;
-
-	if (shell_help_requested(shell)) {
-		shell_help_print(shell);
-		return 0;
-	}
 
 	flash_dev = device_get_binding(DT_FLASH_DEV_NAME);
 
@@ -90,11 +80,6 @@ static int cmd_write_stm32(const struct shell *shell, size_t argc, char *argv[])
 
 	struct device *flash_dev;
 
-	if (shell_help_requested(shell)) {
-		shell_help_print(shell);
-		return 0;
-	}
-
 	flash_dev = device_get_binding(DT_FLASH_DEV_NAME);
 
 	/* 16K reserved to the application */
@@ -123,11 +108,6 @@ static int cmd_write(const struct shell *shell, size_t argc, char *argv[])
 	/* 16K reserved to the application */
 	u32_t *p_mem = (u32_t *) (FLASH_MEM + 0x4000);
 
-	if (shell_help_requested(shell)) {
-		shell_help_print(shell);
-		return 0;
-	}
-
 	PR_SHELL(shell, "write address: 0x%x\n", FLASH_MEM + 0x4000);
 
 	/* Write in to boot FLASH/ROM */
@@ -143,11 +123,6 @@ static int cmd_run(const struct shell *shell, size_t argc, char *argv[])
 	ARG_UNUSED(argv);
 
 	void (*func_ptr)(void) = (void (*)(void)) RAM_MEM;
-
-	if (shell_help_requested(shell)) {
-		shell_help_print(shell);
-		return 0;
-	}
 
 	/* Run code located in RAM */
 	func_ptr();

--- a/samples/mpu/mpu_test/src/main.c
+++ b/samples/mpu/mpu_test/src/main.c
@@ -134,18 +134,6 @@ static int cmd_mtest(const struct shell *shell, size_t argc, char *argv[])
 {
 	u32_t *mem;
 	u32_t val;
-	int err;
-
-	if (argc > 3) {
-		PR_ERROR(shell, "mtest accepts 1 (Read) or 2 (Write)"
-				"parameters\n");
-		return -EINVAL;
-	}
-
-	err = shell_cmd_precheck(shell, (argc >= 2) && (argc <= 3));
-	if (err) {
-		return err;
-	}
 
 	val = (u32_t)strtol(argv[1], NULL, 16);
 	mem = (u32_t *) val;
@@ -166,7 +154,7 @@ void main(void)
 
 SHELL_CREATE_STATIC_SUBCMD_SET(sub_mpu)
 {
-	SHELL_CMD(mtest, NULL, MTEST_CMD_HELP, cmd_mtest),
+	SHELL_CMD_ARG(mtest, NULL, MTEST_CMD_HELP, cmd_mtest, 2, 1),
 	SHELL_CMD(read, NULL, READ_CMD_HELP, cmd_read),
 	SHELL_CMD(run, NULL, RUN_CMD_HELP, cmd_run),
 #if defined(CONFIG_SOC_FLASH_MCUX)

--- a/samples/mpu/mpu_test/src/main.c
+++ b/samples/mpu/mpu_test/src/main.c
@@ -35,7 +35,7 @@ static int cmd_read(const struct shell *shell, size_t argc, char *argv[])
 	u32_t *p_mem = (u32_t *) RESERVED_MEM_MAP;
 
 	if (shell_help_requested(shell)) {
-		shell_help_print(shell, NULL, 0);
+		shell_help_print(shell);
 		return 0;
 	}
 
@@ -56,7 +56,7 @@ static int cmd_write_mcux(const struct shell *shell, size_t argc, char *argv[])
 	u32_t offset;
 
 	if (shell_help_requested(shell)) {
-		shell_help_print(shell, NULL, 0);
+		shell_help_print(shell);
 		return 0;
 	}
 
@@ -91,7 +91,7 @@ static int cmd_write_stm32(const struct shell *shell, size_t argc, char *argv[])
 	struct device *flash_dev;
 
 	if (shell_help_requested(shell)) {
-		shell_help_print(shell, NULL, 0);
+		shell_help_print(shell);
 		return 0;
 	}
 
@@ -124,7 +124,7 @@ static int cmd_write(const struct shell *shell, size_t argc, char *argv[])
 	u32_t *p_mem = (u32_t *) (FLASH_MEM + 0x4000);
 
 	if (shell_help_requested(shell)) {
-		shell_help_print(shell, NULL, 0);
+		shell_help_print(shell);
 		return 0;
 	}
 
@@ -145,7 +145,7 @@ static int cmd_run(const struct shell *shell, size_t argc, char *argv[])
 	void (*func_ptr)(void) = (void (*)(void)) RAM_MEM;
 
 	if (shell_help_requested(shell)) {
-		shell_help_print(shell, NULL, 0);
+		shell_help_print(shell);
 		return 0;
 	}
 
@@ -167,7 +167,7 @@ static int cmd_mtest(const struct shell *shell, size_t argc, char *argv[])
 		return -EINVAL;
 	}
 
-	err = shell_cmd_precheck(shell, (argc >= 2) && (argc <= 3), NULL, 0);
+	err = shell_cmd_precheck(shell, (argc >= 2) && (argc <= 3));
 	if (err) {
 		return err;
 	}

--- a/samples/net/promiscuous_mode/src/main.c
+++ b/samples/net/promiscuous_mode/src/main.c
@@ -147,7 +147,7 @@ static int set_promisc_mode(const struct shell *shell,
 	int idx, ret;
 
 	if (shell_help_requested(shell)) {
-		shell_help_print(shell, NULL, 0);
+		shell_help_print(shell);
 		return -ENOEXEC;
 	}
 

--- a/samples/net/promiscuous_mode/src/main.c
+++ b/samples/net/promiscuous_mode/src/main.c
@@ -146,11 +146,6 @@ static int set_promisc_mode(const struct shell *shell,
 	char *endptr;
 	int idx, ret;
 
-	if (shell_help_requested(shell)) {
-		shell_help_print(shell);
-		return -ENOEXEC;
-	}
-
 	if (argc < 2) {
 		shell_fprintf(shell, SHELL_ERROR, "Invalid arguments.\n");
 		return -ENOEXEC;

--- a/samples/net/rpl_border_router/src/shell.c
+++ b/samples/net/rpl_border_router/src/shell.c
@@ -25,7 +25,7 @@ static int cmd_br_repair(const struct shell *shell,
 	ARG_UNUSED(argv);
 
 	if (shell_help_requested(shell)) {
-		shell_help_print(shell, NULL, 0);
+		shell_help_print(shell);
 		return -ENOEXEC;
 	}
 
@@ -44,7 +44,7 @@ static int cmd_coap_send(const struct shell *shell,
 	int r;
 
 	if (shell_help_requested(shell)) {
-		shell_help_print(shell, NULL, 0);
+		shell_help_print(shell);
 		return -ENOEXEC;
 	}
 

--- a/samples/net/rpl_border_router/src/shell.c
+++ b/samples/net/rpl_border_router/src/shell.c
@@ -24,11 +24,6 @@ static int cmd_br_repair(const struct shell *shell,
 	ARG_UNUSED(argc);
 	ARG_UNUSED(argv);
 
-	if (shell_help_requested(shell)) {
-		shell_help_print(shell);
-		return -ENOEXEC;
-	}
-
 	shell_fprintf(shell, SHELL_INFO, "Starting global repair...\n");
 
 	net_rpl_repair_root(CONFIG_NET_RPL_DEFAULT_INSTANCE);
@@ -42,11 +37,6 @@ static int cmd_coap_send(const struct shell *shell,
 	struct in6_addr peer_addr;
 	enum coap_request_type type;
 	int r;
-
-	if (shell_help_requested(shell)) {
-		shell_help_print(shell);
-		return -ENOEXEC;
-	}
 
 	if (argc != 3 || !argv[1] || !argv[2]) {
 		shell_fprintf(shell, SHELL_ERROR, "Invalid arguments.\n");

--- a/samples/net/zperf/src/zperf_shell.c
+++ b/samples/net/zperf/src/zperf_shell.c
@@ -225,7 +225,7 @@ static int cmd_setip(const struct shell *shell, size_t argc, char *argv[])
 	do_init(shell);
 
 	if (IS_ENABLED(CONFIG_NET_IPV6) && !IS_ENABLED(CONFIG_NET_IPV4)) {
-		if (argc != 3 || shell_help_requested(shell)) {
+		if (argc != 3) {
 			shell_help_print(shell);
 			return -ENOEXEC;
 		}
@@ -243,7 +243,7 @@ static int cmd_setip(const struct shell *shell, size_t argc, char *argv[])
 	}
 
 	if (IS_ENABLED(CONFIG_NET_IPV4) && !IS_ENABLED(CONFIG_NET_IPV6)) {
-		if (argc != 2 || shell_help_requested(shell)) {
+		if (argc != 2) {
 			shell_help_print(shell);
 			return -ENOEXEC;
 		}
@@ -261,7 +261,7 @@ static int cmd_setip(const struct shell *shell, size_t argc, char *argv[])
 
 	if (IS_ENABLED(CONFIG_NET_IPV6) && IS_ENABLED(CONFIG_NET_IPV4)) {
 		if (net_addr_pton(AF_INET6, argv[start + 1], &ipv6) < 0) {
-			if (argc != 2 || shell_help_requested(shell)) {
+			if (argc != 2) {
 				shell_help_print(shell);
 				return -ENOEXEC;
 			}
@@ -277,7 +277,7 @@ static int cmd_setip(const struct shell *shell, size_t argc, char *argv[])
 				      "Setting IP address %s\n",
 				      net_sprint_ipv4_addr(&ipv4));
 		} else {
-			if (argc != 3 || shell_help_requested(shell)) {
+			if (argc != 3) {
 				shell_help_print(shell);
 				return -ENOEXEC;
 			}
@@ -306,11 +306,6 @@ static int cmd_udp_download(const struct shell *shell, size_t argc,
 		int port, start = 0;
 
 		do_init(shell);
-
-		if (shell_help_requested(shell)) {
-			shell_help_print(shell);
-			return -ENOEXEC;
-		}
 
 		if (argc >= 2) {
 			port = strtoul(argv[start + 1], NULL, 10);
@@ -982,11 +977,6 @@ static int cmd_tcp_download(const struct shell *shell, size_t argc,
 		int port;
 
 		do_init(shell);
-
-		if (shell_help_requested(shell)) {
-			shell_help_print(shell);
-			return -ENOEXEC;
-		}
 
 		if (argc >= 2) {
 			port = strtoul(argv[1], NULL, 10);

--- a/samples/net/zperf/src/zperf_shell.c
+++ b/samples/net/zperf/src/zperf_shell.c
@@ -226,7 +226,7 @@ static int cmd_setip(const struct shell *shell, size_t argc, char *argv[])
 
 	if (IS_ENABLED(CONFIG_NET_IPV6) && !IS_ENABLED(CONFIG_NET_IPV4)) {
 		if (argc != 3 || shell_help_requested(shell)) {
-			shell_help_print(shell, NULL, 0);
+			shell_help_print(shell);
 			return -ENOEXEC;
 		}
 
@@ -244,7 +244,7 @@ static int cmd_setip(const struct shell *shell, size_t argc, char *argv[])
 
 	if (IS_ENABLED(CONFIG_NET_IPV4) && !IS_ENABLED(CONFIG_NET_IPV6)) {
 		if (argc != 2 || shell_help_requested(shell)) {
-			shell_help_print(shell, NULL, 0);
+			shell_help_print(shell);
 			return -ENOEXEC;
 		}
 
@@ -262,7 +262,7 @@ static int cmd_setip(const struct shell *shell, size_t argc, char *argv[])
 	if (IS_ENABLED(CONFIG_NET_IPV6) && IS_ENABLED(CONFIG_NET_IPV4)) {
 		if (net_addr_pton(AF_INET6, argv[start + 1], &ipv6) < 0) {
 			if (argc != 2 || shell_help_requested(shell)) {
-				shell_help_print(shell, NULL, 0);
+				shell_help_print(shell);
 				return -ENOEXEC;
 			}
 
@@ -278,7 +278,7 @@ static int cmd_setip(const struct shell *shell, size_t argc, char *argv[])
 				      net_sprint_ipv4_addr(&ipv4));
 		} else {
 			if (argc != 3 || shell_help_requested(shell)) {
-				shell_help_print(shell, NULL, 0);
+				shell_help_print(shell);
 				return -ENOEXEC;
 			}
 
@@ -308,7 +308,7 @@ static int cmd_udp_download(const struct shell *shell, size_t argc,
 		do_init(shell);
 
 		if (shell_help_requested(shell)) {
-			shell_help_print(shell, NULL, 0);
+			shell_help_print(shell);
 			return -ENOEXEC;
 		}
 
@@ -693,12 +693,12 @@ static int shell_cmd_upload(const struct shell *shell, size_t argc,
 
 		if (is_udp) {
 			if (IS_ENABLED(CONFIG_NET_UDP)) {
-				shell_help_print(shell, NULL, 0);
+				shell_help_print(shell);
 				return -ENOEXEC;
 			}
 		} else {
 			if (IS_ENABLED(CONFIG_NET_TCP)) {
-				shell_help_print(shell, NULL, 0);
+				shell_help_print(shell);
 				return -ENOEXEC;
 			}
 		}
@@ -833,12 +833,12 @@ static int shell_cmd_upload2(const struct shell *shell, size_t argc,
 
 		if (is_udp) {
 			if (IS_ENABLED(CONFIG_NET_UDP)) {
-				shell_help_print(shell, NULL, 0);
+				shell_help_print(shell);
 				return -ENOEXEC;
 			}
 		} else {
 			if (IS_ENABLED(CONFIG_NET_TCP)) {
-				shell_help_print(shell, NULL, 0);
+				shell_help_print(shell);
 				return -ENOEXEC;
 			}
 		}
@@ -941,7 +941,7 @@ static int cmd_tcp(const struct shell *shell, size_t argc, char *argv[])
 	if (IS_ENABLED(CONFIG_NET_TCP)) {
 		do_init(shell);
 
-		shell_help_print(shell, NULL, 0);
+		shell_help_print(shell);
 		return -ENOEXEC;
 	}
 
@@ -956,7 +956,7 @@ static int cmd_udp(const struct shell *shell, size_t argc, char *argv[])
 	if (IS_ENABLED(CONFIG_NET_UDP)) {
 		do_init(shell);
 
-		shell_help_print(shell, NULL, 0);
+		shell_help_print(shell);
 		return -ENOEXEC;
 	}
 
@@ -984,7 +984,7 @@ static int cmd_tcp_download(const struct shell *shell, size_t argc,
 		do_init(shell);
 
 		if (shell_help_requested(shell)) {
-			shell_help_print(shell, NULL, 0);
+			shell_help_print(shell);
 			return -ENOEXEC;
 		}
 

--- a/samples/net/zperf/src/zperf_shell.c
+++ b/samples/net/zperf/src/zperf_shell.c
@@ -226,7 +226,7 @@ static int cmd_setip(const struct shell *shell, size_t argc, char *argv[])
 
 	if (IS_ENABLED(CONFIG_NET_IPV6) && !IS_ENABLED(CONFIG_NET_IPV4)) {
 		if (argc != 3) {
-			shell_help_print(shell);
+			shell_help(shell);
 			return -ENOEXEC;
 		}
 
@@ -244,7 +244,7 @@ static int cmd_setip(const struct shell *shell, size_t argc, char *argv[])
 
 	if (IS_ENABLED(CONFIG_NET_IPV4) && !IS_ENABLED(CONFIG_NET_IPV6)) {
 		if (argc != 2) {
-			shell_help_print(shell);
+			shell_help(shell);
 			return -ENOEXEC;
 		}
 
@@ -262,7 +262,7 @@ static int cmd_setip(const struct shell *shell, size_t argc, char *argv[])
 	if (IS_ENABLED(CONFIG_NET_IPV6) && IS_ENABLED(CONFIG_NET_IPV4)) {
 		if (net_addr_pton(AF_INET6, argv[start + 1], &ipv6) < 0) {
 			if (argc != 2) {
-				shell_help_print(shell);
+				shell_help(shell);
 				return -ENOEXEC;
 			}
 
@@ -278,7 +278,7 @@ static int cmd_setip(const struct shell *shell, size_t argc, char *argv[])
 				      net_sprint_ipv4_addr(&ipv4));
 		} else {
 			if (argc != 3) {
-				shell_help_print(shell);
+				shell_help(shell);
 				return -ENOEXEC;
 			}
 
@@ -688,12 +688,12 @@ static int shell_cmd_upload(const struct shell *shell, size_t argc,
 
 		if (is_udp) {
 			if (IS_ENABLED(CONFIG_NET_UDP)) {
-				shell_help_print(shell);
+				shell_help(shell);
 				return -ENOEXEC;
 			}
 		} else {
 			if (IS_ENABLED(CONFIG_NET_TCP)) {
-				shell_help_print(shell);
+				shell_help(shell);
 				return -ENOEXEC;
 			}
 		}
@@ -828,12 +828,12 @@ static int shell_cmd_upload2(const struct shell *shell, size_t argc,
 
 		if (is_udp) {
 			if (IS_ENABLED(CONFIG_NET_UDP)) {
-				shell_help_print(shell);
+				shell_help(shell);
 				return -ENOEXEC;
 			}
 		} else {
 			if (IS_ENABLED(CONFIG_NET_TCP)) {
-				shell_help_print(shell);
+				shell_help(shell);
 				return -ENOEXEC;
 			}
 		}
@@ -936,7 +936,7 @@ static int cmd_tcp(const struct shell *shell, size_t argc, char *argv[])
 	if (IS_ENABLED(CONFIG_NET_TCP)) {
 		do_init(shell);
 
-		shell_help_print(shell);
+		shell_help(shell);
 		return -ENOEXEC;
 	}
 
@@ -951,7 +951,7 @@ static int cmd_udp(const struct shell *shell, size_t argc, char *argv[])
 	if (IS_ENABLED(CONFIG_NET_UDP)) {
 		do_init(shell);
 
-		shell_help_print(shell);
+		shell_help(shell);
 		return -ENOEXEC;
 	}
 

--- a/samples/subsys/shell/shell_module/src/dynamic_cmd.c
+++ b/samples/subsys/shell/shell_module/src/dynamic_cmd.c
@@ -21,7 +21,7 @@ extern void qsort(void *a, size_t n, size_t es, cmp_t *cmp);
 
 static int cmd_dynamic(const struct shell *shell, size_t argc, char **argv)
 {
-	if ((argc == 1) || shell_help_requested(shell)) {
+	if ((argc == 1)) {
 		shell_help_print(shell);
 		return 0;
 	}
@@ -48,11 +48,6 @@ static int cmd_dynamic_add(const struct shell *shell,
 {
 	u8_t idx;
 	u16_t cmd_len;
-
-	if (shell_help_requested(shell)) {
-		shell_help_print(shell);
-		return 0;
-	}
 
 	if (argc != 2) {
 		shell_fprintf(shell, SHELL_ERROR,
@@ -102,11 +97,6 @@ static int cmd_dynamic_add(const struct shell *shell,
 static int cmd_dynamic_show(const struct shell *shell,
 			    size_t argc, char **argv)
 {
-	if (shell_help_requested(shell)) {
-		shell_help_print(shell);
-		return 0;
-	}
-
 	if (argc != 1) {
 		shell_fprintf(shell, SHELL_ERROR,
 			      "%s: bad parameter count\r\n", argv[0]);
@@ -132,11 +122,6 @@ static int cmd_dynamic_show(const struct shell *shell,
 static int cmd_dynamic_execute(const struct shell *shell,
 			       size_t argc, char **argv)
 {
-	if (shell_help_requested(shell)) {
-		shell_help_print(shell);
-		return 0;
-	}
-
 	if (argc != 2) {
 		shell_fprintf(shell, SHELL_ERROR,
 			      "%s: bad parameter count\r\n", argv[0]);
@@ -160,7 +145,7 @@ static int cmd_dynamic_execute(const struct shell *shell,
 static int cmd_dynamic_remove(const struct shell *shell, size_t argc,
 			      char **argv)
 {
-	if ((argc == 1) || shell_help_requested(shell)) {
+	if (argc == 1) {
 		shell_help_print(shell);
 		return 0;
 	}

--- a/samples/subsys/shell/shell_module/src/dynamic_cmd.c
+++ b/samples/subsys/shell/shell_module/src/dynamic_cmd.c
@@ -22,7 +22,7 @@ extern void qsort(void *a, size_t n, size_t es, cmp_t *cmp);
 static int cmd_dynamic(const struct shell *shell, size_t argc, char **argv)
 {
 	if ((argc == 1) || shell_help_requested(shell)) {
-		shell_help_print(shell, NULL, 0);
+		shell_help_print(shell);
 		return 0;
 	}
 
@@ -50,7 +50,7 @@ static int cmd_dynamic_add(const struct shell *shell,
 	u16_t cmd_len;
 
 	if (shell_help_requested(shell)) {
-		shell_help_print(shell, NULL, 0);
+		shell_help_print(shell);
 		return 0;
 	}
 
@@ -103,7 +103,7 @@ static int cmd_dynamic_show(const struct shell *shell,
 			    size_t argc, char **argv)
 {
 	if (shell_help_requested(shell)) {
-		shell_help_print(shell, NULL, 0);
+		shell_help_print(shell);
 		return 0;
 	}
 
@@ -133,7 +133,7 @@ static int cmd_dynamic_execute(const struct shell *shell,
 			       size_t argc, char **argv)
 {
 	if (shell_help_requested(shell)) {
-		shell_help_print(shell, NULL, 0);
+		shell_help_print(shell);
 		return 0;
 	}
 
@@ -161,7 +161,7 @@ static int cmd_dynamic_remove(const struct shell *shell, size_t argc,
 			      char **argv)
 {
 	if ((argc == 1) || shell_help_requested(shell)) {
-		shell_help_print(shell, NULL, 0);
+		shell_help_print(shell);
 		return 0;
 	}
 

--- a/samples/subsys/shell/shell_module/src/dynamic_cmd.c
+++ b/samples/subsys/shell/shell_module/src/dynamic_cmd.c
@@ -19,24 +19,6 @@ static u8_t dynamic_cmd_cnt;
 typedef int cmp_t(const void *, const void *);
 extern void qsort(void *a, size_t n, size_t es, cmp_t *cmp);
 
-static int cmd_dynamic(const struct shell *shell, size_t argc, char **argv)
-{
-	if ((argc == 1)) {
-		shell_help_print(shell);
-		return 0;
-	}
-
-	if (argc > 2) {
-		shell_fprintf(shell, SHELL_ERROR,
-			      "%s: bad parameter count\r\n", argv[0]);
-	} else {
-		shell_fprintf(shell, SHELL_ERROR,
-			      "%s: please specify subcommand\r\n", argv[0]);
-	}
-
-	return -ENOEXEC;
-}
-
 /* function required by qsort */
 static int string_cmp(const void *p_a, const void *p_b)
 {
@@ -46,40 +28,35 @@ static int string_cmp(const void *p_a, const void *p_b)
 static int cmd_dynamic_add(const struct shell *shell,
 			   size_t argc, char **argv)
 {
-	u8_t idx;
 	u16_t cmd_len;
+	u8_t idx;
 
-	if (argc != 2) {
-		shell_fprintf(shell, SHELL_ERROR,
-			      "%s: bad parameter count\r\n", argv[0]);
-		return -ENOEXEC;
-	}
+	ARG_UNUSED(argc);
 
 	if (dynamic_cmd_cnt >= MAX_CMD_CNT) {
-		shell_fprintf(shell, SHELL_ERROR, "command limit reached\r\n");
+		shell_error(shell, "command limit reached");
 		return -ENOEXEC;
 	}
 
 	cmd_len = strlen(argv[1]);
 
 	if (cmd_len >= MAX_CMD_LEN) {
-		shell_fprintf(shell, SHELL_ERROR, "too long command\r\n");
+		shell_error(shell, "too long command");
 		return -ENOEXEC;
 	}
 
 	for (idx = 0U; idx < cmd_len; idx++) {
 		if (!isalnum((int)(argv[1][idx]))) {
-			shell_fprintf(shell, SHELL_ERROR,
-				     "bad command name - please use only"
-				     " alphanumerical characters\r\n");
+			shell_error(shell,
+				    "bad command name - please use only"
+				    " alphanumerical characters");
 			return -ENOEXEC;
 		}
 	}
 
 	for (idx = 0U; idx < MAX_CMD_CNT; idx++) {
 		if (!strcmp(dynamic_cmd_buffer[idx], argv[1])) {
-			shell_fprintf(shell, SHELL_ERROR,
-				      "duplicated command\r\n");
+			shell_error(shell, "duplicated command");
 			return -ENOEXEC;
 		}
 	}
@@ -89,32 +66,7 @@ static int cmd_dynamic_add(const struct shell *shell,
 	qsort(dynamic_cmd_buffer, dynamic_cmd_cnt,
 	      sizeof(dynamic_cmd_buffer[0]), string_cmp);
 
-	shell_fprintf(shell, SHELL_NORMAL, "command added successfully\r\n");
-
-	return 0;
-}
-
-static int cmd_dynamic_show(const struct shell *shell,
-			    size_t argc, char **argv)
-{
-	if (argc != 1) {
-		shell_fprintf(shell, SHELL_ERROR,
-			      "%s: bad parameter count\r\n", argv[0]);
-		return -ENOEXEC;
-	}
-
-	if (dynamic_cmd_cnt == 0) {
-		shell_fprintf(shell, SHELL_WARNING,
-			      "Please add some commands first.\r\n");
-		return -ENOEXEC;
-	}
-
-	shell_fprintf(shell, SHELL_NORMAL, "Dynamic command list:\r\n");
-
-	for (u8_t i = 0; i < dynamic_cmd_cnt; i++) {
-		shell_fprintf(shell, SHELL_NORMAL,
-			      "[%3d] %s\r\n", i, dynamic_cmd_buffer[i]);
-	}
+	shell_print(shell, "command added successfully");
 
 	return 0;
 }
@@ -122,22 +74,17 @@ static int cmd_dynamic_show(const struct shell *shell,
 static int cmd_dynamic_execute(const struct shell *shell,
 			       size_t argc, char **argv)
 {
-	if (argc != 2) {
-		shell_fprintf(shell, SHELL_ERROR,
-			      "%s: bad parameter count\r\n", argv[0]);
-		return -ENOEXEC;
-	}
+	ARG_UNUSED(argc);
+	ARG_UNUSED(argv);
 
 	for (u8_t idx = 0; idx <  dynamic_cmd_cnt; idx++) {
 		if (!strcmp(dynamic_cmd_buffer[idx], argv[1])) {
-			shell_fprintf(shell, SHELL_NORMAL,
-				      "dynamic command: %s\r\n", argv[1]);
+			shell_print(shell, "dynamic command: %s", argv[1]);
 			return 0;
 		}
 	}
 
-	shell_fprintf(shell, SHELL_ERROR,
-		      "%s: uknown parameter: %s\r\n", argv[0], argv[1]);
+	shell_error(shell, "%s: uknown parameter: %s", argv[0], argv[1]);
 
 	return -ENOEXEC;
 }
@@ -145,16 +92,8 @@ static int cmd_dynamic_execute(const struct shell *shell,
 static int cmd_dynamic_remove(const struct shell *shell, size_t argc,
 			      char **argv)
 {
-	if (argc == 1) {
-		shell_help_print(shell);
-		return 0;
-	}
-
-	if (argc != 2) {
-		shell_fprintf(shell, SHELL_ERROR,
-			      "%s: bad parameter count\r\n", argv[0]);
-		return -ENOEXEC;
-	}
+	ARG_UNUSED(argc);
+	ARG_UNUSED(argv);
 
 	for (u8_t idx = 0; idx <  dynamic_cmd_cnt; idx++) {
 		if (!strcmp(dynamic_cmd_buffer[idx], argv[1])) {
@@ -168,15 +107,33 @@ static int cmd_dynamic_remove(const struct shell *shell, size_t argc,
 			}
 
 			--dynamic_cmd_cnt;
-			shell_fprintf(shell, SHELL_NORMAL,
-				      "command removed successfully\r\n");
+			shell_print(shell, "command removed successfully");
 			return 0;
 		}
 	}
-	shell_fprintf(shell, SHELL_ERROR,
-		      "did not find command: %s\r\n", argv[1]);
+	shell_error(shell, "did not find command: %s", argv[1]);
 
 	return -ENOEXEC;
+}
+
+static int cmd_dynamic_show(const struct shell *shell,
+			    size_t argc, char **argv)
+{
+	ARG_UNUSED(argc);
+	ARG_UNUSED(argv);
+
+	if (dynamic_cmd_cnt == 0) {
+		shell_warn(shell, "Please add some commands first.");
+		return -ENOEXEC;
+	}
+
+	shell_print(shell, "Dynamic command list:");
+
+	for (u8_t i = 0; i < dynamic_cmd_cnt; i++) {
+		shell_print(shell, "[%3d] %s", i, dynamic_cmd_buffer[i]);
+	}
+
+	return 0;
 }
 
 /* dynamic command creation */
@@ -201,21 +158,21 @@ static void dynamic_cmd_get(size_t idx, struct shell_static_entry *entry)
 SHELL_CREATE_DYNAMIC_CMD(m_sub_dynamic_set, dynamic_cmd_get);
 SHELL_CREATE_STATIC_SUBCMD_SET(m_sub_dynamic)
 {
-	SHELL_CMD(add, NULL,
+	SHELL_CMD_ARG(add, NULL,
 		"Add a new dynamic command.\nExample usage: [ dynamic add test "
 		"] will add a dynamic command 'test'.\nIn this example, command"
 		" name length is limited to 32 chars. You can add up to 20"
 		" commands. Commands are automatically sorted to ensure correct"
 		" shell completion.",
-		cmd_dynamic_add),
-	SHELL_CMD(execute, &m_sub_dynamic_set,
-		"Execute a command.", cmd_dynamic_execute),
-	SHELL_CMD(remove, &m_sub_dynamic_set,
-		"Remove a command.", cmd_dynamic_remove),
-	SHELL_CMD(show, NULL,
-		"Show all added dynamic commands.", cmd_dynamic_show),
+		cmd_dynamic_add, 2, 0),
+	SHELL_CMD_ARG(execute, &m_sub_dynamic_set,
+		"Execute a command.", cmd_dynamic_execute, 2, 0),
+	SHELL_CMD_ARG(remove, &m_sub_dynamic_set,
+		"Remove a command.", cmd_dynamic_remove, 2, 0),
+	SHELL_CMD_ARG(show, NULL,
+		"Show all added dynamic commands.", cmd_dynamic_show, 1, 0),
 	SHELL_SUBCMD_SET_END
 };
 
 SHELL_CMD_REGISTER(dynamic, &m_sub_dynamic,
-		   "Demonstrate dynamic command usage.", cmd_dynamic);
+		   "Demonstrate dynamic command usage.", NULL);

--- a/samples/subsys/shell/shell_module/src/main.c
+++ b/samples/subsys/shell/shell_module/src/main.c
@@ -31,29 +31,22 @@ static int cmd_log_test_start(const struct shell *shell, size_t argc,
 {
 	ARG_UNUSED(argv);
 
-	int err = shell_cmd_precheck(shell, argc == 1);
-
-	if (err) {
-		return err;
-	}
-
 	k_timer_start(&log_timer, period, period);
-	shell_fprintf(shell, SHELL_NORMAL, "Log test started\n");
+	shell_print(shell, "Log test started\n");
+
 	return 0;
 }
 
 static int cmd_log_test_start_demo(const struct shell *shell, size_t argc,
 				   char **argv)
 {
-	cmd_log_test_start(shell, argc, argv, 200);
-	return 0;
+	return cmd_log_test_start(shell, argc, argv, 200);
 }
 
 static int cmd_log_test_start_flood(const struct shell *shell, size_t argc,
 				    char **argv)
 {
-	cmd_log_test_start(shell, argc, argv, 10);
-	return 0;
+	return cmd_log_test_start(shell, argc, argv, 10);
 }
 
 static int cmd_log_test_stop(const struct shell *shell, size_t argc,
@@ -62,33 +55,28 @@ static int cmd_log_test_stop(const struct shell *shell, size_t argc,
 	ARG_UNUSED(argc);
 	ARG_UNUSED(argv);
 
-	int err = shell_cmd_precheck(shell, argc == 1);
-
-	if (err) {
-		return err;
-	}
-
 	k_timer_stop(&log_timer);
-	shell_fprintf(shell, SHELL_NORMAL, "Log test stopped\n");
+	shell_print(shell, "Log test stopped");
 
 	return 0;
 }
+
 SHELL_CREATE_STATIC_SUBCMD_SET(sub_log_test_start)
 {
 	/* Alphabetically sorted. */
-	SHELL_CMD(demo, NULL,
+	SHELL_CMD_ARG(demo, NULL,
 		  "Start log timer which generates log message every 200ms.",
-		  cmd_log_test_start_demo),
-	SHELL_CMD(flood, NULL,
+		  cmd_log_test_start_demo, 1, 0),
+	SHELL_CMD_ARG(flood, NULL,
 		  "Start log timer which generates log message every 10ms.",
-		  cmd_log_test_start_flood),
+		  cmd_log_test_start_flood, 1, 0),
 	SHELL_SUBCMD_SET_END /* Array terminated. */
 };
 SHELL_CREATE_STATIC_SUBCMD_SET(sub_log_test)
 {
 	/* Alphabetically sorted. */
-	SHELL_CMD(start, &sub_log_test_start, "Start log test", NULL),
-	SHELL_CMD(stop, NULL, "Stop log test.", cmd_log_test_stop),
+	SHELL_CMD_ARG(start, &sub_log_test_start, "Start log test", NULL, 2, 0),
+	SHELL_CMD_ARG(stop, NULL, "Stop log test.", cmd_log_test_stop, 1, 0),
 	SHELL_SUBCMD_SET_END /* Array terminated. */
 };
 
@@ -99,20 +87,18 @@ static int cmd_demo_ping(const struct shell *shell, size_t argc, char **argv)
 	ARG_UNUSED(argc);
 	ARG_UNUSED(argv);
 
-	shell_fprintf(shell, SHELL_NORMAL, "pong\n");
+	shell_print(shell, "pong");
 
 	return 0;
 }
 
 static int cmd_demo_params(const struct shell *shell, size_t argc, char **argv)
 {
-	int cnt;
-
-	shell_fprintf(shell, SHELL_NORMAL, "argc = %d\n", argc);
-	for (cnt = 0; cnt < argc; cnt++) {
-		shell_fprintf(shell, SHELL_NORMAL,
-				"  argv[%d] = %s\n", cnt, argv[cnt]);
+	shell_print(shell, "argc = %d", argc);
+	for (size_t cnt = 0; cnt < argc; cnt++) {
+		shell_print(shell, "  argv[%d] = %s", cnt, argv[cnt]);
 	}
+
 	return 0;
 }
 
@@ -121,8 +107,8 @@ static int cmd_version(const struct shell *shell, size_t argc, char **argv)
 	ARG_UNUSED(argc);
 	ARG_UNUSED(argv);
 
-	shell_fprintf(shell, SHELL_NORMAL,
-		      "Zephyr version %s\n", KERNEL_VERSION_STRING);
+	shell_print(shell, "Zephyr version %s", KERNEL_VERSION_STRING);
+
 	return 0;
 }
 
@@ -135,8 +121,7 @@ SHELL_CREATE_STATIC_SUBCMD_SET(sub_demo)
 };
 SHELL_CMD_REGISTER(demo, &sub_demo, "Demo commands", NULL);
 
-SHELL_CMD_REGISTER(version, NULL, "Show kernel version", cmd_version);
-
+SHELL_CMD_ARG_REGISTER(version, NULL, "Show kernel version", cmd_version, 1, 0);
 
 void main(void)
 {

--- a/samples/subsys/shell/shell_module/src/main.c
+++ b/samples/subsys/shell/shell_module/src/main.c
@@ -31,7 +31,7 @@ static int cmd_log_test_start(const struct shell *shell, size_t argc,
 {
 	ARG_UNUSED(argv);
 
-	int err = shell_cmd_precheck(shell, argc == 1, NULL, 0);
+	int err = shell_cmd_precheck(shell, argc == 1);
 
 	if (err) {
 		return err;
@@ -62,7 +62,7 @@ static int cmd_log_test_stop(const struct shell *shell, size_t argc,
 	ARG_UNUSED(argc);
 	ARG_UNUSED(argv);
 
-	int err = shell_cmd_precheck(shell, argc == 1, NULL, 0);
+	int err = shell_cmd_precheck(shell, argc == 1);
 
 	if (err) {
 		return err;

--- a/subsys/bluetooth/host/mesh/shell.c
+++ b/subsys/bluetooth/host/mesh/shell.c
@@ -1574,12 +1574,6 @@ static int cmd_provision(const struct shell *shell, size_t argc, char *argv[])
 int cmd_timeout(const struct shell *shell, size_t argc, char *argv[])
 {
 	s32_t timeout;
-	int err;
-
-	err = shell_cmd_precheck(shell, (argc >= 1));
-	if (err) {
-		return err;
-	}
 
 	if (argc < 2) {
 		timeout = bt_mesh_cfg_cli_timeout_get();
@@ -1618,11 +1612,6 @@ static int cmd_fault_get(const struct shell *shell, size_t argc, char *argv[])
 	u8_t test_id;
 	u16_t cid;
 	int err;
-
-	err = shell_cmd_precheck(shell, (argc == 1));
-	if (err) {
-		return err;
-	}
 
 	cid = strtoul(argv[1], NULL, 0);
 	fault_count = sizeof(faults);
@@ -2043,7 +2032,7 @@ static int cmd_mesh(const struct shell *shell, size_t argc, char **argv)
 {
 	if (argc == 1) {
 		shell_help_print(shell);
-		/* shell_cmd_precheck returns 1 when help is printed */
+		/* shell returns 1 when help is printed */
 		return 1;
 	}
 

--- a/subsys/bluetooth/host/mesh/shell.c
+++ b/subsys/bluetooth/host/mesh/shell.c
@@ -2031,7 +2031,7 @@ SHELL_CREATE_STATIC_SUBCMD_SET(mesh_cmds) {
 static int cmd_mesh(const struct shell *shell, size_t argc, char **argv)
 {
 	if (argc == 1) {
-		shell_help_print(shell);
+		shell_help(shell);
 		/* shell returns 1 when help is printed */
 		return 1;
 	}

--- a/subsys/bluetooth/host/mesh/shell.c
+++ b/subsys/bluetooth/host/mesh/shell.c
@@ -1576,7 +1576,7 @@ int cmd_timeout(const struct shell *shell, size_t argc, char *argv[])
 	s32_t timeout;
 	int err;
 
-	err = shell_cmd_precheck(shell, (argc >= 1), NULL, 0);
+	err = shell_cmd_precheck(shell, (argc >= 1));
 	if (err) {
 		return err;
 	}
@@ -1619,7 +1619,7 @@ static int cmd_fault_get(const struct shell *shell, size_t argc, char *argv[])
 	u16_t cid;
 	int err;
 
-	err = shell_cmd_precheck(shell, (argc == 1), NULL, 0);
+	err = shell_cmd_precheck(shell, (argc == 1));
 	if (err) {
 		return err;
 	}
@@ -2042,7 +2042,7 @@ SHELL_CREATE_STATIC_SUBCMD_SET(mesh_cmds) {
 static int cmd_mesh(const struct shell *shell, size_t argc, char **argv)
 {
 	if (argc == 1) {
-		shell_help_print(shell, NULL, 0);
+		shell_help_print(shell);
 		/* shell_cmd_precheck returns 1 when help is printed */
 		return 1;
 	}

--- a/subsys/bluetooth/shell/bredr.c
+++ b/subsys/bluetooth/shell/bredr.c
@@ -552,7 +552,7 @@ static int cmd_br(const struct shell *shell, size_t argc, char **argv)
 {
 	if (argc == 1) {
 		shell_help_print(shell);
-		/* shell_cmd_precheck returns 1 when help is printed */
+		/* shell returns 1 when help is printed */
 		return 1;
 	}
 

--- a/subsys/bluetooth/shell/bredr.c
+++ b/subsys/bluetooth/shell/bredr.c
@@ -200,7 +200,7 @@ static int cmd_discovery(const struct shell *shell, size_t argc, char *argv[])
 
 		shell_print(shell, "Discovery stopped");
 	} else {
-		shell_help_print(shell);
+		shell_help(shell);
 	}
 
 	return 0;
@@ -296,7 +296,7 @@ static int cmd_discoverable(const struct shell *shell,
 	} else if (!strcmp(action, "off")) {
 		err = bt_br_set_discoverable(false);
 	} else {
-		shell_help_print(shell);
+		shell_help(shell);
 		return 0;
 	}
 
@@ -324,7 +324,7 @@ static int cmd_connectable(const struct shell *shell,
 	} else if (!strcmp(action, "off")) {
 		err = bt_br_set_connectable(false);
 	} else {
-		shell_help_print(shell);
+		shell_help(shell);
 		return 0;
 	}
 
@@ -514,7 +514,7 @@ static int cmd_sdp_find_record(const struct shell *shell,
 	} else if (!strcmp(action, "A2SRC")) {
 		discov = discov_a2src;
 	} else {
-		shell_help_print(shell);
+		shell_help(shell);
 		return 0;
 	}
 
@@ -551,7 +551,7 @@ SHELL_CREATE_STATIC_SUBCMD_SET(br_cmds) {
 static int cmd_br(const struct shell *shell, size_t argc, char **argv)
 {
 	if (argc == 1) {
-		shell_help_print(shell);
+		shell_help(shell);
 		/* shell returns 1 when help is printed */
 		return 1;
 	}

--- a/subsys/bluetooth/shell/bredr.c
+++ b/subsys/bluetooth/shell/bredr.c
@@ -200,7 +200,7 @@ static int cmd_discovery(const struct shell *shell, size_t argc, char *argv[])
 
 		shell_print(shell, "Discovery stopped");
 	} else {
-		shell_help_print(shell, NULL, 0);
+		shell_help_print(shell);
 	}
 
 	return 0;
@@ -296,7 +296,7 @@ static int cmd_discoverable(const struct shell *shell,
 	} else if (!strcmp(action, "off")) {
 		err = bt_br_set_discoverable(false);
 	} else {
-		shell_help_print(shell, NULL, 0);
+		shell_help_print(shell);
 		return 0;
 	}
 
@@ -324,7 +324,7 @@ static int cmd_connectable(const struct shell *shell,
 	} else if (!strcmp(action, "off")) {
 		err = bt_br_set_connectable(false);
 	} else {
-		shell_help_print(shell, NULL, 0);
+		shell_help_print(shell);
 		return 0;
 	}
 
@@ -514,7 +514,7 @@ static int cmd_sdp_find_record(const struct shell *shell,
 	} else if (!strcmp(action, "A2SRC")) {
 		discov = discov_a2src;
 	} else {
-		shell_help_print(shell, NULL, 0);
+		shell_help_print(shell);
 		return 0;
 	}
 
@@ -551,7 +551,7 @@ SHELL_CREATE_STATIC_SUBCMD_SET(br_cmds) {
 static int cmd_br(const struct shell *shell, size_t argc, char **argv)
 {
 	if (argc == 1) {
-		shell_help_print(shell, NULL, 0);
+		shell_help_print(shell);
 		/* shell_cmd_precheck returns 1 when help is printed */
 		return 1;
 	}

--- a/subsys/bluetooth/shell/bt.c
+++ b/subsys/bluetooth/shell/bt.c
@@ -614,7 +614,7 @@ static int cmd_scan(const struct shell *shell, size_t argc, char *argv[])
 			dups = BT_HCI_LE_SCAN_FILTER_DUP_ENABLE;
 		} else {
 			shell_help_print(shell);
-			/* shell_cmd_precheck returns 1 when help is printed */
+			/* shell returns 1 when help is printed */
 			return 1;
 		}
 	}
@@ -628,7 +628,7 @@ static int cmd_scan(const struct shell *shell, size_t argc, char *argv[])
 		return cmd_passive_scan_on(shell, dups);
 	} else {
 		shell_help_print(shell);
-		/* shell_cmd_precheck returns 1 when help is printed */
+		/* shell returns 1 when help is printed */
 		return 1;
 	}
 
@@ -747,7 +747,7 @@ static int cmd_disconnect(const struct shell *shell, size_t argc, char *argv[])
 
 		if (argc < 3) {
 			shell_help_print(shell);
-			/* shell_cmd_precheck returns 1 when help is printed */
+			/* shell returns 1 when help is printed */
 			return 1;
 		}
 
@@ -796,7 +796,7 @@ static int cmd_auto_conn(const struct shell *shell, size_t argc, char *argv[])
 		return bt_le_set_auto_conn(&addr, NULL);
 	} else {
 		shell_help_print(shell);
-		/* shell_cmd_precheck returns 1 when help is printed */
+		/* shell returns 1 when help is printed */
 		return 1;
 	}
 
@@ -823,7 +823,7 @@ static int cmd_directed_adv(const struct shell *shell,
 
 	if (strcmp(argv[3], "low")) {
 		shell_help_print(shell);
-		/* shell_cmd_precheck returns 1 when help is printed */
+		/* shell returns 1 when help is printed */
 		return 1;
 	}
 
@@ -1015,7 +1015,7 @@ static int cmd_bondable(const struct shell *shell, size_t argc, char *argv[])
 		bt_set_bondable(false);
 	} else {
 		shell_help_print(shell);
-		/* shell_cmd_precheck returns 1 when help is printed */
+		/* shell returns 1 when help is printed */
 		return 1;
 	}
 
@@ -1209,7 +1209,7 @@ static int cmd_auth(const struct shell *shell, size_t argc, char *argv[])
 		bt_conn_auth_cb_register(NULL);
 	} else {
 		shell_help_print(shell);
-		/* shell_cmd_precheck returns 1 when help is printed */
+		/* shell returns 1 when help is printed */
 		return 1;
 	}
 
@@ -1390,7 +1390,7 @@ static int cmd_bt(const struct shell *shell, size_t argc, char **argv)
 {
 	if (argc == 1) {
 		shell_help_print(shell);
-		/* shell_cmd_precheck returns 1 when help is printed */
+		/* shell returns 1 when help is printed */
 		return 1;
 	}
 

--- a/subsys/bluetooth/shell/bt.c
+++ b/subsys/bluetooth/shell/bt.c
@@ -613,7 +613,7 @@ static int cmd_scan(const struct shell *shell, size_t argc, char *argv[])
 		} else if (!strcmp(dup_filter, "nodups")) {
 			dups = BT_HCI_LE_SCAN_FILTER_DUP_ENABLE;
 		} else {
-			shell_help_print(shell);
+			shell_help(shell);
 			/* shell returns 1 when help is printed */
 			return 1;
 		}
@@ -627,7 +627,7 @@ static int cmd_scan(const struct shell *shell, size_t argc, char *argv[])
 	} else if (!strcmp(action, "passive")) {
 		return cmd_passive_scan_on(shell, dups);
 	} else {
-		shell_help_print(shell);
+		shell_help(shell);
 		/* shell returns 1 when help is printed */
 		return 1;
 	}
@@ -702,7 +702,7 @@ static int cmd_advertise(const struct shell *shell, size_t argc, char *argv[])
 	return 0;
 
 fail:
-	shell_help_print(shell);
+	shell_help(shell);
 	return -ENOEXEC;
 }
 
@@ -746,7 +746,7 @@ static int cmd_disconnect(const struct shell *shell, size_t argc, char *argv[])
 		bt_addr_le_t addr;
 
 		if (argc < 3) {
-			shell_help_print(shell);
+			shell_help(shell);
 			/* shell returns 1 when help is printed */
 			return 1;
 		}
@@ -795,7 +795,7 @@ static int cmd_auto_conn(const struct shell *shell, size_t argc, char *argv[])
 	} else if (!strcmp(argv[3], "off")) {
 		return bt_le_set_auto_conn(&addr, NULL);
 	} else {
-		shell_help_print(shell);
+		shell_help(shell);
 		/* shell returns 1 when help is printed */
 		return 1;
 	}
@@ -822,7 +822,7 @@ static int cmd_directed_adv(const struct shell *shell,
 	}
 
 	if (strcmp(argv[3], "low")) {
-		shell_help_print(shell);
+		shell_help(shell);
 		/* shell returns 1 when help is printed */
 		return 1;
 	}
@@ -1014,7 +1014,7 @@ static int cmd_bondable(const struct shell *shell, size_t argc, char *argv[])
 	} else if (!strcmp(bondable, "off")) {
 		bt_set_bondable(false);
 	} else {
-		shell_help_print(shell);
+		shell_help(shell);
 		/* shell returns 1 when help is printed */
 		return 1;
 	}
@@ -1208,7 +1208,7 @@ static int cmd_auth(const struct shell *shell, size_t argc, char *argv[])
 	} else if (!strcmp(argv[1], "none")) {
 		bt_conn_auth_cb_register(NULL);
 	} else {
-		shell_help_print(shell);
+		shell_help(shell);
 		/* shell returns 1 when help is printed */
 		return 1;
 	}
@@ -1389,7 +1389,7 @@ SHELL_CREATE_STATIC_SUBCMD_SET(bt_cmds) {
 static int cmd_bt(const struct shell *shell, size_t argc, char **argv)
 {
 	if (argc == 1) {
-		shell_help_print(shell);
+		shell_help(shell);
 		/* shell returns 1 when help is printed */
 		return 1;
 	}

--- a/subsys/bluetooth/shell/bt.c
+++ b/subsys/bluetooth/shell/bt.c
@@ -613,7 +613,7 @@ static int cmd_scan(const struct shell *shell, size_t argc, char *argv[])
 		} else if (!strcmp(dup_filter, "nodups")) {
 			dups = BT_HCI_LE_SCAN_FILTER_DUP_ENABLE;
 		} else {
-			shell_help_print(shell, NULL, 0);
+			shell_help_print(shell);
 			/* shell_cmd_precheck returns 1 when help is printed */
 			return 1;
 		}
@@ -627,7 +627,7 @@ static int cmd_scan(const struct shell *shell, size_t argc, char *argv[])
 	} else if (!strcmp(action, "passive")) {
 		return cmd_passive_scan_on(shell, dups);
 	} else {
-		shell_help_print(shell, NULL, 0);
+		shell_help_print(shell);
 		/* shell_cmd_precheck returns 1 when help is printed */
 		return 1;
 	}
@@ -702,7 +702,7 @@ static int cmd_advertise(const struct shell *shell, size_t argc, char *argv[])
 	return 0;
 
 fail:
-	shell_help_print(shell, NULL, 0);
+	shell_help_print(shell);
 	return -ENOEXEC;
 }
 
@@ -746,7 +746,7 @@ static int cmd_disconnect(const struct shell *shell, size_t argc, char *argv[])
 		bt_addr_le_t addr;
 
 		if (argc < 3) {
-			shell_help_print(shell, NULL, 0);
+			shell_help_print(shell);
 			/* shell_cmd_precheck returns 1 when help is printed */
 			return 1;
 		}
@@ -795,7 +795,7 @@ static int cmd_auto_conn(const struct shell *shell, size_t argc, char *argv[])
 	} else if (!strcmp(argv[3], "off")) {
 		return bt_le_set_auto_conn(&addr, NULL);
 	} else {
-		shell_help_print(shell, NULL, 0);
+		shell_help_print(shell);
 		/* shell_cmd_precheck returns 1 when help is printed */
 		return 1;
 	}
@@ -822,7 +822,7 @@ static int cmd_directed_adv(const struct shell *shell,
 	}
 
 	if (strcmp(argv[3], "low")) {
-		shell_help_print(shell, NULL, 0);
+		shell_help_print(shell);
 		/* shell_cmd_precheck returns 1 when help is printed */
 		return 1;
 	}
@@ -1014,7 +1014,7 @@ static int cmd_bondable(const struct shell *shell, size_t argc, char *argv[])
 	} else if (!strcmp(bondable, "off")) {
 		bt_set_bondable(false);
 	} else {
-		shell_help_print(shell, NULL, 0);
+		shell_help_print(shell);
 		/* shell_cmd_precheck returns 1 when help is printed */
 		return 1;
 	}
@@ -1208,7 +1208,7 @@ static int cmd_auth(const struct shell *shell, size_t argc, char *argv[])
 	} else if (!strcmp(argv[1], "none")) {
 		bt_conn_auth_cb_register(NULL);
 	} else {
-		shell_help_print(shell, NULL, 0);
+		shell_help_print(shell);
 		/* shell_cmd_precheck returns 1 when help is printed */
 		return 1;
 	}
@@ -1389,7 +1389,7 @@ SHELL_CREATE_STATIC_SUBCMD_SET(bt_cmds) {
 static int cmd_bt(const struct shell *shell, size_t argc, char **argv)
 {
 	if (argc == 1) {
-		shell_help_print(shell, NULL, 0);
+		shell_help_print(shell);
 		/* shell_cmd_precheck returns 1 when help is printed */
 		return 1;
 	}

--- a/subsys/bluetooth/shell/gatt.c
+++ b/subsys/bluetooth/shell/gatt.c
@@ -740,7 +740,7 @@ static int cmd_metrics(const struct shell *shell, size_t argc, char *argv[])
 		err = bt_gatt_service_unregister(&met_svc);
 	} else {
 		shell_error(shell, "Incorrect value: %s", argv[1]);
-		shell_help_print(shell, NULL, 0);
+		shell_help_print(shell);
 		return -ENOEXEC;
 	}
 
@@ -796,7 +796,7 @@ SHELL_CREATE_STATIC_SUBCMD_SET(gatt_cmds) {
 static int cmd_gatt(const struct shell *shell, size_t argc, char **argv)
 {
 	if (argc == 1) {
-		shell_help_print(shell, NULL, 0);
+		shell_help_print(shell);
 		/* shell_cmd_precheck returns 1 when help is printed */
 		return 1;
 	}

--- a/subsys/bluetooth/shell/gatt.c
+++ b/subsys/bluetooth/shell/gatt.c
@@ -740,7 +740,7 @@ static int cmd_metrics(const struct shell *shell, size_t argc, char *argv[])
 		err = bt_gatt_service_unregister(&met_svc);
 	} else {
 		shell_error(shell, "Incorrect value: %s", argv[1]);
-		shell_help_print(shell);
+		shell_help(shell);
 		return -ENOEXEC;
 	}
 
@@ -796,7 +796,7 @@ SHELL_CREATE_STATIC_SUBCMD_SET(gatt_cmds) {
 static int cmd_gatt(const struct shell *shell, size_t argc, char **argv)
 {
 	if (argc == 1) {
-		shell_help_print(shell);
+		shell_help(shell);
 		/* shell returns 1 when help is printed */
 		return 1;
 	}

--- a/subsys/bluetooth/shell/gatt.c
+++ b/subsys/bluetooth/shell/gatt.c
@@ -797,7 +797,7 @@ static int cmd_gatt(const struct shell *shell, size_t argc, char **argv)
 {
 	if (argc == 1) {
 		shell_help_print(shell);
-		/* shell_cmd_precheck returns 1 when help is printed */
+		/* shell returns 1 when help is printed */
 		return 1;
 	}
 

--- a/subsys/bluetooth/shell/l2cap.c
+++ b/subsys/bluetooth/shell/l2cap.c
@@ -417,7 +417,7 @@ static int cmd_l2cap(const struct shell *shell, size_t argc, char **argv)
 {
 	if (argc == 1) {
 		shell_help_print(shell);
-		/* shell_cmd_precheck returns 1 when help is printed */
+		/* shell returns 1 when help is printed */
 		return 1;
 	}
 

--- a/subsys/bluetooth/shell/l2cap.c
+++ b/subsys/bluetooth/shell/l2cap.c
@@ -354,7 +354,7 @@ static int cmd_metrics(const struct shell *shell, size_t argc, char *argv[])
 	} else if (!strcmp(action, "off")) {
 		l2cap_ops.recv = l2cap_recv;
 	} else {
-		shell_help_print(shell);
+		shell_help(shell);
 		return 0;
 	}
 
@@ -416,7 +416,7 @@ SHELL_CREATE_STATIC_SUBCMD_SET(l2cap_cmds) {
 static int cmd_l2cap(const struct shell *shell, size_t argc, char **argv)
 {
 	if (argc == 1) {
-		shell_help_print(shell);
+		shell_help(shell);
 		/* shell returns 1 when help is printed */
 		return 1;
 	}

--- a/subsys/bluetooth/shell/l2cap.c
+++ b/subsys/bluetooth/shell/l2cap.c
@@ -354,7 +354,7 @@ static int cmd_metrics(const struct shell *shell, size_t argc, char *argv[])
 	} else if (!strcmp(action, "off")) {
 		l2cap_ops.recv = l2cap_recv;
 	} else {
-		shell_help_print(shell, NULL, 0);
+		shell_help_print(shell);
 		return 0;
 	}
 
@@ -416,7 +416,7 @@ SHELL_CREATE_STATIC_SUBCMD_SET(l2cap_cmds) {
 static int cmd_l2cap(const struct shell *shell, size_t argc, char **argv)
 {
 	if (argc == 1) {
-		shell_help_print(shell, NULL, 0);
+		shell_help_print(shell);
 		/* shell_cmd_precheck returns 1 when help is printed */
 		return 1;
 	}

--- a/subsys/bluetooth/shell/rfcomm.c
+++ b/subsys/bluetooth/shell/rfcomm.c
@@ -244,7 +244,7 @@ SHELL_CREATE_STATIC_SUBCMD_SET(rfcomm_cmds) {
 static int cmd_rfcomm(const struct shell *shell, size_t argc, char **argv)
 {
 	if (argc == 1) {
-		shell_help_print(shell);
+		shell_help(shell);
 		/* shell returns 1 when help is printed */
 		return 1;
 	}

--- a/subsys/bluetooth/shell/rfcomm.c
+++ b/subsys/bluetooth/shell/rfcomm.c
@@ -244,7 +244,7 @@ SHELL_CREATE_STATIC_SUBCMD_SET(rfcomm_cmds) {
 static int cmd_rfcomm(const struct shell *shell, size_t argc, char **argv)
 {
 	if (argc == 1) {
-		shell_help_print(shell, NULL, 0);
+		shell_help_print(shell);
 		/* shell_cmd_precheck returns 1 when help is printed */
 		return 1;
 	}

--- a/subsys/bluetooth/shell/rfcomm.c
+++ b/subsys/bluetooth/shell/rfcomm.c
@@ -245,7 +245,7 @@ static int cmd_rfcomm(const struct shell *shell, size_t argc, char **argv)
 {
 	if (argc == 1) {
 		shell_help_print(shell);
-		/* shell_cmd_precheck returns 1 when help is printed */
+		/* shell returns 1 when help is printed */
 		return 1;
 	}
 

--- a/subsys/bluetooth/shell/ticker.c
+++ b/subsys/bluetooth/shell/ticker.c
@@ -135,7 +135,7 @@ SHELL_CREATE_STATIC_SUBCMD_SET(ticker_cmds) {
 static int cmd_ticker(const struct shell *shell, size_t argc, char **argv)
 {
 	if (argc == 1) {
-		shell_help_print(shell, NULL, 0);
+		shell_help_print(shell);
 		/* shell_cmd_precheck returns 1 when help is printed */
 		return 1;
 	}

--- a/subsys/bluetooth/shell/ticker.c
+++ b/subsys/bluetooth/shell/ticker.c
@@ -135,7 +135,7 @@ SHELL_CREATE_STATIC_SUBCMD_SET(ticker_cmds) {
 static int cmd_ticker(const struct shell *shell, size_t argc, char **argv)
 {
 	if (argc == 1) {
-		shell_help_print(shell);
+		shell_help(shell);
 		/* shell returns 1 when help is printed */
 		return 1;
 	}

--- a/subsys/bluetooth/shell/ticker.c
+++ b/subsys/bluetooth/shell/ticker.c
@@ -136,7 +136,7 @@ static int cmd_ticker(const struct shell *shell, size_t argc, char **argv)
 {
 	if (argc == 1) {
 		shell_help_print(shell);
-		/* shell_cmd_precheck returns 1 when help is printed */
+		/* shell returns 1 when help is printed */
 		return 1;
 	}
 

--- a/subsys/fs/shell.c
+++ b/subsys/fs/shell.c
@@ -166,7 +166,7 @@ static int cmd_trunc(const struct shell *shell, size_t argc, char **argv)
 	int length;
 	int err;
 
-	err = shell_cmd_precheck(shell, (argc >= 2), NULL, 0);
+	err = shell_cmd_precheck(shell, (argc >= 2));
 	if (err) {
 		return err;
 	}
@@ -212,7 +212,7 @@ static int cmd_mkdir(const struct shell *shell, size_t argc, char **argv)
 	int err;
 	char path[MAX_PATH_LEN];
 
-	err = shell_cmd_precheck(shell, (argc == 2), NULL, 0);
+	err = shell_cmd_precheck(shell, (argc == 2));
 	if (err) {
 		return err;
 	}
@@ -234,7 +234,7 @@ static int cmd_rm(const struct shell *shell, size_t argc, char **argv)
 	int err;
 	char path[MAX_PATH_LEN];
 
-	err = shell_cmd_precheck(shell, (argc == 2), NULL, 0);
+	err = shell_cmd_precheck(shell, (argc == 2));
 	if (err) {
 		return err;
 	}
@@ -260,7 +260,7 @@ static int cmd_read(const struct shell *shell, size_t argc, char **argv)
 	off_t offset;
 	int err;
 
-	err = shell_cmd_precheck(shell, (argc >= 2), NULL, 0);
+	err = shell_cmd_precheck(shell, (argc >= 2));
 	if (err) {
 		return err;
 	}
@@ -356,7 +356,7 @@ static int cmd_write(const struct shell *shell, size_t argc, char **argv)
 	off_t offset = -1;
 	int err;
 
-	err = shell_cmd_precheck(shell, (argc >= 3), NULL, 0);
+	err = shell_cmd_precheck(shell, (argc >= 3));
 	if (err) {
 		return err;
 	}
@@ -439,7 +439,7 @@ static int cmd_mount_fat(const struct shell *shell, size_t argc, char **argv)
 	char *mntpt;
 	int res;
 
-	res = shell_cmd_precheck(shell, (argc == 2), NULL, 0);
+	res = shell_cmd_precheck(shell, (argc == 2));
 	if (res) {
 		return res;
 	}
@@ -473,7 +473,7 @@ static int cmd_mount_nffs(const struct shell *shell, size_t argc, char **argv)
 	char *mntpt;
 	int res;
 
-	res = shell_cmd_precheck(shell, (argc == 2), NULL, 0);
+	res = shell_cmd_precheck(shell, (argc == 2));
 	if (res) {
 		return res;
 	}

--- a/subsys/fs/shell.c
+++ b/subsys/fs/shell.c
@@ -166,11 +166,6 @@ static int cmd_trunc(const struct shell *shell, size_t argc, char **argv)
 	int length;
 	int err;
 
-	err = shell_cmd_precheck(shell, (argc >= 2));
-	if (err) {
-		return err;
-	}
-
 	if (argv[1][0] == '/') {
 		strncpy(path, argv[1], sizeof(path) - 1);
 		path[MAX_PATH_LEN - 1] = '\0';
@@ -212,11 +207,6 @@ static int cmd_mkdir(const struct shell *shell, size_t argc, char **argv)
 	int err;
 	char path[MAX_PATH_LEN];
 
-	err = shell_cmd_precheck(shell, (argc == 2));
-	if (err) {
-		return err;
-	}
-
 	create_abs_path(argv[1], path, sizeof(path));
 
 	err = fs_mkdir(path);
@@ -233,11 +223,6 @@ static int cmd_rm(const struct shell *shell, size_t argc, char **argv)
 {
 	int err;
 	char path[MAX_PATH_LEN];
-
-	err = shell_cmd_precheck(shell, (argc == 2));
-	if (err) {
-		return err;
-	}
 
 	create_abs_path(argv[1], path, sizeof(path));
 
@@ -259,11 +244,6 @@ static int cmd_read(const struct shell *shell, size_t argc, char **argv)
 	int count;
 	off_t offset;
 	int err;
-
-	err = shell_cmd_precheck(shell, (argc >= 2));
-	if (err) {
-		return err;
-	}
 
 	create_abs_path(argv[1], path, sizeof(path));
 
@@ -356,11 +336,6 @@ static int cmd_write(const struct shell *shell, size_t argc, char **argv)
 	off_t offset = -1;
 	int err;
 
-	err = shell_cmd_precheck(shell, (argc >= 3));
-	if (err) {
-		return err;
-	}
-
 	create_abs_path(argv[1], path, sizeof(path));
 
 	if (!strcmp(argv[2], "-o")) {
@@ -439,11 +414,6 @@ static int cmd_mount_fat(const struct shell *shell, size_t argc, char **argv)
 	char *mntpt;
 	int res;
 
-	res = shell_cmd_precheck(shell, (argc == 2));
-	if (res) {
-		return res;
-	}
-
 	mntpt = mntpt_prepare(argv[1]);
 	if (!mntpt) {
 		shell_fprintf(shell, SHELL_ERROR,
@@ -472,11 +442,6 @@ static int cmd_mount_nffs(const struct shell *shell, size_t argc, char **argv)
 	struct device *flash_dev;
 	char *mntpt;
 	int res;
-
-	res = shell_cmd_precheck(shell, (argc == 2));
-	if (res) {
-		return res;
-	}
 
 	mntpt = mntpt_prepare(argv[1]);
 	if (!mntpt) {
@@ -512,13 +477,15 @@ SHELL_CREATE_STATIC_SUBCMD_SET(sub_fs_mount)
 {
 
 #if defined(CONFIG_FAT_FILESYSTEM_ELM)
-	SHELL_CMD(fat, NULL,
-		  "Mount fatfs. fs mount fat <mount-point>", cmd_mount_fat),
+	SHELL_CMD_ARG(fat, NULL,
+		      "Mount fatfs. fs mount fat <mount-point>",
+		      cmd_mount_fat, 2, 0),
 #endif
 
 #if defined(CONFIG_FILE_SYSTEM_NFFS)
-	SHELL_CMD(nffs, NULL,
-		  "Mount nffs. fs mount nffs <mount-point>", cmd_mount_nffs),
+	SHELL_CMD_ARG(nffs, NULL,
+		      "Mount nffs. fs mount nffs <mount-point>",
+		      cmd_mount_nffs, 2, 0),
 #endif
 
 	SHELL_SUBCMD_SET_END
@@ -530,16 +497,16 @@ SHELL_CREATE_STATIC_SUBCMD_SET(sub_fs)
 	SHELL_CMD(cd, NULL,
 			"Change working directory", cmd_cd),
 	SHELL_CMD(ls, NULL, "List files in current directory", cmd_ls),
-	SHELL_CMD(mkdir, NULL, "Create directory", cmd_mkdir),
+	SHELL_CMD_ARG(mkdir, NULL, "Create directory", cmd_mkdir, 2, 0),
 #if defined(CONFIG_FILE_SYSTEM_NFFS) || defined(CONFIG_FAT_FILESYSTEM_ELM)
 	SHELL_CMD(mount, &sub_fs_mount,
 		  "<fs e.g: fat/nffs> <mount-point>", NULL),
 #endif
 	SHELL_CMD(pwd, NULL, "Print current working directory", cmd_pwd),
-	SHELL_CMD(read, NULL, "Read from file", cmd_read),
-	SHELL_CMD(rm, NULL, "Remove file", cmd_rm),
-	SHELL_CMD(trunc, NULL, "Truncate file", cmd_trunc),
-	SHELL_CMD(write, NULL, "Write file", cmd_write),
+	SHELL_CMD_ARG(read, NULL, "Read from file", cmd_read, 2, 255),
+	SHELL_CMD_ARG(rm, NULL, "Remove file", cmd_rm, 2, 0),
+	SHELL_CMD_ARG(trunc, NULL, "Truncate file", cmd_trunc, 2, 255),
+	SHELL_CMD_ARG(write, NULL, "Write file", cmd_write, 3, 255),
 	SHELL_SUBCMD_SET_END
 };
 

--- a/subsys/logging/log_cmds.c
+++ b/subsys/logging/log_cmds.c
@@ -441,7 +441,7 @@ SHELL_CREATE_STATIC_SUBCMD_SET(sub_log_stat)
 
 static int cmd_log(const struct shell *shell, size_t argc, char **argv)
 {
-	if ((argc == 1) || shell_help_requested(shell)) {
+	if (argc == 1)  {
 		shell_help_print(shell);
 		return 0;
 	}

--- a/subsys/logging/log_cmds.c
+++ b/subsys/logging/log_cmds.c
@@ -57,8 +57,7 @@ static bool shell_state_precheck(const struct shell *shell)
 {
 	if (shell->log_backend->control_block->state
 				== SHELL_LOG_BACKEND_UNINIT) {
-		shell_fprintf(shell, SHELL_ERROR,
-			      "Shell log backend not initialized.\r\n");
+		shell_error(shell, "Shell log backend not initialized.");
 		return false;
 	}
 
@@ -82,8 +81,7 @@ static int shell_backend_cmd_execute(const struct shell *shell,
 	if (backend) {
 		func(shell, backend, argc, argv);
 	} else {
-		shell_fprintf(shell, SHELL_ERROR,
-			      "Invalid backend: %s\r\n", name);
+		shell_error(shell, "Invalid backend: %s", name);
 		return -ENOEXEC;
 	}
 	return 0;
@@ -101,7 +99,7 @@ static int log_status(const struct shell *shell,
 
 
 	if (!log_backend_is_active(backend)) {
-		shell_fprintf(shell, SHELL_ERROR, "Logs are halted!\r\n");
+		shell_warn(shell, "Logs are halted!");
 	}
 
 	shell_fprintf(shell, SHELL_NORMAL, "%-40s | current | built-in \r\n",
@@ -168,7 +166,7 @@ static void filters_set(const struct shell *shell,
 	int cnt = all ? log_sources_count() : argc;
 
 	if (!backend->cb->active) {
-		shell_fprintf(shell, SHELL_WARNING, "Backend not active.\r\n");
+		shell_warn(shell, "Backend not active.");
 	}
 
 	for (i = 0; i < cnt; i++) {
@@ -185,13 +183,11 @@ static void filters_set(const struct shell *shell,
 					log_source_name_get(
 						CONFIG_LOG_DOMAIN_ID, i) :
 					argv[i];
-				shell_fprintf(shell, SHELL_WARNING,
-					      "%s: level set to %s.\r\n",
-					      name, severity_lvls[set_lvl]);
+				shell_warn(shell, "%s: level set to %s.",
+					   name, severity_lvls[set_lvl]);
 			}
 		} else {
-			shell_fprintf(shell, SHELL_ERROR,
-				      "%s: unknown source name.\r\n", argv[i]);
+			shell_error(shell, "%s: unknown source name.", argv[i]);
 		}
 	}
 }
@@ -214,17 +210,11 @@ static int log_enable(const struct shell *shell,
 		      char **argv)
 {
 	int severity_level;
-	int err = shell_cmd_precheck(shell, (argc > 1));
-
-	if (err) {
-		return err;
-	}
 
 	severity_level = severity_level_get(argv[1]);
 
 	if (severity_level < 0) {
-		shell_fprintf(shell, SHELL_ERROR, "Invalid severity: %s\r\n",
-			      argv[1]);
+		shell_error(shell, "Invalid severity: %s", argv[1]);
 		return -ENOEXEC;
 	}
 
@@ -254,12 +244,6 @@ static int log_disable(const struct shell *shell,
 		       size_t argc,
 		       char **argv)
 {
-	int err = shell_cmd_precheck(shell, (argc > 1));
-
-	if (err) {
-		return err;
-	}
-
 	filters_set(shell, backend, argc - 1, &argv[1], LOG_LEVEL_NONE);
 	return 0;
 }
@@ -361,11 +345,6 @@ static int cmd_log_backends_list(const struct shell *shell,
 				 size_t argc, char **argv)
 {
 	int backend_count;
-	int err = shell_cmd_precheck(shell, (argc == 1));
-
-	if (err) {
-		return err;
-	}
 
 	backend_count = log_backend_count_get();
 
@@ -387,15 +366,15 @@ static int cmd_log_backends_list(const struct shell *shell,
 
 SHELL_CREATE_STATIC_SUBCMD_SET(sub_log_backend)
 {
-	SHELL_CMD(disable, &dsub_module_name,
+	SHELL_CMD_ARG(disable, &dsub_module_name,
 		  "'log disable <module_0> .. <module_n>' disables logs in "
 		  "specified modules (all if no modules specified).",
-		  cmd_log_backend_disable),
-	SHELL_CMD(enable, &dsub_severity_lvl,
+		  cmd_log_backend_disable, 2, 255),
+	SHELL_CMD_ARG(enable, &dsub_severity_lvl,
 		  "'log enable <level> <module_0> ...  <module_n>' enables logs"
 		  " up to given level in specified modules (all if no modules "
 		  "specified).",
-		  cmd_log_backend_enable),
+		  cmd_log_backend_enable, 2, 255),
 	SHELL_CMD(go, NULL, "Resume logging", cmd_log_backend_go),
 	SHELL_CMD(halt, NULL, "Halt logging", cmd_log_backend_halt),
 	SHELL_CMD(status, NULL, "Logger status", cmd_log_backend_status),
@@ -423,33 +402,21 @@ SHELL_CREATE_STATIC_SUBCMD_SET(sub_log_stat)
 {
 	SHELL_CMD(backend, &dsub_backend_name_dynamic,
 			"Logger backends commands.", NULL),
-	SHELL_CMD(disable, &dsub_module_name,
+	SHELL_CMD_ARG(disable, &dsub_module_name,
 	"'log disable <module_0> .. <module_n>' disables logs in specified "
 	"modules (all if no modules specified).",
-	cmd_log_self_disable),
-	SHELL_CMD(enable, &dsub_severity_lvl,
+	cmd_log_self_disable, 2, 255),
+	SHELL_CMD_ARG(enable, &dsub_severity_lvl,
 	"'log enable <level> <module_0> ...  <module_n>' enables logs up to"
 	" given level in specified modules (all if no modules specified).",
-	cmd_log_self_enable),
+	cmd_log_self_enable, 2, 255),
 	SHELL_CMD(go, NULL, "Resume logging", cmd_log_self_go),
 	SHELL_CMD(halt, NULL, "Halt logging", cmd_log_self_halt),
-	SHELL_CMD(list_backends, NULL, "Lists logger backends.",
-		  cmd_log_backends_list),
+	SHELL_CMD_ARG(list_backends, NULL, "Lists logger backends.",
+		      cmd_log_backends_list, 1, 0),
 	SHELL_CMD(status, NULL, "Logger status", cmd_log_self_status),
 	SHELL_SUBCMD_SET_END
 };
 
-static int cmd_log(const struct shell *shell, size_t argc, char **argv)
-{
-	if (argc == 1)  {
-		shell_help_print(shell);
-		return 0;
-	}
-
-	shell_fprintf(shell, SHELL_ERROR, "%s:%s%s\r\n",
-		      argv[0], " unknown parameter: ", argv[1]);
-	return -ENOEXEC;
-}
-
 SHELL_CMD_REGISTER(log, &sub_log_stat, "Commands for controlling logger",
-		   cmd_log);
+		   NULL);

--- a/subsys/logging/log_cmds.c
+++ b/subsys/logging/log_cmds.c
@@ -214,7 +214,7 @@ static int log_enable(const struct shell *shell,
 		      char **argv)
 {
 	int severity_level;
-	int err = shell_cmd_precheck(shell, (argc > 1), NULL, 0);
+	int err = shell_cmd_precheck(shell, (argc > 1));
 
 	if (err) {
 		return err;
@@ -254,7 +254,7 @@ static int log_disable(const struct shell *shell,
 		       size_t argc,
 		       char **argv)
 {
-	int err = shell_cmd_precheck(shell, (argc > 1), NULL, 0);
+	int err = shell_cmd_precheck(shell, (argc > 1));
 
 	if (err) {
 		return err;
@@ -361,7 +361,7 @@ static int cmd_log_backends_list(const struct shell *shell,
 				 size_t argc, char **argv)
 {
 	int backend_count;
-	int err = shell_cmd_precheck(shell, (argc == 1), NULL, 0);
+	int err = shell_cmd_precheck(shell, (argc == 1));
 
 	if (err) {
 		return err;
@@ -442,7 +442,7 @@ SHELL_CREATE_STATIC_SUBCMD_SET(sub_log_stat)
 static int cmd_log(const struct shell *shell, size_t argc, char **argv)
 {
 	if ((argc == 1) || shell_help_requested(shell)) {
-		shell_help_print(shell, NULL, 0);
+		shell_help_print(shell);
 		return 0;
 	}
 

--- a/subsys/net/ip/net_shell.c
+++ b/subsys/net/ip/net_shell.c
@@ -1153,7 +1153,7 @@ static int cmd_net_allocs(const struct shell *shell, size_t argc, char *argv[])
 	ARG_UNUSED(argv);
 
 	if (shell_help_requested(shell)) {
-		shell_help_print(shell, NULL, 0);
+		shell_help_print(shell);
 		return -ENOEXEC;
 	}
 
@@ -1381,7 +1381,7 @@ static int cmd_net_app(const struct shell *shell, size_t argc, char *argv[])
 	ARG_UNUSED(argv);
 
 	if (shell_help_requested(shell)) {
-		shell_help_print(shell, NULL, 0);
+		shell_help_print(shell);
 		return -ENOEXEC;
 	}
 
@@ -1459,7 +1459,7 @@ static int cmd_net_arp(const struct shell *shell, size_t argc, char *argv[])
 	ARG_UNUSED(argc);
 
 	if (shell_help_requested(shell)) {
-		shell_help_print(shell, NULL, 0);
+		shell_help_print(shell);
 		return -ENOEXEC;
 	}
 
@@ -1489,7 +1489,7 @@ static int cmd_net_arp_flush(const struct shell *shell, size_t argc,
 	ARG_UNUSED(argv);
 
 	if (shell_help_requested(shell)) {
-		shell_help_print(shell, NULL, 0);
+		shell_help_print(shell);
 		return -ENOEXEC;
 	}
 
@@ -1512,7 +1512,7 @@ static int cmd_net_conn(const struct shell *shell, size_t argc, char *argv[])
 	ARG_UNUSED(argv);
 
 	if (shell_help_requested(shell)) {
-		shell_help_print(shell, NULL, 0);
+		shell_help_print(shell);
 		return -ENOEXEC;
 	}
 
@@ -1694,7 +1694,7 @@ static int cmd_net_dns_cancel(const struct shell *shell, size_t argc,
 	ARG_UNUSED(argv);
 
 	if (shell_help_requested(shell)) {
-		shell_help_print(shell, NULL, 0);
+		shell_help_print(shell);
 		return -ENOEXEC;
 	}
 
@@ -1732,7 +1732,7 @@ static int cmd_net_dns_query(const struct shell *shell, size_t argc,
 			     char *argv[])
 {
 	if (shell_help_requested(shell)) {
-		shell_help_print(shell, NULL, 0);
+		shell_help_print(shell);
 		return -ENOEXEC;
 	}
 
@@ -1793,7 +1793,7 @@ static int cmd_net_dns(const struct shell *shell, size_t argc, char *argv[])
 #endif
 
 	if (shell_help_requested(shell)) {
-		shell_help_print(shell, NULL, 0);
+		shell_help_print(shell);
 		return -ENOEXEC;
 	}
 
@@ -2339,7 +2339,7 @@ static int cmd_net_gptp_port(const struct shell *shell, size_t argc,
 #endif
 
 	if (shell_help_requested(shell)) {
-		shell_help_print(shell, NULL, 0);
+		shell_help_print(shell);
 		return -ENOEXEC;
 	}
 
@@ -2376,7 +2376,7 @@ static int cmd_net_gptp(const struct shell *shell, size_t argc, char *argv[])
 #endif
 
 	if (shell_help_requested(shell)) {
-		shell_help_print(shell, NULL, 0);
+		shell_help_print(shell);
 		return -ENOEXEC;
 	}
 
@@ -2498,7 +2498,7 @@ static int cmd_net_http_monitor(const struct shell *shell, size_t argc,
 				char *argv[])
 {
 	if (shell_help_requested(shell)) {
-		shell_help_print(shell, NULL, 0);
+		shell_help_print(shell);
 		return -ENOEXEC;
 	}
 
@@ -2525,7 +2525,7 @@ static int cmd_net_http(const struct shell *shell, size_t argc, char *argv[])
 #endif
 
 	if (shell_help_requested(shell)) {
-		shell_help_print(shell, NULL, 0);
+		shell_help_print(shell);
 		return -ENOEXEC;
 	}
 
@@ -2581,7 +2581,7 @@ static int cmd_net_iface_up(const struct shell *shell, size_t argc,
 	int idx, ret;
 
 	if (shell_help_requested(shell)) {
-		shell_help_print(shell, NULL, 0);
+		shell_help_print(shell);
 		return -ENOEXEC;
 	}
 
@@ -2619,7 +2619,7 @@ static int cmd_net_iface_down(const struct shell *shell, size_t argc,
 	int idx, ret;
 
 	if (shell_help_requested(shell)) {
-		shell_help_print(shell, NULL, 0);
+		shell_help_print(shell);
 		return -ENOEXEC;
 	}
 
@@ -2722,7 +2722,7 @@ static int cmd_net_ipv6(const struct shell *shell, size_t argc, char *argv[])
 	struct net_shell_user_data user_data;
 #endif
 	if (shell_help_requested(shell)) {
-		shell_help_print(shell, NULL, 0);
+		shell_help_print(shell);
 		return -ENOEXEC;
 	}
 
@@ -2793,7 +2793,7 @@ static int cmd_net_iface(const struct shell *shell, size_t argc, char *argv[])
 	int idx;
 
 	if (shell_help_requested(shell)) {
-		shell_help_print(shell, NULL, 0);
+		shell_help_print(shell);
 		return -ENOEXEC;
 	}
 
@@ -2913,7 +2913,7 @@ static int cmd_net_mem(const struct shell *shell, size_t argc, char *argv[])
 	ARG_UNUSED(argv);
 
 	if (shell_help_requested(shell)) {
-		shell_help_print(shell, NULL, 0);
+		shell_help_print(shell);
 		return -ENOEXEC;
 	}
 
@@ -2977,7 +2977,7 @@ static int cmd_net_nbr_rm(const struct shell *shell, size_t argc,
 #endif
 
 	if (shell_help_requested(shell)) {
-		shell_help_print(shell, NULL, 0);
+		shell_help_print(shell);
 		return -ENOEXEC;
 	}
 
@@ -3083,7 +3083,7 @@ static int cmd_net_nbr(const struct shell *shell, size_t argc, char *argv[])
 	ARG_UNUSED(argv);
 
 	if (shell_help_requested(shell)) {
-		shell_help_print(shell, NULL, 0);
+		shell_help_print(shell);
 		return -ENOEXEC;
 	}
 
@@ -3248,7 +3248,7 @@ static int cmd_net_ping(const struct shell *shell, size_t argc, char *argv[])
 	ARG_UNUSED(argc);
 
 	if (shell_help_requested(shell)) {
-		shell_help_print(shell, NULL, 0);
+		shell_help_print(shell);
 		return -ENOEXEC;
 	}
 
@@ -3307,7 +3307,7 @@ static int cmd_net_route(const struct shell *shell, size_t argc, char *argv[])
 	ARG_UNUSED(argv);
 
 	if (shell_help_requested(shell)) {
-		shell_help_print(shell, NULL, 0);
+		shell_help_print(shell);
 		return -ENOEXEC;
 	}
 
@@ -3391,7 +3391,7 @@ static int cmd_net_rpl(const struct shell *shell, size_t argc, char *argv[])
 	ARG_UNUSED(argv);
 
 	if (shell_help_requested(shell)) {
-		shell_help_print(shell, NULL, 0);
+		shell_help_print(shell);
 		return -ENOEXEC;
 	}
 
@@ -3552,7 +3552,7 @@ static int cmd_net_stacks(const struct shell *shell, size_t argc,
 	ARG_UNUSED(argv);
 
 	if (shell_help_requested(shell)) {
-		shell_help_print(shell, NULL, 0);
+		shell_help_print(shell);
 		return -ENOEXEC;
 	}
 
@@ -3632,7 +3632,7 @@ static int cmd_net_stats_all(const struct shell *shell, size_t argc,
 #endif
 
 	if (shell_help_requested(shell)) {
-		shell_help_print(shell, NULL, 0);
+		shell_help_print(shell);
 		return -ENOEXEC;
 	}
 
@@ -3665,7 +3665,7 @@ static int cmd_net_stats_iface(const struct shell *shell, size_t argc,
 #endif
 
 	if (shell_help_requested(shell)) {
-		shell_help_print(shell, NULL, 0);
+		shell_help_print(shell);
 		return -ENOEXEC;
 	}
 
@@ -3704,7 +3704,7 @@ static int cmd_net_stats_iface(const struct shell *shell, size_t argc,
 static int cmd_net_stats(const struct shell *shell, size_t argc, char *argv[])
 {
 	if (shell_help_requested(shell)) {
-		shell_help_print(shell, NULL, 0);
+		shell_help_print(shell);
 		return -ENOEXEC;
 	}
 
@@ -3941,7 +3941,7 @@ static int cmd_net_tcp_connect(const struct shell *shell, size_t argc,
 #endif
 
 	if (shell_help_requested(shell)) {
-		shell_help_print(shell, NULL, 0);
+		shell_help_print(shell);
 		return -ENOEXEC;
 	}
 
@@ -3989,7 +3989,7 @@ static int cmd_net_tcp_send(const struct shell *shell, size_t argc,
 #endif
 
 	if (shell_help_requested(shell)) {
-		shell_help_print(shell, NULL, 0);
+		shell_help_print(shell);
 		return -ENOEXEC;
 	}
 
@@ -4044,7 +4044,7 @@ static int cmd_net_tcp_close(const struct shell *shell, size_t argc,
 #endif
 
 	if (shell_help_requested(shell)) {
-		shell_help_print(shell, NULL, 0);
+		shell_help_print(shell);
 		return -ENOEXEC;
 	}
 
@@ -4076,7 +4076,7 @@ static int cmd_net_tcp(const struct shell *shell, size_t argc, char *argv[])
 	ARG_UNUSED(argv);
 
 	if (shell_help_requested(shell)) {
-		shell_help_print(shell, NULL, 0);
+		shell_help_print(shell);
 		return -ENOEXEC;
 	}
 
@@ -4153,7 +4153,7 @@ static int cmd_net_vlan(const struct shell *shell, size_t argc, char *argv[])
 #endif
 
 	if (shell_help_requested(shell)) {
-		shell_help_print(shell, NULL, 0);
+		shell_help_print(shell);
 		return -ENOEXEC;
 	}
 
@@ -4184,7 +4184,7 @@ static int cmd_net_vlan_add(const struct shell *shell, size_t argc,
 #endif
 
 	if (shell_help_requested(shell)) {
-		shell_help_print(shell, NULL, 0);
+		shell_help_print(shell);
 		return -ENOEXEC;
 	}
 
@@ -4261,7 +4261,7 @@ static int cmd_net_vlan_del(const struct shell *shell, size_t argc,
 #endif
 
 	if (shell_help_requested(shell)) {
-		shell_help_print(shell, NULL, 0);
+		shell_help_print(shell);
 		return -ENOEXEC;
 	}
 

--- a/subsys/net/ip/net_shell.c
+++ b/subsys/net/ip/net_shell.c
@@ -1152,11 +1152,6 @@ static int cmd_net_allocs(const struct shell *shell, size_t argc, char *argv[])
 	ARG_UNUSED(argc);
 	ARG_UNUSED(argv);
 
-	if (shell_help_requested(shell)) {
-		shell_help_print(shell);
-		return -ENOEXEC;
-	}
-
 #if CONFIG_NET_PKT_LOG_LEVEL >= LOG_LEVEL_DBG
 	user_data.shell = shell;
 
@@ -1380,11 +1375,6 @@ static int cmd_net_app(const struct shell *shell, size_t argc, char *argv[])
 	ARG_UNUSED(argc);
 	ARG_UNUSED(argv);
 
-	if (shell_help_requested(shell)) {
-		shell_help_print(shell);
-		return -ENOEXEC;
-	}
-
 #if CONFIG_NET_APP_LOG_LEVEL >= LOG_LEVEL_DBG
 	if (IS_ENABLED(CONFIG_NET_APP_SERVER)) {
 		user_data.shell = shell;
@@ -1458,11 +1448,6 @@ static int cmd_net_arp(const struct shell *shell, size_t argc, char *argv[])
 
 	ARG_UNUSED(argc);
 
-	if (shell_help_requested(shell)) {
-		shell_help_print(shell);
-		return -ENOEXEC;
-	}
-
 #if defined(CONFIG_NET_ARP)
 	if (!argv[arg]) {
 		/* ARP cache content */
@@ -1488,11 +1473,6 @@ static int cmd_net_arp_flush(const struct shell *shell, size_t argc,
 	ARG_UNUSED(argc);
 	ARG_UNUSED(argv);
 
-	if (shell_help_requested(shell)) {
-		shell_help_print(shell);
-		return -ENOEXEC;
-	}
-
 #if defined(CONFIG_NET_ARP)
 	PR("Flushing ARP cache.\n");
 	net_arp_clear_cache(NULL);
@@ -1510,11 +1490,6 @@ static int cmd_net_conn(const struct shell *shell, size_t argc, char *argv[])
 
 	ARG_UNUSED(argc);
 	ARG_UNUSED(argv);
-
-	if (shell_help_requested(shell)) {
-		shell_help_print(shell);
-		return -ENOEXEC;
-	}
 
 	PR("     Context   \tIface         Flags Local           \tRemote\n");
 
@@ -1693,11 +1668,6 @@ static int cmd_net_dns_cancel(const struct shell *shell, size_t argc,
 	ARG_UNUSED(argc);
 	ARG_UNUSED(argv);
 
-	if (shell_help_requested(shell)) {
-		shell_help_print(shell);
-		return -ENOEXEC;
-	}
-
 #if defined(CONFIG_DNS_RESOLVER)
 	ctx = dns_resolve_get_default();
 	if (!ctx) {
@@ -1731,10 +1701,6 @@ static int cmd_net_dns_cancel(const struct shell *shell, size_t argc,
 static int cmd_net_dns_query(const struct shell *shell, size_t argc,
 			     char *argv[])
 {
-	if (shell_help_requested(shell)) {
-		shell_help_print(shell);
-		return -ENOEXEC;
-	}
 
 #if defined(CONFIG_DNS_RESOLVER)
 #define DNS_TIMEOUT K_MSEC(2000) /* ms */
@@ -1791,11 +1757,6 @@ static int cmd_net_dns(const struct shell *shell, size_t argc, char *argv[])
 #if defined(CONFIG_DNS_RESOLVER)
 	struct dns_resolve_context *ctx;
 #endif
-
-	if (shell_help_requested(shell)) {
-		shell_help_print(shell);
-		return -ENOEXEC;
-	}
 
 #if defined(CONFIG_DNS_RESOLVER)
 	if (argv[1]) {
@@ -2338,11 +2299,6 @@ static int cmd_net_gptp_port(const struct shell *shell, size_t argc,
 	int port;
 #endif
 
-	if (shell_help_requested(shell)) {
-		shell_help_print(shell);
-		return -ENOEXEC;
-	}
-
 #if defined(CONFIG_NET_GPTP)
 	if (!argv[arg]) {
 		PR_WARNING("Port number must be given.\n");
@@ -2374,11 +2330,6 @@ static int cmd_net_gptp(const struct shell *shell, size_t argc, char *argv[])
 	int count = 0;
 	int arg = 1;
 #endif
-
-	if (shell_help_requested(shell)) {
-		shell_help_print(shell);
-		return -ENOEXEC;
-	}
 
 #if defined(CONFIG_NET_GPTP)
 	if (argv[arg]) {
@@ -2497,11 +2448,6 @@ static int http_monitor_count;
 static int cmd_net_http_monitor(const struct shell *shell, size_t argc,
 				char *argv[])
 {
-	if (shell_help_requested(shell)) {
-		shell_help_print(shell);
-		return -ENOEXEC;
-	}
-
 #if defined(CONFIG_NET_DEBUG_HTTP_CONN) && defined(CONFIG_HTTP_SERVER)
 	PR_INFO("Activating HTTP monitor. Type \"net http\" "
 		"to disable HTTP connection monitoring.\n");
@@ -2523,11 +2469,6 @@ static int cmd_net_http(const struct shell *shell, size_t argc, char *argv[])
 	struct net_shell_user_data user_data;
 	int arg = 2;
 #endif
-
-	if (shell_help_requested(shell)) {
-		shell_help_print(shell);
-		return -ENOEXEC;
-	}
 
 #if defined(CONFIG_NET_DEBUG_HTTP_CONN) && defined(CONFIG_HTTP_SERVER)
 	http_monitor_count = 0;
@@ -2580,11 +2521,6 @@ static int cmd_net_iface_up(const struct shell *shell, size_t argc,
 	struct net_if *iface;
 	int idx, ret;
 
-	if (shell_help_requested(shell)) {
-		shell_help_print(shell);
-		return -ENOEXEC;
-	}
-
 	idx = get_iface_idx(shell, argv[1]);
 	if (idx < 0) {
 		return -ENOEXEC;
@@ -2617,11 +2553,6 @@ static int cmd_net_iface_down(const struct shell *shell, size_t argc,
 {
 	struct net_if *iface;
 	int idx, ret;
-
-	if (shell_help_requested(shell)) {
-		shell_help_print(shell);
-		return -ENOEXEC;
-	}
 
 	idx = get_iface_idx(shell, argv[1]);
 	if (idx < 0) {
@@ -2721,10 +2652,6 @@ static int cmd_net_ipv6(const struct shell *shell, size_t argc, char *argv[])
 #if defined(CONFIG_NET_IPV6)
 	struct net_shell_user_data user_data;
 #endif
-	if (shell_help_requested(shell)) {
-		shell_help_print(shell);
-		return -ENOEXEC;
-	}
 
 	PR("IPv6 support                              : %s\n",
 	   IS_ENABLED(CONFIG_NET_IPV6) ?
@@ -2791,11 +2718,6 @@ static int cmd_net_iface(const struct shell *shell, size_t argc, char *argv[])
 	struct net_if *iface = NULL;
 	struct net_shell_user_data user_data;
 	int idx;
-
-	if (shell_help_requested(shell)) {
-		shell_help_print(shell);
-		return -ENOEXEC;
-	}
 
 	if (argv[1]) {
 		idx = get_iface_idx(shell, argv[1]);
@@ -2912,11 +2834,6 @@ static int cmd_net_mem(const struct shell *shell, size_t argc, char *argv[])
 	ARG_UNUSED(argc);
 	ARG_UNUSED(argv);
 
-	if (shell_help_requested(shell)) {
-		shell_help_print(shell);
-		return -ENOEXEC;
-	}
-
 	net_pkt_get_info(&rx, &tx, &rx_data, &tx_data);
 
 	PR("Fragment length %d bytes\n", CONFIG_NET_BUF_DATA_SIZE);
@@ -2975,11 +2892,6 @@ static int cmd_net_nbr_rm(const struct shell *shell, size_t argc,
 	struct in6_addr addr;
 	int ret;
 #endif
-
-	if (shell_help_requested(shell)) {
-		shell_help_print(shell);
-		return -ENOEXEC;
-	}
 
 #if defined(CONFIG_NET_IPV6)
 	if (!argv[1]) {
@@ -3081,11 +2993,6 @@ static int cmd_net_nbr(const struct shell *shell, size_t argc, char *argv[])
 
 	ARG_UNUSED(argc);
 	ARG_UNUSED(argv);
-
-	if (shell_help_requested(shell)) {
-		shell_help_print(shell);
-		return -ENOEXEC;
-	}
 
 #if defined(CONFIG_NET_IPV6)
 	user_data.shell = shell;
@@ -3247,11 +3154,6 @@ static int cmd_net_ping(const struct shell *shell, size_t argc, char *argv[])
 
 	ARG_UNUSED(argc);
 
-	if (shell_help_requested(shell)) {
-		shell_help_print(shell);
-		return -ENOEXEC;
-	}
-
 	host = argv[1];
 
 	if (!host) {
@@ -3305,11 +3207,6 @@ static int cmd_net_route(const struct shell *shell, size_t argc, char *argv[])
 
 	ARG_UNUSED(argc);
 	ARG_UNUSED(argv);
-
-	if (shell_help_requested(shell)) {
-		shell_help_print(shell);
-		return -ENOEXEC;
-	}
 
 #if defined(CONFIG_NET_ROUTE) || defined(CONFIG_NET_ROUTE_MCAST)
 	user_data.shell = shell;
@@ -3389,11 +3286,6 @@ static int cmd_net_rpl(const struct shell *shell, size_t argc, char *argv[])
 
 	ARG_UNUSED(argc);
 	ARG_UNUSED(argv);
-
-	if (shell_help_requested(shell)) {
-		shell_help_print(shell);
-		return -ENOEXEC;
-	}
 
 #if defined(CONFIG_NET_RPL)
 	mode = net_rpl_get_mode();
@@ -3551,11 +3443,6 @@ static int cmd_net_stacks(const struct shell *shell, size_t argc,
 	ARG_UNUSED(argc);
 	ARG_UNUSED(argv);
 
-	if (shell_help_requested(shell)) {
-		shell_help_print(shell);
-		return -ENOEXEC;
-	}
-
 	for (info = __net_stack_start; info != __net_stack_end; info++) {
 		net_analyze_stack_get_values(K_THREAD_STACK_BUFFER(info->stack),
 					     info->size, &pcnt, &unused);
@@ -3631,11 +3518,6 @@ static int cmd_net_stats_all(const struct shell *shell, size_t argc,
 	struct net_shell_user_data user_data;
 #endif
 
-	if (shell_help_requested(shell)) {
-		shell_help_print(shell);
-		return -ENOEXEC;
-	}
-
 #if defined(CONFIG_NET_STATISTICS)
 	user_data.shell = shell;
 
@@ -3663,11 +3545,6 @@ static int cmd_net_stats_iface(const struct shell *shell, size_t argc,
 	int idx;
 #endif
 #endif
-
-	if (shell_help_requested(shell)) {
-		shell_help_print(shell);
-		return -ENOEXEC;
-	}
 
 #if defined(CONFIG_NET_STATISTICS)
 #if defined(CONFIG_NET_STATISTICS_PER_INTERFACE)
@@ -3703,11 +3580,6 @@ static int cmd_net_stats_iface(const struct shell *shell, size_t argc,
 
 static int cmd_net_stats(const struct shell *shell, size_t argc, char *argv[])
 {
-	if (shell_help_requested(shell)) {
-		shell_help_print(shell);
-		return -ENOEXEC;
-	}
-
 #if defined(CONFIG_NET_STATISTICS)
 	if (!argv[1]) {
 		cmd_net_stats_all(shell, argc, argv);
@@ -3940,11 +3812,6 @@ static int cmd_net_tcp_connect(const struct shell *shell, size_t argc,
 	u16_t port;
 #endif
 
-	if (shell_help_requested(shell)) {
-		shell_help_print(shell);
-		return -ENOEXEC;
-	}
-
 #if defined(CONFIG_NET_TCP)
 	/* tcp connect <ip> port */
 	if (tcp_ctx && net_context_is_used(tcp_ctx)) {
@@ -3987,11 +3854,6 @@ static int cmd_net_tcp_send(const struct shell *shell, size_t argc,
 	struct net_shell_user_data user_data;
 	struct net_pkt *pkt;
 #endif
-
-	if (shell_help_requested(shell)) {
-		shell_help_print(shell);
-		return -ENOEXEC;
-	}
 
 #if defined(CONFIG_NET_TCP)
 	/* tcp send <data> */
@@ -4043,11 +3905,6 @@ static int cmd_net_tcp_close(const struct shell *shell, size_t argc,
 	int ret;
 #endif
 
-	if (shell_help_requested(shell)) {
-		shell_help_print(shell);
-		return -ENOEXEC;
-	}
-
 #if defined(CONFIG_NET_TCP)
 	/* tcp close */
 	if (!tcp_ctx || !net_context_is_used(tcp_ctx)) {
@@ -4074,11 +3931,6 @@ static int cmd_net_tcp(const struct shell *shell, size_t argc, char *argv[])
 {
 	ARG_UNUSED(argc);
 	ARG_UNUSED(argv);
-
-	if (shell_help_requested(shell)) {
-		shell_help_print(shell);
-		return -ENOEXEC;
-	}
 
 	return 0;
 }
@@ -4152,11 +4004,6 @@ static int cmd_net_vlan(const struct shell *shell, size_t argc, char *argv[])
 	int count;
 #endif
 
-	if (shell_help_requested(shell)) {
-		shell_help_print(shell);
-		return -ENOEXEC;
-	}
-
 #if defined(CONFIG_NET_VLAN)
 	count = 0;
 
@@ -4182,11 +4029,6 @@ static int cmd_net_vlan_add(const struct shell *shell, size_t argc,
 	char *endptr;
 	u32_t iface_idx;
 #endif
-
-	if (shell_help_requested(shell)) {
-		shell_help_print(shell);
-		return -ENOEXEC;
-	}
 
 #if defined(CONFIG_NET_VLAN)
 	/* vlan add <tag> <interface index> */
@@ -4259,11 +4101,6 @@ static int cmd_net_vlan_del(const struct shell *shell, size_t argc,
 	char *endptr;
 	u16_t tag;
 #endif
-
-	if (shell_help_requested(shell)) {
-		shell_help_print(shell);
-		return -ENOEXEC;
-	}
 
 #if defined(CONFIG_NET_VLAN)
 	/* vlan del <tag> */

--- a/subsys/net/l2/bluetooth/bluetooth_shell.c
+++ b/subsys/net/l2/bluetooth/bluetooth_shell.c
@@ -85,7 +85,7 @@ static int shell_cmd_connect(const struct shell *shell,
 	struct net_if *iface = net_if_get_default();
 
 	if (argc < 3 || shell_help_requested(shell)) {
-		shell_help_print(shell, NULL, 0);
+		shell_help_print(shell);
 		return -ENOEXEC;
 	}
 
@@ -113,7 +113,7 @@ static int shell_cmd_scan(const struct shell *shell,
 	struct net_if *iface = net_if_get_default();
 
 	if (argc < 2 || shell_help_requested(shell)) {
-		shell_help_print(shell, NULL, 0);
+		shell_help_print(shell);
 		return -ENOEXEC;
 	}
 
@@ -134,7 +134,7 @@ static int shell_cmd_disconnect(const struct shell *shell,
 	struct net_if *iface = net_if_get_default();
 
 	if (shell_help_requested(shell)) {
-		shell_help_print(shell, NULL, 0);
+		shell_help_print(shell);
 		return -ENOEXEC;
 	}
 
@@ -155,7 +155,7 @@ static int shell_cmd_advertise(const struct shell *shell,
 	struct net_if *iface = net_if_get_default();
 
 	if (argc < 2 || shell_help_requested(shell)) {
-		shell_help_print(shell, NULL, 0);
+		shell_help_print(shell);
 		return -ENOEXEC;
 	}
 

--- a/subsys/net/l2/bluetooth/bluetooth_shell.c
+++ b/subsys/net/l2/bluetooth/bluetooth_shell.c
@@ -84,7 +84,7 @@ static int shell_cmd_connect(const struct shell *shell,
 	bt_addr_le_t addr;
 	struct net_if *iface = net_if_get_default();
 
-	if (argc < 3 || shell_help_requested(shell)) {
+	if (argc < 3) {
 		shell_help_print(shell);
 		return -ENOEXEC;
 	}
@@ -112,7 +112,7 @@ static int shell_cmd_scan(const struct shell *shell,
 {
 	struct net_if *iface = net_if_get_default();
 
-	if (argc < 2 || shell_help_requested(shell)) {
+	if (argc < 2) {
 		shell_help_print(shell);
 		return -ENOEXEC;
 	}
@@ -133,11 +133,6 @@ static int shell_cmd_disconnect(const struct shell *shell,
 {
 	struct net_if *iface = net_if_get_default();
 
-	if (shell_help_requested(shell)) {
-		shell_help_print(shell);
-		return -ENOEXEC;
-	}
-
 	if (net_mgmt(NET_REQUEST_BT_DISCONNECT, iface, NULL, 0)) {
 		shell_fprintf(shell, SHELL_WARNING,
 			      "Disconnect failed\n");
@@ -154,7 +149,7 @@ static int shell_cmd_advertise(const struct shell *shell,
 {
 	struct net_if *iface = net_if_get_default();
 
-	if (argc < 2 || shell_help_requested(shell)) {
+	if (argc < 2) {
 		shell_help_print(shell);
 		return -ENOEXEC;
 	}

--- a/subsys/net/l2/bluetooth/bluetooth_shell.c
+++ b/subsys/net/l2/bluetooth/bluetooth_shell.c
@@ -85,7 +85,7 @@ static int shell_cmd_connect(const struct shell *shell,
 	struct net_if *iface = net_if_get_default();
 
 	if (argc < 3) {
-		shell_help_print(shell);
+		shell_help(shell);
 		return -ENOEXEC;
 	}
 
@@ -113,7 +113,7 @@ static int shell_cmd_scan(const struct shell *shell,
 	struct net_if *iface = net_if_get_default();
 
 	if (argc < 2) {
-		shell_help_print(shell);
+		shell_help(shell);
 		return -ENOEXEC;
 	}
 
@@ -150,7 +150,7 @@ static int shell_cmd_advertise(const struct shell *shell,
 	struct net_if *iface = net_if_get_default();
 
 	if (argc < 2) {
-		shell_help_print(shell);
+		shell_help(shell);
 		return -ENOEXEC;
 	}
 

--- a/subsys/net/l2/ieee802154/ieee802154_shell.c
+++ b/subsys/net/l2/ieee802154/ieee802154_shell.c
@@ -37,7 +37,7 @@ static int cmd_ieee802154_ack(const struct shell *shell,
 	ARG_UNUSED(argc);
 
 	if (shell_help_requested(shell)) {
-		shell_help_print(shell, NULL, 0);
+		shell_help_print(shell);
 		return -ENOEXEC;
 	}
 
@@ -78,7 +78,7 @@ static int cmd_ieee802154_associate(const struct shell *shell,
 	char ext_addr[MAX_EXT_ADDR_STR_LEN];
 
 	if (argc < 3 || shell_help_requested(shell)) {
-		shell_help_print(shell, NULL, 0);
+		shell_help_print(shell);
 		return -ENOEXEC;
 	}
 
@@ -124,7 +124,7 @@ static int cmd_ieee802154_disassociate(const struct shell *shell,
 	ARG_UNUSED(argv);
 
 	if (shell_help_requested(shell)) {
-		shell_help_print(shell, NULL, 0);
+		shell_help_print(shell);
 		return -ENOEXEC;
 	}
 
@@ -218,7 +218,7 @@ static int cmd_ieee802154_scan(const struct shell *shell,
 	int ret;
 
 	if (argc < 3 || shell_help_requested(shell)) {
-		shell_help_print(shell, NULL, 0);
+		shell_help_print(shell);
 		return -ENOEXEC;
 	}
 
@@ -289,7 +289,7 @@ static int cmd_ieee802154_set_chan(const struct shell *shell,
 	u16_t channel;
 
 	if (argc < 2 || shell_help_requested(shell)) {
-		shell_help_print(shell, NULL, 0);
+		shell_help_print(shell);
 		return -ENOEXEC;
 	}
 
@@ -325,7 +325,7 @@ static int cmd_ieee802154_get_chan(const struct shell *shell,
 	ARG_UNUSED(argv);
 
 	if (shell_help_requested(shell)) {
-		shell_help_print(shell, NULL, 0);
+		shell_help_print(shell);
 		return -ENOEXEC;
 	}
 
@@ -358,7 +358,7 @@ static int cmd_ieee802154_set_pan_id(const struct shell *shell,
 	ARG_UNUSED(argc);
 
 	if (argc < 2 || shell_help_requested(shell)) {
-		shell_help_print(shell, NULL, 0);
+		shell_help_print(shell);
 		return -ENOEXEC;
 	}
 
@@ -394,7 +394,7 @@ static int cmd_ieee802154_get_pan_id(const struct shell *shell,
 	ARG_UNUSED(argv);
 
 	if (shell_help_requested(shell)) {
-		shell_help_print(shell, NULL, 0);
+		shell_help_print(shell);
 		return -ENOEXEC;
 	}
 
@@ -425,7 +425,7 @@ static int cmd_ieee802154_set_ext_addr(const struct shell *shell,
 	u8_t addr[IEEE802154_EXT_ADDR_LENGTH];
 
 	if (argc < 2 || shell_help_requested(shell)) {
-		shell_help_print(shell, NULL, 0);
+		shell_help_print(shell);
 		return -ENOEXEC;
 	}
 
@@ -464,7 +464,7 @@ static int cmd_ieee802154_get_ext_addr(const struct shell *shell,
 	u8_t addr[IEEE802154_EXT_ADDR_LENGTH];
 
 	if (shell_help_requested(shell)) {
-		shell_help_print(shell, NULL, 0);
+		shell_help_print(shell);
 		return -ENOEXEC;
 	}
 
@@ -505,7 +505,7 @@ static int cmd_ieee802154_set_short_addr(const struct shell *shell,
 	u16_t short_addr;
 
 	if (argc < 2 || shell_help_requested(shell)) {
-		shell_help_print(shell, NULL, 0);
+		shell_help_print(shell);
 		return -ENOEXEC;
 	}
 
@@ -538,7 +538,7 @@ static int cmd_ieee802154_get_short_addr(const struct shell *shell,
 	u16_t short_addr;
 
 	if (shell_help_requested(shell)) {
-		shell_help_print(shell, NULL, 0);
+		shell_help_print(shell);
 		return -ENOEXEC;
 	}
 
@@ -569,7 +569,7 @@ static int cmd_ieee802154_set_tx_power(const struct shell *shell,
 	s16_t tx_power;
 
 	if (argc < 2 || shell_help_requested(shell)) {
-		shell_help_print(shell, NULL, 0);
+		shell_help_print(shell);
 		return -ENOEXEC;
 	}
 
@@ -602,7 +602,7 @@ static int cmd_ieee802154_get_tx_power(const struct shell *shell,
 	s16_t tx_power;
 
 	if (shell_help_requested(shell)) {
-		shell_help_print(shell, NULL, 0);
+		shell_help_print(shell);
 		return -ENOEXEC;
 	}
 

--- a/subsys/net/l2/ieee802154/ieee802154_shell.c
+++ b/subsys/net/l2/ieee802154/ieee802154_shell.c
@@ -36,11 +36,6 @@ static int cmd_ieee802154_ack(const struct shell *shell,
 
 	ARG_UNUSED(argc);
 
-	if (shell_help_requested(shell)) {
-		shell_help_print(shell);
-		return -ENOEXEC;
-	}
-
 	if (!iface) {
 		shell_fprintf(shell, SHELL_INFO,
 			      "No IEEE 802.15.4 interface found.\n");
@@ -77,7 +72,7 @@ static int cmd_ieee802154_associate(const struct shell *shell,
 	struct net_if *iface = net_if_get_ieee802154();
 	char ext_addr[MAX_EXT_ADDR_STR_LEN];
 
-	if (argc < 3 || shell_help_requested(shell)) {
+	if (argc < 3) {
 		shell_help_print(shell);
 		return -ENOEXEC;
 	}
@@ -122,11 +117,6 @@ static int cmd_ieee802154_disassociate(const struct shell *shell,
 
 	ARG_UNUSED(argc);
 	ARG_UNUSED(argv);
-
-	if (shell_help_requested(shell)) {
-		shell_help_print(shell);
-		return -ENOEXEC;
-	}
 
 	if (!iface) {
 		shell_fprintf(shell, SHELL_INFO,
@@ -217,7 +207,7 @@ static int cmd_ieee802154_scan(const struct shell *shell,
 	u32_t scan_type;
 	int ret;
 
-	if (argc < 3 || shell_help_requested(shell)) {
+	if (argc < 3) {
 		shell_help_print(shell);
 		return -ENOEXEC;
 	}
@@ -288,7 +278,7 @@ static int cmd_ieee802154_set_chan(const struct shell *shell,
 	struct net_if *iface = net_if_get_ieee802154();
 	u16_t channel;
 
-	if (argc < 2 || shell_help_requested(shell)) {
+	if (argc < 2) {
 		shell_help_print(shell);
 		return -ENOEXEC;
 	}
@@ -324,11 +314,6 @@ static int cmd_ieee802154_get_chan(const struct shell *shell,
 	ARG_UNUSED(argc);
 	ARG_UNUSED(argv);
 
-	if (shell_help_requested(shell)) {
-		shell_help_print(shell);
-		return -ENOEXEC;
-	}
-
 	if (!iface) {
 		shell_fprintf(shell, SHELL_INFO,
 			      "No IEEE 802.15.4 interface found.\n");
@@ -357,7 +342,7 @@ static int cmd_ieee802154_set_pan_id(const struct shell *shell,
 
 	ARG_UNUSED(argc);
 
-	if (argc < 2 || shell_help_requested(shell)) {
+	if (argc < 2) {
 		shell_help_print(shell);
 		return -ENOEXEC;
 	}
@@ -393,11 +378,6 @@ static int cmd_ieee802154_get_pan_id(const struct shell *shell,
 	ARG_UNUSED(argc);
 	ARG_UNUSED(argv);
 
-	if (shell_help_requested(shell)) {
-		shell_help_print(shell);
-		return -ENOEXEC;
-	}
-
 	if (!iface) {
 		shell_fprintf(shell, SHELL_INFO,
 			      "No IEEE 802.15.4 interface found.\n");
@@ -424,7 +404,7 @@ static int cmd_ieee802154_set_ext_addr(const struct shell *shell,
 	struct net_if *iface = net_if_get_ieee802154();
 	u8_t addr[IEEE802154_EXT_ADDR_LENGTH];
 
-	if (argc < 2 || shell_help_requested(shell)) {
+	if (argc < 2) {
 		shell_help_print(shell);
 		return -ENOEXEC;
 	}
@@ -463,11 +443,6 @@ static int cmd_ieee802154_get_ext_addr(const struct shell *shell,
 	struct net_if *iface = net_if_get_ieee802154();
 	u8_t addr[IEEE802154_EXT_ADDR_LENGTH];
 
-	if (shell_help_requested(shell)) {
-		shell_help_print(shell);
-		return -ENOEXEC;
-	}
-
 	if (!iface) {
 		shell_fprintf(shell, SHELL_INFO,
 			      "No IEEE 802.15.4 interface found.\n");
@@ -504,7 +479,7 @@ static int cmd_ieee802154_set_short_addr(const struct shell *shell,
 	struct net_if *iface = net_if_get_ieee802154();
 	u16_t short_addr;
 
-	if (argc < 2 || shell_help_requested(shell)) {
+	if (argc < 2) {
 		shell_help_print(shell);
 		return -ENOEXEC;
 	}
@@ -537,11 +512,6 @@ static int cmd_ieee802154_get_short_addr(const struct shell *shell,
 	struct net_if *iface = net_if_get_ieee802154();
 	u16_t short_addr;
 
-	if (shell_help_requested(shell)) {
-		shell_help_print(shell);
-		return -ENOEXEC;
-	}
-
 	if (!iface) {
 		shell_fprintf(shell, SHELL_INFO,
 			      "No IEEE 802.15.4 interface found.\n");
@@ -568,7 +538,7 @@ static int cmd_ieee802154_set_tx_power(const struct shell *shell,
 	struct net_if *iface = net_if_get_ieee802154();
 	s16_t tx_power;
 
-	if (argc < 2 || shell_help_requested(shell)) {
+	if (argc < 2) {
 		shell_help_print(shell);
 		return -ENOEXEC;
 	}
@@ -600,11 +570,6 @@ static int cmd_ieee802154_get_tx_power(const struct shell *shell,
 {
 	struct net_if *iface = net_if_get_ieee802154();
 	s16_t tx_power;
-
-	if (shell_help_requested(shell)) {
-		shell_help_print(shell);
-		return -ENOEXEC;
-	}
 
 	if (!iface) {
 		shell_fprintf(shell, SHELL_INFO,

--- a/subsys/net/l2/ieee802154/ieee802154_shell.c
+++ b/subsys/net/l2/ieee802154/ieee802154_shell.c
@@ -73,7 +73,7 @@ static int cmd_ieee802154_associate(const struct shell *shell,
 	char ext_addr[MAX_EXT_ADDR_STR_LEN];
 
 	if (argc < 3) {
-		shell_help_print(shell);
+		shell_help(shell);
 		return -ENOEXEC;
 	}
 
@@ -208,7 +208,7 @@ static int cmd_ieee802154_scan(const struct shell *shell,
 	int ret;
 
 	if (argc < 3) {
-		shell_help_print(shell);
+		shell_help(shell);
 		return -ENOEXEC;
 	}
 
@@ -279,7 +279,7 @@ static int cmd_ieee802154_set_chan(const struct shell *shell,
 	u16_t channel;
 
 	if (argc < 2) {
-		shell_help_print(shell);
+		shell_help(shell);
 		return -ENOEXEC;
 	}
 
@@ -343,7 +343,7 @@ static int cmd_ieee802154_set_pan_id(const struct shell *shell,
 	ARG_UNUSED(argc);
 
 	if (argc < 2) {
-		shell_help_print(shell);
+		shell_help(shell);
 		return -ENOEXEC;
 	}
 
@@ -405,7 +405,7 @@ static int cmd_ieee802154_set_ext_addr(const struct shell *shell,
 	u8_t addr[IEEE802154_EXT_ADDR_LENGTH];
 
 	if (argc < 2) {
-		shell_help_print(shell);
+		shell_help(shell);
 		return -ENOEXEC;
 	}
 
@@ -480,7 +480,7 @@ static int cmd_ieee802154_set_short_addr(const struct shell *shell,
 	u16_t short_addr;
 
 	if (argc < 2) {
-		shell_help_print(shell);
+		shell_help(shell);
 		return -ENOEXEC;
 	}
 
@@ -539,7 +539,7 @@ static int cmd_ieee802154_set_tx_power(const struct shell *shell,
 	s16_t tx_power;
 
 	if (argc < 2) {
-		shell_help_print(shell);
+		shell_help(shell);
 		return -ENOEXEC;
 	}
 

--- a/subsys/net/l2/wifi/wifi_shell.c
+++ b/subsys/net/l2/wifi/wifi_shell.c
@@ -152,13 +152,13 @@ static int cmd_wifi_connect(const struct shell *shell, size_t argc,
 	int idx = 3;
 
 	if (argc < 3) {
-		shell_help_print(shell);
+		shell_help(shell);
 		return -ENOEXEC;
 	}
 
 	cnx_params.ssid_length = strtol(argv[2], &endptr, 10);
 	if (*endptr != '\0' || cnx_params.ssid_length <= 2) {
-		shell_help_print(shell);
+		shell_help(shell);
 		return -ENOEXEC;
 	}
 
@@ -167,7 +167,7 @@ static int cmd_wifi_connect(const struct shell *shell, size_t argc,
 	if ((idx < argc) && (strlen(argv[idx]) <= 2)) {
 		cnx_params.channel = strtol(argv[idx], &endptr, 10);
 		if (*endptr != '\0') {
-			shell_help_print(shell);
+			shell_help(shell);
 			return -ENOEXEC;
 		}
 

--- a/subsys/net/l2/wifi/wifi_shell.c
+++ b/subsys/net/l2/wifi/wifi_shell.c
@@ -152,13 +152,13 @@ static int cmd_wifi_connect(const struct shell *shell, size_t argc,
 	int idx = 3;
 
 	if (shell_help_requested(shell) || argc < 3) {
-		shell_help_print(shell, NULL, 0);
+		shell_help_print(shell);
 		return -ENOEXEC;
 	}
 
 	cnx_params.ssid_length = strtol(argv[2], &endptr, 10);
 	if (*endptr != '\0' || cnx_params.ssid_length <= 2) {
-		shell_help_print(shell, NULL, 0);
+		shell_help_print(shell);
 		return -ENOEXEC;
 	}
 
@@ -167,7 +167,7 @@ static int cmd_wifi_connect(const struct shell *shell, size_t argc,
 	if ((idx < argc) && (strlen(argv[idx]) <= 2)) {
 		cnx_params.channel = strtol(argv[idx], &endptr, 10);
 		if (*endptr != '\0') {
-			shell_help_print(shell, NULL, 0);
+			shell_help_print(shell);
 			return -ENOEXEC;
 		}
 
@@ -213,7 +213,7 @@ static int cmd_wifi_disconnect(const struct shell *shell, size_t argc,
 	int status;
 
 	if (shell_help_requested(shell)) {
-		shell_help_print(shell, NULL, 0);
+		shell_help_print(shell);
 		return -ENOEXEC;
 	}
 
@@ -246,7 +246,7 @@ static int cmd_wifi_scan(const struct shell *shell, size_t argc, char *argv[])
 	struct net_if *iface = net_if_get_default();
 
 	if (shell_help_requested(shell)) {
-		shell_help_print(shell, NULL, 0);
+		shell_help_print(shell);
 		return -ENOEXEC;
 	}
 

--- a/subsys/net/l2/wifi/wifi_shell.c
+++ b/subsys/net/l2/wifi/wifi_shell.c
@@ -151,7 +151,7 @@ static int cmd_wifi_connect(const struct shell *shell, size_t argc,
 	char *endptr;
 	int idx = 3;
 
-	if (shell_help_requested(shell) || argc < 3) {
+	if (argc < 3) {
 		shell_help_print(shell);
 		return -ENOEXEC;
 	}
@@ -212,11 +212,6 @@ static int cmd_wifi_disconnect(const struct shell *shell, size_t argc,
 	struct net_if *iface = net_if_get_default();
 	int status;
 
-	if (shell_help_requested(shell)) {
-		shell_help_print(shell);
-		return -ENOEXEC;
-	}
-
 	context.disconnecting = true;
 	context.shell = shell;
 
@@ -244,11 +239,6 @@ static int cmd_wifi_disconnect(const struct shell *shell, size_t argc,
 static int cmd_wifi_scan(const struct shell *shell, size_t argc, char *argv[])
 {
 	struct net_if *iface = net_if_get_default();
-
-	if (shell_help_requested(shell)) {
-		shell_help_print(shell);
-		return -ENOEXEC;
-	}
 
 	if (net_mgmt(NET_REQUEST_WIFI_SCAN, iface, NULL, 0)) {
 		shell_fprintf(shell, SHELL_WARNING, "Scan request failed\n");

--- a/subsys/net/lib/openthread/platform/shell.c
+++ b/subsys/net/lib/openthread/platform/shell.c
@@ -36,7 +36,7 @@ static int ot_cmd(const struct shell *shell, size_t argc, char *argv[])
 	int i;
 
 	if (shell_help_requested(shell)) {
-		shell_help_print(shell, NULL, 0);
+		shell_help_print(shell);
 		return -ENOEXEC;
 	}
 

--- a/subsys/net/lib/openthread/platform/shell.c
+++ b/subsys/net/lib/openthread/platform/shell.c
@@ -35,11 +35,6 @@ static int ot_cmd(const struct shell *shell, size_t argc, char *argv[])
 	size_t arg_len = 0;
 	int i;
 
-	if (shell_help_requested(shell)) {
-		shell_help_print(shell);
-		return -ENOEXEC;
-	}
-
 	if (argc < 2) {
 		return -ENOEXEC;
 	}

--- a/subsys/shell/CMakeLists.txt
+++ b/subsys/shell/CMakeLists.txt
@@ -34,6 +34,11 @@ zephyr_sources_ifdef(
 )
 
 zephyr_sources_ifdef(
+  CONFIG_SHELL_HELP
+  shell_help.c
+  )
+
+zephyr_sources_ifdef(
   CONFIG_SHELL_CMDS
   shell_cmds.c
 )

--- a/subsys/shell/shell.c
+++ b/subsys/shell/shell.c
@@ -9,6 +9,7 @@
 #include <stdlib.h>
 #include <shell/shell.h>
 #include <shell/shell_dummy.h>
+#include "shell_help.h"
 #include "shell_utils.h"
 #include "shell_ops.h"
 #include "shell_wildcard.h"
@@ -42,26 +43,6 @@
 
 static int shell_execute(const struct shell *shell);
 
-extern const struct shell_cmd_entry __shell_root_cmds_start[0];
-extern const struct shell_cmd_entry __shell_root_cmds_end[0];
-
-static inline const struct shell_cmd_entry *shell_root_cmd_get(u32_t id)
-{
-	return &__shell_root_cmds_start[id];
-}
-
-static inline u32_t shell_root_cmd_count(void)
-{
-	return ((u8_t *)__shell_root_cmds_end -
-			(u8_t *)__shell_root_cmds_start)/
-				sizeof(struct shell_cmd_entry);
-}
-
-static inline void transport_buffer_flush(const struct shell *shell)
-{
-	shell_fprintf_buffer_flush(shell->fprintf_ctx);
-}
-
 /* Function returns true if delete escape code shall be interpreted as
  * backspace.
  */
@@ -88,93 +69,33 @@ static void shell_cmd_buffer_clear(const struct shell *shell)
 	shell->ctx->cmd_buff_len = 0;
 }
 
-static void shell_pend_on_txdone(const struct shell *shell)
-{
-	if (IS_ENABLED(CONFIG_MULTITHREADING)) {
-		k_poll(&shell->ctx->events[SHELL_SIGNAL_TXDONE], 1, K_FOREVER);
-		k_poll_signal_reset(&shell->ctx->signals[SHELL_SIGNAL_TXDONE]);
-	} else {
-		/* Blocking wait in case of bare metal. */
-		while (!shell->ctx->internal.flags.tx_rdy) {
-		}
-		shell->ctx->internal.flags.tx_rdy = 0;
-	}
-}
-
-/* Function sends data stream to the shell instance. Each time before the
- * shell_write function is called, it must be ensured that IO buffer of fprintf
- * is flushed to avoid synchronization issues.
- * For that purpose, use function transport_buffer_flush(shell)
- */
-static void shell_write(const struct shell *shell, const void *data,
-			size_t length)
-{
-	__ASSERT_NO_MSG(shell && data);
-
-	size_t offset = 0;
-	size_t tmp_cnt;
-
-	while (length) {
-		int err = shell->iface->api->write(shell->iface,
-				&((const u8_t *) data)[offset], length,
-				&tmp_cnt);
-		(void)err;
-		__ASSERT_NO_MSG(err == 0);
-		__ASSERT_NO_MSG(length >= tmp_cnt);
-		offset += tmp_cnt;
-		length -= tmp_cnt;
-		if (tmp_cnt == 0 &&
-		    (shell->ctx->state != SHELL_STATE_PANIC_MODE_ACTIVE)) {
-			shell_pend_on_txdone(shell);
-		}
-	}
-}
-
-/* @brief Function shall be used to search commands.
+/**
+ * @brief Prints error message on wrong argument count.
+ *	  Optionally, printing help on wrong argument count.
  *
- * It moves the pointer entry to command of static command structure. If the
- * command cannot be found, the function will set entry to NULL.
+ * @param[in] shell	  Pointer to the shell instance.
+ * @param[in] arg_cnt_ok  Flag indicating valid number of arguments.
  *
- *   @param command	Pointer to command which will be processed (no matter
- *			the root command).
- *   @param lvl		Level of the requested command.
- *   @param idx		Index of the requested command.
- *   @param entry	Pointer which points to subcommand[idx] after function
- *			execution.
- *   @param st_entry	Pointer to the structure where dynamic entry data can be
- *			stored.
+ * @return 0		  if check passed
+ * @return 1		  if help was requested
+ * @return -EINVAL	  if wrong argument count
  */
-static void cmd_get(const struct shell_cmd_entry *command, size_t lvl,
-		    size_t idx, const struct shell_static_entry **entry,
-		    struct shell_static_entry *d_entry)
+static int shell_cmd_precheck(const struct shell *shell,
+			      bool arg_cnt_ok)
 {
-	__ASSERT_NO_MSG(entry != NULL);
-	__ASSERT_NO_MSG(d_entry != NULL);
+	if (!arg_cnt_ok) {
+		shell_fprintf(shell, SHELL_ERROR,
+			      "%s: wrong parameter count\n",
+			      shell->ctx->active_cmd.syntax);
 
-	if (lvl == SHELL_CMD_ROOT_LVL) {
-		if (idx < shell_root_cmd_count()) {
-			const struct shell_cmd_entry *cmd;
-
-			cmd = shell_root_cmd_get(idx);
-			*entry = cmd->u.entry;
-		} else {
-			*entry = NULL;
+		if (IS_ENABLED(CONFIG_SHELL_HELP_ON_WRONG_ARGUMENT_COUNT)) {
+			shell_help_print(shell);
 		}
-		return;
+
+		return -EINVAL;
 	}
 
-	if (command == NULL) {
-		*entry = NULL;
-		return;
-	}
-
-	if (command->is_dynamic) {
-		command->u.dynamic_get(idx, d_entry);
-		*entry = (d_entry->syntax != NULL) ? d_entry : NULL;
-	} else {
-		*entry = (command->u.entry[idx].syntax != NULL) ?
-				&command->u.entry[idx] : NULL;
-	}
+	return 0;
 }
 
 static void vt100_color_set(const struct shell *shell,
@@ -364,7 +285,7 @@ static const struct shell_static_entry *find_cmd(
 	size_t idx = 0;
 
 	do {
-		cmd_get(cmd, lvl, idx++, &entry, d_entry);
+		shell_cmd_get(cmd, lvl, idx++, &entry, d_entry);
 		if (entry && (strcmp(cmd_str, entry->syntax) == 0)) {
 			return entry;
 		}
@@ -490,8 +411,8 @@ static void find_completion_candidates(const struct shell_static_entry *cmd,
 	*cnt = 0;
 
 	while (true) {
-		cmd_get(cmd ? cmd->subcmd : NULL, cmd ? 1 : 0,
-			idx, &candidate, &dynamic_entry);
+		shell_cmd_get(cmd ? cmd->subcmd : NULL, cmd ? 1 : 0,
+			      idx, &candidate, &dynamic_entry);
 
 		if (!candidate) {
 			break;
@@ -526,8 +447,8 @@ static void autocomplete(const struct shell *shell,
 	/* shell->ctx->active_cmd can be safely used outside of command context
 	 * to save stack
 	 */
-	cmd_get(cmd ? cmd->subcmd : NULL, cmd ? 1 : 0,
-			subcmd_idx, &match, &shell->ctx->active_cmd);
+	shell_cmd_get(cmd ? cmd->subcmd : NULL, cmd ? 1 : 0,
+		      subcmd_idx, &match, &shell->ctx->active_cmd);
 	cmd_len = shell_strlen(match->syntax);
 
 	/* no exact match found */
@@ -589,8 +510,8 @@ static void tab_options_print(const struct shell *shell,
 		/* shell->ctx->active_cmd can be safely used outside of command
 		 * context to save stack
 		 */
-		cmd_get(cmd ? cmd->subcmd : NULL, cmd ? 1 : 0,
-			idx, &match, &shell->ctx->active_cmd);
+		shell_cmd_get(cmd ? cmd->subcmd : NULL, cmd ? 1 : 0,
+			      idx, &match, &shell->ctx->active_cmd);
 		idx++;
 
 		if (str && match->syntax &&
@@ -617,8 +538,9 @@ static u16_t common_beginning_find(const struct shell_static_entry *cmd,
 	u16_t common = UINT16_MAX;
 	size_t idx = first + 1;
 
-	cmd_get(cmd ? cmd->subcmd : NULL, cmd ? 1 : 0,
-		first, &match, &dynamic_entry);
+
+	shell_cmd_get(cmd ? cmd->subcmd : NULL, cmd ? 1 : 0,
+		      first, &match, &dynamic_entry);
 
 	*str = match->syntax;
 
@@ -627,8 +549,8 @@ static u16_t common_beginning_find(const struct shell_static_entry *cmd,
 		const struct shell_static_entry *match2;
 		int curr_common;
 
-		cmd_get(cmd ? cmd->subcmd : NULL, cmd ? 1 : 0,
-			idx++, &match2, &dynamic_entry2);
+		shell_cmd_get(cmd ? cmd->subcmd : NULL, cmd ? 1 : 0,
+			      idx++, &match2, &dynamic_entry2);
 
 		if (match2 == NULL) {
 			break;
@@ -674,6 +596,7 @@ static void shell_tab_handle(const struct shell *shell)
 	size_t first;
 	size_t argc;
 	size_t cnt;
+
 
 	bool tab_possible = shell_tab_prepare(shell, &cmd, argv, &argc,
 					      &arg_idx, &d_entry);
@@ -949,22 +872,6 @@ static void cmd_trim(const struct shell *shell)
 	shell->ctx->cmd_buff_pos = shell->ctx->cmd_buff_len;
 }
 
-/* Function returning pointer to root command matching requested syntax. */
-static const struct shell_cmd_entry *root_cmd_find(const char *syntax)
-{
-	const size_t cmd_count = shell_root_cmd_count();
-	const struct shell_cmd_entry *cmd;
-
-	for (size_t cmd_idx = 0; cmd_idx < cmd_count; ++cmd_idx) {
-		cmd = shell_root_cmd_get(cmd_idx);
-		if (strcmp(syntax, cmd->u.entry->syntax) == 0) {
-			return cmd;
-		}
-	}
-
-	return NULL;
-}
-
 static int exec_cmd(const struct shell *shell, size_t argc, char **argv,
 		    struct shell_static_entry help_entry)
 {
@@ -976,12 +883,14 @@ static int exec_cmd(const struct shell *shell, size_t argc, char **argv,
 				shell->ctx->active_cmd = help_entry;
 			}
 			shell_help_print(shell);
+			/* 1 is return value when shell prints help */
+			ret_val = 1;
 		} else {
 			shell_fprintf(shell, SHELL_ERROR,
 				      SHELL_MSG_SPECIFY_SUBCOMMAND);
+			ret_val = -ENOEXEC;
 		}
 
-		ret_val = -ENOEXEC;
 		goto clear;
 	}
 
@@ -1123,7 +1032,8 @@ static int shell_execute(const struct shell *shell)
 			}
 		}
 
-		cmd_get(p_cmd, cmd_lvl, cmd_idx++, &p_static_entry, &d_entry);
+		shell_cmd_get(p_cmd, cmd_lvl, cmd_idx++, &p_static_entry,
+			      &d_entry);
 
 		if ((cmd_idx == 0) || (p_static_entry == NULL)) {
 			break;
@@ -1482,13 +1392,6 @@ void shell_process(const struct shell *shell)
 			 internal.value);
 }
 
-/* Function shall be only used by the fprintf module. */
-void shell_print_stream(const void *user_ctx, const char *data,
-			size_t data_len)
-{
-	shell_write((const struct shell *) user_ctx, data, data_len);
-}
-
 void shell_fprintf(const struct shell *shell, enum shell_vt100_color color,
 		   const char *p_fmt, ...)
 {
@@ -1516,216 +1419,6 @@ void shell_fprintf(const struct shell *shell, enum shell_vt100_color color,
 	va_end(args);
 }
 
-/* Function prints a string on terminal screen with requested margin.
- * It takes care to not divide words.
- *   shell		Pointer to shell instance.
- *   p_str		Pointer to string to be printed.
- *   terminal_offset	Requested left margin.
- *   offset_first_line	Add margin to the first printed line.
- */
-static void formatted_text_print(const struct shell *shell, const char *str,
-				 size_t terminal_offset, bool offset_first_line)
-{
-	size_t offset = 0;
-	size_t length;
-
-	if (str == NULL) {
-		return;
-	}
-
-	if (offset_first_line) {
-		shell_op_cursor_horiz_move(shell, terminal_offset);
-	}
-
-
-	/* Skipping whitespace. */
-	while (isspace((int) *(str + offset))) {
-		++offset;
-	}
-
-	while (true) {
-		size_t idx = 0;
-
-		length = shell_strlen(str) - offset;
-
-		if (length <=
-		    shell->ctx->vt100_ctx.cons.terminal_wid - terminal_offset) {
-			for (idx = 0; idx < length; idx++) {
-				if (*(str + offset + idx) == '\n') {
-					transport_buffer_flush(shell);
-					shell_write(shell, str + offset, idx);
-					offset += idx + 1;
-					cursor_next_line_move(shell);
-					shell_op_cursor_horiz_move(shell,
-							terminal_offset);
-					break;
-				}
-			}
-
-			/* String will fit in one line. */
-			shell_raw_fprintf(shell->fprintf_ctx, str + offset);
-
-			break;
-		}
-
-		/* String is longer than terminal line so text needs to
-		 * divide in the way to not divide words.
-		 */
-		length = shell->ctx->vt100_ctx.cons.terminal_wid
-				- terminal_offset;
-
-		while (true) {
-			/* Determining line break. */
-			if (isspace((int) (*(str + offset + idx)))) {
-				length = idx;
-				if (*(str + offset + idx) == '\n') {
-					break;
-				}
-			}
-
-			if ((idx + terminal_offset) >=
-			    shell->ctx->vt100_ctx.cons.terminal_wid) {
-				/* End of line reached. */
-				break;
-			}
-
-			++idx;
-		}
-
-		/* Writing one line, fprintf IO buffer must be flushed
-		 * before calling shell_write.
-		 */
-		transport_buffer_flush(shell);
-		shell_write(shell, str + offset, length);
-		offset += length;
-
-		/* Calculating text offset to ensure that next line will
-		 * not begin with a space.
-		 */
-		while (isspace((int) (*(str + offset)))) {
-			++offset;
-		}
-
-		cursor_next_line_move(shell);
-		shell_op_cursor_horiz_move(shell, terminal_offset);
-
-	}
-	cursor_next_line_move(shell);
-}
-
-static void help_cmd_print(const struct shell *shell)
-{
-	static const char cmd_sep[] = " - ";	/* commands separator */
-
-	u16_t field_width = shell_strlen(shell->ctx->active_cmd.syntax) +
-							  shell_strlen(cmd_sep);
-
-	shell_fprintf(shell, SHELL_NORMAL, "%s%s",
-		      shell->ctx->active_cmd.syntax, cmd_sep);
-
-	formatted_text_print(shell, shell->ctx->active_cmd.help,
-			     field_width, false);
-}
-
-static void help_item_print(const struct shell *shell, const char *item_name,
-			    u16_t item_name_width, const char *item_help)
-{
-	static const u8_t tabulator[] = "  ";
-	const u16_t offset = 2 * strlen(tabulator) + item_name_width + 1;
-
-	if (item_name == NULL) {
-		return;
-	}
-
-	if (!IS_ENABLED(CONFIG_NEWLIB_LIBC) && !IS_ENABLED(CONFIG_ARCH_POSIX)) {
-		/* print option name */
-		shell_fprintf(shell, SHELL_NORMAL, "%s%-*s%s:",
-			      tabulator,
-			      item_name_width, item_name,
-			      tabulator);
-	} else {
-		u16_t tmp = item_name_width - strlen(item_name);
-		char space = ' ';
-
-		shell_fprintf(shell, SHELL_NORMAL, "%s%s", tabulator,
-			      item_name);
-		for (u16_t i = 0; i < tmp; i++) {
-			shell_write(shell, &space, 1);
-		}
-		shell_fprintf(shell, SHELL_NORMAL, "%s:", tabulator);
-	}
-
-	if (item_help == NULL) {
-		cursor_next_line_move(shell);
-		return;
-	}
-	/* print option help */
-	formatted_text_print(shell, item_help, offset, false);
-}
-
-/* Function is printing command help, its subcommands name and subcommands
- * help string.
- */
-static void help_subcmd_print(const struct shell *shell)
-{
-	const struct shell_static_entry *entry = NULL;
-	struct shell_static_entry static_entry;
-	u16_t longest_syntax = 0U;
-	size_t cmd_idx = 0;
-
-	/* Checking if there are any subcommands available. */
-	if (!shell->ctx->active_cmd.subcmd) {
-		return;
-	}
-
-	/* Searching for the longest subcommand to print. */
-	do {
-		cmd_get(shell->ctx->active_cmd.subcmd, !SHELL_CMD_ROOT_LVL,
-			cmd_idx++, &entry, &static_entry);
-
-		if (!entry) {
-			break;
-		}
-
-		u16_t len = shell_strlen(entry->syntax);
-
-		longest_syntax = longest_syntax > len ? longest_syntax : len;
-	} while (cmd_idx != 0); /* too many commands */
-
-	if (cmd_idx == 1) {
-		return;
-	}
-
-	shell_fprintf(shell, SHELL_NORMAL, "Subcommands:\r\n");
-
-	/* Printing subcommands and help string (if exists). */
-	cmd_idx = 0;
-
-	while (true) {
-		cmd_get(shell->ctx->active_cmd.subcmd, !SHELL_CMD_ROOT_LVL,
-			cmd_idx++, &entry, &static_entry);
-
-		if (entry == NULL) {
-			break;
-		}
-
-		help_item_print(shell, entry->syntax, longest_syntax,
-				entry->help);
-	}
-}
-
-void shell_help_print(const struct shell *shell)
-{
-	__ASSERT_NO_MSG(shell);
-
-	if (!IS_ENABLED(CONFIG_SHELL_HELP)) {
-		return;
-	}
-
-	help_cmd_print(shell);
-	help_subcmd_print(shell);
-}
-
 int shell_prompt_change(const struct shell *shell, char *prompt)
 {
 
@@ -1741,22 +1434,16 @@ int shell_prompt_change(const struct shell *shell, char *prompt)
 	return -1;
 }
 
-int shell_cmd_precheck(const struct shell *shell,
-		       bool arg_cnt_ok)
+void shell_help_print(const struct shell *shell)
 {
-	if (!arg_cnt_ok) {
-		shell_fprintf(shell, SHELL_ERROR,
-			      "%s: wrong parameter count\n",
-			      shell->ctx->active_cmd.syntax);
+	__ASSERT_NO_MSG(shell);
 
-		if (IS_ENABLED(CONFIG_SHELL_HELP_ON_WRONG_ARGUMENT_COUNT)) {
-			shell_help_print(shell);
-		}
-
-		return -EINVAL;
+	if (!IS_ENABLED(CONFIG_SHELL_HELP)) {
+		return;
 	}
 
-	return 0;
+	shell_help_cmd_print(shell);
+	shell_help_subcmd_print(shell);
 }
 
 int shell_execute_cmd(const struct shell *shell, const char *cmd)

--- a/subsys/shell/shell.c
+++ b/subsys/shell/shell.c
@@ -89,7 +89,7 @@ static int shell_cmd_precheck(const struct shell *shell,
 			      shell->ctx->active_cmd.syntax);
 
 		if (IS_ENABLED(CONFIG_SHELL_HELP_ON_WRONG_ARGUMENT_COUNT)) {
-			shell_help_print(shell);
+			shell_help(shell);
 		}
 
 		return -EINVAL;
@@ -882,7 +882,7 @@ static int exec_cmd(const struct shell *shell, size_t argc, char **argv,
 			if (help_entry.help != shell->ctx->active_cmd.help) {
 				shell->ctx->active_cmd = help_entry;
 			}
-			shell_help_print(shell);
+			shell_help(shell);
 			/* 1 is return value when shell prints help */
 			ret_val = 1;
 		} else {
@@ -1001,7 +1001,7 @@ static int shell_execute(const struct shell *shell)
 			 */
 			if (help_entry.help) {
 				shell->ctx->active_cmd = help_entry;
-				shell_help_print(shell);
+				shell_help(shell);
 				return 1;
 			}
 
@@ -1434,7 +1434,7 @@ int shell_prompt_change(const struct shell *shell, char *prompt)
 	return -1;
 }
 
-void shell_help_print(const struct shell *shell)
+void shell_help(const struct shell *shell)
 {
 	__ASSERT_NO_MSG(shell);
 

--- a/subsys/shell/shell_cmds.c
+++ b/subsys/shell/shell_cmds.c
@@ -434,10 +434,7 @@ static int cmd_shell_stats(const struct shell *shell, size_t argc, char **argv)
 {
 	ARG_UNUSED(argc);
 
-	if (shell_help_requested(shell)) {
-		shell_help_print(shell);
-		return 1;
-	} else if (argc == 1) {
+	if (argc == 1) {
 		shell_help_print(shell);
 	} else {
 		shell_fprintf(shell, SHELL_ERROR, "%s:%s%s\n", argv[0],

--- a/subsys/shell/shell_cmds.c
+++ b/subsys/shell/shell_cmds.c
@@ -184,7 +184,7 @@ static int cmd_clear(const struct shell *shell, size_t argc, char **argv)
 {
 	ARG_UNUSED(argv);
 
-	int ret = shell_cmd_precheck(shell, (argc == 1), NULL, 0);
+	int ret = shell_cmd_precheck(shell, (argc == 1));
 
 	if (ret) {
 		return ret;
@@ -198,7 +198,7 @@ static int cmd_clear(const struct shell *shell, size_t argc, char **argv)
 
 static int cmd_shell(const struct shell *shell, size_t argc, char **argv)
 {
-	int ret = shell_cmd_precheck(shell, (argc == 2), NULL, 0);
+	int ret = shell_cmd_precheck(shell, (argc == 2));
 
 	if (ret) {
 		return ret;
@@ -215,7 +215,7 @@ static int cmd_bacskpace_mode_backspace(const struct shell *shell, size_t argc,
 {
 	ARG_UNUSED(argv);
 
-	int ret = shell_cmd_precheck(shell, (argc == 1), NULL, 0);
+	int ret = shell_cmd_precheck(shell, (argc == 1));
 
 	if (ret == 0) {
 		shell->ctx->internal.flags.mode_delete = 0;
@@ -229,7 +229,7 @@ static int cmd_bacskpace_mode_delete(const struct shell *shell, size_t argc,
 {
 	ARG_UNUSED(argv);
 
-	int ret = shell_cmd_precheck(shell, (argc == 1), NULL, 0);
+	int ret = shell_cmd_precheck(shell, (argc == 1));
 
 	if (ret == 0) {
 		shell->ctx->internal.flags.mode_delete = 1;
@@ -241,7 +241,7 @@ static int cmd_bacskpace_mode_delete(const struct shell *shell, size_t argc,
 static int cmd_bacskpace_mode(const struct shell *shell, size_t argc,
 			      char **argv)
 {
-	int ret = shell_cmd_precheck(shell, (argc == 2), NULL, 0);
+	int ret = shell_cmd_precheck(shell, (argc == 2));
 
 	if (ret) {
 		return ret;
@@ -257,7 +257,7 @@ static int cmd_colors_off(const struct shell *shell, size_t argc, char **argv)
 {
 	ARG_UNUSED(argv);
 
-	int ret = shell_cmd_precheck(shell, (argc == 1), NULL, 0);
+	int ret = shell_cmd_precheck(shell, (argc == 1));
 
 	if (ret == 0) {
 		shell->ctx->internal.flags.use_colors = 0;
@@ -270,7 +270,7 @@ static int cmd_colors_on(const struct shell *shell, size_t argc, char **argv)
 {
 	ARG_UNUSED(argv);
 
-	int ret = shell_cmd_precheck(shell, (argc == 1), NULL, 0);
+	int ret = shell_cmd_precheck(shell, (argc == 1));
 
 	if (ret == 0) {
 		shell->ctx->internal.flags.use_colors = 1;
@@ -281,7 +281,7 @@ static int cmd_colors_on(const struct shell *shell, size_t argc, char **argv)
 
 static int cmd_colors(const struct shell *shell, size_t argc, char **argv)
 {
-	int ret = shell_cmd_precheck(shell, (argc == 2), NULL, 0);
+	int ret = shell_cmd_precheck(shell, (argc == 2));
 
 	if (ret) {
 		return ret;
@@ -297,7 +297,7 @@ static int cmd_echo_off(const struct shell *shell, size_t argc, char **argv)
 {
 	ARG_UNUSED(argv);
 
-	int ret = shell_cmd_precheck(shell, (argc == 1), NULL, 0);
+	int ret = shell_cmd_precheck(shell, (argc == 1));
 
 	if (ret == 0) {
 		shell->ctx->internal.flags.echo = 0;
@@ -310,7 +310,7 @@ static int cmd_echo_on(const struct shell *shell, size_t argc, char **argv)
 {
 	ARG_UNUSED(argv);
 
-	int ret = shell_cmd_precheck(shell, (argc == 1), NULL, 0);
+	int ret = shell_cmd_precheck(shell, (argc == 1));
 
 	if (ret == 0) {
 		shell->ctx->internal.flags.echo = 1;
@@ -321,7 +321,7 @@ static int cmd_echo_on(const struct shell *shell, size_t argc, char **argv)
 
 static int cmd_echo(const struct shell *shell, size_t argc, char **argv)
 {
-	int ret = shell_cmd_precheck(shell, (argc <= 2), NULL, 0);
+	int ret = shell_cmd_precheck(shell, (argc <= 2));
 
 	if (ret) {
 		return ret;
@@ -367,7 +367,7 @@ static int cmd_history(const struct shell *shell, size_t argc, char **argv)
 		return -ENOEXEC;
 	}
 
-	ret = shell_cmd_precheck(shell, (argc == 1), NULL, 0);
+	ret = shell_cmd_precheck(shell, (argc == 1));
 
 	if (ret) {
 		return ret;
@@ -401,7 +401,7 @@ static int cmd_shell_stats_show(const struct shell *shell, size_t argc,
 		return -ENOEXEC;
 	}
 
-	int ret = shell_cmd_precheck(shell, (argc == 1), NULL, 0);
+	int ret = shell_cmd_precheck(shell, (argc == 1));
 
 	if (ret == 0) {
 		shell_fprintf(shell, SHELL_NORMAL, "Lost logs: %u\n",
@@ -421,7 +421,7 @@ static int cmd_shell_stats_reset(const struct shell *shell,
 		return -ENOEXEC;
 	}
 
-	int ret = shell_cmd_precheck(shell, (argc == 1), NULL, 0);
+	int ret = shell_cmd_precheck(shell, (argc == 1));
 
 	if (ret == 0) {
 		shell->stats->log_lost_cnt = 0;
@@ -435,10 +435,10 @@ static int cmd_shell_stats(const struct shell *shell, size_t argc, char **argv)
 	ARG_UNUSED(argc);
 
 	if (shell_help_requested(shell)) {
-		shell_help_print(shell, NULL, 0);
+		shell_help_print(shell);
 		return 1;
 	} else if (argc == 1) {
-		shell_help_print(shell, NULL, 0);
+		shell_help_print(shell);
 	} else {
 		shell_fprintf(shell, SHELL_ERROR, "%s:%s%s\n", argv[0],
 			      SHELL_MSG_UNKNOWN_PARAMETER, argv[1]);
@@ -452,7 +452,7 @@ static int cmd_resize_default(const struct shell *shell,
 {
 	ARG_UNUSED(argv);
 
-	int ret = shell_cmd_precheck(shell, (argc == 1), NULL, 0);
+	int ret = shell_cmd_precheck(shell, (argc == 1));
 
 	if (ret == 0) {
 		SHELL_VT100_CMD(shell, SHELL_VT100_SETCOL_80);
@@ -474,7 +474,7 @@ static int cmd_resize(const struct shell *shell, size_t argc, char **argv)
 		return -ENOEXEC;
 	}
 
-	err = shell_cmd_precheck(shell, (argc <= 2), NULL, 0);
+	err = shell_cmd_precheck(shell, (argc <= 2));
 	if (err) {
 		return err;
 	}

--- a/subsys/shell/shell_help.c
+++ b/subsys/shell/shell_help.c
@@ -1,0 +1,210 @@
+/*
+ * Copyright (c) 2018 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+#include <ctype.h>
+#include "shell_ops.h"
+#include "shell_help.h"
+#include "shell_utils.h"
+
+/* Function prints a string on terminal screen with requested margin.
+ * It takes care to not divide words.
+ *   shell		Pointer to shell instance.
+ *   p_str		Pointer to string to be printed.
+ *   terminal_offset	Requested left margin.
+ *   offset_first_line	Add margin to the first printed line.
+ */
+static void formatted_text_print(const struct shell *shell, const char *str,
+				 size_t terminal_offset, bool offset_first_line)
+{
+	size_t offset = 0;
+	size_t length;
+
+	if (str == NULL) {
+		return;
+	}
+
+	if (offset_first_line) {
+		shell_op_cursor_horiz_move(shell, terminal_offset);
+	}
+
+
+	/* Skipping whitespace. */
+	while (isspace((int) *(str + offset))) {
+		++offset;
+	}
+
+	while (true) {
+		size_t idx = 0;
+
+		length = shell_strlen(str) - offset;
+
+		if (length <=
+		    shell->ctx->vt100_ctx.cons.terminal_wid - terminal_offset) {
+			for (idx = 0; idx < length; idx++) {
+				if (*(str + offset + idx) == '\n') {
+					transport_buffer_flush(shell);
+					shell_write(shell, str + offset, idx);
+					offset += idx + 1;
+					cursor_next_line_move(shell);
+					shell_op_cursor_horiz_move(shell,
+							terminal_offset);
+					break;
+				}
+			}
+
+			/* String will fit in one line. */
+			shell_raw_fprintf(shell->fprintf_ctx, str + offset);
+
+			break;
+		}
+
+		/* String is longer than terminal line so text needs to
+		 * divide in the way to not divide words.
+		 */
+		length = shell->ctx->vt100_ctx.cons.terminal_wid
+				- terminal_offset;
+
+		while (true) {
+			/* Determining line break. */
+			if (isspace((int) (*(str + offset + idx)))) {
+				length = idx;
+				if (*(str + offset + idx) == '\n') {
+					break;
+				}
+			}
+
+			if ((idx + terminal_offset) >=
+			    shell->ctx->vt100_ctx.cons.terminal_wid) {
+				/* End of line reached. */
+				break;
+			}
+
+			++idx;
+		}
+
+		/* Writing one line, fprintf IO buffer must be flushed
+		 * before calling shell_write.
+		 */
+		transport_buffer_flush(shell);
+		shell_write(shell, str + offset, length);
+		offset += length;
+
+		/* Calculating text offset to ensure that next line will
+		 * not begin with a space.
+		 */
+		while (isspace((int) (*(str + offset)))) {
+			++offset;
+		}
+
+		cursor_next_line_move(shell);
+		shell_op_cursor_horiz_move(shell, terminal_offset);
+
+	}
+	cursor_next_line_move(shell);
+}
+
+static void help_item_print(const struct shell *shell, const char *item_name,
+			    u16_t item_name_width, const char *item_help)
+{
+	static const u8_t tabulator[] = "  ";
+	const u16_t offset = 2 * strlen(tabulator) + item_name_width + 1;
+
+	if (item_name == NULL) {
+		return;
+	}
+
+	if (!IS_ENABLED(CONFIG_NEWLIB_LIBC) && !IS_ENABLED(CONFIG_ARCH_POSIX)) {
+		/* print option name */
+		shell_fprintf(shell, SHELL_NORMAL, "%s%-*s%s:",
+			      tabulator,
+			      item_name_width, item_name,
+			      tabulator);
+	} else {
+		u16_t tmp = item_name_width - strlen(item_name);
+		char space = ' ';
+
+		shell_fprintf(shell, SHELL_NORMAL, "%s%s", tabulator,
+			      item_name);
+		for (u16_t i = 0; i < tmp; i++) {
+			shell_write(shell, &space, 1);
+		}
+		shell_fprintf(shell, SHELL_NORMAL, "%s:", tabulator);
+	}
+
+	if (item_help == NULL) {
+		cursor_next_line_move(shell);
+		return;
+	}
+	/* print option help */
+	formatted_text_print(shell, item_help, offset, false);
+}
+
+/* Function is printing command help, its subcommands name and subcommands
+ * help string.
+ */
+void shell_help_subcmd_print(const struct shell *shell)
+{
+	const struct shell_static_entry *entry = NULL;
+	struct shell_static_entry static_entry;
+	u16_t longest_syntax = 0;
+	size_t cmd_idx = 0;
+
+	/* Checking if there are any subcommands available. */
+	if (!shell->ctx->active_cmd.subcmd) {
+		return;
+	}
+
+	/* Searching for the longest subcommand to print. */
+	do {
+		shell_cmd_get(shell->ctx->active_cmd.subcmd,
+			      !SHELL_CMD_ROOT_LVL,
+			      cmd_idx++, &entry, &static_entry);
+
+		if (!entry) {
+			break;
+		}
+
+		u16_t len = shell_strlen(entry->syntax);
+
+		longest_syntax = longest_syntax > len ? longest_syntax : len;
+	} while (cmd_idx != 0); /* too many commands */
+
+	if (cmd_idx == 1) {
+		return;
+	}
+
+	shell_fprintf(shell, SHELL_NORMAL, "Subcommands:\r\n");
+
+	/* Printing subcommands and help string (if exists). */
+	cmd_idx = 0;
+
+	while (true) {
+		shell_cmd_get(shell->ctx->active_cmd.subcmd,
+			      !SHELL_CMD_ROOT_LVL,
+			      cmd_idx++, &entry, &static_entry);
+
+		if (entry == NULL) {
+			break;
+		}
+
+		help_item_print(shell, entry->syntax, longest_syntax,
+				entry->help);
+	}
+}
+
+void shell_help_cmd_print(const struct shell *shell)
+{
+	static const char cmd_sep[] = " - ";	/* commands separator */
+
+	u16_t field_width = shell_strlen(shell->ctx->active_cmd.syntax) +
+							  shell_strlen(cmd_sep);
+
+	shell_fprintf(shell, SHELL_NORMAL, "%s%s",
+		      shell->ctx->active_cmd.syntax, cmd_sep);
+
+	formatted_text_print(shell, shell->ctx->active_cmd.help,
+			     field_width, false);
+}
+

--- a/subsys/shell/shell_help.h
+++ b/subsys/shell/shell_help.h
@@ -1,0 +1,30 @@
+/*
+ * Copyright (c) 2018 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef SHELL_HELP_H__
+#define SHELL_HELP_H__
+
+#include <shell/shell.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/* Function is printing command help string. */
+void shell_help_cmd_print(const struct shell *shell);
+
+/* Function is printing subcommands help string. */
+void shell_help_subcmd_print(const struct shell *shell);
+
+/**
+ * @}
+ */
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* SHELL_HELP__ */

--- a/subsys/shell/shell_ops.h
+++ b/subsys/shell/shell_ops.h
@@ -6,7 +6,6 @@
 #ifndef SHELL_OPS_H__
 #define SHELL_OPS_H__
 
-#include <zephyr.h>
 #include <shell/shell.h>
 #include "shell_vt100.h"
 #include "shell_utils.h"
@@ -121,6 +120,29 @@ void shell_op_completion_insert(const struct shell *shell,
 				u16_t compl_len);
 
 bool shell_cursor_in_empty_line(const struct shell *shell);
+
+/* Function sends data stream to the shell instance. Each time before the
+ * shell_write function is called, it must be ensured that IO buffer of fprintf
+ * is flushed to avoid synchronization issues.
+ * For that purpose, use function transport_buffer_flush(shell)
+ *
+ * This function can be only used by shell module, it shall not be called
+ * directly.
+ */
+void shell_write(const struct shell *shell, const void *data,
+		 size_t length);
+
+/**
+ * @internal @brief This function shall not be used directly, it is required by
+ *		    the fprintf module.
+ *
+ * @param[in] p_user_ctx    Pointer to the context for the shell instance.
+ * @param[in] p_data        Pointer to the data buffer.
+ * @param[in] data_len      Data buffer size.
+ */
+void shell_print_stream(const void *user_ctx, const char *data,
+			size_t data_len);
+
 #ifdef __cplusplus
 }
 #endif

--- a/subsys/shell/shell_utils.h
+++ b/subsys/shell/shell_utils.h
@@ -8,6 +8,7 @@
 
 #include <zephyr.h>
 #include <shell/shell.h>
+
 #ifdef __cplusplus
 extern "C" {
 #endif
@@ -42,8 +43,28 @@ char shell_make_argv(size_t *argc, char **argv, char *cmd, uint8_t max_argc);
  */
 void shell_pattern_remove(char *buff, u16_t *buff_len, const char *pattern);
 
+/* @brief Function shall be used to search commands.
+ *
+ * It moves the pointer entry to command of static command structure. If the
+ * command cannot be found, the function will set entry to NULL.
+ *
+ *   @param command	Pointer to command which will be processed (no matter
+ *			the root command).
+ *   @param lvl		Level of the requested command.
+ *   @param idx		Index of the requested command.
+ *   @param entry	Pointer which points to subcommand[idx] after function
+ *			execution.
+ *   @param st_entry	Pointer to the structure where dynamic entry data can be
+ *			stored.
+ */
+void shell_cmd_get(const struct shell_cmd_entry *command, size_t lvl,
+		   size_t idx, const struct shell_static_entry **entry,
+		   struct shell_static_entry *d_entry);
+
 int shell_command_add(char *buff, u16_t *buff_len,
 		      const char *new_cmd, const char *pattern);
+
+const struct shell_cmd_entry *root_cmd_find(const char *syntax);
 
 void shell_spaces_trim(char *str);
 
@@ -51,6 +72,11 @@ void shell_spaces_trim(char *str);
  *
  */
 void shell_buffer_trim(char *buff, u16_t *buff_len);
+
+static inline void transport_buffer_flush(const struct shell *shell)
+{
+	shell_fprintf_buffer_flush(shell->fprintf_ctx);
+}
 
 #ifdef __cplusplus
 }

--- a/tests/bluetooth/shell/src/main.c
+++ b/tests/bluetooth/shell/src/main.c
@@ -33,7 +33,7 @@ static bool hrs_simulate;
 static int cmd_hrs_simulate(const struct shell *shell,
 			    size_t argc, char *argv[])
 {
-	int err = shell_cmd_precheck(shell, (argc == 2), NULL, 0);
+	int err = shell_cmd_precheck(shell, (argc == 2));
 
 	if (err) {
 		return err;
@@ -55,7 +55,7 @@ static int cmd_hrs_simulate(const struct shell *shell,
 		hrs_simulate = false;
 	} else {
 		shell_print(shell, "Incorrect value: %s", argv[1]);
-		shell_help_print(shell, NULL, 0);
+		shell_help_print(shell);
 		return -ENOEXEC;
 	}
 
@@ -77,10 +77,10 @@ SHELL_CREATE_STATIC_SUBCMD_SET(hrs_cmds) {
 
 static int cmd_hrs(const struct shell *shell, size_t argc, char **argv)
 {
-	int err = shell_cmd_precheck(shell, (argc == 2), NULL, 0);
+	int err = shell_cmd_precheck(shell, (argc == 2));
 
 	if (argc == 1) {
-		shell_help_print(shell, NULL, 0);
+		shell_help_print(shell);
 		/* shell_cmd_precheck returns 1 when help is printed */
 		return 1;
 	}

--- a/tests/bluetooth/shell/src/main.c
+++ b/tests/bluetooth/shell/src/main.c
@@ -33,12 +33,6 @@ static bool hrs_simulate;
 static int cmd_hrs_simulate(const struct shell *shell,
 			    size_t argc, char *argv[])
 {
-	int err = shell_cmd_precheck(shell, (argc == 2));
-
-	if (err) {
-		return err;
-	}
-
 	if (!strcmp(argv[1], "on")) {
 		static bool hrs_registered;
 
@@ -68,34 +62,22 @@ static int cmd_hrs_simulate(const struct shell *shell,
 
 SHELL_CREATE_STATIC_SUBCMD_SET(hrs_cmds) {
 #if defined(CONFIG_BT_CONN)
-	SHELL_CMD(hrs-simulate, NULL,
-		  "register and simulate Heart Rate Service <value: on, off>",
-		  cmd_hrs_simulate),
+	SHELL_CMD_ARG(hrs-simulate, NULL,
+		"register and simulate Heart Rate Service <value: on, off>",
+		cmd_hrs_simulate, 2, 0),
 #endif /* CONFIG_BT_CONN */
 	SHELL_SUBCMD_SET_END
 };
 
 static int cmd_hrs(const struct shell *shell, size_t argc, char **argv)
 {
-	int err = shell_cmd_precheck(shell, (argc == 2));
-
-	if (argc == 1) {
-		shell_help_print(shell);
-		/* shell_cmd_precheck returns 1 when help is printed */
-		return 1;
-	}
-
-	if (err) {
-		return err;
-	}
-
 	shell_error(shell, "%s unknown parameter: %s", argv[0], argv[1]);
 
 	return -ENOEXEC;
 }
 
-SHELL_CMD_REGISTER(hrs, &hrs_cmds, "Heart Rate Service shell commands",
-		   cmd_hrs);
+SHELL_CMD_ARG_REGISTER(hrs, &hrs_cmds, "Heart Rate Service shell commands",
+		       cmd_hrs, 2, 0);
 
 void main(void)
 {

--- a/tests/bluetooth/shell/src/main.c
+++ b/tests/bluetooth/shell/src/main.c
@@ -49,7 +49,7 @@ static int cmd_hrs_simulate(const struct shell *shell,
 		hrs_simulate = false;
 	} else {
 		shell_print(shell, "Incorrect value: %s", argv[1]);
-		shell_help_print(shell);
+		shell_help(shell);
 		return -ENOEXEC;
 	}
 

--- a/tests/shell/src/main.c
+++ b/tests/shell/src/main.c
@@ -34,8 +34,8 @@ static void test_shell_execute_cmd(const char *cmd, int result)
 static void test_cmd_help(void)
 {
 	test_shell_execute_cmd("help", 0);
-	test_shell_execute_cmd("help -h", 0);
-	test_shell_execute_cmd("help --help", 0);
+	test_shell_execute_cmd("help -h", 1);
+	test_shell_execute_cmd("help --help", 1);
 	test_shell_execute_cmd("help dummy", 0);
 	test_shell_execute_cmd("help dummy dummy", 0);
 }
@@ -53,13 +53,13 @@ static void test_cmd_shell(void)
 {
 	test_shell_execute_cmd("shell -h", 1);
 	test_shell_execute_cmd("shell --help", 1);
-	test_shell_execute_cmd("shell dummy", -EINVAL);
-	test_shell_execute_cmd("shell dummy dummy", -EINVAL);
+	test_shell_execute_cmd("shell dummy", 1);
+	test_shell_execute_cmd("shell dummy dummy", 1);
 
 	/* subcommand: backspace_mode */
 	test_shell_execute_cmd("shell backspace_mode -h", 1);
 	test_shell_execute_cmd("shell backspace_mode --help", 1);
-	test_shell_execute_cmd("shell backspace_mode dummy", -EINVAL);
+	test_shell_execute_cmd("shell backspace_mode dummy", 1);
 
 	test_shell_execute_cmd("shell backspace_mode backspace", 0);
 	test_shell_execute_cmd("shell backspace_mode backspace -h", 1);
@@ -78,8 +78,8 @@ static void test_cmd_shell(void)
 	/* subcommand: colors */
 	test_shell_execute_cmd("shell colors -h", 1);
 	test_shell_execute_cmd("shell colors --help", 1);
-	test_shell_execute_cmd("shell colors dummy", -EINVAL);
-	test_shell_execute_cmd("shell colors dummy dummy", -EINVAL);
+	test_shell_execute_cmd("shell colors dummy", 1);
+	test_shell_execute_cmd("shell colors dummy dummy", 1);
 
 	test_shell_execute_cmd("shell colors off", 0);
 	test_shell_execute_cmd("shell colors off -h", 1);
@@ -113,11 +113,11 @@ static void test_cmd_shell(void)
 	test_shell_execute_cmd("shell echo on dummy dummy", -EINVAL);
 
 	/* subcommand: stats */
-	test_shell_execute_cmd("shell stats", -EINVAL);
+	test_shell_execute_cmd("shell stats", 1);
 	test_shell_execute_cmd("shell stats -h", 1);
 	test_shell_execute_cmd("shell stats --help", 1);
-	test_shell_execute_cmd("shell stats dummy", -EINVAL);
-	test_shell_execute_cmd("shell stats dummy dummy", -EINVAL);
+	test_shell_execute_cmd("shell stats dummy", 1);
+	test_shell_execute_cmd("shell stats dummy dummy", 1);
 
 	test_shell_execute_cmd("shell stats reset", 0);
 	test_shell_execute_cmd("shell stats reset -h", 1);
@@ -195,10 +195,11 @@ static void test_shell_wildcards_dynamic(void)
 static int cmd_test_module(const struct shell *shell, size_t argc, char **argv)
 {
 	ARG_UNUSED(argv);
+	ARG_UNUSED(argc);
 
-	return shell_cmd_precheck(shell, (argc == 1));
+	return 0;
 }
-SHELL_CMD_REGISTER(test_shell_cmd, NULL, NULL, cmd_test_module);
+SHELL_CMD_ARG_REGISTER(test_shell_cmd, NULL, "help", cmd_test_module, 1, 0);
 
 
 static int cmd_wildcard(const struct shell *shell, size_t argc, char **argv)

--- a/tests/shell/src/main.c
+++ b/tests/shell/src/main.c
@@ -196,7 +196,7 @@ static int cmd_test_module(const struct shell *shell, size_t argc, char **argv)
 {
 	ARG_UNUSED(argv);
 
-	return shell_cmd_precheck(shell, (argc == 1), NULL, 0);
+	return shell_cmd_precheck(shell, (argc == 1));
 }
 SHELL_CMD_REGISTER(test_shell_cmd, NULL, NULL, cmd_test_module);
 


### PR DESCRIPTION
I have decided to remove options concept as it was not used by anyone. Options are commands starting with `-`. From user perspective I have removed:
- macro to create options: `SHELL_OPT`
- help functionality to print **options help string** when command is called with `-h` or `--help`
Command and its subcommands help string will be still available when user will call it with `-h` or `--help`.

As a result this change allowed to simplify help usage. **With new implementation user will not need to bother to implement help handler inside a command handler.** In addition it shall save a lot of flash  by removing already implemented help handlers.

Apart from that I have moved shell help functionality to separate module: `shell_help.c` and `shell_help.h` and I've update CMakeList accordingly.

And last but not least I have removed `shell_cmd_precheck` from API and command handlers and replaced it with recently added macros: `SHELL_CMD_ARG_REGISTER` and `SHELL_CMD_ARG`. This change also saved some Flash.