### PR TITLE
Add DFU support for intel_s1000.

### DIFF
--- a/boards/xtensa/intel_s1000_crb/Kconfig.defconfig
+++ b/boards/xtensa/intel_s1000_crb/Kconfig.defconfig
@@ -93,6 +93,11 @@ config USB_HID_MAX_PAYLOAD_SIZE
 	default 128
 config USB_COMPOSITE_BUFFER_SIZE
 	default 128
+if USB_DFU_CLASS
+config USB_DFU_MAX_XFER_SIZE
+	default 4096
+endif
+
 endif # USB
 
 if UART_NS16550

--- a/samples/subsys/usb/dfu/sample.yaml
+++ b/samples/subsys/usb/dfu/sample.yaml
@@ -2,6 +2,6 @@ sample:
   name: USB DFU sample
 tests:
   test:
-    platform_whitelist: nrf52840_pca10056
+    platform_whitelist: nrf52840_pca10056 intel_s1000_crb
     depends_on: usb_device
     tags: usb

--- a/subsys/dfu/boot/mcuboot.c
+++ b/subsys/dfu/boot/mcuboot.c
@@ -497,7 +497,11 @@ int boot_erase_img_bank(u32_t bank_offset)
 static int boot_init(struct device *dev)
 {
 	ARG_UNUSED(dev);
+#if defined(DT_FLASH_DEV_NAME)
 	flash_dev = device_get_binding(DT_FLASH_DEV_NAME);
+#elif defined(DT_SPI_NOR_DRV_NAME)
+	flash_dev = device_get_binding(DT_SPI_NOR_DRV_NAME);
+#endif
 	if (!flash_dev) {
 		return -ENODEV;
 	}

--- a/subsys/usb/class/usb_dfu.c
+++ b/subsys/usb/class/usb_dfu.c
@@ -685,7 +685,11 @@ static int usb_dfu_init(struct device *dev)
 
 	ARG_UNUSED(dev);
 
+#if defined(DT_FLASH_DEV_NAME)
 	dfu_data.flash_dev = device_get_binding(DT_FLASH_DEV_NAME);
+#elif defined(DT_SPI_NOR_DRV_NAME)
+	dfu_data.flash_dev = device_get_binding(DT_SPI_NOR_DRV_NAME);
+#endif
 	if (!dfu_data.flash_dev) {
 		LOG_ERR("Flash device not found\n");
 		return -ENODEV;

--- a/subsys/usb/class/usb_dfu.c
+++ b/subsys/usb/class/usb_dfu.c
@@ -63,6 +63,16 @@ LOG_MODULE_REGISTER(usb_dfu);
 #define USB_DFU_MAX_XFER_SIZE		CONFIG_USB_DFU_MAX_XFER_SIZE
 #endif
 
+static struct k_work dfu_work;
+
+struct dfu_worker_data_t {
+	u8_t buf[USB_DFU_MAX_XFER_SIZE];
+	enum dfu_state worker_state;
+	u16_t worker_len;
+};
+
+static struct dfu_worker_data_t dfu_data_worker;
+
 struct usb_dfu_config {
 	struct usb_if_descriptor if0;
 	struct dfu_runtime_descriptor dfu_descr;
@@ -430,13 +440,22 @@ static int dfu_class_handle_req(struct usb_setup_packet *pSetup,
 				break;
 			}
 
-			if (boot_erase_img_bank(FLASH_AREA_IMAGE_1_OFFSET)) {
-				dfu_data.state = dfuERROR;
-				dfu_data.status = errERASE;
-				break;
-			}
+			dfu_data.state = dfuDNBUSY;
+			dfu_data_worker.worker_state = dfuIDLE;
+			dfu_data_worker.worker_len  = pSetup->wLength;
+			memcpy(dfu_data_worker.buf, *data, pSetup->wLength);
+			k_work_submit(&dfu_work);
+			break;
 		case dfuDNLOAD_IDLE:
-			dfu_flash_write(*data, pSetup->wLength);
+			dfu_data.state = dfuDNBUSY;
+			dfu_data_worker.worker_state = dfuDNLOAD_IDLE;
+			dfu_data_worker.worker_len  = pSetup->wLength;
+			if (dfu_data_worker.worker_len == 0) {
+				dfu_data.state = dfuMANIFEST_SYNC;
+			}
+
+			memcpy(dfu_data_worker.buf, *data, pSetup->wLength);
+			k_work_submit(&dfu_work);
 			break;
 		default:
 			LOG_ERR("DFU_DNLOAD wrong state %d", dfu_data.state);
@@ -679,6 +698,27 @@ USBD_CFG_DATA_DEFINE(dfu_mode) struct usb_cfg_data dfu_mode_config = {
 	.num_endpoints = 0,
 };
 
+static void dfu_work_handler(struct k_work *item)
+{
+	ARG_UNUSED(item);
+
+	switch (dfu_data_worker.worker_state) {
+	case dfuIDLE:
+		if (boot_erase_img_bank(FLASH_AREA_IMAGE_1_OFFSET)) {
+			dfu_data.state = dfuERROR;
+			dfu_data.status = errERASE;
+			break;
+		}
+	case dfuDNLOAD_IDLE:
+		dfu_flash_write(dfu_data_worker.buf,
+				dfu_data_worker.worker_len);
+		break;
+	default:
+		LOG_ERR("OUT of state machine");
+		break;
+	}
+}
+
 static int usb_dfu_init(struct device *dev)
 {
 	int ret;
@@ -694,6 +734,8 @@ static int usb_dfu_init(struct device *dev)
 		LOG_ERR("Flash device not found\n");
 		return -ENODEV;
 	}
+
+	k_work_init(&dfu_work, dfu_work_handler);
 
 #ifndef CONFIG_USB_COMPOSITE_DEVICE
 	dfu_config.interface.payload_data = dfu_data.buffer;


### PR DESCRIPTION
The bulk of implementation in the current DFU arch is done in the ISR.
    This works well when the Flash device is memory mapped as these writes
    get done comparatively quickly. However, in case of platforms where
    the flash device is sitting on the SPI Bus, this was observed to
    cause an exception. This exception may be because there are multiple
    function calls consuming larger processing time inside the ISR. The
    ISR stack may also end up going deeper and risk stack corruption on
    devices with low RAM. To resolve this, we deferred flash write to a
    worker thread. Also, some handshaking was added to have synchronization
    with the host in accordance with the Host-Device DFU protocol.
