### PR TITLE
STM32: Fix clock bus for STM32F0 GPIO

### DIFF
--- a/drivers/clock_control/stm32_ll_clock.c
+++ b/drivers/clock_control/stm32_ll_clock.c
@@ -89,6 +89,8 @@ static inline int stm32_clock_control_on(struct device *dev,
 		LL_IOP_GRP1_EnableClock(pclken->enr);
 		break;
 #endif /* CONFIG_SOC_SERIES_STM32L0X */
+	default:
+		return -ENOTSUP;
 	}
 
 	return 0;
@@ -133,6 +135,8 @@ static inline int stm32_clock_control_off(struct device *dev,
 		LL_IOP_GRP1_DisableClock(pclken->enr);
 		break;
 #endif /* CONFIG_SOC_SERIES_STM32L0X */
+	default:
+		return -ENOTSUP;
 	}
 
 	return 0;
@@ -179,6 +183,8 @@ static int stm32_clock_control_get_subsys_rate(struct device *clock,
 		*rate = apb2_clock;
 		break;
 #endif /* CONFIG_SOC_SERIES_STM32F0X */
+	default:
+		return -ENOTSUP;
 	}
 
 	return 0;

--- a/drivers/dma/dma_stm32f4x.c
+++ b/drivers/dma/dma_stm32f4x.c
@@ -499,7 +499,11 @@ static int dma_stm32_init(struct device *dev)
 
 	__ASSERT_NO_MSG(ddata->clk);
 
-	clock_control_on(ddata->clk, (clock_control_subsys_t *) &cdata->pclken);
+	if (clock_control_on(ddata->clk,
+		(clock_control_subsys_t *) &cdata->pclken) != 0) {
+		LOG_ERR("Could not enable DMA clock\n");
+		return -EIO;
+	}
 
 	/* Set controller specific configuration */
 	cdata->config(ddata);

