### PR TITLE
logging: Fix logging thread priority

### DIFF
--- a/subsys/logging/Kconfig
+++ b/subsys/logging/Kconfig
@@ -240,13 +240,6 @@ config LOG_PROCESS_THREAD_SLEEP_MS
 	  Log processing thread sleeps for requested period given in
 	  milliseconds. When waken up, thread process any buffered messages.
 
-config LOG_PROCESS_THREAD_PRIO
-	int "Priority of the log internal thread"
-	default -2
-	help
-	  Change with care since log processing can be time consuming thus it
-	  should be on low priority.
-
 config LOG_PROCESS_THREAD_STACK_SIZE
 	int "Stack size for the internal log processing thread"
 	default 768

--- a/subsys/logging/log_core.c
+++ b/subsys/logging/log_core.c
@@ -609,7 +609,7 @@ static int enable_logger(struct device *arg)
 	k_thread_create(&logging_thread, logging_stack,
 			K_THREAD_STACK_SIZEOF(logging_stack),
 			log_process_thread_func, NULL, NULL, NULL,
-			CONFIG_LOG_PROCESS_THREAD_PRIO, 0, K_NO_WAIT);
+			K_LOWEST_APPLICATION_THREAD_PRIO, 0, K_NO_WAIT);
 	k_thread_name_set(&logging_thread, "logging");
 #else
 	log_init();


### PR DESCRIPTION
Removed kconfig option for setting logging thread priority
and fix it to K_LOWEST_APPLICATION_THREAD_PRIO.

Fixes #11749.

Signed-off-by: Krzysztof Chruscinski <krzysztof.chruscinski@nordicsemi.no>