### PR TITLE
net: Discard received extra data at the end of the IP message

### DIFF
--- a/subsys/net/ip/ipv4.c
+++ b/subsys/net/ip/ipv4.c
@@ -117,9 +117,11 @@ enum net_verdict net_ipv4_process_pkt(struct net_pkt *pkt)
 	int pkt_len = ntohs(hdr->len);
 	enum net_verdict verdict = NET_DROP;
 
-	if (real_len != pkt_len) {
+	if (real_len < pkt_len) {
 		NET_DBG("IPv4 packet size %d pkt len %d", pkt_len, real_len);
 		goto drop;
+	} else if (real_len > pkt_len) {
+		net_pkt_pull(pkt, pkt_len, real_len - pkt_len);
 	}
 
 	if (net_ipv4_is_addr_mcast(&hdr->src)) {

--- a/subsys/net/ip/ipv6.c
+++ b/subsys/net/ip/ipv6.c
@@ -446,10 +446,13 @@ enum net_verdict net_ipv6_process_pkt(struct net_pkt *pkt, bool is_loopback)
 	u16_t total_len = 0;
 	u8_t ext_bitmap;
 
-	if (real_len != pkt_len) {
+	if (real_len < pkt_len) {
 		NET_DBG("IPv6 packet size %d pkt len %d", pkt_len, real_len);
 		net_stats_update_ipv6_drop(net_pkt_iface(pkt));
 		goto drop;
+	} else if (real_len > pkt_len) {
+		net_pkt_pull(pkt, pkt_len, real_len - pkt_len);
+		real_len = net_pkt_get_len(pkt);
 	}
 
 	NET_DBG("IPv6 packet len %d received from %s to %s", real_len,


### PR DESCRIPTION
If we receive extra data at the end of the IP message, then
discard that data and accept the packet.

Fixes #11649

Signed-off-by: Jukka Rissanen <jukka.rissanen@linux.intel.com>