### PR TITLE
SAM E70: fix Ethernet driver cache coherency issues and always enable data cache

### DIFF
--- a/drivers/ethernet/Kconfig.sam_gmac
+++ b/drivers/ethernet/Kconfig.sam_gmac
@@ -7,6 +7,7 @@
 menuconfig ETH_SAM_GMAC
 	bool "Atmel SAM Ethernet driver"
 	depends on SOC_FAMILY_SAM
+	select NOCACHE_MEMORY
 	help
 	  Enable Atmel SAM MCU Family Ethernet driver.
 

--- a/drivers/ethernet/eth_sam_gmac.c
+++ b/drivers/ethernet/eth_sam_gmac.c
@@ -16,8 +16,6 @@
  * Limitations:
  * - one shot PHY setup, no support for PHY disconnect/reconnect
  * - no statistics collection
- * - no support for devices with DCache enabled due to missing non-cacheable
- *   RAM regions in Zephyr.
  */
 
 #define LOG_MODULE_NAME eth_sam
@@ -84,18 +82,18 @@ LOG_MODULE_REGISTER(LOG_MODULE_NAME);
 
 /* RX descriptors list */
 static struct gmac_desc rx_desc_que0[MAIN_QUEUE_RX_DESC_COUNT]
-	__aligned(GMAC_DESC_ALIGNMENT);
+	__nocache __aligned(GMAC_DESC_ALIGNMENT);
 static struct gmac_desc rx_desc_que1[PRIORITY_QUEUE1_RX_DESC_COUNT]
-	__aligned(GMAC_DESC_ALIGNMENT);
+	__nocache __aligned(GMAC_DESC_ALIGNMENT);
 static struct gmac_desc rx_desc_que2[PRIORITY_QUEUE2_RX_DESC_COUNT]
-	__aligned(GMAC_DESC_ALIGNMENT);
+	__nocache __aligned(GMAC_DESC_ALIGNMENT);
 /* TX descriptors list */
 static struct gmac_desc tx_desc_que0[MAIN_QUEUE_TX_DESC_COUNT]
-	__aligned(GMAC_DESC_ALIGNMENT);
+	__nocache __aligned(GMAC_DESC_ALIGNMENT);
 static struct gmac_desc tx_desc_que1[PRIORITY_QUEUE1_TX_DESC_COUNT]
-	__aligned(GMAC_DESC_ALIGNMENT);
+	__nocache __aligned(GMAC_DESC_ALIGNMENT);
 static struct gmac_desc tx_desc_que2[PRIORITY_QUEUE2_TX_DESC_COUNT]
-	__aligned(GMAC_DESC_ALIGNMENT);
+	__nocache __aligned(GMAC_DESC_ALIGNMENT);
 
 /* RX buffer accounting list */
 static struct net_buf *rx_frag_list_que0[MAIN_QUEUE_RX_DESC_COUNT];
@@ -153,13 +151,11 @@ static inline void dcache_clean(u32_t addr, u32_t size)
 /* Get operations */
 static inline u32_t gmac_desc_get_w0(struct gmac_desc *desc)
 {
-	dcache_invalidate((u32_t)desc, sizeof(struct gmac_desc));
 	return desc->w0;
 }
 
 static inline u32_t gmac_desc_get_w1(struct gmac_desc *desc)
 {
-	dcache_invalidate((u32_t)desc, sizeof(struct gmac_desc));
 	return desc->w1;
 }
 
@@ -167,13 +163,11 @@ static inline u32_t gmac_desc_get_w1(struct gmac_desc *desc)
 static inline void gmac_desc_set_w0(struct gmac_desc *desc, u32_t value)
 {
 	desc->w0 = value;
-	dcache_clean((u32_t)desc, sizeof(struct gmac_desc));
 }
 
 static inline void gmac_desc_set_w1(struct gmac_desc *desc, u32_t value)
 {
 	desc->w1 = value;
-	dcache_clean((u32_t)desc, sizeof(struct gmac_desc));
 }
 
 /* Set with 'or' operations */

--- a/drivers/ethernet/eth_sam_gmac.c
+++ b/drivers/ethernet/eth_sam_gmac.c
@@ -1163,8 +1163,6 @@ static struct net_pkt *frame_get(struct gmac_queue *queue)
 				last_frag = frag;
 				frag = new_frag;
 				rx_frag_list->buf[tail] = (u32_t)frag;
-				dcache_clean((u32_t)&rx_frag_list->buf[tail],
-					     sizeof(u32_t));
 			}
 		}
 

--- a/drivers/ethernet/eth_sam_gmac_priv.h
+++ b/drivers/ethernet/eth_sam_gmac_priv.h
@@ -18,11 +18,7 @@
 /** Cache alignment */
 #define GMAC_DCACHE_ALIGNMENT             32
 /** Memory alignment of the RX/TX Buffer Descriptor List */
-#if __DCACHE_PRESENT == 1
-#define GMAC_DESC_ALIGNMENT               GMAC_DCACHE_ALIGNMENT
-#else
 #define GMAC_DESC_ALIGNMENT               4
-#endif
 /** Total number of queues supported by GMAC hardware module */
 #define GMAC_QUEUE_NO                     3
 /** Number of priority queues used */


### PR DESCRIPTION
This pull request fixes the Atmel SAM Ethernet driver cache coherency issues by using the recently added nocache memory and always enable the data cache. After this the `gmac_desc_*` functions introduced to manage the cache coherency through cache operations look a bit empty. I wonder if we should get rid of them. The same way given the cache is now always enabled, I wonder if we should still check if it is enabled. Anyway this can probably be done in a further cleanup PR.

Fixes #9812
