### PR TITLE
doc: Add anchor in Getting Started

### DIFF
--- a/doc/getting_started/installation_linux.rst
+++ b/doc/getting_started/installation_linux.rst
@@ -54,6 +54,8 @@ On Arch Linux:
 
    sudo pacman -Syu
 
+.. _linux_requirements:
+
 Install Requirements and Dependencies
 *************************************
 


### PR DESCRIPTION
Add an anchor in the Getting Started topic to be able to link to
the requirements section.

Signed-off-by: Ruth Fuchss <ruth.fuchss@nordicsemi.no>