### PR TITLE
Shell fix autocompletion

### DIFF
--- a/doc/subsystems/shell/shell.rst
+++ b/doc/subsystems/shell/shell.rst
@@ -104,10 +104,7 @@ subcommands.
 
 .. code-block:: c
 
-	/* Creating subcommands (level 1 command) array for command "demo".
-	 * Subcommands must be added in alphabetical order to ensure correct
-	 * command autocompletion.
-	 */
+	/* Creating subcommands (level 1 command) array for command "demo". */
 	SHELL_CREATE_STATIC_SUBCMD_SET(sub_demo)
 	{
 		SHELL_CMD(params, NULL, "Print params command.",
@@ -500,9 +497,7 @@ The following code shows a simple use case of this library:
 		return 0;
 	}
 
-	/* Creating subcommands (level 1 command) array for command "demo".
-	 * Subcommands must be added in alphabetical order
-	 */
+	/* Creating subcommands (level 1 command) array for command "demo". */
 	SHELL_CREATE_STATIC_SUBCMD_SET(sub_demo)
 	{
 		SHELL_CMD(params, NULL, "Print params command.",


### PR DESCRIPTION
Shell used to require adding commands and subcommands in alphabetical order to ensure correct autocompletion and printing options with the `Tab` key.

PR #10262 implemented correct options printing with the `Tab` key for not sorted commands. This PR allows to partially autocomplete not sorted commands.
