### PR TITLE
boards: doc: Remove 802.15.4 support

### DIFF
--- a/boards/arm/nrf51_pca10028/doc/nrf51_pca10028.rst
+++ b/boards/arm/nrf51_pca10028/doc/nrf51_pca10028.rst
@@ -17,7 +17,7 @@ nRF51822 ARM Cortex-M0 CPU and the following devices:
 * :abbr:`I2C (Inter-Integrated Circuit)`
 * :abbr:`NVIC (Nested Vectored Interrupt Controller)`
 * :abbr:`PWM (Pulse Width Modulation)`
-* RADIO (Bluetooth Low Energy and 802.15.4)
+* RADIO (Bluetooth Low Energy)
 * :abbr:`RTC (nRF RTC System Clock)`
 * Segger RTT (RTT Console)
 * :abbr:`SPI (Serial Peripheral Interface)`

--- a/boards/arm/nrf52_pca10040/doc/nrf52_pca10040.rst
+++ b/boards/arm/nrf52_pca10040/doc/nrf52_pca10040.rst
@@ -19,7 +19,7 @@ the following devices:
 * :abbr:`MPU (Memory Protection Unit)`
 * :abbr:`NVIC (Nested Vectored Interrupt Controller)`
 * :abbr:`PWM (Pulse Width Modulation)`
-* RADIO (Bluetooth Low Energy and 802.15.4)
+* RADIO (Bluetooth Low Energy)
 * :abbr:`RTC (nRF RTC System Clock)`
 * Segger RTT (RTT Console)
 * :abbr:`SPI (Serial Peripheral Interface)`

--- a/boards/arm/nrf52_pca20020/doc/nrf52_pca20020.rst
+++ b/boards/arm/nrf52_pca20020/doc/nrf52_pca20020.rst
@@ -22,7 +22,7 @@ a set of environmental sensors, a pushbutton, and two RGB LEDs.
 * :abbr:`NVIC (Nested Vectored Interrupt Controller)`
 * Pressure sensor
 * :abbr:`PWM (Pulse Width Modulation)`
-* RADIO (Bluetooth Low Energy and 802.15.4)
+* RADIO (Bluetooth Low Energy)
 * RGB LEDs
 * :abbr:`RTC (nRF RTC System Clock)`
 * :abbr:`SPI (Serial Peripheral Interface)`


### PR DESCRIPTION
The nRF51822 and nRF52832 does not support 802.15.4, so remove this
statement from documentation.

Signed-off-by: Stig Bjørlykke <stig.bjorlykke@nordicsemi.no>