### PR TITLE
shell: fix double new line print for RTT backend

### DIFF
--- a/include/shell/shell.h
+++ b/include/shell/shell.h
@@ -349,6 +349,7 @@ struct shell_flags {
 	u32_t tx_rdy      :1;
 	u32_t mode_delete :1; /*!< Operation mode of backspace key */
 	u32_t history_exit:1; /*!< Request to exit history mode */
+	u32_t last_nl     :8; /*!< Last received new line character */
 };
 
 BUILD_ASSERT_MSG((sizeof(struct shell_flags) == sizeof(u32_t)),


### PR DESCRIPTION
In case terminal sends \r\n once user press Enter
shell will go to new line twice and it will print prompt
twice. This patch fixes it.

Signed-off-by: Jakub Rzeszutko <jakub.rzeszutko@nordicsemi.no>