### PR TITLE
sanitycheck: Allow setting of board id

### DIFF
--- a/scripts/sanitycheck
+++ b/scripts/sanitycheck
@@ -647,12 +647,23 @@ class DeviceHandler(Handler):
     def handle(self):
         out_state = "failed"
 
-        if options.ninja:
-            generator_cmd = "ninja"
+        if options.west_flash is not None:
+            command = ["west", "flash", "--skip-rebuild", "-d", self.outdir]
+            # There are two ways this option is used.
+            # 1) bare: --west-flash
+            #    This results in options.west_flash == []
+            # 2) with a value: --west-flash="--board-id=42"
+            #    This results in options.west_flash == "--board-id=42"
+            if options.west_flash != []:
+                command.append('--')
+                command.append(options.west_flash)
         else:
-            generator_cmd = "make"
+            if options.ninja:
+                generator_cmd = "ninja"
+            else:
+                generator_cmd = "make"
 
-        command = [generator_cmd, "-C", self.outdir, "flash"]
+            command = [generator_cmd, "-C", self.outdir, "flash"]
 
         device = options.device_serial
         ser = serial.Serial(
@@ -676,6 +687,7 @@ class DeviceHandler(Handler):
                              args=(ser, rpipe, harness))
         t.start()
 
+        logging.debug('Flash command: %s', command)
         try:
             if VERBOSE:
                 subprocess.check_call(command)
@@ -2886,6 +2898,18 @@ def parse_arguments():
         "cmake -DUSE_CCACHE=0"
 
         which will ultimately disable ccache.
+        """
+    )
+    parser.add_argument(
+        "--west-flash", nargs='?', const=[],
+        help="""Uses west instead of ninja or make to flash when running with
+             --device-testing"
+
+        E.g
+         sanitycheck --device-testing --device-serial /dev/ttyACM0 \
+                     --west-flash="--board-id=foobar"
+        will translate to
+         west flash -- --board-id=foobar
         """
     )
     parser.add_argument("--gcov-tool", default="gcov",

--- a/scripts/sanitycheck
+++ b/scripts/sanitycheck
@@ -1247,13 +1247,13 @@ class MakeGenerator:
             handler.pid_fn = os.path.join(instance.outdir, "renode.pid")
             handler.call_make_run = True
 
-
         if type == 'qemu':
             args.append("QEMU_PIPE=%s" % handler.get_fifo())
 
-        text = (self._get_rule_header(name) +
-                self._get_sub_make(name, "building", directory,
-                                   outdir, build_logfile, args, make_args=make_args))
+        text = self._get_rule_header(name)
+        if not options.test_only:
+            text += self._get_sub_make(name, "building", directory, outdir,
+                                       build_logfile, args, make_args=make_args)
         if handler and handler.run:
             text += self._get_sub_make(name, "running", directory,
                                    outdir, run_logfile,
@@ -2805,9 +2805,14 @@ def parse_arguments():
         action="store",
         help="Save list of tests to be run to file.")
 
-    parser.add_argument(
+    test_or_build = parser.add_mutually_exclusive_group()
+    test_or_build.add_argument(
         "-b", "--build-only", action="store_true",
         help="Only build the code, do not execute any of it in QEMU")
+    test_or_build.add_argument(
+        "--test-only", action="store_true",
+        help="""Only run device tests with current artifacts, do not build
+             the code""")
     parser.add_argument(
         "-j", "--jobs", type=int,
         help="Number of jobs for building, defaults to number of CPU threads "


### PR DESCRIPTION
The "west flash" commands requires a board-id when more than one
board is attached to the host system. When using a tool like
sanitycheck it will actually hang waiting for stdin to tell it which
board is needed.

This change allows a user to pass -DBOARD_ID=<unique id> to cmake so
that a specific board can be targeted.

Signed-off-by: Andy Doan <andy@foundries.io>