### PR TITLE
boards stm32_min_dev: enable usb support

### DIFF
--- a/boards/arm/stm32_min_dev/pinmux.c
+++ b/boards/arm/stm32_min_dev/pinmux.c
@@ -33,6 +33,10 @@ static const struct pin_config pinconf[] = {
 #ifdef CONFIG_PWM_STM32_1
 	{STM32_PIN_PA8, STM32F1_PINMUX_FUNC_PA8_PWM1_CH1},
 #endif /* CONFIG_PWM_STM32_1 */
+#ifdef CONFIG_USB_DC_STM32
+	{STM32_PIN_PA11, STM32F1_PINMUX_FUNC_PA11_USB_DM},
+	{STM32_PIN_PA12, STM32F1_PINMUX_FUNC_PA12_USB_DP},
+#endif	/* CONFIG_USB_DC_STM32 */
 };
 
 static int pinmux_stm32_init(struct device *port)

--- a/boards/arm/stm32_min_dev/stm32_min_dev.dts
+++ b/boards/arm/stm32_min_dev/stm32_min_dev.dts
@@ -61,3 +61,7 @@
 		status = "ok";
 	};
 };
+
+&usb {
+	status = "ok";
+};

--- a/boards/arm/stm32_min_dev/stm32_min_dev.yaml
+++ b/boards/arm/stm32_min_dev/stm32_min_dev.yaml
@@ -9,3 +9,4 @@ ram: 20
 supported:
   - i2c
   - pwm
+  - usb_device


### PR DESCRIPTION
Added usb device related configs to dts and pinmux.
STM32F103C8 has on-chip fullspeed usb interface and the board connected
ralated pins to a mini usb port and xephyr supports it.
Sample cdc_acm and hid work out-of-box.

Signed-off-by: Stephen Yi <stephen.jin.yee@gmail.com>