### PR TITLE
Misra 17 7 fixes

### DIFF
--- a/drivers/serial/leuart_gecko.c
+++ b/drivers/serial/leuart_gecko.c
@@ -50,7 +50,7 @@ static int leuart_gecko_poll_in(struct device *dev, unsigned char *c)
 	return -1;
 }
 
-static unsigned char leuart_gecko_poll_out(struct device *dev, unsigned char c)
+static void leuart_gecko_poll_out(struct device *dev, unsigned char c)
 {
 	LEUART_TypeDef *base = DEV_BASE(dev);
 
@@ -58,8 +58,6 @@ static unsigned char leuart_gecko_poll_out(struct device *dev, unsigned char c)
 	 * and and waits for the bus to be free to transmit.
 	 */
 	LEUART_Tx(base, c);
-
-	return c;
 }
 
 static int leuart_gecko_err_check(struct device *dev)

--- a/drivers/serial/uart_altera_jtag_hal.c
+++ b/drivers/serial/uart_altera_jtag_hal.c
@@ -24,7 +24,7 @@ extern int altera_avalon_jtag_uart_read(altera_avalon_jtag_uart_state *sp,
 extern int altera_avalon_jtag_uart_write(altera_avalon_jtag_uart_state *sp,
 		const char *ptr, int count, int flags);
 
-static unsigned char uart_altera_jtag_poll_out(struct device *dev,
+static void uart_altera_jtag_poll_out(struct device *dev,
 					       unsigned char c)
 {
 	const struct uart_device_config *config;
@@ -34,8 +34,6 @@ static unsigned char uart_altera_jtag_poll_out(struct device *dev,
 
 	ustate.base = JTAG_UART_0_BASE;
 	altera_avalon_jtag_uart_write(&ustate, &c, 1, 0);
-
-	return c;
 }
 
 static int uart_altera_jtag_init(struct device *dev)

--- a/drivers/serial/uart_cc32xx.c
+++ b/drivers/serial/uart_cc32xx.c
@@ -102,13 +102,11 @@ static int uart_cc32xx_poll_in(struct device *dev, unsigned char *c)
 	return 0;
 }
 
-static unsigned char uart_cc32xx_poll_out(struct device *dev, unsigned char c)
+static void uart_cc32xx_poll_out(struct device *dev, unsigned char c)
 {
 	const struct uart_device_config *config = DEV_CFG(dev);
 
 	MAP_UARTCharPut((unsigned long)config->base, c);
-
-	return c;
 }
 
 static int uart_cc32xx_err_check(struct device *dev)

--- a/drivers/serial/uart_cmsdk_apb.c
+++ b/drivers/serial/uart_cmsdk_apb.c
@@ -185,10 +185,8 @@ static int uart_cmsdk_apb_poll_in(struct device *dev, unsigned char *c)
  *
  * @param dev UART device struct
  * @param c Character to send
- *
- * @return Sent character
  */
-static unsigned char uart_cmsdk_apb_poll_out(struct device *dev,
+static void uart_cmsdk_apb_poll_out(struct device *dev,
 					     unsigned char c)
 {
 	volatile struct uart_cmsdk_apb *uart = UART_STRUCT(dev);
@@ -200,7 +198,6 @@ static unsigned char uart_cmsdk_apb_poll_out(struct device *dev,
 
 	/* Send a character */
 	uart->data = (u32_t)c;
-	return c;
 }
 
 #ifdef CONFIG_UART_INTERRUPT_DRIVEN

--- a/drivers/serial/uart_esp32.c
+++ b/drivers/serial/uart_esp32.c
@@ -11,14 +11,12 @@
 #include <uart.h>
 #include <errno.h>
 
-static unsigned char esp32_uart_tx(struct device *dev,
+static void esp32_uart_tx(struct device *dev,
 				   unsigned char c)
 {
 	ARG_UNUSED(dev);
 
 	esp32_rom_uart_tx_one_char(c);
-
-	return c;
 }
 
 static int esp32_uart_rx(struct device *dev, unsigned char *p_char)

--- a/drivers/serial/uart_gecko.c
+++ b/drivers/serial/uart_gecko.c
@@ -43,13 +43,11 @@ static int uart_gecko_poll_in(struct device *dev, unsigned char *c)
 	return -1;
 }
 
-static unsigned char uart_gecko_poll_out(struct device *dev, unsigned char c)
+static void uart_gecko_poll_out(struct device *dev, unsigned char c)
 {
 	const struct uart_gecko_config *config = dev->config->config_info;
 
 	USART_Tx(config->base, c);
-
-	return c;
 }
 
 static int uart_gecko_err_check(struct device *dev)

--- a/drivers/serial/uart_handlers.c
+++ b/drivers/serial/uart_handlers.c
@@ -33,7 +33,9 @@ Z_SYSCALL_HANDLER(uart_poll_in, dev, p_char)
 Z_SYSCALL_HANDLER(uart_poll_out, dev, out_char)
 {
 	Z_OOPS(Z_SYSCALL_DRIVER_UART(dev, poll_out));
-	return _impl_uart_poll_out((struct device *)dev, out_char);
+	_impl_uart_poll_out((struct device *)dev, out_char);
+
+	return 0;
 }
 
 #ifdef CONFIG_UART_INTERRUPT_DRIVEN

--- a/drivers/serial/uart_imx.c
+++ b/drivers/serial/uart_imx.c
@@ -94,15 +94,13 @@ static int uart_imx_init(struct device *dev)
 	return 0;
 }
 
-static unsigned char uart_imx_poll_out(struct device *dev, unsigned char c)
+static void uart_imx_poll_out(struct device *dev, unsigned char c)
 {
 	UART_Type *uart = UART_STRUCT(dev);
 
 	while (!UART_GetStatusFlag(uart, uartStatusTxReady))
 		;
 	UART_Putchar(uart, c);
-
-	return c;
 }
 
 static int uart_imx_poll_in(struct device *dev, unsigned char *c)

--- a/drivers/serial/uart_mcux.c
+++ b/drivers/serial/uart_mcux.c
@@ -42,7 +42,7 @@ static int uart_mcux_poll_in(struct device *dev, unsigned char *c)
 	return ret;
 }
 
-static unsigned char uart_mcux_poll_out(struct device *dev, unsigned char c)
+static void uart_mcux_poll_out(struct device *dev, unsigned char c)
 {
 	const struct uart_mcux_config *config = dev->config->config_info;
 
@@ -50,8 +50,6 @@ static unsigned char uart_mcux_poll_out(struct device *dev, unsigned char c)
 		;
 
 	UART_WriteByte(config->base, c);
-
-	return c;
 }
 
 static int uart_mcux_err_check(struct device *dev)

--- a/drivers/serial/uart_mcux_lpsci.c
+++ b/drivers/serial/uart_mcux_lpsci.c
@@ -42,7 +42,7 @@ static int mcux_lpsci_poll_in(struct device *dev, unsigned char *c)
 	return ret;
 }
 
-static unsigned char mcux_lpsci_poll_out(struct device *dev, unsigned char c)
+static void mcux_lpsci_poll_out(struct device *dev, unsigned char c)
 {
 	const struct mcux_lpsci_config *config = dev->config->config_info;
 
@@ -51,8 +51,6 @@ static unsigned char mcux_lpsci_poll_out(struct device *dev, unsigned char c)
 		;
 
 	LPSCI_WriteByte(config->base, c);
-
-	return c;
 }
 
 static int mcux_lpsci_err_check(struct device *dev)

--- a/drivers/serial/uart_mcux_lpuart.c
+++ b/drivers/serial/uart_mcux_lpuart.c
@@ -42,7 +42,7 @@ static int mcux_lpuart_poll_in(struct device *dev, unsigned char *c)
 	return ret;
 }
 
