### PR TITLE
elf_helper: skip SYS_INIT() "devices"

### DIFF
--- a/scripts/elf_helper.py
+++ b/scripts/elf_helper.py
@@ -415,6 +415,10 @@ class ElfHelper:
             if not name:
                 continue
 
+            if name.startswith("__device_sys_init"):
+                # Boot-time initialization function; not an actual device
+                continue
+
             type_offset = die_get_type_offset(die)
 
             # Is this a kernel object, or a structure containing kernel


### PR DESCRIPTION
SYS_INIT instantiates a device struct, but this is really
just used to run some functions at boot, it does not correspond
to a device driver belonging to a subsystem. Don't put them in
the kernel object table.

These are easy to filter since they are all named with the
_SYS_NAME macro.

Signed-off-by: Andrew Boie <andrew.p.boie@intel.com>