### PR TITLE
shell: remove Console dependencies

### DIFF
--- a/boards/arc/arduino_101_sss/arduino_101_sss.dts
+++ b/boards/arc/arduino_101_sss/arduino_101_sss.dts
@@ -24,6 +24,7 @@
 		zephyr,sram = &sram0;
 		zephyr,flash = &flash0;
 		zephyr,console = &uart1;
+		zephyr,shell-uart = &uart1;
 	};
 
 	leds {

--- a/boards/arc/em_starterkit/em_starterkit.dts
+++ b/boards/arc/em_starterkit/em_starterkit.dts
@@ -24,6 +24,7 @@
 	chosen {
 		zephyr,sram = &dccm0;
 		zephyr,console = &uart1;
+		zephyr,shell-uart = &uart1;
 	};
 
 	iccm@0 {

--- a/boards/arc/em_starterkit/em_starterkit_em11d.dts
+++ b/boards/arc/em_starterkit/em_starterkit_em11d.dts
@@ -24,6 +24,7 @@
 	chosen {
 		zephyr,sram = &ddr0;
 		zephyr,console = &uart1;
+		zephyr,shell-uart = &uart1;
 	};
 
 	iccm@0 {

--- a/boards/arc/em_starterkit/em_starterkit_em7d.dts
+++ b/boards/arc/em_starterkit/em_starterkit_em7d.dts
@@ -24,6 +24,7 @@
 	chosen {
 		zephyr,sram = &ddr0;
 		zephyr,console = &uart1;
+		zephyr,shell-uart = &uart1;
 	};
 
 	iccm@0 {

--- a/boards/arc/em_starterkit/em_starterkit_em7d_v22.dts
+++ b/boards/arc/em_starterkit/em_starterkit_em7d_v22.dts
@@ -24,6 +24,7 @@
 	chosen {
 		zephyr,sram = &ddr0;
 		zephyr,console = &uart1;
+		zephyr,shell-uart = &uart1;
 	};
 
 	iccm@0 {

--- a/boards/arc/quark_se_c1000_ss_devboard/quark_se_c1000_ss_devboard.dts
+++ b/boards/arc/quark_se_c1000_ss_devboard/quark_se_c1000_ss_devboard.dts
@@ -26,6 +26,7 @@
 		zephyr,sram = &sram0;
 		zephyr,flash = &flash0;
 		zephyr,console = &uart1;
+		zephyr,shell-uart = &uart1;
 	};
 
 	leds {

--- a/boards/arm/96b_argonkey/96b_argonkey.dts
+++ b/boards/arm/96b_argonkey/96b_argonkey.dts
@@ -13,6 +13,7 @@
 
 	chosen {
 		zephyr,console = &usart1;
+		zephyr,shell-uart = &usart1;
 		zephyr,sram = &sram0;
 		zephyr,flash = &flash0;
 	};

--- a/boards/arm/96b_carbon/96b_carbon.dts
+++ b/boards/arm/96b_carbon/96b_carbon.dts
@@ -13,6 +13,7 @@
 
 	chosen {
 		zephyr,console = &usart1;
+		zephyr,shell-uart = &usart1;
 		zephyr,sram = &sram0;
 		zephyr,flash = &flash0;
 	};

--- a/boards/arm/96b_carbon_nrf51/96b_carbon_nrf51.dts
+++ b/boards/arm/96b_carbon_nrf51/96b_carbon_nrf51.dts
@@ -14,6 +14,7 @@
 
 	chosen {
 		zephyr,console = &uart0;
+		zephyr,shell-uart = &uart0;
 		zephyr,sram = &sram0;
 		zephyr,flash = &flash0;
 	};

--- a/boards/arm/96b_neonkey/96b_neonkey.dts
+++ b/boards/arm/96b_neonkey/96b_neonkey.dts
@@ -13,6 +13,7 @@
 
 	chosen {
 		zephyr,console = &usart1;
+		zephyr,shell-uart = &usart1;
 		zephyr,sram = &sram0;
 		zephyr,flash = &flash0;
 	};

--- a/boards/arm/96b_nitrogen/96b_nitrogen.dts
+++ b/boards/arm/96b_nitrogen/96b_nitrogen.dts
@@ -14,6 +14,7 @@
 
 	chosen {
 		zephyr,console = &uart0;
+		zephyr,shell-uart = &uart0;
 		zephyr,sram = &sram0;
 		zephyr,flash = &flash0;
 	};

--- a/boards/arm/adafruit_feather_m0_basic_proto/adafruit_feather_m0_basic_proto.dts
+++ b/boards/arm/adafruit_feather_m0_basic_proto/adafruit_feather_m0_basic_proto.dts
@@ -14,6 +14,7 @@
 
 	chosen {
 		zephyr,console = &sercom0;
+		zephyr,shell-uart = &sercom0;
 		zephyr,sram = &sram0;
 		zephyr,flash = &flash0;
 		zephyr,code-partition = &code_partition;

--- a/boards/arm/adafruit_trinket_m0/adafruit_trinket_m0.dts
+++ b/boards/arm/adafruit_trinket_m0/adafruit_trinket_m0.dts
@@ -13,6 +13,7 @@
 
 	chosen {
 		zephyr,console = &sercom0;
+		zephyr,shell-uart = &sercom0;
 		zephyr,sram = &sram0;
 		zephyr,flash = &flash0;
 		zephyr,code-partition = &code_partition;

--- a/boards/arm/arduino_due/arduino_due.dts
+++ b/boards/arm/arduino_due/arduino_due.dts
@@ -17,6 +17,7 @@
 		zephyr,sram = &sram0;
 		zephyr,flash = &flash0;
 		zephyr,console = &uart0;
+		zephyr,shell-uart = &uart0;
 	};
 };
 

--- a/boards/arm/arduino_zero/arduino_zero.dts
+++ b/boards/arm/arduino_zero/arduino_zero.dts
@@ -13,6 +13,7 @@
 
 	chosen {
 		zephyr,console = &sercom5;
+		zephyr,shell-uart = &sercom5;
 		zephyr,sram = &sram0;
 		zephyr,flash = &flash0;
 	};

--- a/boards/arm/atsamd20_xpro/atsamd20_xpro.dts
+++ b/boards/arm/atsamd20_xpro/atsamd20_xpro.dts
@@ -18,6 +18,7 @@
 
 	chosen {
 		zephyr,console = &sercom3;
+		zephyr,shell-uart = &sercom3;
 		zephyr,sram = &sram0;
 		zephyr,flash = &flash0;
 	};

--- a/boards/arm/atsamd21_xpro/atsamd21_xpro.dts
+++ b/boards/arm/atsamd21_xpro/atsamd21_xpro.dts
@@ -13,6 +13,7 @@
 
 	chosen {
 		zephyr,console = &sercom3;
+		zephyr,shell-uart = &sercom3;
 		zephyr,sram = &sram0;
 		zephyr,flash = &flash0;
 	};

--- a/boards/arm/b_l072z_lrwan1/b_l072z_lrwan1.dts
+++ b/boards/arm/b_l072z_lrwan1/b_l072z_lrwan1.dts
@@ -13,6 +13,7 @@
 
 	chosen {
 		zephyr,console = &usart2;
+		zephyr,shell-uart = &usart2;
 		zephyr,sram = &sram0;
 		zephyr,flash = &flash0;
 	};

--- a/boards/arm/bbc_microbit/bbc_microbit.dts
+++ b/boards/arm/bbc_microbit/bbc_microbit.dts
@@ -19,6 +19,7 @@
 
 	chosen {
 		zephyr,console = &uart0;
+		zephyr,shell-uart = &uart0;
 		zephyr,sram = &sram0;
 		zephyr,flash = &flash0;
 	};

--- a/boards/arm/cc2650_sensortag/cc2650_sensortag.dts
+++ b/boards/arm/cc2650_sensortag/cc2650_sensortag.dts
@@ -20,6 +20,7 @@
 		zephyr,sram = &sram0;
 		zephyr,flash = &flash0;
 		zephyr,console = &uart0;
+		zephyr,shell-uart = &uart0;
 	};
 };
 

--- a/boards/arm/cc3220sf_launchxl/cc3220sf_launchxl.dts
+++ b/boards/arm/cc3220sf_launchxl/cc3220sf_launchxl.dts
@@ -20,6 +20,7 @@
 		zephyr,sram = &sram0;
 		zephyr,flash = &flash1;
 		zephyr,console = &uart0;
+		zephyr,shell-uart = &uart0;
 	};
 
 	leds {

--- a/boards/arm/colibri_imx7d_m4/colibri_imx7d_m4.dts
+++ b/boards/arm/colibri_imx7d_m4/colibri_imx7d_m4.dts
@@ -29,6 +29,7 @@
 #endif
 		zephyr,sram = &tcmu_sys;
 		zephyr,console = &uart2;
+		zephyr,shell-uart = &uart2;
 	};
 
 	leds {

--- a/boards/arm/curie_ble/curie_ble.dts
+++ b/boards/arm/curie_ble/curie_ble.dts
@@ -14,6 +14,7 @@
 
 	chosen {
 		zephyr,console = &uart0;
+		zephyr,shell-uart = &uart0;
 		zephyr,sram = &sram0;
 		zephyr,flash = &flash0;
 	};

--- a/boards/arm/cy8ckit_062_wifi_bt_m0/cy8ckit_062_wifi_bt_m0.dts
+++ b/boards/arm/cy8ckit_062_wifi_bt_m0/cy8ckit_062_wifi_bt_m0.dts
@@ -20,6 +20,7 @@
 		zephyr,sram = &sram0;
 		zephyr,flash = &flash0;
 		zephyr,console = &uart6;
+		zephyr,shell-uart = &uart6;
 	};
 };
 

--- a/boards/arm/cy8ckit_062_wifi_bt_m4/cy8ckit_062_wifi_bt_m4.dts
+++ b/boards/arm/cy8ckit_062_wifi_bt_m4/cy8ckit_062_wifi_bt_m4.dts
@@ -20,6 +20,7 @@
 		zephyr,sram = &sram2;
 		zephyr,flash = &flash1;
 		zephyr,console = &uart5;
+		zephyr,shell-uart = &uart5;
 	};
 };
 