--- a/drivers/entropy/entropy_stm32.c
+++ b/drivers/entropy/entropy_stm32.c
@@ -151,6 +151,7 @@ static int entropy_stm32_rng_init(struct device *dev)
 {
 	struct entropy_stm32_rng_dev_data *dev_data;
 	struct entropy_stm32_rng_dev_cfg *dev_cfg;
+	int res;
 
 	__ASSERT_NO_MSG(dev != NULL);
 
@@ -186,8 +187,9 @@ static int entropy_stm32_rng_init(struct device *dev)
 	dev_data->clock = device_get_binding(STM32_CLOCK_CONTROL_NAME);
 	__ASSERT_NO_MSG(dev_data->clock != NULL);
 
-	clock_control_on(dev_data->clock,
+	res = clock_control_on(dev_data->clock,
 		(clock_control_subsys_t *)&dev_cfg->pclken);
+	__ASSERT_NO_MSG(res);
 
 	LL_RNG_Enable(dev_data->rng);
 

--- a/drivers/ethernet/eth_stm32_hal.c
+++ b/drivers/ethernet/eth_stm32_hal.c
@@ -257,6 +257,7 @@ static int eth_initialize(struct device *dev)
 {
 	struct eth_stm32_hal_dev_data *dev_data;
 	struct eth_stm32_hal_dev_cfg *cfg;
+	int ret = 0;
 
 	__ASSERT_NO_MSG(dev != NULL);
 
@@ -270,14 +271,19 @@ static int eth_initialize(struct device *dev)
 	__ASSERT_NO_MSG(dev_data->clock != NULL);
 
 	/* enable clock */
-	clock_control_on(dev_data->clock,
+	ret = clock_control_on(dev_data->clock,
 		(clock_control_subsys_t *)&cfg->pclken);
-	clock_control_on(dev_data->clock,
+	ret |= clock_control_on(dev_data->clock,
 		(clock_control_subsys_t *)&cfg->pclken_tx);
-	clock_control_on(dev_data->clock,
+	ret |= clock_control_on(dev_data->clock,
 		(clock_control_subsys_t *)&cfg->pclken_rx);
-	clock_control_on(dev_data->clock,
+	ret |= clock_control_on(dev_data->clock,
 		(clock_control_subsys_t *)&cfg->pclken_ptp);
+
+	if (ret) {
+		LOG_ERR("Failed to enable ethernet clock");
+		return -EIO;
+	}
 
 	__ASSERT_NO_MSG(cfg->config_func != NULL);
 

--- a/drivers/flash/flash_stm32.c
+++ b/drivers/flash/flash_stm32.c
@@ -252,7 +252,9 @@ static int stm32_flash_init(struct device *dev)
 #endif
 
 	/* enable clock */
-	clock_control_on(clk, (clock_control_subsys_t *)&p->pclken);
+	if (clock_control_on(clk, (clock_control_subsys_t *)&p->pclken) != 0) {
+		return -EIO;
+	}
 #endif
 
 	k_sem_init(&p->sem, 1, 1);

--- a/drivers/gpio/gpio_stm32.c
+++ b/drivers/gpio/gpio_stm32.c
@@ -188,7 +188,10 @@ static int gpio_stm32_init(struct device *device)
 	struct device *clk =
 		device_get_binding(STM32_CLOCK_CONTROL_NAME);
 
-	clock_control_on(clk, (clock_control_subsys_t *) &cfg->pclken);
+	if (clock_control_on(clk,
+		(clock_control_subsys_t *) &cfg->pclken) != 0) {
+		return -EIO;
+	}
 
 	return 0;
 }

--- a/drivers/i2c/i2c_ll_stm32.c
+++ b/drivers/i2c/i2c_ll_stm32.c
@@ -170,7 +170,11 @@ static int i2c_stm32_init(struct device *dev)
 #endif
 
 	__ASSERT_NO_MSG(clock);
-	clock_control_on(clock, (clock_control_subsys_t *) &cfg->pclken);
+	if (clock_control_on(clock,
+		(clock_control_subsys_t *) &cfg->pclken) != 0) {
+		LOG_ERR("i2c: failure enabling clock");
+		return -EIO;
+	}
 
 #if defined(CONFIG_SOC_SERIES_STM32F3X) || defined(CONFIG_SOC_SERIES_STM32F0X)
 	/*

--- a/drivers/i2s/i2s_ll_stm32.c
+++ b/drivers/i2s/i2s_ll_stm32.c
@@ -99,6 +99,7 @@ static int i2s_stm32_enable_clock(struct device *dev)
 
 	ret = clock_control_on(clk, (clock_control_subsys_t *) &cfg->pclken);
 	if (ret != 0) {
+		LOG_ERR("Could not enable I2S clock");
 		return -EIO;
 	}
 

--- a/drivers/pwm/pwm_stm32.c
+++ b/drivers/pwm/pwm_stm32.c
@@ -196,8 +196,10 @@ static int pwm_stm32_init(struct device *dev)
 	__pwm_stm32_get_clock(dev);
 
 	/* enable clock */
-	clock_control_on(data->clock,
-			(clock_control_subsys_t *)&config->pclken);
+	if (clock_control_on(data->clock,
+			(clock_control_subsys_t *)&config->pclken) != 0) {
+		return -EIO;
+	}
 
 	return 0;
 }

--- a/drivers/rtc/rtc_ll_stm32.c
+++ b/drivers/rtc/rtc_ll_stm32.c
@@ -214,7 +214,10 @@ static int rtc_stm32_init(struct device *dev)
 	k_sem_init(DEV_SEM(dev), 1, UINT_MAX);
 	DEV_DATA(dev)->cb_fn = NULL;
 
-	clock_control_on(clk, (clock_control_subsys_t *) &cfg->pclken);
+	if (clock_control_on(clk,
+		(clock_control_subsys_t *) &cfg->pclken) != 0) {
+		return -EIO;
+	}
 
 	LL_PWR_EnableBkUpAccess();
 	LL_RCC_ForceBackupDomainReset();

--- a/drivers/serial/uart_stm32.c
+++ b/drivers/serial/uart_stm32.c
@@ -311,8 +311,10 @@ static int uart_stm32_init(struct device *dev)
 
 	__uart_stm32_get_clock(dev);
 	/* enable clock */
-	clock_control_on(data->clock,
-			(clock_control_subsys_t *)&config->pclken);
+	if (clock_control_on(data->clock,
+			(clock_control_subsys_t *)&config->pclken) != 0) {
+		return -EIO;
+	}
 
 	LL_USART_Disable(UartInstance);
 

--- a/drivers/spi/spi_ll_stm32.c
+++ b/drivers/spi/spi_ll_stm32.c
@@ -465,8 +465,11 @@ static int spi_stm32_init(struct device *dev)
 
 	__ASSERT_NO_MSG(device_get_binding(STM32_CLOCK_CONTROL_NAME));
 
-	clock_control_on(device_get_binding(STM32_CLOCK_CONTROL_NAME),
-			       (clock_control_subsys_t) &cfg->pclken);
+	if (clock_control_on(device_get_binding(STM32_CLOCK_CONTROL_NAME),
+			       (clock_control_subsys_t) &cfg->pclken) != 0) {
+		LOG_ERR("Could not enable SPI clock");
+		return -EIO;
+	}
 
 #ifdef CONFIG_SPI_STM32_INTERRUPT
 	cfg->irq_config(dev);

--- a/drivers/usb/device/usb_dc_stm32.c
+++ b/drivers/usb/device/usb_dc_stm32.c
@@ -253,7 +253,10 @@ static int usb_dc_stm32_clock_enable(void)
 	}
 #endif /* RCC_HSI48_SUPPORT / LL_RCC_USB_CLKSOURCE_NONE */
 
-	clock_control_on(clk, (clock_control_subsys_t *)&pclken);
+	if (clock_control_on(clk, (clock_control_subsys_t *)&pclken) != 0) {
+		LOG_ERR("Unable to enable USB clock");
+		return -EIO;
+	}
 
 #ifdef DT_USB_HS_BASE_ADDRESS
 

--- a/dts/arm/st/f0/stm32f0.dtsi
+++ b/dts/arm/st/f0/stm32f0.dtsi
@@ -64,7 +64,7 @@
 				gpio-controller;
 				#gpio-cells = <2>;
 				reg = <0x48000000 0x400>;
-				clocks = <&rcc STM32_CLOCK_BUS_AHB2 0x00020000>;
+				clocks = <&rcc STM32_CLOCK_BUS_AHB1 0x00020000>;
 				label = "GPIOA";
 			};
 
@@ -73,7 +73,7 @@
 				gpio-controller;
 				#gpio-cells = <2>;
 				reg = <0x48000400 0x400>;
-				clocks = <&rcc STM32_CLOCK_BUS_AHB2 0x00040000>;
+				clocks = <&rcc STM32_CLOCK_BUS_AHB1 0x00040000>;
 				label = "GPIOB";
 			};
 
@@ -82,7 +82,7 @@
 				gpio-controller;
 				#gpio-cells = <2>;
 				reg = <0x48000800 0x400>;
-				clocks = <&rcc STM32_CLOCK_BUS_AHB2 0x00080000>;
+				clocks = <&rcc STM32_CLOCK_BUS_AHB1 0x00080000>;
 				label = "GPIOC";
 			};
 
@@ -91,7 +91,7 @@
 				gpio-controller;
 				#gpio-cells = <2>;
 				reg = <0x48000c00 0x400>;
-				clocks = <&rcc STM32_CLOCK_BUS_AHB2 0x00100000>;
+				clocks = <&rcc STM32_CLOCK_BUS_AHB1 0x00100000>;
 				label = "GPIOD";
 			};
 
