### PR TITLE
samples: net: Fix zperf build issue

### DIFF
--- a/samples/net/zperf/src/zperf_tcp_receiver.c
+++ b/samples/net/zperf/src/zperf_tcp_receiver.c
@@ -32,12 +32,8 @@
 static K_THREAD_STACK_DEFINE(zperf_tcp_rx_stack, TCP_RX_FIBER_STACK_SIZE);
 static struct k_thread zperf_tcp_rx_thread_data;
 
-#if defined(CONFIG_NET_IPV6)
 static struct sockaddr_in6 *in6_addr_my;
-#endif
-#if defined(CONFIG_NET_IPV4)
 static struct sockaddr_in *in4_addr_my;
-#endif
 
 static void tcp_received(struct net_context *context,
 			 struct net_pkt *pkt,


### PR DESCRIPTION
If NET_IPV6 is disabled, build issue happens as below.
    
    zephyr/samples/net/zperf/src/zperf_tcp_receiver.c: In function ‘zperf_tcp_rx_thread’:
    zephyr/samples/net/zperf/src/zperf_tcp_receiver.c:171:9: error: ‘in6_addr_my’ undeclared (first use in this function)
            &in6_addr_my->sin6_addr);
             ^~~~~~~~~~~
    zephyr/samples/net/zperf/src/zperf_tcp_receiver.c:171:9: note: each undeclared identifier is reported only once for each function it appears in
    zephyr/samples/net/zperf/src/zperf_tcp_receiver.c: In function ‘zperf_tcp_receiver_init’:
    zephyr/samples/net/zperf/src/zperf_tcp_receiver.c:250:3: error: ‘in6_addr_my’ undeclared (first use in this function)
       in6_addr_my = zperf_get_sin6();
       ^~~~~~~~~~~
    *** [CMakeFiles/app.dir/src/zperf_tcp_receiver.c.obj] error 1
    *** [CMakeFiles/app.dir/all] error 2
    
    Signed-off-by: Bub Wei <bub.wei@unisoc.com>
