### PR TITLE
Bluetooth: controller: Fix CPR procedure regression

### DIFF
--- a/subsys/bluetooth/controller/ll_sw/ctrl.c
+++ b/subsys/bluetooth/controller/ll_sw/ctrl.c
@@ -7468,7 +7468,7 @@ static inline void event_conn_param_rsp(struct connection *conn)
 		conn->llcp.conn_upd.win_offset_us = 0U;
 		if (conn->llcp_conn_param.preferred_periodicity) {
 			conn->llcp.conn_upd.interval =
-				((conn->llcp_conn_param.interval_max /
+				((conn->llcp_conn_param.interval_min /
 				  conn->llcp_conn_param.preferred_periodicity) +
 				 1) *
 				conn->llcp_conn_param.preferred_periodicity;


### PR DESCRIPTION
This fixes regression introduced in commit a11868fea9c.

Fixes the following conformance tests:
LL/CON/MAS/BV-32-C [Accepting Connection Parameter Request -
Preferred Periodicity]
LL/CON/MAS/BV-33-C [Accepting Connection Parameter Request -
Preferred Periodicity and preferred anchor points]

Signed-off-by: Vinayak Kariappa Chettimada <vich@nordicsemi.no>