### PR TITLE
ext: debug: segger: Fix RTT header inclusion

### DIFF
--- a/drivers/console/rtt_console.c
+++ b/drivers/console/rtt_console.c
@@ -13,7 +13,7 @@
 #include <misc/printk.h>
 #include <device.h>
 #include <init.h>
-#include <rtt/SEGGER_RTT.h>
+#include <SEGGER_RTT.h>
 
 extern void __printk_hook_install(int (*fn)(int));
 extern void __stdout_hook_install(int (*fn)(int));

--- a/ext/debug/segger/systemview/SEGGER_SYSVIEW.c
+++ b/ext/debug/segger/systemview/SEGGER_SYSVIEW.c
@@ -146,7 +146,7 @@ Additional information:
 */
 
 #include "SEGGER_SYSVIEW_Int.h"
-#include "rtt/SEGGER_RTT.h"
+#include "SEGGER_RTT.h"
 #include <string.h>
 #include <stdlib.h>
 #include <stdarg.h>

--- a/ext/debug/segger/systemview/SEGGER_SYSVIEW_ConfDefaults.h
+++ b/ext/debug/segger/systemview/SEGGER_SYSVIEW_ConfDefaults.h
@@ -73,7 +73,7 @@ Revision: $Rev: 3734 $
 */
 
 #include "SEGGER_SYSVIEW_Conf.h"
-#include "rtt/SEGGER_RTT_Conf.h"
+#include "SEGGER_RTT_Conf.h"
 
 #ifdef __cplusplus
 extern "C" {

--- a/ext/debug/segger/systemview/SEGGER_SYSVIEW_Int.h
+++ b/ext/debug/segger/systemview/SEGGER_SYSVIEW_Int.h
@@ -71,9 +71,9 @@ Revision: $Rev: 5626 $
 **********************************************************************
 */
 
+#include "SEGGER_SYSVIEW_ConfDefaults.h"
 #include "SEGGER_SYSVIEW.h"
 #include "SEGGER_SYSVIEW_Conf.h"
-#include "SEGGER_SYSVIEW_ConfDefaults.h"
 
 #ifdef __cplusplus
 extern "C" {

--- a/subsys/debug/tracing/include/SEGGER_SYSVIEW_Zephyr.h
+++ b/subsys/debug/tracing/include/SEGGER_SYSVIEW_Zephyr.h
@@ -7,7 +7,7 @@
 #ifndef SYSVIEW_ZEPHYR_H
 #define SYSVIEW_ZEPHYR_H
 
-#include <systemview/SEGGER_SYSVIEW.h>
+#include <SEGGER_SYSVIEW.h>
 
 /* Services provided to SYSVIEW by Zephyr */
 extern const SEGGER_SYSVIEW_OS_API SYSVIEW_X_OS_TraceAPI;

--- a/subsys/debug/tracing/include/tracing_sysview.h
+++ b/subsys/debug/tracing/include/tracing_sysview.h
@@ -8,8 +8,8 @@
 #include <kernel.h>
 #include <init.h>
 
-#include <systemview/SEGGER_SYSVIEW.h>
-#include <systemview/Global.h>
+#include <SEGGER_SYSVIEW.h>
+#include <Global.h>
 #include "SEGGER_SYSVIEW_Zephyr.h"
 
 #ifndef CONFIG_SMP

--- a/subsys/debug/tracing/sysview.c
+++ b/subsys/debug/tracing/sysview.c
@@ -3,8 +3,8 @@
 #include <kernel_structs.h>
 #include <init.h>
 
-#include <systemview/SEGGER_SYSVIEW.h>
-#include <systemview/Global.h>
+#include <SEGGER_SYSVIEW.h>
+#include <Global.h>
 #include "SEGGER_SYSVIEW_Zephyr.h"
 
 static u32_t interrupt;

--- a/subsys/debug/tracing/sysview_config.c
+++ b/subsys/debug/tracing/sysview_config.c
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <systemview/SEGGER_SYSVIEW.h>
+#include <SEGGER_SYSVIEW.h>
 #include "SEGGER_SYSVIEW_Zephyr.h"
 
 static void _cbSendSystemDesc(void)

--- a/subsys/logging/log_backend_rtt.c
+++ b/subsys/logging/log_backend_rtt.c
@@ -8,7 +8,7 @@
 #include <logging/log_core.h>
 #include <logging/log_msg.h>
 #include <logging/log_output.h>
-#include <rtt/SEGGER_RTT.h>
+#include <SEGGER_RTT.h>
 
 #define DROP_MAX 99
 

--- a/subsys/shell/shell_rtt.c
+++ b/subsys/shell/shell_rtt.c
@@ -6,7 +6,7 @@
 
 #include <shell/shell_rtt.h>
 #include <init.h>
-#include <rtt/SEGGER_RTT.h>
+#include <SEGGER_RTT.h>
 #include <logging/log.h>
 
 SHELL_RTT_DEFINE(shell_transport_rtt);


### PR DESCRIPTION
Fix issue caused by 3fc497ac9af7119e0e56d4b7fe2e47d6ae12cd8a

Signed-off-by: Pawel Dunaj <pawel.dunaj@nordicsemi.no>