### PR TITLE
arch: arm: Add symbol for flash used

### DIFF
--- a/include/arch/arm/cortex_m/scripts/linker.ld
+++ b/include/arch/arm/cortex_m/scripts/linker.ld
@@ -481,4 +481,13 @@ SECTIONS
 	KEEP(*(.gnu.attributes))
 	}
 
+/* Must be last in romable region */
+SECTION_PROLOGUE(.last_section,(NOLOAD),)
+{
+} GROUP_LINK_IN(ROMABLE_REGION)
+
+/* To provide the image size as a const expression,
+ * calculate this value here. */
+_flash_used = LOADADDR(.last_section) - _image_rom_start;
+
     }

--- a/include/linker/linker-defs.h
+++ b/include/linker/linker-defs.h
@@ -233,6 +233,9 @@ extern char _image_rom_start[];
 extern char _image_rom_end[];
 extern char _image_rom_size[];
 
+/* Includes all ROMable data, i.e. the size of the output image file. */
+extern char _flash_used[];
+
 /* datas, bss, noinit */
 extern char _image_ram_start[];
 extern char _image_ram_end[];


### PR DESCRIPTION
Add symbol which contains the number of bytes contained
in the image.

Using '_image_rom_end' will not work, as there are
symbols loaded after its value.

Signed-off-by: Håkon Øye Amundsen <haakon.amundsen@nordicsemi.no>