### PR TITLE
net: gptp: Replace calls to power function with pre-computed values

### DIFF
--- a/include/net/gptp.h
+++ b/include/net/gptp.h
@@ -82,6 +82,13 @@ static inline double _gptp_pow2(int exp)
 #define GPTP_POW2(exp) _gptp_pow2(exp)
 #endif
 
+/* Pre-calculated constants */
+/* 2^16 */
+#define GPTP_POW2_16	65536.0
+/* 2^41 */
+#define GPTP_POW2_41	2199023255552.0
+
+
 /* Message types. Event messages have BIT(3) set to 0, and general messages
  * have that bit set to 1. IEEE 802.1AS chapter 10.5.2.2.2
  */

--- a/subsys/net/l2/ethernet/gptp/gptp_md.c
+++ b/subsys/net/l2/ethernet/gptp/gptp_md.c
@@ -77,7 +77,7 @@ static void gptp_md_follow_up_prepare(struct net_pkt *pkt,
 	fup->tlv.org_sub_type[2] = GPTP_FUP_TLV_ORG_SUB_TYPE;
 
 	fup->tlv.cumulative_scaled_rate_offset =
-		(sync_send->rate_ratio - 1.0) * GPTP_POW2(41);
+		(sync_send->rate_ratio - 1.0) * GPTP_POW2_41;
 	fup->tlv.cumulative_scaled_rate_offset =
 		ntohl(fup->tlv.cumulative_scaled_rate_offset);
 	fup->tlv.gm_time_base_indicator =
@@ -140,7 +140,7 @@ static int gptp_set_md_sync_receive(int port,
 	sync_rcv->upstream_tx_time -= delay_asymmetry_rated;
 
 	sync_rcv->rate_ratio = ntohl(fup->tlv.cumulative_scaled_rate_offset);
-	sync_rcv->rate_ratio *= GPTP_POW2(-41);
+	sync_rcv->rate_ratio /= GPTP_POW2_41;
 	sync_rcv->rate_ratio += 1;
 
 	sync_rcv->gm_time_base_indicator =

--- a/subsys/net/l2/ethernet/gptp/gptp_mi.c
+++ b/subsys/net/l2/ethernet/gptp/gptp_mi.c
@@ -647,10 +647,10 @@ static void gptp_mi_clk_slave_sync_compute(void)
 
 	global_ds->sync_receipt_time.second = sync_receipt_time / NSEC_PER_SEC;
 	global_ds->sync_receipt_time.fract_nsecond =
-		(sync_receipt_time % NSEC_PER_SEC) * GPTP_POW2(16);
+		(sync_receipt_time % NSEC_PER_SEC) * GPTP_POW2_16;
 	global_ds->sync_receipt_time.second += pss->precise_orig_ts.second;
 	global_ds->sync_receipt_time.fract_nsecond +=
-		pss->precise_orig_ts.nanosecond * GPTP_POW2(16);
+		pss->precise_orig_ts.nanosecond * GPTP_POW2_16;
 
 	global_ds->sync_receipt_local_time = port_ds->delay_asymmetry;
 	global_ds->sync_receipt_local_time /= pss->rate_ratio;
@@ -696,7 +696,7 @@ static void gptp_update_local_port_clock(void)
 	second_diff = global_ds->sync_receipt_time.second -
 		(global_ds->sync_receipt_local_time / NSEC_PER_SEC);
 	nanosecond_diff =
-		(global_ds->sync_receipt_time.fract_nsecond / GPTP_POW2(16)) -
+		(global_ds->sync_receipt_time.fract_nsecond / GPTP_POW2_16) -
 		(global_ds->sync_receipt_local_time % NSEC_PER_SEC);
 
 	clk = net_eth_get_ptp_clock(GPTP_PORT_IFACE(port));
@@ -1021,7 +1021,7 @@ static void gptp_compute_gm_rate_ratio(void)
 		src_time_n.fract_nsecond -= src_time_0.fract_nsecond;
 	} else {
 		src_time_n.second -= 1;
-		src_time_n.fract_nsecond = (NSEC_PER_SEC * GPTP_POW2(16))
+		src_time_n.fract_nsecond = (NSEC_PER_SEC * GPTP_POW2_16)
 			- src_time_0.fract_nsecond;
 	}
 
@@ -1037,7 +1037,7 @@ static void gptp_compute_gm_rate_ratio(void)
 
 	/* Calculate it in nanoseconds, new_gm_rate is either 1 or -1 here */
 	new_gm_rate *= ((src_time_n.second * NSEC_PER_SEC)
-		+ (src_time_n.fract_nsecond / GPTP_POW2(16)));
+		+ (src_time_n.fract_nsecond / GPTP_POW2_16));
 
 	new_gm_rate /= local_time_n.low;
 
@@ -1056,7 +1056,7 @@ static void gptp_mi_clk_master_sync_rcv_state_machine(void)
 	invoke_args.src_time.second = cur / NSEC_PER_SEC;
 	cur -= (invoke_args.src_time.second * NSEC_PER_SEC);
 
-	invoke_args.src_time.fract_nsecond = cur * GPTP_POW2(16);
+	invoke_args.src_time.fract_nsecond = cur * GPTP_POW2_16;
 
 	memset(&invoke_args.last_gm_phase_change, 0x0,
 	       sizeof(struct gptp_scaled_ns));


### PR DESCRIPTION
gPTP subsystem was calling pow(x,y) function with X and Y being
constants; these are replaced with the pre-computed values.

Signed-off-by: laperie <andrei.laperie@intel.com>