### PR TITLE
xtensa: Implement CONFIG_TEXT_SECTION_OFFSET

### DIFF
--- a/boards/xtensa/intel_s1000_crb/Kconfig.defconfig
+++ b/boards/xtensa/intel_s1000_crb/Kconfig.defconfig
@@ -77,6 +77,11 @@ choice SPI_NOR_BLOCK_ERASE_SIZE
 	default SPI_NOR_BLOCK_ERASE_64K
 endchoice
 
+if BOOTLOADER_MCUBOOT
+config TEXT_SECTION_OFFSET
+	default 0x100
+endif
+
 if USB
 config USB_DW
 	default y

--- a/soc/xtensa/intel_s1000/linker.ld
+++ b/soc/xtensa/intel_s1000/linker.ld
@@ -172,6 +172,7 @@ SECTIONS
 
   .ResetVector.text : ALIGN(4)
   {
+    . = CONFIG_TEXT_SECTION_OFFSET;
     _ResetVector_text_start = ABSOLUTE(.);
     KEEP (*(.ResetVector.text))
     _ResetVector_text_end = ABSOLUTE(.);


### PR DESCRIPTION
CONFIG_TEXT_SECTION_OFFSET allows the entire image to be moved
in memory to allow space for some type of header. The mcubootloader
can boot only such images which reserve some space for the header.

Signed-off-by: Rajavardhan Gundi <rajavardhan.gundi@intel.com>