### PR TITLE
tests: intel_s1000: i2c: Support green and white LED blinking

### DIFF
--- a/tests/boards/intel_s1000_crb/CMakeLists.txt
+++ b/tests/boards/intel_s1000_crb/CMakeLists.txt
@@ -4,6 +4,7 @@ project(intel_s1000_crb)
 
 if(CONFIG_I2C)
 target_sources(app PRIVATE src/i2c_test.c)
+target_compile_definitions(app PRIVATE -DLED_LIGHT_PAT=1)
 endif()
 if(CONFIG_GPIO)
 target_sources(app PRIVATE src/gpio_test.c)

--- a/tests/boards/intel_s1000_crb/src/i2c_test.c
+++ b/tests/boards/intel_s1000_crb/src/i2c_test.c
@@ -16,6 +16,7 @@
  *
  * In this sample app, the Intel S1000 CRB master I2C communicates with 2 slave
  * LED I2C matrices driving them to emit blue light and red light alternately.
+ * It can also be programmed to emit white and green light instead.
  * While this validates the write functionality, the read functionality is
  * verified by reading the LED0 values after each write. It would display
  * the below message repeatedly on the console every 500ms.
@@ -77,6 +78,24 @@ void test_i2c_write_led(struct device *i2c_dev, u16_t i2c_slave_led, u8_t color)
 		led_val[5] = 0x04;
 		break;
 
+	case 2: /* GREEN color LED */
+		led_val[0] = 0x04;
+		led_val[1] = 0x41;
+		led_val[2] = 0x10;
+		led_val[3] = 0x04;
+		led_val[4] = 0x41;
+		led_val[5] = 0x10;
+		break;
+
+	case 3: /* WHITE color LED */
+		led_val[0] = 0x55;
+		led_val[1] = 0x55;
+		led_val[2] = 0x55;
+		led_val[3] = 0x55;
+		led_val[4] = 0x55;
+		led_val[5] = 0x55;
+		break;
+
 	default:
 		break;
 	}
@@ -111,7 +130,7 @@ void test_i2c_read_led(struct device *i2c_dev, u16_t i2c_slave_led)
 void i2c_thread(void *dummy1, void *dummy2, void *dummy3)
 {
 	struct device *i2c_dev;
-	int toggle = 1;
+	int toggle = LED_LIGHT_PAT;
 
 	ARG_UNUSED(dummy1);
 	ARG_UNUSED(dummy2);
@@ -127,10 +146,10 @@ void i2c_thread(void *dummy1, void *dummy2, void *dummy3)
 		/* take semaphore */
 		k_sem_take(&thread_sem, K_FOREVER);
 
-		if (toggle) {
-			toggle = 0;
+		if (toggle == LED_LIGHT_PAT) {
+			toggle = LED_LIGHT_PAT - 1;
 		} else {
-			toggle = 1;
+			toggle = LED_LIGHT_PAT;
 		}
 
 		test_i2c_write_led(i2c_dev, I2C_ADDR_LED_MAT0, toggle);


### PR DESCRIPTION
S1000 i2c test was blinking only blue and red lights. However, if
we have to distinguish between 2 test images for whatever reasons,
it is handy to have one test image blinking blue-red while the
other blinks green-white.

Signed-off-by: Rajavardhan Gundi <rajavardhan.gundi@intel.com>