### PR TITLE
tty: Support unbuffered operation to extend usecase coverage

### DIFF
--- a/include/tty.h
+++ b/include/tty.h
@@ -32,10 +32,12 @@ struct tty_serial {
 };
 
 /**
- * @brief Initialize buffered serial port (classically known as tty).
+ * @brief Initialize serial port object (classically known as tty).
  *
- * "tty" device provides buffered, interrupt-driver access to an
- * underlying UART device.
+ * "tty" device provides support for buffered, interrupt-driven,
+ * timeout-controlled access to an underlying UART device. For
+ * completeness, it also support non-interrupt-driven, busy-polling
+ * access mode.
  *
  * @param tty tty device structure to initialize
  * @param uart_dev underlying UART device to use (should support
@@ -78,6 +80,34 @@ static inline void tty_set_tx_timeout(struct tty_serial *tty, s32_t timeout)
 {
 	tty->tx_timeout = timeout;
 }
+
+/**
+ * @brief Set receive buffer for tty device.
+ *
+ * Set receive buffer or switch to unbuffered operation for receive.
+ *
+ * @param tty tty device structure
+ * @param buf buffer, or NULL for unbuffered operation
+ * @param size buffer buffer size, 0 for unbuffered operation
+ * @return 0 on success, error code (<0) otherwise:
+ *    EINVAL: unsupported buffer (size)
+ */
+int tty_set_rx_buf(struct tty_serial *tty, void *buf, size_t size);
+
+/**
+ * @brief Set transmit buffer for tty device.
+ *
+ * Set transmit buffer or switch to unbuffered operation for transmit.
+ * Note that unbuffered mode is implicitly blocking, i.e. behaves as
+ * if tty_set_tx_timeout(K_FOREVER) was set.
+ *
+ * @param tty tty device structure
+ * @param buf buffer, or NULL for unbuffered operation
+ * @param size buffer buffer size, 0 for unbuffered operation
+ * @return 0 on success, error code (<0) otherwise:
+ *    EINVAL: unsupported buffer (size)
+ */
+int tty_set_tx_buf(struct tty_serial *tty, void *buf, size_t size);
 
 /**
  * @brief Read data from a tty device.

--- a/include/tty.h
+++ b/include/tty.h
@@ -37,21 +37,19 @@ struct tty_serial {
  * "tty" device provides support for buffered, interrupt-driven,
  * timeout-controlled access to an underlying UART device. For
  * completeness, it also support non-interrupt-driven, busy-polling
- * access mode.
+ * access mode. After initialization, tty is in the "most conservative"
+ * unbuffered mode with infinite timeouts (this is guaranteed to work
+ * on any hardware). Users should configure buffers and timeouts as
+ * they need using functions tty_set_rx_buf(), tty_set_tx_buf(),
+ * tty_set_rx_timeout(), tty_set_tx_timeout().
  *
  * @param tty tty device structure to initialize
  * @param uart_dev underlying UART device to use (should support
  *                 interrupt-driven operation)
- * @param rxbuf pointer to receive buffer
- * @param rxbuf_sz size of receive buffer
- * @param txbuf pointer to transmit buffer
- * @param txbuf_sz size of transmit buffer
  *
- * @return N/A
+ * @return 0 on success, error code (<0) otherwise
  */
