### PR TITLE
drivers: i2c: fix build break for nrfx_twi* with newlib

### DIFF
--- a/drivers/i2c/i2c_nrfx_twi.c
+++ b/drivers/i2c/i2c_nrfx_twi.c
@@ -144,7 +144,7 @@ static int init_twi(struct device *dev, const nrfx_twi_config_t *config)
 					  : I2C_NRFX_TWI_INVALID_FREQUENCY)
 
 #define I2C_NRFX_TWI_DEVICE(idx)					       \
-	static_assert(							       \
+	BUILD_ASSERT_MSG(						       \
 		I2C_NRFX_TWI_FREQUENCY(					       \
 			DT_NORDIC_NRF_I2C_I2C_##idx##_CLOCK_FREQUENCY)	       \
 		!= I2C_NRFX_TWI_INVALID_FREQUENCY,			       \

--- a/drivers/i2c/i2c_nrfx_twim.c
+++ b/drivers/i2c/i2c_nrfx_twim.c
@@ -147,7 +147,7 @@ static int init_twim(struct device *dev, const nrfx_twim_config_t *config)
 					  : I2C_NRFX_TWIM_INVALID_FREQUENCY)
 
 #define I2C_NRFX_TWIM_DEVICE(idx)					       \
-	static_assert(							       \
+	BUILD_ASSERT_MSG(						       \
 		I2C_NRFX_TWIM_FREQUENCY(				       \
 			DT_NORDIC_NRF_I2C_I2C_##idx##_CLOCK_FREQUENCY)	       \
 		!= I2C_NRFX_TWIM_INVALID_FREQUENCY,			       \


### PR DESCRIPTION
When running sanitycheck for reel_board which selects
CONFIG_NRFX_TWIM it fails the following tests:
tests/misc/test_build/test_newlib
tests/kernel/errno/kernel.common.errno.newlib
tests/lib/mem_alloc/libraries.libc.newlib

/zephyr/drivers/i2c/i2c_nrfx_twim.c:144:3: error: expected declaration
specifiers or '...' before '(' token
   (bitrate == I2C_BITRATE_STANDARD ? NRF_TWIM_FREQ_100K         \
   ^
/zephyr/drivers/i2c/i2c_nrfx_twim.c:151:3: note: in expansion of macro
'I2C_NRFX_TWIM_FREQUENCY'
   I2C_NRFX_TWIM_FREQUENCY(           \
   ^~~~~~~~~~~~~~~~~~~~~~~
/zephyr/drivers/i2c/i2c_nrfx_twim.c:184:1: note: in expansion of macro
'I2C_NRFX_TWIM_DEVICE'
 I2C_NRFX_TWIM_DEVICE(0);
 ^~~~~~~~~~~~~~~~~~~~
/zephyr/drivers/i2c/i2c_nrfx_twim.c:154:3: error: expected declaration
specifiers or '...' before string constant
   "Wrong I2C " #idx " frequency setting in dts");         \
   ^
/zephyr/drivers/i2c/i2c_nrfx_twim.c:184:1: note: in expansion of macro
'I2C_NRFX_TWIM_DEVICE'
 I2C_NRFX_TWIM_DEVICE(0);
 ^~~~~~~~~~~~~~~~~~~~
zephyr/drivers/i2c/CMakeFiles/drivers__i2c.dir/build.make:62: recipe
for target
'zephyr/drivers/i2c/CMakeFiles/drivers__i2c.dir/i2c_nrfx_twim.c.obj'
failed

To fix this, let's replace the use of static_assert() with a more
generic macro: BUILD_ASSERT_MSG()  This should work across minimal
libc, newlibc and c++.

Signed-off-by: Michael Scott <mike@foundries.io>