### PR TITLE
boards: Fix and update nxp board doc links

### DIFF
--- a/boards/arm/colibri_imx7d_m4/doc/colibri_imx7d_m4.rst
+++ b/boards/arm/colibri_imx7d_m4/doc/colibri_imx7d_m4.rst
@@ -305,7 +305,7 @@ References
    https://www.nxp.com/docs/en/data-sheet/IMX7DCEC.pdf
 
 .. _i.MX 7 Dual Reference Manual:
-   https://www.nxp.com/docs/en/reference-manual/IMX7DRM.pdf
+   https://www.nxp.com/webapp/Download?colCode=IMX7DRM
 
 .. _J-Link Tools:
    https://www.segger.com/downloads/jlink/#J-LinkSoftwareAndDocumentationPack

--- a/boards/arm/frdm_k64f/doc/frdm_k64f.rst
+++ b/boards/arm/frdm_k64f/doc/frdm_k64f.rst
@@ -261,22 +261,22 @@ You can debug an application in the usual way.  Here is an example for the
    :goals: debug
 
 .. _FRDM-K64F Website:
-   http://www.nxp.com/products/software-and-tools/hardware-development-tools/freedom-development-boards/freedom-development-platform-for-kinetis-k64-k63-and-k24-mcus:FRDM-K64F
+   https://www.nxp.com/support/developer-resources/evaluation-and-development-boards/freedom-development-boards/mcu-boards/freedom-development-platform-for-kinetis-k64-k63-and-k24-mcus:FRDM-K64F
 
 .. _FRDM-K64F User Guide:
-   http://www.nxp.com/assets/documents/data/en/user-guides/FRDMK64FUG.pdf
+   https://www.nxp.com/webapp/Download?colCode=FRDMK64FUG
 
 .. _FRDM-K64F Schematics:
-   http://www.nxp.com/assets/downloads/data/en/schematics/FRDM-K64F-SCH-E4.pdf
+   https://www.nxp.com/webapp/Download?colCode=FRDM-K64F-SCH-E4
 
 .. _K64F Website:
-   http://www.nxp.com/products/microcontrollers-and-processors/arm-processors/kinetis-cortex-m-mcus/k-series-performance-m4/k6x-ethernet/kinetis-k64-120-mhz-256kb-sram-microcontrollers-mcus-based-on-arm-cortex-m4-core:K64_120
+   https://www.nxp.com/products/processors-and-microcontrollers/arm-based-processors-and-mcus/kinetis-cortex-m-mcus/k-seriesperformancem4/k6x-ethernet/kinetis-k64-120-mhz-256kb-sram-microcontrollers-mcus-based-on-arm-cortex-m4-core:K64_120
 
 .. _K64F Datasheet:
-   http://www.nxp.com/assets/documents/data/en/data-sheets/K64P144M120SF5.pdf
+   https://www.nxp.com/docs/en/data-sheet/K64P144M120SF5.pdf
 
 .. _K64F Reference Manual:
-   http://www.nxp.com/assets/documents/data/en/reference-manuals/K64P144M120SF5RM.pdf
+   https://www.nxp.com/docs/en/reference-manual/K64P144M120SF5RM.pdf
 
 .. _DAPLink FRDM-K64F Firmware:
    http://www.nxp.com/assets/downloads/data/en/ide-debug-compile-build-tools/OpenSDAv2.2_DAPLink_frdmk64f_rev0242.zip

--- a/boards/arm/frdm_kl25z/doc/frdm_kl25z.rst
+++ b/boards/arm/frdm_kl25z/doc/frdm_kl25z.rst
@@ -176,22 +176,22 @@ You can debug an application in the usual way.  Here is an example for the
    :goals: debug
 
 .. _FRDM-KL25Z Website:
-   http://www.nxp.com/products/software-and-tools/hardware-development-tools/freedom-development-boards/freedom-development-platform-for-kinetis-kl14-kl15-kl24-kl25-mcus:FRDM-KL25Z?tid=vanFRDM-KL25Z
+   https://www.nxp.com/products/processors-and-microcontrollers/arm-based-processors-and-mcus/kinetis-cortex-m-mcus/l-seriesultra-low-powerm0-plus/freedom-development-platform-for-kinetis-kl14-kl15-kl24-kl25-mcus:FRDM-KL25Z
 
 .. _FRDM-KL25Z User Guide:
