### PR TITLE
scripts: extract_dts_includes: Add simple defines for i2c/spi children

### DIFF
--- a/dts/bindings/i2c/i2c-device.yaml
+++ b/dts/bindings/i2c/i2c-device.yaml
@@ -29,4 +29,8 @@ properties:
       category: required
       description: Human readable string describing the device (used by Zephyr for API name)
       generation: define
+    zephyr,index:
+      type: int
+      category: optional
+      description: Instance ID (Start at 0, used if system has more than one)
 ...

--- a/dts/bindings/spi/spi-device.yaml
+++ b/dts/bindings/spi/spi-device.yaml
@@ -34,4 +34,8 @@ properties:
       category: required
       description: Human readable string describing the device (used by Zephyr for API name)
       generation: define
+    zephyr,index:
+      type: int
+      category: optional
+      description: Instance ID (Start at 0, used if system has more than one)
 ...

--- a/scripts/dts/extract/globals.py
+++ b/scripts/dts/extract/globals.py
@@ -284,11 +284,19 @@ def add_prop_aliases(node_address,
 
     for alias in aliases[node_address]:
         old_alias_label = alias_label_function(alias)
-        new_alias_label = new_alias_prefix + '_' + old_alias_label
+        dash = '_'
+        if alias == '':
+            dash = ''
+        new_alias_label = new_alias_prefix + dash + old_alias_label
+        cell_index = reduced[node_address]['props'].get('zephyr,index')
+        # If the node has a zephyr,index, use it since it means there might be
+        # multiple instances we need to tell apart
+        if (cell_index != None):
+            new_alias_label = new_alias_prefix + '_' + str(cell_index) + dash + old_alias_label
 
         if (new_alias_label != prop_label):
             prop_aliases[new_alias_label] = prop_label
-        if (old_alias_names and old_alias_label != prop_label):
+        if (old_alias_names and old_alias_label != prop_label and alias != ''):
             prop_aliases[old_alias_label] = prop_label
 
 def get_binding(node_address):

--- a/scripts/dts/extract_dts_includes.py
+++ b/scripts/dts/extract_dts_includes.py
@@ -376,6 +376,9 @@ def extract_property(node_compat, node_address, prop, prop_val, names):
                         # Need to generate alias name for this node:
                         aliases[node_address].append(node_alias)
 
+            # Add an alias for simple spi/i2c cases
+            aliases[node_address].append('')
+
             # Use parent label to generate label
             parent_label = get_node_label(parent_address)
             def_label = parent_label + '_' + def_label

--- a/tests/drivers/i2c/i2c_slave_api/nucleo_f091rc.overlay
+++ b/tests/drivers/i2c/i2c_slave_api/nucleo_f091rc.overlay
@@ -11,6 +11,7 @@
 		reg = <0x54>;
 		label = "EEPROM_SLAVE_0";
 		size = <1>;
+		zephyr,index = <0>;
 	};
 };
 
@@ -21,5 +22,6 @@
 		reg = <0x56>;
 		label = "EEPROM_SLAVE_1";
 		size = <1>;
+		zephyr,index = <1>;
 	};
 };

--- a/tests/drivers/i2c/i2c_slave_api/stm32f072b_disco.overlay
+++ b/tests/drivers/i2c/i2c_slave_api/stm32f072b_disco.overlay
@@ -11,6 +11,7 @@
 		reg = <0x54>;
 		label = "EEPROM_SLAVE_0";
 		size = <1>;
+		zephyr,index = <0>;
 	};
 };
 
@@ -21,5 +22,6 @@
 		reg = <0x56>;
 		label = "EEPROM_SLAVE_1";
 		size = <1>;
+		zephyr,index = <1>;
 	};
 };


### PR DESCRIPTION
To simply and reduce what one has to do in a fixup file for i2c & spi
devices, we generate aliased defines based on just the compatible name.
For now we make the assumption that there is only one sensor of a given
compatible in the system (which is how all I2C & SPI client drivers are
currently).

Signed-off-by: Kumar Gala <kumar.gala@linaro.org>