### PR TITLE
kernel: workq: queue: unify APis

### DIFF
--- a/doc/kernel/data_passing/fifos.rst
+++ b/doc/kernel/data_passing/fifos.rst
@@ -28,9 +28,9 @@ FIFO data items must be aligned on a 4-byte boundary, as the kernel reserves
 the first 32 bits of an item for use as a pointer to the next data item in the
 queue. Consequently, a data item that holds N bytes of application data
 requires N+4 bytes of memory. There are no alignment or reserved space
-requirements for data items if they are added with
-:cpp:func:`k_fifo_alloc_put()`, instead additional memory is temporarily
-allocated from the calling thread's resource pool.
+requirements for data items if they are added from user mode, instead
+additional memory is temporarily allocated from the calling thread's resource
+pool.
 
 A data item may be **added** to a fifo by a thread or an ISR.
 The item is given directly to a waiting thread, if one exists;
@@ -115,11 +115,6 @@ to send data to one or more consumer threads.
 Additionally, a singly-linked list of data items can be added to a fifo
 by calling :cpp:func:`k_fifo_put_list()` or :cpp:func:`k_fifo_put_slist()`.
 
-Finally, a data item can be added to a fifo with :cpp:func:`k_fifo_alloc_put()`.
-With this API, there is no need to reserve space for the kernel's use in
-the data item, instead additional memory will be allocated from the calling
-thread's resource pool until the item is read.
-
 Reading from a FIFO
 ===================
 
@@ -163,7 +158,6 @@ The following fifo APIs are provided by :file:`kernel.h`:
 
 * :c:macro:`K_FIFO_DEFINE`
 * :cpp:func:`k_fifo_init()`
-* :cpp:func:`k_fifo_alloc_put()`
 * :cpp:func:`k_fifo_put()`
 * :cpp:func:`k_fifo_put_list()`
 * :cpp:func:`k_fifo_put_slist()`

--- a/doc/kernel/data_passing/lifos.rst
+++ b/doc/kernel/data_passing/lifos.rst
@@ -28,9 +28,9 @@ LIFO data items must be aligned on a 4-byte boundary, as the kernel reserves
 the first 32 bits of an item for use as a pointer to the next data item in the
 queue. Consequently, a data item that holds N bytes of application data
 requires N+4 bytes of memory. There are no alignment or reserved space
-requirements for data items if they are added with
-:cpp:func:`k_lifo_alloc_put()`, instead additional memory is temporarily
-allocated from the calling thread's resource pool.
+requirements for data items if they are added from user mode, instead
+additional memory is temporarily allocated from the calling thread's
+resource pool.
 
 A data item may be **added** to a lifo by a thread or an ISR.
 The item is given directly to a waiting thread, if one exists;
@@ -102,11 +102,6 @@ to send data to one or more consumer threads.
             ...
         }
     }
-
-A data item can be added to a lifo with :cpp:func:`k_lifo_alloc_put()`.
-With this API, there is no need to reserve space for the kernel's use in
-the data item, instead additional memory will be allocated from the calling
-thread's resource pool until the item is read.
 
 Reading from a LIFO
 ===================

