### PR TITLE
cmake: Move libapp.a into it's own directory

### DIFF
--- a/cmake/app/boilerplate.cmake
+++ b/cmake/app/boilerplate.cmake
@@ -338,6 +338,7 @@ Enable Qemu supported ethernet driver like e1000 at drivers/ethernet")
 endif()
 
 zephyr_library_named(app)
+set_property(TARGET app PROPERTY ARCHIVE_OUTPUT_DIRECTORY app)
 
 add_subdirectory(${ZEPHYR_BASE} ${__build_dir})
 


### PR DESCRIPTION
Move libapp.a into it's own directory. This would make it's placement
consistent with how zephyr.elf is placed.

E.g. it might now look like:

ls b/*

b/build.ninja  b/CMakeCache.txt  b/cmake_install.cmake  b/rules.ninja

b/app:
libapp.a

b/CMakeFiles:
3.12.0   cmake.check_cache  CMakeOutput.log  TargetDirectories.txt
app.dir  CMakeError.log     CMakeTmp

b/zephyr:
arch                 kernel                       subsys
boards               lib                          tests
cmake                liboffsets.a                 zephyr.bin
CMakeFiles           libzephyr.a                  zephyr.elf
cmake_install.cmake  linker.cmd                   zephyr.hex
ext                  linker_pass_final.cmd        zephyr.map
include              linker_pass_final.cmd.dep    zephyr_prebuilt.elf
isrList.bin          misc                         zephyr.stat

This fixes #5343 

Signed-off-by: Sebastian Bøe <sebastian.boe@nordicsemi.no>