### PR TITLE
include: adc: Fix async ADC API documentation

### DIFF
--- a/include/adc.h
+++ b/include/adc.h
@@ -346,14 +346,14 @@ static inline int adc_read(struct device *dev,
  *
  * @param dev       Pointer to the device structure for the driver instance.
  * @param sequence  Structure specifying requested sequence of samplings.
+ *                  Caller should ensure lifetime of this structure spans
+ *                  until asynchronous read is finished.
  * @param async     Pointer to a valid and ready to be signaled struct
  *                  k_poll_signal. (Note: if NULL this function will not notify
  *                  the end of the transaction, and whether it went successfully
  *                  or not).
  *
- * @returns The same
- * 0 on success, negative error code otherwise. The returned values
- *          are the
+ * @returns 0 on success, negative error code otherwise.
  *
  */
 static inline int adc_read_async(struct device *dev,


### PR DESCRIPTION
Add information about sequence structure lifespan and fix broken return value description.