@@ -100,7 +100,7 @@
 				gpio-controller;
 				#gpio-cells = <2>;
 				reg = <0x48001400 0x400>;
-				clocks = <&rcc STM32_CLOCK_BUS_AHB2 0x00400000>;
+				clocks = <&rcc STM32_CLOCK_BUS_AHB1 0x00400000>;
 				label = "GPIOF";
 			};
 		};

--- a/dts/arm/st/f0/stm32f072.dtsi
+++ b/dts/arm/st/f0/stm32f072.dtsi
@@ -15,7 +15,7 @@
 				gpio-controller;
 				#gpio-cells = <2>;
 				reg = <0x48001000 0x400>;
-				clocks = <&rcc STM32_CLOCK_BUS_AHB2 0x00200000>;
+				clocks = <&rcc STM32_CLOCK_BUS_AHB1 0x00200000>;
 				label = "GPIOE";
 			};
 		};

--- a/dts/arm/st/f0/stm32f091.dtsi
+++ b/dts/arm/st/f0/stm32f091.dtsi
@@ -42,7 +42,7 @@
 				gpio-controller;
 				#gpio-cells = <2>;
 				reg = <0x48001000 0x400>;
-				clocks = <&rcc STM32_CLOCK_BUS_AHB2 0x00200000>;
+				clocks = <&rcc STM32_CLOCK_BUS_AHB1 0x00200000>;
 				label = "GPIOE";
 			};
 		};


### PR DESCRIPTION
Clock bus was not documented correctly in stm32f0.dtsi.
Failure was exposed since recent change in GPIO drivers using bus setting from device tree.

To avoid this kind of issue in future, add default case that return error when unsupported bus is requested from peripheral drivers. Add matching error checking in peripheral drivers.

Fixes #11904