### PR TITLE
board: stm32_min_dev: Add USB support

### DIFF
--- a/boards/arm/stm32_min_dev/doc/stm32_min_dev.rst
+++ b/boards/arm/stm32_min_dev/doc/stm32_min_dev.rst
@@ -95,6 +95,8 @@ The stm32_min_dev board configuration supports the following hardware features:
 +-----------+------------+----------------------+
 | PWM       | on-chip    | pwm                  |
 +-----------+------------+----------------------+
+| USB       | on-chip    | USB device           |
++-----------+------------+----------------------+
 
 Other hardware features are not supported by the Zephyr kernel.
 

--- a/boards/arm/stm32_min_dev/pinmux.c
+++ b/boards/arm/stm32_min_dev/pinmux.c
@@ -33,6 +33,10 @@ static const struct pin_config pinconf[] = {
 #ifdef CONFIG_PWM_STM32_1
 	{STM32_PIN_PA8, STM32F1_PINMUX_FUNC_PA8_PWM1_CH1},
 #endif /* CONFIG_PWM_STM32_1 */
+#ifdef USB_DC_STM32
+	{STM32_PIN_PA11, STM32F1_PINMUX_FUNC_PA11_USB_DM},
+	{STM32_PIN_PA12, STM32F1_PINMUX_FUNC_PA12_USB_DP},
+#endif /* USB_DC_STM32 */
 };
 
 static int pinmux_stm32_init(struct device *port)

--- a/boards/arm/stm32_min_dev/stm32_min_dev.dts
+++ b/boards/arm/stm32_min_dev/stm32_min_dev.dts
@@ -61,3 +61,7 @@
 		status = "ok";
 	};
 };
+
+&usb {
+	status = "ok";
+};

--- a/boards/arm/stm32_min_dev/stm32_min_dev.yaml
+++ b/boards/arm/stm32_min_dev/stm32_min_dev.yaml
@@ -9,3 +9,4 @@ ram: 20
 supported:
   - i2c
   - pwm
+  - usb_device


### PR DESCRIPTION
Add support USB to stm32_min_dev board

Signed-off-by: Harry Jiang <explora26@gmail.com>