### PR TITLE
samples: mesh: nrf52: removed bug in Gen. onoff unack handler

### DIFF
--- a/samples/boards/nrf52/mesh/onoff_level_lighting_vnd_app/src/mesh/device_composition.c
+++ b/samples/boards/nrf52/mesh/onoff_level_lighting_vnd_app/src/mesh/device_composition.c
@@ -195,8 +195,8 @@ static void gen_onoff_set_unack(struct bt_mesh_model *model,
 
 	if (state->target_onoff != state->onoff) {
 		onoff_tt_values(state, tt, delay);
-		gen_onoff_publisher(model);
 	} else {
+		gen_onoff_publisher(model);
 		return;
 	}
 


### PR DESCRIPTION
In Gen. OnOff Unack handler, gen_onoff_publisher(model) was
misplaced previously & now it is set to proper location.

Signed-off-by: Vikrant More <vikrant8051@gmail.com>