### PR TITLE
logging: log_core: Clarify message when log_strdup failed allocation

### DIFF
--- a/subsys/logging/Kconfig
+++ b/subsys/logging/Kconfig
@@ -273,8 +273,11 @@ config LOG_STRDUP_BUF_COUNT
 	int "Number of buffers in the pool used by log_strdup()"
 	default 4
 	help
-	  When pool is empty log_strdup() returns warning string instead of the
-	  copy.
+	  Number of calls to log_strdup() which can be pending before flushed
+	  to output. If "<log_strdup alloc failed>" message is seen in the log
+	  output, it means this value is too small and should be increased.
+	  Each entry takes CONFIG_LOG_STRDUP_MAX_STRING bytes of memory plus
+	  some additional fixed overhead.
 
 config LOG_DOMAIN_ID
 	int "Domain ID"

--- a/subsys/logging/log_core.c
+++ b/subsys/logging/log_core.c
@@ -26,7 +26,7 @@ struct log_strdup_buf {
 #define LOG_STRDUP_POOL_BUFFER_SIZE \
 	(sizeof(struct log_strdup_buf) * CONFIG_LOG_STRDUP_BUF_COUNT)
 
-static const char *log_strdup_fail_msg = "log_strdup pool empty!";
+static const char *log_strdup_fail_msg = "<log_strdup alloc failed>";
 struct k_mem_slab log_strdup_pool;
 static u8_t __noinit __aligned(sizeof(u32_t))
 		log_strdup_pool_buf[LOG_STRDUP_POOL_BUFFER_SIZE];


### PR DESCRIPTION
Don't say that pool is empty, say that allocation failed, because
that's what happened (because the pool is full apparently).

Partially addresses #11007.

Signed-off-by: Paul Sokolovsky <paul.sokolovsky@linaro.org>