### PR TITLE
samples: cmsis_rtos_v1: Disable tests on qemu_xtensa

### DIFF
--- a/samples/portability/cmsis_rtos_v1/philosophers/sample.yaml
+++ b/samples/portability/cmsis_rtos_v1/philosophers/sample.yaml
@@ -5,6 +5,7 @@ common:
   tags: cmsis_rtos_v1_philosopher
   min_ram: 32
   min_flash: 34
+  platform_exclude: qemu_xtensa
   harness: console
   harness_config:
     type: multi_line


### PR DESCRIPTION
We get an intermittent fail when running on qemu_xtensa.  Disable this
sample for now on that platform to allow sanitycheck / CI to pass for
other PRs.

Signed-off-by: Kumar Gala <kumar.gala@linaro.org>