### PR TITLE
usb: hid: idle rate

### DIFF
--- a/include/usb/class/usb_hid.h
+++ b/include/usb/class/usb_hid.h
@@ -2,6 +2,7 @@
  * Human Interface Device (HID) USB class core header
  *
  * Copyright (c) 2018 Intel Corporation
+ * Copyright (c) 2018 Nordic Semiconductor ASA
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -59,6 +60,7 @@ struct usb_hid_descriptor {
 typedef int (*hid_cb_t)(struct usb_setup_packet *setup, s32_t *len,
 			u8_t **data);
 typedef void (*hid_int_ready_callback)(void);
+typedef void (*hid_idle_cb_t)(u16_t report_id);
 
 struct hid_ops {
 	hid_cb_t get_report;
@@ -67,6 +69,7 @@ struct hid_ops {
 	hid_cb_t set_report;
 	hid_cb_t set_idle;
 	hid_cb_t set_protocol;
+	hid_idle_cb_t on_idle;
 	/*
 	 * int_in_ready is an optional callback that is called when
 	 * the current interrupt IN transfer has completed.  This can

--- a/include/usb/usb_common.h
+++ b/include/usb/usb_common.h
@@ -3,6 +3,7 @@
  *
  * Copyright(c) 2015,2016 Intel Corporation.
  * Copyright(c) 2017 PHYTEC Messtechnik GmbH
+ * Copyright(c) 2018 Nordic Semiconductor ASA
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -85,6 +86,9 @@
 /* USB 1.1 spec indicates 100mA(max) per unit load, up to 5 loads */
 #define MAX_LOW_POWER			0x32
 #define MAX_HIGH_POWER			0xFA
+
+/* Highest value of Frame Number in SOF packets. */
+#define USB_SOF_MAX			2047
 
 /* bmAttributes:
  * D7:Reserved, always 1,

--- a/samples/subsys/usb/hid/src/main.c
+++ b/samples/subsys/usb/hid/src/main.c
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2016-2018 Intel Corporation.
+ * Copyright (c) 2018 Nordic Semiconductor ASA
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -56,34 +57,6 @@ static const u8_t hid_report_desc[] = {
 	HID_MI_COLLECTION_END,
 };
 
-static int debug_cb(struct usb_setup_packet *setup, s32_t *len,
-		    u8_t **data)
-{
-	LOG_DBG("Debug callback");
-
-	return -ENOTSUP;
-}
-
-static int set_idle_cb(struct usb_setup_packet *setup, s32_t *len,
-		       u8_t **data)
-{
-	LOG_DBG("Set Idle callback");
-
-	/* TODO: Do something */
-
-	return 0;
-}
-
-static int get_report_cb(struct usb_setup_packet *setup, s32_t *len,
-			 u8_t **data)
-{
-	LOG_DBG("Get report callback");
-
-	/* TODO: Do something */
-
-	return 0;
-}
-
 static void send_report(struct k_work *work)
 {
 	static u8_t report_1[2] = { REPORT_ID_1, 0x00 };
@@ -117,12 +90,6 @@ static void status_cb(enum usb_dc_status_code status, const u8_t *param)
 }
 
 static const struct hid_ops ops = {
-	.get_report = get_report_cb,
-	.get_idle = debug_cb,
-	.get_protocol = debug_cb,
-	.set_report = debug_cb,
-	.set_idle = set_idle_cb,
-	.set_protocol = debug_cb,
 	.int_in_ready = in_ready_cb,
 	.status_cb = status_cb,
 };

--- a/samples/subsys/usb/hid/src/main.c
+++ b/samples/subsys/usb/hid/src/main.c
@@ -89,9 +89,20 @@ static void status_cb(enum usb_dc_status_code status, const u8_t *param)
 	}
 }
 
+static void idle_cb(u16_t report_id)
+{
+	static u8_t report_1[2] = { 0x00, 0xEB };
+	int ret, wrote;
+
+	ret = hid_int_ep_write(report_1, sizeof(report_1), &wrote);
+
+	LOG_DBG("Idle callback: wrote %d bytes with ret %d", wrote, ret);
+}
+
 static const struct hid_ops ops = {
 	.int_in_ready = in_ready_cb,
 	.status_cb = status_cb,
+	.on_idle = idle_cb,
 };
 
 void main(void)

--- a/subsys/usb/class/hid/Kconfig
+++ b/subsys/usb/class/hid/Kconfig
@@ -37,4 +37,12 @@ config USB_HID_POLL_INTERVAL_MS
 	help
 	  Polling interval in ms selected by the USB HID Device.
 
+config USB_HID_REPORTS
+	int "HID reports in the instance"
+	default 1
+	range 1 256
+	help
+	  Number of HID reports in the instance.
+	  Must be equal or higher than highest report ID (if they are not consecutive).
+
 endif # USB_DEVICE_HID

