### PR TITLE
shell: bluetooth shell asserted after 'bt init'

### DIFF
--- a/subsys/bluetooth/shell/bt.c
+++ b/subsys/bluetooth/shell/bt.c
@@ -325,12 +325,12 @@ static int cmd_init(const struct shell *shell, size_t argc, char *argv[])
 {
 	int err;
 
+    ctx_shell = shell;
+
 	err = bt_enable(bt_ready);
 	if (err) {
 		shell_error(shell, "Bluetooth init failed (err %d)", err);
 	}
-
-	ctx_shell = shell;
 
 	return err;
 }


### PR DESCRIPTION
on bt_ready, ctx_shell would be NULL if not initialized before bt_enable.