### PR TITLE
samples: net: zperf: Refactor zperf_*_receiver_init

### DIFF
--- a/samples/net/zperf/src/zperf_internal.h
+++ b/samples/net/zperf/src/zperf_internal.h
@@ -102,7 +102,7 @@ extern void zperf_udp_upload(const struct shell *shell,
 			     unsigned int rate_in_kbps,
 			     struct zperf_results *results);
 
-extern void zperf_receiver_init(const struct shell *shell, int port);
+extern void zperf_udp_receiver_init(const struct shell *shell, int port);
 
 extern void zperf_tcp_receiver_init(const struct shell *shell, int port);
 extern void zperf_tcp_uploader_init(struct k_fifo *tx_queue);

--- a/samples/net/zperf/src/zperf_shell.c
+++ b/samples/net/zperf/src/zperf_shell.c
@@ -324,7 +324,7 @@ static int cmd_udp_download(const struct shell *shell, size_t argc,
 			return -ENOEXEC;
 		}
 
-		zperf_receiver_init(shell, port);
+		zperf_udp_receiver_init(shell, port);
 
 		k_yield();
 

--- a/samples/net/zperf/src/zperf_tcp_receiver.c
+++ b/samples/net/zperf/src/zperf_tcp_receiver.c
@@ -27,11 +27,6 @@
 #define NET_LOG_ENABLED 1
 #include "net_private.h"
 
-#define TCP_RX_FIBER_STACK_SIZE 1024
-
-static K_THREAD_STACK_DEFINE(zperf_tcp_rx_stack, TCP_RX_FIBER_STACK_SIZE);
-static struct k_thread zperf_tcp_rx_thread_data;
-
 static struct sockaddr_in6 *in6_addr_my;
 static struct sockaddr_in *in4_addr_my;
 
@@ -125,11 +120,19 @@ static void tcp_accepted(struct net_context *context,
 	}
 }
 
-static void zperf_tcp_rx_thread(const struct shell *shell, int port)
+void zperf_tcp_receiver_init(const struct shell *shell, int port)
 {
 	struct net_context *context4 = NULL;
 	struct net_context *context6 = NULL;
-	int ret, fail = 0;
+	int ret;
+
+	if (IS_ENABLED(CONFIG_NET_IPV6)) {
+		in6_addr_my = zperf_get_sin6();
+	}
+
+	if (IS_ENABLED(CONFIG_NET_IPV4)) {
+		in4_addr_my = zperf_get_sin();
+	}
 
 	if (IS_ENABLED(CONFIG_NET_IPV4) && MY_IP4ADDR) {
 		ret = net_context_get(AF_INET, SOCK_STREAM, IPPROTO_TCP,
@@ -185,7 +188,7 @@ static void zperf_tcp_rx_thread(const struct shell *shell, int port)
 			shell_fprintf(shell, SHELL_WARNING,
 				      "Cannot bind IPv6 TCP port %d (%d)\n",
 				      ntohs(in6_addr_my->sin6_port), ret);
-			fail++;
+			return;
 		}
 
 		ret = net_context_listen(context6, 0);
@@ -213,7 +216,7 @@ static void zperf_tcp_rx_thread(const struct shell *shell, int port)
 			shell_fprintf(shell, SHELL_WARNING,
 				      "Cannot bind IPv4 TCP port %d (%d)\n",
 				      ntohs(in4_addr_my->sin_port), ret);
-			fail++;
+			return;
 		}
 
 		ret = net_context_listen(context4, 0);
@@ -233,24 +236,6 @@ static void zperf_tcp_rx_thread(const struct shell *shell, int port)
 		}
 	}
 
-	if (fail > 1) {
-		return;
-	}
-}
-
-void zperf_tcp_receiver_init(const struct shell *shell, int port)
-{
-	if (IS_ENABLED(CONFIG_NET_IPV6)) {
-		in6_addr_my = zperf_get_sin6();
-	}
-
-	if (IS_ENABLED(CONFIG_NET_IPV4)) {
-		in4_addr_my = zperf_get_sin();
-	}
-
-	k_thread_create(&zperf_tcp_rx_thread_data, zperf_tcp_rx_stack,
-			K_THREAD_STACK_SIZEOF(zperf_tcp_rx_stack),
-			(k_thread_entry_t)zperf_tcp_rx_thread,
-			(void *)shell, INT_TO_POINTER(port), 0,
-			K_PRIO_COOP(7), 0, K_NO_WAIT);
+	shell_fprintf(shell, SHELL_NORMAL,
+		      "Listening on port %d\n", port);
 }

--- a/samples/net/zperf/src/zperf_udp_receiver.c
+++ b/samples/net/zperf/src/zperf_udp_receiver.c
@@ -26,17 +26,8 @@
 #define NET_LOG_ENABLED 1
 #include "net_private.h"
 
-#define RX_THREAD_STACK_SIZE 1024
-#define MY_SRC_PORT 50001
-
-/* Static data */
-static K_THREAD_STACK_DEFINE(zperf_rx_stack, RX_THREAD_STACK_SIZE);
-static struct k_thread zperf_rx_thread_data;
-
 static struct sockaddr_in6 *in6_addr_my;
 static struct sockaddr_in *in4_addr_my;
-
-#define MAX_DBG_PRINT 64
 
 static inline void set_dst_addr(const struct shell *shell,
 				sa_family_t family,
@@ -309,12 +300,19 @@ static void udp_received(struct net_context *context,
 	}
 }
 
-/* RX thread entry point */
-static void zperf_rx_thread(const struct shell *shell, int port)
+void zperf_udp_receiver_init(const struct shell *shell, int port)
 {
 	struct net_context *context4 = NULL;
 	struct net_context *context6 = NULL;
 	int ret;
+
+	if (IS_ENABLED(CONFIG_NET_IPV6)) {
+		in6_addr_my = zperf_get_sin6();
+	}
+
+	if (IS_ENABLED(CONFIG_NET_IPV4)) {
+		in4_addr_my = zperf_get_sin();
+	}
 
 	if (IS_ENABLED(CONFIG_NET_IPV4) && MY_IP4ADDR) {
 		ret = net_context_get(AF_INET, SOCK_DGRAM, IPPROTO_UDP,
@@ -410,21 +408,4 @@ static void zperf_rx_thread(const struct shell *shell, int port)
 
 	shell_fprintf(shell, SHELL_NORMAL,
 		      "Listening on port %d\n", port);
-}
-
-void zperf_receiver_init(const struct shell *shell, int port)
-{
-	if (IS_ENABLED(CONFIG_NET_IPV6)) {
-		in6_addr_my = zperf_get_sin6();
-	}
-
-	if (IS_ENABLED(CONFIG_NET_IPV4)) {
-		in4_addr_my = zperf_get_sin();
-	}
-
-	k_thread_create(&zperf_rx_thread_data, zperf_rx_stack,
-			K_THREAD_STACK_SIZEOF(zperf_rx_stack),
-			(k_thread_entry_t)zperf_rx_thread,
-			(void *)shell, INT_TO_POINTER(port), 0,
-			K_PRIO_COOP(7), 0, K_NO_WAIT);
 }


### PR DESCRIPTION
Drop tcp and udp rx threads which are just setting and returning.

Signed-off-by: Bub Wei <bub.wei@unisoc.com>