### PR TITLE
Bluetooth: Remove PRINTK dependency from BT_SETTINGS

### DIFF
--- a/subsys/bluetooth/host/Kconfig
+++ b/subsys/bluetooth/host/Kconfig
@@ -138,7 +138,7 @@ config BT_HOST_CRYPTO
 
 config BT_SETTINGS
 	bool "Store Bluetooth state and configuration persistently"
-	depends on SETTINGS && PRINTK
+	depends on SETTINGS
 	select MPU_ALLOW_FLASH_WRITE if ARM_MPU
 	help
 	  When selected, the Bluetooth stack will take care of storing


### PR DESCRIPTION
BT_SETTINGS does not depend on PRINTK.

This fixes issue #10143

Signed-off-by: Peter Herager <pehe@oticon.com>

