### PR TITLE
ext: debug: segger: Add missing include directories

### DIFF
--- a/ext/debug/segger/CMakeLists.txt
+++ b/ext/debug/segger/CMakeLists.txt
@@ -1,7 +1,8 @@
 
-zephyr_include_directories_ifdef(CONFIG_USE_SEGGER_RTT .)
+zephyr_include_directories_ifdef(CONFIG_USE_SEGGER_RTT rtt)
 zephyr_sources_ifdef(CONFIG_USE_SEGGER_RTT
 	rtt/SEGGER_RTT.c
 	rtt/SEGGER_RTT_zephyr.c
 	)
+zephyr_include_directories_ifdef(CONFIG_SEGGER_SYSTEMVIEW systemview)
 zephyr_sources_ifdef(CONFIG_SEGGER_SYSTEMVIEW systemview/SEGGER_SYSVIEW.c)


### PR DESCRIPTION
Fix #11812 by adding include paths to the `CMakeLists.txt`

Coupled with #11831

Signed-off-by: Sigvart M. Hovland <sigvart.hovland@nordicsemi.no>