### PR TITLE
samples: net: zperf: Allow to build with IPv4 or IPv6 only

### DIFF
--- a/samples/net/zperf/src/zperf_shell.c
+++ b/samples/net/zperf/src/zperf_shell.c
@@ -617,7 +617,9 @@ static int execute_upload(const struct shell *shell,
 			/* We either upload using IPv4 or IPv6, not both at
 			 * the same time.
 			 */
-			net_context_put(context4);
+			if (IS_ENABLED(CONFIG_NET_IPV4)) {
+				net_context_put(context4);
+			}
 
 			zperf_tcp_upload(shell, context6, duration_in_ms,
 					 packet_size, &results);
@@ -641,7 +643,9 @@ static int execute_upload(const struct shell *shell,
 				goto out;
 			}
 
-			net_context_put(context6);
+			if (IS_ENABLED(CONFIG_NET_IPV6)) {
+				net_context_put(context6);
+			}
 
 			zperf_tcp_upload(shell, context4, duration_in_ms,
 					 packet_size, &results);
@@ -658,8 +662,12 @@ static int execute_upload(const struct shell *shell,
 	}
 
 out:
-	net_context_put(context6);
-	net_context_put(context4);
+	if (IS_ENABLED(CONFIG_NET_IPV6)) {
+		net_context_put(context6);
+	}
+	if (IS_ENABLED(CONFIG_NET_IPV4)) {
+		net_context_put(context4);
+	}
 
 	return 0;
 }


### PR DESCRIPTION
context4/6 is initilalized in net_context_get function
which is restricted under CONFIG_NET_IPV4/IPV6 with
IS_EANBLED macro. So add the same macro check for
net_context_put function to avoid NET_ASSERT(context).

Signed-off-by: Bub Wei <bub.wei@unisoc.com>