--- a/kernel/mempool.c
+++ b/kernel/mempool.c
@@ -207,6 +207,8 @@ void *z_thread_malloc(size_t size)
 {
 	void *ret;
 
+	__ASSERT(!k_is_in_isr(), "z_thread_malloc called from ISR context");
+
 	if (_current->resource_pool != NULL) {
 		ret = k_mem_pool_malloc(_current->resource_pool, size);
 	} else {

--- a/kernel/queue.c
+++ b/kernel/queue.c
@@ -187,45 +187,35 @@ void k_queue_insert(struct k_queue *queue, void *prev, void *data)
 	(void)queue_insert(queue, prev, data, false);
 }
 
-void k_queue_append(struct k_queue *queue, void *data)
+s32_t _impl_k_queue_append(struct k_queue *queue, void *data)
 {
-	(void)queue_insert(queue, sys_sflist_peek_tail(&queue->data_q),
-			   data, false);
+	return queue_insert(queue, sys_sflist_peek_tail(&queue->data_q),
+			    data, false);
 }
 
-void k_queue_prepend(struct k_queue *queue, void *data)
+s32_t _impl_k_queue_prepend(struct k_queue *queue, void *data)
 {
-	(void)queue_insert(queue, NULL, data, false);
-}
-
-s32_t _impl_k_queue_alloc_append(struct k_queue *queue, void *data)
-{
-	return queue_insert(queue, sys_sflist_peek_tail(&queue->data_q), data,
-			    true);
+	return queue_insert(queue, NULL, data, false);
 }
 
 #ifdef CONFIG_USERSPACE
-Z_SYSCALL_HANDLER(k_queue_alloc_append, queue, data)
+Z_SYSCALL_HANDLER(k_queue_append, q_ptr, data)
 {
+	struct k_queue *queue = (struct k_queue *)q_ptr;
+
 	Z_OOPS(Z_SYSCALL_OBJ(queue, K_OBJ_QUEUE));
 
-	return _impl_k_queue_alloc_append((struct k_queue *)queue,
-					  (void *)data);
-}
-#endif
-
-s32_t _impl_k_queue_alloc_prepend(struct k_queue *queue, void *data)
-{
-	return queue_insert(queue, NULL, data, true);
+	return queue_insert(queue, sys_sflist_peek_tail(&queue->data_q),
+			    (void *)data, true);
 }
 
-#ifdef CONFIG_USERSPACE
-Z_SYSCALL_HANDLER(k_queue_alloc_prepend, queue, data)
+Z_SYSCALL_HANDLER(k_queue_prepend, q_ptr, data)
 {
+	struct k_queue *queue = (struct k_queue *)q_ptr;
+
 	Z_OOPS(Z_SYSCALL_OBJ(queue, K_OBJ_QUEUE));
 
-	return _impl_k_queue_alloc_prepend((struct k_queue *)queue,
-					   (void *)data);
+	return queue_insert(queue, NULL, (void *)data, true);
 }
 #endif
 

--- a/tests/kernel/poll/src/test_poll.c
+++ b/tests/kernel/poll/src/test_poll.c
@@ -66,7 +66,7 @@ void test_poll_no_wait(void)
 	};
 
 	/* test polling events that are already ready */
-	zassert_false(k_fifo_alloc_put(&no_wait_fifo, &msg), NULL);
+	zassert_false(k_fifo_put(&no_wait_fifo, &msg), NULL);
 	k_poll_signal_raise(&no_wait_signal, SIGNAL_RESULT);
 
 	zassert_equal(k_poll(events, ARRAY_SIZE(events), 0), 0, "");
@@ -144,7 +144,7 @@ static void poll_wait_helper(void *use_fifo, void *p2, void *p3)
 	k_sem_give(&wait_sem);
 
 	if ((intptr_t)use_fifo) {
-		k_fifo_alloc_put(&wait_fifo, &wait_msg);
+		k_fifo_put(&wait_fifo, &wait_msg);
 	}
 
 	k_poll_signal_raise(&wait_signal, SIGNAL_RESULT);
@@ -350,7 +350,7 @@ static void poll_cancel_helper(void *p1, void *p2, void *p3)
 
 	k_fifo_cancel_wait(&cancel_fifo);
 
-	k_fifo_alloc_put(&non_cancel_fifo, &msg);
+	k_fifo_put(&non_cancel_fifo, &msg);
 }
 
 /**

--- a/tests/kernel/queue/src/main.c
+++ b/tests/kernel/queue/src/main.c
@@ -30,7 +30,6 @@ void test_main(void)
 			 ztest_unit_test(test_queue_isr2thread),
 			 ztest_unit_test(test_queue_get_2threads),
 			 ztest_unit_test(test_queue_get_fail),
-			 ztest_unit_test(test_queue_loop),
-			 ztest_unit_test(test_queue_alloc));
+			 ztest_unit_test(test_queue_loop));
 	ztest_run_test_suite(queue_api);
 }

--- a/tests/kernel/queue/src/test_queue.h
+++ b/tests/kernel/queue/src/test_queue.h
@@ -25,6 +25,5 @@ extern void test_queue_alloc(void);
 typedef struct qdata {
 	sys_snode_t snode;
 	u32_t data;
-	bool allocated;
 } qdata_t;
 #endif

--- a/tests/kernel/workq/work_queue_api/src/main.c
+++ b/tests/kernel/workq/work_queue_api/src/main.c
@@ -60,7 +60,7 @@ static void twork_submit(void *data)
 		zassert_false(k_work_pending(&work[i]), NULL);
 		if (work_q) {
 			/**TESTPOINT: work submit to queue*/
-			zassert_false(k_work_submit_to_user_queue(work_q, &work[i]),
+			zassert_false(k_work_submit_to_queue(work_q, &work[i]),
 				      "failed to submit to queue");
 		} else {
 			/**TESTPOINT: work submit to system queue*/


### PR DESCRIPTION
We can just do a runtime check for submitting to a workqueue,
it doesn't depend on whether the target queue is running in
user mode or not.

Similar situation with queue objects, an allocation is now implicit when called from user mode. The old alloc APIs are now deprecated.