### PR TITLE
dts: arm: stm32: USART1 fix in device tree for STM32F7 series devices

### DIFF
--- a/dts/arm/st/f7/stm32f7.dtsi
+++ b/dts/arm/st/f7/stm32f7.dtsi
@@ -133,7 +133,7 @@
 		usart1: serial@40011000 {
 			compatible = "st,stm32-usart", "st,stm32-uart";
 			reg = <0x40011000 0x400>;
-			clocks = <&rcc STM32_CLOCK_BUS_APB2 0x00004000>;
+			clocks = <&rcc STM32_CLOCK_BUS_APB2 0x00000010>;
 			interrupts = <37 0>;
 			status = "disabled";
 			label = "UART_1";


### PR DESCRIPTION
Fixed mask value for RCC_APB1ENR register.