### PR TITLE
samples: cmsis_rtos_v1: remove tracing test

### DIFF
--- a/samples/portability/cmsis_rtos_v1/philosophers/sample.yaml
+++ b/samples/portability/cmsis_rtos_v1/philosophers/sample.yaml
@@ -17,10 +17,6 @@ common:
 tests:
   sample.philosopher:
     tags: cmsis_rtos_v1_philosopher
-  sample.philosopher.tracing:
-    min_ram: 32
-    extra_configs:
-      - CONFIG_SEGGER_SYSTEMVIEW=y
   sample.philosopher.same_prio:
     extra_args: "-DSAME_PRIO=1"
   sample.philosopher.semaphores:


### PR DESCRIPTION
This is not relevant to the test.