### PR TITLE
boards: efr32mg_sltb004a: Fix device name typos

### DIFF
--- a/boards/arm/efr32mg_sltb004a/board.cmake
+++ b/boards/arm/efr32mg_sltb004a/board.cmake
@@ -2,5 +2,5 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 #
-board_runner_args(jlink "--device=EFM32MG12BxxxF1024")
+board_runner_args(jlink "--device=EFR32MG12PxxxF1024")
 include(${ZEPHYR_BASE}/boards/common/jlink.board.cmake)


### PR DESCRIPTION
Chose the wrong device name here.

Signed-off-by: Endre Karlson <endre.karlson@gmail.com>