### PR TITLE
kernel: remove outdated comment in _Cstart

### DIFF
--- a/kernel/init.c
+++ b/kernel/init.c
@@ -455,13 +455,6 @@ FUNC_NORETURN void _Cstart(void)
 	(void)memset(dummy_thread_memory, 0, sizeof(dummy_thread_memory));
 #endif
 #endif
-	/*
-	 * The interrupt library needs to be initialized early since a series
-	 * of handlers are installed into the interrupt table to catch
-	 * spurious interrupts. This must be performed before other kernel
-	 * subsystems install bonafide handlers, or before hardware device
-	 * drivers are initialized.
-	 */
 
 	if (IS_ENABLED(CONFIG_LOG)) {
 		log_core_init();


### PR DESCRIPTION
The comment explaining why _IntLibInit was being invoked was left in
place after the invocation itself was removed.  Remove it too.

Signed-off-by: Peter A. Bigot <pab@pabigot.com>