### PR TITLE
drivers: spi: sam{,0}: avoid unsigned comparision with less than zero

### DIFF
--- a/drivers/spi/spi_sam.c
+++ b/drivers/spi/spi_sam.c
@@ -220,7 +220,7 @@ static void spi_sam_fast_txrx(Spi *regs,
 	u8_t *rx = rx_buf->buf;
 	size_t len = rx_buf->len;
 
-	if (len <= 0) {
+	if (len == 0) {
 		return;
 	}
 

--- a/drivers/spi/spi_sam0.c
+++ b/drivers/spi/spi_sam0.c
@@ -228,7 +228,7 @@ static void spi_sam0_fast_txrx(SercomSpi *regs,
 	u8_t *rx = rx_buf->buf;
 	size_t len = rx_buf->len;
 
-	if (len <= 0) {
+	if (len == 0) {
 		return;
 	}
 


### PR DESCRIPTION
Avoid comparison of size_t with less than zero.
This fixes #11136.