### PR TITLE
drivers: flash: spi_nor: Remove page alignment requirement for read

### DIFF
--- a/boards/xtensa/intel_s1000_crb/Kconfig.defconfig
+++ b/boards/xtensa/intel_s1000_crb/Kconfig.defconfig
@@ -73,9 +73,6 @@ config SPI_NOR_SECTOR_SIZE
 config SPI_NOR_SECTORS
 	default 1024
 
-config SPI_NOR_BLOCK_SIZE
-	default 65536
-
 choice SPI_NOR_BLOCK_ERASE_SIZE
 	default SPI_NOR_BLOCK_ERASE_64K
 endchoice

--- a/drivers/flash/Kconfig.nor
+++ b/drivers/flash/Kconfig.nor
@@ -46,12 +46,6 @@ config SPI_NOR_SECTORS
 	This option specifies number of sector present
 	in SPI flash
 
-config SPI_NOR_BLOCK_SIZE
-	int "Block size of SPI flash"
-	default 0
-	help
-	This option specifies block size of SPI flash
-
 choice SPI_NOR_BLOCK_ERASE_SIZE
 prompt "Select Block size for erasing"
 

--- a/drivers/flash/spi_nor.c
+++ b/drivers/flash/spi_nor.c
@@ -397,8 +397,7 @@ static const struct flash_driver_api spi_nor_api = {
 static const struct spi_nor_config flash_id = {
 	JEDEC_ID(CONFIG_SPI_NOR_JEDEC_ID),
 	CONFIG_SPI_NOR_PAGE_SIZE, CONFIG_SPI_NOR_SECTOR_SIZE,
-	CONFIG_SPI_NOR_SECTORS, CONFIG_SPI_NOR_BLOCK_SIZE,
-	CONFIG_SPI_NOR_BLOCK_ERASE_SIZE,
+	CONFIG_SPI_NOR_SECTORS, CONFIG_SPI_NOR_BLOCK_ERASE_SIZE,
 };
 
 static struct spi_nor_data spi_nor_memory_data;

--- a/drivers/flash/spi_nor.c
+++ b/drivers/flash/spi_nor.c
@@ -184,11 +184,6 @@ static int spi_nor_read(struct device *dev, off_t addr, void *dest,
 		return -EINVAL;
 	}
 
-	/* start address should be aligned on a page size */
-	if ((addr & (params->page_size - 1)) != 0) {
-		return -EINVAL;
-	}
-
 	SYNC_LOCK();
 
 	spi_nor_wait_until_ready(dev);
@@ -226,11 +221,6 @@ static int spi_nor_write(struct device *dev, off_t addr, const void *src,
 	/* should be between 0 and flash size */
 	if ((addr < 0) || ((size + addr) > (params->sector_size *
 						params->n_sectors))) {
-		return -EINVAL;
-	}
-
-	/* start address should be aligned on a page size */
-	if ((addr & (params->page_size - 1)) != 0) {
 		return -EINVAL;
 	}
 

--- a/drivers/flash/spi_nor.h
+++ b/drivers/flash/spi_nor.h
@@ -16,7 +16,6 @@ struct spi_nor_config {
 	u32_t page_size;
 	u32_t sector_size;
 	u32_t n_sectors;
-	u32_t block_size;
 	u32_t flag;
 };
 


### PR DESCRIPTION
For flash R/W, the start address need not be aligned on a page size.

Signed-off-by: Rajavardhan Gundi <rajavardhan.gundi@intel.com>