--- a/boards/arm/disco_l475_iot1/disco_l475_iot1.dts
+++ b/boards/arm/disco_l475_iot1/disco_l475_iot1.dts
@@ -13,6 +13,7 @@
 
 	chosen {
 		zephyr,console = &usart1;
+		zephyr,shell-uart = &usart1;
 		zephyr,sram = &sram0;
 		zephyr,flash = &flash0;
 	};

--- a/boards/arm/dragino_lsn50/dragino_lsn50.dts
+++ b/boards/arm/dragino_lsn50/dragino_lsn50.dts
@@ -13,6 +13,7 @@
 
 	chosen {
 		zephyr,console = &usart1;
+		zephyr,shell-uart = &usart1;
 		zephyr,sram = &sram0;
 		zephyr,flash = &flash0;
 	};

--- a/boards/arm/efm32hg_slstk3400a/efm32hg_slstk3400a.dts
+++ b/boards/arm/efm32hg_slstk3400a/efm32hg_slstk3400a.dts
@@ -13,6 +13,7 @@
 
 	chosen {
 		zephyr,console = &usart1;
+		zephyr,shell-uart = &usart1;
 		zephyr,sram = &sram0;
 		zephyr,flash = &flash0;
 	};

--- a/boards/arm/efm32pg_stk3402a/efm32pg_stk3402a.dts
+++ b/boards/arm/efm32pg_stk3402a/efm32pg_stk3402a.dts
@@ -13,6 +13,7 @@
 
 	chosen {
 		zephyr,console = &usart0;
+		zephyr,shell-uart = &usart0;
 		zephyr,sram = &sram0;
 		zephyr,flash = &flash0;
 	};

--- a/boards/arm/efm32wg_stk3800/efm32wg_stk3800.dts
+++ b/boards/arm/efm32wg_stk3800/efm32wg_stk3800.dts
@@ -17,6 +17,7 @@
 
 	chosen {
 		zephyr,console = &uart0;
+		zephyr,shell-uart = &uart0;
 		zephyr,sram = &sram0;
 		zephyr,flash = &flash0;
 	};

--- a/boards/arm/efr32_slwstk6061a/efr32_slwstk6061a.dts
+++ b/boards/arm/efr32_slwstk6061a/efr32_slwstk6061a.dts
@@ -17,6 +17,7 @@
 
 	chosen {
 		zephyr,console = &usart0;
+		zephyr,shell-uart = &usart0;
 		zephyr,sram = &sram0;
 		zephyr,flash = &flash0;
 	};

--- a/boards/arm/efr32mg_sltb004a/efr32mg_sltb004a.dts
+++ b/boards/arm/efr32mg_sltb004a/efr32mg_sltb004a.dts
@@ -24,6 +24,7 @@
 
 	chosen {
 		zephyr,console = &usart0;
+		zephyr,shell-uart = &usart0;
 		zephyr,sram = &sram0;
 		zephyr,flash = &flash0;
 	};

--- a/boards/arm/frdm_k64f/frdm_k64f.dts
+++ b/boards/arm/frdm_k64f/frdm_k64f.dts
@@ -40,6 +40,7 @@
 		zephyr,sram = &sram0;
 		zephyr,flash = &flash0;
 		zephyr,console = &uart0;
+		zephyr,shell-uart = &uart0;
 		zephyr,uart-pipe = &uart0;
 	};
 

--- a/boards/arm/frdm_kl25z/frdm_kl25z.dts
+++ b/boards/arm/frdm_kl25z/frdm_kl25z.dts
@@ -27,6 +27,7 @@
 		zephyr,sram = &sram0;
 		zephyr,flash = &flash0;
 		zephyr,console = &uart0;
+		zephyr,shell-uart = &uart0;
 	};
 
 	leds {

--- a/boards/arm/frdm_kw41z/frdm_kw41z.dts
+++ b/boards/arm/frdm_kw41z/frdm_kw41z.dts
@@ -29,6 +29,7 @@
 		zephyr,sram = &sram0;
 		zephyr,flash = &flash0;
 		zephyr,console = &lpuart0;
+		zephyr,shell-uart = &lpuart0;
 	};
 
 	leds {

--- a/boards/arm/hexiwear_k64/hexiwear_k64.dts
+++ b/boards/arm/hexiwear_k64/hexiwear_k64.dts
@@ -41,6 +41,7 @@
 		zephyr,sram = &sram0;
 		zephyr,flash = &flash0;
 		zephyr,console = &uart0;
+		zephyr,shell-uart = &uart0;
 		zephyr,bt-uart = &uart4;
 	};
 