-static unsigned char mcux_lpuart_poll_out(struct device *dev, unsigned char c)
+static void mcux_lpuart_poll_out(struct device *dev, unsigned char c)
 {
 	const struct mcux_lpuart_config *config = dev->config->config_info;
 
@@ -51,8 +51,6 @@ static unsigned char mcux_lpuart_poll_out(struct device *dev, unsigned char c)
 		;
 
 	LPUART_WriteByte(config->base, c);
-
-	return c;
 }
 
 static int mcux_lpuart_err_check(struct device *dev)

--- a/drivers/serial/uart_miv.c
+++ b/drivers/serial/uart_miv.c
@@ -150,7 +150,7 @@ struct uart_miv_data {
 #define DEV_DATA(dev)						\
 	((struct uart_miv_data * const)(dev)->driver_data)
 
-static unsigned char uart_miv_poll_out(struct device *dev,
+static void uart_miv_poll_out(struct device *dev,
 				       unsigned char c)
 {
 	volatile struct uart_miv_regs_t *uart = DEV_UART(dev);
@@ -159,8 +159,6 @@ static unsigned char uart_miv_poll_out(struct device *dev,
 		;
 
 	uart->tx = c;
-
-	return c;
 }
 
 static int uart_miv_poll_in(struct device *dev, unsigned char *c)

--- a/drivers/serial/uart_msp432p4xx.c
+++ b/drivers/serial/uart_msp432p4xx.c
@@ -163,14 +163,12 @@ static int uart_msp432p4xx_poll_in(struct device *dev, unsigned char *c)
 	return 0;
 }
 
-static unsigned char uart_msp432p4xx_poll_out(struct device *dev,
-							unsigned char c)
+static void uart_msp432p4xx_poll_out(struct device *dev,
+				     unsigned char c)
 {
 	const struct uart_device_config *config = DEV_CFG(dev);
 
 	MAP_UART_transmitData((unsigned long)config->base, c);
-
-	return c;
 }
 
 #ifdef CONFIG_UART_INTERRUPT_DRIVEN

--- a/drivers/serial/uart_native_posix.c
+++ b/drivers/serial/uart_native_posix.c
@@ -34,7 +34,7 @@
 
 static int np_uart_stdin_poll_in(struct device *dev, unsigned char *p_char);
 static int np_uart_tty_poll_in(struct device *dev, unsigned char *p_char);
-static unsigned char np_uart_poll_out(struct device *dev,
+static void np_uart_poll_out(struct device *dev,
 				      unsigned char out_char);
 
 static bool auto_attach;
@@ -200,7 +200,7 @@ static int np_uart_init(struct device *dev)
  * @param dev UART device struct
  * @param out_char Character to send.
  */
-static unsigned char np_uart_poll_out(struct device *dev,
+static void np_uart_poll_out(struct device *dev,
 				      unsigned char out_char)
 {
 	int ret;
@@ -212,8 +212,6 @@ static unsigned char np_uart_poll_out(struct device *dev,
 	if (ret != 1) {
 		WARN("%s: a character could not be output\n", __func__);
 	}
-
-	return out_char;
 }
 
 /**

--- a/drivers/serial/uart_nrfx_uart.c
+++ b/drivers/serial/uart_nrfx_uart.c
@@ -165,10 +165,8 @@ static int uart_nrfx_poll_in(struct device *dev, unsigned char *c)
  *
  * @param dev UART device struct
  * @param c Character to send
- *
- * @return Sent character
  */
-static unsigned char uart_nrfx_poll_out(struct device *dev,
+static void uart_nrfx_poll_out(struct device *dev,
 					unsigned char c)
 {
 	/* The UART API dictates that poll_out should wait for the transmitter
@@ -199,8 +197,6 @@ static unsigned char uart_nrfx_poll_out(struct device *dev,
 	 * power.
 	 */
 	nrf_uart_task_trigger(uart0_addr, NRF_UART_TASK_STOPTX);
-
-	return c;
 }
 
 /** Console I/O function */

--- a/drivers/serial/uart_nrfx_uarte.c
+++ b/drivers/serial/uart_nrfx_uarte.c
@@ -224,10 +224,8 @@ static int uarte_nrfx_poll_in(struct device *dev, unsigned char *c)
  *
  * @param dev UARTE device struct
  * @param c Character to send
- *
- * @return Sent character
  */
-static unsigned char uarte_nrfx_poll_out(struct device *dev,
+static void uarte_nrfx_poll_out(struct device *dev,
 					 unsigned char c)
 {
 	NRF_UARTE_Type *uarte = get_uarte_instance(dev);
@@ -264,8 +262,6 @@ static unsigned char uarte_nrfx_poll_out(struct device *dev,
 	 * when TX is stopped.
 	 */
 	nrf_uarte_task_trigger(uarte, NRF_UARTE_TASK_STOPTX);
-
-	return c;
 }
 
 static int uarte_nrfx_err_check(struct device *dev)

--- a/drivers/serial/uart_ns16550.c
+++ b/drivers/serial/uart_ns16550.c
@@ -395,10 +395,8 @@ static int uart_ns16550_poll_in(struct device *dev, unsigned char *c)
  *
  * @param dev UART device struct
  * @param c Character to send
- *
- * @return Sent character
  */
-static unsigned char uart_ns16550_poll_out(struct device *dev,
+static void uart_ns16550_poll_out(struct device *dev,
 					   unsigned char c)
 {
 	/* wait for transmitter to ready to accept a character */
@@ -406,8 +404,6 @@ static unsigned char uart_ns16550_poll_out(struct device *dev,
 		;
 
 	OUTBYTE(THR(dev), c);
-
-	return c;
 }
 
 /**

--- a/drivers/serial/uart_nsim.c
+++ b/drivers/serial/uart_nsim.c
@@ -87,7 +87,7 @@ static int uart_nsim_init(struct device *dev)
  * @param dev UART device struct
  * @param c character to output
  */
-unsigned char uart_nsim_poll_out(struct device *dev, unsigned char c)
+static void uart_nsim_poll_out(struct device *dev, unsigned char c)
 {
 	u32_t regs = DEV_CFG(dev)->regs;
 	/* wait for transmitter to ready to accept a character */
@@ -96,8 +96,6 @@ unsigned char uart_nsim_poll_out(struct device *dev, unsigned char c)
 		;
 
 	UART_SET_DATA(regs, c);
-
-	return c;
 }
 
 static int uart_nsim_poll_in(struct device *dev, unsigned char *c)

--- a/drivers/serial/uart_psoc6.c
+++ b/drivers/serial/uart_psoc6.c
@@ -118,14 +118,12 @@ static int uart_psoc6_poll_in(struct device *dev, unsigned char *c)
 	return ((rec == CY_SCB_UART_RX_NO_DATA) ? -1 : 0);
 }
 
-static unsigned char uart_psoc6_poll_out(struct device *dev, unsigned char c)
+static void uart_psoc6_poll_out(struct device *dev, unsigned char c)
 {
 	const struct cypress_psoc6_config *config = dev->config->config_info;
 
 	while (Cy_SCB_UART_Put(config->base, (uint32_t)c) != 1UL)
 		;
-
-	return c;
 }
 
 static const struct uart_driver_api uart_psoc6_driver_api = {

--- a/drivers/serial/uart_qmsi.c
+++ b/drivers/serial/uart_qmsi.c
@@ -202,13 +202,12 @@ static int uart_qmsi_poll_in(struct device *dev, unsigned char *data)
 	return 0;
 }
 
-static unsigned char uart_qmsi_poll_out(struct device *dev,
+static void uart_qmsi_poll_out(struct device *dev,
 					unsigned char data)
 {
 	qm_uart_t instance = GET_CONTROLLER_INSTANCE(dev);
 
 	qm_uart_write(instance, data);
-	return data;
 }
 
 static int uart_qmsi_err_check(struct device *dev)

--- a/drivers/serial/uart_sam.c
+++ b/drivers/serial/uart_sam.c
@@ -153,7 +153,7 @@ static int uart_sam_poll_in(struct device *dev, unsigned char *c)
 	return 0;
 }
 
-static unsigned char uart_sam_poll_out(struct device *dev, unsigned char c)
+static void uart_sam_poll_out(struct device *dev, unsigned char c)
 {
 	Uart *const uart = DEV_CFG(dev)->regs;
 
@@ -163,7 +163,6 @@ static unsigned char uart_sam_poll_out(struct device *dev, unsigned char c)
 
 	/* send a character */
 	uart->UART_THR = (u32_t)c;
-	return c;
 }
 
 static int uart_sam_err_check(struct device *dev)

--- a/drivers/serial/uart_sam0.c
+++ b/drivers/serial/uart_sam0.c
@@ -134,7 +134,7 @@ static int uart_sam0_poll_in(struct device *dev, unsigned char *c)
 	return 0;
 }
 
-static unsigned char uart_sam0_poll_out(struct device *dev, unsigned char c)
+static void uart_sam0_poll_out(struct device *dev, unsigned char c)
 {
 	SercomUsart *const usart = DEV_CFG(dev)->regs;
 
@@ -143,7 +143,6 @@ static unsigned char uart_sam0_poll_out(struct device *dev, unsigned char c)
 
 	/* send a character */
 	usart->DATA.reg = c;
-	return c;
 }
 
 #if CONFIG_UART_INTERRUPT_DRIVEN

--- a/drivers/serial/uart_sifive.c
+++ b/drivers/serial/uart_sifive.c
@@ -77,10 +77,8 @@ struct uart_sifive_data {
  *
  * @param dev UART device struct
  * @param c Character to send
- *
- * @return Sent character
  */
-static unsigned char uart_sifive_poll_out(struct device *dev,
+static void uart_sifive_poll_out(struct device *dev,
 					 unsigned char c)
 {
 	volatile struct uart_sifive_regs_t *uart = DEV_UART(dev);
@@ -90,8 +88,6 @@ static unsigned char uart_sifive_poll_out(struct device *dev,
 		;
 
 	uart->tx = (int)c;
-
-	return c;
 }
 
 /**

--- a/drivers/serial/uart_stellaris.c
+++ b/drivers/serial/uart_stellaris.c
@@ -321,10 +321,8 @@ static int uart_stellaris_poll_in(struct device *dev, unsigned char *c)
  *
  * @param dev UART device struct
  * @param c Character to send
- *
- * @return Sent character
  */
-static unsigned char uart_stellaris_poll_out(struct device *dev,
+static void uart_stellaris_poll_out(struct device *dev,
 					     unsigned char c)
 {
 	volatile struct _uart *uart = UART_STRUCT(dev);
@@ -334,7 +332,6 @@ static unsigned char uart_stellaris_poll_out(struct device *dev,
 
 	/* send a character */
 	uart->dr = (u32_t)c;
-	return c;
 }
 
 #if CONFIG_UART_INTERRUPT_DRIVEN

--- a/drivers/serial/uart_stm32.c
+++ b/drivers/serial/uart_stm32.c
@@ -50,7 +50,7 @@ static int uart_stm32_poll_in(struct device *dev, unsigned char *c)
 	return 0;
 }
 
-static unsigned char uart_stm32_poll_out(struct device *dev,
+static void uart_stm32_poll_out(struct device *dev,
 					unsigned char c)
 {
 	USART_TypeDef *UartInstance = UART_STRUCT(dev);
@@ -62,8 +62,6 @@ static unsigned char uart_stm32_poll_out(struct device *dev,
 	LL_USART_ClearFlag_TC(UartInstance);
 
 	LL_USART_TransmitData8(UartInstance, (u8_t)c);
-
-	return c;
 }
 
 static inline void __uart_stm32_get_clock(struct device *dev)

--- a/drivers/serial/usart_mcux_lpc.c
+++ b/drivers/serial/usart_mcux_lpc.c
@@ -45,7 +45,7 @@ static int usart_mcux_lpc_poll_in(struct device *dev, unsigned char *c)
 	return ret;
 }
 
-static unsigned char usart_mcux_lpc_poll_out(struct device *dev,
+static void usart_mcux_lpc_poll_out(struct device *dev,
 					     unsigned char c)
 {
 	const struct usart_mcux_lpc_config *config = dev->config->config_info;
@@ -55,8 +55,6 @@ static unsigned char usart_mcux_lpc_poll_out(struct device *dev,
 		;
 
 	USART_WriteByte(config->base, c);
-
-	return c;
 }
 
 static int usart_mcux_lpc_err_check(struct device *dev)

--- a/drivers/serial/usart_sam.c
+++ b/drivers/serial/usart_sam.c
@@ -138,7 +138,7 @@ static int usart_sam_poll_in(struct device *dev, unsigned char *c)
 	return 0;
 }
 
-static unsigned char usart_sam_poll_out(struct device *dev, unsigned char c)
+static void usart_sam_poll_out(struct device *dev, unsigned char c)
 {
 	Usart *const usart = DEV_CFG(dev)->regs;
 
@@ -149,7 +149,6 @@ static unsigned char usart_sam_poll_out(struct device *dev, unsigned char c)
 
 	/* send a character */
 	usart->US_THR = (u32_t)c;
-	return c;
 }
 
 static int usart_sam_err_check(struct device *dev)

--- a/include/uart.h
+++ b/include/uart.h
@@ -177,7 +177,7 @@ struct uart_device_config {
 struct uart_driver_api {
 	/** Console I/O function */
 	int (*poll_in)(struct device *dev, unsigned char *p_char);
-	unsigned char (*poll_out)(struct device *dev, unsigned char out_char);
+	void (*poll_out)(struct device *dev, unsigned char out_char);
 
 	/** Console I/O function */
 	int (*err_check)(struct device *dev);
@@ -303,19 +303,17 @@ static inline int _impl_uart_poll_in(struct device *dev, unsigned char *p_char)
  *
  * @param dev UART device structure.
  * @param out_char Character to send.
- *
- * @retval char Sent character.
  */
-__syscall unsigned char uart_poll_out(struct device *dev,
+__syscall void uart_poll_out(struct device *dev,
 				      unsigned char out_char);
 
-static inline unsigned char _impl_uart_poll_out(struct device *dev,
+static inline void _impl_uart_poll_out(struct device *dev,
 						unsigned char out_char)
 {
 	const struct uart_driver_api *api =
 		(const struct uart_driver_api *)dev->driver_api;
 
-	return api->poll_out(dev, out_char);
+	api->poll_out(dev, out_char);
 }
 
 /**

--- a/lib/posix/mqueue.c
+++ b/lib/posix/mqueue.c
@@ -144,7 +144,7 @@ mqd_t mq_open(const char *name, int oflags, ...)
 			goto free_mq_buffer;
 		}
 
-		atomic_set(&msg_queue->ref_count, 1);
+		(void)atomic_set(&msg_queue->ref_count, 1);
 		/* initialize zephyr message queue */
 		k_msgq_init(&msg_queue->queue, msg_queue->mem_buffer, msg_size,
 			    max_msgs);

--- a/subsys/logging/log_core.c
+++ b/subsys/logging/log_core.c
@@ -553,7 +553,7 @@ char *log_strdup(const char *str)
 	}
 
 	/* Set 'allocated' flag. */
-	atomic_set(&dup->refcount, 1);
+	(void)atomic_set(&dup->refcount, 1);
 
 	strncpy(dup->buf, str, sizeof(dup->buf) - 2);
 	dup->buf[sizeof(dup->buf) - 2] = '~';

--- a/subsys/usb/class/cdc_acm.c
+++ b/subsys/usb/class/cdc_acm.c
@@ -898,16 +898,12 @@ static int cdc_acm_poll_in(struct device *dev, unsigned char *c)
  *
  * The UART poll method for USB UART is simulated by waiting till
  * we get the next BULK In upcall from the USB device controller or 100 ms.
- *
- * @return the same character which is sent
  */
-static unsigned char cdc_acm_poll_out(struct device *dev,
+static void cdc_acm_poll_out(struct device *dev,
 				      unsigned char c)
 {
 	cdc_acm_fifo_fill(dev, &c, 1);
 	k_sem_take(&poll_wait_sem, K_MSEC(100));
-
-	return c;
 }
 
 static const struct uart_driver_api cdc_acm_driver_api = {

--- a/tests/drivers/uart/uart_basic_api/src/test_uart_poll.c
+++ b/tests/drivers/uart/uart_basic_api/src/test_uart_poll.c
@@ -38,7 +38,6 @@ static int test_poll_in(void)
 static int test_poll_out(void)
 {
 	int i;
-	unsigned char sent_char;
 	struct device *uart_dev = device_get_binding(UART_DEVICE_NAME);
 
 	if (!uart_dev) {
@@ -48,13 +47,7 @@ static int test_poll_out(void)
 
 	/* Verify uart_poll_out() */
 	for (i = 0; i < strlen(poll_data); i++) {
-		sent_char = uart_poll_out(uart_dev, poll_data[i]);
-
-		if (sent_char != poll_data[i]) {
-			TC_PRINT("expect send %c, actaul send %c\n",
-						poll_data[i], sent_char);
-			return TC_FAIL;
-		}
+		uart_poll_out(uart_dev, poll_data[i]);
 	}
 
 	return TC_PASS;


### PR DESCRIPTION
This rule says that the return of a non-void function must be checked.