### PR TITLE
boards: arm: reel_board: select BT_CTLR if BT is enabled

### DIFF
--- a/boards/arm/reel_board/Kconfig.defconfig
+++ b/boards/arm/reel_board/Kconfig.defconfig
@@ -91,4 +91,11 @@ config IEEE802154_NRF5
 
 endif # IEEE802154
 
+if BT
+
+config BT_CTLR
+	default y
+
+endif # BT
+
 endif # BOARD_REEL_BOARD


### PR DESCRIPTION
Reel Board doesn't enable BT by default like many of the nRF52
boards do.  So let's make enabling BT a bit easier, by selecting
the BT_CTLR config when BT is enabled.  This allows a sample
overlay to merely set:
CONFIG_BT=y

And the end result should be close to correct.

Signed-off-by: Michael Scott <mike@foundries.io>