### PR TITLE
kernel: Remove _IntLibInit function

### DIFF
--- a/arch/arc/include/kernel_arch_func.h
+++ b/arch/arc/include/kernel_arch_func.h
@@ -61,11 +61,6 @@ static ALWAYS_INLINE int _INTERRUPT_CAUSE(void)
 extern void _thread_entry_wrapper(void);
 extern void _user_thread_entry_wrapper(void);
 
-static inline void _IntLibInit(void)
-{
-	/* nothing needed, here because the kernel requires it */
-}
-
 extern void _arc_userspace_enter(k_thread_entry_t user_entry, void *p1,
 		 void *p2, void *p3, u32_t stack, u32_t size);
 

--- a/arch/arm/core/cortex_m/prep_c.c
+++ b/arch/arm/core/cortex_m/prep_c.c
@@ -105,6 +105,8 @@ extern FUNC_NORETURN void _Cstart(void);
  * @return N/A
  */
 
+extern void _IntLibInit(void);
+
 #ifdef CONFIG_BOOT_TIME_MEASUREMENT
 	extern u64_t __start_time_stamp;
 #endif
@@ -117,6 +119,7 @@ void _PrepC(void)
 #ifdef CONFIG_BOOT_TIME_MEASUREMENT
 	__start_time_stamp = 0;
 #endif
+	_IntLibInit();
 	_Cstart();
 	CODE_UNREACHABLE;
 }

--- a/arch/arm/include/kernel_arch_func.h
+++ b/arch/arm/include/kernel_arch_func.h
@@ -127,9 +127,6 @@ extern void k_cpu_atomic_idle(unsigned int key);
 
 #define _is_in_isr() _IsInIsr()
 
-extern void _IntLibInit(void);
-
-
 extern FUNC_NORETURN void _arm_userspace_enter(k_thread_entry_t user_entry,
 					       void *p1, void *p2, void *p3,
 					       u32_t stack_end,

--- a/arch/nios2/include/kernel_arch_func.h
+++ b/arch/nios2/include/kernel_arch_func.h
@@ -41,11 +41,6 @@ _set_thread_return_value(struct k_thread *thread, unsigned int value)
 	thread->callee_saved.retval = value;
 }
 
-static inline void _IntLibInit(void)
-{
-	/* No special initialization of the interrupt subsystem required */
-}
-
 #define _is_in_isr() (_kernel.nested != 0U)
 
 #ifdef CONFIG_IRQ_OFFLOAD

--- a/arch/posix/core/posix_core.c
+++ b/arch/posix/core/posix_core.c
@@ -385,7 +385,7 @@ void posix_new_thread(posix_thread_status_t *ptr)
 }
 
 /**
- * Called from _IntLibInit()
+ * Called from zephyr_wrapper()
  * prepare whatever needs to be prepared to be able to start threads
  */
 void posix_init_multithreading(void)

--- a/arch/posix/include/kernel_arch_func.h
+++ b/arch/posix/include/kernel_arch_func.h
@@ -49,16 +49,6 @@ _set_thread_return_value(struct k_thread *thread, unsigned int value)
 	thread->callee_saved.retval = value;
 }
 
-
-/*
- * _IntLibInit() is called from the non-arch specific function,
- * prepare_multithreading().
- */
-static inline void _IntLibInit(void)
-{
-	posix_init_multithreading();
-}
-
 #ifdef __cplusplus
 }
 #endif

--- a/arch/riscv32/core/prep_c.c
+++ b/arch/riscv32/core/prep_c.c
@@ -35,6 +35,9 @@ void _PrepC(void)
 #ifdef CONFIG_XIP
 	_data_copy();
 #endif
+#if defined(CONFIG_RISCV_SOC_INTERRUPT_INIT)
+	soc_interrupt_init();
+#endif
 	_Cstart();
 	CODE_UNREACHABLE;
 }

--- a/arch/riscv32/include/kernel_arch_func.h
+++ b/arch/riscv32/include/kernel_arch_func.h
@@ -37,13 +37,6 @@ _set_thread_return_value(struct k_thread *thread, unsigned int value)
 	thread->arch.swap_return_value = value;
 }
 
-static inline void _IntLibInit(void)
-{
-#if defined(CONFIG_RISCV_SOC_INTERRUPT_INIT)
-	soc_interrupt_init();
-#endif
-}
-
 FUNC_NORETURN void _NanoFatalErrorHandler(unsigned int reason,
 					  const NANO_ESF *esf);
 

--- a/arch/x86/include/kernel_arch_func.h
+++ b/arch/x86/include/kernel_arch_func.h
@@ -118,16 +118,6 @@ static inline void write_x2apic(unsigned int reg, u32_t val)
 }
 #endif
 
-/*
- * _IntLibInit() is called from the non-arch specific function,
- * prepare_multithreading(). The IA-32 kernel does not require any special
- * initialization of the interrupt subsystem. However, we still need to
- * provide an _IntLibInit() of some sort to prevent build errors.
- */
-static inline void _IntLibInit(void)
-{
-}
-
 extern FUNC_NORETURN void _x86_userspace_enter(k_thread_entry_t user_entry,
 					       void *p1, void *p2, void *p3,
 					       u32_t stack_end,

--- a/arch/xtensa/include/kernel_arch_func.h
+++ b/arch/xtensa/include/kernel_arch_func.h
@@ -118,14 +118,6 @@ _set_thread_return_value(struct k_thread *thread, unsigned int value)
 
 extern void k_cpu_atomic_idle(unsigned int key);
 
-/*
- * Required by the core kernel even though we don't have to do anything on this
- * arch.
- */
-static inline void _IntLibInit(void)
-{
-}
-
 #include <stddef.h> /* For size_t */
 
 #ifdef __cplusplus

--- a/kernel/init.c
+++ b/kernel/init.c
@@ -463,8 +463,6 @@ FUNC_NORETURN void _Cstart(void)
 	 * drivers are initialized.
 	 */
 
-	_IntLibInit();
-
 	if (IS_ENABLED(CONFIG_LOG)) {
 		log_core_init();
 	}

--- a/soc/posix/inf_clock/soc.c
+++ b/soc/posix/inf_clock/soc.c
@@ -183,6 +183,8 @@ static void *zephyr_wrapper(void *a)
 			zephyr_thread);
 #endif
 
+	posix_init_multithreading();
+
 	/* Start Zephyr: */
 	_Cstart();
 	CODE_UNREACHABLE;


### PR DESCRIPTION
There were many platforms where this function was doing nothing. Just
merging its functionality with _PrepC function.

Signed-off-by: Flavio Ceolin <flavio.ceolin@intel.com>