### PR TITLE
boards: usb_kw24d512: add support for DAPLink based adapters

### DIFF
--- a/boards/arm/usb_kw24d512/board.cmake
+++ b/boards/arm/usb_kw24d512/board.cmake
@@ -1,3 +1,5 @@
 board_runner_args(jlink "--device=MKW24D512xxx5" "--speed=4000")
+board_runner_args(pyocd "--target=kw24d5")
 
 include(${ZEPHYR_BASE}/boards/common/jlink.board.cmake)
+include(${ZEPHYR_BASE}/boards/common/pyocd.board.cmake)


### PR DESCRIPTION
Add support for using DAPLink based adapters through pyOCD.