### PR TITLE
samples: net: zperf: Support existing IP

### DIFF
--- a/samples/net/zperf/src/zperf_internal.h
+++ b/samples/net/zperf/src/zperf_internal.h
@@ -114,4 +114,7 @@ extern void zperf_tcp_upload(const struct shell *shell,
 
 extern void connect_ap(char *ssid);
 
+const struct in_addr *zperf_get_default_if_in4_addr(void);
+const struct in6_addr *zperf_get_default_if_in6_addr(void);
+
 #endif /* __ZPERF_INTERNAL_H */

--- a/samples/net/zperf/src/zperf_shell.c
+++ b/samples/net/zperf/src/zperf_shell.c
@@ -218,6 +218,26 @@ int zperf_get_ipv4_addr(const struct shell *shell, char *host,
 	return 0;
 }
 
+const struct in_addr *zperf_get_default_if_in4_addr(void)
+{
+#if CONFIG_NET_IPV4
+	return net_if_ipv4_select_src_addr(NULL,
+					   net_ipv4_unspecified_address());
+#else
+	return NULL;
+#endif
+}
+
+const struct in6_addr *zperf_get_default_if_in6_addr(void)
+{
+#if CONFIG_NET_IPV6
+	return net_if_ipv6_select_src_addr(NULL,
+					   net_ipv6_unspecified_address());
+#else
+	return NULL;
+#endif
+}
+
 static int cmd_setip(const struct shell *shell, size_t argc, char *argv[])
 {
 	int start = 0;

--- a/samples/net/zperf/src/zperf_tcp_receiver.c
+++ b/samples/net/zperf/src/zperf_tcp_receiver.c
@@ -124,6 +124,8 @@ void zperf_tcp_receiver_init(const struct shell *shell, int port)
 {
 	struct net_context *context4 = NULL;
 	struct net_context *context6 = NULL;
+	const struct in_addr *in4_addr = NULL;
+	const struct in6_addr *in6_addr = NULL;
 	int ret;
 
 	if (IS_ENABLED(CONFIG_NET_IPV6)) {
@@ -134,7 +136,7 @@ void zperf_tcp_receiver_init(const struct shell *shell, int port)
 		in4_addr_my = zperf_get_sin();
 	}
 
-	if (IS_ENABLED(CONFIG_NET_IPV4) && MY_IP4ADDR) {
+	if (IS_ENABLED(CONFIG_NET_IPV4)) {
 		ret = net_context_get(AF_INET, SOCK_STREAM, IPPROTO_TCP,
 				      &context4);
 		if (ret < 0) {
@@ -143,12 +145,25 @@ void zperf_tcp_receiver_init(const struct shell *shell, int port)
 			return;
 		}
 
-		ret = zperf_get_ipv4_addr(shell, MY_IP4ADDR,
-					  &in4_addr_my->sin_addr);
-		if (ret < 0) {
-			shell_fprintf(shell, SHELL_WARNING,
-				      "Unable to set IPv4\n");
-			return;
+		if (MY_IP4ADDR && strlen(MY_IP4ADDR)) {
+			/* Use Setting IP */
+			ret = zperf_get_ipv4_addr(shell, MY_IP4ADDR,
+						  &in4_addr_my->sin_addr);
+			if (ret < 0) {
+				shell_fprintf(shell, SHELL_WARNING,
+					      "Unable to set IPv4\n");
+				return;
+			}
+		} else {
+			/* Use existing IP */
+			in4_addr = zperf_get_default_if_in4_addr();
+			if (!in4_addr) {
+				shell_fprintf(shell, SHELL_WARNING,
+					      "Unable to get IPv4 by default\n");
+				return;
+			}
+			memcpy(&in4_addr_my->sin_addr, in4_addr,
+				sizeof(struct in_addr));
 		}
 
 		shell_fprintf(shell, SHELL_NORMAL, "Binding to %s\n",
@@ -157,7 +172,7 @@ void zperf_tcp_receiver_init(const struct shell *shell, int port)
 		in4_addr_my->sin_port = htons(port);
 	}
 
-	if (IS_ENABLED(CONFIG_NET_IPV6) && MY_IP6ADDR) {
+	if (IS_ENABLED(CONFIG_NET_IPV6)) {
 		ret = net_context_get(AF_INET6, SOCK_STREAM, IPPROTO_TCP,
 				      &context6);
 		if (ret < 0) {
@@ -166,12 +181,26 @@ void zperf_tcp_receiver_init(const struct shell *shell, int port)
 			return;
 		}
 
-		ret = zperf_get_ipv6_addr(shell, MY_IP6ADDR, MY_PREFIX_LEN_STR,
-					  &in6_addr_my->sin6_addr);
-		if (ret < 0) {
-			shell_fprintf(shell, SHELL_WARNING,
-				      "Unable to set IPv6\n");
-			return;
+		if (MY_IP6ADDR && strlen(MY_IP6ADDR)) {
+			/* Use Setting IP */
+			ret = zperf_get_ipv6_addr(shell, MY_IP6ADDR,
+						  MY_PREFIX_LEN_STR,
+						  &in6_addr_my->sin6_addr);
+			if (ret < 0) {
+				shell_fprintf(shell, SHELL_WARNING,
+					      "Unable to set IPv6\n");
+				return;
+			}
+		} else {
+			/* Use existing IP */
+			in6_addr = zperf_get_default_if_in6_addr();
+			if (!in6_addr) {
+				shell_fprintf(shell, SHELL_WARNING,
+					      "Unable to get IPv4 by default\n");
+				return;
+			}
+			memcpy(&in6_addr_my->sin6_addr, in6_addr,
+				sizeof(struct in6_addr));
 		}
 
 		shell_fprintf(shell, SHELL_NORMAL, "Binding to %s\n",


### PR DESCRIPTION
Considering that IP can be set dynamically by DHCP
or statically before test previously, we could have
alternative way by supporting both setting IP and
existing IP.

Signed-off-by: Bub Wei <bub.wei@unisoc.com>