### PR TITLE
arch: arc: add missing macro helper definition

### DIFF
--- a/include/arch/arc/v2/linker.ld
+++ b/include/arch/arc/v2/linker.ld
@@ -42,6 +42,14 @@
 		#define MPU_MIN_SIZE 32
 	#endif
 	#define MPU_MIN_SIZE_ALIGN . = ALIGN(MPU_MIN_SIZE );
+	#if defined(CONFIG_MPU_REQUIRES_POWER_OF_TWO_ALIGNMENT)
+		#define MPU_ALIGN(region_size) \
+			. = ALIGN(MPU_MIN_SIZE); \
+			. = ALIGN( 1 << LOG2CEIL(region_size))
+	#else
+		#define MPU_ALIGN(region_size) \
+			. = ALIGN(MPU_MIN_SIZE)
+	#endif
 #else
 	#define MPU_MIN_SIZE_ALIGN
 #endif


### PR DESCRIPTION
Helper macro, MPU_ALIGN() is used by script
gen_app_partitions.py, so the macro needs to be available,
if the APP Shared memory feature is to be used. This commit
defines MPU_ALIGN() in the ARC linker.ld script.

Signed-off-by: Ioannis Glaropoulos <Ioannis.Glaropoulos@nordicsemi.no>