### PR TITLE
bluetooth: Updated comment in conn.h to clarify PoV

### DIFF
--- a/include/bluetooth/conn.h
+++ b/include/bluetooth/conn.h
@@ -112,8 +112,8 @@ enum {
 
 /** LE Connection Info Structure */
 struct bt_conn_le_info {
-	const bt_addr_le_t *src; /** Source Address */
-	const bt_addr_le_t *dst; /** Destination Address */
+	const bt_addr_le_t *src; /** Source (Local) Address */
+	const bt_addr_le_t *dst; /** Destination (Remote) Address */
 	u16_t interval; /** Connection interval */
 	u16_t latency; /** Connection slave latency */
 	u16_t timeout; /** Connection supervision timeout */
@@ -121,7 +121,7 @@ struct bt_conn_le_info {
 
 /** BR/EDR Connection Info Structure */
 struct bt_conn_br_info {
-	const bt_addr_t *dst; /** Destination BR/EDR address */
+	const bt_addr_t *dst; /** Destination (Remote) BR/EDR address */
 };
 
 /** Connection role (master or slave) */


### PR DESCRIPTION
In conn.h the comments on src/dst in bt_conn_le_info and bt_conn_br_info does not clearly state the point of view. src could both be perceived as the connections point of view (src = local address) or the call-back where the structs are used point of view (src = remote address).
The comment about this has been made more clear.

Signed-off-by: Theis Blickfeldt <ttjo@oticon.com>