-   http://www.nxp.com/assets/documents/data/en/user-guides/FRDMKL25ZUM.zip
+   https://www.nxp.com/docs/en/user-guide/FRDMKL25ZUM.zip
 
 .. _FRDM-KL25Z Schematics:
-   http://www.nxp.com/assets/downloads/data/en/schematics/FRDM-KL25Z_SCH_REV_E.pdf
+   https://www.nxp.com/downloads/en/schematics/FRDM-KL25Z_SCH_REV_E.pdf
 
 .. _KL25Z Website:
-   http://www.nxp.com/products/microcontrollers-and-processors/arm-processors/kinetis-cortex-m-mcus/l-series-ultra-low-power-m0-plus/kinetis-kl2x-48-mhz-usb-ultra-low-power-microcontrollers-mcus-based-on-arm-cortex-m0-plus-core:KL2x?lang_cd=en
+   https://www.nxp.com/products/processors-and-microcontrollers/arm-based-processors-and-mcus/kinetis-cortex-m-mcus/l-seriesultra-low-powerm0-plus/kinetis-kl2x-72-96mhz-usb-ultra-low-power-microcontrollers-mcus-based-on-arm-cortex-m0-plus-core:KL2x?&l
 
 .. _KL25Z Datasheet:
-   http://www.nxp.com/assets/documents/data/en/data-sheets/KL25P80M48SF0.pdf
+   https://www.nxp.com/docs/en/data-sheet/KL25P80M48SF0.pdf
 
 .. _KL25Z Reference Manual:
-   http://www.nxp.com/assets/documents/data/en/reference-manuals/KL25P80M48SF0RM.pdf
+   https://www.nxp.com/docs/en/reference-manual/KL25P80M48SF0RM.pdf
 
 .. _DAPLink FRDM-KL25Z Firmware:
    http://www.nxp.com/assets/downloads/data/en/ide-debug-compile-build-tools/OpenSDAv2.2_DAPLink_frdmkl25z_rev0242.zip

--- a/boards/arm/frdm_kw41z/doc/frdm_kw41z.rst
+++ b/boards/arm/frdm_kw41z/doc/frdm_kw41z.rst
@@ -185,22 +185,22 @@ program your Zephyr application to flash. It will leave you at a gdb prompt.
    :goals: debug
 
 .. _FRDM-KW41Z Website:
-   http://www.nxp.com/products/microcontrollers-and-processors/more-processors/application-specific-mcus-mpus/bluetooth-low-energy-ble/nxp-freedom-development-kit-for-kinetis-kw41z-31z-21z-mcus:FRDM-KW41Z
+   https://www.nxp.com/products/processors-and-microcontrollers/arm-based-processors-and-mcus/kinetis-cortex-m-mcus/w-serieswireless-conn.m0-plus-m4/freedom-development-kit-for-kinetis-kw41z-31z-21z-mcus:FRDM-KW41Z
 
 .. _FRDM-KW41Z User Guide:
-   http://www.nxp.com/assets/documents/data/en/user-guides/FRDMKW41ZUG.pdf
+   https://www.nxp.com/webapp/Download?colCode=FRDMKW41ZUG
 
 .. _FRDM-KW41Z Schematics:
-   http://www.nxp.com/assets/downloads/data/en/schematics/FRDM-KW41Z-SCH.pdf
+   https://www.nxp.com/webapp/Download?colCode=FRDM-KW41Z-SCH
 
 .. _KW41Z Website:
-   http://www.nxp.com/products/microcontrollers-and-processors/arm-processors/kinetis-cortex-m-mcus/w-series-wireless-m0-plus-m4/kinetis-kw41z-2.4-ghz-dual-mode-ble-and-802.15.4-wireless-radio-microcontroller-mcu-based-on-arm-cortex-m0-plus-core:KW41Z
+   https://www.nxp.com/products/wireless/zigbee/kinetis-kw41z-2.4-ghz-dual-mode-bluetooth-low-energy-and-802.15.4-wireless-radio-microcontroller-mcu-based-on-arm-cortex-m0-plus-core:KW41Z
 
 .. _KW41Z Datasheet:
-   http://www.nxp.com/assets/documents/data/en/data-sheets/MKW41Z512.pdf
+   https://www.nxp.com/docs/en/data-sheet/MKW41Z512.pdf
 
 .. _KW41Z Reference Manual:
