### PR TITLE
Shell: source code cleanup

### DIFF
--- a/include/shell/shell.h
+++ b/include/shell/shell.h
@@ -77,14 +77,14 @@ struct shell;
  * @param[in] _mandatory Number of mandatory arguments.
  * @param[in] _optional  Number of optional arguments.
  */
-#define SHELL_ARG(_mandatory, _optional) {				\
-	.mandatory = _mandatory,					\
-	.optional = _optional,						\
+#define SHELL_ARG(_mandatory, _optional) {	\
+	.mandatory = _mandatory,		\
+	.optional = _optional,			\
 }
 
 struct shell_static_args {
 	u8_t mandatory; /*!< Number of mandatory arguments. */
-	u8_t optional; /*!< Number of optional arguments. */
+	u8_t optional;  /*!< Number of optional arguments. */
 };
 
 /**
@@ -97,11 +97,11 @@ typedef int (*shell_cmd_handler)(const struct shell *shell,
  * @brief Shell static command descriptor.
  */
 struct shell_static_entry {
-	const char *syntax; /*!< Command syntax strings. */
-	const char *help; /*!< Command help string. */
-	const struct shell_cmd_entry *subcmd; /*!< Pointer to subcommand. */
-	shell_cmd_handler handler; /*!< Command handler. */
-	const struct shell_static_args *args; /*!< Command arguments. */
+	const char *syntax;			/*!< Command syntax strings. */
+	const char *help;			/*!< Command help string. */
+	const struct shell_cmd_entry *subcmd;	/*!< Pointer to subcommand. */
+	shell_cmd_handler handler;		/*!< Command handler. */
+	const struct shell_static_args *args;	/*!< Command arguments. */
 };
 
 /**
@@ -112,12 +112,12 @@ struct shell_static_entry {
  * with wrong number of arguments shell will print an error message and command
  * handler will not be called.
  *
- * @param[in] syntax  Command syntax (for example: history).
- * @param[in] subcmd  Pointer to a subcommands array.
- * @param[in] help    Pointer to a command help string.
- * @param[in] handler Pointer to a function handler.
- * @param[in] mandatory Number of mandatory arguments.
- * @param[in] optional  Number of optional arguments.
+ * @param[in] syntax	Command syntax (for example: history).
+ * @param[in] subcmd	Pointer to a subcommands array.
+ * @param[in] help	Pointer to a command help string.
+ * @param[in] handler	Pointer to a function handler.
+ * @param[in] mandatory	Number of mandatory arguments.
+ * @param[in] optional	Number of optional arguments.
  */
 #define SHELL_CMD_ARG_REGISTER(syntax, subcmd, help, handler,		   \
 			       mandatory, optional)			   \
