### PR TITLE
kernel: init: Add nop instruction in main

### DIFF
--- a/include/arch/arc/arch.h
+++ b/include/arch/arc/arch.h
@@ -220,6 +220,15 @@ extern "C" {
 #ifndef _ASMLANGUAGE
 /* Typedef for the k_mem_partition attribute*/
 typedef u32_t k_mem_partition_attr_t;
+
+/**
+ * @brief Explicitly nop operation.
+ */
+static ALWAYS_INLINE void arch_nop(void)
+{
+	__asm__ volatile("nop");
+}
+
 #endif /* _ASMLANGUAGE */
 
 #ifdef __cplusplus

--- a/include/arch/arm/cortex_m/misc.h
+++ b/include/arch/arm/cortex_m/misc.h
@@ -23,6 +23,15 @@ extern void k_cpu_idle(void);
 
 extern u32_t _timer_cycle_get_32(void);
 #define _arch_k_cycle_get_32()	_timer_cycle_get_32()
+
+/**
+ * @brief Explicitly nop operation.
+ */
+static ALWAYS_INLINE void arch_nop(void)
+{
+	__asm__ volatile("nop");
+}
+
 #endif
 
 #ifdef __cplusplus

--- a/include/arch/nios2/arch.h
+++ b/include/arch/nios2/arch.h
@@ -201,6 +201,14 @@ enum nios2_exception_cause {
 extern u32_t _timer_cycle_get_32(void);
 #define _arch_k_cycle_get_32()	_timer_cycle_get_32()
 
+/**
+ * @brief Explicitly nop operation.
+ */
+static ALWAYS_INLINE void arch_nop(void)
+{
+	__asm__ volatile("nop");
+}
+
 #endif /* _ASMLANGUAGE */
 
 #ifdef __cplusplus

--- a/include/arch/posix/arch.h
+++ b/include/arch/posix/arch.h
@@ -54,6 +54,14 @@ FUNC_NORETURN void _SysFatalErrorHandler(unsigned int reason,
 FUNC_NORETURN void _NanoFatalErrorHandler(unsigned int reason,
 					  const NANO_ESF *esf);
 
+/**
+ * @brief Explicitly nop operation.
+ */
+static ALWAYS_INLINE void arch_nop(void)
+{
+	__asm__ volatile("nop");
+}
+
 #ifdef __cplusplus
 }
 #endif

--- a/include/arch/riscv32/arch.h
+++ b/include/arch/riscv32/arch.h
@@ -115,6 +115,15 @@ static ALWAYS_INLINE void _arch_irq_unlock(unsigned int key)
 			  : "memory");
 }
 
+/**
+ * @brief Explicitly nop operation.
+ */
+static ALWAYS_INLINE void arch_nop(void)
+{
+	__asm__ volatile("nop");
+}
+
+
 extern u32_t _timer_cycle_get_32(void);
 #define _arch_k_cycle_get_32()	_timer_cycle_get_32()
 

--- a/include/arch/x86/arch.h
+++ b/include/arch/x86/arch.h
@@ -454,6 +454,15 @@ static ALWAYS_INLINE void _arch_irq_unlock(unsigned int key)
 }
 
 /**
+ * @brief Explicitly nop operation.
+ */
+static ALWAYS_INLINE void arch_nop(void)
+{
+	__asm__ volatile("nop");
+}
+
+
+/**
  * The NANO_SOFT_IRQ macro must be used as the value for the @a irq parameter
  * to NANO_CPU_INT_REGISTER when connecting to an interrupt that does not
  * correspond to any IRQ line (such as spurious vector or SW IRQ)

--- a/include/arch/xtensa/arch.h
+++ b/include/arch/xtensa/arch.h
@@ -134,6 +134,14 @@ XTENSA_ERR_NORET void _NanoFatalErrorHandler(unsigned int reason,
 extern u32_t _timer_cycle_get_32(void);
 #define _arch_k_cycle_get_32()	_timer_cycle_get_32()
 
+/**
+ * @brief Explicitly nop operation.
+ */
+static ALWAYS_INLINE void arch_nop(void)
+{
+	__asm__ volatile("nop");
+}
+
 #endif /* !defined(_ASMLANGUAGE) && !defined(__ASSEMBLER__)  */
 #ifdef __cplusplus
 }

--- a/kernel/init.c
+++ b/kernel/init.c
@@ -259,6 +259,7 @@ static void bg_thread_main(void *unused1, void *unused2, void *unused3)
 void __weak main(void)
 {
 	/* NOP default main() if the application does not provide one. */
+	arch_nop();
 }
 
 #if defined(CONFIG_MULTITHREADING)


### PR DESCRIPTION
The main function is just a weak function that should be override by the
applications if they need. Just adding a nop instructions to explicitly
says that this function does nothing.

MISRA-C rule 2.2

Signed-off-by: Flavio Ceolin <flavio.ceolin@intel.com>