--- a/boards/arm/lpcxpresso54114/lpcxpresso54114_m0.dts
+++ b/boards/arm/lpcxpresso54114/lpcxpresso54114_m0.dts
@@ -17,6 +17,7 @@
 		zephyr,sram = &sram2;
 		zephyr,flash = &sram1;
 		/*zephyr,console = &usart0; uncomment to use console on M0  */
+		/*zephyr,shell-uart = &usart0; uncomment to use shell on M0 */
 	};
 };
 

--- a/boards/arm/lpcxpresso54114/lpcxpresso54114_m4.dts
+++ b/boards/arm/lpcxpresso54114/lpcxpresso54114_m4.dts
@@ -17,6 +17,7 @@
 		zephyr,sram = &sram0;
 		zephyr,flash = &flash0;
 		zephyr,console = &usart0;
+		zephyr,shell-uart = &usart0;
 	};
 };
 

--- a/boards/arm/mimxrt1050_evk/mimxrt1050_evk.dts
+++ b/boards/arm/mimxrt1050_evk/mimxrt1050_evk.dts
@@ -36,6 +36,7 @@
 #endif
 		zephyr,sram = &dtcm0;
 		zephyr,console = &uart1;
+		zephyr,shell-uart = &uart1;
 	};
 
 	sdram0: memory@80000000 {

--- a/boards/arm/mimxrt1060_evk/mimxrt1060_evk.dts
+++ b/boards/arm/mimxrt1060_evk/mimxrt1060_evk.dts
@@ -33,6 +33,7 @@
 #endif
 		zephyr,sram = &dtcm0;
 		zephyr,console = &uart1;
+		zephyr,shell-uart = &uart1;
 	};
 
 	sdram0: memory@80000000 {

--- a/boards/arm/mps2_an385/mps2_an385.dts
+++ b/boards/arm/mps2_an385/mps2_an385.dts
@@ -10,6 +10,7 @@
 
 	chosen {
 		zephyr,console = &uart0;
+		zephyr,shell-uart = &uart0;
 		zephyr,sram = &sram0;
 		zephyr,flash = &flash0;
 	};

--- a/boards/arm/msp_exp432p401r_launchxl/msp_exp432p401r_launchxl.dts
+++ b/boards/arm/msp_exp432p401r_launchxl/msp_exp432p401r_launchxl.dts
@@ -15,6 +15,7 @@
 		zephyr,sram = &sram0;
 		zephyr,flash = &flash0;
 		zephyr,console = &uart0;
+		zephyr,shell-uart = &uart0;
 	};
 };
 

--- a/boards/arm/nrf51_ble400/nrf51_ble400.dts
+++ b/boards/arm/nrf51_ble400/nrf51_ble400.dts
@@ -13,6 +13,7 @@
 
 	chosen {
 		zephyr,console = &uart0;
+		zephyr,shell-uart = &uart0;
 		zephyr,sram = &sram0;
 		zephyr,flash = &flash0;
 	};

--- a/boards/arm/nrf51_blenano/nrf51_blenano.dts
+++ b/boards/arm/nrf51_blenano/nrf51_blenano.dts
@@ -14,6 +14,7 @@
 
 	chosen {
 		zephyr,console = &uart0;
+		zephyr,shell-uart = &uart0;
 		zephyr,sram = &sram0;
 		zephyr,flash = &flash0;
 	};

