### PR TITLE
samples: net: zperf: Remove invalid forever sleep

### DIFF
--- a/samples/net/zperf/src/zperf_tcp_receiver.c
+++ b/samples/net/zperf/src/zperf_tcp_receiver.c
@@ -236,8 +236,6 @@ static void zperf_tcp_rx_thread(const struct shell *shell, int port)
 	if (fail > 1) {
 		return;
 	}
-
-	k_sleep(K_FOREVER);
 }
 
 void zperf_tcp_receiver_init(const struct shell *shell, int port)

--- a/samples/net/zperf/src/zperf_udp_receiver.c
+++ b/samples/net/zperf/src/zperf_udp_receiver.c
@@ -410,8 +410,6 @@ static void zperf_rx_thread(const struct shell *shell, int port)
 
 	shell_fprintf(shell, SHELL_NORMAL,
 		      "Listening on port %d\n", port);
-
-	k_sleep(K_FOREVER);
 }
 
 void zperf_receiver_init(const struct shell *shell, int port)


### PR DESCRIPTION
 We are not expecting forever k_sleep in multithreading.
 And k_sleep is empty in non-multihreading.
 So remove invalid forever sleep to avoid the below issue.
    
 ASSERTION FAIL [duration != (-1)] @ zephyr/kernel/sched.c:807
    
 Please refer to _impl_k_sleep api in zephyr/kernel/sched.c:807
    
 Signed-off-by: Bub Wei <bub.wei@unisoc.com>
