### PR TITLE
arm: nRF5x: select ENTROPY_NRF5_RNG if ENTROPY_GENERATOR is enabled

### DIFF
--- a/soc/arm/nordic_nrf/Kconfig.defconfig
+++ b/soc/arm/nordic_nrf/Kconfig.defconfig
@@ -33,4 +33,11 @@ config SOC_FLASH_NRF
 
 endif # FLASH
 
+if ENTROPY_GENERATOR
+
+config ENTROPY_NRF5_RNG
+	default y
+
+endif # ENTROPY_GENERATOR
+
 endif # SOC_FAMILY_NRF


### PR DESCRIPTION
This is done on other SoCs and is important for some of the net samples.

Signed-off-by: Aurelien Jarno <aurelien@aurel32.net>