-   http://www.nxp.com/assets/documents/data/en/reference-manuals/MKW41Z512RM.pdf
+   https://www.nxp.com/webapp/Download?colCode=MKW41Z512RM
 
 .. _DAPLink FRDM-KW41Z Firmware:
    http://www.nxp.com/assets/downloads/data/en/reference-applications/OpenSDAv2.2_DAPLink_frdmkw41z_rev0241.zip

--- a/boards/arm/hexiwear_k64/doc/hexiwear_k64.rst
+++ b/boards/arm/hexiwear_k64/doc/hexiwear_k64.rst
@@ -281,22 +281,22 @@ will then see a plot of the heart rate data that updates once per second.
 
 
 .. _Hexiwear Website:
-   http://www.nxp.com/hexiwear
+   https://www.nxp.com/support/developer-resources/nxp-designs/hexiwear-complete-iot-development-solution:HEXIWEAR?&tid=vanHEXIWEAR
 
 .. _Hexiwear Fact Sheet:
-   http://www.nxp.com/assets/documents/data/en/fact-sheets/HEXIWEAR-FS.pdf
+   https://www.nxp.com/docs/en/fact-sheet/HEXIWEAR-FS.pdf
 
 .. _Hexiwear Schematics:
    http://cdn-docs.mikroe.com/images/c/c0/Sch_Hexiwear_MainBoard_v106c.pdf
 
 .. _K64F Website:
-   http://www.nxp.com/products/microcontrollers-and-processors/arm-processors/kinetis-cortex-m-mcus/k-series-performance-m4/k6x-ethernet/kinetis-k64-120-mhz-256kb-sram-microcontrollers-mcus-based-on-arm-cortex-m4-core:K64_120
+   https://www.nxp.com/products/processors-and-microcontrollers/arm-based-processors-and-mcus/kinetis-cortex-m-mcus/k-seriesperformancem4/k6x-ethernet/kinetis-k64-120-mhz-256kb-sram-microcontrollers-mcus-based-on-arm-cortex-m4-core:K64_120
 
 .. _K64F Datasheet:
-   http://www.nxp.com/assets/documents/data/en/data-sheets/K64P144M120SF5.pdf
+   https://www.nxp.com/docs/en/data-sheet/K64P144M120SF5.pdf
 
 .. _K64F Reference Manual:
-   http://www.nxp.com/assets/documents/data/en/reference-manuals/K64P144M120SF5RM.pdf
+   https://www.nxp.com/docs/en/reference-manual/K64P144M120SF5RM.pdf
 
 .. _DAPLink Hexiwear Firmware:
    https://github.com/MikroElektronika/HEXIWEAR/blob/master/HW/HEXIWEAR_DockingStation/HEXIWEAR_DockingStation_DAPLINK_FW.bin

--- a/boards/arm/hexiwear_kw40z/doc/hexiwear_kw40z.rst
+++ b/boards/arm/hexiwear_kw40z/doc/hexiwear_kw40z.rst
@@ -143,16 +143,16 @@ Continue program execution in GDB, then in the telnet terminal you should see:
 
 
 .. _KW40Z Website:
-   http://www.nxp.com/products/microcontrollers-and-processors/arm-processors/kinetis-cortex-m-mcus/w-series-wireless-m0-plus-m4/kinetis-kw40z-2.4-ghz-dual-mode-ble-and-802.15.4-wireless-radio-microcontroller-mcu-based-on-arm-cortex-m0-plus-core:KW40Z
+   https://www.nxp.com/products/processors-and-microcontrollers/arm-based-processors-and-mcus/kinetis-cortex-m-mcus/w-serieswireless-conn.m0-plus-m4/kinetis-kw40z-2.4-ghz-dual-mode-ble-and-802.15.4-wireless-radio-microcontroller-mcu-based-on-arm-cortex-m0-plus-core:KW40Z
 
 .. _KW40Z Datasheet:
-   http://www.nxp.com/assets/documents/data/en/data-sheets/MKW40Z160.pdf
+   https://www.nxp.com/docs/en/data-sheet/MKW40Z160.pdf
 
 .. _KW40Z Reference Manual:
-   http://www.nxp.com/assets/documents/data/en/reference-manuals/MKW40Z160RM.pdf
+   https://www.nxp.com/docs/en/reference-manual/MKW40Z160RM.pdf
 
 .. _Segger RTT:
