### PR TITLE
drivers: ieee802154_mcr20a: various fixes

### DIFF
--- a/boards/arm/frdm_k64f/frdm_k64f.dts
+++ b/boards/arm/frdm_k64f/frdm_k64f.dts
@@ -97,7 +97,6 @@ arduino_serial: &uart3 {};
 
 &spi0 {
 	status = "ok";
-	cs-gpios = <&gpiod 0 0>;
 
 	mcr20a@0 {
 		compatible = "nxp,mcr20a";

--- a/drivers/ieee802154/ieee802154_mcr20a.c
+++ b/drivers/ieee802154/ieee802154_mcr20a.c
@@ -1354,17 +1354,20 @@ static inline int configure_gpios(struct device *dev)
 			   GPIO_PUD_PULL_UP |
 			   GPIO_INT_ACTIVE_LOW);
 
-	/* setup gpio for the modems reset */
-	mcr20a->reset_gpio = device_get_binding(DT_MCR20A_GPIO_RESET_NAME);
-	if (mcr20a->reset_gpio == NULL) {
-		LOG_ERR("Failed to get pointer to %s device",
-			    DT_MCR20A_GPIO_RESET_NAME);
-		return -EINVAL;
-	}
+	if (!PART_OF_KW2XD_SIP) {
+		/* setup gpio for the modems reset */
+		mcr20a->reset_gpio = device_get_binding(
+					DT_MCR20A_GPIO_RESET_NAME);
+		if (mcr20a->reset_gpio == NULL) {
+			LOG_ERR("Failed to get pointer to %s device",
+				DT_MCR20A_GPIO_RESET_NAME);
+			return -EINVAL;
+		}
 
-	gpio_pin_configure(mcr20a->reset_gpio, DT_MCR20A_GPIO_RESET_PIN,
-			   GPIO_DIR_OUT);
-	set_reset(dev, 1);
+		gpio_pin_configure(mcr20a->reset_gpio, DT_MCR20A_GPIO_RESET_PIN,
+				   GPIO_DIR_OUT);
+		set_reset(dev, 0);
+	}
 
 	return 0;
 }

--- a/drivers/ieee802154/ieee802154_mcr20a.c
+++ b/drivers/ieee802154/ieee802154_mcr20a.c
@@ -1258,7 +1258,7 @@ static int mcr20a_update_overwrites(struct mcr20a_context *dev)
 	     i < sizeof(overwrites_indirect) / sizeof(overwrites_t);
 	     i++) {
 
-		if (!_mcr20a_write_reg(dev, true,
+		if (!_mcr20a_write_reg(dev, false,
 				       overwrites_indirect[i].address,
 				       overwrites_indirect[i].data)) {
 			goto error;

--- a/drivers/ieee802154/ieee802154_mcr20a.c
+++ b/drivers/ieee802154/ieee802154_mcr20a.c
@@ -1344,7 +1344,7 @@ static inline int configure_gpios(struct device *dev)
 	mcr20a->irq_gpio = device_get_binding(DT_MCR20A_GPIO_IRQ_B_NAME);
 	if (mcr20a->irq_gpio == NULL) {
 		LOG_ERR("Failed to get pointer to %s device",
-			    DT_MCR20A_GPIO_IRQ_B_NAME);
+			DT_MCR20A_GPIO_IRQ_B_NAME);
 		return -EINVAL;
 	}
 
@@ -1376,8 +1376,7 @@ static inline int configure_spi(struct device *dev)
 {
 	struct mcr20a_context *mcr20a = dev->driver_data;
 
-	mcr20a->spi = device_get_binding(
-			DT_IEEE802154_MCR20A_SPI_DRV_NAME);
+	mcr20a->spi = device_get_binding(DT_IEEE802154_MCR20A_SPI_DRV_NAME);
 	if (!mcr20a->spi) {
 		LOG_ERR("Unable to get SPI device");
 		return -ENODEV;
@@ -1397,8 +1396,8 @@ static inline int configure_spi(struct device *dev)
 	mcr20a->spi_cfg.cs = &mcr20a->cs_ctrl;
 
 	LOG_DBG("SPI GPIO CS configured on %s:%u",
-		    DT_IEEE802154_MCR20A_GPIO_SPI_CS_DRV_NAME,
-		    DT_IEEE802154_MCR20A_GPIO_SPI_CS_PIN);
+		DT_IEEE802154_MCR20A_GPIO_SPI_CS_DRV_NAME,
+		DT_IEEE802154_MCR20A_GPIO_SPI_CS_PIN);
 #endif /* CONFIG_IEEE802154_MCR20A_GPIO_SPI_CS */
 
 	mcr20a->spi_cfg.frequency = DT_IEEE802154_MCR20A_SPI_FREQ;
@@ -1406,8 +1405,8 @@ static inline int configure_spi(struct device *dev)
 	mcr20a->spi_cfg.slave = DT_IEEE802154_MCR20A_SPI_SLAVE;
 
 	LOG_DBG("SPI configured %s, %d",
-		    DT_IEEE802154_MCR20A_SPI_DRV_NAME,
-		    DT_IEEE802154_MCR20A_SPI_SLAVE);
+		DT_IEEE802154_MCR20A_SPI_DRV_NAME,
+		DT_IEEE802154_MCR20A_SPI_SLAVE);
 
 	return 0;
 }


### PR DESCRIPTION
- remove gpio cs property from mcr20a node in frdm_k64f.dts
- fix overwrites update of indirect register
- do not initialize reset gpio on KW2XD SIP
- fix style before DT_IEEE802154_MCR20A* macros