### PR TITLE
soc: silabs_exx32: remove pinmap dependency on part number

### DIFF
--- a/soc/arm/silabs_exx32/efm32hg/soc_pinmap.h
+++ b/soc/arm/silabs_exx32/efm32hg/soc_pinmap.h
@@ -16,7 +16,6 @@
 #include <soc.h>
 #include <em_gpio.h>
 
-#ifdef CONFIG_SOC_PART_NUMBER_EFM32HG322F64
 #ifdef CONFIG_USART_GECKO_0
 #if (DT_USART_GECKO_0_LOCATION == 0)
 #define PIN_USART0_TXD {gpioPortE, 10, gpioModePushPull, 1}
@@ -54,8 +53,5 @@
 #error ("Serial Driver for Gecko MCUs not implemented for this location index")
 #endif
 #endif /* CONFIG_USART_GECKO_1 */
-#else
-#error ("Pinmap not available for this for Happy Gecko MCU")
-#endif /* SOC_PART_NUMBER_EFM32HG322F64*/
 
 #endif /* _SILABS_EFM32HG_SOC_PINMAP_H_ */

--- a/soc/arm/silabs_exx32/efm32pg12b/soc_pinmap.h
+++ b/soc/arm/silabs_exx32/efm32pg12b/soc_pinmap.h
@@ -16,7 +16,6 @@
 #include <soc.h>
 #include <em_gpio.h>
 
-#ifdef CONFIG_SOC_PART_NUMBER_EFM32PG12B500F1024GL125
 #ifdef CONFIG_USART_GECKO_0
 #if (DT_USART_GECKO_0_GPIO_LOC == 0)
 #define PIN_USART0_TXD {gpioPortA, 0, gpioModePushPull, 1}
@@ -82,9 +81,5 @@
 #endif
 #endif /* CONFIG_I2C_1 */
 #endif /* CONFIG_I2C_GECKO */
-
-#else
-#error ("Pinmap not available for this for Pearl Gecko MCU")
-#endif /* SOC_PART_NUMBER_EFM32PG12B500F1024GL125*/
 
 #endif /* _SILABS_EFM32PG12B_SOC_PINMAP_H_ */

--- a/soc/arm/silabs_exx32/efm32wg/soc_pinmap.h
+++ b/soc/arm/silabs_exx32/efm32wg/soc_pinmap.h
@@ -16,7 +16,6 @@
 #include <soc.h>
 #include <em_gpio.h>
 
-#ifdef CONFIG_SOC_PART_NUMBER_EFM32WG990F256
 #ifdef CONFIG_UART_GECKO_0
 #if (DT_UART_GECKO_0_LOCATION == 0)
 #define PIN_UART0_TXD {gpioPortF, 6, gpioModePushPull, 1}
@@ -48,8 +47,5 @@
 #error ("Serial Driver for Gecko MCUs not implemented for this location index")
 #endif
 #endif /* CONFIG_UART_GECKO_0 */
-#else
-#error ("Pinmap not available for this for Wonder Gecko MCU")
-#endif /* SOC_PART_NUMBER_EFM32WG990F256*/
 
 #endif /* _SILABS_EFM32WG_SOC_PINMAP_H_ */

--- a/soc/arm/silabs_exx32/efr32fg1p/soc_pinmap.h
+++ b/soc/arm/silabs_exx32/efr32fg1p/soc_pinmap.h
@@ -16,7 +16,6 @@
 #include <soc.h>
 #include <em_gpio.h>
 
-#ifdef CONFIG_SOC_PART_NUMBER_EFR32FG1P133F256GM48
 #ifdef CONFIG_USART_GECKO_0
 #if (DT_USART_GECKO_0_LOCATION == 0)
 #define PIN_USART0_TXD {gpioPortA, 0, gpioModePushPull, 1}
@@ -48,8 +47,5 @@
 #error ("Serial Driver for Gecko MCUs not implemented for this location index")
 #endif
 #endif /* CONFIG_USART_GECKO_1 */
-#else
-#error ("Pinmap not available for this for Flex Gecko MCU")
-#endif /* CONFIG_SOC_PART_NUMBER_EFR32FG1P133F256GM48 */
 
 #endif /* _SILABS_EFR32FG1P_SOC_PINMAP_H_ */

--- a/soc/arm/silabs_exx32/efr32mg12p/soc_pinmap.h
+++ b/soc/arm/silabs_exx32/efr32mg12p/soc_pinmap.h
@@ -57,7 +57,4 @@
 #endif /* CONFIG_I2C_1 */
 #endif /* CONFIG_I2C_GECKO */
 
-#else
-#error ("Pinmap not available for this Mighty Gecko MCU")
-
 #endif /* _SOC_PINMAP_H_ */


### PR DESCRIPTION
Within a single series pin mapping between location setting and pin name
is uniform. The only difference is availability of the module, i.e. i2c1
may be missing on some part numbers, or availability of the pin, i.e.
32 pin package will not provide all the pins available on 48 pin
package. It's better to manage these differences at the DTS/Kconfig
level.

This commit removes dependency of soc_pinmap.h files on part numbers.