### PR TITLE
boards: qemu_x86: Remove QEMU option which break eth_e1000 driver

### DIFF
--- a/boards/x86/qemu_x86/board.cmake
+++ b/boards/x86/qemu_x86/board.cmake
@@ -11,10 +11,7 @@ set(QEMU_FLAGS_${ARCH}
   -device isa-debug-exit,iobase=0xf4,iosize=0x04
   ${REBOOT_FLAG}
   -nographic
-  -vga none
-  -display none
   -no-acpi
-  -machine type=pc-0.14
   )
 
 # TODO: Support debug


### PR DESCRIPTION
"-machine type=pc-0.14" appears to be the option which leads to
broken PCI emulation in QEMU, where PCI enumeration reports one
IRQ number (11), while actually IRQ 10 is emulated by QEMU.

"-vga none" and "-display none" appear to be just subordinate of
"-machine type=pc-0.14" and are required to get qemu_x86 into
bootable state.

Fixes: #11706

Signed-off-by: Paul Sokolovsky <paul.sokolovsky@linaro.org>