### PR TITLE
Log drop notification

### DIFF
--- a/include/logging/log_backend.h
+++ b/include/logging/log_backend.h
@@ -29,6 +29,7 @@ struct log_backend_api {
 	void (*put)(const struct log_backend *const backend,
 		    struct log_msg *msg);
 
+	void (*dropped)(const struct log_backend *const backend, u32_t cnt);
 	void (*panic)(const struct log_backend *const backend);
 	void (*init)(void);
 };
@@ -94,7 +95,25 @@ static inline void log_backend_put(const struct log_backend *const backend,
 }
 
 /**
- * @brief Function for reconfiguring backend to panic mode.
+ * @brief Notify backend about dropped log messages.
+ *
+ * Function is optional.
+ *
+ * @param[in] backend  Pointer to the backend instance.
+ * @param[in] cnt      Number of dropped logs since last notification.
+ */
+static inline void log_backend_dropped(const struct log_backend *const backend,
+				       u32_t cnt)
+{
+	assert(backend);
+
+	if (backend->api->dropped) {
+		backend->api->dropped(backend, cnt);
+	}
+}
+
+/**
+ * @brief Reconfigure backend to panic mode.
  *
  * @param[in] backend  Pointer to the backend instance.
  */

--- a/include/logging/log_backend.h
+++ b/include/logging/log_backend.h
@@ -81,7 +81,7 @@ extern const struct log_backend __log_backends_end[0];
 
 
 /**
- * @brief Function for putting message with log entry to the backend.
+ * @brief Put message with log entry to the backend.
  *
  * @param[in] backend  Pointer to the backend instance.
  * @param[in] msg      Pointer to message with log entry.
@@ -89,8 +89,8 @@ extern const struct log_backend __log_backends_end[0];
 static inline void log_backend_put(const struct log_backend *const backend,
 				   struct log_msg *msg)
 {
-	assert(backend);
-	assert(msg);
+	__ASSERT_NO_MSG(backend);
+	__ASSERT_NO_MSG(msg);
 	backend->api->put(backend, msg);
 }
 
@@ -105,7 +105,7 @@ static inline void log_backend_put(const struct log_backend *const backend,
 static inline void log_backend_dropped(const struct log_backend *const backend,
 				       u32_t cnt)
 {
-	assert(backend);
+	__ASSERT_NO_MSG(backend);
 
 	if (backend->api->dropped) {
 		backend->api->dropped(backend, cnt);
@@ -119,12 +119,12 @@ static inline void log_backend_dropped(const struct log_backend *const backend,
  */
 static inline void log_backend_panic(const struct log_backend *const backend)
 {
-	assert(backend);
+	__ASSERT_NO_MSG(backend);
 	backend->api->panic(backend);
 }
 
 /**
- * @brief Function for setting backend id.
+ * @brief Set backend id.
  *
  * @note It is used internally by the logger.
  *
@@ -134,12 +134,12 @@ static inline void log_backend_panic(const struct log_backend *const backend)
 static inline void log_backend_id_set(const struct log_backend *const backend,
 				      u8_t id)
 {
-	assert(backend);
+	__ASSERT_NO_MSG(backend);
 	backend->cb->id = id;
 }
 
 /**
- * @brief Function for getting backend id.
+ * @brief Get backend id.
  *
  * @note It is used internally by the logger.
  *
@@ -148,12 +148,12 @@ static inline void log_backend_id_set(const struct log_backend *const backend,
  */
 static inline u8_t log_backend_id_get(const struct log_backend *const backend)
 {
-	assert(backend);
+	__ASSERT_NO_MSG(backend);
 	return backend->cb->id;
 }
 
 /**
- * @brief Function for getting backend.
+ * @brief Get backend.
  *
  * @param[in] idx  Pointer to the backend instance.
  *
@@ -165,7 +165,7 @@ static inline const struct log_backend *log_backend_get(u32_t idx)
 }
 
 /**
- * @brief Function for getting number of backends.
+ * @brief Get number of backends.
  *
  * @return Number of backends.
  */
@@ -176,7 +176,7 @@ static inline int log_backend_count_get(void)
 }
 
 /**
- * @brief Function for activating backend.
+ * @brief Activate backend.
  *
  * @param[in] backend  Pointer to the backend instance.
  * @param[in] ctx      User context.
@@ -184,25 +184,25 @@ static inline int log_backend_count_get(void)
 static inline void log_backend_activate(const struct log_backend *const backend,
 					void *ctx)
 {
-	assert(backend);
+	__ASSERT_NO_MSG(backend);
 	backend->cb->ctx = ctx;
 	backend->cb->active = true;
 }
 
 /**
- * @brief Function for deactivating backend.
+ * @brief Deactivate backend.
  *
  * @param[in] backend  Pointer to the backend instance.
  */
 static inline void log_backend_deactivate(
 				const struct log_backend *const backend)
 {
-	assert(backend);
+	__ASSERT_NO_MSG(backend);
 	backend->cb->active = false;
 }
 
 /**
- * @brief Function for checking state of the backend.
+ * @brief Check state of the backend.
  *
  * @param[in] backend  Pointer to the backend instance.
  *
@@ -211,7 +211,7 @@ static inline void log_backend_deactivate(
 static inline bool log_backend_is_active(
 				const struct log_backend *const backend)
 {
-	assert(backend);
+	__ASSERT_NO_MSG(backend);
 	return backend->cb->active;
 }
 


### PR DESCRIPTION
Extended backend interface to allow notifying backend  that log messages has been dropped due to insufficient internal buffer size. Notification contains number of log messages dropped since last notification. It is optional for a backend to implement handler.

It touches #11763 for log core. Howeverm updates in backends are required to fix the issue.