### PR TITLE
net: app: Remove extra log_strdup() calls

### DIFF
--- a/subsys/net/lib/app/net_app.c
+++ b/subsys/net/lib/app/net_app.c
@@ -109,7 +109,7 @@ char *_net_app_sprint_ipaddr(char *buf, int buflen,
 		net_addr_ntop(addr->sa_family,
 			      &net_sin6(addr)->sin6_addr,
 			      ipaddr, sizeof(ipaddr));
-		snprintk(buf, buflen, "[%s]:%u", log_strdup(ipaddr),
+		snprintk(buf, buflen, "[%s]:%u", ipaddr,
 			 ntohs(net_sin6(addr)->sin6_port));
 #endif
 	} else if (addr->sa_family == AF_INET) {
@@ -119,7 +119,7 @@ char *_net_app_sprint_ipaddr(char *buf, int buflen,
 		net_addr_ntop(addr->sa_family,
 			      &net_sin(addr)->sin_addr,
 			      ipaddr, sizeof(ipaddr));
-		snprintk(buf, buflen, "%s:%u", log_strdup(ipaddr),
+		snprintk(buf, buflen, "%s:%u", ipaddr,
 			 ntohs(net_sin(addr)->sin_port));
 #endif
 	} else {


### PR DESCRIPTION
The _net_app_sprint_ipaddr() was calling log_strdup() when
creating the debug print string. This is not correct as
the log_strdup() can only be used when calling the logging macro
to print strings.

Signed-off-by: Jukka Rissanen <jukka.rissanen@linux.intel.com>