### PR TITLE
ci: Fail shippable if something fails catastrophically

### DIFF
--- a/scripts/ci/run_ci.sh
+++ b/scripts/ci/run_ci.sh
@@ -22,7 +22,7 @@ set -xe
 SANITYCHECK_OPTIONS=" --inline-logs --enable-coverage -N"
 SANITYCHECK_OPTIONS_RETRY="${SANITYCHECK_OPTIONS} --only-failed --outdir=out-2nd-pass"
 SANITYCHECK_OPTIONS_RETRY_2="${SANITYCHECK_OPTIONS} --only-failed --outdir=out-3nd-pass"
-export BSIM_OUT_PATH="/opt/bsim/"
+export BSIM_OUT_PATH="${BSIM_OUT_PATH:-/opt/bsim/}"
 export BSIM_COMPONENTS_PATH="${BSIM_OUT_PATH}/components/"
 BSIM_BT_TEST_RESULTS_FILE="./bsim_bt_out/bsim_results.xml"
 

--- a/scripts/ci/run_ci.sh
+++ b/scripts/ci/run_ci.sh
@@ -17,7 +17,7 @@
 # The script can be run locally using for exmaple:
 # ./scripts/ci/run_ci.sh -b master -r upstream  -p
 
-set -x
+set -xe
 
 SANITYCHECK_OPTIONS=" --inline-logs --enable-coverage -N"
 SANITYCHECK_OPTIONS_RETRY="${SANITYCHECK_OPTIONS} --only-failed --outdir=out-2nd-pass"
@@ -170,12 +170,12 @@ function build_btsim() {
 	if [ -d ext_NRF52_hw_models ]; then
 		cd ext_NRF52_hw_models
 		git describe --tags --abbrev=0 ${NRF52_HW_MODELS_TAG}\
-		> /dev/null
-		if [ "$?" != "0" ]; then
+		> /dev/null ||
+		(
 			echo "`pwd` seems to contain the nRF52 HW\
  models but they are out of date"
 			exit 1;
-		fi
+		)
 	else
 		git clone -b ${NRF_HW_MODELS_VERSION} \
 		https://github.com/BabbleSim/ext_NRF52_hw_models.git
@@ -194,11 +194,8 @@ function run_bsim_bt_tests() {
 
 function build_docs() {
 	echo "- Building Documentation";
-	make htmldocs
-	if [ "$?" != "0" ]; then
-		echo "Documentation build failed";
-		exit 1;
-	fi
+	make htmldocs || ( echo "Documentation build failed" ; exit 1 )
+
 	if [ -s doc/_build/doc.warnings ]; then
 		echo " => New documentation warnings/errors";
 		cp doc/_build/doc.warnings doc.warnings
@@ -243,13 +240,11 @@ if [ -n "$MAIN_CI" ]; then
 	${SANITYCHECK} ${SANITYCHECK_OPTIONS} --save-tests test_file.txt || exit 1
 
 	# Run a subset of tests based on matrix size
-	${SANITYCHECK} ${SANITYCHECK_OPTIONS} --load-tests test_file.txt --subset ${MATRIX}/${MATRIX_BUILDS}
-	if [ "$?" != 0 ]; then
-		# let the host settle down
-		sleep 10
-		${SANITYCHECK} ${SANITYCHECK_OPTIONS_RETRY} || \
-			( sleep 10; ${SANITYCHECK} ${SANITYCHECK_OPTIONS_RETRY_2}; )
-	fi
+	${SANITYCHECK} ${SANITYCHECK_OPTIONS} --load-tests test_file.txt \
+		--subset ${MATRIX}/${MATRIX_BUILDS} || \
+		( sleep 10; ${SANITYCHECK} ${SANITYCHECK_OPTIONS_RETRY} ) || \
+		( sleep 10; ${SANITYCHECK} ${SANITYCHECK_OPTIONS_RETRY_2}; )
+		# sleep 10 to let the host settle down
 
 	# cleanup
 	rm -f test_file.txt

--- a/scripts/ci/run_ci.sh
+++ b/scripts/ci/run_ci.sh
@@ -139,13 +139,6 @@ function on_complete() {
 	mkdir -p shippable/testresults
 	mkdir -p shippable/codecoverage
 
-	if [ "$MATRIX" = "1" ]; then
-		echo "Handle coverage data..."
-		handle_coverage
-	else
-		rm -rf sanity-out out-2nd-pass;
-	fi;
-
 	if [ -e compliance.xml ]; then
 		echo "Copy compliance.xml"
 		cp compliance.xml shippable/testresults/;
@@ -159,6 +152,13 @@ function on_complete() {
 	if [ -e ${BSIM_BT_TEST_RESULTS_FILE} ]; then
 		echo "Copy ${BSIM_BT_TEST_RESULTS_FILE}"
 		cp ${BSIM_BT_TEST_RESULTS_FILE} shippable/testresults/;
+	fi;
+
+	if [ "$MATRIX" = "1" ]; then
+		echo "Handle coverage data..."
+		handle_coverage
+	else
+		rm -rf sanity-out out-2nd-pass;
 	fi;
 }
 


### PR DESCRIPTION
Before run_ci.sh was introduced, if some command in the .shippable.yml script failed, Shippable would stop and report a failure.
When run_ci.sh was introduced we lost this, which is pretty dangerous if something fails cathastrophically and the xml reports are not (properly) generated and copied, as then Shippable reports a pass.
=> Run run_ci.sh in -e mode, so we propagate a bad failure upwards
&
If BSIM_OUT_PATH was set in the environment use that value
&
Coverage parsing has high chances of failing, let's copy first the results

@nashif : With this proposal, as soon as things start failing (say bt_sim cases) the run also stops, which would save some unnecessary compute time. Although you may consider it a drawback if you want to see it go all the way always..