### PR TITLE
Fix gPTP for native_posix board

### DIFF
--- a/drivers/ethernet/Kconfig.native_posix
+++ b/drivers/ethernet/Kconfig.native_posix
@@ -81,6 +81,7 @@ config ETH_NATIVE_POSIX_DEV_NAME
 
 config ETH_NATIVE_POSIX_PTP_CLOCK
 	bool "PTP clock driver support"
+	default y if NET_GPTP
 	select PTP_CLOCK
 	depends on NET_GPTP
 	help

--- a/drivers/ethernet/eth_native_posix.c
+++ b/drivers/ethernet/eth_native_posix.c
@@ -655,6 +655,6 @@ static int ptp_init(struct device *port)
 
 DEVICE_AND_API_INIT(eth_native_posix_ptp_clock_0, PTP_CLOCK_NAME,
 		    ptp_init, &ptp_0_context, NULL, POST_KERNEL,
-		    CONFIG_APPLICATION_INIT_PRIORITY, &api);
+		    CONFIG_KERNEL_INIT_PRIORITY_DEFAULT, &api);
 
 #endif /* CONFIG_ETH_NATIVE_POSIX_PTP_CLOCK */


### PR DESCRIPTION
The gPTP support for native_posix board was bitrotted. The gPTP sample application could not even find any gPTP ports. This startup issue is now fixed.