### PR TITLE
arch: arm: fix the convenience macro for ARMv7-M MPU

### DIFF
--- a/include/arch/arm/cortex_m/mpu/arm_mpu_v7m.h
+++ b/include/arch/arm/cortex_m/mpu/arm_mpu_v7m.h
@@ -147,10 +147,10 @@ typedef struct arm_mpu_region_attr arm_mpu_region_attr_t;
 #define K_MEM_PARTITION_IS_WRITABLE(attr) \
 	({ \
 		int __is_writable__; \
-		switch (attr) { \
-		case P_RW_U_RW: \
-		case P_RW_U_RO: \
-		case P_RW_U_NA: \
+		switch (attr & MPU_RASR_AP_Msk) { \
+		case P_RW_U_RW_Msk: \
+		case P_RW_U_RO_Msk: \
+		case P_RW_U_NA_Msk: \
 			__is_writable__ = 1; \
 			break; \
 		default: \


### PR DESCRIPTION
This commit fixes a bug in the ARMv7-M convenience macro that
evaluates write-ability of given access permissions attributes.

Signed-off-by: Ioannis Glaropoulos <Ioannis.Glaropoulos@nordicsemi.no>