### PR TITLE
sensors: convert lis2mdl to use information coming from dts

### DIFF
--- a/drivers/sensor/lis2mdl/Kconfig
+++ b/drivers/sensor/lis2mdl/Kconfig
@@ -6,34 +6,11 @@
 
 menuconfig LIS2MDL
 	bool "LIS2MDL Magnetometer"
-	depends on I2C
+	depends on (I2C && HAS_DTS_I2C)
 	help
 	  Enable driver for LIS2MDL I2C-based magnetometer sensor.
 
 if LIS2MDL
-
-config LIS2MDL_DEV_NAME
-	string "Driver name"
-	default "LIS2MDL"
-	help
-	  Device name with which the LIS2MDL sensor is identified.
-
-if !HAS_DTS_I2C
-
-config LIS2MDL_I2C_ADDR
-	hex "I2C address"
-	default 0x1E
-	help
-	  I2C address of the LIS2MDL sensor.
-
-config LIS2MDL_I2C_MASTER_DEV_NAME
-	string "I2C master where LIS2MDL is connected"
-	default "I2C_0"
-	help
-	  Specify the device name of the I2C master device to which LIS2MDL is
-	  connected.
-
-endif # LIS2MDL_I2C_ADDR
 
 choice
 	prompt "Trigger mode"
@@ -58,26 +35,6 @@ endchoice
 
 config LIS2MDL_TRIGGER
 	bool
-
-if !HAS_DTS_GPIO
-
-config LIS2MDL_GPIO_DEV_NAME
-	string "GPIO device"
-	default "GPIO_0"
-	depends on LIS2MDL_TRIGGER
-	help
-	  The device name of the GPIO device to which the LIS2MDL interrupt pins
-	  are connected.
-
-config LIS2MDL_GPIO_PIN_NUM
-	int "Interrupt GPIO pin number"
-	default 0
-	depends on LIS2MDL_TRIGGER
-	help
-	  The number of the GPIO on which the interrupt signal from the LIS2MDL
-	  chip will be received.
-
-endif # !HAS_DTS_GPIO
 
 config LIS2MDL_THREAD_PRIORITY
 	int "Thread priority"

--- a/drivers/sensor/lis2mdl/lis2mdl.c
+++ b/drivers/sensor/lis2mdl/lis2mdl.c
@@ -310,12 +310,12 @@ static int lis2mdl_init_interface(struct device *dev)
 }
 
 static const struct lis2mdl_device_config lis2mdl_dev_config = {
-	.master_dev_name = CONFIG_LIS2MDL_I2C_MASTER_DEV_NAME,
+	.master_dev_name = DT_LIS2MDL_I2C_MASTER_DEV_NAME,
 #ifdef CONFIG_LIS2MDL_TRIGGER
-	.gpio_name = CONFIG_LIS2MDL_GPIO_DEV_NAME,
-	.gpio_pin = CONFIG_LIS2MDL_GPIO_PIN_NUM,
+	.gpio_name = DT_LIS2MDL_INT_GPIO_DEV_NAME,
+	.gpio_pin = DT_LIS2MDL_INT_GPIO_PIN_NUM,
 #endif  /* CONFIG_LIS2MDL_TRIGGER */
-	.i2c_addr_config = CONFIG_LIS2MDL_I2C_ADDR,
+	.i2c_addr_config = DT_LIS2MDL_I2C_ADDRESS,
 };
 
 static int lis2mdl_init(struct device *dev)
@@ -374,6 +374,6 @@ static int lis2mdl_init(struct device *dev)
 	return 0;
 }
 
-DEVICE_AND_API_INIT(lis2mdl, CONFIG_LIS2MDL_DEV_NAME, lis2mdl_init,
+DEVICE_AND_API_INIT(lis2mdl, DT_LIS2MDL_DEV_NAME, lis2mdl_init,
 		     &lis2mdl_device_data, &lis2mdl_dev_config, POST_KERNEL,
 		     CONFIG_SENSOR_INIT_PRIORITY, &lis2mdl_driver_api);

--- a/tests/drivers/build_all/dts_fixup.h
+++ b/tests/drivers/build_all/dts_fixup.h
@@ -154,6 +154,14 @@
 #define DT_LIS3DH_GPIO_PIN_NUM 0
 #endif
 
+#ifndef DT_LIS2MDL_DEV_NAME
+#define DT_LIS2MDL_DEV_NAME ""
+#define DT_LIS2MDL_I2C_ADDRESS 0x1e
+#define DT_LIS2MDL_I2C_MASTER_DEV_NAME ""
+#define DT_LIS2MDL_INT_GPIO_DEV_NAME ""
+#define DT_LIS2MDL_INT_GPIO_PIN_NUM 0
+#endif
+
 #endif /* CONFIG_HAS_DTS_I2C */
 
 #if defined(CONFIG_HAS_DTS_SPI)


### PR DESCRIPTION
Convert lis2mdl magnetometer driver to get the device name as well
as i2c slave information from device tree. Updates the build_all
test accordingly.

Signed-off-by: Armando Visconti <armando.visconti@st.com>