-    https://www.segger.com/jlink-rtt.html
+   https://www.segger.com/products/debug-probes/j-link/technology/about-real-time-transfer/
 
 .. _DAPLink Hexiwear Firmware:
    https://github.com/MikroElektronika/HEXIWEAR/blob/master/HW/HEXIWEAR_DockingStation/HEXIWEAR_DockingStation_DAPLINK_FW.bin

--- a/boards/arm/lpcxpresso54114/doc/lpcxpresso54114.rst
+++ b/boards/arm/lpcxpresso54114/doc/lpcxpresso54114.rst
@@ -148,22 +148,22 @@ serial port:
 
 
 .. _LPC54114 SoC Website:
-	http://www.nxp.com/products/microcontrollers-and-processors/arm-processors/lpc-cortex-m-mcus/lpc54000-series-cortex-m4-mcus/low-power-microcontrollers-mcus-based-on-arm-cortex-m4-cores-with-optional-cortex-m0-plus-co-processor:LPC541XX
+   https://www.nxp.com/products/processors-and-microcontrollers/arm-based-processors-and-mcus/lpc-cortex-m-mcus/lpc54000-series-cortex-m4-mcus/low-power-microcontrollers-mcus-based-on-arm-cortex-m4-cores-with-optional-cortex-m0-plus-co-processor:LPC541XX
 
 .. _LPC54114 Datasheet:
-	http://www.nxp.com/docs/en/data-sheet/LPC5411X.pdf
+   https://www.nxp.com/docs/en/data-sheet/LPC5411X.pdf
 
 .. _LPC54114 Reference Manual:
-	http://www.nxp.com/docs/en/user-guide/UM10914.pdf
+   https://www.nxp.com/webapp/Download?colCode=UM10914
 
 .. _LPCXPRESSO54114 Website:
-   http://www.nxp.com/products/developer-resources/software-development-tools/software-tools/lpcxpresso-boards/lpcxpresso54114-board:OM13089
+   https://www.nxp.com/support/developer-resources/evaluation-and-development-boards/lpcxpresso-boards/lpcxpresso54114-board:OM13089
 
 .. _LPCXPRESSO54114 User Guide:
-   http://www.nxp.com/docs/en/user-guide/UM10973.pdf
+   https://www.nxp.com/webapp/Download?colCode=UM10973
 
 .. _LPCXPRESSO54114 Schematics:
-   http://www.nxp.com/downloads/en/design-support/LPCX5411x_Schematic_Rev_A1.pdf
+   https://www.nxp.com/downloads/en/design-support/LPCX5411x_Schematic_Rev_A1.pdf
 
 .. _LPCScrypt:
-   https://www.nxp.com/support/developer-resources/software-development-tools/lpc-developer-resources-/lpc-microcontroller-utilities/lpcscrypt-v1.8.2:LPCSCRYPT?&tab=Design_Tools_Tab
+   https://www.nxp.com/support/developer-resources/software-development-tools/lpc-developer-resources-/lpc-microcontroller-utilities/lpcscrypt-v2.0.0:LPCSCRYPT

--- a/boards/arm/mimxrt1050_evk/doc/mimxrt1050_evk.rst
+++ b/boards/arm/mimxrt1050_evk/doc/mimxrt1050_evk.rst
@@ -235,7 +235,7 @@ Current Zephyr build supports the new MIMXRT1050-EVKB
    https://www.nxp.com/products/microcontrollers-and-processors/arm-based-processors-and-mcus/i.mx-applications-processors/i.mx-rt-series/i.mx-rt1050-evaluation-kit:MIMXRT1050-EVK
 
 .. _MIMXRT1050-EVK User Guide:
-   https://www.nxp.com/docs/en/user-guide/IMXRT1050EVKBHUG.pdf
+   https://www.nxp.com/webapp/Download?colCode=IMXRT1050EVKBHUG
 
 .. _MIMXRT1050-EVK Schematics:
    https://www.nxp.com/webapp/Download?colCode=MIMXRT1050-EVK-DESIGNFILES

--- a/boards/arm/mimxrt1060_evk/doc/mimxrt1060_evk.rst
+++ b/boards/arm/mimxrt1060_evk/doc/mimxrt1060_evk.rst
@@ -178,7 +178,7 @@ your Zephyr application to flash. It will leave you at a GDB prompt.
    https://www.nxp.com/support/developer-resources/software-development-tools/mcuxpresso-software-and-tools/mimxrt1060-evk-i.mx-rt1060-evaluation-kit:MIMXRT1060-EVK
 
 .. _MIMXRT1060-EVK User Guide:
