### PR TITLE
drivers: timer: nrf_rtc_timer: fix handling for 24-bit counter

### DIFF
--- a/drivers/timer/nrf_rtc_timer.c
+++ b/drivers/timer/nrf_rtc_timer.c
@@ -63,7 +63,7 @@ void rtc1_nrf5_isr(void *arg)
 	if (!IS_ENABLED(CONFIG_TICKLESS_KERNEL)) {
 		u32_t next = last_count + CYC_PER_TICK;
 
-		if ((s32_t)(next - t) < MIN_DELAY) {
+		if (counter_sub(next, t) < MIN_DELAY) {
 			next += CYC_PER_TICK;
 		}
 		set_comparator(next);
@@ -126,7 +126,7 @@ void z_clock_set_timeout(s32_t ticks, bool idle)
 	cyc = (cyc / CYC_PER_TICK) * CYC_PER_TICK;
 	cyc += last_count;
 
-	if ((cyc - t) < MIN_DELAY) {
+	if (counter_sub(cyc, t) < MIN_DELAY) {
 		cyc += CYC_PER_TICK;
 	}
 


### PR DESCRIPTION
Two subtractions failed to account for the possibility that a calculated
time exceeded the counter resolution, allowing a comparison to
improperly indicate that a minimum delay was satisfied.

Use the subtraction helper to avoid the problem.

(The subtraction in z_clock_set_timeout was the cause of issue #11694;
the one in rtc1_nrf5_isr was replaced based on inspection rather than
testing.)

Closes #11694 
Fixes #11744

Signed-off-by: Peter A. Bigot <pab@pabigot.com>