### PR TITLE
userspace: add additional debug to elf_helper

### DIFF
--- a/scripts/elf_helper.py
+++ b/scripts/elf_helper.py
@@ -500,6 +500,12 @@ class ElfHelper:
             # if it has one.
             apiaddr = device_get_api_addr(self.elf, addr)
             if apiaddr not in all_objs:
+                if apiaddr == 0:
+                    self.debug("device instance at 0x%x has no associated subsystem"
+                            % addr);
+                else:
+                    self.debug("device instance at 0x%x has unknown API 0x%x"
+                            % (addr, apiaddr));
                 # API struct does not correspond to a known subsystem, skip it
                 continue
 


### PR DESCRIPTION
Devices are identified as belonging to a particular subsystem
by looking at device->driver_api.

Print some debug information if this is NULL or points to an
unrecognized API struct.

This is normal in a lot of cases, for example any use of SYS_INIT().
However, for real devices this may be an indication of mis-
configuration.

Signed-off-by: Andrew Boie <andrew.p.boie@intel.com>