### PR TITLE
STM32: Fixes on Pin configuration

### DIFF
--- a/drivers/gpio/gpio_stm32.c
+++ b/drivers/gpio/gpio_stm32.c
@@ -64,7 +64,11 @@ static int gpio_stm32_config(struct device *dev, int access_op,
 	}
 
 	if (flags & GPIO_INT) {
-		stm32_exti_set_callback(pin, gpio_stm32_isr, dev);
+
+		if (stm32_exti_set_callback(pin, cfg->port,
+					    gpio_stm32_isr, dev)) {
+			return -EBUSY;
+		}
 
 		stm32_gpio_enable_int(cfg->port, pin);
 

--- a/drivers/interrupt_controller/exti_stm32.c
+++ b/drivers/interrupt_controller/exti_stm32.c
@@ -444,16 +444,20 @@ DEVICE_INIT(exti_stm32, STM32_EXTI_NAME, stm32_exti_init,
 /**
  * @brief set & unset for the interrupt callbacks
  */
-void stm32_exti_set_callback(int line, stm32_exti_callback_t cb, void *arg)
+int stm32_exti_set_callback(int line, int port, stm32_exti_callback_t cb,
+				void *arg)
 {
 	struct device *dev = DEVICE_GET(exti_stm32);
 	struct stm32_exti_data *data = dev->driver_data;
 
-	__ASSERT(data->cb[line].cb == NULL,
-		"EXTI %d callback already registered", line);
+	if (data->cb[line].cb) {
+		return -EBUSY;
+	}
 
 	data->cb[line].cb = cb;
 	data->cb[line].data = arg;
+
+	return 0;
 }
 
 void stm32_exti_unset_callback(int line)

--- a/drivers/interrupt_controller/exti_stm32.h
+++ b/drivers/interrupt_controller/exti_stm32.h
@@ -68,7 +68,8 @@ typedef void (*stm32_exti_callback_t) (int line, void *user);
  * @param cb   user callback
  * @param arg  user arg
  */
-void stm32_exti_set_callback(int line, stm32_exti_callback_t cb, void *data);
+int stm32_exti_set_callback(int line, int port, stm32_exti_callback_t cb,
+				void *data);
 
 /**
  * @brief unset EXTI interrupt callback

--- a/drivers/pinmux/stm32/pinmux_stm32.c
+++ b/drivers/pinmux/stm32/pinmux_stm32.c
@@ -52,6 +52,21 @@ static const u32_t ports_enable[STM32_PORTS_MAX] = {
 #else
 	STM32_PORT_NOT_AVAILABLE,
 #endif
+#ifdef GPIOI_BASE
+	STM32_PERIPH_GPIOI,
+#else
+	STM32_PORT_NOT_AVAILABLE,
+#endif
+#ifdef GPIOJ_BASE
+	STM32_PERIPH_GPIOJ,
+#else
+	STM32_PORT_NOT_AVAILABLE,
+#endif
+#ifdef GPIOK_BASE
+	STM32_PERIPH_GPIOK,
+#else
+	STM32_PORT_NOT_AVAILABLE,
+#endif
 };
 
 /**


### PR DESCRIPTION
This PR contains two fixes on STM32 pin configuration:

- Return and error when attempting to configure a PIN sharing resources with already configured PIN.
- Add missing GPIO ports in port_enable array