### PR TITLE
logging: fix to not enable LOG_CMDS if SHELL is disabled

### DIFF
--- a/subsys/logging/Kconfig
+++ b/subsys/logging/Kconfig
@@ -285,6 +285,7 @@ config LOG_DOMAIN_ID
 
 config LOG_CMDS
 	bool "Enable shell commands"
+	depends on SHELL
 	default y if SHELL
 
 config LOG_BACKEND_UART


### PR DESCRIPTION
It was preventing a compile if SHELL is disabled. `undefined reference to `shell_fprintf'` etc.

Signed-off-by: Tavish Naruka <tavishnaruka@gmail.com>