### PR TITLE
uart: native_posix driver: Fix typo

### DIFF
--- a/drivers/serial/uart_native_posix.c
+++ b/drivers/serial/uart_native_posix.c
@@ -179,7 +179,7 @@ static int np_uart_init(struct device *dev)
 		np_uart_driver_api.poll_in = np_uart_stdin_poll_in;
 
 		if (isatty(STDIN_FILENO)) {
-			WARN("The UART dirver has been configured to map to the"
+			WARN("The UART driver has been configured to map to the"
 			     " process stdin&out (NATIVE_UART_0_ON_STDINOUT), "
 			     "but stdin seems to be left attached to the shell."
 			     " This will most likely NOT behave as you want it "


### PR DESCRIPTION
Just a typo fix.
Fixes #11179

Signed-off-by: Alberto Escolar Piedras <alpi@oticon.com>