### PR TITLE
cmake: Fix warning related to policy CMP0079

### DIFF
--- a/cmake/app/boilerplate.cmake
+++ b/cmake/app/boilerplate.cmake
@@ -27,6 +27,12 @@ cmake_minimum_required(VERSION 3.8.2)
 
 cmake_policy(SET CMP0002 NEW)
 
+if(NOT (${CMAKE_VERSION} VERSION_LESS "3.13.0"))
+  # Use the old CMake behaviour until 3.13.x is required and the build
+  # scripts have been ported to the new behaviour.
+  cmake_policy(SET CMP0079 OLD)
+endif()
+
 define_property(GLOBAL PROPERTY ZEPHYR_LIBS
     BRIEF_DOCS "Global list of all Zephyr CMake libs that should be linked in"
     FULL_DOCS  "Global list of all Zephyr CMake libs that should be linked in.


### PR DESCRIPTION
In CMake 3.13 a warning is produced if one does not explicitly state
what the policy for CMP0079 should be. To resolve this warning we set
policy CMP0079 to OLD.

This is expected to have no semantical change. When we want a
semantical change we can flip the policy and port the build scripts to
the new behaviour.

This fixes #11794

Signed-off-by: Sebastian Bøe <sebastian.boe@nordicsemi.no>