### PR TITLE
dts: bindings: Add binding for ADXL372 using SPI

### DIFF
--- a/dts/bindings/sensor/adi,adxl372-spi.yaml
+++ b/dts/bindings/sensor/adi,adxl372-spi.yaml
@@ -1,0 +1,27 @@
+#
+# Copyright (c) 2018 Analog Devices Inc.
+# Copyright (c) 2018 Nordic Semiconductor ASA
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+---
+title: ADXL372 Three Axis High-g I2C/SPI accelerometer
+version: 0.1
+
+description: >
+    This is a representation of the ADXL372 Three Axis High-g accelerometer,
+    accessed through SPI bus
+
+inherits:
+    !include spi-device.yaml
+
+properties:
+    compatible:
+      constraint: "adi,adxl372-spi"
+
+    int1-gpios:
+      type: compound
+      category: optional
+      generation: define, use-prop-name
+
+...


### PR DESCRIPTION
This patch adds dts/bindings/adi,adxl372-spi.yaml for
using ADXL372 on SPI bus instead of I2C which is used
in dts/bindings/adi,adxl372.yaml.

As described in #11375, devices supporting both I2C and SPI can't share
the same compatible-name. So to allow adding ADXL372 as an SPI node in DTS,
this separate .yaml file is required for now. 

Signed-off-by: Jan Tore Guggedal <jantore.guggedal@nordicsemi.no>