### PR TITLE
net: mqtt: Fix two bugs

### DIFF
--- a/subsys/net/lib/mqtt_sock/mqtt.c
+++ b/subsys/net/lib/mqtt_sock/mqtt.c
@@ -185,16 +185,14 @@ int mqtt_connect(struct mqtt_client *client)
 	}
 
 	err_code = client_connect(client);
-	if (err_code < 0) {
-		err_code = -ECONNREFUSED;
-		goto error;
-	}
-
-	return 0;
 
 error:
-	client_reset(client);
+	if (err_code < 0) {
+		client_reset(client);
+	}
+
 	mqtt_mutex_unlock(client);
+
 	return err_code;
 }
 

--- a/subsys/net/lib/mqtt_sock/mqtt_encoder.c
+++ b/subsys/net/lib/mqtt_sock/mqtt_encoder.c
@@ -153,7 +153,8 @@ static u8_t packet_length_encode(u32_t length, struct buf_ctx *buf)
 {
 	u8_t encoded_bytes = 0;
 
-	MQTT_TRC(">> length:0x%08x cur:%p, end:%p", length, buf->cur, buf->end);
+	MQTT_TRC(">> length:0x%08x cur:%p, end:%p", length,
+		 (buf == NULL) ? 0 : buf->cur, (buf == NULL) ? 0 : buf->end);
 
 	do {
 		encoded_bytes++;


### PR DESCRIPTION
Fixing two bugs that slipped in during the rework, found while using the new MQTT implementation "in the field".

Missing mutex unlock was not spotted before as Zephyr sample/tests use MQTT from a single thread, and in that case everything just works fine.