### PR TITLE
doc: fix broken link in upsquared board doc

### DIFF
--- a/boards/x86/up_squared/doc/up_squared.rst
+++ b/boards/x86/up_squared/doc/up_squared.rst
@@ -300,6 +300,6 @@ Steps
          WARNING: no console will be available to OS
 
 
-.. _UP Squared: http://www.up-board.org/upsquared/
+.. _UP Squared: https://www.up-board.org/upsquared/specifications
 
 .. _UP Squared Pinout: https://wiki.up-community.org/Pinout


### PR DESCRIPTION
Link to upsquared specifications was incorrect

Signed-off-by: David B. Kinder <david.b.kinder@intel.com>