-   https://www.nxp.com/docs/en/user-guide/UM11151.PDF
+   https://www.nxp.com/webapp/Download?colCode=UM11151
 
 .. _MIMXRT1060-EVK Schematics:
    https://www.nxp.com/webapp/Download?colCode=MIMXRT1060-EVK-DESIGN-FILE-A2
@@ -190,7 +190,7 @@ your Zephyr application to flash. It will leave you at a GDB prompt.
    https://www.nxp.com/docs/en/nxp/data-sheets/IMXRT1060CEC.pdf
 
 .. _i.MX RT1060 Reference Manual:
-   https://www.nxp.com/docs/en/reference-manual/IMXRT1060RM.pdf
+   https://www.nxp.com/webapp/Download?colCode=IMXRT1060RM
 
 .. _Segger J-Link OpenSDA V2.1 Firmware:
    https://www.segger.com/downloads/jlink/OpenSDA_V2_1.bin

--- a/boards/arm/usb_kw24d512/doc/usb_kw24d512.rst
+++ b/boards/arm/usb_kw24d512/doc/usb_kw24d512.rst
@@ -172,19 +172,19 @@ Continue program execution in GDB, then in the telnet terminal you should see:
      Hello World! arm
 
 .. _USB-KW24D512 Website:
-   http://www.nxp.com/products/microcontrollers-and-processors/arm-processors/kinetis-cortex-m-mcus/w-series-wireless-m0-plus-m4/ieee-802.15.4-packet-sniffer-usb-dongle-form-factor:USB-KW24D512
+   https://www.nxp.com/products/processors-and-microcontrollers/arm-based-processors-and-mcus/kinetis-cortex-m-mcus/w-serieswireless-conn.m0-plus-m4/ieee-802.15.4-packet-sniffer-usb-dongle-form-factor:USB-KW24D512
 
 .. _USB-KW24D512 Hardware Reference Manual:
-   http://www.nxp.com/docs/en/reference-manual/USB-KW2XHWRM.pdf
+   https://www.nxp.com/docs/en/reference-manual/USB-KW2XHWRM.pdf
 
 .. _KW2xD Website:
-   http://www.nxp.com/products/wireless-connectivity/2.4-ghz-wireless-solutions/ieee-802.15.4-wireless-mcus/kinetis-kw2xd-2.4-ghz-802.15.4-wireless-radio-microcontroller-mcu-based-on-arm-cortex-m4-core:KW2xD
+   https://www.nxp.com/products/wireless/thread/kinetis-kw2xd-2.4-ghz-802.15.4-wireless-radio-microcontroller-mcu-based-on-arm-cortex-m4-core:KW2xD
 
 .. _KW2xD Datasheet:
-   http://www.nxp.com/docs/en/data-sheet/MKW2xDxxx.pdf
+   https://www.nxp.com/docs/en/data-sheet/MKW2xDxxx.pdf
 
 .. _KW2xD Reference Manual:
-   http://www.nxp.com/docs/en/reference-manual/MKW2xDxxxRM.pdf
+   https://www.nxp.com/docs/en/reference-manual/MKW2xDxxxRM.pdf
 
 .. _Segger J-Link debug probe:
     https://www.segger.com/products/debug-probes/j-link/models/j-link-base/

--- a/boards/arm/warp7_m4/doc/warp7_m4.rst
+++ b/boards/arm/warp7_m4/doc/warp7_m4.rst
@@ -328,7 +328,7 @@ References
    https://www.nxp.com/docs/en/data-sheet/IMX7SCEC.pdf
 
 .. _i.MX 7 Solo Reference Manual:
-   https://www.nxp.com/docs/en/reference-manual/IMX7SRM.pdf
+   https://www.nxp.com/webapp/Download?colCode=IMX7SRM
 
 .. _J-Link Tools:
    https://www.segger.com/downloads/jlink/#J-LinkSoftwareAndDocumentationPack


### PR DESCRIPTION
Fixes broken user guide and schematics links in nxp board documentation.
Updates remaining nxp.com links from http to https.

Signed-off-by: Maureen Helm <maureen.helm@nxp.com>

Fixes #11914