### PR TITLE
doc: filter new known doc build warnings

### DIFF
--- a/.known-issues/doc/uart.conf
+++ b/.known-issues/doc/uart.conf
@@ -13,3 +13,19 @@
 ^(?P=filename):(?P=lineno): WARNING: Invalid definition: Expected end of definition. \[error at [0-9]+]
 ^.*uart_device_config.__unnamed__.*
 ^[- \t]*\^
+#
+^(?P<filename>([\-:\\/\w\.])+[/\\]doc[/\\]api[/\\]io_interfaces.rst):(?P<lineno>[0-9]+): WARNING: Invalid definition: Expected identifier in nested name. \[error at [0-9]+]
+^[ \t]*
+^[ \t]*\^
+^(?P=filename):(?P=lineno): WARNING: Invalid definition: Expected identifier in nested name. \[error at [0-9]+]
+^[ \t]*
+^[ \t]*\^
+^(?P=filename):(?P=lineno): WARNING: Invalid definition: Expected identifier in nested name. \[error at [0-9]+]
+^[ \t]*
+^[ \t]*\^
+^(?P=filename):(?P=lineno): WARNING: Invalid definition: Expected identifier in nested name. \[error at [0-9]+]
+^[ \t]*
+^[ \t]*\^
+^(?P=filename):(?P=lineno): WARNING: Invalid definition: Expected end of definition. \[error at [0-9]+]
+^.*uart_event.data
+^[- \t]*\^


### PR DESCRIPTION
Changes to uart.h in PR #10820 caused a new warning from Sphinx/Breathe
that we can classify as a "known issue" and should ignore.

Signed-off-by: David B. Kinder <david.b.kinder@intel.com>