--- a/boards/arm/nrf51_pca10028/nrf51_pca10028.dts
+++ b/boards/arm/nrf51_pca10028/nrf51_pca10028.dts
@@ -14,6 +14,7 @@
 
 	chosen {
 		zephyr,console = &uart0;
+		zephyr,shell-uart = &uart0;
 		zephyr,uart-mcumgr = &uart0;
 		zephyr,sram = &sram0;
 		zephyr,flash = &flash0;

--- a/boards/arm/nrf51_vbluno51/nrf51_vbluno51.dts
+++ b/boards/arm/nrf51_vbluno51/nrf51_vbluno51.dts
@@ -14,6 +14,7 @@
 
 	chosen {
 		zephyr,console = &uart0;
+		zephyr,shell-uart = &uart0;
 		zephyr,sram = &sram0;
 		zephyr,flash = &flash0;
 	};

--- a/boards/arm/nrf52810_pca10040/nrf52810_pca10040.dts
+++ b/boards/arm/nrf52810_pca10040/nrf52810_pca10040.dts
@@ -16,6 +16,7 @@
 
 	chosen {
 		zephyr,console = &uart0;
+		zephyr,shell-uart = &uart0;
 		zephyr,uart-mcumgr = &uart0;
 		zephyr,sram = &sram0;
 		zephyr,flash = &flash0;

--- a/boards/arm/nrf52832_mdk/nrf52832_mdk.dts
+++ b/boards/arm/nrf52832_mdk/nrf52832_mdk.dts
@@ -15,6 +15,7 @@
 
 	chosen {
 		zephyr,console = &uart0;
+		zephyr,shell-uart = &uart0;
 		zephyr,uart-mcumgr = &uart0;
 		zephyr,sram = &sram0;
 		zephyr,flash = &flash0;

--- a/boards/arm/nrf52840_mdk/nrf52840_mdk.dts
+++ b/boards/arm/nrf52840_mdk/nrf52840_mdk.dts
@@ -14,6 +14,7 @@
 
 	chosen {
 		zephyr,console = &uart0;
+		zephyr,shell-uart = &uart0;
 		zephyr,uart-mcumgr = &uart0;
 		zephyr,sram = &sram0;
 		zephyr,flash = &flash0;

--- a/boards/arm/nrf52840_pca10056/nrf52840_pca10056.dts
+++ b/boards/arm/nrf52840_pca10056/nrf52840_pca10056.dts
@@ -14,6 +14,7 @@
 
 	chosen {
 		zephyr,console = &uart0;
+		zephyr,shell-uart = &uart0;
 		zephyr,uart-mcumgr = &uart0;
 		zephyr,sram = &sram0;
 		zephyr,flash = &flash0;

--- a/boards/arm/nrf52840_pca10059/nrf52840_pca10059.dts
+++ b/boards/arm/nrf52840_pca10059/nrf52840_pca10059.dts
@@ -15,6 +15,7 @@
 
 	chosen {
 		zephyr,console = &uart0;
+		zephyr,shell-uart = &uart0;
 		zephyr,uart-mcumgr = &uart0;
 		zephyr,sram = &sram0;
 		zephyr,flash = &flash0;

--- a/boards/arm/nrf52_adafruit_feather/nrf52_adafruit_feather.dts
+++ b/boards/arm/nrf52_adafruit_feather/nrf52_adafruit_feather.dts
@@ -15,6 +15,7 @@
 
 	chosen {
 		zephyr,console = &uart0;
+		zephyr,shell-uart = &uart0;
 		zephyr,uart-mcumgr = &uart0;
 		zephyr,sram = &sram0;
 		zephyr,flash = &flash0;

--- a/boards/arm/nrf52_blenano2/nrf52_blenano2.dts
+++ b/boards/arm/nrf52_blenano2/nrf52_blenano2.dts
@@ -14,6 +14,7 @@
 
 	chosen {
 		zephyr,console = &uart0;
+		zephyr,shell-uart = &uart0;
 		zephyr,sram = &sram0;
 		zephyr,flash = &flash0;
 	};

--- a/boards/arm/nrf52_pca10040/nrf52_pca10040.dts
+++ b/boards/arm/nrf52_pca10040/nrf52_pca10040.dts
@@ -15,6 +15,7 @@
 
 	chosen {
 		zephyr,console = &uart0;
+		zephyr,shell-uart = &uart0;
 		zephyr,uart-mcumgr = &uart0;
 		zephyr,sram = &sram0;
 		zephyr,flash = &flash0;

--- a/boards/arm/nrf52_pca20020/nrf52_pca20020.dts
+++ b/boards/arm/nrf52_pca20020/nrf52_pca20020.dts
@@ -16,6 +16,7 @@
 
 	chosen {
 		zephyr,console = &uart0;
+		zephyr,shell-uart = &uart0;
 		zephyr,sram = &sram0;
 		zephyr,flash = &flash0;
 	};

--- a/boards/arm/nrf52_sparkfun/nrf52_sparkfun.dts
+++ b/boards/arm/nrf52_sparkfun/nrf52_sparkfun.dts
@@ -15,6 +15,7 @@
 
 	chosen {
 		zephyr,console = &uart0;
+		zephyr,shell-uart = &uart0;
 		zephyr,sram = &sram0;
 		zephyr,flash = &flash0;
 	};

--- a/boards/arm/nrf52_vbluno52/nrf52_vbluno52.dts
+++ b/boards/arm/nrf52_vbluno52/nrf52_vbluno52.dts
@@ -14,6 +14,7 @@
 
 	chosen {
 		zephyr,console = &uart0;
+		zephyr,shell-uart = &uart0;
 		zephyr,sram = &sram0;
 		zephyr,flash = &flash0;
 	};

--- a/boards/arm/nucleo_f030r8/nucleo_f030r8.dts
+++ b/boards/arm/nucleo_f030r8/nucleo_f030r8.dts
@@ -13,6 +13,7 @@
 
 	chosen {
 		zephyr,console = &usart2;
+		zephyr,shell-uart = &usart2;
 		zephyr,sram = &sram0;
 		zephyr,flash = &flash0;
 	};

--- a/boards/arm/nucleo_f070rb/nucleo_f070rb.dts
+++ b/boards/arm/nucleo_f070rb/nucleo_f070rb.dts
@@ -13,6 +13,7 @@
 
 	chosen {
 		zephyr,console = &usart2;
+		zephyr,shell-uart = &usart2;
 		zephyr,sram = &sram0;
 		zephyr,flash = &flash0;
 	};

--- a/boards/arm/nucleo_f091rc/nucleo_f091rc.dts
+++ b/boards/arm/nucleo_f091rc/nucleo_f091rc.dts
@@ -13,6 +13,7 @@
 
 	chosen {
 		zephyr,console = &usart2;
+		zephyr,shell-uart = &usart2;
 		zephyr,sram = &sram0;
 		zephyr,flash = &flash0;
 	};

--- a/boards/arm/nucleo_f103rb/nucleo_f103rb.dts
+++ b/boards/arm/nucleo_f103rb/nucleo_f103rb.dts
@@ -13,6 +13,7 @@
 
 	chosen {
 		zephyr,console = &usart2;
+		zephyr,shell-uart = &usart2;
 		zephyr,sram = &sram0;
 		zephyr,flash = &flash0;
 	};

--- a/boards/arm/nucleo_f207zg/nucleo_f207zg.dts
+++ b/boards/arm/nucleo_f207zg/nucleo_f207zg.dts
@@ -13,6 +13,7 @@
 
 	chosen {
 		zephyr,console = &usart3;
+		zephyr,shell-uart = &usart3;
 		zephyr,sram = &sram0;
 		zephyr,flash = &flash0;
 	};

--- a/boards/arm/nucleo_f302r8/nucleo_f302r8.dts
+++ b/boards/arm/nucleo_f302r8/nucleo_f302r8.dts
@@ -13,6 +13,7 @@
 
 	chosen {
 		zephyr,console = &usart2;
+		zephyr,shell-uart = &usart2;
 		zephyr,sram = &sram0;
 		zephyr,flash = &flash0;
 	};

--- a/boards/arm/nucleo_f334r8/nucleo_f334r8.dts
+++ b/boards/arm/nucleo_f334r8/nucleo_f334r8.dts
@@ -13,6 +13,7 @@
 
 	chosen {
 		zephyr,console = &usart2;
+		zephyr,shell-uart = &usart2;
 		zephyr,sram = &sram0;
 		zephyr,flash = &flash0;
 	};

--- a/boards/arm/nucleo_f401re/nucleo_f401re.dts
+++ b/boards/arm/nucleo_f401re/nucleo_f401re.dts
@@ -13,6 +13,7 @@
 
 	chosen {
 		zephyr,console = &usart2;
+		zephyr,shell-uart = &usart2;
 		zephyr,sram = &sram0;
 		zephyr,flash = &flash0;
 	};

--- a/boards/arm/nucleo_f411re/nucleo_f411re.dts
+++ b/boards/arm/nucleo_f411re/nucleo_f411re.dts
@@ -13,6 +13,7 @@
 
 	chosen {
 		zephyr,console = &usart2;
+		zephyr,shell-uart = &usart2;
 		zephyr,sram = &sram0;
 		zephyr,flash = &flash0;
 	};

--- a/boards/arm/nucleo_f412zg/nucleo_f412zg.dts
+++ b/boards/arm/nucleo_f412zg/nucleo_f412zg.dts
@@ -13,6 +13,7 @@
 
 	chosen {
 		zephyr,console = &usart3;
+		zephyr,shell-uart = &usart3;
 		zephyr,sram = &sram0;
 		zephyr,flash = &flash0;
 	};

--- a/boards/arm/nucleo_f413zh/nucleo_f413zh.dts
+++ b/boards/arm/nucleo_f413zh/nucleo_f413zh.dts
@@ -13,6 +13,7 @@
 
 	chosen {
 		zephyr,console = &usart3;
+		zephyr,shell-uart = &usart3;
 		zephyr,sram = &sram0;
 		zephyr,flash = &flash0;
 	};

--- a/boards/arm/nucleo_f429zi/nucleo_f429zi.dts
+++ b/boards/arm/nucleo_f429zi/nucleo_f429zi.dts
@@ -13,6 +13,7 @@
 
 	chosen {
 		zephyr,console = &usart3;
+		zephyr,shell-uart = &usart3;
 		zephyr,sram = &sram0;
 		zephyr,flash = &flash0;
 		zephyr,ccm = &ccm0;

--- a/boards/arm/nucleo_f446re/nucleo_f446re.dts
+++ b/boards/arm/nucleo_f446re/nucleo_f446re.dts
@@ -13,6 +13,7 @@
 
 	chosen {
 		zephyr,console = &usart2;
+		zephyr,shell-uart = &usart2;
 		zephyr,sram = &sram0;
 		zephyr,flash = &flash0;
 	};

--- a/boards/arm/nucleo_f746zg/nucleo_f746zg.dts
+++ b/boards/arm/nucleo_f746zg/nucleo_f746zg.dts
@@ -13,6 +13,7 @@
 
 	chosen {
 		zephyr,console = &usart3;
+		zephyr,shell-uart = &usart3;
 		zephyr,sram = &sram0;
 		zephyr,flash = &flash0;
 	};

--- a/boards/arm/nucleo_l053r8/nucleo_l053r8.dts
+++ b/boards/arm/nucleo_l053r8/nucleo_l053r8.dts
@@ -13,6 +13,7 @@
 
 	chosen {
 		zephyr,console = &usart2;
+		zephyr,shell-uart = &usart2;
 		zephyr,sram = &sram0;
 		zephyr,flash = &flash0;
 	};

--- a/boards/arm/nucleo_l073rz/nucleo_l073rz.dts
+++ b/boards/arm/nucleo_l073rz/nucleo_l073rz.dts
@@ -13,6 +13,7 @@
 
 	chosen {
 		zephyr,console = &usart2;
+		zephyr,shell-uart = &usart2;
 		zephyr,sram = &sram0;
 		zephyr,flash = &flash0;
 	};

--- a/boards/arm/nucleo_l432kc/nucleo_l432kc.dts
+++ b/boards/arm/nucleo_l432kc/nucleo_l432kc.dts
@@ -13,6 +13,7 @@
 
 	chosen {
 		zephyr,console = &usart2;
+		zephyr,shell-uart = &usart2;
 		zephyr,sram = &sram0;
 		zephyr,flash = &flash0;
 	};

--- a/boards/arm/nucleo_l476rg/nucleo_l476rg.dts
+++ b/boards/arm/nucleo_l476rg/nucleo_l476rg.dts
@@ -13,6 +13,7 @@
 
 	chosen {
 		zephyr,console = &usart2;
+		zephyr,shell-uart = &usart2;
 		zephyr,sram = &sram0;
 		zephyr,flash = &flash0;
 	};

--- a/boards/arm/nucleo_l4r5zi/nucleo_l4r5zi.dts
+++ b/boards/arm/nucleo_l4r5zi/nucleo_l4r5zi.dts
@@ -13,6 +13,7 @@
 
 	chosen {
 		zephyr,console = &usart2;
+		zephyr,shell-uart = &usart2;
 		zephyr,sram = &sram0;
 		zephyr,flash = &flash0;
 	};

--- a/boards/arm/olimex_stm32_e407/olimex_stm32_e407.dts
+++ b/boards/arm/olimex_stm32_e407/olimex_stm32_e407.dts
@@ -13,6 +13,7 @@
 
 	chosen {
 		zephyr,console = &usart1;
+		zephyr,shell-uart = &usart1;
 		zephyr,sram = &sram0;
 		zephyr,flash = &flash0;
 		zephyr,ccm = &ccm0;

--- a/boards/arm/olimex_stm32_h407/olimex_stm32_h407.dts
+++ b/boards/arm/olimex_stm32_h407/olimex_stm32_h407.dts
@@ -13,6 +13,7 @@
 
 	chosen {
 		zephyr,console = &usart2;
+		zephyr,shell-uart = &usart2;
 		zephyr,sram = &sram0;
 		zephyr,flash = &flash0;
 		zephyr,ccm = &ccm0;

--- a/boards/arm/olimex_stm32_p405/olimex_stm32_p405.dts
+++ b/boards/arm/olimex_stm32_p405/olimex_stm32_p405.dts
@@ -13,6 +13,7 @@
 
 	chosen {
 		zephyr,console = &usart2;
+		zephyr,shell-uart = &usart2;
 		zephyr,sram = &sram0;
 		zephyr,flash = &flash0;
 		zephyr,ccm = &ccm0;

--- a/boards/arm/olimexino_stm32/olimexino_stm32.dts
+++ b/boards/arm/olimexino_stm32/olimexino_stm32.dts
@@ -13,6 +13,7 @@
 
 	chosen {
 		zephyr,console = &usart1;
+		zephyr,shell-uart = &usart1;
 		zephyr,sram = &sram0;
 		zephyr,flash = &flash0;
 	};

--- a/boards/arm/qemu_cortex_m3/qemu_cortex_m3.dts
+++ b/boards/arm/qemu_cortex_m3/qemu_cortex_m3.dts
@@ -16,6 +16,7 @@
 		zephyr,sram = &sram0;
 		zephyr,flash = &flash0;
 		zephyr,console = &uart0;
+		zephyr,shell-uart = &uart0;
 		zephyr,bt-uart = &uart2;
 		zephyr,uart-pipe = &uart1;
 		zephyr,bt-mon-uart = &uart2;

--- a/boards/arm/quark_se_c1000_ble/quark_se_c1000_ble.dts
+++ b/boards/arm/quark_se_c1000_ble/quark_se_c1000_ble.dts
@@ -14,6 +14,7 @@
 
 	chosen {
 		zephyr,console = &uart0;
+		zephyr,shell-uart = &uart0;
 		zephyr,sram = &sram0;
 		zephyr,flash = &flash0;
 	};

--- a/boards/arm/reel_board/reel_board.dts
+++ b/boards/arm/reel_board/reel_board.dts
@@ -15,6 +15,7 @@
 
 	chosen {
 		zephyr,console = &uart0;
+		zephyr,shell-uart = &uart0;
 		zephyr,uart-mcumgr = &uart0;
 		zephyr,sram = &sram0;
 		zephyr,flash = &flash0;

--- a/boards/arm/sam4s_xplained/sam4s_xplained.dts
+++ b/boards/arm/sam4s_xplained/sam4s_xplained.dts
@@ -22,6 +22,7 @@
 
 	chosen {
 		zephyr,console = &uart0;
+		zephyr,shell-uart = &uart0;
 		zephyr,sram = &sram0;
 		zephyr,flash = &flash0;
 	};

--- a/boards/arm/sam_e70_xplained/sam_e70_xplained.dts
+++ b/boards/arm/sam_e70_xplained/sam_e70_xplained.dts
@@ -24,6 +24,7 @@
 
 	chosen {
 		zephyr,console = &usart1;
+		zephyr,shell-uart = &usart1;
 		zephyr,sram = &sram0;
 		zephyr,flash = &flash0;
 	};

--- a/boards/arm/stm3210c_eval/stm3210c_eval.dts
+++ b/boards/arm/stm3210c_eval/stm3210c_eval.dts
@@ -13,6 +13,7 @@
 
 	chosen {
 		zephyr,console = &usart2;
+		zephyr,shell-uart = &usart2;
 		zephyr,sram = &sram0;
 		zephyr,flash = &flash0;
 	};

--- a/boards/arm/stm32373c_eval/stm32373c_eval.dts
+++ b/boards/arm/stm32373c_eval/stm32373c_eval.dts
@@ -13,6 +13,7 @@
 
 	chosen {
 		zephyr,console = &usart2;
+		zephyr,shell-uart = &usart2;
 		zephyr,sram = &sram0;
 		zephyr,flash = &flash0;
 	};

--- a/boards/arm/stm32_min_dev/stm32_min_dev.dts
+++ b/boards/arm/stm32_min_dev/stm32_min_dev.dts
@@ -13,6 +13,7 @@
 
 	chosen {
 		zephyr,console = &usart1;
+		zephyr,shell-uart = &usart1;
 		zephyr,sram = &sram0;
 		zephyr,flash = &flash0;
 	};

--- a/boards/arm/stm32f072_eval/stm32f072_eval.dts
+++ b/boards/arm/stm32f072_eval/stm32f072_eval.dts
@@ -13,6 +13,7 @@
 
 	chosen {
 		zephyr,console = &usart2;
+		zephyr,shell-uart = &usart2;
 		zephyr,sram = &sram0;
 		zephyr,flash = &flash0;
 	};

--- a/boards/arm/stm32f072b_disco/stm32f072b_disco.dts
+++ b/boards/arm/stm32f072b_disco/stm32f072b_disco.dts
@@ -13,6 +13,7 @@
 
 	chosen {
 		zephyr,console = &usart1;
+		zephyr,shell-uart = &usart1;
 		zephyr,sram = &sram0;
 		zephyr,flash = &flash0;
 	};

--- a/boards/arm/stm32f0_disco/stm32f0_disco.dts
+++ b/boards/arm/stm32f0_disco/stm32f0_disco.dts
@@ -13,6 +13,7 @@
 
 	chosen {
 		zephyr,console = &usart1;
+		zephyr,shell-uart = &usart1;
 		zephyr,sram = &sram0;
 		zephyr,flash = &flash0;
 	};

--- a/boards/arm/stm32f3_disco/stm32f3_disco.dts
+++ b/boards/arm/stm32f3_disco/stm32f3_disco.dts
@@ -13,6 +13,7 @@
 
 	chosen {
 		zephyr,console = &usart1;
+		zephyr,shell-uart = &usart1;
 		zephyr,sram = &sram0;
 		zephyr,flash = &flash0;
 	};

--- a/boards/arm/stm32f411e_disco/stm32f411e_disco.dts
+++ b/boards/arm/stm32f411e_disco/stm32f411e_disco.dts
@@ -13,6 +13,7 @@
 
 	chosen {
 		zephyr,console = &usart2;
+		zephyr,shell-uart = &usart2;
 		zephyr,sram = &sram0;
 		zephyr,flash = &flash0;
 	};

--- a/boards/arm/stm32f412g_disco/stm32f412g_disco.dts
+++ b/boards/arm/stm32f412g_disco/stm32f412g_disco.dts
@@ -13,6 +13,7 @@
 
 	chosen {
 		zephyr,console = &usart2;
+		zephyr,shell-uart = &usart2;
 		zephyr,sram = &sram0;
 		zephyr,flash = &flash0;
 	};

--- a/boards/arm/stm32f429i_disc1/stm32f429i_disc1.dts
+++ b/boards/arm/stm32f429i_disc1/stm32f429i_disc1.dts
@@ -13,6 +13,7 @@
 
 	chosen {
 		zephyr,console = &usart1;
+		zephyr,shell-uart = &usart1;
 		zephyr,sram = &sram0;
 		zephyr,flash = &flash0;
 	};

--- a/boards/arm/stm32f469i_disco/stm32f469i_disco.dts
+++ b/boards/arm/stm32f469i_disco/stm32f469i_disco.dts
@@ -13,6 +13,7 @@
 
 	chosen {
 		zephyr,console = &usart3;
+		zephyr,shell-uart = &usart3;
 		zephyr,sram = &sram0;
 		zephyr,flash = &flash0;
 	};

--- a/boards/arm/stm32f4_disco/stm32f4_disco.dts
+++ b/boards/arm/stm32f4_disco/stm32f4_disco.dts
@@ -13,6 +13,7 @@
 
 	chosen {
 		zephyr,console = &usart2;
+		zephyr,shell-uart = &usart2;
 		zephyr,sram = &sram0;
 		zephyr,flash = &flash0;
 	};

--- a/boards/arm/stm32f723e_disco/stm32f723e_disco.dts
+++ b/boards/arm/stm32f723e_disco/stm32f723e_disco.dts
@@ -13,6 +13,7 @@
 
 	chosen {
 		zephyr,console = &usart6;
+		zephyr,shell-uart = &usart6;
 		zephyr,sram = &sram0;
 		zephyr,flash = &flash0;
 	};

--- a/boards/arm/stm32f746g_disco/stm32f746g_disco.dts
+++ b/boards/arm/stm32f746g_disco/stm32f746g_disco.dts
@@ -13,6 +13,7 @@
 
 	chosen {
 		zephyr,console = &usart1;
+		zephyr,shell-uart = &usart1;
 		zephyr,sram = &sram0;
 		zephyr,flash = &flash0;
 	};

--- a/boards/arm/stm32f769i_disco/stm32f769i_disco.dts
+++ b/boards/arm/stm32f769i_disco/stm32f769i_disco.dts
@@ -13,6 +13,7 @@
 
 	chosen {
 		zephyr,console = &usart1;
+		zephyr,shell-uart = &usart1;
 		zephyr,sram = &sram0;
 		zephyr,flash = &flash0;
 	};

--- a/boards/arm/stm32l476g_disco/stm32l476g_disco.dts
+++ b/boards/arm/stm32l476g_disco/stm32l476g_disco.dts
@@ -17,6 +17,7 @@
 
 	chosen {
 		zephyr,console = &usart2;
+		zephyr,shell-uart = &usart2;
 		zephyr,sram = &sram0;
 		zephyr,flash = &flash0;
 	};

--- a/boards/arm/stm32l496g_disco/stm32l496g_disco.dts
+++ b/boards/arm/stm32l496g_disco/stm32l496g_disco.dts
@@ -13,6 +13,7 @@
 
 	chosen {
 		zephyr,console = &usart2;
+		zephyr,shell-uart = &usart2;
 		zephyr,sram = &sram0;
 		zephyr,flash = &flash0;
 	};

--- a/boards/arm/udoo_neo_full_m4/udoo_neo_full_m4.dts
+++ b/boards/arm/udoo_neo_full_m4/udoo_neo_full_m4.dts
@@ -43,6 +43,7 @@
 		zephyr,flash = &flash;
 		zephyr,sram = &tcmu;
 		zephyr,console = &uart5;
+		zephyr,shell-uart = &uart5;
 	};
 
 	leds {

--- a/boards/arm/usb_kw24d512/usb_kw24d512.dts
+++ b/boards/arm/usb_kw24d512/usb_kw24d512.dts
@@ -28,6 +28,7 @@
 		zephyr,sram = &sram0;
 		zephyr,flash = &flash0;
 		zephyr,console = &uart0;
+		zephyr,shell-uart = &uart0;
 		zephyr,uart-pipe = &uart0;
 	};
 

--- a/boards/arm/v2m_beetle/v2m_beetle.dts
+++ b/boards/arm/v2m_beetle/v2m_beetle.dts
@@ -9,6 +9,7 @@
 
 	chosen {
 		zephyr,console = &uart1;
+		zephyr,shell-uart = &uart1;
 		zephyr,sram = &sram0;
 		zephyr,flash = &flash0;
 	};

--- a/boards/arm/warp7_m4/warp7_m4.dts
+++ b/boards/arm/warp7_m4/warp7_m4.dts
@@ -27,6 +27,7 @@
 #endif
 		zephyr,sram = &tcmu_sys;
 		zephyr,console = &uart2;
+		zephyr,shell-uart = &uart2;
 	};
 
 	gpio_keys {

--- a/boards/nios2/altera_max10/altera_max10.dts
+++ b/boards/nios2/altera_max10/altera_max10.dts
@@ -14,6 +14,7 @@
 		zephyr,sram = &sram0;
 		zephyr,flash = &flash0;
 		zephyr,console = &uart0;
+		zephyr,shell-uart = &uart0;
 	};
 };
 

--- a/boards/nios2/qemu_nios2/qemu_nios2.dts
+++ b/boards/nios2/qemu_nios2/qemu_nios2.dts
@@ -15,6 +15,7 @@
 		zephyr,sram = &sram0;
 		zephyr,flash = &flash0;
 		zephyr,console = &ns16550_uart;
+		zephyr,shell-uart = &ns16550_uart;
 	};
 };
 

--- a/boards/riscv32/hifive1/hifive1.dts
+++ b/boards/riscv32/hifive1/hifive1.dts
@@ -13,6 +13,7 @@
 
 	chosen {
 		zephyr,console = &uart0;
+		zephyr,shell-uart = &uart0;
 	};
 
 	leds {

--- a/boards/riscv32/m2gl025_miv/m2gl025_miv.dts
+++ b/boards/riscv32/m2gl025_miv/m2gl025_miv.dts
@@ -16,6 +16,7 @@
 
 	chosen {
 		zephyr,console = &uart0;
+		zephyr,shell-uart = &uart0;
 	};
 };
 

--- a/boards/riscv32/qemu_riscv32/qemu_riscv32.dts
+++ b/boards/riscv32/qemu_riscv32/qemu_riscv32.dts
@@ -8,6 +8,7 @@
 
 	chosen {
 		zephyr,console = &uart0;
+		zephyr,shell-uart = &uart0;
 	};
 
 };

--- a/boards/riscv32/zedboard_pulpino/zedboard_pulpino.dts
+++ b/boards/riscv32/zedboard_pulpino/zedboard_pulpino.dts
@@ -32,6 +32,7 @@
 
 	chosen {
 		zephyr,console = &uart0;
+		zephyr,shell-uart = &uart0;
 	};
 
 	leds {

--- a/boards/x86/arduino_101/arduino_101.dts
+++ b/boards/x86/arduino_101/arduino_101.dts
@@ -21,6 +21,7 @@
 		zephyr,sram = &sram0;
 		zephyr,flash = &flash0;
 		zephyr,console = &uart1;
+		zephyr,shell-uart = &uart1;
 		zephyr,bt-uart = &uart0;
 		zephyr,uart-pipe = &uart1;
 		zephyr,bt-mon-uart = &uart1;

--- a/boards/x86/galileo/galileo.dts
+++ b/boards/x86/galileo/galileo.dts
@@ -20,6 +20,7 @@
 		zephyr,sram = &sram0;
 		zephyr,flash = &flash0;
 		zephyr,console = &uart1;
+		zephyr,shell-uart = &uart1;
 	};
 };
 

--- a/boards/x86/minnowboard/minnowboard.dts
+++ b/boards/x86/minnowboard/minnowboard.dts
@@ -20,6 +20,7 @@
 		zephyr,sram = &sram0;
 		zephyr,flash = &flash0;
 		zephyr,console = &uart0;
+		zephyr,shell-uart = &uart0;
 		zephyr,bt-uart = &uart1;
 		zephyr,uart-pipe = &uart1;
 		zephyr,bt-mon-uart = &uart1;

--- a/boards/x86/qemu_x86/qemu_x86.dts
+++ b/boards/x86/qemu_x86/qemu_x86.dts
@@ -25,6 +25,7 @@
 		zephyr,sram = &sram0;
 		zephyr,flash = &flash0;
 		zephyr,console = &uart0;
+		zephyr,shell-uart = &uart0;
 		zephyr,bt-uart = &uart1;
 		zephyr,uart-pipe = &uart1;
 		zephyr,bt-mon-uart = &uart1;

--- a/boards/x86/quark_d2000_crb/quark_d2000_crb.dts
+++ b/boards/x86/quark_d2000_crb/quark_d2000_crb.dts
@@ -22,6 +22,7 @@
 		zephyr,sram = &sram0;
 		zephyr,flash = &flash0;
 		zephyr,console = &uart0;
+		zephyr,shell-uart = &uart0;
 	};
 
 	leds {

--- a/boards/x86/quark_se_c1000_devboard/quark_se_c1000_devboard.dts
+++ b/boards/x86/quark_se_c1000_devboard/quark_se_c1000_devboard.dts
@@ -23,6 +23,7 @@
 		zephyr,sram = &sram0;
 		zephyr,flash = &flash1;
 		zephyr,console = &uart1;
+		zephyr,shell-uart = &uart1;
 		zephyr,bt-uart = &uart0;
 		zephyr,uart-pipe = &uart1;
 		zephyr,bt-mon-uart = &uart1;

--- a/boards/x86/tinytile/tinytile.dts
+++ b/boards/x86/tinytile/tinytile.dts
@@ -21,6 +21,7 @@
 		zephyr,sram = &sram0;
 		zephyr,flash = &flash0;
 		zephyr,console = &uart1;
+		zephyr,shell-uart = &uart1;
 		zephyr,bt-uart = &uart0;
 		zephyr,uart-pipe = &uart1;
 		zephyr,bt-mon-uart = &uart1;

--- a/boards/x86/up_squared/up_squared.dts
+++ b/boards/x86/up_squared/up_squared.dts
@@ -22,6 +22,7 @@
 		zephyr,sram = &sram0;
 		zephyr,flash = &flash0;
 		zephyr,console = &uart0;
+		zephyr,shell-uart = &uart0;
 		zephyr,bt-uart = &uart1;
 		zephyr,uart-pipe = &uart1;
 		zephyr,bt-mon-uart = &uart1;

--- a/boards/x86/up_squared/up_squared_sbl.dts
+++ b/boards/x86/up_squared/up_squared_sbl.dts
@@ -22,6 +22,7 @@
 		zephyr,sram = &sram0;
 		zephyr,flash = &flash0;
 		zephyr,console = &uart0;
+		zephyr,shell-uart = &uart0;
 		zephyr,bt-uart = &uart1;
 		zephyr,uart-pipe = &uart1;
 		zephyr,bt-mon-uart = &uart1;

--- a/boards/x86/x86_jailhouse/x86_jailhouse.dts
+++ b/boards/x86/x86_jailhouse/x86_jailhouse.dts
@@ -25,6 +25,7 @@
 		zephyr,sram = &sram0;
 		zephyr,flash = &flash0;
 		zephyr,console = &uart0;
+		zephyr,shell-uart = &uart0;
 		zephyr,bt-uart = &uart1;
 		zephyr,uart-pipe = &uart1;
 		zephyr,bt-mon-uart = &uart1;

--- a/boards/xtensa/intel_s1000_crb/intel_s1000_crb.dts
+++ b/boards/xtensa/intel_s1000_crb/intel_s1000_crb.dts
@@ -13,6 +13,7 @@
 	chosen {
 		zephyr,sram = &sram0;
 		zephyr,console = &uart0;
+		zephyr,shell-uart = &uart0;
 	};
 };
 

--- a/doc/application/application.rst
+++ b/doc/application/application.rst
@@ -1195,7 +1195,11 @@ As described in :ref:`device-tree`, Zephyr uses Device Tree to
 describe the hardware it runs on. This section describes how you can
 modify an application build's device tree using overlay files. For additional
 information regarding the relationship between Device Tree and Kconfig see
-:ref:`dt_vs_kconfig`.
+:ref:`dt_vs_kconfig`. In some cases the information contained in Device Tree
+files is closely connected to the software and might need to be modified
+using the overlay file concept. This can be relevant for many of the different
+Device Tree nodes, but is particularly useful for :ref:`certain types
+of nodes <dt-alias-chosen>`.
 
 Overlay files, which customarily have the :file:`.overlay` extension,
 contain device tree fragments which add to or modify the device tree

--- a/doc/devices/dts/device_tree.rst
+++ b/doc/devices/dts/device_tree.rst
@@ -248,6 +248,67 @@ The following is a more precise list of required files:
     :ref:`application_dt` for more information on overlay files and the Zephyr
     build system.
 
+.. _dt-alias-chosen:
+
+``aliases`` and ``chosen`` nodes
+================================
+
+Using an alias with a common name for a particular node makes it easier for you
+to write board-independent source code. Device Tree ``aliases`` nodes  are used
+for this purpose, by mapping certain generic, commonly used names to specific
+hardware resources:
+
+.. code-block:: yaml
+
+   aliases {
+      led0 = &led0;
+      sw0 = &button0;
+      sw1 = &button1;
+      uart-0 = &uart0;
+      uart-1 = &uart1;
+   };
+
+Certain software subsystems require a specific hardware resource to bind to in
+order to function properly. Some of those subsystems are used with many
+different boards, which makes using the Device Tree ``chosen`` nodes very
+convenient. By doing, so the software subsystem can rely on having the specific
+hardware peripheral assigned to it. In the following example we bind the shell
+to ``uart1`` in this board:
+
+.. code-block:: yaml
+
+   chosen {
+      zephyr,shell-uart = &uart1;
+   };
+
+The full set of Zephyr-specific ``chosen`` nodes follows:
+
+.. list-table::
+   :header-rows: 1
+
+   * - ``chosen`` node name
+     - Generated symbol
+
+   * - ``zephyr,flash``
+     - ``CONFIG_FLASH``
+   * - ``zephyr,sram``
+     - ``CONFIG_SRAM``
+   * - ``zephyr,ccm``
+     - ``CONFIG_CCM``
+   * - ``zephyr,console``
+     - :option:`CONFIG_UART_CONSOLE_ON_DEV_NAME`
+   * - ``zephyr,shell-uart``
+     - :option:`CONFIG_UART_SHELL_ON_DEV_NAME`
+   * - ``zephyr,bt-uart``
+     - :option:`CONFIG_BT_UART_ON_DEV_NAME`
+   * - ``zephyr,uart-pipe``
+     - :option:`CONFIG_UART_PIPE_ON_DEV_NAME`
+   * - ``zephyr,bt-mon-uart``
+     - :option:`CONFIG_BT_MONITOR_ON_DEV_NAME`
+   * - ``zephyr,uart-mcumgr``
+     - :option:`CONFIG_UART_MCUMGR_ON_DEV_NAME`
+
+
 Adding support for device tree in drivers
 *****************************************
 

--- a/samples/application_development/out_of_tree_board/boards/arm/nrf52840_pca10056/nrf52840_pca10056.dts
+++ b/samples/application_development/out_of_tree_board/boards/arm/nrf52840_pca10056/nrf52840_pca10056.dts
@@ -14,6 +14,7 @@
 
 	chosen {
 		zephyr,console = &uart0;
+		zephyr,shell-uart = &uart0;
 		zephyr,sram = &sram0;
 		zephyr,flash = &flash0;
 	};

--- a/scripts/dts/extract/globals.py
+++ b/scripts/dts/extract/globals.py
@@ -25,6 +25,7 @@ regs_config = {
 
 name_config = {
     'zephyr,console'     : 'CONFIG_UART_CONSOLE_ON_DEV_NAME',
+    'zephyr,shell-uart'  : 'CONFIG_UART_SHELL_ON_DEV_NAME',
     'zephyr,bt-uart'     : 'CONFIG_BT_UART_ON_DEV_NAME',
     'zephyr,uart-pipe'   : 'CONFIG_UART_PIPE_ON_DEV_NAME',
     'zephyr,bt-mon-uart' : 'CONFIG_BT_MONITOR_ON_DEV_NAME',

--- a/subsys/shell/Kconfig
+++ b/subsys/shell/Kconfig
@@ -3,6 +3,7 @@
 #
 # Copyright (c) 2014-2015 Wind River Systems, Inc.
 # Copyright (c) 2016 Intel Corporation
+# Copyright (c) 2018 Nordic Semiconductor ASA
 #
 # SPDX-License-Identifier: Apache-2.0
 #

--- a/subsys/shell/Kconfig.backends
+++ b/subsys/shell/Kconfig.backends
@@ -24,6 +24,15 @@ config SHELL_BACKEND_SERIAL
 
 if SHELL_BACKEND_SERIAL
 
+if !HAS_DTS
+config UART_SHELL_ON_DEV_NAME
+	string "Device Name of UART Device for SHELL_BACKEND_SERIAL"
+	default "UART_0"
+	help
+	  This option specifies the name of UART device to be used for the
+	  SHELL UART backend.
+endif
+
 # Internal config to enable UART interrupts if supported.
 config SHELL_BACKEND_SERIAL_INTERRUPT_DRIVEN
 	bool "Interrupt driven"

--- a/subsys/shell/shell_uart.c
+++ b/subsys/shell/shell_uart.c
@@ -229,7 +229,7 @@ static int enable_shell_uart(struct device *arg)
 {
 	ARG_UNUSED(arg);
 	struct device *dev =
-			device_get_binding(CONFIG_UART_CONSOLE_ON_DEV_NAME);
+			device_get_binding(CONFIG_UART_SHELL_ON_DEV_NAME);
 	bool log_backend = CONFIG_SHELL_BACKEND_SERIAL_LOG_LEVEL > 0;
 	u32_t level =
 		(CONFIG_SHELL_BACKEND_SERIAL_LOG_LEVEL > LOG_LEVEL_DBG) ?


### PR DESCRIPTION
Removed Console dependencies from shell uart backend.
Generated define: CONFIG_UART_SHELL_ON_DEV_NAME for each board.

Fixes #10191

Signed-off-by: Jakub Rzeszutko <jakub.rzeszutko@nordicsemi.no>