### PR TITLE
shell: Fix thread priority

### DIFF
--- a/subsys/shell/Kconfig
+++ b/subsys/shell/Kconfig
@@ -53,13 +53,6 @@ config SHELL_STACK_SIZE
 	help
 	  Stack size for thread created for each instance.
 
-config SHELL_THREAD_PRIO
-	int "Shell thread priority"
-	depends on MULTITHREADING
-	default -2
-	help
-	  Shell thread priority.
-
 config SHELL_BACKSPACE_MODE_DELETE
 	bool "Default escape code for backspace is DELETE (0x7F)"
 	default y

--- a/subsys/shell/shell.c
+++ b/subsys/shell/shell.c
@@ -1352,7 +1352,7 @@ int shell_init(const struct shell *shell, const void *transport_config,
 			      shell->stack, CONFIG_SHELL_STACK_SIZE,
 			      shell_thread, (void *)shell, (void *)log_backend,
 			      (void *)init_log_level,
-			      CONFIG_SHELL_THREAD_PRIO, 0, K_NO_WAIT);
+			      K_LOWEST_APPLICATION_THREAD_PRIO, 0, K_NO_WAIT);
 
 	k_thread_name_set(tid, shell->thread_name);
 


### PR DESCRIPTION
Removed kconfig option for setting shell thread priority and fix
it to K_LOWEST_APPLICATION_THREAD_PRIO.

Similar issue as in #11762. Kconfig default was -2 which was almost the highest priority.

Signed-off-by: Krzysztof Chruscinski <krzysztof.chruscinski@nordicsemi.no>