-void tty_init(struct tty_serial *tty, struct device *uart_dev,
-	      u8_t *rxbuf, u16_t rxbuf_sz,
-	      u8_t *txbuf, u16_t txbuf_sz);
+int tty_init(struct tty_serial *tty, struct device *uart_dev);
 
 /**
  * @brief Set receive timeout for tty device.

--- a/subsys/console/Kconfig
+++ b/subsys/console/Kconfig
@@ -33,18 +33,19 @@ config CONSOLE_GETCHAR_BUFSIZE
 	int "console_getchar() buffer size"
 	default 16
 	help
-	  Buffer size for console_getchar(). Must be power of 2. The
-	  default is optimized to save RAM. You may need to increase
-	  it e.g. to support large host-side clipboard pastes.
+	  Buffer size for console_getchar(). The default is optimized
+	  to save RAM. You may need to increase it e.g. to support
+	  large host-side clipboard pastes. Set to 0 to disable
+	  interrupt-driven operation and use busy-polling.
 
 config CONSOLE_PUTCHAR_BUFSIZE
 	int "console_putchar() buffer size"
 	default 16
 	help
-	  Buffer size for console_putchar(). Must be power of 2. The
-	  default is optimized to save RAM. You may need to increase
-	  it e.g. to support large host-side clipboard pastes (with
-	  echo).
+	  Buffer size for console_putchar().  The default is optimized
+	  to save RAM. You may need to increase it e.g. to support
+	  large host-side clipboard pastes. Set to 0 to disable
+	  interrupt-driven operation and use busy-polling.
 
 endif # CONSOLE_GETCHAR
 

--- a/subsys/console/getchar.c
+++ b/subsys/console/getchar.c
@@ -51,7 +51,7 @@ void console_init(void)
 	struct device *uart_dev;
 
 	uart_dev = device_get_binding(CONFIG_UART_CONSOLE_ON_DEV_NAME);
-	tty_init(&console_serial, uart_dev,
-		 console_rxbuf, sizeof(console_rxbuf),
-		 console_txbuf, sizeof(console_txbuf));
+	tty_init(&console_serial, uart_dev);
+	tty_set_tx_buf(&console_serial, console_txbuf, sizeof(console_txbuf));
+	tty_set_rx_buf(&console_serial, console_rxbuf, sizeof(console_rxbuf));
 }

--- a/subsys/console/tty.c
+++ b/subsys/console/tty.c
@@ -104,6 +104,17 @@ ssize_t tty_write(struct tty_serial *tty, const void *buf, size_t size)
 	size_t out_size = 0;
 	int res = 0;
 
+	if (tty->tx_ringbuf_sz == 0) {
+		/* Unbuffered operation, implicitly blocking. */
+		out_size = size;
+
+		while (size--) {
+			uart_poll_out(tty->uart_dev, *p++);
+		}
+
+		return out_size;
+	}
+
 	while (size--) {
 		res = tty_putchar(tty, *p++);
 		if (res < 0) {
@@ -149,11 +160,58 @@ static int tty_getchar(struct tty_serial *tty)
 	return c;
 }
 
+static ssize_t tty_read_unbuf(struct tty_serial *tty, void *buf, size_t size)
+{
+	u8_t *p = buf;
+	size_t out_size = 0;
+	int res = 0;
+	u32_t timeout = tty->rx_timeout;
+
+	while (size) {
+		u8_t c;
+		res = uart_poll_in(tty->uart_dev, &c);
+		if (res <= -2) {
+			/* Error occured, best we can do is to return
+			 * accumulated data w/o error, or return error
+			 * directly if none.
+			 */
+			if (out_size == 0) {
+				errno = res;
+				return -1;
+			}
+			break;
+		}
+
+		if (res == 0) {
+			*p++ = c;
+			out_size++;
+			size--;
+		}
+
+		if (size == 0 || (timeout != K_FOREVER && timeout-- == 0)) {
+			break;
+		}
+
+		/* Avoid 100% busy-polling, and yet try to process bursts
+		 * of data without extra delays.
+		 */
+		if (res == -1) {
+			k_sleep(1);
+		}
+	}
+
+	return out_size;
+}
+
 ssize_t tty_read(struct tty_serial *tty, void *buf, size_t size)
 {
 	u8_t *p = buf;
 	size_t out_size = 0;
 	int res = 0;
+
+	if (tty->rx_ringbuf_sz == 0) {
+		return tty_read_unbuf(tty, buf, size);
+	}
 
 	while (size--) {
 		res = tty_getchar(tty);
@@ -198,4 +256,32 @@ void tty_init(struct tty_serial *tty, struct device *uart_dev,
 
 	uart_irq_callback_user_data_set(uart_dev, tty_uart_isr, tty);
 	uart_irq_rx_enable(uart_dev);
+}
+
+int tty_set_rx_buf(struct tty_serial *tty, void *buf, size_t size)
+{
+	uart_irq_rx_disable(tty->uart_dev);
+
+	tty->rx_ringbuf = buf;
+	tty->rx_ringbuf_sz = size;
+
+	if (size > 0) {
+		uart_irq_rx_enable(tty->uart_dev);
+	}
+
+	return 0;
+}
+
+int tty_set_tx_buf(struct tty_serial *tty, void *buf, size_t size)
+{
+	uart_irq_tx_disable(tty->uart_dev);
+
+	tty->tx_ringbuf = buf;
+	tty->tx_ringbuf_sz = size;
+
+	/* New buffer is initially empty, no need to re-enable interrupts,
+	 * it will be done when needed (on first output char).
+	 */
+
+	return 0;
 }

--- a/subsys/console/tty.c
+++ b/subsys/console/tty.c
@@ -238,24 +238,24 @@ ssize_t tty_read(struct tty_serial *tty, void *buf, size_t size)
 	return out_size;
 }
 
-void tty_init(struct tty_serial *tty, struct device *uart_dev,
-	      u8_t *rxbuf, u16_t rxbuf_sz,
-	      u8_t *txbuf, u16_t txbuf_sz)
+int tty_init(struct tty_serial *tty, struct device *uart_dev)
 {
 	tty->uart_dev = uart_dev;
-	tty->rx_ringbuf = rxbuf;
-	tty->rx_ringbuf_sz = rxbuf_sz;
-	tty->tx_ringbuf = txbuf;
-	tty->tx_ringbuf_sz = txbuf_sz;
+
+	/* We start in unbuffer mode. */
+	tty->rx_ringbuf = NULL;
+	tty->rx_ringbuf_sz = 0;
+	tty->tx_ringbuf = NULL;
+	tty->tx_ringbuf_sz = 0;
+
 	tty->rx_get = tty->rx_put = tty->tx_get = tty->tx_put = 0;
-	k_sem_init(&tty->rx_sem, 0, UINT_MAX);
-	k_sem_init(&tty->tx_sem, txbuf_sz - 1, UINT_MAX);
 
 	tty->rx_timeout = K_FOREVER;
 	tty->tx_timeout = K_FOREVER;
 
 	uart_irq_callback_user_data_set(uart_dev, tty_uart_isr, tty);
-	uart_irq_rx_enable(uart_dev);
+
+	return 0;
 }
 
 int tty_set_rx_buf(struct tty_serial *tty, void *buf, size_t size)
@@ -266,6 +266,7 @@ int tty_set_rx_buf(struct tty_serial *tty, void *buf, size_t size)
 	tty->rx_ringbuf_sz = size;
 
 	if (size > 0) {
+		k_sem_init(&tty->rx_sem, 0, UINT_MAX);
 		uart_irq_rx_enable(tty->uart_dev);
 	}
 
@@ -278,6 +279,8 @@ int tty_set_tx_buf(struct tty_serial *tty, void *buf, size_t size)
 
 	tty->tx_ringbuf = buf;
 	tty->tx_ringbuf_sz = size;
+
+	k_sem_init(&tty->tx_sem, size - 1, UINT_MAX);
 
 	/* New buffer is initially empty, no need to re-enable interrupts,
 	 * it will be done when needed (on first output char).


### PR DESCRIPTION
The whole "tty" concept is conceived around efficient
interrupt-driven operation. However, it's beneficial to add
non interupt-driven operation under the same API:

1. Wider usecase coverage in general.
2. Allows to use the same familiar API (based on POSIX concepts)
even for UART implementations without interrupt support.
3. Allows to switch operation dynamically based on the needs.
For example, if the system is in degraded mode and interrupt
handling cannot be trusted/disabled, allows to still output
diagnostic information to user. This was the original motivation
to provide such a mode, to support logging subsystem's "panic"
mode.

To implement this feature, tty_set_rx_buf() and tty_set_tx_buf()
functions are provided, allowing to reconfigure buffers used
dynamically. If configured buffer length is 0, the operation
switched to unbuffered.

Signed-off-by: Paul Sokolovsky <paul.sokolovsky@linaro.org>