### PR TITLE
drivers: eth: Fix gPTP compile error

### DIFF
--- a/drivers/ethernet/eth_native_posix.c
+++ b/drivers/ethernet/eth_native_posix.c
@@ -30,10 +30,8 @@ LOG_MODULE_REGISTER(LOG_MODULE_NAME);
 #include <net/net_if.h>
 #include <net/ethernet.h>
 
-#if defined(CONFIG_ETH_NATIVE_POSIX_PTP_CLOCK)
 #include <ptp_clock.h>
 #include <net/gptp.h>
-#endif
 
 #include "eth_native_posix_priv.h"
 #include "ethernet/eth_stats.h"


### PR DESCRIPTION
If compiling with gPTP support, then avoid compile error that is
seen with gptp sample application.

Signed-off-by: Jukka Rissanen <jukka.rissanen@linux.intel.com>