--- a/subsys/usb/class/hid/core.c
+++ b/subsys/usb/class/hid/core.c
@@ -2,6 +2,7 @@
  * Human Interface Device (HID) USB class core
  *
  * Copyright (c) 2018 Intel Corporation
+ * Copyright (c) 2018 Nordic Semiconductor ASA
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -89,6 +90,66 @@ static struct hid_device_info {
 	const struct hid_ops *ops;
 } hid_device;
 
+static int hid_on_get_idle(struct usb_setup_packet *setup, s32_t *len,
+			   u8_t **data)
+{
+	LOG_DBG("Get Idle callback");
+
+	/* TODO: Do something. */
+
+	return -ENOTSUP;
+}
+
+static int hid_on_get_report(struct usb_setup_packet *setup, s32_t *len,
+			     u8_t **data)
+{
+	LOG_DBG("Get Report callback");
+
+	/* TODO: Do something. */
+
+	return 0;
+}
+
+static int hid_on_get_protocol(struct usb_setup_packet *setup, s32_t *len,
+			       u8_t **data)
+{
+	LOG_DBG("Get Protocol callback");
+
+	/* TODO: Do something. */
+
+	return -ENOTSUP;
+}
+
+static int hid_on_set_idle(struct usb_setup_packet *setup, s32_t *len,
+			   u8_t **data)
+{
+	LOG_DBG("Set Idle callback");
+
+	/* TODO: Do something. */
+
+	return 0;
+}
+
+static int hid_on_set_report(struct usb_setup_packet *setup, s32_t *len,
+			     u8_t **data)
+{
+	LOG_DBG("Set Report callback");
+
+	/* TODO: Do something. */
+
+	return -ENOTSUP;
+}
+
+static int hid_on_set_protocol(struct usb_setup_packet *setup, s32_t *len,
+			       u8_t **data)
+{
+	LOG_DBG("Set Protocol callback");
+
+	/* TODO: Do something. */
+
+	return -ENOTSUP;
+}
+
 static void usb_set_hid_report_size(u16_t size)
 {
 	sys_put_le16(size,
@@ -140,14 +201,28 @@ static int hid_class_handle_req(struct usb_setup_packet *setup,
 
 	if (REQTYPE_GET_DIR(setup->bmRequestType) == REQTYPE_DIR_TO_HOST) {
 		switch (setup->bRequest) {
+		case HID_GET_IDLE:
+			if (hid_device.ops->get_idle) {
+				return hid_device.ops->get_idle(setup, len,
+								data);
+			} else {
+				return hid_on_get_idle(setup, len, data);
+			}
+			break;
 		case HID_GET_REPORT:
-			LOG_DBG("Get Report");
 			if (hid_device.ops->get_report) {
 				return hid_device.ops->get_report(setup, len,
 								  data);
 			} else {
-				LOG_ERR("Mandatory request not supported");
-				return -EINVAL;
+				return hid_on_get_report(setup, len, data);
+			}
+			break;
+		case HID_GET_PROTOCOL:
+			if (hid_device.ops->get_protocol) {
+				return hid_device.ops->get_protocol(setup, len,
+								    data);
+			} else {
+				return hid_on_get_protocol(setup, len, data);
 			}
 			break;
 		default:
@@ -157,18 +232,29 @@ static int hid_class_handle_req(struct usb_setup_packet *setup,
 	} else {
 		switch (setup->bRequest) {
 		case HID_SET_IDLE:
-			LOG_DBG("Set Idle");
 			if (hid_device.ops->set_idle) {
 				return hid_device.ops->set_idle(setup, len,
 								data);
+			} else {
+				return hid_on_set_idle(setup, len, data);
 			}
 			break;
 		case HID_SET_REPORT:
-			if (hid_device.ops->set_report == NULL) {
-				LOG_ERR("set_report not implemented");
-				return -EINVAL;
+			if (hid_device.ops->set_report) {
+				return hid_device.ops->set_report(setup, len,
+								  data);
+			} else {
+				return hid_on_set_report(setup, len, data);
 			}
-			return hid_device.ops->set_report(setup, len, data);
+			break;
+		case HID_SET_PROTOCOL:
+			if (hid_device.ops->set_protocol) {
+				return hid_device.ops->set_protocol(setup, len,
+								    data);
+			} else {
+				return hid_on_set_protocol(setup, len, data);
+			}
+			break;
 		default:
 			LOG_ERR("Unhandled request 0x%x", setup->bRequest);
 			break;


### PR DESCRIPTION
Add idle rate functionality in USB HID class.
Includes a rework of handling class-specific requests in HID.

Tested with USB3CV and a host using idle rate.