### PR TITLE
Replace static_assert by BUILD_ASSERT_MSG

### DIFF
--- a/drivers/i2c/i2c_nrfx_twi.c
+++ b/drivers/i2c/i2c_nrfx_twi.c
@@ -144,7 +144,7 @@ static int init_twi(struct device *dev, const nrfx_twi_config_t *config)
 					  : I2C_NRFX_TWI_INVALID_FREQUENCY)
 
 #define I2C_NRFX_TWI_DEVICE(idx)					       \
-	static_assert(							       \
+	BUILD_ASSERT_MSG(						       \
 		I2C_NRFX_TWI_FREQUENCY(					       \
 			DT_NORDIC_NRF_I2C_I2C_##idx##_CLOCK_FREQUENCY)	       \
 		!= I2C_NRFX_TWI_INVALID_FREQUENCY,			       \

--- a/drivers/i2c/i2c_nrfx_twim.c
+++ b/drivers/i2c/i2c_nrfx_twim.c
@@ -147,7 +147,7 @@ static int init_twim(struct device *dev, const nrfx_twim_config_t *config)
 					  : I2C_NRFX_TWIM_INVALID_FREQUENCY)
 
 #define I2C_NRFX_TWIM_DEVICE(idx)					       \
-	static_assert(							       \
+	BUILD_ASSERT_MSG(						       \
 		I2C_NRFX_TWIM_FREQUENCY(				       \
 			DT_NORDIC_NRF_I2C_I2C_##idx##_CLOCK_FREQUENCY)	       \
 		!= I2C_NRFX_TWIM_INVALID_FREQUENCY,			       \

--- a/drivers/sensor/qdec_nrfx/qdec_nrfx.c
+++ b/drivers/sensor/qdec_nrfx/qdec_nrfx.c
@@ -91,10 +91,10 @@ static int qdec_nrfx_channel_get(struct device       *dev,
 	data->acc = 0;
 	irq_unlock(key);
 
-	static_assert(DT_NORDIC_NRF_QDEC_QDEC_0_STEPS > 0,
-		      "only positive number valid");
-	static_assert(DT_NORDIC_NRF_QDEC_QDEC_0_STEPS <= 2148,
-		      "overflow possible");
+	BUILD_ASSERT_MSG(DT_NORDIC_NRF_QDEC_QDEC_0_STEPS > 0,
+			 "only positive number valid");
+	BUILD_ASSERT_MSG(DT_NORDIC_NRF_QDEC_QDEC_0_STEPS <= 2148,
+			 "overflow possible");
 
 	val->val1 = (acc * FULL_ANGLE) / DT_NORDIC_NRF_QDEC_QDEC_0_STEPS;
 	val->val2 = (acc * FULL_ANGLE)


### PR DESCRIPTION
Replace static_assert in NRFX TWI, TWIM and QDEC drivers by
BUILD_ASSERT_MSG

fixes: #11754

Signed-off-by: Jan Van Winkel <jan.van_winkel@dxplore.eu>