### PR TITLE
boards stm32_min_dev: modify board led pin assignment

### DIFF
--- a/boards/arm/stm32_min_dev/stm32_min_dev.dts
+++ b/boards/arm/stm32_min_dev/stm32_min_dev.dts
@@ -20,7 +20,7 @@
 	leds {
 		compatible = "gpio-leds";
 		led: led {
-			gpios = <&gpiob 12 GPIO_INT_ACTIVE_HIGH>;
+			gpios = <&gpioc 13 GPIO_INT_ACTIVE_HIGH>;
 			label = "LD";
 		};
 	};


### PR DESCRIPTION
Modify board stm32_min_dev aka "blue pill" led pin assignment in dts
from PB12 to PC13.
This board has a user led connected to PC13.
Sample blinky and similar would run out-of-box without additional
circuit to readout PB12 level.
Tested blinky on corresponding board.

Signed-off-by: Stephen Yi <stephen.jin.yee@gmail.com>