@@ -135,12 +135,12 @@ struct shell_static_entry {
  * @brief Macro for defining and adding a root command (level 0) with
  * arguments.
  *
- * @note Each root command shall have unique syntax.
+ * @note All root commands must have different name.
  *
- * @param[in] syntax  Command syntax (for example: history).
- * @param[in] subcmd  Pointer to a subcommands array.
- * @param[in] help    Pointer to a command help string.
- * @param[in] handler Pointer to a function handler.
+ * @param[in] syntax	Command syntax (for example: history).
+ * @param[in] subcmd	Pointer to a subcommands array.
+ * @param[in] help	Pointer to a command help string.
+ * @param[in] handler	Pointer to a function handler.
  */
 #define SHELL_CMD_REGISTER(syntax, subcmd, help, handler) \
 	static const struct shell_static_entry UTIL_CAT(_shell_, syntax) = \
@@ -157,7 +157,7 @@ struct shell_static_entry {
  * @brief Macro for creating a subcommand set. It must be used outside of any
  * function body.
  *
- * @param[in] name  Name of the subcommand set.
+ * @param[in] name	Name of the subcommand set.
  */
 #define SHELL_CREATE_STATIC_SUBCMD_SET(name)			\
 	static const struct shell_static_entry shell_##name[];	\
@@ -176,8 +176,8 @@ struct shell_static_entry {
 /**
  * @brief Macro for creating a dynamic entry.
  *
- * @param[in] name  Name of the dynamic entry.
- * @param[in] get Pointer to the function returning dynamic commands array
+ * @param[in] name	Name of the dynamic entry.
+ * @param[in] get	Pointer to the function returning dynamic commands array
  */
 #define SHELL_CREATE_DYNAMIC_CMD(name, get)		\
 	static const struct shell_cmd_entry name = {	\
@@ -191,30 +191,30 @@ struct shell_static_entry {
  * @note If a command will be called with wrong number of arguments shell will
  * print an error message and command handler will not be called.
  *
- * @param[in] _syntax  Command syntax (for example: history).
- * @param[in] _subcmd  Pointer to a subcommands array.
- * @param[in] _help    Pointer to a command help string.
- * @param[in] _handler Pointer to a function handler.
+ * @param[in] _syntax	 Command syntax (for example: history).
+ * @param[in] _subcmd	 Pointer to a subcommands array.
+ * @param[in] _help	 Pointer to a command help string.
+ * @param[in] _handler	 Pointer to a function handler.
  * @param[in] _mandatory Number of mandatory arguments.
- * @param[in] _optional Number of optional arguments.
+ * @param[in] _optional	 Number of optional arguments.
  */
-#define SHELL_CMD_ARG(_syntax, _subcmd, _help, _handler,		\
-		      _mandatory, _optional) {				\
-	.syntax = (const char *)STRINGIFY(_syntax),			\
-	.subcmd = _subcmd,						\
-	.help  = (const char *)_help,					\
-	.handler = _handler,						\
-	.args = _mandatory ?						\
-	(&(struct shell_static_args) SHELL_ARG(_mandatory, _optional)) : NULL\
+#define SHELL_CMD_ARG(_syntax, _subcmd, _help, _handler,		      \
+		      _mandatory, _optional) {				      \
+	.syntax = (const char *)STRINGIFY(_syntax),			      \
+	.subcmd = _subcmd,						      \
+	.help  = (const char *)_help,					      \
+	.handler = _handler,						      \
+	.args = _mandatory ?						      \
+	(&(struct shell_static_args) SHELL_ARG(_mandatory, _optional)) : NULL \
 }
 
 /**
  * @brief Initializes a shell command.
  *
- * @param[in] _syntax  Command syntax (for example: history).
- * @param[in] _subcmd  Pointer to a subcommands array.
- * @param[in] _help    Pointer to a command help string.
- * @param[in] _handler Pointer to a function handler.
+ * @param[in] _syntax	Command syntax (for example: history).
+ * @param[in] _subcmd	Pointer to a subcommands array.
+ * @param[in] _help	Pointer to a command help string.
+ * @param[in] _handler	Pointer to a function handler.
  */
 #define SHELL_CMD(_syntax, _subcmd, _help, _handler) \
 	SHELL_CMD_ARG(_syntax, _subcmd, _help, _handler, 0, 0)
@@ -238,7 +238,7 @@ enum shell_state {
 	SHELL_STATE_UNINITIALIZED,
 	SHELL_STATE_INITIALIZED,
 	SHELL_STATE_ACTIVE,
-	SHELL_STATE_PANIC_MODE_ACTIVE, /*!< Panic activated.*/
+	SHELL_STATE_PANIC_MODE_ACTIVE,  /*!< Panic activated.*/
 	SHELL_STATE_PANIC_MODE_INACTIVE /*!< Panic requested, not supported.*/
 };
 
@@ -389,7 +389,7 @@ struct shell_ctx {
 	/*!< VT100 color and cursor position, terminal width.*/
 	struct shell_vt100_ctx vt100_ctx;
 
-	u16_t cmd_buff_len;/*!< Command length.*/
+	u16_t cmd_buff_len; /*!< Command length.*/
 	u16_t cmd_buff_pos; /*!< Command buffer cursor position.*/
 
 	u16_t cmd_tmp_buff_len; /*!< Command length in tmp buffer.*/
@@ -403,7 +403,7 @@ struct shell_ctx {
 	/*!< Printf buffer size.*/
 	char printf_buff[CONFIG_SHELL_PRINTF_BUFF_SIZE];
 
-	volatile union shell_internal internal;   /*!< Internal shell data.*/
+	volatile union shell_internal internal; /*!< Internal shell data.*/
 
 	struct k_poll_signal signals[SHELL_SIGNALS];
 	struct k_poll_event events[SHELL_SIGNALS];
@@ -450,52 +450,52 @@ extern void shell_print_stream(const void *user_ctx, const char *data,
 /**
  * @brief Macro for defining a shell instance.
  *
- * @param[in] _name             Instance name.
- * @param[in] _prompt           Shell prompt string.
- * @param[in] transport_iface   Pointer to the transport interface.
- * @param[in] log_queue_size    Logger processing queue size.
+ * @param[in] _name		Instance name.
+ * @param[in] _prompt		Shell prompt string.
+ * @param[in] transport_iface	Pointer to the transport interface.
+ * @param[in] log_queue_size	Logger processing queue size.
  * @param[in] _shell_flag	Shell output newline sequence.
  */
-#define SHELL_DEFINE(_name, _prompt, transport_iface,			     \
-		     log_queue_size, _shell_flag)			     \
-	static const struct shell _name;				     \
-	static struct shell_ctx UTIL_CAT(_name, _ctx);			     \
-	static char _name##prompt[CONFIG_SHELL_PROMPT_LENGTH + 1] = _prompt; \
-	static u8_t _name##_out_buffer[CONFIG_SHELL_PRINTF_BUFF_SIZE];	     \
-	SHELL_LOG_BACKEND_DEFINE(_name, _name##_out_buffer,		     \
-					 CONFIG_SHELL_PRINTF_BUFF_SIZE);     \
-	SHELL_HISTORY_DEFINE(_name, 128, 8);/*todo*/			     \
-	SHELL_FPRINTF_DEFINE(_name##_fprintf, &_name, _name##_out_buffer,    \
-			     CONFIG_SHELL_PRINTF_BUFF_SIZE,		     \
-			     true, shell_print_stream);			     \
-	LOG_INSTANCE_REGISTER(shell, _name, CONFIG_SHELL_LOG_LEVEL);	     \
-	SHELL_STATS_DEFINE(_name);					     \
-	static K_THREAD_STACK_DEFINE(_name##_stack, CONFIG_SHELL_STACK_SIZE);\
-	static struct k_thread _name##_thread;				     \
-	static const struct shell _name = {				     \
-		.prompt = _name##prompt,				     \
-		.iface = transport_iface,				     \
-		.ctx = &UTIL_CAT(_name, _ctx),				     \
-		.history = SHELL_HISTORY_PTR(_name),			     \
-		.shell_flag = _shell_flag,				     \
-		.fprintf_ctx = &_name##_fprintf,			     \
-		.stats = SHELL_STATS_PTR(_name),			     \
-		.log_backend = SHELL_LOG_BACKEND_PTR(_name),		     \
-		LOG_INSTANCE_PTR_INIT(log, shell, _name)		     \
-		.thread_name = STRINGIFY(_name),			     \
-		.thread = &_name##_thread,				     \
-		.stack = _name##_stack					     \
+#define SHELL_DEFINE(_name, _prompt, transport_iface,			      \
+		     log_queue_size, _shell_flag)			      \
+	static const struct shell _name;				      \
+	static struct shell_ctx UTIL_CAT(_name, _ctx);			      \
+	static char _name##prompt[CONFIG_SHELL_PROMPT_LENGTH + 1] = _prompt;  \
+	static u8_t _name##_out_buffer[CONFIG_SHELL_PRINTF_BUFF_SIZE];	      \
+	SHELL_LOG_BACKEND_DEFINE(_name, _name##_out_buffer,		      \
+					 CONFIG_SHELL_PRINTF_BUFF_SIZE);      \
+	SHELL_HISTORY_DEFINE(_name, 128, 8);/*todo*/			      \
+	SHELL_FPRINTF_DEFINE(_name##_fprintf, &_name, _name##_out_buffer,     \
+			     CONFIG_SHELL_PRINTF_BUFF_SIZE,		      \
+			     true, shell_print_stream);			      \
+	LOG_INSTANCE_REGISTER(shell, _name, CONFIG_SHELL_LOG_LEVEL);	      \
+	SHELL_STATS_DEFINE(_name);					      \
+	static K_THREAD_STACK_DEFINE(_name##_stack, CONFIG_SHELL_STACK_SIZE); \
+	static struct k_thread _name##_thread;				      \
+	static const struct shell _name = {				      \
+		.prompt = _name##prompt,				      \
+		.iface = transport_iface,				      \
+		.ctx = &UTIL_CAT(_name, _ctx),				      \
+		.history = SHELL_HISTORY_PTR(_name),			      \
+		.shell_flag = _shell_flag,				      \
+		.fprintf_ctx = &_name##_fprintf,			      \
+		.stats = SHELL_STATS_PTR(_name),			      \
+		.log_backend = SHELL_LOG_BACKEND_PTR(_name),		      \
+		LOG_INSTANCE_PTR_INIT(log, shell, _name)		      \
+		.thread_name = STRINGIFY(_name),			      \
+		.thread = &_name##_thread,				      \
+		.stack = _name##_stack					      \
 	}
 
 /**
  * @brief Function for initializing a transport layer and internal shell state.
  *
- * @param[in] shell            Pointer to shell instance.
- * @param[in] transport_config Transport configuration during initialization.
- * @param[in] use_colors       Enables colored prints.
- * @param[in] log_backend      If true, the console will be used as logger
- *			       backend.
- * @param[in] init_log_level   Default severity level for the logger.
+ * @param[in] shell		Pointer to shell instance.
+ * @param[in] transport_config	Transport configuration during initialization.
+ * @param[in] use_colors	Enables colored prints.
+ * @param[in] log_backend	If true, the console will be used as logger
+ *				backend.
+ * @param[in] init_log_level	Default severity level for the logger.
  *
  * @return Standard error code.
  */
@@ -555,13 +555,13 @@ int shell_stop(const struct shell *shell);
 #define SHELL_ERROR	SHELL_VT100_COLOR_RED
 
 /**
- * @brief Printf-like function which sends formatted data stream to the shell.
+ * @brief printf-like function which sends formatted data stream to the shell.
  *	  This function shall not be used outside of the shell command context.
  *
- * @param[in] shell Pointer to the shell instance.
- * @param[in] color Printf color.
- * @param[in] p_fmt Format string.
- * @param[in] ...   List of parameters to print.
+ * @param[in] shell	Pointer to the shell instance.
+ * @param[in] color	Printed text color.
+ * @param[in] p_fmt	Format string.
+ * @param[in] ...	List of parameters to print.
  */
 void shell_fprintf(const struct shell *shell, enum shell_vt100_color color,
 		   const char *p_fmt, ...);
@@ -643,7 +643,7 @@ int shell_prompt_change(const struct shell *shell, char *prompt);
 void shell_help(const struct shell *shell);
 
 /* @brief Command's help has been printed */
-#define SHELL_CMD_HELP_PRINTED (1)
+#define SHELL_CMD_HELP_PRINTED	(1)
 
 /** @brief Execute command.
  *

--- a/include/shell/shell.h
+++ b/include/shell/shell.h
@@ -627,8 +627,8 @@ void shell_process(const struct shell *shell);
  * @param[in] shell	Pointer to the shell instance.
  * @param[in] prompt	New shell prompt.
  *
- * @return 0		success
- * @return -1		new string is too long
+ * @return 0		Success.
+ * @return -ENOMEM	New prompt is too long.
  */
 int shell_prompt_change(const struct shell *shell, char *prompt);
 
@@ -642,6 +642,9 @@ int shell_prompt_change(const struct shell *shell, char *prompt);
  */
 void shell_help(const struct shell *shell);
 
+/* @brief Command's help has been printed */
+#define SHELL_CMD_HELP_PRINTED (1)
+
 /** @brief Execute command.
  *
  * Pass command line to shell to execute.
@@ -654,7 +657,7 @@ void shell_help(const struct shell *shell);
  *			enabled.
  * @param[in] cmd	Command to be executed.
  *
- * @returns Result of the execution
+ * @returns		Result of the execution
  */
 int shell_execute_cmd(const struct shell *shell, const char *cmd);
 

--- a/subsys/shell/modules/device_service.c
+++ b/subsys/shell/modules/device_service.c
@@ -35,7 +35,7 @@ static bool device_get_config_level(const struct shell *shell, int level)
 								info++) {
 		if (info->driver_api != NULL) {
 			devices = true;
-			shell_fprintf(shell, SHELL_NORMAL, "- %s\r\n",
+			shell_fprintf(shell, SHELL_NORMAL, "- %s\n",
 					info->config->name);
 		}
 	}
@@ -49,28 +49,28 @@ static int cmd_device_levels(const struct shell *shell,
 	ARG_UNUSED(argv);
 	bool ret;
 
-	shell_fprintf(shell, SHELL_NORMAL, "POST_KERNEL:\r\n");
+	shell_fprintf(shell, SHELL_NORMAL, "POST_KERNEL:\n");
 	ret = device_get_config_level(shell, _SYS_INIT_LEVEL_POST_KERNEL);
 	if (ret == false) {
-		shell_fprintf(shell, SHELL_NORMAL, "- None\r\n");
+		shell_fprintf(shell, SHELL_NORMAL, "- None\n");
 	}
 
-	shell_fprintf(shell, SHELL_NORMAL, "APPLICATION:\r\n");
+	shell_fprintf(shell, SHELL_NORMAL, "APPLICATION:\n");
 	ret = device_get_config_level(shell, _SYS_INIT_LEVEL_APPLICATION);
 	if (ret == false) {
-		shell_fprintf(shell, SHELL_NORMAL, "- None\r\n");
+		shell_fprintf(shell, SHELL_NORMAL, "- None\n");
 	}
 
-	shell_fprintf(shell, SHELL_NORMAL, "PRE KERNEL 1:\r\n");
+	shell_fprintf(shell, SHELL_NORMAL, "PRE KERNEL 1:\n");
 	ret = device_get_config_level(shell, _SYS_INIT_LEVEL_PRE_KERNEL_1);
 	if (ret == false) {
-		shell_fprintf(shell, SHELL_NORMAL, "- None\r\n");
+		shell_fprintf(shell, SHELL_NORMAL, "- None\n");
 	}
 
-	shell_fprintf(shell, SHELL_NORMAL, "PRE KERNEL 2:\r\n");
+	shell_fprintf(shell, SHELL_NORMAL, "PRE KERNEL 2:\n");
 	ret = device_get_config_level(shell, _SYS_INIT_LEVEL_PRE_KERNEL_2);
 	if (ret == false) {
-		shell_fprintf(shell, SHELL_NORMAL, "- None\r\n");
+		shell_fprintf(shell, SHELL_NORMAL, "- None\n");
 	}
 
 	return 0;
@@ -83,10 +83,10 @@ static int cmd_device_list(const struct shell *shell,
 	ARG_UNUSED(argc);
 	ARG_UNUSED(argv);
 
-	shell_fprintf(shell, SHELL_NORMAL, "devices:\r\n");
+	shell_fprintf(shell, SHELL_NORMAL, "devices:\n");
 	for (info = __device_init_start; info != __device_init_end; info++) {
 		if (info->driver_api != NULL) {
-			shell_fprintf(shell, SHELL_NORMAL, "- %s\r\n",
+			shell_fprintf(shell, SHELL_NORMAL, "- %s\n",
 					info->config->name);
 		}
 	}

--- a/subsys/shell/modules/kernel_service.c
+++ b/subsys/shell/modules/kernel_service.c
@@ -22,7 +22,7 @@ static int cmd_kernel_version(const struct shell *shell,
 	ARG_UNUSED(argc);
 	ARG_UNUSED(argv);
 
-	shell_fprintf(shell, SHELL_NORMAL, "Zephyr version %d.%d.%d\r\n",
+	shell_fprintf(shell, SHELL_NORMAL, "Zephyr version %d.%d.%d\n",
 		      SYS_KERNEL_VER_MAJOR(version),
 		      SYS_KERNEL_VER_MINOR(version),
 		      SYS_KERNEL_VER_PATCHLEVEL(version));
@@ -35,7 +35,7 @@ static int cmd_kernel_uptime(const struct shell *shell,
 	ARG_UNUSED(argc);
 	ARG_UNUSED(argv);
 
-	shell_fprintf(shell, SHELL_NORMAL, "Uptime: %u ms\r\n",
+	shell_fprintf(shell, SHELL_NORMAL, "Uptime: %u ms\n",
 			k_uptime_get_32());
 	return 0;
 }
@@ -46,7 +46,7 @@ static int cmd_kernel_cycles(const struct shell *shell,
 	ARG_UNUSED(argc);
 	ARG_UNUSED(argv);
 
-	shell_fprintf(shell, SHELL_NORMAL, "cycles: %u hw cycles\r\n",
+	shell_fprintf(shell, SHELL_NORMAL, "cycles: %u hw cycles\n",
 			k_cycle_get_32());
 	return 0;
 }
@@ -68,16 +68,16 @@ static void shell_tdata_dump(const struct k_thread *thread, void *user_data)
 	tname = k_thread_name_get((struct k_thread *)thread);
 
 	shell_fprintf((const struct shell *)user_data, SHELL_NORMAL,
-		      "%s%p %-10s\r\n",
+		      "%s%p %-10s\n",
 		      (thread == k_current_get()) ? "*" : " ",
 		      thread,
 		      tname ? tname : "NA");
 	shell_fprintf((const struct shell *)user_data, SHELL_NORMAL,
-		      "\toptions: 0x%x, priority: %d\r\n",
+		      "\toptions: 0x%x, priority: %d\n",
 		      thread->base.user_options,
 		      thread->base.prio);
 	shell_fprintf((const struct shell *)user_data, SHELL_NORMAL,
-		"\tstack size %u, unused %u, usage %u / %u (%u %%)\r\n\n",
+		"\tstack size %u, unused %u, usage %u / %u (%u %%)\n\n",
 		      size, unused, size - unused, size, pcnt);
 
 }
@@ -88,7 +88,7 @@ static int cmd_kernel_threads(const struct shell *shell,
 	ARG_UNUSED(argc);
 	ARG_UNUSED(argv);
 
-	shell_fprintf(shell, SHELL_NORMAL, "Threads:\r\n");
+	shell_fprintf(shell, SHELL_NORMAL, "Threads:\n");
 	k_thread_foreach(shell_tdata_dump, (void *)shell);
 	return 0;
 }
@@ -107,7 +107,7 @@ static void shell_stack_dump(const struct k_thread *thread, void *user_data)
 	pcnt = ((size - unused) * 100) / size;
 
 	shell_fprintf((const struct shell *)user_data, SHELL_NORMAL,
-		"0x%08X %-10s (real size %u):\tunused %u\tusage %u / %u (%u %%)\r\n",
+		"0x%08X %-10s (real size %u):\tunused %u\tusage %u / %u (%u %%)\n",
 		      (u32_t)thread,
 		      tname ? tname : "NA",
 		      size, unused, size - unused, size, pcnt);

--- a/subsys/shell/shell.c
+++ b/subsys/shell/shell.c
@@ -193,7 +193,7 @@ static void tab_item_print(const struct shell *shell, const char *option,
 	diff = longest_option - shell_strlen(option);
 
 	if (shell->ctx->vt100_ctx.printed_cmd++ % columns == 0) {
-		shell_fprintf(shell, SHELL_OPTION, "\r\n%s%s", tab, option);
+		shell_fprintf(shell, SHELL_OPTION, "\n%s%s", tab, option);
 	} else {
 		shell_fprintf(shell, SHELL_OPTION, "%s", option);
 	}
@@ -1326,7 +1326,7 @@ int shell_start(const struct shell *shell)
 		vt100_color_set(shell, SHELL_NORMAL);
 	}
 
-	shell_raw_fprintf(shell->fprintf_ctx, "\r\n\n");
+	shell_raw_fprintf(shell->fprintf_ctx, "\n\n");
 
 	shell_state_set(shell, SHELL_STATE_ACTIVE);
 

--- a/subsys/shell/shell_cmds.c
+++ b/subsys/shell/shell_cmds.c
@@ -197,7 +197,7 @@ static int cmd_bacskpace_mode_backspace(const struct shell *shell, size_t argc,
 	ARG_UNUSED(argc);
 	ARG_UNUSED(argv);
 
-	shell->ctx->internal.flags.mode_delete = 0;
+	flag_mode_delete_set(shell, false);
 
 	return 0;
 }
@@ -208,7 +208,7 @@ static int cmd_bacskpace_mode_delete(const struct shell *shell, size_t argc,
 	ARG_UNUSED(argc);
 	ARG_UNUSED(argv);
 
-	shell->ctx->internal.flags.mode_delete = 1;
+	flag_mode_delete_set(shell, true);
 
 	return 0;
 }
@@ -218,7 +218,7 @@ static int cmd_colors_off(const struct shell *shell, size_t argc, char **argv)
 	ARG_UNUSED(argc);
 	ARG_UNUSED(argv);
 
-	shell->ctx->internal.flags.use_colors = 0;
+	flag_use_colors_set(shell, false);
 
 	return 0;
 }
@@ -228,7 +228,7 @@ static int cmd_colors_on(const struct shell *shell, size_t argc, char **argv)
 	ARG_UNUSED(argv);
 	ARG_UNUSED(argv);
 
-	shell->ctx->internal.flags.use_colors = 1;
+	flag_use_colors_set(shell, true);
 
 	return 0;
 }
@@ -238,7 +238,7 @@ static int cmd_echo_off(const struct shell *shell, size_t argc, char **argv)
 	ARG_UNUSED(argc);
 	ARG_UNUSED(argv);
 
-	shell->ctx->internal.flags.echo = 0;
+	flag_echo_set(shell, false);
 
 	return 0;
 }
@@ -248,7 +248,7 @@ static int cmd_echo_on(const struct shell *shell, size_t argc, char **argv)
 	ARG_UNUSED(argc);
 	ARG_UNUSED(argv);
 
-	shell->ctx->internal.flags.echo = 1;
+	flag_echo_set(shell, true);
 
 	return 0;
 }
@@ -262,7 +262,7 @@ static int cmd_echo(const struct shell *shell, size_t argc, char **argv)
 	}
 
 	shell_print(shell, "Echo status: %s",
-		    flag_echo_is_set(shell) ? "on" : "off");
+		    flag_echo_get(shell) ? "on" : "off");
 
 	return 0;
 }

--- a/subsys/shell/shell_help.c
+++ b/subsys/shell/shell_help.c
@@ -175,7 +175,7 @@ void shell_help_subcmd_print(const struct shell *shell)
 		return;
 	}
 
-	shell_fprintf(shell, SHELL_NORMAL, "Subcommands:\r\n");
+	shell_fprintf(shell, SHELL_NORMAL, "Subcommands:\n");
 
 	/* Printing subcommands and help string (if exists). */
 	cmd_idx = 0;

--- a/subsys/shell/shell_ops.c
+++ b/subsys/shell/shell_ops.c
@@ -204,7 +204,7 @@ static void data_insert(const struct shell *shell, const char *data, u16_t len)
 	shell->ctx->cmd_buff_len += len;
 	shell->ctx->cmd_buff[shell->ctx->cmd_buff_len] = '\0';
 
-	if (!flag_echo_is_set(shell)) {
+	if (!flag_echo_get(shell)) {
 		shell->ctx->cmd_buff_pos += len;
 		return;
 	}
@@ -263,6 +263,17 @@ void shell_op_completion_insert(const struct shell *shell,
 	data_insert(shell, compl, compl_len);
 }
 
+void shell_cmd_line_erase(const struct shell *shell)
+{
+	shell_multiline_data_calc(&shell->ctx->vt100_ctx.cons,
+				  shell->ctx->cmd_buff_pos,
+				  shell->ctx->cmd_buff_len);
+	shell_op_cursor_horiz_move(shell, -shell->ctx->vt100_ctx.cons.cur_x);
+	shell_op_cursor_vert_move(shell, shell->ctx->vt100_ctx.cons.cur_y - 1);
+
+	clear_eos(shell);
+}
+
 static void shell_pend_on_txdone(const struct shell *shell)
 {
 	if (IS_ENABLED(CONFIG_MULTITHREADING)) {
@@ -270,9 +281,9 @@ static void shell_pend_on_txdone(const struct shell *shell)
 		k_poll_signal_reset(&shell->ctx->signals[SHELL_SIGNAL_TXDONE]);
 	} else {
 		/* Blocking wait in case of bare metal. */
-		while (!shell->ctx->internal.flags.tx_rdy) {
+		while (!flag_tx_rdy_get(shell)) {
 		}
-		shell->ctx->internal.flags.tx_rdy = 0;
+		flag_tx_rdy_set(shell, false);
 	}
 }
 
@@ -305,4 +316,49 @@ void shell_print_stream(const void *user_ctx, const char *data,
 			size_t data_len)
 {
 	shell_write((const struct shell *) user_ctx, data, data_len);
+}
+
+static void vt100_bgcolor_set(const struct shell *shell,
+			      enum shell_vt100_color bgcolor)
+{
+	if ((bgcolor == SHELL_NORMAL) ||
+	    (shell->ctx->vt100_ctx.col.bgcol == bgcolor)) {
+		return;
+	}
+
+	/* -1 because default value is first in enum */
+	u8_t cmd[] = SHELL_VT100_BGCOLOR(bgcolor - 1);
+
+	shell->ctx->vt100_ctx.col.bgcol = bgcolor;
+	shell_raw_fprintf(shell->fprintf_ctx, "%s", cmd);
+
+}
+
+void shell_vt100_color_set(const struct shell *shell,
+			   enum shell_vt100_color color)
+{
+
+	if (shell->ctx->vt100_ctx.col.col == color) {
+		return;
+	}
+
+	shell->ctx->vt100_ctx.col.col = color;
+
+	if (color != SHELL_NORMAL) {
+
+		u8_t cmd[] = SHELL_VT100_COLOR(color - 1);
+
+		shell_raw_fprintf(shell->fprintf_ctx, "%s", cmd);
+	} else {
+		static const u8_t cmd[] = SHELL_VT100_MODESOFF;
+
+		shell_raw_fprintf(shell->fprintf_ctx, "%s", cmd);
+	}
+}
+
+void shell_vt100_colors_restore(const struct shell *shell,
+				       const struct shell_vt100_colors *color)
+{
+	shell_vt100_color_set(shell, color->col);
+	vt100_bgcolor_set(shell, color->bgcol);
 }

--- a/subsys/shell/shell_ops.h
+++ b/subsys/shell/shell_ops.h
@@ -6,6 +6,7 @@
 #ifndef SHELL_OPS_H__
 #define SHELL_OPS_H__
 
+#include <stdbool.h>
 #include <shell/shell.h>
 #include "shell_vt100.h"
 #include "shell_utils.h"
@@ -68,9 +69,79 @@ static inline void shell_putc(const struct shell *shell, char ch)
 	shell_raw_fprintf(shell->fprintf_ctx, "%c", ch);
 }
 
-static inline bool flag_echo_is_set(const struct shell *shell)
+static inline bool flag_insert_mode_get(const struct shell *shell)
+{
+	return ((shell->ctx->internal.flags.insert_mode == 1) ? true : false);
+}
+
+static inline void flag_insert_mode_set(const struct shell *shell, bool val)
+{
+	shell->ctx->internal.flags.insert_mode = val ? 1 : 0;
+}
+
+static inline bool flag_use_colors_get(const struct shell *shell)
+{
+	return shell->ctx->internal.flags.use_colors == 1 ? true : false;
+}
+
+static inline void flag_use_colors_set(const struct shell *shell, bool val)
+{
+	shell->ctx->internal.flags.use_colors = val ? 1 : 0;
+}
+
+static inline bool flag_echo_get(const struct shell *shell)
 {
 	return shell->ctx->internal.flags.echo == 1 ? true : false;
+}
+
+static inline void flag_echo_set(const struct shell *shell, bool val)
+{
+	shell->ctx->internal.flags.echo = val ? 1 : 0;
+}
+
+static inline bool flag_processing_get(const struct shell *shell)
+{
+	return shell->ctx->internal.flags.processing == 1 ? true : false;
+}
+
+static inline bool flag_tx_rdy_get(const struct shell *shell)
+{
+	return shell->ctx->internal.flags.tx_rdy == 1 ? true : false;
+}
+
+static inline void flag_tx_rdy_set(const struct shell *shell, bool val)
+{
+	shell->ctx->internal.flags.tx_rdy = val ? 1 : 0;
+}
+
+static inline bool flag_mode_delete_get(const struct shell *shell)
+{
+	return shell->ctx->internal.flags.mode_delete == 1 ? true : false;
+}
+
+static inline void flag_mode_delete_set(const struct shell *shell, bool val)
+{
+	shell->ctx->internal.flags.mode_delete = val ? 1 : 0;
+}
+
+static inline bool flag_history_exit_get(const struct shell *shell)
+{
+	return shell->ctx->internal.flags.history_exit == 1 ? true : false;
+}
+
+static inline void flag_history_exit_set(const struct shell *shell, bool val)
+{
+	shell->ctx->internal.flags.history_exit = val ? 1 : 0;
+}
+
+static inline u8_t flag_last_nl_get(const struct shell *shell)
+{
+	return shell->ctx->internal.flags.last_nl;
+}
+
+static inline void flag_last_nl_set(const struct shell *shell, u8_t val)
+{
+	shell->ctx->internal.flags.last_nl = val;
 }
 
 void shell_op_cursor_vert_move(const struct shell *shell, s32_t delta);
@@ -121,6 +192,8 @@ void shell_op_completion_insert(const struct shell *shell,
 
 bool shell_cursor_in_empty_line(const struct shell *shell);
 
+void shell_cmd_line_erase(const struct shell *shell);
+
 /* Function sends data stream to the shell instance. Each time before the
  * shell_write function is called, it must be ensured that IO buffer of fprintf
  * is flushed to avoid synchronization issues.
@@ -142,6 +215,19 @@ void shell_write(const struct shell *shell, const void *data,
  */
 void shell_print_stream(const void *user_ctx, const char *data,
 			size_t data_len);
+
+/** @internal @brief Function for setting font color */
+void shell_vt100_color_set(const struct shell *shell,
+			   enum shell_vt100_color color);
+
+static inline void shell_vt100_colors_store(const struct shell *shell,
+					    struct shell_vt100_colors *color)
+{
+	memcpy(color, &shell->ctx->vt100_ctx.col, sizeof(*color));
+}
+
+void shell_vt100_colors_restore(const struct shell *shell,
+				const struct shell_vt100_colors *color);
 
 #ifdef __cplusplus
 }

--- a/subsys/shell/shell_ops.h
+++ b/subsys/shell/shell_ops.h
@@ -59,7 +59,7 @@ static inline void cursor_restore(const struct shell *shell)
  */
 static inline void cursor_next_line_move(const struct shell *shell)
 {
-	shell_raw_fprintf(shell->fprintf_ctx, "\r\n");
+	shell_raw_fprintf(shell->fprintf_ctx, "\n");
 }
 
 /* Function sends 1 character to the shell instance. */

--- a/subsys/shell/shell_utils.c
+++ b/subsys/shell/shell_utils.c
@@ -225,7 +225,7 @@ static inline u32_t shell_root_cmd_count(void)
 }
 
 /* Function returning pointer to root command matching requested syntax. */
-const struct shell_cmd_entry *root_cmd_find(const char *syntax)
+const struct shell_cmd_entry *shell_root_cmd_find(const char *syntax)
 {
 	const size_t cmd_count = shell_root_cmd_count();
 	const struct shell_cmd_entry *cmd;
@@ -335,7 +335,10 @@ void shell_spaces_trim(char *str)
 	}
 }
 
-void shell_buffer_trim(char *buff, u16_t *buff_len)
+/** @brief Remove white chars from beginning and end of command buffer.
+ *
+ */
+static void buffer_trim(char *buff, u16_t *buff_len)
 {
 	u16_t i = 0U;
 
@@ -368,4 +371,10 @@ void shell_buffer_trim(char *buff, u16_t *buff_len)
 		memmove(buff, buff + i, (*buff_len + 1) - i); /* +1 for '\0' */
 		*buff_len = *buff_len - i;
 	}
+}
+
+void shell_cmd_trim(const struct shell *shell)
+{
+	buffer_trim(shell->ctx->cmd_buff, &shell->ctx->cmd_buff_len);
+	shell->ctx->cmd_buff_pos = shell->ctx->cmd_buff_len;
 }

--- a/subsys/shell/shell_utils.h
+++ b/subsys/shell/shell_utils.h
@@ -13,7 +13,7 @@
 extern "C" {
 #endif
 
-#define SHELL_MSG_SPECIFY_SUBCOMMAND	"Please specify a subcommand.\r\n"
+#define SHELL_MSG_SPECIFY_SUBCOMMAND	"Please specify a subcommand.\n"
 
 #define SHELL_DEFAULT_TERMINAL_WIDTH	(80u) /* Default PuTTY width. */
 #define SHELL_DEFAULT_TERMINAL_HEIGHT	(24u) /* Default PuTTY height. */

--- a/subsys/shell/shell_utils.h
+++ b/subsys/shell/shell_utils.h
@@ -64,19 +64,16 @@ void shell_cmd_get(const struct shell_cmd_entry *command, size_t lvl,
 int shell_command_add(char *buff, u16_t *buff_len,
 		      const char *new_cmd, const char *pattern);
 
-const struct shell_cmd_entry *root_cmd_find(const char *syntax);
+const struct shell_cmd_entry *shell_root_cmd_find(const char *syntax);
 
 void shell_spaces_trim(char *str);
-
-/** @brief Remove white chars from beginning and end of command buffer.
- *
- */
-void shell_buffer_trim(char *buff, u16_t *buff_len);
 
 static inline void transport_buffer_flush(const struct shell *shell)
 {
 	shell_fprintf_buffer_flush(shell->fprintf_ctx);
 }
+
+void shell_cmd_trim(const struct shell *shell);
 
 #ifdef __cplusplus
 }

--- a/subsys/shell/shell_wildcard.c
+++ b/subsys/shell/shell_wildcard.c
@@ -112,7 +112,7 @@ static enum shell_wildcard_status commands_expand(const struct shell *shell,
 					      SHELL_WARNING,
 					      "Command buffer is too short to"
 					      " expand all commands matching"
-					      " wildcard pattern: %s\r\n",
+					      " wildcard pattern: %s\n",
 					      pattern);
 				break;
 			} else if (ret_val != SHELL_WILDCARD_CMD_ADDED) {


### PR DESCRIPTION
1. Minor style and formatting updates in shell source files.
2. Removed obsolete '\r' characters.
3. Static functions cleanup.
